### PR TITLE
Add `register_custom_call_target` to `xla_client` API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -315,6 +315,8 @@ def linkcode_resolve(domain, info):
     return None
   if not info['fullname']:
     return None
+  if info['module'].split(".")[0] != 'jax':
+     return None
   try:
     mod = sys.modules.get(info['module'])
     obj = operator.attrgetter(info['fullname'])(mod)

--- a/docs/jax.lib.rst
+++ b/docs/jax.lib.rst
@@ -21,4 +21,6 @@ jax.lib.xla_client
 .. currentmodule:: jaxlib.xla_client
 
 .. autosummary::
-   :toctree: _autosummary
+  :toctree: _autosummary
+
+  register_custom_call_target


### PR DESCRIPTION
This function is (for better or worse) user facing for custom call users. I think it's worth having this in the API docs.

Preview: https://jax--22150.org.readthedocs.build/en/22150/_autosummary/jaxlib.xla_client.register_custom_call_target.html