### PR TITLE
Added stream annotation support via @compute_on('stream:#') decorator

### DIFF
--- a/jax/_src/compute_on.py
+++ b/jax/_src/compute_on.py
@@ -40,10 +40,11 @@ def current_compute_type() -> str | None:
   return config.compute_on_context_manager.value
 
 def _check_valid(c_type: str):
-  if c_type not in {'device_host', 'device', 'tpu_sparsecore'}:
+  if (c_type not in {'device_host', 'device', 'tpu_sparsecore'}
+      and not c_type.startswith("gpu_stream:")):
     raise ValueError(
         f'Invalid compute type {c_type}. Current supported values '
-        'are `device_host`, `device` and `tpu_sparsecore`.')
+        'are `device_host`, `device`, `tpu_sparsecore`, and `gpu_stream:#`. ')
 
 @contextmanager
 def compute_on(compute_type: str):

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -2329,9 +2329,14 @@ def map_compute_type(c_type):
 
 def wrap_compute_type_in_place(ctx, op):
   if ctx.jaxpr_eqn_ctx is not None and ctx.jaxpr_eqn_ctx.compute_type is not None:
-    dict_attr = {"_xla_compute_type": ir.StringAttr.get(
-        map_compute_type(ctx.jaxpr_eqn_ctx.compute_type))}
-    op.operation.attributes["mhlo.frontend_attributes"] = ir.DictAttr.get(dict_attr)
+    if ctx.jaxpr_eqn_ctx.compute_type.startswith("gpu_stream:"):
+      stream = ctx.jaxpr_eqn_ctx.compute_type.split(":")[1]
+      dict_attr = {"_xla_stream_annotation": ir.StringAttr.get(stream)}
+      op.operation.attributes["mhlo.frontend_attributes"] = ir.DictAttr.get(dict_attr)
+    else:
+      dict_attr = {"_xla_compute_type": ir.StringAttr.get(
+          map_compute_type(ctx.jaxpr_eqn_ctx.compute_type))}
+      op.operation.attributes["mhlo.frontend_attributes"] = ir.DictAttr.get(dict_attr)
 
 
 def wrap_xla_metadata_in_place(ctx, op):


### PR DESCRIPTION
This is a tiny change that will add the stream annotation `frontend_attribute` when usin a `compute_on("stream:#")` decorator. This feature is intended to be used when trying to implement a collective matrix multiplication "by hand" within a `shard_map` to be able to better utilize SMs. 

During most cublass / cutlass gemm subroutines, not all SMs are utilized by the kernels due to a process called "wave quantization". Essentially what happens is that each gemm kernel will only use SMs until it reaches an amount that is a divisor of the contracting dimension, leaving the other SMs essentially sitting idle. These idle SMs prevent us from getting full performance of our GPUs. 

If we want to be able to use these idle SMs in our CM subroutine, we would need to be able to run at least 2 gemms in parallel. That isn't currently possible within a `shard_map`, as all of the compute kernels get launched on a single cuda stream. By adding this feature, we would be able to explicitly launch these kernels on several streams.

This feature is not yet fully enabled in XLA, and will sit behind a `--xla_gpu_experimental_stream_annotation` flag for the foreseeable future. When this flag is not enabled, this attribute is just ignored. 