### PR TITLE
jaxlib.hlo_helpers.custom_call returns length 1 tuple for single output functions

### DIFF
--- a/jaxlib/hlo_helpers.py
+++ b/jaxlib/hlo_helpers.py
@@ -70,7 +70,7 @@ def custom_call(
           for input, output in operand_output_aliases.items()
       ]))
   if len(out_types) == 1:
-    return out.result
+    return (out.result,)
   else:
     return [
         hlo.GetTupleElementOp(out, ir.IntegerAttr.get(i32_type, i)).result


### PR DESCRIPTION
Fixes #15095 .

Currently comes without tests. I could not figure out how to make these happen without including native/C code. Recommendations?