### PR TITLE
Add `JaxprInputEffect` and refactor `StateEffect`s to use it

### DIFF
--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -55,11 +55,11 @@ except:
 # pytype: enable=import-error
 
 class DebugEffect(effects.Effect):
-  pass
+  __str__ = lambda self: "Debug"
 debug_effect = DebugEffect()
 
 class OrderedDebugEffect(effects.Effect):
-  pass
+  __str__ = lambda self: "OrderedDebug"
 ordered_debug_effect = OrderedDebugEffect()
 
 effects.ordered_effects.add_type(OrderedDebugEffect)

--- a/jax/_src/lax/control_flow/for_loop.py
+++ b/jax/_src/lax/control_flow/for_loop.py
@@ -249,7 +249,8 @@ def _for_abstract_eval(*avals, jaxpr, **__):
   # Find out for each of the `Ref`s in our jaxpr what effects they have.
   jaxpr_aval_effects = state.get_ref_state_effects(
       [v.aval for v in jaxpr.invars], jaxpr.effects)[1:]
-  aval_effects = [set(eff.replace(ref_aval=aval) for eff in effs) for aval, effs
+  aval_effects = [set(eff.replace(input_index=eff.input_index - 1)
+                      for eff in effs) for aval, effs
                   in zip(avals, jaxpr_aval_effects)
                   if isinstance(aval, ShapedArrayRef)]
   nonlocal_state_effects = core.join_effects(*aval_effects)

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1465,9 +1465,6 @@ pe.custom_staging_rules[pjit_p] = pjit_staging_rule
 
 def _pjit_abstract_eval(*args, jaxpr, out_shardings, resource_env,
                         out_positional_semantics, **_):
-  disallowed_effects = mlir.lowerable_effects.filter_not_in(jaxpr.effects)
-  if disallowed_effects:
-    raise ValueError(f'Effects not supported in `pjit`: {disallowed_effects}.')
   if config.jax_array:
     return jaxpr.out_avals, jaxpr.effects
   return global_to_local(out_positional_semantics, jaxpr.out_avals,

--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -160,7 +160,7 @@ def _get_abstract_eval(ref_aval: ShapedArrayRef, *idx, indexed_dims):
     raise ValueError(f"Invalid `idx` and `indexed_dims`: {idx}, {indexed_dims}")
   idx_shapes = tuple(i.shape for i in idx)
   shape = _get_slice_output_shape(ref_aval.shape, idx_shapes, indexed_dims)
-  return (core.ShapedArray(shape, ref_aval.dtype), {ReadEffect(ref_aval)})
+  return (core.ShapedArray(shape, ref_aval.dtype), {ReadEffect(0)})
 get_p.def_effectful_abstract_eval(_get_abstract_eval)
 
 
@@ -187,7 +187,7 @@ def _swap_abstract_eval(ref_aval: ShapedArrayRef, val_aval: core.AbstractValue,
                      f"Ref dtype: {ref_aval.dtype}. "
                      f"Value shape: {val_aval.dtype}. ")
   return (core.ShapedArray(expected_output_shape, ref_aval.dtype),
-          {WriteEffect(ref_aval)})
+          {WriteEffect(0)})
 swap_p.def_effectful_abstract_eval(_swap_abstract_eval)
 
 
@@ -214,7 +214,7 @@ def _addupdate_abstract_eval(ref_aval: ShapedArrayRef,
     raise ValueError("Invalid dtype for `addupdate`. "
                      f"Ref dtype: {ref_aval.dtype}. "
                      f"Value shape: {val_aval.dtype}. ")
-  return [], {AccumEffect(ref_aval)}
+  return [], {AccumEffect(0)}
 addupdate_p.def_effectful_abstract_eval(_addupdate_abstract_eval)
 
 ## Pretty printing for `get` and `swap` in jaxprs

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -98,7 +98,8 @@ class StatePrimitivesTest(jtu.JaxTestCase):
     else:
       jaxpr, out_avals, _ = pe.trace_to_jaxpr_dynamic(
           lu.wrap_init(f), [ref_aval])
-      self.assertSetEqual(jaxpr.effects, {state.ReadEffect(ref_aval)})
+      self.assertSetEqual(jaxpr.effects,
+                          {state.ReadEffect(len(jaxpr.constvars))})
       self.assertLen(out_avals, 1)
       out_aval, = out_avals
       self.assertIsInstance(out_aval, core.ShapedArray)
@@ -164,7 +165,8 @@ class StatePrimitivesTest(jtu.JaxTestCase):
     else:
       jaxpr, out_avals, _ = pe.trace_to_jaxpr_dynamic(
           lu.wrap_init(f), [ref_aval, val_aval])
-      self.assertSetEqual(jaxpr.effects, {state.WriteEffect(ref_aval)})
+      self.assertSetEqual(jaxpr.effects,
+                          {state.WriteEffect(len(jaxpr.constvars))})
       self.assertLen(out_avals, 1)
       out_aval, = out_avals
       self.assertIsInstance(out_aval, core.ShapedArray)
@@ -219,7 +221,8 @@ class StatePrimitivesTest(jtu.JaxTestCase):
     else:
       jaxpr, out_avals, _ = pe.trace_to_jaxpr_dynamic(
           lu.wrap_init(f), [ref_aval, val_aval])
-      self.assertSetEqual(jaxpr.effects, {state.AccumEffect(ref_aval)})
+      self.assertSetEqual(jaxpr.effects,
+                          {state.AccumEffect(len(jaxpr.constvars))})
       self.assertLen(out_avals, 0)
 
   def test_addupdate_abstract_eval_must_take_in_refs(self):
@@ -646,7 +649,7 @@ class StateDischargeTest(jtu.JaxTestCase):
     self.assertIsInstance(discharged_jaxpr.invars[0].aval, state.ShapedArrayRef)
     self.assertIsInstance(discharged_jaxpr.invars[1].aval, core.ShapedArray)
     self.assertEqual(discharged_jaxpr.effects,
-        {state.WriteEffect(discharged_jaxpr.invars[0].aval)})
+        {state.WriteEffect(len(discharged_jaxpr.constvars))})
 
   def test_ellipsis_index(self):
     def f(ref):


### PR DESCRIPTION
This PR adds a new type of effect to the JAX effects system: `JaxprInputEffect` (I'm open to a better name).

A `JaxprInputEffect` is an effect that's tied to the input of a jaxpr (either a constvar or invar). Specifically, it is an effect tied to the *index* of the input in jaxpr's signature. JAX's internals are therefore responsible for keeping track of how these indices are changed via transformations. 

Transformations that operate by reinterpreting a jaxpr should be fine, since the jaxpr builder correctly constructs JaxprInputEffects with the right indices. This works so long as our `abstract_eval` rules are correct.

Transformations that do jaxpr->jaxpr data structure manipulation also need to be updated to do the bookkeeping correctly because deleting an invar or constvar from a jaxpr could result in the `JaxprInputEffect` now pointing to the wrong invar.

The best example of such an effect is the state effect(s), which tie a `Read/Write/Accum` to a specific `Ref`. This PR thus makes bookkeeping the state effect easier and it no longer needs to be handled specially.

Note that the alternative to this approach would be to use heap-parameters/names. The approaches are isomorphic to each other but in some simple HOPs (like jit or closed_call), we don't need to do name/heap-parameter substitution to update the effects, so it ends up being simpler.