### PR TITLE
get_githash: fix support for missing git

### DIFF
--- a/build/tools/utils.py
+++ b/build/tools/utils.py
@@ -222,7 +222,7 @@ def get_githash():
         capture_output=True,
         check=True,
     ).stdout.strip()
-  except OSError:
+  except (subprocess.CalledProcessError, OSError):
     return ""
 
 def _parse_string_as_bool(s):


### PR DESCRIPTION
When `git` is not installed, or when building from a source tarball instead of a git checkout, `git rev-parse` will fail. At least in Python 3.13, this raises a `subprocess.CalledProcessError`, not `OSError`. To fix this, I simply copied both error classes like we do above for `get_bazel_version`, but honestly I'm not even sure if we need this since we could also remove the `check=True` added by @nitins17 in #24695. I'm open to whichever solution.