### PR TITLE
Fix mlir.merge_mlir_modules to properly remember the inlined symbols

### DIFF
--- a/jax/experimental/export/_export.py
+++ b/jax/experimental/export/_export.py
@@ -1179,7 +1179,8 @@ def _call_exported_lowering(ctx: mlir.LoweringRuleContext, *args,
   # TODO: maybe cache multiple calls
   fn = mlir.merge_mlir_modules(ctx.module_context.module,
                                f"call_exported_{exported.fun_name}",
-                               submodule)
+                               submodule,
+                               dst_symtab=ctx.module_context.symbol_table)
 
   submodule_args = []
   # All the platforms for the current lowering must be among the platforms

--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -571,7 +571,8 @@ def _call_tf_lowering(
   callee_result_types = symtab["main"].type.results
   fn = mlir.merge_mlir_modules(ctx.module_context.module,
                                f"call_tf_{function_flat_tf.name}",
-                               submodule)
+                               submodule,
+                               dst_symtab=ctx.module_context.symbol_table)
   call = func_dialect.CallOp(callee_result_types,
                              ir.FlatSymbolRefAttr.get(fn),
                              tuple(args_op) + captured_ops)


### PR DESCRIPTION
Previously, the `merge_mlir_modules` renamed the inlined symbols to ensure they do not clash with the symbols in the destination module. However, the inlined symbols were not inserted in the symbol table so a conflict could arise later.