### PR TITLE
jax.scipy.stats: manually document functions to avoid scipy import

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -395,6 +395,7 @@ jax.scipy.stats.poisson
 
    logpmf
    pmf
+   cdf
 
 jax.scipy.stats.t
 ~~~~~~~~~~~~~~~~~

--- a/jax/_src/scipy/stats/bernoulli.py
+++ b/jax/_src/scipy/stats/bernoulli.py
@@ -12,19 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import scipy.stats as osp_stats
-
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 from jax.scipy.special import xlogy, xlog1py
 
 
-@implements(osp_stats.bernoulli.logpmf, update_doc=False)
 def logpmf(k: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
+  r"""Bernoulli log probability mass function.
+
+  JAX implementation of :obj:`scipy.stats.bernoulli` ``logpmf``
+
+  The Bernoulli probablility mass function is defined as
+
+  .. math::
+
+     f(k) = \begin{cases}
+       1 - p, & k = 0 \\
+       p, & k = 1 \\
+       0, & \mathrm{otherwise}
+     \end{cases}
+
+  Args:
+    k: arraylike, value at which to evaluate the PMF
+    p: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset
+
+  Returns:
+    array of logpmf values
+
+  See Also:
+    - :func:`jax.scipy.stats.bernoulli.cdf`
+    - :func:`jax.scipy.stats.bernoulli.pmf`
+    - :func:`jax.scipy.stats.bernoulli.ppf`
+  """
   k, p, loc = promote_args_inexact("bernoulli.logpmf", k, p, loc)
   zero = _lax_const(k, 0)
   one = _lax_const(k, 1)
@@ -33,12 +56,65 @@ def logpmf(k: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
   return jnp.where(jnp.logical_or(lax.lt(x, zero), lax.gt(x, one)),
                   -jnp.inf, log_probs)
 
-@implements(osp_stats.bernoulli.pmf, update_doc=False)
+
 def pmf(k: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
+  r"""Bernoulli probability mass function.
+
+  JAX implementation of :obj:`scipy.stats.bernoulli` ``pmf``
+
+  The Bernoulli probablility mass function is defined as
+
+  .. math::
+
+     f(k) = \begin{cases}
+       1 - p, & k = 0 \\
+       p, & k = 1 \\
+       0, & \mathrm{otherwise}
+     \end{cases}
+
+  Args:
+    k: arraylike, value at which to evaluate the PMF
+    p: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset
+
+  Returns:
+    array of pmf values
+
+  See Also:
+    - :func:`jax.scipy.stats.bernoulli.cdf`
+    - :func:`jax.scipy.stats.bernoulli.logpmf`
+    - :func:`jax.scipy.stats.bernoulli.ppf`
+  """
   return jnp.exp(logpmf(k, p, loc))
 
-@implements(osp_stats.bernoulli.cdf, update_doc=False)
+
 def cdf(k: ArrayLike, p: ArrayLike) -> Array:
+  r"""Bernoulli cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.bernoulli` ``cdf``
+
+  The Bernoulli cumulative distribution function is defined as:
+
+  .. math::
+
+     f_{cdf}(k, p) = \sum_{i=0}^k f_{pmf}(k, p)
+
+  where :math:`f_{pmf}(k, p)` is the Bernoulli probability mass function
+  :func:`jax.scipy.stats.bernoulli.pmf`.
+
+  Args:
+    k: arraylike, value at which to evaluate the CDF
+    p: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset
+
+  Returns:
+    array of cdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.bernoulli.logpmf`
+    - :func:`jax.scipy.stats.bernoulli.pmf`
+    - :func:`jax.scipy.stats.bernoulli.ppf`
+  """
   k, p = promote_args_inexact('bernoulli.cdf', k, p)
   zero, one = _lax_const(k, 0), _lax_const(k, 1)
   conds = [
@@ -50,8 +126,28 @@ def cdf(k: ArrayLike, p: ArrayLike) -> Array:
   vals = [jnp.nan, zero, one - p, one]
   return jnp.select(conds, vals)
 
-@implements(osp_stats.bernoulli.ppf, update_doc=False)
+
 def ppf(q: ArrayLike, p: ArrayLike) -> Array:
+  """Bernoulli percent point function.
+
+  JAX implementation of :obj:`scipy.stats.bernoulli` ``ppf``
+
+  The percent point function is the inverse of the cumulative
+  distribution function, :func:`jax.scipy.stats.bernoulli.cdf`.
+
+  Args:
+    k: arraylike, value at which to evaluate the PPF
+    p: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset
+
+  Returns:
+    array of ppf values
+
+  See Also:
+    - :func:`jax.scipy.stats.bernoulli.cdf`
+    - :func:`jax.scipy.stats.bernoulli.logpmf`
+    - :func:`jax.scipy.stats.bernoulli.pmf`
+  """
   q, p = promote_args_inexact('bernoulli.ppf', q, p)
   zero, one = _lax_const(q, 0), _lax_const(q, 1)
   return jnp.where(

--- a/jax/_src/scipy/stats/beta.py
+++ b/jax/_src/scipy/stats/beta.py
@@ -12,19 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import scipy.stats as osp_stats
-
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 from jax.scipy.special import betaln, betainc, xlogy, xlog1py
 
 
-@implements(osp_stats.beta.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, a: ArrayLike, b: ArrayLike,
            loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Beta log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.beta` ``logpdf``.
+
+  The pdf of the beta function is:
+
+  .. math::
+
+    f(x, a, b) = \frac{\Gamma(a + b)}{\Gamma(a)\Gamma(b)} x^{a-1}(1-x)^{b-1}
+
+  where :math:`\Gamma` is the :func:`~jax.scipy.special.gamma` function,
+  It is defined for :math:`0\le x\le 1` and :math:`b>0`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    a: arraylike, distribution shape parameter
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logpdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.beta.cdf`
+    - :func:`jax.scipy.stats.beta.pdf`
+    - :func:`jax.scipy.stats.beta.sf`
+    - :func:`jax.scipy.stats.beta.logcdf`
+    - :func:`jax.scipy.stats.beta.logsf`
+  """
   x, a, b, loc, scale = promote_args_inexact("beta.logpdf", x, a, b, loc, scale)
   one = _lax_const(x, 1)
   zero = _lax_const(a, 0)
@@ -40,15 +67,73 @@ def logpdf(x: ArrayLike, a: ArrayLike, b: ArrayLike,
   return result_positive_constants
 
 
-@implements(osp_stats.beta.pdf, update_doc=False)
 def pdf(x: ArrayLike, a: ArrayLike, b: ArrayLike,
         loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Beta probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.beta` ``pdf``.
+
+  The pdf of the beta function is:
+
+  .. math::
+
+    f(x, a, b) = \frac{\Gamma(a + b)}{\Gamma(a)\Gamma(b)} x^{a-1}(1-x)^{b-1}
+
+  where :math:`\Gamma` is the :func:`~jax.scipy.special.gamma` function.
+  It is defined for :math:`0\le x\le 1` and :math:`b>0`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    a: arraylike, distribution shape parameter
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of pdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.beta.cdf`
+    - :func:`jax.scipy.stats.beta.sf`
+    - :func:`jax.scipy.stats.beta.logcdf`
+    - :func:`jax.scipy.stats.beta.logpdf`
+    - :func:`jax.scipy.stats.beta.logsf`
+  """
   return lax.exp(logpdf(x, a, b, loc, scale))
 
 
-@implements(osp_stats.beta.cdf, update_doc=False)
 def cdf(x: ArrayLike, a: ArrayLike, b: ArrayLike,
         loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Beta cumulative distribution function
+
+  JAX implementation of :obj:`scipy.stats.beta` ``cdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf}(x, a, b) = \int_{-\infty}^x f_{pdf}(y, a, b)\mathrm{d}y
+
+  where :math:`f_{pdf}` is the beta distribution probability density function,
+  :func:`jax.scipy.stats.beta.pdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    a: arraylike, distribution shape parameter
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of cdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.beta.pdf`
+    - :func:`jax.scipy.stats.beta.sf`
+    - :func:`jax.scipy.stats.beta.logcdf`
+    - :func:`jax.scipy.stats.beta.logpdf`
+    - :func:`jax.scipy.stats.beta.logsf`
+  """
   x, a, b, loc, scale = promote_args_inexact("beta.cdf", x, a, b, loc, scale)
   return betainc(
     a,
@@ -61,15 +146,73 @@ def cdf(x: ArrayLike, a: ArrayLike, b: ArrayLike,
   )
 
 
-@implements(osp_stats.beta.logcdf, update_doc=False)
 def logcdf(x: ArrayLike, a: ArrayLike, b: ArrayLike,
            loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Beta log cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.beta` ``logcdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf}(x, a, b) = \int_{-\infty}^x f_{pdf}(y, a, b)\mathrm{d}y
+
+  where :math:`f_{pdf}` is the beta distribution probability density function,
+  :func:`jax.scipy.stats.beta.pdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    a: arraylike, distribution shape parameter
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logcdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.beta.cdf`
+    - :func:`jax.scipy.stats.beta.pdf`
+    - :func:`jax.scipy.stats.beta.sf`
+    - :func:`jax.scipy.stats.beta.logpdf`
+    - :func:`jax.scipy.stats.beta.logsf`
+  """
   return lax.log(cdf(x, a, b, loc, scale))
 
 
-@implements(osp_stats.beta.sf, update_doc=False)
 def sf(x: ArrayLike, a: ArrayLike, b: ArrayLike,
        loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Beta distribution survival function.
+
+  JAX implementation of :obj:`scipy.stats.beta` ``sf``.
+
+  The survival function is defined as
+
+  .. math::
+
+     f_{sf}(x, a, b) = 1 - f_{cdf}(x, a, b)
+
+  where :math:`f_{cdf}(x, a, b)` is the beta cumulative distribution function,
+  :func:`jax.scipy.stats.beta.cdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the SF
+    a: arraylike, distribution shape parameter
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of sf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.beta.cdf`
+    - :func:`jax.scipy.stats.beta.pdf`
+    - :func:`jax.scipy.stats.beta.logcdf`
+    - :func:`jax.scipy.stats.beta.logpdf`
+    - :func:`jax.scipy.stats.beta.logsf`
+  """
   x, a, b, loc, scale = promote_args_inexact("beta.sf", x, a, b, loc, scale)
   return betainc(
     b,
@@ -82,7 +225,36 @@ def sf(x: ArrayLike, a: ArrayLike, b: ArrayLike,
   )
 
 
-@implements(osp_stats.beta.logsf, update_doc=False)
 def logsf(x: ArrayLike, a: ArrayLike, b: ArrayLike,
           loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Beta distribution log survival function.
+
+  JAX implementation of :obj:`scipy.stats.beta` ``logsf``.
+
+  The survival function is defined as
+
+  .. math::
+
+     f_{sf}(x, a, b) = 1 - f_{cdf}(x, a, b)
+
+  where :math:`f_{cdf}(x, a, b)` is the beta cumulative distribution function,
+  :func:`jax.scipy.stats.beta.cdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the SF
+    a: arraylike, distribution shape parameter
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logsf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.beta.cdf`
+    - :func:`jax.scipy.stats.beta.pdf`
+    - :func:`jax.scipy.stats.beta.sf`
+    - :func:`jax.scipy.stats.beta.logcdf`
+    - :func:`jax.scipy.stats.beta.logpdf`
+  """
   return lax.log(sf(x, a, b, loc, scale))

--- a/jax/_src/scipy/stats/betabinom.py
+++ b/jax/_src/scipy/stats/betabinom.py
@@ -12,21 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-
-import scipy.stats as osp_stats
-
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.scipy.special import betaln
 from jax._src.typing import Array, ArrayLike
 
 
-@implements(osp_stats.betabinom.logpmf, update_doc=False)
 def logpmf(k: ArrayLike, n: ArrayLike, a: ArrayLike, b: ArrayLike,
            loc: ArrayLike = 0) -> Array:
-  """JAX implementation of scipy.stats.betabinom.logpmf."""
+  r"""Beta-binomial log probability mass function.
+
+  JAX implementation of :obj:`scipy.stats.betabinom` ``logpmf``
+
+  The beta-binomial distribution's probability mass function is defined as
+
+  .. math::
+
+     f(k, n, a, b) = {n \choose k}\frac{B(k+a,n-k-b)}{B(a,b)}
+
+  where :math:`B(a, b)` is the :func:`~jax.scipy.special.beta` function. It is
+  defined for :math:`n\ge 0`, :math:`a>0`, :math:`b>0`, and non-negative integers `k`.
+
+  Args:
+    k: arraylike, value at which to evaluate the PMF
+    n: arraylike, distribution shape parameter
+    a: arraylike, distribution shape parameter
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+
+  Returns:
+    array of logpmf values
+
+  See Also:
+    :func:`jax.scipy.stats.betabinom.pmf`
+  """
   k, n, a, b, loc = promote_args_inexact("betabinom.logpmf", k, n, a, b, loc)
   y = lax.sub(lax.floor(k), loc)
   one = _lax_const(y, 1)
@@ -40,8 +61,32 @@ def logpmf(k: ArrayLike, n: ArrayLike, a: ArrayLike, b: ArrayLike,
   return jnp.where(n_a_b_cond, jnp.nan, log_probs)
 
 
-@implements(osp_stats.betabinom.pmf, update_doc=False)
 def pmf(k: ArrayLike, n: ArrayLike, a: ArrayLike, b: ArrayLike,
         loc: ArrayLike = 0) -> Array:
-  """JAX implementation of scipy.stats.betabinom.pmf."""
+  r"""Beta-binomial probability mass function.
+
+  JAX implementation of :obj:`scipy.stats.betabinom` ``pmf``.
+
+  The beta-binomial distribution's probability mass function is defined as
+
+  .. math::
+
+     f(k, n, a, b) = {n \choose k}\frac{B(k+a,n-k-b)}{B(a,b)}
+
+  where :math:`B(a, b)` is the :func:`~jax.scipy.special.beta` function. It is
+  defined for :math:`n\ge 0`, :math:`a>0`, :math:`b>0`, and non-negative integers `k`.
+
+  Args:
+    k: arraylike, value at which to evaluate the PMF
+    n: arraylike, distribution shape parameter
+    a: arraylike, distribution shape parameter
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+
+  Returns:
+    array of pmf values
+
+  See Also:
+    :func:`jax.scipy.stats.betabinom.logpmf`
+  """
   return lax.exp(logpmf(k, n, a, b, loc))

--- a/jax/_src/scipy/stats/binom.py
+++ b/jax/_src/scipy/stats/binom.py
@@ -12,31 +12,72 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-
-import scipy.stats as osp_stats
-
 from jax import lax
 import jax.numpy as jnp
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.scipy.special import gammaln, xlogy, xlog1py
 from jax._src.typing import Array, ArrayLike
 
 
-@implements(osp_stats.nbinom.logpmf, update_doc=False)
 def logpmf(k: ArrayLike, n: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
-    """JAX implementation of scipy.stats.binom.logpmf."""
-    k, n, p, loc = promote_args_inexact("binom.logpmf", k, n, p, loc)
-    y = lax.sub(k, loc)
-    comb_term = lax.sub(
-        gammaln(n + 1),
-        lax.add(gammaln(y + 1), gammaln(n - y + 1))
-    )
-    log_linear_term = lax.add(xlogy(y, p), xlog1py(lax.sub(n, y), lax.neg(p)))
-    log_probs = lax.add(comb_term, log_linear_term)
-    return jnp.where(lax.ge(k, loc) & lax.lt(k, loc + n + 1), log_probs, -jnp.inf)
+  r"""Binomial log probability mass function.
+
+  JAX implementation of :obj:`scipy.stats.binom` ``logpmf``.
+
+  The binomial probability mass function is defined as
+
+  .. math::
+
+     f(k, n, p) = {n \choose k}p^k(1-p)^{n-k}
+
+  for :math:`0\le p\le 1` and non-negative integers :math:`k`.
+
+  Args:
+    k: arraylike, value at which to evaluate the PMF
+    n: arraylike, distribution shape parameter
+    p: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+
+  Returns:
+    array of logpmf values.
+
+  See Also:
+    :func:`jax.scipy.stats.binom.pmf`
+  """
+  k, n, p, loc = promote_args_inexact("binom.logpmf", k, n, p, loc)
+  y = lax.sub(k, loc)
+  comb_term = lax.sub(
+      gammaln(n + 1),
+      lax.add(gammaln(y + 1), gammaln(n - y + 1))
+  )
+  log_linear_term = lax.add(xlogy(y, p), xlog1py(lax.sub(n, y), lax.neg(p)))
+  log_probs = lax.add(comb_term, log_linear_term)
+  return jnp.where(lax.ge(k, loc) & lax.lt(k, loc + n + 1), log_probs, -jnp.inf)
 
 
-@implements(osp_stats.nbinom.pmf, update_doc=False)
 def pmf(k: ArrayLike, n: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
-    """JAX implementation of scipy.stats.binom.pmf."""
-    return lax.exp(logpmf(k, n, p, loc))
+  r"""Binomial probability mass function.
+
+  JAX implementation of :obj:`scipy.stats.binom` ``pmf``.
+
+  The binomial probability mass function is defined as
+
+  .. math::
+
+     f(k, n, p) = {n \choose k}p^k(1-p)^{n-k}
+
+  for :math:`0\le p\le 1` and non-negative integers :math:`k`.
+
+  Args:
+    k: arraylike, value at which to evaluate the PMF
+    n: arraylike, distribution shape parameter
+    p: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+
+  Returns:
+      array of pmf values.
+
+  See Also:
+    :func:`jax.scipy.stats.binom.logpmf`
+  """
+  return lax.exp(logpmf(k, n, p, loc))

--- a/jax/_src/scipy/stats/cauchy.py
+++ b/jax/_src/scipy/stats/cauchy.py
@@ -14,17 +14,42 @@
 
 
 import numpy as np
-import scipy.stats as osp_stats
 
 from jax import lax
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax.numpy import arctan
 from jax._src.typing import Array, ArrayLike
 
 
-@implements(osp_stats.cauchy.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Cauchy log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.cauchy` ``logpdf``.
+
+  The Cauchy probability distribution function is
+
+  .. math::
+
+     f(x) = \frac{1}{\pi(1 + x^2)}
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logpdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.cauchy.cdf`
+    - :func:`jax.scipy.stats.cauchy.pdf`
+    - :func:`jax.scipy.stats.cauchy.sf`
+    - :func:`jax.scipy.stats.cauchy.logcdf`
+    - :func:`jax.scipy.stats.cauchy.logsf`
+    - :func:`jax.scipy.stats.cauchy.isf`
+    - :func:`jax.scipy.stats.cauchy.ppf`
+  """
   x, loc, scale = promote_args_inexact("cauchy.logpdf", x, loc, scale)
   pi = _lax_const(x, np.pi)
   scaled_x = lax.div(lax.sub(x, loc), scale)
@@ -32,39 +57,203 @@ def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   return lax.neg(lax.add(normalize_term, lax.log1p(lax.mul(scaled_x, scaled_x))))
 
 
-@implements(osp_stats.cauchy.pdf, update_doc=False)
 def pdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Cauchy probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.cauchy` ``pdf``.
+
+  The Cauchy probability distribution function is
+
+  .. math::
+
+     f(x) = \frac{1}{\pi(1 + x^2)}
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of pdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.cauchy.cdf`
+    - :func:`jax.scipy.stats.cauchy.sf`
+    - :func:`jax.scipy.stats.cauchy.logcdf`
+    - :func:`jax.scipy.stats.cauchy.logpdf`
+    - :func:`jax.scipy.stats.cauchy.logsf`
+    - :func:`jax.scipy.stats.cauchy.isf`
+    - :func:`jax.scipy.stats.cauchy.ppf`
+  """
   return lax.exp(logpdf(x, loc, scale))
 
 
-
-@implements(osp_stats.cauchy.cdf, update_doc=False)
 def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Cauchy cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.cauchy` ``cdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf} = \int_{-\infty}^x f_{pdf}(y) \mathrm{d}y
+
+  where here :math:`f_{pdf}` is the Cauchy probability distribution function,
+  :func:`jax.scipy.stats.cauchy.pdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of cdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.cauchy.pdf`
+    - :func:`jax.scipy.stats.cauchy.sf`
+    - :func:`jax.scipy.stats.cauchy.logcdf`
+    - :func:`jax.scipy.stats.cauchy.logpdf`
+    - :func:`jax.scipy.stats.cauchy.logsf`
+    - :func:`jax.scipy.stats.cauchy.isf`
+    - :func:`jax.scipy.stats.cauchy.ppf`
+  """
   x, loc, scale = promote_args_inexact("cauchy.cdf", x, loc, scale)
   pi = _lax_const(x, np.pi)
   scaled_x = lax.div(lax.sub(x, loc), scale)
   return lax.add(_lax_const(x, 0.5), lax.mul(lax.div(_lax_const(x, 1.), pi), arctan(scaled_x)))
 
 
-@implements(osp_stats.cauchy.logcdf, update_doc=False)
 def logcdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Cauchy log cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.cauchy` ``logcdf``
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf} = \int_{-\infty}^x f_{pdf}(y) \mathrm{d}y
+
+  where here :math:`f_{pdf}` is the Cauchy probability distribution function,
+  :func:`jax.scipy.stats.cauchy.pdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logcdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.cauchy.cdf`
+    - :func:`jax.scipy.stats.cauchy.pdf`
+    - :func:`jax.scipy.stats.cauchy.sf`
+    - :func:`jax.scipy.stats.cauchy.logpdf`
+    - :func:`jax.scipy.stats.cauchy.logsf`
+    - :func:`jax.scipy.stats.cauchy.isf`
+    - :func:`jax.scipy.stats.cauchy.ppf`
+  """
   return lax.log(cdf(x, loc, scale))
 
 
-@implements(osp_stats.cauchy.sf, update_doc=False)
 def sf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Cauchy distribution log survival function.
+
+  JAX implementation of :obj:`scipy.stats.cauchy` ``sf``.
+
+  The survival function is defined as
+
+  .. math::
+
+     f_{sf}(x) = 1 - f_{cdf}(x)
+
+  where :math:`f_{cdf}(x)` is the cumulative distribution function,
+  :func:`jax.scipy.stats.cauchy.cdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the SF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of sf values
+
+  See Also:
+    - :func:`jax.scipy.stats.cauchy.cdf`
+    - :func:`jax.scipy.stats.cauchy.pdf`
+    - :func:`jax.scipy.stats.cauchy.logcdf`
+    - :func:`jax.scipy.stats.cauchy.logpdf`
+    - :func:`jax.scipy.stats.cauchy.logsf`
+    - :func:`jax.scipy.stats.cauchy.isf`
+    - :func:`jax.scipy.stats.cauchy.ppf`
+  """
   x, loc, scale = promote_args_inexact("cauchy.sf", x, loc, scale)
   return cdf(-x, -loc, scale)
 
 
-@implements(osp_stats.cauchy.logsf, update_doc=False)
 def logsf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Cauchy distribution log survival function.
+
+  JAX implementation of :obj:`scipy.stats.cauchy` ``logsf``
+
+  The survival function is defined as
+
+  .. math::
+
+     f_{sf}(x) = 1 - f_{cdf}(x)
+
+  where :math:`f_{cdf}(x)` is the cumulative distribution function,
+  :func:`jax.scipy.stats.cauchy.cdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the SF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logsf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.cauchy.cdf`
+    - :func:`jax.scipy.stats.cauchy.pdf`
+    - :func:`jax.scipy.stats.cauchy.sf`
+    - :func:`jax.scipy.stats.cauchy.logcdf`
+    - :func:`jax.scipy.stats.cauchy.logpdf`
+    - :func:`jax.scipy.stats.cauchy.isf`
+    - :func:`jax.scipy.stats.cauchy.ppf`
+  """
   x, loc, scale = promote_args_inexact("cauchy.logsf", x, loc, scale)
   return logcdf(-x, -loc, scale)
 
 
-@implements(osp_stats.cauchy.isf, update_doc=False)
 def isf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Cauchy distribution inverse survival function.
+
+  JAX implementation of :obj:`scipy.stats.cauchy` ``isf``.
+
+  Returns the inverse of the survival function,
+  :func:`jax.scipy.stats.cauchy.sf`.
+
+  Args:
+    q: arraylike, value at which to evaluate the ISF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of isf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.cauchy.cdf`
+    - :func:`jax.scipy.stats.cauchy.pdf`
+    - :func:`jax.scipy.stats.cauchy.sf`
+    - :func:`jax.scipy.stats.cauchy.logcdf`
+    - :func:`jax.scipy.stats.cauchy.logpdf`
+    - :func:`jax.scipy.stats.cauchy.logsf`
+    - :func:`jax.scipy.stats.cauchy.ppf`
+  """
   q, loc, scale = promote_args_inexact("cauchy.isf", q, loc, scale)
   pi = _lax_const(q, np.pi)
   half_pi = _lax_const(q, np.pi / 2)
@@ -72,8 +261,31 @@ def isf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   return lax.add(lax.mul(unscaled, scale), loc)
 
 
-@implements(osp_stats.cauchy.ppf, update_doc=False)
 def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Cauchy distribution percent point function.
+
+  JAX implementation of :obj:`scipy.stats.cauchy` ``ppf``.
+
+  The percent point function is defined as the inverse of the
+  cumulative distribution function, :func:`jax.scipy.stats.cauchy.cdf`.
+
+  Args:
+    q: arraylike, value at which to evaluate the PPF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of ppf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.cauchy.cdf`
+    - :func:`jax.scipy.stats.cauchy.pdf`
+    - :func:`jax.scipy.stats.cauchy.sf`
+    - :func:`jax.scipy.stats.cauchy.logcdf`
+    - :func:`jax.scipy.stats.cauchy.logpdf`
+    - :func:`jax.scipy.stats.cauchy.logsf`
+    - :func:`jax.scipy.stats.cauchy.isf`
+  """
   q, loc, scale = promote_args_inexact("cauchy.ppf", q, loc, scale)
   pi = _lax_const(q, np.pi)
   half_pi = _lax_const(q, np.pi / 2)

--- a/jax/_src/scipy/stats/chi2.py
+++ b/jax/_src/scipy/stats/chi2.py
@@ -12,19 +12,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-
-import scipy.stats as osp_stats
-
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 from jax.scipy.special import gammainc, gammaincc
 
 
-@implements(osp_stats.chi2.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Chi-square log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.chi2` ``logpdf``.
+
+  The chi-square probability distribution function is given by:
+
+  .. math::
+
+     f(x, k) = \begin{cases}
+       \frac{x^{k/2-1}e^{-x/2}}{2^{k/2}\Gamma(k/2)} & x \ge 0 \\
+       0 & \mathrm{otherwise}
+     \end{cases}
+
+  for :math:`k` degrees of freedom, and where :math:`\Gamma` is the
+  :func:`~jax.scipy.special.gamma` function. JAX follows the scipy
+  convention of using ``df`` to denote degrees of freedom.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    df: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.chi2.cdf`
+    - :func:`jax.scipy.stats.chi2.pdf`
+    - :func:`jax.scipy.stats.chi2.sf`
+    - :func:`jax.scipy.stats.chi2.logcdf`
+    - :func:`jax.scipy.stats.chi2.logsf`
+  """
   x, df, loc, scale = promote_args_inexact("chi2.logpdf", x, df, loc, scale)
   one = _lax_const(x, 1)
   two = _lax_const(x, 2)
@@ -38,13 +67,75 @@ def logpdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1
   log_probs = lax.add(lax.sub(nrml_cnst, lax.log(scale)), kernel)
   return jnp.where(lax.lt(x, loc), -jnp.inf, log_probs)
 
-@implements(osp_stats.chi2.pdf, update_doc=False)
+
 def pdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Chi-square probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.chi2` ``pdf``.
+
+  The chi-square probability distribution function is given by:
+
+  .. math::
+
+     f(x, k) = \begin{cases}
+       \frac{x^{k/2-1}e^{-x/2}}{2^{k/2}\Gamma(k/2)} & x \ge 0 \\
+       0 & \mathrm{otherwise}
+     \end{cases}
+
+  for :math:`k` degrees of freedom, and where :math:`\Gamma` is the
+  :func:`~jax.scipy.special.gamma` function. JAX follows the scipy
+  convention of using ``df`` to denote degrees of freedom.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    df: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of pdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.chi2.cdf`
+    - :func:`jax.scipy.stats.chi2.sf`
+    - :func:`jax.scipy.stats.chi2.logcdf`
+    - :func:`jax.scipy.stats.chi2.logpdf`
+    - :func:`jax.scipy.stats.chi2.logsf`
+  """
   return lax.exp(logpdf(x, df, loc, scale))
 
 
-@implements(osp_stats.chi2.cdf, update_doc=False)
 def cdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Chi-square cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.chi2` ``cdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf}(x, k) = \int_{-\infty}^x f_{pdf}(y, k)\mathrm{d}y
+
+  where :math:`f_{pdf}` is the probability density function,
+  :func:`jax.scipy.stats.chi2.pdf`. JAX follows the scipy
+  convention of using ``df`` to denote degrees of freedom.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    df: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of cdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.chi2.pdf`
+    - :func:`jax.scipy.stats.chi2.sf`
+    - :func:`jax.scipy.stats.chi2.logcdf`
+    - :func:`jax.scipy.stats.chi2.logpdf`
+    - :func:`jax.scipy.stats.chi2.logsf`
+  """
   x, df, loc, scale = promote_args_inexact("chi2.cdf", x, df, loc, scale)
   two = _lax_const(scale, 2)
   return gammainc(
@@ -60,13 +151,71 @@ def cdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -
   )
 
 
-@implements(osp_stats.chi2.logcdf, update_doc=False)
 def logcdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Chi-square log cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.chi2` ``logcdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf}(x, k) = \int_{-\infty}^x f_{pdf}(y, k)\mathrm{d}y
+
+  where :math:`f_{pdf}` is the probability density function,
+  :func:`jax.scipy.stats.chi2.pdf`. JAX follows the scipy
+  convention of using ``df`` to denote degrees of freedom.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    df: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logcdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.chi2.cdf`
+    - :func:`jax.scipy.stats.chi2.pdf`
+    - :func:`jax.scipy.stats.chi2.sf`
+    - :func:`jax.scipy.stats.chi2.logpdf`
+    - :func:`jax.scipy.stats.chi2.logsf`
+  """
   return lax.log(cdf(x, df, loc, scale))
 
 
-@implements(osp_stats.chi2.sf, update_doc=False)
 def sf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Chi-square survival function.
+
+  JAX implementation of :obj:`scipy.stats.chi2` ``sf``.
+
+  The survival function is defined as
+
+  .. math::
+
+     f_{sf}(x, k) = 1 - f_{cdf}(x, k)
+
+  where :math:`f_{cdf}(x, k)` is the cumulative distribution function,
+  :func:`jax.scipy.stats.chi2.cdf`. JAX follows the scipy
+  convention of using ``df`` to denote degrees of freedom.
+
+  Args:
+    x: arraylike, value at which to evaluate the SF
+    df: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of sf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.chi2.cdf`
+    - :func:`jax.scipy.stats.chi2.pdf`
+    - :func:`jax.scipy.stats.chi2.logcdf`
+    - :func:`jax.scipy.stats.chi2.logpdf`
+    - :func:`jax.scipy.stats.chi2.logsf`
+  """
   x, df, loc, scale = promote_args_inexact("chi2.sf", x, df, loc, scale)
   two = _lax_const(scale, 2)
   return gammaincc(
@@ -82,6 +231,35 @@ def sf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) ->
   )
 
 
-@implements(osp_stats.chi2.logsf, update_doc=False)
 def logsf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Chi-square log survival function.
+
+  JAX implementation of :obj:`scipy.stats.chi2` ``logsf``.
+
+  The survival function is defined as
+
+  .. math::
+
+     f_{sf}(x, k) = 1 - f_{cdf}(x, k)
+
+  where :math:`f_{cdf}(x, k)` is the cumulative distribution function,
+  :func:`jax.scipy.stats.chi2.cdf`. JAX follows the scipy
+  convention of using ``df`` to denote degrees of freedom.
+
+  Args:
+    x: arraylike, value at which to evaluate the SF
+    df: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logsf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.chi2.cdf`
+    - :func:`jax.scipy.stats.chi2.pdf`
+    - :func:`jax.scipy.stats.chi2.sf`
+    - :func:`jax.scipy.stats.chi2.logcdf`
+    - :func:`jax.scipy.stats.chi2.logpdf`
+  """
   return lax.log(sf(x, df, loc, scale))

--- a/jax/_src/scipy/stats/dirichlet.py
+++ b/jax/_src/scipy/stats/dirichlet.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import scipy.stats as osp_stats
-
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import promote_dtypes_inexact, implements
+from jax._src.numpy.util import promote_dtypes_inexact
 from jax.scipy.special import gammaln, xlogy
 from jax._src.typing import Array, ArrayLike
 
@@ -28,8 +25,30 @@ def _is_simplex(x: Array) -> Array:
   return jnp.all(x > 0, axis=0) & (abs(x_sum - 1) < 1E-6)
 
 
-@implements(osp_stats.dirichlet.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, alpha: ArrayLike) -> Array:
+  r"""Dirichlet log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.dirichlet` ``logpdf``.
+
+  The Dirichlet probability density function is
+
+  .. math::
+
+     f(\mathbf{x}) = \frac{1}{B(\mathbf{\alpha})} \prod_{i=1}^K x_i^{\alpha_i - 1}
+
+  where :math:`B(\mathbf{\alpha})` is the :func:`~jax.scipy.special.beta` function
+  in a :math:`K`-dimensional vector space.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    alpha: arraylike, distribution shape parameter
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    :func:`jax.scipy.stats.dirichlet.pdf`
+  """
   return _logpdf(*promote_dtypes_inexact(x, alpha))
 
 def _logpdf(x: Array, alpha: Array) -> Array:
@@ -52,6 +71,28 @@ def _logpdf(x: Array, alpha: Array) -> Array:
   return jnp.where(_is_simplex(x), log_probs, -jnp.inf)
 
 
-@implements(osp_stats.dirichlet.pdf, update_doc=False)
 def pdf(x: ArrayLike, alpha: ArrayLike) -> Array:
+  r"""Dirichlet probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.dirichlet` ``pdf``.
+
+  The Dirichlet probability density function is
+
+  .. math::
+
+     f(\mathbf{x}) = \frac{1}{B(\mathbf{\alpha})} \prod_{i=1}^K x_i^{\alpha_i - 1}
+
+  where :math:`B(\mathbf{\alpha})` is the :func:`~jax.scipy.special.beta` function
+  in a :math:`K`-dimensional vector space.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    alpha: arraylike, distribution shape parameter
+
+  Returns:
+    array of pdf values.
+
+  See Also:
+    :func:`jax.scipy.stats.dirichlet.logpdf`
+  """
   return lax.exp(logpdf(x, alpha))

--- a/jax/_src/scipy/stats/expon.py
+++ b/jax/_src/scipy/stats/expon.py
@@ -12,22 +12,67 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import scipy.stats as osp_stats
-
 from jax import lax
 import jax.numpy as jnp
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
-@implements(osp_stats.expon.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Exponential log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.expon` ``logpdf``.
+
+  The Exponential probability distribution function is
+
+  .. math::
+
+     f(x) = \begin{cases}
+       e^{-x} & x \ge 0 \\
+       0 & \mathrm{otherwise}
+     \end{cases}
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    :func:`jax.scipy.stats.expon.pdf`
+  """
   x, loc, scale = promote_args_inexact("expon.logpdf", x, loc, scale)
   log_scale = lax.log(scale)
   linear_term = lax.div(lax.sub(x, loc), scale)
   log_probs = lax.neg(lax.add(linear_term, log_scale))
   return jnp.where(lax.lt(x, loc), -jnp.inf, log_probs)
 
-@implements(osp_stats.expon.pdf, update_doc=False)
+
 def pdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Exponential probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.expon` ``pdf``.
+
+  The Exponential probability distribution function is
+
+  .. math::
+
+     f(x) = \begin{cases}
+       e^{-x} & x \ge 0 \\
+       0 & \mathrm{otherwise}
+     \end{cases}
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of pdf values.
+
+  See Also:
+    :func:`jax.scipy.stats.expon.logpdf`
+  """
   return lax.exp(logpdf(x, loc, scale))

--- a/jax/_src/scipy/stats/gamma.py
+++ b/jax/_src/scipy/stats/gamma.py
@@ -12,18 +12,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import scipy.stats as osp_stats
-
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 from jax.scipy.special import gammaln, xlogy, gammainc, gammaincc
 
 
-@implements(osp_stats.gamma.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, a: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Gamma log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.gamma` ``logpdf``.
+
+  The Gamma probability distribution is given by
+
+  .. math::
+
+     f(x, a) = \frac{1}{\Gamma(a)}x^{a-1}e^{-x}
+
+  Where :math:`\Gamma(a)` is the :func:`~jax.scipy.special.gamma` function.
+  It is defined for :math:`x \ge 0` and :math:`a > 0`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    a: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.gamma.cdf`
+    - :func:`jax.scipy.stats.gamma.pdf`
+    - :func:`jax.scipy.stats.gamma.sf`
+    - :func:`jax.scipy.stats.gamma.logcdf`
+    - :func:`jax.scipy.stats.gamma.logsf`
+  """
   x, a, loc, scale = promote_args_inexact("gamma.logpdf", x, a, loc, scale)
   one = _lax_const(x, 1)
   y = lax.div(lax.sub(x, loc), scale)
@@ -32,13 +58,70 @@ def logpdf(x: ArrayLike, a: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1)
   log_probs = lax.sub(log_linear_term, shape_terms)
   return jnp.where(lax.lt(x, loc), -jnp.inf, log_probs)
 
-@implements(osp_stats.gamma.pdf, update_doc=False)
+
 def pdf(x: ArrayLike, a: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Gamma probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.gamma` ``pdf``.
+
+  The Gamma probability distribution is given by
+
+  .. math::
+
+     f(x, a) = \frac{1}{\Gamma(a)}x^{a-1}e^{-x}
+
+  Where :math:`\Gamma(a)` is the :func:`~jax.scipy.special.gamma` function.
+  It is defined for :math:`x \ge 0` and :math:`a > 0`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    a: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of pdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.gamma.cdf`
+    - :func:`jax.scipy.stats.gamma.sf`
+    - :func:`jax.scipy.stats.gamma.logcdf`
+    - :func:`jax.scipy.stats.gamma.logpdf`
+    - :func:`jax.scipy.stats.gamma.logsf`
+  """
   return lax.exp(logpdf(x, a, loc, scale))
 
 
-@implements(osp_stats.gamma.cdf, update_doc=False)
 def cdf(x: ArrayLike, a: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Gamma cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.gamma` ``cdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf}(x, a) = \int_{-\infty}^x f_{pdf}(y, a)\mathrm{d}y
+
+  where :math:`f_{pdf}` is the probability density function,
+  :func:`jax.scipy.stats.gamma.pdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    a: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of cdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.gamma.pdf`
+    - :func:`jax.scipy.stats.gamma.sf`
+    - :func:`jax.scipy.stats.gamma.logcdf`
+    - :func:`jax.scipy.stats.gamma.logpdf`
+    - :func:`jax.scipy.stats.gamma.logsf`
+  """
   x, a, loc, scale = promote_args_inexact("gamma.cdf", x, a, loc, scale)
   return gammainc(
     a,
@@ -50,17 +133,101 @@ def cdf(x: ArrayLike, a: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) ->
   )
 
 
-@implements(osp_stats.gamma.logcdf, update_doc=False)
 def logcdf(x: ArrayLike, a: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Gamma log cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.gamma` ``logcdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf}(x, a) = \int_{-\infty}^x f_{pdf}(y, a)\mathrm{d}y
+
+  where :math:`f_{pdf}` is the probability density function,
+  :func:`jax.scipy.stats.gamma.pdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    a: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logcdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.gamma.cdf`
+    - :func:`jax.scipy.stats.gamma.pdf`
+    - :func:`jax.scipy.stats.gamma.sf`
+    - :func:`jax.scipy.stats.gamma.logpdf`
+    - :func:`jax.scipy.stats.gamma.logsf`
+  """
   return lax.log(cdf(x, a, loc, scale))
 
 
-@implements(osp_stats.gamma.sf, update_doc=False)
 def sf(x: ArrayLike, a: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Gamma survival function.
+
+  JAX implementation of :obj:`scipy.stats.gamma` ``sf``.
+
+  The survival function is defined as
+
+  .. math::
+
+     f_{sf}(x, k) = 1 - f_{cdf}(x, k)
+
+  where :math:`f_{cdf}(x, k)` is the cumulative distribution function,
+  :func:`jax.scipy.stats.gamma.cdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the SF
+    a: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of sf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.gamma.cdf`
+    - :func:`jax.scipy.stats.gamma.pdf`
+    - :func:`jax.scipy.stats.gamma.logcdf`
+    - :func:`jax.scipy.stats.gamma.logpdf`
+    - :func:`jax.scipy.stats.gamma.logsf`
+  """
   x, a, loc, scale = promote_args_inexact("gamma.sf", x, a, loc, scale)
   return gammaincc(a, lax.div(lax.sub(x, loc), scale))
 
 
-@implements(osp_stats.gamma.logsf, update_doc=False)
 def logsf(x: ArrayLike, a: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Gamma log survival function.
+
+  JAX implementation of :obj:`scipy.stats.gamma` ``logsf``.
+
+  The survival function is defined as
+
+  .. math::
+
+     f_{sf}(x, k) = 1 - f_{cdf}(x, k)
+
+  where :math:`f_{cdf}(x, k)` is the cumulative distribution function,
+  :func:`jax.scipy.stats.gamma.cdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the SF
+    a: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logsf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.gamma.cdf`
+    - :func:`jax.scipy.stats.gamma.pdf`
+    - :func:`jax.scipy.stats.gamma.sf`
+    - :func:`jax.scipy.stats.gamma.logcdf`
+    - :func:`jax.scipy.stats.gamma.logpdf`
+  """
   return lax.log(sf(x, a, loc, scale))

--- a/jax/_src/scipy/stats/gennorm.py
+++ b/jax/_src/scipy/stats/gennorm.py
@@ -12,22 +12,92 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import scipy.stats as osp_stats
 from jax import lax
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
-@implements(osp_stats.gennorm.logpdf, update_doc=False)
-def logpdf(x: ArrayLike, p: ArrayLike) -> Array:
-  x, p = promote_args_inexact("gennorm.logpdf", x, p)
-  return lax.log(.5 * p) - lax.lgamma(1/p) - lax.abs(x)**p
+def logpdf(x: ArrayLike, beta: ArrayLike) -> Array:
+  r"""Generalized normal log probability distribution function.
 
-@implements(osp_stats.gennorm.cdf, update_doc=False)
-def cdf(x: ArrayLike, p: ArrayLike) -> Array:
-  x, p = promote_args_inexact("gennorm.cdf", x, p)
-  return .5 * (1 + lax.sign(x) * lax.igamma(1/p, lax.abs(x)**p))
+  JAX implementation of :obj:`scipy.stats.gennorm` ``logpdf``.
 
-@implements(osp_stats.gennorm.pdf, update_doc=False)
-def pdf(x: ArrayLike, p: ArrayLike) -> Array:
-  return lax.exp(logpdf(x, p))
+  The generalized normal probability distribution function is defined as
+
+  .. math::
+
+     f(x, \beta) = \frac{\beta}{2\Gamma(1/\beta)}\exp(-|x|^\beta)
+
+  where :math:`\Gamma` is the :func:`~jax.scipy.special.gamma` function, and
+  :math:`\beta > 0`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    beta: arraylike, distribution shape parameter
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.gennorm.cdf`
+    - :func:`jax.scipy.stats.gennorm.pdf`
+  """
+  x, beta = promote_args_inexact("gennorm.logpdf", x, beta)
+  return lax.log(.5 * beta) - lax.lgamma(1/beta) - lax.abs(x)**beta
+
+
+def cdf(x: ArrayLike, beta: ArrayLike) -> Array:
+  r"""Generalized normal cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.gennorm` ``cdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf}(x, k) = \int_{-\infty}^x f_{pdf}(y, k)\mathrm{d}y
+
+  where :math:`f_{pdf}` is the probability density function,
+  :func:`jax.scipy.stats.gennorm.pdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    beta: arraylike, distribution shape parameter
+
+  Returns:
+    array of cdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.gennorm.pdf`
+    - :func:`jax.scipy.stats.gennorm.logpdf`
+  """
+  x, beta = promote_args_inexact("gennorm.cdf", x, beta)
+  return .5 * (1 + lax.sign(x) * lax.igamma(1/beta, lax.abs(x)**beta))
+
+
+def pdf(x: ArrayLike, beta: ArrayLike) -> Array:
+  r"""Generalized normal probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.gennorm` ``pdf``.
+
+  The generalized normal probability distribution function is defined as
+
+  .. math::
+
+     f(x, \beta) = \frac{\beta}{2\Gamma(1/\beta)}\exp(-|x|^\beta)
+
+  where :math:`\Gamma` is the :func:`~jax.scipy.special.gamma` function, and
+  :math:`\beta > 0`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    beta: arraylike, distribution shape parameter
+
+  Returns:
+    array of pdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.gennorm.cdf`
+    - :func:`jax.scipy.stats.gennorm.logpdf`
+  """
+  return lax.exp(logpdf(x, beta))

--- a/jax/_src/scipy/stats/geom.py
+++ b/jax/_src/scipy/stats/geom.py
@@ -12,26 +12,68 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import scipy.stats as osp_stats
-
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax.scipy.special import xlog1py
 from jax._src.typing import Array, ArrayLike
 
 
-@implements(osp_stats.geom.logpmf, update_doc=False)
 def logpmf(k: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
-    k, p, loc = promote_args_inexact("geom.logpmf", k, p, loc)
-    zero = _lax_const(k, 0)
-    one = _lax_const(k, 1)
-    x = lax.sub(k, loc)
-    log_probs = xlog1py(lax.sub(x, one), -p) + lax.log(p)
-    return jnp.where(lax.le(x, zero), -jnp.inf, log_probs)
+  r"""Geometric log probability mass function.
+
+  JAX implementation of :obj:`scipy.stats.geom` ``logpmf``.
+
+  The Geometric probability mass function is given by
+
+  .. math::
+
+     f(k) = (1 - p)^{k-1}p
+
+  for :math:`k\ge 1` and :math:`0 \le p \le 1`.
+
+  Args:
+    k: arraylike, value at which to evaluate the PMF
+    p: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+
+  Returns:
+    array of logpmf values.
+
+  See Also:
+    :func:`jax.scipy.stats.geom.pmf`
+  """
+  k, p, loc = promote_args_inexact("geom.logpmf", k, p, loc)
+  zero = _lax_const(k, 0)
+  one = _lax_const(k, 1)
+  x = lax.sub(k, loc)
+  log_probs = xlog1py(lax.sub(x, one), -p) + lax.log(p)
+  return jnp.where(lax.le(x, zero), -jnp.inf, log_probs)
 
 
-@implements(osp_stats.geom.pmf, update_doc=False)
 def pmf(k: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
+  r"""Geometric probability mass function.
+
+  JAX implementation of :obj:`scipy.stats.geom` ``pmf``.
+
+  The Geometric probability mass function is given by
+
+  .. math::
+
+     f(k) = (1 - p)^{k-1}p
+
+  for :math:`k\ge 1` and :math:`0 \le p \le 1`.
+
+  Args:
+    k: arraylike, value at which to evaluate the PMF
+    p: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+
+  Returns:
+    array of pmf values.
+
+  See Also:
+    :func:`jax.scipy.stats.geom.logpmf`
+  """
   return jnp.exp(logpmf(k, p, loc))

--- a/jax/_src/scipy/stats/kde.py
+++ b/jax/_src/scipy/stats/kde.py
@@ -17,19 +17,28 @@ from functools import partial
 from typing import Any
 
 import numpy as np
-import scipy.stats as osp_stats
 
 import jax.numpy as jnp
 from jax import jit, lax, random, vmap
-from jax._src.numpy.util import check_arraylike, promote_dtypes_inexact, implements
+from jax._src.numpy.util import check_arraylike, promote_dtypes_inexact
 from jax._src.tree_util import register_pytree_node_class
 from jax.scipy import linalg, special
 
 
-@implements(osp_stats.gaussian_kde, update_doc=False)
 @register_pytree_node_class
 @dataclass(frozen=True, init=False)
 class gaussian_kde:
+  """Gaussian Kernel Density Estimator
+
+  JAX implementation of :class:`scipy.stats.gaussian_kde`.
+
+  Parameters:
+    dataset: arraylike, real-valued. Data from which to estimate the distribution.
+      If 1D, shape is (n_data,). If 2D, shape is (n_dimensions, n_data).
+    bw_method: string, scalar, or callable. Either "scott", "silverman", a scalar
+      value, or a callable function which takes ``self`` as a parameter.
+    weights: arraylike, optional. Weights of the same shape as the dataset.
+  """
   neff: Any
   dataset: Any
   weights: Any
@@ -113,20 +122,19 @@ class gaussian_kde:
   def n(self):
     return self.dataset.shape[1]
 
-  @implements(osp_stats.gaussian_kde.evaluate, update_doc=False)
   def evaluate(self, points):
+    """Evaluate the Gaussian KDE on the given points."""
     check_arraylike("evaluate", points)
     points = self._reshape_points(points)
     result = _gaussian_kernel_eval(False, self.dataset.T, self.weights[:, None],
                                    points.T, self.inv_cov)
     return result[:, 0]
 
-  @implements(osp_stats.gaussian_kde.__call__, update_doc=False)
   def __call__(self, points):
     return self.evaluate(points)
 
-  @implements(osp_stats.gaussian_kde.integrate_gaussian, update_doc=False)
   def integrate_gaussian(self, mean, cov):
+    """Integrate the distribution weighted by a Gaussian."""
     mean = jnp.atleast_1d(jnp.squeeze(mean))
     cov = jnp.atleast_2d(cov)
 
@@ -141,8 +149,8 @@ class gaussian_kde:
     return _gaussian_kernel_convolve(chol, norm, self.dataset, self.weights,
                                      mean)
 
-  @implements(osp_stats.gaussian_kde.integrate_box_1d, update_doc=False)
   def integrate_box_1d(self, low, high):
+    """Integrate the distribution over the given limits."""
     if self.d != 1:
       raise ValueError("integrate_box_1d() only handles 1D pdfs")
     if jnp.ndim(low) != 0 or jnp.ndim(high) != 0:
@@ -153,8 +161,8 @@ class gaussian_kde:
     high = jnp.squeeze((high - self.dataset) / sigma)
     return jnp.sum(self.weights * (special.ndtr(high) - special.ndtr(low)))
 
-  @implements(osp_stats.gaussian_kde.integrate_kde, update_doc=False)
   def integrate_kde(self, other):
+    """Integrate the product of two Gaussian KDE distributions."""
     if other.d != self.d:
       raise ValueError("KDEs are not the same dimensionality")
 
@@ -189,12 +197,12 @@ class gaussian_kde:
                                      dtype=self.dataset.dtype).T
     return self.dataset[:, ind] + eps
 
-  @implements(osp_stats.gaussian_kde.pdf, update_doc=False)
   def pdf(self, x):
+    """Probability density function"""
     return self.evaluate(x)
 
-  @implements(osp_stats.gaussian_kde.logpdf, update_doc=False)
   def logpdf(self, x):
+    """Log probability density function"""
     check_arraylike("logpdf", x)
     x = self._reshape_points(x)
     result = _gaussian_kernel_eval(True, self.dataset.T, self.weights[:, None],

--- a/jax/_src/scipy/stats/laplace.py
+++ b/jax/_src/scipy/stats/laplace.py
@@ -12,29 +12,93 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import scipy.stats as osp_stats
-
 from jax import lax
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
-@implements(osp_stats.laplace.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Laplace log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.laplace` ``logpdf``.
+
+  The Laplace probability distribution function is given by
+
+  .. math::
+
+     f(x) = \frac{1}{2} e^{-|x|}
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.laplace.cdf`
+    - :func:`jax.scipy.stats.laplace.pdf`
+  """
   x, loc, scale = promote_args_inexact("laplace.logpdf", x, loc, scale)
   two = _lax_const(x, 2)
   linear_term = lax.div(lax.abs(lax.sub(x, loc)), scale)
   return lax.neg(lax.add(linear_term, lax.log(lax.mul(two, scale))))
 
 
-@implements(osp_stats.laplace.pdf, update_doc=False)
 def pdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Laplace probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.laplace` ``pdf``.
+
+  The Laplace probability distribution function is given by
+
+  .. math::
+
+     f(x) = \frac{1}{2} e^{-|x|}
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of pdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.laplace.cdf`
+    - :func:`jax.scipy.stats.laplace.logpdf`
+  """
   return lax.exp(logpdf(x, loc, scale))
 
 
-@implements(osp_stats.laplace.cdf, update_doc=False)
 def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Laplace cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.laplace` ``cdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf}(x, k) = \int_{-\infty}^x f_{pdf}(y, k)\mathrm{d}y
+
+  where :math:`f_{pdf}` is the probability density function,
+  :func:`jax.scipy.stats.laplace.pdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of cdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.laplace.pdf`
+    - :func:`jax.scipy.stats.laplace.logpdf`
+  """
   x, loc, scale = promote_args_inexact("laplace.cdf", x, loc, scale)
   half = _lax_const(x, 0.5)
   one = _lax_const(x, 1)

--- a/jax/_src/scipy/stats/logistic.py
+++ b/jax/_src/scipy/stats/logistic.py
@@ -12,18 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import scipy.stats as osp_stats
 from jax.scipy.special import expit, logit
 
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
-@implements(osp_stats.logistic.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Logistic log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.logistic` ``logpdf``.
+
+  The logistic probability distribution function is given by
+
+  .. math::
+
+     f(x) = \frac{e^{-x}}{(1 + e^{-x})^2}
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    a: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.logistic.cdf`
+    - :func:`jax.scipy.stats.logistic.pdf`
+    - :func:`jax.scipy.stats.logistic.sf`
+    - :func:`jax.scipy.stats.logistic.isf`
+    - :func:`jax.scipy.stats.logistic.ppf`
+  """
   x, loc, scale = promote_args_inexact("logistic.logpdf", x, loc, scale)
   x = lax.div(lax.sub(x, loc), scale)
   two = _lax_const(x, 2)
@@ -31,30 +55,150 @@ def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   return lax.sub(lax.mul(lax.neg(two), jnp.logaddexp(half_x, lax.neg(half_x))), lax.log(scale))
 
 
-@implements(osp_stats.logistic.pdf, update_doc=False)
 def pdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Logistic probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.logistic` ``pdf``.
+
+  The logistic probability distribution function is given by
+
+  .. math::
+
+     f(x) = \frac{e^{-x}}{(1 + e^{-x})^2}
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of pdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.logistic.cdf`
+    - :func:`jax.scipy.stats.logistic.sf`
+    - :func:`jax.scipy.stats.logistic.isf`
+    - :func:`jax.scipy.stats.logistic.logpdf`
+    - :func:`jax.scipy.stats.logistic.ppf`
+  """
   return lax.exp(logpdf(x, loc, scale))
 
 
-@implements(osp_stats.logistic.ppf, update_doc=False)
 def ppf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  """Logistic distribution percent point function.
+
+  JAX implementation of :obj:`scipy.stats.logistic` ``ppf``.
+
+  The percent point function is defined as the inverse of the
+  cumulative distribution function, :func:`jax.scipy.stats.logistic.cdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PPF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of ppf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.logistic.cdf`
+    - :func:`jax.scipy.stats.logistic.pdf`
+    - :func:`jax.scipy.stats.logistic.sf`
+    - :func:`jax.scipy.stats.logistic.isf`
+    - :func:`jax.scipy.stats.logistic.logpdf`
+  """
   x, loc, scale = promote_args_inexact("logistic.ppf", x, loc, scale)
   return lax.add(lax.mul(logit(x), scale), loc)
 
 
-@implements(osp_stats.logistic.sf, update_doc=False)
 def sf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  """Logistic distribution survival function.
+
+  JAX implementation of :obj:`scipy.stats.logistic` ``sf``
+
+  The survival function is defined as
+
+  .. math::
+
+     f_{sf}(x, k) = 1 - f_{cdf}(x, k)
+
+  where :math:`f_{cdf}(x, k)` is the cumulative distribution function,
+  :func:`jax.scipy.stats.logistic.cdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the SF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of sf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.logistic.cdf`
+    - :func:`jax.scipy.stats.logistic.pdf`
+    - :func:`jax.scipy.stats.logistic.isf`
+    - :func:`jax.scipy.stats.logistic.logpdf`
+    - :func:`jax.scipy.stats.logistic.ppf`
+  """
   x, loc, scale = promote_args_inexact("logistic.sf", x, loc, scale)
   return expit(lax.neg(lax.div(lax.sub(x, loc), scale)))
 
 
-@implements(osp_stats.logistic.isf, update_doc=False)
 def isf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  """Logistic distribution inverse survival function.
+
+  JAX implementation of :obj:`scipy.stats.logistic` ``isf``.
+
+  Returns the inverse of the survival function,
+  :func:`jax.scipy.stats.logistic.sf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the ISF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of isf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.logistic.cdf`
+    - :func:`jax.scipy.stats.logistic.pdf`
+    - :func:`jax.scipy.stats.logistic.sf`
+    - :func:`jax.scipy.stats.logistic.logpdf`
+    - :func:`jax.scipy.stats.logistic.ppf`
+  """
   x, loc, scale = promote_args_inexact("logistic.isf", x, loc, scale)
   return lax.add(lax.mul(lax.neg(logit(x)), scale), loc)
 
 
-@implements(osp_stats.logistic.cdf, update_doc=False)
 def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Logistic cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.logistic` ``cdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf}(x, k) = \int_{-\infty}^x f_{pdf}(y, k)\mathrm{d}y
+
+  where :math:`f_{pdf}` is the probability density function,
+  :func:`jax.scipy.stats.logistic.pdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of cdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.logistic.pdf`
+    - :func:`jax.scipy.stats.logistic.sf`
+    - :func:`jax.scipy.stats.logistic.isf`
+    - :func:`jax.scipy.stats.logistic.logpdf`
+    - :func:`jax.scipy.stats.logistic.ppf`
+  """
   x, loc, scale = promote_args_inexact("logistic.cdf", x, loc, scale)
   return expit(lax.div(lax.sub(x, loc), scale))

--- a/jax/_src/scipy/stats/multinomial.py
+++ b/jax/_src/scipy/stats/multinomial.py
@@ -13,17 +13,37 @@
 # limitations under the License.
 
 
-import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
-from jax._src.numpy.util import implements, promote_args_inexact, promote_args_numeric
+from jax._src.numpy.util import promote_args_inexact, promote_args_numeric
 from jax._src.scipy.special import gammaln, xlogy
 from jax._src.typing import Array, ArrayLike
 
 
-@implements(osp_stats.multinomial.logpmf, update_doc=False)
 def logpmf(x: ArrayLike, n: ArrayLike, p: ArrayLike) -> Array:
-  """JAX implementation of scipy.stats.multinomial.logpmf."""
+  r"""Multinomial log probability mass function.
+
+  JAX implementation of :obj:`scipy.stats.multinomial` ``logpdf``.
+
+  The multinomial probability distribution is given by
+
+  .. math::
+
+     f(x, n, p) = n! \prod_{i=1}^k \frac{p_i^{x_i}}{x_i!}
+
+  with :math:`n = \sum_i x_i`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PMF
+    n: arraylike, distribution shape parameter
+    p: arraylike, distribution shape parameter
+
+  Returns:
+    array of logpmf values.
+
+  See Also:
+    :func:`jax.scipy.stats.multinomial.pmf`
+  """
   p, = promote_args_inexact("multinomial.logpmf", p)
   x, n = promote_args_numeric("multinomial.logpmf", x, n)
   if not jnp.issubdtype(x.dtype, jnp.integer):
@@ -34,7 +54,28 @@ def logpmf(x: ArrayLike, n: ArrayLike, p: ArrayLike) -> Array:
   return jnp.where(jnp.equal(jnp.sum(x), n), logprobs, -jnp.inf)
 
 
-@implements(osp_stats.multinomial.pmf, update_doc=False)
 def pmf(x: ArrayLike, n: ArrayLike, p: ArrayLike) -> Array:
-  """JAX implementation of scipy.stats.multinomial.pmf."""
+  r"""Multinomial probability mass function.
+
+  JAX implementation of :obj:`scipy.stats.multinomial` ``pmf``.
+
+  The multinomial probability distribution is given by
+
+  .. math::
+
+     f(x, n, p) = n! \prod_{i=1}^k \frac{p_i^{x_i}}{x_i!}
+
+  with :math:`n = \sum_i x_i`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PMF
+    n: arraylike, distribution shape parameter
+    p: arraylike, distribution shape parameter
+
+  Returns:
+    array of pmf values
+
+  See Also:
+    :func:`jax.scipy.stats.multinomial.logpmf`
+  """
   return lax.exp(logpmf(x, n, p))

--- a/jax/_src/scipy/stats/multivariate_normal.py
+++ b/jax/_src/scipy/stats/multivariate_normal.py
@@ -15,18 +15,39 @@
 from functools import partial
 
 import numpy as np
-import scipy.stats as osp_stats
 
 from jax import lax
 from jax import numpy as jnp
-from jax._src.numpy.util import implements, promote_dtypes_inexact
+from jax._src.numpy.util import promote_dtypes_inexact
 from jax._src.typing import Array, ArrayLike
 
 
-@implements(osp_stats.multivariate_normal.logpdf, update_doc=False, lax_description="""
-In the JAX version, the `allow_singular` argument is not implemented.
-""")
 def logpdf(x: ArrayLike, mean: ArrayLike, cov: ArrayLike, allow_singular: None = None) -> ArrayLike:
+  r"""Multivariate normal log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.multivariate_normal` ``logpdf``.
+
+  The multivariate normal PDF is defined as
+
+  .. math::
+
+     f(x) = \frac{1}{(2\pi)^k\det\Sigma}\exp\left(-\frac{(x-\mu)^T\Sigma^{-1}(x-\mu)}{2} \right)
+
+  where :math:`\mu` is the ``mean``, :math:`\Sigma` is the covarance matrix (``cov``), and
+  :math:`k` is the rank of :math:`\Sigma`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    mean: arraylike, centroid of distribution
+    cov: arraylike, covariance matrix of distribution
+    allow_singular: not supported
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    :func:`jax.scipy.stats.multivariate_normal.pdf`
+  """
   if allow_singular is not None:
     raise NotImplementedError("allow_singular argument of multivariate_normal.logpdf")
   x, mean, cov = promote_dtypes_inexact(x, mean, cov)
@@ -50,6 +71,31 @@ def logpdf(x: ArrayLike, mean: ArrayLike, cov: ArrayLike, allow_singular: None =
       return (-1/2 * jnp.einsum('...i,...i->...', y, y) - n/2 * jnp.log(2*np.pi)
               - jnp.log(L.diagonal(axis1=-1, axis2=-2)).sum(-1))
 
-@implements(osp_stats.multivariate_normal.pdf, update_doc=False)
+
 def pdf(x: ArrayLike, mean: ArrayLike, cov: ArrayLike) -> Array:
+  r"""Multivariate normal probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.multivariate_normal` ``pdf``.
+
+  The multivariate normal PDF is defined as
+
+  .. math::
+
+     f(x) = \frac{1}{(2\pi)^k\det\Sigma}\exp\left(-\frac{(x-\mu)^T\Sigma^{-1}(x-\mu)}{2} \right)
+
+  where :math:`\mu` is the ``mean``, :math:`\Sigma` is the covarance matrix (``cov``), and
+  :math:`k` is the rank of :math:`\Sigma`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    mean: arraylike, centroid of distribution
+    cov: arraylike, covariance matrix of distribution
+    allow_singular: not supported
+
+  Returns:
+    array of pdf values.
+
+  See Also:
+    :func:`jax.scipy.stats.multivariate_normal.logpdf`
+  """
   return lax.exp(logpdf(x, mean, cov))

--- a/jax/_src/scipy/stats/nbinom.py
+++ b/jax/_src/scipy/stats/nbinom.py
@@ -12,32 +12,73 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-
-import scipy.stats as osp_stats
-
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.scipy.special import gammaln, xlogy
 from jax._src.typing import Array, ArrayLike
 
 
-@implements(osp_stats.nbinom.logpmf, update_doc=False)
 def logpmf(k: ArrayLike, n: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
-    """JAX implementation of scipy.stats.nbinom.logpmf."""
-    k, n, p, loc = promote_args_inexact("nbinom.logpmf", k, n, p, loc)
-    one = _lax_const(k, 1)
-    y = lax.sub(k, loc)
-    comb_term = lax.sub(
-        lax.sub(gammaln(lax.add(y, n)), gammaln(n)), gammaln(lax.add(y, one))
-    )
-    log_linear_term = lax.add(xlogy(n, p), xlogy(y, lax.sub(one, p)))
-    log_probs = lax.add(comb_term, log_linear_term)
-    return jnp.where(lax.lt(k, loc), -jnp.inf, log_probs)
+  r"""Negative-binomial log probability mass function.
+
+  JAX implementation of :obj:`scipy.stats.nbinom` ``logpmf``.
+
+  The negative-binomial probability mass function is given by
+
+  .. math::
+
+     f(k) = {{k+n-1} \choose {n-1}}p^n(1-p)^k
+
+  for :math:`k \ge 0` and :math:`0 \le p \le 1`.
+
+  Args:
+    k: arraylike, value at which to evaluate the PMF
+    n: arraylike, distribution shape parameter
+    p: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    :func:`jax.scipy.stats.nbinom.pmf`
+  """
+  k, n, p, loc = promote_args_inexact("nbinom.logpmf", k, n, p, loc)
+  one = _lax_const(k, 1)
+  y = lax.sub(k, loc)
+  comb_term = lax.sub(
+    lax.sub(gammaln(lax.add(y, n)), gammaln(n)), gammaln(lax.add(y, one))
+  )
+  log_linear_term = lax.add(xlogy(n, p), xlogy(y, lax.sub(one, p)))
+  log_probs = lax.add(comb_term, log_linear_term)
+  return jnp.where(lax.lt(k, loc), -jnp.inf, log_probs)
 
 
-@implements(osp_stats.nbinom.pmf, update_doc=False)
 def pmf(k: ArrayLike, n: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
-    """JAX implementation of scipy.stats.nbinom.pmf."""
-    return lax.exp(logpmf(k, n, p, loc))
+  r"""Negative-binomial probability mass function.
+
+  JAX implementation of :obj:`scipy.stats.nbinom` ``pmf``.
+
+  The negative-binomial probability mass function is given by
+
+  .. math::
+
+     f(k) = {{k+n-1} \choose {n-1}}p^n(1-p)^k
+
+  for :math:`k \ge 0` and :math:`0 \le p \le 1`.
+
+  Args:
+    k: arraylike, value at which to evaluate the PMF
+    n: arraylike, distribution shape parameter
+    p: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+
+  Returns:
+    array of pmf values.
+
+  See Also:
+    :func:`jax.scipy.stats.nbinom.logpmf`
+  """
+  return lax.exp(logpmf(k, n, p, loc))

--- a/jax/_src/scipy/stats/norm.py
+++ b/jax/_src/scipy/stats/norm.py
@@ -15,18 +15,43 @@
 from typing import cast
 
 import numpy as np
-import scipy.stats as osp_stats
 
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 from jax.scipy import special
 
 
-@implements(osp_stats.norm.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Normal log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.norm` ``logpdf``.
+
+  The normal distribution pdf is given by
+
+  .. math::
+
+     f(x) = \frac{1}{\sqrt{2\pi}}e^{-x^2/2}
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.norm.cdf`
+    - :func:`jax.scipy.stats.norm.pdf`
+    - :func:`jax.scipy.stats.norm.sf`
+    - :func:`jax.scipy.stats.norm.logcdf`
+    - :func:`jax.scipy.stats.norm.logsf`
+    - :func:`jax.scipy.stats.norm.isf`
+    - :func:`jax.scipy.stats.norm.ppf`
+  """
   x, loc, scale = promote_args_inexact("norm.logpdf", x, loc, scale)
   scale_sqrd = lax.square(scale)
   log_normalizer = lax.log(lax.mul(_lax_const(x, 2 * np.pi), scale_sqrd))
@@ -34,41 +59,229 @@ def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   return lax.div(lax.add(log_normalizer, quadratic), _lax_const(x, -2))
 
 
-@implements(osp_stats.norm.pdf, update_doc=False)
 def pdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Normal probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.norm` ``pdf``.
+
+  The normal distribution pdf is given by
+
+  .. math::
+
+     f(x) = \frac{1}{\sqrt{2\pi}}e^{-x^2/2}
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of pdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.norm.cdf`
+    - :func:`jax.scipy.stats.norm.sf`
+    - :func:`jax.scipy.stats.norm.logcdf`
+    - :func:`jax.scipy.stats.norm.logpdf`
+    - :func:`jax.scipy.stats.norm.logsf`
+    - :func:`jax.scipy.stats.norm.isf`
+    - :func:`jax.scipy.stats.norm.ppf`
+  """
   return lax.exp(logpdf(x, loc, scale))
 
 
-@implements(osp_stats.norm.cdf, update_doc=False)
 def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Normal cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.norm` ``cdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf}(x, k) = \int_{-\infty}^x f_{pdf}(y, k)\mathrm{d}y
+
+  where :math:`f_{pdf}` is the probability density function,
+  :func:`jax.scipy.stats.norm.pdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of cdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.norm.pdf`
+    - :func:`jax.scipy.stats.norm.sf`
+    - :func:`jax.scipy.stats.norm.logcdf`
+    - :func:`jax.scipy.stats.norm.logpdf`
+    - :func:`jax.scipy.stats.norm.logsf`
+    - :func:`jax.scipy.stats.norm.isf`
+    - :func:`jax.scipy.stats.norm.ppf`
+  """
   x, loc, scale = promote_args_inexact("norm.cdf", x, loc, scale)
   return special.ndtr(lax.div(lax.sub(x, loc), scale))
 
 
-@implements(osp_stats.norm.logcdf, update_doc=False)
 def logcdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Normal log cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.norm` ``logcdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf}(x, k) = \int_{-\infty}^x f_{pdf}(y, k)\mathrm{d}y
+
+  where :math:`f_{pdf}` is the probability density function,
+  :func:`jax.scipy.stats.norm.pdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logcdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.norm.cdf`
+    - :func:`jax.scipy.stats.norm.pdf`
+    - :func:`jax.scipy.stats.norm.sf`
+    - :func:`jax.scipy.stats.norm.logpdf`
+    - :func:`jax.scipy.stats.norm.logsf`
+    - :func:`jax.scipy.stats.norm.isf`
+    - :func:`jax.scipy.stats.norm.ppf`
+  """
   x, loc, scale = promote_args_inexact("norm.logcdf", x, loc, scale)
   # Cast required because custom_jvp return type is broken.
   return cast(Array, special.log_ndtr(lax.div(lax.sub(x, loc), scale)))
 
 
-@implements(osp_stats.norm.ppf, update_doc=False)
 def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  """Normal distribution percent point function.
+
+  JAX implementation of :obj:`scipy.stats.norm` ``ppf``.
+
+  The percent point function is defined as the inverse of the
+  cumulative distribution function, :func:`jax.scipy.stats.norm.cdf`.
+
+  Args:
+    q: arraylike, value at which to evaluate the PPF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of ppdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.norm.cdf`
+    - :func:`jax.scipy.stats.norm.pdf`
+    - :func:`jax.scipy.stats.norm.sf`
+    - :func:`jax.scipy.stats.norm.logcdf`
+    - :func:`jax.scipy.stats.norm.logpdf`
+    - :func:`jax.scipy.stats.norm.logsf`
+    - :func:`jax.scipy.stats.norm.isf`
+  """
   return jnp.asarray(special.ndtri(q) * scale + loc, float)
 
 
-@implements(osp_stats.norm.logsf, update_doc=False)
 def logsf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  """Normal distribution log survival function.
+
+  JAX implementation of :obj:`scipy.stats.norm` ``logsf``.
+
+  The survival function is defined as
+
+  .. math::
+
+     f_{sf}(x) = 1 - f_{cdf}(x)
+
+  where :math:`f_{cdf}(x)` is the cumulative distribution function,
+  :func:`jax.scipy.stats.norm.cdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the SF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logsf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.norm.cdf`
+    - :func:`jax.scipy.stats.norm.pdf`
+    - :func:`jax.scipy.stats.norm.sf`
+    - :func:`jax.scipy.stats.norm.logcdf`
+    - :func:`jax.scipy.stats.norm.logpdf`
+    - :func:`jax.scipy.stats.norm.isf`
+    - :func:`jax.scipy.stats.norm.ppf`
+  """
   x, loc, scale = promote_args_inexact("norm.logsf", x, loc, scale)
   return logcdf(-x, -loc, scale)
 
 
-@implements(osp_stats.norm.sf, update_doc=False)
 def sf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  """Normal distribution survival function.
+
+  JAX implementation of :obj:`scipy.stats.norm` ``sf``.
+
+  The survival function is defined as
+
+  .. math::
+
+     f_{sf}(x) = 1 - f_{cdf}(x)
+
+  where :math:`f_{cdf}(x)` is the cumulative distribution function,
+  :func:`jax.scipy.stats.norm.cdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the SF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of sf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.norm.cdf`
+    - :func:`jax.scipy.stats.norm.pdf`
+    - :func:`jax.scipy.stats.norm.logcdf`
+    - :func:`jax.scipy.stats.norm.logpdf`
+    - :func:`jax.scipy.stats.norm.logsf`
+    - :func:`jax.scipy.stats.norm.isf`
+    - :func:`jax.scipy.stats.norm.ppf`
+  """
   x, loc, scale = promote_args_inexact("norm.sf", x, loc, scale)
   return cdf(-x, -loc, scale)
 
 
-@implements(osp_stats.norm.isf, update_doc=False)
 def isf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  """Normal distribution inverse survival function.
+
+  JAX implementation of :obj:`scipy.stats.norm` ``isf``.
+
+  Returns the inverse of the survival function,
+  :func:`jax.scipy.stats.norm.sf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the ISF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of isf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.norm.cdf`
+    - :func:`jax.scipy.stats.norm.pdf`
+    - :func:`jax.scipy.stats.norm.sf`
+    - :func:`jax.scipy.stats.norm.logcdf`
+    - :func:`jax.scipy.stats.norm.logpdf`
+    - :func:`jax.scipy.stats.norm.logsf`
+    - :func:`jax.scipy.stats.norm.ppf`
+  """
   return ppf(lax.sub(_lax_const(q, 1), q), loc, scale)

--- a/jax/_src/scipy/stats/pareto.py
+++ b/jax/_src/scipy/stats/pareto.py
@@ -12,18 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import scipy.stats as osp_stats
-
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
-@implements(osp_stats.pareto.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Pareto log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.pareto` ``logpdf``.
+
+  The Pareto probability density function is given by
+
+  .. math::
+
+     f(x, b) = \begin{cases}
+       bx^{-(b+1)} & x \ge 1\\
+       0 & x < 1
+     \end{cases}
+
+  and is defined for :math:`b > 0`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    :func:`jax.scipy.stats.pareto.pdf`
+  """
   x, b, loc, scale = promote_args_inexact("pareto.logpdf", x, b, loc, scale)
   one = _lax_const(x, 1)
   scaled_x = lax.div(lax.sub(x, loc), scale)
@@ -31,6 +54,33 @@ def logpdf(x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1)
   log_probs = lax.neg(lax.add(normalize_term, lax.mul(lax.add(b, one), lax.log(scaled_x))))
   return jnp.where(lax.lt(x, lax.add(loc, scale)), -jnp.inf, log_probs)
 
-@implements(osp_stats.pareto.pdf, update_doc=False)
+
 def pdf(x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Pareto probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.pareto` ``pdf``.
+
+  The Pareto probability density function is given by
+
+  .. math::
+
+     f(x, b) = \begin{cases}
+       bx^{-(b+1)} & x \ge 1\\
+       0 & x < 1
+     \end{cases}
+
+  and is defined for :math:`b > 0`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of pdf values.
+
+  See Also:
+    :func:`jax.scipy.stats.pareto.logpdf`
+  """
   return lax.exp(logpdf(x, b, loc, scale))

--- a/jax/_src/scipy/stats/poisson.py
+++ b/jax/_src/scipy/stats/poisson.py
@@ -12,19 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import scipy.stats as osp_stats
-
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 from jax.scipy.special import xlogy, gammaln, gammaincc
 
 
-@implements(osp_stats.poisson.logpmf, update_doc=False)
 def logpmf(k: ArrayLike, mu: ArrayLike, loc: ArrayLike = 0) -> Array:
+  r"""Poisson log probability mass function.
+
+  JAX implementation of :obj:`scipy.stats.poisson` ``logpmf``.
+
+  The Poisson probability mass function is given by
+
+  .. math::
+
+     f(k) = e^{-\mu}\frac{\mu^k}{k!}
+
+  and is defined for :math:`k \ge 0` and :math:`\mu \ge 0`.
+
+  Args:
+    k: arraylike, value at which to evaluate the PMF
+    mu: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+
+  Returns:
+    array of logpmf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.poisson.cdf`
+    - :func:`jax.scipy.stats.poisson.pmf`
+  """
   k, mu, loc = promote_args_inexact("poisson.logpmf", k, mu, loc)
   zero = _lax_const(k, 0)
   x = lax.sub(k, loc)
@@ -32,12 +52,61 @@ def logpmf(k: ArrayLike, mu: ArrayLike, loc: ArrayLike = 0) -> Array:
   return jnp.where(jnp.logical_or(lax.lt(x, zero),
                                   lax.ne(jnp.round(k), k)), -jnp.inf, log_probs)
 
-@implements(osp_stats.poisson.pmf, update_doc=False)
+
 def pmf(k: ArrayLike, mu: ArrayLike, loc: ArrayLike = 0) -> Array:
+  r"""Poisson probability mass function.
+
+  JAX implementation of :obj:`scipy.stats.poisson` ``pmf``.
+
+  The Poisson probability mass function is given by
+
+  .. math::
+
+     f(k) = e^{-\mu}\frac{\mu^k}{k!}
+
+  and is defined for :math:`k \ge 0` and :math:`\mu \ge 0`.
+
+  Args:
+    k: arraylike, value at which to evaluate the PMF
+    mu: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+
+  Returns:
+    array of pmf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.poisson.cdf`
+    - :func:`jax.scipy.stats.poisson.logpmf`
+  """
   return jnp.exp(logpmf(k, mu, loc))
 
-@implements(osp_stats.poisson.cdf, update_doc=False)
+
 def cdf(k: ArrayLike, mu: ArrayLike, loc: ArrayLike = 0) -> Array:
+  r"""Poisson cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.poisson` ``cdf``.
+
+  The cumulative distribution function is defined as:
+
+  .. math::
+
+     f_{cdf}(k, p) = \sum_{i=0}^k f_{pmf}(k, p)
+
+  where :math:`f_{pmf}(k, p)` is the probability mass function
+  :func:`jax.scipy.stats.poisson.pmf`.
+
+  Args:
+    k: arraylike, value at which to evaluate the CDF
+    mu: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+
+  Returns:
+    array of cdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.poisson.pmf`
+    - :func:`jax.scipy.stats.poisson.logpmf`
+  """
   k, mu, loc = promote_args_inexact("poisson.logpmf", k, mu, loc)
   zero = _lax_const(k, 0)
   x = lax.sub(k, loc)

--- a/jax/_src/scipy/stats/t.py
+++ b/jax/_src/scipy/stats/t.py
@@ -14,16 +14,39 @@
 
 
 import numpy as np
-import scipy.stats as osp_stats
 
 from jax import lax
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
-@implements(osp_stats.t.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Student's T log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.t` ``logpdf``.
+
+  The Student's T probability distribution function is given by
+
+  .. math::
+
+     f(x, \nu) = \frac{\Gamma((\nu + 1)/2)}{\sqrt{\pi\nu}\Gamma(\nu/2)}(1 + x^2/\nu)^{(\nu+1)/2}
+
+  Where :math:`\Gamma` is the :func:`~jax.scipy.special.gamma` function, and :math:`\nu > 0`
+  is the degrees of freedom (JAX follows the scipy convention of naming this ``df``).
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    df: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    :func:`jax.scipy.stats.t.pdf`
+  """
   x, df, loc, scale = promote_args_inexact("t.logpdf", x, df, loc, scale)
   two = _lax_const(x, 2)
   scaled_x = lax.div(lax.sub(x, loc), scale)
@@ -37,6 +60,30 @@ def logpdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1
   return lax.neg(lax.add(normalize_term, lax.mul(df_plus_one_over_two, lax.log1p(quadratic))))
 
 
-@implements(osp_stats.t.pdf, update_doc=False)
 def pdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Student's T probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.t` ``pdf``.
+
+  The Student's T probability distribution function is given by
+
+  .. math::
+
+     f(x, \nu) = \frac{\Gamma((\nu + 1)/2)}{\sqrt{\pi\nu}\Gamma(\nu/2)}(1 + x^2/\nu)^{(\nu+1)/2}
+
+  Where :math:`\Gamma` is the :func:`~jax.scipy.special.gamma` function, and :math:`\nu > 0`
+  is the degrees of freedom (JAX follows the scipy convention of naming this ``df``).
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    df: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array
+
+  See Also:
+    :func:`jax.scipy.stats.t.logpdf`
+  """
   return lax.exp(logpdf(x, df, loc, scale))

--- a/jax/_src/scipy/stats/truncnorm.py
+++ b/jax/_src/scipy/stats/truncnorm.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import scipy.stats as osp_stats
-
 from jax import lax
 import jax.numpy as jnp
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.scipy.stats import norm
 from jax._src.scipy.special import logsumexp, log_ndtr, ndtr
 
@@ -69,8 +66,41 @@ def _log_gauss_mass(a, b):
   return out
 
 
-@implements(osp_stats.truncnorm.logpdf, update_doc=False)
 def logpdf(x, a, b, loc=0, scale=1):
+  r"""Truncated normal log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.truncnorm` ``logpdf``.
+
+  The truncated normal probability distribution is given by
+
+  .. math::
+
+     f(x, a, b) = \begin{cases}
+       \frac{1}{\sqrt{2\pi}}e^{-x^2/2} & a \le x \le b \\
+       0 & \mathrm{otherwise}
+     \end{cases}
+
+  where :math:`a` and :math:`b` are effectively specified in number of
+  standard deviations from zero. JAX uses the scipy nomenclature
+  of ``loc`` for the centroid and ``scale`` for the standard deviation.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    a: arraylike, distribution shape parameter
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.truncnorm.cdf`
+    - :func:`jax.scipy.stats.truncnorm.pdf`
+    - :func:`jax.scipy.stats.truncnorm.sf`
+    - :func:`jax.scipy.stats.truncnorm.logcdf`
+    - :func:`jax.scipy.stats.truncnorm.logsf`
+  """
   x, a, b, loc, scale = promote_args_inexact("truncnorm.logpdf", x, a, b, loc, scale)
   val = lax.sub(norm.logpdf(x, loc, scale), _log_gauss_mass(a, b))
 
@@ -80,24 +110,144 @@ def logpdf(x, a, b, loc=0, scale=1):
   return val
 
 
-@implements(osp_stats.truncnorm.pdf, update_doc=False)
 def pdf(x, a, b, loc=0, scale=1):
+  r"""Truncated normal probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.truncnorm` ``pdf``.
+
+  The truncated normal probability distribution is given by
+
+  .. math::
+
+     f(x, a, b) = \begin{cases}
+       \frac{1}{\sqrt{2\pi}}e^{-x^2/2} & a \le x \le b \\
+       0 & \mathrm{otherwise}
+     \end{cases}
+
+  where :math:`a` and :math:`b` are effectively specified in number of
+  standard deviations from the centroid. JAX uses the scipy nomenclature
+  of ``loc`` for the centroid and ``scale`` for the standard deviation.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    a: arraylike, distribution shape parameter
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of pdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.truncnorm.cdf`
+    - :func:`jax.scipy.stats.truncnorm.sf`
+    - :func:`jax.scipy.stats.truncnorm.logcdf`
+    - :func:`jax.scipy.stats.truncnorm.logpdf`
+    - :func:`jax.scipy.stats.truncnorm.logsf`
+  """
   return lax.exp(logpdf(x, a, b, loc, scale))
 
 
-@implements(osp_stats.truncnorm.logsf, update_doc=False)
 def logsf(x, a, b, loc=0, scale=1):
+  """Truncated normal distribution log survival function.
+
+  JAX implementation of :obj:`scipy.stats.truncnorm` ``logsf``
+
+  The survival function is defined as
+
+  .. math::
+
+     f_{sf}(x) = 1 - f_{cdf}(x)
+
+  where :math:`f_{cdf}(x)` is the cumulative distribution function,
+  :func:`jax.scipy.stats.truncnorm.cdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the SF
+    a: arraylike, distribution shape parameter
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logsf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.truncnorm.cdf`
+    - :func:`jax.scipy.stats.truncnorm.pdf`
+    - :func:`jax.scipy.stats.truncnorm.sf`
+    - :func:`jax.scipy.stats.truncnorm.logcdf`
+    - :func:`jax.scipy.stats.truncnorm.logpdf`
+  """
   x, a, b, loc, scale = promote_args_inexact("truncnorm.logsf", x, a, b, loc, scale)
   return logcdf(-x, -b, -a, -loc, scale)
 
 
-@implements(osp_stats.truncnorm.sf, update_doc=False)
 def sf(x, a, b, loc=0, scale=1):
+  """Truncated normal distribution log survival function.
+
+  JAX implementation of :obj:`scipy.stats.truncnorm` ``logsf``
+
+  The survival function is defined as
+
+  .. math::
+
+     f_{sf}(x) = 1 - f_{cdf}(x)
+
+  where :math:`f_{cdf}(x)` is the cumulative distribution function,
+  :func:`jax.scipy.stats.truncnorm.cdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the SF
+    a: arraylike, distribution shape parameter
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of sf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.truncnorm.cdf`
+    - :func:`jax.scipy.stats.truncnorm.pdf`
+    - :func:`jax.scipy.stats.truncnorm.sf`
+    - :func:`jax.scipy.stats.truncnorm.logcdf`
+    - :func:`jax.scipy.stats.truncnorm.logpdf`
+  """
   return lax.exp(logsf(x, a, b, loc, scale))
 
 
-@implements(osp_stats.truncnorm.logcdf, update_doc=False)
 def logcdf(x, a, b, loc=0, scale=1):
+  r"""Truncated normal log cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.truncnorm` ``logcdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf} = \int_{-\infty}^x f_{pdf}(y) \mathrm{d}y
+
+  where here :math:`f_{pdf}` is the probability distribution function,
+  :func:`jax.scipy.stats.truncnorm.pdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    a: arraylike, distribution shape parameter
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logcdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.truncnorm.cdf`
+    - :func:`jax.scipy.stats.truncnorm.pdf`
+    - :func:`jax.scipy.stats.truncnorm.sf`
+    - :func:`jax.scipy.stats.truncnorm.logpdf`
+    - :func:`jax.scipy.stats.truncnorm.logsf`
+  """
   x, a, b, loc, scale = promote_args_inexact("truncnorm.logcdf", x, a, b, loc, scale)
   x, a, b = jnp.broadcast_arrays(x, a, b)
   x = lax.div(lax.sub(x, loc), scale)
@@ -113,6 +263,35 @@ def logcdf(x, a, b, loc=0, scale=1):
   return logcdf
 
 
-@implements(osp_stats.truncnorm.cdf, update_doc=False)
 def cdf(x, a, b, loc=0, scale=1):
+  r"""Truncated normal cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.truncnorm` ``cdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf} = \int_{-\infty}^x f_{pdf}(y) \mathrm{d}y
+
+  where here :math:`f_{pdf}` is the probability distribution function,
+  :func:`jax.scipy.stats.truncnorm.pdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    a: arraylike, distribution shape parameter
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of cdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.truncnorm.pdf`
+    - :func:`jax.scipy.stats.truncnorm.sf`
+    - :func:`jax.scipy.stats.truncnorm.logcdf`
+    - :func:`jax.scipy.stats.truncnorm.logpdf`
+    - :func:`jax.scipy.stats.truncnorm.logsf`
+  """
   return lax.exp(logcdf(x, a, b, loc, scale))

--- a/jax/_src/scipy/stats/uniform.py
+++ b/jax/_src/scipy/stats/uniform.py
@@ -12,30 +12,104 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import scipy.stats as osp_stats
-
 from jax import lax
 from jax import numpy as jnp
 from jax.numpy import where, inf, logical_or
 from jax._src.typing import Array, ArrayLike
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 
 
-@implements(osp_stats.uniform.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Uniform log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.uniform` ``logpdf``.
+
+  The uniform distribution pdf is given by
+
+  .. math::
+
+     f(x) = \begin{cases}
+       1 & 0 \le x \le 1 \\
+       0 & \mathrm{otherwise}
+     \end{cases}
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logpdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.uniform.cdf`
+    - :func:`jax.scipy.stats.uniform.pdf`
+    - :func:`jax.scipy.stats.uniform.ppf`
+  """
   x, loc, scale = promote_args_inexact("uniform.logpdf", x, loc, scale)
   log_probs = lax.neg(lax.log(scale))
   return where(logical_or(lax.gt(x, lax.add(loc, scale)),
                           lax.lt(x, loc)),
                -inf, log_probs)
 
-@implements(osp_stats.uniform.pdf, update_doc=False)
+
 def pdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Uniform probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.uniform` ``pdf``.
+
+  The uniform distribution pdf is given by
+
+  .. math::
+
+     f(x) = \begin{cases}
+       1 & 0 \le x \le 1 \\
+       0 & \mathrm{otherwise}
+     \end{cases}
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of pdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.uniform.cdf`
+    - :func:`jax.scipy.stats.uniform.logpdf`
+    - :func:`jax.scipy.stats.uniform.ppf`
+  """
   return lax.exp(logpdf(x, loc, scale))
 
-@implements(osp_stats.uniform.cdf, update_doc=False)
+
 def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Uniform cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.uniform` ``cdf``.
+
+  The cdf is defined as
+
+  .. math::
+
+     f_{cdf} = \int_{-\infty}^x f_{pdf}(y) \mathrm{d}y
+
+  where here :math:`f_{pdf}` is the probability distribution function,
+  :func:`jax.scipy.stats.uniform.pdf`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of cdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.uniform.pdf`
+    - :func:`jax.scipy.stats.uniform.logpdf`
+    - :func:`jax.scipy.stats.uniform.ppf`
+  """
   x, loc, scale = promote_args_inexact("uniform.cdf", x, loc, scale)
   zero, one = jnp.array(0, x.dtype), jnp.array(1, x.dtype)
   conds = [lax.lt(x, loc), lax.gt(x, lax.add(loc, scale)), lax.ge(x, loc) & lax.le(x, lax.add(loc, scale))]
@@ -43,8 +117,28 @@ def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
 
   return jnp.select(conds, vals)
 
-@implements(osp_stats.uniform.ppf, update_doc=False)
+
 def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  """Uniform distribution percent point function.
+
+  JAX implementation of :obj:`scipy.stats.uniform` ``ppf``.
+
+  The percent point function is defined as the inverse of the
+  cumulative distribution function, :func:`jax.scipy.stats.uniform.cdf`.
+
+  Args:
+    q: arraylike, value at which to evaluate the PPF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of ppf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.uniform.cdf`
+    - :func:`jax.scipy.stats.uniform.pdf`
+    - :func:`jax.scipy.stats.uniform.logpdf`
+  """
   q, loc, scale = promote_args_inexact("uniform.ppf", q, loc, scale)
   return where(
     jnp.isnan(q) | (q < 0) | (q > 1),

--- a/jax/_src/scipy/stats/vonmises.py
+++ b/jax/_src/scipy/stats/vonmises.py
@@ -12,20 +12,66 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
-@implements(osp_stats.vonmises.logpdf, update_doc=False)
+
 def logpdf(x: ArrayLike, kappa: ArrayLike) -> Array:
+  r"""von Mises log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.vonmises` ``logpdf``.
+
+  The von Mises probability distribution function is given by
+
+  .. math::
+
+     f(x, \kappa) = \frac{1}{2\pi I_0(\kappa)}e^{\kappa\cos x}
+
+  Where :math:`I_0` is the modified Bessel function :func:`~jax.scipy.special.i0`
+  and :math:`\kappa\ge 0`, and the distribution is normalized in the interval
+  :math:`-\pi \le x \le \pi`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    kappa: arraylike, distribution shape parameter
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    :func:`jax.scipy.stats.vonmises.pdf`
+  """
   x, kappa = promote_args_inexact('vonmises.logpdf', x, kappa)
   zero = _lax_const(kappa, 0)
   return jnp.where(lax.gt(kappa, zero), kappa * (jnp.cos(x) - 1) - jnp.log(2 * jnp.pi * lax.bessel_i0e(kappa)), jnp.nan)
 
-@implements(osp_stats.vonmises.pdf, update_doc=False)
+
 def pdf(x: ArrayLike, kappa: ArrayLike) -> Array:
+  r"""von Mises probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.vonmises` ``pdf``.
+
+  The von Mises probability distribution function is given by
+
+  .. math::
+
+     f(x, \kappa) = \frac{1}{2\pi I_0(\kappa)}e^{\kappa\cos x}
+
+  Where :math:`I_0` is the modified Bessel function :func:`~jax.scipy.special.i0`
+  and :math:`\kappa\ge 0`, and the distribution is normalized in the interval
+  :math:`-\pi \le x \le \pi`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    kappa: arraylike, distribution shape parameter
+
+  Returns:
+    array of pdf values.
+
+  See Also:
+    :func:`jax.scipy.stats.vonmises.logpdf`
+  """
   return lax.exp(logpdf(x, kappa))

--- a/jax/_src/scipy/stats/wrapcauchy.py
+++ b/jax/_src/scipy/stats/wrapcauchy.py
@@ -13,16 +13,36 @@
 # limitations under the License.
 
 
-import scipy.stats as osp_stats
 from jax import lax
 import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
-from jax._src.numpy.util import implements, promote_args_inexact
+from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
-@implements(osp_stats.wrapcauchy.logpdf, update_doc=False)
 def logpdf(x: ArrayLike, c: ArrayLike) -> Array:
+  r"""Wrapped Cauchy log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.wrapcauchy` ``logpdf``.
+
+  The wrapped Cauchy probability distribution function is given by
+
+  .. math::
+
+     f(x, c) = \frac{1-c^2}{2\pi(1+c^2-2c\cos x)}
+
+  for :math:`0<c<1`, and where normalization is on the domain :math:`0\le x\le 2\pi`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    c: arraylike, distribution shape parameter
+
+  Returns:
+    array of logpdf values.
+
+  See Also:
+    :func:`jax.scipy.stats.wrapcauchy.pdf`
+  """
   x, c = promote_args_inexact('wrapcauchy.logpdf', x, c)
   return jnp.where(
     lax.gt(c, _lax_const(c, 0)) & lax.lt(c, _lax_const(c, 1)),
@@ -34,6 +54,28 @@ def logpdf(x: ArrayLike, c: ArrayLike) -> Array:
     jnp.nan,
   )
 
-@implements(osp_stats.wrapcauchy.pdf, update_doc=False)
+
 def pdf(x: ArrayLike, c: ArrayLike) -> Array:
+  r"""Wrapped Cauchy probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.wrapcauchy` ``pdf``.
+
+  The wrapped Cauchy probability distribution function is given by
+
+  .. math::
+
+     f(x, c) = \frac{1-c^2}{2\pi(1+c^2-2c\cos x)}
+
+  for :math:`0<c<1`, and where normalization is on the domain :math:`0\le x\le 2\pi`.
+
+  Args:
+    x: arraylike, value at which to evaluate the PDF
+    c: arraylike, distribution shape parameter
+
+  Returns:
+    array of pdf values.
+
+  See Also:
+    :func:`jax.scipy.stats.wrapcauchy.logpdf`
+  """
   return lax.exp(logpdf(x, c))


### PR DESCRIPTION
This lets us give more implementation-specific information, and lets us avoid a dependency on scipy. Related to #20799.

Part of #21461.