### PR TITLE
jnp.linalg: add matmul, tensordot, & svdvals

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -455,6 +455,7 @@ jax.numpy.linalg
   eigvalsh
   inv
   lstsq
+  matmul
   matrix_norm
   matrix_power
   matrix_rank
@@ -467,6 +468,8 @@ jax.numpy.linalg
   slogdet
   solve
   svd
+  svdvals
+  tensordot
   tensorinv
   tensorsolve
   vector_norm

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import partial
 
 import numpy as np
@@ -748,3 +749,18 @@ def vecdot(x1: ArrayLike, x2: ArrayLike, /, *, axis: int = -1) -> Array:
   x2_arr = jax.numpy.moveaxis(x2_arr, axis, -1)
   # TODO(jakevdp): call lax.dot_general directly
   return jax.numpy.matmul(x1_arr[..., None, :], x2_arr[..., None])[..., 0, 0]
+
+
+@_wraps(getattr(np.linalg, "matmul", None))
+def matmul(x1: ArrayLike, x2: ArrayLike, /) -> Array:
+  return jnp.matmul(x1, x2)
+
+
+@_wraps(getattr(np.linalg, "tensordot", None))
+def tensordot(x1: ArrayLike, x2: ArrayLike, /, *,
+              axes: int | tuple[Sequence[int], Sequence[int]] = 2) -> Array:
+  return jnp.tensordot(x1, x2, axes=axes)
+
+@_wraps(getattr(np.linalg, "svdvals", None))
+def svdvals(x: ArrayLike, /) -> Array:
+  return svd(x, compute_uv=False, hermitian=False)

--- a/jax/experimental/array_api/_linear_algebra_functions.py
+++ b/jax/experimental/array_api/_linear_algebra_functions.py
@@ -85,7 +85,7 @@ def inv(x, /):
 
 def matmul(x1, x2, /):
   """Computes the matrix product."""
-  return jax.numpy.matmul(x1, x2)
+  return jax.numpy.linalg.matmul(x1, x2)
 
 def matrix_norm(x, /, *, keepdims=False, ord='fro'):
   """
@@ -160,11 +160,11 @@ def svdvals(x, /):
   """
   Returns the singular values of a matrix (or a stack of matrices) x.
   """
-  return jax.numpy.linalg.svd(x, compute_uv=False)
+  return jax.numpy.linalg.svdvals(x)
 
 def tensordot(x1, x2, /, *, axes=2):
   """Returns a tensor contraction of x1 and x2 over specific axes."""
-  return jax.numpy.tensordot(x1, x2, axes=axes)
+  return jax.numpy.linalg.tensordot(x1, x2, axes=axes)
 
 def trace(x, /, *, offset=0, dtype=None):
   """

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -25,6 +25,7 @@ from jax._src.numpy.linalg import (
   eigvalsh as eigvalsh,
   inv as inv,
   lstsq as lstsq,
+  matmul as matmul,
   matrix_norm as matrix_norm,
   matrix_power as matrix_power,
   matrix_rank as matrix_rank,
@@ -36,6 +37,8 @@ from jax._src.numpy.linalg import (
   slogdet as slogdet,
   solve as solve,
   svd as svd,
+  svdvals as svdvals,
+  tensordot as tensordot,
   vector_norm as vector_norm,
   vecdot as vecdot,
 )


### PR DESCRIPTION
Part of #18353

Matches the API of similar functions added to NumPy in version 2.0.