### PR TITLE
Use optimize='auto' for `jnp.linalg.multi_dot`

### DIFF
--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -2119,7 +2119,7 @@ def multi_dot(arrays: Sequence[ArrayLike], *, precision: PrecisionLike = None) -
   if arrs[-1].ndim == 1:
     einsum_axes[-1] = einsum_axes[-1][:1]
   return jnp.einsum(*itertools.chain(*zip(arrs, einsum_axes)),  # type: ignore[call-overload]
-                    optimize='optimal', precision=precision)
+                    optimize='auto', precision=precision)
 
 
 @export


### PR DESCRIPTION
This is a re-land of https://github.com/jax-ml/jax/pull/21146, which was mistakenly(?) reverted in https://github.com/jax-ml/jax/pull/21119. This regression was noted in https://github.com/jax-ml/jax/issues/25051.