### PR TITLE
Fix the behavior of `jax.scipy.stats.sem` when `keepdims=True`.

### DIFF
--- a/jax/_src/scipy/stats/_core.py
+++ b/jax/_src/scipy/stats/_core.py
@@ -203,13 +203,11 @@ def sem(a: ArrayLike, axis: int | None = 0, ddof: int = 1, nan_policy: str = "pr
     array
   """
   b, = promote_args_inexact("sem", a)
-  if axis is None:
-    b = b.ravel()
-    axis = 0
   if nan_policy == "propagate":
-    return b.std(axis, ddof=ddof) / jnp.sqrt(b.shape[axis]).astype(b.dtype)
+    size = b.size if axis is None else b.shape[axis]
+    return b.std(axis, ddof=ddof, keepdims=keepdims) / jnp.sqrt(size).astype(b.dtype)
   elif nan_policy == "omit":
-    count = (~jnp.isnan(b)).sum(axis)
-    return jnp.nanstd(b, axis, ddof=ddof) / jnp.sqrt(count).astype(b.dtype)
+    count = (~jnp.isnan(b)).sum(axis, keepdims=keepdims)
+    return jnp.nanstd(b, axis, ddof=ddof, keepdims=keepdims) / jnp.sqrt(count).astype(b.dtype)
   else:
     raise ValueError(f"{nan_policy} is not supported")


### PR DESCRIPTION
`jax.scipy.stats.sem` does not follow the behavior of `scipy.stats.sem` when`keepdims=True`. This PR fixes this.

Current behavior:
```python
>>> import jax, scipy
>>> 
>>> x = jnp.array([[1, 2, 3],
...                [4, 5, 6],
...                [7, 8, 9]])
>>> scipy.stats.sem(x, axis=1, keepdims=True)
array([[0.57735027],
       [0.57735027],
       [0.57735027]])
>>> jax.scipy.stats.sem(x, axis=1, keepdims=True)
Array([0.57735026, 0.57735026, 0.57735026], dtype=float32)
```
With this PR:
```python
>>> jax.scipy.stats.sem(x, axis=1, keepdims=True)
Array([[0.57735026],
       [0.57735026],
       [0.57735026]], dtype=float32)
```