### PR TITLE
[export] Fix handling of float0 when exporting

### DIFF
--- a/jax/experimental/export/serialization.fbs
+++ b/jax/experimental/export/serialization.fbs
@@ -42,36 +42,38 @@ enum AbstractValueKind: byte {
 }
 
 enum DType: byte {
-  bool,
-  i8,
-  i16,
-  i32,
-  i64,
-  ui8,
-  ui16,
-  ui32,
-  ui64,
-  f16,
-  f32,
-  f64,
-  c64,
-  c128,
+  // Last used id: 22
+  bool = 0,
+  i8 = 1,
+  i16 = 2,
+  i32 = 3,
+  i64 = 4,
+  ui8 = 5,
+  ui16 = 6,
+  ui32 = 7,
+  ui64 = 8,
+  f0 = 22,  // Used in JAX to represent float0
+  f16 = 9,
+  f32 = 10,
+  f64 = 11,
+  c64 = 12,
+  c128 = 13,
 
-  bf16,
+  bf16 = 14,
 
-  i4,
-  ui4,
+  i4 = 15,
+  ui4 = 16,
 
-  f8_e4m3b11fnuz,
-  f8_e4m3fn,
-  f8_e4m3fnuz,
-  f8_e5m2,
-  f8_e5m2fnuz,
+  f8_e4m3b11fnuz = 17,
+  f8_e4m3fn = 18,
+  f8_e4m3fnuz = 19,
+  f8_e5m2 = 20,
+  f8_e5m2fnuz = 21,
 }
 
 table AbstractValue {
   kind: AbstractValueKind;
-  shape: [string];  // we support shape polymorphism
+  shape: [string];  // Support shape polymorphism
   dtype: DType;
 }
 
@@ -101,6 +103,11 @@ table DisabledSafetyCheck {
 }
 
 table Exported {
+  /// We increment the serialization version every time we change the
+  /// schema, even if the change is backwards compatible.
+  /// Note that this field has different semantics and purpose from
+  /// `mlir_module_serialization_version`, which encodes
+  /// the calling convention of the `mlir_module_serialized`.
   serialization_version: uint16;
 
   function_name: string;

--- a/jax/experimental/export/serialization_generated.py
+++ b/jax/experimental/export/serialization_generated.py
@@ -20,7 +20,7 @@ import flatbuffers
 from flatbuffers.compat import import_numpy
 np = import_numpy()
 
-class PyTreeDefKind:
+class PyTreeDefKind(object):
     leaf = 0
     none = 1
     tuple = 2
@@ -28,12 +28,12 @@ class PyTreeDefKind:
     dict = 4
 
 
-class AbstractValueKind:
+class AbstractValueKind(object):
     shapedArray = 0
     abstractToken = 1
 
 
-class DType:
+class DType(object):
     bool = 0
     i8 = 1
     i16 = 2
@@ -56,20 +56,21 @@ class DType:
     f8_e4m3fnuz = 19
     f8_e5m2 = 20
     f8_e5m2fnuz = 21
+    f0 = 22
 
 
-class ShardingKind:
+class ShardingKind(object):
     unspecified = 0
     hlo_sharding = 1
 
 
-class DisabledSafetyCheckKind:
+class DisabledSafetyCheckKind(object):
     platform = 0
     custom_call = 1
     shape_assertions = 2
 
 
-class PyTreeDef:
+class PyTreeDef(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -161,7 +162,7 @@ def PyTreeDefEnd(builder):
 
 
 
-class AbstractValue:
+class AbstractValue(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -233,7 +234,7 @@ def AbstractValueEnd(builder):
 
 
 
-class Sharding:
+class Sharding(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -302,7 +303,7 @@ def ShardingEnd(builder):
 
 
 
-class Effect:
+class Effect(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -338,7 +339,7 @@ def EffectEnd(builder):
 
 
 
-class DisabledSafetyCheck:
+class DisabledSafetyCheck(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -384,7 +385,7 @@ def DisabledSafetyCheckEnd(builder):
 
 
 
-class Exported:
+class Exported(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -402,6 +403,11 @@ class Exported:
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # We increment the serialization version every time we change the
+    # schema, even if the change is backwards compatible.
+    # Note that this field has different semantics and purpose from
+    # `mlir_module_serialization_version`, which encodes
+    # the calling convention of the `mlir_module_serialized`.
     # Exported
     def SerializationVersion(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))


### PR DESCRIPTION
There were two problems:
  * the float0 dtype was not part of the schema,
  * there was a bug invoking jax.vjp on a reloaded function, because of a mismatch between the type of symbolic zeros.

We changed the schema to add `f0`, but we add that enum with a value larger than existing values, to
preserve backwards compatibility.