### PR TITLE
Make searchsorted a primitive

### DIFF
--- a/docs/jax.lax.rst
+++ b/docs/jax.lax.rst
@@ -127,6 +127,7 @@ Operators
     scatter_max
     scatter_min
     scatter_mul
+    searchsorted
     select
     shift_left
     shift_right_arithmetic

--- a/jax/_src/lax/search.py
+++ b/jax/_src/lax/search.py
@@ -1,0 +1,190 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+import operator
+
+import numpy as np
+
+import jax
+from jax._src import ad_util
+from jax._src import api
+from jax._src import dispatch
+from jax._src import util
+from jax._src.lax import lax
+from jax._src.lax.control_flow import fori_loop
+from jax import core
+from jax import dtypes
+from jax.interpreters import ad
+from jax.interpreters import batching
+from jax.interpreters import mlir
+from jax.typing import ArrayLike
+
+
+def searchsorted(sorted_arr: ArrayLike, query: ArrayLike, *, side: str = 'left',
+                 dimension: int = 0, batch_dims: int = 0, method: str = "default"):
+  """Find indices of query values within a sorted array.
+
+  Args:
+    sorted_arr : N-dimensional array, which is assumed to be sorted in increasing
+      order along ``dimension``.
+    query : N-dimensional array of query values.
+    side : {'left', 'right'}. If 'left', find the index of the first suitable
+      location. If 'right', find the index of the last.
+    dimension : integer specifying the dimension along which to insert query values.
+    batch_dims : integer specifying the number of leading dimensions of `sorted_arr`
+      and `query` to treat as batch dimensions.
+    method : {'default', 'scan', 'sort', 'compare_all'} The method used to compute the
+      result. If left at 'default', the implementation is free to choose the method.
+
+  Returns:
+    indices : an array specifying the insertion locations of `query` into `sorted_arr`.
+  """
+  dimension = util.canonicalize_axis(dimension, np.ndim(sorted_arr))
+  batch_dims = core.concrete_or_error(operator.index, batch_dims, context="searchsorted batch_dims argument")
+  return searchsorted_p.bind(sorted_arr, query, side=side, dimension=dimension, batch_dims=batch_dims, method=method)
+
+
+def _searchsorted_abstract_eval(sorted_arr, query, *, side, dimension, batch_dims, method):
+  batch_dims = operator.index(batch_dims)
+  if batch_dims < 0:
+    raise ValueError(f"batch_dims must be a non-negative integer; got {batch_dims}")
+  if sorted_arr.dtype != query.dtype:
+    raise ValueError("dtypes of sorted_arr and query must match; got "
+                     f"{sorted_arr.dtype} and {query.dtype}")
+  if method not in ["default", "compare_all", "scan", "sort"]:
+    raise ValueError(f"invalid argument method={method!r}; expected 'default', 'scan', or 'sort'.")
+  if side not in ["left", "right"]:
+    raise ValueError(f"invalid argument side={side!r}, expected 'left' or 'right'")
+  if not batch_dims <= dimension < sorted_arr.ndim:
+    raise ValueError(f"dimension={dimension} must be in range [{batch_dims}, {sorted_arr.ndim})")
+  if sorted_arr.shape[:batch_dims] != query.shape[:batch_dims]:
+    raise ValueError(f"batch dimension sizes must match; got {sorted_arr.shape[:batch_dims]} != "
+                     f"{query.shape[:batch_dims]}")
+  shape = (*sorted_arr.shape[:batch_dims],
+           *(s for d, s in enumerate(sorted_arr.shape) if d >= batch_dims and d != dimension),
+           *(s for d, s in enumerate(query.shape) if d >= batch_dims))
+  dtype = dtypes.canonicalize_dtype(
+    np.int32 if sorted_arr.shape[dimension] < np.iinfo(np.int32).max else np.int64)
+  return core.ShapedArray(shape, dtype)
+
+
+def _searchsorted_impl(sorted_arr, query, *, side, dimension, batch_dims, method):
+  if method == "default":
+    method = "scan"  # TODO(jakevdp): choose optimal method using some heuristic?
+  if method == "scan":
+    _searchsorted = _searchsorted_scan_impl
+  elif method == "sort":
+    _searchsorted = _searchsorted_sort_impl
+  elif method == "compare_all":
+    _searchsorted = _searchsorted_compare_all_impl
+  else:
+    raise ValueError(f"invalid argument method={method!r}; expected one of "
+                     "(default, compare_all, sort, or scan)")
+  out_aval = _searchsorted_abstract_eval(sorted_arr, query, side=side, dimension=dimension,
+                                         batch_dims=batch_dims, method=method)
+  sorted_arr = batching.moveaxis(sorted_arr, dimension, -1)
+  fun = partial(_searchsorted, side=side, dtype=out_aval.dtype)
+  for _ in range(sorted_arr.ndim - batch_dims - 1):
+    fun = api.vmap(fun, in_axes=(0, None))
+  for _ in range(batch_dims):
+    fun = api.vmap(fun, in_axes=0)
+  return fun(sorted_arr, query)
+
+
+@partial(jax.jit, static_argnames=['side', 'dtype'])
+def _searchsorted_scan_impl(sorted_arr: jax.Array, query: jax.Array,
+                            side: str, dtype: type) -> jax.Array:
+  assert sorted_arr.ndim == 1
+  assert side in ['left', 'right']
+  if len(sorted_arr) == 0:
+    return lax._zeros(query, dtype=dtype)
+  if query.ndim > 0:
+    return api.vmap(partial(_searchsorted_scan_impl, side=side, dtype=dtype),
+                    in_axes=(None, 0))(sorted_arr, query)
+
+  op = lax._sort_le_comparator if side == 'left' else lax._sort_lt_comparator
+
+  def body_fun(i, state):
+    low, high = state
+    mid = (low + high) // 2
+    go_left = op(query, sorted_arr[mid])
+    return (lax.select(go_left, low, mid), lax.select(go_left, mid, high))
+
+  N, = sorted_arr.shape
+  n_levels = int(np.ceil(np.log2(N + 1)))
+  return fori_loop(0, n_levels, body_fun, (dtype.type(0), dtype.type(N)))[1]
+
+
+@partial(jax.jit, static_argnames=['side', 'dtype'])
+def _searchsorted_sort_impl(sorted_arr: jax.Array, query: jax.Array,
+                            side: str, dtype: type) -> jax.Array:
+  assert sorted_arr.ndim == 1
+  assert side in ['left', 'right']
+  working_dtype = np.int32 if sorted_arr.size + query.size < np.iinfo(np.int32).max else np.int64
+  def _rank(x):
+    idx = lax.iota(working_dtype, len(x))
+    return lax._zeros(idx).at[lax.sort_key_val(x, idx)[1]].set(idx)
+  if side == 'left':
+    index = _rank(lax.concatenate([query.ravel(), sorted_arr], 0))[:query.size]
+  else:
+    index = _rank(lax.concatenate([sorted_arr, query.ravel()], 0))[sorted_arr.size:]
+  return lax.reshape(lax.sub(index, _rank(query.ravel())), np.shape(query)).astype(dtype)
+
+
+@partial(jax.jit, static_argnames=['side', 'dtype'])
+def _searchsorted_compare_all_impl(sorted_arr: jax.Array, query: jax.Array,
+                                   side: str, dtype: type) -> jax.Array:
+  assert sorted_arr.ndim == 1
+  assert side in ['left', 'right']
+  op = lax._sort_lt_comparator if side == 'left' else lax._sort_le_comparator
+  comparisons = jax.vmap(op, in_axes=(0, None))(sorted_arr, query)
+  return comparisons.sum(dtype=dtype, axis=0)
+
+
+def _searchsorted_batch_rule(batched_args, bdims, *, side, dimension, batch_dims, method):
+  sorted_arr, query = batched_args
+  if bdims[1] is None:
+    # Only sorted_arr is batched; move batched axis to just after batch_dims.
+    sorted_arr = batching.moveaxis(sorted_arr, bdims[0], batch_dims)
+    dimension = dimension if dimension > bdims[0] else dimension + 1
+    out_bdim = batch_dims
+  elif bdims[0] is None:
+    # Only query is batched; move batched axis to just after batch_dims.
+    query = batching.moveaxis(query, bdims[1], batch_dims)
+    out_bdim = sorted_arr.ndim - 1
+  else:
+    # Both are batched; move to front and increment batch_dims.
+    sorted_arr = batching.moveaxis(sorted_arr, bdims[0], 0)
+    query = batching.moveaxis(query, bdims[1], 0)
+    dimension = dimension if dimension > bdims[0] else dimension + 1
+    batch_dims = batch_dims + 1
+    out_bdim = 0
+  batched_result = searchsorted(sorted_arr, query, side=side, dimension=dimension,
+                                batch_dims=batch_dims, method=method)
+  return batched_result, out_bdim
+
+
+def _searchsorted_jvp(primals, tangents, **kwds):
+  primal_out = searchsorted_p.bind(*primals, **kwds)
+  return primal_out, ad_util.Zero.from_value(primal_out)
+
+
+searchsorted_p = core.Primitive("searchsorted")
+searchsorted_p.def_abstract_eval(_searchsorted_abstract_eval)
+searchsorted_p.def_impl(_searchsorted_impl)
+ad.primitive_jvps[searchsorted_p] = _searchsorted_jvp
+batching.primitive_batchers[searchsorted_p] = _searchsorted_batch_rule
+mlir.register_lowering(searchsorted_p, mlir.lower_fun(_searchsorted_impl, multiple_results=False))
+dispatch.simple_impl(searchsorted_p)

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1445,6 +1445,7 @@ tf_not_yet_impl = [
     "for",
     "inspect_sharding",
     "io_callback",
+    "searchsorted",
     "shard_map",
     "global_array_to_host_local_array",
     "host_local_array_to_global_array",

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -361,6 +361,10 @@ from jax._src.lax.other import (
   conv_general_dilated_local as conv_general_dilated_local,
   conv_general_dilated_patches as conv_general_dilated_patches
 )
+from jax._src.lax.search import (
+  searchsorted as searchsorted,
+  searchsorted_p as searchsorted_p,
+)
 from jax._src.lax.ann import (
   approx_max_k as approx_max_k,
   approx_min_k as approx_min_k,

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2058,6 +2058,72 @@ class LaxTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(numpy_op, op, args_maker)
 
   @jtu.sample_product(
+      [dict(shape=shape, queryshape=queryshape, dimension=dimension, batch_dims=batch_dims)
+       for shape, queryshape, dimension, batch_dims in [
+         ((8,), (5,), 0, 0),
+         ((4, 8), (), 0, 0),
+         ((4, 8), (4, 5), 1, 1),
+       ]],
+      dtype=jtu.dtypes.floating + jtu.dtypes.integer,
+      side=["left", "right"],
+      method=["default", "sort", "scan", "compare_all"],
+  )
+  def testSearchsorted(self, shape, queryshape, dimension, batch_dims, dtype, side, method):
+    rng = jtu.rand_some_equal(self.rng())
+    def args_maker():
+      size = np.prod(shape)
+      query_size = np.prod(queryshape).astype(int)
+      buf = rng((size + query_size,), dtype)
+      return np.sort(buf[:size].reshape(shape)), buf[size:].reshape(queryshape)
+    lax_fun = partial(lax.searchsorted, batch_dims=batch_dims, dimension=dimension,
+                      side=side, method=method)
+    self._CompileAndCheck(lax_fun, args_maker)
+
+  @jtu.sample_product(
+      shape=[(0,), (8,), (10,)],
+      queryshape=[(), (5,), (4, 5)],
+      dtype=jtu.dtypes.floating + jtu.dtypes.integer,
+      side=["left", "right"],
+      method=["default", "sort", "scan"],
+  )
+  def testSearchsorted1DAgainstNumpy(self, shape, queryshape, dtype, side, method):
+    rng = jtu.rand_some_equal(self.rng())
+    def args_maker():
+      size = np.prod(shape)
+      query_size = np.prod(queryshape).astype(int)
+      buf = rng((size + query_size,), dtype)
+      return np.sort(buf[:size].reshape(shape)), buf[size:].reshape(queryshape)
+    np_fun = lambda a, v: np.searchsorted(a, v, side=side).astype('int32')
+    lax_fun = partial(lax.searchsorted, side=side, method=method)
+    self._CompileAndCheck(lax_fun, args_maker)
+    self._CheckAgainstNumpy(np_fun, lax_fun, args_maker)
+
+  def testSearchsortedAutodiff(self):
+    x = jnp.arange(5.0)
+    y = jnp.linspace(0, 5, 10).reshape(2, 5)
+
+    # Because searchsorted outputs an integer, the autodiff results should
+    # be identical to those of this function:
+    def f_ref(x, y):
+      del x
+      return jnp.zeros_like(y, dtype='int32')
+
+    # Test JVP via jacfwd
+    self.assertAllClose(
+      jax.jacfwd(lax.searchsorted, argnums=0)(x, y),
+      jax.jacfwd(f_ref, argnums=0)(x, y)
+    )
+    self.assertAllClose(
+      jax.jacfwd(lax.searchsorted, argnums=1)(x, y),
+      jax.jacfwd(f_ref, argnums=1)(x, y)
+    )
+    # Because output is an integer, test VJP directly
+    primals, vjp_fun = jax.vjp(lax.searchsorted, x, y)
+    _, vjp_fun_ref = jax.vjp(f_ref, x, y)
+    self.assertAllClose(primals, lax.searchsorted(x, y))
+    self.assertAllClose(vjp_fun(primals), vjp_fun_ref(primals))
+
+  @jtu.sample_product(
     dtype=[np.float32, np.int32, np.uint32],
     shape=[(20,), (5, 20), (2000,)],
     k=[1, 3, 12],


### PR DESCRIPTION
Re-visiting of #9108 with a slightly smaller scope.

This change adds a new primitive `jax.lax.searchsorted_p`, as well as a new function `jax.lax.searchsorted()` that provides the implementation for the existing `jax.numpy.searchsorted`. The primitive is slightly more complicated than `jax.numpy.searchsorted` in that it handles an arbitrary number of leading batch dimensions, and an arbitrary search axis for multi-dimensional inputs. Importantly, these additions make it closed under batching (that is, `vmap(searchsorted)` is always equivalent to a single call to `searchsorted`).

My reasoning for this proposal is that binary search is a reasonably common operation that cannot be straightforwardly expressed in terms of existing primitive operations (we currently have three implementations available that users can choose from), and so it makes sense to be treating `searchsorted` as a distinct operation.

There are a few benefits to this:

- jaxprs using `searchsorted` are much clearer
- Because the primitive is closed under batching, the batching rule for `searchsorted` is now trivial, where previously the implementation had to be traced op-by-op by the `BatchTracer`.
- Because `searchsorted` returns an integer index, the autodiff rule for `searchsorted` is trivial, where previously the implementation had to be traced op-by-op by the `JVPTracer`.
- this would pave the way for various backends to use more efficient `searchsorted` implementations rather than being beholden to the particular implementation in `jax.numpy`.

Here's an example of a jaxpr with this PR:
```python
In [1]: import jax
   ...: import jax.numpy as jnp
   ...: x = jnp.arange(10)
   ...: y = jnp.array([2, 4, 7])
   ...: jax.make_jaxpr(jnp.searchsorted)(x, y)
Out[1]: 
{ lambda ; a:i32[10] b:i32[3]. let
    c:i32[3] = searchsorted[batch_dims=0 dimension=0 method=default side=left] a b
  in (c,) }
```
And here's the same thing on the main branch:
```python
In [1]: import jax
   ...: import jax.numpy as jnp
   ...: x = jnp.arange(10)
   ...: y = jnp.array([2, 4, 7])
   ...: jax.make_jaxpr(jnp.searchsorted)(x, y)
Out[1]: 
{ lambda ; a:i32[10] b:i32[3]. let
    c:i32[3] = pjit[
      jaxpr={ lambda ; d:i32[10] e:i32[3]. let
          f:i32[3] = broadcast_in_dim[broadcast_dimensions=() shape=(3,)] 0
          g:i32[3] = broadcast_in_dim[broadcast_dimensions=() shape=(3,)] 10
          _:i32[] _:i32[3] h:i32[3] = scan[
            jaxpr={ lambda ; i:i32[10] j:i32[3] k:i32[] l:i32[3] m:i32[3]. let
                n:i32[] = add k 1
                o:i32[3] = add l m
                p:i32[3] = pjit[
                  jaxpr={ lambda ; q:i32[3] r:i32[]. let
                      s:i32[] = convert_element_type[
                        new_dtype=int32
                        weak_type=False
                      ] r
                      t:i32[3] = div q s
                      u:i32[3] = sign q
                      v:i32[] = sign s
                      w:bool[3] = ne u v
                      x:i32[3] = rem q s
                      y:bool[3] = ne x 0
                      z:bool[3] = and w y
                      ba:i32[3] = sub t 1
                      bb:i32[3] = pjit[
                        jaxpr={ lambda ; bc:bool[3] bd:i32[3] be:i32[3]. let
                            bf:i32[3] = select_n bc be bd
                          in (bf,) }
                        name=_where
                      ] z ba t
                    in (bb,) }
                  name=floor_divide
                ] o 2
                bg:bool[3] = lt p 0
                bh:i32[3] = add p 10
                bi:i32[3] = select_n bg p bh
                bj:i32[3,1] = broadcast_in_dim[
                  broadcast_dimensions=(0,)
                  shape=(3, 1)
                ] bi
                bk:i32[3,1] = gather[
                  dimension_numbers=GatherDimensionNumbers(offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,))
                  fill_value=None
                  indices_are_sorted=False
                  mode=GatherScatterMode.PROMISE_IN_BOUNDS
                  slice_sizes=(1,)
                  unique_indices=False
                ] i bj
                bl:i32[3] = squeeze[dimensions=(1,)] bk
                bm:bool[3] = le j bl
                bn:i32[3] = pjit[
                  jaxpr={ lambda ; bc:bool[3] bd:i32[3] be:i32[3]. let
                      bf:i32[3] = select_n bc be bd
                    in (bf,) }
                  name=_where
                ] bm l p
                bo:i32[3] = pjit[
                  jaxpr={ lambda ; bc:bool[3] bd:i32[3] be:i32[3]. let
                      bf:i32[3] = select_n bc be bd
                    in (bf,) }
                  name=_where
                ] bm p m
              in (n, bn, bo) }
            length=4
            linear=(False, False, False, False, False)
            num_carry=3
            num_consts=2
            reverse=False
            unroll=1
          ] d e 0 f g
        in (h,) }
      name=searchsorted
    ] a b
  in (c,) }
```