### PR TITLE
feat (scipy.special): Add a xla version of scipy.special.gamma function

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -120,6 +120,7 @@ jax.scipy.special
    expi
    expit
    expn
+   gamma
    gammainc
    gammaincc
    gammaln

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -42,6 +42,12 @@ def gammaln(x: ArrayLike) -> Array:
   return lax.lgamma(x)
 
 
+@_wraps(osp_special.gammaln, module='scipy.special')
+def gamma(x: ArrayLike) -> Array:
+  x, = promote_args_inexact("gamma", x)
+  return lax.exp(lax.lgamma(x))
+
+
 betaln = _wraps(
     osp_special.betaln,
     module='scipy.special',

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -31,6 +31,7 @@ from jax._src.scipy.special import (
   gammainc as gammainc,
   gammaincc as gammaincc,
   gammaln as gammaln,
+  gamma as gamma,
   i0 as i0,
   i0e as i0e,
   i1 as i1,

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -60,6 +60,9 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
         "betainc", 3, float_dtypes, jtu.rand_positive, False
     ),
     op_record(
+        "gamma", 1, float_dtypes, jtu.rand_positive, True
+    ),
+    op_record(
         "digamma", 1, float_dtypes, jtu.rand_positive, True
     ),
     op_record(


### PR DESCRIPTION
- Add gamma fcn api in scipy.special
- Add tests for this purpose
- Add function to the docs

Currently, there is no implementation of the gamma function in jax but there is one in scipy.special. This breaks some higher level jit-compilation like in the blackjax backend for pymc. This commit adds the missing gamma function.

Resolves: #15409
See also the previously failed PR: #15652