### PR TITLE
Make full Read the Docs builds for PR previews explicitly opt-in

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -176,4 +176,4 @@ jobs:
         pip install -r docs/requirements.txt
     - name: Render documentation
       run: |
-        sphinx-build --color -W --keep-going -b html -D nb_execution_mode=off docs docs/build/html
+        sphinx-build --color -W --keep-going -b html docs docs/build/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -189,9 +189,16 @@ html_css_files = [
 # -- Options for myst ----------------------------------------------
 myst_heading_anchors = 3  # auto-generate 3 levels of heading anchors
 myst_enable_extensions = ['dollarmath']
-nb_execution_mode = "force"
 nb_execution_allow_errors = False
 nb_merge_streams = True
+
+# On Read the Docs, we don't execute the notebooks unless specifically requested
+rtds_version = os.environ.get("READTHEDOCS_VERSION", None)
+print(f"READTHEDOCS_VERSION = {rtds_version}")
+if rtds_version:
+  nb_execution_mode = "off"
+else:
+  nb_execution_mode = "force"
 
 # Notebook cell execution timeout; defaults to 30.
 nb_execution_timeout = 100

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,6 +151,12 @@ exclude_patterns = [
     'autodidax.md',
     'sharded-computation.md',
 ]
+if not full_docs_build:
+  exclude_patterns += ['jax.rst', 'jax.*.rst', 'jax_internal_api.rst']
+  suppress_warnings += [
+      'toc.excluded',
+      'ref.ref',  # 'Undefined label' warning
+  ]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,9 @@ sphinx-design
 sphinxext-rediraffe
 myst-nb>=1.0.0
 
+# Used for checking PR labels
+requests
+
 # Packages used for CI tests.
 flatbuffers
 pytest


### PR DESCRIPTION
This is a proposed method to speed up the Read the Docs build time so that we don't end up with a backed up build queue. The idea is to only execute the notebooks and(/or?) generate the full API docs if explicitly requested by adding a new `full docs build` label to the PR. This means that the rendered previews won't be complete, but we should still be able to catch notebook bugs on GitHub Actions (where I've turned on notebook execution).

This reduces the Read the Docs runtime from ~12 minutes to ~2 minutes, but (of course) produces an incomplete preview of the docs. Here's the preview for this PR: https://jax--21750.org.readthedocs.build/en/21750/

I'm not sure that this is exactly the implementation that makes sense for this feature, but I think that there might be some benefit to limiting the number of PRs which run a full build on Read the Docs. Another option could be to skip the build entirely unless explicitly requested or filtered on file changes, because then that would free up the Read the Docs queue for PRs that do want to investigate docs builds.