### PR TITLE
CI: adjust permissions for upstream-nightly build

### DIFF
--- a/.github/workflows/upstream-nightly.yaml
+++ b/.github/workflows/upstream-nightly.yaml
@@ -23,6 +23,9 @@ on:
 jobs:
   upstream-dev:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write  # for upload-artifact
     defaults:
       run:
         shell: bash -l {0}
@@ -86,6 +89,9 @@ jobs:
   report:
     name: report
     needs: upstream-dev
+    permissions:
+      contents: read
+      issues: write
     if: |
       failure()
       && github.event_name == 'schedule'


### PR DESCRIPTION
The report job failed with a permissions error: https://github.com/google/jax/actions/runs/3958254462/jobs/6779789502

This should fix the issue.

For what it's worth, the root cause is a failure in numpy nightly, and is tracked here: numpy/numpy/issues/23033