### PR TITLE
add `impl` option to random key constructors that picks the RNG implementation

### DIFF
--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -498,7 +498,6 @@ class PrngTest(jtu.JaxTestCase):
         self.assertEqual(k1.shape, impl.key_shape)
         self.assertEqual(k2.shape, impl.key_shape)
 
-
   def test_explicit_threefry2x32_key(self):
     if not config.jax_enable_custom_prng:
       self.skipTest("test requires config.jax_enable_custom_prng")
@@ -516,6 +515,28 @@ class PrngTest(jtu.JaxTestCase):
       self.skipTest("test requires config.jax_enable_custom_prng")
     key = random.unsafe_rbg_key(42)
     self.assertIs(key.impl, prng.unsafe_rbg_prng_impl)
+
+  def test_key_construction_with_explicit_impl_name(self):
+    def check_key_has_impl(key, impl):
+      if isinstance(key, random.PRNGKeyArray):
+        self.assertIs(key.impl, impl)
+      else:
+        self.assertEqual(key.dtype, jnp.dtype('uint32'))
+        self.assertEqual(key.shape, impl.key_shape)
+
+    key = random.key(42, impl='threefry2x32')
+    check_key_has_impl(key, prng.threefry_prng_impl)
+    key = random.key(42, impl='rbg')
+    check_key_has_impl(key, prng.rbg_prng_impl)
+    key = random.key(42, impl='unsafe_rbg')
+    check_key_has_impl(key, prng.unsafe_rbg_prng_impl)
+
+    key = random.PRNGKey(42, impl='threefry2x32')
+    check_key_has_impl(key, prng.threefry_prng_impl)
+    key = random.PRNGKey(42, impl='rbg')
+    check_key_has_impl(key, prng.rbg_prng_impl)
+    key = random.PRNGKey(42, impl='unsafe_rbg')
+    check_key_has_impl(key, prng.unsafe_rbg_prng_impl)
 
   def test_key_array_indexing_0d(self):
     if not config.jax_enable_custom_prng:


### PR DESCRIPTION
This change primarily adds an optional argument to both old- and new-style random key constructors. The option determines the PRNG implementation for the key by name, overriding any default implementation determined by configuration flags.

Along the way, looking ahead:

* We can deprecate the (anyway underused) individual explicit key constructors like `jax.random.threefr2x32_key` in favor of this option.

* Some day, instead of only accepting RNG implementations by name (string), we can also accept the output of some custom PRNG implementation API that we expose, maybe via `jax.extend.random` (corresponding roughly to the current `_src.prng.PRNGImpl`).

cc #9263