### PR TITLE
Do not attempt checking dynamic dimensions values

### DIFF
--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -1539,11 +1539,12 @@ def _gather_shape_rule(operand, indices, *, dimension_numbers,
     slice_size = slice_sizes[i]
     corresponding_input_size = operand.shape[i]
 
-    if not (slice_size >= 0 and
-            corresponding_input_size >= slice_size):
-      raise TypeError(f"Slice size at index {i} in gather op is out of range, "
-                      f"must be within [0, {corresponding_input_size} + 1), "
-                      f"got {slice_size}.")
+    if core.is_constant_dim(corresponding_input_size):
+      if not (slice_size >= 0 and
+              corresponding_input_size >= slice_size):
+        raise TypeError(f"Slice size at index {i} in gather op is out of range, "
+                        f"must be within [0, {corresponding_input_size} + 1), "
+                        f"got {slice_size}.")
 
   for i in range(len(collapsed_slice_dims)):
     bound = slice_sizes[collapsed_slice_dims[i]]

--- a/tests/dynamic_api_test.py
+++ b/tests/dynamic_api_test.py
@@ -1756,6 +1756,20 @@ class JumbleTest(jtu.JaxTestCase):
       self.assertRegex(str(result_jumble.aval), regex)
       self.assertAllClose(result_jumble.data.shape, (3, 512, 128))
 
+@jtu.with_config(jax_dynamic_shapes=True)
+class TestGatherDynamic(jtu.JaxTestCase):
+
+  def test_gather_dynamic(self):
+
+    @jax.jit
+    def index(sz, idx):
+      r = jnp.ones((sz, 3, sz + 1), dtype=int)
+      return r[idx, 2, idx]
+
+    with self.assertRaises(KeyError):
+      index(1, 1)
+
+
 def jumble_map(f):
   def mapped(*jumbles):
     return jax.vmap(f, in_axes=batching.jumble_axis, out_axes=batching.jumble_axis,


### PR DESCRIPTION
Continuation of PR #19083 

In this PR we suggest a fix which would allow lowering of gather primitive when dynamic dimensions are in use. The changes are quite obvious: we check the dimensions only if they are constant. Variable dimensions are assumed to be checked in the runtime.

A test was added, but once this error is fixed, then it bumps into error fixed by #23877 . Happy to make changes to the test. Thanks!