### PR TITLE
[NVIDIA] Add new SDPA API to jax.nn

### DIFF
--- a/jax/nn/__init__.py
+++ b/jax/nn/__init__.py
@@ -36,6 +36,7 @@ from jax._src.nn.functions import (
   one_hot as one_hot,
   relu as relu,
   relu6 as relu6,
+  dot_product_attention as dot_product_attention,
   selu as selu,
   sigmoid as sigmoid,
   soft_sign as soft_sign,

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -28,6 +28,8 @@ from jax._src import config
 from jax._src import core
 from jax._src import test_util as jtu
 from jax._src import ad_checkpoint
+from jax._src.interpreters import mlir
+from jax._src.lib import cuda_versions
 from jax.test_util import check_grads
 from jax import nn
 from jax import random
@@ -36,8 +38,106 @@ import jax.numpy as jnp
 
 config.parse_flags_with_absl()
 
+def _is_required_cudnn_version_satisfied():
+  return (
+      jtu.is_cuda_compute_capability_at_least("8.0") and
+      cuda_versions is not None and
+      cuda_versions.cudnn_get_version() >= 8904
+  )
 
+def _get_causal_mask(T, S):
+  causal_mask = jnp.tril(jnp.ones((T, S), dtype=jnp.bool_))
+  return causal_mask[jnp.newaxis, jnp.newaxis, :, :]
+
+@jtu.with_config(jax_legacy_prng_key="allow",
+                 jax_numpy_dtype_promotion="standard")
 class NNFunctionsTest(jtu.JaxTestCase):
+  @parameterized.product(
+      dtype=[jnp.float32, jnp.bfloat16, jnp.float16],
+      use_bias=(False, True),
+      causal_mode=(None, 'is_causal', 'is_mask'),
+      impl=('xla', 'cudnn'),
+  )
+  def testDotProductAttentionInfer(self, dtype, use_bias, causal_mode, impl):
+    if impl == 'cudnn' and not _is_required_cudnn_version_satisfied():
+      raise unittest.SkipTest("CUDA or cuDNN versions are not compatible.")
+    if impl == 'cudnn' and dtype == jnp.float32:
+      raise unittest.SkipTest("cuDNN only supports fp16 or bf16.")
+
+    sdpa = nn.dot_product_attention
+    B, S, T, N, H = 2, 128, 128, 4, 32
+    keys = random.split(random.PRNGKey(0), 4)
+    Q = random.normal(keys[0], (B, T, N, H), dtype)
+    K = random.normal(keys[1], (B, S, N, H), dtype)
+    V = random.normal(keys[2], (B, S, N, H), dtype)
+    if use_bias:
+      bias = random.normal(keys[3], (1, N, T, S), dtype)
+    else:
+      bias = None
+
+    is_causal = causal_mode == 'is_causal'
+    causal_mask = _get_causal_mask(T, S) if causal_mode == 'is_mask' else None
+
+    sdpa_ref = partial(sdpa, is_causal=is_causal, implementation=None)
+    sdpa_ans = partial(sdpa, is_causal=is_causal, implementation=impl)
+
+    if impl == 'cudnn':
+      lowered = jax.jit(sdpa_ans).lower(Q, K, V, bias=bias, mask=causal_mask)
+      hlo = mlir.module_to_string(lowered.compiler_ir('stablehlo'))
+      self.assertIn('__cudnn$fmha', hlo)
+
+    out_ref = sdpa_ref(Q, K, V, bias=bias, mask=causal_mask)
+    out_ans = sdpa_ans(Q, K, V, bias=bias, mask=causal_mask)
+    self.assertAllClose(out_ref, out_ans, atol=.01, rtol=.01)
+
+  @parameterized.product(
+      dtype=[jnp.float32, jnp.bfloat16, jnp.float16],
+      use_bias=[False, True],
+      causal_mode=[None, 'is_causal', 'is_mask'],
+      impl=['xla', 'cudnn'],
+  )
+  def testDotProductAttentionTrain(self, dtype, use_bias, causal_mode, impl):
+    if impl == 'cudnn' and not _is_required_cudnn_version_satisfied():
+      raise unittest.SkipTest("CUDA or cuDNN versions are not compatible.")
+    if impl == 'cudnn' and dtype == jnp.float32:
+      raise unittest.SkipTest("cuDNN only supports fp16 or bf16.")
+
+    sdpa = nn.dot_product_attention
+    B, S, T, N, H = 2, 128, 128, 4, 32
+    keys = random.split(random.PRNGKey(0), 5)
+    Q = random.normal(keys[0], (B, T, N, H), dtype)
+    K = random.normal(keys[1], (B, S, N, H), dtype)
+    V = random.normal(keys[2], (B, S, N, H), dtype)
+    grad = random.normal(keys[3], (B, T, N, H), dtype)
+    if use_bias:
+      bias = random.normal(keys[4], (1, N, T, S), dtype)
+    else:
+      bias = None
+
+    is_causal = causal_mode == 'is_causal'
+    causal_mask = _get_causal_mask(T, S) if causal_mode == 'is_mask' else None
+
+    sdpa_ref = partial(sdpa, is_causal=is_causal, implementation=None)
+    fn_ref = lambda q, k, v, b, m: sdpa_ref(q, k, v, bias=b, mask=m)
+    _, sdpa_vjp_ref = jax.vjp(fn_ref, Q, K, V, bias, causal_mask)
+    dQ_ref, dK_ref, dV_ref, dbias_ref, _ = sdpa_vjp_ref(grad)
+
+    sdpa_ans = partial(sdpa, is_causal=is_causal, implementation=impl)
+    fn_ans = lambda q, k, v, b, m: sdpa_ans(q, k, v, bias=b, mask=m)
+    _, sdpa_vjp_ans = jax.vjp(fn_ans, Q, K, V, bias, causal_mask)
+    dQ_ans, dK_ans, dV_ans, dbias_ans, _ = sdpa_vjp_ans(grad)
+
+    if impl == 'cudnn':
+      lowered = jax.jit(sdpa_vjp_ans).lower(grad)
+      hlo = mlir.module_to_string(lowered.compiler_ir('stablehlo'))
+      self.assertRegex(hlo, r'__cudnn\$fmha.*Backward\(')
+
+    rtol, atol = (.01, .01)
+    self.assertAllClose(dQ_ref, dQ_ans, rtol=rtol, atol=atol)
+    self.assertAllClose(dK_ref, dK_ans, rtol=rtol, atol=atol)
+    self.assertAllClose(dV_ref, dV_ans, rtol=rtol, atol=atol)
+    self.assertAllClose(dbias_ref, dbias_ans, rtol=.03, atol=.03)
+
   @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def testSoftplusGrad(self):
     check_grads(nn.softplus, (1e-8,), order=4,


### PR DESCRIPTION
Attention plays a crucial role in modern transformer-based models. While there exist various variants, they generally follow the same workflow. Examples include the typical multi-head attention (MHA), global query attention (GQA), and multi-query attention (MQA). Additionally, new implementations like the Flash Attention algorithm aim to enhance the utilization of accelerator devices. For instance, NVIDIA cuDNN supports Flash Attention and, through its API, can result in a 1.3x end-to-end speedup for training large language models based on GPT alone.

This PR proposes introducing a new API in the `jax.nn` module to handle attention. It will first try to use the cudnn flash attention execution path when the config is compatible. Otherwise it falls back to a jax implementation. 

cc. @nluehr @Cjkkkk @cliffwoolley 
