### PR TITLE
[pallas] Add lowering errors for block shapes that are not supported.

### DIFF
--- a/jax/_src/pallas/mosaic/core.py
+++ b/jax/_src/pallas/mosaic/core.py
@@ -203,7 +203,7 @@ class PrefetchScalarGridSpec(pallas_core.GridSpec):
     in_block_mappings = map(
         partial(
             _convert_block_spec_to_block_mapping,
-            (*grid_avals, *scalar_ref_avals),
+            in_avals=(*grid_avals, *scalar_ref_avals),
             in_tree=index_map_in_tree,
             grid=grid_mapping_grid,
             mapped_dims=(),
@@ -216,7 +216,7 @@ class PrefetchScalarGridSpec(pallas_core.GridSpec):
     out_block_mappings = map(
         partial(
             _convert_block_spec_to_block_mapping,
-            (*grid_avals, *scalar_ref_avals),
+            in_avals=(*grid_avals, *scalar_ref_avals),
             in_tree=index_map_in_tree,
             grid=grid_mapping_grid,
             mapped_dims=(),

--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -838,7 +838,7 @@ def pallas_call_checkify_rule(error: checkify.Error,
   error_block_mappings = map(
         partial(
             pallas_core._convert_block_spec_to_block_mapping,
-            (*grid_avals, *scalar_ref_avals),
+            in_avals=(*grid_avals, *scalar_ref_avals),
             in_tree=grid_tree,
             grid=grid_mapping.grid,
             mapped_dims=grid_mapping.mapped_dims,


### PR DESCRIPTION
Previously these errors came Mosaic with less useful stack traces, and in the case of GPU we get a crash instead of an exception.

In order to implement this I had to make sure that _convert_block_spec_to_block_mapping always returns a BlockMapping even if the block spec is no_block_spec.