### PR TITLE
jax.nn.normalize: deprecate using standard framework

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -16,7 +16,6 @@
 
 from functools import partial
 import operator
-import warnings
 import numpy as np
 from typing import Any, Optional, Union
 
@@ -508,16 +507,6 @@ def standardize(x: ArrayLike,
     variance = jnp.mean(
         jnp.square(x), axis, keepdims=True, where=where) - jnp.square(mean)
   return jnp.subtract(x, jnp.asarray(mean)) * lax.rsqrt(jnp.asarray(variance) + epsilon)
-
-def normalize(x: ArrayLike,
-            axis: Optional[Union[int, tuple[int, ...]]] = -1,
-            mean: Optional[ArrayLike] = None,
-            variance: Optional[ArrayLike] = None,
-            epsilon: ArrayLike = 1e-5,
-            where: Optional[ArrayLike] = None) -> Array:
-  r"""Normalizes an array by subtracting ``mean`` and dividing by :math:`\sqrt{\mathrm{variance}}`."""
-  warnings.warn("jax.nn.normalize will be deprecated. Use jax.nn.standardize instead.", DeprecationWarning)
-  return standardize(x, axis, mean, variance, epsilon, where)
 
 # TODO(slebedev): Change the type of `x` to `ArrayLike`.
 @partial(jax.jit, static_argnames=("num_classes", "dtype", "axis"))

--- a/jax/nn/__init__.py
+++ b/jax/nn/__init__.py
@@ -32,7 +32,6 @@ from jax._src.nn.functions import (
   log_sigmoid as log_sigmoid,
   log_softmax as log_softmax,
   logsumexp as logsumexp,
-  normalize as normalize,
   standardize as standardize,
   one_hot as one_hot,
   relu as relu,
@@ -45,3 +44,22 @@ from jax._src.nn.functions import (
   silu as silu,
   swish as swish,
 )
+
+# Deprecations
+
+_deprecations = {
+    # Added Nov 8, 2023:
+    "normalize": (
+        "jax.nn.normalize is deprecated. Use jax.nn.standardize instead.",
+        standardize,
+    ),
+}
+
+import typing
+if typing.TYPE_CHECKING:
+  normalize = standardize
+else:
+  from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
+  __getattr__ = _deprecation_getattr(__name__, _deprecations)
+  del _deprecation_getattr
+del typing


### PR DESCRIPTION
This will help us to finalize the deprecation.

Also, since the original `DeprecationWarning` was raised with `stacklevel=1`, it was likely not visible to most users, so to be safe I'm going to restart the deprecation clock.