### PR TITLE
fix: Fixed `docstrings` indentation to be consistent at all the places

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2101,10 +2101,10 @@ def max_dim(d1: DimSize, d2: DimSize) -> DimSize:
 
 def dimension_as_value(d: DimSize):
   """Turns a dimension size into a JAX array.
-     This is the identity function for constant dimensions.
+  This is the identity function for constant dimensions.
 
-     Has the same abstract value as Python constants.
-     """
+  Has the same abstract value as Python constants.
+  """
   if isinstance(d, (int, Tracer, np.int32, np.int64)): return d
   # For shape_poly._DimPolynomial
   if hasattr(d, "dimension_as_value"): return d.dimension_as_value()

--- a/jax/_src/internal_test_util/test_harnesses.py
+++ b/jax/_src/internal_test_util/test_harnesses.py
@@ -320,20 +320,20 @@ class Limitation:
   ):
     """Args:
 
-      description: text to augment the harness group name with the description
-      of the limitation. Used for reports.
-      enabled: whether this limitation is enabled for the harness in which
-        it appears. This is only used during testing to know whether to ignore
-        harness errors. Use this sparingly, prefer `devices` and
-        `dtypes` for enabled conditions that are included in reports.
-      devices: a device type (string) or a sequence of device types
-        for which this applies. By default, it applies to all devices types.
-        Used for filtering during harness execution, and for reports.
-      dtypes: the sequence of dtypes for which this applies. An empty sequence
-        denotes all dtypes. Used for filtering during harness execution, and
-        for reports.
-      skip_run: this harness should not even be invoked (typically because it
-        results in a crash). This should be rare.
+    description: text to augment the harness group name with the description
+    of the limitation. Used for reports.
+    enabled: whether this limitation is enabled for the harness in which
+      it appears. This is only used during testing to know whether to ignore
+      harness errors. Use this sparingly, prefer `devices` and
+      `dtypes` for enabled conditions that are included in reports.
+    devices: a device type (string) or a sequence of device types
+      for which this applies. By default, it applies to all devices types.
+      Used for filtering during harness execution, and for reports.
+    dtypes: the sequence of dtypes for which this applies. An empty sequence
+      denotes all dtypes. Used for filtering during harness execution, and
+      for reports.
+    skip_run: this harness should not even be invoked (typically because it
+      results in a crash). This should be rare.
     """
     assert isinstance(description, str), f"{description}"
     self.description = description

--- a/jax/_src/lax/eigh.py
+++ b/jax/_src/lax/eigh.py
@@ -103,7 +103,7 @@ def _update_slice(operand, update, start_indices, update_dims):
   update: the padded array to write
   start_indices: the offset at which to write `update`.
   update_dims: the true dimensions of the padded update `update`. Only values
-    inside the rectangle given by `update_dims` will be overwritten."""
+  inside the rectangle given by `update_dims` will be overwritten."""
   operand_shape = operand.shape
   operand = lax.pad(operand,
                     jnp.array(0, operand.dtype),

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -337,7 +337,7 @@ def cos(x: ArrayLike) -> Array:
 
 def atan2(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise arc tangent of two variables:
-    :math:`\mathrm{atan}({x \over y})`."""
+  :math:`\mathrm{atan}({x \over y})`."""
   return atan2_p.bind(x, y)
 
 def real(x: ArrayLike) -> Array:

--- a/jax/_src/lax/special.py
+++ b/jax/_src/lax/special.py
@@ -91,7 +91,7 @@ def erf(x: ArrayLike) -> Array:
 
 def erfc(x: ArrayLike) -> Array:
   r"""Elementwise complementary error function:
-    :math:`\mathrm{erfc}(x) = 1 - \mathrm{erf}(x)`."""
+  :math:`\mathrm{erfc}(x) = 1 - \mathrm{erf}(x)`."""
   return erfc_p.bind(x)
 
 def erf_inv(x: ArrayLike) -> Array:

