### PR TITLE
simplify opaque dtype lowerings

### DIFF
--- a/jax/_src/interpreters/xla.py
+++ b/jax/_src/interpreters/xla.py
@@ -55,14 +55,9 @@ def identity(x): return x
 _scalar_types = dtypes.python_scalar_dtypes.keys()
 
 def _make_array_shape(aval: ShapedArray) -> Sequence[xc.Shape]:
-  def dt(aval):
-    return np.dtype('bool') if aval.dtype == dtypes.float0 else aval.dtype
-
-  if dtypes.is_opaque_dtype(aval.dtype):
-    avals = aval.dtype._rules.physical_avals(aval)
-  else:
-    avals = [aval]
-  return tuple(xc.Shape.array_shape(dt(a), a.shape) for a in avals)
+  aval = core.physical_aval(aval)
+  dtype = np.dtype('bool') if aval.dtype == dtypes.float0 else aval.dtype
+  return (xc.Shape.array_shape(dtype, aval.shape),)
 
 def get_canonical_source_file(frame: source_info_util.Frame):
   source_file = frame.file_name

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1647,10 +1647,10 @@ def _pred_bcast_select_hlo(ctx,
     assert x.type == y.type, (x.type, y.type)
     assert (pred_aval.shape == x_y_aval.shape[:len(pred_aval.shape)]), (
             pred_aval.shape, x_y_aval)
-    if dtypes.is_opaque_dtype(x_y_aval.dtype):
-      x_y_aval, = x_y_aval.dtype._rules.physical_avals(x_y_aval)
-    bcast_pred = mlir.broadcast_in_dim(ctx, pred, core.DShapedArray(x_y_aval.shape, np.dtype(np.bool_)),
-                                       broadcast_dimensions=list(range(len(pred_aval.shape))))
+    x_y_aval = core.physical_aval(x_y_aval)
+    bcast_pred = mlir.broadcast_in_dim(
+        ctx, pred, core.DShapedArray(x_y_aval.shape, np.dtype(np.bool_)),
+        broadcast_dimensions=list(range(len(pred_aval.shape))))
     return hlo.SelectOp(bcast_pred, x, y).results
 
 ### fori_loop

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3273,7 +3273,10 @@ def _transpose_batch_rule(batched_args, batch_dims, *, permutation):
 def _transpose_lower(ctx, x, *, permutation):
   aval_out, = ctx.avals_out
   if dtypes.is_opaque_dtype(aval_out.dtype):
-    return [aval_out.dtype._rules.transpose_mlir(ctx, aval_out, x, permutation=permutation)]
+    elt_shape = aval_out.dtype._rules.physical_element_aval(
+        aval_out.dtype).shape
+    trailing_dims = [aval_out.ndim + i for i in range(len(elt_shape))]
+    permutation = [*permutation, *trailing_dims]
   return hlo.TransposeOp(x, mlir.dense_int_elements(permutation)).results
 
 transpose_p = standard_primitive(_transpose_shape_rule, _input_dtype,

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4720,9 +4720,9 @@ def empty(dtype):
 empty_p = core.Primitive('empty')
 empty_p.def_abstract_eval(lambda *, dtype: core.ShapedArray((), dtype))
 def _empty_lower(ctx, *, dtype):
-  if dtypes.is_opaque_dtype(dtype):
-    return dtype._rules.empty_mlir(ctx, ctx.avals_out[0])
-  return mlir.ir_constants(np.zeros((), np.dtype(dtype)))
+  dtype = dtype if dtypes.is_opaque_dtype(dtype) else np.dtype(dtype)
+  phys_aval = core.physical_aval(core.ShapedArray((), dtype))
+  return mlir.ir_constants(np.zeros(phys_aval.shape, phys_aval.dtype))
 mlir.register_lowering(empty_p, _empty_lower)
 
 

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4728,9 +4728,9 @@ mlir.register_lowering(empty_p, _empty_lower)
 
 class BIntRules:
   @staticmethod
-  def physical_avals(aval) -> Sequence[core.AbstractValue]:
-    dtype = dtypes._scalar_type_to_dtype(int)
-    return [core.ShapedArray(aval.shape, dtype)]
+  def physical_element_aval(dtype) -> core.ShapedArray:
+    int_dtype = dtypes._scalar_type_to_dtype(int)
+    return core.ShapedArray((), int_dtype)
 
   @staticmethod
   def result_handler(sticky_device, aval):
@@ -4742,7 +4742,7 @@ class BIntRules:
   @staticmethod
   def global_sharded_result_handler(aval, out_sharding, committed,
                                     is_out_sharding_from_xla):
-    phys_aval, = BIntRules.physical_avals(aval)
+    phys_aval = core.physical_aval(aval)
     phys_handler_maker = pxla.global_result_handlers[core.ShapedArray]
 
     if not dispatch.is_single_device_sharding(out_sharding):

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2179,21 +2179,43 @@ ad.defjvp_zero(shift_right_logical_p)
 mlir.register_lowering(shift_right_logical_p,
                        partial(_nary_lower_hlo, hlo.ShiftRightLogicalOp))
 
+def _opaque_comparison_hlo(direction, reduction_op, identity, ctx,
+                           avals_in, aval_out, x, y):
+  aval_x, aval_y = avals_in
+  base_aval_x = core.physical_aval(aval_x)
+  base_aval_y = core.physical_aval(aval_y)
+  base_aval_out = core.ShapedArray(base_aval_x.shape, aval_out.dtype)
+  reduce_axes = tuple(range(aval_out.ndim, base_aval_out.ndim))
+  res, = mlir.delegate_lowering(
+      ctx, partial(_compare_lower_hlo, direction),
+      x, y, avals_in=[base_aval_x, base_aval_y], avals_out=[base_aval_out])
+  return mlir.delegate_lowering(
+      ctx, partial(_unary_reduce_lower, reduction_op, identity,
+                   axes=reduce_axes),
+      res, avals_in=[base_aval_out], avals_out=[aval_out])
+
+_opaque_eq_hlo = partial(
+    _opaque_comparison_hlo, 'EQ', hlo.AndOp, _get_bitwise_and_identity)
+_opaque_ne_hlo = partial(
+    _opaque_comparison_hlo, 'NE', hlo.OrOp, _get_bitwise_or_identity)
+
+def _compare_lower_hlo_opaque(direction: str, ctx, avals_in, aval_out, x, y):
+  broadcast_avals_in = tuple(
+      core.ShapedArray(aval_out.shape, aval.dtype) for aval in avals_in)
+  if direction == 'EQ':
+    return _opaque_eq_hlo(ctx, broadcast_avals_in, aval_out, x, y)
+  elif direction == 'NE':
+    return _opaque_ne_hlo(ctx, broadcast_avals_in, aval_out, x, y)
+  else:
+    raise NotImplementedError(
+        f"HLO comparison {direction} for opaque dtype {avals_in[0].dtype}")
+
 def _compare_lower_hlo(direction: str, ctx, x, y):
   avals_in, (aval_out,) = ctx.avals_in, ctx.avals_out
   x_dtype = avals_in[0].dtype
   x, y = mlir.multi_broadcast_in_dim(ctx, (x, y), avals_in, aval_out.shape)
   if dtypes.is_opaque_dtype(x_dtype):
-    broadcast_avals_in = tuple(
-        core.ShapedArray(aval_out.shape, aval.dtype) for aval in avals_in)
-    if direction == 'EQ':
-      return x_dtype._rules.eq_mlir(ctx, broadcast_avals_in, aval_out, x, y)
-    elif direction == 'NE':
-      return x_dtype._rules.ne_mlir(ctx, broadcast_avals_in, aval_out, x, y)
-    else:
-      raise NotImplementedError(
-          f"HLO comparison {direction} for opaque dtype {x_dtype}")
-
+    return _compare_lower_hlo_opaque(direction, ctx, avals_in, aval_out, x, y)
   if dtypes.issubdtype(x_dtype, np.inexact):
     compare_type = "FLOAT"
   elif dtypes.issubdtype(x_dtype, np.signedinteger):

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -522,18 +522,6 @@ class KeyTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def slice_mlir(ctx, aval_out, x, start_indices, limit_indices, strides) -> ir.Value:
-    key_shape = aval_out.dtype.impl.key_shape
-    trailing_zeros = [0] * len(key_shape)
-    trailing_ones  = [1] * len(key_shape)
-    start_indices = (*start_indices, *trailing_zeros)
-    limit_indices = (*limit_indices, *key_shape)
-    strides = (*strides, *trailing_ones)
-    physical_aval_out = core.physical_aval(aval_out)
-    return mlir.slice_op(ctx, x, physical_aval_out,
-                         start_indices=start_indices, limit_indices=limit_indices, strides=strides)
-
-  @staticmethod
   def dynamic_slice_mlir(ctx, aval_out, x, start_indices) -> ir.Value:
     index_avals = ctx.avals_in[1:]
     dtype = dtypes.canonicalize_dtype(index_avals[0].dtype if index_avals else 'int64')

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -522,11 +522,6 @@ class KeyTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def empty_mlir(ctx, aval_out) -> Sequence[ir.Value]:
-    return mlir.ir_constants(np.zeros(aval_out.dtype.impl.key_shape,
-                                      dtype=np.dtype('uint32')))
-
-  @staticmethod
   def slice_mlir(ctx, aval_out, x, start_indices, limit_indices, strides) -> ir.Value:
     key_shape = aval_out.dtype.impl.key_shape
     trailing_zeros = [0] * len(key_shape)

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -522,17 +522,6 @@ class KeyTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def dynamic_slice_mlir(ctx, aval_out, x, start_indices) -> ir.Value:
-    index_avals = ctx.avals_in[1:]
-    dtype = dtypes.canonicalize_dtype(index_avals[0].dtype if index_avals else 'int64')
-    key_shape = aval_out.dtype.impl.key_shape
-    trailing_zeros = [mlir.ir_constant(np.array(0, dtype))] * len(key_shape)
-    start_indices = (*start_indices, *trailing_zeros)
-    physical_aval_out = core.physical_aval(aval_out)
-    return mlir.dynamic_slice(ctx, physical_aval_out, x,
-                              start_indices=start_indices)
-
-  @staticmethod
   def dynamic_update_slice_mlir(ctx, aval_out, x, update, *start_indices) -> ir.Value:
     index_avals = ctx.avals_in[2:]
     dtype = dtypes.canonicalize_dtype(index_avals[0].dtype if index_avals else 'int64')

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -564,28 +564,6 @@ class KeyTyRules:
                                  lax_internal._get_bitwise_or_identity))
 
   @staticmethod
