### PR TITLE
[shape_poly] Add heuristics for deciding >= 0

### DIFF
--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -2353,9 +2353,6 @@ class ShapePolyHarnessesTest(jtu.JaxTestCase):
     if harness.group_name == "eig" and not jtu.test_device_matches(["cpu"]):
       raise unittest.SkipTest("JAX implements eig only on CPU.")
 
-    if harness.group_name == "indexing":
-      raise unittest.SkipTest("TODO(necula): fix the indexing tests")
-
     prev_jax_config_flags = {
       fname: getattr(jax.config, fname)
       for fname, fvalue in harness.override_jax_config_flags.items()


### PR DESCRIPTION
The rules for deciding inequalities of symbolic expressions are incomplete. Here we add two heuristics that help decide the bounds checking of indices computed for indexing with slices:

  1. To decide whether an expression that contains `non_negative(e)` is >= 0, it is sufficient to show that the expression is >=0 if we replace the `non_negative(e)` with `0` and with `e`.

  2. To decide whether `floordiv(e, k)` is >= 0, when `k >= 0`, it is sufficient to show that `e` is >= 0.

These are sufficient for the bounds checking that JAX is doing internally, but may not be for the cases when the user program does index computations using those operators.

This enables us to re-enable the shape_poly indexing tests.