### PR TITLE
[jax2tf] Fix for dot_general with different dtypes for graph serialization

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -21,7 +21,7 @@ import operator
 import os
 import re
 import threading
-from typing import Any, Callable, Optional, Union, cast
+from typing import Any, Callable, Optional, Tuple, Union, cast
 import warnings
 
 from absl import logging
@@ -2064,6 +2064,9 @@ def _dot_general(lhs, rhs, *, dimension_numbers,
   #   raise NotImplementedError(
   #     "dot_general with different lhs_dtype and rhs_dtype is not supported "
   #     "in non-native serialization")
+  lhs, rhs, convert_result = _dot_general_convert_to_common_dtype(
+    lhs, _in_avals[0], rhs, _in_avals[1], _out_aval)
+
   (lhs_contracting, rhs_contracting), (lhs_batch, rhs_batch) = dimension_numbers
   dnums_proto = xla_data_pb2.DotDimensionNumbers()
   dnums_proto.lhs_contracting_dimensions.extend(lhs_contracting)
@@ -2078,6 +2081,7 @@ def _dot_general(lhs, rhs, *, dimension_numbers,
       precision_config_proto,
       preferred_element_type=preferred_element_type,
       use_v2=True)
+  res = convert_result(res)
   if _WRAP_JAX_JIT_WITH_TF_FUNCTION:
     res = tf.stop_gradient(res)  # See #7839
   return res
@@ -2085,6 +2089,25 @@ def _dot_general(lhs, rhs, *, dimension_numbers,
 
 tf_impl_with_avals[lax.dot_general_p] = _dot_general
 
+def _dot_general_convert_to_common_dtype(
+  lhs: TfVal, lhs_aval: core.ShapedArray,
+  rhs: TfVal, rhs_aval: core.ShapedArray,
+  out_aval: core.ShapedArray) -> Tuple[TfVal, TfVal, Callable[[TfVal], TfVal]]:
+  # Returns the converted lhs, rhs, and the converter for the result.
+  # tfxla.dot_general does not handle arguments of different types.
+  # We convert the arguments and the result.
+  # Use native serialization for a more JAX-native behavior.
+  if lhs_aval.dtype != rhs_aval.dtype:
+
+    common_dtype = dtypes.result_type(lhs_aval, rhs_aval)
+    if common_dtype != lhs_aval.dtype:
+      lhs = _convert_element_type(lhs, new_dtype=common_dtype)
+    if common_dtype != rhs_aval.dtype:
+      rhs = _convert_element_type(rhs, new_dtype=common_dtype)
+    convert_result = lambda res: _convert_element_type(res, new_dtype=out_aval.dtype)
+  else:
+    convert_result = lambda res: res
+  return (lhs, rhs, convert_result)
 
 def _broadcast_in_dim(operand, *, shape, broadcast_dimensions,
                       _in_avals: Sequence[core.ShapedArray],


### PR DESCRIPTION
Graph serialization did not work for dot_general with different dtypes. Added a workaround by converting the operands to the smallest type that can represent both operands. This is not accurate w.r.t. what JAX native does (use native serialization for that), but avoids failures.

Added tests for these cases for enable_xla=[True|False]. Some of these tests fail, e.g., when involving x64 types for enable_xla=True and when involving certain unsupported types for enable_xla=False (uint16, int16).

Fixes: #17151