### PR TITLE
DOC: improve documentation of where, nonzero, and related functions

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6017,7 +6017,9 @@ class NumpyDocTests(jtu.JaxTestCase):
     # Test that docstring wrapping & transformation didn't fail.
 
     # Functions that have their own docstrings & don't wrap numpy.
-    known_exceptions = {'fromfile', 'fromiter', 'frompyfunc', 'vectorize'}
+    known_exceptions = {
+      'fromfile', 'fromiter', 'frompyfunc', 'vectorize',
+      'argwhere', 'where', 'nonzero', 'flatnonzero'}
 
     for name in dir(jnp):
       if name in known_exceptions or name.startswith('_'):


### PR DESCRIPTION
These are functions where the arguments and constraints differ enough from numpy that it's useful to write our own docstrings from scratch.

Rendered preview:
- [`argwhere`](https://jax--20941.org.readthedocs.build/en/20941/_autosummary/jax.numpy.argwhere.html)
- [`flatnonzero`](https://jax--20941.org.readthedocs.build/en/20941/_autosummary/jax.numpy.flatnonzero.html)
- [`nonzero`](https://jax--20941.org.readthedocs.build/en/20941/_autosummary/jax.numpy.nonzero.html)
- [`where`](https://jax--20941.org.readthedocs.build/en/20941/_autosummary/jax.numpy.where.html)

Part of #21461.