### PR TITLE
Rename opaque dtype to extended dtype.

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -567,7 +567,7 @@ def _shaped_abstractify_slow(x):
   weak_type = getattr(x, 'weak_type', False)
   named_shape = getattr(x, 'named_shape', {})
   if hasattr(x, 'dtype'):
-    dtype = dtypes.canonicalize_dtype(x.dtype, allow_opaque_dtype=True)
+    dtype = dtypes.canonicalize_dtype(x.dtype, allow_extended_dtype=True)
   else:
     raise TypeError(
         f"Cannot interpret value of type {type(x)} as an abstract array; it "
@@ -592,14 +592,14 @@ def _numpy_array_abstractify(x: np.ndarray) -> ShapedArray:
   dtype = x.dtype
   dtypes.check_valid_dtype(dtype)
   return ShapedArray(x.shape,
-      dtypes.canonicalize_dtype(dtype, allow_opaque_dtype=True))
+      dtypes.canonicalize_dtype(dtype, allow_extended_dtype=True))
 _shaped_abstractify_handlers[np.ndarray] = _numpy_array_abstractify
 
 def _np_scalar_abstractify(x: np.generic) -> ShapedArray:
   dtype = np.dtype(x)
   dtypes.check_valid_dtype(dtype)
   return ShapedArray(np.shape(x),
-      dtypes.canonicalize_dtype(dtype, allow_opaque_dtype=True))
+      dtypes.canonicalize_dtype(dtype, allow_extended_dtype=True))
 _shaped_abstractify_handlers.update((t, _np_scalar_abstractify)
                                     for t in numpy_scalar_types)
 

--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -600,7 +600,7 @@ def make_array_from_callback(
       for device in sharding.addressable_devices
   ]
   aval = core.ShapedArray(shape, arrays[0].dtype, weak_type=False)
-  if dtypes.is_opaque_dtype(aval.dtype):
+  if dtypes.issubdtype(aval.dtype, dtypes.extended):
     return aval.dtype._rules.make_sharded_array(aval, sharding, arrays, committed=True)
   return ArrayImpl(aval, sharding, arrays, committed=True)
 
