### PR TITLE
make remat reduce precision of saved values to avoid xla excess precision

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -28,6 +28,7 @@ from jax._src import api
 from jax._src import config
 from jax._src import core
 from jax._src import dispatch
+from jax._src import dtypes
 from jax._src import linear_util as lu
 from jax._src import effects
 from jax._src import source_info_util
@@ -544,10 +545,15 @@ def remat_partial_eval(trace, *tracers, jaxpr, **params):
   jaxpr_known, in_used_known = pe.dce_jaxpr(jaxpr_known, out_used_known)
   num_res = sum(used_res)
 
+  # To avoid precision mismatches in fwd and bwd passes due to XLA excess
+  # precision, insert explicit x = reduce_precision(x, **finfo(x.dtype)) calls
+  # on producers of any residuals. See https://github.com/google/jax/pull/22244.
+  jaxpr_known_ = _insert_reduce_precision(jaxpr_known, num_res)
+
   # compute known outputs and residuals (hoisted out of remat primitive)
   _, in_consts_ = unzip2(t.pval for t in tracers if t.pval.is_known())
   _, in_consts = partition_list(in_used_known, in_consts_)
-  out_consts = core.eval_jaxpr(jaxpr_known, (), *in_consts)
+  out_consts = core.eval_jaxpr(jaxpr_known_, (), *in_consts)
   out_knowns, residuals = split_list(out_consts, [len(out_consts)-num_res])
 
   # set up unknown outputs with a recipe to call remat
@@ -586,6 +592,43 @@ def remat_partial_eval(trace, *tracers, jaxpr, **params):
   # zip together known and unknown outputs
   return merge_lists(out_unknowns, out_knowns, out_jaxpr_tracers)
 pe.custom_partial_eval_rules[remat_p] = remat_partial_eval
+
+@weakref_lru_cache
+def _insert_reduce_precision(jaxpr: core.Jaxpr, num_res: int) -> core.Jaxpr:
+  res_vars = jaxpr.outvars[len(jaxpr.outvars) - num_res:]
+  used_vars = {x for e in jaxpr.eqns for x in e.invars if isinstance(x, core.Var)}
+  invars, constvars, eqns = jaxpr.invars[:], jaxpr.constvars[:], jaxpr.eqns[:]
+  for v in res_vars:
+    if (not isinstance(v.aval, core.UnshapedArray) or
+        not dtypes.issubdtype(v.aval.dtype, np.inexact)):
+      continue
+    if v not in used_vars:
+      continue
+    assert isinstance(v, core.Var)
+    newvar = core.Var(v.suffix, v.aval)
+    finfo = dtypes.finfo(v.aval.dtype)
+    params = dict(exponent_bits=finfo.nexp, mantissa_bits=finfo.nmant)
+    if v in constvars or v in invars:
+      lst = constvars if v in constvars else invars
+      new_eqn = core.new_jaxpr_eqn(
+          [newvar], [v], lax_internal.reduce_precision_p, params, set())
+      lst[lst.index(v)] = newvar
+      eqns.insert(0, new_eqn)
+    else:
+      (eqn_idx, eqn), = ((i, e) for i, e in enumerate(eqns) if v in e.outvars)
+      if (eqn.primitive == lax_internal.reduce_precision_p and
+          eqn.params == params):
+        continue
+      replace_eqn = eqn.replace(outvars=[v_ if v_ != v else newvar
+                                         for v_ in eqn.outvars])
+      new_eqn = core.new_jaxpr_eqn(
+          [newvar], [v], lax_internal.reduce_precision_p, params, set(),
+          eqn.source_info, eqn.ctx)
+      eqns[eqn_idx] = replace_eqn
+      eqns.insert(eqn_idx+1, new_eqn)
+  new_jaxpr = jaxpr.replace(invars=invars, constvars=constvars, eqns=eqns)
+  config.enable_checks.value and core.check_jaxpr(new_jaxpr)
+  return new_jaxpr
 
 def remat_partial_eval_custom_params_updater(*args):
   *_, params_known, params_staged = args

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6410,6 +6410,39 @@ class RematTest(jtu.JaxTestCase):
     self.assertFalse(any(' sin ' in line for line in l.output))
     self.assertTrue(any(' cos ' in line for line in l.output))
 
+  def test_excess_precision_hell(self):
+    finfo = jnp.finfo('bfloat16')
+    eps = finfo.eps
+
+    @jax.custom_vjp
+    def dot(x):
+      return jnp.dot(x, x)
+    def dot_fwd(x):
+      return dot(x), None
+    def dot_bwd(_, g):
+      return g,
+    dot.defvjp(dot_fwd, dot_bwd)
+
+    @jax.custom_vjp
+    def foo(x):
+      return jnp.float32(1.) * x.astype('float32')
+    def foo_fwd(x):
+      return foo(x), x
+    def foo_bwd(x, _):
+      return jnp.float32(1.) * x.astype('float32'),
+    foo.defvjp(foo_fwd, foo_bwd)
+
+    @jax.jit
+    @partial(jax.remat, policy=lambda *_, **__: True)
+    def f(x):
+      x = dot(x)
+      return foo(x)
+
+    x = (jnp.bfloat16(1) + eps) * jnp.eye(2, dtype='bfloat16')
+    y, vjp = jax.vjp(f, x)
+    y_, = vjp(jnp.ones_like(y))
+    self.assertAllClose(y, y_, atol=0, rtol=0)
+
 
 @jtu.with_config(jax_pprint_use_color=False)
 class JaxprTest(jtu.JaxTestCase):


