### PR TITLE
DOC: Improved docs for jnp.ptp and count_nonzero

### DIFF
--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -1073,9 +1073,44 @@ def _std(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
   return lax.sqrt(var(a, axis=axis, dtype=dtype, correction=correction, keepdims=keepdims, where=where))
 
 
-@implements(np.ptp, skip_params=['out'])
 def ptp(a: ArrayLike, axis: Axis = None, out: None = None,
         keepdims: bool = False) -> Array:
+  r"""Return the peak-to-peak range along a given axis.
+
+  JAX implementation of :func:`numpy.ptp`.
+
+  Args:
+    a: input array.
+    axis: optional, int or sequence of ints, default=None. Axis along which the
+      range is computed. If None, the range is computed on the flattened array.
+    keepdims: bool, default=False. If true, reduced axes are left in the result
+      with size 1.
+    out: Unused by JAX.
+
+  Returns:
+    An array with the range of elements along specified axis of input.
+
+  Examples:
+    By default, ``jnp.ptp`` computes the range along all axes.
+
+    >>> x = jnp.array([[1, 3, 5, 2],
+    ...                [4, 6, 8, 1],
+    ...                [7, 9, 3, 4]])
+    >>> jnp.ptp(x)
+    Array(8, dtype=int32)
+
+    If ``axis=1``, computes the range along axis 1.
+
+    >>> jnp.ptp(x, axis=1)
+    Array([4, 7, 6], dtype=int32)
+
+    To preserve the dimensions of input, you can set ``keepdims=True``.
+
+    >>> jnp.ptp(x, axis=1, keepdims=True)
+    Array([[4],
+           [7],
+           [6]], dtype=int32)
+  """
   return _ptp(a, _ensure_optional_axes(axis), out, keepdims)
 
 @partial(api.jit, static_argnames=('axis', 'keepdims'))
@@ -1089,10 +1124,44 @@ def _ptp(a: ArrayLike, axis: Axis = None, out: None = None,
   return lax.sub(x, y)
 
 
-@implements(np.count_nonzero)
 @partial(api.jit, static_argnames=('axis', 'keepdims'))
 def count_nonzero(a: ArrayLike, axis: Axis = None,
                   keepdims: bool = False) -> Array:
+  r"""Return the number of nonzero elements along a given axis.
+
+  JAX implementation of :func:`numpy.count_nonzero`.
+
+  Args:
+    a: input array.
+    axis: optional, int or sequence of ints, default=None. Axis along which the
+      number of nonzeros are counted. If None, counts within the flattened array.
+    keepdims: bool, default=False. If true, reduced axes are left in the result
+      with size 1.
+
+  Returns:
+    An array with number of nonzeros elements along specified axis of the input.
+
+  Examples:
+    By default, ``jnp.count_nonzero`` counts the nonzero values along all axes.
+
+    >>> x = jnp.array([[1, 0, 0, 0],
+    ...                [0, 0, 1, 0],
+    ...                [1, 1, 1, 0]])
+    >>> jnp.count_nonzero(x)
+    Array(5, dtype=int32)
+
+    If ``axis=1``, counts along axis 1.
+
+    >>> jnp.count_nonzero(x, axis=1)
+    Array([1, 1, 3], dtype=int32)
+
+    To preserve the dimensions of input, you can set ``keepdims=True``.
+
+    >>> jnp.count_nonzero(x, axis=1, keepdims=True)
+    Array([[1],
+           [1],
+           [3]], dtype=int32)
+  """
   check_arraylike("count_nonzero", a)
   return sum(lax.ne(a, _lax_const(a, 0)), axis=axis,
              dtype=dtypes.canonicalize_dtype(int), keepdims=keepdims)


### PR DESCRIPTION
This PR updates the docstrings of `jnp.ptp` and `jnp.count_nonzero`.

Part of #21461.