### PR TITLE
Re-enable jax2tf test for dot algorithm with stricter TF version check

### DIFF
--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -1690,11 +1690,10 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
         res,
         x + _testing_multi_platform_to_add[tf_device_jax_platform])
 
-  @unittest.skip("TODO(danfm): Test fails at head with segfault in GH")
   def test_dot_algorithm(self):
     # ref: https://github.com/jax-ml/jax/issues/24236
-    if tf.version.VERSION.split(".") <= ["2", "17", "0"]:
-      self.skipTest("This test works only with newer versions of TF")
+    if tf.version.VERSION.split(".") <= ["2", "18", "0"]:
+      self.skipTest("Because of an XLA bug this test segfaults with TF v2.18.0")
 
     if jtu.test_device_matches(["tpu"]):
       algorithm = "BF16_BF16_F32"


### PR DESCRIPTION
I expected my XLA fix for the dot algorithm segfault (https://github.com/openxla/xla/pull/18222) to make it into TF v2.18.0 which was released yesterday, but it looks like it didn't. I've updated the TF version check in the relevant test to avoid this issue when testing with the released TF.