### PR TITLE
Drop support for NVIDIA Kepler series GPUs in jaxlib builds.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -62,7 +62,7 @@ build:mkl_open_source_only --define=tensorflow_mkldnn_contraction_kernel=1
 build:cuda --repo_env TF_NEED_CUDA=1
 # "sm" means we emit only cubin, which is forward compatible within a GPU generation.
 # "compute" means we emit both cubin and PTX, which is larger but also forward compatible to future GPU generations.
-build:cuda --action_env TF_CUDA_COMPUTE_CAPABILITIES="sm_35,sm_52,sm_60,sm_70,compute_80"
+build:cuda --action_env TF_CUDA_COMPUTE_CAPABILITIES="sm_52,sm_60,sm_70,compute_80"
 build:cuda --crosstool_top=@local_config_cuda//crosstool:toolchain
 build:cuda --@local_config_cuda//:enable_cuda
 build:cuda --@org_tensorflow//tensorflow/compiler/xla/python:enable_gpu=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ Remember to align the itemized text with the first line of an item within a list
     at import time so it needs to be disabled before jax is imported.
 
 ## jaxlib 0.4.4
+  * Breaking changes
+    * Support for NVIDIA Kepler series GPUs has been removed from the default
+      `jaxlib` builds. If Kepler support is needed, it is still possible to
+      build `jaxlib` from source with Kepler support (via the
+      `--cuda_compute_capabilities=sm_35` option to `build.py`), however note
+      that CUDA 12 has completely dropped support for Kepler GPUs.
 
 ## jax 0.4.3 (Feb 8, 2023)
   * Breaking changes


### PR DESCRIPTION
Notably Colab no longer has Kepler GPUs.

Change in preparation for CUDA 12 support (#13637)