### PR TITLE
removing enhanced barrier from cloud init file because it is getting on by default elsewhere

### DIFF
--- a/jax/_src/cloud_tpu_init.py
+++ b/jax/_src/cloud_tpu_init.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-from jax._src import hardware_utils
 
 running_in_cloud_tpu_vm: bool = False
 
@@ -66,5 +65,3 @@ def cloud_tpu_init() -> None:
   os.environ.setdefault('GRPC_VERBOSITY', 'ERROR')
   os.environ.setdefault('JAX_PLATFORMS', 'tpu,cpu')
   os.environ['TPU_ML_PLATFORM'] = 'JAX'
-  if hardware_utils.tpu_enhanced_barrier_supported():
-    os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS","") + " --xla_tpu_use_enhanced_launch_barrier=true"


### PR DESCRIPTION
Enhanced barrier is getting on by default in another PR. This line is unnecessary and will rewrite the flag, even if the user is purposefully making it off.