### PR TITLE
Updated versions of pre-commit hooks and modified files accordingly.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.4.0
   hooks:
   - id: end-of-file-fixer
     # only include python files
@@ -22,12 +22,12 @@ repos:
     files: \.py$
 
 - repo: https://github.com/pycqa/flake8
-  rev: '6.0.0'
+  rev: '6.1.0'
   hooks:
   - id: flake8
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v1.5.0'
+  rev: 'v1.5.1'
   hooks:
   - id: mypy
     files: (jax/|tests/typing_test\.py)


### PR DESCRIPTION
### Description
In the `.pre-commit-config.yaml` file, versions of most of the hooks are not the latest releases. So, I have updated each of them one by one and also ran `pre-commit run --all-files` command to fix/update all the files accordingly.
1. [pre-commit-hooks new release](https://github.com/pre-commit/pre-commit-hooks/releases/tag/v4.4.0)
2. [mirrors-mypy new release](https://github.com/pre-commit/mirrors-mypy/tags)
3. [flake8 new release](https://github.com/PyCQA/flake8/tags).

When I ran `pre-commit run --all-files` I was surprised that these new versions did not updated/reformatted many files in the repository. All the code is already following the rules of latest versions of these hooks.