### PR TITLE
[shard_map] fix psum rewrite rule's pbroadcast logic

### DIFF
--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -1569,8 +1569,23 @@ class ShardMapTest(jtu.JaxTestCase):
     def g(x):
       return f(f(x))
 
-    with self.assertRaisesRegex(Exception, r"check_rep=False"):
-      jax.grad(lambda x: g(x).sum())(jnp.ones(4))
+    y, grad = jax.value_and_grad(lambda x: g(x).sum())(jnp.ones(4))
+    # first psum sums, second psum multiplies by 4
+    self.assertAllClose(y, (jnp.ones(4) * 4).sum(), check_dtypes=False)
+    # two psums on the backward pass, each one multiplies by 4
+    self.assertAllClose(grad, jnp.ones(4) * 4 * 4, check_dtypes=False)
+
+  def test_repeated_psum_allowed(self):
+    # https://github.com/google/jax/issues/19175
+    mesh = Mesh(jax.devices()[:4], ('i',))
+
+    @partial(shard_map, mesh=mesh, in_specs=P('i'), out_specs=P())
+    def g(x):
+      return jax.lax.psum(jax.lax.psum(x, 'i'), 'i')
+
+    y = g(jnp.arange(4.))
+    self.assertAllClose(y, jnp.arange(4.).sum(keepdims=True) * 4,
+                        check_dtypes=False)
 
   def test_approx_top_k(self):
     mesh = Mesh(np.array(jax.devices()[:2]), ('i',))


### PR DESCRIPTION
We want to allow users to write `psum(x, axes)` regardless of how `x` is replicated. That means when we rewrite it into the stricter `psum2`, which can only sum over non-replicated axes, we need to insert a pbroadcast like this:

```python
psum(x, axes) == psum2(pbroadcast(x, axes & input_replicated_axes), axes)
```

In words, we need to first `pbroadcast` over all those axes we're about to sum over but that the input is already replicated over.

We write it as a comprehension over mesh.axis_names, rather than just that set intersection, just to ensure deterministic ordering, since Python set operations are not guaranteed to be deterministic. There are other places in the file where we don't ensure deterministic ordering; someday I'll come back and fix those.