### PR TITLE
[shape_poly] Add support for jnp.cum{sum,prod,max,min} with shape polymorphism

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1825,6 +1825,11 @@ def associative_scan(fn: Callable, elems, reverse: bool = False, axis: int = 0):
 
   # Check that all inputs have a consistent leading dimension `num_elems`.
   axis = util.canonicalize_axis(axis, elems_flat[0].ndim)
+
+  if core.is_special_dim_size(elems_flat[0].shape[axis]):
+    raise NotImplementedError("associative scan over axis "
+        f"of non-constant size: {elems_flat[0].shape[axis]}. You may be "
+        "able to avoid this on TPU.")
   num_elems = int(elems_flat[0].shape[axis])
   if not all(int(elem.shape[axis]) == num_elems for elem in elems_flat[1:]):
     raise ValueError('Array inputs to associative_scan must have the same '

--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -467,6 +467,9 @@ def _reduce_window_lower(
   operand_aval, = ctx.avals_in
   scalar_aval = operand_aval.update(shape=())
   scalar_type = mlir.aval_to_ir_type(scalar_aval)
+  if any(not core.is_constant_shape(s)
+         for s in [window_dimensions, window_dilation, window_strides, base_dilation, *padding]):
+    raise NotImplementedError("ReduceWindowOp for dynamic shapes")
   rw = hlo.ReduceWindowOp(
       mlir.aval_to_ir_types(aval_out), [operand],
       [mlir.full_like_aval(ctx, init_value(scalar_aval.dtype), scalar_aval)],

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -2281,15 +2281,20 @@ def _common_reduce_window(operand, init_val, reducer, window_dimensions,
 
   if not isinstance(init_val, (tf.Tensor, tf.Variable)):
     init_val = tf.constant(init_val, operand.dtype)
+  window_dimensions_tf = _eval_shape(window_dimensions)
+  window_strides_tf = _eval_shape(window_strides)
+  window_dilation_tf = _eval_shape(window_dilation)
+  base_dilation_tf = _eval_shape(base_dilation)
+  padding_tf = [_eval_shape(p) for p in padding]
   out = tfxla.reduce_window(
       operand,
       init_val,
       reducer_fn,
-      window_dimensions,
-      window_strides,
-      base_dilations=base_dilation,
-      window_dilations=window_dilation,
-      padding=padding)
+      window_dimensions_tf,
+      window_strides_tf,
+      base_dilations=base_dilation_tf,
+      window_dilations=window_dilation_tf,
+      padding=padding_tf)
   # TODO: implement shape inference for XlaReduceWindow
   out = _ensure_tf_shape_if_dynamic(out, _aval_to_tf_shape(_out_aval))
   if _WRAP_JAX_JIT_WITH_TF_FUNCTION:


### PR DESCRIPTION
Unfortunately, on CPU and GPU where we use associative scan, we cannot support shape polymorphism with native lowering, when the axis over which we reduce is non-constant size. Improve the error in that case.