### PR TITLE
[memories] Overlap shard transfers in async_serialize

### DIFF
--- a/jax/experimental/array_serialization/serialization.py
+++ b/jax/experimental/array_serialization/serialization.py
@@ -29,6 +29,7 @@ from typing import Any, Optional
 
 import jax
 from jax._src import array
+from jax._src import config
 from jax._src import distributed
 from jax._src import sharding
 from jax._src import sharding_impls
@@ -184,6 +185,22 @@ class _LimitInFlightBytes:
       self._cv.notify_all()
 
 
+def transfer_shard_to_host(shard: array.Shard) -> np.ndarray:
+  data = shard.data
+  has_pinned_host = any(
+      m.kind == "pinned_host" for m in shard.device.addressable_memories())
+  if config.enable_memories.value and has_pinned_host:
+    # If available, transfer to pinned host memory
+    sharding = jax.sharding.SingleDeviceSharding(shard.device,
+        memory_kind="pinned_host")
+    data = jax.device_put(data, sharding)
+    # Ensure that jax.Array's internal numpy array can be zero-copied.
+    # Tensorstore implicitly converts the written data to a numpy array,
+    # and would otherwise silently copy host-to-host.
+    data = np.array(data, copy=False)
+  return data
+
+
 async def async_serialize(
     arr_inp,
     tensorstore_spec,
@@ -260,8 +277,9 @@ async def async_serialize(
 
   async def _write_array(shard):
     if shard.replica_id == replica_id:
+      data = transfer_shard_to_host(shard)
       write_future = t[shard.index].write(
-          shard.data,
+          data,
           # Avoid additional copy of input array into the TensorStore chunk
           # cache.  If `arr_inp` is a jax.Array, the result of converting
           # it to a NumPy array, as is done internally by TensorStore, is

--- a/jax/experimental/array_serialization/serialization_test.py
+++ b/jax/experimental/array_serialization/serialization_test.py
@@ -621,7 +621,7 @@ class TransferShardTest(jtu.JaxTestCase):
     arr = jax.device_put(np_inp, sharding)
     shard = arr.addressable_shards[0]
 
-    np_out = serialization.transfer_shard_to_host(shard)
+    np_out = asyncio.run(serialization.transfer_shard_to_host(shard))
 
     self.assertArraysEqual(np_out, np_inp)
 

--- a/jax/experimental/array_serialization/serialization_test.py
+++ b/jax/experimental/array_serialization/serialization_test.py
@@ -28,7 +28,7 @@ import jax.numpy as jnp
 from jax._src import test_util as jtu
 from jax._src import array
 from jax._src import xla_bridge as xb
-from jax.sharding import NamedSharding, GSPMDSharding
+from jax.sharding import NamedSharding, GSPMDSharding, SingleDeviceSharding
 from jax.sharding import PartitionSpec as P
 from jax.experimental.array_serialization import serialization
 from jax.experimental.layout import Layout, DeviceLocalLayout as DLL
@@ -609,6 +609,21 @@ class CheckpointTest(jtu.JaxTestCase):
     out = deserialized_arr.astype(jnp.int8)  # doesn't crash
     self.assertEqual(out.dtype, jnp.int8)
     self.assertArraysEqual(out + out, out * 2)
+
+
+@jtu.with_config(jax_enable_memories=True)
+class TransferShardTest(jtu.JaxTestCase):
+
+  @jtu.skip_on_devices('cpu')
+  def test_transfer_shard_to_host(self):
+    np_inp = np.arange(16).reshape((4, 4))
+    sharding = SingleDeviceSharding(jax.devices()[0], memory_kind="device")
+    arr = jax.device_put(np_inp, sharding)
+    shard = arr.addressable_shards[0]
+
+    np_out = serialization.transfer_shard_to_host(shard)
+
+    self.assertArraysEqual(np_out, np_inp)
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Builds upon https://github.com/google/jax/pull/22114, which introduces a fast-path for async checkpoint saving in which each array shard is copied through a single device-to-pinned-host transfer. So far, all of these transfers are serialized.

The present PR allows overlapping the transfers of a single array's shards. This is achieved by inserting `asyncio.sleep(0)` right after the transfer has been started, thereby permitting the `_write_array(shard)` coroutine to yield.

_Why do we need the sleep?_ Python's `await` doesn't actually guarantee that control will be yielded to the eventloop so that other coroutines can be scheduled. Python ties coroutine semantics to that of generators. [As I understand it](https://stackoverflow.com/a/59780868), the only thing that causes control to pass to the eventloop (and thus allows other coroutines to be scheduled) is a `yield`. What we therefore need to achieve overlap in our situation, is something like
```python
import types

@types.coroutine
def noop():
  yield

async def transfer_shard_to_host(shard):
  ...
  await noop() # behaves like asyncio.sleep(0)
  ...
```
This is, in fact, [what `asyncio.sleep(0)` does](https://github.com/python/cpython/blob/6e63d84e43fdce3a5bdb899b024cf947d4e48900/Lib/asyncio/tasks.py#L691-L707).

An alternative, more roundabout way to achieve overlap would be to split `_write_array(shard)` into a first phase that initiates all the transfers, and provides the resulting host-resident arrays to a second phase, in which we invoke `t.write(data)` as before.

cc @yashk2810 