--- a/jax/_src/numpy/setops.py
+++ b/jax/_src/numpy/setops.py
@@ -153,8 +153,8 @@ def setxor1d(ar1: ArrayLike, ar2: ArrayLike, assume_unique: bool = False) -> Arr
 @partial(jit, static_argnames=['return_indices'])
 def _intersect1d_sorted_mask(ar1: ArrayLike, ar2: ArrayLike, return_indices: bool = False) -> tuple[Array, ...]:
   """
-    Helper function for intersect1d which is jit-able
-    """
+  Helper function for intersect1d which is jit-able
+  """
   ar = concatenate((ar1, ar2))
   if return_indices:
     iota = lax.broadcasted_iota(np.int64, np.shape(ar), dimension=0)

--- a/jax/_src/scipy/sparse/linalg.py
+++ b/jax/_src/scipy/sparse/linalg.py
@@ -39,8 +39,8 @@ _einsum = partial(jnp.einsum, precision=lax.Precision.HIGHEST)
 # aliases for working with pytrees
 def _vdot_real_part(x, y):
   """Vector dot-product guaranteed to have a real valued result despite
-     possibly complex input. Thus neglects the real-imaginary cross-terms.
-     The result is a real float.
+  possibly complex input. Thus neglects the real-imaginary cross-terms.
+  The result is a real float.
   """
   # all our uses of vdot() in CG are for computing an operator of the form
   #  z^H M z

--- a/jax/_src/sharding.py
+++ b/jax/_src/sharding.py
@@ -118,7 +118,7 @@ class Sharding:
   @functools.cached_property
   def addressable_devices(self) -> set[Device]:
     """The set of devices in the :class:`Sharding` that are addressable by the
-       current process.
+    current process.
     """
     # Add a fast path for single controller runtimes.
     if xb.process_count() == 1:

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1456,24 +1456,24 @@ def numpy_vecdot(x, y, axis):
 
 def complex_plane_sample(dtype, size_re=10, size_im=None):
   """Return a 2-D array of complex numbers that covers the complex plane
-     with a grid of samples.
+  with a grid of samples.
 
-     The size of the grid is (3 + 2 * size_im) x (3 + 2 * size_re)
-     that includes infinity points, extreme finite points, and the
-     specified number of points from real and imaginary axis.
+  The size of the grid is (3 + 2 * size_im) x (3 + 2 * size_re)
+  that includes infinity points, extreme finite points, and the
+  specified number of points from real and imaginary axis.
 
-     For example:
+  For example:
 
-     >>> print(complex_plane_sample(np.complex64, 0, 3))
-     [[-inf          -infj   0.          -infj  inf          -infj]
-      [-inf-3.4028235e+38j   0.-3.4028235e+38j  inf-3.4028235e+38j]
-      [-inf-2.0000000e+00j   0.-2.0000000e+00j  inf-2.0000000e+00j]
-      [-inf-1.1754944e-38j   0.-1.1754944e-38j  inf-1.1754944e-38j]
-      [-inf+0.0000000e+00j   0.+0.0000000e+00j  inf+0.0000000e+00j]
-      [-inf+1.1754944e-38j   0.+1.1754944e-38j  inf+1.1754944e-38j]
-      [-inf+2.0000000e+00j   0.+2.0000000e+00j  inf+2.0000000e+00j]
-      [-inf+3.4028235e+38j   0.+3.4028235e+38j  inf+3.4028235e+38j]
-      [-inf          +infj   0.          +infj  inf          +infj]]
+  >>> print(complex_plane_sample(np.complex64, 0, 3))
+  [[-inf          -infj   0.          -infj  inf          -infj]
+   [-inf-3.4028235e+38j   0.-3.4028235e+38j  inf-3.4028235e+38j]
+   [-inf-2.0000000e+00j   0.-2.0000000e+00j  inf-2.0000000e+00j]
+   [-inf-1.1754944e-38j   0.-1.1754944e-38j  inf-1.1754944e-38j]
+   [-inf+0.0000000e+00j   0.+0.0000000e+00j  inf+0.0000000e+00j]
+   [-inf+1.1754944e-38j   0.+1.1754944e-38j  inf+1.1754944e-38j]
+   [-inf+2.0000000e+00j   0.+2.0000000e+00j  inf+2.0000000e+00j]
+   [-inf+3.4028235e+38j   0.+3.4028235e+38j  inf+3.4028235e+38j]
+   [-inf          +infj   0.          +infj  inf          +infj]]
 
   """
   if size_im is None:

--- a/jax/experimental/export/_shape_poly.py
+++ b/jax/experimental/export/_shape_poly.py
@@ -315,13 +315,13 @@ class _DimTerm:
 
   def to_var(self) -> str | None:
     """Extract the variable name from a term.
