### PR TITLE
fix vmap-grad-remat-shmap bug with spmd_axis_name

### DIFF
--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -1300,7 +1300,7 @@ def _shard_map_partial_eval(trace, shard_map_p, f, tracers, mesh, in_names,
   in_pvals = [t.pval for t in tracers]
   in_knowns, in_avals, in_consts = pe.partition_pvals(in_pvals)
   unk_in_names, known_in_names = pe.partition_list(in_knowns, in_names)
-  used_names = {n for names in known_in_names for ns in names.values() for n in ns}
+  all_names = _all_mesh_names(mesh)
   in_avals_sharded = map(partial(_shard_aval, mesh), unk_in_names, in_avals)
   f = pe.trace_to_subjaxpr_nounits_fwd2(f, trace.main, False)
   f = _promote_scalar_residuals(f)
@@ -1312,7 +1312,7 @@ def _shard_map_partial_eval(trace, shard_map_p, f, tracers, mesh, in_names,
     in_fwd, out_fwd, out_knowns, _, jaxpr, _ = aux()
     _, out_known_names = pe.partition_list(out_knowns, out_names_thunk())
     num_res = sum(f1 is None and f2 is None for f1, f2 in zip(in_fwd, out_fwd))
-    return (*out_known_names, *({0: (*used_names,)},) * num_res)
+    return (*out_known_names, *({0: (*all_names,)},) * num_res)
 
   known_params = dict(mesh=mesh, in_names=(*known_in_names,),
                       out_names_thunk=known_out_names, check_rep=check_rep,
@@ -1327,7 +1327,7 @@ def _shard_map_partial_eval(trace, shard_map_p, f, tracers, mesh, in_names,
   res = subs_list2(in_fwd, out_fwd, in_consts, out_consts, non_fwd_res)
   res_names = [known_in_names[f1] if f1 is not None else
                known_out_names_[f2] if f2 is not None else
-               {0: (*used_names,)} for f1, f2 in zip(in_fwd, out_fwd)]
+               {0: (*all_names,)} for f1, f2 in zip(in_fwd, out_fwd)]
   unk_in_names = (*res_names,) + ({},) * len(env) + (*unk_in_names,)
   const_tracers = map(trace.new_instantiated_const, res)
   env_tracers = map(trace.full_raise, env)
@@ -1349,7 +1349,7 @@ pe.JaxprTrace.process_shard_map = _shard_map_partial_eval
 def _shard_map_partial_eval_post_process(
     trace, tracers, mesh, in_names, out_names_thunk, check_rep, rewrite, auto):
   del check_rep
-  used_names = {n for names in in_names for ns in names.values() for n in ns}
+  all_names = _all_mesh_names(mesh)
   unk_tracers = [t for t in tracers if not t.is_known()]
   jaxpr, res, env = pe.tracers_to_jaxpr([], unk_tracers)
   # TODO(mattjj): output forwarding optimization
@@ -1370,7 +1370,7 @@ def _shard_map_partial_eval_post_process(
     const_tracers = map(trace.new_instantiated_const, res_)
     env_tracers = map(trace.full_raise, env)
 
-    staged_in_names = ({0: (*used_names,)},) * len(res_) + ({},) * len(env)
+    staged_in_names = ({0: (*all_names,)},) * len(res_) + ({},) * len(env)
     staged_params = dict(jaxpr=jaxpr_, mesh=mesh, in_names=staged_in_names,
                          out_names=(*out_names_unknown,), check_rep=False,
                          rewrite=rewrite, auto=auto)
@@ -1389,7 +1389,7 @@ def _shard_map_partial_eval_post_process(
   def out_names_transform(out_names):
     nonlocal out_names_unknown
     out_names_unknown, out_names_known = partition_list(out_knowns, out_names)
-    return (*out_names_known,) + ({0: (*used_names,)},) * len(res)
+    return (*out_names_known,) + ({0: (*all_names,)},) * len(res)
   out_names_unknown: list | None = None
 
   return out, (todo, out_names_transform)
@@ -1499,10 +1499,10 @@ def _partial_eval_jaxpr_custom_rule(
   _, ins_staged = partition_list(inst_in, eqn.invars)
   _, out_binders_staged = partition_list(inst_out, eqn.outvars)
   newvar = core.gensym()
-  params_known, params_staged = _pe_custom_params(
+  params_known, params_staged, all_names = _pe_custom_params(
       unks_in, inst_in, map(op.not_, unks_out), inst_out, in_fwd, out_fwd, which,
       dict(eqn.params, jaxpr=jaxpr_known), dict(eqn.params, jaxpr=jaxpr_staged))
-  residuals = [newvar(_unshard_aval(mesh, {0: (*mesh.axis_names,)}, var.aval))
+  residuals = [newvar(_unshard_aval(mesh, {0: (*all_names,)}, var.aval))
                for var, w in zip(jaxpr_staged.invars[:num_res], which) if w]
   eqn_known = pe.new_jaxpr_eqn(ins_known, [*out_binders_known, *residuals],
                                eqn.primitive, params_known, jaxpr_known.effects,
@@ -1551,9 +1551,10 @@ def _pe_custom_params(unks_in, inst_in, kept_outs_known, kept_outs_staged,
                       in_fwd, out_fwd, which, params_known, params_staged):
   # prune inputs to jaxpr_known according to unks_in
   mesh = params_known['mesh']
+  all_names = _all_mesh_names(mesh)
   in_names_known, _ = partition_list(unks_in, params_known['in_names'])
   _, out_names_known = partition_list(kept_outs_known, params_known['out_names'])
-  out_names_known = out_names_known + [{0: (*mesh.axis_names,)}] * sum(which)
+  out_names_known = out_names_known + [{0: (*all_names,)}] * sum(which)
   new_params_known = dict(params_known, in_names=tuple(in_names_known),
                           out_names=tuple(out_names_known))
 
@@ -1561,12 +1562,22 @@ def _pe_custom_params(unks_in, inst_in, kept_outs_known, kept_outs_staged,
   _, in_names_staged = partition_list(inst_in, params_staged['in_names'])
   res_names = [in_names_known[f1] if f1 is not None else
                out_names_known[f2] if f2 is not None else
-               {0: (*mesh.axis_names,)} for f1, f2 in zip(in_fwd, out_fwd)]
+               {0: (*all_names,)} for f1, f2 in zip(in_fwd, out_fwd)]
   in_names_staged = res_names + in_names_staged
   _, out_names_staged = partition_list(kept_outs_staged, params_staged['out_names'])
   new_params_staged = dict(params_staged, in_names=tuple(in_names_staged),
                            out_names=tuple(out_names_staged), check_rep=False)
-  return new_params_known, new_params_staged
+  return new_params_known, new_params_staged, all_names
+
+
+# TODO(mattjj): remove this mechanism when we revise mesh scopes
+def _all_mesh_names(mesh: Mesh) -> set[AxisName]:
+  stack = core.thread_local_state.trace_state.trace_stack.stack
+  names = {n for frame in stack
+           if (ns := frame.payload.get('spmd_axis_name', ())) is not None
+           for n in ns}
+  return set(mesh.axis_names) - names
+
 
 # DCE
 


### PR DESCRIPTION
The fix in #21032 was not correct because it assumed that the set of all mesh axis names appearing in in_specs was an upper bound on the set of mesh axes over which residuals could be device-varying. But collectives can introduce device variance! So it's not an upper bound.

We track device variance when check_rep=True, but often people set check_rep=False (e.g. when using pallas_call in a shard_map). So relying on our device variance tracking would be limiting. That may be a decent long term solution, if we can make it easy to annotate pallas_calls with device variance information. But it's not a great short term one to unblock things.

So instead I temporarily went with context sensitivity: instead of making residuals sharded over all mesh.axis_names (as we did before these patches), we make them sharded over all mesh axis names _excluding_ any spmd_axis_names in our dynamic context (by looking at the traces in our trace stack). It's illegal to mention any spmd_axis_names in collectives (indeed anywhere in the body of the function being vmapped), but I don't think we check it.

TODO(mattjj): add more testing (maybe in follow-ups)