### PR TITLE
add jax.explain_cache_misses tracing cache miss explanations

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -818,6 +818,14 @@ log_compiles = define_bool_state(
           'option is set, the log level is WARNING; otherwise the level is '
           'DEBUG.'))
 
+explain_cache_misses = define_bool_state(
+    name='jax_explain_cache_misses',
+    default=False,
+    help=('Each time there is a miss on one of the main caches (e.g. the '
+          'tracing cache), log an explanation.. Logging is performed with '
+          '`logging`. When this option is set, the log level is WARNING; '
+          'otherwise the level is DEBUG.'))
+
 log_checkpoint_residuals = define_bool_state(
     name='jax_log_checkpoint_residuals',
     default=False,

--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -63,6 +63,7 @@ def _one_to_one_unop(
     fn = lambda x, /: lax_fn(*promote_args_inexact(numpy_fn.__name__, x))
   else:
     fn = lambda x, /: lax_fn(*promote_args(numpy_fn.__name__, x))
+  fn.__name__ = numpy_fn.__name__
   fn.__qualname__ = f"jax.numpy.{numpy_fn.__name__}"
   fn = jit(fn, inline=True)
   if lax_doc:


### PR DESCRIPTION
As part of making JAX's behavior more transparent, it must be clear not only when code is slow because it's spending all its time missing caches (and hence retracing/recompiling), but also _why_ it missed those caches. That is, just knowing (from e.g. setting jax_log_compiles) that code is retracing a lot doesn't tell the user what to do to fix things. But once the user knows that the cache misses are due to changing dtypes, or due to jit being passed a new callable object on every iteration of a loop, it's often clear what to do. And JAX can provide that information.

This PR adds such an explanation mechanism for the tracing cache. Follow-up work will add a similar one for the compilation cache.

The main idea here is that pointing out which parts of the cache key differs from previously-seen keys can constitute a pretty good explanation.

For example:
```python
# yash22.py
import jax
import jax.numpy as jnp

@jax.jit
def f(x, y):
  return jnp.sin(x) + y['hi']

print('=== EXAMPLE 0: new function ===')
f(1, {'hi': np.arange(3)})

print('=== EXAMPLE 1: new shape ===')
f(1, {'hi': np.arange(4)})

print('=== EXAMPLE 2: new kwargs signature ===')
f(1, y={'hi': np.arange(4)})

print('=== EXAMPLE 3: redefining function in a loop')
for _ in range(2):
  jax.jit(lambda x: 2 * x)(3)
```

```
$ JAX_EXPLAIN_CACHE_MISSES=1 python yash22.py
=== EXAMPLE 0: new function ===
TRACING CACHE MISS at /usr/local/google/home/mattjj/packages/jax/yash22.py:23 (<module>) because:
  never seen function:
    f defined at /usr/local/google/home/mattjj/packages/jax/yash22.py:18
=== EXAMPLE 1: new shape ===
TRACING CACHE MISS at /usr/local/google/home/mattjj/packages/jax/yash22.py:26 (<module>) because:
  for f defined at /usr/local/google/home/mattjj/packages/jax/yash22.py:18
  never seen input type signature:
    x: i32[],  y['hi']: i32[4]
  closest seen input type signature has 1 mismatches, including:
    * at y['hi'], seen i32[3], but now given i32[4]
=== EXAMPLE 2: new kwargs signature ===
TRACING CACHE MISS at /usr/local/google/home/mattjj/packages/jax/yash22.py:29 (<module>) because:
  for f defined at /usr/local/google/home/mattjj/packages/jax/yash22.py:18
  never seen passing 1 positional args and 1 keyword args with keys:
    'y'
  closest seen is passing no keyword args
=== EXAMPLE 3: redefining function in a loop
TRACING CACHE MISS at /usr/local/google/home/mattjj/packages/jax/yash22.py:33 (<module>) because:
  never seen function:
    <lambda> defined at /usr/local/google/home/mattjj/packages/jax/yash22.py:33
TRACING CACHE MISS at /usr/local/google/home/mattjj/packages/jax/yash22.py:33 (<module>) because:
  never seen function:
    <lambda> defined at /usr/local/google/home/mattjj/packages/jax/yash22.py:33
  but seen another function defined on the same line; maybe the function is
  being re-defined repeatedly, preventing caching?
```

As with any config option, these explanations can be enabled in a few different ways:
  * setting the `JAX_EXPLAIN_CACHE_MISSES` shell environment variable to something truthy;
  * setting the config option `jax.config.update('jax_explain_cache_misses', True)`;
  * using the context manager `jax._src.config.explain_cache_misses` context manager (not in public namespace yet);
  * when parsing command line flags with absl, using the `--jax_explain_cache_misses` flag.


TODO:
* [x] specifically call out weak types
* [x] tests