### PR TITLE
Removed BlockSpec.__init__

### DIFF
--- a/jax/_src/pallas/core.py
+++ b/jax/_src/pallas/core.py
@@ -126,22 +126,12 @@ blocked = Blocked()
 IndexingMode = Union[Blocked, Unblocked]
 
 
-@dataclasses.dataclass(init=False, unsafe_hash=True)
+@dataclasses.dataclass(unsafe_hash=True)
 class BlockSpec:
-  index_map: Callable[..., Any] | None
-  block_shape: tuple[int | None, ...] | None
-  memory_space: Any
-  indexing_mode: IndexingMode
-
-  def __init__(self, index_map: Callable[..., Any] | None = None,
-               block_shape: tuple[int | None, ...] | None = None,
-               memory_space: Any = None, indexing_mode: IndexingMode = blocked):
-    self.index_map = index_map
-    if block_shape is not None and not isinstance(block_shape, tuple):
-      block_shape = tuple(block_shape)
-    self.block_shape = block_shape
-    self.memory_space = memory_space
-    self.indexing_mode = indexing_mode
+  index_map: Callable[..., Any] | None = None
+  block_shape: tuple[int | None, ...] | None = None
+  memory_space: Any | None = None
+  indexing_mode: IndexingMode = blocked
 
   def compute_index(self, *args):
     assert self.index_map is not None

--- a/jax/_src/pallas/mosaic/core.py
+++ b/jax/_src/pallas/mosaic/core.py
@@ -39,7 +39,6 @@ GridMapping = pallas_core.GridMapping
 NoBlockSpec = pallas_core.NoBlockSpec
 AbstractMemoryRef = pallas_core.AbstractMemoryRef
 no_block_spec = pallas_core.no_block_spec
-_preprocess_grid = pallas_core._preprocess_grid
 _convert_block_spec_to_block_mapping = pallas_core._convert_block_spec_to_block_mapping
 split_list = util.split_list
 


### PR DESCRIPTION
We can use the default __init__ generated by the dataclass machinery.