### PR TITLE
Fix `jax.scipy.stats.betabinom.logpmf` and `binom.logpmf` for JAX to emulate SciPy's behavior when `k=n=0`

### DIFF
--- a/jax/_src/scipy/stats/betabinom.py
+++ b/jax/_src/scipy/stats/betabinom.py
@@ -55,9 +55,11 @@ def logpmf(k: ArrayLike, n: ArrayLike, a: ArrayLike, b: ArrayLike,
   combiln = lax.neg(lax.add(lax.log1p(n), betaln(lax.add(lax.sub(n,y), one), lax.add(y,one))))
   beta_lns = lax.sub(betaln(lax.add(y,a), lax.add(lax.sub(n,y),b)), betaln(a,b))
   log_probs = lax.add(combiln, beta_lns)
-  y_cond = jnp.logical_or(lax.lt(y, lax.neg(loc)), lax.gt(y, lax.sub(n, loc)))
+  log_probs = jnp.where(jnp.logical_and(lax.eq(y, zero), lax.eq(n, zero)), 0., log_probs)
+  y_cond = jnp.logical_or(jnp.logical_or(lax.lt(y, lax.neg(loc)), lax.gt(y, n)),
+                          lax.le(lax.add(y, a), zero))
   log_probs = jnp.where(y_cond, -jnp.inf, log_probs)
-  n_a_b_cond = jnp.logical_or(jnp.logical_or(lax.lt(n, one), lax.lt(a, zero)), lax.lt(b, zero))
+  n_a_b_cond = jnp.logical_or(jnp.logical_or(lax.lt(n, zero), lax.le(a, zero)), lax.le(b, zero))
   return jnp.where(n_a_b_cond, jnp.nan, log_probs)
 
 

--- a/jax/_src/scipy/stats/binom.py
+++ b/jax/_src/scipy/stats/binom.py
@@ -15,6 +15,7 @@
 from jax import lax
 import jax.numpy as jnp
 from jax._src.numpy.util import promote_args_inexact
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.scipy.special import gammaln, xlogy, xlog1py
 from jax._src.typing import Array, ArrayLike
 
@@ -46,12 +47,16 @@ def logpmf(k: ArrayLike, n: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Arra
   """
   k, n, p, loc = promote_args_inexact("binom.logpmf", k, n, p, loc)
   y = lax.sub(k, loc)
+  zero = _lax_const(y, 0)
   comb_term = lax.sub(
       gammaln(n + 1),
       lax.add(gammaln(y + 1), gammaln(n - y + 1))
   )
   log_linear_term = lax.add(xlogy(y, p), xlog1py(lax.sub(n, y), lax.neg(p)))
   log_probs = lax.add(comb_term, log_linear_term)
+  y_n_cond = jnp.logical_or(jnp.logical_and(lax.eq(y, zero), lax.eq(n, zero)),
+                            lax.eq(log_linear_term, zero))
+  log_probs = jnp.where(y_n_cond, 0., log_probs)
   return jnp.where(lax.ge(k, loc) & lax.lt(k, loc + n + 1), log_probs, -jnp.inf)
 
 

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -1173,8 +1173,6 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       k, n, a, b, loc = map(rng, shapes, dtypes)
       k = np.floor(k)
       n = np.ceil(n)
-      a = np.clip(a, a_min = 0.1, a_max=None).astype(a.dtype)
-      b = np.clip(a, a_min = 0.1, a_max=None).astype(b.dtype)
       loc = np.floor(loc)
       return [k, n, a, b, loc]
 
@@ -1184,6 +1182,10 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
                               tol=5e-4)
       self._CompileAndCheck(lax_fun, args_maker, rtol=1e-5, atol=1e-5)
 
+  def testBetaBinomLogPmfZerokZeron(self):
+    self.assertEqual(lsp_stats.betabinom.logpmf(0, 0, 10, 5, 0),
+                     osp_stats.betabinom.logpmf(0, 0, 10, 5, 0))
+
   @genNamedParametersNArgs(4)
   def testBinomLogPmf(self, shapes, dtypes):
     rng = jtu.rand_positive(self.rng())
@@ -1192,8 +1194,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
 
     def args_maker():
       k, n, logit, loc = map(rng, shapes, dtypes)
-      k = np.floor(np.abs(k))
-      n = np.ceil(np.abs(n))
+      k = np.floor(k)
+      n = np.ceil(n)
       p = expit(logit)
       loc = np.floor(loc)
       return [k, n, p, loc]
@@ -1208,6 +1210,10 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
   def testBinomPmfOutOfRange(self):
     # Regression test for https://github.com/google/jax/issues/19150
     self.assertEqual(lsp_stats.binom.pmf(k=6.5, n=5, p=0.8), 0.0)
+
+  def testBinomLogPmfZerokZeron(self):
+    self.assertEqual(lsp_stats.binom.logpmf(0, 0, 0.8, 0),
+                     osp_stats.binom.logpmf(0, 0, 0.8, 0))
 
   def testIssue972(self):
     self.assertAllClose(


### PR DESCRIPTION
Fixes #19318 