### PR TITLE
Added `shape` and `dtype` to `AbstractValue`

### DIFF
--- a/jax/_src/ad_util.py
+++ b/jax/_src/ad_util.py
@@ -31,7 +31,6 @@ T = TypeVar('T')
 map = safe_map
 
 def add_jaxvals(x: ArrayLike, y: ArrayLike) -> Array:
-  dtype = core.get_aval(x).dtype
   return add_jaxvals_p.bind(x, y)
 
 add_jaxvals_p = Primitive('add_any')

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1427,6 +1427,20 @@ class AbstractValue:
   def str_short(self, short_dtypes=False):
     return str(self)
 
+  @property
+  def dtype(self) -> np.dtype:
+    raise AttributeError(
+        f"{type(self).__name__} has no dtype. Please open an issue at "
+        "https://github.com/google/jax/issues."
+    )
+
+  @property
+  def shape(self) -> tuple[Any, ...]:
+    raise AttributeError(
+        f"{type(self).__name__} has no shape. Please open an issue at "
+        "https://github.com/google/jax/issues."
+    )
+
 
 # For type signatures involving dynamic shapes, we use lists of abstract values
 # which may contain (reverse) de Bruijn indices in their shapes.
@@ -1658,13 +1672,6 @@ class UnshapedArray(AbstractValue):
     """Returns a copy of the aval with weak_type=False."""
     return self.update(weak_type=False)
 
-  @property
-  def shape(self):
-    msg = ("UnshapedArray has no shape. Please open an issue at "
-           "https://github.com/google/jax/issues because it's unexpected for "
-           "UnshapedArray instances to ever be produced.")
-    raise TypeError(msg)
-
 def _canonicalize_dimension(dim: DimSize) -> DimSize:
   # Dimensions are most commonly integral (by far), so we check that first.
   try:
@@ -1892,7 +1899,7 @@ def primal_dtype_to_tangent_dtype(primal_dtype):
 # it's kind of convenient!
 class DShapedArray(UnshapedArray):
   __slots__ = ['shape']
-  shape: tuple[AxisSize, ...]  # noqa: F821
+  shape: tuple[AxisSize, ...]  # noqa: F821  # type: ignore
   array_abstraction_level: int = 3
 
   def __init__(self, shape, dtype, weak_type=False):

--- a/jax/_src/pallas/core.py
+++ b/jax/_src/pallas/core.py
@@ -607,6 +607,7 @@ def _convert_block_spec_to_block_mapping(
     index_map_func = lambda *args: (0,) * len(array_aval.shape)
   else:
     index_map_func = block_spec.index_map
+  block_shape: tuple[int | None, ...]
   if block_spec.block_shape is None:
     block_shape = array_aval.shape
   else:
@@ -644,8 +645,7 @@ def _convert_block_spec_to_block_mapping(
     jaxpr, out_avals, consts, () = pe.trace_to_jaxpr_dynamic(flat_index_map_fun,
                                                              index_map_avals,
                                                              debug_info=debug)
-  mapped_block_shape = tuple(
-      mapped if s is None else s for s in block_shape)
+  mapped_block_shape = tuple(mapped if s is None else s for s in block_shape)
   if len(out_avals) != len(block_shape):
     raise ValueError(
         f"Index map function {index_map_src_info} for "
@@ -667,7 +667,7 @@ def _convert_block_spec_to_block_mapping(
   array_aval_shape = _max_shape_from_aval(array_aval)
 
   mapping = BlockMapping(
-      block_shape=mapped_block_shape,
+      block_shape=mapped_block_shape,  # type: ignore[arg-type]
       block_aval=block_aval,
       index_map_jaxpr=jax_core.ClosedJaxpr(jaxpr, consts),
       index_map_src_info=index_map_src_info,


### PR DESCRIPTION
We assume that an `AbstractValue` is a `ShapedArray` in lots of places, and currently most of them generate static type errors, because an `AbstractValue` has neither `shape` nor `dtype` (unlike `ShapedArray`).

I decided to use `tuple[Any, ...]` instead of `tuple[int, ...]` for the `shape` because dimension are not `int`s in the presence of dynamic shapes.

With this

     python -m pyright jax/_src

is down to

     2063 errors, 19 warnings, 0 informations