### PR TITLE
Call cuInit before querying compute capability

### DIFF
--- a/jaxlib/cuda/versions_helpers.cc
+++ b/jaxlib/cuda/versions_helpers.cc
@@ -86,6 +86,7 @@ size_t CudnnGetVersion() {
 }
 int CudaComputeCapability(int device) {
   int major, minor;
+  JAX_THROW_IF_ERROR(JAX_AS_STATUS(gpuInit(0)));
   JAX_THROW_IF_ERROR(JAX_AS_STATUS(gpuDeviceGetAttribute(
       &major, GPU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device)));
   JAX_THROW_IF_ERROR(JAX_AS_STATUS(gpuDeviceGetAttribute(


### PR DESCRIPTION
Since https://github.com/google/jax/commit/9fff9aeb69f586d36bdb6422f40b548aa41bd1e3 `jax.distributed.initialize` fails with the error
```
CUDA backend failed to initialize: jaxlib/cuda/versions_helpers.cc:90: operation gpuDeviceGetAttribute( &major, GPU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device) failed: CUDA_ERROR_NOT_INITIALIZED (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
```
in some situations.

Outside special cluster environments, JAX queries CUDA to find out how many GPUs are visible. Querying the device count correctly initialises CUDA, and all is well.
However, at least on a Slurm clusters, the choice of which GPU a given distributed JAX process should use is based on Slurm environment variables, and in those environments JAX does **not** query the device count. 
https://github.com/google/jax/commit/9fff9aeb69f586d36bdb6422f40b548aa41bd1e3 added a check that the selected GPUs have a minimum compute capability. This check assumes that CUDA is already initialised, which it is not in the Slurm case described above.

This PR avoids the issue by calling cuInit before querying the compute capability.