### PR TITLE
Pallas gpu attention- remove a potential downcast

### DIFF
--- a/jax/experimental/pallas/ops/attention.py
+++ b/jax/experimental/pallas/ops/attention.py
@@ -394,7 +394,6 @@ def mha_backward_kernel(
       dv, dk = carry
       q = pl.load(q_ref, (pl.ds(start_q * block_q, block_q), slice(None)))
       qk = pl.dot(q, k.T)
-      qk = qk.astype(q_ref.dtype)
       qk = qk.astype(jnp.float32)
       if sm_scale != 1.0:
         qk *= sm_scale


### PR DESCRIPTION
Line 397 in pallas gpu attention (backward kernel), `qk = qk.astype(q_ref.dtype)` seems to be redundant and can potentially lead to wrong results. 

Context:
```
qk = pl.dot(q, k.T)
qk = qk.astype(q_ref.dtype)
qk = qk.astype(jnp.float32)
```

Since `pl.dot` will accumulates in `float32`, the first cast is either a no-op, or a down-cast (followed by a upcast.)

In some of my experiments, this gives wrong gradients if inputs are in `(b)float16` types and the gradient norm is large.