### PR TITLE
[shape_poly] Improve DimExpr comparison for "a - mod(b, a) >= 1"

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3747,9 +3747,6 @@ def roll(a: ArrayLike, shift: Union[ArrayLike, Sequence[int]],
     return roll(arr.ravel(), shift, 0).reshape(arr.shape)
   axis = _ensure_index_tuple(axis)
   axis = tuple(_canonicalize_axis(ax, arr.ndim) for ax in axis)
-  if not core.is_constant_shape(arr.shape):
-    # TODO(necula): support static roll for polymorphic shapes.
-    return _roll_dynamic(arr, asarray(shift), axis)
   try:
     shift = _ensure_index_tuple(shift)
   except TypeError:

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -233,9 +233,6 @@ class DimExprTest(tf_test_util.JaxToTfTestCase):
     self.assertEqual(((b + 1) // (a + 1)).bounds(), (0, np.PINF))
     self.assertEqual((-b // (a + 1)).bounds(), (np.NINF, -1))
 
-
-
-
     # Generate test cases for floordiv and mod: (a + N) // +-2, (N - a) // +-2
     # and then evaluate them for a = 1, 5, 10000
     div_mod_atoms = [
@@ -252,6 +249,14 @@ class DimExprTest(tf_test_util.JaxToTfTestCase):
         atom_val = atom.evaluate(dict(a=a_val))
         self.assertGreaterEqual(atom_val, lb)
         self.assertLessEqual(atom_val, ub)
+
+    # Inequalities involving mod and floordiv
+    self.assertEqual((5 - a % 5).bounds(), (1, 5))
+    self.assertEqual((-5 - a % (-5)).bounds(), (-5, -1))
+    self.assertEqual((a - 5 % a).bounds(), (1, np.PINF))
+    self.assertEqual((a - 5 % a).bounds(), (1, np.PINF))
+    self.assertEqual((3 * (a + b) - 5 % (3 * (a + b))).bounds(), (1, np.PINF))
+    self.assertEqual((- a + (b - 5) % a).bounds(), (np.NINF, -1))
 
   def test_poly_equal(self):
     a, b = shape_poly._parse_spec("a, b", (2, 3))
@@ -288,6 +293,7 @@ class DimExprTest(tf_test_util.JaxToTfTestCase):
     self.assertTrue((a // b) * b == a - a % b)
     self.assertTrue(2 * (a // b) * b * b == 2 * b * a - 2 * b * (a % b))
     self.assertTrue(a // (2 * b) * 2 * b == a - a % (2 * b))
+    self.assertTrue(a // (2 * b) * 2 * b + 2 * a == 3 * a - a % (2 * b))
 
   def test_poly_compare(self):
     a, b = shape_poly._parse_spec("a, b", (2, 3))


### PR DESCRIPTION
We add a simple mechanism for decomposing (or matching) a symbolic expression, and we use this to specialize the .bounds() method.

We also use it to clean up an older implementation of a transformation
```
   floordiv(a, b) * b = a - mod(a, b)
```