### PR TITLE
Fix __module__ of jax.nn.initializers.* to be jax.nn.initializers.

### DIFF
--- a/jax/nn/initializers.py
+++ b/jax/nn/initializers.py
@@ -41,3 +41,11 @@ from jax._src.nn.initializers import (
   xavier_uniform as xavier_uniform,
   zeros as zeros,
 )
+
+# Set __module__ to the public name.
+def _fixup_modules():
+  for _fn in globals().values():
+    if getattr(_fn, "__module__", None) == "jax._src.nn.initializers":
+      _fn.__module__ = "jax.nn.initializers"
+_fixup_modules()
+del _fixup_modules


### PR DESCRIPTION
Serialization tooling for JAX sometimes prints these names, and we want users to prefer the public names.