### PR TITLE
[shape_poly] Performance improvements for symbolic dimension manipulations (step 2)

### DIFF
--- a/jax/experimental/export/_shape_poly.py
+++ b/jax/experimental/export/_shape_poly.py
@@ -666,7 +666,7 @@ class _DimExpr:
     # We print first the "larger" monomials, so that the constant is last.
     res = " ".join(_one_monomial(mon, c)
                    for mon, c in self._monomials_sorted)
-    if res[0:2] == "+ ":
+    if res.startswith("+ "):
       res = res[2:]
     return res
 
@@ -953,7 +953,7 @@ class SymbolicScope:
       raise ValueError(
           "The symbolic constraints should be a sequence of strings. "
           f"Got {repr(constraints_str)}")
-
+    self._initialized = False
     self._location_frame = source_info_util.user_frame(source_info_util.current())
     # Keep the explicit constraints in the order in which they were added
     self._explicit_constraints: list[_SymbolicConstraint] = []
@@ -964,6 +964,11 @@ class SymbolicScope:
     # bounds precision with which we computed the cached result.
     self._bounds_cache: dict[_DimExpr,
                              tuple[float, float, BoundsPrecision]] = {}
+
+    # We store here a decision procedure state initialized with all the
+    # _explicit_constraints.
+    self._decision_initial_state: Any | None = None
+
     # We turn the equality constraints into normalization rules.
     # For an explicit constraint `t*tk == e`, we keep
     # `_normalization_rules[t] = (e, tk)`.
@@ -974,6 +979,7 @@ class SymbolicScope:
     for c_str in constraints_str:
       self._parse_and_process_explicit_constraint(c_str)
       self._bounds_cache.clear()
+    self._initialized = True
 
   def __str__(self) -> str:
     extras = []

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -79,8 +79,7 @@ def _bounds(e: shape_poly.DimSize) -> tuple[float, float]:
     scope = e.scope
   else:
     scope = shape_poly.SymbolicScope()
-  decision = shape_poly_decision._DecisionByElimination(scope)
-  return decision.bounds(e, shape_poly.BoundsPrecision.BEST)
+  return shape_poly._bounds_decision(e, shape_poly.BoundsPrecision.BEST)
 
 def _assert_equal_bounds(tst: jtu.JaxTestCase,
                          e: shape_poly.DimSize,
@@ -725,7 +724,7 @@ class DimExprTest(jtu.JaxTestCase):
     def _m(e: shape_poly._DimExpr) -> shape_poly._DimMon:
       return e.to_monomial()
     Comparator = shape_poly.Comparator
-    decision = shape_poly_decision._DecisionByElimination(scope)
+    decision = shape_poly_decision._DecisionByElimination(scope).initialize()
 
     self.assertSetEqual(
         set(),
@@ -1085,8 +1084,7 @@ class DimExprTest(jtu.JaxTestCase):
     scope1 = shape_poly.SymbolicScope(assumptions1)
     a1, d1, m1 = shape_poly.symbolic_shape("a1, d1, m1", scope=scope1)
     # TODO: The incompleteness is due to the way we combine external constraints
-    self.assertEqual(_bounds(a1 - 4*d1),
-                     _expect(best=(1, 3), current=(1, 3)))  # a - 4d = m >= 1
+    self.assertEqual(_bounds(a1 - 4*d1), (1, 3))  # a - 4d = m >= 1
     self.assertEqual(_bounds(a1 - 2*d1), (3, np.inf))  # a - 2d = m + 2d >= 3
     # TODO: The incompleteness is due to the way we combine external constraints
     self.assertEqual(_bounds(a1),
@@ -1611,7 +1609,7 @@ class ShapePolyTest(jtu.JaxTestCase):
     # performance
     def f(x):  # x: i32[a, b]
       acc = 0
-      for start in range(0, 10):
+      for start in range(0, 50):
         slice = x[start::2]  # exercises floordiv and min
         acc += jnp.sum(slice, axis=0)
 


### PR DESCRIPTION
We make the following improvements:

  * Cache the state of the decision procedure after we process the explicit
        constraints, and reuse it for new decisions.
  * Rationalize the usage of add_implicit_constraints. We used to call it
        conservatively, too often. Now we call it only once for each explicit constraint,
        and once for each bounds decision we make. Then, in the add_implicit_constraints
        we call it recursively when we encounter new sub-expressions.
  * Eliminate some usage of __str__ for symbolic expressions in combine_and_add_constraints
        since we should only need it for reporting error messages.

This speeds up inequality reasoning:

Before:
```
    In [1]:     from jax.experimental import export
       ...:     from jax import core
       ...:     a, b, c = export.symbolic_shape("a, b, c", constraints=["a >= 3", "a <= 5", "b >= 8"])

    In [2]: %timeit a >= b
    109 µs ± 637 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

    In [3]: %timeit core.max_dim(a, c) >= a - c
    442 µs ± 2.22 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

After:
```
    In [2]: %timeit a >= b
    11.7 µs ± 27.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

    In [3]: %timeit core.max_dim(a, c) >= a - c
    34.8 µs ± 175 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```