### PR TITLE
Make `jax.ensure_compile_time_eval` correctly exposed as a public API

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -62,7 +62,7 @@ from jax._src.config import (
   transfer_guard_device_to_host as transfer_guard_device_to_host,
   spmd_mode as spmd_mode,
 )
-from jax._src.core import eval_context as ensure_compile_time_eval
+from jax._src.core import ensure_compile_time_eval as ensure_compile_time_eval
 from jax._src.environment_info import print_environment_info as print_environment_info
 from jax._src.api import (
   ad,  # TODO(phawkins): update users to avoid this.


### PR DESCRIPTION
This function was added as a public API (#7987) but py.type static
checkers do not recognize it as a public API because of the alias name.

`jax.eval_context` exists only for backward compatibility, so the
correct import would be to import `ensure_compile_time_eval` directly
from `jax._src.core`.
