### PR TITLE
Deprecate non-array inputs to jnp.array_equal & jnp.array_equiv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Remember to align the itemized text with the first line of an item within a list
     It currently is converted to NaN, and in the future will raise a {obj}`TypeError`.
   * Passing the `condition`, `x`, and `y` parameters to `jax.numpy.where` by
     keyword arguments has been deprecated, to match `numpy.where`.
+  * Passing arguments to {func}`jax.numpy.array_equal` and {func}`jax.numpy.array_equiv`
+    that cannot be converted to a JAX array is deprecated and now raises a
+    {obj}`DeprecationWaning`. Currently the functions return False, in the future this
+    will raise an exception.
 
 
 ## jaxlib 0.4.21

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2298,7 +2298,12 @@ def _check_forgot_shape_tuple(name, shape, dtype) -> str | None:  # type: ignore
 def array_equal(a1: ArrayLike, a2: ArrayLike, equal_nan: bool = False) -> Array:
   try:
     a1, a2 = asarray(a1), asarray(a2)
-  except Exception:
+  except Exception as err:
+    # TODO(jakevdp): Deprecated 2023-11-23; change to error.
+    warnings.warn("Inputs to array_equal() cannot be coerced to array. "
+                  "Returning False; in the future this will raise an exception.\n"
+                  f"{err!r}",
+                  DeprecationWarning, stacklevel=2)
     return bool_(False)
   if shape(a1) != shape(a2):
     return bool_(False)
@@ -2312,7 +2317,12 @@ def array_equal(a1: ArrayLike, a2: ArrayLike, equal_nan: bool = False) -> Array:
 def array_equiv(a1: ArrayLike, a2: ArrayLike) -> Array:
   try:
     a1, a2 = asarray(a1), asarray(a2)
-  except Exception:
+  except Exception as err:
+    # TODO(jakevdp): Deprecated 2023-11-23; change to error.
+    warnings.warn("Inputs to array_equiv() cannot be coerced to array. "
+                  "Returning False; in the future this will raise an exception.\n"
+                  f"{err!r}",
+                  DeprecationWarning, stacklevel=2)
     return bool_(False)
   try:
     eq = ufuncs.equal(a1, a2)


### PR DESCRIPTION
Part of #7737. Fixes #14901 and #17621

I opted not to go the `check_arraylike` route, because there are many downstream uses of `jnp.arrays_equal` on tuple/list inputs. Instead, we just deprecate the case where inputs cannot be coerced to an array, which is the most confusing case.