### PR TITLE
Cleanup the code to pick lowering rules based on platform.

### DIFF
--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2782,7 +2782,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     ctx = contextlib.ExitStack()
     if jtu.device_under_test() != "tpu":
       ctx.enter_context(
-        self.assertRaisesRegex(ValueError,
+        self.assertRaisesRegex(NotImplementedError,
                                "translation rule .* not found for platform"))
     with ctx:
       lax.platform_dependent(


### PR DESCRIPTION
Previously, we had special-cased the code to pick the lowering rule for a primitive based on the lowering platform, and separately we had the code to handle multi-platform lowering. The latter, called `mlir.lower_multi_platform` had its own special case for when a single lowering rule applied.

We rename `mlir.lower_multi_platform` to `mlir.lower_per_platform` to not imply that it is only for multi-platform. We simplify its API (takes a dictionary instead of a list of tuples).