### PR TITLE
Fix incorrect wrapped docstring of `jax.scipy.special.gamma`

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -42,7 +42,8 @@ def gammaln(x: ArrayLike) -> Array:
   return lax.lgamma(x)
 
 
-@_wraps(osp_special.gammaln, module='scipy.special')
+@_wraps(osp_special.gamma, module='scipy.special', lax_description="""\
+The JAX version only accepts real-valued inputs.""")
 def gamma(x: ArrayLike) -> Array:
   x, = promote_args_inexact("gamma", x)
   return lax.exp(lax.lgamma(x))


### PR DESCRIPTION
Fixes the docstring `jax.scipy.special.gamma`, which was wrapping `scipy.special.gammaln` by mistake (see [here](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.special.gamma.html#jax.scipy.special.gamma), fixed [here](https://jax--16224.org.readthedocs.build/en/16224/_autosummary/jax.scipy.special.gamma.html#jax.scipy.special.gamma)). Also adds a note that the function currently only accepts real inputs.