### PR TITLE
tangent dtypes for extended dtypes

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1787,12 +1787,9 @@ class ConcreteArray(ShapedArray):
   _complex = concretization_function_error(complex, True)
 
 def primal_dtype_to_tangent_dtype(primal_dtype):
-  # TODO(frostig,mattjj): determines that all extended dtypes have
-  # float0 tangent type, which works fine for all our current
-  # extended dtype applications. We may some day want to delegate
-  # this decision to the dtype rules.
-  if (dtypes.issubdtype(primal_dtype, dtypes.extended) or
-      not dtypes.issubdtype(primal_dtype, np.inexact)):
+  if dtypes.issubdtype(primal_dtype, dtypes.extended):
+    return primal_dtype._rules.tangent_dtype(primal_dtype)  # type: ignore
+  elif not dtypes.issubdtype(primal_dtype, np.inexact):
     return dtypes.float0
   else:
     return primal_dtype

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -706,7 +706,7 @@ def _transpose_cond_jaxpr(jaxpr, num_res, reduce_axes):
     cts_in = ad.backward_pass(
         jaxpr.jaxpr, reduce_axes, False, jaxpr.consts, primals, cts_out)
     _, cts_in = split_list(cts_in, [num_res])
-    return map(ad.instantiate_zeros_aval, primal_avals, cts_in)
+    return map(ad.instantiate_zeros, cts_in)
 
   return _make_closed_jaxpr(transposed, res_avals + jaxpr.out_avals)
 
@@ -729,7 +729,7 @@ def _cond_transpose(reduce_axes, cts, *args, branches, linear):
              for out_aval, lin_in_aval in zip(jaxpr.out_avals, lin_in_avals))
 
   res = ops[:num_res]
