### PR TITLE
Fix libtpu path on older jaxlibs.

### DIFF
--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -128,6 +128,9 @@ def tpu_client_timer_callback(timer_secs: float) -> Optional[xla_client.Client]:
     if xla_extension_version >= 205:
       client = xla_client.make_tpu_client(_get_tpu_library_path())  # type: ignore
     else:
+      libtpu_module = maybe_import_libtpu()
+      if libtpu_module is not None:
+        libtpu_module.configure_library_path()
       client = xla_client.make_tpu_client()  # type: ignore
   finally:
     t.cancel()


### PR DESCRIPTION
This is a follow-up to
https://github.com/google/jax/commit/b81a3e1fd774ebdbc3015f1bc977bfacb5d4b745. We still need to set TPU_LIBRARY_PATH for jaxlibs that don't support the new mechanism for passing in the libtpu path.