### PR TITLE
[sparse] remove handling of padded indices from COO/CSR

### DIFF
--- a/jax/experimental/sparse/csr.py
+++ b/jax/experimental/sparse/csr.py
@@ -48,6 +48,10 @@ class CSR(JAXSparse):
   Note: this class has minimal compatibility with JAX transforms such as
   grad and autodiff, and offers very little functionality. In general you
   should prefer :class:`jax.experimental.sparse.BCOO`.
+
+  Additionally, there are known failures in the case that `nse` is larger
+  than the true number of nonzeros in the represented matrix. This situation
+  is better handled in BCOO.
   """
   data: jax.Array
   indices: jax.Array


### PR DESCRIPTION
While trying to fix failures that arose in #14531, it became clear that the `COO` and `CSR` representation is fundamentally flawed in the case that `nse` is set to larger than the true nse. Fixing this would take a lot of effort that would be better spent on the long-term plans with BCOO and BCSR.

Eventually we should deprecate and remove `COO` and `CSR`.