### PR TITLE
Fix typo in `check_same_dtypes` error message

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4683,7 +4683,7 @@ _JNP_FUNCTION_EQUIVALENTS = {
   'neg': 'negative',
   'nextafter': 'nextafter',
   'pow': 'float_power',
-  'rount': 'rount',
+  'round': 'round',
   'select': 'where',
   'shift_left': 'left_shift',
   'shift_right_logical': 'right_shift',


### PR DESCRIPTION
s/rount/round/