### PR TITLE
Pin matplotlib < 3.9 for Python 3.10 and earlier.

### DIFF
--- a/build/requirements.in
+++ b/build/requirements.in
@@ -2,7 +2,11 @@
 # test deps
 #
 -r test-requirements.txt
-matplotlib
+
+# matplotlib 3.9.0 pins NumPy 1.23, which is incompatible with the requirement
+# below.
+matplotlib~=3.8.4; python_version<="3.10"
+matplotlib; python_version>="3.11"
 
 #
 # build deps


### PR DESCRIPTION
matplotlib 3.9.0 pins NumPy 1.23 or newer, which is incompatible with our minimum Numpy pin.