### PR TITLE
internal: use public dtypes.result_type where possible

### DIFF
--- a/jax/_src/abstract_arrays.py
+++ b/jax/_src/abstract_arrays.py
@@ -35,7 +35,7 @@ canonicalize_shape = core.canonicalize_shape
 raise_to_shaped = core.raise_to_shaped
 
 def zeros_like_array(x):
-  dtype, weak_type = dtypes._lattice_result_type(x)
+  dtype, weak_type = dtypes.result_type(x, return_weak_type_flag=True)
   dtype = dtypes.canonicalize_dtype(dtype)
   aval = ShapedArray(np.shape(x), dtype, weak_type=weak_type)
   return ad_util.zeros_like_aval(aval)

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -270,8 +270,8 @@ def promote_dtypes(*args: ArrayLike) -> List[Array]:
   if len(args) < 2:
     return [lax.asarray(arg) for arg in args]
   else:
-    to_dtype, weak_type = dtypes._lattice_result_type(*args)
-    to_dtype = dtypes.canonicalize_dtype(to_dtype)
+    to_dtype, weak_type = dtypes.result_type(
+        *args, return_weak_type_flag=True, standardize_weak_dtype=False)
     return [lax._convert_element_type(x, to_dtype, weak_type) for x in args]
 
 
@@ -279,8 +279,8 @@ def promote_dtypes_inexact(*args: ArrayLike) -> List[Array]:
   """Convenience function to apply Numpy argument dtype promotion.
 
   Promotes arguments to an inexact type."""
-  to_dtype, weak_type = dtypes._lattice_result_type(*args)
-  to_dtype = dtypes.canonicalize_dtype(to_dtype)
+  to_dtype, weak_type = dtypes.result_type(
+      *args, return_weak_type_flag=True, standardize_weak_dtype=False)
   to_dtype_inexact = dtypes.to_inexact_dtype(to_dtype)
   return [lax._convert_element_type(x, to_dtype_inexact, weak_type)
           for x in args]
@@ -290,8 +290,7 @@ def promote_dtypes_numeric(*args: ArrayLike) -> List[Array]:
   """Convenience function to apply Numpy argument dtype promotion.
 
   Promotes arguments to a numeric (non-bool) type."""
-  to_dtype, weak_type = dtypes._lattice_result_type(*args)
-  to_dtype = dtypes.canonicalize_dtype(to_dtype)
+  to_dtype, weak_type = dtypes.result_type(*args, return_weak_type_flag=True)
   to_dtype_numeric = dtypes.to_numeric_dtype(to_dtype)
   return [lax._convert_element_type(x, to_dtype_numeric, weak_type)
           for x in args]
@@ -301,8 +300,7 @@ def promote_dtypes_complex(*args: ArrayLike) -> List[Array]:
   """Convenience function to apply Numpy argument dtype promotion.
 
   Promotes arguments to a complex type."""
-  to_dtype, weak_type = dtypes._lattice_result_type(*args)
-  to_dtype = dtypes.canonicalize_dtype(to_dtype)
+  to_dtype, weak_type = dtypes.result_type(*args, return_weak_type_flag=True)
   to_dtype_complex = dtypes.to_complex_dtype(to_dtype)
   return [lax._convert_element_type(x, to_dtype_complex, weak_type)
           for x in args]

--- a/jax/_src/scipy/sparse/linalg.py
+++ b/jax/_src/scipy/sparse/linalg.py
@@ -181,7 +181,7 @@ def _bicgstab_solve(A, b, x0=None, *, maxiter, tol=1e-5, atol=0.0, M=_identity):
 
   r0 = _sub(b, A(x0))
   rho0 = alpha0 = omega0 = lax_internal._convert_element_type(
-      1, *dtypes._lattice_result_type(*tree_leaves(b)))
+      1, *dtypes.result_type(*tree_leaves(b), return_weak_type_flag=True))
   initial_value = (x0, r0, r0, alpha0, omega0, rho0, r0, r0, 0)
 
   x_final, *_ = lax.while_loop(cond_fun, body_fun, initial_value)
@@ -300,7 +300,7 @@ def _safe_normalize(x, thresh=None):
   taken to be 0, and the normalized x to be the zero vector.
   """
   norm = _norm(x)
-  dtype, weak_type = dtypes._lattice_result_type(*tree_leaves(x))
+  dtype, weak_type = dtypes.result_type(*tree_leaves(x), return_weak_type_flag=True)
   dtype = dtypes.canonicalize_dtype(dtype)
   if thresh is None:
     thresh = jnp.finfo(norm.dtype).eps
@@ -402,8 +402,7 @@ def _kth_arnoldi_iteration(k, A, M, V, H):
   subspace is declared to have been found, in which case in which case the new
   vector is taken to be the zero vector.
   """
-  dtype, _ = dtypes._lattice_result_type(*tree_leaves(V))
-  dtype = dtypes.canonicalize_dtype(dtype)
+  dtype = dtypes.result_type(*tree_leaves(V))
   eps = jnp.finfo(dtype).eps
 
   v = tree_map(lambda x: x[..., k], V)  # Gets V[:, k]
@@ -534,8 +533,7 @@ def _gmres_batched(A, b, x0, unit_residual, residual_norm, ptol, restart, M):
       lambda x: jnp.pad(x[..., None], ((0, 0),) * x.ndim + ((0, restart),)),
       unit_residual,
   )
-  dtype, weak_type = dtypes._lattice_result_type(*tree_leaves(b))
-  dtype = dtypes.canonicalize_dtype(dtype)
+  dtype, weak_type = dtypes.result_type(*tree_leaves(b), return_weak_type_flag=True)
   H = lax_internal._convert_element_type(
       jnp.eye(restart, restart + 1, dtype=dtype), weak_type=weak_type)
 


### PR DESCRIPTION
The goal here is to make everything go through `dtypes.result_type` so that we can more uniformly handle opaque dtypes.