### PR TITLE
deprecate jax.lax.prod

### DIFF
--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -372,4 +372,16 @@ from jax._src.pjit import with_sharding_constraint as with_sharding_constraint
 from jax._src.pjit import sharding_constraint_p as sharding_constraint_p
 from jax._src.dispatch import device_put_p as device_put_p
 
-from math import prod  # TODO(phawkins): remove this accidental export
+from math import prod as _prod
+
+_deprecations = {
+    # Added May 23, 2023:
+    "prod": (
+        "jax.lax.prod is deprecated. Use math.prod instead.",
+        _prod,
+    ),
+}
+
+from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
+__getattr__ = _deprecation_getattr(__name__, _deprecations)
+del _deprecation_getattr, _prod


### PR DESCRIPTION
This was an inadvertently-exported copy of the builtin `math.prod`.

This will be removed after 3 months, in accordance with the [API compatibility policy](https://jax.readthedocs.io/en/latest/api_compatibility.html)