### PR TITLE
Document methods of custom_jvp/custom_vjp

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -99,11 +99,28 @@ Automatic differentiation
     linearize
     linear_transpose
     vjp
-    custom_jvp
-    custom_vjp
     custom_gradient
     closure_convert
     checkpoint
+
+``custom_jvp``
+~~~~~~~~~~~~~~
+
+.. autosummary::
+  :toctree: _autosummary
+
+  custom_jvp
+  custom_jvp.defjvp
+  custom_jvp.defjvps
+
+``custom_vjp``
+~~~~~~~~~~~~~~
+
+.. autosummary::
+  :toctree: _autosummary
+
+  custom_vjp
+  custom_vjp.defvjp
 
 jax.Array (:code:`jax.Array`)
 -----------------------------


### PR DESCRIPTION
Replaces #22895

I think this is a better approach than using `autoclass`, since the URL for the generated docs does not change and the cross-references to the methods now work correctly.

Rendered preview (in particular, notice how the *methods* section in each case now has links to the appropriate docs):
- https://jax--23069.org.readthedocs.build/en/23069/_autosummary/jax.custom_jvp.html
- https://jax--23069.org.readthedocs.build/en/23069/_autosummary/jax.custom_vjp.html

I tackled this as a warmup for doing the same treatment to `jax.Array`