### PR TITLE
Improve documentation for jax.jacobian

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -91,6 +91,7 @@ Automatic differentiation
 
     grad
     value_and_grad
+    jacobian
     jacfwd
     jacrev
     hessian

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -680,7 +680,13 @@ def jacrev(fun: Callable, argnums: int | Sequence[int] = 0,
       return jac_tree, aux
 
   return jacfun
-jacobian = jacrev
+
+
+def jacobian(fun: Callable, argnums: int | Sequence[int] = 0,
+             has_aux: bool = False, holomorphic: bool = False, allow_int: bool = False) -> Callable:
+  """Alias of :func:`jax.jacrev`."""
+  return jacrev(fun, argnums=argnums, has_aux=has_aux, holomorphic=holomorphic, allow_int=allow_int)
+
 
 _check_input_dtype_jacrev = partial(_check_input_dtype_revderiv, "jacrev")
 _check_output_dtype_jacrev = partial(_check_output_dtype_revderiv, "jacrev")


### PR DESCRIPTION
`jax.jacobian` currently has no listing on the JAX website, which makes it difficult to find documentation for this function. This makes the alias explicit, and adds that missing documentation.