### PR TITLE
Ignore deprecation warnings locally rather than globally

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -140,7 +140,7 @@ jobs:
         PY_COLORS: 1
       run: |
         pytest -n auto --tb=short docs
-        pytest -n auto --tb=short --doctest-modules jax --ignore=jax/config.py --ignore=jax/experimental/jax2tf --ignore=jax/_src/lib/mlir --ignore=jax/_src/lib/triton.py --ignore=jax/_src/lib/mosaic_gpu.py --ignore=jax/interpreters/mlir.py --ignore=jax/_src/iree.py --ignore=jax/experimental/array_serialization --ignore=jax/collect_profile.py --ignore=jax/_src/tpu_custom_call.py --ignore=jax/experimental/mosaic --ignore=jax/experimental/pallas --ignore=jax/_src/pallas
+        pytest -n auto --tb=short --doctest-modules jax --ignore=jax/config.py --ignore=jax/experimental/jax2tf --ignore=jax/_src/lib/mlir --ignore=jax/_src/lib/triton.py --ignore=jax/_src/lib/mosaic_gpu.py --ignore=jax/interpreters/mlir.py --ignore=jax/_src/iree.py --ignore=jax/experimental/array_serialization --ignore=jax/collect_profile.py --ignore=jax/_src/tpu_custom_call.py --ignore=jax/experimental/mosaic --ignore=jax/experimental/pallas --ignore=jax/_src/pallas --ignore=jax/experimental/maps.py
 
 
   documentation_render:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,6 @@ filterwarnings = [
     "ignore:Special cases found for .* but none were parsed.*:UserWarning",
     # end array_api_tests-related warnings
     "ignore:jax.extend.mlir.dialects.mhlo is deprecated.*:DeprecationWarning",
-    "ignore:jax.experimental.maps and .* are deprecated.*:DeprecationWarning",
-    "ignore:The host_callback APIs are deprecated .*:DeprecationWarning",
     "ignore:.*is not JSON-serializable. Using the repr instead.",
 ]
 doctest_optionflags = [

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -238,6 +238,8 @@ class HostCallbackTapTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
+    self.enter_context(jtu.ignore_warning(
+      category=DeprecationWarning, message="The host_callback APIs are deprecated"))
     if jtu.test_device_matches(["gpu"]) and jax.device_count() > 1:
       raise SkipTest("host_callback broken on multi-GPU platforms (#6447)")
     if xla_bridge.using_pjrt_c_api():
@@ -2032,6 +2034,8 @@ class HostCallbackCallTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
+    self.enter_context(jtu.ignore_warning(
+      category=DeprecationWarning, message="The host_callback APIs are deprecated"))
     if jtu.test_device_matches(["gpu"]) and jax.device_count() > 1:
       raise SkipTest("host_callback broken on multi-GPU platforms (#6447)")
     if xla_bridge.using_pjrt_c_api():
@@ -2519,6 +2523,8 @@ class CallJaxTest(jtu.JaxTestCase):
         raise SkipTest("Test needs at least two devices. On CPU use XLA_FLAGS=--xla_force_host_platform_device_count=2")
       self.outside_device = jax.devices("cpu")[1]
     super().setUp()
+    self.enter_context(jtu.ignore_warning(
+      category=DeprecationWarning, message="The host_callback APIs are deprecated"))
 
 
   def test_jax_impl(self):
@@ -2587,6 +2593,8 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
     if xla_bridge.using_pjrt_c_api():
       raise SkipTest("host_callback not implemented in PJRT C API")
     super().setUp()
+    self.enter_context(jtu.ignore_warning(
+      category=DeprecationWarning, message="The host_callback APIs are deprecated"))
 
   def supported_only_in_legacy_mode(self):
     if not hcb._HOST_CALLBACK_LEGACY.value:


### PR DESCRIPTION
Why? We want to prevent unexpected internal usage of deprecated APIs, so we shouldn't disable Deprecation warnings globally.