### PR TITLE
skip export_test.py if flatbuffers not importable

### DIFF
--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -45,6 +45,15 @@ from jax._src.lib.mlir.dialects import hlo
 
 import numpy as np
 
+try:
+  import flatbuffers
+  CAN_USE_FLATBUFFERS = True
+except (ModuleNotFoundError, ImportError):
+  CAN_USE_FLATBUFFERS = False
+
+if not CAN_USE_FLATBUFFERS:
+  raise unittest.SkipTest("tests require flatbuffers")
+
 config.parse_flags_with_absl()
 
 _exit_stack = contextlib.ExitStack()


### PR DESCRIPTION
This way we don't get lots of spurious failures when running things like `pytest tests`.