### PR TITLE
[jax2tf] Refactor the gradient machinery for native serialization

### DIFF
--- a/jax/experimental/jax2tf/tests/back_compat_test.py
+++ b/jax/experimental/jax2tf/tests/back_compat_test.py
@@ -203,7 +203,7 @@ class CompatTest(jtu.JaxTestCase):
     res_from_jax = tuple(np.array(a) for a in res_from_jax)
 
     # Use the native exporter, to make sure we get the proper serialized module.
-    exported = jax2tf.jax_export.serialize_native(
+    exported = jax2tf.jax_export.export_native(
         jax.jit(func),
         [core.ShapedArray(a.shape, a.dtype) for a in data.inputs],
         lowering_platform=default_jax_backend(),

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -1531,7 +1531,7 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
         stack.enter_context(mesh)
       # Run the JAX native version, to check it works, and to fill caches.
       _ = func_to_convert(*args)
-      exported = jax_export.serialize_native(
+      exported = jax_export.export_native(
           func_to_convert,
           [core.ShapedArray(a.shape, a.dtype) for a in args],
           lowering_platform='tpu',
@@ -1608,7 +1608,7 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
       return jnp.sin(x)
 
     with self.assertRaisesRegex(NotImplementedError,
-                                "keepalive must be empty"):
+                                "serialization of host_callbacks is not yet implemented"):
       jax2tf.convert(f_jax, native_serialization=True)(np.float32(42.))
 
     def f_ordered_jax(x):
@@ -1616,7 +1616,7 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
       return jnp.sin(x)
 
     with self.assertRaisesRegex(NotImplementedError,
-                                "keepalive must be empty"):
+                                "serialization of host_callbacks is not yet implemented"):
       jax2tf.convert(f_ordered_jax, native_serialization=True)(np.float32(42.))
 
   def test_tuple_args(self):

--- a/jax/experimental/jax2tf/tests/sharding_test.py
+++ b/jax/experimental/jax2tf/tests/sharding_test.py
@@ -372,7 +372,7 @@ class ShardingTest(tf_test_util.JaxToTfTestCase):
       for out_shardings in ("missing", None, "P")
   )
   @jtu.with_mesh([("x", 2)])
-  def test_grad_pjit(self, in_shardings="missing", out_shardings="None"):
+  def test_grad_pjit(self, in_shardings="P", out_shardings=None):
     def f_jax(x):  # x: f32[10,20] -> f32[20,10]
       return jnp.sin(x.T)
 

--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -133,7 +133,7 @@ SpecErrorType = enum.Enum('SpecErrorType', ['input', 'out'])
 def _check_specs(error_type: SpecErrorType, specs: Any) -> None:
   if error_type == SpecErrorType.input and specs is None:
     raise TypeError(
-        f"shard_map in_specs argument must be a pytree of "
+        "shard_map in_specs argument must be a pytree of "
         "`jax.sharding.PartitionSpec` instances, but it was None.\n"
         "Instead of `in_specs=None`, did you mean `in_specs=P()`, "
         "where `P = jax.sharding.PartitionSpec`?")


### PR DESCRIPTION
In #15341 we have refactored jax2tf to separate the JAX and TF pieces
of the handling of gradients. Now we continue the refactoring and
we move the JAX-only pieces from jax2tf.py into jax_export.py. The
goal is to collect in jax_export all the pure JAX pieces needed
for serialization.

This is a pure refactoring, there should be no change in semantics.