-     Return None if the term is not a single variable."""
+    Return None if the term is not a single variable."""
     a = self.to_factor()
     return a.to_var() if a is not None else None
 
   def to_factor(self) -> _DimFactor | None:
     """Extract the single factor from a term.
-     Return None if the term is not a single factor."""
+    Return None if the term is not a single factor."""
     if len(self._factors) > 1: return None
     (f, f_exp), = self._factors
     if f_exp != 1: return None

--- a/jax/experimental/jax2tf/examples/saved_model_lib.py
+++ b/jax/experimental/jax2tf/examples/saved_model_lib.py
@@ -138,11 +138,11 @@ class _ReusableSavedModelWrapper(tf.train.Checkpoint):
   def __init__(self, tf_graph, param_vars):
     """Args:
 
-      tf_graph: a tf.function taking one argument (the inputs), which can be
-         be tuples/lists/dictionaries of np.ndarray or tensors. The function
-         may have references to the tf.Variables in `param_vars`.
-      param_vars: the parameters, as tuples/lists/dictionaries of tf.Variable,
-         to be saved as the variables of the SavedModel.
+    tf_graph: a tf.function taking one argument (the inputs), which can be
+       be tuples/lists/dictionaries of np.ndarray or tensors. The function
+       may have references to the tf.Variables in `param_vars`.
+    param_vars: the parameters, as tuples/lists/dictionaries of tf.Variable,
+       to be saved as the variables of the SavedModel.
     """
     super().__init__()
     # Implement the interface from https://www.tensorflow.org/hub/reusable_saved_models

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -94,29 +94,29 @@ class PolyHarness(Harness):
                override_jax_config_flags: dict[str, Any] = {}):
     """Args:
 
