### PR TITLE
dtypes.issubdtype: validate a when b is dtypes.extended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,8 +84,8 @@ Remember to align the itemized text with the first line of an item within a list
   * The internal submodule path `jax.linear_util` has been deprecated. Use
     {mod}`jax.extend.linear_util` instead (Part of {ref}`jax-extend-jep`)
   * `jax.random.PRNGKeyArray` and `jax.random.KeyArray` are deprecated.  Use {class}`jax.Array`
-    for type annotations, and `jax.dtypes.issubdtype(arr, jax.dtypes.prng_key)` for runtime
-    detection of typed prng keys.
+    for type annotations, and `jax.dtypes.issubdtype(arr.dtype, jax.dtypes.prng_key)` for
+    runtime detection of typed prng keys.
   * The method `PRNGKeyArray.unsafe_raw_array` is deprecated. Use
     {func}`jax.random.key_data` instead.
   * `jax.experimental.pjit.with_sharding_constraint` is deprecated. Use

--- a/jax/random.py
+++ b/jax/random.py
@@ -194,12 +194,12 @@ _deprecations = {
     # Added September 13, 2023:
     "PRNGKeyArray": (
         "jax.random.PRNGKeyArray is deprecated. Use jax.Array for annotations, and "
-        "jax.dtypes.issubdtype(arr, jax.dtypes.prng_key) for runtime detection of "
+        "jax.dtypes.issubdtype(arr.dtype, jax.dtypes.prng_key) for runtime detection of "
         "typed prng keys.", _PRNGKeyArray
     ),
     "KeyArray": (
         "jax.random.KeyArray is deprecated. Use jax.Array for annotations, and "
-        "jax.dtypes.issubdtype(arr, jax.dtypes.prng_key) for runtime detection of "
+        "jax.dtypes.issubdtype(arr.dtype, jax.dtypes.prng_key) for runtime detection of "
         "typed prng keys.", _PRNGKeyArray
     ),
     # Added September 21, 2023

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -638,6 +638,7 @@ class TestPromotionTables(jtu.JaxTestCase):
       numpy_dtype_promotion=['strict', 'standard']
   )
   def testSafeToCast(self, input_dtype, output_dtype, numpy_dtype_promotion):
+    print(input_dtype, output_dtype)
     with jax.numpy_dtype_promotion(numpy_dtype_promotion):
       # First the special cases which are always safe:
       always_safe = (

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -62,7 +62,7 @@ def _prng_key_as_array(key):
 def _maybe_unwrap(key):
   # TODO(frostig): remove some day when we deprecate "raw" key arrays
   unwrap = prng_internal.random_unwrap
-  return unwrap(key) if jnp.issubdtype(key, dtypes.prng_key) else key
+  return unwrap(key) if jnp.issubdtype(key.dtype, dtypes.prng_key) else key
 
 
 PRNG_IMPLS = [('threefry2x32', prng_internal.threefry_prng_impl),
@@ -1742,6 +1742,8 @@ class KeyArrayTest(jtu.JaxTestCase):
     key = random.key(42)
     self.assertTrue(jnp.issubdtype(key.dtype, dtypes.prng_key))
     self.assertFalse(jnp.issubdtype(key.dtype, np.integer))
+    with self.assertRaisesRegex(TypeError, "Cannot interpret"):
+      jnp.issubdtype(key, dtypes.prng_key)
 
   @skipIf(not config.jax_enable_custom_prng, 'relies on typed key upgrade flag')
   def test_construction_upgrade_flag(self):


### PR DESCRIPTION
Fixes #17699

Part of #9263