### PR TITLE
[dynamic-shapes] don't require buf objects have dtype attribute

### DIFF
--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -866,11 +866,13 @@ def _dynamic_array_result_handler(sticky_device, aval, env, buf):
            out_env[d.val] if type(d) is core.OutDBIdx else d
            for d in aval.shape]
   if all(type(d) is int for d in shape) and type(aval.dtype) is not core.bint:
-    aval = core.ShapedArray(tuple(shape), buf.dtype)
+    aval = core.ShapedArray(tuple(shape), aval.dtype)
     return maybe_create_array_from_da(buf, aval, sticky_device)
   else:
     pad_shape = [d.dtype.bound if _is_bint_axis_size(d) else d for d in shape]
-    buf_aval = core.ShapedArray(tuple(pad_shape), buf.dtype, aval.weak_type)
+    buf_dtype = (aval.dtype if not core.is_opaque_dtype(aval.dtype) else
+                 aval.dtype._rules.physical_avals(aval)[0])
+    buf_aval = core.ShapedArray(tuple(pad_shape), buf_dtype, aval.weak_type)
     data = maybe_create_array_from_da(buf, buf_aval, sticky_device)
     return core.DArray(aval.update(shape=tuple(shape)), data)
 

--- a/tests/dynamic_api_test.py
+++ b/tests/dynamic_api_test.py
@@ -666,11 +666,12 @@ class DynamicShapeTest(jtu.JaxTestCase):
 
   @unittest.skipIf(jtu.device_under_test() != 'iree', 'iree test')
   def test_transpose(self):
+    # see also https://github.com/iree-org/iree-jax/issues/57
     @partial(jax.jit, abstracted_axes=({0: 'h', 1: 'w'},))
     def f(x):  # f32[h, w] -> f32[w, h]
       return x.T
 
-    f(np.ones((3, 5), dtype=np.float32))
+    f(np.ones((3, 5), dtype=np.float32))  # doesn't crash
     # TODO: add assertions
 
   @unittest.skipIf(jtu.device_under_test() != 'iree', 'iree test')


### PR DESCRIPTION
Fixes iree-org/iree-jax#57

An alternative fix would've been just to add the dtype attribute to IreeBuffer. But it seems better not to make demands on the underlying runtime objects when we don't need to.

I had to run the test with:

```
JAX_PLATFORM_NAME=iree JAX_ARRAY=0 JAX_JIT_PJIT_API_MERGE=0 python tests/dynamic_api_test.py DynamicShapeTest.test_iree_buffer_doesnt_need_dtype_attribute
```