### PR TITLE
Add `boundary='wrap'` support for jax.scipy.signal.convolve2d and `jax.scipy.signal.correlate2d` functions

### DIFF
--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -150,7 +150,7 @@ def _fftconvolve_unbatched(in1: Array, in2: Array, mode: str) -> Array:
 # Note: we do not re-use the code from jax.numpy.convolve here, because the handling
 # of padding differs slightly between the two implementations (particularly for
 # mode='same').
-def _convolve_nd(in1: Array, in2: Array, mode: str, boundary: str = 'fill', *, precision: PrecisionLike) -> Array:
+def _convolve_nd(in1: Array, in2: Array, mode: str, boundary: str, *, precision: PrecisionLike) -> Array:
   if mode not in ["full", "same", "valid"]:
     raise ValueError("mode must be one of ['full', 'same', 'valid']")
   if in1.ndim != in2.ndim:
@@ -166,11 +166,10 @@ def _convolve_nd(in1: Array, in2: Array, mode: str, boundary: str = 'fill', *, p
 
   shape1 = in1.shape
   shape_o = in2.shape
-  if in1.ndim > 1:
-    M = shape1[0] if shape1[0] >= shape_o[0] else shape_o[0]
-    N = shape1[1] if shape1[1] >= shape_o[1] else shape_o[1]
-    if boundary == 'wrap' and mode != 'valid':
-      in1 = jnp.pad(in1, (M, N), mode='wrap')
+  M = jnp.maximum(shape1[0], shape_o[0])
+  N = jnp.maximum(shape1[1], shape_o[1])
+  if boundary == 'wrap' and mode != 'valid':
+    in1 = jnp.pad(in1, (M, N), mode='wrap')
 
   if swap:
     in1, in2 = in2, in1
@@ -190,10 +189,13 @@ def _convolve_nd(in1: Array, in2: Array, mode: str, boundary: str = 'fill', *, p
   result = lax.conv_general_dilated(in1[None, None], in2[None, None], strides,
                                       padding, precision=precision)
 
-  if boundary == 'wrap' and mode == 'same':
+  if boundary == 'wrap':
+    if mode == 'same':
       return result[0, 0][M:M+shape1[0], M:M+shape1[1]]
-  elif boundary == 'wrap' and mode == 'full':
+    elif mode == 'full':
       return result[0, 0][M:M+shape1[0]+shape_o[0]-1, M:M+shape1[1]+shape_o[1]-1]
+    else:
+      return result[0, 0]
   else:
     return result[0, 0]
 
@@ -393,21 +395,21 @@ def correlate2d(in1: Array, in2: Array, mode: str = 'full', boundary: str = 'fil
 
   if mode == "same":
     in1, in2 = jnp.flip(in1), in2.conj()
-    result = jnp.flip(_convolve_nd(in1, in2, mode, boundary, precision=precision))
+    result = jnp.flip(_convolve_nd(in1, in2, mode, precision=precision))
   elif mode == "valid":
     if swap and not same_shape:
       in1, in2 = jnp.flip(in2), in1.conj()
-      result = _convolve_nd(in1, in2, mode, boundary, precision=precision)
+      result = _convolve_nd(in1, in2, mode, precision=precision)
     else:
       in1, in2 = jnp.flip(in1), in2.conj()
-      result = jnp.flip(_convolve_nd(in1, in2, mode, boundary, precision=precision))
+      result = jnp.flip(_convolve_nd(in1, in2, mode, precision=precision))
   else:
     if swap and boundary != 'wrap':
       in1, in2 = jnp.flip(in2), in1.conj()
-      result = _convolve_nd(in1, in2, mode, boundary, precision=precision).conj()
+      result = _convolve_nd(in1, in2, mode, precision=precision).conj()
     else:
       in1, in2 = jnp.flip(in1), in2.conj()
-      result = jnp.flip(_convolve_nd(in1, in2, mode, boundary, precision=precision))
+      result = jnp.flip(_convolve_nd(in1, in2, mode, precision=precision))
   return result
 
 

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -126,18 +126,19 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
 
   @jtu.sample_product(
     mode=['full', 'same', 'valid'],
+    boundary = ['fill', 'wrap'],
     op=['convolve2d', 'correlate2d'],
     dtype=default_dtypes,
     xshape=twodim_shapes,
     yshape=twodim_shapes,
   )
-  def testConvolutions2D(self, xshape, yshape, dtype, mode, op):
+  def testConvolutions2D(self, xshape, yshape, dtype, mode, boundary, op):
     jsp_op = getattr(jsp_signal, op)
     osp_op = getattr(osp_signal, op)
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(xshape, dtype), rng(yshape, dtype)]
-    osp_fun = partial(osp_op, mode=mode)
-    jsp_fun = partial(jsp_op, mode=mode, precision=lax.Precision.HIGHEST)
+    osp_fun = partial(osp_op, mode=mode, boundary=boundary)
+    jsp_fun = partial(jsp_op, mode=mode, boundary=boundary, precision=lax.Precision.HIGHEST)
     tol = {np.float16: 1e-2, np.float32: 1e-2, np.float64: 1e-12, np.complex64: 1e-2, np.complex128: 1e-12}
     self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, check_dtypes=False,
                             tol=tol)


### PR DESCRIPTION
Currently `jax.scipy.signal.convolve2d` and `jax.scipy.signal.correlate2d` functions support only `boundary='fill'`. This PR will add `boundary='wrap'` support for both the functions.
