### PR TITLE
fix memory leak in cond jaxpr tracing

### DIFF
--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -393,7 +393,7 @@ class JaxprTypeChecks(jtu.JaxTestCase):
     super().setUp()
     lax_control_flow._initial_style_open_jaxpr.cache_clear()
     lax_control_flow._initial_style_jaxpr.cache_clear()
-    lax_control_flow._initial_style_jaxprs_with_common_consts.cache_clear()
+    lax_control_flow.common._pad_jaxpr_constvars.cache_clear()
 
   def test_check_jaxpr_correct(self):
     jaxpr = make_jaxpr(lambda x: jnp.sin(x) + jnp.cos(x))(1.).jaxpr


### PR DESCRIPTION
fixes #12719

We already have test coverage for getting cache hits in `LaxControlFlowTest.LaxControlFlowTest.test_cond_excessive_compilation`.