### PR TITLE
update sparse _reshape docstring to match jax.Array.reshape

### DIFF
--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -889,7 +889,7 @@ def _sum(self, *args, **kwargs):
   return sparsify(lambda x: x.sum(*args, **kwargs))(self)
 
 def _reshape(self, *args, **kwargs):
-  """Sum array along axis."""
+  """Returns an array containing the same data with a new shape."""
   return sparsify(lambda x: x.reshape(*args, **kwargs))(self)
 
 def _astype(self, *args, **kwargs):


### PR DESCRIPTION
This PR fixes the docstring for the reshape methods in `jax.experimental.sparse` by changing it to match the `jax.Array.reshape` method's docstring. It looks like the old docstring was copied from the sum method above it.