### PR TITLE
[shard-map] replace jaxpr interpreters with final-style-xform-of-eval-jaxpr

### DIFF
--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -1280,6 +1280,12 @@ class ShardMapTest(jtu.JaxTestCase):
     y = f(a, b)  # don't crash
     self.assertAllClose(y, a @ b, check_dtypes=False, atol=1e-2, rtol=1e-2)
 
+  def test_custom_jvp_inside_jit(self):
+    mesh = jtu.create_global_mesh((4,), ('batch',))
+    x = shard_map(jax.jit(jax.nn.relu),
+                  mesh=mesh, in_specs=P('batch'),
+                  out_specs=P('batch'))(jnp.arange(16.))  # don't crash
+
 
 class FunSpec(NamedTuple):
   name: str


### PR DESCRIPTION
When we have a final-style transformation (like `jvp`), and we want a jaxpr-to-jaxpr version of the same transformation, we usually just round-trip through `eval_jaxpr` (e.g. see `jvp_jaxpr` in ad.py). One of the reasons it's nice is that for primitives which have a different bind-form than jaxpr-form (like `custom_jvp`, which is parameterized by a Python callable at bind-time but by a jaxpr when in jaxpr-form) only need a bind-form rule.

Inexplicably, I didn't do that in some `shard_map`-related jaxpr-to-jaxpr transformations: even though we had an eager version, I directly wrote a jaxpr interpreter instead. (Maybe I wrote that one first, before the eager one?)

As a result, this code wouldn't work at HEAD:

```python
x = shard_map(jax.jit(jax.nn.relu), mesh=mesh, in_specs=P('batch'), out_specs=P('batch'))(jnp.arange(16.))
```

```
NotImplementedError: No replication rule for custom_jvp_call. ...
```

But it does after this PR!