### PR TITLE
Add array_api intersphinx & document jnp.permute_dims

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,6 +85,7 @@ extensions = [
 ]
 
 intersphinx_mapping = {
+    'array_api': ('https://data-apis.org/array-api/2023.12/', None),
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -902,8 +902,31 @@ def transpose(a: ArrayLike, axes: Sequence[int] | None = None) -> Array:
   return lax.transpose(a, axes_)
 
 
-@util.implements(getattr(np, "permute_dims", None))
 def permute_dims(a: ArrayLike, /, axes: tuple[int, ...]) -> Array:
+  """Permute the axes/dimensions of an array.
+
+  JAX implementation of :func:`array_api.permute_dims`.
+
+  Args:
+    a: input array
+    axes: tuple of integers in range ``[0, a.ndim)`` specifying the
+      axes permutation.
+
+  Returns:
+    a copy of ``a`` with axes permuted.
+
+  See also:
+    - :func:`jax.numpy.transpose`
+    - :func:`jax.numpy.matrix_transpose`
+
+  Examples:
+    >>> a = jnp.array([[1, 2, 3],
+    ...                [4, 5, 6]])
+    >>> jnp.permute_dims(a, (1, 0))
+    Array([[1, 4],
+           [2, 5],
+           [3, 6]], dtype=int32)
+  """
   util.check_arraylike("permute_dims", a)
   return lax.transpose(a, axes)
 


### PR DESCRIPTION
Preview: https://jax--23512.org.readthedocs.build/en/23512/_autosummary/jax.numpy.permute_dims.html

In particular, we can construct references like ```:func:`array_api.permute_dims` ```, which will be rendered as [`array_api.permute_dims()`](https://data-apis.org/array-api/2023.12/API_specification/generated/array_api.permute_dims.html#array_api.permute_dims), with hyperlink to the associated array API docs.