### PR TITLE
Add a comment about x86 builds of Python to cpu_feature_guard

### DIFF
--- a/jaxlib/cpu_feature_guard.c
+++ b/jaxlib/cpu_feature_guard.c
@@ -77,9 +77,19 @@ static int GetXCR0EAX() {
 static void ReportMissingCpuFeature(const char* name) {
   PyErr_Format(
       PyExc_RuntimeError,
+#if defined(__APPLE__)
+      "This version of jaxlib was built using %s instructions, which your "
+      "CPU and/or operating system do not support. This error is frequently "
+      "encountered on macOS when running an x86 Python installation on ARM "
+      "hardware. In this case, try installing an ARM build of Python. "
+      "Otherwise, you may be able work around this issue by building jaxlib "
+      "from source.",
+#else
       "This version of jaxlib was built using %s instructions, which your "
       "CPU and/or operating system do not support. You may be able work around "
-      "this issue by building jaxlib from source.", name);
+      "this issue by building jaxlib from source.",
+#endif
+      name);
 }
 
 static PyObject *CheckCpuFeatures(PyObject *self, PyObject *args) {


### PR DESCRIPTION
MacOS users frequently encounter a run-time error related to unsupported AVX instructions (#21491, most recently). This is typically caused by running an x86 Python build on ARM hardware, and it requires re-installation of Python. This PR adds this suggestion to the error message when encountered on macOS.