### PR TITLE
skip _origin_msg invar debug info if invar_pos/arg_info is malformed

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -709,13 +709,9 @@ class Tracer(typing.Array, metaclass=StrictABCMeta):
     # This attribute is part of the jax.Array API, but only defined on concrete arrays.
     # Raising a ConcretizationTypeError would make sense, but for backward compatibility
     # we raise an AttributeError so that hasattr() and getattr() work as expected.
-    try:
-      orig_msg = self._origin_msg()
-    except:
-      orig_msg = ''
     raise AttributeError(self,
       f"The 'sharding' attribute is not available on {self._error_repr()}."
-      f"{orig_msg}")
+      f"{self._origin_msg()}")
 
   @property
   def addressable_shards(self):

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1707,7 +1707,8 @@ class DynamicJaxprTracer(core.Tracer):
     origin = ("The error occurred while tracing the function "
               f"{dbg.func_src_info or '<unknown>'} for {dbg.traced_for}. ")
     arg_info = arg_info_all(dbg)
-    if invar_pos and arg_info:
+    # TODO(mattjj): figure out when not (invar_pos < len(arg_info))
+    if invar_pos and arg_info and all(i < len(arg_info) for i in invar_pos):
       arg_info = [arg_info[i] for i in invar_pos]
       arg_names = [f'{name}{keystr(path)}' for name, path in arg_info]
       if len(arg_names) == 1:


### PR DESCRIPTION
cf #20397, #20396

This doesn't actually fix the issue, but in #20396 we only fixed one caller to catch the error. This new logic in `_origin_msg` works for all callers.

EDIT: On reconsideration, I'm going to mark this as fixing #20397 because it fixes the acute issue that was obscuring the error message, and that seems like enough :)

fixes #20397