### PR TITLE
CI: avoid parallelizing sphinx build to fix pydata-sphinx-theme warning

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -176,4 +176,4 @@ jobs:
         pip install -r docs/requirements.txt
     - name: Render documentation
       run: |
-        sphinx-build --color -W --keep-going -b html -D nb_execution_mode=off docs docs/build/html -j auto
+        sphinx-build --color -W --keep-going -b html -D nb_execution_mode=off docs docs/build/html


### PR DESCRIPTION
Avoids new warnings triggered in the recent release of pydata-sphinx-theme