### PR TITLE
[custom-jvp/vjp] allow rules to be run more than once, explicitly manage store lifetimes

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -832,7 +832,6 @@ CustomVJPCallPrimitive.initial_style = custom_vjp_call_jaxpr_p
 mlir.register_lowering(custom_vjp_call_jaxpr_p, mlir.lower_fun(
     _custom_vjp_call_jaxpr_impl, multiple_results=True))
 
-
 def _custom_vjp_call_jaxpr_jvp(
     primals, tangents, *, fun_jaxpr: core.ClosedJaxpr,
     fwd_jaxpr_thunk: Callable[..., tuple[core.Jaxpr, Sequence[Any]]],

--- a/jax/_src/linear_util.py
+++ b/jax/_src/linear_util.py
@@ -130,6 +130,8 @@ class EqualStore:
         if not okay:
           raise StoreException("Store occupied with not-equal value") from None
 
+  def reset(self):
+    self._store.reset()
 
 
 class WrappedFun:

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -1553,6 +1553,7 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: list[core.JaxprEqn],
 
     def unreachable_thunk():
       assert False, "Should not be reached"
+    unreachable_thunk.reset_stores = lambda: None
 
     eqns.append(
         eqn.replace(

--- a/tests/pytorch_interoperability_test.py
+++ b/tests/pytorch_interoperability_test.py
@@ -87,7 +87,7 @@ class DLPackTest(jtu.JaxTestCase):
   @jtu.sample_product(shape=all_shapes, dtype=torch_dtypes)
   def testJaxArrayToTorch(self, shape, dtype):
     if xla_extension_version < 186:
-      self.SkipTest("Need xla_extension_version >= 186")
+      self.skipTest("Need xla_extension_version >= 186")
 
     if not config.x64_enabled and dtype in [
         jnp.int64,


### PR DESCRIPTION
When we originally added `custom_jvp` and `custom_vjp`, we set things up so that the user-supplied rule functions (e.g. the fwd function) would only be called at most once per application of the custom_jvp/vjp-decorated function. That let us reuse some machinery we had from `jit` and `pmap` for `lu.transformation_with_aux` involving `lu.Store`s; we used that machinery to plumb output metadata from the callee `lu.WrappedFun` to the caller of the `lu.transformation_with_aux`-decorated function.

That original machinery was based on running user functions, like `jax.jit`-decorated ones, exactly once. We didn't want to re-run user code because in the context of `jax.jit` the user only asked us to run it once, and it might have expensive computations in it. Plus we only ever needed to run it once.

But actually for rules, like the user-supplied autodiff rules in `custom_jvp/vjp`, that doesn't apply: we might have to run the rules more than once in e.g. the context of a fixed point loop for scan to decide what the symbolic zero pattern is. That is, for rules we don't need this run-once restriction. It was just an accident of history that `custom_jvp/vjp` autodiff rules inherited this run-at-most-once behavior, as an artifact of reusing the same implementation mechanisms.

Until recently, we didn't need to run these rules more than once because `custom_jvp/vjp` didn't support symbolic zeros at all: all zeros were instantiated. But when we added symbolic zero support, we unknowingly introduced the need to run user-supplied rules more than once. And that meant we couldn't rely on the old way of doing things.

In particular, in #16614, when a scan fixed point attempted to run the user-supplied rule multiple times, we got a "Store occupied" error because of our reliance on the run-once machinery.

This PR is a quick fix to the problem: just allow the `WrappedFun`s associated with staged-out custom VJP rules to be run more than once, by clearing their stores right before we run them. Easy!

fixes #16614