### PR TITLE
Added implementation of `null_space`

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -35,6 +35,7 @@ jax.scipy.linalg
    lu
    lu_factor
    lu_solve
+   null_space
    polar
    qr
    rsf2csf

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -30,6 +30,7 @@ from jax._src.scipy.linalg import (
   lu as lu,
   lu_factor as lu_factor,
   lu_solve as lu_solve,
+  null_space as null_space,
   polar as polar,
   qr as qr,
   rsf2csf as rsf2csf,


### PR DESCRIPTION
This fixes #14350 .

For the unit tests I just copy-pasted and corrected the ones from `scipy` (for some reason they were not correct).

As @jakevdp was mentioning, `null_space` is not jittable, but I am not sure how to signal that to the user.