### PR TITLE
revive tangent dtypes test broken by d5646db

### DIFF
--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -1994,6 +1994,9 @@ def full_like_aval(ctx: LoweringRuleContext, value, aval: core.ShapedArray) -> i
   return broadcast_in_dim(ctx, zero, aval, broadcast_dimensions=())
 
 def add_jaxvals_lowering(ctx, x, y):
+  if (isinstance(a := ctx.avals_in[0], core.ShapedArray) and
+      dtypes.issubdtype(a.dtype, dtypes.extended)):
+    return lower_fun(lambda x, y: [a.dtype._rules.add(a.dtype, x, y)])(ctx, x, y)  # type: ignore
   return [hlo.add(x, y)]
 register_lowering(ad_util.add_jaxvals_p, add_jaxvals_lowering)
 

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1513,9 +1513,15 @@ def zeros_like_array(x: ArrayLike) -> Array:
   return full_like(x, 0)
 
 
+def _add_arrays(x, y):
+  if (isinstance(a := core.get_aval(x), ShapedArray) and
+      dtypes.issubdtype(a.dtype, dtypes.extended)):
+    return dtype._rules.add(dtype, x, y)  # type: ignore
+  return add(x, y)
+
 for t in itertools.chain(
     dtypes.python_scalar_dtypes.keys(), array_types, [array.ArrayImpl]):
-  ad_util.raw_jaxval_adders[t] = add
+  ad_util.raw_jaxval_adders[t] = _add_arrays
 
 
 ### primitives

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -379,7 +379,6 @@ class DtypesTest(jtu.JaxTestCase):
     self.assertEqual(dtypes.complex_, np.complex64 if precision == '32' else np.complex128)
 
   def test_custom_tangent_dtype(self):
-    self.skipTest("blocked on fix to downstream user of jax internals")
     from jax._src import core
 
     class scale(dtypes.extended):


### PR DESCRIPTION
d5646db, the partial rollback of #19096, left a tangent dtypes test broken. this pr fixes it, though we'd still like to re-land #19096 eventually.