### PR TITLE
jnp.bitwise_count: fix issue with unsigned ints

### DIFF
--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -201,7 +201,7 @@ def arccosh(x: ArrayLike, /) -> Array:
 @jit
 def bitwise_count(x: ArrayLike, /) -> Array:
   # Following numpy we take the absolute value and return uint8.
-  return lax.population_count(lax.abs(x)).astype('uint8')
+  return lax.population_count(abs(x)).astype('uint8')
 
 @_wraps(np.right_shift, module='numpy')
 @partial(jit, inline=True)

--- a/tests/lax_numpy_operators_test.py
+++ b/tests/lax_numpy_operators_test.py
@@ -576,7 +576,7 @@ class JaxNumpyOperatorTests(jtu.JaxTestCase):
 
   @jtu.sample_product(
     shape=array_shapes,
-    dtype=int_dtypes,
+    dtype=int_dtypes + unsigned_dtypes,
   )
   def testBitwiseCount(self, shape, dtype):
     # np.bitwise_count added after numpy 1.26, but


### PR DESCRIPTION
Fixes #17949

`lax.abs` is incompatible with unsigned ints, but `abs` works for any input type.