### PR TITLE
[jax.distributed] Enable grpc channel compression

### DIFF
--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -123,7 +123,7 @@ class State:
     self.client = xla_extension.get_distributed_runtime_client(
         coordinator_address, process_id, init_timeout=initialization_timeout,
         heartbeat_interval=client_heartbeat_interval_seconds,
-        max_missing_heartbeats=client_max_missing_heartbeats)
+        max_missing_heartbeats=client_max_missing_heartbeats, use_compression=True)
     logger.info('Connecting to JAX distributed service on %s', coordinator_address)
     self.client.connect()
 


### PR DESCRIPTION
Allows passing an additional boolean argument `use_compression` via `jax.distributed.initialize(...)` that controls whether compression is enabled on the gRPC channels created for each distributed runtime client.

Motivation: XLA sends O(mesh) [device topologies](https://github.com/openxla/xla/blob/9fb4f21c3542c10b6a5bd98144801bbeec10b489/xla/pjrt/distributed/protocol.proto#L84) through its centralized coordination service and we have reason to believe that this becomes a bottleneck at large scale. Compression of the underlying gRPC communication is currently implicitly disabled, and might give us a cheap avenue to scale a bit further with the centralized KV store design.

Verified to work via
```
GRPC_VERBOSITY=debug GRPC_TRACE=compression,channel ./some_jax_distributed_example.py |& grep -i 'Compressed'
I0927 09:25:34.942738680 3640719 message_compress_filter.cc:266] Compressed[gzip] 199 bytes vs. 155 bytes (22.11% savings)
I0927 09:25:35.021493311 3640719 message_compress_filter.cc:266] Compressed[gzip] 225 bytes vs. 155 bytes (31.11% savings)
I0927 09:25:36.482614284 3640719 message_compress_filter.cc:266] Compressed[gzip] 180 bytes vs. 143 bytes (20.56% savings)
```

Corresponding XLA PR: https://github.com/openxla/xla/pull/17704