### PR TITLE
Fix test failure in complex clip test.

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -898,18 +898,20 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     rng = jtu.rand_default(self.rng())
     x = rng(shape, dtype=jnp.complex64)
     msg = "Complex values have no ordering and cannot be clipped"
-    with self.assertWarns(DeprecationWarning, msg=msg):
-      jnp.clip(x)
+    # jit is disabled so we don't miss warnings due to caching.
+    with jax.disable_jit():
+      with self.assertWarns(DeprecationWarning, msg=msg):
+        jnp.clip(x)
 
-    with self.assertWarns(DeprecationWarning, msg=msg):
-      jnp.clip(x, max=x)
+      with self.assertWarns(DeprecationWarning, msg=msg):
+        jnp.clip(x, max=x)
 
-    x = rng(shape, dtype=jnp.int32)
-    with self.assertWarns(DeprecationWarning, msg=msg):
-      jnp.clip(x, min=-1+5j)
+      x = rng(shape, dtype=jnp.int32)
+      with self.assertWarns(DeprecationWarning, msg=msg):
+        jnp.clip(x, min=-1+5j)
 
-    with self.assertWarns(DeprecationWarning, msg=msg):
-      jnp.clip(x, max=jnp.array([-1+5j]))
+      with self.assertWarns(DeprecationWarning, msg=msg):
+        jnp.clip(x, max=jnp.array([-1+5j]))
 
 
   @jtu.sample_product(


### PR DESCRIPTION
This test tests for warnings, but if we hit in the jit cache, then the warning was not issued.