### PR TITLE
Cleanup the handling of single- and multi-platform lowering in ModuleContext

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -565,7 +565,7 @@ def xla_computation(fun: Callable,
           core.ClosedJaxpr(jaxpr, consts),
           ordered_effects=ordered_effects,
           backend_or_name=backend,
-          platform=platform,
+          platforms=(platform,),
           axis_context=sharding_impls.ReplicaAxisContext(axis_env_),
           name_stack=source_info_util.new_name_stack(
               wrap_name(fun_name, "xla_computation")),

--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -385,7 +385,7 @@ def inspect_sharding_partition(shapes, arg_shardings, result_shape,
   jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(fun, in_avals)
   closed_jaxpr = core.ClosedJaxpr(jaxpr, consts)
   trivial_comp = mlir.build_xla_computation_helper(closed_jaxpr,
-      name="tmp_xla_computation", platform=module_context.platform,
+      name="tmp_xla_computation", platforms=module_context.platforms,
       backend_or_name=module_context.backend_or_name,
       axis_context=module_context.axis_context)
   # The trivial computation built here has a dummy tuple as the result,

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -554,6 +554,6 @@ def _common_device_put_lowering(ctx, x, *, device, src):
       device.memory_kind is not None):
     raise NotImplementedError(
         "Passing memory_kind to device_put via Shardings is not supported on"
-        f" platform {ctx.module_context.platform}")
+        f" platform {ctx.module_context.platforms}")
   return [x]
 mlir.register_lowering(device_put_p, _common_device_put_lowering)

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -758,7 +758,7 @@ def lower_parallel_callable(
           closed_jaxpr,
           ordered_effects=ordered_effects,
           backend_or_name=backend,
-          platform=lowering_parameters.override_platform or backend.platform,
+          platforms=lowering_parameters.platforms or (backend.platform,),
           axis_context=sharding_impls.ReplicaAxisContext(axis_env),
           name_stack=name_stack,
           donated_args=donated_invars,
@@ -1362,7 +1362,6 @@ def _pmap_lowering(ctx, *in_nodes, axis_name,
                    call_jaxpr, backend=None, in_axes, out_axes,
                    donated_invars, is_explicit_global_axis_size):
   del donated_invars  # Unused.
-  mlir.check_backend_matches(backend, ctx.module_context.platform)
   # We in-line here rather than generating a Call HLO as in the xla_call
   # translation rule just because the extra tuple stuff is a pain.
   if ctx.module_context.axis_env.names and devices is not None:
@@ -1835,7 +1834,7 @@ def _cached_lowering_to_hlo(closed_jaxpr, api_name, fun_name, backend,
         ordered_effects=ordered_effects,
         backend_or_name=backend,
         # Optionally, override the lowering platform
-        platform=lowering_parameters.override_platform or backend.platform,
+        platforms=lowering_parameters.platforms or (backend.platform,),
         axis_context=axis_ctx,
         name_stack=name_stack,
         donated_args=donated_invars,
@@ -2201,7 +2200,7 @@ def lower_mesh_computation(
           closed_jaxpr,
           ordered_effects=ordered_effects,
           backend_or_name=backend,
-          platform=lowering_parameters.override_platform or backend.platform,
+          platforms=lowering_parameters.platforms or (backend.platform,),
           axis_context=axis_ctx,
           name_stack=name_stack,
           donated_args=donated_invars,

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -725,12 +725,7 @@ def _allreduce_abstract_eval(*args, axes, axis_index_groups):
           for arg, named_shape in zip(args, named_shapes)]
 
 def _allreduce_lowering(prim, pos_fn, ctx, *args, axes, axis_index_groups):
-  # TODO(necula): clean this up when we have module_context.platforms
-  if ctx.module_context.lowering_parameters.is_multi_platform:
-    for_tpu = ("tpu" in ctx.module_context.lowering_parameters.platforms)
-  else:
-    for_tpu = (ctx.module_context.platform == "tpu")
-  if axis_index_groups is not None and for_tpu:
+  if axis_index_groups is not None and ("tpu" in ctx.module_context.platforms):
     len_0 = len(axis_index_groups[0])
     if any(len(g) != len_0 for g in axis_index_groups):
       raise ValueError("axis_index_groups must all be the same size for TPU lowering")

--- a/jax/_src/maps.py
+++ b/jax/_src/maps.py
@@ -1305,7 +1305,6 @@ def _xmap_lowering_rule_replica(ctx, *in_nodes,
                                 global_axis_sizes,
                                 spmd_in_axes, spmd_out_axes,
                                 axis_resources, resource_env, backend):
-  mlir.check_backend_matches(backend, ctx.module_context.platform)
   # The only way for any of those two assertions to be violated is when xmap
   # is using the SPMD lowering, but then this rule shouldn't even trigger.
   assert spmd_in_axes is None and spmd_out_axes is None
@@ -1381,7 +1380,6 @@ def _xmap_lowering_rule_spmd(ctx, *global_in_nodes,
                              donated_invars, global_axis_sizes, spmd_in_axes,
                              spmd_out_axes, axis_resources,
                              resource_env, backend):
-  mlir.check_backend_matches(backend, ctx.module_context.platform)
   plan = EvaluationPlan.from_axis_resources(
       axis_resources, resource_env, global_axis_sizes)
 
@@ -1449,7 +1447,6 @@ def _xmap_lowering_rule_spmd_manual(ctx, *global_in_nodes,
                                     resource_env, backend):
   assert spmd_in_axes is None and spmd_out_axes is None
   # This first part (up to vtile_manual) is shared with non-MANUAL SPMD rule.
-  mlir.check_backend_matches(backend, ctx.module_context.platform)
   plan = EvaluationPlan.from_axis_resources(
       axis_resources, resource_env, global_axis_sizes)
   manual_mesh_axes = frozenset(it.chain.from_iterable(plan.physical_axis_resources.values()))

--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -1496,7 +1496,10 @@ def pallas_call_lowering(
         **compiler_params
     )
   num_warps = compiler_params.get("num_warps", 4)
-  if ctx.module_context.platform == 'rocm':
+  if len(ctx.module_context.platforms) > 1:
+    raise NotImplementedError(
+      "Pallas kernels not yet supported for multi-platform lowering")
+  if ctx.module_context.platforms[0] == 'rocm':
     num_stages = compiler_params.get("num_stages", 1)
   else:
     num_stages = compiler_params.get("num_stages", 3)
@@ -1514,7 +1517,7 @@ def pallas_call_lowering(
       debug=debug,
   )
   #Triton returns a tuple for ROCm. We just want file path to be passed
-  if ctx.module_context.platform == 'rocm':
+  if ctx.module_context.platforms[0] == 'rocm':
       compilation_result.ptx = compilation_result.ptx[1]
 
   if debug:

--- a/jax/experimental/custom_partitioning.py
+++ b/jax/experimental/custom_partitioning.py
@@ -181,7 +181,7 @@ def _custom_partitioning_partition(arg_shapes, arg_shardings, result_shape,
   built = mlir.build_xla_computation_helper(
       closed_jaxpr,
       name="tmp_xla_computation",
-      platform=module_context.platform,
+      platforms=module_context.platforms,
       backend_or_name=module_context.backend_or_name,
       axis_context=axis_context.extend_manual(frozenset(mesh.axis_names)),
   )

--- a/jax/experimental/export/export.py
+++ b/jax/experimental/export/export.py
@@ -603,7 +603,7 @@ def _wrap_main_func(
     entry_block = new_main_op.add_entry_block()
     with ir.InsertionPoint(entry_block):
       module_context = mlir.ModuleContext(
-          backend_or_name="cpu", platform="cpu",
+          backend_or_name="cpu", platforms=["cpu"],
           axis_context=sharding_impls.ShardingContext([]),
           name_stack=source_info_util.new_name_stack(),
           keepalives=[], channel_iterator=itertools.count(1),
@@ -1083,11 +1083,7 @@ def _call_exported_lowering(ctx: mlir.LoweringRuleContext, *args,
 
   # All the platforms for the current lowering must be among the platforms
   # for which the callee was lowered.
-  if ctx.module_context.lowering_parameters.is_multi_platform:
-    assert ctx.module_context.lowering_parameters.platforms is not None
-    lowering_platforms = ctx.module_context.lowering_parameters.platforms
-  else:
-    lowering_platforms = (ctx.module_context.platform,)
+  lowering_platforms = ctx.module_context.platforms
 
   callee_lowering_platform_index: list[int] = []
   for platform in lowering_platforms:

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -1101,7 +1101,9 @@ def _outside_call_lowering(ctx: mlir.LoweringRuleContext,
                            flat_results_aval=(),
                            **params):
   """MLIR Lowering for `CustomCall`-based HCB."""
-  platform = ctx.module_context.platform
+  if len(ctx.module_context.platforms) > 1:
+    raise NotImplementedError("multi-platform lowering for host_callback")
+  platform = ctx.module_context.platforms[0]
   use_outfeed = _use_outfeed(platform)
   if use_outfeed:
     # Fall back to XLA path if we are using the outfeed
@@ -1118,7 +1120,7 @@ def _outside_call_lowering(ctx: mlir.LoweringRuleContext,
   else:
     # TODO(necula): It seems that on CPU, with custom call, the device_index
     # does not work, and the callback is always run on device_index=0
-    if (device_index != 0 and ctx.module_context.platform == "cpu"):
+    if (device_index != 0 and "cpu" in ctx.module_context.platforms):
       raise ValueError(
           "The device_index feature on CPU works only when using outfeed.")
   # We expect the current tokens at the end, inserted by _rewrite_jaxpr.


### PR DESCRIPTION
Previously, we introduced support for multi-platform lowering, by adding a new LoweringParameters object that can be used to specify a cross-lowering platform or even multiple platforms. But we had kept the ModuleContext.platform in place because some lowering rules were still referencing it. Now we replace ModuleContext.platform with ModuleContext.platforms, which removes the redundancy, simplifies the code, and makes it cleaer that the lowering rules should not simply assume single-platform lowering.

We still keep a property ModuleContext.platform, which throws an error when used while doing multi-platform lowering. We plan to remove this property once we clean uses in libraries.