### PR TITLE
Add "compare_all" method to searchsorted

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2269,7 +2269,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     vshape=[(), (5,), (5, 5)],
     side=['left', 'right'],
     dtype=number_dtypes,
-    method=['sort', 'scan'],
+    method=['sort', 'scan', 'compare_all'],
   )
   def testSearchsorted(self, ashape, vshape, side, dtype, method):
     rng = jtu.rand_default(self.rng())
@@ -2302,7 +2302,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @jtu.sample_product(
     dtype=inexact_dtypes,
     side=['left', 'right'],
-    method=['sort', 'scan'],
+    method=['sort', 'scan', 'compare_all'],
   )
   def testSearchsortedNans(self, dtype, side, method):
     if np.issubdtype(dtype, np.complexfloating):


### PR DESCRIPTION
This method can be considerably faster than "scan" and "sort" (at least on TPUs) in cases where the array being searched is very small. In particular, this allowed us to remove a bottleneck in one of our training jobs that was doing a very large number of searches where the sorted array was only of size 24.