### PR TITLE
Adjust the indices in _pjit_partial_eval to account for removed primals.

### DIFF
--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -661,6 +661,15 @@ class PJitTest(jtu.BufferDonationTestCase):
     )
     jtu.check_grads(g, (jnp.arange(16.).reshape((4, 4)) / 100,), order=2)
 
+  def testAutodiffPrimals(self):
+    # Test for issue #20267.
+    def f(x):
+        @jax.jit
+        def inner(a, x):
+            return a, jnp.exp(x)
+        return inner(0., x)[0]
+    jax.grad(f)(1.)
+
   @jtu.with_mesh([('x', 2), ('y', 1)])
   def testAutodiffCache(self):
     f = pjit(


### PR DESCRIPTION
`idx_map` indexes the residuals that are also primals (ie. duplicated in the output of known_jaxpr), which are then deduplicated. But non-residual primal outputs of known_jaxpr can also be removed on account of being forwarded inputs, which alters the previously calculated primal indices. We need to adjust them to account for this.

Fixes #20267.