### PR TITLE
[omnitracing] pop frames, see if anything downstream breaks

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -423,7 +423,8 @@ class Primitive:
     return self.bind_with_trace(find_top_trace(args), args, params)
 
   def bind_with_trace(self, trace, args, params):
-    out = trace.process_primitive(self, map(trace.full_raise, args), params)
+    with pop_level(trace.level):
+      out = trace.process_primitive(self, map(trace.full_raise, args), params)
     return map(full_lower, out) if self.multiple_results else full_lower(out)
 
   def def_impl(self, impl):
@@ -1244,6 +1245,17 @@ def new_base_main(trace_type: type[Trace],
     if t() is not None:
       leaked_tracers = maybe_find_leaked_tracers(t())
       if leaked_tracers: raise leaked_tracer_error("trace", t(), leaked_tracers)
+
+@contextmanager
+def pop_level(level: int):
+  level = max(level, 1)  # don't pop the base
+  prev, thread_local_state.trace_state.trace_stack.stack = \
+      thread_local_state.trace_state.trace_stack.stack, \
+      thread_local_state.trace_state.trace_stack.stack[:level]
+  try:
+    yield
+  finally:
+    thread_local_state.trace_state.trace_stack.stack = prev
 
 @contextmanager
 def ensure_compile_time_eval():


### PR DESCRIPTION
At HEAD, as we process frames on the interpreter stack, we don't actually pop them off the stack; we just leave them there, confident that we can't hit them again because `find_top_trace` won't be able to produce them.

Let's try popping them off! (In preparation for introducing an impure bind which doesn't work by data dependence, and instead always uses the top of the stack.)