### PR TITLE
lint: fix jupytext version

### DIFF
--- a/docs/tutorials/jaxpr.md
+++ b/docs/tutorials/jaxpr.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.15.2
+    jupytext_version: 1.16.0
 kernelspec:
   display_name: Python 3
   language: python


### PR DESCRIPTION
This lint failure came from a conflict between #19277 and #19147