### PR TITLE
test: fix dtype in test of lax.logistic

### DIFF
--- a/jax/_src/lax_reference.py
+++ b/jax/_src/lax_reference.py
@@ -70,7 +70,7 @@ asinh = np.arcsinh
 acosh = np.arccosh
 atanh = np.arctanh
 
-def logistic(x): return 1 / (1 + np.exp(-x))
+def logistic(x): return (1 / (1 + np.exp(-x))).astype(x.dtype)
 def betainc(a, b, x): return scipy.special.betainc(a, b, x).astype(x.dtype)
 def lgamma(x): return scipy.special.gammaln(x).astype(x.dtype)
 def digamma(x): return scipy.special.digamma(x).astype(x.dtype)


### PR DESCRIPTION
the `testOpAgainstNumpy` test of `lax.logistic` is failing under NumPy 2.0; this should fix the issue.

Part of #19246