### PR TITLE
jnp.geomspace: make complex behavior consistent with NumPy 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Remember to align the itemized text with the first line of an item within a list
   * Added {func}`jax.numpy.trapezoid`, following the addition of this function in
     NumPy 2.0.
 
+* Changes
+  * Complex-valued {func}`jax.numpy.geomspace` now chooses the logarithmic spiral
+    branch consistent with that of NumPy 2.0.
+
 * Deprecations & Removals
   * {func}`jax.tree_map` is deprecated; use `jax.tree.map` instead, or for backward
     compatibility with older JAX versions, use {func}`jax.tree_util.tree_map`.

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2685,13 +2685,11 @@ def _geomspace(start: ArrayLike, stop: ArrayLike, num: int = 50, endpoint: bool 
   util.check_arraylike("geomspace", start, stop)
   start = asarray(start, dtype=computation_dtype)
   stop = asarray(stop, dtype=computation_dtype)
-  # follow the numpy geomspace convention for negative and complex endpoints
-  signflip = 1 - (1 - ufuncs.sign(ufuncs.real(start))) * (1 - ufuncs.sign(ufuncs.real(stop))) // 2
-  signflip = signflip.astype(computation_dtype)
-  res = signflip * logspace(ufuncs.log10(signflip * start),
-                            ufuncs.log10(signflip * stop), num,
-                            endpoint=endpoint, base=10.0,
-                            dtype=computation_dtype, axis=0)
+
+  sign = ufuncs.sign(start)
+  res = sign * logspace(ufuncs.log10(start / sign), ufuncs.log10(stop / sign),
+                        num, endpoint=endpoint, base=10.0,
+                        dtype=computation_dtype, axis=0)
   if axis != 0:
     res = moveaxis(res, 0, axis)
   return lax.convert_element_type(res, dtype)


### PR DESCRIPTION
Tested locally against NumPy 2.0.0rc1:
```
$ python -c "import numpy; print(numpy.__version__)"
2.0.0rc1
$ JAX_ENABLE_X64=1 JAX_NUM_GENERATED_CASES=90 pytest -n auto tests/lax_numpy_test.py -k Geomspace
============================= test session starts ==============================
platform darwin -- Python 3.9.6, pytest-7.4.4, pluggy-1.3.0
rootdir: /Users/vanderplas/jax_numpy_upstream/jax
configfile: pyproject.toml
plugins: xdist-3.5.0, hypothesis-6.92.5
8 workers [90 items]    
........................................................................ [ 80%]
..................                                                       [100%]
============================== 90 passed in 6.06s ==============================

```
Related to https://github.com/numpy/numpy/issues/26195.