### PR TITLE
jnp.bitwise_count: promote input to numeric

### DIFF
--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -213,6 +213,7 @@ atan2 = _one_to_one_binop(getattr(np, "atan2", np.arctan2), lax.atan2, True)
 @_wraps(getattr(np, 'bitwise_count', None), module='numpy')
 @jit
 def bitwise_count(x: ArrayLike, /) -> Array:
+  x, = promote_args_numeric("bitwise_count", x)
   # Following numpy we take the absolute value and return uint8.
   return lax.population_count(abs(x)).astype('uint8')
 


### PR DESCRIPTION
This makes it compatible with `bitwise_count` for boolean inputs in NumPy 2.0.

Part of https://github.com/google/jax/issues/18353 and https://github.com/google/jax/issues/19246