### PR TITLE
Raise error when converting dot_general with unsupported precision in jax2tf

### DIFF
--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -1689,6 +1689,15 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
         res,
         x + _testing_multi_platform_to_add[tf_device_jax_platform])
 
+  def test_dot_algorithm_non_native_unsupported(self):
+    def f_jax(x):
+      return jax.lax.dot(x, x, precision="F32_F32_F32")
+
+    x = np.ones((128, 128), dtype=np.float32)
+    with self.assertRaisesRegex(NotImplementedError,
+                                "Unsupported precision in dot_general"):
+      jax2tf.convert(f_jax, native_serialization=False)(x)
+
 
 @jtu.with_config(jax_enable_custom_prng=True)
 class Jax2tfWithCustomPRNGTest(tf_test_util.JaxToTfTestCase):


### PR DESCRIPTION
After https://github.com/jax-ml/jax/pull/24079, the `precision` argument to `lax.dot_general` can be a `DotAlgorithm` or `DotAlgorithmPreset`, and this isn't properly handled by `jax2tf` with `native_serialization=False` here:

https://github.com/jax-ml/jax/blob/59ae2af6996b42c3d960d11bc5947075c55646ae/jax/experimental/jax2tf/jax2tf.py#L2097-L2106

This PR adds a check to properly raise a `NotImplementedError` in this case.

Edited to note that this isn't actually a solution to https://github.com/jax-ml/jax/issues/24236 (see https://github.com/openxla/xla/pull/18222 for that), but probably a good thing to fix anyways.