### PR TITLE
Deprecate jax.interpreters xb, xc, xe abbreviations.

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -23,14 +23,27 @@ from jax._src.dispatch import (
   apply_primitive as apply_primitive,
 )
 
-from jax._src import xla_bridge as xb
-from jax._src.lib import xla_client as xc
+from jax._src import xla_bridge as _xb
+from jax._src.lib import xla_client as _xc
 
-xe = xc._xla
-Backend = xe.Client
+_xe = _xc._xla
+Backend = _xe.Client
 
 # Deprecations
 _deprecations = {
+    # Added 2024-06-28
+    "xb": (
+        "jax.interpreters.xla.xb is deprecated. Use jax.lib.xla_bridge instead.",
+        _xb
+    ),
+    "xc": (
+        "jax.interpreters.xla.xc is deprecated. Use jax.lib.xla_client instead.",
+        _xc,
+    ),
+    "xe": (
+        "jax.interpreters.xla.xe is deprecated. Use jax.lib.xla_extension instead.",
+        _xe,
+    ),
     # Finalized 2024-05-13; remove after 2024-08-13
     "backend_specific_translations": (
         "jax.interpreters.xla.backend_specific_translations is deprecated. "
@@ -69,6 +82,13 @@ _deprecations = {
     ),
 }
 
+import typing
 from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
-__getattr__ = _deprecation_getattr(__name__, _deprecations)
+if typing.TYPE_CHECKING:
+  xb = _xb
+  xc = _xc
+  xe = _xe
+else:
+  __getattr__ = _deprecation_getattr(__name__, _deprecations)
 del _deprecation_getattr
+del typing


### PR DESCRIPTION
Instead, any users should import directly as `xb = jax.lib.xla_bridge`, `xc = jax.lib.xla_client`, `xe = jax.lib.xla_extension`.

APIs within `jax.interpreters.xla` are internal and not covered by the deprecation policy (see https://jax.readthedocs.io/en/latest/api_compatibility.html#what-is-covered) but we'll do at least a partial deprecation cycle in case this affects downstream packages.