### PR TITLE
[pallas] Added more documentation for grid and BlockSpec.

### DIFF
--- a/docs/jax.experimental.pallas.rst
+++ b/docs/jax.experimental.pallas.rst
@@ -1,0 +1,23 @@
+``jax.experimental.pallas`` module
+==================================
+
+.. automodule:: jax.experimental.pallas
+
+Classes
+-------
+
+.. autosummary::
+  :toctree: _autosummary
+
+  BlockSpec
+
+Functions
+---------
+
+.. autosummary::
+  :toctree: _autosummary
+
+  pallas_call
+  program_id
+  num_programs
+

--- a/docs/jax.experimental.rst
+++ b/docs/jax.experimental.rst
@@ -28,6 +28,7 @@ Experimental Modules
     jax.experimental.mesh_utils
     jax.experimental.serialize_executable
     jax.experimental.shard_map
+    jax.experimental.pallas
 
 Experimental APIs
 -----------------

--- a/docs/pallas/design.md
+++ b/docs/pallas/design.md
@@ -286,9 +286,10 @@ The signature of `pallas_call` is as follows:
 ```python
 def pallas_call(
     kernel: Callable,
+    out_shape: Sequence[jax.ShapeDtypeStruct],
+    *,
     in_specs: Sequence[Spec],
     out_specs: Sequence[Spec],
-    out_shapes: Sequence[jax.ShapeDtypeStruct],
     grid: Optional[Tuple[int, ...]] = None) -> Callable:
   ...
 ```
