### PR TITLE
Fixing dtype canonicalization in sharp edges tutorial

### DIFF
--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -2165,33 +2165,17 @@
     "\n",
     "Note that #2-#4 work for _any_ of JAX's configuration options.\n",
     "\n",
-    "We can then confirm that `x64` mode is enabled:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "metadata": {
-    "id": "HqGbBa9Rr-2g",
-    "outputId": "5aa72952-08cc-4569-9b51-a10311ae9e81"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dtype('float32')"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
+    "We can then confirm that `x64` mode is enabled, for example:\n",
+    "\n",
+    "```python\n",
+    "import jax\n",
     "import jax.numpy as jnp\n",
     "from jax import random\n",
+    "\n",
+    "jax.config.update(\"jax_enable_x64\", True)\n",
     "x = random.uniform(random.key(0), (1000,), dtype=jnp.float64)\n",
-    "x.dtype # --> dtype('float64')"
+    "x.dtype # --> dtype('float64')\n",
+    "```"
    ]
   },
   {

--- a/docs/notebooks/Common_Gotchas_in_JAX.md
+++ b/docs/notebooks/Common_Gotchas_in_JAX.md
@@ -1111,14 +1111,14 @@ There are a few ways to do this:
 
 Note that #2-#4 work for _any_ of JAX's configuration options.
 
-We can then confirm that `x64` mode is enabled:
+We can then confirm that `x64` mode is enabled, for example:
 
-```{code-cell} ipython3
-:id: HqGbBa9Rr-2g
-:outputId: 5aa72952-08cc-4569-9b51-a10311ae9e81
-
+```python
+import jax
 import jax.numpy as jnp
 from jax import random
+
+jax.config.update("jax_enable_x64", True)
 x = random.uniform(random.key(0), (1000,), dtype=jnp.float64)
 x.dtype # --> dtype('float64')
 ```


### PR DESCRIPTION
As reported in https://github.com/google/jax/issues/22493, the sharp edges tutorial doesn't seem to actually enable x64 when it says it does.

Fixes https://github.com/google/jax/issues/22493