### PR TITLE
Add support for FFI calls with side effects via ffi_call

### DIFF
--- a/tests/extend_test.py
+++ b/tests/extend_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import unittest
 
 import numpy as np
 from absl.testing import absltest
@@ -177,6 +178,25 @@ class FfiTest(jtu.JaxTestCase):
     op = self.find_custom_call_in_module(module)
     self.assertTrue(hlo.TokenType.isinstance(op.operands[0].type))
     self.assertTrue(hlo.TokenType.isinstance(op.results[0].type))
+
+  def testEffectsHlo(self):
+    # The target name must exist on the current platform, but we don't actually
+    # need to call it with the correct syntax, because we're only checking the
+    # compiled HLO.
+    if jtu.test_device_matches(["cpu"]):
+      target_name = "lapack_sgetrf_ffi"
+    elif jtu.test_device_matches(["rocm"]):
+      target_name = "hipsolver_getrf_ffi"
+    elif jtu.test_device_matches(["cuda", "gpu"]):
+      target_name = "cusolver_getrf_ffi"
+    else:
+      raise unittest.SkipTest("Unsupported device")
+    def fun():
+      jex.ffi.ffi_call(target_name, (), has_side_effect=True)
+    hlo = jax.jit(fun).lower()
+    self.assertIn(target_name, hlo.as_text())
+    self.assertIn("has_side_effect = true", hlo.as_text())
+    self.assertIn(target_name, hlo.compile().as_text())
 
   @jtu.sample_product(
     shape=[(1,), (4,), (5,)],


### PR DESCRIPTION
As discussed in https://github.com/jax-ml/jax/discussions/23963, the `jax.extend.ffi.ffi_call` function doesn't currently support FFI calls with side effects. Since we already have support for lowering effectful custom calls, plumbing this through to `ffi_call` is straightforward. I think it's reasonable to stick to the the same terminology here and call the boolean parameter `has_side_effect`.

If needed it would also be possible to add support for ordering via tokens since support for tokens was added in #23394, but I didn't want to do too much in this PR.