### PR TITLE
tweak print_saved_residuals

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -396,8 +396,12 @@ def saved_residuals(f, *args, **kwargs) -> List[Tuple[core.AbstractValue, str]]:
       if v in res_vars:
         if eqn.primitive is name_p:
           results.append((v.aval, f"named '{eqn.params['name']}' from {src}"))
+        elif str(eqn.primitive) == 'xla_call':
+          results.append((v.aval,
+                          f"output of jitted function '{eqn.params['name']}' "
+                          f"from {src}"))
         else:
-          results.append((v.aval, f'from {src}'))
+          results.append((v.aval, f'output of {eqn.primitive.name} from {src}'))
 
   assert len(results) == len(jaxpr.outvars)
   return results

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -33,6 +33,7 @@ import weakref
 import functools
 import itertools as it
 import operator as op
+import gc
 
 from absl import logging
 from absl.testing import absltest, parameterized
@@ -479,11 +480,14 @@ class CPPJitTest(jtu.BufferDonationTestCase):
     def f(x, y): return x + y
 
     client = jax.devices()[0].client
+    gc.collect()
     num_live_initial = len(client.live_executables())
     f(1, 2).block_until_ready()
+    gc.collect()
     num_live = len(client.live_executables())
     self.assertEqual(num_live_initial + 1, num_live)
     f.clear_cache()
+    gc.collect()
     num_live = len(client.live_executables())
     self.assertEqual(num_live_initial, num_live)
 


### PR DESCRIPTION
Small tweak to this utility (the printing details of which are untested, though its internals are tested and unchanged by this PR). 

Given this code:

```python
def g(W, x):
  y = jnp.dot(W, x)
  return jnp.sin(y)

def f(W1, W2, W3, x):
  x = g(W1, x)
  x = g(W2, x)
  x = g(W3, x)
  return x

W1 = jnp.ones((5, 4))
W2 = jnp.ones((6, 5))
W3 = jnp.ones((7, 6))
x = jnp.ones(4)

jax.ad_checkpoint.print_saved_residuals(f, W1, W2, W3, x)
```

Before this PR, we'd print:

```
f32[5,4] from the argument 'W1'
f32[6,5] from the argument 'W2'
f32[7,6] from the argument 'W3'
f32[4] from the argument 'x'
f32[5] from /usr/local/google/home/mattjj/packages/jax/ckpt.py:46 (g)
f32[5] from /usr/local/google/home/mattjj/packages/jax/ckpt.py:46 (g)
f32[6] from /usr/local/google/home/mattjj/packages/jax/ckpt.py:46 (g)
f32[6] from /usr/local/google/home/mattjj/packages/jax/ckpt.py:46 (g)
f32[7] from /usr/local/google/home/mattjj/packages/jax/ckpt.py:46 (g)
```

After this PR, we'll print:

```
f32[5,4] from the argument 'W1'
f32[6,5] from the argument 'W2'
f32[7,6] from the argument 'W3'
f32[4] from the argument 'x'
f32[5] output of sin from /usr/local/google/home/mattjj/packages/jax/ckpt.py:46 (g)
f32[5] output of cos from /usr/local/google/home/mattjj/packages/jax/ckpt.py:46 (g)
f32[6] output of sin from /usr/local/google/home/mattjj/packages/jax/ckpt.py:46 (g)
f32[6] output of cos from /usr/local/google/home/mattjj/packages/jax/ckpt.py:46 (g)
f32[7] output of cos from /usr/local/google/home/mattjj/packages/jax/ckpt.py:46 (g)
```

Also, if we put a `jax.jit` on `g`, we'll get:

```
f32[5,4] from the argument 'W1'
f32[6,5] from the argument 'W2'
f32[7,6] from the argument 'W3'
f32[4] from the argument 'x'
f32[5] output of jitted function 'g' from /usr/local/google/home/mattjj/packages/jax/ckpt.py:50 (f)
f32[5] output of jitted function 'g' from /usr/local/google/home/mattjj/packages/jax/ckpt.py:50 (f)
f32[6] output of jitted function 'g' from /usr/local/google/home/mattjj/packages/jax/ckpt.py:51 (f)
f32[6] output of jitted function 'g' from /usr/local/google/home/mattjj/packages/jax/ckpt.py:51 (f)
f32[7] output of jitted function 'g' from /usr/local/google/home/mattjj/packages/jax/ckpt.py:52 (f)
```

We could instead recurse into jitted functions, but I decided not to because:
1. that would be a bigger change, and
2. if we imagine the jitted functions are e.g. `jnp` functions, then it's probably more informative to print the jitted function name rather than printing the name of some primitive in its implementation (which may be less clear to the user).