### PR TITLE
Add test framework for module attribute

### DIFF
--- a/jax/_src/errors.py
+++ b/jax/_src/errors.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 from jax._src import core
 from jax._src.util import set_module
 
+export = set_module('jax.errors')
+
 
 class _JAXErrorMixin:
   """Mixin for JAX-specific errors"""
@@ -31,17 +33,17 @@ class _JAXErrorMixin:
     super().__init__(error_msg)  # type: ignore
 
 
-@set_module('jax.errors')
+@export
 class JAXTypeError(_JAXErrorMixin, TypeError):
   pass
 
 
-@set_module('jax.errors')
+@export
 class JAXIndexError(_JAXErrorMixin, IndexError):
   pass
 
 
-@set_module('jax.errors')
+@export
 class ConcretizationTypeError(JAXTypeError):
   """
   This error occurs when a JAX Tracer object is used in a context where a
@@ -185,7 +187,7 @@ class ConcretizationTypeError(JAXTypeError):
         f"{tracer}\n{context}{tracer._origin_msg()}\n")
 
 
-@set_module('jax.errors')
+@export
 class NonConcreteBooleanIndexError(JAXIndexError):
   """
   This error occurs when a program attempts to use non-concrete boolean indices
@@ -277,7 +279,7 @@ class NonConcreteBooleanIndexError(JAXIndexError):
         f"Array boolean indices must be concrete; got {tracer}\n")
 
 
-@set_module('jax.errors')
+@export
 class TracerArrayConversionError(JAXTypeError):
   """
   This error occurs when a program attempts to convert a JAX Tracer object into
@@ -358,7 +360,7 @@ class TracerArrayConversionError(JAXTypeError):
         f"the JAX Tracer object {tracer}{tracer._origin_msg()}")
 
 
-@set_module('jax.errors')
+@export
 class TracerIntegerConversionError(JAXTypeError):
   """
   This error can occur when a JAX Tracer object is used in a context where a
@@ -451,7 +453,7 @@ class TracerIntegerConversionError(JAXTypeError):
         f"The __index__() method was called on the JAX Tracer object {tracer}")
 
 
-@set_module('jax.errors')
+@export
 class UnexpectedTracerError(JAXTypeError):
   """
   This error occurs when you use a JAX value that has leaked out of a function.

--- a/jax/_src/nn/initializers.py
+++ b/jax/_src/nn/initializers.py
@@ -27,6 +27,9 @@ from jax import lax
 from jax import random
 from jax._src import core
 from jax._src import dtypes
+from jax._src.util import set_module
+
+export = set_module('jax.nn.initializers')
 
 KeyArray = random.KeyArray
 Array = Any
@@ -37,6 +40,7 @@ DTypeLikeComplex = Any
 DTypeLikeInexact = Any  # DTypeLikeFloat | DTypeLikeComplex
 RealNumeric = Any  # Scalar jnp array or float
 
+@export
 class Initializer(Protocol):
   @staticmethod
   def __call__(key: KeyArray,
@@ -44,6 +48,7 @@ class Initializer(Protocol):
                dtype: DTypeLikeInexact = jnp.float_) -> Array:
     ...
 
+@export
 def zeros(key: KeyArray,
           shape: core.Shape,
           dtype: DTypeLikeInexact = jnp.float_) -> Array:
@@ -58,6 +63,7 @@ def zeros(key: KeyArray,
   """
   return jnp.zeros(shape, dtypes.canonicalize_dtype(dtype))
 
+@export
 def ones(key: KeyArray,
          shape: core.Shape,
          dtype: DTypeLikeInexact = jnp.float_) -> Array:
