### PR TITLE
jax.numpy.ndarray.at: more efficient divide

### DIFF
--- a/jax/_src/numpy/array_methods.py
+++ b/jax/_src/numpy/array_methods.py
@@ -560,12 +560,10 @@ class _IndexUpdateRef:
 
     See :mod:`jax.ops` for details.
     """
-    return ufuncs.divide(
-      self.array,
-      scatter._scatter_update(lax_numpy.ones_like(self.array), self.index, values,
-                              lax.scatter_mul,
-                              indices_are_sorted=indices_are_sorted,
-                              unique_indices=unique_indices, mode=mode))
+    return scatter._scatter_update(self.array, self.index, ufuncs.reciprocal(values),
+                                   lax.scatter_mul,
+                                   indices_are_sorted=indices_are_sorted,
+                                   unique_indices=unique_indices, mode=mode)
 
   def power(self, values, *, indices_are_sorted=False, unique_indices=False,
             mode=None):


### PR DESCRIPTION
Fixes #19162. The generated Jaxexpr in the MWE is now

```python
{ lambda ; a:f32[10000,10000]. let
    b:f32[10000,10000] = pjit[
      name=f
      donated_invars=(True,)
      jaxpr={ lambda ; c:f32[10000,10000]. let
          d:f32[] = div 1.0 7.0
          e:i32[1] = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] 3
          f:f32[] = convert_element_type[new_dtype=float32 weak_type=False] d
          g:f32[10000] = broadcast_in_dim[
            broadcast_dimensions=()
            shape=(10000,)
          ] f
          h:f32[10000,10000] = scatter-mul[
            dimension_numbers=ScatterDimensionNumbers(update_window_dims=(0,), inserted_window_dims=(1,), scatter_dims_to_operand_dims=(1,))
            indices_are_sorted=True
            mode=GatherScatterMode.FILL_OR_DROP
            unique_indices=True
            update_consts=()
            update_jaxpr={ lambda ; i:f32[] j:f32[]. let
                k:f32[] = mul i j
              in (k,) }
          ] c e g
        in (h,) }
    ] a
  in (b,) }
```

Note that the floating point semantics are slightly different (`x / y` versus `x * (1.0 / y)`).