### PR TITLE
add assertions for axis name shadowing bugs

### DIFF
--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -2138,6 +2138,18 @@ class PythonPmapTest(jtu.JaxTestCase):
     self.assertIn("jax.result_info = \"['a']\"", mhlo_str)
     self.assertIn("jax.result_info = \"['b'][0][0]\"", mhlo_str)
 
+  def test_axis_name_shadowing_with_vmap(self):
+    # TODO(mattjj): we don't want assertion errors here, but it's a start! the
+    # main point of including this test for now is to document the bug
+
+    with self.assertRaises(AssertionError):
+      jax.vmap(jax.pmap(lambda x: 2 * x, axis_name='i'),
+               axis_name='i')(jax.numpy.ones((2, 4)))
+
+    with self.assertRaises(AssertionError):
+      jax.vmap(jax.pmap(lambda x: 2 * x, axis_name='i'),
+               axis_name='i')(jax.numpy.ones((4, 4)))
+
 
 @jtu.pytest_mark_if_available('multiaccelerator')
 class CppPmapTest(PythonPmapTest):


### PR DESCRIPTION
Axis name shadowing in `vmap`-of-`vmap` and `vmap`-of-`pmap` is buggy, and has been for at least 2 years, and possibly for as long as we've had axis names in vmap. Damn!

The basic issue is that we look up the axis frame in the axis environment based on name, e.g. with `core.axis_frame(self.axis_name)` in methods on `BatchTrace`. But if axis names can shadow, that means computing a frame based only on `self.axis_name` could give the wrong one!

For example, if we had

```python
jax.vmap(jax.pmap(lambda x: 2 * x, axis_name='i'), axis_name='i')(jax.numpy.ones((2, 4)))
```

then in `BatchTrace.process_primitive` when we're about to call the `pjit` batching rule (since `2 * x` leads to a call to the jitted `jnp.multiply`) we get a `core.axis_frame(self.axis_name).size == 4` when we have `in_vals[0].shape[in_dims[0]] == 2`. That is, when applying `BatchTrace.process_primitive` for the (outer) `vmap`, we accidentally pick up the frame for the (inner) `pmap`. Indeed we always get the frame for the inner guy from `core.axis_frame(self.axis_name)`! The two maps have gotten confused!

An analogous thing happens with

```python
jax.vmap(jax.vmap(lambda x: 2 * x, axis_name='i'), axis_name='i')(jax.numpy.ones((2, 4)))
```

except now we're getting two `vmap`s confused with each other: again `core.axis_frame(self.axis_name)` always gives the frame for the inner `vmap`, even when we're running the outer `vmap`'s `BatchTrace.process_primitive`.

This isn't a problem for `pmap`-of-`vmap` or `pmap`-of-`pmap` because `pmap` isn't a transformation.

**Also, we only noticed this now after the jit-pjit merge because it may only be an issue for vmap-of-vmap-of-initialstyle. Actually, we noticed this as a shape error when testing vmap-of-shmap-of-initialstyle.**

This PR adds assertions as a _late_ check for whether the confusion has happened. I think a better fix would be to disallow shadowing entirely, by raising an error as soon as a shadowing axis name is attempted to be bound. Or maybe we can allow shadowing and improve our implementation. In any case, I'll send such fixes in follow-up PRs. For now I just want to rule out silently incorrect behavior.