### PR TITLE
[shape_poly] Minor improvements for handling of dilation in convolution

### DIFF
--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -142,7 +142,7 @@ def conv_general_dilated(
   if isinstance(padding, str):
     lhs_perm, rhs_perm, _ = dnums
     rhs_shape = np.take(rhs.shape, rhs_perm)[2:]  # type: ignore[index]
-    effective_rhs_shape = [(k-1) * r + 1 for k, r in zip(rhs_shape, rhs_dilation)]
+    effective_rhs_shape = [core.dilate_dim(k, r) for k, r in zip(rhs_shape, rhs_dilation)]
     padding = lax.padtype_to_pads(
         np.take(lhs.shape, lhs_perm)[2:], effective_rhs_shape,  # type: ignore[index]
         window_strides, padding)
@@ -334,7 +334,7 @@ def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
   if isinstance(padding, str) and padding in {'SAME', 'VALID'}:
     if rhs_dilation is None:
       rhs_dilation = (1,) * (rhs.ndim - 2)
-    effective_k_size = map(lambda k, r: (k-1) * r + 1, k_sdims, rhs_dilation)
+    effective_k_size = map(lambda k, r: core.dilate_dim(k, r), k_sdims, rhs_dilation)
     pads = [_conv_transpose_padding(k, s, padding)
             for k,s in zip(effective_k_size, strides)]
   else:

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4747,8 +4747,9 @@ def padtype_to_pads(in_shape, window_shape, window_strides, padding):
 
   if padding == PaddingType.SAME or padding == PaddingType.SAME_LOWER:
     out_shape = _ceil_divide(in_shape, window_strides)
-    pad_sizes = np.maximum(0, (out_shape - 1) * window_strides +
-                                window_shape - in_shape)
+    pad_sizes = (core.max_dim(d, 0)
+                 for d in (out_shape - 1) * window_strides +
+                          window_shape - in_shape)
     if padding == PaddingType.SAME:
       return [
           (pad_size // 2, pad_size - pad_size // 2) for pad_size in pad_sizes


### PR DESCRIPTION
Use` core.dilate_dim`, it is clearer and especially when using shape polymorphism it will result in better error messages.

Replace the use of np.maximum with `core.max_dim`, because the latter will result in fewer errors in presence of shape polymorphism (`core.max_dim` is deferring the actual computation to shape refinement time).