### PR TITLE
CI: run lint_and_typecheck under newest Python version

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -31,10 +31,10 @@ jobs:
           access_token: ${{ github.token }}
         if: ${{github.ref != 'refs/heads/main'}}
       - uses: actions/checkout@v3
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
       - uses: pre-commit/action@v3.0.0
 
   build:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
   - id: mypy
     files: (jax/|tests/typing_test\.py)
     exclude: jax/_src/basearray.py  # Use pyi instead
-    additional_dependencies: [types-requests==2.28.11, jaxlib==0.4.6, ml_dtypes==0.1.0, numpy==1.21.6, scipy==1.7.3]
+    additional_dependencies: [types-requests==2.29.0, jaxlib==0.4.7, ml_dtypes==0.1.0, numpy==1.24.3, scipy==1.10.1]
     args: [--config=pyproject.toml]
 
 - repo: https://github.com/mwouts/jupytext

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1169,10 +1169,10 @@ def _split(op: str, ary: ArrayLike,
                                                f"in jax.numpy.{op} argument 1")
     part_size, r = divmod(size, num_sections)
     if r == 0:
-      split_indices = [np.int64(i) * part_size
-                       for i in range(num_sections + 1)]
+      split_indices = np.array([np.int64(i) * part_size
+                                for i in range(num_sections + 1)])
     elif op == "array_split":
-      split_indices = (
+      split_indices = np.array(
         [np.int64(i) * (part_size + 1) for i in range(r + 1)] +
         [np.int64(i) * part_size + ((r + 1) * (part_size + 1) - 1)
          for i in range(num_sections - r)])

--- a/jax/experimental/multihost_utils.py
+++ b/jax/experimental/multihost_utils.py
@@ -57,8 +57,8 @@ def broadcast_one_to_all(in_tree: Any, is_source: Optional[bool] = None) -> Any:
   if is_source is None:
     is_source = jax.process_index() == 0
 
-  devices = np.array(jax.devices()).reshape(jax.process_count(),
-                                            jax.local_device_count())
+  devices: np.ndarray = np.array(
+      jax.devices()).reshape(jax.process_count(), jax.local_device_count())
   global_mesh = jax.sharding.Mesh(devices, ('processes', 'local_devices'))
   pspec = P('processes')
 


### PR DESCRIPTION
I found that previously it was not possible to run `mypy` pre-commit on Python 3.11 because of package version incompatibilities. By updating to the latest package versions and running under the latest python, this should be runnable in more environments.