### PR TITLE
[jax2tf] Force keep_unused for native lowering when we have shape poly

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -742,6 +742,12 @@ def _jit_lower(fun, static_argnums, static_argnames, device, backend,
       if abstracted_axes:
         raise ValueError("abstracted_axes must be used with --jax_dynamic_shapes")
       in_avals, _ = unzip2(arg_specs_and_devices)
+      if any(not core.is_constant_shape(a.shape) for a in in_avals):
+        # TODO(b/262808613): Do not drop unused inputs when we have
+        # shape polymorphism, to ensure that we can always derive
+        # the dimension variables from the kept inputs.
+        nonlocal keep_unused
+        keep_unused = True
     if jax.config.jax_array:
       computation = dispatch.sharded_lowering(
           flat_fun, device, backend, flat_fun.__name__, donated_invars, True,

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -756,33 +756,17 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
 
     # A polymorphic arg is not used, and the dimension var does not appear
     # elsewhere.
-    if config.jax2tf_default_experimental_native_lowering:
-      with self.assertRaisesRegex(ValueError,
-                                  "The following dimension variables cannot be computed"):
-        self.CheckShapePolymorphism(
-            lambda x_unused, y: y * 2.0,
-            input_signature=[tf.TensorSpec([None]), tf.TensorSpec([None])],
-            polymorphic_shapes=["b1", "b2"])
-    else:
-      self.CheckShapePolymorphism(
-          lambda x_unused, y: y * 2.0,
-          input_signature=[tf.TensorSpec([None]), tf.TensorSpec([None])],
-          polymorphic_shapes=["b1", "b2"])
+    self.CheckShapePolymorphism(
+        lambda x_unused, y: y * 2.0,
+        input_signature=[tf.TensorSpec([None]), tf.TensorSpec([None])],
+        polymorphic_shapes=["b1", "b2"])
 
     # A polymorphic arg is not used, and the dimension var does appear
     # elsewhere but not as a trivial monomial.
-    if config.jax2tf_default_experimental_native_lowering:
-      with self.assertRaisesRegex(ValueError,
-                                  "The following dimension variables cannot be computed"):
-        self.CheckShapePolymorphism(
-            lambda x_unused, y: y * 2.0,
-            input_signature=[tf.TensorSpec([None]), tf.TensorSpec([None])],
-            polymorphic_shapes=["b1", "b1 * b1"])
-    else:
-      self.CheckShapePolymorphism(
-          lambda x_unused, y: y * 2.0,
-          input_signature=[tf.TensorSpec([None]), tf.TensorSpec([None])],
-          polymorphic_shapes=["b1", "b1 * b1"])
+    self.CheckShapePolymorphism(
+        lambda x_unused, y: y * 2.0,
+        input_signature=[tf.TensorSpec([None]), tf.TensorSpec([None])],
+        polymorphic_shapes=["b1", "b1 * b1"])
 
 
   def test_with_custom_vjp(self):


### PR DESCRIPTION
In presence of dimension variables in the input shapes we conservatively keep all unused inputs because otherwise we may drop the only inputs from whose shape we can infer the values of the dimension variables. 

This change has very limited effect: only for native serialization when we have shape polymorphism and only if there are unused inputs. We may revisit this conservative solution, e.g., by changing the mechanism by which we compute the values of the dimension variables.

See b/261971607.