### PR TITLE
Add `--pre` to nightly libtpu pip install command.

### DIFF
--- a/.github/workflows/cloud-tpu-ci-nightly.yml
+++ b/.github/workflows/cloud-tpu-ci-nightly.yml
@@ -41,7 +41,7 @@ jobs:
             pip install .
             pip install --pre jaxlib \
               -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-            pip install libtpu-nightly \
+            pip install --pre libtpu-nightly \
               -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
             pip install requests
 


### PR DESCRIPTION
This is necessary to make sure we pick up the nightly "dev" versions hosted on GCP and not the fake package at
https://pypi.org/project/libtpu-nightly/.