### PR TITLE
add error hint about common jnp.ones / jnp.zeros mistake

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -5216,6 +5216,17 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         "but got first argument of"):
       jnp.rot90(jnp.ones(2))
 
+  @parameterized.named_parameters(
+      ('ones', jnp.ones),
+      ('zeros', jnp.zeros),
+      ('empty', jnp.empty))
+  def test_error_hint(self, fn):
+    with self.assertRaisesRegex(
+        TypeError,
+        r"Did you accidentally write `jax\.numpy\..*?\(2, 3\)` "
+        r"when you meant `jax\.numpy\..*?\(\(2, 3\)\)`"):
+      fn(2, 3)
+
 
 # Most grad tests are at the lax level (see lax_test.py), but we add some here
 # as needed for e.g. particular compound ops of interest.


### PR DESCRIPTION
Context:

https://twitter.com/karpathy/status/789571283079995392

<img width="440" alt="image" src="https://github.com/google/jax/assets/1458824/685f3e05-b60f-495f-9ece-d0e068e3dd45">

(Yes, it's from 2016, before JAX existed, but we're finally getting around to it...)

also https://twitter.com/karpathy/status/1099793055853375489

Before:
<img width="1392" alt="image" src="https://github.com/google/jax/assets/1458824/f1a77176-9578-45d1-a092-35391c76ef19">

After:
<img width="1392" alt="image" src="https://github.com/google/jax/assets/1458824/bd2ff355-d747-4686-aadc-4ca1015160e5">

(Mmmm fewer stack frames...)