### PR TITLE
[pallas] Improve some error messages and add API tests.

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1206,11 +1206,7 @@ def explain_tracing_cache_miss(
     p(f"  never seen input pytree{in_tree_str}")
     dont_match = [t for t, *_ in seen_keys if t != in_tree]
     closest_tree = min(dont_match, key=lambda t: abs(t.num_leaves - in_tree.num_leaves))
-    # TODO(mattjj): make equality_errors not print type name, avoid metaclass
-    leaf = type('LeafMeta', (type,), dict(__repr__=lambda _: 'leaf'))('Leaf', (), {})()
-    this_dummy = tree_unflatten(in_tree, [leaf] * in_tree.num_leaves)
-    close_dummy = tree_unflatten(closest_tree, [leaf] * closest_tree.num_leaves)  # type: ignore
-    errs = list(tree_util.equality_errors(this_dummy, close_dummy))
+    errs = list(tree_util.equality_errors_pytreedef(in_tree, closest_tree))  # type: ignore[arg-type]
     p(f"  closest seen input pytree has {len(errs)} mismatches, including:")
     for path, thing1, thing2, explanation in errs:
       fst, *path = path  # type: ignore

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -621,7 +621,7 @@ def equality_errors(
   """Helper to describe structural differences between two pytrees.
 
   Args:
-    tree1, tree2: pytrees to compare.
+    tree1, tree2: pytrees known to have different structure.
 
   Usage:
 
@@ -635,6 +635,15 @@ def equality_errors(
            in equality_errors(val1, val2))))
   """
   yield from _equality_errors((), tree1, tree2, is_leaf)
+
+def equality_errors_pytreedef(
+    tree1: PyTreeDef,
+    tree2: PyTreeDef) -> Iterable[tuple[KeyPath, str, str, str]]:
+  """Like `equality_errors` but invoked on PyTreeDef."""
+  # TODO(mattjj): make equality_errors not print type name, avoid metaclass
+  leaf = type("LeafMeta", (type,), dict(__repr__=lambda _: "pytree leaf"))("Leaf", (), {})()
+  return equality_errors(tree_unflatten(tree1, [leaf] * tree1.num_leaves),
+                         tree_unflatten(tree2, [leaf] * tree2.num_leaves))
 
 # TODO(mattjj): maybe share some logic with _prefix_error?
 def _equality_errors(path, t1, t2, is_leaf):

--- a/tests/pallas/tpu/pallas_random_test.py
+++ b/tests/pallas/tpu/pallas_random_test.py
@@ -184,7 +184,7 @@ class BlockInvarianceTest(parameterized.TestCase):
 
     def make_kernel_body(index_map):
       def body(key_ref, o_ref):
-        key = key_ref[0, 0]
+        key = key_ref[...]
         samples = plrandom.sample_block(
             jax.random.uniform,
             key,
@@ -199,9 +199,7 @@ class BlockInvarianceTest(parameterized.TestCase):
 
     global_key = jax_random.key(0, impl="pallas_tpu")
     o_shape = jnp.ones((64, 512), dtype=jnp.float32)
-    key_spec = pl.BlockSpec(
-        (1, 1), lambda i, j: (0, 0), memory_space=pltpu.TPUMemorySpace.SMEM
-    )
+    key_spec = pl.BlockSpec(memory_space=pltpu.TPUMemorySpace.SMEM)
     out_spec = pl.BlockSpec((16, 128), lambda i, j: (i, j))
     result_16x128 = pl.pallas_call(
         make_kernel_body(index_map=lambda i, j: (i, j)),


### PR DESCRIPTION
 We make the following improvements:

  * pytree structural disequality messages attempt to localize the
     mismatch using `tree_util.KeyPath`.
  * we generate a simpler error message for when `in_specs` is not
     a sequence, instead of the current PyTreeDef mismatch error.
  * we generate an error message for when the index map function
     returns an unexpected number of values.
  * added error localization to the existing shape polymorphism
     check that the block shapes are static.
  * we check that the rank of the block_shape matches the rank of
        the overall array. Without this we used to get a `safe_zip`
        error. We also carry the pytree paths to localize the error.
  * We check that the kernel function returns None. Without this
        we used to get `body_fun output and input must have same type structure`
        in the interpreter, `assert len(jaxpr.outvars) == 0` on GPU,
        and `INTERNAL: Mosaic failed to compile TPU kernel: has 1 operands, but enclosing function (@main) returns 0`
        on TPU.

To simplify the generation of the error messages we added a helper
function `tree_util.equality_errors_pytreedef`, which is just like
`tree_util.equality_errors` but takes `PyTreeDef` inputs rather than
PyTrees. We then used this new helper function in `pjit.py` and `stages.py`.