### PR TITLE
Remove custom partitioning pointer from pre-compiled HLO

### DIFF
--- a/jax/_src/compilation_cache.py
+++ b/jax/_src/compilation_cache.py
@@ -265,7 +265,9 @@ def put_executable_and_time(
     cache.put(cache_key, executable_and_time)
 
 
-def get_cache_key(module: ir.Module, devices: np.ndarray, compile_options,
+def get_cache_key(module: ir.Module,
+                  devices: np.ndarray,
+                  compile_options,
                   backend) -> str:
   return cache_key.get(module, devices, compile_options, backend,
                        "zstandard" if zstandard is not None else "zlib")

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1347,6 +1347,16 @@ compilation_cache_max_size = int_state(
           'size to grow indefinitely.'),
 )
 
+remove_custom_partitioning_ptr_from_cache_key = bool_state(
+    name='jax_remove_custom_partitioning_ptr_from_cache_key',
+    default=False,
+    help=('If set to True, remove the custom partitioning pointer '
+          'present in the precompiled stableHLO before hashing  '
+          'during cache key computation. This is a potentially '
+          'unsafe flag to set and only users who are sure of '
+          'what they are trying to achieve should set it.'),
+)
+
 default_dtype_bits = enum_state(
     name='jax_default_dtype_bits',
     enum_values=['32', '64'],


### PR DESCRIPTION
When hashing the pre-compiled IR during computation of the JAX compilation cache key, function that use custom_partitioning produce a different hash every time even for the same underlying computation. This is because of the backend_config pointer changing across runs. To make the compilation cache work for functions that implement custom_partitioning, this PR includes a flag, which when set will set that pointer to be a constant. 