### PR TITLE
Fix typo in loops.py

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1701,7 +1701,7 @@ def fori_loop(lower, upper, body_fun, init_val):
                               (lower, upper, init_val))
   return result
 
-### map and miscellanous rules
+### map and miscellaneous rules
 
 @api_boundary
 def map(f, xs):


### PR DESCRIPTION
miscellanous -> miscellaneous