### PR TITLE
generalize vmap spmd_axis_name to accept tuples of axis names

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -101,7 +101,7 @@ traceback_util.register_exclusion(__file__)
 
 _dtype = partial(dtypes.dtype, canonicalize=True)
 
-AxisName = Any
+AxisName = Hashable
 
 Device = xc.Device
 
@@ -1228,7 +1228,7 @@ def value_and_grad(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
 
   check_callable(fun)
   argnums = core.concrete_or_error(_ensure_index, argnums)
-  reduce_axes = _ensure_str_tuple(reduce_axes)
+  reduce_axes = _ensure_str_tuple(reduce_axes)  # type: ignore
 
   @wraps(fun, docstr=docstr, argnums=argnums)
   @api_boundary
@@ -1593,9 +1593,10 @@ def _split(x, indices, axis):
 def vmap(fun: F,
          in_axes: Union[int, Sequence[Any]] = 0,
          out_axes: Any = 0,
-         axis_name: Optional[Hashable] = None,
+         axis_name: Optional[AxisName] = None,
          axis_size: Optional[int] = None,
-         spmd_axis_name: Optional[Hashable] = None) -> F:
+         spmd_axis_name: Optional[Union[AxisName, Tuple[AxisName, ...]]] = None
+         ) -> F:
   """Vectorizing map. Creates a function which maps ``fun`` over argument axes.
 
   Args:
@@ -1733,6 +1734,8 @@ def vmap(fun: F,
     docstr += fun.__doc__
 
   axis_name = core.no_axis_name if axis_name is None else axis_name
+  if spmd_axis_name is not None and type(spmd_axis_name) is not tuple:
+    spmd_axis_name = (spmd_axis_name,)
 
   if isinstance(in_axes, list):
     # To be a tree prefix of the positional args tuple, in_axes can never be a
@@ -2773,7 +2776,7 @@ def vjp(  # type: ignore
   -0.2524413
   """
   check_callable(fun)
-  reduce_axes = _ensure_str_tuple(reduce_axes)
+  reduce_axes = _ensure_str_tuple(reduce_axes)  # type: ignore
   return _vjp(
       lu.wrap_init(fun), *primals, has_aux=has_aux, reduce_axes=reduce_axes)
 

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1466,7 +1466,7 @@ def _pjit_batcher(insert_axis, spmd_axis_name,
 
   # `insert_axis` is set to True only for some `xmap` uses.
   new_parts = (axis_name,) if insert_axis else (
-      () if spmd_axis_name is None else (spmd_axis_name,))
+      () if spmd_axis_name is None else spmd_axis_name)
 
   if resource_env is not None:
     mesh = resource_env.physical_mesh
@@ -2017,7 +2017,7 @@ def _sharding_constraint_batcher(insert_axis, spmd_axis_name, axis_size,
   d, = dims_in
   # None means unconstrained in ParsedPartitionSpec
   new_parts = (axis_name,) if insert_axis else (
-      None if spmd_axis_name is None else (spmd_axis_name,))
+      None if spmd_axis_name is None else spmd_axis_name)
   unconstrained_dims = {ud + (d <= ud) for ud in unconstrained_dims}
   if new_parts is None:
     unconstrained_dims.add(d)

--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -709,7 +709,7 @@ def _shard_map_batch(
                    for ax in names} for names, d in zip(in_names, in_dims)]
   spmd_axis_name = trace.spmd_axis_name
   if spmd_axis_name is not None:
-    new_in_names = [{**ns, d:(spmd_axis_name,)} if d is not batching.not_mapped  # type: ignore
+    new_in_names = [{**ns, d:spmd_axis_name} if d is not batching.not_mapped  # type: ignore
                     else ns for ns, d in zip(new_in_names, in_dims)]
   @as_hashable_function(closure=out_names_thunk)
   def new_out_names_thunk():
@@ -717,7 +717,7 @@ def _shard_map_batch(
     out_names_ = [{ax + (d is not batching.not_mapped and d <= ax): names[ax]
                    for ax in names} for names, d in zip(out_names, out_dims())]
     if spmd_axis_name is not None:
-      out_names_ = [{**ns, d:(spmd_axis_name,)} if d is not batching.not_mapped
+      out_names_ = [{**ns, d:spmd_axis_name} if d is not batching.not_mapped
                     else ns for ns, d in zip(out_names_, out_dims())]
     return out_names_
 


### PR DESCRIPTION
This brings the argument more in line with what can appear as positional arguments to the PartitionSpec constructor.