### PR TITLE
[Typing] Add `Optional` to parameter `boundary` of `stft`.

### DIFF
--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -439,7 +439,7 @@ def _spectral_helper(x: Array, y: Optional[ArrayLike], fs: ArrayLike = 1.0,
 @_wraps(osp_signal.stft)
 def stft(x: Array, fs: ArrayLike = 1.0, window: str = 'hann', nperseg: int = 256,
          noverlap: Optional[int] = None, nfft: Optional[int] = None,
-         detrend: bool = False, return_onesided: bool = True, boundary: str = 'zeros',
+         detrend: bool = False, return_onesided: bool = True, boundary: Optional[str] = 'zeros',
          padded: bool = True, axis: int = -1) -> Tuple[Array, Array, Array]:
   return _spectral_helper(x, None, fs, window, nperseg, noverlap,
                           nfft, detrend, return_onesided,


### PR DESCRIPTION
According to [doc](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.signal.stft.html#jax.scipy.signal.stft), parameter `boundary` should accept `None`, indicating no extension at both ends.
I found this issue when typing checking [one of my own project](https://github.com/JyChang012/espnet/blob/jax/asr_train/espnex/layers/stft.py) using `mypy`.