@@ -661,7 +661,7 @@ def make_array_from_single_device_arrays(
   # All input arrays should be committed. Checking it is expensive on
   # single-controller systems.
   aval = core.ShapedArray(shape, arrays[0].dtype, weak_type=False)
-  if dtypes.is_opaque_dtype(aval.dtype):
+  if dtypes.issubdtype(aval.dtype, dtypes.extended):
     return aval.dtype._rules.make_sharded_array(aval, sharding, arrays, committed=True)
   # TODO(phawkins): ideally the cast() could be checked. Revisit this after
   # removing DeviceArray.
@@ -785,7 +785,7 @@ def _array_global_result_handler(global_aval, out_sharding, committed,
                                  is_out_sharding_from_xla):
   if global_aval.dtype == dtypes.float0:
     return lambda _: np.zeros(global_aval.shape, dtypes.float0)  # type: ignore
-  if dtypes.is_opaque_dtype(global_aval.dtype):
+  if dtypes.issubdtype(global_aval.dtype, dtypes.extended):
     return global_aval.dtype._rules.global_sharded_result_handler(
         global_aval, out_sharding, committed, is_out_sharding_from_xla)
   return xc.array_result_handler(
@@ -800,7 +800,7 @@ pxla.global_result_handlers[core.AbstractToken] = lambda *_: lambda *_: core.tok
 def _array_local_result_handler(aval, sharding, indices):
   if aval.dtype == dtypes.float0:
     return lambda _: np.zeros(aval.shape, dtypes.float0)  # type: ignore
-  if dtypes.is_opaque_dtype(aval.dtype):
+  if dtypes.issubdtype(aval.dtype, dtypes.extended):
     return aval.dtype._rules.local_sharded_result_handler(
         aval, sharding, indices)
   return xc.array_result_handler(

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -514,8 +514,8 @@ def _convert_element_type(operand: ArrayLike, new_dtype: Optional[DTypeLike] = N
   if hasattr(operand, '__jax_array__'):
     operand = operand.__jax_array__()  # type: ignore
 
-  if (dtypes.is_opaque_dtype(new_dtype) or
-      dtypes.is_opaque_dtype(getattr(operand, 'dtype', None))):
+  if (dtypes.issubdtype(new_dtype, dtypes.extended) or
+      dtypes.issubdtype(getattr(operand, 'dtype', None), dtypes.extended)):
     return convert_element_type_p.bind(operand, new_dtype=new_dtype,
                                        weak_type=bool(weak_type))
 
@@ -1201,7 +1201,7 @@ def full(shape: Shape, fill_value: ArrayLike, dtype: Optional[DTypeLike] = None)
   if np.shape(fill_value):
     msg = "full must be called with scalar fill_value, got fill_value.shape {}."
     raise TypeError(msg.format(np.shape(fill_value)))
-  if dtypes.is_opaque_dtype(dtype):
+  if dtypes.issubdtype(dtype, dtypes.extended):
     return dtype._rules.full(shape, fill_value, dtype)  # type: ignore[union-attr]
   weak_type = dtype is None and dtypes.is_weakly_typed(fill_value)
   dtype = dtypes.canonicalize_dtype(dtype or _dtype(fill_value))
@@ -1286,7 +1286,7 @@ def stop_gradient(x: T) -> T:
   """
   def stop(x):
     # only bind primitive on inexact dtypes, to avoid some staging
-    if core.has_opaque_dtype(x):
+    if dtypes.issubdtype(core.get_aval(x).dtype, dtypes.extended):
       return x
     elif (dtypes.issubdtype(_dtype(x), np.floating) or
         dtypes.issubdtype(_dtype(x), np.complexfloating)):
@@ -1352,7 +1352,7 @@ def full_like(x: Union[ArrayLike, DuckTypedArray],
   fill_shape = np.shape(x) if shape is None else canonicalize_shape(shape)  # type: ignore[arg-type]
   weak_type = dtype is None and dtypes.is_weakly_typed(x)
   dtype = dtype or _dtype(x)
-  if dtypes.is_opaque_dtype(dtype):
+  if dtypes.issubdtype(dtype, dtypes.extended):
     return dtype._rules.full(fill_shape, fill_value, dtype)  # type: ignore[union-attr]
   val = full(fill_shape, _convert_element_type(fill_value, dtype, weak_type))
   # If the sharding is SingleDeviceSharding then don't take the `if` branch
@@ -1535,11 +1535,11 @@ _attrgetter = lambda name: lambda x, **kwargs: getattr(x, name)
 
 
 def naryop_dtype_rule(result_dtype, accepted_dtypes, name, *avals,
-                      allow_opaque_dtype=False, **kwargs):
+                      allow_extended_dtype=False, **kwargs):
   del kwargs
   assert len(avals) == len(accepted_dtypes), (avals, accepted_dtypes)
   for i, aval in enumerate(avals):
-    if allow_opaque_dtype and dtypes.is_opaque_dtype(aval.dtype):
+    if allow_extended_dtype and dtypes.issubdtype(aval.dtype, dtypes.extended):
       continue
     types = accepted_dtypes[i]
     if not any(dtypes.issubdtype(aval.dtype, t) for t in types):
@@ -1601,9 +1601,9 @@ def _naryop_weak_type_rule(name, *avals, **kwargs):
         "taken a gradient with respect to an integer argument.")
   return all(aval.weak_type for aval in avals)
 
-def naryop(result_dtype, accepted_dtypes, name, allow_opaque_dtype=False):
+def naryop(result_dtype, accepted_dtypes, name, allow_extended_dtype=False):
   dtype_rule = partial(naryop_dtype_rule, result_dtype, accepted_dtypes, name,
-                       allow_opaque_dtype=allow_opaque_dtype)
+                       allow_extended_dtype=allow_extended_dtype)
   shape_rule = partial(broadcasting_shape_rule, name)
   weak_type_rule = partial(_naryop_weak_type_rule, name)
   prim = standard_primitive(shape_rule, dtype_rule, name,
@@ -2217,13 +2217,13 @@ def _compare_lower_hlo_opaque(direction: str, ctx, avals_in, aval_out, x, y):
     return _opaque_ne_hlo(ctx, broadcast_avals_in, aval_out, x, y)
   else:
     raise NotImplementedError(
-        f"HLO comparison {direction} for opaque dtype {avals_in[0].dtype}")
+        f"HLO comparison {direction} for extended dtype {avals_in[0].dtype}")
 
 def _compare_lower_hlo(direction: str, ctx, x, y):
   avals_in, (aval_out,) = ctx.avals_in, ctx.avals_out
   x_dtype = avals_in[0].dtype
   x, y = mlir.multi_broadcast_in_dim(ctx, (x, y), avals_in, aval_out.shape)
-  if dtypes.is_opaque_dtype(x_dtype):
+  if dtypes.issubdtype(x_dtype, dtypes.extended):
     return _compare_lower_hlo_opaque(direction, ctx, avals_in, aval_out, x, y)
   if dtypes.issubdtype(x_dtype, np.inexact):
     compare_type = "FLOAT"
@@ -2233,11 +2233,11 @@ def _compare_lower_hlo(direction: str, ctx, x, y):
     compare_type = "UNSIGNED"
   return mlir.compare_hlo(x, y, direction, compare_type).results
 
-eq_p = naryop(_fixed_dtype(np.bool_), [_any, _any], 'eq', allow_opaque_dtype=True)
+eq_p = naryop(_fixed_dtype(np.bool_), [_any, _any], 'eq', allow_extended_dtype=True)
 ad.defjvp_zero(eq_p)
 mlir.register_lowering(eq_p, partial(_compare_lower_hlo, "EQ"))
 
-ne_p = naryop(_fixed_dtype(np.bool_), [_any, _any], 'ne', allow_opaque_dtype=True)
+ne_p = naryop(_fixed_dtype(np.bool_), [_any, _any], 'ne', allow_extended_dtype=True)
 ad.defjvp_zero(ne_p)
 mlir.register_lowering(ne_p, partial(_compare_lower_hlo, "NE"))
 
@@ -2263,11 +2263,11 @@ def _convert_element_type_shape_rule(operand, *, new_dtype, weak_type):
 
 def _convert_element_type_dtype_rule(operand, *, new_dtype, weak_type):
   if operand.dtype != new_dtype:
-    if (dtypes.is_opaque_dtype(operand.dtype) and
+    if (dtypes.issubdtype(operand.dtype, dtypes.extended) and
         not isinstance(operand.dtype, core.bint)):
       raise ValueError(
           f"Cannot call convert_element_type on dtype {dtype_to_string(operand.dtype)}")
-    if (dtypes.is_opaque_dtype(new_dtype) and
+    if (dtypes.issubdtype(new_dtype, dtypes.extended) and
         not isinstance(new_dtype, core.bint)):
       raise ValueError(
           f"Cannot convert_element_type to dtype={dtype_to_string(new_dtype)}")
@@ -2308,7 +2308,7 @@ def _convert_elt_type_folding_rule(consts, eqn):
   o, = eqn.outvars
   if (type(c) in {np.ndarray, *dtypes.python_scalar_dtypes} and
       isinstance(o.aval, core.UnshapedArray) and not np.shape(c) and
-      not dtypes.is_opaque_dtype(eqn.params['new_dtype'])):
+      not dtypes.issubdtype(eqn.params['new_dtype'], dtypes.extended)):
     out = np.array(c, eqn.params['new_dtype'])
     if not o.aval.weak_type:
       return [out], None
@@ -2319,8 +2319,8 @@ def _convert_elt_type_folding_rule(consts, eqn):
 
 def _convert_elt_type_fwd_rule(eqn):
   v, = eqn.invars
-  if (not dtypes.is_opaque_dtype(eqn.params['new_dtype']) and
-      not dtypes.is_opaque_dtype(v.aval.dtype) and
+  if (not dtypes.issubdtype(eqn.params['new_dtype'], dtypes.extended) and
+      not dtypes.issubdtype(v.aval.dtype, dtypes.extended) and
       v.aval.dtype == eqn.params['new_dtype'] and
       v.aval.weak_type == eqn.params['weak_type']):
     return [v], None
@@ -3424,7 +3424,7 @@ def _transpose_batch_rule(batched_args, batch_dims, *, permutation):
 
 def _transpose_lower(ctx, x, *, permutation):
   aval_out, = ctx.avals_out
-  if dtypes.is_opaque_dtype(aval_out.dtype):
+  if dtypes.issubdtype(aval_out.dtype, dtypes.extended):
     elt_shape = aval_out.dtype._rules.physical_element_aval(
         aval_out.dtype).shape
     trailing_dims = [aval_out.ndim + i for i in range(len(elt_shape))]
@@ -3555,7 +3555,7 @@ def _select_hlo_lowering(ctx, which, *cases):
   which_aval = ctx.avals_in[0]
   aval_out, = ctx.avals_out
 
-  if dtypes.is_opaque_dtype(aval_out.dtype):
+  if dtypes.issubdtype(aval_out.dtype, dtypes.extended):
     return [_select_hlo_lowering_opaque(ctx, which, *cases)]
 
   if which_aval.dtype == np.dtype(np.bool_):
@@ -4770,7 +4770,7 @@ def check_same_dtypes(name: str, *avals: core.UnshapedArray) -> None:
   """Check that dtypes agree, possibly ignoring float precision."""
   # the `ignore_fp_precision` flag exists because the XLA shape inference logic
   # allows mixed floating point precision, but the HLO verifier often rejects it
-  if any(dtypes.is_opaque_dtype(aval.dtype) for aval in avals):
+  if any(dtypes.issubdtype(aval.dtype, dtypes.extended) for aval in avals):
     return  # TODO(mattjj,frostig): do some checking, friend
   if len(avals) < 2:
     return
@@ -4912,7 +4912,7 @@ def empty(dtype):
 empty_p = core.Primitive('empty')
 empty_p.def_abstract_eval(lambda *, dtype: core.ShapedArray((), dtype))
 def _empty_lower(ctx, *, dtype):
-  dtype = dtype if dtypes.is_opaque_dtype(dtype) else np.dtype(dtype)
+  dtype = dtype if dtypes.issubdtype(dtype, dtypes.extended) else np.dtype(dtype)
   phys_aval = core.physical_aval(core.ShapedArray((), dtype))
   return mlir.ir_constants(np.zeros(phys_aval.shape, phys_aval.dtype))
 mlir.register_lowering(empty_p, _empty_lower)

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -1410,7 +1410,7 @@ mlir.register_lowering(dynamic_update_slice_p, _dynamic_update_slice_lower)
 def _gather_dtype_rule(operand, indices, *, fill_value, **kwargs):
   if not dtypes.issubdtype(indices.dtype, np.integer):
     raise ValueError("indices must have an integer type")
-  return dtypes.canonicalize_dtype(operand.dtype, allow_opaque_dtype=True)
+  return dtypes.canonicalize_dtype(operand.dtype, allow_extended_dtype=True)
 
 _rank = lambda arr: len(arr.shape)
 
@@ -1784,7 +1784,7 @@ def _gather_lower(ctx, operand, indices, *,
                   dimension_numbers, slice_sizes, unique_indices,
                   indices_are_sorted, mode, fill_value):
   aval_out, = ctx.avals_out
-  if dtypes.is_opaque_dtype(aval_out.dtype):
+  if dtypes.issubdtype(aval_out.dtype, dtypes.extended):
     return [_gather_lower_opaque(
         ctx, operand, indices, dimension_numbers=dimension_numbers,
         slice_sizes=slice_sizes, unique_indices=unique_indices,
@@ -1835,7 +1835,7 @@ def _scatter_dtype_rule(operand, indices, updates, **kwargs):
   if not dtypes.issubdtype(indices.dtype, np.integer):
     raise ValueError("indices must have an integer type")
   lax.check_same_dtypes("scatter", operand, updates)
-  return dtypes.canonicalize_dtype(operand.dtype, allow_opaque_dtype=True)
+  return dtypes.canonicalize_dtype(operand.dtype, allow_extended_dtype=True)
 
 def _scatter_shape_rule(operand, indices, updates, *, update_jaxpr,
                         update_consts, dimension_numbers, indices_are_sorted,
@@ -2438,7 +2438,7 @@ def _scatter_lower(ctx, operand, indices, updates, *,
         _scatter_reduction_computation, core.ShapedArray((), operand_dtype))
 
   aval_out, = ctx.avals_out
-  if dtypes.is_opaque_dtype(aval_out.dtype):
+  if dtypes.issubdtype(aval_out.dtype, dtypes.extended):
     return [_scatter_lower_opaque(
         ctx, operand, indices, updates,
         update_jaxpr=update_jaxpr, update_consts=update_consts,

--- a/jax/_src/lax/utils.py
+++ b/jax/_src/lax/utils.py
@@ -31,7 +31,7 @@ import numpy as np
 
 xops = xla_client.ops
 
-_input_dtype: Callable = lambda *args, **_: dtypes.canonicalize_dtype(args[0].dtype, allow_opaque_dtype=True)
+_input_dtype: Callable = lambda *args, **_: dtypes.canonicalize_dtype(args[0].dtype, allow_extended_dtype=True)
 
 def _argnum_weak_type(*argnums):
   return lambda *args, **_: all(args[i].weak_type for i in argnums)

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -217,7 +217,7 @@ savez = np.savez
 def _jnp_dtype(obj: Optional[DTypeLike], *, align: bool = False,
                copy: bool = False) -> DType:
   """Similar to np.dtype, but respects JAX dtype defaults."""
-  if dtypes.is_opaque_dtype(obj):
+  if dtypes.issubdtype(obj, dtypes.extended):
     return obj  # type: ignore[return-value]
   if obj is None:
     obj = dtypes.float_
@@ -2038,7 +2038,7 @@ def array(object: Any, dtype: Optional[DTypeLike] = None, copy: bool = True,
       dtype = dtypes._lattice_result_type(*leaves)[0]
 
   if not weak_type:
-    dtype = dtypes.canonicalize_dtype(dtype, allow_opaque_dtype=True)
+    dtype = dtypes.canonicalize_dtype(dtype, allow_extended_dtype=True)
 
   out: ArrayLike
 
@@ -2085,7 +2085,7 @@ def _convert_to_array_if_dtype_fails(x: ArrayLike) -> ArrayLike:
 def asarray(a: Any, dtype: Optional[DTypeLike] = None, order: Optional[str] = None) -> Array:
   dtypes.check_user_dtype_supported(dtype, "asarray")
   if dtype is not None:
-    dtype = dtypes.canonicalize_dtype(dtype, allow_opaque_dtype=True)
+    dtype = dtypes.canonicalize_dtype(dtype, allow_extended_dtype=True)
   return array(a, dtype=dtype, copy=False, order=order)  # type: ignore
 
 
@@ -2328,7 +2328,7 @@ def arange(start: DimSize, stop: Optional[DimSize] = None,
   if stop is None and step is None:
     start_dtype = _dtype(start)
     if (not dtypes.issubdtype(start_dtype, np.integer) and
-        not dtypes.is_opaque_dtype(start_dtype)):
+        not dtypes.issubdtype(start_dtype, dtypes.extended)):
       ceil_ = ufuncs.ceil if isinstance(start, core.Tracer) else np.ceil
       start = ceil_(start).astype(int)  # type: ignore
     return lax.iota(dtype, start)

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -271,7 +271,7 @@ def promote_dtypes(*args: ArrayLike) -> list[Array]:
     return [lax.asarray(arg) for arg in args]
   else:
     to_dtype, weak_type = dtypes._lattice_result_type(*args)
-    to_dtype = dtypes.canonicalize_dtype(to_dtype, allow_opaque_dtype=True)  # type: ignore[assignment]
+    to_dtype = dtypes.canonicalize_dtype(to_dtype, allow_extended_dtype=True)  # type: ignore[assignment]
     return [lax._convert_element_type(x, to_dtype, weak_type) for x in args]
 
 
@@ -280,7 +280,7 @@ def promote_dtypes_inexact(*args: ArrayLike) -> list[Array]:
 
   Promotes arguments to an inexact type."""
   to_dtype, weak_type = dtypes._lattice_result_type(*args)
-  to_dtype = dtypes.canonicalize_dtype(to_dtype, allow_opaque_dtype=True)  # type: ignore[assignment]
+  to_dtype = dtypes.canonicalize_dtype(to_dtype, allow_extended_dtype=True)  # type: ignore[assignment]
   to_dtype_inexact = dtypes.to_inexact_dtype(to_dtype)
   return [lax._convert_element_type(x, to_dtype_inexact, weak_type)
           for x in args]

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -577,7 +577,7 @@ class KeyTyRules:
     return random_wrap(physical_result, impl=aval.dtype.impl)
 
 
-class KeyTy(dtypes.OpaqueDType):
+class KeyTy(dtypes.ExtendedDType):
   impl: Hashable  # prng.PRNGImpl. TODO(mattjj,frostig): protocol really
   _rules = KeyTyRules
   type = dtypes.prng_key

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -915,8 +915,8 @@ class JaxTestCase(parameterized.TestCase):
 
   def assertDtypesMatch(self, x, y, *, canonicalize_dtypes=True):
     if not config.x64_enabled and canonicalize_dtypes:
-      self.assertEqual(_dtypes.canonicalize_dtype(_dtype(x), allow_opaque_dtype=True),
-                       _dtypes.canonicalize_dtype(_dtype(y), allow_opaque_dtype=True))
+      self.assertEqual(_dtypes.canonicalize_dtype(_dtype(x), allow_extended_dtype=True),
+                       _dtypes.canonicalize_dtype(_dtype(y), allow_extended_dtype=True))
     else:
       self.assertEqual(_dtype(x), _dtype(y))
 

--- a/jax/_src/typing.py
+++ b/jax/_src/typing.py
@@ -37,8 +37,8 @@ from jax._src.basearray import (
 
 DType = np.dtype
 
-# TODO(jakevdp, froystig): make OpaqueDType a protocol
-OpaqueDType = Any
+# TODO(jakevdp, froystig): make ExtendedDType a protocol
+ExtendedDType = Any
 
 class SupportsDType(Protocol):
   @property

--- a/jax/core.py
+++ b/jax/core.py
@@ -104,7 +104,7 @@ from jax._src.core import (
   gensym as gensym,
   get_aval as get_aval,
   get_referent as get_referent,
-  has_opaque_dtype as has_opaque_dtype,
+  has_opaque_dtype as _deprecated_has_opaque_dtype,
   is_constant_dim as is_constant_dim,
   is_constant_shape as is_constant_shape,
   jaxpr_as_fun as jaxpr_as_fun,
@@ -185,5 +185,27 @@ from jax._src.core import (
 symbolic_equal_dim = definitely_equal  # TODO(necula): remove this API
 
 from jax._src.dtypes import (
-  is_opaque_dtype as is_opaque_dtype,
+  is_opaque_dtype as _deprecated_is_opaque_dtype,
 )
+
+_deprecations = {
+    # Added May 23, 2023:
+    "is_opaque_dtype": (
+        "jax.core.is_opaque_dtype is deprecated. Use jnp.issubdtype(dt, dtypes.extended).",
+        _deprecated_is_opaque_dtype,
+    ),
+    "has_opaque_dtype": (
+        "jax.core.is_opaque_dtype is deprecated. Use jnp.issubdtype(x.dtype, dtypes.extended).",
+        _deprecated_has_opaque_dtype,
+    ),
+}
+
+import typing
+if typing.TYPE_CHECKING:
+  from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
+  __getattr__ = _deprecation_getattr(__name__, _deprecations)
+  del _deprecation_getattr
+else:
+  from jax._src.dtypes import is_opaque_dtype as is_opaque_dtype
+  from jax._src.core import has_opaque_dtype as has_opaque_dtype
+del typing, _deprecated_is_opaque_dtype, _deprecated_has_opaque_dtype

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -22,6 +22,7 @@ from jax._src.dtypes import (
     float0 as float0,
     iinfo,  # TODO(phawkins): switch callers to jnp.iinfo?
     issubdtype,  # TODO(phawkins): switch callers to jnp.issubdtype?
+    extended as extended,
     prng_key as prng_key,
     result_type as result_type,
     scalar_type_of as scalar_type_of,

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1093,7 +1093,7 @@ def _tfval_to_tensor_jax_dtype(val: TfVal,
       # The float0 type is not known to TF.
       if jax_dtype == dtypes.float0:
         val = np.zeros(np.shape(val), conversion_dtype.as_numpy_dtype)
-      if hasattr(val, 'dtype') and dtypes.is_opaque_dtype(val.dtype):
+      if hasattr(val, 'dtype') and dtypes.issubdtype(val.dtype, dtypes.extended):
         val = val.dtype._rules.physical_const(val)
       tf_val = tf.convert_to_tensor(val, dtype=conversion_dtype)
       if do_memoize:
@@ -2089,7 +2089,7 @@ tf_impl_with_avals[lax.broadcast_in_dim_p] = _broadcast_in_dim
 
 
 def _empty(*, dtype):
-  if dtypes.is_opaque_dtype(dtype):
+  if dtypes.issubdtype(dtype, dtypes.extended):
     raise NotImplementedError  # TODO(frostig,mattjj): jax2tf handlers
   return tf.constant(np.array(0, dtype=dtype))
 
@@ -2727,7 +2727,7 @@ def _gather(operand, start_indices, *, dimension_numbers, slice_sizes: core.Shap
 
   operand_aval = _in_avals[0]
   start_indices = _maybe_cast_to_int64(start_indices)
-  if dtypes.is_opaque_dtype(operand_aval.dtype):
+  if dtypes.issubdtype(operand_aval.dtype, dtypes.extended):
     opaque_shape = _jax_physical_aval(operand_aval).shape[len(operand_aval.shape):]
     trailing_offset_dims = [len(_out_aval.shape) + i for i in range(len(opaque_shape))]
     dimension_numbers = dimension_numbers._replace(
@@ -2768,7 +2768,7 @@ def _dynamic_slice(operand, *start_indices, slice_sizes: core.Shape,
                    _out_aval: core.ShapedArray):
   start_indices = _maybe_cast_to_int64(tf.stack(start_indices))
   operand_aval = _in_avals[0]
-  if dtypes.is_opaque_dtype(operand_aval.dtype):
+  if dtypes.issubdtype(operand_aval.dtype, dtypes.extended):
     opaque_shape = _jax_physical_aval(operand_aval).shape[len(operand_aval.shape):]
     slice_sizes = (*slice_sizes, *opaque_shape)
     start_indices = tf.concat([start_indices, tf.zeros((len(opaque_shape),),
@@ -2790,7 +2790,7 @@ def _dynamic_update_slice(operand, update, *start_indices,
                           _out_aval: core.ShapedArray):
   start_indices = _maybe_cast_to_int64(tf.stack(start_indices))
   operand_aval = _in_avals[0]
-  if dtypes.is_opaque_dtype(operand_aval.dtype):
+  if dtypes.issubdtype(operand_aval.dtype, dtypes.extended):
     opaque_shape = _jax_physical_aval(operand_aval).shape[len(operand_aval.shape):]
     start_indices = tf.concat([start_indices, tf.zeros((len(opaque_shape),),
                                                        dtype=start_indices.dtype)],

--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -525,7 +525,7 @@ def _xla_shard(ctx: mlir.LoweringRuleContext,
   shard_proto = NamedSharding(
       mesh, sharding_impls.array_mapping_to_axis_resources(axes)  # type: ignore
   )._to_xla_hlo_sharding(aval_in.ndim)
-  if dtypes.is_opaque_dtype(aval_in.dtype):
+  if dtypes.issubdtype(aval_in.dtype, dtypes.extended):
     shard_proto = aval_in.dtype._rules.physical_hlo_sharding(aval_in, shard_proto)
   sx = mlir.wrap_with_sharding_op(ctx, x, aval_in, shard_proto.to_proto(),  # type: ignore
                                   unspecified_dims=set())
@@ -540,7 +540,7 @@ def _xla_unshard(ctx: mlir.LoweringRuleContext,
   shard_proto = NamedSharding(
       mesh, sharding_impls.array_mapping_to_axis_resources(axes)  # type: ignore
   )._to_xla_hlo_sharding(aval_out.ndim)
-  if dtypes.is_opaque_dtype(aval_out.dtype):
+  if dtypes.issubdtype(aval_out.dtype, dtypes.extended):
     shard_proto = aval_out.dtype._rules.physical_hlo_sharding(aval_out, shard_proto)
   return mlir.wrap_with_shard_to_full_op(ctx, sx, aval_out,
                                          shard_proto.to_proto(), set())  # type: ignore

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2913,8 +2913,8 @@ class FooTyRules:
     return handler
 
 
-class FooTy(dtypes.OpaqueDType):
-  type = dtypes.opaque
+class FooTy(dtypes.ExtendedDType):
+  type = dtypes.extended
   name = 'foo'
   _rules = FooTyRules
 


### PR DESCRIPTION
This includes three deprecations:

  - `jax.core.is_opaque_dtype(dt)` is deprecated in favor of `jnp.issubdtype(dt, jax.dtypes.extended)`.
  - `jax.core.has_opaque_dtype(x)` is deprecated in favor of `jnp.issubdtype(x.dtype, jax.dtypes.extended)`.
  - the `allow_opaque_dtype` argument to `jax.core.canonicalize_dtype` is now `allow_extended_dtype`.

All of these APIs are in `jax.core`, which is explicitly excluded from the [API Deprecation Policy](https://jax.readthedocs.io/en/latest/api_compatibility.html), so these will not be mentioned in the changelog, nor will they be subject to the standard 3-month deprecation period.