### PR TITLE
tests: set configs with jtu.with_config rather than manually

### DIFF
--- a/tests/debug_nans_test.py
+++ b/tests/debug_nans_test.py
@@ -29,16 +29,8 @@ from jax._src.maps import xmap
 jax.config.parse_flags_with_absl()
 
 
+@jtu.with_config(jax_debug_nans=True)
 class DebugNaNsTest(jtu.JaxTestCase):
-
-  def setUp(self):
-    super().setUp()
-    self.cfg = jax.config._read("jax_debug_nans")
-    jax.config.update("jax_debug_nans", True)
-
-  def tearDown(self):
-    jax.config.update("jax_debug_nans", self.cfg)
-    super().tearDown()
 
   def testSinc(self):
     # Regression test for #6936
@@ -65,8 +57,8 @@ class DebugNaNsTest(jtu.JaxTestCase):
       ans = jax.jit(lambda x: 0. / x)(A)
       ans.block_until_ready()
 
+  @jax.debug_nans(False)
   def testJitComputationNaNContextManager(self):
-    jax.config.update("jax_debug_nans", False)
     A = jnp.array(0.)
     f = jax.jit(lambda x: 0. / x)
     ans = f(A)
@@ -205,16 +197,8 @@ class DebugNaNsTest(jtu.JaxTestCase):
       jax.jit(f)(inp, inp)
 
 
+@jtu.with_config(jax_debug_infs=True)
 class DebugInfsTest(jtu.JaxTestCase):
-
-  def setUp(self):
-    super().setUp()
-    self.cfg = jax.config._read("jax_debug_infs")
-    jax.config.update("jax_debug_infs", True)
-
-  def tearDown(self):
-    jax.config.update("jax_debug_infs", self.cfg)
-    super().tearDown()
 
   def testSingleResultPrimitiveNoInf(self):
     A = jnp.array([[1., 2.], [2., 3.]])

--- a/tests/memories_test.py
+++ b/tests/memories_test.py
@@ -64,6 +64,7 @@ def _create_inputs(shape, pspec, mem_kind=None):
 # * nested jit
 
 
+@jtu.with_config(jax_enable_memories=True)
 class ShardingMemoriesTest(jtu.JaxTestCase):
 
   def setUp(self):
@@ -73,16 +74,10 @@ class ShardingMemoriesTest(jtu.JaxTestCase):
     if jtu.is_cloud_tpu():
       self.skipTest("Experimental feature not yet implemented on Cloud TPU")
     super().setUp()
-    self.orig_memories_flag = config.enable_memories.value
-    jax.config.update('jax_enable_memories', True)
     if jtu.test_device_matches(["cpu"]):
       self._default_memory_kind = "unpinned_host"
     else:
       self._default_memory_kind = "device"
