### PR TITLE
add experimental jax_log_checkpoint_residuals option

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -749,6 +749,13 @@ log_compiles = config.define_bool_state(
           'option is set, the log level is WARNING; otherwise the level is '
           'DEBUG.'))
 
+log_compiles = config.define_bool_state(
+    name='jax_log_checkpoint_residuals',
+    default=False,
+    help=('Log a message every time jax.checkpoint (aka jax.remat) is '
+          'partially evaluated (e.g. for autodiff), printing what residuals '
+          'are saved.'))
+
 parallel_functions_output_gda = config.define_bool_state(
     name='jax_parallel_functions_output_gda',
     default=False,


### PR DESCRIPTION
The main idea here is to improve tooling for knowing what residuals are being saved and why. There's a lot more that can be done here (e.g. naming the arguments, explaining what JVP rule produced these residuals, explaining what consumed them, etc) but this is a start.

```python
from functools import partial

import jax
import jax.numpy as jnp

@partial(jax.remat, policy=lambda p, *_, **__: str(p) == 'cos')
def f(x):
  x = jnp.sin(x)
  x = jnp.cos(x.sum())
  return x

jax.grad(f)(jnp.arange(3.))
```

```bash
JAX_LOG_CHECKPOINT_RESIDUALS=1 python qiao37.py
```

```
remat-decorated function saving inputs with shapes:
  float32[3]
and saving these intermediates:
  float32[3] from output of cos from /usr/local/google/home/mattjj/packages/jax/qiao37.py:11 (f)
```