### PR TITLE
Bump numpy version requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,18 @@ Remember to align the itemized text with the first line of an item within a list
 ## jax 0.4.26
 
 * Deprecations
+  * JAX now requires NumPy 1.23 or newer as per the
+    [deprecation policy](https://jax.readthedocs.io/en/latest/deprecation.html).
   * {func}`jax.tree_map` is deprecated; use `jax.tree.map` instead, or for backward
     compatibility with older JAX versions, use {func}`jax.tree_util.tree_map`.
   * Passing arguments to {func}`jax.numpy.array_equal` and {func}`jax.numpy.array_equiv`
     that cannot be converted to a JAX array now results in an exception.
 
 ## jaxlib 0.4.26
+
+* Deprecations:
+  * jaxlib now requires NumPy 1.23 or newer as per the
+    [deprecation policy](https://jax.readthedocs.io/en/latest/deprecation.html).
 
 ## jax 0.4.25 (Feb 26, 2024)
 

--- a/build/build.py
+++ b/build/build.py
@@ -89,8 +89,8 @@ def check_numpy_version(python_bin_path):
   version = shell(
       [python_bin_path, "-c", "import numpy as np; print(np.__version__)"])
   numpy_version = tuple(map(int, version.split(".")[:2]))
-  if numpy_version < (1, 22):
-    print("ERROR: JAX requires NumPy 1.22 or newer, found " + version + ".")
+  if numpy_version < (1, 23):
+    print("ERROR: JAX requires NumPy 1.23 or newer, found " + version + ".")
     sys.exit(-1)
   return version
 

--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -4,7 +4,7 @@ cloudpickle
 colorama>=0.4.4
 flatbuffers
 hypothesis
-numpy>=1.22
+numpy>=1.23
 pillow>=9.1.0
 portpicker
 pytest-xdist

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -63,7 +63,7 @@ setup(
     install_requires=[
         'scipy>=1.9',
         "scipy>=1.11.1; python_version>='3.12'",
-        'numpy>=1.22',
+        'numpy>=1.23',
         'ml_dtypes>=0.2.0',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     python_requires='>=3.9',
     install_requires=[
         'ml_dtypes>=0.2.0',
-        'numpy>=1.22',
+        'numpy>=1.23',
         "numpy>=1.23.2; python_version>='3.11'",
         "numpy>=1.26.0; python_version>='3.12'",
         'opt_einsum',

--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -185,7 +185,6 @@ class DLPackTest(jtu.JaxTestCase):
     shape=all_shapes,
     dtype=numpy_dtypes,
   )
-  @unittest.skipIf(numpy_version < (1, 23, 0), "Requires numpy 1.23 or newer")
   @jtu.run_on_devices("cpu") # NumPy only accepts cpu DLPacks
   def testJaxToNumpy(self, shape, dtype):
     rng = jtu.rand_default(self.rng())

--- a/tests/lax_numpy_reducers_test.py
+++ b/tests/lax_numpy_reducers_test.py
@@ -507,7 +507,7 @@ class JaxNumpyReducerTests(jtu.JaxTestCase):
       for weights_shape in ([None, shape] if axis is None or len(shape) == 1 or isinstance(axis, tuple)
                             else [None, (shape[axis],), shape])
     ],
-    keepdims=([False, True] if numpy_version >= (1, 23) else [None]),
+    keepdims=[False, True],
     returned=[False, True],
   )
   def testAverage(self, shape, dtype, axis, weights_shape, returned, keepdims):


### PR DESCRIPTION
NumPy 1.22 was released in December 2021, so we are now past the limit of our [deprecation policy](https://jax.readthedocs.io/en/latest/deprecation.html).