### PR TITLE
Fix FileExistsError for tests/gfile_cache_test.py::FileSystemCacheTest::test_threads

### DIFF
--- a/jax/_src/gfile_cache.py
+++ b/jax/_src/gfile_cache.py
@@ -48,8 +48,8 @@ class GFileCache(CacheInterface):
         f.write(value)
         f.flush()
         os.fsync(f.fileno())
-      os.rename(tmp_path, path_to_new_file)
+      os.replace(tmp_path, path_to_new_file)
     else:
       tmp_path = self._path / f"_temp_{key}"
       tmp_path.write_bytes(value)
-      tmp_path.rename(str(path_to_new_file))
+      tmp_path.replace(str(path_to_new_file))


### PR DESCRIPTION
Use os.replace() for cross-platform renaming with overwriting. See https://bugs.python.org/issue8828.
Note, per the implementation, it is not atomic on Windows as for UNIX.