### PR TITLE
first implementation of scipy fftconvolve

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -77,6 +77,7 @@ jax.scipy.signal
 .. autosummary::
   :toctree: _autosummary
 
+   fftconvolve
    convolve
    convolve2d
    correlate

--- a/jax/scipy/signal.py
+++ b/jax/scipy/signal.py
@@ -16,6 +16,7 @@
 # See PEP 484 & https://github.com/google/jax/issues/7570
 
 from jax._src.scipy.signal import (
+  fftconvolve as fftconvolve,
   convolve as convolve,
   convolve2d as convolve2d,
   correlate as correlate,


### PR DESCRIPTION
I have prepared an implementation of the `scipy` `fftconvolve` function. 
There are limitations wrt the scipy function on the `mode` used (only `same` is implemented) and `axes` argument is fixed to None.

I have not written proper test suite as I am not a specialist of this. However, I have a nb on Collab with some checks against scipy fftconvolve. [see HERE](https://colab.research.google.com/drive/1PFreb5GiTzpw60wE-CYPMq_sDB_DRJqz?usp=sharing).

As mentioned in discussion [#15204](https://github.com/google/jax/discussions/15204), the scipy fft  `next_fast_len` would require more work to be adapted to all devices (CPU, GPU, TPU), in my implementation I only consider power of 2 like FFT extension of the original shapes.

 