### PR TITLE
add `geometric` to `random.py`

### DIFF
--- a/docs/jax.random.rst
+++ b/docs/jax.random.rst
@@ -30,6 +30,7 @@ List of Available Functions
     fold_in
     gamma
     generalized_normal
+    geometric
     gumbel
     laplace
     loggamma

--- a/jax/random.py
+++ b/jax/random.py
@@ -163,6 +163,7 @@ from jax._src.random import (
   fold_in as fold_in,
   gamma as gamma,
   generalized_normal as generalized_normal,
+  geometric as geometric,
   gumbel as gumbel,
   key_data as key_data,
   laplace as laplace,


### PR DESCRIPTION
A counterpart for  `numpy.random.geometric`