### PR TITLE
Simplify extended dtype convert logic

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1608,12 +1608,6 @@ def physical_element_aval(edtype: dtypes.ExtendedDType) -> ShapedArray:
   duck = edtype._rules.physical_element_aval(edtype)  # type: ignore
   return ShapedArray(duck.shape, dtypes.dtype(duck.dtype))
 
-def _short_dtype_name(dtype) -> str:
-  if isinstance(dtype, dtypes.ExtendedDType):
-    return str(dtype)
-  else:
-    return (dtype.name.replace('float', 'f').replace('uint'   , 'u')
-                      .replace('int'  , 'i').replace('complex', 'c'))
 
 def _dtype_object(dtype):
   return dtype if isinstance(dtype, dtypes.ExtendedDType) else np.dtype(dtype)
@@ -1672,7 +1666,7 @@ class UnshapedArray(AbstractValue):
       raise TypeError(self, other)
 
   def str_short(self, short_dtypes=False) -> str:
-    return _short_dtype_name(self.dtype) if short_dtypes else self.dtype.name
+    return dtypes.short_dtype_name(self.dtype) if short_dtypes else self.dtype.name
 
   def strip_weak_type(self):
     """Returns a copy of the aval with weak_type=False."""
@@ -1811,7 +1805,7 @@ class ShapedArray(UnshapedArray):
       raise TypeError(self, other)
 
   def str_short(self, short_dtypes=False):
-    dt_str =  _short_dtype_name(self.dtype) if short_dtypes else self.dtype.name
+    dt_str =  dtypes.short_dtype_name(self.dtype) if short_dtypes else self.dtype.name
     dt_str = dt_str.replace('void', 'float0')
     shapestr = ','.join(map(str, self.shape))
     if hasattr(self, 'sharding'):
@@ -1872,7 +1866,7 @@ class ConcreteArray(ShapedArray):
       raise TypeError(self, other)
 
   def str_short(self, short_dtypes=False) -> str:
-    dt_str =  _short_dtype_name(self.dtype) if short_dtypes else self.dtype.name
+    dt_str = dtypes.short_dtype_name(self.dtype) if short_dtypes else self.dtype.name
     return f'{self.val}, dtype={dt_str}'
 
   _bool    = partialmethod(_forward_to_value, bool)
@@ -1922,7 +1916,7 @@ class DShapedArray(UnshapedArray):
   def str_short(self, short_dtypes=False) -> str:
     del short_dtypes  # ignored
     shape = f'{",".join(str(d) for d in self.shape)}' if self.shape else ''
-    dtype = _short_dtype_name(self.dtype)
+    dtype = dtypes.short_dtype_name(self.dtype)
     return f'{dtype}[{shape}]'
   __str__ = __repr__ = str_short
 
@@ -1989,7 +1983,7 @@ class DArray:
       # special-case scalar bints
       return f'{int(self._data)}{{≤{self.dtype.bound}}}'
 
-    dtypestr = _short_dtype_name(self._aval.dtype)
+    dtypestr = dtypes.short_dtype_name(self._aval.dtype)
     shapestr = ','.join(map(str, self.shape))
     data = self.data
     return f'{dtypestr}[{shapestr}] with value: {data}'
@@ -3203,7 +3197,7 @@ def pp_var(v: Var | Literal, context: JaxprPpContext) -> str:
 def pp_aval(a: AbstractValue, context: JaxprPpContext) -> str:
   if isinstance(a, DShapedArray):
     shape = [pp_var(d, context) if type(d) is Var else str(d) for d in a.shape]
-    dtype = _short_dtype_name(a.dtype)
+    dtype = dtypes.short_dtype_name(a.dtype)
     return f'{dtype}[{",".join(shape)}]'
   else:
     return a.str_short(short_dtypes=True)

--- a/jax/_src/pallas/core.py
+++ b/jax/_src/pallas/core.py
@@ -149,11 +149,8 @@ class ShapedArrayWithMemorySpace(jax_core.ShapedArray):
     raise NotImplementedError
 
   def str_short(self, short_dtypes=False):
-    dt_str = (
-        jax_core._short_dtype_name(self.dtype)
-        if short_dtypes
-        else self.dtype.name
-    )
+    dt_str = \
+        dtypes.short_dtype_name(self.dtype) if short_dtypes else self.dtype.name
     dt_str = dt_str.replace("void", "float0")
     shapestr = ",".join(map(str, self.shape))
     if hasattr(self, "sharding"):

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -321,6 +321,7 @@ def base_arr_shape_to_keys_shape(impl, base_arr_shape):
 
 
 class KeyTyRules:
+  allow_conversion: bool = False
 
   @staticmethod
   def full(shape, fill_value, dtype):
@@ -424,14 +425,6 @@ class KeyTyRules:
   @staticmethod
   def zero(_):
     return np.zeros((), dtypes.float0)
-
-  @staticmethod
-  def convert_from(key_dtype, other_dtype) -> bool:
-    return False
-
-  @staticmethod
-  def convert_to(other_dtype, key_dtype) -> bool:
-    return False
 
 
 class KeyTy(dtypes.ExtendedDType):

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1549,6 +1549,8 @@ tf_not_yet_impl = [
     "ragged_dot",
     "cholesky_update",
     "symmetric_update",
+    "from_edtype",
+    "to_edtype",
     # Pallas TPU primitives
     "bitcast",
     "repeat",

--- a/tests/dynamic_api_test.py
+++ b/tests/dynamic_api_test.py
@@ -1486,6 +1486,9 @@ class DynamicShapeExecutionTest(jtu.JaxTestCase):
                  jax_traceback_filtering='off')
 class JumbleTest(jtu.JaxTestCase):
 
+  def setUp(self):
+    if jax.config.x64_enabled: raise unittest.SkipTest()
+
   @parameterized.parameters((True,), (False,))
   def test_internal_jumble(self, disable_jit):
     with jax.disable_jit(disable_jit):


### PR DESCRIPTION
diffbase: #23812

TODO:
- [x] add test coverage for the code added here

Previously, the idea was that we would use the `convert_element_type` primitive to cast to/from extended dtypes. Extended dtype rules specified `convert_from(dtype1, dtype2) -> bool` and `convert_to(dtype1, dtype2) -> bool` functions. They were meant to do something like indicate whether a convert_element_type was legal. But I'm not sure if they really made sense. The implementation was certainly buggy for non-scalar representation types
(physical element types).

This PR simplifies and fixes things:
1. Instead of overloading the `convert_element_type_p` primitive with more cases involving casts to/from extended dtypes, let's just have distinct `to_edtype_p` and `from_edtype_p` primitives, which can be much simpler. We still reuse the `jax.lax.convert_element_type` API function, so there's no API change to the few existing users who know about this stuff.
2. Instead of extended dtype rules including `convert_from`/`convert_to` functions with questionable semantics, let's only allow casts to/from the representation type, which is already specified by the rules' `physical_element_aval`. (Indeed that should be roughly _all_ we need, and this PR is just one step towards realizing that goal.) We still have a boolean `allow_conversion` on extended dtype rules just so we can handle the PRNGKey case, where we don't want to allow any casts.
3. Fix the conversion logic to handle non-scalar representation types (physical element types).