### PR TITLE
[shape_poly] Update the jax.ops.segment{max|...} to work with shape polymorphism

### DIFF
--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -173,7 +173,7 @@ def _segment_update(name: str,
   dtype = data.dtype
   if num_segments is None:
     num_segments = np.max(segment_ids) + 1
-  num_segments = core.concrete_or_error(int, num_segments, "segment_sum() `num_segments` argument.")
+  num_segments = core.concrete_dim_or_error(num_segments, "segment_sum() `num_segments` argument.")
   if num_segments is not None and num_segments < 0:
     raise ValueError("num_segments must be non-negative.")
 


### PR DESCRIPTION

The fix is very small, just had to check how we check for cases when tracers are passed as num_segments. We add tests.