### PR TITLE
Add Rotation return type hint to Rotation.__mul__()

### DIFF
--- a/jax/_src/scipy/spatial/transform.py
+++ b/jax/_src/scipy/spatial/transform.py
@@ -130,7 +130,7 @@ class Rotation(typing.NamedTuple):
     else:
       return self.quat.shape[0]
 
-  def __mul__(self, other):
+  def __mul__(self, other) -> Rotation:
     """Compose this rotation with the other."""
     return Rotation.from_quat(_compose_quat(self.quat, other.quat))
 


### PR DESCRIPTION
Without this type hint, some tools (including PyCharm) infer the more generic return type from typing.NamedTuple.
To improve user experience, I've added a narrower type hint.

However, the typing of this method is still 'flawed' as the only properly supported input is another Rotation. This is a narrower input type and therefore violates the Liskov substitution principle. Therefore I left the input parameter untyped.

For more info:
https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides