### PR TITLE
specialize tree prefix error message for list/tuple

### DIFF
--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -3405,12 +3405,9 @@ class PJitErrorTest(jtu.JaxTestCase):
     # pjit(lambda x: x, p, p)([x, x, x])  # Error, but make sure we hint at singleton tuple
 
     error = re.escape(
-        "pytree structure error: different numbers of pytree children at "
+        "pytree structure error: different lengths of list at "
         "key path\n"
-        "    pjit out_axis_resources tree root\n"
-        "At that key path, the prefix pytree pjit out_axis_resources has a "
-        "subtree of type\n"
-        "    <class 'list'>\n")
+        "    pjit out_axis_resources tree root\n")
     with self.assertRaisesRegex(ValueError, error):
       pjit(lambda x: x, (p,), [p, None])([x, x, x])  # Error, we raise a generic tree mismatch message
 

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -507,8 +507,25 @@ class TreePrefixErrorsTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, expected):
       raise e2('in_axes')
 
-  def test_different_num_children(self):
+  def test_different_num_children_tuple(self):
     e, = prefix_errors((1,), (2, 3))
+    expected = ("pytree structure error: different lengths of tuple "
+                "at key path\n"
+                "    in_axes tree root")
+    with self.assertRaisesRegex(ValueError, expected):
+      raise e('in_axes')
+
+  def test_different_num_children_list(self):
+    e, = prefix_errors([1], [2, 3])
+    expected = ("pytree structure error: different lengths of list "
+                "at key path\n"
+                "    in_axes tree root")
+    with self.assertRaisesRegex(ValueError, expected):
+      raise e('in_axes')
+
+
+  def test_different_num_children_generic(self):
+    e, = prefix_errors({'hi': 1}, {'hi': 2, 'bye': 3})
     expected = ("pytree structure error: different numbers of pytree children "
                 "at key path\n"
                 "    in_axes tree root")
@@ -517,7 +534,7 @@ class TreePrefixErrorsTest(jtu.JaxTestCase):
 
   def test_different_num_children_nested(self):
     e, = prefix_errors([[1]], [[2, 3]])
-    expected = ("pytree structure error: different numbers of pytree children "
+    expected = ("pytree structure error: different lengths of list "
                 "at key path\n"
                 r"    in_axes\[0\]")
     with self.assertRaisesRegex(ValueError, expected):
@@ -525,12 +542,12 @@ class TreePrefixErrorsTest(jtu.JaxTestCase):
 
   def test_different_num_children_multiple(self):
     e1, e2 = prefix_errors([[1], [2]], [[3, 4], [5, 6]])
-    expected = ("pytree structure error: different numbers of pytree children "
+    expected = ("pytree structure error: different lengths of list "
                 "at key path\n"
                 r"    in_axes\[0\]")
     with self.assertRaisesRegex(ValueError, expected):
       raise e1('in_axes')
-    expected = ("pytree structure error: different numbers of pytree children "
+    expected = ("pytree structure error: different lengths of list "
                 "at key path\n"
                 r"    in_axes\[1\]")
     with self.assertRaisesRegex(ValueError, expected):


### PR DESCRIPTION
Consider:

```python
from jax._src.tree_util import prefix_errors  # internal utility for pytree prefix-related errors
e, = prefix_errors([1], [1, 2])
raise e('test')
```

Before this PR:
```
ValueError: pytree structure error: different numbers of pytree children at key path
    test tree root
At that key path, the prefix pytree test has a subtree of type
    <class 'list'>
with 1 child keys
    0
but at the same key path the full pytree has a subtree of the same type but with 2 child keys
    0 1
so the symmetric difference on key sets is
    1
```

After this PR:
```
ValueError: pytree structure error: different lengths of list at key path
    test tree root
At that key path, the prefix pytree test has a subtree of type list of length 1, but the full pytree has a subtree of the same type but of length 2.
```

The idea is that instead of treating sequences (lists and tuples) as pytrees with generic keys, and reporting the difference in their key sets (which are just sets of integers up to their length), just report the length difference because their key sets are uninteresting.

This PR special-cases lists and tuples. It'd be even better if people registering this key path info could register whether their pytree node is sequence-like, in the sense of the key set just being [0, ..., N), in which case we can just report the length difference like this. But instead of that bigger refactor I'm just special-casing lists and tuples.