### PR TITLE
Fix `UnicodeDecodeError` while installing using `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open('jax/version.py') as f:
 __version__ = _dct['__version__']
 _minimum_jaxlib_version = _dct['_minimum_jaxlib_version']
 
-with open('README.md') as f:
+with open('README.md', encoding='utf-8') as f:
   _long_description = f.read()
 
 if 'PROTOC' in os.environ and os.path.exists(os.environ['PROTOC']):


### PR DESCRIPTION
On a current version, installing by given `pip` or `setup.py`, the error thrown:
```bash
(venv) C:\Users\OWNER\Documents\_github\test>pip install jax
Collecting jax
  Using cached jax-0.4.1.tar.gz (1.2 MB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\OWNER\AppData\Local\Temp\pip-install-3uze50ne\jax_2313d4a2790f4c34bb54679a87916fff\setup.py", line 38, in <module>
          _long_description = f.read()
      UnicodeDecodeError: 'cp949' codec can't decode byte 0xe2 in position 1301: illegal multibyte sequence
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
```

So I fixed it by passing argument `encoding="utf-8"` and it works.