### PR TITLE
Add `boundary='wrap'` support for `jax.scipy.signal.convolve2d` and `jax.scipy.signal.correlate2d`

### DIFF
--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -150,7 +150,8 @@ def _fftconvolve_unbatched(in1: Array, in2: Array, mode: str) -> Array:
 # Note: we do not re-use the code from jax.numpy.convolve here, because the handling
 # of padding differs slightly between the two implementations (particularly for
 # mode='same').
-def _convolve_nd(in1: Array, in2: Array, mode: str, *, precision: PrecisionLike) -> Array:
+def _convolve_nd(in1: Array, in2: Array, mode: str, boundary: str = 'fill', *,
+                 precision: PrecisionLike) -> Array:
   if mode not in ["full", "same", "valid"]:
     raise ValueError("mode must be one of ['full', 'same', 'valid']")
   if in1.ndim != in2.ndim:
@@ -161,10 +162,20 @@ def _convolve_nd(in1: Array, in2: Array, mode: str, *, precision: PrecisionLike)
 
   no_swap = all(s1 >= s2 for s1, s2 in zip(in1.shape, in2.shape))
   swap = all(s1 <= s2 for s1, s2 in zip(in1.shape, in2.shape))
-  if not (no_swap or swap):
-    raise ValueError("One input must be smaller than the other in every dimension.")
+  if mode == 'valid' and not (no_swap or swap):
+    raise ValueError("For 'valid' mode, one input must always be smaller than the other in every dimension.")
 
+  shape1 = in1.shape
   shape_o = in2.shape
+  out_slices: tuple[slice, ...] = ()
+  if boundary == 'wrap' and mode != 'valid':
+    p = max(map(max, shape1, shape_o))
+    in1 = jnp.pad(in1, p, mode='wrap')
+    if mode == 'same':
+      out_slices = tuple(slice(p, p+s) for s in shape1)
+    elif mode == 'full':
+      out_slices = tuple(slice(p, p+s1+s2-1) for s1, s2 in zip(shape1, shape_o))
+
   if swap:
     in1, in2 = in2, in1
   shape = in2.shape
@@ -181,7 +192,7 @@ def _convolve_nd(in1: Array, in2: Array, mode: str, *, precision: PrecisionLike)
   strides = tuple(1 for s in shape)
   result = lax.conv_general_dilated(in1[None, None], in2[None, None], strides,
                                     padding, precision=precision)
