### PR TITLE
custom prng: introduce mechanism to identify key arrays by dtype

### DIFF
--- a/docs/jax.dtypes.rst
+++ b/docs/jax.dtypes.rst
@@ -10,5 +10,6 @@
     canonicalize_dtype
     float0
     issubdtype
+    prng_key
     result_type
     scalar_type_of

--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -22,6 +22,7 @@ from typing import Union, Callable, TypeVar, Any
 import numpy as np
 
 import jax.numpy as jnp
+from jax import dtypes
 from jax import lax
 
 from jax._src import api
@@ -30,7 +31,6 @@ from jax._src import core
 from jax._src import custom_derivatives
 from jax._src import effects
 from jax._src import pjit
-from jax._src import prng
 from jax._src import sharding_impls
 from jax._src import source_info_util
 from jax._src import traceback_util
@@ -576,7 +576,7 @@ def check_nans(prim, error, enabled_errors, out):
     return error
 
   def isnan(x):
-    if isinstance(x, prng.PRNGKeyArray):
+    if jnp.issubdtype(x.dtype, dtypes.prng_key):
       return False
     return jnp.any(jnp.isnan(x))
 

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -46,6 +46,7 @@ else:
 FLAGS = flags.FLAGS
 
 
+# TODO(jakevdp): rename opaque dtypes to something more user-friendly
 class opaque(np.generic):
   """Scalar class for opaque dtypes.
 
@@ -62,6 +63,23 @@ class opaque(np.generic):
   pass
 
 
+class prng_key(opaque):
+  """Scalar class for PRNG Key dtypes.
+
+  This is an abstract class that should never be instantiated, but rather
+  exists for the sake of `jnp.issubdtype`.
+
+  Examples:
+    >>> from jax import random
+    >>> from jax import dtypes
+    >>> key = random.key(0)
+    >>> jnp.issubdtype(key.dtype, dtypes.prng_key)
+    True
+  """
+  pass
+
+
+# TODO(jakevdp): rename opaque dtypes to something more user-friendly
 class OpaqueDType(metaclass=abc.ABCMeta):
   """Abstract Base Class for opaque dtypes"""
   @property
@@ -72,7 +90,6 @@ class OpaqueDType(metaclass=abc.ABCMeta):
 def is_opaque_dtype(dtype: Any) -> bool:
   # TODO(vanderplas, frostig): remove in favor of inlining `issubdtype`
   return issubdtype(dtype, opaque)
-
 
 # fp8 support
 float8_e4m3b11fnuz: type[np.generic] = ml_dtypes.float8_e4m3b11fnuz

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -84,7 +84,7 @@ def _check_prng_key(key) -> tuple[prng.PRNGKeyArray, bool]:
 
 def _return_prng_keys(was_wrapped, key):
   # TODO(frostig): remove once we always enable_custom_prng
-  assert isinstance(key, prng.PRNGKeyArray)
+  assert jnp.issubdtype(key.dtype, dtypes.prng_key)
   if config.jax_enable_custom_prng:
     return key
   else:
@@ -92,7 +92,7 @@ def _return_prng_keys(was_wrapped, key):
 
 
 def _random_bits(key: prng.PRNGKeyArray, bit_width, shape) -> Array:
-  assert isinstance(key, prng.PRNGKeyArray)
+  assert jnp.issubdtype(key.dtype, dtypes.prng_key)
   return prng.random_bits(key, bit_width=bit_width, shape=shape)
 
 
@@ -129,7 +129,7 @@ def resolve_prng_impl(impl_spec: Optional[str]):
 def _key(ctor_name: str, seed: Union[int, Array], impl_spec: Optional[str]
          ) -> PRNGKeyArray:
   impl = resolve_prng_impl(impl_spec)
-  if isinstance(seed, prng.PRNGKeyArray):
+  if hasattr(seed, 'dtype') and jnp.issubdtype(seed.dtype, dtypes.prng_key):
     raise TypeError(
         f"{ctor_name} accepts a scalar seed, but was given a PRNGKeyArray.")
   if np.ndim(seed):
@@ -209,7 +209,7 @@ def unsafe_rbg_key(seed: int) -> KeyArray:
 def _fold_in(key: KeyArray, data: IntegerArray) -> KeyArray:
   # Alternative to fold_in() to use within random samplers.
   # TODO(frostig): remove and use fold_in() once we always enable_custom_prng
-  assert isinstance(key, prng.PRNGKeyArray)
+  assert jnp.issubdtype(key.dtype, dtypes.prng_key)
   if key.ndim:
     raise TypeError("fold_in accepts a single key, but was given a key array of"
                     f"shape {key.shape} != (). Use jax.vmap for batching.")
@@ -236,7 +236,7 @@ def _split(key: KeyArray, num: Union[int, tuple[int, ...]] = 2) -> KeyArray:
   # Alternative to split() to use within random samplers.
   # TODO(frostig): remove and use split(); we no longer need to wait
   # to always enable_custom_prng
-  assert isinstance(key, prng.PRNGKeyArray)
+  assert jnp.issubdtype(key.dtype, dtypes.prng_key)
   if key.ndim:
     raise TypeError("split accepts a single key, but was given a key array of"
                     f"shape {key.shape} != (). Use jax.vmap for batching.")
@@ -258,7 +258,7 @@ def split(key: KeyArray, num: Union[int, tuple[int, ...]] = 2) -> KeyArray:
   return _return_prng_keys(wrapped, _split(key, num))
 
 def _key_data(keys: KeyArray) -> Array:
-  assert isinstance(keys, prng.PRNGKeyArray)
+  assert jnp.issubdtype(keys.dtype, dtypes.prng_key)
   return prng.random_unwrap(keys)
 
 def key_data(keys: KeyArray) -> Array:

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -22,6 +22,7 @@ from jax._src.dtypes import (
     float0 as float0,
     iinfo,  # TODO(phawkins): switch callers to jnp.iinfo?
     issubdtype,  # TODO(phawkins): switch callers to jnp.issubdtype?
+    prng_key as prng_key,
     result_type as result_type,
     scalar_type_of as scalar_type_of,
 )


### PR DESCRIPTION
Part of #16716

Builds on the refactoring in #16795

This proposes a new mechanism by which PRNG key arrays can be identified. Previously we used this:
```python
is_key_array = isinstance(arr, jax.random.PRNGKeyArray)
```
After this change, we can use this:
```python
is_key_array = jnp.issubdtype(arr.dtype, jax.dtypes.prng_key)
```
The reason for making this change is that `PRNGKeyArray` is really an implementation detail – PRNG Keys Arrays could be unified with standard arrays eventually – and what distinguishes them is their dtype.