### PR TITLE
[ANN] Update approx_{max,min}_k jvp to make it more TPU-friendly.

### DIFF
--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -21,7 +21,6 @@ import weakref
 
 import numpy as np
 
-import jax.numpy as jnp
 from jax import lax
 
 from jax._src import core
@@ -39,6 +38,7 @@ from jax._src.lib import xla_client as xc
 from jax._src.lib import xla_extension_version
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import hlo
+from jax._src.numpy import lax_numpy
 from jax._src.sharding import Sharding
 from jax._src.sharding_impls import (GSPMDSharding, NamedSharding,
                                      parse_flatten_op_sharding)
@@ -108,7 +108,7 @@ def debug_callback_batching_rule(args, dims, **params):
   for i in range(axis_size):
     args_idx = map(functools.partial(get_arg_at_dim, i), dims, args)
     outs.append(debug_callback_p.bind(*args_idx, **params))
-  outs = [jnp.stack(xs) for xs in zip(*outs)]
+  outs = [lax_numpy.stack(xs) for xs in zip(*outs)]
   return outs, (0,) * len(outs)
 batching.primitive_batchers[debug_callback_p] = debug_callback_batching_rule
 

--- a/tests/ann_test.py
+++ b/tests/ann_test.py
@@ -107,6 +107,8 @@ class AnnTest(jtu.JaxTestCase):
   def test_autodiff(self, shape, dtype, reduction_dimension, k, is_max_k):
     if reduction_dimension >= len(shape):
       self.skipTest(f'{reduction_dimension=} >= {len(shape)=}')
+    if k > shape[reduction_dimension]:
+      self.skipTest(f'{k=} > {shape[reduction_dimension]=}')
     vals = np.arange(math.prod(shape), dtype=dtype)
     vals = self.rng().permutation(vals).reshape(shape)
     if is_max_k:

--- a/tests/ann_test.py
+++ b/tests/ann_test.py
@@ -100,16 +100,21 @@ class AnnTest(jtu.JaxTestCase):
   @jtu.sample_product(
     dtype=[np.float32],
     shape=[(4,), (5, 5), (2, 1, 4)],
+    reduction_dimension=[0, 1, 2],
     k=[1, 3],
     is_max_k=[True, False],
   )
-  def test_autodiff(self, shape, dtype, k, is_max_k):
+  def test_autodiff(self, shape, dtype, reduction_dimension, k, is_max_k):
+    if reduction_dimension >= len(shape):
+      self.skipTest(f'{reduction_dimension=} >= {len(shape)=}')
     vals = np.arange(math.prod(shape), dtype=dtype)
     vals = self.rng().permutation(vals).reshape(shape)
     if is_max_k:
-      fn = lambda vs: lax.approx_max_k(vs, k=k)[0]
+      fn = lambda vs: lax.approx_max_k(
+        vs, reduction_dimension=reduction_dimension, k=k)[0]
     else:
-      fn = lambda vs: lax.approx_min_k(vs, k=k)[0]
+      fn = lambda vs: lax.approx_min_k(
+        vs, reduction_dimension=reduction_dimension, k=k)[0]
     jtu.check_grads(fn, (vals,), 2, ["fwd", "rev"], eps=1e-2)
 
 


### PR DESCRIPTION
Scatters/gathers are very expensive, so instead we take a dot product with the appropriate one-hot representation of the indices on the tangent.

Also:
* Updated tests to consider varying reduction_dimension
* Removed possibility of cyclic dependency in debugging.py by removing a large jnp import, replacing it with a numpy_lax import.

Speeds up jvp of T5X XL-sized dot product, followed by approx_max_k, by 50x on TPU.