### PR TITLE
[adx3] Add string labels for second-order primitive subjaxprs.

### DIFF
--- a/docs/adx3/core.py
+++ b/docs/adx3/core.py
@@ -109,8 +109,10 @@ class JaxprEqn:
     p.emit(f'{self.binder} = {self.primitive}{arglist_str(self.args)}')
     if isinstance(self.primitive, SecondOrderPrimitive):
       with p.indent():
-        for jaxpr in self.primitive.jaxprs:
-          jaxpr.pretty_print(p)
+        for label, jaxpr in self.primitive.jaxprs.items():
+          p.emit(f"{label} = ")
+          with p.indent():
+            jaxpr.pretty_print(p)
 
 
 @dataclass

--- a/docs/adx3/lax.py
+++ b/docs/adx3/lax.py
@@ -175,7 +175,7 @@ class CondP(SecondOrderPrimitive):
   when_false: Jaxpr
   @property
   def jaxprs(self):
-    return [self.when_true, self.when_false]
+    return {"when_true": self.when_true, "when_false": self.when_false}
 
   def eval_type(self, predicate):
     assert self.when_true.ty == self.when_false.ty
@@ -200,9 +200,10 @@ def fori(n:int, body_callable:Callable):
 class ForP(SecondOrderPrimitive):
   n : int
   body: Jaxpr
+
   @property
   def jaxprs(self):
-    return [self.body]
+     return {"body": self.body}
 
   def eval_type(self):
     return JaxListType(self.n, self.body.ty.result_type)


### PR DESCRIPTION
Subjaxpr labels are helpful for understanding their purpose.

### Demo

See `when_{true,false} =` labels for `cond` subjaxprs below.

```console
$ python3 docs/adx3/tests.py
(v0:f64[]) =>
  v1:f64[] = sin(v0:f64[])
  v2:f64[] = mul(v1:f64[], 2.0)
  v3:f64[] = neg(v2:f64[])
  v4:f64[] = add(v3:f64[], v0:f64[])
  return v4:f64[]
2.7177599838802657
2.7177599838802657
2.7177599838802657
(v5:f64[]) =>
  v6:f64[] = cos(3.0)
  lin v7:f64[] = mul(lin v5:f64[], v6:f64[])
  lin v8:f64[] = mul(2.0, lin v7:f64[])
  lin v9:f64[] = neg(lin v8:f64[])
  lin v10:f64[] = add(lin v9:f64[], lin v5:f64[])
  return v10:f64[]
2.979984993200891
(JaxArrayLit(val=2.7177599838802657), JaxArrayLit(val=2.979984993200891))
(JaxArrayLit(val=2.7177599838802657), JaxArrayLit(val=2.979984663203261))
() =>
  return 1.0
1.0
(v22:f64[]) =>
  v23:bool[] = greater(v22:f64[], 2.0)
  v26:f64[] = cond(v23:bool[])
    when_true = 
      () =>
        v24:f64[] = add(v22:f64[], v22:f64[])
        return v24:f64[]
    when_false = 
      () =>
        v25:f64[] = mul(v22:f64[], v22:f64[])
        return v25:f64[]
  return v26:f64[]
() =>
  v25:f64[] = mul(v22:f64[], v22:f64[])
  return v25:f64[]
1.0
6.0
[0, 2, 6, 12, 20]
```