### PR TITLE
Update Windows Actions workflow name

### DIFF
--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -19,7 +19,7 @@ jobs:
         os: [windows-2019-32core]
         arch: [AMD64]
         pyver: ['3.9']
-    name: ${{ matrix.os }} CI build
+    name: Windows CI build
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
When skipped, the build matrix for the Windows workflow on GitHub Actions doesn't get populated, so the run name ends up as `${{ matrix.os }} CI build`. It doesn't seem necessary to include the matrix value in the name since there is only one build anyways. This PR replaces the name with a constant.

Before:

<img width="498" alt="Screenshot 2024-06-18 at 12 51 59 PM" src="https://github.com/google/jax/assets/350282/0c0307bb-9b61-4b0b-af48-7382118e032e">

After:

<img width="462" alt="Screenshot 2024-06-18 at 1 00 56 PM" src="https://github.com/google/jax/assets/350282/02a22a42-3951-460e-bdd0-5d5d29f322fb">