### PR TITLE
[export] Fix the call_exported in presence of shardings.

### DIFF
--- a/jax/experimental/export/export.py
+++ b/jax/experimental/export/export.py
@@ -116,6 +116,8 @@ class DisabledSafetyCheck:
 minimum_supported_serialization_version = 6
 maximum_supported_serialization_version = 8
 
+Sharding = Union[sharding.XLACompatibleSharding, pxla.UnspecifiedValue]
+
 @dataclasses.dataclass(frozen=True)
 class Exported:
   """A JAX function lowered to StableHLO.
@@ -133,9 +135,8 @@ class Exported:
         expressions in the shapes, with dimension variables among those in
         `in_avals.
     in_shardings: the flattened input shardings. Only for the inputs that are
-        specified in `module_kept_var_idx`. If `None` then it is equivalent
-        to unspecified shardings.
-    out_shardings: the flattened output shardings, as long as `in_avals`.
+        specified in `module_kept_var_idx`.
+    out_shardings: the flattened output shardings, as long as `out_avals`.
     lowering_platforms: a tuple containing at least one of 'tpu', 'cpu',
         'cuda', 'rocm'. See below for the calling convention for when
         there are multiple lowering platforms.
@@ -226,8 +227,8 @@ class Exported:
   out_tree: tree_util.PyTreeDef
   out_avals: tuple[core.AbstractValue, ...]
 
-  in_shardings: Optional[tuple[Union[sharding.XLACompatibleSharding, pxla.UnspecifiedValue], ...]]
-  out_shardings: Optional[tuple[Union[sharding.XLACompatibleSharding, pxla.UnspecifiedValue], ...]]
+  in_shardings: tuple[Sharding, ...]
+  out_shardings: tuple[Sharding, ...]
   lowering_platform: str  # For backwards compatibility
   lowering_platforms: tuple[str, ...]
   disabled_checks: Sequence[DisabledSafetyCheck]
@@ -826,14 +827,64 @@ def _check_module(mod: ir.Module, *,
            "See https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#native-lowering-supports-only-select-custom-calls")
     raise ValueError(msg)
 
+def expand_in_shardings(in_shardings: tuple[Sharding, ...],
+                        module_kept_var_idx: Sequence[int],
+                        nr_inputs: int) -> tuple[Sharding, ...]:
+  """Expands in_shardings with unspecified shardings for inputs not kept.
+
+  Assumes in_shardings corresponds to module_kept_var_idx.
+  """
+  assert len(in_shardings) == len(module_kept_var_idx)
+  assert nr_inputs >= len(module_kept_var_idx)
+  all_in_shardings: list[Sharding] = [sharding_impls.UNSPECIFIED] * nr_inputs
+  for idx, in_s in zip(sorted(module_kept_var_idx), in_shardings):
+    all_in_shardings[idx] = in_s
+  return tuple(all_in_shardings)
+
+# TODO(yashkatariya, necula): remove this function once we relax the checks
+# in the jit front-end.
+def canonical_shardings(
+    in_shardings: Sequence[Sharding],
+    out_shardings: Sequence[Sharding]
+    ) -> tuple[Union[pxla.UnspecifiedValue,
+                     Sequence[sharding.XLACompatibleSharding]],
+               Union[pxla.UnspecifiedValue,
+                     Sequence[sharding.XLACompatibleSharding]]]:
+  """Prepares canonical in_ and out_shardings for a jit invocation.
+
+  The pjit front-end is picky about what in- and out-shardings it accepts,
+  e.g., if all are unspecified then the whole sharding should be the
+  sharding_impls.UNSPECIFIED object, otherwise the unspecified shardings are
+  replaced with the replicated sharding.
+  """
+  # Prepare a replicated sharding, search in both the input and output shardings
+  specified_shardings = [
+      s for s in itertools.chain(in_shardings, out_shardings)
+      if not sharding_impls.is_unspecified(s)]
+  if specified_shardings:
+    in_s = specified_shardings[0]  # pjit will enforce that all have same devices
+    assert isinstance(in_s, sharding.XLACompatibleSharding)
+    replicated_s = sharding.GSPMDSharding.get_replicated(in_s._device_assignment)
+  else:
+    replicated_s = None
+
+  def canonicalize(
+    ss: Sequence[Sharding]) -> Union[pxla.UnspecifiedValue,
+                                     Sequence[sharding.XLACompatibleSharding]]:
+    if all(sharding_impls.is_unspecified(s) for s in ss):
+      return sharding_impls.UNSPECIFIED
+    return tuple(
+        s if not sharding_impls.is_unspecified(s) else replicated_s
+        for s in ss)
+  return (canonicalize(in_shardings), canonicalize(out_shardings))
 
 def _get_vjp_fun(primal_fun: Callable, *,
                  in_tree: tree_util.PyTreeDef,
                  in_avals: Sequence[core.AbstractValue],
                  out_avals: Sequence[core.AbstractValue],
                  module_kept_var_idx: tuple[int, ...],
-                 in_shardings,
-                 out_shardings,
+                 in_shardings: tuple[Sharding, ...],
+                 out_shardings: tuple[Sharding, ...],
                  apply_jit: bool
                  ) -> tuple[Callable, Sequence[core.AbstractValue]]:
   # Since jax.vjp does not handle kwargs, it is easier to do all the work
@@ -855,36 +906,11 @@ def _get_vjp_fun(primal_fun: Callable, *,
       itertools.chain(in_avals,
                       map(lambda a: a.at_least_vspace(), out_avals)))
 
-  # Expand in_shardings to all in_avals even not kept ones.
-  all_in_shardings = [sharding_impls.UNSPECIFIED] * len(in_avals)
-  for idx, in_s in zip(sorted(module_kept_var_idx),
-                       in_shardings):  # type: ignore
-    all_in_shardings[idx] = in_s  # type: ignore
-  all_shardings = all_in_shardings + list(out_shardings)  # type: ignore
-  # Cannot mix unspecified and specified shardings. Make the unspecified
-  # ones replicated.
-  specified_shardings = [
-      s for s in all_shardings if not sharding_impls.is_unspecified(s)]
-
-  vjp_in_shardings: Any  # The primal inputs followed by output cotangents
-  vjp_out_shardings: Any  # The primal output cotangents
-  if 0 == len(specified_shardings):
-    vjp_in_shardings = sharding_impls.UNSPECIFIED
-    vjp_out_shardings = sharding_impls.UNSPECIFIED
-  else:
-    if len(specified_shardings) < len(all_shardings):
-      # There are some specified, but not all; pjit front-end does not liwk
-      in_s = specified_shardings[0]  # pjit will enforce that all have same devices
-      assert isinstance(in_s, sharding.XLACompatibleSharding)
-      replicated_s = sharding.GSPMDSharding.get_replicated(in_s._device_assignment)
-      all_shardings = [
-          s if not sharding_impls.is_unspecified(s) else replicated_s
-          for s in all_shardings]
-
-    vjp_in_shardings = tuple(all_shardings)
-    vjp_out_shardings = tuple(all_shardings[:len(in_avals)])
-    if all(sharding_impls.is_unspecified(s) for s in vjp_out_shardings):
-      vjp_out_shardings = sharding_impls.UNSPECIFIED
+  all_in_shardings = expand_in_shardings(in_shardings,
+                                         module_kept_var_idx, len(in_avals))
+  vjp_in_shardings, vjp_out_shardings = canonical_shardings(
+    tuple(itertools.chain(all_in_shardings, out_shardings)),
+    all_in_shardings)
 
   if apply_jit:
     return pjit.pjit(fun_vjp_jax,
@@ -1037,6 +1063,13 @@ def _call_exported_lowering(ctx: mlir.LoweringRuleContext, *args,
   if exported.uses_shape_polymorphism:
     ctx.module_context.shape_poly_state.uses_dim_vars = True
 
+  # Apply in_shardings
+  all_in_shardings = expand_in_shardings(exported.in_shardings,
+                                         exported.module_kept_var_idx,
+                                         len(args))
+  args = tuple(
+    wrap_with_sharding(ctx, exported, x, x_aval, x_sharding)
+    for x, x_aval, x_sharding in zip(args, ctx.avals_in, all_in_shardings))
   submodule = ir.Module.parse(exported.mlir_module())
   symtab = ir.SymbolTable(submodule.operation)
   # The called function may have been exported with polymorphic shapes and called
@@ -1072,12 +1105,44 @@ def _call_exported_lowering(ctx: mlir.LoweringRuleContext, *args,
                              kept_args)
   # The ctx.avals_out already contain the abstract values refined by
   # _call_exported_abstract_eval.
-  return tuple(
+  results = tuple(
       convert_shape(out, out_aval, refined_out_aval)
       for out, out_aval, refined_out_aval in zip(call.results, exported.out_avals, ctx.avals_out))
+  # Apply out_shardings
+  results = tuple(
+    wrap_with_sharding(ctx, exported, x, x_aval, x_sharding)
+    for x, x_aval, x_sharding in zip(results, ctx.avals_out, exported.out_shardings)
+  )
+  return results
 
 
 for _p in ("cpu", "tpu", "cuda", "rocm"):
   mlir.register_lowering(call_exported_p,
                          functools.partial(_call_exported_lowering, platform=_p),
                          platform=_p)
+
+def wrap_with_sharding(ctx: mlir.LoweringRuleContext,
+                       exported: Exported,
+                       x: ir.Value,
+                       x_aval: core.AbstractValue,
+                       x_sharding: Sharding) -> ir.Value:
+  if sharding_impls.is_unspecified(x_sharding):
+    return x
+  axis_context = ctx.module_context.axis_context
+  if isinstance(axis_context, sharding_impls.ShardingContext):
+    ctx_device_assignment = axis_context.device_assignment
+  elif isinstance(axis_context, sharding_impls.SPMDAxisContext):
+    ctx_device_assignment = list(axis_context.mesh.devices.flat)
+  else:
+    raise NotImplementedError(type(axis_context))
+  assert isinstance(x_sharding, sharding_impls.XLACompatibleSharding)
+  sharding_device_assignment = x_sharding._device_assignment
+  if len(ctx_device_assignment) != len(sharding_device_assignment):
+    raise NotImplementedError(
+      f"Exported module {exported.fun_name} was lowered for "
+      f"{len(sharding_device_assignment)} devices and is called in a context with "
+      f"{len(ctx_device_assignment)} devices"
+    )
+  return mlir.wrap_with_sharding_op(
+    ctx, x, x_aval,
+    x_sharding._to_xla_hlo_sharding(x_aval.ndim).to_proto())

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -11,12 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import contextlib
 import functools
 import logging
 import math
 import re
-from typing import Optional, Sequence
+from typing import Sequence
 import unittest
 
 from absl.testing import absltest
@@ -25,6 +27,9 @@ from jax import numpy as jnp
 from jax import tree_util
 from jax.config import config
 from jax.experimental.export import export
+from jax.experimental import pjit
+from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
 
 from jax._src import core
 from jax._src import test_util as jtu
@@ -37,6 +42,17 @@ from jax._src.lib.mlir.dialects import hlo
 import numpy as np
 
 config.parse_flags_with_absl()
+
+prev_xla_flags = None
+def setUpModule():
+  global prev_xla_flags
+  # This will control the CPU devices. On TPU we always have 2 devices
+  prev_xla_flags = jtu.set_host_platform_device_count(2)
+
+# Reset to previous configuration in case other test modules will be run.
+def tearDownModule():
+  prev_xla_flags()
+
 
 # A primitive for testing multi-platform lowering. Takes one argument and
 # adds a different value to it: cpu=2., tpu=3., cuda=.4, rocm=5.
@@ -72,9 +88,11 @@ for platform in ["cpu", "tpu", "rocm"]:
 def _testing_multi_platform_func(x):
   return _testing_multi_platform_p.bind(x)
 
-def _testing_multi_platform_fun_expected(x):
-  return x + _testing_multi_platform_to_add[xb.canonicalize_platform(jtu.device_under_test())]
-
+def _testing_multi_platform_fun_expected(x,
+                                         platform: str | None = None):
+  return x + _testing_multi_platform_to_add[
+    xb.canonicalize_platform(platform or jtu.device_under_test())
+  ]
 
 class JaxExportTest(jtu.JaxTestCase):
 
@@ -88,6 +106,18 @@ class JaxExportTest(jtu.JaxTestCase):
       logging.info(
         "Using JAX serialization version %s",
         config.jax_serialization_version)
+
+  @classmethod
+  def setUpClass(cls):
+    # Find the available platforms
+    cls.platforms = []
+    for backend in ["cpu", "gpu", "tpu"]:
+      try:
+        jax.devices(backend)
+      except RuntimeError:
+        continue
+      cls.platforms.append(backend)
+    super(JaxExportTest, cls).setUpClass()
 
   def setUp(self):
     super().setUp()
@@ -586,7 +616,7 @@ class JaxExportTest(jtu.JaxTestCase):
            )),
   ])
   def test_shape_constraints_errors(self, *,
-      shape, poly_spec: str, expect_error: Optional[str] = None):
+      shape, poly_spec: str, expect_error: str | None = None):
     def f_jax(x):  # x: f32[a + 2*b, a, a + b + c]
       return 0.
 
@@ -600,49 +630,170 @@ class JaxExportTest(jtu.JaxTestCase):
           export.poly_spec(x.shape, x.dtype, poly_spec))
       export.call_exported(exp)(x)
 
+  def test_with_sharding(self):
+    nr_devices = 2
+    if len(jax.devices()) < nr_devices:
+      self.skipTest("Need at least 2 devices")
+    export_devices = jax.devices()[0:nr_devices]
+    export_mesh = Mesh(export_devices, axis_names=("x",))
+    a = np.arange(16 * 4, dtype=np.float32).reshape((16, 4))
+    @functools.partial(
+        jax.jit,
+        in_shardings=(jax.sharding.NamedSharding(export_mesh, P("x", None),),),
+        out_shardings=jax.sharding.NamedSharding(export_mesh, P(None, "x")))
+    def f_jax(b):  # b: f32[16 // DEVICES, 4]
+      return b * 2.
+
+    res_native = f_jax(a)
+    exp = export.export(f_jax)(a)
+
+    run_devices = export_devices[::-1]  # We can use other devices
+    run_mesh = Mesh(run_devices, "y")
+    a_device = jax.device_put(a, jax.sharding.NamedSharding(run_mesh, P()))
+
+    expected_re = re.compile(
+      # The top-level input it replicated
+      r"func.func .* @main\(%arg0: tensor<16x4xf32> {mhlo.sharding = \"{replicated}\"}\).*"
+      # We apply the in_shardings for f_jax
+      r".*custom_call @Sharding\(%arg0\) {mhlo.sharding = \"{devices=\[2,1\]<=\[2\]}\"}.*"
+      r"%1 = .*call @call_exported_f_jax.*"
+      # We apply the out_shardings for f_jax
+      r".*custom_call @Sharding\(%1\) {mhlo.sharding = \"{devices=\[1,2\]<=\[2\]}\"}.*",
+      re.DOTALL)
+    hlo = jax.jit(export.call_exported(exp)).lower(a_device).as_text()
+    self.assertRegex(hlo, expected_re)
+
+    res_exported = export.call_exported(exp)(a_device)
+    self.assertAllClose(res_native, res_exported)
+
+    # Test error reporting
+    with self.assertRaisesRegex(
+        NotImplementedError,
+        "Exported module .* was lowered for 2 devices and is called in a context with 1 device"):
+      _ = export.call_exported(exp)(a)
+
+    with self.assertRaisesRegex(
+        NotImplementedError,
+        "Exported module .* was lowered for 2 devices and is called in a context with 1 device"):
+      mesh1 = Mesh(jax.devices()[0:1], axis_names=("x",))
+      _ = jax.jit(
+        export.call_exported(exp),
+        in_shardings=(jax.sharding.NamedSharding(mesh1, P("x", None)),)
+      )(a)
+
+  @jtu.parameterized_filterable(
+    kwargs=[
+      dict(testcase_name=f"_in_shardings={in_shardings}_out_shardings={out_shardings}",
+           in_shardings=in_shardings, out_shardings=out_shardings)
+      for in_shardings in ("missing", None, "P")
+      for out_shardings in ("missing", None, "P")
+  ])
+  def test_grad_with_sharding(self, in_shardings="P", out_shardings=None):
+    if len(jax.devices()) < 2:
+      self.skipTest("Test requires at least 2 devices")
+    x_shape = (10, 20)
+    x = np.arange(np.prod(x_shape), dtype=np.float32).reshape(x_shape)
+    def f_jax(x):  # x: f32[10,20] -> f32[20,10]
+      return jnp.sin(x.T)
+
+    pjit_kwargs = {}
+    if in_shardings != "missing":
+      pjit_kwargs["in_shardings"] = (P(None, "x") if in_shardings == "P" else None)
+    if out_shardings != "missing":
+      pjit_kwargs["out_shardings"] = (P("x", None) if out_shardings == "P" else None)
+    f_jax = pjit.pjit(f_jax, **pjit_kwargs)
+
+    with Mesh(jax.devices()[:2], "x"):
+      exp = export.export(f_jax)(x)
+      exp_vjp = exp.vjp()
+
+    vjp_module_str = str(exp_vjp.mlir_module())
+
+    if in_shardings == "P":
+      primal_in_sharding = "{devices=[1,2]<=[2]}"
+    else:
+      primal_in_sharding = "{replicated}"
+    if out_shardings == "P":
+      primal_out_sharding = "{devices=[2,1]<=[2]}"
+    else:
+      primal_out_sharding = "{replicated}"
+
+    main = re.search(
+      r"func.func public @main\(%arg0: tensor<10x20xf32> {mhlo.sharding = \"([^\"]+)\""
+      r".*%arg1: tensor<20x10xf32> {mhlo.sharding = \"([^\"]+)\""
+      # result
+      r".* -> \(tensor<10x20xf32>.*mhlo.sharding = \"([^\"]+)\"",
+      vjp_module_str)
+    self.assertEqual(
+      main.groups(),
+      (primal_in_sharding, primal_out_sharding, primal_in_sharding))
+
+    # Custom calls for the primal input shape
+    primal_in_calls = re.findall(
+      r"custom_call @Sharding.* {mhlo.sharding = \"(.+)\"} : .*tensor<10x20xf32>",
+      vjp_module_str)
+    self.assertTrue(
+      all(s == primal_in_sharding for s in primal_in_calls),
+      primal_in_calls
+    )
+
+    # Custom calls for the primal output shape
+    primal_out_calls = re.findall(
+      r"custom_call @Sharding.* {mhlo.sharding = \"(.+)\"} : .*tensor<20x10xf32>",
+      vjp_module_str)
+    self.assertTrue(
+      all(s == primal_out_sharding for s in primal_out_calls),
+      primal_in_calls
+    )
+
   def test_multi_platform(self):
-    if jtu.test_device_matches(["gpu"]):
-      # The export is not applicable to GPU
-      raise unittest.SkipTest("Not intended for running on GPU")
-    x = np.arange(5, dtype=np.float32)
+    x = np.arange(8, dtype=np.float32)
     exp = export.export(_testing_multi_platform_func,
-                        lowering_platforms=('cpu', 'tpu'))(x)
-    self.assertEqual(exp.lowering_platforms, ('cpu', 'tpu'))
+                        lowering_platforms=("cpu", "tpu", "cuda"))(x)
+    self.assertEqual(exp.lowering_platforms, ("cpu", "tpu", "cuda"))
     module_str = str(exp.mlir_module())
     expected_main_re = (
       r"@main\("
       r"%arg0: tensor<i..> {jax.platform_index = true}.*, "
-      r"%arg1: tensor<5xf32>.* ->")
+      r"%arg1: tensor<8xf32>.* ->")
     self.assertRegex(module_str, expected_main_re)
 
     self.assertIn("jax.uses_shape_polymorphism = true",
                   module_str)
 
-    res = export.call_exported(exp)(x)
-    self.assertAllClose(res, _testing_multi_platform_fun_expected(x))
+    # Call with argument placed on different plaforms
+    for platform in self.__class__.platforms:
+      x_device = jax.device_put(x, jax.devices(platform)[0])
+      res_exp = export.call_exported(exp)(x_device)
+      self.assertAllClose(
+        res_exp,
+        _testing_multi_platform_fun_expected(x, platform=platform))
 
   def test_multi_platform_nested(self):
-    if jtu.test_device_matches(["tpu"]):
-      # The outer export is not applicable to TPU
-      raise unittest.SkipTest("Not intended for running on TPU")
     x = np.arange(5, dtype=np.float32)
     exp = export.export(_testing_multi_platform_func,
-                        lowering_platforms=('cpu', 'tpu', 'cuda'))(x)
-    self.assertEqual(exp.lowering_platforms, ('cpu', 'tpu', 'cuda'))
+                        lowering_platforms=("cpu", "tpu", "cuda"))(x)
+    self.assertEqual(exp.lowering_platforms, ("cpu", "tpu", "cuda"))
 
     # Now serialize the call to the exported using a different sequence of
     # lowering platforms, but included in the lowering platforms for the
     # nested exported.
     exp2 = export.export(export.call_exported(exp),
-                         lowering_platforms=('cpu', 'cuda'))(x)
-    res2 = export.call_exported(exp2)(x)
-    self.assertAllClose(res2, _testing_multi_platform_fun_expected(x))
+                         lowering_platforms=("cpu", "cuda"))(x)
+    # Call with argument placed on different plaforms
+    for platform in self.__class__.platforms:
+      if platform == "tpu": continue
+      x_device = jax.device_put(x, jax.devices(platform)[0])
+      res_exp = export.call_exported(exp2)(x_device)
+      self.assertAllClose(
+        res_exp,
+        _testing_multi_platform_fun_expected(x, platform=platform))
 
   def test_multi_platform_nested_inside_single_platform_export(self):
     x = np.arange(5, dtype=np.float32)
     exp = export.export(_testing_multi_platform_func,
-                        lowering_platforms=('cpu', 'tpu', 'cuda'))(x)
-    self.assertEqual(exp.lowering_platforms, ('cpu', 'tpu', 'cuda'))
+                        lowering_platforms=("cpu", "tpu", "cuda"))(x)
+    self.assertEqual(exp.lowering_platforms, ("cpu", "tpu", "cuda"))
 
     # Now serialize the call for the current platform.
     exp2 = export.export(export.call_exported(exp))(x)
@@ -657,7 +808,7 @@ class JaxExportTest(jtu.JaxTestCase):
       # The export is not applicable to GPU
       raise unittest.SkipTest("Not intended for running on GPU")
     exp = export.export(lambda x: jnp.reshape(_testing_multi_platform_func(x), (-1,)),
-                        lowering_platforms=('cpu', 'tpu'))(
+                        lowering_platforms=("cpu", "tpu"))(
         export.poly_spec((5, 6), np.float32, "b1, b2")
     )
     x = np.arange(12, dtype=np.float32).reshape((3, 4))
@@ -667,6 +818,31 @@ class JaxExportTest(jtu.JaxTestCase):
     exp2 = export.export(export.call_exported(exp))(x)
     res2 = export.call_exported(exp2)(x)
     self.assertAllClose(res2, _testing_multi_platform_fun_expected(x).reshape((-1,)))
+
+  def test_multi_platform_and_sharding(self):
+    export_devices = jax.devices()[0:2]
+    export_mesh = Mesh(export_devices, axis_names=("x",))
+    a = np.arange(16 * 4, dtype=np.float32).reshape((16, 4))
+    @functools.partial(
+        jax.jit,
+        in_shardings=(jax.sharding.NamedSharding(export_mesh, P("x", None),),),
+        out_shardings=jax.sharding.NamedSharding(export_mesh, P(None, "x")))
+    def f_jax(b):  # b: f32[16 // DEVICES, 4]
+      return b * 2.
+
+    res_native = f_jax(a)
+    exp = export.export(f_jax,
+                        lowering_platforms=("cpu", "tpu", "cuda"))(a)
+
+    # Call with argument placed on different plaforms
+    for platform in self.__class__.platforms:
+      run_devices = jax.devices(platform)[0:len(export_devices)]
+      if len(run_devices) != len(export_devices):
+        continue
+      run_mesh = Mesh(run_devices, ("x",))
+      a_device = jax.device_put(a, jax.sharding.NamedSharding(run_mesh, None))
+      res_exp = export.call_exported(exp)(a_device)
+      self.assertArraysAllClose(res_native, res_exp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, when we call_exported of an Exported module
with shardings, we invoke the right HLO but the enclosing
JAX computation does not know about the shardings of the
called module. This results in errors when invoking the
calling module.

We change call_exported lowering rules to add sharding
constraints for the inputs and the outputs and we add
a check that we call the exported module on the same
number of devices as at export time.