### PR TITLE
Expand RaggedAxis representation to support raggedly-shaped broadcasting

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1935,7 +1935,9 @@ def symbolic_equal_dim(d1: DimSize, d2: DimSize) -> bool:
   return handler.symbolic_equal(*ds)
 
 def symbolic_equal_one_of_dim(d1: DimSize, dlist: Sequence[DimSize]) -> bool:
-  if any(d1 is d for d in dlist): return True  # identical always implies equal
+  # TODO(reviewer): Is there a reason that `same_referent` wasn't
+  # included here before?
+  if any(d1 is d or same_referent(d1, d) for d in dlist): return True  # identical always implies equal
   handler, ds = _dim_handler_and_canonical(d1, *dlist)
   return any([handler.symbolic_equal(ds[0], d) for d in ds[1:]])
 

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1935,8 +1935,6 @@ def symbolic_equal_dim(d1: DimSize, d2: DimSize) -> bool:
   return handler.symbolic_equal(*ds)
 
 def symbolic_equal_one_of_dim(d1: DimSize, dlist: Sequence[DimSize]) -> bool:
-  # TODO(reviewer): Is there a reason that `same_referent` wasn't
-  # included here before?
   if any(d1 is d or same_referent(d1, d) for d in dlist): return True  # identical always implies equal
   handler, ds = _dim_handler_and_canonical(d1, *dlist)
   return any([handler.symbolic_equal(ds[0], d) for d in ds[1:]])

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2859,7 +2859,8 @@ def _broadcast_in_dim_batch_rule(batched_args, batch_dims, shape,
   new_shape = (stacked_size,) + _merge_dyn_shape(shape, dyn_limits)
   result = broadcast_in_dim(new_operand, new_shape, new_broadcast_dimensions)
   out_ragged_axes = [idx+1 for idx, s in enumerate(shape) if s is None]
-  out_bdim = batching.make_batch_axis(0, zip(out_ragged_axes, out_ragged_sizes))
+  out_bdim = batching.make_batch_axis(
+      result.ndim, 0, zip(out_ragged_axes, out_ragged_sizes))
   return result, out_bdim
 
 def _broadcast_in_dim_fwd_rule(eqn):

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3232,9 +3232,9 @@ def _squeeze_transpose_rule(t, operand, *, dimensions):
 def _squeeze_batch_rule(batched_args, batch_dims, *, dimensions):
   operand, = batched_args
   bdim, = batch_dims
-  operand = batching.moveaxis(operand, bdim, 0)
+  operand, bdim_out = batching.move_stacked_axis(operand, bdim, 0)
   dimensions = tuple(np.add(1, dimensions))
-  return squeeze(operand, dimensions=dimensions), 0
+  return squeeze(operand, dimensions=dimensions), bdim_out
 
 squeeze_p = standard_primitive(_squeeze_shape_rule, _squeeze_dtype_rule,
                                'squeeze')

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2836,10 +2836,10 @@ def _broadcast_in_dim_batch_rule(batched_args, batch_dims, shape,
     new_operand = operand
     new_broadcast_dimensions = tuple(np.add(1, broadcast_dimensions))
 
-  # TODO(reviewer) This section assumes that the shape of the operand
-  # is broadcast-compatible with the requested shape.  Where should
-  # that be checked, and what should be new rules be, in light of
-  # raggedness?
+  # TODO(mattjj,axch) This section assumes that the shape of the operand is
+  # broadcast-compatible with the requested shape.  We should tweak vmap to run
+  # the abstract_eval rule so this can be checked while the raggedness
+  # information is available.
   dyn_limits = []
   out_ragged_sizes = []
   for sizes, bdim in zip(dyn_shape, dyn_shape_bdims):

--- a/tests/dynamic_api_test.py
+++ b/tests/dynamic_api_test.py
@@ -1540,7 +1540,7 @@ class PileTest(jtu.JaxTestCase):
     self.assertAllClose(y, np.tile(np.array([3, 1, 4])[:, None, None], (7, 7)),
                         check_dtypes=False)
 
-  def test_broadcast_while_ragged(self):
+  def test_broadcast_in_dim_while_ragged(self):
     ins = lax.convert_element_type(jnp.array([3, 1, 4]), core.bint(5))
     def func(size):
       one_d = jnp.arange(size, dtype='int32')
@@ -1551,7 +1551,7 @@ class PileTest(jtu.JaxTestCase):
     data = jax.lax.broadcasted_iota('int32', (3, 5, 7), 1)
     self.assertAllClose(p.data, data)
 
-  def test_broadcast_to_ragged(self):
+  def test_broadcast_in_dim_to_ragged(self):
     ins = lax.convert_element_type(jnp.array([3, 1, 4]), core.bint(5))
     def func(size):
       one_d = jnp.arange(12, dtype='int32')
@@ -1562,7 +1562,7 @@ class PileTest(jtu.JaxTestCase):
     data = jax.lax.broadcasted_iota('int32', (3, 5, 12), 2)
     self.assertAllClose(p.data, data)
 
-  def test_broadcast_to_doubly_ragged(self):
+  def test_broadcast_in_dim_to_doubly_ragged(self):
     ins1 = lax.convert_element_type(jnp.array([3, 1, 4]), core.bint(5))
     ins2 = lax.convert_element_type(jnp.array([2, 5, 1]), core.bint(6))
     def func(size1, size2):
@@ -1584,6 +1584,28 @@ class PileTest(jtu.JaxTestCase):
     p = jax.vmap(func, out_axes=batching.pile_axis)(ins)
     self.assertIsInstance(p, batching.Pile)
     data = jax.lax.broadcasted_iota('int32', (3, 5), 1)
+    self.assertAllClose(p.data, data)
+
+  def test_broadcast_to_while_ragged(self):
+    ins = lax.convert_element_type(jnp.array([3, 1, 4]), core.bint(5))
+    def func(size):
+      one_d = jnp.arange(size, dtype='int32')
+      two_d = jnp.broadcast_to(one_d, (4, size))
+      return two_d
+    p = jax.vmap(func, out_axes=batching.pile_axis)(ins)
+    self.assertIsInstance(p, batching.Pile)
+    data = jax.lax.broadcasted_iota('int32', (3, 4, 5), 2)
+    self.assertAllClose(p.data, data)
+
+  def test_broadcast_to_doubly_ragged(self):
+    ins = lax.convert_element_type(jnp.array([3, 1, 4]), core.bint(5))
+    def func(size):
+      one_d = jnp.arange(size, dtype='int32')
+      two_d = jnp.broadcast_to(one_d, (size, size))
+      return two_d
+    p = jax.vmap(func, out_axes=batching.pile_axis)(ins)
+    self.assertIsInstance(p, batching.Pile)
+    data = jax.lax.broadcasted_iota('int32', (3, 5, 5), 2)
     self.assertAllClose(p.data, data)
 
 def pile_map(f):


### PR DESCRIPTION
Main content:
- Change `RaggedAxis` to allow multiple ragged axes keyed to one stacked axis, e.g., a stack of matrices with different sizes in each dimension.
- Update the batching rules for `broadcast_in_dim` and the implementation of `broadcast_to` to support ragged arguments and target shapes.

I flagged two particular points of uncertainty using `TODO(reviewer)` comments.