### PR TITLE
Added `PyUnstable_Module_SetGIL` to `PyInit_cpu_feature_guard`

### DIFF
--- a/jaxlib/cpu_feature_guard.c
+++ b/jaxlib/cpu_feature_guard.c
@@ -172,5 +172,12 @@ static struct PyModuleDef cpu_feature_guard_module = {
 #endif
 
 EXPORT_SYMBOL PyMODINIT_FUNC PyInit_cpu_feature_guard(void) {
-  return PyModule_Create(&cpu_feature_guard_module);
+  PyObject *module = PyModule_Create(&cpu_feature_guard_module);
+  if (module == NULL) {
+    return NULL;
+  }
+#ifdef Py_GIL_DISABLED
+  PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+  return module;
 }


### PR DESCRIPTION
**This PR is based on https://github.com/google/jax/pull/23129**

Description:
- Added `PyUnstable_Module_SetGIL` to `PyInit_cpu_feature_guard` to explicitly indicate the extension supports running with the GIL disabled.


Refs:
- https://py-free-threading.github.io/porting/#__tabbed_1_1

Context:
- https://github.com/google/jax/issues/23073
