### PR TITLE
Add precision warning and workaround to jnp.arange documentation

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2317,7 +2317,16 @@ def identity(n: DimSize, dtype: DTypeLike | None = None) -> Array:
   return eye(n, dtype=dtype)
 
 
-@util._wraps(np.arange)
+@util._wraps(np.arange,lax_description= """
+.. note::
+
+   Using ``arange`` with the ``step`` argument can lead to precision errors,
+   especially with lower-precision data types like ``fp8`` and ``bf16``.
+   For more details, see the docstring of :func:`numpy.arange`.
+   To avoid precision errors, consider using an expression like
+   ``(jnp.arange(-600, 600) * .01).astype(jnp.bfloat16)`` to generate a sequence in a higher precision
+   and then convert it to the desired lower precision.
+""")
 def arange(start: DimSize, stop: Optional[DimSize] = None,
            step: DimSize | None = None, dtype: DTypeLike | None = None) -> Array:
   dtypes.check_user_dtype_supported(dtype, "arange")


### PR DESCRIPTION
This pull request addresses issue #17723. 

Changes made:
- Added a note to the `jnp.arange` function's documentation warning about potential precision errors when using the `step` argument, especially with lower-precision data types like `fp8` and `bf16`. 
- Provided a reference to the explanation in the NumPy documentation for more details.
- Suggested a workaround for generating a sequence of numbers in a higher precision and then converting it to the desired lower precision.

These changes aim to provide users with more information about potential issues when using the `step` argument in `jnp.arange` and offer a solution to avoid precision errors.