### PR TITLE
Remove use of deprecated make_sharded_device_array

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ filterwarnings = [
     "ignore:DeviceArray, ShardedDeviceArray, and GlobalDeviceArray have been deprecated.*:DeprecationWarning",
     "ignore:backend and device argument on jit is deprecated.*:DeprecationWarning",
     "ignore:GlobalDeviceArray has been deprecated.*:DeprecationWarning",
-    "ignore:jax.interpreters.pxla.make_sharded_device_array is deprecated.*:DeprecationWarning",
     # TODO(skyewm, yashkatariya): Remove after jaxlib 0.4.7 is released.
     "ignore:jax.interpreters.pxla.ShardedDeviceArray is deprecated.*:DeprecationWarning"
 ]

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -871,8 +871,9 @@ class PythonPmapTest(jtu.JaxTestCase):
 
     # test that we can handle device movement on dispatch
     bufs = y._arrays[::-1]
-    sharding_spec = y.sharding.sharding_spec
-    y = pxla.make_sharded_device_array(y.aval, sharding_spec, bufs)
+    sharding = jax.sharding.PmapSharding(
+        [b.device() for b in bufs], y.sharding.sharding_spec)
+    y = jax.make_array_from_single_device_arrays(y.shape, sharding, bufs)
     z = f(y)
     self.assertAllClose(z, 2 * 2 * x[::-1], check_dtypes=False)
 


### PR DESCRIPTION
Per the API deprecation policy, we will remove this deprecated function in a month's time.