### PR TITLE
[jax.distributed] Allow setting local device ids via env var

### DIFF
--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -45,10 +45,12 @@ class State:
                  initialization_timeout: int = 300,
                  coordinator_bind_address: str | None = None):
     coordinator_address = (coordinator_address or
-                           os.environ.get('JAX_COORDINATOR_ADDRESS', None))
+                           os.environ.get('JAX_COORDINATOR_ADDRESS'))
     if isinstance(local_device_ids, int):
       local_device_ids = [local_device_ids]
 
+    if local_device_ids is None and (env_ids := os.environ.get('JAX_LOCAL_DEVICE_IDS')):
+      local_device_ids = list(map(int, env_ids.split(",")))
 
     (coordinator_address, num_processes, process_id, local_device_ids) = (
         clusters.ClusterEnv.auto_detect_unset_distributed_params(


### PR DESCRIPTION
Makes `jax.distributed.initialize` aware of a new environmental variable, `JAX_LOCAL_DEVICE_IDS`, which allows overriding the local device ids set by default or configured by cluster-dependent auto-configuration. Note that `local_device_ids` passed explicitly to `jax.distributed.initialize` are still respected.

We are currently evaluating the benefits of one-process-per-host vs. one-process-per-GPU vs. one-process-per-NUMA-node and this override would be useful for local experiments with different configurations for multiprocess-JAX. E.g. running an existing workload like PAXML with one-process-per-GPU currently requires reaching into the framework and modifying its setup code (e.g. https://github.com/google/paxml/blob/9863f276af5431d8f08542dba06ced1dccb51aa7/paxml/setup_jax.py#L69-L73). Similarly, the auto-configuration for clusters currently presumes a one-to-one mapping of processes to devices (e.g. https://github.com/google/jax/blob/e4b606e38a18867c757c738dd16265ca03d2cf88/jax/_src/clusters/slurm_cluster.py#L65-L66).

The first commit contains the minimal amount of changes necessary. The second commit extends the existing special value `"all"` of config variables `jax_cuda_visible_devices` and `jax_rocm_visible_devices` to the `local_device_ids` parameter and `JAX_LOCAL_DEVICE_IDS`.