### PR TITLE
Error for deprecated scalar conversions of non-scalar arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Remember to align the itemized text with the first line of an item within a list
   * {func}`jax.numpy.linalg.solve` now shows a deprecation warning for batched 1D
     solves with `b.ndim > 1`. In the future these will be treated as batched 2D
     solves.
+  * Conversion of a non-scalar array to a Python scalar now raises an error, regardless
+    of the size of the array. Previously a deprecation warning was raised in the case of
+    non-scalar arrays of size 1. This follows a similar deprecation in NumPy.
 
 ## jaxlib 0.4.25
 

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -639,12 +639,9 @@ def escaped_tracer_error(tracer, detail=None):
 
 
 def check_scalar_conversion(arr: Array):
-  if arr.size != 1:
-    raise TypeError("Only length-1 arrays can be converted to Python scalars.")
-  if arr.shape != ():
-    # Added 2023 September 18.
-    warnings.warn("Conversion of an array with ndim > 0 to a scalar is deprecated, "
-                  "and will error in future.", DeprecationWarning, stacklevel=3)
+  if arr.ndim > 0:
+    raise TypeError("Only scalar arrays can be converted to Python scalars; "
+                    f"got {arr.ndim=}")
 
 
 def check_integer_conversion(arr: Array):


### PR DESCRIPTION
This has been raising a DeprecationWarning since JAX v0.4.16.