### PR TITLE
Fix jvp of convert_element_type for integer types

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2384,7 +2384,8 @@ def _convert_element_type_transpose_rule(ct, operand, *, new_dtype, weak_type):
 
 def _convert_element_type_jvp_rule(tangent, operand , *, new_dtype, weak_type):
   if core.primal_dtype_to_tangent_dtype(new_dtype) == dtypes.float0:
-    return ad_util.Zero(tangent.aval.update(dtype=dtypes.float0, weak_type=False))
+    tangent_aval = core.raise_to_shaped(core.get_aval(tangent))
+    return ad_util.Zero(tangent_aval.update(dtype=dtypes.float0, weak_type=False))
   else:
     return convert_element_type_p.bind(tangent, new_dtype=new_dtype,
                                        weak_type=weak_type)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2617,6 +2617,12 @@ class APITest(jtu.JaxTestCase):
     _, out_tangent = api.jvp(jax.jit(lambda x: x+1), primals, tangents)
     self.assertEqual(out_tangent, np.zeros(shape=(), dtype=float0))
 
+  def test_jvp_of_convert_element_type(self):
+    fun = lambda x: x.astype(np.int32) + 1
+    primal, tangent = jax.jvp(fun, (2.,), (1.,))
+    self.assertAllClose(primal, np.int32(3))
+    self.assertEqual(tangent, np.zeros((), dtype=float0))
+
   def test_vjp_of_int_index(self):
     primal, fn_vjp = api.vjp(lambda x, i: x[i], np.ones(2)*2, 1)
     tangent_x, tangent_i = fn_vjp(1.)


### PR DESCRIPTION
Fix JVP rule for convert_element_type to integer types.
Without this fix, the newly added test fails:

```
    File "/Users/necula/Source/jax/jax/_src/lax/lax.py", line 2382, in _convert_element_type_jvp_rule
        return ad_util.Zero(tangent.aval.update(dtype=dtypes.float0, weak_type=False))
                             ^^^^^^^^^^^^
    AttributeError: 'float' object has no attribute 'aval'
```
because `tangent` is a float constant