### PR TITLE
[NVIDIA] Update JAX doc to include `jax.nn.dot_product_attention`

### DIFF
--- a/docs/jax.nn.rst
+++ b/docs/jax.nn.rst
@@ -52,3 +52,4 @@ Other functions
     logsumexp
     standardize
     one_hot
+    dot_product_attention


### PR DESCRIPTION
We have recently landed a new API `jax.nn.dot.product_attention` in [this PR](https://github.com/google/jax/pull/21371). This PR updates the API doc accordingly.

cc. @hawkinsp 