### PR TITLE
Change type annotation `builtins.list` to `typing.List` for Py38 compatibility

### DIFF
--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -674,7 +674,7 @@ def emit_tf_embedded_graph_custom_call(
   return results
 
 
-def add_to_call_tf_concrete_function_list(concrete_tf_fn: Any, call_tf_concrete_function_list: list[Any]) -> int:
+def add_to_call_tf_concrete_function_list(concrete_tf_fn: Any, call_tf_concrete_function_list: List[Any]) -> int:
   func_name = concrete_tf_fn.function_def.signature.name
   assert func_name not in [f.function_def.signature.name for f in call_tf_concrete_function_list]
   called_index = len(call_tf_concrete_function_list)


### PR DESCRIPTION
We observed that Jax 0.4.11 is supporting Py38 from [1], and the `builtins.list` type annotation is supported "from" Py39 [2].

This breaks our TFX OSS Py38 tests, and I would like to suggest this change to be applied "before" dropping the Py38 support of Jax.

[1] https://pypi.org/project/jax/
[2] https://www.python.org/downloads/release/python-390/