### PR TITLE
outline jitted threefry `split` and `fold_in` subroutines

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -1252,6 +1252,10 @@ def threefry_2x32(keypair, count):
 def threefry_split(key: typing.Array, num: core.DimSize) -> typing.Array:
   if not core.is_special_dim_size(num):
     num = core.concrete_or_error(op.index, num)
+  return _threefry_split(key, num)
+
+@partial(jit, static_argnums=(1,))
+def _threefry_split(key, num) -> typing.Array:
   if config.jax_threefry_partitionable:
     return _threefry_split_foldlike(key, num)  # type: ignore
   else:
@@ -1274,7 +1278,7 @@ def threefry_fold_in(key: typing.Array, data: typing.Array) -> typing.Array:
   assert not data.shape
   return _threefry_fold_in(key, jnp.uint32(data))
 
-@partial(jit, inline=True)
+@jit
 def _threefry_fold_in(key, data):
   return threefry_2x32(key, threefry_seed(data))
 


### PR DESCRIPTION
We may want to continue to inline these in Jaxpr, but it's useful to outline them in HLO for visualization and debugging.

Similar to #16142