### PR TITLE
Improve docs and add test case for RegularGridInterpolator

### DIFF
--- a/jax/_src/third_party/scipy/interpolate.py
+++ b/jax/_src/third_party/scipy/interpolate.py
@@ -40,7 +40,8 @@ class RegularGridInterpolator:
     values: N-dimensional array specifying the grid values.
     method: interpolation method, either ``"linear"`` or ``"nearest"``.
     bounds_error: not implemented by JAX
-    fill_value: value returned for points outside the grid, defaults to NaN.
+    fill_value: value returned for points outside the grid. If None, values outside the
+      grid are extrapolated. Defaults to NaN.
 
   Returns:
     interpolator: callable interpolation object.

--- a/tests/scipy_interpolate_test.py
+++ b/tests/scipy_interpolate_test.py
@@ -33,8 +33,9 @@ class LaxBackedScipyInterpolateTests(jtu.JaxTestCase):
   @jtu.sample_product(
     spaces=(((0., 10., 10),), ((-15., 20., 12), (3., 4., 24))),
     method=("linear", "nearest"),
+    fill_value=(np.nan, None),
   )
-  def testRegularGridInterpolator(self, spaces, method):
+  def testRegularGridInterpolator(self, spaces, method, fill_value):
     rng = jtu.rand_default(self.rng())
     scipy_fun = lambda init_args, call_args: sp_interp.RegularGridInterpolator(
         *init_args[:2], method, False, *init_args[2:])(*call_args)
@@ -44,7 +45,6 @@ class LaxBackedScipyInterpolateTests(jtu.JaxTestCase):
     def args_maker():
       points = tuple(map(lambda x: np.linspace(*x), spaces))
       values = rng(reduce(operator.add, tuple(map(np.shape, points))), float)
-      fill_value = np.nan
 
       init_args = (points, values, fill_value)
       n_validation_points = 50


### PR DESCRIPTION
Aligns the [documentation](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.interpolate.RegularGridInterpolator.html#jax.scipy.interpolate.RegularGridInterpolator) of the `fill_value` argument of `RegularGridInterpolator` with that of [scipy](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RegularGridInterpolator.html), and adds a corresponding test case.

Solves discussion #22031.

---

#### What is the newly documented behavior?

If `fill_value = None` is passed to `RegularGridInterpolator`, extrapolation outside the domain is performed.

#### Is the newly documented behavior tested?

Yes. The current test of JAX's `RegularGridInterpolator` already used validation points outside the domain. I've adjusted the test such that a `fill_value` of `None` is also compared between the scipy and JAX implementations.