### PR TITLE
Fix implicit rank promotion.

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1042,7 +1042,7 @@ def _lu_unblocked(a):
     a = a.at[:, k].set(jnp.where(m_idx > k, a[:, k] / x, a[:, k]))
 
     # a[k+1:, k+1:] -= jnp.outer(a[k+1:, k], a[k, k+1:])
-    a = a - jnp.where((m_idx[:, None] > k) & (n_idx > k),
+    a = a - jnp.where((m_idx[:, None] > k) & (n_idx[None, :] > k),
                      jnp.outer(a[:, k], a[k, :]), jnp.array(0, dtype=a.dtype))
     return pivot, perm, a
 


### PR DESCRIPTION
Fixes an implicit rank promotion in default LU decomposition implementation.

Related to #7208