### PR TITLE
DOC: improve docs of transpose & matrix_transpose

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6018,9 +6018,17 @@ class NumpyDocTests(jtu.JaxTestCase):
 
     # Functions that have their own docstrings & don't wrap numpy.
     known_exceptions = {
-      'fromfile', 'fromiter', 'frompyfunc', 'vectorize',
-      'argwhere', 'where', 'nonzero', 'flatnonzero'}
-
+      'argwhere',
+      'flatnonzero',
+      'fromfile',
+      'fromiter',
+      'frompyfunc',
+      'matrix_transpose',
+      'nonzero',
+      'transpose',
+      'vectorize',
+      'where',
+    }
     for name in dir(jnp):
       if name in known_exceptions or name.startswith('_'):
         continue


### PR DESCRIPTION
The current docs are somewhat confusing because numpy emphasizes that a view is returned, whereas this is not the case for JAX's versions of these functions.

Part of #21461.