### PR TITLE
Update a single name to test tooling post move

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -38,7 +38,7 @@ import jax.core as _core
 del _core
 
 # Note: import <name> as <name> is required for names to be exported.
-# See PEP 484 & https://github.com/google/jax/issues/7570
+# See PEP 484 & https://github.com/jax-ml/jax/issues/7570
 
 from jax._src.basearray import Array as Array
 from jax import tree as tree


### PR DESCRIPTION
This renames a single reference from google/jax to jax-ml/jax for the purposes of testing internal CI.