### PR TITLE
Make sure compilation_cache.is_cache_used always returns a bool

### DIFF
--- a/jax/_src/compilation_cache.py
+++ b/jax/_src/compilation_cache.py
@@ -84,6 +84,8 @@ def is_cache_used(backend: xla_client.Client) -> bool:
         _cache_used = True
       return _cache_used
 
+  return False
+
 
 def get_file_cache(path: str) -> tuple[CacheInterface, str] | None:
   """Returns the file cache and the path to the cache."""


### PR DESCRIPTION
In some cases, `compilation_cache.is_cache_used` can reach the end of the function body without returning anything. This amounts to an implicit `return None`, which is not in line with the functions return type of `bool`. We fix this by adding a final `return False` to the function.