### PR TITLE
Errors: avoid printing tracer repr for concretization errors

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -596,24 +596,32 @@ class Tracer(typing.Array):
   __array_priority__ = 1000
   __slots__ = ['_trace', '_line_info']
 
+  def _error_repr(self):
+    if self.aval is None:
+      return f"traced array with aval {self.aval}"
+    return f"traced array with shape {raise_to_shaped(self.aval).str_short()}."
+
   def __array__(self, *args, **kw):
     raise TracerArrayConversionError(self)
 
   def __dlpack__(self, *args, **kw):
     raise ConcretizationTypeError(self,
-      f"The __dlpack__() method was called on the JAX Tracer object {self}")
+      f"The __dlpack__() method was called on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   def __index__(self):
     raise TracerIntegerConversionError(self)
 
   def tolist(self):
     raise ConcretizationTypeError(self,
-      f"The tolist() method was called on the JAX Tracer object {self}")
+      f"The tolist() method was called on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   def tobytes(self, order="C"):
     del order
     raise ConcretizationTypeError(self,
-      f"The tobytes() method was called on the JAX Tracer object {self}")
+      f"The tobytes() method was called on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   def __init__(self, trace: Trace):
     self._trace = trace
@@ -633,12 +641,14 @@ class Tracer(typing.Array):
     # Raising a ConcretizationTypeError would make sense, but for backward compatibility
     # we raise an AttributeError so that hasattr() and getattr() work as expected.
     raise AttributeError(self,
-      f"The 'sharding' attribute is not available on the JAX Tracer object {self}")
+      f"The 'sharding' attribute is not available on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   @property
   def addressable_shards(self):
     raise ConcretizationTypeError(self,
-      f"The 'addressable_shards' attribute is not available on the JAX Tracer object {self}")
+      f"The 'addressable_shards' attribute is not available on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   @property
   def at(self):
@@ -719,63 +729,76 @@ class Tracer(typing.Array):
   # Methods that are only valid for materialized arrays
   def addressable_data(self, index):
     raise ConcretizationTypeError(self,
-      f"The addressable_data() method was called on the JAX Tracer object {self}")
+      f"The addressable_data() method was called on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   @property
   def block_until_ready(self):
     # Raise AttribureError for backward compatibility with hasattr() and getattr() checks.
     raise AttributeError(self,
-      f"The 'block_until_ready' method is not available on the JAX Tracer object {self}")
+      f"The 'block_until_ready' method is not available on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   @property
   def copy_to_host_async(self):
     # Raise AttribureError for backward compatibility with hasattr() and getattr() checks.
     raise AttributeError(self,
-      f"The 'copy_to_host_async' method is not available on the JAX Tracer object {self}")
+      f"The 'copy_to_host_async' method is not available on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   def delete(self):
     raise ConcretizationTypeError(self,
-      f"The delete() method was called on the JAX Tracer object {self}")
+      f"The delete() method was called on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   def device(self):
     raise ConcretizationTypeError(self,
-      f"The device() method was called on the JAX Tracer object {self}")
+      f"The device() method was called on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   def devices(self):
     raise ConcretizationTypeError(self,
-      f"The devices() method was called on the JAX Tracer object {self}")
+      f"The devices() method was called on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   @property
   def global_shards(self):
     raise ConcretizationTypeError(self,
-      f"The global_shards property was called on the JAX Tracer object {self}")
+      f"The global_shards property was called on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   def is_deleted(self):
     raise ConcretizationTypeError(self,
-      f"The is_deleted() method was called on the JAX Tracer object {self}")
+      f"The is_deleted() method was called on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   @property
   def is_fully_addressable(self):
     raise ConcretizationTypeError(self,
-      f"The is_fully_addressable property was called on the JAX Tracer object {self}")
+      f"The is_fully_addressable property was called on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   @property
   def is_fully_replicated(self):
     raise ConcretizationTypeError(self,
-      f"The is_fully_replicated property was called on the JAX Tracer object {self}")
+      f"The is_fully_replicated property was called on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   def on_device_size_in_bytes(self):
     raise ConcretizationTypeError(self,
-      f"The on_device_size_in_bytes() method was called on the JAX Tracer object {self}")
+      f"The on_device_size_in_bytes() method was called on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   @property
   def traceback(self):
     raise ConcretizationTypeError(self,
-      f"The traceback property was called on the JAX Tracer object {self}")
+      f"The traceback property was called on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
   def unsafe_buffer_pointer(self):
     raise ConcretizationTypeError(self,
-      f"The unsafe_buffer_pointer() method was called on the JAX Tracer object {self}")
+      f"The unsafe_buffer_pointer() method was called on {self._error_repr()}."
+      f"{self._origin_msg()}")
 
 # these can be used to set up forwarding of properties and instance methods from
 # Tracer instances to the underlying avals

