### PR TITLE
Fix `jnp.triu_indices_from` and `jnp.tril_indices_from` to emulate NumPy's behavior for non 2-D input

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -5072,13 +5072,17 @@ def tril_indices(n: int, k: int = 0, m: int | None = None) -> tuple[Array, Array
 @util.implements(np.triu_indices_from)
 def triu_indices_from(arr: ArrayLike, k: int = 0) -> tuple[Array, Array]:
   arr_shape = shape(arr)
-  return triu_indices(arr_shape[-2], k=k, m=arr_shape[-1])
+  if len(arr_shape) != 2:
+    raise ValueError("Only 2-D inputs are accepted")
+  return triu_indices(arr_shape[0], k=k, m=arr_shape[1])
 
 
 @util.implements(np.tril_indices_from)
 def tril_indices_from(arr: ArrayLike, k: int = 0) -> tuple[Array, Array]:
   arr_shape = shape(arr)
-  return tril_indices(arr_shape[-2], k=k, m=arr_shape[-1])
+  if len(arr_shape) != 2:
+    raise ValueError("Only 2-D inputs are accepted")
+  return tril_indices(arr_shape[0], k=k, m=arr_shape[1])
 
 
 @util.implements(np.fill_diagonal, lax_description="""


### PR DESCRIPTION
It seems inconsistent that `np.triu_indices_from` and `np.tril_indices_from` raise an error for non-2D input arrays, while `jnp.triu_indices_from` and `jnp.tril_indices_from` return a tuple of two index arrays for any input shape. Given that the output is a tuple of two arrays, it would be expected that both NumPy and JAX functions would restrict input to 2D arrays for consistency and clarity.

`triu_indices_from`:
```python
>>> arr = jnp.arange(1, 9).reshape(2, 2, 2)
>>> jnp.triu_indices_from(arr)
(Array([0, 0, 1], dtype=int32), Array([0, 1, 1], dtype=int32))
>>> np.triu_indices_from(arr)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/rajasekharp/jax-cpu/lib/python3.11/site-packages/numpy/lib/twodim_base.py", line 1182, in triu_indices_from
    raise ValueError("input array must be 2-d")
ValueError: input array must be 2-d
```

`tril_indices_from`:
```python
>>> jnp.tril_indices_from(arr)
(Array([0, 1, 1], dtype=int32), Array([0, 0, 1], dtype=int32))
>>> np.tril_indices_from(arr)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/rajasekharp/jax-cpu/lib/python3.11/site-packages/numpy/lib/twodim_base.py", line 1029, in tril_indices_from
    raise ValueError("input array must be 2-d")
ValueError: input array must be 2-d
```

This PR fixes this by raising a `ValueError` when the input is not a 2-D array.