### PR TITLE
Refactor effects system to use effect types, not objects

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -43,6 +43,7 @@ from jax._src import callback as jcb
 from jax._src import core
 from jax._src import device_array
 from jax._src import dispatch
+from jax._src import effects
 from jax._src import array
 from jax._src import dtypes
 from jax._src import source_info_util
@@ -1071,10 +1072,10 @@ def xla_computation(fun: Callable,
       else:
         out_parts_flat = tuple(flatten_axes(
             "xla_computation out_parts", out_tree(), out_parts))
-      unordered_effects = [eff for eff in jaxpr.effects
-                           if eff not in core.ordered_effects]
-      ordered_effects = [eff for eff in jaxpr.effects
-                         if eff in core.ordered_effects]
+      unordered_effects = list(
+          effects.ordered_effects.filter_not_in(jaxpr.effects))
+      ordered_effects = list(
+          effects.ordered_effects.filter_in(jaxpr.effects))
       lowering_result = mlir.lower_jaxpr_to_module(
           f"xla_computation_{fun_name}",
           core.ClosedJaxpr(jaxpr, consts),

--- a/jax/_src/callback.py
+++ b/jax/_src/callback.py
@@ -24,6 +24,7 @@ from jax.interpreters import mlir
 
 from jax._src import core
 from jax._src import dtypes
+from jax._src import effects
 from jax._src import util
 from jax._src import dispatch
 from jax._src.interpreters import ad
@@ -158,17 +159,19 @@ def pure_callback(callback: Callable[..., Any], result_shape_dtypes: Any,
 io_callback_p = core.Primitive("io_callback")
 io_callback_p.multiple_results = True
 
-class IOEffect:
+class IOEffect(effects.Effect):
   __str__ = lambda _: "IO"
-class OrderedIOEffect:
+
+class OrderedIOEffect(effects.Effect):
   __str__ = lambda _: "OrderedIO"
+
 _IOEffect = IOEffect()
 _OrderedIOEffect = OrderedIOEffect()
-mlir.lowerable_effects.add(_IOEffect)
-mlir.lowerable_effects.add(_OrderedIOEffect)
-core.control_flow_allowed_effects.add(_IOEffect)
-core.control_flow_allowed_effects.add(_OrderedIOEffect)
-core.ordered_effects.add(_OrderedIOEffect)
+effects.lowerable_effects.add_type(IOEffect)
+effects.lowerable_effects.add_type(OrderedIOEffect)
+effects.control_flow_allowed_effects.add_type(IOEffect)
+effects.control_flow_allowed_effects.add_type(OrderedIOEffect)
+effects.ordered_effects.add_type(OrderedIOEffect)
 
 
 def io_callback_impl(*args, result_avals, callback: Callable[..., Any],

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -37,6 +37,7 @@ import numpy as np
 
 from jax._src import dtypes
 from jax._src import config as jax_config
+from jax._src import effects
 from jax._src.config import FLAGS, config
 from jax.errors import (ConcretizationTypeError, TracerArrayConversionError,
                         TracerIntegerConversionError, UnexpectedTracerError)
@@ -59,12 +60,10 @@ map, unsafe_map = safe_map, map
 
 # -------------------- jaxprs --------------------
 
-Effect = Hashable
-Effects = Set[Effect]
-no_effects: Effects = set()
-ordered_effects: Set[Effect] = set()
-control_flow_allowed_effects: Set[Effect] = set()
-
+Effect = effects.Effect
+Effects = effects.Effects
+EffectTypeSet = effects.EffectTypeSet
+no_effects: Effects = effects.no_effects
 
 class Jaxpr:
   __slots__ = ['__weakref__', '_constvars', '_invars', '_outvars', '_eqns', '_effects']
@@ -2829,7 +2828,7 @@ def _check_map(ctx_factory, prim, in_avals, params):
   if "call_jaxpr" not in params:
     raise JaxprTypeError(f"Map primitive {prim} missing 'call_jaxpr' parameter")
   call_jaxpr = params["call_jaxpr"]
-  ordered_effects_ = call_jaxpr.effects & ordered_effects
+  ordered_effects_ = effects.ordered_effects.filter_in(call_jaxpr.effects)
   if ordered_effects_:
     raise JaxprTypeError(
         f"Map primitive {prim} mapping ordered effects: {ordered_effects_}")

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -42,6 +42,7 @@ from jax._src import array
 from jax._src import core
 from jax._src import device_array
 from jax._src import dtypes
+from jax._src import effects
 from jax._src import linear_util as lu
 from jax._src import path
 from jax._src import profiler
@@ -507,10 +508,10 @@ def lower_xla_callable(
                             if type(d) is pe.InDBIdx else d for d in a.shape))
        if type(a) is core.DShapedArray else a, b) for a, b in out_type]
   module_name = f"jit_{fun.__name__}"
-  unordered_effects = [eff for eff in closed_jaxpr.effects
-                       if eff not in core.ordered_effects]
-  ordered_effects = [eff for eff in closed_jaxpr.effects
-                     if eff in core.ordered_effects]
+  unordered_effects = list(
+    effects.ordered_effects.filter_not_in(closed_jaxpr.effects))
+  ordered_effects = list(
+    effects.ordered_effects.filter_in(closed_jaxpr.effects))
   lowering_result = mlir.lower_jaxpr_to_module(
       module_name, closed_jaxpr, unordered_effects,
       ordered_effects, backend, backend.platform,

--- a/jax/_src/effects.py
+++ b/jax/_src/effects.py
@@ -1,0 +1,46 @@
+# Copyright 2023 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from typing import Type, Set
+
+
+class Effect:
+  """A generic side-effect."""
+
+Effects = Set[Effect]
+
+class EffectTypeSet:
+
+  def __init__(self):
+    self._effect_types: Set[Type[Effect]] = set()
+
+  def add_type(self, effect_type: Type[Effect]):
+    self._effect_types.add(effect_type)
+
+  def contains(self, eff: Effect) -> bool:
+    return any(isinstance(eff, eff_type) for eff_type in self._effect_types)
+
+  def filter_in(self, effects: Effects) -> Effects:
+    return {eff for eff in effects if self.contains(eff)}
+
+  def filter_not_in(self, effects: Effects) -> Effects:
+    return {eff for eff in effects if not self.contains(eff)}
+
+no_effects: Effects = set()
+ordered_effects: EffectTypeSet = EffectTypeSet()
+lowerable_effects: EffectTypeSet = EffectTypeSet()
+control_flow_allowed_effects: EffectTypeSet = EffectTypeSet()
+custom_derivatives_allowed_effects: EffectTypeSet = EffectTypeSet()
+remat_allowed_effects: EffectTypeSet = EffectTypeSet()

--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -19,8 +19,8 @@ from typing import Callable, Optional, Sequence
 
 from jax._src import core
 from jax._src import linear_util as lu
-from jax._src.core import control_flow_allowed_effects as allowed_effects
 from jax._src.lax import lax
+from jax._src.effects import control_flow_allowed_effects as allowed_effects
 from jax._src import ad_util
 from jax._src import util
 from jax._src.util import cache, weakref_lru_cache, safe_map, unzip3
@@ -30,8 +30,7 @@ from jax.tree_util import tree_map, tree_unflatten
 
 map, unsafe_map = safe_map, map
 
-allowed_effects.add(lax.InOutFeedEffect.Infeed)
-allowed_effects.add(lax.InOutFeedEffect.Outfeed)
+allowed_effects.add_type(lax.InOutFeedEffect)
 
 
 def _abstractify(x):

--- a/jax/_src/maps.py
+++ b/jax/_src/maps.py
@@ -25,6 +25,7 @@ from jax._src import core
 from jax._src import linear_util as lu
 from jax import stages
 from jax._src import dispatch
+from jax._src import effects
 from jax.tree_util import (tree_flatten, tree_unflatten, all_leaves, tree_map,
                            treedef_tuple)
 from jax._src.api_util import (flatten_fun_nokwargs, flatten_axes,
@@ -1375,7 +1376,8 @@ def _xmap_lowering_rule_replica(ctx, *in_nodes,
   sub_ctx = ctx.module_context.replace(
       name_stack=extend_name_stack(ctx.module_context.name_stack,
                                    wrap_name(name, 'xmap')))
-  if any(eff in core.ordered_effects for eff in vectorized_jaxpr.effects):
+  if any(effects.ordered_effects.contains(eff) for eff
+         in vectorized_jaxpr.effects):
     raise NotImplementedError('Cannot lower `xmap` with ordered effects.')
   tiled_outs, _ = mlir.jaxpr_subcomp(sub_ctx, vectorized_jaxpr, mlir.TokenSet(),
                                      const_nodes, *tiled_ins,
@@ -1442,7 +1444,8 @@ def _xmap_lowering_rule_spmd(ctx, *global_in_nodes,
   sub_ctx = ctx.module_context.replace(
       name_stack=extend_name_stack(ctx.module_context.name_stack,
                                    wrap_name(name, 'xmap')))
-  if any(eff in core.ordered_effects for eff in vectorized_jaxpr.effects):
+  if any(effects.ordered_effects.contains(eff) for eff
+         in vectorized_jaxpr.effects):
     raise NotImplementedError('Cannot lower `xmap` with ordered effects.')
   global_out_nodes, _ = mlir.jaxpr_subcomp(sub_ctx, vectorized_jaxpr,
       mlir.TokenSet(), const_nodes, *sharded_global_in_nodes,
@@ -1494,7 +1497,8 @@ def _xmap_lowering_rule_spmd_manual(ctx, *global_in_nodes,
       name_stack=extend_name_stack(ctx.module_context.name_stack,
                                    wrap_name(name, 'xmap')),
       axis_context=ctx.module_context.axis_context.extend_manual(manual_mesh_axes))
-  if any(eff in core.ordered_effects for eff in vectorized_jaxpr.effects):
+  if any(effects.ordered_effects.contains(eff) for eff
+         in vectorized_jaxpr.effects):
     raise NotImplementedError('Cannot lower `xmap` with ordered effects.')
   global_out_nodes, _ = mlir.jaxpr_subcomp(sub_ctx, vectorized_jaxpr,
       mlir.TokenSet(), const_nodes, *([n] for n in global_in_nodes),

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1465,9 +1465,9 @@ pe.custom_staging_rules[pjit_p] = pjit_staging_rule
 
 def _pjit_abstract_eval(*args, jaxpr, out_shardings, resource_env,
                         out_positional_semantics, **_):
-  disallowed_effects = jaxpr.effects - mlir.lowerable_effects
+  disallowed_effects = mlir.lowerable_effects.filter_not_in(jaxpr.effects)
   if disallowed_effects:
-    raise ValueError('Effects not supported in `pjit`.')
+    raise ValueError(f'Effects not supported in `pjit`: {disallowed_effects}.')
   if config.jax_array:
     return jaxpr.out_avals, jaxpr.effects
   return global_to_local(out_positional_semantics, jaxpr.out_avals,

--- a/jax/_src/state/types.py
+++ b/jax/_src/state/types.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 from typing import Any, List, Optional, Sequence, Set, Union
 
 from jax._src import core
+from jax._src import effects
 from jax._src.lib import xla_bridge, xla_client
 from jax._src.util import safe_map, safe_zip, tuple_insert, tuple_delete, prod
-from jax._src.lax.control_flow import common
 
 xc = xla_client
 xb = xla_bridge
@@ -31,10 +31,9 @@ zip, unsafe_zip = safe_zip, zip
 
 Array = Any
 
-class RefEffect:
+class RefEffect(effects.Effect):
   def __init__(self, ref_aval: ShapedArrayRef):
     self.ref_aval = ref_aval
-    common.allowed_effects.add(self)
 
   def __eq__(self, other):
     if not isinstance(other, self.__class__):
@@ -60,6 +59,8 @@ class WriteEffect(RefEffect):
 class AccumEffect(RefEffect):
   def __str__(self):
     return f"Accum<{self.ref_aval}>"
+
+effects.control_flow_allowed_effects.add_type(RefEffect)
 
 StateEffect = Union[ReadEffect, WriteEffect, AccumEffect]
 

--- a/jax/core.py
+++ b/jax/core.py
@@ -156,7 +156,6 @@ from jax._src.core import (
   np as np,
   opaque_dtypes as opaque_dtypes,
   operator as operator,
-  ordered_effects as ordered_effects,
   outfeed_primitives as outfeed_primitives,
   partial as partial,
   partialmethod as partialmethod,

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -30,6 +30,7 @@ from jax._src import linear_util as lu
 from jax.config import config
 from jax._src import api_util
 from jax._src import core
+from jax._src import effects
 from jax._src import dtypes
 from jax._src import profiler
 from jax._src import source_info_util
@@ -1782,7 +1783,7 @@ class DynamicJaxprTrace(core.Trace):
       with core.new_sublevel():
         jaxpr, reduced_out_avals, consts = trace_to_subjaxpr_dynamic(
             f, self.main, reduced_in_avals, debug_info=debug_info_final(f, map_primitive.name))
-      ordered_effects = jaxpr.effects & core.ordered_effects
+      ordered_effects = effects.ordered_effects.filter_in(jaxpr.effects)
       if ordered_effects:
         raise ValueError("Ordered effects not supported for "
                          f"map primitives: {ordered_effects}")


### PR DESCRIPTION
Up to this point, JAX effects were allowed/disallowed in transformations if they were members of sets that functioned as allowlists.

This meant that anytime we created a new effect object, we'd have to add it to the appropriate sets. This ended up not being a great abstraction because for things like the `State` effect, which was no longer a "singleton" effect like the debugging effects, we would be creating many effect objects, and all of them would be needed to be part of the allowlists.

This change creates the `EffectTypeSet`, which contains *types* of effects in it. It has a method that checks whether certain an effect has its type in the set.

Another part of this refactor is that it centralizes all the effect sets to a new `effects.py` file.