### PR TITLE
feat (scipy.special): Add a xla version of scipy.special.gamma function

### DIFF
--- a/docs/jax.lax.rst
+++ b/docs/jax.lax.rst
@@ -88,6 +88,7 @@ Operators
     floor
     full
     full_like
+    gamma
     gather
     ge
     gt

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -120,6 +120,7 @@ jax.scipy.special
    expi
    expit
    expn
+   gamma
    gammainc
    gammaincc
    gammaln

--- a/jax/_src/lax/special.py
+++ b/jax/_src/lax/special.py
@@ -45,6 +45,10 @@ def lgamma(x: ArrayLike) -> Array:
   r"""Elementwise log gamma: :math:`\mathrm{log}(\Gamma(x))`."""
   return lgamma_p.bind(x)
 
+def gamma(x: ArrayLike) -> Array:
+  r"""Elementwise gamma: :math:`\Gamma(x)`."""
+  return exp(lgamma_p.bind(x))
+
 def digamma(x: ArrayLike) -> Array:
   r"""Elementwise digamma: :math:`\psi(x)`."""
   return digamma_p.bind(x)

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -42,6 +42,12 @@ def gammaln(x: ArrayLike) -> Array:
   return lax.lgamma(x)
 
 
+@_wraps(osp_special.gammaln, module='scipy.special')
+def gamma(x: ArrayLike) -> Array:
+  x, = promote_args_inexact("gamma", x)
+  return lax.exp(lax.lgamma(x))
+
+
 betaln = _wraps(
     osp_special.betaln,
     module='scipy.special',

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -31,6 +31,7 @@ from jax._src.scipy.special import (
   gammainc as gammainc,
   gammaincc as gammaincc,
   gammaln as gammaln,
+  gamma as gamma,
   i0 as i0,
   i0e as i0e,
   i1 as i1,

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -60,6 +60,9 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
         "betainc", 3, float_dtypes, jtu.rand_positive, False
     ),
     op_record(
+        "gamma", 1, float_dtypes, jtu.rand_positive, True
+    ),
+    op_record(
         "digamma", 1, float_dtypes, jtu.rand_positive, True
     ),
     op_record(


### PR DESCRIPTION
 - Add low-level api in lax.special
 - Add high-level api in scipy.special
 - Add tests for this purpose

Currently, there is no implementation of the gamma function in jax
 but there is one in scipy.special. This breaks some higher level
  jit-compilation like in the blackjax backend for pymc. This commit
  adds the missing gamma function.

Resolves: #15409 