### PR TITLE
Editable jaxlib build

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -446,6 +446,10 @@ def main():
       default=None,
       help="CPU platform to target. Default is the same as the host machine. "
            "Currently supported values are 'darwin_arm64' and 'darwin_x86_64'.")
+  parser.add_argument(
+      "--editable",
+      action="store_true",
+      help="Create an 'editable' jaxlib build instead of a wheel.")
   add_boolean_argument(
       parser,
       "configure_only",
@@ -558,6 +562,8 @@ def main():
     [":build_wheel", "--",
     f"--output_path={output_path}",
     f"--cpu={wheel_cpu}"])
+  if args.editable:
+    command += ["--editable"]
   print(" ".join(command))
   shell(command)
   shell([bazel_path] + args.bazel_startup_options + ["shutdown"])

--- a/build/build_wheel.py
+++ b/build/build_wheel.py
@@ -48,6 +48,10 @@ parser.add_argument(
   default=None,
   required=True,
   help="Target CPU architecture. Required.")
+parser.add_argument(
+  "--editable",
+  action="store_true",
+  help="Create an 'editable' jaxlib build instead of a wheel.")
 args = parser.parse_args()
 
 r = runfiles.Create()
@@ -299,6 +303,15 @@ def build_wheel(sources_path, output_path, cpu):
     shutil.copy(wheel, output_path)
 
 
+def build_editable(sources_path, output_path):
+  sys.stderr.write(
+    "To install the editable jaxlib build, run:\n\n"
+    f"  pip install -e {output_path}\n\n"
+  )
+  shutil.rmtree(output_path, ignore_errors=True)
+  shutil.copytree(sources_path, output_path)
+
+
 tmpdir = None
 sources_path = args.sources_path
 if sources_path is None:
@@ -308,7 +321,10 @@ if sources_path is None:
 try:
   os.makedirs(args.output_path, exist_ok=True)
   prepare_wheel(sources_path)
-  build_wheel(sources_path, args.output_path, args.cpu)
+  if args.editable:
+    build_editable(sources_path, args.output_path)
+  else:
+    build_wheel(sources_path, args.output_path, args.cpu)
 finally:
   if tmpdir:
     tmpdir.cleanup()


### PR DESCRIPTION
This PR adds an `--editable` option to the `build/build.py` script. When set, the build script will
1. Upon compilation completion, copy the jaxlib source folder and the compiled `.so` files from the Bazel sandbox to the output path (`dist`  by default)
2. print a message prompting users to use `pip install -e` to install jaxlib in-place at the output path.

This way, we only need to run `pip install -e` once, and subsequent Bazel builds with `--editable ` will automatically update the installed jaxlib package (e.g., in a virtual environment).

Things worth consideration:
- Would it be better to copy the compiled `.so` files directly back into the jaxlib source folder and run `pip install -e` there? This way, rebuilding is not needed if changes only apply to Python files.

This PR is adapted from the Alpa project as part of a rebasing effort, with contributions from @merrymercy, @zhisbug, @ZYHowell, @zhuohan123 among many others.