### PR TITLE
Bumped the minimum jaxlib to 0.4.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Remember to align the itemized text with the first line of an item within a list
     is deprecated; empty inputs to softmax are now supported without setting this.
   * In {func}`jax.jit`, passing invalid `static_argnums` or `static_argnames`
     now leads to an error rather than a warning.
-
+  * The minimum jaxlib version is now 0.4.23.
 
 ## jaxlib 0.4.27
 
@@ -156,7 +156,7 @@ Remember to align the itemized text with the first line of an item within a list
       cannot interact, e.g., in arithmetic operations.
       Scopes are introduced by {func}`jax.experimental.jax2tf.convert`,
       {func}`jax.experimental.export.symbolic_shape`, {func}`jax.experimental.export.symbolic_args_specs`.
-      The scope of a symbolic expression `e` can be read with `e.scope` and passed 
+      The scope of a symbolic expression `e` can be read with `e.scope` and passed
       into the above functions to direct them to construct symbolic expressions in
       a given scope.
       See https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#user-specified-symbolic-constraints.

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -44,7 +44,6 @@ from jax._src.interpreters import xla
 from jax._src.interpreters import pxla
 from jax._src import lib
 from jax._src.lib import xla_client as xc
-from jax._src.lib import xla_extension_version
 from jax._src.monitoring import record_event_duration_secs
 from jax._src.partition_spec import PartitionSpec
 from jax._src.sharding import Sharding
@@ -82,15 +81,11 @@ def apply_primitive(prim, *args, **params):
   fun = xla_primitive_callable(prim, **params)
   # TODO(yashkatariya): Investigate adding is_primitive to jit and never
   # triggering the disable jit path instead of messing around with it here.
-  if xla_extension_version >= 218:
-    prev = lib.jax_jit.swap_thread_local_state_disable_jit(False)
-    try:
-      outs = fun(*args)
-    finally:
-      lib.jax_jit.swap_thread_local_state_disable_jit(prev)
-  else:
-    with config.disable_jit(False):
-      outs = fun(*args)
+  prev = lib.jax_jit.swap_thread_local_state_disable_jit(False)
+  try:
+    outs = fun(*args)
+  finally:
+    lib.jax_jit.swap_thread_local_state_disable_jit(prev)
   return outs
 
 @util.cache()

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -49,7 +49,6 @@ from jax._src.interpreters import xla
 from jax._src.layout import AutoLayout, DeviceLocalLayout
 from jax._src.lib import xla_client as xc
 from jax._src.lib import xla_extension
-from jax._src.lib import xla_extension_version
 from jax._src.lib.mlir import dialects
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import func as func_dialect
@@ -911,7 +910,7 @@ def lower_jaxpr_to_module(
         "In multi-platform lowering either all or no lowering platforms "
         f"should support donation. Lowering for {platforms} of which "
         f"only {platforms_with_donation} support donation")
