### PR TITLE
prune cond passthrough outputs

### DIFF
--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2930,15 +2930,29 @@ class LaxControlFlowTest(jtu.JaxTestCase):
 
   def test_cond_vmap_forwarding_doesnt_promote(self):
     def f(x, y):
-      x, y = jax.lax.cond(x < 3,
-                          lambda x, y: (x * 2, y),
-                          lambda x, y: (x * 3, y),
-                          x, y)
+      x, y = jax.lax.cond(
+          x < 3,
+          lambda x, y: (x * 2, y),
+          lambda x, y: (x * 3, y),
+          x, y
+      )
       return x, y
 
-    jax.vmap(f, in_axes=(0, None), out_axes=(0, None)
-             )(jnp.arange(3), 3.)  # don't crash
+    x = jnp.arange(3)
+    y = jnp.array(3.)
 
+    x2, y2 = jax.vmap(f, in_axes=(0, None), out_axes=(0, None))(x, y)  # don't crash
+
+    assert x is not x2
+    assert y is y2
+
+  def test_cond_casting(self):
+    x = 1.0
+    identity = lambda x: x
+
+    y = lax.cond(True, identity, identity, x)
+    self.assertEqual(y, x)
+    self.assertIsInstance(y, jax.Array)
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2928,6 +2928,17 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     hlo_text = fn.lower(init).as_text('hlo')
     self.assertNotIn('4,1,2,2', hlo_text)
 
+  def test_cond_vmap_forwarding_doesnt_promote(self):
+    def f(x, y):
+      x, y = jax.lax.cond(x < 3,
+                          lambda x, y: (x * 2, y),
+                          lambda x, y: (x * 3, y),
+                          x, y)
+      return x, y
+
+    jax.vmap(f, in_axes=(0, None), out_axes=(0, None)
+             )(jnp.arange(3), 3.)  # don't crash
+
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
## Changes

Prunes outputs from the true and false jaxprs of `cond` if they are direct inputs on both branches, pruned outputs are then added back to the output of `cond`. This solves some issue related to composing `vmap` of `cond` over broadcasted values which get unintentionally vectorized.