### PR TITLE
Skip float64 test_nextafter on TPU.

### DIFF
--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -1537,6 +1537,8 @@ class PallasOpsTest(PallasTest):
 
   @parameterized.parameters("float32", "float64")
   def test_nextafter(self, dtype):
+    if jtu.test_device_matches(["tpu"]) and dtype == "float64":
+        self.skipTest("float64 disabled on TPU.")
     @functools.partial(
         self.pallas_call, out_shape=jax.ShapeDtypeStruct((4,), dtype), grid=1
     )


### PR DESCRIPTION
Skip float64 test for `test_nextafter` on TPU. X64 lowering is not currently enabled on the backend.

Error: https://github.com/google/jax/actions/runs/8958798888/job/24603466593
```
...
jax/_src/compiler.py:333: in compile_or_get_cached
    return _compile_and_write_cache(
jax/_src/compiler.py:500: in _compile_and_write_cache
    executable = backend_compile(
jax/_src/profiler.py:335: in wrapper
    return func(*args, **kwargs)
jax/_src/compiler.py:238: in backend_compile
    return backend.compile(built_c, compile_options=options)
E   jaxlib.xla_extension.XlaRuntimeError: UNIMPLEMENTED: While rewriting computation to not contain X64 element types, XLA encountered an HLO for which this rewriting is not implemented: %bitcast-convert.45 = s64[4]{0} bitcast-convert(f64[4]{0} %broadcast.39), metadata={op_name="jit(wrapped)/jit(main)/while/body/nextafter" source_file="/home/runner/actions-runner/_work/jax/jax/tests/pallas/pallas_test.py" source_line=1551}
```