### PR TITLE
[shape_poly] Remove old test limitations

### DIFF
--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -705,8 +705,11 @@ def _conv_general_dilated_lower(
   window_reversal = mlir.dense_bool_elements([False] * num_spatial_dims)
   if (not core.is_constant_shape(window_strides) or
       not core.is_constant_shape(lhs_dilation) or
-      not core.is_constant_shape(rhs_dilation)):
-    raise NotImplementedError("Convolutions with non-static strides or dilation")
+      not core.is_constant_shape(rhs_dilation) or
+      not core.is_constant_dim(feature_group_count) or
+      not core.is_constant_dim(batch_group_count)):
+    # TODO(https://github.com/openxla/stablehlo/issues/1268)
+    raise NotImplementedError("Convolutions with non-static strides, dilation, feature_group_count, or batch_group_count")
   if all(core.is_constant_shape(p) for p in padding):
     return [
         hlo.ConvolutionOp(

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1261,6 +1261,8 @@ def _lu_cpu_gpu_lowering(getrf_impl, ctx, operand):
 
 
 def _lu_tpu_lowering_rule(ctx, operand):
+  if any(not is_constant_shape(a.shape) for a in (ctx.avals_in + ctx.avals_out)):
+    raise NotImplementedError(f"Shape polymorphism for custom call is not implemented (lu); b/261671778; {ctx.avals_in + ctx.avals_out}")
   result_types = [
     mlir.aval_to_ir_type(ctx.avals_out[0]),
     mlir.aval_to_ir_type(ctx.avals_out[1]),


### PR DESCRIPTION
When we create "vmap"-based test harnesses from primitive harnesses we used to exclude certain primitives. We reduced the list to one primitive, "tridiagonal_solve" for which vmap is not defined.

We have also added a more explicit error about certain unsupported dynamic shape features for convolution (waiting for StableHLO feature).