### PR TITLE
Add implementation of jnp.partition

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -300,6 +300,7 @@ namespace; they are listed below.
     outer
     packbits
     pad
+    partition
     percentile
     piecewise
     place

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -189,6 +189,7 @@ from jax._src.numpy.lax_numpy import (
     outer as outer,
     packbits as packbits,
     pad as pad,
+    partition as partition,
     percentile as percentile,
     pi as pi,
     piecewise as piecewise,


### PR DESCRIPTION
This implements `jnp.partition` in terms of two calls to `lax.top_k` concatenated together. A nice feature of this approach is that XLA knows how to elide unnecessary parts of concat+slice, so the common pattern of `np.partition(x, n)[n:]` optimizes to a single top-k call under JIT:
```python
import jax
import jax.numpy as jnp

x = jnp.ones(10)
top_three = lambda x: jnp.partition(x, -3)[-3:]
print(jax.jit(top_three).lower(x).compile().as_text())
```
```
HloModule jit__lambda_, entry_computation_layout={(f32[10]{0})->f32[3]{0}}, allow_spmd_sharding_propagation_to_output=true

ENTRY %main.21 (Arg_0.1: f32[10]) -> f32[3] {
  %Arg_0.1 = f32[10]{0} parameter(0), sharding={replicated}
  %custom-call = (f32[3]{0}, s32[3]{0}) custom-call(f32[10]{0} %Arg_0.1), custom_call_target="TopK"
  ROOT %get-tuple-element = f32[3]{0} get-tuple-element((f32[3]{0}, s32[3]{0}) %custom-call), index=0
}
```

Part of #70 and #2079

