### PR TITLE
CI: add numpy & scipy to mypy env

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
   - id: mypy
     files: (jax/|tests/typing_test\.py)
     exclude: jax/_src/basearray.py  # Use pyi instead
-    additional_dependencies: [types-requests==2.28.11, jaxlib==0.4.6, ml_dtypes==0.0.3]
+    additional_dependencies: [types-requests==2.28.11, jaxlib==0.4.6, ml_dtypes==0.0.3, numpy==1.21.6, scipy==1.7.3]
 
 - repo: https://github.com/mwouts/jupytext
   rev: v1.14.4


### PR DESCRIPTION
The pre-commit mypy job doesn't install any dependencies unless they are explicitly listed. This should make the type checks more reflective of a real JAX python environment.