### PR TITLE
`custom_vjp` symbolic zeros support

### DIFF
--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -915,7 +915,8 @@ def custom_jvp_call_rule(in_err, enabled_errors, *in_vals, num_consts,
 error_checks[custom_derivatives.custom_jvp_call_p] = custom_jvp_call_rule
 
 def custom_vjp_call_jaxpr_rule(in_err, enabled_errors, *in_vals, fun_jaxpr,
-                               fwd_jaxpr_thunk, num_consts, bwd, out_trees):
+                               fwd_jaxpr_thunk, num_consts, bwd, out_trees,
+                               symbolic_zeros):
   err_vals, err_tree = jtu.tree_flatten(in_err)
   fun = lu.wrap_init(
       functools.partial(checkify_jaxpr_flat, fun_jaxpr.jaxpr,
@@ -923,15 +924,17 @@ def custom_vjp_call_jaxpr_rule(in_err, enabled_errors, *in_vals, fun_jaxpr,
   fun, fun_metadata = _flatten_and_get_error_metadata_thunk(fun)
 
   @lu.wrap_init
-  def fwd(*xs):
+  def fwd(*args):
     # TODO(lenamartens, sharadmv): why not checkify here?
-    fwd_jaxpr, fwd_consts = fwd_jaxpr_thunk()
+    xs, zeros = args[::2], args[1::2]
+    fwd_jaxpr, fwd_consts = fwd_jaxpr_thunk(*zeros)
     xs_without_consts = xs[num_consts:]
     return core.eval_jaxpr(fwd_jaxpr, fwd_consts, *xs_without_consts)
 
   fwd, fwd_out_tree = flatten_fun_output(fwd)
   all_outs = custom_derivatives.custom_vjp_call_p.bind(
-      fun, fwd, bwd, *err_vals, *in_vals, out_trees=out_trees)
+      fun, fwd, bwd, *err_vals, *in_vals, out_trees=out_trees,
+      symbolic_zeros=symbolic_zeros)
   fst, out_metadata = lu.merge_linear_aux(fun_metadata, fwd_out_tree)
   if fst:
     err_and_out_tree, _ = out_metadata

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -511,7 +511,8 @@ class Trace(Generic[TracerType]):
            "to handle custom_transpose_call primitives")
     raise NotImplementedError(msg)
 
-  def process_custom_vjp_call(self, primitive, fun, fwd, bwd, tracers, out_trees):
+  def process_custom_vjp_call(self, primitive, fun, fwd, bwd, tracers,
+                              out_trees, symbolic_zeros):
     msg = (f"{type(self)} must override process_custom_vjp_call "
            "to handle custom_vjp primitives")
     raise NotImplementedError(msg)

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 from functools import update_wrapper, reduce, partial
 import inspect
 from typing import (Callable, Generic, List, Optional, Sequence, Tuple, TypeVar, Any)
@@ -31,8 +32,8 @@ from jax._src import dtypes
 from jax._src import effects
 from jax._src import linear_util as lu
 from jax._src import traceback_util
-from jax._src.ad_util import (Zero, SymbolicZero, zeros_like_aval,
-                              stop_gradient_p)
+from jax._src.ad_util import (
+    stop_gradient_p, SymbolicZero, Zero, zeros_like_aval)
 from jax._src.api_util import argnums_partial, flatten_fun_nokwargs
 from jax._src.core import raise_to_shaped
 from jax._src.interpreters import ad
@@ -163,12 +164,13 @@ class custom_jvp(Generic[ReturnValue]):
         and the second element is the tangent output. Elements of the input and
         output tuples may be arrays or any nested tuples/lists/dicts thereof.
       symbolic_zeros: boolean, indicating whether the rule should be passed
-        objects representing static symbolic zeros in its tangent tuple
-        argument; otherwise, only standard JAX types (e.g. array-likes) are
-        passed. Setting this option to True allows a JVP rule to detect whether
-        certain inputs are not involved in differentiation, but at the cost of
-        needing special handling for these objects (which e.g. can't be passed
-        into jax.numpy functions). Default False.
+        objects representing static symbolic zeros in its tangent argument in
+        correspondence with unperturbed values; otherwise, only standard JAX
+        types (e.g. array-likes) are passed. Setting this option to ``True``
+        allows a JVP rule to detect whether certain inputs are not involved in
+        differentiation, but at the cost of needing special handling for these
+        objects (which e.g. can't be passed into jax.numpy functions). Default
+        ``False``.
 
     Returns:
       None.
@@ -480,12 +482,15 @@ class custom_vjp(Generic[ReturnValue]):
     self.nondiff_argnums = nondiff_argnums
     self.fwd: Optional[Callable[..., Tuple[ReturnValue, Any]]] = None
     self.bwd: Optional[Callable[..., Tuple[Any, ...]]] = None
+    self.symbolic_zeros = False
 
   __getattr__ = custom_api_util.forward_attr
 
   def defvjp(self,
              fwd: Callable[..., Tuple[ReturnValue, Any]],
-             bwd: Callable[..., Tuple[Any, ...]]) -> None:
+             bwd: Callable[..., Tuple[Any, ...]],
+             symbolic_zeros: bool = False,
+             ) -> None:
     """Define a custom VJP rule for the function represented by this instance.
 
     Args:
@@ -506,6 +511,27 @@ class custom_vjp(Generic[ReturnValue]):
         function, and the tuple elements may be arrays or nested
         tuples/lists/dicts thereof so as to match the structure of the primal
         input arguments.
+      symbolic_zeros: boolean, indicating whether to indicate symbolic zeros in
+        the ``fwd`` and ``bwd`` rules. Setting this option to ``True`` allows
+        custom derivative rules to detect when certain inputs, and when certain
+        cotangent outputs, are not involved in differentiation. If ``True``:
+
+        * ``fwd`` must accept, for each leaf value ``x`` in the pytree
+          comprising an argument to the original function, a pair ``(x, zero)``,
+          where ``x`` is the original argument and ``zero`` is a boolean. The
+          ``zero`` part indicates whether or not the argument is not involved in
+          differentiation (i.e., whether the corresponding Jacobian "column" is
+          zero).
+
+        * ``bwd`` will be passed objects representing static symbolic zeros in
+          its cotangent argument in correspondence with unperturbed values;
+          otherwise, only standard JAX types (e.g. array-likes) are passed.
+
+        Setting this option to ``True`` allows these rules to detect whether
+        certain inputs and outputs are not involved in differentiation, but at
+        the cost of special handling: the signature of ``fwd`` changes, and
+        ``bwd`` receives objects that, for instance, cannot be passed to
+        ``jax.numpy`` functions. Default ``False``.
 
     Returns:
       None.
@@ -527,6 +553,7 @@ class custom_vjp(Generic[ReturnValue]):
     """
     self.fwd = fwd
     self.bwd = bwd
+    self.symbolic_zeros = symbolic_zeros
 
   @traceback_util.api_boundary
   def __call__(self, *args: Any, **kwargs: Any) -> ReturnValue:  # pytype: disable=invalid-annotation
@@ -534,7 +561,7 @@ class custom_vjp(Generic[ReturnValue]):
     if not self.fwd or not self.bwd:
       msg = f"No VJP defined for custom_vjp function {primal_name} using defvjp."
       raise AttributeError(msg)
-    fwd_name    = getattr(self.fwd, '__name__', str(self.fwd))
+    fwd_name = getattr(self.fwd, '__name__', str(self.fwd))
     args = _resolve_kwargs(self.fun, args, kwargs)
     if config.jax_enable_custom_vjp_by_custom_transpose:
       if self.nondiff_argnums:
@@ -555,6 +582,7 @@ class custom_vjp(Generic[ReturnValue]):
       else:
         f_, dyn_args = lu.wrap_init(self.fun), args
         fwd, bwd = lu.wrap_init(self.fwd), lu.wrap_init(self.bwd)
+      fwd = _project_fwd(fwd, self.symbolic_zeros)
       args_flat, in_tree = tree_flatten(dyn_args)
       in_avals = [core.raise_to_shaped(core.get_aval(x)) for x in args_flat]
       flat_fun, out_type = _flatten_fun_nokwargs(f_, in_tree)
@@ -562,9 +590,21 @@ class custom_vjp(Generic[ReturnValue]):
                                          out_type)
       flat_bwd = _flatten_bwd(bwd, in_tree, in_avals, out_trees).call_wrapped
       out_flat = custom_vjp_call_p.bind(flat_fun, flat_fwd, flat_bwd,
-                                        *args_flat, out_trees=out_trees)
+                                        *args_flat, out_trees=out_trees,
+                                        symbolic_zeros=self.symbolic_zeros)
       _, (out_tree, _) = lu.merge_linear_aux(out_type, out_trees)
       return tree_unflatten(out_tree, out_flat)
