### PR TITLE
jax.device_get: handle generic extended dtypes

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2445,12 +2445,8 @@ def _device_get(x):
 
   # Extended dtypes dispatch via their device_get rule.
   if isinstance(x, basearray.Array) and dtypes.issubdtype(x.dtype, dtypes.extended):
-    try:
-      to_device = x.dtype._rules.device_get
-    except AttributeError:
-      pass
-    else:
-      return to_device(x)
+    bufs, tree = tree_util.dispatch_registry.flatten(x)
+    return tree.unflatten(device_get(bufs))
 
   # Other types dispatch via their __array__ method.
   try:

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -401,11 +401,6 @@ class KeyTyRules:
     return PRNGKeyArray(aval.dtype._impl, phys_result)
 
   @staticmethod
-  def device_get(val):
-    buffer = api.device_get(random_unwrap(val))
-    return random_wrap(buffer, impl=val.dtype._impl)
-
-  @staticmethod
   def device_put_sharded(vals, aval, sharding, devices):
     physical_aval = core.physical_aval(aval)
     physical_buffers = tree_util.tree_map(random_unwrap, vals)


### PR DESCRIPTION
We realized we don't need a special rule for this, we can do it generically via existing pytree dispatch.

This codepath is tested via existing tests of typed prng keys.