### PR TITLE
improve concreteness error message in remat

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -410,17 +410,15 @@ def _trace_to_jaxpr(fun, in_tree, in_avals):
     jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(flat_fun, in_avals, debug)
   except core.ConcretizationTypeError as e:
     msg, = e.args
-    if 'for checkpoint' not in msg:
-      raise
-    new_msg = msg + "\n\n" + (
-        "Consider using the `static_argnums` parameter for `jax.remat` or "
-        "`jax.checkpoint`. See the `jax.checkpoint` docstring and its example "
-        "involving `static_argnums`:\n"
-        "https://jax.readthedocs.io/en/latest/_autosummary/jax.checkpoint.html"
-        "\n")
-    new_e = core.ConcretizationTypeError.__new__(core.ConcretizationTypeError)
-    new_e.args = (new_msg,)
-    raise new_e from None
+    if 'for checkpoint' in msg:
+      msg += "\n\n" + (
+          "Consider using the `static_argnums` parameter for `jax.remat` or "
+          "`jax.checkpoint`. See the `jax.checkpoint` docstring and its example "
+          "involving `static_argnums`:\n"
+          "https://jax.readthedocs.io/en/latest/_autosummary/jax.checkpoint.html"
+          "\n")
+      e.args = msg,
+    raise
   return pe.convert_constvars_jaxpr(jaxpr), consts, out_tree()
 
 


### PR DESCRIPTION
```python
import jax

@jax.remat
def f(x):
  if x > 0:
    return x
  else:
    return jnp.sin(x)

f(3.)
```

Before:

```
Traceback (most recent call last):
  File "/usr/local/google/home/mattjj/packages/jax/froystig.py", line 10, in <module>
    f(3.)
jax.errors.ConcretizationTypeError: Attempted boolean conversion of traced array with shape bool[].
The error occurred while tracing the function f at /usr/local/google/home/mattjj/packages/jax/froystig.py:3 for checkpoint. This concrete value was not available in Python because it depends on the value of the argument x.
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.TracerBoolConversionError

Consider using the `static_argnums` parameter for `jax.remat` or `jax.checkpoint`. See the `jax.checkpoint` docstring and its example involving `static_argnums`:
https://jax.readthedocs.io/en/latest/_autosummary/jax.checkpoint.html

--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
```

Setting `JAX_TRACEBACK_FILTERING=off` was no help because the important traceback info was being swallowed by a `from None`.

After:
```
Traceback (most recent call last):
  File "/usr/local/google/home/mattjj/packages/jax/froystig.py", line 10, in <module>
    f(3.)
  File "/usr/local/google/home/mattjj/packages/jax/froystig.py", line 5, in f
    if x > 0:
       ^^^^^
jax.errors.TracerBoolConversionError: Attempted boolean conversion of traced array with shape bool[].
The error occurred while tracing the function f at /usr/local/google/home/mattjj/packages/jax/froystig.py:3 for checkpoint. This concrete value was not available in Python because it depends on the value of the argument x.
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.TracerBoolConversionError
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
```