### PR TITLE
[xmap-removal] remove reduce_axes from grad / vjp / backward_pass

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -446,9 +446,9 @@ mlir.register_lowering(custom_jvp_call_p, _custom_jvp_call_mlir_translation)
 # If a (multi)linear function is defined with a custom jvp, then
 # custom_jvp_call_ can appear in jaxprs to be transposed. Since it's already
 # been linearized, we can drop the jvp rule.
-def _custom_jvp_call_transpose(params, jaxpr, args, ct, _, reduce_axes):
+def _custom_jvp_call_transpose(params, jaxpr, args, ct, _):
   del params
-  return ad.backward_pass(jaxpr.jaxpr, reduce_axes, None, jaxpr.consts, args, ct)
+  return ad.backward_pass(jaxpr.jaxpr, None, jaxpr.consts, args, ct)
 ad.primitive_transposes[custom_jvp_call_p] = _custom_jvp_call_transpose
 
 

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -695,7 +695,7 @@ def _cond_dce_rule(used_outputs: list[bool], eqn: core.JaxprEqn,
   return [True, *used_inputs], new_eqn
 
 
-def _transpose_cond_jaxpr(jaxpr, num_res, reduce_axes):
+def _transpose_cond_jaxpr(jaxpr, num_res):
   res_avals, primal_avals = split_list(jaxpr.in_avals, [num_res])
   primal_avals = map(raise_to_shaped, primal_avals)
 
@@ -704,13 +704,13 @@ def _transpose_cond_jaxpr(jaxpr, num_res, reduce_axes):
     res, cts_out = split_list(args, [num_res])
     primals = res + [ad.UndefinedPrimal(aval) for aval in primal_avals]
     cts_in = ad.backward_pass(
-        jaxpr.jaxpr, reduce_axes, False, jaxpr.consts, primals, cts_out)
+        jaxpr.jaxpr, False, jaxpr.consts, primals, cts_out)
     _, cts_in = split_list(cts_in, [num_res])
     return map(ad.instantiate_zeros, cts_in)
 
   return _make_closed_jaxpr(transposed, res_avals + jaxpr.out_avals)
 
-def _cond_transpose(reduce_axes, cts, *args, branches, linear):
+def _cond_transpose(cts, *args, branches, linear):
   del linear  # could use for error checking, but see #14026
   index, *ops = args
   linear = [type(x) is ad.UndefinedPrimal for x in ops]
