### PR TITLE
CI: update deprecated uses of set-output

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -84,7 +84,7 @@ jobs:
       id: pip-cache
       run: |
         python -m pip install --upgrade pip wheel
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: pip cache
       uses: actions/cache@v3
       with:
@@ -143,7 +143,7 @@ jobs:
       id: pip-cache
       run: |
         python -m pip install --upgrade pip wheel
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: pip cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/upstream-nightly.yaml
+++ b/.github/workflows/upstream-nightly.yaml
@@ -69,7 +69,7 @@ jobs:
               --report-log output-${{ matrix.python-version }}-log.jsonl \
               tests \
               || (
-                echo '::set-output name=ARTIFACTS_AVAILABLE::true' && false
+                echo 'ARTIFACTS_AVAILABLE=true' >> $GITHUB_OUTPUT && false
               )
       - name: Upload artifacts
         if: |


### PR DESCRIPTION
This deprecation has been causing warnings in our CI build; for details see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/