### PR TITLE
lax.expm1: more accurate gradient for large negative inputs

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1777,7 +1777,7 @@ ad.defjvp(log_p, lambda g, x: div(g, x))
 mlir.register_lowering(log_p, partial(_nary_lower_hlo, hlo.LogOp))
 
 expm1_p = standard_unop(_float | _complex, 'expm1')
-ad.defjvp2(expm1_p, lambda g, ans, x: mul(g, add(ans, _one(ans))))
+ad.defjvp2(expm1_p, lambda g, ans, x: mul(g, exp(x)))  # ans + 1 is imprecise for large negative x
 mlir.register_lowering(expm1_p, partial(_nary_lower_hlo, hlo.Expm1Op))
 
 log1p_p = standard_unop(_float | _complex, 'log1p')

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -437,6 +437,12 @@ class LaxAutodiffTest(jtu.JaxTestCase):
                                  preferred_element_type=jax.numpy.float32)
     jax.jacrev(f)(x)  # don't crash!
 
+  def testExpm1GradSmallValues(self):
+    x = np.float32(-25)
+    expected = lax.exp(x)
+    actual = jax.grad(lax.expm1)(x)
+    self.assertAllClose(expected, actual, atol=0)
+
   @jtu.sample_product(
     shape=[(), (2, 3)],
     dtype=float_dtypes,


### PR DESCRIPTION
Experimental change – I want to check if this breaks anything.

Here's an example of where the current implementation of `grad(lax.expm1)` becomes inaccurate:
```python
import matplotlib.pyplot as plt
import jax.numpy as jnp
import jax

x = jnp.linspace(-30, 30, 1000)

def expm1_direct(x):
  return jnp.exp(x) - 1

fig, ax = plt.subplots(1, 2, figsize=(12, 4))
ax[0].semilogy(x, 1 + expm1_direct(x), label='1 + exp(x) - 1')
ax[0].semilogy(x, 1 + jnp.expm1(x), label='1 + expm1(x)')
ax[0].legend()

ax[1].semilogy(x, jax.vmap(jax.grad(expm1_direct))(x), label='exp(x)')
ax[1].semilogy(x, jax.vmap(jax.grad(jnp.expm1))(x), label='grad(expm1)(x)')
ax[1].legend()
```
![download-1](https://github.com/google/jax/assets/781659/601f124c-5108-421c-bff0-1d1a3aa0fce0)


This change makes the gradient more accurate when x is a large negative number, but it comes at the cost of re-computing `exp(x)`, so we may not want to merge (after all, the current answers do agreee to within reasonable floating point accuracy in an absolute sense, though not in a relative sense)