### PR TITLE
Fix test flake which occurred due to a spurious cache misses.

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -825,14 +825,20 @@ class _ThreadLocalExtraJitContext(NamedTuple):
   dynamic_trace_state: Any | None = None
   axis_env_state: Hashable = ()
   mesh_context_manager: Hashable = ()
+
+  # Values set by _StateContextManager context managers.
+  # CAUTION: these must be initialized to `None`! The state context manager
+  # restores these to None on exit. If the object default is not `None`, the
+  # context manager is not a no-op, which leads to problems with stale state
+  # (e.g. spurious cache misses in tests).
   numpy_rank_promotion: str | None = None
   numpy_dtype_promotion: str | None = None
   default_matmul_precision: Any | None = None
-  dynamic_shapes: bool = False
-  random_seed_offset: int = 0
-  threefry_partitionable: bool = False
-  softmax_custom_jvp: bool = False
-  xla_profile_version: int = 0
+  dynamic_shapes: bool | None = None
+  random_seed_offset: int | None = None
+  threefry_partitionable: bool | None = None
+  softmax_custom_jvp: bool | None = None
+  xla_profile_version: int | None = None
 
 
 class _ThreadLocalStateCache(threading.local):

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -2195,6 +2195,8 @@ class CppPmapTest(PythonPmapTest):
       outputs = [f.result() for f in futures]
 
     np.testing.assert_array_equal(pmaped_f(inputs), outputs[0])
+    if pmaped_f._cache_size != 1:
+      print(pmaped_f._debug_cache_keys())
     self.assertEqual(pmaped_f._cache_size, 1)
 
   def test_cache_uses_jax_key(self):


### PR DESCRIPTION
The StateContextManager restores its thread-local state to None, which means that the initial thread-local state must also be None if the context manager is to correctly restore the initial state.

This caused a test failure in a test case in pmap_test which checked for exactly one cache entry across threads. One thread had used the softmax_custom_jvp context manager, and had a different state (None) instead of False.