### PR TITLE
reduce_sum support for int4, int2 and uint4, uint2

### DIFF
--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -72,10 +72,10 @@ def _promote_integer_dtype(dtype: DTypeLike) -> DTypeLike:
   if dtypes.issubdtype(dtype, np.bool_):
     return dtypes.int_
   elif dtypes.issubdtype(dtype, np.unsignedinteger):
-    if np.iinfo(dtype).bits < np.iinfo(dtypes.uint).bits:
+    if dtypes.iinfo(dtype).bits < dtypes.iinfo(dtypes.uint).bits:
       return dtypes.uint
   elif dtypes.issubdtype(dtype, np.integer):
-    if np.iinfo(dtype).bits < np.iinfo(dtypes.int_).bits:
+    if dtypes.iinfo(dtype).bits < dtypes.iinfo(dtypes.int_).bits:
       return dtypes.int_
   return dtype
 

--- a/tests/lax_numpy_reducers_test.py
+++ b/tests/lax_numpy_reducers_test.py
@@ -913,5 +913,20 @@ class JaxNumpyReducerTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
+  @jtu.skip_on_devices("gpu", "cuda", "tpu")
+  @jtu.sample_product(dtype=[dtypes.int4, dtypes.uint4, dtypes.int2, dtypes.uint2])
+  def testLowBitSum(self, dtype) -> None:
+    if dtype is None:
+      self.skipTest(f"Current version of ml_dtypes does not support {dtype}")
+    rng = jtu.rand_default(self.rng())
+    shape = (10, 10)
+    tol = 0
+    args_maker = lambda: [rng(shape, dtype)]
+    sum_jit = jax.jit(jnp.sum)
+    np_dtype = np.uint32 if dtypes.issubdtype(dtype, np.unsignedinteger) else np.int32
+    np_sum = lambda x: np.sum(x.astype(np_dtype))
+    self._CheckAgainstNumpy(sum_jit, np_sum, args_maker, tol=tol)
+
+
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
In this PR, I propose a solution regarding summation of low-bit arrays using integer promotion. Basically, we can already perform the sum of `int8` and `uint8` dtypes since these are already numpy native. However, we cannot do the same with lower precisions, simple because `np.iinfo` does not recognize them. Formally, in the `reductions.py` file, we use the `_promote_integer_dtype` function to figure the dtype conversion target, e.g. `int8` goes to `int32` while `int64` remains `int64`. I propose to add special cases for very low bit-widths as follows

```python
def _promote_integer_dtype(dtype: DTypeLike) -> DTypeLike:
  # Note: NumPy always promotes to 64-bit; jax instead promotes to the
  # default dtype as defined by dtypes.int_ or dtypes.uint.
  if dtypes.issubdtype(dtype, np.bool_):
    return dtypes.int_
  elif dtypes.issubdtype(dtype, np.unsignedinteger):
    if dtype in [np.dtype('uint4'), np.dtype('uint2')]: # <---- changes here
      return dtypes.uint
    if np.iinfo(dtype).bits < np.iinfo(dtypes.uint).bits:
      return dtypes.uint
  elif dtypes.issubdtype(dtype, np.integer):
    if dtype in [np.dtype('int4'), np.dtype('int2')]: # <---- and here
      return dtypes.int_
    if np.iinfo(dtype).bits < np.iinfo(dtypes.int_).bits:
      return dtypes.int_
  return dtype
```

To test the change, you can run the following before and after making the change:
```python
import jax
import jax.numpy as jnp


print("sum int8")
sum_jit = jax.jit(jnp.sum)
sum_jit(
    jax.random.randint(
        key=jax.random.PRNGKey(0),
        shape=(10, 10),
        minval=0,
        maxval=16,
        dtype=jnp.int8,
    ),
)
print("sum int4")
sum_jit(
    jax.random.randint(
        key=jax.random.PRNGKey(0),
        shape=(10, 10),
        minval=0,
        maxval=16,
        dtype=jnp.int8,
    ).astype(jnp.int4),
)
print("done")
```
before the change, you should see an error after the int8 summation (which works) during the int4. After the change, both should run properly :) 