### PR TITLE
checkify: catch OOB errors in dynamic_slice

### DIFF
--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -181,6 +181,23 @@ class CheckifyTransformTests(jtu.JaxTestCase):
     raises_oob(multi_idx, (5, -9), "index 5", axis0_msg)
     raises_oob(multi_idx, ((0, 9), 0), "index 9", axis0_msg)
 
+  def test_dynamic_slice_oobs(self):
+    def raises_oob(fn, x, idx, *expected_strs):
+      err, _ = checkify.checkify(jax.jit(fn), errors=checkify.index_checks)(x, idx)
+      error_txt = err.get()
+      self.assertIsNotNone(error_txt)
+      self.assertStartsWith(error_txt, "out-of-bounds indexing")
+      for s in expected_strs:
+        self.assertIn(s, error_txt)
+
+    x = jnp.ones((2, 3, 7))
+    raises_oob(partial(lax.dynamic_slice, slice_sizes=(1, 1, 1)), x, (2, 0, 0), 'index 2')
+    raises_oob(partial(lax.dynamic_slice, slice_sizes=(1, 1, 1)), x, (-3, 0, 0), 'index -1')
+    raises_oob(partial(lax.dynamic_slice, slice_sizes=(1, 1, 1)), x, (0, 3, 0), 'index 3')
+    raises_oob(partial(lax.dynamic_slice, slice_sizes=(1, 1, 1)), x, (0, -5, 0), 'index -2')
+    raises_oob(partial(lax.dynamic_slice, slice_sizes=(1, 1, 1)), x, (0, 1, 8), 'index 8')
+    raises_oob(partial(lax.dynamic_slice, slice_sizes=(1, 1, 1)), x, (0, 1, -10), 'index -3')
+
   @jtu.sample_product(jit=[False, True])
   def test_jit_ordering(self, jit):
     def f(x, i):


### PR DESCRIPTION
This will allow checkify tests to continue working properly for out-of-bounds indexing after #15377