### PR TITLE
[JAX/version] Support adding custom version suffix.

### DIFF
--- a/jax/version.py
+++ b/jax/version.py
@@ -60,7 +60,11 @@ def _version_from_git_tree(base_version: str) -> str | None:
   except:
     return None
   else:
-    return f"{base_version}.dev{datestring}+{commit_hash}"
+    version = f"{base_version}.dev{datestring}+{commit_hash}"
+    suffix = os.environ.get("JAX_CUSTOM_VERSION_SUFFIX", None)
+    if suffix:
+      return version + "." + suffix
+    return version
 
 
 def _get_version_for_build() -> str:


### PR DESCRIPTION
This PR attempts to add a custom version suffix for JAX dev builds.

The versioning is important when people want to hash the compilation result of the JIT program. The users can use whatever local version of XLA repo and pass a version suffix constructed on their own side as part of the hash key.

This will greatly enhance the cache key especially when developers are doing dev builds based on different commits or local change.