### PR TITLE
fix typo in `jax.numpy.linalg.cross` docstring

### DIFF
--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -1438,7 +1438,7 @@ def lstsq(a: ArrayLike, b: ArrayLike, rcond: float | None = None, *,
 
 
 def cross(x1: ArrayLike, x2: ArrayLike, /, *, axis=-1):
-  r"""Compute the corss-product of two 3D vectors
+  r"""Compute the cross-product of two 3D vectors
 
   JAX implementation of :func:`numpy.linalg.cross`
 


### PR DESCRIPTION
Fixes a simple typo in `jax.numpy.linalg.cross` where `cross` was misspelled as `corss`.