### PR TITLE
DOC: Fix :ref: format

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -53,7 +53,7 @@ JAX Glossary of Terms
 
     pytree
       A pytree is an abstraction that lets JAX handle tuples, lists, dicts, and other more
-      general containers of array values in a uniform way. Refer to {ref}`working-with-pytrees`
+      general containers of array values in a uniform way. Refer to :ref:`working-with-pytrees`
       for a more detailed discussion.
 
     reverse-mode autodiff


### PR DESCRIPTION
Change ref format from {ref}`working-with-pytrees` to :ref:`working-with-pytrees`.  The old version just renders literally,  not as a link.  It appears to be a markdown-style reference.  I'm not familiar with reST, but :ref: is how the other references are formatted.

Introduced in d1235fa (DOC: add key concepts doc).