### PR TITLE
Simplify jaxpr for jnp.repeat in scalar repeat case.

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -4680,11 +4680,12 @@ def repeat(a: ArrayLike, repeats: ArrayLike, axis: int | None = None, *,
     # Fast path for when repeats is a scalar.
     if np.ndim(repeats) == 0 and ndim(a) != 0:
       input_shape = shape(a)
-      aux_axis = axis if axis < 0 else axis + 1
-      a = expand_dims(a, aux_axis)
-      reps: list[DimSize] = [1] * len(shape(a))
-      reps[aux_axis] = repeats
-      a = tile(a, reps)
+      axis = _canonicalize_axis(axis, len(input_shape))
+      aux_axis = axis + 1
+      aux_shape: list[DimSize] = list(input_shape)
+      aux_shape.insert(aux_axis, repeats)
+      a = lax.broadcast_in_dim(
+        a, aux_shape, [i for i in range(len(aux_shape)) if i != aux_axis])
       result_shape: list[DimSize] = list(input_shape)
       result_shape[axis] *= repeats
       return reshape(a, result_shape)


### PR DESCRIPTION
Before:
```
In [2]: jax.make_jaxpr(lambda x: jnp.repeat(x, 3, axis=-1))(jnp.arange(12).reshape(3, 4))
Out[2]:
{ lambda ; a:i32[3,4]. let
    b:i32[3,4,1] = broadcast_in_dim[broadcast_dimensions=(0, 1) shape=(3, 4, 1)] a
    c:i32[1,3,1,4,1,1] = reshape[dimensions=None new_sizes=(1, 3, 1, 4, 1, 1)] b
    d:i32[1,3,1,4,3,1] = broadcast_in_dim[
      broadcast_dimensions=(0, 1, 2, 3, 4, 5)
      shape=(1, 3, 1, 4, 3, 1)
    ] c
    e:i32[3,4,3] = reshape[dimensions=None new_sizes=(3, 4, 3)] d
    f:i32[3,12] = reshape[dimensions=None new_sizes=(3, 12)] e
  in (f,) }
```

After:
```
In [2]: jax.make_jaxpr(lambda x: jnp.repeat(x, 3, axis=-1))(jnp.arange(12).reshape(3, 4))
Out[2]:
{ lambda ; a:i32[3,4]. let
    b:i32[3,4,3] = broadcast_in_dim[broadcast_dimensions=(0, 1) shape=(3, 4, 3)] a
    c:i32[3,12] = reshape[dimensions=None new_sizes=(3, 12)] b
  in (c,) }
```