### PR TITLE
Fix argument names for jnp.arctan2/jnp.atan2

### DIFF
--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -252,8 +252,8 @@ def subtract(x: ArrayLike, y: ArrayLike, /) -> Array:
 
 @implements(np.arctan2, module='numpy')
 @partial(jit, inline=True)
-def arctan2(x: ArrayLike, y: ArrayLike, /) -> Array:
-  return lax.atan2(*promote_args_inexact("arctan2", x, y))
+def arctan2(x1: ArrayLike, x2: ArrayLike, /) -> Array:
+  return lax.atan2(*promote_args_inexact("arctan2", x1, x2))
 
 @implements(np.minimum, module='numpy')
 @partial(jit, inline=True)
@@ -357,9 +357,9 @@ def atanh(x: ArrayLike, /) -> Array:
   return arctanh(*promote_args('atanh', x))
 
 @partial(jit, inline=True)
-def atan2(x: ArrayLike, y: ArrayLike, /) -> Array:
+def atan2(x1: ArrayLike, x2: ArrayLike, /) -> Array:
   """Alias of :func:`jax.numpy.arctan2`"""
-  return arctan2(*promote_args('atan2', x, y))
+  return arctan2(*promote_args('atan2', x1, x2))
 
 @jit
 def bitwise_count(x: ArrayLike, /) -> Array:


### PR DESCRIPTION
Since these arguments are positional-only, this is not a breaking change for typical usage.

Fixes #23151