--- a/jax/_src/errors.py
+++ b/jax/_src/errors.py
@@ -185,7 +185,7 @@ class ConcretizationTypeError(JAXTypeError):
   def __init__(self, tracer: core.Tracer, context: str = ""):
     super().__init__(
         "Abstract tracer value encountered where concrete value is expected: "
-        f"{tracer}\n{context}{tracer._origin_msg()}\n")
+        f"{tracer._error_repr()}\n{context}{tracer._origin_msg()}\n")
 
 
 @export
@@ -288,7 +288,7 @@ class TracerArrayConversionError(JAXTypeError):
   on what a Tracer is). It typically occurs in one of a few situations.
 
   Using non-JAX functions in JAX transformations
-    This error can occur if you attempt to use a non-JAX library like `numpy`
+    This error can occur if you attempt to use a non-JAX library like ``numpy``
     or ``scipy`` inside a JAX transformation (:func:`~jax.jit`, :func:`~jax.grad`,
     :func:`jax.vmap`, etc.). For example::
 
@@ -303,7 +303,7 @@ class TracerArrayConversionError(JAXTypeError):
       Traceback (most recent call last):
           ...
       TracerArrayConversionError: The numpy.ndarray conversion method
-      __array__() was called on the JAX Tracer object
+      __array__() was called on traced array with shape int32[4]
 
     In this case, you can fix the issue by using :func:`jax.numpy.sin` in place of
     :func:`numpy.sin`::
@@ -321,8 +321,8 @@ class TracerArrayConversionError(JAXTypeError):
 
   Indexing a numpy array with a tracer
     If this error arises on a line that involves array indexing, it may be that
-    the array being indexed `x` is a standard numpy.ndarray while the indices `idx`
-    are traced JAX arrays. For example::
+    the array being indexed ``x`` is a standard numpy.ndarray while the indices
+    ``idx`` are traced JAX arrays. For example::
 
       >>> x = np.arange(10)
 
@@ -334,7 +334,7 @@ class TracerArrayConversionError(JAXTypeError):
       Traceback (most recent call last):
           ...
       TracerArrayConversionError: The numpy.ndarray conversion method
-      __array__() was called on the JAX Tracer object
+      __array__() was called on traced array with shape int32[0]
 
     Depending on the context, you may fix this by converting the numpy array
     into a JAX array::
@@ -365,7 +365,7 @@ class TracerArrayConversionError(JAXTypeError):
   def __init__(self, tracer: core.Tracer):
     super().__init__(
         "The numpy.ndarray conversion method __array__() was called on "
-        f"the JAX Tracer object {tracer}{tracer._origin_msg()}")
+        f"{tracer._error_repr()}{tracer._origin_msg()}")
 
 
 @export
@@ -389,8 +389,8 @@ class TracerIntegerConversionError(JAXTypeError):
       >>> func(np.arange(4), 0)  # doctest: +IGNORE_EXCEPTION_DETAIL
       Traceback (most recent call last):
           ...
