### PR TITLE
Expose tile function in array_api namespace

### DIFF
--- a/jax/experimental/array_api/__init__.py
+++ b/jax/experimental/array_api/__init__.py
@@ -180,6 +180,7 @@ from jax.experimental.array_api._manipulation_functions import (
     roll as roll,
     squeeze as squeeze,
     stack as stack,
+    tile as tile,
     unstack as unstack,
 )
 

--- a/jax/experimental/array_api/_manipulation_functions.py
+++ b/jax/experimental/array_api/_manipulation_functions.py
@@ -83,6 +83,12 @@ def stack(arrays: tuple[Array, ...] | list[Array], /, *, axis: int = 0) -> Array
   dtype = _result_type(*arrays)
   return jax.numpy.stack(arrays, axis=axis, dtype=dtype)
 
+
+def tile(x: Array, repetitions: tuple[int], /) -> Array:
+  """Constructs an array by tiling an input array."""
+  return jax.numpy.tile(x, repetitions)
+
+
 def unstack(x: Array, /, *, axis: int = 0) -> tuple[Array, ...]:
   """Splits an array in a sequence of arrays along the given axis."""
   return jax.numpy.unstack(x, axis=axis)

--- a/tests/array_api_test.py
+++ b/tests/array_api_test.py
@@ -161,6 +161,7 @@ MAIN_NAMESPACE = {
   'tan',
   'tanh',
   'tensordot',
+  'tile',
   'tril',
   'triu',
   'trunc',


### PR DESCRIPTION
Towards https://github.com/google/jax/issues/20200

Exposes `jax.experimental.array_api.tile` which is a thin wrapper around `jax.numpy.tile`