### PR TITLE
Added py::mod_gil_not_used() to PYBIND11_MODULE register_jax_dialects

### DIFF
--- a/jaxlib/mlir/_mlir_libs/register_jax_dialects.cc
+++ b/jaxlib/mlir/_mlir_libs/register_jax_dialects.cc
@@ -1,5 +1,6 @@
 // Registers MLIR dialects used by JAX.
 // This module is called by mlir/__init__.py during initialization.
+#include <pybind11/pybind11.h>
 
 #include "mlir-c/Dialect/Arith.h"
 #include "mlir-c/Dialect/Func.h"
@@ -14,11 +15,13 @@
 #include "mlir-c/Transforms.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 
+namespace py = pybind11;
+
 #define REGISTER_DIALECT(name) \
     MlirDialectHandle name##_dialect = mlirGetDialectHandle__##name##__(); \
     mlirDialectHandleInsertDialect(name##_dialect, registry)
 
-PYBIND11_MODULE(register_jax_dialects, m) {
+PYBIND11_MODULE(register_jax_dialects, m, py::mod_gil_not_used()) {
   m.doc() = "Registers upstream MLIR dialects used by JAX.";
 
   m.def("register_dialects", [](MlirDialectRegistry registry) {


### PR DESCRIPTION
Description:
- Added `py::mod_gil_not_used()` to `PYBIND11_MODULE` for `register_jax_dialects`.

Dialects are registered on `import jax` and on module import we can assume that there is a lock held during module initalization and can do thread-unsafe things there, all bets are off after module initialization finishes.

Refs:
- https://py-free-threading.github.io/porting/#__tabbed_1_2

Context: 
- https://github.com/google/jax/issues/23073