### PR TITLE
[jax2tf] Document the JAX serialization version numbers.

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -698,7 +698,7 @@ jax_serialization_version = config.define_int_state(
         'The version number to use for native serialization. This must be '
         'within the range of versions supported by the tf.XlaCallModule '
         'used in your deployment environment. '
-        'See https://github.com/search?q=repo%3Atensorflow%2Ftensorflow+path%3Axla_call_module+%22int+VERSION_MAXIMUM_SUPPORTED%22&type=code.'
+        'See https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#native-serialization-versions.'
     )
 )
 

--- a/jax/experimental/jax2tf/jax_export.py
+++ b/jax/experimental/jax2tf/jax_export.py
@@ -134,7 +134,7 @@ class Exported:
     lowering_platform: one of 'tpu', 'cpu', 'cuda', 'rocm'
     mlir_module_serialized: the serialized lowered VHLO module.
     xla_call_module_version: a version number for the serialized module.
-        See more versioning details at https://github.com/search?q=repo%3Atensorflow%2Ftensorflow+path%3Axla_call_module+%22int+VERSION_MAXIMUM_SUPPORTED%22&type=code
+        See more versioning details at https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#native-serialization-versions.
     module_kept_var_idx: the sorted indices of the arguments among `in_avals` that
         must be passed to the module. The other arguments have been dropped
         because they are not used. Same length as `in_shardings`.

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -460,7 +460,7 @@ class _DimExpr():
   def inconclusive_comparison(self, operation: str, op: Any) -> Exception:
     return InconclusiveDimensionOperation(
       f"Symbolic dimension comparison '{self}' {operation} '{op}' is inconclusive.\n"
-      "See https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#comparison-of-symbolic0dimensions-is-partially-supported.")
+      "See https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#comparison-of-symbolic-dimensions-is-partially-supported.")
 
   def ge(self, other: DimSize) -> bool:
     lb, ub = _ensure_poly(self - other, "ge").bounds()


### PR DESCRIPTION
Previously this was documented in code comments in TF source code: https://github.com/search?q=repo%3Atensorflow%2Ftensorflow+path%3Axla_call_module+%22int+VERSION_MAXIMUM_SUPPORTED%22&type=code

We want to establish a new source of truth for this. We will then update the code comments in TF source.