### PR TITLE
Default to PJRT TPU runtime instead of StreamExecutor on older jaxlibs.

### DIFF
--- a/jax/_src/cloud_tpu_init.py
+++ b/jax/_src/cloud_tpu_init.py
@@ -76,3 +76,6 @@ def cloud_tpu_init() -> None:
         "JAX_USE_PJRT_C_API_ON_TPU no longer has an effect (the new TPU "
         "runtime is always enabled now). Unset the environment variable "
         "to disable this warning.")
+
+  # Remove when minimum jaxlib version is >= 0.4.15
+  os.environ['JAX_USE_PJRT_C_API_ON_TPU'] = "true"


### PR DESCRIPTION
I messed up the forwards compat in
https://github.com/google/jax/commit/3e50fea29edb6b78426dde511414429f2d2fddf8. The next jaxlib release won't need the env var at all, but jaxlib 0.4.14 and older still do.