### PR TITLE
Add jnp.ufunc and jnp.frompyfunc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Remember to align the itemized text with the first line of an item within a list
 ## jax 0.4.15
 
 * Changes
+  * Added {class}`jax.numpy.ufunc`, as well as {func}`jax.numpy.frompyfunc`, which can convert
+    any scalar-valued function into a {func}`numpy.ufunc`-like object, with methods such as
+    {meth}`~jax.numpy.ufunc.outer`, {meth}`~jax.numpy.ufunc.reduce`,
+    {meth}`~jax.numpy.ufunc.accumulate`, {meth}`~jax.numpy.ufunc.at`, and
+    {meth}`~jax.numpy.ufunc.reduceat` ({jax-issue}`#17054`).
   * When not running under IPython: when an exception is raised, JAX now filters out the
     entirety of its internal frames from tracebacks. (Without the "unfiltered stack trace"
     that previously appeared.) This should produce much friendlier-looking tracebacks. See

--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -178,6 +178,7 @@ namespace; they are listed below.
     fromfile
     fromfunction
     fromiter
+    frompyfunc
     fromstring
     from_dlpack
     full
@@ -388,6 +389,7 @@ namespace; they are listed below.
     triu_indices_from
     true_divide
     trunc
+    ufunc
     uint
     uint16
     uint32

