### PR TITLE
Bump ProfilerTest.test_remote_profiler to run computations for 10 seconds.

### DIFF
--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -236,7 +236,7 @@ class ProfilerTest(unittest.TestCase):
     thread_profiler.start()
     start_time = time.time()
     y = jnp.zeros((5, 5))
-    while time.time() - start_time < 5:
+    while time.time() - start_time < 10:
       y = jnp.dot(y, y)
     jax.profiler.stop_server()
     thread_profiler.join()


### PR DESCRIPTION
I hate to make a unit test run for this long, but I'm still seeing cases where the remote profiler will miss the computations and hang forever. (Why is it so slow?) This should hopefully be enough that it always catches some computations.