### PR TITLE
Add IO callback

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -3347,7 +3347,7 @@ def block_until_ready(x):
   return jax.tree_util.tree_map(try_to_block, x)
 
 def pure_callback(callback: Callable[..., Any], result_shape_dtypes: Any,
-                  *args: Any, **kwargs: Any):
+                  *args: Any, vectorized: bool = False, **kwargs: Any):
   """Applies a functionally pure Python callable. Works under :func:`jit`/:func:`~pmap`/etc.
 
   ``pure_callback`` enables calling a Python function in JIT-ed JAX functions.
@@ -3390,14 +3390,15 @@ def pure_callback(callback: Callable[..., Any], result_shape_dtypes: Any,
       via `jax.vmap`, it will be called directly on inputs with leading batch
       dimensions instead of executing ``callback`` on each mapped input
       individually. The callback should also return outputs batched across the
-      leading axis.
+      leading axis. By default, ``vectorized`` is ``False``.
     **kwargs: The keyword arguments to the callback. Must be PyTrees of JAX
       types.
 
   Returns:
     The value of ``callback(*args, **kwargs)``.
   """
-  return jcb.pure_callback(callback, result_shape_dtypes, *args, **kwargs)
+  return jcb.pure_callback(callback, result_shape_dtypes, *args,
+                           vectorized=vectorized, **kwargs)
 
 def clear_backends():
   """

--- a/jax/_src/callback.py
+++ b/jax/_src/callback.py
@@ -23,11 +23,11 @@ from jax._src import core
 from jax._src import dtypes
 from jax._src import util
 from jax._src import dispatch
+from jax._src.lib import xla_client as xc
 from jax.interpreters import ad
 from jax.interpreters import batching
 from jax.interpreters import mlir
 import numpy as np
-from jax._src.lib import xla_client as xc
 
 # `pure_callback_p` is the main primitive for staging out Python pure callbacks.
 pure_callback_p = core.Primitive("pure_callback")
@@ -149,4 +149,107 @@ def pure_callback(callback: Callable[..., Any], result_shape_dtypes: Any,
   out_flat = pure_callback_p.bind(
       *flat_args, callback=_flat_callback,
       result_avals=tuple(flat_result_avals), vectorized=vectorized)
+  return tree_util.tree_unflatten(out_tree, out_flat)
+
+
+# IO Callback
+
+io_callback_p = core.Primitive("io_callback")
+io_callback_p.multiple_results = True
+
+class IOEffect:
+  __str__ = lambda _: "IO"
+class OrderedIOEffect:
+  __str__ = lambda _: "OrderedIO"
+_IOEffect = IOEffect()
+_OrderedIOEffect = OrderedIOEffect()
+mlir.lowerable_effects.add(_IOEffect)
+mlir.lowerable_effects.add(_OrderedIOEffect)
+core.control_flow_allowed_effects.add(_IOEffect)
+core.control_flow_allowed_effects.add(_OrderedIOEffect)
+core.ordered_effects.add(_OrderedIOEffect)
+
+
+def io_callback_impl(*args, result_avals, callback: Callable[..., Any],
+                     ordered: bool):
+  del result_avals, ordered
+  return callback(*args)
+io_callback_p.def_impl(functools.partial(dispatch.apply_primitive,
+                                         io_callback_p))
+
+@io_callback_p.def_effectful_abstract_eval
+def io_callback_abstract_eval(*avals, callback: Callable[..., Any],
+                              result_avals, ordered: bool):
+  del avals, callback
+  effect = _OrderedIOEffect if ordered else _IOEffect
+  return result_avals, {effect}
+
+def io_callback_jvp_rule(*args, **kwargs):
+  del args, kwargs
+  raise ValueError("IO callbacks do not support JVP.")
+ad.primitive_jvps[io_callback_p] = io_callback_jvp_rule
+
+
+def io_callback_transpose_rule(*args, **kwargs):
+  del args, kwargs
+  raise ValueError("IO callbacks do not support transpose.")
+ad.primitive_transposes[io_callback_p] = io_callback_transpose_rule
+
+
+def io_callback_batching_rule(args, dims, callback, result_avals, ordered):
+  if ordered:
+    raise ValueError("Cannot `vmap` ordered IO callback.")
+  return pure_callback_batching_rule(args, dims, callback=callback,
+      vectorized=False, result_avals=result_avals)
+batching.primitive_batchers[io_callback_p] = io_callback_batching_rule
+
+def io_callback_lowering(ctx, *args, callback, ordered, **params):
+
+  def _callback(*flat_args):
+    return tuple(io_callback_impl(*flat_args, callback=callback,
+                                  ordered=ordered, **params))
+
+  # TODO(sharadmv): figure out the best API for sharding callbacks. For now, we
+  # can only safely maximally shard. Should we allow device_index to be passed
+  # in like host_callback?
+  if isinstance(ctx.module_context.axis_context,
+                (mlir.SPMDAxisContext, mlir.ShardingContext)):
+    # Apply maximal sharding so pjit only executes the callback on device 0.
+    sharding = xc.OpSharding()
+    sharding.type = xc.OpSharding.Type.MAXIMAL
+    sharding.tile_assignment_dimensions = [1]
+    sharding.tile_assignment_devices = [0]
+  else:
+    sharding = None
+
+  if ordered:
+    token = ctx.tokens_in.get(_OrderedIOEffect)[0]
+    result, token, keepalive = mlir.emit_python_callback(
+        ctx, _callback, token, list(args), ctx.avals_in, ctx.avals_out, True,
+        sharding=sharding)
+    ctx.set_tokens_out(mlir.TokenSet({_OrderedIOEffect: (token,)}))
+  else:
+    result, token, keepalive = mlir.emit_python_callback(
+        ctx, _callback, None, list(args), ctx.avals_in, ctx.avals_out, True,
+        sharding=sharding)
+  ctx.module_context.add_keepalive(keepalive)
+  return result
+mlir.register_lowering(io_callback_p, io_callback_lowering)
+
+def io_callback(callback: Callable[..., Any], result_shape_dtypes: Any,
+                *args: Any, ordered: bool = False, **kwargs: Any):
+  def _flat_callback(*flat_args):
+    args, kwargs = tree_util.tree_unflatten(in_tree, flat_args)
+    return tree_util.tree_leaves(callback(*args, **kwargs))
+
+  flat_args, in_tree = tree_util.tree_flatten((args, kwargs))
+  tree_util.tree_map(_check_shape_dtype, result_shape_dtypes)
+  flat_shape_dtypes, out_tree = tree_util.tree_flatten(result_shape_dtypes)
+  flat_result_avals = map(lambda x: core.ShapedArray(x.shape, x.dtype),
+                          flat_shape_dtypes)
+  flat_args = map(core.raise_as_much_as_possible, flat_args)
+  out_flat = io_callback_p.bind(
+      *flat_args, callback=_flat_callback,
+      result_avals=tuple(flat_result_avals),
+      ordered=ordered)
   return tree_util.tree_unflatten(out_tree, out_flat)

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -63,6 +63,7 @@ Effect = Hashable
 Effects = Set[Effect]
 no_effects: Effects = set()
 ordered_effects: Set[Effect] = set()
+control_flow_allowed_effects: Set[Effect] = set()
 
 
 class Jaxpr:

--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -15,21 +15,21 @@
 import os
 from functools import partial
 
-from typing import Callable, Optional, Sequence, Set
+from typing import Callable, Optional, Sequence
 
-from jax import core
+from jax._src import core
 from jax._src import linear_util as lu
-from jax.api_util import flatten_fun_nokwargs
-from jax.interpreters import partial_eval as pe
+from jax._src.core import control_flow_allowed_effects as allowed_effects
 from jax._src.lax import lax
 from jax._src import ad_util
 from jax._src import util
 from jax._src.util import cache, weakref_lru_cache, safe_map, unzip3
+from jax.api_util import flatten_fun_nokwargs
+from jax.interpreters import partial_eval as pe
 from jax.tree_util import tree_map, tree_unflatten
 
 map, unsafe_map = safe_map, map
 
-allowed_effects: Set[core.Effect] = set()
 allowed_effects.add(lax.InOutFeedEffect.Infeed)
 allowed_effects.add(lax.InOutFeedEffect.Outfeed)
 

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1143,6 +1143,12 @@ def _while_loop_abstract_eval(*args, cond_jaxpr, body_jaxpr, **kwargs):
 def _while_loop_batching_rule(axis_size, axis_name, main_type, args, dims,
                               cond_nconsts, cond_jaxpr,
                               body_nconsts, body_jaxpr):
+  from jax._src.callback import _IOEffect, _OrderedIOEffect
+  if any(eff in branch.effects for eff in [_IOEffect, _OrderedIOEffect]
+      for branch in [body_jaxpr, cond_jaxpr]):
+    raise NotImplementedError(
+        "IO effect not supported in vmap-of-while.")
+
   orig_batched = [d is not batching.not_mapped for d in dims]
   cconst_bat, bconst_bat, init_bat = split_list(orig_batched, [cond_nconsts, body_nconsts])
   cconsts, bconsts, init = split_list(args, [cond_nconsts, body_nconsts])

--- a/jax/experimental/__init__.py
+++ b/jax/experimental/__init__.py
@@ -22,3 +22,6 @@ from jax.experimental.x64_context import (
   enable_x64 as enable_x64,
   disable_x64 as disable_x64,
 )
+from jax._src.callback import (
+  io_callback as io_callback
+)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -972,6 +972,9 @@ jax_test(
 jax_test(
     name = "python_callback_test",
     srcs = ["python_callback_test.py"],
+    deps = [
+        "//jax:experimental",
+    ],
 )
 
 jax_test(


### PR DESCRIPTION
# Background
In JAX, we usually express computations as compositions of XLA operations but oftentimes we want to call out to Python functions. Historically, the primary mechanism has been `jax.experimental.host_callback` but in making host callback non-experimental, we’re looking into improving it on all fronts: underlying implementation improvements (via send/recv on TPU, custom call on CPU/GPU), simpler API for users (see `jax.debug.print`), and safety/correctness (`jax.pure_callback`, `jax.debug.callback`). 

We’ll discuss a missing new-generation callback (`io_callback`) and some challenges in its implementation.

# Host callback under transformation
We’ve introduced two public, non-experimental Python callback mechanisms, namely `jax.debug.callback` and `jax.pure_callback`, but they aren’t as general purpose as `jax.experimental.host_callback`.

`jax.experimental.host_callback.call` takes in a callable, a set of arguments, and metadata about the return type. It then stages out the callable into HLO as a custom call (or uses infeed/outfeed on TPU). Unlike `jax.debug.callback` and `jax.pure_callback`, it has no requirements for the callable. `jax.debug.callback` doesn’t allow callbacks with return values and `jax.pure_callback` does not allow side-effects in the callable (not enforceable, but it is assumed by JAX and XLA).

Why do we have two separate callbacks that each have restrictions? Why not make a `jax.callback` that can handle any manner of callable? The answer is side-effects. Unlike regular primitives that are staged out, an arbitrary Python callback may not have well defined transformation rules. How do you differentiate through logging to Tensorboard? host_callback defines transformation rules in a particular way and works with basically every transformation and higher order primitive, but as a consequence, it can have counterintuitive behavior when there are side-effects present. 

Let’s look at some brief examples. Although `vmap` is the main instigator, issues can crop up, in general, when transforming higher-order primitives with side effects in them.

Example 1: vmap of cond
```python
def f(pred):
  def true_fun():
    hcb.call(lambda _: print("true"), (), result_shape=None)
  def false_fun():
    hcb.call(lambda _: print("false"), (), result_shape=None)
  return lax.cond(pred, false_fun, true_fun)

jax.vmap(f)(jnp.array([True, True]))
# ==> prints
# true
# false
```

Example 2: vmap of while
```python
def check(x, _):
  assert np.all(x < 5)

def f(i):
  def cond(i):
    return i < 5
  def body(i):
    i = hcb.id_tap(check, i, result=i)
    return i + 1
  return lax.while_loop(cond, body, i)

jax.vmap(f)(jnp.array([0, 4])).block_until_ready() # ==> raises AssertionError!
```

Why are these weird behaviors happening? Fundamentally, it’s because the vmap-of-cond and vmap-of-while transformation rules are not aware of side-effects and assume that their bodies are pure. Lowering a vmap-of-cond to a select and a vmap-of-while to a padded loop are both semantics preserving when the bodies are pure but not so when the bodies have side-effects.

# New callbacks
We’ve designed the new callbacks with limitations or asterisks in place to deal with the aforementioned issues with transformations.

`jax.debug.callback` was designed intentionally to have “undefined” semantics under transformations, i.e. we make no promises about whether these callbacks will be duplicated, dropped, or even called with invalid values. This makes it useful for debugging because it reveals information about the execution of the program. Note that this is more a problem of communication than anything else. We’ve made sure that in our documentation, we explicitly [bring up the intent](https://jax.readthedocs.io/en/latest/debugging/print_breakpoint.html#why-debug-print) of `jax.debug.callback`.

`jax.pure_callback` transforms similarly, but assumes the user does not have side-effects in their callback. This gives JAX and XLA the right to DCE it, duplicate it, etc., but most importantly preserves the correctness of JAX’s current transformation rules.

Basically, in both of the new-gen callbacks, we circumvent the problem by either defining it away or by assuming a property of the input function.

## Are the current callbacks enough?
One way to approach this question would be to answer the question: can we replace all existing uses of host_callback with calls to `jax.debug.callback` and `jax.pure_callback`? First, suggesting people use `jax.debug.callback` as a replacement for `host_callback` is not ideal, since we’ve already defined it as the “undefined” callback function in many ways (it can be transformed arbitrarily). So, the question is, can all `host_callback` usage be replaced with `jax.pure_callback`? Based on conversations with users, we think the answer is no. Effectful host_callbacks are used in a variety of different ways. 

Some known example usages that are not supported by `jax.pure_callback` are:
* Streaming outputs to host while a JAX computation is executing
* Calling out to stateful RPC servers 
* Logging to Tensorboard
* Progress bars

It seems like we should support some side-effects that have well-defined transformation semantics (where well-defined might mean to error!).

# IO Callback
So, is it as easy as creating a new `jax.io_callback` (where IO indicates an arbitrary side-effect)? Well, yes and no. First we need to establish how it behaves under transformations. Here are some properties we’d like to have:

* `jax.io_callback` should throw an error when autodifferentiated, since we have no way of differentiating through arbitrary side effects.
* `jax.io_callback` should (by default) not be allowed in `vmap`, `pmap`, and `xmap`. Since they are parallel maps (`vmap` pushes parallelism down into the op, `pmap` runs ops on separate threads, and `xmap` does a combination thereof), we can’t safely call the function (there may be race conditions or reordering, for example). However, this is a common enough use-case that maybe we should provide an escape hatch. For example, if an `io_callback` is specified to be “unordered” explicitly (as in calls can be executed out of order except wrt to data dependency), they will be allowed in `vmap` and perhaps “thread safe” to be allowed in `pmap`.
* `jax.io_callback` could be allowed in pjit if we run it on a single host + device and do an all-gather on its inputs.
* When inside some higher order primitives under transformation (e.g. vmap-of-while, vmap-of-cond), we must throw an error. Alternatively we could use a sequential (loop-over-batch) lowering of while and cond that avoids calling the callbacks extra times at the cost of performance.
* `jax.io_callback` should be disallowed in `jax.remat/checkpoint` since it will execute the side-effect extra times.

What we see here is that `io_callback` is largely not compatible with JAX transformations because we have no general way of transforming it. Despite that, it should still cover the use-cases mentioned. These limitations can be circumvented more generally, however, through the use of `jax.custom_jvp/vjp/batching/etc`, which will be explicit escape hatches for users.

Alternatively, we can also offer `jax.unsafe_callback` which transforms arbitrarily, but also explicitly opts the user into undefined behavior. However, we should strive to offer as few callback options as possible, to keep things simple for users.

## Challenge: data-dependence in transformations
We said that we want to throw errors when `io_callback`s are transformed. However, data-dependence throws a wrench in our plans. 
Take the following example:

```python
def f(x):
  jax.io_callback(lambda: print("hi!"), result_shape=None)
  return x
jax.vmap(f)(jnp.arange(5))
```

We mentioned before that this should throw an error. However, it is actually nontrivial to make this function error in current JAX. The reason is that `vmap` operates via data-dependency. We only ever run the batching rules for primitives that have batched inputs. The `io_callback` has no inputs at all, so the vmap trace never even sees it. If we were to naively run this code with our aforementioned transformation semantics, we would not get an error because we never actually run the io_callback batching rule. We see a similar issue when transforming with AD.

To actually throw errors here, we could change JAX’s tracing machinery. Specifically, we could make these traces “dynamic traces” that capture all primitive calls. However, this is a pretty heavy duty change and should be avoided unless completely necessary.

For now we punt on this issue. It seems like there are paths to addressing it and for now we can add `io_callback` to `experimental` until we deal with these issues.

## Challenge: sharding callbacks

In this implementation, like `jax.debug.callback`, we **maximally shard** the callback. This means it always happens on a single device (and a single host). This limits its power in that users have no control over how the callback happens inside of a multidevice JIT-ted function. However, it is the safest option that enables it working at all. We should explore this open design question on how to expose more flexible shardings.

cc: @mattjj  @jakevdp 