### PR TITLE
build: write appropriate version strings to build artifacts

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager, ExitStack
@@ -1288,3 +1289,33 @@ def register_event_duration_listener(callback):
     yield
   finally:
     monitoring._unregister_event_duration_listener_by_callback(callback)
+
+
+@contextmanager
+def set_env(**kwargs):
+  """Context manager to temporarily set/unset one or more environment variables.
+
+  Example:
+
+    >>> import os
+    >>> os.environ['my_var'] = 'original'
+
+    >>> with set_env(my_var=None, other_var='some_value'):
+    ...   print("my_var is set:", 'my_var' in os.environ)
+    ...   print("other_var =", os.environ['other_var'])
+    ...
+    my_var is set: False
+    other_var = some_value
+
+    >>> os.environ['my_var']
+    'original'
+    >>> 'other_var' in os.environ
+    False
+  """
+  original = {key: os.environ.pop(key, None) for key in kwargs}
+  os.environ.update({k: v for k, v in kwargs.items() if v is not None})
+  try:
+    yield
+  finally:
+    _ = [os.environ.pop(key, None) for key in kwargs]
+    os.environ.update({k: v for k, v in original.items() if v is not None})

--- a/jax/version.py
+++ b/jax/version.py
@@ -14,18 +14,105 @@
 
 # This file is included as part of both jax and jaxlib. It is also
 # eval()-ed by setup.py, so it should not have any dependencies.
+from __future__ import annotations
 
-import os
 import datetime
+import os
+import pathlib
+import subprocess
 
 _version = "0.4.16"
+# The following line is overwritten by build scripts in distributions &
+# releases. Do not modify this manually, or jax/jaxlib build will fail.
+_release_version: str | None = None
 
-if os.environ.get('JAX_RELEASE') or os.environ.get('JAXLIB_RELEASE'):
-  __version__ = _version
-else:
-  datestring = datetime.datetime.now().strftime('%Y%m%d')
-  __version__ = f'{_version}.dev{datestring}'
 
+def _get_version_string() -> str:
+  # The build/source distribution for jax & jaxlib overwrites _release_version.
+  # In this case we return it directly.
+  if _release_version is not None:
+    return _release_version
+  try:
+    return _version_from_git_tree(_version)
+  except:
+    return _version_from_todays_date(_version)
+
+
+def _version_from_todays_date(base_version: str) -> str:
+  datestring = datetime.date.today().strftime("%Y%m%d")
+  return f"{base_version}.dev{datestring}"
+
+
+def _version_from_git_tree(base_version: str) -> str:
+  stdout = subprocess.check_output(["git", "show", "-s", "--format=%at", "HEAD"])
+  timestamp = int(stdout.decode().strip())
+  datestring = datetime.date.fromtimestamp(timestamp).strftime("%Y%m%d")
+  assert datestring.isnumeric()
+
+  stdout = subprocess.check_output(["git", "describe", "--long", "--always"])
+  commit_hash = stdout.decode().strip().rsplit('-', 1)[-1]
+  assert commit_hash.isalnum()
+
+  return f"{base_version}.dev{datestring}+{commit_hash}"
+
+
+def _get_version_for_build() -> str:
+  """Determine the version at build time.
+
+  The returned version string depends on which environment variables are set:
+  - if JAX_RELEASE or JAXLIB_RELEASE are set: version looks like "0.4.16"
+  - if JAX_NIGHTLY or JAXLIB_NIGHTLY are set: version looks like "0.4.16.dev20230906"
+  - if none are set: version looks like "0.4.16.dev20230906+ge58560fdc
+  """
+  if _release_version is not None:
+    return _release_version
+  if os.environ.get('JAX_NIGHTLY') or os.environ.get('JAXLIB_NIGHTLY'):
+    return _version_from_todays_date(_version)
+  if os.environ.get('JAX_RELEASE') or os.environ.get('JAXLIB_RELEASE'):
+    return _version
+  try:
+    return _version_from_git_tree(_version)
+  except:
+    # Fallback to date string if git is not available.
+    return _version_from_todays_date(_version)
+
+
+def _write_version(fname: str) -> None:
+  """Used by setup.py to write the specified version info into the source tree."""
+  release_version = _get_version_for_build()
+  old_version_string = "release_version: str | None = None"
+  new_version_string = f"release_version: str = {str(release_version)!r}"
+  fhandle = pathlib.Path(fname)
+  contents = fhandle.read_text()
+  # Expect two occurrances: one above, and one here.
+  if contents.count(old_version_string) != 2:
+    raise RuntimeError(f"Build: could not find {old_version_string!r} in {fname}")
+  contents = contents.replace(old_version_string, new_version_string)
+  fhandle.write_text(contents)
+
+
+def _get_cmdclass(pkg_source_path):
+  from setuptools.command.build_py import build_py as build_py_orig  # pytype: disable=import-error
+  from setuptools.command.sdist import sdist as sdist_orig  # pytype: disable=import-error
+
+  class _build_py(build_py_orig):
+    def run(self):
+      super().run()
+      if _release_version is None:
+        _write_version(os.path.join(self.build_lib, pkg_source_path,
+                                    os.path.basename(__file__)))
+
+  class _sdist(sdist_orig):
+    def make_release_tree(self, base_dir, files):
+      super().make_release_tree(base_dir, files)
+      if _release_version is None:
+        _write_version(os.path.join(base_dir, pkg_source_path,
+                                    os.path.basename(__file__)))
+
+  return dict(sdist=_sdist, build_py=_build_py)
+
+
+__version__ = _get_version_string()
 _minimum_jaxlib_version = "0.4.14"
 
 def _version_as_tuple(version_str):

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -12,15 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+import os
 from setuptools import setup
 from setuptools.dist import Distribution
