### PR TITLE
fix pow jvp rule with int exponent (broken since #16419)

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1993,7 +1993,7 @@ def _pow_jvp_lhs(g, ans, x, y):
       shape = broadcast_shapes(x.shape, y.shape)
       x = _maybe_broadcast(shape, x)
       y = _maybe_broadcast(shape, y)
-    jac = select(eq(y, _const(y, 0)), _ones(y),
+    jac = select(eq(y, _const(y, 0)), _zeros(y),
                  mul(_replace_zero(y), pow(x, sub(y, _ones(y)))))
   else:
     jac = mul(y, pow(x, sub(y, _ones(y))))

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -539,7 +539,22 @@ class LaxAutodiffTest(jtu.JaxTestCase):
   def testPowIntPowerAtZero(self):
     # https://github.com/google/jax/issues/14397
     ans = jax.grad(jax.jit(lambda x, n: x ** n))(0., 0)
-    self.assertAllClose(ans, 1., check_dtypes=False)
+    self.assertAllClose(ans, 0., check_dtypes=False)
+
+  @jax.numpy_dtype_promotion('standard')  # This test explicitly exercises mixed type promotion
+  def testPowIntPowerAtZero2(self):
+    # https://github.com/google/jax/issues/17995
+    a = lambda z: jax.numpy.sum(z**jax.numpy.arange(0, 2, dtype=int))
+    b = lambda z: jax.numpy.sum(z**jax.numpy.arange(0, 2, dtype=float))
+    c = lambda z: 1 + z
+    d = lambda z: z ** 0 + z
+    e = lambda z: z ** 0. + z
+
+    self.assertAllClose(jax.grad(a)(3.14), 1., check_dtypes=False)
+    self.assertAllClose(jax.grad(b)(3.14), 1., check_dtypes=False)
+    self.assertAllClose(jax.grad(c)(3.14), 1., check_dtypes=False)
+    self.assertAllClose(jax.grad(d)(3.14), 1., check_dtypes=False)
+    self.assertAllClose(jax.grad(e)(3.14), 1., check_dtypes=False)
 
   @jtu.sample_product(
     [dict(arg_shape=arg_shape, pred_shape=pred_shape)


### PR DESCRIPTION
fixes #17995

Some instances of the pow jvp rule were broken by #16419. There was a 'ones' where we needed a 'zeros'! And the test was hardcoded wrong. Head-slap!

Concretely, we were giving incorrect derivatives for this: `lambda x: jnp.sum(x ** jnp.arange(2))` for any value of `2`. Basically any time we were raising to a power of an int-dtype array (not Python builtin types) with zeros in it, we were getting the wrong derivatives.

I'll send a follow up PR with at least one more test...