### PR TITLE
Update line127 error, debugging.md

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -124,7 +124,7 @@ Here is an example of what a debugger session might look like:
 
 @jax.jit
 def f(x):
-  y, z = jnp.sin(x, jnp.cos(x))
+  y, z = jnp.sin(x), jnp.cos(x)
   jax.debug.breakpoint()
   return y * z
 f(2.) # ==> Pauses during execution


### PR DESCRIPTION
There is an error with "y, z = jnp.sin(x), jnp.cos(x)" where jnp.cos(x) was nested within jnp.sin(x) ==> jnp.sin(x, jnp.cos(x)). This caused an error to be thrown. This change fixes that.