### PR TITLE
Enable arrow keys and command history for CLI debugger

### DIFF
--- a/jax/_src/debugger/cli_debugger.py
+++ b/jax/_src/debugger/cli_debugger.py
@@ -27,12 +27,12 @@ DebuggerFrame = debugger_core.DebuggerFrame
 class CliDebugger(cmd.Cmd):
   """A text-based debugger."""
   prompt = '(jdb) '
-  use_rawinput: bool = False
 
   def __init__(self, frames: List[DebuggerFrame], thread_id,
       stdin: Optional[IO[str]] = None, stdout: Optional[IO[str]] = None,
       completekey: str = "tab"):
     super().__init__(stdin=stdin, stdout=stdout, completekey=completekey)
+    self.use_rawinput = stdin is None
     self.frames = frames
     self.frame_index = 0
     self.thread_id = thread_id


### PR DESCRIPTION
This PR enables the use of arrow keys in a command line jdb prompt.  I found this change drastically improves my debugging experience.
 
The PR does so by simply setting `use_rawinput=True` if the optional `stdin` is the default. 

To elaborate on how this works: 
According to Python's [`cmd.py` source code](https://github.com/python/cpython/blob/3.11/Lib/cmd.py#L106), if `use_rawinput=True`, the `Cmd` class will try to use the `readline` module. This module enables moving the cursor and browsing command history using the arrow keys. 

#### Caveat
I do not know why `use_rawinput` is set to False in the current HEAD. 
But, I think this change should not break any existing applications---if an existing code uses a custom `stdin`, we fallback to the current behavior.

The only possible breakdown is when someone really wants to use arrow keys as shortcuts to enter specific specific strings like "^B" (perhaps as part of a string). This change makes it that they must enter the string manually instead. 
That said, I think the benefit of this PR outweighs this corner use case. And I would prefer the change.