### PR TITLE
[sparse] add support for integer_pow

### DIFF
--- a/tests/sparsify_test.py
+++ b/tests/sparsify_test.py
@@ -262,6 +262,19 @@ class SparsifyTest(jtu.JaxTestCase):
 
     self.assertAllClose(out.todense(), x.todense() - y.todense())
 
+  def testSparsePow(self):
+    x = jnp.arange(20.0).reshape(4, 5)
+    xsp = BCOO.fromdense(x)
+
+    result_dense = x ** 2
+    result_sparse = xsp ** 2
+
+    self.assertAllClose(result_dense, result_sparse.todense())
+
+    with self.assertRaisesRegex(NotImplementedError,
+                                "sparse rule for integer_pow with non-positive exponent"):
+      _ = xsp ** -1
+
   def testSparseSum(self):
     x = jnp.arange(20).reshape(4, 5)
     xsp = BCOO.fromdense(x)
@@ -573,7 +586,8 @@ class SparsifyTest(jtu.JaxTestCase):
         (lax.sqrt, jnp.float32, {}),
         (lax.tan, jnp.float32, {}),
         (lax.tanh, jnp.float32, {}),
-        (lax.convert_element_type, jnp.float32, {"new_dtype": np.dtype('complex64')})])
+        (lax.convert_element_type, jnp.float32, {"new_dtype": np.dtype('complex64')}),
+        (lax.integer_pow, jnp.float32, {'y': 2})])
   def testUnaryOperationsNonUniqueIndices(self, fmt, op, dtype, kwds):
     shape = (4, 5)
 


### PR DESCRIPTION
Addresses #14845

With this change, positive integer powers of sparse matrices will work correctly:
```python
In [1]: import jax.numpy as jnp

In [2]: from jax.experimental import sparse

In [3]: x = sparse.BCOO.fromdense(jnp.arange(4.0))

In [4]: x ** 2
Out[4]: BCOO(float32[4], nse=3)

In [5]: (x ** 2).todense()
Out[5]: Array([0., 1., 4., 9.], dtype=float32)
```