### PR TITLE
GPU tests: disable cusparse_lowering to avoid segfaults.

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -721,7 +721,8 @@ jax_test(
 jax_test(
     name = "sparse_test",
     srcs = ["sparse_test.py"],
-    args = ["--jax_bcoo_cusparse_lowering=true"],
+    # TODO(jakevdp,tianjianlu): re-enable this once segfaults are addressed.
+    # args = ["--jax_bcoo_cusparse_lowering=true"],
     backend_tags = {
         "cpu": [
             "nomsan",  # Times out
@@ -749,7 +750,8 @@ jax_test(
 jax_test(
     name = "sparsify_test",
     srcs = ["sparsify_test.py"],
-    args = ["--jax_bcoo_cusparse_lowering=true"],
+    # TODO(jakevdp,tianjianlu): re-enable this once segfaults are addressed.
+    # args = ["--jax_bcoo_cusparse_lowering=true"],
     shard_count = {
         "cpu": 5,
         "gpu": 20,


### PR DESCRIPTION
We've started seeing failures in the GPU CI jobs: https://source.cloud.google.com/results/invocations/8a57fcfe-439c-4fea-9434-ae71d017625e/targets/jax%2Ftesting%2Fcpu%2Fpresubmit_github/log

I suspect this is due to increased test coverage, and similar to the other cusparse-related GPU segfaults we've been seeing.