-import os
 
 __version__ = None
 project_name = 'jaxlib'
 
-with open('jaxlib/version.py') as f:
-  exec(f.read(), globals())
+def load_version_module(pkg_path):
+  spec = importlib.util.spec_from_file_location(
+    'version', os.path.join(pkg_path, 'version.py'),
+  )
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+_version_module = load_version_module(project_name)
+__version__ = _version_module._get_version_for_build()
+_cmdclass = _version_module._get_cmdclass(project_name)
 
 with open('README.md') as f:
   _long_description = f.read()
@@ -43,6 +52,7 @@ class BinaryDistribution(Distribution):
 setup(
     name=project_name,
     version=__version__,
+    cmdclass=_cmdclass,
     description='XLA library for JAX',
     long_description=_long_description,
     long_description_content_type='text/markdown',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ module = [
     "pytest.*",
     "zstandard.*",
     "jax.experimental.jax2tf.tests.flax_models",
-    "jax.experimental.jax2tf.tests.back_compat_testdata"
+    "jax.experimental.jax2tf.tests.back_compat_testdata",
+    "setuptools.*",
 ]
 ignore_missing_imports = true
 

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 from distutils import spawn
-import subprocess
+import importlib
 import os
+import subprocess
 import sys
 
 from setuptools import setup, find_packages
+
+project_name = 'jax'
 
 _current_jaxlib_version = '0.4.15'
 # The following should be updated with each new jaxlib release.
@@ -27,11 +30,17 @@ _default_cuda11_cudnn_version = '86'
 _default_cuda12_cudnn_version = '89'
 _libtpu_version = '0.1.dev20230830'
 
-_dct = {}
-with open('jax/version.py', encoding='utf-8') as f:
-  exec(f.read(), _dct)
-__version__ = _dct['__version__']
-_minimum_jaxlib_version = _dct['_minimum_jaxlib_version']
+def load_version_module(pkg_path):
+  spec = importlib.util.spec_from_file_location(
+    'version', os.path.join(pkg_path, 'version.py'),
+  )
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+_version_module = load_version_module(project_name)
+__version__ = _version_module._get_version_for_build()
+_cmdclass = _version_module._get_cmdclass(project_name)
+_minimum_jaxlib_version = _version_module._minimum_jaxlib_version
 
 with open('README.md', encoding='utf-8') as f:
   _long_description = f.read()
@@ -52,8 +61,9 @@ generate_proto("jax/experimental/australis/executable.proto")
 generate_proto("jax/experimental/australis/petri.proto")
 
 setup(
-    name='jax',
+    name=project_name,
     version=__version__,
+    cmdclass=_cmdclass,
     description='Differentiate, compile, and transform Numpy code.',
     long_description=_long_description,
     long_description_content_type='text/markdown',

--- a/tests/version_test.py
+++ b/tests/version_test.py
@@ -12,14 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import unittest
 
 from absl.testing import absltest
 
+import jax
 from jax._src.lib import check_jaxlib_version
+from jax._src import test_util as jtu
 
 
 class JaxVersionTest(unittest.TestCase):
+
+  def testBuildVersion(self):
+    base_version = jax.version._version
+
+    if jax.version._release_version is not None:
+      version = jax.version._get_version_for_build()
+      self.assertEqual(version, jax.version._release_version)
+    else:
+      with jtu.set_env(JAX_RELEASE=None, JAXLIB_RELEASE=None,
+                      JAX_NIGHTLY=None, JAXLIB_NIGHTLY=None):
+        version = jax.version._get_version_for_build()
+        # TODO(jakevdp): confirm that this includes a date string & commit hash?
+        self.assertTrue(version.startswith(f"{base_version}.dev"))
+
+      with jtu.set_env(JAX_RELEASE=None, JAXLIB_RELEASE=None,
+                      JAX_NIGHTLY="1", JAXLIB_NIGHTLY=None):
+        version = jax.version._get_version_for_build()
+        datestring = datetime.date.today().strftime("%Y%m%d")
+        self.assertEqual(version, f"{base_version}.dev{datestring}")
+
+      with jtu.set_env(JAX_RELEASE=None, JAXLIB_RELEASE=None,
+                      JAX_NIGHTLY=None, JAXLIB_NIGHTLY="1"):
+        version = jax.version._get_version_for_build()
+        datestring = datetime.date.today().strftime("%Y%m%d")
+        self.assertEqual(version, f"{base_version}.dev{datestring}")
+
+      with jtu.set_env(JAX_RELEASE="1", JAXLIB_RELEASE=None,
+                      JAX_NIGHTLY=None, JAXLIB_NIGHTLY=None):
+        version = jax.version._get_version_for_build()
+        self.assertEqual(version, base_version)
+
+      with jtu.set_env(JAX_RELEASE=None, JAXLIB_RELEASE="1",
+                      JAX_NIGHTLY=None, JAXLIB_NIGHTLY=None):
+        version = jax.version._get_version_for_build()
+        self.assertEqual(version, base_version)
 
   def testVersions(self):
     check_jaxlib_version(jax_version="1.2.3", jaxlib_version="1.2.3",


### PR DESCRIPTION
## Description

The goal of this PR is to address #17371, the issue that led us to yank the 0.4.15 release.

The desired end-state are for `jax.__version__` and `jaxlib.__version__` to satisfy the following (keeping [PEP 440](https://peps.python.org/pep-0440/) in mind):

- when importing or installing jax/jaxlib from the github source tree, the version looks like `0.4.16.dev20230906+g5227f1d14` where `20230906` is the date of the most recent commit, and `g5227f1d14` is the commit hash prefix.
- when building the jax/jaxlib nightly release, the resulting source distribution and wheel files have the date of build (not date of commit) encoded in the version, like `0.4.16.dev20230906`
- when building jax/jaxlib releases, the resulting source distribution and wheel files have clean release versions that look like `0.4.16`.

I looked into the possibility of using `versioneer` or `miniver` for this, but they seem to not be well set up for repositories with multiple packages (`jax` and `jaxlib`), and also use mechanisms that are not compatible with our internal filesystem architecture. So instead I plan to roll our own solution.

The general strategy here:

- put a placeholder `_release_version = None` in `jax/version.py`
- add utilities to determine a version string at build time based on environment variables:
  - if `JAX_RELEASE` or `JAXLIB_RELEASE` are set, set the string to the clean version (e.g. `'0.4.16'`)
  - if `JAX_NIGHTLY` or `JAXLIB_NIGHTLY` are set, set the string to a build date (e.g. `'0.4.16.dev20230906'`)
  - otherwise, set the string to a git commit date & hash (e.g. `0.4.16.dev20230906+g4e32a7683`), falling back to the nightly behavior if outside the git source tree.
- when importing from source, if `_release_version is None` then dynamically generate the appropriate version at runtime from the current git hash.
- add a setuptools `cmdclass` that updates the place-holder in source distributions and wheels with an appropriate hard-coded version string determined at build time.

## Testing

### `jax` source distributions
I tested that JAX source distributions have the expected versions:
```
$ python setup.py sdist
...
creating jax-0.4.16.dev20230906+g4e32a7683
...

$ JAX_RELEASE=1 python setup.py sdist
...
creating jax-0.4.16
...

$ JAX_NIGHTLY=1 python setup.py sdist
...
creating jax-0.4.16.dev20230906
...
```
I then confirmed that code installed from the source distribution has the matching version at runtime.

### `jax` wheel builds
Also confirmed that JAX wheels have the correct versions at runtime:
```
$ python -m build
...
Successfully built jax-0.4.16.dev20230906+ge7f064ab4.tar.gz and jax-0.4.16.dev20230906+ge7f064ab4-py3-none-any.whl
$ cd dist
$ pip install jax-0.4.16.dev20230906+ge7f064ab4-py3-none-any.whl --force-reinstall
$ python -c "import jax; print(jax.__version__)"
0.4.16.dev20230906+ge7f064ab4
$ cd ..

$ JAX_RELEASE=1 python -m build
...
Successfully built jax-0.4.16.tar.gz and jax-0.4.16-py3-none-any.whl
$ cd dist
$ pip install jax-0.4.16-py3-none-any.whl --force-reinstall
$ python -c "import jax; print(jax.__version__)"
0.4.16
$ cd ..

$ JAX_NIGHTLY=1 python -m build
...
Successfully built jax-0.4.16.dev20230906.tar.gz and jax-0.4.16.dev20230906-py3-none-any.whl
$ cd dist
$ pip install jax-0.4.16.dev20230906-py3-none-any.whl --force-reinstall
$ python -c "import jax; print(jax.__version__)"
0.4.16.dev20230906
```

### `jaxlib` wheel builds

The jaxlib wheel build doesn't have any pre-submission CI coverage, so I tested locally.

#### Non-release build
Note that the build happens outside a git source tree, so it uses the fallback build-date version.
```
$ python build/build.py
...
Output wheel: /Users/vanderplas/github/google/jax/dist/jaxlib-0.4.16.dev20230906-cp39-cp39-macosx_11_0_arm64.whl

To install the newly-built jaxlib wheel, run:
  pip install /Users/vanderplas/github/google/jax/dist/jaxlib-0.4.16.dev20230906-cp39-cp39-macosx_11_0_arm64.whl --force-reinstall

$ pip install /Users/vanderplas/github/google/jax/dist/jaxlib-0.4.16.dev20230906-cp39-cp39-macosx_11_0_arm64.whl --force-reinstall

$ python -c "import jaxlib; print(jaxlib.__version__)"
0.4.16.dev20230906
```
#### Release Build
```
$ JAXLIB_RELEASE=1 python build/build.py
...
Output wheel: /Users/vanderplas/github/google/jax/dist/jaxlib-0.4.16-cp39-cp39-macosx_11_0_arm64.whl

To install the newly-built jaxlib wheel, run:
  pip install /Users/vanderplas/github/google/jax/dist/jaxlib-0.4.16-cp39-cp39-macosx_11_0_arm64.whl --force-reinstall

$ pip install /Users/vanderplas/github/google/jax/dist/jaxlib-0.4.16-cp39-cp39-macosx_11_0_arm64.whl --force-reinstall

$ python -c "import jaxlib; print(jaxlib.__version__)"
0.4.16
```
#### Nightly Build
```
$ JAXLIB_NIGHTLY=1 python build/build.py
...
Output wheel: /Users/vanderplas/github/google/jax/dist/jaxlib-0.4.16.dev20230906-cp39-cp39-macosx_11_0_arm64.whl

To install the newly-built jaxlib wheel, run:
  pip install /Users/vanderplas/github/google/jax/dist/jaxlib-0.4.16.dev20230906-cp39-cp39-macosx_11_0_arm64.whl --force-reinstall

$ pip install /Users/vanderplas/github/google/jax/dist/jaxlib-0.4.16.dev20230906-cp39-cp39-macosx_11_0_arm64.whl --force-reinstall

$ python -c "import jaxlib; print(jaxlib.__version__)"
0.4.16.dev20230906
```