### PR TITLE
mypy: suppress annotation-unchecked notes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.mypy]
 show_error_codes = true
-disable_error_code = "attr-defined, name-defined"
+disable_error_code = "attr-defined, name-defined, annotation-unchecked"
 no_implicit_optional = true
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
This suppresses the many notifications that obscured the type-checking error in #16754