### PR TITLE
Add `ClosedJaxpr.{const,in,out}vars` forwarding properties.

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2903,6 +2903,10 @@ def _check_call(ctx_factory, prim, in_atoms, params):
         f"Call primitive {prim} missing 'call_jaxpr' parameter")
   call_jaxpr = params["call_jaxpr"]
 
+  # Handle `closed_call`.
+  if isinstance(call_jaxpr, ClosedJaxpr):
+    call_jaxpr = call_jaxpr.jaxpr
+
   if len(in_atoms) != len(call_jaxpr.invars):
     raise JaxprTypeError(f"Call primitive {prim} with {len(in_atoms)} "
                          f"operands cannot call jaxpr with "

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -183,6 +183,18 @@ class ClosedJaxpr:
     self._consts = list(consts)
 
   @property
+  def constvars(self):
+    return self.jaxpr.constvars
+
+  @property
+  def invars(self):
+    return self.jaxpr.invars
+
+  @property
+  def outvars(self):
+    return self.jaxpr.outvars
+
+  @property
   def in_avals(self):
     return [v.aval for v in self.jaxpr.invars]
 
@@ -2902,10 +2914,6 @@ def _check_call(ctx_factory, prim, in_atoms, params):
     raise JaxprTypeError(
         f"Call primitive {prim} missing 'call_jaxpr' parameter")
   call_jaxpr = params["call_jaxpr"]
-
-  # Handle `closed_call`.
-  if isinstance(call_jaxpr, ClosedJaxpr):
-    call_jaxpr = call_jaxpr.jaxpr
 
   if len(in_atoms) != len(call_jaxpr.invars):
     raise JaxprTypeError(f"Call primitive {prim} with {len(in_atoms)} "


### PR DESCRIPTION
`ClosedJaxpr` already defines many properties (like `in_avals` and `out_avals` and `effects`) that forward properties from its underlying `Jaxpr`.

This PR adds a few more:

```python
class ClosedJaxpr:
  ...

  @property
  def constvars(self):
    return self.jaxpr.constvars

  @property
  def invars(self):
    return self.jaxpr.invars

  @property
  def outvars(self):
    return self.jaxpr.outvars
```

Duck-typed functions like `_check_call` now work with `call_jaxpr: ClosedJaxpr` values without any other changes. Previously, they would fall with an error:

```
  File ".../venv/lib/python3.11/site-packages/jax/_src/core.py", line 2713, in check_jaxpr
    _check_jaxpr(ctx_factory, jaxpr)
  File ".../venv/lib/python3.11/site-packages/jax/_src/core.py", line 2788, in _check_jaxpr
    out_type, eqn_effects = _check_call(ctx_factory, prim, in_atoms,
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...//venv/lib/python3.11/site-packages/jax/_src/core.py", line 2904, in _check_call
    if len(in_atoms) != len(call_jaxpr.invars):
                            ^^^^^^^^^^^^^^^^^
jax._src.traceback_util.UnfilteredStackTrace: AttributeError: 'ClosedJaxpr' object has no attribute 'invars'

The stack trace below excludes JAX-internal frames.
The preceding is the original exception that occurred, unmodified.
```

Adding these properties is cleaner than adding ad-hoc `isinstance(call_jaxpr, ClosedJaxpr)` checks in functions like `core._check_call`.

Note: `core._check_call` isn't currently called for `closed_call_p` since it has its own custom typechecking rule. This change would make typechecking work for `closed_call_p` even if `custom_typechecks[closed_call_p]` were removed.

---

This is helpful for a JAX-based research project that adds a custom primitive subclassing `ClosedCallPrimitive`, but that wants to avoid defining a new typechecking rule and reuse `core._check_call` instead.