### PR TITLE
Fix mypy error on Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ no_implicit_optional = true
 module = [
     "absl.*",
     "colorama.*",
+    "importlib_metadata.*",
     "IPython.*",
     "numpy.*",
     "opt_einsum.*",


### PR DESCRIPTION
This fixes a mypy error I see locally:
```
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

jax/_src/xla_bridge.py:305: error: Cannot find implementation or library stub for module named "importlib_metadata"  [import]
jax/_src/xla_bridge.py:305: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 408 source files)
```
I think the reason this doesn't appear in the CI is that locally I'm using Python 3.9, while the pre-commit CI uses Python 3.11