### PR TITLE
Enable weight offloading tests that are supported on GPUs now

### DIFF
--- a/tests/memories_test.py
+++ b/tests/memories_test.py
@@ -416,8 +416,8 @@ class DevicePutTest(jtu.JaxTestCase):
         out, np_inp * np_inp, s_dev, "device")
 
   def test_parameter_streaming(self):
-    if jtu.test_device_matches(["gpu"]):
-      self.skipTest("This test does not work on GPU backend.")
+    if jtu.test_device_matches(["gpu"]) and xla_extension_version < 289:
+      self.skipTest("Requires xla_extension_version >= 289")
     _, s_host, np_inp, inp_host = _create_inputs(
         (8, 2), P("x", "y"), mem_kind="pinned_host")
     s_dev = s_host.with_memory_kind('device')
@@ -461,8 +461,8 @@ class DevicePutTest(jtu.JaxTestCase):
         out, np_inp, s_host, 'pinned_host')
 
   def test_parameter_streaming_with_scalar_and_constant(self):
-    if jtu.test_device_matches(["gpu"]):
-      self.skipTest("This test does not work on GPU backend.")
+    if jtu.test_device_matches(["gpu"]) and xla_extension_version < 289:
+      self.skipTest("Requires xla_extension_version >= 289")
     mesh = jtu.create_mesh((2, 2), ("x", "y"))
     scalar_inp = 1
     s_host = NamedSharding(mesh, P(), memory_kind="pinned_host")
@@ -512,8 +512,8 @@ class DevicePutTest(jtu.JaxTestCase):
     )
 
   def test_parameter_and_output_streaming_with_scalar(self):
-    if jtu.test_device_matches(["gpu"]):
-      self.skipTest("This test is flaky on GPU backend.")
+    if jtu.test_device_matches(["gpu"]) and xla_extension_version < 289:
+      self.skipTest("Requires xla_extension_version >= 289")
     if xb.backend_xla_version() is not None and xb.backend_xla_version() < 2:
       self.skipTest("This test requires an xla_version >= 2.")
 
@@ -581,8 +581,8 @@ class DevicePutTest(jtu.JaxTestCase):
     self.assertEqual(out_hbm.sharding, out_s)
 
   def test_output_streaming(self):
-    if jtu.test_device_matches(["gpu"]):
-      self.skipTest("This test is flaky on GPU backend.")
+    if jtu.test_device_matches(["gpu"]) and xla_extension_version < 289:
+      self.skipTest("Requires xla_extension_version >= 289")
     mesh = jtu.create_mesh((1, 1), ("x", "y"))
     np_inp = np.arange(16.0).reshape(8, 2)
     s_hbm = NamedSharding(mesh, P("x", "y"), memory_kind="device")
@@ -599,8 +599,8 @@ class DevicePutTest(jtu.JaxTestCase):
     self.assertEqual(out_host.sharding, s_host)
 
   def test_weight_offload_with_dp_on_output(self):
-    if jtu.test_device_matches(["gpu"]):
-      self.skipTest("This test is flaky on GPU backend.")
+    if jtu.test_device_matches(["gpu"]) and xla_extension_version < 289:
+      self.skipTest("Requires xla_extension_version >= 289")
     _, s_dev, np_inp, inp_dev = _create_inputs(
         (8, 2), P("x", "y"), mem_kind="device")
     s_host = s_dev.with_memory_kind('pinned_host')
@@ -616,8 +616,8 @@ class DevicePutTest(jtu.JaxTestCase):
         out_host, np_inp * 2, s_host, 'pinned_host')
 
   def test_output_streaming_inside_scan(self):
-    if jtu.test_device_matches(["gpu"]):
-      self.skipTest("This test does not work on GPU backend.")
+    if jtu.test_device_matches(["gpu"]) and xla_extension_version < 289:
+      self.skipTest("Requires xla_extension_version >= 289")
     if xb.backend_xla_version() is not None and xb.backend_xla_version() < 2:
       self.skipTest("This test requires an xla_version >= 2.")
     mesh = jtu.create_mesh((1, 1, 2), ("x", "y", "z"))
@@ -650,8 +650,8 @@ class DevicePutTest(jtu.JaxTestCase):
     self.assertEqual(t.shape, t_copy.shape)
 
   def test_close_over_host_constant_and_stream(self):
-    if jtu.test_device_matches(["gpu"]):
-      self.skipTest("This test does not work on GPU backend.")
+    if jtu.test_device_matches(["gpu"]) and xla_extension_version < 289:
+      self.skipTest("Requires xla_extension_version >= 289")
 
     _, s_host, np_inp, inp_host = _create_inputs(
         (8, 2), P("x", "y"), mem_kind="pinned_host")


### PR DESCRIPTION
More unit tests are supported on GPUs:
- test_parameter_streaming
- test_parameter_streaming_with_scalar_and_constant
- test_parameter_and_output_streaming_with_scalar
- test_output_streaming
- test_weight_offload_with_dp_on_output
- test_output_streaming_inside_scan
- test_close_over_host_constant_and_stream