### PR TITLE
Add initial implementation of a `run_state` primitive

### DIFF
--- a/jax/_src/state/__init__.py
+++ b/jax/_src/state/__init__.py
@@ -15,7 +15,3 @@
 from jax._src.state.types import (AbstractRef, ReadEffect, WriteEffect,
                                   AccumEffect, StateEffect, RefEffect,
                                   get_ref_state_effects, shaped_array_ref)
-from jax._src.state.primitives import (ref_get, ref_set, ref_swap,
-                                       ref_addupdate, get_p, swap_p,
-                                       addupdate_p)
-from jax._src.state.discharge import discharge_state, register_discharge_rule

--- a/jax/_src/state/discharge.py
+++ b/jax/_src/state/discharge.py
@@ -15,24 +15,34 @@
 from __future__ import annotations
 import dataclasses
 from functools import partial
+import operator
 
-from typing import Any, Dict, List, Optional, Protocol, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Protocol, Sequence, Tuple, Union
 
 import numpy as np
 
 from jax import lax
 
+from jax._src import api_util
+from jax._src import ad_util
 from jax._src import core
 from jax._src import linear_util as lu
 from jax._src.interpreters import partial_eval as pe
-from jax._src.state.types import AbstractRef
+from jax._src import source_info_util
+from jax._src import tree_util
+from jax._src.config import config
+from jax._src.interpreters import ad
+from jax._src.state.types import AbstractRef, RefEffect
 from jax._src.state.primitives import get_p, swap_p, addupdate_p
-from jax._src.util import safe_map, safe_zip, split_list
+from jax._src.state.utils import hoist_consts_to_refs
+from jax._src.util import (safe_map, safe_zip, split_list, weakref_lru_cache,
+                           partition_list, merge_lists, split_dict)
 
 ## JAX utilities
 
 map, unsafe_map = safe_map, map
 zip, unsafe_zip = safe_zip, zip
+PyTreeDef = tree_util.PyTreeDef
 
 ## Discharging state
 
@@ -241,3 +251,461 @@ def _closed_call_discharge_rule(
                      else None for aval in in_avals)
   assert next(ref_vals_iter, None) is None
   return new_invals, out_vals
