### PR TITLE
JAX Implementation of Power Spherical logpdf & pdf

### DIFF
--- a/jax/_src/scipy/stats/power_spherical.py
+++ b/jax/_src/scipy/stats/power_spherical.py
@@ -1,0 +1,34 @@
+# Copyright 2022 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import jax.numpy as jnp
+
+from jax import lax
+from jax._src.lax.lax import _const as _lax_const
+from jax._src.typing import Array, ArrayLike
+
+
+def logpdf(mu: ArrayLike, kappa: ArrayLike) -> Array:
+  t = jnp.promote_types(mu.dtype, kappa.dtype)
+  mu, kappa = mu.astype(t), kappa.astype(t)
+  zero, two = _lax_const(kappa, 0), _lax_const(kappa, 2)
+  n = mu.shape[-1]
+  b = (n - 1) / 2
+  a = b + kappa
+  logpdf = (lax.add(a, b) * lax.log(two)) + (lax.lgamma(a) - lax.lgamma(a + b)) + (b * lax.log(jnp.pi))
+  return jnp.where(lax.ge(kappa, zero), logpdf, jnp.inf)
+
+def pdf(mu: ArrayLike, kappa: ArrayLike) -> Array:
+  return lax.exp(logpdf(mu, kappa))

--- a/jax/scipy/stats/power_spherical.py
+++ b/jax/scipy/stats/power_spherical.py
@@ -1,0 +1,18 @@
+# Copyright 2022 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from jax._src.scipy.stats.power_spherical import (
+  logpdf as logpdf,
+  pdf as pdf,
+)


### PR DESCRIPTION
As referenced in #11737. 

Paper is [here.](https://arxiv.org/pdf/2006.04437.pdf)

Initial implementation. Tested it in notebooks re: the authors [example](https://github.com/nicola-decao/power_spherical) and the [Tensorflow Probability implementation](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/PowerSpherical) and looks good. 

This one is a little less straightforward; I've got a few of questions:

1) As these functions aren't in `scipy.stats`, should they live there? It makes the most sense to be with all other distributions imo.
2) When it comes to writing tests, as these functions aren't in `scipy.stats`, how should I go about validating their correctness without adding extra dependencies?
3) As the two arguments `mu` and `kappa` are usually of alternative shapes, what is the most appropriate way to conduct type promotion?

Edit: looks like I made a bit of a mess with this PR, I'll re-open post discussion.