### PR TITLE
Deprecate passing of None to jax.numpy.array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Remember to align the itemized text with the first line of an item within a list
 * Deprecations
   * The previously-deprecated `sym_pos` argument has been removed from
     {func}`jax.scipy.linalg.solve`. Use `assume_a='pos'` instead.
+  * Passing `None` to {func}`jax.array` or {func}`jax.asarray`, either directly or
+    within a list or tuple, is deprecated and now raises a {obj}`FutureWarning`.
+    It currently is converted to NaN, and in the future will raise a {obj}`TypeError`.
+   
 
 ## jaxlib 0.4.21
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3218,6 +3218,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     with self.assertRaisesRegex(OverflowError, "Python int too large.*"):
       jnp.array([0, val])
 
+  def testArrayNoneWarning(self):
+    # TODO(jakevdp): make this an error after the deprecation period.
+    with self.assertWarnsRegex(FutureWarning, r"None encountered in jnp.array\(\)"):
+      jnp.array([0.0, None])
+
   def testIssue121(self):
     assert not np.isscalar(jnp.array(3))
 


### PR DESCRIPTION
Addresses #14506

Before merging, I'm going to do some additional testing to get a feel for the impact of this deprecation.