### PR TITLE
Update docs/cuda_custom_call (P1)

### DIFF
--- a/docs/cuda_custom_call/cuda_custom_call_test.py
+++ b/docs/cuda_custom_call/cuda_custom_call_test.py
@@ -58,16 +58,13 @@ if jtu.is_running_under_pytest():
 SHARED_LIBRARY = os.path.join(os.path.dirname(__file__), "libfoo.so")
 library = ctypes.cdll.LoadLibrary(SHARED_LIBRARY)
 
-# register the custom calls targets with XLA
-xla_client.register_custom_call_target(name=XLA_CUSTOM_CALL_TARGET_FWD,
-                                       fn=ffi.pycapsule(library.FooFwd),
-                                       platform=XLA_PLATFORM,
-                                       api_version=XLA_CUSTOM_CALL_API_VERSION)
-xla_client.register_custom_call_target(name=XLA_CUSTOM_CALL_TARGET_BWD,
-                                       fn=ffi.pycapsule(library.FooBwd),
-                                       platform=XLA_PLATFORM,
-                                       api_version=XLA_CUSTOM_CALL_API_VERSION)
-
+# register the custom calls targets with XLA, api_version=1 by default
+ffi.register_ffi_target(name=XLA_CUSTOM_CALL_TARGET_FWD,
+                        fn=ffi.pycapsule(library.FooFwd),
+                        platform=XLA_PLATFORM)
+ffi.register_ffi_target(name=XLA_CUSTOM_CALL_TARGET_BWD,
+                        fn=ffi.pycapsule(library.FooBwd),
+                        platform=XLA_PLATFORM)
 
 def foo_fwd(a, b):
   assert a.dtype == jnp.float32

--- a/docs/cuda_custom_call/cuda_custom_call_test.py
+++ b/docs/cuda_custom_call/cuda_custom_call_test.py
@@ -27,7 +27,6 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from jax.extend import ffi
-from jax.lib import xla_client
 
 # start test boilerplate
 from absl.testing import absltest

--- a/docs/cuda_custom_call/foo.cu.cc
+++ b/docs/cuda_custom_call/foo.cu.cc
@@ -77,8 +77,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
         .Arg<ffi::Buffer<ffi::DataType::F32>>()    // b
         .Ret<ffi::Buffer<ffi::DataType::F32>>()    // c
         .Ret<ffi::Buffer<ffi::DataType::F32>>()    // b_plus_1
-        .Attr<size_t>("n"),
-        {xla::ffi::Traits::kCmdBufferCompatible}); // cudaGraph enabled
+        .Attr<size_t>("n"));
 
 //----------------------------------------------------------------------------//
 //                            Backward pass                                   //
@@ -136,5 +135,4 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
         .Arg<ffi::Buffer<ffi::DataType::F32>>()    // b_plus_1
         .Ret<ffi::Buffer<ffi::DataType::F32>>()    // a_grad
         .Ret<ffi::Buffer<ffi::DataType::F32>>()    // b_grad
-        .Attr<size_t>("n"),
-        {xla::ffi::Traits::kCmdBufferCompatible});  // cudaGraph enabled
+        .Attr<size_t>("n"));

--- a/docs/cuda_custom_call/foo.cu.cc
+++ b/docs/cuda_custom_call/foo.cu.cc
@@ -77,7 +77,8 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
         .Arg<ffi::Buffer<ffi::DataType::F32>>()    // b
         .Ret<ffi::Buffer<ffi::DataType::F32>>()    // c
         .Ret<ffi::Buffer<ffi::DataType::F32>>()    // b_plus_1
-        .Attr<size_t>("n"));
+        .Attr<size_t>("n"),
+        {xla::ffi::Traits::kCmdBufferCompatible}); // cudaGraph enabled
 
 //----------------------------------------------------------------------------//
 //                            Backward pass                                   //
@@ -135,4 +136,5 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
         .Arg<ffi::Buffer<ffi::DataType::F32>>()    // b_plus_1
         .Ret<ffi::Buffer<ffi::DataType::F32>>()    // a_grad
         .Ret<ffi::Buffer<ffi::DataType::F32>>()    // b_grad
-        .Attr<size_t>("n"));
+        .Attr<size_t>("n"),
+        {xla::ffi::Traits::kCmdBufferCompatible});  // cudaGraph enabled


### PR DESCRIPTION
~~This PR added `CmdBufferCompatible` traits to the `cuda_custom_call` example, enabling cudaGraph for the custom calls.~~ 
In addition, custom calls are now registered via `jax.extend.ffi.register_ffi_target()`, as recommended by the latest JAX guidelines. 