### PR TITLE
[shape_poly] Refactor the computation of the dimension variables in native serialization

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -744,8 +744,7 @@ def run_exported_as_tf(args_avals: Sequence[core.ShapedArray],
   call_module_attrs = dict(
       version=exported.xla_call_module_version,
       Tout=out_types,
-      Sout=out_shapes,
-      dim_args_spec=exported.dim_args_spec)
+      Sout=out_shapes)
 
   if exported.xla_call_module_version >= 3:
     if native_serialization_strict_checks:

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -1447,7 +1447,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
                      native_serialization=False)(x)
     with self.assertRaisesRegex(
         ValueError,
-        "dimension variables cannot be computed from the static shapes of the kept lowered arguments"):
+        "dimension variables cannot be computed from the static shapes of the array arguments"):
       jax2tf.convert(lambda x: jnp.sum(x), polymorphic_shapes=["a + b"],
                      native_serialization=True)(x)
 


### PR DESCRIPTION

Currently, JAX native serialization produces a module whose main function takes additional arguments for the values of the dimension variables. These values are then resolved in the XlaCallModule based on a dim_args_spec parameter.

We move the code that computes the dimension variables from XlaCallModule to jax_export following pretty much the same technique. This simplifies XlaCallModule and especially its API (the dim_args_spec). So far this is just a refactoring with no semantic changes, but this will allow us to improve the support for dimension variables that occur in linear polynomials, e.g., "2*b" rather than just "b".