### PR TITLE
Document jax config to disable remat HLO pass

### DIFF
--- a/docs/gpu_memory_allocation.rst
+++ b/docs/gpu_memory_allocation.rst
@@ -63,6 +63,6 @@ Common causes of OOM failures
 
 **Disabling rematerialization HLO pass**
   Sometimes disabling the rematerialization HLO pass is favorable to avoid 
-  poor remat choices by the compiler. The pass can be disabled by 
+  poor remat choices by the compiler. The pass can be disabled by adding
   :code:`jax.config.update('enable_remat_opt_pass', False)`. But this can 
   sometimes lead to OOM failures. 

--- a/docs/gpu_memory_allocation.rst
+++ b/docs/gpu_memory_allocation.rst
@@ -60,3 +60,9 @@ Common causes of OOM failures
 **Running JAX on the display GPU.**
   Use :code:`XLA_PYTHON_CLIENT_MEM_FRACTION` or
   :code:`XLA_PYTHON_CLIENT_PREALLOCATE`.
+
+**Disabling rematerialization HLO pass**
+  Sometimes disabling the rematerialization HLO pass is favorable to avoid 
+  poor remat choices by the compiler. The pass can be disabled by 
+  :code:`jax.config.update('enable_remat_opt_pass', False)`. But this can 
+  sometimes lead to OOM failures. 

--- a/docs/gpu_memory_allocation.rst
+++ b/docs/gpu_memory_allocation.rst
@@ -62,7 +62,11 @@ Common causes of OOM failures
   :code:`XLA_PYTHON_CLIENT_PREALLOCATE`.
 
 **Disabling rematerialization HLO pass**
-  Sometimes disabling the rematerialization HLO pass is favorable to avoid 
-  poor remat choices by the compiler. The pass can be disabled by adding
-  :code:`jax.config.update('enable_remat_opt_pass', False)`. But this can 
-  sometimes lead to OOM failures. 
+  Sometimes disabling the automatic rematerialization HLO pass is favorable to avoid 
+  poor remat choices by the compiler. The pass can be enable/disable by setting
+  :code:`jax.config.update('enable_remat_opt_pass', True)` or 
+  :code:`jax.config.update('enable_remat_opt_pass', False)` respectively. Enabling or
+  disabling the automatic remat pass produces different trade-offs between compute and 
+  memory. Note however, that the algorithm is basic and you can often get better 
+  trade-off between compute and memory by disabling the automatic remat pass and doing
+  it manually with `the jax.remat API <https://jax.readthedocs.io/en/latest/jep/11830-new-remat-checkpoint.html>`_


### PR DESCRIPTION
A recent [PR](https://github.com/jax-ml/jax/pull/23738) added a jax config option to disable the remat HLO pass. This PR adds some documentation about that config option. 