### PR TITLE
MAINT Migrate remaining internal/test modules to use state objects

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -116,8 +116,7 @@ def _nan_check_posthook(fun, args, kwargs, output):
     fun._cache_miss(*args, **kwargs)[0]  # probably won't return
 
 def _update_debug_special_global(_):
-  if (config.config._read("jax_debug_nans") or
-      config.config._read("jax_debug_infs")):
+  if config._read("jax_debug_nans") or config._read("jax_debug_infs"):
     jax_jit.global_state().post_hook = _nan_check_posthook
   else:
     jax_jit.global_state().post_hook = None

--- a/jax/_src/compiler.py
+++ b/jax/_src/compiler.py
@@ -305,7 +305,7 @@ def compile_or_get_cached(
   try:
     cache_key = compilation_cache.get_cache_key(
         computation, devices, compile_options, backend,
-        config.config.jax_use_original_compilation_cache_key_generation,
+        config.use_original_compilation_cache_key_generation.value,
     )
   except xc._xla.XlaRuntimeError as ex:
     logger.error("compile_or_get_cached: unable to generate cache key, "
@@ -324,7 +324,7 @@ def compile_or_get_cached(
 
     # TODO(b/293308239) Instrument metrics for new cache savings and cache hit
     # rate after it is enabled.
-    if config.config.jax_use_original_compilation_cache_key_generation:
+    if config.use_original_compilation_cache_key_generation.value:
       # TODO(b/293308239) Remove metrics for the original cache after the new
       # compilation cache key implementation is fully rolled out.
       monitoring.record_event('/jax/compilation_cache/cache_hits_original')

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -598,6 +598,16 @@ class NameSpace:
 
 
 config = Config()
+
+_read = config._read
+update = config.update
+define_bool_state = config.define_bool_state
+define_enum_state = config.define_enum_state
+define_int_state = config.define_int_state
+define_float_state = config.define_float_state
+define_string_state = config.define_string_state
+parse_flags_with_absl = config.parse_flags_with_absl
+
 flags = config
 FLAGS = flags.FLAGS
 

--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -63,8 +63,8 @@ class State:
     if local_device_ids:
       visible_devices = ','.join(str(x) for x in local_device_ids) # type: ignore[union-attr]
       logger.info('JAX distributed initialized with visible devices: %s', visible_devices)
-      config.config.update("jax_cuda_visible_devices", visible_devices)
-      config.config.update("jax_rocm_visible_devices", visible_devices)
+      config.update("jax_cuda_visible_devices", visible_devices)
+      config.update("jax_rocm_visible_devices", visible_devices)
 
     self.process_id = process_id
 

--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -21,9 +21,9 @@ import warnings
 
 import numpy as np
 
-from jax import config
 from jax import lax
 
+from jax._src import config
 from jax._src import core
 from jax._src import dtypes
 from jax._src import util
@@ -91,11 +91,12 @@ def _scatter_impl(x, y, scatter_op, treedef, static_idx, dynamic_idx,
 
   if not dtypes.safe_to_cast(y, x):
     # TODO(jakevdp): change this to an error after the deprecation period.
-    warnings.warn("scatter inputs have incompatible types: cannot safely cast "
-                  f"value from dtype={lax.dtype(y)} to dtype={lax.dtype(x)} "
-                  f"with jax_numpy_dtype_promotion={config.jax_numpy_dtype_promotion!r}. "
-                  "In future JAX releases this will result in an error.",
-                  FutureWarning)
+    warnings.warn(
+      "scatter inputs have incompatible types: cannot safely cast value "
+      f"from dtype={lax.dtype(y)} to dtype={lax.dtype(x)} with "
+      f"jax_numpy_dtype_promotion={config.numpy_dtype_promotion.value!r}. "
+      "In future JAX releases this will result in an error.",
+      FutureWarning)
 
   idx = jnp._merge_static_and_dynamic_indices(treedef, static_idx, dynamic_idx)
   indexer = jnp._index_to_gather(jnp.shape(x), idx,

--- a/jax/_src/tpu_custom_call.py
+++ b/jax/_src/tpu_custom_call.py
@@ -38,7 +38,7 @@ from jaxlib.mlir.dialects import stablehlo
 from jaxlib.mlir.passmanager import PassManager
 import numpy as np
 
-mosaic_use_cpp_passes = config.config.define_bool_state(
+_MOSAIC_USE_CPP_PASSES = config.define_bool_state(
     name="mosaic_use_cpp_passes",
     default=False,
     help=(
@@ -54,13 +54,13 @@ tpu = tpu_mosaic.tpu
 apply_vector_layout = tpu_mosaic.apply_vector_layout
 infer_memref_layout = tpu_mosaic.infer_memref_layout
 
-mosaic_allow_hlo = config.config.define_bool_state(
+_MOSAIC_ALLOW_HLO = config.define_bool_state(
     name="jax_mosaic_allow_hlo",
     default=False,
     help="Allow hlo dialects in Mosaic",
 )
 
-mosaic_dump_mlir = config.config.define_bool_state(
+_MOSAIC_DUMP_MLIR = config.define_bool_state(
     name="jax_mosaic_dump_mlir",
     default=False,
     help="Print mlir module after each pass",
@@ -243,7 +243,7 @@ def _lower_tpu_kernel(
       )
       dump_mlir(module, "initial module")
 
-      if mosaic_allow_hlo.value:
+      if _MOSAIC_ALLOW_HLO.value:
         # Run hlo dialect conversion: hlo -> linalg -> vector.
         pipeline = [
             "hlo-legalize-to-arithmetic",
@@ -255,7 +255,7 @@ def _lower_tpu_kernel(
         )
         dump_mlir(module, "after hlo conversion module")
 
-      if mosaic_use_cpp_passes.value:
+      if _MOSAIC_USE_CPP_PASSES.value:
         pipeline = [
             (
                 f"func.func(tpu-infer-memref-layout{{hardware-generation={hardware_generation}}})"
@@ -278,7 +278,7 @@ def _lower_tpu_kernel(
       module.operation.verify()
       dump_mlir(module, "after infer vector layout pass")
 
-      if mosaic_use_cpp_passes.value:
+      if _MOSAIC_USE_CPP_PASSES.value:
         pipeline = [
             (
                 "func.func(tpu-apply-vector-layout{sublane-count=8"
@@ -418,6 +418,6 @@ def _lowered_as_tpu_kernel(
 
 def dump_mlir(module: ir.Module, msg: str):
   """A helper function to print mlir module with a message."""
-  if mosaic_dump_mlir.value:
+  if _MOSAIC_DUMP_MLIR.value:
     print(f"[jax_mosaic_dump_mlir] {msg}")
     print(module)

--- a/jax/experimental/export/export.py
+++ b/jax/experimental/export/export.py
@@ -28,9 +28,9 @@ from absl import logging
 import numpy as np
 
 import jax
-from jax import config
 from jax import sharding
 
+from jax._src import config
 from jax._src import core
 from jax._src import dispatch
 from jax._src.interpreters import mlir
@@ -386,7 +386,7 @@ def export(fun_jax: Callable,
       exported = jax_export.export(f_jax)(*args, **kwargs)
   """
   fun_name = getattr(fun_jax, "__name__", "unknown")
-  version = config.jax_serialization_version
+  version = config.jax_serialization_version.value
   if (version < minimum_supported_serialization_version or
       version > maximum_supported_serialization_version):
     raise ValueError(

--- a/jax/experimental/export/shape_poly.py
+++ b/jax/experimental/export/shape_poly.py
@@ -48,9 +48,9 @@ import numpy as np
 import opt_einsum
 
 import jax
-from jax import config
 from jax.interpreters import xla
 
+from jax._src import config
 from jax._src import core
 from jax._src import dtypes
 from jax._src import effects
@@ -651,7 +651,7 @@ class _DimExpr():
           raise InconclusiveDimensionOperation("")
         remainder = 0
 
-      if config.jax_enable_checks:
+      if config.enable_checks.value:
         assert self == divisor * quotient + remainder
       return quotient, remainder
     except InconclusiveDimensionOperation:

--- a/jax/experimental/jax2tf/examples/saved_model_main_test.py
+++ b/jax/experimental/jax2tf/examples/saved_model_main_test.py
@@ -17,14 +17,14 @@ import os
 from absl import flags
 from absl.testing import absltest
 from absl.testing import parameterized
-import jax
+
 from jax._src import config
 from jax._src import test_util as jtu
 
 from jax.experimental.jax2tf.examples import saved_model_main
 from jax.experimental.jax2tf.tests import tf_test_util
 
-jax.config.parse_flags_with_absl()
+config.parse_flags_with_absl()
 FLAGS = flags.FLAGS
 
 

--- a/jax/experimental/jax2tf/tests/back_compat_test.py
+++ b/jax/experimental/jax2tf/tests/back_compat_test.py
@@ -26,7 +26,6 @@ from absl.testing import absltest, parameterized
 import numpy as np
 
 import jax
-from jax import config
 from jax import lax
 from jax.experimental.export import export
 from jax.experimental.jax2tf.tests import back_compat_test_util as bctu
@@ -60,6 +59,7 @@ import jax.numpy as jnp
 from jax.sharding import Mesh
 from jax.sharding import PartitionSpec as P
 
+from jax._src import config
 from jax._src import test_util as jtu
 
 config.parse_flags_with_absl()
@@ -159,7 +159,7 @@ class CompatTest(bctu.CompatTestBase):
       dict(testcase_name=f"_dtype={dtype_name}", dtype_name=dtype_name)
       for dtype_name in ("f32", "f64", "c64", "c128"))
   def test_cpu_cholesky_lapack_potrf(self, dtype_name="f32"):
-    if not config.jax_enable_x64 and dtype_name in ["f64", "c128"]:
+    if not config.enable_x64.value and dtype_name in ["f64", "c128"]:
       self.skipTest("Test disabled for x32 mode")
 
     dtype = dict(f32=np.float32, f64=np.float64,
@@ -179,7 +179,7 @@ class CompatTest(bctu.CompatTestBase):
       dict(testcase_name=f"_dtype={dtype_name}", dtype_name=dtype_name)
       for dtype_name in ("f32", "f64", "c64", "c128"))
   def test_cpu_eig_lapack_geev(self, dtype_name="f32"):
-    if not config.jax_enable_x64 and dtype_name in ["f64", "c128"]:
+    if not config.enable_x64.value and dtype_name in ["f64", "c128"]:
       self.skipTest("Test disabled for x32 mode")
 
     dtype = dict(f32=np.float32, f64=np.float64,
@@ -271,7 +271,7 @@ class CompatTest(bctu.CompatTestBase):
       for dtype_name in ("f32", "f64", "c64", "c128"))
   def test_cpu_eigh_lapack_syevd(self, dtype_name="f32"):
     # For lax.linalg.eigh
-    if not config.jax_enable_x64 and dtype_name in ["f64", "c128"]:
+    if not config.enable_x64.value and dtype_name in ["f64", "c128"]:
       self.skipTest("Test disabled for x32 mode")
 
     dtype = dict(f32=np.float32, f64=np.float64,
@@ -327,7 +327,7 @@ class CompatTest(bctu.CompatTestBase):
       for dtype_name in ("f32", "f64", "c64", "c128"))
   def test_cpu_qr_lapack_geqrf(self, dtype_name="f32"):
     # For lax.linalg.qr
-    if not config.jax_enable_x64 and dtype_name in ["f64", "c128"]:
+    if not config.enable_x64.value and dtype_name in ["f64", "c128"]:
       self.skipTest("Test disabled for x32 mode")
 
     dtype = dict(f32=np.float32, f64=np.float64,
@@ -395,7 +395,7 @@ class CompatTest(bctu.CompatTestBase):
       for dtype_name in ("f32", "f64", "c64", "c128"))
   def test_cpu_lu_lapack_getrf(self, dtype_name:str):
     # For lax.linalg.lu on CPU.
-    if not config.jax_enable_x64 and dtype_name in ["f64", "c128"]:
+    if not config.enable_x64.value and dtype_name in ["f64", "c128"]:
       self.skipTest("Test disabled for x32 mode")
     dtype = dict(f32=np.float32, f64=np.float64,
                  c64=np.complex64, c128=np.complex128)[dtype_name]
@@ -480,7 +480,7 @@ class CompatTest(bctu.CompatTestBase):
       for dtype_name in ("f32", "f64", "c64", "c128")])
   @jax.default_matmul_precision("float32")
   def test_cpu_schur_lapack_gees(self, dtype_name="f32"):
-    if not config.jax_enable_x64 and dtype_name in ["f64", "c128"]:
+    if not config.enable_x64.value and dtype_name in ["f64", "c128"]:
       self.skipTest("Test disabled for x32 mode")
 
     dtype = dict(f32=np.float32, f64=np.float64,
@@ -509,7 +509,7 @@ class CompatTest(bctu.CompatTestBase):
       for dtype_name in ("f32", "f64", "c64", "c128"))
   @jax.default_matmul_precision("float32")
   def test_cpu_svd_lapack_gesdd(self, dtype_name="f32"):
-    if not config.jax_enable_x64 and dtype_name in ["f64", "c128"]:
+    if not config.enable_x64.value and dtype_name in ["f64", "c128"]:
       self.skipTest("Test disabled for x32 mode")
 
     dtype = dict(f32=np.float32, f64=np.float64,
@@ -534,7 +534,7 @@ class CompatTest(bctu.CompatTestBase):
       for dtype_name in ("f32", "f64", "c64", "c128")])
   @jax.default_matmul_precision("float32")
   def test_cpu_triangular_solve_blas_trsm(self, dtype_name="f32"):
-    if not config.jax_enable_x64 and dtype_name in ["f64", "c128"]:
+    if not config.enable_x64.value and dtype_name in ["f64", "c128"]:
       self.skipTest("Test disabled for x32 mode")
 
     dtype = dict(f32=np.float32, f64=np.float64,
@@ -669,16 +669,11 @@ class CompatTest(bctu.CompatTestBase):
     # replace this strict check with something else.
     data = self.load_testdata(stablehlo_dynamic_rng_bit_generator.data_2023_06_17)
 
-    prev_default_prng_impl = jax.config.jax_default_prng_impl
-    try:
-      jax.config.update("jax_default_prng_impl", "unsafe_rbg")
-
+    with config.default_prng_impl("unsafe_rbg"):
       self.run_one_test(
         func, data, polymorphic_shapes=(None, "b0, b1"),
         # Recent serializations also include shape_assertion, tested with dynamic_top_k
         expect_current_custom_calls=["stablehlo.dynamic_rng_bit_generator", "shape_assertion"])
-    finally:
-      jax.config.update("jax_default_prng_impl", prev_default_prng_impl)
 
   def test_stablehlo_dynamic_top_k(self):
     # stablehlo.dynamic_top_k is used temporarily for a top_k with dynamism

--- a/jax/experimental/jax2tf/tests/jax2tf_limitations.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_limitations.py
@@ -20,9 +20,9 @@ from typing import Any, Callable, Optional, Union
 import jax
 from jax import lax
 from jax import numpy as jnp
-from jax import config
-from jax._src import test_util as jtu
+from jax._src import config
 from jax._src import dtypes
+from jax._src import test_util as jtu
 from jax.experimental.jax2tf.tests import primitive_harness
 import numpy as np
 
@@ -114,7 +114,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
     """Checks if this limitation is enabled for dtype and device and mode."""
     native_serialization_mask = (
         Jax2TfLimitation.FOR_NATIVE
-        if config.jax2tf_default_native_serialization
+        if config.jax2tf_default_native_serialization.value
         else Jax2TfLimitation.FOR_NON_NATIVE)
     return ((mode is None or mode in self.modes) and
             (self.native_serialization & native_serialization_mask) and

--- a/jax/experimental/jax2tf/tests/jax_primitives_coverage_test.py
+++ b/jax/experimental/jax2tf/tests/jax_primitives_coverage_test.py
@@ -28,9 +28,10 @@ import unittest
 
 from absl.testing import absltest
 
+import jax
+from jax._src import config
 from jax._src import test_util as jtu
 from jax._src import maps  # Needed for config flags.
-from jax import config
 
 import numpy as np
 
@@ -139,7 +140,7 @@ class JaxPrimitiveTest(jtu.JaxTestCase):
       raise unittest.SkipTest("Set JAX_OUTPUT_LIMITATIONS_DOC=1 to enable the generation of the documentation")
     # The CPU/GPU have more supported types than TPU.
     self.assertEqual("cpu", jtu.device_under_test(), "The documentation can be generated only on CPU")
-    self.assertTrue(config.x64_enabled, "The documentation must be generated with JAX_ENABLE_X64=1")
+    self.assertTrue(config.enable_x64.value, "The documentation must be generated with JAX_ENABLE_X64=1")
 
     with open(os.path.join(os.path.dirname(__file__),
                            '../g3doc/jax_primitives_coverage.md.template')) as f:

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -67,8 +67,7 @@ from jax._src import random as jax_random
 # then the test file has to import jtu first (to define the flags) which is not
 # desired if the test file is outside of this project (we don't want a
 # dependency on jtu outside of jax repo).
-jax.config.parse_flags_with_absl()
-FLAGS = config.FLAGS
+config.parse_flags_with_absl()
 
 Rng = Any  # A random number generator
 DType = Any

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -72,7 +72,7 @@ from jax._src.interpreters import xla
 import numpy as np
 import tensorflow as tf  # type: ignore[import]
 
-jax.config.parse_flags_with_absl()
+config.parse_flags_with_absl()
 
 # Import after parsing flags
 from jax.experimental.jax2tf.tests import tf_test_util

--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -29,7 +29,6 @@ import jax
 from jax import lax
 from jax import tree_util
 from jax import vmap
-from jax import config
 from jax.experimental.sparse._base import JAXSparse
 from jax.experimental.sparse.util import (
   nfold_vmap, _count_stored_elements,
@@ -41,6 +40,7 @@ from jax._src.interpreters import mlir
 import jax.numpy as jnp
 from jax.util import safe_zip, unzip2, split_list
 from jax._src import api_util
+from jax._src import config
 from jax._src import core
 from jax._src import dispatch
 from jax._src.interpreters import ad
@@ -784,7 +784,7 @@ def _bcoo_dot_general_fallback(data, indices, spinfo):
 def _bcoo_dot_general_gpu_impl(lhs_data, lhs_indices, rhs, *,
                                dimension_numbers, preferred_element_type,
                                lhs_spinfo):
-  if not config.jax_bcoo_cusparse_lowering:
+  if not config.bcoo_cusparse_lowering.value:
     return _bcoo_dot_general_impl(lhs_data, lhs_indices, rhs,
         dimension_numbers=dimension_numbers,
         preferred_element_type=preferred_element_type,

--- a/jax/experimental/sparse/bcsr.py
+++ b/jax/experimental/sparse/bcsr.py
@@ -25,7 +25,6 @@ import numpy as np
 
 import jax
 import jax.numpy as jnp
-from jax import config
 from jax import lax
 from jax import tree_util
 from jax.experimental.sparse._base import JAXSparse
@@ -37,6 +36,7 @@ from jax.experimental.sparse.util import (
 from jax.util import split_list, safe_zip
 
 from jax._src import api_util
+from jax._src import config
 from jax._src import core
 from jax._src import dispatch
 from jax._src.lax.lax import DotDimensionNumbers, _dot_general_batch_dim_nums
@@ -623,7 +623,7 @@ def _bcsr_dot_general_gpu_lowering(
     ctx, lhs_data, lhs_indices, lhs_indptr, rhs, *, dimension_numbers,
     preferred_element_type, lhs_spinfo: SparseInfo):
 
-  if not config.jax_bcoo_cusparse_lowering:
+  if not config.bcoo_cusparse_lowering.value:
     return _bcsr_dot_general_default_lowering(
       ctx, lhs_data, lhs_indices, lhs_indptr, rhs,
       dimension_numbers=dimension_numbers,

--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -17,9 +17,9 @@ import unittest
 from absl.testing import absltest
 
 import jax
-from jax import config
 import jax.dlpack
 import jax.numpy as jnp
+from jax._src import config
 from jax._src import test_util as jtu
 from jax._src.lib import xla_extension_version
 
@@ -115,7 +115,8 @@ class DLPackTest(jtu.JaxTestCase):
   )
   @unittest.skipIf(not tf, "Test requires TensorFlow")
   def testTensorFlowToJax(self, shape, dtype):
-    if not config.x64_enabled and dtype in [jnp.int64, jnp.uint64, jnp.float64]:
+    if (not config.enable_x64.value and
+        dtype in [jnp.int64, jnp.uint64, jnp.float64]):
       raise self.skipTest("x64 types are disabled by jax_enable_x64")
     if (jtu.test_device_matches(["gpu"]) and
         not tf.config.list_physical_devices("GPU")):
@@ -138,8 +139,8 @@ class DLPackTest(jtu.JaxTestCase):
   )
   @unittest.skipIf(not tf, "Test requires TensorFlow")
   def testJaxToTensorFlow(self, shape, dtype):
-    if not config.x64_enabled and dtype in [jnp.int64, jnp.uint64,
-                                              jnp.float64]:
+    if (not config.enable_x64.value and
+        dtype in [jnp.int64, jnp.uint64, jnp.float64]):
       self.skipTest("x64 types are disabled by jax_enable_x64")
     if (jtu.test_device_matches(["gpu"]) and
         not tf.config.list_physical_devices("GPU")):
@@ -159,7 +160,7 @@ class DLPackTest(jtu.JaxTestCase):
     # See https://github.com/google/jax/issues/11895
     x = jax.dlpack.from_dlpack(
         tf.experimental.dlpack.to_dlpack(tf.ones((2, 3), tf.int64)))
-    dtype_expected = jnp.int64 if config.x64_enabled else jnp.int32
+    dtype_expected = jnp.int64 if config.enable_x64.value else jnp.int32
     self.assertEqual(x.dtype, dtype_expected)
 
   @jtu.sample_product(

--- a/tests/cache_key_test.py
+++ b/tests/cache_key_test.py
@@ -35,7 +35,6 @@ from jax._src.lib import xla_extension_version
 
 
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 
 class CacheKeyTest(jtu.JaxTestCase):

--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -21,15 +21,15 @@ import numpy as np
 
 import jax
 from jax import lax
-import jax._src.test_util as jtu
-from jax._src.lib import xla_extension
-from jax import config
 from jax.experimental import checkify
 from jax.experimental import pjit
 from jax.sharding import NamedSharding
 from jax._src import array
+from jax._src import config
 from jax._src import core
+from jax._src import test_util as jtu
 from jax._src.checkify import JaxRuntimeError, FailedCheckError, ErrorEffect, OOBError
+from jax._src.lib import xla_extension
 import jax.numpy as jnp
 
 config.parse_flags_with_absl()
@@ -1305,12 +1305,7 @@ class AssertPrimitiveTests(jtu.JaxTestCase):
 class LowerableChecksTest(jtu.JaxTestCase):
   def setUp(self):
     super().setUp()
-    self.prev = config.jax_experimental_unsafe_xla_runtime_errors
-    config.update("jax_experimental_unsafe_xla_runtime_errors", True)
-
-  def tearDown(self):
-    config.update("jax_experimental_unsafe_xla_runtime_errors", self.prev)
-    super().tearDown()
+    self.enter_context(config.xla_runtime_errors(True))
 
   @jtu.run_on_devices("cpu", "gpu")
   def test_jit(self):

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -24,16 +24,13 @@ from absl.testing import parameterized
 import numpy as np
 
 import jax
-from jax._src import dtypes
 from jax import numpy as jnp
-
+from jax._src import config
+from jax._src import dtypes
 from jax._src import test_util as jtu
 from jax._src.lax import lax as lax_internal
 
-from jax._src.config import config
 config.parse_flags_with_absl()
-
-FLAGS = config.FLAGS
 
 bool_dtypes = [np.dtype('bool')]
 
@@ -102,7 +99,7 @@ class DtypesTest(jtu.JaxTestCase):
         True: _EXPECTED_CANONICALIZE_X64,
         False: _EXPECTED_CANONICALIZE_X32,
     }
-    for in_dtype, expected_dtype in expected[config.x64_enabled].items():
+    for in_dtype, expected_dtype in expected[config.enable_x64.value].items():
       self.assertEqual(dtypes.canonicalize_dtype(in_dtype), expected_dtype)
 
   @parameterized.named_parameters(
@@ -371,7 +368,7 @@ class DtypesTest(jtu.JaxTestCase):
       dtypes.dtype(None)
 
   def testDefaultDtypes(self):
-    precision = config.jax_default_dtype_bits
+    precision = config.default_dtype_bits.value
     assert precision in ['32', '64']
     self.assertEqual(dtypes.bool_, np.bool_)
     self.assertEqual(dtypes.int_, np.int32 if precision == '32' else np.int64)
@@ -450,7 +447,7 @@ class TestPromotionTables(jtu.JaxTestCase):
     # Note: * here refers to weakly-typed values
     typecodes = \
         ['b1','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*']
-    if config.x64_enabled:
+    if config.enable_x64.value:
       expected = [
         ['b1','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*'],
         ['u1','u1','u2','u4','u8','i2','i2','i4','i8','bf','f2','f4','f8','c4','c8','u1','f*','c*'],

--- a/tests/dynamic_api_test.py
+++ b/tests/dynamic_api_test.py
@@ -32,7 +32,6 @@ from jax._src import core
 from jax._src import test_util as jtu
 
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 
 @jtu.with_config(jax_dynamic_shapes=True, jax_numpy_rank_promotion="allow")

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -22,16 +22,14 @@ from absl.testing import parameterized
 import jax
 import jax.numpy as jnp
 from jax import grad, jit, vmap, lax
-from jax._src import config as jax_config
+from jax._src import config
 from jax._src import core
-from jax._src import test_util as jtu
 from jax._src import source_info_util
+from jax._src import test_util as jtu
 from jax._src import traceback_util
 
 
-from jax import config
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 
 def get_exception(etype, f):
@@ -43,7 +41,7 @@ def get_exception(etype, f):
 
 def check_filtered_stack_trace(test, etype, f, frame_patterns=(),
                                filter_mode="remove_frames"):
-  with jax_config.traceback_filtering(filter_mode):
+  with config.traceback_filtering(filter_mode):
     test.assertRaises(etype, f)
     e = get_exception(etype, f)
   c = e.__cause__

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -23,11 +23,11 @@ from absl.testing import parameterized
 import jax
 from jax import lax
 from jax import numpy as jnp
+from jax._src import config
 from jax._src import dtypes
 from jax._src import test_util as jtu
 from jax._src.numpy.util import promote_dtypes_complex
 
-from jax import config
 config.parse_flags_with_absl()
 
 FFT_NORMS = [None, "ortho", "forward", "backward"]
@@ -129,7 +129,7 @@ class FftTest(jtu.JaxTestCase):
 
   @parameterized.parameters((np.float32,), (np.float64,))
   def testLaxIrfftDoesNotMutateInputs(self, dtype):
-    if dtype == np.float64 and not config.x64_enabled:
+    if dtype == np.float64 and not config.enable_x64.value:
       raise self.skipTest("float64 requires jax_enable_x64=true")
     x = (1 + 1j) * jnp.array([[1.0, 2.0], [3.0, 4.0]],
                              dtype=dtypes.to_complex_dtype(dtype))
@@ -162,7 +162,7 @@ class FftTest(jtu.JaxTestCase):
                             tol=1e-4)
     self._CompileAndCheck(jnp_fn, args_maker)
     # Test gradient for differentiable types.
-    if (config.x64_enabled and
+    if (config.enable_x64.value and
         dtype in (float_dtypes if real and not inverse else inexact_dtypes)):
       # TODO(skye): can we be more precise?
       tol = 0.15

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -28,17 +28,17 @@ from absl.testing import absltest
 
 import jax
 from jax import ad_checkpoint
-from jax._src import core
 from jax import config
 from jax import dtypes
-from jax.experimental import host_callback as hcb
-from jax.sharding import PartitionSpec as P
-from jax.experimental import pjit
 from jax import lax
 from jax import numpy as jnp
-from jax._src import test_util as jtu
 from jax import tree_util
+from jax.experimental import host_callback as hcb
+from jax.experimental import pjit
+from jax.sharding import PartitionSpec as P
+from jax._src import core
 from jax._src import xla_bridge
+from jax._src import test_util as jtu
 from jax._src.lib import xla_client
 
 xops = xla_client.ops
@@ -46,7 +46,6 @@ xops = xla_client.ops
 import numpy as np
 
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 
 class _TestingOutputStream:
@@ -333,7 +332,7 @@ class HostCallbackTapTest(jtu.JaxTestCase):
       ( 6.00 9.00 )""")
 
   def test_tap_eval_exception(self):
-    if not FLAGS.jax_host_callback_outfeed:
+    if not hcb._HOST_CALLBACK_OUTFEED.value:
       raise SkipTest("TODO: implement error handling for customcall")
     # Simulate a tap error
     def tap_err(*args, **kwargs):
@@ -818,7 +817,7 @@ class HostCallbackTapTest(jtu.JaxTestCase):
     self.assertEqual(100, count)
 
   def test_tap_jit_tap_exception(self):
-    if not FLAGS.jax_host_callback_outfeed:
+    if not hcb._HOST_CALLBACK_OUTFEED.value:
       raise SkipTest("TODO: implement error handling for customcall")
     # Simulate a tap error
     def tap_err(*args, **kwargs):
@@ -1541,7 +1540,7 @@ class HostCallbackTapTest(jtu.JaxTestCase):
   @jtu.sample_product(device_index=[0, 1])
   def test_tap_pjit(self, device_index=0):
     if (device_index != 0 and
-        not FLAGS.jax_host_callback_outfeed and
+        not hcb._HOST_CALLBACK_OUTFEED.value and
         jtu.test_device_matches(["cpu"])):
       # See comment in host_callback.py.
       raise SkipTest("device_index works only with outfeed on CPU")

--- a/tests/host_callback_to_tf_test.py
+++ b/tests/host_callback_to_tf_test.py
@@ -39,7 +39,6 @@ except ImportError:
   tf = None
 
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 
 def call_tf_no_ad(tf_fun: Callable, arg, *, result_shape):

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -17,14 +17,14 @@ import inspect
 from absl.testing import absltest
 from absl.testing import parameterized
 import jax
-from jax._src import core
-from jax._src import api_util
-from jax._src.interpreters import pxla
 from jax import dtypes
-from jax._src import lib as jaxlib
 from jax import numpy as jnp
+from jax._src import api_util
+from jax._src import config
+from jax._src import core
+from jax._src import lib as jaxlib
 from jax._src import test_util as jtu
-from jax import config
+from jax._src.interpreters import pxla
 import numpy as np
 
 config.parse_flags_with_absl()
@@ -136,7 +136,7 @@ class JaxJitTest(jtu.JaxTestCase):
       self.assertEqual(jnp.asarray(bool_value).dtype, res.dtype)
 
     # Complex
-    if not (config.x64_enabled and jtu.test_device_matches(["tpu"])):
+    if not (config.enable_x64.value and jtu.test_device_matches(["tpu"])):
       # No TPU support for complex128.
       res = np.asarray(_cpp_device_put(1 + 1j, device))
       self.assertEqual(res, 1 + 1j)
@@ -145,7 +145,7 @@ class JaxJitTest(jtu.JaxTestCase):
 
   def test_arg_signature_of_value(self):
     """Tests the C++ code-path."""
-    jax_enable_x64 = config.x64_enabled
+    jax_enable_x64 = config.enable_x64.value
 
     # 1. Numpy scalar types
     for dtype in jtu.supported_dtypes():

--- a/tests/jaxpr_effects_test.py
+++ b/tests/jaxpr_effects_test.py
@@ -19,20 +19,20 @@ import warnings
 from absl.testing import absltest
 import jax
 import jax.numpy as jnp
-from jax._src import core
 from jax import lax
-from jax._src import effects
-from jax._src import linear_util as lu
-from jax import config
 from jax.experimental import maps
 from jax.experimental import pjit
-from jax._src.interpreters import ad
-from jax._src.interpreters import partial_eval as pe
-from jax._src.interpreters import mlir
 from jax._src import ad_checkpoint
 from jax._src import dispatch
+from jax._src import config
+from jax._src import core
+from jax._src import effects
+from jax._src import linear_util as lu
 from jax._src import test_util as jtu
 from jax._src import util
+from jax._src.interpreters import ad
+from jax._src.interpreters import mlir
+from jax._src.interpreters import partial_eval as pe
 import numpy as np
 
 config.parse_flags_with_absl()
@@ -297,8 +297,7 @@ class EffectfulJaxprLoweringTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
-    self.old_x64 = config.jax_enable_x64
-    config.update('jax_enable_x64', False)
+    self.enter_context(config.enable_x64(False))
     self._old_lowering = mlir._lowerings[effect_p]
     def _effect_lowering(ctx, *, effect):
       if effects.ordered_effects.contains(effect):
@@ -315,7 +314,6 @@ class EffectfulJaxprLoweringTest(jtu.JaxTestCase):
   def tearDown(self):
     super().tearDown()
     dispatch.runtime_tokens.clear()
-    config.update('jax_enable_x64', self.old_x64)
     mlir.register_lowering(effect_p, self._old_lowering)
 
   def test_can_lower_lowerable_effect(self):

--- a/tests/jaxpr_util_test.py
+++ b/tests/jaxpr_util_test.py
@@ -20,10 +20,10 @@ from absl.testing import absltest
 
 import jax
 from jax import jit, make_jaxpr, numpy as jnp
+from jax._src import config
 from jax._src import jaxpr_util
-from jax._src.lib import xla_client
 from jax._src import test_util as jtu
-from jax import config
+from jax._src.lib import xla_client
 
 
 config.parse_flags_with_absl()
@@ -67,15 +67,15 @@ class JaxprStatsTest(jtu.JaxTestCase):
 
     hist = jaxpr_util.primitives_by_shape(make_jaxpr(f)(1., 1.).jaxpr)
 
-    t = '64' if config.x64_enabled else '32'
+    t = '64' if config.enable_x64.value else '32'
     shapes = [
         f'add :: float{t}[]',
         f'sin :: float{t}[]',
         f'cos :: float{t}[]',
         f'reduce_sum :: float{t}[]',
         f'concatenate :: float{t}[2]',
+        f'pjit :: float{t}[] *',
     ]
-    shapes.append(f'pjit :: float{t}[] *')
     for k in shapes:
       self.assertEqual(hist[k], 1)
 

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -33,7 +33,6 @@ from jax.test_util import check_grads
 
 from jax import config
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 
 compatible_shapes = [[(3,)],

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -30,13 +30,13 @@ from jax import lax
 from jax import numpy as jnp
 from jax import ops
 
+from jax._src import config
 from jax._src import dtypes
 from jax._src import test_util as jtu
 from jax._src import util
-from jax._src.util import NumpyComplexWarning
 from jax._src.lax import lax as lax_internal
+from jax._src.util import NumpyComplexWarning
 
-from jax import config
 config.parse_flags_with_absl()
 
 # We disable the whitespace continuation check in this file because otherwise it
@@ -60,7 +60,7 @@ class IndexSpec(typing.NamedTuple):
 
 def check_grads(f, args, order, atol=None, rtol=None, eps=None):
   # TODO(mattjj,dougalm): add higher-order check
-  default_tol = 1e-6 if config.x64_enabled else 1e-2
+  default_tol = 1e-6 if config.enable_x64.value else 1e-2
   atol = atol or default_tol
   rtol = rtol or default_tol
   eps = eps or default_tol

--- a/tests/lax_numpy_operators_test.py
+++ b/tests/lax_numpy_operators_test.py
@@ -31,12 +31,11 @@ import jax.ops
 from jax import lax
 from jax import numpy as jnp
 
+from jax._src import config
 from jax._src import dtypes
 from jax._src import test_util as jtu
 
-from jax import config
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 nonempty_nonscalar_array_shapes = [(4,), (3, 4), (3, 1), (1, 4), (2, 1, 4), (2, 3, 4)]
 nonempty_array_shapes = [()] + nonempty_nonscalar_array_shapes
@@ -612,7 +611,7 @@ class JaxNumpyOperatorTests(jtu.JaxTestCase):
                  np.issubdtype(shift_dtype, np.signedinteger)
     has_32 = any(np.iinfo(d).bits == 32 for d in dtypes)
     promoting_to_64 = has_32 and signed_mix
-    if promoting_to_64 and not config.x64_enabled:
+    if promoting_to_64 and not config.enable_x64.value:
       self.skipTest("np.right_shift/left_shift promoting to int64"
                     "differs from jnp in 32 bit mode.")
 

--- a/tests/lax_numpy_reducers_test.py
+++ b/tests/lax_numpy_reducers_test.py
@@ -31,8 +31,7 @@ from jax._src import dtypes
 from jax._src import test_util as jtu
 from jax._src.util import NumpyComplexWarning
 
-jax.config.parse_flags_with_absl()
-FLAGS = config.FLAGS
+config.parse_flags_with_absl()
 
 numpy_version = jtu.numpy_version()
 

--- a/tests/lax_numpy_ufuncs_test.py
+++ b/tests/lax_numpy_ufuncs_test.py
@@ -26,7 +26,6 @@ from jax._src.numpy.ufunc_api import get_if_single_primitive
 
 from jax import config
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 
 def scalar_add(x, y):

--- a/tests/lax_scipy_sparse_test.py
+++ b/tests/lax_scipy_sparse_test.py
@@ -31,7 +31,7 @@ from jax._src import config
 from jax._src import dtypes
 from jax._src import test_util as jtu
 
-jax.config.parse_flags_with_absl()
+config.parse_flags_with_absl()
 
 
 float_types = jtu.dtypes.floating

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -28,7 +28,6 @@ from jax.scipy import special as lsp_special
 
 from jax import config
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 
 all_shapes = [(), (4,), (3, 4), (3, 1), (1, 4), (2, 1, 4)]

--- a/tests/lax_scipy_spectral_dac_test.py
+++ b/tests/lax_scipy_spectral_dac_test.py
@@ -23,7 +23,6 @@ from absl.testing import absltest
 
 from jax import config
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 
 linear_sizes = [16, 97, 128]

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -37,7 +37,6 @@ from jax.scipy import cluster as lsp_cluster
 
 from jax import config
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 all_shapes = [(), (4,), (3, 4), (3, 1), (1, 4), (2, 1, 4)]
 compatible_shapes = [[(), ()],

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -34,21 +34,21 @@ from jax.test_util import check_grads
 from jax import tree_util
 import jax.util
 
-from jax.interpreters import xla
-from jax._src.interpreters import mlir
 from jax.interpreters import batching
+from jax.interpreters import xla
 from jax._src import array
+from jax._src import config
 from jax._src import dtypes
-from jax._src.interpreters import pxla
-from jax._src import test_util as jtu
 from jax._src import lax_reference
+from jax._src import test_util as jtu
+from jax._src.interpreters import mlir
+from jax._src.interpreters import pxla
+from jax._src.internal_test_util import lax_test_util
 from jax._src.lax import lax as lax_internal
 from jax._src.lib import xla_client as xc
 from jax._src.lib import xla_extension_version
-from jax._src.internal_test_util import lax_test_util
 from jax._src.util import NumpyComplexWarning
 
-from jax import config
 config.parse_flags_with_absl()
 
 
@@ -96,7 +96,7 @@ class LaxTest(jtu.JaxTestCase):
         dtype=rec.dtypes)
       for rec in lax_test_util.lax_ops()))
   def testOpAgainstNumpy(self, op_name, rng_factory, shapes, dtype, tol):
-    if (not config.x64_enabled and op_name == "nextafter"
+    if (not config.enable_x64.value and op_name == "nextafter"
         and dtype == np.float64):
       raise SkipTest("64-bit mode disabled")
     rng = rng_factory(self.rng())
@@ -293,7 +293,7 @@ class LaxTest(jtu.JaxTestCase):
   )
   @jax.default_matmul_precision("float32")
   def testConvPreferredElement(self, lhs_shape, rhs_shape, dtype, preferred_element_type):
-    if (not config.x64_enabled and
+    if (not config.enable_x64.value and
        (dtype == np.float64 or preferred_element_type == np.float64
         or dtype == np.int64 or preferred_element_type == np.int64
         or dtype == np.complex128 or preferred_element_type == np.complex128)):
@@ -1033,7 +1033,7 @@ class LaxTest(jtu.JaxTestCase):
   )
   def testDotPreferredElement(self, lhs_shape, rhs_shape, dtype,
                               preferred_element_type):
-    if (not config.x64_enabled and
+    if (not config.enable_x64.value and
        (dtype == np.float64 or preferred_element_type == np.float64
         or dtype == np.int64 or preferred_element_type == np.int64)):
       raise SkipTest("64-bit mode disabled")
@@ -1682,7 +1682,7 @@ class LaxTest(jtu.JaxTestCase):
       ],
   )
   def testReduce(self, op, reference_op, init_val, shape, dtype, dims, primitive):
-    if not config.x64_enabled and dtype in (np.float64, np.int64, np.uint64):
+    if not config.enable_x64.value and dtype in (np.float64, np.int64, np.uint64):
       raise SkipTest("x64 mode is disabled.")
     def reference_fun(operand):
       if hasattr(reference_op, "reduce"):
@@ -2622,7 +2622,7 @@ class LaxTest(jtu.JaxTestCase):
   def testRngBitGenerator(self):
     # This test covers the original behavior of lax.rng_bit_generator, which
     # required x64=True, and only checks shapes and jit invariance.
-    if not config.x64_enabled:
+    if not config.enable_x64.value:
       raise SkipTest("RngBitGenerator requires 64bit key")
 
     key = np.array((1, 2)).astype(np.uint64)

--- a/tests/lax_vmap_op_test.py
+++ b/tests/lax_vmap_op_test.py
@@ -29,8 +29,6 @@ from jax._src import util
 from jax import config
 config.parse_flags_with_absl()
 
-FLAGS = config.FLAGS
-
 map, unsafe_map = util.safe_map, map
 zip, unsafe_zip = util.safe_zip, zip
 

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -36,7 +36,6 @@ from jax._src.util import safe_map, safe_zip
 
 from jax import config
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 map, unsafe_map = safe_map, map
 zip, unsafe_zip = safe_zip, zip

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -29,13 +29,12 @@ from jax import jit, grad, jvp, vmap
 from jax import lax
 from jax import numpy as jnp
 from jax import scipy as jsp
-from jax._src.numpy.util import promote_dtypes_inexact
+from jax._src import config
 from jax._src import test_util as jtu
 from jax._src import xla_bridge
+from jax._src.numpy.util import promote_dtypes_inexact
 
-from jax import config
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 scipy_version = tuple(map(int, scipy.version.version.split('.')[:3]))
 
@@ -1619,7 +1618,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   def testToeplitzConstrcution(self, rshape, rdtype, cshape, cdtype):
     if ((rdtype in [np.float64, np.complex128]
          or cdtype in [np.float64, np.complex128])
-        and not config.x64_enabled):
+        and not config.enable_x64.value):
       self.skipTest("Only run float64 testcase when float64 is enabled.")
 
     int_types_excl_i8 = set(int_types) - {np.int8}
@@ -1640,7 +1639,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   @jtu.skip_on_devices("rocm")
   def testToeplitzSymmetricConstruction(self, shape, dtype):
     if (dtype in [np.float64, np.complex128]
-        and not config.x64_enabled):
+        and not config.enable_x64.value):
       self.skipTest("Only run float64 testcase when float64 is enabled.")
 
     int_types_excl_i8 = set(int_types) - {np.int8}

--- a/tests/logging_test.py
+++ b/tests/logging_test.py
@@ -28,7 +28,7 @@ import jax._src.test_util as jtu
 # parsing to work correctly with bazel (otherwise we could avoid importing
 # absltest/absl logging altogether).
 from absl.testing import absltest
-jax.config.parse_flags_with_absl()
+config.parse_flags_with_absl()
 
 
 @contextlib.contextmanager

--- a/tests/multibackend_test.py
+++ b/tests/multibackend_test.py
@@ -27,7 +27,7 @@ from jax import numpy as jnp
 
 from jax import config
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
+
 npr.seed(0)
 
 

--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -29,10 +29,11 @@ import jax
 from jax import config
 from jax._src import core
 from jax._src import distributed
-import jax.numpy as jnp
+from jax._src import maps
 from jax._src import test_util as jtu
 from jax._src import util
 from jax.experimental import pjit
+import jax.numpy as jnp
 
 try:
   import portpicker
@@ -258,7 +259,7 @@ class SlurmMultiNodeGpuTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
-    self.xmap_spmd_lowering_enabled = jax.config.experimental_xmap_spmd_lowering
+    self.xmap_spmd_lowering_enabled = maps._SPMD_LOWERING.value
     jax.config.update("experimental_xmap_spmd_lowering", True)
 
   def tearDown(self):

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -34,7 +34,7 @@ from jax import random
 import jax
 import jax.numpy as jnp
 
-jax.config.parse_flags_with_absl()
+config.parse_flags_with_absl()
 
 
 class NNFunctionsTest(jtu.JaxTestCase):

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -25,12 +25,12 @@ from absl.testing import parameterized
 import jax
 from jax import lax
 from jax import random
+from jax._src import config
 from jax._src import linear_util as lu
 from jax._src import test_util as jtu
 from jax._src import state
 from jax._src.lax.control_flow.for_loop import for_loop
 from jax._src.pallas.pallas_call import _trace_to_jaxpr
-from jax.config import config
 from jax.interpreters import partial_eval as pe
 import jax.numpy as jnp
 from jax.experimental import pallas as pl
@@ -751,9 +751,7 @@ class PallasControlFlowTest(PallasTest):
     # fori_loop handles i64 index variables, i.e. error: 'scf.for' op  along
     # control flow edge from Region #0 to Region #0: source type #0
     # 'tensor<4xf64>' should match input type #0 'tensor<4xf32>'
-    orig_val = jax.config.jax_enable_x64
-    jax.config.update("jax_enable_x64", True)
-    try:
+    with config.enable_x64(True):
       @functools.partial(self.pallas_call,
                          out_shape=jax.ShapeDtypeStruct((4,), jnp.float64),
                          grid=1,
@@ -768,8 +766,6 @@ class PallasControlFlowTest(PallasTest):
 
       np.testing.assert_allclose(np.arange(1, 5.) * 3,
                                  f(jnp.arange(1, 5., dtype=jnp.float64)))
-    finally:
-      jax.config.update("jax_enable_x64", orig_val)
 
   def test_cond_simple(self):
     arg = jnp.float32(0.)

--- a/tests/pytorch_interoperability_test.py
+++ b/tests/pytorch_interoperability_test.py
@@ -17,13 +17,13 @@ import unittest
 from absl.testing import absltest
 
 import jax
-from jax import config
 import jax.dlpack
+from jax._src import config
+from jax._src import test_util as jtu
 from jax._src import xla_bridge
 from jax._src.lib import xla_client
 from jax._src.lib import xla_extension_version
 import jax.numpy as jnp
-from jax._src import test_util as jtu
 
 config.parse_flags_with_absl()
 
@@ -69,8 +69,11 @@ class DLPackTest(jtu.JaxTestCase):
 
   @jtu.sample_product(shape=all_shapes, dtype=torch_dtypes)
   def testJaxToTorch(self, shape, dtype):
-    if not config.x64_enabled and dtype in [jnp.int64, jnp.float64,
-                                            jnp.complex128]:
+    if not config.enable_x64.value and dtype in [
+        jnp.int64,
+        jnp.float64,
+        jnp.complex128,
+    ]:
       self.skipTest("x64 types are disabled by jax_enable_x64")
     rng = jtu.rand_default(self.rng())
     np = rng(shape, dtype)
@@ -89,7 +92,7 @@ class DLPackTest(jtu.JaxTestCase):
     if xla_extension_version < 186:
       self.skipTest("Need xla_extension_version >= 186")
 
-    if not config.x64_enabled and dtype in [
+    if not config.enable_x64.value and dtype in [
         jnp.int64,
         jnp.float64,
         jnp.complex128,
@@ -113,13 +116,16 @@ class DLPackTest(jtu.JaxTestCase):
     # See https://github.com/google/jax/issues/11895
     x = jax.dlpack.from_dlpack(
         torch.utils.dlpack.to_dlpack(torch.ones((2, 3), dtype=torch.int64)))
-    dtype_expected = jnp.int64 if config.x64_enabled else jnp.int32
+    dtype_expected = jnp.int64 if config.enable_x64.value else jnp.int32
     self.assertEqual(x.dtype, dtype_expected)
 
   @jtu.sample_product(shape=all_shapes, dtype=torch_dtypes)
   def testTorchToJax(self, shape, dtype):
-    if not config.x64_enabled and dtype in [jnp.int64, jnp.float64,
-                                            jnp.complex128]:
+    if not config.enable_x64.value and dtype in [
+        jnp.int64,
+        jnp.float64,
+        jnp.complex128,
+    ]:
       self.skipTest("x64 types are disabled by jax_enable_x64")
 
     rng = jtu.rand_default(self.rng())
@@ -142,8 +148,11 @@ class DLPackTest(jtu.JaxTestCase):
     if xla_extension_version < 191:
       self.skipTest("Need xla_extension_version >= 191")
 
-    if not config.x64_enabled and dtype in [jnp.int64, jnp.float64,
-                                            jnp.complex128]:
+    if not config.enable_x64.value and dtype in [
+        jnp.int64,
+        jnp.float64,
+        jnp.complex128,
+    ]:
       self.skipTest("x64 types are disabled by jax_enable_x64")
 
     rng = jtu.rand_default(self.rng())

--- a/tests/qdwh_test.py
+++ b/tests/qdwh_test.py
@@ -16,18 +16,18 @@
 import functools
 
 import jax
-from jax import config
 import jax.numpy as jnp
 import numpy as np
 import scipy.linalg as osp_linalg
-from jax._src.lax import qdwh
+from jax._src import config
 from jax._src import test_util as jtu
+from jax._src.lax import qdwh
 
 from absl.testing import absltest
 
 
 config.parse_flags_with_absl()
-_JAX_ENABLE_X64_QDWH = config.x64_enabled
+_JAX_ENABLE_X64_QDWH = config.enable_x64.value
 
 # Input matrix data type for QdwhTest.
 _QDWH_TEST_DTYPE = np.float64 if _JAX_ENABLE_X64_QDWH else np.float32

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -37,7 +37,7 @@ from jax import vmap
 
 from jax._src import prng as prng_internal
 
-jax.config.parse_flags_with_absl()
+config.parse_flags_with_absl()
 
 float_dtypes = jtu.dtypes.all_floating
 complex_dtypes = jtu.dtypes.complex

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -40,7 +40,7 @@ from jax.interpreters import xla
 from jax._src import random as jax_random
 from jax._src import prng as prng_internal
 
-jax.config.parse_flags_with_absl()
+config.parse_flags_with_absl()
 
 
 PRNG_IMPLS = list(prng_internal.prngs.items())

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -43,7 +43,7 @@ import jax.numpy as jnp
 
 from jax.experimental.shard_map import shard_map
 
-jax.config.parse_flags_with_absl()
+config.parse_flags_with_absl()
 
 map, unsafe_map = safe_map, map
 zip, unsafe_zip = safe_zip, zip
@@ -1382,7 +1382,7 @@ class ShardMapSystematicTest(jtu.JaxTestCase):
     return jtu.create_global_mesh(tuple(mesh_shape.values()), tuple(mesh_shape))
 
   @parameterized.named_parameters(
-      sample(config.FLAGS.jax_num_generated_cases, sample_shmap))
+      sample(jtu._NUM_GENERATED_CASES.value, sample_shmap))
   def test_eager_against_ref(self, fun, mesh, _, in_specs, out_specs, args, ref):
     mesh = self.make_mesh(mesh)
     args = map(jnp.array, args)
@@ -1391,7 +1391,7 @@ class ShardMapSystematicTest(jtu.JaxTestCase):
     self.assertAllClose(expected, out, check_dtypes=False)
 
   @parameterized.named_parameters(
-      sample(config.FLAGS.jax_num_generated_cases, sample_shmap))
+      sample(jtu._NUM_GENERATED_CASES.value, sample_shmap))
   def test_jit_against_ref(self, fun, mesh, _, in_specs, out_specs, args, ref):
     mesh = self.make_mesh(mesh)
     args = map(jnp.array, args)
@@ -1401,7 +1401,7 @@ class ShardMapSystematicTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(
       (name + f'_check_rep={check_rep}', *params, check_rep)
-      for (name, *params) in sample(config.FLAGS.jax_num_generated_cases, sample_shmap)
+      for (name, *params) in sample(jtu._NUM_GENERATED_CASES.value, sample_shmap)
       for check_rep in [True, False]
   )
   @jax.default_matmul_precision("float32")
@@ -1414,7 +1414,7 @@ class ShardMapSystematicTest(jtu.JaxTestCase):
     jtu.check_grads(f, args, order=2, atol=1e-2, rtol=1e-2)
 
   @parameterized.named_parameters(
-      sample(config.FLAGS.jax_num_generated_cases, sample_shmap))
+      sample(jtu._NUM_GENERATED_CASES.value, sample_shmap))
   @jax.default_matmul_precision("float32")
   def test_grads_closure(self, fun, mesh, jit, in_specs, out_specs, args, _):
     mesh = self.make_mesh(mesh)
@@ -1433,7 +1433,7 @@ class ShardMapSystematicTest(jtu.JaxTestCase):
     jtu.check_grads(f, (0.2, *closed_over_args), order=2, atol=1e-2, rtol=1e-2)
 
   @parameterized.named_parameters(
-      sample(config.FLAGS.jax_num_generated_cases,
+      sample(jtu._NUM_GENERATED_CASES.value,
              partial(sample_shmap_batched, 5)))
   def test_vmap(self, bdims, fun, mesh, jit, in_specs, out_specs, args, ref):
     mesh = self.make_mesh(mesh)
@@ -1456,7 +1456,7 @@ class ShardMapSystematicTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False, atol=tol, rtol=tol)
 
   @parameterized.named_parameters(
-      sample(config.FLAGS.jax_num_generated_cases,
+      sample(jtu._NUM_GENERATED_CASES.value,
              partial(sample_shmap_batched, 5)))
   def test_vmap_closure(self, bdims, fun, mesh, jit, in_specs, out_specs, args, _):
     mesh = self.make_mesh(mesh)

--- a/tests/sparse_bcoo_bcsr_test.py
+++ b/tests/sparse_bcoo_bcsr_test.py
@@ -41,7 +41,6 @@ from jax.util import split_list
 import numpy as np
 
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 COMPATIBLE_SHAPE_PAIRS = [
     [(), ()],

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -46,7 +46,6 @@ import numpy as np
 import scipy.sparse
 
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 all_dtypes = jtu.dtypes.integer + jtu.dtypes.floating + jtu.dtypes.complex
 

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -48,7 +48,7 @@ from jax._src.state.primitives import (get_p, swap_p, addupdate_p,
 from jax._src.state.types import (shaped_array_ref, ReadEffect, WriteEffect,
                                   AccumEffect, AbstractRef)
 
-jax.config.parse_flags_with_absl()
+config.parse_flags_with_absl()
 
 class StatePrimitivesTest(jtu.JaxTestCase):
 
@@ -831,7 +831,7 @@ if CAN_USE_HYPOTHESIS:
 
     @hp.given(get_vmap_params())
     @hp.settings(deadline=None, print_blob=True,
-        max_examples=config.FLAGS.jax_num_generated_cases)
+        max_examples=jtu._NUM_GENERATED_CASES.value)
     def test_get_vmap(self, get_vmap_param: GetVmapParams):
 
       indexed_dims = get_vmap_param.vmap_index_param.index_param.indexed_dims
@@ -870,7 +870,7 @@ if CAN_USE_HYPOTHESIS:
 
     @hp.given(set_vmap_params())
     @hp.settings(deadline=None, print_blob=True,
-                 max_examples=config.FLAGS.jax_num_generated_cases)
+                 max_examples=jtu._NUM_GENERATED_CASES.value)
     def test_set_vmap(self, set_vmap_param: SetVmapParams):
       if jtu.test_device_matches(["gpu"]):
         self.skipTest("Scatter is nondeterministic on GPU")
@@ -915,7 +915,7 @@ if CAN_USE_HYPOTHESIS:
 
     @hp.given(set_vmap_params())
     @hp.settings(deadline=None, print_blob=True,
-                 max_examples=config.FLAGS.jax_num_generated_cases)
+                 max_examples=jtu._NUM_GENERATED_CASES.value)
     def test_addupdate_vmap(self, set_vmap_param: SetVmapParams):
 
       indexed_dims = set_vmap_param.vmap_index_param.index_param.indexed_dims
@@ -1538,7 +1538,7 @@ if CAN_USE_HYPOTHESIS:
     @jax.legacy_prng_key('allow')
     @hp.given(hps.data())
     @hp.settings(deadline=None, print_blob=True,
-                 max_examples=config.FLAGS.jax_num_generated_cases)
+                 max_examples=jtu._NUM_GENERATED_CASES.value)
     def test_jvp(self, data):
 
       spec = data.draw(func_spec())
@@ -1563,7 +1563,7 @@ if CAN_USE_HYPOTHESIS:
     @jax.legacy_prng_key('allow')
     @hp.given(hps.data())
     @hp.settings(deadline=None, print_blob=True,
-                 max_examples=config.FLAGS.jax_num_generated_cases)
+                 max_examples=jtu._NUM_GENERATED_CASES.value)
     def test_linearize(self, data):
 
       spec = data.draw(func_spec())
@@ -1589,7 +1589,7 @@ if CAN_USE_HYPOTHESIS:
     @jax.legacy_prng_key('allow')
     @hp.given(hps.data())
     @hp.settings(deadline=None, print_blob=True,
-                 max_examples=config.FLAGS.jax_num_generated_cases)
+                 max_examples=jtu._NUM_GENERATED_CASES.value)
     def test_vjp(self, data):
 
       spec = data.draw(func_spec())

--- a/tests/svd_test.py
+++ b/tests/svd_test.py
@@ -16,18 +16,18 @@
 import functools
 
 import jax
-from jax import config
 import jax.numpy as jnp
 import numpy as np
 import scipy.linalg as osp_linalg
-from jax._src.lax import svd
+from jax._src import config
 from jax._src import test_util as jtu
+from jax._src.lax import svd
 
 from absl.testing import absltest
 
 
 config.parse_flags_with_absl()
-_JAX_ENABLE_X64 = config.x64_enabled
+_JAX_ENABLE_X64 = config.enable_x64.value
 
 # Input matrix data type for SvdTest.
 _SVD_TEST_DTYPE = np.float64 if _JAX_ENABLE_X64 else np.float32

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -23,7 +23,6 @@ from jax._src import util
 from jax import config
 from jax._src.util import weakref_lru_cache
 config.parse_flags_with_absl()
-FLAGS = config.FLAGS
 
 try:
   from jax._src.lib import utils as jaxlib_utils


### PR DESCRIPTION
The motivation here is to gradually replace all dynamic lookups on `jax.config` with statically-typed state objects, which are more type checker/IDE friendly.

This is a follow up to #18008.