### PR TITLE
If parameter to `get_aval` is AbstractValue return it.

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1450,6 +1450,8 @@ def concrete_aval(x):
 
 
 def get_aval(x):
+  if isinstance(x, AbstractValue):
+    return x
   if isinstance(x, Tracer):
     return x.aval
   else:


### PR DESCRIPTION
Hello, 

While exploring the `abstracted_axes={0: "n"}` I noticed that passing `AbstractValue`s as inputs to the `make_jaxpr` function will cause it to yield a `TypeError`.

However, passing `AbstractValue`s as inputs to `make_jaxpr` is possible when `abstracted_axes=None`. To preserve this feature, this is a possible change.

I believe passing `AbstractValue`s to `make_jaxpr` directly makes sense as a way to compile AOT via type signatures.

EDIT: The following PR may also be relevant: https://github.com/google/jax/pull/18505