### PR TITLE
Remove jax.dtypes._jax_types

### DIFF
--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -16,7 +16,6 @@
 # See PEP 484 & https://github.com/google/jax/issues/7570
 
 from jax._src.dtypes import (
-    _jax_types,  # TODO(phawkins): fix users and remove?
     bfloat16 as bfloat16,
     canonicalize_dtype as canonicalize_dtype,
     finfo,  # TODO(phawkins): switch callers to jnp.finfo?


### PR DESCRIPTION
Part of the broader namespace cleanup.

This has a few internal users that will need to be patched.