### PR TITLE
Add support for rounding integers with `decimals<0` in `jnp.round`

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1364,9 +1364,12 @@ def round(a: ArrayLike, decimals: int = 0, out: None = None) -> Array:
   dtype = _dtype(a)
   if issubdtype(dtype, integer):
     if decimals < 0:
-      raise NotImplementedError(
-        "integer np.round not implemented for decimals < 0")
-    return asarray(a)  # no-op on integer types
+      a = lax.convert_element_type(a, dtypes.canonicalize_dtype(float_))
+      factor = _lax_const(a, 10 ** decimals)
+      a = lax.div(lax.round(lax.mul(a, factor),
+                            lax.RoundingMethod.TO_NEAREST_EVEN), factor)
+      a = lax.convert_element_type(a, dtype)
+    return asarray(a)  # no-op on integer types if decimals >= 0
 
   def _round_float(x: ArrayLike) -> Array:
     if decimals == 0:

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -964,8 +964,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   )
   def testRoundStaticDecimals(self, shape, dtype, decimals):
     rng = jtu.rand_default(self.rng())
-    if jnp.issubdtype(dtype, np.integer) and decimals < 0:
-      self.skipTest("Integer rounding with decimals < 0 not implemented")
     np_fun = lambda x: np.round(x, decimals=decimals)
     jnp_fun = lambda x: jnp.round(x, decimals=decimals)
     args_maker = lambda: [rng(shape, dtype)]


### PR DESCRIPTION
Is it intended to raise an error when the input is an integer with `decimals<0`?
If not, we can support it in the same way as in numpy.

However, I'm unsure if it is acceptable to use `dtypes.canonicalize_dtype(float_)` for the rescaling.