+
+# # `run_state`
+
+run_state_p = core.Primitive("run_state")
+run_state_p.multiple_results = True
+
+def _run_state_bind(*args: Any, jaxpr: core.Jaxpr,
+                    which_linear: tuple[bool, ...]):
+  if config.jax_enable_checks:
+    core.check_jaxpr(jaxpr)
+    assert len(jaxpr.invars) == len(args)
+    assert len(which_linear) == len(args)
+  return core.Primitive.bind(run_state_p, *args, jaxpr=jaxpr,
+                             which_linear=which_linear)
+run_state_p.def_custom_bind(_run_state_bind)
+
+def _run_state_impl(*args: Any, jaxpr: core.Jaxpr,
+                    which_linear: tuple[bool, ...]):
+  del which_linear
+  discharged_jaxpr, consts = discharge_state(jaxpr, ())
+  return core.eval_jaxpr(discharged_jaxpr, consts, *args)
+run_state_p.def_impl(_run_state_impl)
+
+def _run_state_abstract_eval(*avals: core.AbstractValue, jaxpr: core.Jaxpr,
+                             which_linear: tuple[bool, ...]):
+  del which_linear
+  # When we abstractly evaluate `run_state`, we want to keep track of which
+  # input avals are `Ref`s and which are not. If an aval is a `Ref`, we want to
+  # "propagate" out its inner effects. Otherwise, the effects are local to this
+  # `run_state`.
+  is_ref = {i for i, aval in enumerate(avals) if isinstance(aval, AbstractRef)}
+  nonlocal_effects = {e for e in jaxpr.effects
+                      if (isinstance(e, RefEffect) and e.input_index in is_ref)
+                      or not isinstance(e, RefEffect)}
+  return avals, nonlocal_effects
+run_state_p.def_effectful_abstract_eval(_run_state_abstract_eval)
+
+def _run_state_jvp(primals: Sequence[Any], tangents: Sequence[Any], *,
+                   jaxpr: core.Jaxpr, which_linear: tuple[bool, ...]):
+  nonzero_tangents = [not isinstance(t, ad_util.Zero) for t in tangents]
+  discharged_jaxpr, body_consts = discharge_state(jaxpr, ())
+  for _ in range(len(nonzero_tangents)):
+    _, out_nonzero_tangents = ad.jvp_jaxpr(
+        core.ClosedJaxpr(discharged_jaxpr, body_consts),
+        nonzero_tangents, instantiate=nonzero_tangents)
+    if out_nonzero_tangents == nonzero_tangents:
+      break
+    nonzero_tangents = map(operator.or_, nonzero_tangents, out_nonzero_tangents)
+  else:
+    raise Exception("Invalid fixpoint")
+  del discharged_jaxpr, body_consts, out_nonzero_tangents
+  tangents = [ad.instantiate_zeros(t) if inst else t
+              for t, inst in zip(tangents, nonzero_tangents)]
+  tangents = [t for t in tangents if type(t) is not ad_util.Zero]
+  closed_jvp_jaxpr, _ = ad.jvp_jaxpr(core.ClosedJaxpr(jaxpr, ()),
+                                     nonzero_tangents, [])
+  jvp_jaxpr_, jvp_consts = closed_jvp_jaxpr.jaxpr, closed_jvp_jaxpr.consts
+  jvp_jaxpr = hoist_consts_to_refs(jvp_jaxpr_)
+  jvp_which_linear = (*(False,) * len(jvp_consts), *which_linear, *(True,) * len(tangents))
+  out = run_state_p.bind(*jvp_consts, *primals, *tangents, jaxpr=jvp_jaxpr,
+                         which_linear=jvp_which_linear)
+  out_consts, out_primals, out_tangents = split_list(out, [len(jvp_consts),
+                                                           len(primals)])
+  del out_consts
+  out_tangents_iter = iter(out_tangents)
+  out_tangents = [next(out_tangents_iter) if nz else ad_util.Zero.from_value(p)
+                  for p, nz in zip(out_primals, nonzero_tangents)]
+  return out_primals, out_tangents
+ad.primitive_jvps[run_state_p] = _run_state_jvp
+
+_save_everything = lambda *_, **__: True
+
+def _convert_outputs_to_writes(
+    jaxpr: core.Jaxpr) -> Tuple[core.Jaxpr, List[core.ShapedArray]]:
+  assert not jaxpr.constvars, "Jaxpr shouldn't have constvars."
+
+  in_avals = [v.aval for v in jaxpr.invars]
+  @lu.wrap_init
+  def eval_jaxpr(*refs):
+    # We split the refs into the original input refs and the dummy residual
+    # refs.
+    orig_refs, residual_refs = split_list(refs, [len(in_avals)])
+    residual_vals = core.eval_jaxpr(jaxpr, (), *orig_refs)
+    for res_ref, res_val in zip(residual_refs, residual_vals):
+      res_ref[...] = res_val
+    return []
+  res_ref_avals = [AbstractRef(v.aval) if not isinstance(v.aval, AbstractRef)
+                   else v.aval for v in jaxpr.outvars]
+  jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
+      eval_jaxpr, [*in_avals, *res_ref_avals])
+  assert not consts
+  return jaxpr, [core.ShapedArray(a.shape, a.dtype) for a in res_ref_avals]
+
+def _convert_inputs_to_reads(num_res: int, jaxpr: core.Jaxpr) -> core.Jaxpr:
+  assert not jaxpr.constvars, "Jaxpr should not have constvars"
+
+  @lu.wrap_init
+  def eval_jaxpr(*refs):
+    residual_refs, orig_refs = split_list(refs, [num_res])
+    residual_vals = [r[...] for r in residual_refs]
+    () = core.eval_jaxpr(jaxpr, (), *residual_vals, *orig_refs)
+    return []
+
+  res_val_avals, orig_ref_avals = \
+      split_list([v.aval for v in jaxpr.invars], [num_res])
+  res_ref_avals = [AbstractRef(aval) if not isinstance(aval, AbstractRef) else
+                   aval for aval in res_val_avals]
+  jaxpr, _, () = pe.trace_to_jaxpr_dynamic(
+      eval_jaxpr, [*res_ref_avals, *orig_ref_avals])
+  return jaxpr
+
+def _run_state_partial_eval(trace: pe.JaxprTrace, *tracers: pe.JaxprTracer,
+                            jaxpr: core.Jaxpr, which_linear: tuple[bool, ...]):
+  num_inputs = len(tracers)
+  assert num_inputs == len(jaxpr.invars)
+  in_unknowns = [not t.pval.is_known() for t in tracers]
+  # We first need to run a fixpoint to determine which of the `Ref`s are unknown
+  # after running the for loop. We want to use the jaxpr to determine which
+  # `Ref`s are unknown after executing the for loop body given which `Ref`s are
+  # unknown before. However, the jaxpr has no outputs. Instead, we discharge
+  # the body and run the fixpoint with the discharged jaxpr. We can do this
+  # because the outputs of the jaxpr are one-to-one with the inputs.
+  discharged_jaxpr_, discharged_consts = discharge_state(jaxpr, ())
+  discharged_jaxpr = pe.convert_constvars_jaxpr(discharged_jaxpr_)
+  for _ in range(num_inputs):
+    jaxpr_in_unknowns = [False] * len(discharged_consts) + in_unknowns
+    _, _, out_unknowns, out_inst, _, _ = pe.partial_eval_jaxpr_stateful(
+        discharged_jaxpr, jaxpr_in_unknowns, jaxpr_in_unknowns,
+          in_unknowns, False, _save_everything)
+    # assert out_inst == out_unknowns
+    out_unknowns = list(out_unknowns)
+    if out_unknowns == in_unknowns:
+      break
+    in_unknowns = map(operator.or_, in_unknowns, out_unknowns)
+  else:
+    raise Exception("Invalid fixpoint")
+  del out_unknowns  # redundant since it's the same as `in_unknowns`
+  tracers = tuple(trace.instantiate_const(t) if uk else t  # type: ignore
+                  for t, uk in zip(tracers, in_unknowns))
+
+  # We use `partial_eval_jaxpr_stateful` here because it won't remove effectful
+  # primitives like `get`/`set`.
+  jaxpr_known_resout, jaxpr_unknown_resin_, _, _, num_res_out, num_res_ref = \
+        pe.partial_eval_jaxpr_stateful(jaxpr, in_unknowns, in_inst=in_unknowns,
+                                     ensure_out_unknowns=[], ensure_out_inst=[],
+                                     saveable=_save_everything)
+  # # `partial_eval_jaxpr_stateful` will give us jaxprs that have hybrid `Ref`
+  # and regular valued input/outputs. However, we'd like to bind these jaxprs to
+  # a `for`, which expects only `Ref` inputs and no output. We need to convert
+  # both of these jaxprs into ones that are compatible with `for`.
+
+  # `jaxpr_known_resout` is a jaxpr that maps from all the input `Refs`
+  # to output residual values (none of them should be `Ref`s). We'll need to
+  # convert the output residual values into `Ref`s that are initially empty
+  # `Ref`s that are written to at the end of the jaxpr.
+  num_res = num_res_out + num_res_ref
+
+  num_invars = len(jaxpr_known_resout.invars) - num_res_ref
+  _, res_ref_avals = split_list(
+      [v.aval for v in jaxpr_known_resout.invars], [num_invars])
+  res_avals = [a.inner_aval for a in res_ref_avals]
+  jaxpr_known, new_res_avals = _convert_outputs_to_writes(jaxpr_known_resout)
+  # We now run the known jaxpr to obtain our residual values.
+  known_tracers, _ = partition_list(in_unknowns, tracers)
+  known_which_linear, _ = partition_list(in_unknowns, which_linear)
+  known_vals = [t.pval.get_known() for t in known_tracers]
+  all_res_avals = [*res_avals, *new_res_avals]
+  empty_res = map(ad_util.zeros_like_aval, all_res_avals)
+  jaxpr_known_args = [*known_vals, *empty_res]
+
+  jaxpr_known_which_linear = (*known_which_linear, *(False,) * num_res)
+  out_flat = run_state_p.bind(*jaxpr_known_args, jaxpr=jaxpr_known,
+                              which_linear=jaxpr_known_which_linear)
+  known_outputs, residuals = split_list(out_flat, [len(known_tracers)])
+  residuals = map(trace.new_instantiated_const, residuals)
+  ref_res, nonref_res = split_list(residuals, [num_res_ref])
+
+  # Now we handle the `jaxpr_unknown` that expects residual values as inputs.
+  # This jaxpr is the output of `partial_eval_jaxpr_stateful` that marks which
+  # inputs are actually used.
+  # `partial_eval_jaxpr_stateful` doesn't remove extra inputs/outputs for you
+  # so we use `dce_jaxpr` here to do that.
+  # To make it compatible with `for`, we need to convert those residual values
+  # into `Ref`s.
+  jaxpr_unknown = _convert_inputs_to_reads(len(new_res_avals),
+                                           jaxpr_unknown_resin_)
+  _, unknown_tracers = partition_list(in_unknowns, tracers)
+  _, uk_which_linear = partition_list(in_unknowns, which_linear)
+  unknown_which_linear = (False,) * num_res + tuple(uk_which_linear)
+  unknown_inputs = [*nonref_res, *ref_res, *unknown_tracers]
+  # Outputs match inputs so we construct output tracers that look like the input
+  # tracers.
+  res_ref_unknown_outputs = [
+      pe.JaxprTracer(trace, pe.PartialVal.unknown(t.aval), None)
+      for t in unknown_inputs]
+  name_stack = source_info_util.current_name_stack()[len(trace.name_stack):]
+  source = source_info_util.current().replace(name_stack=name_stack)
+
+  assert len(unknown_inputs) == len(res_ref_unknown_outputs)
+  assert len(unknown_inputs) == len(jaxpr_unknown.invars)
+  uk_params = dict(jaxpr=jaxpr_unknown, which_linear=unknown_which_linear)
+  _, eqn_effects = run_state_p.abstract_eval(*[v.aval for v in unknown_inputs],
+                                             **uk_params)
+  eqn = pe.new_eqn_recipe(unknown_inputs, res_ref_unknown_outputs,
+                          run_state_p, uk_params,
+                          eqn_effects, source)
+  for t in res_ref_unknown_outputs: t.recipe = eqn
+  _, unknown_outputs = split_list(res_ref_unknown_outputs, [num_res])
+  return merge_lists(in_unknowns, known_outputs, unknown_outputs)
+pe.custom_partial_eval_rules[run_state_p] = _run_state_partial_eval
+
+def _run_state_partial_eval_custom(
+    saveable: Callable[..., bool],
+    in_unknowns: Sequence[bool],
+    in_inst: Sequence[bool],
+    eqn: core.JaxprEqn):
+  if not any(in_unknowns):
+    return eqn, None, in_unknowns, [False] * len(in_unknowns), []
+  jaxpr, which_linear = split_dict(eqn.params, ["jaxpr", "which_linear"])
+  num_inputs = len(eqn.invars)
+  # We first need to run a fixpoint to determine which of the `Ref`s are unknown
+  # after running the for loop. However, the jaxpr has no outputs. Instead, we
+  # discharge the body and run the fixpoint with the discharged jaxpr. We can do
+  # this because the outputs of the discharged jaxpr are one-to-one with the
+  # inputs.
+  discharged_jaxpr, discharged_consts = discharge_state(jaxpr, ())
+  discharged_jaxpr = discharged_jaxpr.replace(
+      invars=discharged_jaxpr.constvars + discharged_jaxpr.invars,
+      constvars=[])
+  in_unknowns, in_inst = list(in_unknowns), list(in_inst)
+  out_unknowns, out_inst =  in_unknowns, in_unknowns
+  for _ in range(num_inputs):
+    jaxpr_in_unknowns = [False] * len(discharged_consts) + in_unknowns
+    _, _, out_unknowns, out_inst, _, _ = pe.partial_eval_jaxpr_stateful(
+        discharged_jaxpr,
+        in_unknowns=jaxpr_in_unknowns,
+        in_inst=jaxpr_in_unknowns,
+        ensure_out_unknowns=in_unknowns,
+        ensure_out_inst=in_unknowns,
+        saveable=saveable)
+    out_unknowns = list(out_unknowns)
+    if out_unknowns == in_unknowns:
+      break
+    in_unknowns = map(operator.or_, in_unknowns, out_unknowns)
+  else:
+    if num_inputs > 0: raise Exception("Invalid fixpoint")
+  del out_unknowns # Redundant since it's the same as `in_unknowns`
+  new_inst = [x for x, already, inst in zip(eqn.invars, in_inst, out_inst)
+              if type(x) is core.Var and inst and not already]
+
+  # We use `partial_eval_jaxpr_stateful` here because it won't remove effectful
+  # primitives like `get`/`set`.
+  jaxpr_known_resout, jaxpr_staged_resin_, _, _, num_res_out, num_res_ref = \
+        pe.partial_eval_jaxpr_stateful(jaxpr, in_unknowns,
+            in_unknowns, [], [], saveable)
+  num_res = num_res_ref + num_res_out
+  # `partial_eval_jaxpr_stateful` will give us jaxprs that have hybrid `Ref` and
+  # non-Ref input/outputs. However, we'd like to bind these jaxprs to a
+  # `for`, which expects only `Ref` inputs and no output. We need to convert
+  # both of these jaxprs into ones that are compatible with `for`.
+  # TODO(sharadmv,mattjj): implement "passthrough" optimization.
+
+  # `jaxpr_known_resout` is a jaxpr that maps from all the input `Refs`
+  # to output residual values (none of them should be `Ref`s). We'll need to
+  # convert the output residual values into `Ref`s that are initially empty
+  # `Ref`s that are written to at the end of the jaxpr.
+  jaxpr_known, res_avals = _convert_outputs_to_writes(jaxpr_known_resout)
+
+  # In a stateful partial_eval, the residuals should be `Ref`s.
+  res_avals = map(AbstractRef, res_avals)  # type: ignore
+
+  known_invars, staged_invars = partition_list(in_unknowns, eqn.invars)
+  known_outvars, staged_outvars = partition_list(in_unknowns, eqn.outvars)
+  newvar = core.gensym()
+  _, res_ref_avals = split_list([v.aval for v in jaxpr_known_resout.invars],
+                                [len(known_invars)])
+  nonref_resvars = map(newvar, res_avals)
+  ref_resvars = map(newvar, res_ref_avals)
+  known_out_resvars = map(newvar, [*res_ref_avals, *res_avals])
+
+  known_which_linear, _ = partition_list(in_unknowns, which_linear)
+  jaxpr_known_which_linear = (*known_which_linear, *(False,) * num_res)
+  known_and_res_invars = [*known_invars, *ref_resvars, *nonref_resvars]
+
+  known_params = dict(jaxpr=jaxpr_known, which_linear=jaxpr_known_which_linear)
+  _, known_effects = run_state_p.abstract_eval(
+      *[v.aval for v in known_and_res_invars], **known_params)
+  eqn_known = pe.new_jaxpr_eqn(known_and_res_invars,
+                               [*known_outvars, *known_out_resvars],
+                               run_state_p, known_params,
+                               known_effects, eqn.source_info)
+
+  jaxpr_staged = _convert_inputs_to_reads(len(res_avals), jaxpr_staged_resin_)
+
+  _, staged_which_linear = partition_list(in_unknowns, which_linear)
+  which_linear_unknown = (*[False] * num_res, *staged_which_linear)
+  staged_params = dict(jaxpr=jaxpr_staged, which_linear=which_linear_unknown)
+  rejiggered_resvars = [*nonref_resvars, *ref_resvars]
+  _, staged_invars = partition_list(in_unknowns, eqn.invars)
+  res_staged_invars = [*rejiggered_resvars, *staged_invars]
+  _, staged_effects = run_state_p.abstract_eval(
+      *[v.aval for v in res_staged_invars], **staged_params)
+  _, staged_outvars = partition_list(in_unknowns, eqn.outvars)
+  if num_res:
+    @lu.wrap_init
+    def staged(*args):
+      out = run_state_p.bind(*args, **staged_params)
+      return out[num_res:]
+    staged_call_jaxpr, _, () = pe.trace_to_jaxpr_dynamic(staged,
+        [v.aval for v in res_staged_invars])
+    eqn_staged = pe.new_jaxpr_eqn(res_staged_invars,
+                                  staged_outvars,
+                                  core.closed_call_p,
+                                  dict(call_jaxpr=core.ClosedJaxpr(staged_call_jaxpr, ())),
+                                  staged_effects, eqn.source_info)
+    assert len(res_staged_invars) == len(staged_call_jaxpr.invars)
+    assert len(staged_outvars) == len(staged_call_jaxpr.outvars)
+  else:
+    eqn_staged = pe.new_jaxpr_eqn(staged_invars,
+                                  staged_outvars,
+                                  run_state_p,
+                                  staged_params,
+                                  staged_effects, eqn.source_info)
+  new_vars = [*new_inst, *nonref_resvars, *ref_resvars]
+  return eqn_known, eqn_staged, in_unknowns, in_unknowns, new_vars
+pe.partial_eval_jaxpr_custom_rules[run_state_p] = _run_state_partial_eval_custom
+
+def _transpose_jaxpr(jaxpr: core.Jaxpr, which_linear: Sequence[bool]
+                    ) -> tuple[core.Jaxpr, Any]:
+  def trans(*args):
+    # First we want to run the computation to read all the residual refs. We can
+    # do that by using partial evaluation with all linear inputs unknown.
+    res_jaxpr_, tangent_jaxpr_, *_, num_res_out, num_res_ref = \
+        pe.partial_eval_jaxpr_stateful(jaxpr, which_linear, in_inst=which_linear,
+                                       ensure_out_inst=[],
+                                       ensure_out_unknowns=[],
+                                       saveable=_save_everything)
+
+    num_unknown = sum(which_linear)
+    num_known = len(jaxpr.invars) - num_unknown
+    res_args, _ = partition_list(which_linear, args)
+    res_jaxpr_avals = [v.aval for v in res_jaxpr_.invars]
+    _, res_avals = split_list(res_jaxpr_avals, [num_known])
+    res_avals = [a.inner_aval for a in res_avals]
+    all_avals = [*res_avals, *[v.aval for v in res_jaxpr_.outvars]]
+    empty_res = map(ad.zeros_like_aval, all_avals)
+    res_jaxpr, _ = _convert_outputs_to_writes(res_jaxpr_)
+    res = run_state_p.bind(*res_args, *empty_res, jaxpr=res_jaxpr,
+                           which_linear=(False,) * (len(res_args) + len(empty_res)))
+    res = res[len(res_args):]
+    ref_res_, nonref_res_ = split_list(res, [num_res_ref])
+
+    # Now that we have residual values, we run the tangent jaxpr. It takes as
+    # input the residuals, the loop index, and all the refs (at least, the ones
+    # that are used in the body). Luckily, `tangent_jaxpr_` has all known and
+    # unknown inputs!
+    tangent_jaxpr, used_inputs = pe.dce_jaxpr(tangent_jaxpr_, [])
+    used_res, used_cts = split_list(used_inputs, [len(res)])
+    used_nonref_res, used_ref_res = split_list(used_res, [num_res_out])
+    _, nonref_res = partition_list(used_nonref_res, nonref_res_)
+    _, ref_res = partition_list(used_ref_res, ref_res_)
+    primals_args = [*nonref_res, *ref_res]
+    _, tangent_args = partition_list(which_linear, args)
+    _, ct_args = partition_list(used_cts, tangent_args)
+    ad.backward_pass(
+        tangent_jaxpr, (), False, (), (*primals_args, *ct_args), ())
+    return []
+  jaxpr_trans, _, consts = pe.trace_to_jaxpr_dynamic(
+      lu.wrap_init(trans), [v.aval for v in jaxpr.invars])
+  return jaxpr_trans, consts
+
+def _run_state_transpose(in_cts, *args, jaxpr: core.Jaxpr,
+                         which_linear: tuple[bool, ...]):
+  # if any in_ct is nonzero, we definitely want it in args_ (and the
+  # corresponding x in args could be an undefined primal, but doesnt have to be)
+  # for non-res stuff:
+  #   getting and setting => (nonzero ct, UndefinedPrimal arg)
+  #   just setting =>        (nonzero ct, not UndefinedPrimal, dummy value)
+  #   just getting =>        (zero ct   , UndefinedPrimal arg)
+  # for res stuff:
+  #                          (zero ct   , not UndefinedPrimal)
+  assert any(which_linear)
+  transpose_args = []
+  for x, ct in zip(args, in_cts):
+    if   type(ct) is     ad_util.Zero and not ad.is_undefined_primal(x):
+      # this is a residual, take x!
+      transpose_args.append(x)
+    elif type(ct) is     ad_util.Zero and     ad.is_undefined_primal(x):
+      # the loop was 'just getting', plug in a zero
+      transpose_args.append(ad_util.zeros_like_aval(x.aval))
+    elif type(ct) is not ad_util.Zero and not ad.is_undefined_primal(x):
+      # the loop was 'just setting', grab that cotangent! x is dummy
+      transpose_args.append(ct)
+    elif type(ct) is not ad_util.Zero and     ad.is_undefined_primal(x):
+      # the loop was 'getting and setting', grab that cotangent!
+      transpose_args.append(ct)
+  jaxpr_transpose_, consts = _transpose_jaxpr(jaxpr, which_linear)
+  jaxpr_transpose = hoist_consts_to_refs(jaxpr_transpose_)
+  which_linear = (*[False] * len(consts), *which_linear)
+  const_all_outs = run_state_p.bind(*consts, *transpose_args,
+                                    jaxpr=jaxpr_transpose,
+                                    which_linear=which_linear)
+  _, all_outs = split_list(const_all_outs, [len(consts)])
+  ct_outs = [ct if ad.is_undefined_primal(x) else None
+             for x, ct in zip(args, all_outs)]
+  return ct_outs
+ad.primitive_transposes[run_state_p] = _run_state_transpose
+
+@register_discharge_rule(run_state_p)
+def _run_state_discharge_rule(in_avals: Sequence[core.AbstractValue],
+                              out_avals: Sequence[core.AbstractValue],
+                              *args: Any, jaxpr: core.Jaxpr,
+                              which_linear: Sequence[bool]):
+  del out_avals
+  out_vals = run_state_p.bind(*args, jaxpr=jaxpr, which_linear=which_linear)
+  new_invals = []
+  for aval, out_val in zip(in_avals, out_vals):
+    new_invals.append(out_val if isinstance(aval, AbstractRef) else None)
+  return new_invals, out_vals
+
+def initial_style_jaxpr(
+    fun: Callable, in_tree: PyTreeDef, in_avals: Sequence[core.AbstractValue]
+  ) -> Tuple[core.Jaxpr, List[Any], PyTreeDef]:
+  return _initial_style_jaxpr(fun, in_tree, tuple(in_avals))
+
+@weakref_lru_cache
+def _initial_style_jaxpr(fun, in_tree, in_avals):
+  fun_, out_tree_thunk = api_util.flatten_fun_nokwargs(lu.wrap_init(fun),
+      tree_util.treedef_tuple((in_tree,)))
+  debug = pe.debug_info(fun_, in_tree, False, out_tree_thunk, 'run_state')
+  jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(fun_, in_avals, debug)
+  return jaxpr, consts, out_tree_thunk()
+
+def run_state(f: Callable[..., None]):
+  def wrapped(args):
+    flat_args, in_tree = tree_util.tree_flatten(args)
+    avals = [core.raise_to_shaped(core.get_aval(arg)) for arg in flat_args]
+    jaxpr_, consts, _ = initial_style_jaxpr(f, in_tree, map(AbstractRef, avals))
+    jaxpr = hoist_consts_to_refs(jaxpr_)
+    which_linear = (False,) * (len(consts) + len(flat_args))
+    out_const_flat = run_state_p.bind(*consts, *flat_args, jaxpr=jaxpr,
+                                      which_linear=which_linear)
+    _, out_flat = split_list(out_const_flat, [len(consts)])
+    return in_tree.unflatten(out_flat)
+  return wrapped
+
+def run_state_reference(f: Callable[..., None]):
+  def wrapped(args):
+    flat_args, in_tree = tree_util.tree_flatten(args)
+    avals = [core.raise_to_shaped(core.get_aval(arg)) for arg in flat_args]
+    jaxpr_, consts, _ = initial_style_jaxpr(f, in_tree, map(AbstractRef, avals))
+    jaxpr = hoist_consts_to_refs(jaxpr_)
+    discharged_jaxpr, discharged_consts = discharge_state(jaxpr, ())
+    out_const_flat = core.eval_jaxpr(discharged_jaxpr, discharged_consts,
+                                     *consts, *args)
+    _, out_flat = split_list(out_const_flat, [len(consts)])
+    return in_tree.unflatten(out_flat)
+  return wrapped

