### PR TITLE
Remove warning filters from pyproject.toml, add local warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,23 +54,12 @@ markers = [
 ]
 filterwarnings = [
     "error",
-    "default:Error (reading|writing) persistent compilation cache entry for 'jit_equal'",
-    "default:Error (reading|writing) persistent compilation cache entry for 'jit__lambda_'",
-    "default:jax.extend.mlir.dialects.mhlo is deprecated.*:DeprecationWarning",
 
     # TODO(jakevdp): remove when array_api_tests stabilize
     "default:.*not machine-readable.*:UserWarning",
     "default:Special cases found for .* but none were parsed.*:UserWarning",
     "default:.*is not JSON-serializable. Using the repr instead.*:UserWarning",
     "default:The .* method is good for exploring strategies.*",
-
-    # These are transitive warnings coming from TensorFlow dependencies.
-    # TODO(slebedev): Remove once we bump the minimum TensorFlow version.
-    "default:The key path API is deprecated .*",
-    "default:jax.xla_computation is deprecated.*:DeprecationWarning",
-
-    # TODO(slebedev): Remove once we drop the legacy DLPack import path.
-    "default:.*from_dlpack with a DLPack tensor is deprecated.*:DeprecationWarning",
 ]
 doctest_optionflags = [
     "NUMBER",

--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -221,6 +221,8 @@ class DLPackTest(jtu.JaxTestCase):
     x_np = np.from_dlpack(x_jax)
     self.assertAllClose(x_np, x_jax)
 
+  @jtu.ignore_warning(message="Calling from_dlpack.*",
+                      category=DeprecationWarning)
   def testNondefaultLayout(self):
     # Generate numpy array with nonstandard layout
     a = np.arange(4).reshape(2, 2)

--- a/tests/compilation_cache_test.py
+++ b/tests/compilation_cache_test.py
@@ -243,6 +243,7 @@ class CompilationCacheTest(CompilationCacheTestCase):
       mock.patch.object(cc._get_cache(backend).__class__, "put") as mock_put,
       warnings.catch_warnings(record=True) as w,
     ):
+      warnings.simplefilter("always")
       mock_put.side_effect = RuntimeError("test error")
       self.assertEqual(f(2).item(), 4)
       if len(w) != 1:
@@ -265,6 +266,7 @@ class CompilationCacheTest(CompilationCacheTestCase):
       mock.patch.object(cc._get_cache(backend).__class__, "get") as mock_get,
       warnings.catch_warnings(record=True) as w,
     ):
+      warnings.simplefilter("always")
       mock_get.side_effect = RuntimeError("test error")
       # Calling assertEqual with the jitted f will generate two PJIT
       # executables: Equal and the lambda function itself.

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -1572,6 +1572,10 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       category=RuntimeWarning,
       message="One or more sample arguments is too small; all returned values will be NaN"
   )
+  @jtu.ignore_warning(
+      category=RuntimeWarning,
+      message="All axis-slices of one or more sample arguments are too small",
+  )
   def testMode(self, shape, dtype, axis, contains_nans, keepdims):
     if scipy_version < (1, 9, 0) and keepdims != True:
       self.skipTest("scipy < 1.9.0 only support keepdims == True")


### PR DESCRIPTION
suppressions.

We want to support running Bazel tests with PYTHONWARNINGS=error. In preparation for that change, move warning suppressions from pyproject.toml into the individual test cases that generate them, which is a reasonable cleanup anyway.