### PR TITLE
lax.asarray: avoid explicit device_put

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -132,9 +132,8 @@ def asarray(x: ArrayLike) -> Array:
   """Lightweight conversion of ArrayLike input to Array output."""
   if isinstance(x, Array):
     return x
-  if isinstance(x, np.ndarray) or np.isscalar(x):
-    # Call device_put_impl directly to avoid binding the primitive.
-    return dispatch._device_put_impl(x)
+  if isinstance(x, (np.ndarray, np.generic, bool, int, float, builtins.complex)):
+    return _convert_element_type(x, weak_type=dtypes.is_weakly_typed(x))
   else:
     raise TypeError(f"asarray: expected ArrayLike, got {x} of type {type(x)}.")
 


### PR DESCRIPTION
Fixes #19334

We had used `_device_put` here because we wanted to avoid binding any primitives, but it turns out this falls afoul of the transfer guard in some places. This changes it to using a no-op `convert_element_type`, with tests to ensure no primitives are bound.