### PR TITLE
Add random.roberts_sequence.

### DIFF
--- a/docs/jax.random.rst
+++ b/docs/jax.random.rst
@@ -62,6 +62,7 @@ Random Samplers
     rademacher
     randint
     rayleigh
+    roberts_sequence
     t
     triangular
     truncated_normal

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -24,6 +24,7 @@ import warnings
 
 import numpy as np
 
+import jax
 import jax.numpy as jnp
 from jax import lax
 from jax.numpy.linalg import cholesky, svd, eigh
@@ -2677,3 +2678,79 @@ def clone(key):
     >>> assert data == same_data
   """
   return random_clone_p.bind(key)
+
+
+def _newton_raphson(f, x, iters):
+    """Use the Newton-Raphson method to find a root of the given function."""
+
+    def update(x, _):
+        y = x - f(x) / jax.grad(f)(x)
+        return y, None
+
+    x, _ = lax.scan(update, x, length=iters)
+    return x
+
+
+def roberts_sequence(
+  num: int,
+  dim: int,
+  root_iters: int = 10_000,
+  complement_basis: bool = True,
+  key: ArrayLike | None = None,
+  perturb: bool = False,
+  shuffle: bool = False,
+  dtype: DTypeLikeFloat = float,
+):
+  """Returns the Roberts sequence, a low-discrepancy quasi-random sequence:
+
+  Low-discrepancy sequences are useful for quasi-Monte Carlo methods.
+
+  Reference:
+  Martin Roberts. The Unreasonable Effectiveness of Quasirandom Sequences.
+  extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences
+
+  Args:
+    num: Number of points to return.
+    dim: The dimensionality of each point in the sequence.
+    root_iters: Number of iterations to use to find the root.
+    complement_basis: Complement the basis to improve precision, as described
+      in https://www.martysmods.com/a-better-r2-sequence.
+    key: a PRNG key.
+    perturb: Apply a uniformly random perturbation to the entire sequence,
+      followed by modulo 1.
+    shuffle: Shuffle the elements of the sequence before returning them.
+      Warning: This degrades the low-discrepancy property for prefixes of
+      the output sequence.
+    dtype: optional, a float dtype for the returned values (default float64 if
+      jax_enable_x64 is true, otherwise float32).
+
+  Returns:
+    An array of shape (num, dim) containing the sequence.
+  """
+  def f(x):
+      return x ** (dim + 1) - x - 1
+
+  root = _newton_raphson(f, jnp.astype(1.0, dtype), root_iters)
+
+  basis = 1 / root ** (1 + jnp.arange(dim, dtype=dtype))
+
+  if complement_basis:
+    basis = 1 - basis
+
+  n = jnp.arange(num, dtype=dtype)
+  x = n[:, None] * basis[None, :]
+
+  if perturb:
+    if key is None:
+        raise ValueError("key for roberts_sequence cannot be None when perturb=True")
+    key, subkey = split(key)
+    x += uniform(subkey, (dim,), dtype)[None]
+
+  x, _ = jnp.modf(x)
+
+  if shuffle:
+    if key is None:
+        raise ValueError("key for roberts_sequence cannot be None when shuffle=True")
+    x = permutation(key, x)
+
+  return x

--- a/jax/random.py
+++ b/jax/random.py
@@ -242,6 +242,7 @@ from jax._src.random import (
   randint as randint,
   random_gamma_p as random_gamma_p,
   rayleigh as rayleigh,
+  roberts_sequence as roberts_sequence,
   split as split,
   t as t,
   triangular as triangular,

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -740,6 +740,34 @@ class LaxRandomTest(jtu.JaxTestCase):
       self._CheckKolmogorovSmirnovCDF(norms.ravel(), scipy.stats.uniform().cdf)
 
   @jtu.sample_product(
+    num=[1, 4, 16, 64, 256, 1024],
+    dim=[1, 2, 3],
+    perturb=[True, False],
+    shuffle=[True, False],
+    dtype=jtu.dtypes.floating,
+  )
+  def testRobertsSequence(self, num, perturb, shuffle, dim, dtype):
+    key = random.key(0)
+    x = random.roberts_sequence(
+      num=num,
+      dim=dim,
+      perturb=perturb,
+      shuffle=shuffle,
+      key=key,
+      dtype=dtype,
+    )
+    self.assertEqual(x.shape, (num, dim))
+    self.assertEqual(x.dtype, dtype)
+    self.assertTrue((0 <= x).all())
+    self.assertTrue((x <= 1).all())
+
+  def testRobertsSequencePi(self):
+    key = random.key(0)
+    x = random.roberts_sequence(10**5, 2)
+    fraction_inside_ball = (jnp.linalg.norm(x, axis=1) < 1).mean()
+    self.assertAllClose(fraction_inside_ball * 4, jnp.pi, atol=1e-2)
+
+  @jtu.sample_product(
     b=[0.1, 1., 10.],
     dtype=jtu.dtypes.floating,
   )


### PR DESCRIPTION
Adds a function called `roberts_sequence` to [`jax.random`](https://jax.readthedocs.io/en/latest/jax.random.html).

This function implements the [Roberts sequence](https://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/), a [low-discrepancy sequence](https://en.wikipedia.org/wiki/Low-discrepancy_sequence) (i.e. quasi-random sequence).

For context, see https://github.com/jax-ml/jax/issues/8807#issuecomment-2360303757.