### PR TITLE
Require ml_dtypes >= 0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     python_requires='>=3.10',
     install_requires=[
         f'jaxlib >={_minimum_jaxlib_version}, <={_jax_version}',
-        'ml_dtypes>=0.2.0',
+        'ml_dtypes>=0.4.0',
         'numpy>=1.24',
         "numpy>=1.26.0; python_version>='3.12'",
         'opt_einsum',


### PR DESCRIPTION
This is the minimum version that supports NumPy 2.0.

Fixes #24461