### PR TITLE
Make DTypeLike runtime checkable

### DIFF
--- a/jax/_src/typing.py
+++ b/jax/_src/typing.py
@@ -27,7 +27,7 @@ https://github.com/google/jax/pull/11859/.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any, Protocol, Union
+from typing import Any, Protocol, Union, runtime_checkable
 import numpy as np
 
 from jax._src.basearray import (
@@ -40,6 +40,8 @@ DType = np.dtype
 # TODO(jakevdp, froystig): make ExtendedDType a protocol
 ExtendedDType = Any
 
+
+@runtime_checkable
 class SupportsDType(Protocol):
   @property
   def dtype(self) -> DType: ...

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -74,6 +74,10 @@ class TypingTest(jtu.JaxTestCase):
     out5: typing.DType = dtypelike_to_dtype(HasDType("float32"))
     self.assertEqual(out5, float32_dtype)
 
+  def testSupportsDTypeInstance(self) -> None:
+    self.assertFalse(isinstance(np.dtype(float), typing.SupportsDType))
+    self.assertTrue(isinstance(np.float32, typing.SupportsDType))
+
   def testArrayLike(self) -> None:
     out1: typing.Array = arraylike_to_array(jnp.arange(4))
     self.assertArraysEqual(out1, jnp.arange(4))


### PR DESCRIPTION
@patrick-kidger, as reported in patrick-kidger/jaxtyping#165, here is the PR to make SupportsDType runtime checkable so that DTypeLike can be used with runtime type checkers.
