### PR TITLE
Bundle MLIR .pyi files with jaxlib

### DIFF
--- a/jaxlib/mlir/BUILD.bazel
+++ b/jaxlib/mlir/BUILD.bazel
@@ -44,7 +44,10 @@ symlink_inputs(
     name = "ir",
     rule = py_library,
     symlinked_inputs = {"srcs": {
-        ".": ["@llvm-project//mlir/python:IRPyFiles"],
+        ".": [
+            "@llvm-project//mlir/python:IRPyFiles",
+            "@llvm-project//mlir/python:IRPyIFiles",
+        ],
     }},
     deps = [
         ":mlir",
@@ -197,7 +200,10 @@ symlink_inputs(
     name = "pass_manager",
     rule = py_library,
     symlinked_inputs = {"srcs": {
-        ".": ["@llvm-project//mlir/python:PassManagerPyFiles"],
+        ".": [
+            "@llvm-project//mlir/python:PassManagerPyFiles",
+            "@llvm-project//mlir/python:PassManagerPyIFiles",
+        ],
     }},
     deps = [
         ":mlir",
@@ -224,6 +230,7 @@ symlink_inputs(
     symlinked_inputs = {"srcs": {
         ".": [
             "@llvm-project//mlir/python:ExecutionEnginePyFiles",
+            "@llvm-project//mlir/python:ExecutionEnginePyIFiles",
         ],
     }},
     deps = [

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -102,6 +102,7 @@ setup(
             'mosaic/python/*.py',
             'mosaic/python/*.so',
             'mlir/*.py',
+            'mlir/*.pyi',
             'mlir/dialects/*.py',
             'mlir/dialects/gpu/*.py',
             'mlir/dialects/gpu/passes/*.py',

--- a/jaxlib/tools/build_wheel.py
+++ b/jaxlib/tools/build_wheel.py
@@ -283,9 +283,12 @@ def prepare_wheel(sources_path: pathlib.Path, *, cpu, skip_gpu_kernels):
       dst_dir=jaxlib_dir / "mlir",
       src_files=[
           "__main__/jaxlib/mlir/ir.py",
+          "__main__/jaxlib/mlir/ir.pyi",
           "__main__/jaxlib/mlir/passmanager.py",
+          "__main__/jaxlib/mlir/passmanager.pyi",
       ] + if_has_mosaic_gpu([
           "__main__/jaxlib/mlir/execution_engine.py",
+          "__main__/jaxlib/mlir/execution_engine.pyi",
       ]),
   )
   copy_runfiles(


### PR DESCRIPTION
This allows mypy and pyright to type check the code which uses MLIR Python APIs.