### PR TITLE
[shape_poly] Improve shape constraint checking using shape assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ Remember to align the itemized text with the first line of an item within a list
   * JAX now supports a configuration flag --jax_serialization_version
     and a JAX_SERIALIZATION_VERSION environment variable to control the
     serialization version ({jax-issue}`#16746`).
+  * jax2tf in presence of shape polymorphism now generates code that checks
+    certain shape constraints, if the serialization version is at least 7.
+    See https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#errors-in-presence-of-shape-polymorphism.
 
 ## jaxlib 0.4.14
 

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -2051,7 +2051,7 @@ def custom_call(
     out_types: Sequence[ir.Type],
     operands: Sequence[ir.Value],
     *,
-    backend_config: Union[str, dict] = "",
+    backend_config: Union[str, dict[str, ir.Attribute]] = "",
     has_side_effect: bool = False,
     result_shapes: Optional[Sequence[ir.Value]] = None,
     called_computations: Sequence[str] = (),

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1230,18 +1230,21 @@ def parameterized_filterable(*,
   Args:
     kwargs: Each entry is a set of kwargs to be passed to the test function.
     testcase_name: Optionally, a function to construct the testcase_name from
-      one kwargs dict. If not given then the kwarg must contain `testcase_name`.
+      one kwargs dict. If not given then kwarg may contain `testcase_name` and
+      if not, the test case name is constructed as `str(kwarg)`.
     one_containing: If given, then leave the test name unchanged, and use
       only one `kwargs` whose `testcase_name` includes `one_containing`.
   """
   # Ensure that all kwargs contain a testcase_name
   kwargs_with_testcase_name: Sequence[dict[str, Any]]
   if testcase_name is not None:
-    kwargs_with_testcase_name = [dict(testcase_name=testcase_name(kw), **kw)
+    kwargs_with_testcase_name = [dict(testcase_name=str(testcase_name(kw)), **kw)
                                  for kw in kwargs]
   else:
     for kw in kwargs:
-      assert "testcase_name" in kw
+      if "testcase_name" not in kw:
+        kw["testcase_name"] = "_".join(f"{k}={kw[k]!s}"
+                                       for k in sorted(kw.keys()))
     kwargs_with_testcase_name = kwargs
   if one_containing is not None:
     filtered = tuple(kw for kw in kwargs_with_testcase_name

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -38,6 +38,7 @@ import itertools
 import io
 import math
 import operator as op
+import threading
 import tokenize
 from typing import Any, Callable, Iterable, Optional, Sequence, Union
 
@@ -50,6 +51,7 @@ from jax.interpreters import xla
 
 from jax._src import core
 from jax._src import dtypes
+from jax._src import effects
 from jax._src.lax import lax
 from jax._src.interpreters import mlir
 from jax._src.numpy import lax_numpy
@@ -78,6 +80,15 @@ for more details.
     error_msg = f"{message}\n{InconclusiveDimensionOperation._help_msg}"
     # https://github.com/python/mypy/issues/5887
     super().__init__(error_msg)  # type: ignore
+
+class _ShapePolyThreadLocalState(threading.local):
+
+  def __init__(self):
+    # TODO(necula): this does not play well with some lowering caches, because
+    # this state is not part of the cache key.
+    self.enable_shape_assertions = True
+
+thread_local_state = _ShapePolyThreadLocalState()
 
 class _DimAtom:
   """Represents an atom in a symbolic dimension expression.
@@ -792,6 +803,62 @@ def _einsum_contract_path(*operands, **kwargs):
 
 lax_numpy._poly_einsum_handlers[_DimExpr] = _einsum_contract_path
 
+# To implement shape-constraint checking we use a shape assertion primitive.
+#    shape_assertion_p.bind(assert_what: bool, *error_message_inputs,
+#                           error_message="...{0}...{1}")
+# where "{0}" refers to error_message_inputs[0], etc.
+shape_assertion_p = core.Primitive("shape_assertion")
+shape_assertion_p.multiple_results = True
+shape_assertion_p.def_effectful_abstract_eval(
+  lambda *_, **__: ((), {shape_assertion_effect}))  # type: ignore
+
+def _shape_assertion_lowering_rule(ctx: mlir.LoweringRuleContext,
+                                   assert_what: mlir.ir.Value,
+                                   *error_message_inputs: mlir.ir.Value,
+                                   error_message: str):
+  op = mlir.custom_call(
+    "shape_assertion",
+    [],  # No results
+    [assert_what, *error_message_inputs],
+    has_side_effect=True,
+    extra_attributes=dict(error_message=mlir.ir.StringAttr.get(error_message))
+  )
+  return op.results
+
+mlir.register_lowering(shape_assertion_p, _shape_assertion_lowering_rule)
+
+class ShapeAssertionEffect(effects.Effect):
+  __str__ = lambda _: "ShapeAssertionEffect"
+
+shape_assertion_effect = ShapeAssertionEffect()
+
+effects.lowerable_effects.add_type(ShapeAssertionEffect)
+effects.control_flow_allowed_effects.add_type(ShapeAssertionEffect)
+effects.remat_allowed_effects.add_type(ShapeAssertionEffect)
+effects.custom_derivatives_allowed_effects.add_type(ShapeAssertionEffect)
+
+def shape_assertion(assert_what: jax.Array,
+                    *error_message_inputs: jax.Array,
+                    error_message: str) -> None:
+  """Adds a shape assertion in the code.
+
+  Args:
+    assert_what: a boolean asserted to be true. Must be computed based only
+      on dimension expressions, so that it can be evaluated after shape
+      refinement.
+    error_message_inputs: integers expressions whose values can be referenced
+      in the `error_message`. Must be computed based only
+      on dimension expressions, so that they can be evaluated after shape
+      refinement.
+    error_message: an error message, possibly containing format specifiers
+      {0}, {1}, ..., referencing the values of the `error_message_inputs`.
+      The format specifiers are sometimes processed with Python's
+      `string::format` method, and sometimes with `llvm::formatv`.
+  """
+  if thread_local_state.enable_shape_assertions:
+    shape_assertion_p.bind(assert_what, *error_message_inputs,
+                           error_message=error_message)
+
 # A JAX primitive with no array arguments but with a dimension parameter
 # that is a DimExpr. The value of the primitive is the value of the dimension,
 # using int64 in x64 mode or int32 otherwise (core.dim_value_dtype())
@@ -1055,22 +1122,6 @@ def _evaluate_multiply(v1, v2):
     pass
   return v1 * v2
 
-def _is_known_constant(v) -> Optional[int]:
-  try:
-    return int(v)
-  except Exception:
-    # TODO(necula): added this so that in jax2tf, in Eager mode, we can tell
-    # that a tensor is a constant. We should move this dependency into some
-    # jax2tf-specific area.
-    if hasattr(v, "val"):
-      try:
-        vint = int(v.val)
-        if isinstance(vint, int):  # In TF, int(tf.Tensor) is tf.Tensor!
-          return vint
-      except Exception:
-        pass
-    return None
-
 # dimension_size(operand, dimension=i) get the operand.shape[i] as a
 # value of type shape_poly.dim_as_value_dtype().
 dimension_size_p = core.Primitive("dimension_size")
@@ -1180,8 +1231,8 @@ class ShapeConstraint:
     left, right = [self._eval_operand(o, shapeenv) for o in [self.left,
                                                              self.right]]
     # Try to evaluate the constraint statically.
-    left_int, right_int = _is_known_constant(left), _is_known_constant(right)
-    if left_int is not None and right_int is not None:
+    if core.is_constant_shape((left, right)):
+      left_int, right_int = op.index(left), op.index(right)
       if self.comp == ShapeConstraint.Comparator.EQ:
         if not (left_int == right_int):
           raise ValueError(self.make_err_msg(left_int, right_int))
@@ -1225,34 +1276,21 @@ class ShapeConstraints:
     for constraint in self.constraints:
       constraint.check_statically(shapeenv)
 
-  def compute(self, shapeenv: DimVarEnv) -> tuple[jax.Array, jax.Array, jax.Array, Sequence[str]]:
-    """Computes the error code for the set of constraints.
+  def shape_assertions(self, shapeenv: DimVarEnv) -> None:
+    """Computes the shape assertions the set of constraints.
 
-    The error code is -1 if all constraints are satisfied, or an index into
-    the returned error messages.
-    See Exported.shape_check_module docstring.
+    See _wrap_main_func docstring.
     """
     # We want to report the errors in the same order as `check_statically`.
-    # So, we process them in order, in case some fail statically, but we
-    # accumulate the errors in reverse order in the computation, because the
-    # code-generation strategy will report the last error that failed.
-    acc: list[tuple[jax.Array, jax.Array, jax.Array, str]] = []
+    # So, we process them in order, in case some fail statically, and we
+    # generate the shape assertions in the same order.
     for constraint in self.constraints:
       check_res = constraint.compute(shapeenv)
       if check_res is not None:
-        acc.append((*check_res, constraint.make_err_msg("%1", "%2")))  # type: ignore
-
-    shape_check_messages: list[str] = []
-    shape_check_code: jax.Array = np.int32(-1)  # type: ignore
-    shape_check_op1 = shape_check_op2 = shape_check_code
-    for (is_ok, op1, op2, msg) in reversed(acc):
-      shape_check_code = lax.select(is_ok, shape_check_code,
-                                    np.int32(len(shape_check_messages)))
-      shape_check_op1 = lax.select(is_ok, shape_check_op1, op1)
-      shape_check_op2 = lax.select(is_ok, shape_check_op2, op2)
-      shape_check_messages.append(msg)
-    return (shape_check_code, shape_check_op1, shape_check_op2, shape_check_messages)
-
+        is_ok, op1, op2 = check_res
+        shape_assertion(
+          is_ok, op1, op2,
+          error_message=constraint.make_err_msg("{0}", "{1}"))
 
 @dataclasses.dataclass
 class _DimEquation:
@@ -1352,7 +1390,8 @@ def compute_dim_vars_from_arg_shapes(
 
   Like `solve_dim_vars` except that here we express the solution as
   JAX arrays that reference the `actual_args`. This function can be used to
-  generate the code for computing the dimension variables.
+  generate the code for computing the dimension variables. It also generates
+  the shape assertions.
 
   Returns: the values of the dimension variables, in the order determined by
     `all_dim_vars(args_avals)`.
@@ -1366,38 +1405,8 @@ def compute_dim_vars_from_arg_shapes(
                                                 dimension=dim_idx)
                    for (vname, arg_idx, dim_idx) in synth_dim_vars}
   dim_values = [solution[var].evaluate(synthetic_env) for var in dim_vars]
+  shape_constraints.shape_assertions(synthetic_env)
   return tuple(dim_values)
-
-
-def compute_shape_check_from_arg_shapes(
-    args_avals: Sequence[core.AbstractValue],
-    *actual_args: jax.Array,
-    args_kwargs_tree: tree_util.PyTreeDef,
-    acc_shape_check_messages: list[str]) -> Sequence[jax.Array]:
-  """Computes the shape check code from the actual arguments.
-
-  `acc_shape_check_messages` is an initially empty list where we append the
-  shape checking messages. Each of these correspond to a constraint.
-  See the `Exported.shape_check_module` docstring.
-
-  Returns: a triple of JAX arrays: the shape check code and the values of the
-    two operands for the failed constraint.
-
-  Raises ValueError if a constraint is invalidated statically.
-  """
-  assert not acc_shape_check_messages
-  solution, shape_constraints, synth_dim_vars = solve_dim_vars(
-      tuple(args_avals), args_kwargs_tree=args_kwargs_tree)
-
-  # Replace the synthetic vars with the dynamic shape of the actual arg
-  synthetic_env = {vname: dimension_size_p.bind(actual_args[arg_idx],
-                                                dimension=dim_idx)
-                   for (vname, arg_idx, dim_idx) in synth_dim_vars}
-  shape_check_code, shape_check_op1, shape_check_op2, shape_check_messages = (
-      shape_constraints.compute(synthetic_env))
-  acc_shape_check_messages.extend(shape_check_messages)
-  return (shape_check_code, shape_check_op1, shape_check_op2)
-
 
 def _solve_dim_equations(
     eqns: list[_DimEquation]

--- a/jax/experimental/jax2tf/tests/back_compat_test.py
+++ b/jax/experimental/jax2tf/tests/back_compat_test.py
@@ -125,6 +125,8 @@ class CompatTest(bctu.CompatTestBase):
 
     covered_targets = covered_targets.union({
       "tpu_custom_call",  # tested separately
+      # TODO(necula): add tests for shape_assertion
+      "shape_assertion",
     })
     not_covered = targets_to_cover.difference(covered_targets)
     self.assertEmpty(not_covered)
@@ -608,7 +610,9 @@ class CompatTest(bctu.CompatTestBase):
     data = self.load_testdata(tpu_stablehlo_dynamic_reduce_window.data_unary_2023_06_17)
     self.run_one_test(
         func, data,
-        polymorphic_shapes=("b, ...",))
+        polymorphic_shapes=("b, ...",),
+        # TODO(necula): now also includes shape_assertion
+        compare_with_current=False)
 
   def test_tpu_stablehlo_dynamic_reduce_window_variadic(self):
     # stablehlo.dynamic_reduce_window is used temporarily on TPU for a
@@ -629,7 +633,9 @@ class CompatTest(bctu.CompatTestBase):
     data = self.load_testdata(tpu_stablehlo_dynamic_reduce_window.data_variadic_2023_06_17)
     self.run_one_test(
         func, data,
-        polymorphic_shapes=("b, ...", "b, ..."))
+        polymorphic_shapes=("b, ...", "b, ..."),
+        # TODO(necula): now also includes shape_assertion
+        compare_with_current=False)
 
   def test_stablehlo_dynamic_rbg_bit_generator(self):
     # stablehlo.dynamic_rbg_bit_generator is used temporarily for a
@@ -660,7 +666,9 @@ class CompatTest(bctu.CompatTestBase):
     try:
       jax.config.update("jax_default_prng_impl", "unsafe_rbg")
 
-      self.run_one_test(func, data, polymorphic_shapes=(None, "b0, b1"))
+      self.run_one_test(func, data, polymorphic_shapes=(None, "b0, b1"),
+                        # TODO(necula): now also includes shape_assertion
+                        compare_with_current=False)
     finally:
       jax.config.update("jax_default_prng_impl", prev_default_prng_impl)
 


### PR DESCRIPTION
This is a major improvement in the shape constraint checking. Even before this change JAX assumes
certain constraints on the shapes of actual arguments in presence of shape polymorphism.
For example,  given the `polymorphic_shapes="(b, b, 2*d)"`
specification for an argument `arg`, JAX assumes the following:

  * `arg.shape[0] >= 1`
  * `arg.shape[1] == arg.shape[0]`
  * `arg.shape[2] % 2 == 0` and `arg.shape[0] // 2 >= 1`

Previously, these constraints were checked only in graph serialization mode and only for eager execution,
when we had access to the actual shapes of `arg` during tracing.
With this change we check them for native serialization also (relying on newly added support for shape
assertions to tf.XlaCallModule version 7).

For graph serialization, we use `tf.debugger.assert`, which works in eager execution mode **and** graph
execution mode (but not `jit_compile=True` mode, due to TF limitations) and produces the same errors as
for native serialization.

Note that even after submitting this change it does not become active until the default serialization
version is bumped to version 7, in about [one month](https://github.com/google/jax/blob/4b72163423c7bd89c1f900bdfa29258517473cc2/jax/_src/config.py#L690).

We also add a mechanism to disable these checks using
the `disabled_checks` parameter to `jax2tf.convert` or the `TF_XLA_FLAGS` environment
variable. Note that there is no mechanism to disable these checks for graph serialization. We expect this
to be fine, since more users will be switching to native serialization before this change lands.