### PR TITLE
Add more informative error message for invalid `unroll` parameter in `lax.scan`

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -294,6 +294,8 @@ def scan(f: Callable[[Carry, X], tuple[Carry, Y]],
 
   if isinstance(unroll, bool):
     unroll = max(length, 1) if unroll else 1
+  if unroll < 1:
+    raise ValueError("`unroll` must be a `bool` or a positive `int`.")
   if attrs_tracked:
     in_state = _get_states(attrs_tracked)
     in_carry, in_ext = split_list(in_flat, [num_carry])

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -1951,6 +1951,13 @@ class LaxControlFlowTest(jtu.JaxTestCase):
                                   x[2]), None),
                    (jnp.array(0, 'int32'),) * 3, None, length=1)
 
+  @jax.enable_checks(False)
+  def testScanInvalidUnrollRaises(self):
+    with self.assertRaisesRegex(ValueError, "`unroll` must be"):
+      jax.lax.scan(lambda x, _: (x, x), 0, jnp.arange(5), unroll=-1)
+    with self.assertRaisesRegex(ValueError, "`unroll` must be"):
+      jax.lax.scan(lambda x, _: (x, x), 0, jnp.arange(5), unroll=0)
+
   @parameterized.named_parameters(
       {"testcase_name": f"_{scan_name}",
        "scan": scan_impl}


### PR DESCRIPTION
As reported in #20481, setting `unroll=0` in `lax.scan` resulted in an uninformative `ZeroDivisionError`. This PR adds a check which raises a `ValueError` for `unroll<=0`.

One interesting (to me!) technical point is that a more informative error is raised when `jax_enable_checks` is on ([ref](https://github.com/google/jax/blob/4ccac4c6ce93bfd69a01699c11a30afa35e2ef11/jax/_src/lax/control_flow/loops.py#L1165)), but since this is off by default, I think it is sensible to have a better error message. That being said, I'm not sure if the way I'm turning `jax_enable_checks` off in the test is appropriate.