### PR TITLE
Draft of jax.debug.assert

### DIFF
--- a/jax/debug.py
+++ b/jax/debug.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 __all__ = ["callback", "print", "DebugEffect", "visualize_array_sharding",
            "inspect_array_sharding", "visualize_sharding", "breakpoint"]
+from jax._src.debugging import assert_ as assert_
 from jax._src.debugging import debug_callback as callback
 from jax._src.debugging import debug_print as print
 from jax._src.debugging import DebugEffect


### PR DESCRIPTION
We've had a couple requests recently for a way to define an assertion in a way that will execute normally outside JIT, but be ignored completely inside JIT. The thinking here is that it allows you to write safer code during development, and then once you're ready to run it "for real" you JIT-compile and scrub the assertions for performance reasons.

One way we can do that is to have a primitive that does the assertion in its `impl` rule, but skips the assertion in its lowering rule. Someone suggested `debug.assert_` for this case, but I was worried it would be too confusing if the default behavior were for the assertion to be skipped under JIT.

So the resolution of the idea is here: a primtiive that performs an assertion both inside and outside of JIT, but has an option to turn off the assertion in JIT when desired.

I'm still not sure about all the corner cases of these semantics (e.g. what should we do with the batching rule?) but I think this is a good start.