### PR TITLE
Add repr for UnspecifiedValue

### DIFF
--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -499,7 +499,8 @@ def is_auto(x):
 
 
 class UnspecifiedValue:
-  pass
+  def __repr__(self):
+    return "UnspecifiedValue"
 _UNSPECIFIED = UnspecifiedValue()
 
 def _is_unspecified(x):


### PR DESCRIPTION
This helps make low-level errors with jaxpr dumps more readible. Before:
```
ValueError: Cannot lower jaxpr with verifier errors: #loc = loc(unknown)
...
#loc5 = loc("jit(wrapped_fun)/jit(main)/pjit[in_shardings=(<jax._src.interpreters.pxla.UnspecifiedValue object at 
0x7f211d4a7610>, <jax._src.interpreters.pxla.UnspecifiedValue object at 0x7f211d4a7610>, 
<jax._src.interpreters.pxla.UnspecifiedValue object at 0x7f211d4a7610>) out_shardings=
(<jax._src.interpreters.pxla.UnspecifiedValue object at 0x7f211d4a7610>,) resource_env=None donated_invars=(False, 
False, False) name=_where in_positional_semantics=(<_PositionalSemantics.GLOBAL: 1>, 
<_PositionalSemantics.GLOBAL: 1>, <_PositionalSemantics.GLOBAL: 1>) 
out_positional_semantics=_PositionalSemantics.GLOBAL keep_unused=False inline=False]"(#loc1))
```
After:
```
ValueError: Cannot lower jaxpr with verifier errors: #loc = loc(unknown)
...
#loc5 = loc("jit(wrapped_fun)/jit(main)/pjit[in_shardings=(UnspecifiedValue, UnspecifiedValue, UnspecifiedValue) 
out_shardings=(UnspecifiedValue,) resource_env=None donated_invars=(False, False, False) name=_where 
in_positional_semantics=(<_PositionalSemantics.GLOBAL: 1>, <_PositionalSemantics.GLOBAL: 1>, 
<_PositionalSemantics.GLOBAL: 1>) out_positional_semantics=_PositionalSemantics.GLOBAL keep_unused=False 
inline=False]"(#loc1))
```