### PR TITLE
CI: run the metal CI nightly & on PRs touching the config file

### DIFF
--- a/.github/workflows/metal_plugin_ci.yml
+++ b/.github/workflows/metal_plugin_ci.yml
@@ -2,7 +2,14 @@
 
 name: Jax-Metal CI
 on:
+  schedule:
+    - cron: "0 12 * * *" # Daily at 12:00 UTC
   workflow_dispatch: # allows triggering the workflow run manually
+  pull_request:  # Automatically trigger on pull requests affecting this file
+    branches:
+      - main
+    paths:
+      - '**workflows/metal_plugin_ci.yml'
 
 jobs:
   jax-metal-plugin-test:

--- a/tests/lax_metal_test.py
+++ b/tests/lax_metal_test.py
@@ -882,10 +882,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  def testClipError(self):
-    with self.assertRaisesRegex(ValueError, "At most one of a_min and a_max.*"):
-      jnp.clip(jnp.zeros((3,)))
-
   @jtu.sample_product(
     [dict(shape=shape, dtype=dtype)
       for shape, dtype in _shape_and_dtypes(all_shapes, number_dtypes)],


### PR DESCRIPTION
Had to remove one test because the behavior of `jnp.clip` changed recently.