### PR TITLE
Jax train_test_split 

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -266,6 +266,34 @@ def key_data(keys: KeyArray) -> Array:
   return _key_data(keys)
 
 
+def train_test_split(*arrays: Array, test_size: float = 0.5, shuffle: bool = True,
+                      seed: Optional[int] = None) -> Sequence[Array]:
+  """Splits arrays into random train and test subsets.
+
+  Args:
+    *arrays: sequence of array-like objects to be split into train and test sets.
+    test_size: optional, float or int, if float, should be between 0.0 and 1.0
+      and represent the proportion of the dataset to include in the test split.
+      If int, represents the absolute number of test samples. Defaults to 0.5.
+    shuffle: optional, bool, whether or not to shuffle the data before splitting.
+      If False, the data is split in a stratified fashion. Defaults to True.
+    seed: optional, int, seed for the random number generator.
+
+  Returns:
+    A list of train/test subsets of the input arrays.
+  """
+  rng = _check_prng_key(seed)
+  if not 0 <= test_size <= 1:
+    raise ValueError(f"test_size={test_size} should be between 0.0 and 1.0")
+  if isinstance(test_size, float):
+    test_size = int(test_size * arrays[0].shape[0])
+  if shuffle:
+    perm = permutation(rng, arrays[0].shape[0])
+  else:
+    perm = jnp.arange(arrays[0].shape[0])
+  return [x[perm[test_size:]] for x in arrays], [x[perm[:test_size]] for x in arrays]
+
+
 ### random samplers
 
 

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -267,7 +267,7 @@ def key_data(keys: KeyArray) -> Array:
 
 
 def train_test_split(*arrays: Array, test_size: float = 0.5, shuffle: bool = True,
-                      seed: Optional[int] = None) -> Sequence[Array]:
+                      key: Optional[int] = None) -> Sequence[Array]:
   """Splits arrays into random train and test subsets.
 
   Args:
@@ -282,13 +282,16 @@ def train_test_split(*arrays: Array, test_size: float = 0.5, shuffle: bool = Tru
   Returns:
     A list of train/test subsets of the input arrays.
   """
-  rng = _check_prng_key(seed)
+  
+  if key is None:
+    key = _check_prng_key(seed=42)
+    
   if not 0 <= test_size <= 1:
     raise ValueError(f"test_size={test_size} should be between 0.0 and 1.0")
   if isinstance(test_size, float):
     test_size = int(test_size * arrays[0].shape[0])
   if shuffle:
-    perm = permutation(rng, arrays[0].shape[0])
+    perm = permutation(key, arrays[0].shape[0])
   else:
     perm = jnp.arange(arrays[0].shape[0])
   return [x[perm[test_size:]] for x in arrays], [x[perm[:test_size]] for x in arrays]


### PR DESCRIPTION
# What does this PR do?

This PR aims to add a module for the `train_test_split` function. The `jax.random.split` didn't offer the functionality of splitting the data into train and test sets. Therefore, this PR aims to add the functionality of splitting the data into train and test sets.

like this:
```python
import jax

key = jax.random.PRNGKey(seed=100)

key , subkey = jax.random.split(key , num=2)

input = jax.random.normal(key, (100, 10))

train, test = jax.random.train_test_split(input, test_size=0.2 , key=subkey)
```
