### PR TITLE
KeyArray: implement __eq__ and __ne__

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -905,8 +905,8 @@ class JaxTestCase(parameterized.TestCase):
 
   def assertDtypesMatch(self, x, y, *, canonicalize_dtypes=True):
     if not config.x64_enabled and canonicalize_dtypes:
-      self.assertEqual(_dtypes.canonicalize_dtype(_dtype(x)),
-                       _dtypes.canonicalize_dtype(_dtype(y)))
+      self.assertEqual(_dtypes.canonicalize_dtype(_dtype(x), allow_opaque_dtype=True),
+                       _dtypes.canonicalize_dtype(_dtype(y), allow_opaque_dtype=True))
     else:
       self.assertEqual(_dtype(x), _dtype(y))
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -2132,6 +2132,24 @@ class JnpWithKeyArrayTest(jtu.JaxTestCase):
     self.check_shape(key_func, keys)
     self.check_against_reference(key_func, arr_func, keys)
 
+  def test_equality(self):
+    key = random.PRNGKey(123)
+    key2 = random.PRNGKey(456)
+
+    self.assertTrue(key == key)
+    self.assertFalse(key == key2)
+
+    self.assertTrue(key != key2)
+    self.assertFalse(key != key)
+
+    size = 5
+    idx = slice(2, 4)
+    key_arr = random.split(key, size).at[idx].set(key)
+    expected = jnp.zeros(size, dtype=bool).at[idx].set(True)
+
+    self.assertArraysEqual(key == key_arr, expected)
+    self.assertArraysEqual(key != key_arr, ~expected)
+
   @parameterized.parameters([
     (0,),
     (slice(1),),

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1981,9 +1981,6 @@ def like(keys):
 @skipIf(not config.jax_enable_custom_prng,
         'custom PRNG tests require config.jax_enable_custom_prng')
 class JnpWithKeyArrayTest(jtu.JaxTestCase):
-  def assertKeysEqual(self, key1, key2):
-    self.assertArraysEqual(key1.unsafe_raw_array(), key2.unsafe_raw_array())
-
   def check_shape(self, func, *args):
     out_key = func(*args)
     self.assertIsInstance(out_key, random.KeyArray)
@@ -2092,15 +2089,15 @@ class JnpWithKeyArrayTest(jtu.JaxTestCase):
 
   def test_array(self):
     key = random.PRNGKey(123)
-    self.assertKeysEqual(key, jnp.array(key))
-    self.assertKeysEqual(key, jnp.asarray(key))
-    self.assertKeysEqual(key, jax.jit(jnp.array)(key))
-    self.assertKeysEqual(key, jax.jit(jnp.asarray)(key))
+    self.assertArraysEqual(key, jnp.array(key))
+    self.assertArraysEqual(key, jnp.asarray(key))
+    self.assertArraysEqual(key, jax.jit(jnp.array)(key))
+    self.assertArraysEqual(key, jax.jit(jnp.asarray)(key))
 
   def test_array_user_dtype(self):
     key = random.PRNGKey(123)
-    self.assertKeysEqual(key, jnp.array(key, dtype=key.dtype))
-    self.assertKeysEqual(key, jnp.asarray(key, dtype=key.dtype))
+    self.assertArraysEqual(key, jnp.array(key, dtype=key.dtype))
+    self.assertArraysEqual(key, jnp.asarray(key, dtype=key.dtype))
 
   @parameterized.parameters([
     (0,),


### PR DESCRIPTION
This also allows us to use the stock `assertArraysEqual` in our tests, rather than defining a special `assertKeysEqual` method.