### PR TITLE
Added shape error checking for compute_fans

### DIFF
--- a/jax/_src/nn/initializers.py
+++ b/jax/_src/nn/initializers.py
@@ -157,6 +157,10 @@ def _compute_fans(shape: core.NamedShape,
   Axes not in in_axis, out_axis, or batch_axis are assumed to constitute the
   "receptive field" of a convolution (kernel spatial dimensions).
   """
+  if shape.rank <= 1:
+    raise ValueError(f"Can't compute input and output sizes of a {shape.rank}"
+                     "-dimensional weights tensor. Must be at least 2D.")
+
   if isinstance(in_axis, int):
     in_size = shape[in_axis]
   else:

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -314,6 +314,19 @@ class NNInitializersTest(jtu.JaxTestCase):
 
     self.assertEqual(shape, jnp.shape(val))
 
+  def testVarianceScalingError(self):
+    rng = random.PRNGKey(0)
+    shape = (5,)
+    initializer = nn.initializers.variance_scaling(
+      scale=1.0, mode='fan_avg', distribution='truncated_normal')
+
+    with self.assertRaisesRegex(
+      ValueError,
+      "Can't compute input and output sizes of a 1"
+      "-dimensional weights tensor. Must be at least 2D."
+    ):
+      initializer(rng, shape)
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
When Flax users try to use `variance_scaling` initializers to instantiate bias params, 
```
import jax, jax.numpy as jnp
import flax.linen as nn

layer = nn.Dense(features=5, bias_init=nn.initializers.lecun_normal())
layer.init(jax.random.PRNGKey(42), jnp.zeros((1,4)))
```
they are met with an `IndexError: tuple index out of range` (e.g. [here](https://github.com/google/flax/issues/2749#issue-1505561830) and [here](https://github.com/google/flax/issues/1386#issue-929436644)).

While it is [intentional for these initializers to not work on 1D arrays](https://github.com/google/jax/issues/2075#issuecomment-578465814), this PR adds a more informative error message.