### PR TITLE
[export] Implement the calling convention for exporting with multi-platform lowering

### DIFF
--- a/jax/experimental/jax2tf/tests/back_compat_test_util.py
+++ b/jax/experimental/jax2tf/tests/back_compat_test_util.py
@@ -321,6 +321,7 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
         in_shardings=(pxla.UNSPECIFIED,) * len(in_avals),
         out_shardings=(pxla.UNSPECIFIED,) * len(out_avals),
         lowering_platform=data.platform,
+        lowering_platforms=(data.platform,),
         disabled_checks=(),
         mlir_module_serialized=data.mlir_module_serialized,
         serialization_version=data.xla_call_module_version,


### PR DESCRIPTION

This is a first step towards supporting multi-platform exported JAX modules. Such modules are usable on more than one platform, and take an additional first argument that encodes the actual compilation platform as an index into the sequence of platforms for which the module was lowered. More details about the calling convention are in the docstring for jax_export.Exported in this PR.

The value of the platform index is set by `jax_export.call_exported` when calling from JAX, and in the tf.XlaCallModule prior to compilation, when called from TensorFlow. This is already implemented in tf.XlaCallModule.

This PR has some incomplete pieces:

  * Currently we actually lower only for the first platform specified, and the platform argument is not used. There are a couple of implementation strategies for actual multi-platform lowering, both using the same calling convention. We could lower separately for each platform and put the results together with one top-level conditional. Alternatively, we can take advantage of the fact that few primitives have per-platform lowering; we could lower those using a conditional.
  * we implement multi-platform lowering only for jax_export, not for regular JAX jit or AOT lowering. This ensure that this change is narrowly scoped and safe for most JAX usage.
  * we abuse the `_experimental_lowering_platform` kwarg to `lower()` to pass a tuple of platforms when we want multi-platform lowering. We ought to rename it to `_experimental_lowering_platforms`, but that requires more plumbing.
  * we take advantage of the fact that the lowering for the platform index is identical to that for dimension variables: add a new argument to inner functions and pass the values to callees. We implement platform index as a dimension variable.
  * we do not yet have the connection with jax2tf.convert.