### PR TITLE
[PALLAS Triton] - Adding UINT8 dtype conversion from JAX to TRITON

### DIFF
--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -158,6 +158,8 @@ def _convert_dtype(dtype: jnp.dtype) -> tl.dtype:
     return tl.int32
   elif dtype == jnp.int64:
     return tl.int64
+  elif dtype == jnp.uint8:
+    return tl.uint8
   raise ValueError(f"Unhandled dtype: {dtype}")
 
 

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -783,6 +783,17 @@ class PallasCallTest(PallasTest):
 
     np.testing.assert_allclose(softmax_kernel(x), jax.nn.softmax(x), atol=1e-7)
 
+  def test_bitwise_count(self):
+    x = jnp.arange(8).astype(jnp.int32)
+    
+    @functools.partial(
+        self.pallas_call, out_shape=jax.ShapeDtypeStruct(x.shape, jnp.uint8))
+    def bitwise_count(x_ref, o_ref):
+      o_ref[...] =  jnp.bitwise_count(x_ref[...])
+
+    expected = jnp.bitwise_count(x)
+    np.testing.assert_allclose(bitwise_count(x), expected)
+
 
 class PallasCallInterpreterTest(PallasCallTest):
   INTERPRET = True


### PR DESCRIPTION
Adding UINT8 dtype conversion from JAX to TRITON.

Allow support for `jax.numpy.bitwise_count`

```python
import jax
from jax.experimental import pallas as pl

# JAX
x = jnp.arange(8).astype(jnp.int32)
print(f"{jnp.bitwise_count(x)=}")

# PALLAS
def bitwise_count_kernel(x_ref, o_ref):
    x = pl.load(x_ref, ())
    out = jnp.bitwise_count(x)
    pl.store(o_ref, (), out)

@jax.jit
def exec_fn(_x):
    return pl.pallas_call(
        bitwise_count_kernel, 
        out_shape=jax.ShapeDtypeStruct(_x.shape, dtype=jnp.uint8),
        grid=1
    )(_x)

x = jnp.arange(8).astype(jnp.int32)
print(f"{exec_fn(x)=}")
```

Only works after the fix in this PR:

```python
>>> jnp.bitwise_count(x)=Array([0, 1, 1, 2, 1, 2, 2, 3], dtype=uint8)
>>> exec_fn(x)=Array([0, 1, 1, 2, 1, 2, 2, 3], dtype=uint8)
```