### PR TITLE
Begin deprecation of implicit input conversion in FFT module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ Remember to align the itemized text with the first line of an item within a list
   * The {func}`jax.numpy.hypot` function now issues a deprecation warning when
     passing complex-valued inputs to it. This will raise an error when the
     deprecation is completed.
+  * The {mod}`jax.numpy.fft` module now issues a deprecation warning when
+    passing inputs that would require implicit conversion (e.g. `jnp.float32`
+    with `fft`, `jnp.int32` with `rftt`). Either manually onvert the inputs
+    to preserve old behavior, or use a more appropriate `fft` function.
 
 ## jaxlib 0.4.27
 

--- a/jax/_src/scipy/fft.py
+++ b/jax/_src/scipy/fft.py
@@ -55,7 +55,7 @@ def dct(x: Array, type: int = 2, n: int | None = None,
                  for a in range(x.ndim)])
 
   N = x.shape[axis]
-  v = _dct_interleave(x, axis)
+  v, = promote_dtypes_complex(_dct_interleave(x, axis))
   V = jnp.fft.fft(v, axis=axis)
   k = lax.expand_dims(jnp.arange(N, dtype=V.real.dtype), [a for a in range(x.ndim) if a != axis])
   out = V * _W4(N, k)
@@ -68,7 +68,7 @@ def dct(x: Array, type: int = 2, n: int | None = None,
 def _dct2(x: Array, axes: Sequence[int], norm: str | None) -> Array:
   axis1, axis2 = map(partial(canonicalize_axis, num_dims=x.ndim), axes)
   N1, N2 = x.shape[axis1], x.shape[axis2]
-  v = _dct_interleave(_dct_interleave(x, axis1), axis2)
+  v, = promote_dtypes_complex(_dct_interleave(_dct_interleave(x, axis1), axis2))
   V = jnp.fft.fftn(v, axes=axes)
   k1 = lax.expand_dims(jnp.arange(N1, dtype=V.dtype),
                        [a for a in range(x.ndim) if a != axis1])

--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -247,12 +247,11 @@ def _fft_helper(x: Array, win: Array, detrend_func: Callable[[Array], Array],
   result = detrend_func(result)
 
   # Apply window by multiplication
-  if jnp.iscomplexobj(win):
-    result, = promote_dtypes_complex(result)
   result = win.reshape((1,) * len(batch_shape) + (1, nperseg)) * result
 
   # Perform the fft on last axis. Zero-pads automatically
   if sides == 'twosided':
+    result, = promote_dtypes_complex(result)
     return jax.numpy.fft.fft(result, n=nfft)
   else:
     return jax.numpy.fft.rfft(result.real, n=nfft)

--- a/jax/experimental/array_api/_fft_functions.py
+++ b/jax/experimental/array_api/_fft_functions.py
@@ -13,46 +13,89 @@
 # limitations under the License.
 
 import jax.numpy as jnp
+from jax._src.numpy.fft import NEEDS_COMPLEX_IN, NEEDS_REAL_IN as _NEEDS_REAL_IN
+from jax._src.numpy.util import check_arraylike
 
+NEEDS_REAL_IN = _NEEDS_REAL_IN.union({'rfft', 'rfftn', 'ihfft'})
+
+# TODO(micky774): Remove when jax.numpy.fft deprecation completes. Deprecation
+# began 4-18-24.
+def _check_input_fft(func_name: str, x):
+  check_arraylike('jax.experimental.array_api.' + func_name, x)
+  arr = jnp.asarray(x)
+  kind = arr.dtype.kind
+  suggest_alternative_msg = (
+    " or consider using a more appropriate fft function if applicable."
+  )
+  if func_name in NEEDS_COMPLEX_IN and kind != "c":
+    raise ValueError(
+      f"{func_name} requires complex-valued input, but received input with type "
+      f"{arr.dtype} instead. Please explicitly convert to a complex-valued input "
+      "first," + suggest_alternative_msg,
+    )
+  if func_name in NEEDS_REAL_IN:
+    needs_real_msg = (
+      f"{func_name} requires real-valued floating-point input, but received "
+      f"input with type {arr.dtype} instead. Please convert to a real-valued "
+      "floating-point input first"
+    )
+    if kind == "c":
+      raise ValueError(
+        needs_real_msg + ", such as by using jnp.real or jnp.imag to take the "
+        "real or imaginary components respectively," + suggest_alternative_msg,
+      )
+    elif kind != "f":
+      raise ValueError(needs_real_msg + '.')
+  return arr
 
 def fft(x, /, *, n=None, axis=-1, norm='backward'):
   """Computes the one-dimensional discrete Fourier transform."""
+  _check_input_fft('fft', x)
   return jnp.fft.fft(x, n=n, axis=axis, norm=norm)
 
 def ifft(x, /, *, n=None, axis=-1, norm='backward'):
   """Computes the one-dimensional inverse discrete Fourier transform."""
+  _check_input_fft('ifft', x)
   return jnp.fft.ifft(x, n=n, axis=axis, norm=norm)
 
 def fftn(x, /, *, s=None, axes=None, norm='backward'):
   """Computes the n-dimensional discrete Fourier transform."""
+  _check_input_fft('fftn', x)
   return jnp.fft.fftn(x, s=s, axes=axes, norm=norm)
 
 def ifftn(x, /, *, s=None, axes=None, norm='backward'):
   """Computes the n-dimensional inverse discrete Fourier transform."""
+  _check_input_fft('ifftn', x)
   return jnp.fft.ifftn(x, s=s, axes=axes, norm=norm)
 
 def rfft(x, /, *, n=None, axis=-1, norm='backward'):
   """Computes the one-dimensional discrete Fourier transform for real-valued input."""
+  _check_input_fft('rfft', x)
   return jnp.fft.rfft(x, n=n, axis=axis, norm=norm)
 
 def irfft(x, /, *, n=None, axis=-1, norm='backward'):
   """Computes the one-dimensional inverse of rfft for complex-valued input."""
+  _check_input_fft('irfft', x)
   return jnp.fft.irfft(x, n=n, axis=axis, norm=norm)
 
 def rfftn(x, /, *, s=None, axes=None, norm='backward'):
   """Computes the n-dimensional discrete Fourier transform for real-valued input."""
+  _check_input_fft('rfftn', x)
   return jnp.fft.rfftn(x, s=s, axes=axes, norm=norm)
 
 def irfftn(x, /, *, s=None, axes=None, norm='backward'):
   """Computes the n-dimensional inverse of rfftn for complex-valued input."""
+  _check_input_fft('irfftn', x)
   return jnp.fft.irfftn(x, s=s, axes=axes, norm=norm)
 
 def hfft(x, /, *, n=None, axis=-1, norm='backward'):
   """Computes the one-dimensional discrete Fourier transform of a signal with Hermitian symmetry."""
+  _check_input_fft('hfft', x)
   return jnp.fft.hfft(x, n=n, axis=axis, norm=norm)
 
 def ihfft(x, /, *, n=None, axis=-1, norm='backward'):
   """Computes the one-dimensional inverse discrete Fourier transform of a signal with Hermitian symmetry."""
+  _check_input_fft('ihfft', x)
   return jnp.fft.ihfft(x, n=n, axis=axis, norm=norm)
 
 def fftfreq(n, /, *, d=1.0, device=None):
@@ -65,8 +108,10 @@ def rfftfreq(n, /, *, d=1.0, device=None):
 
 def fftshift(x, /, *, axes=None):
   """Shift the zero-frequency component to the center of the spectrum."""
+  _check_input_fft('fftshift', x)
   return jnp.fft.fftshift(x, axes=axes)
 
 def ifftshift(x, /, *, axes=None):
   """Inverse of fftshift."""
+  _check_input_fft('ifftshift', x)
   return jnp.fft.ifftshift(x, axes=axes)

--- a/tests/jet_test.py
+++ b/tests/jet_test.py
@@ -267,7 +267,7 @@ class JetTest(jtu.JaxTestCase):
   @jtu.skip_on_devices("tpu")
   def test_abs(self):        self.unary_check(jnp.abs)
   @jtu.skip_on_devices("tpu")
-  def test_fft(self):        self.unary_check(jnp.fft.fft)
+  def test_fft(self):        self.unary_check(jnp.fft.fft, dtype=jnp.complex64)
   @jtu.skip_on_devices("tpu")
   def test_log1p(self):      self.unary_check(jnp.log1p, lims=[0, 4.])
   @jtu.skip_on_devices("tpu")

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -177,6 +177,7 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
     boundary=[None, 'even', 'odd', 'zeros'],
     padded=[True, False],
   )
+  @jax.numpy_dtype_promotion('standard')
   def testStftAgainstNumpy(self, *, shape, dtype, fs, window, nperseg,
                            noverlap, nfft, detrend, boundary, padded,
                            timeaxis):
@@ -221,6 +222,7 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
     scaling=['density', 'spectrum'],
     average=['mean'],
   )
