### PR TITLE
Export `jaxlib.xla_client.register_custom_call_target` as `jax.extend.ffi.register_ffi_target`

### DIFF
--- a/docs/jax.extend.ffi.rst
+++ b/docs/jax.extend.ffi.rst
@@ -9,3 +9,4 @@
   ffi_call
   ffi_lowering
   pycapsule
+  register_ffi_target

--- a/jax/_src/extend/ffi.py
+++ b/jax/_src/extend/ffi.py
@@ -29,11 +29,37 @@ from jax._src.interpreters import ad
 from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
 from jax._src.lib import jaxlib
+from jax._src.lib import xla_client
 from jax._src.lib.mlir import ir
 from jax._src.typing import Array, ArrayLike, DimSize, DuckTypedArray
 import numpy as np
 
 map, unsafe_map = util.safe_map, map
+
+
+def register_ffi_target(
+    name: str,
+    fn: Any,
+    platform: str = "cpu",
+    api_version: int = 1,
+    **kwargs: Any,
+) -> None:
+  """Registers a foreign function target.
+
+  Args:
+    name: the name of the target.
+    fn: a ``PyCapsule`` object containing the function pointer, or a ``dict``
+      where the keys are FFI stage names (e.g. `"execute"`) and the values are
+      ``PyCapsule`` objects continaing a pointer to the handler for that stage.
+    platform: the target platform.
+    api_version: the XLA custom call API version to use. Supported versions are:
+      1 (default) for the typed FFI or 0 for the earlier "custom call" API.
+    kwargs: any extra keyword arguments are passed directly to
+      :func:`~jaxlib.xla_client.register_custom_call_target` for more advanced
+      use cases.
+  """
+  return xla_client.register_custom_call_target(name, fn, platform, api_version,
+                                                **kwargs)
 
 
 def pycapsule(funcptr):

--- a/jax/extend/ffi.py
+++ b/jax/extend/ffi.py
@@ -20,4 +20,5 @@ from jax._src.extend.ffi import (
     ffi_lowering as ffi_lowering,
     include_dir as include_dir,
     pycapsule as pycapsule,
+    register_ffi_target as register_ffi_target,
 )


### PR DESCRIPTION
This means that users of the FFI interface won't need to directly interact with `jaxlib.xla_client` at all.

I've expanded the doctring a little and changed one default: the default `api_version` is `1` instead of `0` to be consistent with the new name.