### PR TITLE
simpler pretty-print for pjit, tweak custom pp rule signature

### DIFF
--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -416,10 +416,6 @@ which the computation should run. For example
 { lambda ; a:f32[]. let
     b:f32[] = sub a 2.0
     c:f32[1] = pjit[
-      donated_invars=(False, False)
-      in_positional_semantics=(<_PositionalSemantics.GLOBAL: 1>, <_PositionalSemantics.GLOBAL: 1>)
-      in_shardings=(<jax._src.interpreters.pxla.UnspecifiedValue object ...>, <jax._src.interpreters.pxla.UnspecifiedValue object ...>)
-      inline=False
       jaxpr={ lambda ; d:f32[] e:f32[]. let
           f:f32[1] = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] 1.0
           g:f32[] = convert_element_type[new_dtype=float32 weak_type=False] d
@@ -427,11 +423,7 @@ which the computation should run. For example
           i:f32[] = convert_element_type[new_dtype=float32 weak_type=False] e
           j:f32[1] = add i h
         in (j,) }
-      keep_unused=False
       name=inner
-      out_positional_semantics=_PositionalSemantics.GLOBAL
-      out_shardings=(<jax._src.interpreters.pxla.UnspecifiedValue object ...>,)
-      resource_env=None
     ] a b
     k:f32[] = convert_element_type[new_dtype=float32 weak_type=False] a
     l:f32[1] = add k c

--- a/jax/_src/interpreters/xla.py
+++ b/jax/_src/interpreters/xla.py
@@ -21,8 +21,8 @@ from functools import partial
 import itertools as it
 import operator
 import re
-from typing import (Any, Callable, Dict, List, NamedTuple, Optional,
-                    Protocol, Sequence, Set, Type, Tuple, Union)
+from typing import (Any, Callable, Dict, NamedTuple, Optional, Protocol,
+                    Sequence, Set, Type, Tuple, Union)
 
 import numpy as np
 
@@ -475,19 +475,13 @@ pe.padding_rules[xla_call_p] = partial(pe.call_padding_rule, xla_call_p)
 
 def _pp_xla_call(eqn: core.JaxprEqn, context: core.JaxprPpContext,
                  settings: core.JaxprPpSettings,
-                 ) -> List[pp.Doc]:
+                 ) -> pp.Doc:
   printed_params = {k:v for k, v in eqn.params.items() if
                     k == 'call_jaxpr' or k == 'name' or
                     k == 'backend' and v is not None or
                     k == 'device' and v is not None or
                     k == 'donated_invars' and any(v)}
-  annotation = (source_info_util.summarize(eqn.source_info)
-                if settings.source_info else None)
-  lhs = core.pp_vars(eqn.outvars, context, print_shapes=settings.print_shapes)
-  rhs = [pp.text(eqn.primitive.name),
-         core.pp_kv_pairs(sorted(printed_params.items()), context, settings),
-         pp.text(" ") + core.pp_vars(eqn.invars, context)]
-  return [lhs, pp.text(" = ", annotation=annotation), *rhs]
+  return core._pp_eqn(eqn.replace(params=printed_params), context, settings)
 core.pp_eqn_rules[xla_call_p] = _pp_xla_call
 
 

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, List, Optional, Sequence, Tuple, TypeVar
 
 import jax
 import weakref
-from jax import core
+from jax._src import core
 from jax._src import linear_util as lu
 from jax.config import config
 from jax.core import ConcreteArray, ShapedArray, raise_to_shaped
@@ -29,7 +29,6 @@ from jax.interpreters import batching
 from jax._src.interpreters import mlir
 from jax.interpreters import partial_eval as pe
 from jax.interpreters import xla
-import jax._src.pretty_printer as pp
 from jax.tree_util import (tree_flatten, tree_unflatten, treedef_is_leaf,
                            tree_map)
 from jax._src import ad_checkpoint
@@ -964,14 +963,7 @@ def _scan_pp_rule(eqn, context, settings):
     del printed_params['num_consts']
   if not printed_params['reverse']:
     del printed_params['reverse']
-  lhs = core.pp_vars(eqn.outvars, context, print_shapes=settings.print_shapes)
-  rhs = [pp.text(eqn.primitive.name),
-         core.pp_kv_pairs(sorted(printed_params.items()), context, settings),
-         pp.text(" ") + core.pp_vars(eqn.invars, context)]
-  annotation = (source_info_util.summarize(eqn.source_info)
-                if settings.source_info else None)
-  return [lhs, pp.text(" = ", annotation=annotation), *rhs]
-
+  return core._pp_eqn(eqn.replace(params=printed_params), context, settings)
 
 def scan_bind(*args, **params):
   if config.jax_enable_checks:

