### PR TITLE
[WIP] Add explicit simple vmap customization patterns

### DIFF
--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -2204,7 +2204,7 @@ def call_lowering(fn_name, name_stack, call_jaxpr, backend,
   return out_nodes, tokens_out
 
 def core_call_lowering(ctx: LoweringRuleContext,
-                       *args, name, backend=None, call_jaxpr):
+                       *args, name, backend=None, call_jaxpr, **_):
   out_nodes, tokens = call_lowering(
       name, ctx.name_stack, call_jaxpr, backend, ctx.module_context,
       ctx.avals_in, ctx.avals_out, ctx.tokens_in, *args,


### PR DESCRIPTION
In its general form, `custom_vmap` can't be used with reverse-mode autodiff without `custom_vjp` because it's not clear how to generate vmap rules for partial eval or transposition based on a rule for a primal computation. But, most uses of `custom_vmap` follow some common patterns, and it seems feasible to implement special cases for these patterns.

The specific patterns that we are considering are similar to the ones supported by `pure_callback` and `ffi_call`, and possibly a couple of others.

I'll update this description as I work on this.