### PR TITLE
Update JAX README - add `shard_map` information (`pmap` deprecation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ are instances of such transformations. Others are
 [`pmap`](#spmd-programming-with-pmap) for single-program multiple-data (SPMD)
 parallel programming of multiple accelerators, with more to come.
 
+**Note**: Try `shard_map` (a.k.a. `shmap`) - a new more flexible API that supersedes
+`jax.pmap`. Check out the `jax.experimental.shard_map`
+[JAX Enhancement Proposal (JEP) to learn more](https://jax.readthedocs.io/en/latest/jep/14273-shard-map.html).
+
 This is a research project, not an official Google product. Expect bugs and
 [sharp edges](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html).
 Please help by trying it out, [reporting
@@ -99,7 +103,8 @@ notebooks](https://github.com/google/jax/tree/main/docs/notebooks).
 
 At its core, JAX is an extensible system for transforming numerical functions.
 Here are four transformations of primary interest: `grad`, `jit`, `vmap`, and
-`pmap`.
+`pmap` (Update: check out a note on `shard_map` - a new more flexible API that supersedes `pmap`
+- above, or simply read the [JEP document](https://jax.readthedocs.io/en/latest/jep/14273-shard-map.html)).
 
 ### Automatic differentiation with `grad`
 


### PR DESCRIPTION
`jax.experimental.shard_map` supersedes `jax.pmap` (and `jax.xmap`) for SPMD.

This PR updates the JAX README to add information about `shard_map`, including the `shmap` JEP (https://jax.readthedocs.io/en/latest/jep/14273-shard-map.html).

A typical banner would look like this:

```
**Note**: Try `shard_map` (a.k.a. `shmap`) - a new more flexible API that supersedes
`jax.pmap`. Check out the `jax.experimental.shard_map`
[JAX Enhancement Proposal (JEP) to learn more](https://jax.readthedocs.io/en/latest/jep/14273-shard-map.html).
```

Future PRs: Update the rest of the docs by adding a similar banner after `pmap`. 

@jakevdp @mattjj @skye PTAL