--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -18,8 +18,7 @@ from typing import Any, List, Tuple, Union
 
 import numpy as np
 
-from jax import lax
-
+import jax
 from jax._src import ad_util
 from jax._src import core
 from jax._src import pretty_printer as pp
@@ -421,7 +420,7 @@ def _get_vmap(batched_args, batched_dims, *, indexed_dims):
       # `idxs` doesn't include the non indexed dims.
       idx_place = [i for i, i_dim in enumerate(indexed_dims)
                    if i_dim].index(ref_dim)
-      iota = lax.broadcasted_iota(np.dtype('int32'), idxs_shape, 0)
+      iota = jax.lax.broadcasted_iota(np.dtype('int32'), idxs_shape, 0)
       idxs = tuple_insert(idxs, idx_place, iota)
     else:
       bdim_out = _output_bdim(indexed_dims, ref_dim, idxs_shape)
@@ -454,7 +453,7 @@ def _swap_vmap(batched_args, batched_dims, *, indexed_dims):
     indexed_dims = tuple_insert(indexed_dims, ref_dim, True)
     idx_place = [i for i, i_dim in enumerate(indexed_dims)
                  if i_dim].index(ref_dim)
-    iota = lax.broadcasted_iota(np.dtype('int32'), idxs_shape, 0)
+    iota = jax.lax.broadcasted_iota(np.dtype('int32'), idxs_shape, 0)
     idxs = tuple_insert(idxs, idx_place, iota)
     val = batching.moveaxis(val, val_dim, 0)
     bdim_out = 0
