### PR TITLE
More explicit docstring on the limitations of `spsolve`

### DIFF
--- a/jax/experimental/sparse/linalg.py
+++ b/jax/experimental/sparse/linalg.py
@@ -602,7 +602,9 @@ def spsolve(data, indices, indptr, b, tol=1e-6, reorder=1):
   """A sparse direct solver using QR factorization.
 
   Accepts a sparse matrix in CSR format `data, indices, indptr` arrays.
-  Currently only the CUDA GPU backend is implemented.
+  Currently only the CUDA GPU backend is implemented, the CPU backend will fall
+  back to `scipy.sparse.linalg.spsolve`. Neither the CPU nor the GPU
+  implementation support batching with `vmap`.
 
   Args:
     data : An array containing the non-zero entries of the CSR matrix.


### PR DESCRIPTION
I tried to use `spsolve` for my [current project](https://github.com/jaxleyverse/jaxley), but then found out that `spsolve` does not support batching with `vmap`. This PR suggests adding this to the docstring of `spsolve`.

To reproduce the raised error:
```python
from jax import config
config.update("jax_platform_name", "gpu")

from jax import vmap
import jax.numpy as jnp
from jax.experimental.sparse.linalg import spsolve


indices = jnp.array([0, 2, 2, 0, 1, 2])
indptr = jnp.array([0, 2, 3, 6])

data = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
b = jnp.array([1.0, 1.0, 1.0])

def solve(data, b):
    return spsolve(data, indices, indptr, b)

vmapped_solve = vmap(solve, in_axes=(0, 0))
all_data = jnp.stack([data, data])
all_b = jnp.stack([b, b])
vmapped_solve(all_data, all_b)
```

The above will `raise NotImplementedError`:
```python
    400   return self.get_axis_primitive_batcher(primitive, frame)
    401 msg = "Batching rule for '{}' not implemented"
--> 402 raise NotImplementedError(msg.format(primitive))

NotImplementedError: Batching rule for 'spsolve' not implemented
```