### PR TITLE
random.split: add optional shape parameter

### DIFF
--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -213,6 +213,26 @@ class PrngTest(jtu.JaxTestCase):
       self.assertEqual(key.dtype, jnp.dtype('uint32'))
       self.assertEqual(key.shape, impl.key_shape)
 
+  @jtu.sample_product(
+    num=(None, 6),
+    shape=(None, (6,), (2, 3))
+  )
+  def testSplitSizeShape(self, num, shape):
+    key = jax.random.PRNGKey(0)
+    key_split = jax.random.split(key, num, shape=shape)
+    if num is None and shape is None:
+      assert key_split.shape == (2, *key.shape)
+    elif shape is None:
+      assert key_split.shape == (num, *key.shape)
+    else:
+      assert key_split.shape == (*shape, *key.shape)
+
+  def testSplitSizeShapeMismatch(self):
+    key = jax.random.PRNGKey(0)
+    with self.assertRaisesRegex(
+        ValueError, r".*num=4 is incompatible with shape=\(2, 3\)"):
+      jax.random.split(key, 4, shape=(2, 3))
+
   def testThreefry2x32(self):
     # We test the hash by comparing to known values provided in the test code of
     # the original reference implementation of Threefry. For the values, see


### PR DESCRIPTION
Fixes #4013. Why now? This will aid in the transition to custom PRNG ( #9263) because it allows split keys to be reshaped without having to account for the intrinsic key dimension.

Suppose you'd like to create six keys, reshaped into batch dimensions of shape `(2, 3)`.

Before custom PRNG, you could write something like this, assuming you're using the default PRNG impl:
```python
keys = random.split(key, 6).reshape(2, 3, 2)
```
With custom PRNG, it must change to this:
```python
keys = random.split(key, 6).reshape(2, 3)
```
To write this operation in a way that is compatible with both requires something like this, which is somewhat ugly/unclear: 
```python
keys = random.split(key, 6).reshape(2, 3, *key.shape)
```
With this PR, we can instead write this and be compatible with both cases:
```python
keys = random.split(key, shape=(2, 3))
```
Regarding the API chosen here: I considered overloading the `num` parameter to also accept a tuple of integers, but I judged it cleaner to avoid that kind of polymorphism. I made `shape` a keyword-only argument for clarity.