### PR TITLE
fix bug from #15335 by checking main_trace tag

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2465,10 +2465,12 @@ class _TempAxisName:
     return type(other) is _TempAxisName and self.id < other.id
 
 
-def axis_frame(axis_name):
+def axis_frame(axis_name: AxisName, main_trace: Optional[MainTrace] = None
+               ) -> AxisEnvFrame:
   frames = thread_local_state.trace_state.axis_env
   for frame in reversed(frames):
-    if frame.name == axis_name:
+    if (frame.name == axis_name and
+        (main_trace is None or frame.main_trace is main_trace)):
       return frame
   named_axes = [frame.name for frame in reversed(frames)
                 if not isinstance(frame.name, _TempAxisName)]

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -341,7 +341,7 @@ class BatchTrace(Trace):
     if self.axis_name is core.no_axis_name:
       assert axis_size is not None  # must be inferrable from data
       return core.AxisEnvFrame(self.axis_name, axis_size, self.main)
-    frame = core.axis_frame(self.axis_name)
+    frame = core.axis_frame(self.axis_name, self.main)
     assert axis_size is None or axis_size == frame.size, (axis_size, frame.size)
     assert frame.main_trace is self.main
     return frame

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -2139,16 +2139,21 @@ class PythonPmapTest(jtu.JaxTestCase):
     self.assertIn("jax.result_info = \"['b'][0][0]\"", mhlo_str)
 
   def test_axis_name_shadowing_with_vmap(self):
-    # TODO(mattjj): we don't want assertion errors here, but it's a start! the
-    # main point of including this test for now is to document the bug
+    # vmap-of-pmap with mismatched axis sizes
+    jax.vmap(jax.pmap(lambda x: 2 * x, axis_name='i'),
+             axis_name='i')(jax.numpy.ones((2, 1)))  # don't crash
 
-    with self.assertRaises(AssertionError):
-      jax.vmap(jax.pmap(lambda x: 2 * x, axis_name='i'),
-               axis_name='i')(jax.numpy.ones((2, 4)))
+    # vmap-of-pmap with matched axis sizes
+    jax.vmap(jax.pmap(lambda x: 2 * x, axis_name='i'),
+             axis_name='i')(jax.numpy.ones((1, 1)))  # don't crash
 
-    with self.assertRaises(AssertionError):
-      jax.vmap(jax.pmap(lambda x: 2 * x, axis_name='i'),
-               axis_name='i')(jax.numpy.ones((4, 4)))
+    # vmap-of-vmap with mismatched axis sizes
+    jax.vmap(jax.vmap(lambda x: 2 * x, axis_name='i'),
+             axis_name='i')(jax.numpy.ones((2, 1)))  # don't crash
+
+    # vmap-of-vmap with matched axis sizes
+    jax.vmap(jax.vmap(lambda x: 2 * x, axis_name='i'),
+             axis_name='i')(jax.numpy.ones((1, 1)))  # don't crash
 
 
 @jtu.pytest_mark_if_available('multiaccelerator')


### PR DESCRIPTION
We added the `main_trace` tag field on `core.AxisEnvFrame` so that we could disambiguate which vmap trace instance ("handler") corresponded to which axis env frame. But in one place, namely `BatchTrace.process_primitive`'s subroutine `BatchTrace.get_frame`, we weren't using it to do that disambiguation: we were only using the (ambiguous, shadow-able) name.

While #15335 identified the issue and added assertions that we didn't do the _wrong_ thing, this PR fixes the underlying issue and ensures we do the right thing. The assertions are still there; they just don't fire because we now don't get things confused!

We should still consider disallowing shadowing: @sharadmv suggested for example how confusing it might be to write `vmap(hop(fun=lambda x: ...mentions axis name 'i'...), axis_name='i')(x)` where the `hop` implementation calls `vmap(fun, axis_name='i')`.

**Now we can enable the shmap test we had to skip!** In addition to enabling that test, I'm going to rename it to be more specific and add two more related ones.