### PR TITLE
Better errors for array conversion to bool, int, float, complex, hex, oct, & index

### DIFF
--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -256,29 +256,33 @@ class ArrayImpl(basearray.Array):
       raise TypeError("len() of unsized object") from err  # same as numpy error
 
   def __bool__(self):
-    return bool(self._value)
-
-  def __nonzero__(self):
+    # deprecated 2023 September 18.
+    # TODO(jakevdp) change to warn_on_empty=False
+    core.check_bool_conversion(self, warn_on_empty=True)
     return bool(self._value)
 
   def __float__(self):
+    core.check_scalar_conversion(self)
     return self._value.__float__()
 
   def __int__(self):
+    core.check_scalar_conversion(self)
     return self._value.__int__()
 
   def __complex__(self):
+    core.check_scalar_conversion(self)
     return self._value.__complex__()
 
   def __hex__(self):
-    assert self.ndim == 0, 'hex only works on scalar values'
+    core.check_integer_conversion(self)
     return hex(self._value)  # type: ignore
 
   def __oct__(self):
-    assert self.ndim == 0, 'oct only works on scalar values'
+    core.check_integer_conversion(self)
     return oct(self._value)  # type: ignore
 
   def __index__(self):
+    core.check_integer_conversion(self)
     return op.index(self._value)
 
   def tobytes(self, order="C"):


### PR DESCRIPTION
In cases where values are traced, we previously went immediately to `ConcretizationTypeError` when in many cases errors based on shapes and/or dtypes are more primary. This PR makes the errors more specific and informative, and makes errors under jit match errors outside jit for the same code.

Before:
```python
>>> jax.jit(bool)(jax.numpy.arange(5))
---------------------------------------------------------------------------
TracerBoolConversionError                 Traceback (most recent call last)
...
TracerBoolConversionError: Attempted boolean conversion of traced array with shape int32[5]..
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.TracerBoolConversionError
```
After:
```python
>>> jax.jit(bool)(jnp.arange(5))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
...
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

This also moves some related NumPy 1.25 deprecation warnings into JAX itself, so we can control the deprecation period.