### PR TITLE
[random] remove internal uses of deprecated prng.seed_with_impl()

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -88,7 +88,7 @@ class PRNGImpl(NamedTuple):
 
   A PRNG implementation is adapted to an array-like object of keys
   ``K`` by the ``PRNGKeyArray`` class, which should be created via the
-  ``seed_with_impl`` function.
+  ``random_seed`` function.
   """
   key_shape: Shape
   seed: Callable

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -180,7 +180,7 @@ def _key(ctor_name: str, seed: Union[int, Array], impl_spec: Optional[str]
     raise TypeError(
         f"{ctor_name} accepts a scalar seed, but was given an array of "
         f"shape {np.shape(seed)} != (). Use jax.vmap for batching")
-  return prng.seed_with_impl(impl, seed)
+  return prng.random_seed(seed, impl=impl)
 
 def key(seed: Union[int, Array], *,
         impl: Optional[str] = None) -> PRNGKeyArray:
@@ -234,21 +234,21 @@ def threefry2x32_key(seed: int) -> KeyArray:
   """Creates a threefry2x32 PRNG key from an integer seed."""
   impl = prng.threefry_prng_impl
   _check_default_impl_with_no_custom_prng(impl, 'threefry2x32')
-  key = prng.seed_with_impl(impl, seed)
+  key = prng.random_seed(seed, impl=impl)
   return _return_prng_keys(True, key)
 
 def rbg_key(seed: int) -> KeyArray:
   """Creates an RBG PRNG key from an integer seed."""
   impl = prng.rbg_prng_impl
   _check_default_impl_with_no_custom_prng(impl, 'rbg')
-  key = prng.seed_with_impl(impl, seed)
+  key = prng.random_seed(seed, impl=impl)
   return _return_prng_keys(True, key)
 
 def unsafe_rbg_key(seed: int) -> KeyArray:
   """Creates an unsafe RBG PRNG key from an integer seed."""
   impl = prng.unsafe_rbg_prng_impl
   _check_default_impl_with_no_custom_prng(impl, 'unsafe_rbg')
-  key = prng.seed_with_impl(impl, seed)
+  key = prng.random_seed(seed, impl=impl)
   return _return_prng_keys(True, key)
 
 

--- a/jax/extend/random.py
+++ b/jax/extend/random.py
@@ -20,6 +20,7 @@ from jax._src.prng import (
   # PRNGImpl constructor, to leave some room for us to register or check input,
   # or to change what output type we return.
   PRNGImpl as PRNGImpl,
+  random_seed as random_seed,
   seed_with_impl as seed_with_impl,
   threefry2x32_p as threefry2x32_p,
   threefry_2x32 as threefry_2x32,

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -960,7 +960,7 @@ class PJitTest(jtu.BufferDonationTestCase):
   def testWithCustomPRNGKey(self):
     if not config.enable_custom_prng.value:
       raise unittest.SkipTest("test requires jax_enable_custom_prng")
-    key = prng.seed_with_impl(prng.rbg_prng_impl, 87)
+    key = prng.random_seed(87, impl=prng.rbg_prng_impl)
     # Make sure this doesn't crash
     pjit(lambda x: x, in_shardings=None, out_shardings=None)(key)
 
@@ -1206,7 +1206,7 @@ class PJitTest(jtu.BufferDonationTestCase):
 
     with mesh:
       def make_keys(seeds):
-        make_key = partial(prng.seed_with_impl, prng.threefry_prng_impl)
+        make_key = partial(prng.random_seed, impl=prng.threefry_prng_impl)
         return make_key(seeds)
 
       f = pjit(make_keys, in_shardings=P(None), out_shardings=P(None))
@@ -1830,7 +1830,7 @@ class ArrayPjitTest(jtu.JaxTestCase):
 
     @pjit
     def make_keys(seeds):
-      make_key = partial(prng.seed_with_impl, prng.threefry_prng_impl)
+      make_key = partial(prng.random_seed, impl=prng.threefry_prng_impl)
       return make_key(seeds)
 
     out = make_keys(seeds)
@@ -1847,7 +1847,7 @@ class ArrayPjitTest(jtu.JaxTestCase):
 
     @partial(pjit, out_shardings=NamedSharding(mesh, P('x', 'y')))
     def make_keys(seeds):
-      make_key = partial(prng.seed_with_impl, prng.threefry_prng_impl)
+      make_key = partial(prng.random_seed, impl=prng.threefry_prng_impl)
       return make_key(seeds)
 
     out = make_keys(seeds)
@@ -1864,7 +1864,7 @@ class ArrayPjitTest(jtu.JaxTestCase):
 
     @pjit
     def make_keys(seeds):
-      make_key = partial(prng.seed_with_impl, prng.threefry_prng_impl)
+      make_key = partial(prng.random_seed, impl=prng.threefry_prng_impl)
       return make_key(seeds)
 
     out = make_keys(seeds)

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -1204,7 +1204,7 @@ double_threefry_prng_impl = prng_internal.PRNGImpl(
 @jtu.with_config(jax_default_prng_impl='threefry2x32')
 class LaxRandomWithCustomPRNGTest(LaxRandomTest):
   def make_key(self, seed):
-    return prng_internal.seed_with_impl(double_threefry_prng_impl, seed)
+    return prng_internal.random_seed(seed, impl=double_threefry_prng_impl)
 
   def test_split_shape(self):
     key = self.make_key(73)


### PR DESCRIPTION
Preparing to remove this function (once the external deprecation period is complete).