### PR DESCRIPTION
tl;dr Fix a `jax.remat`+XLA interaction that could cause subtle numerical issues in gradients due to values being saved for the backward pass in a different precision than how they're represented on the forward pass. The fix is to introduce `jax.lax.reduce_precision` calls in the forward pass to ensure XLA's excess precision isn't used on forward-pass consumers of those values.

An implication of this change is that it may cause `f(x) != jax.value_and_grad(f)(x)[0]` (due to numerical differences) for more functions `f` than is currently the case. The reason is that if `f` contains `jax.remat` calls, then `lambda x: jax.value_and_grad(f)(x)[0]` may contain some `jax.lax.reduce_precision` calls that are not in `f`. However, we think this is not problematic because for `jax.jit`-decorated functions we likely already have `f(x) != jax.value_and_grad(f)(x)[0]` simply due to the compiler optimizing the two programs differently.

---

XLA has a feature called ["excess precision"](https://github.com/openxla/xla/blob/3a050122daa3d930c0064396819a8186b4a0db49/xla/xla.proto#L180-L186), which can be turned off but defaults to on:
```
  // Allows xla to increase the output precision of floating point operations
  // and all floating-point conversions to be simplified, including those
  // that affect the numerics. The `FloatNormalization` pass inserts many
  // `f32 -> bf16 -> f32` conversion pairs. These are not removed by the
  // `AlgebraicSimplifier`, as that will only simplify conversions that are
  // no-ops, e.g. `bf16 -> f32 -> bf16`. Removing these improves accuracy.
```

Ah yes, "improves accuracy". The path to numerical hell is paved with "improves accuracy". (Actually, I'm exaggerating: I don't think I've heard any complaints about this XLA feature until we found this remat interaction.)

Here's an example of excess precision in action on TPU, with no `jax.remat` involved yet:

```python
import jax
import jax.numpy as jnp

def f(x):
  return jnp.dot(x, x) * jnp.float32(1.)

finfo = jnp.finfo('bfloat16')
x = (jnp.bfloat16(1) + finfo.eps) * jnp.eye(2, dtype='bfloat16')
print(f(x))
print(jax.jit(f)(x))
```

```
Array([[1.015625, 0.      ],
       [0.      , 1.015625]], dtype=float32)
Array([[1.015686, 0.      ],
       [0.      , 1.015686]], dtype=float32)
```

Different results for `f(x)` and `jax.jit(f)(x)`! In fact, the `jax.jit(f)(x)` results look like we computed things in a higher precision, namely float32. What happened here is that XLA saw this input HLO program:

```
HloModule jit_f, entry_computation_layout={(bf16[2,2]{1,0})->f32[2,2]{1,0}}

ENTRY main.4 {
  Arg_0.1 = bf16[2,2]{1,0} parameter(0)
  dot.2 = bf16[2,2]{1,0} dot(Arg_0.1, Arg_0.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
  ROOT convert.3 = f32[2,2]{1,0} convert(dot.2)
}
```

That is, we compute a (bf16, bf16) -> bf16 dot, and then consume its result in a float32 computation (in this case just simplified to a dtype conversion to f32). The "excess precision" logic in XLA says: "Hey, on TPU I accumulated the result of the dot in f32 anyway; why would I cast it down to bf16 when the consumer just converts back to f32 again? Instead, I'll keep it in f32 and avoid the downcast-then-upcast. Improves accuracy, and faster too!"

So far, so good. Sure, it means `f` and `jit(f)` differ, but is anyone going to complain about getting better precision results?

Well, `jax.remat` is. The issue arises when we save the bf16 dot result for the backward pass: the downcast is elided on the forward pass for the reason above (XLA sees the consumer converts to f32 and skips the downcast), but not on the backward pass because `jax.remat` doesn't let XLA optimize between the forward and backward passes (to prevent CSE).

Here is a very contrived program showing the issue with `jax.remat`:

```python
import jax
import jax.numpy as jnp

finfo = jnp.finfo('bfloat16')
eps = finfo.eps

@jax.custom_vjp
def dot(x):
  return jnp.dot(x, x)
def dot_fwd(x):
  return dot(x), None
def dot_bwd(_, g):
  return g,
dot.defvjp(dot_fwd, dot_bwd)

@jax.custom_vjp
def foo(x):
  return jnp.float32(1.) * x
def foo_fwd(x):
  return foo(x), x
def foo_bwd(x, _):
  return jnp.float32(1.) * x,
foo.defvjp(foo_fwd, foo_bwd)

@jax.jit
@partial(jax.remat, policy=lambda *_, **__: True)
def f(x):
  x = dot(x)
  return foo(x)

x = (jnp.bfloat16(1) + eps) * jnp.eye(2, dtype='bfloat16')
y, vjp = jax.vjp(f, x)
y_, = vjp(jnp.ones_like(y))

print(y)
print(y_)
```

```
Array([[1.015686, 0.      ],
       [0.      , 1.015686]], dtype=float32)
Array([[1.015625, 0.      ],
       [0.      , 1.015625]], dtype=float32)
```

It's basically the same issue, but now even though everything is under a `jax.jit`, we're seeing a different value in the forward and backward passes due to excess precision only on the forward pass.

This behavior can cause bad and difficult-to-debug issues with things like MoE models!

---

The fix in this PR is just to introduce explicit `jax.lax.reduce_precision` calls in the forward pass to disable XLA's excess precision for values that are saved.

An implication of this change is it's another reason why we may have `f(x) != jax.value_and_grad(f)(x)[0]`: if `f` contains `jax.remat` calls then the latter may now disable excess precision in cases where the former does not, changing numerics. But we think that is okay because we probably already have `f(x) != jax.value_and_grad(f)(x)[0]`, just due to XLA making different optimization decisions for the two programs in general.