### PR TITLE
Add a flag to disable the checking of debug_info in ``jax.core.Jaxpr``

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -83,6 +83,7 @@ class JaxprDebugInfo(NamedTuple):
   result_paths: tuple[str, ...]  # e.g. ('[0]', '[1]', ...)
 
 class Jaxpr:
+  _check_debug_info: bool = True
   __slots__ = ['__weakref__', '_constvars', '_invars', '_outvars', '_eqns',
                '_effects', '_debug_info']
 
@@ -139,8 +140,9 @@ class Jaxpr:
     self._eqns = list(eqns)
     self._effects = effects
     self._debug_info = debug_info
-    assert (not debug_info or len(debug_info.arg_names) == len(invars) and
-            len(debug_info.result_paths) == len(outvars))
+    if self._check_debug_info:
+      assert (not debug_info or len(debug_info.arg_names) == len(invars) and
+              len(debug_info.result_paths) == len(outvars))
 
   def __str__(self):
     return str(self.pretty_print())


### PR DESCRIPTION
Adding a flag to disable Jaxpr debug_info checking.

In the new release of ``jax==0.4.29``, the ``make_jaxpr()`` function is crashed in [``brainstate``](https://github.com/brainpy/brainstate). This is because the arguments to JIT-compiled are dynamically added in ``brainstate``, leading to the length of ``debug_info.arg_names`` (which are given by the functional inputs) is not equal to ``len(invars)``. 

Therefore, I added a flag to disable the debug_info checking when customizing the ``make_jaxpr()`` function. This will provide flexibility for the development of downstream packages. Thanks!
