### PR TITLE
Removed ``get_compute_capability`` from ``jax.experimental.pallas.gpu``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Remember to align the itemized text with the first line of an item within a list
 * Deprecations & removals
   * The ``kind`` argument to {func}`jax.numpy.sort` and {func}`jax.numpy.argsort`
     is now removed. Use `stable=True` or `stable=False` instead.
+  * Removed ``get_compute_capability`` from the ``jax.experimental.pallas.gpu``
+    module. Use the ``compute_capability`` attribute of a GPU device, returned
+    by {func}`jax.devices` or {func}`jax.local_devices`, instead.
 
 ## jaxlib 0.4.28
 

--- a/jax/_src/pallas/triton/__init__.py
+++ b/jax/_src/pallas/triton/__init__.py
@@ -12,24 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Contains Triton-specific pallas modules."""
+"""Triton-specific Pallas APIs."""
 
-from jax._src.lib import gpu_triton as triton_kernel_call_lib
 from jax._src.pallas.triton.primitives import approx_tanh
 from jax._src.pallas.triton.primitives import elementwise_inline_asm
-
-
-try:
-  get_compute_capability = triton_kernel_call_lib.get_compute_capability
-except AttributeError:
-
-  def get_compute_capability(device) -> int:
-    del device  # Unused.
-    raise RuntimeError(
-        "get_compute_capability is not available. Try installing jaxlib with"
-        " GPU support following instructions in"
-        " https://jax.readthedocs.io/en/latest/installation.html."
-    )
-
-
-del triton_kernel_call_lib

--- a/jax/_src/pallas/triton/pallas_call_registration.py
+++ b/jax/_src/pallas/triton/pallas_call_registration.py
@@ -25,7 +25,6 @@ from typing import Any
 import jax
 from jax import core as jax_core
 from jax._src.interpreters import mlir
-from jax._src.lib import gpu_triton as triton_kernel_call_lib
 from jax._src.lib.mlir import ir
 from jax._src.pallas import core as pallas_core
 from jax._src.pallas.pallas_call import pallas_call_p
@@ -58,13 +57,10 @@ def _pallas_call_ttir_lowering(
     num_warps: int,
     num_stages: int,
 ):
-  # TODO(sharadmv): handle multiple devices, right now we assume device 0
-  # which is fine when we have multiple of the same GPU but this won't work in
-  # general.
-  device = 0
-  compute_capability = triton_kernel_call_lib.get_compute_capability(device)
+  # TODO(sharadmv): Handle multiple devices with different capabilities.
+  d, *_ = jax.local_devices(backend="gpu")
   cuda_options = dict(
-      compute_capability=compute_capability,
+      compute_capability=d.compute_capability,
       num_warps=num_warps,
       num_stages=num_stages,
       debug=debug,

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -419,6 +419,12 @@ def is_device_tpu(version: int | None = None, variant: str = "") -> bool:
     return "v5 lite" in device_kind
   return expected_version in device_kind
 
+def is_device_gpu_at_least(capability: str) -> bool:
+  if device_under_test() != "gpu":
+    return False
+  d, *_ = jax.local_devices(backend="gpu")
+  return d.compute_capability >= capability
+
 def _get_device_tags():
   """returns a set of tags defined for the device under test"""
   if is_device_rocm():

--- a/jax/experimental/pallas/gpu.py
+++ b/jax/experimental/pallas/gpu.py
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Contains Triton specific Pallas functions."""
-from jax._src.pallas import triton
+"""Triton-specific Pallas APIs."""
+
 from jax._src.pallas.triton import approx_tanh
 from jax._src.pallas.triton import elementwise_inline_asm
-
-get_compute_capability = triton.get_compute_capability
-
-del triton

--- a/tests/pallas/export_back_compat_pallas_test.py
+++ b/tests/pallas/export_back_compat_pallas_test.py
@@ -26,7 +26,6 @@ from jax._src import test_util as jtu
 from jax._src.internal_test_util import export_back_compat_test_util as bctu
 from jax._src.internal_test_util.export_back_compat_test_data.pallas import cuda_add_one
 from jax.experimental import pallas as pl
-from jax.experimental.pallas import gpu as plgpu
 
 config.parse_flags_with_absl()
 
