### PR TITLE
Fix invalid cond param linear of type str, tuple of bool required:\nmulti\nline

### DIFF
--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -41,6 +41,9 @@ def _typecheck_param(prim, param, name, msg_required, pred):
     msg = (f'invalid {prim} param {name} of type {type(param).__name__}, '
            f'{msg_required} required:')
     param_str = str(param)
+    # Avoid using os.linesep here to have the same multi-line error message
+    # format on different platforms.
+    sep = '\n' if '\n' in param_str or '\r' in param_str else ' '
     sep = os.linesep if os.linesep in param_str else ' '
     msg = sep.join([msg, param_str])
     raise core.JaxprTypeError(msg)


### PR DESCRIPTION
Fix test failure for `tests/lax_control_flow_test.py::LaxControlFlowTest::test_cond_typecheck_param`

```
...
      jaxpr, eqn = new_jaxpr()
      eqn.params['linear'] = 'multi\nline'
>     self.assertRaisesRegex(
          core.JaxprTypeError,
          r'invalid cond param linear of type str, '
          r'tuple of bool required:\nmulti\nline',
          lambda: core.check_jaxpr(jaxpr))
E     AssertionError: "invalid cond param linear of type str, tuple of bool required:\nmulti\nline" does not match "invalid cond param linear of type str, tuple of bool required: multi
E     line
E
E     in equation:
E
E     c:f32[] = cond[
E         branches=(
E           { lambda ; d:f32[]. let e:f32[] = sin d in (e,) }
E           { lambda ; f:f32[]. let g:f32[] = cos f in (g,) }
E         )
E         linear=multi
E     line
E       ] b a
...
```