### PR TITLE
Formatting fix in docstring for lax.full

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1233,8 +1233,8 @@ def full(shape: Shape, fill_value: ArrayLike, dtype: DTypeLike | None = None, *,
     dtype: the type of the output array, or `None`. If not `None`, `fill_value`
       will be cast to `dtype`.
     sharding: an optional sharding specification for the resulting array,
-    note, sharding will currently be ignored in jitted mode, this might change
-    in the future.
+      note, sharding will currently be ignored in jitted mode, this might change
+      in the future.
   """
   shape = canonicalize_shape(shape)
   if np.shape(fill_value):


### PR DESCRIPTION
Without this indent, the documentation displays the note about sharding as if it is instead additional args. e.g. see 
https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.full.html 
where "note", "mode", "change", and "future." are listed as additional keyword args.