### PR TITLE
Slice.from_slice now works for slices with a negative start index

### DIFF
--- a/jax/_src/state/indexing.py
+++ b/jax/_src/state/indexing.py
@@ -53,7 +53,7 @@ class Slice:
     start, stop, step = slc.indices(size)
     if step != 1:
       raise ValueError(f"slice must have a step of 1 (found: {step})")
-    return cls(start, stop - start)
+    return cls(start, max(stop - start, 0))
 
 
 def dslice(start: int |  Array | None, size: int | None = None


### PR DESCRIPTION
The implementation still requires the step to be 1, so any slice with a negative start index has size 0.