### PR TITLE
WIP: exploring simple callback-based key reuse checking

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import abc
+import contextlib
 from collections.abc import Hashable, Iterator, Sequence
 from functools import partial, reduce
 import math
@@ -795,6 +796,29 @@ def random_fold_in_lowering(ctx, keys, msgs):
 mlir.register_lowering(random_fold_in_p, random_fold_in_lowering)
 
 
+_USED_KEYS = set()
+def _check_keys(keys):
+  if keys.dtype != 'uint32':
+    raise ValueError(f"expected keys of type uint32; got {keys.dtype=}")
+  if keys.shape[-1] != 2:
+    raise ValueError(f"expected keys with trailing dimension of 2; got {keys.shape=}")
+  for key in keys.reshape(-1, 2):
+    tuple_key = tuple(map(int, key))
+    if tuple_key in _USED_KEYS:
+      raise ValueError(f"Detected repeated use of key {key}")
+    _USED_KEYS.add(tuple_key)
+_KEY_REUSE_CHECKING = False
+
+@contextlib.contextmanager
+def check_key_reuse(computation_id="default"):
+  global _KEY_REUSE_CHECKING
+  _KEY_REUSE_CHECKING = True
+  try:
+    yield
+  finally:
+    _KEY_REUSE_CHECKING = False
+
+
 def random_bits(keys, bit_width, shape):
   shape = core.as_named_shape(shape)
   for name, size in shape.named_items:
@@ -1284,6 +1308,9 @@ def threefry_random_bits(key: typing.Array, bit_width, shape):
     raise TypeError("threefry_random_bits got invalid prng key.")
   if bit_width not in (8, 16, 32, 64):
     raise TypeError("requires 8-, 16-, 32- or 64-bit field width.")
+  
+  if _KEY_REUSE_CHECKING:
+    jax.debug.callback(_check_keys, key)
 
   if config.jax_threefry_partitionable:
     return _threefry_random_bits_partitionable(key, bit_width, shape)

--- a/jax/random.py
+++ b/jax/random.py
@@ -187,7 +187,10 @@ from jax._src.random import (
 
 
 # Deprecations
-from jax._src.prng import PRNGKeyArray as _PRNGKeyArray
+from jax._src.prng import (
+  PRNGKeyArray as _PRNGKeyArray,
+  check_key_reuse as check_key_reuse,
+)
 
 _deprecations = {
     # Added September 13, 2023:


### PR DESCRIPTION
Just putting this out as a simple idea.

Example:
```python
In [1]: import jax

In [2]: key = jax.random.PRNGKey(0)

In [3]: with jax.random.check_key_reuse():
   ...:   jax.random.uniform(key)
   ...:   jax.random.normal(key)
   ...: 
---------------------------------------------------------------------------
XlaRuntimeError                           Traceback (most recent call last)
Cell In[3], line 3
      1 with jax.random.check_key_reuse():
      2   jax.random.uniform(key)
----> 3   jax.random.normal(key)

File ~/github/google/jax/jax/_src/random.py:666, in normal(key, shape, dtype)
    664 dtype = dtypes.canonicalize_dtype(dtype)
    665 shape = core.as_named_shape(shape)
--> 666 return _normal(key, shape, dtype)

    [... skipping hidden 10 frame]

File ~/github/google/jax/jax/_src/interpreters/pxla.py:1160, in ExecuteReplicated.__call__(self, *args)
   1155   self._handle_token_bufs(
   1156       results.disassemble_prefix_into_single_device_arrays(
   1157           len(self.ordered_effects)),
   1158       results.consume_token())
   1159 else:
-> 1160   results = self.xla_executable.execute_sharded(input_bufs)
   1161 if dispatch.needs_check_special():
   1162   out_arrays = results.disassemble_into_single_device_arrays()

XlaRuntimeError: INTERNAL: Generated function failed: CpuCallback error: ValueError: Detected repeated use of key [0 0]
```