### PR TITLE
Remove obsolete numpy version checks

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -240,8 +240,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     dtype=default_dtypes,
   )
   def testUnwrap(self, shape, dtype, axis, discont, period):
-    if period != "2pi":
-      self.skipTest("numpy < 1.21 does not support the period argument to unwrap()")
     special_vals = {"pi": np.pi, "2pi": 2 * np.pi}
     period = special_vals.get(period, period)
     discont = special_vals.get(discont, discont)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -2139,8 +2139,6 @@ class LaxRandomWithCustomPRNGTest(LaxRandomTest):
         ValueError, r'dtype=key<.*> is not a valid dtype for JAX type promotion.',
         lambda: key + 47)
 
-  @skipIf(np.__version__ == "1.21.0",
-          "https://github.com/numpy/numpy/issues/19305")
   def test_grad_of_prng_key(self):
     key = self.make_key(73)
     with self.assertRaisesRegex(TypeError, 'grad requires real- or complex-valued inputs'):
@@ -2210,8 +2208,6 @@ class LaxRandomWithRBGPRNGTest(LaxRandomTest):
         ValueError, r'dtype=key<.*> is not a valid dtype for JAX type promotion.',
         lambda: key + 47)
 
-  @skipIf(np.__version__ == "1.21.0",
-          "https://github.com/numpy/numpy/issues/19305")
   def test_grad_of_prng_key(self):
     key = self.make_key(73)
     with self.assertRaisesRegex(TypeError, 'grad requires real- or complex-valued inputs'):


### PR DESCRIPTION
Jax has dropped support for Numpy 1.21 so these test do no longer need to be skipped.