+
+@dataclasses.dataclass
+class ZeroTagged:
+  val: Any
+  zero: bool
+
+@lu.transformation
+def _project_fwd(symbolic_zeros, *args, **kwargs):
+  project_leaf = ((lambda x: (x.val, x.zero)) if symbolic_zeros else
+                  (lambda x:  x.val))
+  yield (yield tree_map(project_leaf, (args, kwargs)))
 
 def _check_for_tracers(x):
   for leaf in tree_leaves(x):
@@ -579,8 +619,10 @@ def _check_for_tracers(x):
       raise UnexpectedTracerError(msg)
 
 @lu.transformation_with_aux
-def _flatten_fwd(primal_name, fwd_name, in_tree, maybe_out_type, *args):
-  py_args = tree_unflatten(in_tree, args)
+def _flatten_fwd(primal_name, fwd_name, in_tree, maybe_out_type,
+                 *args):
+  tagged_args = [ZeroTagged(x, z) for x, z in zip(args[::2], args[1::2])]
+  py_args = tree_unflatten(in_tree, tagged_args)
   pair_out = yield py_args, {}
   if not isinstance(pair_out, (list, tuple)) or len(pair_out) != 2:
     msg = (f"Custom VJP fwd rule {fwd_name} for function {primal_name} "
@@ -672,7 +714,7 @@ def _flatten_bwd(in_tree, in_avals, out_trees, *args):
 class CustomVJPCallPrimitive(core.CallPrimitive):
   initial_style: core.Primitive
 
-  def bind(self, fun, fwd, bwd, *args, out_trees):
+  def bind(self, fun, fwd, bwd, *args, out_trees, symbolic_zeros):
     args = map(core.full_lower, args)
     top_trace = core.find_top_trace(args)
     fun, env_trace_todo1 = process_env_traces(
@@ -682,7 +724,8 @@ class CustomVJPCallPrimitive(core.CallPrimitive):
     tracers = map(top_trace.full_raise, args)  # type: ignore
     bwd_ = lambda *args: bwd(*args)
     outs = top_trace.process_custom_vjp_call(self, fun, fwd, bwd_, tracers,
-                                             out_trees=out_trees)
+                                             out_trees=out_trees,
+                                             symbolic_zeros=symbolic_zeros)
     fst, env_trace_todo = lu.merge_linear_aux(env_trace_todo1, env_trace_todo2)
     if fst:
       return core.apply_todos(env_trace_todo, map(core.full_lower, outs))
@@ -748,31 +791,34 @@ mlir.register_lowering(custom_vjp_call_jaxpr_p, mlir.lower_fun(
 
 def _custom_vjp_call_jaxpr_jvp(
     primals, tangents, *, fun_jaxpr: core.ClosedJaxpr,
-    fwd_jaxpr_thunk: Callable[[], Tuple[core.Jaxpr, Sequence[Any]]],
-    bwd: Callable, out_trees: Callable, num_consts: int):
+    fwd_jaxpr_thunk: Callable[..., Tuple[core.Jaxpr, Sequence[Any]]],
+    num_consts: int, bwd: Callable, out_trees: Callable, symbolic_zeros: bool):
   _, args = split_list(primals, [num_consts])
   consts_dot, args_dot = split_list(tangents, [num_consts])
   if any(type(t) is not Zero for t in consts_dot):
     raise ad.CustomVJPException()
-  fwd_jaxpr, fwd_consts = fwd_jaxpr_thunk()  # consts can be tracers!
+  zeros = [type(t) is Zero for t in args_dot]
+  fwd_jaxpr, fwd_consts = fwd_jaxpr_thunk(*zeros)  # consts can be tracers!
   out_tree, res_tree = out_trees()
+  res_and_primals_out = core.eval_jaxpr(fwd_jaxpr, fwd_consts, *args)
+  res, primals_out = split_list(res_and_primals_out, [res_tree.num_leaves])
+  avals_out = [raise_to_shaped(core.get_aval(x)) for x in primals_out]
   args_dot = map(ad.instantiate_zeros, args_dot)
   # Cast float0 to zeros with the primal dtype because custom vjp rules don't
   # currently handle float0s
   args_dot = map(ad.replace_float0s, args, args_dot)
-  res_and_primals_out = core.eval_jaxpr(fwd_jaxpr, fwd_consts, *args)
-  res, primals_out = split_list(res_and_primals_out, [res_tree.num_leaves])
-  avals_out = [raise_to_shaped(core.get_aval(x)) for x in primals_out]
   tangents_out = ad.custom_lin_p.bind(
-      *res, *args_dot, num_res=res_tree.num_leaves, bwd=bwd, out_avals=avals_out)
+      *res, *args_dot, num_res=res_tree.num_leaves, bwd=bwd,
+      out_avals=avals_out, symbolic_zeros=symbolic_zeros)
   tangents_out = map(ad.recast_to_float0, primals_out, tangents_out)
   return primals_out, tangents_out
 ad.primitive_jvps[custom_vjp_call_jaxpr_p] = _custom_vjp_call_jaxpr_jvp
 
-def _custom_vjp_call_jaxpr_vmap(spmd_axis_name,
-    axis_size, axis_name, main_type, args, in_dims, *, fun_jaxpr: core.ClosedJaxpr,
-    fwd_jaxpr_thunk: Callable[[], Tuple[core.Jaxpr, Sequence[Any]]],
-    bwd: Callable, out_trees: Callable, num_consts: int):
+def _custom_vjp_call_jaxpr_vmap(
+    spmd_axis_name, axis_size, axis_name, main_type, args, in_dims, *,
+    fun_jaxpr: core.ClosedJaxpr,
+    fwd_jaxpr_thunk: Callable[..., Tuple[core.Jaxpr, Sequence[Any]]],
+    num_consts: int, bwd: Callable, out_trees: Callable, symbolic_zeros: bool):
   args = [batching.moveaxis(x, d, 0) if d is not not_mapped and d != 0
           else x for x, d in zip(args, in_dims)]
 
@@ -785,8 +831,8 @@ def _custom_vjp_call_jaxpr_vmap(spmd_axis_name,
   out_dims2 = []
 
   @pe._memoize
-  def batched_fwd_jaxpr_thunk():
-    fwd_jaxpr = core.ClosedJaxpr(*fwd_jaxpr_thunk())  # consts can be tracers
+  def batched_fwd_jaxpr_thunk(*zeros):
+    fwd_jaxpr = core.ClosedJaxpr(*fwd_jaxpr_thunk(*zeros))  # consts can be tracers
     batched_fwd_jaxpr, out_batched = batching.batch_jaxpr(
         fwd_jaxpr, axis_size, args_batched, False, axis_name, spmd_axis_name,
         main_type)
@@ -795,17 +841,20 @@ def _custom_vjp_call_jaxpr_vmap(spmd_axis_name,
 
   fwd_args_batched = [0 if b else not_mapped for b in args_batched]
   fwd_out_dims = lambda: out_dims2[0]
-  batched_bwd = batching.batch_custom_vjp_bwd(bwd, axis_name, axis_size, fwd_out_dims,
-                                              fwd_args_batched, main_type, spmd_axis_name)
+  batched_bwd = batching.batch_custom_vjp_bwd(
+      bwd, axis_name, axis_size, fwd_out_dims, fwd_args_batched, main_type,
+      spmd_axis_name)
 
   batched_outs = custom_vjp_call_jaxpr_p.bind(
       *args, fun_jaxpr=batched_fun_jaxpr,
       fwd_jaxpr_thunk=batched_fwd_jaxpr_thunk, bwd=batched_bwd,
-      out_trees=out_trees, num_consts=num_consts)
+      num_consts=num_consts, out_trees=out_trees, symbolic_zeros=symbolic_zeros)
   out_dims = out_dims2[0] if out_dims2 else out_dims1
   return batched_outs, out_dims
-batching.spmd_axis_primitive_batchers[custom_vjp_call_jaxpr_p] = _custom_vjp_call_jaxpr_vmap
-batching.axis_primitive_batchers[custom_vjp_call_jaxpr_p] = partial(_custom_vjp_call_jaxpr_vmap, None)
+batching.spmd_axis_primitive_batchers[custom_vjp_call_jaxpr_p] = \
+    _custom_vjp_call_jaxpr_vmap
+batching.axis_primitive_batchers[custom_vjp_call_jaxpr_p] = partial(
+    _custom_vjp_call_jaxpr_vmap, None)
 
 xla.register_initial_style_primitive(custom_vjp_call_jaxpr_p)
 

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -27,9 +27,9 @@ from jax.tree_util import (tree_flatten, tree_unflatten,
 from jax._src import core
 from jax._src import source_info_util
 from jax._src.ad_util import (
-    add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_aval,
-    zeros_like_p, Zero, replace_internal_symbolic_zeros,
-    replace_rule_output_symbolic_zeros)
+    add_jaxvals, add_jaxvals_p, replace_internal_symbolic_zeros,
+    replace_rule_output_symbolic_zeros, Zero, zeros_like_aval,
+    zeros_like_jaxval, zeros_like_p)
 from jax._src.api_util import flatten_fun, flatten_fun_nokwargs
 from jax._src.core import (Trace, Tracer, get_aval, call_p, Primitive, Literal,
                            raise_to_shaped)
@@ -387,16 +387,24 @@ class JVPTrace(Trace):
   def post_process_custom_jvp_call(self, out_tracers, _):
     raise CustomJVPException()
 
-  def process_custom_vjp_call(self, _, __, fwd, bwd, tracers, out_trees):
+  def process_custom_vjp_call(self, _, __, fwd, bwd, tracers, out_trees,
+                              symbolic_zeros):
     primals_in, tangents_in = unzip2((t.primal, t.tangent) for t in tracers)
-    tangents_in = map(instantiate_zeros, tangents_in)
-    res_and_primals_out = fwd.call_wrapped(*map(core.full_lower, primals_in))
+    fwd_in = [(core.full_lower(p), type(t) is Zero)
+              for p, t in zip(primals_in, tangents_in)]
+    fwd_in = [x for pair in fwd_in for x in pair]   # flatten
+    res_and_primals_out = fwd.call_wrapped(*fwd_in)
     out_tree, res_tree = out_trees()
     res, primals_out = split_list(res_and_primals_out, [res_tree.num_leaves])
     avals_out = [raise_to_shaped(core.get_aval(x)) for x in primals_out]
+    # We don't need to handle any symbolic zeros on tangents_in or
+    # tangents_out below, because custom_lin_p is never executed and
+    # doesn't correspond to any custom user rule.
+    # TODO(frostig,mattjj): avoid instantiating zeros when we don't have to!
+    tangents_in = map(instantiate_zeros, tangents_in)
     tangents_out = custom_lin_p.bind(
         *res, *tangents_in, num_res=res_tree.num_leaves, bwd=bwd,
-        out_avals=avals_out)
+        out_avals=avals_out, symbolic_zeros=symbolic_zeros)
     tangents_out = map(recast_to_float0, primals_out, tangents_out)
     return map(partial(JVPTracer, self), primals_out, tangents_out)
 
@@ -745,10 +753,15 @@ def raise_custom_vjp_error_on_jvp(*_, **__):
                   "function.")
 custom_lin_p.def_impl(raise_custom_vjp_error_on_jvp)
 
