### PR TITLE
Add `triangular` to `random.py`

### DIFF
--- a/docs/jax.random.rst
+++ b/docs/jax.random.rst
@@ -48,6 +48,7 @@ List of Available Functions
     shuffle
     split
     t
+    triangular
     truncated_normal
     uniform
     wald

--- a/jax/random.py
+++ b/jax/random.py
@@ -187,6 +187,7 @@ from jax._src.random import (
   threefry_2x32 as threefry_2x32,
   threefry2x32_key as threefry2x32_key,
   threefry2x32_p as threefry2x32_p,
+  triangular as triangular,
   truncated_normal as truncated_normal,
   uniform as uniform,
   unsafe_rbg_key as unsafe_rbg_key,

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1567,6 +1567,23 @@ class LaxRandomTest(jtu.JaxTestCase):
       self.assertAllClose(samples.mean(), 1 / p, rtol=0.02, check_dtypes=False)
       self.assertAllClose(samples.var(), (1 - p) / (p * p) , rtol=0.05, check_dtypes=False)
 
+  @jtu.sample_product(
+      left= [0.1, 0.2, 0.3, 0.4],
+      mode= [1., 2., 3., 4.],
+      right= [10., 20., 30., 40.],
+      dtype=jtu.dtypes.floating)
+  def testTriangular(self, left, mode, right, dtype):
+    key = self.seed_prng(0)
+
+    rand = lambda key: random.triangular(key, left, mode, right, shape=(10000, ), dtype=dtype)
+    crand = jax.jit(rand)
+
+    uncompiled_samples = rand(key)
+    compiled_samples = crand(key)
+
+    for samples in [uncompiled_samples, compiled_samples]:
+      self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.triang((mode - left) / (right - left), loc=left, scale=right - left).cdf)
+
 class KeyArrayTest(jtu.JaxTestCase):
   # Key arrays involve:
   # * a Python key array type, backed by an underlying uint32 "base" array,


### PR DESCRIPTION
A counterpart for `numpy.random.triangular`