### PR TITLE
[shape_poly] Performance improvements for symbolic dimension manipulations (step 3)

### DIFF
--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -75,10 +75,6 @@ def _expect(*, current, best):
   return current
 
 def _bounds(e: shape_poly.DimSize) -> tuple[float, float]:
-  if isinstance(e, shape_poly._DimExpr):
-    scope = e.scope
-  else:
-    scope = shape_poly.SymbolicScope()
   return shape_poly._bounds_decision(e, shape_poly.BoundsPrecision.BEST)
 
 def _assert_equal_bounds(tst: jtu.JaxTestCase,
@@ -682,6 +678,8 @@ class DimExprTest(jtu.JaxTestCase):
     self.assertIsInstance(a + (2 - a), int)
     self.assertEqual(a * 2 // a, 2)
     self.assertIsInstance(a * 2 // a, int)
+    self.assertEqual((4*a)*0, 0)
+    self.assertEqual(0*(4*a), 0)
 
   @jtu.parameterized_filterable(
     kwargs=[
@@ -697,6 +695,7 @@ class DimExprTest(jtu.JaxTestCase):
           (3 * a - 2, 3, a - 1, 1),
           (3 * a * a * b + 2 * b * b * a, a * b, 3 * a + 2 * b, 0),
           (a * a - b * b, a + b, a - b, 0),
+          (256 * a * b, 32, 8 * a * b, 0),
           (a, b, "floordiv(a, b)", "mod(a, b)"),
           (3 * a, 2, "floordiv(3*a, 2)", "mod(3*a, 2)"),
           (2 * a * b + b * b, a + b, "floordiv(2*a*b + b^2, b + a)", "mod(2*a*b + b^2, b + a)"),


### PR DESCRIPTION
We make the following improvements:

  * Add a `linear_combination` function to use for computing linear combinations fo symbolic expressions. E.g, `a - b` used to involve 2 operations: "-1 * b" and "a + -1*b".
  * Change the representation of terms (_DimMon) from a dictionary mapping factors (_DimAtom) to exponents, into a sorted tuple of pairs (factor, exponent). This is worthwhile because in almost all cases a term contains a single factor. Everywhere we used `term.items()` now we use `term._factors`.
  * Make the computation of `._hash` lazy. Previously, we used dictionaries heavily for symbolic expressions and we always needed the hash value, now we use dictionaries less.
  * Replace `t.degree` with `t.is_constant`.
  * Add `__slots__` to the representation of symbolic expressions

Micro benchmark: `a * 2 - b * 2 - a * 3 + c * 4`

After: 12.51 μsec (mean 12.6 μsec ± 105.2 nsec, of 7 runs, 20000 loops each)
Before: 40.33 μsec (mean 40.5 μsec ± 247.6 nsec, of 7 runs, 5000 loops each)