### PR TITLE
[ROCM] Jax/Pallas unit test, limiting tile to 64 in for pallas kernel in multihead attention test.

### DIFF
--- a/tests/pallas/gpu_ops_test.py
+++ b/tests/pallas/gpu_ops_test.py
@@ -284,8 +284,12 @@ class FusedAttentionTest(PallasBaseTest):
       segment_ids = None
 
     def f(q, k, v):
-      return attention.mha(q, k, v, segment_ids, causal=causal,
-                           interpret=self.INTERPRET).sum()
+      if jtu.is_device_rocm():
+        return attention.mha(q, k, v, segment_ids, 1.0, causal, 64, 64,
+                             interpret=self.INTERPRET).sum()
+      else:
+        return attention.mha(q, k, v, segment_ids, causal=causal,
+                             interpret=self.INTERPRET).sum()
 
     def f_ref(q, k, v):
       return attention.mha_reference(q, k, v, segment_ids, causal=causal).sum()


### PR DESCRIPTION
Limiting tile size to 64 for AMD platform on multihead attention test for pallas kernels. Default tile size is set to 128.
A bigger tile size requires more shared memory, and AMD HW is not withstanding with default tile size.