--- a/jax/_src/numpy/ufunc_api.py
+++ b/jax/_src/numpy/ufunc_api.py
@@ -1,0 +1,247 @@
+# Copyright 2023 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools to create numpy-style ufuncs."""
+
+_AT_INPLACE_WARNING = """\
+Because JAX arrays are immutable, jnp.ufunc.at() cannot operate inplace like
+np.ufunc.at(). Instead, you can pass inplace=False and capture the result; e.g.
+>>> arr = jnp.add.at(arr, ind, val, inplace=False)
+"""
+from functools import partial
+import operator
+
+import jax
+from jax._src.lax import lax as lax_internal
+from jax._src.numpy.lax_numpy import _eliminate_deprecated_list_indexing, append, take
+from jax._src.numpy.reductions import _moveaxis
+from jax._src.numpy.util import _wraps, check_arraylike, _broadcast_to, _where
+from jax._src.numpy.vectorize import vectorize
+from jax._src.util import canonicalize_axis
+import numpy as np
+
+
+class ufunc:
+  """Functions that operate element-by-element on whole arrays.
+
+  This is a class for LAX-backed implementations of numpy ufuncs.
+  """
+  def __init__(self, func, /, nin, nout, *, name=None, nargs=None, identity=None):
+    # TODO(jakevdp): validate the signature of func via eval_shape.
+    self.__name__ = name or func.__name__
+    self._call = vectorize(func)
+    self.nin = operator.index(nin)
+    self.nout = operator.index(nout)
+    self.nargs = nargs or self.nin
+    self.identity = identity
+
+  def __repr__(self):
+    return f"<jnp.ufunc '{self.__name__}'>"
+
+  def __call__(self, *args, out=None, where=None, **kwargs):
+    if out is not None:
+      raise NotImplementedError(f"out argument of {self}")
+    if where is not None:
+      raise NotImplementedError(f"where argument of {self}")
+    return self._call(*args, **kwargs)
+
+  @_wraps(np.ufunc.reduce, module="numpy.ufunc")
+  def reduce(self, a, axis=0, dtype=None, out=None, keepdims=False, initial=None, where=None):
+    if self.nin != 2:
+      raise ValueError("reduce only supported for binary ufuncs")
+    if self.nout != 1:
+      raise ValueError("reduce only supported for functions returning a single value")
+    if out is not None:
+      raise NotImplementedError(f"out argument of {self.__name__}.reduce()")
+    # TODO(jakevdp): implement where.
+    if where is not None:
+      raise NotImplementedError(f"where argument of {self.__name__}.reduce()")
+    return self._reduce_via_scan(a, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial)
+
+  def _reduce_via_scan(self, arr, axis=0, dtype=None, keepdims=False, initial=None):
+    assert self.nin == 2 and self.nout == 1
+    check_arraylike(f"{self.__name__}.reduce", arr)
+    arr = lax_internal.asarray(arr)
+    if initial is None:
+      initial = self.identity
+    if dtype is None:
+      dtype = jax.eval_shape(self, lax_internal._one(arr), lax_internal._one(arr)).dtype
+
+    if isinstance(axis, tuple):
+      axis = tuple(canonicalize_axis(a, arr.ndim) for a in axis)
+      raise NotImplementedError("tuple of axes")
+    elif axis is None:
+      if keepdims:
+        final_shape = (1,) * arr.ndim
+      else:
+        final_shape = ()
+      arr = arr.ravel()
+      axis = 0
+    else:
+      axis = canonicalize_axis(axis, arr.ndim)
+      if keepdims:
+        final_shape = (*arr.shape[:axis], 1, *arr.shape[axis + 1:])
+      else:
+        final_shape = (*arr.shape[:axis], *arr.shape[axis + 1:])
+
+    # TODO: handle without transpose?
+    if axis != 0:
+      arr = _moveaxis(arr, axis, 0)
+
+    if initial is None and arr.shape[0] == 0:
+      raise ValueError("zero-size array to reduction operation {self.__name__} which has no ideneity")
+
+    def body_fun(i, val):
+      return self._call(val, arr[i].astype(dtype))
+
+    if initial is None:
+      start = 1
+      initial = arr[0]
+    else:
+      check_arraylike(f"{self.__name__}.reduce", arr)
+      start = 0
+
+    initial = _broadcast_to(lax_internal.asarray(initial).astype(dtype), arr.shape[1:])
+
+    result = jax.lax.fori_loop(start, arr.shape[0], body_fun, initial)
+    if keepdims:
+      result = result.reshape(final_shape)
+    return result
+
+  @_wraps(np.ufunc.accumulate, module="numpy.ufunc")
+  def accumulate(self, a, axis=0, dtype=None, out=None):
+    if self.nin != 2:
+      raise ValueError("accumulate only supported for binary ufuncs")
+    if self.nout != 1:
+      raise ValueError("accumulate only supported for functions returning a single value")
+    if out is not None:
+      raise NotImplementedError(f"out argument of {self.__name__}.accumulate()")
+    return self._accumulate_via_scan(a, axis=axis, dtype=dtype)
+
+  def _accumulate_via_scan(self, arr, axis=0, dtype=None):
+    assert self.nin == 2 and self.nout == 1
+    check_arraylike(f"{self.__name__}.accumulate", arr)
+    arr = lax_internal.asarray(arr)
+
+    if dtype is None:
+      dtype = jax.eval_shape(self, lax_internal._one(arr), lax_internal._one(arr)).dtype
+
+    if axis is None or isinstance(axis, tuple):
+      raise ValueError("accumulate does not allow multiple axes")
+    axis = canonicalize_axis(axis, np.ndim(arr))
+
+    arr = _moveaxis(arr, axis, 0)
+    def scan_fun(carry, _):
+      i, x = carry
+      y = _where(i == 0, arr[0].astype(dtype), self._call(x.astype(dtype), arr[i].astype(dtype)))
+      return (i + 1, y), y
+    _, result = jax.lax.scan(scan_fun, (0, arr[0].astype(dtype)), None, length=arr.shape[0])
+    return _moveaxis(result, 0, axis)
+
+  @_wraps(np.ufunc.accumulate, module="numpy.ufunc")
+  def at(self, a, indices, b=None, /, *, inplace=True):
+    if inplace:
+      raise NotImplementedError(_AT_INPLACE_WARNING)
+    if b is None:
+      return self._at_via_scan(a, indices)
+    else:
+      return self._at_via_scan(a, indices, b)
+
+  def _at_via_scan(self, a, indices, *args):
+    check_arraylike(f"{self.__name__}.at", a, *args)
+    dtype = jax.eval_shape(self, lax_internal._one(a), *(lax_internal._one(arg) for arg in args)).dtype
+    a = lax_internal.asarray(a).astype(dtype)
+    args = tuple(lax_internal.asarray(arg).astype(dtype) for arg in args)
+    indices = _eliminate_deprecated_list_indexing(indices)
+    if not indices:
+      return a
+
+    shapes = [np.shape(i) for i in indices if not isinstance(i, slice)]
+    shape = shapes and jax.lax.broadcast_shapes(*shapes)
+    if not shape:
+      return a.at[indices].set(self._call(a.at[indices].get(), *args))
+
+    args = tuple(_broadcast_to(arg, shape).ravel() for arg in args)
+    indices = [idx if isinstance(idx, slice) else _broadcast_to(idx, shape).ravel() for idx in indices]
+
+    def scan_fun(carry, x):
+      i, a = carry
+      idx = tuple(ind if isinstance(ind, slice) else ind[i] for ind in indices)
+      a = a.at[idx].set(self._call(a.at[idx].get(), *(arg[i] for arg in args)))
+      return (i + 1, a), x
+    carry, _ = jax.lax.scan(scan_fun, (0, a), None, len(indices[0]))
+    return carry[1]
+
+  @_wraps(np.ufunc.reduceat, module="numpy.ufunc")
+  def reduceat(self, a, indices, axis=0, dtype=None, out=None):
+    if self.nin != 2:
+      raise ValueError("reduceat only supported for binary ufuncs")
+    if self.nout != 1:
+      raise ValueError("reduceat only supported for functions returning a single value")
+    if out is not None:
+      raise NotImplementedError(f"out argument of {self.__name__}.reduceat()")
+    return self._reduceat_via_scan(a, indices, axis=axis, dtype=dtype)
+
+  def _reduceat_via_scan(self, a, indices, axis=0, dtype=None):
+    check_arraylike(f"{self.__name__}.reduceat", a, indices)
+    a = lax_internal.asarray(a)
+    idx_tuple = _eliminate_deprecated_list_indexing(indices)
+    assert len(idx_tuple) == 1
+    indices = idx_tuple[0]
+    if a.ndim == 0:
+      raise ValueError(f"reduceat: a must have 1 or more dimension, got {a.shape=}")
+    if indices.ndim != 1:
+      raise ValueError(f"reduceat: indices must be one-dimensional, got {indices.shape=}")
+    if dtype is None:
+      dtype = a.dtype
+    if axis is None or isinstance(axis, (tuple, list)):
+      raise ValueError("reduceat requires a single integer axis.")
+    axis = canonicalize_axis(axis, a.ndim)
+    out = take(a, indices, axis=axis)
+    ind = jax.lax.expand_dims(append(indices, a.shape[axis]),
+                              np.delete(np.arange(out.ndim), axis))
+    ind_start = jax.lax.slice_in_dim(ind, 0, ind.shape[axis] - 1, axis=axis)
+    ind_end = jax.lax.slice_in_dim(ind, 1, ind.shape[axis], axis=axis)
+    def loop_body(i, out):
+      return _where((i > ind_start) & (i < ind_end),
+                    self._call(out, take(a, i.reshape(1), axis=axis)),
+                    out)
+    return jax.lax.fori_loop(0, a.shape[axis], loop_body, out)
+
+  @_wraps(np.ufunc.outer, module="numpy.ufunc")
+  def outer(self, A, B, /, **kwargs):
+    if self.nin != 2:
+      raise ValueError("outer only supported for binary ufuncs")
+    if self.nout != 1:
+      raise ValueError("outer only supported for functions returning a single value")
+    check_arraylike(f"{self.__name__}.outer", A, B)
+    _ravel = lambda A: jax.lax.reshape(A, (np.size(A),))
+    result = jax.vmap(jax.vmap(partial(self._call, **kwargs), (None, 0)), (0, None))(_ravel(A), _ravel(B))
+    return result.reshape(*np.shape(A), *np.shape(B))
+
+
+def frompyfunc(func, /, nin, nout, *, identity=None):
+  """Create a JAX ufunc from an arbitrary JAX-compatible scalar function.
+
+  Args:
+    func : a callable that takes `nin` scalar arguments and return `nout` outputs.
+    nin: integer specifying the number of scalar inputs
+    nout: integer specifying the number of scalar outputs
+    identity: (optional) a scalar specifying the identity of the operation, if any.
+
+  Returns:
+    wrapped : jax.numpy.ufunc wrapper of func.
+  """
+  # TODO(jakevdp): use functools.wraps or similar to wrap the docstring?
+  return ufunc(func, nin, nout, identity=identity)

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -413,6 +413,11 @@ from jax._src.numpy.ufuncs import (
     true_divide as true_divide,
 )
 
