### PR TITLE
Fix listing of `vectorized` deprecation in changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 * Deprecations:
   * The semi-public API `jax.lib.xla_client.PaddingType` has been deprecated.
     No JAX APIs consume this type, so there is no replacement.
+  * The default behavior of {func}`jax.pure_callback` and
+    {func}`jax.extend.ffi.ffi_call` under `vmap` has been deprecated and so has
+    the `vectorized` parameter to those functions. The `vmap_method` parameter
+    should be used instead for better defined behavior. See the discussion in
+    {jax-issue}`#23881` for more details.
 
 ## jax 0.4.34 (October 4, 2024)
 
@@ -65,11 +70,6 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * `jax.lib.xla_client.Device` is deprecated; use `jax.Device` instead.
   * `jax.lib.xla_client.XlaRuntimeError` has been deprecated. Use
     `jax.errors.JaxRuntimeError` instead.
-  * The default behavior of {func}`jax.pure_callback` and
-    {func}`jax.extend.ffi.ffi_call` under `vmap` has been deprecated and so has
-    the `vectorized` parameter to those functions. The `vmap_method` parameter
-    should be used instead for better defined behavior. See the discussion in
-    {jax-issue}`#23881` for more details.
 
 * Deletion:
   * `jax.xla_computation` is deleted. It's been 3 months since it's deprecation


### PR DESCRIPTION
As noted in https://github.com/jax-ml/jax/pull/23881, that change didn't actually make it in in time for the v0.4.34 release so I've moved it to the v0.4.35 section.