### PR TITLE
Fix arcsinh accuracy test failure

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -3794,8 +3794,15 @@ class FunctionAccuracyTest(jtu.JaxTestCase):
     size_im = 11
     atol = None
 
-    mnp = jtu.numpy_with_mpmath(mpmath, extra_prec=1)
-    mnp2 = jtu.numpy_with_mpmath(mpmath, extra_prec_multiplier=1)
+    if name in {"arccos", "arcsin", "arcsinh", "arccosh"}:
+      # TODO(pearu): eliminate this if-block when a fix to mpmath#787
+      # becomes available
+      extra_prec_multiplier = 20
+    else:
+      extra_prec_multiplier = 1
+
+    mnp = jtu.numpy_with_mpmath(mpmath, extra_prec=1, extra_prec_multiplier=extra_prec_multiplier)
+    mnp2 = jtu.numpy_with_mpmath(mpmath, extra_prec_multiplier=extra_prec_multiplier)
 
     ref_op = getattr(mnp, name)
     ref2_op = getattr(mnp2, name)


### PR DESCRIPTION
As in the title.

Background: mpmath 1.3 uses a naive Hull et al method for evaluating complex asin/acos/asinh/acosh function that is known to be inaccurate for small inputs, see https://github.com/mpmath/mpmath/issues/787 . A temporary fix is to drastically increase the mpmath precision when evaluating these mpmath functions to obtain sufficiently accurate reference values for JAX complex functions accuracy tests.

Fixes the test failure reported in https://github.com/google/jax/actions/runs/10155253290/job/28081706499

Note that these failures are false-negatives as these raise due to inaccurate reference values. Previously, the successful tests were actually false-positives because JAX used stablehlo functions which were inaccurate in the same way as the corresponding functions in mpmath 1.3. Now, JAX/XLA uses a more recent version of stablehlo that has the inaccuracies fixed (PRs https://github.com/openxla/stablehlo/pull/2411, https://github.com/openxla/stablehlo/pull/2409, https://github.com/openxla/stablehlo/pull/2402, https://github.com/openxla/stablehlo/pull/2357).
