### PR TITLE
Fix Pyright issue with the type of NotMapped

### DIFF
--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -17,7 +17,7 @@ import collections
 from collections.abc import Callable, Iterable, Sequence
 import dataclasses
 from functools import partial
-from typing import Any, Union
+from typing import Any, Union, TypeAlias
 
 import numpy as np
 
@@ -318,7 +318,7 @@ def flatten_fun_for_vmap(in_tree, *args_flat):
 ### tracer
 
 # TODO(mattjj): use a special sentinel type rather than None
-NotMapped = type(None)
+NotMapped: TypeAlias = type(None)
 not_mapped = None
 
 


### PR DESCRIPTION
Newest pyright is not able to figure out that ```NotMapped``` is a type alias, the correct type annotation forces it to understand.
 

Can be reproduced and/or tested by running pyright on
```
from jax.interpreters.batching import NotMapped
x: NotMapped
```

_discovered this when updating pyright for Equinox_
