### PR TITLE
CI: fix typo in workflow

### DIFF
--- a/.github/workflows/upstream-nightly.yml
+++ b/.github/workflows/upstream-nightly.yml
@@ -54,8 +54,8 @@ jobs:
             --upgrade \
             numpy \
             scipy
-          python -c "import numpy; print(f'numpy.__version__=')"
-          python -c "import scipy; print(f'scipy.__version__=')"
+          python -c "import numpy; print(f'{numpy.__version__=}')"
+          python -c "import scipy; print(f'{scipy.__version__=}')"
       - name: Install JAX
         run: |
           pip install .[ci]


### PR DESCRIPTION
Confirmed the logs print the expected output:
```
Successfully installed numpy-2.1.0.dev0 scipy-1.14.0.dev0
numpy.__version__='2.1.0.dev0+git20240503.53cfea9'
scipy.__version__='1.14.0.dev0+1112.a4ccee2'
```