### PR TITLE
Clean up: remove unused helper functions

### DIFF
--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -15,7 +15,6 @@
 import dataclasses
 import functools
 import itertools as it
-import types
 from typing import Union, Optional, Callable, Dict, Tuple, TypeVar, FrozenSet, Iterable, Type, Set, List, Sequence, Any
 
 import jax
@@ -532,20 +531,6 @@ ad.primitive_jvps[check_p] = check_jvp_rule
 ErrorCheckRule = Callable  # (Error, FrozenSet[ErrorCategory], *in_vals, **params) -> (Any, Error)
 error_checks: Dict[core.Primitive, ErrorCheckRule] = {}
 
-
-def _get_current_traceback(skip_frames = 0) -> Optional[types.TracebackType]:
-  # TODO(lenamartens): use c++ version from XLA?
-  tb = None
-  import inspect
-  for frame_info in inspect.stack():
-    frame = frame_info.frame
-    if skip_frames:
-      skip_frames -= 1
-    elif not traceback_util.include_frame(frame):
-      continue
-    else:
-      tb = types.TracebackType(tb, frame, frame.f_lasti, frame.f_lineno)
-  return tb
 
 def summary() -> str:
   return str(source_info_util.summarize(source_info_util.current()))

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -63,9 +63,6 @@ def _initial_style_jaxpr(fun, in_avals):
 def _close_jaxpr(jaxpr):
   return core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
 
-def _initial_style_staging() -> bool:
-  return core.thread_local_state.trace_state.initial_style
-
 def _sum_tangents(_, x, *xs):
   return reduce(ad.add_tangents, xs, x)
 

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -531,10 +531,6 @@ def lower_xla_callable(
       keepalive=keepalive, host_callbacks=host_callbacks)
 
 
-def _backend_supports_unbounded_dynamic_shapes(backend: Backend) -> bool:
-  return backend.platform == 'iree'
-
-
 def prefetch(x):
   if isinstance(x, device_array.DeviceArray):
     x.copy_to_host_async()
