### PR TITLE
lax.full: add sharding argument

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -36,6 +36,7 @@ import jax.util
 
 from jax.interpreters import batching
 from jax.interpreters import xla
+from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
 from jax._src import array
 from jax._src import config
 from jax._src import dtypes
@@ -2725,6 +2726,13 @@ class LaxTest(jtu.JaxTestCase):
         return carry, carry
 
     a, b = jax.lax.scan(_step, 0, jnp.arange(4, dtype=jnp.complex64))
+
+  def test_lax_full_sharding(self):
+    devices = jax.devices()
+    mesh = Mesh(devices, axis_names=("i"))
+    sharding = NamedSharding(mesh, P('i', None))
+    x = lax.full((len(devices),), 1.0, sharding=sharding)
+    self.assertEqual(x.sharding, sharding)
 
 
 class LazyConstantTest(jtu.JaxTestCase):


### PR DESCRIPTION
This allows passing a `sharding` argument to `lax.full`, in order to construct an array with a particular sharding specification.

This is part of the work needed to implement the `device` argument in the `jax.numpy` array creation routines; part of #18353.