### PR TITLE
jax.random: deprecate passing of batched keys to APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ Remember to align the itemized text with the first line of an item within a list
   * Support for the mhlo MLIR dialect has been deprecated. JAX no longer uses
     the mhlo dialect, in favor of stablehlo. APIs that refer to "mhlo" will be
     removed in the future. Use the "stablehlo" dialect instead.
+  * {mod}`jax.random`: passing batched keys directly to random number generation functions,
+    such as {func}`~jax.random.bits`, {func}`~jax.random.gamma`, and others, is deprecated
+    and will emit a `FutureWarning`.  Use `jax.vmap` for explicit batching.
 
 ## jaxlib 0.4.24
 

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -2108,7 +2108,7 @@ _POLY_SHAPE_TEST_HARNESSES = [
       # non-partitionable), and unsafe_rbg.
       [
         PolyHarness("random_gamma", f"{flags_name}",
-                    lambda key, a: jax.random.gamma(key, a),
+                    lambda key, a: jax.vmap(jax.random.gamma)(key, a),
                     arg_descriptors=[RandArg((3, key_size), np.uint32), RandArg((3, 4, 5), _f32)],
                     polymorphic_shapes=["b, ...", "b, w, ..."], tol=1E-5,
                     override_jax_config_flags=override_jax_config_flags),  # type: ignore

--- a/tests/key_reuse_test.py
+++ b/tests/key_reuse_test.py
@@ -616,7 +616,7 @@ class KeyReuseIntegrationTest(jtu.JaxTestCase):
     def f():
       key = jax.random.key(0)
       key2 = key[None]
-      return jax.random.bits(key) + jax.random.bits(key2)
+      return jax.random.bits(key) + jax.vmap(jax.random.bits)(key2)
 
     with self.assertRaisesRegex(KeyReuseError, self.random_bits_error):
       self.check_key_reuse(f)

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -1247,6 +1247,34 @@ class LaxRandomTest(jtu.JaxTestCase):
     self.assertArraysAllClose(samples2, jnp.array([jnp.nan, 0., jnp.nan, jnp.nan]), check_dtypes=False)
     self.assertArraysAllClose(samples3, jnp.array([jnp.nan, jnp.nan, jnp.nan]), check_dtypes=False)
 
+  def test_batched_key_warnings(self):
+    keys = jax.random.split(self.make_key(0))
+    msg = "{} accepts a single key, but was given a key array of shape.*"
+
+    # Check a handful of functions that are expected to warn.
+    with self.assertWarnsRegex(FutureWarning, msg.format('bits')):
+      jax.random.bits(keys, shape=(2,))
+    with self.assertWarnsRegex(FutureWarning, msg.format('chisquare')):
+      jax.random.chisquare(keys, 1.0, shape=(2,))
+    with self.assertWarnsRegex(FutureWarning, msg.format('dirichlet')):
+      jax.random.dirichlet(keys, jnp.arange(2.0), shape=(2,))
+    with self.assertWarnsRegex(FutureWarning, msg.format('gamma')):
+      jax.random.gamma(keys, 1.0, shape=(2,))
+    with self.assertWarnsRegex(FutureWarning, msg.format('loggamma')):
+      jax.random.loggamma(keys, 1.0, shape=(2,))
+
+    # Other functions should error; test a few cases.
+    with self.assertRaisesRegex(ValueError, msg.format('fold_in')):
+      jax.random.fold_in(keys, 0)
+    with self.assertRaisesRegex(ValueError, msg.format('split')):
+      jax.random.split(keys)
+
+    # Some shouldn't error or warn
+    with self.assertNoWarnings():
+      jax.random.key_data(keys)
+      jax.random.key_impl(keys)
+
+
 threefry_seed = prng_internal.threefry_seed
 threefry_split = prng_internal.threefry_split
 threefry_random_bits = prng_internal.threefry_random_bits

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -1917,7 +1917,7 @@ _POLY_SHAPE_TEST_HARNESSES = [
       # non-partitionable), and unsafe_rbg.
       [
         PolyHarness("random_gamma", f"{flags_name}",
-                    lambda key, a: jax.random.gamma(
+                    lambda key, a: jax.vmap(jax.random.gamma)(
                       jax.random.wrap_key_data(key), a),
                     arg_descriptors=[RandArg((3, key_size), np.uint32),
                                      RandArg((3, 4, 5), _f32)],


### PR DESCRIPTION
Once the deprecation period finishes, this will fix #19376

While batched keys currently error for a number of `jax.random` functions, some functions do (unintentionally) support batched key inputs. Since erroring here would be a breaking change, I opted instead to raise a `FutureWarning` with plans to raise an error after a deprecation period.