### PR TITLE
[shard-map] fix varargs error message bug

### DIFF
--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -1304,6 +1304,18 @@ class ShardMapTest(jtu.JaxTestCase):
     shard_map(lambda k: jax.random.normal(k[0], (1,)),
               mesh=mesh, in_specs=P('i'), out_specs=P('i'))(keys)  # don't crash
 
+  def test_error_for_variable_num_args(self):
+    mesh = Mesh(np.array(jax.devices()[:4]).reshape(2, 2), ('x', 'y'))
+
+    def f(*args):
+      return args[0] @ args[1]
+
+    shard_f = shard_map(
+      f, mesh, in_specs=(P('x', 'y', None), P('x', 'y', None)), out_specs=P('x', 'y'))
+
+    with self.assertRaisesRegex(ValueError, "shard_map applied to the function 'f'"):
+      shard_f(jnp.ones((8, 8)), jnp.ones((8, 8)))
+
 
 class FunSpec(NamedTuple):
   name: str


### PR DESCRIPTION
Co-authored by @chaserileyroberts 

see #18823

```python
import os
os.environ['XLA_FLAGS'] = '--xla_force_host_platform_device_count=8'

import numpy as np

import jax
import jax.numpy as jnp
from jax.experimental.shard_map import shard_map, PartitionSpec as P, Mesh

m = Mesh(np.array(jax.devices()[:4]).reshape(2, 2), ('i', 'j'))

shard_map(lambda *xs: None, m, (P(), P(None)), None)(1., 1.)
```

Before:

```
Traceback (most recent call last):
  File "/usr/local/google/home/mattjj/packages/jax/chase2.py", line 14, in <module>
    shard_map(lambda *args: None, m, (P(), P(None)), None)(1., 1.)
IndexError: list index out of range
```

Oops!

After:

```
Traceback (most recent call last):
  File "/usr/local/google/home/mattjj/packages/jax/chase2.py", line 14, in <module>
    shard_map(lambda *args: None, m, (P(), P(None)), None)(1., 1.)
ValueError: shard_map applied to the function '<lambda>' was given an in_specs
entry which is too long to be compatible with the corresponding input value from
the function:

in_specs[1] is PartitionSpec(None,) which has length 1, but args[1], where
args[1] is the index 1 component of <lambda>'s varargs parameter 'xs', has
shape float32[], which has rank 0 (and 0 < 1)

Entries in in_specs must be of length no greater than the number of axes in the
corresponding input value.

Either revise the spec to be shorter, or modify '<lambda>' so that its inputs
have sufficient rank.

For scalar values (rank 0), consider using an in_specs entry of `P()`, where `P
= jax.sharding.PartitionSpec`.
```

No more bug in the error message!

Maybe these error messages are too long. But that's a separate issue. For now we're just fixing an error in the error-message code!