### PR TITLE
Deprecate the `vectorized` argument to pure_callback and ffi_call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * `jax.lib.xla_client.Device` is deprecated; use `jax.Device` instead.
   * `jax.lib.xla_client.XlaRuntimeError` has been deprecated. Use
     `jax.errors.JaxRuntimeError` instead.
+  * The default behavior of {func}`jax.pure_callback` and
+    {func}`jax.extend.ffi.ffi_call` under `vmap` has been deprecated and so has
+    the `vectorized` parameter to those functions. The `vmap_method` parameter
+    should be used instead for better defined behavior. See the discussion in
+    {jax-issue}`#23881` for more details.
 
 * Deletion:
   * `jax.xla_computation` is deleted. It's been 3 months since it's deprecation

--- a/docs/ffi.ipynb
+++ b/docs/ffi.ipynb
@@ -303,9 +303,9 @@
     "    # type (which corresponds to numpy's `float32` type), and it must be a\n",
     "    # static parameter (i.e. not a JAX array).\n",
     "    eps=np.float32(eps),\n",
-    "    # The `vectorized` parameter controls this function's behavior under `vmap`\n",
+    "    # The `vmap_method` parameter controls this function's behavior under `vmap`\n",
     "    # as discussed below.\n",
-    "    vectorized=True,\n",
+    "    vmap_method=\"broadcast_fullrank\",\n",
     "  )\n",
     "\n",
     "\n",
@@ -325,7 +325,7 @@
     "Any attributes (defined using `Attr` in the C++ wrapper above) should be passed as keyword arguments to {func}`~jax.extend.ffi.ffi_call`.\n",
     "Note that we explicitly cast `eps` to `np.float32` because our FFI library expects a C `float`, and we can't use `jax.numpy` here, because these parameters must be static arguments.\n",
     "\n",
-    "The `vectorized` argument to {func}`~jax.extend.ffi.ffi_call` defines how this FFI call interacts with {func}`~jax.vmap` as described next.\n",
+    "The `vmap_method` argument to {func}`~jax.extend.ffi.ffi_call` defines how this FFI call interacts with {func}`~jax.vmap` as described next.\n",
     "\n",
     "```{tip}\n",
     "If you are familiar with the earlier \"custom call\" interface, you might be surprised that we're not passing the problem dimensions as parameters (batch size, etc.) to {func}`~jax.extend.ffi.ffi_call`.\n",
@@ -336,19 +336,29 @@
     "(ffi-call-vmap)=\n",
     "### Batching with `vmap`\n",
     "\n",
-    "All uses of {func}`~jax.extend.ffi.ffi_call` support {func}`~jax.vmap` out of the box, but this implementation won't necessarily be very efficient.\n",
-    "By default, when `vmap`ped, an `ffi_call` will be rewritten as a {func}`~jax.lax.scan` with the `ffi_call` in the body.\n",
-    "This default implementation is general purpose, but it doesn't parallelize very well.\n",
-    "But, many FFI calls provide more efficient batching behavior and, in some simple cases, the `vectorized` parameter to {func}`~jax.extend.ffi.ffi_call` can be used to expose a better implementation.\n",
+    "{func}`~jax.extend.ffi.ffi_call` supports some simple {func}`~jax.vmap` semantics out of the box using the `vmap_method` parameter.\n",
+    "The docs for {func}`~jax.pure_callback` provide more details about the `vmap_method` parameter, and the same behavior applies to {func}`~jax.extend.ffi.ffi_call`.\n",
     "\n",
