### PR TITLE
[ROCm] Rocm62 fixes

### DIFF
--- a/build/rocm/ci_build
+++ b/build/rocm/ci_build
@@ -34,7 +34,8 @@ def image_by_name(name):
 
 
 def dist_wheels(
-    rocm_version, python_versions, xla_path, rocm_build_job="", rocm_build_num=""
+    rocm_version, python_versions, xla_path, rocm_build_job="", rocm_build_num="",
+    compiler="gcc"
 ):
     if xla_path:
         xla_path = os.path.abspath(xla_path)
@@ -71,6 +72,8 @@ def dist_wheels(
         rocm_version,
         "--python-versions",
         pyver_string,
+        "--compiler",
+        compiler,
     ]
 
     if xla_path:
@@ -91,6 +94,9 @@ def dist_wheels(
         mounts.extend(["-v", "%s:%s" % (xla_path, container_xla_path)])
 
     cmd.extend(mounts)
+
+    if os.isatty(sys.stdout.fileno()):
+        cmd.append("-it")
 
     # NOTE(mrodden): bazel times out without --init, probably blocking on a zombie PID
     cmd.extend(
@@ -251,6 +257,12 @@ def parse_args():
         help="Path to XLA source to use during jaxlib build, instead of builtin XLA",
     )
 
+    p.add_argument(
+        "--compiler",
+        choices=["gcc", "clang"],
+        help="Compiler backend to use when compiling jax/jaxlib"
+    )
+
     subp = p.add_subparsers(dest="action", required=True)
 
     dwp = subp.add_parser("dist_wheels")
@@ -288,6 +300,7 @@ def main():
             args.xla_source_dir,
             args.rocm_build_job,
             args.rocm_build_num,
+            args.compiler,
         )
         dist_docker(
             args.rocm_version,

--- a/build/rocm/ci_build.sh
+++ b/build/rocm/ci_build.sh
@@ -50,6 +50,7 @@ ROCM_BUILD_JOB=""
 ROCM_BUILD_NUM=""
 BASE_DOCKER="ubuntu:20.04"
 CUSTOM_INSTALL=""
+JAX_USE_CLANG=""
 POSITIONAL_ARGS=()
 
 RUNTIME_FLAG=1
@@ -87,6 +88,10 @@ while [[ $# -gt 0 ]]; do
           ;;
         --rocm_build)
           ROCM_BUILD_NUM="$2"
+          shift 2
+          ;;
+        --use_clang)
+          JAX_USE_CLANG="$2"
           shift 2
           ;;
         *)
@@ -135,6 +140,12 @@ echo "Building (runtime) container (${DOCKER_IMG_NAME}) with Dockerfile($DOCKERF
 
 export XLA_CLONE_DIR="${XLA_CLONE_DIR:-}"
 
+# default to gcc
+JAX_COMPILER="gcc"
+if [ -n "$JAX_USE_CLANG" ]; then
+    JAX_COMPILER="clang"
+fi
+
 # ci_build.sh is mostly a compatibility wrapper for ci_build
 
 # 'dist_docker' will run 'dist_wheels' followed by a Docker build to create the "JAX image",
@@ -145,6 +156,7 @@ export XLA_CLONE_DIR="${XLA_CLONE_DIR:-}"
     --xla-source-dir=$XLA_CLONE_DIR \
     --rocm-build-job=$ROCM_BUILD_JOB \
     --rocm-build-num=$ROCM_BUILD_NUM \
+    --compiler=$JAX_COMPILER \
     dist_docker \
     --dockerfile $DOCKERFILE_PATH \
     --image-tag $DOCKER_IMG_NAME


### PR DESCRIPTION
1) Interactive causes bazel to output more useful info when running locally.
2) Work around quirk with rocm version when it ends with 0.
3) Ubu22 and higher have a package name conflict between the debian versions and the AMD provided versions.
4) Use env variable to set compiler type.