### PR TITLE
Pallas bitwise_left_shift unit test fix

### DIFF
--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -1222,7 +1222,11 @@ class PallasOpsTest(PallasTest):
       o_ref[...] = f(x_ref[...], y_ref[...])
 
     x = jnp.array([1, 3, -4, -6, 2, 5, 4, -7]).astype(dtype)
-    y = jnp.array([3, 1, -4, -5, 2, -2, 2, 4]).astype(dtype)
+    if f is jnp.bitwise_left_shift:
+      y = jnp.array([3, 1, 4, 5, 2, 2, 2, 4]).astype(dtype)
+    else:
+      y = jnp.array([3, 1, -4, -5, 2, -2, 2, 4]).astype(dtype)
+
     np.testing.assert_allclose(f(x, y), kernel(x, y))
 
   @parameterized.parameters(


### PR DESCRIPTION
As per the spec, the bitwise_left_shift x2 array must be non-negative, but in the unit test it is not.
https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.bitwise_left_shift.html#jax.numpy.bitwise_left_shift