-  def select_mlir(ctx, avals_in, aval_out, which, *cases):
-    assert all(aval_case == aval_out for aval_case in avals_in[1:])
-    assert avals_in[0].ndim == aval_out.ndim
-    select_lower = lax_internal._select_hlo_lowering
-    key_shape = aval_out.dtype.impl.key_shape
-
-    aval_which = avals_in[0]
-    aval_which_bcast = core.ShapedArray(
-        (*aval_which.shape, *key_shape), aval_which.dtype)
-    aval_out_raw = core.ShapedArray(
-        (*aval_out.shape, *key_shape), np.dtype('uint32'))
-    aval_cases_raw = [aval_out_raw] * (len(avals_in) - 1)
-
-    bcast_dims = list(range(aval_which.ndim))
-    which_bcast = mlir.broadcast_in_dim(
-        ctx, which, aval_which_bcast, broadcast_dimensions=bcast_dims)
-
-    return mlir.delegate_lowering(ctx, select_lower, which_bcast, *cases,
-                                  avals_in=[aval_which_bcast, *aval_cases_raw],
-                                  avals_out=[aval_out_raw])[0]
-
-  @staticmethod
   def device_put_sharded(vals, aval, sharding, devices):
     physical_aval = keys_aval_to_base_arr_aval(aval)
     physical_buffers = tree_util.tree_map(random_unwrap, vals)

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -521,28 +521,6 @@ class KeyTyRules:
 
   # element-type-polymorphic primitive lowering rules
 