-    if num_partitions > 1 and xla_extension_version >= 220 and (
+    if num_partitions > 1 and (
         result_shardings is None or all(s is None for s in result_shardings)):
       xla_donated_args = donated_args
     if xla_donated_args is None:

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -2918,12 +2918,8 @@ class UnloadedMeshExecutable:
         in_shardings, out_shardings, committed, da = _get_metadata_jit_pmap(
             xla_executable.local_devices(), len(in_shardings), len(out_shardings))
 
-    if xla_extension_version >= 217:
-      in_layouts, out_layouts = _get_layouts_from_executable(
-          xla_executable, in_layouts, out_layouts, len(ordered_effects))
-    else:
-      assert all(i is None for i in in_layouts)
-      assert all(o is None for o in out_layouts)
+    in_layouts, out_layouts = _get_layouts_from_executable(
+        xla_executable, in_layouts, out_layouts, len(ordered_effects))
 
     out_shardings = maybe_recover_user_shardings(
         in_shardings, out_shardings, global_in_avals, global_out_avals)

--- a/jax/_src/lax/fft.py
+++ b/jax/_src/lax/fft.py
@@ -30,8 +30,6 @@ from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
 from jax._src.lib.mlir.dialects import hlo
 from jax._src.lib import xla_client
-from jax._src.lib import xla_extension_version
-from jax._src.lib import ducc_fft
 from jax._src.numpy.util import promote_dtypes_complex, promote_dtypes_inexact
 
 __all__ = [
@@ -122,76 +120,6 @@ def _fft_lowering(ctx, x, *, fft_type, fft_lengths):
   ]
 
 
-def _fft_lowering_cpu(ctx, x, *, fft_type, fft_lengths):
-  x_aval, = ctx.avals_in
-
-  in_shape = x_aval.shape
-  dtype = x_aval.dtype
-  out_aval, = ctx.avals_out
-  out_shape = out_aval.shape
-
-  forward = fft_type in (xla_client.FftType.FFT, xla_client.FftType.RFFT)
-  ndims = len(in_shape)
-  assert len(fft_lengths) >= 1
-  assert len(fft_lengths) <= ndims, (fft_lengths, ndims)
-  assert len(in_shape) == len(out_shape) == ndims
-
-  # PocketFft does not allow size 0 dimensions.
-  if 0 in in_shape or 0 in out_shape:
-    if fft_type == xla_client.FftType.RFFT:
-      assert dtype in (np.float32, np.float64), dtype
-      out_dtype = np.dtype(np.complex64 if dtype == np.float32 else np.complex128)
-
-    elif fft_type == xla_client.FftType.IRFFT:
-      assert np.issubdtype(dtype, np.complexfloating), dtype
-      out_dtype = np.dtype(np.float32 if dtype == np.complex64 else np.float64)
-
-    else:
-      assert np.issubdtype(dtype, np.complexfloating), dtype
-      out_dtype = dtype
-
-    zero = mlir.ir_constant(np.array(0, dtype=out_dtype))
-    return [
-        mlir.broadcast_in_dim(ctx, zero, out_aval, broadcast_dimensions=[])]
-
-  strides_in = []
-  stride = 1
-  for d in reversed(in_shape):
-    strides_in.append(stride)
-    stride *= d
-  strides_in = mlir.shape_tensor(
-      mlir.eval_dynamic_shape(ctx, tuple(reversed(strides_in))))
-
-  strides_out = []
-  stride = 1
-  for d in reversed(out_shape):
-    strides_out.append(stride)
-    stride *= d
-  strides_out = mlir.shape_tensor(
-      mlir.eval_dynamic_shape(ctx, tuple(reversed(strides_out))))
-
-  # scale = 1. if forward else (1. / np.prod(fft_lengths)) as a f64[1] tensor
-  double_type = mlir.ir.RankedTensorType.get((), mlir.ir.F64Type.get())
-  size_fft_length_prod = np.prod(fft_lengths) if fft_lengths else 1
-  size_fft_lengths, = mlir.eval_dynamic_shape_as_vals(ctx, (size_fft_length_prod,))
-  size_fft_lengths = hlo.ConvertOp(double_type, size_fft_lengths)
-  one = mlir.ir_constant(np.float64(1.))
-  scale = one if forward else hlo.DivOp(one, size_fft_lengths)
-  scale = hlo.ReshapeOp(
-      mlir.ir.RankedTensorType.get((1,), mlir.ir.F64Type.get()),
-      scale).result
-
-  in_shape = mlir.shape_tensor(mlir.eval_dynamic_shape(ctx, in_shape))
-  out_shape = mlir.shape_tensor(mlir.eval_dynamic_shape(ctx, out_shape))
-  in_shape = in_shape if fft_type != xla_client.FftType.IRFFT else out_shape
-
-  result_type = mlir.aval_to_ir_type(out_aval)
-  return [ducc_fft.dynamic_ducc_fft_hlo(
-      result_type, x,
-      input_dtype=x_aval.dtype, ndims=ndims, input_shape=in_shape,
-      strides_in=strides_in, strides_out=strides_out, scale=scale,
-      fft_type=fft_type, fft_lengths=fft_lengths, result_shape=out_shape)]
-
 def _naive_rfft(x, fft_lengths):
   y = fft(x, xla_client.FftType.FFT, fft_lengths)
   n = fft_lengths[-1]
@@ -253,8 +181,3 @@ fft_p.def_abstract_eval(fft_abstract_eval)
 mlir.register_lowering(fft_p, _fft_lowering)
 ad.deflinear2(fft_p, _fft_transpose_rule)
 batching.primitive_batchers[fft_p] = _fft_batching_rule
-
-# TODO(phawkins): when jaxlib 0.4.21 is the minimum, use XLA's FFT lowering
-# always on CPU. At that point, we can also delete the DUCC FFT kernel from JAX.
-if xla_extension_version < 211:
-  mlir.register_lowering(fft_p, _fft_lowering_cpu, platform='cpu')

--- a/jax/version.py
+++ b/jax/version.py
@@ -133,7 +133,7 @@ def _get_cmdclass(pkg_source_path):
 
 
 __version__ = _get_version_string()
-_minimum_jaxlib_version = "0.4.20"
+_minimum_jaxlib_version = "0.4.23"
 
 def _version_as_tuple(version_str):
   return tuple(int(i) for i in version_str.split(".") if i.isdigit())

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -58,7 +58,6 @@ from jax._src.interpreters import mlir
 from jax._src.interpreters import partial_eval as pe
 from jax._src.lib import xla_client
 from jax._src.lib import xla_extension
-from jax._src.lib import xla_extension_version
 import jax._src.util as jax_util
 from jax.ad_checkpoint import checkpoint_name, checkpoint as new_checkpoint
 import jax.custom_batching
@@ -4590,7 +4589,6 @@ class APITest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, "ndim of its first argument"):
       jax.sharding.Mesh(jax.devices(), ("x", "y"))
 
-  @unittest.skipIf(xla_extension_version < 222, 'jaxlib version too old')
   def test_jit_boundmethod_reference_cycle(self):
     class A:
       def __init__(self):

