### PR TITLE
[pallas] Thread the interpret= parameter to pallas_call.

### DIFF
--- a/tests/pallas/BUILD
+++ b/tests/pallas/BUILD
@@ -378,10 +378,9 @@ jax_test(
         "tpu_splash_attention_kernel_test.py",
     ],
     disable_backends = [
-        "cpu",
         "gpu",
     ],
-    shard_count = 18,
+    shard_count = 24,
     tags = [
         "noasan",  # Times out.
         "nomsan",  # Times out.
@@ -398,7 +397,6 @@ jax_test(
         "tpu_splash_attention_mask_test.py",
     ],
     disable_backends = [
-        "cpu",
         "gpu",
     ],
     deps = [
@@ -417,7 +415,6 @@ jax_test(
         },
     },
     disable_backends = [
-        "cpu",
         "tpu",
     ],
     disable_configs = [
@@ -451,7 +448,6 @@ jax_test(
         },
     },
     disable_backends = [
-        "cpu",
         "tpu",
     ],
     disable_configs = [

--- a/tests/pallas/gpu_attention_test.py
+++ b/tests/pallas/gpu_attention_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import sys
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -34,13 +35,25 @@ config.parse_flags_with_absl()
 
 
 @jtu.with_config(jax_traceback_filtering="off")
-class DecodeAttentionTest(jtu.JaxTestCase):
+class PallasBaseTest(jtu.JaxTestCase):
+  INTERPRET = False
 
   def setUp(self):
-    if not jtu.is_cuda_compute_capability_at_least("8.0"):
-      self.skipTest("Fused attention only works on GPUs with capability >= sm80")
+    if jtu.test_device_matches(["cpu"]) and not self.INTERPRET:
+      self.skipTest("On CPU the test works only in interpret mode")
+    if jtu.test_device_matches(["cpu", "gpu"]) and jax.config.x64_enabled:
+      self.skipTest("On CPU and GPU the test works only in 32-bit")
+    if (jtu.test_device_matches(["cuda"]) and
+        not jtu.is_cuda_compute_capability_at_least("8.0")):
+      self.skipTest("Only works on GPU with capability >= sm80")
+    if sys.platform == "win32" and not self.INTERPRET:
+      self.skipTest("Only works on non-Windows platforms")
 
     super().setUp()
+
+
+class DecodeAttentionTest(PallasBaseTest):
+  INTERPRET = False
 
   @parameterized.named_parameters(*[
       (
@@ -79,7 +92,7 @@ class DecodeAttentionTest(jtu.JaxTestCase):
     k = random.normal(k2, (batch_size, seq_len, head_dim), dtype=jnp.float16)
     v = random.normal(k3, (batch_size, seq_len, head_dim), dtype=jnp.float16)
 
-    o = decode_attention.mqa(q, k, v)
+    o = decode_attention.mqa(q, k, v, interpret=self.INTERPRET)
     o_ref = decode_attention.mqa_reference(q, k, v)
     np.testing.assert_allclose(o, o_ref, atol=0.05)
 
@@ -129,9 +142,12 @@ class DecodeAttentionTest(jtu.JaxTestCase):
         k3, (batch_size, seq_len, num_kv_heads, head_dim), dtype=jnp.float16
     )
 
-    o = decode_attention.gqa(q, k, v)
+    o = decode_attention.gqa(q, k, v, interpret=self.INTERPRET)
     o_ref = decode_attention.gqa_reference(q, k, v)
     np.testing.assert_allclose(o, o_ref, atol=0.05)
+
+class DecodeAttentionInterpreterTest(DecodeAttentionTest):
+  INTERPRET = True
 
 
 if __name__ == "__main__":

--- a/tests/pallas/tpu_splash_attention_kernel_test.py
+++ b/tests/pallas/tpu_splash_attention_kernel_test.py
@@ -290,14 +290,19 @@ def attn_logits_soft_cap_strategy() -> hps.SearchStrategy[float | None]:
   return hps.one_of(hps.just(None), hps.floats(min_value=1.0, max_value=50.0))
 
 
-class AttentionTest(jtu.JaxTestCase):
+@jtu.with_config(jax_traceback_filtering="off")
+class PallasBaseTest(jtu.JaxTestCase):
+  INTERPRET = False
 
   def setUp(self):
-    if not jtu.test_device_matches(["tpu"]):
-      self.skipTest("Need TPU devices")
-    # TODO(b/327487669): selectively re-enable tests that works on TPU v3.
-    if not jtu.is_device_tpu_at_least(4):
-      self.skipTest("Not supported on TPU generations <= 3")
+    if not self.INTERPRET:
+      if not jtu.test_device_matches(["tpu"]):
+        self.skipTest("Only interpret mode supported on non-TPU")
+      # TODO(b/327487669): selectively re-enable tests that works on TPU v3.
+      if not jtu.is_device_tpu_at_least(4):
+        self.skipTest("Not supported on TPU generations <= 3")
+    if jtu.test_device_matches(["cpu"]) and jax.config.x64_enabled:
+      self.skipTest("On CPU the test works only in 32-bit")
 
     super().setUp()
 
@@ -311,7 +316,7 @@ class AttentionTest(jtu.JaxTestCase):
     np.testing.assert_allclose(x, y, **kwargs)
 
 
-class SplashAttentionTest(AttentionTest):
+class SplashAttentionTest(PallasBaseTest):
 
   @parameterized.product(
       is_mqa=(False, True),
@@ -355,6 +360,7 @@ class SplashAttentionTest(AttentionTest):
           mask,
           block_sizes=block_sizes,
           attn_logits_soft_cap=attn_logits_soft_cap,
+          interpret=self.INTERPRET,
       )
     else:
       attn_ref = splash.make_masked_mha_reference(mask)
@@ -362,6 +368,7 @@ class SplashAttentionTest(AttentionTest):
           mask,
           block_sizes=block_sizes,
           attn_logits_soft_cap=attn_logits_soft_cap,
+          interpret=self.INTERPRET,
       )
     o = attn(q, k, v, segment_ids)
     o_ref = attn_ref(
@@ -416,6 +423,7 @@ class SplashAttentionTest(AttentionTest):
           block_sizes=block_sizes,
           save_residuals=True,
           attn_logits_soft_cap=attn_logits_soft_cap,
+          interpret=self.INTERPRET,
       )
     else:
       attn_ref = splash.make_masked_mha_reference(mask)
@@ -424,6 +432,7 @@ class SplashAttentionTest(AttentionTest):
           block_sizes=block_sizes,
           save_residuals=True,
           attn_logits_soft_cap=attn_logits_soft_cap,
+          interpret=self.INTERPRET,
       )
     attn_ref = partial(
         attn_ref,
@@ -564,6 +573,7 @@ class SplashAttentionTest(AttentionTest):
           block_sizes=block_sizes,
           downcast_smem_data=downcast_smem_data,
           attn_logits_soft_cap=attn_logits_soft_cap,
+          interpret=self.INTERPRET,
       )
     else:
       attn_ref = splash.make_masked_mha_reference(mask, backward_impl="custom")
@@ -572,6 +582,7 @@ class SplashAttentionTest(AttentionTest):
           block_sizes=block_sizes,
           downcast_smem_data=downcast_smem_data,
           attn_logits_soft_cap=attn_logits_soft_cap,
+          interpret=self.INTERPRET,
       )
     o, attn_vjp = jax.vjp(attn, q, k, v, segment_ids)
     q32, k32, v32 = jax.tree.map(
@@ -637,6 +648,10 @@ class SplashAttentionTest(AttentionTest):
     self._assert_allclose(dv, dv_ref, atol=2e-2, rtol=3e-2)
     self._assert_allclose(dq, dq_ref, atol=2e-2, rtol=3e-2)
     self._assert_allclose(dk, dk_ref, atol=2e-2, rtol=3e-2)
+
+
+class SplashAttentionInterpreterTest(SplashAttentionTest):
+  INTERPRET = True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This enables the tpu_splash_attention and gpu_attention_test tests to run in `interpret=True` mode.
This is useful for testing run on CPU (in interpreter mode) or TPU/GPU.

This required threading the `interpret` parameter through the TPU splash attention implementation.