### PR TITLE
Update warning message for jit-of-pmap

### DIFF
--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -1868,7 +1868,8 @@ def _raise_warnings_or_errors_for_jit_of_pmap(
          "does not preserve sharded data representations and instead collects "
          "input and output arrays onto a single device. "
          "Consider removing the outer jit unless you know what you're doing. "
-         "See https://github.com/jax-ml/jax/issues/2926.")
+         "See https://github.com/jax-ml/jax/issues/2926. Or "
+         "use jax.experimental.shard_map instead of pmap under jit compilation.")
 
   if nreps > xb.device_count(backend):
     raise ValueError(


### PR DESCRIPTION
This PR includes a reference to shard_map in the warning message for jit-of-pmap as mentioned in the [comment](https://github.com/jax-ml/jax/issues/5178#issuecomment-1922279351).

Fixes #5178