### PR TITLE
prototype 'remat' in hlo metadata

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -629,8 +629,9 @@ def _transpose_jaxpr(jaxpr, in_lin, out_zeros, reduce_axes):
                 pe.PartialVal.known(next(ins_iter))
                 for aval, lin in zip(jaxpr.in_avals, in_lin)]
     assert next(ins_iter, None) is None
-    lin_jaxpr, _, consts = pe.trace_to_jaxpr_nounits(
-        lu.wrap_init(core.jaxpr_as_fun(jaxpr)), in_pvals, False)
+    with source_info_util.extend_name_stack('rematted_computation'):
+      lin_jaxpr, _, consts = pe.trace_to_jaxpr_nounits(
+          lu.wrap_init(core.jaxpr_as_fun(jaxpr)), in_pvals, False)
 
     # Transpose the linear jaxpr (which only has linear inputs).
     out_cts_iter = iter(out_cts_flat)
@@ -696,7 +697,7 @@ def remat_lowering(*args, jaxpr: core.Jaxpr, prevent_cse: bool,
   else:
     translation_rule = lambda *args, jaxpr: core.eval_jaxpr(jaxpr, (), *args)
 
-  return api.named_call(translation_rule, name="remat")(*args, jaxpr=jaxpr)
+  return api.named_call(translation_rule, name="checkpoint")(*args, jaxpr=jaxpr)
 
 def _remat_translation_using_opt_barrier(*args, jaxpr: core.Jaxpr):
   args = _optimization_barrier(args)


### PR DESCRIPTION
After this PR, if we do this:

```python
@jax.remat
def f(x):
  return jnp.sin(x)

print_hlo(jax.grad(f))(3.0)
```

we get this HLO for the `jax.grad(f)` computation:

```
HloModule xla_computation_f, entry_computation_layout={(f32[])->(f32[])}

ENTRY main.10 {
  Arg_0.1 = f32[] parameter(0)
  constant.2 = f32[] constant(1)
  tuple.3 = (f32[], f32[]) tuple(Arg_0.1, constant.2), metadata={op_name="xla_computation(f)/jit(main)/transpose(jvp(checkpoint))/optimization_barrier" source_file="/usr/local/google/home/mattjj/packages/jax/tests/name_stack_test.py" source_line=32}
  opt-barrier.4 = (f32[], f32[]) opt-barrier(tuple.3), metadata={op_name="xla_computation(f)/jit(main)/transpose(jvp(checkpoint))/optimization_barrier" source_file="/usr/local/google/home/mattjj/packages/jax/tests/name_stack_test.py" source_line=32}
  get-tuple-element.6 = f32[] get-tuple-element(opt-barrier.4), index=1, metadata={op_name="xla_computation(f)/jit(main)/transpose(jvp(checkpoint))/optimization_barrier" source_file="/usr/local/google/home/mattjj/packages/jax/tests/name_stack_test.py" source_line=32}
  get-tuple-element.5 = f32[] get-tuple-element(opt-barrier.4), index=0, metadata={op_name="xla_computation(f)/jit(main)/transpose(jvp(checkpoint))/optimization_barrier" source_file="/usr/local/google/home/mattjj/packages/jax/tests/name_stack_test.py" source_line=32}
  cosine.7 = f32[] cosine(get-tuple-element.5), metadata={op_name="xla_computation(f)/jit(main)/transpose(jvp(checkpoint))/rematted_computation/cos" source_file="/usr/local/google/home/mattjj/packages/jax/tests/name_stack_test.py" source_line=274}
  multiply.8 = f32[] multiply(get-tuple-element.6, cosine.7), metadata={op_name="xla_computation(f)/jit(main)/transpose(jvp(checkpoint))/mul" source_file="/usr/local/google/home/mattjj/packages/jax/tests/name_stack_test.py" source_line=274}
  ROOT tuple.9 = (f32[]) tuple(multiply.8)
}
```

Before this PR, we already had stuff like "transpose(jvp(remat))" in there. That is, the substring "remat" already appeared. ~We could change that if we have to.~ We changed that to "transpose(jvp(checkpoint))", shown above.

The new text added after this PR is "rematted_computation", as in "rematted_computation/cos". That is, we're rematerializing the computation of `cos` instead of computing and saving it during the forward pass.