### PR TITLE
Lower jax.numpy matmul functions to mixed-precision dot_general

### DIFF
--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -723,7 +723,8 @@ def _bcoo_dot_general_impl(lhs_data, lhs_indices, rhs, *, dimension_numbers,
       idx_right = (*idx_batch, *idx_right)
     batch_dims = list(range(len(lhs_contracting_b) + bool(lhs_contracting_s)))
     prod = lax.dot_general(lhs_data, rhs.at[idx_right].get(mode='fill', fill_value=0),
-                           (([], []), (batch_dims, batch_dims)))
+                           (([], []), (batch_dims, batch_dims)),
+                           preferred_element_type=preferred_element_type)
     if idx_out:
       return out_array.at[idx_out].add(prod)
     else:

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -1937,7 +1937,7 @@ class BCOOTest(sptu.SparseTestCase):
     args_maker = lambda: [sprng(lhs_shape, lhs_dtype, n_batch=n_batch_lhs),
                           jnp.array(rng(rhs_shape, rhs_dtype))]
 
-    tol = {np.float64: 1E-13, np.complex128: 1E-13,
+    tol = {np.float64: 1E-7, np.complex128: 1E-7,
            np.float32: 2E-6, np.complex64: 2E-6}
 
     with jtu.strict_promotion_if_dtypes_match([lhs_dtype, rhs_dtype]):
@@ -1976,7 +1976,7 @@ class BCOOTest(sptu.SparseTestCase):
     args_maker_sp_de = lambda: [sprng(lhs_shape, lhs_dtype, n_batch=n_batch_lhs),
                                 jnp.array(rng(rhs_shape, rhs_dtype))]
 
-    tol = {np.float64: 1E-13, np.complex128: 1E-13,
+    tol = {np.float64: 1E-7, np.complex128: 1E-7,
            np.float32: 1E-6, np.complex64: 1E-6}
 
     with jtu.strict_promotion_if_dtypes_match([lhs_dtype, rhs_dtype]):


### PR DESCRIPTION
Related to #16703

I opted not to add specific tests for these as I did for `dot` in #16721 and `einsum` in #16733

Note that the sparse test tolerances needed to change because the new path no longer calls `convert_element_type`, which for sparse inputs has a side-effect of calling `sum_duplicates`, which previously improved the numerical accuracy of the matmul output at the expense of a slower runtime. I opted not to force a `sum_duplicates` in `bcoo_dot_general`, but rather to allow for this inaccuracy in order to improve performance of the default impl.