### PR TITLE
Reorganization among notes, user guides, advanced guides

### DIFF
--- a/docs/advanced_guide.rst
+++ b/docs/advanced_guide.rst
@@ -16,5 +16,6 @@ Advanced Tutorials
    notebooks/Writing_custom_interpreters_in_Jax
    notebooks/Neural_Network_and_Data_Loading
    notebooks/xmap_tutorial
+   notebooks/convolutions
    notebooks/external_callbacks
    Custom_Operation_for_GPUs

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -111,6 +111,14 @@ installation options, see the `Install Guide`_ in the project README.
    jax
 
 
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   changelog
+   glossary
+
+
 .. _Autograd: https://github.com/hips/autograd
 .. _XLA: https://www.tensorflow.org/xla
 .. _Install Guide: https://github.com/google/jax#installation

--- a/docs/notes.rst
+++ b/docs/notes.rst
@@ -13,3 +13,4 @@ Notes
    profiling
    device_memory_profiling
    rank_promotion_warning
+   jax_array_migration

--- a/docs/user_guides.rst
+++ b/docs/user_guides.rst
@@ -10,12 +10,8 @@ User Guides
    async_dispatch
    aot
    jaxpr
-   notebooks/convolutions
    pytrees
-   jax_array_migration
    type_promotion
    errors
    transfer_guard
-   glossary
-   changelog
    debugging/index


### PR DESCRIPTION
We still have some more categorization to do, but I think these were the more obvious misplaced sections.

Also pulls "changelog" and "glossary" out of user guides to the main table of contents (cc/ @LenaMartens)