### PR TITLE
Remove `[cpu]` extra from installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Some standouts:
 
 | Hardware   | Instructions                                                                                                    |
 |------------|-----------------------------------------------------------------------------------------------------------------|
-| CPU        | `pip install -U jax[cpu]`                                                                                       |
+| CPU        | `pip install -U jax`                                                                                            |
 | NVIDIA GPU | `pip install -U "jax[cuda12]"`                                                                                  |
 | Google TPU | `pip install -U "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html`                 |
 | AMD GPU    | Use [Docker](https://hub.docker.com/r/rocm/jax) or [build from source](https://jax.readthedocs.io/en/latest/developer.html#additional-notes-for-building-a-rocm-jaxlib-for-amd-gpus). |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ different builds for different operating systems and accelerators.
 
 * **CPU-only (Linux/macOS/Windows)**
   ```
-  pip install -U "jax[cpu]"
+  pip install -U jax
   ```
 * **GPU (NVIDIA, CUDA 12)**
   ```
@@ -54,7 +54,7 @@ development on a laptop, you can run:
 
 ```bash
 pip install --upgrade pip
-pip install --upgrade jax[cpu]
+pip install --upgrade jax
 ```
 
 On Windows, you may also need to install the


### PR DESCRIPTION
`pip install jax` should do the right thing by default now.