### PR TITLE
Fix `jax.scipy.stats.poisson.logpmf` to emulate `scipy.stats.poisson.logpmf` for non-integer values of `k`

### DIFF
--- a/jax/_src/scipy/stats/poisson.py
+++ b/jax/_src/scipy/stats/poisson.py
@@ -29,7 +29,8 @@ def logpmf(k: ArrayLike, mu: ArrayLike, loc: ArrayLike = 0) -> Array:
   zero = _lax_const(k, 0)
   x = lax.sub(k, loc)
   log_probs = xlogy(x, mu) - gammaln(x + 1) - mu
-  return jnp.where(lax.lt(x, zero), -jnp.inf, log_probs)
+  return jnp.where(jnp.logical_or(lax.lt(x, zero),
+                                  lax.ne(jnp.round(k), k)), -jnp.inf, log_probs)
 
 @implements(osp_stats.poisson.pmf, update_doc=False)
 def pmf(k: ArrayLike, mu: ArrayLike, loc: ArrayLike = 0) -> Array:

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -129,7 +129,6 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
 
     def args_maker():
       k, mu, loc = map(rng, shapes, dtypes)
-      k = np.floor(k)
       # clipping to ensure that rate parameter is strictly positive
       mu = np.clip(np.abs(mu), a_min=0.1, a_max=None).astype(mu.dtype)
       loc = np.floor(loc)
@@ -148,7 +147,6 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
 
     def args_maker():
       k, mu, loc = map(rng, shapes, dtypes)
-      k = np.floor(k)
       # clipping to ensure that rate parameter is strictly positive
       mu = np.clip(np.abs(mu), a_min=0.1, a_max=None).astype(mu.dtype)
       loc = np.floor(loc)


### PR DESCRIPTION
Inconsistency exists between `jax.scipy.stats.poisson.logpmf` and `scipy.stats.poisson.logpmf` for non-integer `k`. This pull request rectifies this behavior, enabling both functions `jax.scipy.stats.poisson.logpmf` and `jax.scipy.stats.poisson.pmf`  to emulate their corresponding `scipy` counterparts for any `k` value.

Partly addresses #5650

Current Behavior:
```python
>>> import jax.scipy.stats as lsp
>>> import scipy.stats as osp
>>> osp.poisson.logpmf(k=1.2, mu=1)
-inf
>>> lsp.poisson.logpmf(k=1.2, mu=1)
Array(-1.0969486, dtype=float32, weak_type=True)
>>> osp.poisson.pmf(k=1.2, mu=1)
0.0
>>> lsp.poisson.pmf(k=1.2, mu=1)
Array(0.33388835, dtype=float32, weak_type=True)
```

With this change:
```python
>>> import jax.scipy.stats as lsp
>>> import scipy.stats as osp
>>> osp.poisson.logpmf(k=1.2, mu=1)
-inf
>>> lsp.poisson.logpmf(k=1.2, mu=1)
Array(-inf, dtype=float32, weak_type=True)
>>> osp.poisson.pmf(k=1.2, mu=1)
0.0
>>> lsp.poisson.pmf(k=1.2, mu=1)
Array(0., dtype=float32, weak_type=True)
```
