### PR TITLE
Build: catch stderr when attempting git commands

### DIFF
--- a/jax/version.py
+++ b/jax/version.py
@@ -32,10 +32,7 @@ def _get_version_string() -> str:
   # In this case we return it directly.
   if _release_version is not None:
     return _release_version
-  try:
-    return _version_from_git_tree(_version)
-  except:
-    return _version_from_todays_date(_version)
+  return _version_from_git_tree(_version) or _version_from_todays_date(_version)
 
 
 def _version_from_todays_date(base_version: str) -> str:
@@ -43,17 +40,30 @@ def _version_from_todays_date(base_version: str) -> str:
   return f"{base_version}.dev{datestring}"
 
 
-def _version_from_git_tree(base_version: str) -> str:
-  stdout = subprocess.check_output(["git", "show", "-s", "--format=%at", "HEAD"])
-  timestamp = int(stdout.decode().strip())
-  datestring = datetime.date.fromtimestamp(timestamp).strftime("%Y%m%d")
-  assert datestring.isnumeric()
+def _version_from_git_tree(base_version: str) -> str | None:
+  try:
+    root_directory = os.path.dirname(os.path.realpath(__file__))
 
-  stdout = subprocess.check_output(["git", "describe", "--long", "--always"])
-  commit_hash = stdout.decode().strip().rsplit('-', 1)[-1]
-  assert commit_hash.isalnum()
+    # Get date string from date of most recent git commit.
+    p = subprocess.Popen(["git", "show", "-s", "--format=%at", "HEAD"],
+                         cwd=root_directory,
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, _ = p.communicate()
+    timestamp = int(stdout.decode().strip())
+    datestring = datetime.date.fromtimestamp(timestamp).strftime("%Y%m%d")
+    assert datestring.isnumeric()
 
-  return f"{base_version}.dev{datestring}+{commit_hash}"
+    # Get commit hash from most recent git commit.
+    p = subprocess.Popen(["git", "describe", "--long", "--always"],
+                         cwd=root_directory,
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, _ = p.communicate()
+    commit_hash = stdout.decode().strip().rsplit('-', 1)[-1]
+    assert commit_hash.isalnum()
+  except:
+    return None
+  else:
+    return f"{base_version}.dev{datestring}+{commit_hash}"
 
 
 def _get_version_for_build() -> str:
@@ -70,11 +80,7 @@ def _get_version_for_build() -> str:
     return _version_from_todays_date(_version)
   if os.environ.get('JAX_RELEASE') or os.environ.get('JAXLIB_RELEASE'):
     return _version
-  try:
-    return _version_from_git_tree(_version)
-  except:
-    # Fallback to date string if git is not available.
-    return _version_from_todays_date(_version)
+  return _version_from_git_tree(_version) or _version_from_todays_date(_version)
 
 
 def _write_version(fname: str) -> None:


### PR DESCRIPTION
Tested:
```
$ python -m build
...
Successfully built jax-0.4.16.dev20230908+gdb6104a3d.tar.gz and jax-0.4.16.dev20230908+gdb6104a3d-py3-none-any.whl

$ cd dist

$ pip install jax-0.4.16.dev20230908+gdb6104a3d-py3-none-any.whl

$ python -c "import jax; print(jax.__version__)"
0.4.16.dev20230908+gdb6104a3d
```