### PR TITLE
[shape_poly] Introduce is_symbolic_dim and deprecate is_poly_dim.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,16 +21,20 @@ Remember to align the itemized text with the first line of an item within a list
   * {func}`jax.numpy.argsort` and {func}`jax.numpy.sort` now support the `stable`
     and `descending` arguments.
   * Several changes to the handling of shape polymorphism (used in
-    {mod}`jax.experimental.jax2tf` and {mod}`jax.experimental.export`): cleaner
-    pretty-printing of symbolic expressions ({jax-issue}`#19227`); simplified
-    and faster equality comparisons, where we consider two symbolic dimensions
-    to be equal if the normalized form of their difference reduces to 0
-    ({jax-issue}`#19231`; note that this may result in user-visible behavior
-    changes); improved the error messages for inconclusive inequality comparisons
-    ({jax-issue}`#19235`); the `core.non_negative_dim` API (introduced recently)
-    was deprecated and `core.max_dim` and `core.min_dim` were introduced
-    ({jax-issue}`#18953`) to express `max` and `min` for symbolic dimensions.
-    You can use `core.max_dim(d, 0)` instead of `core.non_negative_dim(d)`.
+    {mod}`jax.experimental.jax2tf` and {mod}`jax.experimental.export`):
+    * cleaner pretty-printing of symbolic expressions ({jax-issue}`#19227`)
+    * simplified and faster equality comparisons, where we consider two symbolic dimensions
+      to be equal if the normalized form of their difference reduces to 0
+      ({jax-issue}`#19231`; note that this may result in user-visible behavior
+        changes)
+    * improved the error messages for inconclusive inequality comparisons
+      ({jax-issue}`#19235`)
+    * the `core.non_negative_dim` API (introduced recently)
+      was deprecated and `core.max_dim` and `core.min_dim` were introduced
+      ({jax-issue}`#18953`) to express `max` and `min` for symbolic dimensions.
+      You can use `core.max_dim(d, 0)` instead of `core.non_negative_dim(d)`.
+    * the `shape_poly.is_poly_dim` is deprecated in favor if `export.is_symbolic_dim`
+      ({jax-issue}`#19282`).
   * Refactored the API for `jax.experimental.export`. Instead of
     `from jax.experimental.export import export` you should use now
     `from jax.experimental import export`. The old way of importing will

--- a/jax/experimental/export/__init__.py
+++ b/jax/experimental/export/__init__.py
@@ -23,8 +23,11 @@ from jax.experimental.export._export import (
     DisabledSafetyCheck,
     default_lowering_platform,
 
+    args_specs,  # TODO: move to shape_poly
+)
+from jax.experimental.export.shape_poly import (
+    is_symbolic_dim,
     symbolic_shape,
-    args_specs,
 )
 from jax.experimental.export.serialization import (
     serialize,

--- a/jax/experimental/jax2tf/__init__.py
+++ b/jax/experimental/jax2tf/__init__.py
@@ -18,6 +18,6 @@ from jax.experimental.jax2tf.jax2tf import (
   dtype_of_val as dtype_of_val,
   split_to_logical_devices as split_to_logical_devices,
   DisabledSafetyCheck as DisabledSafetyCheck,
-  PolyShape as PolyShape
+  PolyShape as PolyShape  # TODO: deprecate
 )
 from jax.experimental.jax2tf.call_tf import call_tf as call_tf

--- a/jax/experimental/jax2tf/examples/saved_model_lib.py
+++ b/jax/experimental/jax2tf/examples/saved_model_lib.py
@@ -39,7 +39,7 @@ def convert_and_save_model(
     model_dir: str,
     *,
     input_signatures: Sequence[tf.TensorSpec],
-    polymorphic_shapes: str | jax2tf.PolyShape | None = None,
+    polymorphic_shapes: str | None = None,
     with_gradient: bool = False,
     enable_xla: bool = True,
     compile_model: bool = True,

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 import contextlib
 import math
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable
 import unittest
 
 from absl import logging
@@ -32,7 +32,7 @@ import re
 
 import jax
 from jax.experimental import jax2tf
-from jax.experimental.export import export
+from jax.experimental import export
 from jax.experimental.export import shape_poly
 from jax.experimental import pjit
 from jax import lax
@@ -440,7 +440,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
       def f_tf(*args_tf):
         avals = tuple(map(
             lambda s, dt, spec: core.ShapedArray(
-                shape_poly.symbolic_shape(spec, like=s),
+                export.symbolic_shape(spec, like=s),
                 dt),
             arg_shapes, arg_dtypes, polymorphic_shapes))
         dim_vars = shape_poly.all_dim_vars(avals)
@@ -468,7 +468,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
 
     def shaped_array(shape_spec: str, actual_shape: core.Shape):
       return core.ShapedArray(
-          shape_poly.symbolic_shape(shape_spec, like=actual_shape), np.float32)
+          export.symbolic_shape(shape_spec, like=actual_shape), np.float32)
 
     # Known shapes for the arguments
     check_avals(
@@ -1443,7 +1443,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     traced = False
     # If we get_concrete_function we trace once
     f_tf = tf.function(
-        jax2tf.convert(f_jax, polymorphic_shapes=[PS("b", ...)]),
+        jax2tf.convert(f_jax, polymorphic_shapes=["b, ..."]),
         autograph=False,
         jit_compile=True).get_concrete_function(
             tf.TensorSpec([None, 2, 3], x.dtype))


### PR DESCRIPTION
The old is_poly_dim seems to be used in a few places externally. This was from the time when the symbolic dimensions were polynomials, now we use the more generic term symbolic dimension or expression.

We introduce is_symbolic_dim and we export it through the jax.experimental.export. We plan to make the entire shape_poly.py module private, and this is a necessary step.