### PR TITLE
declare buffer donation and compilation cache support for platform "neuron"

### DIFF
--- a/jax/_src/compilation_cache.py
+++ b/jax/_src/compilation_cache.py
@@ -72,7 +72,7 @@ def is_cache_used(backend: xla_client.Client) -> bool:
       # backend that supports serialization of executables.
       # TODO(skye): add warning when initializing cache on unsupported default
       # platform
-      supported_platforms = ["tpu", "gpu", "cpu"]
+      supported_platforms = ["tpu", "gpu", "cpu", "neuron"]
 
       if not _is_cache_enabled():
         monitoring.record_event('/jax/compilation_cache/task_disabled_cache')

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -951,7 +951,7 @@ class LoweringResult(NamedTuple):
   shape_poly_state: ShapePolyLoweringState
 
 
-_platforms_with_donation = ["cpu", "cuda", "rocm", "tpu"]
+_platforms_with_donation = ["cpu", "cuda", "rocm", "tpu", "neuron"]
 
 
 def add_manual_axes(axis_ctx: sharding_impls.SPMDAxisContext, sharding, ndim):


### PR DESCRIPTION
The AWS Neuron team added JAX support (https://awsdocs-neuron.readthedocs-hosted.com/en/latest/frameworks/jax/index.html) through the PJRT C-API plugin mechanism under the new platform name "neuron". Declaring support for buffer donation as well as compilation cache will bring some performance optimizations to AWS customers using the Trainium/Inferentia ASICs.

original PR: https://github.com/google/jax/pull/23741