### PR TITLE
Fixed func ref in shared-computation

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -697,7 +697,7 @@ using [jupytext](https://jupytext.readthedocs.io/) by running `jupytext --sync` 
 notebooks; for example:
 
 ```
-pip install jupytext==1.16.0
+pip install jupytext==1.16.4
 jupytext --sync docs/notebooks/thinking_in_jax.ipynb
 ```
 

--- a/docs/sharded-computation.ipynb
+++ b/docs/sharded-computation.ipynb
@@ -360,7 +360,7 @@
     "\n",
     "## 2. Semi-automated sharding with constraints\n",
     "\n",
-    "If you'd like to have some control over the sharding used within a particular computation, JAX offers the {func}`~jax.lax.with_sharding_constraint` function. You can use {func}`jax.lax.with_sharding_constraint` (in place of (func}`jax.device_put()`) together with {func}`jax.jit` for more control over how the compiler constraints how the intermediate values and outputs are distributed.\n",
+    "If you'd like to have some control over the sharding used within a particular computation, JAX offers the {func}`~jax.lax.with_sharding_constraint` function. You can use {func}`jax.lax.with_sharding_constraint` (in place of {func}`jax.device_put()`) together with {func}`jax.jit` for more control over how the compiler constraints how the intermediate values and outputs are distributed.\n",
     "\n",
     "For example, suppose that within `f_contract` above, you'd prefer the output not to be partially-replicated, but rather to be fully sharded across the eight devices:"
    ]

--- a/docs/sharded-computation.md
+++ b/docs/sharded-computation.md
@@ -133,7 +133,7 @@ The result is partially replicated: that is, the first two elements of the array
 
 ## 2. Semi-automated sharding with constraints
 
-If you'd like to have some control over the sharding used within a particular computation, JAX offers the {func}`~jax.lax.with_sharding_constraint` function. You can use {func}`jax.lax.with_sharding_constraint` (in place of (func}`jax.device_put()`) together with {func}`jax.jit` for more control over how the compiler constraints how the intermediate values and outputs are distributed.
+If you'd like to have some control over the sharding used within a particular computation, JAX offers the {func}`~jax.lax.with_sharding_constraint` function. You can use {func}`jax.lax.with_sharding_constraint` (in place of {func}`jax.device_put()`) together with {func}`jax.jit` for more control over how the compiler constraints how the intermediate values and outputs are distributed.
 
 For example, suppose that within `f_contract` above, you'd prefer the output not to be partially-replicated, but rather to be fully sharded across the eight devices:
 


### PR DESCRIPTION
This fixes a typo in the sphinx directive in shared-computation.

<img width="393" alt="Screenshot 2024-09-14 at 3 22 57 PM" src="https://github.com/user-attachments/assets/50798bf4-8d16-4919-8fb7-011e5b518485">

The contributing guide recommended jupytext==1.16.0, but I noticed that all the notebooks seem to be on 1.16.4, so I updated the guide. 