### PR TITLE
jnp.cross: account for numpy 2.0 deprecation

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3573,6 +3573,7 @@ def outer(a: ArrayLike, b: ArrayLike, out: None = None) -> Array:
 @partial(jit, static_argnames=('axisa', 'axisb', 'axisc', 'axis'))
 def cross(a, b, axisa: int = -1, axisb: int = -1, axisc: int = -1,
           axis: int | None = None):
+  # TODO(jakevdp): NumPy 2.0 deprecates 2D inputs. Follow suit here.
   # TODO(jakevdp): Non-array input deprecated 2023-09-22; change to error.
   util.check_arraylike("cross", a, b, emit_warning=True)
   if axis is not None:

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -457,6 +457,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     axisa, axisb, axisc, axis = axes
     jnp_fun = lambda a, b: jnp.cross(a, b, axisa, axisb, axisc, axis)
+    # Note: 2D inputs to jnp.cross are deprecated in numpy 2.0.
+    @jtu.ignore_warning(category=DeprecationWarning,
+                        message="Arrays of 2-dimensional vectors are deprecated.")
     def np_fun(a, b):
       a = a.astype(np.float32) if lhs_dtype == jnp.bfloat16 else a
       b = b.astype(np.float32) if rhs_dtype == jnp.bfloat16 else b


### PR DESCRIPTION
Fixes part of https://github.com/google/jax/issues/18169