### PR TITLE
[sparse] modify impl rules to always use lowering path

### DIFF
--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -41,11 +41,11 @@ import jax.numpy as jnp
 from jax.util import safe_zip, unzip2, split_list
 from jax._src import api_util
 from jax._src import core
+from jax._src import dispatch
 from jax._src.interpreters import ad
 from jax._src.interpreters import batching
 from jax._src.lax.lax import (
-  _const, ranges_like, remaining, _dot_general_batch_dim_nums,
-  DotDimensionNumbers)
+  _const, ranges_like, remaining, _dot_general_batch_dim_nums, DotDimensionNumbers)
 from jax._src.lax.slicing import GatherDimensionNumbers, GatherScatterMode
 from jax._src.lib.mlir import ir
 from jax._src.lib import gpu_sparse
@@ -663,7 +663,6 @@ def _bcoo_rdot_general(lhs: Array, rhs_data: Array, rhs_indices: Array, *,
   permutation = tuple([*range(n_batch), *range(n_swap, result.ndim), *range(n_batch, n_swap)])
   return lax.transpose(result, permutation)
 
-@bcoo_dot_general_p.def_impl
 def _bcoo_dot_general_impl(lhs_data, lhs_indices, rhs, *, dimension_numbers, lhs_spinfo: SparseInfo):
   lhs_data = jnp.asarray(lhs_data)
   lhs_indices = jnp.asarray(lhs_indices)
@@ -908,9 +907,8 @@ def _bcoo_dot_general_batch_rule(batched_args, batch_dims, *, dimension_numbers,
 ad.defjvp(bcoo_dot_general_p, _bcoo_dot_general_jvp_lhs, None, _bcoo_dot_general_jvp_rhs)
 ad.primitive_transposes[bcoo_dot_general_p] = _bcoo_dot_general_transpose
 batching.primitive_batchers[bcoo_dot_general_p] = _bcoo_dot_general_batch_rule
-
-mlir.register_lowering(
-    bcoo_dot_general_p, _bcoo_dot_general_default_lowering)
+mlir.register_lowering(bcoo_dot_general_p, _bcoo_dot_general_default_lowering)
+dispatch.simple_impl(bcoo_dot_general_p)
 
 if gpu_sparse.cuda_is_supported:
   mlir.register_lowering(

--- a/jax/experimental/sparse/bcsr.py
+++ b/jax/experimental/sparse/bcsr.py
@@ -38,6 +38,7 @@ from jax.util import split_list, safe_zip
 
 from jax._src import api_util
 from jax._src import core
+from jax._src import dispatch
 from jax._src.lax.lax import DotDimensionNumbers, _dot_general_batch_dim_nums
 from jax._src.lib import gpu_sparse
 from jax._src.lib.mlir.dialects import hlo
@@ -509,7 +510,6 @@ def _bcsr_dot_general(lhs_data: jax.Array, lhs_indices: jax.Array,
                                  lhs_spinfo=lhs_spinfo)
 
 
-@bcsr_dot_general_p.def_impl
 def _bcsr_dot_general_impl(lhs_data, lhs_indices, lhs_indptr, rhs, *,
                            dimension_numbers, lhs_spinfo):
   lhs_data = jnp.asarray(lhs_data)
@@ -677,9 +677,9 @@ def _bcsr_dot_general_gpu_lowering(
 
 _bcsr_dot_general_default_lowering = mlir.lower_fun(
     _bcsr_dot_general_impl, multiple_results=False)
-
 mlir.register_lowering(
     bcsr_dot_general_p, _bcsr_dot_general_default_lowering)
+dispatch.simple_impl(bcsr_dot_general_p)
 
 if gpu_sparse.cuda_is_supported:
   mlir.register_lowering(bcsr_dot_general_p,

--- a/jax/experimental/sparse/csr.py
+++ b/jax/experimental/sparse/csr.py
@@ -30,6 +30,7 @@ from jax.experimental.sparse.util import _csr_to_coo, _csr_extract, CuSparseEffi
 from jax import lax
 from jax import tree_util
 from jax._src import core
+from jax._src import dispatch
 from jax._src.interpreters import ad
 from jax._src.lax.lax import _const
 from jax._src.lib import gpu_sparse
@@ -235,7 +236,6 @@ def _csr_todense(data: Array, indices: Array, indptr: Array, *, shape: Shape) ->
   """
   return csr_todense_p.bind(data, indices, indptr, shape=shape)
 
-@csr_todense_p.def_impl
 def _csr_todense_impl(data, indices, indptr, *, shape):
   return _coo_todense(data, *_csr_to_coo(indices, indptr), spinfo=COOInfo(shape=shape))
 
@@ -280,6 +280,8 @@ def _csr_todense_transpose(ct, data, indices, indptr, *, shape):
 ad.defjvp(csr_todense_p, _csr_todense_jvp, None, None)
 ad.primitive_transposes[csr_todense_p] = _csr_todense_transpose
 mlir.register_lowering(csr_todense_p, _csr_todense_lowering)
+dispatch.simple_impl(csr_todense_p)
+
 if gpu_sparse.cuda_is_supported:
   mlir.register_lowering(
       csr_todense_p,
@@ -332,7 +334,6 @@ def _csr_fromdense(mat: Array, *, nse: int, index_dtype: DTypeLike = np.int32) -
   nse = core.concrete_or_error(operator.index, nse, "nse argument of csr_fromdense()")
   return csr_fromdense_p.bind(mat, nse=nse, index_dtype=np.dtype(index_dtype))
 
-@csr_fromdense_p.def_impl
 def _csr_fromdense_impl(mat, *, nse, index_dtype):
   mat = jnp.asarray(mat)
   assert mat.ndim == 2
@@ -399,6 +400,8 @@ def _csr_fromdense_transpose(ct, M, *, nse, index_dtype):
 ad.primitive_jvps[csr_fromdense_p] = _csr_fromdense_jvp
 ad.primitive_transposes[csr_fromdense_p] = _csr_fromdense_transpose
 mlir.register_lowering(csr_fromdense_p, _csr_fromdense_lowering)
+dispatch.simple_impl(csr_fromdense_p)
+
 if gpu_sparse.cuda_is_supported:
   mlir.register_lowering(
       csr_fromdense_p,
@@ -451,7 +454,6 @@ def _csr_matvec(data, indices, indptr, v, *, shape, transpose=False):
   """
   return csr_matvec_p.bind(data, indices, indptr, v, shape=shape, transpose=transpose)
 
-@csr_matvec_p.def_impl
 def _csr_matvec_impl(data, indices, indptr, v, *, shape, transpose):
   return _coo_matvec(data, *_csr_to_coo(indices, indptr), v, spinfo=COOInfo(shape=shape), transpose=transpose)
 
@@ -505,6 +507,7 @@ def _csr_matvec_transpose(ct, data, indices, indptr, v, *, shape, transpose):
 ad.defjvp(csr_matvec_p, _csr_matvec_jvp_mat, None, None, _csr_matvec_jvp_vec)
 ad.primitive_transposes[csr_matvec_p] = _csr_matvec_transpose
 mlir.register_lowering(csr_matvec_p, _csr_matvec_lowering)
+dispatch.simple_impl(csr_matvec_p)
 
 if gpu_sparse.cuda_is_supported:
   mlir.register_lowering(
@@ -560,7 +563,6 @@ def _csr_matmat(data: Array, indices: Array, indptr: Array, B: Array,
   """
   return csr_matmat_p.bind(data, indices, indptr, B, shape=shape, transpose=transpose)
 
-@csr_matmat_p.def_impl
 def _csr_matmat_impl(data, indices, indptr, B, *, shape, transpose):
   return _coo_matmat(data, *_csr_to_coo(indices, indptr), B, spinfo=COOInfo(shape=shape), transpose=transpose)
 
@@ -614,6 +616,7 @@ def _csr_matmat_transpose(ct, data, indices, indptr, B, *, shape, transpose):
 ad.defjvp(csr_matmat_p, _csr_matmat_jvp_left, None, None, _csr_matmat_jvp_right)
 ad.primitive_transposes[csr_matmat_p] = _csr_matmat_transpose
 mlir.register_lowering(csr_matmat_p, _csr_matmat_lowering)
+dispatch.simple_impl(csr_matmat_p)
 
 if gpu_sparse:
   if gpu_sparse.cuda_is_supported:


### PR DESCRIPTION
Previously, matmuls would not use GPU lowering rules unless wrapped in JIT. This changes the setup so that GPU lowering rules are always used when available.

cc/ @tlu7 