### PR TITLE
Remove matplotlib from the test requirements.

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,7 +1,6 @@
 absl-py
 cloudpickle
 colorama>=0.4.4
-matplotlib
 pillow>=9.1.0
 pytest-xdist
 wheel

--- a/tests/lobpcg_test.py
+++ b/tests/lobpcg_test.py
@@ -25,7 +25,6 @@ import os
 from absl.testing import absltest
 from absl.testing import parameterized
 import numpy as np
-from matplotlib import pyplot as plt
 import scipy.linalg as sla
 import scipy.sparse as sps
 
@@ -284,6 +283,11 @@ class LobpcgTest(jtu.JaxTestCase):
     self._debug_plots(X, eigs, info, matrix_name, plot_dir)
 
   def _debug_plots(self, X, eigs, info, matrix_name, lobpcg_debug_plot_dir):
+    # We import matplotlib lazily because (a) it's faster this way, and
+    # (b) concurrent imports of matplotlib appear to trigger some sort of
+    # collision on the matplotlib cache lock on Windows.
+    from matplotlib import pyplot as plt
+
     os.makedirs(lobpcg_debug_plot_dir, exist_ok=True)
     clean_matrix_name = _clean_matrix_name(matrix_name)
     n, k = X.shape


### PR DESCRIPTION
In the Windows CI, we seem to be hitting the following error:

```
=================================== ERRORS ====================================
____________________ ERROR collecting tests/lobpcg_test.py ____________________
tests\lobpcg_test.py:28: in <module>
    from matplotlib import pyplot as plt
C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\matplotlib\pyplot.py:52: in <module>
    import matplotlib.colorbar
C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\matplotlib\colorbar.py:19: in <module>
    from matplotlib import _api, cbook, collections, cm, colors, contour, ticker
C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\matplotlib\contour.py:13: in <module>
    from matplotlib.backend_bases import MouseButton
C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\matplotlib\backend_bases.py:45: in <module>
    from matplotlib import (
C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\matplotlib\text.py:16: in <module>
    from .font_manager import FontProperties
C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\matplotlib\font_manager.py:1548: in <module>
    fontManager = _load_fontmanager()
C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\matplotlib\font_manager.py:1543: in _load_fontmanager
    json_dump(fm, fm_path)
C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\matplotlib\font_manager.py:957: in json_dump
    with cbook._lock_path(filename), open(filename, 'w') as fh:
C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\contextlib.py:119: in __enter__
    return next(self.gen)
C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\matplotlib\cbook\__init__.py:1804: in _lock_path
    with lock_path.open("xb"):
C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\pathlib.py:1252: in open
    return io.open(self, mode, buffering, encoding, errors, newline,
C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\pathlib.py:1120: in _opener
    return self._accessor.open(self, flags, mode)
E   PermissionError: [Errno 13] Permission denied: 'C:\\Users\\runneradmin\\.matplotlib\\fontlist-v330.json.matplotlib-lock'
```

The use of matplotlib is only for an optional debugging feature anyway, so just make it an optional dependency.