### PR TITLE
Add jax.make_mesh to API docs

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -73,13 +73,12 @@ Just-in-time compilation (:code:`jit`)
     eval_shape
     ShapeDtypeStruct
     device_put
-    device_put_replicated
-    device_put_sharded
     device_get
     default_backend
     named_call
     named_scope
     block_until_ready
+    make_mesh
 
 .. _jax-grad:
 


### PR DESCRIPTION
I noticed that the docstring for `jax.make_mesh` wasn't in the API docs. I'm not sure if this is the right place to put it (under `jit` vs. Parallelism vs. a new section), but it's probably worthwhile having it somewhere.