### PR TITLE
RFC: specify jit static args via Static annotation

### DIFF
--- a/jax/_src/typing.py
+++ b/jax/_src/typing.py
@@ -94,3 +94,12 @@ class DLDeviceType(enum.IntEnum):
   kDLCPU = 1
   kDLCUDA = 2
   kDLROCM = 10
+
+# Annotation for static arguments.
+StaticTag = object()
+
+# In Python 3.12, switch to this:
+# type Static[T] = typing.Annotated[T, StaticTag]
+
+T = typing.TypeVar('T')
+Static: typing.TypeAlias = typing.Annotated[T, StaticTag]

--- a/jax/typing.py
+++ b/jax/typing.py
@@ -72,4 +72,5 @@ see `Non-array inputs NumPy vs JAX`_
 from jax._src.typing import (
     ArrayLike as ArrayLike,
     DTypeLike as DTypeLike,
+    Static as Static,
 )

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1545,6 +1545,14 @@ class JitTest(jtu.BufferDonationTestCase):
       with jax.no_tracing():
         _ = f(y)  # crash!
 
+  def test_jit_static_annotation(self):
+    @jax.jit
+    def f(x: jax.Array, double: jax.typing.Static[bool]):
+      return 2 * x if double else x
+
+    self.assertEqual(f(1, True), 2)
+    self.assertEqual(f(1, False), 1)
+
 
 class APITest(jtu.JaxTestCase):
 


### PR DESCRIPTION
An idea inspired by chats with @superbobry.

Example:
```python
import jax
from jax.typing import Static

@jax.jit
def f(x: jax.Array, square: Static[bool]):
  return x ** 2 if square else x

print(f(2, True))  # 4
print(f(2, False))  # 2
```
The current way to define this would be
```python
from functools import partial

@partial(jax.jit, static_argnames=['square'])
def f(x: jax.Array, square: bool):
  return x ** 2 if square else x
```
  