### PR TITLE
[shape_poly] Simplify the API for processing polymorphic_shape specifications

### DIFF
--- a/jax/_src/internal_test_util/export_back_compat_test_util.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_util.py
@@ -284,7 +284,7 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
       a string (for debugging), and (c) the module serialization version.
     """
     # Use the native exporter, to make sure we get the proper serialization.
-    args_specs = export.poly_specs(data.inputs, polymorphic_shapes)
+    args_specs = export.args_specs(data.inputs, polymorphic_shapes)
     exported = export.export(
       jax.jit(func),
       lowering_platforms=(self.default_jax_backend(),),
@@ -300,7 +300,7 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
 
   def run_serialized(self, data: CompatTestData,
                      polymorphic_shapes: Optional[Sequence[str]] = None):
-    args_specs = export.poly_specs(data.inputs, polymorphic_shapes)
+    args_specs = export.args_specs(data.inputs, polymorphic_shapes)
     def ndarray_to_aval(a: np.ndarray) -> core.ShapedArray:
       return core.ShapedArray(a.shape, a.dtype)
     in_avals_tree = tree_util.tree_map(ndarray_to_aval, args_specs)

--- a/jax/_src/typing.py
+++ b/jax/_src/typing.py
@@ -59,7 +59,7 @@ DTypeLike = Union[
 
 # Shapes are tuples of dimension sizes, which are normally integers. We allow
 # modules to extend the set of dimension sizes to contain other types, e.g.,
-# symbolic dimensions in jax2tf.shape_poly.DimVar and masking.Poly.
+# symbolic dimensions in export.DimExpr.
 DimSize = Union[int, Any]  # extensible
 Shape = Sequence[DimSize]
 

--- a/jax/experimental/export/export.py
+++ b/jax/experimental/export/export.py
@@ -53,6 +53,7 @@ map = util.safe_map
 zip = util.safe_zip
 
 DType = Any
+Shape = jax._src.core.Shape
 
 class DisabledSafetyCheck:
   """A safety check should be skipped on (de)serialization.
@@ -307,52 +308,40 @@ def default_lowering_platform() -> str:
   # Canonicalize to turn 'gpu' into 'cuda' or 'rocm'
   return xb.canonicalize_platform(jax.default_backend())
 
-def poly_spec(
-    arg_shape: Sequence[Optional[int]],
-    arg_dtype: DType,
-    polymorphic_shape: Optional[str]) -> jax.ShapeDtypeStruct:
+def symbolic_shape(
+  shape_spec: Optional[str],
+  *,
+  like: Optional[Sequence[Optional[int]]] = None) -> Shape:
   """Constructs a jax.ShapeDtypeStruct with polymorphic shapes.
 
   Args:
-    arg_shape: the shape, with possibly some unspecified dimensions.
-    arg_dtype: the jax dtype.
-    polymorphic_shape: a string specifying the polymorphic shape.
+    shape_spec: a symbolic shape specification. None stands for "...".
+    like: when `shape_spec` contains placeholders ("_", "..."), use this
+      shape to fill in the placeholders.
+      The dimensions of `like` that are used for filling
+      must be known (not `None`). If a dimension in `like` is known and
+      the corresponding dimension in `shape_spec` is a constant then they
+      must be equal.
 
-      .. warning:: The shape-polymorphic lowering is an experimental feature.
-        It is meant to be sound, but it is known to reject some JAX programs
-        that are shape polymorphic. The details of this feature can change.
-
-      It should be either `None` (all dimensions are constant), or a string of
-      specification for one axis, and can be either a constant, `_` denoting
-      a constant dimension given by the `arg_shape`, or the name of a
-      dimension variable assumed to range over dimension greater than 0. For
-      convenience, zero or more trailing `_` can be abbreviated with `...`, and
-      the surrounding parentheses may be missing.
-
-      Note that this function does not ensure that the provided `arg_shape`
-      is compatible with `polymorphic_shape`. The `arg_shape` is used only
-      to fill-in placeholders from `polymorphic_shape`.
-
-      See [the README](https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#shape-polymorphic-conversion)
-      for more details.
+  See [the README](https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#shape-polymorphic-conversion)
+  for more details.
 
   Returns: a jax.ShapeDTypeStruct with shapes that may contain symbolic
       expressions involving dimension variables.
   """
