### PR TITLE
Expose a way to check for a name primitive in JAX checkpoint API

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -79,6 +79,10 @@ def dot_with_no_batch_dims_saveable(prim, *_, **params) -> bool:
 
 name_p = core.Primitive('name')
 
+def is_name_primitive(p: core.Primitive) -> bool:
+  """Checks whether a given primitive is a checkpoint name."""
+  return p is name_p 
+
 def save_anything_except_these_names(*names_not_to_save):
   """Save any values (not just named ones) excluding the names given."""
   names_not_to_save = frozenset(names_not_to_save)

--- a/jax/ad_checkpoint.py
+++ b/jax/ad_checkpoint.py
@@ -18,4 +18,5 @@ from jax._src.ad_checkpoint import (
   checkpoint_name,
   print_saved_residuals,
   remat,
+  is_name_primitive,
 )


### PR DESCRIPTION
This seems to be required to write custom checkpointing policy that relies on looking up `checkpoint_name`, e.g. a variant of ` save_only_these_names`.