### PR TITLE
add custom_jvp for jax.nn.softmax

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -51,6 +51,7 @@ from jax._src.config import (
   check_tracer_leaks as check_tracer_leaks,
   checking_leaks as checking_leaks,
   enable_custom_prng as enable_custom_prng,
+  softmax_custom_jvp as softmax_custom_jvp,
   enable_custom_vjp_by_custom_transpose as enable_custom_vjp_by_custom_transpose,
   debug_nans as debug_nans,
   debug_infs as debug_infs,

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -17,6 +17,7 @@
 import collections
 from functools import partial
 import itertools
+import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -25,6 +26,7 @@ import scipy.stats
 
 from jax._src import core
 from jax._src import test_util as jtu
+from jax._src import ad_checkpoint
 from jax.test_util import check_grads
 from jax import nn
 from jax import random
@@ -138,6 +140,37 @@ class NNFunctionsTest(jtu.JaxTestCase):
     out_filtered = fn(x_filtered)
 
     self.assertAllClose(out_masked, out_filtered)
+
+    # TODO(mattjj): log_softmax doesn't pass numerical gradient checking, but at
+    # time of writign only softmax has a custom rule to check
+    if fn is nn.softmax:
+      g_fun = lambda x: jnp.take(fn(x, where=m, initial=-jnp.inf),
+                                jnp.array([0, 2, 3]))
+      jtu.check_grads(g_fun, (x,), order=2)
+
+  def testSoftmaxGrad(self):
+    x = jnp.array([5.5, 1.3, -4.2, 0.9])
+    jtu.check_grads(nn.softmax, (x,), order=2, atol=3e-3)
+
+  def testSoftmaxGradResiduals(self):
+    if not jax.config.jax_softmax_custom_jvp:
+      raise unittest.SkipTest("only applies when upgrade flag enabled")
+    x = jnp.array([5.5, 1.3, -4.2, 0.9])
+    res = ad_checkpoint.saved_residuals(nn.softmax, x)
+    self.assertLen(res, 1)
+
+  def testSoftmaxGradFlag(self):
+    x = jnp.array([5.5, 1.3, -4.2, 0.9])
+
+    with jax.softmax_custom_jvp(False):
+      res = ad_checkpoint.saved_residuals(nn.softmax, x)
+    self.assertLen(res, 3)
+    self.assertEqual(sum(a.size for a, _ in res), 6)
+
+    with jax.softmax_custom_jvp(True):
+      res = ad_checkpoint.saved_residuals(nn.softmax, x)
+    self.assertLen(res, 1)
+    self.assertEqual(sum(a.size for a, _ in res), 4)
 
   def testStandardizeWhereMask(self):
     x = jnp.array([5.5, 1.3, -4.2, 0.9])


### PR DESCRIPTION
This approach avoids saving the jnp.exp(...) value.

This implementation is basically the same as [the one in TF](https://github.com/tensorflow/tensorflow/blob/1df4022ca1ad8b131765148e2340bdea9ffdaec2/tensorflow/python/ops/nn_grad.py#L282-L304).

Thanks to @blakehechtman for pointing this out and advising.

We expect this change to be an improvement for all users, since it can improve stability and may use less memory (though in many cases XLA optimizations mean the memory usage may not really change). However, since it's changing a heavily relied-upon function, we're including a flag which can be set to restore the old behavior. We'll keep the flag around until we're sure this change doesn't cause regressions.

To restore the old behavior for now, we can:
1. use the context manager `with jax.softmax_custom_jvp(False): ...`, or
2. use the shell environment variable `JAX_SOFTMAX_CUSTOM_JVP=0`, or
3. set the config option `jax.config.update('jax_softmax_custom_jvp', False)`, or
4. if parsing flags with absl, use the flag `--jax_softmax_custom_jvp=False`.

The config option is thread- and jit-cache-safe, as usual.

Before:
<img width="1312" alt="image" src="https://user-images.githubusercontent.com/1458824/233800805-1fc5e152-71fc-4294-bcc6-96f2269a5273.png">

After:
<img width="1312" alt="image" src="https://user-images.githubusercontent.com/1458824/233800815-26390185-5feb-48e6-a038-8aa4a140b73e.png">


TODO:
* [x] add a flag to switch this off (doesn't have to be a nice or documented flag, but just "break glass in case of emergency" while we wait for things to shake out)
* [x] show that the saved residuals are different (in a test, or just in this PR message)
* [x] adapt any google-internal goldens that this might affect