### PR TITLE
Don't allow the use of stale cache entries in Github actions CI.

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -89,9 +89,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py', '**/requirements.txt', '**/test-requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('**/setup.py', '**/requirements.txt', '**/test-requirements.txt') }}
     - name: Install dependencies
       run: |
         pip install -r build/test-requirements.txt
@@ -150,8 +148,6 @@ jobs:
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py', '**/requirements.txt', '**/test-requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
         pip install -r docs/requirements.txt


### PR DESCRIPTION
The use of restore-keys allows the pip cache to match stale cache entries. This allows for partial cache reuse, but means the cache also grows without bound.

At the time of writing, the pip cache is 4.7GB, which is much larger than just downloading the wheels we need (130MB)! So it's probably a net positive not to reuse caches even if it requires some redundant downloads, to avoid the caches growing without bound over time.

The lack of a mechanism to clear the cache was noted in the original PR that added the cache: https://github.com/google/jax/pull/3990