+from jax._src.numpy.ufunc_api import (
+    frompyfunc as frompyfunc,
+    ufunc as ufunc,
+)
+
 from jax._src.numpy.vectorize import vectorize as vectorize
 
 # Dynamically register numpy-style methods on JAX arrays.

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -379,6 +379,11 @@ jax_test(
 )
 
 jax_test(
+    name = "lax_numpy_ufuncs_test",
+    srcs = ["lax_numpy_ufuncs_test.py"],
+)
+
+jax_test(
     name = "lax_numpy_vectorize_test",
     srcs = ["lax_numpy_vectorize_test.py"],
 )

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -5469,7 +5469,7 @@ class NumpyDocTests(jtu.JaxTestCase):
     # Test that docstring wrapping & transformation didn't fail.
 
     # Functions that have their own docstrings & don't wrap numpy.
-    known_exceptions = {'fromfile', 'fromiter', 'vectorize'}
+    known_exceptions = {'fromfile', 'fromiter', 'frompyfunc', 'vectorize'}
 
     for name in dir(jnp):
       if name in known_exceptions or name.startswith('_'):

--- a/tests/lax_numpy_ufuncs_test.py
+++ b/tests/lax_numpy_ufuncs_test.py
@@ -1,0 +1,174 @@
+# Copyright 2023 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for jax.numpy.ufunc and its methods."""
+
+from functools import partial
+
+from absl.testing import absltest
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax._src import test_util as jtu
+
+from jax import config
+config.parse_flags_with_absl()
+FLAGS = config.FLAGS
+
+
+def scalar_add(x, y):
+  assert np.shape(x) == np.shape(y) == ()
+  return x + y
+
+
+def scalar_mul(x, y):
+  assert np.shape(x) == np.shape(y) == ()
+  return x * y
+
+
+SCALAR_FUNCS = [
+  {'func': scalar_add, 'nin': 2, 'nout': 1, 'identity': 0},
+  {'func': scalar_mul, 'nin': 2, 'nout': 1, 'identity': 1},
+]
+
+broadcast_compatible_shapes = [(), (1,), (3,), (1, 3), (4, 1), (4, 3)]
+nonscalar_shapes = [(3,), (4,), (4, 3)]
+
+def cast_outputs(fun):
+  def wrapped(*args, **kwargs):
+    dtype = np.asarray(args[0]).dtype
+    return jax.tree_map(lambda x: np.asarray(x, dtype=dtype), fun(*args, **kwargs))
+  return wrapped
+
+
+class LaxNumpyUfuncTests(jtu.JaxTestCase):
+  @jtu.sample_product(
+      SCALAR_FUNCS,
+      lhs_shape=broadcast_compatible_shapes,
+      rhs_shape=broadcast_compatible_shapes,
+      dtype=jtu.dtypes.floating,
+  )
+  def test_call(self, func, nin, nout, identity, lhs_shape, rhs_shape, dtype):
+    jnp_fun = jnp.frompyfunc(func, nin=nin, nout=nout, identity=identity)
+    np_fun = cast_outputs(np.frompyfunc(func, nin=nin, nout=nout, identity=identity))
+
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
+
+    self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
+  @jtu.sample_product(
+      SCALAR_FUNCS,
+      lhs_shape=broadcast_compatible_shapes,
+      rhs_shape=broadcast_compatible_shapes,
+      dtype=jtu.dtypes.floating,
+  )
+  def test_outer(self, func, nin, nout, identity, lhs_shape, rhs_shape, dtype):
+    if (nin, nout) != (2, 1):
+      self.skipTest(f"outer requires (nin, nout)=(2, 1); got {(nin, nout)=}")
+    jnp_fun = jnp.frompyfunc(func, nin=nin, nout=nout, identity=identity).outer
+    np_fun = cast_outputs(np.frompyfunc(func, nin=nin, nout=nout, identity=identity).outer)
+
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
+
+    self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
+  @jtu.sample_product(
+      SCALAR_FUNCS,
+      [{'shape': shape, 'axis': axis}
+       for shape in broadcast_compatible_shapes
+       for axis in [None, *range(-len(shape), len(shape))]],
+      dtype=jtu.dtypes.floating,
+  )
+  def test_reduce(self, func, nin, nout, identity, shape, axis, dtype):
+    if (nin, nout) != (2, 1):
+      self.skipTest(f"reduce requires (nin, nout)=(2, 1); got {(nin, nout)=}")
+    jnp_fun = partial(jnp.frompyfunc(func, nin=nin, nout=nout, identity=identity).reduce, axis=axis)
+    np_fun = cast_outputs(partial(np.frompyfunc(func, nin=nin, nout=nout, identity=identity).reduce, axis=axis))
+
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape, dtype)]
+
+    self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
+    self._CompileAndCheck(jnp_fun, args_maker, check_cache_misses=False)  # TODO(jakevdp): why the cache misses?
+
+  @jtu.sample_product(
+      SCALAR_FUNCS,
+      [{'shape': shape, 'axis': axis}
+       for shape in broadcast_compatible_shapes
+       for axis in range(-len(shape), len(shape))],
+      dtype=jtu.dtypes.floating,
+  )
+  def test_accumulate(self, func, nin, nout, identity, shape, axis, dtype):
+    if (nin, nout) != (2, 1):
+      self.skipTest(f"accumulate requires (nin, nout)=(2, 1); got {(nin, nout)=}")
+    jnp_fun = partial(jnp.frompyfunc(func, nin=nin, nout=nout, identity=identity).accumulate, axis=axis)
+    np_fun = cast_outputs(partial(np.frompyfunc(func, nin=nin, nout=nout, identity=identity).accumulate, axis=axis))
+
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape, dtype)]
+
+    self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
+    self._CompileAndCheck(jnp_fun, args_maker, check_cache_misses=False)  # TODO(jakevdp): why the cache misses?
+
+  @jtu.sample_product(
+      SCALAR_FUNCS,
+      shape=nonscalar_shapes,
+      idx_shape=[(), (2,)],
+      dtype=jtu.dtypes.floating,
+  )
+  def test_at(self, func, nin, nout, identity, shape, idx_shape, dtype):
+    if (nin, nout) != (2, 1):
+      self.skipTest(f"accumulate requires (nin, nout)=(2, 1); got {(nin, nout)=}")
+    jnp_fun = partial(jnp.frompyfunc(func, nin=nin, nout=nout, identity=identity).at, inplace=False)
+    def np_fun(x, idx, y):
+      x_copy = x.copy()
+      np.frompyfunc(func, nin=nin, nout=nout, identity=identity).at(x_copy, idx, y)
+      return x_copy
+
+    rng = jtu.rand_default(self.rng())
+    idx_rng = jtu.rand_int(self.rng(), low=-shape[0], high=shape[0])
+    args_maker = lambda: [rng(shape, dtype), idx_rng(idx_shape, 'int32'), rng(idx_shape[1:], dtype)]
+
+    self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
+    self._CompileAndCheck(jnp_fun, args_maker, check_cache_misses=False)  # TODO(jakevdp): why the cache misses?
+
+  @jtu.sample_product(
+      SCALAR_FUNCS,
+      [{'shape': shape, 'axis': axis}
+       for shape in broadcast_compatible_shapes
+       for axis in [*range(-len(shape), len(shape))]],
+      idx_shape=[(0,), (3,), (5,)],
+      dtype=jtu.dtypes.floating,
+  )
+  def test_reduceat(self, func, nin, nout, identity, shape, axis, idx_shape, dtype):
+    if (nin, nout) != (2, 1):
+      self.skipTest(f"accumulate requires (nin, nout)=(2, 1); got {(nin, nout)=}")
+    jnp_fun = partial(jnp.frompyfunc(func, nin=nin, nout=nout, identity=identity).reduceat, axis=axis)
+    np_fun = cast_outputs(partial(np.frompyfunc(func, nin=nin, nout=nout, identity=identity).reduceat, axis=axis))
+
+    rng = jtu.rand_default(self.rng())
+    idx_rng = jtu.rand_int(self.rng(), low=0, high=shape[axis])
+    args_maker = lambda: [rng(shape, dtype), idx_rng(idx_shape, 'int32')]
+
+    self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
+    self._CompileAndCheck(jnp_fun, args_maker, check_cache_misses=False)  # TODO(jakevdp): why the cache misses?
+
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This refactors some of the code from #9529 with a more narrow scope. The two new public objects are
- `jnp.ufunc`: a class analogous to [`np.ufunc`](https://numpy.org/doc/stable/reference/generated/numpy.ufunc.html), which implements general versions of all the ufunc methods (`outer`, `reduce`, `accumulate`, `at`, `reduceat`)
- `jnp.frompyfunc`: a function analogous to [`np.frompyfunc`](https://numpy.org/doc/stable/reference/generated/numpy.frompyfunc.html) which accepts an arbitrary scalar function and wraps it in `jnp.ufunc` to enable calling these ufunc methods
 
Notably, while NumPy's `np.frompyfunc` has severe performance penalties (it is implemented in terms of python-side loops), JAX's `jnp.frompyfunc` can take advantage of JAX transformations like `vmap` and `jit` to make the resulting operations reasonably efficient.

Example:
```python
In [1]: import jax.numpy as jnp

In [2]: def scalar_add(x, y):
   ...:   # emphasize that only scalar tracers will be passed to this function.
   ...:   assert jnp.shape(x) == jnp.shape(y) == ()
   ...:   return x + y
   ...: 

In [3]: add = jnp.frompyfunc(scalar_add, nin=2, nout=1, identity=0)

In [4]: add
Out[4]: <jnp.ufunc 'scalar_add'>

In [5]: x = jnp.arange(5)

In [6]: indices = jnp.array([1, 1, 3])

In [7]: add(x, 1)  # Standard broadcasting
Out[7]: Array([1, 2, 3, 4, 5], dtype=int32)

In [8]: add.outer(x, x)
Out[8]: 
Array([[0, 1, 2, 3, 4],
       [1, 2, 3, 4, 5],
       [2, 3, 4, 5, 6],
       [3, 4, 5, 6, 7],
       [4, 5, 6, 7, 8]], dtype=int32)

In [9]: add.reduce(x)  # reduce() method applies binary reduction.
Out[9]: Array(10, dtype=int32)

In [10]: add.accumulate(x)  # accumulate() method is cumulative reduction
Out[10]: Array([ 0,  1,  3,  6, 10], dtype=int32)

In [11]: add.at(x, indices, 10, inplace=False)  # at() method is similar to JAX's ndarray.at
Out[11]: Array([ 0, 21,  2, 13,  4], dtype=int32)

In [12]: add.reduceat(x, indices)  # reduction between indices
Out[12]: Array([1, 3, 7], dtype=int32)
```
Once this is landed, we should explore making wrappers of numpy ufuncs within the `jax.numpy` namespace into `jnp.ufunc` objects, so ufunc methods can be used directly.

Additionally, there are a few places where efficiency could be improved. For example, for some binary functions, we should be able to substitute faster implementations for the `scan` approaches: e.g. `jnp.add` could use `jnp.sum` for `reduce`, `jnp.cumsum` for `accumulate`, `jnp.scatter_add` for `at`. and `jnp.segment_sum` for `reduceat`. But the current implementation is a good baseline that implements the desired behavior for arbitrary functions.