### PR TITLE
[scan] don't traverse body jaxpr in lowering

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2383,6 +2383,8 @@ class ClosedCallPrimitive(CallPrimitive):
 
 closed_call_p: ClosedCallPrimitive = ClosedCallPrimitive('closed_call')
 closed_call_p.def_impl(call_impl)
+closed_call_p.def_effectful_abstract_eval(
+    lambda *_, call_jaxpr: (call_jaxpr.out_avals, call_jaxpr.effects))
 
 
 outfeed_primitives: set[Primitive] = set()
@@ -2826,7 +2828,7 @@ custom_typechecks: dict[Primitive, Callable] = {}
 
 def _check_closed_call(_, *in_atoms, call_jaxpr):
   in_avals = [x.aval for x in in_atoms]
-  if list(in_avals) != list(call_jaxpr.in_avals):
+  if not all(map(typecompat, call_jaxpr.in_avals, in_avals)):
     raise JaxprTypeError("Closed call in_avals mismatch")
   return call_jaxpr.out_avals, call_jaxpr.effects
 custom_typechecks[closed_call_p] = _check_closed_call

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -1426,7 +1426,10 @@ def lower_jaxpr_to_fun(
         args.append([hlo.create_token()])
       else:
         args.append(arg)
-    callee_name_stack = name_stack.extend(util.wrap_name(name, api_name))
+    if name is not None:
+      callee_name_stack = name_stack.extend(util.wrap_name(name, api_name))
+    else:
+      callee_name_stack = name_stack
     consts = [ir_constants(xla.canonicalize_dtype(x)) for x in jaxpr.consts]
     out_vals, tokens_out = jaxpr_subcomp(
         ctx, jaxpr.jaxpr, callee_name_stack, tokens_in,
@@ -1883,7 +1886,7 @@ def core_call_lowering(ctx: LoweringRuleContext,
 
 register_lowering(core.call_p, partial(core_call_lowering, name="core_call"))
 register_lowering(core.closed_call_p,
-                  partial(core_call_lowering, name="core_closed_call"))
+                  partial(core_call_lowering, name=None))
 
 def broadcast_in_dim(ctx: LoweringRuleContext, op, aval_out: core.AbstractValue, *,
                      broadcast_dimensions) -> ir.Value:

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1465,10 +1465,12 @@ class TensorFlowTrace(core.Trace):
 def _unexpected_primitive(p: core.Primitive, *args, **kwargs):
   assert False, f"Encountered unexpected primitive {p}"
 
-
-# Call primitives are inlined
 for unexpected in [core.call_p, maps.xmap_p]:
   tf_impl[unexpected] = partial(_unexpected_primitive, unexpected)
+
+tf_impl[lax_control_flow.loops.eval_jaxpr_p] = \
+    lambda *args, jaxpr: _interpret_jaxpr(
+        jaxpr, *args, fresh_constant_cache=False, extra_name_stack=None)
 
 # Primitives that are not yet implemented must be explicitly declared here.
 tf_not_yet_impl = [


### PR DESCRIPTION
This is an attempt to re-land #19819 aka cl/607570860 after a small number of performance regressions caused the original to be rolled back.

As before, the main changes are:
 1. simplify the scan impl that we trace through to get the lowering, and
 2. ensure that when tracing it to a jaxpr, we don't rebuild the scan body jaxpr we already have in hand.

The main motivation was (2), but (1) seems like a useful win too.

The way we achieve (2) is with a new trick: in our scan_impl function, which is only ever traced to a jaxpr, instead of calling `core.jaxpr_as_fun(jaxpr)(*args)` we call a new primitive `eval_jaxpr_p.bind(*args, jaxpr=jaxpr)`. This new primitive only has a staging rule defined for it (i.e. all we can do with it is stage it into a jaxpr), and that rule just generates a call into the jaxpr of interest. Therefore we will not traverse into the jaxpr just to rebuild it inline (as before).

The code in #19819 was simpler in that it avoided reshapes, concats, and un-concats. But it caused at least one apparent performance regression (an XLA bug?) and it was unrelated to the original goal of reducing tracing time. So here we just land the trace time improvement, leaving in the reshapes and stuff.