### PR TITLE
[jax_export] Add the next part of multi-platform lowering support.

### DIFF
--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -2219,7 +2219,7 @@ def lower_mesh_computation(
           closed_jaxpr,
           ordered_effects=ordered_effects,
           backend_or_name=backend,
-          platform=lowering_parameters.platforms or backend.platform,
+          platform=lowering_parameters.override_platform or backend.platform,
           axis_context=axis_ctx,
           name_stack=name_stack,
           donated_args=donated_invars,


### PR DESCRIPTION
We change the lowering rule selection code to work when
`ModuleContext.lowering_parameters.platforms` contains multiple
platforms, and emit conditional code to select the lowering based on the
platform index argument.

These changes will not affect the normal JAX lowering paths (when
`ModuleContext.lowering_parameters.platforms` is `None`). It will
also not affect the JAX native serialization paths for single
platform lowering. This means the new code should only affect
tests.

These changes should work for most primitives, with the exception
of the few ones that actually access `ModuleContext.platform` inside
the lowering rules (most primitives just register different
rules for different platforms, which is taken into account by
these changes). A future CL will add tests for all primitives.

Previous PR in this series: #17316.