### PR TITLE
jnp.linalg: add matrix_norm, matrix_transpose, vector_norm, vector_transpose

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -457,8 +457,10 @@ jax.numpy.linalg
   eigvalsh
   inv
   lstsq
+  matrix_norm
   matrix_power
   matrix_rank
+  matrix_transpose
   multi_dot
   norm
   outer
@@ -469,6 +471,8 @@ jax.numpy.linalg
   svd
   tensorinv
   tensorsolve
+  vector_norm
+  vecdot
 
 JAX Array
 ---------

--- a/jax/experimental/array_api/_linear_algebra_functions.py
+++ b/jax/experimental/array_api/_linear_algebra_functions.py
@@ -91,7 +91,7 @@ def matrix_norm(x, /, *, keepdims=False, ord='fro'):
   """
   Computes the matrix norm of a matrix (or a stack of matrices) x.
   """
-  return jax.numpy.linalg.norm(x, ord=ord, keepdims=keepdims, axis=(-1, -2))
+  return jax.numpy.linalg.matrix_norm(x, ord=ord, keepdims=keepdims)
 
 def matrix_power(x, n, /):
   """
@@ -107,9 +107,7 @@ def matrix_rank(x, /, *, rtol=None):
 
 def matrix_transpose(x, /):
   """Transposes a matrix (or a stack of matrices) x."""
-  if x.ndim < 2:
-    raise ValueError(f"matrix_transpose requres at least 2 dimensions; got {x.ndim=}")
-  return jax.lax.transpose(x, (*range(x.ndim - 2), x.ndim - 1, x.ndim - 2))
+  return jax.numpy.linalg.matrix_transpose(x)
 
 def outer(x1, x2, /):
   """
@@ -177,16 +175,8 @@ def trace(x, /, *, offset=0, dtype=None):
 
 def vecdot(x1, x2, /, *, axis=-1):
   """Computes the (vector) dot product of two arrays."""
-  rank = max(x1.ndim, x2.ndim)
-  x1 = jax.lax.broadcast_to_rank(x1, rank)
-  x2 = jax.lax.broadcast_to_rank(x2, rank)
-  if x1.shape[axis] != x2.shape[axis]:
-    raise ValueError("x1 and x2 must have the same size along specified axis.")
-  x1, x2 = jax.numpy.broadcast_arrays(x1, x2)
-  x1 = jax.numpy.moveaxis(x1, axis, -1)
-  x2 = jax.numpy.moveaxis(x2, axis, -1)
-  return jax.numpy.matmul(x1[..., None, :], x2[..., None])[..., 0, 0]
+  return jax.numpy.linalg.vecdot(x1, x2, axis=axis)
 
 def vector_norm(x, /, *, axis=None, keepdims=False, ord=2):
   """Computes the vector norm of a vector (or batch of vectors) x."""
-  return jax.numpy.linalg.norm(x, axis=axis, keepdims=keepdims, ord=ord)
+  return jax.numpy.linalg.vector_norm(x, axis=axis, keepdims=keepdims, ord=ord)

--- a/jax/experimental/array_api/linalg.py
+++ b/jax/experimental/array_api/linalg.py
@@ -20,7 +20,6 @@ from jax.experimental.array_api._linear_algebra_functions import (
   eigh as eigh,
   eigvalsh as eigvalsh,
   inv as inv,
-  jax as jax,
   matmul as matmul,
   matrix_norm as matrix_norm,
   matrix_power as matrix_power,

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -25,8 +25,10 @@ from jax._src.numpy.linalg import (
   eigvalsh as eigvalsh,
   inv as inv,
   lstsq as lstsq,
+  matrix_norm as matrix_norm,
   matrix_power as matrix_power,
   matrix_rank as matrix_rank,
+  matrix_transpose as matrix_transpose,
   norm as norm,
   outer as outer,
   pinv as pinv,
@@ -34,6 +36,8 @@ from jax._src.numpy.linalg import (
   slogdet as slogdet,
   solve as solve,
   svd as svd,
+  vector_norm as vector_norm,
+  vecdot as vecdot,
 )
 from jax._src.third_party.numpy.linalg import (
   cond as cond,

--- a/tests/array_api_test.py
+++ b/tests/array_api_test.py
@@ -175,7 +175,6 @@ LINALG_NAMESPACE = {
   'eigh',
   'eigvalsh',
   'inv',
-  'jax',
   'matmul',
   'matrix_norm',
   'matrix_power',


### PR DESCRIPTION
These have been added upstream to `numpy.linalg` in NumPy 2.0, as part of the Array API standard.

Part of #18353