### PR TITLE
Remove StreamExecutor-based TPU runtime from Cloud TPU CI

### DIFF
--- a/.github/workflows/cloud-tpu-ci-nightly.yml
+++ b/.github/workflows/cloud-tpu-ci-nightly.yml
@@ -14,8 +14,7 @@ jobs:
       matrix:
         jaxlib-version: ["latest", "nightly"]
         tpu-type: ["v3-8", "v4-8", "nightly"]
-        pjrt: ["true", "false"]
-    name: "TPU test (${{ matrix.jaxlib-version }}, pjrt=${{ matrix.pjrt }}, ${{ matrix.tpu-type }})"
+    name: "TPU test (${{ matrix.jaxlib-version }}, ${{ matrix.tpu-type }})"
     runs-on: ["self-hosted", "tpu", "${{ matrix.tpu-type }}"]
     timeout-minutes: 60
     steps:
@@ -55,7 +54,6 @@ jobs:
       - name: Run tests
         env:
           JAX_PLATFORMS: tpu,cpu
-          JAX_USE_PJRT_C_API_ON_TPU: ${{ matrix.pjrt }}
           PY_COLORS: 1
         run: |
           # Run single-accelerator tests in parallel


### PR DESCRIPTION
The old StreamExecutor-based backend is no longer supported as of https://github.com/google/jax/commit/3e50fea29edb6b78426dde511414429f2d2fddf8