### PR TITLE
[shape_poly] Refactor and simplify tests.

### DIFF
--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -30,6 +30,7 @@ import jax
 from jax import core
 from jax.experimental import jax2tf
 from jax.experimental.jax2tf import shape_poly
+from jax.experimental.jax2tf import jax_export
 from jax.experimental import pjit
 from jax import lax
 import jax.numpy as jnp
@@ -413,9 +414,8 @@ class PolyHarness(Harness):
                fun: Callable,
                *,
                arg_descriptors: Sequence[primitive_harness.ArgDescriptor] = (),
-               polymorphic_shapes: Optional[Sequence[Any]] = None,
+               polymorphic_shapes: Sequence[Optional[str]] = (),
                input_signature: Optional[Sequence[tf.TensorSpec]] = None,
-               poly_axes: Optional[Sequence[Optional[Union[int, Sequence[int]]]]] = None,
                expected_output_signature: Optional[tf.TensorSpec] = None,
                enable_xla: bool = True,
                expect_error: Tuple[Optional[Any], Optional[str]] = (None, None),
@@ -431,21 +431,10 @@ class PolyHarness(Harness):
         static arguments from `arg_descriptors`. See `Harness.__init__`.
       arg_descriptors: The argument descriptors. See `Harness.__init__`. May
         be missing, in which case `skip_jax_run` should be `True` and
-        `poly_axes` cannot be used.
-      polymorphic_shapes: For `jax2tf.convert`. If missing, generated from
-        `poly_axes`.
+        `input_signature` must be present.
+      polymorphic_shapes: For `jax2tf.convert`.
       input_signature: For `tf.function.get_concrete_function`. If missing,
