### PR TITLE
Remove int4 from jtu.dtypes.all_dtypes.

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1452,8 +1452,7 @@ class _LazyDtypes:
 
   @_cached_property
   def all_integer(self):
-    return self.supported([
-        _dtypes.int4, np.int8, np.int16, np.int32, np.int64])
+    return self.supported([np.int8, np.int16, np.int32, np.int64])
 
   @_cached_property
   def unsigned(self):
@@ -1461,8 +1460,7 @@ class _LazyDtypes:
 
   @_cached_property
   def all_unsigned(self):
-    return self.supported([
-        _dtypes.uint4, np.uint8, np.uint16, np.uint32, np.uint64])
+    return self.supported([np.uint8, np.uint16, np.uint32, np.uint64])
 
   @_cached_property
   def complex(self):


### PR DESCRIPTION
Why? It's not included in the supported() enumeration on any platforms, so there is no need to mention it here. I tried fixing this by including it in supported(), but this led to many errors. It's better to not list it here, because it might mislead us into thinking it's being tested.