### PR TITLE
Make JAX Debugging and Profiling guides more visible

### DIFF
--- a/docs/debugging/index.md
+++ b/docs/debugging/index.md
@@ -1,11 +1,17 @@
 # Runtime value debugging in JAX
 
-Do you have exploding gradients? Are nans making you gnash your teeth? Just want to poke around the intermediate values in your computation? Check out the following JAX debugging tools! This page has tl;dr summaries and you can click the "Read more" links at the bottom to learn more.
+Do you have exploding gradients? Are NaNs making you gnash your teeth? Just want to poke around the intermediate values in your computation? Check out the following JAX debugging tools! This page has TL;DR summaries and you can click the "Read more" links at the bottom to learn more.
+
+Table of contents:
+
+* [Interactive inspection with `jax.debug`](print_breakpoint)
+* [Functional error checks with jax.experimental.checkify](checkify_guide)
+* [Throwing Python errors with JAX’s debug flags](flags)
 
 ## [Interactive inspection with `jax.debug`](print_breakpoint)
 
-  **TL;DR** Use {func}`jax.debug.print` to print values to stdout in `jax.jit`-,`jax.pmap`-, and `pjit`-decorated functions
-  and use {func}`jax.debug.breakpoint` to pause execution of your compiled function to inspect values in the call stack:
+  **TL;DR** Use {func}`jax.debug.print` to print values to stdout in `jax.jit`-,`jax.pmap`-, and `pjit`-decorated functions,
+  and {func}`jax.debug.breakpoint` to pause execution of your compiled function to inspect values in the call stack:
 
   ```python
   import jax

--- a/docs/notes.rst
+++ b/docs/notes.rst
@@ -10,7 +10,5 @@ Notes
    deprecation
    concurrency
    gpu_memory_allocation
-   profiling
-   device_memory_profiling
    rank_promotion_warning
    jax_array_migration

--- a/docs/user_guides.rst
+++ b/docs/user_guides.rst
@@ -13,5 +13,7 @@ User Guides
    pytrees
    type_promotion
    errors
-   transfer_guard
    debugging/index
+   profiling
+   device_memory_profiling
+   transfer_guard


### PR DESCRIPTION
[Updated] 

1. Adds a table of contents to the Debugging guide index page:

```
Table of contents:
* Interactive inspection with jax.debug
* Functional error checks with jax.experimental.checkify
* Throwing Python errors with JAX’s debug flags
```

2. Moves the Debugging guides up the ToC tree, below the Errors guide.

3. Moves the Profiling guides from Notes to User Guides, below the Debugging guides.
 
@jakevdp @mattjj 

![image](https://user-images.githubusercontent.com/19637339/213583746-f6fbe244-e0b2-4dbc-949b-1e4d57ff0c75.png)