@@ -487,7 +486,7 @@ def _addupdate_vmap(batched_args, batched_dims, *, indexed_dims):
     idx_place = [i for i, i_dim in enumerate(indexed_dims)
                  if i_dim].index(ref_dim)
     idxs_shape, = {i.shape for i in idxs} or [()]
-    iota = lax.broadcasted_iota(np.dtype('int32'), idxs_shape, 0)
+    iota = jax.lax.broadcasted_iota(np.dtype('int32'), idxs_shape, 0)
     idxs = tuple_insert(idxs, idx_place, iota)
     val = batching.moveaxis(val, val_dim, 0)
   return addupdate_p.bind(ref, val, *idxs, indexed_dims=indexed_dims), []

--- a/jax/_src/state/utils.py
+++ b/jax/_src/state/utils.py
@@ -1,0 +1,54 @@
+# Copyright 2023 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for tracing stateful functions."""
+
+from jax.interpreters import partial_eval as pe
+from jax._src import core
+from jax._src import linear_util as lu
+from jax._src.state import AbstractRef
+from jax._src.util import (partition_list, merge_lists, split_list, safe_map,
+                           safe_zip)
+from jax._src.state.primitives import ref_get
+
+map, unsafe_map = safe_map, map
+zip, unsafe_zip = safe_zip, zip
+
+def hoist_consts_to_refs(jaxpr: core.Jaxpr) -> core.Jaxpr:
+  all_const_avals = [var.aval for var in jaxpr.constvars]
+  is_const_ref = [isinstance(var.aval, AbstractRef) for var in
+                  jaxpr.constvars]
+  const_avals_, const_ref_avals = partition_list(is_const_ref, all_const_avals)
+  const_avals = map(AbstractRef, const_avals_)
+  merged_const_avals = merge_lists(is_const_ref, const_avals, const_ref_avals)
+  arg_avals = [var.aval for var in jaxpr.invars]
+  in_avals = [*merged_const_avals, *arg_avals]
+  num_consts = len(merged_const_avals)
+
+  def _hoist(*consts_args):
+    all_consts, args = split_list(consts_args, [num_consts])
+    consts, const_refs = partition_list(is_const_ref, all_consts)
+    # We immediately read the const values out of the `Ref`s.
+    consts = map(lambda x: ref_get(x, ()), consts)
+    all_consts = merge_lists(is_const_ref, consts, const_refs)
+    return core.eval_jaxpr(jaxpr, all_consts, *args)
+  hoisted_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
+      lu.wrap_init(_hoist), in_avals)
+  assert not consts, "All consts should have been converted to refs"
+  return hoisted_jaxpr
+
+def val_to_ref_aval(x) -> AbstractRef:
+  aval = core.raise_to_shaped(core.get_aval(x))
+  if type(aval) is not core.ShapedArray:
+    raise Exception(f"can't make ref from {x}")
+  return AbstractRef(aval)


