### PR TITLE
update relu6 grad at 0 and 6 to match pytorch convention

### DIFF
--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -68,6 +68,13 @@ class NNFunctionsTest(jtu.JaxTestCase):
     jaxpr = jax.make_jaxpr(jax.grad(nn.relu))(0.)
     self.assertGreaterEqual(len(jaxpr.jaxpr.eqns), 2)
 
+  def testRelu6Grad(self):
+    rtol = 1e-2 if jtu.device_under_test() == "tpu" else None
+    check_grads(nn.relu6, (1.,), order=3, rtol=rtol)
+    check_grads(nn.relu6, (-1.,), order=3, rtol=rtol)
+    self.assertAllClose(jax.grad(nn.relu6)(0.), 0., check_dtypes=False)
+    self.assertAllClose(jax.grad(nn.relu6)(6.), 0., check_dtypes=False)
+
   def testSoftplusValue(self):
     val = nn.softplus(89.)
     self.assertAllClose(val, 89., check_dtypes=False)


### PR DESCRIPTION
We want the same convention at `0.0` as we have for `jax.nn.relu`, and for the convention at `6.0` it makes sense to just use whatever the standard is. I hope PyTorch reflects the standard!

![image](https://user-images.githubusercontent.com/1458824/223595993-284e63c1-1ec3-408b-9506-71e0f95a5fc7.png)
