### PR TITLE
alias jax.sharding.NamedSharding -> jax.NamedSharding

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -125,6 +125,7 @@ from jax._src.api import value_and_grad as value_and_grad
 from jax._src.api import vjp as vjp
 from jax._src.api import vmap as vmap
 from jax._src.api import xla_computation as xla_computation
+from jax._src.sharding_impls import NamedSharding as NamedSharding
 
 # Force import, allowing jax.interpreters.* to be used after import jax.
 from jax.interpreters import ad, batching, mlir, partial_eval, pxla, xla

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1706,7 +1706,7 @@ class APITest(jtu.JaxTestCase):
 
   def test_device_put_sharding(self):
     mesh = jax.sharding.Mesh(jax.devices(), ('x',))
-    s = jax.sharding.NamedSharding(mesh, P('x'))
+    s = jax.NamedSharding(mesh, P('x'))
     x = jnp.arange(len(jax.devices()))
 
     y = jax.device_put(x, s)
@@ -1732,9 +1732,9 @@ class APITest(jtu.JaxTestCase):
 
     mesh = jax.sharding.Mesh(np.array(jax.devices()[:2]).reshape((2, 1)),
                              ("x", "y"))
-    s1 = jax.sharding.NamedSharding(mesh, P("x"))
-    s2 = jax.sharding.NamedSharding(mesh, P("y"))
-    s3 = jax.sharding.NamedSharding(mesh, P("x", "y"))
+    s1 = jax.NamedSharding(mesh, P("x"))
+    s2 = jax.NamedSharding(mesh, P("y"))
+    s3 = jax.NamedSharding(mesh, P("x", "y"))
 
     x = jnp.arange(2)
     y = jnp.arange(2) + 10


### PR DESCRIPTION
This is number 4 in the go/jax-fewer-imports-more-fun list of tiny improvements.

I tested it by switching a few random tests in api_test.py to use the jax.NamedSharding name rather than jax.shardings.NamedSharding.