### PR TITLE
custom PRNG: better error when using key as seed

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -131,8 +131,10 @@ def PRNGKey(seed: Union[int, Array]) -> KeyArray:
 
   """
   impl = default_prng_impl()
+  if isinstance(seed, prng.PRNGKeyArray):
+    raise TypeError("PRNGKey accepts a scalar seed, but was given a PRNGKeyArray.")
   if np.ndim(seed):
-    raise TypeError("PRNGKey accepts a scalar seed, but was given an array of"
+    raise TypeError("PRNGKey accepts a scalar seed, but was given an array of "
                     f"shape {np.shape(seed)} != (). Use jax.vmap for batching")
   key = prng.seed_with_impl(impl, seed)
   return _return_prng_keys(True, key)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1650,6 +1650,11 @@ class KeyArrayTest(jtu.JaxTestCase):
     make_key = partial(prng.seed_with_impl, prng.threefry_prng_impl)
     return jnp.reshape(jax.vmap(make_key)(seeds), shape)
 
+  def test_key_as_seed(self):
+    key = self.make_keys()
+    with self.assertRaisesRegex(TypeError, "PRNGKey accepts a scalar seed"):
+      jax.random.PRNGKey(key)
+
   def test_dtype_property(self):
     k1, k2 = self.make_keys(), self.make_keys()
     self.assertEqual(k1.dtype, k2.dtype)


### PR DESCRIPTION
Before:
```python
In [1]: import jax

In [2]: key = jax.random.PRNGKey(0)

In [3]: jax.random.PRNGKey(key)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<...>
TypeError: Cannot interpret 'key<fry>' as a data type
```
After:
```python
In [3]: jax.random.PRNGKey(key)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<...>
TypeError: PRNGKey accepts a scalar seed, but was given a PRNGKeyArray.
```