### PR TITLE
KeyArray: better errors for operators

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -45,7 +45,8 @@ from jax._src.lax import lax as lax_internal
 from jax._src.lax import utils as lax_utils
 from jax._src.lib import gpu_prng
 from jax._src.lib.mlir.dialects import hlo
-from jax._src.numpy.array_methods import _set_array_base_attributes, _IndexUpdateHelper
+from jax._src.numpy.array_methods import (
+    _array_operators, _set_array_base_attributes, _IndexUpdateHelper)
 from jax._src.partition_spec import PartitionSpec
 from jax._src.sharding_impls import (
     NamedSharding, PmapSharding, GSPMDSharding)
@@ -297,7 +298,8 @@ class PRNGKeyArrayImpl(PRNGKeyArray):
   def transpose(self, *_, **__) -> PRNGKeyArray: assert False
 
 _set_array_base_attributes(PRNGKeyArrayImpl, include=[
-    '__getitem__', 'at', 'flatten', 'ravel', 'reshape',
+    *(f"__{op}__" for op in _array_operators),
+    'at', 'flatten', 'ravel', 'reshape',
     'squeeze', 'swapaxes', 'take', 'transpose', 'T'])
 basearray.Array.register(PRNGKeyArrayImpl)
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1889,7 +1889,7 @@ class LaxRandomWithCustomPRNGTest(LaxRandomTest):
   def test_cannot_add(self):
     key = self.seed_prng(73)
     self.assertRaisesRegex(
-        TypeError, r'unsupported operand type\(s\) for \+*',
+        ValueError, r'dtype=key<.*> is not a valid dtype for JAX type promotion.',
         lambda: key + 47)
 
   @skipIf(np.__version__ == "1.21.0",
@@ -1950,7 +1950,7 @@ class LaxRandomWithRBGPRNGTest(LaxRandomTest):
   def test_cannot_add(self):
     key = self.seed_prng(73)
     self.assertRaisesRegex(
-        TypeError, r'unsupported operand type\(s\) for \+*',
+        ValueError, r'dtype=key<.*> is not a valid dtype for JAX type promotion.',
         lambda: key + 47)
 
   @skipIf(np.__version__ == "1.21.0",
@@ -2153,10 +2153,16 @@ class JnpWithKeyArrayTest(jtu.JaxTestCase):
     key = random.PRNGKey(123)
     with self.assertRaisesRegex(ValueError, "dtype=key<fry> is not a valid dtype"):
       jnp.add(key, 1)
+    with self.assertRaisesRegex(ValueError, "dtype=key<fry> is not a valid dtype"):
+      key + 1
     with self.assertRaisesRegex(TypeError, "add does not accept dtype key<fry>"):
       jnp.add(key, key)
+    with self.assertRaisesRegex(TypeError, "add does not accept dtype key<fry>"):
+      key + key
     with self.assertRaisesRegex(TypeError, "neg does not accept dtype key<fry>"):
       jnp.negative(key)
+    with self.assertRaisesRegex(TypeError, "neg does not accept dtype key<fry>"):
+      -key
     with self.assertRaisesRegex(ValueError, "Cannot call convert_element_type on dtype key<fry>"):
       lax.convert_element_type(key, int)
 


### PR DESCRIPTION
Previously many operators were not defined, and so the errors were different depending on whether the key was traced or not.