### PR TITLE
errors: create TracerBoolConversionError for more targeted debugging tips

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -9,5 +9,6 @@ along with representative examples of how one might fix them.
 .. autoclass:: ConcretizationTypeError
 .. autoclass:: NonConcreteBooleanIndexError
 .. autoclass:: TracerArrayConversionError
+.. autoclass:: TracerBoolConversionError
 .. autoclass:: TracerIntegerConversionError
 .. autoclass:: UnexpectedTracerError

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -41,7 +41,7 @@ from jax._src import config as jax_config
 from jax._src import effects
 from jax._src.config import FLAGS, config
 from jax._src.errors import (
-    ConcretizationTypeError, TracerArrayConversionError,
+    ConcretizationTypeError, TracerArrayConversionError, TracerBoolConversionError,
     TracerIntegerConversionError, UnexpectedTracerError)
 from jax._src import linear_util as lu
 
@@ -1366,8 +1366,12 @@ def concretization_function_error(fun, suggest_astype=False):
     fname_context += ("If trying to convert the data type of a value, "
                       f"try using `x.astype({fun.__name__})` "
                       f"or `jnp.array(x, {fun.__name__})` instead.")
-  def error(self, arg):
-    raise ConcretizationTypeError(arg, fname_context)
+  if fun is bool:
+    def error(self, arg):
+      raise TracerBoolConversionError(arg)
+  else:
+    def error(self, arg):
+      raise ConcretizationTypeError(arg, fname_context)
   return error
 
 def concrete_or_error(force: Any, val: Any, context=""):

--- a/jax/errors.py
+++ b/jax/errors.py
@@ -21,6 +21,7 @@ from jax._src.errors import (
   ConcretizationTypeError as ConcretizationTypeError,
   NonConcreteBooleanIndexError as NonConcreteBooleanIndexError,
   TracerArrayConversionError as TracerArrayConversionError,
+  TracerBoolConversionError as TracerBoolConversionError,
   TracerIntegerConversionError as TracerIntegerConversionError,
   UnexpectedTracerError as UnexpectedTracerError,
 )

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1473,7 +1473,7 @@ class APITest(jtu.JaxTestCase):
     assert grad(f)(1.0) == 1.0
     assert grad(f)(-1.0) == -1.0
     with self.assertRaisesRegex(core.ConcretizationTypeError,
-                                "Abstract tracer value"):
+                                "Attempted boolean conversion"):
       jit(f)(1)
 
   def test_list_index_err(self):


### PR DESCRIPTION
boolean conversion is its own class of tracer error, because it so often occurs implicitly during control flow. This PR makes boolean conversions its own error class, with more targeted debugging tips on the linked docs.

~This will need an update if #16404 is merged first.~ Rebased.