### PR TITLE
custom_vjp now supports jvps

### DIFF
--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -986,7 +986,7 @@ def lift_jvp(num_errs, num_consts, jvp_jaxpr_thunk):
 
 def custom_vjp_call_jaxpr_rule(in_err, enabled_errors, *in_vals, fun_jaxpr,
                                fwd_jaxpr_thunk, num_consts, bwd, out_trees,
-                               symbolic_zeros):
+                               symbolic_zeros, enable_jvp):
   err_vals, err_tree = jtu.tree_flatten(in_err)
   num_errs = err_tree.num_leaves
   checkified_fun = lu.wrap_init(
@@ -1008,7 +1008,7 @@ def custom_vjp_call_jaxpr_rule(in_err, enabled_errors, *in_vals, fun_jaxpr,
   checkified_fwd, fwd_out_tree = flatten_fun_output(checkified_fwd)
   all_outs = custom_derivatives.custom_vjp_call_p.bind(
       checkified_fun, checkified_fwd, bwd_, *err_vals, *in_vals, out_trees=out_trees,
-      symbolic_zeros=symbolic_zeros)
+      symbolic_zeros=symbolic_zeros, enable_jvp=enable_jvp)
   fst, out_metadata = lu.merge_linear_aux(fun_metadata, fwd_out_tree)
   if fst:
     err_and_out_tree, _ = out_metadata

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -600,7 +600,7 @@ class Trace(Generic[TracerType]):
     raise NotImplementedError(msg)
 
   def process_custom_vjp_call(self, primitive, fun, fwd, bwd, tracers,
-                              out_trees, symbolic_zeros):
+                              out_trees, symbolic_zeros, enable_jvp):
     msg = (f"{type(self)} must override process_custom_vjp_call "
            "to handle custom_vjp primitives")
     raise NotImplementedError(msg)

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -550,7 +550,7 @@ class BatchTrace(Trace):
     return vals, todo
 
   def process_custom_vjp_call(self, prim, fun, fwd, bwd, tracers, *, out_trees,
-                              symbolic_zeros):  # pytype: disable=signature-mismatch
+                              symbolic_zeros, enable_jvp):  # pytype: disable=signature-mismatch
     in_vals, in_dims = unzip2((t.val, t.batch_dim) for t in tracers)
     axis_size, = {x.shape[d] for x, d in zip(in_vals, in_dims)
                   if d is not not_mapped}
@@ -561,7 +561,7 @@ class BatchTrace(Trace):
                                out_dims2, in_dims, self.main.trace_type,
                                self.spmd_axis_name)
     out_vals = prim.bind(fun, fwd, bwd, *in_vals, out_trees=out_trees,
-                         symbolic_zeros=symbolic_zeros)
+                         symbolic_zeros=symbolic_zeros, enable_jvp=enable_jvp)
     fst, out_dims = lu.merge_linear_aux(out_dims1, out_dims2)
     if not fst:
       _, res_tree = out_trees()

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -470,12 +470,17 @@ class MapTrace(core.Trace):
     return map(partial(MapTracer, self), out_vals, out_axes())
 
   def process_custom_vjp_call(self, primitive, fun, fwd, bwd, tracers,
-                              out_trees, symbolic_zeros):
+                              out_trees, symbolic_zeros, enable_jvp):
     if symbolic_zeros:
       msg = ("custom_vjp with symbolic_zeros=True not supported with eager pmap. "
              "Please open an issue at https://github.com/google/jax/issues !")
       raise NotImplementedError(msg)
-    del primitive, fwd, bwd, out_trees, symbolic_zeros  # always base main, drop vjp
+    if enable_jvp:
+      msg = ("custom_vjp with enable_jvp=True not supported with eager pmap. "
+             "Please open an issue at https://github.com/google/jax/issues !")
+      raise NotImplementedError(msg)
+    # always base main, drop vjp
+    del primitive, fwd, bwd, out_trees, symbolic_zeros, enable_jvp
     in_vals, in_axes = unzip2((t.val, t.shard_axes) for t in tracers)
     fun, out_axes = _emap_subtrace(fun, self.main, in_axes)
     with core.new_sublevel():

--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -730,12 +730,12 @@ class ShardMapTrace(core.Trace):
     assert False  # unreachable
 
   def process_custom_vjp_call(self, prim, fun, fwd, bwd, tracers, out_trees,
-                              symbolic_zeros):
+                              symbolic_zeros, enable_jvp):
     # Since ShardMapTrace is only used as a base main, we can drop the jvp.
-    if symbolic_zeros:
+    if symbolic_zeros or enable_jvp:
       msg = "Please open an issue at https://github.com/google/jax/issues !"
       raise NotImplementedError(msg)
