### PR TITLE
Remove --distinct_host_configuration from Bazel flags.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -131,7 +131,6 @@ build:rbe --bes_backend=buildeventservice.googleapis.com
 build:rbe --bes_results_url="https://source.cloud.google.com/results/invocations"
 build:rbe --bes_timeout=600s
 build:rbe --define=EXECUTOR=remote
-build:rbe --distinct_host_configuration=false
 build:rbe --flaky_test_attempts=3
 build:rbe --jobs=200
 build:rbe --remote_executor=grpcs://remotebuildexecution.googleapis.com

--- a/build/build.py
+++ b/build/build.py
@@ -260,10 +260,7 @@ def write_bazelrc(*, python_bin_path, remote_build,
       f.write(
         f'build:rocm --action_env TF_ROCM_AMDGPU_TARGETS="{rocm_amdgpu_targets}"\n')
     if cpu is not None:
-      f.write("build --distinct_host_configuration=true\n")
       f.write(f"build --cpu={cpu}\n")
-    else:
-      f.write("build --distinct_host_configuration=false\n")
 
     for o in bazel_options:
       f.write(f"build {o}\n")


### PR DESCRIPTION
This flag does nothing under Bazel 6 and will be removed in Bazel 7.