### PR TITLE
[shape_poly] Generalize binary operations with symbolic dimensions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Remember to align the itemized text with the first line of an item within a list
 
 * Breaking changes
   * Deleted `jax.experimental.callback`
+  * Operations with dimensions in presence of jax2tf shape polymorphism have
+    been generalized to work in more scenarios, by converting the symbolic
+    dimension to JAX arrays. Operations involving symbolic dimensions and
+    `np.ndarray` now can raise errors when the result is used as a shape value
+    ({jax-issue}`#14106`).
 
 * Changes
   * {func}`jax2tf.call_tf` has a new parameter `has_side_effects` (default `True`)

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1197,13 +1197,13 @@ def _split(op: str, ary: ArrayLike, indices_or_sections: Union[int, ArrayLike],
                                                  f"in jax.numpy.{op} argument 1")
     part_size, r = _divmod(size, indices_or_sections)  # type: ignore[misc]
     if r == 0:
-      split_indices = np.arange(indices_or_sections + 1,
-                                dtype=np.int64) * part_size
+      split_indices = [np.int64(i) * part_size  # type: ignore
+                       for i in range(indices_or_sections + 1)]  # type: ignore
     elif op == "array_split":
-      split_indices = np.concatenate(
-          [np.arange(r + 1, dtype=np.int64) * (part_size + 1),
-           np.arange(indices_or_sections - r, dtype=np.int64) * part_size
-           + ((r + 1) * (part_size + 1) - 1)])
+      split_indices = (
+        [np.int64(i) * (part_size + 1) for i in range(r + 1)] +  # type: ignore
+        [np.int64(i) * part_size + ((r + 1) * (part_size + 1) - 1)
+         for i in range(indices_or_sections - r)])
     else:
       raise ValueError("array split does not result in an equal division")
   starts, ends = [0] * ndim(ary), shape(ary)


### PR DESCRIPTION
Previously binary operations involving symbolic dimensions would work only when the other operand is convertible to a symbolic dimension, e.g., an integer. This resulted in errors when trying "x.shape[0] * 3.5" and the recourse was to ask the user to add an explicit "jnp.array(x.shape[0])".

Now we allow binary operations with any operand and the "jnp.array" is added automatically if the other operand is not an integer or a symbolic dimension. This means that instead of an error they may be an error downstream if one tries to use the result as a dimension. There is one known case where JAX works with static shapes and with the previous behavior, but will fail now. When you operate on `np.ndarray` and symbolic dimension, previously this was kept as a `np.ndarray` but not it is turned into a JAX array. The following program will now fail if `x.shape[0]` is a symbolic dimension.:

`jnp.ones(np.arange(5) * x.shape[0])`

Instead you should write

`jnp.ones([i * x.shape[0] for i in range(5)])`

We also took the opportunity to make some improvements to the shape polymorphism documentation.