### PR TITLE
typing: annotate NumpyComplexWarning

### DIFF
--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -588,7 +588,7 @@ else:
 
 try:
   # numpy 1.25.0 or newer
-  NumpyComplexWarning = np.exceptions.ComplexWarning
+  NumpyComplexWarning: type[Warning] = np.exceptions.ComplexWarning
 except AttributeError:
   # legacy numpy
   NumpyComplexWarning = np.ComplexWarning


### PR DESCRIPTION
I found the lack of this annotation leading to errors with some mypy configurations:
```
jax/_src/util.py:594: error: Cannot assign multiple types to name "NumpyComplexWarning" without an explicit "Type[...]" annotation  [misc]
```