### PR TITLE
Added two lines to expose jax.scipy.optimize

### DIFF
--- a/jax/scipy/__init__.py
+++ b/jax/scipy/__init__.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
   from jax.scipy import stats as stats
   from jax.scipy import fft as fft
   from jax.scipy import cluster as cluster
+  from jax.scipy import optimize as optimize
 else:
   import jax._src.lazy_loader as _lazy
   __getattr__, __dir__, __all__ = _lazy.attach(__name__, [
@@ -39,6 +40,7 @@ else:
     "stats",
     "fft",
     "cluster",
+    "optimize",
   ])
   del _lazy
 


### PR DESCRIPTION
My apologies for this rather small PR. I have read most of the contributing guidelines and:
- Made this change only a single commit,
- Tested it with `pre-commit` (all tests seemed to pass)
- Could not test using `pytest -n auto tests/` (for some reason my installation says that `-n` is an unrecognized keyword.

This addresses the issue discussed in #15488 . It exposes `jax.scipy.optimize` for future users of JAX!