### PR TITLE
[shape_poly] Fix handling of dot_general with different lhs_dtype and rhs_type

### DIFF
--- a/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md
+++ b/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md
@@ -1,11 +1,11 @@
 # Primitives with limited JAX support
 
-*Last generated on: 2022-11-07* (YYYY-MM-DD)
+*Last generated on: 2023-07-31* (YYYY-MM-DD)
 
 ## Supported data types for primitives
 
-We use a set of 7308 test harnesses to test
-the implementation of 130 numeric JAX primitives.
+We use a set of 7554 test harnesses to test
+the implementation of 133 numeric JAX primitives.
 We consider a JAX primitive supported for a particular data
 type if it is supported on at least one device type.
 The following table shows the dtypes at which primitives
@@ -46,6 +46,7 @@ be updated.
 | add | 16 | inexact, integer | bool |
 | add_any | 14 | inexact, integer | bool |
 | and | 11 | bool, integer | inexact |
+| approx_top_k | 24 | floating | bool, complex, integer |
 | argmax | 64 | bool, floating, integer | complex |
 | argmin | 64 | bool, floating, integer | complex |
 | asin | 6 | inexact | bool, integer |
@@ -64,7 +65,7 @@ be updated.
 | complex | 4 | float32, float64 | bfloat16, bool, complex, float16, integer |
 | concatenate | 17 | all |  |
 | conj | 5 | complex, float32, float64 | bfloat16, bool, float16, integer |
-| conv_general_dilated | 114 | inexact, int16, int32, int8 | bool, int64, unsigned |
+| conv_general_dilated | 132 | inexact, signed | bool, unsigned |
 | convert_element_type | 201 | all |  |
 | cos | 6 | inexact | bool, integer |
 | cosh | 6 | inexact | bool, integer |
@@ -77,7 +78,7 @@ be updated.
 | device_put | 16 | all |  |
 | digamma | 4 | floating | bool, complex, integer |
 | div | 20 | inexact, integer | bool |
-| dot_general | 245 | all |  |
+| dot_general | 400 | all |  |
 | dynamic_slice | 68 | all |  |
 | dynamic_update_slice | 46 | all |  |
 | eig | 72 | inexact | bool, integer |
@@ -88,9 +89,9 @@ be updated.
 | erfc | 4 | floating | bool, complex, integer |
 | exp | 6 | inexact | bool, integer |
 | expm1 | 6 | inexact | bool, integer |
-| fft | 20 | complex, float32, float64 | bfloat16, bool, float16, integer |
+| fft | 32 | complex, float32, float64 | bfloat16, bool, float16, integer |
 | floor | 4 | floating | bool, complex, integer |
-| gather | 150 | all |  |
+| gather | 164 | all |  |
 | ge | 17 | all |  |
 | gt | 17 | all |  |
 | igamma | 6 | floating | bool, complex, integer |
@@ -98,6 +99,7 @@ be updated.
 | imag | 2 | complex | bool, floating, integer |
 | integer_pow | 108 | inexact, integer | bool |
 | iota | 16 | inexact, integer | bool |
+| iota_2x32_shape | 3 | uint32 | bool, inexact, signed, uint16, uint64, uint8 |
 | is_finite | 4 | floating | bool, complex, integer |
 | le | 17 | all |  |
 | lgamma | 4 | floating | bool, complex, integer |
@@ -106,8 +108,8 @@ be updated.
 | logistic | 6 | inexact | bool, integer |
 | lt | 17 | all |  |
 | lu | 18 | inexact | bool, integer |
-| max | 33 | all |  |
-| min | 33 | all |  |
+| max | 27 | all |  |
+| min | 27 | all |  |
 | mul | 16 | inexact, integer | bool |
 | ne | 17 | all |  |
 | neg | 14 | inexact, integer | bool |
@@ -128,6 +130,7 @@ be updated.
 | reduce_max | 15 | all |  |
 | reduce_min | 15 | all |  |
 | reduce_or | 1 | bool | inexact, integer |
+| reduce_precision | 32 | floating | bool, complex, integer |
 | reduce_prod | 14 | inexact, integer | bool |
 | reduce_sum | 14 | inexact, integer | bool |
 | reduce_window_add | 50 | inexact, integer | bool |
@@ -194,7 +197,8 @@ and search for "limitation".
 | --- | --- | --- | --- |
 |cholesky|unimplemented|float16|cpu, gpu|
 |clamp|unimplemented|bool, complex|cpu, gpu, tpu|
