### PR TITLE
re-enable pjit forwarding optimization, add tests

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -76,7 +76,7 @@ from jax._src.tree_util import (
 from jax._src.util import (
     HashableFunction, safe_map, safe_zip, wraps,
     distributed_debug_log, split_list, weakref_lru_cache,
-    merge_lists, flatten, unflatten)
+    merge_lists, flatten, unflatten, subs_list)
 
 map, unsafe_map = safe_map, map
 zip, unsafe_zip = safe_zip, zip
@@ -1810,35 +1810,33 @@ def _pjit_partial_eval(trace, *in_tracers,
 
   known_out_shardings = keep_where(out_shardings, known_outs) + res_shardings
 
-  # TODO(mattjj): un-disable this optimization after we have more tests
-  # # Input-to-output forwarding: compute which outputs are just forwarded inputs.
-  # num_out_primals = len(known_jaxpr.out_avals) - num_residuals
-  # in_fwd: list[int | None] = pe._jaxpr_forwarding(known_jaxpr.jaxpr)
-  # # Only forward primal outputs when corresponding out_sharding is UNSPECIFIED.
-  # in_fwd_primal, in_fwd_res = split_list(in_fwd, [num_out_primals])
-  # in_fwd = [fwd if is_unspecified(os) else None for os, fwd in
-  #           zip(keep_where(out_shardings, known_outs), in_fwd_primal)
-  #           ] + in_fwd_res
-  # del in_fwd_primal, in_fwd_res
-  # # Prune jaxpr outputs and out_shardings by removing the input-forwards.
-  # keep = [f is None for f in in_fwd]
-  # known_jaxpr = pe.prune_closed_jaxpr_outputs(known_jaxpr, keep)
-  # known_out_shardings = keep_where(known_out_shardings, keep)
-  # # Update num_out_primals to reflect pruning.
-  # kept_primals, kept_res = split_list(keep, [num_out_primals])
-  # num_out_primals = sum(f is None for f in kept_primals)
-  # del keep, kept_primals, kept_res
+  # Input-to-output forwarding: compute which outputs are just forwarded inputs.
+  num_out_primals = len(known_jaxpr.out_avals) - num_residuals
+  in_fwd: list[int | None] = pe._jaxpr_forwarding(known_jaxpr.jaxpr)
+  # Only forward primal outputs when corresponding out_sharding is UNSPECIFIED.
+  in_fwd_primal, in_fwd_res = split_list(in_fwd, [num_out_primals])
+  in_fwd = [fwd if is_unspecified(os) else None for os, fwd in
+            zip(keep_where(out_shardings, known_outs), in_fwd_primal)
+            ] + in_fwd_res
+  del in_fwd_primal, in_fwd_res
+  # Prune jaxpr outputs and out_shardings by removing the input-forwards.
+  keep = [f is None for f in in_fwd]
+  known_jaxpr = pe.prune_closed_jaxpr_outputs(known_jaxpr, keep)
+  known_out_shardings = keep_where(known_out_shardings, keep)
+  # Update num_out_primals to reflect pruning.
+  kept_primals, kept_res = split_list(keep, [num_out_primals])
+  num_out_primals = sum(kept_primals)
+  del keep, kept_primals, kept_res
 
-  # TODO(mattjj): un-disable this optimization after we have more tests
-  # # Output-to-output forwarding: compute which residuals are just primal outputs
-  # out_vars, res_vars = split_list(known_jaxpr.jaxpr.outvars, [num_out_primals])
-  # idx_map = {id(v): i for i, v in enumerate(out_vars)}
-  # out_fwd = [None] * num_out_primals + [idx_map.get(id(v)) for v in res_vars]
-  # # Prune jaxpr outputs and out_shardings by removing forwarded residuals.
-  # keep = [f is None for f in out_fwd]
-  # known_jaxpr = pe.prune_closed_jaxpr_outputs(known_jaxpr, keep)
-  # known_out_shardings = keep_where(known_out_shardings, keep)
-  # del keep
+  # Output-to-output forwarding: compute which residuals are just primal outputs
+  out_vars, res_vars = split_list(known_jaxpr.jaxpr.outvars, [num_out_primals])
+  idx_map = {id(v): i for i, v in enumerate(out_vars)}
+  out_fwd = [None] * num_out_primals + [idx_map.get(id(v)) for v in res_vars]
+  # Prune jaxpr outputs and out_shardings by removing forwarded residuals.
+  keep = [f is None for f in out_fwd]
+  known_jaxpr = pe.prune_closed_jaxpr_outputs(known_jaxpr, keep)
+  known_out_shardings = keep_where(known_out_shardings, keep)
+  del keep
 
   known_params = dict(
       jaxpr=known_jaxpr, in_shardings=keep_where(in_shardings, known_ins),
@@ -1850,11 +1848,10 @@ def _pjit_partial_eval(trace, *in_tracers,
   # Bind known things to pjit_p.
   known_inputs = [pv.get_known() for pv in in_pvals if pv.is_known()]
   all_known_outs = pjit_p.bind(*known_inputs, **known_params)
-  # TODO(mattjj): un-disable this optimization after we have more tests
-  # # Add back in the output fwds.
-  # all_known_outs = subs_list(out_fwd, all_known_outs, all_known_outs)
-  # # Add back in the input fwds.
-  # all_known_outs = subs_list(in_fwd, known_inputs, all_known_outs)
+  # Add back in the output fwds.
+  all_known_outs = subs_list(out_fwd, all_known_outs, all_known_outs)
+  # Add back in the input fwds.
+  all_known_outs = subs_list(in_fwd, known_inputs, all_known_outs)
 
   known_out_vals, residual_vals = \
       split_list(all_known_outs, [len(all_known_outs) - num_residuals])

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -368,8 +368,6 @@ class CoreTest(jtu.JaxTestCase):
     dropvar, b = jaxpr.eqns[0].outvars
     self.assertEqual(dropvar.aval, aval)
 
-  # TODO(mattjj): un-skip
-  @unittest.skip('temporarily skipping until we can add more tests')
   def test_input_residual_forwarding(self):
     # https://github.com/google/jax/pull/11151
     x = jnp.arange(3 * 4.).reshape(3, 4)


### PR DESCRIPTION
Basically comment-in the fixed forwarding code in #20273, and now add tests.

Here are the tests we generate:
```
out_fwd [None, None, None, None, None, None]
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, None, 1, None]
.in_fwd [None, 2, 1, None]
out_fwd [None, 0]
.in_fwd [None, 2, 1, None]
out_fwd [None, 0]
.in_fwd [0, 2, 1]
out_fwd []
.in_fwd [0, 2, 1]
out_fwd []
.in_fwd [0, 2, 1]
out_fwd []
.in_fwd [0, 2, 1]
out_fwd []
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, None, None, None]
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, None, None, 2]
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, 0, None, 2]
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, 0, 1, 2]
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, None, 1, 2]
.in_fwd [None, None, 0, None, None]
out_fwd [None, None, None, None]
.in_fwd [None, None, 0, None, None]
out_fwd [None, None, 0, None]
.in_fwd [None, None, 0, None, None]
out_fwd [None, None, 0, 1]
.in_fwd [None, None, 0, None, None]
out_fwd [None, None, 0, 1]
.in_fwd [2, None, 0, None]
out_fwd [None, None]
.in_fwd [2, None, 0, None]
out_fwd [None, 0]
.in_fwd [2, None, 0, None]
out_fwd [None, 0]
.in_fwd [2, None, 0, None]
out_fwd [None, 0]
.in_fwd [2, 1, 0]
out_fwd []
.in_fwd [2, 1, 0]
out_fwd []
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, 0, 1, 2]
.in_fwd [2, 1, 0]
out_fwd []
.in_fwd [2, 1, 0]
out_fwd []
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, None, None, None]
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, None, 1, None]
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, None, 1, 2]
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, 0, 1, 2]
.in_fwd [None, 2, None, None, None]
out_fwd [None, None, None, None]
.in_fwd [None, 2, None, None, None]
out_fwd [None, None, None, 1]
.in_fwd [None, 2, None, None, None]
out_fwd [None, None, 0, 1]
.in_fwd [None, 2, None, None, None]
out_fwd [None, None, 0, 1]
.in_fwd [None, 2, None, None, None]
out_fwd [None, None, None, None]
.in_fwd [None, 2, 1, None]
out_fwd [None, None]
.in_fwd [None, 2, 1, None]
out_fwd [None, 0]
.in_fwd [None, 2, 1, None]
out_fwd [None, 0]
.in_fwd [None, 2, 1, None]
out_fwd [None, 0]
.in_fwd [0, 2, 1]
out_fwd []
.in_fwd [0, 2, 1]
out_fwd []
.in_fwd [0, 2, 1]
out_fwd []
.in_fwd [0, 2, 1]
out_fwd []
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, None, None, None]
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, 0, None, None]
.in_fwd [None, 2, None, None, None]
out_fwd [None, None, None, 1]
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, 0, None, 2]
.in_fwd [None, None, None, None, None, None]
out_fwd [None, None, None, 0, 1, 2]
.in_fwd [1, None, None, None, None]
out_fwd [None, None, None, None]
.in_fwd [1, None, None, None, None]
out_fwd [None, None, None, 1]
.in_fwd [1, None, None, None, None]
out_fwd [None, None, 0, 1]
.in_fwd [1, None, None, None, None]
out_fwd [None, None, 0, 1]
.in_fwd [1, None, 0, None]
out_fwd [None, None]
.in_fwd [1, None, 0, None]
out_fwd [None, 0]
.in_fwd [1, None, 0, None]
out_fwd [None, 0]
.in_fwd [1, None, 0, None]
out_fwd [None, 0]
.in_fwd [None, 2, None, None, None]
out_fwd [None, None, 0, 1]
.in_fwd [1, 2, 0]
out_fwd []
.in_fwd [1, 2, 0]
out_fwd []
.in_fwd [1, 2, 0]
out_fwd []
.in_fwd [1, 2, 0]
out_fwd []
.in_fwd [None, 2, None, None, None]
out_fwd [None, None, 0, 1]
.in_fwd [None, 2, 1, None]
out_fwd [None, None]
.in_fwd [None, 2, 1, None]
out_fwd [None, 0]
```

I verified that these tests would've caught #20267.