### PR TITLE
doc: link directly to installation on the main page

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -8,15 +8,15 @@
   background-color: #fff;
 }
 
-.getting-started {
+.installation {
   background-color: rgba(78, 150, 253, var(--block-bg-opacity));
 }
 
-.user-guides {
+.getting-started {
   background-color: rgba(0, 169, 154, var(--block-bg-opacity));
 }
 
-.developer-docs {
+.user-guides {
   background-color: rgba(171, 0, 182, var(--block-bg-opacity));
 }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,12 @@ designed for high-performance numerical computing and large-scale machine learni
 
 .. grid:: 3
 
+    .. grid-item-card:: :material-regular:`laptop_chromebook;2em` Installation
+      :columns: 12 6 6 4
+      :link: installation
+      :link-type: ref
+      :class-card: installation
+
     .. grid-item-card:: :material-regular:`rocket_launch;2em` Getting started
       :columns: 12 6 6 4
       :link: beginner-guide
@@ -43,12 +49,6 @@ designed for high-performance numerical computing and large-scale machine learni
       :link: user-guides
       :link-type: ref
       :class-card: user-guides
-
-    .. grid-item-card:: :material-regular:`laptop_chromebook;2em` Developer notes
-      :columns: 12 6 6 4
-      :link: contributor-guide
-      :link-type: ref
-      :class-card: developer-docs
 
 If you're looking to train neural networks, use Flax_ and start with its tutorials.
 For an end-to-end transformer library built on JAX, see MaxText_.


### PR DESCRIPTION
Probably more users will be looking for installation instructions than for development docs when landing on the main page: we should make installation more prominent.