### PR TITLE
Workaround for jit + xmap

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1294,6 +1294,8 @@ def _pjit_lower_cached(
   # For `pjit(xmap)` cases, it needs to take the `lower_mesh_computation` path
   # because `xmap` only supports SPMDAxisContext right now.
   if dispatch.jaxpr_has_primitive(jaxpr.jaxpr, 'xmap'):
+    mesh = mesh_lib.thread_resources.env.physical_mesh
+    api_name = 'pjit'
     return pxla.lower_mesh_computation(
       jaxpr, api_name, name, mesh,
       in_shardings, out_shardings, donated_invars,


### PR DESCRIPTION
In short, JAX does not support `jit` + `xmap`. To address this, we force use `pjit` when `xmap` is detected in `jaxpr`.

For details, JAX relies on the value of an argument, called `resource_env`, to determine whether `jit` or `pjit` is used. If calling from `jit`, then `resource_env` is None, which means the mesh passed into `lower_mesh_computation` is empty. This causes empty mesh errors when running with `xmap`. To solve this, we force `api_name` to be `pjit` when `xmap` is detected in `jaxpr`.