### PR TITLE
CI: fix doc requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,8 +2,10 @@ absl-py
 # TODO(sharadmv,jakevdp): fix IPython3 issue and remove pinned version
 ipython<=8.6.0
 sphinx>=4
-sphinx-autodoc-typehints
-sphinx-book-theme>=0.3.3
+# TODO(jakevdp) unpin sphinx-autodoc-typehints when sphinx-book-theme
+# no longer requires sphinx<5
+sphinx-autodoc-typehints<1.19
+sphinx-book-theme>=0.3.3 
 sphinx-copybutton>=0.5.0
 sphinx-remove-toctrees
 jupyter-sphinx>=0.3.2


### PR DESCRIPTION
`sphinx-autodoc-typehints` now requires sphinx>=5.3, which conflicts with the requirements of `sphinx-book-theme`, and this has slowed down pip's dependency resolver to the point where the CI frequently times out.

`sphinx-book-theme` 0.4.0 with compatibility for sphinx 5.0 will be released soon, at which point we can update these pinnings.