### PR TITLE
Make deprecation warnings warn at appropriate stacklevel

### DIFF
--- a/jax/_src/deprecations.py
+++ b/jax/_src/deprecations.py
@@ -48,7 +48,7 @@ def deprecation_getattr(module, deprecations):
       message, fn = deprecations[name]
       if fn is None:
         raise AttributeError(message)
-      warnings.warn(message, DeprecationWarning)
+      warnings.warn(message, DeprecationWarning, stacklevel=2)
       return fn
     raise AttributeError(f"module {module!r} has no attribute {name!r}")
 


### PR DESCRIPTION
By default, Python silences deprecation warnings unless triggered in `__main__` (see https://docs.python.org/3/library/warnings.html) In practice, this means that our automatic deprecation warnings are always silenced, because they are triggered two levels below where the user accesses the deprecated objects.

This change fixes this by pushing the warnings stack level to the call-site:
```bash
$ git checkout main

$ python -c "from jax.numpy import DeviceArray"

$ git checkout deprecation-stacklevel

$ python -c "from jax.numpy import DeviceArray"
<string>:1: DeprecationWarning: jax.numpy.DeviceArray is deprecated. Use jax.Array.
```