-def _custom_lin_transpose(cts_out, *invals, num_res, bwd, out_avals):
+def _custom_lin_transpose(cts_out, *invals, num_res, bwd, out_avals,
+                          symbolic_zeros):
   res, _ = split_list(invals, [num_res])
-  cts_out = map(instantiate_zeros_aval, out_avals, cts_out)
+  if symbolic_zeros:
+    cts_out = map(replace_internal_symbolic_zeros, cts_out)
+  else:
+    cts_out = map(instantiate_zeros_aval, out_avals, cts_out)
   cts_in = bwd(*res, *cts_out)
+  cts_in = map(replace_rule_output_symbolic_zeros, cts_in)
   return [None] * num_res + list(cts_in)
 primitive_transposes[custom_lin_p] = _custom_lin_transpose
 

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -945,10 +945,11 @@ class MapTrace(core.Trace):
     return self.process_primitive(fake_primitive, tracers, {})
 
   def process_custom_vjp_call(self, primitive, fun, fwd, bwd, tracers,
-                              out_trees):
+                              out_trees, symbolic_zeros):
     bind = HashableFunction(
-        lambda *args, **kwargs: primitive.bind(fun, fwd, bwd, *args,
-                                               out_trees=out_trees, **kwargs),
+        lambda *args, **kwargs: primitive.bind(
+            fun, fwd, bwd, *args, out_trees=out_trees,
+            symbolic_zeros=symbolic_zeros, **kwargs),
         (primitive, fun, fwd, bwd))
     fake_primitive = FakePrimitive(multiple_results=True, bind=bind)
     return self.process_primitive(fake_primitive, tracers, {})

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1472,11 +1472,12 @@ class TensorFlowTrace(core.Trace):
   def post_process_custom_jvp_call(self, out_tracers, _):
     assert False  # unreachable assuming jax2tf runs with clean trace state
 
