### PR TITLE
add jax.custom_gradient to readthedocs

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -99,6 +99,7 @@ Automatic differentiation
     vjp
     custom_jvp
     custom_vjp
+    custom_gradient
     closure_convert
     checkpoint
 


### PR DESCRIPTION
`jax.custom_gradient` is a thin wrapper around `jax.custom_vjp` to provide the same API as TF for customizing reverse mode autodiff's backward pass code. `jax.custom_vjp` is better because it allows for eager evaluation. But people may want to know about this convenience API!