### PR TITLE
Temporarily reinstate the jax[cpu] in the install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Some standouts:
 
 | Hardware   | Instructions                                                                                                    |
 |------------|-----------------------------------------------------------------------------------------------------------------|
-| CPU        | `pip install -U jax`                                                                                            |
+| CPU        | `pip install -U jax[cpu]`                                                                                       |
 | NVIDIA GPU | `pip install -U "jax[cuda12]"`                                                                                  |
 | Google TPU | `pip install -U "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html`                 |
 | AMD GPU    | Use [Docker](https://hub.docker.com/r/rocm/jax) or [build from source](https://jax.readthedocs.io/en/latest/developer.html#additional-notes-for-building-a-rocm-jaxlib-for-amd-gpus). |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ different builds for different operating systems and accelerators.
 
 * **CPU-only (Linux/macOS/Windows)**
   ```
-  pip install -U jax
+  pip install -U jax[cpu]
   ```
 * **GPU (NVIDIA, CUDA 12)**
   ```
@@ -54,7 +54,7 @@ development on a laptop, you can run:
 
 ```bash
 pip install --upgrade pip
-pip install --upgrade jax
+pip install --upgrade jax[cpu]
 ```
 
 On Windows, you may also need to install the


### PR DESCRIPTION
This is still needed until the next release.