### PR TITLE
improve a debug.callback type error message

### DIFF
--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -234,6 +234,9 @@ def debug_callback(callback: Callable[..., Any], *args: Any,
 
   .. _External Callbacks: https://jax.readthedocs.io/en/latest/notebooks/external_callbacks.html
   """
+  if not callable(callback):
+    raise TypeError("first argument to jax.debug.callback must be callable, "
+                    f"but got an object of type {type(callback)}")
   flat_args, in_tree = tree_util.tree_flatten((args, kwargs))
   effect = ordered_debug_effect if ordered else debug_effect
   def _flat_callback(*flat_args):

--- a/tests/debugging_primitives_test.py
+++ b/tests/debugging_primitives_test.py
@@ -58,6 +58,18 @@ class DummyDevice:
     self.platform = platform
     self.id = id
 
+
+class DebugCallbackTest(jtu.JaxTestCase):
+
+  def tearDown(self):
+    super().tearDown()
+    dispatch.runtime_tokens.clear()
+
+  def test_error_with_non_callable(self):
+    with self.assertRaisesRegex(TypeError, "callable"):
+      jax.debug.callback("this is not debug.print!")
+
+
 class DebugPrintTest(jtu.JaxTestCase):
 
   def tearDown(self):


### PR DESCRIPTION
What if some dummy wrote `jax.debug.callback("hello {}", x)`, forgetting to use `jax.debug.print`? Their lives are hard enough, we shouldn't give them a bad error message.

This PR improves the error message from

```
Exception ignored in atexit callback: <function wait_for_tokens at 0x7fb6e89f36d0>
Traceback (most recent call last):
  File "/usr/local/google/home/mattjj/packages/jax/jax/_src/dispatch.py", line 160, in wait_for_tokens
    runtime_tokens.block_until_ready()
  File "/usr/local/google/home/mattjj/packages/jax/jax/_src/dispatch.py", line 153, in block_until_ready
    token.block_until_ready()
jaxlib.xla_extension.XlaRuntimeError:
```

to

```
TypeError: first argument to jax.debug.callback must be callable, but got an object of type <class 'str'>
````