### PR TITLE
[Mosaic GPU] Improve correctness of benchmarking scripts

### DIFF
--- a/jax/experimental/mosaic/gpu/examples/flash_attention.py
+++ b/jax/experimental/mosaic/gpu/examples/flash_attention.py
@@ -649,7 +649,9 @@ if __name__ == "__main__":
       matmul_flops = (
           4 * q_seq_len * kv_seq_len * head_dim * num_q_heads * batch_size
       )
-      peak_flops = 1e15  # f16 TensorCore peak = 1000TFLOPS
+      # Table 1 in
+      # https://resources.nvidia.com/en-us-tensor-core/gtc22-whitepaper-hopper
+      peak_flops = 989.4 * 1e12  # f16 TensorCore peak
       optimal_time = matmul_flops / peak_flops * 1e6  # us
       achieved_tc_util = optimal_time / runtime_us * 100
       has_tma_warp = impl == Implementation.TWO_COMPUTE_ONE_TMA_WG

--- a/jax/experimental/mosaic/gpu/examples/matmul.py
+++ b/jax/experimental/mosaic/gpu/examples/matmul.py
@@ -378,7 +378,7 @@ def verify(
         x,
         y,
         dimension_numbers=dimension_numbers,
-        preferred_element_type=jnp.float32,
+        preferred_element_type=out_dtype,
     ).astype(out_dtype)
 
   ref, ref_runtime = profiler.measure(ref_f, x, y)


### PR DESCRIPTION
Previously in the reference function for matmul, `preferred_element_type=jnp.float32` in combination with `astype(out_dtype)` was forcing a conversion from fp32 down to fp16, causing an additional kernel to run.