### PR TITLE
Add special.factorial function

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -143,6 +143,7 @@ jax.scipy.special
    expi
    expit
    expn
+   factorial
    gamma
    gammainc
    gammaincc

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -58,6 +58,14 @@ betaln = _wraps(
 )(_betaln_impl)
 
 
+@_wraps(osp_special.factorial, module='scipy.special')
+def factorial(n: ArrayLike, exact: bool = False) -> Array:
+  if exact:
+    raise NotImplementedError("factorial with exact=True")
+  n, = promote_args_inexact("factorial", n)
+  return jnp.where(n < 0, 0, lax.exp(lax.lgamma(n + 1)))
+
+
 @_wraps(osp_special.beta, module='scipy.special')
 def beta(x: ArrayLike, y: ArrayLike) -> Array:
   x, y = promote_args_inexact("beta", x, y)

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -30,6 +30,7 @@ from jax._src.scipy.special import (
   expi as expi,
   expit as expit,
   expn as expn,
+  factorial as factorial,
   gammainc as gammainc,
   gammaincc as gammaincc,
   gammaln as gammaln,

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -90,6 +90,9 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
         "gammaln", 1, float_dtypes, jtu.rand_positive, False
     ),
     op_record(
+        "factorial", 1, float_dtypes, jtu.rand_default, True
+    ),
+    op_record(
         "i0", 1, float_dtypes, jtu.rand_default, True
     ),
     op_record(


### PR DESCRIPTION
Fixes #18792

It doesn't seem all that useful to implement `exact=True`, because int64 can only represent the first 20 factorials (and int32 can only represent the first 12) and the correct overflow semantics are unclear. `scipy.factorial` falls back to arbitrary-width Python integers in this regime, but that's not possible in JAX.