### PR TITLE
Add more input validation to jax.distributed.initialize.

### DIFF
--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -81,6 +81,15 @@ class State:
       raise ValueError('Number of processes must be defined.')
     if process_id is None:
       raise ValueError('The process id of the current process must be defined.')
+    if not isinstance(process_id, int):
+      raise TypeError("process_id must be a nonnegative int. "
+                      f"Got process_id={process_id} of type {type(process_id)}.")
+    if not isinstance(num_processes, int):
+      raise TypeError("num_processes must be a positive int. "
+                      f"Got num_processes={num_processes} of type {type(num_processes)}.")
+    if not (0 <= process_id < num_processes):
+      raise ValueError("process_id and num_processes must be nonnegative, with process_id < num_processes. "
+                       f"Got process_id={process_id}, num_processes={num_processes}.")
 
     self.coordinator_address = coordinator_address
 


### PR DESCRIPTION
I accidentally passed something invalid for process_id and it failed confusingly in XLA, so this seemed worth adding.