### PR TITLE
[mutable-arrays] allow state effects in jit by building in run_state

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -553,6 +553,7 @@ pytype_strict_library(
         ":util",
         ":xla",
         ":xla_bridge",
+        ":state_types",
         "//jax/_src/lib",
     ] + py_deps("numpy"),
 )

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -203,6 +203,7 @@ class Jaxpr:
     outvars = self.outvars if outvars is None else outvars
     eqns = self.eqns if eqns is None else eqns
     effects = self.effects if effects is None else effects
+    debug_info = self.debug_info if debug_info is None else debug_info
     return Jaxpr(constvars=constvars, invars=invars, outvars=outvars, eqns=eqns,
                  effects=effects, debug_info=debug_info)
 

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1006,6 +1006,8 @@ def convert_constvars_jaxpr(jaxpr: Jaxpr) -> Jaxpr:
 @weakref_lru_cache
 def convert_invars_to_constvars(jaxpr: Jaxpr, n: int) -> Jaxpr:
   """Move n invars to constvars. Like an inverse of convert_constvars_Jaxpr."""
+  if n == 0:
+    return jaxpr.replace()  # 'return jaxpr' would create cache reference cycle
   if any(isinstance(eff, effects.JaxprInputEffect) for eff in jaxpr.effects):
     raise NotImplementedError
   config.enable_checks.value and core.check_jaxpr(jaxpr)
@@ -1526,9 +1528,10 @@ def dce_jaxpr_consts(jaxpr: Jaxpr, used_outputs: Sequence[bool],
                      instantiate: bool | Sequence[bool] = False,
                      ) -> tuple[Jaxpr, list[bool], list[bool]]:
   jaxpr_ = convert_constvars_jaxpr(jaxpr)
-  new_jaxpr_, used_inputs_ = dce_jaxpr(jaxpr_, used_outputs)
+  new_jaxpr, used_inputs_ = dce_jaxpr(jaxpr_, used_outputs)
   used_consts, used_inputs = split_list(used_inputs_, [len(jaxpr.constvars)])
-  new_jaxpr = convert_invars_to_constvars(new_jaxpr_, sum(used_consts))
+  if sum(used_consts):
+    new_jaxpr = convert_invars_to_constvars(new_jaxpr, sum(used_consts))
   return new_jaxpr, used_consts, used_inputs
 
 

--- a/jax/_src/state/discharge.py
+++ b/jax/_src/state/discharge.py
@@ -109,9 +109,8 @@ def _eval_jaxpr_discharge_state(
   # regular values in this interpreter.
   map(env.write, jaxpr.invars, args)
 
-  refs_to_discharge = {id(v.aval) for v, d
-                          in zip(jaxpr.invars, should_discharge) if d
-                          and isinstance(v.aval, AbstractRef)}
+  refs_to_discharge = {id(v.aval) for v, d in zip(jaxpr.invars, should_discharge)
+                       if d and isinstance(v.aval, AbstractRef)}
 
   for eqn in jaxpr.eqns:
     if _has_refs(eqn) and any(id(v.aval) in refs_to_discharge

--- a/jax/experimental/export/_export.py
+++ b/jax/experimental/export/_export.py
@@ -436,6 +436,8 @@ def export(fun_jax: Callable,
       mlir_module = lowering.stablehlo()
 
       args_avals_flat, _ = tree_util.tree_flatten(lowered.in_avals)
+      if "out_mut" in lowering.compile_args:
+        if lowering.compile_args["out_mut"]: raise NotImplementedError
       if "kept_var_idx" in lowering.compile_args:
         module_kept_var_idx = tuple(sorted(lowering.compile_args["kept_var_idx"]))
       else:
@@ -745,7 +747,7 @@ def _check_lowering(lowering) -> None:
   allowed_compile_args = [
       "backend", "mesh", "global_in_avals",
       "global_out_avals", "in_shardings", "out_shardings", "kept_var_idx",
-      "spmd_lowering", "auto_spmd_lowering",
+      "out_mut", "spmd_lowering", "auto_spmd_lowering",
       "tuple_args", "ordered_effects", "unordered_effects",
       "keepalive", "host_callbacks", "pmap_nreps", "committed",
       "device_assignment", "jaxpr_debug_info", "shape_poly_state",


### PR DESCRIPTION
with help from @sharadmv, @yashk2810, @dougalm, and others

This is an experiment based on @dougalm's `MutableArray` proposal in go/jax-oop-proposal (similar to something we've considered adding for a long time). See [the test](https://github.com/google/jax/pull/20026/files#diff-345fab73b3320212e0556e11f83a3cb1be42ece90f54c04633383d23e34452bdR1542-R1553).

The basic strategy is to apply discharge_state when lowering a jaxpr with state effects to HLO, and update the dispatch path accordingly. Specifically:
1. in tests only for now, introduce a MutableArray data type;
2. teach jit to abstract it to a Ref(ShapedArray) type, register an input handler, etc;
3. call discharge_state in `lower_sharding_computation` to lower a jaxpr with refs to a jaxpr (and then to an HLO) with extra outputs, and set up aliasing;
4. teach the output side of the dispatch path to drop those outputs.

As an alternative to (3), we could potentially lower away the effects at a higher level, like in _pjit_lower_cached. They are similar because _pjit_lower_cached is the only (non-xmap) caller of lower_sharding_computation. I decided to do it in lower_sharding_computation mainly because that's closer to where we set up aliases, and I wanted to make mutable arrays correspond to aliased inputs/outputs on the XLA computation.