### PR TITLE
Add jax.tree_util.register_simple

### DIFF
--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -54,6 +54,7 @@ from jax._src.tree_util import (
     register_pytree_with_keys_class as register_pytree_with_keys_class,
     register_dataclass as register_dataclass,
     register_pytree_with_keys as register_pytree_with_keys,
+    register_simple as register_simple,
     register_static as register_static,
     tree_all as tree_all,
     tree_flatten_with_path as tree_flatten_with_path,


### PR DESCRIPTION
This PR proposes a new API, `jax.tree_util.register_simple` that will simplify pytree registration and promote best practices in the most common of cases. Example usage with `dataclass`, although this will work on any class that can be flattened and unflattened via simple attribute access:
```python
import jax
import jax.numpy as jnp
from dataclasses import dataclass

@jax.tree_util.register_simple(
    dynamic_attributes=['x', 'y'],
    static_attributes=['val'])
@dataclass
class MyContainer:
    x: jax.Array
    y: jax.Array
    val: str

m = MyContainer(jnp.zeros(4), jnp.arange(4), val='name')

leaves, tree = jax.tree.flatten(m)
m2 = jax.tree.unflatten(tree, leaves)

print(m)
# MyContainer(x=Array([0., 0., 0., 0.], dtype=float32), y=Array([0, 1, 2, 3], dtype=int32), val='name')
print(m2)
# MyContainer(x=Array([0., 0., 0., 0.], dtype=float32), y=Array([0, 1, 2, 3], dtype=int32), val='name')
```
One benefit of this is that it's somewhat self-documenting: we mention in the documentation that `children` should contain dynamic data, and `aux_data` should contain static data, but in practice users often miss this detail (e.g. we've had several questions in recent weeks about problems arising after including arrays in `aux_data`). Calling these `static_attributes` and `dynamic_attributes` should hopefully point people in the right direction.