### PR TITLE
Fix tolerance on bernoulli test

### DIFF
--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -194,7 +194,7 @@ class LaxScipySpcialFunctionsTest(jtu.JaxTestCase):
     lax_op = functools.partial(lsp_special.bernoulli, n)
     args_maker = lambda: []
     self._CheckAgainstNumpy(scipy_op, lax_op, args_maker, atol=0, rtol=1E-5)
-    self._CompileAndCheck(lax_op, args_maker)
+    self._CompileAndCheck(lax_op, args_maker, atol=0, rtol=1E-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Should address some Kokoro GPU failures introduced by #17253