### PR TITLE
DOC: Fix the Args of `jax.scipy.special.beta` documentation

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -199,8 +199,8 @@ def beta(x: ArrayLike, y: ArrayLike) -> Array:
   where :math:`\Gamma` is the :func:`~jax.scipy.special.gamma` function.
 
   Args:
-    a: arraylike, real-valued. Parameter *a* of the beta distribution.
-    b: arraylike, real-valued. Parameter *b* of the beta distribution.
+    x: arraylike, real-valued. Parameter *a* of the beta distribution.
+    y: arraylike, real-valued. Parameter *b* of the beta distribution.
 
   Returns:
     array containing the values of the beta function.


### PR DESCRIPTION
`jax.scipy.special.beta` documentation shows that 4 parameters, `a`, `b`, `x`, and ,`y`. 

<img width="815" alt="image" src="https://github.com/google/jax/assets/153593711/1abcf1b8-a77c-4467-82af-7e7e4f131835">

However it has only 2 arguments. This PR would fix it to:

<img width="815" alt="image" src="https://github.com/google/jax/assets/153593711/26f22163-760a-4052-9c94-10b73e0efbbf">

