### PR TITLE
jaxlib/triton: ensure python 3.9 compatibility

### DIFF
--- a/jaxlib/triton/dialect.py
+++ b/jaxlib/triton/dialect.py
@@ -15,6 +15,7 @@
 # ruff: noqa
 
 """Python bindings for the MLIR Triton dialect."""
+from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import Any


### PR DESCRIPTION
mypy was failing on Python 3.9.