### PR TITLE
[shape_poly] Lowering sharding annotations in presence of dynamic shapes

### DIFF
--- a/jax/_src/maps.py
+++ b/jax/_src/maps.py
@@ -1405,7 +1405,7 @@ def _xmap_lowering_rule_spmd(ctx, *global_in_nodes,
 
   global_sharding_spec = pxla.mesh_sharding_specs(mesh.shape, mesh.axis_names)
   sharded_global_in_nodes = [
-    [mlir.wrap_with_sharding_op(node, global_sharding_spec(aval, aval_axes).sharding_proto())]
+    [mlir.wrap_with_sharding_op(ctx, node, aval, global_sharding_spec(aval, aval_axes).sharding_proto())]
     if aval_axes else [node]
     for node, aval, aval_axes in zip(global_in_nodes, global_in_avals, mesh_in_axes)
   ]
@@ -1423,7 +1423,7 @@ def _xmap_lowering_rule_spmd(ctx, *global_in_nodes,
       dim_var_values=ctx.dim_var_values)
 
   sharded_global_out_nodes = [
-    mlir.wrap_with_sharding_op(node, global_sharding_spec(aval, aval_axes).sharding_proto())
+    mlir.wrap_with_sharding_op(ctx, node, aval, global_sharding_spec(aval, aval_axes).sharding_proto())
     if aval_axes else node
     for (node,), aval, aval_axes in zip(global_out_nodes, global_out_avals, mesh_out_axes)
   ]

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1795,6 +1795,7 @@ ad.deflinear2(sharding_constraint_p,
 def _sharding_constraint_hlo_lowering(ctx, x_node, *, sharding,
                                       resource_env, unconstrained_dims):
   aval, = ctx.avals_in
+  out_aval, = ctx.avals_out
   axis_ctx = ctx.module_context.axis_context
   # axis_ctx and manual_axes is *only used with xmap* and xmap only works with
   # NamedSharding. So convert the GSPMDSharding to NamedSharding
@@ -1806,8 +1807,8 @@ def _sharding_constraint_hlo_lowering(ctx, x_node, *, sharding,
     sharding = GSPMDSharding(
         mps._device_assignment, mps._to_xla_op_sharding(aval.ndim, axis_ctx=axis_ctx))
   return [
-      mlir.wrap_with_sharding_op(
-          x_node,
+      mlir.wrap_with_sharding_op(ctx,
+          x_node, out_aval,
           sharding._to_xla_op_sharding(aval.ndim),
           unspecified_dims=unconstrained_dims)
   ]


### PR DESCRIPTION
Sharding annotations are lowered to custom calls, and in presence of dynamic shapes
we must use the `indices_of_shape_operands` attribute to hlo.CustomCall.
In order to be able to generate the code to compute the result shapes
we must pass the `LoweringRuleContext` and the result abstract value
to the lowering helpers that generate the custom calls.

The above is easy everywhere, except for the sharding annotations for
the inputs and outputs for a function, because we do not yet have
a LoweringRuleContext available.

