### PR TITLE
Fix a reference cycle bug.

### DIFF
--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -93,7 +93,7 @@ def jvp_subtrace(tag, primals, tangents):
     with core.set_current_trace(trace):
       ans = yield in_tracers, {}
     out = unzip2(map(trace.to_primal_tangent_pair, ans))
-    yield out
+  yield out
 
 @lu.transformation_with_aux
 def jvp_subtrace_aux(tag, primals, tangents):
@@ -104,7 +104,7 @@ def jvp_subtrace_aux(tag, primals, tangents):
     out_primals, out_tangents = unzip2(map(trace.to_primal_tangent_pair, ans))
     aux_primals = [x.primal if isinstance(x, JVPTracer) and x._trace.tag is tag
                    else x for x in aux]
-    yield (out_primals, out_tangents), aux_primals
+  yield (out_primals, out_tangents), aux_primals
 
 def linearize(traceable, *primals, **kwargs):
   has_aux = kwargs.pop('has_aux', False)

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -595,7 +595,7 @@ def trace_to_subjaxpr_nounits2(
         trace, instantiate, in_pvals)
     out_pvals = [t.pval for t in out_tracers]
     del out_tracers
-    yield jaxpr, (out_pvals, out_consts, env)
+  yield jaxpr, (out_pvals, out_consts, env)
 
 def _trace_to_subjaxpr_nounits(trace:JaxprTrace, instantiate, in_pvals):
   in_knowns  = [pval.is_known()     for pval in in_pvals]
@@ -641,7 +641,7 @@ def trace_to_subjaxpr_nounits_fwd(
     pruned_consts = [c for c, fwd in zip(out_consts, fwds) if fwd is None]
 
     del out_tracers
-    yield jaxpr, (fwds, out_pvals, pruned_consts, env)
+  yield jaxpr, (fwds, out_pvals, pruned_consts, env)
 
 # The below variant implements two optimizations:
 #  1. residuals that are also primal inputs are indicated in aux data rather


### PR DESCRIPTION
When we use a context manager within a linear_util.transformation we should leave the scope of the context manager before the final yield. Otherwise we create spurious reference cycles. This was causing CoreTest.test_reference_cycles to fail on Python 3.10 (but not 3.13 for some reason).