### PR TITLE
If jax is imported with Python 3.8, warn that 3.8 support will be dro…

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -247,6 +247,24 @@ if not config.jax_jit_pjit_api_merge:
       ' disable jax.config.jax_jit_pjit_api_merge.'
   )
 
+import sys as _sys
+if _sys.version_info < (3, 9):
+  from warnings import warn as _warn
+  import jax._src.cloud_tpu_init as _cloud_tpu_init  # type: ignore[no-redef]
+  msg = ("JAX will drop Python 3.8 support in an upcoming future release "
+         "(see https://jax.readthedocs.io/en/latest/deprecation.html). "
+         "Please upgrade your Python version to 3.9 or higher. "
+         f"Current version: {_sys.version.split(' ')[0]}")
+  if _cloud_tpu_init.running_in_cloud_tpu_vm:
+    msg += (
+      "\n\nIf you're using the Python version shipped with the TPU VM image "
+      "'tpu-vm-base' or similar, we recommend switching to "
+      "'tpu-ubuntu2204-base' for all TPU types.")
+  _warn(msg)
+  del _cloud_tpu_init
+  del _warn
+del _sys
+
 import jax.lib  # TODO(phawkins): remove this export.
 
 # trailer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ filterwarnings = [
     # TODO(skyewm): remove when jaxlib >= 0.4.12 is released (needs
     # https://github.com/openxla/xla/commit/fb9dc3db0999bf14c78d95cb7c3aa6815221ddc7)
     "ignore:ml_dtypes.float8_e4m3b11 is deprecated.",
+    # TODO(skyewm): remove when we remove Python 3.8 CI
+    "ignore:JAX will drop Python 3.8 support in an upcoming future release",
 ]
 doctest_optionflags = [
     "NUMBER",


### PR DESCRIPTION
…pped soon.

Non-TPU message:
```
$ python3 -c "import jax"
/usr/local/google/home/skyewm/jax/jax/__init__.py:263: UserWarning: jax will drop Python 3.8 support in an upcoming future release (see https://jax.readthedocs.io/en/latest/deprecation.html). Please upgrade your Python version to 3.9 or higher. Current version: 3.8.5
  _warn(msg)
```

TPU VM message:
```
$ python3 -c "import jax"
/usr/local/google/home/skyewm/jax/jax/__init__.py:263: UserWarning: jax will drop Python 3.8 support in an upcoming future release (see https://jax.readthedocs.io/en/latest/deprecation.html). Please upgrade your Python version to 3.9 or higher. Current version: 3.8.5

If you're using the Python version shipped with the TPU VM image 'tpu-vm-base' or similar, we recommend switching to 'tpu-ubuntu2204-base' for all TPU types.
  _warn(msg)
```