### PR TITLE
Windows CI: write wheel into usual location.

### DIFF
--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -38,8 +38,7 @@ jobs:
         run: |
           python -m pip install -r build/test-requirements.txt
           "C:\\msys64\\;C:\\msys64\\usr\\bin\\;" >> $env:GITHUB_PATH
-          python.exe build\build.py `
-            --output_path=$(Join-Path -Path (Get-Location) -ChildPath "\tmp")
+          python.exe build\build.py
 
       - name: Run tests
         env:


### PR DESCRIPTION
Should fix installation failure.