### PR TITLE
[ROCm] jax-rocm runtime/ci dockerfile multistages

### DIFF
--- a/build/rocm/Dockerfile.ms
+++ b/build/rocm/Dockerfile.ms
@@ -1,0 +1,80 @@
+################################################################################
+FROM rocm/dev-ubuntu-20.04:5.3-complete as rt_build
+MAINTAINER Chao Chen <Chao.Chen.2@amd.com>
+################################################################################
+ARG ROCM_PATH=/opt/rocm-5.3.0
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV HOME /root/
+ENV ROCM_PATH=$ROCM_PATH
+
+RUN apt-get update --allow-insecure-repositories && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  build-essential \
+  software-properties-common \
+  clang-6.0 \
+  clang-format-6.0 \
+  curl \
+  g++-multilib \
+  git \
+  vim \
+  libnuma-dev \
+  virtualenv \
+  python3-pip \
+  pciutils \
+  wget && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+
+# Set up paths
+ENV HCC_HOME=$ROCM_PATH/hcc
+ENV HIP_PATH=$ROCM_PATH/hip
+ENV OPENCL_ROOT=$ROCM_PATH/opencl
+ENV PATH="$HCC_HOME/bin:$HIP_PATH/bin:${PATH}"
+ENV PATH="$ROCM_PATH/bin:${PATH}"
+ENV PATH="$OPENCL_ROOT/bin:${PATH}"
+
+# Add target file to help determine which device(s) to build for
+RUN bash -c 'echo -e "gfx900\ngfx906\ngfx908\ngfx90a\ngfx1030" >> ${ROCM_PATH}/bin/target.lst'
+
+# Need to explicitly create the $ROCM_PATH/.info/version file to workaround what seems to be a bazel bug
+# The env vars being set via --action_env in .bazelrc and .tf_configure.bazelrc files are sometimes
+# not getting set in the build command being spawned by bazel (in theory this should not happen)
+# As a consequence ROCM_PATH is sometimes not set for the hipcc commands.
+# When hipcc incokes hcc, it specifies $ROCM_PATH/.../include dirs via the `-isystem` options
+# If ROCM_PATH is not set, it defaults to /opt/rocm, and as a consequence a dependency is generated on the
+# header files included within `/opt/rocm`, which then leads to bazel dependency errors
+# Explicitly creating the $ROCM_PATH/.info/version allows ROCM path to be set correrctly, even when ROCM_PATH
+# is not explicitly set, and thus avoids the eventual bazel dependency error.
+# The bazel bug needs to be root-caused and addressed, but that is out of our control and may take a long time
+# to come to fruition, so implementing the workaround to make do till then
+# Filed https://github.com/bazelbuild/bazel/issues/11163 for tracking this
+RUN touch ${ROCM_PATH}/.info/version
+
+ENV PATH="/root/bin:/root/.local/bin:$PATH"
+
+
+# Install python3.9
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+  apt update && \
+  apt install -y python3.9-dev \
+    python3-pip \
+    python3.9-distutils \
+    python-is-python3
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
+
+RUN pip3 install --upgrade --force-reinstall setuptools pip
+
+RUN pip3 install absl-py numpy==1.20.0 scipy wheel six setuptools pytest pytest-rerunfailures matplotlib
+
+# Get jax and build it with ROCm
+RUN git clone https://github.com/google/jax.git 
+
+################################################################################
+FROM rt_build as ci_build
+################################################################################
+WORKDIR /jax
+RUN ./build/rocm/build_rocm.sh 
+RUN ./build/rocm/run_single_gpu.py 
+RUN ./build/rocm/run_multi_gpu.sh

--- a/build/rocm/Dockerfile.ms
+++ b/build/rocm/Dockerfile.ms
@@ -1,8 +1,8 @@
 ################################################################################
-FROM rocm/dev-ubuntu-20.04:5.3-complete as rt_build
-MAINTAINER Chao Chen <Chao.Chen.2@amd.com>
+FROM rocm/dev-ubuntu-20.04:5.4-complete as rt_build
+MAINTAINER Rahul Batra<rahbatra@amd.com>
 ################################################################################
-ARG ROCM_PATH=/opt/rocm-5.3.0
+ARG ROCM_PATH=/opt/rocm-5.4.0
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV HOME /root/

--- a/build/rocm/README.md
+++ b/build/rocm/README.md
@@ -1,23 +1,23 @@
 # JAX Builds on ROCm
-This directory contains files and setup instructions t0 build and test JAX for ROCm in Docker environment. You can build, test and run JAX on ROCm yourself!
+This directory contains files and setup instructions to build and test JAX for ROCm in Docker environment (runtime and CI). You can build, test and run JAX on ROCm yourself!
 ***
-### Build JAX-ROCm in docker
+### Build JAX-ROCm in docker for the runtime
 
 1.  Install Docker: Follow the [instructions on the docker website](https://docs.docker.com/engine/installation/).
 
-  2. Build JAX by running the following command from JAX root folder.
+2. Build a runtime JAX-ROCm docker container and keep this image by running the following command.
 
-    ./build/rocm/ci_build.sh --keep_image bash -c "./build/rocm/build_rocm.sh"
+    ./build/rocm/ci_build.sh --keep_image --runtime bash -c "./build/rocm/build_rocm.sh"
 
-  3. Launch a container: If the build was successful, there should be a docker image with name "jax_ci.rocm" in list of docker images (use "docker images" command to list them).
-  ```
-  sudo docker run -it --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --entrypoint /bin/bash jax_ci.rocm:latest
-  ```
+3. To launch a JAX-ROCm container: If the build was successful, there should be a docker image with name "jax-rocm:latest" in list of docker images (use "docker images" command to list them).
+```
+sudo docker run -it --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --entrypoint /bin/bash jax-rocm:latest
+```
 
 ***
-### Build and Test JAX-ROCm in docker (suitable for CI jobs)
+### Build and Test JAX-ROCm in docker for CI jobs
 This folder has all the scripts necessary to build and run tests for JAX-ROCm.
 The following command will build JAX on ROCm and run all the tests inside docker (script should be called from JAX root folder).
 ```
-./build/rocm/ci_build.sh bash -c "./build/rocm/build_rocm.sh&&./build/rocm/run_single_gpu.py&&build/rocm/run_multi_gpu.sh"
+./build/rocm/ci_build.sh
 ```

--- a/build/rocm/build_rocm.sh
+++ b/build/rocm/build_rocm.sh
@@ -29,6 +29,7 @@ then
       cd -
 fi
 
+
 python3 ./build/build.py --enable_rocm --rocm_path=${ROCM_PATH} --bazel_options=--override_repository=org_tensorflow=/tmp/tensorflow-upstream
 pip3 install --force-reinstall dist/*.whl  # installs jaxlib (includes XLA)
 pip3 install --force-reinstall .  # installs jax


### PR DESCRIPTION
Currently ROCm build instruction is for CI job and not for runtime usage.

I have simplised the Dockerfile and updated it to mulistage for both runtime and CI job. The build instruction document has also updated according.

/cc @hawkinsp