### PR TITLE
Clarify that lax.top_k returns values and corresponding indices in descending order

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1200,6 +1200,8 @@ def sort_key_val(keys: Array, values: ArrayLike, dimension: int = -1,
 def top_k(operand: ArrayLike, k: int) -> tuple[Array, Array]:
   """Returns top ``k`` values and their indices along the last axis of ``operand``.
 
+  The order of returned values is implementation-dependent.
+
   Args:
     operand: N-dimensional array of non-complex type.
     k: integer specifying the number of top entries.


### PR DESCRIPTION
Share the fruits of my debugging journey, so that future people like me are less likely to assume index order is preserved.

NOTE: The statement that values are sorted in descending order is based on observed behavior in a colab. I don't know if this is guaranteed or not.