### PR TITLE
Small update to jax profiling docs

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -124,7 +124,7 @@ alternative to `start_trace` and `stop_trace`:
 ```python
 import jax
 
-with jax.profiler.trace():
+with jax.profiler.trace("/tmp/tensorboard"):
   key = jax.random.PRNGKey(0)
   x = jax.random.normal(key, (5000, 5000))
   y = x @ x


### PR DESCRIPTION
Creating the trace object with context manager also requires a logdir. Using the same string as the example above it.