### PR TITLE
[WIP] Add a `custom_ad` interface to allow simultaneous customization of JVP and VJP rules

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -957,6 +957,11 @@ class EvalTrace(Trace):
     with new_sublevel():
       return fun.call_wrapped(*tracers)
 
+  def process_custom_ad_call(self, primitive, fun, fwd, bwd, tracers, **_):  # pytype: disable=signature-mismatch
+    del primitive, fwd, bwd  # Unused.
+    with new_sublevel():
+      return fun.call_wrapped(*tracers)
+
 
 class MainTrace:
   level: int

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -1409,3 +1409,222 @@ def custom_vjp_by_custom_transpose(fun, fwd, bwd):
 
 # TODO(mattjj): remove these stubs, which exist to avoid breaking internal users
 custom_jvp_call_jaxpr_p = core.Primitive("custom_jvp_call_jaxpr")
+
+
+@custom_api_util.register_custom_decorator_type
+class custom_ad(Generic[ReturnValue]):
+  fun: Callable[..., ReturnValue]
+  nondiff_argnums: tuple[int, ...]
+  fwd: Callable[..., tuple[ReturnValue, ReturnValue, Any]] | None = None
+  bwd: Callable[..., tuple[Any, ...]] | None = None
+  symbolic_zeros: bool = False
+
+  def __init__(
+      self,
+      fun: Callable[..., ReturnValue],
+      nondiff_argnums: tuple[int, ...] = (),
+  ):
+    update_wrapper(self, fun)
+    self.fun = fun
+    self.nondiff_argnums = nondiff_argnums
+
+  __getattr__ = custom_api_util.forward_attr
+
+  def defad(
+      self,
+      fwd: Callable[..., tuple[ReturnValue, ReturnValue, Any]],
+      bwd: Callable[..., tuple[Any, ...]],
+      symbolic_zeros: bool = False,
+  ):
+    self.symbolic_zeros = symbolic_zeros
+    self.fwd = fwd
+    self.bwd = bwd
+
+  @traceback_util.api_boundary
+  def __call__(self, *args: Any, **kwargs: Any) -> ReturnValue:  # pytype: disable=invalid-annotation
+    primal_name = getattr(self.fun, "__name__", str(self.fun))
+    if not self.fwd or not self.bwd:
+      msg = f"No AD rules defined for custom_ad function {primal_name} using defad."
+      raise AttributeError(msg)
+    fwd_name = getattr(self.fwd, "__name__", str(self.fwd))
+    args = _resolve_kwargs(self.fun, args, kwargs)
+    if self.nondiff_argnums:
+      raise NotImplementedError("todo")
+    else:
+      dyn_args = args
+      f_ = lu.wrap_init(self.fun)
+      fwd = lu.wrap_init(self.fwd)
+      bwd = lu.wrap_init(self.bwd)
+    args_flat, in_tree = tree_flatten(dyn_args)
+    in_avals = [core.raise_to_shaped(core.get_aval(x)) for x in args_flat]
+    flat_fun, fun_out_type = _flatten_fun_nokwargs(f_, in_tree)
+    flat_fwd, fwd_out_type = _flatten_ad_fwd(fwd, primal_name, fwd_name, in_tree,
+                                             fun_out_type)
+    flat_bwd = _flatten_bwd(bwd, in_tree, in_avals, fwd_out_type).call_wrapped
+    out_flat = custom_ad_p.bind(flat_fun, flat_fwd, flat_bwd, *args_flat,
+                                out_trees=fwd_out_type,
+                                symbolic_zeros=self.symbolic_zeros)
+    _, (out_tree, _) = lu.merge_linear_aux(fun_out_type, fwd_out_type)
+    return tree_unflatten(out_tree, out_flat)
+
+
+@partial(lu.transformation_with_aux, use_eq_store=True)
+def _flatten_ad_fwd(primal_name, fwd_name, in_tree, maybe_out_type, *args):
+  primals_in, tangents_in = split_list(args, [len(args) // 2])
+  py_primals = tree_unflatten(in_tree, primals_in)
+  py_tangents = tree_unflatten(in_tree, tangents_in)
+  py_out = yield (py_primals, py_tangents), {}
+  if not isinstance(py_out, (list, tuple)) or len(py_out) != 3:
+    msg = (f"Custom AD forward rule {fwd_name} for function {primal_name} "
+           "must produce a list or tuple with 3 elements representing "
+           f"primal, tangent, and residuals, but got {py_out}.")
+    raise TypeError(msg)
+  py_primals_out, py_tangents_out, py_res = py_out
+  primals_out, out_tree = tree_flatten(py_primals_out)
+  tangents_out, out_tree2 = tree_flatten(py_tangents_out)
+  res, res_tree = tree_flatten(py_res)
+  primal_avals = [core.raise_to_shaped(core.get_aval(x)) for x in primals_out]
+  if out_tree != out_tree2:
+    msg = (f"Custom AD rule {fwd_name} for function {primal_name} must "
+           "produce primal and tangent outputs with equal container (pytree) "
+           f"structures, but got {out_tree} and {out_tree2} respectively.")
+    raise TypeError(msg)
+  # If the primal function already ran, check out_tree agreement.
+  try: out_type_ = maybe_out_type()
+  except lu.StoreException: out_type_ = None
+  if out_type_ is not None:
+    out_tree_, primal_avals_ = out_type_
+    ty_tree  = tree_unflatten(out_tree , [a.str_short() for a in primal_avals])
+    ty_tree_ = tree_unflatten(out_tree_, [a.str_short() for a in primal_avals_])
+    if out_tree_ != out_tree:
+      m = (f"Custom AD rule {fwd_name} for function {primal_name} must "
+           "produce a list or tuple with 3 elements "
+           "where the first element represents the primal output "
+           "(equal in value to the output of the custom_ad-decorated function "
+           f"{primal_name}, "
+           "and in particular of the same container/pytree structure), but "
+           "instead the AD rule output's first element had container/pytree "
+           "structure:\n"
+           f"""    {str(ty_tree ).replace("'", "")}\n"""
+           f"while the custom_ad-decorated function {primal_name} had output "
+           "container/pytree structure:\n"
+           f"""    {str(ty_tree_).replace("'", "")}.""")
+      raise TypeError(m)
+    if not all(map(core.typematch, primal_avals, primal_avals_)):
+      m = (f"Custom AD rule {fwd_name} for function {primal_name} must "
+           "produce a list or tuple with three elements "
+           "where the first element represents the primal output "
+           "(equal in value to the output of the custom_ad-decorated function "
+           f"{primal_name}, "
+           "and in particular with leaves of the same shape/dtype), but "
+           "instead the AD rule output's first element had shapes/dtypes of:\n"
+           f"""    {str(ty_tree ).replace("'", "")}\n"""
+           f"while the custom_ad-decorated function {primal_name} had output "
+           "shapes/dtypes of:\n"
+           f"""    {str(ty_tree_).replace("'", "")}""")
+      raise TypeError(m)
+  primal_avals_out = [
+      raise_to_shaped(core.get_aval(x), weak_type=False).strip_named_shape()
+      for x in primals_out]
+  tangent_avals_out = [
+      raise_to_shaped(core.get_aval(t), weak_type=False).strip_named_shape()
+      if type(t) is not SymbolicZero else t.aval.strip_weak_type()
+      for t in tangents_out]
+  if primal_avals_out != tangent_avals_out:
+    if len(primal_avals_out) == 1:
+      (av1,), (av2,) = primal_avals_out, tangent_avals_out
+      msg = ("Custom AD rule must produce primal and tangent outputs with "
+             "equal shapes and dtypes, but got {} and {} respectively.")
+      raise TypeError(msg.format(av1.str_short(), av2.str_short()))
+    else:
+      msg = ("Custom AD rule must produce primal and tangent outputs with "
+             "equal shapes and dtypes, but got:\n{}")
+      disagreements = (
+          f"  primal {av1.str_short()} for tangent {av2.str_short()}"
+          for av1, av2 in zip(primal_avals_out, tangent_avals_out) if av1 != av2)
+      raise TypeError(msg.format('\n'.join(disagreements)))
+  yield (*res, *primals_out, *tangents_out), (out_tree, res_tree)
+
+class CustomADPrimitive(core.Primitive):
+  multiple_results = True
+
+  def bind(self, fun, fwd, bwd, *args, out_trees, symbolic_zeros):
+    args = map(core.full_lower, args)
+    top_trace = core.find_top_trace(args)
+    fun, env_trace_todo1 = process_env_traces(
+        fun, self, top_trace and top_trace.level, False)
+    fwd, env_trace_todo2 = process_env_traces_fwd(
+        fwd, top_trace and top_trace.level, out_trees)
+    tracers = map(top_trace.full_raise, args)
+    bwd_ = lambda *args: bwd(*args)
+    outs = top_trace.process_custom_ad_call(self, fun, fwd, bwd_, tracers,
+                                            out_trees=out_trees,
+                                            symbolic_zeros=symbolic_zeros)
+    fst, env_trace_todo = lu.merge_linear_aux(env_trace_todo1, env_trace_todo2)
+    if fst:
+      return core.apply_todos(env_trace_todo, map(core.full_lower, outs))
+    else:
+      env_trace_todo, bwd_transform = env_trace_todo
+      bwd = _apply_bwd_transform(bwd_transform, bwd)
+      return core.apply_todos(env_trace_todo, map(core.full_lower, outs))
+
+  def impl(self, fun, jvp, fwd, bwd, *args, **kwargs):
+    del jvp, fwd, bwd, kwargs
+    with core.new_sublevel():
+      return fun.call_wrapped(*args)
+
+  def post_process(self, trace, out_tracers, params):
+    return trace.post_process_custom_ad_call(out_tracers, params)
+
+  def get_bind_params(self, params):
+    assert 0
+    # new_params = dict(params)
+    # call_jaxpr = new_params.pop('call_jaxpr')
+    # num_consts = new_params.pop('num_consts')
+    # jvp_jaxpr_thunk = new_params.pop('jvp_jaxpr_thunk')
+    # fwd_jaxpr_thunk = new_params.pop('fwd_jaxpr_thunk')
+    # bwd_jaxpr_thunk = new_params.pop('bwd_jaxpr_thunk')
+    # fun = lu.wrap_init(core.jaxpr_as_fun(call_jaxpr))
+    # jvp = lift_jvp(num_consts, jvp_jaxpr_thunk)
+    # fwd = ...
+    # bwd = ...
+    # return [fun, jvp], new_params
+custom_ad_p = CustomADPrimitive("custom_ad")
+
+@partial(lu.transformation_with_aux, use_eq_store=True)
+def process_env_traces_ad_fwd(level: int, out_trees, *args):
+  outs = yield args, {}
+  todo = []
+  bwd_transforms = []
+  while True:
+    tracers = [x for x in outs if isinstance(x, core.Tracer)
+               and (level is None or x._trace.level > level)]
+    if tracers:
+      ans = max(tracers, key=lambda x: x._trace.level)
+    else:
+      break
+    trace = ans._trace.main.with_cur_sublevel()
+    outs = map(trace.full_raise, outs)
+    # TODO(dfm): The custom_vjp logic should work here... I think?
+    outs, cur_todo, bwd_xform = trace.post_process_custom_vjp_call_fwd(outs, out_trees)
+    todo.append(cur_todo)
+    bwd_transforms.append(bwd_xform)
+  yield outs, (tuple(todo), tuple(bwd_transforms))
+
+# def _custom_ad_jaxpr_impl(*args, fun_jaxpr, **_):
+#   return core.jaxpr_as_fun(fun_jaxpr)(*args)
+
+# def _custom_ad_jaxpr_abstract_eval(*_, fun_jaxpr, **__):
+#   disallowed_effects = effects.custom_derivatives_allowed_effects.filter_not_in(fun_jaxpr.effects)
+#   if disallowed_effects:
+#     raise NotImplementedError(
+#         f'Effects not supported in `custom_ad`: {disallowed_effects}')
+#   return fun_jaxpr.out_avals, fun_jaxpr.effects
+
+# custom_ad_jaxpr_p = core.AxisPrimitive("custom_ad")
+# custom_ad_jaxpr_p.multiple_results = True
+# custom_ad_jaxpr_p.def_impl(_custom_ad_jaxpr_impl)
+# custom_ad_jaxpr_p.def_effectful_abstract_eval(_custom_ad_jaxpr_abstract_eval)
+# CustomADPrimitive.initial_style = custom_ad_jaxpr_p
+# mlir.register_lowering(custom_ad_jaxpr_p, mlir.lower_fun(
+#     _custom_ad_jaxpr_impl, multiple_results=True))

--- a/jax/_src/linear_util.py
+++ b/jax/_src/linear_util.py
@@ -397,3 +397,27 @@ def merge_linear_aux(aux1, aux2):
       return True, out1
     else:
       raise StoreException("both stores occupied")
+
+
+def merge_linear_aux2(aux1, aux2, aux3):
+  try:
+    flag, out = merge_linear_aux(aux1, aux2)
+  except StoreException:
+    try:
+      out_ = aux3()
+    except StoreException:
+      raise StoreException("no store occupied") from None
+    else:
+      try:
+        aux1()
+      except StoreException:
+        return 2, out_
+      else:
+        raise StoreException("multiple stores occupied")
+  else:
+    try:
+      aux3()
+    except StoreException:
+      return int(flag), out
+    else:
+      raise StoreException("multiple stores occupied") from None


### PR DESCRIPTION
Last week, @mattjj, @froystig, and I brainstormed some possible APIs for supporting the simultaneous customization of both the JVP and VJP rules for a JAX function. This is a bit tricky as things currently are implemented because the existing `custom_jvp` and `custom_vjp` are currently designed to be mutually exclusive, and even if a user is willing to use a custom `core.Primitive`, the wiring required to intercept and override the appropriate transposition rule gets a bit hairy.

In this PR, I sketch out one possible API which looks very similar to `custom_vjp`, but the `fwd` function has a different signature:

```
(primals_in, tangents_in) -> (primals_out, tangents_out, residuals)
```

instead of

```
primals_in -> (primals_out, residuals)
```

This means that the `fwd` function now allows customization of the JVP rule, while the `bwd` function still customizes the VJP with the same interface as `custom_vjp`.

## Example

Here's an example of what this API looks like in action:

```python
import jax
import jax.numpy as jnp

@jax.custom_ad
def f(x, y):
  return jnp.sin(x) * y

def f_fwd(primals, tangents):
  x, y = primals
  x_dot, y_dot = tangents
  res = (jnp.cos(x), jnp.sin(x), y)
  primal_out = f(x, y)
  tangent_out = res[0] * x_dot * y + res[1] * y_dot
  return primal_out, tangent_out, res

def f_bwd(res, g):
  cos_x, sin_x, y = res
  return (cos_x * g * y, sin_x * g)

f.defad(f_fwd, f_bwd)
```

Unlike if we had used `custom_jvp` or `custom_vjp`, `f` now supports both forward and reverse mode AD, using a custom implementation in each direction.

## Caveats and alternative approaches

One subtlety of this API is that since the `fwd` function returns both the tangents and the residuals, it could introduce extra computational cost: when we compute a VJP, we ignore the tangents returned by `fwd`, and when we compute a JVP, we ignore the residuals. For a pure JAX program, DCE will probably save us by eliminating the unused computations. But, if the `fwd` function involves a Pallas or FFI call (the most common use case, we expect), DCE probably can't help us.

The high level issue here is that, because of how JAX's AD system works, when calling the JVP rule, we don't "know" whether we're computing a JVP or instead just setting the problem up for transposition. One option would be to provide separate JVP and VJP `fwd` rules, and defer calling the appropriate rule until we know which one is needed (in the `impl` or the `transpose` of `custom_ad_lin_p`, respectively). This approach introduces some duplication of effort (the primal computation, the JVP rule, and the VJP `fwd` rule all return the primal outputs), but the bigger reason I didn't try it here is that it makes the implementation harder.

<details>
<summary>Why is the implementation harder in the deferred case?</summary>
It becomes tricky to define the abstract eval rule for the `custom_ad_lin_p` primitive in this case because we don't know the output types until we run either the JVP or VJP `fwd` rule, but we don't do that until too late. This could be solved by converting this whole operation to initial style (i.e. trace the primal computation to a Jaxpr at bind time).
</details>

More broadly, it seems like most users of an interface like this (it seems to come up in the context of Pallas or FFI calls) would probably _also_ want to customize the behavior under `vmap`. With this in mind, maybe it would be better to focus on exposing a more complete customization API. Regardless, from conversations with potential users, it seems like defining the API in terms of custom JVP+VJP instead of customizing JVP+transposition would be useful, so I think that this PR could help to clarify thinking on such an API.