### PR TITLE
[pallas] More simplification of grid mapping and calling convention

### DIFF
--- a/docs/jax.experimental.pallas.rst
+++ b/docs/jax.experimental.pallas.rst
@@ -10,6 +10,7 @@ Classes
   :toctree: _autosummary
 
   BlockSpec
+  GridSpec
   Slice
 
 Functions

--- a/docs/pallas/CHANGELOG.md
+++ b/docs/pallas/CHANGELOG.md
@@ -17,6 +17,13 @@ Remember to align the itemized text with the first line of an item within a list
   * {class}`jax.experimental.pallas.BlockSpec` now expects `block_shape` to
     be passed *before* `index_map`. The old argument order is deprecated and
     will be removed in a future release.
+  * {class}`jax.experimental.pallas.GridSpec` does not have anymore the `in_specs_tree`,
+    and the `out_specs_tree` fields, and the `in_specs` and `out_specs` tree now
+    store the values as pytrees of BlockSpec. Previously, `in_specs` and
+    `out_specs` were flattened ({jax-issue}`#22552`).
+  * The method `compute_index` of {class}`jax.experimental.pallas.GridSpec` has
+    been removed because it is private. Similarly, the `get_grid_mapping` and
+    `unzip_dynamic_bounds` have been removed from `BlockSpec` ({jax-issue}`#22593`).
   * Fixed the interpreter mode to work with BlockSpec that involve padding
     ({jax-issue}`#22275`).
     Padding in interpreter mode will be with NaN, to help debug out-of-bounds

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1705,7 +1705,7 @@ def canonicalize_dim(d: DimSize, context: str="") -> DimSize:
   """Canonicalizes and checks for errors in a user-provided shape dimension value.
 
   Args:
-    f: a Python value that represents a dimension.
+    d: a Python value that represents a dimension.
 
   Returns:
     A canonical dimension value.

--- a/jax/_src/pallas/mosaic/core.py
+++ b/jax/_src/pallas/mosaic/core.py
@@ -67,7 +67,7 @@ class barrier_semaphore(semaphore_dtype): pass
 class AbstractSemaphoreTyRules:
   @staticmethod
   def pallas_interpret_element_aval(_) -> jax_core.ShapedArray:
-    return jax_core.ShapedArray((), jnp.dtype('int32'))
+    return pallas_core.index_map_grid_aval
 
 class AbstractSemaphoreTy(dtypes.ExtendedDType):
   name: str
@@ -145,8 +145,8 @@ class PrefetchScalarGridSpec(pallas_core.GridSpec):
   grid: TupleGrid
   grid_names: tuple[Hashable, ...] | None
   num_scalar_prefetch: int
-  in_specs: tuple[BlockSpec | NoBlockSpec, ...] | NoBlockSpec
-  out_specs: tuple[BlockSpec | NoBlockSpec, ...] | NoBlockSpec
+  in_specs: pallas_core.BlockSpecTree
+  out_specs: pallas_core.BlockSpecTree
   scratch_shapes: tuple[Any, ...]
 
   def __init__(
@@ -172,14 +172,6 @@ class PrefetchScalarGridSpec(pallas_core.GridSpec):
       return obj.get_aval()
     raise ValueError(f"No registered conversion for {type(obj)}. "
                      "Only VMEM and SemaphoreType are supported.")
-
-  def get_grid_mapping(  # type: ignore[override]
-      self, in_avals, in_tree, in_paths, out_avals, out_tree, out_paths
-  ) -> tuple[tuple[jax_core.AbstractValue, ...], GridMapping]:
-    return super().get_grid_mapping(in_avals, in_tree, in_paths,
-                                    out_avals, out_tree, out_paths,
-                                    num_scalar_prefetch=self.num_scalar_prefetch,
-                                    scratch_shapes=self.scratch_shapes)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/jax/_src/pallas/mosaic/pallas_call_registration.py
+++ b/jax/_src/pallas/mosaic/pallas_call_registration.py
@@ -74,8 +74,6 @@ def pallas_call_tpu_lowering_rule(
     compiler_params: dict[str, Any]):
   """Lowers a pallas_call to a Mosaic TPU custom call."""
   del interpret
-  # TODO(necula): cleanup
-  out_shapes = grid_mapping.out_shapes
   if debug:
     print(jaxpr)
   if "mosaic_params" in compiler_params:
@@ -118,7 +116,9 @@ def pallas_call_tpu_lowering_rule(
       (a[0] + num_dyn_bounds + num_extra_args, a[1])
       for a in input_output_aliases
   )
-  out_avals = [jax_core.ShapedArray(s.shape, s.dtype) for s in out_shapes]
+  out_avals = [jax_core.ShapedArray(bm.array_shape_dtype.shape,
+                                    bm.array_shape_dtype.dtype)
+               for bm in grid_mapping.block_mappings_output]
 
   if promela_dump_path := _DUMP_PROMELA_TO.value:
     num_devices = 1 if mesh is None else mesh.devices.size

--- a/jax/_src/pallas/mosaic/pipeline.py
+++ b/jax/_src/pallas/mosaic/pipeline.py
@@ -276,7 +276,7 @@ class BufferedRef:
 
   @property
   def compute_index(self):
-    return self.spec.compute_index
+    return lambda *args: pallas_core.compute_index(self.spec, *args)
 
   @property
   def memory_space(self):

--- a/jax/_src/pallas/mosaic_gpu/lowering.py
+++ b/jax/_src/pallas/mosaic_gpu/lowering.py
@@ -147,7 +147,7 @@ def lower_jaxpr_to_module(
     name: str,
     compiler_params: dict[str, Any],
 ) -> LoweringResult:
-  in_structs = grid_mapping.in_shapes
+  in_structs = tuple(grid_mapping.in_shapes)
   out_structs = grid_mapping.out_shapes
   assert len(jaxpr.outvars) == 0
   assert not grid_mapping.vmapped_dims

--- a/jax/experimental/pallas/__init__.py
+++ b/jax/experimental/pallas/__init__.py
@@ -25,6 +25,7 @@ from jax._src.pallas.core import IndexingMode
 from jax._src.pallas.core import no_block_spec
 from jax._src.pallas.core import Unblocked
 from jax._src.pallas.core import unblocked
+from jax._src.pallas.core import GridSpec
 from jax._src.pallas.pallas_call import pallas_call
 from jax._src.pallas.pallas_call import pallas_call_p
 from jax._src.pallas.primitives import atomic_add


### PR DESCRIPTION
In previous PR #22552 I have expanded `GridMapping` to encode more
parts of the calling convention. Here we use that new functionality
and clean up some code.

I have removed the internal methods from `BlockSpec` and `GridSpec` because
these classes are part of the API. I also removed dangerous `unsafe_hash` tags
on `BlockSpec` and `GridSpec`.

I added entries to pallas/CHANGELOG.