### PR TITLE
[shape_poly] Fix handling of weak_type for jnp.array(x.shape[0])

### DIFF
--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -461,6 +461,7 @@ class _DimPolynomial():
 
 core.pytype_aval_mappings[_DimPolynomial] = _DimPolynomial.get_aval
 xla.pytype_aval_mappings[_DimPolynomial] = _DimPolynomial.get_aval
+dtypes._weak_types.append(_DimPolynomial)
 
 def _ensure_poly(p: DimSize,
                  operation_name: str) -> _DimPolynomial:


### PR DESCRIPTION

In presence of static shapes `jnp.array(x.shape[0])` has weak_type. We must preserve that behavior even with symbolic dimensions.