### PR TITLE
Test changes for out-of-tree backend.

### DIFF
--- a/tests/aot_test.py
+++ b/tests/aot_test.py
@@ -43,7 +43,7 @@ with contextlib.suppress(ImportError):
 
 class JaxAotTest(jtu.JaxTestCase):
 
-  @jtu.skip_on_devices('cpu', 'gpu')
+  @jtu.run_on_devices('tpu')
   def test_pickle_pjit_lower(self):
     if jtu.is_se_tpu():
       raise unittest.SkipTest('StreamExecutor not supported.')

--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -62,8 +62,8 @@ all_shapes = nonempty_array_shapes + empty_array_shapes
 class DLPackTest(jtu.JaxTestCase):
   def setUp(self):
     super().setUp()
-    if jtu.device_under_test() == "tpu":
-      self.skipTest("DLPack not supported on TPU")
+    if jtu.device_under_test() not in ["cpu", "gpu"]:
+      self.skipTest(f"DLPack not supported on {jtu.device_under_test()}")
 
   @jtu.sample_product(
     shape=all_shapes,

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -313,11 +313,11 @@ class JaxArrayTest(jtu.JaxTestCase):
   def test_wrong_num_arrays(self):
     shape = (8, 2)
     mesh = jtu.create_global_mesh((4, 2), ('x', 'y'))
+    devices = jax.local_devices()[:8] # Taking up to 8 devices
     s = jax.sharding.NamedSharding(mesh, P('x', 'y'))
     inp_data = np.arange(math.prod(shape), dtype=np.float32).reshape(shape)
     di_map = s.devices_indices_map(shape)
-    bufs = [jax.device_put(inp_data[di_map[d]], d)
-            for d in jax.local_devices()]
+    bufs = [jax.device_put(inp_data[di_map[d]], d) for d in devices]
     with self.assertRaisesRegex(
         ValueError,
         r'Expected 8 per-device arrays \(this is how many devices are addressable '
@@ -910,8 +910,9 @@ class ShardingTest(jtu.JaxTestCase):
 
     mesh = jtu.create_global_mesh((4, 2), ('x', 'y'))
     mps = jax.sharding.NamedSharding(mesh, pspec)
+    devices = jax.local_devices()[:8] # Taking up to 8 devices
 
-    devices_sharding = jax.sharding.PositionalSharding(jax.devices())
+    devices_sharding = jax.sharding.PositionalSharding(devices)
     devices_sharding = devices_sharding.reshape(shape).replicate(axes)
     if transpose:
       devices_sharding = devices_sharding.T

--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -520,7 +520,8 @@ class CheckifyTransformTests(jtu.JaxTestCase):
       # binary func
       return x / y
 
-    mesh = jax.sharding.Mesh(np.array(jax.devices()), ["dev"])
+    devices = jax.local_devices()[:8] # Taking up to 8 devices
+    mesh = jax.sharding.Mesh(np.array(devices), ["dev"])
     ps = NamedSharding(mesh, jax.sharding.PartitionSpec("dev"))
     inp = np.arange(8)
     x = array.make_array_from_callback(inp.shape, ps, lambda idx: inp[idx])
@@ -1311,7 +1312,7 @@ class LowerableChecksTest(jtu.JaxTestCase):
     config.update("jax_experimental_unsafe_xla_runtime_errors", self.prev)
     super().tearDown()
 
-  @jtu.skip_on_devices("tpu")
+  @jtu.run_on_devices("cpu", "gpu")
   def test_jit(self):
     @jax.jit
     def f(x):

--- a/tests/debugger_test.py
+++ b/tests/debugger_test.py
@@ -57,6 +57,11 @@ foo = 2
 
 class CliDebuggerTest(jtu.JaxTestCase):
 
+  def setUp(self):
+    super().setUp()
+    if jtu.device_under_test() not in ["cpu", "gpu", "tpu"]:
+      self.skipTest(f"Host callback not supported on {jtu.device_under_test()}")
+
   def test_debugger_eof(self):
     stdin, stdout = make_fake_stdin_stdout([])
 

--- a/tests/experimental_rnn_test.py
+++ b/tests/experimental_rnn_test.py
@@ -36,7 +36,7 @@ class RnnTest(jtu.JaxTestCase):
       num_layers=[1, 4],
       bidirectional=[True, False],
   )
-  @jtu.skip_on_devices("cpu", "tpu", "rocm")
+  @jtu.run_on_devices("cuda")
   def test_lstm(self, batch_size: int, seq_len: int, input_size: int,
                 hidden_size: int, num_layers: int, bidirectional: bool):
     if lib.version < (0, 4, 7):

--- a/tests/python_callback_test.py
+++ b/tests/python_callback_test.py
@@ -73,6 +73,8 @@ class PythonCallbackTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
+    if jtu.device_under_test() not in ["cpu", "gpu", "tpu"]:
+      self.skipTest(f"Host callback not supported on {jtu.device_under_test()}")
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
@@ -496,6 +498,8 @@ class PureCallbackTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
+    if jtu.device_under_test() not in ["cpu", "gpu", "tpu"]:
+      self.skipTest(f"Host callback not supported on {jtu.device_under_test()}")
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
@@ -879,6 +883,8 @@ class IOCallbackTest(jtu.JaxTestCase):
     super().setUp()
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+    if jtu.device_under_test() not in ["cpu", "gpu", "tpu"]:
+      self.skipTest(f"Host callback not supported on {jtu.device_under_test()}")
 
   def tearDown(self):
     super().tearDown()

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -158,7 +158,7 @@ class ShardMapTest(jtu.JaxTestCase):
     self.assertEqual(c.device_buffers[0].shape, (2, 8))
 
   def test_collective_permute(self):
-    devices = np.array(jax.devices())
+    devices = np.array(jax.devices()[:8]) # Take up to 8 devices
     mesh = Mesh(devices, axis_names=('x'))
     a = jax.device_put(
         jnp.arange(8 * 8).reshape((8, 8)),
@@ -176,7 +176,7 @@ class ShardMapTest(jtu.JaxTestCase):
     self.assertAllClose(c[1, :], a[0, :])
 
   def test_all_to_all(self):
-    devices = np.array(jax.devices())
+    devices = np.array(jax.devices()[:8]) # Take up to 8 devices
     mesh = Mesh(devices, axis_names=('x'))
     a = jax.device_put(
         jnp.arange(8 * 8).reshape((8, 8)),
@@ -416,7 +416,7 @@ class ShardMapTest(jtu.JaxTestCase):
     y_dot_expected = jnp.sin(jnp.arange(8.)) * (jnp.cos(x) * x).sum()
     self.assertAllClose(y_dot, y_dot_expected, check_dtypes=False)
 
-  @jtu.skip_on_devices("cpu")
+  @jtu.run_on_devices('gpu', 'tpu')
   def test_axis_index(self):
     mesh = Mesh(np.array(jax.devices()[:4]), ('x',))
 
@@ -522,6 +522,7 @@ class ShardMapTest(jtu.JaxTestCase):
     self.assertIn('out_names', e.params)
     self.assertEqual(e.params['out_names'], ({0: ('x', 'y',)},))
 
+  @jtu.run_on_devices('cpu', 'gpu', 'tpu')
   def test_debug_print_jit(self):
     mesh = Mesh(jax.devices(), ('i',))
 
@@ -745,6 +746,7 @@ class ShardMapTest(jtu.JaxTestCase):
     # error!
     jax.jit(g)(x)  # doesn't crash
 
+  @jtu.run_on_devices('cpu', 'gpu', 'tpu')
   def test_key_array_with_replicated_last_tile_dim(self):
     # See https://github.com/google/jax/issues/16137
 

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -459,7 +459,7 @@ class XMapTest(XMapTestCase):
       self.assertAllClose(f_mapped(x, x), expected)
 
   @jtu.with_and_without_mesh
-  @jtu.skip_on_devices("cpu")  # In/out aliasing not supported on CPU.
+  @jtu.run_on_devices("gpu", "tpu")  # In/out aliasing not supported on CPU.
   def testBufferDonation(self, mesh, axis_resources):
     shard = lambda x: x
     if axis_resources:
@@ -476,7 +476,7 @@ class XMapTest(XMapTestCase):
     self.assertNotDeleted(y)
     self.assertDeleted(x)
 
-  @jtu.skip_on_devices("cpu")  # In/out aliasing not supported on CPU.
+  @jtu.run_on_devices("gpu", "tpu")  # In/out aliasing not supported on CPU.
   @jtu.with_mesh([('x', 2)])
   @jtu.ignore_warning(category=UserWarning,  # SPMD test generates warning.
                       message="Some donated buffers were not usable*")


### PR DESCRIPTION
These are the changes I have made to jax to allow me to run the majority of tests on the IPU.

The general idea is many tests are supposed to run on a particular backend. To achieve this, current jax tests exclude the other backends. This works when the set of backends is a closed set.

Another common issue I found is that some tests assume that there at most 8 devices.

I'm not proposing this (draft) PR is actually merged. Looking for feedback/thoughts on whether there is a better way.