### PR TITLE
add custom gradient for relu6 at boundary positions

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -431,6 +431,7 @@ def one_hot(x: Array, num_classes: int, *,
   return _one_hot(x, num_classes, dtype=dtype, axis=axis)
 
 
+@custom_jvp
 @jax.jit
 def relu6(x: Array) -> Array:
   r"""Rectified Linear Unit 6 activation function.
@@ -444,6 +445,9 @@ def relu6(x: Array) -> Array:
     x : input array
   """
   return jnp.minimum(jnp.maximum(x, 0), 6.)
+
+relu6.defjvps(lambda g, ans, x: lax.select((6 > x) & (x > 0), g, lax.full_like(g, 0)))
+
 
 @jax.jit
 def hard_sigmoid(x: Array) -> Array:


### PR DESCRIPTION
Hi,
the gradient for jax.nn.relu6 at 0 and 6 is equal to 0.5, where it should be equal to 0 in order to be consistent with ReLU and ReLU6 in other frameworks such as pytorch and tensorflow