### PR TITLE
fix(docs): typo in `jax.lax.scan`

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -114,9 +114,8 @@ def scan(f: Callable[[Carry, X], tuple[Carry, Y]],
 
     scan :: (c -> a -> (c, b)) -> c -> [a] -> (c, [b])
 
-  where we use [t] here to denote the type t with an additional leading axis.
-  That is, if t is an array type then [t] represents the type with an additional
-  leading axis, and if t is a pytree (container) type with array leaves then [t]
+  where for any array type specifier ``t``, ``[t]`` represents the type with an additional
+  leading axis, and if ``t`` is a pytree (container) type with array leaves then ``[t]``
   represents the type with the same pytree structure and corresponding leaves
   each with an additional leading axis.
 


### PR DESCRIPTION
Hello!

I am not sure this whether this is a typo or not, but I guess so because `t` and `[t]` are not used anywhere else in the documentation. I also used double backsticks ` `` ` to avoid confusion in the text (as already done further below).