### PR TITLE
[sparse] refactor tests to improve runtime

### DIFF
--- a/jax/experimental/sparse/test_util.py
+++ b/jax/experimental/sparse/test_util.py
@@ -44,51 +44,24 @@ class SparseTestCase(jtu.JaxTestCase):
     self.assertAllClose(x_bufs, y_bufs, check_dtypes=check_dtypes, atol=atol, rtol=rtol,
                         canonicalize_dtypes=canonicalize_dtypes, err_msg=err_msg)
 
-  def _CheckAgainstDense(self, dense_op, sparse_op, args_maker,
+  def _CheckAgainstDense(self, dense_op, sparse_op, args_maker, check_jit=True,
                          check_dtypes=True, tol=None, atol=None, rtol=None,
                          canonicalize_dtypes=True):
     """Check an operation against a dense equivalent"""
     sparse_args = args_maker()
     dense_args = tree_util.tree_map(sparse.todense, sparse_args, is_leaf=is_sparse)
+    expected = dense_op(*dense_args)
 
     sparse_ans = sparse_op(*sparse_args)
     actual = tree_util.tree_map(sparse.todense, sparse_ans, is_leaf=is_sparse)
-    expected = dense_op(*dense_args)
 
     self.assertAllClose(expected, actual, check_dtypes=check_dtypes,
                         atol=atol or tol, rtol=rtol or tol,
                         canonicalize_dtypes=canonicalize_dtypes)
-
-  def _CompileAndCheckSparse(self, fun, args_maker, check_dtypes=True,
-                             rtol=None, atol=None, check_cache_misses=True):
-    args = args_maker()
-
-    def wrapped_fun(*args):
-      self.assertTrue(python_should_be_executing)
-      return fun(*args)
-
-    python_should_be_executing = True
-    python_ans = fun(*args)
-
-    cache_misses = dispatch.xla_primitive_callable.cache_info().misses
-    python_ans = fun(*args)
-    if check_cache_misses:
-      self.assertEqual(
-          cache_misses, dispatch.xla_primitive_callable.cache_info().misses,
-          "Compilation detected during second call of {} in op-by-op "
-          "mode.".format(fun))
-
-    cfun = api.jit(wrapped_fun)
-    python_should_be_executing = True
-    monitored_ans = cfun(*args)
-
-    python_should_be_executing = False
-    compiled_ans = cfun(*args)
-
-    self.assertSparseArraysEquivalent(python_ans, monitored_ans, check_dtypes=check_dtypes,
-                                      atol=atol, rtol=rtol)
-    self.assertSparseArraysEquivalent(python_ans, compiled_ans, check_dtypes=check_dtypes,
-                                      atol=atol, rtol=rtol)
+    if check_jit:
+      sparse_ans_jit = jax.jit(sparse_op)(*sparse_args)
+      self.assertSparseArraysEquivalent(sparse_ans, sparse_ans_jit,
+                                        atol=atol or tol, rtol=rtol or tol)
 
   def _CheckGradsSparse(self, dense_fun, sparse_fun, args_maker, *,
                         argnums=None, modes=('fwd', 'rev'), atol=None, rtol=None):
@@ -125,7 +98,7 @@ class SparseTestCase(jtu.JaxTestCase):
     return [rng.randint(0, arg + 1) for arg in args]
 
   def _CheckBatchingSparse(self, dense_fun, sparse_fun, args_maker, *, batch_size=3, bdims=None,
-                           check_dtypes=True, tol=None, atol=None, rtol=None,
+                           check_jit=False, check_dtypes=True, tol=None, atol=None, rtol=None,
                            canonicalize_dtypes=True):
     if bdims is None:
       bdims = self._random_bdims(*(arg.n_batch if is_sparse(arg) else arg.ndim
@@ -139,7 +112,7 @@ class SparseTestCase(jtu.JaxTestCase):
       return [arg[0] if bdim is None else concat([expand(x, bdim) for x in arg], bdim)
               for arg, bdim in safe_zip(args, bdims)]
     self._CheckAgainstDense(jax.vmap(dense_fun, bdims), jax.vmap(sparse_fun, bdims), batched_args_maker,
-                            check_dtypes=check_dtypes, tol=tol, atol=atol, rtol=rtol,
+                            check_dtypes=check_dtypes, tol=tol, atol=atol, rtol=rtol, check_jit=check_jit,
                             canonicalize_dtypes=canonicalize_dtypes)
 
 def _rand_sparse(shape: Sequence[int], dtype: DTypeLike, *,


### PR DESCRIPTION
This effectively combines the `_CheckAgainstDense` and `_CompileAndCheckSparse` test utilities. Previously each test would do two jit and two non-jit calls of each tested function; with this change it's down to one jit and one non-jit call.

We lose some coverage in the area of recompilation checks (this is why `_CompileAndCheckSparse` would call the jit-compiled function twice) but given that test timeouts have become an issue, I think that's an OK tradeoff.