-|conv_general_dilated|preferred_element_type not implemented for integers|int16, int32, int8|gpu|
+|conv_general_dilated|preferred_element_type not implemented for integers|signed|gpu|
+|dot_general|preferred_element_type must be floating for integer dtype|integer|gpu|
 |dot_general|preferred_element_type must match dtype for floating point|inexact|gpu|
 |eig|only supported on CPU in JAX|all|tpu, gpu|
 |eig|unimplemented|bfloat16, float16|cpu|

--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
@@ -1,6 +1,6 @@
 # Primitives with limited support for jax2tf
 
-*Last generated on (YYYY-MM-DD): 2022-11-07*
+*Last generated on (YYYY-MM-DD): 2023-07-31*
 
 This document summarizes known limitations of the jax2tf conversion.
 There are several kinds of limitations.
@@ -61,15 +61,21 @@ More detailed information can be found in the
 
 | Affected primitive | Description of limitation | Affected dtypes | Affected devices | Affected compilation modes |
 | --- | --- | --- | --- | --- |
+| approx_top_k | TF error: compilation not supported for float64. | float64 | cpu, gpu | compiled |
+| approx_top_k | TF error: op not defined for dtype | floating | cpu, gpu | eager, graph |
 | bessel_i0e | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | bessel_i1e | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | cholesky | TF test skipped: Not implemented in JAX: unimplemented | float16 | cpu, gpu | compiled, eager, graph |
 | clamp | TF test skipped: Not implemented in JAX: unimplemented | bool, complex | cpu, gpu, tpu | compiled, eager, graph |
-| conv_general_dilated | TF test skipped: Not implemented in JAX: preferred_element_type not implemented for integers | int16, int32, int8 | gpu | compiled, eager, graph |
+| conv_general_dilated | TF error: Numeric comparison disabled: Non-deterministic NaN for conv_general_dilated with preferred_element_type | int16, int32, int64 | cpu, gpu, tpu | compiled, eager, graph |
+| conv_general_dilated | TF test skipped: Not implemented in JAX: preferred_element_type not implemented for integers | signed | gpu | compiled, eager, graph |
 | digamma | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | div | TF error: TF integer division fails if divisor contains 0; JAX returns NaN | integer | cpu, gpu, tpu | compiled, eager, graph |
+| dot_general | TF test skipped: TF error: Numeric comparison disabled: Crash when lhs_dtype != rhs_dtype for non-native serialization on TPU | all | tpu | compiled, eager, graph |
+| dot_general | TF error: Numeric comparison disabled: Errors when lhs_dtype != rhs_dtype for non-native serialization on CPU and GPU | all | cpu, gpu, tpu | compiled, eager, graph |
 | dot_general | TF error: Numeric comparison disabled: Large tolerances when upcasting with preferred_element_type on CPU (b/241740367) | all | cpu, gpu, tpu | compiled, eager, graph |
 | dot_general | TF error: Numeric comparison disabled: Non-deterministic NaN for dot_general with preferred_element_type on GPU (b/189287598) | bfloat16, complex64, float16, float32 | gpu | compiled, eager, graph |
+| dot_general | TF test skipped: Not implemented in JAX: preferred_element_type must be floating for integer dtype | integer | gpu | compiled, eager, graph |
 | dot_general | TF test skipped: Not implemented in JAX: preferred_element_type must match dtype for floating point | inexact | gpu | compiled, eager, graph |
 | dot_general | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
 | eig | TF test skipped: Not implemented in JAX: only supported on CPU in JAX | all | gpu, tpu | compiled, eager, graph |
@@ -79,8 +85,8 @@ More detailed information can be found in the
 | eigh | TF test skipped: Not implemented in JAX: unimplemented | bfloat16, float16 | cpu, gpu | compiled, eager, graph |
 | eigh | TF error: op not defined for dtype | bfloat16 | tpu | compiled, eager, graph |
 | erf_inv | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
-| fft | TF error: TF function not compilable | float64 | cpu, gpu | compiled |
-| fft | TF error: TF function not compilable for IFFT and IRFFT | complex128 | cpu, gpu | compiled |
+| fft | TF error: TF function not compilableble | float64 | cpu, gpu | compiled |
+| fft | TF error: TF function not compilableble for IFFT and IRFFT | complex128 | cpu, gpu | compiled |
 | igamma | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
 | igammac | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
 | lgamma | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
