### PR TITLE
Add select and scatter 2 lax

### DIFF
--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -294,6 +294,7 @@ from jax._src.lax.convolution import (
 )
 from jax._src.lax.windowed_reductions import (
   reduce_window as reduce_window,
+  select_and_scatter as select_and_scatter,
   reduce_window_max_p as reduce_window_max_p,
   reduce_window_min_p as reduce_window_min_p,
   reduce_window_p as reduce_window_p,


### PR DESCRIPTION
Adds select_and_scatter to lax.

In writing an interpreter to rehydrate HLO modules into Jaxprs, as suggested [here](https://github.com/google/jax/discussions/14147), I encountered SelectAndScatter in rehydrating the gradient of a MaxPool (I believe). Reading the documentation for SelectAndScatter, it was not obvious to me how to implement in terms of alternative lax symbols. But found this symbol, and in my experimental implementation this does indeed seem to be the thing I was looking for. So simply opening a PR adding to lax.