### PR TITLE
Cleanup token handling during lowering

### DIFF
--- a/jax/experimental/export/_export.py
+++ b/jax/experimental/export/_export.py
@@ -578,13 +578,7 @@ def _wrap_main_func(
     orig_main_name = ir.StringAttr(symbol_table.insert(orig_main)).value
 
     def is_token(typ, attrs):
-      if typ == mlir.token_type()[0]:
-        return True
-      # TODO(b/302258959): in older versions we cannot use the token type
-      try:
-        return ir.BoolAttr(ir.DictAttr(attrs)["jax.token"]).value
-      except KeyError:
-        return False
+      return (typ == mlir.token_type()[0])
 
     orig_input_types = orig_main.type.inputs
     arg_attrs = list(ir.ArrayAttr(orig_main.arg_attrs))


### PR DESCRIPTION
Version 0.4.27 of jaxlib is now the minimum version and it supports real stablehlo tokens as module inputs and outputs. Hence we can now clean up `mlir.lower_jaxpr_to_fun` to not use the kwargs `create_tokens` and `replace_tokens_with_dummy` (both of them are always False now).

We also remove `num_output_tokens` that is not used.