### PR TITLE
DOC: document alternatives to jnp.argpartition

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -68,6 +68,7 @@ namespace; they are listed below.
     arctanh
     argmax
     argmin
+    argpartition
     argsort
     argwhere
     around

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -33,6 +33,7 @@ from jax._src.numpy.lax_numpy import (
     arange as arange,
     argmax as argmax,
     argmin as argmin,
+    argpartition as argpartition,
     argsort as argsort,
     argwhere as argwhere,
     around as around,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3610,6 +3610,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       lax.sort(lax.slice_in_dim(jnp_output, start_index=kth + 1, limit_index=shape[axis], axis=axis), dimension=axis),
       lax.sort(lax.slice_in_dim(np_output, start_index=kth + 1, limit_index=shape[axis], axis=axis), dimension=axis))
 
+  def testArgpartition(self):
+    # Make sure jnp.argpartition is exposed for documentation purposes
+    with self.assertRaises(NotImplementedError):
+      jnp.argpartition(jnp.arange(10), 5)
+
   @jtu.sample_product(
     [dict(shifts=shifts, axis=axis)
       for shifts, axis in [
@@ -5330,7 +5335,7 @@ class NumpyDocTests(jtu.JaxTestCase):
     # Test that docstring wrapping & transformation didn't fail.
 
     # Functions that have their own docstrings & don't wrap numpy.
-    known_exceptions = {'broadcast_arrays', 'fromfile', 'fromiter', 'vectorize'}
+    known_exceptions = {'argpartition', 'broadcast_arrays', 'fromfile', 'fromiter', 'vectorize'}
 
     for name in dir(jnp):
       if name in known_exceptions or name.startswith('_'):


### PR DESCRIPTION
Part of #2079

Preview of new docs: https://jax--14360.org.readthedocs.build/en/14360/_autosummary/jax.numpy.argpartition.html