### PR TITLE
Allow to import pallas even in case triton.get_compatible_device not available

### DIFF
--- a/jaxlib/gpu_triton.py
+++ b/jaxlib/gpu_triton.py
@@ -25,6 +25,7 @@ for cuda_module_name in [".cuda", "jax_cuda12_plugin", "jax_cuda11_plugin"]:
   else:
     break
 
+get_compute_capability = None
 if _cuda_triton:
   xla_client.register_custom_call_target(
       "triton_kernel_call", _cuda_triton.get_custom_call(),


### PR DESCRIPTION
Currently, importing pallas causes an attribute error because `get_compatible_device` might not be available.