### PR TITLE
[jax2tf] Add support for serialization version 8.

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -815,10 +815,11 @@ We list here a history of the serialization version numbers:
   * Version 7 adds support for `stablehlo.shape_assertion` operations and
     for `shape_assertions` specified in `disabled_checks`.
     See [Errors in presence of shape polymorphism](https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#errors-in-presence-of-shape-polymorphism).
-    Used in JAX serialization since July 20th, 2023 (JAX 0.4.14).
+    Available in JAX serialization since July 20th, 2023 (JAX 0.4.14).
   * Version 8 adds support for the `jax.uses_shape_polymorphism` module
     attribute and enables the shape refinement pass only when the
-    attribute is present. Not yet used in JAX.
+    attribute is present. Supported by XlaCallModule since July 21st, 2023
+    (cl/549973693) and available in JAX since July 26th, 2023 (JAX 0.4.14).
 
 
 ## Known issues

--- a/jax/experimental/jax2tf/tests/back_compat_test_util.py
+++ b/jax/experimental/jax2tf/tests/back_compat_test_util.py
@@ -290,7 +290,7 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
         for target in allow_additional_custom_call_targets)
     )(*args_specs)
 
-    module_str = str(exported.mlir_module)
+    module_str = str(exported.mlir_module())
     serialized = exported.mlir_module_serialized
     module_version = exported.serialization_version
     return serialized, module_str, module_version

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -1528,9 +1528,9 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
       )(*(core.ShapedArray(a.shape, a.dtype) for a in args))
 
     if transform1 == "shard_map":
-      self.assertIn("stablehlo.all_gather", str(exported.mlir_module))
+      self.assertIn("stablehlo.all_gather", str(exported.mlir_module()))
     else:
-      self.assertIn("stablehlo.reduce_window", str(exported.mlir_module))
+      self.assertIn("stablehlo.reduce_window", str(exported.mlir_module()))
 
   def test_cross_platform_error(self):
     f_tf = jax2tf.convert(jnp.sin, native_serialization=True,


### PR DESCRIPTION
In this version the serialized module contains a StableHLO module boolean attribute `jax.uses_shape_polymorphism` that specifies whether the module uses shape polymorphism. This attribute controls whether to do shape refinement in
consumers that support version 8.

Note that we are still keeping the default serialization version to 6, for forward compatibility. However, the serialization unit tests now run at version 8.

Made Exported.mlir_module a method instead of a property, to make it more obvious that it is a derived artifact.