### PR TITLE
DOC: fix doc formatting

### DIFF
--- a/docs/jax-101/05.1-pytrees.ipynb
+++ b/docs/jax-101/05.1-pytrees.ipynb
@@ -346,7 +346,7 @@
     "\n",
     "* [`jax.tree_util.tree_map_with_path`](https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.tree_map_with_path.html): Works similarly with `jax.tree_util.tree_map`, but the function also takes key paths as arguments.\n",
     "\n",
-    "* [`jax.tree_util.keystr`]((https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.keystr.html)): Given a general key path, returns a reader-friendly string expression.\n",
+    "* [`jax.tree_util.keystr`](https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.keystr.html): Given a general key path, returns a reader-friendly string expression.\n",
     "\n",
     "One use case is to print debugging information related to a certain leaf value:"
    ]

--- a/docs/jax-101/05.1-pytrees.md
+++ b/docs/jax-101/05.1-pytrees.md
@@ -199,7 +199,7 @@ The APIs for working with key paths are:
 
 * [`jax.tree_util.tree_map_with_path`](https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.tree_map_with_path.html): Works similarly with `jax.tree_util.tree_map`, but the function also takes key paths as arguments.
 
-* [`jax.tree_util.keystr`]((https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.keystr.html)): Given a general key path, returns a reader-friendly string expression.
+* [`jax.tree_util.keystr`](https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.keystr.html): Given a general key path, returns a reader-friendly string expression.
 
 One use case is to print debugging information related to a certain leaf value:
 


### PR DESCRIPTION
This should fix the readthedocs build, which appears to have been broken by #15382