### PR TITLE
Add matrix logm

### DIFF
--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -1816,6 +1816,239 @@ def sqrtm(A: ArrayLike, blocksize: int = 1) -> Array:
       raise NotImplementedError("Blocked version is not implemented yet.")
   return _sqrtm(A)
 
+def _fractional_power_superdiag_entry(l1, l2, t12, p):
+  """
+    Compute a superdiagonal entry of a fractional matrix power.
+
+    References
+    ----------
+    .. [1] Nicholas J. Higham and Lijing lin (2011)
+           "A Schur-Pade Algorithm for Fractional Powers of a Matrix."
+           SIAM Journal on Matrix Analysis and Applications,
+           32 (3). pp. 1056-1078. ISSN 0895-4798
+
+    """
+  if l1==l2:
+    return t12*p*l1**(p-1)
+  if jnp.abs(l1) < jnp.abs(l2)/2 or jnp.abs(l2) < jnp.abs(l1)/2:
+    return t12 * ((l2**p)-(l1**p))/(l2-l1)
+  
+  log_l1 = jnp.log(l1)
+  log_l2 = jnp.log(l2)
+  def unwinding_number(z):
+    """Equation 5.3"""
+    return int(jnp.ceil((z.imag - jnp.pi) / (2*jnp.pi)))
+  
+  U = unwinding_number(log_l2-log_l1)
+  return t12 * jnp.exp(p/2*(log_l2+log_l1)) * (2* jnp.sinh(p*(jnp.arctanh(z) + jnp.np*1j*U))) / (l2-l1)
+
+def _briggs_helper_function(a: float, k:int)->float:
+  """
+    References:
+    .. [1] Awad H. Al-Mohy (2012) "A more accurate Briggs method for the logarithm",
+           Numerical Algorithms, 59 : 393--402.
+  """
+  pi_half = jnp.pi/2
+  k_hat = k
+  if jnp.angle(a) >= pi_half:
+    a = jnp.sqrt(a)
+    k_hat = k-1
+  z_0 = a-1
+  a = jnp.sqrt(a)
+  r = 1 + a
+  for _ in range(1, k_hat):
+    a = jnp.sqrt(a)
+    r = r * (1 + a)
+  r = z_0/r
+  return r
+
+def onenormest(A: Array, key:ArrayLike, t:int=2, itmax:int=5)->float:
+  if t>=A.shape[-1]:
+    # if t is greater than number of columns it is faster to just compute exact value
+    # we also avoid getting stuck in an infinite loop when generating vectors that are not parallel in algorithm
+    return jnp.linalg.norm(A, 1, axis=(-2, -1))
+  else:
+    return _onenormest(A, key, t, itmax)
+
+def _onenormest(A: Array, key:ArrayLike, t:int=2, itmax:int=5)->float:
+  """
+    .. [1] Nicholas J. Higham and Francoise Tisseur (2000),
+          "A Block Algorithm for Matrix 1-Norm Estimation,
+          with an Application to 1-Norm Pseudospectra."
+          SIAM J. Matrix Anal. Appl. Vol. 21, No. 4, pp. 1185-1201.
+  """
+  n = A.shape[-1]
+  ind_hist = jnp.empty(0, dtype=jnp.int32)
+  est_old = 0
+  ind = jnp.zeros((n, 1))
+  S = jnp.zeros((n,t))
+
+  #  initialize starting matrix X with columns of unit 1-norm
+  #  choice of columns is explained in scipy/sparse/linalg/_onenormest.py
+  X = jnp.ones((n, t))
+
+  if t > 1:
+    for i in range(1, t):
+        key, subkey = jax.random.split(key)
+        rand_val = jax.random.randint(subkey, shape=X.shape[0], minval=0, maxval=2)*2 - 1
+        X = X.at[:, i].set(rand_val.astype(X.dtype))
+    for i in range(t):
+        #  resample if column of X is parallel to a previous column
+        #  Parrarel vectors will are equal or opposite in this case so their dot product is n
+        while (X[:, :i].T @ X[:, i] == n).any():
+            key, subkey = jax.random.split(key)
+            rand_val = jax.random.randint(subkey, shape=X.shape[0], minval=0, maxval=2)*2 - 1
+            X = X.at[:, i].set(rand_val.astype(X.dtype))
+    
+  X /= n
+  
+  k=1
+  ind = None
+  while k<=itmax:
+    Y = A @ X
+    summed_abs_cols = jnp.abs(Y).sum(0)
+    est = jnp.max(summed_abs_cols)
+    ind_j = jnp.argmax(summed_abs_cols)
+    if k ==2:
+      ind_best = ind[ind_j]
+    if k>2 and est<est_old:
+      est = est_old
+      break
+    est_old=est
+    S_old = S
+    if k>itmax:
+      break
+    S = (Y+(Y==0).astype(Y.dtype))/jnp.abs(Y)
+    if (S.T@S_old == n).all():
+      break
+    if t > 1:
+      # Ensure that no column of S is parallel to another column of S
+      # or to a column of S_old by replacing columns of S by rand{−1, 1}
+      for i in range(t):
+        while (S[:, :i].T@S[:, i] == n).any() or (S_old.T@S[:, i] == n).any():
+          key, subkey = jax.random.split(key)
+          rand_val = jax.random.randint(subkey, shape=X.shape[0], minval=0, maxval=2)*2 - 1
+          S = S.at[:, i].set(rand_val.astype(X.dtype))
+
+    Z = A.T @ S
+    h = jnp.abs(Z).max(1)
+    if k>=2 and jnp.max(h)==h[ind_best]:
+      break
+    ind = jnp.argsort(h, descending=True)[:t+len(ind_hist)]
+    if t > 1:
+      if jnp.isin(ind[:t], ind_hist).all():
+        break
+      seen = jnp.isin(ind, ind_hist)
+      ind = jnp.concatenate((ind[~seen], ind[seen]))
+    
+    elementary_vectors = jax.nn.one_hot(ind, n).T
+    X = elementary_vectors[:, :t]
+    new_ind = ind[:t][~jnp.isin(ind[:t], ind_hist)]
+    ind_hist = jnp.concatenate((ind_hist, new_ind))
+    k += 1
+
+  return est
+
+
+  
+
+def _inverse_squaring(T_0: Array, theta: list[float]):
+  def normest(T: Array, p: int):
+    T = jnp.linalg.matrix_power(T-jnp.eye(T.shape[0]), p)
+    return _onenormest(T, p)
+  T = T_0
+  diag = jnp.diag(T)
+  s_0 = 0
+  while jnp.max((diag-1).abs()) > theta[7]:
+    diag = jnp.sqrt(diag)
+    s_0 +=1
+  
+  for _ in range(s_0):
+    T = _sqrtm_triu(T)
+
+  s = s_0
+  k = 0
+  d_2= normest(T, 2)**(1/2)
+  d_3 = normest(T, 3)**(1/3)
+  a_2 = max(d_2, d_3)
+  m=0
+  for i in (1, 2):
+    if a_2 < theta[i]:
+      m = i
+  
+  #  in this loop replace goto line 32 with continue and 35 with break
+  while m!=0:
+    if s>s_0:
+      d_3 = normest(T, 3)**(1/3)
+    d_4 = normest(T, 4)**(1/4)
+    a_3 = max(d_3, d_4)
+    if a_3 < theta[7]:
+      j_1 = min(i for i in range(3, 8) if a_3 < theta[i])
+      if j_1<6:
+        m = j_1
+        # goto 
+        break
+      if a_3/2<theta[5] and k<2:
+        k += 1
+        T = _sqrtm_triu(T)
+        s +=1
+        continue
+      d_5 = normest(T, 5)**(1/5)
+      a_4 = max(d_4, d_5)
+      eta = max(a_3, a_4)
+      for i in (6, 7):
+        if eta < theta[i]:
+          m = i
+          break
+
+    T = _sqrtm_triu(T)
+    s += 1
+    #  R = (T - I), but we compute it with briggs algorithm to avoid cancellation on diagonal
+    R = T
+
+    for i in range(T.shape[-1]):
+      a = T_0[..., i, i]
+      R[..., i, i] = _briggs_helper_function(a ,s)
+
+    # replace superdiagonal
+    p = jnp.exp2(-s)
+    for i in range(T.shape[-1]-1):
+      l1 = T_0[i, i]
+      l2 = T_0[i+1, i+1]
+      t12 = T_0[i, i+1]
+      R[i, i+1] = _fractional_power_superdiag_entry(l1, l2, t12, p)
+
+  return R, s, m
+  
+
+@jit
+def _logm_triu(T: Array) -> Array:
+  """
+  """
+
+  diag = jnp.sqrt(jnp.diag(T))
+  keep_real = jnp.isrealobj(T) and jnp.min(diag, initial=0.0) >= 0.0
+  T_0 = T
+  if not keep_real:
+    T_0 = T_0.astype(jnp.complex64)
+  #  Bounds defined in table 2.1 from Awad H. et al.
+  #  first entry set to NaN to offset indexes by 1 because they start from 1 in the paper
+  theta_m = [float('nan'), 1.59e-5, 2.31e-3, 1.94e-2, 6.21e-2, 1.28e-1, 2.06e-1, 2.88e-1, 3.67e-1, 4.39e-1, 5.03e-1, 5.60e-1, 6.09e-1, 6.52e-1, 6.89e-1, 7.21e-1, 7.49e-1]
+
+  return U
+
+@jit
+def logm(A: ArrayLike) -> Array:
+  T, Z = schur(A, output='complex')
+  logm_T = _logm_triu(T)
+  return jnp.matmul(jnp.matmul(Z, logm_T, precision=lax.Precision.HIGHEST),
+                    jnp.conj(Z.T), precision=lax.Precision.HIGHEST)
+
+
+def sqrtm(A: ArrayLike) -> Array:
+  """
+  """
+  return _logm(A)
 
 @partial(jit, static_argnames=('check_finite',))
 def rsf2csf(T: ArrayLike, Z: ArrayLike, check_finite: bool = True) -> tuple[Array, Array]:

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -38,6 +38,7 @@ from jax._src.scipy.linalg import (
   sqrtm as sqrtm,
   logm as logm,
   onenormest as onenormest,
+  _inverse_squaring as _inverse_squaring,
   solve as solve,
   solve_triangular as solve_triangular,
   svd as svd,

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -36,6 +36,8 @@ from jax._src.scipy.linalg import (
   rsf2csf as rsf2csf,
   schur as schur,
   sqrtm as sqrtm,
+  logm as logm,
+  onenormest as onenormest,
   solve as solve,
   solve_triangular as solve_triangular,
   svd as svd,

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -37,8 +37,6 @@ from jax._src.scipy.linalg import (
   schur as schur,
   sqrtm as sqrtm,
   logm as logm,
-  onenormest as onenormest,
-  _inverse_squaring as _inverse_squaring,
   solve as solve,
   solve_triangular as solve_triangular,
   svd as svd,

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -54,6 +54,7 @@ from jax._src.scipy.special import (
   poch as poch,
   polygamma as polygamma,
   rel_entr as rel_entr,
+  roots_legendre as roots_legendre,
   softmax as softmax,
   spence as spence,
   sph_harm as sph_harm,

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -287,6 +287,26 @@ class LaxScipySpcialFunctionsTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(osp_special.roots_legendre, jax_roots_legendre, args_maker, rtol=rtol)
     self._CompileAndCheck(functools.partial(lsp_special.roots_legendre, max_n=50), args_maker, rtol=rtol)
 
+  @jtu.sample_product(
+      n=[20, 50]
+  )
+  def testRootsLegendreNotFull(self, n):
+    args_maker = lambda: [n]
+    rtol = 1e-5
+
+    max_n = 10
+
+    def jax_roots_legendre(n):
+      nodes, weights = lsp_special.roots_legendre(n, max_n=max_n)
+      return nodes, weights
+
+    def scipy_roots_legendre_first_max_n(n):
+      # calculate only first max_n roots
+      nodes, weights = osp_special.roots_legendre(n)
+      return nodes[:max_n], weights[:max_n]
+
+    self._CheckAgainstNumpy(scipy_roots_legendre_first_max_n, jax_roots_legendre, args_maker, rtol=rtol)
+    self._CompileAndCheck(functools.partial(lsp_special.roots_legendre, max_n=max_n), args_maker, rtol=rtol)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -273,6 +273,20 @@ class LaxScipySpcialFunctionsTest(jtu.JaxTestCase):
     with self.assertRaises(TypeError):
       lsp_special.beta(x=1, y=1)
 
+  @jtu.sample_product(
+      n=[1, 2, 3, 10, 50]
+  )
+  def testRootsLegendre(self, n):
+    args_maker = lambda: [n]
+    rtol = 1e-5
+
+    def jax_roots_legendre(n):
+      nodes, weights = lsp_special.roots_legendre(n, max_n=50)
+      return nodes[:n], weights[:n]
+
+    self._CheckAgainstNumpy(osp_special.roots_legendre, jax_roots_legendre, args_maker, rtol=rtol)
+    self._CompileAndCheck(functools.partial(lsp_special.roots_legendre, max_n=50), args_maker, rtol=rtol)
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2062,9 +2062,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     self._CompileAndCheck(logm, args_maker)
 
   @jtu.sample_product(
-    # shape=[(4, 4), (15, 15), (50, 50), (100, 100)],
-    shape=[(4, 4)],
-    dtype=float_types,
+    shape=[(4, 4), (15, 15), (50, 50), (100, 100)],
+    dtype=float_types+complex_types,
   )
   def testInverseSquaring(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
@@ -2072,7 +2071,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     np.random.seed(111)
     key = jax.random.key(111)
     
-    theta_m = [float('nan'), 1.59e-5, 2.31e-3, 1.94e-2, 6.21e-2, 1.28e-1, 2.06e-1, 2.88e-1, 3.67e-1, 4.39e-1, 5.03e-1, 5.60e-1, 6.09e-1, 6.52e-1, 6.89e-1, 7.21e-1, 7.49e-1]
+    theta_m = np.array([float('nan'), 1.59e-5, 2.31e-3, 1.94e-2, 6.21e-2, 1.28e-1, 2.06e-1, 2.88e-1, 3.67e-1, 4.39e-1, 5.03e-1, 5.60e-1, 6.09e-1, 6.52e-1, 6.89e-1, 7.21e-1, 7.49e-1])
 
     arg = rng(shape, dtype)
     mat = arg @ arg.T

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2036,7 +2036,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
 
   @jtu.sample_product(
     shape=[(4, 4), (15, 15), (50, 50), (100, 100)],
-    dtype=float_types,
+    dtype=float_types+complex_types,
   )
   def testOneNormEstimator(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
@@ -2070,7 +2070,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     #  scipy algorithm is not deterministic so set seed for reproducibility
     np.random.seed(111)
     key = jax.random.key(111)
-    
+
     theta_m = np.array([float('nan'), 1.59e-5, 2.31e-3, 1.94e-2, 6.21e-2, 1.28e-1, 2.06e-1, 2.88e-1, 3.67e-1, 4.39e-1, 5.03e-1, 5.60e-1, 6.09e-1, 6.52e-1, 6.89e-1, 7.21e-1, 7.49e-1])
 
     arg = rng(shape, dtype)
@@ -2088,7 +2088,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
 
     fn = partial(jsp.linalg._inverse_squaring, key=key)
     scipy_fn = partial(scipy.linalg._matfuncs_inv_ssq._inverse_squaring_helper)
-    
+
     self._CheckAgainstNumpy(scipy_fn,
                         fn,
                         args_maker,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2061,6 +2061,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     dtype=float_types+complex_types,
   )
   def testOneNormEstimator(self, shape, dtype):
+    from jax._src.scipy.linalg import _onenormest
     rng = jtu.rand_default(self.rng())
     #  scipy algorithm is not deterministic so set seed for reproducibility
     np.random.seed(111)
@@ -2074,20 +2075,21 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     else:
       tol = 1e-8
 
-    logm = partial(jsp.linalg.onenormest, key=key, t=50, itmax=50)
-    scipy_logm = partial(osp.sparse.linalg._onenormest.onenormest, t=50, itmax=50)
-    self._CheckAgainstNumpy(scipy_logm,
-                        logm,
+    normest = partial(_onenormest, key=key, t=50, itmax=50)
+    scipy_normest = partial(osp.sparse.linalg._onenormest.onenormest, t=50, itmax=50)
+    self._CheckAgainstNumpy(scipy_normest,
+                        normest,
                         args_maker,
                         tol=tol,
                         check_dtypes=False)
-    self._CompileAndCheck(logm, args_maker)
+    self._CompileAndCheck(normest, args_maker)
 
   @jtu.sample_product(
     shape=[(4, 4), (15, 15), (50, 50), (100, 100)],
     dtype=float_types+complex_types,
   )
   def testInverseSquaring(self, shape, dtype):
+    from jax._src.scipy.linalg import _inverse_squaring
     rng = jtu.rand_default(self.rng())
     #  scipy algorithm is not deterministic so set seed for reproducibility
     np.random.seed(111)
@@ -2104,7 +2106,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     else:
       tol = 1e-8
 
-    fn = partial(jsp.linalg._inverse_squaring, key=key)
+    fn = partial(_inverse_squaring, key=key)
     scipy_fn = partial(scipy.linalg._matfuncs_inv_ssq._inverse_squaring_helper)
 
     self._CheckAgainstNumpy(scipy_fn,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2043,6 +2043,21 @@ class ScipyLinalgTest(jtu.JaxTestCase):
 
   @jtu.sample_product(
     shape=[(4, 4), (15, 15), (50, 50), (100, 100)],
+    dtype=float_types + complex_types,
+  )
+  @jtu.run_on_devices("cpu")
+  def testLogmGenMatrix(self, shape, dtype):
+    rng = jtu.rand_default(self.rng())
+    arg = rng(shape, dtype)
+    if dtype == np.float32 or dtype == np.complex64:
+      tol = 2e-3
+    else:
+      tol = 1e-8
+    R = jsp.linalg.logm(arg, key=jax.random.key(0))
+    self.assertAllClose(jax.scipy.linalg.expm(R), arg, atol=tol, check_dtypes=False)
+
+  @jtu.sample_product(
+    shape=[(4, 4), (15, 15), (50, 50), (100, 100)],
     dtype=float_types+complex_types,
   )
   def testOneNormEstimator(self, shape, dtype):
@@ -2082,10 +2097,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
 
     arg = rng(shape, dtype)
     mat = arg @ arg.T
-
-    for i in range(1, mat.shape[0]):
-      for j in range(i):
-        mat[i,j] = 0.0
 
     args_maker = lambda: [mat, theta_m]
     if dtype == np.float32 or dtype == np.complex64:

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2012,7 +2012,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     self.assertAllClose(root, expected, check_dtypes=False)
 
   @jtu.sample_product(
-    shape=[(4, 4), (15, 15), (50, 50), (100, 100)],
+    shape=[(15, 15), (50, 50), (100, 100)],
     dtype=float_types + complex_types,
   )
   @jtu.run_on_devices("cpu")
@@ -2026,7 +2026,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     if dtype == np.float32 or dtype == np.complex64:
       tol = 1e-4
     else:
-      tol = 1e-8
+      tol = 1e-6
 
     def jax_logm(mat):
       result = jsp.linalg.logm(mat, key=jax.random.key(0))
@@ -2042,7 +2042,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     self._CompileAndCheck(partial(jsp.linalg.logm, key=jax.random.key(0)), args_maker)
 
   @jtu.sample_product(
-    shape=[(4, 4), (15, 15), (50, 50), (100, 100)],
+    shape=[(1, 1), (4, 4), (100, 100)],
     dtype=float_types + complex_types,
   )
   @jtu.run_on_devices("cpu")
@@ -2050,11 +2050,13 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     rng = jtu.rand_default(self.rng())
     arg = rng(shape, dtype)
     if dtype == np.float32 or dtype == np.complex64:
-      tol = 2e-3
+      tol = 5e-3
     else:
-      tol = 1e-8
-    R = jsp.linalg.logm(arg, key=jax.random.key(0))
-    self.assertAllClose(jax.scipy.linalg.expm(R), arg, atol=tol, check_dtypes=False)
+      tol = 1e-5
+    mat = arg
+    mat = jsp.linalg.logm(mat, key=jax.random.key(0))
+    mat = jsp.linalg.expm(mat)
+    self.assertAllClose(mat, arg, atol=tol, check_dtypes=False)
 
   @jtu.sample_product(
     shape=[(4, 4), (15, 15), (50, 50), (100, 100)],


### PR DESCRIPTION
This PR is implementation of matrix logarithm (jax version of `scipy.linalg.logm`). Makes progress on issue #2478. Uses algorithm based on Schur decomposition and inverse squaring and scaling algorithm.

Method is fully described in paper: Awad H. Al-Mohy and Nicholas J. Higham (2012) “Improved Inverse Scaling and Squaring Algorithms for the Matrix Logarithm.” SIAM Journal on Scientific Computing, 34 (4). C152-C169. ISSN 1095-7197

Unlike in scipy in jax implemented function always uses complex types because it is not possible to statically know if result is real or complex, as there is no real solution for matrices with negative eigenvalues.

Used algorithms use a lot of loops and goto's in papers' pseudocodes so code uses a lot of lax control flow operations.

As for performance compared to SciPy:
![Figure_2](https://github.com/user-attachments/assets/9bd3747b-6381-46c5-9ff2-fc440626cb8a)
y axis is time in seconds, and x is matrix size n (of square matrix n x n). Performance excludes first function pass in jax.