### PR TITLE
[shape_poly] Add better support for division, and working with strides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Remember to align the itemized text with the first line of an item within a list
   * {func}`jax2tf.call_tf` has a new parameter `has_side_effects` (default `True`)
     that can be used to declare whether an instance can be removed or replicated
     by JAX optimizations such as dead-code elimination ({jax-issue}`#13980`).
+  * Added more support for floordiv and mod for jax2tf shape polymorphism. Previously,
+    certain division operations resulted in errors in presence of symbolic dimensions
+    ({jax-issue}`#14108`).
 
 ## jaxlib 0.4.2 (Jan 20, 2023)
 

--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -786,7 +786,8 @@ def conv_shape_tuple(lhs_shape, rhs_shape, strides, pads, batch_group_count=1):
     raise ValueError("Negative padding is larger than the size of the corresponding dimension: "
                      f"got padding={pads} for lhs_shape[2:]={lhs_shape[2:]}")
   out_space = core.stride_shape(lhs_padded, rhs_shape[2:], strides)
-  out_space = np.maximum(0, out_space)
+  out_space = [d if core.greater_equal_dim(d, 0) else 0
+               for d in out_space]
   if batch_group_count > 1:
     assert lhs_shape[0] % batch_group_count == 0
     out_shape_0 = lhs_shape[0] // batch_group_count

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2543,7 +2543,7 @@ def repeat(a: ArrayLike, repeats: ArrayLike, axis: Optional[int] = None, *,
 
   if core.is_special_dim_size(repeats):
     if total_repeat_length is not None:
-      raise ValueError("jnp.repeat with a DimPolynomial `repeats` is supported only "
+      raise ValueError("jnp.repeat with a non-constant `repeats` is supported only "
                        "when `total_repeat_length` is None")
 
   # If total_repeat_length is not given, use a default.

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -1097,12 +1097,11 @@ def threefry_2x32(keypair, count):
     msg = "threefry_2x32 requires uint32 arguments, got {}"
     raise TypeError(msg.format([lax.dtype(x) for x in [key1, key2, count]]))
 
-  try:
-    odd_size = count.size % 2
-  except core.InconclusiveDimensionOperation as e:
+  odd_size = count.size % 2
+  if not isinstance(odd_size, int):
     msg = ("jax.random functions have limited support for shape polymorphism. "
            "In particular, the product of the known dimensions must be even.")
-    raise core.InconclusiveDimensionOperation(msg) from e
+    raise core.InconclusiveDimensionOperation(msg)
 
   if odd_size:
     x = list(jnp.split(jnp.concatenate([count.ravel(), np.uint32([0])]), 2))


### PR DESCRIPTION
Previously, division was only supported in certain situation, and this
led to errors, e.g., when using strides. Now we generalize the polynomials
to also include "floordiv(E, E)" and "mod(E, E)" as atoms, in addition
to dimension variables. A symbolic dimension is now a sum of products
of atoms. (We also changed the documentation to use symbolic dimension
 instead of dimension polynomials).