### PR TITLE
remove rules translating opaquely dtyped avals directly to MLIR types

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1293,6 +1293,22 @@ def concrete_or_error(force: Any, val: Any, context=""):
     return force(val)
 
 
+### Opaque dtypes
+#
+# Opaque dtypes are JAX-specific dtypes that allow us to represent logical
+# arrays of element types that do not have an obvious direct correspondence
+# to ("physical") arrays of basic types in a compiler. In particular, their
+# element types differ from those of XLA and NumPy (e.g. int32). These dtypes
+# are only known to JAX. Their implementation is determined by:
+# a) an object representing the opaque dtype, accessible via the `dtype`
+#    attribute on corresponding JAX arrays and, internally, on avals such
+#    as ShapedArrays that correspond to such JAX arrays;
+# b) a set of rules, available via a private attribute on the opaque dtype
+#    object in (a).
+# The rules in (b) tell JAX internals how to ground out the element
+# type for interaction with the compiler and runtime, e.g. when lowering
+# to the compiler's language.
+
 # TODO(frostig,mattjj): achieve this w/ a protocol instead of registry?
 opaque_dtypes: Set[OpaqueDType] = set()
 

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4846,9 +4846,9 @@ mlir.register_lowering(empty_p, _empty_lower)
 
 class BIntRules:
   @staticmethod
-  def aval_to_ir_types(aval):
+  def physical_avals(aval) -> Sequence[core.AbstractValue]:
     dtype = dtypes._scalar_type_to_dtype(int)
-    return (ir.RankedTensorType.get(aval.shape, mlir.dtype_to_ir_type(dtype)),)
+    return [core.ShapedArray(aval.shape, dtype)]
 
   @staticmethod
   def result_handler(sticky_device, aval):

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -288,11 +288,6 @@ class KeyTyRules:
                              jnp.dtype('uint32'))]
 
   @staticmethod
-  def aval_to_ir_types(aval: core.AbstractValue) -> Sequence[mlir.ir.Type]:
-    phys_aval, = KeyTyRules.physical_avals(aval)
-    return mlir.aval_to_ir_types(phys_aval)
-
-  @staticmethod
   def physical_op_sharding(aval, sharding):
     op_sharding = sharding._to_xla_op_sharding(aval.ndim)
     key_shape = aval.dtype.impl.key_shape

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2832,11 +2832,6 @@ class FooTyRules:
     return [core.ShapedArray((*aval.shape, 2), jnp.dtype('uint32'))]
 
   @staticmethod
-  def aval_to_ir_types(aval):
-    aval2, = FooTyRules.physical_avals(aval)
-    return mlir.aval_to_ir_types(aval2)
-
-  @staticmethod
   def physical_op_sharding(aval, sharding):
     return sharding._to_xla_op_sharding(aval.ndim)
 


### PR DESCRIPTION
We have a rule for grounding opaquely dtyped avals into a list of basic ("physical") avals, so we can just translate as usual from there. This should help maintain consistency, and reduces code a bit.

I added some comments along the way.