### PR TITLE
Refactor opaque dtype implementation.

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1439,14 +1439,14 @@ def physical_aval(aval):
     return aval
 
 def _short_dtype_name(dtype) -> str:
-  if type(dtype) in dtypes.opaque_dtypes:
+  if dtypes.issubdtype(dtype, dtypes.opaque):
     return str(dtype)
   else:
     return (dtype.name.replace('float', 'f').replace('uint'   , 'u')
                       .replace('int'  , 'i').replace('complex', 'c'))
 
 def _dtype_object(dtype):
-  return dtype if type(dtype) in dtypes.opaque_dtypes else np.dtype(dtype)
+  return dtype if dtypes.issubdtype(dtype, dtypes.opaque) else np.dtype(dtype)
 
 class UnshapedArray(AbstractValue):
   __slots__ = ['dtype', 'weak_type']
@@ -1780,8 +1780,12 @@ pytype_aval_mappings[DArray] = \
                              x._data)
 
 @dataclass(frozen=True, eq=True)
-class bint:
+class bint(dtypes.OpaqueDType):
   bound: int
+
+  @property
+  def type(self) -> type:
+    return dtypes.opaque
 
   @property
   def name(self) -> str:
@@ -1789,7 +1793,6 @@ class bint:
 
   def __str__(self) -> str:
     return self.name
-dtypes.opaque_dtypes.add(bint)
 
 AxisSize = Union[int, DArray, Tracer, Var, DBIdx, InDBIdx, OutDBIdx]
 

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2047,7 +2047,7 @@ def array(object: Any, dtype: Optional[DTypeLike] = None, copy: bool = True,
     # containing large integers; see discussion in
     # https://github.com/google/jax/pull/6047. More correct would be to call
     # coerce_to_array on each leaf, but this may have performance implications.
-    out = np.array(object, dtype=dtype, ndmin=ndmin, copy=False)
+    out = np.array(object, dtype=dtype, ndmin=ndmin, copy=False)  # type: ignore[arg-type]
   elif isinstance(object, Array):
     assert object.aval is not None
     out = _array_copy(object) if copy else object
@@ -2055,7 +2055,7 @@ def array(object: Any, dtype: Optional[DTypeLike] = None, copy: bool = True,
     if object:
       out = stack([asarray(elt, dtype=dtype) for elt in object])
     else:
-      out = np.array([], dtype=dtype)
+      out = np.array([], dtype=dtype)  # type: ignore[arg-type]
   else:
     try:
       view = memoryview(object)

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -270,7 +270,7 @@ def promote_dtypes(*args: ArrayLike) -> list[Array]:
     return [lax.asarray(arg) for arg in args]
   else:
     to_dtype, weak_type = dtypes._lattice_result_type(*args)
-    to_dtype = dtypes.canonicalize_dtype(to_dtype, allow_opaque_dtype=True)
+    to_dtype = dtypes.canonicalize_dtype(to_dtype, allow_opaque_dtype=True)  # type: ignore[assignment]
     return [lax._convert_element_type(x, to_dtype, weak_type) for x in args]
 
 
@@ -279,7 +279,7 @@ def promote_dtypes_inexact(*args: ArrayLike) -> list[Array]:
 
   Promotes arguments to an inexact type."""
   to_dtype, weak_type = dtypes._lattice_result_type(*args)
-  to_dtype = dtypes.canonicalize_dtype(to_dtype, allow_opaque_dtype=True)
+  to_dtype = dtypes.canonicalize_dtype(to_dtype, allow_opaque_dtype=True)  # type: ignore[assignment]
   to_dtype_inexact = dtypes.to_inexact_dtype(to_dtype)
   return [lax._convert_element_type(x, to_dtype_inexact, weak_type)
           for x in args]

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -577,9 +577,10 @@ class KeyTyRules:
     return random_wrap(physical_result, impl=aval.dtype.impl)
 
 
-class KeyTy:
+class KeyTy(dtypes.OpaqueDType):
   impl: Hashable  # prng.PRNGImpl. TODO(mattjj,frostig): protocol really
   _rules = KeyTyRules
+  type = dtypes.opaque
 
   def __init__(self, impl):
     self.impl = impl
@@ -601,8 +602,6 @@ class KeyTy:
   def __hash__(self) -> int:
     return hash((self.__class__, self.impl))
 
-
-dtypes.opaque_dtypes.add(KeyTy)
 
 
 core.pytype_aval_mappings[PRNGKeyArrayImpl] = lambda x: x.aval

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2913,7 +2913,8 @@ class FooTyRules:
     return handler
 
 
-class FooTy:
+class FooTy(dtypes.OpaqueDType):
+  type = dtypes.opaque
   name = 'foo'
   _rules = FooTyRules
 
@@ -3005,7 +3006,6 @@ def bake_vmap(batched_args, batch_dims):
 class CustomElementTypesTest(jtu.JaxTestCase):
 
   def setUp(self):
-    dtypes.opaque_dtypes.add(FooTy)
     core.pytype_aval_mappings[FooArray] = \
         lambda x: core.ShapedArray(x.shape, FooTy())
     xla.canonicalize_dtype_handlers[FooArray] = lambda x: x
@@ -3021,7 +3021,6 @@ class CustomElementTypesTest(jtu.JaxTestCase):
     batching.primitive_batchers[bake_p] = bake_vmap
 
   def tearDown(self):
-    dtypes.opaque_dtypes.remove(FooTy)
     del core.pytype_aval_mappings[FooArray]
     del xla.canonicalize_dtype_handlers[FooArray]
     del xla.pytype_aval_mappings[FooArray]


### PR DESCRIPTION
This makes it closer to numpy, with `dtypes.OpaqueDtype` analogous to `np.dtype`, and `dtypes.opaque` analogous to `np.numeric`. This will let us replace the `dtypes.is_opaque_dtype(dtype)` function with `jnp.issubdtype(dtype, dtypes.opaque)`.

This underlying change will make the goal in #16781 much easier to realize.