### PR TITLE
pallas: add argument `zeroize_outputs` to pallas_call()

### DIFF
--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -381,6 +381,7 @@ def pallas_call(
     input_output_aliases: Dict[int, int] = {},
     interpret: bool = False,
     name: str | None = None,
+    zeroize_outputs: Tuple[int] | None = None,
     **compiler_params: Any,
 ):
   name = _extract_function_name(f, name)
@@ -410,6 +411,7 @@ def pallas_call(
         interpret=interpret,
         grid_mapping=grid_mapping,
         input_output_aliases=tuple(input_output_aliases.items()),
+        zeroize_outputs=zeroize_outputs,
         **compiler_params)
     out = tree_util.tree_unflatten(out_tree, out_flat)
     return out

--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -1520,6 +1520,7 @@ def pallas_call_lowering(
     debug: bool,
     input_output_aliases: Tuple[Tuple[int, int], ...],
     grid_mapping: GridMapping,
+    zeroize_outputs: Tuple[int] | None,
     triton_params: Dict[str, Any] | None = None,
     **compiler_params: Any,
 ):
@@ -1536,6 +1537,7 @@ def pallas_call_lowering(
         debug=debug,
         input_output_aliases=input_output_aliases,
         grid_mapping=grid_mapping,
+        zeroize_outputs=zeroize_outputs,
         **compiler_params
     )
   num_warps = compiler_params.get("num_warps", 4)
@@ -1579,13 +1581,25 @@ def pallas_call_lowering(
   )
 
   kernel_params = []
-  for _ in range(len(in_shapes) + len(out_shapes)):
+  for _ in range(len(in_shapes)):
     kernel_params.append(
         triton_kernel_call_lib.create_array_parameter(
-            0,  # bytes to zero  # TODO(cjfj): Expose through user API.
+            0,  # bytes to zero
             16,  # divisible by 16
         )
     )
+
+  if zeroize_outputs is None:
+    zeroize_outputs = ()
+
+  for i, out_shape in enumerate(out_shapes):
+    kernel_params.append(
+        triton_kernel_call_lib.create_array_parameter(
+            out_shape.dtype.itemsize * out_shape.size if i in zeroize_outputs else 0,  # bytes to zeroize
+            16,  # divisible by 16
+        )
+    )
+
 
   kernel_call = triton_kernel_call_lib.TritonKernelCall(
       kernel, grid[0], grid[1], grid[2], kernel_params


### PR DESCRIPTION
When using `pallas_call()` I observed that output arrays are not initialized with zeros. This is a big hurdle for custom gradient kernels that use scattered updates to the output array with `atomic_add`.

This PR is a minimal attempt at providing this for pallas_call for gpu/triton, similar to the way it is implemented in [jax_triton.triton_call()](https://github.com/jax-ml/jax-triton/blob/68c6262d78084c5c2f6287bfa4c5b96fa863a7cf/jax_triton/triton_lib.py#L512). 

It adds a new argument `zeroize_outputs` that is a sequence of indices for outputs that should be filled with zero before running the kernel. For a single output this would be `zeroize_outputs=(0,)`. I could imagine that a list of booleans

Similar measure might be needed for TPU/mosaic, but I lack insight.