### PR TITLE
Removed stale version guards and try/except blocks from Pallas GPU

### DIFF
--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -39,7 +39,6 @@ from jax._src import util
 from jax._src.interpreters import mlir
 from jax._src.interpreters import partial_eval as pe
 from jax._src.lax.control_flow import for_loop
-from jax._src.lib import version as jaxlib_version
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import arith as arith_dialect
 from jax._src.lib.mlir.dialects import math as math_dialect
@@ -1616,20 +1615,6 @@ _STR_TO_EVICTION_POLICY = {str(e): e for e in tt_dialect.EvictionPolicy}
 _STR_TO_CACHE_MODIFIER = {str(c): c for c in tt_dialect.CacheModifier}
 
 
-def _infer_load_return_type(ptr: ir.Value) -> ir.Type:
-  if ir.RankedTensorType.isinstance(ptr.type):
-    ptr_type = ir.RankedTensorType(ptr.type)
-    element_type = tt_dialect.PointerType(ptr_type.element_type)
-    return ir.RankedTensorType.get(
-        ptr_type.shape,
-        element_type.pointee_type,
-        ptr_type.encoding,
-    )
-  else:
-    ptr_type = tt_dialect.PointerType(ptr.type)
-    return ptr_type.pointee_type
-
-
 def _load(
     ptr: ir.Value,
     mask: ir.Value | None = None,
@@ -1685,14 +1670,7 @@ def _load(
   if other is not None:
     other = _ir_cast(other, pointee_type, signed=False)
 
-  if jaxlib_version < (0, 4, 27):
-    # TODO(slebedev): Remove once the minimum jaxlib version is 0.4.27.
-    extra_args = (_infer_load_return_type(ptr),)
-  else:
-    extra_args = ()
-
   result = tt_dialect.load(
-      *extra_args,
       ptr,
       mask=mask,
       other=other,
@@ -1935,22 +1913,17 @@ def _dot(
     else:
       max_num_imprecise_acc = 0
 
-  if jaxlib_version < (0, 4, 27):
-    # TODO(slebedev): Remove once the minimum jaxlib version is 0.4.27.
-    extra_kwargs = dict(allow_tf32=allow_tf32)
-  else:
-    # Ideally, replace all allow_tf32 usages with InputPrecision directly.
-    input_precision = tt_dialect.InputPrecision.IEEE
-    if allow_tf32:
-      input_precision = tt_dialect.InputPrecision.TF32
-    extra_kwargs = dict(input_precision=input_precision)
+  # Ideally, replace all allow_tf32 usages with InputPrecision directly.
+  input_precision = tt_dialect.InputPrecision.IEEE
+  if allow_tf32:
+    input_precision = tt_dialect.InputPrecision.TF32
 
   return tt_dialect.dot(
       x,
       y,
       acc,
       max_num_imprecise_acc=max_num_imprecise_acc,
-      **extra_kwargs
+      input_precision=input_precision
   )
 
 

--- a/tests/pallas/export_back_compat_pallas_test.py
+++ b/tests/pallas/export_back_compat_pallas_test.py
@@ -20,19 +20,13 @@ update these tests.
 from absl.testing import absltest
 
 import jax
+import jax.numpy as jnp
 from jax._src import config
 from jax._src import test_util as jtu
 from jax._src.internal_test_util import export_back_compat_test_util as bctu
-
 from jax._src.internal_test_util.export_back_compat_test_data.pallas import cuda_add_one
-
 from jax.experimental import pallas as pl
-try:
-  from jax.experimental.pallas import gpu as plgpu
-except ImportError:
-  plgpu = None
-import jax.numpy as jnp
-
+from jax.experimental.pallas import gpu as plgpu
 
 config.parse_flags_with_absl()
 
@@ -46,7 +40,7 @@ class CompatTest(bctu.CompatTestBase):
     if not jtu.test_device_matches(["gpu"]):
       self.skipTest("Only works on GPU")
     if (jtu.test_device_matches(["cuda"]) and
-        (plgpu is None or plgpu.get_compute_capability(0) < 80)):
+        plgpu.get_compute_capability(0) < 80):
       self.skipTest("Only works on GPUs with capability >= sm80")
     super().setUp()
 

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -16,9 +16,12 @@
 
 import functools
 
+import numpy as np
 from absl.testing import absltest
 from absl.testing import parameterized
+
 import jax
+import jax.numpy as jnp
 from jax import lax
 from jax._src import test_util as jtu
 from jax.experimental import pallas as pl
@@ -26,9 +29,6 @@ try:
   from jax.experimental.pallas import gpu as plgpu
 except ImportError:
   plgpu = None
-import jax.numpy as jnp
-import numpy as np
-
 
 jax.config.parse_flags_with_absl()
 

--- a/tests/sparse_nm_test.py
+++ b/tests/sparse_nm_test.py
@@ -13,20 +13,17 @@
 # limitations under the License.
 
 import math
+
+import numpy as np
 from absl.testing import absltest
 from absl.testing import parameterized
 
 import jax
+import jax.numpy as jnp
 from jax import dtypes
 from jax._src import test_util as jtu
+from jax.experimental.pallas import gpu as plgpu
 from jax.experimental.sparse import nm
-import jax.numpy as jnp
-import numpy as np
-
-try:
-  from jax.experimental.pallas import gpu as plgpu
-except ImportError:
-  plgpu = None
 
 jax.config.parse_flags_with_absl()
 
@@ -42,8 +39,6 @@ class SpmmTest(jtu.JaxTestCase):
 
   def check_gpu_capability_at_least(self, capability,
                                     device: int = 0):
-    if plgpu is None:
-      return False
     return plgpu.get_compute_capability(device) >= capability
 
   # ----- Test different input shapes


### PR DESCRIPTION
They are unnecessary now that the minimum jaxlib version is 0.4.27.