### PR TITLE
Finish pile_map support enough for a basic transformer example

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2124,6 +2124,20 @@ def _invalid_shape_error(shape: Shape, context: str=""):
 
   return TypeError(msg)
 
+class SomeTracer(object):
+  __slots__ = ()
+  def __repr__(self): return "[dynamic]"
+
+def replace_tracer_for_error_message(obj):
+  # TODO(mattjj): Many ideas for improving this.  Crawl the stack and see if
+  # there are user variables whose value is == to this object?  Or search
+  # parameters of functions being transformed, at least?  Or at least assign
+  # short unique ids to them?
+  if isinstance(obj, Tracer):
+    return SomeTracer()
+  else:
+    return obj
+
 def evaluate_shape(shape: Shape, dim_vars: Sequence[str],
                    *dim_values: Array) -> Sequence[Array]:
   """Evaluates a shape possibly containing non-constants.

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -135,14 +135,17 @@ class RaggedAxis:
 
   def transpose_ragged_axes(self, perm):
     new_ragged_axes = [(perm[ax], size) for ax, size in self.ragged_axes]
-    return RaggedAxis(self.stacked_axis, new_ragged_axes)
+    return _sorted_ragged_axis(self.stacked_axis, new_ragged_axes)
+
+def _sorted_ragged_axis(stacked_axis, ragged_axes):
+  return RaggedAxis(stacked_axis, list(sorted(ragged_axes, key=lambda p: p[0])))
 
 def make_batch_axis(
     ndim: int, stacked_axis: int, ragged_axes: list[tuple[int, Array]]
   ) -> Union[int, RaggedAxis]:
   if ragged_axes:
     canonical = [(canonicalize_axis(ax, ndim), sz) for ax, sz in ragged_axes]
-    return RaggedAxis(canonicalize_axis(stacked_axis, ndim), canonical)
+    return _sorted_ragged_axis(canonicalize_axis(stacked_axis, ndim), canonical)
   else:
     return canonicalize_axis(stacked_axis, ndim)
 

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -404,6 +404,8 @@ class BatchTrace(Trace):
     return frame
 
   def process_primitive(self, primitive, tracers, params):
+    if config.jax_dynamic_shapes:
+      primitive.abstract_eval(*(t.aval for t in tracers), **params)
     vals_in, dims_in = unzip2((t.val, t.batch_dim) for t in tracers)
     is_axis_primitive = primitive in axis_primitive_batchers
     used_names = core.used_axis_names(primitive, params)

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -122,7 +122,7 @@ class RaggedAxis:
     # same length!
     return len(self.ragged_axes[0][1])
 
-  def move_stacked_axis(self, dst):
+  def move_stacked_axis(self: RaggedAxis, dst: int) -> RaggedAxis:
     # Assumes that all stored and incoming axes are already canonicalized
     def move_axis(ax):
       if self.stacked_axis > ax and ax >= dst:
@@ -133,14 +133,14 @@ class RaggedAxis:
     new_ragged_axes = [(move_axis(ax), sizes) for ax, sizes in self.ragged_axes]
     return RaggedAxis(dst, new_ragged_axes)
 
-  def transpose_ragged_axes(self, perm):
-    new_ragged_axes = []
-    for idx, old_idx in enumerate(perm):
-      for ax, size in self.ragged_axes:
-        if old_idx == ax:
-          new_ragged_axes.append((idx, size))
-          break
-    return _sorted_ragged_axis(self.stacked_axis, new_ragged_axes)
+def transpose_ragged_axes(dim: RaggedAxis, perm: tuple[int, ...]) -> RaggedAxis:
+  new_ragged_axes = []
+  for idx, old_idx in enumerate(perm):
+    for ax, size in dim.ragged_axes:
+      if old_idx == ax:
+        new_ragged_axes.append((idx, size))
+        break
+  return _sorted_ragged_axis(dim.stacked_axis, new_ragged_axes)
 
 def _sorted_ragged_axis(stacked_axis, ragged_axes):
   return RaggedAxis(stacked_axis, list(sorted(ragged_axes, key=lambda p: p[0])))

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -134,7 +134,12 @@ class RaggedAxis:
     return RaggedAxis(dst, new_ragged_axes)
 
   def transpose_ragged_axes(self, perm):
-    new_ragged_axes = [(perm[ax], size) for ax, size in self.ragged_axes]
+    new_ragged_axes = []
+    for idx, old_idx in enumerate(perm):
+      for ax, size in self.ragged_axes:
+        if old_idx == ax:
+          new_ragged_axes.append((idx, size))
+          break
     return _sorted_ragged_axis(self.stacked_axis, new_ragged_axes)
 
 def _sorted_ragged_axis(stacked_axis, ragged_axes):

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3265,8 +3265,12 @@ def _squeeze_transpose_rule(t, operand, *, dimensions):
 def _squeeze_batch_rule(batched_args, batch_dims, *, dimensions):
   operand, = batched_args
   bdim, = batch_dims
-  operand, bdim_out = batching.move_stacked_axis(operand, bdim, 0)
+  operand, bdim = batching.move_stacked_axis(operand, bdim, 0)
   dimensions = tuple(np.add(1, dimensions))
+  out_stack_dim = bdim.stacked_axis if isinstance(bdim, RaggedAxis) else bdim
+  bdim_out = batching.shape_as_bdim(
+      out_stack_dim,
+      _compute_squeeze_shape(batching.bdim_as_shape(bdim, operand.shape), dimensions))
   return squeeze(operand, dimensions=dimensions), bdim_out
 
 squeeze_p = standard_primitive(_squeeze_shape_rule, _squeeze_dtype_rule,

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3414,10 +3414,10 @@ def _transpose_batch_rule(batched_args, batch_dims, *, permutation):
   stack_dim = bdim.stacked_axis if isinstance(bdim, RaggedAxis) else bdim
   perm = (stack_dim,) + tuple(i if i < stack_dim else i+1 for i in permutation)
   if isinstance(bdim, RaggedAxis):
-    result_bdim = bdim.move_stacked_axis(0).transpose_ragged_axes(perm)
+    res_bdim = batching.transpose_ragged_axes(bdim.move_stacked_axis(0), perm)
   else:
-    result_bdim = 0
-  return transpose(operand, perm), result_bdim
+    res_bdim = 0
+  return transpose(operand, perm), res_bdim
 
 def _transpose_lower(ctx, x, *, permutation):
   aval_out, = ctx.avals_out

--- a/tests/dynamic_api_test.py
+++ b/tests/dynamic_api_test.py
@@ -1639,7 +1639,7 @@ class PileTest(jtu.JaxTestCase):
     data = jax.lax.broadcasted_iota('int32', (3, 5, 7), 1)
     self.assertAllClose(p.data, data)
 
-  def test_einsum_ragged_tensor(self):
+  def test_einsum_with_ragged_tensor_dimension(self):
     x_sizes = lax.convert_element_type(jnp.array([3, 1, 4]), core.bint(5))
     def fprop_layer(x_size):
       one_d = jnp.arange(x_size, dtype='int32')
@@ -1652,7 +1652,7 @@ class PileTest(jtu.JaxTestCase):
     self.assertRegex(str(p.aval), r'Var[0-9]+:3 => i32\[3,bint\{≤5\}\[3\] with value: \[3 1 4\]\.Var[0-9]+,2,7\]')
     self.assertEqual(p.data.shape, (3, 3, 5, 2, 7))
 
-  def test_einsum_ragged_tensor_and_contract(self):
+  def test_einsum_with_ragged_tensor_and_contract_dimensions(self):
     ragged_sizes = lax.convert_element_type(jnp.array([3, 1, 4]), core.bint(5))
     def fprop_layer(ragged_size):
       one_d = jnp.arange(ragged_size, dtype='int32')

--- a/tests/dynamic_api_test.py
+++ b/tests/dynamic_api_test.py
@@ -1652,6 +1652,18 @@ class PileTest(jtu.JaxTestCase):
     self.assertRegex(str(p.aval), r'Var[0-9]+:3 => i32\[3,bint\{≤5\}\[3\] with value: \[3 1 4\]\.Var[0-9]+,2,7\]')
     self.assertEqual(p.data.shape, (3, 3, 5, 2, 7))
 
+  def test_split_while_ragged(self):
+    ins = lax.convert_element_type(jnp.array([3, 1, 4]), core.bint(5))
+    def func(size):
+      one_d = jnp.arange(size, dtype='int32')
+      two_d = jnp.broadcast_to(one_d, (2, size))
+      part_1, part_2 = two_d
+      return part_1
+    p = jax.vmap(func, out_axes=batching.pile_axis)(ins)
+    self.assertIsInstance(p, batching.Pile)
+    data = jax.lax.broadcasted_iota('int32', (3, 5), 1)
+    self.assertAllClose(p.data, data)
+
 def pile_map(f):
   def mapped(*piles):
     return jax.vmap(f, in_axes=batching.pile_axis, out_axes=batching.pile_axis,


### PR DESCRIPTION
The remaining operations to cover were
- Slicing a non-ragged axis when ragged axes are present
- Einsum where both tensor and contraction dimensions are ragged

Also improved the error message that happens when trying to broadcast a ragged axis to a rectangular one