### PR TITLE
[sparse] propagate metadata through vmappable

### DIFF
--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -2624,7 +2624,8 @@ def _bcoo_to_elt(cont, _, val, axis):
     raise ValueError(f"Cannot map in_axis={axis} for BCOO array with n_batch={val.n_batch}. "
                      "in_axes for batched BCOO operations must correspond to a batch dimension.")
   return BCOO((cont(val.data, axis), cont(val.indices, axis)),
-              shape=val.shape[:axis] + val.shape[axis + 1:])
+              shape=val.shape[:axis] + val.shape[axis + 1:],
+              indices_sorted=val.indices_sorted, unique_indices=val.unique_indices)
 
 def _bcoo_from_elt(cont, axis_size, elt, axis):
   if axis is None:
@@ -2633,6 +2634,7 @@ def _bcoo_from_elt(cont, axis_size, elt, axis):
     raise ValueError(f"BCOO: cannot add out_axis={axis} for BCOO array with n_batch={elt.n_batch}. "
                      "BCOO batch axes must be a contiguous block of leading dimensions.")
   return BCOO((cont(axis_size, elt.data, axis), cont(axis_size, elt.indices, axis)),
-              shape=elt.shape[:axis] + (axis_size,) + elt.shape[axis:])
+              shape=elt.shape[:axis] + (axis_size,) + elt.shape[axis:],
+              indices_sorted=elt.indices_sorted, unique_indices=elt.unique_indices)
 
 batching.register_vmappable(BCOO, int, int, _bcoo_to_elt, _bcoo_from_elt, None)

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -2311,10 +2311,12 @@ class SparseObjectTest(sptu.SparseTestCase):
       self.assertIsInstance(x, cls)
       self.assertEqual(x.n_batch, 1)
       self.assertEqual(x.shape, Msp.shape)
+      self.assertEqual(x._info, Msp._info)
 
       self.assertIsInstance(y, cls)
       self.assertEqual(y.n_batch, 1)
       self.assertEqual(y.shape, Msp.shape)
+      self.assertEqual(y._info, Msp._info)
 
   @parameterized.named_parameters(
     {"testcase_name": f"_{cls.__name__}", "cls": cls}


### PR DESCRIPTION
Extra medatadata had been dropped within `vmap` up to this point. This doesn't affect correctness of code, but could result in mapped operations not being lowered to cusparse on GPU.