-    "The specific assumption required to use the `vectorized` parameter is that all leading dimensions of the inputs should be treated as batch axes.\n",
+    "The simplest `vmap_method` is `\"sequential\"`.\n",
+    "In this case, when `vmap`ped, an `ffi_call` will be rewritten as a {func}`~jax.lax.scan` with the `ffi_call` in the body.\n",
+    "This implementation is general purpose, but it doesn't parallelize very well.\n",
+    "Many FFI calls provide more efficient batching behavior and, in some simple cases, the `\"broadcast\"` or `\"broadcast_fullrank\"` methods can be used to expose a better implementation.\n",
+    "\n",
+    "In this case, since we only have one input argument, `\"broadcast\"` and `\"broadcast_fullrank\"` actually have the same behavior.\n",
+    "The specific assumption required to use these methods is that the foreign function knows how to handle batch dimensions.\n",
     "Another way of saying this is that the result of calling `ffi_call` on the batched inputs is assumed to be equal to stacking the repeated application of `ffi_call` to each element in the batched input, roughly:\n",
     "\n",
     "```python\n",
     "ffi_call(xs) == jnp.stack([ffi_call(x) for x in xs])\n",
     "```\n",
     "\n",
-    "Our implementation of `rms_norm` has the appropriate semantics, and it supports `vmap` with `vectorized=True` out of the box:"
+    "```{tip}\n",
+    "Note that things get a bit more complicated when we have multiple input arguments.\n",
+    "For simplicity, we will use the `\"broadcast_fullrank\"` throughout this tutorial, which guarantees that all inputs will be broadcasted to have the same batch dimensions, but it would also be possible to implement a foreign function to handle the `\"broadcast\"` method.\n",
+    "The documentation for {func}`~jax.pure_callback` includes some examples of this\n",
+    "```\n",
+    "\n",
+    "Our implementation of `rms_norm` has the appropriate semantics, and it supports `vmap` with `vmap_method=\"broadcast_fullrank\"` out of the box:"
    ]
   },
   {
@@ -380,7 +390,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If `vectorized` is `False` or omitted, `vmap`ping a `ffi_call` will fall back on a {func}`jax.lax.scan` with the `ffi_call` in the body:"
+    "Using `vmap_method=\"sequential\"`, `vmap`ping a `ffi_call` will fall back on a {func}`jax.lax.scan` with the `ffi_call` in the body:"
    ]
   },
   {
@@ -389,24 +399,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def rms_norm_not_vectorized(x, eps=1e-5):\n",
+    "def rms_norm_sequential(x, eps=1e-5):\n",
     "  return jex.ffi.ffi_call(\n",
     "    \"rms_norm\",\n",
     "    jax.ShapeDtypeStruct(x.shape, x.dtype),\n",
     "    x,\n",
     "    eps=np.float32(eps),\n",
-    "    vectorized=False,  # This is the default behavior\n",
+    "    vmap_method=\"sequential\",\n",
     "  )\n",
     "\n",
     "\n",
-    "jax.make_jaxpr(jax.vmap(rms_norm_not_vectorized))(x)"
+    "jax.make_jaxpr(jax.vmap(rms_norm_sequential))(x)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If your foreign function provides an efficient batching rule that isn't supported by this simple `vectorized` parameter, it might also be possible to define more flexible custom `vmap` rules using the experimental `custom_vmap` interface, but it's worth also opening an issue describing your use case on [the JAX issue tracker](https://github.com/jax-ml/jax/issues)."
+    "If your foreign function provides an efficient batching rule that isn't supported by this simple `vmap_method` parameter, it might also be possible to define more flexible custom `vmap` rules using the experimental `custom_vmap` interface, but it's worth also opening an issue describing your use case on [the JAX issue tracker](https://github.com/jax-ml/jax/issues)."
    ]
   },
   {
@@ -454,7 +464,7 @@
     "    ),\n",
     "    x,\n",
     "    eps=np.float32(eps),\n",
-    "    vectorized=True,\n",
+    "    vmap_method=\"broadcast_fullrank\",\n",
     "  )\n",
     "  return y, (res, x)\n",
     "\n",
@@ -471,7 +481,7 @@
     "      res,\n",
     "      x,\n",
     "      ct,\n",
-    "      vectorized=True,\n",
+    "    vmap_method=\"broadcast_fullrank\",\n",
     "    ),\n",
     "  )\n",
     "\n",
@@ -561,7 +571,7 @@
     "      out_type,\n",
     "      x,\n",
     "      eps=np.float32(eps),\n",
-    "      vectorized=True,\n",
+    "      vmap_method=\"broadcast_fullrank\",\n",
     "    )\n",
     "\n",
     "  return jax.lax.platform_dependent(x, cpu=impl(\"rms_norm\"), cuda=impl(\"rms_norm_cuda\"))\n",

--- a/examples/ffi/src/jax_ffi_example/rms_norm.py
+++ b/examples/ffi/src/jax_ffi_example/rms_norm.py
@@ -60,8 +60,7 @@ def rms_norm(x, eps=1e-5):
     # type (which corresponds to numpy's `float32` type), and it must be a
     # static parameter (i.e. not a JAX array).
     eps=np.float32(eps),
-    # The `vectorized` parameter controls this function's behavior under `vmap`.
-    vectorized=True,
+    vmap_method="broadcast_fullrank",
   )
 
 
