### PR TITLE
Improve vmap out_axes error

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -40,7 +40,7 @@ from jax._src import stages
 from jax._src.tree_util import (
     tree_map, tree_flatten, tree_unflatten, tree_structure, tree_transpose,
     tree_leaves, Partial, PyTreeDef, all_leaves, keystr, broadcast_prefix,
-    prefix_errors, generate_key_paths)
+    prefix_errors, generate_key_paths, tree_flatten_with_path)
 from jax._src import api_util
 from jax._src import config
 from jax._src import core
@@ -1211,11 +1211,22 @@ def vmap(fun: F,
     in_axes_flat = flatten_axes("vmap in_axes", in_tree, (in_axes, 0), kws=True)
     axis_size_ = (axis_size if axis_size is not None else
                   _mapped_axis_size(fun, in_tree, args_flat, in_axes_flat, "vmap"))
-    out_flat = batching.batch(
-        flat_fun, axis_name, axis_size_, in_axes_flat,
-        lambda: flatten_axes("vmap out_axes", out_tree(), out_axes),
-        spmd_axis_name=spmd_axis_name
-    ).call_wrapped(*args_flat)
+    try:
+      out_flat = batching.batch(
+          flat_fun, axis_name, axis_size_, in_axes_flat,
+          lambda: flatten_axes("vmap out_axes", out_tree(), out_axes),
+          spmd_axis_name=spmd_axis_name
+      ).call_wrapped(*args_flat)
+    except batching.SpecMatchError as e:
+      # TODO this is a bit circular, maybe there's a better way to get paths..
+      # let's look at how shard_map organizes things?
+      out_axes_flat = flatten_axes("vmap out_axes", out_tree(), out_axes)
+      out_axes_full = tree_unflatten(out_tree(), out_axes_flat)
+      pairs, _ = tree_flatten_with_path(out_axes_full, is_leaf=lambda x: x is None)
+
+      path, _ = pairs[e.leaf_idx]
+      raise ValueError(f'at vmap out_axes{keystr(path)}, got axis spec {e.dst} '
+                       f'but output was batched on axis {e.src}')
     return tree_unflatten(out_tree(), out_flat)
 
   return cast(F, vmap_f)

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1226,7 +1226,7 @@ def vmap(fun: F,
 
       path, _ = pairs[e.leaf_idx]
       raise ValueError(f'at vmap out_axes{keystr(path)}, got axis spec {e.dst} '
-                       f'but output was batched on axis {e.src}')
+                       f'but output was batched on axis {e.src}') from None
     return tree_unflatten(out_tree(), out_flat)
 
   return cast(F, vmap_f)

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1218,8 +1218,6 @@ def vmap(fun: F,
           spmd_axis_name=spmd_axis_name
       ).call_wrapped(*args_flat)
     except batching.SpecMatchError as e:
-      # TODO this is a bit circular, maybe there's a better way to get paths..
-      # let's look at how shard_map organizes things?
       out_axes_flat = flatten_axes("vmap out_axes", out_tree(), out_axes)
       out_axes_full = tree_unflatten(out_tree(), out_axes_flat)
       pairs, _ = tree_flatten_with_path(out_axes_full, is_leaf=lambda x: x is None)

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -1129,7 +1129,7 @@ def matchaxis(axis_name, sz, src, dst, x, sum_match=False):
 
 class SpecMatchError(Exception):
   def __init__(self, leaf_idx, src, dst):
-    self.leaf_idx  = leaf_idx
+    self.leaf_idx = leaf_idx
     self.src = src
     self.dst = dst
 

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -258,7 +258,9 @@ def from_elt(trace: BatchTrace, axis_size: AxisSize, i: int,
              x: Elt, spec: MapSpec) -> Vmappable:
   handler = from_elt_handlers.get(type(x))
   if handler:
-    return handler(partial(from_elt, trace), axis_size, x, spec)
+    def _cont(axis_size, elt, axis):
+      return from_elt(trace, axis_size, i, elt, axis)
+    return handler(_cont, axis_size, x, spec)
   x_ = trace.full_raise(x)
   val, bdim = x_.val, x_.batch_dim
   if type(bdim) is RaggedAxis:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -10407,7 +10407,7 @@ class CustomVmapTest(jtu.JaxTestCase):
 
     # does err
     self.assertRaisesRegex(
-        ValueError, 'at vmap out_axes',
+        ValueError, "at vmap out_axes",
         lambda: api.vmap(
             f_non_jvp, in_axes=(0, None), out_axes=(0, None))(xs, tx))
 
@@ -10446,7 +10446,7 @@ class CustomVmapTest(jtu.JaxTestCase):
 
     # does err
     self.assertRaisesRegex(
-        ValueError, 'at vmap out_axes',
+        ValueError, "at vmap out_axes",
         lambda: api.vmap(
             f_jvp, in_axes=(None, 0), out_axes=(None, 0))(x, txs))
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3213,7 +3213,7 @@ class APITest(jtu.JaxTestCase):
 
     with self.assertRaisesRegex(
         ValueError,
-        "vmap has mapped output but out_axes is None"):
+        "at vmap out_axes"):
       # If the output is mapped (unnamed axis), then there must be some out_axes
       # specified.
       api.vmap(lambda x: x, out_axes=None)(jnp.array([1., 2.]))
@@ -10407,7 +10407,7 @@ class CustomVmapTest(jtu.JaxTestCase):
 
     # does err
     self.assertRaisesRegex(
-        ValueError, 'vmap has mapped output but out_axes is None',
+        ValueError, 'at vmap out_axes',
         lambda: api.vmap(
             f_non_jvp, in_axes=(0, None), out_axes=(0, None))(xs, tx))
 
@@ -10446,7 +10446,7 @@ class CustomVmapTest(jtu.JaxTestCase):
 
     # does err
     self.assertRaisesRegex(
-        ValueError, 'vmap has mapped output but out_axes is None',
+        ValueError, 'at vmap out_axes',
         lambda: api.vmap(
             f_jvp, in_axes=(None, 0), out_axes=(None, 0))(x, txs))
 


### PR DESCRIPTION
## Changes

Shows the path of invalid leaves when trying to return vectorized arrays through outputs marked as `out_axes=None`.