### PR TITLE
Use self in _ProfileState.reset

### DIFF
--- a/jax/_src/profiler.py
+++ b/jax/_src/profiler.py
@@ -78,10 +78,10 @@ class _ProfileState:
     self.lock = threading.Lock()
 
   def reset(self):
-    _profile_state.profile_session = None
-    _profile_state.create_perfetto_link = False
-    _profile_state.create_perfetto_trace = False
-    _profile_state.log_dir = None
+    self.profile_session = None
+    self.create_perfetto_link = False
+    self.create_perfetto_trace = False
+    self.log_dir = None
 
 
 _profile_state = _ProfileState()


### PR DESCRIPTION
From the member function, modify the self instance instead of the global variable.