### PR TITLE
Removed `jax.device_put` from `jnp.eye` and `jnp.arange` implementations

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1337,16 +1337,27 @@ def iota(dtype: DTypeLike, size: int) -> Array:
   """
   return broadcasted_iota(dtype, (size,), 0)
 
-def broadcasted_iota(dtype: DTypeLike, shape: Shape, dimension: int) -> Array:
+def broadcasted_iota(dtype: DTypeLike, shape: Shape, dimension: int,
+                     *, sharding: Sharding | None = None) -> Array:
   """Convenience wrapper around ``iota``."""
+  # We have to add this redirection due jax.jit circular import problem in this submodule
   dtype = dtypes.canonicalize_dtype(dtype)
   shape = canonicalize_shape(shape)
-  dynamic_shape = [d for d in shape if isinstance(d, core.Tracer)]
-  static_shape = [None if isinstance(d, core.Tracer) else d for d in shape]
   dimension = core.concrete_or_error(
       int, dimension, "dimension argument of lax.broadcasted_iota")
+  return jax.jit(
+    _broadcasted_iota,
+    static_argnames=('dtype', 'shape', 'dimension'),
+    inline=True,
+    out_shardings=sharding,
+  )(dtype, shape=shape, dimension=dimension)
+
+def _broadcasted_iota(dtype: DTypeLike, shape: Shape, dimension: int) -> Array:
+  dynamic_shape = [d for d in shape if isinstance(d, core.Tracer)]
+  static_shape = [None if isinstance(d, core.Tracer) else d for d in shape]
   return iota_p.bind(*dynamic_shape, dtype=dtype, shape=tuple(static_shape),
                      dimension=dimension)
+
 
 def _eye(dtype: DTypeLike, shape: Shape, offset: DimSize) -> Array:
   """Like numpy.eye, create a 2D array with ones on a diagonal."""

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -4889,12 +4889,19 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     device = jax.devices()[-1] if specify_device else None
     kwargs = {"device": device}
     jaxpr = jax.make_jaxpr(lambda: jnp.arange(*args, **kwargs))()
-    # We have 2 statements in jaxpr:
-    # [a:i32[5] = iota[dimension=0 dtype=int32 shape=(5,)],
-    #  a:i32[5] = device_put[devices=[None] srcs=[None]] b]
-    num_eqs = 2 if device is not None else 1
-    self.assertEqual(len(jaxpr.jaxpr.eqns), num_eqs)
-    self.assertEqual(jaxpr.jaxpr.eqns[0].primitive, lax.iota_p)
+    self.assertEqual(len(jaxpr.jaxpr.eqns), 1)
+    eq = jaxpr.jaxpr.eqns[0]
+    if device is not None:
+      self.assertEqual(eq.primitive.name, "pjit")
+      out_shardings = eq.params["out_shardings"]
+      self.assertEqual(len(out_shardings), 1)
+      self.assertIsInstance(out_shardings[0], SingleDeviceSharding)
+      self.assertEqual(out_shardings[0]._device, device)
+      expr = eq.params["jaxpr"]
+      self.assertEqual(len(expr.eqns), 1)
+      eq = expr.eqns[0]
+
+    self.assertEqual(eq.primitive, lax.iota_p)
 
   def testIssue830(self):
     a = jnp.arange(4, dtype=jnp.complex64)


### PR DESCRIPTION
Description:
- Removed `jax.device_put` from `jnp.eye` and `jnp.arange` implementations
- Added `sharding` kwarg and jitted `lax.broadcasted_iota`
