### PR TITLE
jax.lax: raise TypeError for mismatched dtypes

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2209,7 +2209,7 @@ def broadcasting_sharding_rule(name, *avals):
 
 
 def naryop(result_dtype, accepted_dtypes, name, allow_extended_dtype=False,
-           require_same_dtypes=False):
+           require_same_dtypes=True):
   dtype_rule = partial(naryop_dtype_rule, result_dtype, accepted_dtypes, name,
                        allow_extended_dtype=allow_extended_dtype,
                        require_same=require_same_dtypes)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -3366,6 +3366,12 @@ class LaxTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError, ".*does not accept dtype complex.*"):
       op(2+3j, 4+5j)
 
+  @parameterized.parameters([lax.add, lax.mul, lax.div, lax.rem, lax.lt, lax.gt,
+                             lax.ge, lax.le, lax.eq, lax.ne])
+  def test_ops_error_on_mismatched_dtypes(self, op):
+    with self.assertRaisesRegex(TypeError, ".*requires arguments to have the same dtypes.*"):
+      op(0, 0.0)
+
   def test_population_count_booleans_not_supported(self):
     # https://github.com/jax-ml/jax/issues/3886
     msg = "population_count does not accept dtype bool"


### PR DESCRIPTION
This currently results in a verbose jaxpr verifyer error. It looks like this regressed in #16419.

Current behavior:
```python
>>> jax.lax.add(0, 0.0)
...
ValueError: Cannot lower jaxpr with verifier errors:
	op requires the same element type for all operands and results
		at loc("jit(add)/jit(main)/add"(callsite("<module>"("<ipython-input-2-fff9f9eef5ff>":1:0) at callsite("InteractiveShell.run_code"("/lib/python3.12/site-packages/IPython/core/interactiveshell.py":3577:20) at callsite("InteractiveShell.run_ast_nodes"("/lib/python3.12/site-packages/IPython/core/interactiveshell.py":3517:19) at callsite("InteractiveShell.run_cell_async"("/lib/python3.12/site-packages/IPython/core/interactiveshell.py":3334:29) at callsite("_pseudo_sync_runner"("/lib/python3.12/site-packages/IPython/core/async_helpers.py":129:8) at callsite("InteractiveShell._run_cell"("/lib/python3.12/site-packages/IPython/core/interactiveshell.py":3130:21) at callsite("InteractiveShell.run_cell"("/lib/python3.12/site-packages/IPython/core/interactiveshell.py":3075:21) at callsite("TerminalInteractiveShell.interact"("/lib/python3.12/site-packages/IPython/terminal/interactiveshell.py":910:20) at callsite("TerminalInteractiveShell.mainloop"("/lib/python3.12/site-packages/IPython/terminal/interactiveshell.py":917:16) at "TerminalIPythonApp.start"("/lib/python3.12/site-packages/IPython/terminal/ipapp.py":317:12))))))))))))
Define JAX_DUMP_IR_TO to dump the module.
```
Behavior after this PR
```python
>>> jax.lax.add(0, 0.0)
...
TypeError: lax.add requires arguments to have the same dtypes, got int32, float32. (Tip: jnp.add is a similar function that does automatic type promotion on inputs).
```