@@ -74,7 +73,7 @@ def rms_norm_fwd(x, eps=1e-5):
     ),
     x,
     eps=np.float32(eps),
-    vectorized=True,
+    vmap_method="broadcast_fullrank",
   )
   return y, (res, x)
 
@@ -91,7 +90,7 @@ def rms_norm_bwd(eps, res, ct):
       res,
       x,
       ct,
-      vectorized=True,
+      vmap_method="broadcast_fullrank",
     ),
   )
 

--- a/jax/_src/extend/ffi.py
+++ b/jax/_src/extend/ffi.py
@@ -23,6 +23,7 @@ from typing import Any
 import numpy as np
 
 from jax._src import core
+from jax._src import deprecations
 from jax._src import dispatch
 from jax._src import effects
 from jax._src import util
@@ -34,7 +35,8 @@ from jax._src.layout import DeviceLocalLayout
 from jax._src.lib import jaxlib
 from jax._src.lib import xla_client
 from jax._src.lib.mlir import ir
-from jax._src.typing import Array, ArrayLike, DuckTypedArray, Shape
+from jax._src.typing import (Array, ArrayLike, DeprecatedArg, DuckTypedArray,
+                             Shape)
 
 map, unsafe_map = util.safe_map, map
 FfiLayoutOptions = Sequence[int] | DeviceLocalLayout | None
@@ -199,23 +201,22 @@ def ffi_call(
     target_name: str,
     result_shape_dtypes: ResultMetadata | Sequence[ResultMetadata],
     *args: ArrayLike,
-    vectorized: bool = False,
     has_side_effect: bool = False,
+    vmap_method: str | None = None,
+    vectorized: bool | DeprecatedArg = DeprecatedArg(),
     **kwargs: Any,
 ) -> Array | list[Array]:
   """Call a foreign function interface (FFI) target.
 
   Like :func:`~jax.pure_callback`, the behavior of ``ffi_call`` under
-  :func:`~jax.vmap` depends on the value of ``vectorized``. When ``vectorized``
-  is ``True``, the FFI target is assumed to satisfy: ``ffi_call(xs) ==
-  jnp.stack([ffi_call(x) for x in xs])``. In other words, calling the FFI target
-  with an extra leading dimension should return the same result as calling it
-  within a loop and stacking along the zeroth axis. Therefore, the FFI target
-  will be called directly on batched inputs (where the batch axes are the
-  leading dimensions). Additionally, the callbacks should return outputs that
-  have corresponding leading batch axes. If ``vectorized`` is ``False`` (the
-  default behavior), transforming this ``ffi_call`` under :func:`~jax.vmap` will
-  result in a :func:`~jax.lax.scan` with the ``ffi_call`` in the body.
+  :func:`~jax.vmap` depends on the value of ``vmap_method``. See the
+  :func:`~jax.pure_callback` documenation for more details about the allowed
+  values and examples of their behavior.
+
+  The current default behavior is to use ``vmap_method="sequential"`` when
+  not specified, but this behavior is deprecated, and in the future, the
+  default will be to raise a ``NotImplementedError`` unless ``vmap_method`` is
+  explicitly specified.
 
   Args:
     target_name: the name of the XLA FFI custom call target that was registered
@@ -226,11 +227,11 @@ def ffi_call(
       used to define the elements of ``result_shape_dtypes``.
       ``jax.core.abstract_token`` may be used to represent a token-typed output.
     *args: the arguments passed to the custom call.
-    vectorized: boolean specifying whether the FFI call can operate in a
-      vectorized manner, as described above.
     has_side_effect: boolean specifying whether the custom call has side
       effects. When ``True``, the FFI call will be executed even when the
       outputs are not used.
+    vmap_method: string specifying how the FFI call transforms under
+      :func:`~jax.vmap` as described above.
     **kwargs: keyword arguments that are passed as named attributes to the
       custom call using XLA's FFI interface.
 
@@ -238,6 +239,25 @@ def ffi_call(
     One or more :class:`~jax.Array` objects whose shapes and dtypes match
     ``result_shape_dtypes``.
   """
