### PR TITLE
Internal: add dtypes.safe_to_cast utility & use to generate indexing warning

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -677,3 +677,38 @@ def check_user_dtype_supported(dtype, fun_name=None):
     fun_name = f"requested in {fun_name}" if fun_name else ""
     truncated_dtype = canonicalize_dtype(dtype).name
     warnings.warn(msg.format(dtype, fun_name, truncated_dtype), stacklevel=3)
+
+def safe_to_cast(input_dtype_or_value: Any,
+                 output_dtype_or_value: Any) -> bool:
+  """Check if a dtype/value is safe to cast to another dtype/value
+
+  Args:
+    input_dtype_or_value: a dtype or value (to be passed to result_type)
+      representing the source dtype.
+    output_dtype_or_value: a dtype or value (to be passed to result_type)
+      representing the target dtype.
+
+  Returns:
+    boolean representing whether the values are safe to cast according to
+    default type promotion semantics.
+
+  Raises:
+    TypePromotionError: if the inputs have differing types and no type promotion
+    path under the current jax_numpy_dtype_promotion setting.
+
+  Examples:
+
+    >>> safe_to_cast('int32', 'float64')
+    True
+    >>> safe_to_cast('float64', 'int32')
+    False
+    >>> safe_to_cast('float32', 'complex64')
+    True
+    >>> safe_to_cast('complex64', 'float64')
+    False
+  """
+  input_dtype = dtype(input_dtype_or_value, canonicalize=True)
+  output_dtype = dtype(output_dtype_or_value, canonicalize=True)
+  if input_dtype == output_dtype:
+    return True
+  return result_type(input_dtype_or_value, output_dtype_or_value) == output_dtype

--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -21,6 +21,7 @@ import warnings
 
 import numpy as np
 
+from jax import config
 from jax import lax
 
 from jax._src import core
@@ -88,10 +89,11 @@ def _scatter_impl(x, y, scatter_op, treedef, static_idx, dynamic_idx,
   dtype = lax.dtype(x)
   weak_type = dtypes.is_weakly_typed(x)
 
-  if dtype != lax.dtype(y) and dtype != dtypes.result_type(x, y):
+  if not dtypes.safe_to_cast(y, x):
     # TODO(jakevdp): change this to an error after the deprecation period.
     warnings.warn("scatter inputs have incompatible types: cannot safely cast "
-                  f"value from dtype={lax.dtype(y)} to dtype={lax.dtype(x)}. "
+                  f"value from dtype={lax.dtype(y)} to dtype={lax.dtype(x)} "
+                  f"with jax_numpy_dtype_promotion={config.jax_numpy_dtype_promotion!r}. "
                   "In future JAX releases this will result in an error.",
                   FutureWarning)
 


### PR DESCRIPTION
This makes things a bit better defined as we look to complete this deprecation cycle.