### PR TITLE
custom_jvp symbolic zeros support

### DIFF
--- a/jax/_src/ad_util.py
+++ b/jax/_src/ad_util.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import types
 from typing import Any, Callable, Dict, TypeVar, Union, cast
 
 from jax.tree_util import register_pytree_node
@@ -91,3 +92,40 @@ def _stop_gradient_impl(x: T) -> T:
 stop_gradient_p : Primitive = Primitive('stop_gradient')
 stop_gradient_p.def_impl(_stop_gradient_impl)
 stop_gradient_p.def_abstract_eval(lambda x: x)
+
+
+class SymbolicZero:
+  def __init__(self, aval: core.AbstractValue) -> None:
+    self.aval = aval
+
+  def __repr__(self) -> str:
+    return self.__class__.__name__
+
+  # TODO(mattjj,frostig): this forwards attr lookup to self.aval delegate;
+  # should dedup with core.Tracer.__getattr__ which does the same thing
+  def __getattr__(self, name):
+    # if the aval property raises an AttributeError, gets caught here
+    try:
+      attr = getattr(self.aval, name)
+    except KeyError as err:
+      raise AttributeError(
+          f"{self.__class__.__name__} has no attribute {name}"
+      ) from err
+    else:
+      t = type(attr)
+      if t is core.aval_property:
+        return attr.fget(self)
+      elif t is core.aval_method:
+        return types.MethodType(attr.fun, self)
+      else:
+        return attr
+
+JaxTypeOrTracer = Any
+
+def replace_internal_symbolic_zeros(
+    x: Union[JaxTypeOrTracer, Zero]) -> Union[JaxTypeOrTracer, SymbolicZero]:
+  return SymbolicZero(x.aval) if type(x) is Zero else x
+
+def replace_rule_output_symbolic_zeros(
+    x: Union[JaxTypeOrTracer, SymbolicZero]) -> Union[JaxTypeOrTracer, Zero]:
+  return Zero(x.aval) if type(x) is SymbolicZero else x

--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -921,8 +921,8 @@ def custom_jvp_call_rule(in_err, enabled_errors, *in_vals, num_consts,
     return core.eval_jaxpr(jvp_jaxpr, jvp_consts, *primals, *tangents)
 
   jvp, jvp_out_tree = flatten_fun_output(jvp)
-  all_outs = custom_derivatives.custom_jvp_call_p.bind(partial_checkify, jvp,
-                                                       *err_vals, *in_vals)
+  all_outs = custom_derivatives.custom_jvp_call_p.bind(
+      partial_checkify, jvp, *err_vals, *in_vals, **params)
   fst, out_metadata = lu.merge_linear_aux(f_metadata, jvp_out_tree)
   if fst:
     err_and_out_tree, _ = out_metadata

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -484,7 +484,8 @@ class Trace:
            "primitives")
     raise NotImplementedError(msg)
 
-  def process_custom_jvp_call(self, primitive, fun, jvp, tracers):
+  def process_custom_jvp_call(self, primitive, fun, jvp, tracers, *,
+                              symbolic_zeros):
     msg = (f"{type(self)} must override process_custom_jvp_call "
            "to handle custom_jvp primitives")
     raise NotImplementedError(msg)
@@ -794,17 +795,17 @@ class EvalTrace(Trace):
   process_map = process_call
 
   def process_custom_transpose(self, primitive, call, tracers, **_):
-    del primitive
+    del primitive, _
     with new_sublevel():
       return call.call_wrapped(*tracers)
 
-  def process_custom_jvp_call(self, primitive, fun, jvp, tracers):
-    del primitive, jvp  # Unused.
+  def process_custom_jvp_call(self, primitive, fun, jvp, tracers, **_):
+    del primitive, jvp, _  # Unused.
     with new_sublevel():
       return fun.call_wrapped(*tracers)
 
   def process_custom_vjp_call(self, primitive, fun, fwd, bwd, tracers, **_):  # pytype: disable=signature-mismatch
-    del primitive, fwd, bwd  # Unused.
+    del primitive, fwd, bwd, _  # Unused.
     with new_sublevel():
       return fun.call_wrapped(*tracers)
 

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -1166,9 +1166,11 @@ class MapTrace(core.Trace):
                            for v, s, dst in zip(out, outaxes, out_axes_thunk()))
     return map(partial(MapTracer, self), out, outaxes)
 
-  def process_custom_jvp_call(self, primitive, fun, jvp, tracers):
+  def process_custom_jvp_call(self, primitive, fun, jvp, tracers, *,
+                              symbolic_zeros):
     bind = HashableFunction(
-        lambda *args, **kwargs: primitive.bind(fun, jvp, *args, **kwargs),
+        lambda *args, **kwargs: primitive.bind(
+            fun, jvp, *args, symbolic_zeros=symbolic_zeros, **kwargs),
         (primitive, fun, jvp))
     fake_primitive = FakePrimitive(multiple_results=True, bind=bind)
     return self.process_primitive(fake_primitive, tracers, {})

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -29,3 +29,7 @@ from jax._src.custom_derivatives import (
   custom_vjp_call_jaxpr_p as custom_vjp_call_jaxpr_p,
   linear_call as linear_call,
 )
+
+from jax._src.ad_util import (
+  SymbolicZero as SymbolicZero
+)

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1314,11 +1314,11 @@ class TensorFlowTrace(core.Trace):
   def post_process_map(self, map_primitive, out_tracers, params):
     raise NotImplementedError("post_process_map")
 
