### PR TITLE
Fix build dependency in CUDA custom call example

### DIFF
--- a/docs/cuda_custom_call/BUILD
+++ b/docs/cuda_custom_call/BUILD
@@ -39,7 +39,7 @@ jax_test(
         "notap",
     ],
     deps = [
-        "//third_party/py/jax:extend",
+        "//jax:extend",
     ],
 )
 


### PR DESCRIPTION
This path was incorrectly introduced as part of merging #21645.