### PR TITLE
[shape_poly] Improve and rename export.args_specs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,13 @@ Remember to align the itemized text with the first line of an item within a list
       was deprecated and `core.max_dim` and `core.min_dim` were introduced
       ({jax-issue}`#18953`) to express `max` and `min` for symbolic dimensions.
       You can use `core.max_dim(d, 0)` instead of `core.non_negative_dim(d)`.
-    * the `shape_poly.is_poly_dim` is deprecated in favor if `export.is_symbolic_dim`
+    * the `shape_poly.is_poly_dim` is deprecated in favor of `export.is_symbolic_dim`
       ({jax-issue}`#19282`).
+    * the `export.args_specs` is deprecated in favor of `export.symbolic_args_specs
+      ({jax-issue}`#19283`).
     * the `shape_poly.PolyShape` and `jax2tf.PolyShape` are deprecated, use
       strings for polymorphic shapes specifications ({jax-issue}`#19284`).
+
   * Refactored the API for `jax.experimental.export`. Instead of
     `from jax.experimental.export import export` you should use now
     `from jax.experimental import export`. The old way of importing will

--- a/jax/_src/internal_test_util/export_back_compat_test_util.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_util.py
@@ -289,7 +289,7 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
       (d) the number of devices for which the module was serialized.
     """
     # Use the native exporter, to make sure we get the proper serialization.
-    args_specs = export.args_specs(data.inputs, polymorphic_shapes)
+    args_specs = export.symbolic_args_specs(data.inputs, polymorphic_shapes)
     exported = export.export(
       jax.jit(func),
       lowering_platforms=(self.default_jax_backend(),),
@@ -306,7 +306,7 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
 
   def run_serialized(self, data: CompatTestData,
                      polymorphic_shapes: Sequence[str] | None = None):
-    args_specs = export.args_specs(data.inputs, polymorphic_shapes)
+    args_specs = export.symbolic_args_specs(data.inputs, polymorphic_shapes)
     def ndarray_to_aval(a: np.ndarray) -> core.ShapedArray:
       return core.ShapedArray(a.shape, a.dtype)
     in_avals_tree = tree_util.tree_map(ndarray_to_aval, args_specs)

--- a/jax/experimental/export/__init__.py
+++ b/jax/experimental/export/__init__.py
@@ -23,11 +23,12 @@ from jax.experimental.export._export import (
     DisabledSafetyCheck,
     default_lowering_platform,
 
-    args_specs,  # TODO: move to shape_poly
+    args_specs,  # TODO: deprecate
 )
 from jax.experimental.export.shape_poly import (
     is_symbolic_dim,
     symbolic_shape,
+    symbolic_args_specs,
 )
 from jax.experimental.export.serialization import (
     serialize,

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -166,7 +166,7 @@ class PolyHarness(Harness):
         len(polymorphic_shapes), len(args),
         f"polymorphic_shapes {polymorphic_shapes} of length "
         f"{len(polymorphic_shapes)} must match number of arguments {len(args)}")
-      args_specs = export.args_specs(args, polymorphic_shapes)
+      args_specs = export.symbolic_args_specs(args, polymorphic_shapes)
       input_signature = [
         tf.TensorSpec(
             [d if isinstance(d, int) else None for d in a.shape],

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -868,7 +868,7 @@ class JaxExportTest(jtu.JaxTestCase):
       perm = [(j, (j + 1) % axis_size) for j in range(axis_size)]
       return lax.ppermute(b, "x", perm=perm)
 
-    args_specs = export.args_specs((a,), polymorphic_shapes=poly)
+    args_specs = export.symbolic_args_specs((a,), polymorphic_shapes=poly)
     exp = get_exported(f_jax)(*args_specs)
 
     # Test JAX native execution

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -696,7 +696,7 @@ class PolyHarness(Harness):
     f_jax = self.dyn_fun
     args = self.dyn_args_maker(tst.rng())
     args = tree_util.tree_map(jnp.array, args)
-    args_specs = export.args_specs(args, self.polymorphic_shapes)
+    args_specs = export.symbolic_args_specs(args, self.polymorphic_shapes)
 
     if self.expect_error is not None:
       with tst.assertRaisesRegex(self.expect_error[0], self.expect_error[1]):


### PR DESCRIPTION
We rename `args_specs` to `symbolic_args_specs` in line with the other
public APIs related to shape polymorphism. The function used to
be in _export.py for historical reasons, we now move it to
 shape_poly.py but we export the `symbolci_args_specs` from
the public `jax.experimental.export`.

We improve the use case when the `args` passed in
are TF arrays, we move the logic to extract the shapes and dtypes
from this function to the callers. This achieves a better
separation of the JAX and TF use cases.