### PR TITLE
Fix type annotation for `array_api.broadcast_to`

### DIFF
--- a/jax/experimental/array_api/_manipulation_functions.py
+++ b/jax/experimental/array_api/_manipulation_functions.py
@@ -24,7 +24,7 @@ def broadcast_arrays(*arrays: Array) -> list[Array]:
   return jax.numpy.broadcast_arrays(*arrays)
 
 
-def broadcast_to(x: Array, /, shape: tuple[int]) -> Array:
+def broadcast_to(x: Array, /, shape: tuple[int, ...]) -> Array:
   """Broadcasts an array to a specified shape."""
   return jax.numpy.broadcast_to(x, shape=shape)
 


### PR DESCRIPTION
I noticed the shape annotation isn't correct.