--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -227,19 +227,18 @@ def _pp_idx(context, non_slice_idx, indexed_dims):
   assert next(idx_iter, None) is None
   return pp.text(idx)
 
-def _get_pp_rule(eqn, context, settings):
+def _get_pp_rule(eqn, context, settings) -> pp.Doc:
   # Pretty prints `a = get x i` as `x[i] <- a`
   y, = eqn.outvars
   x, *idx = eqn.invars
   idx = _pp_idx(context, idx, eqn.params["indexed_dims"])
   lhs = core.pp_vars([y], context, print_shapes=settings.print_shapes)
   # TODO more general get
-  return [lhs, pp.text(' <- '), pp_ref(pp.concat([
-    pp.text(core.pp_var(x, context)), pp.text('['), idx, pp.text(']')
-    ]))]
+  return pp.concat([lhs, pp.text(' <- '), pp_ref(pp.concat([
+      pp.text(core.pp_var(x, context)), pp.text('['), idx, pp.text(']')]))])
 core.pp_eqn_rules[get_p] = _get_pp_rule
 
-def _swap_pp_rule(eqn, context, settings):
+def _swap_pp_rule(eqn, context, settings) -> pp.Doc:
   y, = eqn.outvars
   x, v, *idx = eqn.invars
   idx = _pp_idx(context, idx, eqn.params["indexed_dims"])
@@ -247,30 +246,31 @@ def _swap_pp_rule(eqn, context, settings):
     # In the case of a set (ignored return value),
     # pretty print `_ = swap x v i` as `x[i] <- v`
     del y
-    return [
-      pp_ref(pp.concat([
-        pp.text(core.pp_var(x, context)),
-        pp.text('['), idx, pp.text(']')
-      ])), pp.text(' <- '), pp.text(core.pp_var(v, context))]
+    return pp.concat([
+        pp_ref(pp.concat([
+            pp.text(core.pp_var(x, context)),
+            pp.text('['), idx, pp.text(']')
+        ])), pp.text(' <- '), pp.text(core.pp_var(v, context))])
   else:
     # pretty-print `y:T = swap x v i` as `y:T, x[i] <- x[i], v`
     x_i = pp.concat([pp.text(core.pp_var(x, context)),
                      pp.text('['), idx, pp.text(']')])
     y = core.pp_vars([y], context, print_shapes=settings.print_shapes)
-    return [y, pp.text(', '), pp_ref(x_i), pp.text(' <- '),
-            pp_ref(x_i), pp.text(', '), pp.text(core.pp_var(v, context))]
+    return pp.concat([y, pp.text(', '), pp_ref(x_i), pp.text(' <- '),
+                      pp_ref(x_i), pp.text(', '),
+                      pp.text(core.pp_var(v, context))])
 core.pp_eqn_rules[swap_p] = _swap_pp_rule
 
-def _addupdate_pp_rule(eqn, context, settings):
+def _addupdate_pp_rule(eqn, context, settings) -> pp.Doc:
   # pretty-print ` = addupdate x i v` as `x[i] += v`
   () = eqn.outvars
   x, v, *idx = eqn.invars
   idx = _pp_idx(context, idx, eqn.params["indexed_dims"])
-  return [
+  return pp.concat([
     pp_ref(pp.concat([
         pp.text(core.pp_var(x, context)),
         pp.text('['), idx, pp.text(']')
-      ])), pp.text(' += '), pp.text(core.pp_var(v, context))]
+    ])), pp.text(' += '), pp.text(core.pp_var(v, context))])
 core.pp_eqn_rules[addupdate_p] = _addupdate_pp_rule
 
 ## get/swap/addupdate JVP rules


### PR DESCRIPTION
Code:
```python
import jax
print(jax.make_jaxpr(jax.jit(lambda x: x[100]))(jax.numpy.arange(100)))
```

Before:
<img width="822" alt="image" src="https://user-images.githubusercontent.com/1458824/217912406-6a607f0f-7ca8-4865-ac4f-f0f714295d94.png">


After:
<img width="829" alt="image" src="https://user-images.githubusercontent.com/1458824/217912374-00887a60-8147-4c75-836b-e55c89b6130e.png">

(~Separately, I'm confused as to why this is a `gather` rather than something simpler like a `dynamic_slice`...~ aha, we only do a `dynamic_slice` when it's statically provable to be in-bounds!)