### PR TITLE
jax.numpy: better docstring for allclose and isclose functions

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1832,10 +1832,50 @@ def _moveaxis(a: Array, source: tuple[int, ...], destination: tuple[int, ...]) -
   return lax.transpose(a, perm)
 
 
-@util.implements(np.isclose)
 @partial(jit, static_argnames=('equal_nan',))
 def isclose(a: ArrayLike, b: ArrayLike, rtol: ArrayLike = 1e-05, atol: ArrayLike = 1e-08,
             equal_nan: bool = False) -> Array:
+  r"""Check if the elements of two arrays are approximately equal within a tolerance.
+
+  JAX implementation of :func:`numpy.allclose`.
+
+  Essentially this function evaluates the following condition:
+
+  .. math::
+
+     |a - b| \le \mathtt{atol} + \mathtt{rtol} * |b|
+
+  ``jnp.inf`` in ``a`` will be considered equal to ``jnp.inf`` in ``b``.
+
+  Args:
+    a: first input array to compare.
+    b: second input array to compare.
+    rtol: relative tolerance used for approximate equality. Default = 1e-05.
+    atol: absolute tolerance used for approximate equality. Default = 1e-08.
+    equal_nan: Boolean. If ``True``, NaNs in ``a`` will be considered
+      equal to NaNs in ``b``. Default is ``False``.
+
+  Returns:
+    A new array containing boolean values indicating whether the input arrays
+    are element-wise approximately equal within the specified tolerances.
+
+  See Also:
+    - :func:`jax.numpy.allclose`
+    - :func:`jax.numpy.equal`
+
+  Examples:
+    >>> jnp.isclose(jnp.array([1e6, 2e6, jnp.inf]), jnp.array([1e6, 2e7, jnp.inf]))
+    Array([ True, False,  True], dtype=bool)
+    >>> jnp.isclose(jnp.array([1e6, 2e6, 3e6]),
+    ...              jnp.array([1.00008e6, 2.00008e7, 3.00008e8]), rtol=1e3)
+    Array([ True,  True,  True], dtype=bool)
+    >>> jnp.isclose(jnp.array([1e6, 2e6, 3e6]),
+    ...              jnp.array([1.00001e6, 2.00002e6, 3.00009e6]), atol=1e3)
+    Array([ True,  True,  True], dtype=bool)
+    >>> jnp.isclose(jnp.array([jnp.nan, 1, 2]),
+    ...              jnp.array([jnp.nan, 1, 2]), equal_nan=True)
+    Array([ True,  True,  True], dtype=bool)
+  """
   a, b = util.promote_args("isclose", a, b)
   dtype = _dtype(a)
   if dtypes.issubdtype(dtype, dtypes.extended):
@@ -2372,10 +2412,50 @@ def nan_to_num(x: ArrayLike, copy: bool = True, nan: ArrayLike = 0.0,
   return out
 
 
-@util.implements(np.allclose)
 @partial(jit, static_argnames=('equal_nan',))
 def allclose(a: ArrayLike, b: ArrayLike, rtol: ArrayLike = 1e-05,
              atol: ArrayLike = 1e-08, equal_nan: bool = False) -> Array:
+  r"""Check if two arrays are element-wise approximately equal within a tolerance.
+
+  JAX implementation of :func:`numpy.allclose`.
+
+  Essentially this function evaluates the following condition:
+
+  .. math::
+
+     |a - b| \le \mathtt{atol} + \mathtt{rtol} * |b|
+
+  ``jnp.inf`` in ``a`` will be considered equal to ``jnp.inf`` in ``b``.
+
+  Args:
+    a: first input array to compare.
+    b: second input array to compare.
+    rtol: relative tolerance used for approximate equality. Default = 1e-05.
+    atol: absolute tolerance used for approximate equality. Default = 1e-08.
+    equal_nan: Boolean. If ``True``, NaNs in ``a`` will be considered
+      equal to NaNs in ``b``. Default is ``False``.
+
+  Returns:
+    Boolean scalar array indicating whether the input arrays are element-wise
+    approximately equal within the specified tolerances.
+
+  See Also:
+    - :func:`jax.numpy.isclose`
+    - :func:`jax.numpy.equal`
+
+  Examples:
+    >>> jnp.allclose(jnp.array([1e6, 2e6, 3e6]), jnp.array([1e6, 2e6, 3e7]))
+    Array(False, dtype=bool)
+    >>> jnp.allclose(jnp.array([1e6, 2e6, 3e6]),
+    ...              jnp.array([1.00008e6, 2.00008e7, 3.00008e8]), rtol=1e3)
+    Array(True, dtype=bool)
+    >>> jnp.allclose(jnp.array([1e6, 2e6, 3e6]),
+    ...              jnp.array([1.00001e6, 2.00002e6, 3.00009e6]), atol=1e3)
+    Array(True, dtype=bool)
+    >>> jnp.allclose(jnp.array([jnp.nan, 1, 2]),
+    ...              jnp.array([jnp.nan, 1, 2]), equal_nan=True)
+    Array(True, dtype=bool)
+  """
   util.check_arraylike("allclose", a, b)
   return reductions.all(isclose(a, b, rtol, atol, equal_nan))
 
@@ -3782,8 +3862,35 @@ def array_equal(a1: ArrayLike, a2: ArrayLike, equal_nan: bool = False) -> Array:
   return reductions.all(eq)
 
 
-@util.implements(np.array_equiv)
 def array_equiv(a1: ArrayLike, a2: ArrayLike) -> Array:
+  """Check if two arrays are element-wise equal.
+
+  JAX implementation of :func:`numpy.array_equiv`.
+
+  This function will return ``False`` if the input arrays cannot be broadcasted
+  to the same shape.
+
+  Args:
+    a1: first input array to compare.
+    a2: second input array to compare.
+
+  Returns:
+    Boolean scalar array indicating whether the input arrays are
+    element-wise equal after broadcasting.
+
+  See Also:
+    - :func:`jax.numpy.allclose`
+    - :func:`jax.numpy.array_equal`
+
+  Examples:
+    >>> jnp.array_equiv(jnp.array([1, 2, 3]), jnp.array([1, 2, 3]))
+    Array(True, dtype=bool)
+    >>> jnp.array_equiv(jnp.array([1, 2, 3]), jnp.array([1, 2, 4]))
+    Array(False, dtype=bool)
+    >>> jnp.array_equiv(jnp.array([[1, 2, 3], [1, 2, 3]]),
+    ...                 jnp.array([1, 2, 3]))
+    Array(True, dtype=bool)
+  """
   a1, a2 = asarray(a1), asarray(a2)
   try:
     eq = ufuncs.equal(a1, a2)


### PR DESCRIPTION
Better docstring added for jax.numpy.allclose and jax.numpy.isclose.
Part of [21461](https://github.com/google/jax/issues/21461)