### PR TITLE
[shape_poly] Export jax.typing.DimSize and jax.typing.Shape.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     more cases. Previously non-parallel computations were always dispatched
     synchronously. You can recover the old behavior by setting
     `jax.config.update('jax_cpu_enable_async_dispatch', False)`.
+  * Added {obj}`jax.typing.DimSize` for annotating shape dimensions, which
+    can be either integer constants or symbolic dimensions (in the presence
+    of shape polymorphism). The {obj}`jax.typing.Shape` denotes a sequence
+    of `DimSize`.
 
 * Breaking changes
   * The MHLO MLIR dialect (`jax.extend.mlir.mhlo`) has been removed. Use the

--- a/docs/export/shape_poly.md
+++ b/docs/export/shape_poly.md
@@ -16,6 +16,7 @@ following example:
 ```python
 >>> import jax
 >>> from jax import export
+>>> from jax.typing import DimSize, Shape
 >>> from jax import numpy as jnp
 >>> def f(x):  # f: f32[a, b]
 ...   return jnp.concatenate([x, x], axis=1)
@@ -24,7 +25,7 @@ following example:
 >>> a, b = export.symbolic_shape("a, b")
 
 >>> # We can use the symbolic dimensions to construct shapes.
->>> x_shape = (a, b)
+>>> x_shape: Shape = (a, b)
 >>> x_shape
 (a, b)
 
@@ -54,6 +55,9 @@ constants to construct shapes. The dimension expression objects
 overload most integer operators, so you can use them as
 you'd use integer constants in most cases.
 See {ref}`computing-with-dimension-variables` for more details.
+
+You can use the type `jax.typing.DimSize` for the type of dimensions,
+which can be either integer constants or symbolic.
 
 Additionally, we provide the {func}`jax.export.symbolic_args_specs` that
 can be used to construct pytrees of `jax.ShapeDtypeStruct` objects based

--- a/jax/_src/typing.py
+++ b/jax/_src/typing.py
@@ -62,9 +62,7 @@ DTypeLike = Union[
   SupportsDType,  # like jnp.float32, jnp.int32
 ]
 
-# Shapes are tuples of dimension sizes, which are normally integers. We allow
-# modules to extend the set of dimension sizes to contain other types, e.g.,
-# symbolic dimensions in export.DimExpr.
+# DimSize is used for shape dimensions, can be integer or symbolic
 DimSize = Union[int, Any]  # extensible
 Shape = Sequence[DimSize]
 

--- a/jax/core.py
+++ b/jax/core.py
@@ -159,11 +159,11 @@ _deprecations = {
     "pp_vars": ("jax.core.pp_vars is deprecated.", _src_core.pp_vars),
     # Finalized 2024-05-13; remove after 2024-08-13
     "DimSize": (
-        "jax.core.DimSize is deprecated. Use DimSize = int | Any.",
+        "jax.core.DimSize is deprecated. Use jax.typing.DimSize.",
         None,
     ),
     "Shape": (
-        "jax.core.Shape is deprecated. Use Shape = Sequence[int | Any].",
+        "jax.core.Shape is deprecated. Use jax.typing.Shape.",
         None,
     ),
     # Finalized 2024-06-24; remove after 2024-09-24

--- a/jax/typing.py
+++ b/jax/typing.py
@@ -72,4 +72,6 @@ see `Non-array inputs NumPy vs JAX`_
 from jax._src.typing import (
     ArrayLike as ArrayLike,
     DTypeLike as DTypeLike,
+    Shape as Shape,
+    DimSize as DimSize,
 )


### PR DESCRIPTION
Some users want to have more precise typing annotations for JAX dimensions sizes and shapes, even in presence of shape polymorphism.

At the moment the `DimSize` is defined as `int | Any`. Defining it more precisely is a more involved affair that would involve specifying the symbolic dimensions duck type integers. This is future work.