### PR TITLE
Add CLI for profiling JAX scripts with output and backend options

### DIFF
--- a/jax/_src/profiler.py
+++ b/jax/_src/profiler.py
@@ -114,6 +114,11 @@ def start_trace(log_dir, create_perfetto_link: bool = False,
       want to generate a Perfetto-compatible trace without blocking the
       process.
   """
+
+  jax_profile_output = os.getenv('JAX_PROFILE')
+  if jax_profile_output:
+    log_dir = jax_profile_output
+
   with _profile_state.lock:
     if _profile_state.profile_session is not None:
       raise RuntimeError("Profile has already been started. "


### PR DESCRIPTION
When using any module that utilizes start_trace() from _src/profiler.py, allows profiler trace destination to be specified through command line like `JAX_PROFILE = output.pb`