### PR TITLE
jnp.ndarray.item(): add args support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ Remember to align the itemized text with the first line of an item within a list
     automatically. Currently, NCCL 2.16 or newer is required.
   * We now provide Linux aarch64 wheels, both with and without NVIDIA GPU
     support.
+  * {meth}`jax.Array.item` now supports optional index arguments.
 
 * Deprecations
   * A number of internal utilities and inadvertent exports in {mod}`jax.lax` have

--- a/jax/_src/numpy/array_methods.py
+++ b/jax/_src/numpy/array_methods.py
@@ -71,19 +71,12 @@ def _nbytes(arr: ArrayLike) -> int:
   return np.size(arr) * dtypes.dtype(arr, canonicalize=True).itemsize
 
 
-def _item(a: Array) -> Any:
+def _item(a: Array, *args) -> bool | int | float | complex:
   """Copy an element of an array to a standard Python scalar and return it."""
-  if dtypes.issubdtype(a.dtype, np.complexfloating):
-    return complex(a)
-  elif dtypes.issubdtype(a.dtype, np.floating):
-    return float(a)
-  elif dtypes.issubdtype(a.dtype, np.integer):
-    return int(a)
-  elif dtypes.issubdtype(a.dtype, np.bool_):
-    return bool(a)
-  else:
-    raise TypeError(a.dtype)
-
+  arr = core.concrete_or_error(np.asarray, a, context="This occurred in the item() method of jax.Array")
+  if dtypes.issubdtype(a.dtype, dtypes.extended):
+    raise TypeError(f"No Python scalar type for {a.dtype=}")
+  return arr.item(*args)
 
 def _itemsize(arr: ArrayLike) -> int:
   """Length of one array element in bytes."""


### PR DESCRIPTION
Addresses https://github.com/google/jax/pull/19181#issuecomment-1875833407

This implements the optional index arguments to `jnp.ndarray.item`, which previously were not implemented in JAX. It also makes `arr.item()` continue to work correctly independent of the deprecation in #19181.