### PR TITLE
fix: typo inside docs/notebooks/How_JAX_primitives_work.md

### DIFF
--- a/docs/notebooks/How_JAX_primitives_work.ipynb
+++ b/docs/notebooks/How_JAX_primitives_work.ipynb
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "cellView": "form",
     "id": "mQRQGEGiE53K"
@@ -281,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "id": "cPqAH1XOGTN4"
    },
@@ -608,7 +608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "id": "FYQWSSjKJaWP"
    },
@@ -779,7 +779,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "id": "zxG24C1JMIMM"
    },
@@ -810,7 +810,7 @@
     "  xt, yt, zt = arg_tangents\n",
     "  _trace(\"Primal evaluation:\")\n",
     "  # Now we have a JAX-traceable computation of the output. \n",
-    "  # Normally, we can use the ma primtive itself to compute the primal output. \n",
+    "  # Normally, we can use the ma primitive itself to compute the primal output. \n",
     "  primal_out = multiply_add_prim(x, y, z)\n",
     "  \n",
     "  _trace(\"Tangent evaluation:\")\n",
@@ -1128,7 +1128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "id": "JaHxFdkRO42r"
    },
@@ -1383,7 +1383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "id": "KQfeqRIrP7zg"
    },

--- a/docs/notebooks/How_JAX_primitives_work.md
+++ b/docs/notebooks/How_JAX_primitives_work.md
@@ -453,7 +453,7 @@ def multiply_add_value_and_jvp(arg_values, arg_tangents):
   xt, yt, zt = arg_tangents
   _trace("Primal evaluation:")
   # Now we have a JAX-traceable computation of the output. 
-  # Normally, we can use the ma primtive itself to compute the primal output. 
+  # Normally, we can use the ma primitive itself to compute the primal output. 
   primal_out = multiply_add_prim(x, y, z)
   
   _trace("Tangent evaluation:")


### PR DESCRIPTION
typo inside docs/notebooks/How_JAX_primitives_work.md has been fixed. Line no 456: changed 'primtive' to 'primitive'