### PR TITLE
Fix jax.numpy.hsplit

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1212,6 +1212,12 @@ def split(ary: ArrayLike, indices_or_sections: Union[int, ArrayLike], axis: int 
 def _split_on_axis(op: str, axis: int) -> Callable[[ArrayLike, Union[int, ArrayLike]], List[Array]]:
   @_wraps(getattr(np, op), update_doc=False)
   def f(ary: ArrayLike, indices_or_sections: Union[int, ArrayLike]) -> List[Array]:
+    # for 1-D array, hsplit becomes vsplit
+    nonlocal axis
+    _check_arraylike(op, ary)
+    a = asarray(ary)
+    if axis == 1 and len(a.shape) == 1:
+      axis = 0
     return _split(op, ary, indices_or_sections, axis=axis)
   return f
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2756,7 +2756,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @jtu.sample_product(
     [dict(shape=shape, axis=axis, num_sections=num_sections)
       for shape, axis, num_sections in [
-          ((12, 4), 0, 4), ((12, 4), 1, 2),
+          ((12, 4), 0, 4), ((12,), 1, 2),
           ((2, 3, 4), 2, 2), ((4, 3, 4), 0, 2)]],
     dtype=default_dtypes,
   )


### PR DESCRIPTION
[numpy docs](https://numpy.org/doc/stable/reference/generated/numpy.hsplit.html): 
> hsplit is equivalent to split with axis=1, the array is always split along the second axis except for 1-D arrays, where it is split at axis=0.