### PR TITLE
[sparse] support preferred_element_type in dot_general

### DIFF
--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -1289,7 +1289,7 @@ class BCOOTest(sptu.SparseTestCase):
 
     def f_sparse(data, indices, Y):
       return sparse_bcoo._bcoo_dot_general(data, indices, Y, lhs_spinfo=sparse_util.SparseInfo(X.shape),
-                                           dimension_numbers=dimension_numbers)
+                                           dimension_numbers=dimension_numbers, preferred_element_type=None)
 
     for data, indices in itertools.product([data, data[:1]], [indices, indices[:1]]):
       X = sparse_bcoo._bcoo_todense(data, indices, spinfo=sparse_util.SparseInfo(X.shape))


### PR DESCRIPTION
Part of #16703

This should fix the errors in #16736

Note that some of the new behavior is not well-tested until #16736 goes in, but because that will (hopefully) be soon, I don't think it's worth adding other tests to `sparse_test.py`, which is already one of the longest/most expensive test suites in JAX.