### PR TITLE
[shape_poly] Better error message for functions that do not use inputs

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -662,9 +662,16 @@ get an error that `a` cannot be derived:
 
 ```python
 jax2tf.convert(lambda x_unused, y: y * 2.,
-               polymorphic_shapes=["b, a", "b, 2 * a"])(x, y)
+               polymorphic_shapes=["b, a", "b, _"])(x, y)
 ```
 
+An input is still considered unused if the computation uses only its shape.
+The code below gives the same error:
+
+```python
+jax2tf.convert(lambda x_unused, y: y * x_unused.shape[0],
+               polymorphic_shapes=["b, a", "b, _"])(x, y)
+```
 
 ## Known issues
 

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -42,7 +42,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set,
 import jax
 from jax._src.numpy import lax_numpy
 from jax._src import dtypes
-from jax.interpreters import mlir
+from jax._src.interpreters import mlir
 from jax.interpreters import xla
 from jax._src.lax import lax
 from jax._src.typing import DimSize, Shape
@@ -207,7 +207,13 @@ class _DimAtom:
 
   def evaluate(self, env: ShapeEnv):
     if self.var is not None:
-      return env[self.var]
+      try:
+        return env[self.var]
+      except KeyError:
+        err_msg = (
+            f"Encountered dimension variable '{self.var}' that is not appearing in the shapes of the used function arguments.\n"
+            "Please see https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#dimension-variables-must-be-solvable-from-the-input-shapes for more details.")
+        raise KeyError(err_msg)
     else:
       operand_values = [opnd.evaluate(env) for opnd in self.operands]
       div_mod = divmod(*operand_values)  # type: ignore


### PR DESCRIPTION

Also:
  * fixed some of the tests that were using the shape but not the value of the input arguments
  * fix importing of mlir.py due to recent move of interpreters.mlir to _src.interpreters.mlir