### PR TITLE
Deprecate jax.numpy.row_stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Remember to align the itemized text with the first line of an item within a list
     * `jax.numpy.NINF` has been deprecated. Use `-jax.numpy.inf` instead.
     * `jax.numpy.PZERO` has been deprecated. Use `0.0` instead.
     * `jax.numpy.NZERO` has been deprecated. Use `-0.0` instead.
+    * `jax.numpy.issubsctype(x, t)` has been deprecated. Use `jax.numpy.issubdtype(x.dtype, t)`.
+    * `jax.numpy.row_stack` has been deprecated. Use `jax.numpy.vstack` instead.
   * `jax.scipy.linalg.tril` and `jax.scipy.linalg.triu` have been deprecated,
     following SciPy. Use `jax.numpy.tril` and `jax.numpy.triu` instead.
 

--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -340,7 +340,6 @@ namespace; they are listed below.
     rot90
     round
     round_
-    row_stack
     s_
     save
     savez

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1868,7 +1868,6 @@ def vstack(tup: np.ndarray | Array | Sequence[ArrayLike],
   else:
     arrs = [atleast_2d(m) for m in tup]
   return concatenate(arrs, axis=0, dtype=dtype)
-row_stack = vstack
 
 
 @util._wraps(np.hstack)

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -206,7 +206,6 @@ from jax._src.numpy.lax_numpy import (
     rot90 as rot90,
     round as round,
     round_ as round_,
-    row_stack as row_stack,
     save as save,
     savez as savez,
     searchsorted as searchsorted,
@@ -464,7 +463,12 @@ _deprecations = {
     "issubsctype": (
         "jax.numpy.issubsctype is deprecated. In most cases, jax.numpy.issubdtype can be used instead.",
         _numpy.core.numerictypes.issubsctype,
-    )
+    ),
+    # Added Aug 22, 2023
+    "row_stack": (
+        "jax.numpy.row_stack is deprecated. Use jax.numpy.vstack instead.",
+        vstack,
+    ),
 }
 
 import typing
@@ -472,6 +476,7 @@ if typing.TYPE_CHECKING:
   alltrue = all
   cumproduct = cumprod
   product = prod
+  row_stack = vstack
   sometrue = any
   NINF = -inf
   NZERO = -0.0

--- a/jax/numpy/__init__.pyi
+++ b/jax/numpy/__init__.pyi
@@ -318,7 +318,7 @@ roots: Any
 rot90: Any
 round: Any
 round_: Any
-row_stack: Any
+row_stack: Any  # TODO(jakevdp): remove this
 s_: Any
 save: Any
 savez: Any


### PR DESCRIPTION
Mirroring the deprecation in [NumPy NEP-52](https://numpy.org/neps/nep-0052-python-api-cleanup.html).