### PR TITLE
improve tree mismatch error in tree_map

### DIFF
--- a/jax/_src/export/_export.py
+++ b/jax/_src/export/_export.py
@@ -1247,7 +1247,7 @@ def call(exported: Exported) -> Callable[..., jax.Array]:
           ("\n".join(
              f"   - {shape_poly.args_kwargs_path_to_str(path)} is a {thing1} in the invocation and a "
              f"{thing2} when exported, so {explanation}.\n"
-             for path, thing1, thing2, explanation
+             for path, thing1, thing2, explanation, _, _
              in tree_util.equality_errors(in_args, exp_in_args))))
       raise ValueError(msg)
 

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -368,7 +368,7 @@ def _check_carry_type(name, body_fun, in_carry, out_carry_tree, out_avals):
     else:
       diffs = [f'{component(path)} is a {thing1} but the corresponding component '
                f'of the carry output is a {thing2}, so {explanation}'
-               for path, thing1, thing2, explanation
+               for path, thing1, thing2, explanation, _, _
                in equality_errors(in_carry, out_carry)]
       if len(diffs) == 1:
         differences = f'{diffs[0]}.\n'.capitalize()

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -340,7 +340,30 @@ def tree_map(f: Callable[..., Any],
              is_leaf: Callable[[Any], bool] | None = None) -> Any:
   """Alias of :func:`jax.tree.map`."""
   leaves, treedef = tree_flatten(tree, is_leaf)
-  all_leaves = [leaves] + [treedef.flatten_up_to(r) for r in rest]
+  all_leaves = [leaves]
+  for i, r in enumerate(rest):
+    try:
+      all_leaves.append(treedef.flatten_up_to(r))
+    except ValueError :
+      # check for pytree structure mismatch errors, for a better error message
+      component = lambda p: 'the tree root' if not p else f'the key path {keystr(p)}'
+      errs = list(equality_errors(tree, r))
+      if errs:
+        (path, ty1, ty2, explanation, x1, x2), *_ = errs
+        nargs = '' if len(rest) == 1 else f' applied to {len(rest)+1} tree arguments'
+        first_arg = ' (argument index 0)' if len(rest) > 1 else ''
+        second_arg = (f'the tree at argument index {i+1}' if i > 0 else
+                      'the second tree')
+        s1, s2 = str(x1), str(x2)
+        values = f':\n{s1}\nvs\n{s2}' if max(len(s1), len(s2)) < 100 else '.'
+        msg = (
+            f'in tree_map{nargs}, at {component(path)} the first '
+            f'tree{first_arg} has a {ty1} but {second_arg} has a {ty2}, '
+            f'so {explanation}{values}')
+        if len(errs) > 1:
+          msg += '\n\nThere were other mismatches in these two trees.'
+        raise ValueError(msg) from None
+      raise
   return treedef.unflatten(f(*xs) for xs in zip(*all_leaves))
 
 
@@ -618,7 +641,7 @@ def prefix_errors(prefix_tree: Any, full_tree: Any,
 # equality_errors is not exported
 def equality_errors(
     tree1: Any, tree2: Any, is_leaf: Callable[[Any], bool] | None = None,
-) -> Iterable[tuple[KeyPath, str, str, str]]:
+) -> Iterable[tuple[KeyPath, str, str, str, type, type]]:
   """Helper to describe structural differences between two pytrees.
 
   Args:
@@ -643,8 +666,9 @@ def equality_errors_pytreedef(
   """Like `equality_errors` but invoked on PyTreeDef."""
   # TODO(mattjj): make equality_errors not print type name, avoid metaclass
   leaf = type("LeafMeta", (type,), dict(__repr__=lambda _: "pytree leaf"))("Leaf", (), {})()
-  return equality_errors(tree_unflatten(tree1, [leaf] * tree1.num_leaves),
-                         tree_unflatten(tree2, [leaf] * tree2.num_leaves))
+  return ((path, ty1, ty2, explanation) for path, ty1, ty2, explanation, _, _
+          in equality_errors(tree_unflatten(tree1, [leaf] * tree1.num_leaves),
+                             tree_unflatten(tree2, [leaf] * tree2.num_leaves)))
 
 # TODO(mattjj): maybe share some logic with _prefix_error?
 def _equality_errors(path, t1, t2, is_leaf):
@@ -654,7 +678,8 @@ def _equality_errors(path, t1, t2, is_leaf):
 
   # The trees may disagree because they are different types:
   if type(t1) != type(t2):
-    yield path, str(type(t1)), str(type(t2)), 'their Python types differ'
+    yield path, str(type(t1)), str(type(t2)), 'their Python types differ', \
+        t1, t2
     return  # no more errors to find
 
   # Or they may disagree because their roots have different numbers or keys of
@@ -665,7 +690,7 @@ def _equality_errors(path, t1, t2, is_leaf):
       yield (path,
              f'{type(t1).__name__} of length {len(t1)}',
              f'{type(t2).__name__} of length {len(t2)}',
-             'the lengths do not match')
+             'the lengths do not match', t1, t2)
       return  # no more errors to find
   t1_children, t1_meta = flatten_one_level(t1)
   t2_children, t2_meta = flatten_one_level(t2)
@@ -684,7 +709,8 @@ def _equality_errors(path, t1, t2, is_leaf):
            f'{type(t2)} with {len(t2_children)} child'
            f'{"ren" if len(t2_children) > 1 else ""}',
            'the numbers of children do not match' +
-           (diff and f', with the symmetric difference of key sets: {{{diff}}}')
+           (diff and f', with the symmetric difference of key sets: {{{diff}}}'),
+           t1, t2
            )
     return  # no more errors to find
 
@@ -693,7 +719,7 @@ def _equality_errors(path, t1, t2, is_leaf):
     yield (path,
            f'{type(t1)} with pytree metadata {t1_meta}',
            f'{type(t2)} with pytree metadata {t2_meta}',
-           'the pytree node metadata does not match')
+           'the pytree node metadata does not match', t1, t2)
     return  # no more errors to find
 
   # If the root types and numbers of children agree, there must be a mismatch in


### PR DESCRIPTION
```python
import jax
import jax.numpy as jnp

jax.tree.map(lambda x: x, {'a': {'b': [1,2,3]}}, {'a': {'b': [1,2,3,4]}})
```

Before:
```
ValueError: List arity mismatch: 4 != 3; list: [1, 2, 3, 4].
```

After:
```
ValueError: in tree_map, at the key path ['a']['b'] the first tree has a list of length 3
but the second tree has a list of length 4, so the lengths do not match:
[1, 2, 3]
vs
[1, 2, 3, 4]
```

---

```python
jax.tree.map(lambda x: x, [1,2,3] * 50, [1,2,3,4] * 50)
```

After:
```
ValueError: in tree_map, at the tree root the first tree has a list of length 150
but the second tree has a list of length 200, so the lengths do not match.
```

Intended improvements:
1. show key path
2. show both mismatching subtree values if they're short (rather than just the latter tree's)

TODO (maybe in follow-ups...):
* [ ] validate on dicts, custom pytree nodes, etc
* [ ] tests