### PR TITLE
[export] Adapt lowering caching to work with multi-platform lowering

### DIFF
--- a/jax/experimental/jax2tf/tests/multi_platform_export_test.py
+++ b/jax/experimental/jax2tf/tests/multi_platform_export_test.py
@@ -29,14 +29,6 @@ from jax.experimental.jax2tf.tests import primitive_harness
 def make_disjunction_regexp(*parts: str) -> re.Pattern[str]:
   return re.compile("(" + "|".join(parts) + ")")
 
-
-# TODO(necula): Failures to be investigated (on multiple platforms)
-_known_failures = make_disjunction_regexp(
-    "cumsum_",
-    "cumprod_",
-)
-
-
 # TODO(necula): Failures to be investigated (on GPU).
 _known_failures_gpu = make_disjunction_regexp(
     # Failures due to failure to export custom call targets for GPU, these
@@ -85,13 +77,8 @@ class PrimitiveTest(jtu.JaxTestCase):
       #one_containing="",
   )
   def test_prim(self, harness: primitive_harness.Harness):
-    if (
-        _known_failures.search(harness.fullname)
-        or (
-            jtu.device_under_test() == "gpu"
-            and _known_failures_gpu.search(harness.fullname)
-        )
-    ):
+    if (jtu.device_under_test() == "gpu"
+        and _known_failures_gpu.search(harness.fullname)):
       self.skipTest("failure to be investigated")
 
     func_jax = harness.dyn_fun
@@ -108,13 +95,7 @@ class PrimitiveTest(jtu.JaxTestCase):
         for d in self.__class__.devices
         if d.platform not in unimplemented_platforms
     ]
-    logging.info(
-        "Using devices %s",
-        [
-            (str(d), d.platform, d.device_kind, d.client.platform)
-            for d in devices
-        ],
-    )
+    logging.info("Using devices %s", [str(d) for d in devices])
     # lowering_platforms uses "cuda" instead of "gpu"
     lowering_platforms: list[str] = [
         p if p != "gpu" else "cuda"


### PR DESCRIPTION
Previously the mlir.cache_lowering was assuming that a primitive has
a unique lowering in a module for given input and output avals. But with
multi-platform lowering we need to allow multiple lowerings. We
fix this by adding the lowering function to the cache key.

This fixes the multi-platform lowering tests for cumsum and cumprod
 and a couple of primitives for TPUs.