### PR TITLE
MAINT Reorder the overloads for `lax.sort`

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1117,12 +1117,12 @@ def _reduce_xor(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_xor_p.bind(operand, axes=tuple(axes))
 
 @overload
-def sort(operand: Sequence[Array], dimension: int = -1,
-         is_stable: bool = True, num_keys: int = 1) -> tuple[Array, ...]: ...
-
-@overload
 def sort(operand: Array, dimension: int = -1,
          is_stable: bool = True, num_keys: int = 1) -> Array: ...
+
+@overload
+def sort(operand: Sequence[Array], dimension: int = -1,
+         is_stable: bool = True, num_keys: int = 1) -> tuple[Array, ...]: ...
 
 def sort(operand: Union[Array, Sequence[Array]], dimension: int = -1,
          is_stable: bool = True, num_keys: int = 1) -> Union[Array, tuple[Array, ...]]:


### PR DESCRIPTION
`Array` is structurally a `Sequence[Array]`, so the first overload always matches under pytype, which defines `collections.abc.Sequence` as a `Protocol`.

See
https://github.com/google/pytype/blob/b8f91a37e59535ce28e8bacb60c6453cd5c0ecfa/pytype/stubs/builtins/typing.pytd#L149.