### PR TITLE
jnp.arange: better validation of inputs

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -631,7 +631,10 @@ def dtype(x: Any, *, canonicalize: bool = False) -> DType:
   elif core.is_opaque_dtype(getattr(x, 'dtype', None)):
     dt = x.dtype
   else:
-    dt = np.result_type(x)
+    try:
+      dt = np.result_type(x)
+    except TypeError as err:
+      raise TypeError(f"Cannot determine dtype of {x}") from err
   if dt not in _jax_dtype_set:
     raise TypeError(f"Value '{x}' with dtype {dt} is not a valid JAX array "
                     "type. Only arrays of numeric types are supported by JAX.")

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -343,6 +343,15 @@ def check_arraylike(fun_name: str, *args: Any):
     raise TypeError(msg.format(fun_name, type(arg), pos))
 
 
+def check_arraylike_or_none(fun_name: str, *args: Any):
+  assert isinstance(fun_name, str), f"fun_name must be a string. Got {fun_name}"
+  if any(not (_arraylike(arg) or arg is None) for arg in args):
+    pos, arg = next((i, arg) for i, arg in enumerate(args)
+                    if not (_arraylike(arg) or arg is None))
+    msg = "{} requires ndarray, scalar, or None arguments, got {} at position {}."
+    raise TypeError(msg.format(fun_name, type(arg), pos))
+
+
 def _check_no_float0s(fun_name: str, *args: Any):
   """Check if none of the args have dtype float0."""
   if any(dtypes.dtype(arg) == dtypes.float0 for arg in args):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -4953,7 +4953,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertEqual(jnp.asarray(v).tolist(), v.tolist())
 
   def testArangeConcretizationError(self):
-    msg = r"It arose in jax.numpy.arange argument `{}`".format
+    msg = r"It arose in the jnp.arange argument '{}'".format
     with self.assertRaisesRegex(core.ConcretizationTypeError, msg('stop')):
       jax.jit(jnp.arange)(3)
 


### PR DESCRIPTION
Fixes #14920

New error for the case mentioned there:
```python
In [1]: import jax.numpy as jnp

In [2]: jnp.arange([1, 2])
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 jnp.arange([1, 2])

File ~/github/google/jax/jax/_src/numpy/lax_numpy.py:2274, in arange(start, stop, step, dtype)
   2270 @util._wraps(np.arange)
   2271 def arange(start: DimSize, stop: Optional[DimSize] = None,
   2272            step: Optional[DimSize] = None, dtype: Optional[DTypeLike] = None) -> Array:
   2273   dtypes.check_user_dtype_supported(dtype, "arange")
-> 2274   util._check_arraylike_or_none("arange", start, stop, step)
   2275   msg = "It arose in jax.numpy.arange argument `{}`."
   2276   start_name = "stop" if stop is None and step is None else "start"

File ~/github/google/jax/jax/_src/numpy/util.py:352, in _check_arraylike_or_none(fun_name, *args)
    349 pos, arg = next((i, arg) for i, arg in enumerate(args)
    350                 if not (_arraylike(arg) or arg is None))
    351 msg = "{} requires ndarray or scalar arguments, got {} at position {}."
--> 352 raise TypeError(msg.format(fun_name, type(arg), pos))

TypeError: arange requires ndarray or scalar arguments, got <class 'list'> at position 0.
```