### PR TITLE
Don't include the --subcommands on the Bazel command line for Windows…

### DIFF
--- a/.github/workflows/wheel_win_x64.yml
+++ b/.github/workflows/wheel_win_x64.yml
@@ -48,7 +48,7 @@ jobs:
             --noremote_build `
             --noenable_cuda `
             --configure_only 
-          bazel build --jobs=1 --subcommands `
+          bazel build --jobs=1 `
             --cxxopt="/Zm2000" `
             --verbose_failures `
             --jobs=1 `

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -41,7 +41,7 @@ jobs:
           python.exe build\build.py `
             --noremote_build `
             --configure_only 
-          bazel build --jobs=1 --subcommands `
+          bazel build --jobs=1 `
             --cxxopt="/Zm2000" `
             --verbose_failures `
             --jobs=1 `


### PR DESCRIPTION
… CI.

This makes the output very verbose.