-    del prim, fwd, bwd, out_trees, symbolic_zeros
+    del prim, fwd, bwd, out_trees, symbolic_zeros, enable_jvp
     in_vals, in_rep = unzip2((t.val, t.rep) for t in tracers)
     fun, out_rep = _shmap_subtrace(fun, self.main, in_rep)
     with core.new_sublevel():
@@ -1113,7 +1113,7 @@ def _custom_jvp_call_check(mesh, *in_rep, call_jaxpr, jvp_jaxpr_thunk,
 @register_rewrite(custom_derivatives.custom_vjp_call_jaxpr_p)
 def _custom_vjp_call_jaxpr_rewrite(
     mesh, in_rep, *args, fun_jaxpr, fwd_jaxpr_thunk, bwd, num_consts, out_trees,
-    symbolic_zeros):
+    symbolic_zeros, enable_jvp):
   if symbolic_zeros:
     msg = "Please open an issue at https://github.com/google/jax/issues !"
     raise NotImplementedError(msg)
@@ -1133,7 +1133,8 @@ def _custom_vjp_call_jaxpr_rewrite(
 
   outs = custom_derivatives.custom_vjp_call_jaxpr_p.bind(
       *args, fun_jaxpr=fun_jaxpr_, fwd_jaxpr_thunk=fwd_jaxpr_thunk_, bwd=bwd_,
-      num_consts=num_consts, out_trees=out_trees, symbolic_zeros=symbolic_zeros)
+      num_consts=num_consts, out_trees=out_trees, symbolic_zeros=symbolic_zeros,
+      enable_jvp=enable_jvp)
   out_rep = out_rep2[0] if out_rep2 else out_rep
   return outs, out_rep
 
@@ -1695,7 +1696,7 @@ class RewriteTrace(core.Trace):
     assert False  # unreachable
 
   def process_custom_vjp_call(self, prim, fun, fwd, bwd, tracers, out_trees,
-                              symbolic_zeros):
+                              symbolic_zeros, enable_jvp):
     if symbolic_zeros:
       msg = "Please open an issue at https://github.com/google/jax/issues !"
       raise NotImplementedError(msg)
@@ -1706,7 +1707,7 @@ class RewriteTrace(core.Trace):
     bwd = _rewrite_bwd(bwd, self.mesh, out_reps2, in_reps)
     with core.new_dynamic(self.dyna):
       out_vals = prim.bind(fun, fwd, bwd, *in_vals, out_trees=out_trees,
-                          symbolic_zeros=symbolic_zeros)
+                          symbolic_zeros=symbolic_zeros, enable_jvp=enable_jvp)
     fst, out_reps = lu.merge_linear_aux(out_reps1, out_reps2)
     if not fst:
       _, res_tree = out_trees()

--- a/tests/ode_test.py
+++ b/tests/ode_test.py
@@ -216,7 +216,7 @@ class ODETest(jtu.JaxTestCase):
     def f(k):
       return odeint(lambda x, t: k*x, 1.,  jnp.linspace(0, 1., 50)).sum()
 
-    with self.assertRaisesRegex(TypeError, "can't apply forward-mode.*"):
+    with self.assertRaisesRegex(NotImplementedError, "vmap-of-jvp-of-custom_vjp"):
       jax.jacfwd(f)(3.)
 
   @jtu.skip_on_devices("tpu", "gpu")


### PR DESCRIPTION
This adds an `enable_jvp=False/True` flag to `custom_vjp.defvjp`. If `True`, then it will now support JVPs by computing the JVP of `fwd`, and discarding the residuals. As for why I took this approach:

- Alternative 1: compute the transpose of `bwd`. At least for my use case, this wouldn't work: my downstream `custom_vjp` has a `lax.while_loop` in both its forward and backward rules. Morally speaking a `custom_vjp` already indicates some kind of funny business for autodiff, so I think this would probably be an odd choice regardless.

- Alternative 2: compute the JVP of the original function. I don't think this is feasible for the following reason. Suppose we compute `out, lin_fn = jax.linearise(custom_vjp(...), ...)`. If `lin_fn` is then called, we would expect to follow the JVP path and use JVP-of-original-function. If `lin_fn` is transposed and called, we would expect to follow the VJP path and use both `fwd` and `bwd`. However, right now we don't know which will happen -- and in the mean time we are nevertheless obliged to make a choice, so that we can return the primals `out`.

    - Addendum: calling both `fwd` and the original function is obviously undesirable -- besides being inefficient, it would also generate a `StoreException` from the fact that both of these things have been ran.

In this PR, a few things still need to be implemented:
- the JVP rule for `custom_lin_p` (=jvp-jvp-custom_vjp)
- the batch rule for `custom_lin_p` (=vmap-jvp-custom_vjp)
- the `custom_vjp = custom_jvp + custom_transpose` implementation
- more than two tests!

But I wanted to gather some initial feedback before filling in these niceties.

WDYT?