### PR TITLE
Added `py::mod_gil_not_used()` to `PYBIND11_MODULE` for `_triton_ext` and `_tpu_ext`

### DIFF
--- a/jaxlib/mlir/_mlir_libs/tpu_ext.cc
+++ b/jaxlib/mlir/_mlir_libs/tpu_ext.cc
@@ -314,7 +314,7 @@ MlirContext getDefaultContext() {
 
 }  // namespace
 
-PYBIND11_MODULE(_tpu_ext, m) {
+PYBIND11_MODULE(_tpu_ext, m, py::mod_gil_not_used()) {
   mlirRegisterTPUPasses();  // Register all passes on load.
 
   py::class_<MlirTpuApplyVectorLayoutContext>(m, "ApplyVectorLayoutCtx",

--- a/jaxlib/mlir/_mlir_libs/triton_ext.cc
+++ b/jaxlib/mlir/_mlir_libs/triton_ext.cc
@@ -22,7 +22,7 @@ limitations under the License.
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(_triton_ext, m) {
+PYBIND11_MODULE(_triton_ext, m, py::mod_gil_not_used()) {
   //
   // Dialects.
   //


### PR DESCRIPTION
Description:
- Added `py::mod_gil_not_used()` to `PYBIND11_MODULE` for `_triton_ext` and `_tpu_ext`.
- follow-up to https://github.com/google/jax/pull/23129


Refs:
- https://py-free-threading.github.io/porting/#__tabbed_1_2

Context:
- https://github.com/google/jax/issues/23073