### PR TITLE
[shape_poly] Cleaning up naming of terms and factors

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2177,7 +2177,7 @@ def evaluate_shape(shape: Shape, dim_vars: Sequence[str],
       return operator.index(d)
     except:
       # Is a _DimExpr
-      return d.evaluate(env)  # type: ignore
+      return d._evaluate(env)  # type: ignore
   return tuple(eval_one_dim(d) for d in shape)
 
 def dim_value_dtype():

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -925,7 +925,7 @@ def lower_jaxpr_to_module(
     # Find the dimension variables
     all_dim_poly = [d for aval in jaxpr.in_avals if hasattr(aval, "shape")
                     for d in aval.shape if not core.is_constant_dim(d)]
-    dim_vars = tuple(sorted(functools.reduce(lambda acc, new: acc.union(new.get_vars()),
+    dim_vars = tuple(sorted(functools.reduce(lambda acc, new: acc.union(new._get_vars()),
                                              all_dim_poly, set())))
   else:
     dim_vars = ()

--- a/jax/experimental/export/_shape_poly_decision.py
+++ b/jax/experimental/export/_shape_poly_decision.py
@@ -25,7 +25,7 @@ import numpy as np
 
 from jax.experimental.export import _shape_poly
 from jax.experimental.export._shape_poly import (
-  _DimExpr, _DimMon, _DimAtom,
+  _DimExpr, _DimTerm, _DimFactor,
   SymbolicScope,
   DimSize,
   InconclusiveDimensionOperation,
@@ -49,33 +49,33 @@ _shape_poly._bounds_decision = bounds_decision
 class _DecisionByElimination:
   """A decision procedure based on elimination of terms.
 
-  Given an expression `e = m_k*m + rest_e` for which we want to compute bounds,
-  and a constraint `c = m_c*m + rest_c >= 0`,
+  Given an expression `e = t*t_k + rest_e` for which we want to compute bounds,
+  and a constraint `c = t*t_c_k + rest_c >= 0`,
 
-  Let `e0 = abs(m_c)*e - sgn(m_c)*m_k*c`. (Note that we eliminated `m` from
-  `e0`, since `abs(m_c)*m_k = sgn(m_c)*m_k*m_c`.)
+  Let `e0 = e*abs(t_c_k) - c*sgn(t_c_k)*t_k`. (Note that we eliminated `t` from
+  `e0`, since `abs(t_c_k)*t_k = sgn(t_c_k)*t_k*t_c_k`.)
 
   Since `c >= 0`,
-  if `sgn(m_c)*m_k > 0`:
-     then `abs(m_c)*e >= e0`, hence, `LB(e) >= ceil(LB(e0) / abs(m_c))`,
+  if `sgn(t_c_k)*t_k > 0`:
+     then `abs(t_c_k)*e >= e0`, hence, `LB(e) >= ceil(LB(e0) / abs(t_c_k))`,
 
-  if `sgn(m_c)*m_k < 0`
-    then `abs(m_c)*e <= e0`, hence, `UB(e) <= floor(UB(e0) / abs(m_c))`,
+  if `sgn(t_c_k)*t_k < 0`
+    then `abs(t_c_k)*e <= e0`, hence, `UB(e) <= floor(UB(e0) / abs(t_c_k))`,
 
   See the implementation in self.combine_term_with_existing.
   Do not use the constructor directly, use the `build` static method.
   """
   def __init__(self, scope: SymbolicScope):
     self.scope = scope
-    self._processed_for_internal_constraints: set[_DimMon] = set()
+    self._processed_for_internal_constraints: set[_DimTerm] = set()
     # The other fields are for keeping an efficient representation of
     # the explicit constraints.
-    self._term_bounds: dict[_DimMon, tuple[float, float]] = {}
+    self._term_bounds: dict[_DimTerm, tuple[float, float]] = {}
     # The _expr_constraints represents a set of constraints that are not
     # just simple terms. The set is represented as a mapping from a
     # term "t" to tuples (cmp, k, c) where "c >= 0" (if cmp is GEQ else "c == 0")
     # represents a constraint that has "t" as the leading term with coefficient "k".
-    self._expr_constraints: dict[_DimMon, set[tuple[Comparator, int, _DimExpr]]] = {}
+    self._expr_constraints: dict[_DimTerm, set[tuple[Comparator, int, _DimExpr]]] = {}
 
   def initialize(self) -> _DecisionByElimination:
     # Process the explicit constraints in the order in which the user specifies
@@ -137,14 +137,11 @@ class _DecisionByElimination:
       assert e2 == np.floor(e2)
       e2 = int(e2)
     e = e1 - e2
-    if (const := _DimExpr.to_constant(e)) is not None:
+    if (const := _DimExpr._to_constant(e)) is not None:
       if const < 0:
         raise ValueError(f"Unsatisfiable constraint: {debug_str or str(e1) + ' >= ' + str(e2)}")
       return
     assert isinstance(e, _DimExpr)
-    # TODO: we only really need to add the implicit constraints now, else
-    # we may have to consider combining e with itself below (not harmful, just
-    # wasteful.
     self.add_to_state(cmp, e, debug_str)
     geq_combinations = self.combine_constraint_with_existing(cmp, e, debug_str)
     for cmp, a in geq_combinations:
@@ -155,37 +152,37 @@ class _DecisionByElimination:
                    e: _DimExpr,
                    debug_str: str | None):
     """Updates the internal state to reflect "e >= 0". """
-    assert _DimExpr.to_constant(e) is None
+    assert _DimExpr._to_constant(e) is None
 
-    if (mon_factors := e.to_single_term()) is not None:
-      n, mon_c, mon = mon_factors  # n + mon * mon_c [== | >=] 0
-      lb, ub = self._term_bounds.get(mon, (- np.inf, np.inf))
+    if (term_factors := e._to_single_term()) is not None:
+      n, t_k, t = term_factors  # n + t * t_k [== | >=] 0
+      lb, ub = self._term_bounds.get(t, (- np.inf, np.inf))
       if cmp == Comparator.EQ:
-        # n + mon_c * mon == 0  ->  mon == - n // mon_c
-        if n % mon_c:
+        # n + t_k * t == 0  ->  t == - n // t_k
+        if n % t_k:
           raise ValueError(f"Unsatisfiable constraint: {debug_str}")
-        mon_val = - (n // mon_c)
-        lb = max(lb, mon_val)
-        ub = min(ub, mon_val)
+        t_val = - (n // t_k)
+        lb = max(lb, t_val)
+        ub = min(ub, t_val)
       else:  # GEQ
-        if mon_c > 0:
-          lb = max(lb, int(np.ceil(- n / mon_c)))
+        if t_k > 0:
+          lb = max(lb, int(np.ceil(- n / t_k)))
         else:
-          ub = min(ub, int(np.floor(- n / mon_c)))
+          ub = min(ub, int(np.floor(- n / t_k)))
       if lb > ub:
         raise ValueError(f"Unsatisfiable constraint: {debug_str}")
 
-      self._term_bounds[mon] = (lb, ub)
+      self._term_bounds[t] = (lb, ub)
       return
 
-    lead_t, lead_t_k = e.leading_term
+    lead_t, lead_t_k = e._leading_term
     lead_t_constraints = self._expr_constraints.get(lead_t)
     if lead_t_constraints is None:
       lead_t_constraints = set()
       self._expr_constraints[lead_t] = lead_t_constraints
     lead_t_constraints.add((cmp, lead_t_k, e))
 
-  def combine_term_with_existing(self, t: _DimMon, t_k: int, *,
+  def combine_term_with_existing(self, t: _DimTerm, t_k: int, *,
                                  scope: _shape_poly.SymbolicScope,
                                  only_smaller_than_t=True,
                                  ) -> Sequence[tuple[Comparator,
@@ -224,7 +221,7 @@ class _DecisionByElimination:
                             else self._expr_constraints.values()):
       for c_eq, _, c in prev_constraint:
         # TODO: optimize this dict()
-        tc_k = dict(c._monomials_sorted).get(t)
+        tc_k = dict(c._sorted_terms).get(t)
         if tc_k is not None:
           # c =[c_eq] 0 AND t*tc_k appears in c.
           c_s = abs(t_k)
@@ -237,7 +234,7 @@ class _DecisionByElimination:
                                        e: _DimExpr,
                                        debug_str: str | None) -> set[tuple[Comparator, _DimExpr]]:
     combinations: set[tuple[Comparator, _DimExpr]] = set()
-    for t, t_k in e._monomials_sorted:
+    for t, t_k in e._sorted_terms:
       if t.is_constant: continue
       for (c_eq, c, c_s, t_s) in self.combine_term_with_existing(t, t_k,
                                                                  only_smaller_than_t=False,
@@ -246,7 +243,7 @@ class _DecisionByElimination:
         if t_s > 0 or eq == Comparator.EQ:
           new_eq = Comparator.EQ if (eq == c_eq == Comparator.EQ) else Comparator.GEQ
           new_e = _DimExpr._linear_combination(e, t_s, c, c_s, e.scope)
-          if (const := _DimExpr.to_constant(new_e)) is not None:
+          if (const := _DimExpr._to_constant(new_e)) is not None:
             if ((new_eq == Comparator.GEQ and const < 0) or
                 (new_eq == Comparator.EQ and const != 0)):
               raise ValueError(f"Unsatisfiable constraints: {debug_str or str(e) + ' >= 0'}")
@@ -266,10 +263,10 @@ class _DecisionByElimination:
       add_implicit_constraints: if True, then before computing the bounds
         add the implicit constraints for the terms inside `e`.
     """
-    if (const := _DimExpr.to_constant(e)) is not None:
+    if (const := _DimExpr._to_constant(e)) is not None:
       return (const, const)
     assert isinstance(e, _DimExpr)
-    # Caching bounds is tricky. Since the underlying _bounds_for_sorted_monomials
+    # Caching bounds is tricky. Since the underlying _bounds_for_sorted_terms
     # is incomplete, and it may produce better results in the context of
     # specific queries (due to the implicit constraints), if we cache the
     # bounds computation we may stick to sub-optimal results. Also, we should
@@ -282,7 +279,7 @@ class _DecisionByElimination:
 
     if add_implicit_constraints:
       self.add_implicit_constraints_expr(e)
-    lb, ub = self._bounds_for_sorted_terms(e.scope, e._monomials_sorted, 0, prec)
+    lb, ub = self._bounds_for_sorted_terms(e.scope, e._sorted_terms, 0, prec)
     lb, ub = (int(lb) if lb > -np.inf else lb,
               int(ub) if ub < np.inf else ub)
     self.scope._bounds_cache[e] = (lb, ub, prec)
@@ -290,7 +287,7 @@ class _DecisionByElimination:
 
   def _bounds_for_sorted_terms(self,
                                scope: SymbolicScope,
-                               e: Sequence[tuple[_DimMon, int]],
+                               e: Sequence[tuple[_DimTerm, int]],
                                i: int,
                                prec: BoundsPrecision) -> tuple[float, float]:
     """The lower and upper bounds of e[i:].
@@ -315,7 +312,7 @@ class _DecisionByElimination:
       # AND c_s > 0.
       # rest = e[i:]*t_s + c*c_s` AND `rest_ub >= rest >= rest_lb`
       rest = _DimExpr._linear_combination_sorted_pairs(e, i, t_s,
-                                                       c._monomials_sorted, 0, c_s)
+                                                       c._sorted_terms, 0, c_s)
       rest_lb, rest_ub = self._bounds_for_sorted_terms(scope, rest, 0,
                                                        BoundsPrecision.BEST)
       if rest_ub < np.inf:
@@ -332,21 +329,21 @@ class _DecisionByElimination:
 
       if prec._bounds_are_sufficient(lb, ub): return (lb, ub)
 
-    # Now look for special rules for atoms
-    if (m_a := t.to_atom()) is not None:
-      if m_a.operation in [_DimAtom.MAX, _DimAtom.MIN]:
+    # Now look for special rules for factors
+    if (t_f := t.to_factor()) is not None:
+      if t_f.operation in [_DimFactor.MAX, _DimFactor.MIN]:
         # m_c*MAX(op1, op2) + rest_e >= max(m_c * op1 + rest_e, m_c * op2 + rest_e)
         #   if m_c > 0. Similar rules for when m_c < 0 and for MIN.
-        op1, op2 = m_a.operands
+        op1, op2 = t_f.operands
         rest1 = _DimExpr._linear_combination_sorted_pairs(e, i + 1, 1,
-                                                          op1._monomials_sorted, 0, t_k)
+                                                          op1._sorted_terms, 0, t_k)
         rest2 = _DimExpr._linear_combination_sorted_pairs(e, i + 1, 1,
-                                                          op2._monomials_sorted, 0, t_k)
+                                                          op2._sorted_terms, 0, t_k)
         rest1_lb, rest1_ub = self._bounds_for_sorted_terms(scope, rest1, 0,
                                                            BoundsPrecision.BEST)
         rest2_lb, rest2_ub = self._bounds_for_sorted_terms(scope, rest2, 0,
                                                            BoundsPrecision.BEST)
-        like_max = (t_k > 0 if m_a.operation == _DimAtom.MAX else t_k < 0)
+        like_max = (t_k > 0 if t_f.operation == _DimFactor.MAX else t_k < 0)
         if like_max:
           lb = max(lb, max(rest1_lb, rest2_lb))
           ub = min(ub, max(rest1_ub, rest2_ub))
@@ -359,58 +356,58 @@ class _DecisionByElimination:
 
   def add_implicit_constraints_expr(self, e: _DimExpr):
     """Adds the implicit constraints for the expression `e`"""
-    for m, _ in e.monomials():
-      if m.is_constant: continue
-      self.add_implicit_constraints_term(m)
+    for t, _ in e._sorted_terms:
+      if t.is_constant: continue
+      self.add_implicit_constraints_term(t)
 
-  def add_implicit_constraints_term(self, m: _DimMon):
-    if m in self._processed_for_internal_constraints: return
-    self._processed_for_internal_constraints.add(m)
-    m_e = _DimExpr.from_monomial(m, 1, self.scope)  # m as a _DimExpr
-    a = m.to_atom()
-    if a is None:
-      # This is a multiplication of atoms. Try to compute bounds based on
-      # the bounds of the atoms.
+  def add_implicit_constraints_term(self, t: _DimTerm):
+    if t in self._processed_for_internal_constraints: return
+    self._processed_for_internal_constraints.add(t)
+    t_e = _DimExpr._from_term(t, 1, self.scope)  # m as a _DimExpr
+    f = t.to_factor()
+    if f is None:
+      # This is a multiplication of factors. Try to compute bounds based on
+      # the bounds of the factors.
       bounds = []
-      for a1, a1_exp in m._factors:
-        a1_t = _DimMon.from_atom(a1, 1)
-        a1_e = _DimExpr.from_monomial(a1_t, 1, self.scope)
-        self.add_implicit_constraints_term(a1_t)
-        a1_l, a1_u = self.bounds(a1_e, BoundsPrecision.BEST)
+      for f1, f1_exp in t._factors:
+        f1_t = _DimTerm.from_factor(f1, 1)
+        f1_e = _DimExpr._from_term(f1_t, 1, self.scope)
+        self.add_implicit_constraints_term(f1_t)
+        a1_l, a1_u = self.bounds(f1_e, BoundsPrecision.BEST)
         assert a1_l <= a1_u
-        bounds.append((a1_l ** a1_exp, a1_u ** a1_exp))
+        bounds.append((a1_l ** f1_exp, a1_u ** f1_exp))
 
-      candidate_bounds = [math.prod(atom_bounds)
-                          for atom_bounds in itertools.product(*bounds)]
+      candidate_bounds = [math.prod(factor_bounds)
+                          for factor_bounds in itertools.product(*bounds)]
       m_l = min(*candidate_bounds)
       m_u = max(*candidate_bounds)
-      self.combine_and_add_constraint(Comparator.GEQ, m_e, m_l)
-      self.combine_and_add_constraint(Comparator.GEQ, m_u, m_e)
+      self.combine_and_add_constraint(Comparator.GEQ, t_e, m_l)
+      self.combine_and_add_constraint(Comparator.GEQ, m_u, t_e)
       return
 
-    # It is an atom, is it a variable?
-    if (v := a.to_var()) is not None:
-      self.combine_and_add_constraint(Comparator.GEQ, m_e, 1)  # v >= 1
+    # It is a factor, is it a variable?
+    if (v := f.to_var()) is not None:
+      self.combine_and_add_constraint(Comparator.GEQ, t_e, 1)  # v >= 1
       return
 
-    for oper in a.operands:
+    for oper in f.operands:
       self.add_implicit_constraints_expr(oper)
 
-    if a.operation == _DimAtom.MOD:
-      op1, op2 = a.operands
+    if f.operation == _DimFactor.MOD:
+      op1, op2 = f.operands
       op2_b_l, op2_b_u = self.bounds(op2, BoundsPrecision.FOR_GEQ0_OR_LT0)
       if op2_b_l > 0:  # positive divisor
-        self.combine_and_add_constraint(Comparator.GEQ, m_e, 0)  # m >= 0
-        self.combine_and_add_constraint(Comparator.GEQ, op2 - 1, m_e)  # m <= op2 - 1
-        self.combine_and_add_constraint(Comparator.GEQ, op2_b_u - 1, m_e)
+        self.combine_and_add_constraint(Comparator.GEQ, t_e, 0)  # m >= 0
+        self.combine_and_add_constraint(Comparator.GEQ, op2 - 1, t_e)  # m <= op2 - 1
+        self.combine_and_add_constraint(Comparator.GEQ, op2_b_u - 1, t_e)
       elif op2_b_u < 0:  # negative divisor
-        self.combine_and_add_constraint(Comparator.GEQ, m_e, op2 + 1)  # m >= op2 + 1
-        self.combine_and_add_constraint(Comparator.GEQ, m_e, op2_b_l + 1)
-        self.combine_and_add_constraint(Comparator.GEQ, 0, m_e)  # m <= 0
+        self.combine_and_add_constraint(Comparator.GEQ, t_e, op2 + 1)  # m >= op2 + 1
+        self.combine_and_add_constraint(Comparator.GEQ, t_e, op2_b_l + 1)
+        self.combine_and_add_constraint(Comparator.GEQ, 0, t_e)  # m <= 0
       return
 
-    if a.operation == _DimAtom.FLOORDIV:
-      op1, op2 = a.operands
+    if f.operation == _DimFactor.FLOORDIV:
+      op1, op2 = f.operands
       (op1_l, op1_u) = self.bounds(op1, BoundsPrecision.BEST)
       (op2_l, op2_u) = self.bounds(op2, BoundsPrecision.BEST)
 
@@ -440,35 +437,35 @@ class _DecisionByElimination:
                           math_floor_with_inf(op1_u, op2_u)]
       m_l = min(*candidate_bounds)
       m_u = max(*candidate_bounds)
-      self.combine_and_add_constraint(Comparator.GEQ, m_e, m_l)
-      self.combine_and_add_constraint(Comparator.GEQ, m_u, m_e)
+      self.combine_and_add_constraint(Comparator.GEQ, t_e, m_l)
+      self.combine_and_add_constraint(Comparator.GEQ, m_u, t_e)
       if op2_l >= 0:
         if op1_l >= 0:
-          self.combine_and_add_constraint(Comparator.GEQ, m_e, 0)
-        mod_e = _DimExpr.from_operation(_DimAtom.MOD, op1, op2,
-                                        scope=self.scope)
+          self.combine_and_add_constraint(Comparator.GEQ, t_e, 0)
+        mod_e = _DimExpr._from_operation(_DimFactor.MOD, op1, op2,
+                                         scope=self.scope)
         if isinstance(mod_e, _DimExpr):
           self.add_implicit_constraints_expr(mod_e)
-        combined = op2 * m_e + mod_e
+        combined = op2 * t_e + mod_e
         self.combine_and_add_constraint(Comparator.EQ, op1, combined)
       return
 
-    if a.operation == _DimAtom.MAX:
-      op1, op2 = a.operands
+    if f.operation == _DimFactor.MAX:
+      op1, op2 = f.operands
       op1_b_l, op1_b_u = self.bounds(op1, BoundsPrecision.BEST)
       op2_b_l, op2_b_u = self.bounds(op2, BoundsPrecision.BEST)
-      self.combine_and_add_constraint(Comparator.GEQ, m_e, max(op1_b_l, op2_b_l))
-      self.combine_and_add_constraint(Comparator.GEQ, max(op1_b_u, op2_b_u), m_e)
-      self.combine_and_add_constraint(Comparator.GEQ, m_e, op1)
-      self.combine_and_add_constraint(Comparator.GEQ, m_e, op2)
+      self.combine_and_add_constraint(Comparator.GEQ, t_e, max(op1_b_l, op2_b_l))
+      self.combine_and_add_constraint(Comparator.GEQ, max(op1_b_u, op2_b_u), t_e)
+      self.combine_and_add_constraint(Comparator.GEQ, t_e, op1)
+      self.combine_and_add_constraint(Comparator.GEQ, t_e, op2)
       return
 
-    if a.operation == _DimAtom.MIN:
-      op1, op2 = a.operands
+    if f.operation == _DimFactor.MIN:
+      op1, op2 = f.operands
       op1_b_l, op1_b_u = self.bounds(op1, BoundsPrecision.BEST)
       op2_b_l, op2_b_u = self.bounds(op2, BoundsPrecision.BEST)
-      self.combine_and_add_constraint(Comparator.GEQ, m_e, min(op1_b_l, op2_b_l))
-      self.combine_and_add_constraint(Comparator.GEQ, min(op1_b_u, op2_b_u), m_e)
-      self.combine_and_add_constraint(Comparator.GEQ, op1, m_e)
-      self.combine_and_add_constraint(Comparator.GEQ, op2, m_e)
+      self.combine_and_add_constraint(Comparator.GEQ, t_e, min(op1_b_l, op2_b_l))
+      self.combine_and_add_constraint(Comparator.GEQ, min(op1_b_u, op2_b_u), t_e)
+      self.combine_and_add_constraint(Comparator.GEQ, op1, t_e)
+      self.combine_and_add_constraint(Comparator.GEQ, op2, t_e)
       return

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -141,7 +141,7 @@ class DimExprTest(jtu.JaxTestCase):
     dim_vars: set[str] = set()
     for a in (e, computed_sym, *operands_sym):
       if core.is_symbolic_dim(a):
-        dim_vars = dim_vars.union(a.get_vars())
+        dim_vars = dim_vars.union(a._get_vars())
     if not dim_vars:
       return
     dim_vars_tuple = tuple(dim_vars)
@@ -149,7 +149,7 @@ class DimExprTest(jtu.JaxTestCase):
     for dim_values in itertools.product(*([(1, 2, 5, 10)] * len(dim_vars_tuple))):
       env = dict(zip(dim_vars_tuple, dim_values))
       def eval(d: shape_poly.DimSize):
-        return d.evaluate(env) if core.is_symbolic_dim(d) else d  # type: ignore
+        return d._evaluate(env) if core.is_symbolic_dim(d) else d  # type: ignore
 
       compute_concrete = fun(*map(eval, operands_sym))
       expected_concrete = eval(e)
@@ -313,15 +313,15 @@ class DimExprTest(jtu.JaxTestCase):
   def test_get_vars(self):
     a, b = shape_poly.symbolic_shape("a, b")
 
-    self.assertEqual({"a"}, a.get_vars())
-    self.assertEqual({"a", "b"}, (a * b * a).get_vars())
+    self.assertEqual({"a"}, a._get_vars())
+    self.assertEqual({"a", "b"}, (a * b * a)._get_vars())
 
   def test_evaluate(self):
     a, b = shape_poly.symbolic_shape("a, b")
 
-    self.assertEqual(1, (a * a - b).evaluate(dict(a=2, b=3)))
-    self.assertEqual(1, ((a * a) // b).evaluate(dict(a=2, b=3)))
-    self.assertEqual(4, ((a * a) % b).evaluate(dict(a=5, b=7)))
+    self.assertEqual(1, (a * a - b)._evaluate(dict(a=2, b=3)))
+    self.assertEqual(1, ((a * a) // b)._evaluate(dict(a=2, b=3)))
+    self.assertEqual(4, ((a * a) % b)._evaluate(dict(a=5, b=7)))
 
   def test_dim_vars_definitely_equal(self):
     a, b = shape_poly.symbolic_shape("a, b")
@@ -340,54 +340,54 @@ class DimExprTest(jtu.JaxTestCase):
     self.assertTrue(core.definitely_equal(1, jnp.add(0, 1)))  # An Array
     self.assertFalse(core.definitely_equal(1, "a"))
 
-  def test_atoms_ordering(self):
+  def test_factors_ordering(self):
     a, b = shape_poly.symbolic_shape("a, b")
 
-    self.assertTrue(a.to_atom() < b.to_atom())
-    self.assertFalse(a.to_atom() >= b.to_atom())
-    self.assertTrue(a.to_atom() <= b.to_atom())
-    self.assertTrue(a.to_atom() != b.to_atom())
+    self.assertTrue(a._to_factor() < b._to_factor())
+    self.assertFalse(a._to_factor() >= b._to_factor())
+    self.assertTrue(a._to_factor() <= b._to_factor())
+    self.assertTrue(a._to_factor() != b._to_factor())
 
-    self.assertTrue(a.to_atom() < (a % 4).to_atom())
-    self.assertFalse(a.to_atom() > (a % 4).to_atom())
+    self.assertTrue(a._to_factor() < (a % 4)._to_factor())
+    self.assertFalse(a._to_factor() > (a % 4)._to_factor())
     # FLOORDIV comes before MON because we compare operations alphabetically
-    self.assertTrue((a // 4).to_atom() < (a % 4).to_atom())
+    self.assertTrue((a // 4)._to_factor() < (a % 4)._to_factor())
 
-    self.assertEqual(hash((a // 4).to_atom()), hash((a // 4).to_atom()))
+    self.assertEqual(hash((a // 4)._to_factor()), hash((a // 4)._to_factor()))
 
-  def test_monomial_ordering(self):
+  def test_term_ordering(self):
     a, b = shape_poly.symbolic_shape("a, b")
-    self.assertTrue(a.to_monomial() < b.to_monomial())
-    self.assertTrue(a.to_monomial() <= b.to_monomial())
-    self.assertTrue(b.to_monomial() >= a.to_monomial())
-    self.assertTrue(b.to_monomial() > a.to_monomial())
+    self.assertTrue(a._to_term() < b._to_term())
+    self.assertTrue(a._to_term() <= b._to_term())
+    self.assertTrue(b._to_term() >= a._to_term())
+    self.assertTrue(b._to_term() > a._to_term())
 
-    self.assertTrue(((3 * b) // a).to_monomial() >= ((2 * b) // a).to_monomial())
-    self.assertTrue(((3 * b) // a).to_monomial() <= ((4 * a) // b).to_monomial())
-    self.assertTrue(a.to_monomial() < (a * a).to_monomial())
-    self.assertTrue(b.to_monomial() < (a * a).to_monomial())
-    self.assertTrue((a * a * b).to_monomial() < (a * b * b).to_monomial())
+    self.assertTrue(((3 * b) // a)._to_term() >= ((2 * b) // a)._to_term())
+    self.assertTrue(((3 * b) // a)._to_term() <= ((4 * a) // b)._to_term())
+    self.assertTrue(a._to_term() < (a * a)._to_term())
+    self.assertTrue(b._to_term() < (a * a)._to_term())
+    self.assertTrue((a * a * b)._to_term() < (a * b * b)._to_term())
     e1 = 2 + a * a * b + a * b * b + a * b + a * a + a + b
 
-    sorted_e1 = [shape_poly._DimExpr.from_monomial(m, m_count, a.scope)
-                 for m, m_count in e1.monomials()]
+    sorted_e1 = [shape_poly._DimExpr._from_term(m, m_count, a.scope)
+                 for m, m_count in e1._sorted_terms]
     self.assertSequenceEqual(sorted_e1,
                              [a * b * b, a * a * b, a * b, a * a, b, a, 2])
 
     e2 = a * (a // 4) + (a // 4) + b * (a // 4) + b * (a % 4) + a * a + b + 15
-    sorted_e2 = [shape_poly._DimExpr.from_monomial(m, m_count, a.scope)
-                 for m, m_count in e2.monomials()]
+    sorted_e2 = [shape_poly._DimExpr._from_term(m, m_count, a.scope)
+                 for m, m_count in e2._sorted_terms]
     self.assertSequenceEqual(sorted_e2,
                              [b * (a % 4), b * (a // 4), a * (a // 4), a // 4,
                               a * a, b, 15])
 
-    # This failed with a previous implementation of atom equality
-    self.assertNotEqual(shape_poly._DimMon.from_operation(shape_poly._DimAtom.NON_NEGATIVE,
-                                                          a - b - 1,
-                                                          scope=a.scope),
-                        shape_poly._DimMon.from_operation(shape_poly._DimAtom.NON_NEGATIVE,
-                                                          a - 2 * b - 1,
-                                                          scope=a.scope))
+    # This failed with a previous implementation of factor equality
+    self.assertNotEqual(shape_poly._DimTerm.from_operation(shape_poly._DimFactor.NON_NEGATIVE,
+                                                           a - b - 1,
+                                                           scope=a.scope),
+                        shape_poly._DimTerm.from_operation(shape_poly._DimFactor.NON_NEGATIVE,
+                                                           a - 2 * b - 1,
+                                                           scope=a.scope))
   def test_bounds_arithmetic(self):
     a, b, c = shape_poly.symbolic_shape("a, b, c")
     bounded_le4 = 5 - a
@@ -479,20 +479,20 @@ class DimExprTest(jtu.JaxTestCase):
     a, b = shape_poly.symbolic_shape("a, b")
     # Generate test cases for floordiv and mod: (a + N) // +-2, (N - a) // +-2
     # and then evaluate them for a = 1, 5, 10000
-    div_mod_atoms = [
+    div_mod_factors = [
         operation(op1 + n, div)
         for op1 in (a, a + 10, a + 11, -a, -a + 10, -a + 11)
         for n in (-3, -1, 0, 1, 3)
         for div in (-2, 2, a + 4, -4 - a)  # Either negative, or positive
         for operation in (op.floordiv, op.mod)
         ]
-    for atom in div_mod_atoms:
-      lb, ub = _bounds(atom)
+    for fact in div_mod_factors:
+      lb, ub = _bounds(fact)
       self.assertLessEqual(lb, ub)
       for a_val in (1, 5, 10000):
-        atom_val = atom.evaluate(dict(a=a_val))
-        self.assertGreaterEqual(atom_val, lb)
-        self.assertLessEqual(atom_val, ub)
+        fact_val = fact._evaluate(dict(a=a_val))
+        self.assertGreaterEqual(fact_val, lb)
+        self.assertLessEqual(fact_val, ub)
 
   def test_bounds_non_negative(self):
     a, b = shape_poly.symbolic_shape("a, b")
@@ -597,15 +597,15 @@ class DimExprTest(jtu.JaxTestCase):
     self.assertEqual(poly3, np.array(3, np.int64)[()])
     self.assertNotEqual(poly3 + 1, 3)
     self.assertNotEqual(poly3, poly3 + 1)
-    self.assertTrue((2 * a * b * a + 3).eq(1 + b * a * a + a * a * b + 2))
-    self.assertFalse((2 * a * b * a + 3).eq(a * b * a + 3))
+    self.assertTrue((2 * a * b * a + 3)._eq(1 + b * a * a + a * a * b + 2))
+    self.assertFalse((2 * a * b * a + 3)._eq(a * b * a + 3))
 
-    self.assertFalse((a * b * a + 3).eq(a * b * a + 4))
-    self.assertFalse((2 * a * b * a).eq(a * b * a))
-    self.assertFalse((2 * a * b * a + 1).eq(a * b * a))
-    self.assertFalse((3 * a * b * a - 1).eq(a * b * a))
+    self.assertFalse((a * b * a + 3)._eq(a * b * a + 4))
+    self.assertFalse((2 * a * b * a)._eq(a * b * a))
+    self.assertFalse((2 * a * b * a + 1)._eq(a * b * a))
+    self.assertFalse((3 * a * b * a - 1)._eq(a * b * a))
 
-    self.assertFalse((3 * a * b * a - 2).eq(a * b * a))
+    self.assertFalse((3 * a * b * a - 2)._eq(a * b * a))
 
     self.sampled_assertion(a % b,
                            lambda x: x, a % b)
@@ -722,8 +722,8 @@ class DimExprTest(jtu.JaxTestCase):
            "c + 3*d >= 10", "c - 2*d >= -4",  # -> 5c >= 8 -> c >= 2
         ])
     scope = a.scope
-    def _m(e: shape_poly._DimExpr) -> shape_poly._DimMon:
-      return e.to_monomial()
+    def _m(e: shape_poly._DimExpr) -> shape_poly._DimTerm:
+      return e._to_term()
     Comparator = shape_poly.Comparator
     decision = shape_poly_decision._DecisionByElimination(scope).initialize()
 
@@ -902,7 +902,7 @@ class DimExprTest(jtu.JaxTestCase):
                                     # Contradicts the default a >= 1
                                     constraints=("a == a + 1",))
 
-  def test_constraints_ge_monomial(self):
+  def test_constraints_ge_term(self):
     a, b = shape_poly.symbolic_shape(
         "a, b",
         constraints=("max(a, b) >= 8", "min(a, b) <= 2",
@@ -915,7 +915,7 @@ class DimExprTest(jtu.JaxTestCase):
     self.assertGreaterEqual(a % b, 1)
     self.assertGreaterEqual(core.max_dim(a, b) % 4, 2)
 
-  def test_constraints_ge_monomial_derived(self):
+  def test_constraints_ge_term_derived(self):
     a, b = shape_poly.symbolic_shape(
         "a, b",
         constraints=("a >= 4", "3 >= b"))
@@ -927,7 +927,7 @@ class DimExprTest(jtu.JaxTestCase):
     self.assertEqual(_bounds(a + b), (5, np.inf))
     self.assertEqual(_bounds(a - b), (1, np.inf))
 
-  def test_constraints_ge_not_monomial(self):
+  def test_constraints_ge_not_term(self):
     a, b = shape_poly.symbolic_shape("a, b",
                                      constraints=("a >= b",))
     self.assertGreaterEqual(a, b)
@@ -1118,7 +1118,7 @@ class DimExprTest(jtu.JaxTestCase):
     )
     self.assertEqual(_bounds(a1 - a5), (0, np.inf))
 
-  def test_constraints_rounding_monomials(self):
+  def test_constraints_rounding_terms(self):
     a1, a2 = shape_poly.symbolic_shape(
         "a1, a2",
         constraints=(
@@ -1128,7 +1128,7 @@ class DimExprTest(jtu.JaxTestCase):
     )
     self.assertEqual(_bounds(a1), (2, 2))
 
-  def test_constraints_rounding_not_monomials(self):
+  def test_constraints_rounding_not_terms(self):
     a1, a2 = shape_poly.symbolic_shape(
         "a1, a2",
         constraints=(
@@ -1145,7 +1145,7 @@ class DimExprTest(jtu.JaxTestCase):
       _ = shape_poly.symbolic_shape(
           "a1", constraints=("a1 >= a1 + 1",))
 
-  def test_constraints_unsat_monomials(self):
+  def test_constraints_unsat_terms(self):
     with self.assertRaisesRegex(ValueError,
                                 "Unsatisfiable constraint"):
       a1, a2, *_ = shape_poly.symbolic_shape(
@@ -1157,7 +1157,7 @@ class DimExprTest(jtu.JaxTestCase):
               "a1 <= a4 + 2", "a4 <= 2"))
       a1 >= a2
 
-  def test_constraints_unsat_not_monomials(self):
+  def test_constraints_unsat_not_terms(self):
     with self.assertRaisesRegex(ValueError,
                                 "Unsatisfiable constraint"):
       a1, a2, a3, a4 = shape_poly.symbolic_shape(
@@ -1716,7 +1716,7 @@ class ShapePolyTest(jtu.JaxTestCase):
         polymorphic_shapes=["b1", "b2"])
 
     # A polymorphic arg is not used, and the dimension var does appear
-    # elsewhere but not as a trivial monomial.
+    # elsewhere but not as a trivial term.
     check_shape_poly(self,
         lambda x_unused, y: y * 2.0,
         arg_descriptors=[RandArg((3,), _f32), RandArg((9,), _f32)],


### PR DESCRIPTION
In the past symbolic expressions were polynomials, made of sums
of monomials, which were products of atoms. Over time the language
of symbolic expressions has become richers. Now expressions
are sums of terms, which are products of factors.

Here we rename references to monomials to terms, and `_DimMon`
to `_DimTerm`. We also rename reference of atoms to factors,
and `_DimAtom` to `_DimFactor`.

At the same time we rename most of the methods of `_DimExpr`
to have a leading underscore, to indicate that they are
private methods.