### PR TITLE
Fix typos in `multi_process.md`

### DIFF
--- a/docs/multi_process.md
+++ b/docs/multi_process.md
@@ -28,11 +28,11 @@ Key concepts:
   * Each process has a
     distinct set of *local* devices it can address. The *global* devices are the set
     of all devices across all processes.
-  *  Use standard JAX parallelism APIs like {func}`~jax.pmap` and
-    {func}`~jax.experimental.maps.xmap` . Each process “sees” *local* input and
+  * Use standard JAX parallelism APIs like {func}`~jax.pmap` and
+    {func}`~jax.experimental.maps.xmap`. Each process “sees” *local* input and
     output to parallelized functions, but communication inside the computations
     is *global*.
-  *  Make sure all processes run the same parallel computations in the same
+  * Make sure all processes run the same parallel computations in the same
     order.
 
 ### Launching JAX processes
@@ -106,13 +106,13 @@ only launch computations on the 8 TPU cores attached directly to that host (see
 the
 [Cloud TPU System Architecture](https://cloud.google.com/tpu/docs/system-architecture)
 documentation for more details). You can see a process’s local devices via
-{func}`jax.local_devices()` .
+{func}`jax.local_devices()`.
 
 **The *global* devices are the devices across all processes.** A computation can
 span devices across processes and perform collective operations via the direct
 communication links between devices, as long as each process launches the
 computation on its local devices. You can see all available global devices via
-{func}`jax.devices()` . A process’s local devices are always a subset of the
+{func}`jax.devices()`. A process’s local devices are always a subset of the
 global devices.
 
 ### Running multi-process computations


### PR DESCRIPTION
Remove redundant spaces.