### PR TITLE
[typing] improve sphinx rendering of type aliases

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,5 +295,12 @@ epub_exclude_files = ['search.html']
 always_document_param_types = True
 
 
+# Tell sphinx autodoc how to render type aliases.
+autodoc_type_aliases = {
+    'ArrayLike': 'ArrayLike',
+    'DTypeLike': 'DTypeLike',
+}
+
+
 # Remove auto-generated API docs from sidebars. They take too long to build.
 remove_from_toctrees = ["_autosummary/*"]


### PR DESCRIPTION
This ensures that `ArrayLike` and `DTypeLike` will be rendered more succinctly in the sphinx-generated docs. For example:

Before:
![Screen Shot 2023-01-04 at 9 09 32 AM](https://user-images.githubusercontent.com/781659/210611294-fb0c94c4-9e66-4376-b7b6-5ad756af8368.png)

After:
![Screen Shot 2023-01-04 at 9 09 45 AM](https://user-images.githubusercontent.com/781659/210611307-efaf5e62-a90f-4370-8955-49f203854610.png)

Related to https://github.com/google/jax/issues/13853