### PR TITLE
``debug_info`` no longer requires non-None ``func_src_info``

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -628,7 +628,7 @@ def debug_info(
   """Try to build trace-time debug info for fun when applied to args/kwargs."""
   arg_names = _arg_names(fun_signature, args, kwargs, static_argnums,
                          static_argnames)
-  if src is None or arg_names is None:
+  if arg_names is None:
     return None
   return TracingDebugInfo(traced_for, src, arg_names, None)
 

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -78,7 +78,7 @@ no_effects: Effects = effects.no_effects
 
 class JaxprDebugInfo(NamedTuple):
   traced_for: str     # e.g. 'jit', 'scan', etc
-  func_src_info: str  # e.g. f'{fun.__name__} at {filename}:{lineno}'
+  func_src_info: str | None  # e.g. f'{fun.__name__} at {filename}:{lineno}'
   arg_names: tuple[str | None, ...]     # e.g. ('args[0]', ... )
   result_paths: tuple[str, ...]  # e.g. ('[0]', '[1]', ...)
 

--- a/jax/_src/linear_util.py
+++ b/jax/_src/linear_util.py
@@ -309,7 +309,7 @@ class TracingDebugInfo(NamedTuple):
   # formed just before staging to a jaxpr and read in trace-time error messages.
   # TODO(mattjj): delete partial_eval.DebugInfo, replace all uses with this cls
   traced_for: str             # e.g. 'jit', 'scan', etc
-  func_src_info: str          # e.g. f'{fun.__name__} at {filename}:{lineno}'
+  func_src_info: str | None   # e.g. f'{fun.__name__} at {filename}:{lineno}'
   arg_names: tuple[str, ...]  # e.g. ('args[0]', ... )
   result_paths: Callable[[], tuple[str, ...]] | None
 
@@ -351,7 +351,7 @@ def cache(call: Callable, *, explain: Callable | None = None):
     else:
       ans = call(fun, *args)
       if explain and config.explain_cache_misses.value:
-        explain(fun.f, cache is new_cache, cache, key, ans)
+        explain(fun.f, cache is new_cache, cache, key)
       cache[key] = (ans, fun.stores)
 
     return ans

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1127,7 +1127,7 @@ def _process_in_axis_resources(in_shardings_treedef, in_shardings_leaves,
 callsites: set[str] = set()
 
 def explain_tracing_cache_miss(
-    f: Callable, unseen_f: bool, cache: dict, key: tuple, result: tuple):
+    f: Callable, unseen_f: bool, cache: dict, key: tuple):
   if config.check_tracer_leaks.value: return
 
   def unpack(key):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4618,8 +4618,8 @@ class APITest(jtu.JaxTestCase):
     for msg in cm.output:
       self.assertIn("TRACING CACHE MISS", msg)
 
-  def test_cache_miss_explanations_no_debug_info(self):
-    # ``operator.add`` is a built-in function and does not have debug info.
+  def test_cache_miss_explanations_no_source_info(self):
+    # ``operator.add`` is a built-in function and does not have source info.
     with config.explain_cache_misses(True):
       jax.jit(operator.add)(42, 24)
 


### PR DESCRIPTION
I suspect in the past lack of source info meant that the function also has no signature, but this is no longer the case.

I also removed an unused parameter from ``explain_tracing_cache_miss`` as a drive by change.

This is a follow up to #22269.