### PR TITLE
[shard-map] handle scalar residuals in post_process partial eval

### DIFF
--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -812,6 +812,12 @@ class ShardMapTest(jtu.JaxTestCase):
         expected_num_eqns=1 + 1,  # one outer eqn, two remain in body
         check_diff=False)
 
+  def test_post_process_partial_eval_with_scalar_res(self):
+    mesh = jtu.create_global_mesh((4, 2), ('i', 'j'))
+    g = jax.grad(lambda x: shard_map(lambda: jnp.sin(x), mesh=mesh,
+                                     in_specs=P(), out_specs=P())())(2.0)
+    self.assertAllClose(g, jnp.cos(2.0), check_dtypes=False)
+
 
 class FunSpec(NamedTuple):
   name: str


### PR DESCRIPTION
This is the third time fixing one bug! Well, it was three different instances of the same conceptual issue: `shard_map`ped functions can't have scalar outputs (unless they're the same value for every function instance) because out_specs only let us express concatenation not stacking. So when autodiff of the body produces scalar residuals, we need to add a new axis to those scalars to be able to concatenate them in the output of the forward pass, and then remove that extra axis on the backward pass.

We had fixed that bug before in shard_map's partial eval rule, and then in its custom-policy partial eval rule. Here finally we're fixing it in the third and last place: in the post-process partial eval rule, which gets called when we differentiate with respect to a variable closed over by the `shard_map`ped function and none of its arguments.