-  def process_custom_vjp_call(self, prim, fun, fwd, bwd, tracers, out_trees):
+  def process_custom_vjp_call(self, prim, fun, fwd, bwd, tracers, out_trees,
+                              symbolic_zeros):
     # Drop the custom differentiation rule and act like a call primitive. This
     # behavior is desirable because jax2tf stages code out of the JAX system, so
     # there are no more JAX differentiation transformations to be applied.
-    del fwd, bwd, out_trees  # Unused.
+    del fwd, bwd, out_trees, symbolic_zeros  # Unused.
     return self.process_call(core.call_p, fun, tracers, {})
 
   def post_process_custom_vjp_call(self, out_tracers, _):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -7314,10 +7314,10 @@ class CustomJVPTest(jtu.JaxTestCase):
     primal_outs, tangent_outs = run(primal_ins, tangent_ins)
     primal_out1, primal_out2 = primal_outs
     tangent_out1, tangent_out2 = tangent_outs
-    scalar_dtype = jax.Array if maybe_jit or maybe_vmap else float
-    self.assertIsInstance(primal_out1, scalar_dtype)
+    scalar_type = jax.Array if maybe_jit or maybe_vmap else float
+    self.assertIsInstance(primal_out1, scalar_type)
     self.assertAllClose(primal_out1, 5.)
