### PR TITLE
DOC: pin pydata-sphinx-theme to fix incompatibility

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 absl-py
 ipython>=8.8.0  # 8.7.0 has ipython3 lexer error
+pydata-sphinx-theme==0.13.1  # 0.13.2 is incompatible with sphinx-book-theme 1.0.0
 # TODO(jakevdp) Update to sphinx>=6 when myst-nb supports it.
 sphinx>=5
 sphinx-autodoc-typehints


### PR DESCRIPTION
Error reported in https://github.com/executablebooks/sphinx-book-theme/issues/711