### PR TITLE
[shape_poly] Add support for max0 for symbolic dimensions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ Remember to align the itemized text with the first line of an item within a list
   * JAX now supports a configuration flag --jax_serialization_version
     and a JAX_SERIALIZATION_VERSION environment variable to control the
     serialization version ({jax-issue}`#16746`).
+  * jax2tf in presence of shape polymorphism now generates code that checks
+    certain shape constraints, if the serialization version is at least 7.
+    See https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#errors-in-presence-of-shape-polymorphism.
 
 ## jaxlib 0.4.14
 

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -2044,7 +2044,7 @@ def custom_call(
     out_types: Sequence[ir.Type],
     operands: Sequence[ir.Value],
     *,
-    backend_config: Union[str, dict] = "",
+    backend_config: Union[str, dict[str, ir.Attribute]] = "",
     has_side_effect: bool = False,
     result_shapes: Optional[Sequence[ir.Value]] = None,
     called_computations: Sequence[str] = (),

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2358,23 +2358,7 @@ def _arange_dynamic(
         f"be resolved statically if it is > 0 or < 0.\nDetails: {e}")
   gap = step if step_gt_0 else - step
   distance = (stop - start) if step_gt_0 else (start - stop)
-  try:
-    if distance >= 1 - gap:
-      size = (distance + gap - 1) // gap
-    else:
-      size = 0
-  except core.InconclusiveDimensionOperation:
-    # Cannot resolve "distance >= 1 - gap". Perhaps we can resolve "distance >= 1"
-    try:
-        if distance >= 1:
-          assert False
-        else:
-          size = 0
-    except core.InconclusiveDimensionOperation:
-      raise core.InconclusiveDimensionOperation(
-          "In arange with non-constant dimensions the distance between "
-          f"start ({start}) and stop ({stop}) must be resolved statically "
-          f"if it is >= {1 - gap} or >= 1.")
+  size = core.non_negative_dim(distance + gap - 1) // gap
   return (array(start, dtype=dtype) +
           array(step, dtype=dtype) * lax.iota(dtype, size))
 

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1230,18 +1230,21 @@ def parameterized_filterable(*,
   Args:
     kwargs: Each entry is a set of kwargs to be passed to the test function.
     testcase_name: Optionally, a function to construct the testcase_name from
-      one kwargs dict. If not given then the kwarg must contain `testcase_name`.
+      one kwargs dict. If not given then kwarg may contain `testcase_name` and
+      if not, the test case name is constructed as `str(kwarg)`.
     one_containing: If given, then leave the test name unchanged, and use
       only one `kwargs` whose `testcase_name` includes `one_containing`.
   """
   # Ensure that all kwargs contain a testcase_name
   kwargs_with_testcase_name: Sequence[dict[str, Any]]
   if testcase_name is not None:
-    kwargs_with_testcase_name = [dict(testcase_name=testcase_name(kw), **kw)
+    kwargs_with_testcase_name = [dict(testcase_name=str(testcase_name(kw)), **kw)
                                  for kw in kwargs]
   else:
     for kw in kwargs:
-      assert "testcase_name" in kw
+      if "testcase_name" not in kw:
+        kw["testcase_name"] = "_".join(f"{k}={str(kw[k])}"
+                                       for k in sorted(kw.keys()))
     kwargs_with_testcase_name = kwargs
   if one_containing is not None:
     filtered = tuple(kw for kw in kwargs_with_testcase_name

--- a/jax/experimental/jax2tf/jax_export.py
+++ b/jax/experimental/jax2tf/jax_export.py
@@ -82,6 +82,15 @@ class DisabledSafetyCheck:
     """
     return DisabledSafetyCheck(f"custom_call:{target_name}")
 
+  @classmethod
+  def shape_assertions(cls) -> "DisabledSafetyCheck":
+    """Allows invocations with shapes that do not meet the constraints.
+
+    Has effect on serialization (to supress the generation of the assertions)
+    and also on deserialization (to suppress the checking of the assertions).
+    """
+    return DisabledSafetyCheck("shape_assertions")
+
   def is_custom_call(self) -> Optional[str]:
     """Returns the custom call target allowed by this directive."""
     m = re.match(r'custom_call:(.+)$', self._impl)
@@ -162,66 +171,6 @@ class Exported:
   @property
   def mlir_module(self) -> ir.Module:
     return xla_client._xla.mlir.deserialize_portable_artifact(self.mlir_module_serialized)
-
-  def shape_check_module(self) -> Optional[tuple[bytes, Sequence[str]]]:
-    """Generates a serialized shape checking module and the error messages.
-
-    Consider the exporting of a function with one array argument of type
-    "f32[w, 2 * h]", where "w" and "h" are two dimension variables. JAX tracing
-    assumes that `arg.shape[1]` is even, and that both `w` and `h` have
-    values >= 1. We must ensure that these assumptions hold when the function
-    is invoked.
-
-    If we `call_exported` for this module we perform these checks
-    statically (in `call_exported_abstract_eval`).
-
-    But if we wrap the exported module with XlaCallModule for execution outside
-    JAX, we must defer these checks to compile time, when the static shapes
-    are known.
-    We generate a separate MLIR shape checking module with a main
-    function that returns a triple of int32's, with a shape checking code and
-    two shape checking operands. The shape checking code is -1 if the checks
-    pass, or is an index into the returned shape_check_messages otherwise.
-    The returned shape checking operands are substituted for "%1" and "%2" in
-    the shape checking messages to obtain the error message. Here is a shape
-    checking module for our example:
-
-       func public main(arg: f32[?, ?]) {
-         # code will be the index of the last failed shape check.
-         code = op1 = op2 = -1  # Assume no errors initially
-         # Check that w is >= 1
-         arg_w = hlo.get_dimension_size(arg, 0)
-         code = hlo.select(arg_w >= 1, code, 0)  # error message 0
-         op1 = hlo.select(arg_w >= 1, op1, arg_w)
-         op2 = hlo.select(arg_w >= 1, op2, 1)
-         # Check that dim1 is even
-         dim1 = hlo.get_dimension_size(arg, 1)
-         code = hlo.select(dim1 % 2 == 0, code, 1)  # error message 1
-         op1 = hlo.select(dim1 % 2 == 0, op1, dim1 % 2)
-         op2 = hlo.select(dim1 % 2 == 0, op2, 0)
-         # Check that h >= 1
-         arg_h = hlo.floordiv(dim1, 2)
-         code = hlo.select(arg_h >= 1, code, 2)  # error message 2
-         op1 = hlo.select(arg_h >= 1, op1, arg_h)
-         op2 = hlo.select(arg_h >= 1, op2, 1)
-         return (code, op1, op2)
-
-    We also return the following shape checking messages to be used for
-    constructing error messages:
-
-      shape_check_messages = [
-          "Dimension variable 'w' must have integer value >= 1. Found %1",
-          "Dimension variable 'h' must have integer value >= 1. Found non-zero remainder %1",
-          "Dimension variable 'h' must have integer value >= 1. Found %1"]
-    """
-    shape_check_res = _make_shape_check_module(
-        self.in_avals, args_kwargs_tree=self.in_tree)
-    if shape_check_res is None:
-      return None
-    module, shape_check_messages = shape_check_res
-    module_serialized, xla_call_module_version = _serialize_module(module)
-    assert xla_call_module_version == self.xla_call_module_version
-    return module_serialized, shape_check_messages
 
   def __str__(self):
     # This is called to make a MLIR source location when we call an Exported, and we
@@ -359,6 +308,8 @@ def export(fun_jax: Callable,
       exported = jax_export.export(f_jax)(*args, **kwargs)
   """
   fun_name = getattr(fun_jax, "__name__", "unknown")
+  version = config.jax_serialization_version
+
   def do_export(*args_specs, **kwargs_specs) -> Exported:
     if not hasattr(fun_jax, "lower"):
       # We support convert(pjit(f_jax)) and convert(jit(f_jax)) but also
@@ -373,28 +324,39 @@ def export(fun_jax: Callable,
       allow_non_replicated_sharding = True
 
     lowering_platform_str = lowering_platform or default_lowering_platform()
-    lowered = wrapped_fun_jax.lower(
-        *args_specs, **kwargs_specs,
-        _experimental_lowering_platform=lowering_platform_str)
-    lowering = lowered._lowering  # type: ignore
-    _check_lowering(lowering)
-    mlir_module = lowering.stablehlo()
 
-    args_avals_flat, _ = tree_util.tree_flatten(lowered.in_avals)
-    if "kept_var_idx" in lowering.compile_args:
-      module_kept_var_idx = tuple(sorted(lowering.compile_args["kept_var_idx"]))
-    else:
-      # For pmap
-      module_kept_var_idx = tuple(range(len(args_avals_flat)))
-    shape_poly_state = lowering.compile_args["shape_poly_state"]
-    if (not all(core.is_constant_shape(a.shape) for a in args_avals_flat)
-        or lowering.compile_args.get("ordered_effects", [])):
-      # All arguments are kept if we have dimension variables.
-      assert len(module_kept_var_idx) == len(args_avals_flat)
-      mlir_module = _wrap_main_func(
-          mlir_module, args_avals_flat, args_kwargs_tree=lowered.in_tree
-      )
-    mlir_module_serialized, xla_call_module_version = _serialize_module(mlir_module)
+    # Do not include shape assertions if the version is < 7.
+    enable_shape_assertions = (
+        DisabledSafetyCheck.shape_assertions() not in disabled_checks and
+        version >= 7)  # type: ignore
+    try:
+      prev_enable_shape_assertions = shape_poly.thread_local_state.enable_shape_assertions
+      shape_poly.thread_local_state.enable_shape_assertions = enable_shape_assertions
+      lowered = wrapped_fun_jax.lower(
+          *args_specs, **kwargs_specs,
+          _experimental_lowering_platform=lowering_platform_str)
+
+      lowering = lowered._lowering  # type: ignore
+      _check_lowering(lowering)
+      mlir_module = lowering.stablehlo()
+
+      args_avals_flat, _ = tree_util.tree_flatten(lowered.in_avals)
+      if "kept_var_idx" in lowering.compile_args:
+        module_kept_var_idx = tuple(sorted(lowering.compile_args["kept_var_idx"]))
+      else:
+        # For pmap
+        module_kept_var_idx = tuple(range(len(args_avals_flat)))
+      shape_poly_state = lowering.compile_args["shape_poly_state"]
+      if (not all(core.is_constant_shape(a.shape) for a in args_avals_flat)
+          or lowering.compile_args.get("ordered_effects", [])):
+        # All arguments are kept if we have dimension variables.
+        assert len(module_kept_var_idx) == len(args_avals_flat)
+        mlir_module = _wrap_main_func(
+            mlir_module, args_avals_flat, args_kwargs_tree=lowered.in_tree
+        )
+    finally:
+      shape_poly.thread_local_state.enable_shape_assertions = prev_enable_shape_assertions
+    mlir_module_serialized = _serialize_module(mlir_module)
 
     # Figure out the result types and shapes
     if "global_out_avals" in lowering.compile_args:
@@ -408,7 +370,7 @@ def export(fun_jax: Callable,
     # Log and then check the module.
     if logging.vlog_is_on(3):
       mlir_module_text = mlir.module_to_string(mlir_module)
-      logmsg = (f"version={xla_call_module_version} "
+      logmsg = (f"version={version} "
                 f"lowering_platform={lowering_platform_str} "
                 f"disabled_checks={disabled_checks}")
       logging.info("Lowered JAX module: %s\n", logmsg)
@@ -432,14 +394,13 @@ def export(fun_jax: Callable,
         mlir_module_serialized=mlir_module_serialized,
         module_kept_var_idx=module_kept_var_idx,
         module_uses_dim_vars=shape_poly_state.uses_dim_vars,
-        xla_call_module_version=xla_call_module_version,
+        xla_call_module_version=version,  # type: ignore
         _get_vjp=lambda exported: _export_native_vjp(fun_jax, exported))
 
   return do_export
 
 
-def _serialize_module(module: ir.Module) -> tuple[bytes, int]:
-  xla_call_module_version = config.jax_serialization_version
+def _serialize_module(module: ir.Module) -> bytes:
   mlir_str = mlir.module_to_bytecode(module)
   if hlo.get_api_version() < 4:
     target_version = hlo.get_earliest_forward_compatible_version()
@@ -463,7 +424,7 @@ def _serialize_module(module: ir.Module) -> tuple[bytes, int]:
     target_version = hlo.get_minimum_version()
   module_serialized = xla_client._xla.mlir.serialize_portable_artifact(
       mlir_str, target_version)
-  return module_serialized, xla_call_module_version
+  return module_serialized
 
 
 def _wrap_main_func(
@@ -481,9 +442,9 @@ def _wrap_main_func(
   the `args_avals`, in sorted order.
 
   Consider the lowering of a function with one array argument of type "f32[w,
-  2 * h]",
-  where "w" and "h" are two dimension variables. The `module` will also
-  contain two dimension arguments, corresponding to "h" and "w" respectively:
+  2 * h]", where "w" and "h" are two dimension variables. The `module` will
+  also contain two dimension arguments, corresponding to "h" and "w"
+  respectively:
 
       func public main(arg_h: i32, arg_w: i32, arg: f32[?, ?]) {
         ...
@@ -495,6 +456,7 @@ def _wrap_main_func(
          arg_w = hlo.get_dimension_size(arg, 0)
          dim1 = hlo.get_dimension_size(arg, 1)
          arg_h = hlo.floordiv(dim1, 2)
+         call _check_shape_assertions(arg)  # See below
          res = call _wrapped_jax_export_main(arg_h, arg_w, arg)
          return res
       }
@@ -502,6 +464,31 @@ def _wrap_main_func(
   In addition, this function also removes token arguments/results from the main
   function by providing dummy values. This ensures that the main function's
   calling convention is as expected.
+
+  Note that the lowering contains a call to `_check_shape_assertions.
+  JAX tracing assumes that `arg.shape[1]` is even, and that both `w` and `h`
+  have values >= 1. We must check these constraints when we invoke the
+  module. We use a special custom call `@shape_assertion` that takes
+  a boolean first operand, a string `error_message` attribute that may contain
+  format specifiers `{0}`, `{1}`, ..., and a variadic number of integer
+  scalar operands corresponding to the format specifiers.
+
+       func private _check_shape_assertions(arg: f32[?, ?]) {
+         # Check that w is >= 1
+         arg_w = hlo.get_dimension_size(arg, 0)
+         custom_call @shape_assertion(arg_w >= 1, arg_w,
+            error_message="Dimension variable 'w' must have integer value >= 1. Found {0}")
+         # Check that dim1 is even
+         dim1 = hlo.get_dimension_size(arg, 1)
+         custom_call @shape_assertion(dim1 % 2 == 0, dim1,
+            error_message="Dimension variable 'h' must have integer value >= 1. Found non-zero remainder {0}")
+         # Check that h >= 1
+         arg_h = hlo.floordiv(dim1, 2)
+         custom_call @shape_assertion(arg_h >= 1, arg_h,
+            error_message=""Dimension variable 'h' must have integer value >= 1. Found {0}")
+
+  If we `call_exported` with this module we perform these checks
+  statically (in `call_exported_abstract_eval`).
 
   Args:
     module: the HLO module as obtained from lowering. May have a number of
@@ -600,55 +587,6 @@ def _wrap_main_func(
     symbol_table.set_symbol_name(new_main_op, "main")
 
   return wrapped_module
-
-
-def _make_shape_check_module(
-    args_avals_flat: Sequence[core.AbstractValue],
-    *,
-    args_kwargs_tree: tree_util.PyTreeDef
-) -> Optional[tuple[ir.Module, Sequence[str]]]:
-  """Codegens the shape checking function.
-
-  The shape checking function takes the array inputs and returns a triple.
-  See `Exported.shape_check_module` docstring.
-
-  Returns the shape checking module and the tuple of shape checking messages.
-  """
-  context = mlir.make_ir_context()
-  with context, ir.Location.unknown(context):
-    array_input_types = tuple(mlir.aval_to_ir_type(a) for a in args_avals_flat)
-    module = ir.Module.create(loc=ir.Location.unknown(context))
-
-    symbol_table = ir.SymbolTable(module.operation)
-    shape_check_code_type = mlir.aval_to_ir_type(core.ShapedArray((), np.int32))
-    shape_check_output_types = (shape_check_code_type,) * 3
-    shape_check_ftype = ir.FunctionType.get(array_input_types,
-                                            shape_check_output_types)
-    shape_check_func = func_dialect.FuncOp(
-      "main", shape_check_ftype,
-      ip=ir.InsertionPoint.at_block_begin(module.body))
-    shape_check_func.attributes["sym_visibility"] = ir.StringAttr.get("public")
-    symbol_table.insert(shape_check_func)
-    entry_block = shape_check_func.add_entry_block()
-    with ir.InsertionPoint(entry_block):
-      module_context = mlir.ModuleContext(
-          "cpu", "cpu", sharding_impls.ShardingContext([]),
-          source_info_util.new_name_stack(),
-          [], itertools.count(1), [], module=module, context=context)
-      ctx = mlir.LoweringRuleContext(module_context=module_context,
-                                     primitive=None, avals_in=args_avals_flat,
-                                     avals_out=None, tokens_in=mlir.TokenSet(),
-                                     tokens_out=None)
-      acc_shape_check_messages: list[str] = []
-      values = mlir.lower_fun(
-          functools.partial(shape_poly.compute_shape_check_from_arg_shapes,
-                            args_avals_flat, args_kwargs_tree=args_kwargs_tree,
-                            acc_shape_check_messages=acc_shape_check_messages),
-          multiple_results=True)(ctx, *shape_check_func.arguments)
-      func_dialect.ReturnOp(util.flatten(values))
-
-  return (module, acc_shape_check_messages) if acc_shape_check_messages else None
-
 
 def _check_lowering(lowering) -> None:
   if not isinstance(lowering, pxla.MeshComputation):
@@ -749,6 +687,7 @@ _CUSTOM_CALL_TARGETS_GUARANTEED_STABLE = {
     # See https://github.com/openxla/stablehlo/issues/8.
     "stablehlo.dynamic_reduce_window",
     "stablehlo.dynamic_rng_bit_generator",
+    "shape_assertion",  # Used by shape_poly to evaluate assertions
 }
 
 
@@ -763,6 +702,7 @@ def _check_module(mod: ir.Module, *,
     disabled_checks: the safety checks that are disabled.
   """
   sharding_attr = ir.StringAttr.get("Sharding", mod.context)
+  shape_assertion_attr = ir.StringAttr.get("shape_assertion", mod.context)
   allowed_custom_call_targets: set[str] = copy.copy(_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE)
   for dc in disabled_checks:
     target = dc.is_custom_call()
@@ -799,6 +739,8 @@ def _check_module(mod: ir.Module, *,
         disallowed_custom_call_ops.append(f"{op} at {op.location}")
       if call_target_name_attr == sharding_attr:
         check_sharding(op, op.location)
+      elif call_target_name_attr == shape_assertion_attr:
+        assert (DisabledSafetyCheck.shape_assertions() not in disabled_checks)
 
   def walk_operations(op):
     check_op(op)

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -38,6 +38,7 @@ import itertools
 import io
 import math
 import operator as op
+import threading
 import tokenize
 from typing import Any, Callable, Iterable, Optional, Sequence, Union
 
@@ -50,6 +51,7 @@ from jax.interpreters import xla
 
 from jax._src import core
 from jax._src import dtypes
+from jax._src import effects
 from jax._src.lax import lax
 from jax._src.interpreters import mlir
 from jax._src.numpy import lax_numpy
@@ -78,6 +80,15 @@ for more details.
     error_msg = f"{message}\n{InconclusiveDimensionOperation._help_msg}"
     # https://github.com/python/mypy/issues/5887
     super().__init__(error_msg)  # type: ignore
+
+class _ShapePolyThreadLocalState(threading.local):
+
+  def __init__(self):
+    # TODO(necula): this does not play well with some lowering caches, because
+    # this state is not part of the cache key.
+    self.enable_shape_assertions = True
+
+thread_local_state = _ShapePolyThreadLocalState()
 
 class _DimAtom:
   """Represents an atom in a symbolic dimension expression.
@@ -792,6 +803,62 @@ def _einsum_contract_path(*operands, **kwargs):
 
 lax_numpy._poly_einsum_handlers[_DimExpr] = _einsum_contract_path
 
+# To implement shape-constraint checking we use a shape assertion primitive.
+#    shape_assertion_p.bind(assert_what: bool, *error_message_inputs,
+#                           error_message="...{0}...{1}")
+# where "{0}" refers to error_message_inputs[0], etc.
+shape_assertion_p = core.Primitive("shape_assertion")
+shape_assertion_p.multiple_results = True
+shape_assertion_p.def_effectful_abstract_eval(
+  lambda *_, **__: ((), {shape_assertion_effect}))  # type: ignore
+
+def _shape_assertion_lowering_rule(ctx: mlir.LoweringRuleContext,
+                                   assert_what: mlir.ir.Value,
+                                   *error_message_inputs: mlir.ir.Value,
+                                   error_message: str):
+  op = mlir.custom_call(
+    "shape_assertion",
+    [],  # No results
+    [assert_what, *error_message_inputs],
+    has_side_effect=True,
+    extra_attributes=dict(error_message=mlir.ir.StringAttr.get(error_message))
+  )
+  return op.results
+
+mlir.register_lowering(shape_assertion_p, _shape_assertion_lowering_rule)
+
+class ShapeAssertionEffect(effects.Effect):
+  __str__ = lambda _: "ShapeAssertionEffect"
+
+shape_assertion_effect = ShapeAssertionEffect()
+
+effects.lowerable_effects.add_type(ShapeAssertionEffect)
+effects.control_flow_allowed_effects.add_type(ShapeAssertionEffect)
+effects.remat_allowed_effects.add_type(ShapeAssertionEffect)
+effects.custom_derivatives_allowed_effects.add_type(ShapeAssertionEffect)
+
+def shape_assertion(assert_what: jax.Array,
+                    *error_message_inputs: jax.Array,
+                    error_message: str) -> None:
+  """Adds a shape assertion in the code.
+
+  Args:
+    assert_what: a boolean asserted to be true. Must be computed based only
+      on dimension expressions, so that it can be evaluated after shape
+      refinement.
+    error_message_inputs: integers expressions whose values can be referenced
+      in the `error_message`. Must be computed based only
+      on dimension expressions, so that they can be evaluated after shape
+      refinement.
+    error_message: an error message, possibly containing format specifiers
+      {0}, {1}, ..., referencing the values of the `error_message_inputs`.
+      The format specifiers are sometimes processed with Python's
+      `string::format` method, and sometimes with `llvm::formatv`.
+  """
+  if thread_local_state.enable_shape_assertions:
+    shape_assertion_p.bind(assert_what, *error_message_inputs,
+                           error_message=error_message)
+
 # A JAX primitive with no array arguments but with a dimension parameter
 # that is a DimExpr. The value of the primitive is the value of the dimension,
 # using int64 in x64 mode or int32 otherwise (core.dim_value_dtype())
@@ -1055,22 +1122,6 @@ def _evaluate_multiply(v1, v2):
     pass
   return v1 * v2
 
-def _is_known_constant(v) -> Optional[int]:
-  try:
-    return int(v)
-  except Exception:
-    # TODO(necula): added this so that in jax2tf, in Eager mode, we can tell
-    # that a tensor is a constant. We should move this dependency into some
-    # jax2tf-specific area.
-    if hasattr(v, "val"):
-      try:
-        vint = int(v.val)
-        if isinstance(vint, int):  # In TF, int(tf.Tensor) is tf.Tensor!
-          return vint
-      except Exception:
-        pass
-    return None
-
 # dimension_size(operand, dimension=i) get the operand.shape[i] as a
 # value of type shape_poly.dim_as_value_dtype().
 dimension_size_p = core.Primitive("dimension_size")
@@ -1180,8 +1231,8 @@ class ShapeConstraint:
     left, right = [self._eval_operand(o, shapeenv) for o in [self.left,
                                                              self.right]]
     # Try to evaluate the constraint statically.
-    left_int, right_int = _is_known_constant(left), _is_known_constant(right)
-    if left_int is not None and right_int is not None:
+    if core.is_constant_shape((left, right)):
+      left_int, right_int = op.index(left), op.index(right)
       if self.comp == ShapeConstraint.Comparator.EQ:
         if not (left_int == right_int):
           raise ValueError(self.make_err_msg(left_int, right_int))
@@ -1225,34 +1276,21 @@ class ShapeConstraints:
     for constraint in self.constraints:
       constraint.check_statically(shapeenv)
 
-  def compute(self, shapeenv: DimVarEnv) -> tuple[jax.Array, jax.Array, jax.Array, Sequence[str]]:
-    """Computes the error code for the set of constraints.
+  def shape_assertions(self, shapeenv: DimVarEnv) -> None:
+    """Computes the shape assertions the set of constraints.
 
-    The error code is -1 if all constraints are satisfied, or an index into
-    the returned error messages.
-    See Exported.shape_check_module docstring.
+    See _wrap_main_func docstring.
     """
     # We want to report the errors in the same order as `check_statically`.
-    # So, we process them in order, in case some fail statically, but we
-    # accumulate the errors in reverse order in the computation, because the
-    # code-generation strategy will report the last error that failed.
-    acc: list[tuple[jax.Array, jax.Array, jax.Array, str]] = []
+    # So, we process them in order, in case some fail statically, and we
+    # generate the shape assertions in the same order.
     for constraint in self.constraints:
       check_res = constraint.compute(shapeenv)
       if check_res is not None:
-        acc.append((*check_res, constraint.make_err_msg("%1", "%2")))  # type: ignore
-
-    shape_check_messages: list[str] = []
-    shape_check_code: jax.Array = np.int32(-1)  # type: ignore
-    shape_check_op1 = shape_check_op2 = shape_check_code
-    for (is_ok, op1, op2, msg) in reversed(acc):
-      shape_check_code = lax.select(is_ok, shape_check_code,
-                                    np.int32(len(shape_check_messages)))
-      shape_check_op1 = lax.select(is_ok, shape_check_op1, op1)
-      shape_check_op2 = lax.select(is_ok, shape_check_op2, op2)
-      shape_check_messages.append(msg)
-    return (shape_check_code, shape_check_op1, shape_check_op2, shape_check_messages)
-
+        is_ok, op1, op2 = check_res
+        shape_assertion(
+          is_ok, op1, op2,
+          error_message=constraint.make_err_msg("{0}", "{1}"))
 
 @dataclasses.dataclass
 class _DimEquation:
@@ -1352,7 +1390,8 @@ def compute_dim_vars_from_arg_shapes(
 
   Like `solve_dim_vars` except that here we express the solution as
   JAX arrays that reference the `actual_args`. This function can be used to
-  generate the code for computing the dimension variables.
+  generate the code for computing the dimension variables. It also generates
+  the shape assertions.
 
   Returns: the values of the dimension variables, in the order determined by
     `all_dim_vars(args_avals)`.
@@ -1366,38 +1405,8 @@ def compute_dim_vars_from_arg_shapes(
                                                 dimension=dim_idx)
                    for (vname, arg_idx, dim_idx) in synth_dim_vars}
   dim_values = [solution[var].evaluate(synthetic_env) for var in dim_vars]
+  shape_constraints.shape_assertions(synthetic_env)
   return tuple(dim_values)
-
-
-def compute_shape_check_from_arg_shapes(
-    args_avals: Sequence[core.AbstractValue],
-    *actual_args: jax.Array,
-    args_kwargs_tree: tree_util.PyTreeDef,
-    acc_shape_check_messages: list[str]) -> Sequence[jax.Array]:
-  """Computes the shape check code from the actual arguments.
-
-  `acc_shape_check_messages` is an initially empty list where we append the
-  shape checking messages. Each of these correspond to a constraint.
-  See the `Exported.shape_check_module` docstring.
-
-  Returns: a triple of JAX arrays: the shape check code and the values of the
-    two operands for the failed constraint.
-
-  Raises ValueError if a constraint is invalidated statically.
-  """
-  assert not acc_shape_check_messages
-  solution, shape_constraints, synth_dim_vars = solve_dim_vars(
-      tuple(args_avals), args_kwargs_tree=args_kwargs_tree)
-
-  # Replace the synthetic vars with the dynamic shape of the actual arg
-  synthetic_env = {vname: dimension_size_p.bind(actual_args[arg_idx],
-                                                dimension=dim_idx)
-                   for (vname, arg_idx, dim_idx) in synth_dim_vars}
-  shape_check_code, shape_check_op1, shape_check_op2, shape_check_messages = (
-      shape_constraints.compute(synthetic_env))
-  acc_shape_check_messages.extend(shape_check_messages)
-  return (shape_check_code, shape_check_op1, shape_check_op2)
-
 
 def _solve_dim_equations(
     eqns: list[_DimEquation]

--- a/jax/experimental/jax2tf/tests/back_compat_test.py
+++ b/jax/experimental/jax2tf/tests/back_compat_test.py
@@ -125,6 +125,8 @@ class CompatTest(bctu.CompatTestBase):
 
     covered_targets = covered_targets.union({
       "tpu_custom_call",  # tested separately
+      # TODO(necula): add tests for shape_assertion
+      "shape_assertion",
     })
     not_covered = targets_to_cover.difference(covered_targets)
     self.assertEmpty(not_covered)
@@ -608,7 +610,9 @@ class CompatTest(bctu.CompatTestBase):
     data = self.load_testdata(tpu_stablehlo_dynamic_reduce_window.data_unary_2023_06_17)
     self.run_one_test(
         func, data,
-        polymorphic_shapes=("b, ...",))
+        polymorphic_shapes=("b, ...",),
+        # TODO(necula): now also includes shape_assertion
+        compare_with_current=False)
 
   def test_tpu_stablehlo_dynamic_reduce_window_variadic(self):
     # stablehlo.dynamic_reduce_window is used temporarily on TPU for a
@@ -629,7 +633,9 @@ class CompatTest(bctu.CompatTestBase):
     data = self.load_testdata(tpu_stablehlo_dynamic_reduce_window.data_variadic_2023_06_17)
     self.run_one_test(
         func, data,
-        polymorphic_shapes=("b, ...", "b, ..."))
+        polymorphic_shapes=("b, ...", "b, ..."),
+        # TODO(necula): now also includes shape_assertion
+        compare_with_current=False)
 
   def test_stablehlo_dynamic_rbg_bit_generator(self):
     # stablehlo.dynamic_rbg_bit_generator is used temporarily for a
@@ -660,7 +666,9 @@ class CompatTest(bctu.CompatTestBase):
     try:
       jax.config.update("jax_default_prng_impl", "unsafe_rbg")
 
-      self.run_one_test(func, data, polymorphic_shapes=(None, "b0, b1"))
+      self.run_one_test(func, data, polymorphic_shapes=(None, "b0, b1"),
+                        # TODO(necula): now also includes shape_assertion
+                        compare_with_current=False)
     finally:
       jax.config.update("jax_default_prng_impl", prev_default_prng_impl)
 

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for the shape-polymorphic jax2tf conversion."""
 import contextlib
+import itertools
 import math
 import unittest
 
@@ -69,7 +70,41 @@ expect_error_associative_scan = (
      "associative scan over axis of non-constant size"))
 
 
+
 class DimExprTest(tf_test_util.JaxToTfTestCase):
+
+  def sampled_assert_equal(self,
+                           expected_sym: shape_poly.DimSize,
+                           fun: Callable,
+                           *operands_sym: shape_poly.DimSize
+                           ):
+    """Checks `expected == fun(*operands)` with the `fun` invocation and the
+    equality check both done symbolically, and also concretely by replacing
+    several values for each of the dimension variables.
+
+    This is useful when `fun` can operate both with polynomials and with
+    concrete values, and we want to double-check that the behavior is sound.
+    """
+    computed_sym = fun(*operands_sym)
+    self.assertEqual(expected_sym, computed_sym)
+    dim_vars: set[str] = set()
+    for a in (expected_sym, computed_sym, *operands_sym):
+      if core.is_symbolic_dim(a):
+        dim_vars = dim_vars.union(a.get_vars())
+    if not dim_vars:
+      return
+    dim_vars_tuple = tuple(dim_vars)
+    # All combinations of values
+    for dim_values in itertools.product(*([(1, 2, 5, 10)] * len(dim_vars_tuple))):
+      env = {d: dv for d, dv in zip(dim_vars_tuple, dim_values)}
+      def eval(d: shape_poly.DimSize):
+        return d.evaluate(env) if core.is_symbolic_dim(d) else d  # type: ignore
+
+      compute_concrete = fun(*map(eval, operands_sym))
+      expected_concrete = eval(expected_sym)
+      self.assertEqual(
+        expected_concrete, compute_concrete,
+        f"{expected_sym=} {expected_concrete=} {compute_concrete=} {env=}")
 
   def test_parse_shape(self):
     self.assertEqual((), shape_poly._parse_spec("", ()))
@@ -102,6 +137,7 @@ class DimExprTest(tf_test_util.JaxToTfTestCase):
           ("a + -1", a - 1),
           ("3 * a * mod(a + 2, b + 2)", 3 * a * ((a + 2) % (b + 2))),
           ("3 * floordiv(a + 2, b + 2) * 2", 3 * ((a + 2) // (b + 2)) * 2),
+          ("non_negative(a - 2)", core.non_negative_dim(a - 2)),
   ]])
   def test_parse_dim(self,
                      dim_spec="-2 * a^2 * b + b^2",
@@ -254,13 +290,19 @@ class DimExprTest(tf_test_util.JaxToTfTestCase):
         self.assertGreaterEqual(atom_val, lb)
         self.assertLessEqual(atom_val, ub)
 
-    # Inequalities involving mod and floordiv
+    # Bounds involving mod and floordiv
     self.assertEqual((5 - a % 5).bounds(), (1, 5))
     self.assertEqual((-5 - a % (-5)).bounds(), (-5, -1))
     self.assertEqual((a - 5 % a).bounds(), (1, np.PINF))
     self.assertEqual((a - 5 % a).bounds(), (1, np.PINF))
     self.assertEqual((3 * (a + b) - 5 % (3 * (a + b))).bounds(), (1, np.PINF))
     self.assertEqual((- a + (b - 5) % a).bounds(), (np.NINF, -1))
+
+    # non_negative
+    self.assertEqual(core.non_negative_dim(a).bounds(), (1, np.PINF))
+    self.assertEqual(core.non_negative_dim(a - 5).bounds(), (0, np.PINF))
+    self.assertEqual(core.non_negative_dim(15 - a).bounds(), (0, 14))
+    self.assertEqual((core.non_negative_dim(15 - a) // 3).bounds(), (0, 4))
 
   def test_poly_equal(self):
     a, b = shape_poly._parse_spec("a, b", (2, 3))
@@ -280,24 +322,40 @@ class DimExprTest(tf_test_util.JaxToTfTestCase):
 
     self.assertFalse((3 * a * b * a - 2).eq(a * b * a))
 
-    self.assertTrue(a % b == a % b)
-    self.assertTrue(a % b - a % b == 0)
-    self.assertTrue(a // b == a // b)
-    self.assertTrue(a // b - a // b == 0)
+    self.sampled_assert_equal(a % b,
+                              lambda x: x, a % b)
+    self.sampled_assert_equal(a % b - a % b,
+                              lambda x: x, 0)
+    self.sampled_assert_equal(a // b,
+                              lambda x: x, a // b)
+    self.sampled_assert_equal(a // b - a // b,
+                              lambda x: x, 0)
 
-    self.assertTrue(a % b == (2 * a // 2) % (a + b - a))
-    self.assertTrue(a // b == (2 * a // 2) // (a + b - a))
+    self.sampled_assert_equal(a % b,
+                              lambda x: x, (2 * a // 2) % (a + b - a))
+    self.sampled_assert_equal(a // b,
+                              lambda x: x, (2 * a // 2) // (a + b - a))
 
-    self.assertTrue(a, a + (a + b) // b - (b + a) // b)
+    self.sampled_assert_equal(a, lambda x: x,
+                              a + (a + b) // b - (b + a) // b)
 
     # Test the normalization (a // b) * b == a - a % b
-    self.assertTrue((a // 2) * 2 == a - a % 2)
-    self.assertTrue((a // 2) + (a // 2) == a - a % 2)
-    self.assertTrue((a // 2) * 6 == 3 * a - 3 * (a % 2))
-    self.assertTrue((a // b) * b == a - a % b)
-    self.assertTrue(2 * (a // b) * b * b == 2 * b * a - 2 * b * (a % b))
-    self.assertTrue(a // (2 * b) * 2 * b == a - a % (2 * b))
-    self.assertTrue(a // (2 * b) * 2 * b + 2 * a == 3 * a - a % (2 * b))
+    self.sampled_assert_equal((a // 2) * 2,
+                              lambda x: x, a - a % 2)
+    self.sampled_assert_equal((a // 2) + (a // 2),
+                              lambda x: x, a - a % 2)
+    self.sampled_assert_equal((a // 2) * 6,
+                              lambda x: x, 3 * a - 3 * (a % 2))
+    self.sampled_assert_equal((a // b) * b,
+                              lambda x: x, a - a % b)
+    self.sampled_assert_equal(2 * (a // b) * b * b,
+                              lambda x: x, 2 * b * a - 2 * b * (a % b))
+    self.sampled_assert_equal(a // (2 * b) * 2 * b,
+                              lambda x: x, a - a % (2 * b))
+    self.sampled_assert_equal(a // (2 * b) * 2 * b + 2 * a,
+                              lambda x: x, 3 * a - a % (2 * b))
+    self.sampled_assert_equal(a // (2 * b) * 2 * b + 2 * a,
+                              lambda x: x, 3 * a - a % (2 * b))
 
   def test_poly_compare(self):
     a, b = shape_poly._parse_spec("a, b", (2, 3))
@@ -375,34 +433,50 @@ class DimExprTest(tf_test_util.JaxToTfTestCase):
       d1, d2 = divmod(dividend, divisor)
       self.assertEqual((quotient, remainder), (str(d1), str(d2)))
     else:
-      self.assertEqual((quotient, remainder), divmod(dividend, divisor))
+      self.sampled_assert_equal(quotient, lambda *args: divmod(*args)[0],
+                                dividend, divisor)
+      self.sampled_assert_equal(remainder, lambda *args: divmod(*args)[1],
+                                dividend, divisor)
+
+  def test_non_negative_dim(self):
+    a, = shape_poly._parse_spec("a,", (2,))
+
+    self.sampled_assert_equal(2, core.non_negative_dim, 2)
+    self.sampled_assert_equal(0, core.non_negative_dim, 0)
+    self.sampled_assert_equal(0, core.non_negative_dim, -1)
+    self.sampled_assert_equal(a, core.non_negative_dim, a)
+    self.sampled_assert_equal(2 * a - 1, core.non_negative_dim, 2 * a - 1)
+    self.sampled_assert_equal(core.non_negative_dim(a - 2),
+                              core.non_negative_dim, a - 2)
 
   def test_dilate_dim(self):
     """0 if d == 0 else 1 + dilation * (d - 1))"""
     a, = shape_poly._parse_spec("a,", (2,))
 
-    self.assertEqual(4, core.dilate_dim(2, 3))
-    self.assertEqual(7, core.dilate_dim(3, 3))
-    self.assertEqual(0, core.dilate_dim(0, 3))
-    self.assertEqual(a, core.dilate_dim(a, 1))
-    self.assertEqual(2 * a - 1, core.dilate_dim(a, 2))
+    self.sampled_assert_equal(4, core.dilate_dim, 2, 3)
+    self.sampled_assert_equal(7, core.dilate_dim, 3, 3)
+    self.sampled_assert_equal(0, core.dilate_dim, 0, 3)
+    self.sampled_assert_equal(a, core.dilate_dim, a, 1)
+    self.sampled_assert_equal(2 * a - 1, core.dilate_dim, a, 2)
+    self.sampled_assert_equal(core.non_negative_dim(2 * a - 3),
+                              core.dilate_dim, a - 1, 2)
 
   def test_stride_dim(self):
     """(d - window_size) // window_stride + 1
 
-    If d == 0 or window_size > d, returns 0.
+    If d <  window_size, returns 0.
     """
     a, stride = shape_poly._parse_spec("a, s", (2, 3))
+    self.sampled_assert_equal(8, core.stride_dim, 10, 3, 1)
+    self.sampled_assert_equal(9, core.stride_dim, 20, 3, 2)
+    self.sampled_assert_equal(9, core.stride_dim, 20, 4, 2)
+    self.sampled_assert_equal(a, core.stride_dim, a, 1, 1)
 
-    self.assertEqual(8, core.stride_dim(10, window_size=3, window_stride=1))
-    self.assertEqual(9, core.stride_dim(20, window_size=3, window_stride=2))
-    self.assertEqual(9, core.stride_dim(20, window_size=4, window_stride=2))
-    self.assertEqual(a, core.stride_dim(a, window_size=1, window_stride=1))
-
-    self.assertEqual(a - 1, core.stride_dim(a, window_size=2, window_stride=1))
-    self.assertEqual(a + 1, core.stride_dim(a * stride + 2, window_size=2,
-                                            window_stride=stride))
-    self.assertEqual((a - 1) // 2 + 1, core.stride_dim(a, 1, 2))
+    self.sampled_assert_equal(a - 1, core.stride_dim, a, 2, 1)
+    self.sampled_assert_equal(a + 1, core.stride_dim, a * stride + 2, 2, stride)
+    self.sampled_assert_equal((a - 1) // 2 + 1, core.stride_dim, a, 1, 2)
+    self.sampled_assert_equal(core.non_negative_dim((a - 4) // 2 + 1),
+                              core.stride_dim, a, 4, 2)
 
 
 class PolyHarness(Harness):
@@ -654,7 +728,9 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
 
   @jtu.parameterized_filterable(
     # make_args invoked with op.shape[0]: start, stop, step, dtype
+    # b == 6
     kwargs=[
+      # Positive step
       dict(testcase_name="b", make_args=lambda b: (b, None, None, None)),
       dict(testcase_name="0_b+1", make_args=lambda b: (0, b + 1, None, None)),
       dict(testcase_name="0_5b_2", make_args=lambda b: (0, 5 * b, 2, None)),
@@ -664,12 +740,14 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
       dict(testcase_name="0_b-2_2", make_args=lambda b: (0, b - 2, 2, None)),
       dict(testcase_name="0_-b_2", make_args=lambda b: (0, -b, 2, None)),
       dict(testcase_name="0_1-b_2", make_args=lambda b: (0, 1 - b, 2, None)),
+      dict(testcase_name="0_b-3_2", make_args=lambda b: (0, b - 3, 2, None)),  # Cannot tell if size >= 0
       # Negative step
       dict(testcase_name="b_0_-1", make_args=lambda b: (b, 0, -1, None)),
       dict(testcase_name="b_1_-2", make_args=lambda b: (b, 1, -2, None)),
       dict(testcase_name="b_-1_-1", make_args=lambda b: (b, -1, -1, None)),
       dict(testcase_name="5b+1_0_-2", make_args=lambda b: (5 * b + 1, 0, -2, None)),
       dict(testcase_name="5b+2_0_-2", make_args=lambda b: (5 * b + 2, 0, -2, None)),
+      dict(testcase_name="b-3_0_-2", make_args=lambda b: (b - 3, 0, -2, None)),  # Cannot tell if size >= 0
       # Symbolic step
       dict(testcase_name="0_10_b", make_args=lambda b: (0, 10, b)),
       dict(testcase_name="0_0_b", make_args=lambda b: (0, 0, b)),
@@ -681,7 +759,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
   def test_arange(self, make_args):
     def f_jax(x):  # x: i32[b]
       return x[0] + jnp.arange(*(make_args(x.shape[0])))
-    x = np.ones((3,), dtype=np.int32)
+    x = np.ones((6,), dtype=np.int32)
     self.assertAllClose(jax2tf.convert(f_jax, polymorphic_shapes="b")(x),
                         f_jax(x))
 
@@ -700,9 +778,6 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
           ("inconclusive_step_sign", lambda b: (0, b, b - 2),
            core.InconclusiveDimensionOperation,
            "must be resolved statically if it is > 0 or < 0"),
-          ("inconclusive_distance", lambda b: (0, b - 3, 2),
-           core.InconclusiveDimensionOperation,
-           "must be resolved statically if it is >= -1 or >= 1"),
       ]
     ]
   )
@@ -1956,6 +2031,20 @@ _POLY_SHAPE_TEST_HARNESSES = [
                                                                out_spec=(0, 2, 1))),
                 arg_descriptors=[RandArg((1, 13, 16), _f32), RandArg((4, 16, 16), _f32)],
                 polymorphic_shapes=["_, b, _", None]).both_enable_and_disable_xla(),
+    PolyHarness("conv_general_dilated", "1d_stride=2_zero_output",
+              lambda lhs, rhs: lax.conv_general_dilated(
+                lhs, rhs,
+                window_strides=(2,),
+                padding="VALID",
+                rhs_dilation=None,
+                dimension_numbers=lax.ConvDimensionNumbers(lhs_spec=(0, 2, 1),
+                                                           rhs_spec=(2, 1, 0),
+                                                           out_spec=(0, 2, 1))
+              ).shape[1],  # should be 0 in JAX native
+              arg_descriptors=[RandArg((1, 4, 16), _f32),
+                               RandArg((8, 16, 16), _f32)],
+              polymorphic_shapes=["_, b, _",
+                                  None]).both_enable_and_disable_xla(),
     # Issue #11402
     PolyHarness("conv_general_dilated", "1d_2",
                 lambda lhs, rhs: lax.conv_transpose(lhs, rhs,
@@ -2988,6 +3077,9 @@ class ShapePolyPrimitivesTest(tf_test_util.JaxToTfTestCase):
 
       if harness.group_name == "eig" and "left=True_right=True" in harness.fullname:
         raise unittest.SkipTest("jax2tf graph serialization does not support both left and right.")
+
+      if "conv_general_dilated_1d_stride=2_zero_output_enable_xla=False" in harness.fullname:
+        raise unittest.SkipTest("incomplete support for conv_general_dilated in enable_xla=False")
 
       if harness.group_name == "reduce_window" and "variadic" in harness.fullname:
         raise unittest.SkipTest("jax2tf graph serialization does not support variadic reduce_window.")


### PR DESCRIPTION
There are a few cases when JAX computes `max(v, 0)`, most notably when computing the sizes of strided access, dilated convolutions and padding, and for the size of jnp.arange.

Until now these cases were supported
for shape polymorphism only when we can tell statically that the size is >= 0. Here we add support to the
symbolic expressions for a `non_negative` operator, which essentially implements `max(v, 0)` and with this we can now support the general case for `jnp.arange`, with simpler code.

We could add a general `max` operator, and we may do so in the future, but for now `non_negative` suffices.

Note that this fixes a couple of bugs

  * for core.dilated_dim we had the code "if d == 0 then 0 else ..." but this works only if we can tell statically that `d == 0`, and it produced wrong results when `d` was symbolic and could take the value 0.
  * for core.stride_dim we did not handle correctly the case when `d < window_size`.

Handling the above fundamentally requires a `max(d, 0)` operation.