### PR TITLE
Add citation for random.orthogonal.

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -2041,6 +2041,11 @@ def orthogonal(
 
   Returns:
     A random array of shape `(*shape, n, n)` and specified dtype.
+
+  References:
+    .. [1] Mezzadri, Francesco. (2007). "How to generate random matrices from
+           the classical compact groups". Notices of the American Mathematical
+           Society, 54(5), 592-604. https://arxiv.org/abs/math-ph/0609050.
   """
   shape = core.canonicalize_shape(shape)
   key, _ = _check_prng_key("orthogonal", key)


### PR DESCRIPTION
https://github.com/google/jax/pull/23207#discussion_r1731137697

Rendered preview: https://jax--23257.org.readthedocs.build/en/23257/_autosummary/jax.random.orthogonal.html