### PR TITLE
BUG: avoid passing functions directly to abstractmethod

### DIFF
--- a/jax/_src/basearray.py
+++ b/jax/_src/basearray.py
@@ -40,5 +40,10 @@ class Array(abc.ABC):
 
   __slots__ = ['__weakref__']
 
+  # at property must be defined because we overwrite its docstring in lax_numpy.py
+  @property
+  def at(self):
+    raise NotImplementedError("property must be defined in subclasses")
+
 
 Array.__module__ = "jax"

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -5249,6 +5249,7 @@ class _IndexUpdateHelper:
 
   def __repr__(self):
     return f"_IndexUpdateHelper({repr(self.array)})"
+ndarray.at.__doc__ = _IndexUpdateHelper.__doc__
 
 _power_fn = power
 _divide_fn = divide

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -24,7 +24,6 @@ transformations for NumPy primitives can be derived from the transformation
 rules for the underlying :code:`lax` primitives.
 """
 
-import abc
 import builtins
 import collections
 from functools import partial
@@ -5567,13 +5566,3 @@ for t in device_array.device_array_types:
 _set_device_array_attributes(pxla._ShardedDeviceArray)
 _set_device_array_attributes(pmap_lib.ShardedDeviceArray)
 _set_device_array_attributes(ArrayImpl)
-
-def _set_jax_array_abstract_methods(jax_array):
-  for operator_name, function in _array_operators.items():
-    setattr(jax_array, f"__{operator_name}__", abc.abstractmethod(function))
-  for method_name, method in _array_methods.items():
-    setattr(jax_array, method_name, abc.abstractmethod(method))
-  for prop_name, prop in _array_properties.items():
-    setattr(jax_array, prop_name, abc.abstractproperty(prop))
-
-_set_jax_array_abstract_methods(jax.Array)


### PR DESCRIPTION
`abstractmethod` mutates its arguments, which causes problems (see https://github.com/google/jax/discussions/14548)

Further, it turns out we can't add true abstract methods to `Array` because `Tracer` inherits from it and depends on methods being unimplemented.

This reverts part of #14474, and fixes #14548

Unfortunately, this means that array methods no longer have any HTML documentation.... but it's more important for now to fix the broken code. We'll need to find another approach for that.