### PR TITLE
linear_transpose now performs DCE before transposition

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2250,6 +2250,7 @@ def linear_transpose(fun: Callable, *primals, reduce_axes=()) -> Callable:
   in_pvals = map(pe.PartialVal.unknown, in_avals)
   jaxpr, out_pvals, const = pe.trace_to_jaxpr_nounits(flat_fun, in_pvals,
                                                       instantiate=True)
+  jaxpr, _ = pe.dce_jaxpr(jaxpr, [True] * len(jaxpr.outvars), True)
   out_avals, _ = unzip2(out_pvals)
   out_dtypes = map(dtypes.dtype, out_avals)
   if not (all(dtypes.issubdtype(d, np.inexact) for d in in_dtypes + out_dtypes)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2076,6 +2076,12 @@ class APITest(jtu.JaxTestCase):
     expected = 6
     self.assertEqual(actual, expected)
 
+  def test_linear_transpose_dce(self):
+    # https://github.com/google/jax/issues/15660
+    f = jit(lambda x: (2 * x, x > 0))
+    g = lambda x: f(x)[0]
+    api.linear_transpose(g, 1.)(1.)
+
   def test_linear_transpose_error(self):
     with self.assertRaisesRegex(
         TypeError, "linear_transpose only supports"):


### PR DESCRIPTION
Fixes #15660.

On the latest version of JAX/jaxlib, and without the DCE, this test will actually segfault.