### PR TITLE
Fix stdout buffer error in JAX UT api_test.py

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -10883,6 +10883,8 @@ class CleanupTest(jtu.JaxTestCase):
 class EnvironmentInfoTest(jtu.JaxTestCase):
   @parameterized.parameters([True, False])
   def test_print_environment_info(self, return_string):
+    # Flush stdout buffer before checking.
+    sys.stdout.flush()
     with jtu.capture_stdout() as stdout:
       result = jax.print_environment_info(return_string=return_string)
     if return_string:


### PR DESCRIPTION
This PR is to avoid stdout buffer error in `EnvironmentInfoTest.test_print_environment_info0` of JAX UT `api_test.py`. This error will be triggered while running lots of UT in sequence.

Error msg:
```
======================================================================
FAIL: test_print_environment_info0 (True) (__main__.EnvironmentInfoTest)
EnvironmentInfoTest.test_print_environment_info0 (True)
test_print_environment_info(True)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/sdp/miniforge3/envs/xla_ww35.5_driver_950_13_base_2024_2_1_100_04f9967/lib/python3.11/site-packages/absl/testing/parameterized.py", line 323, in bound_param_test
    return test_method(self, testcase_params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sdp/jenkins_workspace/workspace/XLA_weekly_2@5/dl_automation_repo/openXLA/jax/tests/api_test.py", line 10693, in test_print_environment_info
    self.assertEmpty(stdout())
AssertionError: "2.7177599838802657\n-0.9899924966004454\n-0.9899924966004454\n2.7177599838802657\n2.979984993200891\n-0.9899924966004454\n-0.1411200080598672\n0.9899924966004454\n0.1411200080598672\n2.0\n1.0\n{'hi': 2.7177599838802657, 'there': [3.0, 0.2822400161197344]}\n{'hi': 2.979984993200891, 'there': [1.0, -1.9799849932008908]}\n[0. 1. 2.]\n[1. 2. 3.]\n{ lambda a:float64[] .\n  let b:float64[] = mul 2.0 a\n  in ( b ) }\n(float64[]) -> (float64[])\n{ lambda  .\n  let \n  in ( 4.0 ) }\n{ lambda  .\n  let a:float64[] = mul 2.0 2.0\n  in ( a ) }\ntracing!\n-0.09224219304455371\n-0.21467624978307004\n6.0\n0.2822400161197344\n0.2822400161197344\ntracing!\n2.7177599838802657\n2.979984993200891\n[ 0.         -0.68294197  0.18140515]\n2.7177599838802657\n2.979984993200891\n0.1411200080598672 0.1411200080598672\n-0.9899924966004454 -0.9899924966004454\n2.7177599838802657 2.979984993200891\n-0.7077524804807109 -2.121105001260758\n(-0.9899924966004454,) -0.9899924966004454\n2.979984993200891\n1.1176619927957037\n3\n2.0\n[2. 3. 4.]\n2\n3.14\n3.14\n2.0\n" has length of 995.

----------------------------------------------------------------------
Ran 804 tests in 117.619s

FAILED (failures=1, skipped=87)
[0 1]
[0 1]
```