### PR TITLE
Tracebacks no longer have JAX-internal frames prepended by default

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1025,17 +1025,21 @@ default_matmul_precision = config.define_enum_state(
 
 traceback_filtering = config.define_enum_state(
     name = 'jax_traceback_filtering',
-    enum_values=["off", "tracebackhide", "remove_frames", "auto"],
+    enum_values=["off", "tracebackhide", "remove_frames", "quiet_remove_frames",
+                 "auto"],
     default="auto",
     help="Controls how JAX filters internal frames out of tracebacks.\n\n"
          "Valid values are:\n"
          " * \"off\": disables traceback filtering.\n"
-         " * \"auto\": use \"tracebackhide\" if running under a sufficiently "
-         "new IPython, or \"remove_frames\" otherwise.\n"
-         " * \"tracebackhide\": adds \"__tracebackhide__\" annotations to "
+         " * \"auto\": use \"tracebackhide\" if running under a sufficiently"
+         " new IPython, or \"remove_frames\" otherwise.\n"
+         " * \"tracebackhide\": adds \"__tracebackhide__\" annotations to"
          " hidden stack frames, which some traceback printers support.\n"
-         " * \"remove_frames\": removes hidden frames from tracebacks, and adds "
-         " the unfiltered traceback as a __cause__ of the exception.\n")
+         " * \"remove_frames\": removes hidden frames from tracebacks, and adds"
+         " the unfiltered traceback as a __cause__ of the exception.\n"
+         " * \"quiet_remove_frames\": removes hidden frames from tracebacks, and adds"
+         " a brief message (to the __cause__ of the exception) describing that this has"
+         " happened.\n")
 
 # This flag is for internal use.
 # TODO(tianjianlu): Removes once we always enable cusparse lowering.

--- a/jax/errors.py
+++ b/jax/errors.py
@@ -25,3 +25,4 @@ from jax._src.errors import (
   TracerIntegerConversionError as TracerIntegerConversionError,
   UnexpectedTracerError as UnexpectedTracerError,
 )
+from jax._src.traceback_util import SimplifiedTraceback as SimplifiedTraceback

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import re
+import sys
 import traceback
 
 from absl.testing import absltest
