### PR TITLE
[shape_poly] Fix handling of core.non_negative_dim symbolic expressions.

### DIFF
--- a/jax/experimental/export/export.py
+++ b/jax/experimental/export/export.py
@@ -1126,7 +1126,7 @@ def _call_exported_abstract_eval(
   # `f32[c, d]` it is better to fail because `c == d` is inconclusive, than
   # succeed and add a compile-time check that `c == d`. In the latter case,
   # it would be ambiguous whether we should continue tracing with a result
-  # a type `f32[c]` or `f32[d]`.
+  # of type `f32[c]` or `f32[d]`.
   shape_constraints.check_statically(synthetic_eval)
   exported_dim_values = [synthetic_eval.evaluate(solution[var])
                          for var in exported_dim_vars]

--- a/jax/experimental/export/shape_poly.py
+++ b/jax/experimental/export/shape_poly.py
@@ -242,7 +242,14 @@ class _DimAtom:
       elif self.operation == _DimAtom.MOD:
         return divmod(*operand_values)[1]  # type: ignore
       elif self.operation == _DimAtom.NON_NEGATIVE:
-        return lax.max(operand_values[0], 0)
+        operand = operand_values[0]
+        if core.is_constant_dim(operand):
+          return max(operand, 0)
+        if core.is_symbolic_dim(operand):
+          return core.non_negative_dim(operand)
+        # In the context of `evaluate` dimension variables may be mapped to
+        # JAX Tracers.
+        return lax.max(operand, 0)
       else:
         assert False, self.operation
 


### PR DESCRIPTION
Previously we used lax.max to evaluate core.non_negative_dim, but this is problematic if we are in a tracing context. Then, even if the operand is a constant we produce a tracer. Change the code to check explicitly if the operand is a constant.