### PR TITLE
Export device_put_p as jax.lax.device_put_p.

### DIFF
--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -367,4 +367,5 @@ from jax._src.lax.ann import (
 from jax._src.ad_util import stop_gradient_p as stop_gradient_p
 from jax.lax import linalg as linalg
 
-from jax.experimental.pjit import with_sharding_constraint
+from jax._src.pjit import with_sharding_constraint
+from jax._src.dispatch import device_put_p


### PR DESCRIPTION
lax seems like the most natural place to export the primitive for now.

In passing, get `with_sharding_constraint` via a shorter path.