### PR TITLE
[shape_poly] Fix handling of stride_in_dim with symbolic stride.

### DIFF
--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -772,7 +772,7 @@ def slice_in_dim(operand: Array | np.ndarray, start_index: int | None,
   axis = int(axis)
   start_indices[axis] = start_index_int
   limit_indices[axis] = limit_index_int
-  strides[axis] = int(stride)
+  strides[axis] = core._canonicalize_dimension(stride)
 
   return slice(operand, start_indices, limit_indices, strides)
 

--- a/jax/experimental/export/_shape_poly_decision.py
+++ b/jax/experimental/export/_shape_poly_decision.py
@@ -414,12 +414,13 @@ class _DecisionByElimination:
       (op1_l, op1_u) = self.bounds(op1, BoundsPrecision.BEST)
       (op2_l, op2_u) = self.bounds(op2, BoundsPrecision.BEST)
 
-      def math_floor_with_inf(a: float, b: float):  # math.floor, but aware of inf
-        # When either a or b are infinite, the results represent the limit
+      def math_floor_with_inf(a: float, b: float):
+        # math.floor(a / b), but aware of inf.
+        # When either a or b are infinite, the result represents the limit
         # of "a // b".
-        assert b != 0
+        assert b != 0  # we caught division by 0 earlier
         if not np.isinf(b):  # divisor b is finite
-          if not np.isinf(a):
+          if not np.isinf(a):  # both dividend a and divisor b are finite
             return math.floor(a / b)
           # a is infinite, b is finite
           return -np.inf if (a >= 0) != (b >= 0) else np.inf
@@ -430,6 +431,9 @@ class _DecisionByElimination:
 
       # Same reasoning as for multiplication: the bounds are among the cross-product
       # of the bounds.
+      if op2_l <= 0 <= op2_u:
+        raise InconclusiveDimensionOperation(
+            f"Possible division by 0 in division by {op2}")
       candidate_bounds = [math_floor_with_inf(op1_l, op2_l),
                           math_floor_with_inf(op1_l, op2_u),
                           math_floor_with_inf(op1_u, op2_l),


### PR DESCRIPTION
The fix is simple, just avoid using `int(stride)`. 

While fixing this I discovered some issues with a test being disabled and handling of division by 0 when
computing the bounds of floordiv.