### PR TITLE
delegate `select` lowering to opaque dtype rule

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3372,6 +3372,12 @@ def _select_jvp(primals, tangents):
 
 def _select_hlo_lowering(ctx, which, *cases):
   which_aval = ctx.avals_in[0]
+  aval_out, = ctx.avals_out
+
+  if core.is_opaque_dtype(aval_out.dtype):
+    return [aval_out.dtype._rules.select_mlir(
+        ctx, ctx.avals_in, aval_out, which, *cases)]
+
   if which_aval.dtype == np.dtype(np.bool_):
     assert len(cases) <= 2
     if len(cases) == 1: return cases

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -579,6 +579,28 @@ class KeyTyRules:
                                  lax_internal._get_bitwise_or_identity))
 
   @staticmethod
+  def select_mlir(ctx, avals_in, aval_out, which, *cases):
+    assert all(aval_case == aval_out for aval_case in avals_in[1:])
+    assert avals_in[0].ndim == aval_out.ndim
+    select_lower = lax_internal._select_hlo_lowering
+    key_shape = aval_out.dtype.impl.key_shape
+
+    aval_which = avals_in[0]
+    aval_which_bcast = core.ShapedArray(
+        (*aval_which.shape, *key_shape), aval_which.dtype)
+    aval_out_raw = core.ShapedArray(
+        (*aval_out.shape, *key_shape), np.dtype('uint32'))
+    aval_cases_raw = [aval_out_raw] * (len(avals_in) - 1)
+
+    bcast_dims = list(range(aval_which.ndim))
+    which_bcast = mlir.broadcast_in_dim(
+        ctx, which, aval_which_bcast, broadcast_dimensions=bcast_dims)
+
+    return mlir.delegate_lowering(ctx, select_lower, which_bcast, *cases,
+                                  avals_in=[aval_which_bcast, *aval_cases_raw],
+                                  avals_out=[aval_out_raw])[0]
+
+  @staticmethod
   def device_put_sharded(vals, aval, sharding, devices):
     physical_aval = keys_aval_to_base_arr_aval(aval)
     physical_buffers = tree_util.tree_map(random_unwrap, vals)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2925,6 +2925,24 @@ class FooTyRules:
                                   avals_in=[aval_x_raw, aval_indices],
                                   avals_out=[aval_y_raw])[0]
 
+  @staticmethod
+  def select_mlir(ctx, avals_in, aval_out, which, *cases):
+    assert all(aval_case == aval_out for aval_case in avals_in[1:])
+    assert avals_in[0].ndim == aval_out.ndim
+    select_lower = lax_internal._select_hlo_lowering
+    aval_which = avals_in[0]
+    aval_which_bcast = core.ShapedArray(
+        (*aval_which.shape, 2), aval_which.dtype)
+    aval_out_raw = core.ShapedArray(
+        (*aval_out.shape, 2), np.dtype('uint32'))
+    aval_cases_raw = [aval_out_raw] * (len(avals_in) - 1)
+    bcast_dims = list(range(aval_which.ndim))
+    which_bcast = mlir.broadcast_in_dim(
+        ctx, which, aval_which_bcast, broadcast_dimensions=bcast_dims)
+    return mlir.delegate_lowering(ctx, select_lower, which_bcast, *cases,
+                                  avals_in=[aval_which_bcast, *aval_cases_raw],
+                                  avals_out=[aval_out_raw])[0]
+
 
 class FooTy:
   name = 'foo'
@@ -3196,6 +3214,13 @@ class CustomElementTypesTest(jtu.JaxTestCase):
     ys = jax.jit(lambda x: x[:, 2:4, 3:4])(ks)
     self.assertIsInstance(ys, FooArray)
     self.assertEqual(ys.shape, (3, 2, 1))
+
+  def test_select(self):
+    ks = jax.jit(lambda: make((3,)))()
+    cs = jnp.array([True, False, False])
+    ys = jax.jit(lax.select)(cs, ks, ks)
+    self.assertIsInstance(ys, FooArray)
+    self.assertEqual(ys.shape, (3,))
 
   def test_xla_reverse_bug(self):
     # Regression test for b/248295786

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1835,6 +1835,25 @@ class KeyArrayTest(jtu.JaxTestCase):
     self.assertIsInstance(ys, random.KeyArray)
     self.assertEqual(ys.shape, (3, 2, 1))
 
+  @skipIf(not config.jax_enable_custom_prng,
+          'requires config.jax_enable_custom_prng')
+  def test_select(self):
+    ks = self.make_keys(3, 2)
+    cs = jnp.array([True, False, False, True, False, True]).reshape(3, 2)
+    ys = jax.jit(lax.select)(cs, ks, ks)
+    self.assertIsInstance(ys, random.KeyArray)
+    self.assertEqual(ys.shape, (3, 2))
+
+  @skipIf(not config.jax_enable_custom_prng,
+          'requires config.jax_enable_custom_prng')
+  def test_select2(self):
+    # See https://github.com/google/jax/issues/15869
+    def f(x):
+      keys = lax.broadcast(jax.random.PRNGKey(0), x.shape)
+      return lax.select(x, keys, keys)
+    x = jnp.array([True, False, False])
+    f(x)  # doesn't crash
+
   def test_device_put(self):
     device = jax.devices()[0]
     keys = self.make_keys(4)


### PR DESCRIPTION
... and implement it for PRNG key arrays.

Fixes #15869.

cc #9263 