-
-  def tearDown(self):
-    jax.config.update('jax_enable_memories', self.orig_memories_flag)
-    super().tearDown()
 
   @parameterized.named_parameters(
       ("named_sharding", "named_sharding"),
@@ -206,18 +201,13 @@ class ShardingMemoriesTest(jtu.JaxTestCase):
     self.assertEqual(dev.default_memory().kind, self._default_memory_kind)
 
 
+@jtu.with_config(jax_enable_memories=True)
 class DevicePutTest(jtu.JaxTestCase):
 
   def setUp(self):
     if not jtu.test_device_matches(["tpu"]):
       self.skipTest("Memories do not work on CPU and GPU backends yet.")
     super().setUp()
-    self.orig_memories_flag = config.enable_memories.value
-    jax.config.update('jax_enable_memories', True)
-
-  def tearDown(self):
-    jax.config.update('jax_enable_memories', self.orig_memories_flag)
-    super().tearDown()
 
   def _check_device_put_addressable_shards(
       self, out, inp, expected_sharding, expected_mem_kind, index=True):
@@ -612,18 +602,13 @@ class DevicePutTest(jtu.JaxTestCase):
     self.assertEqual(t.shape, t_copy.shape)
 
 
+@jtu.with_config(jax_enable_memories=True)
 class ComputeOffload(jtu.BufferDonationTestCase):
 
   def setUp(self):
     if not jtu.test_device_matches(["tpu"]):
       self.skipTest("Memories do not work on CPU and GPU backends yet.")
     super().setUp()
-    self.orig_memories_flag = config.enable_memories.value
-    jax.config.update('jax_enable_memories', True)
-
-  def tearDown(self):
-    jax.config.update('jax_enable_memories', self.orig_memories_flag)
-    super().tearDown()
 
   def _check_mem_kind(self, executable_kind, out_sharding, expected_kind):
     out_kind = out_sharding.memory_kind
@@ -1107,18 +1092,13 @@ class ComputeOffload(jtu.BufferDonationTestCase):
     self.assertDeleted(x)
 
 
+@jtu.with_config(jax_enable_memories=True)
 class ActivationOffloadingTest(jtu.JaxTestCase):
 
   def setUp(self):
     if not jtu.test_device_matches(["tpu", "gpu"]):
       self.skipTest("Memories do not work on CPU backend.")
     super().setUp()
-    self.orig_memories_flag = config.enable_memories.value
-    jax.config.update('jax_enable_memories', True)
-
-  def tearDown(self):
-    jax.config.update('jax_enable_memories', self.orig_memories_flag)
-    super().tearDown()
 
   def test_remat_jaxpr_offloadable(self):
     mesh = jtu.create_global_mesh((2,), ("x",))

--- a/tests/mock_gpu_test.py
+++ b/tests/mock_gpu_test.py
@@ -24,23 +24,14 @@ from jax.sharding import PartitionSpec as P
 import numpy as np
 
 jax.config.parse_flags_with_absl()
+NUM_SHARDS = 16
 
 
+@jtu.with_config(use_mock_gpu_client=True, mock_num_gpus=NUM_SHARDS)
 class MockGPUTest(jtu.JaxTestCase):
 
-  def setUp(self):
-    super().setUp()
-    jax.config.update('use_mock_gpu_client', True)
-
-  def tearDown(self):
-    jax.config.update('use_mock_gpu_client', False)
-    jax.config.update('mock_num_gpus', 1)
-    super().tearDown()
-
   def testMockWithSharding(self):
-    num_shards = 16
-    jax.config.update('mock_num_gpus', num_shards)
-    mesh = jtu.create_global_mesh((num_shards,), ('x',))
+    mesh = jtu.create_global_mesh((NUM_SHARDS,), ('x',))
     @partial(
         jax.jit,
         in_shardings=NamedSharding(mesh, P('x',)),

--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -28,7 +28,6 @@ import numpy as np
 import jax
 from jax._src import core
 from jax._src import distributed
-from jax._src import maps
 from jax._src import test_util as jtu
 from jax._src import util
 from jax.experimental import pjit
@@ -224,6 +223,7 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
     os.environ.get("SLURM_JOB_NUM_NODES", None) != "2",
     "Slurm environment with at least two nodes needed!")
 @jtu.pytest_mark_if_available('SlurmMultiNodeGpuTest')
+@jtu.with_config(experimental_xmap_spmd_lowering=True)
 class SlurmMultiNodeGpuTest(jtu.JaxTestCase):
 
   def sorted_devices(self):
@@ -255,16 +255,6 @@ class SlurmMultiNodeGpuTest(jtu.JaxTestCase):
     assert [d.id for d in device_mesh.flat
            ] == [0, 2, 4, 6, 1, 3, 5, 7, 8, 10, 12, 14, 9, 11, 13, 15]
     return jax.sharding.Mesh(device_mesh, ("x", "y"))
-
-  def setUp(self):
-    super().setUp()
-    self.xmap_spmd_lowering_enabled = maps.SPMD_LOWERING.value
-    jax.config.update("experimental_xmap_spmd_lowering", True)
-
-  def tearDown(self):
-    jax.config.update("experimental_xmap_spmd_lowering",
-                      self.xmap_spmd_lowering_enabled)
-    super().tearDown()
 
   def test_gpu_multi_node_initialize_and_psum(self):
 

--- a/tests/transfer_guard_test.py
+++ b/tests/transfer_guard_test.py
@@ -99,12 +99,11 @@ _COMMON_TEST_PARAMETERS = [
 ]
 
 
+# TransferGuardTest disables `--jax_enable_checks` because it
+# can prematurely fetch the value of device arrays and make
+# device-to-host tests to incur no transfers unexpectedly.
+@jtu.with_config(jax_enable_checks=False)
 class TransferGuardTest(jtu.JaxTestCase):
-  # `_default_config` is used by `jtu.JaxTestCase` to update the JAX config for
-  # every test case. TransferGuardTest disables `--jax_enable_checks` because it
-  # can prematurely fetch the value of device arrays and make device-to-host
-  # tests to incur no transfers unexpectedly.
-  _default_config = {"jax_enable_checks": False}
 
   @contextlib.contextmanager
   def assertAllows(self, func_name):


### PR DESCRIPTION
More cleanup related to #21650.

This fixes potential issues in a few places, where the global config setting is restored to the thread-local value. This shouldn't be problematic in tests because there shouldn't be thread-local context during test setup, but in any case I think using `with_config` makes things cleaner and less error-prone.