### PR TITLE
[shard-map] improve error message when in_specs is None

### DIFF
--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -131,6 +131,12 @@ def _canonicalize_spec(spec: PartitionSpec) -> AxisNames:
 SpecErrorType = enum.Enum('SpecErrorType', ['input', 'out'])
 
 def _check_specs(error_type: SpecErrorType, specs: Any) -> None:
+  if error_type == SpecErrorType.input and specs is None:
+    raise TypeError(
+        f"shard_map in_specs argument must be a pytree of "
+        "`jax.sharding.PartitionSpec` instances, but it was None.\n"
+        "Instead of `in_specs=None`, did you mean `in_specs=P()`, "
+        "where `P = jax.sharding.PartitionSpec`?")
   if all(isinstance(p, PartitionSpec) for p in tree_leaves(specs)): return
   prefix = 'in' if error_type == SpecErrorType.input else 'out'
   msgs = [f"  {prefix}_specs{keystr(key)} is {x} of type {type(x).__name__}, "

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -581,6 +581,20 @@ class ShardMapTest(jtu.JaxTestCase):
     with self.assertRaises(ValueError):
       g(x)
 
+  def test_in_specs_none_error(self):
+    mesh = jtu.create_global_mesh((4,), ('x',))
+
+    def f(x): return x
+
+    with self.assertRaisesRegex(TypeError, "but it was None"):
+      shard_map(f, mesh, in_specs=None, out_specs=P())(3.)
+
+    # TODO(mattjj): enable this test once we fix the tree_map(f, None, 3.0) bug
+    # with self.assertRaises(TypeError):
+    #   shard_map(f, mesh, in_specs=(None,), out_specs=P())(3.)
+
+    shard_map(f, mesh, in_specs=P(), out_specs=P())(3.)  # doesn't crash
+
 
 class FunSpec(NamedTuple):
   name: str


### PR DESCRIPTION
In pjit (at least at one point) None was accepted as having the same meaning as P() (or P(None), or P(None, None), ...). But shard_map doesn't accept None as an in_spec. We should have a nice error message if a user accidentally writes that.

While working on this, I noticed jax.tree_util.tree_map(lambda x: x, None, 3.0) evaluates to [], rather than being an error. We need to fix that before we can further (conveniently) improve the error messages here.