### PR TITLE
jnp.mean: for f16 inputs, accumulate in f32

### DIFF
--- a/tests/lax_numpy_reducers_test.py
+++ b/tests/lax_numpy_reducers_test.py
@@ -758,6 +758,15 @@ class JaxNumpyReducerTests(jtu.JaxTestCase):
     self.assertEqual(0.0, jnp.std(x))
     self.assertEqual(0.0, jnp.std(x, where=True))
 
+  @jtu.sample_product(
+      dtype=[np.dtype(np.float16), np.dtype(dtypes.bfloat16)],
+  )
+  def test_f16_mean(self, dtype):
+    x = np.full(100_000, 1E-5, dtype=dtype)
+    expected = np.mean(x.astype('float64')).astype(dtype)
+    actual = jnp.mean(x)
+    self.assertAllClose(expected, actual, atol=0)
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Fixes the issue reported in b/302143127

Before:
```python
In [22]: jnp.mean((jnp.ones((1048576, 1), dtype=jnp.float16) * 1e-5))
Out[22]: Array(0., dtype=float16)

In [23]: np.mean((np.ones((1048576, 1), dtype=np.float16) * 1e-5))
Out[23]: 1e-05
```
After:
```python
In [2]: jnp.mean((jnp.ones((1048576, 1), dtype=jnp.float16) * 1e-5))
Out[2]: Array(1.e-05, dtype=float16)
```