### PR TITLE
[shape_poly] Fix the lowering of lax.dynamic_slice with shape poly

### DIFF
--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -2054,6 +2054,16 @@ _POLY_SHAPE_TEST_HARNESSES = [
                 lambda x, idx: lax.dynamic_slice(x, idx, (x.shape[0], 2)),
                 arg_descriptors=[RandArg((3, 4), _f32), np.array([-2, -1], dtype=np.int32)],
                 poly_axes=[0, None]).both_enable_and_disable_xla(),
+    PolyHarness("dynamic_slice", "idx=tuple_int_start_oob_large",
+                # x:shape: (b, 4)
+                lambda x: lax.dynamic_slice(x, (1, 1), (x.shape[0], 2)),
+                arg_descriptors=[RandArg((3, 4), _f32)],
+                poly_axes=[0]).both_enable_and_disable_xla(),
+    PolyHarness("dynamic_slice", "idx=tuple_int_start_oob_small",
+              # x:shape: (b, 4)
+              lambda x: lax.dynamic_slice(x, (-1, 1), (x.shape[0] - 1, 2)),
+              arg_descriptors=[RandArg((3, 4), _f32)],
+              poly_axes=[0]).both_enable_and_disable_xla(),
     PolyHarness("dynamic_slice_in_dim", "idx=0",
                 # x:shape: (b, 4)
                 lambda x: lax.dynamic_slice_in_dim(x, 0, x.shape[0], axis=0),


### PR DESCRIPTION
lax.dynamic_shapes clamps the start indices to ensure the access is in bounds, but when lowering with shape polymorphism we use stablehlo.RealDynamicSliceOp, which is a version of SliceOp and does not have the clamping. We clamp explicitly during lowering.

This changes the lowering in very limited circumstances: when we have a lax.dynamic_slice with shape polymorphism and a dynamic slice size, under native lowering only, and only when the start indices were out of bounds.