### PR TITLE
identify PRNG schemes on key arrays; recognize them in key constructors

### DIFF
--- a/jax/extend/random.py
+++ b/jax/extend/random.py
@@ -16,6 +16,9 @@
 # See PEP 484 & https://github.com/google/jax/issues/7570
 
 from jax._src.prng import (
+  # TODO(frostig,vanderplas): expose a define_prng_impl instead of the
+  # PRNGImpl constructor, to leave some room for us to register or check input,
+  # or to change what output type we return.
   PRNGImpl as PRNGImpl,
   seed_with_impl as seed_with_impl,
   threefry2x32_p as threefry2x32_p,

--- a/jax/random.py
+++ b/jax/random.py
@@ -155,6 +155,7 @@ from jax._src.random import (
   gumbel as gumbel,
   key as key,
   key_data as key_data,
+  key_impl as key_impl,
   laplace as laplace,
   logistic as logistic,
   loggamma as loggamma,


### PR DESCRIPTION
This change covers another iteration on #17768, following discussion there.

Specifically:

* Introduce `jax.random.key_impl`, which accepts a key array and returns a hashable identifier of its PRNG implementation.
* Accept this identifier optionally as the `impl` argument to `jax.random.key` and `wrap_key_data`.

This now works:

```python
k1 = jax.random.key(72, impl='threefry2x32')
impl = jax.random.key_impl(k1)
k2 = jax.random.key(72, impl=impl)
assert arrays_equal(k1, k2)
assert k1.dtype == k2.dtype
```

This change also set up an internal PRNG registry and register built-in implementations, to simplify various places where we essentially reconstruct such a registry from scratch (such as in tests).