### PR TITLE
jnp.ufunc: add __hash__ method and jit methods by default

### DIFF
--- a/tests/lax_numpy_ufuncs_test.py
+++ b/tests/lax_numpy_ufuncs_test.py
@@ -33,14 +33,26 @@ def scalar_add(x, y):
   return x + y
 
 
+def scalar_div(x, y):
+  assert np.shape(x) == np.shape(y) == ()
+  return x / y
+
+
 def scalar_mul(x, y):
   assert np.shape(x) == np.shape(y) == ()
   return x * y
 
 
+def scalar_sub(x, y):
+  assert np.shape(x) == np.shape(y) == ()
+  return x - y
+
+
 SCALAR_FUNCS = [
   {'func': scalar_add, 'nin': 2, 'nout': 1, 'identity': 0},
+  {'func': scalar_div, 'nin': 2, 'nout': 1, 'identity': None},
   {'func': scalar_mul, 'nin': 2, 'nout': 1, 'identity': 1},
+  {'func': scalar_sub, 'nin': 2, 'nout': 1, 'identity': None},
 ]
 
 broadcast_compatible_shapes = [(), (1,), (3,), (1, 3), (4, 1), (4, 3)]
@@ -54,6 +66,34 @@ def cast_outputs(fun):
 
 
 class LaxNumpyUfuncTests(jtu.JaxTestCase):
+
+  @jtu.sample_product(SCALAR_FUNCS)
+  def test_ufunc_properties(self, func, nin, nout, identity):
+    jnp_fun = jnp.frompyfunc(func, nin=nin, nout=nout, identity=identity)
+    self.assertEqual(jnp_fun.identity, identity)
+    self.assertEqual(jnp_fun.nin, nin)
+    self.assertEqual(jnp_fun.nout, nout)
+    self.assertEqual(jnp_fun.nargs, nin)
+
+  @jtu.sample_product(SCALAR_FUNCS)
+  def test_ufunc_properties_readonly(self, func, nin, nout, identity):
+    jnp_fun = jnp.frompyfunc(func, nin=nin, nout=nout, identity=identity)
+    for attr in ['nargs', 'nin', 'nout', 'identity', '_func', '_call']:
+      getattr(jnp_fun, attr)  # no error on attribute access.
+      with self.assertRaises(AttributeError):
+        setattr(jnp_fun, attr, None)  # error when trying to mutate.
+
+  @jtu.sample_product(SCALAR_FUNCS)
+  def test_ufunc_hash(self, func, nin, nout, identity):
+    jnp_fun = jnp.frompyfunc(func, nin=nin, nout=nout, identity=identity)
+    jnp_fun_2 = jnp.frompyfunc(func, nin=nin, nout=nout, identity=identity)
+    self.assertEqual(jnp_fun, jnp_fun_2)
+    self.assertEqual(hash(jnp_fun), hash(jnp_fun_2))
+
+    other_fun = jnp.frompyfunc(jnp.add, nin=2, nout=1, identity=0)
+    self.assertNotEqual(jnp_fun, other_fun)
+    # Note: don't test hash for non-equality because it may collide.
+
   @jtu.sample_product(
       SCALAR_FUNCS,
       lhs_shape=broadcast_compatible_shapes,
@@ -124,7 +164,7 @@ class LaxNumpyUfuncTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype)]
 
     self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
-    self._CompileAndCheck(jnp_fun, args_maker, check_cache_misses=False)  # TODO(jakevdp): why the cache misses?
+    self._CompileAndCheck(jnp_fun, args_maker)
 
   @jtu.sample_product(
       SCALAR_FUNCS,
@@ -146,7 +186,7 @@ class LaxNumpyUfuncTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype), idx_rng(idx_shape, 'int32'), rng(idx_shape[1:], dtype)]
 
     self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
-    self._CompileAndCheck(jnp_fun, args_maker, check_cache_misses=False)  # TODO(jakevdp): why the cache misses?
+    self._CompileAndCheck(jnp_fun, args_maker)
 
   @jtu.sample_product(
       SCALAR_FUNCS,
@@ -167,7 +207,7 @@ class LaxNumpyUfuncTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype), idx_rng(idx_shape, 'int32')]
 
     self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
-    self._CompileAndCheck(jnp_fun, args_maker, check_cache_misses=False)  # TODO(jakevdp): why the cache misses?
+    self._CompileAndCheck(jnp_fun, args_maker)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This allows the JIT cache to work properly with ufunc methods, because bound methods are created with a new ID each time.

Followup to https://github.com/google/jax/pull/17054#discussion_r1291888689