### PR TITLE
DOC: Clarify the behaviour of lax.switch with vmap.

### DIFF
--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -78,6 +78,11 @@ def switch(index, branches: Sequence[Callable], *operands,
       index = clamp(0, index, len(branches) - 1)
       return branches[index](*operands)
 
+  Internally this wraps XLA's `Conditional
+  <https://www.tensorflow.org/xla/operation_semantics#conditional>`_
+  operator. However, when transformed with :func:`~jax.vmap` to operate over a
+  batch of predicates, ``cond`` is converted to :func:`~jax.lax.select`.
+
   Args:
     index: Integer scalar type, indicating which branch function to apply.
     branches: Sequence of functions (A -> B) to be applied based on ``index``.


### PR DESCRIPTION
This is in-line with PR #13589, also related to #8409

Add explanation: `switch` will be converted to `select` when transformed with `vmap` in doc.