### PR TITLE
[shape_poly] Improve compile-time shape checking. 

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -575,6 +575,18 @@ class GraphSerializationImpl(SerializationImpl):
         partial(shape_poly.compute_dim_vars_from_arg_shapes,
                 self.args_avals_flat, args_kwargs_tree=self.in_tree),
         self.args_flat_tf, self.args_avals_flat, self.name_stack)
+
+    # We invoke shape checking to give it a chance to raise shape errors that
+    # are evident statically. This should work in TF eager mode because all
+    # the shapes are known.
+    # TODO: handle non-static shape checking for graph serialization
+    acc_shape_check_messages: List[str] = []
+    _, _ = _interpret_fun_jax(
+        partial(shape_poly.compute_shape_check_from_arg_shapes,
+                self.args_avals_flat, args_kwargs_tree=self.in_tree,
+                acc_shape_check_messages=acc_shape_check_messages),
+        self.args_flat_tf, self.args_avals_flat, self.name_stack)
+
     _thread_local_state.shape_env = zip(dim_vars, dim_values)
 
     fun_flat_jax, out_tree_thunk = flatten_fun_jax(self.fun_jax, self.in_tree)


### PR DESCRIPTION
JAX shape polymorphism relies on implicit assumptions.
For example, when tracing with input specification `(a, a)`,
we assume that the first two dimensions have the same size
greater or equal to 1.

Here we extend the checking that these assumptions hold. When
we call an `Exported` module from jax, with `jax_export.call_exported`
we check these assumptions statically. However, when we
stage an `Exported` using `XlaCallModule` to be called from
TensorFlow, or when we use TF graph serialization we need
to check these assumptions when we execute and compile
the op (that is when the shapes are available).

To prepare for this compile-time shape checking we add
`Exported.shape_check_module` to produce a serialized
MLIR module containing the shape checking code. This
will be added in a future change to `XlaCallModule`.