### PR TITLE
[shape_poly] Add static constraint checking to the computation of dim vars

### DIFF
--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -82,11 +82,14 @@ def i64_attr(i): return ir.IntegerAttr.get(ir.IntegerType.get_signless(64), i)
 def shape_tensor(sizes: Sequence[Union[int, ir.RankedTensorType]]
                  ) -> ir.RankedTensorType:
   int1d = aval_to_ir_type(core.ShapedArray((1,), np.int32))
+  i32_type = aval_to_ir_type(core.ShapedArray((), np.int32))
   def lower_dim(d):
     if type(d) is int:
       return ir_constant(np.array([d], np.int32))
     else:
-      return hlo.ReshapeOp(int1d, hlo.ConvertOp(aval_to_ir_type(core.ShapedArray((), np.int32)), d))
+      if d.type != i32_type:
+        d = hlo.ConvertOp(i32_type, d)
+      return hlo.ReshapeOp(int1d, d)
   ds = map(lower_dim, sizes)
   if not ds:
     return ir_constant(np.array([], np.int32))

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2291,7 +2291,7 @@ def arange(start: DimSize, stop: Optional[DimSize] = None,
       step = 1
     elif stop is not None and step is None:
       step = 1
-    return _arange_dynamic(start, stop, step, dtype or int_)
+    return _arange_dynamic(start, stop, step, dtype or dtypes.canonicalize_dtype(np.int64))
   if dtype is None:
     dtype = result_type(start, *(x for x in [stop, step] if x is not None))
   dtype = _jnp_dtype(dtype)

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -564,9 +564,8 @@ class GraphSerializationImpl(SerializationImpl):
         map(lambda a: core.raise_to_shaped(core.get_aval(a)), args_specs_flat))
     dim_vars = shape_poly.all_dim_vars(self.args_avals_flat)
     dim_values, _ = _interpret_fun_jax(
-        partial(shape_poly.unify_avals_with_args, self.args_avals_flat, dim_vars,
-                use_static_dimension_size=False,
-                args_kwargs_tree=self.in_tree),
+        partial(shape_poly.compute_dim_vars_from_arg_shapes,
+                self.args_avals_flat, args_kwargs_tree=self.in_tree),
         self.args_flat_tf, self.args_avals_flat, self.name_stack)
     _thread_local_state.shape_env = zip(dim_vars, dim_values)
 


### PR DESCRIPTION

Previously we had one function `shape_poly.unify_avals_with_args` that was solving the dimension variables and was also used for generating the code to compute them. Now we separate the solving part, which is now using just symbolic expressions (`shape_poly.solve_dim_vars`), from the code generator for the dimension variables (`shape_poly.compute_dim_vars_from_arg_shapes`).

We also add a notion of shape constraints, e.g., `dimexpr1 == dimexpr2` or `dimexpr1 >= dimexpr2`, under which the solution for the dimension variables is valid.

For now we implement the static checking of the shape constraints, e.g., when the dimension expressions are constant or TF EagerTensor. We do not yet have compile-time checking of the constraints. This matches the previous behavior. However, the code is now ready for implementing compile-time checking of the constraints that cannot be checked statically.