### PR TITLE
Update WORKSPACE for jaxlib 0.4.2 release (again)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,10 +7,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 #    and update the sha256 with the result.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "dc7063605dc5281b6b99b1b0b2de250f55bd7fb959b27a86d2f91cae0528fd5d",
-    strip_prefix = "tensorflow-48f9d3dfcf148e1c2dfcf79b6334c2e2a2783093",
+    sha256 = "eee3984f41375d438c18fdfae71f66673a35cefe883ef309f4c6a9a4ffc16218",
+    strip_prefix = "tensorflow-bbabe41b20327819d2472425d43178c35ce2b1bf",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/48f9d3dfcf148e1c2dfcf79b6334c2e2a2783093.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/bbabe41b20327819d2472425d43178c35ce2b1bf.tar.gz",
     ],
 )
 


### PR DESCRIPTION
This fixes a segfault that was affecting the previous 0.4.2 candidate.