### PR TITLE
(follow-up #23852) add missing `typename` keyword to work with `gcc`

### DIFF
--- a/jaxlib/gpu/solver_kernels_ffi.cc
+++ b/jaxlib/gpu/solver_kernels_ffi.cc
@@ -915,7 +915,7 @@ ffi::Error GesvdjImpl(int64_t batch, int64_t rows, int64_t cols,
 
   auto a_data = static_cast<T*>(a.untyped_data());
   auto out_data = static_cast<T*>(out->untyped_data());
-  auto s_data = static_cast<solver::RealType<T>::value*>(s->untyped_data());
+  auto s_data = static_cast<typename solver::RealType<T>::value*>(s->untyped_data());
   auto u_data = static_cast<T*>(u->untyped_data());
   auto v_data = static_cast<T*>(v->untyped_data());
   auto info_data = info->typed_data();


### PR DESCRIPTION
@dfm This update is a follow-up of PR #23852. In the previous PR, there was one missing place where the `typename` was not added.

Without this update, when running:

```sh
python build/build.py --enable_cuda
```

the following error will occur:

```log
ERROR: /opt/jax/jaxlib/cuda/BUILD:246:11: Compiling jaxlib/gpu/solver_kernels_ffi.cc failed: (Exit 1): crosstool_wrapper_driver_is_not_gcc failed: error executing command (from target //jaxlib/cuda:cusolver_kernels_ffi) 
  (cd /root/.cache/bazel/_bazel_root/cfd1b2cc6fe180f3eb424db6004de364/execroot/__main__ && \
  exec env - \
    CLANG_COMPILER_PATH=/usr/lib/llvm-14/bin/clang \
    CLANG_CUDA_COMPILER_PATH=/usr/lib/llvm-14/bin/clang \
    LD_LIBRARY_PATH=/usr/local/lib/python3.10/dist-packages/torch/lib:/usr/local/lib/python3.10/dist-packages/torch_tensorrt/lib:/usr/local/cuda/compat/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64 \
    PATH=/root/.vscode-server/bin/e8653663e8840adaf45af01eab5c627a5af81807/bin/remote-cli:/usr/local/lib/python3.10/dist-packages/torch_tensorrt/bin:/usr/local/mpi/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/ucx/bin:/opt/tensorrt/bin \
    PWD=/proc/self/cwd \
    TF_NVCC_CLANG=1 \
...
jaxlib/gpu/solver_kernels_ffi.cc:918:29: error: missing 'typename' prior to dependent type name 'solver::RealType<T>::value'
  auto s_data = static_cast<solver::RealType<T>::value*>(s->untyped_data());
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~
                            typename
```

After fixing this error, the build will successfully pass.

* Tested on the commit: 60a6cd475b4155892a90da60bb2af086be5fc9b3
* Tested on the docker image: nvcr.io/nvidia/pytorch:24.10-py3
* Clang version: Ubuntu clang version 14.0.0-1ubuntu1.1
* GCC version: gcc version 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04)
