### PR TITLE
Added check for CUDA device compute capability

### DIFF
--- a/jaxlib/cuda/versions.cc
+++ b/jaxlib/cuda/versions.cc
@@ -45,6 +45,8 @@ NB_MODULE(_versions, m) {
   m.def("cusolver_get_version", &CusolverGetVersion);
   m.def("cublas_get_version", &CublasGetVersion);
   m.def("cusparse_get_version", &CusparseGetVersion);
+  m.def("cuda_compute_capability", &CudaComputeCapability);
+  m.def("cuda_device_count", &CudaDeviceCount);
 }
 
 }  // namespace

--- a/jaxlib/cuda/versions_helpers.cc
+++ b/jaxlib/cuda/versions_helpers.cc
@@ -84,5 +84,22 @@ size_t CudnnGetVersion() {
   }
   return version;
 }
+int CudaComputeCapability(int device) {
+  int major, minor;
+  JAX_THROW_IF_ERROR(JAX_AS_STATUS(gpuDeviceGetAttribute(
+      &major, GPU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device)));
+  JAX_THROW_IF_ERROR(JAX_AS_STATUS(gpuDeviceGetAttribute(
+      &minor, GPU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device)));
+  return major * 10 + minor;
+}
+
+int CudaDeviceCount() {
+  int device_count = 0;
+  JAX_THROW_IF_ERROR(JAX_AS_STATUS(cuInit(0)));
+  JAX_THROW_IF_ERROR(JAX_AS_STATUS(cuDeviceGetCount(&device_count)));
+
+  return device_count;
+}
+
 
 }  // namespace jax::cuda

--- a/jaxlib/cuda/versions_helpers.h
+++ b/jaxlib/cuda/versions_helpers.h
@@ -29,6 +29,8 @@ int CusolverGetVersion();
 int CublasGetVersion();
 int CusparseGetVersion();
 size_t CudnnGetVersion();
+int CudaComputeCapability(int);
+int CudaDeviceCount();
 
 }  // namespace jax::cuda
 


### PR DESCRIPTION
Closes https://github.com/google/jax/issues/993

This PR adds a runtime checks for the compute capability of all visible CUDA devices. If any device has a compute capability that is unsupported, a `RuntimeWarning` is issued.