### PR TITLE
resolve opaque dtypes in MLIR callback lowering and in XLA shape translation

### DIFF
--- a/jax/_src/interpreters/xla.py
+++ b/jax/_src/interpreters/xla.py
@@ -54,11 +54,15 @@ def identity(x): return x
 
 _scalar_types = dtypes.python_scalar_dtypes.keys()
 
-def _make_array_shape(a: ShapedArray) -> Sequence[xc.Shape]:
-  if a.dtype == dtypes.float0:
-    return (xc.Shape.array_shape(np.dtype('bool'), a.shape),)
+def _make_array_shape(aval: ShapedArray) -> Sequence[xc.Shape]:
+  def dt(aval):
+    return np.dtype('bool') if aval.dtype == dtypes.float0 else aval.dtype
+
+  if core.is_opaque_dtype(aval.dtype):
+    avals = aval.dtype._rules.physical_avals(aval)
   else:
-    return (xc.Shape.array_shape(a.dtype, a.shape),)
+    avals = [aval]
+  return tuple(xc.Shape.array_shape(dt(a), a.shape) for a in avals)
 
 def get_canonical_source_file(frame: source_info_util.Frame):
   source_file = frame.file_name

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -1908,6 +1908,15 @@ class HostCallbackTapTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError, r"Support for \*\*kwargs in ``id_tap``"):
       hcb.id_tap(func, 1, y=2)
 
+  def test_tap_id_tap_random_key(self):
+    # See https://github.com/google/jax/issues/13949
+    with jax.enable_custom_prng():
+      @jax.jit
+      def f(x):
+        def tap(tap_x, _): pass
+        return hcb.id_tap(tap, x, result=x)
+      f(jax.random.PRNGKey(123))
+
   def test_tap_odeint(self):
     # TODO: find a smaller repro for bug #4015
     # Seems to be xla_call(scan(xla_call)), all under grad.


### PR DESCRIPTION
fixes #13949