### PR TITLE
Revert to old test runners to investigate runner queue failure.

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -22,8 +22,8 @@ permissions:
 
 jobs:
   lint_and_typecheck:
-    runs-on: ubuntu-20.04-16core
-    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Cancel previous
         uses: styfle/cancel-workflow-action@0.11.0
@@ -46,7 +46,7 @@ jobs:
         include:
           - name-prefix: "with 3.8"
             python-version: "3.8"
-            os: ubuntu-20.04-16core
+            os: ubuntu-latest
             enable-x64: 0
             prng-upgrade: 0
             package-overrides: "none"
@@ -54,7 +54,7 @@ jobs:
             use-latest-jaxlib: false
           - name-prefix: "with numpy-dispatch"
             python-version: "3.9"
-            os: ubuntu-20.04-16core
+            os: ubuntu-latest
             enable-x64: 1
             prng-upgrade: 1
             # Test experimental NumPy dispatch
@@ -63,7 +63,7 @@ jobs:
             use-latest-jaxlib: false
           - name-prefix: "with 3.10"
             python-version: "3.10"
-            os: ubuntu-20.04-16core
+            os: ubuntu-latest
             enable-x64: 0
             prng-upgrade: 0
             package-overrides: "none"
@@ -123,7 +123,7 @@ jobs:
 
 
   documentation:
-    runs-on: ubuntu-20.04-16core
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:


### PR DESCRIPTION
We're seeing broken queues - testing if it only affects newer larger runner VMs.