### PR TITLE
[shape_poly] Expands support for random.choice

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -1067,8 +1067,9 @@ def threefry_2x32(keypair, count):
 
   odd_size = count.size % 2
   if not isinstance(odd_size, int):
-    msg = ("jax.random functions have limited support for shape polymorphism. "
-           "In particular, the product of the known dimensions must be even.")
+    msg = ("jax.random functions have limited support for shape polymorphism "
+           "when using threefry. "
+           f"In particular, the array size ({count.size}) must be even.")
     raise core.InconclusiveDimensionOperation(msg)
 
   if odd_size:

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -2114,7 +2114,7 @@ _POLY_SHAPE_TEST_HARNESSES = [
                     polymorphic_shapes=[None, "b0, ..."],
                     expect_error=(
                         (core.InconclusiveDimensionOperation,
-                         "the product of the known dimensions must be even") if flags_name == "threefry_non_partitionable" else (None, None)),
+                         "array size .* must be even") if flags_name == "threefry_non_partitionable" else (None, None)),
                     override_jax_config_flags=override_jax_config_flags)  # type: ignore
       ]
         for key_size, flags_name, override_jax_config_flags in [


### PR DESCRIPTION
`random.choice` uses `np.insert(arr.shape, new_shape)` which attempts to coerce all the values in `new_shape` to constants when `arr.shape` is constant. Replace use of `np.insert` with tuple slicing and concatenation.

The case when the sampled axis has non-constant size and `replace=False` is not supported, because `permutation` on arrays with non-constant size is not supported.

Adds tests for many combinations of arguments for `random.choice`. Improves a few error messages.