### PR TITLE
[key reuse] improve error message using source_info_util

### DIFF
--- a/tests/key_reuse_test.py
+++ b/tests/key_reuse_test.py
@@ -334,10 +334,10 @@ class KeyReuseUnitTestWithForwarding(jtu.JaxTestCase):
 
 @jtu.with_config(jax_enable_key_reuse_checks=False)
 class KeyReuseIntegrationTest(jtu.JaxTestCase):
-  random_bits_error = "In random_bits, key values .+ are already consumed.*"
-  random_split_error = "In random_split, key values .+ are already consumed.*"
-  generic_error = ".*key values .+ are already consumed.*"
-  pjit_error = "In pjit, key values a are already consumed."
+  random_bits_error = "In random_bits, argument [0-9]+ is already consumed.*"
+  random_split_error = "In random_split, argument [0-9]+ is already consumed.*"
+  generic_error = ".*argument [0-9]+ is already consumed.*"
+  pjit_error = "In pjit, argument 0 is already consumed."
 
   def check_key_reuse(self, f, *args):
     return _core.check_key_reuse(f, *args)
@@ -589,7 +589,7 @@ class KeyReuseIntegrationTest(jtu.JaxTestCase):
 class KeyReuseEager(jtu.JaxTestCase):
   jit_msg = "Previously-consumed key passed to jit-compiled function at index 0"
   eager_bits_msg = "Previously-consumed key passed to random_bits at index 0"
-  traced_bits_msg = "In random_bits, key values a are already consumed."
+  traced_bits_msg = "In random_bits, argument 0 is already consumed."
 
   def test_simple_reuse_nojit(self):
     key = jax.random.key(0)


### PR DESCRIPTION
Test script `test.py`:
```python
import jax
jax.config.update('jax_enable_key_reuse_checks', True)

def f(seed):
    key = jax.random.key(seed)
    vals1 = jax.random.bits(key)
    vals2 = jax.random.bits(key)
    return vals1 + vals2

jax.jit(f)(0)
```
Error after this change:
```pytb
$ python test.py
Traceback (most recent call last):
  File "/Users/vanderplas/github/google/jax/test.py", line 10, in <module>
    jax.jit(f)(0)
  File "/Users/vanderplas/github/google/jax/test.py", line 7, in f
    vals2 = jax.random.bits(key)
  File "/Users/vanderplas/github/google/jax/jax/_src/random.py", line 377, in bits
    return _random_bits(key, bit_width, shape)
  File "/Users/vanderplas/github/google/jax/jax/_src/random.py", line 126, in _random_bits
    return prng.random_bits(key, bit_width=bit_width, shape=shape)
  File "/Users/vanderplas/github/google/jax/jax/_src/prng.py", line 746, in random_bits
    return random_bits_p.bind(keys, bit_width=bit_width, shape=shape.positional)
jax._src.source_info_util.JaxStackTraceBeforeTransformation: jax.experimental.key_reuse._core.KeyReuseError: In random_bits, argument 0 is already consumed.

The preceding stack trace is the source of the JAX operation that, once transformed by JAX, triggered the following exception.

--------------------

The above exception was the direct cause of the following exception:

jax.errors.SimplifiedTraceback: For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/vanderplas/github/google/jax/test.py", line 10, in <module>
    jax.jit(f)(0)
  File "/Users/vanderplas/github/google/jax/jax/experimental/key_reuse/_core.py", line 279, in check_key_reuse_jaxpr
    get_jaxpr_type_signature(jaxpr)
  File "/Users/vanderplas/github/google/jax/jax/experimental/key_reuse/_core.py", line 257, in get_jaxpr_type_signature
    raise KeyReuseError(f"In {eqn.primitive}, argument {snk.idx} is already consumed.")
jax.experimental.key_reuse._core.KeyReuseError: In random_bits, argument 0 is already consumed.

```
Previous error:
```pytb
$ python test.py
jax.errors.SimplifiedTraceback: For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/vanderplas/github/google/jax/test.py", line 10, in <module>
    jax.jit(f)(0)
  File "/Users/vanderplas/github/google/jax/jax/experimental/key_reuse/_core.py", line 283, in check_key_reuse_jaxpr
    get_jaxpr_type_signature(jaxpr)
  File "/Users/vanderplas/github/google/jax/jax/experimental/key_reuse/_core.py", line 258, in get_jaxpr_type_signature
    raise KeyReuseError(f"In {eqn.primitive}, key values {key_vals_str} are already consumed.\n"
jax.experimental.key_reuse._core.KeyReuseError: In random_bits, key values b are already consumed.
  signature: KeyReuseSignature(sinks=[Sink(0)], sources=[], forwards=[])
  eqn: d:u32[] = random_bits[bit_width=32 shape=()] b
  jaxpr:
{ lambda ; a:i32[]. let
    b:key<fry>[] = random_seed[impl=fry] a
    c:u32[] = random_bits[bit_width=32 shape=()] b
    d:u32[] = random_bits[bit_width=32 shape=()] b
    e:u32[] = add c d
  in (e,) }
```
In particular, this is **much** nicer when the jaxpr is very long, which happens frequently in my own testing.