### PR TITLE
Implements Ragged Dot API

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -784,6 +784,33 @@ def dot_general(lhs: ArrayLike, rhs: ArrayLike, dimension_numbers: DotDimensionN
                             precision=canonicalize_precision(precision),
                             preferred_element_type=preferred_element_type)
 
+
+def ragged_dot(
+    lhs: Array,
+    rhs: Array,
+    group_sizes: Array,
+    precision: PrecisionLike = None,
+    preferred_element_type: DTypeLike | None = None,
+    group_offset: Array | None = None,
+    ) -> Array:
+  """Ragged matrix multiplication.
+
+  Args:
+    lhs: (m, k) shaped array.
+    rhs: (g, k, n) shaped array.
+    group_sizes: (g,) shaped array with integer element type, where g denotes   number of groups. The ith element indicates the size of ith group.
+    precision: Optional. Consistent with precision argument for :func:`jax.lax.dot`.
+    preferred_element_type: Optional. Consistent with precision argument for :func:`jax.lax.dot`.
+    group_offset: Optional. (1,) shaped array that ndicates the group in group_sizes to start computing from. If not specified, defaults to [0].
+
+  Results:
+    (m, n) shaped array with preferred_element_type element type.
+  """
+  return ragged_dot_p.bind(lhs, rhs, group_sizes,
+                            precision=canonicalize_precision(precision),
+                            preferred_element_type=preferred_element_type, group_offset=group_offset)
+
+
 def broadcast(operand: ArrayLike, sizes: Sequence[int]) -> Array:
   """Broadcasts an array, adding new leading dimensions
 
@@ -2944,6 +2971,62 @@ for platform in ["cpu", "tpu"]:
   mlir.register_lowering(dot_general_p,
                          partial(_dot_general_lower, platform=platform),
                          platform=platform)
+
+
+def _ragged_dot_shape_rule(lhs: Array, rhs: Array, group_sizes: Array, **_) -> Shape:
+  m, k = lhs.shape
+  group_count, rk, n = rhs.shape
+  if k != rk:
+    raise TypeError("ragged_dot requires that lhs.shape[1] == rhs.shape[1]: got {} and {}.".format(k, rk))
+  num_groups = group_sizes.shape[0]
+  if group_count != num_groups:
+    raise TypeError("ragged_dot requires that rhs.shape[0] == group_sizes.shape[0]: got {} and {}.".format(group_count, num_groups))
+  return (m, n)
+
+# DotDimensionNumbers used in the dot_general call for ragged_dot().
+_RAGGED_DOT_DOT_DIMENSION_NUMBERS: DotDimensionNumbers = (([2, 0], [1, 0]), ([], []))
+
+def _ragged_dot_dtype_rule(lhs: Array, rhs: Array, group_sizes: Array,
+                           precision,                          preferred_element_type: DTypeLike | None, **_) -> np.dtype:
+  if not dtypes.issubdtype(group_sizes.dtype, np.integer):
+    raise TypeError("ragged_dot requires that group_sizes.dtype is subtype of np.integer.")
+  # defer the output dtype to dot_general, which is part of the _ragged_dot_impl.
+  return _dot_general_dtype_rule(lhs, rhs, dimension_numbers=_RAGGED_DOT_DOT_DIMENSION_NUMBERS, precision=precision, preferred_element_type=preferred_element_type)
+
+ragged_dot_p = standard_primitive(_ragged_dot_shape_rule,
+                                  _ragged_dot_dtype_rule, 'ragged_dot')
+ragged_dot_p.def_impl(partial(dispatch.apply_primitive, ragged_dot_p))
+
+def _ragged_dot_impl(
+    lhs: Array,
+    rhs: Array,
+    group_sizes: Array,
+    precision: PrecisionLike = None,
+    preferred_element_type: DTypeLike | None = None,
+    group_offset: Array | None = None,
+    ) -> Array:
+  if group_offset is not None:
+    raise NotImplementedError("Unimplemented group_offset support.")
+  shape = (rhs.shape[0], lhs.shape[0], lhs.shape[1])
+  lhs = broadcast_in_dim(lhs, shape, [1, 2])
+  iota = broadcasted_iota(group_sizes.dtype, shape, 1)
+  group_ends = jax.lax.cumsum(group_sizes)
+  group_starts = concatenate(
+      [_zeros(group_sizes)[:1], group_ends[:-1]], dimension=0,
+  )
+  group_ends = broadcast_in_dim(group_ends, shape, (0,))
+  group_starts = broadcast_in_dim(group_starts, shape, (0,))
+  mask = bitwise_and(group_starts <= iota, iota < group_ends)
+  lhs = select(mask, lhs, _zeros(lhs))
+  return dot_general(
+      lhs,
+      rhs,
+      dimension_numbers=_RAGGED_DOT_DOT_DIMENSION_NUMBERS,
+      precision=precision,
+      preferred_element_type=preferred_element_type,
+  )
+
+mlir.register_lowering(ragged_dot_p, mlir.lower_fun(_ragged_dot_impl, multiple_results=False))
 
 
 def _broadcast_in_dim_shape_rule(operand, *, shape, broadcast_dimensions):

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1527,6 +1527,7 @@ tf_not_yet_impl = [
     "platform_index",
     "assert_consumed_value",
     "consume",
+    "ragged_dot",
 ]
 
 tf_impl[random_internal.random_clone_p] = lambda x: x

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -1730,6 +1730,15 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
     f_switch_tf = jax2tf.convert(f_switch, enable_xla=False)
     self.assertIn("switch_case", self.TfToHlo(f_switch_tf, np.pi))
 
+  @jtu.skip_on_flag("jax2tf_default_native_serialization", False)
+  def test_ragged_dot(self):
+    dtype = np.float32
+    m, k, n, num_groups = 5, 4, 3, 2
+    lhs = np.arange(m * k, dtype=dtype).reshape((m, k))
+    rhs = np.arange(num_groups * k * n, dtype=dtype).reshape((num_groups, k, n))
+    group_sizes = np.array([3, 2], dtype=np.int32)
+    self.ConvertAndCompare(jax.lax.ragged_dot, lhs, rhs, group_sizes)
+
 
 @jtu.with_config(jax_enable_custom_prng=True)
 class Jax2tfWithCustomPRNGTest(tf_test_util.JaxToTfTestCase):

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -152,6 +152,7 @@ from jax._src.lax.lax import (
   population_count_p as population_count_p,
   pow as pow,
   pow_p as pow_p,
+  ragged_dot as ragged_dot,
   real as real,
   real_p as real_p,
   reciprocal as reciprocal,


### PR DESCRIPTION
# Background

Ragged Dot is a specialized matrix multiplication operation that is commonly used in the context of Mixture of Experts (MoE) models. MoE models are a type of neural network architecture that consists of a collection of independent expert networks, each of which is responsible for processing a specific subset of the input data. In order to determine which expert should process a given input, a routing mechanism is employed. Ragged Dot plays a crucial role in this routing process.

At the linear algebra level, Ragged Dot can be defined as follows:

Given matrices, A (m x k), B (g x k x n), and G (g), where m is the number of input samples, k is the dimensionality of the input features, and g is the number of experts, the Ragged Dot operation produces a matrix C (m x n), where each row of C corresponds to the weighted sum of the corresponding row of A and the columns of B associated with the expert assigned to that input sample.

More formally, the (i, j)-th element of C is computed as follows:

```
C[i, j] = \sum_{k=1}^{k} A[i, k] * B[g,k, j]
```

where k ranges over the columns of B associated with the expert assigned to the i-th input sample.

The key characteristic of Ragged Dot is that the rows of A and slices of B in the 0th dimension (of size g) are grouped into disjoint sets, with each set corresponding to an expert. This grouping structure allows the routing mechanism to efficiently assign input samples to the appropriate experts.

# Requirements

Arguments:
+ lhs: (m, k) shaped array with integer or floating point element type. (REQUIRED)
+ rhs: (g1, k, n) shaped array with integer or floating point element type, where g1 denotes the number of local groups. (REQUIRED)
+ group_sizes: (g2,) shaped array with integer element type, where g2 denotes number of groups. The ith element indicates the size of ith group. (REQUIRED)
+ precision: consistent with precision argument for [jax.lax.dot](https://jax.readthedocs.io/en/latest/_autosummary/.html). (OPTIONAL).
+ preferred_element_type: the element type (jnp.dtype) for the output array. Consistent with preferred_element_type argument for [jax.lax.dot](https://jax.readthedocs.io/en/latest/_autosummary/.html). (OPTIONAL).
+ group_offset: (1,) shaped array. Indicates the group in group_sizes to start computing from. (OPTIONAL) If not specified, defaults to [0].
+ existing_output: (m, n) shaped array with elements of type preferred_element_type, where the output should we written to. (OPTIONAL) defaults to None, in which case the output should be written to a newly allocated array.

Results:
+ (m, n) shaped array with preferred_element_type element type.

Preconditions:

1. group_sizes = [s_1, ..., s_g2], where s_1 + ... + s_g2 <= m

2. g1 <= g2 (number of local groups <= number of groups).

If g1 == g2, group_offsets must be either unspecified or explicitly set to [0].

If g1 < g2, group_offsets must contain a single value in [0, g2) where group_offsets[0] + g1 <= g2. In this case, we perform g1 dots, where irrelevant slices of the results remain unchanged.