@@ -1136,25 +1132,6 @@ def _cache_write(serialized_computation: Union[str, bytes, ir.Module],
     warnings.warn(
         f"Error writing persistent compilation cache entry for "
         f"'{module_name}': {type(ex).__name__}: {ex}")
-
-
-def _instruction_count(module: ir.Module, max_count: Optional[int] = None):
-
-  def _blocks_count(blocks, count):
-    for block in blocks:
-      for op in block.operations:
-        count += 1
-        # Untested premature performance optimization
-        if max_count is not None and count >= max_count:
-          return max_count
-        for region in op.regions:
-          count = _blocks_count(region.blocks, count)
-    return count
-
-  count = 0
-  for func in module.body.operations:
-    count = _blocks_count(func.body.blocks, count)
-  return count
 
 
 def get_buffer_counts(out_avals, ordered_effects, has_unordered_effects):

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1560,18 +1560,6 @@ def _svd_impl(operand, *, full_matrices, compute_uv):
   return xla.apply_primitive(svd_p, operand, full_matrices=full_matrices,
                              compute_uv=compute_uv)
 
-
-def _zeros_like_xla(c, aval):
-  zero = xops.Constant(c, np.array(0, aval.dtype))
-  return xops.Broadcast(zero, aval.shape)
-
-def _eye_like_xla(c, aval):
-  iota_shape = xla_client.Shape.array_shape(
-      xla.dtype_to_primitive_type(np.dtype(np.int32)), aval.shape)
-  x = xops.Eq(xops.Iota(c, iota_shape, len(aval.shape) - 1),
-              xops.Iota(c, iota_shape, len(aval.shape) - 2))
-  return xops.ConvertElementType(x, xla.dtype_to_primitive_type(aval.dtype))
-
 def _svd_abstract_eval(operand, *, full_matrices, compute_uv):
   if isinstance(operand, ShapedArray):
     if operand.ndim < 2:

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -256,12 +256,6 @@ _DEFAULT_TYPEMAP: Dict[type, _ScalarMeta] = {
 _lax_const = lax_internal._const
 
 
-def _result_dtype(op: Callable[..., ArrayLike], *args: Any) -> DType:
-  """Compute result dtype of applying op to arguments with given dtypes."""
-  np_args = [np.ones((0,) * ndim(arg), _dtype(arg)) for arg in args]
-  return _dtype(op(*np_args))
-
-
 def _convert_and_clip_integer(val: ArrayLike, dtype: DType) -> Array:
   """
   Convert integer-typed val to specified integer dtype, clipping to dtype
@@ -3249,14 +3243,6 @@ def _einsum(operands: Sequence,
     operands.append(operand)  # used in next iteration
 
   return operands[0]
-
-
-def _movechars(s, src, dst):
-  """Helper for einsum string munging, like moveaxis on identifier strings."""
-  chars = [c for i, c in enumerate(s) if i not in src]
-  for i, j in sorted(zip(dst, src)):
-    chars.insert(i, s[j])
-  return ''.join(chars)
 
 
 @_wraps(np.inner, lax_description=_PRECISION_DOC)

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -841,11 +841,6 @@ def _make_rotate_left(dtype):
   return _rotate_left
 
 
-def _bit_stats(bits):
-  """This is a debugging function to compute the statistics of bit fields."""
-  return np.array([list(map(int, np.binary_repr(x, 64))) for x in bits]).mean(0)
-
-
 ### hash function and split
 
 def _threefry2x32_abstract_eval(*args):

--- a/jax/experimental/jax2tf/impl_no_xla.py
+++ b/jax/experimental/jax2tf/impl_no_xla.py
@@ -210,13 +210,6 @@ def _normalize_window_strides(window_strides):
   return window_strides
 
 
-def _normalize_output_perm(output_perm, is_conv1d):
-  """Ensure that output_perm has length 4."""
-  if is_conv1d:
-    output_perm = list(output_perm) + [1]
-  return output_perm
-
-
 def _validate_conv_features(
       is_transpose, is_atrous, is_depthwise, feature_group_count,
       batch_group_count, preferred_element_type, lhs_dtype):

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -2161,12 +2161,6 @@ def _select_and_gather_add(
 tf_impl_with_avals[lax.select_and_gather_add_p] = _select_and_gather_add
 
 
-def _get_shape_from_tensor_or_array(x):
-  if isinstance(x.shape, tf.TensorShape):
-    return tuple(x.shape.as_list())
-  return tuple(x.shape)
-
-
 def _common_reduce_window(operand, init_val, reducer, window_dimensions,
                           window_strides, padding, base_dilation,
                           window_dilation, _in_avals, _out_aval):

--- a/jax/experimental/sparse/util.py
+++ b/jax/experimental/sparse/util.py
@@ -52,11 +52,6 @@ class SparseInfo(NamedTuple):
 # TODO: possibly make these primitives, targeting cusparse rountines
 #       csr2coo/coo2csr/SPDDMM
 
-def _asarray_or_float0(arg) -> Union[np.ndarray, Array]:
-  if isinstance(arg, np.ndarray) and arg.dtype == dtypes.float0:
-    return arg
-  return jnp.asarray(arg)
-
 def nfold_vmap(fun, N, *, broadcasted=True, in_axes=0):
   """Convenience function to apply (broadcasted) vmap N times."""
   _vmap = broadcasting_vmap if broadcasted else vmap
@@ -109,17 +104,6 @@ def _count_stored_elements_per_batch(mat: Array, n_batch: int = 0, n_dense: int 
 def _count_stored_elements(mat: Array, n_batch: int = 0, n_dense: int = 0) -> int:
   """Return the number of stored elements (nse) of the given dense matrix."""
   return int(_count_stored_elements_per_batch(mat, n_batch, n_dense).max(initial=0))
-
-def _is_pytree_placeholder(*args: Any) -> bool:
-  # Returns True if the arguments are consistent with being a placeholder within
-  # pytree validation.
-  return all(type(arg) is object for arg in args) or all(arg is None for arg in args)
-
-def _is_aval(*args: Any) -> bool:
-  return all(isinstance(arg, core.AbstractValue) for arg in args)
-
-def _is_arginfo(*args: Any) -> bool:
-  return all(isinstance(arg, stages.ArgInfo) for arg in args)
 
 def _dot_general_validated_shape(
     lhs_shape: Tuple[int, ...], rhs_shape: Tuple[int, ...],

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -2262,20 +2262,6 @@ def _extract_implicit_args(
   tracers_validated = cast(List[DynamicJaxprTracer], tracers)  # remove Optional annotation.
   return [t for t, (_, e) in zip(tracers_validated, in_type) if not e]
 
-def _in_avals_from_tracers(
-    tracers: List[DynamicJaxprTracer]
-  ) -> List[AbstractValue]:
-  # Returned AbstractValues contain DBIdx indices. Uses Tracer obj id as name.
-  dbidxs: Dict[TracerId, DBIdx] = {id(t): DBIdx(i) for i, t in enumerate(tracers)}
-  in_avals: List[AbstractValue] = []
-  for t in tracers:
-    a = t.aval
-    if isinstance(a, DShapedArray) and any(isinstance(d, Tracer) for d in a.shape):
-      shape = [dbidxs[id(d)] if isinstance(d, Tracer) else d for d in a.shape]
-      a = a.update(shape=tuple(shape))
-    in_avals.append(a)
-  return in_avals
-
 def _input_type_to_tracers(
     new_arg: Callable[[AbstractValue], Tracer],
     in_avals: Sequence[AbstractValue]

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -250,9 +250,6 @@ def _canonicalize_masked_array_dtype(x):
 def _canonicalize_ndarray_dtype(x):
   return np.asarray(x, dtypes.canonicalize_dtype(x.dtype))
 
-def _canonicalize_numpy_scalar_dtype(x):
-  return np.asarray(x, dtypes.canonicalize_dtype(np.dtype(x)))
-
 def _canonicalize_python_scalar_dtype(typ, x):
   return np.asarray(
       x, dtypes.canonicalize_dtype(dtypes._scalar_type_to_dtype(typ, x)))


### PR DESCRIPTION
Used [vulture](https://github.com/jendrikseipp/vulture) to find all un-referenced function definitions whose name starts with an underscore. Also confirmed that each has no downstream callers internally.