### PR TITLE
[key reuse]: handle remat

### DIFF
--- a/jax/experimental/key_reuse/_forwarding.py
+++ b/jax/experimental/key_reuse/_forwarding.py
@@ -28,6 +28,7 @@ from jax._src import pjit
 from jax._src import prng
 from jax._src import random
 from jax._src import util
+from jax._src.ad_checkpoint import remat_p
 from jax._src.debugging import debug_callback_p
 from jax._src.interpreters import partial_eval as pe
 
@@ -322,3 +323,22 @@ def _while_key_type_signature(eqn, args_consumed):
   return body_signature
 
 key_reuse_signatures_dynamic[jax.lax.while_p] = _while_key_type_signature
+
+def _remat_key_type_signature(eqn, args_consumed):
+  # The assumption here is that the non-differentiated pass contains all relevant
+  # key usage, and the differentiated pass
+  #  1) will only consume keys that are already consumed in the non-differentiated pass
+  #  2) will never create keys
+  # Therefore, the differentiated pass is a no-op.
+  if eqn.params['differentiated']:
+    return KeyReuseSignatureWithForwards([], [])
+  jaxpr = eqn.params['jaxpr']
+  forwarded_inputs = {i: eqn.invars.index(var) for i, var in enumerate(eqn.invars)
+                      if var in eqn.invars[:i]}
+  sig = get_jaxpr_type_signature(jaxpr)
+  if args_consumed and any(np.any(args_consumed[s.idx] & s.mask) for s in sig.sinks):
+    # Double consumption detected: re-trace with context for better errors.
+    get_jaxpr_type_signature(jaxpr, args_consumed, forwarded_inputs)
+  return sig
+
+key_reuse_signatures_dynamic[remat_p] = _remat_key_type_signature


### PR DESCRIPTION
The challenge here is that under autodiff, `remat` involves explicitly repeating past computations, so in that context key reuse would be expected. For example:
```python
import jax

@jax.checkpoint
def f(x, key):
  return x * jax.random.bits(key)

x = jax.numpy.float32(1)
key = jax.random.key(0)
print(jax.make_jaxpr(f)(x, key))
# { lambda ; a:f32[] b:key<fry>[]. let
#     c:f32[] = remat2[
#       differentiated=False
#       jaxpr={ lambda ; d:f32[] e:key<fry>[]. let
#           f:u32[] = random_bits[bit_width=32 shape=()] e
#           g:f32[] = convert_element_type[new_dtype=float32 weak_type=False] f
#           h:f32[] = mul d g
#         in (h,) }
#       policy=None
#       prevent_cse=True
#     ] a b
#   in (c,) }

print(jax.make_jaxpr(jax.grad(f))(x, key))
# { lambda ; a:f32[] b:key<fry>[]. let
#     c:u32[] = random_bits[bit_width=32 shape=()] b
#     d:f32[] = convert_element_type[new_dtype=float32 weak_type=False] c
#     _:f32[] = mul a d
#     e:f32[] = remat2[
#       differentiated=True
#       jaxpr={ lambda ; f:key<fry>[] g:f32[]. let
#           h:u32[] = random_bits[bit_width=32 shape=()] f
#           i:f32[] = convert_element_type[new_dtype=float32 weak_type=False] h
#           j:f32[] = mul g i
#         in (j,) }
#       policy=None
#       prevent_cse=True
#     ] b 1.0
#   in (e,) }
```
Notice in the first version, the `random_bits` call appears only once. In the second, the `random_bits` call appears twice, one outside the `remat2` primitive, and once inside. However, this key reuse should not be considered problematic because `remat2` is explicit about re=computing previous values.

To address this, this PR skips the key reuse checks for the `remat2` jaxpr when `differentiated=True`.