### PR TITLE
[shard-map] fix custom/stateful remat with scalar residuals

### DIFF
--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -42,7 +42,7 @@ from jax._src.lax import (lax, parallel as lax_parallel, slicing,
                           windowed_reductions, fft, linalg)
 from jax._src.util import (HashableFunction, HashablePartial, unzip2, unzip3,
                            as_hashable_function, memoize, partition_list,
-                           merge_lists)
+                           merge_lists, split_list)
 from jax.api_util import flatten_fun_nokwargs, shaped_abstractify
 from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
@@ -133,7 +133,7 @@ SpecErrorType = enum.Enum('SpecErrorType', ['input', 'out'])
 def _check_specs(error_type: SpecErrorType, specs: Any) -> None:
   if error_type == SpecErrorType.input and specs is None:
     raise TypeError(
-        f"shard_map in_specs argument must be a pytree of "
+        "shard_map in_specs argument must be a pytree of "
         "`jax.sharding.PartitionSpec` instances, but it was None.\n"
         "Instead of `in_specs=None`, did you mean `in_specs=P()`, "
         "where `P = jax.sharding.PartitionSpec`?")
@@ -831,7 +831,7 @@ def _shard_map_partial_eval(trace, shard_map_p, f, tracers, mesh, in_names,
                       out_names_thunk=known_out_names, check_rep=check_rep)
   out = shard_map_p.bind(f_known, *in_consts, **known_params)
   out_knowns, out_avals_sharded, jaxpr, env = aux()
-  out_consts, res = pe.split_list(out, [len(out) - len(jaxpr.constvars)])
+  out_consts, res = split_list(out, [len(out) - len(jaxpr.constvars)])
   with core.extend_axis_env_nd(mesh.shape.items()):
     jaxpr = pe.convert_constvars_jaxpr(jaxpr)
   unk_out_names, _ = pe.partition_list(out_knowns, out_names_thunk())
