### PR TITLE
Improve array setitem error

### DIFF
--- a/jax/_src/numpy/array_methods.py
+++ b/jax/_src/numpy/array_methods.py
@@ -580,10 +580,9 @@ def _defer_to_unrecognized_arg(opchar, binary_op, swap=False):
   return deferring_binary_op
 
 def _unimplemented_setitem(self, i, x):
-  msg = ("'{}' object does not support item assignment. JAX arrays are "
-         "immutable. Instead of ``x[idx] = y``, use ``x = x.at[idx].set(y)`` "
-         "or another .at[] method: "
-         "https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html")
+  msg = ("JAX arrays are immutable and do not support in-place item assignment."
+         " Instead of x[idx] = y, use x = x.at[idx].set(y) or another .at[] method:"
+         " https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html")
   raise TypeError(msg.format(type(self)))
 
 def _operator_round(number: ArrayLike, ndigits: int | None = None) -> Array:


### PR DESCRIPTION
Before:
```python
>>> import jax
>>> x = jax.numpy.arange(4)
>>> x[0] = 1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/vanderplas/github/google/jax/jax/_src/numpy/array_methods.py", line 587, in _unimplemented_setitem
    raise TypeError(msg.format(type(self)))
TypeError: '<class 'jaxlib.xla_extension.ArrayImpl'>' object does not support item assignment. JAX arrays are immutable. Instead of ``x[idx] = y``, use ``x = x.at[idx].set(y)`` or another .at[] method: https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html
```
After:
```python
>>> import jax
>>> x = jax.numpy.arange(4)
>>> x[0] = 1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/vanderplas/github/google/jax/jax/_src/numpy/array_methods.py", line 586, in _unimplemented_setitem
    raise TypeError(msg.format(type(self)))
TypeError: JAX arrays are immutable and do not support in-place item assignment. Instead of x[idx] = y, use x = x.at[idx].set(y) or another .at[] method: https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html
```