### PR TITLE
Drop support for numpy 1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Remember to align the itemized text with the first line of an item within a list
 * Deprecations
   * Python 3.8 support has been dropped as per
     https://jax.readthedocs.io/en/latest/deprecation.html
+  * JAX now requires NumPy 1.22 or newer as per
+    https://jax.readthedocs.io/en/latest/deprecation.html
 
 ## jaxlib 0.4.14
 

--- a/build/build.py
+++ b/build/build.py
@@ -83,8 +83,8 @@ def check_numpy_version(python_bin_path):
   version = shell(
       [python_bin_path, "-c", "import numpy as np; print(np.__version__)"])
   numpy_version = tuple(map(int, version.split(".")[:2]))
-  if numpy_version < (1, 21):
-    print("ERROR: JAX requires NumPy 1.21 or newer, found " + version + ".")
+  if numpy_version < (1, 22):
+    print("ERROR: JAX requires NumPy 1.22 or newer, found " + version + ".")
     sys.exit(-1)
   return version
 

--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,7 +1,7 @@
 absl-py
 cloudpickle
 colorama>=0.4.4
-numpy>=1.21
+numpy>=1.22
 pillow>=9.1.0
 portpicker
 pytest-xdist

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -50,7 +50,7 @@ setup(
     author_email='jax-dev@google.com',
     packages=['jaxlib', 'jaxlib.xla_extension'],
     python_requires='>=3.9',
-    install_requires=['scipy>=1.7', 'numpy>=1.21', 'ml_dtypes>=0.1.0'],
+    install_requires=['scipy>=1.7', 'numpy>=1.22', 'ml_dtypes>=0.1.0'],
     extras_require={
       'cuda11_pip': [
         "nvidia-cublas-cu11>=11.11",

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     python_requires='>=3.9',
     install_requires=[
         'ml_dtypes>=0.1.0',
-        'numpy>=1.21',
+        'numpy>=1.22',
         'opt_einsum',
         'scipy>=1.7',
         # Required by xla_bridge.discover_pjrt_plugins for forwards compat with

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -79,8 +79,6 @@ config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
 
-numpy_version = jtu.numpy_version()
-
 def _check_instance(self, x):
   self.assertIsInstance(x, array.ArrayImpl)
 
@@ -2465,8 +2463,6 @@ class APITest(jtu.JaxTestCase):
        r"sub-dtype of np.inexact\), but got int.*."),
       lambda: dfn(3))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_jvp_of_int_identity(self):
     primals = (1,)
     tangents = (np.zeros(shape=(), dtype=float0),)
@@ -2474,8 +2470,6 @@ class APITest(jtu.JaxTestCase):
     _, out = api.jvp(lambda x: x, primals, tangents)
     self.assertEqual(out, np.zeros(shape=(), dtype=float0))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_jvp_of_int_add(self):
     primals = (2,)
     tangents = (np.zeros(shape=(), dtype=float0),)
@@ -2483,8 +2477,6 @@ class APITest(jtu.JaxTestCase):
     _, out_tangent = api.jvp(lambda x: x+1, primals, tangents)
     self.assertEqual(out_tangent, np.zeros(shape=(), dtype=float0))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_jit_jvp_of_int(self):
     primals = (2,)
     tangents = (np.zeros(shape=(), dtype=float0),)
@@ -2492,8 +2484,6 @@ class APITest(jtu.JaxTestCase):
     _, out_tangent = api.jvp(jax.jit(lambda x: x+1), primals, tangents)
     self.assertEqual(out_tangent, np.zeros(shape=(), dtype=float0))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_vjp_of_int_index(self):
     primal, fn_vjp = api.vjp(lambda x, i: x[i], np.ones(2)*2, 1)
     tangent_x, tangent_i = fn_vjp(1.)
@@ -2501,16 +2491,12 @@ class APITest(jtu.JaxTestCase):
     self.assertAllClose(tangent_x, jnp.array([0., 1.]))
     self.assertEqual(tangent_i, np.zeros(shape=(), dtype=float0))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_vjp_of_int_shapes(self):
     out, fn_vjp = api.vjp(lambda x: lax.reshape(x, (2, 2)), np.ones((4, 1),
                                                                     dtype=int))
     tangent, = fn_vjp(out)
     self.assertArraysEqual(tangent, np.zeros(shape=(4, 1), dtype=float0))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_jit_vjp_of_int(self):
     primal, fn_vjp = api.vjp(lambda x, y: x+y, 2, 1)
     tangent_x, tangent_i = jax.jit(fn_vjp)(1)
@@ -2518,8 +2504,6 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(tangent_x, np.zeros(shape=(), dtype=float0))
     self.assertEqual(tangent_i, np.zeros(shape=(), dtype=float0))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_vjp_of_int_fulllike(self):
     # Regression test for tangent and cotangent mismatch in convert_element_type
     # transpose rule wrt a ConstVar
@@ -2530,15 +2514,11 @@ class APITest(jtu.JaxTestCase):
     self.assertAllClose(tangent_x, jnp.zeros((2, 2)))
     self.assertEqual(tangent_y, np.zeros(shape=(), dtype=float0))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_grad_of_int(self):
     # Need real-valued output, but testing integer input.
     out = api.grad(lambda x: x+0., allow_int=True)(1)
     self.assertEqual(out, np.zeros(shape=(), dtype=float0))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_grad_of_bool(self):
     def cond(pred):
       return lax.cond(pred, lambda _: 1., lambda _: 2., 1.)
@@ -2546,24 +2526,18 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(value, 1.)
     self.assertEqual(grd, np.zeros(shape=(), dtype=float0))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_grad_of_int_index(self):
     grad_x, grad_i = api.grad(lambda x, i: x[i], argnums=(0, 1),
                               allow_int=True)(np.ones(2), 1)
     self.assertAllClose(grad_x, jnp.array([0., 1.]))
     self.assertEqual(grad_i, np.zeros(shape=(), dtype=float0))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_jit_grad_of_int(self):
     grad_f = api.grad(lambda x, i: x[i], argnums=(0, 1), allow_int=True)
     grad_x, grad_i = jax.jit(grad_f)(np.ones(2), 1)
     self.assertAllClose(grad_x, jnp.array([0., 1.]))
     self.assertEqual(grad_i, np.zeros(shape=(), dtype=float0))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_float0_reshape(self):
     # dtype-agnostic operations are supported
     float0_array = jax.grad(lambda x: jnp.sum(x+0.),
@@ -7083,8 +7057,6 @@ class CustomJVPTest(jtu.JaxTestCase):
     self.assertAllClose(primals ,     jnp.arange(3., dtype='float32'))
     self.assertAllClose(tangents, 2 * jnp.arange(3., dtype='float32'))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_float0(self):
     @jax.custom_jvp
     def f(x, y):
@@ -7100,8 +7072,6 @@ class CustomJVPTest(jtu.JaxTestCase):
     self.assertArraysEqual(api.jvp(f, primals, tangents),
                            (primals, expected_tangents))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_float0_initial_style(self):
     @jax.custom_jvp
     def f(x, y):
@@ -8234,8 +8204,6 @@ class CustomVJPTest(jtu.JaxTestCase):
     ans = jax.grad(f)(4.)
     self.assertAllClose(ans, -2. * jnp.sin(4.))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_float0(self):
     @jax.custom_vjp
     def f(x, _):
@@ -8252,8 +8220,6 @@ class CustomVJPTest(jtu.JaxTestCase):
     self.assertEqual(api.grad(f, allow_int=True, argnums=(0, 1))(x, y),
                      (2., np.zeros(shape=(), dtype=float0)))
 
-  @unittest.skipIf(numpy_version == (1, 21, 0),
-                   "https://github.com/numpy/numpy/issues/19305")
   def test_float0_initial_style(self):
     @jax.custom_vjp
     def f(x):

--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -145,7 +145,6 @@ class DLPackTest(jtu.JaxTestCase):
     shape=all_shapes,
     dtype=numpy_dtypes,
   )
-  @unittest.skipIf(numpy_version < (1, 22, 0), "Requires numpy 1.22 or newer")
   def testNumpyToJax(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
     x_np = rng(shape, dtype)

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -395,10 +395,9 @@ class DtypesTest(jtu.JaxTestCase):
       assertInfinite(2. ** info.maxexp)
 
     # smallest_normal & smallest_subnormal added in numpy 1.22
-    if jtu.numpy_version() >= (1, 22, 0):
-      assertRepresentable(info.smallest_subnormal)
-      assertZero(info.smallest_subnormal * 0.5)
-      self.assertEqual(info.tiny, info.smallest_normal)
+    assertRepresentable(info.smallest_subnormal)
+    assertZero(info.smallest_subnormal * 0.5)
+    self.assertEqual(info.tiny, info.smallest_normal)
 
     # Identities according to the documentation:
     self.assertAllClose(info.resolution, make_val(10 ** -info.precision))

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -31,7 +31,6 @@ from jax import config
 config.parse_flags_with_absl()
 
 scipy_version = tuple(map(int, scipy.version.version.split('.')[:3]))
-numpy_version = jtu.numpy_version()
 
 all_shapes = [(), (4,), (3, 4), (3, 1), (1, 4), (2, 1, 4)]
 one_and_two_dim_shapes = [(4,), (3, 4), (3, 1), (1, 4)]


### PR DESCRIPTION
This is in accordance with NEP 29 and https://jax.readthedocs.io/en/latest/deprecation.html

Looks like we need to update some kokoro scripts first.