### PR TITLE
Add `rayleigh` distribution to `random.py`

### DIFF
--- a/docs/jax.random.rst
+++ b/docs/jax.random.rst
@@ -43,6 +43,7 @@ List of Available Functions
     poisson
     rademacher
     randint
+    rayleigh
     shuffle
     split
     t

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -1828,3 +1828,47 @@ def ball(
   g = generalized_normal(k1, p, (*shape, d), dtype)
   e = exponential(k2, shape, dtype)
   return g / (((jnp.abs(g) ** p).sum(-1) + e) ** (1 / p))[..., None]
+
+
+def rayleigh(key: KeyArray,
+             scale: RealArray,
+             shape: Optional[Shape] = None,
+             dtype: DTypeLikeFloat = dtypes.float_) -> Array:
+  """Sample Rayleigh random values with given shape and float dtype.
+
+  Args:
+    key: a PRNG key used as the random key.
+    scale: a float or array of floats broadcast-compatible with ``shape``
+      representing the parameter of the distribution.
+    shape: optional, a tuple of nonnegative integers specifying the result
+      shape. Must be broadcast-compatible with ``scale``. The default (None)
+      produces a result shape equal to ``scale.shape``.
+    dtype: optional, a float dtype for the returned values (default float64 if
+      jax_enable_x64 is true, otherwise float32).
+
+  Returns:
+    A random array with the specified dtype and with shape given by ``shape`` if
+    ``shape`` is not None, or else by ``scale.shape``.
+  """
+  key, _ = _check_prng_key(key)
+  if not dtypes.issubdtype(dtype, np.floating):
+    raise ValueError("dtype argument to `rayleigh` must be a float "
+                     f"dtype, got {dtype}")
+  dtype = dtypes.canonicalize_dtype(dtype)
+  if shape is not None:
+    shape = core.canonicalize_shape(shape)
+  return _rayleigh(key, scale, shape, dtype)
+
+@partial(jit, static_argnums=(2, 3), inline=True)
+def _rayleigh(key, scale, shape, dtype) -> Array:
+  if shape is None:
+    shape = np.shape(scale)
+  else:
+    _check_shape("rayleigh", shape, np.shape(scale))
+  u = uniform(key, shape, dtype)
+  scale = scale.astype(dtype)
+  log_u = lax.log(u)
+  n_two = _lax_const(scale, -2)
+  sqrt_u = lax.sqrt(lax.mul(log_u, n_two))
+  ray = lax.mul(scale, sqrt_u)
+  return ray

--- a/jax/random.py
+++ b/jax/random.py
@@ -178,6 +178,7 @@ from jax._src.random import (
   rademacher as rademacher,
   randint as randint,
   random_gamma_p as random_gamma_p,
+  rayleigh as rayleigh,
   rbg_key as rbg_key,
   shuffle as shuffle,
   split as split,

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1519,6 +1519,20 @@ class LaxRandomTest(jtu.JaxTestCase):
     for samples in [uncompiled_samples, compiled_samples]:
       self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.f(dfnum, dfden).cdf)
 
+  @jtu.sample_product(
+      scale= [0.2, 1., 2., 10. ,100.],
+      dtype=jtu.dtypes.floating)
+  def testRayleigh(self, scale, dtype):
+    key = self.seed_prng(0)
+    rand = lambda key: random.rayleigh(key, scale, shape = (10000, ), dtype = dtype)
+    crand = jax.jit(rand)
+
+    uncompiled_samples = rand(key)
+    compiled_samples = crand(key)
+
+    for samples in [uncompiled_samples, compiled_samples]:
+      self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.rayleigh(scale=scale).cdf)
+
 class KeyArrayTest(jtu.JaxTestCase):
   # Key arrays involve:
   # * a Python key array type, backed by an underlying uint32 "base" array,


### PR DESCRIPTION
Add a counterpart  of `numpy.random.rayleigh` for JAX