### PR TITLE
Remove unneeded Python 3.9+ version checks

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -459,16 +459,6 @@ def _flat_out_axes(leaves, treedef, *args, **kwargs):
     raise ValueError(msg) from None
   yield ans, spec_flat
 
-def _isgeneratorfunction(fun):
-  # TODO 3.9+: remove
-  # re-implemented here because of https://bugs.python.org/issue33261
-  while inspect.ismethod(fun):
-    fun = fun.__func__
-  while isinstance(fun, partial):
-    fun = fun.func
-  return inspect.isfunction(fun) and bool(fun.__code__.co_flags & inspect.CO_GENERATOR)
-
-
 def check_callable(fun):
   # In Python 3.10+, the only thing stopping us from supporting staticmethods
   # is that we can't take weak references to them, which the C++ JIT requires.
@@ -476,7 +466,7 @@ def check_callable(fun):
     raise TypeError(f"staticmethod arguments are not supported, got {fun}")
   if not callable(fun):
     raise TypeError(f"Expected a callable value, got {fun}")
-  if _isgeneratorfunction(fun):
+  if inspect.isgeneratorfunction(fun):
     raise TypeError(f"Expected a function, got a generator function: {fun}")
 
 _POSITIONAL_OR_KEYWORD = inspect.Parameter.POSITIONAL_OR_KEYWORD

--- a/jax/_src/sharding_impls.py
+++ b/jax/_src/sharding_impls.py
@@ -21,7 +21,6 @@ import functools
 import itertools
 import math
 import operator as op
-import sys
 from typing import (Any, Mapping, Optional, OrderedDict, NamedTuple, Sequence,
                     Union, cast)
 
@@ -40,11 +39,6 @@ from jax._src.lib import xla_extension_version
 from jax._src.partition_spec import PartitionSpec
 
 import numpy as np
-
-if sys.version_info >= (3, 9):
-  OrderedDictType = OrderedDict
-else:
-  OrderedDictType = dict
 
 
 Shape = tuple[int, ...]
@@ -889,7 +883,7 @@ that would mean that a flat list of chunks would get assigned to a flattened lis
 mesh devices without any modifications. If the mapping was {'y': 1, 'x': 1}, then the
 mesh devices ndarray would have to be transposed before flattening and assignment.
 """
-ArrayMapping = OrderedDictType[MeshAxisName, int]
+ArrayMapping = OrderedDict[MeshAxisName, int]
 ArrayMappingOrAutoOrUnspecified = Union[ArrayMapping, AUTO, UnspecifiedValue]
 
 def array_mapping_to_axis_resources(array_mapping: ArrayMapping):


### PR DESCRIPTION
Jax requires Python 3.9 or newer so these version checks should not be needed anymore.