### PR TITLE
[shape_poly] Cleanup the evaluation of dynamic shapes

### DIFF
--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -731,7 +731,7 @@ def _conv_general_dilated_lower(
     # spatial dimension.
     int2d = mlir.aval_to_ir_type(core.ShapedArray((1, 2), np.int32))
     def prep_one_pad(pad_lo_hi: tuple[core.DimSize, core.DimSize]):
-      pad1 = mlir.shape_tensor(mlir.eval_dynamic_shape(ctx, pad_lo_hi))  # i32[2]
+      pad1 = mlir.eval_dynamic_shape_as_tensor(ctx, pad_lo_hi)  # i32[2]
       return hlo.ReshapeOp(int2d, pad1)
     d_padding = hlo.ConcatenateOp(list(map(prep_one_pad, padding)),
                                   mlir.i64_attr(0))

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -636,7 +636,7 @@ def _eigh_jacobi_lowering_rule(ctx, operand, lower, sort_eigenvalues):
       raise ValueError("shape polymorphism with native lowering for eigh on "
                        "TPU requires jaxlib version 0.4.9.")
     result_shapes = [
-        mlir.shape_tensor(mlir.eval_dynamic_shape(ctx, aval_out.shape))
+        mlir.eval_dynamic_shape_as_tensor(ctx, aval_out.shape)
         # The custom call returns the results swapped
         for aval_out in list(reversed(ctx.avals_out))
     ]
@@ -707,9 +707,9 @@ def _eigh_cpu_gpu_lowering(syevd_impl, ctx, operand, *, lower,
     batch_size = mlir.eval_dynamic_shape(ctx, (batch_size_num,))[0]
     if isinstance(batch_size, int):
       batch_size = mlir.ir_constant(np.int32(batch_size))
-    v_shape: ir.Value = mlir.shape_tensor(mlir.eval_dynamic_shape(ctx, v_aval.shape))
-    w_shape: ir.Value = mlir.shape_tensor(mlir.eval_dynamic_shape(ctx, w_aval.shape))
-    info_shape: ir.Value = mlir.shape_tensor(mlir.eval_dynamic_shape(ctx, batch_dims))
+    v_shape: ir.Value = mlir.eval_dynamic_shape_as_tensor(ctx, v_aval.shape)
+    w_shape: ir.Value = mlir.eval_dynamic_shape_as_tensor(ctx, w_aval.shape)
+    info_shape: ir.Value = mlir.eval_dynamic_shape_as_tensor(ctx, batch_dims)
     v, w, info = syevd_impl(operand_aval.dtype, operand, batch_size,
                             v_shape, w_shape, info_shape,
                             lower=lower)
@@ -1290,7 +1290,7 @@ def _lu_tpu_lowering_rule(ctx, operand):
     mlir.aval_to_ir_type(ctx.avals_out[2])]
   if any(not is_constant_shape(a.shape) for a in ctx.avals_out):
     result_shapes = [
-      mlir.shape_tensor(mlir.eval_dynamic_shape(ctx, a.shape))
+      mlir.eval_dynamic_shape_as_tensor(ctx, a.shape)
       for a in ctx.avals_out]
   else:
     result_shapes = None
@@ -1424,7 +1424,7 @@ def _geqrf_lowering_rule(ctx, operand):
   if any(not is_constant_shape(aval_out.shape)
          for aval_out in ctx.avals_out):
     result_shapes = [
-        mlir.shape_tensor(mlir.eval_dynamic_shape(ctx, aval_out.shape))
+        mlir.eval_dynamic_shape_as_tensor(ctx, aval_out.shape)
         for aval_out in ctx.avals_out
     ]
   else:
@@ -1551,7 +1551,7 @@ def _householder_product_lowering_rule(ctx, a, taus):
   aval_out, = ctx.avals_out
   if not is_constant_shape(aval_out.shape):
     result_shapes = [
-        mlir.shape_tensor(mlir.eval_dynamic_shape(ctx, aval_out.shape))]
+        mlir.eval_dynamic_shape_as_tensor(ctx, aval_out.shape)]
   else:
     result_shapes = None
   op = mlir.custom_call(

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -1416,14 +1416,14 @@ def _gather_lower(ctx, operand, indices, *,
     offset_dims=list(dimension_numbers.offset_dims),
     start_index_map=list(dimension_numbers.start_index_map))
   if not core.is_constant_shape(slice_sizes):
-    slice_sizes = mlir.eval_dynamic_shape(ctx, slice_sizes)
+    slice_sizes = mlir.eval_dynamic_shape_as_tensor(ctx, slice_sizes)
     # TODO(burmako): Fix overly conservative type inference of DynamicGatherOp.
     # For now use the build_generic so that we can specify the result type.
     # return hlo.DynamicGatherOp(
     #     operand, indices, mlir.shape_tensor(slice_sizes),
     #     dnums, indices_are_sorted=ir.BoolAttr.get(indices_are_sorted)).results
     results = [mlir.aval_to_ir_type(aval_out)]
-    operands = [operand, indices, mlir.shape_tensor(slice_sizes)]
+    operands = [operand, indices, slice_sizes]
     attributes = {
         "dimension_numbers": dnums,
         "indices_are_sorted": ir.BoolAttr.get(indices_are_sorted)

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -1068,11 +1068,11 @@ def _threefry2x32_gpu_lowering(lowering_func, ctx, k1, k2, x1, x2):
 
   out_len = reduce(op.mul, aval_out.shape, 1)
   if not core.is_constant_dim(out_len):
-    length = mlir.shape_tensor(mlir.eval_dynamic_shape(ctx, [out_len]))
+    length = mlir.eval_dynamic_shape_as_tensor(ctx, [out_len])
     length = mlir.hlo.ConvertOp(
         ir.RankedTensorType.get((1,), ir.IntegerType.get_signless(64)),
         length).result
-    output_shape = mlir.shape_tensor(mlir.eval_dynamic_shape(ctx, aval_out.shape))
+    output_shape = mlir.eval_dynamic_shape_as_tensor(ctx, aval_out.shape)
   else:
     length = int(out_len)  # will be passed statically
     output_shape = None


### PR DESCRIPTION
Previously, we used the following pattern to generate the 1D tensors representing dynamic shapes:

```
mlir.shape_tensor(mlir.eval_dynamic_shape(ctx, shape))
```

Now we write:
```
mlir.eval_dynamic_shape_as_tensor(ctx, shape)
```