@@ -91,7 +97,8 @@ More detailed information can be found in the
 | reduce_max | TF error: op not defined for dtype | complex | cpu, gpu, tpu | compiled, eager, graph |
 | reduce_min | TF error: op not defined for dtype | complex | cpu, gpu, tpu | compiled, eager, graph |
 | regularized_incomplete_beta | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
-| rem | TF error: TF integer division fails if divisor contains 0; JAX returns NaN | integer | cpu, gpu, tpu | compiled, eager, graph |
+| rem | TF error: Numeric comparison disabled: TF division of inf by inf returns inf while in JAX returns nan | float32 | gpu | compiled, eager, graph |
+| rem | TF error: Numeric comparison disabled: TF integer division fails if divisor contains 0; JAX returns NaN | integer | cpu, gpu, tpu | compiled, eager, graph |
 | round | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | scatter | TF error: Numeric comparison disabled: out-of-bounds scatters are not supported in graph and eager mode | inexact | cpu, gpu, tpu | eager, graph |
 | scatter_add | TF test skipped: Not implemented in JAX: unimplemented | bool | cpu, gpu, tpu | compiled, eager, graph |
@@ -120,6 +127,7 @@ with jax2tf. The following table lists that cases when this does not quite hold:
 | Affected primitive | Description of limitation | Affected dtypes | Affected devices | Affected compilation modes |
 | --- | --- | --- | --- | --- |
 | acosh | May return different but still correct results | complex | cpu, gpu, tpu | eager, graph |
+| approx_top_k | custom numeric comparison | floating | cpu, gpu | eager, graph |
 | argmax | Numeric comparison disabled: different results when the input contains NaN and enable_xla=False | inexact | cpu, gpu, tpu | compiled, eager, graph |
 | argmin | Numeric comparison disabled: different results when the input contains NaN and enable_xla=False | inexact | cpu, gpu, tpu | compiled, eager, graph |
 | asin | May return different but still correct results | complex | cpu, gpu, tpu | eager, graph |
@@ -140,7 +148,9 @@ with jax2tf. The following table lists that cases when this does not quite hold:
 | integer_pow | custom numeric comparison | complex | cpu, gpu, tpu | eager, graph |
 | lu | May return different, but also correct, results when the decomposition is not unique | all | cpu, gpu | compiled, eager, graph |
 | max | May return different values when one of the values is NaN. JAX always returns NaN, while TF returns the value NaN is compared with. | all | cpu, gpu, tpu | compiled, eager, graph |
+| max | TF and JAX use different values of the compiler flag xla_cpu_enable_fast_min_max compiler flag and therefore have different behavior of NaN propagation through min/max. | all | cpu | compiled, eager, graph |
 | min | May return different values when one of the values is NaN. JAX always returns NaN, while TF returns the value NaN is compared with. | all | cpu, gpu, tpu | compiled, eager, graph |
+| min | TF and JAX use different values of the compiler flag xla_cpu_enable_fast_min_max compiler flag and therefore have different behavior of NaN propagation through min/max. | all | cpu | compiled, eager, graph |
 | pow | custom numeric comparison | complex | cpu, gpu, tpu | eager, graph |
 | random_split | Returns JAX key arrays, so compare underlying base array | all | cpu, gpu, tpu | compiled, eager, graph |
 | reduce_window_add | Numeric comparison disabled: Large deviations on TPU for enable_xla=False | float16, float32 | tpu | compiled, eager, graph |

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -2049,6 +2049,19 @@ def _dot_general(lhs, rhs, *, dimension_numbers,
                  _in_avals: Sequence[core.ShapedArray],
                  _out_aval: core.ShapedArray):
   """Implementation of lax.dot_general_p in terms of tf.linalg.einsum."""
+  # TODO(b/293247337): we ought to turn on this safety check, but this leads to
+  # failures. Since we are going to turn on native serializaton soon, wait
+  # until then to turn on this check.
+  # lhs_aval, rhs_aval = _in_avals
+  # if lhs_aval.dtype != rhs_aval.dtype:
+  #   # There are multiple kinds of errors: handling jnp.bfloat16 in xla.py and
+  #   # returning different result dtype than JAX expects for various combinations
+  #   # of types. We ought to implement the same workarounds as in the
+  #   # native dot_general lowering rules, but this is not a high priority now
+  #   # that we deprecate non-native serialization.
+  #   raise NotImplementedError(
+  #     "dot_general with different lhs_dtype and rhs_dtype is not supported "
+  #     "in non-native serialization")
   (lhs_contracting, rhs_contracting), (lhs_batch, rhs_batch) = dimension_numbers
   dnums_proto = xla_data_pb2.DotDimensionNumbers()
   dnums_proto.lhs_contracting_dimensions.extend(lhs_contracting)

