### PR TITLE
Raise an error when attempting to mutate Jaxpr objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Remember to align the itemized text with the first line of an item within a list
     dimension to JAX arrays. Operations involving symbolic dimensions and
     `np.ndarray` now can raise errors when the result is used as a shape value
     ({jax-issue}`#14106`).
+  * jaxpr objects now raise an error on attribute setting in order to avoid
+    problematic mutations ({jax-issue}`14102`)
 
 * Changes
   * {func}`jax2tf.call_tf` has a new parameter `has_side_effects` (default `True`)

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -579,8 +579,8 @@ def _scan_partial_eval(trace, *tracers, reverse, length, num_consts, num_carry,
   # Drop any extensive output we can instead get by forwarding an input.
   # TODO(mattjj): use pe.dce_jaxpr here, though need a fixpoint
   jaxpr_known_, () = jaxpr_known.jaxpr, jaxpr_known.consts
-  jaxpr_known_.outvars = [x for x, i in zip(jaxpr_known_.outvars, fwds_known)
-                          if i is None]
+  jaxpr_known_ = jaxpr_known_.replace(
+    outvars=[x for x, i in zip(jaxpr_known_.outvars, fwds_known) if i is None])
   jaxpr_known = core.ClosedJaxpr(jaxpr_known_, ())
   del jaxpr_known_
   # We use `fwds_known` below when forming the output of scanning jaxpr_known.
@@ -1327,7 +1327,9 @@ def _while_partial_eval(trace: pe.JaxprTrace, *tracers: pe.Tracer, cond_nconsts:
   body_nconsts_known = len(body_consts_uk) - sum(body_consts_uk)
   num_known_outs = len(carry_uk) - sum(carry_uk)
   # TODO(mattjj): use pe.dce_jaxpr to drop res computations and not just outputs
-  body_jaxpr_known.jaxpr.outvars = body_jaxpr_known.jaxpr.outvars[:num_known_outs]
+  body_jaxpr_known = body_jaxpr_known.replace(
+    jaxpr=body_jaxpr_known.jaxpr.replace(
+      outvars=body_jaxpr_known.jaxpr.outvars[:num_known_outs]))
   out_known = while_p.bind(
       *in_consts, cond_nconsts=cond_nconsts_known, cond_jaxpr=cond_jaxpr_known,
       body_nconsts=body_nconsts_known, body_jaxpr=body_jaxpr_known)

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -1641,13 +1641,13 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
     new_jaxpr_invars = (
         new_jaxpr_invars[0:nr_const_and_carry] + new_jaxpr_invars[-2:] +
         new_jaxpr_invars[nr_const_and_carry:-2])
-    new_jaxpr.jaxpr.invars = new_jaxpr_invars
+    new_jaxpr = new_jaxpr.replace(jaxpr=new_jaxpr.jaxpr.replace(invars=new_jaxpr_invars))
 
     new_jaxpr_outvars = new_jaxpr.jaxpr.outvars
     new_jaxpr_outvars = (
         new_jaxpr_outvars[0:num_carry] + new_jaxpr_outvars[-2:] +
         new_jaxpr_outvars[num_carry:-2])
-    new_jaxpr.jaxpr.outvars = new_jaxpr_outvars
+    new_jaxpr = new_jaxpr.replace(jaxpr=new_jaxpr.jaxpr.replace(outvars=new_jaxpr_outvars))
     eqns.append(
         eqn.replace(
             invars=new_invars,

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -411,7 +411,7 @@ class JaxprTypeChecks(jtu.JaxTestCase):
   def test_check_jaxpr_cond_invalid(self):
     jaxpr = make_jaxpr(lambda x: lax.switch(0, [jnp.sin, jnp.cos], x))(1.).jaxpr
     cond = next(eqn for eqn in jaxpr.eqns if eqn.primitive.name == 'cond')
-    cond.params['branches'][0].jaxpr.invars = ()
+    cond.params['branches'][0].jaxpr._invars = ()
     self.assertRaisesRegex(
         core.JaxprTypeError,
         'cond branch 0 takes 0 inputs, branch 1 takes 1',
@@ -445,7 +445,7 @@ class JaxprTypeChecks(jtu.JaxTestCase):
         lambda x: lax.switch(0, [jnp.sin, jnp.cos], x), 100))(1.).jaxpr
 
     cond = next(eqn for eqn in jaxpr.eqns if eqn.primitive.name == 'cond')
-    cond.params['branches'][0].jaxpr.invars = ()
+    cond.params['branches'][0].jaxpr._invars = ()
     msg = ''
     try:
       core.check_jaxpr(jaxpr)


### PR DESCRIPTION
@sharadmv has recently run into an error that came down to a cached jaxpr being mutated in place. This is an attempt to guard against that kind of footgun by making jaxpr attributes read-only.

A more heavyweight solution might be to make `Jaxpr` and `ClosedJaxpr` either a `NamedTuple` or a frozen `dataclass`, but this is a quick fix that we can use to find any potential offending code using a global presubmit.