### PR TITLE
Improve trace-time performance of jnp.isscalar

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -624,9 +624,11 @@ def isscalar(element: Any) -> bool:
     >>> jnp.isscalar(slice(10))
     False
   """
-  if (isinstance(element, (np.ndarray, jax.Array))
-      or hasattr(element, '__jax_array__')
-      or np.isscalar(element)):
+  if np.isscalar(element):
+    return True
+  elif isinstance(element, (np.ndarray, jax.Array)):
+    return element.ndim == 0
+  elif hasattr(element, '__jax_array__'):
     return asarray(element).ndim == 0
   return False
 


### PR DESCRIPTION
This avoids calling `device_put` on non-jax values within `isscalar`. This should improve trace time for `isscalar` and functions that use it, such as array indexing.

Before:
```python
In [1]: import jax
In [2]: %timeit jax.numpy.isscalar(1)
23.9 μs ± 162 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```
After:
```python
In [1]: import jax
In [2]: %timeit jax.numpy.isscalar(1)
108 ns ± 0.59 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```
(This is part of addressing #25109)