### PR TITLE
device-side heap experiment ("slab")

### DIFF
--- a/jax/experimental/slab/djax.py
+++ b/jax/experimental/slab/djax.py
@@ -1,0 +1,166 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from functools import partial
+from typing import Callable
+import collections
+import sys
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax import lax
+
+from jax._src import core
+from jax._src import util
+
+import jax.experimental.slab.slab as sl
+
+jax.config.update('jax_dynamic_shapes', True)
+
+map, zip = util.safe_map, util.safe_zip
+
+make_djaxpr = jax.make_jaxpr
+
+def _check_axis_size_conflicts(all_axes, sizes):
+  if len(all_axes) != len(set(all_axes)):
+    d = collections.defaultdict(list)
+    for name, sz in zip(all_axes, sizes):
+      d[name].append(sz)
+    msg = '; '.join([f'{name}: {" != ".join(map(str, sizes))}'
+                      for name, sizes in d.items() if len(sizes) > 1])
+    raise ValueError(f'abstracted axes resolve to conflicting sizes. {msg}')
+
+@partial(jax.jit, static_argnums=(0, 1, 2, 3))
+def interp(djaxpr, abstracted_axes, dim_index, dtypes, slab, dims, addrs):
+  # TODO(frostig,mattjj): reconstructing slab views seems less than ideal
+  dim_index = dict(dim_index)
+  views = []
+  for addr, axes, dtype in zip(addrs, abstracted_axes, dtypes):
+    resolved_shape = tuple(dims[dim_index[name]] for name in axes)
+    views.append(sl.SlabView(addr, resolved_shape, dtype))
+  slab, outs = eval_djaxpr(djaxpr, slab, *dims, *views)
+  return slab, outs
+
+def djit(f, abstracted_axes, **djit_kwargs):
+  # TODO(frostig,mattjj): un/flatten f
+  def f_wrapped(slab, *args):  # TODO(frostig,mattjj): kw support
+    djaxpr = make_djaxpr(
+        f, abstracted_axes=abstracted_axes, **djit_kwargs)(*args).jaxpr
+    slab, views = sl.chain(slab, sl.slab_upload, *args, unary=True)
+    shapes = [x.shape for x in args]
+    all_axes, sizes = util.unzip2(
+        {(name, sz): None for axes, shape in zip(abstracted_axes, shapes)
+         for name, sz in zip(axes, shape)})
+    _check_axis_size_conflicts(all_axes, sizes)
+    dim_index = {n: i for i, n in enumerate(all_axes)}
+
+    slab, out_views = interp(
+        djaxpr, abstracted_axes, tuple(dim_index.items()),
+        tuple(v.dtype for v in views), slab, sizes, [v.addr for v in views])
+    return slab, tuple(sl.slab_download(slab, v) for v in out_views)
+
+  return f_wrapped
+
+def eval_djaxpr(jaxpr: core.Jaxpr, slab: sl.Slab, *args: jax.Array | sl.SlabView):
+  if jaxpr.constvars: raise NotImplementedError
+
+  env: dict[core.Var, jax.Array | sl.SlabView] = {}
+
+  def read(a):
+    return env[a] if type(a) is core.Var else a.val
+
+  def write(v, val):
+    env[v] = val
+
+  map(write, jaxpr.invars, args)
+  for eqn in jaxpr.eqns:
+    invals = map(read, eqn.invars)
+    slab, outvals = rules[eqn.primitive](slab, *invals, **eqn.params)
+    map(write, eqn.outvars, outvals)
+  return slab, map(read, jaxpr.outvars)
+
+rules: dict[core.Primitive, Callable] = {}
+
+def matmul_rule(slab, lhs, rhs, *, dimension_numbers, **_):
+  slab, out = sl.matmul(slab, lhs, rhs)
+  return slab, [out]
+rules[lax.dot_general_p] = matmul_rule
+
+def tanh_rule(slab, x, **_):
+  slab, out = sl.tanh(slab, x)
+  return slab, [out]
+rules[lax.tanh_p] = tanh_rule
+
+# -------
+
+def print_seg(msg):
+  print()
+  print(f'-- {msg}')
+  print()
+
+def check_djit(slab, f, abstracted_axes, *args):
+  refs, _ = jax.tree.flatten(f(*args))
+  f_djit = djit(f, abstracted_axes=abstracted_axes)
+  slab, outs = f_djit(slab, *args)
+  for out, ref in zip(outs, refs):
+    abs_err = jnp.max(jnp.abs(out - ref))
+    rel_err = jnp.max(jnp.abs(out - ref) / jnp.abs(ref))
+    msg = f'abs={abs_err}, rel={rel_err}'
+    assert jnp.allclose(out, ref, atol=1e-4), msg
+
+def test(slab, xs):
+  a, b = xs
+
+  def f(a, b):
+    c = jnp.dot(a, b)
+    return jnp.tanh(c)
+
+  abstracted_axes = (('m', 'k'), ('k', 'n'))
+
+  print_seg('djaxpr')
+  djaxpr = make_djaxpr(f, abstracted_axes=abstracted_axes)(a, b).jaxpr
+  print(djaxpr)
+
+  print_seg('djax output')
+  f_djit = djit(f, abstracted_axes=abstracted_axes)
+  slab, [c] = f_djit(slab, a, b)
+  print(c)
+
+  print_seg('djax -> jax lowering')
+  big_jaxpr = jax.make_jaxpr(f_djit)(slab, a, b)
+  print('\n'.join(str(big_jaxpr).split('\n')[:20]))
+  print('...')
+  print('\n'.join(str(big_jaxpr).split('\n')[-20:]))
+  print(len(str(big_jaxpr).split('\n')))
+
+  check_djit(slab, f, abstracted_axes, a, b)
+
+def parse_arr(i, s):
+  shape = eval(s)
+  return np.random.RandomState(i).normal(size=shape).astype(np.float32)
+
+def main(args):
+  slab_sz = eval(args[0])
+  print('slab size', slab_sz)
+  xs = map(parse_arr, range(len(args[1:])), args[1:])
+  assert all(len(x.shape) == 2 for x in xs)
+  slab = sl.slab_make(slab_sz)
+  test(slab, xs)
+
+
+if __name__ == '__main__':
+  main(sys.argv[1:])

