### PR TITLE
[custom_vjp] bwd function should not be WrappedFun, may run multiple times

### DIFF
--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -748,7 +748,7 @@ custom_lin_p.def_impl(raise_custom_vjp_error_on_jvp)
 def _custom_lin_transpose(cts_out, *invals, num_res, bwd, out_avals):
   res, _ = split_list(invals, [num_res])
   cts_out = map(instantiate_zeros_aval, out_avals, cts_out)
-  cts_in = bwd.call_wrapped(*res, *cts_out)
+  cts_in = bwd(*res, *cts_out)
   return [None] * num_res + list(cts_in)
 primitive_transposes[custom_lin_p] = _custom_lin_transpose
 

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -308,6 +308,9 @@ class _HashableCallableShim:
       return self.fun == other.fun
     return self.fun == other
 
+  def __repr__(self):
+    return f'_HashableCallableShim({repr(self.fun)})'
+
 
 class Partial(functools.partial):
   """A version of functools.partial that works in pytrees.

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -8385,6 +8385,18 @@ class CustomVJPTest(jtu.JaxTestCase):
 
     jax.grad(f)(A([1.]))  # doesn't crash
 
+  def test_vmap_vjp_called_twice(self):
+    # https://github.com/google/jax/pull/14728
+    @jax.custom_vjp
+    def f(x):
+      return x
+    f.defvjp(lambda x: (x, None), lambda _, y_bar: (y_bar,))
+
+    _, f_vjp = jax.vjp(jax.vmap(f), jnp.array([3.]))
+    f_vjp(jnp.array([3.]))
+    f_vjp(jnp.array([3.]))  # doesn't crash
+
+
 def transpose_unary(f, x_example):
   def transposed(y):
     x, = api.linear_transpose(f, x_example)(y)


### PR DESCRIPTION
The `custom_jvp_p` primitive is kind of like the `xla_call_p` primitive underlying final-style (old) `jit`. With `xla_call_p`, we have one Python callable (wrapped in an `lu.WrappedFun`) which is called exactly once. With `custom_jvp_p` we have two functions (each wrapped in an `lu.WrappedFun`), representing either the un-differentiated primal function or its JVP rule, and exactly one is called exactly once (determined not at runtime but rather by whether an AD pass hits at tracing time).

The called-exactly-once property is useful for reasoning about values plumbed through mutable cells. Indeed one of the main reasons `lu.WrappedFun` exists is to handle populating `Store`s for such plumbing.

While for `xla_call_p` and `custom_jvp_p` we have one and two functions, respectively, wrapped as `lu.WrappedFun`s corresponding to how they're called exactly once, the `custom_vjp_p` primitive is parameterized by _three_ callables. The three callables represent the primal function, the forward pass under autodiff, and the backward pass under autodiff. And each is wrapped as an `lu.WrappedFun`.

At least, they were until this PR. But that was a bug: after differentiation, the backward pass rule need not be called exactly once. Unlike the primal and forward pass functions, that's just not a property it has. So it never should have been an `lu.WrappedFun`! Tellingly, we never _needed_ it to be a `WrappedFun` either, in that we never used any `Store`s with it.

Even though the backward-pass rule could be run more than once, for some reason we never noticed until now. Perhaps that's because we only indirectly check whether `WrappedFun`s are run more than once, by checking whether any `Store`s are populated more than once. But `Store`s only became associated with the backward pass rule when `vmap` got involved. So I guess we just hadn't hit this combination until now!

The fix is simple: just don't make the backward pass rule a `WrappedFun`. Adapt callees not to expect it.