### PR TITLE
Fast jvp for 3x3 and 2x2 determinants

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -111,7 +111,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     self.assertAllClose(np.float32(0), jsp.linalg.det(x))
 
   @jtu.sample_product(
-    shape=[(1, 1), (3, 3), (2, 4, 4)],
+    shape=[(1, 1), (2, 2), (3, 3), (2, 2, 2), (2, 3, 3), (2, 4, 4), (5, 7, 7)],
     dtype=float_types,
   )
   @jtu.skip_on_flag("jax_skip_slow_tests", True)


### PR DESCRIPTION
Speed up jvp's for 3x3 and 2x2 determinants 

The current det implementation custom_jvp is all encompassing, so while there's specific functions for the 2 and 3d cases they still go via the generic jvp. PR localises the custom_jvp to the generic case.

This generic implementation is ~10x slower on GPU (A100) and ~250x slower on TPU (v2) than the 3d jvp of the specific implementations.

```python
import jax
from jax import numpy as jnp
from jax import random

def det_3x3(a: jax.Array) -> jax.Array:
  return (a[..., 0, 0] * a[..., 1, 1] * a[..., 2, 2] +
          a[..., 0, 1] * a[..., 1, 2] * a[..., 2, 0] +
          a[..., 0, 2] * a[..., 1, 0] * a[..., 2, 1] -
          a[..., 0, 2] * a[..., 1, 1] * a[..., 2, 0] -
          a[..., 0, 0] * a[..., 1, 2] * a[..., 2, 1] -
          a[..., 0, 1] * a[..., 1, 0] * a[..., 2, 2])

key = random.key(42)
x = random.normal(key, (int(1e5), 3, 3))

general_grad = jax.grad(lambda x: jnp.linalg.det(x).sum())
direct_3by3_grad = jax.vmap(jax.grad(det_3x3))
general_grad, direct_3by3_grad = (jax.jit(f) for f in (general_grad, direct_3by3_grad))

_ = jax.block_until_ready(general_grad(x))
_ = jax.block_until_ready(direct_3by3_grad(x))

%timeit _ = jax.block_until_ready(general_grad(x))
%timeit _ = jax.block_until_ready(direct_3by3_grad(x))
## A100 GPU
#100 loops, best of 5: 1.89 ms per loop
#10000 loops, best of 5: 199 µs per loop
## TPUv2
# 265ms -> 1.22ms