### PR TITLE
[array api] fix deprecation to support old import pattern

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -141,7 +141,7 @@ jobs:
         PY_COLORS: 1
       run: |
         pytest -n auto --tb=short --doctest-glob='*.md' --doctest-glob='*.rst' docs --doctest-continue-on-failure --ignore=docs/multi_process.md --ignore=docs/jax.experimental.array_api.rst
-        pytest -n auto --tb=short --doctest-modules jax --ignore=jax/config.py --ignore=jax/experimental/jax2tf --ignore=jax/_src/lib/mlir --ignore=jax/_src/lib/triton.py --ignore=jax/_src/lib/mosaic_gpu.py --ignore=jax/interpreters/mlir.py --ignore=jax/experimental/array_serialization --ignore=jax/collect_profile.py --ignore=jax/_src/tpu_custom_call.py --ignore=jax/experimental/mosaic --ignore=jax/experimental/pallas --ignore=jax/_src/pallas --ignore=jax/experimental/maps.py
+        pytest -n auto --tb=short --doctest-modules jax --ignore=jax/config.py --ignore=jax/experimental/jax2tf --ignore=jax/_src/lib/mlir --ignore=jax/_src/lib/triton.py --ignore=jax/_src/lib/mosaic_gpu.py --ignore=jax/interpreters/mlir.py --ignore=jax/experimental/array_serialization --ignore=jax/collect_profile.py --ignore=jax/_src/tpu_custom_call.py --ignore=jax/experimental/mosaic --ignore=jax/experimental/pallas --ignore=jax/_src/pallas --ignore=jax/experimental/array_api
 
 
   documentation_render:

--- a/jax/BUILD
+++ b/jax/BUILD
@@ -987,9 +987,13 @@ pytype_library(
 
 pytype_library(
     name = "experimental_array_api",
+    srcs = glob(
+        [
+            "experimental/array_api/*.py",
+        ],
+    ),
     visibility = [":internal"] + jax_visibility("array_api"),
     deps = [
-        ":experimental",
         ":jax",
     ],
 )

--- a/jax/experimental/array_api/__init__.py
+++ b/jax/experimental/array_api/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The JAX Authors.
+# Copyright 2024 The JAX Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,13 +15,18 @@
 # Note: import <name> as <name> is required for names to be exported.
 # See PEP 484 & https://github.com/google/jax/issues/7570
 
-from jax.experimental.x64_context import (
-  enable_x64 as enable_x64,
-  disable_x64 as disable_x64,
+import sys as _sys
+import warnings as _warnings
+
+import jax.numpy as _array_api
+
+# Added 2024-08-01
+_warnings.warn(
+    "jax.experimental.array_api import is no longer required as of JAX v0.4.32; "
+    "jax.numpy supports the array API by default.",
+    DeprecationWarning, stacklevel=2
 )
-from jax._src.callback import (
-  io_callback as io_callback
-)
-from jax._src.earray import (
-    EArray as EArray
-)
+
+_sys.modules['jax.experimental.array_api'] = _array_api
+
+del _array_api, _sys, _warnings

--- a/tests/array_api_test.py
+++ b/tests/array_api_test.py
@@ -249,8 +249,8 @@ class ArrayAPISmokeTest(absltest.TestCase):
   def test_deprecated_import(self):
     msg = "jax.experimental.array_api import is no longer required"
     with self.assertWarnsRegex(DeprecationWarning, msg):
-      from jax.experimental import array_api
-    self.assertIs(array_api, ARRAY_API_NAMESPACE)
+      import jax.experimental.array_api as nx
+    self.assertIs(nx, ARRAY_API_NAMESPACE)
 
 
 class ArrayAPIInspectionUtilsTest(jtu.JaxTestCase):


### PR DESCRIPTION
Followup to #22818

The previous approach made it so that a common import pattern didn't work:
```python
>>> import jax.experimental.array_api as nx
ModuleNotFoundError: No module named 'jax.experimental.array_api'
```
We need to keep a stub submodule here, but patch `sys.modules` to return the new path. With this change, it looks like this:
```python
In [1]: import jax.experimental.array_api as nx
<ipython-input-1-9d2abc00e9fa>:1: DeprecationWarning: jax.experimental.array_api import is no longer required as of JAX v0.4.32; jax.numpy supports the array API by default.
  import jax.experimental.array_api as nx

In [2]: import jax.numpy as jnp

In [3]: nx is jnp
Out[3]: True
```