### PR TITLE
Fix complex sin and cos on inputs with small absolute value or large pure imaginary part

### DIFF
--- a/tests/filecheck/shapes.filecheck.py
+++ b/tests/filecheck/shapes.filecheck.py
@@ -96,12 +96,14 @@ def main(_):
 
   # CHECK-LABEL: TEST: cos complex64[]
   # CHECK: hlo.cosine
-  # CHECK-SAME: tensor<complex<f32>>
+  # TODO: when the accuracy of lax.cos is fixed upstream, undo relevant parts of jax PR 19823
+  # CHECK-SAME: tensor<f32>
   print_ir(np.complex64(0))(lax.cos)
 
   # CHECK-LABEL: TEST: cos complex128[]
   # CHECK: hlo.cosine
-  # CHECK-SAME: tensor<complex<f64>>
+  # TODO: when the accuracy of lax.cos is fixed upstream, undo relevant parts of jax PR 19823
+  # CHECK-SAME: tensor<f64>
   print_ir(np.complex128(0))(lax.cos)
 
 


### PR DESCRIPTION
As in the title.

In addition, a test ` testUfuncOnComplexPlane` is introduced that validates jax implementations of complex ufuncs on the whole complex plane using numpy ufuncs as references.

Fixes https://github.com/google/jax/issues/19753, https://github.com/google/jax/issues/19754

In terms of the [Validate complex functions in array libraries](https://github.com/pearu/complex_function_validation) tool, the validity state of the sin function on complex plane is 
[before](https://github.com/pearu/complex_function_validation/blob/main/mpmath_jax_results/data/sin_MPMath_complex128_cpu_versus_JAX_complex64_cpu.txt) and [after](https://github.com/pearu/complex_function_validation/blob/main/mpmath_jax_results_dev/data/sin_MPMath_complex128_cpu_versus_JAX_complex64_cpu.txt) this PR.

Discussion: ideally, issues with sin/cos ought to be fixed upstream (https://github.com/openxla/stablehlo). This PR implements lowerings for complex sin and cos functions because it is the fastest way to enable the fix for the end-users.
