### PR TITLE
jax.random: clean up handling of dtypes

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -616,6 +616,15 @@ def dtype(x: Any, *, canonicalize: bool = False) -> DType:
                     "type. Only arrays of numeric types are supported by JAX.")
   return canonicalize_dtype(dt) if canonicalize else dt
 
+def default_int():
+  return canonicalize_dtype(int_)
+
+def default_float():
+  return canonicalize_dtype(float_)
+
+def default_complex():
+  return canonicalize_dtype(complex_)
+
 def _lattice_result_type(*args: Any) -> Tuple[DType, bool]:
   dtypes, weak_types = zip(*(_dtype_and_weaktype(arg) for arg in args))
   if len(dtypes) == 1:

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -978,7 +978,7 @@ class LaxRandomTest(jtu.JaxTestCase):
 
   @jtu.sample_product(
     lam=[0.5, 3, 9, 11, 50, 500],
-    dtype=[np.int16, np.int32, np.int64],
+    dtype=jtu.dtypes.integer,
   )
   def testPoisson(self, lam, dtype):
     key = self.seed_prng(0)

--- a/tests/x64_context_test.py
+++ b/tests/x64_context_test.py
@@ -111,6 +111,7 @@ class X64ContextTests(jtu.JaxTestCase):
       self.assertEqual(x64.result(), jnp.int64)
       self.assertEqual(x32.result(), jnp.int32)
 
+  @jtu.ignore_warning(category=UserWarning, message="Explicitly requested dtype float64")
   def test_jit_cache(self):
     if jtu.device_under_test() == "tpu":
       self.skipTest("64-bit random not available on TPU")


### PR DESCRIPTION
This change regularizes the handling of the `dtype` argument to `jax.random` distributions. The main changes:

1. Previously, the default behavior clobbered the dtype of the inputs. Now, if `dtype` is not specified, it will be derived from input parameters. For example, previously this was the behavior:
```python
>>> random.uniform(random.PRNGKey(0), minval=jnp.bfloat16(0), maxval=jnp.bfloat16(1))
Array(0.41845703, dtype=float32)
```
Now this is the behavior:
```python
>>> random.uniform(random.PRNGKey(0), minval=jnp.bfloat16(0), maxval=jnp.bfloat16(1))
Array(0, dtype=bfloat16)
```

2. Previously there was no warning in case of the specified dtype being truncated. For example, previously this was the behavior (with `jax_enable_x64=False`):
```python
>>> random.uniform(random.PRNGKey(0), dtype='float64')
Array(0.41845703, dtype=float32)
```
Now this is the behavior:
```python
>>> random.uniform(random.PRNGKey(0), dtype='float64')
UserWarning: Explicitly requested dtype float64 requested in uniform is not available, and will be truncated to dtype float32.
To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable.
 See https://github.com/google/jax#current-gotchas for more.

Array(0.41845703, dtype=float32)
```