### PR TITLE
make mlir arg and result names work with static_argnums/argnames

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -67,7 +67,7 @@ from jax._src.lib import pmap_lib
 from jax._src.lib import xla_extension_version
 from jax._src.sharding_impls import PmapSharding
 from jax._src.traceback_util import api_boundary
-from jax._src.tree_util import broadcast_prefix, _generate_key_paths
+from jax._src.tree_util import broadcast_prefix, generate_key_paths
 from jax._src.util import (unzip2, curry, safe_map, safe_zip, split_list,
                            wrap_name, cache, wraps, HashableFunction,
                            weakref_lru_cache)
@@ -1298,16 +1298,16 @@ def _mapped_axis_size(fn, tree, vals, dims, name):
   if ba is None:
     args_paths = [f'args{keystr(p)} '
                   f'of type {shaped_abstractify(x).str_short()}'
-                  for p, x in _generate_key_paths(args)]
+                  for p, x in generate_key_paths(args)]
     kwargs_paths = [f'kwargs{keystr(p)} '
                     f'of type {shaped_abstractify(x).str_short()}'
-                    for p, x in _generate_key_paths(kwargs)]
+                    for p, x in generate_key_paths(kwargs)]
     key_paths = [*args_paths, *kwargs_paths]
   else:
     key_paths = [f'argument {name}{keystr(p)} '
                  f'of type {shaped_abstractify(x).str_short()}'
                  for name, arg in ba.arguments.items()
-                 for p, x in _generate_key_paths(arg)]
+                 for p, x in generate_key_paths(arg)]
   all_sizes = [_get_axis_size(name, np.shape(x), d) if d is not None else None
                for x, d in zip(vals, dims)]
   size_counts = collections.Counter(s for s in all_sizes if s is not None)

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -667,8 +667,8 @@ def lower_jaxpr_to_module(
     replicated_args: Optional[Sequence[bool]] = None,
     arg_shardings: Optional[Sequence[Optional[xc.OpSharding]]] = None,
     result_shardings: Optional[Sequence[Optional[xc.OpSharding]]] = None,
-    arg_names: Optional[Sequence[str]] = None,
-    result_names: Optional[Sequence[str]] = None,
+    arg_names: Optional[Sequence[Optional[str]]] = None,
+    result_names: Optional[Sequence[Optional[str]]] = None,
 ) -> LoweringResult:
   """Lowers a top-level jaxpr to an MLIR module.
 
@@ -863,8 +863,8 @@ def lower_jaxpr_to_fun(
     input_output_aliases: Optional[Sequence[Optional[int]]] = None,
     num_output_tokens: int = 0,
     api_name: str = 'jit',
-    arg_names: Optional[Sequence[str]] = None,
-    result_names: Optional[Sequence[str]] = None,
+    arg_names: Optional[Sequence[Optional[str]]] = None,
+    result_names: Optional[Sequence[Optional[str]]] = None,
 ) -> func_dialect.FuncOp:
   """Lowers jaxpr and its callees to an IR function.
 
