### PR TITLE
Include <cstdint> in files where it is used

### DIFF
--- a/jaxlib/gpu/lu_pivot_kernels.cu.cc
+++ b/jaxlib/gpu/lu_pivot_kernels.cu.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "jaxlib/gpu/lu_pivot_kernels.h"
 
 #include <array>
+#include <cstdint>
 #include <iostream>
 
 #include "jaxlib/gpu/vendor.h"

--- a/jaxlib/gpu/lu_pivot_kernels.h
+++ b/jaxlib/gpu/lu_pivot_kernels.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define JAXLIB_GPU_LU_PIVOT_KERNELS_H_
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 
 #include "jaxlib/gpu/vendor.h"

--- a/jaxlib/gpu/prng_kernels.cu.cc
+++ b/jaxlib/gpu/prng_kernels.cu.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 
 #include "jaxlib/gpu/vendor.h"
 

--- a/jaxlib/gpu/prng_kernels.h
+++ b/jaxlib/gpu/prng_kernels.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define JAXLIB_GPU_PRNG_KERNELS_H_
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 
 #include "jaxlib/gpu/vendor.h"


### PR DESCRIPTION
Due to a change in NVCC itself or CUDA headers in CUDA 12.4, `<cstdint>` is no longer implicitly included. This uncovered files where `<cstdint>` is used but is not explicitly included. This PR includes it explicitly in those files.