### PR TITLE
[random] make PRNG impl attributes private

### DIFF
--- a/docs/jep/9263-typed-keys.md
+++ b/docs/jep/9263-typed-keys.md
@@ -330,7 +330,7 @@ True
 True
 ```
 And in addition to `key.dtype._rules` as outlined for extended dtypes in
-general, PRNG dtypes define `key.dtype.impl`, which contains the metadata
+general, PRNG dtypes define `key.dtype._impl`, which contains the metadata
 that defines the PRNG implementation. The PRNG implementation is currently
 defined by the non-public `jax._src.prng.PRNGImpl` class. For now, `PRNGImpl`
 isn't meant to be a public API, but we might revisit this soon to allow for

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -308,7 +308,7 @@ def split(key: KeyArray, num: Union[int, tuple[int, ...]] = 2) -> KeyArray:
 def _key_impl(keys: KeyArray) -> PRNGImpl:
   assert jnp.issubdtype(keys.dtype, dtypes.prng_key)
   keys_dtype = typing.cast(prng.KeyTy, keys.dtype)
-  return keys_dtype.impl
+  return keys_dtype._impl
 
 def key_impl(keys: KeyArray) -> Hashable:
   keys, _ = _check_prng_key(keys)
@@ -1501,7 +1501,8 @@ def poisson(key: KeyArray,
   dtypes.check_user_dtype_supported(dtype)
   # TODO(frostig): generalize underlying poisson implementation and
   # remove this check
-  key_impl = key.dtype.impl  # type: ignore[union-attr]
+  keys_dtype = typing.cast(prng.KeyTy, key.dtype)
+  key_impl = keys_dtype._impl
   if key_impl is not prng.threefry_prng_impl:
     raise NotImplementedError(
         '`poisson` is only implemented for the threefry2x32 RNG, '

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -2651,7 +2651,7 @@ def _random_split_impl(keys: TfVal, *, shape, _in_avals, _out_aval):
 
   def impl_wrapper(keys: TfVal, *, shape):
     return prng.random_split_impl_base(
-        keys_aval.dtype.impl, keys, keys_aval.ndim, shape=shape)
+        keys_aval.dtype._impl, keys, keys_aval.ndim, shape=shape)
 
   converted_impl = _convert_jax_impl(
       impl_wrapper, multiple_results=False, with_physical_avals=True,
@@ -2667,7 +2667,7 @@ def _random_fold_in_impl(keys: TfVal, msgs: TfVal, *, _in_avals, _out_aval):
 
   def impl_wrapper(keys: TfVal, msgs: TfVal):
     return prng.random_fold_in_impl_base(
-        keys_aval.dtype.impl, keys, msgs, keys_aval.shape)
+        keys_aval.dtype._impl, keys, msgs, keys_aval.shape)
 
   converted_impl = _convert_jax_impl(
       impl_wrapper, multiple_results=False, with_physical_avals=True,
@@ -2683,7 +2683,7 @@ def _random_bits_impl(keys: TfVal, *, bit_width, shape, _in_avals, _out_aval):
 
   def impl_wrapper(keys: TfVal, **kwargs):
     return prng.random_bits_impl_base(
-        keys_aval.dtype.impl, keys, keys_aval.ndim,
+        keys_aval.dtype._impl, keys, keys_aval.ndim,
         bit_width=bit_width, shape=shape)
 
   converted_impl = _convert_jax_impl(

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -184,7 +184,7 @@ class PrngTest(jtu.JaxTestCase):
 
   def check_key_has_impl(self, key, impl):
     if jnp.issubdtype(key.dtype, dtypes.prng_key):
-      self.assertIs(key.impl, impl)
+      self.assertIs(key._impl, impl)
     else:
       self.assertEqual(key.dtype, jnp.dtype('uint32'))
       self.assertEqual(key.shape, impl.key_shape)
@@ -1190,7 +1190,7 @@ class JnpWithKeyArrayTest(jtu.JaxTestCase):
 
     newshape = (2, 2)
     key_func = partial(jnp.reshape, newshape=newshape)
-    arr_func = partial(jnp.reshape, newshape=(*newshape, *key.impl.key_shape))
+    arr_func = partial(jnp.reshape, newshape=(*newshape, *key._impl.key_shape))
 
     self.check_shape(key_func, keys)
     self.check_against_reference(key_func, arr_func, keys)
@@ -1200,7 +1200,7 @@ class JnpWithKeyArrayTest(jtu.JaxTestCase):
 
     reps = 3
     key_func = partial(jnp.tile, reps=reps)
-    arr_func = lambda x: jnp.tile(x[None], reps=(reps, *(1 for _ in key.impl.key_shape)))
+    arr_func = lambda x: jnp.tile(x[None], reps=(reps, *(1 for _ in key._impl.key_shape)))
 
     self.check_shape(key_func, key)
     self.check_against_reference(key_func, arr_func, key)
@@ -1219,7 +1219,7 @@ class JnpWithKeyArrayTest(jtu.JaxTestCase):
 
     shape = (3,)
     key_func = partial(jnp.broadcast_to, shape=shape)
-    arr_func = partial(jnp.broadcast_to, shape=(*shape, *key.impl.key_shape))
+    arr_func = partial(jnp.broadcast_to, shape=(*shape, *key._impl.key_shape))
 
     self.check_shape(key_func, key)
     self.check_against_reference(key_func, arr_func, key)
@@ -1257,7 +1257,7 @@ class JnpWithKeyArrayTest(jtu.JaxTestCase):
     keys = random.split(key, 4).reshape(2, 2)
 
     key_func = jnp.ravel
-    arr_func = partial(jnp.reshape, newshape=(4, *key.impl.key_shape))
+    arr_func = partial(jnp.reshape, newshape=(4, *key._impl.key_shape))
 
     self.check_shape(key_func, keys)
     self.check_against_reference(key_func, arr_func, keys)


### PR DESCRIPTION
We don't want users to rely on these – instead they should use APIs like `jax.random.key_impl`