### PR TITLE
Avoid querying `named_shape` to support `DShapedArray`s.

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2474,8 +2474,9 @@ def make_jaxpr(fun: Callable,
     closed_jaxpr = core.ClosedJaxpr(jaxpr, consts)
     if return_shape:
       out_avals, _ = unzip2(out_type)
+      named_shape = lambda a: a.named_shape if hasattr(a, "named_shape") else {}
       out_shapes_flat = [
-          ShapeDtypeStruct(a.shape, a.dtype, a.named_shape) for a in out_avals]
+          ShapeDtypeStruct(a.shape, a.dtype, named_shape(a)) for a in out_avals]
       return closed_jaxpr, tree_unflatten(out_tree(), out_shapes_flat)
     return closed_jaxpr
 


### PR DESCRIPTION
Hi,

We are using JAX to compile Python to MLIR. We are currently exploring the implementation of dynamic tensor sizes support in JAX (i.e., `abstracted_axes`). I noticed that when using the option calling `make_jaxpr` with `abstracted_axes=something` and `return_shapes=True` an exception is raised. This is because `DShapedArray`s does not have a `named_shape` attribute which is needed in these lines of code:

```python
2447   @wraps(fun)
2448   @api_boundary
2449   def make_jaxpr_f(*args, **kwargs):
#      ... snip ...
2465     if return_shape:
2466       out_avals, _ = unzip2(out_type)
2467       out_shapes_flat = [
2468           ShapeDtypeStruct(a.shape, a.dtype, a.named_shape) for a in out_avals] # <-- Here
2469       return closed_jaxpr, tree_unflatten(out_tree(), out_shapes_flat)
2470     return closed_jaxpr
```

I am not too familiar with Dynamic shapes in JAX yet, but implementing the changes allowed me to return a meaningful shape with the following value:

```
ShapeDtypeStruct(shape=(InDBIdx(val=0),), dtype=int64)
```

which appears to be sufficient.

Happy to hear your thoughts here. I would really like to be able to use `abstracted_axes` and `return_shapes=True`.

Thank you! :)