### PR TITLE
Make shard_map_test compatible with custom_prng

### DIFF
--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -582,7 +582,8 @@ class ShardMapTest(jtu.JaxTestCase):
       return jax.random.randint(key[0], shape=(1, 16), minval=0, maxval=16,
                                 dtype=jnp.int32)
 
-    g = shard_map(f, mesh, in_specs=(P('x', None),), out_specs=P('x', None))
+    pspec = P('x') if config.jax_enable_custom_prng else P('x', None)
+    g = shard_map(f, mesh, in_specs=(pspec,), out_specs=pspec)
     _ = g(sharded_rng)  # don't crash!
 
   def test_functools_partial_rank_error(self):


### PR DESCRIPTION
Tested:
```
$ JAX_ENABLE_CUSTOM_PRNG=1 pytest tests/shard_map_test.py -k test_prngkeyarray_eager
===================================== test session starts =====================================
platform darwin -- Python 3.8.2, pytest-7.2.2, pluggy-0.13.1
rootdir: /Users/vanderplas/github/google/jax, configfile: pyproject.toml
plugins: env-0.6.2, xdist-3.2.1, cov-2.10.0, forked-1.3.0, reportlog-0.1.2
collected 103 items / 102 deselected / 1 selected                                             

tests/shard_map_test.py .                                                               [100%]

============================== 1 passed, 102 deselected in 2.01s ==============================
```
There's no CI test coverage for this yet, but we're getting there...