### PR TITLE
[jax2tf] Refactor and simplify the native lowering

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -3,7 +3,7 @@
 <!-- Next line must match the copybara config. -->
 <!-- Link to internal documentation. -->
 
-This package provides experimental support for interoperation between JAX and TensorFlow.
+This package provides support for interoperation between JAX and TensorFlow.
 There are two interoperation directions:
 
 - `jax2tf.convert`: for using JAX functions in a TensorFlow context, e.g.,

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -1490,7 +1490,7 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
         stack.enter_context(mesh)
       # Run the JAX native version, to check it works, and to fill caches.
       _ = func_to_convert(*args)
-      exported = jax2tf.jax2tf.export_native(
+      exported = jax2tf.jax2tf.serialize_native(
           func_to_convert,
           [core.ShapedArray(a.shape, a.dtype) for a in args],
           lowering_platform='tpu',


### PR DESCRIPTION
Bring the native lowering code further up in the call stack, which simplifies some internals and is the first step towards separating out the native lowering code.