### PR TITLE
Upgrade remaining sources to Python 3.9

### DIFF
--- a/jax/_src/basearray.py
+++ b/jax/_src/basearray.py
@@ -14,9 +14,11 @@
 
 # Note that type annotations for this file are defined in basearray.pyi
 
+from __future__ import annotations
+
 import abc
 import numpy as np
-from typing import Any, Union
+from typing import Any
 from collections.abc import Sequence
 
 # TODO(jakevdp): fix import cycles and define these.
@@ -73,7 +75,7 @@ class Array(abc.ABC):
 
   # Documentation for sharding-related methods and properties defined on ArrayImpl:
   @abc.abstractmethod
-  def addressable_data(self, index: int) -> "Array":
+  def addressable_data(self, index: int) -> Array:
     """Return an array of the addressable data at a particular index."""
 
   @property
@@ -118,10 +120,10 @@ Array.__module__ = "jax"
 # standard JAX array (i.e. not including future non-standard array types like
 # KeyArray and BInt). It's different than np.typing.ArrayLike in that it doesn't
 # accept arbitrary sequences, nor does it accept string data.
-ArrayLike = Union[
-  Array,  # JAX array type
-  np.ndarray,  # NumPy array type
-  np.bool_, np.number,  # NumPy scalar types
-  bool, int, float, complex,  # Python scalar types
-]
+ArrayLike = (
+  Array |  # JAX array type
+  np.ndarray |  # NumPy array type
+  np.bool_ | np.number |  # NumPy scalar types
+  bool | int | float | complex  # Python scalar types
+)
 ArrayLike.__doc__ = "Type annotation for JAX array-like objects."

--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -17,7 +17,7 @@ from collections.abc import Sequence
 import dataclasses
 import functools
 import itertools as it
-from typing import Union, Callable, TypeVar, Any
+from typing import Callable, TypeVar, Any
 
 import numpy as np
 
@@ -55,10 +55,10 @@ traceback_util.register_exclusion(__file__)
 map, unsafe_map = safe_map, map
 zip, unsafe_zip = safe_zip, zip
 
-Bool = Union[bool, Array]
-Int = Union[int, Array]
+Bool = bool | Array
+Int = int | Array
 ErrorCategory = type['JaxException']
-Payload = list[Union[np.ndarray, Array]]
+Payload = list[np.ndarray | Array]
 PyTreeDef = jtu.PyTreeDef
 Out = TypeVar('Out')
 

--- a/jax/_src/clusters/cloud_tpu_cluster.py
+++ b/jax/_src/clusters/cloud_tpu_cluster.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 import re
 import socket
 import time
-from typing import Optional
 from jax._src import clusters
 from jax._src.cloud_tpu_init import running_in_cloud_tpu_vm
 
@@ -99,7 +100,7 @@ class SingleSliceGceTpuCluster(clusters.ClusterEnv):
     return int(get_metadata('agent-worker-number'))
 
   @classmethod
-  def get_local_process_id(cls) -> Optional[int]:
+  def get_local_process_id(cls) -> int | None:
     return None
 
 class MultisliceGceTpuCluster(clusters.ClusterEnv):
@@ -147,7 +148,7 @@ class MultisliceGceTpuCluster(clusters.ClusterEnv):
     return process_id_in_slice + slice_id * processes_per_slice
 
   @classmethod
-  def get_local_process_id(cls) -> Optional[int]:
+  def get_local_process_id(cls) -> int | None:
     return None
 
   @staticmethod

--- a/jax/_src/clusters/cluster.py
+++ b/jax/_src/clusters/cluster.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import logging
-from typing import Optional
 from jax._src.cloud_tpu_init import running_in_cloud_tpu_vm
 
 logger = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ class ClusterEnv:
   :class:`ClusterEnv` subclasses are automatically detected when imported.
   """
 
-  _cluster_types: list[type['ClusterEnv']] = []
+  _cluster_types: list[type[ClusterEnv]] = []
 
   def __init_subclass__(cls, **kwargs):
     super().__init_subclass__(**kwargs)
@@ -38,12 +39,12 @@ class ClusterEnv:
   @classmethod
   # pytype: disable=bad-return-type
   def auto_detect_unset_distributed_params(cls,
-                                           coordinator_address: Optional[str],
-                                           num_processes: Optional[int],
-                                           process_id: Optional[int],
-                                           local_device_ids: Optional[Sequence[int]]
-                                          ) -> tuple[Optional[str], Optional[int], Optional[int],
-                                                     Optional[Sequence[int]]]:
+                                           coordinator_address: str | None,
+                                           num_processes: int | None,
+                                           process_id: int | None,
+                                           local_device_ids: Sequence[int] | None
+                                          ) -> tuple[str | None, int | None, int | None,
+                                                     Sequence[int] | None]:
     if all(p is not None for p in (coordinator_address, num_processes,
       process_id, local_device_ids)):
       return (coordinator_address, num_processes, process_id,
@@ -100,7 +101,7 @@ class ClusterEnv:
     raise NotImplementedError("ClusterEnv subclasses must implement get_process_id")
 
   @classmethod
-  def get_local_process_id(cls) -> Optional[int]:
+  def get_local_process_id(cls) -> int | None:
     """ Get index of current process inside a host.
 
     The method is only useful to support single device per process.

--- a/jax/_src/clusters/ompi_cluster.py
+++ b/jax/_src/clusters/ompi_cluster.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 import re
-from typing import Optional
 from jax._src import clusters
 
 #  OMPI_MCA_orte_hnp_uri exists only when processes are launched via mpirun or mpiexec
@@ -55,5 +56,5 @@ class OmpiCluster(clusters.ClusterEnv):
     return int(os.environ[_PROCESS_ID])
 
   @classmethod
-  def get_local_process_id(cls) -> Optional[int]:
+  def get_local_process_id(cls) -> int | None:
     return int(os.environ[_LOCAL_PROCESS_ID])

--- a/jax/_src/clusters/slurm_cluster.py
+++ b/jax/_src/clusters/slurm_cluster.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
-from typing import Optional
 from jax._src import clusters
 
 _JOBID_PARAM = 'SLURM_JOB_ID'
@@ -58,5 +59,5 @@ class SlurmCluster(clusters.ClusterEnv):
     return int(os.environ[_PROCESS_ID])
 
   @classmethod
-  def get_local_process_id(cls) -> Optional[int]:
+  def get_local_process_id(cls) -> int | None:
     return int(os.environ[_LOCAL_PROCESS_ID])

--- a/jax/_src/compilation_cache.py
+++ b/jax/_src/compilation_cache.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
 import threading
-from typing import Optional
 import zlib
 
 import numpy as np
@@ -35,7 +36,7 @@ from jax._src.lib.mlir import ir
 
 logger = logging.getLogger(__name__)
 
-_cache: Optional[CacheInterface] = None
+_cache: CacheInterface | None = None
 
 _cache_initialized: bool = False
 
@@ -102,7 +103,7 @@ def _initialize_cache() -> None:
     logger.debug("Initialized persistent compilation cache at %s", path)
 
 
-def _get_cache() -> Optional[CacheInterface]:
+def _get_cache() -> CacheInterface | None:
   # TODO(b/289098047): consider making this an API and changing the callers of
   # get_executable_and_time() and put_executable_and_time() to call get_cache()
   # and passing the result to them.
@@ -113,7 +114,7 @@ def _get_cache() -> Optional[CacheInterface]:
 
 def get_executable_and_time(
     cache_key: str, compile_options, backend
-) -> tuple[Optional[xla_client.LoadedExecutable], Optional[int]]:
+) -> tuple[xla_client.LoadedExecutable | None, int | None]:
   """Returns the cached executable and its compilation time if present, or None
   otherwise.
   """

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-import collections
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 from collections.abc import Generator, Hashable, Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -28,8 +27,8 @@ import operator
 from operator import attrgetter
 import threading
 import types
-from typing import (Any, Callable, ClassVar, DefaultDict, Generic, NamedTuple,
-                    TypeVar, Union, cast, overload)
+from typing import (Any, Callable, ClassVar, Generic, NamedTuple, TypeVar,
+                    cast, overload)
 import warnings
 from weakref import ref
 
@@ -379,7 +378,7 @@ class Literal:
 
 literalable_types: set[type] = set()
 
-Atom = Union[Var, Literal]
+Atom = Var | Literal
 
 class Primitive:
   name: str
@@ -1887,7 +1886,7 @@ class bint(dtypes.ExtendedDType):
   def __str__(self) -> str:
     return self.name
 
-AxisSize = Union[int, DArray, Tracer, Var, DBIdx, InDBIdx, OutDBIdx]
+AxisSize = int | DArray | Tracer | Var | DBIdx | InDBIdx | OutDBIdx
 
 
 class AbstractToken(AbstractValue):
@@ -3024,10 +3023,10 @@ class JaxprPpSettings(NamedTuple):
 # A JaxprPpContext allows us to globally uniquify variable names within nested
 # Jaxprs.
 class JaxprPpContext:
-  var_ids: DefaultDict[Var, int]
+  var_ids: defaultdict[Var, int]
 
   def __init__(self):
-    self.var_ids = collections.defaultdict(it.count().__next__, {})
+    self.var_ids = defaultdict(it.count().__next__, {})
 
 
 def pp_var(v: Var, context: JaxprPpContext) -> str:

--- a/jax/_src/custom_batching.py
+++ b/jax/_src/custom_batching.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import functools
 import operator
-from typing import Callable, Optional
+from typing import Callable
 
 from jax import lax
 from jax._src import api
@@ -47,7 +49,7 @@ zip, unsafe_zip = util.safe_zip, zip
 @custom_api_util.register_custom_decorator_type
 class custom_vmap:
   fun: Callable
-  vmap_rule: Optional[Callable]
+  vmap_rule: Callable | None
 
   def __init__(self, fun: Callable):
     functools.update_wrapper(self, fun)

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import dataclasses
 from functools import update_wrapper, reduce, partial
 import inspect
-from typing import Any, Callable, Generic, Optional, TypeVar
+from typing import Any, Callable, Generic, TypeVar
 
 from jax._src import config
 from jax._src import core
@@ -136,7 +138,7 @@ class custom_jvp(Generic[ReturnValue]):
   """
   fun: Callable[..., ReturnValue]
   nondiff_argnums: tuple[int, ...]
-  jvp: Optional[Callable[..., tuple[ReturnValue, ReturnValue]]] = None
+  jvp: Callable[..., tuple[ReturnValue, ReturnValue]] | None = None
   symbolic_zeros: bool = False
 
   def __init__(self,
@@ -194,7 +196,7 @@ class custom_jvp(Generic[ReturnValue]):
     self.symbolic_zeros = symbolic_zeros
     return jvp
 
-  def defjvps(self, *jvps: Optional[Callable[..., ReturnValue]]):
+  def defjvps(self, *jvps: Callable[..., ReturnValue] | None):
     """Convenience wrapper for defining JVPs for each argument separately.
 
     This convenience wrapper cannot be used together with ``nondiff_argnums``.
@@ -493,8 +495,8 @@ class custom_vjp(Generic[ReturnValue]):
     update_wrapper(self, fun)
     self.fun = fun
     self.nondiff_argnums = nondiff_argnums
-    self.fwd: Optional[Callable[..., tuple[ReturnValue, Any]]] = None
-    self.bwd: Optional[Callable[..., tuple[Any, ...]]] = None
+    self.fwd: Callable[..., tuple[ReturnValue, Any]] | None = None
+    self.bwd: Callable[..., tuple[Any, ...]] | None = None
     self.symbolic_zeros = False
 
   __getattr__ = custom_api_util.forward_attr

--- a/jax/_src/custom_transpose.py
+++ b/jax/_src/custom_transpose.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import functools
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from jax._src import ad_util
 from jax._src import api_util
@@ -65,7 +67,7 @@ flatten_fun_nokwargs = transformation_with_aux(
 @custom_api_util.register_custom_decorator_type
 class custom_transpose:
   fun: Callable
-  transpose: Optional[Callable] = None
+  transpose: Callable | None = None
 
   def __init__(self, fun: Callable):
     functools.update_wrapper(self, fun)

--- a/jax/_src/debugger/colab_lib.py
+++ b/jax/_src/debugger/colab_lib.py
@@ -20,7 +20,7 @@ import functools
 import sys
 import uuid
 
-from typing import Any, Union
+from typing import Any
 
 IS_COLAB_ENABLED = "google.colab" in sys.modules
 if IS_COLAB_ENABLED:
@@ -39,7 +39,7 @@ class DOMElement(metaclass=abc.ABCMeta):
     pass
 
 
-Element = Union[DOMElement, str]
+Element = DOMElement | str
 
 
 class DynamicDOMElement(DOMElement):

--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 """Module for JAX debugging primitives and related functionality."""
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import functools
 import string
 import sys
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable
 import weakref
 
 import numpy as np
@@ -434,12 +436,12 @@ def _slice_to_chunk_idx(size: int, slc: slice) -> int:
   assert size % slice_size == 0
   return slc.start // slice_size
 
-def _raise_to_slice(slc: Union[slice, int]):
+def _raise_to_slice(slc: slice | int):
   if isinstance(slc, int):
     return slice(slc, slc + 1)
   return slc
 
-Color = Union[tuple[float, float, float], str]
+Color = tuple[float, float, float] | str
 ColorMap = Callable[[float], tuple[float, float, float, float]]
 
 def _canonicalize_color(color: Color) -> str:
@@ -465,7 +467,7 @@ def make_color_iter(color_map, num_rows, num_cols):
 def visualize_sharding(shape: Sequence[int], sharding: Sharding, *,
                        use_color: bool = True, scale: float = 1.,
                        min_width: int = 9, max_width: int = 80,
-                       color_map: Optional[ColorMap] = None):
+                       color_map: ColorMap | None = None):
   """Visualizes a ``Sharding`` using ``rich``."""
   if not RICH_ENABLED:
     raise ValueError("`visualize_sharding` requires `rich` to be installed.")
@@ -491,7 +493,7 @@ def visualize_sharding(shape: Sequence[int], sharding: Sharding, *,
 
   device_indices_map = sharding.devices_indices_map(tuple(shape))
   slices: dict[tuple[int, ...], set[int]] = {}
-  heights: dict[tuple[int, ...], Optional[float]] = {}
+  heights: dict[tuple[int, ...], float | None] = {}
   widths: dict[tuple[int, ...], float] = {}
 
   for i, (dev, slcs) in enumerate(device_indices_map.items()):

--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import atexit
 from collections.abc import Sequence
 import logging
 import os
-from typing import Any, Optional, Union
+from typing import Any
 
 from jax._src import clusters
 from jax._src import config
@@ -29,16 +31,16 @@ logger = logging.getLogger(__name__)
 class State:
   process_id: int = 0
   num_processes: int = 1
-  service: Optional[Any] = None
-  client: Optional[Any] = None
-  preemption_sync_manager: Optional[Any] = None
-  coordinator_address: Optional[str] = None
+  service: Any | None = None
+  client: Any | None = None
+  preemption_sync_manager: Any | None = None
+  coordinator_address: str | None = None
 
   def initialize(self,
-                 coordinator_address: Optional[str] = None,
-                 num_processes: Optional[int] = None,
-                 process_id: Optional[int] = None,
-                 local_device_ids: Optional[Union[int, Sequence[int]]] = None,
+                 coordinator_address: str | None = None,
+                 num_processes: int | None = None,
+                 process_id: int | None = None,
+                 local_device_ids: int | Sequence[int] | None = None,
                  initialization_timeout: int = 300):
     coordinator_address = (coordinator_address or
                            os.environ.get('JAX_COORDINATOR_ADDRESS', None))
@@ -108,10 +110,10 @@ class State:
 global_state = State()
 
 
-def initialize(coordinator_address: Optional[str] = None,
-               num_processes: Optional[int] = None,
-               process_id: Optional[int] = None,
-               local_device_ids: Optional[Union[int, Sequence[int]]] = None,
+def initialize(coordinator_address: str | None = None,
+               num_processes: int | None = None,
+               process_id: int | None = None,
+               local_device_ids: int | Sequence[int] | None = None,
                initialization_timeout: int = 300):
   """Initializes the JAX distributed system.
 

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import abc
 import builtins
 import functools
-from typing import cast, overload, Any, Literal, Union
+from typing import cast, overload, Any, Literal
 import warnings
 
 import ml_dtypes
@@ -364,7 +364,7 @@ def issubdtype(a: DTypeLike | None, b: DTypeLike | None) -> bool:
 
 can_cast = np.can_cast
 
-JAXType = Union[type, DType]
+JAXType = type | DType
 
 # Enumeration of all valid JAX types in order.
 _weak_types: list[JAXType] = [int, float, complex]

--- a/jax/_src/environment_info.py
+++ b/jax/_src/environment_info.py
@@ -12,24 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import subprocess
 import sys
 import textwrap
-from typing import Optional, Union
 
 from jax import version
 from jax._src import lib
 from jax._src import xla_bridge
 import numpy as np
 
-def try_nvidia_smi() -> Optional[str]:
+def try_nvidia_smi() -> str | None:
   try:
     return subprocess.check_output(['nvidia-smi']).decode()
   except Exception:
     return None
 
 
-def print_environment_info(return_string: bool = False) -> Union[None, str]:
+def print_environment_info(return_string: bool = False) -> str | None:
   """Returns a string containing local environment & JAX installation information.
 
   This is useful information to include when asking a question or filing a bug.

--- a/jax/_src/image/scale.py
+++ b/jax/_src/image/scale.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 from functools import partial
 import enum
-from typing import Callable, Union
+from typing import Callable
 
 import numpy as np
 
@@ -171,7 +173,7 @@ _kernels = {
 def scale_and_translate(image, shape: core.Shape,
                         spatial_dims: Sequence[int],
                         scale, translation,
-                        method: Union[str, ResizeMethod],
+                        method: str | ResizeMethod,
                         antialias: bool = True,
                         precision=lax.Precision.HIGHEST):
   """Apply a scale and translation to an image.
@@ -269,7 +271,7 @@ def _resize_nearest(x, output_shape: core.Shape):
 
 
 @partial(jit, static_argnums=(1, 2, 3, 4))
-def _resize(image, shape: core.Shape, method: Union[str, ResizeMethod],
+def _resize(image, shape: core.Shape, method: str | ResizeMethod,
             antialias: bool, precision):
   if len(shape) != image.ndim:
     msg = ('shape must have length equal to the number of dimensions of x; '
@@ -295,7 +297,7 @@ def _resize(image, shape: core.Shape, method: Union[str, ResizeMethod],
                               antialias, precision)
 
 
-def resize(image, shape: core.Shape, method: Union[str, ResizeMethod],
+def resize(image, shape: core.Shape, method: str | ResizeMethod,
            antialias: bool = True,
            precision = lax.Precision.HIGHEST):
   """Image resize.

--- a/jax/_src/internal_test_util/export_back_compat_test_util.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_util.py
@@ -65,13 +65,15 @@ then update `test_custom_call_coverage`, and then update your `test_foo_call`:
 
 """
 
+from __future__ import annotations
+
 from collections.abc import Iterable, Sequence
 import dataclasses
 import datetime
 import os
 import re
 import sys
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from absl import logging
 
@@ -163,12 +165,12 @@ class CompatTestBase(jtu.JaxTestCase):
 
   def run_one_test(self, func: Callable[..., jax.Array],
                    data: CompatTestData,
-                   polymorphic_shapes: Optional[Sequence[str]] = None,
-                   rtol: Optional[float] = None,
-                   atol: Optional[float] = None,
+                   polymorphic_shapes: Sequence[str] | None = None,
+                   rtol: float | None = None,
+                   atol: float | None = None,
                    allow_unstable_custom_call_targets: Sequence[str] = (),
-                   check_results: Optional[Callable[..., None]] = None,
-                   expect_current_custom_calls: Optional[Sequence[str]] = None):
+                   check_results: Callable[..., None] | None = None,
+                   expect_current_custom_calls: Sequence[str] | None = None):
     """Run one compatibility test.
 
     Args:
@@ -271,7 +273,7 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
 
   def serialize(self,
                 func: Callable, data: CompatTestData, *,
-                polymorphic_shapes: Optional[Sequence[str]] = None,
+                polymorphic_shapes: Sequence[str] | None = None,
                 allow_unstable_custom_call_targets: Sequence[str] = ()
                 ) -> tuple[bytes, str, int, int]:
     """Serializes the test function.
@@ -303,7 +305,7 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
     return serialized, module_str, module_version, nr_devices
 
   def run_serialized(self, data: CompatTestData,
-                     polymorphic_shapes: Optional[Sequence[str]] = None):
+                     polymorphic_shapes: Sequence[str] | None = None):
     args_specs = export.args_specs(data.inputs, polymorphic_shapes)
     def ndarray_to_aval(a: np.ndarray) -> core.ShapedArray:
       return core.ShapedArray(a.shape, a.dtype)

--- a/jax/_src/internal_test_util/lax_test_util.py
+++ b/jax/_src/internal_test_util/lax_test_util.py
@@ -17,9 +17,11 @@
 # only, and may be changed or removed at any time and without any deprecation
 # cycle.
 
+from __future__ import annotations
+
 import collections
 import itertools
-from typing import Optional, cast
+from typing import cast
 
 from jax import lax
 from jax._src import dtypes
@@ -355,7 +357,7 @@ def lax_ops():
 
 
 def all_bdims(*shapes):
-  bdims = (itertools.chain([cast(Optional[int], None)],
+  bdims = (itertools.chain([cast(int | None, None)],
                            range(len(shape) + 1)) for shape in shapes)
   return (t for t in itertools.product(*bdims) if not all(e is None for e in t))
 

--- a/jax/_src/internal_test_util/test_harnesses.py
+++ b/jax/_src/internal_test_util/test_harnesses.py
@@ -36,11 +36,13 @@ The limitations are used to filter out from tests the harnesses that are known
 to fail. A Limitation is specific to a harness.
 """
 
+from __future__ import annotations
+
 from collections.abc import Iterable, Sequence
 import operator
 import os
 from functools import partial
-from typing import Any, Callable, Optional, NamedTuple, Union
+from typing import Any, Callable, NamedTuple
 
 from absl import testing
 import numpy as np
@@ -96,7 +98,7 @@ class CustomArg(NamedTuple):
   make: Callable[[Rng], Any]  # Called with a Rng to make a tensor
 
 
-ArgDescriptor = Union[RandArg, StaticArg, CustomArg, Any]
+ArgDescriptor = RandArg | StaticArg | CustomArg | Any
 
 
 class Harness:
@@ -151,7 +153,7 @@ class Harness:
   dtype: DType
   # A set of limitations describing the cases that are not supported or
   # partially implemented in JAX for this harness.
-  jax_unimplemented: Sequence["Limitation"]
+  jax_unimplemented: Sequence[Limitation]
   rng_factory: Callable
   # Carry some arbitrary parameters that the test can access.
   params: dict[str, Any]
@@ -164,7 +166,7 @@ class Harness:
                *,
                dtype,
                rng_factory=jtu.rand_default,
-               jax_unimplemented: Sequence["Limitation"] = (),
+               jax_unimplemented: Sequence[Limitation] = (),
                **params):
     """See class docstring."""
     self.group_name = jtu.sanitize_test_name(group_name)
@@ -224,7 +226,7 @@ class Harness:
              device_under_test: str,
              *,
              include_jax_unimpl: bool = False,
-             one_containing: Optional[str] = None) -> bool:
+             one_containing: str | None = None) -> bool:
     if not include_jax_unimpl:
       if any(
           device_under_test in l.devices
@@ -285,7 +287,7 @@ def define(
     *,
     dtype,
     rng_factory=jtu.rand_default,
-    jax_unimplemented: Sequence["Limitation"] = (),
+    jax_unimplemented: Sequence[Limitation] = (),
     **params):
   """Defines a harness and stores it in `all_harnesses`. See Harness."""
   group_name = str(group_name)
@@ -312,7 +314,7 @@ class Limitation:
       description: str,
       *,
       enabled: bool = True,
-      devices: Union[str, Sequence[str]] = ("cpu", "gpu", "tpu"),
+      devices: str | Sequence[str] = ("cpu", "gpu", "tpu"),
       dtypes: Sequence[DType] = (),
       skip_run: bool = False,
   ):