-  return result[0, 0]
+  return result[(0, 0, *out_slices)]
 
 
 def convolve(in1: Array, in2: Array, mode: str = 'full', method: str = 'auto',
@@ -266,7 +277,7 @@ def convolve2d(in1: Array, in2: Array, mode: str = 'full', boundary: str = 'fill
       * ``"valid"``: return the portion of the ``"full"`` output which do not
         depend on padding at the array edges.
 
-    boundary: only ``"fill"`` is supported.
+    boundary: only ``"fill"`` and ``"wrap"`` are supported.
     fillvalue: only ``0`` is supported.
     method: controls the computation method. Options are
 
@@ -285,11 +296,13 @@ def convolve2d(in1: Array, in2: Array, mode: str = 'full', boundary: str = 'fill
     - :func:`jax.scipy.signal.convolve`: ND convolution
     - :func:`jax.scipy.signal.correlate`: ND correlation
   """
-  if boundary != 'fill' or fillvalue != 0:
-    raise NotImplementedError("convolve2d() only supports boundary='fill', fillvalue=0")
+  if boundary not in ["fill", "wrap"]:
+    raise NotImplementedError("convolve2d() only supports boundary='fill' or 'wrap'")
+  elif boundary == 'fill' and fillvalue != 0:
+    raise NotImplementedError("convolve2d() only supports fillvalue=0 when boundary='fill'")
   if jnp.ndim(in1) != 2 or jnp.ndim(in2) != 2:
     raise ValueError("convolve2d() only supports 2-dimensional inputs.")
-  return _convolve_nd(in1, in2, mode, precision=precision)
+  return _convolve_nd(in1, in2, mode, boundary, precision=precision)
 
 
 def correlate(in1: Array, in2: Array, mode: str = 'full', method: str = 'auto',
@@ -346,7 +359,7 @@ def correlate2d(in1: Array, in2: Array, mode: str = 'full', boundary: str = 'fil
       * ``"valid"``: return the portion of the ``"full"`` output which do not
         depend on padding at the array edges.
 
-    boundary: only ``"fill"`` is supported.
+    boundary: only ``"fill"`` and ``"wrap"`` are supported.
     fillvalue: only ``0`` is supported.
     method: controls the computation method. Options are
 
@@ -365,8 +378,10 @@ def correlate2d(in1: Array, in2: Array, mode: str = 'full', boundary: str = 'fil
     - :func:`jax.scipy.signal.correlate`: ND cross-correlation
     - :func:`jax.scipy.signal.convolve`: ND convolution
   """
-  if boundary != 'fill' or fillvalue != 0:
-    raise NotImplementedError("correlate2d() only supports boundary='fill', fillvalue=0")
+  if boundary not in ["fill", "wrap"]:
+    raise NotImplementedError("correlate2d() only supports boundary='fill' or 'wrap'")
+  elif boundary == 'fill' and fillvalue != 0:
+    raise NotImplementedError("correlate2d() only supports fillvalue=0 when boundary='fill'")
   if jnp.ndim(in1) != 2 or jnp.ndim(in2) != 2:
     raise ValueError("correlate2d() only supports 2-dimensional inputs.")
 
@@ -375,21 +390,17 @@ def correlate2d(in1: Array, in2: Array, mode: str = 'full', boundary: str = 'fil
 
   if mode == "same":
     in1, in2 = jnp.flip(in1), in2.conj()
-    result = jnp.flip(_convolve_nd(in1, in2, mode, precision=precision))
+    result = jnp.flip(_convolve_nd(in1, in2, mode, boundary, precision=precision))
   elif mode == "valid":
     if swap and not same_shape:
       in1, in2 = jnp.flip(in2), in1.conj()
-      result = _convolve_nd(in1, in2, mode, precision=precision)
+      result = _convolve_nd(in1, in2, mode, boundary, precision=precision)
     else:
       in1, in2 = jnp.flip(in1), in2.conj()
-      result = jnp.flip(_convolve_nd(in1, in2, mode, precision=precision))
+      result = jnp.flip(_convolve_nd(in1, in2, mode, boundary, precision=precision))
   else:
-    if swap:
-      in1, in2 = jnp.flip(in2), in1.conj()
-      result = _convolve_nd(in1, in2, mode, precision=precision).conj()
-    else:
-      in1, in2 = jnp.flip(in1), in2.conj()
-      result = jnp.flip(_convolve_nd(in1, in2, mode, precision=precision))
+    in1, in2 = jnp.flip(in1), in2.conj()
+    result = jnp.flip(_convolve_nd(in1, in2, mode, boundary, precision=precision))
   return result
 
 

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -126,18 +126,39 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
 
   @jtu.sample_product(
     mode=['full', 'same', 'valid'],
+    boundary = ['fill', 'wrap'],
     op=['convolve2d', 'correlate2d'],
     dtype=default_dtypes,
     xshape=twodim_shapes,
     yshape=twodim_shapes,
   )
-  def testConvolutions2D(self, xshape, yshape, dtype, mode, op):
+  def testConvolutions2D(self, xshape, yshape, dtype, mode, boundary, op):
     jsp_op = getattr(jsp_signal, op)
     osp_op = getattr(osp_signal, op)
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(xshape, dtype), rng(yshape, dtype)]
-    osp_fun = partial(osp_op, mode=mode)
-    jsp_fun = partial(jsp_op, mode=mode, precision=lax.Precision.HIGHEST)
+    osp_fun = partial(osp_op, mode=mode, boundary=boundary)
+    jsp_fun = partial(jsp_op, mode=mode, boundary=boundary, precision=lax.Precision.HIGHEST)
+    tol = {np.float16: 1e-2, np.float32: 1e-2, np.float64: 1e-12, np.complex64: 1e-2, np.complex128: 1e-12}
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, check_dtypes=False,
+                            tol=tol)
+    self._CompileAndCheck(jsp_fun, args_maker, rtol=tol, atol=tol)
+
+  @jtu.sample_product(
+    mode=['full', 'same'],
+    boundary = ['fill', 'wrap'],
+    op=['convolve2d', 'correlate2d'],
+    dtype=default_dtypes,
+    xshape=[(3, 4), (5, 2), (4, 6)],
+    yshape=[(4, 3), (2, 5), (5, 4)],
+  )
+  def testConvolutions2DNotValidMode(self, xshape, yshape, dtype, mode, boundary, op):
+    jsp_op = getattr(jsp_signal, op)
+    osp_op = getattr(osp_signal, op)
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(xshape, dtype), rng(yshape, dtype)]
+    osp_fun = partial(osp_op, mode=mode, boundary=boundary)
+    jsp_fun = partial(jsp_op, mode=mode, boundary=boundary, precision=lax.Precision.HIGHEST)
     tol = {np.float16: 1e-2, np.float32: 1e-2, np.float64: 1e-12, np.complex64: 1e-2, np.complex128: 1e-12}
     self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, check_dtypes=False,
                             tol=tol)


### PR DESCRIPTION
Currently `jax.scipy.signal.convolve2d` and `jax.scipy.signal.correlate2d` functions support only `boundary='fill'`. This PR will add `boundary='wrap'` support for both the functions.

Fixes #7276 