### PR TITLE
Document jax.tree_util.register_dataclass

### DIFF
--- a/docs/jax.tree_util.rst
+++ b/docs/jax.tree_util.rst
@@ -14,6 +14,7 @@ List of Functions
    Partial
    all_leaves
    build_tree
+   register_dataclass
    register_pytree_node
    register_pytree_node_class
    register_pytree_with_keys


### PR DESCRIPTION
Rendered preview: https://jax--21268.org.readthedocs.build/en/21268/_autosummary/jax.tree_util.register_dataclass.html

Also a couple minor adjustments to type annotations & implementation.