### PR TITLE
Windows CI: don't fail-fast.

### DIFF
--- a/.github/workflows/wheel_win_x64.yml
+++ b/.github/workflows/wheel_win_x64.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   win-wheels:
     strategy:
-      fail-fast: true
+      fail-fast: false  # Don't stop all wheel builds if one has a test failure.
       matrix:
         os: [win-2019-16core]
         arch: [AMD64]


### PR DESCRIPTION
We expect some of the tests to fail at the moment, and we'd like all of the builds to run to completion even if one of them fails.