### PR TITLE
[pallas] Add more documentation and tests for BlockSpec.

### DIFF
--- a/jax/_src/pallas/mosaic/core.py
+++ b/jax/_src/pallas/mosaic/core.py
@@ -187,9 +187,9 @@ class PrefetchScalarGridSpec(pallas_core.GridSpec):
     in_avals, in_avals_tree = tree_util.tree_flatten(tuple(unflat_in_avals))
     flat_in_specs, flat_out_specs = self._get_in_out_specs(
         in_avals, in_avals_tree, out_avals, out_tree)
-    in_specs, in_ref_avals, out_specs, out_ref_avals = (
+    in_ref_avals, out_ref_avals = (
         pallas_core._get_ref_avals(
-            self.grid, in_avals, flat_in_specs, in_paths[num_flat_scalar_prefetch:],
+            in_avals, flat_in_specs, in_paths[num_flat_scalar_prefetch:],
             out_avals, flat_out_specs, out_paths))
     scalar_ref_avals = [
         AbstractMemoryRef(jax_core.ShapedArray(aval.shape, aval.dtype),
@@ -209,7 +209,7 @@ class PrefetchScalarGridSpec(pallas_core.GridSpec):
             mapped_dims=(),
             what="input",
         ),
-        in_specs,
+        flat_in_specs,
         in_paths[num_flat_scalar_prefetch:],
         in_ref_avals,
     )
@@ -222,7 +222,7 @@ class PrefetchScalarGridSpec(pallas_core.GridSpec):
             mapped_dims=(),
             what="output",
         ),
-        out_specs,
+        flat_out_specs,
         out_paths,
         out_ref_avals,
     )

--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -1034,12 +1034,14 @@ def pallas_call(
       See details at :ref:`pallas_grid`.
     in_specs: a PyTree of :class:`jax.experimental.pallas.BlockSpec` with
       a structure matching that of the positional arguments.
+      The default value for ``in_specs`` specifies the whole array for all
+      inputs, e.g., as ``pl.BlockSpec(x.shape, lambda *indices: (0,) * x.ndim)``.
       See details at :ref:`pallas_blockspec`.
     out_specs: a PyTree of :class:`jax.experimental.pallas.BlockSpec` with
       a structure matching that of the outputs.
+      The default value for ``out_specs`` specifies the whole array,
+      e.g., as ``pl.BlockSpec(x.shape, lambda *indices: (0,) * x.ndim)``.
       See details at :ref:`pallas_blockspec`.
-      The default value for `out_specs` specifies the whole array,
-      e.g., as ``pl.BlockSpec(x.shape, lambda *indices: indices)``.
     input_output_aliases: a dictionary mapping the index of some inputs to
       the index of the output that aliases them. These indices are in the
       flattened inputs and outputs.
@@ -1063,6 +1065,9 @@ def pallas_call(
   if grid_spec is None:
     grid_spec = GridSpec(grid, in_specs, out_specs)
   grid_spec, dynamic_grid_bounds = grid_spec.unzip_dynamic_grid_bounds()
+  # TODO(necula): this canonicalization may be convenient for some usage
+  # but it is lossy, because it prevents expressing functions that return
+  # lists.
   if isinstance(out_shape, list):
     out_shape = tuple(out_shape)
   flat_out_shapes_with_paths, out_tree = tree_util.tree_flatten_with_path(out_shape)


### PR DESCRIPTION
This PR deals with the default values for the parameters of the `BlockSpec` constructor, and the mapped block dimensions.

Fix a bug where previously a missing block_shape while the index_map was present was resulting in a crash.