### PR TITLE
DOC: remove reference to TpuDevice

### DIFF
--- a/docs/jax.lib.rst
+++ b/docs/jax.lib.rst
@@ -35,4 +35,3 @@ jax.lib.xla_extension
    :toctree: _autosummary
 
    Device
-   TpuDevice


### PR DESCRIPTION
Should fix the current readthedocs breakage.