### PR TITLE
improve error message for e.g. jnp.zeros(5)[:, 0]

### DIFF
--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -302,6 +302,13 @@ class ArrayImpl(basearray.Array):
     from jax._src.numpy import lax_numpy
     self._check_if_deleted()
 
+    if isinstance(idx, tuple):
+      num_idx = sum(e is not None and e is not Ellipsis for e in idx)
+      if num_idx > self.ndim:
+        raise IndexError(
+            f"Too many indices for array: array has ndim of {self.ndim}, but "
+            f"was indexed with {num_idx} non-None/Ellipsis indices.")
+
     if isinstance(self.sharding, PmapSharding):
       if not isinstance(idx, tuple):
         cidx = (idx,) + (slice(None),) * (len(self.shape) - 1)

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -4891,7 +4891,7 @@ def _is_scalar(x):
 
 def _canonicalize_tuple_index(arr_ndim, idx, array_name='array'):
   """Helper to remove Ellipsis and add in the implicit trailing slice(None)."""
-  len_without_none = sum(1 for e in idx if e is not None and e is not Ellipsis)
+  len_without_none = sum(e is not None and e is not Ellipsis for e in idx)
   if len_without_none > arr_ndim:
     raise IndexError(
         f"Too many indices for {array_name}: {len_without_none} "

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -1030,7 +1030,7 @@ class IndexingTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError, msg):
       jnp.zeros(2)['abc']
     with self.assertRaisesRegex(TypeError, msg):
-      jnp.zeros(2)[:, 'abc']
+      jnp.zeros((2, 3))[:, 'abc']
 
   def testIndexOutOfBounds(self):  # https://github.com/google/jax/issues/2245
     x = jnp.arange(5, dtype=jnp.int32) + 1
@@ -1131,6 +1131,13 @@ class IndexingTest(jtu.JaxTestCase):
       _check_raises(jnp.int32, jnp.complex64, msg)
       _check_raises(jnp.float16, jnp.float32, msg)
       _check_raises(jnp.float32, jnp.complex64, msg)
+
+  def testWrongNumberOfIndices(self):
+    with self.assertRaisesRegex(
+        IndexError,
+        "Too many indices for array: array has ndim of 1, "
+        "but was indexed with 2 non-None/Ellipsis indices"):
+      jnp.zeros(3)[:, 5]
 
 
 def _broadcastable_shapes(shape):


### PR DESCRIPTION
Before:

![image](https://github.com/google/jax/assets/1458824/659a89ac-9714-4865-a4ce-2fd0731cef18)

After:

![image](https://github.com/google/jax/assets/1458824/09da75a2-592e-4a2c-ad5a-a01709009c73)

Shorter traceback by catching the error earlier! Also improved the wording of the error IMO.