### PR TITLE
Fix pbroadcast under shard_map.

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -982,9 +982,17 @@ def _pbroadcast_lowering(ctx, x, *, axis_name, source):
   def source_to_front(group):
     return [group[source]] + list(group[:source]) + list(group[source + 1:])
   replica_groups = [source_to_front(group) for group in replica_groups]
-  channel = ctx.module_context.new_channel()
+  axis_context = ctx.module_context.axis_context
+  is_manual = (
+      isinstance(axis_context, sharding_impls.SPMDAxisContext)
+      and axis_context.manual_axes
+  )
+  other_args = dict()
+  if is_manual:
+    channel = ctx.module_context.new_channel()
+    other_args['channel_handle'] = hlo.ChannelHandle.get(channel, mlir.DEVICE_TO_DEVICE_TYPE)
   return hlo.CollectiveBroadcastOp(
-      x, replica_groups=_replica_groups_hlo(replica_groups)).results
+      x, replica_groups=_replica_groups_hlo(replica_groups), **other_args).results
 
 pbroadcast_p = core.AxisPrimitive('pbroadcast')
 pbroadcast_p.def_abstract_eval(lambda x, **params: raise_to_shaped(x))

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -216,6 +216,36 @@ class ShardMapTest(jtu.JaxTestCase):
     for i, sums in enumerate(np.split(sum_of_odd_columns, 4, 0)):
       self.assertAllClose(np.squeeze(c.addressable_data(2 * i + 1), -1), sums)
 
+  def test_collective_broadcast(self):
+    devices = np.array(jax.devices()[:8]) # Take up to 8 devices
+    mesh = Mesh(devices, axis_names=('x'))
+    a = jax.device_put(
+        jnp.arange(8 * 8).reshape((8, 8)),
+        jax.sharding.NamedSharding(mesh, P('x', None)))
+    
+    # TODO: pbroadcast needs a replication rule. If that surprises you it's
+    # actually worse than that. There's two completely unrelated primitives
+    # called pbroadcast:
+    #  - one in jax.lax.parallel (this lowers the actual StableHLO
+    #    CollectiveBroadcast op),
+    #  - one in jax.experimental.shard_map (this is an implementation detail
+    #    of grad-of-shard_map and lowers to a no-op)
+    # The former is the one we're testing here. One of these should seriously
+    # be renamed.
+    
+    # For now we just use check_rep=False.
+
+    @jax.jit
+    @partial(
+        shard_map, mesh=mesh, in_specs=(P('x', None),), out_specs=P('x', None), check_rep=False
+    )
+    def fwd(a):
+      return lax.pbroadcast(a, axis_name='x', source=0)
+
+    c = fwd(a)
+    self.assertEqual(c.shape, a.shape)
+    self.assertAllClose(c, jnp.broadcast_to(a[0], c.shape))
+
   def test_collective_permute(self):
     devices = np.array(jax.devices()[:8]) # Take up to 8 devices
     mesh = Mesh(devices, axis_names=('x'))


### PR DESCRIPTION
Added the same channel handle logic from ppermute. This fixes the pmap unit tests that were broken in
https://github.com/google/jax/pull/20705.  I also added a unit test for pbroadcast in shard_map_test.py. This should also fix https://github.com/openxla/xla/issues/10992.

Something not fixed here, which is probably a huge problem, is that there's also a completely unrelated 'pbroadcast' primitive in shard_map.py that's used as part of the implementation of shard_map transposition. I'm not sure if having identically named primitives like this actually causes correctness issues, but it sure is confusing.