-  aval_shape = shape_poly._parse_spec(polymorphic_shape, arg_shape)
-  return jax.ShapeDtypeStruct(aval_shape, arg_dtype)
+  return shape_poly.symbolic_shape(shape_spec, like=like)
 
 def shape_and_dtype_jax_array(a) -> tuple[Sequence[Optional[int]], DType]:
   """Returns the shape and dtype of a jax.Array."""
   aval = core.raise_to_shaped(core.get_aval(a))
   return aval.shape, aval.dtype
 
-def poly_specs(
+def args_specs(
     args,  # pytree of arguments
     polymorphic_shapes,  # prefix pytree of strings
     get_shape_and_dtype=shape_and_dtype_jax_array,
 ):
-  """Constructs a pytree of jax.ShapeDtypeSpec.
+  """Constructs a pytree of jax.ShapeDtypeSpec arguments specs for `export`.
 
   Args:
     args: a pytree of arguments
@@ -363,12 +352,14 @@ def poly_specs(
       arguments](https://jax.readthedocs.io/en/latest/pytrees.html#applying-optional-parameters-to-pytrees).
 
       Note that this function does not ensure that the provided `args` shapes
-      are compatible with `polymorphic_shapes`. The `args.shape` are used only
-      to fill-in placeholders from `polymorphic_shapes`.
+      are compatible with `polymorphic_shapes`. The `.shape` of the `args` are
+      used only to fill-in placeholders from `polymorphic_shapes`.
 
-      See docstring of `poly_spec` and
+      See docstring of `symbolic_shape` and
       [the README](https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#shape-polymorphic-conversion)
       for more details.
+    get_shape_and_dtype: a function that given an argument extracts a tuple
+      of a shape and a dtype.
 
   Returns: a pytree of jax.ShapeDTypeStruct matching `args`.
   """
@@ -394,8 +385,9 @@ def poly_specs(
     raise e("jax_export polymorphic_shapes") from None
 
   # Now add in the polymorphic shapes
-  args_specs_flat = tuple(
-      map(poly_spec, shapes, dtypes, polymorphic_shapes_flat))
+  args_specs_flat = (
+      jax.ShapeDtypeStruct(symbolic_shape(spec, like=s), t)
+      for s, t, spec in zip(shapes, dtypes, polymorphic_shapes_flat))
 
   return args_tree.unflatten(args_specs_flat)
 

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -367,12 +367,12 @@ def convert(fun_jax: Callable,
       _, a_jax_dtype = _tfval_to_tensor_jax_dtype(a)
       return tf_arg_shape, a_jax_dtype
 
-    args_specs = export.poly_specs(args_tf,
+    args_specs = export.args_specs(args_tf,
                                    polymorphic_shapes=polymorphic_shapes,
                                    get_shape_and_dtype=shape_and_dtype_tf)
     # The polymorphic_shapes argument refers to positional arguments only.
     # We assume None for the kwargs.
-    kwargs_specs = export.poly_specs(kwargs_tf,
+    kwargs_specs = export.args_specs(kwargs_tf,
                                      polymorphic_shapes=None,
                                      get_shape_and_dtype=shape_and_dtype_tf)
     combined_args_tf = (args_tf, kwargs_tf)
@@ -652,7 +652,7 @@ def eval_polymorphic_shape(fun_jax: Callable,
   (c, a)
   """
   def do_eval_polymorphic_shape(*args_specs) -> Any:
-    args_poly_specs = export.poly_specs(
+    args_poly_specs = export.args_specs(
         args_specs, polymorphic_shapes=polymorphic_shapes)
     res_poly_spec = jax.eval_shape(fun_jax, *args_poly_specs)
     # TODO(necula): For now we export the polymorphic shapes using `str`.


### PR DESCRIPTION
Before, we had `export.poly_spec` to create a `jax.ShapedDtypeStruct` given a polymorphic shape specification. This function was invoked `poly_spec(arg_shape, arg_dtype, polymorphic_shape)`. The `arg_shape` was only needed when the polymorphic shape spec contained placeholders.

We break out an `export.symbolic_shape` that is just a parser of polymorphic shape specs and we ask the user to invoke `jax.ShapeDtypeStruct` directly:

`jax.ShapeDtypeStruct(export.symbolic_shape(polymorphic_shape, like=arg_shape), arg_dtype)`.

We also rename the `export.poly_specs` to `export.arg_specs`.