### PR TITLE
Switch to XLA_CLIENT_MEM_FRACTION instead of XLA_PYTHON_CLIENT_MEM_FRACTION.

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -837,7 +837,7 @@ This is especially likely when running multiple JAX instances, running JAX in
 tandem with TensorFlow which performs its own pre-allocation, or when running
 JAX on a system where the GPU is being heavily utilized by other processes. When
 in doubt, try running the program again with reduced pre-allocation, either by
-reducing :code:`XLA_PYTHON_CLIENT_MEM_FRACTION` from the default of :code:`.75`,
+reducing :code:`XLA_CLIENT_MEM_FRACTION` from the default of :code:`.75`,
 or setting :code:`XLA_PYTHON_CLIENT_PREALLOCATE=false`. For more details, please
 see the page on `JAX GPU memory allocation`_.
 

--- a/docs/gpu_memory_allocation.rst
+++ b/docs/gpu_memory_allocation.rst
@@ -14,7 +14,7 @@ override the default behavior:
   that uses most of the available GPU memory may OOM with preallocation
   disabled.
 
-``XLA_PYTHON_CLIENT_MEM_FRACTION=.XX``
+``XLA_CLIENT_MEM_FRACTION=.XX``
   If preallocation is enabled, this makes JAX preallocate XX% of
   the total GPU memory, instead of the default 75%. Lowering the
   amount preallocated can fix OOMs that occur when the JAX program starts.
@@ -31,7 +31,7 @@ Common causes of OOM failures
 -----------------------------
 
 **Running multiple JAX processes concurrently.**
-  Either use :code:`XLA_PYTHON_CLIENT_MEM_FRACTION` to give each process an
+  Either use :code:`XLA_CLIENT_MEM_FRACTION` to give each process an
   appropriate amount of memory, or set
   :code:`XLA_PYTHON_CLIENT_PREALLOCATE=false`.
 
@@ -44,7 +44,7 @@ Common causes of OOM failures
   TensorFlow from using the GPU with the command
   :code:`tf.config.experimental.set_visible_devices([], "GPU")`
 
-  Alternatively, use :code:`XLA_PYTHON_CLIENT_MEM_FRACTION` or
+  Alternatively, use :code:`XLA_CLIENT_MEM_FRACTION` or
   :code:`XLA_PYTHON_CLIENT_PREALLOCATE`. There are
   also similar options to configure TensorFlow's GPU memory allocation
   (`gpu_memory_fraction
@@ -58,5 +58,5 @@ Common causes of OOM failures
   for TF2).
 
 **Running JAX on the display GPU.**
-  Use :code:`XLA_PYTHON_CLIENT_MEM_FRACTION` or
+  Use :code:`XLA_CLIENT_MEM_FRACTION` or
   :code:`XLA_PYTHON_CLIENT_PREALLOCATE`.

--- a/tests/pallas/gpu_attention_test.py
+++ b/tests/pallas/gpu_attention_test.py
@@ -26,7 +26,7 @@ import jax.numpy as jnp
 import numpy as np
 
 
-os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+os.environ["XLA_CLIENT_MEM_FRACTION"] = "0.5"
 
 # pylint: disable=no-value-for-parameter
 

--- a/tests/pallas/gpu_ops_test.py
+++ b/tests/pallas/gpu_ops_test.py
@@ -16,7 +16,7 @@ import functools
 import os
 import sys
 
-os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+os.environ["XLA_CLIENT_MEM_FRACTION"] = "0.5"
 
 from absl.testing import absltest
 from absl.testing import parameterized

--- a/tests/pallas/pallas_jumble_test.py
+++ b/tests/pallas/pallas_jumble_test.py
@@ -15,7 +15,7 @@
 import os
 import sys
 
-os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+os.environ["XLA_CLIENT_MEM_FRACTION"] = "0.5"
 
 from absl.testing import absltest
 import jax

--- a/tests/pallas/pallas_shape_poly_test.py
+++ b/tests/pallas/pallas_shape_poly_test.py
@@ -19,7 +19,7 @@ import math
 import os
 import sys
 
-os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+os.environ["XLA_CLIENT_MEM_FRACTION"] = "0.5"
 
 from absl.testing import absltest
 from absl.testing import parameterized

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -20,7 +20,7 @@ import os
 import re
 import sys
 
-os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+os.environ["XLA_CLIENT_MEM_FRACTION"] = "0.5"
 
 from absl.testing import absltest
 from absl.testing import parameterized

--- a/tests/pallas/pallas_vmap_test.py
+++ b/tests/pallas/pallas_vmap_test.py
@@ -16,7 +16,7 @@ import functools
 import os
 import sys
 
-os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+os.environ["XLA_CLIENT_MEM_FRACTION"] = "0.5"
 
 from absl.testing import absltest
 import jax


### PR DESCRIPTION
The latter one is [deprecated](https://github.com/openxla/xla/commit/8ad80bd15bd3ce237f9e999234bbb3c7a1ff3653) in XLA.