### PR TITLE
Improve error message for missing vmap rule in custom_vmap

### DIFF
--- a/jax/_src/custom_batching.py
+++ b/jax/_src/custom_batching.py
@@ -65,6 +65,11 @@ class custom_vmap:
   @traceback_util.api_boundary
   def __call__(self, *args, **kwargs):
     assert not kwargs
+    fun_name = getattr(self.fun, "__name__", str(self.fun))
+    if not self.vmap_rule:
+      raise AttributeError(
+          f"No batching rule defined for custom_vmap function {fun_name} "
+          "using def_vmap.")
     args_flat, in_tree = tree_flatten(args)
     flat_fun, out_tree = flatten_fun_nokwargs(lu.wrap_init(self.fun), in_tree)
     in_avals = [core.raise_to_shaped(core.get_aval(x)) for x in args_flat]

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -10780,7 +10780,6 @@ class CustomVmapTest(jtu.JaxTestCase):
     )
     self.assertAllClose(outputs['b'], expected)
 
-
   def test_batch_divides_axis(self):
     def f(t):
       x, a = t
@@ -10797,6 +10796,15 @@ class CustomVmapTest(jtu.JaxTestCase):
     y = g(x, a)
 
     self.assertAllClose(y, (x + a)**2)
+
+  def test_undefined_rule(self):
+    @jax.custom_batching.custom_vmap
+    def f(x): return jnp.sin(x)
+
+    with self.assertRaisesRegex(
+        AttributeError, "No batching rule defined for custom_vmap function f"):
+      f(0.5)
+
 
 class CustomApiTest(jtu.JaxTestCase):
   """Test interactions among the custom_{vmap,jvp,vjp,transpose,*} APIs"""


### PR DESCRIPTION
This is a partial re-land of https://github.com/google/jax/pull/22869 after it was rolled back to fix internal users. This part of the change didn't cause the issues, and I'll follow up with the rest of the changes in a second PR.