### PR TITLE
NumpySignaturesTest: account for 'mean' param to std/var

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -5258,13 +5258,17 @@ class NumpySignaturesTest(jtu.JaxTestCase):
       'histogram': ['normed'],
       'histogram2d': ['normed'],
       'histogramdd': ['normed'],
+      'nanstd': ['mean'],
+      'nanvar': ['mean'],
       'ones': ['order', 'like'],
       'ones_like': ['subok', 'order'],
       'partition': ['kind', 'order'],
       'row_stack': ['casting'],
       'stack': ['casting'],
+      'std': ['mean'],
       'tri': ['like'],
       'unique': ['equal_nan'],
+      'var': ['mean'],
       'vstack': ['casting'],
       'zeros_like': ['subok', 'order']
     }


### PR DESCRIPTION
Eventually we should implement these, but that can wait. In the meantime, this fixes broken tests with the nightly NumPy release.

Fixes #16662