### PR TITLE
profiler_test.py fixes and add coverage to Cloud TPU CI

### DIFF
--- a/.github/workflows/cloud-tpu-ci-nightly.yml
+++ b/.github/workflows/cloud-tpu-ci-nightly.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Install JAX test requirements
         run: |
           pip install -r build/test-requirements.txt
+          pip install -r build/collect-profile-requirements.txt
       - name: Install JAX
         run: |
           pip uninstall -y jax jaxlib libtpu-nightly

--- a/build/collect-profile-requirements.txt
+++ b/build/collect-profile-requirements.txt
@@ -1,0 +1,4 @@
+tensorflow
+tensorboard-plugin-profile
+# Needed for the profile plugin to work without error
+protobuf<=3.20

--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -3,6 +3,7 @@ cloudpickle
 colorama>=0.4.4
 numpy>=1.21
 pillow>=9.1.0
+portpicker
 pytest-xdist
 wheel
 rich


### PR DESCRIPTION
* Add deps to test requirements, including in new `collect-profile-requirements.txt` (to avoid adding tensorflow to `test-requirements.txt`).
* Use correct Python executable `ProfilerTest.test_remote_profiler` (`python` sometimes defaults to python2)
* Run computations for longer in `ProfilerTest.test_remote_profiler`, othewise `collect_profile` sometimes misses it.