### PR TITLE
Recursively pull out __wrapped__ in linkcode_resolve()

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -322,7 +322,7 @@ def linkcode_resolve(domain, info):
     obj = operator.attrgetter(info['fullname'])(mod)
     if isinstance(obj, property):
         obj = obj.fget
-    if hasattr(obj, '__wrapped__'):  # jit decorated functions
+    while hasattr(obj, '__wrapped__'):  # decorated functions
         obj = obj.__wrapped__
     filename = inspect.getsourcefile(obj)
     source, linenum = inspect.getsourcelines(obj)


### PR DESCRIPTION
This should actually fix the source lookup for `jax.nn.relu`, which uses both `custom_jvp` and `jit` decorators.