### PR TITLE
Remove deprecated shims and update deprecated ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,11 @@ exclude = [
     "build",
     "__pycache__",
 ]
+line-length = 88
+indent-width = 2
+target-version = "py39"
+
+[tool.ruff.lint]
 ignore = [
     # Unnecessary collection call
     "C408",
@@ -134,8 +139,6 @@ ignore = [
     # Raise with from clause inside except block
     "B904",
 ]
-line-length = 88
-indent-width = 2
 select = [
     "B9",
     "C",
@@ -147,12 +150,11 @@ select = [
     "E227",
     "E228",
 ]
-target-version = "py39"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 18
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # F811: Redefinition of unused name.
 "docs/autodidax.py" = ["F811"]
 # Note: we don't use jax/*.py because this matches contents of jax/_src


### PR DESCRIPTION
- Removes kwarg compatibility shims that were marked for removal after 2022/08/11.
- Updates the ruff configuration to use the `[tool.ruff.lint]` format over the deprecated top-level `[tool.ruff]` specification.