### PR TITLE
Improve repr for empty jax.Array

### DIFF
--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -376,8 +376,11 @@ class ArrayImpl(basearray.Array):
 
     if self.is_fully_addressable or self.is_fully_replicated:
       line_width = np.get_printoptions()["linewidth"]
-      s = np.array2string(self._value, prefix=prefix, suffix=',',
-                          separator=', ', max_line_width=line_width)
+      if self.size == 0:
+        s = f"[], shape={self.shape}"
+      else:
+        s = np.array2string(self._value, prefix=prefix, suffix=',',
+                            separator=', ', max_line_width=line_width)
       last_line_len = len(s) - s.rfind('\n') + 1
       sep = ' '
       if last_line_len + len(dtype_str) + 1 > line_width:

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -231,6 +231,12 @@ class JaxArrayTest(jtu.JaxTestCase):
         input_shape, jax.sharding.NamedSharding(global_mesh, P('x', 'y')))
     self.assertStartsWith(repr(arr), "Array(")
 
+  def test_empty_repr(self):
+    shape = (0, 5)
+    dtype = 'float32'
+    x = jnp.empty(shape, dtype)
+    self.assertEqual(repr(x), f"Array([], shape={shape}, dtype={dtype})")
+
   def test_jnp_array(self):
     arr = jnp.array([1, 2, 3])
     self.assertIsInstance(arr, array.ArrayImpl)


### PR DESCRIPTION
Before:
```python
>>> jnp.empty((0, 5))
Array([], dtype=float32)
```

After:
```python
>>> jnp.empty((0, 5))
Array([], shape=(0, 5), dtype=float32)
```

Compare to recent versions of numpy:
```python
>>> np.empty((0, 5))
array([], shape=(0, 5), dtype=float64)
```