### PR TITLE
[shape_poly] Add limited support for equality explicit constraints.

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2016,7 +2016,9 @@ def divide_shape_sizes(s1: Shape, s2: Shape) -> DimSize:
     return 1
   q, r = divmod(sz1, sz2)
   if isinstance(r, Tracer) or r != 0:
-    raise InconclusiveDimensionOperation(f"Cannot divide evenly the sizes of shapes {tuple(s1)} and {tuple(s2)}")
+    raise InconclusiveDimensionOperation(
+        f"Cannot divide evenly the sizes of shapes {tuple(s1)} and {tuple(s2)}. "
+        f"The remainder {r} should be 0.")
   return q
 
 def cancel_divide_tracers(num, denom):

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3396,10 +3396,14 @@ def _reshape_shape_rule(operand, *, new_sizes, dimensions):
     msg = 'reshape new_sizes must all be positive, got {}.'
     raise TypeError(msg.format(new_sizes))
   # TODO(necula): re-enable this check
+  operand_size = math.prod(np.shape(operand))
+  new_size = math.prod(new_sizes)
   if (not config.dynamic_shapes.value and
-      not math.prod(np.shape(operand)) == math.prod(new_sizes)):
-    msg = 'reshape total size must be unchanged, got new_sizes {} for shape {}.'
-    raise TypeError(msg.format(new_sizes, np.shape(operand)))
+      not operand_size == new_size):
+    msg = (f"reshape total size must be unchanged, got new_sizes {new_sizes} "
+           f"(of total size {new_size}) for shape {np.shape(operand)} "
+           f"(of total size {operand_size}).")
+    raise TypeError(msg)
   if dimensions is not None:
     if set(dimensions) != set(range(np.ndim(operand))):
       msg = ('reshape dimensions must be a permutation of operand dimensions, '

--- a/jax/experimental/export/_shape_poly_decision.py
+++ b/jax/experimental/export/_shape_poly_decision.py
@@ -31,8 +31,10 @@ from jax.experimental.export._shape_poly import (
   SymbolicScope,
   DimSize,
   InconclusiveDimensionOperation,
+  Comparator,
 )
 
+def sgn(x): return 1 if x >= 0 else -1
 
 def geq_decision(e1: DimSize, e2: DimSize,
                  cmp_str: Callable[[], str]) -> bool:
@@ -55,7 +57,7 @@ def geq_decision(e1: DimSize, e2: DimSize,
   else:
     return int(e1) >= int(e2)
   decision = _DecisionByElimination(scope)
-  lb, ub = decision.bounds(e1 - e2, _stop_early_for_geq0)
+  lb, ub = decision.bounds(e1 - e2, _stop_early_for_geq0_or_lt0)
   if lb >= 0:
     return True
   if ub < 0:
@@ -70,7 +72,7 @@ def geq_decision(e1: DimSize, e2: DimSize,
 
 _shape_poly._geq_decision = geq_decision
 
-def _stop_early_for_geq0(lb, ub):
+def _stop_early_for_geq0_or_lt0(lb, ub):
   return lb >= 0 or ub < 0
 
 def bounds_decision(e: DimSize,
@@ -98,6 +100,8 @@ class _DecisionByElimination:
 
   if `sgn(m_c)*m_k < 0`
     then `abs(m_c)*e <= e0`, hence, `UB(e) <= floor(UB(e0) / abs(m_c))`,
+
+  See the implementation in self.combine_term_with_existing.
   """
   def __init__(self, scope: SymbolicScope):
     self.scope = scope
@@ -106,122 +110,161 @@ class _DecisionByElimination:
     # the explicit constraints.
     self._term_bounds: dict[_DimMon, tuple[float, float]] = {}
     # The _expr_constraints represents a set of constraints that are not
-    # just simple monomials. The set is represented as a mapping from a
-    # monomial "m" to tuples (k, c) where "c >= 0" represents a constraint that
-    # has "m" as the leading monomial with coefficient "k".
-    self._expr_constraints: dict[_DimMon, set[tuple[int, _DimExpr]]] = collections.defaultdict(set)
+    # just simple terms. The set is represented as a mapping from a
+    # term "t" to tuples (cmp, k, c) where "c >= 0" (if cmp is GEQ else "c == 0")
+    # represents a constraint that has "t" as the leading term with coefficient "k".
+    self._expr_constraints: dict[_DimMon, set[tuple[Comparator, int, _DimExpr]]] = collections.defaultdict(set)
 
-    # TODO: find a way to reuse the state reflecting the explicit constraints
-    # We sort the constraints, so that the results of the heuristics do not
-    # depend on the order in which the user writes the constraints.
-    for c, c_str in sorted(scope._explicit_constraints,
-                           key=lambda c: c[0]._monomials_sorted):
-      self.add_constraint(c, 0, c_str)
+    # Process the explicit constraints in the order in which the user specifies
+    # them. This is because the heuristics depend on the order in which the
+    # constraints are processed, and this way we give the user a way to control
+    # the result (albeit, for now, without a good feedback loop to understand
+    # how the order matters for inequalities).
+    for constr in scope._explicit_constraints:
+      if constr.cmp == Comparator.GEQ:
+        self.combine_and_add_constraint(constr.cmp, constr.diff, 0, constr.debug_str)
+      else:
+        # The equality constraints are not needed for inequality decisions,
+        # because the LHS should always be rewritten in terms of the RHS.
+        # In fact, adding them may break the assumption that if we eliminate
+        # the leading term we end up with only smaller terms, because the LHS
+        # may appear in the rest and may be rewritten to something larger.
+        # However, we want to add the implicit constraints within.
+        for m, _ in constr.diff.monomials():
+          if m.degree == 0: continue
+          self.add_implicit_constraints(m)
 
-  def add_constraint(self,
-                     e1: _DimExpr | int | float,
-                     e2: _DimExpr | int | float,
-                     constraint_str: str | None = None):
+  def combine_and_add_constraint(self,
+                                 cmp: Comparator,
+                                 e1: _DimExpr | int | float,
+                                 e2: _DimExpr | int | float,
+                                 debug_str: str | None = None):
     """Adds a constraint "e1 >= e2" to the internal state."""
     if isinstance(e1, float):
-      if np.isinf(e1) and e1 >= 0: return
+      if np.isinf(e1) and e1 >= 0 and cmp == Comparator.GEQ: return
       assert e1 == np.floor(e1)
       e1 = int(e1)
     if isinstance(e2, float):
-      if np.isinf(e2) and e2 <= 0: return
+      if np.isinf(e2) and e2 <= 0 and cmp == Comparator.GEQ: return
+      assert e2 == np.floor(e2)
       e2 = int(e2)
-    e = e1 if isinstance(e2, (int, float)) and e2 == 0 else e1 - e2
-    if constraint_str is None:
-      constraint_str = f"{e1} >= {e2}"
+    e = e1 - e2
+    if debug_str is None:
+      debug_str = f"{e1} >= {e2}"
     if (const := _DimExpr.to_constant(e)) is not None:
       if const < 0:
-        raise ValueError(f"Unsatisfiable constraint: {constraint_str}")
+        raise ValueError(f"Unsatisfiable constraint: {debug_str}")
       return
     assert isinstance(e, _DimExpr)
-    self._add_to_state(e, constraint_str)
-    combinations = self._combine_with_existing_constraints(e, constraint_str)
-    for a in combinations:
-      self._add_to_state(a, f"{a} >= 0")
+    # TODO: we only really need to add the implicit constraints now, else
+    # we may have to consider combining e with itself below (not harmful, just
+    # wasteful.
+    self.add_to_state(cmp, e, debug_str)
+    geq_combinations = self.combine_constraint_with_existing(cmp, e, debug_str)
+    for cmp, a in geq_combinations:
+      self.add_to_state(cmp, a, f"{a} >= 0")
 
-
-  def _combine_with_existing_constraints(self,
-                                         e: _DimExpr,
-                                         debug_str: str) -> set[_DimExpr]:
-    # This combines `e` with those constraints already present. The resulting
-    # constraints are not scanned for new internal constraints (because there
-    # are no new monomials), but they are also not combined further.
-    # TODO: this results in incompleteness, but it is probably a good
-    # compromise.
-    combinations: set[_DimExpr] = set()
-    def acc_combination(e: _DimExpr | int):
-      if (const := _DimExpr.to_constant(e)) is not None:
-        if const < 0:
-          raise ValueError(f"Unsatisfiable constraints: {debug_str}")
-      else:
-        combinations.add(e)  # type: ignore
-
-    # First combine with the existing monomial constraints
-    for e_m, e_c in e.monomials():
-      if e_m.degree == 0: continue
-      m_lb, m_ub = self._term_bounds.get(e_m, (-np.inf, np.inf))
-      if e_c > 0:
-        if m_ub < np.inf:
-          e_minus_m = _DimExpr._linear_combination(e._monomials_sorted, 0, 1,
-                                                   [(e_m, e_c)], 0, -1)
-          e_minus_m_ub = _DimExpr._linear_combination(e_minus_m, 0, 1,
-                                                      [(_DimMon(), 1)], 0, e_c * int(m_ub))
-          acc_combination(_DimExpr(e_minus_m_ub, e.scope))
-      else:
-        if m_lb > -np.inf:
-          e_minus_m = _DimExpr._linear_combination(e._monomials_sorted, 0, 1,
-                                                   [(e_m, e_c)], 0, -1)
-          e_minus_m_lb = _DimExpr._linear_combination(e_minus_m, 0, 1,
-                                                      [(_DimMon(), 1)], 0, e_c * int(m_lb))
-          acc_combination(_DimExpr(e_minus_m_lb, e.scope))
-
-    for prev_constraints in self._expr_constraints.values():
-      for _, prev in prev_constraints:
-        # Compose "e" with "prev" if they have one monomial with different
-        # signs
-        prev_coeffs = dict(prev._monomials_sorted)
-        for e_m, e_c in e.monomials():
-          if e_m.degree == 0: continue
-          prev_c = prev_coeffs.get(e_m)
-          if prev_c is not None and prev_c * e_c < 0:
-            new_constraint = _DimExpr(
-                _DimExpr._linear_combination(e._monomials_sorted, 0, abs(prev_c),
-                                             prev._monomials_sorted, 0, abs(e_c)),
-                e.scope)
-            acc_combination(new_constraint)
-            break
-
-    return combinations
-
-  def _add_to_state(self, e: _DimExpr,
-                    constraint_str: str):
+  def add_to_state(self,
+                   cmp: Comparator,
+                   e: _DimExpr,
+                   debug_str: str):
     """Updates the internal state to reflect "e >= 0". """
     assert _DimExpr.to_constant(e) is None
     for m, m_c in e.monomials():
       if m.degree == 0: continue
-      _add_internal_constraints(self, m, e.scope)
+      self.add_implicit_constraints(m)
 
     if (mon_factors := e.to_single_term()) is not None:
-      n, mon_c, mon = mon_factors
-      bounds = self._term_bounds.get(mon, (- np.inf, np.inf))
-      if mon_c > 0:
-        mon_ge = int(np.ceil(- n / mon_c))
-        new_bounds = (max(mon_ge, bounds[0]), bounds[1])
-      else:
-        le = int(np.floor(-n / mon_c))
-        new_bounds = (bounds[0], min(le, bounds[1]))
-      if new_bounds[0] > new_bounds[1]:
-        raise ValueError(f"Unsatisfiable constraint: {constraint_str}")
+      n, mon_c, mon = mon_factors  # n + mon * mon_c [== | >=] 0
+      lb, ub = self._term_bounds.get(mon, (- np.inf, np.inf))
+      if cmp == Comparator.EQ:
+        # n + mon_c * mon == 0  ->  mon == - n // mon_c
+        if n % mon_c:
+          raise ValueError(f"Unsatisfiable constraint: {debug_str}")
+        mon_val = - (n // mon_c)
+        lb = max(lb, mon_val)
+        ub = min(ub, mon_val)
+      else:  # GEQ
+        if mon_c > 0:
+          lb = max(lb, int(np.ceil(- n / mon_c)))
+        else:
+          ub = min(ub, int(np.floor(- n / mon_c)))
+      if lb > ub:
+        raise ValueError(f"Unsatisfiable constraint: {debug_str}")
 
-      self._term_bounds[mon] = new_bounds
+      self._term_bounds[mon] = (lb, ub)
       return
 
-    lead_m, lead_m_c = e.leading_term
-    self._expr_constraints[lead_m].add((lead_m_c, e))
+    lead_t, lead_t_k = e.leading_term
+    self._expr_constraints[lead_t].add((cmp, lead_t_k, e))
+
+  def combine_term_with_existing(self, t: _DimMon, t_k: int, *,
+                                 scope: _shape_poly.SymbolicScope,
+                                 only_smaller_than_t=True,
+                                 ) -> Sequence[tuple[Comparator,
+                                                     _DimExpr,
+                                                     int,
+                                                     int]]:
+    """
+    Combine a term with existing constraints.
+    For input (t, t_k) the tuple (c_eq, c, c_s, t_s) is among the returned
+    tuples if there exists a constraint `c =[c_eq] 0` that can be combined
+    with `t*t_k` to eliminate `t`.
+
+      * `c =[c_eq] 0`
+      * The term `comb = t*t_k*t_s + c*c_s` does not contain `t`, and if
+        `only_smaller_than_t` then `comb` contains only terms structurally
+         smaller than `t`.
+      * `c_s > 0`
+    """
+    # TODO: maybe a generator is useful here instead of materializing the list
+    acc: list[tuple[Comparator, _DimExpr, int, int]] = []
+    # First combine with the existing term constraints
+    t_lb, t_ub = self._term_bounds.get(t, (-np.inf, np.inf))
+    if t_lb == t_ub:
+      acc.append((Comparator.EQ, _DimExpr(((t, 1),), scope) - int(t_lb),
+                  abs(t_k), - sgn(t_k)))
+    else:
+      if t_lb > -np.inf:
+        acc.append((Comparator.GEQ, _DimExpr(((t, 1),), scope) - int(t_lb),
+                    abs(t_k), - sgn(t_k)))
+      if t_ub < np.inf:
+        acc.append((Comparator.GEQ, _DimExpr(((t, -1),), scope) + int(t_ub),
+                    abs(t_k), sgn(t_k)))
+
+    for prev_constraint in ([self._expr_constraints[t]] if only_smaller_than_t
+                            else self._expr_constraints.values()):
+      for c_eq, _, c in prev_constraint:
+        # TODO: optimize this dict()
+        tc_k = dict(c._monomials_sorted).get(t)
+        if tc_k is not None:
+          # c =[c_eq] 0 AND t*tc_k appears in c.
+          c_s = abs(t_k)
+          c_t = - tc_k * sgn(t_k)
+          acc.append((c_eq, c, c_s, c_t))
+    return acc
+
+  def combine_constraint_with_existing(self,
+                                       eq: Comparator,
+                                       e: _DimExpr,
+                                       debug_str: str) -> set[tuple[Comparator, _DimExpr]]:
+    combinations: set[tuple[Comparator, _DimExpr]] = set()
+    for t, t_k in e._monomials_sorted:
+      if t.degree == 0: continue
+      for (c_eq, c, c_s, t_s) in self.combine_term_with_existing(t, t_k,
+                                                                 only_smaller_than_t=False,
+                                                                 scope=e.scope):
+        # c =[c_eq] 0 AND c_s > 0 AND t*t_k*t_s + c*c_s does not contain t
+        if t_s > 0 or eq == Comparator.EQ:
+          new_eq = Comparator.EQ if (eq == c_eq == Comparator.EQ) else Comparator.GEQ
+          new_e = e * t_s + c * c_s
+          if (const := _DimExpr.to_constant(new_e)) is not None:
+            if ((new_eq == Comparator.GEQ and const < 0) or
+                (new_eq == Comparator.EQ and const != 0)):
+              raise ValueError(f"Unsatisfiable constraints: {debug_str}")
+          else:
+            combinations.add((new_eq, new_e))  # type: ignore
+    return combinations
 
   def bounds(self, e: DimSize,
              stop_early: Callable[[float, float], bool] | None
@@ -233,10 +276,17 @@ class _DecisionByElimination:
     if (const := _DimExpr.to_constant(e)) is not None:
       return (const, const)
     assert isinstance(e, _DimExpr)
-    cache_key = (e, stop_early)
-    if (res := self.scope._bounds_cache.get(cache_key)) is not None: return res
-    res = self._bounds_for_sorted_terms(e.scope, e._monomials_sorted, 0, stop_early)
-    self.scope._bounds_cache[cache_key] = res
+    # TODO: turn off the caching for now. Sometimes it leads to incompleteness.
+    # It is also too weak because if the stop_early is None, then the result
+    # should apply for any other stop_early. Similarly, if stop_early is
+    # _stop_early_for_geq0_or_leq0 and the result spans 0, then this should
+    # apply even if we don't have a stop_early.
+    #cache_key = (e, stop_early)
+    #if (res := self.scope._bounds_cache.get(cache_key)) is not None: return res
+    lb, ub = self._bounds_for_sorted_terms(e.scope, e._monomials_sorted, 0, stop_early)
+    res = (int(lb) if lb > -np.inf else lb,
+           int(ub) if ub < np.inf else ub)
+    #self.scope._bounds_cache[cache_key] = res
     return res
 
   def _bounds_for_sorted_terms(self,
@@ -250,59 +300,51 @@ class _DecisionByElimination:
     """
     if i >= len(e): return (0, 0)
 
-    m, m_c = e[i]
-    if len(m) == 0:  # A constant
+    t, t_k = e[i]
+    if len(t) == 0:  # A constant
       assert i == len(e) - 1  # Must be last
-      return (m_c, m_c)
+      return (t_k, t_k)
 
-    _add_internal_constraints(self, m, scope)
+    self.add_implicit_constraints(t)
     lb = -np.inf
     ub = np.inf
 
-    # Look among the term bounds
-    if m in self._term_bounds:
-      m_lb, m_ub = self._term_bounds.get(m, (- np.inf, np.inf))
-      rest_lb, rest_ub = self._bounds_for_sorted_terms(scope, e, i + 1, None)
-      if m_c > 0:
-        lb = max(lb, m_c * m_lb + rest_lb)
-        ub = min(ub, m_c * m_ub + rest_ub)
-      else:
-        lb = max(lb, m_c * m_ub + rest_lb)
-        ub = min(ub, m_c * m_lb + rest_ub)
+    for (c_eq, c, c_s, t_s) in self.combine_term_with_existing(t, t_k,
+                                                               only_smaller_than_t=True,
+                                                               scope=scope):
+      # `c =[eq] 0` AND `t*t_k*t_s + c*c_s` contains only terms smaller than t
+      # AND c_s > 0.
+      # rest = e[i:]*t_s + c*c_s` AND `rest_ub >= rest >= rest_lb`
+      rest = _DimExpr._linear_combination(e, i, t_s,
+                                          c._monomials_sorted, 0, c_s)
+      rest_lb, rest_ub = self._bounds_for_sorted_terms(scope, rest, 0, None)
+      if rest_ub < np.inf:
+        if t_s > 0:
+          ub = min(ub, int(np.floor(rest_ub / t_s)))
+        else:
+          lb = max(lb, int(np.ceil(rest_ub / t_s)))
+
+      if rest_lb > - np.inf and c_eq == Comparator.EQ:
+        if t_s > 0:
+          lb = max(lb, int(np.ceil(rest_lb / t_s)))
+        else:
+          ub = min(ub, int(np.floor(rest_lb / t_s)))
 
       if stop_early is not None and stop_early(lb, ub): return (lb, ub)
 
-    # Now look through the _expr_constraints
-    if m in self._expr_constraints:
-      for m_k, c in self._expr_constraints[m]:
-        # A complex expression. See comments from top of class.
-        sgn_m_k = 1 if m_k > 0 else -1
-        abs_m_k = m_k * sgn_m_k
-        # The recursive call has a smaller leading monomial, because we are only
-        # looking at the tail of e, and in c the largest monomial is m, and the
-        # merging will cancel the m.
-        rest = _DimExpr._linear_combination(e, i, abs_m_k,
-                                            c._monomials_sorted, 0, - sgn_m_k * m_c)
-        rest_lb, rest_ub = self._bounds_for_sorted_terms(scope, rest, 0, None)
-        if m_c / m_k > 0:
-          lb = max(lb, np.ceil(rest_lb / abs_m_k))
-        else:
-          ub = min(ub, np.floor(rest_ub / abs_m_k))
-        if stop_early is not None and stop_early(lb, ub): return (lb, ub)
-
     # Now look for special rules for atoms
-    if (m_a := m.to_atom()) is not None:
+    if (m_a := t.to_atom()) is not None:
       if m_a.operation in [_DimAtom.MAX, _DimAtom.MIN]:
         # m_c*MAX(op1, op2) + rest_e >= max(m_c * op1 + rest_e, m_c * op2 + rest_e)
         #   if m_c > 0. Similar rules for when m_c < 0 and for MIN.
         op1, op2 = m_a.operands
         rest1 = _DimExpr._linear_combination(e, i + 1, 1,
-                                             op1._monomials_sorted, 0, m_c)
+                                             op1._monomials_sorted, 0, t_k)
         rest2 = _DimExpr._linear_combination(e, i + 1, 1,
-                                             op2._monomials_sorted, 0, m_c)
+                                             op2._monomials_sorted, 0, t_k)
         rest1_lb, rest1_ub = self._bounds_for_sorted_terms(scope, rest1, 0, None)
         rest2_lb, rest2_ub = self._bounds_for_sorted_terms(scope, rest2, 0, None)
-        like_max = (m_c > 0 if m_a.operation == _DimAtom.MAX else m_c < 0)
+        like_max = (t_k > 0 if m_a.operation == _DimAtom.MAX else t_k < 0)
         if like_max:
           lb = max(lb, max(rest1_lb, rest2_lb))
           ub = min(ub, max(rest1_ub, rest2_ub))
@@ -313,101 +355,101 @@ class _DecisionByElimination:
 
     return lb, ub
 
-def _add_internal_constraints(decision: _DecisionByElimination, m: _DimMon, scope: SymbolicScope):
-  """Adds the internal constraints for the monomial `m`."""
-  if m in decision._processed_for_internal_constraints: return
-  decision._processed_for_internal_constraints.add(m)
-  m_e = _DimExpr.from_monomial(m, 1, scope)  # m as a _DimExpr
-  a = m.to_atom()
-  if a is None:
-    # This is a multiplication of atoms. Try to compute bounds based on
-    # the bounds of the atoms.
-    bounds = []
-    for a, exp in m.items():
-      a_l, a_u = decision.bounds(_DimExpr.from_monomial(_DimMon.from_atom(a, 1),
-                                                        1, scope), None)
-      assert a_l <= a_u
-      bounds.append((a_l ** exp, a_u ** exp))
+  def add_implicit_constraints(self: _DecisionByElimination, m: _DimMon):
+    """Adds the internal constraints for the monomial `m`."""
+    if m in self._processed_for_internal_constraints: return
+    self._processed_for_internal_constraints.add(m)
+    m_e = _DimExpr.from_monomial(m, 1, self.scope)  # m as a _DimExpr
+    a = m.to_atom()
+    if a is None:
+      # This is a multiplication of atoms. Try to compute bounds based on
+      # the bounds of the atoms.
+      bounds = []
+      for a, exp in m.items():
+        a_l, a_u = self.bounds(_DimExpr.from_monomial(_DimMon.from_atom(a, 1),
+                                                      1, self.scope), None)
+        assert a_l <= a_u
+        bounds.append((a_l ** exp, a_u ** exp))
 
-    candidate_bounds = [math.prod(atom_bounds)
-                        for atom_bounds in itertools.product(*bounds)]
-    m_l = min(*candidate_bounds)
-    m_u = max(*candidate_bounds)
-    decision.add_constraint(m_e, m_l)
-    decision.add_constraint(m_u, m_e)
-    return
+      candidate_bounds = [math.prod(atom_bounds)
+                          for atom_bounds in itertools.product(*bounds)]
+      m_l = min(*candidate_bounds)
+      m_u = max(*candidate_bounds)
+      self.combine_and_add_constraint(Comparator.GEQ, m_e, m_l)
+      self.combine_and_add_constraint(Comparator.GEQ, m_u, m_e)
+      return
 
-  # It is an atom, is it a variable?
-  if (v := a.to_var()) is not None:
-    decision.add_constraint(m_e, 1)  # v >= 1
-    return
+    # It is an atom, is it a variable?
+    if (v := a.to_var()) is not None:
+      self.combine_and_add_constraint(Comparator.GEQ, m_e, 1,
+                                      debug_str=f"{v} >= 1")  # v >= 1
+      return
 
-  if a.operation == _DimAtom.MOD:
-    op1, op2 = a.operands
-    op2_b_l, op2_b_u = decision.bounds(op2, _stop_early_for_geq0)
-    if op2_b_l > 0:  # positive divisor
-      decision.add_constraint(m_e, 0)  # m >= 0
-      decision.add_constraint(op2 - 1, m_e)  # m <= op2 - 1
-      decision.add_constraint(op2_b_u - 1, m_e)
-    elif op2_b_u < 0:  # negative divisor
-      decision.add_constraint(m_e, op2 + 1)  # m >= op2 + 1
-      decision.add_constraint(m_e, op2_b_l + 1)
-      decision.add_constraint(0, m_e)  # m <= 0
-    return
+    if a.operation == _DimAtom.MOD:
+      op1, op2 = a.operands
+      op2_b_l, op2_b_u = self.bounds(op2, _stop_early_for_geq0_or_lt0)
+      if op2_b_l > 0:  # positive divisor
+        self.combine_and_add_constraint(Comparator.GEQ, m_e, 0)  # m >= 0
+        self.combine_and_add_constraint(Comparator.GEQ, op2 - 1, m_e)  # m <= op2 - 1
+        self.combine_and_add_constraint(Comparator.GEQ, op2_b_u - 1, m_e)
+      elif op2_b_u < 0:  # negative divisor
+        self.combine_and_add_constraint(Comparator.GEQ, m_e, op2 + 1)  # m >= op2 + 1
+        self.combine_and_add_constraint(Comparator.GEQ, m_e, op2_b_l + 1)
+        self.combine_and_add_constraint(Comparator.GEQ, 0, m_e)  # m <= 0
+      return
 
-  if a.operation == _DimAtom.FLOORDIV:
-    op1, op2 = a.operands
-    (op1_l, op1_u) = decision.bounds(op1, None)
-    (op2_l, op2_u) = decision.bounds(op2, None)
+    if a.operation == _DimAtom.FLOORDIV:
+      op1, op2 = a.operands
+      (op1_l, op1_u) = self.bounds(op1, None)
+      (op2_l, op2_u) = self.bounds(op2, None)
 
-    def math_floor_with_inf(a: float, b: float):  # math.floor, but aware of inf
-      # When either a or b are infinite, the results represent the limit
-      # of "a // b".
-      assert b != 0
-      if not np.isinf(b):  # divisor b is finite
-        if not np.isinf(a):
-          return math.floor(a / b)
-        # a is infinite, b is finite
-        return -np.inf if (a >= 0) != (b >= 0) else np.inf
-      elif not np.isinf(a):  # dividend a is finite and divisor b is infinite
-        return -1 if (a >= 0) != (b >= 0) else 0
-      else:  # both dividend and divisor are infinite
-        return -np.inf if (a >= 0) != (b >= 0) else np.inf
+      def math_floor_with_inf(a: float, b: float):  # math.floor, but aware of inf
+        # When either a or b are infinite, the results represent the limit
+        # of "a // b".
+        assert b != 0
+        if not np.isinf(b):  # divisor b is finite
+          if not np.isinf(a):
+            return math.floor(a / b)
+          # a is infinite, b is finite
+          return -np.inf if (a >= 0) != (b >= 0) else np.inf
+        elif not np.isinf(a):  # dividend a is finite and divisor b is infinite
+          return -1 if (a >= 0) != (b >= 0) else 0
+        else:  # both dividend and divisor are infinite
+          return -np.inf if (a >= 0) != (b >= 0) else np.inf
 
-    # Same reasoning as for multiplication: the bounds are among the cross-product
-    # of the bounds.
-    candidate_bounds = [math_floor_with_inf(op1_l, op2_l),
-                        math_floor_with_inf(op1_l, op2_u),
-                        math_floor_with_inf(op1_u, op2_l),
-                        math_floor_with_inf(op1_u, op2_u)]
-    m_l = min(*candidate_bounds)
-    m_u = max(*candidate_bounds)
-    decision.add_constraint(m_e, m_l)
-    decision.add_constraint(m_u, m_e)
-    if op2_l >= 0:
-      if decision.bounds(op1, _stop_early_for_geq0)[0] >= 0:
-        decision.add_constraint(m_e, 0)
-      mod_e = _DimExpr.from_operation(_DimAtom.MOD, op1, op2,
-                                      scope=scope)
-      combined = op2 * m_e + mod_e
-      decision.add_constraint(op1, combined)
-      decision.add_constraint(combined, op1)
-    return
+      # Same reasoning as for multiplication: the bounds are among the cross-product
+      # of the bounds.
+      candidate_bounds = [math_floor_with_inf(op1_l, op2_l),
+                          math_floor_with_inf(op1_l, op2_u),
+                          math_floor_with_inf(op1_u, op2_l),
+                          math_floor_with_inf(op1_u, op2_u)]
+      m_l = min(*candidate_bounds)
+      m_u = max(*candidate_bounds)
+      self.combine_and_add_constraint(Comparator.GEQ, m_e, m_l)
+      self.combine_and_add_constraint(Comparator.GEQ, m_u, m_e)
+      if op2_l >= 0:
+        if self.bounds(op1, _stop_early_for_geq0_or_lt0)[0] >= 0:
+          self.combine_and_add_constraint(Comparator.GEQ, m_e, 0)
+        mod_e = _DimExpr.from_operation(_DimAtom.MOD, op1, op2,
+                                        scope=self.scope)
+        combined = op2 * m_e + mod_e
+        self.combine_and_add_constraint(Comparator.EQ, op1, combined)
+      return
 
-  if a.operation == _DimAtom.MAX:
-    op1, op2 = a.operands
-    op1_b_l, op1_b_u = decision.bounds(op1, None)
-    op2_b_l, op2_b_u = decision.bounds(op2, None)
-    decision.add_constraint(m_e, max(op1_b_l, op2_b_l))
-    decision.add_constraint(max(op1_b_u, op2_b_u), m_e)
-    decision.add_constraint(m_e, op1)
-    decision.add_constraint(m_e, op2)
+    if a.operation == _DimAtom.MAX:
+      op1, op2 = a.operands
+      op1_b_l, op1_b_u = self.bounds(op1, None)
+      op2_b_l, op2_b_u = self.bounds(op2, None)
+      self.combine_and_add_constraint(Comparator.GEQ, m_e, max(op1_b_l, op2_b_l))
+      self.combine_and_add_constraint(Comparator.GEQ, max(op1_b_u, op2_b_u), m_e)
+      self.combine_and_add_constraint(Comparator.GEQ, m_e, op1)
+      self.combine_and_add_constraint(Comparator.GEQ, m_e, op2)
 
-  if a.operation == _DimAtom.MIN:
-    op1, op2 = a.operands
-    op1_b_l, op1_b_u = decision.bounds(op1, None)
-    op2_b_l, op2_b_u = decision.bounds(op2, None)
-    decision.add_constraint(m_e, min(op1_b_l, op2_b_l))
-    decision.add_constraint(min(op1_b_u, op2_b_u), m_e)
-    decision.add_constraint(op1, m_e)
-    decision.add_constraint(op2, m_e)
+    if a.operation == _DimAtom.MIN:
+      op1, op2 = a.operands
+      op1_b_l, op1_b_u = self.bounds(op1, None)
+      op2_b_l, op2_b_u = self.bounds(op2, None)
+      self.combine_and_add_constraint(Comparator.GEQ, m_e, min(op1_b_l, op2_b_l))
+      self.combine_and_add_constraint(Comparator.GEQ, min(op1_b_u, op2_b_u), m_e)
+      self.combine_and_add_constraint(Comparator.GEQ, op1, m_e)
+      self.combine_and_add_constraint(Comparator.GEQ, op2, m_e)


### PR DESCRIPTION
Previously, we have added support for inequality constraints. Now we also add equality constraints. These are useful when encountering errors due to inability to check equalities of symbolic expressions, e.g., in the broadcasting rules. For example, the current decision procedure cannot decide that `mod(mod(a, 2), 2) == mod(a, 2)`. To work around such limitations, it is now possible to add the above like an equality constraint. Like other explicit constraints, this will be used to decide equalities during staging, and will be checked at shape refinement time.

See more details in the README.md changes.

This change is known to make some of the reasoning about symbolic constraints slower than before, but I decided
to land this change in functionality as is, and leave internal refactoring for performance optimizations to a separate change.