### PR TITLE
add overflow errors for numpy.ndarray (from canonicalize_dtype)

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -685,3 +685,13 @@ def check_user_dtype_supported(dtype, fun_name=None):
     fun_name = f"requested in {fun_name}" if fun_name else ""
     truncated_dtype = canonicalize_dtype(dtype).name
     warnings.warn(msg.format(dtype, fun_name , truncated_dtype), stacklevel=3)
+
+def check_ndarray_for_int_overflow(x: np.ndarray):
+  dtype = canonicalize_dtype(x.dtype)
+  if np.issubdtype(dtype, np.integer) and (
+      (x < np.iinfo(dtype).min).any() or (x > np.iinfo(dtype).max).any()):
+    raise OverflowError(
+        f"Some values in a NumPy array of dtype {x.dtype} are too large in "
+        f"magnitude to convert to dtype {dtype}. Try setting "
+        "jax_enble_x64=True. See "
+        "https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#double-64bit-precision")

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -231,6 +231,7 @@ def ir_constant(val: Any, canonicalize_types: bool = True) -> ir.Value:
 def _numpy_array_constant(x: np.ndarray, canonicalize_types
                          ) -> Sequence[ir.Value]:
   if canonicalize_types:
+    dtypes.check_ndarray_for_int_overflow(x)  # TODO(mattjj): test coverage
     x = np.asarray(x, dtypes.canonicalize_dtype(x.dtype))
   element_type = dtype_to_ir_type(x.dtype)
   shape = x.shape

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -432,6 +432,11 @@ def _shard_array(x, devices, indices, sharding):
 for _t in array_types:
   shard_arg_handlers[_t] = _shard_array
 
+def _shard_numpy_ndarray(x, devices, indices, sharding):
+  dtypes.check_ndarray_for_int_overflow(x)
+  return _shard_array(x, devices, indices, sharding)
+shard_arg_handlers[np.ndarray] = _shard_numpy_ndarray
+
 def shard_device_array(x, devices, indices, sharding):
   start_indices, limit_indices, removed_dims = unzip3(
       as_slice_indices(x, idx) for idx in indices)

--- a/jax/_src/interpreters/xla.py
+++ b/jax/_src/interpreters/xla.py
@@ -169,10 +169,13 @@ def canonicalize_dtype(x):
   raise TypeError(f"No canonicalize_dtype handler for type: {type(x)}")
 
 def _canonicalize_masked_array_dtype(x):
-  raise ValueError("numpy masked arrays are not supported as direct inputs to JAX functions. "
-                   "Use arr.filled() to convert the value to a standard numpy array.")
+  raise ValueError("numpy masked arrays are not supported as direct inputs to "
+                   "JAX functions. "
+                   "Use arr.filled() to convert the value to a standard numpy "
+                   "array.")
 
 def _canonicalize_ndarray_dtype(x):
+  dtypes.check_ndarray_for_int_overflow(x)
   return np.asarray(x, dtypes.canonicalize_dtype(x.dtype))
 
 def _canonicalize_python_scalar_dtype(typ, x):

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1941,8 +1941,11 @@ def array(object: Any, dtype: Optional[DTypeLike] = None, copy: bool = True,
   # to be used for type inference below.
   if isinstance(object, (bool, int, float, complex)):
     _ = dtypes.coerce_to_array(object, dtype)
+  if isinstance(object, np.ndarray):
+    dtypes.check_ndarray_for_int_overflow(object)
 
-  object = tree_map(lambda leaf: leaf.__jax_array__() if hasattr(leaf, "__jax_array__") else leaf,
+  object = tree_map(lambda leaf: leaf.__jax_array__()
+                    if hasattr(leaf, "__jax_array__") else leaf,
                     object)
   leaves = tree_leaves(object)
   if dtype is None:

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -19,10 +19,12 @@ import functools
 from functools import partial
 import math
 import re
+import operator
 import os
 import tempfile
 import textwrap
-from typing import Callable, List, Generator, Optional, Sequence, Tuple, Union
+from typing import (Callable, List, Generator, Optional, Sequence, Tuple, Union,
+                    NamedTuple)
 import unittest
 import warnings
 import zlib
@@ -1016,14 +1018,14 @@ class JaxTestCase(parameterized.TestCase):
                         atol=atol or tol, rtol=rtol or tol,
                         canonicalize_dtypes=canonicalize_dtypes)
 
-_PJIT_IMPLEMENTATION = jax.jit
-_PJIT_IMPLEMENTATION._name = "jit"
-_NOOP_JIT_IMPLEMENTATION = lambda x, *args, **kwargs: x
-_NOOP_JIT_IMPLEMENTATION._name = "noop"
+class JitImplementation(NamedTuple):
+  name: str
+  fun: Callable
+  __call__ = property(operator.attrgetter('fun.__call__'))  # type: ignore
 
 JIT_IMPLEMENTATION = (
-  _PJIT_IMPLEMENTATION,
-  _NOOP_JIT_IMPLEMENTATION,
+    JitImplementation('jit', jax.jit),  # type: ignore
+    JitImplementation('noop', lambda f, *_, **__: f),  # type: ignore
 )
 
 class BufferDonationTestCase(JaxTestCase):

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -389,7 +389,7 @@ class LaxVmapTest(jtu.JaxTestCase):
   )
   def testReduce(self, op, init_val, shape, dtype, dims, bdims):
     rng = jtu.rand_small(self.rng())
-    init_val = np.asarray(init_val, dtype=dtype)
+    init_val = np.asarray(init_val, dtype=dtypes.canonicalize_dtype(dtype))
     fun = lambda operand: lax.reduce(operand, init_val, op, dims)
     self._CheckBatching(fun, 5, bdims, (shape,), (dtype,), rng)
 


### PR DESCRIPTION
Before this change, doing things like `jax.jit(lambda x: x + 0)(numpy.array([2**32]))` would silently truncate the input values. Now we raise an error.

in jax:
* add helper function dtypes.check_ndarray_for_int_overflow
* call it in mlir.py when we canonicalize constants (though deleting this line doesn't cause any tests to fail)
* call it in numpy.ndarray's shard_arg handler in pxla.py
* call it in _canonicalize_ndarray_dtype in xla.py
* call it in lax_numpy.asarray

in the tests and test utils:
* add a new test for numpy.ndarray overflows, and add more cases to Python builtin int overflow tests
* in lax_vmap_test.py, changed a test to canonicalize dtype earlier (because now the old tests raise an OverflowException)
* unrelated, change JIT_IMPLEMENTATION in test_util.py so as not to mutate jax.jit