### PR TITLE
Add pycapsule utility to jax.extend.ffi

### DIFF
--- a/jax/_src/extend/ffi.py
+++ b/jax/_src/extend/ffi.py
@@ -15,8 +15,44 @@
 from __future__ import annotations
 
 import os
+import ctypes
 
 from jax._src.lib import jaxlib
+
+
+def pycapsule(funcptr):
+  """Construct a PyCapsule out of a ctypes function pointer.
+
+  A typical use for this is registering custom call targets with XLA:
+
+    import ctypes
+    import jax
+    from jax.lib import xla_client
+
+    fooso = ctypes.cdll.LoadLibrary('./foo.so')
+    xla_client.register_custom_call_target(
+        name="bar",
+        fn=jax.extend.ffi.pycapsule(fooso.bar),
+        platform=PLATFORM,
+        api_version=API_VERSION
+    )
+  """
+  # Note (https://docs.python.org/3/library/ctypes.html):
+  #
+  #  ctypes.pythonapi
+  #    An instance of PyDLL that exposes Python C API functions as attributes.
+  #    Note that all these functions are assumed to return C int, which is of
+  #    course not always the truth, so you have to assign the correct restype
+  #    attribute to use these functions.
+  #
+  # Following this advice we annotate argument and return types of
+  # PyCapsule_New before we call it, based on the example here:
+  # https://stackoverflow.com/questions/65056619/converting-ctypes-c-void-p-to-pycapsule
+  PyCapsule_Destructor = ctypes.CFUNCTYPE(None, ctypes.py_object)
+  PyCapsule_New = ctypes.pythonapi.PyCapsule_New
+  PyCapsule_New.restype = ctypes.py_object
+  PyCapsule_New.argtypes = (ctypes.c_void_p, ctypes.c_char_p, PyCapsule_Destructor)
+  return PyCapsule_New(funcptr, None, PyCapsule_Destructor(0))
 
 
 def include_dir() -> str:

--- a/jax/extend/ffi.py
+++ b/jax/extend/ffi.py
@@ -12,4 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from jax._src.extend.ffi import include_dir as include_dir
+# Note: import <name> as <name> is required for names to be exported.
+# See PEP 484 & https://github.com/google/jax/issues/7570
+
+from jax._src.extend.ffi import (
+  include_dir as include_dir,
+  pycapsule as pycapsule,
+)


### PR DESCRIPTION
This allows one to build PyCapsules ready for XLA custom call registration out of function pointers retrieved from shared libraries using ctypes. In particular, this obviates the need to create Python bindings to custom call targets.