### PR TITLE
Revert setup.py changes.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,13 @@ import sys
 
 from setuptools import setup, find_packages
 
-_current_jaxlib_version = '0.4.9'
+_current_jaxlib_version = '0.4.7'
 # The following should be updated with each new jaxlib release.
 _latest_jaxlib_version_on_pypi = '0.4.7'
 _available_cuda11_cudnn_versions = ['82', '86']
 _default_cuda11_cudnn_version = '86'
 _default_cuda12_cudnn_version = '88'
-_libtpu_version = '0.1.dev20230504'
+_libtpu_version = '0.1.dev20230327'
 
 _dct = {}
 with open('jax/version.py', encoding='utf-8') as f:


### PR DESCRIPTION
This reverts the setup.py changes from
f28b20175f307d5a56502446a9706480126a5bd4. We actually need to fix some more issues before releasing 0.4.9, so fix the install at HEAD in the meantime.