### PR TITLE
[ROCM] Fix hipsolverSsyevd tests due to align with the rocm behavior.

### DIFF
--- a/jaxlib/gpu_solver.py
+++ b/jaxlib/gpu_solver.py
@@ -320,7 +320,10 @@ def _syevd_hlo(platform, gpu_solver, have_jacobi_solver, dtype, a, *,
     kernel = f"{platform}solver_syevd"
     lwork, opaque = gpu_solver.build_syevd_descriptor(
         np.dtype(dtype), lower, batch_int, n)
-    assert lwork > 0
+    # TODO(Ruturaj4): Currently, hipsolverSsyevd sets lwork to 0 if n==0.
+    # Remove if this behavior changes in then new ROCm release.
+    if n > 0 or platform != "hip":
+      assert lwork > 0
 
   if ir.ComplexType.isinstance(a_type.element_type):
     eigvals_type = ir.ComplexType(a_type.element_type).element_type


### PR DESCRIPTION
We get some tests failures on ROCm side due this small issue. I observe that the value returned by hipsolverSsyevd function is always 0, while in case of cuda it is 32929, i.e. greater than zero for n == 0.

possible reasoning of this discrepancy:
CUDA might be ensuring that a minimum amount of workspace is available to handle edge cases or initialization overhead, which is why it returns a default positive value for lwork even when the actual computation doesn't require it. And ROCm may be optimizing resources.