### PR TITLE
Simplify JVP of `lax.div` by reusing already computed values

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2126,9 +2126,9 @@ def _div_transpose_rule(cotangent, x, y):
   else:
     return [_unbroadcast(x.aval, div(cotangent, y)), None]
 div_p = standard_naryop([_num, _num], 'div')
-ad.defjvp(div_p,
-          lambda g, x, y: div(g, y),
-          lambda g, x, y: mul(mul(neg(g), x), integer_pow(y, -2)))
+ad.defjvp2(div_p,
+           lambda g, ans, x, y: div(g, y),
+           lambda g, ans, x, y: mul(neg(g), div(ans, y)))
 ad.primitive_transposes[div_p] = _div_transpose_rule
 mlir.register_lowering(div_p, partial(_nary_lower_hlo, hlo.DivOp))
 


### PR DESCRIPTION
This simplifies the JVP of `lax.div` by reusing its result $r = \frac{x}{y}$, since $\frac{\partial r}{\partial y} = - \frac{x}{y^2} = - \frac{r}{y}$.

The change improves the generated HLO which might help with downstream compiler passes. Click expand to see the before and after of the HLO generated by
```python
jax.value_and_grad(lax.div, argnums=1)(jnp.ones(()), jnp.ones(()))
```

<details><summary>HLO before (click to expand)</summary>

```mlir
module @jit_div attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
  func.func public @main(%arg0: tensor<f32> {jax.arg_info = "x", mhlo.sharding = "{replicated}"}, %arg1: tensor<f32> {jax.arg_info = "y", mhlo.sharding = "{replicated}"}) -> (tensor<f32> {jax.result_info = "[0]"}, tensor<f32> {jax.result_info = "[1]"}) {
    %0 = stablehlo.divide %arg0, %arg1 : tensor<f32>
    %1 = stablehlo.multiply %arg1, %arg1 : tensor<f32>
    %2 = stablehlo.constant dense<1.000000e+00> : tensor<f32>
    %3 = stablehlo.divide %2, %1 : tensor<f32>
    %4 = stablehlo.constant dense<1.000000e+00> : tensor<f32>
    %5 = stablehlo.multiply %4, %3 : tensor<f32>
    %6 = stablehlo.multiply %5, %arg0 : tensor<f32>
    %7 = stablehlo.negate %6 : tensor<f32>
    return %0, %7 : tensor<f32>, tensor<f32>
  }
}
```

</details> 

<details><summary>HLO after (click to expand)</summary>

```mlir
module @jit_div attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
  func.func public @main(%arg0: tensor<f32> {jax.arg_info = "x", mhlo.sharding = "{replicated}"}, %arg1: tensor<f32> {jax.arg_info = "y", mhlo.sharding = "{replicated}"}) -> (tensor<f32> {jax.result_info = "[0]"}, tensor<f32> {jax.result_info = "[1]"}) {
    %0 = stablehlo.divide %arg0, %arg1 : tensor<f32>
    %1 = stablehlo.divide %0, %arg1 : tensor<f32>
    %2 = stablehlo.constant dense<1.000000e+00> : tensor<f32>
    %3 = stablehlo.multiply %2, %1 : tensor<f32>
    %4 = stablehlo.negate %3 : tensor<f32>
    return %0, %4 : tensor<f32>, tensor<f32>
  }
}
```

</details> 