### PR TITLE
improve scan error messages

### DIFF
--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -107,7 +107,6 @@ def _check_tree_and_avals(what, tree1, avals1, tree2, avals2):
                     tree_unflatten(tree2, avals2))
     raise TypeError(f"{what} must have identical types, got\n{diff}.")
 
-
 def _check_tree(func_name, expected_name, actual_tree, expected_tree, has_aux=False):
   if has_aux:
     actual_tree_children = actual_tree.children()


### PR DESCRIPTION
@zhangqiaorjc sniped me into this...

Consider:
```python
import jax
import jax.numpy as jnp
jax.lax.scan(lambda x, _: (({'a': x[0]['a'], 'b': x[0]['a']},) * 2, None), ({'a': jnp.array(0, 'int32')},) * 2, None, length=1)
```

Before (hard-wrapped to 80 columns for github):
```
TypeError: scan carry output and input must have same type structure, got
PyTreeDef(({'a': *, 'b': *}, {'a': *, 'b': *})) and PyTreeDef(({'a': *}, {'a':
*})).
```

After this PR (again hard-wrapped manually):
```
TypeError: Scanned function carry input and carry output must have the same
pytree structure, but they differ:
  * the input carry component x[0] is a <class 'dict'> with 1 child but the
  corresponding component of the carry output is a <class 'dict'> with 2
  children, so the numbers of children do not match, with the symmetric
  difference of key sets: {'b'}

  * the input carry component x[1] is a <class 'dict'> with 1 child but the
  corresponding component of the carry output is a <class 'dict'> with 2
  children, so the numbers of children do not match, with the symmetric
  difference of key sets: {'b'}

Revise the scanned function so that its output is a pair where the first element
has the same pytree structure as the first argument.
```

Also consider:
```python
jax.lax.scan(lambda x, _: ((x[0].astype('float32'), x[1].astype('float32').reshape(1, 1)), None), (jnp.array(0, 'int32'),) * 2, None, length=1)
```

Before:
```
TypeError: scan carry output and input must have identical types, got
('DIFFERENT ShapedArray(float32[]) vs. ShapedArray(int32[])', 'DIFFERENT
ShapedArray(float32[1,1]) vs. ShapedArray(int32[])').
```

After this PR:
```
TypeError: Scanned function carry input and carry output must have equal types
(e.g. shapes and dtypes of arrays), but they differ:
  * the input carry component x[0] has type int32[] but the corresponding output
  carry component has type float32[], so the dtypes do not match

  * the input carry component x[1] has type int32[] but the corresponding output
  carry component has type float32[1,1], so the dtypes do not match and also
  the shapes do not match

Revise the scanned function so that all output types (e.g. shapes and dtypes)
match the corresponding input types.
```