### PR TITLE
Add a link to another page with XLA flags.

### DIFF
--- a/docs/gpu_performance_tips.md
+++ b/docs/gpu_performance_tips.md
@@ -23,6 +23,10 @@ code examples:
 
 ## XLA performance flags
 
+```{note}
+  JAX-Toolbox also has a page on [NVIDIA XLA performance FLAGS](https://github.com/NVIDIA/JAX-Toolbox/blob/main/rosetta/docs/GPU_performance.md).
+```
+
 The existence and exact behavior of XLA flags may be `jaxlib`-version dependent.
 
 As of `jaxlib==0.4.18` (released [Oct 6


### PR DESCRIPTION
See title.

This will help users find all the information about all the flags.

It show up like this when I build the doc.
![image](https://github.com/google/jax/assets/180987/5461f88d-220c-4174-8ff4-c8cf6859988f)
