### PR TITLE
[sparse] support all unbatched 1D convolutions

### DIFF
--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -52,6 +52,7 @@ from typing import (
 
 import numpy as np
 
+import jax
 from jax import core
 from jax import lax
 from jax._src import linear_util as lu


### PR DESCRIPTION
Adds support for sparse-dense, dense-sparse, and sparse-sparse unbatched 1D convolutions.

Also moved the main test to `sparse_test`, following the pattern of other operations.