### PR TITLE
[export] Add a LoweringParameters.for_export boolean context for exporting

### DIFF
--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -560,6 +560,9 @@ class LoweringParameters:
   # or multi-platform lowering.
   global_constant_computation: bool = False
 
+  # Signals that we are lowering for exporting.
+  for_export: bool = False
+
 
 @dataclasses.dataclass
 class TracebackCaches:

--- a/jax/experimental/export/_export.py
+++ b/jax/experimental/export/_export.py
@@ -467,7 +467,8 @@ def export(fun_jax: Callable,
     lowered = wrapped_fun_jax.lower(
         *args_specs, **kwargs_specs,
         _experimental_lowering_parameters=mlir.LoweringParameters(
-          platforms=actual_lowering_platforms,
+            platforms=actual_lowering_platforms,
+            for_export=True,
         ))
     return _export_lowered(
         lowered, disabled_checks=disabled_checks,
@@ -737,7 +738,8 @@ def _wrap_main_func(
           keepalives=[], channel_iterator=itertools.count(1),
           host_callbacks=[], module=wrapped_module, context=context,
           lowering_parameters=mlir.LoweringParameters(
-            global_constant_computation=True
+              global_constant_computation=True,
+              for_export=True,
           ))
       ctx = mlir.LoweringRuleContext(
         module_context=module_context,


### PR DESCRIPTION
This boolean context field is set only when we are lowering for exporting. It can be used, e.g., to adapt the lowering rules for the export case.