-  @staticmethod
-  def scatter_mlir(ctx, avals_in, aval_out, x, indices, updates, *,
-                   update_jaxpr, update_consts, dimension_numbers,
-                   unique_indices, indices_are_sorted, mode):
-    aval_x, aval_indices, aval_updates = avals_in
-    aval_y = aval_out
-    key_shape = aval_x.dtype.impl.key_shape
-    trailing_window_dims = [aval_updates.ndim + i for i in range(len(key_shape))]
-    dimension_numbers = dimension_numbers._replace(
-        update_window_dims=(*dimension_numbers.update_window_dims, *trailing_window_dims))
-    scatter_lower = partial(
-        lax_internal.slicing._scatter_lower, update_jaxpr=update_jaxpr,
-        update_consts=update_consts, dimension_numbers=dimension_numbers,
-        unique_indices=unique_indices, indices_are_sorted=indices_are_sorted,
-        mode=mode)
-    res, = mlir.delegate_lowering(
-        ctx, scatter_lower, x, indices, updates,
-        avals_in=[keys_aval_to_base_arr_aval(aval_x), aval_indices,
-                  keys_aval_to_base_arr_aval(aval_updates)],
-        avals_out=[keys_aval_to_base_arr_aval(aval_y)])
-    return res
-
   def _comparison_mlir(direction, reduction_op, identity,
                        ctx, avals_in, aval_out, x, y, **kwargs):
     aval_x, aval_y = avals_in

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -522,15 +522,6 @@ class KeyTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def broadcast_in_dim_mlir(ctx, aval_out, x,
-                            broadcast_dimensions) -> ir.Value:
-    key_shape = aval_out.dtype.impl.key_shape
-    trailing_dims = [aval_out.ndim + i for i in range(len(key_shape))]
-    broadcast_dimensions = [*broadcast_dimensions, *trailing_dims]
-    physical_aval_out = core.physical_aval(aval_out)
-    return mlir.broadcast_in_dim(ctx, x, physical_aval_out, broadcast_dimensions=broadcast_dimensions)
-
-  @staticmethod
   def transpose_mlir(ctx, aval_out, x, *, permutation) -> ir.Value:
     key_shape = aval_out.dtype.impl.key_shape
     trailing_dims = [aval_out.ndim + i for i in range(len(key_shape))]

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -522,27 +522,6 @@ class KeyTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def gather_mlir(ctx, avals_in, aval_out, x, indices, *,
-                  dimension_numbers, slice_sizes, unique_indices,
-                  indices_are_sorted, mode, fill_value) -> ir.Value:
-    aval_x, aval_indices = avals_in
-    aval_y = aval_out
-    key_shape = aval_x.dtype.impl.key_shape
-    trailing_offset_dims = [aval_y.ndim + i for i in range(len(key_shape))]
-    dimension_numbers = dimension_numbers._replace(
-        offset_dims=(*dimension_numbers.offset_dims, *trailing_offset_dims))
-    slice_sizes = (*slice_sizes, *key_shape)
-    gather_lower = partial(
-        lax_internal.slicing._gather_lower, dimension_numbers=dimension_numbers,
-        slice_sizes=slice_sizes, unique_indices=unique_indices,
-        indices_are_sorted=indices_are_sorted, mode=mode, fill_value=fill_value)
-    res, = mlir.delegate_lowering(
-        ctx, gather_lower, x, indices,
-        avals_in=[keys_aval_to_base_arr_aval(aval_x), aval_indices],
-        avals_out=[keys_aval_to_base_arr_aval(aval_y)])
-    return res
-
-  @staticmethod
   def scatter_mlir(ctx, avals_in, aval_out, x, indices, updates, *,
                    update_jaxpr, update_consts, dimension_numbers,
                    unique_indices, indices_are_sorted, mode):

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -519,28 +519,6 @@ class KeyTyRules:
     phys_result = phys_handler(phys_arrays)
     return PRNGKeyArrayImpl(aval.dtype.impl, phys_result)
 
