### PR TITLE
Add missing key_path functions to tree_util api reference

### DIFF
--- a/docs/jax.tree_util.rst
+++ b/docs/jax.tree_util.rst
@@ -16,10 +16,13 @@ List of Functions
    build_tree
    register_pytree_node
    register_pytree_node_class
+   register_pytree_with_keys
+   register_pytree_with_keys_class
    tree_all
    tree_flatten
    tree_leaves
    tree_map
+   tree_map_with_path
    tree_reduce
    tree_structure
    tree_transpose


### PR DESCRIPTION
# Changes

* Exposes the `register_pytree_with_keys`, `register_pytree_with_keys_class`, and `tree_map_with_path` functions in `tree_util`'s API reference.

Preview: https://jax--15289.org.readthedocs.build/en/15289/jax.tree_util.html