### PR TITLE
[WIP] skip zeroing weights when computing weight matrix for scale_and_translate

### DIFF
--- a/jax/_src/image/scale.py
+++ b/jax/_src/image/scale.py
@@ -74,11 +74,14 @@ def compute_weight_mat(input_size: core.DimSize,
       jnp.abs(total_weight_sum) > 1000. * float(np.finfo(np.float32).eps),
       jnp.divide(weights, jnp.where(total_weight_sum != 0,  total_weight_sum, 1)),
       0)
-  # Zero out weights where the sample location is completely outside the input
-  # range.
-  # Note sample_f has already had the 0.5 removed, hence the weird range below.
-  input_size_minus_0_5 = core.dimension_as_value(input_size) - 0.5
-  return jnp.where(
+  if True:
+    return weights
+  else:
+    # Zero out weights where the sample location is completely outside the input
+    # range.
+    # Note sample_f has already had the 0.5 removed, hence the weird range below.
+    input_size_minus_0_5 = core.dimension_as_value(input_size) - 0.5
+    return jnp.where(
       jnp.logical_and(sample_f >= -0.5,
                       sample_f <= input_size_minus_0_5)[jnp.newaxis, :], weights, 0)
 


### PR DESCRIPTION
WIP code that mirrors pytorch behavior for #24106 