--- a/jax/experimental/jax2tf/tests/jax_primitives_coverage_test.py
+++ b/jax/experimental/jax2tf/tests/jax_primitives_coverage_test.py
@@ -29,6 +29,7 @@ import unittest
 from absl.testing import absltest
 
 from jax._src import test_util as jtu
+from jax._src import maps  # Needed for config flags.
 from jax import config
 
 import numpy as np
@@ -48,7 +49,7 @@ class JaxPrimitiveTest(jtu.JaxTestCase):
   # If you want to run this test for only one harness, add parameter
   # `one_containing="foo"` to parameterized below.
   @primitive_harness.parameterized(primitive_harness.all_harnesses,
-                                   #one_containing="gather_from_slicing_name",
+                                   #one_containing="",
                                    include_jax_unimpl=True)
   @jtu.ignore_warning(category=UserWarning,
                       message="Using reduced precision for gradient.*")

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -38,6 +38,7 @@ to fail. A Limitation is specific to a harness.
 """
 
 from collections.abc import Iterable, Sequence
+import itertools
 import operator
 import os
 from functools import partial
@@ -2781,7 +2782,8 @@ def _make_dot_general_harness(name,
                               *,
                               lhs_shape=(3, 4),
                               rhs_shape=(4, 2),
-                              dtype=np.float32,
+                              lhs_dtype=np.float32,
+                              rhs_dtype=np.float32,
                               precision=None,
                               dimension_numbers=(((1,), (0,)), ((), ())),
                               preferred_element_type=None):
@@ -2793,17 +2795,18 @@ def _make_dot_general_harness(name,
 
   define(
       lax.dot_general_p,
-      f"{name}_lhs={jtu.format_shape_dtype_string(lhs_shape, dtype)}_rhs={jtu.format_shape_dtype_string(rhs_shape, dtype)}_dimensionnumbers={dimension_numbers}{suffix}"
+      f"{name}_lhs={jtu.format_shape_dtype_string(lhs_shape, lhs_dtype)}_rhs={jtu.format_shape_dtype_string(rhs_shape, rhs_dtype)}_dimensionnumbers={dimension_numbers}{suffix}"
       .replace(" ", ""),
       lax.dot_general,
       [
-          RandArg(lhs_shape, dtype),
-          RandArg(rhs_shape, dtype),
+          RandArg(lhs_shape, lhs_dtype),
+          RandArg(rhs_shape, rhs_dtype),
           StaticArg(dimension_numbers),
           StaticArg(precision),
           StaticArg(preferred_element_type)
       ],
-      dtype=dtype,
+      dtype=lhs_dtype,
+      rhs_dtype=rhs_dtype,
       lhs_shape=lhs_shape,
       rhs_shape=rhs_shape,
       dimension_numbers=dimension_numbers,
@@ -2813,9 +2816,17 @@ def _make_dot_general_harness(name,
           Limitation("preferred_element_type must match dtype for floating point",
                      devices="gpu",
                      dtypes=[np.float16, dtypes.bfloat16, np.float32, np.float64, np.complex64, np.complex128],
-                     enabled=(preferred_element_type is not None and preferred_element_type != dtype))
-      ]
-  )
+                     enabled=(preferred_element_type is not None and preferred_element_type != lhs_dtype)),
+          Limitation("preferred_element_type must be floating for integer dtype",
+                     devices="gpu",
+                     dtypes=[np.int8, np.uint8, np.int16, np.uint16,
+                             np.int32, np.uint32, np.int64, np.uint64],
+                     enabled=(preferred_element_type is not None
+                              and preferred_element_type in [
+                                np.float16, dtypes.bfloat16, np.float32,
+                                np.float64, np.complex64, np.complex128]),
+                     skip_run=True),  # skip run because we get internal XLA error
+     ])
 
 
 # There are two execution paths in the conversion of dot_general. The main path
@@ -2843,7 +2854,8 @@ for dtype in jtu.dtypes.all:
           lhs_shape=lhs_shape,
           rhs_shape=rhs_shape,
           dimension_numbers=dimension_numbers,
-          dtype=dtype)
+          lhs_dtype=dtype,
+          rhs_dtype=dtype)
 
 # The other tests are only for float32.
 # Validate batch dimensions
@@ -2873,28 +2885,50 @@ for lhs_shape, rhs_shape, dimension_numbers in [
 
 # Validate preferred element type
 # From lax_test.py
-preferred_type_combinations = [(np.float16, np.float16), (np.float16,
-                                                          np.float32),
-                               (np.float16, np.float64),
-                               (dtypes.bfloat16, np.float32),
-                               (dtypes.bfloat16, np.float64),
-                               (np.float32, np.float32),
-                               (np.float32, np.float64), (np.int8, np.int16),
-                               (np.int8, np.int32), (np.int8, np.int64),
-                               (np.int16, np.int32), (np.int16, np.int64),
-                               (np.int32, np.int32), (np.int32, np.int64),
-                               (np.complex64, np.complex128)]
+preferred_type_combinations = [
+  (np.float16, np.float16), (np.float16, np.float32), (np.float16, np.float64),
+  (dtypes.bfloat16, dtypes.bfloat16), (dtypes.bfloat16, np.float32),
+  (dtypes.bfloat16, np.float64), (np.float32, np.float32),
+  (np.float32, np.float64),
+  (np.float64, np.float64), (np.int8, np.int8), (np.int8, np.int16),
+  (np.int8, np.int32),
+  (np.int8, np.int64), (np.int16, np.int16), (np.int16, np.int32),
+  (np.int16, np.int64),
+  (np.int32, np.int32), (np.int32, np.int64), (np.int64, np.int64),
+  (np.complex64, np.complex64), (np.complex64, np.complex128),
+  (np.complex128, np.complex128),
+  (np.int8, np.float16), (np.int8, dtypes.bfloat16), (np.int8, np.float32),
+  (np.int8, np.float64),
+  (np.int16, np.float16), (np.int16, dtypes.bfloat16), (np.int16, np.float32),
+  (np.int16, np.float64),
+  (np.int32, np.float32), (np.int32, np.float64), (np.int64, np.float64)]
 
-for lhs_shape in [(3,), (4, 3)]:
-  for rhs_shape in [(3,), (3, 6)]:
+for lhs_shape in [(4, 3)]:
+  for rhs_shape in [(3, 6)]:
     for dtype, preferred_element_type in preferred_type_combinations:
       _make_dot_general_harness(
           "preferred",
-          dtype=dtype,
+          lhs_dtype=dtype,
+          rhs_dtype=dtype,
           lhs_shape=lhs_shape,
           rhs_shape=rhs_shape,
           dimension_numbers=(((len(lhs_shape) - 1,), (0,)), ((), ())),
           preferred_element_type=preferred_element_type)
+
+    # Validate lhs_dtype different than rhs_dtype
+    for lhs_dtype, rhs_dtype in itertools.product(jtu.dtypes.all_integer +
+                                                  jtu.dtypes.all_unsigned +
+                                                  jtu.dtypes.all_inexact,
+                                                  repeat=2):
+      if lhs_dtype == rhs_dtype:
+        continue
+      _make_dot_general_harness(
+          "different_dtypes",
+          lhs_dtype=lhs_dtype,
+          rhs_dtype=rhs_dtype,
+          lhs_shape=lhs_shape,
+          rhs_shape=rhs_shape,
+          dimension_numbers=(((len(lhs_shape) - 1,), (0,)), ((), ())))
 
 
 def _make_concatenate_harness(name,
@@ -2980,7 +3014,7 @@ def _make_conv_harness(name,
             Limitation(
                 "preferred_element_type not implemented for integers",
                 devices="gpu",
-                dtypes=(np.int8, np.int16, np.int32),
+                dtypes=(np.int8, np.int16, np.int32, np.int64),
                 enabled=(preferred_element_type in [np.int16, np.int32,
                                                     np.int64])),
         ],


### PR DESCRIPTION
Add primitives tests for the case of dot_general with different lhs_dtype and rhs_dtype. Then fix the lowering to work with dynamic shapes.

This uncovered bugs in the non-native serialization, which we do not fix here because we are deprioritizing non-native serialization.

This is another attempt at #16846m which was rolled back due to test failures. We added more limitations for the GPU harnesses where the preferred_element_type is floating point and the dtype is integer (these are not supported by XLA:GPU)