### PR TITLE
[ROCm] Re-enable some linalg and sparse tests

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -523,7 +523,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     dtype=float_types + complex_types,
     compute_uv=[False, True],
   )
-  @jtu.skip_on_devices("rocm")  # will be fixed in ROCm-5.1
   @jax.default_matmul_precision("float32")
   def testSVD(self, b, m, n, dtype, full_matrices, compute_uv, hermitian):
     rng = jtu.rand_default(self.rng())
@@ -831,7 +830,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
      for hermitian in ([False, True] if shape[-1] == shape[-2] else [False])],
     dtype=float_types + complex_types,
   )
-  @jtu.skip_on_devices("rocm")  # will be fixed in ROCm-5.1
   def testPinv(self, shape, hermitian, dtype):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -345,7 +345,6 @@ class cuSparseTest(sptu.SparseTestCase):
     dtype=all_dtypes,
     transpose=[True, False],
   )
-  @jtu.skip_on_devices("rocm")  # will be fixed in rocm-5.1
   def test_csr_matvec(self, shape, dtype, transpose):
     op = lambda M: M.T if transpose else M
 
@@ -445,7 +444,6 @@ class cuSparseTest(sptu.SparseTestCase):
     dtype=all_dtypes,
     transpose=[True, False],
   )
-  @jtu.skip_on_devices("rocm")  # will be fixed in rocm-5.1
   def test_coo_matmat(self, shape, dtype, transpose):
     op = lambda M: M.T if transpose else M
 
@@ -1043,7 +1041,6 @@ class BCOOTest(sptu.SparseTestCase):
     ],
     dtype=jtu.dtypes.floating + jtu.dtypes.complex,
   )
-  @jtu.skip_on_devices("rocm")
   @jax.default_matmul_precision("float32")
   def test_bcoo_batched_matmat_cusparse(
     self, n_batch, lhs_shape, rhs_shape, dtype, lhs_contracting,
@@ -1102,7 +1099,6 @@ class BCOOTest(sptu.SparseTestCase):
     ],
     dtype=jtu.dtypes.floating + jtu.dtypes.complex,
   )
-  @jtu.skip_on_devices("rocm")
   def test_bcoo_batched_matmat_default_lowering(
     self, n_batch, lhs_shape, rhs_shape, dtype, lhs_contracting,
     rhs_contracting):


### PR DESCRIPTION
This PR re-enables following test on ROCm platform
linalg_Test::testSVD
linalg_test::testPinv
sparse_test::test_csr_matvec
sparse_test::test_coo_matmat
sparse_test::test_bcoo_batched_matmat_cusparse
sparse_test::test_bcoo_batched_matmat_default_lowering


