### PR TITLE
DOC: Improve docs for `jax.numpy`: `remainder`, `mod` and `fmod`

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6309,7 +6309,7 @@ class NumpyDocTests(jtu.JaxTestCase):
     unimplemented = ['fromfile', 'fromiter']
     aliases = ['abs', 'acos', 'acosh', 'asin', 'asinh', 'atan', 'atanh', 'atan2',
                'amax', 'amin', 'around', 'bitwise_right_shift', 'degrees', 'divide',
-               'pow', 'radians', 'round_']
+               'mod', 'pow', 'radians', 'round_']
     skip_args_check = ['vsplit', 'hsplit', 'dsplit', 'array_split']
 
     for name in dir(jnp):


### PR DESCRIPTION
Part of #21461 