### PR TITLE
fix(pallas): flash attention tiled iteration upper bound too small when `block_q > block_k`

### DIFF
--- a/jax/experimental/pallas/ops/attention.py
+++ b/jax/experimental/pallas/ops/attention.py
@@ -108,7 +108,8 @@ def mha_forward_kernel(
     acc = acc + pl.dot(p.astype(v.dtype), v)
     return acc, m_curr, l_curr
   if causal:
-    upper_bound = lax.div(block_q * start_q, block_k) + 1
+    # Ceildiv (`pl.cdiv` and `//` do not work due to type of start_q)
+    upper_bound = lax.div(block_q * (start_q + 1) + block_k - 1, block_k)
   else:
     upper_bound = pl.cdiv(seq_len, block_k)  # type: ignore
   acc, m_i, l_i = lax.fori_loop(0, upper_bound, body,


### PR DESCRIPTION
https://github.com/google/jax/blob/36cdafdcf400e5f201ebffe94c9d048c5d2ae952/jax/experimental/pallas/ops/attention.py#L80
- For reference: https://github.com/openai/triton/blob/5f448b2f085f554aaf291db07d18f7b16942d21f/python/triton/ops/flash_attention.py#L74
- When `block_q` > `block_k`, the bound is too small. Consider `start_q = 1, block_q = 3, block_k = 1`. As implemented, this would yield 4 iterations. However, what is actually required is `cdiv((block_q * (start_q + 1)), block_k) == 6` 

Originally identified: https://github.com/google/jax/issues/17267

---

Added regression test that fails on master:
`
tests/pallas/pallas_test.py::FusedAttentionTest::test_fused_attention_fwd_batch_size=1_seq_len=384_num_heads=8_head_dim=64_causal=True_use_fwd=True_kwargs={'block_q': 128, 'block_k': 64} FAILED [ 55%]
`

CC: @sharadmv 