### PR TITLE
internal: remove aliasing of builtins from lax_numpy

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -22,7 +22,7 @@ import jax
 import weakref
 from jax._src import core
 from jax._src import linear_util as lu
-from jax import config
+from jax import config  # type: ignore[no-redef]
 from jax._src.core import ConcreteArray, ShapedArray, raise_to_shaped
 from jax.tree_util import (tree_flatten, tree_unflatten, treedef_is_leaf,
                            tree_map, tree_flatten_with_path, keystr)


### PR DESCRIPTION
The overrides for these functions are no longer part of this file, so we no longer need these aliases.