### PR TITLE
Added `serial_dot_products` benchmark

### DIFF
--- a/benchmarks/api_benchmark.py
+++ b/benchmarks/api_benchmark.py
@@ -785,9 +785,9 @@ def batch_inplace_while(inplace_op, state):
 
   size = 100_000
   args = jnp.array([0]), jnp.zeros((1, size))
-  f(*args)  # compile
+  jax.block_until_ready(f(*args))  # compile
   while state:
-    f(*args)
+    jax.block_until_ready(f(*args))
 
 
 google_benchmark.register(
@@ -795,6 +795,26 @@ google_benchmark.register(
 google_benchmark.register(
     partial(batch_inplace_while, 'dynamic_update_slice'),
     name='batch_inplace_while_dynamic_update_slice')
+
+
+@google_benchmark.register
+def serial_dot_products(state):
+  SIZE = 50
+
+  @jax.jit
+  @jax.vmap
+  @jax.grad
+  def f(x):
+    out = 0
+    for i in range(SIZE):
+      y = x @ jnp.array([i, i + 1], dtype=jnp.float32)
+      out = out + y * x[0]
+    return out
+
+  x = jax.random.normal(jax.random.PRNGKey(0), (2, 2))
+  f(x).block_until_ready()  # compile
+  while state:
+    f(x).block_until_ready()
 
 
 @google_benchmark.register


### PR DESCRIPTION
Added a benchmark for an OS-specific slowdown identified in `jaxlib==0.4.16`. The root cause was found to be https://github.com/openxla/xla/commit/4f675c5715d23a49933e481d09adcf5065edfca5.

Drive by: added some missing `block_until_ready`s.