### PR TITLE
Don't include test details in testcase names for jax2tf tests.

### DIFF
--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -175,6 +175,9 @@ class Harness:
   def __str__(self):
     return self.fullname
 
+  def __repr__(self):
+    return self.fullname
+
   @property
   def fullname(self):
     return self.name if self.group_name is None else f"{self.group_name}_{self.name}"
@@ -378,9 +381,7 @@ def parameterized(harnesses: Iterable[Harness],
       "JAX_TEST_HARNESS_ONE_CONTAINING")
   cases = tuple(
       # Change the testcase name to include the harness name.
-      dict(
-          testcase_name=harness.fullname if one_containing is None else "",
-          harness=harness) for harness in harnesses if harness.filter(
+      dict(harness=harness) for harness in harnesses if harness.filter(
               jtu.device_under_test(),
               one_containing=one_containing,
               include_jax_unimpl=include_jax_unimpl))
@@ -394,7 +395,7 @@ def parameterized(harnesses: Iterable[Harness],
   if not cases:
     # We filtered out all the harnesses.
     return jtu.skip_on_devices(jtu.device_under_test())
-  return testing.parameterized.named_parameters(*cases)
+  return testing.parameterized.parameters(*cases)
 
 
 ###############################################################################

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -277,9 +277,8 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   # The rest of the test are checking special cases
 
-  @parameterized.named_parameters(
-      dict(testcase_name=f"_{f_jax.__name__}",
-           f_jax=f_jax)
+  @parameterized.parameters(
+      dict(f_jax=f_jax)
       for f_jax in [jnp.add, jnp.subtract, jnp.multiply, jnp.divide,
                     jnp.less, jnp.less_equal, jnp.equal, jnp.greater,
                     jnp.greater_equal, jnp.not_equal, jnp.maximum,


### PR DESCRIPTION
Including the test details makes testcases very hard to match using filters like `-k`. Use a numeric testcase name, matching other JAX test cases, but include the harness fullname in the __repr__ of the harness which is printed when the test case is run.