### PR TITLE
DOC: clarify lax.rng_uniform behavior for b<=a

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4437,7 +4437,9 @@ mlir.register_lowering(outfeed_p, _outfeed_lowering)
 def rng_uniform(a, b, shape):
   """Stateful PRNG generator. Experimental and its use is discouraged.
 
-  Returns uniformly distributed random numbers in the range [a, b)
+  Returns uniformly distributed random numbers in the range [a, b). If
+  b <= a, then the result is undefined, and different implementations may
+  return different results.
 
   You should use jax.random for most purposes; this function exists only for
   niche use cases with special performance requirements.


### PR DESCRIPTION
Fixes #19616