-      TracerIntegerConversionError: The __index__() method was called on the JAX
-      Tracer object
+      TracerIntegerConversionError: The __index__() method was called on
+      traced array with shape int32[0]
 
     When this happens, the solution is often to mark the problematic argument as
     static::
@@ -431,7 +431,8 @@ class TracerIntegerConversionError(JAXTypeError):
       >>> func(0)  # doctest: +IGNORE_EXCEPTION_DETAIL
       Traceback (most recent call last):
           ...
-      TracerIntegerConversionError: The __index__() method was called on the JAX Tracer object
+      TracerIntegerConversionError: The __index__() method was called on
+      traced array with shape int32[0]
 
     Depending on the context, you can generally fix this either by converting
     the list to a JAX array::
@@ -459,7 +460,8 @@ class TracerIntegerConversionError(JAXTypeError):
   """
   def __init__(self, tracer: core.Tracer):
     super().__init__(
-        f"The __index__() method was called on the JAX Tracer object {tracer}")
+        f"The __index__() method was called on {tracer._error_repr()}"
+        f"{tracer._origin_msg()}")
 
 
 @export

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1484,7 +1484,7 @@ class APITest(jtu.JaxTestCase):
     assert jit(f, static_argnums=(0,))(0) == L[0]
     self.assertRaisesRegex(
         TypeError,
-        r"The __index__\(\) method was called on the JAX Tracer object.*",
+        r"The __index__\(\) method was called on traced array.*",
         lambda: jit(f)(0))
 
   def test_range_err(self):
@@ -1496,7 +1496,7 @@ class APITest(jtu.JaxTestCase):
     assert jit(f, static_argnums=(1,))(0, 5) == 10
     self.assertRaisesRegex(
         TypeError,
-        r"The __index__\(\) method was called on the JAX Tracer object.*",
+        r"The __index__\(\) method was called on traced array.*",
         lambda: jit(f)(0, 5))
 
   def test_cast_int(self):
@@ -1511,7 +1511,7 @@ class APITest(jtu.JaxTestCase):
       f = lambda x: castfun(x)
       self.assertRaisesRegex(
           TypeError,
-          r"The __index__\(\) method was called on the JAX Tracer object.*", lambda: jit(f)(0))
+          r"The __index__\(\) method was called on traced array.*", lambda: jit(f)(0))
 
   def test_unimplemented_interpreter_rules(self):
     foo_p = core.Primitive('foo')

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -4928,7 +4928,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testToBytesJitError(self):
     v = np.arange(12, dtype=np.int32).reshape(3, 4)
     f = jax.jit(lambda x: x.tobytes())
-    msg = r".*The tobytes\(\) method was called on the JAX Tracer object"
+    msg = r".*The tobytes\(\) method was called on traced array"
     with self.assertRaisesRegex(core.ConcretizationTypeError, msg):
       f(v)
 
@@ -4939,7 +4939,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testToListJitError(self):
     v = np.arange(12, dtype=np.int32).reshape(3, 4)
     f = jax.jit(lambda x: x.tolist())
-    msg = r".*The tolist\(\) method was called on the JAX Tracer object"
+    msg = r".*The tolist\(\) method was called on traced array"
     with self.assertRaisesRegex(core.ConcretizationTypeError, msg):
       f(v)
 


### PR DESCRIPTION
The full tracer repr is rarely helpful. Here's an example of the current behavior:
```python
import jax
import numpy as np

@jax.grad
def sum_sin(x):
  return np.sin(x).sum()

sum_sin(np.random.randn(10, 10))
```
```pytb
jax.errors.TracerArrayConversionError: The numpy.ndarray conversion method __array__() was called on the JAX Tracer object Traced<ConcreteArray([[ 1.0571735   0.0440403  -0.23343705  0.95599681  0.28299336 -0.0098045
   0.12151756  0.76139765  0.46330835 -1.74211435]
 [ 1.09851478  0.47966261  1.25234831 -0.09094748  1.55391084 -1.27840149
  -0.3978845   2.0043795  -0.32312173  0.6580057 ]
 [-0.01309867 -0.9268315   0.21376577  3.0703807   0.377359   -0.42559635
  -0.21421879  0.04693396  1.91978567  2.96202774]
 [ 0.60268684  2.08358676  0.17348753 -0.82481748 -1.35939656  0.03508975
   0.51151781 -0.10885926  1.32747007 -0.40655023]
 [-0.44808506  0.25314046 -0.23842131 -1.52859064 -0.50329484  0.8484657
  -0.60516379 -0.7950479   0.54331745 -1.13217281]
 [ 0.76083012 -0.10592252  0.66773773 -2.80284785 -0.49745775  1.91657703
   0.15262782  1.22338914 -0.49593778  0.14990106]
 [-0.33246581  0.79084492  0.53033973  1.63779586 -0.25660609 -0.08625574
  -0.52179116 -0.9604968   0.66293027  0.89933985]
 [ 0.39507027  0.02963277 -0.27290613  0.49380279 -1.38089001  1.20947103
   1.82146182 -0.20944454  1.99964929 -0.74383492]
 [ 0.52780041  1.06396082  1.55812848 -0.09604877  1.25605771  0.97010621
   0.66573957 -0.67517096 -0.94860548  0.53076209]
 [-0.57659766 -1.38717229  0.95182264  0.32474039 -0.86295082 -0.32853092
   0.41360607 -0.97074471  0.99456903  0.05333148]], dtype=float32)>with<JVPTrace(level=2/0)> with
  primal = array([[ 1.0571735 ,  0.0440403 , -0.23343705,  0.95599681,  0.28299336,
        -0.0098045 ,  0.12151756,  0.76139765,  0.46330835, -1.74211435],
       [ 1.09851478,  0.47966261,  1.25234831, -0.09094748,  1.55391084,
        -1.27840149, -0.3978845 ,  2.0043795 , -0.32312173,  0.6580057 ],
       [-0.01309867, -0.9268315 ,  0.21376577,  3.0703807 ,  0.377359  ,
        -0.42559635, -0.21421879,  0.04693396,  1.91978567,  2.96202774],
       [ 0.60268684,  2.08358676,  0.17348753, -0.82481748, -1.35939656,
         0.03508975,  0.51151781, -0.10885926,  1.32747007, -0.40655023],
       [-0.44808506,  0.25314046, -0.23842131, -1.52859064, -0.50329484,
         0.8484657 , -0.60516379, -0.7950479 ,  0.54331745, -1.13217281],
       [ 0.76083012, -0.10592252,  0.66773773, -2.80284785, -0.49745775,
         1.91657703,  0.15262782,  1.22338914, -0.49593778,  0.14990106],
       [-0.33246581,  0.79084492,  0.53033973,  1.63779586, -0.25660609,
        -0.08625574, -0.52179116, -0.9604968 ,  0.66293027,  0.89933985],
       [ 0.39507027,  0.02963277, -0.27290613,  0.49380279, -1.38089001,
         1.20947103,  1.82146182, -0.20944454,  1.99964929, -0.74383492],
       [ 0.52780041,  1.06396082,  1.55812848, -0.09604877,  1.25605771,
         0.97010621,  0.66573957, -0.67517096, -0.94860548,  0.53076209],
       [-0.57659766, -1.38717229,  0.95182264,  0.32474039, -0.86295082,
        -0.32853092,  0.41360607, -0.97074471,  0.99456903,  0.05333148]])
  tangent = Traced<ShapedArray(float32[10,10])>with<JaxprTrace(level=1/0)> with
    pval = (ShapedArray(float32[10,10]), None)
    recipe = LambdaBinding()
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.TracerArrayConversionError
```
And after this PR:
```pytb
jax.errors.TracerArrayConversionError: The numpy.ndarray conversion method __array__() was called on traced array with shape float32[10, 10].
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.TracerArrayConversionError
```