### PR TITLE
fix key opaque dtype physical HLO sharding

### DIFF
--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -1500,7 +1500,7 @@ def _wrap_with_spmd_op(name: str,
   else:
     backend_config = ""
   result_type = aval_to_ir_type(aval_out)
-  out_shape = aval_out.shape  # type: ignore
+  out_shape = core.physical_aval(aval_out).shape  # type: ignore
   if core.is_constant_shape(out_shape):
     result_shapes = None
   else:

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -470,7 +470,8 @@ class KeyTyRules:
       op_sharding_proto = op_sharding_proto.to_proto()
     new_op_sharding = op_sharding_proto.clone()
     tad = list(new_op_sharding.tile_assignment_dimensions)
-    tad.extend([1] * len(key_shape))
+    suffix = [tad.pop()] if op_sharding_proto.replicate_on_last_tile_dim else []
+    tad.extend([1] * len(key_shape) + suffix)
     new_op_sharding.tile_assignment_dimensions = tad
     return xc.HloSharding.from_proto(new_op_sharding)
 


### PR DESCRIPTION
... in the case where the last tile dimension is replicated, and thus needs to be preserved in the final position of the tile assignment dimensions.

fixes #16137

with @mattjj 