### PR TITLE
Made scatter-transpose more efficient

### DIFF
--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -1981,12 +1981,10 @@ def _scatter_transpose_rule(t, operand, indices, updates, *,
     operand_t = update_t = None
     if ad.is_undefined_primal(operand):
       # Zero out gradient entries that correspond to updated indices.
-      mask = scatter(lax._ones(t, dtype=np.bool_), indices,
-                     lax.full(updates_shape, False),
-                     dimension_numbers=dimension_numbers,
-                     indices_are_sorted=indices_are_sorted,
-                     unique_indices=True, mode=mode)
-      operand_t = lax.select(mask, t, lax._zeros(t))
+      operand_t = scatter(t, indices, lax.full(updates_shape, 0, dtype=t.dtype),
+                          dimension_numbers=dimension_numbers,
+                          indices_are_sorted=indices_are_sorted,
+                          unique_indices=True, mode=mode)
 
     if ad.is_undefined_primal(updates):
       gather_dnums = GatherDimensionNumbers(


### PR DESCRIPTION
Running locally, this speeds up the following MWE from `0.052` seconds to `0.014` seconds.

```python
import functools as ft
import jax
import jax.lax as lax
import jax.numpy as jnp
import jax.random as jr
import timeit

@ft.partial(jax.jit, static_argnums=1)
@jax.grad
def f(p0, n):
    P = jnp.concatenate([p0[None], jnp.empty([n - 1, 10, 10])])

    def body(P, i):
        return P.at[i].set(P[i - 1]), None

    P, _ = lax.scan(body, P, jnp.arange(1, n))
    return jnp.sum(P[-1])


p0 = jr.normal(jr.PRNGKey(0), (10, 10))
elapsed = min(timeit.repeat(lambda: f(p0, 800), number=1, repeat=10))
print(elapsed)
```