### PR TITLE
validate shape & dtype in ShapeDtypeStruct

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2988,7 +2988,9 @@ def device_get(x: Any):
 class ShapeDtypeStruct:
   __slots__ = ["shape", "dtype", "named_shape", "sharding"]
   def __init__(self, shape, dtype, named_shape=None, sharding=None):
-    self.shape = shape
+    self.shape = tuple(shape)
+    if dtype is None:
+      raise ValueError("ShapeDtypeStruct: dtype must be specified.")
     self.dtype = dtype if core.is_opaque_dtype(dtype) else np.dtype(dtype)
     if sharding is not None:
       self.sharding = sharding

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2252,6 +2252,14 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(hash(s1), hash(s2))
     self.assertNotEqual(hash(s1), hash(s3))
 
+  def test_shape_dtype_struct_invalid_shape(self):
+    with self.assertRaisesRegex(TypeError, "'int' object is not iterable"):
+      api.ShapeDtypeStruct(shape=4, dtype='float32')
+
+  def test_shape_dtype_struct_dtype_none(self):
+    with self.assertRaisesRegex(ValueError, "dtype must be specified"):
+      api.ShapeDtypeStruct(shape=(), dtype=None)
+
   def test_eval_shape(self):
     def fun(x, y):
       return jnp.tanh(jnp.dot(x, y) + 3.)


### PR DESCRIPTION
Followup to #13258

There was maybe some disagreement about this in #13258, but my opinion remains that passing `dtype=None` in `ShapeDtypeStruct` should be an error, rather than us trying to guess what the user might have intended. I'll be sure to run a global test on this to find out if anyone is depending on this behavior.