### PR TITLE
Remove stale references to //jaxlib:setup.cfg in Bazel build.

### DIFF
--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -97,7 +97,6 @@ symlink_files(
 exports_files([
     "README.md",
     "setup.py",
-    "setup.cfg",
 ])
 
 cc_library(

--- a/jaxlib/tools/BUILD.bazel
+++ b/jaxlib/tools/BUILD.bazel
@@ -30,7 +30,6 @@ py_binary(
         "//jaxlib",
         "//jaxlib:README.md",
         "//jaxlib:setup.py",
-        "//jaxlib:setup.cfg",
         "@xla//xla/python:xla_client",
     ] + if_windows([
         "//jaxlib/mlir/_mlir_libs:jaxlib_mlir_capi.dll",


### PR DESCRIPTION
Fixes broken jaxlib wheel build.