### PR TITLE
DOC: change requirements pinnings to prevent timeout

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,9 @@
 absl-py
-# TODO(sharadmv,jakevdp): fix IPython3 issue and remove pinned version
-ipython<=8.6.0
+ipython>=8.8.0  # 8.7.0 has ipython3 lexer error
 sphinx>=4
 # TODO(jakevdp) unpin sphinx-autodoc-typehints when sphinx-book-theme
-# no longer requires sphinx<5
-sphinx-autodoc-typehints<1.19
+# 0.4.0 is released and no longer requires sphinx<5
+sphinx-autodoc-typehints~=1.18.0
 sphinx-book-theme>=0.3.3 
 sphinx-copybutton>=0.5.0
 sphinx-remove-toctrees


### PR DESCRIPTION
The documentation build was timing out during dependency resolution (e.g. https://github.com/google/jax/actions/runs/3875612625/jobs/6608391582); I think this should fix it.