### PR TITLE
[export] Fix the serialization of effects

### DIFF
--- a/jax/experimental/export/serialization.py
+++ b/jax/experimental/export/serialization.py
@@ -386,17 +386,24 @@ def _deserialize_sharding(s: ser_flatbuf.Sharding) -> export.Sharding:
 
 
 def _serialize_effect(builder: flatbuffers.Builder, eff: core.Effect) -> int:
-  # TODO(necula): for now serialize just the name of the class
   try:
-    _ = eff.__class__()
-  except:
+    eff_replica = eff.__class__()
+  except Exception:
     raise NotImplementedError(
-        f"serializing effect {eff} that does not have a nullary class"
-        " constructor"
+        f"Effect {eff} must have a nullary constructor to be serializable"
     )
-  # TODO: fix the effects serialization and deserialization, to ensure that
-  # upon deserialization we reconstruct an effect that compares equal to the
-  # one that was serialized.
+  try:
+    hash_eff = hash(eff)
+    hash_eff_replica = hash(eff_replica)
+  except Exception:
+    raise NotImplementedError(
+        f"Effect {eff} must be hashable to be serializable"
+    )
+  if eff != eff_replica or hash_eff != hash_eff_replica:
+    raise NotImplementedError(
+      f"Effect {eff} must have a nullary class constructor that produces an "
+      "equal effect object."
+    )
   effect_type_name = str(eff.__class__)
   effect_type_name_offset = builder.CreateString(effect_type_name)
   ser_flatbuf.EffectStart(builder)

--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -26,6 +26,7 @@ https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#callin
 from __future__ import annotations
 
 from collections.abc import Sequence
+import dataclasses
 import functools
 from typing import Any, Callable, Optional
 
@@ -35,20 +36,16 @@ from jax import dlpack
 from jax import dtypes
 from jax import numpy as jnp
 from jax import tree_util
-from jax._src import ad_checkpoint
 from jax._src import ad_util
 from jax._src import core
-from jax._src import custom_derivatives
 from jax._src import effects
 from jax._src import util
-from jax._src.lax import control_flow as lax_control_flow
 from jax._src.lib import xla_client
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import func as func_dialect
 from jax._src.lib.mlir.dialects import hlo
 from jax.experimental.jax2tf import jax2tf as jax2tf_internal
 from jax.interpreters import mlir
-from jax.interpreters import xla
 import numpy as np
 import tensorflow as tf
 
@@ -376,6 +373,7 @@ def _get_concrete_function_tf(function_flat_tf, args_flat_sig_tf):  # -> tf.Conc
 
 
 # Mark the effectful instances of call_tf
+@dataclasses.dataclass(frozen=True)
 class CallTfEffect(effects.Effect):
   __str__ = lambda _: "CallTfEffect"
 


### PR DESCRIPTION
We currently support only the serialization of effects with nullary constructors. We must also ensure that upon deserialization we produce an event that tests equal to the original one. Here we add explicit error checks and tests.

We also make the CallTfEffect to have this property.

As a cleanup, we replace the name of effect classes in export_test.py to not start with "Test"; this confuses
pytest sometimes.