### PR TITLE
Workaround numpy 1.x assert_allclose false-positive result in comparing complex infinities.

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1725,22 +1725,12 @@ class numpy_with_mpmath:
 
   def sqrt(self, x):
     ctx = x.context
-    # workaround mpmath bugs:
     if isinstance(x, ctx.mpc):
-      if ctx.isinf(x.real) and ctx.isinf(x.imag):
-        if x.real > 0: return x
-        ninf = x.real
-        inf = -ninf
-        if x.imag > 0: return ctx.make_mpc((inf._mpf_, inf._mpf_))
-        return ctx.make_mpc((inf._mpf_, inf._mpf_))
-      elif ctx.isfinite(x.real) and ctx.isinf(x.imag):
-        if x.imag > 0:
-          inf = x.imag
-          return ctx.make_mpc((inf._mpf_, inf._mpf_))
-        else:
-          ninf = x.imag
-          inf = -ninf
-          return ctx.make_mpc((inf._mpf_, ninf._mpf_))
+      # Workaround mpmath 1.3 bug in sqrt(+-inf+-infj) evaluation (see mpmath/mpmath#776).
+      # TODO(pearu): remove this function when mpmath 1.4 or newer
+      # will be the required test dependency.
+      if ctx.isinf(x.imag):
+        return ctx.make_mpc((ctx.inf._mpf_, x.imag._mpf_))
     return ctx.sqrt(x)
 
   def expm1(self, x):


### PR DESCRIPTION
As in the title.

Reproducer of the numpy 1.x assert_allclose bug is:
```python
>>> a1 = np.array([complex(np.inf, np.inf), 2], dtype=np.complex64)
>>> a2 = np.array([complex(np.inf, -np.inf), 2], dtype=np.complex64)
>>> np.testing.assert_allclose(a1, a2)
/home/pearu/miniconda3/envs/jax-cuda-dev/lib/python3.11/site-packages/numpy/core/numeric.py:2358: RuntimeWarning: invalid value encountered in multiply
  x = x * ones_like(cond)
/home/pearu/miniconda3/envs/jax-cuda-dev/lib/python3.11/site-packages/numpy/core/numeric.py:2359: RuntimeWarning: invalid value encountered in multiply
  y = y * ones_like(cond)
```
Since `a1` and `a2` are not close, np.testing.assert_allclose should raise an exception.
