### PR TITLE
[export] Fix multi-platform lowering for unknown platform, with donated_argnums

### DIFF
--- a/jax/_src/export/_export.py
+++ b/jax/_src/export/_export.py
@@ -161,10 +161,10 @@ class Exported:
         the mesh. See `out_shardings_jax` for a way to turn these
         into sharding specification that can be used with JAX APIs.
     nr_devices: the number of devices that the module has been lowered for.
-    platforms: a tuple containing at least one of 'tpu', 'cpu',
-        'cuda', 'rocm'. See https://jax.readthedocs.io/en/latest/export.html#module-calling-convention
-        for the calling convention for when
-        there are multiple export platforms.
+    platforms: a tuple containing the platforms for which the function should
+        be exported. The set of platforms in JAX is open-ended; users can
+        add platforms. JAX built-in platforms are: 'tpu', 'cpu', 'cuda', 'rocm'.
+        See https://jax.readthedocs.io/en/latest/export/export.html#cross-platform-and-multi-platform-export.
     ordered_effects: the ordered effects present in the serialized module.
         This is present from serialization version 9. See https://jax.readthedocs.io/en/latest/export.html#module-calling-convention
         for the calling convention in presence of ordered effects.

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -886,7 +886,8 @@ def lower_jaxpr_to_module(
   platforms_with_donation = [p for p in platforms
                              if p in _platforms_with_donation]
   if platforms_with_donation:
-    if len(platforms_with_donation) != len(platforms):
+    if len(platforms_with_donation) != len(platforms) and (
+        xla_donated_args or any(donated_args)):
       raise NotImplementedError(
         "In multi-platform lowering either all or no lowering platforms "
         f"should support donation. Lowering for {platforms} of which "


### PR DESCRIPTION

I had to ensure that the check for platforms supporting donation only kicks in when we actually have donation.