+  @jax.numpy_dtype_promotion('standard')
   def testCsdAgainstNumpy(
       self, *, xshape, yshape, dtype, fs, window, nperseg, noverlap, nfft,
       detrend, scaling, timeaxis, average):
@@ -263,6 +265,7 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
     scaling=['density', 'spectrum'],
     average=['mean'],
   )
+  @jax.numpy_dtype_promotion('standard')
   def testCsdWithSameParamAgainstNumpy(
       self, *, shape, dtype, fs, window, nperseg, noverlap, nfft,
       detrend, scaling, timeaxis, average):
@@ -308,6 +311,7 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
     scaling=['density', 'spectrum'],
     average=['mean', 'median'],
   )
+  @jax.numpy_dtype_promotion('standard')
   def testWelchAgainstNumpy(self, *, shape, dtype, fs, window, nperseg,
                             noverlap, nfft, detrend, return_onesided,
                             scaling, timeaxis, average):
@@ -347,6 +351,7 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
     use_noverlap=[False, True],
     dtype=jtu.dtypes.floating + jtu.dtypes.integer,
   )
+  @jax.numpy_dtype_promotion('standard')
   def testWelchWithDefaultStepArgsAgainstNumpy(
       self, *, shape, dtype, nperseg, noverlap, use_nperseg, use_noverlap,
       use_window, timeaxis):


### PR DESCRIPTION
Towards #20200

Array API 2023 [changelog](https://data-apis.org/array-api/latest/changelog.html#id2). 

Updates the `jax.numpy.fft` namespace to begin a deprecation of implicitly converted inputs -- explicitly sets `fft` function domains to either `real floating` or `complex`, warning on implicit conversion (i.e. `fft(x: float32)`, `rfft(x: int32)`, etc.).

Updates the `jax.experimental.array_api.fft` namespace with corresponding changes which directly raise `ValueError`, marked with deprecation once `jax.numpy.fft` is array API compliant.

Adds corresponding tests for both modules.

Updates dtype coverage in `tests/fft_test.py` to reflect new restricted domains.