### PR TITLE
disable custom_jvp for softmax by default

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -562,7 +562,7 @@ class _GlobalExtraJitContext(NamedTuple):
   default_matmul_precision: Optional[Any] = None
   dynamic_shapes: bool = False
   threefry_partitionable: bool = False
-  softmax_custom_jvp: bool = True
+  softmax_custom_jvp: bool = False
 
 
 def _update_global_jit_state(**kw):
@@ -587,7 +587,7 @@ class _ThreadLocalExtraJitContext(NamedTuple):
   numpy_dtype_promotion: Optional[str] = None
   default_matmul_precision: Optional[Any] = None
   dynamic_shapes: bool = False
-  softmax_custom_jvp: bool = True
+  softmax_custom_jvp: bool = False
 
 
 class _ThreadLocalStateCache(threading.local):
@@ -852,10 +852,10 @@ threefry_partitionable = config.define_bool_state(
 
 softmax_custom_jvp = config.define_bool_state(
     name='jax_softmax_custom_jvp',
-    default=True,
+    default=False,
     upgrade=True,
     help=('Use a new custom_jvp rule for jax.nn.softmax. The new rule should '
-          'improve memory usage and stability. Set False to revert to old '
+          'improve memory usage and stability. Set True to use new '
           'behavior. See https://github.com/google/jax/pull/15677'),
     update_global_hook=lambda val: _update_global_jit_state(
         softmax_custom_jvp=val),

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -141,9 +141,10 @@ class NNFunctionsTest(jtu.JaxTestCase):
 
     self.assertAllClose(out_masked, out_filtered)
 
-    # TODO(mattjj): log_softmax doesn't pass numerical gradient checking, but at
-    # time of writign only softmax has a custom rule to check
-    if fn is nn.softmax:
+    # TODO(mattjj): include log_softmax in these extra tests if/when we add a
+    # custom_jvp rule for it (since otherwise it doesn't pass the numerical
+    # checks below).
+    if fn is nn.softmax and config.jax_softmax_custom_jvp:
       g_fun = lambda x: jnp.take(fn(x, where=m, initial=-jnp.inf),
                                 jnp.array([0, 2, 3]))
       jtu.check_grads(g_fun, (x,), order=2)


### PR DESCRIPTION
Follow-up on #15677, basically undoing it. Some training runs experienced mysterious failures after many steps, like the gray line below (only difference with the blue line is the setting of `jax_softmax_custom_jvp`). We may leave this disabled until we diagnose the cause of the failures.

![image](https://github.com/google/jax/assets/1458824/e6c77553-9bb8-48fb-bcea-165666552401)
