### PR TITLE
Enable opt-in autodetection of distributed configuration for mpi4py

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -952,6 +952,7 @@ pytype_strict_library(
         "_src/clusters/cluster.py",
         "_src/clusters/ompi_cluster.py",
         "_src/clusters/slurm_cluster.py",
+        "_src/clusters/mpi4py_cluster.py",
         "_src/distributed.py",
         "_src/xla_bridge.py",
     ],

--- a/jax/_src/clusters/__init__.py
+++ b/jax/_src/clusters/__init__.py
@@ -22,5 +22,6 @@ from .cluster import ClusterEnv
 # available one from the list will be picked.
 from .ompi_cluster import OmpiCluster
 from .slurm_cluster import SlurmCluster
+from .mpi4py_cluster import Mpi4pyCluster
 from .cloud_tpu_cluster import GkeTpuCluster
 from .cloud_tpu_cluster import GceTpuCluster

--- a/jax/_src/clusters/cloud_tpu_cluster.py
+++ b/jax/_src/clusters/cloud_tpu_cluster.py
@@ -74,6 +74,9 @@ def has_megascale_address():
   return get_tpu_env_value('MEGASCALE_COORDINATOR_ADDRESS') is not None
 
 class BaseTpuCluster(clusters.ClusterEnv):
+
+  name: str = "tpu"
+
   """Abstract cluster supports both single and multislice TPU environments.
 
   If MEGASCALE_COORDINATOR_ADDRESS is not set, we assume single slice topology.
@@ -169,6 +172,9 @@ class BaseTpuCluster(clusters.ClusterEnv):
     raise NotImplementedError()
 
 class GceTpuCluster(BaseTpuCluster):
+
+  name: str = "gcetpu"
+
   @classmethod
   def is_env_present(cls) -> bool:
     if not running_in_cloud_tpu_vm:
@@ -194,6 +200,9 @@ class GceTpuCluster(BaseTpuCluster):
     return [worker.split(':')[2] for worker in workers]
 
 class GkeTpuCluster(BaseTpuCluster):
+
+  name: str = "gketpu"
+
   @classmethod
   def is_env_present(cls) -> bool:
     if running_in_cloud_tpu_vm and os.environ.get("TPU_WORKER_HOSTNAMES") is not None:

--- a/jax/_src/clusters/cluster.py
+++ b/jax/_src/clusters/cluster.py
@@ -31,10 +31,12 @@ class ClusterEnv:
   """
 
   _cluster_types: list[type[ClusterEnv]] = []
+  opt_in_only_method: bool = False # Override this in derived classes if necessary
 
   def __init_subclass__(cls, **kwargs):
     super().__init_subclass__(**kwargs)
     cls._cluster_types.append(cls)
+
 
   @classmethod
   # pytype: disable=bad-return-type
@@ -43,14 +45,33 @@ class ClusterEnv:
                                            num_processes: int | None,
                                            process_id: int | None,
                                            local_device_ids: Sequence[int] | None,
+                                           cluster_detection_method: str | None,
                                            initialization_timeout: int | None,
                                           ) -> tuple[str | None, int | None, int | None,
                                                      Sequence[int] | None]:
+
     if all(p is not None for p in (coordinator_address, num_processes,
       process_id, local_device_ids)):
       return (coordinator_address, num_processes, process_id,
               local_device_ids)
-    env = next((env for env in cls._cluster_types if env.is_env_present()), None)
+
+    # First, we check the spec detection method because it will ignore submitted values
+    # If if succeeds.
+    if cluster_detection_method is not None:
+      env = next( (env for env in cls._cluster_types if env.name == cluster_detection_method), None )
+      if env is None:
+        logger.error(f"Automatic Distributed initialization can not proceed:"
+                     f" {cluster_detection_method} is not supported.")
+      elif not env.is_env_present():
+        logger.error(f"Automatic Distributed initialization can not proceed:"
+                     f" {cluster_detection_method} is supported but not functional in this environment.")
+    else:
+      env = next((env for env in cls._cluster_types if env.opt_in_only_method == False and env.is_env_present()), None)
+
+    # Above: I have wrapped the env selection in a conditional to go through
+    # opt-in methods first (currently only mpi4py) but to check all possible options
+    # otherwise.  Passing no cluster_detection_method results in the default, original behavior.
+
     if env:
       logger.debug('Initializing distributed JAX environment via %s', env.__name__)
       if coordinator_address is None:

--- a/jax/_src/clusters/mpi4py_cluster.py
+++ b/jax/_src/clusters/mpi4py_cluster.py
@@ -1,0 +1,93 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from jax._src import clusters
+import socket
+
+from importlib.util import find_spec
+
+
+class Mpi4pyCluster(clusters.ClusterEnv):
+
+
+  name: str = "mpi4py"
+  opt_in_only_method: bool = True
+
+  @classmethod
+  def is_env_present(cls) -> bool:
+
+    # Relies on mpi4py:
+    return find_spec("mpi4py") is not None
+
+  @classmethod
+  def get_coordinator_address(cls, timeout_secs: int | None) -> str:
+
+    # Using mpi4py, figure out rank 0 and it's hostname.
+    # Then broadcast the hostname and port.
+
+
+    from mpi4py import MPI #type: ignore
+    # Get the global communicator:
+    COMM_WORLD = MPI.COMM_WORLD
+
+    # On rank 0, get the hostname:
+
+    if COMM_WORLD.Get_rank() == 0:
+        # Order all the hostnames, and find unique ones
+        hostname = socket.gethostname()
+
+        # Apparently, we want to pick a port in an ephemeral range...
+        port_id = hash(hostname) % 2**12 + (65535 - 2**12 + 1)
+
+        hostname = f'{hostname}:{port_id}'
+
+    else:
+        hostname = "None"
+
+
+
+    # Broadcast the host_ip to all ranks:
+    hostname = COMM_WORLD.bcast(hostname, root=0)
+
+
+    return hostname
+
+
+  @classmethod
+  def get_process_count(cls) -> int:
+    from mpi4py import MPI
+    return int(MPI.COMM_WORLD.Get_size())
+
+  @classmethod
+  def get_process_id(cls) -> int:
+    from mpi4py import MPI
+    return int(MPI.COMM_WORLD.Get_rank())
+
+  @classmethod
+  def get_local_process_id(cls) -> int | None:
+
+    # Using mpi4py, split the global communicator into sub communicators
+    # based on hostname.  mpi will assign them ranks and that will allow
+    # a selection of the local process ID.
+    from mpi4py import MPI
+    COMM_WORLD = MPI.COMM_WORLD
+
+    # This is the alternative method that is simpler:
+    new_comm = COMM_WORLD.Split_type(MPI.COMM_TYPE_SHARED)
+
+
+    # The rank in the new communicator - which is host-local only - IS the local rank:
+    return int(new_comm.Get_rank())

