### PR TITLE
Avoid index out of range error in carry structure check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 
 ## jax 0.4.37
 
+* Bug fixes
+  * Fix a bug that will throw `index out of range` error in
+    {func}`jax.lax.while_loop` if the user register pytree node class with
+    different aux data for the flatten and flatten_with_path.
+
 ## jax 0.4.36 (Dec 5, 2024)
 
 * Breaking Changes

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -376,6 +376,9 @@ def _check_carry_type(name, body_fun, in_carry, out_carry_tree, out_avals):
                f'of the carry output is a {thing2}, so {explanation}'
                for path, thing1, thing2, explanation
                in equality_errors(in_carry, out_carry)]
+      if len(diffs) == 0:
+        # The trees may have different aux data but structures are the same.
+        return
       if len(diffs) == 1:
         differences = f'{diffs[0]}.\n'.capitalize()
       else:
@@ -393,6 +396,9 @@ def _check_carry_type(name, body_fun, in_carry, out_carry_tree, out_avals):
              f'{out_aval.str_short()}{_aval_mismatch_extra(in_aval, out_aval)}'
              for path, in_aval, out_aval in zip(paths, in_avals, out_avals)
              if not core.typematch(in_aval, out_aval)]
+    if len(diffs) == 0:
+      # The trees may have different aux data but structures are the same.
+      return
     if len(diffs) == 1:
       differences = f'{diffs[0]}.\n'.capitalize()
     else:

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -322,6 +322,19 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       lax.while_loop(lambda c: True, lambda c: (True, True),
                      (np.bool_(True), np.float32(0.)))
 
+  def testWhileLoopCustomPytreeDiffAuxData(self):
+    class Node:
+      def __init__(self, x, y):
+        self.x = x
+        self.y = y
+    tree_util.register_pytree_with_keys(
+        Node,
+        lambda o: ((("x", o.x), ("y", o.y)), 'with_keys'),  # flatten_with_keys
+        lambda _, xy: Node(xy[0], xy[1]),   # unflatten (no key involved)
+        lambda o: ((o.x, o.y), 'without_keys'),    # flatten
+    )
+    lax.while_loop(lambda o: o.x > 0., lambda c: Node(0., 0.), Node(1., 1.))
+
   def testNestedWhileWithDynamicUpdateSlice(self):
     num = 5
 


### PR DESCRIPTION
Make sure to only throw error of a pytree mismatch when we can calculate sensible diffs from them.

This is because a custom pytree node may produce different aux data for flatten and flatten-with-path registries, and simply checking aux data equality won't be enough. In long term we should enforce the same aux data being returned in both registered functions.

Tested on the currently-breaking Chex dataclass tests.