### PR TITLE
typing: fix incorrect tuple annotations

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -614,7 +614,7 @@ def api_hook(fun, tag: str):
 
 def debug_info(
   traced_for: str, src: str | None, fun_signature: inspect.Signature | None,
-  args: tuple[Any], kwargs: dict[str, Any], static_argnums: tuple[int, ...],
+  args: tuple[Any, ...], kwargs: dict[str, Any], static_argnums: tuple[int, ...],
   static_argnames: tuple[str, ...]
 ) -> TracingDebugInfo | None:
   """Try to build trace-time debug info for fun when applied to args/kwargs."""

--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -682,7 +682,7 @@ def _dot_product_attention(query: Array,
                             scale: float,
                             seed: int,
                             dropout_rate: float,
-                            variadic_args: tuple[bool],
+                            variadic_args: tuple[bool, ...],
                             is_flash_attention: bool,
                             is_causal_mask: bool):
   output = _dot_product_attention_fwd(

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -421,7 +421,7 @@ _dtype_kinds: dict[str, set] = {
 }
 
 
-def isdtype(dtype: DTypeLike, kind: str | DType | tuple[str | DType]) -> bool:
+def isdtype(dtype: DTypeLike, kind: str | DType | tuple[str | DType, ...]) -> bool:
   """Returns a boolean indicating whether a provided dtype is of a specified kind.
 
   Args:
@@ -444,7 +444,7 @@ def isdtype(dtype: DTypeLike, kind: str | DType | tuple[str | DType]) -> bool:
     True or False
   """
   the_dtype = np.dtype(dtype)
-  kind_tuple: tuple[DType | str] = kind if isinstance(kind, tuple) else (kind,)
+  kind_tuple: tuple[DType | str, ...] = kind if isinstance(kind, tuple) else (kind,)
   options: set[DType] = set()
   for kind in kind_tuple:
     if isinstance(kind, str):

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -888,7 +888,7 @@ def squeeze(a: ArrayLike, axis: int | Sequence[int] | None = None) -> Array:
   return _squeeze(asarray(a), _ensure_index_tuple(axis) if axis is not None else None)
 
 @partial(jit, static_argnames=('axis',), inline=True)
-def _squeeze(a: Array, axis: tuple[int]) -> Array:
+def _squeeze(a: Array, axis: tuple[int, ...]) -> Array:
   if axis is None:
     a_shape = shape(a)
     if not core.is_constant_shape(a_shape):
@@ -1427,7 +1427,7 @@ def nonzero(a: ArrayLike, *, size: int | None = None,
 
 @util.implements(np.flatnonzero, lax_description=_NONZERO_DOC, extra_params=_NONZERO_EXTRA_PARAMS)
 def flatnonzero(a: ArrayLike, *, size: int | None = None,
-                fill_value: None | ArrayLike | tuple[ArrayLike] = None) -> Array:
+                fill_value: None | ArrayLike | tuple[ArrayLike, ...] = None) -> Array:
   return nonzero(ravel(a), size=size, fill_value=fill_value)[0]
 
 

--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -740,7 +740,7 @@ def _maybe_cast_to_index(cast_to_index, x):
     return _make_index(x)
   return _ensure_mlir_value(x, aval=jax_core.ShapedArray((), jnp.int32))
 
-def _index_to_start_size(idx: tuple[indexing.Slice | int | ir.Value],
+def _index_to_start_size(idx: tuple[indexing.Slice | int | ir.Value, ...],
                          cast_to_index: bool) -> tuple[ir.Value, int, bool]:
   assert not isinstance(idx, slice)
   if isinstance(idx, indexing.Slice):

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1761,7 +1761,7 @@ ad.primitive_jvps[pjit_p] = _pjit_jvp
 
 @weakref_lru_cache
 def _known_jaxpr_fwd(known_jaxpr: core.ClosedJaxpr,
-                     in_fwd: tuple[int | None]) -> core.ClosedJaxpr:
+                     in_fwd: tuple[int | None, ...]) -> core.ClosedJaxpr:
   updated_jaxpr = known_jaxpr.jaxpr.replace(
       outvars=[x for x, i in zip(known_jaxpr.jaxpr.outvars, in_fwd)
                if i is None])
@@ -1957,7 +1957,7 @@ ad.reducing_transposes[pjit_p] = _pjit_transpose
 
 @weakref_lru_cache
 def _dce_jaxpr_pjit(
-    jaxpr: core.ClosedJaxpr, used_outputs: tuple[bool]
+    jaxpr: core.ClosedJaxpr, used_outputs: tuple[bool, ...]
 ) -> tuple[core.ClosedJaxpr, list[bool]]:
   new_jaxpr, used_inputs = pe.dce_jaxpr(jaxpr.jaxpr, used_outputs)
   return core.ClosedJaxpr(new_jaxpr, jaxpr.consts), used_inputs

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -19,7 +19,7 @@ from functools import partial
 import numpy as np
 import scipy.linalg
 import textwrap
-from typing import cast, overload, Any, Literal
+from typing import overload, Any, Literal
 
 import jax
 import jax.numpy as jnp
@@ -601,8 +601,8 @@ def expm_frechet(A: ArrayLike, E: ArrayLike, *, method: str | None = None,
 @jit
 def block_diag(*arrs: ArrayLike) -> Array:
   if len(arrs) == 0:
-    arrs = cast(tuple[ArrayLike], (jnp.zeros((1, 0)),))
-  arrs = cast(tuple[ArrayLike], promote_dtypes(*arrs))
+    arrs =  (jnp.zeros((1, 0)),)
+  arrs = tuple(promote_dtypes(*arrs))
   bad_shapes = [i for i, a in enumerate(arrs) if jnp.ndim(a) > 2]
   if bad_shapes:
     raise ValueError("Arguments to jax.scipy.linalg.block_diag must have at "

--- a/jax/_src/sharding_impls.py
+++ b/jax/_src/sharding_impls.py
@@ -1238,7 +1238,7 @@ class ShardingContext:
   This context also uses the GSPMD partitioner.
   """
   num_devices: int
-  device_assignment: tuple[xc.Device] | None = None
+  device_assignment: tuple[xc.Device, ...] | None = None
 
   def __post_init__(self):
     if self.device_assignment is not None:

--- a/jax/experimental/array_api/_manipulation_functions.py
+++ b/jax/experimental/array_api/_manipulation_functions.py
@@ -58,7 +58,7 @@ def reshape(x: Array, /, shape: tuple[int, ...], *, copy: bool | None = None) ->
   return jax.numpy.reshape(x, shape)
 
 
-def roll(x: Array, /, shift: int | tuple[int], *, axis: int | tuple[int, ...] | None = None) -> Array:
+def roll(x: Array, /, shift: int | tuple[int, ...], *, axis: int | tuple[int, ...] | None = None) -> Array:
   """Rolls array elements along a specified axis."""
   return jax.numpy.roll(x, shift=shift, axis=axis)
 

--- a/jax/experimental/sparse/ad.py
+++ b/jax/experimental/sparse/ad.py
@@ -31,7 +31,7 @@ from jax.experimental.sparse._base import JAXSparse
 is_sparse = lambda x: isinstance(x, JAXSparse)
 
 
-def flatten_fun_for_sparse_ad(fun, argnums: int | tuple[int], args: tuple[Any]):
+def flatten_fun_for_sparse_ad(fun, argnums: int | tuple[int, ...], args: tuple[Any, ...]):
   argnums_tup = _ensure_index_tuple(argnums)
   assert all(0 <= argnum < len(args) for argnum in argnums_tup)
 


### PR DESCRIPTION
Replace a number of instances of `tuple[foo]` with `tuple[foo, ...]`