### PR TITLE
issubdtype: fix corner cases with extended dtypes

### DIFF
--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -288,6 +288,16 @@ class DtypesTest(jtu.JaxTestCase):
           self.assertEqual(dtypes.issubdtype(t, category),
                            np.issubdtype(np.dtype(t).type, category))
 
+  def testIsSubdtypeExtended(self):
+    self.assertTrue(dtypes.issubdtype(dtypes.extended, dtypes.extended))
+    self.assertTrue(dtypes.issubdtype(dtypes.extended, np.generic))
+    self.assertFalse(dtypes.issubdtype(dtypes.extended, np.number))
+
+    self.assertTrue(jnp.issubdtype(dtypes.prng_key, dtypes.prng_key))
+    self.assertTrue(jnp.issubdtype(dtypes.prng_key, dtypes.extended))
+    self.assertTrue(jnp.issubdtype(dtypes.prng_key, np.generic))
+    self.assertFalse(dtypes.issubdtype(dtypes.prng_key, np.number))
+
   @parameterized.product(dtype=custom_float_dtypes)
   def testIsSubdtypeCustomFloats(self, dtype):
     for dt in [dtype, np.dtype(dtype), str(np.dtype(dtype))]:

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1740,8 +1740,14 @@ class KeyArrayTest(jtu.JaxTestCase):
 
   def test_issubdtype(self):
     key = random.key(42)
+
+    self.assertTrue(jnp.issubdtype(key.dtype, key.dtype))
     self.assertTrue(jnp.issubdtype(key.dtype, dtypes.prng_key))
+    self.assertTrue(jnp.issubdtype(key.dtype, dtypes.extended))
+    self.assertTrue(jnp.issubdtype(key.dtype, np.generic))
+
     self.assertFalse(jnp.issubdtype(key.dtype, np.integer))
+    self.assertFalse(jnp.issubdtype(key.dtype, np.number))
     with self.assertRaisesRegex(TypeError, "Cannot interpret"):
       jnp.issubdtype(key, dtypes.prng_key)
 


### PR DESCRIPTION
Needed a few extra test cases for corners that were not properly handled.