### PR TITLE
CI nightly: update nightly wheel location

### DIFF
--- a/.github/workflows/upstream-nightly.yaml
+++ b/.github/workflows/upstream-nightly.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Install numpy & scipy development versions
         run: |
           pip install \
-            -i https://pypi.anaconda.org/scipy-wheels-nightly/simple \
+            -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
             --no-deps \
             --pre \
             --upgrade \


### PR DESCRIPTION
It looks like this is now the recommended location for nightly numpy/scipy wheels (see https://github.com/scipy/scipy/issues/18675#issuecomment-1590697109)