### PR TITLE
Rename "Example" to "Examples" in docstrings.

### DIFF
--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -653,7 +653,7 @@ def make_array_from_callback(
   Returns:
     A ``jax.Array`` via data fetched from ``data_callback``.
 
-  Example:
+  Examples:
 
     >>> import math
     >>> from jax.sharding import Mesh

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -119,7 +119,9 @@ class Config:
     registers an absl boolean flag, with the same name.
 
     This is the recommended method to call if you use `app.run(main)` and you
-    need JAX flags.  Example:
+    need JAX flags.
+
+    Examples:
 
     ```python
     from absl import app
@@ -370,7 +372,7 @@ def bool_state(
   Returns:
     A contextmanager to control the thread-local state value.
 
-  Example:
+  Examples:
 
     ENABLE_FOO = config.bool_state(
         name='jax_enable_foo',

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -180,7 +180,7 @@ class custom_jvp(Generic[ReturnValue]):
     Returns:
       None.
 
-    Example::
+    Examples:
 
       @jax.custom_jvp
       def f(x, y):
@@ -212,7 +212,7 @@ class custom_jvp(Generic[ReturnValue]):
     Returns:
       None.
 
-    Example::
+    Examples:
 
       @jax.custom_jvp
       def f(x, y):
@@ -567,7 +567,7 @@ class custom_vjp(Generic[ReturnValue]):
     Returns:
       None.
 
-    Example::
+    Examples:
 
       @jax.custom_vjp
       def f(x, y):

--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -179,7 +179,7 @@ def initialize(coordinator_address: str | None = None,
     RuntimeError: If :func:`~jax.distributed.initialize` is called more than once
       or if called after the backend is already initialized.
 
-  Example:
+  Examples:
 
   Suppose there are two GPU processes, and process 0 is the designated coordinator
   with address ``10.0.0.1:1234``. To initialize the GPU cluster, run the

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1241,7 +1241,7 @@ def top_k(operand: ArrayLike, k: int) -> tuple[Array, Array]:
     - :func:`jax.lax.approx_max_k`
     - :func:`jax.lax.approx_min_k`
 
-  Example:
+  Examples:
     Find the largest three values, and their indices, within an array:
 
     >>> x = jnp.array([9., 3., 6., 4., 10.])

--- a/jax/_src/maps.py
+++ b/jax/_src/maps.py
@@ -116,7 +116,7 @@ class SerialLoop:
   jointly over chunks of multiple axes (with the usual requirement that they
   do not coincide in a named shape of any value in the program).
 
-  Example::
+  Examples:
 
       # Processes `x` in a vectorized way, but in 20 micro-batches.
       xmap(f, in_axes=['i'], out_axes=[i], axis_resources={'i': SerialLoop(20)})(x)
@@ -161,7 +161,7 @@ def serial_loop(name: ResourceAxisName, length: int):
     name: Name of the loop in the resource environment.
     length: Number of iterations.
 
-  Example::
+  Examples:
 
     >>> x = jnp.linspace(0, jnp.pi, 4)
     ...

--- a/jax/_src/mesh.py
+++ b/jax/_src/mesh.py
@@ -144,7 +144,7 @@ class Mesh(contextlib.ContextDecorator):
       dimensions of the ``devices`` argument. Its length should match the
       rank of ``devices``.
 
-  Example:
+  Examples:
 
     >>> from jax.experimental.pjit import pjit
     >>> from jax.sharding import Mesh

--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -69,7 +69,7 @@ def relu(x: ArrayLike) -> Array:
   Returns:
     An array.
 
-  Example:
+  Examples:
     >>> jax.nn.relu(jax.numpy.array([-2., -1., -0.5, 0, 0.5, 1., 2.]))
     Array([0. , 0. , 0. , 0. , 0.5, 1. , 2. ], dtype=float32)
 

--- a/jax/_src/nn/initializers.py
+++ b/jax/_src/nn/initializers.py
@@ -372,7 +372,7 @@ def glorot_uniform(in_axis: int | Sequence[int] = -2,
   Returns:
     An initializer.
 
-  Example:
+  Examples:
 
   >>> import jax, jax.numpy as jnp
   >>> initializer = jax.nn.initializers.glorot_uniform()
@@ -410,7 +410,7 @@ def glorot_normal(in_axis: int | Sequence[int] = -2,
   Returns:
     An initializer.
 
-  Example:
+  Examples:
 
   >>> import jax, jax.numpy as jnp
   >>> initializer = jax.nn.initializers.glorot_normal()
@@ -448,7 +448,7 @@ def lecun_uniform(in_axis: int | Sequence[int] = -2,
   Returns:
     An initializer.
 
-  Example:
+  Examples:
 
   >>> import jax, jax.numpy as jnp
   >>> initializer = jax.nn.initializers.lecun_uniform()
@@ -484,7 +484,7 @@ def lecun_normal(in_axis: int | Sequence[int] = -2,
   Returns:
     An initializer.
 
-  Example:
+  Examples:
 
   >>> import jax, jax.numpy as jnp
   >>> initializer = jax.nn.initializers.lecun_normal()
@@ -520,7 +520,7 @@ def he_uniform(in_axis: int | Sequence[int] = -2,
   Returns:
     An initializer.
 
-  Example:
+  Examples:
 
   >>> import jax, jax.numpy as jnp
   >>> initializer = jax.nn.initializers.he_uniform()
@@ -558,7 +558,7 @@ def he_normal(in_axis: int | Sequence[int] = -2,
   Returns:
     An initializer.
 
-  Example:
+  Examples:
 
   >>> import jax, jax.numpy as jnp
   >>> initializer = jax.nn.initializers.he_normal()
@@ -591,7 +591,7 @@ def orthogonal(scale: RealNumeric = 1.0,
   Returns:
     An orthogonal initializer.
 
-  Example:
+  Examples:
 
   >>> import jax, jax.numpy as jnp
   >>> initializer = jax.nn.initializers.orthogonal()
@@ -634,7 +634,7 @@ def delta_orthogonal(
     A `delta orthogonal initializer`_. The shape passed to the initializer must
     be 3D, 4D, or 5D.
 
-  Example:
+  Examples:
 
   >>> import jax, jax.numpy as jnp
   >>> initializer = jax.nn.initializers.delta_orthogonal()

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -872,7 +872,7 @@ def flip(m: ArrayLike, axis: int | Sequence[int] | None = None) -> Array:
     - :func:`jax.numpy.fliplr`: reverse the order along axis 1 (left/right)
     - :func:`jax.numpy.flipud`: reverse the order along axis 0 (up/down)
 
-  Example:
+  Examples:
     >>> x1 = jnp.array([[1, 2],
     ...                 [3, 4]])
     >>> jnp.flip(x1)
@@ -936,7 +936,7 @@ def fliplr(m: ArrayLike) -> Array:
     - :func:`jax.numpy.flip`: reverse the order along the given axis
     - :func:`jax.numpy.flipud`: reverse the order along axis 0
 
-  Example:
+  Examples:
     >>> x = jnp.array([[1, 2],
     ...                [3, 4]])
     >>> jnp.fliplr(x)
@@ -962,7 +962,7 @@ def flipud(m: ArrayLike) -> Array:
     - :func:`jax.numpy.flip`: reverse the order along the given axis
     - :func:`jax.numpy.fliplr`: reverse the order along axis 1
 
-  Example:
+  Examples:
     >>> x = jnp.array([[1, 2],
     ...                [3, 4]])
     >>> jnp.flipud(x)
@@ -1000,7 +1000,7 @@ def angle(z: ArrayLike, deg: bool = False) -> Array:
     An array of counterclockwise angle of each element of ``z``, with the same
     shape as ``z`` of dtype float.
 
-  Example:
+  Examples:
 
     If ``z`` is a number
 
@@ -1337,7 +1337,7 @@ def ravel_multi_index(multi_index: Sequence[ArrayLike], dims: Sequence[int],
   See also:
     :func:`jax.numpy.unravel_index`: inverse of this function.
 
-  Example:
+  Examples:
     Define a 2-dimensional array and a sequence of indices of even values:
 
     >>> x = jnp.array([[2., 3., 4.],
@@ -3804,7 +3804,7 @@ def ix_(*args: ArrayLike) -> tuple[Array, ...]:
     - :obj:`jax.numpy.mgrid`
     - :func:`jax.numpy.meshgrid`
 
-  Example:
+  Examples:
     >>> rows = jnp.array([0, 2])
     >>> cols = jnp.array([1, 3])
     >>> open_mesh = jnp.ix_(rows, cols)
@@ -5240,7 +5240,7 @@ def einsum_path(
     A tuple containing the path that may be passed to :func:`~jax.numpy.einsum`, and a
     printable object representing this optimal path.
 
-  Example:
+  Examples:
     >>> key1, key2, key3 = jax.random.split(jax.random.key(0), 3)
     >>> x = jax.random.randint(key1, minval=-5, maxval=5, shape=(2, 3))
     >>> y = jax.random.randint(key2, minval=-5, maxval=5, shape=(3, 100))
@@ -6178,7 +6178,7 @@ def take(
     - :attr:`jax.numpy.ndarray.at`: take values via indexing syntax.
     - :func:`jax.numpy.take_along_axis`: take values along an axis
 
-  Example:
+  Examples:
     >>> x = jnp.array([[1., 2., 3.],
     ...                [4., 5., 6.]])
     >>> indices = jnp.array([2, 0])

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -103,7 +103,7 @@ def cholesky(a: ArrayLike, *, upper: bool = False) -> Array:
     - :func:`jax.scipy.linalg.cholesky`: SciPy-style Cholesky API
     - :func:`jax.lax.linalg.cholesky`: XLA-style Cholesky API
 
-  Example:
+  Examples:
     A small real Hermitian positive-definite matrix:
 
     >>> x = jnp.array([[2., 1.],
@@ -250,7 +250,7 @@ def svd(
     - :func:`jax.scipy.linalg.svd`: SciPy-style SVD API
     - :func:`jax.lax.linalg.svd`: XLA-style SVD API
 
-  Example:
+  Examples:
     Consider the SVD of a small real-valued array:
 
     >>> x = jnp.array([[1., 2., 3.],
@@ -1007,7 +1007,7 @@ def inv(a: ArrayLike) -> Array:
     - :func:`jax.scipy.linalg.inv`: SciPy-style API for matrix inverse
     - :func:`jax.numpy.linalg.solve`: direct linear solver
 
-  Example:
+  Examples:
     Compute the inverse of a 3x3 matrix
 
     >>> a = jnp.array([[1., 2., 3.],
@@ -1316,7 +1316,7 @@ def solve(a: ArrayLike, b: ArrayLike) -> Array:
     - :func:`jax.scipy.linalg.solve`: SciPy-style API for solving linear systems.
     - :func:`jax.lax.custom_linear_solve`: matrix-free linear solver.
 
-  Example:
+  Examples:
     A simple 3x3 linear system:
 
     >>> A = jnp.array([[1., 2., 3.],
@@ -1422,7 +1422,7 @@ def lstsq(a: ArrayLike, b: ArrayLike, rcond: float | None = None, *,
     - ``rank`` is the rank of the matrix ``a``.
     - ``s`` is the singular values of the matrix ``a``.
 
-  Example:
+  Examples:
     >>> a = jnp.array([[1, 2],
     ...                [3, 4]])
     >>> b = jnp.array([5, 6])
@@ -1454,7 +1454,7 @@ def cross(x1: ArrayLike, x2: ArrayLike, /, *, axis=-1):
   See Also:
     :func:`jax.numpy.cross`: more flexible cross-product API.
 
-  Example:
+  Examples:
 
     Showing that :math:`\hat{x} \times \hat{y} = \hat{z}`:
 
@@ -1497,7 +1497,7 @@ def outer(x1: ArrayLike, x2: ArrayLike, /) -> Array:
   See also:
     :func:`jax.numpy.outer`: similar function in the main :mod:`jax.numpy` module.
 
-  Example:
+  Examples:
     >>> x1 = jnp.array([1, 2, 3])
     >>> x2 = jnp.array([4, 5, 6])
     >>> jnp.linalg.outer(x1, x2)
@@ -1846,7 +1846,7 @@ def svdvals(x: ArrayLike, /) -> Array:
   See also:
     :func:`jax.numpy.linalg.svd`: compute singular values and singular vectors
 
-  Example:
+  Examples:
     >>> x = jnp.array([[1, 2, 3],
     ...                [4, 5, 6]])
     >>> jnp.linalg.svdvals(x)
@@ -1916,7 +1916,7 @@ def tensorinv(a: ArrayLike, ind: int = 2) -> Array:
     - :func:`jax.numpy.linalg.tensordot`
     - :func:`jax.numpy.linalg.tensorsolve`
 
-  Example:
+  Examples:
     >>> key = jax.random.key(1337)
     >>> x = jax.random.normal(key, shape=(2, 2, 4))
     >>> xinv = jnp.linalg.tensorinv(x, 2)

--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -232,7 +232,7 @@ def bitwise_count(x: ArrayLike, /) -> Array:
     An array-like object containing the binary 1 bit counts of the absolute value of
     each element in ``x``, with the same shape as ``x`` of dtype uint8.
 
-  Example:
+  Examples:
     >>> x1 = jnp.array([64, 32, 31, 20])
     >>> # 64 = 0b1000000, 32 = 0b100000, 31 = 0b11111, 20 = 0b10100
     >>> jnp.bitwise_count(x1)
@@ -274,7 +274,7 @@ def right_shift(x1: ArrayLike, x2: ArrayLike, /) -> Array:
     shared shape, this shared shape will also be the shape of the output. Right shifting
     a scalar x1 by scalar x2 is equivalent to ``x1 // 2**x2``.
 
-  Example:
+  Examples:
     >>> def print_binary(x):
     ...   return [bin(int(val)) for val in x]
 
@@ -328,7 +328,7 @@ def absolute(x: ArrayLike, /) -> Array:
     with the same shape as ``x``. For complex valued input, :math:`a + ib`,
     the absolute value is :math:`\sqrt{a^2+b^2}`.
 
-  Example:
+  Examples:
     >>> x1 = jnp.array([5, -2, 0, 12])
     >>> jnp.absolute(x1)
     Array([ 5,  2,  0, 12], dtype=int32)

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -2620,7 +2620,7 @@ def clone(key):
   Outside the context of key reuse checking (see :mod:`jax.experimental.key_reuse`)
   this function operates as an identity.
 
-  Example:
+  Examples:
 
     >>> import jax
     >>> key = jax.random.key(0)

--- a/jax/_src/scipy/fft.py
+++ b/jax/_src/scipy/fft.py
@@ -65,7 +65,7 @@ def dct(x: Array, type: int = 2, n: int | None = None,
     - :func:`jax.scipy.fft.idct`: inverse DCT
     - :func:`jax.scipy.fft.idctn`: multidimensional inverse DCT
 
-  Example:
+  Examples:
     >>> x = jax.random.normal(jax.random.key(0), (3, 3))
     >>> with jnp.printoptions(precision=2, suppress=True):
     ...   print(jax.scipy.fft.dct(x))
@@ -157,7 +157,7 @@ def dctn(x: Array, type: int = 2,
     - :func:`jax.scipy.fft.idct`: one-dimensional inverse DCT
     - :func:`jax.scipy.fft.idctn`: multidimensional inverse DCT
 
-  Example:
+  Examples:
 
     ``jax.scipy.fft.dctn`` computes the transform along both the axes by default
     when ``axes`` argument is ``None``.
@@ -240,7 +240,7 @@ def idct(x: Array, type: int = 2, n: int | None = None,
     - :func:`jax.scipy.fft.dctn`: multidimensional DCT
     - :func:`jax.scipy.fft.idctn`: multidimensional inverse DCT
 
-  Example:
+  Examples:
 
     >>> x = jax.random.normal(jax.random.key(0), (3, 3))
     >>> with jnp.printoptions(precision=2, suppress=True):
@@ -332,7 +332,7 @@ def idctn(x: Array, type: int = 2,
     - :func:`jax.scipy.fft.dctn`: multidimensional DCT
     - :func:`jax.scipy.fft.idct`: one-dimensional inverse DCT
 
-  Example:
+  Examples:
 
     ``jax.scipy.fft.idctn`` computes the transform along both the axes by default
     when ``axes`` argument is ``None``.

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -78,7 +78,7 @@ def cholesky(a: ArrayLike, lower: bool = False, overwrite_a: bool = False,
    - :func:`jax.scipy.linalg.cho_factor`
    - :func:`jax.scipy.linalg.cho_solve`
 
-  Example:
+  Examples:
     A small real Hermitian positive-definite matrix:
 
     >>> x = jnp.array([[2., 1.],
@@ -130,7 +130,7 @@ def cho_factor(a: ArrayLike, lower: bool = False, overwrite_a: bool = False,
     - :func:`jax.scipy.linalg.cholesky`
     - :func:`jax.scipy.linalg.cho_solve`
 
-  Example:
+  Examples:
     A small real Hermitian positive-definite matrix:
 
     >>> x = jnp.array([[2., 1.],
@@ -186,7 +186,7 @@ def cho_solve(c_and_lower: tuple[ArrayLike, bool], b: ArrayLike,
     - :func:`jax.scipy.linalg.cholesky`
     - :func:`jax.scipy.linalg.cho_factor`
 
-  Example:
+  Examples:
     A small real Hermitian positive-definite matrix:
 
     >>> x = jnp.array([[2., 1.],
@@ -288,7 +288,7 @@ def svd(a: ArrayLike, full_matrices: bool = True, compute_uv: bool = True,
     - :func:`jax.numpy.linalg.svd`: NumPy-style SVD API
     - :func:`jax.lax.linalg.svd`: XLA-style SVD API
 
-  Example:
+  Examples:
     Consider the SVD of a small real-valued array:
 
     >>> x = jnp.array([[1., 2., 3.],
@@ -516,7 +516,7 @@ def schur(a: ArrayLike, output: str = 'real') -> tuple[Array, Array]:
     - :func:`jax.scipy.linalg.rsf2csf`: convert real Schur form to complex Schur form.
     - :func:`jax.lax.linalg.schur`: XLA-style API for Schur decomposition.
 
-  Example:
+  Examples:
     A Schur decomposition of a 3x3 matrix:
 
     >>> a = jnp.array([[1., 2., 3.],
@@ -570,7 +570,7 @@ def inv(a: ArrayLike, overwrite_a: bool = False, check_finite: bool = True) -> A
     - :func:`jax.numpy.linalg.inv`: NumPy-style API for matrix inverse
     - :func:`jax.scipy.linalg.solve`: direct linear solver
 
-  Example:
+  Examples:
     Compute the inverse of a 3x3 matrix
 
     >>> a = jnp.array([[1., 2., 3.],
@@ -630,7 +630,7 @@ def lu_factor(a: ArrayLike, overwrite_a: bool = False, check_finite: bool = True
     - :func:`jax.scipy.linalg.lu`
     - :func:`jax.scipy.linalg.lu_solve`
 
-  Example:
+  Examples:
     Solving a small linear system via LU factorization:
 
     >>> a = jnp.array([[2., 1.],
@@ -686,7 +686,7 @@ def lu_solve(lu_and_piv: tuple[Array, ArrayLike], b: ArrayLike, trans: int = 0,
     - :func:`jax.scipy.linalg.lu`
     - :func:`jax.scipy.linalg.lu_factor`
 
-  Example:
+  Examples:
     Solving a small linear system via LU factorization:
 
     >>> a = jnp.array([[2., 1.],
@@ -784,7 +784,7 @@ def lu(a: ArrayLike, permute_l: bool = False, overwrite_a: bool = False,
     - :func:`jax.lax.linalg.lu`: XLA-style API for LU decomposition.
     - :func:`jax.scipy.linalg.lu_solve`: LU-based linear solver.
 
-  Example:
+  Examples:
     An LU decomposition of a 3x3 matrix:
 
     >>> a = jnp.array([[1., 2., 3.],
@@ -999,7 +999,7 @@ def solve(a: ArrayLike, b: ArrayLike, lower: bool = False,
     - :func:`jax.numpy.linalg.solve`: NumPy-style API for solving linear systems.
     - :func:`jax.lax.custom_linear_solve`: matrix-free linear solver.
 
-  Example:
+  Examples:
     A simple 3x3 linear system:
 
     >>> A = jnp.array([[1., 2., 3.],
@@ -1083,7 +1083,7 @@ def solve_triangular(a: ArrayLike, b: ArrayLike, trans: int | str = 0, lower: bo
   See also:
     :func:`jax.scipy.linalg.solve`: Solve a general linear system.
 
-  Example:
+  Examples:
     A simple 3x3 triangular linear system:
 
     >>> A = jnp.array([[1., 2., 3.],
@@ -1138,7 +1138,7 @@ def expm(A: ArrayLike, *, upper_triangular: bool = False, max_squarings: int = 1
   See Also:
     :func:`jax.scipy.linalg.expm_frechet`
 
-  Example:
+  Examples:
 
     ``expm`` is the matrix exponential, and has similar properties to the more
     familiar scalar exponential. For scalars ``a`` and ``b``, :math:`e^{a + b}
@@ -1384,7 +1384,7 @@ def block_diag(*arrs: ArrayLike) -> Array:
     2D block-diagonal array constructed by placing the input arrays
     along the diagonal.
 
-  Example:
+  Examples:
     >>> A = jnp.ones((1, 1))
     >>> B = jnp.ones((2, 2))
     >>> C = jnp.ones((3, 3))
@@ -1668,7 +1668,7 @@ def polar(a: ArrayLike, side: str = 'right', *, method: str = 'qdwh', eps: float
     ``posdef`` is either :math:`n \times n` or :math:`m \times m` depending on
     whether ``side`` is ``"right"`` or ``"left"``, respectively.
 
-  Example:
+  Examples:
 
     Polar decomposition of a 3x3 matrix:
 
@@ -1786,7 +1786,7 @@ def sqrtm(A: ArrayLike, blocksize: int = 1) -> Array:
   See Also:
     :func:`jax.scipy.linalg.expm`
 
-  Example:
+  Examples:
     >>> a = jnp.array([[1., 2., 3.],
     ...                [2., 4., 2.],
     ...                [3., 2., 1.]])
@@ -1836,7 +1836,7 @@ def rsf2csf(T: ArrayLike, Z: ArrayLike, check_finite: bool = True) -> tuple[Arra
   See Also:
     :func:`jax.scipy.linalg.schur`: Schur decomposition
 
-  Example:
+  Examples:
     >>> A = jnp.array([[0., 3., 3.],
     ...                [0., 1., 2.],
     ...                [2., 0., 1.]])
@@ -1961,7 +1961,7 @@ def hessenberg(a: ArrayLike, *, calc_q: bool = False, overwrite_a: bool = False,
     - ``H`` has shape ``(..., N, N)`` and is the Hessenberg form of ``a``
     - ``Q`` has shape ``(..., N, N)`` and is the associated unitary matrix
 
-  Example:
+  Examples:
     Computing the Hessenberg form of a 4x4 matrix
 
     >>> a = jnp.array([[1., 2., 3., 4.],

--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -501,7 +501,7 @@ def detrend(data: ArrayLike, axis: int = -1, type: str = 'linear', bp: int = 0,
   Returns:
     The detrended data array.
 
-  Example:
+  Examples:
     A simple detrend operation in one dimension:
 
     >>> data = jnp.array([1., 4., 8., 8., 9.])
@@ -1082,7 +1082,7 @@ def istft(Zxx: Array, fs: ArrayLike = 1.0, window: str = 'hann',
   See Also:
     :func:`jax.scipy.signal.stft`: short-time Fourier transform.
 
-  Example:
+  Examples:
     Demonstrate that this gives the inverse of :func:`~jax.scipy.signal.stft`:
 
     >>> x = jnp.array([1., 2., 3., 2., 1., 0., 1., 2.])

--- a/jax/_src/sharding_impls.py
+++ b/jax/_src/sharding_impls.py
@@ -183,7 +183,7 @@ class NamedSharding(sharding.Sharding):
     mesh: A :class:`jax.sharding.Mesh` object.
     spec: A :class:`jax.sharding.PartitionSpec` object.
 
-  Example:
+  Examples:
 
     >>> from jax.sharding import Mesh
     >>> from jax.sharding import PartitionSpec as P
@@ -308,7 +308,7 @@ class SingleDeviceSharding(sharding.Sharding):
   Args:
     device: A single :py:class:`Device`.
 
-  Example:
+  Examples:
 
     >>> single_device_sharding = jax.sharding.SingleDeviceSharding(
     ...     jax.devices()[0])

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1501,7 +1501,7 @@ def register_event_duration_listener(callback):
 def set_env(**kwargs):
   """Context manager to temporarily set/unset one or more environment variables.
 
-  Example:
+  Examples:
 
     >>> import os
     >>> os.environ['my_var'] = 'original'

--- a/jax/_src/third_party/scipy/interpolate.py
+++ b/jax/_src/third_party/scipy/interpolate.py
@@ -45,7 +45,7 @@ class RegularGridInterpolator:
   Returns:
     interpolator: callable interpolation object.
 
-  Example:
+  Examples:
     >>> points = (jnp.array([1, 2, 3]), jnp.array([4, 5, 6]))
     >>> values = jnp.array([[10, 20, 30], [40, 50, 60], [70, 80, 90]])
     >>> interpolate = RegularGridInterpolator(points, values, method='linear')

--- a/jax/_src/third_party/scipy/linalg.py
+++ b/jax/_src/third_party/scipy/linalg.py
@@ -65,7 +65,7 @@ def funm(A: ArrayLike, func: Callable[[Array], Array],
     close to zero, the SciPy function may return a real-valued array, whereas
     the JAX implementation will return a complex-valued array.
 
-  Example:
+  Examples:
     Applying an arbitrary matrix function:
 
     >>> A = jnp.array([[1., 2.], [3., 4.]])

--- a/jax/_src/tree.py
+++ b/jax/_src/tree.py
@@ -67,7 +67,7 @@ def flatten(tree: Any,
     A pair where the first element is a list of leaf values and the second
     element is a treedef representing the structure of the flattened tree.
 
-  Example:
+  Examples:
     >>> import jax
     >>> vals, treedef = jax.tree.flatten([1, (2, 3), [4, 5]])
     >>> vals
@@ -98,7 +98,7 @@ def leaves(tree: Any,
   Returns:
     leaves: a list of tree leaves.
 
-  Example:
+  Examples:
     >>> import jax
     >>> jax.tree.leaves([1, (2, 3), [4, 5]])
     [1, 2, 3, 4, 5]
@@ -211,7 +211,7 @@ def structure(tree: Any,
   Returns:
     pytreedef: a PyTreeDef representing the structure of the tree.
 
-  Example:
+  Examples:
     >>> import jax
     >>> jax.tree.structure([1, (2, 3), [4, 5]])
     PyTreeDef([*, (*, *), [*, *]])
@@ -270,7 +270,7 @@ def unflatten(treedef: tree_util.PyTreeDef,
     The reconstructed pytree, containing the ``leaves`` placed in the structure
     described by ``treedef``.
 
-  Example:
+  Examples:
     >>> import jax
     >>> vals, treedef = jax.tree.flatten([1, (2, 3), [4, 5]])
     >>> newvals = [100, 200, 300, 400, 500]

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -110,7 +110,7 @@ def treedef_tuple(treedefs: Iterable[PyTreeDef]) -> PyTreeDef:
   Returns:
     a single treedef representing a tuple of the structures
 
-  Example:
+  Examples:
     >>> import jax
     >>> x = [1, 2, 3]
     >>> y = {'a': 4, 'b': 5}
@@ -161,7 +161,7 @@ def treedef_is_leaf(treedef: PyTreeDef) -> bool:
   Returns:
     True if treedef is a leaf (i.e. has a single node); False otherwise.
 
-  Example:
+  Examples:
     >>> import jax
     >>> tree1 = jax.tree.structure(1)
     >>> jax.tree_util.treedef_is_leaf(tree1)
@@ -193,7 +193,7 @@ def all_leaves(iterable: Iterable[Any],
   Returns:
     A boolean indicating if all elements in the input are leaves.
 
-  Example:
+  Examples:
     >>> import jax
     >>> tree = {"a": [1, 2, 3]}
     >>> assert all_leaves(jax.tree_util.tree_leaves(tree))
@@ -236,7 +236,7 @@ def register_pytree_node(nodetype: type[T],
     - :func:`~jax.tree_util.register_pytree_node_class`
     - :func:`~jax.tree_util.register_pytree_with_keys_class`
 
-  Example:
+  Examples:
     First we'll define a custom type:
 
     >>> class MyContainer:
@@ -306,7 +306,7 @@ def register_pytree_node_class(cls: Typ) -> Typ:
     - :func:`~jax.tree_util.register_pytree_with_keys`
     - :func:`~jax.tree_util.register_pytree_with_keys_class`
 
-  Example:
+  Examples:
     Here we'll define a custom container that will be compatible with :func:`jax.jit`
     and other JAX transformations:
 
@@ -357,7 +357,7 @@ def build_tree(treedef: PyTreeDef, xs: Any) -> Any:
   See Also:
     - :func:`jax.tree.unflatten`
 
-  Example:
+  Examples:
     >>> import jax
     >>> tree = [(1, 2), {'a': 3, 'b': 4}]
     >>> treedef = jax.tree.structure(tree)
@@ -591,7 +591,7 @@ def flatten_one_level(pytree: Any) -> tuple[Iterable[Any], Hashable]:
     ValueError: If the given pytree is not a built-in or registered container
     via ``register_pytree_node`` or ``register_pytree_with_keys``.
 
-  Example:
+  Examples:
     >>> import jax
     >>> from jax._src.tree_util import flatten_one_level
     >>> flattened, meta = flatten_one_level({'a': [1, 2], 'b': {'c': 3}})
@@ -745,7 +745,7 @@ def keystr(keys: KeyPath):
   Returns:
     A string that joins all string representations of the keys.
 
-  Example:
+  Examples:
     >>> import jax
     >>> keys = (0, 1, 'a', 'b')
     >>> jax.tree_util.keystr(keys)
@@ -822,7 +822,7 @@ def register_pytree_with_keys(
       This argument is optional and only needed for faster traversal when
       calling functions without keys like ``tree_map`` and ``tree_flatten``.
 
-  Example:
+  Examples:
     First we'll define a custom type:
 
     >>> class MyContainer:
@@ -891,7 +891,7 @@ def register_pytree_with_keys_class(cls: Typ) -> Typ:
     - :func:`~jax.tree_util.register_pytree_with_keys`
     - :func:`~jax.tree_util.register_pytree_node_class`
 
-  Example:
+  Examples:
     >>> from jax.tree_util import register_pytree_with_keys_class, GetAttrKey
     >>> @register_pytree_with_keys_class
     ... class Special:
@@ -946,7 +946,7 @@ def register_dataclass(
     pytree registry. This return value allows ``register_dataclass`` to be partially
     evaluated and used as a decorator as in the example below.
 
-  Example:
+  Examples:
     >>> from dataclasses import dataclass
     >>> from functools import partial
     >>>

--- a/jax/experimental/array_serialization/serialization.py
+++ b/jax/experimental/array_serialization/serialization.py
@@ -412,7 +412,7 @@ class GlobalAsyncCheckpointManagerBase(util.StrictABC):
   is finished, checkpoint for step 2 will need to be blocked. Maintaining a
   class allows to maintain that state.
 
-  Example:
+  Examples:
 
   Below is a simplified training loop:
 

--- a/jax/experimental/custom_partitioning.py
+++ b/jax/experimental/custom_partitioning.py
@@ -299,7 +299,7 @@ class custom_partitioning:
   Positional arguments can be specified as static using static_argnums. JAX uses
   :code:`inspect.signature(fun)` to resolve these positional arguments.
 
-  Example:
+  Examples:
 
     As an example, assume we want to enhance the existing ``jax.numpy.fft.fft``. This function computes
     the discrete Fourier transform of an N-dimensional input along the last dimension, and is batched

--- a/jax/experimental/mosaic/gpu/fragmented_array.py
+++ b/jax/experimental/mosaic/gpu/fragmented_array.py
@@ -46,7 +46,7 @@ class WGSplatFragLayout:
   wants. This means we can trivially broadcast, reshape and do
   elementwise operations with all other layouts.
 
-  Example:
+  Examples:
 
   To load a value in
   ```

--- a/jax/experimental/sparse/ad.py
+++ b/jax/experimental/sparse/ad.py
@@ -81,7 +81,7 @@ def value_and_grad(fun: Callable, argnums: int | Sequence[int] = 0,
   taking the gradient with respect to a :class:`jax.experimental.sparse` array, the
   gradient is computed in the subspace defined by the array's sparsity pattern.
 
-  Example:
+  Examples:
 
     >>> from jax.experimental import sparse
     >>> X = sparse.BCOO.fromdense(jnp.arange(6.))
@@ -109,7 +109,7 @@ def grad(fun: Callable, argnums: int | Sequence[int] = 0,
   the gradient with respect to a :class:`jax.experimental.sparse` array, the
   gradient is computed in the subspace defined by the array's sparsity pattern.
 
-  Example:
+  Examples:
 
     >>> from jax.experimental import sparse
     >>> X = sparse.BCOO.fromdense(jnp.arange(6.))


### PR DESCRIPTION
This PR updates all docstrings that previously had a section heading called "Example" and replaces that with "Examples" to be consistent.

Fixes #21979 