### PR TITLE
DOC: Remove dependency on sphinx_autodoc_typehints

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.9"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,6 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'matplotlib.sphinxext.plot_directive',
-    'sphinx_autodoc_typehints',
     'myst_nb',
     "sphinx_remove_toctrees",
     'sphinx_copybutton',
@@ -294,17 +293,13 @@ epub_exclude_files = ['search.html']
 
 # -- Extension configuration -------------------------------------------------
 
-# Tell sphinx-autodoc-typehints to generate stub parameter annotations including
-# types, even if the parameters aren't explicitly documented.
-always_document_param_types = True
-
-
 # Tell sphinx autodoc how to render type aliases.
+autodoc_typehints = "description"
+autodoc_typehints_description_target = "all"
 autodoc_type_aliases = {
     'ArrayLike': 'jax.typing.ArrayLike',
     'DTypeLike': 'jax.typing.DTypeLike',
 }
-
 
 # Remove auto-generated API docs from sidebars. They take too long to build.
 remove_from_toctrees = ["_autosummary/*"]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,6 @@
 absl-py
 ipython>=8.8.0  # 8.7.0 has ipython3 lexer error
 sphinx>=7.3.2  # 7.3.0 breaks sphinx-book-theme
-sphinx-autodoc-typehints
 sphinx-book-theme>=1.0.1  # Older versions fail to pin pydata-sphinx-theme
 sphinx-copybutton>=0.5.0
 sphinx-remove-toctrees


### PR DESCRIPTION
`sphinx_autodoc_typehints` does not have any support for declaring type aliases (see https://github.com/tox-dev/sphinx-autodoc-typehints/issues/132 and https://github.com/tox-dev/sphinx-autodoc-typehints/issues/284). The only option is using their `typehints_formatter` config, which we probably shouldn't use because it breaks sphinx cacheing (see https://github.com/google/jax/pull/20872/)

The net result is that aliases like `ArrayLike` and `DtypeLike` are expanded into their full unions in our docs, which makes for a poor user experience. For example: here are the current [`jax.lax.argmin` docs](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.argmin.html):

![324624157-6fe8ed01-e958-46be-83a7-cb2f1031e53d](https://github.com/google/jax/assets/781659/c87ae36f-6dd0-474c-8822-a03d6cea30d8)

This PR removes the `sphinx_autodoc_typehints` extension, and instead uses sphinx's native typehint handlers; the result is this:
![Screenshot 2024-04-23 at 12 07 19 PM](https://github.com/google/jax/assets/781659/8928032a-c432-4842-ab06-8929befc33e6)

I have tried unsuccessfully to figure out how to make `jax.typing.ArrayLike` and `jax.typing.DtypeLike` link to their documentation page, but I think this is better than the current version.