### PR TITLE
Turn down jax_persistent_cache_min_compile_time_secs logging from info to debug.

### DIFF
--- a/jax/_src/compiler.py
+++ b/jax/_src/compiler.py
@@ -332,13 +332,13 @@ def _cache_write(cache_key: str,
   min_compile_time = config.jax_persistent_cache_min_compile_time_secs
   if min_compile_time:
     if compile_time_secs < min_compile_time:
-      logger.info(
+      logger.debug(
           "Not writing persistent cache entry for '%s' because it took < %.2f "
           "seconds to compile (%.2fs)", module_name, min_compile_time,
           compile_time_secs)
       return
     else:
-      logger.info(
+      logger.debug(
           "'%s' took at least %.2f seconds to compile (%.2fs), writing "
           "persistent cache entry", module_name, min_compile_time,
           compile_time_secs)


### PR DESCRIPTION
It's very noisy otherwise, since jax usually produces many small computations that aren't cached.