### PR TITLE
Remove `linear` parameter from `lax.cond_p`

### DIFF
--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -103,7 +103,7 @@ Here there are no constvars, ``a`` and ``b`` are the input variables
 and they correspond respectively to
 ``first`` and ``second`` function parameters. The scalar literal ``3.0`` is kept
 inline.
-The ``reduce_sum`` primitive has named parameter ``axes``, in addition to the 
+The ``reduce_sum`` primitive has named parameter ``axes``, in addition to the
 operand ``e``.
 
 Note that even though execution of a program that calls into JAX builds a jaxpr,
@@ -218,18 +218,12 @@ For example:
         { lambda ; h:f32[]. let i:f32[] = sub h 2.0 in (i,) }
         { lambda ; j:f32[]. let k:f32[] = add j 3.0 in (k,) }
       )
-      linear=(False,)
     ] d b
   in (e,) }
 
-The cond primitive has a number of parameters:
-
-  * `branches` are jaxprs that correspond to the branch
-    functionals. In this example, those functionals each take one
-    input variable, corresponding to ``x``.
-  * `linear` is a tuple of booleans that is used internally by the
-    auto-differentiation machinery to encode which of the input
-    parameters are used linearly in the conditional.
+The `branches` parameter to the cond primitive corresponds to the branch
+functionals. In this example, those functionals each take one input variable,
+corresponding to ``x``.
 
 The above instance of the cond primitive takes two operands.  The first
 one (``d``) is the branch index, then ``b`` is the operand (``arg``) to
@@ -255,7 +249,6 @@ Another example, using :py:func:`lax.cond`:
         { lambda ; e:f32[]. let f:f32[] = sub e 3.0 in (f,) }
         { lambda ; g:f32[]. let h:f32[] = add g 3.0 in (h,) }
       )
-      linear=(False,)
     ] c a
   in (d,) }
 
@@ -287,7 +280,6 @@ contains a constant ``jnp.ones(1)`` that is hoisted as a `constvar`
           in (l,) }
         { lambda ; m_:i32[1] n:f32[1] o:f32[]. let  in (n,) }
       )
-      linear=(False, False, False)
     ] f a c d
   in (g,) }
 

