### PR TITLE
make mlir arg and result names work with pmap

### DIFF
--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -1340,6 +1340,7 @@ def stage_parallel_callable(
                                    event=dispatch.JAXPR_TRACE_EVENT):
       jaxpr, out_sharded_avals, consts = pe.trace_to_jaxpr_final(
           fun, global_sharded_avals, pe.debug_info_final(fun, "pmap"))
+  jaxpr = api_util.jaxpr_debug_info(jaxpr, fun.debug_info)
   jaxpr = dispatch.apply_outfeed_rewriter(jaxpr)
 
   assert len(out_sharded_avals) == len(pci.out_axes), (
@@ -1488,7 +1489,6 @@ def lower_parallel_callable(
       raise ValueError("Ordered effects not supported in `pmap`.")
     unordered_effects = list(
         effects.ordered_effects.filter_not_in(closed_jaxpr.effects))
-    arg_names, result_names = _debug_names(jaxpr.debug_info)
     lowering_result = mlir.lower_jaxpr_to_module(
         module_name,
         closed_jaxpr,
@@ -1502,7 +1502,8 @@ def lower_parallel_callable(
         replicated_args=replicated_args,
         arg_shardings=_shardings_to_mlir_shardings(parts.arg_parts),
         result_shardings=_shardings_to_mlir_shardings(parts.out_parts),
-        arg_names=arg_names, result_names=result_names)
+        arg_names=jaxpr.debug_info and jaxpr.debug_info.arg_names,
+        result_names=jaxpr.debug_info and jaxpr.debug_info.result_paths)
     module, keepalive, host_callbacks = (
         lowering_result.module, lowering_result.keepalive,
         lowering_result.host_callbacks)
@@ -2788,7 +2789,6 @@ def lower_sharding_computation(
   unordered_effects = list(
       effects.ordered_effects.filter_not_in(closed_jaxpr.effects))
   ordered_effects = list(effects.ordered_effects.filter_in(closed_jaxpr.effects))
-  arg_names, result_names = _debug_names(jaxpr.debug_info)
   lowering_result = mlir.lower_jaxpr_to_module(
       module_name,
       closed_jaxpr,
@@ -2803,7 +2803,8 @@ def lower_sharding_computation(
       replicated_args=replicated_args,
       arg_shardings=in_op_shardings,
       result_shardings=out_op_shardings,
-      arg_names=arg_names, result_names=result_names)
+      arg_names=jaxpr.debug_info and jaxpr.debug_info.arg_names,
+      result_names=jaxpr.debug_info and jaxpr.debug_info.result_paths)
 
   module, keepalive, host_callbacks = (
       lowering_result.module, lowering_result.keepalive,
@@ -2974,7 +2975,6 @@ def lower_mesh_computation(
       closed_jaxpr.effects))
     ordered_effects = list(effects.ordered_effects.filter_in(
       closed_jaxpr.effects))
-    arg_names, result_names = _debug_names(jaxpr.debug_info)
     lowering_result = mlir.lower_jaxpr_to_module(
         module_name,
         closed_jaxpr,
@@ -2988,8 +2988,8 @@ def lower_mesh_computation(
         replicated_args=replicated_args,
         arg_shardings=in_partitions,
         result_shardings=out_partitions,
-        arg_names=arg_names,
-        result_names=result_names)
+        arg_names=jaxpr.debug_info and jaxpr.debug_info.arg_names,
+        result_names=jaxpr.debug_info and jaxpr.debug_info.result_paths)
     module, keepalive, host_callbacks = (
         lowering_result.module, lowering_result.keepalive,
         lowering_result.host_callbacks)
@@ -3014,12 +3014,6 @@ def lower_mesh_computation(
       backend=backend,
       device_assignment=list(mesh.devices.flat),
       committed=True)
-
-def _debug_names(
-    dbg: Optional[core.JaxprDebugInfo]
-) -> Union[Tuple[None, None],
-           Tuple[Sequence[Optional[str]], Sequence[Optional[str]]]]:
-  return (None, None) if dbg is None else (dbg.arg_names, dbg.result_paths)
 
 class MeshComputation(stages.XlaLowering):
   _hlo: Optional[ir.Module]

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -2036,7 +2036,6 @@ class PythonPmapTest(jtu.JaxTestCase):
     self.assertEqual(jaxpr_text.count(' cos '), 2)
 
   def test_pmap_lower_arg_info(self):
-    raise SkipTest("arg info not plumbed to pmap yet")  # TODO(mattjj)
     def f(x, y, *args, **kwargs):
       return y['hi'] + args[1] + sum(kwargs.values())
 
@@ -2052,7 +2051,6 @@ class PythonPmapTest(jtu.JaxTestCase):
     self.assertIn("kwargs['w']", mhlo_str)
 
   def test_pmap_lower_result_info(self):
-    raise SkipTest("arg info not plumbed to pmap yet")  # TODO(mattjj)
     def f(x, y, z):
       return {'a': x, 'b': [y]}
 


### PR DESCRIPTION
~**This PR includes the commit from #15080, i.e. that's its diffbase, so ignore this one until that one goes in!**~

This is a follow-up on #15080 to restore (and indeed fix!) how pmap builds a jaxpr with debug info (i.e. parameter names and result paths). The difference with the machinery in #15080 is just to deal with pmap being final-style (i.e.     build the jaxpr at the last second, well after pytrees have been flattened away and transformations have been applied), whereas pjit is initial style (i.e. build the jaxpr as soon as possible, so all the relevant debug information is still present). As you might imagine, plumbing for the former is a bit more long-range and subtle.

The main idea here is that we need to annotate and maintain debug info on the `lu.WrappedFun` instance, which we first form at the api.py level, then pass through transformations (which can either update or drop debug info), then finally   hand off to the impl rule to be traced to a jaxpr. It makes sense as an annotation, parallel with the `in_type` annotation on `lu.WrappedFun`s used for dynamic shapes, because the debug info has to be determined initially early on (at the api.py level) updated incrementally as transformations are applied, as they might e.g. add tangent inputs and outputs.

In more detail: with an initial-style higher-orer primitive (like pjit), a jaxpr is formed immediately. Transformations, like autodiff, are jaxpr-to-jaxpr, and so those transformations (like ad.jvp_jaxpr) need to return a new jaxpr       either with updated debug info or no debug info at all. (The initial implementation in #15080 doesn't provide updated debug info in any of those jaxpr-to-jaxpr transformation functions, so the debug info is only applied to the jaxpr and  then lowered to MLIR when the pjit as at the top level.)

For final-style, like pmap here, instead of transformations being jaxpr-to-jaxpr, they're WrappedFun-to-WrappedFun. And so, analogously, transformations, like ad.JVPTrace.process_map, would need to produce a WrappedFun with updated debug info or no debug info at all. (Also analogously to #15080, this PR only implements enough for the debug info to be preserved for top-level pmaps, and preserving debug info through transformations is left as follow-up work.)

This PR doesn't yet delete the trace-time debug info in partial_eval.py. But that'll happen next!