### PR TITLE
Add Kaggle TPU VM link, update Distributed Arrays and Auto Parallelization guide

### DIFF
--- a/docs/notebooks/Distributed_arrays_and_automatic_parallelization.ipynb
+++ b/docs/notebooks/Distributed_arrays_and_automatic_parallelization.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "Refer to the [`jax.Array migration`](https://jax.readthedocs.io/en/latest/jax_array_migration.html#jax-array-migration) guide to learn how to migrate the existing JAX pre-v0.4.1 codebases to `jax.Array`.\n",
     "\n",
-    "**Note:** The features required by `jax.Array` are not supported by the Colab TPU runtime at this time, but are available on Goole Cloud TPU and Kaggle TPU VMs."
+    "**Note:** The features required by `jax.Array` are not supported by the Colab TPU runtime at this time, but are available on Google Cloud TPU and Kaggle TPU VMs."
    ]
   },
   {
@@ -49,7 +49,7 @@
     "id": "eyHMwyEfQJcz"
    },
    "source": [
-    "⚠️ WARNING: notebook requires 8 devices to run."
+    "⚠️ WARNING: The notebook requires 8 devices to run."
    ]
   },
   {

--- a/docs/notebooks/Distributed_arrays_and_automatic_parallelization.ipynb
+++ b/docs/notebooks/Distributed_arrays_and_automatic_parallelization.ipynb
@@ -15,11 +15,13 @@
     "id": "pFtQjv4SzHRj"
    },
    "source": [
-    "**This tutorial discusses parallelism via `jax.Array`, the unified array object model available in JAX v0.4.1 and newer.**\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/main/docs/notebooks/Distributed_arrays_and_automatic_parallelization.ipynb) [![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/google/jax/blob/main/docs/notebooks/Distributed_arrays_and_automatic_parallelization.ipynb)\n",
     "\n",
-    "See [`jax-array-migration`](https://jax.readthedocs.io/en/latest/jax_array_migration.html#jax-array-migration) guide for migrating existing pre-v0.4.1 codebases to `jax.Array`.\n",
+    "This tutorial discusses parallelism via `jax.Array`, the unified array object model available in JAX v0.4.1 and newer.\n",
     "\n",
-    "**The features required by `jax.Array` are not supported by the Colab TPU runtime at this time, but are available on Cloud TPU.**"
+    "Refer to the [`jax.Array migration`](https://jax.readthedocs.io/en/latest/jax_array_migration.html#jax-array-migration) guide to learn how to migrate the existing JAX pre-v0.4.1 codebases to `jax.Array`.\n",
+    "\n",
+    "**Note:** The features required by `jax.Array` are not supported by the Colab TPU runtime at this time, but are available on Goole Cloud TPU and Kaggle TPU VMs."
    ]
   },
   {

--- a/docs/notebooks/Distributed_arrays_and_automatic_parallelization.md
+++ b/docs/notebooks/Distributed_arrays_and_automatic_parallelization.md
@@ -23,7 +23,7 @@ This tutorial discusses parallelism via `jax.Array`, the unified array object mo
 
 Refer to the [`jax.Array migration`](https://jax.readthedocs.io/en/latest/jax_array_migration.html#jax-array-migration) guide to learn how to migrate the existing JAX pre-v0.4.1 codebases to `jax.Array`.
 
-**Note:** The features required by `jax.Array` are not supported by the Colab TPU runtime at this time, but are available on Goole Cloud TPU and Kaggle TPU VMs.
+**Note:** The features required by `jax.Array` are not supported by the Colab TPU runtime at this time, but are available on Google Cloud TPU and Kaggle TPU VMs.
 
 ```{code-cell}
 :id: FNxScTfq3vGF
@@ -41,7 +41,7 @@ import jax.numpy as jnp
 
 +++ {"id": "eyHMwyEfQJcz"}
 
-⚠️ WARNING: notebook requires 8 devices to run.
+⚠️ WARNING: The notebook requires 8 devices to run.
 
 ```{code-cell}
 :id: IZMLqOUV3vGG

--- a/docs/notebooks/Distributed_arrays_and_automatic_parallelization.md
+++ b/docs/notebooks/Distributed_arrays_and_automatic_parallelization.md
@@ -17,11 +17,13 @@ kernelspec:
 
 +++ {"id": "pFtQjv4SzHRj"}
 
-**This tutorial discusses parallelism via `jax.Array`, the unified array object model available in JAX v0.4.1 and newer.**
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/main/docs/notebooks/Distributed_arrays_and_automatic_parallelization.ipynb) [![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/google/jax/blob/main/docs/notebooks/Distributed_arrays_and_automatic_parallelization.ipynb)
 
-See [`jax-array-migration`](https://jax.readthedocs.io/en/latest/jax_array_migration.html#jax-array-migration) guide for migrating existing pre-v0.4.1 codebases to `jax.Array`.
+This tutorial discusses parallelism via `jax.Array`, the unified array object model available in JAX v0.4.1 and newer.
 
-**The features required by `jax.Array` are not supported by the Colab TPU runtime at this time, but are available on Cloud TPU.**
+Refer to the [`jax.Array migration`](https://jax.readthedocs.io/en/latest/jax_array_migration.html#jax-array-migration) guide to learn how to migrate the existing JAX pre-v0.4.1 codebases to `jax.Array`.
+
+**Note:** The features required by `jax.Array` are not supported by the Colab TPU runtime at this time, but are available on Goole Cloud TPU and Kaggle TPU VMs.
 
 ```{code-cell}
 :id: FNxScTfq3vGF


### PR DESCRIPTION
Similar to the Parallel Evaluation in JAX (101) guide (https://jax.readthedocs.io/en/latest/jax-101/06-parallelism.html), updating the Distributed Arrays and Automatic Parallelization guide:

- Add Open in Colab and Open in Kaggle links (for modern TPU VMs)
- Update the guide to mention Kaggle TPUs:

> **Note:** The features required by `jax.Array` are not supported by the Colab TPU runtime at this time, but are available on Goole Cloud TPU and Kaggle TPU VMs.