### PR TITLE
[shape_poly] Add support for symbolic constraints on dimension variables

### DIFF
--- a/jax/experimental/export/__init__.py
+++ b/jax/experimental/export/__init__.py
@@ -29,6 +29,7 @@ from jax.experimental.export._shape_poly import (
     is_symbolic_dim,
     symbolic_shape,
     symbolic_args_specs,
+    SymbolicScope,
 )
 from jax.experimental.export._serialization import (
     serialize,


### PR DESCRIPTION
Until now all the reasoning about symbolic dimensions was done with the implicit assumption that the dimension variables range over strictly positive integers. Here we allow the user to specify stronger constraints, so that they can be used in the reasoning about inequalities of symbolic dimensions. These explicit constraints are checked at compilation time, when the shapes are known.

This adds significant power to the implementation of shape polymorphism, and in particular it adds an
escape hatch for when in the past users saw
inconclusive comparison exceptions.

See more details in the README.md in this PR.