### PR TITLE
[jax2tf] Refactor and simplify jax2tf.py

### DIFF
--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -1005,7 +1005,7 @@ def arg_aval(
   Args:
     arg_shape: the shape for the argument, possibly having None dimensions.
     arg_dtype: the inferred JAX dtype for the arg.
-    polymorphic_shape: the polymorphic specifications for the argument.
+    polymorphic_shape: the polymorphic specification for the argument.
   Returns: the JAX abstract value for the argument.
   """
   aval_shape = _parse_spec(polymorphic_shape, arg_shape)

--- a/jax/experimental/jax2tf/tests/back_compat_test.py
+++ b/jax/experimental/jax2tf/tests/back_compat_test.py
@@ -207,13 +207,12 @@ class CompatTest(jtu.JaxTestCase):
     res_from_jax_run_now = tuple(np.array(a) for a in res_from_jax_run_now)
 
     # Use the native exporter, to make sure we get the proper serialized module.
-    exported = jax2tf.jax_export.export_native(
+    exported = jax2tf.jax_export.export(
         jax.jit(func),
-        [core.ShapedArray(a.shape, a.dtype) for a in data.inputs],
         lowering_platform=default_jax_backend(),
         # Must turn off strict checks because the custom calls may be unallowed.
-        strict_checks=False,
-    )
+        strict_checks=False
+    )(*(jax.ShapeDtypeStruct(a.shape, a.dtype) for a in data.inputs))
 
     module_str = str(exported.mlir_module)
     custom_call_re = r"stablehlo.custom_call\s*@([^\(]+)\("


### PR DESCRIPTION
This is the next step in the refactoring and simplifying jax2tf. An additional goal is to move to jax_export.py as much pure-JAX functionalit as possible so that jax_export can start to become a standalone API for native serialization.

Previous PRs in this series:
  * #15258 and #15287: refactoring computation of dimension variables
  * #15341 and #15432: refactor handling of tf.custom_gradient (moved VJP serialization to jax_export)
  
Here we do the following:
  * we move the handling of in/out pytrees to jax_export. This allows the removal of a workaround that introduced a trampoline for the `lower` function for native lowering.
  * we move most of the code to set up the input abstract values into jax_export (`poly_spec` and `poly_specs`)
  * we separate out the implementation details for graph and native serialization into two classes `GraphSerializationImpl` and `NativeSerializationImpl`. This simplifies the core of the jax2tf.convert.

This is a pure refactoring, it should not change any existing behavior for jax2tf.