### PR DESCRIPTION
# Background

## Side effects and types
We often say JAX is inspired by functional programming when discussing the requirement that programs in JAX be *pure* to be transformed. However, taking more inspiration from functional programming, we could lift that requirement. Specifically, JAX could allow side-effects, but only effects that JAX's type system can track and ones that have well-defined interactions with transformations.

What does it mean to track effects in the type system? Consider how the Koka programming language incorporates effects into its type system:

```koka
fun sqr    : (int) -> total int       // total: mathematical total function    
fun divide : (int,int) -> exn int     // exn: may raise an exception (partial)  
fun turing : (tape) -> div int        // div: may not terminate (diverge)  
fun print  : (string) -> console ()   // console: may write to the console  
fun rand   : () -> ndet int           // ndet: non-deterministic
```

In Koka, the type of a function not only contains its input and output types, but also a list of effect types. For example, the print function has the `console` effect and the `randr` function has the `ndet` effect. Functions can have multiple effects, which often happens when effectful functions are composed. At the Jaxpr level, JAX currently similarly tracks effect types (specifically the effects field in Jaxprs is the set of side effects associated with the Jaxpr).

We can add a primitive with the ndet effect pretty easily into JAX.

```python
random_p = core.Primitive('random')
@random_p.def_effectful_abstract_eval
def _random_abstract_eval():
  return core.ShapedArray((), jnp.float32), {"ndet"}

def f():
  return random_p.bind()
jaxpr = jax.make_jaxpr(f)()
print(jaxpr.effects)  # ⇒ Prints {"ndet"}
```