-  cts = map(ad.instantiate_zeros_aval, branches[0].out_avals, cts)
+  cts = map(ad.instantiate_zeros, cts)
   linear_trans = (False,) * num_res + (True,) * len(cts)
 
   out = cond_p.bind(

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -740,7 +740,7 @@ def _scan_transpose(reduce_axes, cts, *args, reverse, length, num_consts,
 
   carry_avals, y_avals = split_list(jaxpr.out_avals, [num_carry])
   ct_carry, ct_ys = split_list(cts, [num_carry])
-  ct_carry = _map(ad.instantiate_zeros_aval, carry_avals, ct_carry)
+  ct_carry = _map(ad.instantiate_zeros, ct_carry)
   ct_ys_is_zeros = [type(ct_y) is ad.Zero for ct_y in ct_ys]
   ct_ys = [x for x in ct_ys if type(x) is not ad.Zero]
 
@@ -797,9 +797,8 @@ def _transpose_scan_jaxpr(num_res1, num_c, num_res2, jaxpr, reduce_axes,
     cbar_abar = ad.backward_pass(
         jaxpr.jaxpr, reduce_axes, False, jaxpr.consts, primals, b_bar + ys_bar)
     _, new_c_bar, a_bar, _ = split_list(cbar_abar, [num_res1, num_c, num_a])
-    a_bar = _map(ad.instantiate_zeros_aval, a_avals, a_bar)
-    c_bar = _map(ad.instantiate_zeros_aval, c_avals,
-                _map(ad.add_tangents, c_bar, new_c_bar))
+    a_bar = _map(ad.instantiate_zeros, a_bar)
+    c_bar = _map(ad.instantiate_zeros, _map(ad.add_tangents, c_bar, new_c_bar))
     return c_bar + a_bar
   return _make_closed_jaxpr(transposed,
       res1_avals + c_avals + b_carry_avals + b_ys_avals_stripped + res2_avals)

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -473,23 +473,6 @@ class KeyTyRules:
     return random_wrap(key_data, impl=dtype._impl)
 
   @staticmethod
-  def make_tangent(shape, dtype):
-    physical_shape = (*shape, *dtype._impl.key_shape)
-    def not_implemented(name):
-      def func(*args):
-        raise NotImplementedError(f"Cannot call {name} on tangent of PRNG key.")
-      return func
-    impl = PRNGImpl(
-      key_shape=dtype._impl.key_shape,
-      seed=not_implemented('seed'),
-      split=not_implemented('split'),
-      random_bits=not_implemented('random_bits'),
-      fold_in=not_implemented('fold_in'),
-      name=f"{dtype._impl.name}_tangent",
-      tag=f"{dtype._impl.tag}_t")
-    return random_wrap(jnp.zeros(physical_shape, dtype='uint32'), impl=impl)
-
-  @staticmethod
   def physical_element_aval(dtype) -> core.ShapedArray:
     return core.ShapedArray(dtype._impl.key_shape, jnp.dtype('uint32'))
 
@@ -610,19 +593,8 @@ class KeyTyRules:
     physical_result = pxla.batched_device_put(physical_aval, physical_sharding, [physical_buf] * len(devices), devices)
     return random_wrap(physical_result, impl=aval.dtype._impl)
 
-
-class KeyTangentTy(dtypes.ExtendedDType):
-  """A dtype to use for the tangent of a PRNGKey"""
-  _impl: PRNGImpl
-  type = dtypes.prng_key
-
-  @property
-  def _rules(self):
-    raise ValueError("Cannot perform operations on the tangent of a PRNGKey.")
-
-  @property
-  def name(self) -> str:
-    return f'key_tangent<{self._impl.tag}>'
+  def tangent_dtype(_):
+    return dtypes.float0
 
 
 class KeyTy(dtypes.ExtendedDType):

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -1299,17 +1299,8 @@ def _aval_is_empty(aval) -> bool:
   return math.prod(aval.shape) == 0
 
 def _instantiate_zeros(tan, arg):
-  """Turn special ad.zero tangents into arrays of 0s for sending to host.
-  Args:
-    tan: the tangent.
-    arg: the argument for which we need to instantiate the tangent
-
-  Returns: tan if it is not ad.Zero, otherwise a 0 array of appropriate type
-    and shape
-  """
-  if type(tan) is not ad.Zero:
-    return tan
-  return ad.instantiate_zeros_aval(tan.aval, tan)
+  del arg
+  return ad.instantiate_zeros(tan)
 
 def _outside_call_jvp_rule(primals, tangents, **params):
   assert "has_token" not in params

--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -338,6 +338,9 @@ def _call_tf_impl(*args_jax_flat, callable_flat_tf, **_):
     # The following avoids copies to the host on CPU, always for Array
     # and even for ndarray if they are sufficiently aligned.
     # TODO(necula): on TPU this copies to the host!
+    if getattr(arg_jax, 'dtype', None) == dtypes.float0:
+      return tf.zeros(shape=arg_jax.shape,
+                      dtype=jax2tf_internal._tf_np_dtype_for_float0)
     return tf.constant(np.asarray(arg_jax))
 
   args_tf_flat = tuple(map(_arg_jax_to_tf, args_jax_flat))

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -43,7 +43,6 @@ from jax._src.interpreters.ad import (
   f_jvp_traceable as f_jvp_traceable,
   get_primitive_transpose as get_primitive_transpose,
   instantiate_zeros as instantiate_zeros,
-  instantiate_zeros_aval as instantiate_zeros_aval,
   is_undefined_primal as is_undefined_primal,
   jvp as jvp,
   jvp_jaxpr as jvp_jaxpr,

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1125,8 +1125,8 @@ class KeyArrayTest(jtu.JaxTestCase):
     def _f_fwd(_, state):
       return state, None
     def _f_bwd(_, state_bar):
-      assert state_bar[1].dtype.name == "key<fry_t>"  # key tangent type
-      return state_bar
+      assert state_bar[1].dtype == dtypes.float0  # key tangent type
+      return state_bar[0], state_bar
     f.defvjp(_f_fwd, _f_bwd)
     state = (8.0, jax.random.key(123))
     result = jax.grad(lambda theta: f(theta, state)[0])(3.0)
@@ -1139,9 +1139,9 @@ class KeyArrayTest(jtu.JaxTestCase):
     def _f_fwd(_, state):
       return tree_util.tree_map(lambda x: x.value, state), None
     def _f_bwd(_, state_bar):
-      self.assertTrue(dtypes.issubdtype(state_bar[1].dtype, dtypes.prng_key))
+      self.assertTrue(state_bar[1].dtype == dtypes.float0)
       self.assertIsInstance(state_bar[1], jax.custom_derivatives.SymbolicZero)
-      return state_bar
+      return state_bar[0], state_bar
     f.defvjp(_f_fwd, _f_bwd, symbolic_zeros=True)
     state = (8.0, jax.random.key(123))
     result = jax.grad(lambda theta: f(theta, state)[0])(3.0)


### PR DESCRIPTION
Revise logic for tangent types of extended dtypes. This is in preparation for some immediate follow-up work.

This involved several simple fixes that are a bit inter-dependent.
* remove the dead code KeyTangentTy (for now, though we may want such a key-tangent-type in the future)
* replace TyRules.make_tangent with TyRules.zero
* removed ad.instantiate_zeros_aval, which was redundant with ad.instantiate_zeros ever since (1) we removed units and (2) we made Zero carry an aval on it
* fix a bug in backward_pass where we instantiated a Zero at the primal type rather than the corresponding tangent type
* fix _f_bwd in test_keyarray_custom_vjp, which had the wrong type (need to return cotangents for all inputs, we were returning a (float_tangent, key_tangent) pair instead of a (float_tangent, (float_tangent, key_tangent)) nested tuple,  see #19009 for a check which catches this and hence includes the same test change

We probably also need a TyRules.add for any extended dtypes that can occur as tangent dtypes, but we currently don't have any tests that exercise that (because all extended dtype tangent types are currently float0). I will add such cases in the follow-up work though!