### PR TITLE
lax.top_k: improve documentation and errors on invalid values

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1182,7 +1182,20 @@ def sort_key_val(keys: Array, values: ArrayLike, dimension: int = -1,
   return k, v
 
 def top_k(operand: ArrayLike, k: int) -> Tuple[Array, Array]:
-  """Returns top ``k`` values and their indices along the last axis of ``operand``."""
+  """Returns top ``k`` values and their indices along the last axis of ``operand``.
+
+  Args:
+    operand: N-dimensional array of non-complex type.
+    k: integer specifying the number of top entries.
+
+  Returns:
+    values: array containing the top k values along the last axis.
+    indices: array containing the indices corresponding to values.
+
+  See also:
+  - :func:`jax.lax.approx_max_k`
+  - :func:`jax.lax.approx_min_k`
+  """
   k = int(k)
   if k < 0:
     raise ValueError(f"k argument to top_k must be nonnegative, got {k}")
@@ -4013,6 +4026,8 @@ mlir.register_lowering(sort_p, _sort_lower)
 
 
 def _top_k_abstract_eval(operand, *, k):
+  if dtypes.issubdtype(operand.dtype, np.complexfloating):
+    raise ValueError("top_k is not compatible with complex inputs.")
   if k < 0:
     raise ValueError(f"k argument to top_k must be nonnegative, got {k}")
   if len(operand.shape) == 0:


### PR DESCRIPTION
Rendered docs: https://jax--14361.org.readthedocs.build/en/14361/_autosummary/jax.lax.top_k.html