### PR TITLE
Removed `__dlpack__` extraction leading to forced legacy path

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2438,7 +2438,7 @@ def fromiter(*args, **kwargs):
 """)
 def from_dlpack(x: Any) -> Array:
   from jax.dlpack import from_dlpack  # pylint: disable=g-import-not-at-top
-  return from_dlpack(x.__dlpack__())
+  return from_dlpack(x)
 
 @util.implements(np.fromfunction)
 def fromfunction(function: Callable[..., Array], shape: Any,


### PR DESCRIPTION
`jnp.from_dlpack` no longer passes `x.__dlpack__()` to `jax.dlpack.from_dlpack` and instead passes `x` directly, allowing for the use of the new DLPack API, including `__dlpack_device__`.