### PR TITLE
Make linkcode_resolve() a bit more robust

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import inspect
+import operator
 import os
 import sys
 
@@ -318,7 +319,11 @@ def linkcode_resolve(domain, info):
     return None
   try:
     mod = sys.modules.get(info['module'])
-    obj = getattr(mod, info['fullname'])
+    obj = operator.attrgetter(info['fullname'])(mod)
+    if isinstance(obj, property):
+        obj = obj.fget
+    if hasattr(obj, '__wrapped__'):  # jit decorated functions
+        obj = obj.__wrapped__
     filename = inspect.getsourcefile(obj)
     source, linenum = inspect.getsourcelines(obj)
   except:


### PR DESCRIPTION
This handles three cases that came up when adopting this snippet (for finding source code corresponding to API docs) [for neuralgcm](https://github.com/google-research/neuralgcm/pull/58):

1. documenting class method or attributes
2. documenting properties
3. documenting `jit` decorated methods

I'm not sure if case (1) or (2) comes up in the JAX docs, but case (3) definitely does -- `jit` decorated functions like `jax.nn.relu` [currently do not](https://jax.readthedocs.io/en/latest/_autosummary/jax.nn.relu.html) have a source code link. This is because `jit` is implemented in C++, so `inspect` can't find the source code.