### PR TITLE
Cleanup: Remove unused variable in lax.scan test

### DIFF
--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -92,13 +92,6 @@ def scan_with_for(f, *args, **kwargs):
 def scan_with_remat_for(f, *args, **kwargs):
   return jax.remat(lambda *args: for_loop.scan(f, *args, **kwargs))(*args)
 
-SCAN_IMPLS = [
-    (lax.scan, 'unroll1'),
-    (partial(lax.scan, unroll=2), 'unroll2'),
-    (scan_with_new_checkpoint , 'new_checkpoint'),
-    (scan_with_new_checkpoint2, 'new_checkpoint2'),
-]
-
 SCAN_IMPLS_WITH_FOR = [
     (lax.scan, 'unroll1'),
     (partial(lax.scan, unroll=2), 'unroll2'),


### PR DESCRIPTION
The parameter `SCAN_IMPLS` seems not being used for over 10 months, and is replaced by `SCAL_IMPLS_WITH_FOR` fully. This is a result of several PRs: #11301, #11344, #11900, #11954 and #12149. This cleanup should make the codebase better.