### PR TITLE
[key reuse] print information about key reuse location

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -34,6 +34,7 @@ from jax._src import dispatch
 from jax._src import dtypes
 from jax._src import pretty_printer as pp
 from jax._src import sharding_specs
+from jax._src import source_info_util
 from jax._src import tree_util as tree_util_internal
 from jax._src import typing
 from jax._src import op_shardings
@@ -154,6 +155,7 @@ class PRNGKeyArray(jax.Array):
   _impl: PRNGImpl
   _base_array: typing.Array
   _consumed: bool | np.ndarray  # Used in jax.experimental.key_reuse.
+  _source_info: None | source_info_util.SourceInfo = None
 
   def __init__(self, impl, key_data: Any):
     assert not isinstance(key_data, core.Tracer)


### PR DESCRIPTION
Example; when running this file:
```python
# test.py
import jax

jax.config.update('jax_enable_key_reuse_checks', True)

def f(seed):
    key = jax.random.key(seed)
    x = jax.random.uniform(key)
    y = 2 * x
    y += jax.random.normal(key)
    return 2 * y

print(f(42))
```
We now get this error message:
```pytb
Traceback (most recent call last):
  File "/Users/vanderplas/github/google/jax/test.py", line 12, in <module>
    print(f(42))
  File "/Users/vanderplas/github/google/jax/test.py", line 7, in f
    x = jax.random.uniform(key)
  File "/Users/vanderplas/github/google/jax/jax/_src/random.py", line 398, in uniform
    return _uniform(key, shape, dtype, minval, maxval)  # type: ignore
jax.errors.KeyReuseError: PRNG key first used at the above location was subsequently reused at the following location:
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.KeyReuseError

The above exception was the direct cause of the following exception:

jax.errors.SimplifiedTraceback: For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/vanderplas/github/google/jax/test.py", line 12, in <module>
    print(f(42))
  File "/Users/vanderplas/github/google/jax/test.py", line 9, in f
    y += jax.random.normal(key)
  File "/Users/vanderplas/github/google/jax/jax/_src/random.py", line 711, in normal
    return _normal(key, shape, dtype)  # type: ignore
jax.errors.KeyReuseError: Previously-consumed key passed to jit-compiled function at index 0
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.KeyReuseError
```