### PR TITLE
[sparse] support BCSR in sparsify transform

### DIFF
--- a/jax/experimental/sparse/__init__.py
+++ b/jax/experimental/sparse/__init__.py
@@ -239,6 +239,7 @@ from jax.experimental.sparse.bcsr import (
     bcsr_extract_p as bcsr_extract_p,
     bcsr_fromdense as bcsr_fromdense,
     bcsr_fromdense_p as bcsr_fromdense_p,
+    bcsr_sum_duplicates as bcsr_sum_duplicates,
     bcsr_todense as bcsr_todense,
     bcsr_todense_p as bcsr_todense_p,
     BCSR as BCSR,

--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -2495,8 +2495,6 @@ class BCOO(JAXSparse):
 
   def __init__(self, args: Tuple[Array, Array], *, shape: Sequence[int],
                indices_sorted: bool = False, unique_indices: bool = False):
-    # JAX transforms will sometimes instantiate pytrees with null values, so we
-    # must catch that in the initialization of inputs.
     self.data, self.indices = map(jnp.asarray, args)
     self.indices_sorted = indices_sorted
     self.unique_indices = unique_indices


### PR DESCRIPTION
This adds scaffolding to support BCSR matrices in `jax.experimental.sparse.sparsify`, and adds support for some of the simplest unary operation sparsification rules.

cc @tlu7 
