### PR TITLE
BUG: fix cholesky upper implementation

### DIFF
--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -69,7 +69,7 @@ def cholesky(a: ArrayLike, *, upper: bool = False) -> Array:
   check_arraylike("jnp.linalg.cholesky", a)
   a, = promote_dtypes_inexact(jnp.asarray(a))
   if upper:
-    a = jax.numpy.matrix_transpose(a)
+    a = jax.numpy.matrix_transpose(a).conj()
   return lax_linalg.cholesky(a)
 
 @overload

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -77,7 +77,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       if upper:
         axes = list(range(x.ndim))
         axes[-1], axes[-2] = axes[-2], axes[-1]
-        x = np.transpose(x, axes)
+        x = np.transpose(x, axes).conj()
       return np.linalg.cholesky(x)
 
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker,


### PR DESCRIPTION
Followup to #19606; fixes bug in implementation discovered when testing against NumPy 2.0 in our nightly run.

Part of #18353