### PR TITLE
Enhance Consistency of Kaiming He Initializer Documentation 

### DIFF
--- a/jax/_src/nn/initializers.py
+++ b/jax/_src/nn/initializers.py
@@ -481,7 +481,7 @@ def he_uniform(in_axis: Union[int, Sequence[int]] = -2,
   Example:
 
   >>> import jax, jax.numpy as jnp
-  >>> initializer = jax.nn.initializers.kaiming_uniform()
+  >>> initializer = jax.nn.initializers.he_uniform()
   >>> initializer(jax.random.PRNGKey(42), (2, 3), jnp.float32)  # doctest: +SKIP
   Array([[ 0.79611576,  1.2789248 ,  1.2896855 ],
          [-1.0108745 , -1.0855657 ,  0.17398663]], dtype=float32)
@@ -519,7 +519,7 @@ def he_normal(in_axis: Union[int, Sequence[int]] = -2,
   Example:
 
   >>> import jax, jax.numpy as jnp
-  >>> initializer = jax.nn.initializers.kaiming_normal()
+  >>> initializer = jax.nn.initializers.he_normal()
   >>> initializer(jax.random.PRNGKey(42), (2, 3), jnp.float32)  # doctest: +SKIP
   Array([[ 0.6604483 ,  1.1900088 ,  1.2047218 ],
          [-0.87225807, -0.95321447,  0.1369438 ]], dtype=float32)


### PR DESCRIPTION
**Purpose**
This pull request addresses a discrepancy between a method name and the example provided in the documentation. Currently the `jax._src.nn.he_normal` and `jax._src.nn.he_uniform` docstrings reference examples with `jax._src.nn.kaiming_normal` and `jax._src.nn.kaiming_uniform` respectively. This pull request alters these examples to ensure that they use the prefix `he` rather than `kaiming` in order to avoid confusion among users reading the API docs.

While these methods are functionally equivalent due to [assignment](https://github.com/google/jax/blob/8d80e2587b613d12533273b2299937a6f93dc893/jax/_src/nn/initializers.py#L494), the current documentation may be confusing to users who haven't read the source code.

**Implications**
This has implications for documentation that is generated from Jax method docstrings (e.g. Flax: [example doc](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/_autosummary/flax.linen.initializers.he_normal.html))

**Affected Documentation**
[he_normal doc](https://jax.readthedocs.io/en/latest/_autosummary/jax.nn.initializers.he_normal.html#jax.nn.initializers.he_normal)
[he_uniform doc](https://jax.readthedocs.io/en/latest/_autosummary/jax.nn.initializers.he_uniform.html#jax.nn.initializers.he_uniform)

**Example**
<img width="794" alt="Screenshot 2023-08-07 at 11 03 25" src="https://github.com/google/jax/assets/42982057/cc8f9a31-6a8a-4e7a-b198-8bd1745fe30b">