### PR TITLE
[export] Add an alternative jax.export.create API.

### DIFF
--- a/jax/_src/export/shape_poly.py
+++ b/jax/_src/export/shape_poly.py
@@ -1861,7 +1861,7 @@ class ShapeConstraints:
   def shape_assertions(self, eval: CachingShapeEvaluator) -> None:
     """Computes the shape assertions for the set of constraints.
 
-    See jax_export.Exported docstring.
+    See {class}`jax_export.Exported` docstring.
     """
     # We want to report the errors in the same order as `check_statically`.
     # So, we process them in order, in case some fail statically, and we

--- a/jax/_src/internal_test_util/export_back_compat_test_util.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_util.py
@@ -293,13 +293,13 @@ data_{datetime.date.today().strftime('%Y_%m_%d')} = dict(
     """
     # Use the native exporter, to make sure we get the proper serialization.
     args_specs = export.symbolic_args_specs(data.inputs, polymorphic_shapes)
-    exported = export.export(
-      jax.jit(func),
-      lowering_platforms=(self.default_jax_backend(),),
-      disabled_checks=tuple(
+    exported = export.create(
+      jax.jit(func), *args_specs,
+      export_platforms=(self.default_jax_backend(),),
+      export_disabled_checks=tuple(
         export.DisabledSafetyCheck.custom_call(target)
         for target in allow_unstable_custom_call_targets)
-    )(*args_specs)
+    )
 
     module_str = str(exported.mlir_module())
     serialized = exported.mlir_module_serialized

--- a/jax/experimental/jax2tf/tests/call_tf_test.py
+++ b/jax/experimental/jax2tf/tests/call_tf_test.py
@@ -778,8 +778,8 @@ class CallTfTest(tf_test_util.JaxToTfTestCase):
 
     lowering_platforms = ("tpu", "cpu", "cuda")
 
-    exp = export.export(jax.jit(f_jax),
-                        lowering_platforms=lowering_platforms)(x)
+    exp = export.create(jax.jit(f_jax), x,
+                        export_platforms=lowering_platforms)
     for jax_platform in jax_and_tf_platforms:
       with self.subTest(jax_platform):
         jax_device = jax.devices(jax_platform)[0]

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -1558,10 +1558,10 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
         stack.enter_context(mesh)
       # Run the JAX native version, to check it works, and to fill caches.
       _ = func_to_convert(*args)
-      exported = export.export(
+      exported = export.create(
           (jax.jit(func_to_convert) if not hasattr(func_to_convert, "trace") else func_to_convert),
-          lowering_platforms=("tpu",)
-      )(*(core.ShapedArray(a.shape, a.dtype) for a in args))
+          *(core.ShapedArray(a.shape, a.dtype) for a in args),
+          export_platforms=("tpu",))
 
     if transform1 == "shard_map":
       self.assertIn("stablehlo.all_gather", str(exported.mlir_module()))

--- a/jax/export.py
+++ b/jax/export.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 __all__ = ["DisabledSafetyCheck", "Exported", "export", "deserialize",
+           "create",
            "maximum_supported_calling_convention_version",
            "minimum_supported_calling_convention_version",
            "default_export_platform",
@@ -21,7 +22,7 @@ __all__ = ["DisabledSafetyCheck", "Exported", "export", "deserialize",
 from jax._src.export._export import (
   DisabledSafetyCheck,
   Exported,
-  export,
+  create,
   deserialize,
   maximum_supported_calling_convention_version,
   minimum_supported_calling_convention_version,
@@ -34,3 +35,24 @@ from jax._src.export.shape_poly import (
   is_symbolic_dim,
   symbolic_shape,
   symbolic_args_specs)
+
+# For backwards compatibility only
+def export(
+    fun_jit,
+    *,
+    platforms = None,
+    lowering_platforms = None,
+    disabled_checks = (),
+    ):
+  import warnings
+  warnings.warn("The function jax.export.export is deprecated. Use jax.export.create instead",
+                DeprecationWarning, stacklevel=2)
+  if platforms is not None and lowering_platforms is not None:
+    raise ValueError("Cannot use both `platforms` and `lowering_platforms`")
+  if platforms is None and lowering_platforms is not None:
+    platforms = lowering_platforms
+  def create_exported(*fun_args, **fun_kwargs):
+    return create(fun_jit, *fun_args, **fun_kwargs,
+                  export_platforms=platforms,
+                  export_disabled_checks=disabled_checks)
+  return create_exported

--- a/tests/export_harnesses_multi_platform_test.py
+++ b/tests/export_harnesses_multi_platform_test.py
@@ -152,8 +152,8 @@ class PrimitiveTest(jtu.JaxTestCase):
       )
 
     logging.info("Exporting harness for %s", lowering_platforms)
-    exp = export.export(jax.jit(func_jax),
-                        lowering_platforms=lowering_platforms)(*args)
+    exp = export.create(jax.jit(func_jax), *args,
+                        export_platforms=lowering_platforms)
 
     for device in devices:
       if device.platform in skip_run_on_platforms:


### PR DESCRIPTION
Following a suggestion from Tom Ward, I am proposing a streamlined API for exporting functions. Previously, one had to write:

```
exp: export.Exported = export.export(jax.jit(f))(*f_args, **f_kwargs)
```

Now we can write:
```
exp: export.Exported = export.create(jax.jit(f), *f_args, **f_kwargs)
```

The new name `export.create` helps in two ways: it avoids the mess of changing the semantics of `export.export`, even though `jax.export.export` was introduced only last week. And also `export.create` reads better than `export.export.

There is one downside: if we need to pass special options to exporting, then you need to write:

```
export.create(jax.jit(f), f_arg, export_platforms=..., export_disabled_checks=...)
```

This means that the exported function cannot use the reserved keyword arguments `export_platforms` and `export_disabled_checks`. We assume here that it is rare for exported JAX functions to have kwargs, and it is an acceptable compromise
to reserve these two keyword args for exporting. However, it will be harder to add new options for exporting.

I am not convinced reserving kwargs is a good idea. Proposing this for discussion.