### PR TITLE
DOC: fix readthedocs for sphinx-book-theme=1.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,7 +149,6 @@ html_theme = 'sphinx_book_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    'logo_only': True,
     'show_toc_level': 2,
     'repository_url': 'https://github.com/google/jax',
     'use_repository_button': True,     # add a "link to repository" button


### PR DESCRIPTION
The new version was released a few hours ago: https://pypi.org/project/sphinx-book-theme/#history

I'll address this TODO in a followup, because it's a bit more involved: https://github.com/google/jax/blob/1ee750e79509942ed06b8f05bbd9eda3c821348e/docs/requirements.txt#L4-L5