### PR TITLE
Improve vmap error

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -25,7 +25,7 @@ from jax._src import core
 from jax._src import dtypes
 from jax._src.tree_util import (
     PyTreeDef, tree_flatten, tree_unflatten, tree_map, tree_structure,
-    treedef_children, treedef_is_leaf)
+    treedef_children)
 from jax._src.tree_util import _replace_nones
 from jax._src import linear_util as lu
 from jax._src.util import safe_map, WrapKwArgs, Hashable, Unhashable
@@ -417,8 +417,7 @@ def flatten_axes(name, treedef, axis_tree, *, kws=False, tupled_args=False):
     if kws:
       # if keyword arguments are included in the tree, we make adapt the error
       # message only to be about the positional arguments
-      treedef, leaf = treedef_children(treedef)
-      assert treedef_is_leaf(leaf)
+      treedef, _ = treedef_children(treedef)
       axis_tree, _ = axis_tree
     hint = ""
     if tupled_args:


### PR DESCRIPTION
Part of #7465. As far as I can tell there's no reason for this assertion as the only thing it accomplishes is preventing a more informative error from being raised. I think this error still could be better, but this is an easy start.

Example:
```python
import jax
from functools import partial

@partial(jax.vmap, in_axes=(0, 0))
def f(x, y):
  return x + y

x = y = jax.numpy.arange(4)
f(x, y=y)
```
Error before:
```pytb
Traceback (most recent call last):
  File "/Users/vanderplas/github/google/jax/jax/_src/api_util.py", line 415, in flatten_axes
    tree_map(add_leaves, _replace_nones(proxy, axis_tree), dummy)
  File "/Users/vanderplas/github/google/jax/jax/_src/tree_util.py", line 206, in tree_map
    all_leaves = [leaves] + [treedef.flatten_up_to(r) for r in rest]
  File "/Users/vanderplas/github/google/jax/jax/_src/tree_util.py", line 206, in <listcomp>
    all_leaves = [leaves] + [treedef.flatten_up_to(r) for r in rest]
ValueError: Tuple arity mismatch: 1 != 2; tuple: (<object object at 0x7f99e0e769b0>,).

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "tmp.py", line 8, in <module>
    f(x, y=y)
  File "/Users/vanderplas/github/google/jax/jax/_src/traceback_util.py", line 162, in reraise_with_filtered_traceback
    return fun(*args, **kwargs)
  File "/Users/vanderplas/github/google/jax/jax/_src/api.py", line 1594, in vmap_f
    in_axes_flat = flatten_axes("vmap in_axes", in_tree, (in_axes, 0), kws=True)
  File "/Users/vanderplas/github/google/jax/jax/_src/api_util.py", line 421, in flatten_axes
    assert treedef_is_leaf(leaf)
jax._src.traceback_util.UnfilteredStackTrace: AssertionError

The stack trace below excludes JAX-internal frames.
The preceding is the original exception that occurred, unmodified.

--------------------

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "tmp.py", line 8, in <module>
    f(x, y=y)
AssertionError
```
Error after:
```pytb
Traceback (most recent call last):
  File "tmp.py", line 8, in <module>
    f(x, y=y)
  File "/Users/vanderplas/github/google/jax/jax/_src/traceback_util.py", line 162, in reraise_with_filtered_traceback
    return fun(*args, **kwargs)
  File "/Users/vanderplas/github/google/jax/jax/_src/api.py", line 1594, in vmap_f
    in_axes_flat = flatten_axes("vmap in_axes", in_tree, (in_axes, 0), kws=True)
  File "/Users/vanderplas/github/google/jax/jax/_src/api_util.py", line 435, in flatten_axes
    raise ValueError(f"{name} specification must be a tree prefix of the "
jax._src.traceback_util.UnfilteredStackTrace: ValueError: vmap in_axes specification must be a tree prefix of the corresponding value, got specification (0, 0) for value tree PyTreeDef((*,)).

The stack trace below excludes JAX-internal frames.
The preceding is the original exception that occurred, unmodified.

--------------------

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "tmp.py", line 8, in <module>
    f(x, y=y)
ValueError: vmap in_axes specification must be a tree prefix of the corresponding value, got specification (0, 0) for value tree PyTreeDef((*,)).
```