### PR TITLE
[sparse] implement sparse rule for lax.rev

### DIFF
--- a/jax/experimental/sparse/__init__.py
+++ b/jax/experimental/sparse/__init__.py
@@ -214,6 +214,7 @@ from jax.experimental.sparse.bcoo import (
     bcoo_update_layout as bcoo_update_layout,
     bcoo_reduce_sum as bcoo_reduce_sum,
     bcoo_reshape as bcoo_reshape,
+    bcoo_rev as bcoo_rev,
     bcoo_slice as bcoo_slice,
     bcoo_sort_indices as bcoo_sort_indices,
     bcoo_sort_indices_p as bcoo_sort_indices_p,

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -507,6 +507,7 @@ _BCOO_STANDARD_PRIMITIVES = {
   lax.dot_general_p: sparse.bcoo_dot_general,
   lax.dynamic_slice_p: lambda *a, **k: sparse.bcoo_dynamic_slice(a[0], a[1:], **k),
   lax.reshape_p: sparse.bcoo_reshape,
+  lax.rev_p: sparse.bcoo_rev,
   lax.slice_p: sparse.bcoo_slice,
   lax.squeeze_p: sparse.bcoo_squeeze,
 }

--- a/tests/sparsify_test.py
+++ b/tests/sparsify_test.py
@@ -291,6 +291,19 @@ class SparsifyTest(jtu.JaxTestCase):
 
     self.assertAllClose(result_sparse, result_dense)
 
+  def testSparseRev(self):
+    # Note: more comprehensive tests in sparse_test.py:test_bcoo_rev
+    rng = jtu.rand_default(self.rng())
+
+    M_dense = rng((2, 3, 4), np.float32)
+    M_sparse = BCOO.fromdense(M_dense)
+    func = self.sparsify(partial(lax.rev, dimensions=(1, 2)))
+
+    result_dense = func(M_dense)
+    result_sparse = func(M_sparse).todense()
+
+    self.assertAllClose(result_sparse, result_dense)
+
   @jtu.sample_product(
     [dict(shapes=shapes, func=func, n_batch=n_batch)
       for shapes, func, n_batch in [


### PR DESCRIPTION
Related to #14252: `lax.rev` is used by `jnp.convolve` when the rhs is larger than the lhs.