### PR TITLE
[dynamic-shapes] djax+pjit staging to jaxpr

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -308,7 +308,7 @@ def jit(
         out_shardings=out_shardings, static_argnums=static_argnums,
         static_argnames=static_argnames, donate_argnums=donate_argnums,
         device=device, backend=backend, keep_unused=keep_unused,
-        inline=inline, resource_env=None)
+        inline=inline, resource_env=None, abstracted_axes=abstracted_axes)
     return pjit.common_infer_params(pjit_info_args, *args, **kwargs)
 
   has_explicit_sharding = pjit._pjit_explicit_sharding(

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4710,4 +4710,21 @@ class BIntRules:
       return core.DArray(aval, buf)
     return handler
 
+  @staticmethod
+  def global_sharded_result_handler(aval, out_sharding, committed,
+                                    is_out_sharding_from_xla):
+    phys_aval, = BIntRules.physical_avals(aval)
+    phys_handler_maker = pxla.global_result_handlers[core.ShapedArray]
+
+    if not dispatch.is_single_device_sharding(out_sharding):
+      raise NotImplementedError  # TODO(mattjj)
+    else:
+      phys_sharding = out_sharding
+    phys_handler = phys_handler_maker(phys_aval, phys_sharding, committed,
+                                      is_out_sharding_from_xla)
+
+    def handler(bufs):
+      return core.DArray(aval, phys_handler(bufs))
+    return handler
+
 core.bint._rules = BIntRules

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1732,6 +1732,7 @@ class DynamicJaxprTrace(core.Trace):
     tracer = self.frame.constid_to_tracer.get(id(c))
     if tracer is None:
       aval = raise_to_shaped(get_aval(c), weak_type=dtypes.is_weakly_typed(c))
+      aval = self._lift_tracers_in_aval(aval)
       tracer = self._new_const(aval, c)
     return tracer
 
@@ -1820,8 +1821,8 @@ class DynamicJaxprTrace(core.Trace):
     for aval, _ in out_type:
       if type(aval) is DShapedArray:
         shape = [[*consts, *in_tracers][d.val] if type(d) is InDBIdx else
-                out_tracers[d.val] if type(d) is OutDBIdx else
-                d for d in aval.shape]
+                 out_tracers[d.val] if type(d) is OutDBIdx else
+                 d for d in aval.shape]
         aval = aval.update(shape=tuple(get_referent(d) for d in shape))
       out_tracers.append(DynamicJaxprTracer(self, aval, source_info))
     invars = map(self.getvar, in_tracers)


### PR DESCRIPTION
This is the first in a sequence of PRs making the dynamic shape machinery work with `pjit`, aka the new "initial-style" `jit`. (Previously it only worked with the old "final-style" `jit`.)

Concretely, we want to make all the tests in `tests/dynamic_api_test.py` work again (better than ever!).

We're going to break this down into a sequence of steps:
1. [x] staging-to-jaxpr e.g. with `jax.make_jaxpr` (this PR, #15187)
3. [ ] padded-and-masked bint-based lowering and execution (e.g. with XLA, using our own padding-and-masking and/or using the HLO DynamicPadder)
4. [ ] dynamic shape compiler lowering and execution (e.g. with IREE)
5. [ ] autodiff e.g. with `jax.jvp`, `jax.linearize`, and `jax.grad`
6. [ ] batching e.g. with `jax.vmap`

Once we get these things working again, we'll be able to start landing new features!

---

This PR tackles staging to dynamic shape jaxprs. The relevant tests, moved to their own `DynamicShapeStagingTest` class and un-skipped in this PR, basically involve using `jax.make_jaxpr`, though the main work is in the underlying `partial_eval.trace_to_jaxpr_dynamic2` and the changes to `pjit`.

So most of this PR is adapting pre-existing stuff for the old `jit` to work with the new `jit`/`pjit`.

Here's an overview of the changes made in this PR and why they were needed:
* The changes in tests/dynamic_api_test.py are just code movement, plus renaming like `xla_call_p` -> `pjit` and `call_jaxpr`->`jaxpr`.
* In partial_eval.py, we needed to handle a previously unhandled case where constants closed over by a `pjit`-decorated function had `Tracer`s in their shapes (and hence those Tracers need to be lifted into the `pjit`-trace). Conceptually, because with dynamic shapes `Tracer`s can now have `Tracer`s in their shapes, whatever we did to handle closed-over `Tracer`s in the static shape world, we now also have to apply to `Tracer`s in the shapes of closed-over `Tracer`s. The reason this case wasn't handled in the previous implementation is that due to a detail of final-style tracing we would hit the `DynamicJaxprTrace.sublift` where with initial-style we now hit `DynamicJaxprTrace.new_const`; see the pre-existing comment in the body of `DynamicJaxprTrace.sublift`. The change here was just a one liner to call `DynamicJaxprTrace._lift_tracers_in_aval`.
* In pjit.py, we had to plumb through the `abstracted_axes` API option, and use it in the call to the new helper `_flat_axes_specs` which resolves the `abstracted_axes` user annotations to the internal abstracted axis size specification. We then use that specification to determine the input type on which to trace the `jit`-decorated Python callable (and the corresponding jaxpr's input type) by calling the existing utility `partial_eval.infer_lambda_input_type`.
* Also in pjit.py, we use that input type `in_type: core.InputType` in place of the tuple of avals `global_in_avals: core.AbstractValue`. The previous `global_in_avals`, representing things like `(f32[3], f32[4, 5])`, was sufficient to represent statically shaped input types on which to trace `jit`-decorated functions. But with dynamic shapes we need to generalize that to represent things more like `(n:i32[], f32[n], f32[4,5])`. That is, a tuple of avals is no longer sufficient. But it's useful to remember that the logic is staying the same: we always had to trace on an input type, it's just that dynamic shape input types are more general.
* The generalization to `core.InputType` has a corresponding generalization of the calling convention for the `pjit_p` primitive: if we apply `jit(f)(x)` for some dynamically-shaped `x` (dynamically shaped due to some outer `jit`), we need to build an input type with axis size arguments, like `(n:i32[], f32[n])`, and the convention is that the `pjit_p` primitive needs to be applied to _two_ arguments, corresponding to the pair `(x.shape[0], x)`. That is, with dynamic shapes, we need to automatically extract implicit-to-user-code axis size arguments. That's also done in pjit.py, in the function `_extract_implicit_args`, which is like an intial-style analogue of the pre-existing `partial_eval._extract_implicit_args` utility for final-style.
* The staging rule for `pjit_p` also needs to be generalized, mainly to be able to produce output `Tracer`s with `Tracer`s in their shapes, i.e. to be able to produce dynamically-shaped outputs.

All of the changes are guarded by the `jax.config.jax_dynamic_shapes` flag, so unless I've made a mistake we shouldn't be breaking anyone's code.