### PR TITLE
WAR the dependency issue in the nightly CI container.

### DIFF
--- a/.github/workflows/slurm_job_scripts/run_e2e_t5x_tests.sub
+++ b/.github/workflows/slurm_job_scripts/run_e2e_t5x_tests.sub
@@ -40,12 +40,16 @@ EXPORTS="--export=ALL,PYTHONPATH=${T5X_DIR}"
 #-------------------------------------------------------------------------------
 
 # Setup command to be run before the actual pytest command
+# We remove cudf from the container as a temporary WAR to a protobuf
+# dependency issue between cudf and tensorflow-cpu that t5x try to
+# install.
 read -r -d '' setup_cmd <<EOF
 rm -rf ${E2E_TESTS_WORKSPACE_DIR}/* \
 && mkdir -p ${E2E_TESTS_WORKSPACE_DIR} \
 && mkdir -p ${TFDS_DATA_DIR} \
 && python3.8 -m pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html \
 && git clone https://github.com/google-research/t5x.git ${T5X_DIR} \
+&& python3.8 -m pip uninstall -y cudf \
 && python3.8 -m pip install ${T5X_DIR} \
 && python3.8 -m pip install ${T5X_DIR}/t5x/contrib/gpu/scripts_gpu/dummy_wikipedia_config \
 && hostname > ${E2E_TESTS_WORKSPACE_DIR}/hostname.txt


### PR DESCRIPTION
This is to help fix error like:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
cudf 22.8.0a0+304.g6ca81bbc78.dirty requires protobuf<3.21.0a0,>=3.20.1, but you have protobuf 3.19.6 which is incompatible.
```

https://github.com/google/jax/actions/runs/4489606264
