### PR TITLE
[export] Rename some API entry points

### DIFF
--- a/docs/jax.export.rst
+++ b/docs/jax.export.rst
@@ -20,9 +20,9 @@ Functions
 
   export
   deserialize
-  minimum_supported_serialization_version
-  maximum_supported_serialization_version
-  default_lowering_platform
+  minimum_supported_calling_convention_version
+  maximum_supported_calling_convention_version
+  default_export_platform
 
 Functions related to shape polymorphism
 ---------------------------------------
@@ -40,8 +40,8 @@ Constants
 
 .. data:: jax.export.minimum_supported_serialization_version
 
-   The minimum supported serialization version; see :ref:`export-serialization-version`.
+   The minimum supported serialization version; see :ref:`export-calling-convention-version`.
 
 .. data:: jax.export.maximum_supported_serialization_version
 
-   The maximum supported serialization version; see :ref:`export-serialization-version`.
+   The maximum supported serialization version; see :ref:`export-calling-convention-version`.

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -912,13 +912,21 @@ jax2tf_default_native_serialization = define_bool_state(
 
 jax_serialization_version = define_int_state(
     name='jax_serialization_version',
-    # Note: bump the default serialization version at least one month after
+    default=int_env('JAX_SERIALIZATION_VERSION', 0),  # We use 0 to detect default.
+    help=(
+        'DEPRECATED: use jax_export_calling_convention_version.'
+    )
+)
+
+jax_export_calling_convention_version = define_int_state(
+    name='jax_export_calling_convention_version',
+    # Note: bump the default calling convention version at least one month after
     # we update XlaCallModule to support the new version, so that serialized
     # modules are forward compatible with deployed versions of XlaCallModule.
     # Version 9 of XlaCallModule is supported since October 27th, 2023.
-    default=int_env('JAX_SERIALIZATION_VERSION', 9),
+    default=int_env('JAX_EXPORT_CALLING_CONVENTION_VERSION', 9),
     help=(
-        'The version number to use for native serialization. This must be '
+        'The calling convention version number to use for exporting. This must be '
         'within the range of versions supported by the tf.XlaCallModule '
         'used in your deployment environment. '
         'See https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#native-serialization-versions.'

--- a/jax/_src/export/serialization.fbs
+++ b/jax/_src/export/serialization.fbs
@@ -119,16 +119,16 @@ table Exported {
   in_shardings: [Sharding];
   out_shardings: [Sharding];
 
-  lowering_platforms: [string];
+  platforms: [string];
 
   ordered_effects: [Effect];
   unordered_effects: [Effect];
   disabled_checks: [DisabledSafetyCheck];
 
   mlir_module_serialized: [byte];
-  mlir_module_serialization_version: uint16;
+  calling_convention_version: uint16;
   module_kept_var_idx: [uint16];
-  uses_shape_polymorphism: bool;
+  uses_global_constants: bool;
 
   vjp: Exported;
 }

--- a/jax/_src/export/serialization.py
+++ b/jax/_src/export/serialization.py
@@ -93,8 +93,8 @@ def _serialize_exported(
   disabled_safety_checks = _serialize_array(
       builder, _serialize_disabled_safety_check, exp.disabled_safety_checks
   )
-  lowering_platforms = _serialize_array(
-      builder, lambda b, p: b.CreateString(p), exp.lowering_platforms
+  platforms = _serialize_array(
+      builder, lambda b, p: b.CreateString(p), exp.platforms
   )
   mlir_module_serialized = builder.CreateByteVector(exp.mlir_module_serialized)
   module_kept_var_idx = builder.CreateNumpyVector(
@@ -121,17 +121,17 @@ def _serialize_exported(
   ser_flatbuf.ExportedAddNrDevices(builder, exp.nr_devices)
   ser_flatbuf.ExportedAddInShardings(builder, in_shardings)
   ser_flatbuf.ExportedAddOutShardings(builder, out_shardings)
-  ser_flatbuf.ExportedAddLoweringPlatforms(builder, lowering_platforms)
+  ser_flatbuf.ExportedAddPlatforms(builder, platforms)
   ser_flatbuf.ExportedAddOrderedEffects(builder, ordered_effects)
   ser_flatbuf.ExportedAddUnorderedEffects(builder, unordered_effects)
   ser_flatbuf.ExportedAddDisabledChecks(builder, disabled_safety_checks)
   ser_flatbuf.ExportedAddMlirModuleSerialized(builder, mlir_module_serialized)
-  ser_flatbuf.ExportedAddMlirModuleSerializationVersion(
-      builder, exp.mlir_module_serialization_version
+  ser_flatbuf.ExportedAddCallingConventionVersion(
+      builder, exp.calling_convention_version
   )
   ser_flatbuf.ExportedAddModuleKeptVarIdx(builder, module_kept_var_idx)
-  ser_flatbuf.ExportedAddUsesShapePolymorphism(
-      builder, exp.uses_shape_polymorphism
+  ser_flatbuf.ExportedAddUsesGlobalConstants(
+      builder, exp.uses_global_constants
   )
   if vjp is not None:
     ser_flatbuf.ExportedAddVjp(builder, vjp)
@@ -179,9 +179,9 @@ def _deserialize_exported(exp: ser_flatbuf.Exported) -> _export.Exported:
   out_shardings = _deserialize_tuple(
       exp.OutShardingsLength, exp.OutShardings, _deserialize_sharding
   )
-  lowering_platforms = _deserialize_tuple(
-      exp.LoweringPlatformsLength,
-      exp.LoweringPlatforms,
+  platforms = _deserialize_tuple(
+      exp.PlatformsLength,
+      exp.Platforms,
       lambda v: v.decode("utf-8"),
   )
   ordered_effects = _deserialize_tuple(
@@ -197,9 +197,9 @@ def _deserialize_exported(exp: ser_flatbuf.Exported) -> _export.Exported:
   )
 
   mlir_module_serialized = exp.MlirModuleSerializedAsNumpy().tobytes()
-  mlir_module_serialization_version = exp.MlirModuleSerializationVersion()
+  calling_convention_version = exp.CallingConventionVersion()
   module_kept_var_idx = tuple(exp.ModuleKeptVarIdxAsNumpy().tolist())
-  uses_shape_polymorphism = exp.UsesShapePolymorphism()
+  uses_global_constants = exp.UsesGlobalConstants()
 
   _get_vjp = None
   if vjp := exp.Vjp():
@@ -214,14 +214,14 @@ def _deserialize_exported(exp: ser_flatbuf.Exported) -> _export.Exported:
       nr_devices=nr_devices,
       in_shardings_hlo=in_shardings,
       out_shardings_hlo=out_shardings,
-      lowering_platforms=lowering_platforms,
+      platforms=platforms,
       ordered_effects=ordered_effects,
       unordered_effects=unordered_effects,
       disabled_safety_checks=disabled_safety_checks,
       mlir_module_serialized=mlir_module_serialized,
-      mlir_module_serialization_version=mlir_module_serialization_version,
+      calling_convention_version=calling_convention_version,
       module_kept_var_idx=module_kept_var_idx,
-      uses_shape_polymorphism=uses_shape_polymorphism,
+      uses_global_constants=uses_global_constants,
       _get_vjp=_get_vjp,
   )
 

--- a/jax/_src/export/serialization_generated.py
+++ b/jax/_src/export/serialization_generated.py
@@ -547,7 +547,7 @@ class Exported(object):
         return o == 0
 
     # Exported
-    def LoweringPlatforms(self, j):
+    def Platforms(self, j):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(22))
         if o != 0:
             a = self._tab.Vector(o)
@@ -555,14 +555,14 @@ class Exported(object):
         return ""
 
     # Exported
-    def LoweringPlatformsLength(self):
+    def PlatformsLength(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(22))
         if o != 0:
             return self._tab.VectorLen(o)
         return 0
 
     # Exported
-    def LoweringPlatformsIsNone(self):
+    def PlatformsIsNone(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(22))
         return o == 0
 
@@ -666,7 +666,7 @@ class Exported(object):
         return o == 0
 
     # Exported
-    def MlirModuleSerializationVersion(self):
+    def CallingConventionVersion(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(32))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Uint16Flags, o + self._tab.Pos)
@@ -700,7 +700,7 @@ class Exported(object):
         return o == 0
 
     # Exported
-    def UsesShapePolymorphism(self):
+    def UsesGlobalConstants(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(36))
         if o != 0:
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
@@ -758,10 +758,10 @@ def ExportedAddOutShardings(builder, outShardings):
 def ExportedStartOutShardingsVector(builder, numElems):
     return builder.StartVector(4, numElems, 4)
 
-def ExportedAddLoweringPlatforms(builder, loweringPlatforms):
-    builder.PrependUOffsetTRelativeSlot(9, flatbuffers.number_types.UOffsetTFlags.py_type(loweringPlatforms), 0)
+def ExportedAddPlatforms(builder, platforms):
+    builder.PrependUOffsetTRelativeSlot(9, flatbuffers.number_types.UOffsetTFlags.py_type(platforms), 0)
 
-def ExportedStartLoweringPlatformsVector(builder, numElems):
+def ExportedStartPlatformsVector(builder, numElems):
     return builder.StartVector(4, numElems, 4)
 
 def ExportedAddOrderedEffects(builder, orderedEffects):
@@ -788,8 +788,8 @@ def ExportedAddMlirModuleSerialized(builder, mlirModuleSerialized):
 def ExportedStartMlirModuleSerializedVector(builder, numElems):
     return builder.StartVector(1, numElems, 1)
 
-def ExportedAddMlirModuleSerializationVersion(builder, mlirModuleSerializationVersion):
-    builder.PrependUint16Slot(14, mlirModuleSerializationVersion, 0)
+def ExportedAddCallingConventionVersion(builder, callingConventionVersion):
+    builder.PrependUint16Slot(14, callingConventionVersion, 0)
 
 def ExportedAddModuleKeptVarIdx(builder, moduleKeptVarIdx):
     builder.PrependUOffsetTRelativeSlot(15, flatbuffers.number_types.UOffsetTFlags.py_type(moduleKeptVarIdx), 0)
@@ -797,8 +797,8 @@ def ExportedAddModuleKeptVarIdx(builder, moduleKeptVarIdx):
 def ExportedStartModuleKeptVarIdxVector(builder, numElems):
     return builder.StartVector(2, numElems, 2)
 
-def ExportedAddUsesShapePolymorphism(builder, usesShapePolymorphism):
-    builder.PrependBoolSlot(16, usesShapePolymorphism, 0)
+def ExportedAddUsesGlobalConstants(builder, usesGlobalConstants):
+    builder.PrependBoolSlot(16, usesGlobalConstants, 0)
 
 def ExportedAddVjp(builder, vjp):
     builder.PrependUOffsetTRelativeSlot(17, flatbuffers.number_types.UOffsetTFlags.py_type(vjp), 0)

--- a/jax/_src/export/shape_poly.py
+++ b/jax/_src/export/shape_poly.py
@@ -1313,7 +1313,7 @@ dim_as_value_p.def_abstract_eval(lambda dim: core.dim_value_aval())
 def dim_as_value_impl(dim: DimSize):
   raise NotImplementedError(
       "Evaluation rule for 'dim_as_value' is not implemented. "
-      "It seems that you are using shape polymorphism outside jax2tf.")
+      "It seems that you are using shape polymorphism outside jax.export.")
 
 dim_as_value_p.def_impl(dim_as_value_impl)
 def _dim_as_value(dim: DimSize):

--- a/jax/_src/internal_test_util/export_back_compat_test_util.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_util.py
@@ -303,7 +303,7 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
 
     module_str = str(exported.mlir_module())
     serialized = exported.mlir_module_serialized
-    module_version = exported.mlir_module_serialization_version
+    module_version = exported.calling_convention_version
     nr_devices = exported.nr_devices
     return serialized, module_str, module_version, nr_devices
 
@@ -332,15 +332,15 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
         out_avals=tuple(out_avals),
         in_shardings_hlo=(None,) * len(in_avals),
         out_shardings_hlo=(None,) * len(out_avals),
-        lowering_platforms=(data.platform,),
+        platforms=(data.platform,),
         ordered_effects=(),
         unordered_effects=(),
         disabled_safety_checks=(),
         mlir_module_serialized=data.mlir_module_serialized,
-        mlir_module_serialization_version=data.xla_call_module_version,
+        calling_convention_version=data.xla_call_module_version,
         nr_devices=data.nr_devices,
         module_kept_var_idx=tuple(range(len(in_avals))),
-        uses_shape_polymorphism=any(not core.is_constant_shape(a.shape)
+        uses_global_constants=any(not core.is_constant_shape(a.shape)
                                     for a in in_avals),
       _get_vjp=_get_vjp)
 

--- a/jax/experimental/export/__init__.py
+++ b/jax/experimental/export/__init__.py
@@ -14,13 +14,13 @@
 # ==============================================================================
 
 from jax._src.export._export import (
-    minimum_supported_serialization_version,
-    maximum_supported_serialization_version,
-    Exported,
-    call_exported,  # TODO: deprecate
-    call,
-    DisabledSafetyCheck,
-    default_lowering_platform,  # TODO: deprecate
+  minimum_supported_calling_convention_version,
+  maximum_supported_calling_convention_version,
+  Exported,
+  call_exported,  # TODO: deprecate
+  call,
+  DisabledSafetyCheck,
+  default_lowering_platform,  # TODO: deprecate
 )
 from jax._src.export._export import export_back_compat as export
 

--- a/jax/experimental/jax2tf/tests/call_tf_test.py
+++ b/jax/experimental/jax2tf/tests/call_tf_test.py
@@ -1652,10 +1652,10 @@ class RoundTripToTfTest(tf_test_util.JaxToTfTestCase):
     kwargs=[dict(version=version) for version in [9]]
   )
   def test_call_tf_graph_ordered(self, *, version: int):
-    with config.jax_serialization_version(version):
+    with config.jax_export_calling_convention_version(version):
       logging.info(
         "Using JAX serialization version %s",
-        jax.config.jax_serialization_version)
+        jax.config.jax_export_calling_convention_version)
 
       @tf.function
       def tf_print(x):
@@ -1725,10 +1725,10 @@ class RoundTripToTfTest(tf_test_util.JaxToTfTestCase):
             for version in [9]]
   )
   def test_call_tf_ordered_dead_inputs(self, *, poly: bool, version: int):
-    with config.jax_serialization_version(version):
+    with config.jax_export_calling_convention_version(version):
       logging.info(
         "Using JAX serialization version %s",
-        jax.config.jax_serialization_version)
+        jax.config.jax_export_calling_convention_version)
       def f_jax(x1, x_dead, x3):
         return (x1, jax2tf.call_tf(lambda x: tf.math.sin(x), ordered=True,
                                   call_tf_graph=True)(x3))
@@ -1750,10 +1750,10 @@ class RoundTripToTfTest(tf_test_util.JaxToTfTestCase):
     ]
   )
   def test_call_tf_graph_polymorphic(self, ordered: bool, version: int):
