### PR TITLE
Add kl_div and rel_entr functions

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -153,6 +153,8 @@ jax.scipy.special
    xlog1py
    xlogy
    zeta
+   kl_div
+   rel_entr
 
 
 jax.scipy.stats

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -50,4 +50,6 @@ from jax._src.scipy.special import (
   xlogy as xlogy,
   xlog1py as xlog1py,
   zeta as zeta,
+  kl_div as kl_div,
+  rel_entr as rel_entr,
 )

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -137,6 +137,11 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
     op_record("exp1", 1, [np.float32], jtu.rand_positive, True),
     op_record(
         "expn", 2, (int_dtypes, [np.float32]), jtu.rand_positive, True, (0,)),
+    op_record("kl_div", 2, float_dtypes, jtu.rand_positive, True),
+    op_record(
+        "rel_entr", 2, float_dtypes, jtu.rand_positive, True,
+    ),
+
 ]
 
 


### PR DESCRIPTION
Their behavior is the same as functions in scipy.special. The only small difference is in rel_entr function, which unlike scipy.special does not take the optional parameter 'out', as JAX's arrays are immutable.
@jakevdp 

Resolves #16630