### PR TITLE
[PALLAS Triton] - Adding BOOL dtype conversion from JAX to TRITON

### DIFF
--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -158,6 +158,8 @@ def _convert_dtype(dtype: jnp.dtype) -> tl.dtype:
     return tl.int32
   elif dtype == jnp.int64:
     return tl.int64
+  elif dtype == jnp.dtype("bool"):
+    return tl.int1
   raise ValueError(f"Unhandled dtype: {dtype}")
 
 

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -783,6 +783,17 @@ class PallasCallTest(PallasTest):
 
     np.testing.assert_allclose(softmax_kernel(x), jax.nn.softmax(x), atol=1e-7)
 
+  def test_bool_cast(self):
+    x = jnp.arange(8).astype(jnp.int32)
+    
+    @functools.partial(
+        self.pallas_call, out_shape=jax.ShapeDtypeStruct(x.shape, jnp.dtype("bool")))
+    def bool_cast(x_ref, o_ref):
+      o_ref[...] =  jnp.bool_(x_ref[...])
+
+    expected = jnp.bool_(x)
+    np.testing.assert_allclose(bool_cast(x), expected)
+
 
 class PallasCallInterpreterTest(PallasCallTest):
   INTERPRET = True


### PR DESCRIPTION
Similarly to #18849

Adding BOOL dtype conversion from JAX to TRITON.

Allow support for `jax.numpy.bool_`

```python
import jax
from jax.experimental import pallas as pl

# JAX
x = jnp.arange(8).astype(jnp.int32)
print(f"{jnp.bool_(x)=}")

# PALLAS
def bool_cast_kernel(x_ref, o_ref):
    x = pl.load(x_ref, ())
    out = jnp.bool_(x)
    pl.store(o_ref, (), out)

@jax.jit
def exec_fn(_x):
    return pl.pallas_call(
        bool_cast_kernel, 
        out_shape=jax.ShapeDtypeStruct(_x.shape, dtype=jnp.dtype("bool")),
        grid=1
    )(_x)

x = jnp.arange(8).astype(jnp.int32)
print(f"{exec_fn(x)=}")
```

Only works after the fix in this PR:

```python
>>> jnp.bool_(x)=Array([False,  True,  True,  True,  True,  True,  True,  True], dtype=bool)
>>> exec_fn(x)=Array([False,  True,  True,  True,  True,  True,  True,  True], dtype=bool)
```