### PR TITLE
[shape_poly] Refactor the unification of the argument abstract value with the actual arguments

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2094,7 +2094,12 @@ def dim_value_dtype():
   return dtypes.canonicalize_dtype(np.int64)
 
 def dim_constant(ct: int):
-  return np.array(ct, dtype=dim_value_dtype())
+  dtype = dim_value_dtype()
+  assert dtype in (np.int32, np.int64)
+  if dtype == np.int32:
+    return np.int32(ct)
+  elif dtype == np.int64:
+    return np.int64(ct)
 
 def dim_value_aval() -> AbstractValue:
   return ShapedArray((), dim_value_dtype(), weak_type=True)

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -627,7 +627,6 @@ def lower_jaxpr_to_module(
     module_string = module_to_string(ctx.module)
     raise ValueError(
         f"Cannot lower jaxpr with verifier errors: {module_string}")
-
   return LoweringResult(ctx.module, ctx.keepalives, ctx.host_callbacks)
 
 def module_to_string(module: ir.Module) -> str:

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -563,7 +563,9 @@ class GraphSerializationImpl(SerializationImpl):
         map(lambda a: core.raise_to_shaped(core.get_aval(a)), args_specs_flat))
     dim_vars = shape_poly.all_dim_vars(self.args_avals_flat)
     dim_values, _ = _interpret_fun_jax(
-        partial(shape_poly.compute_dim_values, self.args_avals_flat, dim_vars),
+        partial(shape_poly.unify_avals_with_args, self.args_avals_flat, dim_vars,
+                use_static_dimension_size=False,
+                args_kwargs_tree=self.in_tree),
         self.args_flat_tf, self.args_avals_flat, self.name_stack)
     _thread_local_state.shape_env = zip(dim_vars, dim_values)
 


### PR DESCRIPTION
This was called shape_poly.compute_dim_values. We rename it to shape_poly.unify_avals_with_args and we add better error reporting to it. Now it will identify the arg/kwarg where there is a shape discrepancy.

This is intended to be a pure refactoring, in preparation for adding support for shape polymorphism to jax_export.call_exported.