-    self.assertIsInstance(tangent_out1, scalar_dtype)
+    self.assertIsInstance(tangent_out1, scalar_type)
     self.assertAllClose(tangent_out1, 91.)
     self.assertIsInstance(primal_out2, jax.Array)
     self.assertArraysAllClose(primal_out2, jnp.array([7., 9.]))
@@ -8395,6 +8395,183 @@ class CustomVJPTest(jtu.JaxTestCase):
     f_vjp(jnp.array([3.]))
     f_vjp(jnp.array([3.]))  # doesn't crash
 
+  def test_symbolic_zero_custom_vjp_basic(self):
+    @jax.custom_vjp
+    def f(x, y, z):
+      return x, x
+
+    def fwd(x, y, z):
+      self.assertFalse(x[1])
+      self.assertTrue(y[1])
+      self.assertTrue(z[1])
+      return (x[0], x[0]), None
+
+    def fwd_all(x, y, z):
+      self.assertFalse(x[1])
+      self.assertFalse(y[1])
+      self.assertFalse(z[1])
+      return (x[0], x[0]), None
+
+    def bwd_all(_, g):
+      x1, x2 = g
+      self.assertFalse(type(x1) is custom_derivatives_public.SymbolicZero)
+      self.assertFalse(type(x2) is custom_derivatives_public.SymbolicZero)
+      return x1, x1, x2
+
+    def bwd_fst(_, g):
+      x1, x2 = g
+      self.assertFalse(type(x1) is custom_derivatives_public.SymbolicZero)
+      self.assertIs(type(x2), custom_derivatives_public.SymbolicZero)
+      return x1, x1, x2
+
+    def bwd_snd(_, g):
+      x1, x2 = g
+      self.assertIs(type(x1), custom_derivatives_public.SymbolicZero)
+      self.assertFalse(type(x2) is custom_derivatives_public.SymbolicZero)
+      return x1, x1, x2
+
+    x, y, z = 4., 5., 6.
+    i = np.array(7, np.int32)
+    zero = np.array(0.)
+
+    f.defvjp(fwd, bwd_all, symbolic_zeros=True)
+    h = jax.jit(f)
+    jax.jacrev(h)(x, y, z)
+    jax.jacrev(lambda x: h(x, y, z))(x)
+    jax.jacrev(h, argnums=(0, 1, 2), allow_int=True)(x, i, i)
+
+    f.defvjp(fwd_all, bwd_fst, symbolic_zeros=True)
+    fst_f = lambda *xs: f(*xs)[0]
+    _, vjp = jax.vjp(fst_f, x, y, z)
+    _, _, gz = vjp(x)
+    self.assertArraysAllClose(gz, zero)
+
+    f.defvjp(fwd_all, bwd_snd, symbolic_zeros=True)
+    snd_f = lambda *xs: f(*xs)[1]
+    _, vjp = jax.vjp(snd_f, x, y, z)
+    gx, gy, _ = vjp(x)
+    self.assertArraysAllClose(gx, zero)
+    self.assertArraysAllClose(gy, zero)
+
+    f.defvjp(fwd, bwd_snd, symbolic_zeros=True)
+    _, vjp = jax.vjp(lambda x: snd_f(x, y, z), x)
+    gx, = vjp(x)
+    self.assertArraysAllClose(gx, zero)
+
+  @parameterized.named_parameters(
+      ('jit_vmap', True, True),
+      ('jit', True, False),
+      ('vmap', False, True),
+      ('', False, False),
+  )
+  def test_symbolic_zero_custom_vjp(self, maybe_jit, maybe_vmap):
+    # below:
+    # * static_scalar will be static in and out
+    # * static_array will be static in, but dynamic out
+    # * dyn_scalar and dyn_array will be dynamic in and out
+
+    ZERO = custom_derivatives_public.SymbolicZero
+
+    def f(static_scalar, static_array, dyn_scalar, dyn_array):
+      out1 = static_scalar + dyn_scalar
+      out2 = static_array + dyn_array
+      return static_scalar, static_array, out1, out2
+
+    def _pack(x):
+      return lax.broadcast(x, (1,))
+
+    def _unpack(x):
+      (x,) = x
+      return x
+
+    def _vmap(fun):
+      def _fun(*args):
+        args = tree_util.tree_map(_pack, args)
+        out = jax.vmap(fun)(*args)
+        out = tree_util.tree_map(_unpack, out)
+        return out
+      return _fun
+
+    f = api.custom_vjp(f)
+
+    def fwd(*args):
+      xs, zeros = [x[0] for x in args], [x[1] for x in args]
+      self.assertTrue(zeros[0])
+      self.assertTrue(zeros[1])
+      self.assertFalse(zeros[2])
+      self.assertFalse(zeros[3])
+      return f(*xs), xs
+
+    def bwd(res, g):
+      static_scalar, *_ = res
+      t_static, t_static_arr, t_dyn_scalar, t_dyn_array = g
+      self.assertIs(type(t_static), ZERO)
+      self.assertFalse(type(t_static_arr) is ZERO)
+      self.assertFalse(type(t_dyn_scalar) is ZERO)
+      self.assertFalse(type(t_dyn_array)  is ZERO)
+      self.assertEqual(t_static.shape, ())
+      self.assertEqual(t_static_arr.shape, (2,))
+      return (static_scalar + 90,
+              t_static_arr  + 91,
+              t_dyn_scalar  + 92,
+              t_dyn_array   + 93)
+
+    f.defvjp(fwd, bwd, symbolic_zeros=True)
+
+    def g(dyn_scalar, dyn_array):
+      if maybe_vmap:
+        f_ = _vmap(f)
+      else:
+        f_ = f
+      outs = f_(1., jnp.array([2., 3.]), dyn_scalar, dyn_array)
+      return outs[1:]
+
+    def run(primal_ins, cotangent_outs):
+      primal_outs, vjp = jax.vjp(g, *primal_ins)
+      cotangent_ins = vjp(cotangent_outs)
+      return primal_outs, cotangent_ins
+
+    if maybe_jit:
+      run = jax.jit(run)
+
+    scalar_type = jax.Array if maybe_jit or maybe_vmap else float
+    primal_ins = (4., jnp.array([5., 6.]))
+    cotangent_outs = (jnp.array([10., 11.]), 7., jnp.array([8., 9.]))
+    primal_outs, cotangent_ins = run(primal_ins, cotangent_outs)
+
+    primal_out1, primal_out2, primal_out3 = primal_outs
+    self.assertIsInstance(primal_out1, jax.Array)
+    self.assertAllClose(primal_out1, jnp.array([2., 3.]))
+    self.assertIsInstance(primal_out2, scalar_type)
+    self.assertAllClose(primal_out2, 5.)
+    self.assertIsInstance(primal_out3, jax.Array)
+    self.assertAllClose(primal_out3, jnp.array([7., 9.]))
+
+    ct_in1, ct_in2 = cotangent_ins
+    self.assertIsInstance(ct_in1, scalar_type)
+    self.assertAllClose(ct_in1, 99.)
+    self.assertIsInstance(ct_in2, jax.Array)
+    self.assertArraysAllClose(ct_in2, jnp.array([101., 102.]))
+
+  def test_symbolic_zero_custom_vjp_vmap_output(self):
+    @api.custom_vjp
+    def f(x, y):
+      return x, y
+
+    def fwd(x, y):
+      (x, x0), (y, y0) = x, y
+      self.assertFalse(x0)
+      self.assertTrue(y0)
+      return f(x, y), None
+
+    def bwd(_, g):
+      ct_x, ct_y = g
+      #import ipdb; ipdb.set_trace()
+      self.assertIs(type(ct_y), custom_derivatives_public.SymbolicZero)
+      return g
+
+    f.defvjp(fwd, bwd, symbolic_zeros=True)
+    jax.grad(lambda x, y: jax.vmap(f)(x, y)[0].sum())(jnp.ones(3), jnp.ones(3))
 
 def transpose_unary(f, x_example):
   def transposed(y):