+  if not isinstance(vectorized, DeprecatedArg) and not vectorized is None:
+    deprecations.warn(
+        "jax-callback-vectorized",
+        "The vectorized argument of ffi_call is deprecated and setting "
+        "it will soon raise an error. To avoid an error in the future, and to "
+        "suppress this warning, please use the vmap_method argument instead.",
+        stacklevel=2)
+    if vmap_method is not None:
+      raise ValueError(
+          "the vectorized and vmap_method arguments of ffi_call cannot "
+          "be used together. Please use the vmap_method argument.")
+    vmap_method = "legacy_vectorized" if vectorized else "sequential"
+  allowed_vmap_methods = ["sequential", "broadcast", "broadcast_fullrank",
+                          "legacy_vectorized", None]
+  if vmap_method not in allowed_vmap_methods:
+    raise ValueError(
+        f"vmap_method must be on of the allowed methods {allowed_vmap_methods}, "
+        f"but got: {vmap_method}")
+
   if isinstance(result_shape_dtypes, Sequence):
     multiple_results = True
     result_avals = _result_avals(result_shape_dtypes)
@@ -248,6 +268,7 @@ def ffi_call(
       *args,
       result_avals=result_avals,
       vectorized=vectorized,
+      vmap_method=vmap_method,
       target_name=target_name,
       has_side_effect=has_side_effect,
       **_wrap_kwargs_hashable(kwargs),
@@ -342,11 +363,12 @@ def ffi_call_abstract_eval(
     *avals_in,
     result_avals: tuple[core.AbstractValue, ...],
     target_name: str,
-    vectorized: bool,
+    vectorized: bool | DeprecatedArg,
+    vmap_method: str | None,
     has_side_effect: bool,
     **kwargs: Any,
 ):
-  del avals_in, target_name, vectorized, kwargs
+  del avals_in, target_name, vectorized, vmap_method, kwargs
   effects = {_FfiEffect} if has_side_effect else core.no_effects
   return result_avals, effects
 
@@ -370,11 +392,12 @@ def ffi_call_lowering(
     *operands: ir.Value,
     result_avals: tuple[core.AbstractValue, ...],
     target_name: str,
-    vectorized: bool,
+    vectorized: bool | DeprecatedArg,
+    vmap_method: str | None,
     has_side_effect: bool,
     **kwargs: Any,
 ) -> Sequence[ir.Value]:
-  del result_avals, vectorized
+  del result_avals, vectorized, vmap_method
   rule = ffi_lowering(target_name, has_side_effect=has_side_effect)
   return rule(ctx, *operands, **_unwrap_kwargs_hashable(kwargs))
 

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -1724,7 +1724,8 @@ class HostCallbackCallTest(jtu.JaxTestCase):
                                   "batching rules are implemented only for id_tap, not for call"):
         jax.vmap(fun)(np.ones((2, 3)))
     else:
