### PR TITLE
[attrs] fix tracer lifetime bug, fixes #20082

### DIFF
--- a/jax/experimental/attrs.py
+++ b/jax/experimental/attrs.py
@@ -72,6 +72,7 @@ def _ensure_tracked(trace: pe.DynamicJaxprTrace, obj: Any, attr: str):
     frame.attrs_tracked.append((obj, attr))
     frame.attrs_inits.append(init_val)
     frame.attrs_vars.append(var)
+    frame.tracers.append(tracer)
 pe.DynamicJaxprTrace._ensure_tracked = _ensure_tracked
 
 def _getattr_staging(trace, *, obj, attr):


### PR DESCRIPTION
fixes #20082 

We should probably persist all the Tracers we create during jaxpr tracing. That's usually what we do with [this attribute on the builder](https://github.com/google/jax/blob/67e3542d326d2bb6e4cc958e134ace4baaa152ec/jax/_src/interpreters/partial_eval.py#L1760), and we [append to it when we make new tracers in the usual path](https://github.com/google/jax/blob/67e3542d326d2bb6e4cc958e134ace4baaa152ec/jax/_src/interpreters/partial_eval.py#L2001), but as pointed out we neglected to do it on the attrs path.