### PR TITLE
[docs] Fix docs building error

### DIFF
--- a/docs/jax.experimental.rst
+++ b/docs/jax.experimental.rst
@@ -38,7 +38,3 @@ Experimental APIs
 
    enable_x64
    disable_x64
-
-   jax.experimental.checkify.checkify
-   jax.experimental.checkify.check
-   jax.experimental.checkify.check_error


### PR DESCRIPTION
The checkify APIs were mentioned in the jax.experimental.rst and also in jax.experimental.checkify.rst.