### PR TITLE
[key reuse] Eager checks

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -932,8 +932,11 @@ enable_checks = define_bool_state(
 enable_key_reuse_checks = define_bool_state(
     name='jax_enable_key_reuse_checks',
     default=False,
-    help="Turn on experimental key reuse checking."
-)
+    help=('Turn on experimental key reuse checking. With this configuration enabled,'
+          ' typed PRNG keys (i.e. keys created with jax.random.key()) will have their'
+          ' usage tracked, and incorrect reuse of a previously-used key will lead to'
+          ' an error. Currently enabling this leads to a small Python overhead on'
+          ' every call to a JIT-compiled function with keys as inputs or outputs.'))
 
 check_tracer_leaks = define_bool_state(
     name='jax_check_tracer_leaks',

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1737,10 +1737,10 @@ class PythonPmapTest(jtu.JaxTestCase):
       res = res.reshape(res.shape[0] * res.shape[1], *res.shape[2:])
       return res
 
-    key = random.PRNGKey(1)
-    x = random.normal(key, (80, 50))
+    key = lambda: random.PRNGKey(1)
+    x = random.normal(key(), (80, 50))
     batched_mvm = vmap(lambda b: distributed_matrix_vector(x, b), in_axes=0)
-    y = random.normal(key, (10, 50, 1))
+    y = random.normal(key(), (10, 50, 1))
     result = batched_mvm(y)
     expected = jnp.einsum('ij,njk->nik', x, y)
     self.assertAllClose(result, expected, check_dtypes=False, atol=1e-3,

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -1475,17 +1475,18 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
 
     ndim = shape[0] if len(shape) > 1 else 1
 
-    args = args_maker()
     func = partial(resample, shape=())
-    self._CompileAndCheck(
-      func, args_maker, rtol={np.float32: 3e-07, np.float64: 4e-15})
-    result = func(*args)
+    with jax.enable_key_reuse_checks(False):
+      self._CompileAndCheck(
+        func, args_maker, rtol={np.float32: 3e-07, np.float64: 4e-15})
+    result = func(*args_maker())
     assert result.shape == (ndim,)
 
     func = partial(resample, shape=(4,))
-    self._CompileAndCheck(
-      func, args_maker, rtol={np.float32: 3e-07, np.float64: 4e-15})
-    result = func(*args)
+    with jax.enable_key_reuse_checks(False):
+      self._CompileAndCheck(
+        func, args_maker, rtol={np.float32: 3e-07, np.float64: 4e-15})
+    result = func(*args_maker())
     assert result.shape == (ndim, 4)
 
   @jtu.sample_product(

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -29,6 +29,7 @@ from jax._src import core
 from jax._src import config
 from jax._src import linear_util as lu
 from jax._src.interpreters import partial_eval as pe
+from jax._src import prng
 from jax._src import test_util as jtu
 from jax._src.util import tuple_insert
 import jax.numpy as jnp
@@ -1696,8 +1697,8 @@ if CAN_USE_HYPOTHESIS:
       y, impl_vjp = jax.vjp(impl, x)
       y_ref, ref_vjp = jax.vjp(ref, x)
       self.assertAllClose(y, y_ref)
-      t = random.normal(k2, x.shape)
-      y2 = random.normal(k1, y.shape)
+      t = random.normal(prng.reuse_key(k2), x.shape)
+      y2 = random.normal(prng.reuse_key(k1), y.shape)
       self.assertAllClose(impl_vjp(t), ref_vjp(t))
 
       # Second order
@@ -1713,7 +1714,7 @@ if CAN_USE_HYPOTHESIS:
       (x,), impl_vjp2 = jax.vjp(impl_vjp, t2)
       (x_ref,), ref_vjp2 = jax.vjp(ref_vjp, t2)
       self.assertAllClose(x, x_ref)
-      y2 = random.normal(k1, y.shape)
+      y2 = random.normal(prng.reuse_key(k1), y.shape)
       self.assertAllClose(impl_vjp2((y2,)), ref_vjp2((y2,)))
 
 if __name__ == '__main__':

--- a/tests/x64_context_test.py
+++ b/tests/x64_context_test.py
@@ -112,6 +112,7 @@ class X64ContextTests(jtu.JaxTestCase):
       self.assertEqual(x32.result(), jnp.int32)
 
   @jax.legacy_prng_key('allow')
+  @jax.enable_key_reuse_checks(False)
   @jtu.ignore_warning(category=UserWarning,
                       message="Explicitly requested dtype float64  is not available")
   def test_jit_cache(self):


### PR DESCRIPTION
cc/ @mattjj, @froystig 

~Test failures are due to the fact that many of our tests reuse keys!~

~Test failures caused by key reuse are now addressed via explicit calls to `reuse_key`: remaining test failures are due to us breaking cacheing when key reuse is enabled.~

Tests pass!