### PR TITLE
[export] Create the jax.export module APIs.

### DIFF
--- a/benchmarks/shape_poly_benchmark.py
+++ b/benchmarks/shape_poly_benchmark.py
@@ -18,7 +18,7 @@ import google_benchmark as benchmark
 import jax
 from jax import core
 from jax._src.numpy import lax_numpy
-from jax.experimental import export
+from jax import export
 
 jax.config.parse_flags_with_absl()
 

--- a/jax/_src/export/serialization.py
+++ b/jax/_src/export/serialization.py
@@ -48,7 +48,7 @@ SerT = TypeVar("SerT")
 _SERIALIZATION_VERSION = 2
 
 def serialize(exp: _export.Exported, vjp_order: int = 0) -> bytearray:
-  """Serialize an Exported.
+  """Serializes an Exported.
 
   Args:
     exp: the Exported to serialize.
@@ -64,7 +64,7 @@ def serialize(exp: _export.Exported, vjp_order: int = 0) -> bytearray:
 
 
 def deserialize(ser: bytearray) -> _export.Exported:
-  """Deserialize an Exported."""
+  """Deserializes an Exported."""
   exp = ser_flatbuf.Exported.GetRootAsExported(ser)
   return _deserialize_exported(exp)
 

--- a/jax/_src/internal_test_util/export_back_compat_test_util.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_util.py
@@ -86,7 +86,7 @@ from numpy import array, float32
 
 import jax
 from jax import tree_util
-from jax.experimental import export
+from jax import export
 
 from jax.experimental import pjit
 
@@ -345,4 +345,4 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
       _get_vjp=_get_vjp)
 
       # We use pjit in case there are shardings in the exported module.
-    return pjit.pjit(export.call(exported))(*data.inputs)
+    return pjit.pjit(exported.call)(*data.inputs)

--- a/jax/_src/stages.py
+++ b/jax/_src/stages.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, NamedTuple, Protocol, Union
+from typing import Any, NamedTuple, Protocol, Union, runtime_checkable
 import warnings
 
 import jax
@@ -756,8 +756,9 @@ class Lowered(Stage):
       return None
 
 
+@runtime_checkable
 class Wrapped(Protocol):
-  """A function ready to be specialized, lowered, and compiled.
+  """A function ready to be traced, lowered, and compiled.
 
   This protocol reflects the output of functions such as
   ``jax.jit``. Calling it results in JIT (just-in-time) lowering,

--- a/jax/experimental/export/__init__.py
+++ b/jax/experimental/export/__init__.py
@@ -17,12 +17,13 @@ from jax._src.export._export import (
     minimum_supported_serialization_version,
     maximum_supported_serialization_version,
     Exported,
-    export,
     call_exported,  # TODO: deprecate
     call,
     DisabledSafetyCheck,
-    default_lowering_platform,
+    default_lowering_platform,  # TODO: deprecate
 )
