### PR TITLE
Add support for passing array attributes via ffi_call and an example demonstrating the different attribute APIs supported by the FFI

### DIFF
--- a/examples/ffi/CMakeLists.txt
+++ b/examples/ffi/CMakeLists.txt
@@ -13,3 +13,7 @@ find_package(nanobind CONFIG REQUIRED)
 nanobind_add_module(_rms_norm NB_STATIC "src/jax_ffi_example/rms_norm.cc")
 target_include_directories(_rms_norm PUBLIC ${XLA_DIR})
 install(TARGETS _rms_norm LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})
+
+nanobind_add_module(_attrs NB_STATIC "src/jax_ffi_example/attrs.cc")
+target_include_directories(_attrs PUBLIC ${XLA_DIR})
+install(TARGETS _attrs LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})

--- a/examples/ffi/src/jax_ffi_example/attrs.cc
+++ b/examples/ffi/src/jax_ffi_example/attrs.cc
@@ -1,0 +1,66 @@
+/* Copyright 2024 The JAX Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+
+#include "nanobind/nanobind.h"
+#include "xla/ffi/api/ffi.h"
+
+namespace nb = nanobind;
+namespace ffi = xla::ffi;
+
+ffi::Error ArrayAttrImpl(ffi::Span<const int32_t> array,
+                         ffi::Result<ffi::BufferR0<ffi::S32>> res) {
+  int64_t total = 0;
+  for (int32_t x : array) {
+    total += x;
+  }
+  res->typed_data()[0] = total;
+  return ffi::Error::Success();
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(ArrayAttr, ArrayAttrImpl,
+                              ffi::Ffi::Bind()
+                                  .Attr<ffi::Span<const int32_t>>("array")
+                                  .Ret<ffi::BufferR0<ffi::S32>>());
+
+ffi::Error DictionaryAttrImpl(ffi::Dictionary attrs,
+                              ffi::Result<ffi::BufferR0<ffi::S32>> secret,
+                              ffi::Result<ffi::BufferR0<ffi::S32>> count) {
+  auto maybe_secret = attrs.get<int64_t>("secret");
+  if (maybe_secret.has_error()) {
+    return maybe_secret.error();
+  }
+  secret->typed_data()[0] = maybe_secret.value();
+  count->typed_data()[0] = attrs.size();
+  return ffi::Error::Success();
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(DictionaryAttr, DictionaryAttrImpl,
+                              ffi::Ffi::Bind()
+                                  .Attrs()
+                                  .Ret<ffi::BufferR0<ffi::S32>>()
+                                  .Ret<ffi::BufferR0<ffi::S32>>());
+
+NB_MODULE(_attrs, m) {
+  m.def("registrations", []() {
+    nb::dict registrations;
+    registrations["array_attr"] =
+        nb::capsule(reinterpret_cast<void *>(ArrayAttr));
+    registrations["dictionary_attr"] =
+        nb::capsule(reinterpret_cast<void *>(DictionaryAttr));
+    return registrations;
+  });
+}

--- a/examples/ffi/src/jax_ffi_example/attrs.py
+++ b/examples/ffi/src/jax_ffi_example/attrs.py
@@ -1,0 +1,47 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An example demonstrating the different ways that attributes can be passed to
+the FFI.
+
+For example, we can pass arrays, variadic attributes, and user-defined types.
+Full support of user-defined types isn't yet supported by XLA, so that example
+will be added in the future.
+"""
+
+import numpy as np
+
+import jax
+import jax.extend as jex
+
+from jax_ffi_example import _attrs
+
+for name, target in _attrs.registrations().items():
+  jex.ffi.register_ffi_target(name, target)
+
+
+def array_attr(num: int):
+  return jex.ffi.ffi_call(
+      "array_attr",
+      jax.ShapeDtypeStruct((), np.int32),
+      array=np.arange(num, dtype=np.int32),
+  )
+
+
+def dictionary_attr(**kwargs):
+  return jex.ffi.ffi_call(
+      "dictionary_attr",
+      (jax.ShapeDtypeStruct((), np.int32), jax.ShapeDtypeStruct((), np.int32)),
+      **kwargs,
+  )

--- a/examples/ffi/tests/attrs_test.py
+++ b/examples/ffi/tests/attrs_test.py
@@ -1,0 +1,61 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+
+import jax
+import jax.numpy as jnp
+from jax._src import test_util as jtu
+
+from jax_ffi_example import attrs
+
+jax.config.parse_flags_with_absl()
+
+
+class AttrsTests(jtu.JaxTestCase):
+  def test_array_attr(self):
+    self.assertEqual(attrs.array_attr(5), jnp.arange(5).sum())
+    self.assertEqual(attrs.array_attr(3), jnp.arange(3).sum())
+
+  def test_array_attr_jit_cache(self):
+    jit_array_attr = jax.jit(attrs.array_attr, static_argnums=(0,))
+    with jtu.count_jit_and_pmap_lowerings() as count:
+      jit_array_attr(5)
+    self.assertEqual(count[0], 1)  # compiles once the first time
+    with jtu.count_jit_and_pmap_lowerings() as count:
+      jit_array_attr(5)
+    self.assertEqual(count[0], 0)  # cache hit
+
+  def test_array_attr_no_jit(self):
+    with jax.disable_jit():
+      attrs.array_attr(5)  # doesn't crash
+
+  def test_dictionary_attr(self):
+    secret, count = attrs.dictionary_attr(secret=5)
+    self.assertEqual(secret, 5)
+    self.assertEqual(count, 1)
+
+    secret, count = attrs.dictionary_attr(secret=3, a_string="hello")
+    self.assertEqual(secret, 3)
+    self.assertEqual(count, 2)
+
+    with self.assertRaisesRegex(Exception, "Unexpected attribute"):
+      attrs.dictionary_attr()
+
+    with self.assertRaisesRegex(Exception, "Wrong attribute type"):
+      attrs.dictionary_attr(secret="invalid")
+
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
The XLA FFI supports [a rich interface for specifying "attributes"](https://openxla.org/xla/custom_call#attributes), but this interface hasn't been widely used from the JAX side. We discovered that passing array attributes wasn't supported by the current front end, so I added support for that and took advantage of this change to add a more complete example of the e2e usage of attributes.

The core JAX change that was needed was to add support for passing `np.array` objects (which aren't hashable!) as keyword arguments to the `ffi_call` primitive. To do this, I wrap any unhashable keyword arguments in the `_HashableByObjectId` helper which creates a hashable object based on the `id`.

"Why not pass these unhashable objects as positional arguments?" you ask. Well, the problem is that we need access to the concrete value of this array _when lowering_, so we can't have them turning into tracers.

I don't expect this to introduce any real caching issues, but if anyone has concerns or other suggestions for a better API, I'd love to hear them!