### PR TITLE
Add 1-hour timeout to each Cloud TPU CI job.

### DIFF
--- a/.github/workflows/cloud-tpu-ci-nightly.yml
+++ b/.github/workflows/cloud-tpu-ci-nightly.yml
@@ -18,6 +18,7 @@ jobs:
         pjrt: ["true", "false"]
     name: "TPU test (${{ matrix.jaxlib-version }}, pjrt=${{ matrix.pjrt }}, ${{ matrix.tpu-type }})"
     runs-on: ["self-hosted", "tpu", "${{ matrix.tpu-type }}"]
+    timeout-minutes: 60
     steps:
       # https://opensource.google/documentation/reference/github/services#actions
       # mandates using a specific commit for non-Google actions. We use


### PR DESCRIPTION
Sometimes they hang, and the default timeout is 6 hours, which is way too long.