### PR TITLE
[JAX cuDNN SDPA API] Add is_training and fix seqlen/head_dim checks

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1437,7 +1437,10 @@ jax_test(
         "tpu",
         "cpu",
     ],
-    shard_count = 4,
+    shard_count = {
+        "gpu": 4,
+    },
+    tags = ["multiaccelerator"],
     deps = [
         "//jax:fused_attention_stablehlo",
     ],

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -26,6 +26,7 @@ from jax.sharding import PartitionSpec, NamedSharding
 from jax._src import config
 from jax._src import test_util as jtu
 from jax._src.cudnn.fused_attention_stablehlo import dot_product_attention, check_is_flash_attention
+import unittest
 
 config.parse_flags_with_absl()
 Array = jnp.ndarray
@@ -202,6 +203,7 @@ class DotProductAttentionTest(jtu.JaxTestCase):
       self.assertArraysAllClose(key_grad_ref, key_grad, rtol=1e-5, atol=1e-5)
       self.assertArraysAllClose(value_grad_ref, value_grad, rtol=1e-5, atol=1e-5)
 
+  @unittest.skipIf(len(jax.local_devices()) < 4, '4 gpus required')
   @jtu.run_on_devices("cuda")
   def test_sdpa_inference(self):
     k1, k2, k3 = jax.random.split(jax.random.key(0), 3)

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -16,7 +16,7 @@ from functools import partial
 from absl.testing import absltest
 from typing import Optional
 import os
-os.environ['XLA_FLAGS'] = '--xla_gpu_enable_cudnn_fmha=true --xla_gpu_fused_attention_use_cudnn_rng=true --xla_dump_hlo_as_text --xla_dump_to=./hlo'
+os.environ['XLA_FLAGS'] = '--xla_gpu_enable_cudnn_fmha=true --xla_gpu_fused_attention_use_cudnn_rng=true'
 
 import numpy as np
 import jax

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -16,7 +16,7 @@ from functools import partial
 from absl.testing import absltest
 from typing import Optional
 import os
-os.environ['XLA_FLAGS'] = '--xla_gpu_enable_cudnn_fmha=true --xla_gpu_fused_attention_use_cudnn_rng=true'
+os.environ['XLA_FLAGS'] = '--xla_gpu_enable_cudnn_fmha=true --xla_gpu_fused_attention_use_cudnn_rng=true --xla_dump_hlo_as_text --xla_dump_to=./hlo'
 
 import numpy as np
 import jax
@@ -25,7 +25,7 @@ from jax.sharding import Mesh
 from jax.sharding import PartitionSpec, NamedSharding
 from jax._src import config
 from jax._src import test_util as jtu
-from jax._src.cudnn.fused_attention_stablehlo import dot_product_attention
+from jax._src.cudnn.fused_attention_stablehlo import dot_product_attention, check_is_flash_attention
 
 config.parse_flags_with_absl()
 Array = jnp.ndarray
@@ -43,7 +43,7 @@ def sdpa_train(query: Array,
     # convert bool mask to dtype mask
     mask = mask.astype(query.dtype)
   out, sdpa_vjp = jax.vjp(
-    partial(dot_product_attention, scale=scale, is_causal_mask=is_causal_mask, dropout_rate=dropout_rate),
+    partial(dot_product_attention, scale=scale, is_causal_mask=is_causal_mask, dropout_rate=dropout_rate, is_training=True),
     query, key, value, bias, mask)
   query_grad, key_grad, value_grad, _, _ = sdpa_vjp(grad)
   return out, (query_grad, key_grad, value_grad)
@@ -201,6 +201,58 @@ class DotProductAttentionTest(jtu.JaxTestCase):
         self.assertArraysAllClose(query_grad_ref, query_grad, rtol=1e-5, atol=1e-5)
       self.assertArraysAllClose(key_grad_ref, key_grad, rtol=1e-5, atol=1e-5)
       self.assertArraysAllClose(value_grad_ref, value_grad, rtol=1e-5, atol=1e-5)
+  
+  @jtu.run_on_devices("cuda")
+  def test_sdpa_inference(self):
+    k1, k2, k3 = jax.random.split(jax.random.key(0), 3)
+    query = jax.random.normal(
+        k1, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    key = jax.random.normal(
+        k2, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    value = jax.random.normal(
+        k3, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+
+    devices = np.array(jax.local_devices()[:4])
+    devices = devices.reshape((2, 2))
+    with Mesh(devices, ('dp', 'tp')) as mesh:
+      qkv_spec = PartitionSpec('dp', None, 'tp', None)
+      qkv_sharding = NamedSharding(mesh, qkv_spec)
+      replicated = NamedSharding(mesh, PartitionSpec())
+      in_shardings = (qkv_sharding, qkv_sharding, qkv_sharding, replicated, replicated)
+      out_shardings = replicated
+      query = jax.device_put(query, qkv_sharding)
+      key = jax.device_put(key, qkv_sharding)
+      value = jax.device_put(value, qkv_sharding)
+      jitted_sdpa_inference = jax.jit(
+        partial(dot_product_attention, scale=1.0, is_causal_mask=False, dropout_rate=0),
+        in_shardings=in_shardings,
+        out_shardings=out_shardings
+      )
+
+      jitted_sdpa_inference_ref = jax.jit(
+        partial(sdpa_ref, scale=1.0, is_causal_mask=False, dropout_rate=0),
+        in_shardings=in_shardings,
+        out_shardings=out_shardings
+      )
+
+      out = jitted_sdpa_inference(query, key, value, None, None)
+      out_ref = jitted_sdpa_inference_ref(query, key, value, None, None)
+      self.assertArraysAllClose(out_ref, out, rtol=1e-5, atol=1e-5)
+
+  def test_sdpa_utils(self):
+    test_cases = {
+      (256, 512, 64, 8905, False, False): False,
+      (1, 257, 64, 8905, False, True): True,
+      (1, 1024, 64, 8905, False, False): True,
+      (1024, 1024, 64, 8905, False, False): True,
+      (1024, 1024, 128, 8905, False, False): True,
+    }
+
+    for k, v in test_cases.items():
+      sql_q, sql_v, head_dim, cudnn_version, has_bias, is_training = k
+      query = jnp.empty((4, sql_q, 4, head_dim))
+      key = jnp.empty((4, sql_v, 4, head_dim))
+      self.assertEqual(check_is_flash_attention(query, key, cudnn_version, has_bias, is_training), v)
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -201,7 +201,7 @@ class DotProductAttentionTest(jtu.JaxTestCase):
         self.assertArraysAllClose(query_grad_ref, query_grad, rtol=1e-5, atol=1e-5)
       self.assertArraysAllClose(key_grad_ref, key_grad, rtol=1e-5, atol=1e-5)
       self.assertArraysAllClose(value_grad_ref, value_grad, rtol=1e-5, atol=1e-5)
-  
+
   @jtu.run_on_devices("cuda")
   def test_sdpa_inference(self):
     k1, k2, k3 = jax.random.split(jax.random.key(0), 3)


### PR DESCRIPTION
* add `is_training` to API to distinguish between inference and training fwd so cuDNN does not export activation.
* fix incorrect checks for seqlen/head_dim
  * seqlen_k = 256 and seqlen_v = 1024 is incorrectly dispatched to fused attn and it is not supported by fused attn
  * missing checks for seqlen % 64  == 0 for fused attn training
  * missing checks for seqlen % 2 == 0 for flash attn training with bias
  * incorrect head_dim checks for flash attn