### PR TITLE
Add support for device kwarg in astype, and add matching utility func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Remember to align the itemized text with the first line of an item within a list
 
 ## jax 0.4.28 (May 9, 2024)
 
+* New Functionality
+  * {func}`jax.numpy.astype` supports a new `device` keyword argument.
+
 * Bug fixes
   * Reverted a change to `make_jaxpr` that was breaking Equinox (#21116).
 

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2853,17 +2853,13 @@ def astype(x: ArrayLike, dtype: DTypeLike | None,
   # to issue our warning.
   with warnings.catch_warnings():
     warnings.simplefilter("ignore", ComplexWarning)
-    return _place_array(
+    return util._place_array(
       lax.convert_element_type(x_arr, dtype),
-      device=device, copy=copy,
+      device=device,
+      # We translate between array API semantics of copy in _place_array, and
+      # the NumPy semantics of copy in astype.
+      copy=True if copy else None,
     )
-
-def _place_array(x, device=None, copy=None):
-  # TODO(micky774): Implement in future PRs as we formalize device placement
-  # semantics
-  if copy:
-    return _array_copy(x)
-  return x
 
 
 @util.implements(np.asarray, lax_description=_ARRAY_DOC)

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -18,14 +18,16 @@ from functools import partial
 import re
 import textwrap
 from typing import Any, Callable, NamedTuple, TypeVar
-
 import warnings
+
+from jax.sharding import Sharding
 
 from jax._src import api
 from jax._src import config
 from jax._src import core
 from jax._src import dtypes
 from jax._src.lax import lax
+from jax._src.lib import xla_client as xc
 from jax._src.util import safe_zip, safe_map
 from jax._src.typing import Array, ArrayLike, DimSize, DType, DTypeLike, Shape
 
@@ -115,6 +117,27 @@ def _parse_extra_params(extra_params: str) -> dict[str, str]:
   """Parse the extra parameters passed to implements()"""
   parameters = _parameter_break.split(extra_params.strip('\n'))
   return {p.partition(' : ')[0].partition(', ')[0]: p for p in parameters}
+
+
+def _place_array(x: Array, device: xc.Device | Sharding | None = None, copy=None) -> Array:
+  """Helper utility for copying an array, or placing it on a device or sharding.
+
+  This utility uses `jax.device_put` for device placement.
+  """
+  out = x
+  if device is not None:
+    # TODO(micky774): Add check to avoid error if no actual device transfer is
+    # necessary
+    if copy is not None and not copy:
+      raise ValueError(
+        f"Specified {device=} which requires a copy, however copy=False. Set "
+        "copy=True or copy=None to perform the requested operation."
+      )
+    out = api.device_put(out, device)
+
+  # TODO(micky774): Avoid copy if data has already been copied via device
+  # transfer
+  return lax._array_copy(out) if copy else out
 
 
 def implements(

--- a/jax/experimental/array_api/__init__.py
+++ b/jax/experimental/array_api/__init__.py
@@ -32,6 +32,12 @@ The ``xp`` namespace is the array API compliant analog of :mod:`jax.numpy`,
 and implements most of the API listed in the standard.
 
 .. _Python array API standard: https://data-apis.org/array-api/latest/
+
+
+Note that JAX may not always strictly adhere to array API device semantics when
+using ``jax.jit``. In particular, specifying the ``device`` argument is
+equivalent to calling ``jax.device_put(x, device)``. For up-to-date details on
+device placement, see the documentation of ``jax.device_put`` for more details.
 """
 
 from __future__ import annotations

--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -195,13 +195,14 @@ class DLPackTest(jtu.JaxTestCase):
     shape=all_shapes,
     dtype=numpy_dtypes,
     copy=[False, True],
+    device_transfer=[False, True],
   )
-  def testNumpyToJax(self, shape, dtype, copy):
+  def testNumpyToJax(self, shape, dtype, copy, device_transfer):
     rng = jtu.rand_default(self.rng())
     x_np = rng(shape, dtype)
-    device = jax.devices()[0]
+    device = jax.devices()[0] if device_transfer else None
     _from_dlpack = lambda: jnp.from_dlpack(x_np, device=device, copy=copy)
-    if jax.default_backend() == 'gpu' and not copy:
+    if device_transfer and not copy:
       self.assertRaisesRegex(
         ValueError,
         r"Specified .* which requires a copy",


### PR DESCRIPTION
Towards https://github.com/google/jax/issues/20200

This PR adds a private device-placement utility `jax._src.numpy.util._place_array` to manage array API compliant array placement behavior for use in the `jax.numpy` namespace. Copies are mediated by the `lax._array_copy` utility, while device transfer is performed via `api.device_put`. 

cc: @jakevdp 