--- a/jax/experimental/slab/slab.py
+++ b/jax/experimental/slab/slab.py
@@ -1,0 +1,171 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from functools import partial
+from typing import NamedTuple, Union
+import sys
+
+import numpy as np
+
+import jax
+import jax.numpy as jnp
+
+from jax._src import util
+
+map, zip = util.safe_map, util.safe_zip
+
+Slab = jax.Array
+Address = jax.Array
+DShape = tuple[Union[int, jax.Array]]
+SShape = tuple[int]
+
+block_sz = 2
+
+class Slab(NamedTuple):
+  data: jax.Array
+  cursor: Address
+
+class SlabView(NamedTuple):
+  addr: Address
+  shape: DShape
+  # We'll want dtypes eventually. For now, everything is f32.
+  #dtype: jax.typing.DTypeLike
+
+  def size(self):
+    return jnp.prod(jnp.array(self.shape))
+
+  def ndim(self):
+    return len(self.shape)
+
+def slab_make(sz, dtype):
+  return Slab(jnp.zeros(sz, dtype=dtype), jnp.array(0, dtype=int))
+
+def slab_alloc(slab, shape):
+  sz = jnp.prod(jnp.array(shape))
+  new_slab = Slab(slab.data, slab.cursor + sz)
+  slab_val = SlabView(slab.cursor, shape)
+  return new_slab, slab_val
+
+def slab_read(slab, addr, shape):
+  sz = np.prod(shape)
+  flat = jax.lax.dynamic_slice_in_dim(slab.data, addr, sz, axis=0)
+  return flat.reshape(shape)
+
+def slab_write(slab, addr, y):
+  flat = jnp.ravel(y)
+  data = jax.lax.dynamic_update_slice_in_dim(slab.data, flat, addr, axis=0)
+  return Slab(data, slab.cursor)
+
+def tile_loop_bounds(operands):
+  x, *_ = operands
+  x_sz = x.size()
+  return 0, x_sz
+
+def tile_loop_cond(kernel, slab, cursor, end, operands, results):
+  return cursor < end
+
+def tile_loop_body(kernel, slab, cursor, end, operands, results):
+  x, *_ = operands
+  in_tiles = [slab_read(slab, x.addr + cursor, (block_sz,) * x.ndim())
+              for x in operands]
+  out_tiles = kernel(*in_tiles)
+  for y, r in zip(out_tiles, results):
+    slab = slab_write(slab, r.addr + cursor, y)
+  cursor = cursor + block_sz * x.ndim()
+  return slab, cursor, end, operands, results
+
+def while_loop(cond, body, *args):
+  def c(x): return cond(*x)
+  def b(x): return body(*x)
+  return jax.lax.while_loop(c, b, args)
+
+@partial(jax.jit, static_argnums=0)
+def tile(kernel, slab: Slab, operands: tuple[SlabView], results: tuple[SlabView]):
+  start, end = tile_loop_bounds(operands)
+  slab, *_ = while_loop(partial(tile_loop_cond, kernel),
+                        partial(tile_loop_body, kernel),
+                        slab, start, end, operands, results)
+  return slab
+
+def make_elementwise_op(name, op):
+  def kernel(*args): return [op(*args)]
+
+  def f(slab: Slab, *operands: tuple[SlabView]):
+    x, *_ = operands
+    slab, result = slab_alloc(slab, x.shape)
+    slab = tile(kernel, slab, operands, [result])
+    return slab, result
+
+  f.__name__ = name
+  return f
+
+add = make_elementwise_op('add', jax.lax.add)
+mul = make_elementwise_op('mul', jax.lax.mul)
+
+def parse_arr(i, s):
+  shape = eval(s)
+  assert all(d % block_sz == 0 for d in shape)
+  return 3 * i + jnp.arange(np.prod(shape), dtype=jnp.float32).reshape(shape)
+
+def main(args):
+  xs = map(parse_arr, range(len(args)), args)
+  print('initial args:')
+  for x in xs:
+    print(x)
+
+  sz = xs[0].size
+  shape = xs[0].shape
+
+  slab = slab_make(1024, jnp.float32)
+
+  vals = []
+  for x in xs:
+    slab, v = slab_alloc(slab, x.shape)
+    slab = slab_write(slab, v.addr, x)
+    vals.append(v)
+
+  print()
+  print('-- args allocated on slab:')
+  print('slab:', slab)
+  print('ptrs:', vals)
+
+  def f(slab, *vals):
+    slab, y = add(slab, *vals)
+    slab, z = mul(slab, y, vals[0])
+    return slab, y, z
+
+  print()
+  print(jax.make_jaxpr(f)(slab, *vals))
+
+  slab, y, z = jax.jit(f)(slab, *vals)
+  print()
+  print('-- slab ptr results')
+  print('add:', y)
+  print('mul:', z)
+  print()
+  print('-- slab space')
+  print('arg:', slab.data[:sz])
+  print('arg:', slab.data[sz:sz * 2])
+  print('add:', slab.data[sz * 2:sz * 3])
+  print('mul:', slab.data[sz * 3:sz * 4])
+  print()
+  print('-- read off slab')
+  print(slab_read(slab, y.addr, shape))
+  print(slab_read(slab, z.addr, shape))
+
+
+if __name__ == '__main__':
+  main(sys.argv[1:])


### PR DESCRIPTION
Our compiler stack (roughly) requires that array shapes be static at compile time, which allows it to statically schedule computation and memory for all intermediate arrays. How could we lift this requirement? How would programs that lower with some shape dynamism fare practically in comparison to alternatives, like a collection of many static-shape programs, or a hand-written Pallas kernel? This introduces an experiment meant to answer questions like these.

Specifically, this adds:

* The `slab` module, which implements a heap-like data structure on device, backed by one big (statically shaped) array that we call a "slab." It exposes functions to dynamically allocate arrays on the slab, and basic operations over these dynamic-shape arrays, such as `matmul`. The operations work by iterating a static-shape computation across tiles of the dynamic-shape array. The internal shape calculations (needed for e.g. de/allocation and tiling) are carried out as integer operations on the device. Everything is compatible with `jax.jit`.
* The `djax` module, which stands up a simple "dynamic shape jax" frontend (the function `djit`) and lowers it to static-shape jax by evaluation using `slab` operations.

Work with the inimitable @apaszke and @mattjj!