-    with config.jax_serialization_version(version):
+    with config.jax_export_calling_convention_version(version):
       logging.info(
         "Using JAX serialization version %s",
-        jax.config.jax_serialization_version)
+        jax.config.jax_export_calling_convention_version)
 
       @tf.function(jit_compile=True, autograph=False)
       @partial(jax2tf.convert,

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -180,18 +180,18 @@ class JaxToTfTestCase(jtu.JaxTestCase):
     # We run the tests using the maximum version supported, even though
     # the default serialization version may be held back for a while to
     # ensure compatibility
-    version = config.jax_serialization_version.value
+    version = config.jax_export_calling_convention_version.value
     if self.use_max_serialization_version:
       # Use the largest supported by both export and tfxla.call_module
-      version = min(export.maximum_supported_serialization_version,
+      version = min(export.maximum_supported_calling_convention_version,
                     tfxla.call_module_maximum_supported_version())
       self.assertGreaterEqual(version,
-                              export.minimum_supported_serialization_version)
-      self.enter_context(config.jax_serialization_version(version))
+                              export.minimum_supported_calling_convention_version)
+      self.enter_context(config.jax_export_calling_convention_version(version))
     logging.info(
       "Using JAX serialization version %s (export.max_version %s, tf.XlaCallModule max version %s)",
       version,
-      export.maximum_supported_serialization_version,
+      export.maximum_supported_calling_convention_version,
       tfxla.call_module_maximum_supported_version())
 
     with contextlib.ExitStack() as stack:

--- a/jax/export.py
+++ b/jax/export.py
@@ -12,23 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 __all__ = ["DisabledSafetyCheck", "Exported", "export", "deserialize",
-           "maximum_supported_serialization_version",
-           "minimum_supported_serialization_version",
-           "default_lowering_platform",
+           "maximum_supported_calling_convention_version",
+           "minimum_supported_calling_convention_version",
+           "default_export_platform",
            "SymbolicScope", "is_symbolic_dim",
            "symbolic_shape", "symbolic_args_specs"]
 
-from jax._src.export._export import DisabledSafetyCheck as DisabledSafetyCheck
-from jax._src.export._export import Exported as Exported
-from jax._src.export._export import export as export
-from jax._src.export._export import deserialize as deserialize
-from jax._src.export._export import maximum_supported_serialization_version as maximum_supported_serialization_version
-from jax._src.export._export import minimum_supported_serialization_version as minimum_supported_serialization_version
-from jax._src.export._export import default_lowering_platform as default_lowering_platform
+from jax._src.export._export import (
+  DisabledSafetyCheck,
+  Exported,
+  export,
+  deserialize,
+  maximum_supported_calling_convention_version,
+  minimum_supported_calling_convention_version,
+  default_export_platform)
 
 from jax._src.export import shape_poly_decision  # Import only to set the decision procedure
 del shape_poly_decision
-from jax._src.export.shape_poly import SymbolicScope as SymbolicScope
-from jax._src.export.shape_poly import is_symbolic_dim as is_symbolic_dim
-from jax._src.export.shape_poly import symbolic_shape as symbolic_shape
-from jax._src.export.shape_poly import symbolic_args_specs as symbolic_args_specs
+from jax._src.export.shape_poly import (
+  SymbolicScope,
+  is_symbolic_dim,
+  symbolic_shape,
+  symbolic_args_specs)


### PR DESCRIPTION
We take the opportunity of a new jax.export package to rename some of the API entry points:

  * `Exported.uses_shape_polymorphism` is renamed to `Exported.uses_global_constants` because this is more accurate. The dimension variables are global constants, but so is the platform index. And we need to run global constant propagation and shape refinement for all of these.
  * We rename "serialization version" with "calling convention version". Hence we now have `Exported.calling_convention_version`, and the configuration flag is renamed from `--jax-serialization-version` to `--jax-export-calling-convention-version`. Also, `jax.export.minimum_supported_serialization_version` is now `jax.export.minimum_supported_calling_convention_version`.
   * We rename `lowering_platforms` to `platforms` both as a field of `Exported` and as the kwarg to `export.export`.
   * We rename `jax.export.default_lowering_platform` to `jax.export.default_export_version`.

I did not mark anything formally deprecated because:
* the `jax.export` package only landed yesterday
* the `jax.experimental.export` will be marked deprecated in its entirety very soon