--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -751,7 +751,7 @@ def jaxpr_to_checkify_jaxpr(
   out_tree, error_effects = metadata()
   return checked_jaxpr, out_tree, error_effects
 
-def cond_error_check(error: Error, enabled_errors, index, *ops, branches, linear):
+def cond_error_check(error: Error, enabled_errors, index, *ops, branches):
   # Get the error-effects out of all branches so the cond can be called with
   # a merged error with all these effects.
   err_vals, err_tree = jtu.tree_flatten(error)
@@ -763,7 +763,6 @@ def cond_error_check(error: Error, enabled_errors, index, *ops, branches, linear
   effects = [get_error_effects_from_jaxpr(jxpr) for jxpr in branches]
   merged_error = error._add_placeholder_effects(set().union(*effects))
   err_vals, err_tree = jtu.tree_flatten(merged_error)
-  new_linear = (*[False] * len(err_vals), *linear)
 
   # Update branch jaxprs to be checkified jaxprs.
   in_avals = map(get_shaped_aval, [*err_vals, *ops])
@@ -773,7 +772,7 @@ def cond_error_check(error: Error, enabled_errors, index, *ops, branches, linear
 
   err_and_outs = lax.cond_p.bind(
       index, *err_vals, *ops,
-      branches=tuple(new_branches), linear=new_linear)
+      branches=tuple(new_branches))
 
   # we need to merge metadata across out_trees (a tuple)
   err0, out = tree_unflatten(out_trees[0], err_and_outs)

--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -2080,7 +2080,7 @@ def _while_lowering_rule(
 
 lowering_rules[lax.while_p] = _while_lowering_rule
 
-def _cond_lowering_rule(ctx: LoweringRuleContext, *args, branches, linear):
+def _cond_lowering_rule(ctx: LoweringRuleContext, *args, branches):
   index, *args = args
   out_types = map(aval_to_ir_type, ctx.avals_out)
   pred = arith.CmpIOp(
@@ -2099,7 +2099,6 @@ def _cond_lowering_rule(ctx: LoweringRuleContext, *args, branches, linear):
           arith.SubIOp(index, ir_constant(1, index.type)).result,
           *args,
           branches=branches[1:],
-          linear=linear,
       )
     else:
       out = jaxpr_subcomp(lowering_context, branches[1].jaxpr, *args)

--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -2542,7 +2542,6 @@ def _cond_lowering_rule(
     index,
     *args,  # *consts, *ops
     branches,  # tuple(jaxprs)
-    linear,
 ):
   block_infos = ctx.block_infos
 
@@ -2572,7 +2571,6 @@ def _cond_lowering_rule(
           _sub(index, _ir_constant(1, index.type)),
           *args,
           branches=branches[1:],
-          linear=linear,
       )
     else:
       outs1 = lower_jaxpr_to_triton_ir(

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -1528,7 +1528,7 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: list[core.JaxprEqn],
                 body_jaxpr=_rewrite_closed_jaxpr(body_jaxpr, True, True),
                 cond_jaxpr=_rewrite_closed_jaxpr(cond_jaxpr, True, False))))
   elif eqn.primitive is lax.cond_p:
-    branches, linear = util.split_dict(eqn.params, ["branches", "linear"])
+    branches, = util.split_dict(eqn.params, ["branches"])
     index, *operands = eqn.invars
     new_invars = [index, *operands, input_token_var, input_itoken_var]
     eqns.append(
@@ -1538,8 +1538,7 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: list[core.JaxprEqn],
                 eqn.params,
                 branches=tuple(
                     _rewrite_closed_jaxpr(jaxpr, True, True)
-                    for jaxpr in branches),
-                linear=(*linear, False, False))))
+                    for jaxpr in branches))))
   elif eqn.primitive is lax.scan_p:
     num_consts, num_carry, carry_jaxpr, linear, _, _, _, _ = util.split_dict(
         eqn.params,

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -3019,9 +3019,9 @@ tf_impl_with_avals[lax.scatter_mul_p] = _scatter
 tf_impl_with_avals[lax.scatter_add_p] = _scatter
 
 
-def _cond(index: TfVal, *operands: TfVal, branches: Sequence[core.ClosedJaxpr],
-          linear: Sequence[bool]) -> Sequence[TfVal]:
-  del linear
+def _cond(
+    index: TfVal, *operands: TfVal, branches: Sequence[core.ClosedJaxpr]
+) -> Sequence[TfVal]:
   # tf.cond needs lambdas with no arguments.
   branches_tf = [
       partial(_interpret_jaxpr, jaxpr, *operands,

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -848,15 +848,14 @@ def _scan_sparse(spenv, *spvalues, jaxpr, num_consts, num_carry, **params):
 
 sparse_rules_bcoo[lax.scan_p] = _scan_sparse
 
-def _cond_sparse(spenv, pred, *operands, branches, linear, **params):
+def _cond_sparse(spenv, pred, *operands, branches, **params):
   sp_branches, treedefs = zip(*(_sparsify_jaxpr(spenv, jaxpr, *operands)
                                 for jaxpr in branches))
   _check_tree_and_avals("sparsified true_fun and false_fun output",
                         treedefs[0], sp_branches[0].out_avals,
                         treedefs[1], sp_branches[1].out_avals)
-  sp_linear = tuple(_duplicate_for_sparse_spvalues(operands, linear))
   args, _ = tree_flatten(spvalues_to_arrays(spenv, (pred, *operands)))
-  out_flat = lax.cond_p.bind(*args, branches=sp_branches, linear=sp_linear, **params)
+  out_flat = lax.cond_p.bind(*args, branches=sp_branches, **params)
   out = tree_unflatten(treedefs[0], out_flat)
   return arrays_to_spvalues(spenv, out)
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6448,7 +6448,6 @@ class JaxprTest(jtu.JaxTestCase):
             p:f32[] = add n l
           in (p,) }
       )
-      linear=(False, False, False, False)
     ] e a a c d
   in (f,) }"""
     jaxpr = api.make_jaxpr(f)(jnp.float32(3.))
@@ -10028,8 +10027,7 @@ class CustomTransposeTest(jtu.JaxTestCase):
       return x + fn(y, x)
 
     def cond_wrap(f):
-      return lambda i, x: lax.cond(i > 0, f, lambda x: x, x,
-                                   linear=(True,))
+      return lambda i, x: lax.cond(i > 0, f, lambda x: x, x)
 
     i = 7.
     x = jnp.ones(2) * 6.
@@ -10053,8 +10051,7 @@ class CustomTransposeTest(jtu.JaxTestCase):
       return x + fn(y, x)
 
     def cond_wrap(f):
-      return lambda i, x: lax.cond(i > 0, f, lambda x: x, x,
-                                   linear=(True,))
+      return lambda i, x: lax.cond(i > 0, f, lambda x: x, x)
 
     i = 7.
     x = jnp.ones(2) * 6.

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -2721,8 +2721,7 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
                                  { lambda  ; f_ a b c g h.
                                    let d = broadcast_in_dim[ broadcast_dimensions=(  )
                                                              shape=(5,) ] 0.00
-                                   in (a, d, g, h) } )
-                      linear=(False, False, False, False, False, False) ] e a 1 2 c h i
+                                   in (a, d, g, h) } ) ] e a 1 2 c h i
           in (f, g, j, k) }""", func, [y, 5])
 
   def test_while(self):

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2562,22 +2562,6 @@ class LaxControlFlowTest(jtu.JaxTestCase):
                   'tuple of ClosedJaxpr required: (4, 2)'),
         lambda: core.check_jaxpr(jaxpr))
 
-    jaxpr, eqn = new_jaxpr()
-    eqn.params['linear'] = (4, 2)
-    self.assertRaisesRegex(
-        core.JaxprTypeError,
-        re.escape('invalid cond param linear of type tuple, '
-                  'tuple of bool required: (4, 2)'),
-        lambda: core.check_jaxpr(jaxpr))
-
-    jaxpr, eqn = new_jaxpr()
-    eqn.params['linear'] = 'multi\nline'
-    self.assertRaisesRegex(
-        core.JaxprTypeError,
-        r'invalid cond param linear of type str, '
-        r'tuple of bool required:\r?\nmulti\r?\nline',
-        lambda: core.check_jaxpr(jaxpr))
-
   def test_cond_transformation_rule_with_consts(self):
     # https://github.com/google/jax/pull/9731
 

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -81,7 +81,6 @@ class MetadataTest(jtu.JaxTestCase):
     def f(which, x):
       return jax.lax.cond(which, x, true_fun, x, false_fun)
     hlo = module_to_string(jax.jit(f).lower(True, 1.).compiler_ir())
-    self.assertRegex(hlo, r'loc\(".*cond\[linear=\(False, False\)\]"')
     self.assertRegex(hlo, r'loc\(".*cond/branch_0_fun/cos"')
     self.assertRegex(hlo, r'loc\(".*cond/branch_1_fun/sin"')
 


### PR DESCRIPTION
As far as I can tell, it seems like the `linear` parameter in the `lax.cond_p` primitive only exists for historical reasons. It could be used for type checking in `_cond_transpose`, but that was removed because of #14026. With this in mind, we could stop tracking this parameter as implemented in this PR, unless we expect that we'd want to re-introduce the type checking in the future.