@@ -721,7 +721,7 @@ def _cond_transpose(reduce_axes, cts, *args, branches, linear):
     raise NotImplementedError("State effect not supported in cond transpose.")
 
   branches_trans = tuple(
-      _transpose_cond_jaxpr(jaxpr, num_res, reduce_axes) for jaxpr in branches)
+      _transpose_cond_jaxpr(jaxpr, num_res) for jaxpr in branches)
   lin_in_avals = [raise_to_shaped(a, weak_type=False)
                   for a, l in zip(in_avals, linear) if l]
   assert all(core.typematch(out_aval, lin_in_aval)

--- a/jax/_src/lax/control_flow/for_loop.py
+++ b/jax/_src/lax/control_flow/for_loop.py
@@ -717,8 +717,7 @@ def transpose_jaxpr(jaxpr: core.Jaxpr, which_linear: list[bool]) -> core.Jaxpr:
     if used_i:
       primals_args = [*primals_args, i]
     ct_args = [x for x, u in zip(args, used_ct) if u]
-    ad.backward_pass(
-        tangent_jaxpr, (), False, (), (*primals_args, *ct_args), ())
+    ad.backward_pass(tangent_jaxpr, False, (), (*primals_args, *ct_args), ())
     return []
   jaxpr_trans, _, _, () = pe.trace_to_jaxpr_dynamic(
       lu.wrap_init(trans), [v.aval for v in jaxpr.invars])

--- a/jax/_src/pallas/primitives.py
+++ b/jax/_src/pallas/primitives.py
@@ -30,7 +30,7 @@ from jax._src.util import (safe_map, safe_zip)
 from jax._src.state import discharge as state_discharge
 from jax._src.state import indexing
 from jax._src.state import primitives as sp
-from jax.interpreters import ad
+from jax._src.interpreters import ad
 from jax.interpreters import mlir
 from jax.interpreters import xla
 import jax.numpy as jnp

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1906,14 +1906,14 @@ def _pjit_transpose_trace(fun, in_avals):
   return transpose_jaxpr, attrs_tracked
 
 
-def _pjit_transpose(reduce_axes, cts_in, *primals_in,
+def _pjit_transpose(cts_in, *primals_in,
                     jaxpr, in_shardings, out_shardings,
                     resource_env, donated_invars, name, keep_unused, inline):
   def prune_type(ty, xs, maybe_zeros):
     return tuple(x for x, mz in zip(xs, maybe_zeros) if type(mz) is not ty)
 
   body = lu.wrap_init(ad.closed_backward_pass)
-  body = lu.hashable_partial(body, jaxpr, reduce_axes, False)
+  body = lu.hashable_partial(body, jaxpr, False)
   primals_and_nz_cts_in, in_treedef = tree_flatten((primals_in, cts_in))
   body, cts_out_treedef_thunk = flatten_fun_nokwargs(body, in_treedef)
 

--- a/jax/_src/state/discharge.py
+++ b/jax/_src/state/discharge.py
@@ -704,8 +704,7 @@ def _transpose_jaxpr(jaxpr: core.Jaxpr, which_linear: Sequence[bool]
     primals_args = [*nonref_res, *ref_res]
     _, tangent_args = partition_list(which_linear, args)
     _, ct_args = partition_list(used_cts, tangent_args)
-    ad.backward_pass(
-        tangent_jaxpr, (), False, (), (*primals_args, *ct_args), ())
+    ad.backward_pass(tangent_jaxpr, False, (), (*primals_args, *ct_args), ())
     return []
   jaxpr_trans, _, consts, () = pe.trace_to_jaxpr_dynamic(
       lu.wrap_init(trans), [v.aval for v in jaxpr.invars])

--- a/jax/experimental/attrs.py
+++ b/jax/experimental/attrs.py
@@ -211,7 +211,7 @@ def _vjp_wrap(jaxpr, consts, out_pvals, attr_avals, io_tree, in_attrs, out_attrs
     assert out_tree == out_tree_
     attr_cts = [attr_cotangents.get(a, ad.Zero(aval))
                 for a, aval in zip(out_attrs, attr_avals)]
-    out = ad.backward_pass(jaxpr, (), (), consts, dummies, (*out_cts, *attr_cts))
+    out = ad.backward_pass(jaxpr, (), consts, dummies, (*out_cts, *attr_cts))
     in_attr_bars, arg_cts = split_list(out, [len(in_attrs)])
     args_ct = tree_unflatten(in_tree, map(ad.instantiate_zeros, arg_cts))
     return args_ct, dict(zip(in_attrs, in_attr_bars))

--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -58,7 +58,7 @@ from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
 from jax._src.interpreters import partial_eval as pe
 from jax._src.interpreters import pxla
-from jax.interpreters import ad
+from jax._src.interpreters import ad
 from jax.tree_util import (tree_map, tree_flatten, tree_unflatten,
                            tree_structure, tree_leaves, keystr)
 from jax._src.tree_util import (broadcast_prefix, prefix_errors, PyTreeDef,
@@ -1400,7 +1400,7 @@ def _shard_map_transpose(out_cts, *args, jaxpr, mesh, in_names, out_names,
         pe.close_jaxpr(jaxpr), map(ad.is_undefined_primal, args), False)
     res_reshaped = core.jaxpr_as_fun(jaxpr_known)(*res)
     out = ad.backward_pass(
-        jaxpr_unknown.jaxpr, (), False, (), (*res_reshaped, *undefs), out_cts
+        jaxpr_unknown.jaxpr, False, (), (*res_reshaped, *undefs), out_cts
     )
     out = [ad.Zero(_unshard_aval(mesh, ns, x.aval)) if type(x) is ad.Zero
            else x if rewrite else jax.lax.psum(x, tuple(_unmentioned(mesh, ns)))

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -27,7 +27,7 @@ from jax._src.interpreters.ad import (
   add_jaxvals as add_jaxvals,
   add_jaxvals_p as add_jaxvals_p,
   add_tangents as add_tangents,
-  backward_pass as backward_pass,
+  backward_pass as backward_pass_internal,
   bilinear_transpose as bilinear_transpose,
   call_param_updaters as call_param_updaters,
   call_transpose as call_transpose,
@@ -98,3 +98,11 @@ else:
 del typing
 del _deprecated_config
 del _deprecated_source_info_util
+
+def backward_pass(jaxpr, reduce_axes, transform_stack,
+                  consts, primals_in, cotangents_in):
+  if reduce_axes:
+    raise NotImplementedError("reduce_axes on ad.backward_pass is deprecated")
+  del reduce_axes
+  return backward_pass_internal(
+      jaxpr, transform_stack, consts, primals_in, cotangents_in)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6247,6 +6247,7 @@ class JaxprTest(jtu.JaxTestCase):
 
   @parameterized.parameters(True, False)
   def test_vjp_reduce_axes_jaxpr(self, gy_batched):
+    raise unittest.SkipTest("reduce_axes autodiff is removed")
     def f(w, x):
       return jnp.sin(jnp.dot(x, w))
 

--- a/tests/pallas/splash_attention_kernel_test.py
+++ b/tests/pallas/splash_attention_kernel_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 from typing import Any, Callable, TypeVar
+import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -39,7 +40,7 @@ except (ModuleNotFoundError, ImportError):
   CAN_USE_HYPOTHESIS = False
 
 if not CAN_USE_HYPOTHESIS:
-  import sys; sys.exit(0)
+  raise unittest.SkipTest("tests require hypothesis")
 
 
 jax.config.parse_flags_with_absl()

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -618,6 +618,7 @@ class XMapTest(XMapTestCase):
     self.assertAllClose(f(x * 2), ref(x * 2))
 
   def testAutodiffBroadcast(self):
+    raise SkipTest("reduce_axes on vjp is deprecated")
     f = xmap(lambda x, y: jnp.cos(lax.dot(x, jnp.sin(y),
                                           precision=lax.Precision.HIGHEST)),
              in_axes=(['i', ...], {}), out_axes=['i', ...])
@@ -1713,6 +1714,7 @@ class XMapErrorTest(jtu.JaxTestCase):
            in_axes=['i', None], out_axes=['i', None])(jnp.ones((5, 4)))
 
   def testReturnExtraMappedAxes(self):
+    raise SkipTest("reduce_axes on vjp is deprecated")
     fm = xmap(lambda x, y: x + y,
               in_axes=(['a', ...], ['b', ...]), out_axes=['a', ...])
     x = np.arange(12).reshape((4, 3))
@@ -1871,6 +1873,7 @@ class XMapErrorTest(jtu.JaxTestCase):
 class NamedAutodiffTests(jtu.JaxTestCase):
 
   def testVjpReduceAxes(self):
+    raise SkipTest("reduce_axes on vjp is deprecated")
     def f(w, x):
       return jnp.sin(jnp.dot(x, w))
 
@@ -1909,6 +1912,7 @@ class NamedAutodiffTests(jtu.JaxTestCase):
     self.assertAllClose(out, expected, check_dtypes=True, rtol=0.005)
 
   def testVjpReduceAxesCollective(self):
+    raise SkipTest("reduce_axes on vjp is deprecated")
 
     # lax.psum has the wrong transpose, so test with a corrected version for now
     @functools.partial(jax.custom_vjp, nondiff_argnums=(1,))


### PR DESCRIPTION
The incomplete reduce_axes machinery was planned to be used for xmap. It's not needed for e.g. shard_map, see https://jax.readthedocs.io/en/latest/jep/17111-shmap-transpose.html.

See #6950.

This PR changes the signature of `jax._src.interpreters.ad.backward_pass`, while leaving the signature of `jax.interpreters.ad.backward_pass` unchanged since it has a few uses outside JAX core (to be updated in a follow-up). This PR leaves in the `reduce_axes` arguments on `jax.grad`, `jax.vjp`, and `jax.linear_transpose`, but raises a `NotImplementedError` if the argument is set. The latter are public APIs, but this was always an experimental feature, and I didn't see _any_ uses in google's monorepo given a search (and global presubmit is clean), so I think it's fine to just kill without a deprecation cycle in an immediate follow-up.