### PR TITLE
allow custom_gradient to close over non-autodiff tracers

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -9030,7 +9030,7 @@ class CustomVJPTest(jtu.JaxTestCase):
       vjp = lambda g: (jnp.cos(x) * jnp.arange(3., 6.),)
       return jnp.sum(jnp.sin(x)), vjp
 
-    self.assertAllClose(f(jnp.arange(3)), jnp.sum(jnp.sin(jnp.arange(3.))),
+    self.assertAllClose(f(jnp.arange(3.)), jnp.sum(jnp.sin(jnp.arange(3.))),
                         check_dtypes=False)
     self.assertAllClose(
         api.grad(f)(jnp.arange(3.)),
@@ -9045,6 +9045,20 @@ class CustomVJPTest(jtu.JaxTestCase):
     self.assertAllClose(f(3.), 9., check_dtypes=False)
     self.assertAllClose(api.grad(f)(3.), 3., check_dtypes=False)
     self.assertAllClose(api.grad(api.grad(f))(3.), 1., check_dtypes=False)
+
+  def test_custom_gradient_jit_closure(self):
+    @jax.jit
+    def f(x, y):
+      y = jnp.sin(y)
+
+      @jax.custom_gradient
+      def g(x):
+        return y * jnp.sin(x), lambda g: (y * jnp.cos(x) * g,)
+
+      return g(x)
+
+    g = jax.grad(f)(1., 2.)
+    self.assertAllClose(g, jnp.sin(2.) * jnp.cos(1.), check_dtypes=False)
 
   def test_closure_convert(self):
     def cos_after(fn, x):


### PR DESCRIPTION
re-landing #24545, after (1) downstream fixes and (2) rearrangements to pytree handling to preserve error messages and corner case behaviors