### PR TITLE
Raise `TypeError` when `None` passed to `jax.numpy.array`

### DIFF
--- a/jax/_src/deprecations.py
+++ b/jax/_src/deprecations.py
@@ -124,7 +124,6 @@ def warn(deprecation_id: str, message: str, stacklevel: int) -> None:
 register('jax-aval-named-shape')
 register('jax-dlpack-import-legacy')
 register("jax-numpy-astype-complex-to-real")
-register("jax-numpy-array-none")
 register('jax-scipy-beta-args')
 register('tracer-hash')
 register('jax-numpy-reshape-newshape')

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -4618,14 +4618,8 @@ def array(object: Any, dtype: DTypeLike | None = None, copy: bool = True,
                     if hasattr(leaf, "__jax_array__") else leaf, object)
   leaves = tree_leaves(object, is_leaf=lambda x: x is None)
   if any(leaf is None for leaf in leaves):
-    # Added Nov 16 2023
-    if deprecations.is_accelerated("jax-numpy-array-none"):
-      raise TypeError("None is not a valid value for jnp.array")
-    warnings.warn(
-      "None encountered in jnp.array(); this is currently treated as NaN. "
-      "In the future this will result in an error.",
-      FutureWarning, stacklevel=2)
-    leaves = tree_leaves(object)
+    raise TypeError("None is not a valid value for jnp.array")
+
   if dtype is None:
     # Use lattice_result_type rather than result_type to avoid canonicalization.
     # Otherwise, weakly-typed inputs would have their dtypes canonicalized.

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3707,9 +3707,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     with self.assertRaisesRegex(OverflowError, "Python int too large.*"):
       jnp.array([0, val])
 
-  def testArrayNoneWarning(self):
+  def testArrayNoneError(self):
     # TODO(jakevdp): make this an error after the deprecation period.
-    with self.assertWarnsRegex(FutureWarning, r"None encountered in jnp.array\(\)"):
+    with self.assertRaisesRegex(TypeError, r"None is not a valid value for jnp.array"):
       jnp.array([0.0, None])
 
   def testIssue121(self):


### PR DESCRIPTION
[Passing `None` to `jax.numpy.array` has been deprecated](https://jax.readthedocs.io/en/latest/changelog.html#jax-0-4-33:~:text=Passing%20None%20to%20jax.array()%20or%20jax.asarray()%2C%20either%20directly%20or%20within%20a%20list%20or%20tuple%2C%20is%20deprecated%20and%20now%20raises%20a%20FutureWarning.%20It%20currently%20is%20converted%20to%20NaN%2C%20and%20in%20the%20future%20will%20raise%20a%20TypeError.) with the PR #18564 in JAX 0.4.21 which was released in December 2023. It's been 9 months since it was deprecated.