### PR TITLE
DOC: pin sphinx to >=7.3.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 absl-py
 ipython>=8.8.0  # 8.7.0 has ipython3 lexer error
-sphinx>=6.0.0,<7.3.0  # 7.3.0 breaks sphinx-book-theme
+sphinx>=7.3.2  # 7.3.0 breaks sphinx-book-theme
 sphinx-autodoc-typehints
 sphinx-book-theme>=1.0.1  # Older versions fail to pin pydata-sphinx-theme
 sphinx-copybutton>=0.5.0


### PR DESCRIPTION
The issue in #20794 has been fixed upstream.