### PR TITLE
Change vmap argument from axis to in_axes for Inadvertent transposing of key buffers in 9263-typed-keys.md

### DIFF
--- a/docs/jep/9263-typed-keys.md
+++ b/docs/jep/9263-typed-keys.md
@@ -237,15 +237,15 @@ time boils down to this:
 :class: red-background
 # Incorrect
 keys = random.split(random.PRNGKey(0))
-data = jax.vmap(random.uniform, axis=1)(keys)
+data = jax.vmap(random.uniform, in_axes=1)(keys)
 ```
 ```{code-block} python
 :class: green-background
 # Correct
 keys = random.split(random.PRNGKey(0))
-data = jax.vmap(random.uniform, axis=0)(keys)
+data = jax.vmap(random.uniform, in_axes=0)(keys)
 ```
-The bug here is subtle. By mapping over `axis=1`, this code makes new keys by
+The bug here is subtle. By mapping over `in_axes=1`, this code makes new keys by
 combining a single element from each key buffer in the batch. The resulting
 keys are different from one another, but are effectively "derived" in a
 non-standard way. Again, the PRNG is not designed or tested to produce


### PR DESCRIPTION
The examples mentioned in `Inadvertent transposing of key buffers` takes `axis` as argument to `vmap`. It gives TypeError: `vmap() got an unexpected keyword argument 'axis'` when executed. 
```python
import jax
from jax import random
# Incorrect
keys = random.split(random.PRNGKey(0))
data = jax.vmap(random.uniform, axis=0)(keys)
```
Output:
```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
[<ipython-input-23-1ecf2be8dc5e>](https://localhost:8080/#) in <cell line: 5>()
      3 # Incorrect
      4 keys = random.split(random.PRNGKey(0))
----> 5 data = jax.vmap(random.uniform, axis=0)(keys)

TypeError: vmap() got an unexpected keyword argument 'axis'
```

This PR modifies the argument of `vmap` to `in_axes` to get the expected output.