### PR TITLE
Apply ruff formatting to all docstrings

### DIFF
--- a/examples/advi.py
+++ b/examples/advi.py
@@ -16,7 +16,8 @@
 
 This demo fits a Gaussian approximation to an intractable, unnormalized
 density, by differentiating through a Monte Carlo estimate of the
-variational evidence lower bound (ELBO)."""
+variational evidence lower bound (ELBO).
+"""
 
 
 from functools import partial

--- a/examples/gaussian_process_regression.py
+++ b/examples/gaussian_process_regression.py
@@ -40,6 +40,7 @@ def main(unused_argv):
     Args:
       cov_func: callable function, maps pairs of data points to scalars.
       xs: array of data points, stacked along the leading dimension.
+
     Returns:
       A 2d array `a` such that `a[i, j] = cov_func(xs[i], xs[j])`.
     """

--- a/examples/kernel_lsq.py
+++ b/examples/kernel_lsq.py
@@ -23,7 +23,7 @@ from jax import grad, jit, make_jaxpr, vmap, lax
 
 
 def gram(kernel, xs):
-  '''Compute a Gram matrix from a kernel and an array of data points.
+  """Compute a Gram matrix from a kernel and an array of data points.
 
   Args:
     kernel: callable, maps pairs of data points to scalars.
@@ -31,7 +31,7 @@ def gram(kernel, xs):
 
   Returns:
     A 2d array `a` such that `a[i, j] = kernel(xs[i], xs[j])`.
