### PR TITLE
add api_boundary decorator to jax.eval_shape

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -3281,6 +3281,7 @@ core.pytype_aval_mappings[ShapeDtypeStruct] = (
     lambda x: ShapedArray(x.shape, dtypes.canonicalize_dtype(x.dtype),
                           weak_type=False, named_shape=x.named_shape))
 
+@api_boundary
 def eval_shape(fun: Callable, *args, **kwargs):
   """Compute the shape/dtype of ``fun`` without any FLOPs.
 


### PR DESCRIPTION
```python
import jax

x = jax.ShapeDtypeStruct((1.0,), jax.numpy.dtype('int32'))
jax.eval_shape(lambda x: x, x)
```

Before:
```
Traceback (most recent call last):
  File "/usr/local/google/home/mattjj/packages/jax/qiao34.py", line 4, in <module>
    jax.eval_shape(lambda x: x, x)
  File "/usr/local/google/home/mattjj/packages/jax/jax/_src/traceback_util.py", line 164, in reraise_with_filtered_traceback
    return fun(*args, **kwargs)
  File "/usr/local/google/home/mattjj/packages/jax/jax/_src/api.py", line 3349, in eval_shape
    *map(shaped_abstractify, args_flat),
  File "/usr/local/google/home/mattjj/packages/jax/jax/_src/util.py", line 79, in safe_map
    return list(map(f, *args))
  File "/usr/local/google/home/mattjj/packages/jax/jax/_src/api_util.py", line 561, in shaped_abstractify
    return _shaped_abstractify_slow(x)
  File "/usr/local/google/home/mattjj/packages/jax/jax/_src/api_util.py", line 553, in _shaped_abstractify_slow
    return core.ShapedArray(np.shape(x), dtype, weak_type=weak_type,
  File "/usr/local/google/home/mattjj/packages/jax/jax/_src/core.py", line 1483, in __init__
    self.shape = canonicalize_shape(shape)
  File "/usr/local/google/home/mattjj/packages/jax/jax/_src/core.py", line 2024, in canonicalize_shape
    raise _invalid_shape_error(shape, context)
jax._src.traceback_util.UnfilteredStackTrace: TypeError: Shapes must be 1D sequences of concrete values of integer type, got (1.0,).
```

After:
```
Traceback (most recent call last):
  File "/usr/local/google/home/mattjj/packages/jax/qiao34.py", line 4, in <module>
    jax.eval_shape(lambda x: x, x)
TypeError: Shapes must be 1D sequences of concrete values of integer type, got (1.0,).
```

(Both are with `JAX_TRACEBACK_FILTERING=auto`, the default setting.)