### PR TITLE
[export] Cleaned up types of [in|out]_shardings

### DIFF
--- a/jax/_src/export/serialization.fbs
+++ b/jax/_src/export/serialization.fbs
@@ -38,7 +38,7 @@ table PyTreeDef {
 
 enum AbstractValueKind: byte {
   shapedArray = 0,
-  abstractToken = 1,
+  abstractToken = 1,  // unused
 }
 
 enum DType: byte {

--- a/jax/_src/export/serialization.py
+++ b/jax/_src/export/serialization.py
@@ -331,28 +331,24 @@ _dtype_kind_to_dtype = {
 
 
 def _serialize_aval(
-    builder: flatbuffers.Builder, aval: core.AbstractValue
+    builder: flatbuffers.Builder, aval: core.ShapedArray
 ) -> int:
-  aval_type = type(aval)
-  if aval_type is core.ShapedArray:
-    aval_kind = ser_flatbuf.AbstractValueKind.shapedArray
-    shape_offsets = [builder.CreateString(str(d)) for d in aval.shape]
-    ser_flatbuf.AbstractValueStartShapeVector(builder, len(aval.shape))
-    for d in reversed(shape_offsets):
-      builder.PrependUOffsetTRelative(d)
-    shape_vector_offset = builder.EndVector()
+  aval_kind = ser_flatbuf.AbstractValueKind.shapedArray
+  shape_offsets = [builder.CreateString(str(d)) for d in aval.shape]
+  ser_flatbuf.AbstractValueStartShapeVector(builder, len(aval.shape))
+  for d in reversed(shape_offsets):
+    builder.PrependUOffsetTRelative(d)
+  shape_vector_offset = builder.EndVector()
 
-    ser_flatbuf.AbstractValueStart(builder)
-    ser_flatbuf.AbstractValueAddKind(builder, aval_kind)
-    ser_flatbuf.AbstractValueAddShape(builder, shape_vector_offset)
-    ser_flatbuf.AbstractValueAddDtype(builder, _dtype_to_dtype_kind[aval.dtype])
-    return ser_flatbuf.AbstractValueEnd(builder)
-  else:
-    raise NotImplementedError(f"serializing AbstractValue: {aval}")
+  ser_flatbuf.AbstractValueStart(builder)
+  ser_flatbuf.AbstractValueAddKind(builder, aval_kind)
+  ser_flatbuf.AbstractValueAddShape(builder, shape_vector_offset)
+  ser_flatbuf.AbstractValueAddDtype(builder, _dtype_to_dtype_kind[aval.dtype])
+  return ser_flatbuf.AbstractValueEnd(builder)
 
 
 def _deserialize_aval(aval: ser_flatbuf.AbstractValue,
-                      scope) -> core.AbstractValue:
+                      scope) -> core.ShapedArray:
   aval_kind = aval.Kind()
   if aval_kind == ser_flatbuf.AbstractValueKind.shapedArray:
     dtype = _dtype_kind_to_dtype[aval.Dtype()]

--- a/jax/_src/export/shape_poly.py
+++ b/jax/_src/export/shape_poly.py
@@ -1717,10 +1717,10 @@ def _dimension_size_lowering_rule(ctx, arg, *, dimension):
 mlir.register_lowering(dimension_size_p, _dimension_size_lowering_rule)
 
 
-def all_dim_vars(args_avals: Sequence[core.AbstractValue]) -> Sequence[str]:
+def all_dim_vars(args_avals: Sequence[core.ShapedArray]) -> Sequence[str]:
   dim_vars: set[str] = set()
   for a in args_avals:
-    for d in a.shape:  # type: ignore[attribute-error,unused-ignore]
+    for d in a.shape:
       if is_symbolic_dim(d):
         dim_vars = dim_vars.union(d._get_vars())
   return sorted(dim_vars)
@@ -1911,7 +1911,7 @@ def pretty_print_dimension_descriptor(
 
 @util.cache()
 def solve_dim_vars(
-    args_avals: Sequence[core.AbstractValue],
+    args_avals: Sequence[core.ShapedArray],
     args_kwargs_tree: tree_util.PyTreeDef,
     ) -> tuple[DimVarEnv, ShapeConstraints, Sequence[tuple[str, int, int]]]:
   """Solves dimension variables in a called function's avals in terms of actual argument shapes.
@@ -1956,12 +1956,12 @@ def solve_dim_vars(
   # tuples with argument name and its polymorphic shape ('args[0]', '(a, a + b'))
   polymorphic_shape_specs: list[tuple[str, str]] = []
   for arg_idx, aval in enumerate(args_avals):
-    if all(not is_symbolic_dim(d) for d in aval.shape):  # type: ignore[attribute-error,unused-ignore]
+    if all(not is_symbolic_dim(d) for d in aval.shape):
       continue
     polymorphic_shape_specs.append(
       (pretty_print_dimension_descriptor(args_kwargs_tree, arg_idx, None),
-       str(aval.shape)))  # type: ignore[attribute-error,unused-ignore]
-    for dim_idx, aval_d in enumerate(aval.shape):  # type: ignore[attribute-error,unused-ignore]
+       str(aval.shape)))
+    for dim_idx, aval_d in enumerate(aval.shape):
       if is_symbolic_dim(aval_d):
         synth_dim_var = pretty_print_dimension_descriptor(args_kwargs_tree,
                                                           arg_idx, dim_idx)
@@ -1976,7 +1976,7 @@ def solve_dim_vars(
 
 
 def compute_dim_vars_from_arg_shapes(
-    args_avals: Sequence[core.AbstractValue],
+    args_avals: Sequence[core.ShapedArray],
     *actual_args: jax.Array,
     args_kwargs_tree: tree_util.PyTreeDef) -> Sequence[jax.Array]:
   """Computes values of dimension variables to unify args_avals with actual arguments.

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -1489,10 +1489,10 @@ class JaxExportTest(jtu.JaxTestCase):
       self.assertAllClose(2. * 2. * x + 10. + 4. * 2. * x, res)
 
   @jtu.parameterized_filterable(
-    kwargs=[
-      dict(v=v)
-      for v in range(export.minimum_supported_serialization_version,
-                     export.maximum_supported_serialization_version + 1)])
+      kwargs=[
+          dict(v=v)
+          for v in range(export.minimum_supported_serialization_version,
+                         export.maximum_supported_serialization_version + 1)])
   def test_ordered_effects_poly(self, *, v: int):
     with config.jax_serialization_version(v):
       logging.info(


### PR DESCRIPTION
Previously we declared Exported.in_shardings to be a sequence of `core.AbstractValue`, but in reality we only support `core.ShapedArray`. We change the type declaration and this allowed us to clean up some `# type: ignore"