### PR TITLE
Condition numpy versios based on python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,8 @@ setup(
     install_requires=[
         'ml_dtypes>=0.2.0',
         'numpy>=1.22',
+        "numpy>=1.23.2; python_version>='3.11'",
+        "numpy>=1.26.0; python_version>='3.12'",
         'opt_einsum',
         'scipy>=1.7',
         # Required by xla_bridge.discover_pjrt_plugins for forwards compat with


### PR DESCRIPTION
# Changes

Adds constraints to the version of numpy depending on the available python version based on wheel availability. Certain version of Numpy don't have wheels for certain version of Python, while technically numpy could be installed the build process is unlikely to succeed e.g. [example](https://github.com/google/flax/actions/runs/6408470644/job/17397565601#step:6:1559), so its better to constraint the numpy version similar to what is done in [ml-dtypes](https://github.com/jax-ml/ml_dtypes/blob/3155ae4e868afcbabda35d8b0d5c9ce67ea1572d/pyproject.toml#L21-L23).