### PR TITLE
Fixing the naming conventions in linalg.py

### DIFF
--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -415,7 +415,7 @@ def eigh(a: ArrayLike, b: ArrayLike | None = None, lower: bool = True,
          type: int = 1, check_finite: bool = True) -> Array | tuple[Array, Array]:
   """Compute eigenvalues and eigenvectors for a Hermitian matrix
 
-  JAX implementation of :func:`jax.scipy.linalg.eigh`.
+  JAX implementation of :func:`scipy.linalg.eigh`.
 
   Args:
     a: Hermitian input array of shape ``(..., N, N)``


### PR DESCRIPTION
Modified the **jax.scipy.linalg.eigh** to **scipy.linalg.eigh** in the `linalg.py` file