### PR TITLE
[Mosaic GPU] Fix mbarrier inline ptx for newer CTK

### DIFF
--- a/jax/experimental/mosaic/gpu/utils.py
+++ b/jax/experimental/mosaic/gpu/utils.py
@@ -617,7 +617,7 @@ class BarrierRef:
       i32 = ir.IntegerType.get_signless(32)
       bytes = arith.index_cast(i32, bytes)
 
-    nvvm.mbarrier_arrive_expect_tx(self.get_ptr(), bytes)
+    nvvm.mbarrier_arrive_expect_tx_shared(self.get_ptr(), bytes)
 
   def get_ptr(self):
     ptr = ir.Type.parse("!llvm.ptr<3>")


### PR DESCRIPTION
On CUDA toolkit 12.6, Mosaic GPU crashes with:
```
error: `ptxas` invocation failed. Log:
ptxas warning : Program uses 32-bit address on line '86' which is conflicting with .address_size 64
ptxas fatal   :  32-Bit ABI (--machine 32 or 32-Bit addressing) is not supported on sm_90 or higher architectures.
```
Line '86' mentioned comes from [here](https://github.com/jax-ml/jax/blob/ce99c18a7461eb3d46bd3fb03e3838752a3da8a1/jax/experimental/mosaic/gpu/utils.py#L620).
Using the more specialized API expecting a smem ptr solves the issue instead of the API expecting a generic ptr.

CC @apaszke @superbobry @andportnoy 