### PR TITLE
Minor formatting fix for `jax.nn.one_hot` docstring

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -667,7 +667,7 @@ def one_hot(x: Any, num_classes: int, *,
            [0., 1., 0.],
            [0., 0., 1.]], dtype=float32)
 
-  Indices outside the range [0, num_classes) will be encoded as zeros::
+  Indices outside the range ``[0, num_classes)`` will be encoded as zeros::
 
     >>> jax.nn.one_hot(jnp.array([-1, 3]), 3)
     Array([[0., 0., 0.],


### PR DESCRIPTION
Adds minor code formatting to the `jax.nn.one_hot` so that it is self-consistent.