### PR TITLE
remove double dots from an error message

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -686,7 +686,7 @@ class Tracer(typing.Array, metaclass=StrictABCMeta):
   def _error_repr(self):
     if self.aval is None:
       return f"traced array with aval {self.aval}"
-    return f"traced array with shape {raise_to_shaped(self.aval).str_short()}."
+    return f"traced array with shape {raise_to_shaped(self.aval).str_short()}"
 
   def __array__(self, *args, **kw):
     raise TracerArrayConversionError(self)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4765,6 +4765,14 @@ class APITest(jtu.JaxTestCase):
 
     f.trace(jnp.arange(8)).lower(lowering_platforms=('tpu',))  # doesn't crash
 
+  def test_no_double_dots_in_error_message(self):
+    @jax.jit
+    def f(x):
+      return 1 if x > 0 else 0
+
+    with self.assertRaisesRegex(TracerBoolConversionError, r"with shape bool\[\]\.[^\.]"):
+      f(0)
+
 
 class RematTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
```python
import jax

@jax.jit
def f(qiaoqiao):
  if True and qiaoqiao:
    return 1
  return 0

f(True)
```


Before:
```
jax.errors.TracerBoolConversionError: Attempted boolean conversion of traced array with shape bool[]..
```

After:
```
jax.errors.TracerBoolConversionError: Attempted boolean conversion of traced array with shape bool[].
```