### PR TITLE
Address drastic slowdown in mypy runtime

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   lint_and_typecheck:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
     steps:
       - name: Cancel previous
         uses: styfle/cancel-workflow-action@0.11.0

--- a/jax/_src/third_party/scipy/betaln.py
+++ b/jax/_src/third_party/scipy/betaln.py
@@ -3,7 +3,10 @@ import jax.numpy as jnp
 from jax._src.typing import Array, ArrayLike
 from jax._src.numpy.lax_numpy import _promote_args_inexact
 
-def algdiv(a: ArrayLike, b: ArrayLike) -> Array:
+# Note: for mysterious reasons, annotating this leads to very slow mypy runs.
+# def algdiv(a: ArrayLike, b: ArrayLike) -> Array:
+
+def algdiv(a, b):
     """
     Compute ``log(gamma(a))/log(gamma(a + b))`` when ``b >= 8``.
 


### PR DESCRIPTION
Our mypy runtimes have become very long lately - a bisect revealed the culprit was #13288

This PR removes the type anniotations from that function. I'm not sure why it is problematic, and I don't plan to dig into it further, but this should fix our mypy presubmit and make it usable again.

Confirmed that after this change, `mypy -m jax` finishes in about 30 seconds. Before this change, it's 5+ minutes (I ran out of patience and didn't let it finish)

Related to https://github.com/google/jax/issues/12049.