### PR TITLE
`jit` the threefry seed function

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -875,6 +875,10 @@ def threefry_seed(seed: typing.Array) -> typing.Array:
     bit-casting to a pair of uint32 values (or from a 32-bit seed by
     first padding out with zeros).
   """
+  return _threefry_seed(seed)
+
+@partial(jit, inline=True)
+def _threefry_seed(seed: typing.Array) -> typing.Array:
   if seed.shape:
     raise TypeError(f"PRNG key seed must be a scalar; got {seed!r}.")
   if not np.issubdtype(seed.dtype, np.integer):

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -527,6 +527,13 @@ class PrngTest(jtu.JaxTestCase):
     self.assertIsInstance(key, jax.Array)
 
 
+class ThreefryPrngTest(jtu.JaxTestCase):
+  def test_seed_no_implicit_transfers(self):
+    # See https://github.com/google/jax/issues/15613
+    with jax.transfer_guard('disallow'):
+      random.threefry2x32_key(jax.device_put(42))  # doesn't crash
+
+
 class LaxRandomTest(jtu.JaxTestCase):
 
   def _CheckCollisions(self, samples, nbits):


### PR DESCRIPTION
The Threefry PRNG's seeding function involves operations with small constants, such as `lax.shift_right_logical(seed, 32)`. This causes to host-to-device transfers of small scalars (e.g. `32`) every time that one seeds outside of a `jit`. To avoid these transfers, and any inflexibility under JAX's transfer guard, this change `jit`s the seeding function (baking the constants in to the computation).

This shifts costs around a bit. Whereas previously we were moving scalars to device on every (eager) seed call, we are now tracing and compiling the seed function. The latter will only happen once per input shape.

Fixes #15613.