### PR TITLE
Fix `axis=None, keepdims=True` for `jnp.quantile` and `jnp.median`

### DIFF
--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -751,6 +751,8 @@ def _quantile(a: Array, q: Array, axis: int | tuple[int, ...] | None,
   if dtypes.issubdtype(a.dtype, np.complexfloating):
     raise ValueError("quantile does not support complex input, as the operation is poorly defined.")
   if axis is None:
+    if keepdims:
+      keepdim = [1] * a.ndim
     a = a.ravel()
     axis = 0
   elif isinstance(axis, tuple):

--- a/tests/lax_numpy_reducers_test.py
+++ b/tests/lax_numpy_reducers_test.py
@@ -662,6 +662,7 @@ class JaxNumpyReducerTests(jtu.JaxTestCase):
     [dict(a_shape=a_shape, axis=axis)
       for a_shape, axis in (
         ((7,), None),
+        ((6, 7,), None),
         ((47, 7), 0),
         ((47, 7), ()),
         ((4, 101), 1),
@@ -716,6 +717,7 @@ class JaxNumpyReducerTests(jtu.JaxTestCase):
     [dict(a_shape=a_shape, axis=axis)
       for a_shape, axis in (
         ((7,), None),
+        ((6, 7,), None),
         ((47, 7), 0),
         ((4, 101), 1),
       )


### PR DESCRIPTION
This PR fixes the incorrect behavior:

```bash
>>> x = np.ones([2, 3, 4])
>>> np.median(x, axis=None, keepdims=True).shape
(1, 1, 1)
>>> jnp.median(x, axis=None, keepdims=True).shape
(1,)  # mismatched!
>>> np.quantile(x, 0.5, axis=None, keepdims=True).shape
(1, 1, 1)
>>> jnp.quantile(x, 0.5, axis=None, keepdims=True).shape
(1,)  # mismatched!
```

The corresponding tests have been included