### PR TITLE
KeyArray: improve errors for unimplemented primitives

### DIFF
--- a/jax/_src/lax/utils.py
+++ b/jax/_src/lax/utils.py
@@ -16,7 +16,6 @@
 # avoid cyclic dependencies. Definitions that are used at import time by
 # multiple modules can go here.
 
-import builtins
 from functools import partial
 import operator
 from typing import Callable
@@ -28,12 +27,9 @@ from jax._src.interpreters import xla
 from jax._src.util import safe_zip
 from jax._src.lib import xla_client
 
+import numpy as np
+
 xops = xla_client.ops
-
-_max = builtins.max
-
-# ### primitives
-
 
 _input_dtype: Callable = lambda *args, **_: dtypes.canonicalize_dtype(args[0].dtype, allow_opaque_dtype=True)
 
@@ -58,8 +54,8 @@ def standard_abstract_eval(prim, shape_rule, dtype_rule, weak_type_rule,
   assert all(isinstance(aval, core.UnshapedArray) for aval in avals), avals
   assert not prim.multiple_results
   weak_type = weak_type_rule(*avals, **kwargs)
-  least_specialized = _max(map(type, avals),
-                           key=operator.attrgetter('array_abstraction_level'))
+  least_specialized = max(map(type, avals),
+                          key=operator.attrgetter('array_abstraction_level'))
   if least_specialized is core.ConcreteArray:
     out = prim.impl(*[x.val for x in avals], **kwargs)
     return core.ConcreteArray(out.dtype, out, weak_type=weak_type)
@@ -82,8 +78,8 @@ def standard_multi_result_abstract_eval(
     named_shape_rule, *avals, **kwargs):
   assert prim.multiple_results
   assert all(isinstance(aval, core.UnshapedArray) for aval in avals), avals
-  least_specialized = _max(map(type, avals),
-                           key=operator.attrgetter('array_abstraction_level'))
+  least_specialized = max(map(type, avals),
+                          key=operator.attrgetter('array_abstraction_level'))
   weak_types = weak_type_rule(*avals, **kwargs)
   if least_specialized is core.ConcreteArray:
     out_vals = prim.impl(*[x.val for x in avals], **kwargs)
@@ -116,3 +112,14 @@ def standard_named_shape_rule(*avals, **kwargs):
 
 def _standard_weak_type_rule(*avals, **kwargs):
   return all(aval.weak_type for aval in avals)
+
+def dtype_to_string(dtype):
+  try:
+    return str(np.dtype(dtype).name)
+  except TypeError:
+    pass
+  try:
+    return dtype.name
+  except AttributeError:
+    pass
+  return str(dtype)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -2097,6 +2097,17 @@ class JnpWithKeyArrayTest(jtu.JaxTestCase):
     self.assertKeysEqual(key, jax.jit(jnp.array)(key))
     self.assertKeysEqual(key, jax.jit(jnp.asarray)(key))
 
+  def test_errors(self):
+    key = random.PRNGKey(123)
+    with self.assertRaisesRegex(ValueError, "dtype=key<fry> is not a valid dtype"):
+      jnp.add(key, 1)
+    with self.assertRaisesRegex(TypeError, "add does not accept dtype key<fry>"):
+      jnp.add(key, key)
+    with self.assertRaisesRegex(TypeError, "neg does not accept dtype key<fry>"):
+      jnp.negative(key)
+    with self.assertRaisesRegex(ValueError, "Cannot call convert_element_type on dtype key<fry>"):
+      lax.convert_element_type(key, int)
+
 
 def _sampler_unimplemented_with_custom_prng(*args, **kwargs):
   raise SkipTest('sampler only implemented for default RNG')


### PR DESCRIPTION
Previously these errors were unclear/ambiguous.