### PR TITLE
Adjust copyright notice.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ ForwardRef._evaluate = _do_not_evaluate_in_jax
 # -- Project information -----------------------------------------------------
 
 project = 'JAX'
-copyright = '2024, The JAX Authors. NumPy and SciPy documentation are copyright the respective authors.'
+copyright = '2024, The JAX Authors'
 author = 'The JAX authors'
 
 # The short X.Y version


### PR DESCRIPTION
Previously we had been pulling-in NumPy and SciPy docs at runtime, but after the work in #21461 this is no longer the case.