### PR TITLE
Bump minimum jaxlib version to 0.4.10.

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -62,7 +62,6 @@ from jax._src.api_util import (
 from jax._src.lax import lax as lax_internal
 from jax._src.lib import jax_jit
 from jax._src.lib import xla_client as xc
-from jax._src.lib import xla_extension_version
 from jax._src.lib import pmap_lib
 from jax._src.sharding import Sharding
 from jax._src.sharding_impls import PmapSharding
@@ -2894,9 +2893,8 @@ def clear_caches():
   xc._xla.PjitFunctionCache.clear_all()
 
   # Clear all C++ compiled executable caches for pmap
-  if xla_extension_version >= 146:  # TODO(frostig): remove when ready
-    for fun in _pmap_cache_clears:
-      fun._cache_clear()
+  for fun in _pmap_cache_clears:
+    fun._cache_clear()
 
   # Clear particular util.cache instances.
   dispatch.xla_primitive_callable.cache_clear()

--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -32,7 +32,6 @@ from jax._src import profiler
 from jax._src import xla_bridge
 from jax._src.config import config
 from jax._src.lib import xla_client as xc
-from jax._src.lib import xla_extension_version
 from jax._src.interpreters import mlir
 from jax._src.interpreters import pxla
 from jax._src.interpreters import xla
@@ -425,7 +424,7 @@ class ArrayImpl(basearray.Array):
 
   def addressable_data(self, index: int) -> ArrayImpl:
     self._check_if_deleted()
-    if self.is_fully_replicated and xla_extension_version >= 148:
+    if self.is_fully_replicated:
       return self._fully_replicated_shard()
     return self._arrays[index]
 

--- a/jax/_src/compilation_cache.py
+++ b/jax/_src/compilation_cache.py
@@ -35,7 +35,6 @@ from jax._src.compilation_cache_interface import CacheInterface
 from jax._src.gfile_cache import GFileCache
 from jax._src.lib import xla_client
 from jax._src.lib import version_str as jaxlib_version_str
-from jax._src.lib import xla_extension_version
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir import passmanager as pm
 
@@ -200,10 +199,7 @@ def _hash_devices(hash_obj, devices: np.ndarray) -> None:
     _hash_string(hash_obj, device.device_kind)
 
 def _hash_compile_options(hash_obj, compile_options_obj):
-  if xla_extension_version >= 145:
-    expected_num_compile_options = 12
-  else:
-    expected_num_compile_options = 11
+  expected_num_compile_options = 12
   # Ignore private and built-in methods. These can unexpectedly change and lead
   # to false positives, e.g. when different Python versions include different
   # built-ins.
@@ -232,16 +228,15 @@ def _hash_compile_options(hash_obj, compile_options_obj):
   if compile_options_obj.device_assignment is not None:
     hash_obj.update(compile_options_obj.device_assignment.serialize())
   _hash_bool(hash_obj, compile_options_obj.compile_portable_executable)
-  if xla_extension_version >= 145:
-    _hash_int(hash_obj, len(compile_options_obj.env_option_overrides))
-    for kv in compile_options_obj.env_option_overrides:
-      _hash_string(hash_obj, kv[0])
-      if isinstance(kv[1], str):
-        _hash_string(hash_obj, kv[1])
-      elif isinstance(kv[1], bool):
-        _hash_bool(hash_obj, kv[1])
-      else:
-        raise RuntimeError("Invalid type: %s" % repr(type(kv[1])))
+  _hash_int(hash_obj, len(compile_options_obj.env_option_overrides))
+  for kv in compile_options_obj.env_option_overrides:
+    _hash_string(hash_obj, kv[0])
+    if isinstance(kv[1], str):
+      _hash_string(hash_obj, kv[1])
+    elif isinstance(kv[1], bool):
+      _hash_bool(hash_obj, kv[1])
+    else:
+      raise RuntimeError("Invalid type: %s" % repr(type(kv[1])))
 
 
 def _hash_executable_build_options(hash_obj, executable_obj):

--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -36,7 +36,6 @@ from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
 from jax._src.interpreters import partial_eval as pe
 from jax._src.lib import xla_client as xc
-from jax._src.lib import xla_extension_version
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import hlo
 from jax._src.sharding import Sharding
@@ -357,19 +356,10 @@ def _inspect_sharding_lowering_rule(ctx: mlir.LoweringRuleContext, value, *,
 
   # Here we store information in a container that we store globally so the
   # custom partitioning code can access it.
-  sharding_callback_info = ShardingCallbackInfo(_hlo_sharding_callback,
-                                                ctx.module_context)
-  if xla_extension_version < 150:
-    key = str(id(sharding_callback_info))
-    sharding_callbacks[key] = sharding_callback_info
-    # We need to make sure `sharding_callback_info` is still alive when the SPMD
-    # partitioner runs so we keep it alive by attaching it to the executable.
-    ctx.module_context.add_keepalive(sharding_callback_info)
-  else:
-    key = xc.encode_inspect_sharding_callback(_hlo_sharding_callback)
-    # We need to make sure `_hlo_sharding_callback` is still alive when the SPMD
-    # partitioner runs so we keep it alive by attaching it to the executable.    #
-    ctx.module_context.add_keepalive(_hlo_sharding_callback)
+  key = xc.encode_inspect_sharding_callback(_hlo_sharding_callback)
+  # We need to make sure `_hlo_sharding_callback` is still alive when the SPMD
+  # partitioner runs so we keep it alive by attaching it to the executable.    #
+  ctx.module_context.add_keepalive(_hlo_sharding_callback)
 
   hlo.CustomCallOp([value.type], [value],
                    call_target_name=ir.StringAttr.get(
@@ -419,15 +409,6 @@ def inspect_sharding_infer_sharding_from_operands(arg_shapes, arg_shardings,
                                                   shape, backend_string):
   del arg_shapes, shape, backend_string
   return arg_shardings[0]
-
-if xla_extension_version < 150:
-  xc.register_custom_call_partitioner(  # pytype: disable=module-attr
-      _INSPECT_SHARDING_CALL_NAME,
-      inspect_sharding_prop_user_sharding,
-      inspect_sharding_partition,
-      inspect_sharding_infer_sharding_from_operands,
-      True,
-  )
 
 def _slice_to_chunk_idx(size: int, slc: slice) -> int:
   if slc.stop == slc.start == None:

--- a/jax/_src/lax/ann.py
+++ b/jax/_src/lax/ann.py
@@ -441,18 +441,9 @@ approx_top_k_p = core.Primitive('approx_top_k')
 approx_top_k_p.multiple_results = True
 approx_top_k_p.def_impl(partial(dispatch.apply_primitive, approx_top_k_p))
 approx_top_k_p.def_abstract_eval(_approx_top_k_abstract_eval)
-if xc.mlir_api_version > 48:
-  mlir.register_lowering(approx_top_k_p,
-                        partial(_approx_top_k_lowering, fallback=True))
-  mlir.register_lowering(approx_top_k_p, _approx_top_k_lowering,
-                          platform='tpu')
-elif xc.mlir_api_version == 48:
-  xla.register_translation(approx_top_k_p, _approx_top_k_fallback_translation)
-  mlir.register_lowering(approx_top_k_p, _approx_top_k_lowering,
-                          platform='tpu')
-else:
-  xla.register_translation(approx_top_k_p, _approx_top_k_fallback_translation)
-  xla.register_translation(approx_top_k_p, _approx_top_k_tpu_translation,
-                            platform='tpu')
+mlir.register_lowering(approx_top_k_p,
+                       partial(_approx_top_k_lowering, fallback=True))
+mlir.register_lowering(approx_top_k_p, _approx_top_k_lowering,
+                       platform='tpu')
 batching.primitive_batchers[approx_top_k_p] = _approx_top_k_batch_rule
 ad.primitive_jvps[approx_top_k_p] = _approx_top_k_jvp

--- a/jax/_src/op_shardings.py
+++ b/jax/_src/op_shardings.py
@@ -19,7 +19,6 @@ from typing import List, Sequence, Tuple, Union
 import numpy as np
 
 from jax._src.lib import xla_client as xc
-from jax._src.lib import xla_extension_version
 
 
 def get_num_ways_dim_sharded(
@@ -49,11 +48,7 @@ def get_num_ways_dim_sharded(
 
 def is_op_sharding_replicated(op: Union[xc.OpSharding, xc.HloSharding]) -> bool:
   if isinstance(op, xc.OpSharding):
-    if xla_extension_version >= 147:
-      return xc._xla.is_op_sharding_fully_replicated(op)
-    if len(op.tile_assignment_devices) == 1:
-      return True
-    return xc.HloSharding.from_proto(op).is_replicated()  # type: ignore
+    return xc._xla.is_op_sharding_fully_replicated(op)
   else:
     assert isinstance(op, xc.HloSharding)
     if op.num_devices() == 1:

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -47,7 +47,6 @@ from jax._src.lax import lax as lax_internal
 from jax._src.lax import utils as lax_utils
 from jax._src.lib.mlir import ir
 from jax._src.lib import gpu_prng
-from jax._src.lib import version as jaxlib_version
 from jax._src.lib import xla_client as xc
 from jax._src.lib.mlir.dialects import hlo
 from jax._src.numpy.array_methods import (
@@ -1037,18 +1036,10 @@ def _threefry2x32_gpu_lowering(lowering_func, ctx, k1, k2, x1, x2):
     length = int(out_len)  # will be passed statically
     output_shape = None
 
-  if (jaxlib_version >= (0, 4, 9)):
-    return lowering_func(
-            (_broadcast(k1, k1_aval), _broadcast(k2, k2_aval)),
-            (_broadcast(x1, x1_aval), _broadcast(x2, x2_aval)), length,
-            output_shape)
-  else:
-    if output_shape is not None:
-      raise ValueError("native lowering with shape polymorphism "
-                       "for threefry on GPU requires jaxlib version 0.4.9")
-    return lowering_func(
-            (_broadcast(k1, k1_aval), _broadcast(k2, k2_aval)),
-            (_broadcast(x1, x1_aval), _broadcast(x2, x2_aval)), length)
+  return lowering_func(
+          (_broadcast(k1, k1_aval), _broadcast(k2, k2_aval)),
+          (_broadcast(x1, x1_aval), _broadcast(x2, x2_aval)), length,
+          output_shape)
 
 threefry2x32_p = core.Primitive("threefry2x32")
 threefry2x32_p.multiple_results = True

--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -31,7 +31,6 @@ import sys
 import threading
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 import warnings
-from jax._src.lib import xla_extension_version
 import numpy as np
 
 from jax._src import lib
@@ -164,11 +163,7 @@ def get_compile_options(
     compile_options.device_assignment = device_assignment
 
   if env_options_overrides is not None:
-    if xla_extension_version >= 145:
-      compile_options.env_option_overrides = list(env_options_overrides.items())
-    else:
-      raise TypeError(
-          "`env_options_overrides` is only supported in later versions of jaxlib")
+    compile_options.env_option_overrides = list(env_options_overrides.items())
 
   debug_options = compile_options.executable_build_options.debug_options
   if lib.cuda_path is not None:
@@ -416,16 +411,8 @@ def register_plugin(
     options: Optional. It is used when creating a PJRT plugin client.
   """
   def factory():
-    if xla_extension_version >= 152:
-      # Plugin may already be statically linked in some configurations.
-      if not xla_client.pjrt_plugin_loaded(plugin_name):
-        if library_path is None:
-          raise ValueError(
-              'The library path is None when trying to dynamically load the'
-              ' plugin.'
-          )
-        xla_client.load_pjrt_plugin_dynamically(plugin_name, library_path)
-    else:
+    # Plugin may already be statically linked in some configurations.
+    if not xla_client.pjrt_plugin_loaded(plugin_name):
       if library_path is None:
         raise ValueError(
             'The library path is None when trying to dynamically load the'
@@ -816,11 +803,9 @@ def using_pjrt_c_api(backend=None):
 
 # TODO(parkers): Get rid of this in favor of a generic way to get topologies.
 def make_pjrt_tpu_topology(topology_name=None, **kwargs):
-  if xla_extension_version >= 153:
-    # TODO(b/261484192): Make a system for lazily loading libtpu.so and call
-    # that inside make_tfrt_tpu_c_api_device_topology.
-    get_backend()  # Properly initialize libtpu.so.
-    return xla_client.make_tfrt_tpu_c_api_device_topology(
-        topology_name, **kwargs
-    )
-  raise NotImplementedError('make_pjrt_tpu_topology is not implemented')
+  # TODO(b/261484192): Make a system for lazily loading libtpu.so and call
+  # that inside make_tfrt_tpu_c_api_device_topology.
+  get_backend()  # Properly initialize libtpu.so.
+  return xla_client.make_tfrt_tpu_c_api_device_topology(
+      topology_name, **kwargs
+  )

--- a/jax/experimental/rnn.py
+++ b/jax/experimental/rnn.py
@@ -370,8 +370,7 @@ def lstm_fwd(x: Array, h_0: Array, c_0: Array, w: Array, seq_lengths: Array,
              bidirectional: bool):
   if seq_lengths.dtype != jnp.dtype("int32"):
     raise NotImplementedError("`seq_lengths` can only be int32.")
-  if jax._src.lib.version < (0, 4, 9):
-    y, h_n, c_n, workspace, reserve_space = rnn_fwd_p.bind(
+  y, h_n, c_n, reserve_space = rnn_fwd_p.bind(
       x,
       h_0,
       c_0,
@@ -382,21 +381,7 @@ def lstm_fwd(x: Array, h_0: Array, c_0: Array, w: Array, seq_lengths: Array,
       num_layers=num_layers,
       dropout=dropout,
       bidirectional=bidirectional)
-    return (y, h_n, c_n), (x, h_0, c_0, w, seq_lengths, y, workspace,
-                          reserve_space)
-  else:
-    y, h_n, c_n, reserve_space = rnn_fwd_p.bind(
-        x,
-        h_0,
-        c_0,
-        w,
-        seq_lengths,
-        input_size=input_size,
-        hidden_size=hidden_size,
-        num_layers=num_layers,
-        dropout=dropout,
-        bidirectional=bidirectional)
-    return (y, h_n, c_n), (x, h_0, c_0, w, seq_lengths, y, reserve_space)
+  return (y, h_n, c_n), (x, h_0, c_0, w, seq_lengths, y, reserve_space)
 
 
 def rnn_abstract_eval(x_aval, h_0_aval, c_0_aval, w_aval, seq_lengths_aval,
@@ -406,21 +391,12 @@ def rnn_abstract_eval(x_aval, h_0_aval, c_0_aval, w_aval, seq_lengths_aval,
   num_directions = 2 if bidirectional else 1
   output_shape = (batch_size, max_seq_length, num_directions * hidden_size)
   output_aval = core.ShapedArray(output_shape, x_aval.dtype)
-  if jax._src.lib.version < (0, 4, 9):
-    workspace_size, reserve_space_size = (
+  _, reserve_space_size = (
       gpu_rnn.compute_rnn_workspace_reserve_space_sizes(  # pytype: disable=attribute-error
           input_size, hidden_size, num_layers, batch_size, max_seq_length,
           dropout, bidirectional))
-    workspace_aval = core.ShapedArray((workspace_size,), jnp.float32)
-    reserve_space_aval = core.ShapedArray((reserve_space_size,), jnp.float32)
-    return output_aval, h_0_aval, c_0_aval, workspace_aval, reserve_space_aval
-  else:
-    _, reserve_space_size = (
-        gpu_rnn.compute_rnn_workspace_reserve_space_sizes(  # pytype: disable=attribute-error
-            input_size, hidden_size, num_layers, batch_size, max_seq_length,
-            dropout, bidirectional))
-    reserve_space_aval = core.ShapedArray((reserve_space_size,), jnp.float32)
-    return output_aval, h_0_aval, c_0_aval, reserve_space_aval
+  reserve_space_aval = core.ShapedArray((reserve_space_size,), jnp.float32)
+  return output_aval, h_0_aval, c_0_aval, reserve_space_aval
 
 
 rnn_fwd_p = core.Primitive('rnn_fwd')
@@ -433,61 +409,32 @@ if gpu_rnn:
 
 def lstm_bwd(input_size: int, hidden_size: int, num_layers: int, dropout: float,
              bidirectional, residuals, gradients):
-  if jax._src.lib.version < (0, 4, 9):
-    x, h_0, c_0, w, seq_lengths, y, workspace, reserve_space = residuals
-    dy, dh_n, dc_n = gradients
-    dx, dh_0, dc_0, dw = rnn_bwd_p.bind(
-        dy,
-        dh_n,
-        dc_n,
-        x,
-        h_0,
-        c_0,
-        w,
-        y,
-        workspace,
-        reserve_space,
-        seq_lengths,
-        input_size=input_size,
-        hidden_size=hidden_size,
-        num_layers=num_layers,
-        dropout=dropout,
-        bidirectional=bidirectional)
-    return (dx, dh_0, dc_0, dw, jnp.zeros_like(seq_lengths))
-  else:
-    x, h_0, c_0, w, seq_lengths, y, reserve_space = residuals
-    dy, dh_n, dc_n = gradients
-    dx, dh_0, dc_0, dw = rnn_bwd_p.bind(
-        dy,
-        dh_n,
-        dc_n,
-        x,
-        h_0,
-        c_0,
-        w,
-        y,
-        reserve_space,
-        seq_lengths,
-        input_size=input_size,
-        hidden_size=hidden_size,
-        num_layers=num_layers,
-        dropout=dropout,
-        bidirectional=bidirectional)
-    return (dx, dh_0, dc_0, dw, jnp.zeros_like(seq_lengths))
+  x, h_0, c_0, w, seq_lengths, y, reserve_space = residuals
+  dy, dh_n, dc_n = gradients
+  dx, dh_0, dc_0, dw = rnn_bwd_p.bind(
+      dy,
+      dh_n,
+      dc_n,
+      x,
+      h_0,
+      c_0,
+      w,
+      y,
+      reserve_space,
+      seq_lengths,
+      input_size=input_size,
+      hidden_size=hidden_size,
+      num_layers=num_layers,
+      dropout=dropout,
+      bidirectional=bidirectional)
+  return (dx, dh_0, dc_0, dw, jnp.zeros_like(seq_lengths))
 
 
-if jax._src.lib.version < (0, 4, 9):
-  def rnn_bwd_abstract_eval(dy_aval, dhn_aval, dcn_aval, x_aval, h0_aval, c0_aval,
-                          w_aval, y_aval, workspace_aval, reserve_space_aval,
+def rnn_bwd_abstract_eval(dy_aval, dhn_aval, dcn_aval, x_aval, h0_aval, c0_aval,  # type: ignore
+                          w_aval, y_aval, reserve_space_aval,
                           seq_lengths_aval, input_size: int, hidden_size: int,
                           num_layers: int, dropout: float, bidirectional: bool):
-    return x_aval, h0_aval, c0_aval, w_aval
-else:
-  def rnn_bwd_abstract_eval(dy_aval, dhn_aval, dcn_aval, x_aval, h0_aval, c0_aval,  # type: ignore
-                            w_aval, y_aval, reserve_space_aval,
-                            seq_lengths_aval, input_size: int, hidden_size: int,
-                            num_layers: int, dropout: float, bidirectional: bool):
-    return x_aval, h0_aval, c0_aval, w_aval
+  return x_aval, h0_aval, c0_aval, w_aval
 
 
 rnn_bwd_p = core.Primitive('rnn_bwd')

--- a/jax/version.py
+++ b/jax/version.py
@@ -16,7 +16,7 @@
 # eval()-ed by setup.py, so it should not have any dependencies.
 
 __version__ = "0.4.11"
-_minimum_jaxlib_version = "0.4.7"
+_minimum_jaxlib_version = "0.4.10"
 
 def _version_as_tuple(version_str):
   return tuple(int(i) for i in version_str.split(".") if i.isdigit())

--- a/tests/aot_test.py
+++ b/tests/aot_test.py
@@ -26,7 +26,6 @@ from jax._src.config import flags
 from jax.experimental.pjit import pjit
 from jax.experimental.serialize_executable import (
     serialize, deserialize_and_load)
-from jax._src.lib import xla_extension_version
 from jax.experimental import topologies
 from jax.sharding import PartitionSpec as P
 
@@ -40,9 +39,6 @@ with contextlib.suppress(ImportError):
   pytestmark = pytest.mark.multiaccelerator
 
 
-@unittest.skipIf(
-    xla_extension_version < 151, 'Test requires xla_extension_version >= 151'
-)
 class JaxAotTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices('cpu', 'gpu')

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -68,7 +68,6 @@ from jax._src import prng
 from jax._src import xla_bridge
 from jax._src.lib import xla_client
 from jax._src.lib import xla_extension
-from jax._src.lib import xla_extension_version
 from jax._src import test_util as jtu
 from jax import tree_util
 from jax._src import linear_util as lu
@@ -1177,8 +1176,6 @@ class CPPJitTest(jtu.BufferDonationTestCase):
     self.assertIn("jax.result_info = \"['a']\"", mhlo_str)
     self.assertIn("jax.result_info = \"['b'][0][0]\"", mhlo_str)
 
-  @unittest.skipIf(xla_extension_version < 145,
-                   'Test requires xla_extension_version >= 145')
   def test_jit_lower_compile_with_compiler_options(self):
     def f(x):
       return jnp.sqrt(x ** 2) + 1.
@@ -1188,8 +1185,6 @@ class CPPJitTest(jtu.BufferDonationTestCase):
     lowered.compile(            # doesn't crash
         compiler_options={"xla_embed_ir_in_executable": True})
 
-  @unittest.skipIf(xla_extension_version < 145,
-                   'Test requires xla_extension_version >= 145')
   def test_jit_lower_compile_with_compiler_options_invalid(self):
     def f(x):
       return jnp.sqrt(x ** 2) + 1.
@@ -1207,8 +1202,6 @@ class CPPJitTest(jtu.BufferDonationTestCase):
         lambda: lowered.compile(
             compiler_options={"xla_embed_ir_in_executable": "invalid_value"}))
 
-  @unittest.skipIf(xla_extension_version < 145,
-                   'Test requires xla_extension_version >= 145')
   def test_jit_lower_compile_with_compiler_options_multiple(self):
     def f(x):
       return jnp.sqrt(x ** 2) + 1.
@@ -4231,8 +4224,6 @@ class APITest(jtu.JaxTestCase):
     out = jax.grad(f)(3.0)  # doesn't crash
     self.assertAllClose(out, 1., check_dtypes=False)
 
-  @unittest.skipIf(xla_extension_version < 146,
-                   'Test requires xla_extension_version >= 146')
   def test_cache_clear_pmap(self):
     @jax.pmap
     def f(i):

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -742,9 +742,6 @@ class JaxArrayTest(jtu.JaxTestCase):
     self.assertArraysEqual(np.arange(8.), x)
 
   def test_array_fully_replicated_shard(self):
-    if xla_extension_version < 148:
-      self.skipTest('Requires xla_extension_version >= 148')
-
     global_mesh = jtu.create_global_mesh((4, 2), ('x', 'y'))
     inp_shape = (8, 2)
     arr, inp_data = create_array(

--- a/tests/compilation_cache_test.py
+++ b/tests/compilation_cache_test.py
@@ -201,8 +201,6 @@ class CompilationCacheTest(jtu.JaxTestCase):
         cc.get_cache_key(computation2, devices, compile_options, backend),
     )
 
-  @unittest.skipIf(jax._src.lib.version < (0, 4, 9),
-                   "Test requires jaxlib 0.4.9")
   @parameterized.parameters([False, True])
   def test_identical_computations_different_metadata(self, include_metadata):
     f = lambda x, y: lax.mul(lax.add(x, y), 2)

--- a/tests/debugging_primitives_test.py
+++ b/tests/debugging_primitives_test.py
@@ -28,7 +28,6 @@ from jax._src import debugging
 from jax._src import dispatch
 from jax._src import test_util as jtu
 from jax._src import xla_bridge
-from jax._src.lib import xla_extension_version
 import jax.numpy as jnp
 import numpy as np
 
@@ -1150,7 +1149,7 @@ class InspectShardingTest(jtu.JaxTestCase):
 
     if jtu.is_cloud_tpu():
       raise unittest.SkipTest("Inspect sharding is not supported on libtpu.")
-    if xla_bridge.using_pjrt_c_api() and xla_extension_version < 150:
+    if xla_bridge.using_pjrt_c_api():
       raise unittest.SkipTest("Inspect sharding is not supported on Cloud TPU")
 
     is_called = False

--- a/tests/experimental_rnn_test.py
+++ b/tests/experimental_rnn_test.py
@@ -16,7 +16,6 @@ from absl.testing import absltest
 import numpy as np
 import jax
 import jax.numpy as jnp
-from jax._src import lib
 from jax._src import test_util as jtu
 from jax.experimental import rnn
 
@@ -38,10 +37,6 @@ class RnnTest(jtu.JaxTestCase):
   @jtu.skip_on_devices("cpu", "tpu", "rocm")
   def test_lstm(self, batch_size: int, seq_len: int, input_size: int,
                 hidden_size: int, num_layers: int, bidirectional: bool):
-    if lib.version < (0, 4, 7):
-      # TODO(sharadmv, zhangqiaorjc): remove this when minimum jaxlib version is
-      # bumped
-      self.skipTest("Need latest jaxlib for this test to pass.")
     num_directions = 2 if bidirectional else 1
     seq_length_key, root_key = jax.random.split(jax.random.PRNGKey(0))
 

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -1285,8 +1285,6 @@ class CustomPartitionerTest(jtu.JaxTestCase):
   @jtu.with_mesh([('x', 4), ('y', 2)])
   def test_custom_partitioner_invalid_sharding(self):
     self.skip_if_custom_partitioning_not_supported()
-    if xla_extension_version < 149:
-      self.skipTest('Requires xla_extension_version >= 149')
 
     def partition(arg_shapes, result_shape):
       def lower_fn(x):

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -47,7 +47,6 @@ from jax._src import sharding_impls
 from jax._src import sharding_specs
 from jax._src import xla_bridge
 from jax._src.lib import xla_extension
-from jax._src.lib import xla_extension_version
 from jax._src.util import safe_map, safe_zip
 from jax._src.interpreters import pxla
 from jax.interpreters import xla
@@ -332,8 +331,6 @@ class PythonPmapTest(jtu.JaxTestCase):
     f = f.lower(x).compile()
     self.assertIsNotNone(f.runtime_executable())
 
-  @unittest.skipIf(xla_extension_version < 145,
-                   'Test requires xla_extension_version >= 145')
   def test_jit_lower_compile_with_compiler_options(self):
     f = self.pmap(lambda x: x - lax.pmean(x, 'i'), axis_name='i')
     shape = (jax.device_count(), 4)
@@ -343,8 +340,6 @@ class PythonPmapTest(jtu.JaxTestCase):
     lowered.compile(            # doesn't crash
         compiler_options={"xla_embed_ir_in_executable": True})
 
-  @unittest.skipIf(xla_extension_version < 145,
-                   'Test requires xla_extension_version >= 145')
   def test_jit_lower_compile_with_compiler_options_invalid(self):
     f = self.pmap(lambda x: x - lax.pmean(x, 'i'), axis_name='i')
     shape = (jax.device_count(), 4)
@@ -361,8 +356,6 @@ class PythonPmapTest(jtu.JaxTestCase):
         lambda: lowered.compile(
             compiler_options={"xla_embed_ir_in_executable": "invalid_value"}))
 
-  @unittest.skipIf(xla_extension_version < 145,
-                   'Test requires xla_extension_version >= 145')
   def test_jit_lower_compile_with_compiler_options_multiple(self):
     f = self.pmap(lambda x: x - lax.pmean(x, 'i'), axis_name='i')
     shape = (jax.device_count(), 4)


### PR DESCRIPTION
The minimum xla_extension_version is 153, and mlir_api_version is 49.