### PR TITLE
Avoid dynamic docstring generation for jax.tree aliases

### DIFF
--- a/jax/_src/tree.py
+++ b/jax/_src/tree.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import functools
 from typing import Any, Callable, Iterable, TypeVar, overload
 
 from jax._src import tree_util
@@ -21,43 +20,30 @@ from jax._src import tree_util
 T = TypeVar("T")
 
 
-def _add_doc(docstr):
-  def wrapper(fun):
-    doc = fun.__doc__
-    firstline, rest = doc.split('\n', 1)
-    fun.__doc__ = f'{firstline}\n\n  {docstr}\n{rest}'
-    return fun
-  return wrapper
-
-
-@_add_doc("Alias of :func:`jax.tree_util.tree_all`.")
-@functools.wraps(tree_util.tree_all)
 def all(tree: Any) -> bool:
+  """Alias of :func:`jax.tree_util.tree_all`."""
   return tree_util.tree_all(tree)
 
 
-@_add_doc("Alias of :func:`jax.tree_util.tree_flatten`.")
-@functools.wraps(tree_util.tree_flatten)
 def flatten(tree: Any,
             is_leaf: Callable[[Any], bool] | None = None
             ) -> tuple[list[tree_util.Leaf], tree_util.PyTreeDef]:
+  """Alias of :func:`jax.tree_util.tree_flatten`."""
   return tree_util.tree_flatten(tree, is_leaf)
 
 
-@_add_doc("Alias of :func:`jax.tree_util.tree_leaves`.")
-@functools.wraps(tree_util.tree_leaves)
 def leaves(tree: Any,
            is_leaf: Callable[[Any], bool] | None = None
            ) -> list[tree_util.Leaf]:
+  """Alias of :func:`jax.tree_util.tree_leaves`."""
   return tree_util.tree_leaves(tree, is_leaf)
 
 
-@_add_doc("Alias of :func:`jax.tree_util.tree_map`.")
-@functools.wraps(tree_util.tree_map)
 def map(f: Callable[..., Any],
         tree: Any,
         *rest: Any,
         is_leaf: Callable[[Any], bool] | None = None) -> Any:
+  """Alias of :func:`jax.tree_util.tree_map`."""
   return tree_util.tree_map(f, tree, *rest, is_leaf=is_leaf)
 
 
@@ -73,32 +59,28 @@ def reduce(function: Callable[[T, Any], T],
            initializer: T,
            is_leaf: Callable[[Any], bool] | None = None) -> T:
     ...
-@_add_doc("Alias of :func:`jax.tree_util.tree_reduce`.")
-@functools.wraps(tree_util.tree_reduce)
 def reduce(function: Callable[[T, Any], T],
            tree: Any,
            initializer: Any = tree_util.no_initializer,
            is_leaf: Callable[[Any], bool] | None = None) -> T:
+  """Alias of :func:`jax.tree_util.tree_reduce`."""
   return tree_util.tree_reduce(function, tree, initializer, is_leaf=is_leaf)
 
 
-@_add_doc("Alias of :func:`jax.tree_util.tree_structure`.")
-@functools.wraps(tree_util.tree_structure)
 def structure(tree: Any,
               is_leaf: None | (Callable[[Any], bool]) = None) -> tree_util.PyTreeDef:
+  """Alias of :func:`jax.tree_util.tree_structure`."""
   return tree_util.tree_structure(tree, is_leaf)
 
 
-@_add_doc("Alias of :func:`jax.tree_util.tree_transpose`.")
-@functools.wraps(tree_util.tree_transpose)
 def transpose(outer_treedef: tree_util.PyTreeDef,
               inner_treedef: tree_util.PyTreeDef,
               pytree_to_transpose: Any) -> Any:
+  """Alias of :func:`jax.tree_util.tree_transpose`."""
   return tree_util.tree_transpose(outer_treedef, inner_treedef, pytree_to_transpose)
 
 
-@_add_doc("Alias of :func:`jax.tree_util.tree_unflatten`.")
-@functools.wraps(tree_util.tree_unflatten)
 def unflatten(treedef: tree_util.PyTreeDef,
               leaves: Iterable[tree_util.Leaf]) -> Any:
+  """Alias of :func:`jax.tree_util.tree_unflatten`."""
   return tree_util.tree_unflatten(treedef, leaves)

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -1144,20 +1144,67 @@ class TreePrefixErrorsTest(jtu.JaxTestCase):
 
 
 class TreeAliasTest(jtu.JaxTestCase):
-  @parameterized.parameters(
-      ('all', 'tree_all'),
-      ('flatten', 'tree_flatten'),
-      ('leaves', 'tree_leaves'),
-      ('map', 'tree_map'),
-      ('reduce', 'tree_reduce'),
-      ('structure', 'tree_structure'),
-      ('transpose', 'tree_transpose'),
-      ('unflatten', 'tree_unflatten'),
-  )
-  def test_tree_aliases(self, tree_name, tree_util_name):
-    wrapper = getattr(jax.tree, tree_name)
-    original = getattr(jax.tree_util, tree_util_name)
-    self.assertIs(wrapper.__wrapped__, original)
+  """Simple smoke-tests for tree_util aliases under jax.tree"""
+
+  def test_tree_all(self):
+    obj = [True, True, (True, False)]
+    self.assertEqual(
+      jax.tree.all(obj),
+      tree_util.tree_all(obj),
+    )
+
+  def test_tree_flatten(self):
+    obj = [1, 2, (3, 4)]
+    self.assertEqual(
+      jax.tree.flatten(obj),
+      tree_util.tree_flatten(obj),
+    )
+
+  def test_tree_leaves(self):
+    obj = [1, 2, (3, 4)]
+    self.assertEqual(
+      jax.tree.leaves(obj),
+      tree_util.tree_leaves(obj),
+    )
+
+  def test_tree_map(self):
+    func = lambda x: x * 2
+    obj = [1, 2, (3, 4)]
+    self.assertEqual(
+      jax.tree.map(func, obj),
+      tree_util.tree_map(func, obj),
+    )
+
+  def test_tree_reduce(self):
+    func = lambda a, b: a + b
+    obj = [1, 2, (3, 4)]
+    self.assertEqual(
+      jax.tree.reduce(func, obj),
+      tree_util.tree_reduce(func, obj),
+    )
+
+  def test_tree_structure(self):
+    obj = [1, 2, (3, 4)]
+    self.assertEqual(
+      jax.tree.structure(obj),
+      tree_util.tree_structure(obj),
+    )
+
+  def test_tree_transpose(self):
+    obj = [(1, 2), (3, 4), (5, 6)]
+    outer_treedef = tree_util.tree_structure(['*', '*', '*'])
+    inner_treedef = tree_util.tree_structure(('*', '*'))
+    self.assertEqual(
+      jax.tree.transpose(outer_treedef, inner_treedef, obj),
+      tree_util.tree_transpose(outer_treedef, inner_treedef, obj)
+    )
+
+  def test_tree_unflatten(self):
+    leaves, treedef = jax.tree.flatten([1, 2, (3, 4)])
+    self.assertEqual(
+      jax.tree.unflatten(treedef, leaves),
+      tree_util.tree_unflatten(treedef, leaves)
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #21542

I think it makes sense for these aliases to not have their own docstrings.

Also, given the difference in how these functions are now defined, I expanded their tests somewhat in `tree_util_test.py`.