### PR TITLE
[shape_poly] Fixes for the lexicographic ordering of monomials.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1143,7 +1143,7 @@ def _eval_shape(shape: Sequence[shape_poly.DimSize], dtype=None) -> Sequence[TfV
       partial(core.evaluate_shape, shape, dim_vars),
       dim_values, [core.dim_value_aval()] * len(dim_values), "")  # type: ignore
   # Keep only the non-constant dimensions
-  return tuple(operator.index(d) if core.is_constant_dim(d) else d_tf
+  return tuple(operator.index(d) if core.is_constant_dim(d) else d_tf  # type: ignore
                for d, d_tf in zip(shape, shape_values_tf))
 
 

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -604,9 +604,9 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
            expect_error=(
              "Input shapes do not match the polymorphic shapes specification. "
              "Expected value >= 1 for dimension variable 'b'. "
-             "Using the following polymorphic shapes specifications: args[0].shape = (a + 2*b, a, a + b + c). "
+             "Using the following polymorphic shapes specifications: args[0].shape = (2*b + a, a, c + b + a). "
              "Obtained dimension variables: 'a' = 2 from specification 'a' for dimension args[0].shape[1] (= 2), "
-             "'b' = 0 from specification 'a + 2*b' for dimension args[0].shape[0] (= 2), . "
+             "'b' = 0 from specification '2*b + a' for dimension args[0].shape[0] (= 2), . "
              "Please see https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#shape-assertion-errors for more details."
            )),
       dict(shape=(3, 2, 6),  # a = 2, b = 0.5, c = 4 - b is not integer
@@ -614,7 +614,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
            expect_error=(
              "Input shapes do not match the polymorphic shapes specification. "
              "Division had remainder 1 when computing the value of 'b'. "
-             "Using the following polymorphic shapes specifications: args[0].shape = (a + 2*b, a, a + b + c). "
+             "Using the following polymorphic shapes specifications: args[0].shape = (2*b + a, a, c + b + a). "
              "Obtained dimension variables: 'a' = 2 from specification 'a' for dimension args[0].shape[1] (= 2), . "
              "Please see https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#shape-assertion-errors for more details."
            )),
@@ -622,10 +622,10 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
            poly_spec="(a + 2*b, a, a + b)",
            expect_error=(
              "Input shapes do not match the polymorphic shapes specification. "
-             "Found inconsistency between dimension size args[0].shape[0] (= 8) and the specification 'a + 2*b' (= 10). "
-             "Using the following polymorphic shapes specifications: args[0].shape = (a + 2*b, a, a + b). "
+             "Found inconsistency between dimension size args[0].shape[0] (= 8) and the specification '2*b + a' (= 10). "
+             "Using the following polymorphic shapes specifications: args[0].shape = (2*b + a, a, b + a). "
              "Obtained dimension variables: 'a' = 2 from specification 'a' for dimension args[0].shape[1] (= 2), "
-             "'b' = 4 from specification 'a + b' for dimension args[0].shape[2] (= 6), . "
+             "'b' = 4 from specification 'b + a' for dimension args[0].shape[2] (= 6), . "
              "Please see https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#shape-assertion-errors for more details."
            )),
       dict(shape=(7, 2, 36),  # a = 2, b = 3, c = 6 - cannot solve c
@@ -633,7 +633,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
            expect_error=(
              "Cannot solve for values of dimension variables {'c'}. "
              "We can only solve linear uni-variate constraints. "
-             "Using the following polymorphic shapes specifications: args[0].shape = (2*a + b, a, c^2). "
+             "Using the following polymorphic shapes specifications: args[0].shape = (b + 2*a, a, c^2). "
              "Unprocessed specifications: 'c^2' for dimension size args[0].shape[2]. "
              "Please see https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#dimension-variables-must-be-solvable-from-the-input-shapes for more details."
            )),
@@ -1501,7 +1501,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
         polymorphic_shapes=[x_polymorphic_shape, y_polymorphic_shape])(x, y)
     self.assertEqual(np.float32, zw_specs[0].dtype)
     self.assertEqual(np.float32, zw_specs[1].dtype)
