### PR TITLE
Fixed failing shardmap error message builder when using functions with variable number of arguments

### DIFF
--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -313,7 +313,10 @@ def _unmentioned(mesh: Mesh, names: AxisNames) -> list[AxisName]:
 def _try_infer_args(f, tree):
   dummy_args = tree_unflatten(tree, [False] * tree.num_leaves)
   try:
-    return inspect.signature(f).bind(*dummy_args)
+    signature = inspect.signature(f).bind(*dummy_args)
+    if len(signature.arguments) != len(dummy_args):
+      return None
+    return signature
   except (TypeError, ValueError):
     return None
 


### PR DESCRIPTION
Previously, when using `shard_map` with a function that uses a variable number of arguments (i.e. `f(*args)`), if you made a mistake in your shard_map spec, instead of the really nicely formatted error message, you would actually get this error instead.

```
File "/Users/chaser/jax/jax/experimental/failure.py", line 23, in <module>
    jax.jit(f)(a, b)
  ...
  ... # Removed for brevity
  ...
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/jax/experimental/shard_map.py", line 191, in _check_specs_vs_args
    msg = _spec_rank_error(SpecErrorType.input, f, in_tree, in_specs, fail)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/jax/experimental/shard_map.py", line 215, in _spec_rank_error
    f"parameter '{list(ba.arguments.keys())[arg_key.idx]}',")
IndexError: list index out of range
```

This PR fixes the issue.