### PR TITLE
make hypothesis use in all_gather_test.py optional

### DIFF
--- a/tests/pallas/all_gather_test.py
+++ b/tests/pallas/all_gather_test.py
@@ -16,8 +16,6 @@
 from __future__ import annotations
 
 from absl.testing import absltest
-import hypothesis as hp
-import hypothesis.strategies as hps
 import jax
 from jax import random
 from jax._src import test_util as jtu
@@ -27,104 +25,113 @@ from jax.experimental.pallas.ops.tpu import all_gather
 import jax.numpy as jnp
 import numpy as np
 
+try:
+  import hypothesis as hp
+  import hypothesis.strategies as hps
+  CAN_USE_HYPOTHESIS = True
+except (ModuleNotFoundError, ImportError):
+  CAN_USE_HYPOTHESIS = False
+
 
 jax.config.parse_flags_with_absl()
-
 P = jax.sharding.PartitionSpec
-hp.settings.register_profile(
-    "deterministic",
-    database=None,
-    derandomize=True,
-    deadline=None,
-    max_examples=50,
-    print_blob=True,
-    verbosity=hp.Verbosity.verbose,
-)
-hp.settings.load_profile("deterministic")
 
+if CAN_USE_HYPOTHESIS:
 
-@hps.composite
-def _array_shapes(draw):
-  # TODO(sharadmv, apaszke): enable this on a wider variety of shapes
-  valid_shapes = [
-      (128, 128),
-      (256, 128),
-      (256, 512),
-      (256, 1024),
-      # TODO(sharadmv,apaszke): enable these shapes
-      # (256, 129),
-      # (129, 128),
-      # (64, 64),
-      # (1, 1),
-  ]
-  return draw(hps.sampled_from(valid_shapes))
-
-
-@hps.composite
-def _array_dtypes(draw):
-  return draw(
-      hps.sampled_from([
-          jnp.float32,
-          jnp.bfloat16,
-          jnp.int32,
-          # jnp.float16,  # TODO(sharadmv,apaszke): enable float16 all gather
-          # jnp.int16,  # TODO(sharadmv,apaszke): enable int16 all gather
-          # jnp.int8,  # TODO(sharadmv,apaszke): enable int8 all gather
-      ])
+  hp.settings.register_profile(
+      "deterministic",
+      database=None,
+      derandomize=True,
+      deadline=None,
+      max_examples=50,
+      print_blob=True,
+      verbosity=hp.Verbosity.verbose,
   )
+  hp.settings.load_profile("deterministic")
 
 
-class AllGatherTest(jtu.JaxTestCase):
+  @hps.composite
+  def _array_shapes(draw):
+    # TODO(sharadmv, apaszke): enable this on a wider variety of shapes
+    valid_shapes = [
+        (128, 128),
+        (256, 128),
+        (256, 512),
+        (256, 1024),
+        # TODO(sharadmv,apaszke): enable these shapes
+        # (256, 129),
+        # (129, 128),
+        # (64, 64),
+        # (1, 1),
+    ]
+    return draw(hps.sampled_from(valid_shapes))
 
-  def setUp(self):
-    super().setUp()
-    if not jtu.test_device_matches(["tpu"]):
-      self.skipTest("Need TPU devices")
-    if not jtu.is_device_tpu(version=5, variant="e"):
-      # TODO(sharadmv,apaszke): expand support to more versions
-      self.skipTest("Currently only supported on TPU v5e")
 
-  @hp.given(hps.booleans(), _array_shapes(), _array_dtypes())
-  def test_all_gather_1d_mesh(self, is_vmem, shape, dtype):
-    if jax.device_count() < 2:
-      self.skipTest("Need more devices")
-    memory_space = pltpu.VMEM if is_vmem else pltpu.ANY
-    mesh_shape = (jax.device_count(),)
-    mesh = jax.sharding.Mesh(
-        mesh_utils.create_device_mesh(mesh_shape, jax.devices()), ["x"]
+  @hps.composite
+  def _array_dtypes(draw):
+    return draw(
+        hps.sampled_from([
+            jnp.float32,
+            jnp.bfloat16,
+            jnp.int32,
+            # jnp.float16,  # TODO(sharadmv,apaszke): enable float16 all gather
+            # jnp.int16,  # TODO(sharadmv,apaszke): enable int16 all gather
+            # jnp.int8,  # TODO(sharadmv,apaszke): enable int8 all gather
+        ])
     )
-    leading, *rest = shape
-    shape = (mesh.shape["x"] * leading, *rest)
-    x = random.normal(random.key(0), shape, dtype=jnp.float32).astype(dtype)
-    x_sharded = jax.device_put(x, jax.sharding.NamedSharding(mesh, P("x")))
-    y = all_gather.all_gather(x_sharded, mesh=mesh, axis_name="x",
-                              memory_space=memory_space)
-    np.testing.assert_array_equal(y, x)
 
-  @hp.given(hps.booleans(), _array_shapes(), _array_dtypes(),
-            hps.sampled_from(["x", "y"]))
-  def test_all_gather_2d_mesh(self, is_vmem, shape, dtype,
-                              axis_name):
-    if jax.device_count() < 2:
-      self.skipTest("Need more devices")
-    if jax.device_count() % 2:
-      self.skipTest("Need an even number of devices")
-    memory_space = pltpu.VMEM if is_vmem else pltpu.ANY
-    mesh_shape = (2, jax.device_count() // 2)
-    mesh = jax.sharding.Mesh(
-        mesh_utils.create_device_mesh(mesh_shape, jax.devices()), ["x", "y"]
-    )
-    if axis_name == "x":
-      sharding = jax.sharding.NamedSharding(mesh, P("x", None))
-    else:
-      sharding = jax.sharding.NamedSharding(mesh, P("y", None))
-    leading, *rest = shape
-    shape = (mesh.shape[axis_name] * leading, *rest)
-    x = random.normal(random.key(0), shape, dtype=jnp.float32).astype(dtype)
-    x_sharded = jax.device_put(x, sharding)
-    y = all_gather.all_gather(x_sharded, mesh=mesh, axis_name=axis_name,
-                              memory_space=memory_space)
-    np.testing.assert_array_equal(y, x)
+
+  class AllGatherTest(jtu.JaxTestCase):
+
+    def setUp(self):
+      super().setUp()
+      if not jtu.test_device_matches(["tpu"]):
+        self.skipTest("Need TPU devices")
+      if not jtu.is_device_tpu(version=5, variant="e"):
+        # TODO(sharadmv,apaszke): expand support to more versions
+        self.skipTest("Currently only supported on TPU v5e")
+
+    @hp.given(hps.booleans(), _array_shapes(), _array_dtypes())
+    def test_all_gather_1d_mesh(self, is_vmem, shape, dtype):
+      if jax.device_count() < 2:
+        self.skipTest("Need more devices")
+      memory_space = pltpu.VMEM if is_vmem else pltpu.ANY
+      mesh_shape = (jax.device_count(),)
+      mesh = jax.sharding.Mesh(
+          mesh_utils.create_device_mesh(mesh_shape, jax.devices()), ["x"]
+      )
+      leading, *rest = shape
+      shape = (mesh.shape["x"] * leading, *rest)
+      x = random.normal(random.key(0), shape, dtype=jnp.float32).astype(dtype)
+      x_sharded = jax.device_put(x, jax.sharding.NamedSharding(mesh, P("x")))
+      y = all_gather.all_gather(x_sharded, mesh=mesh, axis_name="x",
+                                memory_space=memory_space)
+      np.testing.assert_array_equal(y, x)
+
+    @hp.given(hps.booleans(), _array_shapes(), _array_dtypes(),
+              hps.sampled_from(["x", "y"]))
+    def test_all_gather_2d_mesh(self, is_vmem, shape, dtype,
+                                axis_name):
+      if jax.device_count() < 2:
+        self.skipTest("Need more devices")
+      if jax.device_count() % 2:
+        self.skipTest("Need an even number of devices")
+      memory_space = pltpu.VMEM if is_vmem else pltpu.ANY
+      mesh_shape = (2, jax.device_count() // 2)
+      mesh = jax.sharding.Mesh(
+          mesh_utils.create_device_mesh(mesh_shape, jax.devices()), ["x", "y"]
+      )
+      if axis_name == "x":
+        sharding = jax.sharding.NamedSharding(mesh, P("x", None))
+      else:
+        sharding = jax.sharding.NamedSharding(mesh, P("y", None))
+      leading, *rest = shape
+      shape = (mesh.shape[axis_name] * leading, *rest)
+      x = random.normal(random.key(0), shape, dtype=jnp.float32).astype(dtype)
+      x_sharded = jax.device_put(x, sharding)
+      y = all_gather.all_gather(x_sharded, mesh=mesh, axis_name=axis_name,
+                                memory_space=memory_space)
+      np.testing.assert_array_equal(y, x)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I think a31129a aka cl/587963496 accidentally made hypothesis a test dependency in tests/all_gather_test.py, rather than following our existing convention as in tests/state_test.py of making it optional. I think it was an accident because there's no discussion of adding hypothesis as a test dependence on the review for that PR/CL.

This PR changes tests/all_gather_test.py to follow the convention for making hypothesis optional.

I noticed because this broke my local use of `pytest -n auto tests`.