### PR TITLE
Add checkify.debug_check which is a no-op outside of checkify.

### DIFF
--- a/jax/experimental/checkify.py
+++ b/jax/experimental/checkify.py
@@ -21,6 +21,7 @@ from jax._src.checkify import (
     check as check,
     check_error as check_error,
     checkify as checkify,
+    debug_check as debug_check,
     div_checks as div_checks,
     float_checks as float_checks,
     index_checks as index_checks,


### PR DESCRIPTION
`checkify.debug_check` is a check which only executes under a `checkify` transform, otherwise the check will be dropped.

```
def f(x):
  checkify.debug_check(jnp.all(x != x), "{x} cannot be {x}", x=x)
f(1.)  # no error
err, _ = checkify.checkify(f)(1.)
err.throw() #raises error
```

### Motivation

Library writers might want to add `check`s to their code without forcing their users to call `checkify`. `debug_check` allows them to encode predicates in their code which will run under "debug" mode, but will otherwise have no effect on the execution of the code. We could later expose a `debug_mode` which would run all checks, including those in library code, automatically. (eg. https://github.com/google/jax/pull/12597)

### ~Why a `pred_fun` and not a `pred`?~

Making the `pred` a callable means we can defer executing the predicate function to when we need it, and users can implement expensive validation logic which will not be run  if not necessary. Is this worth the API complexity? 
**Decision: NO, let's stick with a `pred` for now and rely on XLA to DCE.**

### ~Why a new primitive?~
Not sure, should it be a parameter on `check_p` instead? 
**Decision: YES, let's unify those primitives**

### Could this be a bad idea?
Could it be confusing to the user when these checks are silently dropped when not under `checkify`, or is the name `debug_check` clear enough?