### PR TITLE
Use PEP484-style exports in several submodules

### DIFF
--- a/jax/custom_batching.py
+++ b/jax/custom_batching.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 from jax._src.custom_batching import (
-  custom_vmap,
-  sequential_vmap,
+  custom_vmap as custom_vmap,
+  sequential_vmap as sequential_vmap,
 )

--- a/jax/custom_transpose.py
+++ b/jax/custom_transpose.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 from jax._src.custom_transpose import (
-  custom_transpose,
+  custom_transpose as custom_transpose,
 )

--- a/jax/distributed.py
+++ b/jax/distributed.py
@@ -12,4 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from jax._src.distributed import (initialize, shutdown)
+from jax._src.distributed import (
+   initialize as initialize,
+   shutdown as shutdown,
+)

--- a/jax/dlpack.py
+++ b/jax/dlpack.py
@@ -12,4 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from jax._src.dlpack import (to_dlpack, from_dlpack, SUPPORTED_DTYPES)
+from jax._src.dlpack import (
+  to_dlpack as to_dlpack,
+  from_dlpack as from_dlpack,
+  SUPPORTED_DTYPES as SUPPORTED_DTYPES,
+)


### PR DESCRIPTION
This ensures the names are considered public by some static analyzers.