### PR TITLE
separate `PRNGKeyArray` implementation from interface

### DIFF
--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1605,6 +1605,16 @@ class KeyArrayTest(jtu.JaxTestCase):
     self.assertEqual(g[0], k1.dtype)
     self.assertEqual(g[0], k2.dtype)
 
+  def test_isinstance(self):
+    @jax.jit
+    def f(k):
+      self.assertIsInstance(k, random.KeyArray)
+      return k
+
+    k1 = self.make_keys()
+    k2 = f(k1)
+    self.assertIsInstance(k1, random.KeyArray)
+    self.assertIsInstance(k2, random.KeyArray)
 
   # -- prng primitives
 


### PR DESCRIPTION
We expose the `PRNGKeyArray` symbol publicly, at least for use in annotations (especially by libraries). Doing this prevents instantiations. Also, should anyone try to inherit from the public type for some reason, they will not pick up all of the magic behavior of the implementing class (e.g. presence in pytype-aval mappings).

This reflects what we do with `jax.Array` as well.