### PR TITLE
Test: move lax.full sharding tests to multi_device_test

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -36,7 +36,6 @@ import jax.util
 
 from jax.interpreters import batching
 from jax.interpreters import xla
-from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
 from jax._src import array
 from jax._src import config
 from jax._src import dtypes
@@ -2726,21 +2725,6 @@ class LaxTest(jtu.JaxTestCase):
         return carry, carry
 
     a, b = jax.lax.scan(_step, 0, jnp.arange(4, dtype=jnp.complex64))
-
-  def test_lax_full_sharding(self):
-    devices = jax.devices()
-    mesh = Mesh(devices, axis_names=("i"))
-    sharding = NamedSharding(mesh, P('i', None))
-    x = lax.full((len(devices),), 1.0, sharding=sharding)
-    self.assertEqual(x.sharding, sharding)
-
-  def test_lax_full_like_sharding(self):
-    devices = jax.devices()
-    mesh = Mesh(devices, axis_names=("i"))
-    sharding = NamedSharding(mesh, P('i'))
-    x = lax.iota("float32", len(devices))
-    y = lax.full_like(x, 1, sharding=sharding)
-    self.assertEqual(y.sharding, sharding)
 
 
 class LazyConstantTest(jtu.JaxTestCase):


### PR DESCRIPTION
Followup to #19445 and #19466.