### PR TITLE
in scatter, cast values to be scattered to target dtype

### DIFF
--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -66,7 +66,7 @@ def _scatter_update(x, idx, y, scatter_op, indices_are_sorted,
   """
 
   x = jnp.asarray(x)
-  y = jnp.asarray(y)
+  y = jnp.asarray(y, x.dtype)
   # XLA gathers and scatters are very similar in structure; the scatter logic
   # is more or less a transpose of the gather equivalent.
   treedef, static_idx, dynamic_idx = jnp._split_index_for_jit(idx, x.shape)

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -1467,5 +1467,16 @@ class IndexedUpdateTest(jtu.JaxTestCase):
     y = jnp.zeros(8)
     self.assertArraysEqual(fn(y), jax.jit(fn)(y))
 
+  def testScatterValuesCastToTargetDType(self):
+    # https://github.com/google/jax/issues/15505
+    a = jnp.zeros((1), dtype=jnp.uint32)
+    val = 2**32 - 1
+    # val and its uint32 representation are identical
+    # assignment works with an explicit cast to uint32
+    b = a.at[1].set(jnp.uint32(val))
+    # assignment with an implicit cast throws an exception
+    b = a.at[1].set(val)  # don't crash
+
+
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
fixes #15505

Or at least it might, but I need to check with @jakevdp as #10892 and #10924 show some precedence that I'm not familiar with.