### PR TITLE
jax.vmap: improve docs & error for structured in_axes

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -404,7 +404,6 @@ def flatten_axes(name, treedef, axis_tree, *, kws=False, tupled_args=False):
   # the given treedef, build a complete axis spec tree with the same structure
   # and return the flattened result
   # TODO(mattjj,phawkins): improve this implementation
-
   proxy = object()
   dummy = tree_unflatten(treedef, [object()] * treedef.num_leaves)
   axes = []


### PR DESCRIPTION
Fixes #18548

I hope I haven't forgotten any corner cases in this validation... tests will tell.

Motivating example:
```python
import jax
import jax.numpy as jnp

def f(x):
  return x['a']
input = {'a': jnp.zeros((3, 3))}
jax.vmap(f, in_axes={'a': 0})(input)
```
Current error in JAX:
```pytb
ValueError                                Traceback (most recent call last)
in <module>()
      2   return x['a']
      3 input = {'a': jnp.zeros((3, 3))}
----> 4 jax.vmap(f, in_axes={'a': 0})(input)

ValueError: vmap in_axes specification must be a tree prefix of the corresponding value, got specification {'a': 0} for value tree PyTreeDef(({'a': *},)).
```
Error after this PR:
```pytb
TypeError                                Traceback (most recent call last)
in <module>()
      2   return x['a']
      3 input = {'a': jnp.zeros((3, 3))}
----> 4 jax.vmap(f, in_axes={'a': 0})(input)

TypeError: vmap in_axes must be an int, None, or a tuple of entries corresponding to the positional arguments passed to the function, but got {'a': 0}.
```