### PR TITLE
[shard-map] handle closed-over vmap tracers

### DIFF
--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -858,7 +858,6 @@ class ShardMapSystematicTest(jtu.JaxTestCase):
       sample(config.FLAGS.jax_num_generated_cases,
              partial(sample_shmap_batched, 5)))
   def test_vmap_closure(self, bdims, fun, mesh, jit, in_specs, out_specs, args, _):
-    raise unittest.SkipTest("need BatchTrace.post_process_shard_map")  # TODO
     mesh = self.make_mesh(mesh)
     args = map(jnp.array, args)
 


### PR DESCRIPTION
Reviewer: compare the new function `_shard_map_batch_post_process` to `_shard_map_batch` (have to do same axis index logic, but in a post-process-y way),`batching.BatchTrace.post_process_call` (the prototypical post-process-y thing, though with no axis index logic), and `experimental.maps._batch_trace_post_process_xmap` (very analogous: both post-process-y and has axis index logic).