### PR TITLE
Fix Windows CI to install the jaxlib wheel it builds.

### DIFF
--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -66,7 +66,7 @@ jobs:
           PY_COLORS: 1
         run: |
           cd jax
+          python -m pip install --pre --find-links ${{ github.workspace }}\jax\dist jaxlib
           python -m pip install -e ${{ github.workspace }}\jax
-          python -m pip install --no-index --find-links ${{ github.workspace }}\jax\dist jaxlib
           echo "JAX_ENABLE_CHECKS=$JAX_ENABLE_CHECKS"
           pytest -n auto --tb=short tests examples


### PR DESCRIPTION
Currently we install jax first and then try to install jaxlib. But pip won't overwrite the jaxlib installed as a jax dependency, so our CI builds were always using the released jaxlib.