### PR TITLE
make jvp(asarray, (1.,), (2.,)) produce Arrays

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -542,7 +542,10 @@ def _convert_element_type(operand: ArrayLike, new_dtype: Optional[DTypeLike] = N
     operand = np.asarray(operand).astype(new_dtype)
     old_weak_type = False
 
-  if (old_dtype, old_weak_type) == (new_dtype, weak_type) and isinstance(operand, Array):
+  if ((old_dtype, old_weak_type) == (new_dtype, weak_type) and
+      isinstance(operand, Array) and
+      not (isinstance(operand, core.Tracer) and
+           isinstance(core.get_aval(operand), core.ConcreteArray))):
     return type_cast(Array, operand)
   else:
     return convert_element_type_p.bind(operand, new_dtype=new_dtype,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4358,6 +4358,12 @@ class APITest(jtu.JaxTestCase):
     args_maker = lambda: [jnp.ones((), dtype=dtype)]
     self._CompileAndCheck(f, args_maker)
 
+  def test_jvp_asarray_returns_array(self):
+    # https://github.com/google/jax/issues/15676
+    p, t = jax.jvp(jax.numpy.asarray, (1.,), (2.,))
+    _check_instance(self, p)
+    _check_instance(self, t)
+
 
 class RematTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
fixes #15676

The basic idea here is that we have a path in `lax._convert_element_type` to skip binding the primitive if we determine it would have no effect, i.e. it wouldn't convert to a JAX Array or to a different dtype. That check logic assumed that any Tracer could be passed through. But because we allow non-jax.Arrays to be boxed in JVPTracers, that meant we might return non-jax.Arrays from `jax.jvp(jnp.asarray, ...)`.

We could either ensure that JVPTracers always box jax.Arrays, or we could adjust the logic in the `lax._convert_element_type` short-circuit. The latter is easier so I thought I'd try that first, and see what @jakevdp thinks!