### PR TITLE
Reflow three boxes on docs main page for mobile

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ JAX is Autograd_ and XLA_, brought together for high-performance numerical compu
    guide for more information.
 
 
-.. grid:: 3
+.. grid:: 1 3
 
     .. grid-item::
 
@@ -44,14 +44,12 @@ JAX is Autograd_ and XLA_, brought together for high-performance numerical compu
          :link-type: ref
          :class-card: getting-started
 
-    .. grid-item::
 
       .. card:: :material-regular:`library_books;2em` User Guides
          :link: user-guides
          :link-type: ref
          :class-card: user-guides
 
-    .. grid-item::
 
       .. card:: :material-regular:`laptop_chromebook;2em` Developer Docs
          :link: contributor-guide


### PR DESCRIPTION
On mobile the boxes for key jax features don't reflow. Trying to figure out how to do so, though this admittedly is not something I'm familiar with.

Creating PR for discussion and collaboration.

cc @jakevdp @8bitmp3 

https://sphinx-design.readthedocs.io/en/latest/grids.html
<img width="1562" alt="image" src="https://user-images.githubusercontent.com/7213793/213318940-01d8c75c-4d7f-487a-984c-b862d2e149c5.png">
