### PR TITLE
Remove all testing of jax.experimental.sparse on cusparse

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1051,7 +1051,9 @@ traceback_filtering = config.define_enum_state(
 bcoo_cusparse_lowering = config.define_bool_state(
     name='jax_bcoo_cusparse_lowering',
     default=False,
-    help=('Enables lowering BCOO ops to cuSparse.'))
+    help=('Enables lowering of jax.experimental.sparse operations to cuSparse when available. '
+          'Note that due to instability in cusparse behavior across versions, these lowerings '
+          'are currently untested. Use at your own risk.'))
 
 # TODO(mattjj): remove this flag when we ensure we only succeed at trace-staging
 # if the intended backend can handle lowering the result

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -782,7 +782,7 @@ jax_test(
 jax_test(
     name = "sparse_test",
     srcs = ["sparse_test.py"],
-    args = ["--jax_bcoo_cusparse_lowering=true"],
+    args = ["--jax_bcoo_cusparse_lowering=false"],  # Cusparse lowerings fail in CUDA 12
     backend_tags = {
         "cpu": [
             "nomsan",  # Times out
@@ -817,7 +817,7 @@ jax_test(
 jax_test(
     name = "sparsify_test",
     srcs = ["sparsify_test.py"],
-    args = ["--jax_bcoo_cusparse_lowering=true"],
+    args = ["--jax_bcoo_cusparse_lowering=false"],  # Cusparse lowerings fail in CUDA 12
     backend_tags = {
         "cpu": [
             "noasan",  # Times out under asan


### PR DESCRIPTION
A number of the tests in `jax.experimental.sparse` began failing on CUDA 12. This is similar to failures that have been resulted a number of times in the past from CUDA upgrades. Due to these and similar reasons, the cusparse lowerings have been disabled by default since #13593, and in testing we currently skip a number of sparse tests for particular CUDA configurations that we know lead to failures or flakes.

Given the new CI failures introduced by CUDA 12, and the relative paucity of existing users for this experimental feature (which again has been disabled for nearly a year unless users set `jax_bcoo_cusparse_lowering=true`), it's my judgment that the best fix for these CI failures going forward will be to stop testing these code paths entirely.

At some point we should think about removing the GPU lowerings from `jax.experimental.sparse`.

Fixes #17118