### PR TITLE
[mutable-arrays] enable refs without cps, and not just at top level

### DIFF
--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -1588,6 +1588,21 @@ class MutableArrayTest(jtu.JaxTestCase):
                         check_dtypes=False)
     self.assertAllClose(w, 10, check_dtypes=False)
 
+  @parameterized.parameters([True, False])
+  def test_internal_mutarray_basic(self, jit):
+    def f():
+      x_mut = core.mutable_array(jnp.zeros(3))
+      x_mut[0] += 1
+      x_mut[0] += 1
+      x_mut[2] += 1
+      return x_mut[...]
+
+    if jit:
+      f = jax.jit(f)
+
+    out = f()
+    self.assertAllClose(out, jnp.array([2., 0., 1.]), check_dtypes=False)
+
 
 if CAN_USE_HYPOTHESIS:
 


### PR DESCRIPTION
The main change here is very simple:
1. instead of making the `mutable_array_p` staging rule raise an error as it did in partial_eval.py (reflecting how we wanted it only to work at the top level), give it a basic abstract eval rule in core.py, which need not be effectful at all (but see second bullet below);
2. also give `mutable_array_p` a discharge rule in state/discharge.py, which doesn't quite fit the existing discharge rule signature because it has no ref invars and has a ref outvar, but other than that it's pretty straightforward;
3. in the pjit lowering path in pxla.py, run a simpler version of the state-discharge machinery even if the jaxpr has no effects / takes no refs as inputs, since we may need to discharge internal refs created by non-top-level `mutable_array` calls.

Morally, that's it!

But actually we had to do a bit more to make things compatible with the `JaxprInputEffect` machinery. We're considering removing that stuff, but since that idea is in flux, for now we're just landing some minimal changes to make things work:
* When we produce a ref-typed value with `mutable_array` in a jaxpr, any primitive like `get` operating on that ref won't have a corresponding jaxpr input, so we can't actually produce a `JaxprInputEffect(input_index: int)` for the jaxpr as we do for passed-in refs. So our small extension is to produce a `JaxprInputEffect(None: Optional[int])` instead. We adapt `make_jaxpr_effects` in partial_eval.py and the typechecking machinery in core.py accordingly. Think of these changes as likely temporary.

To avoid calling this experimental stuff even when people aren't using mutable arrays, we also gave `mutable_array_p` an effect which just serves to tag when it's present. When neither jaxpr-internal mutable arrays nor ref-typed inputs are present, we don't call the state discharge machinery. This is another bit of machinery we might not keep long term, but it seems expedient now.