### PR TITLE
[shape_poly] More cleanup for the internal APIs for shape polymorphism.

### DIFF
--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 from collections import namedtuple
 from contextlib import contextmanager, AbstractContextManager
-import functools
 from functools import partial
 import inspect
 import itertools as it
@@ -2451,44 +2450,6 @@ def _substitute_vars_in_type(
     return a.update(shape=tuple(shape))
   else:
     return a
-
-
-class DimensionHandlerTracer(core.DimensionHandler):
-  """See core.DimensionHandler.
-
-  Most methods are inherited.
-  """
-  def is_constant(self, d: core.DimSize) -> bool:
-    assert isinstance(d, Tracer)
-    return False
-
-  def symbolic_equal(self, d1: core.DimSize, d2: core.DimSize) -> bool:
-    return d1 is d2
-
-  def greater_equal(self, d1: core.DimSize, d2: core.DimSize):
-    raise core.InconclusiveDimensionOperation("TODO")
-
-  def divide_shape_sizes(self, s1: core.Shape, s2: core.Shape) -> core.DimSize:
-    """Computes integer "i" such that i  * size(s2) == size(s1).
-
-    Raise InconclusiveDimensionOperation if there is no such integer for all
-    contexts.
-    """
-    s1_size = functools.reduce(op.mul, s1, 1)
-    s2_size = functools.reduce(op.mul, s2, 1)
-    q, r = divmod(s1_size, s2_size)
-    # TODO(necula): must check that r == 0!
-    return q
-
-  def stride(self, d: core.DimSize, window_size: core.DimSize, window_stride: core.DimSize) -> core.DimSize:
-    """Implements `(d - window_size) // window_stride + 1`"""
-    raise core.InconclusiveDimensionOperation("TODO")
-
-  def as_value(self, d: core.DimSize):
-    """Turns a dimension size into a Jax value that we can compute with."""
-    raise core.InconclusiveDimensionOperation("TODO")
-
-core._SPECIAL_DIMENSION_HANDLERS[DynamicJaxprTracer] = DimensionHandlerTracer()
 
 Const = Any
 Val = Any

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -984,7 +984,7 @@ def _scan_typecheck(bind_time, *in_atoms, reverse, length, num_consts,
      type(linear) is tuple and all(type(x) is bool for x in linear))
   tc(unroll, 'unroll', 'positive int', type(unroll) is int and unroll > 0)
 
-  tc(length, 'length', 'non-negative int', core.greater_equal_dim(length, 0))
+  tc(length, 'length', 'non-negative int', length >= 0)
 
   if len(linear) != len(avals):
     raise core.JaxprTypeError(

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3169,9 +3169,9 @@ def _pad_shape_rule(operand, padding_value, *, padding_config):
   if not all(i >= 0 for _, _, i in padding_config):
     raise ValueError("interior padding in padding_config must be nonnegative, "
                      f"got padding_config {padding_config}")
-  result = tuple(core.sum_dim(l, h, core.dilate_dim(d, i + 1))
+  result = tuple(l + h + core.dilate_dim(d, i + 1)
                  for (l, h, i), d in zip(padding_config, op_shape))
-  if not all(core.greater_equal_dim(d, 0) for d in result):
+  if not all(d >= 0 for d in result):
     msg = (f"Dimension size after padding is not at least 0, "
            f"got result shape {result}, for padding_config {padding_config}"
            f" and operand shape {op_shape}")
@@ -3298,12 +3298,12 @@ def shape_as_value(shape: core.Shape):
   return concatenate(dims, dimension=0)
 
 def _reshape_shape_rule(operand, *, new_sizes, dimensions):
-  if not all(core.greater_equal_dim(d, 0) for d in new_sizes):
+  if not all(d >= 0 for d in new_sizes):
     msg = 'reshape new_sizes must all be positive, got {}.'
     raise TypeError(msg.format(new_sizes))
   # TODO(necula): re-enable this check
   if (not config.jax_dynamic_shapes and
-      not core.same_shape_sizes(np.shape(operand), new_sizes)):
+      not math.prod(np.shape(operand)) == math.prod(new_sizes)):
     msg = 'reshape total size must be unchanged, got new_sizes {} for shape {}.'
     raise TypeError(msg.format(new_sizes, np.shape(operand)))
   if dimensions is not None:
@@ -3822,7 +3822,7 @@ def _argminmax_shape_rule(operand, *, axes, index_dtype):
   axis, = axes
   if not (0 <= axis < len(operand.shape)):
     raise ValueError(f"Invalid axis {axis} for operand shape {operand.shape}")
-  if not core.greater_equal_dim(operand.shape[axis], 1):
+  if operand.shape[axis] < 1:
     raise ValueError("argmin and argmax require non-empty reduced dimension. "
                      f"operand.shape={operand.shape} {axis=}")
   return tuple(np.delete(operand.shape, axis))
@@ -4661,7 +4661,7 @@ def _dilate_shape(shape, dilation):
     msg = "All dilations must be positive, got {}."
     raise TypeError(msg.format(dilation))
   dilation = (1,) * (len(shape) - len(dilation)) + tuple(dilation)
-  return core.dilate_shape(shape, dilation)
+  return tuple(map(core.dilate_dim, shape, dilation))
 
 def _ceil_divide(x1, x2):
   return -np.floor_divide(np.negative(x1), x2)
@@ -4803,7 +4803,7 @@ def _check_shapelike(fun_name, arg_name, obj, non_zero_shape=False):
     raise TypeError(msg.format(fun_name, arg_name, tuple(map(type, obj)))) from err
   lower_bound, bound_error = (
       (1, "strictly positive") if non_zero_shape else (0, "nonnegative"))
-  if not all(core.greater_equal_dim(d, lower_bound) for d in obj_arr):
+  if not all(d >= lower_bound for d in obj_arr):
     msg = "{} {} must have every element be {}, got {}."
     raise TypeError(msg.format(fun_name, arg_name, bound_error, obj))
 

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import enum
+import operator
 from functools import partial
 import math
 from typing import Callable, NamedTuple, Optional, Sequence, Union
@@ -1081,34 +1082,33 @@ def _slice_shape_rule(operand, *, start_indices, limit_indices, strides):
     msg = ("slice limit_indices must have the same length as start_indices, "
            "got start_indices {} and limit_indices {}.")
     raise TypeError(msg.format(start_indices, limit_indices))
-  if not core.greater_equal_shape(operand.shape, limit_indices):
+  if not all(map(operator.ge, operand.shape, limit_indices)):
     msg = ("slice limit_indices must be less than or equal to operand shape, "
            "got limit_indices {} for operand shape {}.")
     raise TypeError(msg.format(limit_indices, operand.shape))
-  if not all(core.greater_equal_dim(si, 0) for si in start_indices):
+  if not all(si >= 0 for si in start_indices):
     msg = ("slice start_indices must be greater than or equal to zero, "
            "got start_indices of {}.")
     raise TypeError(msg.format(start_indices))
   if not jax.config.jax_dynamic_shapes:
-    if not core.greater_equal_shape(limit_indices, start_indices):
+    if not all(map(operator.ge, limit_indices, start_indices)):
       msg = ("slice limit_indices must be greater than or equal to start_indices,"
             " got start_indices {} and limit_indices {}.")
       raise TypeError(msg.format(start_indices, limit_indices))
+  diff = tuple(map(operator.sub, limit_indices, start_indices))
   if strides is None or tuple(strides) == (1,) * len(operand.shape):
-    shape = [limit if type(start) is int and start == 0 else limit - start
-             for start, limit in zip(start_indices, limit_indices)]
-    return tuple(shape)
+    return diff
 
   lax._check_shapelike("slice", "strides", strides)
   if len(strides) != operand.ndim:
     msg = ("slice strides must have length equal to the number of dimensions "
             "of the operand, got strides {} for operand shape {}.")
     raise TypeError(msg.format(strides, operand.shape))
-  if not core.greater_equal_shape(strides, (0,) * len(strides)):
+  if not all(s >= 0 for s in strides):
     msg = "slice strides must be positive, got {}"
     raise TypeError(msg.format(strides))
-  diff = core.diff_shape(limit_indices, start_indices)
-  return core.stride_shape(diff, (1,) * len(diff), strides)
+  return tuple(core.stride_dim(d, window_size=1, window_stride=s)
+               for d, s in zip(diff, strides))
 
 def _slice_transpose_rule(t, operand, *, start_indices, limit_indices, strides):
   assert ad.is_undefined_primal(operand)
@@ -1172,11 +1172,11 @@ def _dynamic_slice_shape_rule(
     msg = ("dynamic_slice slice_sizes must have the same length as "
            "start_indices, got start_indices length {} and slice_sizes {}.")
     raise TypeError(msg.format(len(start_indices), slice_sizes))
-  if not dyn and not core.greater_equal_shape(operand.shape, slice_sizes):
+  if not dyn and not all(map(operator.ge, operand.shape, slice_sizes)):
     msg = ("slice slice_sizes must be less than or equal to operand shape, "
            "got slice_sizes {} for operand shape {}.")
     raise TypeError(msg.format(slice_sizes, operand.shape))
-  if not dyn and not all(core.greater_equal_dim(ssz, 0) for ssz in slice_sizes):
+  if not dyn and not all(ssz >= 0 for ssz in slice_sizes):
     msg = ("slice slice_sizes must be greater than or equal to zero, "
            "got slice_sizes of {}.")
     raise TypeError(msg.format(slice_sizes))
@@ -1321,7 +1321,7 @@ def _dynamic_update_slice_shape_rule(operand, update, *start_indices):
     msg = ("dynamic_update_slice start_indices must have length equal to the "
            "rank of operand, got indices {} for operand shape {}.")
     raise TypeError(msg.format(start_indices, operand.shape))
-  if not core.greater_equal_shape(operand.shape, update.shape):
+  if not all(map(operator.ge, operand.shape, update.shape)):
     msg = ("dynamic_update_slice update shape must be smaller than operand "
            "shape, got update shape {} for operand shape {}.")
     raise TypeError(msg.format(update.shape, operand.shape))
@@ -1522,8 +1522,8 @@ def _gather_shape_rule(operand, indices, *, dimension_numbers,
     slice_size = slice_sizes[i]
     corresponding_input_size = operand.shape[i]
 
-    if not (core.greater_equal_dim(slice_size, 0) and
-            core.greater_equal_dim(corresponding_input_size, slice_size)):
+    if not (slice_size >= 0 and
+            corresponding_input_size >= slice_size):
       raise TypeError(f"Slice size at index {i} in gather op is out of range, "
                       f"must be within [0, {corresponding_input_size} + 1), "
                       f"got {slice_size}.")
@@ -1917,7 +1917,7 @@ def _scatter_shape_rule(operand, indices, updates, *, update_jaxpr,
 
   for i in range(len(update_window_dims)):
     update_window_dim = update_window_dims[i]
-    if not core.greater_equal_dim(max_update_slice_sizes[i], updates.shape[update_window_dim]):
+    if max_update_slice_sizes[i] < updates.shape[update_window_dim]:
       raise TypeError(f"Bounds of the window dimensions of updates must not "
                       f"exceed the bounds of the corresponding dimensions of "
                       f"operand. For dimension {update_window_dim}, updates "

--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -438,9 +438,8 @@ def reduce_window_shape_tuple(operand_shape, window_dimensions, window_strides,
     operand_shape = lax._dilate_shape(operand_shape, base_dilation)
   if window_dilation is not None:
     window_dimensions = lax._dilate_shape(window_dimensions, window_dilation)
-  pads_lo, pads_hi = util.unzip2(padding)
-  operand_padded = core.sum_shapes(operand_shape, pads_lo, pads_hi)
-  return core.stride_shape(operand_padded, window_dimensions, window_strides)
+  operand_padded = tuple(d + pl + ph for d, (pl, ph) in zip(operand_shape, padding))
+  return tuple(map(core.stride_dim, operand_padded, window_dimensions, window_strides))
 
 reduce_window_max_p = lax.standard_primitive(
     _common_reduce_window_shape_rule, lax._input_dtype, 'reduce_window_max')

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2311,7 +2311,7 @@ def arange(start: DimSize, stop: Optional[DimSize] = None,
   for name, val in [(start_name, start), ("stop", stop), ("step", step)]:
     if val is not None and np.ndim(val) != 0:
       raise ValueError(f"jax.numpy.arange: arguments must be scalars; got {name}={val}")
-  if any(core.is_dynamic_dim(v) for v in (start, stop, step)):
+  if any(core.is_symbolic_dim(v) for v in (start, stop, step)):
     # Some dynamic shapes
     if stop is None and step is None:
       stop = start
@@ -2628,7 +2628,7 @@ def repeat(a: ArrayLike, repeats: ArrayLike, axis: Optional[int] = None, *,
   axis = core.concrete_or_error(operator.index, axis, "'axis' argument of jnp.repeat()")
   assert isinstance(axis, int)  # to appease mypy
 
-  if core.is_dynamic_dim(repeats):
+  if core.is_symbolic_dim(repeats):
     if total_repeat_length is not None:
       raise ValueError("jnp.repeat with a non-constant `repeats` is supported only "
                        f"when `total_repeat_length` is None. ({repeats=} {total_repeat_length=})")
@@ -4389,7 +4389,7 @@ def _index_to_gather(x_shape: Sequence[int], idx: Sequence[Any],
           if start is None or core.definitely_equal(start, 0):
             start = None
           if stop is None or (not isinstance(stop, core.Tracer) and
-              core.greater_equal_dim(stop, x_shape[x_axis])):
+              stop >= x_shape[x_axis]):
             stop = None
         elif core.definitely_equal(step, -1):
           step = -1

--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -94,7 +94,7 @@ def _reduction(a: ArrayLike, name: str, np_fun: Any, op: ReductionOp, init_val: 
 
   if initial is None and not has_identity:
     shape = np.shape(a)
-    if not _all(core.greater_equal_dim(shape[d], 1) for d in pos_dims):
+    if not _all(shape[d] >= 1 for d in pos_dims):
       raise ValueError(f"zero-size array to reduction operation {name} which has no identity")
 
   result_dtype = dtype or dtypes.dtype(a)

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -21,7 +21,6 @@ from jax._src.interpreters.partial_eval import (
   ConstVar as ConstVar,
   DCERule as DCERule,
   DebugInfo as DebugInfo,
-  DimensionHandlerTracer as DimensionHandlerTracer,
   DynamicJaxprTrace as DynamicJaxprTrace,
   DynamicJaxprTracer as DynamicJaxprTracer,
   ForwardingRule as ForwardingRule,

--- a/tests/dynamic_api_test.py
+++ b/tests/dynamic_api_test.py
@@ -621,11 +621,6 @@ class DynamicShapeStagingTest(jtu.JaxTestCase):
     jaxpr = jax.make_jaxpr(lambda x: x.reshape(-1, 12), abstracted_axes={0: 'n'})(x)
     self.assertLessEqual(len(jaxpr.jaxpr.eqns), 3)
 
-    # do need divide, also shouldn't typecheck
-    _ = jax.make_jaxpr(lambda x: x.reshape(x.shape[0], x.shape[0], -1),
-                       abstracted_axes={0: 'n'})(x)  # don't crash
-
-
 @unittest.skip("Test does not work with jax.Array")
 @jtu.with_config(jax_dynamic_shapes=True, jax_numpy_rank_promotion="allow")
 class DynamicShapeAutodiffTest(jtu.JaxTestCase):


### PR DESCRIPTION
Previously we had a number of APIs in core.py that operated on dimensions and shapes and delegated to instances of DimensionHandler. We remove most of those APIs because by now they ended up doing very little, e.g., `core.sum_dim` was the same as `operator.add`, and `core.sum_shape` was the same as `tuple(map(operator.add))`.

We also remove the whole `DimensionHandler` machinery because by now the only other use of non-constant dimensions using this mechanism are the symbolic dimensions used for shape polymorphism, and those support now full operator overloading. (When we introduced `DimensionHandler` we had the masking transformation around that needed it also.)

This is a new attempt at landing this, the first attempt in #16689, was rolled back due to internal test failures.