### PR TITLE
Drop `complex dtype` support in `jnp.arctan2` to make it consistent with `np.arctan2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     `jax.lib.xla_client.Shape`, `jax.lib.xla_client.XlaBuilder`, and
     `jax.lib.xla_client.XlaComputation` have been deprecated. Use StableHLO
     instead.
+  * To align with the behavior of `numpy.arctan2`, `jax.numpy.arctan2` has been
+    modified to no longer support `complex dtypes`.
 
 ## jax 0.4.34 (October 4, 2024)
 

--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -1352,6 +1352,9 @@ def subtract(x: ArrayLike, y: ArrayLike, /) -> Array:
 @implements(np.arctan2, module='numpy')
 @partial(jit, inline=True)
 def arctan2(x1: ArrayLike, x2: ArrayLike, /) -> Array:
+  check_arraylike('arctan2', x1, x2)
+  if dtypes.issubdtype(dtypes.result_type(x1, x2), np.complexfloating):
+    raise TypeError("ufunc 'arctan2/atan2' does not support complex dtypes.")
   return lax.atan2(*promote_args_inexact("arctan2", x1, x2))
 
 


### PR DESCRIPTION
This PR fixes a discrepancy between `jnp.arctan2` and `np.arctan2` by raising a `TypeError` for `complex` inputs, as `np.arctan2` currently does.

Current behavior:
```python
>>> jnp.arctan2(1-2j, 3)
Array(0.4913969-0.6412373j, dtype=complex64, weak_type=True)
```

New behavior:
```python
>>> jnp.arctan2(1-2j, 3)
TypeError: ufunc 'arctan2/atan2' does not support complex dtypes.
```