### PR TITLE
gitignore: specify root-directory files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 *.so
 *.egg-info
 *.whl
-build/bazel*
-dist/
+/build/lib
+/build/bazel*
+/dist/
 .ipynb_checkpoints
 /bazel-*
 .jax_configure.bazelrc
@@ -11,18 +12,18 @@ dist/
 .DS_Store
 .mypy_cache/
 .pytype/
-docs/build
+/docs/build
 *_pb2.py
-docs/notebooks/.ipynb_checkpoints/
-docs/_autosummary
+/docs/notebooks/.ipynb_checkpoints/
+/docs/_autosummary
 .idea
 .vscode
 .envrc
 jax.iml
 
 # virtualenv/venv directories
-venv/
-bin/
-include/
-lib/
-share/
+/venv/
+/bin/
+/include/
+/lib/
+/share/


### PR DESCRIPTION
My VSCode was unable to search files that appeared in `jax/lib/`. It turns out this is because VSCode respects `.gitignore` during file search, and the `lib/` entry matches `lib` within *any* directory.

This tightens up our gitignore so that root-directory ignores are explicitly in the root directory.