### PR TITLE
jax.tree_util: use standard deprecation framework for deprecated items

### DIFF
--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -22,7 +22,6 @@ from functools import partial
 import operator as op
 import textwrap
 from typing import Any, Callable, NamedTuple, Type, TypeVar, Union, overload
-import warnings
 
 from jax._src import traceback_util
 from jax._src.lib import pytree
@@ -541,8 +540,6 @@ def _equality_errors(path, t1, t2, is_leaf):
     yield from _equality_errors((*path, k), c1, c2, is_leaf)
 
 
-# TODO(ivyzheng): Remove old APIs when all users migrated.
-
 class _DeprecatedKeyPathEntry(NamedTuple):
   key: Any
 
@@ -560,13 +557,6 @@ class AttributeKeyPathEntry(_DeprecatedKeyPathEntry):
     return f'.{self.key}'
   def __str__(self):
     return self.pprint()
-
-class FlattenedKeyPathEntry(_DeprecatedKeyPathEntry):  # fallback
-  def pprint(self) -> str:
-    return f'[<flat index {self.key}>]'
-  def __str__(self):
-    return self.pprint()
-
 
 @dataclass(frozen=True)
 class SequenceKey():
@@ -623,15 +613,6 @@ def register_keypaths(
 
   Only works if the type was already registered with ``register_pytree_node``.
   """
-  warnings.warn(
-      (
-          "jax.tree_util.register_keypaths is deprecated, and will be removed"
-          " in a future release. Please use `register_pytree_with_keys()`"
-          " instead."
-      ),
-      category=FutureWarning,
-      stacklevel=2,
-  )
   _register_keypaths(ty, handler)
 
 

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -67,8 +67,36 @@ from jax._src.tree_util import (
   GetAttrKey as GetAttrKey,
   FlattenedIndexKey as FlattenedIndexKey,
   register_static as register_static,
-  # TODO(ivyzheng): Remove these old APIs after June 10 2023.
-  register_keypaths,
-  AttributeKeyPathEntry,
-  GetitemKeyPathEntry,
+  register_keypaths as _deprecated_register_keypaths,
+  AttributeKeyPathEntry as _DeprecatedAttributeKeyPathEntry,
+  GetitemKeyPathEntry as _DeprecatedGetitemKeyPathEntry,
 )
+
+
+_deprecations = {
+    # Added August 29, 2023; emitted warning since March 10, 2023
+    "register_keypaths": (
+        "jax.tree_util.register_keypaths is deprecated. Use register_pytree_with_keys instead",
+        _deprecated_register_keypaths,
+    ),
+    # Added August 29, 2023:
+    "AttributeKeyPathEntry": (
+        "jax.tree_util.AttributeKeyPathEntry is deprecated. Use `SequenceKey` or `DictKey` instead.",
+        _DeprecatedAttributeKeyPathEntry,
+    ),
+    "GetitemKeyPathEntry": (
+        "jax.scipy.linalg.triu is deprecated. Use `SequenceKey` or `DictKey` instead.",
+        _DeprecatedGetitemKeyPathEntry,
+    ),
+}
+
+import typing
+if typing.TYPE_CHECKING:
+  register_keypaths = _deprecated_register_keypaths
+  AttributeKeyPathEntry = _DeprecatedAttributeKeyPathEntry
+  GetitemKeyPathEntry = _DeprecatedGetitemKeyPathEntry
+else:
+  from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
+  __getattr__ = _deprecation_getattr(__name__, _deprecations)
+  del _deprecation_getattr
+del typing


### PR DESCRIPTION
This will make it easier to finalize the deprecations using existing utilities.