### PR TITLE
Add validation that tests do not change global configs

### DIFF
--- a/tests/compilation_cache_test.py
+++ b/tests/compilation_cache_test.py
@@ -63,6 +63,7 @@ def increment_event_count(event):
 
 @jtu.with_config(
     jax_enable_compilation_cache=True,
+    jax_compilation_cache_dir="", # will be updated by test cases
     jax_raise_persistent_cache_errors=True,
     jax_persistent_cache_min_compile_time_secs=0,
     jax_persistent_cache_min_entry_size_bytes=0,
@@ -451,6 +452,7 @@ class CompilationCacheTest(jtu.JaxTestCase):
 
 @jtu.with_config(
     jax_enable_compilation_cache=False,
+    jax_compilation_cache_dir="", # will be updated by test cases
     jax_persistent_cache_min_compile_time_secs=0,
     jax_persistent_cache_min_entry_size_bytes=0,
 )
@@ -458,7 +460,6 @@ class CompilationCacheDisabledTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
-
     cc.reset_cache()
 
   def tearDown(self):

--- a/tests/jaxpr_effects_test.py
+++ b/tests/jaxpr_effects_test.py
@@ -296,7 +296,8 @@ class EffectfulJaxprLoweringTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
-    self.enter_context(config.enable_x64(False))
+    if not config.enable_x64.value:
+      raise unittest.SkipTest("Test requires X64")
     self._old_lowering = mlir._lowerings[effect_p]
     def _effect_lowering(ctx, *, effect):
       if effects.ordered_effects.contains(effect):

--- a/tests/logging_test.py
+++ b/tests/logging_test.py
@@ -103,31 +103,35 @@ class LoggingTest(jtu.JaxTestCase):
       jax.jit(lambda x: x + 1)(1)
     self.assertEmpty(log_output.getvalue())
 
-    # Turn on all debug logging.
-    jax.config.update("jax_debug_log_modules", "jax")
-    with capture_jax_logs() as log_output:
-      jax.jit(lambda x: x + 1)(1)
-    self.assertIn("Finished tracing + transforming", log_output.getvalue())
-    self.assertIn("Compiling <lambda>", log_output.getvalue())
+    original_value = jax.config.jax_debug_log_modules
+    try:
+      # Turn on all debug logging.
+      jax.config.update("jax_debug_log_modules", "jax")
+      with capture_jax_logs() as log_output:
+        jax.jit(lambda x: x + 1)(1)
+      self.assertIn("Finished tracing + transforming", log_output.getvalue())
+      self.assertIn("Compiling <lambda>", log_output.getvalue())
 
-    # Turn off all debug logging.
-    jax.config.update("jax_debug_log_modules", None)
-    with capture_jax_logs() as log_output:
-      jax.jit(lambda x: x + 1)(1)
-    self.assertEmpty(log_output.getvalue())
+      # Turn off all debug logging.
+      jax.config.update("jax_debug_log_modules", None)
+      with capture_jax_logs() as log_output:
+        jax.jit(lambda x: x + 1)(1)
+      self.assertEmpty(log_output.getvalue())
 
-    # Turn on one module.
-    jax.config.update("jax_debug_log_modules", "jax._src.dispatch")
-    with capture_jax_logs() as log_output:
-      jax.jit(lambda x: x + 1)(1)
-    self.assertIn("Finished tracing + transforming", log_output.getvalue())
-    self.assertNotIn("Compiling <lambda>", log_output.getvalue())
+      # Turn on one module.
+      jax.config.update("jax_debug_log_modules", "jax._src.dispatch")
+      with capture_jax_logs() as log_output:
+        jax.jit(lambda x: x + 1)(1)
+      self.assertIn("Finished tracing + transforming", log_output.getvalue())
+      self.assertNotIn("Compiling <lambda>", log_output.getvalue())
 
-    # Turn everything off again.
-    jax.config.update("jax_debug_log_modules", None)
-    with capture_jax_logs() as log_output:
-      jax.jit(lambda x: x + 1)(1)
-    self.assertEmpty(log_output.getvalue())
+      # Turn everything off again.
+      jax.config.update("jax_debug_log_modules", None)
+      with capture_jax_logs() as log_output:
+        jax.jit(lambda x: x + 1)(1)
+      self.assertEmpty(log_output.getvalue())
+    finally:
+      jax.config.update("jax_debug_log_modules", original_value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Because pytest runs all tests in the same process, if a test case changes a global config it might change the behavior of other tests in a difficult to detect way (i.e. depending on order of test executions).

This check is not perfect (e.g. it wouldn't catch config changes made at the top level) but it should catch a few existing problematic cases.