### PR TITLE
fix `gamma_p` in vmap-based impl rule mode

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -291,15 +291,18 @@ def split(key: ArrayLike, num: int | tuple[int, ...] = 2) -> Array:
   return _return_prng_keys(wrapped, _split(typed_key, num))
 
 
-def _key_impl(keys: Array) -> str | PRNGSpec:
+def _key_impl(keys: Array) -> PRNGImpl:
   assert jnp.issubdtype(keys.dtype, dtypes.prng_key)
   keys_dtype = typing.cast(prng.KeyTy, keys.dtype)
-  impl = keys_dtype._impl
+  return keys_dtype._impl
+
+def _key_spec(keys: Array) -> str | PRNGSpec:
+  impl = _key_impl(keys)
   return impl.name if impl.name in prng.prngs else PRNGSpec(impl)
 
 def key_impl(keys: ArrayLike) -> str | PRNGSpec:
   typed_keys, _ = _check_prng_key("key_impl", keys, allow_batched=True)
-  return _key_impl(typed_keys)
+  return _key_spec(typed_keys)
 
 
 def _key_data(keys: Array) -> Array:


### PR DESCRIPTION
This was a regression introduced in #24593, which broke this check:
https://github.com/jax-ml/jax/blob/c73f3060997ac3b1c6de4f075111b684ea20b6ac/jax/_src/random.py#L1233-L1234

It would be nice to remove `gamma_p` altogether if we can, and always back it by the vmap-based implementation that is guarded above.

fixes #25469