### PR TITLE
Fix pytest failures from compilation cache test.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,9 @@ filterwarnings = [
     "ignore:numpy.ufunc size changed",
     "ignore:.*experimental feature",
     "ignore:The distutils.* is deprecated.*:DeprecationWarning",
+    "default:Error reading persistent compilation cache entry for 'jit_equal'",
     "default:Error reading persistent compilation cache entry for 'jit__lambda_'",
+    "default:Error writing persistent compilation cache entry for 'jit_equal'",
     "default:Error writing persistent compilation cache entry for 'jit__lambda_'",
     "ignore:backend and device argument on jit is deprecated.*:DeprecationWarning",
     # TODO(skyewm): remove when jaxlib >= 0.4.12 is released (needs


### PR DESCRIPTION
The names of the functions in the compilation cache tests changed, causing warnings emitted by that test to become errors.