### PR TITLE
Fix `clean_up_dead_vars` when `jax_dynamic_shapes` is `True`

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -3393,8 +3393,22 @@ def last_used(jaxpr: Jaxpr) -> dict[Var, JaxprEqn | None]:
   """Returns a mapping from every var in jaxpr to what equation uses it last."""
   last_used: dict[Var, JaxprEqn | None] = {
       v: None for v in jaxpr.outvars if not isinstance(v, Literal)}
+  for out in jaxpr.outvars:
+    for elem in out.aval.shape:
+      if not isinstance(elem, Literal):
+        last_used[elem] = None
+
   for eqn in reversed(jaxpr.eqns):
+    for v in eqn.outvars:
+      for elem in v.aval.shape:
+        if not isinstance(elem, Literal) and elem not in last_used:
+          last_used[elem] = eqn
+
     for v in eqn.invars:
+      for elem in v.aval.shape:
+        if not isinstance(elem, Literal) and elem not in last_used:
+          last_used[elem] = eqn
+
       if not isinstance(v, Literal) and v not in last_used:
         last_used[v] = eqn
   return last_used

--- a/tests/dynamic_api_test.py
+++ b/tests/dynamic_api_test.py
@@ -1756,6 +1756,24 @@ class JumbleTest(jtu.JaxTestCase):
       self.assertRegex(str(result_jumble.aval), regex)
       self.assertAllClose(result_jumble.data.shape, (3, 512, 128))
 
+@jtu.with_config(jax_dynamic_shapes=True)
+class TestCleanUpDeadVariables(jtu.JaxTestCase):
+
+  def test_jaxpr_generation(self):
+
+    @jax.jit
+    def add_ones_dynamic(size):
+      a = jnp.ones(size)
+      b = jnp.ones(size)
+      return a + b
+
+    # Even though the program is not a valid HLO program
+    # it shouldn't trigger the KeyError in lowering.
+    msg = 'can.t be translated to XLA HLO'
+    with self.assertRaisesRegex(Exception, msg):
+      add_ones_dynamic(1)
+
+
 def jumble_map(f):
   def mapped(*jumbles):
     return jax.vmap(f, in_axes=batching.jumble_axis, out_axes=batching.jumble_axis,


### PR DESCRIPTION
Fixes #18936.

When compiling the following program:

```python
import jax

jax.config.update("jax_enable_x64", True)
jax.config.update("jax_platform_name", "cpu")
jax.config.update("jax_dynamic_shapes", True)

@jax.jit
def f(s):
    a = jax.numpy.ones(s)
    b = jax.numpy.ones(s)
    return a + b

print(f(1))
```

An exception is triggered during the lowering:

```
Traceback (most recent call last):
  File "/home/ubuntu/code/jax/../catalyst/test.py", line 13, in <module>
    print(f(1))
  File "/home/ubuntu/code/jax/jax/_src/traceback_util.py", line 180, in reraise_with_filtered_traceback
    return fun(*args, **kwargs)
  File "/home/ubuntu/code/jax/jax/_src/pjit.py", line 356, in cache_miss
    outs, out_flat, out_tree, args_flat, jaxpr, attrs_tracked = _python_pjit_helper(
  File "/home/ubuntu/code/jax/jax/_src/pjit.py", line 189, in _python_pjit_helper
    out_flat = pjit_p.bind(*args_flat, **p.params)
  File "/home/ubuntu/code/jax/jax/_src/core.py", line 2787, in bind
    return self.bind_with_trace(top_trace, args, params)
  File "/home/ubuntu/code/jax/jax/_src/core.py", line 442, in bind_with_trace
    out = trace.process_primitive(self, map(trace.full_raise, args), params)
  File "/home/ubuntu/code/jax/jax/_src/core.py", line 948, in process_primitive
    return primitive.impl(*tracers, **params)
  File "/home/ubuntu/code/jax/jax/_src/pjit.py", line 1759, in _pjit_call_impl
    return xc._xla.pjit(
  File "/home/ubuntu/code/jax/jax/_src/pjit.py", line 1727, in call_impl_cache_miss
    out_flat, compiled = _pjit_call_impl_python(
  File "/home/ubuntu/code/jax/jax/_src/pjit.py", line 1649, in _pjit_call_impl_python
    compiled = _resolve_and_lower(
  File "/home/ubuntu/code/jax/jax/_src/pjit.py", line 1616, in _resolve_and_lower
    lowered = _pjit_lower(
  File "/home/ubuntu/code/jax/jax/_src/pjit.py", line 1768, in _pjit_lower
    return _pjit_lower_cached(*args, **kwargs)
  File "/home/ubuntu/code/jax/jax/_src/pjit.py", line 1789, in _pjit_lower_cached
    return pxla.lower_sharding_computation(
  File "/home/ubuntu/code/jax/jax/_src/profiler.py", line 333, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/code/jax/jax/_src/interpreters/pxla.py", line 2232, in lower_sharding_computation
    nreps, tuple_args, shape_poly_state) = _cached_lowering_to_hlo(
  File "/home/ubuntu/code/jax/jax/_src/interpreters/pxla.py", line 1952, in _cached_lowering_to_hlo
    lowering_result = mlir.lower_jaxpr_to_module(
  File "/home/ubuntu/code/jax/jax/_src/interpreters/mlir.py", line 1132, in lower_jaxpr_to_module
    lower_jaxpr_to_fun(
  File "/home/ubuntu/code/jax/jax/_src/interpreters/mlir.py", line 1590, in lower_jaxpr_to_fun
    out_vals, tokens_out = jaxpr_subcomp(
  File "/home/ubuntu/code/jax/jax/_src/interpreters/mlir.py", line 1799, in jaxpr_subcomp
    axis_size_env = {d: read(d)
  File "/home/ubuntu/code/jax/jax/_src/interpreters/mlir.py", line 1799, in <dictcomp>
    axis_size_env = {d: read(d)
  File "/home/ubuntu/code/jax/jax/_src/interpreters/mlir.py", line 1720, in read
    return env[v]
KeyError: Var(id=139995609458928):int64[]

```

This is because an equation was incorrectly labeled as a variable's last use in these methods:

```python
def last_used(jaxpr: Jaxpr) -> dict[Var, JaxprEqn | None]:
  """Returns a mapping from every var in jaxpr to what equation uses it last."""
  last_used: dict[Var, JaxprEqn | None] = {
      v: None for v in jaxpr.outvars if not isinstance(v, Literal)}
  for eqn in reversed(jaxpr.eqns):
    for v in eqn.invars:
      if not isinstance(v, Literal) and v not in last_used:
        last_used[v] = eqn
  return last_used

def clean_up_dead_vars(eqn: JaxprEqn, env: dict[Var, Any],
                       last_used: dict[Var, JaxprEqn | None]):
  """Remove all eqn.invars from env if eqn is the last time they were used."""
  for v in {v for v in eqn.invars if not isinstance(v, Literal)}:
    if last_used[v] is eqn:
      # Delete ref to variable when it is no longer needed by next equations.
      del env[v]
```

When `jax_dynamic_shapes` is True, tracers may be used as types in `Var`. So we need to check the shape of all input and output variables in JAXPR's variables.

With these changes, we check for variables in the type of the JAXPR variables as well.