### PR DESCRIPTION
#14570 covered custom JVPs. This one covers custom VJPs.

Symbolic zeros are meant to indicate when things that aren't involved in autodiff. In custom AD, this means indicating this to the custom rules, which can then adapt computation accordingly (for instance by saving on unnecessary computation).

For reverse-mode custom AD, there are two ways that these indications come in. As of this PR, let's say we have a python function `jax.custom_vjp(f)` for which we've set `f.defvjp(fwd, bwd, symbolic_zeros=True)`. Then:

1. The forward rule `fwd` is told which primal inputs are not involved in differentiation by a boolean indicator on every argument (more precisely, every leaf on every argument pytree). For example, wherever `f` accepts an argument of the form `(x, [y, z])` where `x`, `y`, and `z` are arrays, then `fwd` accepts `((x, x0), [(y, y0), (z, z0)])`, where `x` is the original primal array and `x0` is a boolean, indicating `True` for a "symbolic zero" (i.e. inactivity in AD).
2. The backward rule `bwd` receives `SymbolicZero` instances in place of cotangents that aren't involved in AD. This mirrors the `custom_jvp` symbolic zero interface (#14570).

Why is support for symbolic zeros simpler in `custom_jvp`? Conceptually, JVPs take primal and tangent inputs in correspondence, and each primal-tangent pair is "zero" in correspondence. Symbolic zeros indicated on the tangents (similar to item 2 above) therefore provide all indication that the rule could need.

Another way to visualize this is by thinking about rows and columns of Jacobian matrices. A primal value not involved in differentiation corresponds to zero columns in the Jacobian matrix. In JVPs, where we compute `x, u -> J(x) @ u`, zeros in the perturbation vector `u` (tangents) line up with zero columns of the Jacobian `J(x)`. In VJPs, where we compute `x, v -> transpose(J(x)) @ v`, zeros in the perturbation vector `v` (cotangents) line up with rows of the Jacobian instead, and we need to point out the zero columns separately from the zero perturbations.

Thanks to @mattjj for helping thinking through the interface here, and for how to "project" the `fwd` function into a canonical form!