### PR TITLE
Roll back cumulative reduction lowering on METAL

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -2373,6 +2373,8 @@ def _cumulative_reduction_primitive(name, reduce_fn, reduce_window_fn):
         platform=platform)
 
   if xla_extension_version >= 266:
+    # For jax-metal, until reduce_window legalization is better supported.
+    register_lowering(partial(associative_scan, reduce_fn), 'METAL')
     # In XLA, there's a rewriter for an O(N^2) reduce-window implementation.
     register_lowering(
         partial(cumred_reduce_window_impl, reduce_window_fn)


### PR DESCRIPTION
Roll back cum_red lowering on jax-metal  to pre[PR 21213](https://github.com/google/jax/pull/21213), for cum_red reduce window pattern is not fully supported on jax-metal. 