### PR TITLE
Add Hilbert matrix to jax.scipy.linalg

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -43,6 +43,7 @@ jax.scipy.linalg
    expm_frechet
    funm
    hessenberg
+   hilbert
    inv
    lu
    lu_factor

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -1038,28 +1038,6 @@ def toeplitz(c: ArrayLike, r: ArrayLike | None = None) -> Array:
 
 @implements(scipy.linalg.hilbert)
 @partial(jit, static_argnames=("n",))
-def hilbert(n: int):
-  """
-  Creates a Hilbert matrix of order n.
-    
-  Returns the n by n array with entries h[i,j] = 1 / (i + j + 1).
-    
-    Parameters:
-            n: int
-               Size of the array.
-
-    Returns:
-            h(n, n): ndarray
-                     The Hilbert matrix.
-    
-  Examples:
-  >>> from jax.scipy.linalg import hilbert
-  >>> hilbert(4)
-  Array([[1.        , 0.5       , 0.33333334, 0.25      ],
-     [0.5       , 0.33333334, 0.25      , 0.2       ],
-     [0.33333334, 0.25      , 0.2       , 0.16666667],
-     [0.25      , 0.2       , 0.16666667, 0.14285715]], dtype=float32)
-  """
-  a = jnp.arange(n)
-  return 1 / (jnp.expand_dims(a, axis=0) + jnp.expand_dims(a, axis=1) + 1)
-  
+def hilbert(n: int) -> Array:
+  a = lax.broadcasted_iota(jnp.float64, (n, 1), 0)
+  return 1/(a + a.T + 1)

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -1035,3 +1035,31 @@ def toeplitz(c: ArrayLike, r: ArrayLike | None = None) -> Array:
       (nrows,), (1,), 'VALID', dimension_numbers=('NTC', 'IOT', 'NTC'),
       precision=lax.Precision.HIGHEST)[0]
   return jnp.flip(patches, axis=0)
+
+@implements(scipy.linalg.hilbert)
+@partial(jit, static_argnames=("n",))
+def hilbert(n: int):
+  """
+  Creates a Hilbert matrix of order n.
+    
+  Returns the n by n array with entries h[i,j] = 1 / (i + j + 1).
+    
+    Parameters:
+            n: int
+               Size of the array.
+
+    Returns:
+            h(n, n): ndarray
+                     The Hilbert matrix.
+    
+  Examples:
+  >>> from jax.scipy.linalg import hilbert
+  >>> hilbert(4)
+  Array([[1.        , 0.5       , 0.33333334, 0.25      ],
+     [0.5       , 0.33333334, 0.25      , 0.2       ],
+     [0.33333334, 0.25      , 0.2       , 0.16666667],
+     [0.25      , 0.2       , 0.16666667, 0.14285715]], dtype=float32)
+  """
+  a = jnp.arange(n)
+  return 1 / (jnp.expand_dims(a, axis=0) + jnp.expand_dims(a, axis=1) + 1)
+  

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -26,6 +26,7 @@ from jax._src.scipy.linalg import (
   expm as expm,
   expm_frechet as expm_frechet,
   hessenberg as hessenberg,
+  hilbert as hilbert,
   inv as inv,
   lu as lu,
   lu_factor as lu_factor,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2089,8 +2089,11 @@ class LaxLinalgTest(jtu.JaxTestCase):
     n=[0, 1, 5, 10, 20],
     )
   def testHilbert(self, n):
-    args_maker = lambda: [n]
-    self._CheckAgainstNumpy(osp.linalg.hilbert, jsp.linalg.hilbert, args_maker)
+    args_maker = lambda: []
+    osp_fun = partial(osp.linalg.hilbert, n=n)
+    jsp_fun = partial(jsp.linalg.hilbert, n=n)
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker)
+    self._CompileAndCheck(jsp_fun, args_maker)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2085,6 +2085,12 @@ class LaxLinalgTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
+  @jtu.sample_product(
+    n=[0, 1, 5, 10, 20],
+    )
+  def testHilbert(self, n):
+    args_maker = lambda: [n]
+    self._CheckAgainstNumpy(osp.linalg.hilbert, jsp.linalg.hilbert, args_maker)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2089,11 +2089,8 @@ class LaxLinalgTest(jtu.JaxTestCase):
     n=[0, 1, 5, 10, 20],
     )
   def testHilbert(self, n):
-    args_maker = lambda: []
-    osp_fun = partial(osp.linalg.hilbert, n=n)
-    jsp_fun = partial(jsp.linalg.hilbert, n=n)
-    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker)
-    self._CompileAndCheck(jsp_fun, args_maker)
+    args_maker = lambda: [n]
+    self._CheckAgainstNumpy(osp.linalg.hilbert, jsp.linalg.hilbert, args_maker)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This PR implements the hilbert function which returns a Hilbert matrix of order `n`.