### PR TITLE
Use __slots__ in Jaxpr & ClosedJaxpr

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -67,6 +67,8 @@ control_flow_allowed_effects: Set[Effect] = set()
 
 
 class Jaxpr:
+  __slots__ = ['__weakref__', '_constvars', '_invars', '_outvars', '_eqns', '_effects']
+
   _constvars: List[Var]
   _invars: List[Var]
   _outvars: List[Atom]
@@ -148,6 +150,8 @@ def subjaxprs(jaxpr: Jaxpr) -> Iterator[Jaxpr]:
 
 
 class ClosedJaxpr:
+  __slots__ = ['__weakref__', '_jaxpr', '_consts']
+
   _jaxpr: Jaxpr
   _consts: List[Any]
 


### PR DESCRIPTION
Followup to #14102

For true immutability, there are more comprehensive options:

- `NamedTuple`, but then we can't have custom init logic
- frozen `dataclass`, but there is concern about extra overhead because jaxprs are so frequently created

We could still explore & benchmark the latter, but in the meantime there's little to no downside to defining `__slots__` here: it will prevent undefined attributes from being defined on jaxprs, and should speed up the common case.