### PR TITLE
Replaced most usages of abc.ABC with util.StrictABC

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -387,7 +387,10 @@ pytype_strict_library(
 pytype_strict_library(
     name = "compilation_cache_interface",
     srcs = ["_src/compilation_cache_interface.py"],
-    deps = [":path"],
+    deps = [
+        ":path",
+        ":util",
+    ],
 )
 
 pytype_strict_library(
@@ -672,7 +675,10 @@ pytype_strict_library(
 pytype_strict_library(
     name = "pretty_printer",
     srcs = ["_src/pretty_printer.py"],
-    deps = [":config"] + py_deps("colorama"),
+    deps = [
+        ":config",
+        ":util",
+    ] + py_deps("colorama"),
 )
 
 pytype_strict_library(

--- a/jax/_src/compilation_cache_interface.py
+++ b/jax/_src/compilation_cache_interface.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
 from jax._src import path as pathlib
+from jax._src import util
 
 
-class CacheInterface(ABC):
+class CacheInterface(util.StrictABC):
   _path: pathlib.Path
 
   @abstractmethod

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -48,7 +48,7 @@ from jax._src import source_info_util
 from jax._src.util import (safe_zip, safe_map, curry, tuple_insert,
                            tuple_delete, as_hashable_function,
                            HashableFunction, HashableWrapper, weakref_lru_cache,
-                           partition_list)
+                           partition_list, StrictABCMeta)
 import jax._src.pretty_printer as pp
 from jax._src.lib import jax_jit
 from jax._src import traceback_util
@@ -689,7 +689,7 @@ def _aval_property(name):
   return property(lambda self: getattr(self.aval, name))
 
 
-class Tracer(typing.Array):
+class Tracer(typing.Array, metaclass=StrictABCMeta):
   __array_priority__ = 1000
   __slots__ = ['_trace', '_line_info']
 

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -32,7 +32,7 @@ import numpy as np
 
 from jax._src import config
 from jax._src.typing import DType, DTypeLike
-from jax._src.util import set_module
+from jax._src.util import set_module, StrictABC
 
 from jax._src import traceback_util
 traceback_util.register_exclusion(__file__)
@@ -80,7 +80,7 @@ class prng_key(extended):
   """
 
 
-class ExtendedDType(metaclass=abc.ABCMeta):
+class ExtendedDType(StrictABC):
   """Abstract Base Class for extended dtypes"""
   @property
   @abc.abstractmethod

--- a/jax/_src/numpy/index_tricks.py
+++ b/jax/_src/numpy/index_tricks.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import abc
 from collections.abc import Iterable
 from typing import Any, Union
 
@@ -136,7 +135,7 @@ ogrid = _Ogrid()
 _IndexType = Union[ArrayLike, str, slice]
 
 
-class _AxisConcat(abc.ABC):
+class _AxisConcat:
   """Concatenates slices, scalars and array-like objects along a given axis."""
   axis: int
   ndmin: int

--- a/jax/_src/pretty_printer.py
+++ b/jax/_src/pretty_printer.py
@@ -27,7 +27,6 @@
 
 from __future__ import annotations
 
-import abc
 from collections.abc import Sequence
 import enum
 from functools import partial
@@ -35,6 +34,7 @@ import sys
 from typing import NamedTuple
 
 from jax._src import config
+from jax._src import util
 
 try:
   import colorama  # pytype: disable=import-error
@@ -66,7 +66,7 @@ def _can_use_color() -> bool:
 
 CAN_USE_COLOR = _can_use_color()
 
-class Doc(abc.ABC):
+class Doc(util.StrictABC):
   __slots__ = ()
 
   def format(self, width: int = 80, use_color: bool | None = None,

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import abc
 from collections.abc import Iterable, Iterator, Sequence
 import functools
 from functools import partial
@@ -633,3 +634,22 @@ try:
 except AttributeError:
   # legacy numpy
   NumpyComplexWarning = np.ComplexWarning
+
+
+class StrictABCMeta(abc.ABCMeta):
+  """A variant of `abc.ABCMeta` which does not allow virtual subclasses.
+
+  Virtual subclasses support require `abc.ABCMeta` to roundtrip through
+  pure Python when doing instance/subclass checking. This if fine for ABCs
+  which need virtual subclasses, but is wasteful for the ones which don't.
+  """
+  def register(cls, subclass):
+    del subclass  # Unused.
+    raise NotImplementedError(f"{cls} does not support virtual subclasses")
+
+  __instancecheck__ = type.__instancecheck__  # type: ignore[assignment]
+  __subclasscheck__ = type.__subclasscheck__  # type: ignore[assignment]
+
+
+class StrictABC(metaclass=StrictABCMeta):
+  __slots__ = ()

--- a/jax/experimental/array_serialization/serialization.py
+++ b/jax/experimental/array_serialization/serialization.py
@@ -33,6 +33,7 @@ from jax._src import array
 from jax._src import sharding
 from jax._src import sharding_impls
 from jax._src import typing
+from jax._src import util
 from jax._src.lib import xla_extension as xe
 import jax.numpy as jnp
 import numpy as np
@@ -334,7 +335,7 @@ def _get_key(key: int):
   return f'tensorstore_checkpoint_{key}'
 
 
-class GlobalAsyncCheckpointManagerBase(metaclass=abc.ABCMeta):
+class GlobalAsyncCheckpointManagerBase(util.StrictABC):
   """Interface for checkpointing GDAs asynchronously.
 
   This class manages the state of an ongoing asynchronous checkpoint.

--- a/jax/experimental/sparse/_base.py
+++ b/jax/experimental/sparse/_base.py
@@ -19,10 +19,11 @@ import math
 
 import jax
 from jax._src import core
+from jax._src import util
 from jax._src.typing import Array
 
 
-class JAXSparse(abc.ABC):
+class JAXSparse(util.StrictABC):
   """Base class for high-level JAX sparse objects."""
   data: jax.Array
   shape: tuple[int, ...]

--- a/jax/experimental/topologies.py
+++ b/jax/experimental/topologies.py
@@ -26,7 +26,7 @@ from jax._src import xla_bridge as xb
 Device = xc.Device
 
 
-class TopologyDescription(abc.ABC):
+class TopologyDescription:
   def __init__(self, devices: list[Device]):
     self.devices: list[Device] = devices
 


### PR DESCRIPTION
StrictABC does not allow registering virtual subclasses and can thus avoid using relatively expensive `__instancecheck__`/`__sublclasscheck__` defined in abc.ABCMeta.

The only abc.ABC subclass left is jax.Array which *does* use virtual subclasses for natively-defined array types.