### PR TITLE
Cloud TPU CI: make sure we update test deps and upgrade protobuf version

### DIFF
--- a/.github/workflows/cloud-tpu-ci-nightly.yml
+++ b/.github/workflows/cloud-tpu-ci-nightly.yml
@@ -25,8 +25,8 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # ratchet:actions/checkout@v3
       - name: Install JAX test requirements
         run: |
-          pip install -r build/test-requirements.txt
-          pip install -r build/collect-profile-requirements.txt
+          pip install -U -r build/test-requirements.txt
+          pip install -U -r build/collect-profile-requirements.txt
       - name: Install JAX
         run: |
           pip uninstall -y jax jaxlib libtpu-nightly

--- a/build/collect-profile-requirements.txt
+++ b/build/collect-profile-requirements.txt
@@ -1,4 +1,4 @@
 tensorflow
 tensorboard-plugin-profile
 # Needed for the profile plugin to work without error
-protobuf<=3.20
+protobuf


### PR DESCRIPTION
`profiler_test.py:ProfilerTest.test_remote_profiler` fails with the protobuf upgrade. However, I was seeing mysterious hangs without this, and in general I think we should be testing with up-to-date deps given that we don't pin. I'm gonna continue working on getting the Cloud TPU CI green.