The `ndet` effect in the previous example is unhandled, meaning that if we try evaluating this jaxpr or lowering it to MHLO, we will get a type error (something along the lines of “cannot run a primitive with an `ndet` effect” or “cannot lower a jaxpr with an `ndet` effect”). In order to transform this jaxpr into something practical (something we can run, or lower to MHLO), we “discharge” the effect with a transformation.

For example, to discharge the `ndet` effect, we could convert the jaxpr into one that is deterministic but consumes a functional source of randomness, i.e. a `jax.random.PRNGKey`. We write the following “discharge” transformation:
`run_ndet :: (a -> {ndet} b) -> (PRNGKey -> a -> b)`


Pairing side-effects with discharging transformations enables their usage with other parts of JAX. For example, we could now `vmap` the function returned from `run_ndet`.

## The state effect from Dex
JAX takes inspiration from Dex and Koka for its effect types. One of the effects from Dex that is of particular interest is the *state* effect.

From the Dex prelude, we see that Dex offers a set of effectful functions (`get`, `:=` and `ask`) that each consume a special Ref type and emit a side-effect.
```dex
def Ref (r:Type) (a:Type) : Type = %Ref r a
def get  {h s} (ref:Ref h s)       : {State h} s    = %get  ref
def (:=) {h s} (ref:Ref h s) (x:s) : {State h} Unit = %put  ref x
def ask  {h r} (ref:Ref h r)       : {Read  h} r    = %ask  ref
```

