### PR TITLE
[Mosaic GPU] Skip OSS Flash Attention test unless running on sm90

### DIFF
--- a/jax/experimental/mosaic/gpu/examples/flash_attention.py
+++ b/jax/experimental/mosaic/gpu/examples/flash_attention.py
@@ -18,6 +18,7 @@ import dataclasses
 import enum
 import itertools
 import os
+import warnings
 
 from absl import app
 import jax
@@ -606,6 +607,13 @@ def benchmark_and_verify(
 
 
 if __name__ == "__main__":
+  if (not jtu.test_device_matches(["cuda"]) or
+      not jtu.is_cuda_compute_capability_at_least("9.0")):
+    warnings.warn(
+      "Mosaic GPU Flash Attention requires compute capability 9.0 to run, "
+      "skipping.")
+    exit(0)
+
   batch_size = 1
   num_q_heads = 4
   num_kv_heads = 1


### PR DESCRIPTION
This helps OSS CIs skip the test gracefully when running on non-Hopper machines.
Example failure: https://github.com/NVIDIA/JAX-Toolbox/actions/runs/11338705167/job/31532699797?pr=1091#step:7:1482.