### PR TITLE
Implementation of poch and hyp1f1

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -147,6 +147,7 @@ jax.scipy.special
    gammainc
    gammaincc
    gammaln
+   hyp1f1
    i0
    i0e
    i1
@@ -159,6 +160,7 @@ jax.scipy.special
    multigammaln
    ndtr
    ndtri
+   poch
    polygamma
    spence
    sph_harm

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -54,4 +54,6 @@ from jax._src.scipy.special import (
   zeta as zeta,
   kl_div as kl_div,
   rel_entr as rel_entr,
+  poch as poch,
+  hyp1f1 as hyp1f1,
 )

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -141,7 +141,8 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
     op_record(
         "rel_entr", 2, float_dtypes, jtu.rand_positive, True,
     ),
-
+    op_record("poch", 2, float_dtypes, jtu.rand_positive, True),
+    op_record("hyp1f1", 3, float_dtypes, functools.partial(jtu.rand_uniform, low=0.5, high=30), True)
 ]
 
 


### PR DESCRIPTION
I plan to implement some hypergeometric special functions for real parameter cases in JAX

- Pochhammer symbol, with handling of real + integer cases
- Confluent hypergeometric function 1F1 

Might close #15670

Some comments on the implementation : 
- I added custom jvp for both using known recursive relations 
- 1F1 is concordant with scipy's for values of b and z not too high and a not too low (if a <<1, b>~50 and z >~100, precision is lost, but these are extreme cases since 1F1 is an exponential function)
- Improvements can be found in [Pearson+2014](https://arxiv.org/abs/1407.7786), which I might add at some point 

I'm looking for feedback on the implementation of these two before digging in 2F1 and add recursions to improve 1F1 evaluation for large values of a and b 