### PR TITLE
nn.softmax: use double-where when where is specified

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -432,7 +432,8 @@ def log_softmax(x: ArrayLike,
   numpy_util.check_arraylike("log_softmax", x)
   x_arr = jnp.asarray(x)
   x_max = jnp.max(x_arr, axis, where=where, initial=initial, keepdims=True)
-  shifted = x_arr - lax.stop_gradient(x_max)
+  x_safe = x_arr if where is None else jnp.where(where, x_arr, initial)
+  shifted = x_safe - lax.stop_gradient(x_max)
   shifted_logsumexp = jnp.log(
       jnp.sum(jnp.exp(shifted), axis, where=where, keepdims=True))
   result = shifted - shifted_logsumexp
@@ -486,7 +487,8 @@ def _softmax(
     where: ArrayLike | None = None,
     initial: ArrayLike | None = None) -> Array:
   x_max = jnp.max(x, axis, where=where, initial=initial, keepdims=True)
-  unnormalized = jnp.exp(x - x_max)
+  x_safe = x if where is None else jnp.where(where, x, initial)
+  unnormalized = jnp.exp(x_safe - x_max)
   result = unnormalized / jnp.sum(unnormalized, axis, where=where, keepdims=True)
   if where is not None:
     result = jnp.where(where, result, 0)
@@ -504,7 +506,8 @@ def _softmax_deprecated(
     where: ArrayLike | None = None,
     initial: ArrayLike | None = None) -> Array:
   x_max = jnp.max(x, axis, where=where, initial=initial, keepdims=True)
-  unnormalized = jnp.exp(x - lax.stop_gradient(x_max))
+  x_safe = x if where is None else jnp.where(where, x, initial)
+  unnormalized = jnp.exp(x_safe - lax.stop_gradient(x_max))
   result = unnormalized / jnp.sum(unnormalized, axis, where=where, keepdims=True)
   if where is not None:
     result = jnp.where(where, result, 0)

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -172,6 +172,16 @@ class NNFunctionsTest(jtu.JaxTestCase):
                                 jnp.array([0, 2, 3]))
       jtu.check_grads(g_fun, (x,), order=2)
 
+  @parameterized.parameters([nn.softmax, nn.log_softmax])
+  def testSoftmaxWhereGrad(self, fn):
+    # regression test for https://github.com/google/jax/issues/19490
+    x = jnp.array([36., 10000.])
+    mask = x < 1000
+
+    f = lambda x, mask: fn(x, where=mask, initial=x.min())[0]
+
+    self.assertAllClose(jax.grad(f)(x, mask), jnp.zeros_like(x))
+
   def testSoftmaxGrad(self):
     x = jnp.array([5.5, 1.3, -4.2, 0.9])
     jtu.check_grads(nn.softmax, (x,), order=2, atol=5e-3)


### PR DESCRIPTION
Fixes #19490

I'll have to run some additional tests to know if we can merge this, because we've found in the past that changing the numerics of softmax can have unexpected downstream consequences.