### PR TITLE
Update versions for jaxlib 0.4.2 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Remember to align the itemized text with the first line of an item within a list
 
 ## jaxlib 0.4.3
 
-## jax 0.4.2 (Jan 20, 2023)
+## jax 0.4.2 (Jan 24, 2023)
 
 * Breaking changes
   * Deleted `jax.experimental.callback`
@@ -27,7 +27,7 @@ Remember to align the itemized text with the first line of an item within a list
     that can be used to declare whether an instance can be removed or replicated
     by JAX optimizations such as dead-code elimination ({jax-issue}`#13980`).
 
-## jaxlib 0.4.2 (Jan 20, 2023)
+## jaxlib 0.4.2 (Jan 24, 2023)
 
 * Changes
   * Set JAX_USE_PJRT_C_API_ON_TPU=1 to enable new Cloud TPU runtime, featuring

--- a/jax/version.py
+++ b/jax/version.py
@@ -15,7 +15,7 @@
 # This file is included as part of both jax and jaxlib. It is also
 # eval()-ed by setup.py, so it should not have any dependencies.
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 _minimum_jaxlib_version = "0.4.1"
 
 def _version_as_tuple(version_str):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages
 
 _current_jaxlib_version = '0.4.2'
 # The following should be updated with each new jaxlib release.
-_latest_jaxlib_version_on_pypi = '0.4.1'
+_latest_jaxlib_version_on_pypi = '0.4.2'
 _available_cuda_versions = ['11']
 _default_cuda_version = '11'
 _available_cudnn_versions = ['82', '86']


### PR DESCRIPTION
I also screwed up the CHANGELOG before (I shouldn't have added a date), so I'm fixing the dates now.