### PR TITLE
Preserve integer dtype in broadcast_one_to_all

### DIFF
--- a/jax/experimental/multihost_utils.py
+++ b/jax/experimental/multihost_utils.py
@@ -38,7 +38,7 @@ import numpy as np
 
 
 def _psum(x: Any) -> Any:
-  return jax.tree_map(partial(jnp.sum, axis=0), x)
+  return jax.tree_map(partial(jnp.sum, axis=0, promote_integers=False), x)
 
 
 def broadcast_one_to_all(in_tree: Any, is_source: Optional[bool] = None) -> Any:


### PR DESCRIPTION
I was trying to broadcast PRNGKeys using `jax.experimental.multihost_utils.broadcast_one_to_all` while in 64 bit mode, which resulted in invalid keys because the `uint32` arrays were promoted to `uint64`.
This PR fixes this.

reproducer:
```python
import jax
import jax.numpy as jnp

jax.config.update("jax_enable_x64", True)

# jax.distributed.initialize(...)

x = jnp.ones(1, dtype=jnp.uint32)
y = jax.experimental.multihost_utils.broadcast_one_to_all(x)
print(x.dtype, y.dtype)
```
output before: `uint32 uint64`
output after this change: `uint32 uint32`
