### PR TITLE
[jax2tf] Fix numpy deprecation warning in test harness

### DIFF
--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -768,7 +768,10 @@ for dtype in jtu.dtypes.all:
       dtype=dtype)
 
 for dtype in jtu.dtypes.all_integer + jtu.dtypes.all_unsigned:
-  arg = np.array([-1, -2, 0, 1], dtype=dtype)
+  if np.issubdtype(dtype, np.unsignedinteger):
+    arg = np.array([0, 1, 2], dtype=dtype)
+  else:
+    arg = np.array([-1, -2, 0, 1], dtype=dtype)
   define(
       "population_count",
       f"{jtu.dtype_str(dtype)}",


### PR DESCRIPTION
In newer versions of numpy we a deprecation warning:

DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of -1 to uint8 will fail in the future.