### PR TITLE
jnp.sign: use x/abs(x) for complex arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,11 @@ Remember to align the itemized text with the first line of an item within a list
   * {func}`jax.numpy.unique` with `return_inverse = True` returns inverse indices
     reshaped to the dimension of the input, following a similar change to
     {func}`numpy.unique` in NumPy 2.0.
+  * {func}`jax.numpy.sign` now returns `x / abs(x)` for nonzero complex inputs. This is
+    consistent with the behavior of {func}`numpy.sign` in NumPy version 2.0.
   * {func}`jax.scipy.special.logsumexp` with `return_sign=True` now uses the NumPy 2.0
     convention for the complex sign, `x / abs(x)`. This is consistent with the behavior
-    of the function in SciPy v1.13.
+    of {func}`scipy.special.logsumexp` in SciPy v1.13.
 
 * Deprecations & Removals
   * A number of previously deprecated functions have been removed, following a

--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -173,6 +173,7 @@ arcsinh = _one_to_one_unop(np.arcsinh, lax.asinh, True)
 arccosh = _one_to_one_unop(np.arccosh, _arccosh, True)
 tanh = _one_to_one_unop(np.tanh, lax.tanh, True)
 arctanh = _one_to_one_unop(np.arctanh, lax.atanh, True)
+sign = _one_to_one_unop(np.sign, lax.sign)
 sqrt = _one_to_one_unop(np.sqrt, lax.sqrt, True)
 cbrt = _one_to_one_unop(np.cbrt, lax.cbrt, True)
 
@@ -255,18 +256,6 @@ def rint(x: ArrayLike, /) -> Array:
   if dtypes.issubdtype(dtype, np.complexfloating):
     return lax.complex(rint(lax.real(x)), rint(lax.imag(x)))
   return lax.round(x, lax.RoundingMethod.TO_NEAREST_EVEN)
-
-
-@_wraps(np.sign, module='numpy')
-@jit
-def sign(x: ArrayLike, /) -> Array:
-  check_arraylike('sign', x)
-  dtype = dtypes.dtype(x)
-  if dtypes.issubdtype(dtype, np.complexfloating):
-    re = lax.real(x)
-    return lax.complex(
-      lax.sign(_where(re != 0, re, lax.imag(x))), _constant_like(re, 0))
-  return lax.sign(x)
 
 
 @_wraps(np.copysign, module='numpy')


### PR DESCRIPTION
Part of #19246

Follows NumPy change in https://github.com/numpy/numpy/pull/25441

We'll need to rebase on #19389 to fix some test failures.