### PR TITLE
jnp.linalg.multi_dot: use optimize='auto'

### DIFF
--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -2017,4 +2017,4 @@ def multi_dot(arrays: Sequence[ArrayLike], *, precision: PrecisionLike = None) -
   if arrs[-1].ndim == 1:
     einsum_axes[-1] = einsum_axes[-1][:1]
   return jnp.einsum(*itertools.chain(*zip(arrs, einsum_axes)),  # type: ignore[arg-type, call-overload]
-                    optimize='optimal', precision=precision)
+                    optimize='auto', precision=precision)


### PR DESCRIPTION
The old value makes tracing time factorial in the number of arrays, which is not a great default for a function meant to work with many arrays.

Followup to #21115 