### PR TITLE
[sparse] fix corner case of bcoo_extract

### DIFF
--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -417,8 +417,9 @@ def _bcoo_extract_impl(indices, mat):
   else:
     result = mat.at[batch_ind + sparse_ind].get(mode='fill', fill_value=0)
   if n_sparse == 0 and nse != 1:
-    result = lax.broadcast_in_dim(
-      result, _tuple_replace(result.shape, n_batch, nse), range(result.ndim))
+    out_shape = _tuple_replace(result.shape, n_batch, nse)
+    ind = n_batch * (slice(None),) + (slice(1),)
+    result = jnp.zeros_like(result, shape=out_shape).at[ind].set(result)
   return result
 
 @bcoo_extract_p.def_abstract_eval


### PR DESCRIPTION
This fixes a bug that was introduced in #13653, and adds some test cases.

I discovered this via discrepancies in the JVP rule for `bcoo_fromdense`.