@@ -303,9 +304,9 @@ information about how the kernel will be scheduled on the accelerator.
 The (rough) semantics for `pallas_call` are as follows:
 
 ```python
-def pallas_call(kernel, in_specs, out_specs, out_shapes, grid):
+def pallas_call(kernel, out_shape, *, in_specs, out_specs, grid):
   def execute(*args):
-    outputs = map(empty_ref, out_shapes)
+    outputs = map(empty_ref, out_shape)
     grid_indices = map(range, grid)
     for indices in itertools.product(*grid_indices): # Could run in parallel!
       local_inputs = [in_spec.transform(arg, indices) for arg, in_spec in

--- a/docs/pallas/grid_blockspec.md
+++ b/docs/pallas/grid_blockspec.md
@@ -1,0 +1,213 @@
+(pallas_grids_and_blockspecs)=
+
+# Grids and BlockSpecs
+
+(pallas_grid)=
+### `grid`, a.k.a. kernels in a loop
+
+When using {func}`jax.experimental.pallas.pallas_call` the kernel function
+is executed multiple times on different inputs, as specified via the `grid` argument
+to `pallas_call`. Conceptually:
+```python
+pl.pallas_call(some_kernel, grid=(n,))(...)
+```
+maps to
+```python
+for i in range(n):
+  some_kernel(...)
+```
+Grids can be generalized to be multi-dimensional, corresponding to nested
+loops. For example,
+
+```python
+pl.pallas_call(some_kernel, grid=(n, m))(...)
+```
+is equivalent to
+```python
+for i in range(n):
+  for j in range(m):
+    some_kernel(...)
+```
+This generalizes to any tuple of integers (a length `d` grid will correspond
+to `d` nested loops).
+The kernel is executed as many times
+as `prod(grid)`. Each of these invocations is referred to as a "program".
+To access which program (i.e. which element of the grid) the kernel is currently
+executing, we use {func}`jax.experimental.pallas.program_id`.
+For example, for invocation `(1, 2)`, `program_id(axis=0)` returns `1` and
+`program_id(axis=1)` returns `2`.
+You can also use {func}`jax.experimental.pallas.num_programs` to get the
+grid size for a given axis.
+
+Here's an example kernel that uses a `grid` and `program_id`.
+
+```python
+>>> import jax
+>>> from jax.experimental import pallas as pl
+
+>>> def iota_kernel(o_ref):
+...   i = pl.program_id(0)
+...   o_ref[i] = i
+
+```
+
+We now execute it using `pallas_call` with an additional `grid` argument.
+
+```python
+>>> def iota(size: int):
+...   return pl.pallas_call(iota_kernel,
+...                         out_shape=jax.ShapeDtypeStruct((size,), jnp.int32),
+...                         grid=(size,), interpret=True)()
+>>> iota(8)
+Array([0, 1, 2, 3, 4, 5, 6, 7], dtype=int32)
+
+```
+
+On GPUs, each program is executed in parallel on separate thread blocks.
+Thus, we need to think about race conditions on writes to HBM.
+A reasonable approach is to write our kernels in such a way that different
+programs write to disjoint places in HBM to avoid these parallel writes.
+
+On TPUs, programs are executed in a combination of parallel and sequential
+(depending on the architecture) so there are slightly different considerations.
+See [the Pallas TPU documentation](https://jax.readthedocs.io/en/latest/pallas/tpu/details.html#noteworthy-properties-and-restrictions).
+
+(pallas_blockspec)=
+
+### `BlockSpec`, a.k.a. how to chunk up inputs
+
+```{note}
+The documentation here applies to the ``indexing_mode == Blocked``, which
+is the default.
+The documentation for the ``indexing_mode == Unblocked`` is coming.
+```
+
+In conjunction with the `grid` argument, we need to provide Pallas
+the information on how to slice up the input for each invocation.
+Specifically, we need to provide a mapping between *the iteration of the loop*
+to *which block of our inputs and outputs to be operated on*.
+This is provided via {class}`jax.experimental.pallas.BlockSpec` objects.
+
+Before we get into the details of `BlockSpec`s, you may want
+to revisit the
+[Pallas Quickstart BlockSpecs example](https://jax.readthedocs.io/en/latest/pallas/quickstart.html#block-specs-by-example).
+
+`BlockSpec`s are provided to `pallas_call` via the
+`in_specs` and `out_specs`, one for each input and output respectively.
+
+Informally, the `index_map` of the `BlockSpec` takes as arguments
+the invocation indices (as many as the length of the `grid` tuple),
+and returns **block indices** (one block index for each axis of
+the overall array). Each block index is then multiplied by the
+corresponding axis size from `block_shape`
+to get the actual element index on the corresponding array axis.
+
+```{note}
+This documentation applies to the case when the block shape divides
+the array shape.
+The documentation for the other cases is pending.
+```
+
+More precisely, the slices for each axis of the input `x` of
+shape `x_shape` are computed as in the function `slice_for_invocation`
+below:
+
+```python
+>>> def slices_for_invocation(x_shape: tuple[int, ...],
+...                           x_spec: pl.BlockSpec,
+...                           grid: tuple[int, ...],                            
+...                           invocation_indices: tuple[int, ...]) -> tuple[slice, ...]:
+...   assert len(invocation_indices) == len(grid)
+...   assert all(0 <= i < grid_size for i, grid_size in zip(invocation_indices, grid))
+...   block_indices = x_spec.index_map(*invocation_indices)
+...   assert len(x_shape) == len(x_spec.block_shape) == len(block_indices)
+...   elem_indices = []
+...   for x_size, block_size, block_idx in zip(x_shape, x_spec.block_shape, block_indices):
+...     assert block_size <= x_size  # Blocks must be smaller than the array
+...     start_idx = block_idx * block_size
+...     # For now, we document only the case when the entire iteration is in bounds
+...     assert start_idx + block_size <= x_size
+...     elem_indices.append(slice(start_idx, start_idx + block_size))
+...   return elem_indices
+
+```
+
+For example:
+```python
+>>> slices_for_invocation(x_shape=(100, 100),
+...                       x_spec = pl.BlockSpec(lambda i, j: (i, j), (10, 20)),
+...                       grid = (10, 5),    
+...                       invocation_indices = (2, 3))
+[slice(20, 30, None), slice(60, 80, None)]
+
+>>> # Same shape of the array and blocks, but we iterate over each block 4 times
+>>> slices_for_invocation(x_shape=(100, 100),
+...                       x_spec = pl.BlockSpec(lambda i, j, k: (i, j), (10, 20)),
+...                       grid = (10, 5, 4),    
+...                       invocation_indices = (2, 3, 0))
+[slice(20, 30, None), slice(60, 80, None)]
+
+```
+
+The function `show_invocations` defined below uses Pallas to show the
+invocation indices. The `iota_2D_kernel` will fill each output block
+with a decimal number where the first digit represents the invocation
+index over the first axis, and the second the invocation index
+over the second axis:
+
+```python
+>>> def show_invocations(x_shape, block_shape, grid, out_index_map=lambda i, j: (i, j)):
+...   def iota_2D_kernel(o_ref):
+...    axes = 0
+...    for axis in range(len(grid)):
+...      axes += pl.program_id(axis) * 10**(len(grid) - 1 - axis)
+...    o_ref[...] = jnp.full(o_ref.shape, axes)
+...   res = pl.pallas_call(iota_2D_kernel,
+...                        out_shape=jax.ShapeDtypeStruct(x_shape, dtype=np.int32),
+...                        grid=grid,
+...                        in_specs=[],
+...                        out_specs=pl.BlockSpec(out_index_map, block_shape),
+...                        interpret=True)()
+...   print(res)
+
+```
+
+For example:
+```python
+>>> show_invocations(x_shape=(8, 6), block_shape=(2, 3), grid=(4, 2))
+[[ 0  0  0  1  1  1]
+ [ 0  0  0  1  1  1]
+ [10 10 10 11 11 11]
+ [10 10 10 11 11 11]
+ [20 20 20 21 21 21]
+ [20 20 20 21 21 21]
+ [30 30 30 31 31 31]
+ [30 30 30 31 31 31]]
+
+```
+
+When multiple invocations write to the same elements of the output
+array the result is platform dependent.
+
+In the example below, we have a 3D grid with the last grid dimension
+not used in the block selection (`out_index_map=lambda i, j, k: (i, j)`).
+Hence, we iterate over the same output block 10 times.
+The output shown below was generated on CPU using `interpret=True`
+mode, which at the moment executes the invocation sequentially.
+On TPUs, programs are executed in a combination of parallel and sequential,
+and this function generates the output shown. 
+See [the Pallas TPU documentation](https://jax.readthedocs.io/en/latest/pallas/tpu/details.html#noteworthy-properties-and-restrictions).
+
+```python
+>>> show_invocations(x_shape=(8, 6), block_shape=(2, 3), grid=(4, 2, 10),
+...                  out_index_map=lambda i, j, k: (i, j))
+[[  9   9   9  19  19  19]
+ [  9   9   9  19  19  19]
+ [109 109 109 119 119 119]
+ [109 109 109 119 119 119]
+ [209 209 209 219 219 219]
+ [209 209 209 219 219 219]
+ [309 309 309 319 319 319]
+ [309 309 309 319 319 319]]
+
+```

--- a/docs/pallas/index.rst
+++ b/docs/pallas/index.rst
@@ -4,13 +4,15 @@ Pallas: a JAX kernel language
 =============================
 Pallas is an extension to JAX that enables writing custom kernels for GPU and TPU.
 This section contains tutorials, guides and examples for using Pallas.
+See also the :class:`jax.experimental.pallas` module API documentation.
 
 .. toctree::
    :caption: Guides
    :maxdepth: 2
 
-   design
    quickstart
+   design
+   grid_blockspec
 
 .. toctree::
    :caption: Platform Features

--- a/docs/pallas/quickstart.ipynb
+++ b/docs/pallas/quickstart.ipynb
@@ -72,7 +72,7 @@
     "\n",
     "Let's dissect this function a bit. Unlike most JAX functions you've probably written,\n",
     "it does not take in `jax.Array`s as inputs and doesn't return any values.\n",
-    "Instead it takes in *`Ref`* objects as inputs. Note that we also don't have any outputs\n",
+    "Instead, it takes in *`Ref`* objects as inputs. Note that we also don't have any outputs\n",
     "but we are given an `o_ref`, which corresponds to the desired output.\n",
     "\n",
     "**Reading from `Ref`s**\n",
@@ -194,7 +194,7 @@
     "live in high-bandwidth memory (HBM, also known as DRAM) and expressing computations\n",
     "that operate on \"blocks\" of those arrays that can fit in SRAM.\n",
     "\n",
-    "### Grids\n",
+    "### Grids by example\n",
     "\n",
     "To automatically \"carve\" up the inputs and outputs, you provide a `grid` and\n",
     "`BlockSpec`s to `pallas_call`.\n",
@@ -259,10 +259,10 @@
     }
    ],
    "source": [
-    "def iota(len: int):\n",
+    "def iota(size: int):\n",
     "  return pl.pallas_call(iota_kernel,\n",
-    "                        out_shape=jax.ShapeDtypeStruct((len,), jnp.int32),\n",
-    "                        grid=(len,))()\n",
+    "                        out_shape=jax.ShapeDtypeStruct((size,), jnp.int32),\n",
+    "                        grid=(size,))()\n",
     "iota(8)"
    ]
   },
@@ -279,7 +279,9 @@
     "operations like matrix multiplications really quickly.\n",
     "\n",
     "On TPUs, programs are executed in a combination of parallel and sequential\n",
-    "(depending on the architecture) so there are slightly different considerations."
+    "(depending on the architecture) so there are slightly different considerations.\n",
+    "\n",
+    "You can read more details at {ref}`pallas_grid`."
    ]
   },
   {
@@ -287,7 +289,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Block specs"
+    "### Block specs by example"
    ]
   },
   {
@@ -384,6 +386,8 @@
     "Finally, for `z` we use `BlockSpec(lambda i, j: (i, j), (512, 512))`.\n",
     "\n",
     "These `BlockSpec`s are passed into `pallas_call` via `in_specs` and `out_specs`.\n",
+    "\n",
+    "For more detail on `BlockSpec`s see {ref}`pallas_blockspec`.\n",
     "\n",
     "Underneath the hood, `pallas_call` will automatically carve up your inputs and\n",
     "outputs into `Ref`s for each block that will be passed into the kernel."

--- a/docs/pallas/quickstart.md
+++ b/docs/pallas/quickstart.md
@@ -53,7 +53,7 @@ def add_vectors_kernel(x_ref, y_ref, o_ref):
 
 Let's dissect this function a bit. Unlike most JAX functions you've probably written,
 it does not take in `jax.Array`s as inputs and doesn't return any values.
-Instead it takes in *`Ref`* objects as inputs. Note that we also don't have any outputs
+Instead, it takes in *`Ref`* objects as inputs. Note that we also don't have any outputs
 but we are given an `o_ref`, which corresponds to the desired output.
 
 **Reading from `Ref`s**
@@ -133,7 +133,7 @@ Part of writing Pallas kernels is thinking about how to take big arrays that
 live in high-bandwidth memory (HBM, also known as DRAM) and expressing computations
 that operate on "blocks" of those arrays that can fit in SRAM.
 
-### Grids
+### Grids by example
 
 To automatically "carve" up the inputs and outputs, you provide a `grid` and
 `BlockSpec`s to `pallas_call`.
@@ -170,10 +170,10 @@ def iota_kernel(o_ref):
 We now execute it using `pallas_call` with an additional `grid` argument.
 
 ```{code-cell} ipython3
