### PR TITLE
Use the traceback of the call site when assigning a source location t…

### DIFF
--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1879,7 +1879,8 @@ class DynamicJaxprTrace(core.Trace):
       dbg = debug_info_final(f, call_primitive.name)
       jaxpr, out_type, consts = trace_to_subjaxpr_dynamic2(f, self.main, debug_info=dbg)
     if params.get('inline', False):
-      return core.eval_jaxpr(jaxpr, consts, *in_tracers)
+      return core.eval_jaxpr(jaxpr, consts, *in_tracers,
+                             propagate_source_info=False)
     source_info = source_info_util.current()
     out_tracers = []
     for aval, _ in out_type:

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1233,7 +1233,8 @@ def pjit_staging_rule(trace, *args, **params):
       all(is_unspecified(i) for i in params["in_shardings"]) and
       all(is_unspecified(o) for o in params["out_shardings"])):
     jaxpr = params['jaxpr']
-    return core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, *args)
+    return core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, *args,
+                           propagate_source_info=False)
   elif config.jax_dynamic_shapes:
     source_info = source_info_util.current()
     out_tracers = []

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1060,6 +1060,15 @@ jax_test(
     ],
 )
 
+py_test(
+    name = "source_info_test",
+    srcs = ["source_info_test.py"],
+    deps = [
+        "//jax",
+        "//jax:test_util",
+    ],
+)
+
 exports_files(
     [
         "api_test.py",

--- a/tests/source_info_test.py
+++ b/tests/source_info_test.py
@@ -1,0 +1,55 @@
+# Copyright 2023 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+import inspect
+
+from absl.testing import absltest
+
+import jax
+from jax import lax
+from jax.config import config
+from jax._src import source_info_util
+from jax._src import test_util as jtu
+
+config.parse_flags_with_absl()
+
+
+class SourceInfoTest(jtu.JaxTestCase):
+
+  def test_inline_jit_location_uses_callee_location(self):
+
+    # 'f' should be inlined into both 'g' and 'h', using the source line
+    # information of the call site. In particular, the source line information
+    # of 'h' should not refer to the source information of 'g'.
+    @partial(jax.jit, inline=True)
+    def f(x): return lax.add(x, 3)
+
+    def g(x): return lax.add(f(x), 4)
+
+    def h(x): return lax.add(f(x), 5)
+
+    for fn in (g, h):
+      lines, fn_startline = inspect.getsourcelines(fn)
+      fn_endline = fn_startline + len(lines)
+      jaxpr = jax.make_jaxpr(fn)(2)
+      for eqn in jaxpr.eqns:
+        frame = source_info_util.user_frame(eqn.source_info)
+        assert frame is not None, eqn
+        self.assertLessEqual(fn_startline, frame.start_line)
+        self.assertLessEqual(frame.end_line, fn_endline)
+
+
+if __name__ == '__main__':
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
…o an inlined function.

Improves but does not completely fix https://github.com/google/jax/issues/15663 . The non-inlined case still has similar problems.