### PR TITLE
[pallas] align interpreter load/store with masked behaviour (and adds stride support)

### DIFF
--- a/.github/workflows/wheel_win_x64.yml
+++ b/.github/workflows/wheel_win_x64.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           python -m pip install -r build/test-requirements.txt
           python -m pip uninstall -y matplotlib
-          python -m pip install --pre --upgrade numpy==2.0.0rc1 scipy==1.13.0rc1
+          python -m pip install --pre --upgrade numpy==2.0.0rc1 scipy==1.13.0
           "C:\\msys64\\;C:\\msys64\\usr\\bin\\;" >> $env:GITHUB_PATH
           python.exe build\build.py --bazel_options=--color=yes --verbose
 

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -47,7 +47,7 @@ jobs:
           cd jax
           python -m pip install -r build/test-requirements.txt
           python -m pip uninstall -y matplotlib
-          python -m pip install --pre --upgrade numpy==2.0.0rc1 scipy==1.13.0rc1
+          python -m pip install --pre --upgrade numpy==2.0.0rc1 scipy==1.13.0
           "C:\\msys64\\;C:\\msys64\\usr\\bin\\;" >> $env:GITHUB_PATH
           python.exe build\build.py ('--bazel_options=--override_repository=xla=${{ github.workspace }}\xla' -replace '\\','\\') --bazel_options=--color=yes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Remember to align the itemized text with the first line of an item within a list
 * Changes
   * JAX now supports CUDA 12.1 or newer only. Support for CUDA 11.8 has been
     dropped.
+  * JAX now supports NumPy 2.0.
 
 ## jax 0.4.25 (Feb 26, 2024)
 

--- a/docs/multi_process.md
+++ b/docs/multi_process.md
@@ -62,6 +62,9 @@ The API {func}`jax.distributed.initialize` takes several arguments, namely:
     with a port available on that process. Process 0 will start a JAX service
     exposed via that IP address and port, to which the other processes in the
     cluster will connect.
+  * `coordinator_bind_address`: the IP address and port to which the JAX service
+    on process 0 in your cluster will bind. By default, it will bind to all
+    available interfaces using the same port as `coordinator_address`.
   * `num_processes`: the number of processes in the cluster
   * `process_id`: the ID number of this process, in the range `[0 ..
     num_processes)`.

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3443,8 +3443,11 @@ def vdot(
              preferred_element_type=preferred_element_type)
 
 
-@util.implements(getattr(np, "vecdot", None), lax_description=_PRECISION_DOC,
-                 extra_params=_DOT_PREFERRED_ELEMENT_TYPE_DESCRIPTION)
+@util.implements(
+    getattr(np, "vecdot", None), lax_description=_PRECISION_DOC,
+    extra_params=_DOT_PREFERRED_ELEMENT_TYPE_DESCRIPTION,
+    # TODO(phawkins): numpy.vecdot doesn't have a __module__ attribute.
+    module="numpy")
 def vecdot(x1: ArrayLike, x2: ArrayLike, /, *, axis: int = -1,
            precision: PrecisionLike = None,
            preferred_element_type: DTypeLike | None = None) -> Array:

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1746,6 +1746,24 @@ class numpy_with_mpmath:
   def expm1(self, x):
     return x.context.expm1(x)
 
+  def log1p(self, x):
+    ctx = x.context
+    if isinstance(x, ctx.mpc):
+      # Workaround mpmath 1.3 bug in log(+-inf+-infj) evaluation (see mpmath/mpmath#774).
+      # TODO(pearu): remove this function when mpmath 1.4 or newer
+      # will be the required test dependency.
+      if ctx.isinf(x.real) and ctx.isinf(x.imag):
+        pi = ctx.pi
+        if x.real > 0 and x.imag > 0:
+          return ctx.make_mpc((x.real._mpf_, (pi / 4)._mpf_))
+        if x.real > 0 and x.imag < 0:
+          return ctx.make_mpc((x.real._mpf_, (-pi / 4)._mpf_))
+        if x.real < 0 and x.imag < 0:
+          return ctx.make_mpc(((-x.real)._mpf_, (-3 * pi / 4)._mpf_))
+        if x.real < 0 and x.imag > 0:
+          return ctx.make_mpc(((-x.real)._mpf_, (3 * pi / 4)._mpf_))
+    return ctx.log1p(x)
+
   def log2(self, x):
     return x.context.ln(x) / x.context.ln2
 

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,12 @@ from setuptools import setup, find_packages
 
 project_name = 'jax'
 
-_current_jaxlib_version = '0.4.25'
+_current_jaxlib_version = '0.4.26'
 # The following should be updated with each new jaxlib release.
 _latest_jaxlib_version_on_pypi = '0.4.25'
 _default_cuda12_cudnn_version = '89'
 _available_cuda12_cudnn_versions = [_default_cuda12_cudnn_version]
-_libtpu_version = '0.1.dev20240224'
+_libtpu_version = '0.1.dev20240403'
 
 def load_version_module(pkg_path):
   spec = importlib.util.spec_from_file_location(

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -3666,11 +3666,9 @@ class FunctionAccuracyTest(jtu.JaxTestCase):
         regions_with_inaccuracies_keep('q1', 'q2', 'q3', 'q4', 'neg', 'pos', 'negj', 'posj', 'ninf', 'pinf', 'ninfj', 'pinfj')
 
     elif name == 'arctanh':
-      if xla_extension_version < 251:
-        regions_with_inaccuracies_keep('q1', 'q2', 'q3', 'q4', 'neg', 'pos', 'negj', 'posj', 'ninf', 'pinf', 'ninfj', 'pinfj', 'mpos')
-      else:
-        regions_with_inaccuracies_keep('pos', 'ninf', 'pinf', 'ninfj', 'pinfj', 'mpos')
-
+      regions_with_inaccuracies_keep('q1', 'q2', 'q3', 'q4', 'neg', 'pos', 'negj', 'posj', 'ninf', 'pinf', 'ninfj', 'pinfj', 'mpos')
+      # TODO(pearu): after landing openxla/xla#10503, switch to
+      # regions_with_inaccuracies_keep('pos', 'ninf', 'pinf', 'ninfj', 'pinfj', 'mpos')
     elif name in {'positive', 'negative', 'conjugate', 'sin', 'cos', 'sqrt', 'expm1'}:
       regions_with_inaccuracies.clear()
     else:


### PR DESCRIPTION
Matches behaviour in Triton where for load/store/swap any masked indexing does not occur. 

For load it sets any masked indexing to index to the first element in the array instead.
For swap(/store) it also sets masked indexing to the first element (and then deals with special rules to make sure the first element is dealt with correctly)

The currently used dynamic_slices are replaced with explicit index materialisation and gathers/scatters.

The advantage of doing it this way is that you can combine it with `checkify(f, errors=checkify.index_checks)` in interpreter mode to check for any unmasked OOB indexing which is (I think, and believe should be) undefined behaviour.