### PR TITLE
[memories] Transfer to pinned_host fast path in async_serialize

### DIFF
--- a/jax/experimental/array_serialization/serialization.py
+++ b/jax/experimental/array_serialization/serialization.py
@@ -29,6 +29,7 @@ from typing import Any, Optional
 
 import jax
 from jax._src import array
+from jax._src import config
 from jax._src import distributed
 from jax._src import sharding
 from jax._src import sharding_impls
@@ -184,6 +185,22 @@ class _LimitInFlightBytes:
       self._cv.notify_all()
 
 
+def transfer_shard_to_host(shard: array.Shard) -> np.ndarray:
+  data = shard.data
+  has_pinned_host = any(
+      m.kind == "pinned_host" for m in shard.device.addressable_memories())
+  if config.enable_memories.value and has_pinned_host:
+    # If available, transfer to pinned host memory
+    sharding = jax.sharding.SingleDeviceSharding(shard.device,
+        memory_kind="pinned_host")
+    data = jax.device_put(data, sharding)
+    # Ensure that jax.Array's internal numpy array can be zero-copied.
+    # Tensorstore implicitly converts the written data to a numpy array,
+    # and would otherwise silently copy host-to-host.
+    data = np.array(data, copy=False)
+  return data
+
+
 async def async_serialize(
     arr_inp,
     tensorstore_spec,
@@ -260,8 +277,9 @@ async def async_serialize(
 
   async def _write_array(shard):
     if shard.replica_id == replica_id:
+      data = transfer_shard_to_host(shard)
       write_future = t[shard.index].write(
-          shard.data,
+          data,
           # Avoid additional copy of input array into the TensorStore chunk
           # cache.  If `arr_inp` is a jax.Array, the result of converting
           # it to a NumPy array, as is done internally by TensorStore, is

--- a/jax/experimental/array_serialization/serialization_test.py
+++ b/jax/experimental/array_serialization/serialization_test.py
@@ -28,7 +28,7 @@ import jax.numpy as jnp
 from jax._src import test_util as jtu
 from jax._src import array
 from jax._src import xla_bridge as xb
-from jax.sharding import NamedSharding, GSPMDSharding
+from jax.sharding import NamedSharding, GSPMDSharding, SingleDeviceSharding
 from jax.sharding import PartitionSpec as P
 from jax.experimental.array_serialization import serialization
 from jax.experimental.layout import Layout, DeviceLocalLayout as DLL
@@ -609,6 +609,21 @@ class CheckpointTest(jtu.JaxTestCase):
     out = deserialized_arr.astype(jnp.int8)  # doesn't crash
     self.assertEqual(out.dtype, jnp.int8)
     self.assertArraysEqual(out + out, out * 2)
+
+
+@jtu.with_config(jax_enable_memories=True)
+class TransferShardTest(jtu.JaxTestCase):
+
+  @jtu.skip_on_devices('cpu')
+  def test_transfer_shard_to_host(self):
+    np_inp = np.arange(16).reshape((4, 4))
+    sharding = SingleDeviceSharding(jax.devices()[0], memory_kind="device")
+    arr = jax.device_put(np_inp, sharding)
+    shard = arr.addressable_shards[0]
+
+    np_out = serialization.transfer_shard_to_host(shard)
+
+    self.assertArraysEqual(np_out, np_inp)
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Adds a fast path to `jax.experimental.array_serialization.serialization.async_serialize` that avoids XLA's regular device-to-host transfer and instead uses a single device-to-pinned-host transfer per `_write_array(arr)` invocation. This allows us to achieve much closer to ideal transfer bandwidths in practice. For comparison, the existing approach stages copies through a fixed size intermediate 128MB-buffer and requires `sizeof(arr)/128MB` alternations between D2H and H2H copies.

Note that the `np.array(data, copy=False)` is not strictly necessary as the tensorstore invocation `t.write(...)` immediately performs the C-API equivalent of `np.array(data, copy=None)`. We expect all of these to be zero-copy, hence explicitly calling `np.array(data, copy=False)` provides some extra safety, since it would fail if jax.Array's implementation changed and no longer permitted zero-copying its private numpy array `_value`. Alas the latter check is not fool-proof: for example, prior to [XLA#14089](https://github.com/openxla/xla/pull/14089) the construction of the jax.Array from the device buffer also forced a copy.

Depends on [XLA#14087](https://github.com/openxla/xla/pull/14087) [XLA#14088](https://github.com/openxla/xla/pull/14088) [XLA#14089](https://github.com/openxla/xla/pull/14089) ~[XLA#14090](https://github.com/openxla/xla/pull/14090)~