### PR TITLE
make pe.inline_jaxpr_into_trace work with dynamic shapes

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2073,7 +2073,7 @@ raise_to_shaped_mappings : dict[type, Callable] = {
   UnshapedArray: lambda aval, _: aval,
   ShapedArray: lambda aval, weak_type: ShapedArray(
       aval.shape, aval.dtype, weak_type, aval.named_shape),
-  DConcreteArray: lambda aval, weak_type: DShapedArray(
+  DShapedArray: lambda aval, weak_type: DShapedArray(
       aval.shape, aval.dtype, weak_type),
 }
 

--- a/jax/_src/linear_util.py
+++ b/jax/_src/linear_util.py
@@ -286,7 +286,7 @@ def _check_input_type(in_type: core.InputType) -> None:
     return (isinstance(d, (int, core.DBIdx, core.DArray)) and
             (not isinstance(d, core.DArray) or type(d) is core.bint and not d.shape))
   assert all(valid_size(d) for a, _ in in_type if type(a) is core.DShapedArray
-             for d in a.shape)
+             for d in a.shape), in_type
 
   # Check that all DBIdx point to positions to the left of the input on which
   # they appear.

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1782,16 +1782,7 @@ def pjit_staging_rule(trace, *args, **params):
       all(is_unspecified(o) for o in params["out_shardings"]) and
       all(i is None for i in params["in_layouts"]) and
       all(o is None for o in params["out_layouts"])):
-
-    if config.dynamic_shapes.value:
-      # Inline jaxpr doesn't handle dynamic shapes when inlining. If dynamic
-      # shapes are enabled, use eval_jaxpr, which uses the tracing machinery,
-      # but redundantly performs abstract evaluation again.
-      out_tracers = core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, *args,
-                                    propagate_source_info=False)
-    else:
-      out_tracers = pe.inline_jaxpr_into_trace(
-          trace, jaxpr.jaxpr, jaxpr.consts, *args)
+    out_tracers = pe.inline_jaxpr_into_trace(trace, jaxpr.jaxpr, jaxpr.consts, *args)
   elif config.dynamic_shapes.value:
     source_info = source_info_util.current()
     out_tracers = []


### PR DESCRIPTION
To make `inline_jaxpr_into_trace` work with dynamic shapes, we need to perform variable substitution into the types of the jaxpr eqns being inlined. We also need to substitute in the appropriate tracers into the tracers produced corresponding to the inlined jaxpr's outvars.

The only difference is when `jax_dynamic_shapes=True`, so this shouldn't affect anything other than our own tests.