### PR TITLE
DOC: Add `sparse_sigmoid` to `jax.nn` docs

### DIFF
--- a/docs/jax.nn.rst
+++ b/docs/jax.nn.rst
@@ -23,6 +23,7 @@ Activation functions
     sigmoid
     softplus
     sparse_plus
+    sparse_sigmoid
     soft_sign
     silu
     swish


### PR DESCRIPTION
`jax.nn.sparse_sigmoid` is not added into the documentation. This PR will fix this.