### PR TITLE
Add jax.tree_util.tree_traverse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Remember to align the itemized text with the first line of an item within a list
 
 ## jax 0.4.25
 
+* New Features
+  * Added {func}`jax.tree_util.tree_traverse`
+
 ## jaxlib 0.4.25
 
 ## jax 0.4.24 (Feb 6, 2024)

--- a/docs/jax.tree_util.rst
+++ b/docs/jax.tree_util.rst
@@ -12,6 +12,7 @@ List of Functions
    :toctree: _autosummary
 
    Partial
+   MAP_TO_NONE
    all_leaves
    build_tree
    register_pytree_node
@@ -28,6 +29,7 @@ List of Functions
    tree_reduce
    tree_structure
    tree_transpose
+   tree_traverse
    tree_unflatten
    treedef_children
    treedef_is_leaf

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -39,6 +39,7 @@ for examples.
 # See PEP 484 & https://github.com/google/jax/issues/7570
 
 from jax._src.tree_util import (
+  MAP_TO_NONE as MAP_TO_NONE,
   Partial as Partial,
   PyTreeDef as PyTreeDef,
   all_leaves as all_leaves,
@@ -52,6 +53,7 @@ from jax._src.tree_util import (
   tree_reduce as tree_reduce,
   tree_structure as tree_structure,
   tree_transpose as tree_transpose,
+  tree_traverse as tree_traverse,
   tree_unflatten as tree_unflatten,
   treedef_children as treedef_children,
   treedef_is_leaf as treedef_is_leaf,


### PR DESCRIPTION
This provides the same API as `tree.traverse` from https://github.com/google-deepmind/tree

cc/ @mtthss

Fixes #19631