### PR TITLE
checkify: in traceable, convert constvars to args to fit ClosedJaxpr convention

### DIFF
--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -1066,12 +1066,10 @@ def checkify(f: Callable[..., Out],
     flat_fun, out_tree = flatten_fun(fun, in_tree)
     flat_avals = map(get_shaped_aval, flat_args)
     jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(flat_fun, flat_avals)
-    out_tree = out_tree()
+    jaxpr = pe.close_jaxpr(pe.convert_constvars_jaxpr(jaxpr))
     # checkify:
-    flat_args = jtu.tree_leaves((args, kwargs))
-    error, out_flat = checkify_jaxpr(core.ClosedJaxpr(jaxpr, consts), errors,
-                                     init_error, *flat_args)
-    return error, jtu.tree_unflatten(out_tree, out_flat)
+    error, out_flat = checkify_jaxpr(jaxpr, errors, init_error, *consts, *flat_args)
+    return error, jtu.tree_unflatten(out_tree(), out_flat)
   return checked_fun
 
 def check(pred: Bool, msg: str, *fmt_args, **fmt_kwargs) -> None:

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -146,6 +146,7 @@ class ClosedJaxpr:
 
   def __init__(self, jaxpr: Jaxpr, consts: Sequence):
     assert len(consts) == len(jaxpr.constvars)
+    assert not any(isinstance(c, Tracer) for c in consts)
     self.jaxpr = jaxpr
     self.consts = list(consts)
 


### PR DESCRIPTION
Because the 'consts' that come out when we trace the user function to a jaxpr could be `Tracers` (e.g. doing `grad`-of-`checkify`), **by `ClosedJaxpr` convention** we shouldn't package them up in a ClosedJaxpr.

Since checkify isn't a higher-order primitive, and is instead an initial-style transformation, putting Tracers in the ClosedJaxpr **was not actually a bug**, in that it wouldn't cause any incorrect behavior. Still, it's _usually_ a bug for Tracers to end up in ClosedJaxprs, since _usually_ ClosedJaxprs are used for higher-order primitives. For that reason, I'd like to add the assertion in core.py.

Without this change, if we add the assertion in core.py, the test AssertPrimitiveTests.test_assert_discharging_no_data_dependence fails.

But let me know if you think this convention is not worth keeping!