### PR TITLE
Test: make scipy version parsing compatible with pre-releases

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1268,14 +1268,14 @@ def strict_promotion_if_dtypes_match(dtypes):
   return jax.numpy_dtype_promotion('standard')
 
 _version_regex = re.compile(r"([0-9]+(?:\.[0-9]+)*)(?:(rc|dev).*)?")
-def _parse_version(v: str) -> tuple[int, ...]:
+def parse_version(v: str) -> tuple[int, ...]:
   m = _version_regex.match(v)
   if m is None:
     raise ValueError(f"Unable to parse version '{v}'")
   return tuple(int(x) for x in m.group(1).split('.'))
 
 def numpy_version():
-  return _parse_version(np.__version__)
+  return parse_version(np.__version__)
 
 def parameterized_filterable(*,
     kwargs: Sequence[dict[str, Any]],

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -39,7 +39,7 @@ from jax._src.numpy.util import promote_dtypes_inexact
 
 config.parse_flags_with_absl()
 
-scipy_version = tuple(map(int, scipy.version.version.split('.')[:3]))
+scipy_version = jtu.parse_version(scipy.version.version)
 
 T = lambda x: np.swapaxes(x, -1, -2)
 

--- a/tests/scipy_spatial_test.py
+++ b/tests/scipy_spatial_test.py
@@ -29,7 +29,7 @@ from jax import config
 
 config.parse_flags_with_absl()
 
-scipy_version = tuple(map(int, scipy.version.version.split('.')[:3]))
+scipy_version = jtu.parse_version(scipy.version.version)
 
 float_dtypes = jtu.dtypes.floating
 real_dtypes = float_dtypes + jtu.dtypes.integer + jtu.dtypes.boolean

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -30,7 +30,7 @@ from jax.scipy.special import expit
 from jax import config
 config.parse_flags_with_absl()
 
-scipy_version = tuple(map(int, scipy.version.version.split('.')[:3]))
+scipy_version = jtu.parse_version(scipy.version.version)
 
 all_shapes = [(), (4,), (3, 4), (3, 1), (1, 4), (2, 1, 4)]
 one_and_two_dim_shapes = [(4,), (3, 4), (3, 1), (1, 4)]


### PR DESCRIPTION
Tested by running against scipy v1.12.0rc2