### PR TITLE
[Pallas-Triton] Fix squeeze lowering required sharding argument

### DIFF
--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -1622,7 +1622,7 @@ def _broadcast_in_dim_lowering_rule(
 @register_lowering(lax.squeeze_p)
 def _squeeze_lowering_rule(ctx: LoweringRuleContext, a, *, dimensions):
   del dimensions
-  return _reshape_lowering_rule(ctx, a, new_sizes=None, dimensions=None)
+  return _reshape_lowering_rule(ctx, a, new_sizes=None, dimensions=None, sharding=None)
 
 
 @register_lowering(lax.reshape_p)


### PR DESCRIPTION
Error comes from this PR: https://github.com/jax-ml/jax/pull/25103 if there is no sharding argument passed to squeeze.

I observed my pallas kernel (using squeeze) failure due to the above PR, and the kernel was fine before that PR was merged.