### PR TITLE
A few developer workflow enhancements for working with jaxlib.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -256,6 +256,24 @@ common:tensorflow_testing_rbe_linux --remote_instance_name=projects/tensorflow-t
 build:tensorflow_testing_rbe_linux --config=tensorflow_testing_rbe
 #############################################################################
 
+#############################################################################
+# Some configs to make getting some forms of debug builds. In general, the
+# codebase is only regularly built with optimizations. Use 'debug_symbols' to
+# just get symbols for the parts of XLA/PJRT that jaxlib uses.
+# Or try 'debug' to get a build with assertions enabled and minimal 
+# optimizations.
+# Include these in a local .bazelrc.user file as:
+#   build --config=debug_symbols
+# Or:
+#   build --config=debug
+#
+# Additional files can be opted in for debug symbols by adding patterns
+# to a per_file_copt similar to below.
+#############################################################################
+
+build:debug_symbols --strip=never --per_file_copt="xla/pjrt|xla/python@-g3"
+build:debug --config debug_symbols -c fastbuild
+
 # Load `.jax_configure.bazelrc` file written by build.py
 try-import %workspace%/.jax_configure.bazelrc
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 .vscode
 .envrc
 jax.iml
+.bazelrc.user
 
 # virtualenv/venv directories
 /venv/

--- a/build/build_wheel.py
+++ b/build/build_wheel.py
@@ -295,7 +295,7 @@ def build_wheel(sources_path, output_path, cpu):
     output_file = os.path.join(output_path, os.path.basename(wheel))
     sys.stderr.write(f"Output wheel: {output_file}\n\n")
     sys.stderr.write("To install the newly-built jaxlib wheel, run:\n")
-    sys.stderr.write(f"  pip install {output_file}\n\n")
+    sys.stderr.write(f"  pip install {output_file} --force-reinstall\n\n")
     shutil.copy(wheel, output_path)
 
 


### PR DESCRIPTION
It seems to me that jaxlib development must be mostly happening on CI, because some basics are pretty essential. Here are a few things I've been typing/carrying for a while in my flow:

* Add .bazelrc.user to .gitignore so it doesn't accidentally get checked in.
* Add configs for 'debug_symbols' and 'debug' that make some things minimally workable under a debugger (or to get backtraces, etc).
* Add `--force-reinstall` to the copy/paste command to update a built jaxlib wheel (without this, if you are iterating, it fairly quietly does nothing).