+from jax._src.export._export import export_back_compat as export
+
 from jax._src.export.shape_poly import (
     is_symbolic_dim,
     symbolic_shape,
@@ -33,4 +34,6 @@ from jax._src.export.serialization import (
     serialize,
     deserialize,
 )
+# Import only to set the shape poly decision procedure
 from jax._src.export import shape_poly_decision
+del shape_poly_decision

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -36,7 +36,7 @@ from jax import random
 from jax import numpy as jnp
 from jax import tree_util
 from jax import sharding
-from jax.experimental import export
+from jax import export
 from jax.experimental.jax2tf import impl_no_xla
 from jax.interpreters import xla
 
@@ -515,7 +515,7 @@ class NativeSerializationImpl(SerializationImpl):
 
     self._restore_context = _restore_context
     _exported_device_assignment = [None]
-    self.exported = export.export(
+    self.exported = _export.export_back_compat(
         self.fun_jax,
         lowering_platforms=self.native_serialization_platforms,
         disabled_checks=self.native_serialization_disabled_checks,

--- a/jax/experimental/jax2tf/tests/call_tf_test.py
+++ b/jax/experimental/jax2tf/tests/call_tf_test.py
@@ -25,13 +25,13 @@ from absl.testing import parameterized
 import jax
 from jax import dlpack
 from jax import dtypes
+from jax import export
 from jax import lax
 from jax import numpy as jnp
 from jax._src import config
 from jax._src import test_util as jtu
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import hlo
-from jax.experimental import export
 from jax.experimental import jax2tf
 from jax.experimental.jax2tf.tests import tf_test_util
 import numpy as np
@@ -778,7 +778,7 @@ class CallTfTest(tf_test_util.JaxToTfTestCase):
 
     lowering_platforms = ("tpu", "cpu", "cuda")
 
-    exp = export.export(f_jax,
+    exp = export.export(jax.jit(f_jax),
                         lowering_platforms=lowering_platforms)(x)
     for jax_platform in jax_and_tf_platforms:
       with self.subTest(jax_platform):
@@ -787,7 +787,7 @@ class CallTfTest(tf_test_util.JaxToTfTestCase):
         logging.info("Running harness natively on %s", jax_device)
         native_res = f_jax(x_device)
         logging.info("Running exported harness on %s", jax_device)
-        exported_res = export.call(exp)(x_device)
+        exported_res = exp.call(x_device)
         self.assertAllClose(native_res, exported_res)
 
   def test_multi_platform_call_tf_graph(self):

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -27,6 +27,7 @@ from absl.testing import absltest, parameterized
 import jax
 from jax import ad_checkpoint
 from jax import dtypes
+from jax import export
 from jax import lax
 from jax import numpy as jnp
 from jax import sharding
@@ -37,7 +38,6 @@ from jax._src import source_info_util
 from jax._src import test_util as jtu
 from jax._src import xla_bridge as xb
 from jax.experimental import jax2tf
-from jax.experimental import export
 from jax.experimental.jax2tf.tests import tf_test_util
 from jax.experimental.shard_map import shard_map
 from jax.experimental import pjit
@@ -1559,7 +1559,7 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
       # Run the JAX native version, to check it works, and to fill caches.
       _ = func_to_convert(*args)
       exported = export.export(
-          func_to_convert,
+          (jax.jit(func_to_convert) if not hasattr(func_to_convert, "trace") else func_to_convert),
           lowering_platforms=("tpu",)
       )(*(core.ShapedArray(a.shape, a.dtype) for a in args))
 

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -32,8 +32,8 @@ import re
 
 import jax
 from jax.experimental import jax2tf
-from jax.experimental import export
 from jax.experimental import pjit
+from jax import export
 from jax import lax
 import jax.numpy as jnp
 from jax import random

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -31,7 +31,7 @@ from jax._src import test_util as jtu
 from jax import tree_util
 
 from jax.experimental import jax2tf
-from jax.experimental import export
+from jax import export
 from jax._src import config
 from jax._src import xla_bridge
 import numpy as np

--- a/jax/export.py
+++ b/jax/export.py
@@ -1,0 +1,34 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+__all__ = ["DisabledSafetyCheck", "Exported", "export", "deserialize",
+           "maximum_supported_serialization_version",
+           "minimum_supported_serialization_version",
+           "default_lowering_platform",
+           "SymbolicScope", "is_symbolic_dim",
+           "symbolic_shape", "symbolic_args_specs"]
+
+from jax._src.export._export import DisabledSafetyCheck as DisabledSafetyCheck
+from jax._src.export._export import Exported as Exported
+from jax._src.export._export import export as export
+from jax._src.export._export import deserialize as deserialize
+from jax._src.export._export import maximum_supported_serialization_version as maximum_supported_serialization_version
+from jax._src.export._export import minimum_supported_serialization_version as minimum_supported_serialization_version
+from jax._src.export._export import default_lowering_platform as default_lowering_platform
+
+from jax._src.export import shape_poly_decision  # Import only to set the decision procedure
+del shape_poly_decision
+from jax._src.export.shape_poly import SymbolicScope as SymbolicScope
+from jax._src.export.shape_poly import is_symbolic_dim as is_symbolic_dim
+from jax._src.export.shape_poly import symbolic_shape as symbolic_shape
+from jax._src.export.shape_poly import symbolic_args_specs as symbolic_args_specs

--- a/tests/export_harnesses_multi_platform_test.py
+++ b/tests/export_harnesses_multi_platform_test.py
@@ -31,9 +31,9 @@ from absl.testing import absltest
 import numpy as np
 
 import jax
+from jax import export
 from jax import lax
 from jax._src import test_util as jtu
-from jax.experimental import export
 from jax._src.internal_test_util import test_harnesses
 
 
@@ -152,7 +152,8 @@ class PrimitiveTest(jtu.JaxTestCase):
       )
 
     logging.info("Exporting harness for %s", lowering_platforms)
-    exp = export.export(func_jax, lowering_platforms=lowering_platforms)(*args)
+    exp = export.export(jax.jit(func_jax),
+                        lowering_platforms=lowering_platforms)(*args)
 
     for device in devices:
       if device.platform in skip_run_on_platforms:
@@ -164,7 +165,7 @@ class PrimitiveTest(jtu.JaxTestCase):
       logging.info("Running harness natively on %s", device)
       native_res = func_jax(*device_args)
       logging.info("Running exported harness on %s", device)
-      exported_res = export.call(exp)(*device_args)
+      exported_res = exp.call(*device_args)
       if tol is not None:
         logging.info(f"Using non-standard tolerance {tol}")
       self.assertAllClose(native_res, exported_res, atol=tol, rtol=tol)


### PR DESCRIPTION
The functionality comes from the jax.experimental.export module, which will be deprecated.

The following APIs are introduced:

```
  from jax import export
  def f(...): ...
  ex: export.Exported = export.export(jax.jit(f))(*args, **kwargs)

  blob: bytearray = ex.serialize()
  rehydrated: export.Export = export.deserialize(blob)

  def caller(...):
     ... rehydrated.call(*args, **kwargs)
```

Module documentation will follow shortly.
There are no changes for now in the jax.experimental.export APIs.

Most of the changes in this PR are in tests and are due to some differences in the new jax.export APIs compared to jax.experimental.export:

  * Instead of `jax.experimental.export.call(exp)` we now write `exp.call`
  * The `jax.experimental.export.export` allowed the function argument to be any Python callable and it would wrap it with a `jax.jit`. This is not supported anymore by export, and instead the user must use `jax.jit`.