### PR TITLE
compute jit number of replicas using least-common-multiple, not max

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -368,7 +368,6 @@ def _effect_free_abstract_eval(abstract_eval):
 
 # TODO(mattjj): replace this approach with a primitive-keyed table of rules
 def traverse_jaxpr_params(f, params):
-  """Applies f to each jaxpr parameter and returns a tuple of returned values."""
   return {name: f(p)
           for name, param in params.items()
           for p in (param if isinstance(param, (tuple, list)) else [param])

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -2063,6 +2063,16 @@ class PythonPmapTest(jtu.JaxTestCase):
     self.assertEqual(jaxpr_text.count(' sin '), 1)
     self.assertEqual(jaxpr_text.count(' cos '), 2)
 
+  def test_jit_of_pmap_replica_calculation(self):
+    # https://github.com/google/jax/issues/13931
+    @jax.jit
+    def f():
+      a = jax.pmap(lambda x: x)(jnp.arange(2))
+      b = jax.pmap(lambda x: x)(jnp.arange(3))
+      return a, b
+
+    f()  # doesn't crash
+
 
 class CppPmapTest(PythonPmapTest):
 


### PR DESCRIPTION
fix #13931 (see discussion thread there)