### PR TITLE
Add RegularGridInterpolator to generated API docs

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -34,6 +34,17 @@ jax.scipy.integrate
 
    trapezoid
 
+jax.scipy.interpolate
+---------------------
+
+.. automodule:: jax.scipy.interpolate
+
+.. autosummary::
+  :toctree: _autosummary
+
+   RegularGridInterpolator
+
+
 jax.scipy.linalg
 ----------------
 


### PR DESCRIPTION
In responding to #21279, I noticed that `RegularGridInterpolator` isn't currently listed in the API docs. I know that `scipy.interpolate` is [out of scope](https://jax.readthedocs.io/en/latest/jep/18137-numpy-scipy-scope.html#scipy-interpolate), but since we do currently provide this wrapper, it seems like it makes sense to include it in the docs!

_Edit:_ I note that this docstring could also probably use some work. Happy to flesh it out as part of this PR if anyone thinks that's worthwhile.