### PR TITLE
if fori_loop statically takes zero trips, don't run body

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1985,8 +1985,7 @@ def fori_loop(lower, upper, body_fun, init_val,
     if unroll is None:
       unroll = False
     length = max(upper_ - lower_, 0)
-    if config.disable_jit.value and length == 0:
-      # non-jit implementation of scan does not support length=0
+    if length == 0:
       return init_val
 
     (_, result), _ = scan(

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -693,6 +693,14 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     with jax.disable_jit():
       self.assertRaises(ValueError, should_raise_wo_jit)
 
+  def testForiEmpty(self):
+    # https://github.com/google/jax/issues/20399
+    def foo(j, carry):
+      return carry.at[j].set(j)
+
+    myarray = jnp.array([])
+    _ = jax.lax.fori_loop(0, 0, foo, myarray)  # doesn't crash
+
   def testCond(self):
     def fun(x):
       if x < 3:


### PR DESCRIPTION
fixes #20399

(I checked #8152 and #8160, and there was no reason to only have this body-skipping behavior when disable_jit=True.)