### PR TITLE
Update conda-forge installation docs after drop of support for CUDA 11

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -253,17 +253,13 @@ simply run:
 conda install jax -c conda-forge
 ```
 
-To install it on a machine with an NVIDIA GPU, run:
+If you run this command on machine with an NVIDIA GPU, this should install a CUDA-enabled package of `jaxlib`.
+
+To ensure that the jax version you are installing is indeed CUDA-enabled, run:
 
 ```bash
-conda install "jaxlib=*=*cuda*" jax cuda-nvcc -c conda-forge -c nvidia
+conda install "jaxlib=*=*cuda*" jax -c conda-forge
 ```
-
-Note the `cudatoolkit` distributed by `conda-forge` is missing `ptxas`, which
-JAX requires. You must therefore either install the `cuda-nvcc` package from
-the `nvidia` channel, or install CUDA on your machine separately so that `ptxas`
-is in your path. The channel order above is important (`conda-forge` before
-`nvidia`).
 
 If you would like to override which release of CUDA is used by JAX, or to
 install the CUDA build on a machine without GPUs, follow the instructions in the


### PR DESCRIPTION
Since April 2024 `jax` does not support anymore CUDA 11, see https://github.com/jax-ml/jax/blob/jax-v0.4.37/CHANGELOG.md#jaxlib-0426-april-3-2024 .

If only CUDA 12 is supported, the installation instructions for the `conda-forge` build of `jax` can be simplified:
* Since CUDA 12, the `ptxas` executable is now available directly in conda-forge and is automatically installed as a dependency of cuda-enabled `jaxlib` builds (see https://github.com/conda-forge/jaxlib-feedstock/pull/241), so there is no need to manually add the `nvidia` channel or install additional packages, or explain what this additional packages are
* Unless the latest build of CUDA-enabled `jaxlib` gets marked as `broken` (i.e. `yanked`) for any reason, on a machine with a CUDA-enabled GPU `conda install jax -c conda-forge` will automatically install the CUDA-enabled build of `jaxlib`. However, this will silently fail if for any reason `nvidia-smi` does not work on the machine, so I also left the documentation on the command to explicitly request the installation of a CUDA-enabled build of `jaxlib`. 