### PR TITLE
Avoid duplicate symbol definition.

### DIFF
--- a/jaxlib/mlir/_mlir_libs/passes/BUILD
+++ b/jaxlib/mlir/_mlir_libs/passes/BUILD
@@ -74,7 +74,7 @@ cc_library(
     deps = [
         ":jax_pass_inc_gen",
         ":jax_passes",
-        "@llvm-project//mlir:CAPIIR",
+        "@llvm-project//mlir:CAPIIRHeaders",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:Pass",
     ],


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/16525