### PR TITLE
Add a helper function for building custom call lowering rules

### DIFF
--- a/jax/_src/extend/ffi.py
+++ b/jax/_src/extend/ffi.py
@@ -16,8 +16,16 @@ from __future__ import annotations
 
 import os
 import ctypes
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
 
+import numpy as np
+
+from jax._src import dtypes
+from jax._src.interpreters import mlir
 from jax._src.lib import jaxlib
+from jax._src.lib.mlir import ir
+from jax._src.typing import DimSize
 
 
 def pycapsule(funcptr):
@@ -59,3 +67,77 @@ def include_dir() -> str:
   """Get the path to the directory containing header files bundled with jaxlib"""
   jaxlib_dir = os.path.dirname(os.path.abspath(jaxlib.__file__))
   return os.path.join(jaxlib_dir, "include")
+
+
+def ffi_lowering(
+    call_target_name: str,
+    *,
+    operand_layouts: Sequence[Sequence[DimSize]] | None = None,
+    result_layouts: Sequence[Sequence[DimSize]] | None = None,
+    backend_config: Mapping[str, ir.Attribute] | None = None,
+    **lowering_args: Any
+) -> mlir.LoweringRule:
+  """Build a lowering rule for an foreign function interface (FFI) target.
+
+  By default, this lowering rule can use the input and output abstract values to
+  compute the input and output types and shapes for the custom call, assuming
+  row-major layouts.
+
+  If keyword arguments are passed to the lowering rule, these are treated as
+  attributes, and added to `backend_config`.
+
+  Args:
+    call_target_name: The name of the custom call target.
+    operand_layouts: A sequence of layouts (dimension orders) for each operand.
+      By default, the operands are assumed to be row-major.
+    result_layouts: A sequence of layouts (dimension orders) for each result.
+      By default, the results are assumed to be row-major.
+    backend_config: Configuration data for the custom call. Any keyword
+      arguments passed to the lowering rule will added to this dictionary.
+    lowering_args: Any other arguments to :func:`mlir.custom_call` will also be
+      passed through if provided as extra arguments to this function.
+  """
+
+  def _lowering(
+    ctx: mlir.LoweringRuleContext, *operands: ir.Value, **params: Any
+  ) -> Sequence[ir.Value | Sequence[ir.Value]]:
+    kwargs = dict(lowering_args)
+    kwargs.setdefault("api_version", 4)
+    kwargs["backend_config"] = dict(
+      backend_config or {}, **{k: _ir_attribute(v) for k, v in params.items()})
+    if "result_types" not in kwargs:
+      kwargs["result_types"] = [mlir.aval_to_ir_type(aval) for aval in ctx.avals_out]
+    if operand_layouts is None:
+      kwargs["operand_layouts"] = _default_layouts(aval.shape for aval in ctx.avals_in)  # pytype: disable=attribute-error
+    if result_layouts is None:
+      kwargs["result_layouts"] = _default_layouts(aval.shape for aval in ctx.avals_out)
+
+    return mlir.custom_call(call_target_name, operands=operands, **kwargs).results  # type: ignore
+
+  return _lowering
+
+
+def _default_layouts(shapes: Iterable[Sequence[DimSize]]) -> list[list[DimSize]]:
+  return [list(reversed(range(len(shape)))) for shape in shapes]
+
+
+def _ir_attribute(obj: Any) -> ir.Attribute:
+  # TODO(dfm): Similar functions exist in Pallas and Mosaic GPU. Perhaps these
+  # could be consolidated into mlir or similar.
+  if isinstance(obj, str):
+    return ir.StringAttr.get(obj)
+  elif isinstance(obj, bool):
+    return ir.BoolAttr.get(obj)
+  elif isinstance(obj, int):
+    return mlir.i64_attr(obj)
+  elif isinstance(obj, float):
+    return ir.FloatAttr.get_f64(obj)
+  elif hasattr(obj, "dtype"):
+    if not (dtypes.is_python_scalar(obj) or np.isscalar(obj)):
+      raise TypeError("Only scalar attributes are supported")
+    mlir_type = mlir.dtype_to_ir_type(obj.dtype)
+    if isinstance(mlir_type, ir.IntegerType):
+      return ir.IntegerAttr.get(mlir_type, obj)
+    elif isinstance(mlir_type, ir.FloatType):
+      return ir.FloatAttr.get(mlir_type, obj)
+  raise TypeError(f"Unsupported attribute type: {type(obj)}")

--- a/jax/extend/ffi.py
+++ b/jax/extend/ffi.py
@@ -16,6 +16,7 @@
 # See PEP 484 & https://github.com/google/jax/issues/7570
 
 from jax._src.extend.ffi import (
-  include_dir as include_dir,
-  pycapsule as pycapsule,
+    ffi_lowering as ffi_lowering,
+    include_dir as include_dir,
+    pycapsule as pycapsule,
 )


### PR DESCRIPTION
This function provides sensible defaults for custom call lowering rules with the goal of reducing the amount of boilerplate required for implementing custom calls. While all of the behavior can be overridden, this will be particularly useful when (a) the inputs and outputs are in row-major order because then the layouts and types can be evaluated from the context avals, and/or (b) the custom call supports `api_version=4` attributes provided via a `backend_config` dictionary.

There are a number of lowering rules in the core library that could be rewritten using this helper, but I think it probably wouldn't make sense to port those as part of this PR.

For now the tests only check that lowering succeeds for parameters/attributes of different types, but it might be useful to check that the output is appropriate. I haven't figured out a reasonable way to do that yet - thoughts would be appreciated!

@superbobry — I'd love to hear your feedback. Since this is closely based on code you wrote previously, I added you as a co-author on the commit, but I'm happy to remove that if you'd prefer.