### PR TITLE
Update test-requirements.txt

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -10,3 +10,4 @@ pytest-xdist
 wheel
 rich
 setuptools
+matplotlib


### PR DESCRIPTION
matplotlib is required to pass //tests:lobpcg_test_cpu when we make:
- bazel test --//jax:build_jaxlib=false //tests:cpu_tests //tests:backend_independent_tests