### PR TITLE
CI: print numpy/scipy version in upstream job

### DIFF
--- a/.github/workflows/upstream-nightly.yml
+++ b/.github/workflows/upstream-nightly.yml
@@ -54,6 +54,8 @@ jobs:
             --upgrade \
             numpy \
             scipy
+          python -c "import numpy; print(f'numpy.__version__=')"
+          python -c "import scipy; print(f'scipy.__version__=')"
       - name: Install JAX
         run: |
           pip install .[ci]


### PR DESCRIPTION
The upstream wheels don't have the date or commit hash in their filename or metadata version string, but they do have this in the runtime version string. Printing this will help with debugging, because we can see exactly which version is being installed.