### PR TITLE
Add a "broadcasting vmap" helper to custom_batching.

### DIFF
--- a/jax/custom_batching.py
+++ b/jax/custom_batching.py
@@ -15,4 +15,5 @@
 from jax._src.custom_batching import (
   custom_vmap as custom_vmap,
   sequential_vmap as sequential_vmap,
+  broadcasting_vmap as broadcasting_vmap,
 )


### PR DESCRIPTION
It has come up a few times (most recently in https://github.com/google/jax/issues/23624) that the "vectorized" behavior of `pure_callback` and `ffi_call` is confusing. I'm working on improving that, but in the meantime, it seems like it would be useful to provide a `broadcasting_vmap` similar to the `sequential_vmap` helper that we currently have for vmapping with a `lax.map`.