### PR TITLE
testUnique: avoid invalid fill_value

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1889,7 +1889,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for axis in [None] + list(range(len(shape)))],
     dtype=number_dtypes,
     size=[1, 5, 10],
-    fill_value=[None, -1.0, "slice"],
+    fill_value=[None, 0, "slice"],
   )
   def testUniqueSize(self, shape, dtype, axis, size, fill_value):
     rng = jtu.rand_some_equal(self.rng())


### PR DESCRIPTION
The use of `-1.0` was causing issues in some test configurations because it raises a warning or error when converting to an unsigned int. Better to avoid this by using a value that is valid for all dtypes.