### PR TITLE
Tighten the public API for jax.lib.xla_client & xla_extension

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -141,7 +141,7 @@ jobs:
         PY_COLORS: 1
       run: |
         pytest -n auto --tb=short --doctest-glob='*.md' --doctest-glob='*.rst' docs --doctest-continue-on-failure --ignore=docs/multi_process.md --ignore=docs/jax.experimental.array_api.rst
-        pytest -n auto --tb=short --doctest-modules jax --ignore=jax/config.py --ignore=jax/experimental/jax2tf --ignore=jax/_src/lib/mlir --ignore=jax/_src/lib/triton.py --ignore=jax/_src/lib/mosaic_gpu.py --ignore=jax/interpreters/mlir.py --ignore=jax/experimental/array_serialization --ignore=jax/collect_profile.py --ignore=jax/_src/tpu_custom_call.py --ignore=jax/experimental/mosaic --ignore=jax/experimental/pallas --ignore=jax/_src/pallas --ignore=jax/experimental/array_api
+        pytest -n auto --tb=short --doctest-modules jax --ignore=jax/config.py --ignore=jax/experimental/jax2tf --ignore=jax/_src/lib/mlir --ignore=jax/_src/lib/triton.py --ignore=jax/_src/lib/mosaic_gpu.py --ignore=jax/interpreters/mlir.py --ignore=jax/experimental/array_serialization --ignore=jax/collect_profile.py --ignore=jax/_src/tpu_custom_call.py --ignore=jax/experimental/mosaic --ignore=jax/experimental/pallas --ignore=jax/_src/pallas --ignore=jax/experimental/array_api --ignore=jax/lib/xla_extension.py
 
 
   documentation_render:

--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -15,7 +15,9 @@
 # ruff: noqa: F401
 from jax._src.lib import (
   version_str as __version__,
+)
+from jax.lib import (
+  xla_bridge as xla_bridge,
   xla_client as xla_client,
   xla_extension as xla_extension,
 )
-from jax.lib import xla_bridge as xla_bridge

--- a/jax/lib/xla_client.py
+++ b/jax/lib/xla_client.py
@@ -1,0 +1,45 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from jax._src.lib import xla_client as _xc
+
+_xla = _xc._xla  # TODO(jakevdp): deprecate this in favor of jax.lib.xla_extension
+bfloat16 = _xc.bfloat16  # TODO(jakevdp): deprecate this in favor of ml_dtypes.bfloat16
+
+dtype_to_etype = _xc.dtype_to_etype
+execute_with_python_values = _xc.execute_with_python_values
+get_topology_for_devices = _xc.get_topology_for_devices
+heap_profile = _xc.heap_profile
+mlir_api_version = _xc.mlir_api_version
+ops = _xc.ops
+register_custom_call_target = _xc.register_custom_call_target
+shape_from_pyval = _xc.shape_from_pyval
+ArrayImpl = _xc.ArrayImpl
+Client = _xc.Client
+CompileOptions = _xc.CompileOptions
+Device = _xc.Device
+DeviceAssignment = _xc.DeviceAssignment
+FftType = _xc.FftType
+Frame = _xc.Frame
+HloSharding = _xc.HloSharding
+OpSharding = _xc.OpSharding
+PaddingType = _xc.PaddingType
+PrimitiveType = _xc.PrimitiveType
+Shape = _xc.Shape
+Traceback = _xc.Traceback
+XlaBuilder = _xc.XlaBuilder
+XlaComputation = _xc.XlaComputation
+XlaRuntimeError = _xc.XlaRuntimeError
+
+del _xc

--- a/jax/lib/xla_extension.py
+++ b/jax/lib/xla_extension.py
@@ -1,0 +1,37 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from jax._src.lib import xla_extension as _xe
+
+get_distributed_runtime_client = _xe.get_distributed_runtime_client
+get_distributed_runtime_service = _xe.get_distributed_runtime_service
+hlo_module_cost_analysis = _xe.hlo_module_cost_analysis
+hlo_module_to_dot_graph = _xe.hlo_module_to_dot_graph
+ifrt_proxy = _xe.ifrt_proxy
+jax_jit = _xe.jax_jit
+mlir = _xe.mlir
+pmap_lib = _xe.pmap_lib
+profiler = _xe.profiler
+pytree = _xe.pytree
+ArrayImpl = _xe.ArrayImpl
+Device = _xe.Device
+DistributedRuntimeClient = _xe.DistributedRuntimeClient
+HloPrintOptions = _xe.HloPrintOptions
+OpSharding = _xe.OpSharding
+PjitFunctionCache = _xe.PjitFunctionCache
+PjitFunction = _xe.PjitFunction
+PmapFunction = _xe.PmapFunction
+XlaRuntimeError = _xe.XlaRuntimeError
+
+del _xe


### PR DESCRIPTION
Currently `jax.lib.xla_client` and `jax.lib.xla_extension` expose everything in the source namespace: this makes it difficult to maintain these sources, because any change to the namespace may break downstream projects. There are also a number of duplicated symbols in these namespaces, which can be confusing for downstream users.

Note that `jax.lib` is not technically covered by the [API compatibility](https://jax.readthedocs.io/en/latest/api_compatibility.html) guarantees, so we can tighten this namespace without a deprecation cycle.

I chose which symbols to include here based on a search of downstream uses. My plan is to run some further tests, and make sure we include all symbols that are currently used by downstream projects: once this is in, we can begin to deprecate symbols that we don't want downstream users to depend on (for example, change users of `jax.lib.xla_client._xla` to using `jax.lib.xla_extension` directly)