### PR TITLE
Fix incorrect usage of assertWarns in tests

### DIFF
--- a/tests/deprecation_test.py
+++ b/tests/deprecation_test.py
@@ -26,7 +26,7 @@ class DeprecationTest(absltest.TestCase):
       warnings.simplefilter("error")
       self.assertEqual(m.x, 42)
 
-    with self.assertWarns(DeprecationWarning, msg="Please use x"):
+    with self.assertWarnsRegex(DeprecationWarning, "Please use x"):
       self.assertEqual(m.y, 101)
 
     with self.assertRaisesRegex(AttributeError, "Please do not use z"):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -907,17 +907,17 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     msg = "Complex values have no ordering and cannot be clipped"
     # jit is disabled so we don't miss warnings due to caching.
     with jax.disable_jit():
-      with self.assertWarns(DeprecationWarning, msg=msg):
+      with self.assertWarnsRegex(DeprecationWarning, msg):
         jnp.clip(x)
 
-      with self.assertWarns(DeprecationWarning, msg=msg):
+      with self.assertWarnsRegex(DeprecationWarning, msg):
         jnp.clip(x, max=x)
 
       x = rng(shape, dtype=jnp.int32)
-      with self.assertWarns(DeprecationWarning, msg=msg):
+      with self.assertWarnsRegex(DeprecationWarning, msg):
         jnp.clip(x, min=-1+5j)
 
-      with self.assertWarns(DeprecationWarning, msg=msg):
+      with self.assertWarnsRegex(DeprecationWarning, msg):
         jnp.clip(x, max=jnp.array([-1+5j]))
 
   # TODO(micky774): Check for ValueError instead of DeprecationWarning when
@@ -932,10 +932,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     msg = "Passing complex-valued inputs to hypot"
     # jit is disabled so we don't miss warnings due to caching.
     with jax.disable_jit():
-      with self.assertWarns(DeprecationWarning, msg=msg):
+      with self.assertWarnsRegex(DeprecationWarning, msg):
         jnp.hypot(x, x)
 
-      with self.assertWarns(DeprecationWarning, msg=msg):
+      with self.assertWarnsRegex(DeprecationWarning, msg):
         y = jnp.ones_like(x)
         jnp.hypot(x, y)
 
@@ -3962,8 +3962,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   def testAstypeComplexDowncast(self):
     x = jnp.array(2.0+1.5j, dtype='complex64')
-    msg = "Casting from complex to non-complex dtypes will soon raise "
-    with self.assertWarns(DeprecationWarning, msg=msg):
+    msg = "Casting from complex to real dtypes will soon raise "
+    with self.assertWarnsRegex(DeprecationWarning, msg):
       x.astype('float32')
 
   @parameterized.parameters('int2', 'int4')


### PR DESCRIPTION
`assertWarns(..., msg=msg)` does not check that the warning matches `msg`, rather this allows overriding the error message in case of failure. Instead, I think we intended `assertWarnsRegex`.