### PR TITLE
Print pjit name= before other params

### DIFF
--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -416,6 +416,7 @@ which the computation should run. For example
 { lambda ; a:f32[]. let
     b:f32[] = sub a 2.0
     c:f32[1] = pjit[
+      name=inner
       jaxpr={ lambda ; d:f32[] e:f32[]. let
           f:f32[1] = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] 1.0
           g:f32[] = convert_element_type[new_dtype=float32 weak_type=False] d
@@ -423,7 +424,6 @@ which the computation should run. For example
           i:f32[] = convert_element_type[new_dtype=float32 weak_type=False] e
           j:f32[1] = add i h
         in (j,) }
-      name=inner
     ] a b
     k:f32[] = convert_element_type[new_dtype=float32 weak_type=False] a
     l:f32[1] = add k c

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -3086,13 +3086,15 @@ def pp_eqn(eqn: JaxprEqn, context: JaxprPpContext, settings: JaxprPpSettings
           pp_eqn_rules.get(eqn.primitive, _pp_eqn))
   return rule(eqn, context, settings)  # type: ignore[operator]
 
-def _pp_eqn(eqn, context, settings) -> pp.Doc:
+def _pp_eqn(eqn, context, settings, params=None) -> pp.Doc:
   annotation = (source_info_util.summarize(eqn.source_info)
                 if settings.source_info else None)
+  if params is None:
+    params = sorted(eqn.params)
   name_stack_annotation = f'[{eqn.source_info.name_stack}]' if settings.name_stack else None
   lhs = pp_vars(eqn.outvars, context, print_shapes=settings.print_shapes)
   rhs = [pp.text(eqn.primitive.name, annotation=name_stack_annotation),
-         pp_kv_pairs(sorted(eqn.params.items()), context, settings),
+         pp_kv_pairs([(p, eqn.params[p]) for p in params], context, settings),
          pp.text(" ") + pp_vars(eqn.invars, context)]
   if lhs.format():
     return pp.concat([lhs, pp.text(" = ", annotation=annotation), *rhs])

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1864,7 +1864,11 @@ def _pjit_pp_rule(eqn, context, settings):
   if (params['resource_env'] is None or
       params['resource_env'].physical_mesh.empty):
     del params['resource_env']
-  return core._pp_eqn(eqn.replace(params=params), context, settings)
+
+  # Move name= to the front to make the resulting equation easier to scan.
+  del params["name"]
+  return core._pp_eqn(eqn, context, settings, params=["name"] + sorted(params))
+
 core.pp_eqn_rules[pjit_p] = _pjit_pp_rule
 
 

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -18,6 +18,7 @@ import re
 from functools import partial, lru_cache
 import logging
 import math
+import textwrap
 import threading
 import unittest
 
@@ -1223,6 +1224,19 @@ class PJitTest(jtu.BufferDonationTestCase):
           r"spec=PartitionSpec\(None, \('mdl',\), None, None\).*\) is only "
           "valid for values of rank at least 4, but was applied to a value of rank 1"):
         pjit_f(jnp.array([1, 2, 3]))
+
+  def test_pretty_print(self):
+    f = pjit(lambda x: x)
+    x = jnp.array([4.2], dtype=jnp.float32)
+    jaxpr = jax.make_jaxpr(f)(x)
+    self.assertEqual(
+        jaxpr.pretty_print(),
+        textwrap.dedent("""
+            { lambda ; a:f32[1]. let
+                b:f32[1] = pjit[name=<lambda> jaxpr={ lambda ; c:f32[1]. let  in (c,) }] a
+              in (b,) }
+        """).strip(),
+    )
 
 
 @jtu.pytest_mark_if_available('multiaccelerator')


### PR DESCRIPTION
The jaxpr sometimes gets pretty big, making it hard to see the name.