### PR TITLE
Update README.md so that CPU install instruction works

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Some standouts:
 
 | Hardware   | Instructions                                                                                                    |
 |------------|-----------------------------------------------------------------------------------------------------------------|
-| CPU        | `pip install -U jax[cpu]`                                                                                       |
+| CPU        | `pip install -U "jax[cpu]"`                                                                                       |
 | NVIDIA GPU | `pip install -U "jax[cuda12_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html`        |
 | Google TPU | `pip install -U "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html`                 |
 | AMD GPU    | Use [Docker](https://hub.docker.com/r/rocm/jax) or [build from source](https://jax.readthedocs.io/en/latest/developer.html#additional-notes-for-building-a-rocm-jaxlib-for-amd-gpus). |


### PR DESCRIPTION
Fix readme #18034
current `pip install -U jax[cpu]` has no matches in pip `no matches found: jax[cpu]`. Corrected install instruction to `pip install -U "jax[cpu]"` which successfully installs cpu version of JAX via pip.