### PR TITLE
[export] Fix github links in the export documentation

### DIFF
--- a/docs/export/export.md
+++ b/docs/export/export.md
@@ -181,7 +181,7 @@ target. To use the latest lowering rules, you can pass the
 or the `JAX_EXPORT_IGNORE_FORWARD_COMPATIBILITY=1` environment variable.
 
 Only a subset of custom calls are guaranteed stable and have
-compatibility guarantees ([see list](https://github.com/search?q=repo%3Agoogle%2Fjax%20_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE&type=code)).
+compatibility guarantees ([see list](https://github.com/search?q=repo%3Ajax-ml%2Fjax++%22_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE+%3D%22+path%3A_export.py&amp%3Btype=code&type=code)).
 We continuously
 add more custom call targets to the allowed list along with backwards
 compatibility tests. If you try to serialize
@@ -747,7 +747,7 @@ that live in jaxlib):
        * Note that the forward compatibility mode is always false in JIT mode
          or if the user passes `--jax_export_ignore_forward_compatibility=true`
        * We add `T_NEW` to the list of
-         [`_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE`](https://github.com/search?q=repo%3Agoogle%2Fjax++%22_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE+%3D%22+path%3A_export.py&amp%3Btype=code&type=code)
+         [`_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE`](https://github.com/search?q=repo%3Ajax-ml%2Fjax++%22_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE+%3D%22+path%3A_export.py&amp%3Btype=code&type=code)
          in `_export.py`.
   3. Day “D + 21” (end of forward compatibility window; can be even later than 21 days):
     We remove the `forward_compat_mode` in the lowering code, so now exporting
@@ -757,7 +757,7 @@ that live in jaxlib):
     we start the clock for the 6 months backwards compatibility.
     Note that this is relevant only if `T` is among the custom call targets for which
     we already guarantee stability, i.e., are listed in
-    [`_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE`](https://github.com/search?q=repo%3Agoogle%2Fjax++%22_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE+%3D%22+path%3A_export.py&amp%3Btype=code&type=code).
+    [`_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE`](https://github.com/search?q=repo%3Ajax-ml%2Fjax++%22_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE+%3D%22+path%3A_export.py&amp%3Btype=code&type=code).
       * If `RELEASE` is in the forward compatibility window `[D, D + 21]` and if
         we make `RELEASE` the minimum allowed jaxlib version then we can
         remove the `jaxlib_version < (0, 4, 31)` conditional in the

--- a/jax/_src/export/_export.py
+++ b/jax/_src/export/_export.py
@@ -1041,9 +1041,10 @@ def _check_module(mod: ir.Module, *,
   if disallowed_custom_call_ops:
     disallowed_custom_call_ops_str = "\n".join(disallowed_custom_call_ops)
     msg = ("Cannot serialize code with custom calls whose targets have no "
-           "compatibility guarantees. Examples are:\n"
-           f"{disallowed_custom_call_ops_str}.\n"
-           "See https://jax.readthedocs.io/en/latest/export/export.html#compatibility-guarantees-for-custom-calls")
+           "compatibility guarantees. "
+           "See https://jax.readthedocs.io/en/latest/export/export.html#compatibility-guarantees-for-custom-calls. "
+           "Examples are:\n"
+           f"{disallowed_custom_call_ops_str}.\n")
     raise ValueError(msg)
   return module_uses_non_replicated_sharding
 


### PR DESCRIPTION
Reflects the repo change google/jax -> jax-ml/jax.
Also changes the error message to put the link to the documentation in a more visible place.