@@ -73,6 +79,7 @@ def ones(key: KeyArray,
   """
   return jnp.ones(shape, dtypes.canonicalize_dtype(dtype))
 
+@export
 def constant(value: Array,
              dtype: DTypeLikeInexact = jnp.float_
              ) -> Initializer:
@@ -95,6 +102,7 @@ def constant(value: Array,
     return jnp.full(shape, value, dtype=dtype)
   return init
 
+@export
 def uniform(scale: RealNumeric = 1e-2,
             dtype: DTypeLikeInexact = jnp.float_) -> Initializer:
   """Builds an initializer that returns real uniformly-distributed random arrays.
@@ -120,6 +128,7 @@ def uniform(scale: RealNumeric = 1e-2,
     return random.uniform(key, shape, dtype) * scale
   return init
 
+@export
 def normal(stddev: RealNumeric = 1e-2,
            dtype: DTypeLikeInexact = jnp.float_) -> Initializer:
   """Builds an initializer that returns real normally-distributed random arrays.
@@ -145,6 +154,7 @@ def normal(stddev: RealNumeric = 1e-2,
     return random.normal(key, shape, dtype) * stddev
   return init
 
+@export
 def _compute_fans(shape: core.NamedShape,
                   in_axis: Union[int, Sequence[int]] = -2,
                   out_axis: Union[int, Sequence[int]] = -1,
@@ -208,6 +218,7 @@ def _complex_truncated_normal(key: KeyArray, upper: Array,
   theta = 2 * jnp.pi * random.uniform(key_theta, shape, real_dtype).astype(dtype)
   return r * jnp.exp(1j * theta)
 
+@export
 def variance_scaling(
   scale: RealNumeric,
   mode: Union[Literal["fan_in"], Literal["fan_out"], Literal["fan_avg"]],
@@ -295,6 +306,7 @@ def variance_scaling(
 
   return init
 
+@export
 def glorot_uniform(in_axis: Union[int, Sequence[int]] = -2,
                    out_axis: Union[int, Sequence[int]] = -1,
                    batch_axis: Sequence[int] = (),
@@ -332,7 +344,7 @@ def glorot_uniform(in_axis: Union[int, Sequence[int]] = -2,
 
 xavier_uniform = glorot_uniform
 
-
+@export
 def glorot_normal(in_axis: Union[int, Sequence[int]] = -2,
                   out_axis: Union[int, Sequence[int]] = -1,
                   batch_axis: Sequence[int] = (),
@@ -370,6 +382,7 @@ def glorot_normal(in_axis: Union[int, Sequence[int]] = -2,
 
 xavier_normal = glorot_normal
 
+@export
 def lecun_uniform(in_axis: Union[int, Sequence[int]] = -2,
                   out_axis: Union[int, Sequence[int]] = -1,
                   batch_axis: Sequence[int] = (),
@@ -405,6 +418,7 @@ def lecun_uniform(in_axis: Union[int, Sequence[int]] = -2,
   return variance_scaling(1.0, "fan_in", "uniform", in_axis=in_axis,
                           out_axis=out_axis, batch_axis=batch_axis, dtype=dtype)
 
+@export
 def lecun_normal(in_axis: Union[int, Sequence[int]] = -2,
                  out_axis: Union[int, Sequence[int]] = -1,
                  batch_axis: Sequence[int] = (),
@@ -440,7 +454,7 @@ def lecun_normal(in_axis: Union[int, Sequence[int]] = -2,
   return variance_scaling(1.0, "fan_in", "truncated_normal", in_axis=in_axis,
                           out_axis=out_axis, batch_axis=batch_axis, dtype=dtype)
 
-
+@export
 def he_uniform(in_axis: Union[int, Sequence[int]] = -2,
                out_axis: Union[int, Sequence[int]] = -1,
                batch_axis: Sequence[int] = (),
@@ -478,7 +492,7 @@ def he_uniform(in_axis: Union[int, Sequence[int]] = -2,
 
 kaiming_uniform = he_uniform
 
-
+@export
 def he_normal(in_axis: Union[int, Sequence[int]] = -2,
               out_axis: Union[int, Sequence[int]] = -1,
               batch_axis: Sequence[int] = (),
@@ -516,7 +530,7 @@ def he_normal(in_axis: Union[int, Sequence[int]] = -2,
 
 kaiming_normal = he_normal
 
-
+@export
 def orthogonal(scale: RealNumeric = 1.0,
                column_axis: int = -1,
                dtype: DTypeLikeInexact = jnp.float_) -> Initializer:
@@ -560,7 +574,7 @@ def orthogonal(scale: RealNumeric = 1.0,
     return scale * Q
   return init
 
-
+@export
 def delta_orthogonal(
   scale: RealNumeric = 1.0,
   column_axis: int = -1,

--- a/jax/nn/initializers.py
+++ b/jax/nn/initializers.py
@@ -41,11 +41,3 @@ from jax._src.nn.initializers import (
   xavier_uniform as xavier_uniform,
   zeros as zeros,
 )
-
-# Set __module__ to the public name.
-def _fixup_modules():
-  for _fn in globals().values():
-    if getattr(_fn, "__module__", None) == "jax._src.nn.initializers":
-      _fn.__module__ = "jax.nn.initializers"
-_fixup_modules()
-del _fixup_modules

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1072,6 +1072,15 @@ py_test(
     ],
 )
 
+py_test(
+    name = "package_structure_test",
+    srcs = ["package_structure_test.py"],
+    deps = [
+        "//jax",
+        "//jax:test_util",
+    ],
+)
+
 exports_files(
     [
         "api_test.py",

--- a/tests/package_structure_test.py
+++ b/tests/package_structure_test.py
@@ -1,0 +1,50 @@
+# Copyright 2023 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests of the JAX public package structure"""
+
+import importlib
+import types
+from typing import Sequence
+
+from absl.testing import absltest, parameterized
+
+from jax._src import test_util as jtu
+
+
+def _mod(module_name: str, *, include: Sequence[str] = (), exclude: Sequence[str] = ()):
+  return {"module_name": module_name, "include": include, "exclude": exclude}
+
+
+class PackageStructureTest(jtu.JaxTestCase):
+  @parameterized.parameters([
+    # TODO(jakevdp): expand test to other public modules.
+    _mod("jax.errors"),
+    _mod("jax.nn.initializers"),
+  ])
+  def test_exported_names_match_module(self, module_name, include, exclude):
+    """Test that all public exports have __module__ set correctly."""
+    module = importlib.import_module(module_name)
+    self.assertEqual(module.__name__, module_name)
+    for name in dir(module):
+      if name not in include and (name.startswith('_') or name in exclude):
+        continue
+      obj = getattr(module, name)
+      if isinstance(obj, types.ModuleType):
+        continue
+      self.assertEqual(obj.__module__, module_name)
+
+
+if __name__ == '__main__':
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
I'd like to get us to the point where the attributes of `jax.xxx.yyy` report its public module rather than the location in `_src` where it happens to be defined. We already have that for a smattering of public objects, and the main change here is to add a test so we don't backslide on that.

Also, for `jax.nn.initializers`, we mark the public module at the definition, rather than post-hoc in the imports, because we decided that approach is better in #15698.