### PR TITLE
relax custom_vjp dtype checks, tweak float0 behavior

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -758,7 +758,7 @@ def _flatten_bwd(in_tree, in_avals, out_trees, *args):
     raise TypeError(msg.format(in_tree2, in_tree)) from None
   results = []
   for kp, a, ct in zip(keypaths, in_avals, cts_in_flat):
-    if ct is zero or a != a.at_least_vspace():
+    if ct is zero:
       results.append(Zero(a.at_least_vspace()))
     elif type(ct) is SymbolicZero:
       if not core.typecompat(a.at_least_vspace(), a_ := ct.aval):
@@ -786,9 +786,7 @@ def _flatten_bwd(in_tree, in_avals, out_trees, *args):
 # TODO(mattjj): remove both these exceptions to cotangent compatibility check
 def _temporary_dtype_exception(a, a_) -> bool:
   if isinstance(a, core.ShapedArray) and isinstance(a_, core.ShapedArray):
-    return (a.shape == a_.shape and
-            (dtypes.issubdtype(a_.dtype, dtypes.extended) or
-             dtypes.issubdtype(a.dtype, dtypes.np.inexact)))
+    return a.shape == a_.shape
   return False
 
 # TODO(mattjj): remove both these exceptions to cotangent compatibility check

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -403,7 +403,6 @@ class JVPTrace(Trace):
         *res, *tangents_in, num_res=res_tree.num_leaves, bwd=bwd,
         out_avals=avals_out, symbolic_zeros=symbolic_zeros)
     tangents_out = map(jax._src.lax.lax.tie_p.bind, primals_out, tangents_out)
-    tangents_out = map(recast_to_float0, primals_out, tangents_out)
     return map(partial(JVPTracer, self), primals_out, tangents_out)
 
   def post_process_custom_vjp_call(self, out_tracers, _):
@@ -480,7 +479,8 @@ def _primal_tangent_shapes_match(primal, tangent):
     tangent_aval = raise_to_shaped(get_aval(tangent), weak_type=False)
     assert core.definitely_equal_shape(primal_aval.shape, tangent_aval.shape)
     expected_tangent_dtype = core.primal_dtype_to_tangent_dtype(primal_aval.dtype)
-    assert expected_tangent_dtype == tangent_aval.dtype, (expected_tangent_dtype, tangent_aval.dtype)
+    assert expected_tangent_dtype == tangent_aval.dtype or \
+        expected_tangent_dtype == float0, (expected_tangent_dtype, tangent_aval.dtype)
 
 call_param_updaters: dict[core.Primitive, Callable] = {}
 call_transpose_param_updaters: dict[core.Primitive, Callable] = {}


### PR DESCRIPTION
The goal is to support stuff like this:

```python
import jax
import jax.numpy as jnp
from typing import NamedTuple

@jax.tree_util.register_pytree_with_keys_class
class QArray(NamedTuple):
  qvalue: jax.Array
  scales: list[jax.Array]

  def tree_flatten_with_keys(self):
    return [('.qvalue', self.qvalue), ('.scales', self.scales)], None

  @classmethod
  def tree_unflatten(self, _, children):
    qvalue, scales = children
    return QArray(qvalue, scales)

@jax.custom_vjp
def quant(x):
  scale = 100.
  return QArray((x / scale).astype('int8'), [scale])
def quant_fwd(x):
  return quant(x), ()
def quant_bwd(res, g):
  assert res == ()
  return dequant(g),
quant.defvjp(quant_fwd, quant_bwd)


@jax.custom_vjp
def dequant(q):
  qvalue, [scale] = q
  return qvalue.astype('float32') * scale
def dequant_fwd(x):
  return dequant(x), ()
def dequant_bwd(res, g):
  assert res == ()
  return quant(g),
dequant.defvjp(dequant_fwd, dequant_bwd)

def f(x):
  return dequant(quant(x))

q, bwd = jax.vjp(f, jnp.array(11.))
dq = bwd(jnp.array(1232.))
print(q, dq)
```