@@ -354,8 +356,8 @@ class Limitation:
   __repr__ = __str__
 
   def filter(self,
-             device: Optional[str] = None,
-             dtype: Optional[DType] = None) -> bool:
+             device: str | None = None,
+             dtype: DType | None = None) -> bool:
     """Check that a limitation is enabled for the given dtype and device."""
     return (self.enabled and
             (not self.dtypes or dtype is None or dtype in self.dtypes) and
@@ -364,7 +366,7 @@ class Limitation:
 
 def parameterized(harnesses: Iterable[Harness],
                   *,
-                  one_containing: Optional[str] = None,
+                  one_containing: str | None = None,
                   include_jax_unimpl: bool = False):
   """Decorator for tests.
 

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import contextlib
 import functools
 import itertools as it
 from functools import partial
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable
 
 import jax
 from jax._src import config
@@ -46,7 +48,7 @@ def identity(x): return x
 
 def _update_annotation(
     f: lu.WrappedFun,
-    orig_type: Optional[tuple[tuple[core.AbstractValue, bool], ...]],
+    orig_type: tuple[tuple[core.AbstractValue, bool], ...] | None,
     explicit_nonzeros: list[bool]
   ) -> lu.WrappedFun:
   if orig_type is None:
@@ -694,7 +696,7 @@ def map_transpose(primitive, params, call_jaxpr, args, ct, _, reduce_axes):
 
 
 def jvp_jaxpr(jaxpr: core.ClosedJaxpr, nonzeros: Sequence[bool],
-              instantiate: Union[bool, Sequence[bool]]
+              instantiate: bool | Sequence[bool]
               ) -> tuple[core.ClosedJaxpr, list[bool]]:
   if type(instantiate) is bool:
     instantiate = (instantiate,) * len(jaxpr.out_avals)

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -17,7 +17,7 @@ import collections
 from collections.abc import Iterable, Sequence
 import dataclasses
 from functools import partial
-from typing import Any, Callable, Union
+from typing import Any, Callable
 
 import numpy as np
 
@@ -966,7 +966,7 @@ def _matchaxis_symbolic_zeros(axis_name, sz, name, src, dst, x, sum_match=False)
 
 ### utilities for defining primitives' batching rules
 
-BatchingRule = Callable[..., tuple[Any, Union[None, int, tuple[Union[None, int], ...]]]]
+BatchingRule = Callable[..., tuple[Any, int | tuple[int | None, ...] | None]]
 primitive_batchers : dict[core.Primitive, BatchingRule] = {}
 axis_primitive_batchers: dict[core.Primitive, Callable] = {}
 spmd_axis_primitive_batchers: dict[core.Primitive, Callable] = {}

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -25,7 +25,7 @@ import itertools
 import operator
 import re
 import typing
-from typing import Any, Callable, NamedTuple, Protocol, Union
+from typing import Any, Callable, NamedTuple, Protocol
 import warnings
 
 import numpy as np
@@ -390,11 +390,11 @@ def make_ir_context() -> ir.Context:
   return context
 
 
-AxisContext = Union[
-    sharding_impls.SPMDAxisContext,
-    sharding_impls.ReplicaAxisContext,
-    sharding_impls.ShardingContext,
-]
+AxisContext = (
+    sharding_impls.SPMDAxisContext |
+    sharding_impls.ReplicaAxisContext |
+    sharding_impls.ShardingContext
+)
 
 class ShapePolyLoweringState:
   # The names of the dimension variables, sorted by name. This is the order in
@@ -942,7 +942,7 @@ class TokenSet:
   primitives. A `TokenSet` encapsulates a set of HLO tokens that will be
   used by the lowering rules.
   """
-  _tokens: typing.OrderedDict[core.Effect, Token]
+  _tokens: collections.OrderedDict[core.Effect, Token]
 
   def __init__(self, *args, **kwargs):
     self._tokens = collections.OrderedDict(*args, **kwargs)

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -25,7 +25,7 @@ import itertools as it
 import logging
 import math
 import threading
-from typing import (Any, Callable, NamedTuple, Optional, Union, cast, TypeVar)
+from typing import (Any, Callable, NamedTuple, cast, TypeVar)
 from collections.abc import Iterator
 import warnings
 
@@ -87,7 +87,7 @@ unsafe_map, map = map, safe_map  # type: ignore
 
 logger = logging.getLogger(__name__)
 
-Index = Union[int, slice, tuple[Union[int, slice], ...]]
+Index = int | slice | tuple[int | slice, ...]
 
 NoSharding = sharding_specs.NoSharding
 Chunked = sharding_specs.Chunked
@@ -96,10 +96,10 @@ Unstacked = sharding_specs.Unstacked
 ShardedAxis = sharding_specs.ShardedAxis
 Replicated = sharding_specs.Replicated
 
-AvalDimSharding = Union[Unstacked, Chunked, NoSharding]
+AvalDimSharding = Unstacked | Chunked | NoSharding
 Mesh = mesh_lib.Mesh
 MeshAxisName = sharding_impls.MeshAxisName
-MeshDimAssignment = Union[ShardedAxis, Replicated]
+MeshDimAssignment = ShardedAxis | Replicated
 ShardingSpec = sharding_specs.ShardingSpec
 
 
@@ -1541,7 +1541,7 @@ class TileVectorize:
 class TileManual:
   manual_axes: frozenset[sharding_impls.MeshAxisName]
 
-TilingMethod = Union[TileVectorize, TileManual]
+TilingMethod = TileVectorize | TileManual
 
 
 def check_if_any_auto(
@@ -1608,8 +1608,10 @@ class DeviceAssignmentMismatchError(Exception):
 
 
 ShardingInfo = tuple[
-    Union[sharding_impls.XLACompatibleSharding, UnspecifiedValue, AUTO],
-    MismatchType, Optional[Any]]  # Any is dispatch.SourceInfo to avoid circular imports
+    sharding_impls.XLACompatibleSharding | UnspecifiedValue | AUTO,
+    MismatchType,
+    Any | None,  # Any is dispatch.SourceInfo to avoid circular imports
+]
 
 
 def _get_default_device() -> xc.Device:
@@ -1663,7 +1665,7 @@ def _get_and_check_device_assignment(
     final_device_assignment = first_sharding_info[0]
   return xb.get_device_backend(final_device_assignment[0]), final_device_assignment
 
-MaybeSharding = Union[sharding_impls.XLACompatibleSharding, UnspecifiedValue]
+MaybeSharding = sharding_impls.XLACompatibleSharding | UnspecifiedValue
 
 
 def prune_unused_inputs(
@@ -1870,7 +1872,7 @@ def are_all_shardings_default_mem_kind(da_object, shardings):
       return False
   return True
 
-MaybeLayout = Sequence[Optional[Union[XLACompatibleLayout, LayoutRequest]]]
+MaybeLayout = Sequence[XLACompatibleLayout | LayoutRequest | None]
 
 
 class AllArgsInfo(NamedTuple):

--- a/jax/_src/interpreters/xla.py
+++ b/jax/_src/interpreters/xla.py
@@ -14,6 +14,8 @@
 
 # Lowering of jaxprs into XLA (HLO) computations.
 
+from __future__ import annotations
+
 from collections import defaultdict
 from collections.abc import Sequence
 import dataclasses
@@ -21,7 +23,7 @@ import functools
 from functools import partial
 import itertools as it
 import operator
-from typing import Any, Callable, Optional, Protocol, Union
+from typing import Any, Callable, Protocol
 
 import numpy as np
 
@@ -78,9 +80,8 @@ def parameter(builder, num, shape, name=None, replicated=None):
 # arbitrary tuple nesting, but JAX only uses one level of tupling (and our type
 # checkers don't support recursive types), so we only represent one level of
 # nesting in this type definition.
-SpatialSharding = Union[Shape,
-                        None,
-                        tuple[Optional[Shape], ...]]
+SpatialSharding = Shape | None | tuple[Shape | None, ...]
+
 
 def sharding_to_proto(sharding: SpatialSharding):
   """Converts a SpatialSharding to an OpSharding.
@@ -204,7 +205,7 @@ pytype_aval_mappings.update(
     (t, partial(_make_abstract_python_scalar, t)) for t in _scalar_types)
 
 
-def primitive_subcomputation(platform: str, axis_env: 'AxisEnv',
+def primitive_subcomputation(platform: str, axis_env: AxisEnv,
                              prim: core.Primitive,
                              avals_in: Sequence[core.AbstractValue],
                              avals_out: Sequence[core.AbstractValue],
@@ -237,9 +238,9 @@ class TranslationContext:
   builder: xc.XlaBuilder
   # TODO(phawkins): make platform non-optional. We should always be translating
   # with a specific platform in mind.
-  platform: Optional[str]
+  platform: str | None
   axis_env: AxisEnv
-  name_stack: Union[str, source_info_util.NameStack]
+  name_stack: str | source_info_util.NameStack
 
   def replace(self, **kw): return dataclasses.replace(self, **kw)
 
@@ -272,7 +273,7 @@ def register_initial_style_primitive(prim: core.Primitive):
   initial_style_primitives.add(prim)
 
 def register_translation(prim: core.Primitive, rule: TranslationRule, *,
-                         platform: Optional[str] = None) -> None:
+                         platform: str | None = None) -> None:
   if platform is None:
     _translations[prim] = rule
   else:

--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 """Module for the common control flow utilities."""
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import os
 from functools import partial
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from jax._src import core
 from jax._src import linear_util as lu
@@ -52,7 +54,7 @@ def _typecheck_param(prim, param, name, msg_required, pred):
 
 @weakref_lru_cache
 def _initial_style_open_jaxpr(fun: Callable, in_tree, in_avals,
-                              primitive_name: Optional[str] = None):
+                              primitive_name: str | None = None):
   wrapped_fun, out_tree = flatten_fun_nokwargs(lu.wrap_init(fun), in_tree)
   debug = pe.debug_info(fun, in_tree, out_tree, False,
                         primitive_name or "<unknown>")
@@ -61,7 +63,7 @@ def _initial_style_open_jaxpr(fun: Callable, in_tree, in_avals,
 
 @weakref_lru_cache
 def _initial_style_jaxpr(fun: Callable, in_tree, in_avals,
-                         primitive_name: Optional[str] = None):
+                         primitive_name: str | None = None):
   jaxpr, consts, out_tree = _initial_style_open_jaxpr(
       fun, in_tree, in_avals, primitive_name)
   closed_jaxpr = core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())

--- a/jax/_src/lax/control_flow/for_loop.py
+++ b/jax/_src/lax/control_flow/for_loop.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 """Module for the `for_loop` primitive."""
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import functools
 import operator
-from typing import Any, Callable, Generic, Optional, TypeVar, Union
+from typing import Any, Callable, Generic, TypeVar
 
 import jax.numpy as jnp
 from jax import lax
@@ -100,7 +102,7 @@ def _trace_to_jaxpr_with_refs(f, state_tree: PyTreeDef,
       f, state_avals)
   return jaxpr, consts, out_tree_thunk()
 
-def for_loop(nsteps: Union[int, Sequence[int]],
+def for_loop(nsteps: int | Sequence[int],
              body: Callable[[Array, Ref[S]], None], init_state: S,
              *, reverse: bool = False, unroll: int = 1) -> S:
   """A for-loop combinator that allows read/write semantics in the loop body.
@@ -176,7 +178,7 @@ Y = TypeVar('Y')
 def scan(f: Callable[[Carry, X], tuple[Carry, Y]],
          init: Carry,
          xs: X,
-         length: Optional[int] = None,
+         length: int | None = None,
          reverse: bool = False,
          unroll: int = 1) -> tuple[Carry, Y]:
   if not callable(f):
@@ -254,7 +256,7 @@ def _for_abstract_eval(*avals, jaxpr, **__):
 def _for_discharge_rule(in_avals, _, *args: Any, jaxpr: core.Jaxpr,
                         reverse: bool, which_linear: Sequence[bool],
                         nsteps: int, unroll: int
-                        ) -> tuple[Sequence[Optional[Any]], Sequence[Any]]:
+                        ) -> tuple[Sequence[Any | None], Sequence[Any]]:
   out_vals = for_p.bind(*args, jaxpr=jaxpr, reverse=reverse,
                         which_linear=which_linear, nsteps=nsteps,
                         unroll=unroll)

--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 from functools import partial
 import operator
-from typing import NamedTuple, Optional, Union
+from typing import NamedTuple
 
 import numpy as np
 
@@ -45,18 +47,21 @@ class ConvDimensionNumbers(NamedTuple):
   rhs_spec: Sequence[int]
   out_spec: Sequence[int]
 
-ConvGeneralDilatedDimensionNumbers = Union[
-  None, ConvDimensionNumbers, tuple[str, str, str]]
+ConvGeneralDilatedDimensionNumbers = (
+    tuple[str, str, str] |
+    ConvDimensionNumbers |
+    None
+)
 
 def conv_general_dilated(
   lhs: Array, rhs: Array, window_strides: Sequence[int],
-  padding: Union[str, Sequence[tuple[int, int]]],
-  lhs_dilation: Optional[Sequence[int]] = None,
-  rhs_dilation: Optional[Sequence[int]] = None,
+  padding: str | Sequence[tuple[int, int]],
+  lhs_dilation: Sequence[int] | None = None,
+  rhs_dilation: Sequence[int] | None = None,
   dimension_numbers: ConvGeneralDilatedDimensionNumbers  = None,
   feature_group_count: int = 1, batch_group_count: int = 1,
   precision: lax.PrecisionLike = None,
-  preferred_element_type: Optional[DTypeLike] = None) -> Array:
+  preferred_element_type: DTypeLike | None = None) -> Array:
   """General n-dimensional convolution operator, with optional dilation.
 
   Wraps XLA's `Conv
@@ -168,7 +173,7 @@ def conv_general_dilated(
 
 def conv(lhs: Array, rhs: Array, window_strides: Sequence[int],
          padding: str, precision: lax.PrecisionLike = None,
-         preferred_element_type: Optional[DTypeLike] = None) -> Array:
+         preferred_element_type: DTypeLike | None = None) -> Array:
   """Convenience wrapper around `conv_general_dilated`.
 
   Args:
@@ -194,11 +199,11 @@ def conv(lhs: Array, rhs: Array, window_strides: Sequence[int],
 
 def conv_with_general_padding(lhs: Array, rhs: Array,
                               window_strides: Sequence[int],
-                              padding: Union[str, Sequence[tuple[int, int]]],
-                              lhs_dilation: Optional[Sequence[int]],
-                              rhs_dilation: Optional[Sequence[int]],
+                              padding: str | Sequence[tuple[int, int]],
+                              lhs_dilation: Sequence[int] | None,
+                              rhs_dilation: Sequence[int] | None,
                               precision: lax.PrecisionLike = None,
-                              preferred_element_type: Optional[DTypeLike] = None) -> Array:
+                              preferred_element_type: DTypeLike | None = None) -> Array:
   """Convenience wrapper around `conv_general_dilated`.
 
   Args:
@@ -266,12 +271,12 @@ def _flip_axes(x, axes):
 
 
 def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
-                   padding: Union[str, Sequence[tuple[int, int]]],
-                   rhs_dilation: Optional[Sequence[int]] = None,
+                   padding: str | Sequence[tuple[int, int]],
+                   rhs_dilation: Sequence[int] | None = None,
                    dimension_numbers: ConvGeneralDilatedDimensionNumbers = None,
                    transpose_kernel: bool = False,
                    precision: lax.PrecisionLike = None,
-                   preferred_element_type: Optional[DTypeLike] = None) -> Array:
+                   preferred_element_type: DTypeLike | None = None) -> Array:
   """Convenience wrapper for calculating the N-d convolution "transpose".
 
   This function directly calculates a fractionally strided conv rather than
@@ -325,7 +330,7 @@ def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
   k_shape = np.take(rhs.shape, dn.rhs_spec)
   k_sdims = k_shape[2:]  # type: ignore[index]
   # Calculate correct output shape given padding and strides.
-  pads: Union[str, Sequence[tuple[int, int]]]
+  pads: str | Sequence[tuple[int, int]]
   if isinstance(padding, str) and padding in {'SAME', 'VALID'}:
     if rhs_dilation is None:
       rhs_dilation = (1,) * (rhs.ndim - 2)

--- a/jax/_src/lax/fft.py
+++ b/jax/_src/lax/fft.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 from functools import partial
 import math
-from typing import Union
 
 import numpy as np
 
@@ -51,7 +52,7 @@ def _str_to_fft_type(s: str) -> xla_client.FftType:
     raise ValueError(f"Unknown FFT type '{s}'")
 
 @partial(jit, static_argnums=(1, 2))
-def fft(x, fft_type: Union[xla_client.FftType, str], fft_lengths: Sequence[int]):
+def fft(x, fft_type: xla_client.FftType | str, fft_lengths: Sequence[int]):
   if isinstance(fft_type, str):
     typ = _str_to_fft_type(fft_type)
   elif isinstance(fft_type, xla_client.FftType):

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -22,8 +22,7 @@ from functools import partial
 import itertools
 import math
 import operator
-from typing import (Any, Callable, TypeVar, Union,
-                    cast as type_cast, overload)
+from typing import (Any, Callable, TypeVar, cast as type_cast, overload)
 import warnings
 
 import numpy as np
@@ -673,8 +672,13 @@ class Precision(xla_client.PrecisionConfig.Precision):  # type: ignore
 
 
 PrecisionType = Precision
-PrecisionLike = Union[None, str, PrecisionType, tuple[str, str],
-                      tuple[PrecisionType, PrecisionType]]
+PrecisionLike = (
+    str |
+    PrecisionType |
+    tuple[str, str] |
+    tuple[PrecisionType, PrecisionType] |
+    None
+)
 
 def dot(lhs: Array, rhs: Array, precision: PrecisionLike = None,
         preferred_element_type: DTypeLike | None = None) -> Array:

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import inspect
 import functools
 from functools import partial
 import math
-from typing import cast, Any, Callable, Literal, Optional, TypeVar, Union, overload
+from typing import cast, Any, Callable, Literal, TypeVar, overload
 import warnings
 
 import numpy as np
@@ -167,7 +169,7 @@ def eigh(
     lower: bool = True,
     symmetrize_input: bool = True,
     sort_eigenvalues: bool = True,
-    subset_by_index: Optional[tuple[int, int]] = None,
+    subset_by_index: tuple[int, int] | None = None,
 ) -> tuple[Array, Array]:
   r"""Eigendecomposition of a Hermitian matrix.
 
@@ -303,11 +305,11 @@ def svd(x: ArrayLike, *, full_matrices: bool = True, compute_uv: Literal[True]) 
 def svd(x: ArrayLike, *, full_matrices: bool = True, compute_uv: Literal[False]) -> Array: ...
 
 @overload
-def svd(x: ArrayLike, *, full_matrices: bool = True, compute_uv: bool = True) -> Union[Array, tuple[Array, Array, Array]]: ...
+def svd(x: ArrayLike, *, full_matrices: bool = True, compute_uv: bool = True) -> Array | tuple[Array, Array, Array]: ...
 
 # TODO: Add `max_qdwh_iterations` to the function signature for TPU SVD.
 @_warn_on_positional_kwargs
-def svd(x: ArrayLike, *, full_matrices: bool = True, compute_uv: bool = True) -> Union[Array, tuple[Array, Array, Array]]:
+def svd(x: ArrayLike, *, full_matrices: bool = True, compute_uv: bool = True) -> Array | tuple[Array, Array, Array]:
   """Singular value decomposition.
 
   Returns the singular values if compute_uv is False, otherwise returns a triple
@@ -2116,7 +2118,7 @@ def tridiagonal_solve(dl: Array, d: Array, du: Array, b: Array) -> Array:
 def schur(x: ArrayLike, *,
           compute_schur_vectors: bool = True,
           sort_eig_vals: bool = False,
-          select_callable: Optional[Callable[..., Any]] = None) -> tuple[Array, Array]:
+          select_callable: Callable[..., Any] | None = None) -> tuple[Array, Array]:
   return schur_p.bind(
       x,
       compute_schur_vectors=compute_schur_vectors,

--- a/jax/_src/lax/other.py
+++ b/jax/_src/lax/other.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import math
-from typing import Any, Optional, Union, cast as type_cast
+from typing import Any, cast as type_cast
 
 import jax
 from jax._src.numpy import lax_numpy as jnp
@@ -27,12 +29,12 @@ def conv_general_dilated_patches(
     lhs: jax.typing.ArrayLike,
     filter_shape: Sequence[int],
     window_strides: Sequence[int],
-    padding: Union[str, Sequence[tuple[int, int]]],
-    lhs_dilation: Optional[Sequence[int]] = None,
-    rhs_dilation: Optional[Sequence[int]] = None,
-    dimension_numbers: Optional[convolution.ConvGeneralDilatedDimensionNumbers] = None,
-    precision: Optional[lax.PrecisionType] = None,
-    preferred_element_type: Optional[DType] = None,
+    padding: str | Sequence[tuple[int, int]],
+    lhs_dilation: Sequence[int] | None = None,
+    rhs_dilation: Sequence[int] | None = None,
+    dimension_numbers: convolution.ConvGeneralDilatedDimensionNumbers | None = None,
+    precision: lax.PrecisionType | None = None,
+    preferred_element_type: DType | None = None,
 ) -> jax.Array:
   """Extract patches subject to the receptive field of `conv_general_dilated`.
 
@@ -123,11 +125,11 @@ def conv_general_dilated_local(
     lhs: jax.typing.ArrayLike,
     rhs: jax.typing.ArrayLike,
     window_strides: Sequence[int],
-    padding: Union[str, Sequence[tuple[int, int]]],
+    padding: str | Sequence[tuple[int, int]],
     filter_shape: Sequence[int],
-    lhs_dilation: Optional[Sequence[int]] = None,
-    rhs_dilation: Optional[Sequence[int]] = None,
-    dimension_numbers: Optional[convolution.ConvGeneralDilatedDimensionNumbers] = None,
+    lhs_dilation: Sequence[int] | None = None,
+    rhs_dilation: Sequence[int] | None = None,
+    dimension_numbers: convolution.ConvGeneralDilatedDimensionNumbers | None = None,
     precision: lax.PrecisionLike = None
 ) -> jax.Array:
   """General n-dimensional unshared convolution operator with optional dilation.
@@ -202,7 +204,7 @@ def conv_general_dilated_local(
 
   c_precision = lax.canonicalize_precision(precision)
   lhs_precision = type_cast(
-      Optional[lax.PrecisionType],
+      lax.PrecisionType | None,
       (c_precision[0]
        if (isinstance(c_precision, tuple) and len(c_precision) == 2)
        else c_precision))

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -15,12 +15,13 @@
 Parallelization primitives.
 """
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 from functools import partial
 import itertools
 import math
 import string
-from typing import Union
 
 import numpy as np
 
@@ -606,7 +607,7 @@ class XeinsumSpecParser:
     return arg_specs
 
 
-def pgather(src, idx, axes: Union[int, AxisName]):
+def pgather(src, idx, axes: int | AxisName):
   """Uses the last positional axis of idx to index into src's axes."""
   if not isinstance(axes, (tuple, list)):
     axes = (axes,)

--- a/jax/_src/lax/qdwh.py
+++ b/jax/_src/lax/qdwh.py
@@ -24,8 +24,9 @@ SIAM Journal on Matrix Analysis and Applications 31, no. 5 (2010): 2700-2720.
 https://epubs.siam.org/doi/abs/10.1137/090774999
 """
 
+from __future__ import annotations
+
 import functools
-from typing import Optional
 
 import jax
 import jax.numpy as jnp
@@ -196,7 +197,7 @@ def _qdwh(x, m, n, is_hermitian, max_iterations, eps):
 # TODO: Add pivoting.
 @functools.partial(jax.jit, static_argnames=('is_hermitian',))
 def qdwh(x, *, is_hermitian=False, max_iterations=None, eps=None,
-         dynamic_shape: Optional[tuple[int, int]] = None):
+         dynamic_shape: tuple[int, int] | None = None):
   """QR-based dynamically weighted Halley iteration for polar decomposition.
 
   Args:

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import enum
 import operator
 from functools import partial
 import math
-from typing import Callable, NamedTuple, Optional, Union
+from typing import Callable, NamedTuple
 import weakref
 
 import numpy as np
@@ -54,7 +56,7 @@ _dtype = partial(dtypes.dtype, canonicalize=True)
 
 def slice(operand: ArrayLike, start_indices: Sequence[int],
           limit_indices: Sequence[int],
-          strides: Optional[Sequence[int]] = None) -> Array:
+          strides: Sequence[int] | None = None) -> Array:
   """Wraps XLA's `Slice
   <https://www.tensorflow.org/xla/operation_semantics#slice>`_
   operator.
@@ -109,8 +111,8 @@ def slice(operand: ArrayLike, start_indices: Sequence[int],
 
 
 def dynamic_slice(
-    operand: Union[Array, np.ndarray],
-    start_indices: Union[Union[Array, np.ndarray], Sequence[ArrayLike]],
+    operand: Array | np.ndarray,
+    start_indices: Array | np.ndarray | Sequence[ArrayLike],
     slice_sizes: Shape,
 ) -> Array:
   """Wraps XLA's `DynamicSlice
@@ -166,8 +168,8 @@ def dynamic_slice(
                               slice_sizes=tuple(static_sizes))
 
 
-def dynamic_update_slice(operand: Union[Array, np.ndarray], update: ArrayLike,
-                         start_indices: Union[Array, Sequence[ArrayLike]]) -> Array:
+def dynamic_update_slice(operand: Array | np.ndarray, update: ArrayLike,
+                         start_indices: Array | Sequence[ArrayLike]) -> Array:
   """Wraps XLA's `DynamicUpdateSlice
   <https://www.tensorflow.org/xla/operation_semantics#dynamicupdateslice>`_
   operator.
@@ -268,7 +270,7 @@ class GatherScatterMode(enum.Enum):
   PROMISE_IN_BOUNDS = enum.auto()
 
   @staticmethod
-  def from_any(s: Optional[Union[str, 'GatherScatterMode']]):
+  def from_any(s: str | GatherScatterMode | None):
     if isinstance(s, GatherScatterMode):
       return s
     if s == "clip":
@@ -287,7 +289,7 @@ def gather(operand: ArrayLike, start_indices: ArrayLike,
            *,
            unique_indices: bool = False,
            indices_are_sorted: bool = False,
-           mode: Optional[Union[str, GatherScatterMode]] = None,
+           mode: str | GatherScatterMode | None = None,
            fill_value = None) -> Array:
   """Gather operator.
 
@@ -382,7 +384,7 @@ def scatter_add(
   operand: ArrayLike, scatter_indices: ArrayLike, updates: ArrayLike,
   dimension_numbers: ScatterDimensionNumbers, *,
   indices_are_sorted: bool = False, unique_indices: bool = False,
-  mode: Optional[Union[str, GatherScatterMode]] = None) -> Array:
+  mode: str | GatherScatterMode | None = None) -> Array:
   """Scatter-add operator.
 
   Wraps `XLA's Scatter operator
@@ -429,7 +431,7 @@ def scatter_mul(
   operand: ArrayLike, scatter_indices: ArrayLike, updates: ArrayLike,
   dimension_numbers: ScatterDimensionNumbers, *,
   indices_are_sorted: bool = False, unique_indices: bool = False,
-  mode: Optional[Union[str, GatherScatterMode]] = None) -> Array:
+  mode: str | GatherScatterMode | None = None) -> Array:
   """Scatter-multiply operator.
 
   Wraps `XLA's Scatter operator
@@ -476,7 +478,7 @@ def scatter_min(
   operand: ArrayLike, scatter_indices: ArrayLike, updates: ArrayLike,
   dimension_numbers: ScatterDimensionNumbers, *,
   indices_are_sorted: bool = False, unique_indices: bool = False,
-  mode: Optional[Union[str, GatherScatterMode]] = None) -> Array:
+  mode: str | GatherScatterMode | None = None) -> Array:
   """Scatter-min operator.
 
   Wraps `XLA's Scatter operator
@@ -523,7 +525,7 @@ def scatter_max(
   operand: ArrayLike, scatter_indices: ArrayLike, updates: ArrayLike,
   dimension_numbers: ScatterDimensionNumbers, *,
   indices_are_sorted: bool = False, unique_indices: bool = False,
-  mode: Optional[Union[str, GatherScatterMode]] = None) -> Array:
+  mode: str | GatherScatterMode | None = None) -> Array:
   """Scatter-max operator.
 
   Wraps `XLA's Scatter operator
@@ -575,7 +577,7 @@ def scatter_apply(
   dimension_numbers: ScatterDimensionNumbers, *,
   update_shape: Shape = (),
   indices_are_sorted: bool = False, unique_indices: bool = False,
-  mode: Optional[Union[str, GatherScatterMode]] = None) -> Array:
+  mode: str | GatherScatterMode | None = None) -> Array:
   """Scatter-apply operator.
 
   Wraps `XLA's Scatter operator
@@ -637,7 +639,7 @@ def scatter(
   operand: ArrayLike, scatter_indices: ArrayLike, updates: ArrayLike,
   dimension_numbers: ScatterDimensionNumbers, *,
   indices_are_sorted: bool = False, unique_indices: bool = False,
-  mode: Optional[Union[str, GatherScatterMode]] = None) -> Array:
+  mode: str | GatherScatterMode | None = None) -> Array:
   """Scatter-update operator.
 
   Wraps `XLA's Scatter operator
@@ -700,8 +702,8 @@ def index_take(src: Array, idxs: Array, axes: Sequence[int]) -> Array:
 
 ### convenience wrappers around traceables
 
