### PR TITLE
[jax2tf] Added error for attempting to use wrong jax_serialization_version

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -834,7 +834,7 @@ def _run_exported_as_tf(args_flat_tf: Sequence[TfVal],
   kept_args_avals = [aval for i, aval in enumerate(exported.in_avals) if i in exported.module_kept_var_idx]
   kept_args_flat_tf = [atf for i, atf in enumerate(args_flat_tf) if i in exported.module_kept_var_idx]
 
-  version = exported.xla_call_module_version
+  version = exported.serialization_version
   call_module_attrs = dict(
       version=version,
       Tout=out_types,

--- a/jax/experimental/jax2tf/tests/back_compat_test_util.py
+++ b/jax/experimental/jax2tf/tests/back_compat_test_util.py
@@ -292,7 +292,7 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
 
     module_str = str(exported.mlir_module)
     serialized = exported.mlir_module_serialized
-    module_version = exported.xla_call_module_version
+    module_version = exported.serialization_version
     return serialized, module_str, module_version
 
   def run_serialized(self, data: CompatTestData,
@@ -323,10 +323,10 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
         lowering_platform=data.platform,
         disabled_checks=(),
         mlir_module_serialized=data.mlir_module_serialized,
-        xla_call_module_version=data.xla_call_module_version,
+        serialization_version=data.xla_call_module_version,
         module_kept_var_idx=tuple(range(len(in_avals))),
-        module_uses_dim_vars=any(not core.is_constant_shape(a.shape)
-                                 for a in in_avals),
+        uses_shape_polymorphism=any(not core.is_constant_shape(a.shape)
+                                    for a in in_avals),
       _get_vjp=_get_vjp)
 
       # We use pjit in case there are shardings in the exported module.

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -31,6 +31,7 @@ from jax import tree_util
 
 from jax import config
 from jax.experimental import jax2tf
+from jax.experimental.jax2tf import jax_export
 from jax._src import xla_bridge
 import numpy as np
 import tensorflow as tf  # type: ignore[import]
@@ -156,7 +157,7 @@ def ComputeTfValueAndGrad(tf_f: Callable, tf_args: Sequence,
                  jax_numpy_dtype_promotion='standard')
 class JaxToTfTestCase(jtu.JaxTestCase):
   # We want most tests to use the maximum available version, from the locally
-  # installed tfxla module.
+  # installed tfxla module and jax_export.
   use_max_serialization_version = True
 
   def setUp(self):
@@ -179,14 +180,17 @@ class JaxToTfTestCase(jtu.JaxTestCase):
     self.addCleanup(functools.partial(config.update,
                                       "jax_serialization_version", version))
     if self.use_max_serialization_version:
-      # The largest version we support is 7
-      max_version = min(7, tfxla.call_module_maximum_supported_version())
-      self.assertLessEqual(version, max_version)
-      version = max_version
-      config.update("jax_serialization_version", max_version)
-    logging.info("Using JAX serialization version %s%s",
-                 version,
-                 " (max_version)" if self.use_max_serialization_version else "")
+      # Use the largest supported by both jax_export and tfxla.call_module
+      version = min(jax_export.maximum_supported_serialization_version,
+                    tfxla.call_module_maximum_supported_version())
+      self.assertGreaterEqual(version,
+                              jax_export.minimum_supported_serialization_version)
+      config.update("jax_serialization_version", version)
+    logging.info(
+      "Using JAX serialization version %s (jax_export.max_version %s, tf.XlaCallModule max version %s)",
+      version,
+      jax_export.maximum_supported_serialization_version,
+      tfxla.call_module_maximum_supported_version())
 
     with contextlib.ExitStack() as stack:
       stack.enter_context(tf.device(self.tf_default_device))


### PR DESCRIPTION
Previously, the serialization would use the specified serialization version without checking if it supported by the serialzier. This could result in invalid serializations

Also add some compatibility tests for all supported versions.