### PR TITLE
jnp.mean: fix normalizer for large arrays

### DIFF
--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -766,7 +766,8 @@ def _mean(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
     else:
       normalizer = core.dimension_as_value(_axis_size(a, axis))
   else:
-    normalizer = sum(_broadcast_to(where, np.shape(a)), axis, dtype=dtype, keepdims=keepdims)
+    normalizer = sum(_broadcast_to(where, np.shape(a)), axis,
+                     dtype=computation_dtype, keepdims=keepdims)
 
   return lax.div(
       sum(a, axis, dtype=computation_dtype, keepdims=keepdims, where=where),


### PR DESCRIPTION
For large sharded arrays, it's currently possible for the mask sum to overflow int32, leading to strange outputs. Explicitly accumulating the sum using the computation dtype avoids this kind of overflow.

No unit tests here, because testing this would require more memory than is available in our test runners.