### PR TITLE
unsupported indexer reporting in lax_numpy

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -4875,9 +4875,8 @@ def _index_to_gather(x_shape: Sequence[int], idx: Sequence[Any],
                "with type {} at position {}, indexer value {}")
         raise TypeError(msg.format(abstract_i.dtype.name, idx_pos, i))
 
-      msg = ("Indexing mode not yet supported. Got unsupported indexer "
-             "with type {} at position {} and value {!r}. Open a feature request!")
-      raise IndexError(msg.format(abstract_i.dtype.name if i is not None else abstract_i, idx_pos, i))
+      raise IndexError("Indexing mode not yet supported. Got unsupported indexer "
+                      f"at position {idx_pos}: {i!r}")
 
   if len(gather_indices) == 0:
     gather_indices_array: ArrayLike = np.zeros((0,), dtype=index_dtype)

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -4877,7 +4877,7 @@ def _index_to_gather(x_shape: Sequence[int], idx: Sequence[Any],
 
       msg = ("Indexing mode not yet supported. Got unsupported indexer "
              "with type {} at position {} and value {!r}. Open a feature request!")
-      raise IndexError(msg.format(abstract_i.dtype.name, idx_pos, i))
+      raise IndexError(msg.format(abstract_i.dtype.name if i is not None else abstract_i, idx_pos, i))
 
   if len(gather_indices) == 0:
     gather_indices_array: ArrayLike = np.zeros((0,), dtype=index_dtype)

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -4875,8 +4875,9 @@ def _index_to_gather(x_shape: Sequence[int], idx: Sequence[Any],
                "with type {} at position {}, indexer value {}")
         raise TypeError(msg.format(abstract_i.dtype.name, idx_pos, i))
 
-      msg = "Indexing mode not yet supported. Open a feature request!\n{}"
-      raise IndexError(msg.format(idx))
+      msg = ("Indexing mode not yet supported. Got unsupported indexer "
+             "with type {} at position {} and value {!r}. Open a feature request!")
+      raise IndexError(msg.format(abstract_i.dtype.name, idx_pos, i))
 
   if len(gather_indices) == 0:
     gather_indices_array: ArrayLike = np.zeros((0,), dtype=index_dtype)


### PR DESCRIPTION
prints offending indexer value with type and position, instead of printing all of the index