### PR TITLE
doc: don't use typehints for signatures.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -294,7 +294,11 @@ epub_exclude_files = ['search.html']
 # -- Extension configuration -------------------------------------------------
 
 # Tell sphinx autodoc how to render type aliases.
-autodoc_typehints = "description"
+
+# type aliases are not respected in overloaded function signatures, which leads to
+# hard to read docs. Until this is improved, we'll disable typehints
+# (https://github.com/google/jax/pull/21797).
+autodoc_typehints = "none"
 autodoc_typehints_description_target = "all"
 autodoc_type_aliases = {
     'ArrayLike': 'jax.typing.ArrayLike',


### PR DESCRIPTION
The reason to avoid this is that overloaded signatures can be very confusing.

This is the current documentation page for `jax.numpy.where`:
<img width="600" alt="screenshot-2" src="https://github.com/google/jax/assets/781659/91ba6fb2-cee0-485f-9cd8-50adbeb25663">

This is the same page built with this PR:
<img width="600" alt="screenshot-1" src="https://github.com/google/jax/assets/781659/2754cf78-cb8a-444b-a973-27cb8f98ca9e">

The downside is that for non-overloaded functions, this change causes type annotations to not be inserted into parameter descriptions. For example this is the current documentation page for `jax.scipy.linalg.inv`:
<img width="600" alt="screenshot-4" src="https://github.com/google/jax/assets/781659/e6935839-27ce-4be2-84e1-c9db6b257f7c">

And this is the same page built with this PR:
<img width="600" alt="screenshot-3" src="https://github.com/google/jax/assets/781659/dd8b72dc-81d0-47a9-a9c2-448878ea337b">

I think the benefit in the case of `jnp.where` and other overloaded functions far outweighs the loss of annotations in other cases.
