### PR TITLE
Remove leading underscores in jax._src.numpy.util

### DIFF
--- a/jax/_src/image/scale.py
+++ b/jax/_src/image/scale.py
@@ -23,7 +23,7 @@ from jax import lax
 from jax import numpy as jnp
 from jax._src import core
 from jax._src.util import canonicalize_axis
-from jax._src.numpy.util import _promote_dtypes_inexact
+from jax._src.numpy.util import promote_dtypes_inexact
 
 
 def _fill_lanczos_kernel(radius, x):
@@ -243,8 +243,8 @@ def scale_and_translate(image, shape: core.Shape,
   assert isinstance(method, ResizeMethod)
 
   kernel = _kernels[method]
-  image, = _promote_dtypes_inexact(image)
-  scale, translation = _promote_dtypes_inexact(scale, translation)
+  image, = promote_dtypes_inexact(image)
+  scale, translation = promote_dtypes_inexact(scale, translation)
   return _scale_and_translate(image, shape, spatial_dims, scale, translation,
                               kernel, antialias, precision)
 
@@ -281,7 +281,7 @@ def _resize(image, shape: core.Shape, method: Union[str, ResizeMethod],
   assert isinstance(method, ResizeMethod)
   kernel = _kernels[method]
 
-  image, = _promote_dtypes_inexact(image)
+  image, = promote_dtypes_inexact(image)
   # Skip dimensions that have scale=1 and translation=0, this is only possible
   # since all of the current resize methods (kernels) are interpolating, so the
   # output = input under an identity warp.

--- a/jax/_src/lax/fft.py
+++ b/jax/_src/lax/fft.py
@@ -30,7 +30,7 @@ from jax._src.interpreters import batching
 from jax._src.lib.mlir.dialects import hlo
 from jax._src.lib import xla_client
 from jax._src.lib import ducc_fft
-from jax._src.numpy.util import _promote_dtypes_complex, _promote_dtypes_inexact
+from jax._src.numpy.util import promote_dtypes_complex, promote_dtypes_inexact
 
 __all__ = [
   "fft",
@@ -61,9 +61,9 @@ def fft(x, fft_type: Union[xla_client.FftType, str], fft_lengths: Sequence[int])
   if typ == xla_client.FftType.RFFT:
     if np.iscomplexobj(x):
       raise ValueError("only real valued inputs supported for rfft")
-    x, = _promote_dtypes_inexact(x)
+    x, = promote_dtypes_inexact(x)
   else:
-    x, = _promote_dtypes_complex(x)
+    x, = promote_dtypes_complex(x)
   if len(fft_lengths) == 0:
     # XLA FFT doesn't support 0-rank.
     return x

--- a/jax/_src/numpy/fft.py
+++ b/jax/_src/numpy/fft.py
@@ -21,7 +21,7 @@ from jax import dtypes
 from jax import lax
 from jax._src.lib import xla_client
 from jax._src.util import safe_zip
-from jax._src.numpy.util import _check_arraylike, _wraps
+from jax._src.numpy.util import check_arraylike, _wraps
 from jax._src.numpy import lax_numpy as jnp
 from jax._src.numpy import ufuncs, reductions
 from jax._src.typing import Array, ArrayLike
@@ -43,7 +43,7 @@ def _fft_core(func_name: str, fft_type: xla_client.FftType, a: ArrayLike,
               s: Optional[Shape], axes: Optional[Sequence[int]],
               norm: Optional[str]) -> Array:
   full_name = "jax.numpy.fft." + func_name
-  _check_arraylike(full_name, a)
+  check_arraylike(full_name, a)
   arr = jnp.asarray(a)
 
   if s is not None:
@@ -293,7 +293,7 @@ def rfftfreq(n: int, d: ArrayLike = 1.0, *, dtype=None) -> Array:
 
 @_wraps(np.fft.fftshift)
 def fftshift(x: ArrayLike, axes: Union[None, int, Sequence[int]] = None) -> Array:
-  _check_arraylike("fftshift", x)
+  check_arraylike("fftshift", x)
   x = jnp.asarray(x)
   shift: Union[int, Sequence[int]]
   if axes is None:
@@ -309,7 +309,7 @@ def fftshift(x: ArrayLike, axes: Union[None, int, Sequence[int]] = None) -> Arra
 
 @_wraps(np.fft.ifftshift)
 def ifftshift(x: ArrayLike, axes: Union[None, int, Sequence[int]] = None) -> Array:
-  _check_arraylike("ifftshift", x)
+  check_arraylike("ifftshift", x)
   x = jnp.asarray(x)
   shift: Union[int, Sequence[int]]
   if axes is None:

--- a/jax/_src/numpy/index_tricks.py
+++ b/jax/_src/numpy/index_tricks.py
@@ -17,7 +17,7 @@ from typing import Any, Iterable, List, Tuple, Union
 
 import jax
 from jax._src import core
-from jax._src.numpy.util import _promote_dtypes
+from jax._src.numpy.util import promote_dtypes
 from jax._src.numpy.lax_numpy import (
   arange, array, concatenate, expand_dims, linspace, meshgrid, stack, transpose
 )
@@ -54,7 +54,7 @@ class _IndexGrid(abc.ABC):
       return _make_1d_grid_from_slice(key, op_name=self.op_name)
     output: Iterable[Array] = (_make_1d_grid_from_slice(k, op_name=self.op_name) for k in key)
     with jax.numpy_dtype_promotion('standard'):
-      output = _promote_dtypes(*output)
+      output = promote_dtypes(*output)
     output_arr = meshgrid(*output, indexing='ij', sparse=self.sparse)
     if self.sparse:
       return output_arr

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -28,7 +28,7 @@ from jax._src.lax import lax as lax_internal
 from jax._src.lax import linalg as lax_linalg
 from jax._src.numpy import lax_numpy as jnp
 from jax._src.numpy import reductions, ufuncs
-from jax._src.numpy.util import _wraps, _promote_dtypes_inexact, _check_arraylike
+from jax._src.numpy.util import _wraps, promote_dtypes_inexact, check_arraylike
 from jax._src.util import canonicalize_axis
 from jax._src.typing import ArrayLike, Array
 
@@ -47,8 +47,8 @@ def _symmetrize(x: Array) -> Array: return (x + _H(x)) / 2
 @_wraps(np.linalg.cholesky)
 @jit
 def cholesky(a: ArrayLike) -> Array:
-  _check_arraylike("jnp.linalg.cholesky", a)
-  a, = _promote_dtypes_inexact(jnp.asarray(a))
+  check_arraylike("jnp.linalg.cholesky", a)
+  a, = promote_dtypes_inexact(jnp.asarray(a))
   return lax_linalg.cholesky(a)
 
 @overload
@@ -71,8 +71,8 @@ def svd(a: ArrayLike, full_matrices: bool = True, compute_uv: bool = True,
 @partial(jit, static_argnames=('full_matrices', 'compute_uv', 'hermitian'))
 def svd(a: ArrayLike, full_matrices: bool = True, compute_uv: bool = True,
         hermitian: bool = False) -> Union[Array, Tuple[Array, Array, Array]]:
-  _check_arraylike("jnp.linalg.svd", a)
-  a, = _promote_dtypes_inexact(jnp.asarray(a))
+  check_arraylike("jnp.linalg.svd", a)
+  a, = promote_dtypes_inexact(jnp.asarray(a))
   if hermitian:
     w, v = lax_linalg.eigh(a)
     s = lax.abs(v)
@@ -95,8 +95,8 @@ def svd(a: ArrayLike, full_matrices: bool = True, compute_uv: bool = True,
 @_wraps(np.linalg.matrix_power)
 @partial(jit, static_argnames=('n',))
 def matrix_power(a: ArrayLike, n: int) -> Array:
-  _check_arraylike("jnp.linalg.matrix_power", a)
-  arr, = _promote_dtypes_inexact(jnp.asarray(a))
+  check_arraylike("jnp.linalg.matrix_power", a)
+  arr, = promote_dtypes_inexact(jnp.asarray(a))
 
   if arr.ndim < 2:
     raise TypeError("{}-dimensional array given. Array must be at least "
@@ -134,8 +134,8 @@ def matrix_power(a: ArrayLike, n: int) -> Array:
 @_wraps(np.linalg.matrix_rank)
 @jit
 def matrix_rank(M: ArrayLike, tol: Optional[ArrayLike] = None) -> Array:
-  _check_arraylike("jnp.linalg.matrix_rank", M)
-  M, = _promote_dtypes_inexact(jnp.asarray(M))
+  check_arraylike("jnp.linalg.matrix_rank", M)
+  M, = promote_dtypes_inexact(jnp.asarray(M))
   if M.ndim < 2:
     return (M != 0).any().astype(jnp.int32)
   S = svd(M, full_matrices=False, compute_uv=False)
@@ -197,8 +197,8 @@ def _slogdet_qr(a: Array) -> Tuple[Array, Array]:
     """))
 @partial(jit, static_argnames=('method',))
 def slogdet(a: ArrayLike, *, method: Optional[str] = None) -> Tuple[Array, Array]:
-  _check_arraylike("jnp.linalg.slogdet", a)
-  a, = _promote_dtypes_inexact(jnp.asarray(a))
+  check_arraylike("jnp.linalg.slogdet", a)
+  a, = promote_dtypes_inexact(jnp.asarray(a))
   a_shape = jnp.shape(a)
   if len(a_shape) < 2 or a_shape[-1] != a_shape[-2]:
     msg = "Argument to slogdet() must have shape [..., n, n], got {}"
@@ -269,8 +269,8 @@ def _cofactor_solve(a: ArrayLike, b: ArrayLike) -> Tuple[Array, Array]:
   Returns:
     det(a) and cofactor(a)^T*b, aka adjugate(a)*b
   """
-  a, = _promote_dtypes_inexact(jnp.asarray(a))
-  b, = _promote_dtypes_inexact(jnp.asarray(b))
+  a, = promote_dtypes_inexact(jnp.asarray(a))
+  b, = promote_dtypes_inexact(jnp.asarray(b))
   a_shape = jnp.shape(a)
   b_shape = jnp.shape(b)
   a_ndims = len(a_shape)
@@ -336,8 +336,8 @@ def _det_3x3(a: Array) -> Array:
 @_wraps(np.linalg.det)
 @jit
 def det(a: ArrayLike) -> Array:
-  _check_arraylike("jnp.linalg.det", a)
-  a, = _promote_dtypes_inexact(jnp.asarray(a))
+  check_arraylike("jnp.linalg.det", a)
+  a, = promote_dtypes_inexact(jnp.asarray(a))
   a_shape = jnp.shape(a)
   if len(a_shape) >= 2 and a_shape[-1] == 2 and a_shape[-2] == 2:
     return _det_2x2(a)
@@ -369,8 +369,8 @@ backend. However eigendecomposition for symmetric/Hermitian matrices is
 implemented more widely (see :func:`jax.numpy.linalg.eigh`).
 """)
 def eig(a: ArrayLike) -> Tuple[Array, Array]:
-  _check_arraylike("jnp.linalg.eig", a)
-  a, = _promote_dtypes_inexact(jnp.asarray(a))
+  check_arraylike("jnp.linalg.eig", a)
+  a, = promote_dtypes_inexact(jnp.asarray(a))
   w, v = lax_linalg.eig(a, compute_left_eigenvectors=False)
   return w, v
 
@@ -378,7 +378,7 @@ def eig(a: ArrayLike) -> Tuple[Array, Array]:
 @_wraps(np.linalg.eigvals)
 @jit
 def eigvals(a: ArrayLike) -> Array:
-  _check_arraylike("jnp.linalg.eigvals", a)
+  check_arraylike("jnp.linalg.eigvals", a)
   return lax_linalg.eig(a, compute_left_eigenvectors=False,
                         compute_right_eigenvectors=False)[0]
 
@@ -387,7 +387,7 @@ def eigvals(a: ArrayLike) -> Array:
 @partial(jit, static_argnames=('UPLO', 'symmetrize_input'))
 def eigh(a: ArrayLike, UPLO: Optional[str] = None,
          symmetrize_input: bool = True) -> Tuple[Array, Array]:
-  _check_arraylike("jnp.linalg.eigh", a)
+  check_arraylike("jnp.linalg.eigh", a)
   if UPLO is None or UPLO == "L":
     lower = True
   elif UPLO == "U":
@@ -396,7 +396,7 @@ def eigh(a: ArrayLike, UPLO: Optional[str] = None,
     msg = f"UPLO must be one of None, 'L', or 'U', got {UPLO}"
     raise ValueError(msg)
 
-  a, = _promote_dtypes_inexact(jnp.asarray(a))
+  a, = promote_dtypes_inexact(jnp.asarray(a))
   v, w = lax_linalg.eigh(a, lower=lower, symmetrize_input=symmetrize_input)
   return w, v
 
@@ -404,7 +404,7 @@ def eigh(a: ArrayLike, UPLO: Optional[str] = None,
 @_wraps(np.linalg.eigvalsh)
 @partial(jit, static_argnames=('UPLO',))
 def eigvalsh(a: ArrayLike, UPLO: Optional[str] = 'L') -> Array:
-  _check_arraylike("jnp.linalg.eigvalsh", a)
+  check_arraylike("jnp.linalg.eigvalsh", a)
   w, _ = eigh(a, UPLO)
   return w
 
@@ -420,7 +420,7 @@ def pinv(a: ArrayLike, rcond: Optional[ArrayLike] = None,
          hermitian: bool = False) -> Array:
   # Uses same algorithm as
   # https://github.com/numpy/numpy/blob/v1.17.0/numpy/linalg/linalg.py#L1890-L1979
-  _check_arraylike("jnp.linalg.pinv", a)
+  check_arraylike("jnp.linalg.pinv", a)
   arr = jnp.asarray(a)
   m, n = arr.shape[-2:]
   if m == 0 or n == 0:
@@ -473,7 +473,7 @@ def _pinv_jvp(rcond, hermitian, primals, tangents):
 @_wraps(np.linalg.inv)
 @jit
 def inv(a: ArrayLike) -> Array:
-  _check_arraylike("jnp.linalg.inv", a)
+  check_arraylike("jnp.linalg.inv", a)
   arr = jnp.asarray(a)
   if arr.ndim < 2 or arr.shape[-1] != arr.shape[-2]:
     raise ValueError(
@@ -487,8 +487,8 @@ def inv(a: ArrayLike) -> Array:
 def norm(x: ArrayLike, ord: Union[int, str, None] = None,
          axis: Union[None, Tuple[int, ...], int] = None,
          keepdims: bool = False) -> Array:
-  _check_arraylike("jnp.linalg.norm", x)
-  x, = _promote_dtypes_inexact(jnp.asarray(x))
+  check_arraylike("jnp.linalg.norm", x)
+  x, = promote_dtypes_inexact(jnp.asarray(x))
   x_shape = jnp.shape(x)
   ndim = len(x_shape)
 
@@ -587,8 +587,8 @@ def qr(a: ArrayLike, mode: str = "reduced") -> Union[Array, Tuple[Array, Array]]
 @_wraps(np.linalg.qr)
 @partial(jit, static_argnames=('mode',))
 def qr(a: ArrayLike, mode: str = "reduced") -> Union[Array, Tuple[Array, Array]]:
-  _check_arraylike("jnp.linalg.qr", a)
-  a, = _promote_dtypes_inexact(jnp.asarray(a))
+  check_arraylike("jnp.linalg.qr", a)
+  a, = promote_dtypes_inexact(jnp.asarray(a))
   if mode == "raw":
     a, taus = lax_linalg.geqrf(a)
     return _T(a), taus
@@ -607,8 +607,8 @@ def qr(a: ArrayLike, mode: str = "reduced") -> Union[Array, Tuple[Array, Array]]
 @_wraps(np.linalg.solve)
 @jit
 def solve(a: ArrayLike, b: ArrayLike) -> Array:
-  _check_arraylike("jnp.linalg.solve", a, b)
-  a, b = _promote_dtypes_inexact(jnp.asarray(a), jnp.asarray(b))
+  check_arraylike("jnp.linalg.solve", a, b)
+  a, b = promote_dtypes_inexact(jnp.asarray(a), jnp.asarray(b))
   return lax_linalg._solve(a, b)
 
 
@@ -616,7 +616,7 @@ def _lstsq(a: ArrayLike, b: ArrayLike, rcond: Optional[float], *,
            numpy_resid: bool = False) -> Tuple[Array, Array, Array, Array]:
   # TODO: add lstsq to lax_linalg and implement this function via those wrappers.
   # TODO: add custom jvp rule for more robust lstsq differentiation
-  a, b = _promote_dtypes_inexact(a, b)
+  a, b = promote_dtypes_inexact(a, b)
   if a.shape[0] != b.shape[0]:
     raise ValueError("Leading dimensions of input arrays must match")
   b_orig_ndim = b.ndim
@@ -674,7 +674,7 @@ _jit_lstsq = jit(partial(_lstsq, numpy_resid=False))
     """))
 def lstsq(a: ArrayLike, b: ArrayLike, rcond: Optional[float] = None, *,
           numpy_resid: bool = False) -> Tuple[Array, Array, Array, Array]:
-  _check_arraylike("jnp.linalg.lstsq", a, b)
+  check_arraylike("jnp.linalg.lstsq", a, b)
   if numpy_resid:
     return _lstsq(a, b, rcond, numpy_resid=True)
   return _jit_lstsq(a, b, rcond)

--- a/jax/_src/numpy/polynomial.py
+++ b/jax/_src/numpy/polynomial.py
@@ -31,7 +31,7 @@ from jax._src.numpy.ufuncs import maximum, true_divide, sqrt
 from jax._src.numpy.reductions import all
 from jax._src.numpy import linalg
 from jax._src.numpy.util import (
-    _check_arraylike, _promote_dtypes, _promote_dtypes_inexact, _where, _wraps)
+    check_arraylike, promote_dtypes, promote_dtypes_inexact, _where, _wraps)
 from jax._src.typing import Array, ArrayLike
 
 
@@ -84,8 +84,8 @@ strip_zeros : bool, default=True
     :func:`jax.jit` and other JAX transformations.
 """)
 def roots(p: ArrayLike, *, strip_zeros: bool = True) -> Array:
-  _check_arraylike("roots", p)
-  p_arr = atleast_1d(*_promote_dtypes_inexact(p))
+  check_arraylike("roots", p)
+  p_arr = atleast_1d(*promote_dtypes_inexact(p))
   if p_arr.ndim != 1:
     raise ValueError("Input must be a rank-1 array.")
   if p_arr.size < 2:
@@ -111,7 +111,7 @@ Also, it works best on rcond <= 10e-3 values.
 def polyfit(x: Array, y: Array, deg: int, rcond: Optional[float] = None,
             full: bool = False, w: Optional[Array] = None, cov: bool = False
             ) -> Union[Array, Tuple[Array, ...]]:
-  _check_arraylike("polyfit", x, y)
+  check_arraylike("polyfit", x, y)
   deg = core.concrete_or_error(int, deg, "deg must be int")
   order = deg + 1
   # check arguments
@@ -136,8 +136,8 @@ def polyfit(x: Array, y: Array, deg: int, rcond: Optional[float] = None,
 
   # apply weighting
   if w is not None:
-    _check_arraylike("polyfit", w)
-    w, = _promote_dtypes_inexact(w)
+    check_arraylike("polyfit", w)
+    w, = promote_dtypes_inexact(w)
     if w.ndim != 1:
       raise TypeError("expected a 1-d array for weights")
     if w.shape[0] != y.shape[0]:
@@ -190,8 +190,8 @@ jax returns an array with a complex dtype in such cases.
 @_wraps(np.poly, lax_description=_POLY_DOC)
 @jit
 def poly(seq_of_zeros: Array) -> Array:
-  _check_arraylike('poly', seq_of_zeros)
-  seq_of_zeros, = _promote_dtypes_inexact(seq_of_zeros)
+  check_arraylike('poly', seq_of_zeros)
+  seq_of_zeros, = promote_dtypes_inexact(seq_of_zeros)
   seq_of_zeros = atleast_1d(seq_of_zeros)
 
   sh = seq_of_zeros.shape
@@ -224,8 +224,8 @@ compilation time.
 """)
 @partial(jit, static_argnames=['unroll'])
 def polyval(p: Array, x: Array, *, unroll: int = 16) -> Array:
-  _check_arraylike("polyval", p, x)
-  p, x = _promote_dtypes_inexact(p, x)
+  check_arraylike("polyval", p, x)
+  p, x = promote_dtypes_inexact(p, x)
   shape = lax.broadcast_shapes(p.shape[1:], x.shape)
   y = lax.full_like(x, 0, shape=shape, dtype=x.dtype)
   y, _ = lax.scan(lambda y, p: (y * x + p, None), y, p, unroll=unroll)
@@ -234,8 +234,8 @@ def polyval(p: Array, x: Array, *, unroll: int = 16) -> Array:
 @_wraps(np.polyadd)
 @jit
 def polyadd(a1: Array, a2: Array) -> Array:
-  _check_arraylike("polyadd", a1, a2)
-  a1, a2 = _promote_dtypes(a1, a2)
+  check_arraylike("polyadd", a1, a2)
+  a1, a2 = promote_dtypes(a1, a2)
   if a2.shape[0] <= a1.shape[0]:
     return a1.at[-a2.shape[0]:].add(a2)
   else:
@@ -247,8 +247,8 @@ def polyadd(a1: Array, a2: Array) -> Array:
 def polyint(p: Array, m: int = 1, k: Optional[int] = None) -> Array:
   m = core.concrete_or_error(operator.index, m, "'m' argument of jnp.polyint")
   k = 0 if k is None else k
-  _check_arraylike("polyint", p, k)
-  p, k_arr = _promote_dtypes_inexact(p, k)
+  check_arraylike("polyint", p, k)
+  p, k_arr = promote_dtypes_inexact(p, k)
   if m < 0:
     raise ValueError("Order of integral must be positive (see polyder)")
   k_arr = atleast_1d(k_arr)
@@ -268,9 +268,9 @@ def polyint(p: Array, m: int = 1, k: Optional[int] = None) -> Array:
 @_wraps(np.polyder)
 @partial(jit, static_argnames=('m',))
 def polyder(p: Array, m: int = 1) -> Array:
-  _check_arraylike("polyder", p)
+  check_arraylike("polyder", p)
   m = core.concrete_or_error(operator.index, m, "'m' argument of jnp.polyder")
-  p, = _promote_dtypes_inexact(p)
+  p, = promote_dtypes_inexact(p)
   if m < 0:
     raise ValueError("Order of derivative must be positive")
   if m == 0:
@@ -290,8 +290,8 @@ JAX backends. The result may lead to inconsistent output shapes when trim_leadin
 
 @_wraps(np.polymul, lax_description=_LEADING_ZEROS_DOC)
 def polymul(a1: ArrayLike, a2: ArrayLike, *, trim_leading_zeros: bool = False) -> Array:
-  _check_arraylike("polymul", a1, a2)
-  a1_arr, a2_arr = _promote_dtypes_inexact(a1, a2)
+  check_arraylike("polymul", a1, a2)
+  a1_arr, a2_arr = promote_dtypes_inexact(a1, a2)
   if trim_leading_zeros and (len(a1_arr) > 1 or len(a2_arr) > 1):
     a1_arr, a2_arr = trim_zeros(a1_arr, trim='f'), trim_zeros(a2_arr, trim='f')
   if len(a1_arr) == 0:
@@ -302,8 +302,8 @@ def polymul(a1: ArrayLike, a2: ArrayLike, *, trim_leading_zeros: bool = False) -
 
 @_wraps(np.polydiv, lax_description=_LEADING_ZEROS_DOC)
 def polydiv(u: ArrayLike, v: ArrayLike, *, trim_leading_zeros: bool = False) -> Tuple[Array, Array]:
-  _check_arraylike("polydiv", u, v)
-  u_arr, v_arr = _promote_dtypes_inexact(u, v)
+  check_arraylike("polydiv", u, v)
+  u_arr, v_arr = promote_dtypes_inexact(u, v)
   m = len(u_arr) - 1
   n = len(v_arr) - 1
   scale = 1. / v_arr[0]
@@ -320,6 +320,6 @@ def polydiv(u: ArrayLike, v: ArrayLike, *, trim_leading_zeros: bool = False) -> 
 @_wraps(np.polysub)
 @jit
 def polysub(a1: Array, a2: Array) -> Array:
-  _check_arraylike("polysub", a1, a2)
-  a1, a2 = _promote_dtypes(a1, a2)
+  check_arraylike("polysub", a1, a2)
+  a1, a2 = promote_dtypes(a1, a2)
   return polyadd(a1, -a2)

--- a/jax/_src/numpy/setops.py
+++ b/jax/_src/numpy/setops.py
@@ -32,7 +32,7 @@ from jax._src.numpy.lax_numpy import (
     sort, where, zeros)
 from jax._src.numpy.reductions import any, cumsum
 from jax._src.numpy.ufuncs import isnan
-from jax._src.numpy.util import _check_arraylike, _wraps
+from jax._src.numpy.util import check_arraylike, _wraps
 from jax._src.typing import Array, ArrayLike
 
 
@@ -48,7 +48,7 @@ def in1d(ar1: ArrayLike, ar2: ArrayLike, assume_unique: bool = False, invert: bo
 
 @partial(jit, static_argnames=('invert',))
 def _in1d(ar1: ArrayLike, ar2: ArrayLike, invert: bool) -> Array:
-  _check_arraylike("in1d", ar1, ar2)
+  check_arraylike("in1d", ar1, ar2)
   ar1_flat = ravel(ar1)
   ar2_flat = ravel(ar2)
   # Note: an algorithm based on searchsorted has better scaling, but in practice
@@ -80,7 +80,7 @@ def _in1d(ar1: ArrayLike, ar2: ArrayLike, invert: bool) -> Array:
         remaining elements will be filled with ``fill_value``, which defaults to zero."""))
 def setdiff1d(ar1: ArrayLike, ar2: ArrayLike, assume_unique: bool = False,
               *, size: Optional[int] = None, fill_value: Optional[ArrayLike] = None) -> Array:
-  _check_arraylike("setdiff1d", ar1, ar2)
+  check_arraylike("setdiff1d", ar1, ar2)
   if size is None:
     ar1 = core.concrete_or_error(None, ar1, "The error arose in setdiff1d()")
   else:
@@ -118,7 +118,7 @@ def setdiff1d(ar1: ArrayLike, ar2: ArrayLike, assume_unique: bool = False,
         value of the union."""))
 def union1d(ar1: ArrayLike, ar2: ArrayLike,
             *, size: Optional[int] = None, fill_value: Optional[ArrayLike] = None) -> Array:
-  _check_arraylike("union1d", ar1, ar2)
+  check_arraylike("union1d", ar1, ar2)
   if size is None:
     ar1 = core.concrete_or_error(None, ar1, "The error arose in union1d()")
     ar2 = core.concrete_or_error(None, ar2, "The error arose in union1d()")
@@ -132,7 +132,7 @@ In the JAX version, the input arrays are explicitly flattened regardless
 of assume_unique value.
 """)
 def setxor1d(ar1: ArrayLike, ar2: ArrayLike, assume_unique: bool = False) -> Array:
-  _check_arraylike("setxor1d", ar1, ar2)
+  check_arraylike("setxor1d", ar1, ar2)
   ar1 = core.concrete_or_error(None, ar1, "The error arose in setxor1d()")
   ar2 = core.concrete_or_error(None, ar2, "The error arose in setxor1d()")
 
@@ -174,7 +174,7 @@ def _intersect1d_sorted_mask(ar1: ArrayLike, ar2: ArrayLike, return_indices: boo
 @_wraps(np.intersect1d)
 def intersect1d(ar1: ArrayLike, ar2: ArrayLike, assume_unique: bool = False,
                 return_indices: bool = False) -> Union[Array, Tuple[Array, Array, Array]]:
-  _check_arraylike("intersect1d", ar1, ar2)
+  check_arraylike("intersect1d", ar1, ar2)
   ar1 = core.concrete_or_error(None, ar1, "The error arose in intersect1d()")
   ar2 = core.concrete_or_error(None, ar2, "The error arose in intersect1d()")
 
@@ -326,7 +326,7 @@ def _unique(ar: Array, axis: int, return_index: bool = False, return_inverse: bo
 def unique(ar: ArrayLike, return_index: bool = False, return_inverse: bool = False,
            return_counts: bool = False, axis: Optional[int] = None,
            *, size: Optional[int] = None, fill_value: Optional[ArrayLike] = None):
-  _check_arraylike("unique", ar)
+  check_arraylike("unique", ar)
   if size is None:
     ar = core.concrete_or_error(None, ar,
         "The error arose for the first argument of jnp.unique(). " + UNIQUE_SIZE_HINT)

--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -28,7 +28,7 @@ from jax._src import util
 from jax._src.lax import lax as lax_internal
 from jax._src.numpy import lax_numpy as jnp
 from jax._src.numpy import reductions
-from jax._src.numpy.util import _check_arraylike, _promote_dtypes
+from jax._src.numpy.util import check_arraylike, promote_dtypes
 
 
 Array = Any
@@ -100,7 +100,7 @@ def _scatter_impl(x, y, scatter_op, treedef, static_idx, dynamic_idx,
   if core.is_empty_shape(indexer.slice_shape):
     return x
 
-  x, y = _promote_dtypes(x, y)
+  x, y = promote_dtypes(x, y)
 
   # Broadcast `y` to the slice output shape.
   y = jnp.broadcast_to(y, tuple(indexer.slice_shape))
@@ -157,7 +157,7 @@ def _segment_update(name: str,
                     bucket_size: Optional[int] = None,
                     reducer: Optional[Callable] = None,
                     mode: Optional[lax.GatherScatterMode] = None) -> Array:
-  _check_arraylike(name, data, segment_ids)
+  check_arraylike(name, data, segment_ids)
   mode = lax.GatherScatterMode.FILL_OR_DROP if mode is None else mode
   data = jnp.asarray(data)
   segment_ids = jnp.asarray(segment_ids)

--- a/jax/_src/ops/special.py
+++ b/jax/_src/ops/special.py
@@ -18,7 +18,7 @@ import jax
 from jax import lax
 from jax import numpy as jnp
 from jax._src.numpy.reductions import _reduction_dims
-from jax._src.numpy.util import _promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 import numpy as np
 
@@ -67,10 +67,10 @@ def logsumexp(a: ArrayLike, axis: Optional[int] = None, b: Optional[ArrayLike] =
     on the value of the ``return_sign`` argument.
   """
   if b is not None:
-    a_arr, b_arr = _promote_args_inexact("logsumexp", a, b)
+    a_arr, b_arr = promote_args_inexact("logsumexp", a, b)
     a_arr = jnp.where(b_arr != 0, a_arr, -jnp.inf)
   else:
-    a_arr, = _promote_args_inexact("logsumexp", a)
+    a_arr, = promote_args_inexact("logsumexp", a)
     b_arr = a_arr  # for type checking
   pos_dims, dims = _reduction_dims(a_arr, axis)
   amax = jnp.max(a_arr, axis=dims, keepdims=keepdims)

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -38,7 +38,7 @@ from jax._src.interpreters import ad
 from jax._src.interpreters import batching
 from jax._src.lax import lax as lax_internal
 from jax._src.numpy.lax_numpy import _convert_and_clip_integer
-from jax._src.numpy.util import _arraylike, _check_arraylike, _promote_dtypes_inexact
+from jax._src.numpy.util import _arraylike, check_arraylike, promote_dtypes_inexact
 from jax._src.typing import Array, ArrayLike, DTypeLike
 from jax._src.util import canonicalize_axis
 
@@ -330,7 +330,7 @@ def _randint(key, shape, minval, maxval, dtype) -> Array:
   if not jnp.issubdtype(dtype, np.integer):
     raise TypeError(f"randint only accepts integer dtypes, got {dtype}")
 
-  _check_arraylike("randint", minval, maxval)
+  check_arraylike("randint", minval, maxval)
   minval = jnp.asarray(minval)
   maxval = jnp.asarray(maxval)
   if not jnp.issubdtype(minval.dtype, np.integer):
@@ -423,7 +423,7 @@ def permutation(key: KeyArray,
     A shuffled version of x or array range
   """
   key, _ = _check_prng_key(key)
-  _check_arraylike("permutation", x)
+  check_arraylike("permutation", x)
   axis = canonicalize_axis(axis, np.ndim(x) or 1)
   if not np.ndim(x):
     if not np.issubdtype(lax.dtype(x), np.integer):
@@ -500,7 +500,7 @@ def choice(key: KeyArray,
   if not isinstance(shape, Sequence):
     raise TypeError("shape argument of jax.random.choice must be a sequence, "
                     f"got {shape}")
-  _check_arraylike("choice", a)
+  check_arraylike("choice", a)
   arr = jnp.asarray(a)
   if arr.ndim == 0:
     n_inputs = core.concrete_or_error(int, a, "The error occurred in jax.random.choice()")
@@ -523,8 +523,8 @@ def choice(key: KeyArray,
       slices = (slice(None),) * axis + (slice(n_draws),)
       result = permutation(key, n_inputs if arr.ndim == 0 else arr, axis)[slices]
   else:
-    _check_arraylike("choice", p)
-    p_arr, = _promote_dtypes_inexact(p)
+    check_arraylike("choice", p)
+    p_arr, = promote_dtypes_inexact(p)
     if p_arr.shape != (n_inputs,):
       raise ValueError("p must be None or match the shape of a")
     if replace:
@@ -615,7 +615,7 @@ def multivariate_normal(key: KeyArray,
     ``broadcast_shapes(mean.shape[:-1], cov.shape[:-2]) + mean.shape[-1:]``.
   """
   key, _ = _check_prng_key(key)
-  mean, cov = _promote_dtypes_inexact(mean, cov)
+  mean, cov = promote_dtypes_inexact(mean, cov)
   if method not in {'svd', 'eigh', 'cholesky'}:
     raise ValueError("method must be one of {'svd', 'eigh', 'cholesky'}")
   if dtype is None:
@@ -1328,7 +1328,7 @@ def categorical(key: KeyArray,
     is not None, or else ``np.delete(logits.shape, axis)``.
   """
   key, _ = _check_prng_key(key)
-  _check_arraylike("categorical", logits)
+  check_arraylike("categorical", logits)
   logits_arr = jnp.asarray(logits)
 
   if axis >= 0:

--- a/jax/_src/scipy/cluster/vq.py
+++ b/jax/_src/scipy/cluster/vq.py
@@ -19,7 +19,7 @@ import textwrap
 
 from jax import vmap
 import jax.numpy as jnp
-from jax._src.numpy.util import _wraps, _check_arraylike, _promote_dtypes_inexact
+from jax._src.numpy.util import _wraps, check_arraylike, promote_dtypes_inexact
 
 
 _no_chkfinite_doc = textwrap.dedent("""
@@ -30,10 +30,10 @@ because compiled JAX code cannot perform checks of array values at runtime
 
 @_wraps(scipy.cluster.vq.vq, lax_description=_no_chkfinite_doc, skip_params=('check_finite',))
 def vq(obs, code_book, check_finite=True):
-    _check_arraylike("scipy.cluster.vq.vq", obs, code_book)
+    check_arraylike("scipy.cluster.vq.vq", obs, code_book)
     if obs.ndim != code_book.ndim:
         raise ValueError("Observation and code_book should have the same rank")
-    obs, code_book = _promote_dtypes_inexact(obs, code_book)
+    obs, code_book = promote_dtypes_inexact(obs, code_book)
     if obs.ndim == 1:
         obs, code_book = obs[..., None], code_book[..., None]
     if obs.ndim != 2:

--- a/jax/_src/scipy/fft.py
+++ b/jax/_src/scipy/fft.py
@@ -19,11 +19,11 @@ import scipy.fft as osp_fft
 from jax import lax
 import jax.numpy as jnp
 from jax._src.util import canonicalize_axis
-from jax._src.numpy.util import _wraps, _promote_dtypes_complex
+from jax._src.numpy.util import _wraps, promote_dtypes_complex
 from jax._src.typing import Array
 
 def _W4(N: int, k: Array) -> Array:
-  N_arr, k = _promote_dtypes_complex(N, k)
+  N_arr, k = promote_dtypes_complex(N, k)
   return jnp.exp(-.5j * jnp.pi * k / N_arr)
 
 def _dct_interleave(x: Array, axis: int) -> Array:

--- a/jax/_src/scipy/optimize/line_search.py
+++ b/jax/_src/scipy/optimize/line_search.py
@@ -15,7 +15,7 @@
 from typing import NamedTuple, Union
 from functools import partial
 
-from jax._src.numpy.util import _promote_dtypes_inexact
+from jax._src.numpy.util import promote_dtypes_inexact
 import jax.numpy as jnp
 import jax
 from jax import lax
@@ -272,7 +272,7 @@ def line_search(f, xk, pk, old_fval=None, old_old_fval=None, gfk=None, c1=1e-4,
 
   Returns: LineSearchResults
   """
-  xk, pk = _promote_dtypes_inexact(xk, pk)
+  xk, pk = promote_dtypes_inexact(xk, pk)
   def restricted_func_and_grad(t):
     t = jnp.array(t, dtype=pk.dtype)
     phi, g = jax.value_and_grad(f)(xk + t * pk)

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -29,7 +29,7 @@ from jax._src import api
 from jax._src import core
 from jax._src import dtypes
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _promote_args_inexact, _promote_dtypes_inexact
+from jax._src.numpy.util import promote_args_inexact, promote_dtypes_inexact
 from jax._src.numpy.util import _wraps
 from jax._src.ops import special as ops_special
 from jax._src.third_party.scipy.betaln import betaln as _betaln_impl
@@ -38,7 +38,7 @@ from jax._src.typing import Array, ArrayLike
 
 @_wraps(osp_special.gammaln, module='scipy.special')
 def gammaln(x: ArrayLike) -> Array:
-  x, = _promote_args_inexact("gammaln", x)
+  x, = promote_args_inexact("gammaln", x)
   return lax.lgamma(x)
 
 
@@ -51,14 +51,14 @@ betaln = _wraps(
 
 @_wraps(osp_special.betainc, module='scipy.special')
 def betainc(a: ArrayLike, b: ArrayLike, x: ArrayLike) -> Array:
-  a, b, x = _promote_args_inexact("betainc", a, b, x)
+  a, b, x = promote_args_inexact("betainc", a, b, x)
   return lax.betainc(a, b, x)
 
 
 @_wraps(osp_special.digamma, module='scipy.special', lax_description="""\
 The JAX version only accepts real-valued inputs.""")
 def digamma(x: ArrayLike) -> Array:
-  x, = _promote_args_inexact("digamma", x)
+  x, = promote_args_inexact("digamma", x)
   return lax.digamma(x)
 ad.defjvp(
     lax.digamma_p,
@@ -67,39 +67,39 @@ ad.defjvp(
 
 @_wraps(osp_special.gammainc, module='scipy.special', update_doc=False)
 def gammainc(a: ArrayLike, x: ArrayLike) -> Array:
-  a, x = _promote_args_inexact("gammainc", a, x)
+  a, x = promote_args_inexact("gammainc", a, x)
   return lax.igamma(a, x)
 
 
 @_wraps(osp_special.gammaincc, module='scipy.special', update_doc=False)
 def gammaincc(a: ArrayLike, x: ArrayLike) -> Array:
-  a, x = _promote_args_inexact("gammaincc", a, x)
+  a, x = promote_args_inexact("gammaincc", a, x)
   return lax.igammac(a, x)
 
 
 @_wraps(osp_special.erf, module='scipy.special', skip_params=["out"],
         lax_description="Note that the JAX version does not support complex inputs.")
 def erf(x: ArrayLike) -> Array:
-  x, = _promote_args_inexact("erf", x)
+  x, = promote_args_inexact("erf", x)
   return lax.erf(x)
 
 
 @_wraps(osp_special.erfc, module='scipy.special', update_doc=False)
 def erfc(x: ArrayLike) -> Array:
-  x, = _promote_args_inexact("erfc", x)
+  x, = promote_args_inexact("erfc", x)
   return lax.erfc(x)
 
 
 @_wraps(osp_special.erfinv, module='scipy.special')
 def erfinv(x: ArrayLike) -> Array:
-  x, = _promote_args_inexact("erfinv", x)
+  x, = promote_args_inexact("erfinv", x)
   return lax.erf_inv(x)
 
 
 @api.custom_jvp
 @_wraps(osp_special.logit, module='scipy.special', update_doc=False)
 def logit(x: ArrayLike) -> Array:
-  x, = _promote_args_inexact("logit", x)
+  x, = promote_args_inexact("logit", x)
   return lax.log(lax.div(x, lax.sub(_lax_const(x, 1), x)))
 logit.defjvps(
     lambda g, ans, x: lax.div(g, lax.mul(x, lax.sub(_lax_const(x, 1), x))))
@@ -107,7 +107,7 @@ logit.defjvps(
 
 @_wraps(osp_special.expit, module='scipy.special', update_doc=False)
 def expit(x: ArrayLike) -> Array:
-  x, = _promote_args_inexact("expit", x)
+  x, = promote_args_inexact("expit", x)
   return lax.logistic(x)
 
 
@@ -116,7 +116,7 @@ logsumexp = _wraps(osp_special.logsumexp, module='scipy.special')(ops_special.lo
 
 @_wraps(osp_special.xlogy, module='scipy.special')
 def xlogy(x: ArrayLike, y: ArrayLike) -> Array:
-  x, y = _promote_args_inexact("xlogy", x, y)
+  x, y = promote_args_inexact("xlogy", x, y)
   x_ok = x != 0.
   safe_x = jnp.where(x_ok, x, 1.)
   safe_y = jnp.where(x_ok, y, 1.)
@@ -125,7 +125,7 @@ def xlogy(x: ArrayLike, y: ArrayLike) -> Array:
 
 @_wraps(osp_special.xlog1py, module='scipy.special', update_doc=False)
 def xlog1py(x: ArrayLike, y: ArrayLike) -> Array:
-  x, y = _promote_args_inexact("xlog1py", x, y)
+  x, y = promote_args_inexact("xlog1py", x, y)
   x_ok = x != 0.
   safe_x = jnp.where(x_ok, x, 1.)
   safe_y = jnp.where(x_ok, y, 1.)
@@ -134,7 +134,7 @@ def xlog1py(x: ArrayLike, y: ArrayLike) -> Array:
 
 @_wraps(osp_special.entr, module='scipy.special')
 def entr(x: ArrayLike) -> Array:
-  x, = _promote_args_inexact("entr", x)
+  x, = promote_args_inexact("entr", x)
   return lax.select(lax.lt(x, _lax_const(x, 0)),
                     lax.full_like(x, -np.inf),
                     lax.neg(xlogy(x, x)))
@@ -143,7 +143,7 @@ def entr(x: ArrayLike) -> Array:
 @_wraps(osp_special.multigammaln, update_doc=False)
 def multigammaln(a: ArrayLike, d: ArrayLike) -> Array:
   d = core.concrete_or_error(int, d, "d argument of multigammaln")
-  a, d_ = _promote_args_inexact("multigammaln", a, d)
+  a, d_ = promote_args_inexact("multigammaln", a, d)
 
   constant = lax.mul(lax.mul(lax.mul(_lax_const(a, 0.25), d_),
                              lax.sub(d_, _lax_const(a, 1))),
@@ -185,7 +185,7 @@ def zeta(x: ArrayLike, q: Optional[ArrayLike] = None) -> Array:
   # Numerical Algorithms 69.2 (2015): 253-270.
   # https://arxiv.org/abs/1309.2877 - formula (5)
   # here we keep the same notation as in reference
-  s, a = _promote_args_inexact("zeta", x, q)
+  s, a = promote_args_inexact("zeta", x, q)
   dtype = lax.dtype(a).type
   s_, a_ = jnp.expand_dims(s, -1), jnp.expand_dims(a, -1)
   # precision ~ N, M
@@ -209,7 +209,7 @@ def zeta(x: ArrayLike, q: Optional[ArrayLike] = None) -> Array:
 @_wraps(osp_special.polygamma, module='scipy.special', update_doc=False)
 def polygamma(n: ArrayLike, x: ArrayLike) -> Array:
   assert jnp.issubdtype(lax.dtype(n), jnp.integer)
-  n_arr, x_arr = _promote_args_inexact("polygamma", n, x)
+  n_arr, x_arr = promote_args_inexact("polygamma", n, x)
   shape = lax.broadcast_shapes(n_arr.shape, x_arr.shape)
   return _polygamma(jnp.broadcast_to(n_arr, shape), jnp.broadcast_to(x_arr, shape))
 
@@ -631,22 +631,22 @@ def _norm_logpdf(x):
 
 @_wraps(osp_special.i0e, module='scipy.special')
 def i0e(x: ArrayLike) -> Array:
-  x, = _promote_args_inexact("i0e", x)
+  x, = promote_args_inexact("i0e", x)
   return lax.bessel_i0e(x)
 
 @_wraps(osp_special.i0, module='scipy.special')
 def i0(x: ArrayLike) -> Array:
-  x, = _promote_args_inexact("i0", x)
+  x, = promote_args_inexact("i0", x)
   return lax.mul(lax.exp(lax.abs(x)), lax.bessel_i0e(x))
 
 @_wraps(osp_special.i1e, module='scipy.special')
 def i1e(x: ArrayLike) -> Array:
-  x, = _promote_args_inexact("i1e", x)
+  x, = promote_args_inexact("i1e", x)
   return lax.bessel_i1e(x)
 
 @_wraps(osp_special.i1, module='scipy.special')
 def i1(x: ArrayLike) -> Array:
-  x, = _promote_args_inexact("i1", x)
+  x, = promote_args_inexact("i1", x)
   return lax.mul(lax.exp(lax.abs(x)), lax.bessel_i1e(x))
 
 def _bessel_jn_scan_body_fun(carry, k):
@@ -713,7 +713,7 @@ def bessel_jn(z: ArrayLike, *, v: int, n_iter: int=50) -> Array:
     ValueError if elements of array `z` are not float.
   """
   z = jnp.asarray(z)
-  z, = _promote_dtypes_inexact(z)
+  z, = promote_dtypes_inexact(z)
   z_dtype = lax.dtype(z)
   if dtypes.issubdtype(z_dtype, complex):
     raise ValueError("complex input not supported.")
@@ -1365,7 +1365,7 @@ def _expi_neg(x: Array) -> Array:
 @jit
 @_wraps(osp_special.expi, module='scipy.special')
 def expi(x: ArrayLike) -> Array:
-  x_arr, = _promote_args_inexact("expi", x)
+  x_arr, = promote_args_inexact("expi", x)
   return jnp.piecewise(x_arr, [x_arr < 0], [_expi_neg, _expi_pos])
 
 
@@ -1484,7 +1484,7 @@ def _expn3(n: int, x: Array) -> Array:
 @_wraps(osp_special.expn, module='scipy.special')
 @jit
 def expn(n: ArrayLike, x: ArrayLike) -> Array:
-  n, x = _promote_args_inexact("expn", n, x)
+  n, x = promote_args_inexact("expn", n, x)
   _c = _lax_const
   zero = _c(x, 0)
   one = _c(x, 1)
@@ -1521,7 +1521,7 @@ def expn_jvp(n, primals, tangents):
 
 @_wraps(osp_special.exp1, module="scipy.special")
 def exp1(x: ArrayLike, module='scipy.special') -> Array:
-  x, = _promote_args_inexact("exp1", x)
+  x, = promote_args_inexact("exp1", x)
   # Casting becuase custom_jvp generic does not work correctly with mypy.
   return cast(Array, expn(1, x))
 

--- a/jax/_src/scipy/stats/_core.py
+++ b/jax/_src/scipy/stats/_core.py
@@ -22,7 +22,7 @@ import jax.numpy as jnp
 from jax import jit
 from jax._src import dtypes
 from jax._src.api import vmap
-from jax._src.numpy.util import _check_arraylike, _wraps
+from jax._src.numpy.util import check_arraylike, _wraps
 from jax._src.typing import ArrayLike, Array
 from jax._src.util import canonicalize_axis
 
@@ -35,7 +35,7 @@ Currently the only supported nan_policy is 'propagate'
 """)
 @partial(jit, static_argnames=['axis', 'nan_policy', 'keepdims'])
 def mode(a: ArrayLike, axis: Optional[int] = 0, nan_policy: str = "propagate", keepdims: bool = False) -> ModeResult:
-  _check_arraylike("mode", a)
+  check_arraylike("mode", a)
   x = jnp.atleast_1d(a)
 
   if nan_policy not in ["propagate", "omit", "raise"]:
@@ -100,7 +100,7 @@ def rankdata(
   nan_policy: str = "propagate",
 ) -> Array:
 
-  _check_arraylike("rankdata", a)
+  check_arraylike("rankdata", a)
 
   if nan_policy not in ["propagate", "omit", "raise"]:
     raise ValueError(

--- a/jax/_src/scipy/stats/bernoulli.py
+++ b/jax/_src/scipy/stats/bernoulli.py
@@ -18,14 +18,14 @@ import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 from jax.scipy.special import xlogy, xlog1py
 
 
 @_wraps(osp_stats.bernoulli.logpmf, update_doc=False)
 def logpmf(k: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
-  k, p, loc = _promote_args_inexact("bernoulli.logpmf", k, p, loc)
+  k, p, loc = promote_args_inexact("bernoulli.logpmf", k, p, loc)
   zero = _lax_const(k, 0)
   one = _lax_const(k, 1)
   x = lax.sub(k, loc)
@@ -39,7 +39,7 @@ def pmf(k: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
 
 @_wraps(osp_stats.bernoulli.cdf, update_doc=False)
 def cdf(k: ArrayLike, p: ArrayLike) -> Array:
-  k, p = _promote_args_inexact('bernoulli.cdf', k, p)
+  k, p = promote_args_inexact('bernoulli.cdf', k, p)
   zero, one = _lax_const(k, 0), _lax_const(k, 1)
   conds = [
     jnp.isnan(k) | jnp.isnan(p) | (p < zero) | (p > one),
@@ -52,7 +52,7 @@ def cdf(k: ArrayLike, p: ArrayLike) -> Array:
 
 @_wraps(osp_stats.bernoulli.ppf, update_doc=False)
 def ppf(q: ArrayLike, p: ArrayLike) -> Array:
-  q, p = _promote_args_inexact('bernoulli.ppf', q, p)
+  q, p = promote_args_inexact('bernoulli.ppf', q, p)
   zero, one = _lax_const(q, 0), _lax_const(q, 1)
   return jnp.where(
     jnp.isnan(q) | jnp.isnan(p) | (p < zero) | (p > one) | (q < zero) | (q > one),

--- a/jax/_src/scipy/stats/beta.py
+++ b/jax/_src/scipy/stats/beta.py
@@ -17,7 +17,7 @@ import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 from jax.scipy.special import betaln, xlogy, xlog1py
 
@@ -25,7 +25,7 @@ from jax.scipy.special import betaln, xlogy, xlog1py
 @_wraps(osp_stats.beta.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, a: ArrayLike, b: ArrayLike,
            loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
-  x, a, b, loc, scale = _promote_args_inexact("beta.logpdf", x, a, b, loc, scale)
+  x, a, b, loc, scale = promote_args_inexact("beta.logpdf", x, a, b, loc, scale)
   one = _lax_const(x, 1)
   shape_term = lax.neg(betaln(a, b))
   y = lax.div(lax.sub(x, loc), scale)

--- a/jax/_src/scipy/stats/betabinom.py
+++ b/jax/_src/scipy/stats/betabinom.py
@@ -18,7 +18,7 @@ import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.scipy.special import betaln
 from jax._src.typing import Array, ArrayLike
 
@@ -27,7 +27,7 @@ from jax._src.typing import Array, ArrayLike
 def logpmf(k: ArrayLike, n: ArrayLike, a: ArrayLike, b: ArrayLike,
            loc: ArrayLike = 0) -> Array:
   """JAX implementation of scipy.stats.betabinom.logpmf."""
-  k, n, a, b, loc = _promote_args_inexact("betabinom.logpmf", k, n, a, b, loc)
+  k, n, a, b, loc = promote_args_inexact("betabinom.logpmf", k, n, a, b, loc)
   y = lax.sub(lax.floor(k), loc)
   one = _lax_const(y, 1)
   zero = _lax_const(y, 0)

--- a/jax/_src/scipy/stats/cauchy.py
+++ b/jax/_src/scipy/stats/cauchy.py
@@ -19,13 +19,13 @@ import scipy.stats as osp_stats
 from jax import lax
 from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.util import _wraps
-from jax._src.numpy.util import _promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
 @_wraps(osp_stats.cauchy.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
-  x, loc, scale = _promote_args_inexact("cauchy.logpdf", x, loc, scale)
+  x, loc, scale = promote_args_inexact("cauchy.logpdf", x, loc, scale)
   pi = _lax_const(x, np.pi)
   scaled_x = lax.div(lax.sub(x, loc), scale)
   normalize_term = lax.log(lax.mul(pi, scale))

--- a/jax/_src/scipy/stats/chi2.py
+++ b/jax/_src/scipy/stats/chi2.py
@@ -18,13 +18,13 @@ import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
 @_wraps(osp_stats.chi2.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
-    x, df, loc, scale = _promote_args_inexact("chi2.logpdf", x, df, loc, scale)
+    x, df, loc, scale = promote_args_inexact("chi2.logpdf", x, df, loc, scale)
     one = _lax_const(x, 1)
     two = _lax_const(x, 2)
     y = lax.div(lax.sub(x, loc), scale)

--- a/jax/_src/scipy/stats/dirichlet.py
+++ b/jax/_src/scipy/stats/dirichlet.py
@@ -18,7 +18,7 @@ import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _promote_dtypes_inexact, _wraps
+from jax._src.numpy.util import promote_dtypes_inexact, _wraps
 from jax.scipy.special import gammaln, xlogy
 from jax._src.typing import Array, ArrayLike
 
@@ -30,7 +30,7 @@ def _is_simplex(x: Array) -> Array:
 
 @_wraps(osp_stats.dirichlet.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, alpha: ArrayLike) -> Array:
-  return _logpdf(*_promote_dtypes_inexact(x, alpha))
+  return _logpdf(*promote_dtypes_inexact(x, alpha))
 
 def _logpdf(x: Array, alpha: Array) -> Array:
   if alpha.ndim != 1:

--- a/jax/_src/scipy/stats/expon.py
+++ b/jax/_src/scipy/stats/expon.py
@@ -16,13 +16,13 @@ import scipy.stats as osp_stats
 
 from jax import lax
 import jax.numpy as jnp
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
 @_wraps(osp_stats.expon.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
-  x, loc, scale = _promote_args_inexact("expon.logpdf", x, loc, scale)
+  x, loc, scale = promote_args_inexact("expon.logpdf", x, loc, scale)
   log_scale = lax.log(scale)
   linear_term = lax.div(lax.sub(x, loc), scale)
   log_probs = lax.neg(lax.add(linear_term, log_scale))

--- a/jax/_src/scipy/stats/gamma.py
+++ b/jax/_src/scipy/stats/gamma.py
@@ -17,14 +17,14 @@ import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 from jax.scipy.special import gammaln, xlogy
 
 
 @_wraps(osp_stats.gamma.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, a: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
-  x, a, loc, scale = _promote_args_inexact("gamma.logpdf", x, a, loc, scale)
+  x, a, loc, scale = promote_args_inexact("gamma.logpdf", x, a, loc, scale)
   one = _lax_const(x, 1)
   y = lax.div(lax.sub(x, loc), scale)
   log_linear_term = lax.sub(xlogy(lax.sub(a, one), y), y)

--- a/jax/_src/scipy/stats/gennorm.py
+++ b/jax/_src/scipy/stats/gennorm.py
@@ -14,18 +14,18 @@
 
 import scipy.stats as osp_stats
 from jax import lax
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
 @_wraps(osp_stats.gennorm.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, p: ArrayLike) -> Array:
-  x, p = _promote_args_inexact("gennorm.logpdf", x, p)
+  x, p = promote_args_inexact("gennorm.logpdf", x, p)
   return lax.log(.5 * p) - lax.lgamma(1/p) - lax.abs(x)**p
 
 @_wraps(osp_stats.gennorm.cdf, update_doc=False)
 def cdf(x: ArrayLike, p: ArrayLike) -> Array:
-  x, p = _promote_args_inexact("gennorm.cdf", x, p)
+  x, p = promote_args_inexact("gennorm.cdf", x, p)
   return .5 * (1 + lax.sign(x) * lax.igamma(1/p, lax.abs(x)**p))
 
 @_wraps(osp_stats.gennorm.pdf, update_doc=False)

--- a/jax/_src/scipy/stats/geom.py
+++ b/jax/_src/scipy/stats/geom.py
@@ -17,14 +17,14 @@ import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax.scipy.special import xlog1py
 from jax._src.typing import Array, ArrayLike
 
 
 @_wraps(osp_stats.geom.logpmf, update_doc=False)
 def logpmf(k: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
-    k, p, loc = _promote_args_inexact("geom.logpmf", k, p, loc)
+    k, p, loc = promote_args_inexact("geom.logpmf", k, p, loc)
     zero = _lax_const(k, 0)
     one = _lax_const(k, 1)
     x = lax.sub(k, loc)

--- a/jax/_src/scipy/stats/laplace.py
+++ b/jax/_src/scipy/stats/laplace.py
@@ -16,13 +16,13 @@ import scipy.stats as osp_stats
 
 from jax import lax
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
 @_wraps(osp_stats.laplace.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
-  x, loc, scale = _promote_args_inexact("laplace.logpdf", x, loc, scale)
+  x, loc, scale = promote_args_inexact("laplace.logpdf", x, loc, scale)
   two = _lax_const(x, 2)
   linear_term = lax.div(lax.abs(lax.sub(x, loc)), scale)
   return lax.neg(lax.add(linear_term, lax.log(lax.mul(two, scale))))
@@ -35,7 +35,7 @@ def pdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
 
 @_wraps(osp_stats.laplace.cdf, update_doc=False)
 def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
-  x, loc, scale = _promote_args_inexact("laplace.cdf", x, loc, scale)
+  x, loc, scale = promote_args_inexact("laplace.cdf", x, loc, scale)
   half = _lax_const(x, 0.5)
   one = _lax_const(x, 1)
   zero = _lax_const(x, 0)

--- a/jax/_src/scipy/stats/logistic.py
+++ b/jax/_src/scipy/stats/logistic.py
@@ -18,13 +18,13 @@ from jax.scipy.special import expit, logit
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
 @_wraps(osp_stats.logistic.logpdf, update_doc=False)
 def logpdf(x: ArrayLike) -> Array:
-  x, = _promote_args_inexact("logistic.logpdf", x)
+  x, = promote_args_inexact("logistic.logpdf", x)
   two = _lax_const(x, 2)
   half_x = lax.div(x, two)
   return lax.mul(lax.neg(two), jnp.logaddexp(half_x, lax.neg(half_x)))

--- a/jax/_src/scipy/stats/multinomial.py
+++ b/jax/_src/scipy/stats/multinomial.py
@@ -16,7 +16,7 @@
 import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
-from jax._src.numpy.util import _wraps, _promote_args_inexact, _promote_args_numeric
+from jax._src.numpy.util import _wraps, promote_args_inexact, promote_args_numeric
 from jax._src.scipy.special import gammaln, xlogy
 from jax._src.typing import Array, ArrayLike
 
@@ -24,8 +24,8 @@ from jax._src.typing import Array, ArrayLike
 @_wraps(osp_stats.multinomial.logpmf, update_doc=False)
 def logpmf(x: ArrayLike, n: ArrayLike, p: ArrayLike) -> Array:
   """JAX implementation of scipy.stats.multinomial.logpmf."""
-  p, = _promote_args_inexact("multinomial.logpmf", p)
-  x, n = _promote_args_numeric("multinomial.logpmf", x, n)
+  p, = promote_args_inexact("multinomial.logpmf", p)
+  x, n = promote_args_numeric("multinomial.logpmf", x, n)
   if not jnp.issubdtype(x.dtype, jnp.integer):
     raise ValueError(f"x and n must be of integer type; got x.dtype={x.dtype}, n.dtype={n.dtype}")
   x = x.astype(p.dtype)

--- a/jax/_src/scipy/stats/multivariate_normal.py
+++ b/jax/_src/scipy/stats/multivariate_normal.py
@@ -19,7 +19,7 @@ import scipy.stats as osp_stats
 
 from jax import lax
 from jax import numpy as jnp
-from jax._src.numpy.util import _wraps, _promote_dtypes_inexact
+from jax._src.numpy.util import _wraps, promote_dtypes_inexact
 from jax._src.typing import Array, ArrayLike
 
 
@@ -29,7 +29,7 @@ In the JAX version, the `allow_singular` argument is not implemented.
 def logpdf(x: ArrayLike, mean: ArrayLike, cov: ArrayLike, allow_singular: None = None) -> ArrayLike:
   if allow_singular is not None:
     raise NotImplementedError("allow_singular argument of multivariate_normal.logpdf")
-  x, mean, cov = _promote_dtypes_inexact(x, mean, cov)
+  x, mean, cov = promote_dtypes_inexact(x, mean, cov)
   if not mean.shape:
     return (-1/2 * jnp.square(x - mean) / cov
             - 1/2 * (jnp.log(2*np.pi) + jnp.log(cov)))

--- a/jax/_src/scipy/stats/nbinom.py
+++ b/jax/_src/scipy/stats/nbinom.py
@@ -18,7 +18,7 @@ import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.scipy.special import gammaln, xlogy
 from jax._src.typing import Array, ArrayLike
 
@@ -26,7 +26,7 @@ from jax._src.typing import Array, ArrayLike
 @_wraps(osp_stats.nbinom.logpmf, update_doc=False)
 def logpmf(k: ArrayLike, n: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
     """JAX implementation of scipy.stats.nbinom.logpmf."""
-    k, n, p, loc = _promote_args_inexact("nbinom.logpmf", k, n, p, loc)
+    k, n, p, loc = promote_args_inexact("nbinom.logpmf", k, n, p, loc)
     one = _lax_const(k, 1)
     y = lax.sub(k, loc)
     comb_term = lax.sub(

--- a/jax/_src/scipy/stats/norm.py
+++ b/jax/_src/scipy/stats/norm.py
@@ -20,13 +20,13 @@ import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 from jax.scipy import special
 
 @_wraps(osp_stats.norm.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
-  x, loc, scale = _promote_args_inexact("norm.logpdf", x, loc, scale)
+  x, loc, scale = promote_args_inexact("norm.logpdf", x, loc, scale)
   scale_sqrd = lax.square(scale)
   log_normalizer = lax.log(lax.mul(_lax_const(x, 2 * np.pi), scale_sqrd))
   quadratic = lax.div(lax.square(lax.sub(x, loc)), scale_sqrd)
@@ -40,13 +40,13 @@ def pdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
 
 @_wraps(osp_stats.norm.cdf, update_doc=False)
 def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
-  x, loc, scale = _promote_args_inexact("norm.cdf", x, loc, scale)
+  x, loc, scale = promote_args_inexact("norm.cdf", x, loc, scale)
   return special.ndtr(lax.div(lax.sub(x, loc), scale))
 
 
 @_wraps(osp_stats.norm.logcdf, update_doc=False)
 def logcdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
-  x, loc, scale = _promote_args_inexact("norm.logcdf", x, loc, scale)
+  x, loc, scale = promote_args_inexact("norm.logcdf", x, loc, scale)
   # Cast required because custom_jvp return type is broken.
   return cast(Array, special.log_ndtr(lax.div(lax.sub(x, loc), scale)))
 

--- a/jax/_src/scipy/stats/pareto.py
+++ b/jax/_src/scipy/stats/pareto.py
@@ -18,13 +18,13 @@ import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
 @_wraps(osp_stats.pareto.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
-  x, b, loc, scale = _promote_args_inexact("pareto.logpdf", x, b, loc, scale)
+  x, b, loc, scale = promote_args_inexact("pareto.logpdf", x, b, loc, scale)
   one = _lax_const(x, 1)
   scaled_x = lax.div(lax.sub(x, loc), scale)
   normalize_term = lax.log(lax.div(scale, b))

--- a/jax/_src/scipy/stats/poisson.py
+++ b/jax/_src/scipy/stats/poisson.py
@@ -18,14 +18,14 @@ import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 from jax.scipy.special import xlogy, gammaln, gammaincc
 
 
 @_wraps(osp_stats.poisson.logpmf, update_doc=False)
 def logpmf(k: ArrayLike, mu: ArrayLike, loc: ArrayLike = 0) -> Array:
-  k, mu, loc = _promote_args_inexact("poisson.logpmf", k, mu, loc)
+  k, mu, loc = promote_args_inexact("poisson.logpmf", k, mu, loc)
   zero = _lax_const(k, 0)
   x = lax.sub(k, loc)
   log_probs = xlogy(x, mu) - gammaln(x + 1) - mu
@@ -37,7 +37,7 @@ def pmf(k: ArrayLike, mu: ArrayLike, loc: ArrayLike = 0) -> Array:
 
 @_wraps(osp_stats.poisson.cdf, update_doc=False)
 def cdf(k: ArrayLike, mu: ArrayLike, loc: ArrayLike = 0) -> Array:
-  k, mu, loc = _promote_args_inexact("poisson.logpmf", k, mu, loc)
+  k, mu, loc = promote_args_inexact("poisson.logpmf", k, mu, loc)
   zero = _lax_const(k, 0)
   x = lax.sub(k, loc)
   p = gammaincc(jnp.floor(1 + x), mu)

--- a/jax/_src/scipy/stats/t.py
+++ b/jax/_src/scipy/stats/t.py
@@ -18,13 +18,13 @@ import scipy.stats as osp_stats
 
 from jax import lax
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
 @_wraps(osp_stats.t.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
-  x, df, loc, scale = _promote_args_inexact("t.logpdf", x, df, loc, scale)
+  x, df, loc, scale = promote_args_inexact("t.logpdf", x, df, loc, scale)
   two = _lax_const(x, 2)
   scaled_x = lax.div(lax.sub(x, loc), scale)
   df_over_two = lax.div(df, two)

--- a/jax/_src/scipy/stats/truncnorm.py
+++ b/jax/_src/scipy/stats/truncnorm.py
@@ -17,7 +17,7 @@ import scipy.stats as osp_stats
 
 from jax import lax
 import jax.numpy as jnp
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.scipy.stats import norm
 from jax._src.scipy.special import logsumexp, log_ndtr, ndtr
 
@@ -71,7 +71,7 @@ def _log_gauss_mass(a, b):
 
 @_wraps(osp_stats.truncnorm.logpdf, update_doc=False)
 def logpdf(x, a, b, loc=0, scale=1):
-  x, a, b, loc, scale = _promote_args_inexact("truncnorm.logpdf", x, a, b, loc, scale)
+  x, a, b, loc, scale = promote_args_inexact("truncnorm.logpdf", x, a, b, loc, scale)
   val = lax.sub(norm.logpdf(x, loc, scale), _log_gauss_mass(a, b))
 
   x_scaled = lax.div(lax.sub(x, loc), scale)
@@ -87,7 +87,7 @@ def pdf(x, a, b, loc=0, scale=1):
 
 @_wraps(osp_stats.truncnorm.logsf, update_doc=False)
 def logsf(x, a, b, loc=0, scale=1):
-  x, a, b, loc, scale = _promote_args_inexact("truncnorm.logsf", x, a, b, loc, scale)
+  x, a, b, loc, scale = promote_args_inexact("truncnorm.logsf", x, a, b, loc, scale)
   x, a, b = jnp.broadcast_arrays(x, a, b)
   x = lax.div(lax.sub(x, loc), scale)
   logsf = _log_gauss_mass(x, b) - _log_gauss_mass(a, b)
@@ -109,7 +109,7 @@ def sf(x, a, b, loc=0, scale=1):
 
 @_wraps(osp_stats.truncnorm.logcdf, update_doc=False)
 def logcdf(x, a, b, loc=0, scale=1):
-  x, a, b, loc, scale = _promote_args_inexact("truncnorm.logcdf", x, a, b, loc, scale)
+  x, a, b, loc, scale = promote_args_inexact("truncnorm.logcdf", x, a, b, loc, scale)
   x, a, b = jnp.broadcast_arrays(x, a, b)
   x = lax.div(lax.sub(x, loc), scale)
   logcdf = _log_gauss_mass(a, x) - _log_gauss_mass(a, b)

--- a/jax/_src/scipy/stats/uniform.py
+++ b/jax/_src/scipy/stats/uniform.py
@@ -18,12 +18,12 @@ import scipy.stats as osp_stats
 from jax import lax
 from jax.numpy import where, inf, logical_or
 from jax._src.typing import Array, ArrayLike
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 
 
 @_wraps(osp_stats.uniform.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
-  x, loc, scale = _promote_args_inexact("uniform.logpdf", x, loc, scale)
+  x, loc, scale = promote_args_inexact("uniform.logpdf", x, loc, scale)
   log_probs = lax.neg(lax.log(scale))
   return where(logical_or(lax.gt(x, lax.add(loc, scale)),
                           lax.lt(x, loc)),

--- a/jax/_src/scipy/stats/vonmises.py
+++ b/jax/_src/scipy/stats/vonmises.py
@@ -17,12 +17,12 @@ import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import _wraps, _promote_args_inexact
+from jax._src.numpy.util import _wraps, promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 @_wraps(osp_stats.vonmises.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, kappa: ArrayLike) -> Array:
-  x, kappa = _promote_args_inexact('vonmises.logpdf', x, kappa)
+  x, kappa = promote_args_inexact('vonmises.logpdf', x, kappa)
   zero = _lax_const(kappa, 0)
   return jnp.where(lax.gt(kappa, zero), kappa * (jnp.cos(x) - 1) - jnp.log(2 * jnp.pi * lax.bessel_i0e(kappa)), jnp.nan)
 

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -47,7 +47,7 @@ from jax._src.interpreters import pxla
 from jax._src.config import (flags, bool_env, config,
                              raise_persistent_cache_errors,
                              persistent_cache_min_compile_time_secs)
-from jax._src.numpy.util import _promote_dtypes, _promote_dtypes_inexact
+from jax._src.numpy.util import promote_dtypes, promote_dtypes_inexact
 from jax._src.util import unzip2
 from jax._src.public_test_util import (  # noqa: F401
     _assert_numpy_allclose, _check_dtypes_match, _default_tolerance, _dtype, check_close, check_grads,
@@ -827,7 +827,7 @@ def promote_like_jnp(fun, inexact=False):
   tests make an np reference implementation act more like an jnp
   implementation.
   """
-  _promote = _promote_dtypes_inexact if inexact else _promote_dtypes
+  _promote = promote_dtypes_inexact if inexact else promote_dtypes
   def wrapper(*args, **kw):
     flat_args, tree = tree_flatten(args)
     args = tree_unflatten(tree, _promote(*flat_args))

--- a/jax/_src/third_party/numpy/linalg.py
+++ b/jax/_src/third_party/numpy/linalg.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import jax.numpy as jnp
 import jax.numpy.linalg as la
-from jax._src.numpy.util import _check_arraylike, _wraps
+from jax._src.numpy.util import check_arraylike, _wraps
 
 
 def _isEmpty2d(arr):
@@ -41,7 +41,7 @@ def _assert2d(*arrays):
 
 @_wraps(np.linalg.cond)
 def cond(x, p=None):
-  _check_arraylike('jnp.linalg.cond', x)
+  check_arraylike('jnp.linalg.cond', x)
   _assertNoEmpty2d(x)
   if p in (None, 2):
     s = la.svd(x, compute_uv=False)
@@ -64,7 +64,7 @@ def cond(x, p=None):
 
 @_wraps(np.linalg.tensorinv)
 def tensorinv(a, ind=2):
-  _check_arraylike('jnp.linalg.tensorinv', a)
+  check_arraylike('jnp.linalg.tensorinv', a)
   a = jnp.asarray(a)
   oldshape = a.shape
   prod = 1
@@ -81,7 +81,7 @@ def tensorinv(a, ind=2):
 
 @_wraps(np.linalg.tensorsolve)
 def tensorsolve(a, b, axes=None):
-  _check_arraylike('jnp.linalg.tensorsolve', a, b)
+  check_arraylike('jnp.linalg.tensorsolve', a, b)
   a = jnp.asarray(a)
   b = jnp.asarray(b)
   an = a.ndim
@@ -110,7 +110,7 @@ def tensorsolve(a, b, axes=None):
 
 @_wraps(np.linalg.multi_dot)
 def multi_dot(arrays, *, precision=None):
-  _check_arraylike('jnp.linalg.multi_dot', *arrays)
+  check_arraylike('jnp.linalg.multi_dot', *arrays)
   n = len(arrays)
   # optimization only makes sense for len(arrays) > 2
   if n < 2:

--- a/jax/_src/third_party/scipy/betaln.py
+++ b/jax/_src/third_party/scipy/betaln.py
@@ -1,7 +1,7 @@
 from jax import lax
 import jax.numpy as jnp
 from jax._src.typing import Array, ArrayLike
-from jax._src.numpy.util import _promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 
 # Note: for mysterious reasons, annotating this leads to very slow mypy runs.
 # def algdiv(a: ArrayLike, b: ArrayLike) -> Array:
@@ -58,7 +58,7 @@ def betaln(a: ArrayLike, b: ArrayLike) -> Array:
     .. _betaln:
         https://github.com/scipy/scipy/blob/ef2dee592ba8fb900ff2308b9d1c79e4d6a0ad8b/scipy/special/cdflib/betaln.f
     """
-    a, b = _promote_args_inexact("betaln", a, b)
+    a, b = promote_args_inexact("betaln", a, b)
     a, b = jnp.minimum(a, b), jnp.maximum(a, b)
     small_b = lax.lgamma(a) + (lax.lgamma(b) - lax.lgamma(a + b))
     large_b = lax.lgamma(a) + algdiv(a, b)

--- a/jax/_src/third_party/scipy/interpolate.py
+++ b/jax/_src/third_party/scipy/interpolate.py
@@ -4,7 +4,7 @@ import scipy.interpolate as osp_interpolate
 from jax.numpy import (asarray, broadcast_arrays, can_cast,
                        empty, nan, searchsorted, where, zeros)
 from jax._src.tree_util import register_pytree_node
-from jax._src.numpy.util import _check_arraylike, _promote_dtypes_inexact, _wraps
+from jax._src.numpy.util import check_arraylike, promote_dtypes_inexact, _wraps
 
 
 def _ndim_coords_from_arrays(points, ndim=None):
@@ -21,7 +21,7 @@ def _ndim_coords_from_arrays(points, ndim=None):
     for j, item in enumerate(p):
       points = points.at[..., j].set(item)
   else:
-    _check_arraylike("_ndim_coords_from_arrays", points)
+    check_arraylike("_ndim_coords_from_arrays", points)
     points = asarray(points)  # SciPy: asanyarray(points)
     if points.ndim == 1:
       if ndim is None:
@@ -56,15 +56,15 @@ class RegularGridInterpolator:
     if self.bounds_error:
       raise NotImplementedError("`bounds_error` takes no effect under JIT")
 
-    _check_arraylike("RegularGridInterpolator", values)
+    check_arraylike("RegularGridInterpolator", values)
     if len(points) > values.ndim:
       ve = f"there are {len(points)} point arrays, but values has {values.ndim} dimensions"
       raise ValueError(ve)
 
-    values, = _promote_dtypes_inexact(values)
+    values, = promote_dtypes_inexact(values)
 
     if fill_value is not None:
-      _check_arraylike("RegularGridInterpolator", fill_value)
+      check_arraylike("RegularGridInterpolator", fill_value)
       fill_value = asarray(fill_value)
       if not can_cast(fill_value.dtype, values.dtype, casting='same_kind'):
         ve = "fill_value must be either 'None' or of a type compatible with values"
@@ -72,7 +72,7 @@ class RegularGridInterpolator:
     self.fill_value = fill_value
 
     # TODO: assert sanity of `points` similar to SciPy but in a JIT-able way
-    _check_arraylike("RegularGridInterpolator", *points)
+    check_arraylike("RegularGridInterpolator", *points)
     self.grid = tuple(asarray(p) for p in points)
     self.values = values
 

--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -34,7 +34,7 @@ import jax.numpy as jnp
 from jax._src import core
 from jax import custom_derivatives
 from jax import lax
-from jax._src.numpy.util import _promote_dtypes_inexact
+from jax._src.numpy.util import promote_dtypes_inexact
 from jax._src.util import safe_map, safe_zip
 from jax.flatten_util import ravel_pytree
 from jax.tree_util import tree_leaves, tree_map
@@ -76,7 +76,7 @@ def initial_step_size(fun, t0, y0, order, rtol, atol, f0):
   # Algorithm from:
   # E. Hairer, S. P. Norsett G. Wanner,
   # Solving Ordinary Differential Equations I: Nonstiff Problems, Sec. II.4.
-  y0, f0 = _promote_dtypes_inexact(y0, f0)
+  y0, f0 = promote_dtypes_inexact(y0, f0)
   dtype = y0.dtype
 
   scale = atol + jnp.abs(y0) * rtol

--- a/jax/experimental/sparse/coo.py
+++ b/jax/experimental/sparse/coo.py
@@ -34,7 +34,7 @@ from jax._src.interpreters import ad
 from jax._src.lax.lax import _const
 from jax._src.lib.mlir.dialects import hlo
 from jax._src.lib import gpu_sparse
-from jax._src.numpy.util import _promote_dtypes
+from jax._src.numpy.util import promote_dtypes
 from jax._src.typing import Array, ArrayLike, DTypeLike
 import jax.numpy as jnp
 
@@ -156,7 +156,7 @@ class COO(JAXSparse):
     if isinstance(other, JAXSparse):
       raise NotImplementedError("matmul between two sparse objects.")
     other = jnp.asarray(other)
-    data, other = _promote_dtypes(self.data, other)
+    data, other = promote_dtypes(self.data, other)
     self_promoted = COO((data, self.row, self.col), **self._info._asdict())
     if other.ndim == 1:
       return coo_matvec(self_promoted, other)

--- a/jax/experimental/sparse/csr.py
+++ b/jax/experimental/sparse/csr.py
@@ -34,7 +34,7 @@ from jax._src import dispatch
 from jax._src.interpreters import ad
 from jax._src.lax.lax import _const
 from jax._src.lib import gpu_sparse
-from jax._src.numpy.util import _promote_dtypes
+from jax._src.numpy.util import promote_dtypes
 from jax._src.typing import Array, ArrayLike, DTypeLike
 import jax.numpy as jnp
 
@@ -117,7 +117,7 @@ class CSR(JAXSparse):
     if isinstance(other, JAXSparse):
       raise NotImplementedError("matmul between two sparse objects.")
     other = jnp.asarray(other)
-    data, other = _promote_dtypes(self.data, other)
+    data, other = promote_dtypes(self.data, other)
     if other.ndim == 1:
       return _csr_matvec(data, self.indices, self.indptr, other, shape=self.shape)
     elif other.ndim == 2:
@@ -184,7 +184,7 @@ class CSC(JAXSparse):
     if isinstance(other, JAXSparse):
       raise NotImplementedError("matmul between two sparse objects.")
     other = jnp.asarray(other)
-    data, other = _promote_dtypes(self.data, other)
+    data, other = promote_dtypes(self.data, other)
     if other.ndim == 1:
       return _csr_matvec(data, self.indices, self.indptr, other,
                          shape=self.shape[::-1], transpose=True)

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -25,7 +25,7 @@ from jax import lax
 from jax import numpy as jnp
 from jax._src import dtypes
 from jax._src import test_util as jtu
-from jax._src.numpy.util import _promote_dtypes_complex
+from jax._src.numpy.util import promote_dtypes_complex
 
 from jax.config import config
 config.parse_flags_with_absl()
@@ -175,7 +175,7 @@ class FftTest(jtu.JaxTestCase):
       return jax.vmap(linear_func)(jnp.eye(size, size))
 
     def func(x):
-      x, = _promote_dtypes_complex(x)
+      x, = promote_dtypes_complex(x)
       return jnp.fft.irfft(jnp.concatenate([jnp.zeros_like(x, shape=1),
                                             x[:2] + 1j*x[2:]]))
 


### PR DESCRIPTION
These functions only have leading underscores for historical reasons – they used to be exposed in the public `jax.numpy` module. Now that they are behind `jax._src.numpy.util`, they should not have leading underscores, as they are imported in other private modules within JAX.