-  def process_custom_jvp_call(self, prim, fun, jvp, tracers):
+  def process_custom_jvp_call(self, prim, fun, jvp, tracers, *, symbolic_zeros):
     # Drop the custom differentiation rule and act like a call primitive. This
     # behavior is desirable because jax2tf stages code out of the JAX system, so
     # there are no more JAX differentiation transformations to be applied.
-    del jvp  # Unused.
+    del jvp, symbolic_zeros  # Unused.
     return self.process_call(core.call_p, fun, tracers, {})
 
   def post_process_custom_jvp_call(self, out_tracers, _):

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -245,7 +245,8 @@ class JetTrace(core.Trace):
       return map(partial(JetTracer, trace), primals, series)
     return out, todo
 
-  def process_custom_jvp_call(self, primitive, fun, jvp, tracers):
+  def process_custom_jvp_call(self, primitive, fun, jvp, tracers, *,
+                              symbolic_zeros):
     # TODO(mattjj): don't just ignore custom jvp rules?
     del primitive, jvp  # Unused.
     return fun.call_wrapped(*tracers)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -62,6 +62,7 @@ from jax._src import array, sharding
 from jax.experimental import pjit
 from jax._src import config as jax_config
 from jax._src import custom_derivatives
+from jax import custom_derivatives as custom_derivatives_public
 from jax._src import device_array
 from jax._src import prng
 from jax._src.lib import xla_bridge
@@ -7273,6 +7274,87 @@ class CustomJVPTest(jtu.JaxTestCase):
     grad     = jax.grad(g    )(0.1)  # doesn't crash
     grad_ref = jax.grad(g_ref)(0.1)
     self.assertAllClose(grad, grad_ref, check_dtypes=False)
+
+  @parameterized.named_parameters(
+      ('jit_vmap', True, True),
+      ('jit', True, False),
+      ('vmap', False, True),
+      ('', False, False),
+  )
+  def test_symbolic_zero_custom_jvp(self, maybe_jit, maybe_vmap):
+    def f(static_scalar, static_array, dyn_scalar, dyn_array):
+      out1 = static_scalar + dyn_scalar
+      out2 = static_array + dyn_array
+      return out1, out2
+
+    def _pack(x):
+      return lax.broadcast(x, (1,))
+
+    def _unpack(x):
+      (x,) = x
+      return x
+
+    def _vmap(fun):
+      def _fun(*args):
+        args = tree_util.tree_map(_pack, args)
+        out = jax.vmap(fun)(*args)
+        out = tree_util.tree_map(_unpack, out)
+        return out
+      return _fun
+
+    f = api.custom_jvp(f)
+
+    @partial(f.defjvp, symbolic_zeros=True)
+    def f_jvp(primals, tangents):
+      static_scalar, *_ = primals
+      t_static, t_static_arr, t_dyn_scalar, t_dyn_array = tangents
+      self.assertIs(type(t_static)    , custom_derivatives_public.SymbolicZero)
+      self.assertIs(type(t_static_arr), custom_derivatives_public.SymbolicZero)
+      self.assertEqual(t_static.shape, ())
+      self.assertEqual(t_static_arr.shape, (2,))
+      return f(*primals), (static_scalar + 90, t_dyn_array + 91)
+
+    def g(dyn_scalar, dyn_array):
+      if maybe_vmap:
+        f_ = _vmap(f)
+      else:
+        f_ = f
+      return f_(1., jnp.array([2., 3.]), dyn_scalar, dyn_array)
+
+    def run(primal_ins, tangent_ins):
+      return jax.jvp(g, primal_ins, tangent_ins)
+
+    if maybe_jit:
+      run = jax.jit(run)
+
+    primal_ins = (4., jnp.array([5., 6.]))
+    tangent_ins = (7., jnp.array([8., 9.]))
+    primal_outs, tangent_outs = run(primal_ins, tangent_ins)
+    primal_out1, primal_out2 = primal_outs
+    tangent_out1, tangent_out2 = tangent_outs
+    scalar_dtype = jax.Array if maybe_jit or maybe_vmap else float
+    self.assertIsInstance(primal_out1, scalar_dtype)
+    self.assertAllClose(primal_out1, 5.)
+    self.assertIsInstance(tangent_out1, scalar_dtype)
+    self.assertAllClose(tangent_out1, 91.)
+    self.assertIsInstance(primal_out2, jax.Array)
+    self.assertArraysAllClose(primal_out2, jnp.array([7., 9.]))
+    self.assertIsInstance(tangent_out2, jax.Array)
+    self.assertArraysAllClose(tangent_out2, jnp.array([99., 100.]))
+
+  def test_symbolic_zero_custom_jvp_vmap_output(self):
+    @api.custom_jvp
+    def f(x, y):
+      return x * y
+
+    @partial(f.defjvp, symbolic_zeros=True)
+    def f_jvp(primals, tangents):
+      x, y = primals
+      x_dot, y_dot = tangents
+      self.assertIs(type(y_dot), custom_derivatives_public.SymbolicZero)
+      return f(x, y), y_dot
+
+    jax.grad(lambda x, y: jax.vmap(f)(x, y).sum())(jnp.ones(3), jnp.ones(3))
 
 
 class CustomVJPTest(jtu.JaxTestCase):


### PR DESCRIPTION
follow-up on #13993

After this, we need to:
* [ ] add the custom_vjp version
* [ ] use it to adapt `closure_convert` and then fix #14561 by updating the odeint custom_vjp (and related issues)
* [ ] clarify (in code and in docs) that nondiff_argnums means non_jaxtype_argnums (or non_array_argnums / non_tracer_argnums)