### PR TITLE
Guard shard_alike usage on xla_extension_version

### DIFF
--- a/jax/_src/shard_alike.py
+++ b/jax/_src/shard_alike.py
@@ -23,6 +23,7 @@ from jax._src.tree_util import tree_flatten, tree_unflatten
 from jax._src.interpreters import batching
 from jax._src.util import safe_zip
 from jax._src.lib import xla_client as xc
+from jax._src.lib import xla_extension_version
 from jax._src.api_util import shaped_abstractify
 from jax._src.lib.mlir import ir
 
@@ -30,6 +31,8 @@ _next_shard_group_id = itertools.count()
 
 def shard_alike(x, y):
   """Shards x and y alike."""
+  if xla_extension_version < 227:
+    raise ValueError("shard_alike requires jaxlib v0.4.24 or newer.")
   x_flat, x_tree = tree_flatten(x)
   y_flat, y_tree = tree_flatten(y)
 

--- a/tests/shard_alike_test.py
+++ b/tests/shard_alike_test.py
@@ -50,6 +50,16 @@ def tearDownModule():
   xla_bridge.get_backend.cache_clear()
 
 
+class ShardAlikeDownstreamTest(jtu.JaxTestCase):
+
+  def test_full_like(self):
+    x = jnp.arange(16, dtype='float32').reshape(8, 2)
+    mesh = jtu.create_global_mesh((8,), ("i",))
+    x = jax.device_put(x, NamedSharding(mesh, P('i', None)))
+    y = jnp.full_like(x, 1)
+    self.assertEqual(x.sharding, y.sharding)
+
+
 class ShardAlikeTest(jtu.JaxTestCase):
 
   def setUp(self):


### PR DESCRIPTION
Fixes #19440

We have to fall back to the old behavior from #19115 when using older jaxlib versions.