### PR TITLE
DOC: improve docs for reshape() and ravel()

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6026,9 +6026,12 @@ class NumpyDocTests(jtu.JaxTestCase):
       'matrix_transpose',
       'nonzero',
       'transpose',
+      'ravel',
+      'reshape',
       'vectorize',
       'where',
     }
+
     for name in dir(jnp):
       if name in known_exceptions or name.startswith('_'):
         continue


### PR DESCRIPTION
Similar to #20957, these are functions where the view semantics differ from those of NumPy, so documenting the correct features from scratch is better than relying on a JAX-specific note above inaccurate docs.

Rendered preview:

- [`reshape`](https://jax--20980.org.readthedocs.build/en/20980/_autosummary/jax.numpy.reshape.html)
- [`ravel`](https://jax--20980.org.readthedocs.build/en/20980/_autosummary/jax.numpy.ravel.html)

Part of #21461.