-def slice_in_dim(operand: Union[Array, np.ndarray], start_index: Optional[int],
-                 limit_index: Optional[int],
+def slice_in_dim(operand: Array | np.ndarray, start_index: int | None,
+                 limit_index: int | None,
                  stride: int = 1, axis: int = 0) -> Array:
   """Convenience wrapper around :func:`lax.slice` applying to only one dimension.
 
@@ -775,7 +777,7 @@ def slice_in_dim(operand: Union[Array, np.ndarray], start_index: Optional[int],
   return slice(operand, start_indices, limit_indices, strides)
 
 
-def index_in_dim(operand: Union[Array, np.ndarray], index: int, axis: int = 0,
+def index_in_dim(operand: Array | np.ndarray, index: int, axis: int = 0,
                  keepdims: bool = True) -> Array:
   """Convenience wrapper around :func:`lax.slice` to perform int indexing.
 
@@ -835,7 +837,7 @@ def index_in_dim(operand: Union[Array, np.ndarray], index: int, axis: int = 0,
     return lax.squeeze(result, (axis,))
 
 
-def dynamic_slice_in_dim(operand: Union[Array, np.ndarray],
+def dynamic_slice_in_dim(operand: Array | np.ndarray,
                          start_index: ArrayLike,
                          slice_size: int, axis: int = 0) -> Array:
   """Convenience wrapper around :func:`lax.dynamic_slice` applied to one dimension.
@@ -893,8 +895,8 @@ def dynamic_slice_in_dim(operand: Union[Array, np.ndarray],
   return dynamic_slice(operand, start_indices, slice_sizes)
 
 
-def dynamic_index_in_dim(operand: Union[Array, np.ndarray],
-                         index: Union[int, Array],
+def dynamic_index_in_dim(operand: Array | np.ndarray,
+                         index: int | Array,
                          axis: int = 0, keepdims: bool = True) -> Array:
   """Convenience wrapper around dynamic_slice to perform int indexing.
 
@@ -945,7 +947,7 @@ def dynamic_index_in_dim(operand: Union[Array, np.ndarray],
     return lax.squeeze(result, (axis,))
 
 
-def dynamic_update_slice_in_dim(operand: Union[Array, np.ndarray],
+def dynamic_update_slice_in_dim(operand: Array | np.ndarray,
                                 update: ArrayLike,
                                 start_index: ArrayLike, axis: int) -> Array:
   """Convenience wrapper around :func:`dynamic_update_slice` to update
@@ -1007,7 +1009,7 @@ def dynamic_update_slice_in_dim(operand: Union[Array, np.ndarray],
   return dynamic_update_slice(operand, update, start_indices)
 
 
-def dynamic_update_index_in_dim(operand: Union[Array, np.ndarray],
+def dynamic_update_index_in_dim(operand: Array | np.ndarray,
                                 update: ArrayLike, index: ArrayLike,
                                 axis: int) -> Array:
   """Convenience wrapper around :func:`dynamic_update_slice` to update a slice
@@ -2566,8 +2568,8 @@ mlir.register_lowering(scatter_add_p, _scatter_add_lower_gpu, platform="gpu")
 
 
 def _dynamic_slice_indices(
-    operand: Union[Array, np.ndarray],
-    start_indices: Union[Union[Array, np.ndarray], Sequence[ArrayLike]]
+    operand: Array | np.ndarray,
+    start_indices: Array | np.ndarray | Sequence[ArrayLike]
   ) -> list[ArrayLike]:
   # Normalize the start_indices w.r.t. operand.shape
   if len(start_indices) != operand.ndim:

--- a/jax/_src/lax/svd.py
+++ b/jax/_src/lax/svd.py
@@ -33,9 +33,11 @@ SIAM Journal on Matrix Analysis and Applications 31, no. 5 (2010): 2700-2720.
 https://epubs.siam.org/doi/abs/10.1137/090774999
 """
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import functools
-from typing import Any, Union
+from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -46,7 +48,7 @@ from jax._src import core
 @functools.partial(jax.jit, static_argnums=(2, 3))
 def _constant_svd(
     a: Any, return_nan: bool, full_matrices: bool, compute_uv: bool = True
-) -> Union[Any, Sequence[Any]]:
+) -> Any | Sequence[Any]:
   """SVD on matrix of all zeros."""
   m, n = a.shape
   k = min(m, n)
@@ -91,7 +93,7 @@ def _constant_svd(
 @functools.partial(jax.jit, static_argnums=(1, 2, 3))
 def _svd_tall_and_square_input(
     a: Any, hermitian: bool, compute_uv: bool, max_iterations: int
-) -> Union[Any, Sequence[Any]]:
+) -> Any | Sequence[Any]:
   """Singular value decomposition for m x n matrix and m >= n.
 
   Args:
@@ -151,7 +153,7 @@ def _qdwh_svd(a: Any,
               full_matrices: bool,
               compute_uv: bool = True,
               hermitian: bool = False,
-              max_iterations: int = 10) -> Union[Any, Sequence[Any]]:
+              max_iterations: int = 10) -> Any | Sequence[Any]:
   """Singular value decomposition.
 
   Args:
@@ -217,7 +219,7 @@ def svd(a: Any,
         full_matrices: bool,
         compute_uv: bool = True,
         hermitian: bool = False,
-        max_iterations: int = 10) -> Union[Any, Sequence[Any]]:
+        max_iterations: int = 10) -> Any | Sequence[Any]:
   """Singular value decomposition.
 
   Args:

--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 from functools import partial
-from typing import Callable, Optional, Union
+from typing import Callable
 import warnings
 
 import numpy as np
@@ -44,9 +46,9 @@ zip = util.safe_zip
 
 def reduce_window(operand, init_value, computation: Callable,
                   window_dimensions: core.Shape, window_strides: Sequence[int],
-                  padding: Union[str, Sequence[tuple[int, int]]],
-                  base_dilation: Optional[Sequence[int]] = None,
-                  window_dilation: Optional[Sequence[int]] = None) -> Array:
+                  padding: str | Sequence[tuple[int, int]],
+                  base_dilation: Sequence[int] | None = None,
+                  window_dilation: Sequence[int] | None = None) -> Array:
   """Wraps XLA's `ReduceWindowWithGeneralPadding
   <https://www.tensorflow.org/xla/operation_semantics#reducewindow>`_
   operator.
@@ -94,7 +96,7 @@ def reduce_window(operand, init_value, computation: Callable,
     return tree_util.tree_unflatten(out_tree, out_flat)
 
 def _get_monoid_window_reducer(monoid_op: Callable,
-                               xs: Sequence[Array]) -> Optional[Callable]:
+                               xs: Sequence[Array]) -> Callable | None:
   if len(xs) != 1:
     return None
   x, = xs
@@ -113,8 +115,8 @@ def _get_monoid_window_reducer(monoid_op: Callable,
 def _reduce_window_sum(operand: Array, window_dimensions: core.Shape,
                        window_strides: Sequence[int],
                        padding: Sequence[tuple[int, int]],
-                       base_dilation: Optional[Sequence[int]] = None,
-                       window_dilation: Optional[Sequence[int]] = None) -> Array:
+                       base_dilation: Sequence[int] | None = None,
+                       window_dilation: Sequence[int] | None = None) -> Array:
   if base_dilation is None:
     base_dilation = (1,) * len(window_dimensions)
   if window_dilation is None:
@@ -128,8 +130,8 @@ def _reduce_window_sum(operand: Array, window_dimensions: core.Shape,
 def _reduce_window_prod(operand: Array, window_dimensions: core.Shape,
                         window_strides: Sequence[int],
                         padding: Sequence[tuple[int, int]],
-                        base_dilation: Optional[Sequence[int]] = None,
-                        window_dilation: Optional[Sequence[int]] = None) -> Array:
+                        base_dilation: Sequence[int] | None = None,
+                        window_dilation: Sequence[int] | None = None) -> Array:
   init_value = lax._const(operand, 1)
   jaxpr, consts = lax._reduction_jaxpr(lax.mul, lax._abstractify(init_value))
   if base_dilation is None:
@@ -147,8 +149,8 @@ def _reduce_window_prod(operand: Array, window_dimensions: core.Shape,
 def _reduce_window_max(operand: Array, window_dimensions: core.Shape,
                        window_strides: Sequence[int],
                        padding: Sequence[tuple[int, int]],
-                       base_dilation: Optional[Sequence[int]] = None,
-                       window_dilation: Optional[Sequence[int]] = None) -> Array:
+                       base_dilation: Sequence[int] | None = None,
+                       window_dilation: Sequence[int] | None = None) -> Array:
   if base_dilation is None:
     base_dilation = (1,) * len(window_dimensions)
   if window_dilation is None:
@@ -162,8 +164,8 @@ def _reduce_window_max(operand: Array, window_dimensions: core.Shape,
 def _reduce_window_min(operand: Array, window_dimensions: core.Shape,
                        window_strides: Sequence[int],
                        padding: Sequence[tuple[int, int]],
-                       base_dilation: Optional[Sequence[int]] = None,
-                       window_dilation: Optional[Sequence[int]] = None) -> Array:
+                       base_dilation: Sequence[int] | None = None,
+                       window_dilation: Sequence[int] | None = None) -> Array:
   if base_dilation is None:
     base_dilation = (1,) * len(window_dimensions)
   if window_dilation is None:
@@ -178,8 +180,8 @@ def _reduce_window_logaddexp(
     operand: Array, window_dimensions: core.Shape,
     window_strides: Sequence[int],
     padding: Sequence[tuple[int, int]],
-    base_dilation: Optional[Sequence[int]] = None,
-    window_dilation: Optional[Sequence[int]] = None) -> Array:
+    base_dilation: Sequence[int] | None = None,
+    window_dilation: Sequence[int] | None = None) -> Array:
   init_value = lax._const(operand, -np.inf)
   jaxpr, consts = lax._reduction_jaxpr(logaddexp, lax._abstractify(init_value))
   if base_dilation is None:

--- a/jax/_src/lib/__init__.py
+++ b/jax/_src/lib/__init__.py
@@ -15,11 +15,11 @@
 # This module is largely a wrapper around `jaxlib` that performs version
 # checking on import.
 
-import datetime
+from __future__ import annotations
+
 import gc
 import pathlib
 import re
-from typing import Optional
 
 try:
   import jaxlib as jaxlib
@@ -125,7 +125,7 @@ mlir_api_version = xla_client.mlir_api_version
 
 # TODO(rocm): check if we need the same for rocm.
 
-def _cuda_path() -> Optional[str]:
+def _cuda_path() -> str | None:
   _jaxlib_path = pathlib.Path(jaxlib.__file__).parent
   # If the pip package nvidia-cuda-nvcc-cu11 is installed, it should have
   # both of the things XLA looks for in the cuda path, namely bin/ptxas and

--- a/jax/_src/maps.py
+++ b/jax/_src/maps.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections import OrderedDict, abc
 from collections.abc import Iterable, Sequence, Mapping
 import contextlib
 from functools import wraps, partial, partialmethod, lru_cache
 import itertools as it
 import math
-from typing import (Callable, Optional, Any,
-                    NamedTuple, Union)
+from typing import Callable, Any, NamedTuple
 
 import numpy as np
 
@@ -205,7 +206,7 @@ def fresh_resource_name(tag=None):
 # pytree instance for it, so that it is treated as a leaf.
 class AxisNamePos(FrozenDict):
   user_repr: str
-  expected_rank: Optional[int] = None
+  expected_rank: int | None = None
 
   def __init__(self, *args, user_repr, **kwargs):
     super().__init__(*args, **kwargs)
@@ -269,8 +270,8 @@ def _prepare_axes(axes, arg_name):
   entries = map(partial(_parse_entry, arg_name), entries)
   return tree_unflatten(treedef, entries), entries, treedef
 
-Resource = Union[ResourceAxisName, SerialLoop]
-ResourceSet = Union[Resource, tuple[Resource, ...]]
+Resource = ResourceAxisName | SerialLoop
+ResourceSet = Resource | tuple[Resource, ...]
 
 # TODO: Some syntactic sugar to make the API more usable in a single-axis case?
 # TODO: Are the resource axes scoped lexically or dynamically? Dynamically for now!
@@ -278,10 +279,10 @@ def xmap(fun: Callable,
          in_axes,
          out_axes,
          *,
-         axis_sizes: Optional[Mapping[AxisName, int]] = None,
-         axis_resources: Optional[Mapping[AxisName, ResourceSet]] = None,
-         donate_argnums: Union[int, Sequence[int]] = (),
-         backend: Optional[str] = None) -> stages.Wrapped:
+         axis_sizes: Mapping[AxisName, int] | None = None,
+         axis_resources: Mapping[AxisName, ResourceSet] | None = None,
+         donate_argnums: int | Sequence[int] = (),
+         backend: str | None = None) -> stages.Wrapped:
   """Assign a positional signature to a program that uses named array axes.
 
   .. warning::
@@ -717,7 +718,7 @@ class EvaluationPlan(NamedTuple):
   physical_axis_resources: dict[AxisName, tuple[ResourceAxisName, ...]]
   loop_axis_resources: dict[AxisName, tuple[ResourceAxisName, ...]]
   axis_subst_dict: dict[AxisName, tuple[ResourceAxisName, ...]]
-  axis_vmap_size: dict[AxisName, Optional[int]]
+  axis_vmap_size: dict[AxisName, int | None]
 
   @property
   def axis_subst(self) -> core.AxisSubst:
@@ -743,7 +744,7 @@ class EvaluationPlan(NamedTuple):
     axis_resource_count = _get_axis_resource_count(
         axis_resources, resource_env)
     axis_subst_dict = dict(axis_resources)
-    axis_vmap_size: dict[AxisName, Optional[int]] = {}
+    axis_vmap_size: dict[AxisName, int | None] = {}
     for naxis, raxes in sorted(axis_resources.items(), key=lambda x: str(x[0])):
       num_resources = axis_resource_count[naxis]
       assert global_axis_sizes[naxis] % num_resources.nglobal == 0
@@ -1402,7 +1403,7 @@ def _xmap_lowering_rule_spmd(ctx, *global_in_nodes,
   # XXX: We modify mesh_in_axes and mesh_out_axes here
   def add_spmd_axes(
       flat_mesh_axes: Sequence[ArrayMapping],
-      flat_extra_axes: Optional[Sequence[Sequence[Sequence[MeshAxisName]]]]):
+      flat_extra_axes: Sequence[Sequence[Sequence[MeshAxisName]]] | None):
     if flat_extra_axes is None:
       return
     for axes, extra in zip(flat_mesh_axes, flat_extra_axes):
@@ -1562,7 +1563,7 @@ def _insert_aval_axes(aval, axes: AxisNamePos, local_axis_sizes):
 
 class ResourceCount(NamedTuple):
   nglobal: int
-  nlocal: Optional[int]
+  nlocal: int | None
   distributed: bool
 
   def to_local(self, global_size):
@@ -1673,7 +1674,7 @@ def _to_resource_axes(axes_specs: Sequence[AxisNamePos],
                for axes in axes_specs)
 
 
-def _merge_leading_axis(x, axis: Optional[int]):
+def _merge_leading_axis(x, axis: int | None):
   if axis is None:
     # We assume that the output does not vary along the leading axis
     return lax.index_in_dim(x, 0, axis=0, keepdims=False)
@@ -1684,7 +1685,7 @@ def _merge_leading_axis(x, axis: Optional[int]):
     return x_moved.reshape(shape)
 
 
-def _slice_tile(x, dim: Optional[int], i, n: int):
+def _slice_tile(x, dim: int | None, i, n: int):
   """Selects an `i`th (out of `n`) tiles of `x` along `dim`."""
   if dim is None: return x
   (tile_size, rem) = divmod(x.shape[dim], n)

--- a/jax/_src/monitoring.py
+++ b/jax/_src/monitoring.py
@@ -20,19 +20,22 @@ during program execution, the registered listeners will be invoked.
 A typical listener callback is to send an event to a metrics collector for
 aggregation/exporting.
 """
-from typing import Protocol, Union
+
+from __future__ import annotations
+
+from typing import Protocol
 
 
 class EventListenerWithMetadata(Protocol):
 
-  def __call__(self, event: str, **kwargs: Union[str, int]) -> None:
+  def __call__(self, event: str, **kwargs: str | int) -> None:
     ...
 
 
 class EventDurationListenerWithMetadata(Protocol):
 
   def __call__(self, event: str, duration_secs: float,
-               **kwargs: Union[str, int]) -> None:
+               **kwargs: str | int) -> None:
     ...
 
 
@@ -40,7 +43,7 @@ _event_listeners: list[EventListenerWithMetadata] = []
 _event_duration_secs_listeners: list[EventDurationListenerWithMetadata] = []
 
 
-def record_event(event: str, **kwargs: Union[str, int]) -> None:
+def record_event(event: str, **kwargs: str | int) -> None:
   """Record an event.
 
   If **kwargs are specified, all of the named arguments have to be passed in the
@@ -51,7 +54,7 @@ def record_event(event: str, **kwargs: Union[str, int]) -> None:
 
 
 def record_event_duration_secs(event: str, duration: float,
-                               **kwargs: Union[str, int]) -> None:
+                               **kwargs: str | int) -> None:
   """Record an event duration in seconds (float).
 
   If **kwargs are specified, all of the named arguments have to be passed in the

--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -14,10 +14,12 @@
 
 """Shared neural network activations and other functions."""
 
+from __future__ import annotations
+
 from functools import partial
 import operator
 import numpy as np
-from typing import Any, Optional, Union
+from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -401,9 +403,9 @@ logsumexp = _logsumexp
 
 @partial(jax.jit, static_argnames=("axis",))
 def log_softmax(x: ArrayLike,
-                axis: Optional[Union[int, tuple[int, ...]]] = -1,
-                where: Optional[ArrayLike] = None,
-                initial: Optional[ArrayLike] = None) -> Array:
+                axis: int | tuple[int, ...] | None = -1,
+                where: ArrayLike | None = None,
+                initial: ArrayLike | None = None) -> Array:
   r"""Log-Softmax function.
 
   Computes the logarithm of the :code:`softmax` function, which rescales
@@ -442,9 +444,9 @@ def log_softmax(x: ArrayLike,
 # TODO(phawkins): this jit was found to change numerics in a test. Debug this.
 #@partial(jax.jit, static_argnames=("axis",))
 def softmax(x: ArrayLike,
-            axis: Optional[Union[int, tuple[int, ...]]] = -1,
-            where: Optional[ArrayLike] = None,
-            initial: Optional[ArrayLike] = None) -> Array:
+            axis: int | tuple[int, ...] | None = -1,
+            where: ArrayLike | None = None,
+            initial: ArrayLike | None = None) -> Array:
   r"""Softmax function.
 
   Computes the function which rescales elements to the range :math:`[0, 1]`
@@ -480,9 +482,9 @@ def softmax(x: ArrayLike,
 @partial(jax.custom_jvp, nondiff_argnums=(1,))
 def _softmax(
     x: ArrayLike,
-    axis: Optional[Union[int, tuple[int, ...]]] = -1,
-    where: Optional[ArrayLike] = None,
-    initial: Optional[ArrayLike] = None) -> Array:
+    axis: int | tuple[int, ...] | None = -1,
+    where: ArrayLike | None = None,
+    initial: ArrayLike | None = None) -> Array:
   x_max = jnp.max(x, axis, where=where, initial=initial, keepdims=True)
   unnormalized = jnp.exp(x - x_max)
   result = unnormalized / jnp.sum(unnormalized, axis, where=where, keepdims=True)
@@ -498,9 +500,9 @@ def _softmax_jvp(axis, primals, tangents):
 
 def _softmax_deprecated(
     x: ArrayLike,
-    axis: Optional[Union[int, tuple[int, ...]]] = -1,
-    where: Optional[ArrayLike] = None,
-    initial: Optional[ArrayLike] = None) -> Array:
+    axis: int | tuple[int, ...] | None = -1,
+    where: ArrayLike | None = None,
+    initial: ArrayLike | None = None) -> Array:
   x_max = jnp.max(x, axis, where=where, initial=initial, keepdims=True)
   unnormalized = jnp.exp(x - lax.stop_gradient(x_max))
   result = unnormalized / jnp.sum(unnormalized, axis, where=where, keepdims=True)
@@ -511,11 +513,11 @@ def _softmax_deprecated(
 
 @partial(jax.jit, static_argnames=("axis",))
 def standardize(x: ArrayLike,
-              axis: Optional[Union[int, tuple[int, ...]]] = -1,
-              mean: Optional[ArrayLike] = None,
-              variance: Optional[ArrayLike] = None,
+              axis: int | tuple[int, ...] | None = -1,
+              mean: ArrayLike | None = None,
+              variance: ArrayLike | None = None,
               epsilon: ArrayLike = 1e-5,
-              where: Optional[ArrayLike] = None) -> Array:
+              where: ArrayLike | None = None) -> Array:
   r"""Normalizes an array by subtracting ``mean`` and dividing by :math:`\sqrt{\mathrm{variance}}`."""
   numpy_util.check_arraylike("standardize", x)
   numpy_util.check_arraylike_or_none("standardize", mean, variance, where)
@@ -533,7 +535,7 @@ def standardize(x: ArrayLike,
 # TODO(slebedev): Change the type of `x` to `ArrayLike`.
 @partial(jax.jit, static_argnames=("num_classes", "dtype", "axis"))
 def _one_hot(x: Any, num_classes: int, *,
-             dtype: Any, axis: Union[int, AxisName]) -> Array:
+             dtype: Any, axis: int | AxisName) -> Array:
   num_classes = core.concrete_dim_or_error(
       num_classes,
       "The error arose in jax.nn.one_hot argument `num_classes`.")
@@ -557,7 +559,7 @@ def _one_hot(x: Any, num_classes: int, *,
 
 # TODO(slebedev): Change the type of `x` to `ArrayLike`.
 def one_hot(x: Any, num_classes: int, *,
-            dtype: Any = jnp.float_, axis: Union[int, AxisName] = -1) -> Array:
+            dtype: Any = jnp.float_, axis: int | AxisName = -1) -> Array:
   """One-hot encodes the given indices.
 
   Each index in the input ``x`` is encoded as a vector of zeros of length

--- a/jax/_src/nn/initializers.py
+++ b/jax/_src/nn/initializers.py
@@ -17,9 +17,11 @@ Common neural network layer initializers, consistent with definitions
 used in Keras and Sonnet.
 """
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import math
-from typing import Any, Literal, Protocol, Union
+from typing import Any, Literal, Protocol
 
 import numpy as np
 
@@ -194,9 +196,9 @@ def truncated_normal(stddev: RealNumeric = 1e-2,
 
 @export
 def _compute_fans(shape: core.NamedShape,
-                  in_axis: Union[int, Sequence[int]] = -2,
-                  out_axis: Union[int, Sequence[int]] = -1,
-                  batch_axis: Union[int, Sequence[int]] = ()
+                  in_axis: int | Sequence[int] = -2,
+                  out_axis: int | Sequence[int] = -1,
+                  batch_axis: int | Sequence[int] = ()
                   ) -> tuple[Array, Array]:
   """
   Compute effective input and output sizes for a linear or convolutional layer.
@@ -226,7 +228,7 @@ def _compute_fans(shape: core.NamedShape,
   return fan_in, fan_out
 
 def _complex_uniform(key: KeyArray,
-                     shape: Union[Sequence[int], core.NamedShape],
+                     shape: Sequence[int] | core.NamedShape,
                      dtype: DTypeLikeInexact) -> Array:
   """
   Sample uniform random values within a disk on the complex plane,
@@ -240,7 +242,7 @@ def _complex_uniform(key: KeyArray,
   return r * jnp.exp(1j * theta)
 
 def _complex_truncated_normal(key: KeyArray, upper: ArrayLike,
-                              shape: Union[Sequence[int], core.NamedShape],
+                              shape: Sequence[int] | core.NamedShape,
                               dtype: DTypeLikeInexact) -> Array:
   """
   Sample random values from a centered normal distribution on the complex plane,
@@ -259,11 +261,11 @@ def _complex_truncated_normal(key: KeyArray, upper: ArrayLike,
 @export
 def variance_scaling(
   scale: RealNumeric,
-  mode: Union[Literal["fan_in"], Literal["fan_out"], Literal["fan_avg"]],
-  distribution: Union[Literal["truncated_normal"], Literal["normal"],
-                      Literal["uniform"]],
-  in_axis: Union[int, Sequence[int]] = -2,
-  out_axis: Union[int, Sequence[int]] = -1,
+  mode: Literal["fan_in"] | Literal["fan_out"] | Literal["fan_avg"],
+  distribution: (Literal["truncated_normal"] | Literal["normal"] |
+                      Literal["uniform"]),
+  in_axis: int | Sequence[int] = -2,
+  out_axis: int | Sequence[int] = -1,
   batch_axis: Sequence[int] = (),
   dtype: DTypeLikeInexact = jnp.float_
 ) -> Initializer:
@@ -345,8 +347,8 @@ def variance_scaling(
   return init
 
 @export
-def glorot_uniform(in_axis: Union[int, Sequence[int]] = -2,
-                   out_axis: Union[int, Sequence[int]] = -1,
+def glorot_uniform(in_axis: int | Sequence[int] = -2,
+                   out_axis: int | Sequence[int] = -1,
                    batch_axis: Sequence[int] = (),
                    dtype: DTypeLikeInexact = jnp.float_) -> Initializer:
   """Builds a Glorot uniform initializer (aka Xavier uniform initializer).
@@ -383,8 +385,8 @@ def glorot_uniform(in_axis: Union[int, Sequence[int]] = -2,
 xavier_uniform = glorot_uniform
 
 @export
-def glorot_normal(in_axis: Union[int, Sequence[int]] = -2,
-                  out_axis: Union[int, Sequence[int]] = -1,
+def glorot_normal(in_axis: int | Sequence[int] = -2,
+                  out_axis: int | Sequence[int] = -1,
                   batch_axis: Sequence[int] = (),
                   dtype: DTypeLikeInexact = jnp.float_) -> Initializer:
   """Builds a Glorot normal initializer (aka Xavier normal initializer).
@@ -421,8 +423,8 @@ def glorot_normal(in_axis: Union[int, Sequence[int]] = -2,
 xavier_normal = glorot_normal
 
 @export
-def lecun_uniform(in_axis: Union[int, Sequence[int]] = -2,
-                  out_axis: Union[int, Sequence[int]] = -1,
+def lecun_uniform(in_axis: int | Sequence[int] = -2,
+                  out_axis: int | Sequence[int] = -1,
                   batch_axis: Sequence[int] = (),
                   dtype: DTypeLikeInexact = jnp.float_) -> Initializer:
   """Builds a Lecun uniform initializer.
@@ -457,8 +459,8 @@ def lecun_uniform(in_axis: Union[int, Sequence[int]] = -2,
                           out_axis=out_axis, batch_axis=batch_axis, dtype=dtype)
 
 @export
-def lecun_normal(in_axis: Union[int, Sequence[int]] = -2,
-                 out_axis: Union[int, Sequence[int]] = -1,
+def lecun_normal(in_axis: int | Sequence[int] = -2,
+                 out_axis: int | Sequence[int] = -1,
                  batch_axis: Sequence[int] = (),
                  dtype: DTypeLikeInexact = jnp.float_) -> Initializer:
   """Builds a Lecun normal initializer.
@@ -493,8 +495,8 @@ def lecun_normal(in_axis: Union[int, Sequence[int]] = -2,
                           out_axis=out_axis, batch_axis=batch_axis, dtype=dtype)
 
 @export
-def he_uniform(in_axis: Union[int, Sequence[int]] = -2,
-               out_axis: Union[int, Sequence[int]] = -1,
+def he_uniform(in_axis: int | Sequence[int] = -2,
+               out_axis: int | Sequence[int] = -1,
                batch_axis: Sequence[int] = (),
                dtype: DTypeLikeInexact = jnp.float_) -> Initializer:
   """Builds a He uniform initializer (aka Kaiming uniform initializer).
@@ -531,8 +533,8 @@ def he_uniform(in_axis: Union[int, Sequence[int]] = -2,
 kaiming_uniform = he_uniform
 
 @export
-def he_normal(in_axis: Union[int, Sequence[int]] = -2,
-              out_axis: Union[int, Sequence[int]] = -1,
+def he_normal(in_axis: int | Sequence[int] = -2,
+              out_axis: int | Sequence[int] = -1,
               batch_axis: Sequence[int] = (),
               dtype: DTypeLikeInexact = jnp.float_) -> Initializer:
   """Builds a He normal initializer (aka Kaiming normal initializer).

--- a/jax/_src/numpy/array_methods.py
+++ b/jax/_src/numpy/array_methods.py
@@ -19,12 +19,14 @@
 This is done dynamically in order to avoid circular imports.
 """
 
+from __future__ import annotations
+
 __all__ = ['register_jax_array_methods']
 
 import abc
 from functools import partial, wraps
 import math
-from typing import Any, Optional, Union
+from typing import Any
 
 import numpy as np
 import jax
@@ -89,7 +91,7 @@ def _itemsize(arr: ArrayLike) -> int:
 
 
 def _clip(number: ArrayLike,
-          min: Optional[ArrayLike] = None, max: Optional[ArrayLike] = None,
+          min: ArrayLike | None = None, max: ArrayLike | None = None,
           out: None = None) -> Array:
   """Return an array whose values are limited to a specified range.
 
@@ -111,7 +113,7 @@ def _transpose(a: Array, *args: Any) -> Array:
   return lax_numpy.transpose(a, axis)
 
 
-def _compute_newshape(a: ArrayLike, newshape: Union[DimSize, Shape]) -> Shape:
+def _compute_newshape(a: ArrayLike, newshape: DimSize | Shape) -> Shape:
   """Fixes a -1 value in newshape, if present."""
   orig_newshape = newshape  # for error messages
   try:
@@ -162,7 +164,7 @@ def _reshape(a: Array, *args: Any, order: str = "C") -> Array:
     raise ValueError(f"Unexpected value for 'order' argument: {order}.")
 
 
-def _view(arr: Array, dtype: Optional[DTypeLike] = None, type: None = None) -> Array:
+def _view(arr: Array, dtype: DTypeLike | None = None, type: None = None) -> Array:
   """Return a bitwise copy of the array, viewed as a new dtype.
 
   This is fuller-featured wrapper around :func:`jax.lax.bitcast_convert_type`.
@@ -282,7 +284,7 @@ def _unimplemented_setitem(self, i, x):
          "https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html")
   raise TypeError(msg.format(type(self)))
 
-def _operator_round(number: ArrayLike, ndigits: Optional[int] = None) -> Array:
+def _operator_round(number: ArrayLike, ndigits: int | None = None) -> Array:
   out = lax_numpy.round(number, decimals=ndigits or 0)
   # If `ndigits` is None, for a builtin float round(7.5) returns an integer.
   return out.astype(int) if ndigits is None else out
@@ -308,7 +310,7 @@ def __array_module__(self, types):
 
 
 def _compress_method(a: ArrayLike, condition: ArrayLike,
-                     axis: Optional[int] = None, out: None = None) -> Array:
+                     axis: int | None = None, out: None = None) -> Array:
   """Return selected slices of this array along given axis.
 
   Refer to :func:`jax.numpy.compress` for full documentation."""

--- a/jax/_src/numpy/fft.py
+++ b/jax/_src/numpy/fft.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import operator
-from typing import Optional, Union
 import numpy as np
 
 from jax import dtypes
@@ -40,8 +41,8 @@ def _fft_norm(s: Array, func_name: str, norm: str) -> Array:
 
 
 def _fft_core(func_name: str, fft_type: xla_client.FftType, a: ArrayLike,
-              s: Optional[Shape], axes: Optional[Sequence[int]],
-              norm: Optional[str]) -> Array:
+              s: Shape | None, axes: Sequence[int] | None,
+              norm: str | None) -> Array:
   full_name = "jax.numpy.fft." + func_name
   check_arraylike(full_name, a)
   arr = jnp.asarray(a)
@@ -105,34 +106,34 @@ def _fft_core(func_name: str, fft_type: xla_client.FftType, a: ArrayLike,
 
 
 @_wraps(np.fft.fftn)
-def fftn(a: ArrayLike, s: Optional[Shape] = None,
-         axes: Optional[Sequence[int]] = None,
-         norm: Optional[str] = None) -> Array:
+def fftn(a: ArrayLike, s: Shape | None = None,
+         axes: Sequence[int] | None = None,
+         norm: str | None = None) -> Array:
   return _fft_core('fftn', xla_client.FftType.FFT, a, s, axes, norm)
 
 
 @_wraps(np.fft.ifftn)
-def ifftn(a: ArrayLike, s: Optional[Shape] = None,
-          axes: Optional[Sequence[int]] = None,
-          norm: Optional[str] = None) -> Array:
+def ifftn(a: ArrayLike, s: Shape | None = None,
+          axes: Sequence[int] | None = None,
+          norm: str | None = None) -> Array:
   return _fft_core('ifftn', xla_client.FftType.IFFT, a, s, axes, norm)
 
 
 @_wraps(np.fft.rfftn)
-def rfftn(a: ArrayLike, s: Optional[Shape] = None,
-          axes: Optional[Sequence[int]] = None,
-          norm: Optional[str] = None) -> Array:
+def rfftn(a: ArrayLike, s: Shape | None = None,
+          axes: Sequence[int] | None = None,
+          norm: str | None = None) -> Array:
   return _fft_core('rfftn', xla_client.FftType.RFFT, a, s, axes, norm)
 
 
 @_wraps(np.fft.irfftn)
-def irfftn(a: ArrayLike, s: Optional[Shape] = None,
-           axes: Optional[Sequence[int]] = None,
-           norm: Optional[str] = None) -> Array:
+def irfftn(a: ArrayLike, s: Shape | None = None,
+           axes: Sequence[int] | None = None,
+           norm: str | None = None) -> Array:
   return _fft_core('irfftn', xla_client.FftType.IRFFT, a, s, axes, norm)
 
 
-def _axis_check_1d(func_name: str, axis: Optional[int]):
+def _axis_check_1d(func_name: str, axis: int | None):
   full_name = "jax.numpy.fft." + func_name
   if isinstance(axis, (list, tuple)):
     raise ValueError(
@@ -141,8 +142,8 @@ def _axis_check_1d(func_name: str, axis: Optional[int]):
     )
 
 def _fft_core_1d(func_name: str, fft_type: xla_client.FftType,
-                 a: ArrayLike, n: Optional[int], axis: Optional[int],
-                 norm: Optional[str]) -> Array:
+                 a: ArrayLike, n: int | None, axis: int | None,
+                 norm: str | None) -> Array:
   _axis_check_1d(func_name, axis)
   axes = None if axis is None else [axis]
   s = None if n is None else [n]
@@ -150,32 +151,32 @@ def _fft_core_1d(func_name: str, fft_type: xla_client.FftType,
 
 
 @_wraps(np.fft.fft)
-def fft(a: ArrayLike, n: Optional[int] = None,
-        axis: int = -1, norm: Optional[str] = None) -> Array:
+def fft(a: ArrayLike, n: int | None = None,
+        axis: int = -1, norm: str | None = None) -> Array:
   return _fft_core_1d('fft', xla_client.FftType.FFT, a, n=n, axis=axis,
                       norm=norm)
 
 @_wraps(np.fft.ifft)
-def ifft(a: ArrayLike, n: Optional[int] = None,
-         axis: int = -1, norm: Optional[str] = None) -> Array:
+def ifft(a: ArrayLike, n: int | None = None,
+         axis: int = -1, norm: str | None = None) -> Array:
   return _fft_core_1d('ifft', xla_client.FftType.IFFT, a, n=n, axis=axis,
                       norm=norm)
 
 @_wraps(np.fft.rfft)
-def rfft(a: ArrayLike, n: Optional[int] = None,
-         axis: int = -1, norm: Optional[str] = None) -> Array:
+def rfft(a: ArrayLike, n: int | None = None,
+         axis: int = -1, norm: str | None = None) -> Array:
   return _fft_core_1d('rfft', xla_client.FftType.RFFT, a, n=n, axis=axis,
                       norm=norm)
 
 @_wraps(np.fft.irfft)
-def irfft(a: ArrayLike, n: Optional[int] = None,
-          axis: int = -1, norm: Optional[str] = None) -> Array:
+def irfft(a: ArrayLike, n: int | None = None,
+          axis: int = -1, norm: str | None = None) -> Array:
   return _fft_core_1d('irfft', xla_client.FftType.IRFFT, a, n=n, axis=axis,
                       norm=norm)
 
 @_wraps(np.fft.hfft)
-def hfft(a: ArrayLike, n: Optional[int] = None,
-         axis: int = -1, norm: Optional[str] = None) -> Array:
+def hfft(a: ArrayLike, n: int | None = None,
+         axis: int = -1, norm: str | None = None) -> Array:
   conj_a = ufuncs.conj(a)
   _axis_check_1d('hfft', axis)
   nn = (conj_a.shape[axis] - 1) * 2 if n is None else n
@@ -183,8 +184,8 @@ def hfft(a: ArrayLike, n: Optional[int] = None,
                       norm=norm) * nn
 
 @_wraps(np.fft.ihfft)
-def ihfft(a: ArrayLike, n: Optional[int] = None,
-          axis: int = -1, norm: Optional[str] = None) -> Array:
+def ihfft(a: ArrayLike, n: int | None = None,
+          axis: int = -1, norm: str | None = None) -> Array:
   _axis_check_1d('ihfft', axis)
   arr = jnp.asarray(a)
   nn = arr.shape[axis] if n is None else n
@@ -194,8 +195,8 @@ def ihfft(a: ArrayLike, n: Optional[int] = None,
 
 
 def _fft_core_2d(func_name: str, fft_type: xla_client.FftType, a: ArrayLike,
-                 s: Optional[Shape], axes: Sequence[int],
-                 norm: Optional[str]) -> Array:
+                 s: Shape | None, axes: Sequence[int],
+                 norm: str | None) -> Array:
   full_name = "jax.numpy.fft." + func_name
   if len(axes) != 2:
     raise ValueError(
@@ -206,26 +207,26 @@ def _fft_core_2d(func_name: str, fft_type: xla_client.FftType, a: ArrayLike,
 
 
 @_wraps(np.fft.fft2)
-def fft2(a: ArrayLike, s: Optional[Shape] = None, axes: Sequence[int] = (-2,-1),
-         norm: Optional[str] = None) -> Array:
+def fft2(a: ArrayLike, s: Shape | None = None, axes: Sequence[int] = (-2,-1),
+         norm: str | None = None) -> Array:
   return _fft_core_2d('fft2', xla_client.FftType.FFT, a, s=s, axes=axes,
                       norm=norm)
 
 @_wraps(np.fft.ifft2)
-def ifft2(a: ArrayLike, s: Optional[Shape] = None, axes: Sequence[int] = (-2,-1),
-          norm: Optional[str] = None) -> Array:
+def ifft2(a: ArrayLike, s: Shape | None = None, axes: Sequence[int] = (-2,-1),
+          norm: str | None = None) -> Array:
   return _fft_core_2d('ifft2', xla_client.FftType.IFFT, a, s=s, axes=axes,
                       norm=norm)
 
 @_wraps(np.fft.rfft2)
-def rfft2(a: ArrayLike, s: Optional[Shape] = None, axes: Sequence[int] = (-2,-1),
-          norm: Optional[str] = None) -> Array:
+def rfft2(a: ArrayLike, s: Shape | None = None, axes: Sequence[int] = (-2,-1),
+          norm: str | None = None) -> Array:
   return _fft_core_2d('rfft2', xla_client.FftType.RFFT, a, s=s, axes=axes,
                       norm=norm)
 
 @_wraps(np.fft.irfft2)
-def irfft2(a: ArrayLike, s: Optional[Shape] = None, axes: Sequence[int] = (-2,-1),
-           norm: Optional[str] = None) -> Array:
+def irfft2(a: ArrayLike, s: Shape | None = None, axes: Sequence[int] = (-2,-1),
+           norm: str | None = None) -> Array:
   return _fft_core_2d('irfft2', xla_client.FftType.IRFFT, a, s=s, axes=axes,
                       norm=norm)
 
@@ -292,10 +293,10 @@ def rfftfreq(n: int, d: ArrayLike = 1.0, *, dtype=None) -> Array:
 
 
 @_wraps(np.fft.fftshift)
-def fftshift(x: ArrayLike, axes: Union[None, int, Sequence[int]] = None) -> Array:
+def fftshift(x: ArrayLike, axes: None | int | Sequence[int] = None) -> Array:
   check_arraylike("fftshift", x)
   x = jnp.asarray(x)
-  shift: Union[int, Sequence[int]]
+  shift: int | Sequence[int]
   if axes is None:
     axes = tuple(range(x.ndim))
     shift = [dim // 2 for dim in x.shape]
@@ -308,10 +309,10 @@ def fftshift(x: ArrayLike, axes: Union[None, int, Sequence[int]] = None) -> Arra
 
 
 @_wraps(np.fft.ifftshift)
-def ifftshift(x: ArrayLike, axes: Union[None, int, Sequence[int]] = None) -> Array:
+def ifftshift(x: ArrayLike, axes: None | int | Sequence[int] = None) -> Array:
   check_arraylike("ifftshift", x)
   x = jnp.asarray(x)
-  shift: Union[int, Sequence[int]]
+  shift: int | Sequence[int]
   if axes is None:
     axes = tuple(range(x.ndim))
     shift = [-(dim // 2) for dim in x.shape]

--- a/jax/_src/numpy/index_tricks.py
+++ b/jax/_src/numpy/index_tricks.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import abc
 from collections.abc import Iterable
-from typing import Any, Union
+from typing import Any
 
 import jax
 from jax._src import core
@@ -74,7 +76,7 @@ class _Mgrid:
             [0, 1, 2]]], dtype=int32)
   """
 
-  def __getitem__(self, key: Union[slice, tuple[slice, ...]]) -> Array:
+  def __getitem__(self, key: slice | tuple[slice, ...]) -> Array:
     if isinstance(key, slice):
       return _make_1d_grid_from_slice(key, op_name="mgrid")
     output: Iterable[Array] = (_make_1d_grid_from_slice(k, op_name="mgrid") for k in key)
@@ -118,8 +120,8 @@ class _Ogrid:
   """
 
   def __getitem__(
-      self, key: Union[slice, tuple[slice, ...]]
-  ) -> Union[Array, list[Array]]:
+      self, key: slice | tuple[slice, ...]
+  ) -> Array | list[Array]:
     if isinstance(key, slice):
       return _make_1d_grid_from_slice(key, op_name="ogrid")
     output: Iterable[Array] = (_make_1d_grid_from_slice(k, op_name="ogrid") for k in key)
@@ -131,7 +133,7 @@ class _Ogrid:
 ogrid = _Ogrid()
 
 
-_IndexType = Union[ArrayLike, str, slice]
+_IndexType = ArrayLike | str | slice
 
 
 class _AxisConcat(abc.ABC):
@@ -141,7 +143,7 @@ class _AxisConcat(abc.ABC):
   trans1d: int
   op_name: str
 
-  def __getitem__(self, key: Union[_IndexType, tuple[_IndexType, ...]]) -> Array:
+  def __getitem__(self, key: _IndexType | tuple[_IndexType, ...]) -> Array:
     key_tup: tuple[_IndexType, ...] = key if isinstance(key, tuple) else (key,)
 
     params = [self.axis, self.ndmin, self.trans1d, -1]

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -32,7 +32,7 @@ from functools import partial
 import math
 import operator
 import types
-from typing import (overload, Any, Callable, Literal, NamedTuple, Protocol, TypeVar, Union)
+from typing import (overload, Any, Callable, Literal, NamedTuple, Protocol, TypeVar, TypeAlias)
 from textwrap import dedent as _dedent
 import warnings
 
@@ -1465,7 +1465,7 @@ def unwrap(p: ArrayLike, discont: ArrayLike | None = None,
 
 ### Padding
 
-PadValueLike = Union[T, Sequence[T], Sequence[Sequence[T]]]
+PadValueLike: TypeAlias = T | Sequence[T] | Sequence[Sequence[T]]
 PadValue = tuple[tuple[T, T], ...]
 
 class PadStatFunc(Protocol):

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 from functools import partial
 
 import numpy as np
 import textwrap
 import operator
-from typing import Literal, Optional, Union, cast, overload
+from typing import Literal, cast, overload
 
 import jax
 from jax import jit, custom_jvp
@@ -61,12 +62,12 @@ def svd(a: ArrayLike, full_matrices: bool, compute_uv: Literal[False],
         hermitian: bool = False) -> Array: ...
 @overload
 def svd(a: ArrayLike, full_matrices: bool = True, compute_uv: bool = True,
-        hermitian: bool = False) -> Union[Array, tuple[Array, Array, Array]]: ...
+        hermitian: bool = False) -> Array | tuple[Array, Array, Array]: ...
 
 @_wraps(np.linalg.svd)
 @partial(jit, static_argnames=('full_matrices', 'compute_uv', 'hermitian'))
 def svd(a: ArrayLike, full_matrices: bool = True, compute_uv: bool = True,
-        hermitian: bool = False) -> Union[Array, tuple[Array, Array, Array]]:
+        hermitian: bool = False) -> Array | tuple[Array, Array, Array]:
   check_arraylike("jnp.linalg.svd", a)
   a, = promote_dtypes_inexact(jnp.asarray(a))
   if hermitian:
@@ -129,7 +130,7 @@ def matrix_power(a: ArrayLike, n: int) -> Array:
 
 @_wraps(np.linalg.matrix_rank)
 @jit
-def matrix_rank(M: ArrayLike, tol: Optional[ArrayLike] = None) -> Array:
+def matrix_rank(M: ArrayLike, tol: ArrayLike | None = None) -> Array:
   check_arraylike("jnp.linalg.matrix_rank", M)
   M, = promote_dtypes_inexact(jnp.asarray(M))
   if M.ndim < 2:
@@ -193,7 +194,7 @@ def _slogdet_qr(a: Array) -> tuple[Array, Array]:
         LU decomposition if ``None``.
     """))
 @partial(jit, static_argnames=('method',))
-def slogdet(a: ArrayLike, *, method: Optional[str] = None) -> tuple[Array, Array]:
+def slogdet(a: ArrayLike, *, method: str | None = None) -> tuple[Array, Array]:
   check_arraylike("jnp.linalg.slogdet", a)
   a, = promote_dtypes_inexact(jnp.asarray(a))
   a_shape = jnp.shape(a)
@@ -382,7 +383,7 @@ def eigvals(a: ArrayLike) -> Array:
 
 @_wraps(np.linalg.eigh)
 @partial(jit, static_argnames=('UPLO', 'symmetrize_input'))
-def eigh(a: ArrayLike, UPLO: Optional[str] = None,
+def eigh(a: ArrayLike, UPLO: str | None = None,
          symmetrize_input: bool = True) -> tuple[Array, Array]:
   check_arraylike("jnp.linalg.eigh", a)
   if UPLO is None or UPLO == "L":
@@ -400,7 +401,7 @@ def eigh(a: ArrayLike, UPLO: Optional[str] = None,
 
 @_wraps(np.linalg.eigvalsh)
 @partial(jit, static_argnames=('UPLO',))
-def eigvalsh(a: ArrayLike, UPLO: Optional[str] = 'L') -> Array:
+def eigvalsh(a: ArrayLike, UPLO: str | None = 'L') -> Array:
   check_arraylike("jnp.linalg.eigvalsh", a)
   w, _ = eigh(a, UPLO)
   return w
@@ -413,7 +414,7 @@ def eigvalsh(a: ArrayLike, UPLO: Optional[str] = 'L') -> Array:
     `10. * max(num_rows, num_cols) * jnp.finfo(dtype).eps`.
     """))
 @partial(jit, static_argnames=('hermitian',))
-def pinv(a: ArrayLike, rcond: Optional[ArrayLike] = None,
+def pinv(a: ArrayLike, rcond: ArrayLike | None = None,
          hermitian: bool = False) -> Array:
   # Uses same algorithm as
   # https://github.com/numpy/numpy/blob/v1.17.0/numpy/linalg/linalg.py#L1890-L1979
@@ -481,8 +482,8 @@ def inv(a: ArrayLike) -> Array:
 
 @_wraps(np.linalg.norm)
 @partial(jit, static_argnames=('ord', 'axis', 'keepdims'))
-def norm(x: ArrayLike, ord: Union[int, str, None] = None,
-         axis: Union[None, tuple[int, ...], int] = None,
+def norm(x: ArrayLike, ord: int | str | None = None,
+         axis: None | tuple[int, ...] | int = None,
          keepdims: bool = False) -> Array:
   check_arraylike("jnp.linalg.norm", x)
   x, = promote_dtypes_inexact(jnp.asarray(x))
@@ -579,11 +580,11 @@ def norm(x: ArrayLike, ord: Union[int, str, None] = None,
 @overload
 def qr(a: ArrayLike, mode: Literal["r"]) -> Array: ...
 @overload
-def qr(a: ArrayLike, mode: str = "reduced") -> Union[Array, tuple[Array, Array]]: ...
+def qr(a: ArrayLike, mode: str = "reduced") -> Array | tuple[Array, Array]: ...
 
 @_wraps(np.linalg.qr)
 @partial(jit, static_argnames=('mode',))
-def qr(a: ArrayLike, mode: str = "reduced") -> Union[Array, tuple[Array, Array]]:
+def qr(a: ArrayLike, mode: str = "reduced") -> Array | tuple[Array, Array]:
   check_arraylike("jnp.linalg.qr", a)
   a, = promote_dtypes_inexact(jnp.asarray(a))
   if mode == "raw":
@@ -611,7 +612,7 @@ def solve(a: ArrayLike, b: ArrayLike) -> Array:
   return lax_linalg._solve(a, b)
 
 
-def _lstsq(a: ArrayLike, b: ArrayLike, rcond: Optional[float], *,
+def _lstsq(a: ArrayLike, b: ArrayLike, rcond: float | None, *,
            numpy_resid: bool = False) -> tuple[Array, Array, Array, Array]:
   # TODO: add lstsq to lax_linalg and implement this function via those wrappers.
   # TODO: add custom jvp rule for more robust lstsq differentiation
@@ -671,7 +672,7 @@ _jit_lstsq = jit(partial(_lstsq, numpy_resid=False))
     The lstsq function does not currently have a custom JVP rule, so the gradient is
     poorly behaved for some inputs, particularly for low-rank `a`.
     """))
-def lstsq(a: ArrayLike, b: ArrayLike, rcond: Optional[float] = None, *,
+def lstsq(a: ArrayLike, b: ArrayLike, rcond: float | None = None, *,
           numpy_resid: bool = False) -> tuple[Array, Array, Array, Array]:
   check_arraylike("jnp.linalg.lstsq", a, b)
   if numpy_resid:

--- a/jax/_src/numpy/polynomial.py
+++ b/jax/_src/numpy/polynomial.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 from functools import partial
 import operator
-from typing import Optional, Union
 
 import numpy as np
 
@@ -108,9 +108,9 @@ Also, it works best on rcond <= 10e-3 values.
 """
 @_wraps(np.polyfit, lax_description=_POLYFIT_DOC)
 @partial(jit, static_argnames=('deg', 'rcond', 'full', 'cov'))
-def polyfit(x: Array, y: Array, deg: int, rcond: Optional[float] = None,
-            full: bool = False, w: Optional[Array] = None, cov: bool = False
-            ) -> Union[Array, tuple[Array, ...]]:
+def polyfit(x: Array, y: Array, deg: int, rcond: float | None = None,
+            full: bool = False, w: Array | None = None, cov: bool = False
+            ) -> Array | tuple[Array, ...]:
   check_arraylike("polyfit", x, y)
   deg = core.concrete_or_error(int, deg, "deg must be int")
   order = deg + 1
@@ -244,7 +244,7 @@ def polyadd(a1: Array, a2: Array) -> Array:
 
 @_wraps(np.polyint)
 @partial(jit, static_argnames=('m',))
-def polyint(p: Array, m: int = 1, k: Optional[int] = None) -> Array:
+def polyint(p: Array, m: int = 1, k: int | None = None) -> Array:
   m = core.concrete_or_error(operator.index, m, "'m' argument of jnp.polyint")
   k = 0 if k is None else k
   check_arraylike("polyint", p, k)

--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import builtins
 from collections.abc import Sequence
 from functools import partial
 import math
 import operator
-from typing import overload, Any, Callable, Literal, Optional, Protocol, Union
+from typing import overload, Any, Callable, Literal, Protocol
 import warnings
 
 import numpy as np
@@ -41,7 +43,7 @@ _all = builtins.all
 _lax_const = lax_internal._const
 
 
-Axis = Union[None, int, Sequence[int]]
+Axis = int | Sequence[int] | None
 
 def _isscalar(element: Any) -> bool:
   if hasattr(element, '__jax_array__'):
@@ -67,13 +69,13 @@ ReductionOp = Callable[[Any, Any], Any]
 
 def _reduction(a: ArrayLike, name: str, np_fun: Any, op: ReductionOp, init_val: ArrayLike,
                *, has_identity: bool = True,
-               preproc: Optional[Callable[[ArrayLike], ArrayLike]] = None,
-               bool_op: Optional[ReductionOp] = None,
+               preproc: Callable[[ArrayLike], ArrayLike] | None = None,
+               bool_op: ReductionOp | None = None,
                upcast_f16_for_computation: bool = False,
-               axis: Axis = None, dtype: Optional[DTypeLike] = None, out: None = None,
-               keepdims: bool = False, initial: Optional[ArrayLike] = None,
-               where_: Optional[ArrayLike] = None,
-               parallel_reduce: Optional[Callable[..., Array]] = None,
+               axis: Axis = None, dtype: DTypeLike | None = None, out: None = None,
+               keepdims: bool = False, initial: ArrayLike | None = None,
+               where_: ArrayLike | None = None,
+               parallel_reduce: Callable[..., Array] | None = None,
                promote_integers: bool = False) -> Array:
   bool_op = bool_op or op
   # Note: we must accept out=None as an argument, because numpy reductions delegate to
@@ -203,9 +205,9 @@ promote_integers : bool, default=True
 
 
 @partial(api.jit, static_argnames=('axis', 'dtype', 'keepdims', 'promote_integers'), inline=True)
-def _reduce_sum(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None,
+def _reduce_sum(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
                 out: None = None, keepdims: bool = False,
-                initial: Optional[ArrayLike] = None, where: Optional[ArrayLike] = None,
+                initial: ArrayLike | None = None, where: ArrayLike | None = None,
                 promote_integers: bool = True) -> Array:
   return _reduction(a, "sum", np.sum, lax.add, 0, preproc=_cast_to_numeric,
                     bool_op=lax.bitwise_or, upcast_f16_for_computation=True,
@@ -214,18 +216,18 @@ def _reduce_sum(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = No
                     promote_integers=promote_integers)
 
 @_wraps(np.sum, skip_params=['out'], extra_params=_PROMOTE_INTEGERS_DOC)
-def sum(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None,
-        out: None = None, keepdims: bool = False, initial: Optional[ArrayLike] = None,
-        where: Optional[ArrayLike] = None, promote_integers: bool = True) -> Array:
+def sum(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
+        out: None = None, keepdims: bool = False, initial: ArrayLike | None = None,
+        where: ArrayLike | None = None, promote_integers: bool = True) -> Array:
   return _reduce_sum(a, axis=_ensure_optional_axes(axis), dtype=dtype, out=out,
                      keepdims=keepdims, initial=initial, where=where,
                      promote_integers=promote_integers)
 
 
 @partial(api.jit, static_argnames=('axis', 'dtype', 'keepdims', 'promote_integers'), inline=True)
-def _reduce_prod(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None,
+def _reduce_prod(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
                  out: None = None, keepdims: bool = False,
-                 initial: Optional[ArrayLike] = None, where: Optional[ArrayLike] = None,
+                 initial: ArrayLike | None = None, where: ArrayLike | None = None,
                  promote_integers: bool = True) -> Array:
   return _reduction(a, "prod", np.prod, lax.mul, 1, preproc=_cast_to_numeric,
                     bool_op=lax.bitwise_and, upcast_f16_for_computation=True,
@@ -233,9 +235,9 @@ def _reduce_prod(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = N
                     initial=initial, where_=where, promote_integers=promote_integers)
 
 @_wraps(np.prod, skip_params=['out'], extra_params=_PROMOTE_INTEGERS_DOC)
-def prod(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None,
+def prod(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
          out: None = None, keepdims: bool = False,
-         initial: Optional[ArrayLike] = None, where: Optional[ArrayLike] = None,
+         initial: ArrayLike | None = None, where: ArrayLike | None = None,
          promote_integers: bool = True) -> Array:
   return _reduce_prod(a, axis=_ensure_optional_axes(axis), dtype=dtype,
                       out=out, keepdims=keepdims, initial=initial, where=where,
@@ -244,62 +246,62 @@ def prod(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None,
 
 @partial(api.jit, static_argnames=('axis', 'keepdims'), inline=True)
 def _reduce_max(a: ArrayLike, axis: Axis = None, out: None = None,
-                keepdims: bool = False, initial: Optional[ArrayLike] = None,
-                where: Optional[ArrayLike] = None) -> Array:
+                keepdims: bool = False, initial: ArrayLike | None = None,
+                where: ArrayLike | None = None) -> Array:
   return _reduction(a, "max", np.max, lax.max, -np.inf, has_identity=False,
                     axis=axis, out=out, keepdims=keepdims,
                     initial=initial, where_=where, parallel_reduce=lax.pmax)
 
 @_wraps(np.max, skip_params=['out'])
 def max(a: ArrayLike, axis: Axis = None, out: None = None,
-        keepdims: bool = False, initial: Optional[ArrayLike] = None,
-        where: Optional[ArrayLike] = None) -> Array:
+        keepdims: bool = False, initial: ArrayLike | None = None,
+        where: ArrayLike | None = None) -> Array:
   return _reduce_max(a, axis=_ensure_optional_axes(axis), out=out,
                      keepdims=keepdims, initial=initial, where=where)
 
 @partial(api.jit, static_argnames=('axis', 'keepdims'), inline=True)
 def _reduce_min(a: ArrayLike, axis: Axis = None, out: None = None,
-                keepdims: bool = False, initial: Optional[ArrayLike] = None,
-                where: Optional[ArrayLike] = None) -> Array:
+                keepdims: bool = False, initial: ArrayLike | None = None,
+                where: ArrayLike | None = None) -> Array:
   return _reduction(a, "min", np.min, lax.min, np.inf, has_identity=False,
                     axis=axis, out=out, keepdims=keepdims,
                     initial=initial, where_=where, parallel_reduce=lax.pmin)
 
 @_wraps(np.min, skip_params=['out'])
 def min(a: ArrayLike, axis: Axis = None, out: None = None,
-        keepdims: bool = False, initial: Optional[ArrayLike] = None,
-        where: Optional[ArrayLike] = None) -> Array:
+        keepdims: bool = False, initial: ArrayLike | None = None,
+        where: ArrayLike | None = None) -> Array:
   return _reduce_min(a, axis=_ensure_optional_axes(axis), out=out,
                      keepdims=keepdims, initial=initial, where=where)
 
 @partial(api.jit, static_argnames=('axis', 'keepdims'), inline=True)
 def _reduce_all(a: ArrayLike, axis: Axis = None, out: None = None,
-                keepdims: bool = False, *, where: Optional[ArrayLike] = None) -> Array:
+                keepdims: bool = False, *, where: ArrayLike | None = None) -> Array:
   return _reduction(a, "all", np.all, lax.bitwise_and, True, preproc=_cast_to_bool,
                     axis=axis, out=out, keepdims=keepdims, where_=where)
 
 @_wraps(np.all, skip_params=['out'])
 def all(a: ArrayLike, axis: Axis = None, out: None = None,
-        keepdims: bool = False, *, where: Optional[ArrayLike] = None) -> Array:
+        keepdims: bool = False, *, where: ArrayLike | None = None) -> Array:
   return _reduce_all(a, axis=_ensure_optional_axes(axis), out=out,
                      keepdims=keepdims, where=where)
 
 @partial(api.jit, static_argnames=('axis', 'keepdims'), inline=True)
 def _reduce_any(a: ArrayLike, axis: Axis = None, out: None = None,
-                keepdims: bool = False, *, where: Optional[ArrayLike] = None) -> Array:
+                keepdims: bool = False, *, where: ArrayLike | None = None) -> Array:
   return _reduction(a, "any", np.any, lax.bitwise_or, False, preproc=_cast_to_bool,
                     axis=axis, out=out, keepdims=keepdims, where_=where)
 
 @_wraps(np.any, skip_params=['out'])
 def any(a: ArrayLike, axis: Axis = None, out: None = None,
-        keepdims: bool = False, *, where: Optional[ArrayLike] = None) -> Array:
+        keepdims: bool = False, *, where: ArrayLike | None = None) -> Array:
   return _reduce_any(a, axis=_ensure_optional_axes(axis), out=out,
                      keepdims=keepdims, where=where)
 
 amin = min
 amax = max
 
-def _axis_size(a: ArrayLike, axis: Union[int, Sequence[int]]):
+def _axis_size(a: ArrayLike, axis: int | Sequence[int]):
   if not isinstance(axis, (tuple, list)):
     axis_seq: Sequence[int] = (axis,)  # type: ignore[assignment]
   else:
@@ -311,17 +313,17 @@ def _axis_size(a: ArrayLike, axis: Union[int, Sequence[int]]):
   return size
 
 @_wraps(np.mean, skip_params=['out'])
-def mean(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None,
+def mean(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
          out: None = None, keepdims: bool = False, *,
-         where: Optional[ArrayLike] = None) -> Array:
+         where: ArrayLike | None = None) -> Array:
   return _mean(a, _ensure_optional_axes(axis), dtype, out, keepdims,
                where=where)
 
 @partial(api.jit, static_argnames=('axis', 'dtype', 'keepdims'), inline=True)
-def _mean(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None,
+def _mean(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
           out: None = None, keepdims: bool = False, *,
           upcast_f16_for_computation: bool = True,
-          where: Optional[ArrayLike] = None) -> Array:
+          where: ArrayLike | None = None) -> Array:
   check_arraylike("mean", a)
   if out is not None:
     raise NotImplementedError("The 'out' argument to jnp.mean is not supported.")
@@ -351,22 +353,22 @@ def _mean(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None,
   ).astype(result_dtype)
 
 @overload
-def average(a: ArrayLike, axis: Axis = None, weights: Optional[ArrayLike] = None,
+def average(a: ArrayLike, axis: Axis = None, weights: ArrayLike | None = None,
             returned: Literal[False] = False, keepdims: bool = False) -> Array: ...
 @overload
-def average(a: ArrayLike, axis: Axis = None, weights: Optional[ArrayLike] = None, *,
+def average(a: ArrayLike, axis: Axis = None, weights: ArrayLike | None = None, *,
             returned: Literal[True], keepdims: bool = False) -> Array: ...
 @overload
-def average(a: ArrayLike, axis: Axis = None, weights: Optional[ArrayLike] = None,
-            returned: bool = False, keepdims: bool = False) -> Union[Array, tuple[Array, Array]]: ...
+def average(a: ArrayLike, axis: Axis = None, weights: ArrayLike | None = None,
+            returned: bool = False, keepdims: bool = False) -> Array | tuple[Array, Array]: ...
 @_wraps(np.average)
-def average(a: ArrayLike, axis: Axis = None, weights: Optional[ArrayLike] = None,
-            returned: bool = False, keepdims: bool = False) -> Union[Array, tuple[Array, Array]]:
+def average(a: ArrayLike, axis: Axis = None, weights: ArrayLike | None = None,
+            returned: bool = False, keepdims: bool = False) -> Array | tuple[Array, Array]:
   return _average(a, _ensure_optional_axes(axis), weights, returned, keepdims)
 
 @partial(api.jit, static_argnames=('axis', 'returned', 'keepdims'), inline=True)
-def _average(a: ArrayLike, axis: Axis = None, weights: Optional[ArrayLike] = None,
-             returned: bool = False, keepdims: bool = False) -> Union[Array, tuple[Array, Array]]:
+def _average(a: ArrayLike, axis: Axis = None, weights: ArrayLike | None = None,
+             returned: bool = False, keepdims: bool = False) -> Array | tuple[Array, Array]:
   if weights is None: # Treat all weights as 1
     check_arraylike("average", a)
     a, = promote_dtypes_inexact(a)
@@ -420,16 +422,16 @@ def _average(a: ArrayLike, axis: Axis = None, weights: Optional[ArrayLike] = Non
 
 
 @_wraps(np.var, skip_params=['out'])
-def var(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None,
+def var(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
         out: None = None, ddof: int = 0, keepdims: bool = False, *,
-        where: Optional[ArrayLike] = None) -> Array:
+        where: ArrayLike | None = None) -> Array:
   return _var(a, _ensure_optional_axes(axis), dtype, out, ddof, keepdims,
               where=where)
 
 @partial(api.jit, static_argnames=('axis', 'dtype', 'keepdims'))
-def _var(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None,
+def _var(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
          out: None = None, ddof: int = 0, keepdims: bool = False, *,
-         where: Optional[ArrayLike] = None) -> Array:
+         where: ArrayLike | None = None) -> Array:
   check_arraylike("var", a)
   dtypes.check_user_dtype_supported(dtype, "var")
   if out is not None:
@@ -459,7 +461,7 @@ def _var(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None,
   return lax.div(result, normalizer).astype(dtype)
 
 
-def _var_promote_types(a_dtype: DTypeLike, dtype: Optional[DTypeLike]) -> tuple[DType, DType]:
+def _var_promote_types(a_dtype: DTypeLike, dtype: DTypeLike | None) -> tuple[DType, DType]:
   if dtype:
     if (not dtypes.issubdtype(dtype, np.complexfloating) and
         dtypes.issubdtype(a_dtype, np.complexfloating)):
@@ -481,16 +483,16 @@ def _var_promote_types(a_dtype: DTypeLike, dtype: Optional[DTypeLike]) -> tuple[
 
 
 @_wraps(np.std, skip_params=['out'])
-def std(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None,
+def std(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
         out: None = None, ddof: int = 0, keepdims: bool = False, *,
-        where: Optional[ArrayLike] = None) -> Array:
+        where: ArrayLike | None = None) -> Array:
   return _std(a, _ensure_optional_axes(axis), dtype, out, ddof, keepdims,
               where=where)
 
 @partial(api.jit, static_argnames=('axis', 'dtype', 'keepdims'))
-def _std(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None,
+def _std(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
          out: None = None, ddof: int = 0, keepdims: bool = False, *,
-         where: Optional[ArrayLike] = None) -> Array:
+         where: ArrayLike | None = None) -> Array:
   check_arraylike("std", a)
   dtypes.check_user_dtype_supported(dtype, "std")
   if dtype is not None and not dtypes.issubdtype(dtype, np.inexact):
@@ -543,8 +545,8 @@ def _nan_reduction(a: ArrayLike, name: str, jnp_reduction: Callable[..., Array],
 @_wraps(np.nanmin, skip_params=['out'])
 @partial(api.jit, static_argnames=('axis', 'keepdims'))
 def nanmin(a: ArrayLike, axis: Axis = None, out: None = None,
-           keepdims: bool = False, initial: Optional[ArrayLike] = None,
-           where: Optional[ArrayLike] = None) -> Array:
+           keepdims: bool = False, initial: ArrayLike | None = None,
+           where: ArrayLike | None = None) -> Array:
   return _nan_reduction(a, 'nanmin', min, np.inf, nan_if_all_nan=initial is None,
                         axis=axis, out=out, keepdims=keepdims,
                         initial=initial, where=where)
@@ -552,17 +554,17 @@ def nanmin(a: ArrayLike, axis: Axis = None, out: None = None,
 @_wraps(np.nanmax, skip_params=['out'])
 @partial(api.jit, static_argnames=('axis', 'keepdims'))
 def nanmax(a: ArrayLike, axis: Axis = None, out: None = None,
-           keepdims: bool = False, initial: Optional[ArrayLike] = None,
-           where: Optional[ArrayLike] = None) -> Array:
+           keepdims: bool = False, initial: ArrayLike | None = None,
+           where: ArrayLike | None = None) -> Array:
   return _nan_reduction(a, 'nanmax', max, -np.inf, nan_if_all_nan=initial is None,
                         axis=axis, out=out, keepdims=keepdims,
                         initial=initial, where=where)
 
 @_wraps(np.nansum, skip_params=['out'])
 @partial(api.jit, static_argnames=('axis', 'dtype', 'keepdims'))
-def nansum(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None, out: None = None,
-           keepdims: bool = False, initial: Optional[ArrayLike] = None,
-           where: Optional[ArrayLike] = None) -> Array:
+def nansum(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None, out: None = None,
+           keepdims: bool = False, initial: ArrayLike | None = None,
+           where: ArrayLike | None = None) -> Array:
   dtypes.check_user_dtype_supported(dtype, "nanprod")
   return _nan_reduction(a, 'nansum', sum, 0, nan_if_all_nan=False,
                         axis=axis, dtype=dtype, out=out, keepdims=keepdims,
@@ -574,9 +576,9 @@ if nansum.__doc__ is not None:
 
 @_wraps(np.nanprod, skip_params=['out'])
 @partial(api.jit, static_argnames=('axis', 'dtype', 'keepdims'))
-def nanprod(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None, out: None = None,
-            keepdims: bool = False, initial: Optional[ArrayLike] = None,
-            where: Optional[ArrayLike] = None) -> Array:
+def nanprod(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None, out: None = None,
+            keepdims: bool = False, initial: ArrayLike | None = None,
+            where: ArrayLike | None = None) -> Array:
   dtypes.check_user_dtype_supported(dtype, "nanprod")
   return _nan_reduction(a, 'nanprod', prod, 1, nan_if_all_nan=False,
                         axis=axis, dtype=dtype, out=out, keepdims=keepdims,
@@ -584,8 +586,8 @@ def nanprod(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None, 
 
 @_wraps(np.nanmean, skip_params=['out'])
 @partial(api.jit, static_argnames=('axis', 'dtype', 'keepdims'))
-def nanmean(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None, out: None = None,
-            keepdims: bool = False, where: Optional[ArrayLike] = None) -> Array:
+def nanmean(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None, out: None = None,
+            keepdims: bool = False, where: ArrayLike | None = None) -> Array:
   check_arraylike("nanmean", a)
   if out is not None:
     raise NotImplementedError("The 'out' argument to jnp.nanmean is not supported.")
@@ -604,9 +606,9 @@ def nanmean(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None, 
 
 @_wraps(np.nanvar, skip_params=['out'])
 @partial(api.jit, static_argnames=('axis', 'dtype', 'keepdims'))
-def nanvar(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None, out: None = None,
+def nanvar(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None, out: None = None,
            ddof: int = 0, keepdims: bool = False,
-           where: Optional[ArrayLike] = None) -> Array:
+           where: ArrayLike | None = None) -> Array:
   check_arraylike("nanvar", a)
   dtypes.check_user_dtype_supported(dtype, "nanvar")
   if out is not None:
@@ -635,9 +637,9 @@ def nanvar(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None, o
 
 @_wraps(np.nanstd, skip_params=['out'])
 @partial(api.jit, static_argnames=('axis', 'dtype', 'keepdims'))
-def nanstd(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None, out: None = None,
+def nanstd(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None, out: None = None,
            ddof: int = 0, keepdims: bool = False,
-           where: Optional[ArrayLike] = None) -> Array:
+           where: ArrayLike | None = None) -> Array:
   check_arraylike("nanstd", a)
   dtypes.check_user_dtype_supported(dtype, "nanstd")
   if out is not None:
@@ -647,7 +649,7 @@ def nanstd(a: ArrayLike, axis: Axis = None, dtype: Optional[DTypeLike] = None, o
 
 class CumulativeReduction(Protocol):
   def __call__(self, a: ArrayLike, axis: Axis = None,
-               dtype: Optional[DTypeLike] = None, out: None = None) -> Array: ...
+               dtype: DTypeLike | None = None, out: None = None) -> Array: ...
 
 
 # TODO(jakevdp): should we change these semantics to match those of numpy?
@@ -661,12 +663,12 @@ def _make_cumulative_reduction(np_reduction: Any, reduction: Callable[..., Array
   @_wraps(np_reduction, skip_params=['out'],
           lax_description=CUML_REDUCTION_LAX_DESCRIPTION)
   def cumulative_reduction(a: ArrayLike, axis: Axis = None,
-                           dtype: Optional[DTypeLike] = None, out: None = None) -> Array:
+                           dtype: DTypeLike | None = None, out: None = None) -> Array:
     return _cumulative_reduction(a, _ensure_optional_axes(axis), dtype, out)
 
   @partial(api.jit, static_argnames=('axis', 'dtype'))
   def _cumulative_reduction(a: ArrayLike, axis: Axis = None,
-                            dtype: Optional[DTypeLike] = None, out: None = None) -> Array:
+                            dtype: DTypeLike | None = None, out: None = None) -> Array:
     check_arraylike(np_reduction.__name__, a)
     if out is not None:
       raise NotImplementedError(f"The 'out' argument to jnp.{np_reduction.__name__} "
@@ -706,7 +708,7 @@ nancumprod = _make_cumulative_reduction(np.nancumprod, lax.cumprod,
 @_wraps(np.quantile, skip_params=['out', 'overwrite_input'])
 @partial(api.jit, static_argnames=('axis', 'overwrite_input', 'interpolation',
                                'keepdims', 'method'))
-def quantile(a: ArrayLike, q: ArrayLike, axis: Optional[Union[int, tuple[int, ...]]] = None,
+def quantile(a: ArrayLike, q: ArrayLike, axis: int | tuple[int, ...] | None = None,
              out: None = None, overwrite_input: bool = False, method: str = "linear",
              keepdims: bool = False, interpolation: None = None) -> Array:
   check_arraylike("quantile", a, q)
@@ -722,7 +724,7 @@ def quantile(a: ArrayLike, q: ArrayLike, axis: Optional[Union[int, tuple[int, ..
 @_wraps(np.nanquantile, skip_params=['out', 'overwrite_input'])
 @partial(api.jit, static_argnames=('axis', 'overwrite_input', 'interpolation',
                                'keepdims', 'method'))
-def nanquantile(a: ArrayLike, q: ArrayLike, axis: Optional[Union[int, tuple[int, ...]]] = None,
+def nanquantile(a: ArrayLike, q: ArrayLike, axis: int | tuple[int, ...] | None = None,
                 out: None = None, overwrite_input: bool = False, method: str = "linear",
                 keepdims: bool = False, interpolation: None = None) -> Array:
   check_arraylike("nanquantile", a, q)
@@ -735,7 +737,7 @@ def nanquantile(a: ArrayLike, q: ArrayLike, axis: Optional[Union[int, tuple[int,
                   "Use 'method=' instead.", DeprecationWarning)
   return _quantile(lax_internal.asarray(a), lax_internal.asarray(q), axis, interpolation or method, keepdims, True)
 
-def _quantile(a: Array, q: Array, axis: Optional[Union[int, tuple[int, ...]]],
+def _quantile(a: Array, q: Array, axis: int | tuple[int, ...] | None,
               interpolation: str, keepdims: bool, squash_nans: bool) -> Array:
   if interpolation not in ["linear", "lower", "higher", "midpoint", "nearest"]:
     raise ValueError("interpolation can only be 'linear', 'lower', 'higher', "
@@ -860,7 +862,7 @@ def _quantile(a: Array, q: Array, axis: Optional[Union[int, tuple[int, ...]]],
 @partial(api.jit, static_argnames=('axis', 'overwrite_input', 'interpolation',
                                    'keepdims', 'method'))
 def percentile(a: ArrayLike, q: ArrayLike,
-               axis: Optional[Union[int, tuple[int, ...]]] = None,
+               axis: int | tuple[int, ...] | None = None,
                out: None = None, overwrite_input: bool = False, method: str = "linear",
                keepdims: bool = False, interpolation: None = None) -> Array:
   check_arraylike("percentile", a, q)
@@ -872,7 +874,7 @@ def percentile(a: ArrayLike, q: ArrayLike,
 @partial(api.jit, static_argnames=('axis', 'overwrite_input', 'interpolation',
                                'keepdims', 'method'))
 def nanpercentile(a: ArrayLike, q: ArrayLike,
-                  axis: Optional[Union[int, tuple[int, ...]]] = None,
+                  axis: int | tuple[int, ...] | None = None,
                   out: None = None, overwrite_input: bool = False, method: str = "linear",
                   keepdims: bool = False, interpolation: None = None) -> Array:
   check_arraylike("nanpercentile", a, q)
@@ -883,7 +885,7 @@ def nanpercentile(a: ArrayLike, q: ArrayLike,
 
 @_wraps(np.median, skip_params=['out', 'overwrite_input'])
 @partial(api.jit, static_argnames=('axis', 'overwrite_input', 'keepdims'))
-def median(a: ArrayLike, axis: Optional[Union[int, tuple[int, ...]]] = None,
+def median(a: ArrayLike, axis: int | tuple[int, ...] | None = None,
            out: None = None, overwrite_input: bool = False,
            keepdims: bool = False) -> Array:
   check_arraylike("median", a)
@@ -892,7 +894,7 @@ def median(a: ArrayLike, axis: Optional[Union[int, tuple[int, ...]]] = None,
 
 @_wraps(np.nanmedian, skip_params=['out', 'overwrite_input'])
 @partial(api.jit, static_argnames=('axis', 'overwrite_input', 'keepdims'))
-def nanmedian(a: ArrayLike, axis: Optional[Union[int, tuple[int, ...]]] = None,
+def nanmedian(a: ArrayLike, axis: int | tuple[int, ...] | None = None,
               out: None = None, overwrite_input: bool = False,
               keepdims: bool = False) -> Array:
   check_arraylike("nanmedian", a)

--- a/jax/_src/numpy/setops.py
+++ b/jax/_src/numpy/setops.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from functools import partial
 import math
 import operator
 from textwrap import dedent as _dedent
-from typing import Optional, Union, cast
+from typing import cast
 
 import numpy as np
 
@@ -79,7 +81,7 @@ def _in1d(ar1: ArrayLike, ar2: ArrayLike, invert: bool) -> Array:
         When ``size`` is specified and there are fewer than the indicated number of elements, the
         remaining elements will be filled with ``fill_value``, which defaults to zero."""))
 def setdiff1d(ar1: ArrayLike, ar2: ArrayLike, assume_unique: bool = False,
-              *, size: Optional[int] = None, fill_value: Optional[ArrayLike] = None) -> Array:
+              *, size: int | None = None, fill_value: ArrayLike | None = None) -> Array:
   check_arraylike("setdiff1d", ar1, ar2)
   if size is None:
     ar1 = core.concrete_or_error(None, ar1, "The error arose in setdiff1d()")
@@ -117,7 +119,7 @@ def setdiff1d(ar1: ArrayLike, ar2: ArrayLike, assume_unique: bool = False,
         remaining elements will be filled with ``fill_value``, which defaults to the minimum
         value of the union."""))
 def union1d(ar1: ArrayLike, ar2: ArrayLike,
-            *, size: Optional[int] = None, fill_value: Optional[ArrayLike] = None) -> Array:
+            *, size: int | None = None, fill_value: ArrayLike | None = None) -> Array:
   check_arraylike("union1d", ar1, ar2)
   if size is None:
     ar1 = core.concrete_or_error(None, ar1, "The error arose in union1d()")
@@ -175,7 +177,7 @@ def _intersect1d_sorted_mask(ar1: ArrayLike, ar2: ArrayLike, return_indices: boo
 
 @_wraps(np.intersect1d)
 def intersect1d(ar1: ArrayLike, ar2: ArrayLike, assume_unique: bool = False,
-                return_indices: bool = False) -> Union[Array, tuple[Array, Array, Array]]:
+                return_indices: bool = False) -> Array | tuple[Array, Array, Array]:
   check_arraylike("intersect1d", ar1, ar2)
   ar1 = core.concrete_or_error(None, ar1, "The error arose in intersect1d()")
   ar2 = core.concrete_or_error(None, ar2, "The error arose in intersect1d()")
@@ -253,9 +255,9 @@ def _unique_sorted_mask(ar: Array, axis: int) -> tuple[Array, Array, Array]:
   return aux, mask, perm
 
 def _unique(ar: Array, axis: int, return_index: bool = False, return_inverse: bool = False,
-            return_counts: bool = False, size: Optional[int] = None,
-            fill_value: Optional[ArrayLike] = None, return_true_size: bool = False
-            ) -> Union[Array, tuple[Array, ...]]:
+            return_counts: bool = False, size: int | None = None,
+            fill_value: ArrayLike | None = None, return_true_size: bool = False
+            ) -> Array | tuple[Array, ...]:
   """
   Find the unique elements of an array along a particular axis.
   """
@@ -325,8 +327,8 @@ def _unique(ar: Array, axis: int, return_index: bool = False, return_inverse: bo
         remaining elements will be filled with ``fill_value``. The default is the minimum value
         along the specified axis of the input."""))
 def unique(ar: ArrayLike, return_index: bool = False, return_inverse: bool = False,
-           return_counts: bool = False, axis: Optional[int] = None,
-           *, size: Optional[int] = None, fill_value: Optional[ArrayLike] = None):
+           return_counts: bool = False, axis: int | None = None,
+           *, size: int | None = None, fill_value: ArrayLike | None = None):
   check_arraylike("unique", ar)
   if size is None:
     ar = core.concrete_or_error(None, ar,

--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -16,10 +16,12 @@
 Implements ufuncs for jax.numpy.
 """
 
+from __future__ import annotations
+
 from functools import partial
 import operator
 from textwrap import dedent
-from typing import Any, Callable, Union, overload
+from typing import Any, Callable, overload
 
 import numpy as np
 
@@ -124,9 +126,9 @@ def _logical_op(np_op: Callable[..., Any], bitwise_op: UnOp) -> UnOp: ...
 @overload
 def _logical_op(np_op: Callable[..., Any], bitwise_op: BinOp) -> BinOp: ...
 @overload
-def _logical_op(np_op: Callable[..., Any], bitwise_op: Union[UnOp, BinOp]) -> Union[UnOp, BinOp]: ...
+def _logical_op(np_op: Callable[..., Any], bitwise_op: UnOp | BinOp) -> UnOp | BinOp: ...
 
-def _logical_op(np_op: Callable[..., Any], bitwise_op: Union[UnOp, BinOp]) -> Union[UnOp, BinOp]:
+def _logical_op(np_op: Callable[..., Any], bitwise_op: UnOp | BinOp) -> UnOp | BinOp:
   @_wraps(np_op, update_doc=False, module='numpy')
   @partial(jit, inline=True)
   def op(*args):

--- a/jax/_src/op_shardings.py
+++ b/jax/_src/op_shardings.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 """Sharding utilities"""
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import itertools
-from typing import Union
 
 import numpy as np
 
@@ -43,7 +44,7 @@ def get_num_ways_dim_sharded(
   return partitions, num_replicas
 
 
-def is_op_sharding_replicated(op: Union[xc.OpSharding, xc.HloSharding]) -> bool:
+def is_op_sharding_replicated(op: xc.OpSharding | xc.HloSharding) -> bool:
   if isinstance(op, xc.OpSharding):
     op = xc.HloSharding.from_proto(op)
   if op.num_devices() == 1:
@@ -51,8 +52,8 @@ def is_op_sharding_replicated(op: Union[xc.OpSharding, xc.HloSharding]) -> bool:
   return op.is_replicated()  # type: ignore
 
 
-def are_op_shardings_equal(op1: Union[xc.OpSharding, xc.HloSharding],
-                           op2: Union[xc.OpSharding, xc.HloSharding]) -> bool:
+def are_op_shardings_equal(op1: xc.OpSharding | xc.HloSharding,
+                           op2: xc.OpSharding | xc.HloSharding) -> bool:
   if id(op1) == id(op2):
     return True
   if is_op_sharding_replicated(op1) and is_op_sharding_replicated(op2):
@@ -62,7 +63,7 @@ def are_op_shardings_equal(op1: Union[xc.OpSharding, xc.HloSharding],
   return hc1 == hc2
 
 
-_Index = Union[int, slice, tuple[Union[int, slice], ...]]
+_Index = int | slice | tuple[int | slice, ...]
 
 
 def op_sharding_to_numpy_indices(

--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -14,9 +14,11 @@
 
 # Helpers for indexed updates.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import sys
-from typing import Callable, Optional, Union
+from typing import Callable
 import warnings
 
 import numpy as np
@@ -36,11 +38,11 @@ from jax._src.typing import Array, ArrayLike
 
 if sys.version_info >= (3, 10):
     from types import EllipsisType
-    SingleIndex = Union[None, int, slice, Sequence[int], Array, EllipsisType]
+    SingleIndex = int | slice | Sequence[int] | Array | EllipsisType | None
 else:
-    SingleIndex = Union[None, int, slice, Sequence[int], Array]
-Index = Union[SingleIndex, tuple[SingleIndex, ...]]
-Scalar = Union[complex, float, int, np.number]
+    SingleIndex = int | slice | Sequence[int] | Array | None
+Index = SingleIndex | tuple[SingleIndex, ...]
+Scalar = complex | float | int | np.number
 
 
 def _scatter_update(x, idx, y, scatter_op, indices_are_sorted,
@@ -158,12 +160,12 @@ def _segment_update(name: str,
                     data: ArrayLike,
                     segment_ids: ArrayLike,
                     scatter_op: Callable,
-                    num_segments: Optional[int] = None,
+                    num_segments: int | None = None,
                     indices_are_sorted: bool = False,
                     unique_indices: bool = False,
-                    bucket_size: Optional[int] = None,
-                    reducer: Optional[Callable] = None,
-                    mode: Optional[lax.GatherScatterMode] = None) -> Array:
+                    bucket_size: int | None = None,
+                    reducer: Callable | None = None,
+                    mode: lax.GatherScatterMode | None = None) -> Array:
   check_arraylike(name, data, segment_ids)
   mode = lax.GatherScatterMode.FILL_OR_DROP if mode is None else mode
   data = jnp.asarray(data)
@@ -198,11 +200,11 @@ def _segment_update(name: str,
 
 def segment_sum(data: ArrayLike,
                 segment_ids: ArrayLike,
-                num_segments: Optional[int] = None,
+                num_segments: int | None = None,
                 indices_are_sorted: bool = False,
                 unique_indices: bool = False,
-                bucket_size: Optional[int] = None,
-                mode: Optional[lax.GatherScatterMode] = None) -> Array:
+                bucket_size: int | None = None,
+                mode: lax.GatherScatterMode | None = None) -> Array:
   """Computes the sum within segments of an array.
 
   Similar to TensorFlow's `segment_sum
@@ -253,11 +255,11 @@ def segment_sum(data: ArrayLike,
 
 def segment_prod(data: ArrayLike,
                  segment_ids: ArrayLike,
-                 num_segments: Optional[int] = None,
+                 num_segments: int | None = None,
                  indices_are_sorted: bool = False,
                  unique_indices: bool = False,
-                 bucket_size: Optional[int] = None,
-                 mode: Optional[lax.GatherScatterMode] = None) -> Array:
+                 bucket_size: int | None = None,
+                 mode: lax.GatherScatterMode | None = None) -> Array:
   """Computes the product within segments of an array.
 
   Similar to TensorFlow's `segment_prod
@@ -309,11 +311,11 @@ def segment_prod(data: ArrayLike,
 
 def segment_max(data: ArrayLike,
                 segment_ids: ArrayLike,
-                num_segments: Optional[int] = None,
+                num_segments: int | None = None,
                 indices_are_sorted: bool = False,
                 unique_indices: bool = False,
-                bucket_size: Optional[int] = None,
-                mode: Optional[lax.GatherScatterMode] = None) -> Array:
+                bucket_size: int | None = None,
+                mode: lax.GatherScatterMode | None = None) -> Array:
   """Computes the maximum within segments of an array.
 
   Similar to TensorFlow's `segment_max
@@ -364,11 +366,11 @@ def segment_max(data: ArrayLike,
 
 def segment_min(data: ArrayLike,
                 segment_ids: ArrayLike,
-                num_segments: Optional[int] = None,
+                num_segments: int | None = None,
                 indices_are_sorted: bool = False,
                 unique_indices: bool = False,
-                bucket_size: Optional[int] = None,
-                mode: Optional[lax.GatherScatterMode] = None) -> Array:
+                bucket_size: int | None = None,
+                mode: lax.GatherScatterMode | None = None) -> Array:
   """Computes the minimum within segments of an array.
 
   Similar to TensorFlow's `segment_min

--- a/jax/_src/ops/special.py
+++ b/jax/_src/ops/special.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import overload, Literal, Optional, Union
+from __future__ import annotations
+
+from typing import overload, Literal
 
 import jax
 from jax import lax
@@ -27,19 +29,19 @@ import numpy as np
 # unnecessary scipy dependencies.
 
 @overload
-def logsumexp(a: ArrayLike, axis: Axis = None, b: Optional[ArrayLike] = None,
+def logsumexp(a: ArrayLike, axis: Axis = None, b: ArrayLike | None = None,
               keepdims: bool = False, return_sign: Literal[False] = False) -> Array: ...
 
 @overload
-def logsumexp(a: ArrayLike, axis: Axis = None, b: Optional[ArrayLike] = None,
+def logsumexp(a: ArrayLike, axis: Axis = None, b: ArrayLike | None = None,
               keepdims: bool = False, *, return_sign: Literal[True]) -> tuple[Array, Array]: ...
 
 @overload
-def logsumexp(a: ArrayLike, axis: Axis = None, b: Optional[ArrayLike] = None,
-              keepdims: bool = False, return_sign: bool = False) -> Union[Array, tuple[Array, Array]]: ...
+def logsumexp(a: ArrayLike, axis: Axis = None, b: ArrayLike | None = None,
+              keepdims: bool = False, return_sign: bool = False) -> Array | tuple[Array, Array]: ...
 
-def logsumexp(a: ArrayLike, axis: Axis = None, b: Optional[ArrayLike] = None,
-              keepdims: bool = False, return_sign: bool = False) -> Union[Array, tuple[Array, Array]]:
+def logsumexp(a: ArrayLike, axis: Axis = None, b: ArrayLike | None = None,
+              keepdims: bool = False, return_sign: bool = False) -> Array | tuple[Array, Array]:
   r"""Log-sum-exp reduction.
 
   Computes

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence, Iterable
 import dataclasses
 from functools import partial, lru_cache
@@ -19,7 +21,7 @@ import inspect
 import itertools as it
 import logging
 import weakref
-from typing import Callable, Union, cast, Optional, NamedTuple, Any
+from typing import Callable, cast, NamedTuple, Any
 import threading
 import warnings
 
@@ -76,10 +78,10 @@ zip, unsafe_zip = safe_zip, zip
 
 traceback_util.register_exclusion(__file__)
 
-PjitSharding = Union[GSPMDSharding, UnspecifiedValue, AUTO]
-PjitShardingMinusUnspecified = Union[GSPMDSharding, AUTO]
-MeshSharding = Union[NamedSharding, UnspecifiedValue, AUTO]
-MeshShardingMinusUnspecified = Union[NamedSharding, AUTO]
+PjitSharding = GSPMDSharding | UnspecifiedValue | AUTO
+PjitShardingMinusUnspecified = GSPMDSharding | AUTO
+MeshSharding = NamedSharding | UnspecifiedValue | AUTO
+MeshShardingMinusUnspecified = NamedSharding | AUTO
 
 logger = logging.getLogger(__name__)
 
@@ -384,12 +386,12 @@ class PjitInfo(NamedTuple):
   static_argnames: tuple[str, ...]
   donate_argnums: tuple[int, ...]
   donate_argnames: tuple[str, ...]
-  device: Optional[xc.Device]
-  backend: Optional[str]
+  device: xc.Device | None
+  backend: str | None
   keep_unused: bool
   inline: bool
   resource_env: Any
-  abstracted_axes: Optional[Any]
+  abstracted_axes: Any | None
   in_layouts: Any  # pytree[XlaCompatibleLayout] | None
   out_layouts: Any  # pytree[XlaCompatibleLayout] | None
 
@@ -554,7 +556,7 @@ def _extract_implicit_args(
   return [x for x, (_, e) in zip(args, in_type) if not e]  # type: ignore
 
 def _flat_axes_specs(abstracted_axes, *args, **kwargs
-                     ) -> Optional[list[pe.AbstractedAxesSpec]]:
+                     ) -> list[pe.AbstractedAxesSpec] | None:
   if abstracted_axes is None: return None
   if kwargs: raise NotImplementedError
   def ax_leaf(l):
@@ -569,15 +571,15 @@ def pjit(
     fun: Callable,
     in_shardings=UNSPECIFIED,
     out_shardings=UNSPECIFIED,
-    static_argnums: Union[int, Sequence[int], None] = None,
-    static_argnames: Union[str, Iterable[str], None] = None,
-    donate_argnums: Union[int, Sequence[int], None] = None,
-    donate_argnames: Union[str, Iterable[str], None] = None,
+    static_argnums: int | Sequence[int] | None = None,
+    static_argnames: str | Iterable[str] | None = None,
+    donate_argnums: int | Sequence[int] | None = None,
+    donate_argnames: str | Iterable[str] | None = None,
     keep_unused: bool = False,
-    device: Optional[xc.Device] = None,
-    backend: Optional[str] = None,
+    device: xc.Device | None = None,
+    backend: str | None = None,
     inline: bool = False,
-    abstracted_axes: Optional[Any] = None,
+    abstracted_axes: Any | None = None,
 ) -> stages.Wrapped:
   """Makes ``fun`` compiled and automatically partitioned across multiple devices.
 
@@ -996,7 +998,7 @@ def _pjit_jaxpr(fun, out_shardings_thunk, out_layouts_thunk, in_type, debug_info
 
 
 def pjit_check_aval_sharding(
-    shardings, flat_avals, names: Optional[tuple[str, ...]],
+    shardings, flat_avals, names: tuple[str, ...] | None,
     what_aval: str, allow_uneven_sharding: bool):
   new_names = [''] * len(shardings) if names is None else names
   for aval, s, name in zip(flat_avals, shardings, new_names):
@@ -1040,7 +1042,7 @@ pjit_p.multiple_results = True
 def _resolve_in_shardings(
     args, pjit_in_shardings: Sequence[PjitSharding],
     out_shardings: Sequence[PjitSharding],
-    pjit_mesh: Optional[pxla.Mesh]) -> Sequence[PjitSharding]:
+    pjit_mesh: pxla.Mesh | None) -> Sequence[PjitSharding]:
   # If True, means that device or backend is set by the user on pjit and it
   # has the same semantics as device_put i.e. doesn't matter which device the
   # arg is on, reshard it to the device mentioned. So don't do any of the
@@ -1248,7 +1250,7 @@ class SameDeviceAssignmentTuple:
   # device_assignment is Optional because shardings can contain `AUTO` and in
   # that case `mesh` is compulsory to be used. So in that case
   # `_pjit_lower_cached` cache, resource_env will check against the devices.
-  device_assignment: Optional[XLADeviceAssignment]
+  device_assignment: XLADeviceAssignment | None
 
   def __hash__(self):
     shardings_hash = tuple(
@@ -1298,8 +1300,8 @@ def _pjit_lower_cached(
     inline: bool,
     *,
     lowering_parameters: mlir.LoweringParameters,
-    in_layouts: Optional[pxla.MaybeLayout] = None,
-    out_layouts: Optional[pxla.MaybeLayout] = None):
+    in_layouts: pxla.MaybeLayout | None = None,
+    out_layouts: pxla.MaybeLayout | None = None):
   in_shardings: tuple[PjitShardingMinusUnspecified, ...] = cast(
       tuple[PjitShardingMinusUnspecified, ...], sdat_in_shardings.shardings)
   out_shardings: tuple[PjitSharding, ...] = sdat_out_shardings.shardings
@@ -1499,7 +1501,7 @@ batching.axis_primitive_batchers[pjit_p] = partial(_pjit_batcher, False, None)
 pxla.spmd_primitive_batchers[pjit_p] = partial(_pjit_batcher, True, None)
 
 def _pjit_batcher_for_sharding(
-    s: Union[GSPMDSharding, UnspecifiedValue],
+    s: GSPMDSharding | UnspecifiedValue,
     dim: int, val: tuple[str, ...], mesh, ndim: int):
   if is_unspecified(s):
     return s
@@ -1569,7 +1571,7 @@ ad.primitive_jvps[pjit_p] = _pjit_jvp
 
 @weakref_lru_cache
 def _known_jaxpr_fwd(known_jaxpr: core.ClosedJaxpr,
-                     in_fwd: tuple[Optional[int]]) -> core.ClosedJaxpr:
+                     in_fwd: tuple[int | None]) -> core.ClosedJaxpr:
   updated_jaxpr = known_jaxpr.jaxpr.replace(
       outvars=[x for x, i in zip(known_jaxpr.jaxpr.outvars, in_fwd)
                if i is None])
@@ -1761,7 +1763,7 @@ def _dce_jaxpr_pjit(
 
 
 def dce_jaxpr_pjit_rule(used_outputs: list[bool], eqn: core.JaxprEqn
-                        ) -> tuple[list[bool], Optional[core.JaxprEqn]]:
+                        ) -> tuple[list[bool], core.JaxprEqn | None]:
   dced_jaxpr, used_inputs = _dce_jaxpr_pjit(
       eqn.params['jaxpr'], tuple(used_outputs))
 
@@ -2042,7 +2044,7 @@ def get_unconstrained_dims(sharding: NamedSharding):
 
 
 def _fast_path_get_device_assignment(
-    shardings: Iterable[PjitSharding]) -> Optional[XLADeviceAssignment]:
+    shardings: Iterable[PjitSharding]) -> XLADeviceAssignment | None:
   da = None
   for i in shardings:
     if is_unspecified(i):

--- a/jax/_src/profiler.py
+++ b/jax/_src/profiler.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from contextlib import contextmanager
 from functools import wraps
 import glob
@@ -23,7 +25,7 @@ import os
 import socketserver
 import threading
 
-from typing import Callable, Optional
+from typing import Callable
 
 from jax._src import traceback_util
 traceback_util.register_exclusion(__file__)
@@ -31,7 +33,7 @@ traceback_util.register_exclusion(__file__)
 from jax._src import xla_bridge
 from jax._src.lib import xla_client
 
-_profiler_server: Optional[xla_client.profiler.ProfilerServer] = None
+_profiler_server: xla_client.profiler.ProfilerServer | None = None
 
 logger = logging.getLogger(__name__)
 
@@ -300,7 +302,7 @@ class StepTraceAnnotation(TraceAnnotation):
     super().__init__(name, _r=1, **kwargs)
 
 
-def annotate_function(func: Callable, name: Optional[str] = None,
+def annotate_function(func: Callable, name: str | None = None,
                       **decorator_kwargs):
   """Decorator that generates a trace event for the execution of a function.
 
@@ -336,7 +338,7 @@ def annotate_function(func: Callable, name: Optional[str] = None,
   return wrapper
 
 
-def device_memory_profile(backend: Optional[str] = None) -> bytes:
+def device_memory_profile(backend: str | None = None) -> bytes:
   """Captures a JAX device memory profile as ``pprof``-format protocol buffer.
 
   A device memory profile is a snapshot of the state of memory, that describes the JAX
@@ -364,7 +366,7 @@ def device_memory_profile(backend: Optional[str] = None) -> bytes:
   return xla_client.heap_profile(xla_bridge.get_backend(backend))
 
 
-def save_device_memory_profile(filename, backend: Optional[str] = None) -> None:
+def save_device_memory_profile(filename, backend: str | None = None) -> None:
   """Collects a device memory profile and writes it to a file.
 
   :func:`save_device_memory_profile` is a convenience wrapper around :func:`device_memory_profile`

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -19,7 +19,6 @@ from functools import partial
 import math
 from operator import index
 import typing
-from typing import Union
 from collections.abc import Hashable
 import warnings
 
@@ -148,7 +147,7 @@ class PRNGSpec:
 
 # TODO(frostig,vanderplas): remove PRNGImpl from this union when it's
 # no longer in the public API because `default_prng_impl` is gone
-PRNGSpecDesc = Union[str, PRNGSpec, PRNGImpl]
+PRNGSpecDesc = str | PRNGSpec | PRNGImpl
 
 
 def resolve_prng_impl(impl_spec: PRNGSpecDesc | None) -> PRNGImpl:

--- a/jax/_src/scipy/fft.py
+++ b/jax/_src/scipy/fft.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 from functools import partial
 import math
-from typing import Optional
 
 import scipy.fft as osp_fft
 from jax import lax
@@ -42,8 +43,8 @@ def _dct_ortho_norm(out: Array, axis: int) -> Array:
 # John Makhoul: A Fast Cosine Transform in One and Two Dimensions (1980)
 
 @_wraps(osp_fft.dct)
-def dct(x: Array, type: int = 2, n: Optional[int] = None,
-        axis: int = -1, norm: Optional[str] = None) -> Array:
+def dct(x: Array, type: int = 2, n: int | None = None,
+        axis: int = -1, norm: str | None = None) -> Array:
   if type != 2:
     raise NotImplementedError('Only DCT type 2 is implemented.')
 
@@ -64,7 +65,7 @@ def dct(x: Array, type: int = 2, n: Optional[int] = None,
   return out
 
 
-def _dct2(x: Array, axes: Sequence[int], norm: Optional[str]) -> Array:
+def _dct2(x: Array, axes: Sequence[int], norm: str | None) -> Array:
   axis1, axis2 = map(partial(canonicalize_axis, num_dims=x.ndim), axes)
   N1, N2 = x.shape[axis1], x.shape[axis2]
   v = _dct_interleave(_dct_interleave(x, axis1), axis2)
@@ -82,9 +83,9 @@ def _dct2(x: Array, axes: Sequence[int], norm: Optional[str]) -> Array:
 
 @_wraps(osp_fft.dctn)
 def dctn(x: Array, type: int = 2,
-         s: Optional[Sequence[int]]=None,
-         axes: Optional[Sequence[int]] = None,
-         norm: Optional[str] = None) -> Array:
+         s: Sequence[int] | None=None,
+         axes: Sequence[int] | None = None,
+         norm: str | None = None) -> Array:
   if type != 2:
     raise NotImplementedError('Only DCT type 2 is implemented.')
 
@@ -109,8 +110,8 @@ def dctn(x: Array, type: int = 2,
 
 
 @_wraps(osp_fft.dct)
-def idct(x: Array, type: int = 2, n: Optional[int] = None,
-        axis: int = -1, norm: Optional[str] = None) -> Array:
+def idct(x: Array, type: int = 2, n: int | None = None,
+        axis: int = -1, norm: str | None = None) -> Array:
   if type != 2:
     raise NotImplementedError('Only DCT type 2 is implemented.')
 
@@ -140,9 +141,9 @@ def idct(x: Array, type: int = 2, n: Optional[int] = None,
 
 @_wraps(osp_fft.idctn)
 def idctn(x: Array, type: int = 2,
-         s: Optional[Sequence[int]]=None,
-         axes: Optional[Sequence[int]] = None,
-         norm: Optional[str] = None) -> Array:
+         s: Sequence[int] | None=None,
+         axes: Sequence[int] | None = None,
+         norm: str | None = None) -> Array:
   if type != 2:
     raise NotImplementedError('Only DCT type 2 is implemented.')
 

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 from functools import partial
 
 import numpy as np
 import scipy.linalg
 import textwrap
-from typing import cast, overload, Any, Literal, Optional, Union
+from typing import cast, overload, Any, Literal
 
 import jax
 import jax.numpy as jnp
@@ -84,10 +85,10 @@ def _svd(x: ArrayLike, *, full_matrices: bool, compute_uv: Literal[True]) -> tup
 def _svd(x: ArrayLike, *, full_matrices: bool, compute_uv: Literal[False]) -> Array: ...
 
 @overload
-def _svd(x: ArrayLike, *, full_matrices: bool, compute_uv: bool) -> Union[Array, tuple[Array, Array, Array]]: ...
+def _svd(x: ArrayLike, *, full_matrices: bool, compute_uv: bool) -> Array | tuple[Array, Array, Array]: ...
 
 @partial(jit, static_argnames=('full_matrices', 'compute_uv'))
-def _svd(a: ArrayLike, *, full_matrices: bool, compute_uv: bool) -> Union[Array, tuple[Array, Array, Array]]:
+def _svd(a: ArrayLike, *, full_matrices: bool, compute_uv: bool) -> Array | tuple[Array, Array, Array]:
   a, = promote_dtypes_inexact(jnp.asarray(a))
   return lax_linalg.svd(a, full_matrices=full_matrices, compute_uv=compute_uv)
 
@@ -109,13 +110,13 @@ def svd(a: ArrayLike, full_matrices: bool = True, *, compute_uv: Literal[False],
 @overload
 def svd(a: ArrayLike, full_matrices: bool = True, compute_uv: bool = True,
         overwrite_a: bool = False, check_finite: bool = True,
-        lapack_driver: str = 'gesdd') -> Union[Array, tuple[Array, Array, Array]]: ...
+        lapack_driver: str = 'gesdd') -> Array | tuple[Array, Array, Array]: ...
 
 @_wraps(scipy.linalg.svd,
         lax_description=_no_overwrite_and_chkfinite_doc, skip_params=('overwrite_a', 'check_finite', 'lapack_driver'))
 def svd(a: ArrayLike, full_matrices: bool = True, compute_uv: bool = True,
         overwrite_a: bool = False, check_finite: bool = True,
-        lapack_driver: str = 'gesdd') -> Union[Array, tuple[Array, Array, Array]]:
+        lapack_driver: str = 'gesdd') -> Array | tuple[Array, Array, Array]:
   del overwrite_a, check_finite, lapack_driver  # unused
   return _svd(a, full_matrices=full_matrices, compute_uv=compute_uv)
 
@@ -127,20 +128,20 @@ def det(a: ArrayLike, overwrite_a: bool = False, check_finite: bool = True) -> A
 
 
 @overload
-def _eigh(a: ArrayLike, b: Optional[ArrayLike], lower: bool, eigvals_only: Literal[True],
+def _eigh(a: ArrayLike, b: ArrayLike | None, lower: bool, eigvals_only: Literal[True],
           eigvals: None, type: int) -> Array: ...
 
 @overload
-def _eigh(a: ArrayLike, b: Optional[ArrayLike], lower: bool, eigvals_only: Literal[False],
+def _eigh(a: ArrayLike, b: ArrayLike | None, lower: bool, eigvals_only: Literal[False],
           eigvals: None, type: int) -> tuple[Array, Array]: ...
 
 @overload
-def _eigh(a: ArrayLike, b: Optional[ArrayLike], lower: bool, eigvals_only: bool,
-          eigvals: None, type: int) -> Union[Array, tuple[Array, Array]]: ...
+def _eigh(a: ArrayLike, b: ArrayLike | None, lower: bool, eigvals_only: bool,
+          eigvals: None, type: int) -> Array | tuple[Array, Array]: ...
 
 @partial(jit, static_argnames=('lower', 'eigvals_only', 'eigvals', 'type'))
-def _eigh(a: ArrayLike, b: Optional[ArrayLike], lower: bool, eigvals_only: bool,
-          eigvals: None, type: int) -> Union[Array, tuple[Array, Array]]:
+def _eigh(a: ArrayLike, b: ArrayLike | None, lower: bool, eigvals_only: bool,
+          eigvals: None, type: int) -> Array | tuple[Array, Array]:
   if b is not None:
     raise NotImplementedError("Only the b=None case of eigh is implemented")
   if type != 1:
@@ -158,36 +159,36 @@ def _eigh(a: ArrayLike, b: Optional[ArrayLike], lower: bool, eigvals_only: bool,
     return w, v
 
 @overload
-def eigh(a: ArrayLike, b: Optional[ArrayLike] = None, lower: bool = True,
+def eigh(a: ArrayLike, b: ArrayLike | None = None, lower: bool = True,
          eigvals_only: Literal[False] = False, overwrite_a: bool = False,
          overwrite_b: bool = False, turbo: bool = True, eigvals: None = None,
          type: int = 1, check_finite: bool = True) -> tuple[Array, Array]: ...
 
 @overload
-def eigh(a: ArrayLike, b: Optional[ArrayLike] = None, lower: bool = True, *,
+def eigh(a: ArrayLike, b: ArrayLike | None = None, lower: bool = True, *,
          eigvals_only: Literal[True], overwrite_a: bool = False,
          overwrite_b: bool = False, turbo: bool = True, eigvals: None = None,
          type: int = 1, check_finite: bool = True) -> Array: ...
 
 @overload
-def eigh(a: ArrayLike, b: Optional[ArrayLike], lower: bool,
+def eigh(a: ArrayLike, b: ArrayLike | None, lower: bool,
          eigvals_only: Literal[True], overwrite_a: bool = False,
          overwrite_b: bool = False, turbo: bool = True, eigvals: None = None,
          type: int = 1, check_finite: bool = True) -> Array: ...
 
 @overload
-def eigh(a: ArrayLike, b: Optional[ArrayLike] = None, lower: bool = True,
+def eigh(a: ArrayLike, b: ArrayLike | None = None, lower: bool = True,
          eigvals_only: bool = False, overwrite_a: bool = False,
          overwrite_b: bool = False, turbo: bool = True, eigvals: None = None,
-         type: int = 1, check_finite: bool = True) -> Union[Array, tuple[Array, Array]]: ...
+         type: int = 1, check_finite: bool = True) -> Array | tuple[Array, Array]: ...
 
 @_wraps(scipy.linalg.eigh,
         lax_description=_no_overwrite_and_chkfinite_doc,
         skip_params=('overwrite_a', 'overwrite_b', 'turbo', 'check_finite'))
-def eigh(a: ArrayLike, b: Optional[ArrayLike] = None, lower: bool = True,
+def eigh(a: ArrayLike, b: ArrayLike | None = None, lower: bool = True,
          eigvals_only: bool = False, overwrite_a: bool = False,
          overwrite_b: bool = False, turbo: bool = True, eigvals: None = None,
-         type: int = 1, check_finite: bool = True) -> Union[Array, tuple[Array, Array]]:
+         type: int = 1, check_finite: bool = True) -> Array | tuple[Array, Array]:
   del overwrite_a, overwrite_b, turbo, check_finite  # unused
   return _eigh(a, b, lower, eigvals_only, eigvals, type)
 
@@ -239,10 +240,10 @@ def _lu(a: ArrayLike, permute_l: Literal[True]) -> tuple[Array, Array]: ...
 def _lu(a: ArrayLike, permute_l: Literal[False]) -> tuple[Array, Array, Array]: ...
 
 @overload
-def _lu(a: ArrayLike, permute_l: bool) -> Union[tuple[Array, Array], tuple[Array, Array, Array]]: ...
+def _lu(a: ArrayLike, permute_l: bool) -> tuple[Array, Array] | tuple[Array, Array, Array]: ...
 
 @partial(jit, static_argnums=(1,))
-def _lu(a: ArrayLike, permute_l: bool) -> Union[tuple[Array, Array], tuple[Array, Array, Array]]:
+def _lu(a: ArrayLike, permute_l: bool) -> tuple[Array, Array] | tuple[Array, Array, Array]:
   a, = promote_dtypes_inexact(jnp.asarray(a))
   lu, _, permutation = lax_linalg.lu(a)
   dtype = lax.dtype(a)
@@ -266,13 +267,13 @@ def lu(a: ArrayLike, permute_l: Literal[True], overwrite_a: bool = False,
 
 @overload
 def lu(a: ArrayLike, permute_l: bool = False, overwrite_a: bool = False,
-       check_finite: bool = True) -> Union[tuple[Array, Array], tuple[Array, Array, Array]]: ...
+       check_finite: bool = True) -> tuple[Array, Array] | tuple[Array, Array, Array]: ...
 
 @_wraps(scipy.linalg.lu, update_doc=False,
         lax_description=_no_overwrite_and_chkfinite_doc, skip_params=('overwrite_a', 'check_finite'))
 @partial(jit, static_argnames=('permute_l', 'overwrite_a', 'check_finite'))
 def lu(a: ArrayLike, permute_l: bool = False, overwrite_a: bool = False,
-       check_finite: bool = True) -> Union[tuple[Array, Array], tuple[Array, Array, Array]]:
+       check_finite: bool = True) -> tuple[Array, Array] | tuple[Array, Array, Array]:
   del overwrite_a, check_finite  # unused
   return _lu(a, permute_l)
 
@@ -283,10 +284,10 @@ def _qr(a: ArrayLike, mode: Literal["r"], pivoting: bool) -> tuple[Array]: ...
 def _qr(a: ArrayLike, mode: Literal["full", "economic"], pivoting: bool) -> tuple[Array, Array]: ...
 
 @overload
-def _qr(a: ArrayLike, mode: str, pivoting: bool) -> Union[tuple[Array], tuple[Array, Array]]: ...
+def _qr(a: ArrayLike, mode: str, pivoting: bool) -> tuple[Array] | tuple[Array, Array]: ...
 
 @partial(jit, static_argnames=('mode', 'pivoting'))
-def _qr(a: ArrayLike, mode: str, pivoting: bool) -> Union[tuple[Array], tuple[Array, Array]]:
+def _qr(a: ArrayLike, mode: str, pivoting: bool) -> tuple[Array] | tuple[Array, Array]:
   if pivoting:
     raise NotImplementedError(
         "The pivoting=True case of qr is not implemented.")
@@ -317,12 +318,12 @@ def qr(a: ArrayLike,  overwrite_a: bool = False, lwork: Any = None, *, mode: Lit
 
 @overload
 def qr(a: ArrayLike, overwrite_a: bool = False, lwork: Any = None, mode: str = "full",
-       pivoting: bool = False, check_finite: bool = True) -> Union[tuple[Array], tuple[Array, Array]]: ...
+       pivoting: bool = False, check_finite: bool = True) -> tuple[Array] | tuple[Array, Array]: ...
 
 @_wraps(scipy.linalg.qr,
         lax_description=_no_overwrite_and_chkfinite_doc, skip_params=('overwrite_a', 'check_finite', 'lwork'))
 def qr(a: ArrayLike, overwrite_a: bool = False, lwork: Any = None, mode: str = "full",
-       pivoting: bool = False, check_finite: bool = True) -> Union[tuple[Array], tuple[Array, Array]]:
+       pivoting: bool = False, check_finite: bool = True) -> tuple[Array] | tuple[Array, Array]:
   del overwrite_a, lwork, check_finite  # unused
   return _qr(a, mode, pivoting)
 
@@ -364,7 +365,7 @@ def solve(a: ArrayLike, b: ArrayLike, lower: bool = False,
   return _solve(a, b, assume_a, lower)
 
 @partial(jit, static_argnames=('trans', 'lower', 'unit_diagonal'))
-def _solve_triangular(a: ArrayLike, b: ArrayLike, trans: Union[int, str],
+def _solve_triangular(a: ArrayLike, b: ArrayLike, trans: int | str,
                       lower: bool, unit_diagonal: bool) -> Array:
   if trans == 0 or trans == "N":
     transpose_a, conjugate_a = False, False
@@ -392,7 +393,7 @@ def _solve_triangular(a: ArrayLike, b: ArrayLike, trans: Union[int, str],
 
 @_wraps(scipy.linalg.solve_triangular,
         lax_description=_no_overwrite_and_chkfinite_doc, skip_params=('overwrite_b', 'debug', 'check_finite'))
-def solve_triangular(a: ArrayLike, b: ArrayLike, trans: Union[int, str] = 0, lower: bool = False,
+def solve_triangular(a: ArrayLike, b: ArrayLike, trans: int | str = 0, lower: bool = False,
                      unit_diagonal: bool = False, overwrite_b: bool = False,
                      debug: Any = None, check_finite: bool = True) -> Array:
   del overwrite_b, debug, check_finite  # unused
@@ -570,21 +571,21 @@ support the ``method='blockEnlarge'`` argument.
 """)
 
 @overload
-def expm_frechet(A: ArrayLike, E: ArrayLike, *, method: Optional[str] = None,
+def expm_frechet(A: ArrayLike, E: ArrayLike, *, method: str | None = None,
                  compute_expm: Literal[True] = True) -> tuple[Array, Array]: ...
 
 @overload
-def expm_frechet(A: ArrayLike, E: ArrayLike, *, method: Optional[str] = None,
+def expm_frechet(A: ArrayLike, E: ArrayLike, *, method: str | None = None,
                  compute_expm: Literal[False]) -> Array: ...
 
 @overload
-def expm_frechet(A: ArrayLike, E: ArrayLike, *, method: Optional[str] = None,
-                 compute_expm: bool = True) -> Union[Array, tuple[Array, Array]]: ...
+def expm_frechet(A: ArrayLike, E: ArrayLike, *, method: str | None = None,
+                 compute_expm: bool = True) -> Array | tuple[Array, Array]: ...
 
 @_wraps(scipy.linalg.expm_frechet, lax_description=_expm_frechet_description)
 @partial(jit, static_argnames=('method', 'compute_expm'))
-def expm_frechet(A: ArrayLike, E: ArrayLike, *, method: Optional[str] = None,
-                 compute_expm: bool = True) -> Union[Array, tuple[Array, Array]]:
+def expm_frechet(A: ArrayLike, E: ArrayLike, *, method: str | None = None,
+                 compute_expm: bool = True) -> Array | tuple[Array, Array]:
   A_arr = jnp.asarray(A)
   E_arr = jnp.asarray(E)
   if A_arr.ndim != 2 or A_arr.shape[0] != A_arr.shape[1]:
@@ -631,8 +632,8 @@ def block_diag(*arrs: ArrayLike) -> Array:
 @_wraps(scipy.linalg.eigh_tridiagonal)
 @partial(jit, static_argnames=("eigvals_only", "select", "select_range"))
 def eigh_tridiagonal(d: ArrayLike, e: ArrayLike, *, eigvals_only: bool = False,
-                     select: str = 'a', select_range: Optional[tuple[float, float]] = None,
-                     tol: Optional[float] = None) -> Array:
+                     select: str = 'a', select_range: tuple[float, float] | None = None,
+                     tol: float | None = None) -> Array:
   if not eigvals_only:
     raise NotImplementedError("Calculation of eigenvectors is not implemented")
 
@@ -786,8 +787,8 @@ def eigh_tridiagonal(d: ArrayLike, e: ArrayLike, *, eigvals_only: bool = False,
 
 @partial(jit, static_argnames=('side', 'method'))
 @jax.default_matmul_precision("float32")
-def polar(a: ArrayLike, side: str = 'right', *, method: str = 'qdwh', eps: Optional[float] = None,
-          max_iterations: Optional[int] = None) -> tuple[Array, Array]:
+def polar(a: ArrayLike, side: str = 'right', *, method: str = 'qdwh', eps: float | None = None,
+          max_iterations: int | None = None) -> tuple[Array, Array]:
   r"""Computes the polar decomposition.
 
   Given the :math:`m \times n` matrix :math:`a`, returns the factors of the polar
@@ -999,7 +1000,7 @@ def hessenberg(a: ArrayLike, *, calc_q: Literal[True], overwrite_a: bool = False
 @_wraps(scipy.linalg.hessenberg, lax_description=_no_overwrite_and_chkfinite_doc)
 @partial(jit, static_argnames=('calc_q', 'check_finite', 'overwrite_a'))
 def hessenberg(a: ArrayLike, *, calc_q: bool = False, overwrite_a: bool = False,
-               check_finite: bool = True) -> Union[Array, tuple[Array, Array]]:
+               check_finite: bool = True) -> Array | tuple[Array, Array]:
   del overwrite_a, check_finite
   n = jnp.shape(a)[-1]
   if n == 0:
@@ -1020,7 +1021,7 @@ def hessenberg(a: ArrayLike, *, calc_q: bool = False, overwrite_a: bool = False,
     return h
 
 @_wraps(scipy.linalg.toeplitz)
-def toeplitz(c: ArrayLike, r: Optional[ArrayLike] = None) -> Array:
+def toeplitz(c: ArrayLike, r: ArrayLike | None = None) -> Array:
   if r is None:
     check_arraylike("toeplitz", c)
     r = jnp.conjugate(jnp.asarray(c))

--- a/jax/_src/scipy/optimize/_lbfgs.py
+++ b/jax/_src/scipy/optimize/_lbfgs.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Limited-Memory Broyden-Fletcher-Goldfarb-Shanno minimization algorithm."""
-from typing import Callable, NamedTuple, Optional, Union
+
+from __future__ import annotations
+
+from typing import Callable, NamedTuple
 from functools import partial
 
 import jax
@@ -50,32 +53,32 @@ class LBFGSResults(NamedTuple):
       5 = line search failed
     ls_status: integer describing the end status of the last line search
   """
-  converged: Union[bool, Array]
-  failed: Union[bool, Array]
-  k: Union[int, Array]
-  nfev: Union[int, Array]
-  ngev: Union[int, Array]
+  converged: bool | Array
+  failed: bool | Array
+  k: int | Array
+  nfev: int | Array
+  ngev: int | Array
   x_k: Array
   f_k: Array
   g_k: Array
   s_history: Array
   y_history: Array
   rho_history: Array
-  gamma: Union[float, Array]
-  status: Union[int, Array]
-  ls_status: Union[int, Array]
+  gamma: float | Array
+  status: int | Array
+  ls_status: int | Array
 
 
 def _minimize_lbfgs(
     fun: Callable,
     x0: Array,
-    maxiter: Optional[float] = None,
+    maxiter: float | None = None,
     norm=jnp.inf,
     maxcor: int = 10,
     ftol: float = 2.220446049250313e-09,
     gtol: float = 1e-05,
-    maxfun: Optional[float] = None,
-    maxgrad: Optional[float] = None,
+    maxfun: float | None = None,
+    maxgrad: float | None = None,
     maxls: int = 20,
 ):
   """

--- a/jax/_src/scipy/optimize/bfgs.py
+++ b/jax/_src/scipy/optimize/bfgs.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Broyden-Fletcher-Goldfarb-Shanno minimization algorithm."""
+
+from __future__ import annotations
+
 from functools import partial
-from typing import Callable, NamedTuple, Optional, Union
+from typing import Callable, NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -45,19 +48,19 @@ class _BFGSResults(NamedTuple):
     line_search_status: int describing line search end state (only means
       something if line search fails).
   """
-  converged: Union[bool, jax.Array]
-  failed: Union[bool, jax.Array]
-  k: Union[int, jax.Array]
-  nfev: Union[int, jax.Array]
-  ngev: Union[int, jax.Array]
-  nhev: Union[int, jax.Array]
+  converged: bool | jax.Array
+  failed: bool | jax.Array
+  k: int | jax.Array
+  nfev: int | jax.Array
+  ngev: int | jax.Array
+  nhev: int | jax.Array
   x_k: jax.Array
   f_k: jax.Array
   g_k: jax.Array
   H_k: jax.Array
   old_old_fval: jax.Array
-  status: Union[int, jax.Array]
-  line_search_status: Union[int, jax.Array]
+  status: int | jax.Array
+  line_search_status: int | jax.Array
 
 
 _dot = partial(jnp.dot, precision=lax.Precision.HIGHEST)
@@ -67,7 +70,7 @@ _einsum = partial(jnp.einsum, precision=lax.Precision.HIGHEST)
 def minimize_bfgs(
     fun: Callable,
     x0: jax.Array,
-    maxiter: Optional[int] = None,
+    maxiter: int | None = None,
     norm=jnp.inf,
     gtol: float = 1e-5,
     line_search_maxiter: int = 10,

--- a/jax/_src/scipy/optimize/line_search.py
+++ b/jax/_src/scipy/optimize/line_search.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import NamedTuple, Union
+from __future__ import annotations
+
+from typing import NamedTuple
 from functools import partial
 
 from jax._src.numpy.util import promote_dtypes_inexact
@@ -57,23 +59,23 @@ def _binary_replace(replace_bit, original_dict, new_dict, keys=None):
 
 
 class _ZoomState(NamedTuple):
-  done: Union[bool, jax.Array]
-  failed: Union[bool, jax.Array]
-  j: Union[int, jax.Array]
-  a_lo: Union[float, jax.Array]
-  phi_lo: Union[float, jax.Array]
-  dphi_lo: Union[float, jax.Array]
-  a_hi: Union[float, jax.Array]
-  phi_hi: Union[float, jax.Array]
-  dphi_hi: Union[float, jax.Array]
-  a_rec: Union[float, jax.Array]
-  phi_rec: Union[float, jax.Array]
-  a_star: Union[float, jax.Array]
-  phi_star: Union[float, jax.Array]
-  dphi_star: Union[float, jax.Array]
-  g_star: Union[float, jax.Array]
-  nfev: Union[int, jax.Array]
-  ngev: Union[int, jax.Array]
+  done: bool | jax.Array
+  failed: bool | jax.Array
+  j: int | jax.Array
+  a_lo: float | jax.Array
+  phi_lo: float | jax.Array
+  dphi_lo: float | jax.Array
+  a_hi: float | jax.Array
+  phi_hi: float | jax.Array
+  dphi_hi: float | jax.Array
+  a_rec: float | jax.Array
+  phi_rec: float | jax.Array
+  a_star: float | jax.Array
+  phi_star: float | jax.Array
+  dphi_star: float | jax.Array
+  g_star: float | jax.Array
+  nfev: int | jax.Array
+  ngev: int | jax.Array
 
 
 def _zoom(restricted_func_and_grad, wolfe_one, wolfe_two, a_lo, phi_lo,
@@ -213,17 +215,17 @@ def _zoom(restricted_func_and_grad, wolfe_one, wolfe_two, a_lo, phi_lo,
 
 
 class _LineSearchState(NamedTuple):
-  done: Union[bool, jax.Array]
-  failed: Union[bool, jax.Array]
-  i: Union[int, jax.Array]
-  a_i1: Union[float, jax.Array]
-  phi_i1: Union[float, jax.Array]
-  dphi_i1: Union[float, jax.Array]
-  nfev: Union[int, jax.Array]
-  ngev: Union[int, jax.Array]
-  a_star: Union[float, jax.Array]
-  phi_star: Union[float, jax.Array]
-  dphi_star: Union[float, jax.Array]
+  done: bool | jax.Array
+  failed: bool | jax.Array
+  i: int | jax.Array
+  a_i1: float | jax.Array
+  phi_i1: float | jax.Array
+  dphi_i1: float | jax.Array
+  nfev: int | jax.Array
+  ngev: int | jax.Array
+  a_star: float | jax.Array
+  phi_star: float | jax.Array
+  dphi_star: float | jax.Array
   g_star: jax.Array
 
 
@@ -241,15 +243,15 @@ class _LineSearchResults(NamedTuple):
     g_k: final gradient value
     status: integer end status
   """
-  failed: Union[bool, jax.Array]
-  nit: Union[int, jax.Array]
-  nfev: Union[int, jax.Array]
-  ngev: Union[int, jax.Array]
-  k: Union[int, jax.Array]
-  a_k: Union[int, jax.Array]
+  failed: bool | jax.Array
+  nit: int | jax.Array
+  nfev: int | jax.Array
+  ngev: int | jax.Array
+  k: int | jax.Array
+  a_k: int | jax.Array
   f_k: jax.Array
   g_k: jax.Array
-  status: Union[bool, jax.Array]
+  status: bool | jax.Array
 
 
 def line_search(f, xk, pk, old_fval=None, old_old_fval=None, gfk=None, c1=1e-4,

--- a/jax/_src/scipy/optimize/minimize.py
+++ b/jax/_src/scipy/optimize/minimize.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Mapping
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable
 
 import jax
 from jax._src.scipy.optimize.bfgs import minimize_bfgs
@@ -39,14 +41,14 @@ class OptimizeResults(NamedTuple):
     nit: integer number of iterations of the optimization algorithm.
   """
   x: jax.Array
-  success: Union[bool, jax.Array]
-  status: Union[int, jax.Array]
+  success: bool | jax.Array
+  status: int | jax.Array
   fun: jax.Array
   jac: jax.Array
-  hess_inv: Optional[jax.Array]
-  nfev: Union[int, jax.Array]
-  njev: Union[int, jax.Array]
-  nit: Union[int, jax.Array]
+  hess_inv: jax.Array | None
+  nfev: int | jax.Array
+  njev: int | jax.Array
+  nit: int | jax.Array
 
 
 def minimize(
@@ -55,8 +57,8 @@ def minimize(
     args: tuple = (),
     *,
     method: str,
-    tol: Optional[float] = None,
-    options: Optional[Mapping[str, Any]] = None,
+    tol: float | None = None,
+    options: Mapping[str, Any] | None = None,
 ) -> OptimizeResults:
   """Minimization of scalar function of one or more variables.
 

--- a/jax/_src/scipy/spatial/transform.py
+++ b/jax/_src/scipy/spatial/transform.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import functools
 import re
 import typing
@@ -74,14 +76,14 @@ class Rotation(typing.NamedTuple):
     return cls(_from_rotvec(rotvec, degrees))
 
   @classmethod
-  def identity(cls, num: typing.Optional[int] = None, dtype=float):
+  def identity(cls, num: int | None = None, dtype=float):
     """Get identity rotation(s)."""
     assert num is None
     quat = jnp.array([0., 0., 0., 1.], dtype=dtype)
     return cls(quat)
 
   @classmethod
-  def random(cls, random_key: jax.Array, num: typing.Optional[int] = None):
+  def random(cls, random_key: jax.Array, num: int | None = None):
     """Generate uniformly distributed rotations."""
     # Need to implement scipy.stats.special_ortho_group for this to work...
     raise NotImplementedError
@@ -147,7 +149,7 @@ class Rotation(typing.NamedTuple):
     """Get the magnitude(s) of the rotation(s)."""
     return _magnitude(self.quat)
 
-  def mean(self, weights: typing.Optional[jax.Array] = None):
+  def mean(self, weights: jax.Array | None = None):
     """Get the mean of the rotations."""
     w = jnp.ones(self.quat.shape[0], dtype=self.quat.dtype) if weights is None else jnp.asarray(weights, dtype=self.quat.dtype)
     if w.ndim != 1:

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from functools import partial
 import operator
-from typing import cast, Any, Optional
+from typing import cast, Any
 
 import numpy as np
 import scipy.special as osp_special
@@ -267,7 +269,7 @@ _BERNOULLI_COEFS = [
 
 @custom_derivatives.custom_jvp
 @_wraps(osp_special.zeta, module='scipy.special')
-def zeta(x: ArrayLike, q: Optional[ArrayLike] = None) -> Array:
+def zeta(x: ArrayLike, q: ArrayLike | None = None) -> Array:
   if q is None:
     raise NotImplementedError(
       "Riemann zeta function not implemented; pass q != None to compute the Hurwitz Zeta function.")
@@ -277,7 +279,7 @@ def zeta(x: ArrayLike, q: Optional[ArrayLike] = None) -> Array:
 
 # There is no general closed-form derivative for the zeta function, so we compute
 # derivatives via a series expansion
-def _zeta_series_expansion(x: ArrayLike, q: Optional[ArrayLike] = None) -> Array:
+def _zeta_series_expansion(x: ArrayLike, q: ArrayLike | None = None) -> Array:
   if q is None:
     raise NotImplementedError(
       "Riemann zeta function not implemented; pass q != None to compute the Hurwitz Zeta function.")
@@ -1199,7 +1201,7 @@ def sph_harm(m: Array,
              n: Array,
              theta: Array,
              phi: Array,
-             n_max: Optional[int] = None) -> Array:
+             n_max: int | None = None) -> Array:
   r"""Computes the spherical harmonics.
 
   The JAX version has one extra argument `n_max`, the maximum value in `n`.

--- a/jax/_src/scipy/stats/_core.py
+++ b/jax/_src/scipy/stats/_core.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections import namedtuple
 from functools import partial
 import math
-from typing import Optional
 
 import jax
 import jax.numpy as jnp
@@ -34,7 +35,7 @@ ModeResult = namedtuple('ModeResult', ('mode', 'count'))
 Currently the only supported nan_policy is 'propagate'
 """)
 @partial(jit, static_argnames=['axis', 'nan_policy', 'keepdims'])
-def mode(a: ArrayLike, axis: Optional[int] = 0, nan_policy: str = "propagate", keepdims: bool = False) -> ModeResult:
+def mode(a: ArrayLike, axis: int | None = 0, nan_policy: str = "propagate", keepdims: bool = False) -> ModeResult:
   check_arraylike("mode", a)
   x = jnp.atleast_1d(a)
 
@@ -97,7 +98,7 @@ def rankdata(
   a: ArrayLike,
   method: str = "average",
   *,
-  axis: Optional[int] = None,
+  axis: int | None = None,
   nan_policy: str = "propagate",
 ) -> Array:
 

--- a/jax/_src/sharding_impls.py
+++ b/jax/_src/sharding_impls.py
@@ -22,7 +22,7 @@ import enum
 import functools
 import itertools
 import math
-from typing import Any, NamedTuple, Union, cast
+from typing import Any, NamedTuple, cast
 
 from jax._src import mesh as mesh_lib
 from jax._src.op_shardings import (
@@ -894,7 +894,7 @@ mesh devices without any modifications. If the mapping was {'y': 1, 'x': 1}, the
 mesh devices ndarray would have to be transposed before flattening and assignment.
 """
 ArrayMapping = OrderedDict[MeshAxisName, int]
-ArrayMappingOrAutoOrUnspecified = Union[ArrayMapping, AUTO, UnspecifiedValue]
+ArrayMappingOrAutoOrUnspecified = ArrayMapping | AUTO | UnspecifiedValue
 
 def array_mapping_to_axis_resources(array_mapping: ArrayMapping):
   if not array_mapping:

--- a/jax/_src/sharding_specs.py
+++ b/jax/_src/sharding_specs.py
@@ -27,12 +27,14 @@
 # This encoding is assumed by various parts of the system, e.g. generating
 # replica groups for collective operations.
 
+from __future__ import annotations
+
 import collections
 from collections.abc import Mapping, Sequence
 import functools
 import itertools
 import math
-from typing import Any, Optional, Union, cast
+from typing import Any, cast
 
 import numpy as np
 
@@ -51,7 +53,7 @@ _UNSHARDED_INSTANCE = NoSharding()
 
 ShardedAxis = pmap_lib.ShardedAxis
 Replicated = pmap_lib.Replicated
-MeshDimAssignment = Union[ShardedAxis, Replicated]
+MeshDimAssignment = ShardedAxis | Replicated
 
 ShardingSpec = pmap_lib.ShardingSpec
 
@@ -82,7 +84,7 @@ def get_logical_mesh_ids(mesh_shape):
 _MeshAxisName = Any
 
 def sharding_spec_sharding_proto(
-    self, special_axes: Optional[Mapping[int, OpShardingType]] = None
+    self, special_axes: Mapping[int, OpShardingType] | None = None
 ) -> xc.HloSharding:
   """Converts a ShardingSpec to an OpSharding proto.
 
@@ -226,7 +228,7 @@ ShardingSpec.indices = _sharding_spec_indices
 ShardingSpec.__repr__ = _sharding_spec_repr  # type: ignore
 
 
-Index = Union[int, slice, tuple[Union[int, slice], ...]]
+Index = int | slice | tuple[int | slice, ...]
 
 def spec_to_indices(shape: Sequence[int],
                     spec: ShardingSpec) -> tuple[Index, ...]:
@@ -273,7 +275,7 @@ def new_mesh_sharding_specs(axis_sizes, axis_names):
   return functools.partial(make_sharding_spec, axis_sizes, mesh_axis_pos)
 
 def pmap_sharding_spec(nrep, axis_size, sharded_shape: Sequence[int],
-                       map_axis: Optional[int]) -> ShardingSpec:
+                       map_axis: int | None) -> ShardingSpec:
   """Sharding spec for arguments or results of a pmap.
   Args:
     nrep: number of local XLA replicas (product of local axis sizes)
@@ -310,7 +312,7 @@ def pmap_sharding_spec(nrep, axis_size, sharded_shape: Sequence[int],
 
 
 def create_pmap_sharding_spec(shape: tuple[int, ...], sharded_dim: int = 0,
-                              sharded_dim_size: Optional[int] = None):
+                              sharded_dim_size: int | None = None):
   if sharded_dim is not None:
     sharded_shape = shape[:sharded_dim] + shape[sharded_dim+1:]
     if sharded_dim_size is None:

--- a/jax/_src/stages.py
+++ b/jax/_src/stages.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, NamedTuple, Protocol, Union
+from typing import Any, NamedTuple, Protocol
 
 import jax
 
@@ -56,7 +56,7 @@ xla_extension = xc._xla
 map, unsafe_map = util.safe_map, map
 zip, unsafe_zip = util.safe_zip, zip
 
-CompilerOptions = dict[str, Union[str, bool]]
+CompilerOptions = dict[str, str | bool]
 
 
 # -- Internal protocols

--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Module for state primitives."""
-from functools import partial
+from __future__ import annotations
 
-from typing import Any, Union
+from functools import partial
+from typing import Any
 
 import numpy as np
 
@@ -55,7 +56,7 @@ def _get_impl(ref: AbstractRef, *idx: int, **_):
   raise ValueError("Cannot run stateful primitive.")
 get_p.def_impl(_get_impl)
 
-Indexer = tuple[Union[int, slice, Array], ...]
+Indexer = tuple[int | slice | Array, ...]
 # or Ellipsis, but that can't be annotated until Python 3.10? (types.EllipsisType)
 
 def _is_trivial_indexer(idx: Indexer) -> bool:

--- a/jax/_src/state/types.py
+++ b/jax/_src/state/types.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Module for state types."""
+
 from __future__ import annotations
 
 from collections.abc import Sequence
 import dataclasses
 import math
-from typing import Any, Generic, TypeVar, Union
+from typing import Any, Generic, TypeVar
 
 from jax._src import core
 from jax._src import effects
@@ -68,7 +69,7 @@ class AccumEffect(RefEffect):
 
 effects.control_flow_allowed_effects.add_type(RefEffect)
 
-StateEffect = Union[ReadEffect, WriteEffect, AccumEffect]
+StateEffect = ReadEffect | WriteEffect | AccumEffect
 
 # ## `Ref`s
 

--- a/jax/_src/third_party/scipy/signal_helper.py
+++ b/jax/_src/third_party/scipy/signal_helper.py
@@ -1,14 +1,16 @@
 """Utility functions adopted from scipy.signal."""
 
+from __future__ import annotations
+
 import scipy.signal as osp_signal
-from typing import Any, Optional, Union
+from typing import Any
 import warnings
 
 import jax.numpy as jnp
 from jax._src.typing import Array, ArrayLike, DTypeLike
 
 
-def _triage_segments(window: Union[ArrayLike, str, tuple[Any, ...]], nperseg: Optional[int],
+def _triage_segments(window: ArrayLike | str | tuple[Any, ...], nperseg: int | None,
                      input_length: int, dtype: DTypeLike) -> tuple[Array, int]:
   """
   Parses window and nperseg arguments for spectrogram and _spectral_helper.

--- a/jax/_src/traceback_util.py
+++ b/jax/_src/traceback_util.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import functools
 import os
 import sys
 import traceback
 import types
-from typing import Any, Callable, Optional, TypeVar, cast
+from typing import Any, Callable, TypeVar, cast
 
 from jax._src import config
 from jax._src import util
@@ -67,7 +69,7 @@ def _add_tracebackhide_to_hidden_frames(tb: types.TracebackType):
     if not include_frame(f):
       f.f_locals["__tracebackhide__"] = True
 
-def filter_traceback(tb: types.TracebackType) -> Optional[types.TracebackType]:
+def filter_traceback(tb: types.TracebackType) -> types.TracebackType | None:
   out = None
   # Scan the traceback and collect relevant frames.
   frames = list(traceback.walk_tb(tb))

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -21,7 +21,7 @@ import functools
 from functools import partial
 import operator as op
 import textwrap
-from typing import Any, Callable, NamedTuple, TypeVar, Union, overload
+from typing import Any, Callable, NamedTuple, TypeVar, overload
 
 from jax._src import traceback_util
 from jax._src.lib import pytree
@@ -603,7 +603,7 @@ class FlattenedIndexKey():
   def __str__(self):
     return f'[<flat index {self.key}>]'
 
-BuiltInKeyEntry = Union[SequenceKey, DictKey, GetAttrKey, FlattenedIndexKey]
+BuiltInKeyEntry = SequenceKey | DictKey | GetAttrKey | FlattenedIndexKey
 
 KeyEntry = TypeVar("KeyEntry", bound=Hashable)
 KeyPath = tuple[KeyEntry, ...]

--- a/jax/_src/typing.py
+++ b/jax/_src/typing.py
@@ -27,7 +27,7 @@ https://github.com/google/jax/pull/11859/.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any, Protocol, Union
+from typing import Any, Protocol
 import numpy as np
 
 from jax._src.basearray import (
@@ -50,17 +50,17 @@ class SupportsDType(Protocol):
 # Unlike np.typing.DTypeLike, we exclude None, and instead require
 # explicit annotations when None is acceptable.
 # TODO(jakevdp): consider whether to add ExtendedDtype to the union.
-DTypeLike = Union[
-  str,            # like 'float32', 'int32'
-  type[Any],      # like np.float32, np.int32, float, int
-  np.dtype,       # like np.dtype('float32'), np.dtype('int32')
-  SupportsDType,  # like jnp.float32, jnp.int32
-]
+DTypeLike = (
+  str |          # like 'float32', 'int32'
+  type[Any] |    # like np.float32, np.int32, float, int
+  np.dtype |     # like np.dtype('float32'), np.dtype('int32')
+  SupportsDType  # like jnp.float32, jnp.int32
+)
 
 # Shapes are tuples of dimension sizes, which are normally integers. We allow
 # modules to extend the set of dimension sizes to contain other types, e.g.,
 # symbolic dimensions in export.DimExpr.
-DimSize = Union[int, Any]  # extensible
+DimSize = int | Any  # extensible
 Shape = Sequence[DimSize]
 
 class DuckTypedArray(Protocol):

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Iterable, Iterator, Sequence
 import functools
 from functools import partial
 import itertools as it
 import logging
 import operator
-from typing import (Any, Callable, Generic, Optional, TypeVar, overload, TYPE_CHECKING, cast)
+from typing import (Any, Callable, Generic, TypeVar, overload, TYPE_CHECKING, cast)
 import weakref
 
 import numpy as np
@@ -144,7 +146,7 @@ def merge_lists(bs: Sequence[bool], l0: Sequence[T], l1: Sequence[T]) -> list[T]
   return out
 
 def subs_list(
-    subs: Sequence[Optional[int]], src: Sequence[T], base: Sequence[T],
+    subs: Sequence[int | None], src: Sequence[T], base: Sequence[T],
 ) -> list[T]:
   base_ = iter(base)
   out = [src[i] if i is not None else next(base_) for i in subs]
@@ -153,7 +155,7 @@ def subs_list(
   return out
 
 def subs_list2(
-    subs1: Sequence[Optional[int]], subs2: Sequence[Optional[int]],
+    subs1: Sequence[int | None], subs2: Sequence[int | None],
     src1: Sequence[T], src2: Sequence[T], base: Sequence[T],
 ) -> list[T]:
   assert len(subs1) == len(subs2)
@@ -374,8 +376,8 @@ def ceil_of_ratio(x, y):
 
 def wraps(
     wrapped: Callable,
-    namestr: Optional[str] = None,
-    docstr: Optional[str] = None,
+    namestr: str | None = None,
+    docstr: str | None = None,
     **kwargs,
 ) -> Callable[[T], T]:
   """
@@ -533,7 +535,7 @@ class OrderedSet(Generic[T]):
 
 class HashableWrapper:
   x: Any
-  hash: Optional[int]
+  hash: int | None
   def __init__(self, x):
     self.x = x
     try: self.hash = hash(x)

--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -19,6 +19,8 @@ and provide some automatic type mapping logic for converting between Numpy and
 XLA. There are also a handful of related casting utilities.
 """
 
+from __future__ import annotations
+
 from collections.abc import Mapping
 import dataclasses
 from functools import lru_cache, partial
@@ -32,7 +34,7 @@ import pkgutil
 import platform as py_platform
 import sys
 import threading
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable
 import warnings
 
 from jax._src import config
@@ -47,7 +49,7 @@ from jax._src.lib import xla_extension_version
 
 logger = logging.getLogger(__name__)
 
-jax_plugins: Optional[Any]
+jax_plugins: Any | None
 try:
   import jax_plugins  # type: ignore
 except ModuleNotFoundError:
@@ -100,7 +102,7 @@ _MOCK_NUM_GPUS = config.DEFINE_integer(
 # Backends
 
 
-def _get_tpu_library_path() -> Optional[str]:
+def _get_tpu_library_path() -> str | None:
   path_from_env = os.getenv("TPU_LIBRARY_PATH")
   if path_from_env is not None:
     return path_from_env
@@ -122,7 +124,7 @@ def _get_tpu_library_path() -> Optional[str]:
   return None
 
 
-def tpu_client_timer_callback(timer_secs: float) -> Optional[xla_client.Client]:
+def tpu_client_timer_callback(timer_secs: float) -> xla_client.Client | None:
   def _log_warning():
     warnings.warn(
       f'TPU backend initialization is taking more than {timer_secs} seconds. '
@@ -148,7 +150,7 @@ def tpu_client_timer_callback(timer_secs: float) -> Optional[xla_client.Client]:
 # example, there could be multiple backends that provide the same kind of
 # device.
 
-BackendFactory = Callable[[], Optional[xla_client.Client]]
+BackendFactory = Callable[[], xla_client.Client | None]
 
 @dataclasses.dataclass
 class BackendRegistration:
@@ -170,7 +172,7 @@ class BackendRegistration:
   experimental: bool = False
 
 _backend_factories: dict[str, BackendRegistration] = {}
-_default_backend: Optional[xla_client.Client] = None
+_default_backend: xla_client.Client | None = None
 _backends : dict[str, xla_client.Client] = {}
 _backend_errors : dict[str, str] = {}
 _backend_lock = threading.Lock()
@@ -357,7 +359,7 @@ def _get_pjrt_plugin_names_and_library_paths(
 def _get_pjrt_plugin_config(
     json_path: str,
 ) -> tuple[
-    str, Optional[Mapping[str, Union[str, int, list[int], float, bool]]]
+    str, Mapping[str, str | int | list[int] | float | bool] | None
 ]:
   """Gets PJRT plugin configuration from a json file.
 
@@ -454,8 +456,8 @@ def register_plugin(
     plugin_name: str,
     *,
     priority: int = 400,
-    library_path: Optional[str] = None,
-    options: Optional[Mapping[str, Union[str, int, list[int], float, bool]]] = None,
+    library_path: str | None = None,
+    options: Mapping[str, str | int | list[int] | float | bool] | None = None,
 ) -> None:
   """Registers a backend factory for the PJRT plugin.
 
@@ -752,7 +754,7 @@ def _init_backend(platform: str) -> xla_client.Client:
 
 
 def _get_backend_uncached(
-    platform: Union[None, str, xla_client.Client] = None
+    platform: None | str | xla_client.Client = None
 ) -> xla_client.Client:
   # TODO(mattjj,skyewm): remove this input polymorphism after we clean up how
   # 'backend' values are handled
@@ -779,13 +781,13 @@ def _get_backend_uncached(
 
 @lru_cache(maxsize=None)  # don't use util.memoize because there is no X64 dependence.
 def get_backend(
-    platform: Union[None, str, xla_client.Client] = None
+    platform: None | str | xla_client.Client = None
 ) -> xla_client.Client:
   return _get_backend_uncached(platform)
 
 
 def get_device_backend(
-    device: Optional[xla_client.Device] = None,
+    device: xla_client.Device | None = None,
 ) -> xla_client.Client:
   """Returns the Backend associated with `device`, or the default Backend."""
   if device is not None:
@@ -794,7 +796,7 @@ def get_device_backend(
 
 
 def device_count(
-    backend: Optional[Union[str, xla_client.Client]] = None
+    backend: str | xla_client.Client | None = None
 ) -> int:
   """Returns the total number of devices.
 
@@ -816,14 +818,14 @@ def device_count(
 
 
 def local_device_count(
-    backend: Optional[Union[str, xla_client.Client]] = None
+    backend: str | xla_client.Client | None = None
 ) -> int:
   """Returns the number of devices addressable by this process."""
   return int(get_backend(backend).local_device_count())
 
 
 def devices(
-    backend: Optional[Union[str, xla_client.Client]] = None
+    backend: str | xla_client.Client | None = None
 ) -> list[xla_client.Device]:
   """Returns a list of all devices for a given backend.
 
@@ -855,7 +857,7 @@ def default_backend() -> str:
   return get_backend(None).platform
 
 
-def backend_pjrt_c_api_version(platform=None) -> Optional[tuple[int, int]]:
+def backend_pjrt_c_api_version(platform=None) -> tuple[int, int] | None:
   """Returns the PJRT C API version of the backend.
 
   Returns None if the backend does not use PJRT C API.
@@ -869,9 +871,9 @@ def backend_pjrt_c_api_version(platform=None) -> Optional[tuple[int, int]]:
 
 
 @lru_cache
-def local_devices(process_index: Optional[int] = None,
-                  backend: Optional[Union[str, xla_client.Client]] = None,
-                  host_id: Optional[int] = None) -> list[xla_client.Device]:
+def local_devices(process_index: int | None = None,
+                  backend: str | xla_client.Client | None = None,
+                  host_id: int | None = None) -> list[xla_client.Device]:
   """Like :py:func:`jax.devices`, but only returns devices local to a given process.
 
   If ``process_index`` is ``None``, returns devices local to this process.
@@ -900,7 +902,7 @@ def local_devices(process_index: Optional[int] = None,
 
 
 def process_index(
-    backend: Optional[Union[str, xla_client.Client]] = None
+    backend: str | xla_client.Client | None = None
 ) -> int:
   """Returns the integer process index of this process.
 
@@ -919,7 +921,7 @@ def process_index(
 
 
 # TODO: remove this sometime after jax 0.2.13 is released
-def host_id(backend: Optional[Union[str, xla_client.Client]] = None) -> int:
+def host_id(backend: str | xla_client.Client | None = None) -> int:
   warnings.warn(
       "jax.host_id has been renamed to jax.process_index. This alias "
       "will eventually be removed; please update your code.")
@@ -928,14 +930,14 @@ def host_id(backend: Optional[Union[str, xla_client.Client]] = None) -> int:
 
 @lru_cache
 def process_count(
-    backend: Optional[Union[str, xla_client.Client]] = None
+    backend: str | xla_client.Client | None = None
 ) -> int:
   """Returns the number of JAX processes associated with the backend."""
   return max(d.process_index for d in devices(backend)) + 1
 
 
 # TODO: remove this sometime after jax 0.2.13 is released
-def host_count(backend: Optional[Union[str, xla_client.Client]] = None) -> int:
+def host_count(backend: str | xla_client.Client | None = None) -> int:
   warnings.warn(
       "jax.host_count has been renamed to jax.process_count. This alias "
       "will eventually be removed; please update your code.")
@@ -944,7 +946,7 @@ def host_count(backend: Optional[Union[str, xla_client.Client]] = None) -> int:
 
 # TODO: remove this sometime after jax 0.2.13 is released
 def host_ids(
-    backend: Optional[Union[str, xla_client.Client]] = None
+    backend: str | xla_client.Client | None = None
 ) -> list[int]:
   warnings.warn(
       "jax.host_ids has been deprecated; please use range(jax.process_count()) "

--- a/jax/collect_profile.py
+++ b/jax/collect_profile.py
@@ -11,13 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import argparse
 import gzip
 import os
 import pathlib
 import tempfile
-
-from typing import Optional
 
 # pytype: disable=import-error
 from jax._src import profiler as jax_profiler
@@ -65,7 +66,7 @@ parser.add_argument("--python_tracer_level", default=1,
                     help="Profiler Python tracer level", type=int)
 
 def collect_profile(port: int, duration_in_ms: int, host: str,
-                    log_dir: Optional[str], host_tracer_level: int,
+                    log_dir: str | None, host_tracer_level: int,
                     device_tracer_level: int, python_tracer_level: int,
                     no_perfetto_link: bool):
   options = profiler.ProfilerOptions(

--- a/jax/example_libraries/optimizers.py
+++ b/jax/example_libraries/optimizers.py
@@ -89,7 +89,9 @@ Example Usage:
 .. _Optax: https://github.com/deepmind/optax
 """
 
-from typing import Any, Callable, NamedTuple, Union
+from __future__ import annotations
+
+from typing import Any, Callable, NamedTuple
 
 from collections import namedtuple
 import functools
@@ -550,7 +552,7 @@ def piecewise_constant(boundaries: Any, values: Any):
     return values[jnp.sum(i > boundaries)]
   return schedule
 
-def make_schedule(scalar_or_schedule: Union[float, Schedule]) -> Schedule:
+def make_schedule(scalar_or_schedule: float | Schedule) -> Schedule:
   if callable(scalar_or_schedule):
     return scalar_or_schedule
   elif jnp.ndim(scalar_or_schedule) == 0:

--- a/jax/experimental/array_api/_manipulation_functions.py
+++ b/jax/experimental/array_api/_manipulation_functions.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import operator
 from typing import List, Optional, Tuple, Union
 
@@ -30,7 +32,7 @@ def broadcast_to(x: Array, /, shape: tuple[int]) -> Array:
   return jax.numpy.broadcast_to(x, shape=shape)
 
 
-def concat(arrays: Union[tuple[Array, ...], list[Array]], /, *, axis: Optional[int] = 0) -> Array:
+def concat(arrays: tuple[Array, ...] | list[Array], /, *, axis: int | None = 0) -> Array:
   """Joins a sequence of arrays along an existing axis."""
   dtype = _result_type(*arrays)
   if axis is None:
@@ -46,7 +48,7 @@ def expand_dims(x: Array, /, *, axis: int = 0) -> Array:
   return jax.numpy.expand_dims(x, axis=axis)
 
 
-def flip(x: Array, /, *, axis: Optional[Union[int, tuple[int, ...]]] = None) -> Array:
+def flip(x: Array, /, *, axis: int | tuple[int, ...] | None = None) -> Array:
   """Reverses the order of elements in an array along the given axis."""
   return jax.numpy.flip(x, axis=axis)
 
@@ -56,24 +58,24 @@ def permute_dims(x: Array, /, axes: tuple[int, ...]) -> Array:
   return jax.lax.transpose(x, axes)
 
 
-def reshape(x: Array, /, shape: tuple[int, ...], *, copy: Optional[bool] = None) -> Array:
+def reshape(x: Array, /, shape: tuple[int, ...], *, copy: bool | None = None) -> Array:
   """Reshapes an array without changing its data."""
   del copy  # unused
   return jax.numpy.reshape(x, shape)
 
 
-def roll(x: Array, /, shift: Union[int, tuple[int]], *, axis: Optional[Union[int, tuple[int, ...]]] = None) -> Array:
+def roll(x: Array, /, shift: int | tuple[int], *, axis: int | tuple[int, ...] | None = None) -> Array:
   """Rolls array elements along a specified axis."""
   return jax.numpy.roll(x, shift=shift, axis=axis)
 
 
-def squeeze(x: Array, /, axis: Union[int, tuple[int, ...]]) -> Array:
+def squeeze(x: Array, /, axis: int | tuple[int, ...]) -> Array:
   """Removes singleton dimensions (axes) from x."""
   dimensions = axis if isinstance(axis, tuple) else (axis,)
   return jax.lax.squeeze(x, dimensions=dimensions)
 
 
-def stack(arrays: Union[tuple[Array, ...], list[Array]], /, *, axis: int = 0) -> Array:
+def stack(arrays: tuple[Array, ...] | list[Array], /, *, axis: int = 0) -> Array:
   """Joins a sequence of arrays along a new axis."""
   dtype = _result_type(*arrays)
   return jax.numpy.stack(arrays, axis=axis, dtype=dtype)

--- a/jax/experimental/array_serialization/serialization.py
+++ b/jax/experimental/array_serialization/serialization.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Array serialization and deserialization."""
 
+from __future__ import annotations
+
 import abc
 import asyncio
 from collections.abc import Awaitable, Sequence
@@ -257,10 +259,10 @@ def estimate_read_memory_footprint(t: ts.TensorStore,
 
 async def async_deserialize(
     in_sharding: sharding_impls.XLACompatibleSharding,
-    tensorstore_spec: Union[ts.Spec, dict[str, Any]],
-    global_shape: Optional[Sequence[int]] = None,
+    tensorstore_spec: ts.Spec | dict[str, Any],
+    global_shape: Sequence[int] | None = None,
     dtype=None,
-    byte_limiter: Optional[_LimitInFlightBytes] = None,
+    byte_limiter: _LimitInFlightBytes | None = None,
     context=TS_CONTEXT,
     assume_metadata: bool = False,
 ):
@@ -310,8 +312,8 @@ async def async_deserialize(
 
 def run_deserialization(shardings: Sequence[sharding.Sharding],
                         tensorstore_specs: Sequence[dict[str, Any]],
-                        global_shapes: Optional[Sequence[array.Shape]] = None,
-                        dtypes: Optional[Sequence[typing.DTypeLike]] = None,
+                        global_shapes: Sequence[array.Shape] | None = None,
+                        dtypes: Sequence[typing.DTypeLike] | None = None,
                         concurrent_gb: int = 32):
   concurrent_bytes = concurrent_gb * 10**9
 
@@ -392,8 +394,8 @@ class GlobalAsyncCheckpointManagerBase(metaclass=abc.ABCMeta):
   @abc.abstractmethod
   def deserialize(self, shardings: Sequence[sharding.Sharding],
                   tensorstore_specs: Sequence[dict[str, Any]],
-                  global_shapes: Optional[Sequence[array.Shape]] = None,
-                  dtypes: Optional[Sequence[typing.DTypeLike]] = None):
+                  global_shapes: Sequence[array.Shape] | None = None,
+                  dtypes: Sequence[typing.DTypeLike] | None = None):
     """Deserializes GDAs from TensorStore."""
 
 
@@ -548,8 +550,8 @@ class GlobalAsyncCheckpointManager(AsyncManager, GlobalAsyncCheckpointManagerBas
 
   def deserialize(self, shardings: Sequence[sharding.Sharding],
                   tensorstore_specs: Sequence[dict[str, Any]],
-                  global_shapes: Optional[Sequence[array.Shape]] = None,
-                  dtypes: Optional[Sequence[typing.DTypeLike]] = None,
+                  global_shapes: Sequence[array.Shape] | None = None,
+                  dtypes: Sequence[typing.DTypeLike] | None = None,
                   concurrent_gb: int = 32):
     self.wait_until_finished()
     return run_deserialization(shardings, tensorstore_specs,
@@ -558,8 +560,8 @@ class GlobalAsyncCheckpointManager(AsyncManager, GlobalAsyncCheckpointManagerBas
   def deserialize_with_paths(
       self, shardings: Sequence[sharding.Sharding],
       paths: Sequence[str],
-      global_shapes: Optional[Sequence[array.Shape]] = None,
-      dtypes: Optional[Sequence[typing.DTypeLike]] = None,
+      global_shapes: Sequence[array.Shape] | None = None,
+      dtypes: Sequence[typing.DTypeLike] | None = None,
       concurrent_gb: int = 32):
     tspecs = jax.tree_map(get_tensorstore_spec, paths)
     return self.deserialize(shardings, tspecs, global_shapes, dtypes,

--- a/jax/experimental/custom_partitioning.py
+++ b/jax/experimental/custom_partitioning.py
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import jax
+from __future__ import annotations
+
 import inspect
 from typing import Optional
+import weakref
+
+import jax
 from jax._src import core
 from jax import tree_util
 from jax._src import linear_util as lu
@@ -31,8 +35,6 @@ from jax._src import custom_api_util
 from jax._src.lib import xla_client as xc
 from jax._src.api_util import flatten_fun_nokwargs
 from jax._src.api_util import argnums_partial
-
-import weakref
 
 
 def _resolve_kwargs(fun, args, kwargs):
@@ -494,7 +496,7 @@ def _custom_partitioning_lowering_rule(ctx: mlir.LoweringRuleContext, *values,
     return mlir.lower_fun(
         core.jaxpr_as_fun(call), multiple_results=True)(ctx, *values)
 
-  def to_mesh_pspec_sharding(hlo_sharding: Optional[xc.HloSharding], ndim):
+  def to_mesh_pspec_sharding(hlo_sharding: xc.HloSharding | None, ndim):
     if hlo_sharding is None:
       return hlo_sharding
     if mesh.empty or not decode_shardings:

--- a/jax/experimental/export/export.py
+++ b/jax/experimental/export/export.py
@@ -15,6 +15,8 @@
 
 """
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import copy
 import dataclasses
@@ -69,7 +71,7 @@ class DisabledSafetyCheck:
   _impl: str
 
   @classmethod
-  def platform(cls) -> "DisabledSafetyCheck":
+  def platform(cls) -> DisabledSafetyCheck:
     """Allows the execution platform to differ from the serialization platform.
 
     Has effect only on deserialization.
@@ -77,7 +79,7 @@ class DisabledSafetyCheck:
     return DisabledSafetyCheck("platform")
 
   @classmethod
-  def custom_call(cls, target_name: str) -> "DisabledSafetyCheck":
+  def custom_call(cls, target_name: str) -> DisabledSafetyCheck:
     """Allows the serialization of a call target not known to be stable.
 
     Has effect only on serialization.
@@ -87,7 +89,7 @@ class DisabledSafetyCheck:
     return DisabledSafetyCheck(f"custom_call:{target_name}")
 
   @classmethod
-  def shape_assertions(cls) -> "DisabledSafetyCheck":
+  def shape_assertions(cls) -> DisabledSafetyCheck:
     """Allows invocations with shapes that do not meet the constraints.
 
     Has effect on serialization (to suppress the generation of the assertions)
@@ -95,7 +97,7 @@ class DisabledSafetyCheck:
     """
     return DisabledSafetyCheck("shape_assertions")
 
-  def is_custom_call(self) -> Optional[str]:
+  def is_custom_call(self) -> str | None:
     """Returns the custom call target allowed by this directive."""
     m = re.match(r'custom_call:(.+)$', self._impl)
     return m.group(1) if m else None
@@ -123,10 +125,10 @@ _VERSION_START_SUPPORT_SHAPE_ASSERTIONS = 7
 _VERSION_START_SUPPORT_EFFECTS_WITH_REAL_TOKENS = 9
 
 # The values of input and output sharding from the lowering.
-LoweringSharding = Union[sharding.XLACompatibleSharding, pxla.UnspecifiedValue]
+LoweringSharding = sharding.XLACompatibleSharding | pxla.UnspecifiedValue
 
 # None means unspecified sharding
-Sharding = Optional[xla_client.HloSharding]
+Sharding = xla_client.HloSharding | None
 
 @dataclasses.dataclass(frozen=True)
 class Exported:
@@ -289,7 +291,7 @@ class Exported:
   module_kept_var_idx: tuple[int, ...]
   uses_shape_polymorphism: bool
 
-  _get_vjp: Optional[Callable[["Exported"], "Exported"]]
+  _get_vjp: Callable[[Exported], Exported] | None
 
   def mlir_module(self) -> ir.Module:
     return xla_client._xla.mlir.deserialize_portable_artifact(self.mlir_module_serialized)
@@ -299,7 +301,7 @@ class Exported:
     # do not want the entire serialized module to end up in locations.
     return f"Exported(fun_name={self.fun_name}, ...)"
 
-  def vjp(self) -> "Exported":
+  def vjp(self) -> Exported:
     """Gets the exported VJP.
 
     Returns None if not available, which can happen if the Exported has been
@@ -314,9 +316,9 @@ def default_lowering_platform() -> str:
   return xb.canonicalize_platform(jax.default_backend())
 
 def symbolic_shape(
-  shape_spec: Optional[str],
+  shape_spec: str | None,
   *,
-  like: Optional[Sequence[Optional[int]]] = None) -> Shape:
+  like: Sequence[int | None] | None = None) -> Shape:
   """Constructs a jax.ShapeDtypeStruct with polymorphic shapes.
 
   Args:
@@ -336,7 +338,7 @@ def symbolic_shape(
   """
   return shape_poly.symbolic_shape(shape_spec, like=like)
 
-def shape_and_dtype_jax_array(a) -> tuple[Sequence[Optional[int]], DType]:
+def shape_and_dtype_jax_array(a) -> tuple[Sequence[int | None], DType]:
   """Returns the shape and dtype of a jax.Array."""
   aval = core.raise_to_shaped(core.get_aval(a))
   return aval.shape, aval.dtype
@@ -402,7 +404,7 @@ def _keep_main_tokens(serialization_version: int) -> bool:
 
 def export(fun_jax: Callable,
            *,
-           lowering_platforms: Optional[Sequence[str]] = None,
+           lowering_platforms: Sequence[str] | None = None,
            disabled_checks: Sequence[DisabledSafetyCheck] = (),
            ) -> Callable[..., Exported]:
   """Exports native serialization for a JAX function.
@@ -963,10 +965,10 @@ def canonical_shardings(
     device_assignment: Sequence[jax.Device],
     in_shardings: Sequence[Sharding],
     out_shardings: Sequence[Sharding]
-    ) -> tuple[Union[pxla.UnspecifiedValue,
-                     Sequence[sharding.XLACompatibleSharding]],
-               Union[pxla.UnspecifiedValue,
-                     Sequence[sharding.XLACompatibleSharding]]]:
+    ) -> tuple[(pxla.UnspecifiedValue |
+                     Sequence[sharding.XLACompatibleSharding]),
+               (pxla.UnspecifiedValue |
+                     Sequence[sharding.XLACompatibleSharding])]:
   """Prepares canonical in_ and out_shardings for a pjit invocation.
 
   The pjit front-end is picky about what in- and out-shardings it accepts,
@@ -978,8 +980,8 @@ def canonical_shardings(
   """
   replicated_s = sharding.GSPMDSharding.get_replicated(device_assignment)
   def canonicalize(
-    ss: Sequence[Sharding]) -> Union[pxla.UnspecifiedValue,
-                                     Sequence[sharding.XLACompatibleSharding]]:
+    ss: Sequence[Sharding]) -> (pxla.UnspecifiedValue |
+                                     Sequence[sharding.XLACompatibleSharding]):
     if all(s is None for s in ss):
       return sharding_impls.UNSPECIFIED
     return tuple(
@@ -1106,7 +1108,7 @@ def _call_exported_abstract_eval(
   assert len(in_avals) == len(exported.in_avals)  # since the pytrees have the same structure
   # Check that the expected shapes match the actual ones
   for arg_idx, (exp_aval, actual_aval) in enumerate(zip(exported.in_avals, in_avals)):
-    def pp_arg_dim(dim_idx: Optional[int]) -> str:
+    def pp_arg_dim(dim_idx: int | None) -> str:
       return shape_poly.pretty_print_dimension_descriptor(exported.in_tree,
                                                           arg_idx, dim_idx)
     if len(exp_aval.shape) != len(actual_aval.shape):

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -494,6 +494,9 @@ Still to do:
   * Explore implementation with XLA CustomCall for CPU and GPU.
 
 """
+
+from __future__ import annotations
+
 import atexit
 from collections.abc import Sequence
 import functools
@@ -1699,7 +1702,7 @@ class _CallbackHandlerData:
   initialized: bool
   on_exit: bool
   lock: threading.Lock
-  last_callback_exception: Optional[tuple[Exception, str]]
+  last_callback_exception: tuple[Exception, str] | None
   clients: tuple[XlaLocalClient, ...]
   devices: tuple[XlaDevice, ...]
   consumer_registry: dict[Callable, int]
@@ -1818,7 +1821,7 @@ def _initialize_outfeed_receiver(
     _callback_handler_data.initialized = True
 
 
-def barrier_wait(logging_name: Optional[str] = None):
+def barrier_wait(logging_name: str | None = None):
   """Blocks the calling thread until all current outfeed is processed.
 
   Waits until all callbacks from computations already running on all devices

--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -22,6 +22,9 @@ For examples and details, see
 https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#calling-tensorflow-functions-from-jax.
 
 """
+
+from __future__ import annotations
+
 from collections.abc import Sequence
 import functools
 from typing import Any, Callable, Optional
@@ -271,7 +274,7 @@ def call_tf(
   return util.wraps(callable_tf)(make_call)
 
 
-def check_tf_result(idx: int, r_tf: TfVal, r_aval: Optional[core.ShapedArray]) -> TfVal:
+def check_tf_result(idx: int, r_tf: TfVal, r_aval: core.ShapedArray | None) -> TfVal:
   # Check that the TF function returns values of expected types. This
   # improves error reporting, preventing hard-to-diagnose errors downstream
   try:

--- a/jax/experimental/jax2tf/examples/mnist_lib.py
+++ b/jax/experimental/jax2tf/examples/mnist_lib.py
@@ -18,6 +18,9 @@ moving parts, at the expense of code size), and another using Flax.
 
 See README.md for how these are used.
 """
+
+from __future__ import annotations
+
 from collections.abc import Sequence
 import functools
 import logging
@@ -288,7 +291,7 @@ def plot_images(ds,
                 nr_rows: int,
                 nr_cols: int,
                 title: str,
-                inference_fn: Optional[Callable] = None):
+                inference_fn: Callable | None = None):
   """Plots a grid of images with their predictions.
 
   Params:

--- a/jax/experimental/jax2tf/examples/saved_model_lib.py
+++ b/jax/experimental/jax2tf/examples/saved_model_lib.py
@@ -24,6 +24,8 @@ control over what metadata is saved in the SavedModel. Please copy and
 customize this function as needed.
 """
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 from typing import Any, Callable, Optional, Union
 
@@ -37,11 +39,11 @@ def convert_and_save_model(
     model_dir: str,
     *,
     input_signatures: Sequence[tf.TensorSpec],
-    polymorphic_shapes: Optional[Union[str, jax2tf.PolyShape]] = None,
+    polymorphic_shapes: str | jax2tf.PolyShape | None = None,
     with_gradient: bool = False,
     enable_xla: bool = True,
     compile_model: bool = True,
-    saved_model_options: Optional[tf.saved_model.SaveOptions] = None):
+    saved_model_options: tf.saved_model.SaveOptions | None = None):
   """Convert a JAX function and saves a SavedModel.
 
   This is an example, we do not promise backwards compatibility for this code.

--- a/jax/experimental/jax2tf/impl_no_xla.py
+++ b/jax/experimental/jax2tf/impl_no_xla.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Workarounds for jax2tf transforms when XLA is not linked in."""
 
+from __future__ import annotations
+
 import builtins
 from collections.abc import Sequence
 import dataclasses
@@ -250,8 +252,8 @@ def _conv_general_dilated(
     lhs, rhs, *, window_strides, padding, lhs_dilation, rhs_dilation,
     dimension_numbers: lax.ConvDimensionNumbers, feature_group_count: int,
     batch_group_count: int,
-    precision: Optional[tuple[PrecisionType, PrecisionType]],
-    preferred_element_type: Optional[DType],
+    precision: tuple[PrecisionType, PrecisionType] | None,
+    preferred_element_type: DType | None,
     _in_avals: Sequence[core.ShapedArray], _out_aval: core.ShapedArray):
   """Implementation of lax.conv_general_dilated_p using XlaConv."""
   # In presence of shape polymorphism, lhs.shape and rhs.shape may contain
@@ -360,8 +362,8 @@ tf_impl_no_xla[lax.conv_general_dilated_p] = _conv_general_dilated
 
 
 def _dot_general(lhs, rhs, *, dimension_numbers,
-                 precision: Optional[tuple[PrecisionType, PrecisionType]],
-                 preferred_element_type: Optional[DType],
+                 precision: tuple[PrecisionType, PrecisionType] | None,
+                 preferred_element_type: DType | None,
                  _in_avals: Sequence[core.ShapedArray],
                  _out_aval: core.ShapedArray):
   """Implementation of lax.dot_general_p in terms of tf.linalg.einsum."""

--- a/jax/experimental/jax2tf/tests/back_compat_tf_test.py
+++ b/jax/experimental/jax2tf/tests/back_compat_tf_test.py
@@ -17,6 +17,8 @@ See the back_compat_test_util module docstring for how to setup and update
 these tests.
 """
 
+from __future__ import annotations
+
 import base64
 from collections.abc import Sequence
 import io
@@ -82,7 +84,7 @@ class CompatTensoflowTest(bctu.CompatTestBase):
       self,
       func: Callable,
       data: bctu.CompatTestData,
-      polymorphic_shapes: Optional[Sequence[str]] = None,
+      polymorphic_shapes: Sequence[str] | None = None,
       allow_unstable_custom_call_targets: Sequence[str] = (),
   ):
     # We serialize as a tf.Graph
@@ -125,7 +127,7 @@ class CompatTensoflowTest(bctu.CompatTestBase):
   def run_serialized(
       self,
       data: bctu.CompatTestData,
-      polymorphic_shapes: Optional[Sequence[str]] = None,
+      polymorphic_shapes: Sequence[str] | None = None,
   ):
     root_dir = self.create_tempdir()
     deserialize_directory(data.mlir_module_serialized, root_dir)

--- a/jax/experimental/jax2tf/tests/cross_compilation_check.py
+++ b/jax/experimental/jax2tf/tests/cross_compilation_check.py
@@ -23,6 +23,9 @@ If a saved file already exists produced on a different backend, then compare the
 currently saved file with the saved one.
 
 """
+
+from __future__ import annotations
+
 from collections.abc import Sequence
 import contextlib
 import dataclasses
@@ -173,7 +176,7 @@ def write_and_check_harness(harness: primitive_harness.Harness,
 def write_and_check_harnesses(io: Io,
                               save_directory: str,
                               *,
-                              filter_harness: Optional[Callable[[str], bool]] = None,
+                              filter_harness: Callable[[str], bool] | None = None,
                               for_platforms: Sequence[str] = ("cpu", "tpu"),
                               verbose = False):
   logging.info("Writing and checking harnesses at %s", save_directory)

--- a/jax/experimental/jax2tf/tests/flax_models/bilstm_classifier.py
+++ b/jax/experimental/jax2tf/tests/flax_models/bilstm_classifier.py
@@ -16,6 +16,8 @@
 https://github.com/google/flax/tree/main/examples/sst2
 """
 
+from __future__ import annotations
+
 import functools
 from typing import Any, Callable, Optional
 
@@ -88,10 +90,10 @@ class WordDropout(nn.Module):
   """
   dropout_rate: float
   unk_idx: int
-  deterministic: Optional[bool] = None
+  deterministic: bool | None = None
 
   @nn.compact
-  def __call__(self, inputs: Array, deterministic: Optional[bool] = None):
+  def __call__(self, inputs: Array, deterministic: bool | None = None):
     deterministic = nn.module.merge_param(
         'deterministic', self.deterministic, deterministic)
     if deterministic or self.dropout_rate == 0.:
@@ -120,8 +122,8 @@ class Embedder(nn.Module):
   frozen: bool = False
   dropout_rate: float = 0.
   word_dropout_rate: float = 0.
-  unk_idx: Optional[int] = None
-  deterministic: Optional[bool] = None
+  unk_idx: int | None = None
+  deterministic: bool | None = None
   dtype: jnp.dtype = jnp.dtype('float32')
 
   def setup(self):
@@ -137,7 +139,7 @@ class Embedder(nn.Module):
         unk_idx=self.unk_idx)
 
   def __call__(self, inputs: Array,
-               deterministic: Optional[bool] = None) -> Array:
+               deterministic: bool | None = None) -> Array:
     """Embeds the input sequences and applies word dropout and dropout.
 
     Args:
@@ -222,14 +224,14 @@ class MLP(nn.Module):
   activation: Callable[..., Any] = nn.tanh
   dropout_rate: float = 0.0
   output_bias: bool = False
-  deterministic: Optional[bool] = None
+  deterministic: bool | None = None
 
   def setup(self):
     self.intermediate_layer = nn.Dense(self.hidden_size)
     self.output_layer = nn.Dense(self.output_size, use_bias=self.output_bias)
     self.dropout_layer = nn.Dropout(rate=self.dropout_rate)
 
-  def __call__(self, inputs: Array, deterministic: Optional[bool] = None):
+  def __call__(self, inputs: Array, deterministic: bool | None = None):
     """Applies the MLP to the last dimension of the inputs.
 
     Args:
@@ -306,7 +308,7 @@ class AttentionClassifier(nn.Module):
   hidden_size: int
   output_size: int
   dropout_rate: float = 0.
-  deterministic: Optional[bool] = None
+  deterministic: bool | None = None
 
   def setup(self):
     self.dropout_layer = nn.Dropout(rate=self.dropout_rate)
@@ -319,7 +321,7 @@ class AttentionClassifier(nn.Module):
         dropout_rate=self.dropout_rate)
 
   def __call__(self, encoded_inputs: Array, lengths: Array,
-               deterministic: Optional[bool] = None) -> Array:
+               deterministic: bool | None = None) -> Array:
     """Applies model to the encoded inputs.
 
     Args:
@@ -362,7 +364,7 @@ class TextClassifier(nn.Module):
   dropout_rate: float
   word_dropout_rate: float
   unk_idx: int = 1
-  deterministic: Optional[bool] = None
+  deterministic: bool | None = None
 
   def setup(self):
     self.embedder = Embedder(
@@ -378,14 +380,14 @@ class TextClassifier(nn.Module):
         dropout_rate=self.dropout_rate)
 
   def embed_token_ids(self, token_ids: Array,
-                      deterministic: Optional[bool] = None) -> Array:
+                      deterministic: bool | None = None) -> Array:
     deterministic = nn.module.merge_param(
         'deterministic', self.deterministic, deterministic)
     return self.embedder(token_ids, deterministic=deterministic)
 
   def logits_from_embedded_inputs(
       self, embedded_inputs: Array, lengths: Array,
-      deterministic: Optional[bool] = None) -> Array:
+      deterministic: bool | None = None) -> Array:
     deterministic = nn.module.merge_param(
         'deterministic', self.deterministic, deterministic)
     encoded_inputs = self.encoder(embedded_inputs, lengths)
@@ -393,7 +395,7 @@ class TextClassifier(nn.Module):
         encoded_inputs, lengths, deterministic=deterministic)
 
   def __call__(self, token_ids: Array, lengths: Array,
-               deterministic: Optional[bool] = None) -> Array:
+               deterministic: bool | None = None) -> Array:
     """Embeds the token IDs, encodes them, and classifies with attention."""
     embedded_inputs = self.embed_token_ids(
         token_ids, deterministic=deterministic)

--- a/jax/experimental/jax2tf/tests/flax_models/transformer_lm1b.py
+++ b/jax/experimental/jax2tf/tests/flax_models/transformer_lm1b.py
@@ -22,6 +22,8 @@ https://github.com/google/flax/tree/main/examples/lm1b
 # pytype: disable=wrong-keyword-args
 # pytype: disable=attribute-error
 
+from __future__ import annotations
+
 from typing import Callable, Any, Optional
 
 from flax import linen as nn
@@ -50,7 +52,7 @@ class TransformerConfig:
   decode: bool = False
   kernel_init: Callable = nn.initializers.xavier_uniform()
   bias_init: Callable = nn.initializers.normal(stddev=1e-6)
-  posemb_init: Optional[Callable] = None
+  posemb_init: Callable | None = None
 
 
 def shift_right(x, axis=1):
@@ -173,7 +175,7 @@ class MlpBlock(nn.Module):
     out_dim: optionally specify out dimension.
   """
   config: TransformerConfig
-  out_dim: Optional[int] = None
+  out_dim: int | None = None
 
   @nn.compact
   def __call__(self, inputs):

--- a/jax/experimental/jax2tf/tests/flax_models/transformer_nlp_seq.py
+++ b/jax/experimental/jax2tf/tests/flax_models/transformer_nlp_seq.py
@@ -16,6 +16,8 @@
 https://github.com/google/flax/tree/main/examples/lm1b
 """
 
+from __future__ import annotations
+
 from typing import Callable, Any, Optional
 
 from flax import linen as nn
@@ -40,7 +42,7 @@ class TransformerConfig:
   attention_dropout_rate: float = 0.3
   kernel_init: Callable = nn.initializers.xavier_uniform()
   bias_init: Callable = nn.initializers.normal(stddev=1e-6)
-  posemb_init: Optional[Callable] = None
+  posemb_init: Callable | None = None
 
 
 def sinusoidal_init(max_len=2048):
@@ -117,7 +119,7 @@ class MlpBlock(nn.Module):
     out_dim: optionally specify out dimension.
   """
   config: TransformerConfig
-  out_dim: Optional[int] = None
+  out_dim: int | None = None
 
   @nn.compact
   def __call__(self, inputs, deterministic=True):

--- a/jax/experimental/jax2tf/tests/flax_models/transformer_wmt.py
+++ b/jax/experimental/jax2tf/tests/flax_models/transformer_wmt.py
@@ -22,6 +22,8 @@ https://github.com/google/flax/tree/main/examples/wmt
 # pytype: disable=wrong-keyword-args
 # pytype: disable=attribute-error
 
+from __future__ import annotations
+
 from typing import Callable, Any, Optional
 
 from flax import linen as nn
@@ -51,7 +53,7 @@ class TransformerConfig:
   decode: bool = False
   kernel_init: Callable = nn.initializers.xavier_uniform()
   bias_init: Callable = nn.initializers.normal(stddev=1e-6)
-  posemb_init: Optional[Callable] = None
+  posemb_init: Callable | None = None
 
 
 def shift_right(x, axis=1):
@@ -164,7 +166,7 @@ class MlpBlock(nn.Module):
     out_dim: optionally specify out dimension.
   """
   config: TransformerConfig
-  out_dim: Optional[int] = None
+  out_dim: int | None = None
 
   @nn.compact
   def __call__(self, inputs):

--- a/jax/experimental/jax2tf/tests/jax2tf_limitations.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_limitations.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """See primitives_test docstring for how the Jax2TfLimitations are used."""
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import itertools
 from typing import Any, Callable, Optional, Union
@@ -43,7 +45,7 @@ class Jax2TfLimitation(test_harnesses.Limitation):
       self,
       description: str,
       *,
-      devices: Union[str, Sequence[str]] = ("cpu", "gpu", "tpu"),
+      devices: str | Sequence[str] = ("cpu", "gpu", "tpu"),
       dtypes: Sequence[DType] = (),
       enabled: bool = True,
       # jax2tf specific
@@ -52,7 +54,7 @@ class Jax2TfLimitation(test_harnesses.Limitation):
       skip_tf_run=False,
       expect_tf_error: bool = True,
       skip_comparison=False,
-      custom_assert: Optional[Callable] = None,
+      custom_assert: Callable | None = None,
       tol=None):
     """See the test_harnesses.Limitation common arguments.
 
@@ -92,8 +94,8 @@ class Jax2TfLimitation(test_harnesses.Limitation):
     self.skip_comparison = skip_comparison
 
   def get_max_tolerance_limitation(
-      self, limitations: Sequence["Jax2TfLimitation"]
-  ) -> Optional["Jax2TfLimitation"]:
+      self, limitations: Sequence[Jax2TfLimitation]
+  ) -> Jax2TfLimitation | None:
     """Pick the tolerance limitation that establishes the maximum tolerance."""
     # TODO: it would be best if the limitations with tolerance are mutually exclusive
     # and we don't have to compute the maximum
@@ -108,9 +110,9 @@ class Jax2TfLimitation(test_harnesses.Limitation):
 
   def filter(  # type: ignore[override]
       self,
-      dtype: Optional[DType] = None,
-      device: Optional[str] = None,
-      mode: Optional[str] = None) -> bool:
+      dtype: DType | None = None,
+      device: str | None = None,
+      mode: str | None = None) -> bool:
     """Checks if this limitation is enabled for dtype and device and mode."""
     native_serialization_mask = (
         Jax2TfLimitation.FOR_NATIVE
@@ -122,7 +124,7 @@ class Jax2TfLimitation(test_harnesses.Limitation):
 
   @classmethod
   def limitations_for_harness(
-      cls, harness: test_harnesses.Harness) -> Sequence["Jax2TfLimitation"]:
+      cls, harness: test_harnesses.Harness) -> Sequence[Jax2TfLimitation]:
     group_method = getattr(cls, harness.group_name, None)
     if harness.group_name in cls.harness_groups_no_limitations:
       assert group_method is None, (

--- a/jax/experimental/jax2tf/tests/model_harness.py
+++ b/jax/experimental/jax2tf/tests/model_harness.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """All the models to convert."""
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import dataclasses
 import functools
@@ -46,8 +48,8 @@ class ModelHarness:
   variables: dict[str, Any]
   inputs: Sequence[np.ndarray]
   rtol: float = 1e-4
-  polymorphic_shapes: Optional[Sequence[Union[str, None]]] = None
-  tensor_spec: Optional[Sequence[tf.TensorSpec]] = None
+  polymorphic_shapes: Sequence[str | None] | None = None
+  tensor_spec: Sequence[tf.TensorSpec] | None = None
 
   def __post_init__(self):
     # When providing polymorphic shapes, tensor_spec should be provided as well.

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import contextlib
 import dataclasses
-import functools
 import re
 import os
 from typing import Any, Callable, Optional
@@ -91,8 +92,8 @@ def SaveAndLoadModel(model: tf.Module,
   return restored_model
 
 def SaveAndLoadFunction(f_tf: Callable, *,
-                        input_signature: Optional[Sequence[tf.TensorSpec]] = None,
-                        input_args: Optional[Sequence[Any]] = None,
+                        input_signature: Sequence[tf.TensorSpec] | None = None,
+                        input_args: Sequence[Any] | None = None,
                         variables: Sequence[tf.Variable] = (),
                         save_gradients=True) -> tuple[Callable, tf.train.Checkpoint]:
   # Roundtrip through saved model on disk. Return the Checkpoint also
@@ -364,7 +365,7 @@ class JaxToTfTestCase(jtu.JaxTestCase):
     return result_jax, result_tf
 
   def TransformConvertAndCompare(self, func: Callable, arg,
-                                 transform: Optional[str]):
+                                 transform: str | None):
     """Like ConvertAndCompare but first applies a transformation.
 
     `func` must be a function from one argument to one result. `arg` is

--- a/jax/experimental/mesh_utils.py
+++ b/jax/experimental/mesh_utils.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Utils for building a device mesh."""
 
+from __future__ import annotations
+
 import collections
 from collections.abc import Sequence
 import itertools
@@ -95,7 +97,7 @@ def _tpu_v2_v3_create_device_mesh(
 # return None; in that case, it will fall back to using the default logic.
 device_kind_handler_dict: dict[
     str,
-    Callable[..., Optional[np.ndarray]],
+    Callable[..., np.ndarray | None],
 ] = {
     _TPU_V2: _tpu_v2_v3_create_device_mesh,
     _TPU_V3: _tpu_v2_v3_create_device_mesh,
@@ -269,7 +271,7 @@ def _transpose_trick(physical_mesh: np.ndarray,
 
 def create_device_mesh(
     mesh_shape: Sequence[int],
-    devices: Optional[Sequence[Any]] = None, *,
+    devices: Sequence[Any] | None = None, *,
     contiguous_submeshes: bool = False) -> np.ndarray:
   """Creates a performant device mesh for jax.sharding.Mesh.
 
@@ -323,7 +325,7 @@ def create_device_mesh(
 
 def create_hybrid_device_mesh(mesh_shape: Sequence[int],
                               dcn_mesh_shape: Sequence[int],
-                              devices: Optional[Sequence[Any]] = None, *,
+                              devices: Sequence[Any] | None = None, *,
                               process_is_granule: bool = False) -> np.ndarray:
   """Creates a device mesh for hybrid (e.g., ICI and DCN) parallelism.
 

--- a/jax/experimental/multihost_utils.py
+++ b/jax/experimental/multihost_utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Utilities for synchronizing and communication across multiple hosts."""
 
+from __future__ import annotations
+
 from functools import partial, lru_cache
 from typing import Optional
 import zlib
@@ -41,7 +43,7 @@ def _psum(x: Any) -> Any:
   return jax.tree_map(partial(jnp.sum, axis=0), x)
 
 
-def broadcast_one_to_all(in_tree: Any, is_source: Optional[bool] = None) -> Any:
+def broadcast_one_to_all(in_tree: Any, is_source: bool | None = None) -> Any:
   """Broadcast data from a source host (host 0 by default) to all other hosts.
 
   Args:

--- a/jax/experimental/pallas/ops/layer_norm.py
+++ b/jax/experimental/pallas/ops/layer_norm.py
@@ -14,6 +14,8 @@
 
 """Module containing fused layer norm forward and backward pass."""
 
+from __future__ import annotations
+
 import functools
 
 from typing import Optional
@@ -69,8 +71,8 @@ def layer_norm_forward_kernel(
 
 def layer_norm_forward(
     x, weight, bias,
-    num_warps: Optional[int] = None,
-    num_stages: Optional[int] = 3,
+    num_warps: int | None = None,
+    num_stages: int | None = 3,
     eps: float = 1e-5,
     backward_pass_impl: str = 'triton',
     interpret: bool = False):
@@ -179,8 +181,8 @@ def layer_norm_backward_kernel_dw_db(
 
 
 def layer_norm_backward(
-    num_warps: Optional[int],
-    num_stages: Optional[int],
+    num_warps: int | None,
+    num_stages: int | None,
     eps: float,
     backward_pass_impl: str,
     interpret: bool,
@@ -246,8 +248,8 @@ def layer_norm_backward(
                                              "interpret"])
 def layer_norm(
     x, weight, bias,
-    num_warps: Optional[int] = None,
-    num_stages: Optional[int] = 3,
+    num_warps: int | None = None,
+    num_stages: int | None = 3,
     eps: float = 1e-5,
     backward_pass_impl: str = 'triton',
     interpret: bool = False):

--- a/jax/experimental/pallas/ops/rms_norm.py
+++ b/jax/experimental/pallas/ops/rms_norm.py
@@ -14,6 +14,8 @@
 
 """Module containing rms forward and backward pass."""
 
+from __future__ import annotations
+
 import functools
 
 from typing import Optional
@@ -58,8 +60,8 @@ def rms_norm_forward_kernel(
 
 def rms_norm_forward(
     x, weight, bias,
-    num_warps: Optional[int] = None,
-    num_stages: Optional[int] = 3,
+    num_warps: int | None = None,
+    num_stages: int | None = 3,
     eps: float = 1e-5,
     backward_pass_impl: str = 'triton',
     interpret: bool = False):
@@ -161,8 +163,8 @@ def rms_norm_backward_kernel_dw_db(
 
 
 def rms_norm_backward(
-    num_warps: Optional[int],
-    num_stages: Optional[int],
+    num_warps: int | None,
+    num_stages: int | None,
     eps: float,
     backward_pass_impl: str,
     interpret: bool,
@@ -227,8 +229,8 @@ def rms_norm_backward(
                                              "interpret"])
 def rms_norm(
     x, weight, bias,
-    num_warps: Optional[int] = None,
-    num_stages: Optional[int] = 3,
+    num_warps: int | None = None,
+    num_stages: int | None = 3,
     eps: float = 1e-5,
     backward_pass_impl: str = 'triton',
     interpret: bool = False):

--- a/jax/experimental/serialize_executable.py
+++ b/jax/experimental/serialize_executable.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Pickling support for precompiled binaries."""
 
+from __future__ import annotations
+
 import pickle
 import io
 from typing import Optional, Union
@@ -42,7 +44,7 @@ def serialize(compiled: jax.stages.Compiled):
 def deserialize_and_load(serialized,
                          in_tree,
                          out_tree,
-                         backend: Optional[Union[str, xc.Client]] = None):
+                         backend: str | xc.Client | None = None):
   """Constructs a jax.stages.Compiled from a serialized executable."""
 
   if backend is None or isinstance(backend, str):

--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -332,7 +332,7 @@ def _iter_paths(tree: PyTreeDef, specs: Specs, fails: list[T | NoFail]
 # Primitive
 
 JaxType = Any
-MaybeTracer = Union[JaxType, Tracer]
+MaybeTracer = JaxType | Tracer
 
 class ShardMapPrimitive(core.Primitive):
   multiple_results = True
@@ -456,7 +456,7 @@ def _unshard_aval(mesh: Mesh, names: AxisNames, aval: core.AbstractValue
 
 # Type-checking
 
-RepType = Optional[set[AxisName]]
+RepType = set[AxisName] | None
 
 def _shard_map_typecheck(_, *in_atoms, jaxpr, mesh, in_names, out_names,
                          check_rep, rewrite, auto):

--- a/jax/experimental/sparse/ad.py
+++ b/jax/experimental/sparse/ad.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import itertools
 from typing import Any, Callable, Union
@@ -29,7 +31,7 @@ from jax.experimental.sparse._base import JAXSparse
 is_sparse = lambda x: isinstance(x, JAXSparse)
 
 
-def flatten_fun_for_sparse_ad(fun, argnums: Union[int, tuple[int]], args: tuple[Any]):
+def flatten_fun_for_sparse_ad(fun, argnums: int | tuple[int], args: tuple[Any]):
   argnums_tup = _ensure_index_tuple(argnums)
   assert all(0 <= argnum < len(args) for argnum in argnums_tup)
 
@@ -71,7 +73,7 @@ def flatten_fun_for_sparse_ad(fun, argnums: Union[int, tuple[int]], args: tuple[
   return fun_flat, argnums_flat, args_flat, postprocess_gradients
 
 
-def value_and_grad(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
+def value_and_grad(fun: Callable, argnums: int | Sequence[int] = 0,
                    has_aux=False, **kwargs) -> Callable[..., tuple[Any, Any]]:
   """Sparse-aware version of :func:`jax.value_and_grad`
 
@@ -99,7 +101,7 @@ def value_and_grad(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
   return value_and_grad_fun
 
 
-def grad(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
+def grad(fun: Callable, argnums: int | Sequence[int] = 0,
          has_aux=False, **kwargs) -> Callable:
   """Sparse-aware version of :func:`jax.grad`
 
@@ -129,7 +131,7 @@ def grad(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
   return grad_fun
 
 
-def jacfwd(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
+def jacfwd(fun: Callable, argnums: int | Sequence[int] = 0,
            has_aux: bool = False, **kwargs) -> Callable:
   """Sparse-aware version of :func:`jax.jacfwd`
 
@@ -152,7 +154,7 @@ def jacfwd(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
   return jacfwd_fun
 
 
-def jacrev(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
+def jacrev(fun: Callable, argnums: int | Sequence[int] = 0,
            has_aux: bool = False, **kwargs) -> Callable:
   """Sparse-aware version of :func:`jax.jacrev`
 

--- a/jax/experimental/sparse/api.py
+++ b/jax/experimental/sparse/api.py
@@ -29,6 +29,9 @@ computed efficiently via cusparse/hipsparse.
 Further down are some examples of potential high-level wrappers for sparse objects.
 (API should be considered unstable and subject to change).
 """
+
+from __future__ import annotations
+
 from functools import partial
 import operator
 from typing import Optional, Union
@@ -56,7 +59,7 @@ from jax._src.typing import Array, DTypeLike, Shape
 todense_p = core.Primitive('todense')
 todense_p.multiple_results = False
 
-def todense(arr: Union[JAXSparse, Array]) -> Array:
+def todense(arr: JAXSparse | Array) -> Array:
   """Convert input to a dense matrix. If input is already dense, pass through."""
   bufs, tree = tree_util.tree_flatten(arr)
   return todense_p.bind(*bufs, tree=tree)
@@ -113,7 +116,7 @@ mlir.register_lowering(todense_p, mlir.lower_fun(
     _todense_impl, multiple_results=False))
 
 
-def empty(shape: Shape, dtype: Optional[DTypeLike]=None, index_dtype: DTypeLike = 'int32',
+def empty(shape: Shape, dtype: DTypeLike | None=None, index_dtype: DTypeLike = 'int32',
           sparse_format: str = 'bcoo', **kwds) -> JAXSparse:
   """Create an empty sparse array.
 
@@ -134,7 +137,7 @@ def empty(shape: Shape, dtype: Optional[DTypeLike]=None, index_dtype: DTypeLike 
   return cls._empty(shape, dtype=dtype, index_dtype=index_dtype, **kwds)
 
 
-def eye(N: int, M: Optional[int] = None, k: int = 0, dtype: Optional[DTypeLike] = None,
+def eye(N: int, M: int | None = None, k: int = 0, dtype: DTypeLike | None = None,
         index_dtype: DTypeLike = 'int32', sparse_format: str = 'bcoo', **kwds) -> JAXSparse:
   """Create 2D sparse identity matrix.
 

--- a/jax/experimental/sparse/linalg.py
+++ b/jax/experimental/sparse/linalg.py
@@ -14,6 +14,8 @@
 
 """Sparse linear algebra routines."""
 
+from __future__ import annotations
+
 from typing import Union, Callable
 import functools
 
@@ -33,10 +35,10 @@ from scipy.sparse import csr_matrix, linalg
 
 
 def lobpcg_standard(
-    A: Union[jax.Array, Callable[[jax.Array], jax.Array]],
+    A: jax.Array | Callable[[jax.Array], jax.Array],
     X: jax.Array,
     m: int = 100,
-    tol: Union[jax.Array, float, None] = None):
+    tol: jax.Array | float | None = None):
   """Compute the top-k standard eigenvalues using the LOBPCG routine.
 
   LOBPCG [1] stands for Locally Optimal Block Preconditioned Conjugate Gradient.
@@ -106,7 +108,7 @@ def _lobpcg_standard_matrix(
     A: jax.Array,
     X: jax.Array,
     m: int,
-    tol: Union[jax.Array, float, None],
+    tol: jax.Array | float | None,
     debug: bool = False):
   """Computes lobpcg_standard(), possibly with debug diagnostics."""
   return _lobpcg_standard_callable(
@@ -117,7 +119,7 @@ def _lobpcg_standard_callable(
     A: Callable[[jax.Array], jax.Array],
     X: jax.Array,
     m: int,
-    tol: Union[jax.Array, float, None],
+    tol: jax.Array | float | None,
     debug: bool = False):
   """Supports generic lobpcg_standard() callable interface."""
 

--- a/jax/experimental/sparse/test_util.py
+++ b/jax/experimental/sparse/test_util.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Sparse test utilities."""
 
+from __future__ import annotations
+
 from collections.abc import Iterable, Iterator, Sequence
 import functools
 import itertools
@@ -145,8 +147,8 @@ class SparseTestCase(jtu.JaxTestCase):
 
 def _rand_sparse(shape: Sequence[int], dtype: DTypeLike, *,
                  rng: np.random.RandomState, rand_method: Callable[..., Any],
-                 nse: Union[int, float], n_batch: int, n_dense: int,
-                 sparse_format: str) -> Union[sparse.BCOO, sparse.BCSR]:
+                 nse: int | float, n_batch: int, n_dense: int,
+                 sparse_format: str) -> sparse.BCOO | sparse.BCSR:
   if sparse_format not in ['bcoo', 'bcsr']:
     raise ValueError(f"Sparse format {sparse_format} not supported.")
 
@@ -186,7 +188,7 @@ def _rand_sparse(shape: Sequence[int], dtype: DTypeLike, *,
 
 def rand_bcoo(rng: np.random.RandomState,
               rand_method: Callable[..., Any]=jtu.rand_default,
-              nse: Union[int, float]=0.5, n_batch: int=0, n_dense: int=0):
+              nse: int | float=0.5, n_batch: int=0, n_dense: int=0):
   """Generates a random BCOO array."""
   return functools.partial(_rand_sparse, rng=rng, rand_method=rand_method,
                            nse=nse, n_batch=n_batch, n_dense=n_dense,
@@ -194,7 +196,7 @@ def rand_bcoo(rng: np.random.RandomState,
 
 def rand_bcsr(rng: np.random.RandomState,
               rand_method: Callable[..., Any]=jtu.rand_default,
-              nse: Union[int, float]=0.5, n_batch: int=0, n_dense: int=0):
+              nse: int | float=0.5, n_batch: int=0, n_dense: int=0):
   """Generates a random BCSR array."""
   return functools.partial(_rand_sparse, rng=rng, rand_method=rand_method,
                            nse=nse, n_batch=n_batch, n_dense=n_dense,

--- a/jax/experimental/topologies.py
+++ b/jax/experimental/topologies.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import abc
 from collections.abc import Sequence
 from typing import Optional
@@ -34,7 +36,7 @@ def get_attached_topology(platform=None) -> TopologyDescription:
 
 
 def get_topology_desc(
-    topology_name: str = "", platform: Optional[str] = None, **kwargs
+    topology_name: str = "", platform: str | None = None, **kwargs
 ) -> TopologyDescription:
   if platform == "tpu" or platform is None:
     return TopologyDescription(

--- a/jaxlib/gpu_prng.py
+++ b/jaxlib/gpu_prng.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 import functools
 from functools import partial
 import importlib
 import itertools
 import operator
-from typing import Optional, Union
 
 import jaxlib.mlir.ir as ir
 
@@ -51,8 +51,8 @@ except ImportError:
 _prod = lambda xs: functools.reduce(operator.mul, xs, 1)
 
 def _threefry2x32_lowering(prng, platform, keys, data,
-                           length: Optional[Union[int, ir.Value]] = None,
-                           output_shape: Optional[ir.Value] = None):
+                           length: int | ir.Value | None = None,
+                           output_shape: ir.Value | None = None):
   """ThreeFry2x32 kernel for GPU.
 
   In presence of dynamic shapes, `length` is an `ir.Value` and `output_shape`

--- a/jaxlib/hlo_helpers.py
+++ b/jaxlib/hlo_helpers.py
@@ -14,9 +14,11 @@
 
 """A small library of helpers for use in jaxlib to build MLIR operations."""
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 from functools import partial
-from typing import Callable, Optional, Union
+from typing import Callable
 
 import jaxlib.mlir.ir as ir
 import jaxlib.mlir.dialects.stablehlo as hlo
@@ -53,12 +55,12 @@ def shape_dtype_to_ir_type(shape: Sequence[int], dtype) -> ir.Type:
 # representing 1D int32 tensors. If all the shapes are static we can use
 # result_shapes=None. We first construct for each result a pair with the shape
 # and element type, the shape containing either integer or ir.Value.
-DimensionSize = Union[int, ir.Value]  # an ir.Value if not static dimension
+DimensionSize = int | ir.Value  # an ir.Value if not static dimension
 ShapeTypePair = tuple[Sequence[DimensionSize], ir.Type]
 
 def mk_result_types_and_shapes(
     shape_type_pairs: Sequence[ShapeTypePair]
-) -> tuple[list[ir.Type], Optional[list[ir.Value]]]:
+) -> tuple[list[ir.Type], list[ir.Value] | None]:
   result_types: list[ir.Type] = []
   result_shapes: list[ir.Value] = []
   has_dynamic_shapes = any(
@@ -76,7 +78,7 @@ def mk_result_types_and_shapes(
           result_shapes if has_dynamic_shapes else None)
 
 # TODO(necula): share this with mlir.shape_tensor
-def shape_tensor(sizes: Sequence[Union[int, ir.Value]]) -> ir.Value:
+def shape_tensor(sizes: Sequence[int | ir.Value]) -> ir.Value:
   int1d = shape_dtype_to_ir_type((1,), np.int32)
   i32_type = shape_dtype_to_ir_type((), np.int32)
   def dim_to_i32x1(d):
@@ -136,15 +138,15 @@ def custom_call(
     *,
     result_types: Sequence[ir.Type],
     operands: Sequence[ir.Value],
-    backend_config: Union[str, bytes, dict[str, ir.Attribute]] = "",
+    backend_config: str | bytes | dict[str, ir.Attribute] = "",
     has_side_effect: bool = False,
-    result_shapes: Optional[Sequence[ir.Value]] = None,
+    result_shapes: Sequence[ir.Value] | None = None,
     called_computations: Sequence[str] = (),
     api_version: int = 2,
-    operand_output_aliases: Optional[dict[int, int]] = None,
-    operand_layouts: Optional[Sequence[Sequence[int]]] = None,
-    result_layouts: Optional[Sequence[Sequence[int]]] = None,
-    extra_attributes: Optional[dict[str, ir.Attribute]] = None,
+    operand_output_aliases: dict[int, int] | None = None,
+    operand_layouts: Sequence[Sequence[int]] | None = None,
+    result_layouts: Sequence[Sequence[int]] | None = None,
+    extra_attributes: dict[str, ir.Attribute] | None = None,
 ) -> ir.Operation:
   """Helper function for building an hlo.CustomCall.
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 import collections
 import collections.abc
@@ -32,7 +33,7 @@ import re
 import subprocess
 import sys
 import types
-from typing import Callable, NamedTuple, Optional
+from typing import Callable, NamedTuple
 import unittest
 import weakref
 
@@ -6226,7 +6227,7 @@ class DCETest(jtu.JaxTestCase):
 
   def assert_dce_result(self, jaxpr: core.Jaxpr, used_outputs: list[bool],
                         expected_used_inputs: list[bool],
-                        expected_num_eqns: Optional[int] = None,
+                        expected_num_eqns: int | None = None,
                         check_diff: bool = True):
     jaxpr_dce, used_inputs = pe.dce_jaxpr(jaxpr, used_outputs)
     core.check_jaxpr(jaxpr_dce)

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from contextlib import contextmanager
 from functools import partial
 import itertools as it
-from typing import Any, Optional, Callable, Union, TypeVar
+from typing import Any, Callable, TypeVar
 
 import numpy as np
 from absl.testing import absltest
@@ -1331,7 +1333,7 @@ class BatchingTest(jtu.JaxTestCase):
 
 Array = Any
 ArrayElt = Any
-Int = Union[int, core.Tracer]
+Int = int | core.Tracer
 
 # Can't used NamedTuple here b/c those are pytrees
 class NamedArray:
@@ -1347,10 +1349,10 @@ class NamedArray:
     return f'NamedArray(names={self.names}, data={self.data})'
 
 class NamedMapSpec:
-  name: Optional[str]
-  axis: Optional[int]
+  name: str | None
+  axis: int | None
 
-  def __init__(self, name: str, axis: Optional[int]):
+  def __init__(self, name: str, axis: int | None):
     assert (name is None) == (axis is None)
     self.name = name
     self.axis = axis
@@ -1365,7 +1367,7 @@ register_pytree_node(NamedArray,
                      lambda names, xs: NamedArray(names, xs[0]))
 
 
-def named_to_elt(cont: Callable[[Array, Optional[int]], ArrayElt],
+def named_to_elt(cont: Callable[[Array, int | None], ArrayElt],
                  _: Int, val: NamedArray, spec: NamedMapSpec) -> NamedArray:
   if spec.name is None:
     return val
@@ -1375,7 +1377,7 @@ def named_to_elt(cont: Callable[[Array, Optional[int]], ArrayElt],
     elt = cont(val.data, spec.axis)
     return NamedArray(elt_names, elt)
 
-def named_from_elt(cont: Callable[[int, ArrayElt, Optional[int]], Array],
+def named_from_elt(cont: Callable[[int, ArrayElt, int | None], Array],
                    axis_size: int, elt: NamedArray, annotation: NamedMapSpec
                    ) -> NamedArray:
   data = cont(axis_size, elt.data, annotation.axis)

--- a/tests/export_harnesses_multi_platform_test.py
+++ b/tests/export_harnesses_multi_platform_test.py
@@ -19,9 +19,11 @@ cross-platform lowering mode. The actual mechanism for multi-platform and
 cross-platform lowering is tested in export_test.py.
 """
 
+from __future__ import annotations
+
 import math
 import re
-from typing import Callable, Optional
+from typing import Callable
 
 from absl import logging
 from absl.testing import absltest
@@ -124,7 +126,7 @@ class PrimitiveTest(jtu.JaxTestCase):
       *args: jax.Array,
       unimplemented_platforms: set[str] = set(),
       skip_run_on_platforms: set[str] = set(),
-      tol: Optional[float] = None):
+      tol: float | None = None):
     devices = [
         d
         for d in self.__class__.devices

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 from functools import partial
 import itertools
@@ -20,7 +22,7 @@ import os
 import re
 import threading
 import time
-from typing import Callable, Optional
+from typing import Callable
 import unittest
 from unittest import skip, SkipTest
 
@@ -102,7 +104,7 @@ def fun1_equiv(a):  # Numerical equivalent of fun1
 def maybe_print(do_print: bool,
                 arg,
                 what: str,
-                tap_with_device: Optional[bool] = False,
+                tap_with_device: bool | None = False,
                 device_index: int = 0):
   """Conditionally print on testing_string"""
   if do_print:

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 import enum
 from functools import partial
 import itertools
 import typing
-from typing import Any, Optional
+from typing import Any
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -54,7 +55,7 @@ all_dtypes = default_dtypes + jtu.dtypes.boolean
 class IndexSpec(typing.NamedTuple):
   shape: tuple[int, ...]
   indexer: Any
-  out_shape: Optional[tuple[int, ...]] = None
+  out_shape: tuple[int, ...] | None = None
 
 
 def check_grads(f, args, order, atol=None, rtol=None, eps=None):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 import collections
 from collections.abc import Iterator
@@ -22,7 +23,7 @@ import io
 import itertools
 import math
 import platform
-from typing import cast, Optional
+from typing import cast
 import unittest
 from unittest import SkipTest
 
@@ -3888,7 +3889,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     [dict(shape=shape, axis=axis)
       for shape in [(3,), (3, 4), (3, 4, 5)]
       for axis in itertools.chain(range(-len(shape), len(shape)),
-                                  [cast(Optional[int], None)])
+                                  [cast(int | None, None)])
     ],
     index_shape=scalar_shapes + [(3,), (2, 1, 3)],
     dtype=all_dtypes,
@@ -3940,7 +3941,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         filter(_shapes_are_broadcast_compatible,
                itertools.combinations_with_replacement(nonempty_nonscalar_array_shapes, 2)))
       for axis in itertools.chain(range(len(x_shape)), [-1],
-                                  [cast(Optional[int], None)])
+                                  [cast(int | None, None)])
     ],
     dtype=default_dtypes,
     index_dtype=int_dtypes,

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 from functools import partial
 import itertools
 import math
-from typing import Optional, cast
+from typing import cast
 import unittest
 
 from absl.testing import absltest
@@ -73,8 +74,8 @@ class LaxVmapTest(jtu.JaxTestCase):
      for lhs_shape in [(b * batch_group_count, i * feature_group_count, 6, 7)]
      for rhs_shape in [(j * batch_group_count * feature_group_count, i, 1, 2)]],
     [dict(lhs_bdim=lhs_bdim, rhs_bdim=rhs_bdim)
-        for lhs_bdim in itertools.chain([cast(Optional[int], None)], range(5))
-        for rhs_bdim in itertools.chain([cast(Optional[int], None)], range(5))
+        for lhs_bdim in itertools.chain([cast(int | None, None)], range(5))
+        for rhs_bdim in itertools.chain([cast(int | None, None)], range(5))
         if (lhs_bdim, rhs_bdim) != (None, None)
     ],
     [dict(dimension_numbers=dim_nums, perms=perms)

--- a/tests/pallas/indexing_test.py
+++ b/tests/pallas/indexing_test.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 """Tests for Pallas indexing logic and abstractions."""
-from typing import Union
+
+from __future__ import annotations
+
 import unittest
 
 from absl.testing import absltest
@@ -45,7 +47,7 @@ def int_indexer_strategy(dim) -> hps.SearchStrategy[int]:
 
 
 @hps.composite
-def slice_indexer_strategy(draw, dim) -> Union[Slice, slice]:
+def slice_indexer_strategy(draw, dim) -> Slice | slice:
   start = draw(int_indexer_strategy(dim))
   size = draw(hps.integers(min_value=0, max_value=np.iinfo(np.int32).max))
   return draw(
@@ -64,7 +66,7 @@ def array_indexer_strategy(draw, shape) -> jax.Array:
 
 @hps.composite
 def indexer_strategy(draw, dim, int_indexer_shape
-                     ) -> Union[int, Slice, jax.Array]:
+                     ) -> int | Slice | jax.Array:
   return draw(hps.one_of(
       int_indexer_strategy(dim),
       slice_indexer_strategy(dim),

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
@@ -21,7 +22,7 @@ import math
 import os
 from random import shuffle
 import re
-from typing import Optional, cast
+from typing import cast
 import unittest
 from unittest import SkipTest
 import weakref
@@ -60,7 +61,7 @@ prev_xla_flags = None
 compatible_shapes = [[(3,)], [(3, 4), (3, 1), (1, 4)], [(2, 3, 4), (2, 1, 4)]]
 
 def all_bdims(*shapes, pmap):
-  bdims = (it.chain([cast(Optional[int], None)], range(len(shape) + 1))
+  bdims = (it.chain([cast(int | None, None)], range(len(shape) + 1))
            for shape in shapes)
   return (t for t in it.product(*bdims) if not all(e is None for e in t))
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import copy
 import enum
 from functools import partial
 import math
 from unittest import skipIf
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 import zlib
 
 from absl.testing import absltest
@@ -59,8 +61,8 @@ class RandomValuesCase(NamedTuple):
   params: dict
   expected: np.ndarray
   on_x64: OnX64 = OnX64.ALSO
-  atol: Optional[float] = None
-  rtol: Optional[float] = None
+  atol: float | None = None
+  rtol: float | None = None
 
   def _testname(self):
     if self.dtype is None:

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for the shape-polymorphic export."""
+
+from __future__ import annotations
+
 import enum
 from collections.abc import Sequence
 import itertools
 import math
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 import unittest
 
 from absl import logging
@@ -526,10 +529,10 @@ class PolyHarness(Harness):
                fun: Callable[..., Any],
                *,
                arg_descriptors: Sequence[test_harnesses.ArgDescriptor] = (),
-               polymorphic_shapes: Sequence[Optional[str]] = (),
-               expect_error: Optional[tuple[Any, str]] = None,
+               polymorphic_shapes: Sequence[str | None] = (),
+               expect_error: tuple[Any, str] | None = None,
                check_result: bool = True,
-               tol: Optional[float] = None,
+               tol: float | None = None,
                limitations: Sequence[test_harnesses.Limitation] = (),
                override_jax_config_flags: dict[str, Any] = {}):
     """Args:
@@ -560,7 +563,7 @@ class PolyHarness(Harness):
     self.limitations = limitations
     self.override_jax_config_flags = override_jax_config_flags
 
-  def run_test(self, tst: jtu.JaxTestCase) -> Optional[jax.Array]:
+  def run_test(self, tst: jtu.JaxTestCase) -> jax.Array | None:
     def log_message(extra: str):
       return f"[{tst._testMethodName}]: {extra}"
 
@@ -612,8 +615,8 @@ class PolyHarness(Harness):
 
 def check_shape_poly(tst, f_jax: Callable, *,
                      arg_descriptors: Sequence[test_harnesses.ArgDescriptor] = (),
-                     polymorphic_shapes: Sequence[Optional[str]] = (),
-                     expect_error=None) -> Optional[jax.Array]:
+                     polymorphic_shapes: Sequence[str | None] = (),
+                     expect_error=None) -> jax.Array | None:
   # Builds a PolyHarness and runs the test. See PolyHarness documentation.
   h = PolyHarness("", "", f_jax,
                   arg_descriptors=arg_descriptors,
@@ -2288,7 +2291,7 @@ def _make_vmap_primitive_harnesses() -> Sequence[PolyHarness]:
       continue
 
     def make_batched_arg_descriptor(
-        ad: test_harnesses.ArgDescriptor) -> Optional[test_harnesses.ArgDescriptor]:
+        ad: test_harnesses.ArgDescriptor) -> test_harnesses.ArgDescriptor | None:
       if isinstance(ad, RandArg):
         return RandArg((batch_size,) + ad.shape, ad.dtype)
       elif isinstance(ad, CustomArg):

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 from functools import partial
 import itertools as it
-from typing import Any, Callable, NamedTuple, Optional, Union
+from typing import Any, Callable, NamedTuple
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -709,8 +711,8 @@ if CAN_USE_HYPOTHESIS:
 
   class VmappableIndexParam(NamedTuple):
     index_param: IndexParam
-    ref_bdim: Optional[int]
-    non_slice_idx_bdims: tuple[Optional[int], ...]
+    ref_bdim: int | None
+    non_slice_idx_bdims: tuple[int | None, ...]
     slice_bdim: int
     bat_ref_aval: shaped_array_ref
     bat_ref_shape: Shape
@@ -719,7 +721,7 @@ if CAN_USE_HYPOTHESIS:
     bat_slice_aval: core.ShapedArray
     bat_slice_shape: Shape
 
-  def maybe_tuple_insert(t: tuple[Any, ...], idx: Optional[int],
+  def maybe_tuple_insert(t: tuple[Any, ...], idx: int | None,
                          val: Any) -> tuple[Any, ...]:
     if idx is None:
       return t
@@ -812,15 +814,15 @@ if CAN_USE_HYPOTHESIS:
     bat_val = draw(hnp.arrays(np.float32, vmap_index_param.bat_slice_shape))
     return SetVmapParams(vmap_index_param, bat_ref, bat_val, bat_idxs)
 
-  Indexer = tuple[Union[int, slice, np.ndarray]]
+  Indexer = tuple[int | slice | np.ndarray]
 
   def _unpack_idx(idx: Indexer
-      ) -> tuple[Sequence[Union[int, np.ndarray]], Sequence[bool]]:
+      ) -> tuple[Sequence[int | np.ndarray], Sequence[bool]]:
     indexed_dims = [type(i) != slice for i in idx]
     non_slice_idx = [i for i, b in zip(idx, indexed_dims) if b]
     return non_slice_idx, indexed_dims
 
-  def _pack_idx(non_slice_idx: Sequence[Union[int, np.ndarray]],
+  def _pack_idx(non_slice_idx: Sequence[int | np.ndarray],
       indexed_dims: Sequence[bool]) -> Indexer:
     idx_ = iter(non_slice_idx)
     idx = tuple(next(idx_) if b else slice(None) for b in indexed_dims)

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -579,7 +579,7 @@ class TreeTest(jtu.JaxTestCase):
     self.assertEqual(list(restored_d.keys()), ["a", "b", "c"])
 
   def testFlattenDefaultDictKeyOrder(self):
-    d = collections.defaultdict(lambda: 0,
+    d = collections.defaultdict(int,
                                 {"b": 2, "a": 1, "c": {"b": 2, "a": 1}})
     leaves, treedef = tree_util.tree_flatten(d)
     self.assertEqual(leaves, [1, 2, 1, 2])

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -17,7 +17,10 @@ Typing tests
 This test is meant to be both a runtime test and a static type annotation test,
 so it should be checked with pytype/mypy as well as being run with pytest.
 """
-from typing import Any, Optional, Union, TYPE_CHECKING
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
 
 import jax
 from jax._src import core
@@ -100,7 +103,7 @@ class TypingTest(jtu.JaxTestCase):
     self.assertArraysEqual(out9, jnp.float32(0))
 
   def testArrayInstanceChecks(self):
-    def is_array(x: typing.ArrayLike) -> Union[bool, typing.Array]:
+    def is_array(x: typing.ArrayLike) -> bool | typing.Array:
       return isinstance(x, typing.Array)
 
     x = jnp.arange(5)
@@ -114,7 +117,7 @@ class TypingTest(jtu.JaxTestCase):
   def testAnnotations(self):
     # This test is mainly meant for static type checking: we want to ensure that
     # Tracer and ArrayImpl are valid as array.Array.
-    def f(x: Any) -> Optional[typing.Array]:
+    def f(x: Any) -> typing.Array | None:
       if isinstance(x, core.Tracer):
         return x
       elif isinstance(x, ArrayImpl):

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Generator, Iterator
 import functools
 import itertools as it
@@ -19,7 +21,6 @@ import math
 import os
 import re
 from itertools import product, permutations
-from typing import Union, Optional
 from unittest import SkipTest
 
 import numpy as np
@@ -133,7 +134,7 @@ core.axis_substitution_rules[constant_introducing_p] = partial(
 
 # -------------------- Axis resources generation --------------------
 
-AxisResources = dict[str, Union[str, tuple[str, ...]]]
+AxisResources = dict[str, str | tuple[str, ...]]
 
 def schedules(sizes: dict[str, int]
               ) -> Generator[tuple[AxisResources, jtu.MeshSpec], None, None]:
@@ -1912,7 +1913,7 @@ class NamedAutodiffTests(jtu.JaxTestCase):
 
     # lax.psum has the wrong transpose, so test with a corrected version for now
     @functools.partial(jax.custom_vjp, nondiff_argnums=(1,))
-    def psum_idrev(x, axis_name: Optional[AxisNames] = None):
+    def psum_idrev(x, axis_name: AxisNames | None = None):
       if axis_name is None:
         return x
       return jax.lax.psum(x, axis_name)


### PR DESCRIPTION
This PR is a follow up to #18881.

The changes were generated by adding

    from __future__ import annotations

to the files which did not already have them and running

    pyupgrade --py39-plus --keep-percent-format {jax,tests,jaxlib,examples,benchmarks}/**/*.py