### PR TITLE
Fix triton capi_objects target to depend on MLIR CAPIIRObjects bazel

### DIFF
--- a/jaxlib/triton/BUILD
+++ b/jaxlib/triton/BUILD
@@ -116,7 +116,7 @@ cc_library(
     hdrs = ["triton_dialect_capi.h"],
     deps = [
         "@llvm-project//llvm:Support",
-        "@llvm-project//mlir:CAPIIR",
+        "@llvm-project//mlir:CAPIIRObjects",
         "@llvm-project//mlir:IR",
         "@triton//:TritonDialects",
     ],


### PR DESCRIPTION
target.

"...Objects" targets should only depend on other "...Objects" targets in MLIR land. Don't mix them.