### PR TITLE
Use standard framework for jax.tree* deprecation.

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -138,13 +138,12 @@ from jax.version import __version_info__ as __version_info__
 
 from jax._src.tree_util import (
   tree_map as tree_map,
-  # TODO(jakevdp): remove these deprecated routines after October 2022
-  _deprecated_treedef_is_leaf as treedef_is_leaf,
-  _deprecated_tree_flatten as tree_flatten,
-  _deprecated_tree_leaves as tree_leaves,
-  _deprecated_tree_structure as tree_structure,
-  _deprecated_tree_transpose as tree_transpose,
-  _deprecated_tree_unflatten as tree_unflatten,
+  treedef_is_leaf as _deprecated_treedef_is_leaf,
+  tree_flatten as _deprecated_tree_flatten,
+  tree_leaves as _deprecated_tree_leaves,
+  tree_structure as _deprecated_tree_structure,
+  tree_transpose as _deprecated_tree_transpose,
+  tree_unflatten as _deprecated_tree_unflatten,
 )
 
 # These submodules are separate because they are in an import cycle with
@@ -185,11 +184,43 @@ _deprecations = {
     "jax.abstract_arrays is deprecated. Refer to jax.core.",
     _deprecated_abstract_arrays
   ),
+  # Added July 2022
+  "treedef_is_leaf": (
+    "jax.treedef_is_leaf is deprecated: use jax.tree_util.treedef_is_leaf.",
+    _deprecated_treedef_is_leaf
+  ),
+  "tree_flatten": (
+    "jax.tree_flatten is deprecated: use jax.tree_util.tree_flatten.",
+    _deprecated_tree_flatten
+  ),
+  "tree_leaves": (
+    "jax.tree_leaves is deprecated: use jax.tree_util.tree_leaves.",
+    _deprecated_tree_leaves
+  ),
+  "tree_structure": (
+    "jax.tree_structure is deprecated: use jax.tree_util.tree_structure.",
+    _deprecated_tree_structure
+  ),
+  "tree_transpose": (
+    "jax.tree_transpose is deprecated: use jax.tree_util.tree_transpose.",
+    _deprecated_tree_transpose
+  ),
+  "tree_unflatten": (
+    "jax.tree_unflatten is deprecated: use jax.tree_util.tree_unflatten.",
+    _deprecated_tree_unflatten
+  )
 }
 
 import typing as _typing
 if _typing.TYPE_CHECKING:
   from jax._src import abstract_arrays as abstract_arrays
+  from jax._src.tree_util import treedef_is_leaf as treedef_is_leaf
+  from jax._src.tree_util import tree_flatten as tree_flatten
+  from jax._src.tree_util import tree_leaves as tree_leaves
+  from jax._src.tree_util import tree_structure as tree_structure
+  from jax._src.tree_util import tree_transpose as tree_transpose
+  from jax._src.tree_util import tree_unflatten as tree_unflatten
+
 else:
   from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
   __getattr__ = _deprecation_getattr(__name__, _deprecations)

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -968,27 +968,3 @@ def _prefix_error(
      f"{prefix_tree_keys} and {full_tree_keys}")
   for k, t1, t2 in zip(prefix_tree_keys, prefix_tree_children, full_tree_children):
     yield from _prefix_error((*key_path, k), t1, t2)
-
-
-# TODO(jakevdp) remove these deprecated wrappers & their imports in jax/__init__.py
-def _deprecate(f):
-
-  @functools.wraps(f)
-  def wrapped(*args, **kwargs):
-    warnings.warn(
-        f"jax.{f.__name__} is deprecated, and will be removed in a future release. "
-        f"Use jax.tree_util.{f.__name__} instead.",
-        category=FutureWarning,
-        stacklevel=2)
-    return f(*args, **kwargs)
-
-  return wrapped
-
-
-def __getattr__(name):
-  prefix = "_deprecated_"
-  if name.startswith(prefix):
-    name = name[len(prefix):]
-    return _deprecate(globals()[name])
-  else:
-    raise AttributeError(f"module {__name__} has no attribute {name!r}")


### PR DESCRIPTION
This will let us use existing tools to finalize the deprecation.