@@ -987,8 +987,8 @@ def lower_jaxpr_to_fun(
 
     if arg_names:
       named_arg_attrs = arg_attrs[num_dim_vars + num_tokens:]
-      if len(named_arg_attrs) == len(arg_names):
-        for attrs, name_ in zip(named_arg_attrs, arg_names):
+      for attrs, name_ in zip(named_arg_attrs, arg_names):
+        if name_:
           attrs['jax.arg_info'] = ir.StringAttr.get(name_)
 
     func_op.arg_attrs = ir.ArrayAttr.get(
@@ -1007,13 +1007,6 @@ def lower_jaxpr_to_fun(
     for attrs, sharding in zip(result_attrs, ir_result_shardings):
       if sharding is not None:
         attrs['mhlo.sharding'] = get_sharding_attr(sharding)
-
-    # func_op.result_attrs = ir.ArrayAttr.get([
-    #         ir.DictAttr.get(
-    #         {} if sharding is None else
-    #         {"mhlo.sharding": get_sharding_attr(sharding)}
-    #     ) for sharding in ir_result_shardings
-    # ])
 
   func_op.result_attrs = ir.ArrayAttr.get(
       [ir.DictAttr.get(attrs) for attrs in result_attrs])

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -14,7 +14,6 @@
 
 import functools
 from functools import partial
-import inspect
 import itertools as it
 import logging
 import operator
@@ -577,15 +576,3 @@ else:
           "Decorator got wrong type: @use_cpp_method(is_enabled: bool=True)"
       )
     return decorator
-
-
-def fun_sourceinfo(fun: Callable) -> Optional[str]:
-  while isinstance(fun, partial):
-    fun = fun.func
-  fun = inspect.unwrap(fun)
-  try:
-    filename = fun.__code__.co_filename
-    lineno = fun.__code__.co_firstlineno
-    return f"{fun.__name__} at {filename}:{lineno}"
-  except AttributeError:
-    return None

--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -52,7 +52,7 @@ from jax.interpreters import ad
 from jax.tree_util import (tree_map, tree_flatten, tree_unflatten,
                            tree_structure, tree_leaves, keystr)
 from jax._src.tree_util import (broadcast_prefix, prefix_errors, PyTreeDef,
-                                _generate_key_paths, KeyPath)
+                                generate_key_paths, KeyPath)
 
 P = PartitionSpec
 
@@ -133,7 +133,7 @@ def _check_specs(error_type: SpecErrorType, specs: Any) -> None:
   if all(isinstance(p, PartitionSpec) for p in tree_leaves(specs)): return
   prefix = 'in' if error_type == SpecErrorType.input else 'out'
   msgs = [f"  {prefix}_specs{keystr(key)} is {x} of type {type(x).__name__}, "
-          for key, x in _generate_key_paths(specs) if not isinstance(x, P)]
+          for key, x in generate_key_paths(specs) if not isinstance(x, P)]
   raise TypeError(
       f"shard_map {prefix}_specs argument must be a pytree of "
       f"`jax.sharding.PartitionSpec` instances, but:\n\n"
@@ -276,8 +276,8 @@ T = TypeVar('T')
 def _iter_paths(tree: PyTreeDef, specs: Specs, fails: List[Union[T, NoFail]]
                 ) -> List[Tuple[Tuple[KeyPath, P], Tuple[KeyPath, T]]]:
   failures = tree_unflatten(tree, fails)
-  failures_aug = _generate_key_paths(failures)
-  specs_ = tree_unflatten(tree_structure(specs), _generate_key_paths(specs))
+  failures_aug = generate_key_paths(failures)
+  specs_ = tree_unflatten(tree_structure(specs), generate_key_paths(specs))
   leaf = lambda x: type(x) is tuple and len(x) == 2 and type(x[1]) is P
   specs_aug = broadcast_prefix(specs_, failures, is_leaf=leaf)
   return [((spec_key, spec), (fail_key, fail_data))

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -2036,6 +2036,7 @@ class PythonPmapTest(jtu.JaxTestCase):
     self.assertEqual(jaxpr_text.count(' cos '), 2)
 
   def test_pmap_lower_arg_info(self):
+    raise SkipTest("arg info not plumbed to pmap yet")  # TODO(mattjj)
     def f(x, y, *args, **kwargs):
       return y['hi'] + args[1] + sum(kwargs.values())
 
@@ -2051,6 +2052,7 @@ class PythonPmapTest(jtu.JaxTestCase):
     self.assertIn("kwargs['w']", mhlo_str)
 
   def test_pmap_lower_result_info(self):
+    raise SkipTest("arg info not plumbed to pmap yet")  # TODO(mattjj)
     def f(x, y, z):
       return {'a': x, 'b': [y]}
 


### PR DESCRIPTION
This is the first step in a revision to how we handle the debug info pertaining to staged functions' parameter names and result pytree paths. To limit complexity, this first step adds machinery required to make our MLIR lowerings' parameter and result names work, but it does *not* yet unify it with existing arg-name machinery used at tracing time (in partial_eval.py, e.g. `partial_eval.DebugInfo` etc). That unification will come in a follow up commits. (I wrote the unified version first, then broke it down into this sequence of commits.)

Another thing that will arrive in follow-up commits is `pmap` support (handling `static_broadcasted_argnums`). This PR doesn't include support for `pmap` because `pmap`'s final style implementation requires slightly different machinery than jit/pjit's initial style implementation. Indeed this PR removes the previous support for `pmap` arg/result info, and skips the corresponding tests, because the previous support didn't handle `pmap`'s `static_broadcasted_argnums` (and I think it could even lead to silently incorrect annotations when `pmap` was not at the top-level, though I didn't work out an example case to be sure that was possible).

~This commit includes the changes from PR #15071, so that PR should be merged first.~

Here's the _why_ of this change:
* The pre-existing solution (from PRs #14702, #14764, and #14813) did not handle static_argnums or static_argnames correctly. Instead it would fail, resulting in debug info being dropped from the jaxpr and ultimately the MLIR computation (but no Exception raised). We need to handle static_argnums/argnames because while the corresponding parameters remain on the Python callable signature, they are excluded from the args/kwargs pytrees; the previous solution didn't account for that divergence.
* The best way to handle static_argnums/argnames is to work out this debug info when we still have the original args/kwargs in hand, i.e. much earlier than the previous mechanism. We then just have to pass this debug info to the right places. Indeed we often already had to work out some debug-related information at these call sites (e.g. whether the function is being staged out for jit, or scan, or whatever), so after this change we're working out all the debug info at the same time.
* A side benefit is that now to get this debug info we no longer need to unflatten user pytree defs with dummy objects (to reconstruct dummy args/kwargs trees so that we can call inspect.signature(fun).bind), since we just use the original args/kwargs instead. Since some user pytree node types are not fully polymorphic in their element types (e.g. their __init__ methods sometimes contained assertions about their elements' shapes, expecting them to be arrays), that means the new mechanism is fundamentally more compatible with custom pytree node types.

More concretely, effecting those high-level changes led to:
* replacing the previous `core.DebugInfo` with a class `core.JaxprDebugInfo`, which in addition to the more precise name has fields like `arg_names: Tuple[Optional[str], ...]` and `result_paths: Tuple[Optional[str], ...]`, rather than `in_tree: Optional[PyTreeDef]`, reflecting the fact that we work out the actual debug info more eagerly than before and we don't need pytrees for dummy-unflattening;
* introducing the new `api_util.TracingDebugInfo` class representing the debug info about inputs which we have available at tracing time; in a follow-up PR, we'll adapt partial_eval.py to use this new class and we'll delete `partial_eval.DebugInfo` and its corresponding helper methods (not done in this commit just to reduce complexity of each change);
* moving the old `core.DebugInfo`, which before #14702 lived in partial_eval.py, back to partial_eval.py pending cleanup (deletion) of that partial_eval.py debug info code;
* making specific jaxpr-processing functions produce an appropriately updated `core.JaxprDebugInfo` object for their output (e.g. `pe.dce_jaxpr` prunes elements from the `arg_names` field), maintaining now-checked invariants like a Jaxpr's `debug_info` should have the same number of argument names as the jaxpr has invars (the jaxpr-processing functions updated here are enough for top-level jit jaxprs to have debug info attached, handling the original intended use case of jit(f).lower, but not e.g. grad-of-jit cases, which can be handled later by updating `ad.jvp_jaxpr` and the like to produce updated debug info on their outputs);
* add some tests for static_argnums/static_argnames.

Follow-ups:
* [x] restore pmap support for arg/result info #15085
* [ ] replace partial_eval.py's trace-time `pe.DebugInfo` machinery with the new `api_util.TracingDebugInfo` stuff
* [ ] produce updated jaxpr debug info on more jaxpr-to-jaxpr functions (needed when the jaxpr-staging function is not at the top level)