### PR TITLE
Remove pylint sections from pyproject.toml (use ruff instead)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,30 +72,6 @@ doctest_optionflags = [
 ]
 addopts = "--doctest-glob='*.rst' --ignore='examples/ffi'"
 
-[tool.pylint.master]
-extension-pkg-whitelist = "numpy"
-
-[tool.pylint."messages control"]
-disable = [
-    "missing-docstring",
-    "too-many-locals",
-    "invalid-name",
-    "redefined-outer-name",
-    "redefined-builtin",
-    "protected-name",
-    "no-else-return",
-    "fixme",
-    "protected-access",
-    "too-many-arguments",
-    "blacklisted-name",
-    "too-few-public-methods",
-    "unnecessary-lambda"
-]
-enable = "c-extension-no-member"
-
-[tool.pylint.format]
-indent-string=" "
-
 [tool.ruff]
 preview = true
 exclude = [


### PR DESCRIPTION
There is no such message code as "protected-name" in pylint 3.3.1 and prev versions 

```
Unknown option value for '--disable', expected a valid pylint message and got 'protected-name'
```