### PR TITLE
better AOT signature mismatch errors (plus docfix)

### DIFF
--- a/docs/aot.md
+++ b/docs/aot.md
@@ -95,7 +95,7 @@ lowering raises an error:
 
 ```python
 >>> x_1d = y_1d = jnp.arange(3)
->>> jax.jit(f)(i32_scalar, i32_scalar).compile(x_1d, y_1d)
+>>> jax.jit(f).lower(i32_scalar, i32_scalar).compile()(x_1d, y_1d)
 ...
 TypeError: Computation compiled for input types:
   ShapedArray(int32[]), ShapedArray(int32[])
@@ -103,7 +103,7 @@ called with:
   ShapedArray(int32[3]), ShapedArray(int32[3])
 
 >>> x_f = y_f = 72.0
->>> jax.jit(f)(i32_scalar, i32_scalar).compile(x_f, y_f)
+>>> jax.jit(f).lower(i32_scalar, i32_scalar).compile()(x_f, y_f)
 ...
 TypeError: Computation compiled for input types:
   ShapedArray(int32[]), ShapedArray(int32[])

--- a/docs/aot.md
+++ b/docs/aot.md
@@ -97,18 +97,16 @@ lowering raises an error:
 >>> x_1d = y_1d = jnp.arange(3)
 >>> jax.jit(f).lower(i32_scalar, i32_scalar).compile()(x_1d, y_1d)
 ...
-TypeError: Computation compiled for input types:
-  ShapedArray(int32[]), ShapedArray(int32[])
-called with:
-  ShapedArray(int32[3]), ShapedArray(int32[3])
+TypeError: Argument types differ from the types for which this computation was compiled. The mismatches are:
+Argument 'x' compiled with int32[] and called with int32[3]
+Argument 'y' compiled with int32[] and called with int32[3]
 
->>> x_f = y_f = 72.0
+>>> x_f = y_f = jnp.float32(72.)
 >>> jax.jit(f).lower(i32_scalar, i32_scalar).compile()(x_f, y_f)
 ...
-TypeError: Computation compiled for input types:
-  ShapedArray(int32[]), ShapedArray(int32[])
-called with:
-  ShapedArray(float32[]), ShapedArray(float32[])
+TypeError: Argument types differ from the types for which this computation was compiled. The mismatches are:
+Argument 'x' compiled with int32[] and called with float32[]
+Argument 'y' compiled with int32[] and called with float32[]
 ```
 
 Relatedly, AOT-compiled functions [cannot be transformed by JAX's just-in-time

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -986,9 +986,9 @@ class CPPJitTest(jtu.BufferDonationTestCase):
     f_exe = self.jit(f).lower(x_f32).compile()
     self.assertRaisesRegex(
         TypeError,
-        r"Computation was compiled for different input types and called with "
-        r"different types. Here are the 1 mismatches:\n"
-        r"Compiled with.*float32.*and called with.*int32.*for arg x",
+        r"Argument types differ .*"
+        r"The mismatches are:\n"
+        r"Argument 'x' compiled with.*float32.*and called with.*int32.*",
         lambda: f_exe(x_i32))
 
   def test_jit_lower_compile_multi_arg(self):

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -952,10 +952,10 @@ class PJitTest(jtu.BufferDonationTestCase):
     exe = f.lower(x_f32, x_f32).compile()
     with self.assertRaisesRegex(
         TypeError,
-        r"Computation was compiled for different input types and called with "
-        r"different types. Here are the 2 mismatches:\n"
-        r"Compiled with.*float32.*and called with.*int32.*for arg x\n"
-        r"Compiled with.*float32.*and called with.*int32.*for arg y"):
+        r"Argument types differ .*"
+        r"The mismatches are:\n"
+        r"Argument 'x' compiled with.*float32.*and called with.*int32.*\n"
+        r"Argument 'y' compiled with.*float32.*and called with.*int32.*"):
       exe(x_i32, x_i32)
 
   @jtu.with_mesh([('x', 2), ('y', 2)])

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -242,9 +242,9 @@ class PythonPmapTest(jtu.JaxTestCase):
     f_exe = f.lower(x_f32).compile()
     self.assertRaisesRegex(
         TypeError,
-        r"Computation was compiled for different input types and called with "
-        r"different types. Here are the 1 mismatches:\n"
-        r"Compiled with.*float32.*and called with.*int32.*for arg x",
+        r"Argument types differ .*"
+        r"The mismatches are:\n"
+        r"Argument 'x' compiled with.*float32.*and called with.*int32.*",
         lambda: f_exe(x_i32))
 
   def testLowerCompileMultiArg(self):

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -708,9 +708,9 @@ class XMapTest(XMapTestCase):
     f_exe = f.lower(x_f32).compile()
     self.assertRaisesRegex(
         TypeError,
-        r"Computation was compiled for different input types and called with "
-        r"different types. Here are the 1 mismatches:\n"
-        r"Compiled with.*float32.*and called with.*int32.*",
+        r"Argument types differ .*"
+        r"The mismatches are:\n"
+        r"Argument 1/1 compiled with.*float32.*and called with.*int32.*",
       lambda: f_exe(x_i32))
 
   def testLowerAsText(self):


### PR DESCRIPTION
... in the code example on compile/call signature mismatch errors.