### PR TITLE
Use jnp.nanmin and jnp.nanmax in jax.experimental.ode.optimal_step_size

### DIFF
--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -142,8 +142,8 @@ def optimal_step_size(last_step, mean_error_ratio, safety=0.9, ifactor=10.0,
   """Compute optimal Runge-Kutta stepsize."""
   dfactor = jnp.where(mean_error_ratio < 1, 1.0, dfactor)
 
-  factor = jnp.minimum(ifactor,
-                      jnp.maximum(mean_error_ratio**(-1.0 / order) * safety, dfactor))
+  factor = jnp.nanmin(jnp.array([ifactor,
+                                 jnp.nanmax(jnp.array([mean_error_ratio**(-1.0 / order) * safety, dfactor]))]))  
   return jnp.where(mean_error_ratio == 0, last_step * ifactor, last_step * factor)
 
 def odeint(func, y0, t, *args, rtol=1.4e-8, atol=1.4e-8, mxstep=jnp.inf, hmax=jnp.inf):


### PR DESCRIPTION
This simple bug fix prevents jax.experimental.ode.odeint from getting stuck on NaN's if a trial adaptive stepsize led to a NaN for mean_error_ratio.

See the following discussions for more info: 
https://github.com/google/jax/issues/14612
https://github.com/patrick-kidger/diffrax/issues/223