### PR TITLE
[pallas] Expand shape polymorphism support for Pallas.

### DIFF
--- a/jax/_src/pallas/core.py
+++ b/jax/_src/pallas/core.py
@@ -411,13 +411,6 @@ class BlockSpec:
       )
     block_aval = AbstractMemoryRef(block_array_aval, self.memory_space)
 
-    if not jax_core.is_constant_shape(block_aval.shape):
-      raise ValueError(
-          "shape polymorphism for Pallas does not support "
-          "dynamically-shaped blocks. "
-          f"Block spec for {origin} has block_shape: {block_aval.shape}"
-      )
-
     flat_index_map_fun, index_map_out_tree_thunk = api_util.flatten_fun(
         lu.wrap_init(index_map_func), index_map_tree
     )

--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -187,6 +187,10 @@ def _dtype_to_ir_type(dtype: jnp.dtype,
   else:
     return type
 
+def ir_shape(shape: jax_core.Shape):
+  dyn_size = ir.ShapedType.get_dynamic_size()
+  return [d if type(d) is int else dyn_size for d in shape]
+
 def aval_to_ir_type(aval,
                     shape=None,
                     memory_space: MemorySpace | None = None,
@@ -218,7 +222,7 @@ def aval_to_ir_type(aval,
     if shape is None:
       shape = aval.shape
     memspace = _memory_space_to_mosaic_attribute(memory_space)
-    return ir.MemRefType.get(shape,
+    return ir.MemRefType.get(ir_shape(shape),
       _dtype_to_ir_type(aval.dtype, is_kernel_boundary=True),
       memory_space=memspace)
   if isinstance(aval, jax_core.ShapedArray):
@@ -228,7 +232,7 @@ def aval_to_ir_type(aval,
       return _dtype_to_ir_type(
           aval.dtype, is_kernel_boundary=is_kernel_boundary)
     return ir.VectorType.get(
-        shape,
+        ir_shape(shape),
         _dtype_to_ir_type(aval.dtype, is_kernel_boundary=is_kernel_boundary))
   raise NotImplementedError(aval)
 

--- a/jax/_src/state/indexing.py
+++ b/jax/_src/state/indexing.py
@@ -36,9 +36,9 @@ class Slice:
   and compilation time, or dynamic.
   """
 
-  start: int | Array
-  size: int | Array
-  stride: int = 1
+  start: core.DimSize | Array
+  size: core.DimSize | Array
+  stride: core.DimSize = 1
 
   def __post_init__(self):
     if self.stride < 1:


### PR DESCRIPTION
Currently, shape polymorphism works for Pallas for symbolic input sizes and grids, but statically-shaped blocks.

This change adds tests for the cases where the blocks would have to be symbolic. These tests are now failing, WIP to
see what it would take to enable them.

