### PR TITLE
Register several jax.numpy argument name deprecations

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -180,11 +180,6 @@ from jax._src.array import Shard as Shard
 import jax.experimental.compilation_cache.compilation_cache as _ccache
 del _ccache
 
-from jax._src.deprecations import register as _register_deprecation
-_register_deprecation('jax-scipy-beta-args')
-_register_deprecation('tracer-hash')
-del _register_deprecation
-
 _deprecations = {
   # Added July 2022
   "treedef_is_leaf": (

--- a/jax/_src/deprecations.py
+++ b/jax/_src/deprecations.py
@@ -117,3 +117,16 @@ def warn(deprecation_id: str, message: str, stacklevel: int) -> None:
   else:
     warnings.warn(message, category=DeprecationWarning,
                   stacklevel=stacklevel + 1)
+
+
+# Register a number of deprecations: we do this here to ensure they're
+# always registered by the time `accelerate` and `is_acelerated` are called.
+register("jax-numpy-astype-complex-to-real")
+register("jax-numpy-array-none")
+register('jax-scipy-beta-args')
+register('tracer-hash')
+register('jax-numpy-reshape-newshape')
+register('jax-numpy-clip-args')
+register('jax-numpy-linalg-matrix_rank-tol')
+register('jax-numpy-linalg-pinv-rcond')
+register('jax-numpy-quantile-interpolation')

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1388,6 +1388,8 @@ def reshape(
       JAX does not support ``order="A"``.
     copy: unused by JAX; JAX always returns a copy, though under JIT the compiler
       may optimize such copies away.
+    newshape: deprecated alias of the ``shape`` argument. Will result in a
+      :class:`DeprecationWarning` if used.
 
   Returns:
     reshaped copy of input array with the specified shape.
@@ -1452,11 +1454,10 @@ def reshape(
         "jnp.reshape received both `shape` and `newshape` arguments. Note that "
         "using `newshape` is deprecated, please only use `shape` instead."
       )
-    warnings.warn(
-      "The newshape argument of jax.numpy.reshape is deprecated and setting it "
-      "will soon raise an error. To avoid an error in the future, and to "
-      "suppress this warning, please use the shape argument instead.",
-      DeprecationWarning, stacklevel=2)
+    deprecations.warn(
+      "jax-numpy-reshape-newshape",
+      ("The newshape argument of jax.numpy.reshape is deprecated. "
+       "Please use the shape argument instead."), stacklevel=2)
     shape = newshape
     del newshape
   elif shape is None:
@@ -2502,10 +2503,10 @@ def clip(
   min = a_min if not isinstance(a_min, DeprecatedArg) else min
   max = a_max if not isinstance(a_max, DeprecatedArg) else max
   if any(not isinstance(t, DeprecatedArg) for t in (a, a_min, a_max)):
-    warnings.warn(
-      "Passing arguments 'a', 'a_min' or 'a_max' to jax.numpy.clip is "
-      "deprecated. Please use 'arr', 'min' or 'max' respectively instead.",
-      DeprecationWarning,
+    deprecations.warn(
+      "jax-numpy-clip-args",
+      ("Passing arguments 'a', 'a_min' or 'a_max' to jax.numpy.clip is "
+       "deprecated. Please use 'arr', 'min' or 'max' respectively instead."),
       stacklevel=2,
     )
 
@@ -3479,8 +3480,6 @@ available in the JAX FAQ at :ref:`faq-data-placement` (full FAQ at
 https://jax.readthedocs.io/en/latest/faq.html).
 """
 
-deprecations.register("jax-numpy-array-none")
-
 
 def array(object: Any, dtype: DTypeLike | None = None, copy: bool = True,
           order: str | None = "K", ndmin: int = 0,
@@ -3669,8 +3668,6 @@ def _convert_to_array_if_dtype_fails(x: ArrayLike) -> ArrayLike:
   else:
     return x
 
-
-deprecations.register("jax-numpy-astype-complex-to-real")
 
 def astype(x: ArrayLike, dtype: DTypeLike | None,
            /, *, copy: bool = False,

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -28,6 +28,7 @@ import jax
 from jax import jit, custom_jvp
 from jax import lax
 
+from jax._src import deprecations
 from jax._src.lax import lax as lax_internal
 from jax._src.lax.lax import PrecisionLike
 from jax._src.lax import linalg as lax_linalg
@@ -408,6 +409,8 @@ def matrix_rank(
       smaller than `rtol * largest_singular_value` are considered to be zero. If
       ``rtol`` is None (the default), a reasonable default is chosen based the
       floating point precision of the input.
+    tol: deprecated alias of the ``rtol`` argument. Will result in a
+      :class:`DeprecationWarning` if used.
 
   Returns:
     array of shape ``a.shape[-2]`` giving the matrix rank.
@@ -433,11 +436,11 @@ def matrix_rank(
   if not isinstance(tol, DeprecatedArg):
     rtol = tol
     del tol
-    warnings.warn(
-      "The tol argument for linalg.matrix_rank is deprecated using it will soon raise "
-      "an error. To prepare for future releases, and suppress this warning, "
-      "please use rtol instead.",
-      DeprecationWarning, stacklevel=2
+    deprecations.warn(
+      "jax-numpy-linalg-matrix_rank-tol",
+      ("The tol argument for linalg.matrix_rank is deprecated. "
+       "Please use rtol instead."),
+      stacklevel=2
     )
   M, = promote_dtypes_inexact(jnp.asarray(M))
   if M.ndim < 2:
@@ -891,6 +894,8 @@ def pinv(a: ArrayLike, rtol: ArrayLike | None = None,
       determined based on the floating point precision of the dtype.
     hermitian: if True, then the input is assumed to be Hermitian, and a more
       efficient algorithm is used (default: False)
+    rcond: deprecated alias of the ``rtol`` argument. Will result in a
+      :class:`DeprecationWarning` if used.
 
   Returns:
     An array of shape ``(..., N, M)`` containing the pseudo-inverse of ``a``.
@@ -921,11 +926,11 @@ def pinv(a: ArrayLike, rtol: ArrayLike | None = None,
   if not isinstance(rcond, DeprecatedArg):
     rtol = rcond
     del rcond
-    warnings.warn(
-      "The rcond argument for linalg.pinv is deprecated using it will soon "
-      "raise an error. To prepare for future releases, and suppress this "
-      "warning, please use rtol instead.",
-      DeprecationWarning, stacklevel=2
+    deprecations.warn(
+      "jax-numpy-linalg-pinv-rcond",
+      ("The rcond argument for linalg.pinv is deprecated. "
+       "Please use rtol instead."),
+       stacklevel=2
     )
 
   return _pinv(a, rtol, hermitian)

--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -28,6 +28,7 @@ import jax
 from jax import lax
 from jax._src import api
 from jax._src import core
+from jax._src import deprecations
 from jax._src import dtypes
 from jax._src.numpy import ufuncs
 from jax._src.numpy.util import (
@@ -1893,8 +1894,10 @@ def quantile(a: ArrayLike, q: ArrayLike, axis: int | tuple[int, ...] | None = No
            "out != None")
     raise ValueError(msg)
   if not isinstance(interpolation, DeprecatedArg):
-    warnings.warn("The interpolation= argument to 'quantile' is deprecated. "
-                  "Use 'method=' instead.", DeprecationWarning, stacklevel=2)
+    deprecations.warn(
+      "jax-numpy-quantile-interpolation",
+      ("The interpolation= argument to 'quantile' is deprecated. "
+       "Use 'method=' instead."), stacklevel=2)
     method = interpolation
   return _quantile(lax_internal.asarray(a), lax_internal.asarray(q), axis, method, keepdims, False)
 
@@ -1910,8 +1913,10 @@ def nanquantile(a: ArrayLike, q: ArrayLike, axis: int | tuple[int, ...] | None =
            "out != None")
     raise ValueError(msg)
   if not isinstance(interpolation, DeprecatedArg):
-    warnings.warn("The interpolation= argument to 'nanquantile' is deprecated. "
-                  "Use 'method=' instead.", DeprecationWarning, stacklevel=2)
+    deprecations.warn(
+      "jax-numpy-quantile-interpolation",
+      ("The interpolation= argument to 'nanquantile' is deprecated. "
+       "Use 'method=' instead."), stacklevel=2)
     method = interpolation
   return _quantile(lax_internal.asarray(a), lax_internal.asarray(q), axis, method, keepdims, True)
 
@@ -2047,8 +2052,10 @@ def percentile(a: ArrayLike, q: ArrayLike,
   check_arraylike("percentile", a, q)
   q, = promote_dtypes_inexact(q)
   if not isinstance(interpolation, DeprecatedArg):
-    warnings.warn("The interpolation= argument to 'percentile' is deprecated. "
-                  "Use 'method=' instead.", DeprecationWarning, stacklevel=2)
+    deprecations.warn(
+      "jax-numpy-quantile-interpolation",
+      ("The interpolation= argument to 'percentile' is deprecated. "
+       "Use 'method=' instead."), stacklevel=2)
     method = interpolation
   return quantile(a, q / 100, axis=axis, out=out, overwrite_input=overwrite_input,
                   method=method, keepdims=keepdims)
@@ -2063,8 +2070,10 @@ def nanpercentile(a: ArrayLike, q: ArrayLike,
   check_arraylike("nanpercentile", a, q)
   q = ufuncs.true_divide(q, 100.0)
   if not isinstance(interpolation, DeprecatedArg):
-    warnings.warn("The interpolation= argument to 'nanpercentile' is deprecated. "
-                  "Use 'method=' instead.", DeprecationWarning, stacklevel=2)
+    deprecations.warn(
+      "jax-numpy-quantile-interpolation",
+      ("The interpolation= argument to 'nanpercentile' is deprecated. "
+       "Use 'method=' instead."), stacklevel=2)
     method = interpolation
   return nanquantile(a, q, axis=axis, out=out, overwrite_input=overwrite_input,
                      method=method, keepdims=keepdims)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -983,6 +983,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       with self.assertRaisesRegex(ValueError, msg):
         jnp.clip(x, max=jnp.array([-1+5j]))
 
+  def testClipDeprecatedArgs(self):
+    msg = "Passing arguments 'a', 'a_min' or 'a_max' to jax.numpy.clip is deprecated"
+    def assert_warns_or_errors(msg=msg):
+      if deprecations.is_accelerated("jax-numpy-clip-args"):
+        return self.assertRaisesRegex(ValueError, msg)
+      else:
+        return self.assertWarnsRegex(DeprecationWarning, msg)
+    with assert_warns_or_errors(msg):
+      jnp.clip(jnp.arange(4), a_min=2, a_max=3)
+
   def testHypotComplexInputError(self):
     rng = jtu.rand_default(self.rng())
     x = rng((5,), dtype=jnp.complex64)
@@ -3365,6 +3375,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(arg_shape, dtype)]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
+
+  def testReshapeDeprecatedArgs(self):
+    msg = "The newshape argument of jax.numpy.reshape is deprecated."
+    def assert_warns_or_errors(msg=msg):
+      if deprecations.is_accelerated("jax-numpy-reshape-newshape"):
+        return self.assertRaisesRegex(ValueError, msg)
+      else:
+        return self.assertWarnsRegex(DeprecationWarning, msg)
+    with assert_warns_or_errors(msg):
+      jnp.reshape(jnp.arange(4), newshape=(2, 2))
 
   @jtu.sample_product(
     [dict(arg_shape=arg_shape, out_shape=out_shape)

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -30,6 +30,7 @@ from jax import lax
 from jax import numpy as jnp
 from jax import scipy as jsp
 from jax._src import config
+from jax._src import deprecations
 from jax._src.lax import linalg as lax_linalg
 from jax._src import test_util as jtu
 from jax._src import xla_bridge
@@ -1155,6 +1156,17 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     # TODO(phawkins): 6e-2 seems like a very loose tolerance.
     jtu.check_grads(jnp_fn, args_maker(), 1, rtol=6e-2, atol=1e-3)
 
+  def testPinvDeprecatedArgs(self):
+    msg = "The rcond argument for linalg.pinv is deprecated."
+    def assert_warns_or_errors(msg=msg):
+      if deprecations.is_accelerated("jax-numpy-linalg-pinv-rcond"):
+        return self.assertRaisesRegex(ValueError, msg)
+      else:
+        return self.assertWarnsRegex(DeprecationWarning, msg)
+    x = jnp.ones((3, 3))
+    with assert_warns_or_errors(msg):
+      jnp.linalg.pinv(x, rcond=1E-2)
+
   def testPinvGradIssue2792(self):
     def f(p):
       a = jnp.array([[0., 0.],[-p, 1.]], jnp.float32) * 1 / (1 + p**2)
@@ -1196,6 +1208,17 @@ class NumpyLinalgTest(jtu.JaxTestCase):
                             args_maker, check_dtypes=False, tol=1e-3)
     self._CompileAndCheck(jnp.linalg.matrix_rank, args_maker,
                           check_dtypes=False, rtol=1e-3)
+
+  def testMatrixRankDeprecatedArgs(self):
+    msg = "The tol argument for linalg.matrix_rank is deprecated."
+    def assert_warns_or_errors(msg=msg):
+      if deprecations.is_accelerated("jax-numpy-linalg-matrix_rank-tol"):
+        return self.assertRaisesRegex(ValueError, msg)
+      else:
+        return self.assertWarnsRegex(DeprecationWarning, msg)
+    x = jnp.ones((3, 3))
+    with assert_warns_or_errors(msg):
+      jnp.linalg.matrix_rank(x, tol=1E-2)
 
   @jtu.sample_product(
     shapes=[


### PR DESCRIPTION
This should not change any user-visible behavior (aside from deprecation warning messages) and will set us up for finalizing these deprecations, since we're close to the end of the three-month window.