### PR TITLE
[sparse] add a few missing methods to BCOO

### DIFF
--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -827,6 +827,7 @@ _bcoo_methods = {
   "astype": _astype,
   "reshape": _reshape,
   "sum": _sum,
+  "__abs__": sparsify(jnp.abs),
   "__neg__": sparsify(jnp.negative),
   "__pos__": sparsify(jnp.positive),
   "__matmul__": sparsify(jnp.matmul),
@@ -839,6 +840,12 @@ _bcoo_methods = {
   "__rsub__": sparsify(_swap_args(jnp.subtract)),
   "__getitem__": _sparse_rewriting_take,
   "__iter__": _sparse_iter,
+  "__gt__": sparsify(jnp.greater),
+  "__ge__": sparsify(jnp.greater_equal),
+  "__lt__": sparsify(jnp.less),
+  "__le__": sparsify(jnp.less_equal),
+  "__eq__": sparsify(jnp.equal),
+  "__ne__": sparsify(jnp.not_equal),
 }
 
 for method, impl in _bcoo_methods.items():


### PR DESCRIPTION
The inequalities are unimplemented, but adding the methods leads to more informative errors:
```python
>>> x = sparse.BCOO.fromdense(jnp.arange(4))
>>> x == 0
NotImplementedError: sparse rule for eq is not implemented because it would result in dense output.
If this is your intent, use sparse.todense() to convert your arguments to dense matrices.
```