### PR TITLE
Update incorrect Dirichlet PDF in documentation

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -947,7 +947,7 @@ def dirichlet(key: KeyArray,
   The values are distributed according the the probability density function:
 
   .. math::
-     f(\{x_i\}; \{\alpha_i\}) = \propto \prod_{i=1}^k x_i^{\alpha_i}
+     f(\{x_i\}; \{\alpha_i\}) = \propto \prod_{i=1}^k x_i^{\alpha_i - 1}
 
   Where :math:`k` is the dimension, and :math:`\{x_i\}` satisfies
 


### PR DESCRIPTION
The PDF listed in the documentation of the jax.random.dirichlet function is wrong, the exponent should be \alpha_i - 1 instead of \alpha_i. Here is the Wikipedia article for reference: https://en.wikipedia.org/wiki/Dirichlet_distribution 
While the parametrization currently listed would in principle also be a valid parametrization \alpha_i > -1 would need to be allowed but currently result in nan. More importantly, the sampling method used is the one corresponding to Wikipedia's parametrization.