### PR TITLE
Fix typo for `random.py`

### DIFF
--- a/jax/random.py
+++ b/jax/random.py
@@ -116,8 +116,9 @@ Here is a short summary:
    identical across JAX/XLA versions    ✅        ✅
    =================================   ========  =========  ===  ==========  =====  ============
 
-(*): with jax_threefry_partitionable=1 set
-(**): with XLA_FLAGS=--xla_tpu_spmd_rng_bit_generator_unsafe=1 set
+(*): with ``jax_threefry_partitionable=1`` set
+
+(**): with ``XLA_FLAGS=--xla_tpu_spmd_rng_bit_generator_unsafe=1`` set
 
 The difference between "rbg" and "unsafe_rbg" is that while "rbg" uses a less
 robust/studied hash function for random value generation (but not for


### PR DESCRIPTION
The layout for the footnote under the table is not correct:
![](https://github.com/google/jax/assets/33915732/67b4a749-24d0-47a3-8c8e-6e7aea136093)
