### PR TITLE
explicitly convert jnp.var scalar normalizer to float (from int)

### DIFF
--- a/tests/lax_numpy_reducers_test.py
+++ b/tests/lax_numpy_reducers_test.py
@@ -753,6 +753,20 @@ class JaxNumpyReducerTests(jtu.JaxTestCase):
                             tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker, rtol=tol)
 
+  def testMeanLargeArray(self):
+    # https://github.com/google/jax/issues/15068
+    raise unittest.SkipTest("test is slow, but it passes!")
+    x = jnp.ones((16, 32, 1280, 4096), dtype='int8')
+    self.assertEqual(1.0, jnp.mean(x))
+    self.assertEqual(1.0, jnp.mean(x, where=True))
+
+  def testStdLargeArray(self):
+    # https://github.com/google/jax/issues/15068
+    raise unittest.SkipTest("test is slow, but it passes!")
+    x = jnp.ones((16, 32, 1280, 4096), dtype='int8')
+    self.assertEqual(0.0, jnp.std(x))
+    self.assertEqual(0.0, jnp.std(x, where=True))
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -5027,13 +5027,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     actual = jnp.fromstring(s, sep=',', dtype=int)
     self.assertArraysEqual(expected, actual)
 
-  def testMeanLargeArray(self):
-    # https://github.com/google/jax/issues/15068
-    raise unittest.SkipTest("test is slow, but it passes!")
-    x = jnp.ones((16, 32, 1280, 4096), dtype='int8')
-    self.assertEqual(1.0, jnp.mean(x))
-    self.assertEqual(1.0, jnp.mean(x, where=True))
-
 
 # Most grad tests are at the lax level (see lax_test.py), but we add some here
 # as needed for e.g. particular compound ops of interest.


### PR DESCRIPTION
This way we don't pass a potentially-large (Python builtin) int value to an int32 JAX computation parameter and get an error.

Fixes #15068