### PR TITLE
Use qualified Python names in metadata if available

### DIFF
--- a/jax/_src/source_info_util.py
+++ b/jax/_src/source_info_util.py
@@ -147,11 +147,12 @@ if hasattr(xla_client.Traceback, "code_addr2location"):
     loc = xla_client.Traceback.code_addr2location(code, lasti)
     start_line, start_column, end_line, end_column = loc
     return Frame(file_name=code.co_filename,
-                function_name=code.co_name,
+                function_name=code.co_qualname,
                 start_line=start_line, start_column=start_column,
                 end_line=end_line, end_column=end_column)
 else:
   def raw_frame_to_frame(code: types.CodeType, lasti: int) -> Frame:
+    # pre-3.11 co_qualname does not exist, use co_name
     return Frame(file_name=code.co_filename,
                 function_name=code.co_name,
                 start_line=xla_client.Traceback.code_addr2line(code, lasti),


### PR DESCRIPTION
`co_qualname` is the equivalent of `__qualname__` in Python code.
For a member function
```python
class A:
  def b(self):
    pass
```
then the `co_name` of `b` was `b`, and the `co_qualname` of it is `A.b`.
These locations are propagated to XLA and the metadata of the compiled graph.
Depending on the coding style, `b` can be a very generic name (`run`, or whatever) with the useful information contained in the class name, `A`. In that case, having both in the metadata is more informative.

Unfortunately before Python 3.11 then the qualified name was not available through the code object.

See https://github.com/google/jax/issues/18764 for an example of the `co_name`-based metadata.

cc: @nouiz 