### PR TITLE
Extend plugin discovery to also include entry-points.

### DIFF
--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -346,8 +346,8 @@ def discover_pjrt_plugins() -> None:
       from importlib_metadata import entry_points
     except ModuleNotFoundError:
       logger.debug(
-          f"No importlib_metadata found (for Python < 3.10): "
-          f"Plugins advertised from entrypoints will not be found.")
+          "No importlib_metadata found (for Python < 3.10): "
+          "Plugins advertised from entrypoints will not be found.")
       entry_points = None
   else:
     from importlib.metadata import entry_points


### PR DESCRIPTION
This effectively implements a mix of option 2 and option 3 from https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/ as a pragmatic way to cover all packaging cases. The namespace/path based iteration works for situations where code has not been packaged and is present on the PYTHONPATH, whereas the advertised entry-points work around setuptools/pkgutil issues that make it impossible to reliably iterate over installed modules in certain scenarios (noted for editable installs which use a custom finder that does not implement iter_modules()).

A plugin entry-point can be advertised in setup.py (or equivalent pyproject.toml) with something like:

```
    entry_points={
        "jax_plugins": [
          "openxla-cpu = jax_plugins.openxla_cpu",
        ],
    }
```