### PR TITLE
Update quickstart to suggested jax[cuda12] installation

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,7 +31,7 @@ pip install "jax[cpu]"
 ```
 or, for NVIDIA GPU:
 ```
-pip install -U "jax[cuda12_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+pip install -U "jax[cuda12]"
 ```
 For more detailed platform-specific installation information, check out {ref}`installation`.
 


### PR DESCRIPTION
This PR updates the quickstart docs to match the README and Installation Guide suggestion of using

```
pip install jax[cuda12]
```

for GPU.