### PR TITLE
Updated ubuntu os version in `readthedocs.yml` file to the latest recommended version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
     python: "3.9"
 


### PR DESCRIPTION
I see that the [readthedocs.yml](https://github.com/google/jax/blame/main/.readthedocs.yml) config was setup almost 3 years ago. I think we should update the **build OS** version from 20.04 to 22.04 as recommended in the [configuring section of documentation](https://docs.readthedocs.io/en/stable/tutorial/index.html#id13) of readthedocs.