### PR TITLE
[call_tf] Temporary fix for CallTfEffect being visible after lowering.

### DIFF
--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -237,10 +237,12 @@ def _get_concrete_function_tf(function_flat_tf, args_flat_sig_tf):  # -> tf.Conc
   with jax2tf_internal.inside_call_tf():
     return function_flat_tf.get_concrete_function(*args_flat_sig_tf)
 
-
+# Added only to prevent DCE from removing arguments to call_tf
+# TODO(necula): there must be a better way of preventing DCE, or dealing with
+# it, rather than hijacking the unrelated effects mechanism.
 CallTfEffect = enum.Enum('CallTfEffect', ['EFFECT'])
 
-mlir.lowerable_effects.add(CallTfEffect.EFFECT)
+mlir.ignore_effects_when_lowering.add(CallTfEffect.EFFECT)
 lax_control_flow.allowed_effects.add(CallTfEffect.EFFECT)
 ad_checkpoint.remat_allowed_effects.add(CallTfEffect.EFFECT)
 custom_derivatives.allowed_effects.add(CallTfEffect.EFFECT)

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -2924,9 +2924,11 @@ def lower_sharding_computation(
     if any(eff in core.ordered_effects for eff in closed_jaxpr.effects):
       raise ValueError("Ordered effects are not supported for more than 1 device.")
   unordered_effects = [eff for eff in closed_jaxpr.effects
-                       if eff not in core.ordered_effects]
+                       if (eff not in mlir.ignore_effects_when_lowering and
+                           eff not in core.ordered_effects)]
   ordered_effects = [eff for eff in closed_jaxpr.effects
-                     if eff in core.ordered_effects]
+                     if (eff not in mlir.ignore_effects_when_lowering and
+                         eff in core.ordered_effects)]
   lowering_result = mlir.lower_jaxpr_to_module(
       module_name,
       closed_jaxpr,

--- a/tests/jaxpr_effects_test.py
+++ b/tests/jaxpr_effects_test.py
@@ -665,7 +665,7 @@ class ParallelEffectsTest(jtu.JaxTestCase):
       effect_p.bind(effect='abc')
       return x
     with self.assertRaisesRegex(
-        ValueError, "Cannot lower jaxpr with effects: {'abc'}"):
+        ValueError, "Cannot lower jaxpr with unlowerable effects: {'abc'}"):
       jax.pmap(f)(jnp.arange(jax.local_device_count()))
 
   def test_cannot_pmap_ordered_effect(self):


### PR DESCRIPTION
The CallTfEffect was added recently as an internal workaround for DCE removing arguments to call_tf. This may have been a convenient available mechanism, but there is no real "effect" here, and we should not hijack the effects mechanism for dealing with DCE.

This PR does not really solve the problem, but it removes the CallTfEffect from the externally-visible set of effects, so that users of the AOT APIs do not have to worry about the computation having real effects.

Relates to #13963