-def iota(len: int):
+def iota(size: int):
   return pl.pallas_call(iota_kernel,
-                        out_shape=jax.ShapeDtypeStruct((len,), jnp.int32),
-                        grid=(len,))()
+                        out_shape=jax.ShapeDtypeStruct((size,), jnp.int32),
+                        grid=(size,))()
 iota(8)
 ```
 
@@ -187,9 +187,11 @@ operations like matrix multiplications really quickly.
 On TPUs, programs are executed in a combination of parallel and sequential
 (depending on the architecture) so there are slightly different considerations.
 
+You can read more details at {ref}`pallas_grid`.
+
 +++
 
-### Block specs
+### Block specs by example
 
 +++
 
@@ -278,6 +280,8 @@ For `y`, we use a transposed version `BlockSpec(lambda i, j: (0, j), (1024, 512)
 Finally, for `z` we use `BlockSpec(lambda i, j: (i, j), (512, 512))`.
 
 These `BlockSpec`s are passed into `pallas_call` via `in_specs` and `out_specs`.
+
+For more detail on `BlockSpec`s see {ref}`pallas_blockspec`.
 
 Underneath the hood, `pallas_call` will automatically carve up your inputs and
 outputs into `Ref`s for each block that will be passed into the kernel.

--- a/docs/pallas/tpu/details.rst
+++ b/docs/pallas/tpu/details.rst
@@ -65,7 +65,8 @@ Noteworthy properties and restrictions
 ``BlockSpec``\s and grid iteration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``BlockSpec``\s generally behave as expected in Pallas --- every invocation of
+``BlockSpec``\s (see :ref:`pallas_blockspec`) generally behave as expected
+in Pallas --- every invocation of
 the kernel body gets access to slices of the inputs and is meant to initialize a slice
 of the output.
 

--- a/docs/pallas/tpu/pipelining.ipynb
+++ b/docs/pallas/tpu/pipelining.ipynb
@@ -6,7 +6,7 @@
     "id": "teoJ_fUwlu0l"
    },
    "source": [
-    "# Pipelining and `BlockSpec`s\n",
+    "# Pipelining\n",
     "\n",
     "<!--* freshness: { reviewed: '2024-04-08' } *-->"
    ]
