### PR TITLE
Update conv_transpose docstring to inform users about swapped spatial axes in kernel as compared to Keras

### DIFF
--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -298,8 +298,8 @@ def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
       channel axes of the kernel. This makes the output of this function identical
       to the gradient-derived functions like keras.layers.Conv2DTranspose
       applied to the same kernel. And if False, the spatial axes of the kernel used
-      are the reverse of the same in keras.layers.Conv2DTranspose.
-      For typical use in neural nets this is completely
+      are the reverse of that used by keras.layers.Conv2DTranspose applied to the
+      same kernel. For typical use in neural nets this is completely
       pointless and just makes input/output channel specification confusing.
     precision: Optional. Either ``None``, which means the default precision for
       the backend, a :class:`~jax.lax.Precision` enum value (``Precision.DEFAULT``,

--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -297,7 +297,9 @@ def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
     transpose_kernel: if True flips spatial axes and swaps the input/output
       channel axes of the kernel. This makes the output of this function identical
       to the gradient-derived functions like keras.layers.Conv2DTranspose
-      applied to the same kernel. For typical use in neural nets this is completely
+      applied to the same kernel. And if False, the spatial axes of the kernel used
+      are the reverse of the same in keras.layers.Conv2DTranspose.
+      For typical use in neural nets this is completely
       pointless and just makes input/output channel specification confusing.
     precision: Optional. Either ``None``, which means the default precision for
       the backend, a :class:`~jax.lax.Precision` enum value (``Precision.DEFAULT``,


### PR DESCRIPTION
Hey! I made this pull request to solve issue [#14337](https://github.com/google/jax/issues/14337). I have just updated the documentation of the `transpose_kernel` parameter of the `conv_transpose` function in [jax/_src/lax/convolution.py](https://github.com/google/jax/blob/main/jax/_src/lax/convolution.py) to inform users that the spatial axes of the kernel is swapped (as compared to the Keras convention) when `transpose_kernel` is not specified as True.