### PR TITLE
[sparse] validate BCOO on instantiation

### DIFF
--- a/jax/experimental/sparse/_base.py
+++ b/jax/experimental/sparse/_base.py
@@ -62,8 +62,9 @@ class JAXSparse(abc.ABC):
     ...
 
   @classmethod
+  @abc.abstractmethod
   def tree_unflatten(cls, aux_data, children):
-    return cls(children, **aux_data)
+    ...
 
   @abc.abstractmethod
   def transpose(self, axes=None):

--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -31,7 +31,7 @@ from jax import vmap
 from jax.config import config
 from jax.experimental.sparse._base import JAXSparse
 from jax.experimental.sparse.util import (
-  _broadcasting_vmap, _count_stored_elements, _safe_asarray,
+  _broadcasting_vmap, _count_stored_elements,
   _dot_general_validated_shape, CuSparseEfficiencyWarning,
   SparseEfficiencyError, SparseEfficiencyWarning)
 from jax.interpreters import batching
@@ -2386,10 +2386,11 @@ class BCOO(JAXSparse):
                indices_sorted: bool = False, unique_indices: bool = False):
     # JAX transforms will sometimes instantiate pytrees with null values, so we
     # must catch that in the initialization of inputs.
-    self.data, self.indices = _safe_asarray(args)  # type: ignore[assignment]
+    self.data, self.indices = map(jnp.asarray, args)
     self.indices_sorted = indices_sorted
     self.unique_indices = unique_indices
     super().__init__(args, shape=tuple(shape))
+    _validate_bcoo(self.data, self.indices, self.shape)
 
   def __repr__(self):
     name = self.__class__.__name__
@@ -2581,6 +2582,15 @@ class BCOO(JAXSparse):
 
   def tree_flatten(self):
     return (self.data, self.indices), self._info._asdict()
+
+  @classmethod
+  def tree_unflatten(cls, aux_data, children):
+    obj = object.__new__(cls)
+    obj.data, obj.indices = children
+    if aux_data.keys() != {'shape', 'indices_sorted', 'unique_indices'}:
+      raise ValueError(f"BCOO.tree_unflatten: invalid {aux_data=}")
+    obj.__dict__.update(**aux_data)
+    return obj
 
 
 # vmappable handlers

--- a/jax/experimental/sparse/bcsr.py
+++ b/jax/experimental/sparse/bcsr.py
@@ -25,7 +25,7 @@ from jax import core
 from jax import tree_util
 from jax.experimental.sparse._base import JAXSparse
 from jax.experimental.sparse import bcoo
-from jax.experimental.sparse.util import _broadcasting_vmap, _count_stored_elements, _csr_to_coo, _safe_asarray
+from jax.experimental.sparse.util import _broadcasting_vmap, _count_stored_elements, _csr_to_coo
 import jax.numpy as jnp
 from jax.util import split_list, safe_zip
 from jax.interpreters import batching
@@ -320,8 +320,9 @@ class BCSR(JAXSparse):
   def __init__(self, args, *, shape):
     # JAX transforms will sometimes instantiate pytrees with null values, so we
     # must catch that in the initialization of inputs.
-    self.data, self.indices, self.indptr = _safe_asarray(args)
+    self.data, self.indices, self.indptr = map(jnp.asarray, args)
     super().__init__(args, shape=shape)
+    _validate_bcsr(self.data, self.indices, self.indptr, self.shape)
 
   def __repr__(self):
     name = self.__class__.__name__
@@ -347,6 +348,15 @@ class BCSR(JAXSparse):
 
   def tree_flatten(self):
     return (self.data, self.indices, self.indptr), {'shape': self.shape}
+
+  @classmethod
+  def tree_unflatten(cls, aux_data, children):
+    obj = object.__new__(cls)
+    obj.data, obj.indices, obj.indptr = children
+    if aux_data.keys() != {'shape'}:
+      raise ValueError(f"BCSR.tree_unflatten: invalid {aux_data=}")
+    obj.__dict__.update(**aux_data)
+    return obj
 
   @classmethod
   def _empty(cls, shape, *, dtype=None, index_dtype='int32', n_dense=0,

--- a/jax/experimental/sparse/util.py
+++ b/jax/experimental/sparse/util.py
@@ -107,11 +107,6 @@ def _is_aval(*args: Any) -> bool:
 def _is_arginfo(*args: Any) -> bool:
   return all(isinstance(arg, stages.ArgInfo) for arg in args)
 
-def _safe_asarray(args: Sequence[Any]) -> Iterable[Union[np.ndarray, Array]]:
-  if _is_pytree_placeholder(*args) or _is_aval(*args) or _is_arginfo(*args):
-    return args
-  return map(_asarray_or_float0, args)
-
 def _dot_general_validated_shape(
     lhs_shape: Tuple[int, ...], rhs_shape: Tuple[int, ...],
     dimension_numbers: DotDimensionNumbers) -> Tuple[int, ...]:

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -692,7 +692,8 @@ class BCOOTest(sptu.SparseTestCase):
     y = sparse.BCOO.fromdense(jnp.arange(6, dtype='float32').reshape(2, 3), n_batch=1, n_dense=1)
     self.assertEqual(repr(y), "BCOO(float32[2, 3], nse=1, n_batch=1, n_dense=1)")
 
-    M_invalid = sparse.BCOO(([], []), shape=(100,))
+    M_invalid = sparse.BCOO.fromdense(jnp.arange(6, dtype='float32').reshape(2, 3))
+    M_invalid.indices = jnp.array([])
     self.assertEqual(repr(M_invalid), "BCOO(<invalid>)")
 
     @jit


### PR DESCRIPTION
We're able to do this by avoiding calling `__init__` on pytree unflattening.