### PR TITLE
Correct multidimensional Rosenbrock function

### DIFF
--- a/tests/scipy_optimize_test.py
+++ b/tests/scipy_optimize_test.py
@@ -28,7 +28,7 @@ config.parse_flags_with_absl()
 
 def rosenbrock(np):
   def func(x):
-    return np.sum(100. * np.diff(x) ** 2 + (1. - x[:-1]) ** 2)
+    return np.sum(100. * (x[1:] - x[:-1]**2) ** 2 + (1. - x[:-1]) ** 2)
 
   return func
 


### PR DESCRIPTION
Using `np.diff` will give a function with the same minimum as the Rosenbrock function but which may be easier to optimise. In particular, the Rosenbrock function should have the term $(x_{i + 1} - x_i^2)^2$ but using `np.diff` will give $(x_{i + 1} - x_i)^2$. Both have minima at $x = \mathbf{1}$.