### PR TITLE
improve `scan` error message on non-concrete `unroll` argument

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -296,6 +296,10 @@ def scan(f: Callable[[Carry, X], tuple[Carry, Y]],
     raise NotImplementedError(
         f'Effects not supported in `scan`: {disallowed_effects}')
 
+  unroll = core.concrete_or_error(
+      None, unroll,
+      "The `unroll` argument to `scan` expects a concrete `int` or `bool` "
+      "value.")
   if isinstance(unroll, bool):
     unroll = max(length, 1) if unroll else 1
   if unroll < 1:

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2958,6 +2958,17 @@ class LaxControlFlowTest(jtu.JaxTestCase):
         "The `length` argument to `scan` expects a concrete `int` value.*"):
       f(3, 1.)
 
+  def test_scan_unroll_concrete_error(self):
+    f = jax.jit(lambda n, x: jax.lax.scan(
+        lambda c, z: (c, z), x, (), 10, unroll=n))
+
+    msg = ("The `unroll` argument to `scan` expects a concrete `int` or "
+           "`bool` value.*")
+    with self.assertRaisesRegex(core.ConcretizationTypeError, msg):
+      f(3, 1.)
+    with self.assertRaisesRegex(core.ConcretizationTypeError, msg):
+      f(True, 1.)
+
   def test_cond_vmap_forwarding_doesnt_promote(self):
     def f(x, y):
       x, y = jax.lax.cond(


### PR DESCRIPTION
Like #23228 but for the `unroll` argument.

Example:
```python
jax.jit(lambda n, x: jax.lax.scan(lambda c, z: (c, z), x, (), 10, unroll=n))(3, 1.)
```

Before:
```
jax.errors.TracerBoolConversionError: Attempted boolean conversion of traced array with shape bool[].
The error occurred while tracing the function <lambda> at test.py:9 for jit. This concrete value was not available in Python because it depends on the value of the argument n.
```

After:
```
jax.errors.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected: traced array with shape int32[]
The `unroll` argument to `scan` expects a concrete `int` or `bool` value.
The error occurred while tracing the function <lambda> at test.py:9 for jit. This concrete value was not available in Python because it depends on the value of the argument n.
```

Handles boolean values of `unroll` similarly.