For example, when we pass a `Ref h s` into `get`, we are returned a value of type `s` and emit a `State h` effect. 

Dex has already established how these effectful primitives are transposed, so we follow their lead in incorporating these stateful primitives into JAX.

# Reference types and stateful primitives
We add a new type to JAX and Jaxprs: `Ref`s.
```
data Ref = Ref Array
```

`Ref`s are basically wrapper around Array types that allow reading from and writing into the Array. Note that Arrays in JAX are immutable, so Refs offer mutation semantics.

`Ref`s can be input to Jaxprs but not outputs. An example Jaxpr is:
```
{ lambda ; a:Ref{float32[4]} b:Ref{bool[]} .
  ...
  in ...
}
```

### Why not make mutable arrays?
Why not just make Arrays mutable? Well, we can index into an Array a giving us another Array b. If we mutate b does that also mutate a? Tracking these aliased arrays can be really tricky. We can circumvent this particular aliasing problem by making a single mutable type that produces immutable types when read from.

## Effectful primitives
Refs can only be manipulated/used with 3 new JAX primitives: `get`, `swap`, and `addupdate`. All of these primitives can be provided indices that are used to manipulate subarrays in the Ref. Like in NumPy, we can index Refs using Python integers, Python slice objects, and integer Arrays.
```
type Indices = Tuple[Int | Slice | Array, ...]
```


Each of the state primitives is effectful, specifically when called, it emits an effect that is recorded into the type signature of the containing Jaxpr. Stateful primitives emit effects that are tied to their input Refs. In the notation below, we indicate this by using a “heap parameter” h. In practice, we tie the effect to the corresponding abstract reference value when determining the type of the Jaxpr. We cannot lower or evaluate Jaxprs that have state effects present.

### `get`
`get` is a JAX primitive that reads from an `Ref`. Specifically, it can do indexed reads from a `Ref` and returns an Array while emitting the Read effect.
```
get :: Ref h -> Indices -> {Read h} Array
```


Example usage:
```python
x = get(x_ref, (0, slice(0, 2)))
# Equivalent sugar:
y = x_ref[0, :2]
```

### `swap`

`swap` is a JAX primitive that first performs an indexed read from a Ref and then updates the Ref at the provided indices with a new value Array and returns the old value.
```
swap :: Ref h -> Indices -> Array -> {Write h} Array
```


Example usage:
```python
x = swap(x_ref, (0, slice(0, 2)), y)
# Analogous to: x, x_ref[0, :2] = x_ref[0, :2], y
```


We also use the shorthand set when the value returned by swap is ignored.
```python
set(x_ref, (0, slice(0, 2)), y)
# Equivalent sugar:
x_ref[0, :2] = y
```

### `addupdate`
`addupdate` is a JAX primitive that accumulates (i.e. adds) a value into a Ref at some specified indices.
```
addupdate :: Ref h -> Indices -> Array -> {Accum h} ()
```


Example usage:
```python
addupdate(x_ref, (0, slice(0, 2)), y) # Analogous to `x_ref[0, :2] += y`
```

# Creating Refs and discharging state effects

Thus far we have discussed manipulating Refs and their associated side-effects. We have not discussed how Refs are created and how the side-effects are discharged to produce functions that are compilable.

We introduce `run_state`, a higher-order function that creates Refs initialized to particular values, runs a stateful function, and returns the final values of the Refs after they have been mutated.
```
run_state :: ([Ref a] -> {Read a, Write a, Accum a | eff} ()) -> [a] -> {eff} [a]
```

`run_state` doesn’t have any state effects corresponding to the created Refs, “discharging” the state effects. Note that other effects `{eff}` will remain (e.g. error effects, or state effects corresponding to outer Refs).

An important point here is that we have not provided a way of creating Refs in “top level” user code. What we mean by this is that only run_state creates Refs, and there is no make_ref function.

## Implementation

