### PR TITLE
Add the FFI functions and tutorial to the changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 
 ## jax 0.4.32
 
+* New Functionality
+  * Added {func}`jax.extend.ffi.ffi_call` and {func}`jax.extend.ffi.ffi_lowering`
+    to support the use of the new {ref}`ffi-tutorial` to interface with custom
+    C++ and CUDA code from JAX.
+
 * Changes
   * `jax_enable_memories` flag is set to `True` by default.
   * {mod}`jax.numpy` now supports v2023.12 of the Python Array API Standard.

--- a/docs/ffi.ipynb
+++ b/docs/ffi.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "(ffi-tutorial)=\n",
+    "\n",
     "# Foreign function interface (FFI)\n",
     "\n",
     "_This tutorial requires JAX v0.4.31 or newer._\n",

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -12,6 +12,8 @@ kernelspec:
   name: python3
 ---
 
+(ffi-tutorial)=
+
 # Foreign function interface (FFI)
 
 _This tutorial requires JAX v0.4.31 or newer._


### PR DESCRIPTION
Although we soft launched the FFI with v0.4.31, it would be nice to include an update in the changelog to help with visibility.