### PR TITLE
RFC: add pytree-compatible dataclass decorator

### DIFF
--- a/docs/jax.tree.rst
+++ b/docs/jax.tree.rst
@@ -5,8 +5,8 @@
 
 .. automodule:: jax.tree
 
-List of Functions
------------------
+Pytree manipulation functions
+-----------------------------
 
 .. autosummary::
    :toctree: _autosummary
@@ -19,3 +19,12 @@ List of Functions
    structure
    transpose
    unflatten
+
+Pytree-compatible dataclasses
+-----------------------------
+
+.. autosummary::
+   :toctree: _autosummary
+
+   dataclass
+   field

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -933,9 +933,14 @@ def register_dataclass(
 ) -> Typ:
   """Extends the set of types that are considered internal nodes in pytrees.
 
-  This differs from ``register_pytree_with_keys_class`` in that the C++
-  registries use the optimized C++ dataclass builtin instead of the argument
-  functions.
+  .. note::
+
+     This is a lower-level API, and most users of this function will be better
+     served by using :func:`jax.tree.dataclass`; see Examples below.
+
+  :func:`register_dataclass` differs from :func:`register_pytree_with_keys_class`
+  in that the C++ registries use the optimized C++ dataclass builtin instead of
+  the argument functions.
 
   See :ref:`extending-pytrees` for more information about registering pytrees.
 

--- a/jax/tree.py
+++ b/jax/tree.py
@@ -19,6 +19,8 @@ The :mod:`jax.tree` namespace contains aliases of utilities from :mod:`jax.tree_
 
 from jax._src.tree import (
     all as all,
+    dataclass as dataclass,
+    field as field,
     flatten as flatten,
     leaves as leaves,
     map as map,

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'opt_einsum',
         'scipy>=1.10',
         "scipy>=1.11.1; python_version>='3.12'",
+        "typing_extensions>=4.5.0",
     ],
     extras_require={
         # Minimum jaxlib version; used in testing.


### PR DESCRIPTION
I think it's time for JAX to have its own pytree-compatible `dataclass` decorator similar to `flax.struct.dataclass` and `chex.dataclass`. These are mechanisms that have been re-invented by several downstream packages, and JAX can serve users well by providing it directly in JAX itself.

Given the (relatively recent) addition of `register_dataclass`, the implementation is quite concise.

Comments welcome!

Example usage:
```python
import jax

@jax.tree.dataclass
class MyClass:
    arrs: list[jax.Array]                    # By default, attributes will be treated as data fields.
    name: str = jax.tree.field(static=True)  # Optionally mark attributes as static via extended
                                             #  `dataclasses.field` mechanism.

m = MyClass([jax.numpy.arange(4), jax.numpy.ones(2)], "my class")

print(jax.tree.structure(m))
# PyTreeDef(CustomNode(MyClass[('my class',)], [[*, *]]))

print(jax.tree.leaves(m))
# [Array([0, 1, 2, 3], dtype=int32), Array([1., 1.], dtype=float32)]
```
Notice that the metadata specification uses Python's standard `dataclasses.field` mechanism. Rather than the `pytree_node=False` nomenclature used by `flax.struct.dataclass`, I opted for `static=True`, because it makes more clear the connection between pytree metadata and static arguments to JIT.