-      group_name, name: The name for the harness. See `Harness.__init__`.
-      fun: the function to be converted, possibly after partial application to
-        static arguments from `arg_descriptors`. See `Harness.__init__`.
-      arg_descriptors: The argument descriptors. See `Harness.__init__`. May
-        be missing, in which case `skip_jax_run` should be `True` and
-        `input_signature` must be present.
-      polymorphic_shapes: For `jax2tf.convert`.
-      polymorphic_constraints: For `jax2tf.convert`.
-      input_signature: For `tf.function.get_concrete_function`. If missing,
-        generated from `polymorphic_shapes`.
-      expected_output_signature: the expected inferred output shape.
-      enable_xla: For `jax2tf.convert`.
-      expect_error: a pair of an Exception type and a regular expression to
-        match the expected exception string.
-      skip_jax_run: If True, then neither the JAX nor the TF functions are
-        executed.
-      check_result: specifies if we want to check that the result of the shape
-        polymorphic conversion produces the same result and the JAX function.
-      tol: the tolerance to use for checking results.
-      limitations: if given, then apply the custom_assert and tolerance from the
-        Jax2TfLimitations.
-      override_jax_config_flags: jax.config flags to override for the duration
-        of the test.
+    group_name, name: The name for the harness. See `Harness.__init__`.
+    fun: the function to be converted, possibly after partial application to
+      static arguments from `arg_descriptors`. See `Harness.__init__`.
+    arg_descriptors: The argument descriptors. See `Harness.__init__`. May
+      be missing, in which case `skip_jax_run` should be `True` and
+      `input_signature` must be present.
+    polymorphic_shapes: For `jax2tf.convert`.
+    polymorphic_constraints: For `jax2tf.convert`.
+    input_signature: For `tf.function.get_concrete_function`. If missing,
+      generated from `polymorphic_shapes`.
+    expected_output_signature: the expected inferred output shape.
+    enable_xla: For `jax2tf.convert`.
+    expect_error: a pair of an Exception type and a regular expression to
+      match the expected exception string.
+    skip_jax_run: If True, then neither the JAX nor the TF functions are
+      executed.
+    check_result: specifies if we want to check that the result of the shape
+      polymorphic conversion produces the same result and the JAX function.
+    tol: the tolerance to use for checking results.
+    limitations: if given, then apply the custom_assert and tolerance from the
+      Jax2TfLimitations.
+    override_jax_config_flags: jax.config flags to override for the duration
+      of the test.
     """
     super().__init__(group_name, name, fun, arg_descriptors,
                      dtype=np.float32)

--- a/jax/experimental/jax2tf/tests/sharding_test.py
+++ b/jax/experimental/jax2tf/tests/sharding_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Tests for the jax2tf conversion of pjit.
 
- To verify that the tests do run indeed on multiple devices you can run
+To verify that the tests do run indeed on multiple devices you can run
 
-  perftools/gputools/profiler/jfprof.sh jax/experimental/jax2tf/tests:sharding_test_tpu -- -c opt --test_filter=ShardingTest.test_shmap_all_to_all --test_arg=--vmodule=jax2tf=3 --
+perftools/gputools/profiler/jfprof.sh jax/experimental/jax2tf/tests:sharding_test_tpu -- -c opt --test_filter=ShardingTest.test_shmap_all_to_all --test_arg=--vmodule=jax2tf=3 --
 
 """
 from collections.abc import Sequence

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -13,43 +13,43 @@
 # limitations under the License.
 
 r"""Jet is an experimental module for higher-order automatic differentiation
-  that does not rely on repeated first-order automatic differentiation.
+that does not rely on repeated first-order automatic differentiation.
 
-  How? Through the propagation of truncated Taylor polynomials.
-  Consider a function :math:`f = g \circ h`, some point :math:`x`
-  and some offset :math:`v`.
-  First-order automatic differentiation (such as :func:`jax.jvp`)
-  computes the pair :math:`(f(x), \partial f(x)[v])` from the pair
-  :math:`(h(x), \partial h(x)[v])`.
+How? Through the propagation of truncated Taylor polynomials.
+Consider a function :math:`f = g \circ h`, some point :math:`x`
+and some offset :math:`v`.
+First-order automatic differentiation (such as :func:`jax.jvp`)
+computes the pair :math:`(f(x), \partial f(x)[v])` from the pair
+:math:`(h(x), \partial h(x)[v])`.
 
-  :func:`jet` implements the higher-order analogue:
-  Given the tuple
+:func:`jet` implements the higher-order analogue:
+Given the tuple
 
-  .. math::
-    (h_0, ... h_K) :=
-    (h(x), \partial h(x)[v], \partial^2 h(x)[v, v], ..., \partial^K h(x)[v,...,v]),
+.. math::
+(h_0, ... h_K) :=
+(h(x), \partial h(x)[v], \partial^2 h(x)[v, v], ..., \partial^K h(x)[v,...,v]),
 
-  which represents a :math:`K`-th order Taylor approximation
-  of :math:`h` at :math:`x`, :func:`jet` returns a :math:`K`-th order
-  Taylor approximation of :math:`f` at :math:`x`,
+which represents a :math:`K`-th order Taylor approximation
+of :math:`h` at :math:`x`, :func:`jet` returns a :math:`K`-th order
+Taylor approximation of :math:`f` at :math:`x`,
 
-  .. math::
-    (f_0, ..., f_K) :=
-    (f(x), \partial f(x)[v], \partial^2 f(x)[v, v], ..., \partial^K f(x)[v,...,v]).
+.. math::
+(f_0, ..., f_K) :=
+(f(x), \partial f(x)[v], \partial^2 f(x)[v, v], ..., \partial^K f(x)[v,...,v]).
 
-  More specifically, :func:`jet` computes
+More specifically, :func:`jet` computes
 
-  .. math::
-    f_0, (f_1, . . . , f_K) = \texttt{jet} (f, h_0, (h_1, . . . , h_K))
+.. math::
+f_0, (f_1, . . . , f_K) = \texttt{jet} (f, h_0, (h_1, . . . , h_K))
 
-  and can thus be used for high-order
-  automatic differentiation of :math:`f`.
-  Details are explained in
-  `these notes <https://github.com/google/jax/files/6717197/jet.pdf>`__.
+and can thus be used for high-order
+automatic differentiation of :math:`f`.
+Details are explained in
+`these notes <https://github.com/google/jax/files/6717197/jet.pdf>`__.
 
-  Note:
-    Help improve :func:`jet` by contributing
-    `outstanding primitive rules <https://github.com/google/jax/issues/2431>`__.
+Note:
+Help improve :func:`jet` by contributing
+`outstanding primitive rules <https://github.com/google/jax/issues/2431>`__.
 """
 
 from typing import Any, Callable

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -1230,23 +1230,23 @@ class PolyHarness(Harness):
                override_jax_config_flags: dict[str, Any] = {}):
     """Args:
 
-      group_name, name: The name for the harness. See `Harness.__init__`.
-      fun: the function to be converted. See `Harness.__init__`.
-      arg_descriptors: The argument descriptors. See `Harness.__init__`.
-      polymorphic_shapes: For `export.args_specs`.
-      symbolic_constraints: For `export.args_specs`.
-      expect_error: an optional pair of an Exception type and a regular
-        expression to match the expected exception string.
-        We expect this error during tracing and exporting with shape
-        polymorphism.
-      check_result: specifies if we want to check that the result of invoking
-        the shape polymorphic export produces the same result as the
-        native JAX function.
-      tol: the tolerance to use for checking results.
-      limitations: a sequence of Limitation(s), used for obtaining the default
-        tolerance (if `tol` is not specified).
-      override_jax_config_flags: jax.config flags to override for the duration
-        of the test.
+    group_name, name: The name for the harness. See `Harness.__init__`.
+    fun: the function to be converted. See `Harness.__init__`.
+    arg_descriptors: The argument descriptors. See `Harness.__init__`.
+    polymorphic_shapes: For `export.args_specs`.
+    symbolic_constraints: For `export.args_specs`.
+    expect_error: an optional pair of an Exception type and a regular
+      expression to match the expected exception string.
+      We expect this error during tracing and exporting with shape
+      polymorphism.
+    check_result: specifies if we want to check that the result of invoking
+      the shape polymorphic export produces the same result as the
+      native JAX function.
+    tol: the tolerance to use for checking results.
+    limitations: a sequence of Limitation(s), used for obtaining the default
+      tolerance (if `tol` is not specified).
+    override_jax_config_flags: jax.config flags to override for the duration
+      of the test.
     """
     super().__init__(group_name, name, fun, arg_descriptors,
                      dtype=np.float32)


### PR DESCRIPTION
There are inconsistencies in the indentation of `docstrings` at few places. [PEP 257](https://google.github.io/styleguide/pyguide.html), [NumPy Style Guide](https://numpydoc.readthedocs.io/en/latest/format.html) and [Google Python Style Guide - Docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) all recommend docstrings to be indented to the same level as their opening quotes and to avoid over-indenting docstrings, for consistency.

I used the following [`ruff check`](https://docs.astral.sh/ruff/rules/over-indentation/), to automatically fix this at all the places.