### PR TITLE
Bump minimum jaxlib version from 0.4.6 to 0.4.7.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Remember to align the itemized text with the first line of an item within a list
 
 ## jax 0.4.8
 
+* Changes
+  * The minimum jaxlib version has been bumped from 0.4.6 to 0.4.7.
+
 * Deprecations
   * CUDA 11.4 support has been dropped. JAX GPU wheels only support
     CUDA 11.8 and CUDA 12. Older CUDA versions may work if jaxlib is built

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -64,7 +64,6 @@ from jax._src.lax import lax as lax_internal
 from jax._src.lib import jax_jit
 from jax._src.lib import xla_client as xc
 from jax._src.lib import pmap_lib
-from jax._src.lib import xla_extension_version
 from jax._src.sharding_impls import PmapSharding
 from jax._src.traceback_util import api_boundary
 from jax._src.tree_util import broadcast_prefix, generate_key_paths
@@ -2605,8 +2604,6 @@ def device_put_sharded(shards: Sequence[Any], devices: Sequence[xc.Device]):  # 
       raise ValueError("the shards passed to device_put_sharded must have "
                        f"consistent shape and dtype, but got {a1} and {a2}.")
     stacked_aval = avals[0].update(shape=(len(devices),) + avals[0].shape)
-    if xla_extension_version < 139:
-      xs = [xla.canonicalize_dtype(arg) for arg in xs]
     sharding_spec = pxla._create_pmap_sharding_spec(stacked_aval)
     return pxla.batched_device_put(
         stacked_aval, PmapSharding(np.array(devices), sharding_spec),
@@ -2656,8 +2653,6 @@ def device_put_replicated(x: Any, devices: Sequence[xc.Device]):  # noqa: F811
     assert (isinstance(aval, ShapedArray) and
             len(xla.aval_to_xla_shapes(aval)) == 1)
     sharding_spec = pxla._create_pmap_sharding_spec(aval)
-    if xla_extension_version < 139:
-      x = xla.canonicalize_dtype(x)
     buf = jax.device_put(x, devices[0])
     return pxla.batched_device_put(
         aval, PmapSharding(np.array(devices), sharding_spec),

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -25,7 +25,6 @@ from jax._src import lib
 from jax._src.lib import jax_jit
 from jax._src.lib import transfer_guard_lib
 from jax._src.lib import xla_client
-from jax._src.lib import xla_extension_version
 
 logger = logging.getLogger(__name__)
 
@@ -758,8 +757,6 @@ def _update_jax_array_global(val):
         'jax.config.jax_array cannot be disabled after jax 0.4.7 release.'
         ' Please downgrade to jax and jaxlib 0.4.6 if you want to disable'
         ' jax.config.jax_array.')
-  if xla_extension_version < 141:
-    lib.jax_jit.global_state().jax_array = val
 
 def _update_jax_array_thread_local(val):
   if val is not None and not val:
@@ -767,8 +764,6 @@ def _update_jax_array_thread_local(val):
         'jax.config.jax_array cannot be disabled after jax 0.4.7 release.'
         ' Please downgrade to jax and jaxlib 0.4.6 if you want to disable'
         ' jax.config.jax_array.')
