### PR TITLE
jnp.finfo: add missing properties

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -245,6 +245,7 @@ class finfo(np.finfo):
     obj.nmant = 7
     obj.iexp = obj.nexp
     obj.maxexp = 128
+    obj.minexp = -126
     obj.precision = 2
     obj.resolution = bfloat16(resolution)
     obj._machar = _Bfloat16MachArLike()
@@ -256,6 +257,7 @@ class finfo(np.finfo):
 
     obj._str_tiny = float_to_str(tiny)
     obj._str_smallest_normal = float_to_str(tiny)
+    obj._str_smallest_subnormal = float_to_str(obj.smallest_subnormal)
     obj._str_max = float_to_str(max)
     obj._str_epsneg = float_to_str(epsneg)
     obj._str_eps = float_to_str(eps)
@@ -287,6 +289,7 @@ class finfo(np.finfo):
     obj.nmant = 3
     obj.iexp = obj.nexp
     obj.maxexp = 9
+    obj.minexp = -6
     obj.precision = 1
     obj.resolution = float8_e4m3fn(resolution)
     obj._machar = _Float8E4m3FnMachArLike()
@@ -298,6 +301,7 @@ class finfo(np.finfo):
 
     obj._str_tiny = float_to_str(tiny)
     obj._str_smallest_normal = float_to_str(tiny)
+    obj._str_smallest_subnormal = float_to_str(obj.smallest_subnormal)
     obj._str_max = float_to_str(max)
     obj._str_epsneg = float_to_str(epsneg)
     obj._str_eps = float_to_str(eps)
@@ -329,6 +333,7 @@ class finfo(np.finfo):
     obj.nmant = 2
     obj.iexp = obj.nexp
     obj.maxexp = 16
+    obj.minexp = -14
     obj.precision = 1
     obj.resolution = float8_e5m2(resolution)
     obj._machar = _Float8E5m2MachArLike()
@@ -340,6 +345,7 @@ class finfo(np.finfo):
 
     obj._str_tiny = float_to_str(tiny)
     obj._str_smallest_normal = float_to_str(tiny)
+    obj._str_smallest_subnormal = float_to_str(obj.smallest_subnormal)
     obj._str_max = float_to_str(max)
     obj._str_epsneg = float_to_str(epsneg)
     obj._str_eps = float_to_str(eps)

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -76,6 +76,13 @@ _EXPECTED_CANONICALIZE_X32[np.float64] = np.float32
 _EXPECTED_CANONICALIZE_X32[np.complex128] = np.complex64
 _EXPECTED_CANONICALIZE_X32[np.longlong] = np.int32
 
+UINT_DTYPES = {
+  8: np.uint8,
+  16: np.uint16,
+  32: np.uint32,
+  64: np.uint64,
+}
+
 def identity(x):
   """A named identity function for use in tests"""
   return x
@@ -323,6 +330,8 @@ class DtypesTest(jtu.JaxTestCase):
       self.skipTest("x64 not enabled")
     info = dtypes.finfo(dtype)
 
+    _ = str(info)  # doesn't crash
+
     def make_val(val):
       return jnp.array(val, dtype=dtype)
 
@@ -361,6 +370,12 @@ class DtypesTest(jtu.JaxTestCase):
     self.assertEqual(info.epsneg, make_val(2 ** info.negep))
     self.assertEqual(info.eps, make_val(2 ** info.machep))
     self.assertEqual(info.iexp, info.nexp)
+
+    # Check that minexp is consistent with nmant
+    self.assertEqual(
+        make_val(2 ** info.minexp).view(UINT_DTYPES[info.bits]),
+        2 ** info.nmant,
+    )
 
 
 class TestPromotionTables(jtu.JaxTestCase):


### PR DESCRIPTION
Back-port of https://github.com/jax-ml/ml_dtypes/pull/52

Until we're able to merge https://github.com/google/jax/pull/15247, we need to back-port the fixes.