### PR TITLE
Add CUDA Array Interface consumer support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Remember to align the itemized text with the first line of an item within a list
 
 ## jax 0.4.24 (Feb 6, 2024)
 
+* New Features
+  * Added [CUDA Array
+    Interface](https://numba.readthedocs.io/en/stable/cuda/cuda_array_interface.html)
+    import support.
+
 * Changes
 
   * JAX lowering to StableHLO does not depend on physical devices anymore.


### PR DESCRIPTION
This PR adds CUDA Array Interface (versions 2 and 3) consumer support to JAX.

In addition, the PR enables constructing JAX arrays from objects that implement dlpack provider support.

Fixes #1100 

Requires https://github.com/openxla/xla/pull/8237