### PR TITLE
Speed up pre-commit by filtering jupytext to only run on files in docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,4 +43,5 @@ repos:
   rev: v1.16.1
   hooks:
   - id: jupytext
+    files: docs/
     args: [--sync]


### PR DESCRIPTION
I noticed that the `jupytext` pre-commit was running slowly because it reads a lot of files that it doesn't need to. I think that the only synced notebooks are in `docs`, and restricting this pre-commit to only run in this directory decreases the runtime of `pre-commit run --all-files` on my machine from 37s to 15s.