### PR TITLE
`tree_transpose` now checks treedef vs expected_treedef

### DIFF
--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -383,9 +383,14 @@ def tree_transpose(outer_treedef: PyTreeDef, inner_treedef: PyTreeDef | None,
     inner_treedef = tree_structure(outer_treedef.flatten_up_to(pytree_to_transpose)[0])
   inner_size = inner_treedef.num_leaves
   outer_size = outer_treedef.num_leaves
+  expected_treedef = outer_treedef.compose(inner_treedef)
   if treedef.num_leaves != (inner_size * outer_size):
-    expected_treedef = outer_treedef.compose(inner_treedef)
     raise TypeError(f"Mismatch\n{treedef}\n != \n{expected_treedef}")
+  if expected_treedef != treedef:
+    # Try to unflatten -> flatten to update expected_treedef
+    _, expected_treedef = tree_flatten(tree_unflatten(expected_treedef, flat))
+    if expected_treedef != treedef:
+      raise TypeError(f"Mismatch\n{treedef}\n != \n{expected_treedef}")
   iter_flat = iter(flat)
   lol = [
       [next(iter_flat) for _ in range(inner_size)] for __ in range(outer_size)

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -617,6 +617,18 @@ class TreeTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError, "Mismatch"):
       tree_util.tree_transpose(outer_treedef, inner_treedef, tree)
 
+  @parameterized.parameters([
+    (tuple, [[1, 2], [3, 4], [5, 6]]),
+    (list, [(1, 2), (3, 4), (5, 6)]),
+    (list, [1, [2, [3, [4, [5, [6]]]]]]),
+  ])
+  def testTransposeMismatchStructure(self, type_cls, tree):
+    # https://github.com/google/jax/issues/19810
+    outer_treedef = tree_util.tree_structure(['*', '*', '*'])
+    inner_treedef = tree_util.tree_structure(type_cls(['*', '*']))
+    with self.assertRaisesRegex(TypeError, "Mismatch"):
+      tree_util.tree_transpose(outer_treedef, inner_treedef, tree)
+
   def testTransposeWithCustomObject(self):
     outer_treedef = tree_util.tree_structure(FlatCache({"a": 1, "b": 2}))
     inner_treedef = tree_util.tree_structure([1, 2])
@@ -629,7 +641,6 @@ class TreeTest(jtu.JaxTestCase):
   def testStringRepresentation(self, tree, correct_string):
     """Checks that the string representation of a tree works."""
     treedef = tree_util.tree_structure(tree)
-    print(TREES)
     self.assertRegex(str(treedef), correct_string)
 
   def testTreeDefWithEmptyDictStringRepresentation(self):


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/19810

Description:

- tree_transpose now checks treedef vs expected_treedef

However, structures with custom nodes can lead to `expected_treedef != treedef` situations, in this case an additional step is done: `flatten(unflatten(expected_treedef, flat))` to updated `expected_treedef` before raising an error.
Maybe, we can achieve the same results in a more efficient way, i'll be happy to implement it, instead of doing `flatten(unflatten(...))`.

cc @jakevdp 

