### PR TITLE
actions/checkout: pin specific hash

### DIFF
--- a/.github/workflows/metal_plugin_ci.yml
+++ b/.github/workflows/metal_plugin_ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Get repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
         with:
           path: jax
       - name: Setup build and test enviroment


### PR DESCRIPTION
As required by https://opensource.google/documentation/reference/github/services#actions