### PR TITLE
Fix `BatchTrace.process_call`.

### DIFF
--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -385,7 +385,7 @@ class BatchTrace(Trace):
     f_ = _update_annotation(f_, f.in_type, axis_size, self.axis_name, dims, [])
     vals_out = call_primitive.bind(f_, *vals, **params)
     src = source_info_util.current()
-    return [BatchTracer(self, v, d, src) for v, d in zip(vals_out, dims_out)]
+    return [BatchTracer(self, v, d, src) for v, d in zip(vals_out, dims_out())]
 
   def post_process_call(self, call_primitive, out_tracers, params):
     vals, dims, srcs = unzip3((t.val, t.batch_dim, t.source_info)


### PR DESCRIPTION
In the line below, `dims_out` is a thunk that produces output dimensions when called.

```python
f_, dims_out = batch_subtrace(f, self.main, tuple(dims))
```

However, `BatchTrace.process_call` forgets to call `dims_out()` and uses `dims_out` instead, which leads to an error:

```console
  File ".../jax/_src/interpreters/batching.py", line 388, in process_call
    return [BatchTracer(self, v, d, src) for v, d in zip(vals_out, dims_out)]
                                                     ^^^^^^^^^^^^^^^^^^^^^^^
jax._src.traceback_util.UnfilteredStackTrace: TypeError: 'function' object is not iterable
```

Calling `dims_out()` like other `BatchTrace` methods fixes the issue.

This issue appeared in JAX 0.4.12 and does not exist in JAX 0.4.11.

---

For reference, below is `BatchTrace.process_map`, which correctly calls `dims_out()` and avoids this issue.

https://github.com/google/jax/blob/c287b2a1db982f4fdce566405de35de275fb32a8/jax/_src/interpreters/batching.py#L399-L438