### PR TITLE
[pallas] Improve error localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ see {ref}`pallas-changelog`.
 
 <!--
 Remember to align the itemized text with the first line of an item within a list.
+
+When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.md.
 -->
 
 ## jax 0.4.32

--- a/docs/pallas/CHANGELOG.md
+++ b/docs/pallas/CHANGELOG.md
@@ -11,7 +11,17 @@ For the overall JAX change log see [here](https://jax.readthedocs.io/en/latest/c
 Remember to align the itemized text with the first line of an item within a list.
 -->
 
-## Released with JAX 0.4.31
+## Released with jax 0.4.32
+
+* Changes
+
+* Deprecations
+
+* New functionality:
+  * Improved error messages for mistakes in the signature of the index map functions,
+    to include the name and source location of the index map.
+
+##  Released with jax 0.4.31 (July 29, 2024)
 
 * Changes
   * {class}`jax.experimental.pallas.BlockSpec` now expects `block_shape` to

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -2301,8 +2301,7 @@ class DebugInfo(NamedTuple):
 def debug_info(fn: Callable, in_tree: PyTreeDef | None,
                out_tree_thunk: Callable[[], PyTreeDef] | None,
                has_kwargs: bool, traced_for: str) -> DebugInfo:
-  try: sig = inspect.signature(fn)
-  except (ValueError, TypeError): sig = None
+  sig = api_util.fun_signature(fn)
   src_info = fun_sourceinfo(fn)
   return DebugInfo(src_info, sig, in_tree, out_tree_thunk, has_kwargs,
                    traced_for)

--- a/jax/_src/pallas/mosaic/pipeline.py
+++ b/jax/_src/pallas/mosaic/pipeline.py
@@ -276,7 +276,7 @@ class BufferedRef:
 
   @property
   def compute_index(self):
-    return lambda *args: pallas_core.compute_index(self.spec, *args)
+    return self.spec.index_map
 
   @property
   def memory_space(self):

--- a/jax/_src/pallas/primitives.py
+++ b/jax/_src/pallas/primitives.py
@@ -810,7 +810,7 @@ def run_scoped(f: Callable[..., Any], *types, **kw_types) -> Any:
   """Call the function with allocated references.
 
   Args:
-    f: The function that generatest the jaxpr.
+    f: The function that generates the jaxpr.
     *types: The types of the function's positional arguments.
     **kw_types: The types of the function's keyword arguments.
   """

--- a/tests/pallas/tpu_pallas_test.py
+++ b/tests/pallas/tpu_pallas_test.py
@@ -208,64 +208,6 @@ class PallasCallScalarPrefetchTest(PallasBaseTest):
     self.assertIsInstance(res, tuple)  # Even though we asked for a list!
     self.assertAllClose(res[0][0], x)
 
-  def test_block_spec_with_wrong_block_shape_errors(self):
-    def body(x_ref, o_ref):
-      o_ref[...] = x_ref[...]
-
-    x = jnp.ones((16, 128))
-    with self.assertRaisesRegex(
-        ValueError,
-        'Block shape .* must have the same number of dimensions as the array shape .*'):
-      _ = self.pallas_call(
-          body,
-          grid_spec=pltpu.PrefetchScalarGridSpec(
-              num_scalar_prefetch=0,
-              in_specs=[pl.BlockSpec((128,), lambda i: (i, 0))],  # WRONG
-              out_specs=pl.BlockSpec((8, 128,), lambda i: (i, 0)),
-              grid=(2,),
-          ),
-          out_shape=x,
-      )(x)
-
-  def test_block_spec_with_index_map_that_accepts_wrong_number_of_args_errors(self):
-    def body(x_ref, o_ref):
-      o_ref[...] = x_ref[...]
-
-    x = jnp.ones((16, 128))
-    with self.assertRaisesRegex(
-        TypeError,
-        'missing 1 required positional argument: \'j\''):
-      _ = self.pallas_call(
-          body,
-          grid_spec=pltpu.PrefetchScalarGridSpec(
-              num_scalar_prefetch=0,
-              in_specs=[pl.BlockSpec((8, 128,), lambda i, j: (i, 0))],  # WRONG
-              out_specs=pl.BlockSpec((8, 128,), lambda i: (i, 0),),
-              grid=(2,),
-          ),
-          out_shape=x,
-      )(x)
-
-  def test_block_spec_with_index_map_returns_wrong_number_of_values_errors(self):
-    def body(x_ref, o_ref):
-      o_ref[...] = x_ref[...]
-
-    x = jnp.ones((16, 128))
-    with self.assertRaisesRegex(
-        ValueError,
-        r'Index map for inputs\[0\] must return 2 values to match block shape \(8, 128\).'
-        ' Currently returning 1 values.'):
-      _ = self.pallas_call(
-          body,
-          grid_spec=pltpu.PrefetchScalarGridSpec(
-              num_scalar_prefetch=0,
-              in_specs=[pl.BlockSpec((8, 128,), lambda i: (i,))],  # WRONG
-              out_specs=pl.BlockSpec((8, 128), lambda i: (i, 0)),
-              grid=(2,),
-          ),
-          out_shape=x,
-      )(x)
-
   def test_vmap_scalar_prefetch(self):
     def body(_, x_ref, o_ref):
       o_ref[...] = x_ref[...]


### PR DESCRIPTION
  * Add the function name and the source location information for the index map function to
    `BlockMapping`.
  * Removed the `compute_index` wrapper around the `BlockSpec.index_map`, so that
    we can get the location information for the `index_map`, not the wrapper.
  * Added source location to the errors related to index map functions.
  * Added an error if the index map returns something other than integer
    scalars.
  * Construct BlockSpec origins for arguments using JAX helper functions
    to get argument names, e.g., "block spec for x['field']" rather than "block spec for args[5]['field']".
  * Removed redundant API error tests from tpu_pallas_test.py