### PR TITLE
dtypes: make issubdtype(dt, np.generic) work for custom types

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -339,15 +339,15 @@ def issubdtype(a: DTypeLike, b: DTypeLike) -> bool:
       # Avoid implicitly casting list elements below to a dtype.
       if isinstance(b, np.dtype):
         return a == b
-      return b in [np.floating, np.inexact, np.number]
+      return b in [np.floating, np.inexact, np.number, np.generic]
     if a == _int4_dtype:
       if isinstance(b, np.dtype):
         return a == b
-      return b in [np.signedinteger, np.integer, np.number]
+      return b in [np.signedinteger, np.integer, np.number, np.generic]
     if a == _uint4_dtype:
       if isinstance(b, np.dtype):
         return a == b
-      return b in [np.unsignedinteger, np.integer, np.number]
+      return b in [np.unsignedinteger, np.integer, np.number, np.generic]
   return np.issubdtype(a, b)
 
 can_cast = np.can_cast

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -297,7 +297,29 @@ class DtypesTest(jtu.JaxTestCase):
       self.assertTrue(dtypes.issubdtype(dt, np.floating))
       self.assertTrue(dtypes.issubdtype(dt, np.inexact))
       self.assertTrue(dtypes.issubdtype(dt, np.number))
+      self.assertTrue(dtypes.issubdtype(dt, np.generic))
+      self.assertFalse(dtypes.issubdtype(dt, object))
       self.assertFalse(dtypes.issubdtype(dt, np.float64))
+      self.assertFalse(dtypes.issubdtype(np.generic, dt))
+
+  @parameterized.product(dtype=int4_dtypes)
+  def testIsSubdtypeInt4(self, dtype):
+    if dtype == 'int4':
+      int_category = np.signedinteger
+    elif dtype == 'uint4':
+      int_category = np.unsignedinteger
+    else:
+      raise ValueError("Unexpected dtype: {dtype}")
+    for dt in [dtype, np.dtype(dtype), str(np.dtype(dtype))]:
+      self.assertTrue(dtypes.issubdtype(dt, dt))
+      self.assertTrue(dtypes.issubdtype(dt, np.dtype(dtype)))
+      self.assertTrue(dtypes.issubdtype(dt, str(np.dtype(dtype))))
+      self.assertTrue(dtypes.issubdtype(dt, int_category))
+      self.assertTrue(dtypes.issubdtype(dt, np.integer))
+      self.assertTrue(dtypes.issubdtype(dt, np.number))
+      self.assertTrue(dtypes.issubdtype(dt, np.generic))
+      self.assertFalse(dtypes.issubdtype(dt, object))
+      self.assertFalse(dtypes.issubdtype(dt, np.int64))
       self.assertFalse(dtypes.issubdtype(np.generic, dt))
 
   def testArrayCasts(self):


### PR DESCRIPTION
I noticed that this returns false:
```python
>>> jnp.issubdtype(jnp.bfloat16, jnp.generic)
False
```
while it returns True for standard types:
```python
>>> jnp.issubdtype(jnp.float32, jnp.generic)
True
```
This PR fixes that inconsistency.