### PR TITLE
jax.tree_util: test serialize_using_proto

### DIFF
--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -913,6 +913,15 @@ class StaticTest(parameterized.TestCase):
     self.assertEqual(fn(3, BlackBox(1)), 5)
     self.assertEqual(num_called, 1)
 
+  def test_serialize_treedef(self):
+    tree_structure = jax.tree_util.tree_structure([1, [2], (3,), {'a': 4, 'b': 5}])
+    serialized = tree_structure.serialize_using_proto()
+    new_structure = jax.tree_util.PyTreeDef.deserialize_using_proto(
+      jax.tree_util.default_registry,
+      serialized
+    )
+    self.assertEqual(tree_structure, new_structure)
+
 
 class RavelUtilTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
I'm not sure why this was ever exported... I can't find any existing use of this, and I'm not sure why anyone would need to access it.