### PR TITLE
Raise SkipTest before running setUp

### DIFF
--- a/tests/lobpcg_test.py
+++ b/tests/lobpcg_test.py
@@ -368,10 +368,10 @@ class LobpcgTest(jtu.JaxTestCase):
 class F32LobpcgTest(LobpcgTest):
 
   def setUp(self):
-    super().setUp()
     # TODO(phawkins): investigate this failure
     if jtu.device_under_test() == "gpu":
       raise unittest.SkipTest("Test is failing on CUDA gpus")
+    super().setUp()
 
   def testLobpcgValidatesArguments(self):
     A, _ = _concrete_generators(np.float32)['id'](100, 10)
@@ -408,10 +408,10 @@ class F32LobpcgTest(LobpcgTest):
 class F64LobpcgTest(LobpcgTest):
 
   def setUp(self):
-    super().setUp()
     # TODO(phawkins): investigate this failure
     if jtu.device_under_test() == "gpu":
       raise unittest.SkipTest("Test is failing on CUDA gpus")
+    super().setUp()
 
   @parameterized.named_parameters(_make_concrete_cases(f64=True))
   @jtu.skip_on_devices("tpu", "iree", "gpu")


### PR DESCRIPTION
If `setUp` raises, then `tearDown` is never run. This, in conjunction with `jtu.with_config` leads to leaked configs and causes downstreram test failures due to NaN checking.