### PR TITLE
[Mosaic GPU] Restrict WGMMA tests to sm90a

### DIFF
--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -169,6 +169,10 @@ class TestCase(parameterized.TestCase):
     self.enter_context(mlir.make_ir_context())
     self.enter_context(ir.Location.unknown())
 
+  def skip_unless_sm90a(self):
+    if not jtu.is_cuda_compute_capability_equal("9.0"):
+      self.skipTest("Only works on GPU with capability sm90a")
+
 
 class TestUtilTest(TestCase):
 
@@ -582,6 +586,7 @@ class WGMMATest(TestCase):
       swizzle,
       jax_out_dtype,
   ):
+    self.skip_unless_sm90a()
     if jax_out_dtype == jnp.float16 and in_mlir_dtype_cls is not ir.F16Type:
       raise self.skipTest("Only f16 input is supported for f16 output.")
     if swizzle != 128 and lhs_transpose:
@@ -713,6 +718,7 @@ class WGMMATest(TestCase):
       dtype=[jnp.float16, jnp.bfloat16],
   )
   def test_wgmma_reg_lhs(self, m, n, k_steps, rhs_transpose, swizzle, dtype):
+    self.skip_unless_sm90a()
     index = ir.IndexType.get()
 
     row_major = mgpu.WGMMALayout.ROW_MAJOR
@@ -765,6 +771,7 @@ class WGMMATest(TestCase):
       swizzle=(32, 64, 128),
   )
   def test_narrow_n(self, rhs_transpose, swizzle):
+    self.skip_unless_sm90a()
     m, n, k_steps = 64, 8, 2
 
     row_major = mgpu.WGMMALayout.ROW_MAJOR


### PR DESCRIPTION
Follow up to https://github.com/jax-ml/jax/pull/24839.