### PR TITLE
add pjit input-output forwarding rule

### DIFF
--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1679,7 +1679,11 @@ class DynamicJaxprTracer(core.Tracer):
     self.aval = aval
 
   def full_lower(self):
-    return self
+    var = self._trace.frame.tracer_to_var.get(id(self))
+    if var is None: return self
+    val = self._trace.frame.constvar_to_val.get(var)
+    if val is None: return self
+    return core.full_lower(val)
 
   def _contents(self):
     return ()
@@ -1874,7 +1878,6 @@ def _const_folding_and_forwarding(
     # if the application trivially maps some inputs to outputs, simplify
     if eqn.primitive in forwarding_rules and not has_input_effect:
       fwd_vars, new_eqn = forwarding_rules[eqn.primitive](eqn)
-      assert (new_eqn is None) == all(v is not None for v in fwd_vars)
       for v_orig, v_new in zip(eqn.outvars, fwd_vars):
         if v_new is not None: var_subs[v_orig] = v_new
       if new_eqn is None: continue

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4677,6 +4677,37 @@ class APITest(jtu.JaxTestCase):
     jtu.check_grads(f, (list(jnp.arange(float(num_args))),), order=1,
                     modes=['rev'], atol=1e-3, rtol=1e-3)
 
+  @jtu.run_on_devices("cpu")
+  def test_inner_jit_forwarding_happens(self):
+    jaxpr = jax.make_jaxpr(lambda: jax.jit(lambda x: x)(3))()
+    self.assertLen(jaxpr.jaxpr.outvars, 1)
+    self.assertIsInstance(jaxpr.jaxpr.outvars[0], core.Literal)
+    self.assertEqual(jaxpr.jaxpr.outvars[0].val, 3)
+
+  @parameterized.parameters(range(8))
+  @jtu.run_on_devices("cpu")
+  def test_inner_jit_forwarding_correctness(self, num_input_fwd):
+    num_args = 8
+    rng = np.random.RandomState(0)
+
+    @jax.jit
+    def f(inputs):
+      inputs = [inputs[i] for i in rng.permutation(num_args)]
+      outputs = (inputs[:num_input_fwd] +
+                 [jnp.sin(inputs[i]) for i in range(num_args - num_input_fwd)])
+      return [outputs[i] for i in rng.permutation(num_args)]
+
+    f2 = jax.jit(f)
+    inputs = list(jnp.arange(float(num_args)))
+    expected = f(inputs)
+    ans = f2(inputs)
+    for a, b in zip(ans, expected):
+      self.assertAllClose(a, b)
+
+  def test_inner_jit_forwarded_consts_stay_const(self):
+    out = jax.jit(lambda: int(jax.jit(lambda x: x)(3)))()  # don't crash
+    self.assertEqual(out, 3)
+
 
 class RematTest(jtu.JaxTestCase):
 

--- a/tests/dynamic_api_test.py
+++ b/tests/dynamic_api_test.py
@@ -232,7 +232,7 @@ class DynamicShapeStagingTest(jtu.JaxTestCase):
     def f(n):
       m = 2 * n
       x = jnp.zeros(m)
-      return jax.jit(lambda: x)()
+      return jax.jit(jnp.sin)(x)
 
     # { lambda ; a:i32[]. let
     #     b:i32[] = mul a 2
@@ -517,7 +517,7 @@ class DynamicShapeStagingTest(jtu.JaxTestCase):
     self.assertIs(e.aval.shape[0], d)
 
   def test_jit_abstracted_axes_return_polymorphic_shape(self):
-    f = jax.jit(lambda x: x, abstracted_axes=('n',))
+    f = jax.jit(lambda x: jnp.sin(x), abstracted_axes=('n',))
     jaxpr = jax.make_jaxpr(f)(jnp.arange(3))  # doesn't crash
     # { lambda ; a:i32[3]. let
     #     b:i32[3] = pjit[

--- a/tests/jaxpr_util_test.py
+++ b/tests/jaxpr_util_test.py
@@ -61,8 +61,8 @@ class JaxprStatsTest(jtu.JaxTestCase):
   def test_primitives_by_shape(self):
     def f(x, y):
       def sub(x, y):
-        return jnp.sum(jnp.array([x, y])), y
-      s, _ = jit(sub)(x, y)
+        return jnp.sum(jnp.array([x, y]))
+      s = jit(sub)(x, y)
       return jnp.sin(s) + jnp.cos(y)
 
     hist = jaxpr_util.primitives_by_shape(make_jaxpr(f)(1., 1.).jaxpr)
@@ -74,7 +74,7 @@ class JaxprStatsTest(jtu.JaxTestCase):
         f'cos :: float{t}[]',
         f'reduce_sum :: float{t}[]',
         f'concatenate :: float{t}[2]',
-        f'pjit :: float{t}[] *',
+        f'pjit :: float{t}[]',
     ]
     for k in shapes:
       self.assertEqual(hist[k], 1)

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -1282,22 +1282,22 @@ class PJitTest(jtu.BufferDonationTestCase):
     y = jnp.array([4.2, 2.4], dtype=jnp.float32)
     jaxpr = jax.make_jaxpr(g)(x, y)
     self.assertEqual(
-        jaxpr.pretty_print(),
+        jaxpr.pretty_print(use_color=False),
         textwrap.dedent("""
-            let f = { lambda ; a:f32[1]. let  in (a,) } in
-            let f1 = { lambda ; b:f32[2]. let  in (b,) } in
+            let f = { lambda ; a:f32[1]. let  in () } in
+            let f1 = { lambda ; b:f32[2]. let  in () } in
             { lambda ; c:f32[1] d:f32[2]. let
                 e:f32[2] = pjit[
                   name=g
                   jaxpr={ lambda ; g:f32[1] h:f32[2]. let
-                      i:f32[1] = pjit[name=f jaxpr=f] g
-                      j:f32[1] = pjit[name=f jaxpr=f] g
-                      k:f32[1] = mul i j
-                      l:f32[2] = pjit[name=f jaxpr=f1] h
-                      m:f32[2] = pjit[name=f jaxpr=f1] h
-                      n:f32[2] = mul l m
-                      o:f32[2] = add k n
-                    in (o,) }
+                      pjit[name=f jaxpr=f] g
+                      pjit[name=f jaxpr=f] g
+                      i:f32[1] = mul g g
+                      pjit[name=f jaxpr=f1] h
+                      pjit[name=f jaxpr=f1] h
+                      j:f32[2] = mul h h
+                      k:f32[2] = add i j
+                    in (k,) }
                 ] c d
               in (e,) }
             """).strip(),

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -1353,13 +1353,13 @@ class ShardMapTest(jtu.JaxTestCase):
 
     @partial(shard_map, mesh=mesh, in_specs=P(), out_specs=P())
     def g(x):
-      return jax.jit(lambda x: x)(x)
+      return jax.jit(lambda x: 1. * x)(x)
 
     jaxpr = jax.make_jaxpr(jax.vjp(g, 1.)[1])(1.)
     e, = jaxpr.jaxpr.eqns
     e1, e2 = e.params['jaxpr'].eqns
     self.assertEmpty(e1.outvars)
-    self.assertEmpty(e2.params['jaxpr'].eqns)
+    self.assertLen(e2.params['jaxpr'].eqns, 1)
 
   def test_fanout_specs_transpose_to_psum(self):
     mesh = jtu.create_global_mesh((4,), ('x',))


### PR DESCRIPTION
When an inner jit simply forwards some of its inputs to outputs, we can prune those outputs and use the caller's value for them.

We want to do it at trace time (i.e. in the `pjit_staging_rule`, not just as a jaxpr-pass forwarding rule) so that we can keep more values in the caller static constants. (We implement `DynamicJaxprTrace.full_lower` so as to unbox returned constants too.)

```python
import jax

@jax.jit
def f(x):
  return x, 2 * x

print(jax.make_jaxpr(lambda: f(3))())
```

Before:
```
{ lambda ; . let
    a:i32[] b:i32[] = pjit[
      name=f
      jaxpr={ lambda ; c:i32[]. let d:i32[] = mul 2 c in (c, d) }
    ] 3
  in (a, b) }
```

After:
```
{ lambda ; . let
    a:i32[] = pjit[
      name=f
      jaxpr={ lambda ; b:i32[]. let c:i32[] = mul 2 b in (c,) }
    ] 3
  in (3, a) }
```

The motivating application is related to a dynamic shapes experiment, where it's useful to keep static shapes static.