### PR TITLE
Casted finfo attributes from np.float to float for Array API compliance

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -310,7 +310,15 @@ def coerce_to_array(x: Any, dtype: DTypeLike | None = None) -> np.ndarray:
   return np.asarray(x, dtype)
 
 iinfo = ml_dtypes.iinfo
-finfo = ml_dtypes.finfo
+
+# We cast finfo attributes from np.float to built-in python floats
+# for Array API compliance
+class finfo(ml_dtypes.finfo):
+  def __setattr__(self, name, value):
+    if isinstance(value, np.floating):
+      value = float(value)
+    object.__setattr__(self, name, value)
+
 
 def _issubclass(a: Any, b: Any) -> bool:
   """Determines if ``a`` is a subclass of ``b``.

--- a/jax/experimental/array_api/_data_type_functions.py
+++ b/jax/experimental/array_api/_data_type_functions.py
@@ -64,8 +64,6 @@ class FInfo(NamedTuple):
     smallest_normal: float
     dtype: jnp.dtype
 
-# TODO(micky774): Update jax.numpy.finfo so that its attributes are python
-# floats
 def finfo(type, /) -> FInfo:
   info = jnp.finfo(type)
   return FInfo(


### PR DESCRIPTION
Description:
- Addresses "jnp.finfo: Update eps, max, min, smallest_normal attributes to Python floats" from https://github.com/google/jax/issues/21088 (https://data-apis.org/array-api/latest/API_specification/generated/array_api.finfo.html#finfo)


```python
>>> import jax.numpy as jnp
>>> f = jnp.finfo("float16")
>>> f.__dict__
```
Output on `main`:
```
{
  'dtype': dtype('float16'), 'precision': 3, 'iexp': 5, 'maxexp': 16, 
  'minexp': -14, 'negep': -11, 'machep': -10, 'resolution': np.float16(0.001), 
  'epsneg': np.float16(0.0004883), 'smallest_subnormal': np.float16(6e-08), 'bits': 16, 'max': np.float16(65500.0), 
  'min': np.float16(-65500.0), 'eps': np.float16(0.000977), 'nexp': 5, 'nmant': 10, '_machar': <numpy._core.getlimits.MachArLike object at 0x7f4b3bdaff70>, 
  '_str_tiny': '6.10352e-05', '_str_max': '6.55040e+04', '_str_epsneg': '4.88281e-04', '_str_eps': '9.76562e-04',
  '_str_resolution': '1.00040e-03', '_str_smallest_normal': '6.10352e-05', '_str_smallest_subnormal': '5.96046e-08'
}
```

This PR:
```
{
  'dtype': dtype('float16'), 'precision': 3, 'iexp': 5, 'maxexp': 16, 
  'minexp': -14, 'negep': -11, 'machep': -10, 'resolution': 0.0010004043579101562, 
  'epsneg': 0.00048828125, 'smallest_subnormal': 5.960464477539063e-08, 'bits': 16, 'max': 65504.0, 
  'min': -65504.0, 'eps': 0.0009765625, 'nexp': 5, 'nmant': 10, '_machar': <numpy._core.getlimits.MachArLike object at 0x7fd87f65aa10>, 
  '_str_tiny': '6.10352e-05', '_str_max': '6.55040e+04', '_str_epsneg': '4.88281e-04', '_str_eps': '9.76562e-04',
  '_str_resolution': '1.00040e-03', '_str_smallest_normal': '6.10352e-05', '_str_smallest_subnormal': '5.96046e-08'
}
```