### PR TITLE
[shape_poly] Improve core.max_dim and core.min_dim

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2072,28 +2072,20 @@ def min_dim(d1: DimSize, d2: DimSize) -> DimSize:
   d1_is_constant = is_constant_dim(d1)
   if d1_is_constant and is_constant_dim(d2):
     return min(d1, d2)
-  try:
-    d2_ge_d1 = (d2 >= d1)
-    return d1 if d2_ge_d1 else d2
-  except InconclusiveDimensionOperation:
-    if d1_is_constant:
-      return d2.rmin(d1)  # type: ignore[union-attr]
-    else:
-      return d1.min(d2)  # type: ignore[union-attr]
+  if d1_is_constant:
+    return d2.rmin(d1)  # type: ignore[union-attr]
+  else:
+    return d1.min(d2)  # type: ignore[union-attr]
 
 def max_dim(d1: DimSize, d2: DimSize) -> DimSize:
   """Like max(d1, d2) but for both constant and symbolic dimensions."""
   d1_is_constant = is_constant_dim(d1)
   if d1_is_constant and is_constant_dim(d2):
       return max(d1, d2)
-  try:
-    d1_ge_d2 = (d1 >= d2)
-    return d1 if d1_ge_d2 else d2
-  except InconclusiveDimensionOperation:
-    if d1_is_constant:
-      return d2.rmax(d1)  # type: ignore[union-attr]
-    else:
-      return d1.max(d2)  # type: ignore[union-attr]
+  if d1_is_constant:
+    return d2.rmax(d1)  # type: ignore[union-attr]
+  else:
+    return d1.max(d2)  # type: ignore[union-attr]
 
 def dimension_as_value(d: DimSize):
   """Turns a dimension size into a JAX array.

--- a/jax/experimental/export/_shape_poly.py
+++ b/jax/experimental/export/_shape_poly.py
@@ -882,16 +882,28 @@ class _DimExpr():
              for mon, coeff in self.monomials()]
     return functools.reduce(_evaluate_add, terms) if len(terms) > 1 else terms[0]
 
-  def max(self, other: DimSize) -> _DimExpr:
+  def max(self, other: DimSize) -> DimSize:
+    lb, ub = _ensure_poly(self - other, "max").bounds()
+    if 0 <= lb: return self
+    if ub <= 0: return other
     return _DimExpr.from_operation(_DimAtom.MAX, self, other)
 
-  def rmax(self, other: DimSize) -> _DimExpr:
+  def rmax(self, other: DimSize) -> DimSize:
+    lb, ub = _ensure_poly(self - other, "max").bounds()
+    if 0 <= lb: return self
+    if ub <= 0: return other
     return _DimExpr.from_operation(_DimAtom.MAX, other, self)
 
-  def min(self, other: DimSize) -> _DimExpr:
+  def min(self, other: DimSize) -> DimSize:
+    lb, ub = _ensure_poly(self - other, "min").bounds()
+    if 0 <= lb: return other
+    if ub <= 0: return self
     return _DimExpr.from_operation(_DimAtom.MIN, self, other)
 
-  def rmin(self, other: DimSize) -> _DimExpr:
+  def rmin(self, other: DimSize) -> DimSize:
+    lb, ub = _ensure_poly(self - other, "min").bounds()
+    if 0 <= lb: return other
+    if ub <= 0: return self
     return _DimExpr.from_operation(_DimAtom.MIN, other, self)
 
   @staticmethod

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -419,6 +419,8 @@ class DimExprTest(jtu.JaxTestCase):
 
     self.assertEqual(a, core.min_dim(a, a + 2))
     self.assertEqual(a - 2, core.min_dim(a, a - 2))
+    self.assertEqual(core.min_dim(a % 2 - 1, -1), -1)
+    self.assertEqual(core.min_dim(-1, a % 2 - 1), -1)
     self.assertGreaterEqual(a, core.min_dim(a, b))
     self.assertGreaterEqual(a + c - 1, core.min_dim(a, b))
     self.assertGreaterEqual(b, core.min_dim(a, b))
@@ -440,6 +442,8 @@ class DimExprTest(jtu.JaxTestCase):
 
     self.assertEqual(a + 2, core.max_dim(a, a + 2))
     self.assertEqual(a , core.max_dim(a, a - 2))
+    self.assertEqual(core.max_dim(a % 2 - 1, 0), 0)
+    self.assertEqual(core.max_dim(0, a % 2 - 1), 0)
     self.assertGreaterEqual(core.max_dim(a, b), a)
     self.assertGreaterEqual(core.max_dim(a, b) + c - 1, a)
     self.assertGreaterEqual(core.max_dim(a, b), b)


### PR DESCRIPTION
Previously, we optimized `core.max_dim(a, b)` to `a` if `a >= b` and to `b` if `a < b`. Now we also optimize it to `b` if `a <= b`.

Similarly for `core.min_dim`.
At the same time we move more of the logic from `core.py` to `shape_poly.py`.