### PR TITLE
minor modification for silu and swish func description

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -149,7 +149,7 @@ def sigmoid(x: ArrayLike) -> Array:
 
 @jax.jit
 def silu(x: ArrayLike) -> Array:
-  r"""SiLU (a.k.a. swish) activation function.
+  r"""SiLU (aka swish) activation function.
 
   Computes the element-wise function:
 


### PR DESCRIPTION
Modify unfinished statement:
"SiLU (a.k.a." 
to complete statement:
"SiLU (aka swish) activation function." for both 'silu' and 'swish'.

Fixed by removing problematic characters.
https://jax.readthedocs.io/en/latest/jax.nn.html
