### PR TITLE
[shape_poly] Add a version of jax.eval_shape that works with shape polymorphism

### DIFF
--- a/jax/experimental/jax2tf/__init__.py
+++ b/jax/experimental/jax2tf/__init__.py
@@ -14,6 +14,7 @@
 
 from jax.experimental.jax2tf.jax2tf import (
   convert as convert,
+  eval_polymorphic_shape as eval_polymorphic_shape,
   dtype_of_val as dtype_of_val,
   split_to_logical_devices as split_to_logical_devices,
   PolyShape as PolyShape


### PR DESCRIPTION

The use would be to find the output shapes for a function in presence of shape polymorphism, and to compute the `polymorphic_shapes` value that can be used in a subsequent call to `jax2tf.convert`.