### PR TITLE
Add tree_util.Static

### DIFF
--- a/docs/jax.tree_util.rst
+++ b/docs/jax.tree_util.rst
@@ -12,6 +12,7 @@ List of Functions
    :toctree: _autosummary
 
    Partial
+   Static
    all_leaves
    build_tree
    register_pytree_node

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -66,6 +66,7 @@ from jax._src.tree_util import (
   DictKey as DictKey,
   GetAttrKey as GetAttrKey,
   FlattenedIndexKey as FlattenedIndexKey,
+  Static as Static,
   # TODO(ivyzheng): Remove these old APIs after June 10 2023.
   register_keypaths,
   AttributeKeyPathEntry,

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -589,6 +589,35 @@ class TreeTest(jtu.JaxTestCase):
     leaves, _ = tree_util.tree_flatten_with_path(ATuple2(1, 'hi'))
     self.assertLen(leaves, 1)
 
+  def test_static(self):
+    num_compilations = 0
+
+    @jax.jit
+    def add_exclamation(static):
+      nonlocal num_compilations
+      num_compilations += 1
+      return tree_util.Static(static.value + "!")
+
+    static = add_exclamation(tree_util.Static("hi"))
+    self.assertEqual(num_compilations, 1)
+    self.assertEqual(static.value, "hi!")
+
+    # check no recompilation for same value
+    static = add_exclamation(tree_util.Static("hi"))
+    self.assertEqual(num_compilations, 1)
+    self.assertEqual(static.value, "hi!")
+
+    # check recompilation for different value
+    static = add_exclamation(tree_util.Static("bye"))
+    self.assertEqual(num_compilations, 2)
+    self.assertEqual(static.value, "bye!")
+
+
+
+
+
+
+
 
 class RavelUtilTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
# Changes

Partial solution for google/flax#3110.

Adds a `Static` type that is an empty pytree node with its value as metadata, useful to pass non-JAX types across JAX boundaries.