### PR TITLE
Handle jaxpr `list`s when pretty-printing key-value pairs

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -3130,7 +3130,7 @@ def pp_vars(vs: Sequence[Any], context: JaxprPpContext,
     ))
 
 def pp_kv_pair(k:str, v: Any, context: JaxprPpContext, settings: JaxprPpSettings) -> pp.Doc:
-  if type(v) is tuple and all(isinstance(j, (Jaxpr, ClosedJaxpr)) for j in v):
+  if isinstance(v, Iterable) and all(isinstance(j, (Jaxpr, ClosedJaxpr)) for j in v):
     pp_v = pp_jaxprs(v, context, settings)
   elif isinstance(v, Jaxpr):
     pp_v = pp_jaxpr(v, context, settings)


### PR DESCRIPTION
This PR adds support for pretty-printing jaxpr parameter values which are non-`tuple` iterables.

As an example, consider a program which declares a JAX primitive that, when evaluated, accepts a sequence of `ClosedJaxpr` instances as a parameter input:

```python
from typing import Sequence

from jax import make_jaxpr
from jax.core import Primitive, ClosedJaxpr

# ------------------------------------------------------------------------------

simple_if_p = Primitive("if")

@simple_if_p.def_abstract_eval
def simple_if_abstract_eval(_pred, branch_jaxprs: Sequence[ClosedJaxpr]):
    return branch_jaxprs[0].out_avals[0]

# ------------------------------------------------------------------------------

def simple_if_list(pred, true_fn, false_fn, *args):
    true_jaxpr = make_jaxpr(true_fn)(*args)
    false_jaxpr = make_jaxpr(false_fn)(*args)
    return simple_if_p.bind(pred, branch_jaxprs=[true_jaxpr, false_jaxpr])

def simple_if_tuple(pred, true_fn, false_fn, *args):
    true_jaxpr = make_jaxpr(true_fn)(*args)
    false_jaxpr = make_jaxpr(false_fn)(*args)
    return simple_if_p.bind(pred, branch_jaxprs=(true_jaxpr, false_jaxpr))

def foo():
    x = simple_if_list(True, lambda x: x + 1, lambda x: x + 2, 3)
    y = simple_if_tuple(True, lambda x: x + 1, lambda x: x + 2, 3)
    return x + y

print(make_jaxpr(foo)())
```

Before this PR, the program would output

```console
$ python example.py
{ lambda ; . let
    a:i32[] = if[
      branch_jaxprs=[{ lambda ; a:i32[]. let b:i32[] = add a 1 in (b,) }, { lambda ; a:i32[]. let b:i32[] = add a 2 in (b,) }]
    ] True
    b:i32[] = if[
      branch_jaxprs=(
        { lambda ; c:i32[]. let d:i32[] = add c 1 in (d,) }
        { lambda ; e:i32[]. let f:i32[] = add e 2 in (f,) }
      )
    ] True
    g:i32[] = add a b
  in (g,) }
```

Note that the first `if` equation is formatted by converting each `ClosedJaxpr` value into a string. This looks unseemly and results in duplicate variable identifiers. On the other hand, the second `if` equation is indented properly and uses unique variable identifiers (since a shared `JaxprPpContext` is used).

After this PR, the output changes to

```console
$ python example.py
{ lambda ; . let
    a:i32[] = if[
      branch_jaxprs=(
        { lambda ; b:i32[]. let c:i32[] = add b 1 in (c,) }
        { lambda ; d:i32[]. let e:i32[] = add d 2 in (e,) }
      )
    ] True
    f:i32[] = if[
      branch_jaxprs=(
        { lambda ; g:i32[]. let h:i32[] = add g 1 in (h,) }
        { lambda ; i:i32[]. let j:i32[] = add i 2 in (j,) }
      )
    ] True
    k:i32[] = add a f
  in (k,) }
```