### PR TITLE
jax2tf: make shape_poly_test pass with custom PRNG

### DIFF
--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -2348,7 +2348,7 @@ _POLY_SHAPE_TEST_HARNESSES = [
                     poly_axes=[None, (0, 1)],
                     override_jax_config_flags=override_jax_config_flags),  # type: ignore
         PolyHarness("random_split", f"{flags_name}",
-                    lambda key, a: jax.random.split(key, 2 * a.shape[0]),
+                    lambda key, a: jax.random.key_data(jax.random.split(key, 2 * a.shape[0])),
                     arg_descriptors=[RandArg((key_size,), np.uint32),
                                      RandArg((3, 4), _f32)],
                     poly_axes=[None, (0,)],


### PR DESCRIPTION
Tested with:
```
(jax) bash-3.2$ JAX_ENABLE_CUSTOM_PRNG=1 pytest jax/experimental/jax2tf/tests/shape_poly_test.py -k random_split
================================================================ test session starts ================================================================
platform darwin -- Python 3.11.1, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/vanderplas/github/google/jax
configfile: pyproject.toml
plugins: json-report-1.5.0, xdist-3.2.1, hypothesis-6.75.3, metadata-2.0.4
collected 1674 items / 1666 deselected / 8 selected                                                                                                 

jax/experimental/jax2tf/tests/shape_poly_test.py ........                                                                                     [100%]

================================================================= warnings summary ==================================================================
jax/experimental/jax2tf/tests/shape_poly_test.py::ShapePolyPrimitivesTest::test_harness_random_split_threefry_non_partitionable
jax/experimental/jax2tf/tests/shape_poly_test.py::ShapePolyPrimitivesTest::test_harness_random_split_threefry_partitionable
jax/experimental/jax2tf/tests/shape_poly_test.py::ShapePolyPrimitivesTest::test_harness_random_split_unsafe_rbg
  /Users/vanderplas/github/google/jax/jax/_src/random.py:76: FutureWarning: Raw arrays as random keys to jax.random functions are deprecated. Assuming valid threefry2x32 key for now.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================== 8 passed, 1666 deselected, 3 warnings in 11.40s ==================================================
```