@@ -40,7 +39,7 @@ class CompatTest(bctu.CompatTestBase):
     if not jtu.test_device_matches(["gpu"]):
       self.skipTest("Only works on GPU")
     if (jtu.test_device_matches(["cuda"]) and
-        plgpu.get_compute_capability(0) < 80):
+        not jtu.is_device_gpu_at_least("8.0")):
       self.skipTest("Only works on GPUs with capability >= sm80")
     super().setUp()
 

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -134,7 +134,7 @@ class PallasTest(parameterized.TestCase):
       if not jtu.test_device_matches(["gpu"]):
         self.skipTest("Only works on GPU")
       if (jtu.test_device_matches(["cuda"]) and
-          not self.check_gpu_capability_at_least(80)):
+          not jtu.is_device_gpu_at_least("8.0")):
         self.skipTest("Only works on GPUs with capability >= sm80")
 
     super().setUp()
@@ -142,12 +142,6 @@ class PallasTest(parameterized.TestCase):
 
   def pallas_call(self, *args, **kwargs):
     return pl.pallas_call(*args, **kwargs, interpret=self.INTERPRET)
-
-  def check_gpu_capability_at_least(self, capability,
-                                    device: int = 0):
-    if self.INTERPRET:
-      return True
-    return plgpu.get_compute_capability(device) >= capability
 
 
 class PallasCallTest(PallasTest):
@@ -336,11 +330,6 @@ class PallasCallTest(PallasTest):
       if block_size_m <= m and block_size_n <= n and block_size_k <= k
     ])
   def test_matmul(self, m, n, k, dtype, bm, bn, bk, gm):
-    if not self.INTERPRET and (
-        plgpu.get_compute_capability(0) <= 75
-        and (bm >= 128 or bn > 128 or bk > 32)
-    ):
-      raise unittest.SkipTest("Block sizes too big for sm70.")
     k1, k2 = random.split(random.key(0))
     x = random.normal(k1, (m, k), dtype=dtype)
     y = random.normal(k2, (k, n), dtype=dtype)
@@ -362,12 +351,6 @@ class PallasCallTest(PallasTest):
       if block_size_m <= m and block_size_n <= n and block_size_k <= k
     ])
   def test_matmul_block_spec(self, m, n, k, dtype, bm, bn, bk):
-    if not self.INTERPRET and (
-        plgpu.get_compute_capability(0) <= 75
-        and (bm >= 128 or bn > 128 or bk > 32)
-    ):
-      raise unittest.SkipTest("Block sizes too big for sm70.")
-
     k1, k2 = random.split(random.key(0))
     x = random.normal(k1, (m, k), dtype=dtype)
     y = random.normal(k2, (k, n), dtype=dtype)
@@ -1666,7 +1649,7 @@ class PallasOpsTest(PallasTest):
   def test_approx_tanh(self, dtype):
     if self.INTERPRET:
       self.skipTest("approx_tanh is not supported in interpreter mode")
-    if dtype == "bfloat16" and not self.check_gpu_capability_at_least(90):
+    if dtype == "bfloat16" and not jtu.is_device_gpu_at_least("9.0"):
       self.skipTest("tanh.approx.bf16 requires a GPU with capability >= sm90")
 
     @functools.partial(

--- a/tests/sparse_nm_test.py
+++ b/tests/sparse_nm_test.py
@@ -22,7 +22,6 @@ import jax
 import jax.numpy as jnp
 from jax import dtypes
 from jax._src import test_util as jtu
-from jax.experimental.pallas import gpu as plgpu
 from jax.experimental.sparse import nm
 
 jax.config.parse_flags_with_absl()
@@ -33,13 +32,9 @@ class SpmmTest(jtu.JaxTestCase):
     if not jtu.test_device_matches(["gpu"]):
       self.skipTest("Only works on GPU")
     if (jtu.test_device_matches(["cuda"]) and
-        not self.check_gpu_capability_at_least(80)):
+        not jtu.is_device_gpu_at_least("8.0")):
       self.skipTest("Only works on GPUs with capability >= sm80")
     super().setUp()
-
-  def check_gpu_capability_at_least(self, capability,
-                                    device: int = 0):
-    return plgpu.get_compute_capability(device) >= capability
 
   # ----- Test different input shapes
   @parameterized.product(


### PR DESCRIPTION
Compute capability is available as a `str` attribute on a GPU device since jaxlib 0.4.26.