-      jax.vmap(fun)(np.ones((2, 3)))
+      with jtu.ignore_warning(category=DeprecationWarning):
+        jax.vmap(fun)(np.ones((2, 3)))
 
   def test_call_error_bad_result_shape(self):
     with self.assertRaisesRegex(


### PR DESCRIPTION
Currently, the primitives backing `pure_callback` and (by extension) `ffi_call` provide a default batching rule that is controlled by the parameter `vectorized` to these two functions. This batching rule (allegedly) implements the following behavior:

* For `vectorized=True`, vmapping results in a call to the callback directly with the batched inputs after moving the batch axis to the front. This assumes that the callback function directly handles vectorized inputs and (roughly) `callback(x_batch) == stack([callback(x) for x in x_batch])`.
* When `vectorized=False`, the vmap produces a sequential scan with the callback in the body, which could have significant performance implications.

While these don't seem like unreasonable defaults, the behavior when `vectorized=False` could result in unexpectedly poor performance for users who aren't familiar with this behavior. More importantly, the `vectorized=True` semantics are confusing—and I would argue wrong—when the function takes more than one input. For example, consider the following function:

```python
import jax
import jax.numpy as jnp

def callback(x, y):
  print(x.shape, y.shape)
  return x + y

def fun(x, y):
  shape = jnp.broadcast_shapes(x.shape, y.shape)
  dtype = jnp.result_type(x, y)
  out_type = jax.ShapeDtypeStruct(shape, dtype)
  return jax.pure_callback(callback, out_type, x, y, vectorized=True)
```

We can call this function under `vmap` as follows:

```python
jax.vmap(fun, in_axes=(0, None))(jnp.ones(3), 0.5)
```

This prints `(3,)` and `()` for the shapes, and the result has shape `(3,)`, as we expect. However, things get a little ugly if we apply a second `vmap` as follows:

```python
jax.vmap(jax.vmap(fun, in_axes=(0, None)), in_axes=(None, 0))(jnp.ones(3), jnp.ones(4))
```

In this case, by the time our callback is executed, it receives `x` and `y` with shapes `(3,)` and `(4,)`, respectively, and it crashes with a `TypeError` because of the mismatched shapes. Even worse, callback doesn't have enough metadata to gracefully handle this case no matter what; how can callback ever know which argument was batched first?

This behavior is bad, and the docs are (at least somewhat) misleading. This confusion has bitten me, and it has come up several times on the JAX issue tracker, most recently in #23624. In this PR, I propose a refactoring of this API.

## Proposal

I think that the best approach for handling these issues would be to deprecate both the default behavior (using a `lax.map`) and the `vectorized` parameter, in favor of an explicitly opt-in API using a `str` (or `Enum`) parameter called `vmap_method`. After the appropriate deprecation periods, my proposed API would have the following behavior:

* Calling `vmap` on a callback without an explicit `vmap_method` would raise an error.
* Using `vmap_method="sequential"` would produce a `lax.map` when vmapped (the current default behavior).
* Using `vmap_method="broadcast"` would be similar to the current `vectorized=True` behavior, but new axes would be added in the appropriate locations for unbatched inputs. For example, in the double `vmap` example from above, x would have shape `(1, 3)` and y would have shape `(4, 1)` when they reach the callback.
* Finally, `vmap_method="broadcast_fullrank"` would behave like broadcast, but the inputs would be tiled to the expected batched shape (e.g. `(4, 3)` in the example above). I would argue that the documentation for `pure_callback` and `ffi_call` currently imply this behavior for `vectorized=True`.

This proposed API would continue to support existing use cases, while minimizing the chance of confusion and performance footguns.

## Alternatives

Another approach would be to remove support for batching callbacks entirely in favor of an API like `custom_vmap` or something more general. This was what I suggested in response to #23624, but since `custom_vmap` isn't documented or well supported, I'm not sure this is a totally satisfying solution. Furthermore, I expect that the vast majority of use cases for batching callbacks will be supported by some simple rules like the ones listed above, with minimal maintenance burden. More advanced needs could still be covered by `custom_vmap`.