### PR TITLE
DOC: remove redundant backticks in pjit tutorial stub

### DIFF
--- a/docs/jax-101/08-pjit.rst
+++ b/docs/jax-101/08-pjit.rst
@@ -3,7 +3,7 @@
 Introduction to `pjit`
 ======================
 
-This content is no longer relevant, because :func:`~jax.pjit`` and :func:`~jax.jit``
+This content is no longer relevant, because :func:`~jax.pjit` and :func:`~jax.jit`
 have been merged into a single unified interface.
 For an updated guide to compiling and executing JAX functions in multi-host or multi-core environments,
 see :doc:`../notebooks/Distributed_arrays_and_automatic_parallelization`.


### PR DESCRIPTION
This should fix rendering quirks in https://jax.readthedocs.io/en/latest/jax-101/08-pjit.html.