-  # element-type-polymorphic primitive lowering rules
-
-  def _comparison_mlir(direction, reduction_op, identity,
-                       ctx, avals_in, aval_out, x, y, **kwargs):
-    aval_x, aval_y = avals_in
-    base_aval_x = keys_aval_to_base_arr_aval(aval_x)
-    base_aval_y = keys_aval_to_base_arr_aval(aval_y)
-    base_aval_out = core.ShapedArray(base_aval_x.shape, aval_out.dtype)
-    reduce_axes = tuple(range(aval_out.ndim, base_aval_out.ndim))
-    res, = mlir.delegate_lowering(
-      ctx, partial(lax_internal._compare_lower_hlo, direction),
-      x, y, avals_in=[base_aval_x, base_aval_y], avals_out=[base_aval_out])
-    return mlir.delegate_lowering(
-      ctx, partial(lax_internal._unary_reduce_lower, reduction_op,
-                   identity, axes=reduce_axes),
-      res, avals_in=[base_aval_out], avals_out=[aval_out])
-
-  eq_mlir = staticmethod(partial(_comparison_mlir, 'EQ', hlo.AndOp,
-                                 lax_internal._get_bitwise_and_identity))
-  ne_mlir = staticmethod(partial(_comparison_mlir, 'NE', hlo.OrOp,
-                                 lax_internal._get_bitwise_or_identity))
-
   @staticmethod
   def device_put_sharded(vals, aval, sharding, devices):
     physical_aval = keys_aval_to_base_arr_aval(aval)

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -522,13 +522,6 @@ class KeyTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def transpose_mlir(ctx, aval_out, x, *, permutation) -> ir.Value:
-    key_shape = aval_out.dtype.impl.key_shape
-    trailing_dims = [aval_out.ndim + i for i in range(len(key_shape))]
-    perm = [*permutation, *trailing_dims]
-    return hlo.TransposeOp(x, mlir.dense_int_elements(perm)).result
-
-  @staticmethod
   def gather_mlir(ctx, avals_in, aval_out, x, indices, *,
                   dimension_numbers, slice_sizes, unique_indices,
                   indices_are_sorted, mode, fill_value) -> ir.Value:

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -522,17 +522,6 @@ class KeyTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def dynamic_update_slice_mlir(ctx, aval_out, x, update, *start_indices) -> ir.Value:
-    index_avals = ctx.avals_in[2:]
-    dtype = dtypes.canonicalize_dtype(index_avals[0].dtype if index_avals else 'int64')
-    key_shape = aval_out.dtype.impl.key_shape
-    zeros = [mlir.ir_constant(np.array(0, dtype=dtype))] * len(key_shape)
-    start_indices = (*start_indices, *zeros)
-    physical_aval_out = core.physical_aval(aval_out)
-    return mlir.dynamic_update_slice(ctx, physical_aval_out, x, update,
-                                     start_indices=start_indices)
-
-  @staticmethod
   def broadcast_in_dim_mlir(ctx, aval_out, x,
                             broadcast_dimensions) -> ir.Value:
     key_shape = aval_out.dtype.impl.key_shape

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -990,12 +990,10 @@ def _jax_physical_aval(aval: core.ShapedArray) -> core.ShapedArray:
   physical avals, but we don't support those here. Instead we assert
   there is only one and return it.
   """
-  if dtypes.is_opaque_dtype(aval.dtype):
-    physical_aval, = aval.dtype._rules.physical_avals(aval)
-    assert (len(physical_aval.shape) >= len(aval.shape) and
-            physical_aval.shape[:len(aval.shape)] == aval.shape), (physical_aval, aval)
-    return physical_aval
-  return aval
+  physical_aval = core.physical_aval(aval)
+  assert (len(physical_aval.shape) >= len(aval.shape) and
+          physical_aval.shape[:len(aval.shape)] == aval.shape), (physical_aval, aval)
+  return physical_aval
 
 def _jax_physical_dtype(dtype):
   # assuming () is a fine stand-in shape

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2870,13 +2870,6 @@ class FooTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def dynamic_slice_mlir(ctx, aval_out, x, start_indices):
-    dtype = dtypes.canonicalize_dtype(np.dtype('int64'))
-    start_indices = (*start_indices, mlir.ir_constant(np.array(0, dtype=dtype)))
-    slice_sizes_ = mlir.dense_int_elements((*aval_out.shape, 2))
-    return hlo.DynamicSliceOp(x, start_indices, slice_sizes_).result
-
-  @staticmethod
   def dynamic_update_slice_mlir(ctx, aval_out, x, update, *start_indices):
     aval_out, = ctx.avals_out
     dtype = dtypes.canonicalize_dtype(np.dtype('int64'))

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2870,16 +2870,6 @@ class FooTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def slice_mlir(ctx, aval_out, x, start_indices, limit_indices, strides):
-    start_indices = (*start_indices, 0)
-    limit_indices = (*limit_indices, 2)
-    strides = (*strides, 1)
-    return hlo.SliceOp(x,
-                       mlir.dense_int_elements(start_indices),
-                       mlir.dense_int_elements(limit_indices),
-                       mlir.dense_int_elements(strides)).result
-
-  @staticmethod
   def dynamic_slice_mlir(ctx, aval_out, x, start_indices):
     dtype = dtypes.canonicalize_dtype(np.dtype('int64'))
     start_indices = (*start_indices, mlir.ir_constant(np.array(0, dtype=dtype)))

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2870,13 +2870,6 @@ class FooTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def dynamic_update_slice_mlir(ctx, aval_out, x, update, *start_indices):
-    aval_out, = ctx.avals_out
-    dtype = dtypes.canonicalize_dtype(np.dtype('int64'))
-    start_indices = (*start_indices, mlir.ir_constant(np.array(0, dtype=dtype)))
-    return hlo.DynamicUpdateSliceOp(x, update, start_indices).result
-
-  @staticmethod
   def broadcast_in_dim_mlir(ctx, aval_out, x, broadcast_dimensions):
     broadcast_dimensions = [*broadcast_dimensions, aval_out.ndim]
     return hlo.BroadcastInDimOp(

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2870,25 +2870,6 @@ class FooTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def gather_mlir(ctx, avals_in, aval_out, x, indices, *,
-                  dimension_numbers, slice_sizes, unique_indices,
-                  indices_are_sorted, mode, fill_value):
-    aval_x, aval_indices = avals_in
-    aval_y = aval_out
-    dimension_numbers = dimension_numbers._replace(
-        offset_dims=(*dimension_numbers.offset_dims, aval_y.ndim))
-    slice_sizes = (*slice_sizes, 2)
-    gather_lower = partial(
-        lax_internal.slicing._gather_lower, dimension_numbers=dimension_numbers,
-        slice_sizes=slice_sizes, unique_indices=unique_indices,
-        indices_are_sorted=indices_are_sorted, mode=mode, fill_value=fill_value)
-    aval_x_raw = core.ShapedArray((*aval_x.shape, 2), np.dtype('uint32'))
-    aval_y_raw = core.ShapedArray((*aval_y.shape, 2), np.dtype('uint32'))
-    return mlir.delegate_lowering(ctx, gather_lower, x, indices,
-                                  avals_in=[aval_x_raw, aval_indices],
-                                  avals_out=[aval_y_raw])[0]
-
-  @staticmethod
   def select_mlir(ctx, avals_in, aval_out, which, *cases):
     assert all(aval_case == aval_out for aval_case in avals_in[1:])
     assert avals_in[0].ndim == aval_out.ndim

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -3139,6 +3139,19 @@ class CustomElementTypesTest(jtu.JaxTestCase):
     self.assertIsInstance(ys, FooArray)
     self.assertEqual(ys.shape, (3, 2, 1))
 
+  @parameterized.parameters([
+    (0,),
+    (slice(1),),
+    (np.array([0, 2]),),
+    (np.array([False, True, True]),)
+  ])
+  def test_scatter(self, idx):
+    k  = jax.jit(lambda: make(()))()
+    ks = jax.jit(lambda: make((3,)))()
+    ys = jax.jit(lambda x, y: x.at[idx].set(y))(ks, k)
+    self.assertIsInstance(ys, FooArray)
+    self.assertEqual(ys.shape, (3,))
+
   def test_select(self):
     ks = jax.jit(lambda: make((3,)))()
     cs = jnp.array([True, False, False])

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2867,26 +2867,6 @@ class FooTyRules:
       return FooArray(aval.shape, buf)
     return handler
 
-  # element-type-polymorphic primitive lowering rules
-
-  @staticmethod
-  def select_mlir(ctx, avals_in, aval_out, which, *cases):
-    assert all(aval_case == aval_out for aval_case in avals_in[1:])
-    assert avals_in[0].ndim == aval_out.ndim
-    select_lower = lax_internal._select_hlo_lowering
-    aval_which = avals_in[0]
-    aval_which_bcast = core.ShapedArray(
-        (*aval_which.shape, 2), aval_which.dtype)
-    aval_out_raw = core.ShapedArray(
-        (*aval_out.shape, 2), np.dtype('uint32'))
-    aval_cases_raw = [aval_out_raw] * (len(avals_in) - 1)
-    bcast_dims = list(range(aval_which.ndim))
-    which_bcast = mlir.broadcast_in_dim(
-        ctx, which, aval_which_bcast, broadcast_dimensions=bcast_dims)
-    return mlir.delegate_lowering(ctx, select_lower, which_bcast, *cases,
-                                  avals_in=[aval_which_bcast, *aval_cases_raw],
-                                  avals_out=[aval_out_raw])[0]
-
 
 class FooTy:
   name = 'foo'

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2838,8 +2838,8 @@ class FooTyRules:
   # handlers
 
   @staticmethod
-  def physical_avals(aval):
-    return [core.ShapedArray((*aval.shape, 2), jnp.dtype('uint32'))]
+  def physical_element_aval(dtype) -> core.ShapedArray:
+    return core.ShapedArray((2,), jnp.dtype('uint32'))
 
   @staticmethod
   def physical_op_sharding(aval, op_sharding_proto):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2870,13 +2870,6 @@ class FooTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def broadcast_in_dim_mlir(ctx, aval_out, x, broadcast_dimensions):
-    broadcast_dimensions = [*broadcast_dimensions, aval_out.ndim]
-    return hlo.BroadcastInDimOp(
-        mlir.aval_to_ir_type(aval_out), x,
-        mlir.dense_int_elements(broadcast_dimensions)).result
-
-  @staticmethod
   def transpose_mlir(ctx, aval_out, x, *, permutation):
     perm = [*permutation, len(permutation)]
     return hlo.TransposeOp(x, mlir.dense_int_elements(perm)).result

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2870,10 +2870,6 @@ class FooTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def empty_mlir(ctx, aval_out):
-    return mlir.ir_constants(np.zeros((2,), dtype=np.dtype('uint32')))
-
-  @staticmethod
   def slice_mlir(ctx, aval_out, x, start_indices, limit_indices, strides):
     start_indices = (*start_indices, 0)
     limit_indices = (*limit_indices, 2)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2870,11 +2870,6 @@ class FooTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def transpose_mlir(ctx, aval_out, x, *, permutation):
-    perm = [*permutation, len(permutation)]
-    return hlo.TransposeOp(x, mlir.dense_int_elements(perm)).result
-
-  @staticmethod
   def gather_mlir(ctx, avals_in, aval_out, x, indices, *,
                   dimension_numbers, slice_sizes, unique_indices,
                   indices_are_sorted, mode, fill_value):


### PR DESCRIPTION
When we originally introduced opaque dtypes in #11768, we set them up to arbitrarily customize lowering rules for dtype-polymorphic operations. Since then, our applications of opaque dtypes have exhibited more common structure, which we assume and take advantage of in this change in order to unify lowering rules across opaque dtype definitions.

Namely, an array with opaque dtype lowers to a single "physical" array of basic (non-opaque) dtype. The physical array's leading dimensions equal the opaquely dtyped array's shape, and its trailing dimensions represent (homogeneous) elements. To define an opaque dtype, it suffices to describe the trailing shape and the physical element type.

We were already making these assumption in some scattered places throughout the codebase (e.g. jax2tf). Some day, we might generalize (back) from one element-wise physical shape and dtype to several, meaning that an opaquely dtyped array could correspond to several parallel physical arrays (all with the same leading shape). This might be useful, for example, for bigint or extra-wide float representations, but we don't have those today.

cc @gnecula 