`run_state` runs a Jaxpr interpreter (i.e. it's an initial-style primitive) that keeps track of the values associated with Refs. When the interpreter hits an effectful primitive that operates on a Ref introduced by run_state, we run a discharge rule wherein we convert the stateful semantics into value semantics. For example, the `get` primitive can be discharged into `lax.dynamic_slice` or `lax.gather` depending on the index pattern. Similarly `swap` is discharged into a `dynamic_slice/gather` and `dynamic_update_slice/scatter`. `addupdate` is discharged into a `dynamic_slice/gather`, `add`, and `dynamic_update_slice/scatter`. `run_state` is also responsible for discharging higher-order primitives that contain state effects (for example, control flow primitives or nested jits). Note that `run_state` is only responsible for discharge effects corresponding to the Refs it introduces and no others.

## Usage with control flow
State primitives should *just work* with control flow primitives. You won’t, however, be able to pass Refs into them or return Refs from them. Reading from and writing into closed-over Refs should be sufficient.

## Examples without transformations
#### Implementing a simple pure function by discharging state effects

Using only one read-write Ref
```python
def f(x_ref):
  x = get(x_ref, ())
  set(x_ref, (), x * 2)

def mul2(x):
  return run_state(f)(x)
```

Using read-only and write-only Refs
```python
def f(refs):
  x_ref, y_ref = refs
  x = get(x_ref, ())
  set(y_ref, (), x * 2)

def mul2(x):
  return run_state(f)(x, 0)[1]
```

#### Array indexing
```python
def f(x_ref, i_ref, v_ref):
  i = get(i_ref, ())
  set(x_ref, (i,), get(v_ref, ()))

def set_at_index(x, i, v):
  return run_state(f)(x, i, v)[0]
set_at_index(jnp.arange(4), 2, -1)
# ⇒ Returns [0, 1, -1, 3]
```

#### Nesting state effects
Here’s an example where we nest two `run_state`s with non-overlapping state effects
```python
def square_ref(x_ref):
  x = x_ref[()]
  set(x_ref, (), jnp.square(x))

def f(x_ref, y_ref):
  x = x_ref[()]
  mul_x = run_state(square_ref)(x)
  set(y_ref, (), mul_x)
run_state(f)(2, 0)
# ⇒ Returns (2, 4)
```

Here’s an example where we mutate an outer Ref from a nested run_state
```python
def f(x_ref, y_ref):
  def set_x(z_ref):
    # Mutating a closed-over `Ref`
    set(x_ref, (), get(z_ref, ()))
  run_state(set_x)(4)
  set(y_ref, (), get(x_ref, ()))
run_state(f)(2, 0)
# ⇒ Returns (4, 4)
```

#### Using state inside of control flow
Here we write to a Ref inside of a `fori_loop` body.
```python
def f(x_ref, y_ref):
  def body(i, _):
    set(y_ref, (i,), get(x_ref, (i,)) + 1)
  lax.fori_loop(0, x_ref.shape[0], body, ())
run_state(f)(jnp.arange(4), jnp.zeros(4))[1]
# ⇒ Returns [1., 2., 3., 4.]
```

Here we conditionally write to a Ref using a `lax.cond`
```python
def f(x_ref):
  def true_fun():
    set(x_ref, (), 100)
  def false_fun():
    pass
  x = get(x_ref, ())
  lax.cond(x < 100, true_fun, false_fun)
run_state(f)(5)   # ⇒ Returns 100
run_state(f)(105) # ⇒ Returns 105
```

# Transformations of effectful functions

In general, we disallow passing `Ref`s into higher order functions. They *must* be closed over, meaning we only need to take care of some cases under transformations. However, `run_state` should always be transformable by JAX functions, since it has a pure signature (it discharges away state effects).
## Autodifferentiation

If we are differentiating a function, we can safely assume there are no Ref inputs and therefore we are not differentiating with respect to any Refs. Functions we are differentiating that close over Refs and updating them is fair game. However, we will never need to apply transformation rules to the primitives in this case since they will only ever show up as purely primal values (no associated tangents). They will similarly not show up in the backwards pass so no transpose rule needed.

In this example, we are mutating x_ref inside of a function we are taking `jax.grad` of. `x` is mutated in the forward pass and is untouched during the backward pass.
```python
def f(x_ref):
  def mul(x):
    z = x_ref[()]
    x_ref[()] += 1
    return jnp.sin(x * z)
  x = x_ref[()]
  z = jax.grad(mul)(x)
  x_ref[()] = z
run_state(f)(2)
```

Differentiating through `run_state` is something we also support, but involves dealing with transforming the state primitives. When we are differentiating w.r.t. to values that are then passed into run_state to initialize Refs, we will need to differentiate through the body of run_state, which contains state side-effects.

With these rules in place, we can mechanically differentiate run_state with little modification to JAX’s core machinery.

# Examples with transformations

Differentiating through run_state
```python
def f(x_ref):
  x_ref[()] = jnp.sin(x_ref[()])
jax.grad(lambda x: run_state(f)(x))(4.) ⇒ Returns cos(4.)
```

Digging deeper into this, the function we are differentiating is this (in jaxpr representation):
```
{ lambda ; a:f32[]. let
    b:f32[] = run_state[
      jaxpr={ lambda ; c:Ref{float32[]}. let
          d:f32[] = get c ()
          e:f32[] = sin d
          _:f32[] = swap c () e
        in () }
    ] a
  in (b,) }
```

When we take its gradient, we obtain the following function:
```
{ lambda ; a:f32[]. let
    _:f32[] b:f32[] = run_state[
      jaxpr={ lambda ; c:Ref{float32[]} d:Ref{float32[]}. let
          e:f32[] = get c ()
          f:f32[] = sin e
          g:f32[] = cos e
          _:f32[] = swap c () f
          _:f32[] = swap d () g
        in () }
    ] a
    _:f32[], h:f32[] = run_state[
      jaxpr={ lambda ; i:Ref{float32[]} j:Ref{float32[]}. let
          k:f32[] = get i ()
          l:f32[] = swap j () 0.0
          m:f32[] = mul l k
          addupdate j () m
        in () }
    ] b 1.0
  in (h,) }
```

Notice that we have two `run_state`s in our gradient function. The first corresponds to the forward pass where we compute `sin(x)` and the residual term `cos(x)`. The residual term is passed into the second `run_state` and read into the variable k. We then perform the transpose where the `get` and `swap` in the first jaxpr are turned into an `addupdate` and `swap` respectively (and run in reverse). The end result is that we write `cos(x) * 1.` into `j` and return `cos(x)` from the function.

Still TODO: vmap rule