### PR TITLE
Handle error in case outputs subscripts of xeinsum are not unique

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -479,6 +479,10 @@ def xeinsum(spec: str, *operands):
     raise ValueError("Found subscript(s) "
                      f"{set(out_subs) - set().union(*all_in_subs)} "
                      "appearing in the output spec but not in the input")
+  if len(out_named) != len(set(out_named)):
+    raise ValueError("Output axes should be unique.")
+  if len(out_subs) != len(set(out_subs)):
+    raise ValueError("Output subscripts should be unique.")
 
   xs = list(operands)
   for idx, (in_subs, in_named) in enumerate(safe_zip(all_in_subs, all_in_named)):

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -1451,6 +1451,13 @@ class PDotTests(XMapTestCase):
     self.assertAllClose(lhs_bar, expected_lhs, check_dtypes=False)
     self.assertAllClose(rhs_bar, expected_rhs, check_dtypes=False)
 
+  def test_xeinsum_error(self):
+    with self.assertRaisesRegex(ValueError, "Output axes should be unique"):
+      lax.xeinsum("{i,j}->{j,i,j}", jnp.zeros((2, 2)))
+    with self.assertRaisesRegex(ValueError,
+                                "Output subscripts should be unique"):
+      lax.xeinsum("ij->jij", jnp.zeros((2, 2)))
+
   def test_xeinsum_vector_dot(self):
     rng = self.rng()
     x = rng.randn(3)


### PR DESCRIPTION
```python
np.einsum("ij->jij", np.zeros((2, 2)))
```
throws an error since the output subscript `j` is specified multiple times:
```python-traceback
ValueError: einstein sum subscripts string includes output subscript 'j' multiple times
```

However
```python
jnp.einsum_path("ij->jij", jnp.zeros((2, 2)))
```
runs into an internal assertion error which is not very user friendly.
```python-traceback
   3629   raise NotImplementedError  # if this is actually reachable, open an issue!
   3631 # the resulting 'operand' with axis labels 'names' should be a permutation
   3632 # of the desired result
-> 3633 assert len(names) == len(result_names) == len(set(names))
   3634 assert set(names) == set(result_names)
   3635 if names != result_names:

AssertionError:
```
Since jax relies on `opt_einsum` for its error handling I made an upstream PR to fix that in https://github.com/dgasmith/opt_einsum/pull/222 (also see https://github.com/numpy/numpy/pull/25230 which does the same for `np.einsum_path`)

This PR fixes the `_use_xeinsum=True` code path which currently would completely ignore the error and still output an array:
```python
jnp.einsum_path("ij->jij", jnp.zeros((2, 2)), _use_xeinsum=True)
# Array([[0., 0.],
#        [0., 0.]], dtype=float32)
```