### PR TITLE
[sparse] coo - assume padded unless otherwise specified

### DIFF
--- a/jax/experimental/sparse/coo.py
+++ b/jax/experimental/sparse/coo.py
@@ -45,7 +45,7 @@ class COOInfo(NamedTuple):
   shape: Shape
   rows_sorted: bool = False
   cols_sorted: bool = False
-  padded: bool = False
+  padded: bool = True  # assume padded unless specified otherwise
 
 
 @tree_util.register_pytree_node_class


### PR DESCRIPTION
This fixes a GPU lowering bug for csr matrices: fixes half the failures from #14531