### PR TITLE
Update GPU and NVGPU MLIR bindings to match upstream MLIR changes

### DIFF
--- a/jaxlib/mlir/BUILD.bazel
+++ b/jaxlib/mlir/BUILD.bazel
@@ -242,6 +242,7 @@ symlink_inputs(
         ":core",
         ":ir",
         ":mlir",
+        "//jaxlib/mlir/_mlir_libs:_mlirDialectsNvgpu",
     ],
 )
 
@@ -290,6 +291,7 @@ py_library(
         ":core",
         ":ir",
         ":mlir",
+        "//jaxlib/mlir/_mlir_libs:_mlirDialectsGPU",
         "//jaxlib/mlir/_mlir_libs:_mlirGPUPasses",
     ],
 )

--- a/jaxlib/mlir/_mlir_libs/BUILD.bazel
+++ b/jaxlib/mlir/_mlir_libs/BUILD.bazel
@@ -75,6 +75,22 @@ py_extension(
 )
 
 py_extension(
+    name = "_mlirDialectsGPU",
+    srcs = [
+        "@llvm-project//mlir:lib/Bindings/Python/DialectGPU.cpp",
+    ],
+    copts = COPTS,
+    linkopts = LINKOPTS,
+    deps = [
+        ":jaxlib_mlir_capi_shared_library",
+        "@llvm-project//mlir:CAPIGPUHeaders",
+        "@llvm-project//mlir:CAPIIRHeaders",
+        "@llvm-project//mlir:MLIRBindingsPythonHeaders",
+        "@pybind11",
+    ],
+)
+
+py_extension(
     name = "_mlirGPUPasses",
     srcs = [
         "@llvm-project//mlir:lib/Bindings/Python/GPUPasses.cpp",
@@ -84,6 +100,22 @@ py_extension(
     deps = [
         ":jaxlib_mlir_capi_shared_library",
         "@llvm-project//mlir:CAPIGPUHeaders",
+        "@pybind11",
+    ],
+)
+
+py_extension(
+    name = "_mlirDialectsNvgpu",
+    srcs = [
+        "@llvm-project//mlir:lib/Bindings/Python/DialectNVGPU.cpp",
+    ],
+    copts = COPTS,
+    linkopts = LINKOPTS,
+    deps = [
+        ":jaxlib_mlir_capi_shared_library",
+        "@llvm-project//mlir:CAPIIRHeaders",
+        "@llvm-project//mlir:CAPINVGPUHeaders",
+        "@llvm-project//mlir:MLIRBindingsPythonHeaders",
         "@pybind11",
     ],
 )

--- a/jaxlib/tools/build_wheel.py
+++ b/jaxlib/tools/build_wheel.py
@@ -380,9 +380,12 @@ def prepare_wheel(sources_path: pathlib.Path, *, cpu, skip_gpu_kernels):
               "__main__/jaxlib/mlir/_mlir_libs/_triton_ext.pyi",
           ]
       ) + if_has_mosaic_gpu([
-          f"__main__/jaxlib/mlir/_mlir_libs/_mosaic_gpu_ext.{pyext}",
+          f"__main__/jaxlib/mlir/_mlir_libs/_mlirDialectsGPU.{pyext}",
           f"__main__/jaxlib/mlir/_mlir_libs/_mlirDialectsLLVM.{pyext}",
+          f"__main__/jaxlib/mlir/_mlir_libs/_mlirDialectsNvgpu.{pyext}",
           f"__main__/jaxlib/mlir/_mlir_libs/_mlirExecutionEngine.{pyext}",
+          f"__main__/jaxlib/mlir/_mlir_libs/_mlirGPUPasses.{pyext}",
+          f"__main__/jaxlib/mlir/_mlir_libs/_mosaic_gpu_ext.{pyext}",
       ]),
   )
 


### PR DESCRIPTION
Upstream MLIR Python bindings now require two more extension libraries to work properly. The dialects fail to import without this change.