### PR TITLE
Bump minimum supported CUDNN version to 9.0

### DIFF
--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -366,7 +366,7 @@ def _check_cuda_versions(raise_on_first_error: bool = False,
       # versions:
       # https://docs.nvidia.com/deeplearning/cudnn/developer-guide/index.html#api-compat
       scale_for_comparison=100,
-      min_supported_version=8900
+      min_supported_version=9000
   )
   _version_check("cuFFT", cuda_versions.cufft_get_version,
                  cuda_versions.cufft_build_version,


### PR DESCRIPTION
This should have been changed for the 0.4.30 release; updating this value will lead to better errors when attempting to install with an older cudnn.