### PR TITLE
test_util: avoid overflow errors in NumPy 2.0

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -575,9 +575,9 @@ def _rand_dtype(rand, shape, dtype, scale=1., post=lambda x: x):
     to rand but scaled, converted to the appropriate dtype, and post-processed.
   """
   if _dtypes.issubdtype(dtype, np.unsignedinteger):
-    r = lambda: np.asarray(scale * abs(rand(*_dims_of_shape(shape))), dtype)
+    r = lambda: np.asarray(scale * abs(rand(*_dims_of_shape(shape)))).astype(dtype)
   else:
-    r = lambda: np.asarray(scale * rand(*_dims_of_shape(shape)), dtype)
+    r = lambda: np.asarray(scale * rand(*_dims_of_shape(shape))).astype(dtype)
   if _dtypes.issubdtype(dtype, np.complexfloating):
     vals = r() + 1.0j * r()
   else:


### PR DESCRIPTION
Part of #19246.

NumPy 2.0 added OverflowErrors on array creation if the input is not representable under the requested dtype. For example:
```python
>>> np.array(1000, dtype='uint8')
---------------------------------------------------------------------------
OverflowError                             Traceback (most recent call last)
Cell In[2], line 1
----> 1 np.array(1000, dtype='uint8')

OverflowError: Python integer 1000 out of bounds for uint8
```
This can be prevented by explicitly calling `astype`:
```python
>>> np.array(1000).astype('uint8')
array(232, dtype=uint8)
```
This PR fixes a number of test failures under NumPy 2.0 that are related to this NumPy 2.0 behavior.