### PR TITLE
tweaks to enable adding custom tangent dtypes

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1911,7 +1911,7 @@ pytype_aval_mappings[DArray] = \
     lambda x: DConcreteArray(x._aval.shape, x._aval.dtype, x._aval.weak_type,
                              x._data)
 
-@dataclass(frozen=True, eq=True)
+@dataclass(frozen=True)
 class bint(dtypes.ExtendedDType):
   bound: int
 

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -599,8 +599,16 @@ class KeyTyRules:
   # tangents, our ad.replace_float0s in custom_jvp/vjp means passing in zeros
   # like the primal to user rules
   @staticmethod
-  def zero(aval):
-    return lax_internal.zeros_like_shaped_array(aval.update(dtype=dtypes.float0))
+  def zero(_):
+    return np.zeros((), dtypes.float0)
+
+  @staticmethod
+  def convert_from(key_dtype, other_dtype) -> bool:
+    return False
+
+  @staticmethod
+  def convert_to(other_dtype, key_dtype) -> bool:
+    return False
 
 
 class KeyTy(dtypes.ExtendedDType):

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1399,8 +1399,10 @@ class JnpWithKeyArrayTest(jtu.JaxTestCase):
       jnp.negative(key)
     with self.assertRaisesRegex(TypeError, "neg does not accept dtype key<fry>"):
       -key
-    with self.assertRaisesRegex(ValueError, "Cannot call convert_element_type on dtype key<fry>"):
+    with self.assertRaisesRegex(ValueError, "Cannot convert_element_type from key<fry> to int64"):
       lax.convert_element_type(key, int)
+    with self.assertRaisesRegex(ValueError, "Cannot convert_element_type from int32 to key<fry>"):
+      lax.convert_element_type(np.int32(0), key.dtype)
 
   def test_eval_shape(self):
     key = random.key(1701)


### PR DESCRIPTION
tweaks to enable adding custom tangent dtypes:
* fix a bug in zeros_like_shaped_array and KeyTyRules.zero to ensure `scalar_zero` is actually a scalar
* upgrade the adder handler for ShapedArray to delegate to an extended dtype rule for addition
* `convert_element_type` shouldn't blanket-disallow extended dtypes; actually that can be a key operation for working with them! instead, add new `convert_from` and `convert_to` rules. instead of letting these rules perform arbitrary logic, for now they can just return a bool indicating whether the conversion is legit; if false, an error is raised, and if true, the existing `convert_element_type` lowering rule just generates a `ConvertElementType` HLO from one physical type to the other

this pr also adds a test for a custom tangent dtype of interest for plumbing quantization scales out of a backward pass