### PR TITLE
[JAX/distributed] Small clean ups on warning emissions in jax.distributed.

### DIFF
--- a/jax/_src/clusters/cluster.py
+++ b/jax/_src/clusters/cluster.py
@@ -49,12 +49,6 @@ class ClusterEnv:
                                            initialization_timeout: int | None,
                                           ) -> tuple[str | None, int | None, int | None,
                                                      Sequence[int] | None]:
-
-    if all(p is not None for p in (coordinator_address, num_processes,
-      process_id, local_device_ids)):
-      return (coordinator_address, num_processes, process_id,
-              local_device_ids)
-
     # First, we check the spec detection method because it will ignore submitted values
     # If if succeeds.
     if cluster_detection_method is not None:


### PR DESCRIPTION
Different users have different cluster setups. Some warnings might be meaningful for some users but not all. emitting those warnings regardless of the user's specific cluster env could lead to 1) noisy logging and 2) confusions.

This PR does two tiny things inside `jax._src.distributed`:

1. Adds a flag to disable proxy env checks and also the warning emissions.
2. Refactor the `auto_detect_distributed_params` method a bit to make it more readable and update the comments.
 - In the `_src.distributed` code, we should explicitly tell readers when all necesary args are provided, the auto-detect thing is skipped. Otherwise, users need to go in and look around to know this. Also update the comment of the method.