-        generated from `poly_axes`.
-      poly_axes: If present, used to generate `polymorphic_shapes` and
-        `input_signature`. Must correspond to the non-static arguments, and for
-        each one it must specify which axes are polymorphic: None, or an int
-        (for the index of the polymorphic axis), or a tuple of ints
-        (for multiple polymorphic axes). For each argument, we use its
-        `poly_axes` entry to generate the polymorphic_shapes specification,
-        creating dimension variables `b0`, `b1, ..., for each of its polymorphic
-        axes. This means that separate arguments will share the same dimension
-        variable names, in the order in which the axes are listed in
-        `poly_axes`. We also generate the input_signature from `poly_axes`.
+        generated from `polymorphic_shapes`.
       expected_output_signature: the expected inferred output shape.
       enable_xla: For `jax2tf.convert`.
       expect_error: a pair of an Exception type and a regular expression to
@@ -462,7 +451,6 @@ class PolyHarness(Harness):
     """
     super().__init__(group_name, name, fun, arg_descriptors,
                      dtype=np.float32)
-    self.poly_axes = poly_axes
     self.polymorphic_shapes = polymorphic_shapes
     self.input_signature = input_signature
     self.expected_output_signature = expected_output_signature
@@ -481,7 +469,6 @@ class PolyHarness(Harness):
                         f"{self.name}_enable_xla=False",
                         self.fun,
                         arg_descriptors=self.arg_descriptors,
-                        poly_axes=self.poly_axes,
                         polymorphic_shapes=self.polymorphic_shapes,
                         input_signature=self.input_signature,
                         expected_output_signature=self.expected_output_signature,
@@ -500,49 +487,25 @@ class PolyHarness(Harness):
       tst.assertEqual(getattr(jax.config, fname), fvalue, (
           f"Flag {fname} current value {getattr(jax.config, fname)} != {fvalue}"))
 
-    # Make polymorphic_shapes and input_signature from poly_axes.
-    if self.poly_axes is None:
-      polymorphic_shapes = self.polymorphic_shapes
-      input_signature = self.input_signature
-      assert input_signature is not None
-      if not self.skip_jax_run:
-        args = self.dyn_args_maker(tst.rng())
-
-    else:
-      assert isinstance(self.poly_axes, Sequence)
-      # Make poly_axes: Sequence[Sequence[int]], one top-level element for each argument
-      poly_axes = tuple(map(lambda pa: pa if isinstance(pa, Sequence) or pa is None else (pa,),
-                            self.poly_axes))
+    tst.assertIsNotNone(self.polymorphic_shapes)
+    polymorphic_shapes = self.polymorphic_shapes
+    if not self.skip_jax_run:
       args = self.dyn_args_maker(tst.rng())
+    else:
+      tst.assertIsNotNone(self.input_signature)
 
-      assert self.polymorphic_shapes is None
-      assert self.input_signature is None
-      assert args is not None and len(args) == len(poly_axes)
-      # Make the polymorphic_shapes and input_signature
-      polymorphic_shapes = []
-      input_signature = []
-      for arg, poly_axis in zip(args, poly_axes):
-        if poly_axis is None:
-          polymorphic_shapes.append(None)
-          input_signature.append(tf.TensorSpec(np.shape(arg), arg.dtype))
-        else:
-          def make_arg_polymorphic_shapes(poly_axis: Sequence[int]) -> Tuple[str, tf.TensorSpec]:
-            idx = -1
-            dims = []
-            tensorspec_dims: List[Optional[int]] = []
-            for i, d in enumerate(arg.shape):
-              if i in poly_axis:
-                idx += 1
-                dims.append(f"b{idx}")
-                tensorspec_dims.append(None)
-              else:
-                dims.append(str(d))
-                tensorspec_dims.append(d)
-            return ", ".join(dims), tf.TensorSpec(tensorspec_dims, arg.dtype)
-
-          arg_polymorphic_shapes, arg_tensorspec = make_arg_polymorphic_shapes(poly_axis)
-          polymorphic_shapes.append(arg_polymorphic_shapes)
-          input_signature.append(arg_tensorspec)
+    if self.input_signature is None:
+      tst.assertEqual(
+        len(polymorphic_shapes), len(args),
+        f"polymorphic_shapes {polymorphic_shapes} of length "
+        f"{len(polymorphic_shapes)} must match number of arguments {len(args)}")
+      args_specs = jax_export.poly_specs(args, polymorphic_shapes)
+      input_signature = [
+        tf.TensorSpec(
+            [d if isinstance(d, int) else None for d in a.shape],
+            dtype=a.dtype) for a in args_specs]
+    else:
+      input_signature = self.input_signature  # type: ignore
 
     expect_error_type, expect_error_regex = self.expect_error
     if self.skip_jax_run and not self.arg_descriptors:
@@ -609,15 +572,14 @@ class PolyHarness(Harness):
 def check_shape_poly(tst, f_jax: Callable, *,
                      arg_descriptors: Sequence[primitive_harness.ArgDescriptor] = (),
                      skip_jax_run: bool = False,
-                     poly_axes = None,
-                     polymorphic_shapes: Optional[Sequence[Any]] = None,
+                     polymorphic_shapes: Sequence[Optional[str]] = (),
                      input_signature: Optional[Sequence[tf.TensorSpec]] = None,
                      expected_output_signature: Optional[tf.TensorSpec] = None,
                      expect_error=(None, None)):
   # Makes and tests a harness. See PolyHarness documentation.
   h = PolyHarness("", "", f_jax,
                   arg_descriptors=arg_descriptors,
-                  skip_jax_run=skip_jax_run, poly_axes=poly_axes,
+                  skip_jax_run=skip_jax_run,
                   polymorphic_shapes=polymorphic_shapes,
                   input_signature=input_signature,
                   expected_output_signature=expected_output_signature,
@@ -636,29 +598,25 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     check_shape_poly(self,
                      f_jax,
                      arg_descriptors=[RandArg((2, 3), _f32)],
-                     input_signature=[tf.TensorSpec([2, 3])],
-                     polymorphic_shapes=None,
+                     polymorphic_shapes=[None],
                      expected_output_signature=tf.TensorSpec([2, 3]))
 
     check_shape_poly(self,
                      f_jax,
                      arg_descriptors=[RandArg((2, 3), _f32)],
-                     input_signature=[tf.TensorSpec([2, None])],
                      polymorphic_shapes=["_, h"],
                      expected_output_signature=tf.TensorSpec([2, None]))
 
     check_shape_poly(self,
                      f_jax,
                      arg_descriptors=[RandArg((3, 3), _f32)],
-                     input_signature=[tf.TensorSpec([None, None])],
                      polymorphic_shapes=["h, h"],
                      expected_output_signature=tf.TensorSpec([None, None]))
 
     check_shape_poly(self,
                      f_jax,
                      arg_descriptors=[RandArg((3, 3), _f32)],
-                     input_signature=[tf.TensorSpec([None, None])],
-                     polymorphic_shapes="h, h",
+                     polymorphic_shapes=["h, h"],
                      expected_output_signature=tf.TensorSpec([None, None]))
 
   def test_simple_binary(self):
@@ -670,15 +628,14 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     check_shape_poly(self,
                      f_jax,
                      arg_descriptors=[RandArg((2, 3), _f32), RandArg((2, 3), _f32)],
-                     input_signature=[tf.TensorSpec([2, 3]), tf.TensorSpec([2, 3])],
-                     polymorphic_shapes=None,
+                     polymorphic_shapes=[None, None],
                      expected_output_signature=tf.TensorSpec([2, 3]))
 
     check_shape_poly(self,
                      f_jax,
                      arg_descriptors=[RandArg((2, 3), _f32), RandArg((2, 3), _f32)],
+                     polymorphic_shapes=["_, h", "_, h"],
                      input_signature=[tf.TensorSpec([2, None]), tf.TensorSpec([2, 3])],
-                     polymorphic_shapes="_, h",
                      expected_output_signature=(
                          # for native serialization we cannot refine the inferred shape of the
                          # output if the input is more specific than polymorphic_shapes.
@@ -688,50 +645,46 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     check_shape_poly(self,
                      f_jax,
                      arg_descriptors=[RandArg((3, 3), _f32), RandArg((3, 3), _f32)],
-                     input_signature=[tf.TensorSpec([None, None]), tf.TensorSpec([None, None])],
-                     polymorphic_shapes=PS("h", "h"),
+                     polymorphic_shapes=["h, h", "h, h"],
                      expected_output_signature=tf.TensorSpec([None, None]))
 
-  @parameterized.named_parameters([
-      dict(testcase_name=f"_{name}",
-           make_args=make_args)
-      for name, make_args in [
-          # make_args invoked with op.shape[0]: start, stop, step, dtype
-          ("b", lambda b: (b, None, None, None)),
-          ("0_b+1", lambda b: (0, b + 1, None, None)),
-          ("0_5b_2", lambda b: (0, 5 * b, 2, None)),
-          ("0_5b+1_2", lambda b: (0, 5 * b + 1, 2, None)),
-          ("b_5b+2_2", lambda b: (b, 5 * b + 2, 2, None)),
-          ("0_b-1_2", lambda b: (0, b - 1, 2, None)),
-          ("0_b-2_2", lambda b: (0, b - 2, 2, None)),
-          ("0_-b_2", lambda b: (0, -b, 2, None)),
-          ("0_1-b_2", lambda b: (0, 1 - b, 2, None)),
-          # Negative step
-          ("b_0_-1", lambda b: (b, 0, -1, None)),
-          ("b_1_-2", lambda b: (b, 1, -2, None)),
-          ("b_-1_-1", lambda b: (b, -1, -1, None)),
-          ("5b+1_0_-2", lambda b: (5 * b + 1, 0, -2, None)),
-          ("5b+2_0_-2", lambda b: (5 * b + 2, 0, -2, None)),
-          # Symbolic step
-          ("0_10_b", lambda b: (0, 10, b)),
-          ("0_0_b", lambda b: (0, 0, b)),
-          ("10_0_-b", lambda b: (10, 0, -b)),
-          ("b_1_-b", lambda b: (b, 1, -b)),
-          # Float return type
-          ("0_b_1_f32", lambda b: (0, b, 1, np.float32))
-      ]
+  @jtu.parameterized_filterable(
+    # make_args invoked with op.shape[0]: start, stop, step, dtype
+    kwargs=[
+      dict(testcase_name="b", make_args=lambda b: (b, None, None, None)),
+      dict(testcase_name="0_b+1", make_args=lambda b: (0, b + 1, None, None)),
+      dict(testcase_name="0_5b_2", make_args=lambda b: (0, 5 * b, 2, None)),
+      dict(testcase_name="0_5b+1_2", make_args=lambda b: (0, 5 * b + 1, 2, None)),
+      dict(testcase_name="b_5b+2_2", make_args=lambda b: (b, 5 * b + 2, 2, None)),
+      dict(testcase_name="0_b-1_2", make_args=lambda b: (0, b - 1, 2, None)),
+      dict(testcase_name="0_b-2_2", make_args=lambda b: (0, b - 2, 2, None)),
+      dict(testcase_name="0_-b_2", make_args=lambda b: (0, -b, 2, None)),
+      dict(testcase_name="0_1-b_2", make_args=lambda b: (0, 1 - b, 2, None)),
+      # Negative step
+      dict(testcase_name="b_0_-1", make_args=lambda b: (b, 0, -1, None)),
+      dict(testcase_name="b_1_-2", make_args=lambda b: (b, 1, -2, None)),
+      dict(testcase_name="b_-1_-1", make_args=lambda b: (b, -1, -1, None)),
+      dict(testcase_name="5b+1_0_-2", make_args=lambda b: (5 * b + 1, 0, -2, None)),
+      dict(testcase_name="5b+2_0_-2", make_args=lambda b: (5 * b + 2, 0, -2, None)),
+      # Symbolic step
+      dict(testcase_name="0_10_b", make_args=lambda b: (0, 10, b)),
+      dict(testcase_name="0_0_b", make_args=lambda b: (0, 0, b)),
+      dict(testcase_name="10_0_-b", make_args=lambda b: (10, 0, -b)),
+      dict(testcase_name="b_1_-b", make_args=lambda b: (b, 1, -b)),
+      # Float return type
+      dict(testcase_name="0_b_1_f32", make_args=lambda b: (0, b, 1, np.float32))
   ])
-  def test_arange(self, make_args=lambda b: (0, -b, 2, None)):
+  def test_arange(self, make_args):
     def f_jax(x):  # x: i32[b]
       return x[0] + jnp.arange(*(make_args(x.shape[0])))
     x = np.ones((3,), dtype=np.int32)
     self.assertAllClose(jax2tf.convert(f_jax, polymorphic_shapes="b")(x),
                         f_jax(x))
 
-  @parameterized.named_parameters([
-      dict(testcase_name=f"_{name}",
-           make_args=make_args,
-           expect_error=expect_error, expect_msg=expect_msg)
+  @jtu.parameterized_filterable(
+    # make_args invoked with op.shape[0]: start, stop, step, dtype
+    kwargs=[
+      dict(testcase_name=name, make_args=make_args, expect_error=expect_error, expect_msg=expect_msg)
       for name, make_args, expect_error, expect_msg in [
           # make_args invoked with op.shape[0]: start, stop, step, dtype
           ("float_start", lambda b: (0., b, None),
@@ -747,7 +700,8 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
            core.InconclusiveDimensionOperation,
            "must be resolved statically if it is >= -1 or >= 1"),
       ]
-  ])
+    ]
+  )
   def test_arange_error(self, make_args=lambda b: (0., b, 2),
                         expect_error=ValueError,
                         expect_msg="must be either dimension expressions or integers"):
@@ -764,8 +718,9 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     self.assertAllClose(jax2tf.convert(f_jax, polymorphic_shapes="(b, _, _)")(x),
                         f_jax(x))
 
-  @parameterized.named_parameters([
-      dict(testcase_name=f"_expr={name}", expr=expr)
+  @jtu.parameterized_filterable(
+    kwargs=[
+      dict(testcase_name=f"expr={name}", expr=expr)
       for name, expr in [
           ("d + 2", lambda d: d + 2),
           ("2 - d", lambda d: 2 - d),
@@ -796,10 +751,10 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
   def test_non_trivial_dim_expr(self, expr=lambda d: d % -2):
     # Check the lowering for shape expressions
     check_shape_poly(
-       self,
-       lambda x: x[0] * 0 + expr(x.shape[0]),
-       arg_descriptors=[RandArg((3,), np.int64)],
-       poly_axes=[0])
+      self,
+      lambda x: x[0] * 0 + expr(x.shape[0]),
+      arg_descriptors=[RandArg((3,), np.int64)],
+      polymorphic_shapes=["b"])
 
   def test_static_shape_result(self):
     """The result has static shape."""
@@ -810,15 +765,13 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     check_shape_poly(self,
                      f_jax,
                      arg_descriptors=[RandArg((2, 3), _f32)],
-                     input_signature=[tf.TensorSpec([2, 3])],
-                     polymorphic_shapes=None,
+                     polymorphic_shapes=[None],
                      expected_output_signature=tf.TensorSpec([3]))
 
     check_shape_poly(self,
                      f_jax,
                      arg_descriptors=[RandArg((2, 3), _f32)],
-                     input_signature=[tf.TensorSpec([None, 3])],
-                     polymorphic_shapes="b, _",
+                     polymorphic_shapes=["b, _"],
                      expected_output_signature=tf.TensorSpec([3]))
 
   def test_forgot_polymorphic_shapes_error(self):
@@ -828,7 +781,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
                        jnp.sin,
                        arg_descriptors=[RandArg((1, 3,), _f32)],
                        input_signature=[tf.TensorSpec([1, None])],
-                       polymorphic_shapes=None)
+                       polymorphic_shapes=[None])
 
   def test_kwargs(self):
     """Test shape polymorphism for a function with kwargs."""
@@ -1063,14 +1016,14 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
                                          dict(a="(_,)", b="(4,)")),
                      expected_output_signature=tf.TensorSpec([4]))
 
-  @parameterized.named_parameters(
-      dict(testcase_name=f"_{name}",
-           polymorphic_shapes=polymorphic_shapes)
+  @jtu.parameterized_filterable(
+    kwargs=[
+      dict(testcase_name=name, polymorphic_shapes=polymorphic_shapes)
       for name, polymorphic_shapes in [
           ("1", ("b", "b", "b")),
           ("2", dict(a="b")),
           ("3", (dict(a="b"), "b")),
-      ]
+      ]]
   )
   def test_pytree_errors(self, polymorphic_shapes=("b", "b", "b")):
     """Arguments and polymorphic_shapes are not-matching pytrees."""
@@ -1094,17 +1047,18 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     check_shape_poly(self,
                      lambda x: x + jax.jit(f_jax)(x),
                      arg_descriptors=[RandArg((3, 4), _f32)],
-                     poly_axes=[(0, 1)])
+                     polymorphic_shapes=["a, b"])
 
-  @parameterized.named_parameters(
-      dict(testcase_name=f"_{str(polymorphic_shapes)}",
-           polymorphic_shapes=polymorphic_shapes)
+  @jtu.parameterized_filterable(
+    kwargs=[
+      dict(testcase_name=str(polymorphic_shapes), polymorphic_shapes=polymorphic_shapes)
       # The polymorphic_shapes should have three comma-separated DimExpr matching
       # 16, 24, 32
       for polymorphic_shapes in [
           "b1+6,b1+14,b2",  # b1=10, b2=32
           "2*b1,4*b2,b1+b2+18",  # b1=8,b2=6
           "b1+2*b2,4*b2,b1*b1+16",  # b1=4,b2=6
+      ]
   ])
   def test_non_trivial_polynomials_spec(self,
                                         polymorphic_shapes="2*b1,4*b2,b1+b2+18"):
@@ -1113,8 +1067,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     check_shape_poly(self,
         lambda x: 2 * x.shape[0] + 3 * x.shape[1] + 4 * x.shape[2],
         arg_descriptors=[RandArg((16, 24, 32), _f32)],
-        input_signature=[tf.TensorSpec([None, None, None])],
-        polymorphic_shapes=polymorphic_shapes)
+        polymorphic_shapes=[polymorphic_shapes])
 
   def test_unused_args(self):
     # Tests with functions that do not use their inputs.
@@ -1123,7 +1076,6 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     check_shape_poly(self,
                      lambda x_unused, y: y * 2.0,
                      arg_descriptors=[RandArg((2, 3), _f32), RandArg((3,), _f32)],
-                     input_signature=[tf.TensorSpec([]), tf.TensorSpec([None])],
                      polymorphic_shapes=[None, "b"])
 
     # Some args unused, not polymorphic
@@ -1131,8 +1083,6 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
                      lambda x_unused, y, z_unused, w: jnp.concatenate([y, w]),
                      arg_descriptors=[RandArg((3,), _f32), RandArg((4,), _f32),
                            RandArg((5,), _f32), RandArg((6,), _f32)],
-                     input_signature=[tf.TensorSpec([]), tf.TensorSpec([None]),
-                         tf.TensorSpec([]), tf.TensorSpec([None])],
                      polymorphic_shapes=[None, "b1", None, "b2"])
 
     # A polymorphic arg is not used, but the dimension var appears
@@ -1140,7 +1090,6 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     check_shape_poly(self,
                      lambda x_unused, y: y * 2.0,
                      arg_descriptors=[RandArg((3,), _f32), RandArg((3,), _f32)],
-                     input_signature=[tf.TensorSpec([None]), tf.TensorSpec([None])],
                      polymorphic_shapes=["b", "b"])
 
     # A polymorphic arg is not used, and the dimension var does not appear
@@ -1148,7 +1097,6 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     check_shape_poly(self,
         lambda x_unused, y: y * 2.0,
         arg_descriptors=[RandArg((4,), _f32), RandArg((3,), _f32)],
-        input_signature=[tf.TensorSpec([None]), tf.TensorSpec([None])],
         polymorphic_shapes=["b1", "b2"])
 
     # A polymorphic arg is not used, and the dimension var does appear
@@ -1156,14 +1104,12 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     check_shape_poly(self,
         lambda x_unused, y: y * 2.0,
         arg_descriptors=[RandArg((3,), _f32), RandArg((9,), _f32)],
-        input_signature=[tf.TensorSpec([None]), tf.TensorSpec([None])],
         polymorphic_shapes=["b1", "b1 * b1"])
 
     # It is not sufficient to just use the shape of an input; it is still unused
     check_shape_poly(self,
         lambda x_unused, y: y + x_unused.shape[0],
         arg_descriptors=[RandArg((3,), _f32), RandArg((9,), _f32)],
-        input_signature=[tf.TensorSpec([None]), tf.TensorSpec([None])],
         polymorphic_shapes=["b1", "b2"])
 
   def test_with_custom_vjp(self):
@@ -1367,11 +1313,9 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
 
       check_shape_poly(self, f_jax,
                        arg_descriptors=[RandArg((3, 4), _f32)],
-                       input_signature=[tf.TensorSpec([None, None], dtype=tf.float32)],
                        polymorphic_shapes=["b1, b2"])
     finally:
       config.update("jax_enable_custom_prng", prev_custom_prng)
-
 
   def test_saved_model(self):
     f_jax = jnp.sin
@@ -1411,7 +1355,6 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     restored_f, _ = tf_test_util.SaveAndLoadFunction(
         f_tf, input_signature=[tf.TensorSpec([None], x.dtype)])
     self.assertAllClose(f_jax(x), restored_f(x))
-
 
   def test_readme_examples(self):
     """Some of the examples from the README."""
@@ -1538,7 +1481,6 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
         "Cannot solve for values of dimension variables"):
       jax2tf.convert(lambda x: jnp.sum(x), polymorphic_shapes=["a + b"])(x)
 
-
   def test_dynamic_shapes(self):
     # Test dim_as_value with dynamic shapes.
     def f(x):
@@ -1595,16 +1537,15 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     finally:
       setattr(shape_poly._DimExpr, "__hash__", orig_hash)
 
-  @parameterized.named_parameters([
-      dict(testcase_name=f"_{op_name}",
-           op=op)
+  @jtu.parameterized_filterable(
+    kwargs=[
+      dict(testcase_name=op_name, op=op)
       for op, op_name in [
           (jnp.array, "array"),
           (jnp.sin, "sin"),
           (lambda x: x, "id"),
           (core.dimension_as_value, "dimension_as_value"),
-      ]
-  ])
+      ]])
   def test_poly_unary_op(self, *, op=jnp.array):
     def f_jax(x):  # x: f32[b]
       poly = 2 * x.shape[0]
@@ -1613,10 +1554,11 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     check_shape_poly(self,
                      f_jax,
                      arg_descriptors=[RandArg((3,), _f32)],
-                     poly_axes=[0],
+                     polymorphic_shapes=["b"],
                      expected_output_signature=(tf.TensorSpec([]), tf.TensorSpec((None,), _f32)))
 
-  @parameterized.named_parameters([
+  @jtu.parameterized_filterable(
+    kwargs=[
       dict(testcase_name=f"_{op.__name__}_other={other}:{type(other)}{'_other_jnp_array' if other_jnp_array else ''}{'_swap' if swap else ''}",
            op=op, other=other,
            other_jnp_array=other_jnp_array, swap=swap)
@@ -1668,7 +1610,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     check_shape_poly(self,
                      f_jax,
                      arg_descriptors=[RandArg((3,), np.int32)],
-                     poly_axes=[0])
+                     polymorphic_shapes=["b"])
 
   def test_mean0(self):
     def f_jax(x):  # x: f32[b, 4]
@@ -1676,9 +1618,8 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     check_shape_poly(self,
                      f_jax,
                      arg_descriptors=[RandArg((3, 4), _f32)],
-                     poly_axes=[0],
+                     polymorphic_shapes=["b, _"],
                      expected_output_signature=tf.TensorSpec([4]))
-
 
   def test_shape_as_array(self):
     def f_jax(x):
@@ -1688,7 +1629,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     check_shape_poly(self,
                      f_jax,
                      arg_descriptors=[RandArg((3, 4), _f32)],
-                     poly_axes=[0])
+                     polymorphic_shapes=["b, _"])
 
   def test_dim_as_value_weak_type(self):
     def f_jax(x):  # x: f32[b]
@@ -1707,7 +1648,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
       check_shape_poly(self,
                        f_jax,
                        arg_descriptors=[RandArg((3,), _f32)],
-                       poly_axes=[0])
+                       polymorphic_shapes=["b"])
 
   def test_vmap_while(self):
     def cond_func(x):  # x: f32[3]
@@ -1719,8 +1660,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
 
     check_shape_poly(self,
                      jax.vmap(f_jax),
-                     arg_descriptors=[RandArg((3,), _f32)],
-                     input_signature=[tf.TensorSpec((None, 3), dtype=tf.float32)],
+                     arg_descriptors=[RandArg((5, 3), _f32)],
                      polymorphic_shapes=["b, ..."],
                      expected_output_signature=tf.TensorSpec((None, 3), dtype=tf.float32)
                      )
@@ -1857,31 +1797,31 @@ _POLY_SHAPE_TEST_HARNESSES = [
     PolyHarness("add", "",
                 jnp.add,
                 arg_descriptors=[RandArg((3, 4), _f32), RandArg((2, 3, 4), _f32)],
-                poly_axes=[0, 1]),
+                polymorphic_shapes=["b, ...", "_, b, _"]),
     PolyHarness("add_transpose", "",
                 jax.grad(lambda x: jnp.sum(jnp.sum(x, axis=0, keepdims=False) + jnp.sin(x))),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     # Reduce the poly dimension
     PolyHarness("argmax", "0",
                 lambda op: lax.argmax(op, axis=0, index_dtype=np.int32),
                 arg_descriptors=[RandArg((3, 4, 5), _f32)],
-                poly_axes=[0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ..."]).both_enable_and_disable_xla(),
     # Reduce the non-poly dimension
     PolyHarness("argmax", "1",
                 lambda op: lax.argmax(op, axis=1, index_dtype=np.int32),
                 arg_descriptors=[RandArg((3, 4, 5), _f32)],
-                poly_axes=[0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ..."]).both_enable_and_disable_xla(),
     PolyHarness("jnp.argsort", "",
                 lambda op: jnp.argsort(op),
                 arg_descriptors=[RandArg((3, 4, 5), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     [
         PolyHarness("average",
                     f"{axis=}_weights=None",
                     lambda x, axis: jnp.average(x, axis=axis, returned=False, weights=None),
                     arg_descriptors=[RandArg((7, 8, 4), _f32), StaticArg(axis)],
-                    poly_axes=[0])
+                    polymorphic_shapes=["b, ..."])
         for axis in [None, 0, 1]
     ],
     [
@@ -1889,59 +1829,59 @@ _POLY_SHAPE_TEST_HARNESSES = [
                     f"{axis=}_weights=Some",
                     lambda x, weights, axis: jnp.average(x, axis=axis, returned=False, weights=weights),
                     arg_descriptors=[RandArg((7, 8, 4), _f32), RandArg((7, 8, 4), _f32), StaticArg(axis)],
-                    poly_axes=[0, 0])
+                    polymorphic_shapes=["b, ...", "b, ..."])
         for axis in [None, 0, 1]
     ],
     PolyHarness("jnp.bincount", "length=constant",
                 lambda x: jnp.bincount(x % 2, length=4),
                 arg_descriptors=[RandArg((12,), np.int32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("jnp.bincount", "length=poly",
                 lambda x: jnp.bincount(x % 4, length=x.shape[0]),
                 arg_descriptors=[RandArg((12,), np.int32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("broadcast_to", "",
                 lambda x: jnp.broadcast_to(x, [x.shape[0], x.shape[0], 4]),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("broadcast_in_dim", "0",
                 lambda x: lax.broadcast_in_dim(x, [x.shape[0], 4, 5, 6],
                                                broadcast_dimensions=(0, 2, 3)),
                 arg_descriptors=[RandArg((3, 1, 6), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("broadcast_in_dim", "poly",
                 lambda x: lax.broadcast_in_dim(x, [x.shape[0], x.shape[0] + x.shape[0], 4],
                                                broadcast_dimensions=(0, 1, 2)),
                 arg_descriptors=[RandArg((3, 1, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("broadcast_in_dim", "poly2",
                 lambda x: lax.broadcast_in_dim(x, [x.shape[0], 5, 6, x.shape[2], 4],
                                                broadcast_dimensions=(0, 2, 3)),
                 arg_descriptors=[RandArg((3, 1, 4), _f32)],
-                poly_axes=[(0, 2)]),
+                polymorphic_shapes=["b1, _, b2"]),
     PolyHarness("broadcast_in_dim", "transpose",
                 jax.grad(lambda x: jnp.sum(
                     lax.broadcast_in_dim(jnp.sin(x), [2, x.shape[0], 5, x.shape[2], 4],
                                          broadcast_dimensions=(1, 2, 3)))),
                 arg_descriptors=[RandArg((3, 1, 4), _f32)],
-                poly_axes=[(0, 2)]),
+                polymorphic_shapes=["b1, _, b2"]),
     PolyHarness("clamp", "",
                 lax.clamp,
                 arg_descriptors=[RandArg((3, 4, 5), _f32), RandArg((3, 4, 5), _f32),
                                  RandArg((3, 4, 5), _f32)],
-                poly_axes=[0, 0, 0]),
+                polymorphic_shapes=["b, ...", "b, ...", "b, ..."]),
     PolyHarness("collapse", "",
                 lambda x: lax.collapse(x, 1, 4),
                 arg_descriptors=[RandArg((3, 4, 5, 6, 7), _f32)],
-                poly_axes=[(0, 1, 3)]),
+                polymorphic_shapes=["b0, b1, _, b3, ..."]),
     PolyHarness("concatenate", "",
                 lambda x: jnp.concatenate([x, x], axis=0),
                 arg_descriptors=[RandArg((3, 4, 5), _f32)],
-                poly_axes=[(0, 1)]),
+                polymorphic_shapes=["b0, b1, _"]),
     PolyHarness("concatenate", "grad",
                 jax.grad(lambda x: jnp.sum(jnp.concatenate([x, jnp.sin(x)], axis=0))),
                 arg_descriptors=[RandArg((3, 4, 5), _f32)],
-                poly_axes=[(0, 1)]),
+                polymorphic_shapes=["b0, b1, _"]),
 
     PolyHarness("conv_general_dilated", "1d_stride=1",
                 lambda lhs, rhs: lax.conv_general_dilated(
@@ -1953,7 +1893,7 @@ _POLY_SHAPE_TEST_HARNESSES = [
                                                                rhs_spec=(2, 1, 0),
                                                                out_spec=(0, 2, 1))),
                 arg_descriptors=[RandArg((1, 12, 16), _f32), RandArg((4, 16, 16), _f32)],
-                poly_axes=[1, None]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["_, b, _", None]).both_enable_and_disable_xla(),
     # The same example from above, but with stride=2.
     PolyHarness("conv_general_dilated", "1d_stride=2_even",
                 lambda lhs, rhs: lax.conv_general_dilated(
@@ -1965,8 +1905,7 @@ _POLY_SHAPE_TEST_HARNESSES = [
                                                                rhs_spec=(2, 1, 0),
                                                                out_spec=(0, 2, 1))),
                 arg_descriptors=[RandArg((1, 12, 16), _f32), RandArg((4, 16, 16), _f32)],
-                poly_axes=[1, None],
-              ).both_enable_and_disable_xla(),
+                polymorphic_shapes=["_, b, _", None]).both_enable_and_disable_xla(),
     # The same example from above, but with stride=2 and odd input size.
     PolyHarness("conv_general_dilated", "1d_stride=2_odd",
                 lambda lhs, rhs: lax.conv_general_dilated(
@@ -1978,8 +1917,7 @@ _POLY_SHAPE_TEST_HARNESSES = [
                                                                rhs_spec=(2, 1, 0),
                                                                out_spec=(0, 2, 1))),
                 arg_descriptors=[RandArg((1, 13, 16), _f32), RandArg((4, 16, 16), _f32)],
-                poly_axes=[1, None],
-                ).both_enable_and_disable_xla(),
+                polymorphic_shapes=["_, b, _", None]).both_enable_and_disable_xla(),
     # Issue #11402
     PolyHarness("conv_general_dilated", "1d_2",
                 lambda lhs, rhs: lax.conv_transpose(lhs, rhs,
@@ -1988,7 +1926,7 @@ _POLY_SHAPE_TEST_HARNESSES = [
                                                     rhs_dilation=None,
                                                     transpose_kernel=False),
                 arg_descriptors=[RandArg((5, 12, 16), _f32), RandArg((4, 16, 16), _f32)],
-                poly_axes=[0, None],
+                polymorphic_shapes=["b, _, _", None],
                 tol=1e-5).both_enable_and_disable_xla(),
     # Issue #11402
     PolyHarness("conv_general_dilated", "1d_3",
@@ -1998,7 +1936,7 @@ _POLY_SHAPE_TEST_HARNESSES = [
                                                     rhs_dilation=None,
                                                     transpose_kernel=False),
                 arg_descriptors=[RandArg((5, 12, 16), _f32), RandArg((4, 16, 16), _f32)],
-                poly_axes=[1, None],
+                polymorphic_shapes=["_, b, _", None],
                 tol=1e-5).both_enable_and_disable_xla(),
     PolyHarness("conv_general_dilated", "",
                 lambda lhs, rhs: lax.conv_general_dilated(
@@ -2012,15 +1950,15 @@ _POLY_SHAPE_TEST_HARNESSES = [
                     batch_group_count=1,
                     precision=None),
                 arg_descriptors=[RandArg((7, 3, 9, 10), _f32), RandArg((3, 3, 4, 5), _f32)],
-                poly_axes=[0, None]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ...", None]).both_enable_and_disable_xla(),
     PolyHarness("cummax", "",
                 lambda x: lax_control_flow.cummax(x, axis=1, reverse=False),
                 arg_descriptors=[RandArg((3, 4, 5), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("jnp.cumsum", "reduce_axis=poly",
                 lambda x: jnp.cumsum(x, axis=0),
                 arg_descriptors=[RandArg((3, 5), _f32)],
-                poly_axes=[0],
+                polymorphic_shapes=["b, ..."],
                 expect_error=(
                   (None, None) if (not config.jax2tf_default_native_serialization or
                                    jtu.device_under_test() == "tpu") else
@@ -2029,113 +1967,113 @@ _POLY_SHAPE_TEST_HARNESSES = [
     PolyHarness("jnp.cumsum", "reduce_axis=static",
                 lambda x: jnp.cumsum(x, axis=1),
                 arg_descriptors=[RandArg((3, 5), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("delta", "0",
                 lambda x: lax_internal._delta(_f32, x.shape, axes=(0, 1)) + x,
                 arg_descriptors=[RandArg((3, 1), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("dot_general", "",
                 lambda lhs, rhs: lax.dot_general(lhs, rhs,
                                                  dimension_numbers=(((2,), (1,)), ((0,), (0,)))),
                 arg_descriptors=[RandArg((3, 4, 4), _f32), RandArg((3, 4), _f32)],
-                poly_axes=[0, 0]),
+                polymorphic_shapes=["b, ...", "b, ..."]),
     PolyHarness("dynamic_slice", "idx=tuple_int",
                 # x:shape: (b, 4)
                 lambda x: lax.dynamic_slice(x, (0, 1), (x.shape[0], 2)),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ..."]).both_enable_and_disable_xla(),
     PolyHarness("dynamic_slice", "idx=tuple_arg",
                 # x:shape: (b, 4)
                 lambda x, i0: lax.dynamic_slice(x, (i0, np.int32(1)), (x.shape[0], 2)),
                 arg_descriptors=[RandArg((3, 4), _f32), np.array(-2, dtype=np.int32)],
-                poly_axes=[0, None]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ...", None]).both_enable_and_disable_xla(),
     PolyHarness("dynamic_slice", "idx=array",
                 # x:shape: (b, 4)
                 lambda x, idx: lax.dynamic_slice(x, idx, (x.shape[0], 2)),
                 arg_descriptors=[RandArg((3, 4), _f32), np.array([-2, -1], dtype=np.int32)],
-                poly_axes=[0, None]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ...", None]).both_enable_and_disable_xla(),
     PolyHarness("dynamic_slice", "idx=tuple_int_start_oob_large",
                 # x:shape: (b, 4)
                 lambda x: lax.dynamic_slice(x, (1, 1), (x.shape[0], 2)),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ..."]).both_enable_and_disable_xla(),
     PolyHarness("dynamic_slice", "idx=tuple_int_start_oob_small",
               # x:shape: (b, 4)
               lambda x: lax.dynamic_slice(x, (-1, 1), (x.shape[0] - 1, 2)),
               arg_descriptors=[RandArg((3, 4), _f32)],
-              poly_axes=[0]).both_enable_and_disable_xla(),
+              polymorphic_shapes=["b, ..."]).both_enable_and_disable_xla(),
     PolyHarness("dynamic_slice_in_dim", "idx=0",
                 # x:shape: (b, 4)
                 lambda x: lax.dynamic_slice_in_dim(x, 0, x.shape[0], axis=0),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ..."]).both_enable_and_disable_xla(),
     PolyHarness("dynamic_update_slice", "idx=tuple_int",
                 # x:shape: (b, 4)
                 lambda x: lax.dynamic_update_slice(x, x, (0, 0)),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ..."]).both_enable_and_disable_xla(),
     PolyHarness("dynamic_update_slice", "idx=tuple_arg",
                 # x:shape: (b, 4)
                 lambda x, i0: lax.dynamic_update_slice(x, x, (i0, np.int32(0))),
                 arg_descriptors=[RandArg((3, 4), _f32), np.array(-2, dtype=np.int32)],
-                poly_axes=[0, None]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ...", None]).both_enable_and_disable_xla(),
     PolyHarness("dynamic_update_slice", "idx=array",
                 # x:shape: (b, 4)
                 lambda x, idx: lax.dynamic_update_slice(x, x, idx),
                 arg_descriptors=[RandArg((3, 4), _f32), np.array([-2, -1], dtype=np.int32)],
-                poly_axes=[0, None]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ...", None]).both_enable_and_disable_xla(),
     PolyHarness("einsum", "0",
                 lambda x: jnp.einsum("...i->...", x),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("einsum", "0_alt",
                 lambda x: jnp.einsum(x, (..., 1), [...]),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("einsum", "1",
                 lambda x, y: jnp.einsum("...ij,...jk->...ik", x, y),
                 arg_descriptors=[RandArg((3, 4, 5), _f32), RandArg((3, 5, 6), _f32)],
-                poly_axes=[0, 0]),
+                polymorphic_shapes=["b, ...", "b, ..."]),
     PolyHarness("einsum", "1_alt",
                 lambda x, y: jnp.einsum(x, [..., 0, 1], y, (..., 1, 2), [..., 0, 2]),
                 arg_descriptors=[RandArg((3, 4, 5), _f32), RandArg((3, 5, 6), _f32)],
-                poly_axes=[0, 0]),
+                polymorphic_shapes=["b, ...", "b, ..."]),
     PolyHarness("einsum", "2",
                 lambda x, y: jnp.einsum("...ij,jk->...ik", x, y),
                 arg_descriptors=[RandArg((3, 4, 5), _f32), RandArg((5, 6), _f32)],
-                poly_axes=[0, None]),
+                polymorphic_shapes=["b, ...", None]),
     PolyHarness("einsum", "2_alt",
                 lambda x, y: jnp.einsum(x, [..., 0, 1], y, [1, 2], [..., 0, 2]),
                 arg_descriptors=[RandArg((3, 4, 5), _f32), RandArg((5, 6), _f32)],
-                poly_axes=[0, None]),
+                polymorphic_shapes=["b, ...", None]),
     PolyHarness("einsum", "3",
                 # Reduced dimension is polymorphic
                 lambda x, y: jnp.einsum("ij,jk->ik", x, y),
                 arg_descriptors=[RandArg((3, 4), _f32), RandArg((4, 5), _f32)],
-                poly_axes=[1, 0]),
+                polymorphic_shapes=["_, b", "b, ..."]),
     PolyHarness("einsum", "3_alt",
                 # Reduced dimension is polymorphic
                 lambda x, y: jnp.einsum(x, [0, 1], y, [1, 2], [0, 2]),
                 arg_descriptors=[RandArg((3, 4), _f32), RandArg((4, 5), _f32)],
-                poly_axes=[1, 0]),
+                polymorphic_shapes=["_, b", "b, ..."]),
     PolyHarness("einsum", "4",
                 # Reduced dimension is polymorphic, and is 2*b
                 lambda x, y: jnp.einsum("ij,jk->ik",
                                         jnp.concatenate([x, x], axis=1),
                                         jnp.concatenate([y, y], axis=0)),
                 arg_descriptors=[RandArg((3, 4), _f32), RandArg((4, 5), _f32)],
-                poly_axes=[1, 0]),
+                polymorphic_shapes=["_, b", "b, ..."]),
     PolyHarness("einsum", "4_alt",
                 # Reduced dimension is polymorphic, and is 2*b
                 lambda x, y: jnp.einsum(jnp.concatenate([x, x], axis=1), [0, 1],
                                         jnp.concatenate([y, y], axis=0), [1, 2],
                                         [0, 2]),
                 arg_descriptors=[RandArg((3, 4), _f32), RandArg((4, 5), _f32)],
-                poly_axes=[1, 0]),
+                polymorphic_shapes=["_, b", "b, ..."]),
     PolyHarness("einsum", "multiple_contractions",
                 lambda x, y, z: jnp.einsum("ab,bc,cd->ad", x, y, z),
                 arg_descriptors=[RandArg((3, 2), _f32), RandArg((2, 3), _f32), RandArg((3, 4), _f32)],
-                poly_axes=[0, None, None]),
+                polymorphic_shapes=["b, ...", None, None]),
     PolyHarness("einsum", "incompatible_contractions_error",
                 lambda x, y: jnp.einsum("ab,cb->ac", x, y),
                 arg_descriptors=[RandArg((2, 3), _f32), RandArg((2, 3), _f32)],
@@ -2146,11 +2084,11 @@ _POLY_SHAPE_TEST_HARNESSES = [
     PolyHarness("eye", "N=poly_M=None",
                 lambda x: jnp.eye(x.shape[0]) + x,
                 arg_descriptors=[RandArg((3, 1), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("eye", "N=poly_M=poly",
                 lambda x: jnp.eye(x.shape[0], M=x.shape[0] + 2) + x,
                 arg_descriptors=[RandArg((3, 1), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     [
         PolyHarness("fft", f"{fft_type=}_{nr_fft_lengths=}",
             lambda x, fft_type, nr_fft_lengths: lax.fft_p.bind(
@@ -2165,7 +2103,7 @@ _POLY_SHAPE_TEST_HARNESSES = [
                 StaticArg(nr_fft_lengths)],
             # All axes but the last one are dynamic. This means that the test
             # with nr_fft_lengths==1 will not have dynamic fft_lengths.
-            poly_axes=[(0, 1, 2)],
+            polymorphic_shapes=["b0, b1, b2, ..."],
             tol=1e-4)
 
          for fft_type in (xla_client.FftType.FFT, xla_client.FftType.IFFT,
@@ -2175,109 +2113,109 @@ _POLY_SHAPE_TEST_HARNESSES = [
     PolyHarness("full", "",
                 lambda x: lax.full((x.shape[0], 2), 3.) + x,
                 arg_descriptors=[RandArg((3, 1), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     # operand is non-poly, index is poly
     PolyHarness("getitem", "op=static_idx=poly",
                 lambda a, i: a[i],
                 arg_descriptors=[RandArg((3, 4), _f32), np.array([2, 2], np.int32)],
-                poly_axes=[None, 0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=[None, "b0, ..."]).both_enable_and_disable_xla(),
     # operand is poly, index is integer
     PolyHarness("getitem", "op=poly_idx=const",
                 lambda a: a[1],
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ..."]).both_enable_and_disable_xla(),
     # operand is poly, index is dim poly
     PolyHarness("getitem", "op=poly_idx=dim",
                 lambda a: a[jnp.array(a.shape[0] - 2)],
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ..."]).both_enable_and_disable_xla(),
     # Both the operand and the index are poly
     PolyHarness("getitem", "op=poly_idx=poly",
                 lambda a, i: a[i],
                 arg_descriptors=[RandArg((3, 4), _f32), np.array([1, 2, 0], np.int32)],
-                poly_axes=[0, 0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ...", "b, ..."]).both_enable_and_disable_xla(),
     # op is poly and index is an entire slice
     PolyHarness("getitem", "op=poly_idx=slice-all",
                 lambda a: a[:],
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ..."]).both_enable_and_disable_xla(),
     # op is poly and index is a partial slice
     PolyHarness("getitem", "op=poly_idx=slice-ct-1",
                 lambda a: a[:2],
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0],
+                polymorphic_shapes=["b, ..."],
                 expect_error=(IndexError, "Cannot use NumPy slice indexing on an array dimension")
                 ).both_enable_and_disable_xla(),
     PolyHarness("getitem", "op=poly_idx=slice-ct-2",
                 lambda a: a[:, :2],
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ..."]).both_enable_and_disable_xla(),
     PolyHarness("getitem", "op=poly_idx=slice-None-1",
                 lambda a: a[:a.shape[0]],
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ..."]).both_enable_and_disable_xla(),
     PolyHarness("getitem", "op=poly_idx=slice-poly",
                 lambda a: a[:a.shape[0] - 1],
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0],
+                polymorphic_shapes=["b, ..."],
                 expect_error=(IndexError, "Array slice indices must have static")).both_enable_and_disable_xla(),
     PolyHarness("image_resize", "linear_0",
                 lambda x: jax.image.resize(x, (x.shape[0], 2 * x.shape[1], 2 * x.shape[2], x.shape[3]),
                                            method="linear"),
                 arg_descriptors=[RandArg((3, 16, 32, 3), _f32)],
-                poly_axes=[(1, 2)]),
+                polymorphic_shapes=["_, b1, b2, ..."]),
     PolyHarness("image_resize", "linear_to_fixed_dim",
                 lambda x: jax.image.resize(x, (x.shape[0], 64, 64, x.shape[3]),
                                            method="linear"),
                 arg_descriptors=[RandArg((3, 16, 32, 3), _f32)],
-                poly_axes=[(1, 2)]),
+                polymorphic_shapes=["_, b1, b2, ..."]),
     PolyHarness("image_resize", "nearest_0",
                 lambda x: jax.image.resize(x, (x.shape[0], 2 * x.shape[1], 2 * x.shape[2], x.shape[3]),
                                            method="nearest"),
                 arg_descriptors=[RandArg((3, 5, 7, 3), _f32)],
-                poly_axes=[(1, 2)]),
+                polymorphic_shapes=["_, b1, b2, ..."]),
     PolyHarness("index_in_dim", "0",
                 lambda x: lax.index_in_dim(x, -1, axis=0, keepdims=False),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("index_in_dim", "idx=neg",
                 lambda x: lax.index_in_dim(x, -1, axis=0, keepdims=False),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("index_in_dim", "idx=last",
                 lambda x: lax.index_in_dim(x, x.shape[0] - 1, axis=0, keepdims=False),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("jnp.insert", "insert=constant",
                 lambda x: jnp.insert(x, jnp.arange(3, dtype=_i32), np.array([3, 4, 5], dtype=_i32)),
                 arg_descriptors=[RandArg((12,), _i32)],
-                poly_axes=[0],
+                polymorphic_shapes=["b, ..."],
                 expect_error=expect_error_associative_scan),
     PolyHarness("jnp.insert", "insert=poly",
                 lambda x: jnp.insert(x, jnp.arange(x.shape[0], dtype=_i32), x, axis=0),
                 arg_descriptors=[RandArg((12, 3), _i32)],
-                poly_axes=[(0, 1)],
+                polymorphic_shapes=["b0, b1, ..."],
                 expect_error=expect_error_associative_scan),
     PolyHarness("iota", "",
                 lambda x: x + lax.iota(_f32, x.shape[0]),
                 arg_descriptors=[RandArg((3,), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("matmul", "0",
                 jnp.matmul,
                 arg_descriptors=[RandArg((7, 8, 4), _f32), RandArg((7, 4, 5), _f32)],
-                poly_axes=[0, 0],
+                polymorphic_shapes=["b, ...", "b, ..."],
                 tol=1e-5),
     PolyHarness("matmul", "1",
                 jnp.matmul,
                 arg_descriptors=[RandArg((7, 8, 4), _f32), RandArg((4, 5), _f32)],
-                poly_axes=[0, None],
+                polymorphic_shapes=["b, ...", None],
                 tol=1e-5),
     [
         PolyHarness("mean",
                     f"{axis=}_{keepdims=}_where=None",
                     lambda x, axis, keepdims: jnp.mean(x, axis=axis, keepdims=keepdims, where=None),
                     arg_descriptors=[RandArg((7, 8, 4), _f32), StaticArg(axis), StaticArg(keepdims)],
-                    poly_axes=[0])
+                    polymorphic_shapes=["b, ..."])
         for keepdims in [False, True]
         for axis in [None, (0,), (0, 1), (1,)]
     ],
@@ -2287,48 +2225,48 @@ _POLY_SHAPE_TEST_HARNESSES = [
                     lambda x, where, axis, keepdims: jnp.mean(x, axis=axis, keepdims=keepdims, where=where),
                     arg_descriptors=[RandArg((7, 8, 4), _f32), RandArg((7, 8, 4), np.bool_),
                                      StaticArg(axis), StaticArg(keepdims)],
-                    poly_axes=[0, 0])
+                    polymorphic_shapes=["b, ...", "b, ..."])
         for keepdims in [False, True]
         for axis in [None, (0,), (0, 1), (1,)]
     ],
     PolyHarness("jnp.nonzero", "size=constant",
                 lambda x: jnp.nonzero(x % 3, size=10, fill_value=100),
                 arg_descriptors=[RandArg((3, 2, 4), _i32)],
-                poly_axes=[0],
+                polymorphic_shapes=["b, ..."],
                 expect_error=expect_error_associative_scan),
     PolyHarness("jnp.nonzero", "size=poly",
                 lambda x: jnp.nonzero(x % 3, size=x.shape[0] * 2, fill_value=100),
                 arg_descriptors=[RandArg((3, 2, 4), _i32)],
-                poly_axes=[0],
+                polymorphic_shapes=["b, ..."],
                 expect_error=expect_error_associative_scan),
     PolyHarness("one_hot", "poly_num_classes",
                 lambda x, y: jax.nn.one_hot(x, y.shape[0]),
                 arg_descriptors=[np.arange(16, dtype=_f32), RandArg((16,), _f32)],
-                poly_axes=[None, 0]),
+                polymorphic_shapes=[None, "b0, ..."]),
     PolyHarness("one_hot", "all_poly",
                 lambda x, y: jax.nn.one_hot(x, y.shape[0]),
                 arg_descriptors=[np.arange(16, dtype=_f32), RandArg((16,), _f32)],
-                poly_axes=[0, 0]),
+                polymorphic_shapes=["b, ...", "b, ..."]),
     PolyHarness("ones", "",
                 lambda x: jnp.ones(x.shape, dtype=_f32) + x,
                 arg_descriptors=[RandArg((3, 2, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("pad", "",
                 lax.pad,
                 arg_descriptors=[RandArg((3, 2, 5), _f32), np.float32(5.),
                                  StaticArg(((0, 0, 0), (0, 0, 0), (1, 1, 1)))],
-                poly_axes=[0, None]),
+                polymorphic_shapes=["b, ...", None]),
     PolyHarness("pad", "poly_padding_config",
                 lambda x: lax.pad(x, _f32(0.),
                                   ((x.shape[0], x.shape[1], x.shape[0]),
                                    (0, 0, 0))),
                 arg_descriptors=[RandArg((3, 2), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("jnp.pad", "mode=constant",
                 lambda x: jnp.pad(x, [[x.shape[0], 0], [x.shape[1], 1]],
                                   mode="constant"),
                 arg_descriptors=[RandArg((3, 5), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("jnp.pad", "mode=constant_bminus1",
                 # We slice first the unknown dimension to make it of size b - 1
                 # which may be 0.
@@ -2337,28 +2275,28 @@ _POLY_SHAPE_TEST_HARNESSES = [
                                   [[x.shape[0], 0], [x.shape[1], 1]],
                                   mode="constant"),
                 arg_descriptors=[RandArg((3, 5), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("jnp.pad", "mode=edge",
                 lambda x: jnp.pad(x, [[x.shape[0], 0], [x.shape[1], 1]],
                                   mode="edge"),
                 arg_descriptors=[RandArg((3, 5), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("percentile", "axis=None",
                 lambda x: jnp.percentile(x, 50, axis=None),
                 arg_descriptors=[RandArg((3, 5), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("nanquantile", "axis=None",
                 lambda x: jnp.nanquantile(x, .5, axis=None),
                 arg_descriptors=[RandArg((3, 5), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("percentile", "axis=0",
                 lambda x: jnp.percentile(x, 50, axis=0),
                 arg_descriptors=[RandArg((3, 5), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("nanquantile", "axis=0",
                 lambda x: jnp.nanquantile(x, .5, axis=0),
                 arg_descriptors=[RandArg((3, 5), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     [
       # The random primitive tests, with threefry (both partitionable and
       # non-partitionable), and unsafe_rbg.
@@ -2366,51 +2304,51 @@ _POLY_SHAPE_TEST_HARNESSES = [
         PolyHarness("random_gamma", f"{flags_name}",
                     lambda key, a: jax.random.gamma(key, a),
                     arg_descriptors=[RandArg((3, key_size), np.uint32), RandArg((3, 4, 5), _f32)],
-                    poly_axes=[0, (0, 1)],
+                    polymorphic_shapes=["b, ...", "b, w, ..."],
                     override_jax_config_flags=override_jax_config_flags),  # type: ignore
         # The known dimensions product must be even.
         PolyHarness("random_categorical", f"axis=0_{flags_name}",
                     lambda key, a: jax.random.categorical(key, a, axis=0),
                     arg_descriptors=[RandArg((key_size,), np.uint32), RandArg((3, 8), _f32)],
-                    poly_axes=[None, 0],
+                    polymorphic_shapes=[None, "b0, ..."],
                     override_jax_config_flags=override_jax_config_flags),  # type: ignore
         PolyHarness("random_categorical", f"axis=1_{flags_name}",
                     lambda key, a: jax.random.categorical(key, a, axis=1),
                     arg_descriptors=[RandArg((key_size,), np.uint32), RandArg((3, 5, 8), _f32)],
-                    poly_axes=[None, (0, 1)],
+                    polymorphic_shapes=[None, "b0, b1, ..."],
                     override_jax_config_flags=override_jax_config_flags),  # type: ignore
         PolyHarness("random_categorical", f"axis=1_then_reshape_{flags_name}",
                     lambda key, a: jax.random.categorical(key, a, axis=1).reshape((-1)),
                     arg_descriptors=[RandArg((key_size,), np.uint32), RandArg((3, 5, 8), _f32)],
-                    poly_axes=[None, (0, 1)],
+                    polymorphic_shapes=[None, "b0, b1, ..."],
                     override_jax_config_flags=override_jax_config_flags),  # type: ignore
         PolyHarness("random_categorical", f"0_dim_{flags_name}",  # One axis has 0 size
                     lambda key, a: jax.random.categorical(key, a, axis=1),
                     arg_descriptors=[RandArg((key_size,), np.uint32), RandArg((3, 5, 0), _f32)],
-                    poly_axes=[None, (0, 1)],
+                    polymorphic_shapes=[None, "b0, b1, ..."],
                     override_jax_config_flags=override_jax_config_flags),  # type: ignore
         PolyHarness("random_split", f"{flags_name}",
                     lambda key, a: jax.random.key_data(jax.random.split(key, 2 * a.shape[0])),
                     arg_descriptors=[RandArg((key_size,), np.uint32),
                                      RandArg((3, 4), _f32)],
-                    poly_axes=[None, (0,)],
+                    polymorphic_shapes=[None, "b0, ..."],
                     override_jax_config_flags=override_jax_config_flags),  # type: ignore
         # Works when the known dimensions are known to be even or odd.
         PolyHarness("random_uniform", f"even_1_{flags_name}",
                     lambda key, a: jax.random.uniform(key, a.shape, dtype=_f32),
                     arg_descriptors=[RandArg((key_size,), np.uint32), RandArg((3, 4, 5), _f32)],
-                    poly_axes=[None, 0],
+                    polymorphic_shapes=[None, "b0, ..."],
                     override_jax_config_flags=override_jax_config_flags),  # type: ignore
         PolyHarness("random_uniform", f"even_2_{flags_name}",
                     lambda key, a: jax.random.uniform(key, (2 * a.shape[0], a.shape[1]),
                                                       dtype=_f32),
                     arg_descriptors=[RandArg((key_size,), np.uint32), RandArg((3, 4), _f32)],
-                    poly_axes=[None, (0, 1)],
+                    polymorphic_shapes=[None, "b0, b1, ..."],
                     override_jax_config_flags=override_jax_config_flags),  # type: ignore
         PolyHarness("random_uniform", f"error_not_even_{flags_name}",
                     lambda key, a: jax.random.uniform(key, a.shape, dtype=_f32),
                     arg_descriptors=[RandArg((key_size,), np.uint32), RandArg((3, 5), _f32)],
-                    poly_axes=[None, 0],
+                    polymorphic_shapes=[None, "b0, ..."],
                     expect_error=(
                         (core.InconclusiveDimensionOperation,
                          "the product of the known dimensions must be even") if flags_name == "threefry_non_partitionable" else (None, None)),
@@ -2430,13 +2368,13 @@ _POLY_SHAPE_TEST_HARNESSES = [
                 lambda x: lax.reduce_window(x, np.array(1., _f32), lax.min,
                                             (2, 2), (1, 1), "VALID"),
                 arg_descriptors=[RandArg((3, 8), _f32)],
-                poly_axes=[0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ..."]).both_enable_and_disable_xla(),
     PolyHarness("reduce_window", "add_0",
                 # x.shape = (b, 8)
                 lambda x: lax.reduce_window(x, 0, lax.add, (2, 2), (1, 1),
                                             "VALID"),
                 arg_descriptors=[RandArg((3, 8), _f32)],
-                poly_axes=[0]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ..."]).both_enable_and_disable_xla(),
     # https://github.com/google/jax/issues/11804
     # Use the reshape trick to simulate a polymorphic dimension of 16*b.
     # (See test "conv_general_dilated.1d_1" above for more details.)
@@ -2446,163 +2384,165 @@ _POLY_SHAPE_TEST_HARNESSES = [
                     jnp.reshape(x, (1, -1, 1)),
                     0., lax.add, (1, 4, 1), (1, 2, 1), "SAME"),
                 arg_descriptors=[RandArg((1, 128, 16), _f32)],
-                poly_axes=[1]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["_, b1, ..."]).both_enable_and_disable_xla(),
     # TODO(necula): not yet supported, but also unlikely to come up.
     # PolyHarness("random_uniform", "odd",
     #               lambda key, a: jax.random.uniform(key, (2 * a.shape[0] + 1, a.shape[1]),
     #                                                 dtype=_f32),
     #               [RandArg((2,), np.uint32), RandArg((3, 5), _f32)],
-    #               poly_axes=[None, 0]),
+    #               polymorphic_shapes=[None, "b0, ..."]),
     [
         PolyHarness("reduce", reduce_op.__name__,
                     lambda x: reduce_op(x, axis=-1, keepdims=True),  # type: ignore
                     arg_descriptors=[RandArg((3, 5), _f32)],
-                    poly_axes=[0])
+                    polymorphic_shapes=["b, ..."])
         for reduce_op in [jnp.all, jnp.any, jnp.max, jnp.min, jnp.prod, jnp.sum]
     ],
     # Repeat f32[b, 2] * 3
     PolyHarness("repeat", "repeats=int_axis=0",
                 lambda x: jnp.repeat(x, repeats=3, axis=0),
                 arg_descriptors=[RandArg((3, 2), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     # Repeat f32[b, 2] * b
     PolyHarness("repeat", "repeats=poly_axis=0",
                 lambda x: jnp.repeat(x, repeats=x.shape[0], axis=0),
                 arg_descriptors=[RandArg((3, 2), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     # Repeat f32[b, 2] * b
     PolyHarness("repeat", "repeats=poly_axis=None",
                 lambda x: jnp.repeat(x, repeats=x.shape[0], axis=None),
                 arg_descriptors=[RandArg((3, 2), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     # Repeat f32 * b
     PolyHarness("repeat", "repeats=poly_axis=None_scalar",
                 lambda x, y: jnp.repeat(x, repeats=y.shape[0], axis=None) + y,
                 arg_descriptors=[RandArg((), _f32), RandArg((3, 1), _f32)],
-                poly_axes=[None, 0]),
+                polymorphic_shapes=[None, "b0, ..."]),
     PolyHarness("repeat", "repeats=poly_axis=None_total_repeat_length1",
                 lambda x: jnp.repeat(x, repeats=x.shape[0], axis=None, total_repeat_length=8),
                 arg_descriptors=[RandArg((3, 2), _f32)],
-                poly_axes=[0],
+                polymorphic_shapes=["b, ..."],
                 expect_error=(ValueError, "jnp.repeat with a non-constant `repeats` is supported only .*")),
     PolyHarness("reshape", "0",
                 lambda x: x.reshape([x.shape[0], -1]),
                 arg_descriptors=[RandArg((3, 2, 3), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("reshape", "1",
                 lambda x: x.reshape([x.shape[0], -1]),
                 arg_descriptors=[RandArg((3, 2, 3), _f32)],
-                poly_axes=[(0, 1)]),
+                polymorphic_shapes=["b0, b1, ..."]),
     PolyHarness("reshape", "2",
                 lambda x: x.reshape([x.shape[0], -1, x.shape[3], x.shape[2]]),
                 arg_descriptors=[RandArg((3, 4, 5, 6, 7), _f32)],
-                poly_axes=[(0, 2, 3)]),
+                polymorphic_shapes=["b0, _, b2, b3, ..."]),
     PolyHarness("reshape", "3",
                 lambda x: jnp.reshape(x, [2, -1]),
                 arg_descriptors=[RandArg((3, 4, 5, 6, 7), _f32)],
-                poly_axes=[(0, 2)]),
+                polymorphic_shapes=["b0, _, b2, ..."]),
     PolyHarness("reshape", "_issue_9975",
                 # The newshape is a scalar
                 lambda x: jnp.reshape(x, x.shape[0] * x.shape[1]),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("reshape", "error",
                 lambda x: x.reshape([x.shape[0], -1, 3]),
                 arg_descriptors=[RandArg((3, 2, 4), _f32)],
-                poly_axes=[0],
+                polymorphic_shapes=["b, ..."],
+                input_signature=[tf.TensorSpec([None, 2, 4], _f32)],
                 skip_jax_run=True,
                 expect_error=(core.InconclusiveDimensionOperation,
                               re.escape(
-                                "Cannot divide evenly the sizes of shapes (b0, 2, 4) and (b0, -1, 3)"))),
+                                "Cannot divide evenly the sizes of shapes (b, 2, 4) and (b, -1, 3)"))),
     PolyHarness("roll", "axis=0",
                 lambda x: jnp.roll(x, 2, axis=0),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("roll", "axis=None",
                 lambda x: jnp.roll(x, 2),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("scatter_add", "",
                 partial(lax.scatter_add, indices_are_sorted=False, unique_indices=True),
                 arg_descriptors=[RandArg((7, 4), _f32),
                                  np.array([[1], [2]], np.int32),  # indices: [2, 1]
                                  RandArg((7, 2), _f32),  # updates: [7, 2]
                                  StaticArg(lax.ScatterDimensionNumbers((0,), (1,), (1,)))],
-                poly_axes=[0, None, 0]),
+                polymorphic_shapes=["b, ...", None, "b, ..."]),
     PolyHarness("scatter_add", "clip0",
                 partial(lax.scatter_add, indices_are_sorted=False, unique_indices=True, mode=lax.GatherScatterMode.CLIP),
                 arg_descriptors=[RandArg((7, 4), _f32),  # [b, 4]
                                  np.array([[1], [2]], np.int32),  # indices: [2, 1]
                                  RandArg((7, 2), _f32),  # updates: [b, 2]
                                  StaticArg(lax.ScatterDimensionNumbers((0,), (1,), (1,)))],
-                poly_axes=[0, None, 0]),
+                polymorphic_shapes=["b, ...", None, "b, ..."]),
     PolyHarness("scatter_add", "clip1",
                 partial(lax.scatter_add, indices_are_sorted=False, unique_indices=True, mode=lax.GatherScatterMode.CLIP),
                 arg_descriptors=[RandArg((7, 4), _f32),  # [b, 4]
                                  np.array([[1, 2], [-2, 0], [6, 4], [7, -1], [1, 0], [3, 0], [0, 5]], np.int32),  # indices: [b, 2]
                                  RandArg((7, 1), _f32),  # updates: [b, 1]
                                  StaticArg(lax.ScatterDimensionNumbers((1,), (0,), (0, 1,)))],
-                poly_axes=[0, 0, 0]),
+                polymorphic_shapes=["b, ...", "b, ...", "b, ..."]),
     PolyHarness("select", "0",
                 # x.shape = (b, 3)
                 lambda x: lax.select(x > 5., x, x),
                 arg_descriptors=[RandArg((7, 3), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("select", "1",
                 # x.shape = (b, 3); y.shape = (3,)
                 jax.vmap(lambda x, y: lax.select(x > 5., x, y), in_axes=[0, None]),
                 arg_descriptors=[RandArg((7, 3), _f32), RandArg((3,), _f32)],
-                poly_axes=[0, None]),
+                polymorphic_shapes=["b, ...", None]),
     PolyHarness("slice", "entire_axis",
                 lambda x: lax.slice(x, start_indices=(0, 1), limit_indices=(x.shape[0], 3)),
                 arg_descriptors=[RandArg((7, 3), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("slice_in_dim", "entire_axis",
                 lambda x: lax.slice_in_dim(x, 0, x.shape[0], stride=1, axis=0),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("slice_in_dim", "start=neg",
                 lambda x: lax.slice_in_dim(x, -1, x.shape[0], stride=1, axis=0),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("slice_in_dim", "limit=neg",
                 lambda x: lax.slice_in_dim(x, 0, -1, stride=1, axis=0),
                 arg_descriptors=[RandArg((3, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("slice_in_dim", "stride=2_even",
                 lambda x: lax.slice_in_dim(x, 0, x.shape[0], stride=2, axis=0),
                 arg_descriptors=[RandArg((12, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("slice_in_dim", "stride=2_odd",
                 lambda x: lax.slice_in_dim(x, 0, x.shape[0], stride=2, axis=0),
                 arg_descriptors=[RandArg((13, 4), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     # Not yet, the slice_in_dim does int(stride)
     # PolyHarness("slice_in_dim", "stride=sym",
     #             lambda x: lax.slice_in_dim(x, 0, x.shape[0], stride=x.shape[0] // 4, axis=0),
     #             arg_descriptors=[RandArg((13, 4), _f32)],
-    #             poly_axes=[0]),
+    #             polymorphic_shapes=["b, ..."]),
     PolyHarness("squeeze", "axis=empty",
                 jnp.squeeze,
                 arg_descriptors=[RandArg((5,), _f32), StaticArg(())],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("squeeze", "axis=None",
                 jnp.squeeze,
                 arg_descriptors=[RandArg((5,), _f32), StaticArg(None)],
-                poly_axes=[0],
+                polymorphic_shapes=["b, ..."],
                 expect_error=(ValueError, "jnp.squeeze with axis=None is not supported with shape polymorphism")),
     PolyHarness("squeeze", "axis=1",
                 jnp.squeeze,
                 arg_descriptors=[RandArg((4, 1), _f32), StaticArg((1,))],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("squeeze", "axis=1_2",
                 jnp.squeeze,
                 arg_descriptors=[RandArg((4, 1, 1), _f32), StaticArg((1, 2))],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("squeeze", "error",
                 jnp.squeeze,
                 arg_descriptors=[RandArg((3, 33), _f32), StaticArg(-1)],
-                poly_axes=[(0, 1)],
+                polymorphic_shapes=["b0, b1"],
+                input_signature=[tf.TensorSpec([None, None], _f32)],
                 skip_jax_run=True,
                 expect_error=(ValueError,
                               re.escape(
@@ -2611,42 +2551,42 @@ _POLY_SHAPE_TEST_HARNESSES = [
     PolyHarness("take", "",
                 lambda a, i: jnp.take(a, i, axis=1),
                 arg_descriptors=[RandArg((3, 4, 5), _f32), np.array([1, 2], np.int32)],
-                poly_axes=[0, None]).both_enable_and_disable_xla(),
+                polymorphic_shapes=["b, ...", None]).both_enable_and_disable_xla(),
     PolyHarness("take_along_axis", "0",
                 lambda x, y: jnp.take_along_axis(x, y, axis=0),
                 arg_descriptors=[RandArg((5, 2), _f32), RandArg((5, 1), np.int32)],
-                poly_axes=[0, 0]),
+                polymorphic_shapes=["b, ...", "b, ..."]),
     PolyHarness("take_along_axis", "1",
                 lambda x, y: jnp.take_along_axis(x, y, axis=1),
                 arg_descriptors=[RandArg((5, 2), _f32), RandArg((5, 1), np.int32)],
-                poly_axes=[0, 0]),
+                polymorphic_shapes=["b, ...", "b, ..."]),
     PolyHarness("tile", "0",
                 lambda x: jnp.tile(x, (1, 2)),
                 arg_descriptors=[RandArg((4, 3), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("tile", "1",
                 # The repetitions are polys
                 lambda x: jnp.tile(x, (1, x.shape[0])),
                 arg_descriptors=[RandArg((4, 2), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("lax_top_k", "",
                 lambda x: jax.lax.top_k(x, x.shape[-1] - 1),
                 arg_descriptors=[RandArg((16,), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("tri", "N=poly_M=None",
                 lambda x: jnp.tri(x.shape[0]) + x,
                 arg_descriptors=[RandArg((3, 1), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     PolyHarness("tri", "N=poly_M=poly",
                 lambda x: jnp.tri(x.shape[0], M=x.shape[0] + 2) + x,
                 arg_descriptors=[RandArg((3, 1), _f32)],
-                poly_axes=[0]),
+                polymorphic_shapes=["b, ..."]),
     [
         PolyHarness("var",
                     f"{axis=}_{keepdims=}_where=None",
                     lambda x, axis, keepdims: jnp.var(x, axis=axis, keepdims=keepdims, where=None),
                     arg_descriptors=[RandArg((7, 8, 4), _f32), StaticArg(axis), StaticArg(keepdims)],
-                    poly_axes=[0])
+                    polymorphic_shapes=["b, ..."])
         for keepdims in [False, True]
         for axis in [None, (0,), (0, 1), (1,)]
     ],
@@ -2655,14 +2595,14 @@ _POLY_SHAPE_TEST_HARNESSES = [
                     f"{axis=}_{keepdims=}_where=Some",
                     lambda x, where, axis, keepdims: jnp.var(x, axis=axis, keepdims=keepdims, where=where),
                     arg_descriptors=[RandArg((7, 8, 4), _f32), RandArg((7, 8, 4), np.bool_), StaticArg(axis), StaticArg(keepdims)],
-                    poly_axes=[0, 0])
+                    polymorphic_shapes=["b, ...", "b, ..."])
         for keepdims in [False, True]
         for axis in [None, (0,), (0, 1), (1,)]
     ],
     PolyHarness("where", "",
                 jnp.where,
                 arg_descriptors=[RandArg((2,), np.bool_), RandArg((), _f32), RandArg((2,), _f32)],
-                poly_axes=[0, None, 0]),
+                polymorphic_shapes=["b, ...", None, "b, ..."]),
 ]
 
 def _get_jax2tf_limitations(
@@ -2747,7 +2687,7 @@ def _make_vmap_primitive_harnesses() -> Sequence[PolyHarness]:
     vmap_harness = PolyHarness("vmap_" + h.group_name, h.name,
                                jax.vmap(h.dyn_fun, in_axes=0, out_axes=0),
                                arg_descriptors=new_args,
-                               poly_axes=[0] * len(new_args),
+                               polymorphic_shapes=["b, ..."] * len(new_args),
                                limitations=limitations)
     vmap_harness.original_harness = h
     res.append(vmap_harness)


### PR DESCRIPTION
Removed the poly_axes parameter and replaced with
polymorphic_shapes, which is a standard way to specify polymorphic shapes.