### PR TITLE
cleanup: remove several unused imports across the package

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -25,10 +25,8 @@ import collections
 import functools
 from functools import partial
 import inspect
-import itertools as it
 from typing import (Any, Callable, Generator, Hashable, Iterable, List, Literal,
                     NamedTuple, Optional, Sequence, Tuple, TypeVar, Union, overload)
-from warnings import warn
 
 import numpy as np
 from contextlib import contextmanager, ExitStack
@@ -38,8 +36,7 @@ from jax._src import linear_util as lu
 from jax import stages
 from jax.tree_util import (tree_map, tree_flatten, tree_unflatten,
                            tree_structure, tree_transpose, tree_leaves,
-                           treedef_is_leaf, treedef_children,
-                           Partial, PyTreeDef, all_leaves, treedef_tuple)
+                           Partial, PyTreeDef, all_leaves)
 from jax._src import callback as jcb
 from jax._src import core
 from jax._src import device_array

--- a/jax/experimental/custom_partitioning.py
+++ b/jax/experimental/custom_partitioning.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Tuple
-
 import jax
 from jax import core
 from jax import tree_util
@@ -24,7 +22,6 @@ from jax._src.lib.mlir.dialects import hlo
 from jax._src.lib.mlir import ir
 import jax.interpreters.pxla as pxla
 from jax.interpreters import mlir
-from jax.interpreters import xla
 from jax.interpreters import partial_eval as pe
 from jax._src import custom_api_util
 from jax._src.lib import xla_client as xc

--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -24,7 +24,6 @@ https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#callin
 """
 import enum
 import functools
-import re
 from typing import Any, Callable, Optional, Sequence, Tuple
 
 from absl import logging

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Experimental module transforms JAX functions to be executed by TensorFlow."""
-from functools import partial, reduce
+from functools import partial
 import contextlib
 import operator
 import os

--- a/jax/experimental/jax2tf/tests/control_flow_ops_test.py
+++ b/jax/experimental/jax2tf/tests/control_flow_ops_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for the jax2tf conversion for control-flow primitives."""
-import unittest
 
 from absl.testing import absltest
 

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -58,7 +58,6 @@ from functools import partial
 
 import numpy as np
 
-import jax
 from jax import core
 from jax import lax
 from jax.interpreters import xla

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import threading
 import contextlib
 import numpy as np
 import itertools as it
 from collections import OrderedDict, abc
 from typing import (Callable, Iterable, Tuple, Optional, Dict, Any, Set,
                     NamedTuple, Union, Sequence)
-from warnings import warn
 from functools import wraps, partial, partialmethod, lru_cache
 
 from jax import numpy as jnp
@@ -28,8 +26,7 @@ from jax._src import linear_util as lu
 from jax import stages
 from jax._src import dispatch
 from jax.tree_util import (tree_flatten, tree_unflatten, all_leaves, tree_map,
-                           tree_leaves, treedef_tuple)
-from jax._src.tree_util import _replace_nones
+                           treedef_tuple)
 from jax._src.api_util import (flatten_fun_nokwargs, flatten_axes,
                                _ensure_index_tuple, donation_vector,
                                shaped_abstractify, check_callable)
@@ -46,8 +43,6 @@ from jax.interpreters import pxla
 from jax.interpreters import xla
 from jax.interpreters import batching
 from jax.interpreters import ad
-from jax._src.lib import xla_bridge as xb
-from jax._src.lib import xla_client as xc
 from jax._src.util import (safe_map, safe_zip, HashableFunction, unzip2, unzip3,
                            as_hashable_function, distributed_debug_log,
                            tuple_insert, moveaxis, split_list, wrap_name,

--- a/jax/experimental/sparse/bcsr.py
+++ b/jax/experimental/sparse/bcsr.py
@@ -34,7 +34,6 @@ import jax.numpy as jnp
 from jax._src import api_util
 from jax._src.lax.lax import DotDimensionNumbers
 from jax.util import split_list, safe_zip
-from jax.interpreters import ad
 from jax.interpreters import batching
 from jax.interpreters import mlir
 from jax._src.typing import Array, ArrayLike, DTypeLike


### PR DESCRIPTION
Technically our flake8 check should catch these, but we disable unused import checks on many files to avoid having to annotate `# skip: F401` on a line-by-line basis in top-level modules. The `setup.cfg` syntax doesn't have the flexibiilty to do this with more granularity, as far as I know.