### PR TITLE
[shape_poly] Add support for evaluating div/mod for DimExpr

### DIFF
--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -56,7 +56,7 @@ TfVal = Any
 # A dimension environment maps dimension variables to expressions that
 # compute the values of the dimension. An expression must support addition
 # and multiplication with other expressions or with int32/int64, e.g.,
-# by overloading __add__, __radd__, __mul__, __rmul__.
+# by overloading __add__, __radd__, __mul__, __rmul__, __divmod__, __rdivmod__.
 ShapeEnv = Dict[str, Any]
 DType = Any
 
@@ -942,20 +942,30 @@ def _parse_spec(spec: Optional[Union[str, PolyShape]],
 
 
 def _evaluate_add(v1, v2):
-  if isinstance(v1, (int, np.int32, np.int64)) and v1 == 0:
-    return v2
-  elif isinstance(v2, (int, np.int32, np.int64)) and v2 == 0:
-    return v1
-  else:
-    return v1 + v2
+  try:
+    if op.index(v1) == 0:
+      return v2
+  except:
+    pass
+  try:
+    if op.index(v2) == 0:
+      return v1
+  except:
+    pass
+  return v1 + v2
 
 def _evaluate_multiply(v1, v2):
-  if isinstance(v1, (int, np.int32, np.int64)) and v1 == 1:
-    return v2
-  elif isinstance(v2, (int, np.int32, np.int64)) and v2 == 1:
-    return v1
-  else:
-    return v1 * v2
+  try:
+    if op.index(v1) == 1:
+      return v2
+  except:
+    pass
+  try:
+    if op.index(v2) == 1:
+      return v1
+  except:
+    pass
+  return v1 * v2
 
 def _is_known_constant(v) -> Optional[int]:
   try:

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -651,6 +651,16 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     self.assertAllClose(jax2tf.convert(f_jax, polymorphic_shapes="(b, _, _)")(x),
                         f_jax(x))
 
+  def test_non_trivial_dim_expr(self):
+     check_shape_poly(
+        self,
+        lambda x: (x[0] + x.shape[0] + x.shape[0] * x.shape[0] + (5 * x.shape[0]) +
+                   x.shape[0] // 2 + (5 + x.shape[0]) // x.shape[0] +
+                   17 // x.shape[0] +
+                   x.shape[0] % 3 + 17 % x.shape[0]),
+        arg_descriptors=[RandArg((3,), np.int64)],
+        poly_axes=[0])
+
   def test_static_shape_result(self):
     """The result has static shape."""
 
@@ -972,7 +982,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
                      arg_descriptors=[RandArg((3, 4), _f32)],
                      poly_axes=[(0, 1)])
 
-  def test_non_trivial_polynomials(self):
+  def test_non_trivial_polynomials_spec(self):
     if config.jax_dynamic_shapes:
       raise unittest.SkipTest("--jax_dynamic_shapes supports only trivial polynomials")
     # We can handle non-trivial polynomials in the input shape,


### PR DESCRIPTION
We have added the ability to represent floordiv and mod to DimExper. Here we add support for evaluating these dimensions for the native lowering.