### PR TITLE
fix error message for vjp arguments

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1767,6 +1767,7 @@ class ShapedArray(UnshapedArray):
 
   def str_short(self, short_dtypes=False):
     dt_str =  _short_dtype_name(self.dtype) if short_dtypes else self.dtype.name
+    dt_str = dt_str.replace('void', 'float0')
     shapestr = ','.join(map(str, self.shape))
     if self.named_shape:
       named_shapestr = ','.join(f'{k}:{v}' for k, v in self.named_shape.items())


### PR DESCRIPTION
fixes an error message that we noticed in #18931 is inaccurate (though it has nothing to do with solving the issue)

The example was

```python
import jax 
import jax.numpy as jnp

@jax.custom_vjp
def f(x):
  return  x.astype(jnp.int8)

def f_fwd(x):
  return f(x), ()

def f_bwd(res, g):
  assert res == ()
  return g,

f.defvjp(f_fwd, f_bwd)

q, bwd = jax.vjp(f, jnp.array(11.))
dq = bwd((1232.))  # note: f primal out is int, so cotangent should be float0
print(q, dq)
```

Before this PR the error message was:

```
TypeError: Type of cotangent input to vjp pullback function ([('float0', 'V')]) is not 
the expected tangent type (float32) of corresponding primal output with dtype float32.
```

After this PR the error message is:

```
ValueError: unexpected JAX type (e.g. shape/dtype) for argument to vjp function: got float32[], 
but expected float0[] because the corresponding output of the function f had JAX type int8[]
```