### PR TITLE
[shape_poly] Keep track of whether a lowering contains shape polymorphism

### DIFF
--- a/jax/experimental/jax2tf/tests/back_compat_test.py
+++ b/jax/experimental/jax2tf/tests/back_compat_test.py
@@ -275,6 +275,8 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
         mlir_module_serialized=data.mlir_module_serialized,
         xla_call_module_version=data.xla_call_module_version,
         module_kept_var_idx=tuple(range(len(in_avals))),
+        module_uses_dim_vars=any(not core.is_constant_shape(a.shape)
+                                 for a in in_avals),
         _get_vjp=_get_vjp)
 
     # We use pjit in case there are shardings in the exported module.


### PR DESCRIPTION
Previously, we kept the `dim_vars` in the `mlir.ModuleContext`. Now we replace that with a mutable `ShapePolyLoweringState` that also tracks whether we encounter shape polymorphism anywhere in the lowering. For this purpose, we also add `shape_poly_state` to the lowering.compile_args.

We need to keep track of whether a module contains dimension variables because such modules need shape refinement before they can be converted to MHLO and compiled. For now, we just test that we set the `Exported.module_uses_dim_vars` correctly.