### PR TITLE
Allow implicit float8 and int4 promotion under numpy_dtype_promotion='full'

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -907,7 +907,7 @@ config.define_enum_state(
 
 numpy_dtype_promotion = config.define_enum_state(
     name='jax_numpy_dtype_promotion',
-    enum_values=['standard', 'strict'],
+    enum_values=['standard', 'strict', 'full'],
     default='standard',
     help=('Specify the rules used for implicit type promotion in operations '
           'between arrays. Options are "standard" or "strict"; in strict-mode, '


### PR DESCRIPTION
This adds a new type promotion mode, `jax.numpy_dtype_promotion('full')` which enables implicit type promotion of `float8` values. For example:
```python
In [1]: import jax

In [2]: import jax.numpy as jnp

In [3]: x = jnp.array(1, dtype='float8_e5m2')

In [4]: y = jnp.array(1, dtype='float32')

In [5]: with jax.numpy_dtype_promotion('full'):
   ...:     print(x + y)
   ...: 
2.0
```
I'm still unsure of whether this should be included in the default `standard` promotion table for the reasons discussed in 
#16705, but at least this gives users a way to opt-in for the time being.