### PR TITLE
Fix scatter batching rule for scatter_apply

### DIFF
--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -466,6 +466,15 @@ class IndexingTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_op_idx, jnp_op_idx, args_maker)
     self._CompileAndCheck(jnp_op_idx, args_maker)
 
+  def testIndexApplyBatchingBug(self):
+    # https://github.com/google/jax/issues/16655
+    arr = jnp.array([[1, 2, 3, 4, 5, 6]])
+    ind = jnp.array([3])
+    func = lambda a, i: a.at[i].apply(lambda x: x - 1)
+    expected = jnp.array(list(map(func, arr, ind)))
+    out = jax.vmap(func)(arr, ind)
+    self.assertArraysEqual(out, expected)
+
   def testIndexUpdateScalarBug(self):
     # https://github.com/google/jax/issues/14923
     a = jnp.arange(10.)


### PR DESCRIPTION
The issue is that the batching rule assumes that each scatter variant
always has the same update_jaxpr. This is not true of scatter_apply, which
lowers to scatter with a custom update_jaxpr. To address this, we change
the batching rule such that it re-uses the input jaxpr rather than always
re-generating it.

Fixes #16655