### PR TITLE
[ROCm] Fix kernel build

### DIFF
--- a/jaxlib/tools/build_gpu_kernels_wheel.py
+++ b/jaxlib/tools/build_gpu_kernels_wheel.py
@@ -145,7 +145,7 @@ def prepare_wheel_rocm(
           f"__main__/jaxlib/rocm/_linalg.{pyext}",
           f"__main__/jaxlib/rocm/_prng.{pyext}",
           f"__main__/jaxlib/rocm/_sparse.{pyext}",
-          f"__main__/jaxlib/cuda/_hybrid.{pyext}",
+          f"__main__/jaxlib/rocm/_hybrid.{pyext}",
           f"__main__/jaxlib/rocm/_triton.{pyext}",
           f"__main__/jaxlib/rocm_plugin_extension.{pyext}",
           "__main__/jaxlib/version.py",


### PR DESCRIPTION
When we build the wheel that contains prebuilt GPU kernels, we want to check the  directory for the hybrid file instead of the  directory, which won't exist if you're only building the ROCm wheel.

Created from: rocm/jax#173