### PR TITLE
docs: tidy up titles and headings

### DIFF
--- a/docs/advanced_guide.rst
+++ b/docs/advanced_guide.rst
@@ -1,8 +1,11 @@
 .. _advanced_guide:
 
-Advanced tutorials
-==================
-This section contains examples and tutorials on more advanced topics, such as Multi Core computation, Custom operations, and more in depth applications
+Advanced guides
+===============
+
+This section contains examples and tutorials on more advanced topics,
+such as multi-core computation, custom operations, and more in-depth
+applications.
 
 .. toctree::
    :caption: Examples

--- a/docs/debugging/index.md
+++ b/docs/debugging/index.md
@@ -1,4 +1,4 @@
-# Runtime value debugging in JAX
+# Debugging runtime values
 
 <!--* freshness: { reviewed: '2024-04-11' } *-->
 

--- a/docs/device_memory_profiling.md
+++ b/docs/device_memory_profiling.md
@@ -1,4 +1,4 @@
-# Device memory profiling
+# Profiling device memory
 
 <!--* freshness: { reviewed: '2024-03-08' } *-->
 

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -1,7 +1,8 @@
 .. _jax-errors:
 
-JAX Errors
-==========
+Errors
+======
+
 This page lists a few of the errors you might encounter when using JAX,
 along with representative examples of how one might fix them.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,5 +1,5 @@
-JAX frequently asked questions (FAQ)
-====================================
+Frequently asked questions (FAQ)
+================================
 
 .. comment RST primer for Sphinx: https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html
 .. comment Some links referenced here. Use `JAX - The Sharp Bits`_ (underscore at the end) to reference

--- a/docs/ffi.ipynb
+++ b/docs/ffi.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# JAX's foreign function interface\n",
+    "# Foreign function interface (FFI)\n",
     "\n",
     "_This tutorial requires JAX v0.4.31 or newer._\n",
     "\n",

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -12,7 +12,7 @@ kernelspec:
   name: python3
 ---
 
-# JAX's foreign function interface
+# Foreign function interface (FFI)
 
 _This tutorial requires JAX v0.4.31 or newer._
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1,5 +1,5 @@
-JAX glossary of terms
-=====================
+Glossary of terms
+=================
 
 .. glossary::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-JAX: High-Performance Array Computing
+JAX: High performance array computing
 =====================================
 
 JAX is a Python library for accelerator-oriented array computation and program transformation,
@@ -75,7 +75,7 @@ For an end-to-end transformer library built on JAX, see MaxText_.
 .. toctree::
    :hidden:
    :maxdepth: 2
-   :caption: Further resources
+   :caption: Resources
 
    user_guides
    advanced_guide

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,5 @@
 (installation)=
-# Installing JAX
+# Installation
 
 <!--* freshness: { reviewed: '2024-06-18' } *-->
 

--- a/docs/key-concepts.md
+++ b/docs/key-concepts.md
@@ -13,7 +13,7 @@ kernelspec:
 ---
 
 (key-concepts)=
-# Key Concepts
+# Key concepts
 
 <!--* freshness: { reviewed: '2024-05-03' } *-->
 

--- a/docs/notebooks/external_callbacks.ipynb
+++ b/docs/notebooks/external_callbacks.ipynb
@@ -6,7 +6,7 @@
     "id": "7XNMxdTwURqI"
    },
    "source": [
-    "# External callbacks in JAX\n",
+    "# External callbacks\n",
     "\n",
     "<!--* freshness: { reviewed: '2024-04-08' } *-->"
    ]

--- a/docs/notebooks/external_callbacks.md
+++ b/docs/notebooks/external_callbacks.md
@@ -13,7 +13,7 @@ kernelspec:
 
 +++ {"id": "7XNMxdTwURqI"}
 
-# External callbacks in JAX
+# External callbacks
 
 <!--* freshness: { reviewed: '2024-04-08' } *-->
 

--- a/docs/notebooks/vmapped_log_probs.ipynb
+++ b/docs/notebooks/vmapped_log_probs.ipynb
@@ -6,7 +6,7 @@
     "id": "6umP1IKf4Dg6"
    },
    "source": [
-    "# Autobatching for Bayesian Inference\n",
+    "# Autobatching for Bayesian inference\n",
     "\n",
     "<!--* freshness: { reviewed: '2024-04-08' } *-->\n",
     "\n",

--- a/docs/notebooks/vmapped_log_probs.md
+++ b/docs/notebooks/vmapped_log_probs.md
@@ -14,7 +14,7 @@ kernelspec:
 
 +++ {"id": "6umP1IKf4Dg6"}
 
-# Autobatching for Bayesian Inference
+# Autobatching for Bayesian inference
 
 <!--* freshness: { reviewed: '2024-04-08' } *-->
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,4 +1,4 @@
-# Profiling JAX programs
+# Profiling computation
 
 <!--* freshness: { reviewed: '2024-03-18' } *-->
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -1,7 +1,7 @@
 .. _jax-tutorials:
 
-JAX tutorials
-=============
+Tutorials
+=========
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
This shortens some titles and makes them more consistent. It also removes "JAX" from several titles ("in JAX", "for JAX", "JAX's", etc.). Since these are the JAX docs, that ought to be clear from context.

In this and other changes, I'm aiming to make our docs easier to skim and navigate (even if sometimes in small steps).