-    self.assertEqual(("(a, 5)", "(a + b, 5)"), zw_polymorphic_shapes)
+    self.assertEqual(("(a, 5)", "(b + a, 5)"), zw_polymorphic_shapes)
 
     # We can use the zw_polymorphic_shapes for jax2tf.convert
     z, w = jax2tf.convert(

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -590,10 +590,10 @@ class JaxExportTest(jtu.JaxTestCase):
       dict(inner_poly_spec="3,a,a+b", outer_poly_spec="3,4,c",
            expect_error_outer_exp=re.escape(
              "Expected value >= 1 for dimension variable 'b'. "
-             "Using the following polymorphic shapes specifications: args[0].shape = (3, a, a + b). "
+             "Using the following polymorphic shapes specifications: args[0].shape = (3, a, b + a). "
              "Obtained dimension variables: 'a' = 4 from specification "
              "'a' for dimension args[0].shape[1] (= 4), "
-             "'b' = c + -4 from specification 'a + b' for dimension args[0].shape[2] (= c),")),
+             "'b' = c - 4 from specification 'b + a' for dimension args[0].shape[2] (= c),")),
       dict(inner_poly_spec="3,a,a", outer_poly_spec="3,4,c",
            expect_error_outer_exp=re.escape(
              "Found inconsistency between dimension size "
@@ -610,10 +610,10 @@ class JaxExportTest(jtu.JaxTestCase):
       dict(inner_poly_spec="3,a,a+b", outer_poly_spec="3,c,c",
            expect_error_outer_exp=re.escape(
                "Expected value >= 1 for dimension variable 'b'. "
-               "Using the following polymorphic shapes specifications: args[0].shape = (3, a, a + b). "
+               "Using the following polymorphic shapes specifications: args[0].shape = (3, a, b + a). "
                "Obtained dimension variables: 'a' = c from "
                "specification 'a' for dimension args[0].shape[1] (= c), "
-               "'b' = 0 from specification 'a + b' for dimension args[0].shape[2] (= c)")),
+               "'b' = 0 from specification 'b + a' for dimension args[0].shape[2] (= c)")),
       dict(inner_poly_spec="3,a,a+b", outer_poly_spec="c,4,12",
            expect_error_outer_exp=re.escape(
                "Shape mismatch for args[0].shape[0] (expected same constant)")),
@@ -689,9 +689,9 @@ class JaxExportTest(jtu.JaxTestCase):
            expect_error=(
              "Input shapes do not match the polymorphic shapes specification. "
              "Expected value >= 1 for dimension variable 'b'. "
-             "Using the following polymorphic shapes specifications: args[0].shape = (a + 2*b, a, a + b + c). "
+             "Using the following polymorphic shapes specifications: args[0].shape = (2*b + a, a, c + b + a). "
              "Obtained dimension variables: 'a' = 2 from specification 'a' for dimension args[0].shape[1] (= 2), "
-             "'b' = 0 from specification 'a + 2*b' for dimension args[0].shape[0] (= 2), . "
+             "'b' = 0 from specification '2*b + a' for dimension args[0].shape[0] (= 2), . "
              "Please see https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#shape-assertion-errors for more details."
            )),
       dict(shape=(3, 2, 6),  # a = 2, b = 0.5, c = 4 - b is not integer
@@ -699,7 +699,7 @@ class JaxExportTest(jtu.JaxTestCase):
            expect_error=(
              "Input shapes do not match the polymorphic shapes specification. "
              "Division had remainder 1 when computing the value of 'b'. "
-             "Using the following polymorphic shapes specifications: args[0].shape = (a + 2*b, a, a + b + c). "
+             "Using the following polymorphic shapes specifications: args[0].shape = (2*b + a, a, c + b + a). "
              "Obtained dimension variables: 'a' = 2 from specification 'a' for dimension args[0].shape[1] (= 2), . "
              "Please see https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#shape-assertion-errors for more details."
            )),
@@ -707,10 +707,10 @@ class JaxExportTest(jtu.JaxTestCase):
            poly_spec="(a + 2*b, a, a + b)",
            expect_error=(
              "Input shapes do not match the polymorphic shapes specification. "
-             "Found inconsistency between dimension size args[0].shape[0] (= 8) and the specification 'a + 2*b' (= 10). "
-             "Using the following polymorphic shapes specifications: args[0].shape = (a + 2*b, a, a + b). "
+             "Found inconsistency between dimension size args[0].shape[0] (= 8) and the specification '2*b + a' (= 10). "
+             "Using the following polymorphic shapes specifications: args[0].shape = (2*b + a, a, b + a). "
              "Obtained dimension variables: 'a' = 2 from specification 'a' for dimension args[0].shape[1] (= 2), "
-             "'b' = 4 from specification 'a + b' for dimension args[0].shape[2] (= 6), . "
+             "'b' = 4 from specification 'b + a' for dimension args[0].shape[2] (= 6), . "
              "Please see https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#shape-assertion-errors for more details."
            )),
       dict(shape=(7, 2, 36),  # a = 2, b = 3, c = 6 - cannot solve c
@@ -718,7 +718,7 @@ class JaxExportTest(jtu.JaxTestCase):
            expect_error=(
              "Cannot solve for values of dimension variables {'c'}. "
              "We can only solve linear uni-variate constraints. "
-             "Using the following polymorphic shapes specifications: args[0].shape = (2*a + b, a, c^2). "
+             "Using the following polymorphic shapes specifications: args[0].shape = (b + 2*a, a, c^2). "
              "Unprocessed specifications: 'c^2' for dimension size args[0].shape[2]. "
              "Please see https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#dimension-variables-must-be-solvable-from-the-input-shapes for more details."
            )),


### PR DESCRIPTION
There were several bugs in the ordering of atoms and monomials. The ordering for atoms and moomials is used for sorting, and the __eq__ is also used for hashing.

One bug was that the ordering of atoms sometimes used the `id` ordering. Another (performance) bug was that the __eq__ for atoms used the (semantic) __eq__ for DimExpr. The latter is expensive to compute, but for sorting all we need is a syntactic comparison.

We introduce a `_syntactic_cmp` method for atoms,
monomials and expressions and we use it exclusively for the ordering of atoms and monomials.

We also clean up printing and add tests for ordering and pretty printing.