### PR TITLE
Prevent silent overflow in lapack worker size calculations.

### DIFF
--- a/jaxlib/cpu/BUILD
+++ b/jaxlib/cpu/BUILD
@@ -37,6 +37,8 @@ cc_library(
         "@xla//xla/service:custom_call_status",
         "@com_google_absl//absl/base:dynamic_annotations",
     ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],
 )
 
 cc_library(


### PR DESCRIPTION
As in the title.

Addresses the issues of wrong results and crashes reported in https://github.com/google/jax/issues/10420, https://github.com/google/jax/issues/10411, etc.