### PR TITLE
[sparse] generalize batch rule for bcoo_spdot_general

### DIFF
--- a/jax/experimental/sparse/test_util.py
+++ b/jax/experimental/sparse/test_util.py
@@ -128,8 +128,8 @@ class SparseTestCase(jtu.JaxTestCase):
                            check_dtypes=True, tol=None, atol=None, rtol=None,
                            canonicalize_dtypes=True):
     if bdims is None:
-      bdims = self._random_bdims([arg.n_batch if is_sparse(arg) else arg.ndim
-                                  for arg in args_maker()])
+      bdims = self._random_bdims(*(arg.n_batch if is_sparse(arg) else arg.ndim
+                                  for arg in args_maker()))
     def concat(args, bdim):
       return sparse.sparsify(functools.partial(lax.concatenate, dimension=bdim))(args)
     def expand(arg, bdim):


### PR DESCRIPTION
Previously, `vmap(bcoo_spdot_general)` only supported `in_axes=None` or `in_axes=0` for the data and index arrays. It now supports any axis corresponding to a batch dimension of the sparse matrix. Related PRs: #13887