### PR TITLE
Run LSTM test using FP32 math

### DIFF
--- a/jax/experimental/rnn.py
+++ b/jax/experimental/rnn.py
@@ -93,6 +93,7 @@ from jax.interpreters import mlir
 from jax.interpreters import xla
 from jax._src.custom_derivatives import custom_vjp
 from jax._src.typing import Array, Shape
+from jax._src.lax import lax
 import jax.numpy as jnp
 try:
   from jax._src.lib import gpu_rnn
@@ -217,10 +218,34 @@ def unpack_lstm_weights(
   return W_ih, W_hh, b_ih, b_hh
 
 
-@partial(custom_vjp, nondiff_argnums=(5, 6, 7, 8, 9))
+def _lstm_cudnn_allow_tf32(precision: lax.PrecisionLike) -> bool:
+  # the logic from canonicalize_precision that we require here boils down to:
+  #
+  #   if precision is None and config.jax_default_matmul_precision is not None:
+  #     precision = Precision(config.jax_default_matmul_precision)
+  #   else:
+  #     precision = None
+  #
+  # but we prefer to still invoke it here for consistency
+  precision = lax.canonicalize_precision(precision)
+  if precision is None:
+    return True
+  # cuDNN allows only one precision specifier per RNN op
+  precision, _ = precision
+  if precision == lax.Precision.HIGHEST:
+    return False
+  elif precision == lax.Precision.HIGH:
+    return True
+  elif precision == lax.Precision.DEFAULT: # bfloat16
+    raise NotImplementedError("bfloat16 support not implemented for LSTM")
+  else:
+    raise ValueError(f"Unexpected precision specifier value {precision}")
+
+
+@partial(custom_vjp, nondiff_argnums=(5, 6, 7, 8, 9, 10))
 def lstm(x: Array, h_0: Array, c_0: Array, weights: Array, seq_lengths: Array,
          input_size: int, hidden_size: int, num_layers: int, dropout: float,
-         bidirectional: bool) -> tuple[Array, Array, Array]:
+         bidirectional: bool, precision: lax.PrecisionLike = None) -> tuple[Array, Array, Array]:
   """LSTM via CuDNN or HIPDNN (not-yet-supported).
 
   Assume batch-first inputs.
@@ -246,7 +271,8 @@ def lstm(x: Array, h_0: Array, c_0: Array, weights: Array, seq_lengths: Array,
       hidden_size=hidden_size,
       num_layers=num_layers,
       dropout=dropout,
-      bidirectional=bidirectional)
+      bidirectional=bidirectional,
+      precision=precision)
   return y, h_n, c_n
 
 
@@ -367,9 +393,10 @@ def _flip_sequence(sequences: Array, seq_lengths: Array) -> Array:
 
 def lstm_fwd(x: Array, h_0: Array, c_0: Array, w: Array, seq_lengths: Array,
              input_size: int, hidden_size: int, num_layers: int, dropout: float,
-             bidirectional: bool):
+             bidirectional: bool, precision: lax.PrecisionLike):
   if seq_lengths.dtype != jnp.dtype("int32"):
     raise NotImplementedError("`seq_lengths` can only be int32.")
+  cudnn_allow_tf32 = _lstm_cudnn_allow_tf32(precision)
   if jax._src.lib.version < (0, 4, 9):
     y, h_n, c_n, workspace, reserve_space = rnn_fwd_p.bind(
       x,
@@ -381,7 +408,8 @@ def lstm_fwd(x: Array, h_0: Array, c_0: Array, w: Array, seq_lengths: Array,
       hidden_size=hidden_size,
       num_layers=num_layers,
       dropout=dropout,
-      bidirectional=bidirectional)
+      bidirectional=bidirectional,
+      cudnn_allow_tf32=cudnn_allow_tf32)
     return (y, h_n, c_n), (x, h_0, c_0, w, seq_lengths, y, workspace,
                           reserve_space)
   else:
@@ -395,13 +423,15 @@ def lstm_fwd(x: Array, h_0: Array, c_0: Array, w: Array, seq_lengths: Array,
         hidden_size=hidden_size,
         num_layers=num_layers,
         dropout=dropout,
-        bidirectional=bidirectional)
+        bidirectional=bidirectional,
+        cudnn_allow_tf32=cudnn_allow_tf32)
     return (y, h_n, c_n), (x, h_0, c_0, w, seq_lengths, y, reserve_space)
 
 
 def rnn_abstract_eval(x_aval, h_0_aval, c_0_aval, w_aval, seq_lengths_aval,
                       input_size: int, hidden_size: int, num_layers: int,
-                      dropout: float, bidirectional: bool):
+                      dropout: float, bidirectional: bool,
+                      cudnn_allow_tf32: bool):
   batch_size, max_seq_length = x_aval.shape[0], x_aval.shape[1]
   num_directions = 2 if bidirectional else 1
   output_shape = (batch_size, max_seq_length, num_directions * hidden_size)
@@ -410,7 +440,7 @@ def rnn_abstract_eval(x_aval, h_0_aval, c_0_aval, w_aval, seq_lengths_aval,
     workspace_size, reserve_space_size = (
       gpu_rnn.compute_rnn_workspace_reserve_space_sizes(  # pytype: disable=attribute-error
           input_size, hidden_size, num_layers, batch_size, max_seq_length,
-          dropout, bidirectional))
+          dropout, bidirectional, cudnn_allow_tf32))
     workspace_aval = core.ShapedArray((workspace_size,), jnp.float32)
     reserve_space_aval = core.ShapedArray((reserve_space_size,), jnp.float32)
     return output_aval, h_0_aval, c_0_aval, workspace_aval, reserve_space_aval
@@ -418,7 +448,7 @@ def rnn_abstract_eval(x_aval, h_0_aval, c_0_aval, w_aval, seq_lengths_aval,
     _, reserve_space_size = (
         gpu_rnn.compute_rnn_workspace_reserve_space_sizes(  # pytype: disable=attribute-error
             input_size, hidden_size, num_layers, batch_size, max_seq_length,
-            dropout, bidirectional))
+            dropout, bidirectional, cudnn_allow_tf32))
     reserve_space_aval = core.ShapedArray((reserve_space_size,), jnp.float32)
     return output_aval, h_0_aval, c_0_aval, reserve_space_aval
 
@@ -432,7 +462,9 @@ if gpu_rnn:
 
 
 def lstm_bwd(input_size: int, hidden_size: int, num_layers: int, dropout: float,
-             bidirectional, residuals, gradients):
+             bidirectional: bool, precision: lax.PrecisionLike,
+             residuals, gradients):
+  cudnn_allow_tf32 = _lstm_cudnn_allow_tf32(precision)
   if jax._src.lib.version < (0, 4, 9):
     x, h_0, c_0, w, seq_lengths, y, workspace, reserve_space = residuals
     dy, dh_n, dc_n = gradients
@@ -452,7 +484,8 @@ def lstm_bwd(input_size: int, hidden_size: int, num_layers: int, dropout: float,
         hidden_size=hidden_size,
         num_layers=num_layers,
         dropout=dropout,
-        bidirectional=bidirectional)
+        bidirectional=bidirectional,
+        cudnn_allow_tf32=cudnn_allow_tf32)
     return (dx, dh_0, dc_0, dw, jnp.zeros_like(seq_lengths))
   else:
     x, h_0, c_0, w, seq_lengths, y, reserve_space = residuals
@@ -472,7 +505,8 @@ def lstm_bwd(input_size: int, hidden_size: int, num_layers: int, dropout: float,
         hidden_size=hidden_size,
         num_layers=num_layers,
         dropout=dropout,
-        bidirectional=bidirectional)
+        bidirectional=bidirectional,
+        cudnn_allow_tf32=cudnn_allow_tf32)
     return (dx, dh_0, dc_0, dw, jnp.zeros_like(seq_lengths))
 
 
@@ -480,13 +514,15 @@ if jax._src.lib.version < (0, 4, 9):
   def rnn_bwd_abstract_eval(dy_aval, dhn_aval, dcn_aval, x_aval, h0_aval, c0_aval,
                           w_aval, y_aval, workspace_aval, reserve_space_aval,
                           seq_lengths_aval, input_size: int, hidden_size: int,
-                          num_layers: int, dropout: float, bidirectional: bool):
+                          num_layers: int, dropout: float, bidirectional: bool,
+                          cudnn_allow_tf32: bool):
     return x_aval, h0_aval, c0_aval, w_aval
 else:
   def rnn_bwd_abstract_eval(dy_aval, dhn_aval, dcn_aval, x_aval, h0_aval, c0_aval,  # type: ignore
                             w_aval, y_aval, reserve_space_aval,
                             seq_lengths_aval, input_size: int, hidden_size: int,
-                            num_layers: int, dropout: float, bidirectional: bool):
+                            num_layers: int, dropout: float, bidirectional: bool,
+                            cudnn_allow_tf32: bool):
     return x_aval, h0_aval, c0_aval, w_aval
 
 

--- a/jaxlib/gpu/rnn.cc
+++ b/jaxlib/gpu/rnn.cc
@@ -28,11 +28,12 @@ namespace nb = nanobind;
 
 nb::bytes BuildRnnDescriptor(int input_size, int hidden_size, int num_layers,
                              int batch_size, int max_seq_length, float dropout,
-                             bool bidirectional, int workspace_size,
-                             int reserve_space_size) {
+                             bool bidirectional, bool cudnn_allow_tf32,
+			     int workspace_size, int reserve_space_size) {
   return PackDescriptor(RnnDescriptor{
       input_size, hidden_size, num_layers, batch_size, max_seq_length, dropout,
-      bidirectional, workspace_size, reserve_space_size});
+      bidirectional, cudnn_allow_tf32, workspace_size, reserve_space_size
+  });
 }
 
 nb::dict Registrations() {

--- a/jaxlib/gpu/rnn_kernels.h
+++ b/jaxlib/gpu/rnn_kernels.h
@@ -32,6 +32,7 @@ struct RnnDescriptor {
   int max_seq_length;
   float dropout;
   bool bidirectional;
+  bool cudnn_allow_tf32;
   int workspace_size;
   int reserve_space_size;
 };
@@ -39,7 +40,8 @@ struct RnnDescriptor {
 // Return (workspace size, reserve space size).
 absl::StatusOr<std::pair<int, int>> RnnComputeWorkspaceReserveSpaceSizes(
     int input_size, int hidden_size, int num_layers, int batch_size,
-    int max_seq_length, float dropout, bool bidirectional);
+    int max_seq_length, float dropout, bool bidirectional,
+    bool cudnn_allow_tf32);
 
 void RNNForward(gpuStream_t stream, void** buffers, const char* opaque,
                 size_t opaque_len, XlaCustomCallStatus* status);

--- a/tests/experimental_rnn_test.py
+++ b/tests/experimental_rnn_test.py
@@ -37,6 +37,7 @@ class RnnTest(jtu.JaxTestCase):
       bidirectional=[True, False],
   )
   @jtu.run_on_devices("cuda")
+  @jax.default_matmul_precision("float32")
   def test_lstm(self, batch_size: int, seq_len: int, input_size: int,
                 hidden_size: int, num_layers: int, bidirectional: bool):
     if lib.version < (0, 4, 7):


### PR DESCRIPTION
This PR:
- implements handling for the precision specifier in LSTM
- switches the test to using FP32 math

This solves the test flakiness that we've been observing, for example: https://github.com/NVIDIA/JAX-Toolbox/actions/runs/6220851834/job/16881691737#step:9:359.

I'm following up on whether it is possible to run the cuDNN kernel using BF16 math, in which case it would make sense to add support for it for API completeness. I doubt there's much demand for this though.