### PR TITLE
Enabling xla_tpu_use_enhanced_launch_barrier for all the supported clout tpus

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -342,6 +342,9 @@ pytype_strict_library(
 pytype_strict_library(
     name = "cloud_tpu_init",
     srcs = ["_src/cloud_tpu_init.py"],
+    deps = [
+        ":hardware_utils",
+    ]
 )
 
 pytype_strict_library(
@@ -468,6 +471,11 @@ pytype_strict_library(
         ":compilation_cache_interface",
         ":path",
     ],
+)
+
+pytype_strict_library(
+    name = "hardware_utils",
+    srcs = ["_src/hardware_utils.py"],
 )
 
 pytype_library(
@@ -831,6 +839,7 @@ pytype_strict_library(
     deps = [
         ":cloud_tpu_init",
         ":config",
+	":hardware_utils",
         ":traceback_util",
         ":util",
         "//jax/_src/lib",

--- a/jax/_src/cloud_tpu_init.py
+++ b/jax/_src/cloud_tpu_init.py
@@ -14,6 +14,7 @@
 
 import os
 import warnings
+from jax._src import hardware_utils
 
 running_in_cloud_tpu_vm: bool = False
 
@@ -66,6 +67,8 @@ def cloud_tpu_init() -> None:
   os.environ.setdefault('GRPC_VERBOSITY', 'ERROR')
   os.environ.setdefault('JAX_PLATFORMS', 'tpu,cpu')
   os.environ['TPU_ML_PLATFORM'] = 'JAX'
+  if hardware_utils.tpu_enhanced_barrier_supported():
+    os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS","") + " --xla_tpu_use_enhanced_launch_barrier=true"
 
   # TODO(skyewm): remove this warning at some point, say around Sept 2023.
   use_pjrt_c_api = os.environ.get('JAX_USE_PJRT_C_API_ON_TPU', None)

--- a/jax/_src/hardware_utils.py
+++ b/jax/_src/hardware_utils.py
@@ -1,0 +1,59 @@
+# Copyright 2023 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pathlib
+import glob
+
+_GOOGLE_PCI_VENDOR_ID = '0x1ae0'
+_TPU_PCI_DEVICE_IDS = [
+    # TPU v2, v3
+    '0x0027',
+    # TPU v4
+    '0x005e',
+    # TPU v5e
+    '0x0063',
+    # Testing only
+    '0x0056',
+    '0x0062',
+]
+
+_TPU_ENHANCED_BARRIER_SUPPORTED = [
+    # TPU v2, v3
+    '0x0027',
+    # TPU v4
+    '0x005e',
+]
+
+def num_available_tpu_chips_and_device_id():
+  """Returns the device id and number of TPU chips attached through PCI."""
+  num_chips = 0
+  device_id = ''
+  for vendor_path in glob.glob('/sys/bus/pci/devices/*/vendor'):
+    vendor_id = pathlib.Path(vendor_path).read_text().strip()
+    if vendor_id != _GOOGLE_PCI_VENDOR_ID:
+      continue
+
+    device_path = os.path.join(os.path.dirname(vendor_path), 'device')
+    device_id = pathlib.Path(device_path).read_text().strip()
+    if device_id in _TPU_PCI_DEVICE_IDS:
+      num_chips += 1
+
+  return num_chips, device_id
+
+
+def tpu_enhanced_barrier_supported() -> bool:
+  """Returns if tpu_enhanced_barrier flag is supported on this TPU version."""
+  _, device_id = num_available_tpu_chips_and_device_id()
+  return device_id in _TPU_ENHANCED_BARRIER_SUPPORTED


### PR DESCRIPTION
Setting --xla_tpu_use_enhanced_launch_barrier=true by default for Clout TPUs that supports this (v5 does not support it)

This will prevent different programs to run on different chips. 