### PR TITLE
Edit `pycapsule` docstring to provide a little bit more context

### DIFF
--- a/docs/jax.extend.ffi.rst
+++ b/docs/jax.extend.ffi.rst
@@ -1,0 +1,10 @@
+``jax.extend.ffi`` module
+=========================
+
+.. automodule:: jax.extend.ffi
+
+.. autosummary::
+  :toctree: _autosummary
+
+  ffi_lowering
+  pycapsule

--- a/docs/jax.extend.rst
+++ b/docs/jax.extend.rst
@@ -11,6 +11,7 @@ Modules
 .. toctree::
   :maxdepth: 1
 
+  jax.extend.ffi
   jax.extend.linear_util
   jax.extend.mlir
   jax.extend.random


### PR DESCRIPTION
The docstring for the recently added `pycapsule` function in `jax.extend.ffi` didn't conform to our usual docstring format, so I updated it and added a little bit more context.