### PR TITLE
Fix to scipy.ndimage.map_coordinates documentation.

### DIFF
--- a/jax/_src/scipy/ndimage.py
+++ b/jax/_src/scipy/ndimage.py
@@ -151,8 +151,13 @@ def map_coordinates(
       * 1: Linear
 
     mode: Points outside the boundaries of the input are filled according to the given mode.
-      JAX supports one of ``('constant', 'nearest', 'mirror', 'wrap', 'reflect')``.
-      Default is 'constant'.
+      JAX supports one of ``('constant', 'nearest', 'mirror', 'wrap', 'reflect')``. Note the
+      ``'wrap'`` mode in JAX behaves as ``'grid-wrap'`` mode in SciPy, and ``'constant'``
+      mode in JAX behaves as ``'grid-constant'`` mode in SciPy. This discrepancy was caused
+      by a former bug in those modes in SciPy (https://github.com/scipy/scipy/issues/2640),
+      which was first fixed in JAX by changing the behavior of the existing modes, and later
+      on fixed in SciPy, by adding modes with new names, rather than fixing the existing
+      ones, for backwards compatibility reasons. Default is 'constant'.
     cval: Value used for points outside the boundaries of the input if ``mode='constant'``
       Default is 0.0.
 


### PR DESCRIPTION
This correctly documents the current behavior of `constant`, and `wrap` modes.

Fixes https://github.com/google/jax/issues/20333