### PR TITLE
Fix Typo in `scipy.stats.vonmise`

### DIFF
--- a/jax/_src/scipy/stats/vonmises.py
+++ b/jax/_src/scipy/stats/vonmises.py
@@ -22,7 +22,7 @@ from jax._src.typing import Array, ArrayLike
 
 @_wraps(osp_stats.vonmises.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, kappa: ArrayLike) -> Array:
-  x, kappa = _promote_args_inexact('vonmises.pdf', x, kappa)
+  x, kappa = _promote_args_inexact('vonmises.logpdf', x, kappa)
   zero = _lax_const(kappa, 0)
   return jnp.where(lax.gt(kappa, zero), kappa * (jnp.cos(x) - 1) - jnp.log(2 * jnp.pi * lax.bessel_i0e(kappa)), jnp.nan)
 


### PR DESCRIPTION
In line 25, `vonmises.pdf` should be `vonmises.logpdf`