### PR TITLE
lobpcg: avoid changing X64 setting

### DIFF
--- a/tests/lobpcg_test.py
+++ b/tests/lobpcg_test.py
@@ -30,6 +30,7 @@ import scipy.linalg as sla
 import scipy.sparse as sps
 
 import jax
+from jax._src import config
 from jax._src import test_util as jtu
 from jax.experimental.sparse import linalg, bcoo
 import jax.numpy as jnp
@@ -406,13 +407,14 @@ class F32LobpcgTest(LobpcgTest):
     self.checkApproxEigs(matrix_name, jnp.float32)
 
 
-@jtu.with_config(jax_enable_x64=True)
 class F64LobpcgTest(LobpcgTest):
 
   def setUp(self):
     # TODO(phawkins): investigate this failure
     if jtu.test_device_matches(["gpu"]):
       raise unittest.SkipTest("Test is failing on CUDA gpus")
+    if not config.enable_x64.value:
+      raise unittest.SkipTest("Test requires X64")
     super().setUp()
 
   @parameterized.named_parameters(_make_concrete_cases(f64=True))


### PR DESCRIPTION
Because all tests are run in the same process and setting X64 locally is not well-supported, it's better that we not do this: it's possible that it would change caches in a way that would cause other tests to fail depending on their order of execution.