### PR TITLE
[ffi] Support handler bundles in GPU plugin extension

### DIFF
--- a/jaxlib/cuda_plugin_extension.cc
+++ b/jaxlib/cuda_plugin_extension.cc
@@ -38,7 +38,7 @@ namespace xla {
 namespace {
 absl::Status RegisterCustomCallTarget(const PJRT_Api* c_api,
                                       const char* fn_name_c_str,
-                                      size_t fn_name_size, nb::capsule fn,
+                                      size_t fn_name_size, nb::object fn,
                                       int api_version,
                                       XLA_FFI_Handler_Traits traits) {
   if (c_api->extension_start == nullptr) {
@@ -54,6 +54,8 @@ absl::Status RegisterCustomCallTarget(const PJRT_Api* c_api,
   if (next == nullptr) {
     return Unimplemented("The plugin does not have a custom call extension.");
   }
+  PJRT_Gpu_Register_Custom_Call* register_custom_call =
+    reinterpret_cast<const PJRT_Gpu_Custom_Call*>(next)->custom_call;
 
   if (traits != 0) {
     return Unimplemented("The plugin does not support custom call traits.");
@@ -63,14 +65,73 @@ absl::Status RegisterCustomCallTarget(const PJRT_Api* c_api,
   args.struct_size = PJRT_Gpu_Register_Custom_Call_Args_STRUCT_SIZE;
   args.function_name = fn_name_c_str;
   args.function_name_size = fn_name_size;
+
 #if PJRT_API_GPU_EXTENSION_VERSION >= 1
   args.api_version = api_version;
 #endif
-  args.custom_call_function = static_cast<void*>(fn.data());
-  RETURN_STATUS_IF_PJRT_ERROR(
-      reinterpret_cast<const PJRT_Gpu_Custom_Call*>(next)->custom_call(&args),
-      c_api);
+
+  auto as_capsule = [](nb::object obj) -> absl::StatusOr<nb::capsule> {
+    nb::capsule capsule;
+    if (!nb::try_cast<nb::capsule>(obj, capsule)) {
+      return absl::InvalidArgumentError(
+          "Custom call target registration requires handlers as PyCapsules");
+    }
+    return capsule;
+  };
+
+#if PJRT_API_GPU_EXTENSION_VERSION <= 1
+  TF_ASSIGN_OR_RETURN(nb::capsule fn_execute, as_capsule(fn));
+  args.custom_call_function = fn_execute.data();
+  RETURN_STATUS_IF_PJRT_ERROR(register_custom_call(&args), c_api);
   return absl::OkStatus();
+#else
+  args.handler_instantiate = nullptr;
+  args.handler_prepare = nullptr;
+  args.handler_initialize = nullptr;
+  args.handler_execute = nullptr;
+
+  // Register legacy custom call target (untyped void* API).
+  if (api_version == 0) {
+    TF_ASSIGN_OR_RETURN(nb::capsule capsule_execute, as_capsule(fn));
+    args.handler_execute = capsule_execute.data();
+    RETURN_STATUS_IF_PJRT_ERROR(register_custom_call(&args), c_api);
+    return absl::OkStatus();
+  }
+
+  // Register XLA FFI handler (typed API with explicit function signatures).
+  if (api_version == 1) {
+    auto capsule_execute = as_capsule(fn);
+    if (capsule_execute.ok()) {
+      args.handler_execute = capsule_execute->data();
+      RETURN_STATUS_IF_PJRT_ERROR(register_custom_call(&args), c_api);
+      return absl::OkStatus();
+    }
+
+    nb::dict bundle;
+    if (nb::try_cast<nb::dict>(fn, bundle)) {
+      auto handler = [&](const char* name) -> absl::StatusOr<void*> {
+        if (!bundle.contains(name)) return nullptr;
+        TF_ASSIGN_OR_RETURN(nb::capsule capsule, as_capsule(bundle[name]));
+        return capsule.data();
+      };
+
+      TF_ASSIGN_OR_RETURN(args.handler_instantiate, handler("instantiate"));
+      TF_ASSIGN_OR_RETURN(args.handler_prepare, handler("prepare"));
+      TF_ASSIGN_OR_RETURN(args.handler_initialize, handler("initialize"));
+      TF_ASSIGN_OR_RETURN(args.handler_execute, handler("execute"));
+      RETURN_STATUS_IF_PJRT_ERROR(register_custom_call(&args), c_api);
+      return absl::OkStatus();
+    }
+
+    return absl::InvalidArgumentError(
+        "Unsupported custom call target type for api_version=1");
+  }
+
+  return absl::UnimplementedError(absl::StrFormat(
+      "API version %d is not supported by RegisterCustomCallTarget. "
+      "Supported versions are 0 and 1.",
+      api_version));
+#endif
 }
 
 nb::dict Registrations() {
@@ -97,7 +158,7 @@ NB_MODULE(cuda_plugin_extension, m) {
   tsl::ImportNumpy();
   m.def(
       "register_custom_call_target",
-      [](nb::capsule c_api, nb::object fn_name_py, nb::capsule fn,
+      [](nb::capsule c_api, nb::object fn_name_py, nb::object fn,
          nb::str xla_platform_name, int api_version,
          XLA_FFI_Handler_Traits traits) {
         const char* fn_name_c_str;


### PR DESCRIPTION
Currently only the execute handler is supported, this allows all of them to be set, bringing the GPU plugin extensions in sync with https://github.com/openxla/xla/blob/b9fcb2422f5e38ed8aecaec6b604d2fc86755c4d/xla/python/xla_compiler.cc#L306-L308

See also the XLA part of this change: https://github.com/openxla/xla/pull/17422