### PR TITLE
[ROCm]: Disable some tests on ROCm platform

### DIFF
--- a/tests/experimental_rnn_test.py
+++ b/tests/experimental_rnn_test.py
@@ -33,7 +33,7 @@ class RnnTest(jtu.JaxTestCase):
       num_layers=[1, 4],
       bidirectional=[True, False],
   )
-  @jtu.skip_on_devices("cpu", "tpu")
+  @jtu.skip_on_devices("cpu", "tpu","rocm")
   def test_lstm(self, batch_size: int, seq_len: int, input_size: int,
                 hidden_size: int, num_layers: int, bidirectional: bool):
     batch_size = 6

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -337,6 +337,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     dtype=float_types + complex_types,
     lower=[True, False],
   )
+  @jtu.skip_on_devices("rocm")
   def testEighIdentity(self, n, dtype, lower):
     tol = 1e-3
     uplo = "L" if lower else "U"
@@ -1337,7 +1338,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       dtype=float_types + complex_types,
       lower=[False, True],
   )
-  @jtu.skip_on_devices("tpu")
+  @jtu.skip_on_devices("tpu","rocm")
   def testTridiagonal(self, shape, dtype, lower):
     rng = jtu.rand_default(self.rng())
     def jax_func(a):
@@ -1594,6 +1595,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   @jtu.sample_product(
     shape=[(), (3,), (1, 4), (1, 5, 9), (11, 0, 13)],
     dtype=float_types + complex_types + int_types)
+  @jtu.skip_on_devices("rocm")
   def testToeplitzSymmetricConstruction(self, shape, dtype):
     if (dtype in [np.float64, np.complex128]
         and not config.x64_enabled):

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -861,7 +861,7 @@ class LaxRandomTest(jtu.JaxTestCase):
     alpha=[np.array([0.2, 1., 5.]),],
     dtype=jtu.dtypes.floating,
   )
-  @jtu.skip_on_devices("tpu")  # TODO(mattjj): slow compilation times
+  @jtu.skip_on_devices("tpu","rocm")  # TODO(mattjj): slow compilation times
   def testDirichlet(self, alpha, dtype):
     key = self.seed_prng(0)
     rand = lambda key, alpha: random.dirichlet(key, alpha, (10000,), dtype)
@@ -876,6 +876,7 @@ class LaxRandomTest(jtu.JaxTestCase):
       for i, a in enumerate(alpha):
         self._CheckKolmogorovSmirnovCDF(samples[..., i], scipy.stats.beta(a, alpha_sum - a).cdf)
 
+  @jtu.skip_on_devices("rocm")
   def testDirichletSmallAlpha(self, dtype=np.float32):
     # Regression test for https://github.com/google/jax/issues/9896
     key = self.seed_prng(0)


### PR DESCRIPTION
Disable some failing tests on ROCm for now

1. tests/experimental_rnn_test.py::test_lstm
2. tests/linalg_test.py::testEighIdentity
3. tests/linalg_test.py::testTridiagonal
4. tests/linalg_test.py::testToeplitzSymmetricConstruction
5. tests/linalg_test.py::testDirichlet
6. tests/linalg_test.py::testDirichletSmallAlpha