### PR TITLE
Add optional size argument to jnp.compress & jnp.extract

### DIFF
--- a/jax/_src/numpy/array_methods.py
+++ b/jax/_src/numpy/array_methods.py
@@ -304,11 +304,13 @@ def __array_module__(self, types):
 
 
 def _compress_method(a: ArrayLike, condition: ArrayLike,
-                     axis: int | None = None, out: None = None) -> Array:
+                     axis: int | None = None, *, out: None = None,
+                     size: int | None = None, fill_value: ArrayLike = 0) -> Array:
   """Return selected slices of this array along given axis.
 
   Refer to :func:`jax.numpy.compress` for full documentation."""
-  return lax_numpy.jaxcompress(condition, a, axis, out)
+  return lax_numpy.compress(condition, a, axis=axis, out=out,
+                            size=size, fill_value=fill_value)
 
 
 @core.stash_axis_env()


### PR DESCRIPTION
Preview new docs:
- [``jnp.compress``](https://jax--21090.org.readthedocs.build/en/21090/_autosummary/jax.numpy.compress.html)
- [``jnp.extract``](https://jax--21090.org.readthedocs.build/en/21090/_autosummary/jax.numpy.extract.html)
Part of #3614