### PR TITLE
jax.make_jaxpr: fix __name__ & related attributes

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2480,7 +2480,11 @@ def make_jaxpr(fun: Callable,
       return closed_jaxpr, tree_unflatten(out_tree(), out_shapes_flat)
     return closed_jaxpr
 
-  make_jaxpr_f.__name__ = f"make_jaxpr({make_jaxpr.__name__})"
+  make_jaxpr_f.__module__ = "jax"
+  if hasattr(fun, "__qualname__"):
+    make_jaxpr_f.__qualname__ = f"make_jaxpr({fun.__qualname__})"
+  if hasattr(fun, "__name__"):
+    make_jaxpr_f.__name__ = f"make_jaxpr({fun.__name__})"
   return make_jaxpr_f
 
 def _infer_src_sharding(src, x):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4351,6 +4351,14 @@ class APITest(jtu.JaxTestCase):
 
     jax.make_jaxpr(Foo(1))(3)  # don't crash
 
+  def test_make_jaxpr_name(self):
+    def foo(x, y, z):
+      return x + y + z
+    jfoo = jax.make_jaxpr(foo)
+    self.assertEqual(jfoo.__name__, f"make_jaxpr({foo.__name__})")
+    self.assertEqual(jfoo.__qualname__, f"make_jaxpr({foo.__qualname__})")
+    self.assertEqual(jfoo.__module__, "jax")
+
   def test_inner_jit_function_retracing(self):
     # https://github.com/google/jax/issues/7155
     inner_count = outer_count = 0


### PR DESCRIPTION
I noticed that the logic for the `__name__` attribute in `make_jaxpr` was incorrect.

Before:
```python
In [1]: import jax
   ...: def foo(x, y, z):
   ...:   return x + y + z
   ...: 

In [2]: jax.make_jaxpr(foo).__name__
Out[2]: 'make_jaxpr(make_jaxpr)'

In [3]: jax.make_jaxpr(foo)
Out[3]: <function __main__.foo(x, y, z)>
```
After:
```python
In [1]: import jax
   ...: def foo(x, y, z):
   ...:   return x + y + z
   ...: 

In [2]: jax.make_jaxpr(foo).__name__
Out[2]: 'make_jaxpr(foo)'

In [3]: jax.make_jaxpr(foo)
Out[3]: <function jax.make_jaxpr(foo)(x, y, z)>
```