### PR TITLE
[typing] Use ParamSpec in JIT annotation

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -32,8 +32,8 @@ import dataclasses
 import enum
 from functools import partial
 import inspect
-from typing import (Any, Literal, Optional, TypeVar, overload,
-                    cast, TYPE_CHECKING)
+from typing import (Any, Literal, Optional, TypeVar, overload, cast,
+                    TYPE_CHECKING)
 import weakref
 
 import numpy as np
@@ -175,8 +175,8 @@ class NotSpecified:
     return "<not-specified>"
 
 @overload
-def jit(
-  fun: Callable, /, *,
+def jit[**Parameters, ReturnType](
+  fun: Callable[Parameters, ReturnType], /, *,
   in_shardings: Any = ...,
   out_shardings: Any = ...,
   static_argnums: int | Sequence[int] | None = ...,
@@ -188,11 +188,11 @@ def jit(
   backend: str | None = ...,
   inline: bool | Inline = ...,
   compiler_options: dict[str, Any] | None = ...,
-) -> pjit.JitWrapped:
+) -> pjit.JitWrapped[Parameters, ReturnType]:
   ...
 
 @overload
-def jit(
+def jit[**Parameters, ReturnType](
   *,
   in_shardings: Any = ...,
   out_shardings: Any = ...,
@@ -205,11 +205,12 @@ def jit(
   backend: str | None = ...,
   inline: bool | Inline = ...,
   compiler_options: dict[str, Any] | None = ...,
-) -> Callable[[Callable], pjit.JitWrapped]:
+) -> Callable[[Callable[Parameters, ReturnType]],
+              pjit.JitWrapped[Parameters, ReturnType]]:
   ...
 
-def jit(
-  fun: Callable | NotSpecified = NotSpecified(), /, *,
+def jit[**Parameters, ReturnType](
+  fun: Callable[Parameters, ReturnType] | NotSpecified = NotSpecified(), /, *,
   in_shardings: Any = sharding_impls.UNSPECIFIED,
   out_shardings: Any = sharding_impls.UNSPECIFIED,
   static_argnums: int | Sequence[int] | None = None,
@@ -221,7 +222,9 @@ def jit(
   backend: str | None = None,
   inline: bool | Inline = False,
   compiler_options: dict[str, Any] | None = None,
-) -> pjit.JitWrapped | Callable[[Callable], pjit.JitWrapped]:
+) -> (pjit.JitWrapped[Parameters, ReturnType]
+      | Callable[[Callable[Parameters, ReturnType]],
+                 pjit.JitWrapped[Parameters, ReturnType]]):
   """Sets up ``fun`` for just-in-time compilation with XLA.
 
   Args:

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass, replace
 from functools import partial
 import inspect
 import weakref
-from typing import NamedTuple, Any, Union
+from typing import NamedTuple, Any, Self, Union, overload
 import warnings
 
 import numpy as np
@@ -676,7 +676,8 @@ def _infer_input_type(fun: Callable, dbg_fn: Callable[[], core.DebugInfo],
   return tuple(avals)
 
 
-class JitWrapped(stages.Wrapped):
+class JitWrapped[**Parameters, ReturnType](
+    stages.Wrapped[Parameters, ReturnType]):
 
   def eval_shape(self, *args, **kwargs):
     """See ``jax.eval_shape``."""
@@ -685,12 +686,27 @@ class JitWrapped(stages.Wrapped):
   def trace(self, *args, **kwargs) -> stages.Traced:
     raise NotImplementedError
 
+  # The underlying C++ implementation is a descriptor (like a plain
+  # function), so accessing a jitted method through an instance binds it,
+  # dropping the leading `self` parameter. There's no way to express that
+  # precisely for an arbitrary ParamSpec, so the bound case falls back to
+  # `Callable[..., ReturnType]`, matching how `types.FunctionType.__get__`
+  # is typed in typeshed.
+  @overload
+  def __get__(self, instance: None, owner: type | None = None, /) -> Self: ...
+  @overload
+  def __get__(
+      self, instance: object, owner: type | None = None, /
+  ) -> Callable[..., ReturnType]: ...
+  def __get__(self, instance, owner=None):
+    raise NotImplementedError
+
 
 # in_shardings and out_shardings can't be None as the default value
 # because `None` means that the input is fully replicated.
 @partial(api_boundary, repro_api_name="pjit.pjit")
-def pjit(
-    fun: Callable,
+def pjit[**Parameters, ReturnType](
+    fun: Callable[Parameters, ReturnType],
     in_shardings: Any = UNSPECIFIED,
     out_shardings: Any = UNSPECIFIED,
     static_argnums: int | Sequence[int] | None = None,
@@ -702,7 +718,7 @@ def pjit(
     backend: str | None = None,
     inline: bool = False,
     compiler_options: dict[str, Any] | None = None,
-) -> JitWrapped:
+) -> JitWrapped[Parameters, ReturnType]:
   """`jax.experimental.pjit.pjit` has been deprecated. Please use `jax.jit`."""
   return make_jit(
       fun, in_shardings=in_shardings, out_shardings=out_shardings,

--- a/jax/_src/stages.py
+++ b/jax/_src/stages.py
@@ -889,7 +889,7 @@ def raise_lo_outs(hi_avals, lo_outs):
   return hi_outs
 
 @runtime_checkable
-class Wrapped(Protocol):
+class Wrapped[**Parameters, ReturnType](Protocol):
   """A function ready to be traced, lowered, and compiled.
 
   This protocol reflects the output of functions such as
@@ -898,7 +898,8 @@ class Wrapped(Protocol):
   to compilation, and the result compiled prior to execution.
   """
 
-  def __call__(self, *args, **kwargs):
+  def __call__(self, *args: Parameters.args, **kwargs: Parameters.kwargs
+               ) -> ReturnType:
     """Executes the wrapped function, lowering and compiling as needed."""
     raise NotImplementedError
 


### PR DESCRIPTION
This pull request would be a huge improvement for Jax users who use type checkers like MyPy or Pyright, which now support `ParamSpec`. 

Consider:
```python
from jax import Array, jit

@jit
def f(x: Array, y: Array) -> Array:
    pass

reveal_type(f.__call__)
```
Previous to this PR, users who decorate a function with `jit` lose all annotations of the method:
```
Pyright: Type of "f.__call__" is "(*args: Unknown, **kwargs: Unknown) -> Unknown"
MyPy: Revealed type is "def (*args: Any, **kwargs: Any) -> Any"
```
After this PR, we get:
```
Pyright: Type of "f.__call__" is "(x: Array, y: Array) -> Array"
MyPy: Revealed type is "def (x: Array, y: Array) -> Array"
```
This unblocks a lot of type checking.

Part of https://github.com/google/jax/issues/12049 cc: @jakevdp 