### PR TITLE
jnp.unique: make return_inverse shape match NumPy 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Remember to align the itemized text with the first line of an item within a list
     `from jax.experimental import export`. The old way of importing will
     continue to work for a deprecation period of 3 months.
   * Added {func}`jax.scipy.stats.sem`.
+  * {func}`jax.numpy.unique` with `return_inverse = True` returns inverse indices
+    reshaped to the dimension of the input, following a similar change to
+    {func}`numpy.unique` in NumPy 2.0.
 
 * Deprecations & Removals
   * A number of previously deprecated functions have been removed, following a

--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -1453,6 +1453,9 @@ def _unique_indices_unbatched(indices, *, shape, return_inverse=False,
   # TODO: check if `indices_sorted` is True.
   out = _unique(indices, axis=0, return_inverse=return_inverse, return_index=return_index,
                 return_true_size=return_true_size, size=props.nse, fill_value=fill_value)
+  if return_inverse:
+    idx = 2 if return_index else 1
+    out = (*out[:idx], out[idx].ravel(), *out[idx + 1:])
   if return_true_size:
     nse = out[-1]
     nse = nse - (indices == fill_value).any().astype(nse.dtype)


### PR DESCRIPTION
Part of #19246

Follows NumPy change in https://github.com/numpy/numpy/pull/25553