### PR TITLE
[jax2tf] Add a safety check for which dialects are allowed in native serialization

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -1005,12 +1005,22 @@ The `jax2tf`-lowered function supports higher-order gradients, but when the
 function is saved in a SavedModel, only the first-order gradient is saved.
 This is primarily a limitation of the SavedModel support for custom gradients.
 
+### Native serialization supports only select dialects
+
+Applies to native serialization only.
+
+JAX native serialization checks that the code to be serialized contains
+operations only from MLIR dialects that are known to have stability guarantees,
+e.g., StableHLO, and the "builtin" dialect. As an exception, it also accepts
+operations from the MHLO dialect, but they are converted to corresponding
+StableHLO operations upon serialization.
+
 ### Native serialization supports only select custom calls
 
 Applies to native serialization only.
 
 JAX natively uses custom calls for lowering of certain primitives.
-The most common example is for the implementation of PRNG on GPUs
+The most common example is for the implementation of PRNG on GPUs,
 where we get better performance with a custom call (`cu_threefry32`)
 than if we use native StableHLO. Another class of examples are for
 FFT and some linear algebra primitives (e.g., QR decomposition).

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -308,7 +308,7 @@ def convert(fun_jax: Callable,
       backend on the machine where the lowering is done.
     native_serialization_disabled_checks: In conjunction with
       `native_serialization`, disable the specified safety checks.
-      See docstring of DisabledSafetyCheck.
+      See docstring of `DisabledSafetyCheck`.
 
   Returns:
     A version of `fun_jax` that expects TfVals as arguments (or

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -1132,18 +1132,6 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
 
     self.ConvertAndCompare(randint)
 
-  def test_error_disallowed_custom_call(self):
-    if jtu.device_under_test() != "cpu":
-      self.skipTest("Test intended for CPU only")
-    # For now triangular_solve on CPU uses the unsupported "blas_strsm" target
-    a = np.arange(16, dtype=np.float32).reshape((4, 4))
-    b = np.arange(4, dtype=np.float32).reshape((4, 1))
-    with self.assertRaisesRegex(ValueError,
-        "Cannot serialize code with custom calls whose targets .*"):
-      jax2tf.convert(
-          lambda a, b: jax.lax.linalg.triangular_solve(a, b, left_side=True),
-          native_serialization=True)(a, b)
-
   def test_op_metadata_simple(self):
     self.skipTest("include_xla_op_metadata not yet enabled")
     # A simple example


### PR DESCRIPTION
This is fixing a loophole in the existing safety check, if the code uses mhlo.custom_call.
