### PR TITLE
Added symbolic zeros as inputs to `custom_jvp`

### DIFF
--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -910,10 +910,11 @@ def custom_jvp_call_rule(in_err, enabled_errors, *in_vals, num_consts,
   @lu.wrap_init
   def jvp(*xs):
     # TODO(lenamartens, sharadmv): why not checkify here?
-    jvp_jaxpr, jvp_consts = jvp_jaxpr_thunk()
     n, ragged = divmod(len(xs), 2)
     assert not ragged
     primals, tangents = xs[num_consts:n], xs[n+num_consts:]
+    avals = tuple(map(core.get_aval, primals) + map(core.get_aval, tangents))
+    jvp_jaxpr, jvp_consts = jvp_jaxpr_thunk(*avals)
     return core.eval_jaxpr(jvp_jaxpr, jvp_consts, *primals, *tangents)
 
   jvp, jvp_out_tree = flatten_fun_output(jvp)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -307,6 +307,7 @@ pytype_aval_mappings.update((t, _make_shaped_array_for_numpy_scalar)
 pytype_aval_mappings[np.ndarray] = _make_shaped_array_for_numpy_array
 pytype_aval_mappings.update(
     (t, partial(_make_abstract_python_scalar, t)) for t in _scalar_types)
+pytype_aval_mappings[ad.SymbolicZero] = operator.attrgetter("aval")
 
 
 def primitive_subcomputation(platform: str, axis_env: 'AxisEnv',

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6186,6 +6186,21 @@ class DCETest(jtu.JaxTestCase):
     self.assert_dce_result(jaxpr, [True, False], [True, True], 5)
 
 
+def _pack(x):
+  return lax.broadcast(x, (1,))
+
+def _unpack(x):
+  (x,) = x
+  return x
+
+def _vmap(fun):
+  def _fun(*args):
+    args = tree_util.tree_map(_pack, args)
+    out = jax.vmap(fun)(*args)
+    out = tree_util.tree_map(_unpack, out)
+    return out
+  return _fun
+
 class CustomJVPTest(jtu.JaxTestCase):
 
   def test_basic(self):
@@ -7258,6 +7273,58 @@ class CustomJVPTest(jtu.JaxTestCase):
     grad     = jax.grad(g    )(0.1)  # doesn't crash
     grad_ref = jax.grad(g_ref)(0.1)
     self.assertAllClose(grad, grad_ref, check_dtypes=False)
+
+  @parameterized.named_parameters(
+      ('jit_vmap', True, True),
+      ('jit', True, False),
+      ('vmap', False, True),
+      ('', False, False),
+  )
+  def test_symbolic_zero_custom_jvp(self, maybe_jit, maybe_vmap):
+    def f(static_scalar, static_array, dyn_scalar, dyn_array):
+      out1 = static_scalar + dyn_scalar
+      out2 = static_array + dyn_array
+      return out1, out2
+
+    f = api.custom_jvp(f, symbolic_zeros=True)
+
+    @f.defjvp
+    def f_jvp(primals, tangents):
+      static_scalar, *_ = primals
+      t_static_scalar, t_static_array, t_dyn_scalar, t_dyn_array = tangents
+      self.assertIsInstance(t_static_scalar.aval, ad.ZeroShapedArray)
+      self.assertIsInstance(t_static_array.aval, ad.ZeroShapedArray)
+      self.assertEqual(t_static_scalar.shape, ())
+      self.assertEqual(t_static_array.shape, (2,))
+      return f(*primals), (static_scalar + 90, t_dyn_array + 91)
+
+    def g(dyn_scalar, dyn_array):
+      if maybe_vmap:
+        f_ = _vmap(f)
+      else:
+        f_ = f
+      return f_(1., jnp.array([2., 3.]), dyn_scalar, dyn_array)
+
+    def run(primal_ins, tangent_ins):
+      return jax.jvp(g, primal_ins, tangent_ins)
+
+    if maybe_jit:
+      run = jax.jit(run)
+
+    primal_ins = (4., jnp.array([5., 6.]))
+    tangent_ins = (7., jnp.array([8., 9.]))
+    primal_outs, tangent_outs = run(primal_ins, tangent_ins)
+    primal_out1, primal_out2 = primal_outs
+    tangent_out1, tangent_out2 = tangent_outs
+    scalar_dtype = jax.Array if maybe_jit or maybe_vmap else float
+    self.assertIsInstance(primal_out1, scalar_dtype)
+    self.assertAllClose(primal_out1, 5.)
+    self.assertIsInstance(tangent_out1, scalar_dtype)
+    self.assertAllClose(tangent_out1, 91.)
+    self.assertIsInstance(primal_out2, jax.Array)
+    self.assertArraysAllClose(primal_out2, jnp.array([7., 9.]))
+    self.assertIsInstance(tangent_out2, jax.Array)
+    self.assertArraysAllClose(tangent_out2, jnp.array([99., 100.]))
 
 
 class CustomVJPTest(jtu.JaxTestCase):


### PR DESCRIPTION
Added a `jax.custom_jvp(..., symbolic_zeros=True)` flag, which causes symbolic zero tangents to be passed as a `SymbolicZero` object.

Design choices already discussed with @froystig:

1. We decided to make this a new `SymbolicZero` object since (a) `ad_util.Zero` is so far only used inside AD rules, and we didn't want to promulgate that outside of its current context, and (b) `None` doesn't carry any aval information.
2. In time we imagined that `ad_util.Zero` could potentially be removed in favour of the new `SymbolicZero`, which can be treated as a concrete array type. Special symbolic-zero-handling would move from being a thing done in AD rules to a thing done in impl/lowering rules.
3. This behaviour is gated behind a `symbolic_zeros` flag to avoid breaking everyone who depends on the current behaviour.

Design choices not discussed with @froystig:

1. The symbolic zero gets its own aval (not just `ShapedArray`), since in practice things may be wrapped in tracers (e.g. batch tracers), so the appropriate way to check for a symbolic zero in user-code is currently `isinstance(tangent.aval, ad.ZeroShapedArray)`. Hypothetically we could imagine avoiding this new aval by having every `FooTrace.process_custom_jvp_call` special-case a symbolic zero, but that strikes me as very intrusive. (E.g. `BatchTrace` would remove a dimension from `SymbolicZero` instead of wrapping it into a `BatchTracer`; `JVPTrace` would instead pass it through unchanged, etc.)

Questions for @froystig and/or @mattjj:

1. Are we happy with the above design choices?
2. Which file do we want to put `SymbolicZero` in?
3. What API do we want for downstream users to detect symbolic zeros?
    - The current `isinstance(tangent.aval, ad.ZeroShapedArray)`?
    - An `is_symbolic_zero` function?
    - We could also drop all tracer information and substitute `Traced<ZeroShapedArray>` for `SymbolicZero` immediately prior to passing to the user, to allow for a relatively-natural `isinstance(tangent, SymbolicZero)`.

[To-do for me: also add an equivalent `ShapedArrayRef -> ZeroShapedArrayRef` mapping. But I wanted to get this first version out to get some feedback first.]

---

Partially addresses #11208.