### PR TITLE
jax.numpy: better docstring for array_equal function 

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3741,8 +3741,38 @@ def _check_forgot_shape_tuple(name, shape, dtype) -> str | None:  # type: ignore
             "with a single tuple argument for the shape?")
 
 
-@util.implements(np.array_equal)
 def array_equal(a1: ArrayLike, a2: ArrayLike, equal_nan: bool = False) -> Array:
+  """Check if two arrays are element-wise equal.
+
+  JAX implementation of :func:`numpy.array_equal`.
+
+  Args:
+    a1: first input array to compare.
+    a2: second input array to compare.
+    equal_nan: Boolean. If ``True``, NaNs in ``a1`` will be considered
+      equal to NaNs in ``a2``. Default is ``False``.
+
+  Returns:
+    Boolean scalar array indicating whether the input arrays are element-wise equal.
+
+  See Also:
+    - :func:`jax.numpy.allclose`
+    - :func:`jax.numpy.array_equiv`
+
+  Examples:
+    >>> jnp.array_equal(jnp.array([1, 2, 3]), jnp.array([1, 2, 3]))
+    Array(True, dtype=bool)
+    >>> jnp.array_equal(jnp.array([1, 2, 3]), jnp.array([1, 2]))
+    Array(False, dtype=bool)
+    >>> jnp.array_equal(jnp.array([1, 2, 3]), jnp.array([1, 2, 4]))
+    Array(False, dtype=bool)
+    >>> jnp.array_equal(jnp.array([1, 2, float('nan')]),
+    ...                 jnp.array([1, 2, float('nan')]))
+    Array(False, dtype=bool)
+    >>> jnp.array_equal(jnp.array([1, 2, float('nan')]),
+    ...                 jnp.array([1, 2, float('nan')]), equal_nan=True)
+    Array(True, dtype=bool)
+  """
   a1, a2 = asarray(a1), asarray(a2)
   if shape(a1) != shape(a2):
     return bool_(False)


### PR DESCRIPTION
Better docstring added for jax.numpy.array_equal.
Part of [21461](https://github.com/google/jax/issues/21461) 