### PR TITLE
Suppress mypy warnings about missing imports.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -25,3 +25,31 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-iree.*]
 ignore_missing_imports = True
+[mypy-rich.*]
+ignore_missing_imports = True
+[mypy-optax.*]
+ignore_missing_imports = True
+[mypy-flax.*]
+ignore_missing_imports = True
+[mypy-tensorflow.*]
+ignore_missing_imports = True
+[mypy-tensorflowjs.*]
+ignore_missing_imports = True
+[mypy-tensorflow.io.*]
+ignore_missing_imports = True
+[mypy-tensorstore.*]
+ignore_missing_imports = True
+[mypy-web_pdb.*]
+ignore_missing_imports = True
+[mypy-etils.*]
+ignore_missing_imports = True
+[mypy-google.colab.*]
+ignore_missing_imports = True
+[mypy-pygments.*]
+ignore_missing_imports = True
+[mypy-jraph.*]
+ignore_missing_imports = True
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+[mypy-tensorboard_plugin_profile.convert.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Many warnings are emitted if you simply run `mypy jax`; this PR suppresses them.