### PR TITLE
[ROCm] Remove cuda include from gpu plugin extension

### DIFF
--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -222,7 +222,6 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",
-        "@local_config_cuda//cuda:cuda_headers",
         "@nanobind",
         "@tsl//tsl/platform:statusor",
         "@xla//xla:util",

--- a/jaxlib/gpu_plugin_extension.cc
+++ b/jaxlib/gpu_plugin_extension.cc
@@ -22,7 +22,6 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
-#include "third_party/gpus/cuda/include/cuda.h"
 #include "jaxlib/kernel_nanobind_helpers.h"
 #include "xla/ffi/api/c_api.h"
 #include "xla/pjrt/c/pjrt_c_api.h"


### PR DESCRIPTION
This got added in this commit: https://github.com/ROCm/jax/commit/593143e17e746812b25d7e302e165d986a039c7e#diff-b52f574a70f65685ee099dc763c8de233db507c50ea331d6a6c82e8dcb54fc08R25. It's not needed for the CUDA build, as  gets included inside of , and this breaks the ROCm build since CUDA isn't there.

Created from: rocm/jax#183