### PR TITLE
Add config flag to enable/disable remat HLO pass

### DIFF
--- a/jax/_src/compiler.py
+++ b/jax/_src/compiler.py
@@ -53,17 +53,6 @@ _COMPILER_DETAILED_LOGGING_MIN_OPS = config.int_flag(
     ),
 )
 
-_ENABLE_COMPILER_REMAT_OPTIMIZATION_PASS = config.bool_flag(
-    "jax_compiler_enable_remat_pass",
-    config.bool_env('JAX_COMPILER_ENABLE_REMAT_PASS', False),
-    help=(
-      'Config to enable the rematerialization HLO pass. '
-      'Useful to allow XLA to automatically trade off memory and '
-      'compute when encountering OOM errors. However, you are '
-      'likely to get better results manually with jax.checkpoint'
-    )
-)
-
 # The special XLA-AutoFDO profile version that indicates that a profile is not
 # available and retrieval should not be attempted.
 _NO_PROFILE_DONT_RETRIEVE = -1
@@ -211,7 +200,7 @@ def get_compile_options(
     debug_options.xla_llvm_disable_expensive_passes = True
     debug_options.xla_test_all_input_layouts = False
   
-  if not _ENABLE_COMPILER_REMAT_OPTIMIZATION_PASS.value:
+  if not config.enable_remat_opt_pass.value:
     debug_options.xla_disable_hlo_passes = "rematerialization"
 
   # XLA-AutoFDO profile version: precedence order is:

--- a/jax/_src/compiler.py
+++ b/jax/_src/compiler.py
@@ -53,6 +53,17 @@ _COMPILER_DETAILED_LOGGING_MIN_OPS = config.int_flag(
     ),
 )
 
+_ENABLE_COMPILER_REMAT_OPTIMIZATION_PASS = config.bool_flag(
+    "jax_compiler_enable_remat_pass",
+    config.bool_env('JAX_COMPILER_ENABLE_REMAT_PASS', False),
+    help=(
+      'Config to enable the rematerialization HLO pass. '
+      'Useful to allow XLA to automatically trade off memory and '
+      'compute when encountering OOM errors. However, you are '
+      'likely to get better results manually with jax.checkpoint'
+    )
+)
+
 # The special XLA-AutoFDO profile version that indicates that a profile is not
 # available and retrieval should not be attempted.
 _NO_PROFILE_DONT_RETRIEVE = -1
@@ -199,6 +210,9 @@ def get_compile_options(
     debug_options.xla_backend_optimization_level = 0
     debug_options.xla_llvm_disable_expensive_passes = True
     debug_options.xla_test_all_input_layouts = False
+  
+  if not _ENABLE_COMPILER_REMAT_OPTIMIZATION_PASS.value:
+    debug_options.xla_disable_hlo_passes = "rematerialization"
 
   # XLA-AutoFDO profile version: precedence order is:
   # 1. Whatever --jax_xla_profile_version is set to.

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1528,6 +1528,14 @@ remat_opt_barrier = bool_state(
     default=True,
     help=('Enables using optimization-barrier op for lowering remat.'))
 
+enable_remat_opt_pass = bool_state(
+    name='jax_compiler_enable_remat_pass', 
+    default=False, 
+    help=('Config to enable / disable the rematerialization HLO pass. '
+          'Useful to allow XLA to automatically trade off memory and '
+          'compute when encountering OOM errors. However, you are '
+          'likely to get better results manually with jax.checkpoint'))
+
 # TODO(sharadmv,mattjj): set default to True, then remove
 eager_pmap = bool_state(
     name='jax_eager_pmap',

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1530,7 +1530,7 @@ remat_opt_barrier = bool_state(
 
 enable_remat_opt_pass = bool_state(
     name='jax_compiler_enable_remat_pass', 
-    default=False, 
+    default=True, 
     help=('Config to enable / disable the rematerialization HLO pass. '
           'Useful to allow XLA to automatically trade off memory and '
           'compute when encountering OOM errors. However, you are '


### PR DESCRIPTION
The flag --xla_disable_hlo_passes=rematerialization is often passed to XLA during compilation as the currently this pass often makes a poor choice of what to remat. With this patch the remat HLO pass is enabled by default but there is no need to pass --xla_disable_hlo_passes=rematerialization to disable it. Users can use the added config flag instead. 