### PR TITLE
generalize dot_general input dtypes, and transposition rule

### DIFF
--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -417,11 +417,11 @@ def _conv_general_dilated_shape_rule(
 def _conv_general_dilated_dtype_rule(
     lhs, rhs, *, window_strides, padding, lhs_dilation, rhs_dilation,
     dimension_numbers, preferred_element_type, **unused_kwargs):
-  input_dtype = lax.naryop_dtype_rule(lax._input_dtype, [lax._any, lax._any],
-                                      'conv_general_dilated', lhs, rhs)
+  result_dtype = lax.naryop_dtype_rule(lax._input_dtype, [lax._any, lax._any],
+                                       'conv_general_dilated', lhs, rhs)
   if preferred_element_type is None:
-    return input_dtype
-  lax._validate_preferred_element_type(input_dtype, preferred_element_type)
+    return result_dtype
+  lax._validate_preferred_element_type(result_dtype, preferred_element_type)
   return preferred_element_type
 
 _conv_spec_transpose = lambda spec: (spec[1], spec[0]) + spec[2:]

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -424,6 +424,14 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     s = str(jax.make_jaxpr(pullback)(gresult))
     assert "Precision.HIGHEST" in s
 
+  def testDotPreferredElementType(self):
+    # https://github.com/google/jax/issues/10818
+    x = jax.numpy.ones((), jax.numpy.float16)
+    def f(x):
+      return jax.lax.dot_general(x, x, (((), ()), ((), ())),
+                                 preferred_element_type=jax.numpy.float32)
+    jax.jacrev(f)(x)  # don't crash!
+
   @jtu.sample_product(
     shape=[(), (2, 3)],
     dtype=float_dtypes,

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -977,12 +977,17 @@ class LaxTest(jtu.JaxTestCase):
                                            padding=(3, 3))
 
   @jtu.sample_product(
-      [
-          dict(lhs_shape=lhs_shape, rhs_shape=rhs_shape)
-          for lhs_shape in [(3,), (4, 3)]
-          for rhs_shape in [(3,), (3, 6)]
-      ],
-      dtype=lax_test_util.all_dtypes,
+      [dict(lhs_shape=lhs_shape, rhs_shape=rhs_shape)
+       for lhs_shape in [(3,), (4, 3)] for rhs_shape in [(3,), (3, 6)]],
+      [dict(lhs_dtype=lhs_dtype, rhs_dtype=rhs_dtype)
+       for lhs_dtype, rhs_dtype in
+       itertools.chain(
+           itertools.product(lax_test_util.int_dtypes +
+                             lax_test_util.float_dtypes +
+                             lax_test_util.complex_dtypes +
+                             lax_test_util.uint_dtypes,
+                             repeat=2),
+           zip(lax_test_util.bool_dtypes, lax_test_util.bool_dtypes))],
       precision=[
           None,
           lax.Precision.DEFAULT,
@@ -991,9 +996,9 @@ class LaxTest(jtu.JaxTestCase):
           (lax.Precision.DEFAULT, lax.Precision.HIGHEST),
       ],
   )
-  def testDot(self, lhs_shape, rhs_shape, dtype, precision):
+  def testDot(self, lhs_shape, rhs_shape, lhs_dtype, rhs_dtype, precision):
     rng = jtu.rand_default(self.rng())
-    args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
+    args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     self._CompileAndCheck(partial(lax.dot, precision=precision), args_maker)
 
   @jtu.sample_product(
@@ -1002,7 +1007,8 @@ class LaxTest(jtu.JaxTestCase):
     [dict(dtype=d, preferred_element_type=p)
      for d, p in preferred_type_combinations],
   )
-  def testDotPreferredElement(self, lhs_shape, rhs_shape, dtype, preferred_element_type):
+  def testDotPreferredElement(self, lhs_shape, rhs_shape, dtype,
+                              preferred_element_type):
     if (not config.x64_enabled and
        (dtype == np.float64 or preferred_element_type == np.float64
         or dtype == np.int64 or preferred_element_type == np.int64)):
@@ -1012,7 +1018,8 @@ class LaxTest(jtu.JaxTestCase):
       raise SkipTest("np.complex128 is not yet supported on TPU")
     if jtu.device_under_test() == "gpu":
       # TODO(b/189287598)
-      raise SkipTest("dot_general with preferred_element_type returns NaN non-deterministically on GPU")
+      raise SkipTest("dot_general with preferred_element_type returns NaN "
+                     "non-deterministically on GPU")
     rng = jtu.rand_default(self.rng())
     x = rng(lhs_shape, dtype)
     y = rng(rhs_shape, dtype)


### PR DESCRIPTION
fixes #10818

This change brings the dot_general primitive more in line with the HLO primitive, as it is described in XLA's shape_inference.cc (but not in the StableHLO spec). In particular we allow different input dtypes.

The main motivation is to support transposition in the presence of preferred_element_type (which can set the output dtype to be different from the inputs), e.g. to fix #10818.

However, because XLA platforms/backends can't seem to codegen all the cases that are accepted by shape_inference.cc, in our lowering rules we generate ConvertElementTypes on the inputs in a platform-dependent way.

Some follow-ups that may be necessary:
- [ ] file bugs with XLA to get clarity on what cases of mixed input dtypes the backends should support (and/or what shape_inference.cc should accept in HLO)
- [ ] update jax2tf to handle dots with mixed input precisions