### PR TITLE
Fix hashcode for `HashablePartial` to get equal hashes for equal objects

### DIFF
--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -465,7 +465,13 @@ class HashablePartial:
             self.args == other.args and self.kwargs == other.kwargs)
 
   def __hash__(self):
-    return hash((self.f.__code__, self.args, tuple(self.kwargs.items())))
+    return hash(
+      (
+        self.f.__code__,
+        self.args,
+        tuple(sorted(self.kwargs.items(), key=lambda kv: kv[0])),
+      ),
+    )
 
   def __call__(self, *args, **kwargs):
     return self.f(*self.args, *args, **self.kwargs, **kwargs)


### PR DESCRIPTION
This PR takes the order of the keys in `kwargs` into account. This ensures that "equality implies equal hash codes".

In the `__eq__` method, the statement `self.kwargs == other.kwargs` is key order insensitive.

While in the `__hash__` method, the statement `tuple(self.kwargs)` is key order sensitive.

```python
In [1]: from jax._src.util import HashablePartial

In [2]: def myprint(*args, **kwargs):
   ...:     print(*args, **kwargs)
   ...:     

In [3]: HashablePartial(myprint, end='', flush=True) == HashablePartial(myprint, flush=True, end='')
Out[3]: True

In [4]: hash(HashablePartial(myprint, end='', flush=True)) == hash(HashablePartial(myprint, flush=True, end=''))
Out[4]: False
```