### PR TITLE
remove jax.extend.backend.default_backend in favor of jax.default_backend

### DIFF
--- a/jax/extend/backend.py
+++ b/jax/extend/backend.py
@@ -21,7 +21,6 @@ from jax._src.api import (
 from jax._src.xla_bridge import (
   backends as backends,
   backend_xla_version as backend_xla_version,
-  default_backend as default_backend,
   get_backend as get_backend,
   register_backend_factory as register_backend_factory,
 )

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -35,7 +35,7 @@ _deprecations = {
     _deprecated_get_backend
   ),
   "default_backend": (
-    "jax.lib.xla_bridge.default_backend is deprecated; use jax.extend.backend.default_backend.",
+    "jax.lib.xla_bridge.default_backend is deprecated; use jax.default_backend.",
     _deprecated_default_backend
   ),
 }

--- a/tests/extend_test.py
+++ b/tests/extend_test.py
@@ -50,7 +50,6 @@ class ExtendTest(jtu.JaxTestCase):
     # Assume these are tested elsewhere, only check equivalence
     self.assertIs(jex.backend.backends, xla_bridge.backends)
     self.assertIs(jex.backend.backend_xla_version, xla_bridge.backend_xla_version)
-    self.assertIs(jex.backend.default_backend, xla_bridge.default_backend)
     self.assertIs(jex.backend.clear_backends, api.clear_backends)
     self.assertIs(jex.backend.get_backend, xla_bridge.get_backend)
     self.assertIs(jex.backend.register_backend_factory, xla_bridge.register_backend_factory)


### PR DESCRIPTION
I added this two days ago before realizing there is already a canonical API for this in the top-level namespace, so it should be safe to remove from `jax.extend`.