### PR TITLE
tweak dynamic trace state to only depend on level int, not MainTrace

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -875,7 +875,7 @@ class _ThreadLocalStateCache(threading.local):
 
   The extra_jit_context in jax_jit.thread_local_state() may get updated and thus
   incurring dispatch overhead for comparing this python object during jit calls.
-  We want to duduplicate the objects that have the same hash/equality to also
+  We want to deduplicate the objects that have the same hash/equality to also
   have the same object ID, since the equality check is much faster if the object
   IDs match.
   """

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1040,13 +1040,8 @@ class TraceState:
 
 
 def _update_thread_local_jit_state(dynamic):
-  # Copies the MainTrace instance, removing any .debug_info or .jaxpr_stack
-  # fields that should not be kept alive as part of a cache key.
-  # TODO(mattjj): split debug_info and jaxpr_stack out of MainTrace.
-  # TODO(mattjj): add a test that verifies that JIT-ted functions are not kept
-  # alive by the JIT cache, particularly for nested JIT-ted functions.
-  copy = MainTrace(dynamic.level, dynamic.trace_type, **dynamic.payload)
-  config.update_thread_local_jit_state(dynamic_trace_state=copy)
+  state = (dynamic.level, dynamic.trace_type)
+  config.update_thread_local_jit_state(dynamic_trace_state=state)
 
 
 # The global state of the tracer is accessed by a thread-local object.
@@ -1071,8 +1066,8 @@ def _initialize_jax_jit_thread_local_state():
   tls = jax_jit.thread_local_state()
   if tls.extra_jit_context is None:
     dynamic = thread_local_state.trace_state.trace_stack.dynamic
-    copy = MainTrace(dynamic.level, dynamic.trace_type, **dynamic.payload)
-    config.update_thread_local_jit_state(dynamic_trace_state=copy)
+    state = (dynamic.level, dynamic.trace_type)
+    config.update_thread_local_jit_state(dynamic_trace_state=state)
 
 
 jax_jit.set_thread_local_state_initialization_callback(


### PR DESCRIPTION
This is a small step in simplifying some parts of the core tracing machinery.

Our caches, like the C++ dispatch cache, must depend on JAX's global tracing state. The main part of the global state is the trace stack (aka `core.thread_local_state.trace_state.trace_stack`), and one component of that is which trace is the 'dynamic' trace, i.e. `core.thread_local_state.trace_state.trace_stack.dynamic`. That attribute is a reference to a `MainTrace` instance, but it could've just been an `int`: it's just pointing to object in`core.thread_local_state.trace_state.trace_stack.stack`, which is a `list[MainTrace]`.

We should probably make it an int! Or revise it away completely.

That's planned follow-up work. For now, this PR just changes the way we represent it to the C++ cache: we can only hit the fast path when the trace state is basically `TraceStack(stack=[EvalTrace(0)], dynamic=0)`, so we should include `(dynamic.level, dynamic.trace_type)` in the cache key (and we'll only ever populate a cache entry when it's `(0, EvalTrace)`).