### PR TITLE
Fix for log-normal prior in example.

### DIFF
--- a/examples/gaussian_process_regression.py
+++ b/examples/gaussian_process_regression.py
@@ -73,7 +73,7 @@ def main(unused_argv):
           -0.5 * jnp.dot(y.T, kinvy) -
           jnp.sum(jnp.log(jnp.diag(chol))) -
           (numpts / 2.) * log2pi)
-      ml -= jnp.sum(-0.5 * jnp.log(2 * 3.1415) - jnp.log(amp)**2) # lognormal prior
+      ml -= jnp.sum(-0.5 * jnp.log(2 * 3.1415) - jnp.log(amp) - 0.5 * jnp.log(amp)**2) # lognormal prior
       return -ml
 
     if xtest is not None:


### PR DESCRIPTION
Haven't thought about this much but the comment in one of the examples indicated a log-normal prior was desired but the $-\log(x)$ term was missing.
A reminder the density for log-normal is

$$
f(x) = \frac{1}{x \sqrt{2 \pi}} \exp \left( - \frac{(\log x)^2}{2} \right)
$$