### PR TITLE
Remove type promotion for mixed fp8 matmuls.

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2912,6 +2912,9 @@ def precision_attr(precision: Precision) -> ir.ArrayAttr:
 def _dot_general_lower(ctx, lhs, rhs, *, dimension_numbers,
                        precision, preferred_element_type: np.dtype | None,
                        platform: str = "default"):
+  def _is_fp8_mixed_precision_matmul(_lhs_dtypes, _rhs_dtypes):
+      fp8_dtypes = (dtypes.float8_e4m3fn, dtypes.float8_e5m2)
+      return _lhs_dtypes in fp8_dtypes and _rhs_dtypes in fp8_dtypes
   del preferred_element_type  # Implied by the output aval
   lhs_aval, rhs_aval = ctx.avals_in
   lhs_dtype, rhs_dtype = lhs_aval.dtype, rhs_aval.dtype
@@ -2934,11 +2937,13 @@ def _dot_general_lower(ctx, lhs, rhs, *, dimension_numbers,
                                core.ShapedArray(rhs_aval.shape, aval_out.dtype))
         lhs_dtype = rhs_dtype = aval_out.dtype
     else:  # cpu and gpu
-      lhs = mlir.convert_hlo(ctx, lhs, lhs_aval,
-                             core.ShapedArray(lhs_aval.shape, aval_out.dtype))
-      rhs = mlir.convert_hlo(ctx, rhs, rhs_aval,
-                             core.ShapedArray(rhs_aval.shape, aval_out.dtype))
-      lhs_dtype = rhs_dtype = aval_out.dtype
+      # Do not convert mixed fp8 types to output type.
+      if not _is_fp8_mixed_precision_matmul(lhs_dtype, rhs_dtype):
+        lhs = mlir.convert_hlo(ctx, lhs, lhs_aval,
+                              core.ShapedArray(lhs_aval.shape, aval_out.dtype))
+        rhs = mlir.convert_hlo(ctx, rhs, rhs_aval,
+                              core.ShapedArray(rhs_aval.shape, aval_out.dtype))
+        lhs_dtype = rhs_dtype = aval_out.dtype
 
   # TODO(b/195364460): Work around slow XLA/CPU implementation of float16 matmul
   if platform == "cpu":

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1075,6 +1075,33 @@ class LaxTest(jtu.JaxTestCase):
     self.assertArraysAllClose(result_with_preferred_type, result_with_upcast_inputs)
 
   @jtu.sample_product(
+    [dict(lhs_shape=lhs_shape, rhs_shape=rhs_shape)
+     for lhs_shape in [(3,), (4, 3)] for rhs_shape in [(3,), (3, 6)]],
+    [dict(dtype_lhs=dtype_lhs, dtype_rhs=dtype_rhs)
+     for dtype_lhs, dtype_rhs in [(dtypes.float8_e4m3fn, dtypes.float8_e5m2),
+                                  (dtypes.float8_e5m2, dtypes.float8_e4m3fn)]],
+  )
+  def test_mixed_fp8_dot_general(self, lhs_shape, rhs_shape, dtype_lhs, dtype_rhs):
+    if jtu.test_device_matches(["tpu"]):
+        raise SkipTest("Mixed fp8 precision matmul is not yet supported on TPU")
+    rng = jtu.rand_default(self.rng())
+    lhs = rng(lhs_shape, dtype=dtype_lhs)
+    rhs = rng(rhs_shape, dtype=dtype_rhs)
+    dot_general_result = lax.dot(
+        lhs, rhs,
+        preferred_element_type=jnp.float32
+    )
+
+    lhs_upcasted = lhs.astype(jnp.float32)
+    rhs_upcasted = rhs.astype(jnp.float32)
+    dot_general_result_upcasted = lax.dot(
+        lhs_upcasted, rhs_upcasted,
+        preferred_element_type=jnp.float32
+    )
+    self.assertArraysAllClose(
+        dot_general_result, dot_general_result_upcasted, rtol=1e-3, atol=1e-3)
+
+  @jtu.sample_product(
       [
           dict(lhs_shape=lhs_shape, rhs_shape=rhs_shape)
           for lhs_shape in [(3,), (4, 3)]


### PR DESCRIPTION
Remove type promotion for mixed fp8 matmuls (Nvidia supported formats only).  
Resend the PR as XLA backend is ready. 
