### PR TITLE
[export] Add jax.global_constant MLIR attributes for dimension variable arguments

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1283,7 +1283,10 @@ def parameterized_filterable(*,
   if one_containing is not None:
     filtered = tuple(kw for kw in kwargs_with_testcase_name
                      if one_containing in kw["testcase_name"])
-    assert filtered, f"No testcase_name contains '{one_containing}'"
+    assert filtered, (
+      f"No testcase_name contains '{one_containing}'. "
+      "The testcase_name values are\n  " +
+      "\n  ".join(kw["testcase_name"] for kw in kwargs_with_testcase_name))
     kw = filtered[0]
     kw["testcase_name"] = ""
     return parameterized.named_parameters([kw])

--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -828,6 +828,8 @@ We list here a history of the serialization version numbers:
     attribute and enables the shape refinement pass only when the
     attribute is present. Supported by XlaCallModule since July 21st, 2023
     (cl/549973693) and available in JAX since July 26th, 2023 (JAX 0.4.14).
+  * Version 9 (not yet in use) adds support for the `jax.global_constant`
+    attribute.
 
 
 ## Known issues


### PR DESCRIPTION
In presence of shape polymorphism and multi-platorm lowering we pass the global values for the dimension variables and the platform index to all inner HLO functions. At the moment, prior to compilation we run a shape refinement pass to infer which of the arguments of a function carry such global values and to constant-fold those values.
This inference can yield false positives, e.g., when a user-defined function is called with a constant int32 as the first argument.

With this change we do not need to infer anymore the arguments that carry global constants. This is in preparation for a more reliable implementation of shape refinement.