### PR TITLE
Introduce a LoweringParameters dataclass for easier plumbing

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -582,7 +582,8 @@ def xla_computation(fun: Callable,
               wrap_name(fun_name, "xla_computation")),
           donated_args=donated_invars,
           arg_shardings=None,
-          result_shardings=None)
+          result_shardings=None,
+          lowering_parameters=mlir.LoweringParameters())
       built = xc._xla.mlir.mlir_module_to_xla_computation(
           mlir.module_to_string(lowering_result.module),
           use_tuple_args=tuple_args,
@@ -1904,8 +1905,8 @@ def _pmap_lower(fun, axis_name, in_axes, out_axes, static_broadcasted_tuple,
     Returns:
       A ``Lowered`` instance representing the post-map lowering.
     """
-    _experimental_lowering_platform = kwargs.pop(
-        '_experimental_lowering_platform', None)
+    lowering_parameters = kwargs.pop(
+        '_experimental_lowering_parameters', mlir.LoweringParameters())
     p = _prepare_pmap(
         fun, in_axes, out_axes, static_broadcasted_tuple, donate_tuple,
         devices, backend, axis_size, args, kwargs)
@@ -1920,7 +1921,7 @@ def _pmap_lower(fun, axis_name, in_axes, out_axes, static_broadcasted_tuple,
         donated_invars=p.donated_invars,
         is_explicit_global_axis_size=p.is_explicit_global_axis_size,
         avals=abstract_args,
-        lowering_platform=_experimental_lowering_platform)
+        lowering_parameters=lowering_parameters)
     return stages.Lowered.from_flat_info(
         computation, p.in_tree, abstract_args, donate_tuple, p.out_tree())
 

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -149,7 +149,7 @@ def xla_primitive_callable(
   computation = sharded_lowering(
       flat_fun, prim.name, donated_invars, keep_unused=False,
       inline=True, in_avals=in_avals, in_shardings=orig_in_shardings.shardings,
-      lowering_platform=None)
+      lowering_parameters=mlir.LoweringParameters())
   compiled = computation.compile()
   if xla_extension_version >= 192:
     if config.jax_disable_jit:
@@ -169,7 +169,8 @@ def xla_primitive_callable(
 def sharded_lowering(
     fun: lu.WrappedFun, name: str, donated_invars: Sequence[bool],
     keep_unused: bool, inline: bool, in_avals: tuple[core.AbstractValue, ...],
-    in_shardings: Sequence[Sharding | None], lowering_platform: str | None
+    in_shardings: Sequence[Sharding | None],
+    lowering_parameters: mlir.LoweringParameters
 ) -> pxla.MeshComputation:
   in_shardings_unspec = [UNSPECIFIED if i is None else i for i in in_shardings]
 
@@ -179,7 +180,8 @@ def sharded_lowering(
   return pxla.lower_sharding_computation(
       fun, 'jit', name, in_shardings_unspec, UNSPECIFIED, donated_invars,
       in_avals, keep_unused=keep_unused, inline=inline,
-      devices_from_context=None, lowering_platform=lowering_platform)
+      devices_from_context=None,
+      lowering_parameters=lowering_parameters)
 
 
 def simple_impl(prim):

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -325,10 +325,8 @@ def post_infer_params(fun, infer_params_fn, static_argnums, static_argnames,
 
   @api_boundary
   def lower(*args, **kwargs):
-    _experimental_lowering_platform = kwargs.pop(
-        '_experimental_lowering_platform', None)
-    _experimental_override_lowering_rules = kwargs.pop(
-        '_experimental_override_lowering_rules', None)
+    lowering_parameters = kwargs.pop(
+        '_experimental_lowering_parameters', mlir.LoweringParameters())
     (args_flat, flat_global_in_avals, params, in_tree, out_tree,
      donated_invars) = infer_params_fn(*args, **kwargs)
     resource_env = params['resource_env']
@@ -340,8 +338,7 @@ def post_infer_params(fun, infer_params_fn, static_argnums, static_argnames,
           params['jaxpr'], in_shardings, params['out_shardings'],
           params['resource_env'], params['donated_invars'], params['name'],
           params['keep_unused'], params['inline'],
-          lowering_platform=_experimental_lowering_platform,
-          override_lowering_rules=_experimental_override_lowering_rules)
+          lowering_parameters=lowering_parameters)
     except pxla.DeviceAssignmentMismatchError as e:
       fails, = e.args
       api_name = 'jit' if params['resource_env'] is None else 'pjit'
@@ -1131,7 +1128,7 @@ def _pjit_call_impl_python(
   compiled = _pjit_lower(
       jaxpr, in_shardings, out_shardings, resource_env,
       donated_invars, name, keep_unused, inline,
-      lowering_platform=None).compile()
+      lowering_parameters=mlir.LoweringParameters()).compile()
   _most_recent_pjit_call_executable.weak_key_dict[jaxpr] = compiled
   # This check is expensive so only do it if enable_checks is on.
   if compiled._auto_spmd_lowering and config.jax_enable_checks:
@@ -1273,9 +1270,7 @@ def _pjit_lower_cached(
     keep_unused: bool,
     inline: bool,
     *,
-    lowering_platform: Optional[str],
-    override_lowering_rules: Optional[
-        tuple[tuple[core.Primitive, mlir.LoweringRule]]] = None):
+    lowering_parameters: mlir.LoweringParameters):
   in_shardings: tuple[PjitShardingMinusUnspecified, ...] = cast(
       tuple[PjitShardingMinusUnspecified, ...], sdat_in_shardings.shardings)
   out_shardings: tuple[PjitSharding, ...] = sdat_out_shardings.shardings
@@ -1298,7 +1293,7 @@ def _pjit_lower_cached(
       jaxpr, api_name, name, mesh,
       in_shardings, out_shardings, donated_invars,
       True, jaxpr.in_avals, tiling_method=None,
-      lowering_platform=lowering_platform)
+      lowering_parameters=lowering_parameters)
   else:
     return pxla.lower_sharding_computation(
         jaxpr, api_name, name, in_shardings, out_shardings,
@@ -1306,8 +1301,7 @@ def _pjit_lower_cached(
         keep_unused=keep_unused, inline=inline,
         devices_from_context=(
             None if mesh is None or mesh.empty else list(mesh.devices.flat)),
-        lowering_platform=lowering_platform,
-        override_lowering_rules=override_lowering_rules,
+        lowering_parameters=lowering_parameters,
 )
 
 

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -16,6 +16,7 @@ from jax._src.interpreters.mlir import (
   AxisContext as AxisContext,
   ConstantHandler as ConstantHandler,
   DEVICE_TO_DEVICE_TYPE as DEVICE_TO_DEVICE_TYPE,
+  LoweringParameters as LoweringParameters,
   LoweringResult as LoweringResult,
   LoweringRule as LoweringRule,
   LoweringRuleContext as LoweringRuleContext,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -10347,7 +10347,8 @@ class OverrideLoweringTest(jtu.JaxTestCase):
     lowered_ir = (
         jax.jit(f)
         .lower(jax.ShapeDtypeStruct((2, 4), dtype=jnp.bfloat16),
-               _experimental_override_lowering_rules=rules).as_text())
+               _experimental_lowering_parameters=mlir.LoweringParameters(
+                 override_lowering_rules=rules)).as_text())
     self.assertNotIn("stablehlo.custom_call @Sharding", lowered_ir)
 
 

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -570,7 +570,7 @@ class JaxExportTest(jtu.JaxTestCase):
     x = np.arange(5, dtype=np.float32)
     # TODO: use a function with different behavior for different platforms
     exp = export.export(jnp.sin,
-                            lowering_platforms=('cpu', 'tpu'))(x)
+                        lowering_platforms=('cpu', 'tpu'))(x)
     self.assertEqual(exp.lowering_platforms, ('cpu', 'tpu'))
     module_str = str(exp.mlir_module())
     platform_index = re.findall(


### PR DESCRIPTION
There are currently two parameters that are used to configure lowering: lowering_platform (for cross-platform lowering), and override_lowering_rules. Each of them are passed as separate arguments through several layers of lowering internal functions. This is tedious, and error prone. In fact, override_lowering_rules was not plumbed in all places, and due to using default arguments in all places, this leads to silent errors.

We foresee introducing other parameters for lowering: for multi-platform lowering, for controlling the lowering of effects.

Here is pack all such parameters into a `mlir.LoweringParameters` dataclass and we plumb that through.