-  '''
+  """
   return vmap(lambda x: vmap(lambda y: kernel(x, y))(xs))(xs)
 
 

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1008,6 +1008,7 @@ def _possible_downcast(x, example):
 
 def _unravel_array_into_pytree(pytree, axis, example, arr):
   """Unravel an array into a PyTree with a given structure.
+
   Args:
       pytree: The pytree that provides the structure.
       axis: The parameter axis is either -1, 0, or 1.  It controls the
@@ -2866,6 +2867,7 @@ def named_scope(
   Args:
     name: The prefix to use to name all operations created within the name
       scope.
+
   Yields:
     Yields ``None``, but enters a context in which `name` will be appended to
     the active name stack.

--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -133,7 +133,8 @@ def flatten_fun_nokwargs2(in_tree, *args_flat):
 class _HashableWithStrictTypeEquality:
   """Box object used when comparing static arguments as a jit key.
 
-  Requires exact type equality using `is` and value equality."""
+  Requires exact type equality using `is` and value equality.
+  """
   __slots__ = ["val"]
 
   def __init__(self, val):
@@ -254,7 +255,7 @@ def _ensure_inbounds(allow_invalid: bool, num_args: int, argnums: Sequence[int]
 
 def argnums_partial_except(f: lu.WrappedFun, static_argnums: tuple[int, ...],
                            args: tuple[Any, ...], *, allow_invalid: bool):
-  "Version of ``argnums_partial`` that checks hashability of static_argnums."
+  """Version of ``argnums_partial`` that checks hashability of static_argnums."""
   if not static_argnums:
     return f, args
   static_argnums = _ensure_inbounds(allow_invalid, len(args), static_argnums)
@@ -667,7 +668,7 @@ def _arg_names(fn_signature, args, kwargs, static_argnums, static_argnames,
 
 @lu.transformation_with_aux
 def result_paths(*args, **kwargs):
-  "linear_util transform to get output pytree paths of pre-flattened function."
+  """linear_util transform to get output pytree paths of pre-flattened function."""
   ans = yield args, kwargs
   yield ans, [keystr(path) for path, _ in generate_key_paths(ans)]
 
@@ -687,7 +688,7 @@ def jaxpr_debug_info(jaxpr: core.Jaxpr, trace_debug: TracingDebugInfo | None,
 
 def debug_info_final(f: lu.WrappedFun, dbg: TracingDebugInfo | None,
                      res_paths: Callable[[], tuple[str, ...]]) -> lu.WrappedFun:
-  "Attach trace-time debug info and result paths lazy thunk to an lu.WrappedFun"
+  """Attach trace-time debug info and result paths lazy thunk to an lu.WrappedFun"""
   if dbg is None: return f
   assert dbg.result_paths is None
   res_paths_ = HashableFunction(res_paths, closure=())

--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -654,7 +654,6 @@ def make_array_from_callback(
     A ``jax.Array`` via data fetched from ``data_callback``.
 
   Examples:
-
     >>> import math
     >>> from jax.sharding import Mesh
     >>> from jax.sharding import PartitionSpec as P
@@ -923,7 +922,6 @@ def make_array_from_single_device_arrays(
       contents matching ``arrays``.
 
   Examples:
-
     In this single-process example, we use ``make_array_from_single_device_arrays`` to create an
     a global array.
 

--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -1102,6 +1102,7 @@ def checkify(f: Callable[..., Out],
       DIV errors by passing the ``float_checks`` set, or for
       example combine multiple sets through set operations
       (``float_checks | user_checks``)
+
   Returns:
     A function which accepts the same arguments as ``fun`` and returns as output
     a pair where the first element is an ``Error`` value, representing the first

--- a/jax/_src/clusters/cluster.py
+++ b/jax/_src/clusters/cluster.py
@@ -103,7 +103,7 @@ class ClusterEnv:
 
   @classmethod
   def get_local_process_id(cls) -> int | None:
-    """ Get index of current process inside a host.
+    """Get index of current process inside a host.
 
     The method is only useful to support single device per process.
     In that case, each process will see a local device whose ID is

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -122,17 +122,15 @@ class Config:
     need JAX flags.
 
     Examples:
+      .. code-block:: python
 
-    ```python
-    from absl import app
-    import jax
-    ...
+        from absl import app
+        import jax
+        ...
 
-    if __name__ == '__main__':
-      jax.config.config_with_absl()
-      app.run(main)
-    ```
-
+        if __name__ == '__main__':
+          jax.config.config_with_absl()
+          app.run(main)
     """
     import absl.flags as absl_FLAGS  # noqa: F401  # pytype: disable=import-error
     from absl import app, flags as absl_flags  # pytype: disable=import-error
@@ -317,7 +315,8 @@ class State(Generic[_T]):
   def _add_hooks(self, update_global_hook, update_thread_local_hook):
     """Private method that adds hooks to an existing context-manager.
 
-    Used to avoid cyclic import dependencies."""
+    Used to avoid cyclic import dependencies.
+    """
     self._update_thread_local_hook = update_thread_local_hook
     self._update_global_hook = update_global_hook
     update_global_hook(self._value)
@@ -373,7 +372,6 @@ def bool_state(
     A contextmanager to control the thread-local state value.
 
   Examples:
-
     ENABLE_FOO = config.bool_state(
         name='jax_enable_foo',
         default=False,

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2125,7 +2125,8 @@ def definitely_equal_shape(s1: Shape, s2: Shape) -> bool:
 
 def divide_shape_sizes(s1: Shape, s2: Shape) -> DimSize:
   """Returns an integer "i" s.t., i * size(s2) == size(s1).
-  Raises InconclusiveDimensionOperation if there is no such integer."""
+  Raises InconclusiveDimensionOperation if there is no such integer.
+  """
   sz1 = math.prod(s1)
   sz2 = math.prod(s2)
   if definitely_equal(sz1, sz2):  # Takes care of sz1 and sz2 being 0
@@ -2207,10 +2208,10 @@ def max_dim(d1: DimSize, d2: DimSize) -> DimSize:
 
 def dimension_as_value(d: DimSize):
   """Turns a dimension size into a JAX array.
-     This is the identity function for constant dimensions.
+  This is the identity function for constant dimensions.
 
-     Has the same abstract value as Python constants.
-     """
+  Has the same abstract value as Python constants.
+  """
   if isinstance(d, (int, Tracer, np.int32, np.int64)): return d
   # For shape_poly._DimPolynomial
   if hasattr(d, "dimension_as_value"): return d.dimension_as_value()
@@ -2629,7 +2630,7 @@ def extend_axis_env_nd(axes: Iterable[tuple[AxisName, int]], tag: Any = None):
 
 @contextmanager
 def stash_axis_env():
-  "Promise that a function or with-suite does not depend implicitly on axis env"
+  """Promise that a function or with-suite does not depend implicitly on axis env"""
   # If the promise is broken, then a NameError about an unbound axis name will
   # be raised.
   ts = thread_local_state.trace_state
@@ -3343,7 +3344,7 @@ def _compact_eqn_should_include(k: str, v: Any) -> bool:
   return True
 
 def str_eqn_compact(primitive_name: str, params: dict) -> str:
-  "Compact equation to string conversion used in HLO metadata."
+  """Compact equation to string conversion used in HLO metadata."""
   kvs = " ".join(f"{k}={v}" for k, v in params.items()
                  if _compact_eqn_should_include(k, v))
   return f"{primitive_name}[{kvs}]" if len(kvs) > 0 else primitive_name

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -181,7 +181,6 @@ class custom_jvp(Generic[ReturnValue]):
       None.
 
     Examples:
-
       @jax.custom_jvp
       def f(x, y):
         return jnp.sin(x) * y
@@ -213,7 +212,6 @@ class custom_jvp(Generic[ReturnValue]):
       None.
 
     Examples:
-
       @jax.custom_jvp
       def f(x, y):
         return jnp.sin(x) * y
@@ -568,7 +566,6 @@ class custom_vjp(Generic[ReturnValue]):
       None.
 
     Examples:
-
       @jax.custom_vjp
       def f(x, y):
         return jnp.sin(x) * y
@@ -1077,7 +1074,9 @@ def closure_convert(fun: Callable, *example_args) -> tuple[Callable, list[Any]]:
 
   The function ``fun`` must be a pure function.
 
-  Example usage::
+  For example,
+
+  .. code-block:: python
 
     def minimize(objective_fn, x0):
       converted_fn, aux_args = closure_convert(objective_fn, x0)

--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -180,18 +180,17 @@ def initialize(coordinator_address: str | None = None,
       or if called after the backend is already initialized.
 
   Examples:
+    Suppose there are two GPU processes, and process 0 is the designated coordinator
+    with address ``10.0.0.1:1234``. To initialize the GPU cluster, run the
+    following commands before anything else.
 
-  Suppose there are two GPU processes, and process 0 is the designated coordinator
-  with address ``10.0.0.1:1234``. To initialize the GPU cluster, run the
-  following commands before anything else.
+    On process 0:
 
-  On process 0:
+      >>> jax.distributed.initialize(coordinator_address='10.0.0.1:1234', num_processes=2, process_id=0)  # doctest: +SKIP
 
-  >>> jax.distributed.initialize(coordinator_address='10.0.0.1:1234', num_processes=2, process_id=0)  # doctest: +SKIP
+    On process 1:
 
-  On process 1:
-
-  >>> jax.distributed.initialize(coordinator_address='10.0.0.1:1234', num_processes=2, process_id=1)  # doctest: +SKIP
+      >>> jax.distributed.initialize(coordinator_address='10.0.0.1:1234', num_processes=2, process_id=1)  # doctest: +SKIP
   """
   if xla_bridge.backends_are_initialized():
     raise RuntimeError("jax.distributed.initialize() must be called before "
@@ -204,5 +203,6 @@ def initialize(coordinator_address: str | None = None,
 def shutdown():
   """Shuts down the distributed system.
 
-  Does nothing if the distributed system is not running."""
+  Does nothing if the distributed system is not running.
+  """
   global_state.shutdown()

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -272,25 +272,23 @@ def scalar_type_of(x: Any) -> type:
 def _scalar_type_to_dtype(typ: type, value: Any = None) -> DType:
   """Return the numpy dtype for the given scalar type.
 
-  Raises
-  ------
-  OverflowError: if `typ` is `int` and the value is too large for int64.
+  Raises:
+    OverflowError: if `typ` is `int` and the value is too large for int64.
 
-  Examples
-  --------
-  >>> _scalar_type_to_dtype(int)
-  dtype('int32')
-  >>> _scalar_type_to_dtype(float)
-  dtype('float32')
-  >>> _scalar_type_to_dtype(complex)
-  dtype('complex64')
-  >>> _scalar_type_to_dtype(int)
-  dtype('int32')
-  >>> _scalar_type_to_dtype(int, 0)
-  dtype('int32')
-  >>> _scalar_type_to_dtype(int, 1 << 63)  # doctest: +IGNORE_EXCEPTION_DETAIL
-  Traceback (most recent call last):
-  OverflowError: Python int 9223372036854775808 too large to convert to int32
+  Examples:
+    >>> _scalar_type_to_dtype(int)
+    dtype('int32')
+    >>> _scalar_type_to_dtype(float)
+    dtype('float32')
+    >>> _scalar_type_to_dtype(complex)
+    dtype('complex64')
+    >>> _scalar_type_to_dtype(int)
+    dtype('int32')
+    >>> _scalar_type_to_dtype(int, 0)
+    dtype('int32')
+    >>> _scalar_type_to_dtype(int, 1 << 63)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    OverflowError: Python int 9223372036854775808 too large to convert to int32
   """
   dtype = canonicalize_dtype(python_scalar_dtypes[typ])
   if typ is int and value is not None:
@@ -787,7 +785,6 @@ def safe_to_cast(input_dtype_or_value: Any,
     path under the current jax_numpy_dtype_promotion setting.
 
   Examples:
-
     >>> safe_to_cast('int32', 'float64')
     True
     >>> safe_to_cast('float64', 'int32')

--- a/jax/_src/errors.py
+++ b/jax/_src/errors.py
@@ -53,8 +53,6 @@ class ConcretizationTypeError(JAXTypeError):
   program is doing operations that are not directly supported by JAX's JIT
   compilation model.
 
-  Examples:
-
   Traced value where static value is expected
     One common cause of this error is using a traced value where a static value
     is required. For example:
@@ -425,8 +423,6 @@ class TracerBoolConversionError(ConcretizationTypeError):
   In some situations, this problem can be easily fixed by marking traced values as
   static; in others, it may indicate that your program is doing operations that are
   not directly supported by JAX's JIT compilation model.
-
-  Examples:
 
   Traced value used in control flow
     One case where this often arises is when a traced value is used in

--- a/jax/_src/export/_export.py
+++ b/jax/_src/export/_export.py
@@ -95,6 +95,7 @@ class DisabledSafetyCheck:
     """Allows the serialization of a call target not known to be stable.
 
     Has effect only on serialization.
+
     Args:
       target_name: the name of the custom call target to allow.
     """

--- a/jax/_src/export/shape_poly.py
+++ b/jax/_src/export/shape_poly.py
@@ -290,13 +290,15 @@ class _DimTerm:
 
   def to_var(self) -> str | None:
     """Extract the variable name from a term.
-     Return None if the term is not a single variable."""
+    Return None if the term is not a single variable.
+    """
     a = self.to_factor()
     return a.to_var() if a is not None else None
 
   def to_factor(self) -> _DimFactor | None:
     """Extract the single factor from a term.
-     Return None if the term is not a single factor."""
+    Return None if the term is not a single factor.
+    """
     if len(self._factors) > 1: return None
     (f, f_exp), = self._factors
     if f_exp != 1: return None
@@ -531,27 +533,31 @@ class _DimExpr:
 
   def _to_term(self) -> _DimTerm | None:
     """Extract the single term from a symbolic expression.
-    Returns None if the expression is not a single term."""
+    Returns None if the expression is not a single term.
+    """
     if len(self._sorted_terms) > 1: return None
     (t, t_k), = self._sorted_terms
     return t if t_k == 1 else None
 
   def _to_factor(self) -> _DimFactor | None:
     """Extract the factor from a symbolic expression.
-    Returns None if the expression is not a single factor."""
+    Returns None if the expression is not a single factor.
+    """
     t = self._to_term()
     return t.to_factor() if t is not None else None
 
   def _to_var(self) -> str | None:
     """Extract the variable name from a symbolic expression.
-    Returns None if the expression is not a single variable."""
+    Returns None if the expression is not a single variable.
+    """
     mon = self._to_factor()
     return mon.to_var() if mon is not None else None
 
   @staticmethod
   def _to_constant(e: DimSize) -> int | None:
     """Extract the constant from a symbolic expression.
-    Returns None if the expression is not a single constant."""
+    Returns None if the expression is not a single constant.
+    """
     if not isinstance(e, _DimExpr):
       return int(e)
     m, m_c = e._leading_term
@@ -1199,7 +1205,6 @@ def _einsum_contract_path(*operands, **kwargs):
   error if there are more than 1 contractions. Essentially, we just use
   opt_einsum.contract_path to parse the specification.
   """
-
   # Replace the polymorphic shapes with some concrete shapes for calling
   # into opt_einsum.contract_path, because the latter wants to compute the
   # sizes of operands and intermediate results.

--- a/jax/_src/export/shape_poly_decision.py
+++ b/jax/_src/export/shape_poly_decision.py
@@ -151,7 +151,7 @@ class _DecisionByElimination:
                    cmp: Comparator,
                    e: _DimExpr,
                    debug_str: str | None):
-    """Updates the internal state to reflect "e >= 0". """
+    """Updates the internal state to reflect "e >= 0"."""
     assert _DimExpr._to_constant(e) is None
 
     if (term_factors := e._to_single_term()) is not None:

--- a/jax/_src/image/scale.py
+++ b/jax/_src/image/scale.py
@@ -337,6 +337,7 @@ def resize(image, shape: core.Shape, method: str | ResizeMethod,
       string. Available methods are: LINEAR, LANCZOS3, LANCZOS5, CUBIC.
     antialias: should an antialiasing filter be used when downsampling? Defaults
       to ``True``. Has no effect when upsampling.
+
   Returns:
     The resized image.
   """

--- a/jax/_src/internal_test_util/test_harnesses.py
+++ b/jax/_src/internal_test_util/test_harnesses.py
@@ -310,6 +310,22 @@ class Limitation:
   """Encodes conditions under which a harness is limited, e.g., not runnable in JAX.
 
   See the module docstring for an introduction to harnesses and limitations.
+
+  Args:
+    description: text to augment the harness group name with the description
+    of the limitation. Used for reports.
+    enabled: whether this limitation is enabled for the harness in which
+      it appears. This is only used during testing to know whether to ignore
+      harness errors. Use this sparingly, prefer `devices` and
+      `dtypes` for enabled conditions that are included in reports.
+    devices: a device type (string) or a sequence of device types
+      for which this applies. By default, it applies to all devices types.
+      Used for filtering during harness execution, and for reports.
+    dtypes: the sequence of dtypes for which this applies. An empty sequence
+      denotes all dtypes. Used for filtering during harness execution, and
+      for reports.
+    skip_run: this harness should not even be invoked (typically because it
+      results in a crash). This should be rare.
   """
 
   def __init__(
@@ -321,23 +337,6 @@ class Limitation:
       dtypes: Sequence[DType] = (),
       skip_run: bool = False,
   ):
-    """Args:
-
-      description: text to augment the harness group name with the description
-      of the limitation. Used for reports.
-      enabled: whether this limitation is enabled for the harness in which
-        it appears. This is only used during testing to know whether to ignore
-        harness errors. Use this sparingly, prefer `devices` and
-        `dtypes` for enabled conditions that are included in reports.
-      devices: a device type (string) or a sequence of device types
-        for which this applies. By default, it applies to all devices types.
-        Used for filtering during harness execution, and for reports.
-      dtypes: the sequence of dtypes for which this applies. An empty sequence
-        denotes all dtypes. Used for filtering during harness execution, and
-        for reports.
-      skip_run: this harness should not even be invoked (typically because it
-        results in a crash). This should be rare.
-    """
     assert isinstance(description, str), f"{description}"
     self.description = description
     self.skip_run = skip_run

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -198,7 +198,8 @@ def aval_to_ir_types(aval: core.AbstractValue) -> Sequence[ir.Type]:
   """Converts a JAX aval to zero or more MLIR IR types.
 
   In general, a JAX value may be represented by multiple IR values, so this
-  function returns multiple types."""
+  function returns multiple types.
+  """
   try:
     return ir_type_handlers[type(aval)](aval)
   except KeyError as err:
@@ -213,7 +214,8 @@ def aval_to_ir_type(aval: core.AbstractValue) -> ir.Type:
   """Convenience wrapper around aval_to_ir_types for single types.
 
   For some common cases, e.g. dense arrays, we know JAX values are represented
-  by a single IR value."""
+  by a single IR value.
+  """
   types = aval_to_ir_types(aval)
   if len(types) != 1:
     raise TypeError(f"aval_to_ir_type called on {aval} which corresponds to "
@@ -227,7 +229,8 @@ class ConstantHandler(Protocol):
   def __call__(self, val: Any) -> Sequence[ir.Value]:
     """Builds an IR representation for a constant `val`.
 
-    A JAX value is represented by zero or more IR values."""
+    A JAX value is represented by zero or more IR values.
+    """
 
 _constant_handlers : dict[type, ConstantHandler] = {}
 
@@ -1129,10 +1132,10 @@ def lower_jaxpr_to_fun(
     xla_donated_args: optional sequence of args to set donation annotations.
     api_name: The name of the higher level primitive which should show up in the
       name stack.
+
   Returns:
     MLIR func op
   """
-
   # The first dimension variable may be the platform index
   num_dim_vars = len(ctx.shape_poly_state.dim_vars)
   dim_var_avals = [core.ShapedArray((), dtypes.canonicalize_dtype(np.int64))] * num_dim_vars
@@ -1763,7 +1766,8 @@ def lower_fun(fun: Callable, multiple_results: bool = True) -> Callable:
   """Converts a traceable JAX function `fun` into a lowering rule.
 
   The returned function does not use `avals_out`, so callers may pass any value
-  as `avals_out`."""
+  as `avals_out`.
+  """
   def f_lowered(ctx: LoweringRuleContext, *args, **params):
     f = fun if multiple_results else lambda *args, **kw: (fun(*args, **kw),)
     wrapped_fun = lu.wrap_init(f, params)
@@ -2109,7 +2113,8 @@ def convert_hlo(ctx: LoweringRuleContext, x, aval_in, aval_out):
   """Variant of convert that has HLO semantics.
 
   In particular, treat casts to boolean as x != 0, rather than truncating
-  integer values (b/209440332)."""
+  integer values (b/209440332).
+  """
   if (not dtypes.issubdtype(aval_out.dtype, dtypes.extended) and
       aval_out.dtype == np.dtype(np.bool_)):
     if dtypes.issubdtype(aval_in.dtype, np.inexact):
@@ -2716,7 +2721,6 @@ def reduce_window(
     out_avals: Sequence[core.AbstractValue],
     window_dimensions, window_strides, padding, base_dilation, window_dilation):
   """Builds a ReduceWindowOp, with support for dynamic shapes."""
-
   scalar_types = [aval_to_ir_type(aval) for aval in init_values_avals]
   if any(not core.is_constant_shape(s)
          for s in [window_dimensions, window_dilation, window_strides, base_dilation, *padding]):

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -2307,7 +2307,7 @@ def debug_info(fn: Callable, in_tree: PyTreeDef | None,
                    traced_for)
 
 def debug_info_final(fn: lu.WrappedFun, traced_for: str) -> DebugInfo:
-  "Make a DebugInfo from data available to final-style primitives like pmap."
+  """Make a DebugInfo from data available to final-style primitives like pmap."""
   in_tree, out_tree, has_kws = flattened_fun_in_tree(fn) or (None, None, False)
   return debug_info(fn.f, in_tree, out_tree, has_kws, traced_for)
 

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -1432,6 +1432,7 @@ def _axis_groups(mesh_spec, mesh_axes):
     mesh_spec: A sequence of integers representing the mesh shape.
     mesh_axes: A sequence of integers between 0 and `len(mesh_spec)` (exclusive)
       indicating over which axes the collective is performed.
+
   Returns:
     A tuple of replica groups (i.e. tuples containing replica ids).
   """

--- a/jax/_src/lax/control_flow/for_loop.py
+++ b/jax/_src/lax/control_flow/for_loop.py
@@ -137,6 +137,7 @@ def for_loop(nsteps: int | Sequence[int],
       `for` primitive, how many iterations to unroll within a single iteration
       of a loop. Higher values may speed up execution time at the cost of longer
       compilation time.
+
   Returns:
     A Pytree of values representing the output of the for loop.
   """

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -92,6 +92,7 @@ def _promote_weak_typed_inputs(in_vals, in_avals, out_avals):
     in_vals : flattened list of input values.
     in_avals : corresponding list of avals.
     out_avals : list of target output avals.
+
   Returns:
     in_vals_new : flattened list of modified in_vals with no weak types.
     changed : bool; true if in_vals required modification.
@@ -2229,7 +2230,6 @@ def associative_scan(fn: Callable, elems, reverse: bool = False, axis: int = 0):
   # a (small two-down-to-one) reduction step.
   def _scan(elems):
     """Perform scan on `elems`."""
-
     num_elems = elems[0].shape[axis]
 
     if num_elems < 2:

--- a/jax/_src/lax/eigh.py
+++ b/jax/_src/lax/eigh.py
@@ -80,6 +80,7 @@ def _slice(operand, start_indices, dynamic_slice_sizes, static_slice_sizes,
     static_slice_sizes: the padded size of the slice, which must be known at
       compile time. The static size must be larger than the dynamic size.
     fill_value: value with which to replace masked-out elements.
+
   Returns:
     An array with static shape `static_slice_sizes`, padded from its true
     (dynamic) size `dynamic_slice_sizes`.
@@ -99,11 +100,12 @@ def _update_slice(operand, update, start_indices, update_dims):
   values should not overwrite existing values in the array.
 
   Args:
-  operand: the array to update
-  update: the padded array to write
-  start_indices: the offset at which to write `update`.
-  update_dims: the true dimensions of the padded update `update`. Only values
-    inside the rectangle given by `update_dims` will be overwritten."""
+    operand: the array to update
+    update: the padded array to write
+    start_indices: the offset at which to write `update`.
+    update_dims: the true dimensions of the padded update `update`. Only values
+      inside the rectangle given by `update_dims` will be overwritten.
+  """
   operand_shape = operand.shape
   operand = lax.pad(operand,
                     jnp.array(0, operand.dtype),
@@ -187,7 +189,7 @@ def _projector_subspace(P, H, n, rank, maxiter=2, swap=False):
 
 
 def split_spectrum(H, n, split_point, V0=None):
-  """ The Hermitian matrix `H` is split into two matrices `H_minus`
+  """The Hermitian matrix `H` is split into two matrices `H_minus`
   `H_plus`, respectively sharing its eigenspaces beneath and above
   its `split_point`th eigenvalue.
 
@@ -200,6 +202,7 @@ def split_spectrum(H, n, split_point, V0=None):
     H: The Hermitian matrix to split.
     split_point: The eigenvalue to split along.
     V0: Matrix of isometries to be updated.
+
   Returns:
     H_minus: A Hermitian matrix sharing the eigenvalues of `H` beneath
       `split_point`.
@@ -287,7 +290,7 @@ class _Subproblem(NamedTuple):
 
 @partial(jax.jit, static_argnames=('termination_size', 'subset_by_index'))
 def _eigh_work(H, n, termination_size, subset_by_index):
-  """ The main work loop performing the symmetric eigendecomposition of H.
+  """The main work loop performing the symmetric eigendecomposition of H.
   Each step recursively computes a projector into the space of eigenvalues
   above jnp.mean(jnp.diag(H)). The result of the projections into and out of
   that space, along with the isometries accomplishing these, are then computed.

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -338,7 +338,8 @@ def cos(x: ArrayLike) -> Array:
 
 def atan2(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise arc tangent of two variables:
-    :math:`\mathrm{atan}({x \over y})`."""
+  :math:`\mathrm{atan}({x \over y})`.
+  """
   return atan2_p.bind(x, y)
 
 def real(x: ArrayLike) -> Array:
@@ -453,14 +454,16 @@ def max(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise maximum: :math:`\mathrm{max}(x, y)`
 
   For complex numbers, uses a lexicographic comparison on the
-  `(real, imaginary)` pairs."""
+  `(real, imaginary)` pairs.
+  """
   return max_p.bind(x, y)
 
 def min(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise minimum:  :math:`\mathrm{min}(x, y)`
 
   For complex numbers, uses a lexicographic comparison on the
-  `(real, imaginary)` pairs."""
+  `(real, imaginary)` pairs.
+  """
   return min_p.bind(x, y)
 
 def shift_left(x: ArrayLike, y: ArrayLike) -> Array:
@@ -991,6 +994,7 @@ def select_n(which: ArrayLike, *cases: ArrayLike) -> Array:
       implementation-defined.
     *cases: a non-empty list of array cases. All must have equal dtypes and
       equal shapes.
+
   Returns:
     An array with shape and dtype equal to the cases, whose values are chosen
     according to ``which``.
@@ -1724,7 +1728,8 @@ standard_naryop = partial(naryop, _input_dtype)
 def _broadcast_translate(op, ctx, avals_in, avals_out, *args):
   """Variant of _standard_translate that performs explicit broadcasting.
 
-  Not all XLA library functions perform their own broadcasting."""
+  Not all XLA library functions perform their own broadcasting.
+  """
   aval_out, = avals_out
   broadcasted_args = []
   for aval_in, arg in zip(avals_in, args):
@@ -4489,7 +4494,8 @@ mlir.register_lowering(create_token_p, _create_token_lowering)
 def after_all(*operands):
   """Merges one or more XLA token values. Experimental.
 
-  Wraps the XLA AfterAll operator."""
+  Wraps the XLA AfterAll operator.
+  """
   return after_all_p.bind(*operands)
 
 def _after_all_abstract_eval(*operands):
@@ -4942,7 +4948,6 @@ class PaddingType(enum.Enum):
 
 def padtype_to_pads(in_shape, window_shape, window_strides, padding):
   """Convert padding string to list of pairs of pad values."""
-
   if isinstance(padding, str):
     mapping = {
         'VALID': PaddingType.VALID,

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -61,7 +61,7 @@ TFun = TypeVar('TFun', bound=Callable[..., Any])
 # traceables
 
 def cholesky(x: Array, *, symmetrize_input: bool = True) -> Array:
-  """Cholesky decomposition.
+  r"""Cholesky decomposition.
 
   Computes the Cholesky decomposition
 
@@ -101,6 +101,7 @@ def eig(x: ArrayLike, *, compute_left_eigenvectors: bool = True,
     compute_left_eigenvectors: If true, the left eigenvectors will be computed.
     compute_right_eigenvectors: If true, the right eigenvectors will be
       computed.
+
   Returns:
     The eigendecomposition of ``x``, which is a tuple of the form
     ``(w, vl, vr)`` where ``w`` are the eigenvalues, ``vl`` are the left
@@ -683,7 +684,8 @@ def eigh_jacobi(x: ArrayLike, *, lower: bool = True,
                 sort_eigenvalues: bool = True) -> tuple[Array, Array]:
   """Helper Jacobi eigendecomposition implemented by XLA.
 
-  Used as a subroutine of QDWH-eig on TPU."""
+  Used as a subroutine of QDWH-eig on TPU.
+  """
   w, v = eigh_jacobi_p.bind(x, lower=lower, sort_eigenvalues=sort_eigenvalues)
   return w, v
 
@@ -1140,6 +1142,7 @@ def _generic_lu_pivots_to_permutation(swaps, permutation_size):
   Args:
     swaps: an array of shape (..., k) of row swaps to perform
     permutation_size: the size of the output permutation. Should be >= k.
+
   Returns:
     An int32 array of shape (..., m).
   """
@@ -1517,6 +1520,7 @@ def geqrf(a: ArrayLike) -> tuple[Array, Array]:
 
   Args:
     a: an ``[..., m, n]`` batch of matrices, with floating-point or complex type.
+
   Returns:
     An ``(a, taus)`` pair where ``r`` is in the upper triangle of ``a``,
     ``q`` is represented in the lower triangle of ``a`` and in ``taus`` as
@@ -2206,7 +2210,6 @@ def tridiagonal_solve(dl: Array, d: Array, du: Array, b: Array) -> Array:
     A . X = B
 
   Args:
-
     dl: A batch of vectors with shape ``[..., m]``.
       The lower diagonal of A: ``dl[i] := A[i, i-1]`` for i in ``[0,m)``.
       Note that ``dl[0] = 0``.

--- a/jax/_src/lax/qdwh.py
+++ b/jax/_src/lax/qdwh.py
@@ -56,7 +56,7 @@ def _pad_in_dim(x, low=0, high=0, interior=0, fill_value=0, axis=0):
   return lax.pad(x, jnp.array(fill_value, x.dtype), pads)
 
 def _dynamic_concat(a, b, m, axis=0):
-  "Concatenates padded arrays `a` and `b` where the true size of `a` is `m`."
+  """Concatenates padded arrays `a` and `b` where the true size of `a` is `m`."""
   if m is None:
     return jnp.concatenate([a, b], axis=axis)
   return lax.dynamic_update_slice_in_dim(
@@ -114,7 +114,6 @@ def _use_cholesky(u, m, n, params):
 
 def _qdwh(x, m, n, max_iterations, eps):
   """QR-based dynamically weighted Halley iteration for polar decomposition."""
-
   # Estimates `alpha` and `beta = alpha * l`, where `alpha` is an estimate of
   # norm(x, 2) such that `alpha >= norm(x, 2)` and `beta` is a lower bound for
   # the smallest singular value of x.

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -963,7 +963,6 @@ def dynamic_update_slice_in_dim(operand: Array | np.ndarray,
     The updated array
 
   Examples:
-
     >>> x = jnp.zeros(6)
     >>> y = jnp.ones(3)
     >>> dynamic_update_slice_in_dim(x, y, 2, axis=0)
@@ -1025,7 +1024,6 @@ def dynamic_update_index_in_dim(operand: Array | np.ndarray,
     The updated array
 
   Examples:
-
     >>> x = jnp.zeros(6)
     >>> y = 1.0
     >>> dynamic_update_index_in_dim(x, y, 2, axis=0)
@@ -1464,7 +1462,6 @@ def _gather_shape_rule(operand, indices, *, dimension_numbers,
   operator and following the outline of the implementation of
   ShapeInference::InferGatherShape in TensorFlow.
   """
-
   offset_dims = dimension_numbers.offset_dims
   collapsed_slice_dims = dimension_numbers.collapsed_slice_dims
   start_index_map = dimension_numbers.start_index_map
@@ -1870,7 +1867,6 @@ def _scatter_shape_rule(operand, indices, updates, *, update_jaxpr,
   operator and following the outline of the implementation of
   ShapeInference::InferScatterShape in TensorFlow.
   """
-
   update_window_dims = dimension_numbers.update_window_dims
   inserted_window_dims = dimension_numbers.inserted_window_dims
   scatter_dims_to_operand_dims = dimension_numbers.scatter_dims_to_operand_dims

--- a/jax/_src/lax/special.py
+++ b/jax/_src/lax/special.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-""" Special functions
+"""Special functions
 
 LAX decompositions for special functions into their StableHLO counterparts.
 """
@@ -91,7 +91,8 @@ def erf(x: ArrayLike) -> Array:
 
 def erfc(x: ArrayLike) -> Array:
   r"""Elementwise complementary error function:
-    :math:`\mathrm{erfc}(x) = 1 - \mathrm{erf}(x)`."""
+  :math:`\mathrm{erfc}(x) = 1 - \mathrm{erf}(x)`.
+  """
   return erfc_p.bind(x)
 
 def erf_inv(x: ArrayLike) -> Array:

--- a/jax/_src/lax/svd.py
+++ b/jax/_src/lax/svd.py
@@ -68,7 +68,6 @@ def _svd_tall_and_square_input(
     order, `v` is a unitary matrix of shape `n x n`, and
     `a = (u * s) @ v.T.conj()`. For `compute_uv=False`, only `s` is returned.
   """
-
   u_p, h, _, _ = lax.linalg.qdwh(
       a, is_hermitian=hermitian, max_iterations=max_iterations
   )

--- a/jax/_src/lazy_loader.py
+++ b/jax/_src/lazy_loader.py
@@ -31,7 +31,6 @@ def attach(package_name: str, submodules: Sequence[str]) -> tuple[
   __getattr__, __dir__, __all__ = lazy_loader.attach(__name__, ["sub1", "sub2"])
   ```
   """
-
   __all__: list[str] = list(submodules)
 
   def __getattr__(name: str) -> Any:

--- a/jax/_src/lru_cache.py
+++ b/jax/_src/lru_cache.py
@@ -40,17 +40,16 @@ class LRUCache(CacheInterface):
   Notably, when ``max_size`` is set to -1, the cache eviction
   is disabled, and the LRU cache functions as a normal cache
   without any size limitations.
+
+  Args:
+    path: The path to the cache directory.
+    max_size: The maximum size of the cache in bytes. Caching will be
+      disabled if this value is set to ``0``. A special value of ``-1``
+      indicates no limit, allowing the cache size to grow indefinitely.
+    lock_timeout_secs: (optional) The timeout for acquiring a file lock.
   """
 
   def __init__(self, path: str, *, max_size: int, lock_timeout_secs: float | None = 10):
-    """Args:
-
-      path: The path to the cache directory.
-      max_size: The maximum size of the cache in bytes. Caching will be
-        disabled if this value is set to ``0``. A special value of ``-1``
-        indicates no limit, allowing the cache size to grow indefinitely.
-      lock_timeout_secs: (optional) The timeout for acquiring a file lock.
-    """
     # TODO(ayx): add support for cloud other filesystems such as GCS
     if not self._is_local_filesystem(path):
       raise NotImplementedError("LRUCache only supports local filesystem at this time.")

--- a/jax/_src/maps.py
+++ b/jax/_src/maps.py
@@ -117,7 +117,6 @@ class SerialLoop:
   do not coincide in a named shape of any value in the program).
 
   Examples:
-
       # Processes `x` in a vectorized way, but in 20 micro-batches.
       xmap(f, in_axes=['i'], out_axes=[i], axis_resources={'i': SerialLoop(20)})(x)
 
@@ -162,7 +161,6 @@ def serial_loop(name: ResourceAxisName, length: int):
     length: Number of iterations.
 
   Examples:
-
     >>> x = jnp.linspace(0, jnp.pi, 4)
     ...
     >>> with serial_loop('l', len(x)):

--- a/jax/_src/mesh.py
+++ b/jax/_src/mesh.py
@@ -145,7 +145,6 @@ class Mesh(contextlib.ContextDecorator):
       rank of ``devices``.
 
   Examples:
-
     >>> from jax.experimental.pjit import pjit
     >>> from jax.sharding import Mesh
     >>> from jax.sharding import PartitionSpec as P

--- a/jax/_src/nn/initializers.py
+++ b/jax/_src/nn/initializers.py
@@ -373,12 +373,11 @@ def glorot_uniform(in_axis: int | Sequence[int] = -2,
     An initializer.
 
   Examples:
-
-  >>> import jax, jax.numpy as jnp
-  >>> initializer = jax.nn.initializers.glorot_uniform()
-  >>> initializer(jax.random.key(42), (2, 3), jnp.float32)  # doctest: +SKIP
-  Array([[ 0.50350785,  0.8088631 ,  0.81566876],
-         [-0.6393332 , -0.6865721 ,  0.11003882]], dtype=float32)
+    >>> import jax, jax.numpy as jnp
+    >>> initializer = jax.nn.initializers.glorot_uniform()
+    >>> initializer(jax.random.key(42), (2, 3), jnp.float32)  # doctest: +SKIP
+    Array([[ 0.50350785,  0.8088631 ,  0.81566876],
+          [-0.6393332 , -0.6865721 ,  0.11003882]], dtype=float32)
 
   .. _Glorot uniform initializer: http://proceedings.mlr.press/v9/glorot10a.html
   """
@@ -411,12 +410,11 @@ def glorot_normal(in_axis: int | Sequence[int] = -2,
     An initializer.
 
   Examples:
-
-  >>> import jax, jax.numpy as jnp
-  >>> initializer = jax.nn.initializers.glorot_normal()
-  >>> initializer(jax.random.key(42), (2, 3), jnp.float32)  # doctest: +SKIP
-  Array([[ 0.41770416,  0.75262755,  0.7619329 ],
-         [-0.5516644 , -0.6028657 ,  0.08661086]], dtype=float32)
+    >>> import jax, jax.numpy as jnp
+    >>> initializer = jax.nn.initializers.glorot_normal()
+    >>> initializer(jax.random.key(42), (2, 3), jnp.float32)  # doctest: +SKIP
+    Array([[ 0.41770416,  0.75262755,  0.7619329 ],
+          [-0.5516644 , -0.6028657 ,  0.08661086]], dtype=float32)
 
   .. _Glorot normal initializer: http://proceedings.mlr.press/v9/glorot10a.html
   """
@@ -449,12 +447,11 @@ def lecun_uniform(in_axis: int | Sequence[int] = -2,
     An initializer.
 
   Examples:
-
-  >>> import jax, jax.numpy as jnp
-  >>> initializer = jax.nn.initializers.lecun_uniform()
-  >>> initializer(jax.random.key(42), (2, 3), jnp.float32)  # doctest: +SKIP
-  Array([[ 0.56293887,  0.90433645,  0.9119454 ],
-         [-0.71479625, -0.7676109 ,  0.12302713]], dtype=float32)
+    >>> import jax, jax.numpy as jnp
+    >>> initializer = jax.nn.initializers.lecun_uniform()
+    >>> initializer(jax.random.key(42), (2, 3), jnp.float32)  # doctest: +SKIP
+    Array([[ 0.56293887,  0.90433645,  0.9119454 ],
+          [-0.71479625, -0.7676109 ,  0.12302713]], dtype=float32)
 
   .. _Lecun uniform initializer: https://arxiv.org/abs/1706.02515
   """
@@ -485,12 +482,11 @@ def lecun_normal(in_axis: int | Sequence[int] = -2,
     An initializer.
 
   Examples:
-
-  >>> import jax, jax.numpy as jnp
-  >>> initializer = jax.nn.initializers.lecun_normal()
-  >>> initializer(jax.random.key(42), (2, 3), jnp.float32)  # doctest: +SKIP
-  Array([[ 0.46700746,  0.8414632 ,  0.8518669 ],
-         [-0.61677957, -0.67402434,  0.09683388]], dtype=float32)
+    >>> import jax, jax.numpy as jnp
+    >>> initializer = jax.nn.initializers.lecun_normal()
+    >>> initializer(jax.random.key(42), (2, 3), jnp.float32)  # doctest: +SKIP
+    Array([[ 0.46700746,  0.8414632 ,  0.8518669 ],
+          [-0.61677957, -0.67402434,  0.09683388]], dtype=float32)
 
   .. _Lecun normal initializer: https://arxiv.org/abs/1706.02515
   """
@@ -521,12 +517,11 @@ def he_uniform(in_axis: int | Sequence[int] = -2,
     An initializer.
 
   Examples:
-
-  >>> import jax, jax.numpy as jnp
-  >>> initializer = jax.nn.initializers.he_uniform()
-  >>> initializer(jax.random.key(42), (2, 3), jnp.float32)  # doctest: +SKIP
-  Array([[ 0.79611576,  1.2789248 ,  1.2896855 ],
-         [-1.0108745 , -1.0855657 ,  0.17398663]], dtype=float32)
+    >>> import jax, jax.numpy as jnp
+    >>> initializer = jax.nn.initializers.he_uniform()
+    >>> initializer(jax.random.key(42), (2, 3), jnp.float32)  # doctest: +SKIP
+    Array([[ 0.79611576,  1.2789248 ,  1.2896855 ],
+          [-1.0108745 , -1.0855657 ,  0.17398663]], dtype=float32)
 
   .. _He uniform initializer: https://arxiv.org/abs/1502.01852
   """
@@ -559,12 +554,11 @@ def he_normal(in_axis: int | Sequence[int] = -2,
     An initializer.
 
   Examples:
-
-  >>> import jax, jax.numpy as jnp
-  >>> initializer = jax.nn.initializers.he_normal()
-  >>> initializer(jax.random.key(42), (2, 3), jnp.float32)  # doctest: +SKIP
-  Array([[ 0.6604483 ,  1.1900088 ,  1.2047218 ],
-         [-0.87225807, -0.95321447,  0.1369438 ]], dtype=float32)
+    >>> import jax, jax.numpy as jnp
+    >>> initializer = jax.nn.initializers.he_normal()
+    >>> initializer(jax.random.key(42), (2, 3), jnp.float32)  # doctest: +SKIP
+    Array([[ 0.6604483 ,  1.1900088 ,  1.2047218 ],
+          [-0.87225807, -0.95321447,  0.1369438 ]], dtype=float32)
 
   .. _He normal initializer: https://arxiv.org/abs/1502.01852
   """
@@ -592,12 +586,11 @@ def orthogonal(scale: RealNumeric = 1.0,
     An orthogonal initializer.
 
   Examples:
-
-  >>> import jax, jax.numpy as jnp
-  >>> initializer = jax.nn.initializers.orthogonal()
-  >>> initializer(jax.random.key(42), (2, 3), jnp.float32)  # doctest: +SKIP
-  Array([[ 3.9026976e-01,  7.2495741e-01, -5.6756169e-01],
-         [ 8.8047469e-01, -4.7409311e-01, -1.3157725e-04]],            dtype=float32)
+    >>> import jax, jax.numpy as jnp
+    >>> initializer = jax.nn.initializers.orthogonal()
+    >>> initializer(jax.random.key(42), (2, 3), jnp.float32)  # doctest: +SKIP
+    Array([[ 3.9026976e-01,  7.2495741e-01, -5.6756169e-01],
+          [ 8.8047469e-01, -4.7409311e-01, -1.3157725e-04]],            dtype=float32)
   """
   def init(key: KeyArray,
            shape: core.Shape,
@@ -635,22 +628,20 @@ def delta_orthogonal(
     be 3D, 4D, or 5D.
 
   Examples:
-
-  >>> import jax, jax.numpy as jnp
-  >>> initializer = jax.nn.initializers.delta_orthogonal()
-  >>> initializer(jax.random.key(42), (3, 3, 3), jnp.float32)  # doctest: +SKIP
-  Array([[[ 0.        ,  0.        ,  0.        ],
-          [ 0.        ,  0.        ,  0.        ],
-          [ 0.        ,  0.        ,  0.        ]],
-  <BLANKLINE>
-         [[ 0.27858758, -0.7949833 , -0.53887904],
-          [ 0.9120717 ,  0.04322892,  0.40774566],
-          [-0.30085585, -0.6050892 ,  0.73712474]],
-  <BLANKLINE>
-         [[ 0.        ,  0.        ,  0.        ],
-          [ 0.        ,  0.        ,  0.        ],
-          [ 0.        ,  0.        ,  0.        ]]], dtype=float32)
-
+    >>> import jax, jax.numpy as jnp
+    >>> initializer = jax.nn.initializers.delta_orthogonal()
+    >>> initializer(jax.random.key(42), (3, 3, 3), jnp.float32)  # doctest: +SKIP
+    Array([[[ 0.        ,  0.        ,  0.        ],
+            [ 0.        ,  0.        ,  0.        ],
+            [ 0.        ,  0.        ,  0.        ]],
+    <BLANKLINE>
+          [[ 0.27858758, -0.7949833 , -0.53887904],
+            [ 0.9120717 ,  0.04322892,  0.40774566],
+            [-0.30085585, -0.6050892 ,  0.73712474]],
+    <BLANKLINE>
+          [[ 0.        ,  0.        ,  0.        ],
+            [ 0.        ,  0.        ,  0.        ],
+            [ 0.        ,  0.        ,  0.        ]]], dtype=float32)
 
   .. _delta orthogonal initializer: https://arxiv.org/abs/1806.05393
   """

--- a/jax/_src/numpy/array_methods.py
+++ b/jax/_src/numpy/array_methods.py
@@ -89,7 +89,8 @@ def _clip(number: ArrayLike,
           min: ArrayLike | None = None, max: ArrayLike | None = None) -> Array:
   """Return an array whose values are limited to a specified range.
 
-  Refer to :func:`jax.numpy.clip` for full documentation."""
+  Refer to :func:`jax.numpy.clip` for full documentation.
+  """
   return lax_numpy.clip(number, min=min, max=max)
 
 
@@ -308,7 +309,8 @@ def _compress_method(a: ArrayLike, condition: ArrayLike,
                      size: int | None = None, fill_value: ArrayLike = 0) -> Array:
   """Return selected slices of this array along given axis.
 
-  Refer to :func:`jax.numpy.compress` for full documentation."""
+  Refer to :func:`jax.numpy.compress` for full documentation.
+  """
   return lax_numpy.compress(condition, a, axis=axis, out=out,
                             size=size, fill_value=fill_value)
 
@@ -388,10 +390,8 @@ class _IndexUpdateHelper:
   By default, JAX assumes that all indices are in-bounds. Alternative out-of-bound
   index semantics can be specified via the ``mode`` parameter (see below).
 
-  Arguments
-  ---------
-  mode : str
-      Specify out-of-bound indexing mode. Options are:
+  Args:
+    mode (str): Specify out-of-bound indexing mode. Options are:
 
       - ``"promise_in_bounds"``: (default) The user promises that indices are in bounds.
         No additional checking will be performed. In practice, this means that
@@ -403,39 +403,35 @@ class _IndexUpdateHelper:
         argument specifies the value that will be returned.
 
         See :class:`jax.lax.GatherScatterMode` for more details.
+    indices_are_sorted (bool): If True, the implementation will assume that the
+      indices passed to ``at[]`` are sorted in ascending order, which can lead to
+      more efficient execution on some backends.
+    unique_indices (bool): If True, the implementation will assume that the indices
+      passed to ``at[]`` are unique, which can result in more efficient execution on
+      some backends.
+    fill_value: Only applies to the ``get()`` method: the fill value to return for
+      out-of-bounds slices when `mode` is ``'fill'``. Ignored otherwise. Defaults to
+      ``NaN`` for inexact types, the largest negative value for signed types, the
+      largest positive value for unsigned types, and ``True`` for booleans.
 
-  indices_are_sorted : bool
-      If True, the implementation will assume that the indices passed to ``at[]``
-      are sorted in ascending order, which can lead to more efficient execution
-      on some backends.
-  unique_indices : bool
-      If True, the implementation will assume that the indices passed to ``at[]``
-      are unique, which can result in more efficient execution on some backends.
-  fill_value : Any
-      Only applies to the ``get()`` method: the fill value to return for out-of-bounds
-      slices when `mode` is ``'fill'``. Ignored otherwise. Defaults to ``NaN`` for
-      inexact types, the largest negative value for signed types, the largest positive
-      value for unsigned types, and ``True`` for booleans.
-
-  Examples
-  --------
-  >>> x = jnp.arange(5.0)
-  >>> x
-  Array([0., 1., 2., 3., 4.], dtype=float32)
-  >>> x.at[2].add(10)
-  Array([ 0.,  1., 12.,  3.,  4.], dtype=float32)
-  >>> x.at[10].add(10)  # out-of-bounds indices are ignored
-  Array([0., 1., 2., 3., 4.], dtype=float32)
-  >>> x.at[20].add(10, mode='clip')
-  Array([ 0.,  1.,  2.,  3., 14.], dtype=float32)
-  >>> x.at[2].get()
-  Array(2., dtype=float32)
-  >>> x.at[20].get()  # out-of-bounds indices clipped
-  Array(4., dtype=float32)
-  >>> x.at[20].get(mode='fill')  # out-of-bounds indices filled with NaN
-  Array(nan, dtype=float32)
-  >>> x.at[20].get(mode='fill', fill_value=-1)  # custom fill value
-  Array(-1., dtype=float32)
+  Examples:
+    >>> x = jnp.arange(5.0)
+    >>> x
+    Array([0., 1., 2., 3., 4.], dtype=float32)
+    >>> x.at[2].add(10)
+    Array([ 0.,  1., 12.,  3.,  4.], dtype=float32)
+    >>> x.at[10].add(10)  # out-of-bounds indices are ignored
+    Array([0., 1., 2., 3., 4.], dtype=float32)
+    >>> x.at[20].add(10, mode='clip')
+    Array([ 0.,  1.,  2.,  3., 14.], dtype=float32)
+    >>> x.at[2].get()
+    Array(2., dtype=float32)
+    >>> x.at[20].get()  # out-of-bounds indices clipped
+    Array(4., dtype=float32)
+    >>> x.at[20].get(mode='fill')  # out-of-bounds indices filled with NaN
+    Array(nan, dtype=float32)
+    >>> x.at[20].get(mode='fill', fill_value=-1)  # custom fill value
+    Array(-1., dtype=float32)
   """
   __slots__ = ("array",)
 

--- a/jax/_src/numpy/index_tricks.py
+++ b/jax/_src/numpy/index_tricks.py
@@ -291,7 +291,6 @@ class CClass(_AxisConcat):
     ``jnp.r_``: Concatenates slices, scalars and array-like objects along the first axis.
 
   Examples:
-
     >>> a = jnp.arange(6).reshape((2,3))
     >>> jnp.c_[a,a]
     Array([[0, 1, 2, 0, 1, 2],

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -299,18 +299,17 @@ def _convert_and_clip_integer(val: ArrayLike, dtype: DType) -> Array:
   Returns:
     equivalent of val in new dtype
 
-  Examples
-  --------
-  Normal integer type conversion will wrap:
+  Examples:
+    Normal integer type conversion will wrap:
 
-  >>> val = jnp.uint32(0xFFFFFFFF)
-  >>> val.astype('int32')
-  Array(-1, dtype=int32)
+    >>> val = jnp.uint32(0xFFFFFFFF)
+    >>> val.astype('int32')
+    Array(-1, dtype=int32)
 
-  This function clips to the values representable in the new type:
+    This function clips to the values representable in the new type:
 
-  >>> _convert_and_clip_integer(val, 'int32')
-  Array(2147483647, dtype=int32)
+    >>> _convert_and_clip_integer(val, 'int32')
+    Array(2147483647, dtype=int32)
   """
   val = val if isinstance(val, Array) else asarray(val)
   dtype = dtypes.canonicalize_dtype(dtype)
@@ -1066,7 +1065,6 @@ def angle(z: ArrayLike, deg: bool = False) -> Array:
     shape as ``z`` of dtype float.
 
   Examples:
-
     If ``z`` is a number
 
     >>> z1 = 2+3j
@@ -2410,7 +2408,6 @@ def nonzero(a: ArrayLike, *, size: int | None = None,
     - :func:`jax.numpy.where`
 
   Examples:
-
     One-dimensional array returns a length-1 tuple of indices:
 
     >>> x = jnp.array([0, 5, 0, 6, 0, 7])

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -1455,7 +1455,6 @@ def cross(x1: ArrayLike, x2: ArrayLike, /, *, axis=-1):
     :func:`jax.numpy.cross`: more flexible cross-product API.
 
   Examples:
-
     Showing that :math:`\hat{x} \times \hat{y} = \hat{z}`:
 
     >>> x = jnp.array([1., 0., 0.])
@@ -2103,7 +2102,6 @@ def cond(x: ArrayLike, p=None):
     :func:`jax.numpy.linalg.norm`
 
   Examples:
-
     Well-conditioned matrix:
 
     >>> x = jnp.array([[1, 2],

--- a/jax/_src/numpy/polynomial.py
+++ b/jax/_src/numpy/polynomial.py
@@ -128,14 +128,14 @@ def polyfit(x: Array, y: Array, deg: int, rcond: float | None = None,
 
   .. math::
 
-	   y = p(x) = p[0] x^{deg} + p[1] x^{deg - 1} + ... + p[deg]
+      y = p(x) = p[0] x^{deg} + p[1] x^{deg - 1} + ... + p[deg]
 
   Args:
     x: Array of data points of shape ``(M,)``.
     y: Array of data points of shape ``(M,)`` or ``(M, K)``.
     deg: Degree of the polynomials. It must be specified statically.
     rcond: Relative condition number of the fit. Default value is ``len(x) * eps``.
-       It must be specified statically.
+      It must be specified statically.
     full: Switch that controls the return value. Default is ``False`` which
       restricts the return value to the array of polynomail coefficients ``p``.
       If ``True``, the function returns a tuple ``(p, resids, rank, s, rcond)``.
@@ -296,7 +296,6 @@ def poly(seq_of_zeros: Array) -> Array:
     output is always promoted to inexact.
 
   Note:
-
     :func:`jax.numpy.poly` differs from :func:`numpy.poly`:
 
     - When the input is a scalar, ``np.poly`` raises a ``TypeError``, whereas
@@ -312,7 +311,6 @@ def poly(seq_of_zeros: Array) -> Array:
       coefficients.
 
   Example:
-
     Scalar inputs:
 
     >>> jnp.poly(1)
@@ -385,7 +383,6 @@ def polyval(p: Array, x: Array, *, unroll: int = 16) -> Array:
     An array of same shape as ``x``.
 
   Note:
-
     The ``unroll`` parameter is JAX specific. It does not affect correctness but
     can have a major impact on performance for evaluating high-order polynomials.
     The parameter controls the number of unrolled steps with ``lax.scan`` inside
@@ -454,7 +451,6 @@ def polyint(p: Array, m: int = 1, k: int | None = None) -> Array:
     - :func:`jax.numpy.polyval`: Evaluates a polynomial at specific values.
 
   Examples:
-
     The first order integration of the polynomial :math:`12 x^2 + 12 x + 6` is
     :math:`4 x^3 + 6 x^2 + 6 x`.
 
@@ -525,7 +521,6 @@ def polyder(p: Array, m: int = 1) -> Array:
     - :func:`jax.numpy.polyval`: Evaluates a polynomial at specific values.
 
   Examples:
-
     The first order derivative of the polynomial :math:`2 x^3 - 5 x^2 + 3 x - 1`
     is :math:`6 x^2 - 10 x +3`:
 

--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -258,7 +258,6 @@ def sum(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
     - :func:`jax.numpy.min`: Compute the minimum of array elements over given axis.
 
   Examples:
-
     By default, the sum is computed along all the axes.
 
     >>> x = jnp.array([[1, 3, 4, 2],
@@ -358,7 +357,6 @@ def max(a: ArrayLike, axis: Axis = None, out: None = None,
       axis.
 
   Examples:
-
     By default, ``jnp.max`` computes the maximum of elements along all the axes.
 
     >>> x = jnp.array([[9, 3, 4, 5],

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -281,7 +281,8 @@ def promote_dtypes(*args: ArrayLike) -> list[Array]:
 def promote_dtypes_inexact(*args: ArrayLike) -> list[Array]:
   """Convenience function to apply Numpy argument dtype promotion.
 
-  Promotes arguments to an inexact type."""
+  Promotes arguments to an inexact type.
+  """
   to_dtype, weak_type = dtypes._lattice_result_type(*args)
   to_dtype = dtypes.canonicalize_dtype(to_dtype, allow_extended_dtype=True)  # type: ignore[assignment]
   to_dtype_inexact = dtypes.to_inexact_dtype(to_dtype)
@@ -292,7 +293,8 @@ def promote_dtypes_inexact(*args: ArrayLike) -> list[Array]:
 def promote_dtypes_numeric(*args: ArrayLike) -> list[Array]:
   """Convenience function to apply Numpy argument dtype promotion.
 
-  Promotes arguments to a numeric (non-bool) type."""
+  Promotes arguments to a numeric (non-bool) type.
+  """
   to_dtype, weak_type = dtypes._lattice_result_type(*args)
   to_dtype = dtypes.canonicalize_dtype(to_dtype)
   to_dtype_numeric = dtypes.to_numeric_dtype(to_dtype)
@@ -303,7 +305,8 @@ def promote_dtypes_numeric(*args: ArrayLike) -> list[Array]:
 def promote_dtypes_complex(*args: ArrayLike) -> list[Array]:
   """Convenience function to apply Numpy argument dtype promotion.
 
-  Promotes arguments to a complex type."""
+  Promotes arguments to a complex type.
+  """
   to_dtype, weak_type = dtypes._lattice_result_type(*args)
   to_dtype = dtypes.canonicalize_dtype(to_dtype)
   to_dtype_complex = dtypes.to_complex_dtype(to_dtype)
@@ -391,7 +394,8 @@ def promote_args_numeric(fun_name: str, *args: ArrayLike) -> list[Array]:
 def promote_args_inexact(fun_name: str, *args: ArrayLike) -> list[Array]:
   """Convenience function to apply Numpy argument shape and dtype promotion.
 
-  Promotes non-inexact types to an inexact type."""
+  Promotes non-inexact types to an inexact type.
+  """
   check_arraylike(fun_name, *args)
   _check_no_float0s(fun_name, *args)
   check_for_prngkeys(fun_name, *args)

--- a/jax/_src/pallas/mosaic/pipeline.py
+++ b/jax/_src/pallas/mosaic/pipeline.py
@@ -486,14 +486,14 @@ class Scheduler:
               ):
     """Initializes scheduler.
 
-      Args:
-        step: inner step number.
-        grid: pallas grid for BufferedRefs.
-        grid_offsets: offsets for grid indices (used for megacore).
-        first_cycle: whether this is the first invocation of the pipeline.
-        last_cycle: whether this is the last invocation of the pipeline.
-        init_accumulators: do we zero-initialize accumulator state for this
-          invocation of the pipeline.
+    Args:
+      step: inner step number.
+      grid: pallas grid for BufferedRefs.
+      grid_offsets: offsets for grid indices (used for megacore).
+      first_cycle: whether this is the first invocation of the pipeline.
+      last_cycle: whether this is the last invocation of the pipeline.
+      init_accumulators: do we zero-initialize accumulator state for this
+        invocation of the pipeline.
     """
     self.step = step
     self.grid = grid

--- a/jax/_src/pallas/mosaic/primitives.py
+++ b/jax/_src/pallas/mosaic/primitives.py
@@ -644,6 +644,7 @@ def make_async_remote_copy(src_ref, dst_ref, send_sem, recv_sem, device_id,
     recv_sem: The semaphore on the destination device.
     device_id: The device id of the destination device.
     device_id_type: The type of the device id.
+
   Returns:
     An AsyncCopyDescriptor.
   """

--- a/jax/_src/pallas/mosaic/random.py
+++ b/jax/_src/pallas/mosaic/random.py
@@ -37,7 +37,6 @@ SUPPORTED_CONVERSION_KEYS = ["rbg", "unsafe_rbg", "pallas_tpu"]
 
 def to_pallas_key(key: jax_prng.PRNGKeyArray) -> jax_prng.PRNGKeyArray:
   """Helper function for converting non-Pallas PRNG keys into Pallas keys."""
-
   # Only allow conversion from RBG -> Pallas keys.
   # There is no technical reason why we cannot support Threefry here, but
   # this reduces the chance of unintended behavior where the pallas PRNG

--- a/jax/_src/pallas/mosaic_gpu/lowering.py
+++ b/jax/_src/pallas/mosaic_gpu/lowering.py
@@ -59,7 +59,6 @@ class ModuleContext:
 
   def scratch_view(self, shapes: list[jax.ShapeDtypeStruct]) -> list[ir.Value]:
     """Return memref views into the runtime scrath based on the shapes."""
-
     smem_scratch_bytes = math.prod(ir.MemRefType(self.runtime_smem.type).shape)
     required_scratch_bytes = sum(
         math.prod(sh.shape) * jnp.dtype(sh.dtype).itemsize for sh in shapes

--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -411,7 +411,6 @@ def _broadcast_input_output_aliases(
   mapped. If the input is mapped, but on a different axis, we tranpose the input
   to match the output.
   """
-
   args_ = list(args)
   dims_ = list(dims)
   for input_index, _ in input_output_aliases:
@@ -451,7 +450,6 @@ def _batch_with_explicit_loop(
   to the current iteration index and dynamic_updates an (initially empty) output
   allocation.
   """
-
   if not dims:
     raise NotImplementedError("vmapping pallas_call with no arguments.")
 

--- a/jax/_src/pallas/primitives.py
+++ b/jax/_src/pallas/primitives.py
@@ -317,7 +317,6 @@ def _pad_values_to_avoid_dynamic_slice_oob_shift(value,
 
   unpad=True performs the inverse operation
   """
-
   padding_config = tuple((0, slice_size, 0) for slice_size in slice_sizes)
   if unpad:
     padding_config = tuple((-low, -high, -interior)

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -2482,6 +2482,7 @@ def with_sharding_constraint(x, shardings):
     x: PyTree of jax.Arrays which will have their shardings constrained
     shardings: PyTree of sharding specifications. Valid values are the same as for
       the ``in_shardings`` argument of :func:`jax.experimental.pjit`.
+
   Returns:
     x_with_shardings: PyTree of jax.Arrays with specified sharding constraints.
 

--- a/jax/_src/profiler.py
+++ b/jax/_src/profiler.py
@@ -326,7 +326,6 @@ def annotate_function(func: Callable, name: str | None = None,
 
   >>> result = f(jnp.ones((1000, 1000)))
   """
-
   name = name or getattr(func, '__qualname__', None)
   name = name or func.__name__
   @wraps(func)

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -757,6 +757,7 @@ def multivariate_normal(key: KeyArrayLike,
     method: optional, a method to compute the factor of ``cov``.
       Must be one of 'svd', 'eigh', and 'cholesky'. Default 'cholesky'. For
       singular covariance matrices, use 'svd' or 'eigh'.
+
   Returns:
     A random array with the specified dtype and shape given by
     ``shape + mean.shape[-1:]`` if ``shape`` is not None, or else
@@ -2360,7 +2361,7 @@ def lognormal(key: KeyArrayLike,
               sigma: RealArray = np.float32(1),
               shape: Shape | None = None,
               dtype: DTypeLikeFloat = float) -> Array:
-  r""" Sample lognormal random values with given shape and float dtype.
+  r"""Sample lognormal random values with given shape and float dtype.
 
   The values are distributed according to the probability density function:
 
@@ -2621,7 +2622,6 @@ def clone(key):
   this function operates as an identity.
 
   Examples:
-
     >>> import jax
     >>> key = jax.random.key(0)
     >>> data = jax.random.uniform(key)

--- a/jax/_src/scipy/fft.py
+++ b/jax/_src/scipy/fft.py
@@ -158,7 +158,6 @@ def dctn(x: Array, type: int = 2,
     - :func:`jax.scipy.fft.idctn`: multidimensional inverse DCT
 
   Examples:
-
     ``jax.scipy.fft.dctn`` computes the transform along both the axes by default
     when ``axes`` argument is ``None``.
 
@@ -241,7 +240,6 @@ def idct(x: Array, type: int = 2, n: int | None = None,
     - :func:`jax.scipy.fft.idctn`: multidimensional inverse DCT
 
   Examples:
-
     >>> x = jax.random.normal(jax.random.key(0), (3, 3))
     >>> with jnp.printoptions(precision=2, suppress=True):
     ...    print(jax.scipy.fft.idct(x))
@@ -333,7 +331,6 @@ def idctn(x: Array, type: int = 2,
     - :func:`jax.scipy.fft.idct`: one-dimensional inverse DCT
 
   Examples:
-
     ``jax.scipy.fft.idctn`` computes the transform along both the axes by default
     when ``axes`` argument is ``None``.
 

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -327,7 +327,7 @@ def det(a: ArrayLike, overwrite_a: bool = False, check_finite: bool = True) -> A
     overwrite_a: unused by JAX
     check_finite: unused by JAX
 
-  Returns
+  Returns:
     Determinant of shape ``a.shape[:-2]``
 
   See Also:
@@ -1139,7 +1139,6 @@ def expm(A: ArrayLike, *, upper_triangular: bool = False, max_squarings: int = 1
     :func:`jax.scipy.linalg.expm_frechet`
 
   Examples:
-
     ``expm`` is the matrix exponential, and has similar properties to the more
     familiar scalar exponential. For scalars ``a`` and ``b``, :math:`e^{a + b}
     = e^a e^b`. However, for matrices, this property only holds when ``A`` and
@@ -1669,7 +1668,6 @@ def polar(a: ArrayLike, side: str = 'right', *, method: str = 'qdwh', eps: float
     whether ``side`` is ``"right"`` or ``"left"``, respectively.
 
   Examples:
-
     Polar decomposition of a 3x3 matrix:
 
     >>> a = jnp.array([[1., 2., 3.],

--- a/jax/_src/scipy/optimize/bfgs.py
+++ b/jax/_src/scipy/optimize/bfgs.py
@@ -93,7 +93,6 @@ def minimize_bfgs(
   Returns:
     Optimization result.
   """
-
   if maxiter is None:
     maxiter = jnp.size(x0) * 200
 

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -951,7 +951,6 @@ def ndtri(p: ArrayLike) -> Array:
 
 def _ndtri(p: ArrayLike) -> Array:
   """Implements ndtri core logic."""
-
   # Constants used in piece-wise rational approximations. Taken from the cephes
   # library:
   # https://root.cern.ch/doc/v608/SpecFuncCephesInv_8cxx_source.html
@@ -1403,7 +1402,6 @@ def _gen_recurrence_mask(
   Returns:
     Arrays representing the mask used by the recurrence relations.
   """
-
   # Computes all coefficients.
   m_mat, l_mat = jnp.meshgrid(
     jnp.arange(l_max + 1, dtype=dtype),
@@ -1451,11 +1449,11 @@ def _gen_derivatives(p: Array,
       points.
     x: A vector of type `float32` or `float64` containing the sampled points.
     is_normalized: True if the associated Legendre functions are normalized.
+
   Returns:
     The 3D array representing the derivatives of associated Legendre functions
     of the first kind.
   """
-
   num_m, num_l, num_x = p.shape
 
   # p_{l-1}^m.
@@ -1742,7 +1740,6 @@ def _sph_harm(m: Array,
               phi: Array,
               n_max: int) -> Array:
   """Computes the spherical harmonics."""
-
   cos_colatitude = jnp.cos(phi)
 
   legendre = _gen_associated_legendre(n_max, cos_colatitude, True)
@@ -1795,7 +1792,6 @@ def sph_harm(m: Array,
   Returns:
     A 1D array containing the spherical harmonics at (m, n, theta, phi).
   """
-
   if jnp.isscalar(phi):
     phi = jnp.array([phi])
 
@@ -2397,7 +2393,6 @@ def _poch_z_derivative(z, m):
   Defined in :
   https://functions.wolfram.com/GammaBetaErf/Pochhammer/20/01/01/
   """
-
   return (digamma(z + m) - digamma(z)) * poch(z, m)
 
 
@@ -2406,7 +2401,6 @@ def _poch_m_derivative(z, m):
   Defined in :
   https://functions.wolfram.com/GammaBetaErf/Pochhammer/20/01/02/
   """
-
   return digamma(z + m) * poch(z, m)
 
 
@@ -2422,7 +2416,6 @@ def _hyp1f1_serie(a, b, x):
   See Eq. 3.2 and associated method (a) from PEARSON, OLVER & PORTER 2014
   https://doi.org/10.48550/arXiv.1407.7786
   """
-
   precision = jnp.finfo(x.dtype).eps
 
   def body(state):
@@ -2449,7 +2442,6 @@ def _hyp1f1_asymptotic(a, b, x):
   See Eq. 3.8 and simplification for real inputs from PEARSON, OLVER & PORTER 2014
   https://doi.org/10.48550/arXiv.1407.7786
   """
-
   precision = jnp.finfo(x.dtype).eps
 
   def body(state):
@@ -2478,7 +2470,6 @@ def _hyp1f1_a_derivative(a, b, x):
   Define it as a serie using :
   https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric1F1/20/01/01/
   """
-
   precision = jnp.finfo(x.dtype).eps
 
   def body(state):
@@ -2506,7 +2497,6 @@ def _hyp1f1_b_derivative(a, b, x):
   Define it as a serie using :
   https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric1F1/20/01/02/
   """
-
   precision = jnp.finfo(x.dtype).eps
 
   def body(state):
@@ -2533,7 +2523,6 @@ def _hyp1f1_x_derivative(a, b, x):
   Define it as a serie using :
   https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric1F1/20/01/04/
   """
-
   return a / b * hyp1f1(a + 1, b + 1, x)
 
 

--- a/jax/_src/scipy/stats/_core.py
+++ b/jax/_src/scipy/stats/_core.py
@@ -162,7 +162,6 @@ def rankdata(
     array of ranks along the specified axis.
 
   Examples:
-
     >>> x = jnp.array([10, 30, 20])
     >>> rankdata(x)
     Array([1., 3., 2.], dtype=float32)

--- a/jax/_src/sharding.py
+++ b/jax/_src/sharding.py
@@ -133,7 +133,7 @@ class Sharding:
   @functools.cached_property
   def addressable_devices(self) -> set[Device]:
     """The set of devices in the :class:`Sharding` that are addressable by the
-       current process.
+    current process.
     """
     # Add a fast path for single controller runtimes.
     if xb.process_count() == 1:

--- a/jax/_src/sharding_impls.py
+++ b/jax/_src/sharding_impls.py
@@ -184,7 +184,6 @@ class NamedSharding(sharding.Sharding):
     spec: A :class:`jax.sharding.PartitionSpec` object.
 
   Examples:
-
     >>> from jax.sharding import Mesh
     >>> from jax.sharding import PartitionSpec as P
     >>> mesh = Mesh(np.array(jax.devices()).reshape(2, 4), ('x', 'y'))
@@ -309,7 +308,6 @@ class SingleDeviceSharding(sharding.Sharding):
     device: A single :py:class:`Device`.
 
   Examples:
-
     >>> single_device_sharding = jax.sharding.SingleDeviceSharding(
     ...     jax.devices()[0])
   """
@@ -1462,7 +1460,6 @@ def local_to_global_shape(
   Returns:
     global_shape with Nones in non-uniform dimensions.
   """
-
   global_shape : list[int | None] = [None] * len(local_shape)
   for i, local_dim in enumerate(local_shape):
     try:

--- a/jax/_src/sharding_specs.py
+++ b/jax/_src/sharding_specs.py
@@ -150,6 +150,7 @@ def spec_to_indices(shape: Sequence[int],
 def pmap_sharding_spec(nrep, axis_size, sharded_shape: Sequence[int],
                        map_axis: int | None) -> ShardingSpec:
   """Sharding spec for arguments or results of a pmap.
+
   Args:
     nrep: number of local XLA replicas (product of local axis sizes)
     axis_size: local axis size for outer pmap

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -194,7 +194,6 @@ def unaccelerate_getattr_deprecation(module, name):
 @contextmanager
 def capture_stdout() -> Generator[Callable[[], str | None], None, None]:
   """Context manager to capture all stdout output."""
-
   # The encoding should also work on windows, the default doesn't necessarily.
   with tempfile.NamedTemporaryFile(mode="w+", delete=True, encoding='utf-8') as f:
     original_stdout = os.dup(sys.stdout.fileno())
@@ -480,7 +479,7 @@ def is_cuda_compute_capability_at_least(capability: str) -> bool:
   return d.compute_capability >= capability
 
 def _get_device_tags():
-  """returns a set of tags defined for the device under test"""
+  """Returns a set of tags defined for the device under test"""
   if is_device_rocm():
     device_tags = {device_under_test(), "rocm"}
   elif is_device_cuda():
@@ -527,7 +526,8 @@ def run_on_devices(*enabled_devices):
 
 def device_supports_buffer_donation():
   """A decorator for test methods to run the test only on devices that support
-  buffer donation."""
+  buffer donation.
+  """
   return _device_filter(
       lambda: test_device_matches(mlir._platforms_with_donation)
   )
@@ -1518,7 +1518,6 @@ def set_env(**kwargs):
   """Context manager to temporarily set/unset one or more environment variables.
 
   Examples:
-
     >>> import os
     >>> os.environ['my_var'] = 'original'
 
@@ -1561,24 +1560,24 @@ def numpy_vecdot(x, y, axis):
 
 def complex_plane_sample(dtype, size_re=10, size_im=None):
   """Return a 2-D array of complex numbers that covers the complex plane
-     with a grid of samples.
+  with a grid of samples.
 
-     The size of the grid is (3 + 2 * size_im) x (3 + 2 * size_re)
-     that includes infinity points, extreme finite points, and the
-     specified number of points from real and imaginary axis.
+  The size of the grid is (3 + 2 * size_im) x (3 + 2 * size_re)
+  that includes infinity points, extreme finite points, and the
+  specified number of points from real and imaginary axis.
 
-     For example:
+  For example:
 
-     >>> print(complex_plane_sample(np.complex64, 0, 3))
-     [[-inf          -infj   0.          -infj  inf          -infj]
-      [-inf-3.4028235e+38j   0.-3.4028235e+38j  inf-3.4028235e+38j]
-      [-inf-2.0000000e+00j   0.-2.0000000e+00j  inf-2.0000000e+00j]
-      [-inf-1.1754944e-38j   0.-1.1754944e-38j  inf-1.1754944e-38j]
-      [-inf+0.0000000e+00j   0.+0.0000000e+00j  inf+0.0000000e+00j]
-      [-inf+1.1754944e-38j   0.+1.1754944e-38j  inf+1.1754944e-38j]
-      [-inf+2.0000000e+00j   0.+2.0000000e+00j  inf+2.0000000e+00j]
-      [-inf+3.4028235e+38j   0.+3.4028235e+38j  inf+3.4028235e+38j]
-      [-inf          +infj   0.          +infj  inf          +infj]]
+  >>> print(complex_plane_sample(np.complex64, 0, 3))
+  [[-inf          -infj   0.          -infj  inf          -infj]
+   [-inf-3.4028235e+38j   0.-3.4028235e+38j  inf-3.4028235e+38j]
+   [-inf-2.0000000e+00j   0.-2.0000000e+00j  inf-2.0000000e+00j]
+   [-inf-1.1754944e-38j   0.-1.1754944e-38j  inf-1.1754944e-38j]
+   [-inf+0.0000000e+00j   0.+0.0000000e+00j  inf+0.0000000e+00j]
+   [-inf+1.1754944e-38j   0.+1.1754944e-38j  inf+1.1754944e-38j]
+   [-inf+2.0000000e+00j   0.+2.0000000e+00j  inf+2.0000000e+00j]
+   [-inf+3.4028235e+38j   0.+3.4028235e+38j  inf+3.4028235e+38j]
+   [-inf          +infj   0.          +infj  inf          +infj]]
 
   """
   if size_im is None:

--- a/jax/_src/traceback_util.py
+++ b/jax/_src/traceback_util.py
@@ -150,7 +150,7 @@ def _filtering_mode() -> str:
   return mode
 
 def api_boundary(fun: C) -> C:
-  '''Wraps ``fun`` to form a boundary for filtering exception tracebacks.
+  """Wraps ``fun`` to form a boundary for filtering exception tracebacks.
 
   When an exception occurs below ``fun``, this appends to it a custom
   ``__cause__`` that carries a filtered traceback. The traceback imitates the
@@ -170,7 +170,7 @@ def api_boundary(fun: C) -> C:
   ``g``. Because the function returned by :func:`~jax.jit` is annotated as an
   :func:`~api_boundary`, such an exception is accompanied by an additional
   traceback that excludes the frames specific to JAX's implementation.
-  '''
+  """
 
   @functools.wraps(fun)
   def reraise_with_filtered_traceback(*args, **kwargs):

