### PR TITLE
MeshComputation.cost_analysis() isn't implemented with PJRT C API.

### DIFF
--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -3259,8 +3259,13 @@ class MeshComputation(stages.XlaLowering):
     return self._executable
 
   def cost_analysis(self) -> Dict[str, float]:
-    return xe.hlo_module_cost_analysis(self.compile_args["backend"],
-                                       self.hlo().as_hlo_module())
+    backend = self.compile_args["backend"]
+    if xb.using_pjrt_c_api(backend):
+      raise NotImplementedError(
+          "Lowered.cost_analysis not implemented on platform "
+          f"'{backend.platform}'. Use compile().cost_analysis() for "
+          "post-compilation cost estimates.")
+    return xe.hlo_module_cost_analysis(backend, self.hlo().as_hlo_module())
 
 def get_input_metadata(
     global_in_avals: Sequence[ShapedArray],

--- a/jax/_src/lib/xla_bridge.py
+++ b/jax/_src/lib/xla_bridge.py
@@ -631,3 +631,7 @@ def host_ids(backend=None):
       "instead. jax.host_ids will eventually be removed; please update your "
       "code.")
   return list(range(process_count(backend)))
+
+
+def using_pjrt_c_api(backend=None):
+  return "PJRT C API" in get_backend(backend).platform_version


### PR DESCRIPTION
This was caught via PJitTest.testLowerCostAnalysis (https://github.com/google/jax/blob/e74852f79695c9f2fcf06b4c8400b176bb899766/tests/pjit_test.py#L998). We don't need to change the test because NotImplementedError is already caught in Lowered.cost_analysis:
https://github.com/google/jax/blob/e74852f79695c9f2fcf06b4c8400b176bb899766/jax/_src/stages.py#L659-L660