### PR TITLE
[jax2tf] Add native_lowering_disabled_checks parameter to jax2tf.convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Remember to align the itemized text with the first line of an item within a list
   * Fixed incorrect wheel name in CUDA 12 releases (#16362); the correct wheel
     is named `cudnn89` instead of `cudnn88`.
 
+* Deprecations
+  * The `native_serialization_strict_checks` parameter to
+    {func}`jax.experimental.jax2tf.convert` is deprecated in favor of the
+    new `native_serializaation_disabled_checks` ({jax-issue}`#16347`).
+
 ## jaxlib 0.4.13
 
 ## jax 0.4.12 (June 8, 2023)

--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -96,7 +96,7 @@ for `jax2tf.call_tf`.
 For more involved examples, please see examples involving:
 
    * SavedModel for archival ([examples below](#usage-saved-model)), including
-     saving [batch-polymorphic functions](#shape-polymorphic-conversion), 
+     saving [batch-polymorphic functions](#shape-polymorphic-conversion),
    * TensorFlow Lite ([examples](https://github.com/google/jax/blob/main/jax/experimental/jax2tf/examples/tflite/mnist/README.md)),
    * TensorFlow.js ([examples](https://github.com/google/jax/blob/main/jax/experimental/jax2tf/examples/tf_js/quickdraw/README.md)),
    * TFX ([examples](https://github.com/tensorflow/tfx/blob/master/tfx/examples/penguin/README.md#instructions-for-using-flax)),
@@ -1563,8 +1563,10 @@ purposes of `call_tf`.)
 
 Inside Google, you can turn on logging by using the `--vmodule` argument to
 specify the logging levels for different modules,
-e.g., `--vmodule=jax_export=3`.
-following modules are useful for debugging JAX native serialization:
+e.g., `--vmodule=jax_export=3`. You can set `TF_DUMP_GRAPH_PREFIX` to
+a directory where modules should be dumped, or to `"-"` to dump the
+modules to the log.
+The following modules are useful for debugging JAX native serialization:
 
   * `jax_export=3` - will log the StableHLO module on serialization.
   * `jax2tf=3` - will log the parameters to `XlaCallModule` op on serialization.
@@ -1586,7 +1588,7 @@ TF_CPP_MIN_LOG_LEVEL=0 TF_CPP_VMODULE=xla_call_module_loader=3 python ...
 ```
 
 In addition, `TF_DUMP_GRAPH_PREFIX` controls where the dump will be stored, `-`
-for stderr, `${SOME_DIR}` to store the dumps in the specified directory. 
+for stderr, `${SOME_DIR}` to store the dumps in the specified directory.
 
 ## TensorFlow versions supported
 

--- a/jax/experimental/jax2tf/__init__.py
+++ b/jax/experimental/jax2tf/__init__.py
@@ -17,6 +17,7 @@ from jax.experimental.jax2tf.jax2tf import (
   eval_polymorphic_shape as eval_polymorphic_shape,
   dtype_of_val as dtype_of_val,
   split_to_logical_devices as split_to_logical_devices,
+  DisabledSafetyCheck as DisabledSafetyCheck,
   PolyShape as PolyShape
 )
 from jax.experimental.jax2tf.call_tf import call_tf as call_tf

--- a/jax/experimental/jax2tf/tests/call_tf_test.py
+++ b/jax/experimental/jax2tf/tests/call_tf_test.py
@@ -1415,7 +1415,7 @@ class RoundTripToTfTest(tf_test_util.JaxToTfTestCase):
 
     # Check the xla_call_module version and function_list attributes.
     xla_call_module = xla_call_module_list[0]
-    self.assertEqual(xla_call_module.attr["version"].i, 5)
+    self.assertGreaterEqual(xla_call_module.attr["version"].i, 5)
     self.assertIn("function_list", str(xla_call_module.attr))
     xla_call_module_list.clear()
     called_index_list.clear()

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -1536,8 +1536,7 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
       _ = func_to_convert(*args)
       exported = jax_export.export(
           func_to_convert,
-          lowering_platform='tpu',
-          strict_checks=True
+          lowering_platform='tpu'
       )(*(core.ShapedArray(a.shape, a.dtype) for a in args))
 
     if transform1 == "shard_map":
@@ -1574,7 +1573,8 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
       self.assertAllClose(jnp.sin(x), f_tf(x))
 
     f_tf = jax2tf.convert(jnp.sin,
-                          native_serialization_strict_checks=False)
+                          native_serialization_disabled_checks=(
+                            jax2tf.DisabledSafetyCheck.platform(),))
     self.assertAllClose(jnp.sin(x), f_tf(x))
 
   def test_native_serialization_grad(self):


### PR DESCRIPTION
Previously, we had a boolean parameter `native_lowering_strict_checks` that was disabling all safety checks. This mechanism had several disadvantages:

  * the mechanism did not differentiate between different safety checks. E.g., in order to disable checking of the custom call targets, one had to disable checking for all custom call targets, and also the checking that the serialization and execution platforms are the same.
  * the mechanism operated only at serialization time. Now, the XlaCallModule supports a `disabled_checks` attribute to control which safety checks should be disabled.

Here we replace the `native_serialization_strict_checks` with `native_serialization_disabled_checks`, whose values are sequences of disabled check descriptors.