--- a/jax/_src/clusters/ompi_cluster.py
+++ b/jax/_src/clusters/ompi_cluster.py
@@ -25,6 +25,9 @@ _PROCESS_ID = 'OMPI_COMM_WORLD_RANK'
 _LOCAL_PROCESS_ID = 'OMPI_COMM_WORLD_LOCAL_RANK'
 
 class OmpiCluster(clusters.ClusterEnv):
+
+  name: str = "ompi"
+
   @classmethod
   def is_env_present(cls) -> bool:
     return _ORTE_URI in os.environ

--- a/jax/_src/clusters/slurm_cluster.py
+++ b/jax/_src/clusters/slurm_cluster.py
@@ -25,6 +25,9 @@ _LOCAL_PROCESS_ID = 'SLURM_LOCALID'
 _NUM_NODES = 'SLURM_STEP_NUM_NODES'
 
 class SlurmCluster(clusters.ClusterEnv):
+
+  name: str = "slurm"
+
   @classmethod
   def is_env_present(cls) -> bool:
     return _JOBID_PARAM in os.environ

--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -33,6 +33,9 @@ from jax._src import util
 from jax.experimental import pjit
 import jax.numpy as jnp
 
+# Used to test for mpi4py installation and skip tests if not installed
+import importlib.util
+
 try:
   import portpicker
 except ImportError:
@@ -200,6 +203,46 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
           '-c',
           ('import jax, os; '
           'jax.distributed.initialize(); '
+          'print(f\'{jax.local_device_count()},{jax.device_count()}\' if jax.process_index() == 0 else \'\', end="")'
+          )
+      ]
+      env = os.environ.copy()
+      # In case the job was launched via Slurm,
+      # prevent OpenMPI from detecting Slurm environment
+      env.pop('SLURM_JOBID', None)
+      proc = subprocess.Popen(args, env=env, stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE, universal_newlines=True)
+      proc = exit_stack.enter_context(proc)
+
+      try:
+        out, _ = proc.communicate()
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(out, f'{num_gpus_per_task},{num_gpus}')
+      finally:
+        proc.kill()
+
+  def test_gpu_mpi4py_distributed_initialize(self):
+    if not jtu.test_device_matches(['gpu']):
+      raise unittest.SkipTest('Tests only for GPU.')
+    if shutil.which('mpirun') is None:
+      raise unittest.SkipTest('Tests only for MPI (mpirun not found).')
+    if importlib.util.find_spec("mpi4py") is None:
+      raise unittest.SkipTest('Test of mpi4py initialize only possible with mpi4py installed.')
+
+    num_gpus = 4
+    num_gpus_per_task = 1
+
+    with contextlib.ExitStack() as exit_stack:
+      args = [
+          'mpirun',
+          '--oversubscribe',
+          '--allow-run-as-root',
+          '-n',
+          str(num_gpus),
+          sys.executable,
+          '-c',
+          ('import jax, os; '
+          'jax.distributed.initialize(spec_detection_method="mpi4py"); '
           'print(f\'{jax.local_device_count()},{jax.device_count()}\' if jax.process_index() == 0 else \'\', end="")'
           )
       ]


### PR DESCRIPTION
This PR is in response to the discussion on #19409.

It does the following:
- First, it adds an additional cluster environment for jax.distributed that is based on autodetection of rank, size, local_rank/devices, and coordination address based on mpi4py.  The motivation here is that for clusters with mpi4py, the parameters needed for `jax.distributed.initialize` can be entirely inferred from `mpi4py` provided the job is launched in a way compatible with `MPI`.
- Because of the constraint above, compatibility with `MPI`, this autodetect method is *exclusively* opt-in.  Users must pass `spec_detection_method="mpi4py"` in a call to `jax.distributed.initialize`.
- Consistent with the behavior of all other initialization methods, options passed to `jax.distributed.initialize` for coordinator_address, etc., will override and auto-detected settings from `mpi4py`.
- Because of the new option in the arguments to `jax.distributed.initialize`, I have updated the documentation accordingly.
- Lastly, related to using `jax.distributed.initialize` on HPC systems, there is sometimes a hang (See #9582).  I have included a warning  if any of the suspect variables are detected, and updated the documentation to point out that the user may want to unset these variables if they are on an HPC cluster.   I suspect the warning will be viewed as to noisy, since I don't know the default log level in JAX off the top of my head.  In this case, perhaps it can only be emitted if the TimeOut occurs, or at the very least maintained in the documentation.

I hope this is helpful, and it would simplify our lives using JAX on supercomputers :).

Corey

