### PR TITLE
jax.lax.pbroadcast

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -247,6 +247,36 @@ def _canonicalize_axis_index_groups(axis_index_groups):
     return
   return tuple(map(tuple, axis_index_groups))
 
+
+def pbroadcast(x, axis_name, source):
+  """Perform a collective broadcast and replicate from ``source``.
+
+  This is equivalent to
+  ```
+  def pbroadcast(x, axis_name, source):
+    masked = jnp.where(axis_index(axis_name) == source, x, zeros_like(x))
+    return psum(masked, axis_name)
+  ```
+  but implemented in a hardware optimized way.
+
+  If ``x`` is a pytree then the result is equivalent to mapping this function to
+  each leaf in the tree.
+
+  This function is an analog of the CollectiveBroadcast HLO.
+
+  Args:
+    x: array(s) with a mapped axis named ``axis_name``.
+    axis_name: hashable Python object used to name a pmapped axis (see the
+      :func:`jax.pmap` documentation for more details).
+    source: int, representing which index into ``axis_name`` that should be copied.
+
+  Returns:
+    Array(s) with ``x`` being copied from the ``source`` index slice of ``axis_name``.
+  """
+  return tree_util.tree_map(
+      partial(pbroadcast_p.bind, axis_name=axis_name, source=source), x)
+
+
 def ppermute(x, axis_name, perm):
   """Perform a collective permutation according to the permutation ``perm``.
 
@@ -926,6 +956,43 @@ mlir.register_lowering(ppermute_p, _ppermute_lowering)
 batching.primitive_batchers[ppermute_p] = partial(_collective_batcher, ppermute_p)
 batching.axis_primitive_batchers[ppermute_p] = _ppermute_batcher
 core.axis_substitution_rules[ppermute_p] = partial(_subst_all_names_in_param, 'axis_name')
+
+def _pbroadcast_transpose_rule(t, x, source, axis_name):
+  is_source = axis_index(axis_name) == source
+  tsum = psum(t, axis_name)
+  return [lax_numpy.where(is_source, tsum, lax_numpy.zeros_like(t))]
+
+def _pbroadcast_batcher(axis_size, frame_name, _, vals_in, dims_in, axis_name, source):
+  (v,), (d,) = vals_in, dims_in
+  if not isinstance(axis_name, (tuple, list)):
+    axis_name = (axis_name,)
+  remaining_axes = tuple(axis for axis in axis_name if axis != frame_name)
+  if remaining_axes:
+    raise NotImplementedError("pbroadcast batcher only supports a single axis")
+  assert axis_name[0] == frame_name, "pbroadcast batcher called with a wrong axis!"
+  assert source >= 0 and source < axis_size, "collective broadcast doesn't fit in the axis size!"
+  if axis_size == 1 and remaining_axes:
+    return pbroadcast_p.bind(v, source=source, axis_name=remaining_axes), d
+  if d is batching.not_mapped:
+    return v, d
+  return lax_numpy.take(v, [source] * axis_size, d), d
+
+def _pbroadcast_lowering(ctx, x, *, axis_name, source):
+  replica_groups = _replica_groups(ctx.module_context.axis_env, axis_name, None)
+  def source_to_front(group):
+    return [group[source]] + list(group[:source]) + list(group[source + 1:])
+  replica_groups = [source_to_front(group) for group in replica_groups]
+  channel = ctx.module_context.new_channel()
+  return hlo.CollectiveBroadcastOp(
+      x, replica_groups=_replica_groups_hlo(replica_groups)).results
+
+pbroadcast_p = core.AxisPrimitive('pbroadcast')
+pbroadcast_p.def_abstract_eval(lambda x, **params: raise_to_shaped(x))
+ad.deflinear2(pbroadcast_p, _pbroadcast_transpose_rule)
+mlir.register_lowering(pbroadcast_p, _pbroadcast_lowering)
+batching.primitive_batchers[pbroadcast_p] = partial(_collective_batcher, pbroadcast_p)
+batching.axis_primitive_batchers[pbroadcast_p] = _pbroadcast_batcher
+core.axis_substitution_rules[pbroadcast_p] = partial(_subst_all_names_in_param, 'axis_name')
 
 
 def _moveaxis(src, dst, x):

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -342,6 +342,7 @@ from jax._src.lax.parallel import (
   all_to_all_p as all_to_all_p,
   axis_index as axis_index,
   axis_index_p as axis_index_p,
+  pbroadcast as pbroadcast,
   pmax as pmax,
   pmax_p as pmax_p,
   pmean as pmean,


### PR DESCRIPTION
This is only a draft PR, and shouldn't be seriously reviewed until after https://github.com/openxla/xla/pull/8968 is merged into openXLA.

Add a new op `jax.lax.pbroadcast` that calls the new `CollectiveBroadcast` StableHlo op. 

This new operation is intended to be able to lower directly to `ncclBroadcast`. https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/colls.html#ncclbroadcast.


Example usage of this operation:

```python
@jax.jit
@partial(shard_map, mesh=..., 
    in_specs=P('i', None), out_specs=P('i', None), check_rep=False)
def f(a):
  return jax.lax.pbroadcast(a, 'i', 3)

x = jnp.arange(64).reshape((8, 8))
print(x)
print(f(x))
```

This prints
```
Array([[ 0,  1,  2,  3,  4,  5,  6,  7],
       [ 8,  9, 10, 11, 12, 13, 14, 15],
       [16, 17, 18, 19, 20, 21, 22, 23],
       [24, 25, 26, 27, 28, 29, 30, 31],
       [32, 33, 34, 35, 36, 37, 38, 39],
       [40, 41, 42, 43, 44, 45, 46, 47],
       [48, 49, 50, 51, 52, 53, 54, 55],
       [56, 57, 58, 59, 60, 61, 62, 63]], dtype=int32)
Array([[24, 25, 26, 27, 28, 29, 30, 31],
       [24, 25, 26, 27, 28, 29, 30, 31],
       [24, 25, 26, 27, 28, 29, 30, 31],
       [24, 25, 26, 27, 28, 29, 30, 31],
       [24, 25, 26, 27, 28, 29, 30, 31],
       [24, 25, 26, 27, 28, 29, 30, 31],
       [24, 25, 26, 27, 28, 29, 30, 31],
       [24, 25, 26, 27, 28, 29, 30, 31]], dtype=int32)
```

as the row `x[3] == [24, 25, 26, 27, 28, 29, 30, 31]` is broadcast to all devices. 