### PR TITLE
Adds warning, in particular to catch `Partial(Partial(...), ...)`

### DIFF
--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -363,6 +363,11 @@ class Partial(functools.partial):
   Traced<ShapedArray(int32[], weak_type=True)>with<DynamicJaxprTrace...>
   """
   def __new__(klass, func, *args, **kw):
+    if tree_structure(func) != tree_structure(0):
+      warnings.warn(
+        "`jax.tree_util.Partial` treats its callable argument as static, and should "
+        "probably not be called on a PyTree."
+      )
     # In Python 3.10+, if func is itself a functools.partial instance,
     # functools.partial.__new__ would merge the arguments of this Partial
     # instance with the arguments of the func. We box func in a class that does


### PR DESCRIPTION
Fixes #13071 by raising a warning for what is almost certainly a user error.