@@ -46,7 +47,12 @@ def check_filtered_stack_trace(test, etype, f, frame_patterns=(),
     test.assertRaises(etype, f)
     e = get_exception(etype, f)
   c = e.__cause__
-  if filter_mode == "remove_frames":
+  if filter_mode == "quiet_remove_frames":
+    if sys.version_info >= (3, 11):
+      assert any("For simplicity" in x for x in e.__notes__)
+    else:
+      test.assertIsInstance(c, jax.errors.SimplifiedTraceback)
+  elif filter_mode == "remove_frames":
     test.assertIsInstance(c, traceback_util.UnfilteredStackTrace)
   else:
     test.assertFalse(isinstance(c, traceback_util.UnfilteredStackTrace))
@@ -74,7 +80,7 @@ def check_filtered_stack_trace(test, etype, f, frame_patterns=(),
 @jtu.with_config(jax_traceback_filtering='auto')  # JaxTestCase defaults to off.
 @parameterized.named_parameters(
   {"testcase_name": f"_{f}", "filter_mode": f}
-  for f in ("tracebackhide", "remove_frames"))
+  for f in ("tracebackhide", "remove_frames", "quiet_remove_frames"))
 class FilteredTracebackTest(jtu.JaxTestCase):
 
   def test_nested_jit(self, filter_mode):
@@ -347,9 +353,13 @@ class FilteredTracebackTest(jtu.JaxTestCase):
     check_filtered_stack_trace(self, TypeError, f, [
         ('<lambda>', 'f = lambda: outer'),
         ('outer', 'raise TypeError')], filter_mode=filter_mode)
-    e = get_exception(TypeError, f)
-    self.assertIsInstance(e.__cause__, traceback_util.UnfilteredStackTrace)
-    self.assertIsInstance(e.__cause__.__cause__, ValueError)
+    e = get_exception(TypeError, f)  # Uses the default JAX_TRACEBACK_FILTERING=auto
+    if sys.version_info >= (3, 11):
+      assert any("For simplicity" in x for x in e.__notes__)
+      self.assertIsInstance(e.__cause__, ValueError)
+    else:
+      self.assertIsInstance(e.__cause__, jax.errors.SimplifiedTraceback)
+      self.assertIsInstance(e.__cause__.__cause__, ValueError)
 
   def test_null_traceback(self, filter_mode):
     class TestA: pass
@@ -375,9 +385,14 @@ class UserContextTracebackTest(jtu.JaxTestCase):
       e = exc
     self.assertIsNot(e, None)
     self.assertIn("invalid value", str(e))
-    self.assertIsInstance(
-        e.__cause__.__cause__,
-        source_info_util.JaxStackTraceBeforeTransformation)
+    if sys.version_info >= (3, 11):
+      self.assertIsInstance(
+          e.__cause__,
+          source_info_util.JaxStackTraceBeforeTransformation)
+    else:
+      self.assertIsInstance(
+          e.__cause__.__cause__,
+          source_info_util.JaxStackTraceBeforeTransformation)
 
 
 class CustomErrorsTest(jtu.JaxTestCase):


### PR DESCRIPTION
This change is to make JAX errors a little less inscrutable.

When running:
```python
import jax

@jax.grad
def g(x):
    bool(x)  # not valid code

@jax.jit
def f(x):
    return g(x)

f(1.)
```

Then for Python >=3.11 we now get (using the new [add_notes](https://peps.python.org/pep-0678/) feature):
```
❯ python file.py
Traceback (most recent call last):
  File "file.py", line 11, in <module>
    f(1.)
  File "file.py", line 9, in f
    return g(x)
           ^^^^
  File "file.py", line 5, in g
    bool(x)  # not valid code
    ^^^^^^^
jax.errors.TracerBoolConversionError: Attempted boolean conversion of traced array with shape float32[]..
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.TracerBoolConversionError
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
```

and for Python <3.11 we now get:
```
❯ python file.py       
jax.errors.SimplifiedTraceback: For simplicity, JAX has removed its internal frames from the traceback of of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "file.py", line 11, in <module>
    f(1.)
  File "file.py", line 9, in f
    return g(x)
           ^^^^
  File "file.py", line 5, in g
    bool(x)  # not valid code
    ^^^^^^^
jax.errors.TracerBoolConversionError: Attempted boolean conversion of traced array with shape float32[]..
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.TracerBoolConversionError
```

and previously, we used to always get:
```
❯ python file.py
Traceback (most recent call last):
  File "file.py", line 11, in <module>
    f(1.)
  File "jax/_src/traceback_util.py", line 174, in reraise_with_filtered_traceback
    return fun(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/pjit.py", line 252, in cache_miss
    outs, out_flat, out_tree, args_flat, jaxpr = _python_pjit_helper(
                                                 ^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/pjit.py", line 160, in _python_pjit_helper
    args_flat, _, params, in_tree, out_tree, _ = infer_params_fn(
                                                 ^^^^^^^^^^^^^^^^
  File "jax/_src/api.py", line 324, in infer_params
    return pjit.common_infer_params(pjit_info_args, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/pjit.py", line 486, in common_infer_params
    jaxpr, consts, canonicalized_out_shardings_flat = _pjit_jaxpr(
                                                      ^^^^^^^^^^^^
  File "jax/_src/pjit.py", line 964, in _pjit_jaxpr
    jaxpr, final_consts, out_type = _create_pjit_jaxpr(
                                    ^^^^^^^^^^^^^^^^^^^
  File "jax/_src/linear_util.py", line 345, in memoized_fun
    ans = call(fun, *args)
          ^^^^^^^^^^^^^^^^
  File "jax/_src/pjit.py", line 917, in _create_pjit_jaxpr
    jaxpr, global_out_avals, consts = pe.trace_to_jaxpr_dynamic(
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/profiler.py", line 314, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/interpreters/partial_eval.py", line 2155, in trace_to_jaxpr_dynamic
    jaxpr, out_avals, consts = trace_to_subjaxpr_dynamic(
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/interpreters/partial_eval.py", line 2177, in trace_to_subjaxpr_dynamic
    ans = fun.call_wrapped(*in_tracers_)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/linear_util.py", line 188, in call_wrapped
    ans = self.f(*args, **dict(self.params, **kwargs))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "file.py", line 9, in f
    return g(x)
           ^^^^
  File "jax/_src/traceback_util.py", line 174, in reraise_with_filtered_traceback
    return fun(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/api.py", line 665, in grad_f
    _, g = value_and_grad_f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/traceback_util.py", line 174, in reraise_with_filtered_traceback
    return fun(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/api.py", line 741, in value_and_grad_f
    ans, vjp_py = _vjp(f_partial, *dyn_args, reduce_axes=reduce_axes)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/api.py", line 2247, in _vjp
    out_primal, out_vjp = ad.vjp(
                          ^^^^^^^
  File "jax/_src/interpreters/ad.py", line 140, in vjp
    out_primals, pvals, jaxpr, consts = linearize(traceable, *primals)
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/interpreters/ad.py", line 129, in linearize
    jaxpr, out_pvals, consts = pe.trace_to_jaxpr_nounits(jvpfun_flat, in_pvals)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/profiler.py", line 314, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/interpreters/partial_eval.py", line 777, in trace_to_jaxpr_nounits
    jaxpr, (out_pvals, consts, env) = fun.call_wrapped(pvals)
                                      ^^^^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/linear_util.py", line 188, in call_wrapped
    ans = self.f(*args, **dict(self.params, **kwargs))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "file.py", line 5, in g
    bool(x)  # not valid code
    ^^^^^^^
  File "jax/_src/core.py", line 673, in __bool__
    def __bool__(self): return self.aval._bool(self)
                               ^^^^^^^^^^^^^^^^^^^^^
  File "jax/_src/core.py", line 1383, in error
    raise TracerBoolConversionError(arg)
jax._src.traceback_util.UnfilteredStackTrace: jax.errors.TracerBoolConversionError: Attempted boolean conversion of traced array with shape float32[]..
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.TracerBoolConversionError

The stack trace below excludes JAX-internal frames.
The preceding is the original exception that occurred, unmodified.

--------------------

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "file.py", line 11, in <module>
    f(1.)
  File "file.py", line 9, in f
    return g(x)
           ^^^^
  File "file.py", line 5, in g
    bool(x)  # not valid code
    ^^^^^^^
jax.errors.TracerBoolConversionError: Attempted boolean conversion of traced array with shape float32[]..
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.TracerBoolConversionError
```