### PR TITLE
[docs] change donate_argnums FAQ link to rst format

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -228,7 +228,7 @@ def jit(
       arguments will not be donated.
 
       For more details on buffer donation see the
-      [FAQ](https://jax.readthedocs.io/en/latest/faq.html#buffer-donation).
+      `FAQ <https://jax.readthedocs.io/en/latest/faq.html#buffer-donation>`_.
 
     inline: Specify whether this function should be inlined into enclosing
       jaxprs (rather than being represented as an application of the xla_call
@@ -1774,7 +1774,7 @@ def pmap(
       arguments will not be donated.
 
       For more details on buffer donation see the
-      [FAQ](https://jax.readthedocs.io/en/latest/faq.html#buffer-donation).
+      `FAQ <https://jax.readthedocs.io/en/latest/faq.html#buffer-donation>`_.
 
     global_arg_shapes: Optional, must be set when using pmap(sharded_jit) and
       the partitioned values span multiple processes. The global cross-process

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -283,7 +283,7 @@ def pjit(
       for example recycling one of your input buffers to store a result. You
       should not reuse buffers that you donate to a computation, JAX will raise
       an error if you try to.
-      For more details on buffer donation see the [FAQ](https://jax.readthedocs.io/en/latest/faq.html#buffer-donation).
+      For more details on buffer donation see the `FAQ <https://jax.readthedocs.io/en/latest/faq.html#buffer-donation>`_.
     keep_unused: If `False` (the default), arguments that JAX determines to be
       unused by `fun` *may* be dropped from resulting compiled XLA executables.
       Such arguments will not be transferred to the device nor provided to the

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -371,7 +371,7 @@ def xmap(fun: Callable,
       should not reuse buffers that you donate to a computation, JAX will raise
       an error if you try to.
 
-      For more details on buffer donation see the [FAQ](https://jax.readthedocs.io/en/latest/faq.html#buffer-donation).
+      For more details on buffer donation see the `FAQ <https://jax.readthedocs.io/en/latest/faq.html#buffer-donation>`_.
 
     backend: This is an experimental feature and the API is likely to change.
       Optional, a string representing the XLA backend. 'cpu', 'gpu', or 'tpu'.


### PR DESCRIPTION
## Summary

Fix markdown-style link which does not render properly, integrated to RestructuredText hyperlink format.

## References
* https://stackoverflow.com/a/17189724/11853111
* https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#hyperlink-references