### PR TITLE
Pin sphinx version to avoid error in 7.3.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 absl-py
 ipython>=8.8.0  # 8.7.0 has ipython3 lexer error
-sphinx>=6.0.0
+sphinx>=6.0.0,<7.3.0  # 7.3.0 breaks sphinx-book-theme
 sphinx-autodoc-typehints
 sphinx-book-theme>=1.0.1  # Older versions fail to pin pydata-sphinx-theme
 sphinx-copybutton>=0.5.0


### PR DESCRIPTION
This avoids the following error:
```pytb
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/jax/envs/20792/lib/python3.9/site-packages/sphinx/cmd/build.py", line 332, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/docs/checkouts/readthedocs.org/user_builds/jax/envs/20792/lib/python3.9/site-packages/sphinx/application.py", line 268, in __init__
    self._init_builder()
  File "/home/docs/checkouts/readthedocs.org/user_builds/jax/envs/20792/lib/python3.9/site-packages/sphinx/application.py", line 338, in _init_builder
    self.builder.init()
  File "/home/docs/checkouts/readthedocs.org/user_builds/jax/envs/20792/lib/python3.9/site-packages/sphinx/builders/html/__init__.py", line 228, in init
    self.init_templates()
  File "/home/docs/checkouts/readthedocs.org/user_builds/jax/envs/20792/lib/python3.9/site-packages/sphinx/builders/html/__init__.py", line 278, in init_templates
    self.theme = theme_factory.create(theme_name)
  File "/home/docs/checkouts/readthedocs.org/user_builds/jax/envs/20792/lib/python3.9/site-packages/sphinx/theming.py", line 228, in create
    themes, theme_dirs, tmp_dirs = _load_theme_with_ancestors(self._themes, name)
  File "/home/docs/checkouts/readthedocs.org/user_builds/jax/envs/20792/lib/python3.9/site-packages/sphinx/theming.py", line 266, in _load_theme_with_ancestors
    raise ThemeError(msg)
sphinx.errors.ThemeError: The 'sphinx_book_theme' theme inherits from 'pydata_sphinx_theme', which is not a loaded theme. Loaded themes are: agogo, alabaster, basic, bizstyle, classic, default, epub, haiku, nature, nonav, pyramid, scrolls, sphinx_book_theme, sphinxdoc, traditional
```
sphinx issue: https://github.com/sphinx-doc/sphinx/issues/12292