### PR TITLE
Share binary size threshold

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1190,8 +1190,9 @@ share_binary_between_hosts = define_bool_state(
     name='jax_share_binary_between_hosts',
     default=False,
     help=(
-        'If set to True, the compiled module will be shared between hosts '
-        'directly.'
+        'If set to True and the cumulative size of constants in the pre-compiled graph is '
+        'less than share_binary_between_hosts_size_threshold, the compiled module will be '
+        'shared between hosts directly. '
     ),
 )
 
@@ -1199,6 +1200,18 @@ share_binary_between_hosts_timeout_ms = define_int_state(
     name='jax_share_binary_between_hosts_timeout_ms',
     default=20 * 60 * 1000,
     help='Timeout for the compiled module share.',
+)
+
+share_binary_between_hosts_size_threshold = define_float_state(
+  name='jax_share_binary_between_hosts_size_threshold',
+  default=10.0,
+  help=(
+    'If the size of all constants in a pre-compiled graph is less than this '
+    'threshold, allow sharing of compiled binary with other processes. '
+    'Even if share_binary_between hosts is True, the total size of all '
+    'constants in the graph must be less than this threshold. '
+    'The unit is MB.'
+  ),
 )
 
 enable_compilation_cache = define_bool_state(

--- a/jax/_src/lib/mlir/dialects/__init__.py
+++ b/jax/_src/lib/mlir/dialects/__init__.py
@@ -23,6 +23,7 @@ import jaxlib.mlir.dialects.func as func
 import jaxlib.mlir.dialects.scf as scf
 import jaxlib.mlir.dialects.sparse_tensor as sparse_tensor
 import jaxlib.mlir.dialects.vector as vector
+import jaxlib.mlir.dialects._stablehlo_ops_gen as _stablehlo_ops_gen
 
 from jax._src import lib
 


### PR DESCRIPTION
When running JAX in a distributed system with multiple processes, only allow sharing of compiled modules when the cumulative size of constants in the pre-compiled graph is less than a threshold
