### PR TITLE
update gpu_performance_tips doc to remove deleted and redundant flags

### DIFF
--- a/docs/gpu_performance_tips.md
+++ b/docs/gpu_performance_tips.md
@@ -46,9 +46,7 @@ import os
 os.environ['XLA_FLAGS'] = (
     '--xla_gpu_enable_triton_softmax_fusion=true '
     '--xla_gpu_triton_gemm_any=True '
-    '--xla_gpu_enable_async_collectives=true '
     '--xla_gpu_enable_latency_hiding_scheduler=true '
-    '--xla_gpu_enable_highest_priority_async_stream=true '
 )
 ```
 


### PR DESCRIPTION
Removing 2 flags in gpu_performance_tips doc:
xla_gpu_enable_async_collectives - deprecated: async collectives are enabled by default
xla_gpu_enable_highest_priority_async_stream: Not deprecated but already enabled by default