### PR TITLE
jax.numpy: ensure scalar type wrappers always use XLA-style casting

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -152,7 +152,7 @@ class _ScalarMeta(type):
     return not (self == other)
 
   def __call__(self, x: Any) -> Array:
-    return asarray(x, dtype=self.dtype)
+    return asarray(x).astype(self.dtype)
 
   def __instancecheck__(self, instance: Any) -> bool:
     return isinstance(instance, self.dtype.type)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -211,6 +211,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     prims = [eqn.primitive for eqn in jaxpr.eqns]
     self.assertEqual(prims, [lax.convert_element_type_p])  # No copy generated.
 
+  def testDtypeWrapperCasting(self):
+    self.assertEqual(jnp.uint8(-1.0), jnp.uint8(0))
+    self.assertEqual(jnp.uint8(np.float32(-1.0)), jnp.uint8(0))
+    self.assertEqual(jnp.uint8(np.array([-1.0])), jnp.uint8([0]))
+    self.assertEqual(jnp.uint8(jnp.float32(-1.0)), jnp.uint8(0))
+
   def testBoolDtypeAlias(self):
     self.assertIs(jnp.bool, jnp.bool_)
 


### PR DESCRIPTION
Previous behavior:
```python
>>> import numpy as np
>>> import jax.numpy as jnp

>>> jnp.uint8(-1.0)
Array(255, dtype=uint8)
>>> jnp.uint8(np.float32(-1.0))
Array(255, dtype=uint8)
>>> jnp.uint8(jnp.float32(-1.0))
Array(0, dtype=uint8)
```
Behavior with this PR:
```python
>>> jnp.uint8(-1.0)
Array(0, dtype=uint8)
>>> jnp.uint8(np.float32(-1.0))
Array(0, dtype=uint8)
>>> jnp.uint8(jnp.float32(-1.0))
Array(0, dtype=uint8)
```