### PR TITLE
Small improvements to build/build.py

### DIFF
--- a/.github/workflows/wheel_win_x64.yml
+++ b/.github/workflows/wheel_win_x64.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           python -m pip install -r build/test-requirements.txt
           "C:\\msys64\\;C:\\msys64\\usr\\bin\\;" >> $env:GITHUB_PATH
-          python.exe build\build.py --bazel_options=--color=yes
+          python.exe build\build.py --bazel_options=--color=yes --verbose
 
       - uses: actions/upload-artifact@v3
         with:

--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -9,3 +9,4 @@ portpicker
 pytest-xdist
 wheel
 rich
+setuptools


### PR DESCRIPTION
Add a --verbose option that logs all shell() commands run by the script. Remove some Python 2 backward compatibility logic related to urllib and shutil.

Enable debug logging on Windows wheel builds.

Also include setuptools in the build requirements and test for its presence in build.py.