### PR TITLE
multiprocess_test: print error message on failure

### DIFF
--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -175,8 +175,8 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
 
       try:
         for proc in subprocesses:
-          out, _ = proc.communicate()
-          self.assertEqual(proc.returncode, 0)
+          out, err = proc.communicate()
+          self.assertEqual(proc.returncode, 0, msg=f"Process failed:\n\n{err}")
           self.assertRegex(out, f'{num_gpus_per_task},{num_gpus},\\[{num_gpus}.\\]$')
       finally:
         for proc in subprocesses:


### PR DESCRIPTION
This test is currently failing, but the failure gives no hint as to why it might be failing.