### PR TITLE
Include triton/ in jaxlib wheel

### DIFF
--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -69,6 +69,7 @@ py_library_providing_imports_info(
         "//jaxlib/mlir:stablehlo_dialect",
         "//jaxlib/mlir:vector_dialect",
         "//jaxlib/mosaic",
+	"//jaxlib/triton:compat",
     ],
 )
 

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -115,6 +115,8 @@ setup(
             'mlir/_mlir_libs/*.pyd',
             'mlir/_mlir_libs/*.py',
             'rocm/*',
+            "triton/*.py",
+            "triton/*.so",
         ],
         'jaxlib.xla_extension': ['*.pyi'],
     },

--- a/jaxlib/tools/build_wheel.py
+++ b/jaxlib/tools/build_wheel.py
@@ -332,6 +332,22 @@ def prepare_wheel(sources_path: pathlib.Path, *, cpu, include_gpu_plugin_extensi
       ],
   )
 
+  triton_dir = jaxlib_dir / "triton"
+  copy_runfiles(
+      dst_dir=triton_dir,
+      src_files=[
+          "__main__/jaxlib/triton/compat.py",
+          "__main__/jaxlib/triton/dialect.py",
+          f"__main__/jaxlib/triton/_triton_ext.{pyext}",
+      ],
+  )
+  patch_copy_mlir_import(
+      "__main__/jaxlib/triton/_triton_enum_gen.py", dst_dir=triton_dir
+  )
+  patch_copy_mlir_import(
+      "__main__/jaxlib/triton/_triton_ops_gen.py", dst_dir=triton_dir
+  )
+
 
 tmpdir = None
 sources_path = args.sources_path


### PR DESCRIPTION
Otherwise imports such as https://github.com/google/jax/blob/424cece35a1da4cee9d330a5cf77544c7162159c/jax/_src/lib/triton.py#L22-L23 will fail with a jaxlib installed from a wheel.

cc: @superbobry 