### PR TITLE
MAINT Clean up leftover ``Array = Any`` aliases in jax/_src/**.py

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -666,6 +666,7 @@ pytype_strict_library(
         ":core",
         ":effects",
         ":pretty_printer",
+        ":typing",
         ":util",
     ],
 )

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -33,12 +33,12 @@ from jax._src.core import raise_to_shaped, Trace, Tracer, AxisName
 from jax._src.interpreters import partial_eval as pe
 from jax._src.tree_util import (tree_unflatten, tree_flatten,
                                 register_pytree_node)
+from jax._src.typing import Array
 from jax._src.util import (unzip2, unzip3, safe_map, safe_zip, split_list,
                            canonicalize_axis, moveaxis, as_hashable_function,
                            curry, memoize, weakref_lru_cache)
 
 
-Array = Any
 map, unsafe_map = safe_map, map
 zip, unsafe_zip = safe_zip, zip
 
@@ -116,7 +116,7 @@ class RaggedAxis:
   # For each axis, we store its index and the corresponding segment lengths.
   # For example, the jumble i:(Fin 3) => f32[lens1.i, 7, lens2.i]
   # would be represented with ragged_axes = [(1, lens1), (3, lens2)]
-  ragged_axes: tuple[tuple[int, Array], ...]
+  ragged_axes: tuple[tuple[int, Any], ...]
 
   @property
   def size(self):
@@ -148,8 +148,10 @@ def _sorted_ragged_axis(stacked_axis, ragged_axes):
   return RaggedAxis(stacked_axis, tuple(sorted(ragged_axes, key=lambda p: p[0])))
 
 def make_batch_axis(
-    ndim: int, stacked_axis: int, ragged_axes: list[tuple[int, Array]]
-  ) -> int | RaggedAxis:
+    ndim: int,
+    stacked_axis: int,
+    ragged_axes: list[tuple[int, Array | core.Var]],
+) -> int | RaggedAxis:
   if ragged_axes:
     canonical = [(canonicalize_axis(ax, ndim), sz) for ax, sz in ragged_axes]
     return _sorted_ragged_axis(canonicalize_axis(stacked_axis, ndim), canonical)

--- a/jax/_src/lax/ann.py
+++ b/jax/_src/lax/ann.py
@@ -70,7 +70,6 @@ Todos::
 """
 
 from functools import partial
-from typing import Any
 
 import numpy as np
 
@@ -88,9 +87,7 @@ from jax._src.lib import xla_client as xc
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import func
 from jax._src.lib.mlir.dialects import hlo
-
-
-Array = Any
+from jax._src.typing import Array
 
 
 def approx_max_k(operand: Array,

--- a/jax/_src/lax/control_flow/for_loop.py
+++ b/jax/_src/lax/control_flow/for_loop.py
@@ -39,6 +39,7 @@ from jax._src.state import discharge as state_discharge
 from jax._src.state import primitives as state_primitives
 from jax._src.state import utils as state_utils
 from jax._src.state import types as state_types
+from jax._src.typing import Array
 from jax._src.util import (partition_list, merge_lists, safe_map, safe_zip,
                            split_list, split_dict)
 from jax._src.lax.control_flow import loops
@@ -53,7 +54,6 @@ zip, unsafe_zip = safe_zip, zip
 S = TypeVar('S')
 T = TypeVar('T')
 class Ref(Generic[T]): pass
-Array = Any
 
 ref_set = state_primitives.ref_set
 ref_get = state_primitives.ref_get

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -52,6 +52,7 @@ from jax._src import state
 from jax._src.state import discharge as state_discharge
 from jax._src.numpy.ufuncs import logaddexp
 from jax._src.traceback_util import api_boundary
+from jax._src.typing import Array
 from jax._src.util import (partition_list, safe_map, safe_zip, split_list,
                            unzip2, weakref_lru_cache, merge_lists)
 import numpy as np
@@ -64,7 +65,6 @@ _map = safe_map
 zip = safe_zip
 
 T = TypeVar('T')
-Array = Any
 BooleanNumeric = Any  # A bool, or a Boolean array.
 
 ### Helper functions

--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -14,7 +14,7 @@
 
 from collections.abc import Sequence
 from functools import partial
-from typing import Any, Callable, Optional, Union
+from typing import Callable, Optional, Union
 import warnings
 
 import numpy as np
@@ -36,11 +36,10 @@ from jax._src.lax import slicing
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import hlo
 from jax._src.numpy.ufuncs import logaddexp
+from jax._src.typing import Array
 
 map = util.safe_map
 zip = util.safe_zip
-
-Array = Any
 
 
 def reduce_window(operand, init_value, computation: Callable,

--- a/jax/_src/nn/initializers.py
+++ b/jax/_src/nn/initializers.py
@@ -23,18 +23,17 @@ from typing import Any, Literal, Protocol, Union
 
 import numpy as np
 
-import jax
 import jax.numpy as jnp
 from jax import lax
 from jax import random
 from jax._src import core
 from jax._src import dtypes
+from jax._src.typing import Array, ArrayLike
 from jax._src.util import set_module
 
 export = set_module('jax.nn.initializers')
 
-KeyArray = jax.Array
-Array = Any
+KeyArray = Array
 # TODO: Import or define these to match
 # https://github.com/numpy/numpy/blob/main/numpy/typing/_dtype_like.py.
 DTypeLikeFloat = Any
@@ -48,7 +47,7 @@ class Initializer(Protocol):
   def __call__(key: KeyArray,
                shape: core.Shape,
                dtype: DTypeLikeInexact = jnp.float_) -> Array:
-    ...
+    raise NotImplementedError
 
 @export
 def zeros(key: KeyArray,
@@ -82,7 +81,7 @@ def ones(key: KeyArray,
   return jnp.ones(shape, dtypes.canonicalize_dtype(dtype))
 
 @export
-def constant(value: Array,
+def constant(value: ArrayLike,
              dtype: DTypeLikeInexact = jnp.float_
              ) -> Initializer:
   """Builds an initializer that returns arrays full of a constant ``value``.
@@ -240,7 +239,7 @@ def _complex_uniform(key: KeyArray,
   theta = 2 * jnp.pi * random.uniform(key_theta, shape, real_dtype).astype(dtype)
   return r * jnp.exp(1j * theta)
 
-def _complex_truncated_normal(key: KeyArray, upper: Array,
+def _complex_truncated_normal(key: KeyArray, upper: ArrayLike,
                               shape: Union[Sequence[int], core.NamedShape],
                               dtype: DTypeLikeInexact) -> Array:
   """

--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -16,7 +16,7 @@
 
 from collections.abc import Sequence
 import sys
-from typing import Any, Callable, Optional, Union
+from typing import Callable, Optional, Union
 import warnings
 
 import numpy as np
@@ -31,9 +31,9 @@ from jax._src.lax import lax as lax_internal
 from jax._src.numpy import lax_numpy as jnp
 from jax._src.numpy import reductions
 from jax._src.numpy.util import check_arraylike, promote_dtypes
+from jax._src.typing import Array, ArrayLike
 
 
-Array = Any
 if sys.version_info >= (3, 10):
     from types import EllipsisType
     SingleIndex = Union[None, int, slice, Sequence[int], Array, EllipsisType]
@@ -154,8 +154,8 @@ def _get_identity(op, dtype):
 
 
 def _segment_update(name: str,
-                    data: Array,
-                    segment_ids: Array,
+                    data: ArrayLike,
+                    segment_ids: ArrayLike,
                     scatter_op: Callable,
                     num_segments: Optional[int] = None,
                     indices_are_sorted: bool = False,
@@ -195,8 +195,8 @@ def _segment_update(name: str,
   return reducer(out, axis=0).astype(dtype)
 
 
-def segment_sum(data: Array,
-                segment_ids: Array,
+def segment_sum(data: ArrayLike,
+                segment_ids: ArrayLike,
                 num_segments: Optional[int] = None,
                 indices_are_sorted: bool = False,
                 unique_indices: bool = False,
@@ -250,8 +250,8 @@ def segment_sum(data: Array,
       indices_are_sorted, unique_indices, bucket_size, reductions.sum, mode=mode)
 
 
-def segment_prod(data: Array,
-                 segment_ids: Array,
+def segment_prod(data: ArrayLike,
+                 segment_ids: ArrayLike,
                  num_segments: Optional[int] = None,
                  indices_are_sorted: bool = False,
                  unique_indices: bool = False,
@@ -306,8 +306,8 @@ def segment_prod(data: Array,
       indices_are_sorted, unique_indices, bucket_size, reductions.prod, mode=mode)
 
 
-def segment_max(data: Array,
-                segment_ids: Array,
+def segment_max(data: ArrayLike,
+                segment_ids: ArrayLike,
                 num_segments: Optional[int] = None,
                 indices_are_sorted: bool = False,
                 unique_indices: bool = False,
@@ -361,8 +361,8 @@ def segment_max(data: Array,
       indices_are_sorted, unique_indices, bucket_size, reductions.max, mode=mode)
 
 
-def segment_min(data: Array,
-                segment_ids: Array,
+def segment_min(data: ArrayLike,
+                segment_ids: ArrayLike,
                 num_segments: Optional[int] = None,
                 indices_are_sorted: bool = False,
                 unique_indices: bool = False,

--- a/jax/_src/scipy/optimize/_lbfgs.py
+++ b/jax/_src/scipy/optimize/_lbfgs.py
@@ -12,18 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Limited-Memory Broyden-Fletcher-Goldfarb-Shanno minimization algorithm."""
-from typing import Any, Callable, NamedTuple, Optional, Union
+from typing import Callable, NamedTuple, Optional, Union
 from functools import partial
 
 import jax
 import jax.numpy as jnp
 from jax import lax
 from jax._src.scipy.optimize.line_search import line_search
+from jax._src.typing import Array
+
 
 _dot = partial(jnp.dot, precision=lax.Precision.HIGHEST)
 
 
-Array = Any
 
 class LBFGSResults(NamedTuple):
   """Results from L-BFGS optimization

--- a/jax/_src/state/types.py
+++ b/jax/_src/state/types.py
@@ -23,13 +23,12 @@ from jax._src import core
 from jax._src import effects
 from jax._src import pretty_printer as pp
 from jax._src.util import safe_map, safe_zip
+from jax._src.typing import Array
 
 ## JAX utilities
 
 map, unsafe_map = safe_map, map
 zip, unsafe_zip = safe_zip, zip
-
-Array = Any
 
 _ref_effect_color = pp.Color.GREEN
 


### PR DESCRIPTION
This seemingly minor change uncovered a few inconsistencies in existing code. I silenced the new type errors via ``type: ignore` and added a TODO to investigate later.