--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -221,7 +221,6 @@ class DLPackTest(jtu.JaxTestCase):
     x_np = np.from_dlpack(x_jax)
     self.assertAllClose(x_np, x_jax)
 
-  @unittest.skipIf(xla_extension_version < 221, "Requires newer jaxlib")
   def testNondefaultLayout(self):
     # Generate numpy array with nonstandard layout
     a = np.arange(4).reshape(2, 2)

--- a/tests/export_back_compat_test.py
+++ b/tests/export_back_compat_test.py
@@ -60,7 +60,6 @@ from jax.sharding import PartitionSpec as P
 
 from jax._src import config
 from jax._src import test_util as jtu
-from jax._src.lib import version as jaxlib_version
 
 config.parse_flags_with_absl()
 
@@ -142,23 +141,16 @@ class CompatTest(bctu.CompatTestBase):
     def func(x):
       return lax.fft(x, fft_type="fft", fft_lengths=(4,))
 
-    # An old lowering, with ducc_fft. We keep it for 6 months.
-    data = self.load_testdata(cpu_ducc_fft.data_2023_03_17)
-    if jaxlib_version <= (0, 4, 20):
-      expect_current_custom_calls = ["dynamic_ducc_fft"]
-    else:
-      # We have changed the lowering for fft since we saved this data.
-      # FFT no longer lowers to a custom call.
-      expect_current_custom_calls = []
+    # TODO(b/311175955): Remove this test and the corresponding custom calls.
 
-    self.run_one_test(func, data,
-                      expect_current_custom_calls=expect_current_custom_calls)
+    # An old lowering, with ducc_fft.
+    data = self.load_testdata(cpu_ducc_fft.data_2023_03_17)
+    self.run_one_test(func, data, expect_current_custom_calls=[])
 
     # A newer lowering, with dynamic_ducc_fft.
     data = self.load_testdata(cpu_ducc_fft.data_2023_06_14)
     # FFT no longer lowers to a custom call.
-    self.run_one_test(func, data,
-                      expect_current_custom_calls=expect_current_custom_calls)
+    self.run_one_test(func, data, expect_current_custom_calls=[])
 
   def cholesky_input(self, shape, dtype):
     a = jtu.rand_default(self.rng())(shape, dtype)

--- a/tests/layout_test.py
+++ b/tests/layout_test.py
@@ -26,7 +26,6 @@ from jax._src.layout import Layout, DeviceLocalLayout as DLL
 from jax._src import test_util as jtu
 from jax._src.util import safe_zip
 from jax._src import xla_bridge
-from jax._src.lib import xla_extension_version
 
 config.parse_flags_with_absl()
 
@@ -66,8 +65,6 @@ class LayoutTest(jtu.JaxTestCase):
   def setUp(self):
     if not jtu.test_device_matches(['tpu']):
       self.skipTest("Layouts do not work on CPU and GPU backends yet.")
-    if xla_extension_version < 215:
-      self.skipTest('All tests require xla_extension_version >= 215')
     super().setUp()
 
   def test_auto_layout(self):

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -16,7 +16,6 @@
 
 from functools import partial
 import itertools
-import unittest
 
 import numpy as np
 import scipy
@@ -30,7 +29,6 @@ from jax import jit, grad, jvp, vmap
 from jax import lax
 from jax import numpy as jnp
 from jax import scipy as jsp
-from jax._src.lib import version as jaxlib_version
 from jax._src import config
 from jax._src.lax import linalg as lax_linalg
 from jax._src import test_util as jtu
@@ -269,7 +267,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   # TODO(phawkins): enable when there is an eigendecomposition implementation
   # for GPU/TPU.
   @jtu.run_on_devices("cpu")
-  @unittest.skipIf(jaxlib_version < (0, 4, 21), "Test requires jaxlib 0.4.21")
   def testEigHandlesNanInputs(self, shape, dtype, compute_left_eigenvectors,
                               compute_right_eigenvectors):
     """Verifies that `eig` fails gracefully if given non-finite inputs."""

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -389,7 +389,6 @@ class PJitTest(jtu.BufferDonationTestCase):
     jax.tree.map(self.assertDeleted, y_tree)
     jax.tree.map(self.assertNotDeleted, z_tree)
 
-  @unittest.skipIf(xla_extension_version < 220, 'jaxlib version too old')
   @jtu.run_on_devices('tpu', 'cpu', 'gpu')
   def testBufferDonationWithOutputShardingInference(self):
     mesh = jtu.create_global_mesh((2,), 'x')
@@ -443,7 +442,6 @@ class PJitTest(jtu.BufferDonationTestCase):
     jax.effects_barrier()
     self.assertDeleted(x)
 
-  @unittest.skipIf(xla_extension_version < 220, 'jaxlib version too old')
   @jtu.run_on_devices('tpu', 'cpu', 'gpu')
   def testBufferDonationNotDonated(self):
     mesh = jtu.create_global_mesh((2,), 'x')


### PR DESCRIPTION
The new minimum `xla_extension_version` is 223, and the new minimum `mlir_api_version` is 54.