### PR TITLE
[ROCM] test_computation_follows_data fix for rocm and cuda

### DIFF
--- a/tests/multi_device_test.py
+++ b/tests/multi_device_test.py
@@ -115,7 +115,9 @@ class MultiDeviceTest(jtu.JaxTestCase):
     # arguments are first device_put to the specified device. The result
     # will be committed on the specified.
     # The `device` parameter is experimental, and subject to change.
-    jit_add_on4 = jax.jit(lambda a, b: a + b, device=devices[4])
+    with jtu.ignore_warning(category=DeprecationWarning,
+                            message="backend and device argument"):
+      jit_add_on4 = jax.jit(lambda a, b: a + b, device=devices[4])
     self.assert_committed_to_device(jit_add_on4(1, 2), devices[4])
     self.assert_committed_to_device(jit_add_on4(1, jax.device_put(2, devices[2])),
                                     devices[4])


### PR DESCRIPTION
To test ->

```
python3 -m pytest -v tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data
```