### PR TITLE
mypy: type-check ml_dtypes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
   - id: mypy
     files: (jax/|tests/typing_test\.py)
     exclude: jax/_src/basearray.py  # Use pyi instead
-    additional_dependencies: [types-requests==2.28.11, jaxlib==0.4.6, ml_dtypes==0.0.3, numpy==1.21.6, scipy==1.7.3]
+    additional_dependencies: [types-requests==2.28.11, jaxlib==0.4.6, ml_dtypes==0.1.0, numpy==1.21.6, scipy==1.7.3]
     args: [--config=pyproject.toml]
 
 - repo: https://github.com/mwouts/jupytext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ module = [
     "jaxlib.*",
     "pytest.*",
     "zstandard.*",
-    "ml_dtypes",
     "jax.experimental.jax2tf.tests.flax_models",
     "jax.experimental.jax2tf.tests.back_compat_testdata"
 ]


### PR DESCRIPTION
Older versions of `ml_dtypes` didn't include `py.typed`; newer versions do.