### PR TITLE
Ignore numpy deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ filterwarnings = [
     # https://github.com/openxla/xla/commit/fb9dc3db0999bf14c78d95cb7c3aa6815221ddc7)
     "ignore:ml_dtypes.float8_e4m3b11 is deprecated.",
     "ignore:JAX_USE_PJRT_C_API_ON_TPU=false will no longer be supported.*:UserWarning",
+    "ignore:np.find_common_type is deprecated.*:DeprecationWarning",
 ]
 doctest_optionflags = [
     "NUMBER",


### PR DESCRIPTION
This is coming up when running tests under numpy 1.25.1 with scipy 1.9.3

Should fix errors like the one seen here: https://source.cloud.google.com/results/invocations/dde07b27-1a8d-42a5-ac79-c1404a9a6988/targets