### PR TITLE
Remove placeholder functions for unimplemented NumPy functions.

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -35,7 +35,7 @@ namespace; they are listed below.
 
 .. Generate the list below as follows:
    >>> import jax.numpy, numpy
-   >>> fns = set(dir(numpy)) & set(dir(jax.numpy)) - set(jax.numpy._NOT_IMPLEMENTED)
+   >>> fns = set(dir(numpy)) & set(dir(jax.numpy))
    >>> print('\n'.join('    ' + x for x in fns if callable(getattr(jax.numpy, x))))  # doctest: +SKIP
 
    # Finally, sort the list using sort(1), which is different than Python's

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -5062,7 +5062,6 @@ _diff_methods = ["choose", "conj", "conjugate", "copy", "cumprod", "cumsum",
 # _not_implemented implementations of them here rather than in __init__.py.
 # TODO(phawkins): implement these.
 argpartition = _not_implemented(np.argpartition)
-_NOT_IMPLEMENTED = ['argpartition']
 
 
 # Experimental support for NumPy's module dispatch with NEP-37.

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -257,7 +257,6 @@ from jax._src.numpy.lax_numpy import (
     where as where,
     zeros as zeros,
     zeros_like as zeros_like,
-    _NOT_IMPLEMENTED,
 )
 
 if xla_extension_version >= 117:
@@ -423,18 +422,4 @@ from jax._src.numpy.ufuncs import (
 
 from jax._src.numpy.vectorize import vectorize as vectorize
 
-# Module initialization is encapsulated in a function to avoid accidental
-# namespace pollution.
-def _init():
-  import numpy as np
-  from jax._src.numpy import lax_numpy
-  from jax._src import util
-  # Builds a set of all unimplemented NumPy functions.
-  for name, func in util.get_module_functions(np).items():
-    if name not in globals() and not name.startswith('_'):
-      _NOT_IMPLEMENTED.append(name)
-      globals()[name] = lax_numpy._not_implemented(func, module='numpy')
-
-_init()
-del _init
 del xla_extension_version

--- a/jax/numpy/fft.py
+++ b/jax/numpy/fft.py
@@ -35,19 +35,3 @@ from jax._src.numpy.fft import (
   rfftfreq as rfftfreq,
   rfftn as rfftn,
 )
-
-# Module initialization is encapsulated in a function to avoid accidental
-# namespace pollution.
-_NOT_IMPLEMENTED = []
-def _init():
-  import numpy as np
-  from jax._src.numpy import lax_numpy
-  from jax._src import util
-  # Builds a set of all unimplemented NumPy functions.
-  for name, func in util.get_module_functions(np.fft).items():
-    if name not in globals():
-      _NOT_IMPLEMENTED.append(name)
-      globals()[name] = lax_numpy._not_implemented(func)
-
-_init()
-del _init

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -39,19 +39,3 @@ from jax._src.third_party.numpy.linalg import (
   tensorinv as tensorinv,
   tensorsolve as tensorsolve,
 )
-
-# Module initialization is encapsulated in a function to avoid accidental
-# namespace pollution.
-_NOT_IMPLEMENTED = []
-def _init():
-  import numpy as np
-  from jax._src.numpy import lax_numpy
-  from jax._src import util
-  # Builds a set of all unimplemented NumPy functions.
-  for name, func in util.get_module_functions(np.linalg).items():
-    if name not in globals():
-      _NOT_IMPLEMENTED.append(name)
-      globals()[name] = lax_numpy._not_implemented(func)
-
-_init()
-del _init

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -93,12 +93,6 @@ def _zero_for_irfft(z, axes):
 
 class FftTest(jtu.JaxTestCase):
 
-  def testNotImplemented(self):
-    for name in jnp.fft._NOT_IMPLEMENTED:
-      func = getattr(jnp.fft, name)
-      with self.assertRaises(NotImplementedError):
-        func()
-
   def testLaxFftAcceptsStringTypes(self):
     rng = jtu.rand_default(self.rng())
     x = rng((10,), np.complex64)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -151,12 +151,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
               for a in out]
     return f
 
-  def testNotImplemented(self):
-    for name in jnp._NOT_IMPLEMENTED:
-      func = getattr(jnp, name)
-      with self.assertRaises(NotImplementedError):
-        func()
-
   @parameterized.parameters(
     [dtype for dtype in [jnp.bool_, jnp.uint8, jnp.uint16, jnp.uint32,
                          jnp.uint64, jnp.int8, jnp.int16, jnp.int32, jnp.int64,
@@ -3228,17 +3222,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
     self.assertRaises(jax.errors.ConcretizationTypeError, lambda: g(3.))
 
-  def testTracingPrimitiveWithNoTranslationErrorMessage(self):
-    # TODO(mattjj): update this for jax3
-    self.skipTest("test needs jax3 update")
-    foo = jnp._not_implemented(lambda x: x)
-
-    # No error if there's no tracing.
-    foo(np.arange(3))
-
-    cfoo = jax.jit(foo)
-    self.assertRaises(NotImplementedError, lambda: cfoo(np.arange(3)))
-
   @jtu.sample_product(
     [dict(shape=shape, axis=axis)
       for shape in [(3,), (2, 3)]
@@ -5293,7 +5276,9 @@ def _all_numpy_ufuncs() -> Iterator[str]:
   for name in dir(np):
     f = getattr(np, name)
     if isinstance(f, np.ufunc):
-      yield name
+      # jnp.spacing is not implemented.
+      if f.__name__ != "spacing":
+        yield name
 
 
 def _dtypes_for_ufunc(name: str) -> Iterator[Tuple[str, ...]]:

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -45,12 +45,6 @@ int_types = jtu.dtypes.all_integer
 
 class NumpyLinalgTest(jtu.JaxTestCase):
 
-  def testNotImplemented(self):
-    for name in jnp.linalg._NOT_IMPLEMENTED:
-      func = getattr(jnp.linalg, name)
-      with self.assertRaises(NotImplementedError):
-        func()
-
   @jtu.sample_product(
     shape=[(1, 1), (4, 4), (2, 5, 5), (200, 200), (1000, 0, 0)],
     dtype=float_types + complex_types,


### PR DESCRIPTION
These don't seem necessary now JAX has fairly complete coverage of the NumPy API. Also removes the accidental export of _NOT_IMPLEMENTED in several modules.