### PR TITLE
Reexport jax.interpreters.mlir.token_type.

### DIFF
--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -62,5 +62,6 @@ from jax._src.interpreters.mlir import (
   register_constant_handler as register_constant_handler,
   register_lowering as register_lowering,
   shape_tensor as shape_tensor,
+  token_type as token_type,
   xla_computation_to_mlir_module as xla_computation_to_mlir_module,
 )


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/14551