### PR TITLE
Renamed is_device_gpu_at_least to is_cuda_compute_capability_at_least

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -419,8 +419,8 @@ def is_device_tpu(version: int | None = None, variant: str = "") -> bool:
     return "v5 lite" in device_kind
   return expected_version in device_kind
 
-def is_device_gpu_at_least(capability: str) -> bool:
-  if device_under_test() != "gpu":
+def is_cuda_compute_capability_at_least(capability: str) -> bool:
+  if not is_device_cuda():
     return False
   d, *_ = jax.local_devices(backend="gpu")
   return d.compute_capability >= capability

--- a/tests/pallas/export_back_compat_pallas_test.py
+++ b/tests/pallas/export_back_compat_pallas_test.py
@@ -39,7 +39,7 @@ class CompatTest(bctu.CompatTestBase):
     if not jtu.test_device_matches(["gpu"]):
       self.skipTest("Only works on GPU")
     if (jtu.test_device_matches(["cuda"]) and
-        not jtu.is_device_gpu_at_least("8.0")):
+        not jtu.is_cuda_compute_capability_at_least("8.0")):
       self.skipTest("Only works on GPUs with capability >= sm80")
     super().setUp()
 

--- a/tests/pallas/gpu_attention_test.py
+++ b/tests/pallas/gpu_attention_test.py
@@ -38,7 +38,7 @@ class DecodeAttentionTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
-    if not jtu.is_device_gpu_at_least("8.0"):
+    if not jtu.is_cuda_compute_capability_at_least("8.0"):
       self.skipTest("Fused attention only works on GPUs with capability >= sm80")
 
   @parameterized.named_parameters(*[

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -41,7 +41,7 @@ class OpsTest(jtu.JaxTestCase):
       if jtu.device_under_test() == "cpu":
         self.skipTest("Only interpreter mode supported on CPU")
       if (jtu.test_device_matches(["cuda"]) and
-          not jtu.is_device_gpu_at_least("8.0")):
+          not jtu.is_cuda_compute_capability_at_least("8.0")):
         self.skipTest("Only works on GPUs with capability >= sm80")
 
   @classmethod

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -134,7 +134,7 @@ class PallasTest(parameterized.TestCase):
       if not jtu.test_device_matches(["gpu"]):
         self.skipTest("Only works on GPU")
       if (jtu.test_device_matches(["cuda"]) and
-          not jtu.is_device_gpu_at_least("8.0")):
+          not jtu.is_cuda_compute_capability_at_least("8.0")):
         self.skipTest("Only works on GPUs with capability >= sm80")
 
     super().setUp()
@@ -1649,7 +1649,8 @@ class PallasOpsTest(PallasTest):
   def test_approx_tanh(self, dtype):
     if self.INTERPRET:
       self.skipTest("approx_tanh is not supported in interpreter mode")
-    if dtype == "bfloat16" and not jtu.is_device_gpu_at_least("9.0"):
+    if (dtype == "bfloat16" and
+        not jtu.is_cuda_compute_capability_at_least("9.0")):
       self.skipTest("tanh.approx.bf16 requires a GPU with capability >= sm90")
 
     @functools.partial(

--- a/tests/sparse_nm_test.py
+++ b/tests/sparse_nm_test.py
@@ -32,7 +32,7 @@ class SpmmTest(jtu.JaxTestCase):
     if not jtu.test_device_matches(["gpu"]):
       self.skipTest("Only works on GPU")
     if (jtu.test_device_matches(["cuda"]) and
-        not jtu.is_device_gpu_at_least("8.0")):
+        not jtu.is_cuda_compute_capability_at_least("8.0")):
       self.skipTest("Only works on GPUs with capability >= sm80")
     super().setUp()
 


### PR DESCRIPTION
This makes it clear that the predicate is only supposed to be used for NVidia GPUs at the moment.