### PR TITLE
simplify code generated by select_n transpose with bool `which`

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3618,11 +3618,15 @@ def _select_transpose_rule(t, which, *cases):
                      for c in cases]
   else:
     zeros = full_like(t, 0)
-    return [None] + [
-        select(eq(which, _const(which, i)), t, zeros)
-        if ad.is_undefined_primal(case) else None
-        for i, case in enumerate(cases)
-    ]
+    if dtypes.dtype(which) == np.dtype(np.bool_):
+      ct0 = select(which, zeros, t) if ad.is_undefined_primal(cases[0]) else None
+      ct1 = select(which, t, zeros) if ad.is_undefined_primal(cases[1]) else None
+      return (None, ct0, ct1)
+    else:
+      return [None] + [
+          select(eq(which, _const(which, i)), t, zeros)
+          if ad.is_undefined_primal(case) else None for i, case in enumerate(cases)
+      ]
 
 def _select_batch_rule(batched_args, batch_dims, **unused_kwargs):
   which, *cases = batched_args

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -4429,6 +4429,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(np_fun, jnp.where, args_maker)
       self._CompileAndCheck(jnp.where, args_maker)
 
+  def testWhereExtraCode(self):
+    def f(x):
+      return jnp.where(x > 0, x, -x)
+
+    jaxpr = jax.make_jaxpr(jax.grad(f))(3.)
+    # Test no comparison literal True/False in jaxpr, and hence no comparison to
+    # literals
+    self.assertNotIn('False', str(jaxpr))
+    self.assertNotIn('True', str(jaxpr))
+
   def testWhereScalarPromotion(self):
     x = jnp.where(jnp.array([True, False]), 3,
                   jnp.ones((2,), dtype=jnp.float32))


### PR DESCRIPTION
Before:
```
    h:f32[] i:f32[] = pjit[
      name=_where
      jaxpr={ lambda ; j:bool[] k:f32[]. let
          l:bool[] = eq j False
          m:f32[] = select_n l 0.0 k
          n:bool[] = eq j True
          o:f32[] = select_n n 0.0 k
        in (o, m) }
    ] b 1.0
```

After:
```
    h:f32[] i:f32[] = pjit[
      name=_where
      jaxpr={ lambda ; j:bool[] k:f32[]. let
          l:f32[] = select_n j k 0.0
          m:f32[] = select_n j 0.0 k
        in (m, l) }
    ] b 10
```