### PR TITLE
[jax2tf] Enable strict platform checking for native serialized modules.

### DIFF
--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -293,10 +293,13 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     y = np.int32(3)
     self.ConvertAndCompare(jnp.floor_divide, x, y)
     expected = jnp.floor_divide(x, y)
-    # Try it with TF 1 as well (#5831)
-    with tf.compat.v1.Session() as sess:
-      tf1_res = sess.run(jax2tf.convert(jnp.floor_divide)(x, y))
-      self.assertAllClose(expected, tf1_res)
+    if not config.jax2tf_default_experimental_native_lowering:
+      # With native lowering TF1 seems to want to run the converted code
+      # on the CPU even when the default backend is the TPU.
+      # Try it with TF 1 as well (#5831)
+      with tf.compat.v1.Session() as sess:
+        tf1_res = sess.run(jax2tf.convert(jnp.floor_divide)(x, y))
+        self.assertAllClose(expected, tf1_res)
 
   def test_boolean_gather(self):
     values = np.array([[True, True], [False, True], [False, False]],


### PR DESCRIPTION
This takes advantage of recent changes to XlaCallModule that allow us to use a `platforms` attribute to specify what are the allowable platforms for a serialized module.

Also add a `experimental_native_lowering_strict_checks` parameter to `jax2tf.convert` to disable the check.