-  if xla_extension_version < 141:
-    lib.jax_jit.thread_local_state().jax_array = val
 
 jax_array = config.define_bool_state(
     name='jax_array',

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -63,7 +63,7 @@ from jax._src.lax.utils import (
 )
 from jax._src.lib import pytree
 from jax._src import xla_bridge
-from jax._src.lib import xla_client, xla_extension_version
+from jax._src.lib import xla_client
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import chlo
 from jax._src.lib.mlir.dialects import hlo
@@ -4209,14 +4209,8 @@ def _rng_bit_generator_lowering(
           (key_shape == [2] and key_etype == u64_type)), (key_shape, key_etype)
   dtype = np.dtype(dtype)
   etype = mlir.dtype_to_ir_type(dtype)
-  if (
-      dtype == np.dtype('uint32')
-      or dtype == np.dtype('uint64')
-      or (
-          xla_extension_version >= 140
-          and (dtype == np.dtype('uint16') or dtype == np.dtype('uint8'))
-      )
-  ):
+  if dtype in (np.dtype('uint8'), np.dtype('uint16'), np.dtype('uint32'),
+               np.dtype('uint64')):
     rbg_etype = etype
   else:
     rbg_etype = u32_type

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -32,7 +32,6 @@ from jax._src import core
 from jax._src import dtypes
 from jax._src import prng
 from jax._src import xla_bridge
-from jax._src.lib import xla_extension_version
 from jax._src.api import jit, vmap
 from jax._src.core import NamedShape
 from jax._src.interpreters import ad
@@ -286,7 +285,7 @@ def _uniform(key, shape, dtype, minval, maxval) -> Array:
     raise TypeError("uniform only accepts 32- or 64-bit dtypes.")
 
   rng_bits = nbits
-  if xla_extension_version >= 140 and nmant < 8:
+  if nmant < 8:
     rng_bits = 8
   bits = _random_bits(key, rng_bits, shape)
   uint_dtype = UINT_DTYPES[nbits]

--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -319,15 +319,7 @@ def register_pjrt_plugin_factories(plugins_from_env: str) -> None:
         options = None
 
       xla_client.load_pjrt_plugin_dynamically(name, library_path)
-      if lib.xla_extension_version >= 134:
-        return xla_client.make_c_api_client(name, options)
-      else:
-        if options:
-          raise ValueError(
-              'Setting PJRT plugin options through json file requires'
-              ' jaxlib.xla_extension_version >= 134.'
-          )
-        return xla_client.make_c_api_client(name)
+      return xla_client.make_c_api_client(name, options)
 
     return factory
 

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -1964,16 +1964,10 @@ def _initialize_outfeed_receiver(
         device_repr = ", ".join([str(d) for d in devices_with_outfeed])
         logger.debug("Starting outfeed_receiver for %s. max_callback_queue_size_bytes=%s",
                        device_repr, max_callback_queue_size_bytes)
-      if jaxlib.xla_extension_version > 143:
-        # TODO(phawkins): remove type:ignore after minimum jaxlib version bump
-        _callback_handler_data.receiver = outfeed_receiver_module.start(
-            _callback_input_received, tuple(clients_with_outfeed),
-            max_callback_queue_size_bytes,
-            xb.get_compile_options(1, 1).executable_build_options)  # type:ignore
-      else:
-        _callback_handler_data.receiver = outfeed_receiver_module.start(
-            _callback_input_received, tuple(clients_with_outfeed),
-            max_callback_queue_size_bytes)
+      _callback_handler_data.receiver = outfeed_receiver_module.start(
+          _callback_input_received, tuple(clients_with_outfeed),
+          max_callback_queue_size_bytes,
+          xb.get_compile_options(1, 1).executable_build_options)  # type:ignore
 
     def exit_handler():
       # Prevent logging usage during compilation, gives errors under pytest

--- a/jax/experimental/jax2tf/jax_export.py
+++ b/jax/experimental/jax2tf/jax_export.py
@@ -129,15 +129,11 @@ def serialize_native(fun_jax: Callable,
     assert len(module_kept_var_idx) == len(args_avals)
     mlir_module = compute_dim_vars(mlir_module, args_avals)
 
-  if xla_client.mlir_api_version >= 46:
-    xla_call_module_version = 4
-    mlir_str = mlir.module_to_bytecode(mlir_module)
-    target_version = stablehlo.get_earliest_forward_compatible_version()
-    mlir_module_serialized = xla_client._xla.mlir.serialize_portable_artifact(
-        mlir_str, target_version)
-  else:
-    xla_call_module_version = 3
-    mlir_module_serialized = mlir.module_to_bytecode(mlir_module)
+  xla_call_module_version = 4
+  mlir_str = mlir.module_to_bytecode(mlir_module)
+  target_version = stablehlo.get_earliest_forward_compatible_version()
+  mlir_module_serialized = xla_client._xla.mlir.serialize_portable_artifact(
+      mlir_str, target_version)
 
   # Figure out the result types and shapes
   if "global_out_avals" in lowered.compile_args:

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -2631,17 +2631,6 @@ class ShapePolyPrimitivesTest(tf_test_util.JaxToTfTestCase):
       if harness.group_name in require_stablehlo_feature_support:
         raise unittest.SkipTest(
             "native lowering with shape polymorphism requires additional StableHLO feature support")
-      # API version 47 supports CHLO ops that decompose into shape dialect ops
-      if xla_client.mlir_api_version < 47:
-        require_stablehlo_feature_support_shape_dialect = {
-          "vmap_acosh", "vmap_asin", "vmap_asinh", "vmap_atan", "vmap_atanh",
-          "vmap_bessel_i1e", "vmap_cosh", "vmap_digamma", "vmap_erf",
-          "vmap_erfc", "vmap_lgamma", "vmap_nextafter",
-          "vmap_nextafter_broadcasting", "vmap_sinh"
-        }
-        if harness.group_name in require_stablehlo_feature_support_shape_dialect:
-          raise unittest.SkipTest(
-              "native lowering with shape polymorphism requires additional StableHLO feature support")
       if (jtu.device_under_test() == "tpu" and
           harness.fullname in [
               "jnp.cumsum_reduce_axis=poly",

--- a/jax/version.py
+++ b/jax/version.py
@@ -16,7 +16,7 @@
 # eval()-ed by setup.py, so it should not have any dependencies.
 
 __version__ = "0.4.8"
-_minimum_jaxlib_version = "0.4.6"
+_minimum_jaxlib_version = "0.4.7"
 
 def _version_as_tuple(version_str):
   return tuple(int(i) for i in version_str.split(".") if i.isdigit())

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -19,9 +19,7 @@ from absl.testing import parameterized
 import jax
 from jax._src import core
 from jax._src import api_util
-from jax._src.interpreters import xla
 from jax._src.interpreters import pxla
-from jax._src.lib import xla_extension_version
 from jax import dtypes
 from jax._src import lib as jaxlib
 from jax import numpy as jnp
@@ -33,8 +31,6 @@ config.parse_flags_with_absl()
 
 def _cpp_device_put(value, device):
   aval = api_util.shaped_abstractify(value)
-  if xla_extension_version < 139:
-    value = xla.canonicalize_dtype(value)
   return pxla.batched_device_put(
       aval, jax.sharding.SingleDeviceSharding(device), [value], [device])
 

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -39,7 +39,6 @@ from jax.interpreters import xla
 from jax._src.interpreters import mlir
 from jax.interpreters import batching
 from jax._src import array
-from jax._src.lib import xla_extension_version
 from jax._src.lib.mlir.dialects import hlo
 from jax._src import dtypes
 from jax._src.interpreters import pxla
@@ -2855,8 +2854,6 @@ class FooTyRules:
         buf, = arr._arrays
       else:
         buf, = arr
-      if xla_extension_version < 140:
-        buf.aval = core.ShapedArray(buf.shape, buf.dtype)
       return FooArray(aval.shape, buf)
     return handler
 


### PR DESCRIPTION
Also removes a bunch of dead version guards (0.4.7 has xla_extension_version 144 and mlir_api_version 47)