@@ -865,7 +865,7 @@ def _shard_map_partial_eval_post_process(
 
   def todo(out):
     trace = main.with_cur_sublevel()
-    out_consts, res = pe.split_list(out, [len(out) - len(jaxpr.constvars)])
+    out_consts, res = split_list(out, [len(out) - len(jaxpr.constvars)])
     const_tracers = map(trace.new_instantiated_const, res)
     env_tracers = map(trace.full_raise, env)
 
@@ -963,11 +963,64 @@ core.axis_substitution_rules[shard_map_p] = _shard_map_axis_subst
 
 # Remat
 
-def _pe_custom_params(
-    unks_in: List[bool], inst_in: List[bool], kept_outs_known: List[bool],
-    kept_outs_staged: List[bool], num_res: int, params_known: Dict[str, Any],
-    params_staged: Dict[str, Any]
-  ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+def _partial_eval_jaxpr_custom_rule(
+    saveable: Callable[..., bool], unks_in: Sequence[bool],
+    inst_in: Sequence[bool], eqn: core.JaxprEqn
+) -> Tuple[core.JaxprEqn, core.JaxprEqn, Sequence[bool], Sequence[bool],
+           List[core.Var]]:
+  jaxpr, mesh = eqn.params['jaxpr'], eqn.params['mesh']
+  with core.extend_axis_env_nd(mesh.shape.items()):
+    jaxpr_known, jaxpr_staged, unks_out, inst_out, num_res = \
+        pe.partial_eval_jaxpr_custom(jaxpr, unks_in, inst_in, False, False, saveable)
+  jaxpr_known, jaxpr_staged = _add_reshapes(num_res, jaxpr_known, jaxpr_staged)
+  ins_known, _ = partition_list(unks_in, eqn.invars)
+  out_binders_known, _ = partition_list(unks_out, eqn.outvars)
+  _, ins_staged = partition_list(inst_in, eqn.invars)
+  _, out_binders_staged = partition_list(inst_out, eqn.outvars)
+  newvar = core.gensym([jaxpr_known, jaxpr_staged])
+  params_known, params_staged = _pe_custom_params(
+      unks_in, inst_in, map(op.not_, unks_out), inst_out, num_res,
+      dict(eqn.params, jaxpr=jaxpr_known), dict(eqn.params, jaxpr=jaxpr_staged))
+  residuals = [newvar(_unshard_aval(mesh, {0: (*mesh.axis_names,)}, var.aval))
+               for var in jaxpr_staged.invars[:num_res]]
+  eqn_known = pe.new_jaxpr_eqn(ins_known, [*out_binders_known, *residuals],
+                               eqn.primitive, params_known, jaxpr_known.effects,
+                               eqn.source_info)
+  eqn_staged = pe.new_jaxpr_eqn([*residuals, *ins_staged], out_binders_staged,
+                                eqn.primitive, params_staged,
+                                jaxpr_staged.effects, eqn.source_info)
+  assert len(eqn_staged.invars) == len(jaxpr_staged.invars)
+  new_inst = [x for x, inst in zip(eqn.invars, inst_in)
+              if type(x) is core.Var and not inst]
+  return eqn_known, eqn_staged, unks_out, inst_out, new_inst + residuals
+pe.partial_eval_jaxpr_custom_rules[shard_map_p] = \
+    _partial_eval_jaxpr_custom_rule
+
+def _add_reshapes(num_res, jaxpr_known, jaxpr_staged):
+  if not num_res: return jaxpr_known, jaxpr_staged
+  assert not jaxpr_known.constvars and not jaxpr_staged.constvars
+
+  @lu.wrap_init
+  def known(*args):
+    out = core.eval_jaxpr(jaxpr_known, (), *args)
+    out_known, res = split_list(out, [len(out) - num_res])
+    return [*out_known, *map(_add_singleton, res)]
+  avals_in = [v.aval for v in jaxpr_known.invars]
+  jaxpr_known, _, () = pe.trace_to_jaxpr_dynamic(known, avals_in)
+
+  @lu.wrap_init
+  def staged(*args):
+    res_, ins = split_list(args, [num_res])
+    res = map(_rem_singleton, res_)
+    return core.eval_jaxpr(jaxpr_staged, (), *res, *ins)
+  res_avals = [v.aval for v in jaxpr_known.outvars[-num_res:]]
+  avals_in = [*res_avals, *[v.aval for v in jaxpr_staged.invars[num_res:]]]
+  jaxpr_staged, _, () = pe.trace_to_jaxpr_dynamic(staged, avals_in)
+
+  return jaxpr_known, jaxpr_staged
+
+def _pe_custom_params(unks_in, inst_in, kept_outs_known, kept_outs_staged,
+                      num_res, params_known, params_staged):
   # prune inputs to jaxpr_known according to unks_in
   mesh = params_known['mesh']
   in_names_known, _ = partition_list(unks_in, params_known['in_names'])
@@ -983,14 +1036,3 @@ def _pe_custom_params(
   new_params_staged = dict(params_staged, in_names=tuple(in_names_staged),
                            out_names=tuple(out_names_staged), check_rep=False)
   return new_params_known, new_params_staged
-
-def _pe_custom_res(params_known, aval):
-  mesh = params_known['mesh']
-  return _unshard_aval(mesh, {0: (*mesh.axis_names,)}, aval)
-
-def _pe_custom_ctx(params):
-  return core.extend_axis_env_nd(params['mesh'].shape.items())
-
-pe.partial_eval_jaxpr_custom_rules[shard_map_p] = \
-    partial(pe.call_partial_eval_custom_rule, 'jaxpr', _pe_custom_params,
-            res_aval=_pe_custom_res, ctx=_pe_custom_ctx)


### PR DESCRIPTION
The body of a `shard_map` can only have scalar outputs if they're equal across all mesh axes, and so we can use `out_specs=P()` for them. That's because the only way to collect together distinct outputs is via concatenation on an existing axis, and scalars can't be concatenated! (It was a design decision not to let shmap out_specs express stacking, just to keep them simple; the burden of inserting singleton axes then falls to the body function.)

But autodiff might want to create scalar residuals, e.g. if it needs to save a scalar intermediate value. We don't want to constrain all intermediate values to have rank >0. So we need the partial eval rule to add an extra axis onto residuals (or at least the rank-0 ones).

The partial eval rule already did that, but the custom-policy aka stateful partial eval rule did not!

This PR makes the custom-policy partial eval rule of `shard_map`. correctly manage scalar residuals.