### PR TITLE
Fix _sph_harm to agree with scipy results.

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -1122,7 +1122,7 @@ def _sph_harm(m: Array,
   cos_colatitude = jnp.cos(phi)
 
   legendre = _gen_associated_legendre(n_max, cos_colatitude, True)
-  legendre_val = legendre.at[abs(m), n, jnp.arange(len(n))].get(mode="clip")
+  legendre_val = legendre.at[abs(m), n, jnp.arange(len(cos_colatitude))].get(mode="clip")
 
   angle = abs(m) * theta
   vandermonde = lax.complex(jnp.cos(angle), jnp.sin(angle))

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -415,7 +415,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
   def testSphHarmForJitAndAgainstNumpy(self, l_max, num_z, dtype):
     """Tests against JIT compatibility and Numpy."""
     n_max = l_max
-    shape = (num_z,)
+    shape = (1,)
     rng = jtu.rand_int(self.rng(), -l_max, l_max + 1)
 
     lsp_special_fn = partial(lsp_special.sph_harm, n_max=n_max)


### PR DESCRIPTION
Before the fix, the following code to compute spherical harmonics produces mostly an array filled with zeros (see sph.pdf) and does not agree with the scipy results. After the change, it does (see sph_fixed.pdf).

To reproduce:

```python
import jax.numpy as jnp
import jax.scipy.special as jp
import matplotlib.pyplot as plt
import numpy as np
import scipy.special as sp

l_max = jnp.array([2])
m_values = jnp.array([-2, -1, 0, 1, 2])


theta = jnp.linspace(0, 2 * np.pi, 1000)
phi = jnp.linspace(0, np.pi, 1000)

# Calculate the spherical harmonics
Y_lm = []
Y_lm_scipy = []
for m in m_values:
    Y_lm.append(jp.sph_harm(m, l_max, theta, phi))
    Y_lm_scipy.append(sp.sph_harm(m, l_max, theta, phi))

Ylm = jnp.array(Y_lm)
Ysci = jnp.array(Y_lm_scipy)

fig, ax = plt.subplots()
for idx in range(Ylm.shape[0]):
    ax.plot(Ylm.real[idx], "--", label="Jax", c=f"C{idx}", alpha=0.5)
    ax.plot(Ysci.real[idx], "-", label="Scipy", c=f"C{idx}", alpha=0.5)
ax.legend()
fig.savefig("sph_fixed.pdf")
```
[sph.pdf](https://github.com/google/jax/files/11889562/sph.pdf)
[sph_fixed.pdf](https://github.com/google/jax/files/11889563/sph_fixed.pdf)
