### PR TITLE
[callback] Improve caching effectiveness in presence of callbacks.

### DIFF
--- a/tests/python_callback_test.py
+++ b/tests/python_callback_test.py
@@ -586,6 +586,20 @@ class PythonCallbackTest(jtu.JaxTestCase):
       self.assertIn(f"jax.{api_name} failed", output)
       self.assertIn("Traceback (most recent call last)", output)
 
+  @with_pure_and_io_callbacks
+  def test_compilation_caching(self, *, callback):
+    def f_outside(x):
+      return 2 * x
+
+    def fun(x):
+      return callback(f_outside, x, x)
+
+    x = np.arange(6, dtype=np.int32).reshape((2, 3))
+    with jtu.count_primitive_compiles() as count:
+      for _ in range(3):
+        self.assertAllClose(2 * x, fun(x))
+    self.assertEqual(count[0], 1)
+
 
 class PureCallbackTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Previously, the user-provided Python callback function was first flattened and then the result passed as a primitive parameter to the callback primitives. This means that two separate io_callback invocations with the same Python callable will generate different Jaxprs. To prevent this we defer the flattening to lowering time.

I discovered this problem by trying to ensure that io_callback passes the host_callback_test.py.