--- a/jax/_src/tree.py
+++ b/jax/_src/tree.py
@@ -136,7 +136,6 @@ def map(f: Callable[..., Any],
     ``rest``.
 
   Examples:
-
     >>> import jax
     >>> jax.tree.map(lambda x: x + 1, {"x": 7, "y": 42})
     {'x': 8, 'y': 43}

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -618,7 +618,7 @@ def prefix_errors(prefix_tree: Any, full_tree: Any,
 def equality_errors(
     tree1: Any, tree2: Any, is_leaf: Callable[[Any], bool] | None = None,
 ) -> Iterable[tuple[KeyPath, str, str, str]]:
-  """Helper to describe structural differences between two pytrees.
+  r"""Helper to describe structural differences between two pytrees.
 
   Args:
     tree1, tree2: pytrees to compare.
@@ -1065,6 +1065,7 @@ def tree_flatten_with_path(
   Args:
     tree: a pytree to flatten. If it contains a custom type, it must be
       registered with ``register_pytree_with_keys``.
+
   Returns:
     A pair which the first element is a list of key-leaf pairs, each of
     which contains a leaf and its key path. The second element is a treedef
@@ -1083,6 +1084,7 @@ def tree_leaves_with_path(
   Args:
     tree: a pytree. If it contains a custom type, it must be registered with
       ``register_pytree_with_keys``.
+
   Returns:
     A list of key-leaf pairs, each of which contains a leaf and its key path.
 
@@ -1163,7 +1165,6 @@ def tree_map_with_path(f: Callable[..., Any],
     - :func:`jax.tree_util.tree_flatten_with_path`
     - :func:`jax.tree_util.tree_leaves_with_path`
   """
-
   keypath_leaves, treedef = tree_flatten_with_path(tree, is_leaf)
   keypath_leaves = list(zip(*keypath_leaves))
   all_keypath_leaves = keypath_leaves + [treedef.flatten_up_to(r) for r in rest]

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -197,7 +197,8 @@ _unflatten_done = object()
 def unflatten(xs: Iterable[T], ns: Sequence[int]) -> list[list[T]]:
   """Splits `xs` into subsequences of lengths `ns`.
 
-  Unlike `split_list`, the `sum(ns)` must be equal to `len(xs)`."""
+  Unlike `split_list`, the `sum(ns)` must be equal to `len(xs)`.
+  """
   xs_iter = iter(xs)
   unflattened = [[next(xs_iter) for _ in range(n)] for n in ns]
   assert next(xs_iter, _unflatten_done) is _unflatten_done

--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -321,7 +321,6 @@ def _check_cuda_versions(raise_on_first_error: bool = False,
       RuntimeError: If the component is not found, or is of unsupported version,
         and if raising the error is not deferred till later.
     """
-
     build_version = get_build_version()
     try:
       version = get_version()
@@ -808,7 +807,7 @@ def is_gpu(platform):
 
 
 def backends_are_initialized() -> bool:
-  "Returns true if backends have already been initialized."
+  """Returns true if backends have already been initialized."""
   with _backend_lock:
     return len(_backends) != 0
 

--- a/jax/example_libraries/optimizers.py
+++ b/jax/example_libraries/optimizers.py
@@ -23,16 +23,14 @@ initialization and update functions, which can be used with ndarrays or
 arbitrarily-nested tuple/list/dicts of ndarrays.
 
 An optimizer is modeled as an ``(init_fun, update_fun, get_params)`` triple of
-functions, where the component functions have these signatures:
-
-::
+functions, where the component functions have these signatures::
 
   init_fun(params)
 
-  Args:
-    params: pytree representing the initial parameters.
+Args:
+  params: pytree representing the initial parameters.
 
-  Returns:
+Returns:
     A pytree representing the initial optimizer state, which includes the
     initial parameters and may also include auxiliary values like initial
     momentum. The optimizer state pytree structure generally differs from that
@@ -42,26 +40,26 @@ functions, where the component functions have these signatures:
 
   update_fun(step, grads, opt_state)
 
-  Args:
-    step: integer representing the step index.
-    grads: a pytree with the same structure as `get_params(opt_state)`
-      representing the gradients to be used in updating the optimizer state.
-    opt_state: a pytree representing the optimizer state to be updated.
+Args:
+  step: integer representing the step index.
+  grads: a pytree with the same structure as `get_params(opt_state)`
+    representing the gradients to be used in updating the optimizer state.
+  opt_state: a pytree representing the optimizer state to be updated.
 
-  Returns:
-    A pytree with the same structure as the `opt_state` argument representing
-    the updated optimizer state.
+Returns:
+  A pytree with the same structure as the `opt_state` argument representing
+  the updated optimizer state.
 
 ::
 
   get_params(opt_state)
 
-  Args:
-    opt_state: pytree representing an optimizer state.
+Args:
+  opt_state: pytree representing an optimizer state.
 
-  Returns:
-    A pytree representing the parameters extracted from `opt_state`, such that
-    the invariant `params == get_params(init_fun(params))` holds true.
+Returns:
+  A pytree representing the parameters extracted from `opt_state`, such that
+  the invariant `params == get_params(init_fun(params))` holds true.
 
 
 Notice that an optimizer implementation has a lot of flexibility in the form of
@@ -613,6 +611,7 @@ def pack_optimizer_state(marked_pytree):
 
   Args:
     marked_pytree: A pytree containing JoinPoint leaves that hold more pytrees.
+
   Returns:
     An equivalent OptimizerState to the input argument.
   """

--- a/jax/experimental/array_serialization/serialization.py
+++ b/jax/experimental/array_serialization/serialization.py
@@ -413,33 +413,32 @@ class GlobalAsyncCheckpointManagerBase(util.StrictABC):
   class allows to maintain that state.
 
   Examples:
+    Below is a simplified training loop:
 
-  Below is a simplified training loop:
+    .. code-block:: python
 
-  ```
-  # Call this at the start of your program.
-  jax.distributed.initialize()
+      # Call this at the start of your program.
+      jax.distributed.initialize()
 
-  manager = GlobalAsyncCheckpointManager()
+      manager = GlobalAsyncCheckpointManager()
 
-  # Restore checkpoint if available or initialize the train_state from
-  # init_fn().
-  train_state = manager.deserialize(...)
+      # Restore checkpoint if available or initialize the train_state from
+      # init_fn().
+      train_state = manager.deserialize(...)
 
-  while ...:
-    if step % num_steps_between_checkpoints == 0:
+      while ...:
+        if step % num_steps_between_checkpoints == 0:
+          manager.serialize(train_state, temp_checkpoint_dir=...,
+                            final_checkpoint_dir=...)
+          train_state = train_step(train_state, input)
+          # This is a non-blocking call.
+          manager.check_for_errors()
+
       manager.serialize(train_state, temp_checkpoint_dir=...,
                         final_checkpoint_dir=...)
-      train_state = train_step(train_state, input)
-      # This is a non-blocking call.
-      manager.check_for_errors()
-
-  manager.serialize(train_state, temp_checkpoint_dir=...,
-                    final_checkpoint_dir=...)
-  # Wait before the end of the program for the checkpoint to finish. This is a
-  # blocking call.
-  manager.wait_until_finished()
-  ```
+      # Wait before the end of the program for the checkpoint to finish. This is a
+      # blocking call.
+      manager.wait_until_finished()
   """
 
   @abc.abstractmethod

--- a/jax/experimental/custom_partitioning.py
+++ b/jax/experimental/custom_partitioning.py
@@ -300,7 +300,6 @@ class custom_partitioning:
   :code:`inspect.signature(fun)` to resolve these positional arguments.
 
   Examples:
-
     As an example, assume we want to enhance the existing ``jax.numpy.fft.fft``. This function computes
     the discrete Fourier transform of an N-dimensional input along the last dimension, and is batched
     along the first N-1 dimensions.

--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -120,7 +120,6 @@ def call_tf(
   @jax.custom_vjp
   def make_call(*args_jax):
     """We wrap it all in `make_call` so that we can attach custom VJP."""
-
     args_flat_jax, args_treedef = tree_util.tree_flatten(args_jax)
     # Canonicalize the arguments; e.g., makes them x32 if JAX is in 32-bit mode
     def canonical_arg(v):

--- a/jax/experimental/jax2tf/examples/saved_model_lib.py
+++ b/jax/experimental/jax2tf/examples/saved_model_lib.py
@@ -133,17 +133,16 @@ class _ReusableSavedModelWrapper(tf.train.Checkpoint):
 
   Implements the interface described at
   https://www.tensorflow.org/hub/reusable_saved_models.
+
+  Args:
+    tf_graph: a tf.function taking one argument (the inputs), which can be
+      be tuples/lists/dictionaries of np.ndarray or tensors. The function
+      may have references to the tf.Variables in `param_vars`.
+    param_vars: the parameters, as tuples/lists/dictionaries of tf.Variable,
+      to be saved as the variables of the SavedModel.
   """
 
   def __init__(self, tf_graph, param_vars):
-    """Args:
-
-      tf_graph: a tf.function taking one argument (the inputs), which can be
-         be tuples/lists/dictionaries of np.ndarray or tensors. The function
-         may have references to the tf.Variables in `param_vars`.
-      param_vars: the parameters, as tuples/lists/dictionaries of tf.Variable,
-         to be saved as the variables of the SavedModel.
-    """
     super().__init__()
     # Implement the interface from https://www.tensorflow.org/hub/reusable_saved_models
     self.variables = tf.nest.flatten(param_vars)

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -461,13 +461,15 @@ class SerializationImpl:
   def before_conversion(self):
     """Called in the resulting TF function, before any other method.
 
-    Useful to set any global context."""
+    Useful to set any global context.
+    """
     raise NotImplementedError
 
   def after_conversion(self):
     """Called in the resulting TF function, after conversion is done.
 
-    Useful to restore any global context set up by `before_conversion`."""
+    Useful to restore any global context set up by `before_conversion`.
+    """
     raise NotImplementedError
 
   def run_fun_tf(self,
@@ -1056,7 +1058,6 @@ def _jax_physical_dtype(dtype):
 
 
 def _aval_to_tf_shape(aval: core.ShapedArray) -> tuple[int | None, ...]:
-
   """Generate a TF shape, possibly containing None for polymorphic dimensions."""
   aval = _jax_physical_aval(aval)
   return tuple(map(lambda d: None if export.is_symbolic_dim(d) else d,
@@ -1176,7 +1177,8 @@ def _ensure_tf_shape_if_dynamic(x: TfVal, shape):
 
 def _assert_matching_abstract_shape(x: TfVal, shape: Sequence[shape_poly.DimSize]):
   """Asserts that shape matches x.shape in the known dimensions and has
-  dimension polynomials elsewhere."""
+  dimension polynomials elsewhere.
+  """
   # Ensures that the shape does not contain None; it should contain symbolic expressions.
   def check_one(xd: int | None, sd: Any):
     if core.is_constant_dim(sd):

--- a/jax/experimental/jax2tf/tests/call_tf_test.py
+++ b/jax/experimental/jax2tf/tests/call_tf_test.py
@@ -861,7 +861,7 @@ class CallTfTest(tf_test_util.JaxToTfTestCase):
 
 
 class RoundTripToJaxTest(tf_test_util.JaxToTfTestCase):
-  "Reloading output of jax2tf into JAX with call_tf"
+  """Reloading output of jax2tf into JAX with call_tf"""
   def setUp(self):
     if tf is None:
       raise unittest.SkipTest("Test requires tensorflow")
@@ -1138,7 +1138,7 @@ class RoundTripToJaxTest(tf_test_util.JaxToTfTestCase):
 
 
 class RoundTripToTfTest(tf_test_util.JaxToTfTestCase):
-  "Reloading output of call_tf into TF with jax2tf."
+  """Reloading output of call_tf into TF with jax2tf."""
 
   def setUp(self):
     if tf is None:
@@ -1463,7 +1463,7 @@ class RoundTripToTfTest(tf_test_util.JaxToTfTestCase):
 
   @classmethod
   def _walk_stablehlo_operations(cls, op, cb):
-    """walk the stablehlo operation recursive with callback function."""
+    """Walk the stablehlo operation recursive with callback function."""
     cb(op)
     for region in op.operation.regions:
       for block in region:

--- a/jax/experimental/jax2tf/tests/control_flow_ops_test.py
+++ b/jax/experimental/jax2tf/tests/control_flow_ops_test.py
@@ -67,7 +67,8 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
                       message="Explicitly requested dtype .* requested in array is not available")
   def test_cond_custom_jvp(self):
     """Conversion of function with custom JVP, inside cond.
-    This exercises the custom_jvp_call_jaxpr primitives."""
+    This exercises the custom_jvp_call_jaxpr primitives.
+    """
     @jax.custom_jvp
     def f(x):
       return x * x
@@ -95,7 +96,8 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
                       message="Explicitly requested dtype .* requested in array is not available")
   def test_cond_custom_vjp(self):
     """Conversion of function with custom VJP, inside cond.
-    This exercises the custom_vjp_call_jaxpr primitives."""
+    This exercises the custom_vjp_call_jaxpr primitives.
+    """
     @jax.custom_vjp
     def f(x):
       return x * x
@@ -182,7 +184,8 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
                       message="Explicitly requested dtype .* requested in array is not available")
   def test_while_custom_jvp(self):
     """Conversion of function with custom JVP, inside while.
-    This exercises the custom_jvp_call_jaxpr primitives."""
+    This exercises the custom_jvp_call_jaxpr primitives.
+    """
     @jax.custom_jvp
     def f(x):
       return x * x
@@ -233,7 +236,8 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
 
   def test_scan_custom_jvp(self):
     """Conversion of function with custom JVP, inside scan.
-    This exercises the custom_jvp_call_jaxpr primitives."""
+    This exercises the custom_jvp_call_jaxpr primitives.
+    """
     @jax.custom_jvp
     def f(x):
       return x * x
@@ -261,7 +265,8 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
 
   def test_scan_custom_vjp(self):
     """Conversion of function with custom VJP, inside scan.
-    This exercises the custom_vjp_call_jaxpr primitives."""
+    This exercises the custom_vjp_call_jaxpr primitives.
+    """
     @jax.custom_vjp
     def f(x):
       return x * x

--- a/jax/experimental/jax2tf/tests/flax_models/gnn.py
+++ b/jax/experimental/jax2tf/tests/flax_models/gnn.py
@@ -139,7 +139,6 @@ class GraphConvNet(nn.Module):
 
   def pool(self, graphs: jraph.GraphsTuple) -> jraph.GraphsTuple:
     """Pooling operation, taken from Jraph."""
-
     # Equivalent to jnp.sum(n_node), but JIT-able.
     sum_n_node = graphs.nodes.shape[0]
     # To aggregate nodes from each graph to global features,

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 """Tests for JAX2TF converted.
 
-Specific JAX primitive conversion tests are in primitives_test."""
+Specific JAX primitive conversion tests are in primitives_test.
+"""
 import collections
 import contextlib
 import math

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -198,7 +198,6 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
     See the doc for instructions.
     """
-
     harnesses = [
         h for h in test_harnesses.all_harnesses
         if h.filter(h, include_jax_unimpl=True)

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -75,6 +75,31 @@ class PolyHarness(Harness):
   given `input_signature` and checks the inferred output shapes to match
   `expected_output_shapes`, then checks that the JAX and the TF functions
   produce the same results.
+
+  Args:
+    group_name, name: The name for the harness. See `Harness.__init__`.
+    fun: the function to be converted, possibly after partial application to
+      static arguments from `arg_descriptors`. See `Harness.__init__`.
+    arg_descriptors: The argument descriptors. See `Harness.__init__`. May
+      be missing, in which case `skip_jax_run` should be `True` and
+      `input_signature` must be present.
+    polymorphic_shapes: For `jax2tf.convert`.
+    polymorphic_constraints: For `jax2tf.convert`.
+    input_signature: For `tf.function.get_concrete_function`. If missing,
+      generated from `polymorphic_shapes`.
+    expected_output_signature: the expected inferred output shape.
+    enable_xla: For `jax2tf.convert`.
+    expect_error: a pair of an Exception type and a regular expression to
+      match the expected exception string.
+    skip_jax_run: If True, then neither the JAX nor the TF functions are
+      executed.
+    check_result: specifies if we want to check that the result of the shape
+      polymorphic conversion produces the same result and the JAX function.
+    tol: the tolerance to use for checking results.
+    limitations: if given, then apply the custom_assert and tolerance from the
+      Jax2TfLimitations.
+    override_jax_config_flags: jax.config flags to override for the duration
+      of the test.
   """
   def __init__(self,
                group_name: str, name: str,
@@ -92,32 +117,6 @@ class PolyHarness(Harness):
                tol: float | None = None,
                limitations: Sequence[Jax2TfLimitation] = (),
                override_jax_config_flags: dict[str, Any] = {}):
-    """Args:
-
-      group_name, name: The name for the harness. See `Harness.__init__`.
-      fun: the function to be converted, possibly after partial application to
-        static arguments from `arg_descriptors`. See `Harness.__init__`.
-      arg_descriptors: The argument descriptors. See `Harness.__init__`. May
-        be missing, in which case `skip_jax_run` should be `True` and
-        `input_signature` must be present.
-      polymorphic_shapes: For `jax2tf.convert`.
-      polymorphic_constraints: For `jax2tf.convert`.
-      input_signature: For `tf.function.get_concrete_function`. If missing,
-        generated from `polymorphic_shapes`.
-      expected_output_signature: the expected inferred output shape.
-      enable_xla: For `jax2tf.convert`.
-      expect_error: a pair of an Exception type and a regular expression to
-        match the expected exception string.
-      skip_jax_run: If True, then neither the JAX nor the TF functions are
-        executed.
-      check_result: specifies if we want to check that the result of the shape
-        polymorphic conversion produces the same result and the JAX function.
-      tol: the tolerance to use for checking results.
-      limitations: if given, then apply the custom_assert and tolerance from the
-        Jax2TfLimitations.
-      override_jax_config_flags: jax.config flags to override for the duration
-        of the test.
-    """
     super().__init__(group_name, name, fun, arg_descriptors,
                      dtype=np.float32)
     self.polymorphic_shapes = polymorphic_shapes
@@ -433,7 +432,6 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
 
   def test_kwargs(self):
     """Test shape polymorphism for a function with kwargs."""
-
     x = np.ones(3, dtype=np.float32)
     y = np.ones(1, dtype=np.float32)
     def f_jax(x, *, y):
@@ -724,7 +722,6 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
   )
   def test_pytree_errors(self, polymorphic_shapes=("b", "b", "b")):
     """Arguments and polymorphic_shapes are not-matching pytrees."""
-
     # Arguments are of the form [([x00, x01], [x10]), dict(a=ya, b=yb)]
     x = np.arange(4, dtype=_f32)
     args = (([x, x], [x]), dict(a=x, b=x))
@@ -1055,7 +1052,6 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
 
   def test_readme_examples(self):
     """Some of the examples from the README."""
-
     jax2tf.convert(lambda x: jnp.reshape(x, (x.shape[0] * x.shape[1],)),
                    polymorphic_shapes=["(b, 4)"])(np.ones((3, 4)))
 

--- a/jax/experimental/jax2tf/tests/sharding_test.py
+++ b/jax/experimental/jax2tf/tests/sharding_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Tests for the jax2tf conversion of pjit.
 
- To verify that the tests do run indeed on multiple devices you can run
+To verify that the tests do run indeed on multiple devices you can run::
 
   perftools/gputools/profiler/jfprof.sh jax/experimental/jax2tf/tests:sharding_test_tpu -- -c opt --test_filter=ShardingTest.test_shmap_all_to_all --test_arg=--vmodule=jax2tf=3 --
 

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -13,43 +13,45 @@
 # limitations under the License.
 
 r"""Jet is an experimental module for higher-order automatic differentiation
-  that does not rely on repeated first-order automatic differentiation.
+that does not rely on repeated first-order automatic differentiation.
 
-  How? Through the propagation of truncated Taylor polynomials.
-  Consider a function :math:`f = g \circ h`, some point :math:`x`
-  and some offset :math:`v`.
-  First-order automatic differentiation (such as :func:`jax.jvp`)
-  computes the pair :math:`(f(x), \partial f(x)[v])` from the pair
-  :math:`(h(x), \partial h(x)[v])`.
+How? Through the propagation of truncated Taylor polynomials.
+Consider a function :math:`f = g \circ h`, some point :math:`x`
+and some offset :math:`v`.
+First-order automatic differentiation (such as :func:`jax.jvp`)
+computes the pair :math:`(f(x), \partial f(x)[v])` from the pair
+:math:`(h(x), \partial h(x)[v])`.
 
-  :func:`jet` implements the higher-order analogue:
-  Given the tuple
+:func:`jet` implements the higher-order analogue:
+Given the tuple
 
-  .. math::
-    (h_0, ... h_K) :=
-    (h(x), \partial h(x)[v], \partial^2 h(x)[v, v], ..., \partial^K h(x)[v,...,v]),
+.. math::
 
-  which represents a :math:`K`-th order Taylor approximation
-  of :math:`h` at :math:`x`, :func:`jet` returns a :math:`K`-th order
-  Taylor approximation of :math:`f` at :math:`x`,
+  (h_0, ... h_K) :=
+  (h(x), \partial h(x)[v], \partial^2 h(x)[v, v], ..., \partial^K h(x)[v,...,v]),
 
-  .. math::
-    (f_0, ..., f_K) :=
-    (f(x), \partial f(x)[v], \partial^2 f(x)[v, v], ..., \partial^K f(x)[v,...,v]).
+which represents a :math:`K`-th order Taylor approximation
+of :math:`h` at :math:`x`, :func:`jet` returns a :math:`K`-th order
+Taylor approximation of :math:`f` at :math:`x`,
 
-  More specifically, :func:`jet` computes
+.. math::
 
-  .. math::
-    f_0, (f_1, . . . , f_K) = \texttt{jet} (f, h_0, (h_1, . . . , h_K))
+  (f_0, ..., f_K) :=
+  (f(x), \partial f(x)[v], \partial^2 f(x)[v, v], ..., \partial^K f(x)[v,...,v]).
 
-  and can thus be used for high-order
-  automatic differentiation of :math:`f`.
-  Details are explained in
-  `these notes <https://github.com/google/jax/files/6717197/jet.pdf>`__.
+More specifically, :func:`jet` computes
 
-  Note:
-    Help improve :func:`jet` by contributing
-    `outstanding primitive rules <https://github.com/google/jax/issues/2431>`__.
+.. math::
+
+  f_0, (f_1, . . . , f_K) = \texttt{jet} (f, h_0, (h_1, . . . , h_K))
+
+and can thus be used for high-order
+automatic differentiation of :math:`f`.
+Details are explained in
+`these notes <https://github.com/google/jax/files/6717197/jet.pdf>`__.
+
+.. note:: Help improve :func:`jet` by contributing
+  `outstanding primitive rules <https://github.com/google/jax/issues/2431>`__.
 """
 
 from typing import Any, Callable

--- a/jax/experimental/mosaic/gpu/fragmented_array.py
+++ b/jax/experimental/mosaic/gpu/fragmented_array.py
@@ -47,13 +47,11 @@ class WGSplatFragLayout:
   elementwise operations with all other layouts.
 
   Examples:
+    .. code-block:: python
 
-  To load a value in
-  ```
-  FragmentedArray.splat(memref.load(ref_1d, [1]), (10,20,2))
-  ```
+      FragmentedArray.splat(memref.load(ref_1d, [1]), (10,20,2))
 
-  A shape is always provided for sanity check reasons.
+    A shape is always provided for sanity check reasons.
 
   """
 

--- a/jax/experimental/pallas/ops/tpu/megablox/gmm.py
+++ b/jax/experimental/pallas/ops/tpu/megablox/gmm.py
@@ -339,7 +339,6 @@ def gmm(
   Returns:
     A 2d, jnp.ndarray with shape [m, n].
   """
-
   if existing_out is not None:
     assert isinstance(existing_out, jax.Array)
     expected_dtype = existing_out.dtype

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py
@@ -58,6 +58,7 @@ class SegmentIds(NamedTuple):
   This condition holds for causal self-attention because in this case segment
   ids form a block diagonal matrix so at least one element in each row is set.
   It is easy to break this condition with non-self-attention configurations.
+
   Attributes:
     q: segment ids along the Q sequence
     kv: segment ids along the KV sequence

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
@@ -87,7 +87,6 @@ def _downcast_to_small_type(array: np.ndarray) -> np.ndarray:
     ValueError: if the input array is not np.int32 or if its elements are not
     all positive.
   """
-
   if array.dtype != np.int32:
     raise ValueError('Expected int32 input.')
 
@@ -120,7 +119,6 @@ def _check_mask(mask: mask_lib.Mask) -> None:
   Raises:
     ValueError: the mask is invalid.
   """
-
   assert len(mask.shape) == 2
 
   exception_message = (
@@ -349,7 +347,6 @@ def _process_mask(
     ValueError: if the input mask is invalid or the block sizes are not
     compatible with the mask sizes.
   """
-
   if len(mask.shape) != 3:
     raise ValueError(f'Expected a 3-dim mask, instead got: {mask.shape=}')
 

--- a/jax/experimental/rnn.py
+++ b/jax/experimental/rnn.py
@@ -11,11 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""`jax.experimental.rnn`: GPU accelerated RNN
-
-----------------------------------------------
-
-This module provides experimental support to CUDNN-backed LSTM.
+"""This module provides experimental support to CUDNN-backed LSTM.
 
 Currently, the only supported RNN flavor is LSTM with double-bias. We use
 notations and variable names similar to

--- a/jax/experimental/serialize_executable.py
+++ b/jax/experimental/serialize_executable.py
@@ -46,7 +46,6 @@ def deserialize_and_load(serialized,
                          out_tree,
                          backend: str | xc.Client | None = None):
   """Constructs a jax.stages.Compiled from a serialized executable."""
-
   if backend is None or isinstance(backend, str):
     backend = jax.devices(backend)[0].client
 

--- a/jax/experimental/sparse/ad.py
+++ b/jax/experimental/sparse/ad.py
@@ -82,7 +82,6 @@ def value_and_grad(fun: Callable, argnums: int | Sequence[int] = 0,
   gradient is computed in the subspace defined by the array's sparsity pattern.
 
   Examples:
-
     >>> from jax.experimental import sparse
     >>> X = sparse.BCOO.fromdense(jnp.arange(6.))
     >>> y = jnp.ones(6)
@@ -110,7 +109,6 @@ def grad(fun: Callable, argnums: int | Sequence[int] = 0,
   gradient is computed in the subspace defined by the array's sparsity pattern.
 
   Examples:
-
     >>> from jax.experimental import sparse
     >>> X = sparse.BCOO.fromdense(jnp.arange(6.))
     >>> y = jnp.ones(6)

--- a/jax/experimental/sparse/api.py
+++ b/jax/experimental/sparse/api.py
@@ -126,6 +126,7 @@ def empty(shape: Shape, dtype: DTypeLike | None=None, index_dtype: DTypeLike = '
     index_dtype: (optional) dtype of the index arrays.
     format: string specifying the matrix format (e.g. ['bcoo']).
     **kwds: additional keywords passed to the format-specific _empty constructor.
+
   Returns:
     mat: empty sparse matrix.
   """

--- a/jax/experimental/sparse/bcsr.py
+++ b/jax/experimental/sparse/bcsr.py
@@ -331,6 +331,7 @@ def _bcsr_todense(data: ArrayLike, indices: ArrayLike, indptr: ArrayLike, *,
       of the matrix, which is equal to
       ``batch_dims + 2(sparse_dims) + block_dims`` where
       ``len(sparse_dims) == 2``.
+
   Returns:
     mat : array with specified shape and dtype matching ``data``
   """

--- a/jax/experimental/sparse/linalg.py
+++ b/jax/experimental/sparse/linalg.py
@@ -122,7 +122,6 @@ def _lobpcg_standard_callable(
     tol: jax.Array | float | None,
     debug: bool = False):
   """Supports generic lobpcg_standard() callable interface."""
-
   # TODO(vladf): support mixed_precision flag, which allows f64 Rayleigh-Ritz
   # with f32 inputs.
 
@@ -326,7 +325,6 @@ def _svqb(X):
     An orthonormal space `V` described by a `(n, k)` array, with trailing
     columns possibly zeroed out if `X` is of low rank.
   """
-
   # In [1] diagonal conditioning is explicit, but by normalizing first
   # we can simplify the formulas a bit, since then diagonal conditioning
   # becomes a no-op.
@@ -383,7 +381,6 @@ def _project_out(basis, U):
     the component of `U` in the complement of `basis`. The nonzero columns
     are mutually orthonormal.
   """
-
   # See Sec. 6.9 of The Symmetric Eigenvalue Problem by Beresford Parlett [1]
   # which motivates two loop iterations for basis subtraction. This
   # "twice is enough" approach is due to Kahan. See also a practical note
@@ -450,7 +447,6 @@ def _rayleigh_ritz_orth(A, S):
     Eigenvectors `V` and eigenvalues `w` satisfying the size-`k` system
     described in this method doc. Note `V` will be full rank, even if `S` isn't.
   """
-
   SAS = _mm(S.T, A(S))
 
   # Solve the projected subsystem.

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -472,7 +472,6 @@ def sparsify(f, use_tracer=False):
   """Experimental sparsification transform.
 
   Examples:
-
     Decorate JAX functions to make them compatible with :class:`jax.experimental.sparse.BCOO`
     matrices:
 

--- a/jax/experimental/x64_context.py
+++ b/jax/experimental/x64_context.py
@@ -38,9 +38,8 @@ def enable_x64(new_val: bool = True):
     ...
     float64
 
-  See Also
-  --------
-  jax.experimental.enable_x64 : temporarily enable X64 mode.
+  See also:
+    :func:`jax.experimental.enable_x64`
   """
   with config.enable_x64(new_val):
     yield
@@ -57,9 +56,8 @@ def disable_x64():
     ...
     float32
 
-  See Also
-  --------
-  jax.experimental.enable_x64 : temporarily enable X64 mode.
+  See also:
+    :func:`jax.experimental.enable_x64`
   """
   with config.enable_x64(False):
     yield

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,10 +116,21 @@ ignore = [
     "F841",
     # Raise with from clause inside except block
     "B904",
+    # Less strict docs
+    "D1",    # Missing doctrings
+    "D200",  # One line docstrings
+    "D205",  # Blank line required between summary line and description
+    "D212",  # Multi-line docstring summary should start at the first line
+    "D402",  # First line should not be the function's signature
+    "D405",  # Section name should be properly capitalized
+    "D403",  # First word of the first line should be capitalized
+    "D415",  # First line should end with punctuation
+    "D417",  # Missing argument description
 ]
 select = [
     "B9",
     "C",
+    "D",
     "F",
     "W",
     "YTT",
@@ -128,6 +139,9 @@ select = [
     "E227",
     "E228",
 ]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.ruff.lint.mccabe]
 max-complexity = 18
@@ -176,3 +190,10 @@ max-complexity = 18
 "jax/util.py" = ["F401"]
 # F821: Undefined name.
 "jax/numpy/__init__.pyi" = ["F821"]
+# D301: Use `r"""` if any backslashes in a docstring
+"jax/_src/debugger/cli_debugger.py" = ["D301"]
+# Disable docs checks for jax.scipy.sparse because the docstrings are all
+# numpy style
+"jax/_src/scipy/sparse/linalg.py" = ["D"]
+# One test requires a numpy-style docstring
+"tests/lax_numpy_test.py" = ["D416"]

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -930,7 +930,7 @@ class JitTest(jtu.BufferDonationTestCase):
 
   def test_jit_wrapped_attributes(self):
     def f(x: int) -> int:
-      """docstring of f."""
+      """Docstring of f."""
       return x + 1
     f.some_value = 4
     jf = jit(f)

--- a/tests/filecheck/jax_filecheck_helpers.py
+++ b/tests/filecheck/jax_filecheck_helpers.py
@@ -21,7 +21,8 @@ def print_ir(*prototypes):
   def lower(f):
     """Prints the MLIR IR that results from lowering `f`.
 
-    The arguments to `f` are taken to be arrays shaped like `prototypes`."""
+    The arguments to `f` are taken to be arrays shaped like `prototypes`.
+    """
     inputs = jax.tree.map(np.array, prototypes)
     flat_inputs, _ = jax.tree.flatten(inputs)
     shape_strs = " ".join([f"{x.dtype.name}[{','.join(map(str, x.shape))}]"

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -573,7 +573,7 @@ class HostCallbackTapTest(jtu.JaxTestCase):
 
   @jtu.sample_product(concurrent=[True, False])
   def test_tap_multiple(self, concurrent=False):
-    """Call id_tap multiple times, concurrently or in sequence. """
+    """Call id_tap multiple times, concurrently or in sequence."""
     if concurrent and jtu.test_device_matches(["cpu", "gpu"]):
       # TODO(necula): if there is device side concurrency, outfeeds from
       # different computations can be interleaved. For example, it seems that
@@ -1556,7 +1556,7 @@ class HostCallbackTapTest(jtu.JaxTestCase):
 
   @ignore_jit_of_pmap_warning()
   def test_tap_pmap_pmap_extra(self):
-    """pmap of a pmap surrounded by extra code."""
+    """Pmap of a pmap surrounded by extra code."""
     # A matrix M[ij] = i * 10 + j
     self.supported_only_in_legacy_mode()
     nr_devices = len(local_devices())
@@ -1646,7 +1646,7 @@ class HostCallbackTapTest(jtu.JaxTestCase):
 
   @ignore_jit_of_pmap_warning()
   def test_tap_jit_pmap_extra(self):
-    """jit of a pmap surrounded by extra code."""
+    """Jit of a pmap surrounded by extra code."""
     self.supported_only_in_legacy_mode()
     # A matrix M[ij] = i * 10 + j
     nr_devices = len(local_devices())
@@ -1764,8 +1764,9 @@ class HostCallbackTapTest(jtu.JaxTestCase):
         [33 33 33 33]]""")
 
   def test_tap_scan_custom_jvp(self):
-    """custom JVP, inside scan.
-    This exercises the custom_jvp_call_jaxpr primitives."""
+    """Custom JVP, inside scan.
+    This exercises the custom_jvp_call_jaxpr primitives.
+    """
     self.supported_only_in_legacy_mode()
     @jax.custom_jvp
     def f(x):
@@ -1808,8 +1809,9 @@ class HostCallbackTapTest(jtu.JaxTestCase):
         2.1""", testing_stream.output)
 
   def test_tap_scan_custom_vjp(self):
-    """custom VJP, inside scan.
-    This exercises the custom_vjp_call_jaxpr primitives."""
+    """Custom VJP, inside scan.
+    This exercises the custom_vjp_call_jaxpr primitives.
+    """
     self.supported_only_in_legacy_mode()
     @jax.custom_vjp
     def f(x):
@@ -1895,7 +1897,8 @@ class HostCallbackTapTest(jtu.JaxTestCase):
   def test_tap_error_bad_consumer_id(self):
     """Try to use reserved consumer ID 0.
 
-    Check that we get the proper error from the runtime."""
+    Check that we get the proper error from the runtime.
+    """
     if not hcb._use_outfeed(jtu.device_under_test()):
       raise SkipTest("test works only for outfeed")
     comp = xla_client.XlaBuilder(self._testMethodName)
@@ -2834,8 +2837,9 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
           in (c, d, e, h, i) }""", func, [y])
 
   def test_scan_custom_jvp(self):
-    """custom JVP, inside scan.
-    This exercises the custom_jvp_call_jaxpr primitives."""
+    """Custom JVP, inside scan.
+    This exercises the custom_jvp_call_jaxpr primitives.
+    """
     self.supported_only_in_legacy_mode()
     @jax.custom_jvp
     def f(x):
@@ -2916,8 +2920,9 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
           in (c, h, i) }""", jax.grad(g), [arg])
 
   def test_scan_custom_vjp(self):
-    """custom VJP, inside scan.
-    This exercises the custom_vjp_call_jaxpr primitives."""
+    """Custom VJP, inside scan.
+    This exercises the custom_vjp_call_jaxpr primitives.
+    """
     self.supported_only_in_legacy_mode()
     @jax.custom_vjp
     def f(x):

--- a/tests/host_callback_to_tf_test.py
+++ b/tests/host_callback_to_tf_test.py
@@ -45,7 +45,8 @@ def call_tf_no_ad(tf_fun: Callable, arg, *, result_shape):
   """The simplest implementation of calling to TF, without AD support.
 
   We must use hcb.call because the TF invocation must happen outside the
-  JAX staged computation."""
+  JAX staged computation.
+  """
 
   def tf_to_numpy(t):
     # Turn the Tensor to NumPy array without copying.

--- a/tests/lax_metal_test.py
+++ b/tests/lax_metal_test.py
@@ -1974,10 +1974,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   @jtu.sample_product(fixed_size=[False, True])
   def testNonScalarRepeats(self, fixed_size):
-    '''
+    """
     Following numpy test suite from `test_repeat` at
     https://github.com/numpy/numpy/blob/main/numpy/core/tests/test_multiarray.py
-    '''
+    """
     tol = 1e-5
 
     def test_single(m, args_maker, repeats, axis):
@@ -2018,9 +2018,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       test_single(m_rect, args_maker, repeats, axis=1)
 
   def testIssue2330(self):
-    '''
+    """
     Make sure return value of jnp.concatenate is a jax.ndarray and is side-effect save
-    '''
+    """
     def attempt_sideeffect(x):
       x = [x]
       x = jnp.concatenate(x)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2081,10 +2081,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   @jtu.sample_product(fixed_size=[False, True])
   def testNonScalarRepeats(self, fixed_size):
-    '''
+    """
     Following numpy test suite from `test_repeat` at
     https://github.com/numpy/numpy/blob/main/numpy/core/tests/test_multiarray.py
-    '''
+    """
     tol = 1e-5
 
     def test_single(m, args_maker, repeats, axis):
@@ -2125,9 +2125,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       test_single(m_rect, args_maker, repeats, axis=1)
 
   def testIssue2330(self):
-    '''
+    """
     Make sure return value of jnp.concatenate is a jax.ndarray and is side-effect save
-    '''
+    """
     def attempt_sideeffect(x):
       x = [x]
       x = jnp.concatenate(x)

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -491,7 +491,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
   def testPolar(
     self, n_zero_sv, degeneracy, geometric_spectrum, max_sv, shape, method,
       side, nonzero_condition_number, dtype, seed):
-    """ Tests jax.scipy.linalg.polar."""
+    """Tests jax.scipy.linalg.polar."""
     if not jtu.test_device_matches(["cpu"]):
       if jnp.dtype(dtype).name in ("bfloat16", "float16"):
         raise unittest.SkipTest("Skip half precision off CPU.")

--- a/tests/pallas/pallas_call_tpu_test.py
+++ b/tests/pallas/pallas_call_tpu_test.py
@@ -1934,7 +1934,6 @@ class PallasCallWhileLoopTest(PallasTPUTest):
   )
   def test_while_loop_carry_memref(self, shape):
     """Tests a while loop carrying a memref."""
-
     # TODO(hmckenzie): Investigate further why this occurs.
     if shape == (1, 128):
       self.skipTest('memref<1x128> inexplicably doubles to 2x128.')

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -1467,7 +1467,6 @@ class CustomPartitionerTest(jtu.JaxTestCase):
     This test is makes sure that the custom partitioner lowering supports
     CallOps.
     """
-
     self.skip_if_custom_partitioning_not_supported()
 
     @custom_partitioning

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -1215,6 +1215,25 @@ class PolyHarness(Harness):
 
   Exports `fun` with shape polymorphism, then checks that the JAX native and
   the exported function produce the same results.
+
+  Args:
+    group_name, name: The name for the harness. See `Harness.__init__`.
+    fun: the function to be converted. See `Harness.__init__`.
+    arg_descriptors: The argument descriptors. See `Harness.__init__`.
+    polymorphic_shapes: For `export.args_specs`.
+    symbolic_constraints: For `export.args_specs`.
+    expect_error: an optional pair of an Exception type and a regular
+      expression to match the expected exception string.
+      We expect this error during tracing and exporting with shape
+      polymorphism.
+    check_result: specifies if we want to check that the result of invoking
+      the shape polymorphic export produces the same result as the
+      native JAX function.
+    tol: the tolerance to use for checking results.
+    limitations: a sequence of Limitation(s), used for obtaining the default
+      tolerance (if `tol` is not specified).
+    override_jax_config_flags: jax.config flags to override for the duration
+      of the test.
   """
   def __init__(self,
                group_name: str, name: str,
@@ -1228,26 +1247,6 @@ class PolyHarness(Harness):
                tol: float | None = None,
                limitations: Sequence[test_harnesses.Limitation] = (),
                override_jax_config_flags: dict[str, Any] = {}):
-    """Args:
-
-      group_name, name: The name for the harness. See `Harness.__init__`.
-      fun: the function to be converted. See `Harness.__init__`.
-      arg_descriptors: The argument descriptors. See `Harness.__init__`.
-      polymorphic_shapes: For `export.args_specs`.
-      symbolic_constraints: For `export.args_specs`.
-      expect_error: an optional pair of an Exception type and a regular
-        expression to match the expected exception string.
-        We expect this error during tracing and exporting with shape
-        polymorphism.
-      check_result: specifies if we want to check that the result of invoking
-        the shape polymorphic export produces the same result as the
-        native JAX function.
-      tol: the tolerance to use for checking results.
-      limitations: a sequence of Limitation(s), used for obtaining the default
-        tolerance (if `tol` is not specified).
-      override_jax_config_flags: jax.config flags to override for the duration
-        of the test.
-    """
     super().__init__(group_name, name, fun, arg_descriptors,
                      dtype=np.float32)
     self.polymorphic_shapes = polymorphic_shapes
@@ -1402,7 +1401,6 @@ class ShapePolyTest(jtu.JaxTestCase):
 
   def test_kwargs(self):
     """Test shape polymorphism for a function with kwargs."""
-
     x = np.ones(3, dtype=np.float32)
     y = np.ones(1, dtype=np.float32)
     def f_jax(x, *, y):
@@ -1508,7 +1506,6 @@ class ShapePolyTest(jtu.JaxTestCase):
   )
   def test_pytree_errors(self, polymorphic_shapes=("b", "b", "b")):
     """Arguments and polymorphic_shapes are not-matching pytrees."""
-
     # Arguments are of the form [([x00, x01], [x10]), dict(a=ya, b=yb)]
     x = np.arange(4, dtype=_f32)
     args = (([x, x], [x]), dict(a=x, b=x))

--- a/tests/sparse_bcoo_bcsr_test.py
+++ b/tests/sparse_bcoo_bcsr_test.py
@@ -608,7 +608,6 @@ class BCOOTest(sptu.SparseTestCase):
   @jtu.run_on_devices("gpu")
   def test_bcoo_dot_general_oob_and_unsorted_indices_cusparse(self):
     """Tests bcoo dot general with out-of-bound and unsorted indices."""
-
     rhs = jnp.ones((5, 3), dtype=jnp.float32)
 
     # It creates out-of-bound indices when nse > nnz.

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -37,7 +37,8 @@ class UtilTest(jtu.JaxTestCase):
     def f(*args, **kwargs):
       """The function to be transformed.
       Scales the positional arguments by a factor.
-      Takes only one keyword argument, the factor to scale by."""
+      Takes only one keyword argument, the factor to scale by.
+      """
       factor = kwargs.pop('factor', 2)  # For PY2
       assert not kwargs
       return tuple(a * factor for a in args)


### PR DESCRIPTION
I used a combination of ruff's `--fix` option and manual editing to get all the doctrings to the be a little more consistent in formatting. This is a huge PR, but the only changes are to docstrings, so maybe that's ok. I'd also be happy to break this up into smaller chunks if that would be better for reviewing.

I've left in the ruff config that I used which means that this lint check would become part of our pre-commit that we run on CI. I don't feel strongly about actually including these checks as part of our pre-commit, and I'd be happy to revert the changes to `pyproject.toml`, but @jakevdp suggested that it could be useful to try it out for catching at least some doc formatting errors.