### PR TITLE
[mutable-arrays] support closed-over mutable arrays in jit

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1918,6 +1918,7 @@ class MutableArray:
   dtype = property(lambda self: self._aval.dtype)
   def __getitem__(self, idx): return get_aval(self)._getitem(self, idx)
   def __setitem__(self, idx, x): return get_aval(self)._setitem(self, idx, x)
+  def __repr__(self) -> str: return 'Mutable' + repr(self[...])
 pytype_aval_mappings[MutableArray] = lambda x: x._aval
 
 def mutable_array(init_val):

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1005,11 +1005,9 @@ def convert_constvars_jaxpr(jaxpr: Jaxpr) -> Jaxpr:
 
 @weakref_lru_cache
 def convert_invars_to_constvars(jaxpr: Jaxpr, n: int) -> Jaxpr:
-  """Move n invars to constvars. Like an inverse of convert_constvars_Jaxpr."""
+  """Move n invars to constvars. Like an inverse of convert_constvars_jaxpr."""
   if n == 0:
     return jaxpr.replace()  # 'return jaxpr' would create cache reference cycle
-  if any(isinstance(eff, effects.JaxprInputEffect) for eff in jaxpr.effects):
-    raise NotImplementedError
   config.enable_checks.value and core.check_jaxpr(jaxpr)
   constvars, invars = split_list(jaxpr.invars, [n])
   dbg = jaxpr.debug_info and jaxpr.debug_info._replace(

--- a/jax/experimental/export/_export.py
+++ b/jax/experimental/export/_export.py
@@ -436,8 +436,8 @@ def export(fun_jax: Callable,
       mlir_module = lowering.stablehlo()
 
       args_avals_flat, _ = tree_util.tree_flatten(lowered.in_avals)
-      if "out_mut" in lowering.compile_args:
-        if lowering.compile_args["out_mut"]: raise NotImplementedError
+      if "mut" in lowering.compile_args:
+        if lowering.compile_args["mut"]: raise NotImplementedError
       if "kept_var_idx" in lowering.compile_args:
         module_kept_var_idx = tuple(sorted(lowering.compile_args["kept_var_idx"]))
       else:
@@ -747,7 +747,7 @@ def _check_lowering(lowering) -> None:
   allowed_compile_args = [
       "backend", "mesh", "global_in_avals",
       "global_out_avals", "in_shardings", "out_shardings", "kept_var_idx",
-      "out_mut", "spmd_lowering", "auto_spmd_lowering",
+      "mut", "spmd_lowering", "auto_spmd_lowering",
       "tuple_args", "ordered_effects", "unordered_effects",
       "keepalive", "host_callbacks", "pmap_nreps", "committed",
       "device_assignment", "jaxpr_debug_info", "shape_poly_state",


### PR DESCRIPTION
This PR adds support for jitted functions closing over mutable arrays, like this:

```python
x_mut = mutable_array(jnp.zeros(3))

@jax.jit
def f():
  x_mut[0] += 1

f()  # don't crash!
print(x_mut)  # [1, 0, 0]
```

Previously we only handled mutable arrays that were explicit arguments, like `def f(x_mut): ...`.

Here are the main ingredients:
1. When we lower to an XLA computation, we don't want closed-over MutableArrays to be treated as constants in the XLA computation; instead we want them to correspond to inputs (and outputs, with aliasing) so that the computation can be fed their current value (and return the new value) on each execution. To produce such an XLA computation, starting from a ClosedJaxpr with MutableArrays in its consts, we hoist out those MutableArray consts from the ClosedJaxpr and convert the corresponding jaxpr binders from const-binders to lambda-binders. (We also do some bookkeeping to handle the newly-introduced inputs, e.g. triviallyextending the list of input shardings.)
2. Correspondingly, we pass along those MutableArray objects to the dispatch path, so that their buffers can be fed in on every dispatch. That is, where before this PR we had the dispatch logic take a `list[int | None]` of length equal to the number of outputs identifying which outputs were updates to which inputs, now we have `MutableData = tuple[list[MutableArray], list[int | None]]` which passes along the extra arguments.
3. To handle the nested jit case, we ensure any MutableArrays closed over by inner jits get hoisted into constants in the outer jit by changing the pjit staging rule.

Ultimately we'll want to change the C++ dispatch path to handle the `MutableData` information and perform the same logic that the Python dispatch path is now performing.

That's it! Not so bad.