### PR TITLE
[jax2tf] First step to enable multi-platform native lowering

### DIFF
--- a/jax/experimental/jax2tf/tests/back_compat_test_util.py
+++ b/jax/experimental/jax2tf/tests/back_compat_test_util.py
@@ -284,7 +284,7 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
     args_specs = export.poly_specs(data.inputs, polymorphic_shapes)
     exported = export.export(
       jax.jit(func),
-      lowering_platform=self.default_jax_backend(),
+      lowering_platforms=(self.default_jax_backend(),),
       disabled_checks=tuple(
         export.DisabledSafetyCheck.custom_call(target)
         for target in allow_unstable_custom_call_targets)
@@ -320,7 +320,6 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
         out_avals=tuple(out_avals),
         in_shardings=(pxla.UNSPECIFIED,) * len(in_avals),
         out_shardings=(pxla.UNSPECIFIED,) * len(out_avals),
-        lowering_platform=data.platform,
         lowering_platforms=(data.platform,),
         disabled_checks=(),
         mlir_module_serialized=data.mlir_module_serialized,


### PR DESCRIPTION
Enable experiments with jax2tf native serialization for
multiple platforms. This feature is not yet fully functional
but we need this change to enable further testing.

Cleanup some of the places that are specific to single-platform
serialization, e.g., `lowering_platform`, and generalize
them to multiple platforms (`lowering_platforms`)