### PR TITLE
Add lfilter and sosfilt to scipy.signal

### DIFF
--- a/jax/scipy/signal.py
+++ b/jax/scipy/signal.py
@@ -26,4 +26,6 @@ from jax._src.scipy.signal import (
   istft as istft,
   stft as stft,
   welch as welch,
+  lfilter as lfilter,
+  sosfilt as sosfilt,
 )


### PR DESCRIPTION
Hi there!

Absolutely love this project, so I thought I'd contribute.

I started implementing https://github.com/google/jax/issues/17540, when I noticed there was no `lfilter` or `sosfilt` in Jax, so I changed course. To obtain a butterworth filter, you can generate the coefficients using `scipy.signal.butter` and then run the filter using either `lfilter` or `sosfilt`.

I am also working on a implementation of `scipy.signal.butter` in Jax (mostly copy-pasting the scipy implementation...not sure if it's worth it to invest time in this), but that'll be a bigger PR with less use (IMO), so I'm opening this one first.

A few notes:
- `lfilter` (like the scipy version) is a transposed direct form II implementation. Meaning you shouldn't use this for higher filter orders (`order` > 3) if you want to avoid stability issues.
- `sosfilt` uses cascaded second order filters instead, meaning you can have filters of arbitrary order without stability concerns (all things being equal).
- The error margins for the `numpy`/`scipy` comparison are relatively lax, as recursive errors accumulate quickly and bigger differences are to be expected when using different compilers.
- We could optionally make `sosfilt` take a `Callable` with the same signature as `lfilter` in case the user wants to use different filter types - for example [SVF filters if heavy modulation of the parameters is to be expected](https://www.dafx14.fau.de/papers/dafx14_aaron_wishnick_time_varying_filters_for_.pdf) or even nonlinear filters for specific use-cases (such as virtual analog synth filters).

This is my first contribution to Jax, so please bear with me, as I'm sure I've made a few avoidable mistakes :) If you point them out I'm happy to correct them ASAP.

Thanks!
