### PR TITLE
Checkify: Validate format arguments to make sure they're arrays

### DIFF
--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -1117,6 +1117,11 @@ def _check(pred, msg, debug, *fmt_args, **fmt_kwargs):
   if not is_scalar_pred(pred):
     prim_name = 'debug_check' if debug else 'check'
     raise TypeError(f'{prim_name} takes a scalar pred as argument, got {pred}')
+  for arg in jtu.tree_leaves((fmt_args, fmt_kwargs)):
+    if not isinstance(arg, (jax.Array, np.ndarray)):
+      raise TypeError('Formatting arguments to checkify.check need to be '
+                      'PyTrees of arrays, but got '
+                      f'{repr(arg)} of type {type(arg)}.')
   new_error = FailedCheckError(summary(), msg, *fmt_args, **fmt_kwargs)
   error = assert_func(init_error, jnp.logical_not(pred), new_error)
   _check_error(error, debug=debug)

--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -1173,6 +1173,20 @@ class AssertPrimitiveTests(jtu.JaxTestCase):
     self.assertIsNotNone(err.get())
     self.assertStartsWith(err.get(), "1.0 cannot be 1.0")
 
+  def test_fmt_args_array_type_error(self):
+    args_error = lambda: checkify.check(False, "{} world", "hello")
+    with self.assertRaisesRegex(TypeError, "Formatting arguments"):
+      checkify.checkify(args_error)()
+
+    kwargs_error = lambda: checkify.check(False, "{hello} world", hello="hello")
+    with self.assertRaisesRegex(TypeError, "Formatting arguments"):
+      checkify.checkify(kwargs_error)()
+
+    np_arrays_ok = lambda: checkify.check(False, "{} world", np.array(1.))
+    checkify.checkify(np_arrays_ok)()
+
+    trees_ok = lambda: checkify.check(False, "{}", {"hello": jnp.array(1.)})
+    checkify.checkify(trees_ok)()
 
 class LowerableChecksTest(jtu.JaxTestCase):
   def setUp(self):


### PR DESCRIPTION
This disallows `checkify.check("{}", 1.)`, but you probably shouldn't be doing that anyway (you can embed static info in the msg directly)