### PR TITLE
Use `$(RULEDIR)` to avoid an implicit dependency on `output_to_genfiles`.

### DIFF
--- a/jaxlib/triton/BUILD
+++ b/jaxlib/triton/BUILD
@@ -49,9 +49,11 @@ genrule(
         "_triton_ops_gen.py",
         "_triton_enum_gen.py",
     ],
+    # Use $(RULEDIR) to avoid an implicit dependency on whether inputs are in bin or genfiles.
     cmd = """
     for src in $(SRCS); do
-      out=$${src//_raw/}
+      base=$$(basename $$src)
+      out=$(RULEDIR)/$${base//_raw/}
       echo '# pytype: skip-file' > $${out} && \
           cat $${src} |
           sed -e 's/^from \\.\\./from jaxlib.mlir\\./g' |


### PR DESCRIPTION
This uses `gentbl_rule` which has `output_to_genfiles = True` set. When removing that, these rules break: genrules by default place their outputs in `bazel-genfiles`, but the input files are now in `bazel-bin`, and the genrule doesn't put it in the right place. Instead of taking the full path, use `$(RULEDIR)` to put in the right place, regardless of where the input file comes from.