### PR TITLE
Fix issue with multiple arguments when using custom_vjp with optimize_remat

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -1468,6 +1468,7 @@ def optimize_remat_of_custom_vjp_fwd(
     flat_fun, out_type = _flatten_fun_nokwargs(f_, in_tree)
     flat_fwd, out_trees = _flatten_fwd(fwd_, False, primal_name, fwd_name,
                                        in_tree, out_type)
+    flat_fwd = _fix_fwd_args(flat_fwd)
 
     in_avals = [core.raise_to_shaped(core.get_aval(x)) for x in args_flat]
     fwd_jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(flat_fwd, in_avals)
@@ -1496,6 +1497,12 @@ def optimize_remat_of_custom_vjp_fwd(
     return tree_unflatten(out_tree, (*out_flat, *res))
 
   return wrapped_fwd
+
+@lu.transformation
+def _fix_fwd_args(*args):
+  args = [(x, True) for x in args]
+  args = [x for pair in args for x in pair]
+  yield (yield args, {})
 
 def _remat_opt_impl(
     *args,


### PR DESCRIPTION
This was a silly bug in how we were handling the fact that the `fwd` function expects `bool` entries for symbolic zeros. At least now I've added a test!