### PR TITLE
Update xmap guide - add jit/shard_map note

### DIFF
--- a/docs/notebooks/xmap_tutorial.ipynb
+++ b/docs/notebooks/xmap_tutorial.ipynb
@@ -8,13 +8,11 @@
    "source": [
     "# Named axes and easy-to-revise parallelism with `xmap`\n",
     "\n",
-    "This tutorial introduces `jax.xmap` and the named-axis programming model that comes with it. By reading this, you'll learn how to write error-avoiding, self-documenting functions using named axes, then control how they're executed on hardware at any scale, from your laptop CPU to the largest TPU supercomputer.\n",
+    "**_UPDATE:_** The recommended ways to do multi-device programming in JAX are using: 1) [`jit` (automatic partitioning of computation and `jax.Array` sharding)](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html); and/or 2) [`shard_map` (manual data sharding)](https://jax.readthedocs.io/en/latest/jep/14273-shard-map.html). Learn more in [Why don’t `pmap` or `xmap` already solve this?](https://jax.readthedocs.io/en/latest/jep/14273-shard-map.html#why-don-t-pmap-or-xmap-already-solve-this) in the [`shard_map` JEP document](https://jax.readthedocs.io/en/latest/jep/14273-shard-map.html).\n",
     "\n",
-    "We start with a toy neural network example.\n",
+    "This tutorial introduces JAX `xmap` (`jax.experimental.maps.xmap`) and the named-axis programming model that comes with it. By reading this, you'll learn how to write error-avoiding, self-documenting functions using named axes, then control how they're executed on hardware at any scale, from your laptop CPU to the largest TPU supercomputer.\n",
     "\n",
-    "---\n",
-    "> **xmap is an experimental API. Expect rough edges and changes in the future!**\n",
-    "---"
+    "We start with a toy neural network example."
    ]
   },
   {

--- a/docs/notebooks/xmap_tutorial.md
+++ b/docs/notebooks/xmap_tutorial.md
@@ -15,13 +15,11 @@ kernelspec:
 
 # Named axes and easy-to-revise parallelism with `xmap`
 
-This tutorial introduces `jax.xmap` and the named-axis programming model that comes with it. By reading this, you'll learn how to write error-avoiding, self-documenting functions using named axes, then control how they're executed on hardware at any scale, from your laptop CPU to the largest TPU supercomputer.
+**_UPDATE:_** The recommended ways to do multi-device programming in JAX are using: 1) [`jit` (automatic partitioning of computation and `jax.Array` sharding)](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html); and/or 2) [`shard_map` (manual data sharding)](https://jax.readthedocs.io/en/latest/jep/14273-shard-map.html). Learn more in [Why don’t `pmap` or `xmap` already solve this?](https://jax.readthedocs.io/en/latest/jep/14273-shard-map.html#why-don-t-pmap-or-xmap-already-solve-this) in the [`shard_map` JEP document](https://jax.readthedocs.io/en/latest/jep/14273-shard-map.html).
+
+This tutorial introduces JAX `xmap` (`jax.experimental.maps.xmap`) and the named-axis programming model that comes with it. By reading this, you'll learn how to write error-avoiding, self-documenting functions using named axes, then control how they're executed on hardware at any scale, from your laptop CPU to the largest TPU supercomputer.
 
 We start with a toy neural network example.
-
----
-> **xmap is an experimental API. Expect rough edges and changes in the future!**
----
 
 +++ {"id": "7kppYlqDLJg9"}
 


### PR DESCRIPTION
Adds a note to the `xmap` guide:

> UPDATE: The recommended ways to do multi-device programming in JAX are using: 1) `jit` (automatic partitioning of computation and `jax.Array` sharding); and/or 2) `shard_map` (manual data sharding). Learn more in Why don’t `pmap` or `xmap` already solve this? in the `shard_map` JEP document.
