### PR TITLE
Windows CI fixes:

### DIFF
--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -26,6 +26,11 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v3
+        path: jax
+
+      - uses: actions/checkout@v3
+        repository: openxla/xla
+        path: xla
 
       - uses: actions/setup-python@v4
         with:
@@ -36,23 +41,24 @@ jobs:
         env:
           BAZEL_VC: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC"
         run: |
-          git clone https://github.com/openxla/xla.git
+          cd jax
           python -m pip install -r build/test-requirements.txt
           "C:\\msys64\\;C:\\msys64\\usr\\bin\\;" >> $env:GITHUB_PATH
-          python.exe build\build.py --bazel_options=--override_repository=xla=${{ github.workspace }}\xla
+          python.exe build\build.py '--bazel_options=--override_repository=xla=${{ github.workspace }}\xla'
 
       - name: Run tests
         env:
           JAX_ENABLE_CHECKS: true
           JAX_SKIP_SLOW_TESTS: true
         run: |
-          python -m pip install -e ${{ github.workspace }}
-          python -m pip install --no-index --find-links ${{ github.workspace }}\dist jaxlib
+          cd jax
+          python -m pip install -e ${{ github.workspace }}\jax
+          python -m pip install --no-index --find-links ${{ github.workspace }}\jax\dist jaxlib
           echo "JAX_ENABLE_CHECKS=$JAX_ENABLE_CHECKS"
           pytest -n auto --tb=short tests examples
 
       - uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: ${{ github.workspace }}\dist\*.whl
+          path: ${{ github.workspace }}\jax\dist\*.whl
           retention-days: 5


### PR DESCRIPTION
* try single-quoting the bazel override path to avoid \ substitution.
* use a second github checkout action to checkout the XLA repository.