### PR TITLE
Fix debug_nans false positive in jnp.quantile

### DIFF
--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -2360,7 +2360,8 @@ def _quantile(a: Array, q: Array, axis: int | tuple[int, ...] | None,
     index[axis] = high
     high_value = a[tuple(index)]
   else:
-    a = _where(any(lax_internal._isnan(a), axis=axis, keepdims=True), np.nan, a)
+    with jax.debug_nans(False):
+      a = _where(any(lax_internal._isnan(a), axis=axis, keepdims=True), np.nan, a)
     a = lax.sort(a, dimension=axis)
     n = lax.convert_element_type(a_shape[axis], lax_internal._dtype(q))
     q = lax.mul(q, n - 1)


### PR DESCRIPTION
Fixes #24732

I'm deliberately leaving out test coverage, because we don't cover this combination of configurations (`debug_nans` + `disable_jit`). But we're happy to fix these kinds of issues when they come up.