### PR TITLE
Update doc with the other error that can be thrown.

### DIFF
--- a/docs/jax.experimental.rst
+++ b/docs/jax.experimental.rst
@@ -26,6 +26,7 @@ Experimental Modules
     jax.experimental.compilation_cache
     jax.experimental.key_reuse
     jax.experimental.mesh_utils
+    jax.experimental.serialize_executable
     jax.experimental.shard_map
 
 Experimental APIs

--- a/docs/jax.experimental.serialize_executable.rst
+++ b/docs/jax.experimental.serialize_executable.rst
@@ -1,0 +1,13 @@
+``jax.experimental.serialize_executable`` module
+================================================
+
+.. automodule:: jax.experimental.serialize_executable
+
+API
+---
+
+.. autosummary::
+  :toctree: _autosummary
+
+  serialize
+  deserialize_and_load

--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -174,7 +174,8 @@ def initialize(coordinator_address: str | None = None,
       have the coordinator service listen on one address/interface.
 
   Raises:
-    RuntimeError: If :func:`~jax.distributed.initialize` is called more than once.
+    RuntimeError: If :func:`~jax.distributed.initialize` is called more than once
+      or if called after the backend is already initialized.
 
   Example:
 


### PR DESCRIPTION
The error is raised here: https://github.com/nouiz/jax/blob/f578d78f2b93cfba49f158f3f916097de982b725/jax/_src/distributed.py#L194