### PR TITLE
[attrs] allow passing a jax-attrs object to jit functions

### DIFF
--- a/jax/experimental/attrs.py
+++ b/jax/experimental/attrs.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Any
 
 from jax._src import core
+from jax._src import api_util
 from jax._src import linear_util as lu
 from jax._src.api_util import flatten_fun_nokwargs
 from jax._src.interpreters import ad
@@ -25,6 +26,8 @@ from jax._src.tree_util import tree_flatten, tree_unflatten
 from jax._src.util import unzip2
 
 JaxVal = Any
+
+register = api_util.register_class_with_attrs
 
 class GetAttrPrimitive(core.Primitive):
   def bind_with_trace(self, trace, args, params):


### PR DESCRIPTION
Currently we don't get any interesting cache hits; only on object identity match.

The ~meat~ vegetables of the change is just [this one line](https://github.com/google/jax/pull/19796/files#diff-68f102042d489fc82482d2539efc8f603692473ea674ae9f52eaf833f1526585R436) where we hoist out of the arguments list objects of any type registered with our `attrs` module. Boy, I love linear util!