### PR TITLE
Fix typo in advanced-autodiff.md

### DIFF
--- a/docs/_tutorials/advanced-autodiff.md
+++ b/docs/_tutorials/advanced-autodiff.md
@@ -15,7 +15,7 @@ kernelspec:
 (advanced-autodiff)=
 # Advanced automatic differentiation
 
-In this tutorial, you will learn about complex applications of automatic differentiation (autodiff) in JAX and gain a better understanding of how taking derivatives in JAX can be both easy and powerful.docs.g
+In this tutorial, you will learn about complex applications of automatic differentiation (autodiff) in JAX and gain a better understanding of how taking derivatives in JAX can be both easy and powerful.
 
 Make sure to check out the {ref}`automatic-differentiation` tutorial to go over the JAX autodiff basics, if you haven't already.
 


### PR DESCRIPTION
removed `doc.g` text from the first section.