### PR TITLE
Unifying persistent cache messages

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -56,6 +56,7 @@ from jax._src.config import (
   debug_nans as debug_nans,
   debug_infs as debug_infs,
   log_compiles as log_compiles,
+  explain_cache_misses as explain_cache_misses,
   default_device as default_device,
   default_matmul_precision as default_matmul_precision,
   default_prng_impl as default_prng_impl,


### PR DESCRIPTION
 Also moving persistent cache messages (miss & hit)  to WARNING logging level when `config.explain_cache_misses` is true; otherwise they remain in DEBUG.

Message "Persistent compilation cache hit for" becomes "PERSISTENT COMPILATION CACHE (HIT|MISS)" to remain consistent with "TRACING CACHE MISS".

The included tests test for correct presence of cache miss/hit messages in the logging level depending on the value of `config.explain_cache_misses`