### PR TITLE
add `jax.threefry_partitionable` context manager

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -67,6 +67,7 @@ from jax._src.config import (
   numpy_rank_promotion as numpy_rank_promotion,
   jax2tf_associative_scan_reductions as jax2tf_associative_scan_reductions,
   legacy_prng_key as legacy_prng_key,
+  threefry_partitionable as threefry_partitionable,
   transfer_guard as transfer_guard,
   transfer_guard_host_to_device as transfer_guard_host_to_device,
   transfer_guard_device_to_device as transfer_guard_device_to_device,

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -683,6 +683,7 @@ class _ThreadLocalExtraJitContext(NamedTuple):
   numpy_dtype_promotion: Optional[str] = None
   default_matmul_precision: Optional[Any] = None
   dynamic_shapes: bool = False
+  threefry_partitionable: bool = False
   softmax_custom_jvp: bool = False
   xla_profile_version: int = 0
 


### PR DESCRIPTION
... for convenience during an upcoming default value upgrade.

Also add `threefry_partitionable` as a field in the thread-local JIT context.