### PR TITLE
don't call lax.xeinsum from jnp.einsum when str contains '{'

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3469,8 +3469,6 @@ def einsum(
   if out is not None:
     raise NotImplementedError("The 'out' argument to jnp.einsum is not supported.")
   spec = operands[0] if isinstance(operands[0], str) else None
-  if spec is not None and '{' in spec:
-    return jax.named_call(lax.xeinsum, name=spec)(*operands)
   optimize = 'optimal' if optimize is True else optimize
 
   # Allow handling of shape polymorphism

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -1455,7 +1455,7 @@ class PDotTests(XMapTestCase):
     rng = self.rng()
     x = rng.randn(3)
     y = rng.randn(3)
-    out = xmap(partial(jnp.einsum, '{i},{i}->'),
+    out = xmap(partial(lax.xeinsum, '{i},{i}->'),
                in_axes=(['i'], ['i']), out_axes=[])(x, y)
     expected = np.einsum('i,i->', x, y)
     self.assertAllClose(out, expected, check_dtypes=False)
@@ -1464,7 +1464,7 @@ class PDotTests(XMapTestCase):
     rng = self.rng()
     x = rng.randn(3)
     y = rng.randn(3)
-    out = xmap(partial(jnp.einsum, '{i},{j}->{i,j}'),
+    out = xmap(partial(lax.xeinsum, '{i},{j}->{i,j}'),
                in_axes=(['i'], ['j']), out_axes=['i', 'j'])(x, y)
     expected = np.einsum('i,j->ij', x, y)
     self.assertAllClose(out, expected, check_dtypes=True)
@@ -1476,7 +1476,7 @@ class PDotTests(XMapTestCase):
     y = rng.randn(4, 5)
 
     def check(spec):
-      out = xmap(partial(jnp.einsum, spec),
+      out = xmap(partial(lax.xeinsum, spec),
                  in_axes=(['i', 'j'], ['j', 'k']),
                  out_axes=['i', 'k'])(x, y)
       expected = np.einsum('ij,jk->ik', x, y)
@@ -1537,7 +1537,7 @@ class PDotTests(XMapTestCase):
     y = rng.randn(5,)
 
     def check(spec):
-      out = xmap(partial(jnp.einsum, spec),
+      out = xmap(partial(lax.xeinsum, spec),
                  in_axes=(['i', 'j'], ['k']),
                  out_axes=['i', 'k'])(x, y)
       expected = np.einsum('ij,k->ik', x, y)
@@ -1552,7 +1552,7 @@ class PDotTests(XMapTestCase):
     y = rng.randn(8,)
 
     def check(spec):
-      out = xmap(partial(jnp.einsum, spec),
+      out = xmap(partial(lax.xeinsum, spec),
                  in_axes=(['i', 'j'], ['k']),
                  out_axes=['i', 'k'],
                  axis_resources={'i': 'x', 'k': 'y'})(x, y)
@@ -1572,7 +1572,7 @@ class PDotTests(XMapTestCase):
     y = rng.randn(8, 4, 5)
 
     def check(spec):
-      out = xmap(partial(jnp.einsum, spec),
+      out = xmap(partial(lax.xeinsum, spec),
                  in_axes=(['b', 'i', 'j'], ['b', 'j', 'k']),
                  out_axes=['b', 'i', 'k'],
                  axis_resources={'b': 'x', 'j': 'y'})(x, y)
@@ -1589,7 +1589,7 @@ class PDotTests(XMapTestCase):
     x = rng.randn(8, 6, 4)
 
     def check(spec):
-      out = xmap(partial(jnp.einsum, spec),
+      out = xmap(partial(lax.xeinsum, spec),
                  in_axes=['b', 'i', 'j'],
                  out_axes=['b'],
                  axis_resources={'b': 'x', 'i': 'y'})(x)
@@ -1607,7 +1607,7 @@ class PDotTests(XMapTestCase):
     x = rng.randn(8, 6, 4, 5)
 
     def check(spec):
-      out = xmap(partial(jnp.einsum, spec),
+      out = xmap(partial(lax.xeinsum, spec),
                  in_axes=['b', 'i', ...],
                  out_axes=['b', ...],
                  axis_resources={'b': 'x', 'i': 'y'})(x)


### PR DESCRIPTION
can still call lax.xeinsum directly

the first commit is included in another PR going in now, so the real diff here is b9a52958a7b841727885b40fa69328a2d186549e