### PR TITLE
[export] Add support for serialization for some custom PyTree nodes

### DIFF
--- a/jax/_src/export/serialization.fbs
+++ b/jax/_src/export/serialization.fbs
@@ -28,12 +28,15 @@ enum PyTreeDefKind: byte {
   tuple = 2,
   list = 3,
   dict = 4,
+  custom = 5,
 }
 
 table PyTreeDef {
   kind: PyTreeDefKind;
   children: [PyTreeDef];
-  children_names: [string];  // only for "dict"
+  children_names: [string];  // only for "kind==dict"
+  custom_name: string;  // only for "kind==custom"
+  custom_auxdata: [byte];  // only for "kind==custom"
 }
 
 enum AbstractValueKind: byte {

--- a/jax/_src/export/serialization_generated.py
+++ b/jax/_src/export/serialization_generated.py
@@ -21,20 +21,21 @@ import flatbuffers
 from flatbuffers.compat import import_numpy
 np = import_numpy()
 
-class PyTreeDefKind:
+class PyTreeDefKind(object):
     leaf = 0
     none = 1
     tuple = 2
     list = 3
     dict = 4
+    custom = 5
 
 
-class AbstractValueKind:
+class AbstractValueKind(object):
     shapedArray = 0
     abstractToken = 1
 
 
-class DType:
+class DType(object):
     bool = 0
     i8 = 1
     i16 = 2
@@ -60,18 +61,18 @@ class DType:
     f0 = 22
 
 
-class ShardingKind:
+class ShardingKind(object):
     unspecified = 0
     hlo_sharding = 1
 
 
-class DisabledSafetyCheckKind:
+class DisabledSafetyCheckKind(object):
     platform = 0
     custom_call = 1
     shape_assertions = 2
 
 
-class PyTreeDef:
+class PyTreeDef(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -140,8 +141,42 @@ class PyTreeDef:
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         return o == 0
 
+    # PyTreeDef
+    def CustomName(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        if o != 0:
+            return self._tab.String(o + self._tab.Pos)
+        return None
+
+    # PyTreeDef
+    def CustomAuxdata(self, j):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
+        if o != 0:
+            a = self._tab.Vector(o)
+            return self._tab.Get(flatbuffers.number_types.Int8Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 1))
+        return 0
+
+    # PyTreeDef
+    def CustomAuxdataAsNumpy(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
+        if o != 0:
+            return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Int8Flags, o)
+        return 0
+
+    # PyTreeDef
+    def CustomAuxdataLength(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
+        if o != 0:
+            return self._tab.VectorLen(o)
+        return 0
+
+    # PyTreeDef
+    def CustomAuxdataIsNone(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
+        return o == 0
+
 def PyTreeDefStart(builder):
-    builder.StartObject(3)
+    builder.StartObject(5)
 
 def PyTreeDefAddKind(builder, kind):
     builder.PrependInt8Slot(0, kind, 0)
@@ -158,12 +193,21 @@ def PyTreeDefAddChildrenNames(builder, childrenNames):
 def PyTreeDefStartChildrenNamesVector(builder, numElems):
     return builder.StartVector(4, numElems, 4)
 
+def PyTreeDefAddCustomName(builder, customName):
+    builder.PrependUOffsetTRelativeSlot(3, flatbuffers.number_types.UOffsetTFlags.py_type(customName), 0)
+
+def PyTreeDefAddCustomAuxdata(builder, customAuxdata):
+    builder.PrependUOffsetTRelativeSlot(4, flatbuffers.number_types.UOffsetTFlags.py_type(customAuxdata), 0)
+
+def PyTreeDefStartCustomAuxdataVector(builder, numElems):
+    return builder.StartVector(1, numElems, 1)
+
 def PyTreeDefEnd(builder):
     return builder.EndObject()
 
 
 
-class AbstractValue:
+class AbstractValue(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -235,7 +279,7 @@ def AbstractValueEnd(builder):
 
 
 
-class Sharding:
+class Sharding(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -304,7 +348,7 @@ def ShardingEnd(builder):
 
 
 
-class Effect:
+class Effect(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -340,7 +384,7 @@ def EffectEnd(builder):
 
 
 
-class DisabledSafetyCheck:
+class DisabledSafetyCheck(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -386,7 +430,7 @@ def DisabledSafetyCheckEnd(builder):
 
 
 
-class Exported:
+class Exported(object):
     __slots__ = ['_tab']
 
     @classmethod

--- a/jax/experimental/export/__init__.py
+++ b/jax/experimental/export/__init__.py
@@ -35,8 +35,8 @@ _deprecations = {
     "call": (_deprecation_message, _src_export.call),
     "call_exported": (_deprecation_message, _src_export.call_exported),
     "default_lowering_platform":  (_deprecation_message, _src_export.default_lowering_platform),
-    "minimum_supported_serialization_version" : (_deprecation_message, _src_export.minimum_supported_calling_convention_version),
-    "maximum_supported_serialization_version" : (_deprecation_message, _src_export.maximum_supported_calling_convention_version),
+    "minimum_supported_serialization_version": (_deprecation_message, _src_export.minimum_supported_calling_convention_version),
+    "maximum_supported_serialization_version": (_deprecation_message, _src_export.maximum_supported_calling_convention_version),
 
     "serialize": (_deprecation_message, _src_serialization.serialize),
     "deserialize": (_deprecation_message, _src_serialization.deserialize),

--- a/jax/export.py
+++ b/jax/export.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 __all__ = ["DisabledSafetyCheck", "Exported", "export", "deserialize",
+           "register_pytree_node_serialization",
+           "register_namedtuple_serialization",
            "maximum_supported_calling_convention_version",
            "minimum_supported_calling_convention_version",
            "default_export_platform",
@@ -23,6 +25,8 @@ from jax._src.export._export import (
   Exported,
   export,
   deserialize,
+  register_pytree_node_serialization,
+  register_namedtuple_serialization,
   maximum_supported_calling_convention_version,
   minimum_supported_calling_convention_version,
   default_export_platform)


### PR DESCRIPTION
See the added documentation for `jax._src.export.register_pytree_node_serialization` and `jax._src.export.register_namedtuple_serialization`.

Serialization of PyTree nodes is needed to serialize the `in_tree` and `out_tree` of `Exported` function (not to serialize actual instances of the custom types).

When writing this I have looked at how TensorFlow handles namedtuple. It does so transparently, without requiring the user to register a serialization handler for the namedtuple type. But this has the disadvantage that on deserializaton a fresh distinct namedtuple type is created for each input and output type of the serialized function. This means that calling the deserialized function will return outputs of different types than then function that was serialized. This can be confusing.

The Python pickle mode does a bit better: it attempts to look up the namedtuple type as a module attribute in the deserializing code, importing automatically the module whose name was saved during serialization. This is too much magic for my taste, and can result in strange import errors.

Hence I added an explicit step for the user to say how they want the namedtuple to be serialized and deserialized.

Since I wanted to also add support for `collections.OrderedDict`, which users are asking for, I added more general support for PyTree custom nodes. Note that this registration mechanism works in conjunction with the PyTree custom node registration mechanism. The burden is on the user to decide how to serialize and deserialize the custom auxdata that the PyTree custom registration mechanism uses. Not all custom types will be serializable, but many commonly used ones, e.g., dataclasses, can now be inputs and outputs of the serialized functions.