### PR TITLE
Add Github Actions supported wheel-builds for CPU-only jaxlib on Winx64 

### DIFF
--- a/.github/workflows/wheel_win_x64.yml
+++ b/.github/workflows/wheel_win_x64.yml
@@ -1,0 +1,85 @@
+name: Wheel::Windows::x86_64
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  release:
+    types: [published]
+
+env:
+  DISTUTILS_USE_SDK: 1
+  MSSdk: 1
+
+jobs:
+  win-wheels:
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [windows-2019]
+        arch: [AMD64]
+        pyver: ['3.8', '3.9', '3.10', '3.11']
+    name: ${{ matrix.os }} jaxlib Wheel-builder
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.pyver }}
+          cache: 'pip'
+
+      - name: Build wheels
+        env:
+          BAZEL_VC: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC"
+        run: |
+          python -m pip install -r build/test-requirements.txt
+          "C:\\msys64\\;C:\\msys64\\usr\\bin\\;" >> $env:GITHUB_PATH
+
+          python.exe build\build.py `
+            --noenable_tpu `
+            --noenable_remote_tpu `
+            --noenable_mkl_dnn `
+            --target_cpu_features release `
+            --noenable_plugin_device `
+            --noremote_build `
+            --noenable_cuda `
+            --configure_only
+                    
+          bazel build --jobs=1 --subcommands `
+            --cxxopt="/Zm2000" `
+            --verbose_failures `
+            --jobs=1 `
+            --discard_analysis_cache `
+            --notrack_incremental_state `
+            --nokeep_state_after_build `
+            --experimental_local_memory_estimate="true" `
+            --local_ram_resources=2048 `
+            //jaxlib
+
+          bazel run `
+            --verbose_failures=true `
+            //build:build_wheel -- `
+            --output_path=$(Join-Path -Path (Get-Location) -ChildPath "\tmp") `
+            --cpu="AMD64"
+
+      - name: Run tests
+        env:
+          JAX_ENABLE_CHECKS: true
+          JAX_SKIP_SLOW_TESTS: true
+        run: |
+          python -m pip install -e ${{ github.workspace }}
+          python -m pip install --no-index --find-links ${{ github.workspace }}\dist jaxlib
+          echo "JAX_ENABLE_CHECKS=$JAX_ENABLE_CHECKS"
+          pytest -n auto --tb=short tests examples
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: jaxlib_wheels
+          path: ${{ github.workspace }}\dist\*.whl

--- a/.github/workflows/wheel_win_x64.yml
+++ b/.github/workflows/wheel_win_x64.yml
@@ -41,7 +41,6 @@ jobs:
         run: |
           python -m pip install -r build/test-requirements.txt
           "C:\\msys64\\;C:\\msys64\\usr\\bin\\;" >> $env:GITHUB_PATH
-
           python.exe build\build.py `
             --noenable_tpu `
             --noenable_remote_tpu `
@@ -50,8 +49,7 @@ jobs:
             --noenable_plugin_device `
             --noremote_build `
             --noenable_cuda `
-            --configure_only
-                    
+            --configure_only 
           bazel build --jobs=1 --subcommands `
             --cxxopt="/Zm2000" `
             --verbose_failures `
@@ -62,7 +60,6 @@ jobs:
             --experimental_local_memory_estimate="true" `
             --local_ram_resources=2048 `
             //jaxlib
-
           bazel run `
             --verbose_failures=true `
             //build:build_wheel -- `
@@ -80,6 +77,7 @@ jobs:
           pytest -n auto --tb=short tests examples
 
       - uses: actions/upload-artifact@v2
+        if: ${{ github.event_name == 'release' }}
         with:
           name: jaxlib_wheels
           path: ${{ github.workspace }}\dist\*.whl


### PR DESCRIPTION
**Context:** This PR aims to build CPU-only x64 wheels for Windows platforms. Since the current jaxlib wheel support for Windows is community-oriented with no officially-supported builds, this causes problems for platforms that need a cross-platform way to depend on jax, of which has become a recent issue for us on [PennyLane](https://github.com/PennyLaneAI/pennylane). Our goal to to fully replace autograd (our default AD framework) in PennyLane with jax, and we require officially supported Windows wheels to allow this. This PR follows a recent discussion between Xanadu (@mlxd @trbromley) and the JAX team (@hawkinsp @yashk2810 ) on Xanadu preliminary exploring and adding the support.

**Description of the Change:** This PR adds a Github Actions workflow to make use of the `windows-2019` runner and Visual Studio Enterprise 2019 to build jaxlib wheels, targeting CPU-only execution under Windows. This has been validated on 16GB private instances, though may require additional configuration to ensure memory walls are not hit on the 7GB free instances.

**Benefits:** Adds native support for CPU-only jaxlib under Windows.

**Possible Drawbacks:** Additional maintenance may be required for further development and extensions. May require a larger CI runner to compile end-to-end.