### PR TITLE
jax.numpy reductions: validate axis for scalar input

### DIFF
--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -657,6 +657,7 @@ def _make_cumulative_reduction(np_reduction: Any, reduction: Callable[..., Array
 
     if axis is None or _isscalar(a):
       a = lax.reshape(a, (np.size(a),))
+    if axis is None:
       axis = 0
 
     a_shape = list(np.shape(a))


### PR DESCRIPTION
Fixes #14625