### PR TITLE
DOC: add docstrings for callback functions

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -141,7 +141,9 @@ Callbacks
   :toctree: _autosummary
 
     pure_callback
+    experimental.io_callback
     debug.callback
+    debug.print
 
 Miscellaneous
 -------------

--- a/jax/_src/callback.py
+++ b/jax/_src/callback.py
@@ -139,6 +139,32 @@ def _check_shape_dtype(shape_dtype):
 
 def pure_callback(callback: Callable[..., Any], result_shape_dtypes: Any,
                   *args: Any, vectorized: bool = False, **kwargs: Any):
+  """Calls a pure Python callback.
+
+  For more explanation, see `External Callbacks`_.
+
+  Args:
+    callback: function to execute on the host. The callback is assumed to be a pure
+      function (i.e. one without side-effects): if an impure function is passed, it
+      may behave in unexpected ways, particularly under transformation.
+    result_shape_dtypes: pytree whose leaves have ``shape`` and ``dtype`` attributes,
+      whose structure matches the expected output of the callback function at runtime.
+    *args: arguments to be passed to the callback function
+    vectorized: boolean specifying whether the callback function can operate in a
+      vectorized manner.
+    **kwargs: keyword arguments to be passed to the callback function
+
+  Returns:
+    result: a pytree of :class:`jax.Array` objects whose structure matches that of
+      ``result_shape_dtypes``.
+
+  See Also:
+    - :func:`jax.experimental.io_callback`: callback designed for impure functions.
+    - :func:`jax.debug.callback`: callback designed for general-purpose debugging.
+    - :func:`jax.debug.print`: callback designed for printing.
+
+  .. _External Callbacks: https://jax.readthedocs.io/en/latest/notebooks/external_callbacks.html
+  """
   def _flat_callback(*flat_args):
     args, kwargs = tree_util.tree_unflatten(in_tree, flat_args)
     return tree_util.tree_leaves(callback(*args, **kwargs))
@@ -298,6 +324,31 @@ mlir.register_lowering(io_callback_p, io_callback_lowering)
 
 def io_callback(callback: Callable[..., Any], result_shape_dtypes: Any,
                 *args: Any, ordered: bool = False, **kwargs: Any):
+  """Calls an impure Python callback.
+
+  For more explanation, see `External Callbacks`_.
+
+  Args:
+    callback: function to execute on the host. It is assumet to be an impure function.
+      If ``callback`` is pure, using :func:`jax.pure_callback` instead may lead to
+      more efficient execution.
+    result_shape_dtypes: pytree whose leaves have ``shape`` and ``dtype`` attributes,
+      whose structure matches the expected output of the callback function at runtime.
+    *args: arguments to be passed to the callback function
+    ordered: boolean specifying whether sequential calls to callback must be ordered.
+    **kwargs: keyword arguments to be passed to the callback function
+
+  Returns:
+    result: a pytree of :class:`jax.Array` objects whose structure matches that of
+      ``result_shape_dtypes``.
+
+  See Also:
+    - :func:`jax.pure_callback`: callback designed for pure functions.
+    - :func:`jax.debug.callback`: callback designed for general-purpose debugging.
+    - :func:`jax.debug.print`: callback designed for printing.
+
+  .. _External Callbacks: https://jax.readthedocs.io/en/latest/notebooks/external_callbacks.html
+  """
   def _flat_callback(*flat_args):
     args, kwargs = tree_util.tree_unflatten(in_tree, flat_args)
     return tree_util.tree_leaves(callback(*args, **kwargs))

--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -203,6 +203,8 @@ def debug_callback(callback: Callable[..., Any], *args: Any,
                    ordered: bool = False, **kwargs: Any) -> None:
   """Calls a stageable Python callback.
 
+  For more explanation, see `External Callbacks`_.
+
   `debug_callback` enables you to pass in a Python function that can be called
   inside of a staged JAX program. A `debug_callback` follows existing JAX
   transformation *pure* operational semantics, which are therefore unaware of
@@ -222,8 +224,16 @@ def debug_callback(callback: Callable[..., Any], *args: Any,
       staged out computation will enforce ordering of this callback w.r.t.
       other ordered callbacks.
     **kwargs: The keyword arguments to the callback.
+
   Returns:
     None
+
+  See Also:
+    - :func:`jax.experimental.io_callback`: callback designed for impure functions.
+    - :func:`jax.pure_callback`: callback designed for pure functions.
+    - :func:`jax.debug.print`: callback designed for printing.
+
+  .. _External Callbacks: https://jax.readthedocs.io/en/latest/notebooks/external_callbacks.html
   """
   flat_args, in_tree = tree_util.tree_flatten((args, kwargs))
   effect = ordered_debug_effect if ordered else debug_effect


### PR DESCRIPTION
Add basic docstrings, pointing to the main discussion at https://jax.readthedocs.io/en/latest/debugging/index.html

Rendered doc preview:
- [`jax.experimental.io_callback`](https://jax--15545.org.readthedocs.build/en/15545/_autosummary/jax.experimental.io_callback.html#jax.experimental.io_callback)
- [`jax.pure_callback`](https://jax--15545.org.readthedocs.build/en/15545/_autosummary/jax.pure_callback.html#jax.pure_callback)
- [`jax.debug.callback`](https://jax--15545.org.readthedocs.build/en/15545/_autosummary/jax.debug.callback.html#jax.debug.callback)