### PR TITLE
Add NumPy as a test requirement.

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,6 +1,7 @@
 absl-py
 cloudpickle
 colorama>=0.4.4
+numpy>=1.21
 pillow>=9.1.0
 pytest-xdist
 wheel


### PR DESCRIPTION
The Windows CI currently installs all of the test requirements before building jaxlib, but NumPy is needed to build jaxlib. Previously this came transitively via matplotlib.