### PR TITLE
Making JAX API Reference easier to find on documentation sidebar

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,10 +79,10 @@ For an end-to-end transformer library built on JAX, see MaxText_.
 
    user_guides
    advanced_guide
+   jax
    contributor_guide
    building_on_jax
    notes
-   jax
 
 
 .. toctree::

--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: jax
 
-Public API: jax package
-=======================
+API Reference
+=============
 
 Subpackages
 -----------


### PR DESCRIPTION
Following #20535 (closes #20535), this PR makes the JAX "API Reference" page easier to find on documentation sidebar by making the following two changes:

1. Rename "Public API: jax package" to "API Reference" (same as Pandas, NumPy, SciPy, etc)
2. Move "API Reference" before "Developer Documentation"

| Before modification | After modification |
| :- | :- |
| ![](https://github.com/google/jax/assets/68557794/78acd00b-9e19-44b1-b62e-57e1b4a4fe9b) | ![](https://github.com/google/jax/assets/68557794/746dd755-9ed4-46b3-b0d9-7dedc337ef86) |
