### PR TITLE
Fix wrong cond-state discharge rule.

### DIFF
--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -839,8 +839,7 @@ def _cond_state_discharge_rule(in_avals, out_avals, *args, branches, linear):
       core.ClosedJaxpr(state.discharge_state(branch.jaxpr, ())[0], ())
       for branch in branches)
   out_vals = cond_p.bind(*args, branches=discharged_branches, linear=linear)
-  out_ref_vals, out_vals = util.split_list(
-      out_vals, [len(out_vals) - len(out_avals)])
+  out_vals, out_ref_vals = util.split_list(out_vals, [len(out_avals)])
   ref_val_iter = iter(out_ref_vals)
   new_invals = []
   for aval in in_avals:


### PR DESCRIPTION
`discharge_state` returns the original output and then the updated refs, not the other way around.