### PR TITLE
array API: improve test coverage

### DIFF
--- a/.github/workflows/jax-array-api.yml
+++ b/.github/workflows/jax-array-api.yml
@@ -38,11 +38,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install .[ci]
-        python -m pip install -r array-api-tests/requirements.txt
+        python -m pip install pytest-xdist -r array-api-tests/requirements.txt
     - name: Run the test suite
       env:
         ARRAY_API_TESTS_MODULE: jax.numpy
         JAX_ENABLE_X64: 'true'
       run: |
         cd ${GITHUB_WORKSPACE}/array-api-tests
-        pytest array_api_tests --max-examples=5 --derandomize --disable-deadline --skips-file ${GITHUB_WORKSPACE}/tests/array_api_skips.txt
+        pytest -n auto array_api_tests --derandomize --disable-deadline --skips-file ${GITHUB_WORKSPACE}/tests/array_api_skips.txt

--- a/tests/array_api_skips.txt
+++ b/tests/array_api_skips.txt
@@ -13,3 +13,9 @@ array_api_tests/test_special_cases.py::test_unary[sign((x_i is -0 or x_i == +0))
 
 # Returns int32 when int64 is expected
 array_api_tests/test_searching_functions.py::test_searchsorted
+
+# clip out dtype has ambiguous semantics (https://github.com/numpy/numpy/issues/24976)
+array_api_tests/test_operators_and_elementwise_functions.py::test_clip
+
+# JAX raises a ValueError rather than the expected IndexError for out-of-bound axis
+array_api_tests/test_manipulation_functions.py::test_expand_dims


### PR DESCRIPTION
`max_examples` defaults to 200; previously there were some performance issues in the test suite that led to timeouts with the full run, so we limited it to 5 examples. That seems to have been fixed, and we can now do the full test run in about 3 minutes of CI time.