### PR TITLE
Refactored common upcast for integral-type accumulators 

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3364,13 +3364,6 @@ def trace(a: ArrayLike, offset: int = 0, axis1: int = 0, axis2: int = 1,
   dtypes.check_user_dtype_supported(dtype, "trace")
 
   a_shape = shape(a)
-  if dtype is None:
-    dtype = _dtype(a)
-    if issubdtype(dtype, integer):
-      default_int = dtypes.canonicalize_dtype(int)
-      if iinfo(dtype).bits < iinfo(default_int).bits:
-        dtype = default_int
-
   a = moveaxis(a, (axis1, axis2), (-2, -1))
 
   # Mask out the diagonal and reduce.

--- a/jax/experimental/array_api/_data_type_functions.py
+++ b/jax/experimental/array_api/_data_type_functions.py
@@ -76,18 +76,3 @@ def finfo(type, /) -> FInfo:
     smallest_normal=float(info.smallest_normal),
     dtype=jnp.dtype(type)
   )
-
-# TODO(micky774): Update utility to only promote integral types
-def _promote_to_default_dtype(x):
-  if x.dtype.kind == 'b':
-    return x
-  elif x.dtype.kind == 'i':
-    return x.astype(jnp.int_)
-  elif x.dtype.kind == 'u':
-    return x.astype(jnp.uint)
-  elif x.dtype.kind == 'f':
-    return x.astype(jnp.float_)
-  elif x.dtype.kind == 'c':
-    return x.astype(jnp.complex_)
-  else:
-    raise ValueError(f"Unrecognized {x.dtype=}")

--- a/tests/lax_numpy_reducers_test.py
+++ b/tests/lax_numpy_reducers_test.py
@@ -791,13 +791,8 @@ class JaxNumpyReducerTests(jtu.JaxTestCase):
     rng = jtu.rand_some_zero(self.rng())
 
     def np_mock_op(x, axis=None, dtype=None, include_initial=False):
-      kind = x.dtype.kind
-      if (dtype is None and kind in {'i', 'u'}
-          and x.dtype.itemsize*8 < int(config.default_dtype_bits.value)):
-        dtype = dtypes.canonicalize_dtype(dtypes._default_types[kind])
       axis = axis or 0
-      x = x.astype(dtype=dtype or x.dtype)
-      out = jnp.cumsum(x, axis=axis)
+      out = np.cumsum(x, axis=axis, dtype=dtype or x.dtype)
       if include_initial:
         zeros_shape = list(x.shape)
         zeros_shape[axis] = 1


### PR DESCRIPTION
Towards https://github.com/google/jax/issues/20200

This PR refactors integer accumulator promotion from `jax._src.numpy.reductions._reduction` and applies it to `_make_cumulative_reduction` as well.

Temporarily disables tests for `prod`, `sum`, and `trace` since the 2023 API included breaking changes which are not yet accounted for in the tests repository.