### PR TITLE
Documentation: add stub files for new tutorial structure

### DIFF
--- a/docs/tutorial/advanced-autodiff.md
+++ b/docs/tutorial/advanced-autodiff.md
@@ -1,0 +1,11 @@
+# Advanced automatic differentiation
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../jax-101/04-advanced-autodiff`
+- {doc}`../notebooks/autodiff_cookbook`
+- {doc}`../notebooks/autodiff_remat`
+- {doc}`../notebooks/Custom_derivative_rules_for_Python_code`.
+```

--- a/docs/tutorial/advanced-compilation.md
+++ b/docs/tutorial/advanced-compilation.md
@@ -1,0 +1,10 @@
+# Advanced compilation
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../aot`
+- {doc}`../Custom_Operation_for_GPUs`
+- {doc}`../pallas/index`
+```

--- a/docs/tutorial/automatic-differentiation.md
+++ b/docs/tutorial/automatic-differentiation.md
@@ -1,0 +1,8 @@
+# Automatic differentiation
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../jax-101/04-advanced-autodiff`
+```

--- a/docs/tutorial/debugging.md
+++ b/docs/tutorial/debugging.md
@@ -1,0 +1,9 @@
+# Debugging
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../debugging/index`
+- {doc}`../errors`
+```

--- a/docs/tutorial/external-callbacks.md
+++ b/docs/tutorial/external-callbacks.md
@@ -1,0 +1,8 @@
+# External callbacks
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../notebooks/external_callbacks`
+```

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -1,0 +1,52 @@
+:orphan:
+
+.. _jax-tutorials:
+
+JAX tutorials
+=============
+
+.. note::
+
+   The tutorials below are a work in progress; for the time being, please refer
+   to the older tutorial content at :ref:`Jax-101`, :ref:`beginner-guide` and
+   :ref:`user-guides`.
+
+JAX 101
+-------
+
+.. toctree::
+   :maxdepth: 1
+
+   installation
+   quickstart
+   jax-as-accelerated-numpy
+   automatic-differentiation
+   jit-compilation
+   random-numbers
+   working-with-pytrees
+   single-host-sharding
+   stateful-computations
+   external-callbacks
+   simple-neural-network
+
+
+JAX 201
+-------
+
+.. toctree::
+   :maxdepth: 1
+
+   parallelism
+   advanced-autodiff
+   debugging
+   profiling-and-performance
+
+
+JAX 301
+-------
+
+.. toctree::
+   :maxdepth: 1
+
+   jax-internals
+   advanced-compilation

--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -1,0 +1,8 @@
+# Installation
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../installation`
+```

--- a/docs/tutorial/jax-as-accelerated-numpy.md
+++ b/docs/tutorial/jax-as-accelerated-numpy.md
@@ -1,0 +1,8 @@
+# JAX as accelerated NumPy
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../jax-101/01-jax-basics`
+```

--- a/docs/tutorial/jax-internals.md
+++ b/docs/tutorial/jax-internals.md
@@ -1,0 +1,11 @@
+# JAX internals
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../notebooks/How_JAX_primitives_work`
+- {doc}`../jaxpr`
+- {doc}`../notebooks/Writing_custom_interpreters_in_Jax`
+- {doc}`../type_promotion`
+```

--- a/docs/tutorial/jit-compilation.md
+++ b/docs/tutorial/jit-compilation.md
@@ -1,0 +1,8 @@
+# Just-in-time compilation
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../jax-101/02-jitting`
+```

--- a/docs/tutorial/parallelism.md
+++ b/docs/tutorial/parallelism.md
@@ -1,0 +1,9 @@
+# Parallel computation
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../multi_process`
+- {doc}`../notebooks/Distributed_arrays_and_automatic_parallelization`
+```

--- a/docs/tutorial/profiling-and-performance.md
+++ b/docs/tutorial/profiling-and-performance.md
@@ -1,0 +1,10 @@
+# Profiling and performance
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../profiling`
+- {doc}`../device_memory_profiling`
+- {doc}`../transfer_guard`
+```

--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -1,0 +1,8 @@
+# Quickstart
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../notebooks/quickstart`
+```

--- a/docs/tutorial/random-numbers.md
+++ b/docs/tutorial/random-numbers.md
@@ -1,0 +1,8 @@
+# Pseudorandom numbers
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../jax-101/05-random-numbers`
+```

--- a/docs/tutorial/simple-neural-network.md
+++ b/docs/tutorial/simple-neural-network.md
@@ -1,0 +1,5 @@
+# Example: Writing a simple neural network
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+```

--- a/docs/tutorial/single-host-sharding.md
+++ b/docs/tutorial/single-host-sharding.md
@@ -1,0 +1,5 @@
+# Sharded data on a single host
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+```

--- a/docs/tutorial/stateful-computations.md
+++ b/docs/tutorial/stateful-computations.md
@@ -1,0 +1,8 @@
+# Stateful computations
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../jax-101/07-state`
+```

--- a/docs/tutorial/working-with-pytrees.md
+++ b/docs/tutorial/working-with-pytrees.md
@@ -1,0 +1,9 @@
+# Working with PyTrees
+
+```{note}
+This is a placeholder for a section in the new {ref}`jax-tutorials`.
+
+For the time being, you may find some related content in the old documentation:
+- {doc}`../jax-101/05.1-pytrees`
+- {doc}`../pytrees`
+```


### PR DESCRIPTION
This adds stub files for the new tutorial structure discussed by a number of JAX collaborators. We will add these stubs to the existing documentation build in order to take advantage of our existing CI setup, and to ensure that content does not bitrot as we develop it.

Rendered preview is here: https://jax--18269.org.readthedocs.build/en/18269/tutorial/

- I've chosen to keep the filenames flat within the `tutorial` subdirectory, so that we are free to rearrange the table of contents in the future. The only thing we cannot change is the actual filenames themselves, as the filenames are reflected in the user-facing URLs.

- The main tutorial table of contents is orphaned, meaning there is no way to access these new files them from the existing documentation site. Still, they may somehow end up indexed by search engines, and so in case users encounter them, I've pre-filled the stubs with back-links to the content they will replace.

- Once these stubs are merged, each team member can proceed independently with filling the content they're in charge of.

- Once the new tutorial is complete, we will feature it prominently in the main documentation page, and make the old content into orphaned stubs with references to the new content.

**The goal is to finish work on this tutorial by the end of 2023**