### PR TITLE
Typo in documentation

### DIFF
--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -501,7 +501,7 @@ def slogdet(a: ArrayLike, *, method: str | None = None) -> SlogdetResult:
   """
   Compute the sign and (natural) logarithm of the determinant of an array.
 
-  JAX implementation of :func:`numpy.linalg.slotdet`.
+  JAX implementation of :func:`numpy.linalg.slogdet`.
 
   Args:
     a: array of shape ``(..., M, M)`` for which to compute the sign and log determinant.


### PR DESCRIPTION
Fixed typo in documentation of `slogdet`