### PR TITLE
add an api_boundary around device_put

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2411,6 +2411,7 @@ def _infer_src_sharding(src, x):
   return x.sharding if isinstance(x, array.ArrayImpl) else None
 
 
+@api_boundary
 def device_put(
     x,
     device: Union[None, xc.Device, Sharding, Any] = None,

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -591,11 +591,18 @@ def _device_put_impl(
     device: Optional[Union[Device, Sharding]] = None,
     src: Optional[Union[Device, Sharding]] = None):
   from jax._src import array
+  if not isinstance(device, (Device, Sharding, type(None))):
+    raise TypeError("device_put 'device' argument must be a Device or Sharding, "
+                    f"but got type {type(device)} with value {device}.")
+  if not isinstance(src, (Device, Sharding, type(None))):
+    raise TypeError("device_put 'src' argument must be a Device or Sharding, "
+                    f"but got type {type(src)} with value {src}.")
   try:
     aval = xla.abstractify(x)
   except TypeError as err:
     raise TypeError(
-        f"Argument '{x}' of type {type(x)} is not a valid JAX type") from err
+        f"device_put argument '{x}' of type {type(x)} is not a valid JAX type"
+    ) from err
 
   if isinstance(device, Sharding):
     s = device


### PR DESCRIPTION
Two fixes:
* raise a nice `TypeError` instead of a low-level XLA/PjRt error when the second argument to a `device_put` is of the wrong type, and
* put an `api_boundary` around `device_put` (see screenshot below)

Actually these screenshots are a little buggy but I'm too lazy to re-generate them and they get the point across :P

Before this PR:
<img width="952" alt="image" src="https://user-images.githubusercontent.com/1458824/231889262-a9b28067-80ab-408c-98a2-44daae5d14eb.png">

Before `api_boundary`:
<img width="952" alt="image" src="https://user-images.githubusercontent.com/1458824/231889219-f566db64-dfc4-4fc0-9cf0-1eddd47064e2.png">

After:
<img width="952" alt="image" src="https://user-images.githubusercontent.com/1458824/231889166-45a9f11e-ed11-45ac-8cb5-8d5cac18d182.png">

This last one is the best because it shows the problematic `jax.device_put(1, 1)` right at the bottom of the traceback.
