### PR TITLE
refactor jax.lax to not depend on jax.numpy

### DIFF
--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -23,7 +23,6 @@ import itertools
 import operator
 from typing import Any, TypeVar
 
-import jax
 from jax.tree_util import tree_flatten, tree_unflatten
 from jax._src import ad_util
 from jax._src import config
@@ -275,12 +274,8 @@ def _cond(pred, true_fun: Callable, false_fun: Callable, *operands,
   num_consts = len(consts)
   out_ = iter(out)
 
-  def _cast_to_array(x):
-    _copy = isinstance(x, np.bool_)
-    return jax.numpy.asarray(x, copy=_copy)
-
   out = [
-    next(out_) if fwd is None else _cast_to_array(ops[fwd - num_consts])
+    next(out_) if fwd is None else lax.asarray(ops[fwd - num_consts])
     for fwd in in_fwd
   ]
   assert next(out_, None) is None

--- a/jax/_src/lax/fft.py
+++ b/jax/_src/lax/fft.py
@@ -23,6 +23,7 @@ import numpy as np
 from jax import lax
 
 from jax._src import dispatch
+from jax._src import dtypes
 from jax._src.api import jit, linear_transpose, ShapeDtypeStruct
 from jax._src.core import Primitive, is_constant_shape
 from jax._src.interpreters import ad
@@ -30,7 +31,6 @@ from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
 from jax._src.lib.mlir.dialects import hlo
 from jax._src.lib import xla_client
-from jax._src.numpy.util import promote_dtypes_complex, promote_dtypes_inexact
 
 __all__ = [
   "fft",
@@ -61,9 +61,9 @@ def fft(x, fft_type: xla_client.FftType | str, fft_lengths: Sequence[int]):
   if typ == xla_client.FftType.RFFT:
     if np.iscomplexobj(x):
       raise ValueError("only real valued inputs supported for rfft")
-    x, = promote_dtypes_inexact(x)
+    x = lax.convert_element_type(x, dtypes.to_inexact_dtype(dtypes.dtype(x)))
   else:
-    x, = promote_dtypes_complex(x)
+    x = lax.convert_element_type(x, dtypes.to_complex_dtype(dtypes.dtype(x)))
   if len(fft_lengths) == 0:
     # XLA FFT doesn't support 0-rank.
     return x

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -22,14 +22,15 @@ from typing import Any, Literal, TypeVar, overload
 
 import numpy as np
 
-import jax
 from jax import lax
 
 from jax._src import ad_util
 from jax._src import api
+from jax._src import config
 from jax._src import core
 from jax._src import dispatch
 from jax._src import dtypes
+from jax._src import util
 from jax._src.core import (
     Primitive, ShapedArray, raise_to_shaped, is_constant_dim, is_constant_shape)
 from jax._src.extend import ffi
@@ -48,19 +49,42 @@ from jax._src.lib import gpu_solver
 from jax._src.lib import gpu_sparse
 from jax._src.lib import lapack
 from jax._src.lib import version as jaxlib_version
-from jax._src.lib import xla_client
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import chlo
 from jax._src.lib.mlir.dialects import hlo
-from jax._src.numpy import lax_numpy as jnp
-from jax._src.numpy import reductions
-from jax._src.numpy import ufuncs
-from jax._src.numpy.vectorize import vectorize
 from jax._src.typing import Array, ArrayLike
 
-xops = xla_client.ops
 
 TFun = TypeVar('TFun', bound=Callable[..., Any])
+
+def _broadcasted_iotas(*sizes):
+  ones = (1,) * (len(sizes) - 1)
+  shapes = (util.tuple_insert(ones, i, s) for i, s in enumerate(sizes))
+  return [lax.broadcasted_iota('int32', shape, i) for i, shape in enumerate(shapes)]
+
+def _tril(m: Array, k:int = 0) -> Array:
+  *_, N, M = m.shape
+  mask = lax_internal._tri(bool, (N, M), k)
+  return lax.select(lax.broadcast(mask, m.shape[:-2]), m, lax.zeros_like_array(m))
+
+def _triu(m: Array, k:int = 0) -> Array:
+  *_, N, M = m.shape
+  mask = lax_internal._tri(bool, (N, M), k - 1)
+  return lax.select(lax.broadcast(mask, m.shape[:-2]), lax.zeros_like_array(m), m)
+
+def _construct_diagonal(s: Array) -> Array:
+  """Construct a (batched) diagonal matrix"""
+  i = lax.iota('int32', s.shape[-1])
+  return lax.full((*s.shape, s.shape[-1]), 0, s.dtype).at[..., i, i].set(s)
+
+def _extract_diagonal(s: Array) -> Array:
+  """Extract the diagonal from a batched matrix"""
+  i = lax.iota('int32', min(s.shape[-2], s.shape[-1]))
+  return s[..., i, i]
+
+def _broadcast_to(x: Array, shape: tuple[int, ...]) -> Array:
+  assert x.ndim <= len(shape)
+  return lax.broadcast_in_dim(x, shape, range(len(shape) - x.ndim, len(shape)))
 
 # traceables
 
@@ -91,7 +115,7 @@ def cholesky(x: Array, *, symmetrize_input: bool = True) -> Array:
   """
   if symmetrize_input:
     x = symmetrize(x)
-  return jnp.tril(cholesky_p.bind(x))
+  return _tril(cholesky_p.bind(x))
 
 
 def eig(x: ArrayLike, *, compute_left_eigenvectors: bool = True,
@@ -368,10 +392,10 @@ def triangular_solve(a: ArrayLike, b: ArrayLike, *,
   Returns:
     A batch of matrices the same shape and dtype as ``b``.
   """
-  conjugate_a = conjugate_a and jnp.issubdtype(lax.dtype(a), jnp.complexfloating)
-  singleton = jnp.ndim(b) == jnp.ndim(a) - 1
+  conjugate_a = conjugate_a and dtypes.issubdtype(lax.dtype(a), np.complexfloating)
+  singleton = np.ndim(b) == np.ndim(a) - 1
   if singleton:
-    b = jnp.expand_dims(b, -1 if left_side else -2)
+    b = lax.expand_dims(b, (-1 if left_side else -2,))
   out = triangular_solve_p.bind(
       a, b, left_side=left_side, lower=lower, transpose_a=transpose_a,
       conjugate_a=conjugate_a, unit_diagonal=unit_diagonal)
@@ -381,9 +405,17 @@ def triangular_solve(a: ArrayLike, b: ArrayLike, *,
 
 
 # utilities
-@partial(vectorize, signature='(n,m),(m)->(n)')
-def _matvec_multiply(a: Array, b: Array) -> Array:
-  return lax.dot(a, b, precision=lax.Precision.HIGHEST)
+def _broadcasted_matvec(a: Array, b: Array) -> Array:
+  # This is a broadcasted dot_general with signature (...,n,m),(...,m)->(...,n)
+  assert a.ndim >= 2
+  assert b.ndim >= 1
+  batch_shape = lax.broadcast_shapes(a.shape[:-2], b.shape[:-1])
+  n_batch = len(batch_shape)
+  a = _broadcast_to(a, (*batch_shape, *a.shape[-2:]))
+  b = _broadcast_to(b, (*batch_shape, b.shape[-1]))
+
+  dimension_numbers = (([a.ndim - 1], [b.ndim - 1]), (list(range(n_batch)), list(range(n_batch))))
+  return lax.dot_general(a, b, dimension_numbers=dimension_numbers, precision=lax.Precision.HIGHEST)
 
 def _check_solve_shapes(a: Array, b: Array):
   if not (a.ndim >= 2 and b.ndim in [a.ndim, a.ndim - 1] and
@@ -399,14 +431,14 @@ def _solve(a: Array, b: Array) -> Array:
   # custom_linear_solve.
   out_shape = tuple(d_a if d_b == 1 else d_b
                     for d_a, d_b in zip(a.shape[:-1] + (1,), b.shape))
-  b = jnp.broadcast_to(b, out_shape)
+  b = lax.broadcast_in_dim(b, out_shape, range(b.ndim))
 
   # With custom_linear_solve, we can reuse the same factorization when
   # computing sensitivities. This is considerably faster.
   lu_, _, permutation = lu(lax.stop_gradient(a))
   custom_solve = partial(
       lax.custom_linear_solve,
-      lambda x: _matvec_multiply(a, x),
+      lambda x: _broadcasted_matvec(a, x),
       solve=lambda _, x: lu_solve(lu_, permutation, x, trans=0),
       transpose_solve=lambda _, x: lu_solve(lu_, permutation, x, trans=1))
   if a.ndim == b.ndim + 1:
@@ -416,8 +448,10 @@ def _solve(a: Array, b: Array) -> Array:
     # b.shape == [..., m, k]
     return api.vmap(custom_solve, b.ndim - 1, max(a.ndim, b.ndim) - 1)(b)
 
-def _T(x: Array) -> Array: return jnp.swapaxes(x, -1, -2)
-def _H(x: Array) -> Array: return ufuncs.conj(_T(x))
+def _T(x: Array) -> Array:
+  return lax.transpose(x, (*range(x.ndim - 2), x.ndim - 1, x.ndim - 2))
+def _H(x: Array) -> Array:
+  return _T(x).conj()
 def symmetrize(x: Array) -> Array: return (x + _H(x)) / 2
 
 # primitives
@@ -430,13 +464,13 @@ _cpu_lapack_types = {np.dtype(np.float32), np.dtype(np.float64),
 def _cholesky_jvp_rule(primals, tangents):
   x, = primals
   sigma_dot, = tangents
-  L = jnp.tril(cholesky_p.bind(x))
+  L = _tril(cholesky_p.bind(x))
 
   # Forward-mode rule from https://arxiv.org/pdf/1602.07527.pdf
   def phi(X):
-    l = jnp.tril(X)
+    l = _tril(X)
     return l / lax.expand_dims(
-        lax_internal._const(X, 1) + jnp.eye(X.shape[-1], dtype=X.dtype),
+        lax_internal._const(X, 1) + lax_internal._eye(X.dtype, (X.shape[-1], X.shape[-1])),
         range(l.ndim - 2))
 
   tmp = triangular_solve(L, sigma_dot, left_side=False, transpose_a=True,
@@ -532,22 +566,22 @@ def _cholesky_update_jax_fn(R, z):
   def _drotg(x, y):
     """Get coefs for Givens rotation in a numerically stable way."""
     def _drotg_nonzero(x, y):
-      abs_x = jax.numpy.abs(x)
-      abs_y = jax.numpy.abs(y)
-      denominator = jnp.where(abs_x > abs_y, abs_x, abs_y)
+      abs_x = abs(x)
+      abs_y = abs(y)
+      denominator = lax.select(abs_x > abs_y, abs_x, abs_y)
       x /= denominator
       y /= denominator
-      rh = 1 / jax.numpy.sqrt(x ** 2 + y ** 2)
+      rh = 1 / lax.sqrt(x ** 2 + y ** 2)
       return x * rh, -y * rh
     one_and_zero = (
-        jnp.array(1., dtype=x.dtype),
-        jnp.array(0., dtype=x.dtype),
+        np.array(1., dtype=x.dtype),
+        np.array(0., dtype=x.dtype),
     )
-    return jax.lax.cond(y == 0, lambda x, y: one_and_zero, _drotg_nonzero, x, y)
+    return lax.cond(y == 0, lambda x, y: one_and_zero, _drotg_nonzero, x, y)
 
   def _drot(
-      first_vector: jax.Array, second_vector: jax.Array,
-      c_coef: float, s_coef: float) -> tuple[jax.Array, jax.Array]:
+      first_vector: Array, second_vector: Array,
+      c_coef: float, s_coef: float) -> tuple[Array, Array]:
     return (
         c_coef * first_vector - s_coef * second_vector,
         c_coef * second_vector + s_coef * first_vector)
@@ -681,7 +715,7 @@ def eig_jvp_rule(primals, tangents, *, compute_left_eigenvectors,
   a, = primals
   da, = tangents
   l, v = eig(a, compute_left_eigenvectors=False)
-  return [l], [reductions.sum(_solve(v, da.astype(v.dtype)) * _T(v), -1)]
+  return [l], [(_solve(v, da.astype(v.dtype)) * _T(v)).sum(-1)]
 
 eig_p = Primitive('eig')
 eig_p.multiple_results = True
@@ -875,16 +909,17 @@ def _eigh_tpu_impl(x, *, lower, sort_eigenvalues, subset_by_index):
     # We should only look at elements from the lower/upper triangle. Reflects
     # that triangle into the other triangle to form a Hermitian matrix.
     if lower:
-      mask = jnp.tri(n, k=0, dtype=bool)
+      mask = lax_internal._tri(bool, (n, n), 0)
     else:
-      mask = ufuncs.logical_not(jnp.tri(n, k=-1, dtype=bool))
-    if dtypes.issubdtype(x.dtype, jnp.complexfloating):
+      mask = lax.bitwise_not(lax_internal._tri(bool, (n, n), -1))
+    if dtypes.issubdtype(x.dtype, np.complexfloating):
       re = lax.select(mask, lax.real(x), _T(lax.real(x)))
       if lower:
-        im_mask = jnp.tri(n, k=-1, dtype=bool)
+        im_mask = lax_internal._tri(bool, (n, n), -1)
       else:
-        im_mask = ufuncs.logical_not(jnp.tri(n, k=0, dtype=bool))
-      im = lax.select(im_mask, lax.imag(x), jnp.zeros_like(lax.imag(x)))
+        im_mask = lax.bitwise_not(lax_internal._tri(bool, (n, n), 0))
+      im = lax.imag(x)
+      im = lax.select(im_mask, im, lax.full_like(im, 0))
       im = lax.select(mask, im, -_T(im))
       x = lax.complex(re, im)
     else:
@@ -929,15 +964,15 @@ def _eigh_jvp_rule(
 
   # for complex numbers we need eigenvalues to be full dtype of v, a:
   w = w_real.astype(a.dtype)
-  eye_n = jnp.eye(n, dtype=a.dtype)
+  eye_n = lax_internal._eye(a.dtype, (n, n))
   # carefully build reciprocal delta-eigenvalue matrix, avoiding NaNs.
-  Fmat = ufuncs.reciprocal(eye_n + w[..., jnp.newaxis, :] - w[..., jnp.newaxis]) - eye_n
+  Fmat = lax.integer_pow(eye_n + w[..., np.newaxis, :] - w[..., np.newaxis], -1) - eye_n
   # eigh impl doesn't support batch dims, but future-proof the grad.
   dot = partial(lax.dot if a.ndim == 2 else lax.batch_matmul,
                 precision=lax.Precision.HIGHEST)
   vdag_adot_v = dot(dot(_H(v), a_dot), v)
-  dv = dot(v, ufuncs.multiply(Fmat, vdag_adot_v))
-  dw = ufuncs.real(jnp.diagonal(vdag_adot_v, axis1=-2, axis2=-1))
+  dv = dot(v, Fmat * vdag_adot_v)
+  dw = _extract_diagonal(vdag_adot_v.real)
   return (v, w_real), (dv, dw)
 
 
@@ -1011,10 +1046,10 @@ def _triangular_solve_jvp_rule_a(
     unit_diagonal):
   m, n = b.shape[-2:]
   k = 1 if unit_diagonal else 0
-  g_a = jnp.tril(g_a, k=-k) if lower else jnp.triu(g_a, k=k)
+  g_a = _tril(g_a, k=-k) if lower else _triu(g_a, k=k)
   g_a = lax.neg(g_a)
-  g_a = jnp.swapaxes(g_a, -1, -2) if transpose_a else g_a
-  g_a = ufuncs.conj(g_a) if conjugate_a else g_a
+  g_a = _T(g_a) if transpose_a else g_a
+  g_a = g_a.conj() if conjugate_a else g_a
   dot = partial(lax.dot if g_a.ndim == 2 else lax.batch_matmul,
                 precision=lax.Precision.HIGHEST)
 
@@ -1149,11 +1184,11 @@ def _lu_pivots_body_fn(i, permutation_and_swaps):
   permutation, swaps = permutation_and_swaps
   batch_dims = swaps.shape[:-1]
   j = swaps[..., i]
-  iotas = jnp.ix_(*(lax.iota(jnp.int32, b) for b in batch_dims))
+  iotas = _broadcasted_iotas(*batch_dims)
   x = permutation[..., i]
-  y = permutation[iotas + (j,)]
+  y = permutation[(*iotas, j)]
   permutation = permutation.at[..., i].set(y)
-  return permutation.at[iotas + (j,)].set(x), swaps
+  return permutation.at[(*iotas, j)].set(x), swaps
 
 
 def _generic_lu_pivots_to_permutation(swaps, permutation_size):
@@ -1173,7 +1208,7 @@ def _generic_lu_pivots_to_permutation(swaps, permutation_size):
   k = swaps.shape[-1]
   m = permutation_size
 
-  permutation = lax.broadcasted_iota(jnp.int32, batch_dims + (m,),
+  permutation = lax.broadcasted_iota(np.int32, batch_dims + (m,),
                                      len(batch_dims))
   if m == 0 or k == 0:
     return permutation
@@ -1250,30 +1285,32 @@ def _lu_unblocked(a):
   m, n = a.shape
   def body(k, state):
     pivot, perm, a = state
-    m_idx = jnp.arange(m)
-    n_idx = jnp.arange(n)
+    m_idx = lax.iota('int32', m)
+    n_idx = lax.iota('int32', n)
 
-    if jnp.issubdtype(a.dtype, jnp.complexfloating):
+    if dtypes.issubdtype(a.dtype, np.complexfloating):
       t = a[:, k]
-      magnitude = ufuncs.abs(ufuncs.real(t)) + ufuncs.abs(ufuncs.imag(t))
+      magnitude = abs(t.real) + abs(t.imag)
     else:
-      magnitude = ufuncs.abs(a[:, k])
-    i = jnp.argmax(jnp.where(m_idx >= k, magnitude, -jnp.inf))
-    pivot = pivot.at[k].set(i.astype(pivot.dtype))
+      magnitude = abs(a[:, k])
+    i = lax.argmax(lax.select(m_idx >= k, magnitude, lax.full_like(magnitude, -np.inf)),
+                   axis=0, index_dtype=pivot.dtype)
+    pivot = pivot.at[k].set(i)
     a = a.at[[k, i],].set(a[[i, k],])
     perm = perm.at[[i, k],].set(perm[[k, i],])
 
     # a[k+1:, k] /= a[k, k], adapted for loop-invariant shapes
     x = a[k, k]
-    a = a.at[:, k].set(jnp.where((m_idx > k) & (x != 0), a[:, k] / x, a[:, k]))
+    a = a.at[:, k].set(lax.select((m_idx > k) & (x != 0), a[:, k] / x, a[:, k]))
 
     # a[k+1:, k+1:] -= jnp.outer(a[k+1:, k], a[k, k+1:])
-    a = a - jnp.where((m_idx[:, None] > k) & (n_idx[None, :] > k),
-                     jnp.outer(a[:, k], a[k, :]), jnp.array(0, dtype=a.dtype))
+    a_outer = a[:, k, None] * a[k, None]
+    a = a - lax.select((m_idx[:, None] > k) & (n_idx[None, :] > k),
+                       a_outer, lax_internal._zeros(a_outer))
     return pivot, perm, a
 
-  pivot = jnp.zeros((min(m, n),), dtype=jnp.int32)
-  perm = jnp.arange(m, dtype=jnp.int32)
+  pivot = lax.full((min(m, n),), 0, dtype=np.int32)
+  perm = lax.iota('int32', m)
   if m == 0 and n == 0:
     # If the array is empty, the loop body never executes but tracing it to a
     # jaxpr fails because the indexing cannot succeed.
@@ -1285,8 +1322,8 @@ def _lu_blocked(a, block_size=128):
   """Blocked LU decomposition, as an unrolled loop."""
   m, n = a.shape
   r = min(m, n)
-  pivot = jnp.zeros((r,), dtype=jnp.int32)
-  perm = jnp.arange(m, dtype=jnp.int32)
+  pivot = lax.full((r,), 0, dtype=np.int32)
+  perm = lax.iota('int32', m)
   for k in range(0, r, block_size):
     b = min(r - k, block_size)
     block_pivot, block_perm, lu_block = _lu_unblocked(a[k:, k:k+b])
@@ -1327,8 +1364,8 @@ def _lu_abstract_eval(operand):
     m = operand.shape[-2]
     n = operand.shape[-1]
     pivot = operand.update(shape=batch_dims + (core.min_dim(m, n),),
-                           dtype=jnp.int32)
-    perm = operand.update(shape=batch_dims + (m,), dtype=jnp.int32)
+                           dtype=np.int32)
+    perm = operand.update(shape=batch_dims + (m,), dtype=np.int32)
   else:
     pivot = operand
     perm = operand
@@ -1339,14 +1376,14 @@ def _lu_jvp_rule(primals, tangents):
   a_dot, = tangents
   lu, pivots, permutation = lu_p.bind(a)
 
-  a_shape = jnp.shape(a)
+  a_shape = np.shape(a)
   m, n = a_shape[-2:]
   dtype = lax.dtype(a)
   k = min(m, n)
 
   batch_dims = a_shape[:-2]
-  iotas = jnp.ix_(*(lax.iota(jnp.int32, b) for b in batch_dims + (1,)))
-  x = a_dot[iotas[:-1] + (permutation, slice(None))]
+  iotas = _broadcasted_iotas(*batch_dims, 1)
+  x = a_dot[(*iotas[:-1], permutation, slice(None))]
 
   # Differentiation of Matrix Functionals Using Triangular Factorization
   # F. R. De Hoog, R. S. Anderssen, and M. A. Lukas
@@ -1361,14 +1398,13 @@ def _lu_jvp_rule(primals, tangents):
   l_padding = [(0, 0, 0)] * ndims
   l_padding[-1] = (0, m - k, 0)
   zero = lax_internal._const(lu, 0)
-  l = lax.pad(jnp.tril(lu[..., :, :k], -1), zero, l_padding)
-  l = l + lax.expand_dims(jnp.eye(m, m, dtype=dtype), range(l.ndim - 2))
-
-  u_eye = lax.pad(jnp.eye(n - k, n - k, dtype=dtype), zero,
+  l = lax.pad(_tril(lu[..., :, :k], -1), zero, l_padding)
+  l = l + lax.expand_dims(lax_internal._eye(dtype, (m, m)), range(l.ndim - 2))
+  u_eye = lax.pad(lax_internal._eye(dtype, (n - k, n - k)), zero,
                   ((k, 0, 0), (k, 0, 0)))
   u_padding = [(0, 0, 0)] * ndims
   u_padding[-2] = (0, n - k, 0)
-  u = (lax.pad(jnp.triu(lu[..., :k, :]), zero, u_padding) +
+  u = (lax.pad(_triu(lu[..., :k, :]), zero, u_padding) +
        lax.expand_dims(u_eye, range(lu.ndim - 2)))
 
   la = triangular_solve(l, x, left_side=True, transpose_a=False, lower=True,
@@ -1376,8 +1412,9 @@ def _lu_jvp_rule(primals, tangents):
   lau = triangular_solve(u, la, left_side=False, transpose_a=False,
                          lower=False)
 
-  l_dot = jnp.matmul(l, jnp.tril(lau, -1), precision=lax.Precision.HIGHEST)
-  u_dot = jnp.matmul(jnp.triu(lau), u, precision=lax.Precision.HIGHEST)
+  with config.default_matmul_precision("highest"):
+    l_dot = l @ _tril(lau, -1)
+    u_dot = _triu(lau) @ u
   lu_dot = l_dot + u_dot
   return (lu, pivots, permutation), (lu_dot, ad_util.Zero.from_value(pivots),
                                      ad_util.Zero.from_value(permutation))
@@ -1493,10 +1530,9 @@ mlir.register_lowering(
 mlir.register_lowering(lu_p, _lu_tpu_lowering_rule, platform='tpu')
 
 
-@partial(vectorize, excluded={3}, signature='(n,n),(n),(n,k)->(n,k)')
 def _lu_solve_core(lu: Array, permutation: Array, b: Array, trans: int) -> Array:
   m = lu.shape[0]
-  x = jnp.reshape(b, (m, math.prod(b.shape[1:])))
+  x = lax.reshape(b, (m, math.prod(b.shape[1:])))
   if trans == 0:
     x = x[permutation, :]
     x = triangular_solve(lu, x, left_side=True, lower=True, unit_diagonal=True)
@@ -1507,7 +1543,8 @@ def _lu_solve_core(lu: Array, permutation: Array, b: Array, trans: int) -> Array
                          conjugate_a=conj)
     x = triangular_solve(lu, x, left_side=True, lower=True, unit_diagonal=True,
                          transpose_a=True, conjugate_a=conj)
-    x = x[jnp.argsort(permutation), :]
+    _, ind = lax.sort_key_val(permutation, lax.iota('int32', len(permutation)))
+    x = x[ind, :]
   else:
     raise ValueError(f"'trans' value must be 0, 1, or 2, got {trans}")
   return lax.reshape(x, b.shape)
@@ -1531,7 +1568,7 @@ def _lu_solve(lu: Array, permutation: Array, b: Array, trans: int) -> Array:
                        "number of dimensions, last axis of LU decomposition "
                        "matrix (shape {}) and b array (shape {}) must match"
                        .format(lu.shape, b.shape))
-    b = b[..., jnp.newaxis]
+    b = b[..., np.newaxis]
   else:
     if b.shape[-2] != lu.shape[-1]:
       raise ValueError("When LU decomposition matrix and b different "
@@ -1539,7 +1576,15 @@ def _lu_solve(lu: Array, permutation: Array, b: Array, trans: int) -> Array:
                        "matrix (shape {}) and second to last axis of b array "
                        "(shape {}) must match"
                        .format(lu.shape, b.shape))
-  x = _lu_solve_core(lu, permutation, b, trans)
+
+  batch_shape = lax.broadcast_shapes(lu.shape[:-2], permutation.shape[:-1], b.shape[:-2])
+  lu = _broadcast_to(lu, (*batch_shape, *lu.shape[-2:]))
+  permutation = _broadcast_to(permutation, (*batch_shape, permutation.shape[-1]))
+  b = _broadcast_to(b, (*batch_shape, *b.shape[-2:]))
+  fn = _lu_solve_core
+  for _ in batch_shape:
+    fn = api.vmap(fn, in_axes=(0, 0, 0, None))
+  x = fn(lu, permutation, b, trans)
   return x[..., 0] if rhs_vector else x
 
 
@@ -1823,14 +1868,14 @@ def qr_jvp_rule(primals, tangents, *, full_matrices):
     raise NotImplementedError(
       "Unimplemented case of QR decomposition derivative")
   dx_rinv = triangular_solve(r, dx)  # Right side solve by default
-  qt_dx_rinv = jnp.matmul(_H(q), dx_rinv)
-  qt_dx_rinv_lower = jnp.tril(qt_dx_rinv, -1)
+  qt_dx_rinv = _H(q) @ dx_rinv
+  qt_dx_rinv_lower = _tril(qt_dx_rinv, -1)
   do = qt_dx_rinv_lower - _H(qt_dx_rinv_lower)  # This is skew-symmetric
   # The following correction is necessary for complex inputs
-  I = lax.expand_dims(jnp.eye(n, dtype=do.dtype), range(qt_dx_rinv.ndim - 2))
+  I = lax.expand_dims(lax_internal._eye(do.dtype, (n, n)), range(qt_dx_rinv.ndim - 2))
   do = do + I * (qt_dx_rinv - qt_dx_rinv.real.astype(qt_dx_rinv.dtype))
-  dq = jnp.matmul(q, do - qt_dx_rinv) + dx_rinv
-  dr = jnp.matmul(qt_dx_rinv - do, r)
+  dq = q @ (do - qt_dx_rinv) + dx_rinv
+  dr = (qt_dx_rinv - do) @ r
   return (q, r), (dq, dr)
 
 def _qr_batching_rule(batched_args, batch_dims, *, full_matrices):
@@ -1843,8 +1888,10 @@ def _qr_lowering(a, *, full_matrices):
   *batch_dims, m, n = a.shape
   if m == 0 or n == 0:
     k = m if full_matrices else min(m, n)
-    q = jnp.broadcast_to(jnp.eye(m, k, dtype=a.dtype), (*batch_dims, m, k))
-    r = jnp.empty((*batch_dims, k, n), dtype=a.dtype)
+    q = lax.broadcast_in_dim(lax_internal._eye(a.dtype, (m, k)),
+                             (*batch_dims, m, k),
+                             (len(batch_dims), len(batch_dims) + 1))
+    r = lax.full((*batch_dims, k, n), 0, dtype=a.dtype)
     return q, r
 
   r, taus = geqrf(a)
@@ -1857,7 +1904,7 @@ def _qr_lowering(a, *, full_matrices):
   else:
     q = householder_product(r, taus)
     r = r[..., :n, :n]
-  r = jnp.triu(r)
+  r = _triu(r)
   return q, r
 
 
@@ -1908,7 +1955,7 @@ def _svd_abstract_eval(operand, *, full_matrices, compute_uv, subset_by_index):
     raise NotImplementedError
 
 
-@jax.default_matmul_precision("float32")
+@config.default_matmul_precision("float32")
 def _svd_jvp_rule(
     primals, tangents, *, full_matrices, compute_uv, subset_by_index
 ):
@@ -1926,13 +1973,13 @@ def _svd_jvp_rule(
   Ut, V = _H(U), _H(Vt)
   s_dim = s[..., None, :]
   dS = Ut @ dA @ V
-  ds = ufuncs.real(jnp.diagonal(dS, 0, -2, -1))
+  ds = _extract_diagonal(dS.real)
 
   if not compute_uv:
     return (s,), (ds,)
 
   s_diffs = (s_dim + _T(s_dim)) * (s_dim - _T(s_dim))
-  s_diffs_zeros = jnp.eye(s.shape[-1], dtype=s.dtype)  # jnp.ones((), dtype=A.dtype) * (s_diffs == 0.)  # is 1. where s_diffs is 0. and is 0. everywhere else
+  s_diffs_zeros = lax_internal._eye(s.dtype, (s.shape[-1], s.shape[-1]))  # jnp.ones((), dtype=A.dtype) * (s_diffs == 0.)  # is 1. where s_diffs is 0. and is 0. everywhere else
   s_diffs_zeros = lax.expand_dims(s_diffs_zeros, range(s_diffs.ndim - 2))
   F = 1 / (s_diffs + s_diffs_zeros) - s_diffs_zeros
   dSS = s_dim.astype(A.dtype) * dS  # dS.dot(jnp.diag(s))
@@ -1940,7 +1987,7 @@ def _svd_jvp_rule(
 
   s_zeros = (s == 0).astype(s.dtype)
   s_inv = 1 / (s + s_zeros) - s_zeros
-  s_inv_mat = jnp.vectorize(jnp.diag, signature='(k)->(k,k)')(s_inv)
+  s_inv_mat = _construct_diagonal(s_inv)
   dUdV_diag = .5 * (dS - _H(dS)) * s_inv_mat.astype(A.dtype)
   dU = U @ (F.astype(A.dtype) * (dSS + _H(dSS)) + dUdV_diag)
   dV = V @ (F.astype(A.dtype) * (SdS + _H(SdS)))
@@ -1959,15 +2006,17 @@ def _svd_jvp_rule(
 def _empty_svd(a, *, full_matrices, compute_uv):
   batch_shape = a.shape[:-2]
   m, n = a.shape[-2:]
-  s = jnp.empty(batch_shape + (0,), dtype=lax_internal._complex_basetype(a.dtype))
+  s = lax.full(batch_shape + (0,), 0, dtype=lax_internal._complex_basetype(a.dtype))
   if not compute_uv:
     return (s,)
   if full_matrices:
     size = max(m, n)
-    u = jnp.broadcast_to(jnp.eye(size, dtype=a.dtype), batch_shape + (size, size))
+    u = lax.broadcast_in_dim(lax_internal._eye(a.dtype, (size, size)),
+                             (*batch_shape, size, size),
+                             (len(batch_shape), len(batch_shape) + 1))
   else:
-    u = jnp.empty(batch_shape + (m, n), dtype=a.dtype)
-  v = jnp.empty(batch_shape + (0, 0), dtype=a.dtype)
+    u = lax.full(batch_shape + (m, n), 0, dtype=a.dtype)
+  v = lax.full(batch_shape + (0, 0), 0, dtype=a.dtype)
   if m < n:
     u, v = v, u
   return s, u, v
@@ -2207,24 +2256,25 @@ mlir.register_lowering(
 def _tridiagonal_solve_jax(dl, d, du, b, **kw):
   """Pure JAX implementation of `tridiagonal_solve`."""
   def prepend_zero(x):
-    return jnp.append(
-        jnp.zeros((1,) + x.shape[1:], dtype=x.dtype),
-        x[:-1], axis=0)
+    return lax.concatenate(
+      [lax.full((1,) + x.shape[1:], 0, dtype=x.dtype), x[:-1]], dimension=0)
   fwd1 = lambda tu_, x: x[1] / (x[0] - x[2] * tu_)
 
   def fwd2(b_, x):
-    return (x[0] - x[3][jnp.newaxis, ...] * b_) / (
-        x[1] - x[3] * x[2])[jnp.newaxis, ...]
+    return (x[0] - x[3][np.newaxis, ...] * b_) / (
+        x[1] - x[3] * x[2])[np.newaxis, ...]
 
-  bwd1 = lambda x_, x: x[0] - x[1][jnp.newaxis, ...] * x_
+  bwd1 = lambda x_, x: x[0] - x[1][np.newaxis, ...] * x_
   double = lambda f, args: (f(*args), f(*args))
 
   # Move relevant dimensions to the front for the scan.
-  dl = jnp.moveaxis(dl, -1, 0)
-  d = jnp.moveaxis(d, -1, 0)
-  du = jnp.moveaxis(du, -1, 0)
-  b = jnp.moveaxis(b, -1, 0)
-  b = jnp.moveaxis(b, -1, 0)
+  moveaxis_fwd = lambda x: lax.transpose(x, (x.ndim - 1, *range(x.ndim - 1)))
+  moveaxis_bwd = lambda x: lax.transpose(x, (*range(1, x.ndim), 0))
+  dl = moveaxis_fwd(dl)
+  d = moveaxis_fwd(d)
+  du = moveaxis_fwd(du)
+  b = moveaxis_fwd(b)
+  b = moveaxis_fwd(b)
 
   # Forward pass.
   _, tu_ = lax.scan(lambda tu_, x: double(fwd1, (tu_, x)),
@@ -2244,8 +2294,8 @@ def _tridiagonal_solve_jax(dl, d, du, b, **kw):
                    unroll=32)
 
   result = x_[::-1]
-  result = jnp.moveaxis(result, 0, -1)
-  result = jnp.moveaxis(result, 0, -1)
+  result = moveaxis_bwd(result)
+  result = moveaxis_bwd(result)
   return result
 
 
@@ -2433,7 +2483,7 @@ def hessenberg(a: ArrayLike) -> tuple[Array, Array]:
   return hessenberg_p.bind(a)
 
 def _hessenberg_abstract_eval(a):
-  if a.dtype not in (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128):
+  if a.dtype not in (np.float32, np.float64, np.complex64, np.complex128):
     raise TypeError("hessenberg requires a.dtype to be float32, float64, "
                     f"complex64, or complex128, got {a.dtype}.")
   if a.ndim < 2:
@@ -2509,19 +2559,20 @@ def tridiagonal(a: ArrayLike, *, lower=True
   first superdiagonal. ``taus`` contains the scalar factors of the elementary
   Householder reflectors.
   """
-  arr, d, e, taus, info = tridiagonal_p.bind(jnp.asarray(a), lower=lower)
-  nan = arr.dtype.type(jnp.nan)
-  if jnp.issubdtype(arr.dtype, np.complexfloating):
-    nan = nan + arr.dtype.type(jnp.nan * 1j)
-  arr = jnp.where((info == 0)[..., None, None], arr, nan)
-  real_type = jnp.finfo(arr.dtype).dtype.type
-  d = jnp.where((info == 0)[..., None], d, real_type(jnp.nan))
-  e = jnp.where((info == 0)[..., None], e, real_type(jnp.nan))
-  taus = jnp.where((info == 0)[..., None], taus, nan)
+  arr, d, e, taus, info = tridiagonal_p.bind(lax_internal.asarray(a), lower=lower)
+  def nans_like(arr):
+    if dtypes.issubdtype(arr.dtype, np.complexfloating):
+      return lax.full_like(arr, np.nan + 1j * np.nan)
+    return lax.full_like(arr, np.nan)
+  mask = lambda x: lax.broadcast_in_dim(info == 0, x.shape, range(info.ndim))
+  arr = lax.select(mask(arr), arr, nans_like(arr))
+  d = lax.select(mask(d), d, nans_like(d))
+  e = lax.select(mask(e), e, nans_like(e))
+  taus = lax.select(mask(taus), taus, nans_like(taus))
   return arr, d, e, taus
 
 def _tridiagonal_abstract_eval(a, *, lower):
-  if a.dtype not in (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128):
+  if a.dtype not in (np.float32, np.float64, np.complex64, np.complex128):
     raise TypeError("tridiagonal requires a.dtype to be float32, float64, "
                     f"complex64, or complex128, got {a.dtype}.")
   if a.ndim < 2:
@@ -2533,7 +2584,7 @@ def _tridiagonal_abstract_eval(a, *, lower):
   if a.shape[-1] == 0:
     raise TypeError("tridiagonal requires the last two dimensions of a to be "
                     f"non-zero, got a.shape of {a.shape}.")
-  real_dtype = jnp.finfo(a.dtype).dtype
+  real_dtype = dtypes.finfo(a.dtype).dtype
   return [
       a,
       ShapedArray(a.shape[:-2] + (a.shape[-1],), real_dtype),
@@ -2573,7 +2624,7 @@ mlir.register_lowering(
 # Utilities
 
 def _nan_like_hlo(ctx: mlir.LoweringRuleContext, aval) -> ir.Value:
-  if jnp.issubdtype(aval.dtype, np.complexfloating):
+  if dtypes.issubdtype(aval.dtype, np.complexfloating):
     return mlir.full_like_aval(ctx, np.nan + np.nan * 1j, aval)
   else:
     return mlir.full_like_aval(ctx, np.nan, aval)

--- a/jax/_src/lax/qdwh.py
+++ b/jax/_src/lax/qdwh.py
@@ -28,11 +28,33 @@ from __future__ import annotations
 
 import functools
 
-import jax
-import jax.numpy as jnp
-from jax import lax
+from jax._src import api
+from jax._src import config
 from jax._src import core
+from jax._src import dtypes
+from jax._src.lax.control_flow import loops
+from jax._src.lax import lax
 from jax._src.lax import linalg as lax_linalg
+from jax._src.lax import slicing
+from jax._src.typing import Array
+import numpy as np
+
+
+def _norm(x, axis=None):
+  return lax.sqrt((abs(x) ** 2).sum(axis=axis))
+
+def _one_norm(x):
+  assert x.ndim == 2
+  return abs(x).sum(0).max()
+
+def _inf_norm(x):
+  assert x.ndim == 2
+  return abs(x).sum(1).max()
+
+
+def _broadcast_to(x: Array, shape: tuple[int, ...]) -> Array:
+  assert x.ndim <= len(shape)
+  return lax.broadcast_in_dim(x, shape, range(len(shape) - x.ndim, len(shape)))
 
 
 # Helpers for working with padded shapes
@@ -42,24 +64,26 @@ def _mask(x, dims, alternative=0):
   Replaces values outside those dimensions with `alternative`. `alternative` is
   broadcast with `x`.
   """
-  assert jnp.ndim(x) == len(dims)
+  assert np.ndim(x) == len(dims)
   mask = None
   for i, d in enumerate(dims):
     if d is not None:
-      mask_dim_i = lax.broadcasted_iota(jnp.int32, x.shape, i) < d
+      mask_dim_i = lax.broadcasted_iota(np.int32, x.shape, i) < d
       mask = mask_dim_i if mask is None else (mask & mask_dim_i)
-  return x if mask is None else jnp.where(mask, x, alternative)
+
+  alternative = _broadcast_to(lax.asarray(alternative), x.shape).astype(x.dtype)
+  return x if mask is None else lax.select(mask, x, alternative)
 
 def _pad_in_dim(x, low=0, high=0, interior=0, fill_value=0, axis=0):
   pads = [(0, 0, 0)] * x.ndim
   pads[axis] = (low, high, interior)
-  return lax.pad(x, jnp.array(fill_value, x.dtype), pads)
+  return lax.pad(x, lax.convert_element_type(fill_value, x.dtype), pads)
 
 def _dynamic_concat(a, b, m, axis=0):
   "Concatenates padded arrays `a` and `b` where the true size of `a` is `m`."
   if m is None:
-    return jnp.concatenate([a, b], axis=axis)
-  return lax.dynamic_update_slice_in_dim(
+    return lax.concatenate([a, b], dimension=axis)
+  return slicing.dynamic_update_slice_in_dim(
       _pad_in_dim(a, high=b.shape[axis], axis=axis), b, m, axis)
 
 
@@ -74,12 +98,12 @@ def _use_qr(u, m, n, params):
   a_minus_e_by_sqrt_c, sqrt_c, e = params
   M, N = u.shape
 
-  y = _dynamic_concat(sqrt_c * u, jnp.eye(N, dtype=jnp.dtype(u)), m)
+  y = _dynamic_concat(sqrt_c * u, lax._eye(np.dtype(u), (N, N)), m)
   q, _ = lax_linalg.qr(y, full_matrices=False)
   # q1 = q[:m, :]
-  q1 = _mask(lax.slice(q, (0, 0), (M, N)), (m, n))
+  q1 = _mask(slicing.slice(q, (0, 0), (M, N)), (m, n))
   # q2 = (q[m:, :]).T.conj()
-  q2 = lax.dynamic_slice_in_dim(q, m, N, axis=0)
+  q2 = slicing.dynamic_slice_in_dim(q, m, N, axis=0)
   q2 = _mask(q2, (n, n)).T.conj()
   return e * u + a_minus_e_by_sqrt_c * (q1 @ q2)
 
@@ -94,11 +118,11 @@ def _use_cholesky(u, m, n, params):
   """
   a_minus_e, c, e = params
   _, N = u.shape
-  x = c * (u.T.conj() @ u) + jnp.eye(N, dtype=jnp.dtype(u))
+  x = c * (u.T.conj() @ u) + lax._eye(np.dtype(u), (N, N))
   # Pads the lower-right corner with the identity matrix to prevent the Cholesky
   # decomposition from failing due to the matrix not being PSD if padded with
   # zeros.
-  x = _mask(x, (n, n), jnp.eye(N, dtype=x.dtype))
+  x = _mask(x, (n, n), lax._eye(x.dtype, (N, N)))
 
   # `y` is lower triangular.
   y = lax_linalg.cholesky(x, symmetrize_input=False)
@@ -119,18 +143,18 @@ def _qdwh(x, m, n, max_iterations, eps):
   # norm(x, 2) such that `alpha >= norm(x, 2)` and `beta` is a lower bound for
   # the smallest singular value of x.
   if eps is None:
-    eps = float(jnp.finfo(x.dtype).eps)
-  one_norm = jnp.linalg.norm(x, ord=1)
-  inf_norm = jnp.linalg.norm(x, ord=jnp.inf)
+    eps = float(dtypes.finfo(x.dtype).eps)
+  one_norm = _one_norm(x)
+  inf_norm = _inf_norm(x)
   alpha_inverse = lax.rsqrt(one_norm) * lax.rsqrt(inf_norm)
-  alpha_inverse = jnp.where(one_norm == 0, 1, alpha_inverse)
+  alpha_inverse = lax.select(one_norm == 0, lax._ones(alpha_inverse), alpha_inverse)
   u = x * alpha_inverse.astype(x.dtype)
 
   l = eps
 
   # Iteration tolerances.
   tol_l = 10.0 * eps / 2.0
-  tol_norm = jnp.cbrt(tol_l)
+  tol_norm = lax.cbrt(tol_l)
 
   def get_qr_params(a, b, c):
     e = b / c
@@ -169,22 +193,22 @@ def _qdwh(x, m, n, max_iterations, eps):
       # As l → 1, the coefficients a, b, c → 3, 1, 3, which is Halley's method.
       params = get_chol_params(3, 1, 3)
     else:
-      params = lax.dynamic_index_in_dim(coefs, k, keepdims=False)
+      params = slicing.dynamic_index_in_dim(coefs, k, keepdims=False)
 
     u_prev = u
     u = update_fn(u, m, n, params)
 
     is_not_converged = True
     if test_convergence:
-      is_not_converged = jnp.linalg.norm(u - u_prev) > tol_norm
+      is_not_converged = _norm(u - u_prev) > tol_norm
     return u, is_not_converged
 
   def iterate(u, coefs, **kwargs):
     if not coefs:
       return u, True
-    coefs = jnp.array(coefs).astype(x.dtype)
+    coefs = np.array(coefs).astype(x.dtype)
     body = functools.partial(iteration, coefs=coefs, **kwargs)
-    return lax.fori_loop(0, len(coefs), body, (u, True))
+    return loops.fori_loop(0, len(coefs), body, (u, True))
 
   u, _ = iterate(
       u, coefs=qr_coefs, update_fn=_use_qr, test_convergence=False
@@ -197,7 +221,7 @@ def _qdwh(x, m, n, max_iterations, eps):
   # (coef = None) until convergence.
   def cond_fun(state):
     k, _, is_not_converged = state
-    return jnp.logical_and(is_not_converged, k < max_iterations)
+    return lax.bitwise_and(is_not_converged, k < max_iterations)
 
   def body_fun(state):
     k, u, is_not_converged = state
@@ -211,7 +235,7 @@ def _qdwh(x, m, n, max_iterations, eps):
     return k + 1, u, is_not_converged
 
   k = len(qr_coefs) + len(chol_coefs)
-  num_iters, u, is_not_converged = lax.while_loop(
+  num_iters, u, is_not_converged = loops.while_loop(
       cond_fun, body_fun, (k, u, is_not_converged)
   )
 
@@ -222,14 +246,14 @@ def _qdwh(x, m, n, max_iterations, eps):
   h = (h + h.T.conj()) / 2
 
   # Converged within the maximum number of iterations.
-  is_converged = jnp.logical_not(is_not_converged)
+  is_converged = lax.bitwise_not(is_not_converged)
 
   return u, h, num_iters, is_converged
 
 
 # TODO: Add pivoting.
 @functools.partial(
-    jax.jit, static_argnames=('is_hermitian', 'max_iterations', 'eps')
+    api.jit, static_argnames=('is_hermitian', 'max_iterations', 'eps')
 )
 def qdwh(
     x,
@@ -279,7 +303,7 @@ def qdwh(
   else:
     m, n = M, N
 
-  with jax.default_matmul_precision('float32'):
+  with config.default_matmul_precision('float32'):
     u, h, num_iters, is_converged = _qdwh(x, m, n, max_iterations, eps)
 
   return u, h, num_iters, is_converged

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -24,9 +24,8 @@ import weakref
 
 import numpy as np
 
-import jax
-
 from jax._src import ad_util
+from jax._src import api
 from jax._src import config
 from jax._src import core
 from jax._src import dispatch
@@ -1401,7 +1400,7 @@ def _dynamic_update_slice_batching_rule(batched_args, batch_dims):
                                   inserted_window_dims=(),
                                   scatter_dims_to_operand_dims=dims)
   index, index_bdim = _batch_dynamic_slice_indices(start_idx, start_idx_bd)
-  return jax.vmap(
+  return api.vmap(
     partial(scatter, dimension_numbers=dnums,
             indices_are_sorted=True, unique_indices=True,
             mode=GatherScatterMode.CLIP),

--- a/jax/_src/lax/stack.py
+++ b/jax/_src/lax/stack.py
@@ -22,9 +22,9 @@ from __future__ import annotations
 
 from typing import Any
 
-import jax
-from jax import lax
-import jax.numpy as jnp
+from jax._src.lax import lax
+from jax._src.lax import slicing
+from jax._src import tree_util
 
 class Stack:
   """A bounded functional stack implementation. Elements may be pytrees."""
@@ -44,9 +44,9 @@ class Stack:
     structure; the specific values are ignored.
     """
     return Stack(
-      jnp.array(0, jnp.int32),
-      jax.tree_util.tree_map(
-        lambda x: jnp.zeros((capacity,) + tuple(x.shape), x.dtype), prototype))
+      lax.full((), 0, 'int32'),
+      tree_util.tree_map(
+        lambda x: lax.full((capacity, *x.shape), 0, x.dtype), prototype))
 
   def empty(self) -> Any:
     """Returns true if the stack is empty."""
@@ -56,23 +56,23 @@ class Stack:
     """Pushes `elem` onto the stack, returning the updated stack."""
     return Stack(
       self._size + 1,
-      jax.tree_util.tree_map(
-        lambda x, y: lax.dynamic_update_index_in_dim(x, y, self._size, 0),
+      tree_util.tree_map(
+        lambda x, y: slicing.dynamic_update_index_in_dim(x, y, self._size, 0),
         self._data, elem))
 
   def pop(self) -> tuple[Any, Stack]:
     """Pops from the stack, returning an (elem, updated stack) pair."""
-    elem = jax.tree_util.tree_map(
-      lambda x: lax.dynamic_index_in_dim(x, self._size - 1, 0, keepdims=False),
+    elem = tree_util.tree_map(
+      lambda x: slicing.dynamic_index_in_dim(x, self._size - 1, 0, keepdims=False),
       self._data)
     return elem, Stack(self._size - 1, self._data)
 
   def flatten(self):
-    leaves, treedef = jax.tree_util.tree_flatten(self._data)
+    leaves, treedef = tree_util.tree_flatten(self._data)
     return ([self._size] + leaves), treedef
 
   @staticmethod
   def unflatten(treedef, leaves):
-    return Stack(leaves[0], jax.tree_util.tree_unflatten(treedef, leaves[1:]))
+    return Stack(leaves[0], tree_util.tree_unflatten(treedef, leaves[1:]))
 
-jax.tree_util.register_pytree_node(Stack, Stack.flatten, Stack.unflatten)
+tree_util.register_pytree_node(Stack, Stack.flatten, Stack.unflatten)

--- a/jax/_src/lax/svd.py
+++ b/jax/_src/lax/svd.py
@@ -40,13 +40,30 @@ import functools
 import operator
 from typing import Any
 
-import jax
-from jax import lax
+from jax._src import api
+from jax._src import config
 from jax._src import core
-import jax.numpy as jnp
+from jax._src import dtypes
+from jax._src.lax.control_flow import loops
+from jax._src.lax import lax
+from jax._src.lax import linalg as lax_linalg
+from jax._src.lax import qdwh
+from jax._src.typing import Array
+import numpy as np
 
+def _construct_diagonal(s: Array) -> Array:
+  """Construct a (batched) diagonal matrix"""
+  # signature: (...,n)->(...,n,n)
+  i = lax.iota('int32', s.shape[-1])
+  return lax.full((*s.shape, s.shape[-1]), 0, s.dtype).at[..., i, i].set(s)
 
-@functools.partial(jax.jit, static_argnums=(1, 2, 3, 4))
+def _extract_diagonal(s: Array) -> Array:
+  """Extract the diagonal from a batched matrix"""
+  # signature: (...,n,m)->(...k) where k=min(n,m)
+  i = lax.iota('int32', min(s.shape[-2], s.shape[-1]))
+  return s[..., i, i]
+
+@functools.partial(api.jit, static_argnums=(1, 2, 3, 4))
 def _svd_tall_and_square_input(
     a: Any,
     hermitian: bool,
@@ -69,22 +86,23 @@ def _svd_tall_and_square_input(
     `a = (u * s) @ v.T.conj()`. For `compute_uv=False`, only `s` is returned.
   """
 
-  u_p, h, _, _ = lax.linalg.qdwh(
+  u_p, h, _, _ = qdwh.qdwh(
       a, is_hermitian=hermitian, max_iterations=max_iterations
   )
 
   # TODO: Uses `eigvals_only=True` if `compute_uv=False`.
-  v, s = lax.linalg.eigh(
+  v, s = lax_linalg.eigh(
       h, subset_by_index=subset_by_index, sort_eigenvalues=False
   )
 
   # Singular values are non-negative by definition. But eigh could return small
   # negative values, so we clamp them to zero.
-  s = jnp.maximum(s, 0.0)
+  s = lax.max(s, lax._zeros(s))
 
   # Sort or reorder singular values to be in descending order.
-  sort_idx = jnp.argsort(s, descending=True)
-  s_out = s[sort_idx]
+  s_out, sort_idx = lax.rev(s, (0,)), lax.rev(lax.iota('int32', len(s)), (0,))
+  s_out, sort_idx = lax.sort_key_val(s_out, sort_idx)
+  s_out, sort_idx = lax.rev(s_out, (0,)), lax.rev(sort_idx, (0,))
 
   if not compute_uv:
     return s_out
@@ -99,18 +117,20 @@ def _svd_tall_and_square_input(
   # eigenvalue decomposition and the SVD." SIAM Journal on Scientific Computing
   # 35, no. 3 (2013): A1325-A1349.
   def correct_rank_deficiency(u_out):
-    u_out, r = lax.linalg.qr(u_out, full_matrices=False)
-    u_out = u_out @ jnp.diag(jnp.where(jnp.diag(r) >= 0, 1, -1))
+    u_out, r = lax_linalg.qr(u_out, full_matrices=False)
+    r_diag = _extract_diagonal(r)
+    ones = lax.full(r_diag.shape, 1, u_out.dtype)
+    u_out = u_out @ _construct_diagonal(lax.select(r_diag >= 0, ones, -ones))
     return u_out
 
-  eps = float(jnp.finfo(a.dtype).eps)
+  eps = float(dtypes.finfo(a.dtype).eps)
   do_correction = s_out[-1] <= a.shape[1] * eps * s_out[0]
   cond_f = lambda args: args[1]
   body_f = lambda args: (correct_rank_deficiency(args[0]), False)
-  u_out, _ = lax.while_loop(cond_f, body_f, (u_out, do_correction))
+  u_out, _ = loops.while_loop(cond_f, body_f, (u_out, do_correction))
   return (u_out, s_out, v_out)
 
-@functools.partial(jax.jit, static_argnums=(1, 2, 3, 4, 5))
+@functools.partial(api.jit, static_argnums=(1, 2, 3, 4, 5))
 def svd(
     a: Any,
     full_matrices: bool,
@@ -197,7 +217,7 @@ def svd(
 
   reduce_to_square = False
   if full_matrices:
-    q_full, a_full = lax.linalg.qr(a, full_matrices=True)
+    q_full, a_full = lax_linalg.qr(a, full_matrices=True)
     q = q_full[:, :n]
     u_out_null = q_full[:, n:]
     a = a_full[:n, :]
@@ -206,16 +226,16 @@ def svd(
     # The constant `1.15` comes from Yuji Nakatsukasa's implementation
     # https://www.mathworks.com/matlabcentral/fileexchange/36830-symmetric-eigenvalue-decomposition-and-the-svd?s_tid=FX_rc3_behav
     if m > 1.15 * n:
-      q, a = lax.linalg.qr(a, full_matrices=False)
+      q, a = lax_linalg.qr(a, full_matrices=False)
       reduce_to_square = True
 
   if not compute_uv:
-    with jax.default_matmul_precision('float32'):
+    with config.default_matmul_precision('float32'):
       return _svd_tall_and_square_input(
           a, hermitian, compute_uv, max_iterations, subset_by_index
       )
 
-  with jax.default_matmul_precision('float32'):
+  with config.default_matmul_precision('float32'):
     u_out, s_out, v_out = _svd_tall_and_square_input(
         a, hermitian, compute_uv, max_iterations, subset_by_index
     )
@@ -223,17 +243,20 @@ def svd(
       u_out = q @ u_out
 
   if full_matrices:
-    u_out = jnp.hstack((u_out, u_out_null))
+    u_out = lax.concatenate([u_out, u_out_null], dimension=1)
 
-  is_finite = jnp.all(jnp.isfinite(a))
-  cond_f = lambda args: jnp.logical_not(args[0])
+  if dtypes.issubdtype(a.dtype, np.complexfloating):
+    is_finite = (lax.is_finite(a.real) & lax.is_finite(a.imag)).all()
+  else:
+    is_finite = lax.is_finite(a).all()
+  cond_f = lambda args: lax.bitwise_not(args[0].astype(bool))
   body_f = lambda args: (
-      jnp.array(True),
-      jnp.full_like(u_out, jnp.nan),
-      jnp.full_like(s_out, jnp.nan),
-      jnp.full_like(v_out, jnp.nan),
+      lax.full((), True, dtype=bool),
+      lax.full_like(u_out, np.nan),
+      lax.full_like(s_out, np.nan),
+      lax.full_like(v_out, np.nan),
   )
-  _, u_out, s_out, v_out = lax.while_loop(
+  _, u_out, s_out, v_out = loops.while_loop(
       cond_f, body_f, (is_finite, u_out, s_out, v_out)
   )
 

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -951,7 +951,7 @@ def _solve(a: ArrayLike, b: ArrayLike, assume_a: str, lower: bool) -> Array:
   factors = cho_factor(lax.stop_gradient(a), lower=lower)
   custom_solve = partial(
       lax.custom_linear_solve,
-      lambda x: lax_linalg._matvec_multiply(a, x),
+      lambda x: lax_linalg._broadcasted_matvec(a, x),
       solve=lambda _, x: cho_solve(factors, x),
       symmetric=True)
   if a.ndim == b.ndim + 1:


### PR DESCRIPTION
`jax.numpy` sources depend on `jax.lax`, so to improve our import/dependency graph and avoid problems with circular imports, `jax.lax` implementations should not depend on `jax.numpy`.

This was motivated by circular import problems that came up when implementing #23304. This change is a step toward putting `jax.lax` in its own BUILD rule.