### PR TITLE
Solution for https://github.com/google/jax/pull/18641

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -237,6 +237,9 @@ MULTI_GPU="--run_under $PWD/build/parallel_accelerator_execute.sh --test_env=JAX
 bazel test //tests:gpu_tests //tests:backend_independent_tests --test_env=XLA_PYTHON_CLIENT_PREALLOCATE=false --test_tag_filters=-multiaccelerator $MULTI_GPU
 ```
 
+Some test targets, like a `//tests:logpcg_tests` optionally use matplotlib, so you may need to `pip
+install matplotlib` to run tests via bazel.
+
 ### Using `pytest`
 
 To run all the JAX tests using `pytest`, we recommend using `pytest-xdist`,


### PR DESCRIPTION
In tests/BUILD file, set the environment variable to 0 for lobpcg_test. When using a clean installation, such as a base Python and relying solely on the test-requirements.txt from /build, as per the instructions in the documentation, the tests that require matplotlib tend to fail. Users are required to install matplotlib independently.

To prevent these failures by default, it is advisable to disable matplotlib:

name = "lobpcg_test",
    srcs = ["lobpcg_test.py"],
    env = {"LOBPCG_EMIT_DEBUG_PLOTS": "0"},

If someone wishes to visualize results using matplotlib, they should be informed in the documentation (developer.rmd). For example in section Running the tests, we may add extra information:

Moreover, if you require visualization generated by Matplotlib during the tests, it is necessary to install it separately using the command:
```
pip install matplotlib
```

Additionally, set the LOBPCG_EMIT_DEBUG_PLOTS environment variable to 1 in the /tests/BUILD file or pass it via the command line. For example, for a Bazel test case:
```
bazel test //tests:cpu_tests //tests:backend_independent_tests --test_env=LOBPCG_EMIT_DEBUG_PLOTS=1
```