### PR TITLE
[DOC] Add documentation for jax.experimental.serialize_executable module

### DIFF
--- a/docs/jax.experimental.rst
+++ b/docs/jax.experimental.rst
@@ -26,6 +26,7 @@ Experimental Modules
     jax.experimental.compilation_cache
     jax.experimental.key_reuse
     jax.experimental.mesh_utils
+    jax.experimental.serialize_executable
     jax.experimental.shard_map
 
 Experimental APIs

--- a/docs/jax.experimental.serialize_executable.rst
+++ b/docs/jax.experimental.serialize_executable.rst
@@ -1,0 +1,13 @@
+``jax.experimental.serialize_executable`` module
+================================================
+
+.. automodule:: jax.experimental.serialize_executable
+
+API
+---
+
+.. autosummary::
+  :toctree: _autosummary
+
+  serialize
+  deserialize_and_load


### PR DESCRIPTION
At least, have the visible in JAX documentation.