### PR TITLE
[shape_poly] Simplify and speed-up the __eq__ functions for symbolic expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ Remember to align the itemized text with the first line of an item within a list
     devices.
   * {func}`jax.numpy.argsort` and {func}`jax.numpy.sort` now support the `stable`
     and `descending` arguments.
+  * Several changes to the handling of shape polymorphism (for
+    {mod}`jax.experimental.jax2tf` and {mod}`jax.experimental.export`): cleaner
+    pretty-printing of symbolic expressions ({jax-issue}`#19227`); simplified
+    and faster equality comparisons, where we consider two symbolic dimensions
+    to be equal if the normalized form of their difference reduces to 0
+    ({jax-issue}`#19231`; note that this may result in user-visible behavior
+    changes).
 * Deprecations & Removals
   * A number of previously deprecated functions have been removed, following a
     standard 3+ month deprecation cycle (see {ref}`api-compatibility`).


### PR DESCRIPTION
Equality is used heavily for symbolic expressions because we use them as dictionary keys or in sets. Previously, we used a more complete and more expensive form of equality where we attempted to prove that "e1 - e2 >= 0" and "e1 - e2 <= 0". This is an overkill and none of the tests we have so far rely on this power. Now we just normalize "e1 - e2" and if it reduces syntactically to an integer we check if the integer is 0. If the difference does not reduce to an integer we say that the expressions are disequal.

This may possibly change user-visible behavior when it depends on the outcome of equality comparisons of symbolic dimensions in presence of shape polymorphism.