### PR TITLE
improve an error message during Mesh creation

### DIFF
--- a/jax/_src/mesh.py
+++ b/jax/_src/mesh.py
@@ -184,7 +184,13 @@ class Mesh(contextlib.ContextDecorator):
     if isinstance(axis_names, str):
       axis_names = (axis_names,)
     axis_names = tuple(axis_names)
-    assert devices.ndim == len(axis_names)
+
+    if devices.ndim != len(axis_names):
+      raise ValueError(
+          "Mesh requires the ndim of its first argument (`devices`) to equal "
+          "the length of its second argument (`axis_names`), but got "
+          f"devices.ndim == {devices.ndim} and "
+          f"len(axis_names) == {len(axis_names)}.")
 
     key = (axis_names, devices.shape, tuple(devices.flat))
     val = _mesh_object_dict.get(key, None)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4446,6 +4446,10 @@ class APITest(jtu.JaxTestCase):
     if (x_ptr & 15) != 0:
       self.assertTrue(np.shares_memory(out, x))
 
+  def test_mesh_creation_error_message(self):
+    with self.assertRaisesRegex(ValueError, "ndim of its first argument"):
+      jax.sharding.Mesh(jax.devices(), ("x", "y"))
+
 
 class RematTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Before we had an assertion error:

```
$ JAX_PLATFORMS=cpu python -c 'import jax; jax.sharding.Mesh(jax.devices(), ("a", "b"))'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/google/home/mattjj/packages/jax/jax/_src/mesh.py", line 187, in __new__
    assert devices.ndim == len(axis_names)
AssertionError
```

Now we have a ValueError:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/google/home/mattjj/packages/jax/jax/_src/mesh.py", line 190, in __new__
    raise ValueError(
ValueError: Mesh requires the ndim of its first argument (`devices`) to equal the length of its second argument (`axis_names`), but got devices.ndim == 1 and len(axis_names) == 2.
```