### PR TITLE
[shape_poly] Replace non_negative_dim with max_dim and min_dim.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,18 +20,22 @@ Remember to align the itemized text with the first line of an item within a list
     devices.
   * {func}`jax.numpy.argsort` and {func}`jax.numpy.sort` now support the `stable`
     and `descending` arguments.
-  * Several changes to the handling of shape polymorphism (for
+  * Several changes to the handling of shape polymorphism (used in
     {mod}`jax.experimental.jax2tf` and {mod}`jax.experimental.export`): cleaner
     pretty-printing of symbolic expressions ({jax-issue}`#19227`); simplified
     and faster equality comparisons, where we consider two symbolic dimensions
     to be equal if the normalized form of their difference reduces to 0
     ({jax-issue}`#19231`; note that this may result in user-visible behavior
     changes); improved the error messages for inconclusive inequality comparisons
-    ({jax-issue}`#19235`).
+    ({jax-issue}`#19235`); the `core.non_negative_dim` API (introduced recently)
+    was deprecated and `core.max_dim` and `core.min_dim` were introduced
+    ({jax-issue}`#18953`) to express `max` and `min` for symbolic dimensions.
+    You can use `core.max_dim(d, 0)` instead of `core.non_negative_dim(d)`.
   * Refactored the API for `jax.experimental.export`. Instead of
     `from jax.experimental.export import export` you should use now
     `from jax.experimental import export`. The old way of importing will
     continue to work for a deprecation period of 3 months.
+
 * Deprecations & Removals
   * A number of previously deprecated functions have been removed, following a
     standard 3+ month deprecation cycle (see {ref}`api-compatibility`).

--- a/jax/core.py
+++ b/jax/core.py
@@ -116,7 +116,7 @@ from jax._src.core import (
   new_sublevel as new_sublevel,
   no_axis_name as no_axis_name,
   no_effects as no_effects,
-  non_negative_dim as non_negative_dim,
+  non_negative_dim as _deprecated_non_negative_dim,
   outfeed_primitives as outfeed_primitives,
   pp_aval as pp_aval,
   pp_eqn as pp_eqn,
@@ -265,6 +265,10 @@ _deprecations = {
     "symbolic_equal_dim": (
       "jax.core.symbolic_equal_dim is deprecated. Use ==.", _deprecated_definitely_equal,
     ),
+    # Added Jan 8, 2024
+    "non_negative_dim": (
+      "jax.core.non_negative_dim is deprecated. Use max_dim(..., 0).", _deprecated_non_negative_dim,
+    ),
 }
 
 import typing
@@ -279,6 +283,7 @@ if typing.TYPE_CHECKING:
   collections = _src_core.collections
   dimension_as_value = _deprecated_dimension_as_value
   definitely_equal = _deprecated_definitely_equal
+  non_negative_dim = _deprecated_non_negative_dim
   dtypes = _src_core.dtypes
   lu = _src_core.lu
   map = _src_core.map

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -775,7 +775,7 @@ class JaxExportTest(jtu.JaxTestCase):
     def output_shape(b):
       return (b + b, b - b, b * b,
               (b + 13) // b, (b + 13) % b,
-              core.non_negative_dim(b - 5))
+              core.max_dim(b - 5, 0))
     def f(x):  # x: f32[b]
       b = x.shape[0]
       return jnp.ones(output_shape(b), dtype=x.dtype)


### PR DESCRIPTION
Previously, we had `core.non_negative_dim` and we used it to express `max(d, 0)`. This is needed in several places internally to express index computations involving clamping (for numpy indexing), or striding and dilation (which have a conditional semantics). It seemed that this special case was sufficient, and we expressed `max(a, b)` as `a + non_negative(b - a)` and `min(a, b)` as `a - non_negative(a - b)`.

One drawback was that `non_negative` can be a surprising construct when it appears in error messages. Also, users need `max` and `min` computations with dimensions. It is clearer if we use `max` and `min` directly instead of rewriring these to use `non_negative`. The drawback is that we now have to duplicate some internal logic to for `max` and `min`, but overall I feel this is worth it for the better error messages we get.