### PR TITLE
Define a threefry partitionable PRNG impl

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -804,7 +804,7 @@ enable_custom_prng = config.define_bool_state(
 
 default_prng_impl = config.define_enum_state(
     name='jax_default_prng_impl',
-    enum_values=['threefry2x32', 'rbg', 'unsafe_rbg'],
+    enum_values=['threefry2x32', 'threefry2x32_partitionable', 'rbg', 'unsafe_rbg'],
     default='threefry2x32',
     help=('Select the default PRNG implementation, used when one is not '
           'explicitly provided at seeding time.'))

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -1356,6 +1356,14 @@ threefry_prng_impl = PRNGImpl(
     fold_in=threefry_fold_in,
     tag='fry')
 
+threefry_partitionable_prng_impl = PRNGImpl(
+    key_shape=(2,),
+    seed=threefry_seed,
+    split=_threefry_split_foldlike,
+    random_bits=_threefry_random_bits_partitionable,
+    fold_in=threefry_fold_in,
+    tag='fry_partitionable')
+
 
 # -- RngBitGenerator PRNG implementation
 

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -98,6 +98,7 @@ def _random_bits(key: prng.PRNGKeyArray, bit_width, shape) -> Array:
 
 PRNG_IMPLS = {
     'threefry2x32': prng.threefry_prng_impl,
+    'threefry2x32_partitionable': prng.threefry_partitionable_prng_impl,
     'rbg': prng.rbg_prng_impl,
     'unsafe_rbg': prng.unsafe_rbg_prng_impl,
 }

--- a/jax/prng.py
+++ b/jax/prng.py
@@ -21,6 +21,7 @@ from jax._src.prng import (
   threefry2x32_p as threefry2x32_p,
   threefry_2x32 as threefry_2x32,
   threefry_prng_impl as threefry_prng_impl,
+  threefry_partitionable_prng_impl as threefry_partitionable_prng_impl,
   rbg_prng_impl as rbg_prng_impl,
   unsafe_rbg_prng_impl as unsafe_rbg_prng_impl,
 )

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -67,6 +67,7 @@ def _maybe_unwrap(key):
 
 
 PRNG_IMPLS = [('threefry2x32', prng.threefry_prng_impl),
+              ('threefry2x32_partitionable', prng.threefry_partitionable_prng_impl),
               ('rbg', prng.rbg_prng_impl),
               ('unsafe_rbg', prng.unsafe_rbg_prng_impl)]
 


### PR DESCRIPTION
Previously this could only be specified via a global flag; now it can be used with
```python
jax.random.key(seed, impl='threefry2x32_partitionable')
```
The result is maybe a bit confusing, because there's still the `jax_threefry_partitionable` global configuration, which causes the default `'threefry2x32'` impl to behave like the partitionable version.

Longer term, we could think about deprecating that in favor of `jax_default_prng_impl` instead.