### PR TITLE
[NVIDIA] Fix CUDA version checks

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -493,7 +493,9 @@ def is_cuda_compute_capability_at_least(capability: str) -> bool:
   if not is_device_cuda():
     return False
   d, *_ = jax.local_devices(backend="gpu")
-  return d.compute_capability >= capability
+  target = tuple(int(x) for x in capability.split("."))
+  current = tuple(int(x) for x in d.compute_capability.split("."))
+  return current >= target
 
 def _get_device_tags():
   """returns a set of tags defined for the device under test"""


### PR DESCRIPTION
This PR allows the `is_cuda_compute_capability_at_least` to support newer GPU compute capability like 10.0.

