### PR TITLE
Add copy argument to Array.__array__

### DIFF
--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -399,8 +399,10 @@ class ArrayImpl(basearray.Array):
     """
     return self.sharding.is_fully_addressable
 
-  def __array__(self, dtype=None, context=None):
-    return np.asarray(self._value, dtype=dtype)
+  def __array__(self, dtype=None, context=None, copy=None):
+    # copy argument is supported by np.asarray starting in numpy 2.0
+    kwds = {} if copy is None else {'copy': copy}
+    return np.asarray(self._value, dtype=dtype, **kwds)
 
   def __dlpack__(self, *, stream: int | Any | None = None):
     if len(self._arrays) != 1:

--- a/jax/_src/basearray.pyi
+++ b/jax/_src/basearray.pyi
@@ -181,7 +181,8 @@ class Array(abc.ABC):
   # Even though we don't always support the NumPy array protocol, e.g., for
   # tracer types, for type checking purposes we must declare support so we
   # implement the NumPy ArrayLike protocol.
-  def __array__(self) -> np.ndarray: ...
+  def __array__(self, dtype: Optional[np.dtype] = ...,
+                copy: Optional[bool] = ...) -> np.ndarray: ...
   def __dlpack__(self) -> Any: ...
 
   # JAX extensions

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3465,7 +3465,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     assert type(jnp.array(np.array([]))) is array.ArrayImpl
 
     class NDArrayLike:
-      def __array__(self, dtype=None):
+      def __array__(self, dtype=None, copy=None):
         return np.array([], dtype=dtype)
     assert type(jnp.array(NDArrayLike())) is array.ArrayImpl
 
@@ -3478,7 +3478,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testArrayMethod(self):
     class arraylike:
       dtype = np.dtype('float32')
-      def __array__(self, dtype=None):
+      def __array__(self, dtype=None, copy=None):
         return np.array(3., dtype=dtype)
     a = arraylike()
     ans = jnp.array(a)


### PR DESCRIPTION
This is used by NumPy 2.0, and will be required in a future numpy version (see https://github.com/numpy/numpy/issues/25941).

Part of #19246 