### PR TITLE
Officially deprecate `jax.host_*` APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Remember to align the itemized text with the first line of an item within a list
   * Removed a number of previously-deprecated internal APIs related to
     polymorphic shapes. From {mod}`jax.core`: removed `canonicalize_shape`,
     `dimension_as_value`, `definitely_equal`, and `symbolic_equal_dim`.
+  * The {func}`jax.host_count`, {func}`jax.host_id`, and {func}`jax.host_ids`
+    aliases were initially deprecated in v0.2.13, and are now scheduled for
+    removal after the standard 3 month deprecation period.
 
 ## jaxlib 0.4.31
 

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -99,9 +99,9 @@ from jax._src.api import eval_shape as eval_shape
 from jax._src.dtypes import float0 as float0
 from jax._src.api import grad as grad
 from jax._src.api import hessian as hessian
-from jax._src.xla_bridge import host_count as host_count
-from jax._src.xla_bridge import host_id as host_id
-from jax._src.xla_bridge import host_ids as host_ids
+from jax._src.xla_bridge import host_count as _deprecated_host_count
+from jax._src.xla_bridge import host_id as _deprecated_host_id
+from jax._src.xla_bridge import host_ids as _deprecated_host_ids
 from jax._src.api import jacobian as jacobian
 from jax._src.api import jacfwd as jacfwd
 from jax._src.api import jacrev as jacrev
@@ -234,6 +234,19 @@ _deprecations = {
       "CHANGELOG.md for 0.4.30 for more examples.",
       _deprecated_xla_computation
   ),
+  # Added Jul 8, 2024
+  "host_count": (
+    "jax.host_count is deprecated: use jax.process_count instead.",
+    _deprecated_host_count
+  ),
+  "host_id": (
+    "jax.host_id is deprecated: use jax.process_index instead.",
+    _deprecated_host_id
+  ),
+  "host_ids": (
+    "jax.host_ids is deprecated: use list(range(jax.process_count())) instead.",
+    _deprecated_host_ids
+  ),
 }
 
 import typing as _typing
@@ -247,6 +260,9 @@ if _typing.TYPE_CHECKING:
   from jax._src.tree_util import tree_structure as tree_structure
   from jax._src.tree_util import tree_transpose as tree_transpose
   from jax._src.tree_util import tree_unflatten as tree_unflatten
+  from jax._src.xla_bridge import host_count as host_count
+  from jax._src.xla_bridge import host_id as host_id
+  from jax._src.xla_bridge import host_ids as host_ids
 
 else:
   from jax._src.deprecations import deprecation_getattr as _deprecation_getattr

--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -1151,11 +1151,8 @@ def process_index(
   return get_backend(backend).process_index()
 
 
-# TODO: remove this sometime after jax 0.2.13 is released
+# TODO(dfm): Remove this 3 months after 0.4.31 is released.
 def host_id(backend: str | xla_client.Client | None = None) -> int:
-  warnings.warn(
-      "jax.host_id has been renamed to jax.process_index. This alias "
-      "will eventually be removed; please update your code.")
   return process_index(backend)
 
 
@@ -1167,22 +1164,15 @@ def process_count(
   return max(d.process_index for d in devices(backend)) + 1
 
 
-# TODO: remove this sometime after jax 0.2.13 is released
+# TODO(dfm): Remove this 3 months after 0.4.31 is released.
 def host_count(backend: str | xla_client.Client | None = None) -> int:
-  warnings.warn(
-      "jax.host_count has been renamed to jax.process_count. This alias "
-      "will eventually be removed; please update your code.")
   return process_count(backend)
 
 
-# TODO: remove this sometime after jax 0.2.13 is released
+# TODO(dfm): Remove this 3 months after 0.4.31 is released.
 def host_ids(
     backend: str | xla_client.Client | None = None
 ) -> list[int]:
-  warnings.warn(
-      "jax.host_ids has been deprecated; please use range(jax.process_count()) "
-      "instead. jax.host_ids will eventually be removed; please update your "
-      "code.")
   return list(range(process_count(backend)))
 
 


### PR DESCRIPTION
These APIs have produced `UserWarning`s since v0.2.13, but this PR deprecates these functions using the standard JAX deprecation machinery.