### PR TITLE
[CI] remove another dependency not currently needed.

### DIFF
--- a/.github/workflows/slurm_job_scripts/run_e2e_t5x_tests.sub
+++ b/.github/workflows/slurm_job_scripts/run_e2e_t5x_tests.sub
@@ -49,7 +49,7 @@ rm -rf ${E2E_TESTS_WORKSPACE_DIR}/* \
 && mkdir -p ${TFDS_DATA_DIR} \
 && python3.8 -m pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html \
 && git clone https://github.com/google-research/t5x.git ${T5X_DIR} \
-&& python3.8 -m pip uninstall -y cudf \
+&& python3.8 -m pip uninstall -y cudf dask-cudf \
 && python3.8 -m pip install ${T5X_DIR} \
 && python3.8 -m pip install ${T5X_DIR}/t5x/contrib/gpu/scripts_gpu/dummy_wikipedia_config \
 && hostname > ${E2E_TESTS_WORKSPACE_DIR}/hostname.txt


### PR DESCRIPTION
To fix this error:
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
dask-cudf 22.8.0a0+304.g6ca81bbc78.dirty requires cudf, which is not installed.
```