### PR TITLE
DOC: add note about localhost & friends in jax.distributed.initialize

### DIFF
--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -131,6 +131,8 @@ def initialize(coordinator_address: Optional[str] = None,
       port does not matter, so long as the port is available on the coordinator
       and all processes agree on the port.
       May be ``None`` only on supported environments, in which case it will be chosen automatically.
+      Note that special addresses like ``localhost`` or ``127.0.0.1`` usually mean that the program
+      will bind to a local interface and are not suited when running in a multi-node environment.
     num_processes: Number of processes. May be ``None`` only on supported environments, in
       which case it will be chosen automatically.
     process_id: The ID number of the current process. The ``process_id`` values across

--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -132,7 +132,7 @@ def initialize(coordinator_address: Optional[str] = None,
       and all processes agree on the port.
       May be ``None`` only on supported environments, in which case it will be chosen automatically.
       Note that special addresses like ``localhost`` or ``127.0.0.1`` usually mean that the program
-      will bind to a local interface and are not suited when running in a multi-node environment.
+      will bind to a local interface and are not suitable when running in a multi-host environment.
     num_processes: Number of processes. May be ``None`` only on supported environments, in
       which case it will be chosen automatically.
     process_id: The ID number of the current process. The ``process_id`` values across


### PR DESCRIPTION
This PR adds a note in the `jax.distribute.initialize` doc to warn users to not use `localhost` or `127.0.0.1` addresses when doing multi-node runs. This is because using `localhost`, for instance, means that the socket will be bound to a local interface (`lo` for instance). This will prevent other processes to connect to it during bootstrapping and will lead to timeouts (`DEADLINE EXCEEDED`).