### PR TITLE
Better error message for XLA negative axes

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -2235,7 +2235,9 @@ def cumlogsumexp(operand: Array, axis: int = 0, reverse: bool = False) -> Array:
   return cumlogsumexp_p.bind(operand, axis=int(axis), reverse=bool(reverse))
 
 def _cumred_shape_rule(x, *, axis: int, reverse: bool):
-  if axis < 0 or axis >= x.ndim:
+  if axis < 0:
+    raise ValueError("XLA operations do not allow negative axes")
+  elif axis >= x.ndim:
     raise ValueError(
         f"axis {axis} is out of bounds for array of shape {x.shape}")
   return x.shape


### PR DESCRIPTION
Error message modified for clarity to show XLA does not allow negative axes specifications.

Fixes [10916](https://github.com/google/jax/issues/10916)