### PR TITLE
custom_vjp: don't drop tangents just because they have a different dtype than the primal

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -783,7 +783,7 @@ def _flatten_bwd(in_tree, in_avals, out_trees, *args):
     raise TypeError(msg.format(in_tree2, in_tree)) from None
   results = []
   for kp, a, ct in zip(keypaths, in_avals, cts_in_flat):
-    if ct is zero or a != a.to_tangent_aval():
+    if ct is zero or getattr(a.to_tangent_aval(), 'dtype') == dtypes.float0:
       results.append(Zero(a.to_tangent_aval()))
     elif type(ct) is SymbolicZero:
       if not core.typecompat(a.to_tangent_aval(), a_ := ct.aval):


### PR DESCRIPTION
in custom_vjp, don't drop cotangents produced by the user's rule just because the tangent dtype differs from the primal dtype

instead, drop them when primal_aval.to_tangent_aval().dtype == float0

TODO: don't do that either. we shouldn't drop the user's output on the floor; we should require that their rule produce a value of the correct float0 dtype, or else produce a special symbol that means "zero of whatever type I need" (and that symbol should probably be a None). but i'm not doing that TODO right now...