### PR TITLE
Use modern packaging standards for setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,35 @@
+[metadata]
+name = jax
+version = attr: jax.version.__version__
+description = Differentiate, compile, and transform Numpy code.
+author = JAX team
+author_email = jax-dev@google.com
+url = https://github.com/google/jax
+license = Apache-2.0
+classifiers =
+  Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
+long_description = file: README.md
+long_description_content_type = text/markdown
+
+[options]
+install_requires =
+  ml_dtypes>=0.0.3
+  numpy>=1.21
+  opt_einsum
+  scipy>=1.7
+packages = find:
+python_requires = >= 3.8
+zip_safe = False
+
+[options.package_data]
+jax = py.typed, *.pyi, **/*.pyi
+
+[options.packages.find]
+exclude = examples, jax/src/internal_test_util
+
 [flake8]
 max-line-length = 88
 ignore =

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import subprocess
 import os
 import sys
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 _current_jaxlib_version = '0.4.7'
 # The following should be updated with each new jaxlib release.
@@ -30,11 +30,7 @@ _libtpu_version = '0.1.dev20230327'
 _dct = {}
 with open('jax/version.py', encoding='utf-8') as f:
   exec(f.read(), _dct)
-__version__ = _dct['__version__']
 _minimum_jaxlib_version = _dct['_minimum_jaxlib_version']
-
-with open('README.md', encoding='utf-8') as f:
-  _long_description = f.read()
 
 if 'PROTOC' in os.environ and os.path.exists(os.environ['PROTOC']):
   protoc = os.environ['PROTOC']
@@ -52,22 +48,6 @@ generate_proto("jax/experimental/australis/executable.proto")
 generate_proto("jax/experimental/australis/petri.proto")
 
 setup(
-    name='jax',
-    version=__version__,
-    description='Differentiate, compile, and transform Numpy code.',
-    long_description=_long_description,
-    long_description_content_type='text/markdown',
-    author='JAX team',
-    author_email='jax-dev@google.com',
-    packages=find_packages(exclude=["examples", "jax/src/internal_test_util"]),
-    package_data={'jax': ['py.typed', "*.pyi", "**/*.pyi"]},
-    python_requires='>=3.8',
-    install_requires=[
-        'ml_dtypes>=0.0.3',
-        'numpy>=1.21',
-        'opt_einsum',
-        'scipy>=1.7',
-    ],
     extras_require={
         # Minimum jaxlib version; used in testing.
         'minimum-jaxlib': [f'jaxlib=={_minimum_jaxlib_version}'],
@@ -131,13 +111,4 @@ setup(
         **{f'cuda11_cudnn{cudnn_version}': f"jaxlib=={_current_jaxlib_version}+cuda11.cudnn{cudnn_version}"
            for cudnn_version in _available_cuda11_cudnn_versions}
     },
-    url='https://github.com/google/jax',
-    license='Apache-2.0',
-    classifiers=[
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-    ],
-    zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from distutils import spawn
+import shutil
 import subprocess
 import os
 import sys
@@ -35,7 +35,7 @@ _minimum_jaxlib_version = _dct['_minimum_jaxlib_version']
 if 'PROTOC' in os.environ and os.path.exists(os.environ['PROTOC']):
   protoc = os.environ['PROTOC']
 else:
-  protoc = spawn.find_executable('protoc')
+  protoc = shutil.which('protoc')
 
 def generate_proto(source):
   if not protoc or not os.path.exists(source):


### PR DESCRIPTION
In setuptools 30.3.0 (December 2016), support was added for specifying setup options in setup.cfg as opposed to arguments to the setup function. Options are merged, and setup.py takes priority when disagreements occur.

setup.cfg arguments are superior for a couple reasons. They are:
- declarative -- no python code is executed to evaluate them
- easier to read
- capable of doing things that you'd need to open-code in python

Of particular note, it is possible to load files or statically parse the AST for a simple assignment, via values such as `attr:` or `file:`. This is a cfg-exclusive feature.