@@ -262,83 +262,23 @@
     "It seems like a complex sequence of asynchronous data operations and\n",
     "executing kernels that would be a pain to implement manually.\n",
     "Fear not! Pallas offers an API for expressing pipelines without too much\n",
-    "boilerplate, namely through `grid`s and `BlockSpec`s."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "x-LQKu8HwED7"
-   },
-   "source": [
-    "### `grid`, a.k.a. kernels in a loop\n",
+    "boilerplate, namely through `grid`s and `BlockSpec`s.\n",
     "\n",
     "See how in the above pipelined example, we are executing the same logic\n",
     "multiple times: steps 3-5 and 8-10 both execute the same operations,\n",
     "only on different inputs.\n",
-    "The generalized version of this is a loop in which the same kernel is\n",
-    "executed multiple times.\n",
-    "`pallas_call` provides an option to do exactly that.\n",
+    "The {func}`jax.experimental.pallas.pallas_call` provides a way to\n",
+    "execute a kernel multiple times, by using the `grid` argument.\n",
+    "See {ref}`pallas_grid`.\n",
     "\n",
-    "The number of iterations in the loop is specified via the `grid` argument\n",
-    "to `pallas_call`. Conceptually:\n",
-    "```python\n",
-    "pl.pallas_call(some_kernel, grid=n)(...)\n",
-    "```\n",
-    "maps to\n",
-    "```python\n",
-    "for i in range(n):\n",
-    "  # do HBM -> VMEM copies\n",
-    "  some_kernel(...)\n",
-    "  # do VMEM -> HBM copies\n",
-    "```\n",
-    "Grids can be generalized to be multi-dimensional, corresponding to nested\n",
-    "loops. For example,\n",
+    "We also use {class}`jax.experimental.pallas.BlockSpec` to specify\n",
+    "how to construct the input of each kernel invocation.\n",
+    "See {ref}`pallas_blockspec`.\n",
     "\n",
-    "```python\n",
-    "pl.pallas_call(some_kernel, grid=(n, m))(...)\n",
-    "```\n",
-    "is equivalent to\n",
-    "```python\n",
-    "for i in range(n):\n",
-    "  for j in range(m):\n",
-    "    # do HBM -> VMEM copies\n",
-    "    some_kernel(...)\n",
-    "    # do VMEM -> HBM copies\n",
-    "```\n",
-    "This generalizes to any tuple of integers (a length `d` grid will correspond\n",
-    "to `d` nested loops)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "hRLr5JeyyEwM"
-   },
-   "source": [
-    "### `BlockSpec`, a.k.a. how to chunk up inputs"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "miWgPkytyIIa"
-   },
-   "source": [
-    "The next piece of information we need to provide Pallas in order to\n",
-    "automatically pipeline our computation is information on how to chunk it up.\n",
-    "Specifically, we need to provide a mapping between *the iteration of the loop*\n",
-    "to *which block of our inputs and outputs to be operated on*.\n",
-    "A `BlockSpec` is exactly these two pieces of information.\n",
-    "\n",
-    "First we pick a `block_shape` for our inputs.\n",
     "In the pipelining example above, we had `(512, 512)`-shaped arrays and\n",
     "split them along the leading dimension into two `(256, 512)`-shaped arrays.\n",
-    "In this pipeline, our `block_shape` would be `(256, 512)`.\n",
-    "\n",
-    "We then provide an `index_map` function that maps the iteration space to the\n",
-    "blocks.\n",
-    "Specifically, in the aforementioned pipeline, on the 1st iteration we'd\n",
+    "In this pipeline, our `BlockSpec.block_shape` would be `(256, 512)`.\n",
+    "On the 1st iteration we'd\n",
     "like to select `x1` and on the second iteration we'd like to use `x2`.\n",
     "This can be expressed with the following `index_map`:\n",
     "\n",

--- a/jax/_src/pallas/core.py
+++ b/jax/_src/pallas/core.py
@@ -171,6 +171,10 @@ IndexingMode = Union[Blocked, Unblocked]
 
 @dataclasses.dataclass(unsafe_hash=True)
 class BlockSpec:
+  """Specifies how an array should be sliced for each iteration of a kernel.
+
+  See :ref:`pallas_blockspec` for more details.
+  """
   index_map: Callable[..., Any] | None = None
   block_shape: tuple[int | None, ...] | None = None
   memory_space: Any | None = None

--- a/jax/_src/pallas/primitives.py
+++ b/jax/_src/pallas/primitives.py
@@ -49,7 +49,15 @@ zip, unsafe_zip = util.safe_zip, zip
 program_id_p = jax_core.Primitive("program_id")
 
 def program_id(axis: int) -> jax.Array:
-  """Returns the kernel execution position along the given axis of the grid."""
+  """Returns the kernel execution position along the given axis of the grid.
+
+  For example, with a 2D `grid` in the kernel execution corresponding to the
+  grid coordinates `(1, 2)`,
+  `program_id(axis=0)` returns `1` and `program_id(axis=1)` returns `2`.
+
+  Args:
+    axis: the axis of the grid along which to count the program.
+  """
   return program_id_p.bind(axis=axis)
 
 def program_id_bind(*, axis: int):

--- a/jax/experimental/pallas/__init__.py
+++ b/jax/experimental/pallas/__init__.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module for pallas, a JAX extension for custom kernels."""
+"""Module for Pallas, a JAX extension for custom kernels.
+
+See the Pallas documentation at https://jax.readthedocs.io/en/latest/pallas.html.
+"""
 
 from jax._src import pallas
 from jax._src.pallas.core import BlockSpec


### PR DESCRIPTION
The starting point was the text in pipelining.md, where I replaced it now with a reference to the separate grid and BlockSpec documentation.

The grids and BlockSpecs are also documented in the quickstart.md, which I mostly left alone because it was good enough for a simple example.

I have also attempted to add a few docstrings.

The rendered documentation is at: https://jax--22134.org.readthedocs.build/en/22134/pallas/index.html and https://jax--22134.org.readthedocs.build/en/22134/jax.experimental.pallas.html#module-jax.experimental.pallas.