### PR TITLE
Enhance the speed of slogdet with qr method

### DIFF
--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -176,8 +176,9 @@ def _slogdet_qr(a: Array) -> tuple[Array, Array]:
   # The determinant of a triangular matrix is the product of its diagonal
   # elements. We are working in log space, so we compute the magnitude as the
   # the trace of the log-absolute values, and we compute the sign separately.
-  log_abs_det = jnp.trace(ufuncs.log(ufuncs.abs(a)), axis1=-2, axis2=-1)
-  sign_diag = reductions.prod(ufuncs.sign(jnp.diagonal(a, axis1=-2, axis2=-1)), axis=-1)
+  a_diag = jnp.diagonal(a, axis1=-2, axis2=-1)
+  log_abs_det = reductions.sum(ufuncs.log(ufuncs.abs(a_diag)), axis=-1)
+  sign_diag = reductions.prod(ufuncs.sign(a_diag), axis=-1)
   # The determinant of a Householder reflector is -1. So whenever we actually
   # made a reflection (tau != 0), multiply the result by -1.
   sign_taus = reductions.prod(jnp.where(taus[..., :(n-1)] != 0, -1, 1), axis=-1).astype(sign_diag.dtype)


### PR DESCRIPTION
We can avoid taking log of the whole matrix when only the diagonal part is needed.