### PR TITLE
DOC: update sphinx & sphinx-autodoc-typehints

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -19,8 +19,3 @@
 .developer-docs {
   background-color: rgba(171, 0, 182, var(--block-bg-opacity));
 }
-
-.key-ideas
-{
-  border: 0px
-}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,21 +10,21 @@ JAX is Autograd_ and XLA_, brought together for high-performance numerical compu
 
    .. grid-item-card:: Familiar API
       :columns: 12 6 6 4
-      :class-card: key-ideas
+      :class-card: sd-border-0
       :shadow: None
 
       JAX provides a familiar NumPy-style API for ease of adoption by researchers and engineers. 
 
    .. grid-item-card:: Transformations
       :columns: 12 6 6 4
-      :class-card: key-ideas
+      :class-card: sd-border-0
       :shadow: None
 
       JAX includes composable function transformations for compilation, batching, automatic differentiation, and parallelization.
 
    .. grid-item-card:: Run Anywhere
       :columns: 12 6 6 4
-      :class-card: key-ideas
+      :class-card: sd-border-0
       :shadow: None
 
       The same code executes on multiple backends, including CPU, GPU, & TPU

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,9 @@
 absl-py
 ipython>=8.8.0  # 8.7.0 has ipython3 lexer error
-sphinx>=4
-# TODO(jakevdp) unpin sphinx-autodoc-typehints when sphinx-book-theme
-# 0.4.0 is released and no longer requires sphinx<5
-sphinx-autodoc-typehints~=1.18.0
-sphinx-book-theme>=0.3.3 
+# TODO(jakevdp) Update to sphinx>=6 when myst-nb supports it.
+sphinx>=5
+sphinx-autodoc-typehints
+sphinx-book-theme>=1.0.0
 sphinx-copybutton>=0.5.0
 sphinx-remove-toctrees
 jupyter-sphinx>=0.3.2


### PR DESCRIPTION
Fixes old TODO now that sphinx-book-theme 1.0 has been released. Followup to #14736

Also fix some border CSS issues that the theme update introduced on the front page.

Preview here: https://jax--14738.org.readthedocs.build/en/14738/ Note the lack of border around the three columns at the top of the screen.