### PR TITLE
Add an example demonstrating input-output aliasing with the FFI

### DIFF
--- a/examples/ffi/src/jax_ffi_example/cpu_examples.py
+++ b/examples/ffi/src/jax_ffi_example/cpu_examples.py
@@ -39,3 +39,9 @@ def dictionary_attr(**kwargs):
 def counter(index):
   return jax.ffi.ffi_call(
     "counter", jax.ShapeDtypeStruct((), jax.numpy.int32))(index=int(index))
+
+
+def aliasing(x):
+  return jax.ffi.ffi_call(
+      "aliasing", jax.ShapeDtypeStruct(x.shape, x.dtype),
+      input_output_aliases={0: 0})(x)

--- a/examples/ffi/tests/cpu_examples_test.py
+++ b/examples/ffi/tests/cpu_examples_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from absl.testing import absltest
+from absl.testing import absltest, parameterized
 
 import jax
 import jax.numpy as jnp
@@ -89,6 +89,17 @@ class CounterTests(jtu.JaxTestCase):
     # Persists after the cache is cleared
     counter_fun.clear_cache()
     self.assertEqual(counter_fun(0)[1], 3)
+
+
+class AliasingTests(jtu.JaxTestCase):
+  def setUp(self):
+    super().setUp()
+    if not jtu.test_device_matches(["cpu"]):
+      self.skipTest("Unsupported platform")
+
+  @parameterized.parameters((jnp.linspace(0, 0.5, 10),), (jnp.int32(6),))
+  def test_basic(self, x):
+    self.assertAllClose(cpu_examples.aliasing(x), x)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
diffbase https://github.com/jax-ml/jax/pull/25041

As requested in https://github.com/jax-ml/jax/issues/24986, this PR adds an FFI example that uses input-output aliasing.

Fixes https://github.com/jax-ml/jax/issues/24986

Edited to add: This is the relevant diff: https://github.com/dfm/jax/compare/ffi-example-refactor...ffi-example-input-output-alias