### PR TITLE
[shape_poly] Improve handling of equality shape constraints

### DIFF
--- a/docs/export/shape_poly.md
+++ b/docs/export/shape_poly.md
@@ -353,7 +353,7 @@ symbolic constraints:
     E.g., `floordiv(a, b) == c` works by replacing all
     occurences of `floordiv(a, b)` with `c`.
     Equality constraints must not contain addition or
-    subtraction at the top-leve on the left-hand-side. Examples of
+    subtraction at the top-level on the left-hand-side. Examples of
     valid left-hand-sides are `a * b`, or `4 * a`, or
     `floordiv(a + c, b)`.
 
@@ -530,7 +530,7 @@ Array([[ 9,  8,  7],
 >>> k, = export.symbolic_shape("k", constraints=["k <= 10"])
 >>> export.export(jax.jit(my_top_k, static_argnums=0))(k, x)  # doctest: +IGNORE_EXCEPTION_DETAIL
 Traceback (most recent call last):
-KeyError: "Encountered dimension variable 'k' that is not appearing in the shapes of the function arguments
+UnexpectedDimVar: "Encountered dimension variable 'k' that is not appearing in the shapes of the function arguments
 
 ```
 

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1253,7 +1253,7 @@ class TensorFlowTracer(core.Tracer):
             # We have a TF value with known shape, and the abstract shape is a shape variable.
             try:
               aval_int = int(_eval_shape([aval_dim]))  # type: ignore
-            except (TypeError, KeyError):
+            except (TypeError, KeyError, shape_poly.UnexpectedDimVar):
               continue
             assert aval_int == val_dim, f"expected {phys_aval.shape} == {val_shape}. Found {aval_int} != {val_dim}."
 


### PR DESCRIPTION
This fixes several bugs in presence of equality constraints where the left-hand side is just a dimension variable.

First, such constraints were not applied when parsing variables. Now, with a constraint `a == b` when we parse "a" we obtain `b`.

Second, when we evaluate symbolic dimensions that contain dimension variables that are constrained to be equal to something else, we may fail to find the dimension variable in the environment because the environment construction has applied the constraints. We fix this by looking up the unknown dimension variable in the equality constraints.

Fixes: #23437
Fixes: #23456