### PR TITLE
Flexible Type Annotation for jax.lax.scan Function - Fixes #17405

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -55,6 +55,7 @@ from jax._src.traceback_util import api_boundary
 from jax._src.util import (partition_list, safe_map, safe_zip, split_list,
                            unzip2, weakref_lru_cache, merge_lists)
 import numpy as np
+from typing import Any, Callable, Optional, Tuple
 
 from jax._src.lax.control_flow.common import (
     _abstractify, _avals_short, _check_tree_and_avals, _initial_style_jaxpr,

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -97,15 +97,15 @@ def _promote_weak_typed_inputs(in_vals, in_avals, out_avals):
 
 Carry = TypeVar('Carry')
 X = TypeVar('X')
-Y = TypeVar('Y')
+Any = TypeVar('Any')
 
 @api_boundary
-def scan(f: Callable[[Carry, X], tuple[Carry, Y]],
+def scan(f: Callable[[Carry, X], Tuple[Carry, Any]],
          init: Carry,
          xs: X,
          length: Optional[int] = None,
          reverse: bool = False,
-         unroll: int = 1) -> tuple[Carry, Y]:
+         unroll: int = 1) -> Tuple[Carry, Any]:
   """Scan a function over leading array axes while carrying along state.
 
   The `Haskell-like type signature`_ in brief is


### PR DESCRIPTION
What does this PR do?

fix : #17405

This pull request addresses issue #17405, which concerns the type annotation for the jax.lax.scan function in the JAX library. The issue pointed out that the existing type annotation was not accurate when the function f returned different types, especially when it returned Python scalar types.

To resolve this issue, this pull request introduces a more flexible type annotation for the jax.lax.scan function. Instead of specifying a fixed type for the return value, we use Any for the type of Y. This change acknowledges the inherent variability in the return type of f and ensures that the type annotation is more inclusive and representative of real-world usage.

By using Any for Y, we avoid overly restrictive type annotations that might lead to type errors in cases where f returns Python scalar types, while still maintaining type safety for common cases where Y represents an array with an unspecified number of dimensions.

This change aims to make the type annotation for jax.lax.scan more accurate and compatible with various use cases, ultimately improving the developer experience when working with JAX.

Changes Made:

Updated the type annotation for the jax.lax.scan function by changing the type of Y from a specific type to Any, allowing for more flexibility in handling different return types from the function f.