### PR TITLE
Support sharing names in save_and_offload_only_these_names.

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -124,10 +124,10 @@ def save_and_offload_only_these_names(
   names_which_can_be_saved = set(names_which_can_be_saved)
   names_which_can_be_offloaded = set(names_which_can_be_offloaded)
   def policy(prim, *_, **params):
-    if prim is name_p and params['name'] in names_which_can_be_saved:
-      return pe.Saveable
     if prim is name_p and params['name'] in names_which_can_be_offloaded:
       return pe.Offloadable(src=offload_src, dst=offload_dst)
+    if prim is name_p and params['name'] in names_which_can_be_saved:
+      return pe.Saveable
     return pe.Recompute  # not saveable unless it's in the allow-list
   return policy
 

--- a/tests/memories_test.py
+++ b/tests/memories_test.py
@@ -1197,6 +1197,50 @@ class ActivationOffloadingTest(jtu.JaxTestCase):
       self.assertNotRegex(compiled_text, r"copy-start.*S\(5\)")
       self.assertNotRegex(compiled_text, r"copy-done.*S\(5\)")
 
+  def test_remat_scan_jaxpr_offloadable_duplicate_names(self):
+    mesh = jtu.create_global_mesh((2,), ("x",))
+    shape = (256, 128)
+    np_inp = np.arange(math.prod(shape), dtype=np.float32).reshape(shape)
+    s = NamedSharding(mesh, P("x"))
+    inp = jax.device_put(np_inp, s)
+
+    policy = jax.checkpoint_policies.save_and_offload_only_these_names(
+        names_which_can_be_saved=["z", "w", "y"], names_which_can_be_offloaded=["z", "w"],
+        offload_src='device', offload_dst='pinned_host')
+
+    @functools.partial(remat, policy=policy)
+    def f(x):
+      def g(ys, _):
+        y, _ = ys
+        y = checkpoint_name(jnp.sin(y), "y")
+        z = checkpoint_name(jnp.sin(y), "z")
+        z = jax.lax.with_sharding_constraint(z, s)
+        w = checkpoint_name(jnp.sin(z), "w")
+        return (w, jnp.sum(w)), None
+      _, scan_out = jax.lax.scan(g, (x, np.array(1, dtype=np.float32)), [np_inp])[0]
+      return scan_out
+
+    fwd_jaxpr, bwd_jaxpr = jtu.fwd_bwd_jaxprs(f, inp)
+
+    self.assertLen(fwd_jaxpr.out_avals, 5)  # 2 output, 3 offloaded residuals
+    fwd_mem_kind_count = str(fwd_jaxpr).count(
+        "TransferToMemoryKind(memory_kind='pinned_host')")
+    self.assertEqual(fwd_mem_kind_count, 2)
+
+    self.assertLen(bwd_jaxpr.in_avals, 5)  # 3 offloaded residuals, 2 input
+    bwd_mem_kind_count = str(bwd_jaxpr).count(
+        "TransferToMemoryKind(memory_kind='device')")
+    self.assertEqual(bwd_mem_kind_count, 2)
+
+    f = jax.jit(jax.grad(f))
+    f(inp)  # doesn't crash
+
+    compiled_text = f.lower(inp).compile().as_text()
+    if compiled_text is not None:
+      self.assertIn('S(5)', compiled_text)
+      self.assertNotRegex(compiled_text, r"copy-start.*S\(5\)")
+      self.assertNotRegex(compiled_text, r"copy-done.*S\(5\)")
+
   def test_remat_checkpoint_dots_with_no_batch_dims(self):
     policy = jax.checkpoint_policies.offload_dot_with_no_batch_dims(
         "device", "pinned_host")


### PR DESCRIPTION
Current implementation is slightly counter-intuitive when using shared names for checkpointing and host offloading. Host offloading implicitly assumes checkpointing as well but currently it's implemented as if one is exclusive of the other.

Specifically, the current implementation silently fails to host offload on this example:

```
   policy = jax.checkpoint_policies.save_and_offload_only_these_names(
        names_which_can_be_saved=["x"], 
        names_which_can_be_offloaded=["x", "y"],
        offload_src='device', offload_dst='pinned_host')
```

The solution is fairly trivial: just flip the order of primitive checks in the policy.