### PR TITLE
Fix type annotations on jax.vmap

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1071,7 +1071,7 @@ def _split(x, indices, axis):
 
 
 def vmap(fun: F,
-         in_axes: Union[int, Sequence[Any]] = 0,
+         in_axes: Union[int, None, Sequence[Any]] = 0,
          out_axes: Any = 0,
          axis_name: Optional[AxisName] = None,
          axis_size: Optional[int] = None,


### PR DESCRIPTION
`in_axes=None` is valid, as is already explained in the docstring (it means `None` on each `vmap` argument).

I'm not sure how this wrong type annotation stuck around for so long!