### PR TITLE
Expose unroll option supported in lax.scan into lax.map

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1787,7 +1787,7 @@ def fori_loop(lower, upper, body_fun, init_val):
 ### map and miscellaneous rules
 
 @api_boundary
-def map(f, xs):
+def map(f: Callable[[X], Y], xs: X, unroll: int = 1):
   """Map a function over leading array axes.
 
   Like Python's builtin map, except inputs and outputs are in the form of
@@ -1810,12 +1810,15 @@ def map(f, xs):
     f: a Python function to apply element-wise over the first axis or axes of
       ``xs``.
     xs: values over which to map along the leading axis.
+    unroll: optional positive int specifying, in the underlying operation of the
+      scan primitive, how many scan iterations to unroll within a single
+      iteration of a loop.
 
   Returns:
     Mapped values.
   """
   g = lambda _, x: ((), f(x))
-  _, ys = scan(g, (), xs)
+  _, ys = scan(g, (), xs, unroll=unroll)
   return ys
 
 def _rng_bit_generator_batching_rule(batched_args, batch_dims, *, shape, dtype, algorithm):


### PR DESCRIPTION
This is a trivial feature since PR #3738 has landed.

`map` is usually used when `vmap` can not be used due to memory constraint. Adding an `unroll` option would make the code at use site cleaner and performant, as #3076 has suggested ([here](https://github.com/google/jax/pull/3076#issuecomment-907898756)).

I checked other optional parameters in `lax.scan` as well, but they are not relevant to `map`.

Also this PR adds type hints for `map` following the same style of `scan`.