### PR TITLE
Custom PRNG: support PRNGKeyArray.copy()

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -294,6 +294,9 @@ class PRNGKeyArrayImpl(PRNGKeyArray):
       pp.text('PRNGKeyArray:') +
       pp.nest(2, pp.brk() + pp_keys + pp.brk() + pp_impl)))
 
+  def copy(self):
+    return self.__class__(self.impl, self._base_array.copy())
+
   # Overwritten immediately below
   @property
   def at(self)                  -> _IndexUpdateHelper: assert False

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import copy
 import enum
 from functools import partial
 import math
@@ -2073,6 +2073,13 @@ class LaxRandomWithRBGPRNGTest(LaxRandomTest):
   def test_randint_out_of_range(self):
     # TODO(mattjj): enable this test if/when RngBitGenerator supports it
     raise SkipTest('8-bit types not supported with RBG PRNG')
+
+  def test_copy(self):
+    key = random.PRNGKey(8459302)
+    self.assertArraysEqual(key, key.copy())
+    self.assertArraysEqual(key, copy.copy(key))
+    self.assertArraysEqual(key, copy.deepcopy(key))
+    self.assertArraysEqual(key, jax.jit(lambda k: k.copy())(key))
 
 
 # TODO(frostig): remove `with_config` we always enable_custom_prng


### PR DESCRIPTION
Note that this was already supported under `jit` via `Tracer.copy()`; this just adds `copy` support outside JIT. Evenutally, we can think about whether this copied key should be marked as consumed for the sake of reuse checking (I'm not sure what would be semantically most appropriate there!)