### PR TITLE
Avoid numpy.core import for NumPy 2.0

### DIFF
--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -15,8 +15,6 @@
 # Note: import <name> as <name> is required for names to be exported.
 # See PEP 484 & https://github.com/google/jax/issues/7570
 
-import numpy as _numpy
-
 from jax.numpy import fft as fft
 from jax.numpy import linalg as linalg
 
@@ -426,6 +424,11 @@ from jax._src.numpy.array_methods import register_jax_array_methods
 register_jax_array_methods()
 del register_jax_array_methods
 
+try:
+  import numpy.core as _numpy_core  # pytype: disable=import-error
+except ImportError:
+  # numpy.core moved to numpy._core in NumPy 2.0
+  import numpy._core as _numpy_core  # pytype: disable=import-error
 
 # Deprecations
 
@@ -446,7 +449,7 @@ _deprecations = {
     # Added Aug 17, 2023:
     "issubsctype": (
         "jax.numpy.issubsctype is deprecated. In most cases, jax.numpy.issubdtype can be used instead.",
-        _numpy.core.numerictypes.issubsctype,
+        _numpy_core.numerictypes.issubsctype,
     ),
     # Added Aug 22, 2023
     "row_stack": (
@@ -471,7 +474,7 @@ if typing.TYPE_CHECKING:
   NINF = -inf
   NZERO = -0.0
   PZERO = 0.0
-  issubsctype = _numpy.core.numerictypes.issubsctype
+  issubsctype = _numpy_core.numerictypes.issubsctype
   in1d = _deprecated_in1d
   trapz = _deprecated_trapz
 else:
@@ -479,7 +482,6 @@ else:
   __getattr__ = _deprecation_getattr(__name__, _deprecations)
   del _deprecation_getattr
 del typing
-del _numpy
-
+del _numpy_core
 del _deprecated_in1d
 del _deprecated_trapz


### PR DESCRIPTION
Addresses the most recent nightly CI failure (#18169)