### PR TITLE
Remove `scale` parameter info in `random.wald` docstring

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -2069,7 +2069,7 @@ def wald(key: KeyArray,
 
   Returns:
     A random array with the specified dtype and with shape given by ``shape`` if
-    ``shape`` is not None, or else by ``mean.shape`` and ``scale.shape``.
+    ``shape`` is not None, or else by ``mean.shape``.
   """
   key, _ = _check_prng_key(key)
   if not dtypes.issubdtype(dtype, np.floating):


### PR DESCRIPTION
Remove `scale` info in `Return` field 