### PR TITLE
Add installation instructions back to documentation homepage.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,35 @@ For an end-to-end transformer library built on JAX, see MaxText_.
       :class-card: developer-docs
 
 
+Installation
+------------
+
+The easiest way to install JAX is with pip_:
+
+.. tab-set::
+
+    .. tab-item:: CPU
+
+       .. code-block:: bash
+
+          pip install -U jax
+
+    .. tab-item:: GPU (CUDA)
+
+       .. code-block:: bash
+
+          pip install -U "jax[cuda12]"
+
+    .. tab-item:: TPU (Google Cloud)
+
+       .. code-block:: bash
+
+          pip install -U "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+
+For more information about supported accelerators and platforms, and for other
+installation options, continue to :ref:`installation`.
+
+
 .. toctree::
    :hidden:
    :maxdepth: 1
@@ -97,3 +126,4 @@ For an end-to-end transformer library built on JAX, see MaxText_.
 .. _Orbax: https://orbax.readthedocs.io/
 .. _Optax: https://optax.readthedocs.io/
 .. _MaxText: https://github.com/google/maxtext/
+.. _pip: https://pip.pypa.io/


### PR DESCRIPTION
These instructions were removed in #17744, but it has been suggested that it would be useful to have easy access to this info directly from the docs homepage. Here, I added these instructions back and updated them with the current recommendations. This results in some duplication of the instructions (here, README, and `installation.md`), but it doesn't seem too onerous to keep these synchronized.

Here's what it looks like when rendered (I'll add a link to RTDs when it's finished):

<img width="833" alt="Screenshot 2024-07-01 at 4 18 58 PM" src="https://github.com/google/jax/assets/350282/d4f9ea23-4e79-4d10-96de-1f3d5c8101cc">
