### PR TITLE
Register jax.Array device method deprecation

### DIFF
--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -30,6 +30,7 @@ from jax._src import api_util
 from jax._src import basearray
 from jax._src import config
 from jax._src import core
+from jax._src import deprecations
 from jax._src import dispatch
 from jax._src import dtypes
 from jax._src import errors
@@ -46,6 +47,8 @@ from jax._src.sharding_impls import (
     device_replica_id_map, hashed_index)
 from jax._src.typing import ArrayLike
 from jax._src.util import safe_zip, unzip3, use_cpp_class, use_cpp_method
+
+deprecations.register(__name__, "device-method")
 
 Shape = tuple[int, ...]
 Device = xc.Device
@@ -473,8 +476,11 @@ class ArrayImpl(basearray.Array):
 
   # TODO(yashkatariya): Remove this method when everyone is using devices().
   def device(self) -> Device:
-    warnings.warn("arr.device() is deprecated. Use arr.devices() instead.",
-                  DeprecationWarning, stacklevel=2)
+    if deprecations.is_accelerated(__name__, "device-method"):
+      raise NotImplementedError("arr.device() is deprecated. Use arr.devices() instead.")
+    else:
+      warnings.warn("arr.device() is deprecated. Use arr.devices() instead.",
+                    DeprecationWarning, stacklevel=2)
     self._check_if_deleted()
     device_set = self.sharding.device_set
     if len(device_set) == 1:

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -34,6 +34,7 @@ from jax import random
 from jax import tree_util
 from jax._src import config
 from jax._src import core
+from jax._src import deprecations
 from jax._src import dtypes
 from jax._src import test_util as jtu
 from jax import vmap
@@ -1010,8 +1011,9 @@ class KeyArrayTest(jtu.JaxTestCase):
 
     self.assertEqual(key.is_fully_addressable, key._base_array.is_fully_addressable)
     self.assertEqual(key.is_fully_replicated, key._base_array.is_fully_replicated)
-    with jtu.ignore_warning(category=DeprecationWarning, message="arr.device"):
-      self.assertEqual(key.device(), key._base_array.device())
+    if not deprecations.is_accelerated('jax._src.array', 'device-method'):
+      with jtu.ignore_warning(category=DeprecationWarning, message="arr.device"):
+        self.assertEqual(key.device(), key._base_array.device())
     self.assertEqual(key.devices(), key._base_array.devices())
     self.assertEqual(key.on_device_size_in_bytes, key._base_array.on_device_size_in_bytes)
     self.assertEqual(key.unsafe_buffer_pointer, key._base_array.unsafe_buffer_pointer)


### PR DESCRIPTION
In preparation for finalizing this deprecation.