### PR TITLE
feat (scipy.special): Add beta function

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -131,6 +131,7 @@ jax.scipy.special
   :toctree: _autosummary
 
    bernoulli
+   beta
    betainc
    betaln
    digamma

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -56,6 +56,12 @@ betaln = _wraps(
 )(_betaln_impl)
 
 
+@_wraps(osp_special.beta, module='scipy.special')
+def beta(x: ArrayLike, y: ArrayLike) -> Array:
+  x, y = promote_args_inexact("beta", x, y)
+  return lax.exp(betaln(x, y))
+
+
 @_wraps(osp_special.betainc, module='scipy.special')
 def betainc(a: ArrayLike, b: ArrayLike, x: ArrayLike) -> Array:
   a, b, x = promote_args_inexact("betainc", a, b, x)

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -19,6 +19,7 @@ from jax._src.scipy.special import (
   bernoulli as bernoulli,
   betainc as betainc,
   betaln as betaln,
+  beta as beta,
   bessel_jn as bessel_jn,
   digamma as digamma,
   entr as entr,

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -53,6 +53,9 @@ int_dtypes = jtu.dtypes.integer
 
 JAX_SPECIAL_FUNCTION_RECORDS = [
     op_record(
+        "beta", 2, float_dtypes, jtu.rand_positive, False
+    ),
+    op_record(
         "betaln", 2, float_dtypes, jtu.rand_positive, False
     ),
     op_record(


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/12742 by exposing a beta function which is the exponential of the previously existing `betaln` function. Basically a modernized version of [this commit](https://github.com/tkillestein/jax/commit/8c123afef55354283c9d51ebd0c36111afd695ae). Also inspired by https://github.com/google/jax/pull/15656 which did the same thing but for the gamma function.