### PR TITLE
Fix debug_nans regressions.

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -99,6 +99,7 @@ map, unsafe_map = safe_map, map
 zip, unsafe_zip = safe_zip, zip
 
 
+@api_boundary
 def _nan_check_posthook(fun, args, kwargs, output):
   """Hook function called by the C++ jit/pmap to perform NaN checking."""
   buffers = []
@@ -108,12 +109,18 @@ def _nan_check_posthook(fun, args, kwargs, output):
 
   try:
     dispatch.check_special(pjit.pjit_p.name, buffers)
-  except FloatingPointError:
-    # compiled_fun can only raise in this case
+  except dispatch.InternalFloatingPointError as e:
     assert config.debug_nans.value or config.debug_infs.value
-    print("Invalid nan value encountered in the output of a C++-jit/pmap "
-          "function. Calling the de-optimized version.")
-    fun._cache_miss(*args, **kwargs)[0]  # probably won't return
+    if hasattr(fun, '_fun'):
+      f = fun._fun
+      if getattr(f, '_apply_primitive', False):
+        raise FloatingPointError(f"invalid value ({e.ty}) encountered in {f.__qualname__}") from None
+      # compiled_fun can only raise in this case
+      dispatch.maybe_recursive_nan_check(e, f, args, kwargs)
+      raise AssertionError("Unreachable") from e
+    else:
+      # TODO(emilyaf): Shouldn't need this fallback.
+      raise
 
 def _update_debug_special_global(_):
   if config._read("jax_debug_nans") or config._read("jax_debug_infs"):
@@ -1574,11 +1581,14 @@ def _cpp_pmap(
 
     execute: Callable | None = None
     with core.take_current_trace() as trace:
-      if isinstance(trace, core.EvalTrace):
-        execute = pxla.xla_pmap_impl_lazy(p.flat_fun, *p.flat_args, **params)
-        out = execute(*p.flat_args)
-      else:
-        out = pxla.xla_pmap_p.bind_with_trace(trace, (p.flat_fun, *p.flat_args), params)
+      try:
+        if isinstance(trace, core.EvalTrace):
+          execute = pxla.xla_pmap_impl_lazy(p.flat_fun, *p.flat_args, **params)
+          out = execute(*p.flat_args)
+        else:
+          out = pxla.xla_pmap_p.bind_with_trace(trace, (p.flat_fun, *p.flat_args), params)
+      except dispatch.InternalFloatingPointError as e:
+        raise FloatingPointError(f'Invalid value ({e.ty}) encountered in parallel computation.')
 
     out_tree, out_flat = p.out_tree, out
     out_pytree_def = out_tree()
@@ -1629,6 +1639,7 @@ def _cpp_pmap(
   _pmap_cache_clears.add(cpp_mapped_f)
 
   pmap_f = wraps(fun)(cpp_mapped_f)
+  pmap_f._fun = fun
 
   @api_boundary
   def lower(*args, **kwargs):
@@ -1674,6 +1685,7 @@ def _cpp_pmap(
 _pmap_cache_clears = weakref.WeakSet()  # type: ignore
 
 
+@api_boundary
 def jvp(
     fun: Callable, primals, tangents, has_aux: bool = False
   ) -> tuple[Any, ...]:
@@ -1878,6 +1890,7 @@ def _lift_linearized(jaxpr, primal_avals, io_tree, out_pvals, consts, *py_args):
 
   return apply_flat_fun_nokwargs(fun, io_tree, py_args)
 
+@api_boundary
 def _vjp_pullback_wrapper(name, out_primal_avals, io_tree, fun, *py_args_):
   if len(py_args_) != 1:
     msg = (f"The function returned by `jax.vjp` applied to {name} was called "
@@ -1937,6 +1950,7 @@ def vjp(fun: Callable[..., tuple[T, U]], *primals: Any,
         has_aux: Literal[True],
         reduce_axes: Sequence[AxisName] = ()) -> tuple[T, Callable, U]:
   ...
+@api_boundary
 def vjp(
     fun: Callable, *primals, has_aux: bool = False, reduce_axes=()
   ) -> tuple[Any, Callable] | tuple[Any, Callable, Any]:

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -22,6 +22,7 @@ from functools import partial
 from typing import Any
 
 from jax._src import config
+from jax._src import dispatch
 from jax._src import linear_util as lu
 from jax._src.interpreters import partial_eval as pe
 from jax.tree_util import (tree_flatten, tree_unflatten,
@@ -360,8 +361,15 @@ def backward_pass(jaxpr: core.Jaxpr, transform_stack,
           cts_out = get_primitive_transpose(eqn.primitive)(
               params, call_jaxpr, invals, cts_in, cts_in_avals)
         else:
-          cts_out = get_primitive_transpose(eqn.primitive)(
-              cts_in, *invals, **eqn.params)
+          try:
+            cts_out = get_primitive_transpose(eqn.primitive)(
+                cts_in, *invals, **eqn.params)
+          except (FloatingPointError, ZeroDivisionError) as e:
+            msg = "When differentiating the code at the top of the callstack:"
+            if msg not in e.args[0]:
+              e.args = e.args[0] + f'\n{msg}',
+            e.args = e.args[0] + f'\n{source_info_util.summarize(eqn.source_info)}',
+            raise e from None
         cts_out = [Zero(v.aval) for v in eqn.invars] if cts_out is Zero else cts_out
         # FIXME: Some invars correspond to primals!
         map(partial(write_cotangent, eqn.primitive), eqn.invars, cts_out)
@@ -1000,7 +1008,20 @@ def map_transpose(primitive, params, call_jaxpr, args, ct, _):
   if update_params:
     new_params = update_params(new_params, map(is_undefined_primal, args),
                                [type(x) is not Zero for x in ct])
-  out_flat = primitive.bind(fun, *all_args, **new_params)
+
+  try:
+    out_flat = primitive.bind(fun, *all_args, **new_params)
+  except dispatch.InternalFloatingPointError as e:
+    print("Invalid nan value encountered in the backward pass of a jax.jit "
+          "function. Calling the de-optimized backward pass.")
+    try:
+      _ = backward_pass(call_jaxpr, None, {}, args, ct)
+    except (FloatingPointError, ZeroDivisionError) as e2:
+      raise e2 from None
+    else:
+      # If control reaches this line, we got a NaN on the output of `compiled`
+      # but not `fun.call_wrapped` on the same arguments. Let's tell the user.
+      dispatch._raise_no_nan_in_deoptimized(e)
   arg_cts = tree_unflatten(out_tree(), out_flat)
 
   # The freevars are being fanned out (not mapped). During transpose the

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -222,6 +222,10 @@ def _python_pjit_helper(fun: Callable, jit_info: PjitInfo, *args, **kwargs):
               f"Argument '{name}' of shape {aval.str_short()} of type"
               f' {type(arg)} is not a valid JAX type.') from e
       raise AssertionError("Unreachable") from e
+  except dispatch.InternalFloatingPointError as e:
+    if getattr(fun, '_apply_primitive', False):
+      raise FloatingPointError(f"invalid value ({e.ty}) encountered in {fun.__qualname__}") from None
+    dispatch.maybe_recursive_nan_check(e, fun, args, kwargs)
 
   if p.attrs_tracked:
     num_states_out = sum(end_tree.num_leaves for _, end_tree, _ in p.attrs_tracked)
@@ -1700,33 +1704,7 @@ def _pjit_call_impl_python(
                           ("out_layouts", out_layouts),
                           ("abstract args", map(core.abstractify, args)),
                           ("fingerprint", fingerprint))
-  try:
-    return compiled.unsafe_call(*args), compiled, pgle_profiler
-  except FloatingPointError as e:
-    assert config.debug_nans.value or config.debug_infs.value  # compiled_fun can only raise in this case
-
-    if len(jaxpr.eqns) > 1:
-      _ = core.jaxpr_as_fun(jaxpr)(*args)  # may raise, not return
-
-    # If control reaches this line, we got a NaN on the output of `compiled`
-    # but not `fun.call_wrapped` on the same arguments. Let's tell the user.
-    msg = (f"{str(e)}. Because "
-           "jax_config.debug_nans.value and/or config.jax_debug_infs is set, the "
-           "de-optimized function (i.e., the function as if the `jit` "
-           "decorator were removed) was called in an attempt to get a more "
-           "precise error message. However, the de-optimized function did not "
-           "produce invalid values during its execution. This behavior can "
-           "result from `jit` optimizations causing the invalid value to be "
-           "produced. It may also arise from having nan/inf constants as "
-           "outputs, like `jax.jit(lambda ...: jax.numpy.nan)(...)`. "
-           "\n\n"
-           "It may be possible to avoid the invalid value by removing the "
-           "`jit` decorator, at the cost of losing optimizations. "
-           "\n\n"
-           "If you see this error, consider opening a bug report at "
-           "https://github.com/jax-ml/jax.")
-    raise FloatingPointError(msg)
-
+  return compiled.unsafe_call(*args), compiled, pgle_profiler
 
 @weakref_lru_cache
 def _get_jaxpr_as_fun(jaxpr, in_shardings, out_shardings, in_layouts,
@@ -2401,19 +2379,31 @@ def _pjit_transpose(cts_in, *primals_in,
     transpose_in_layouts = (None,) * len(attrs_tracked) + transpose_in_layouts
     transpose_out_layouts = (None,) * len(attrs_tracked) + transpose_out_layouts
 
-  nz_cts_out = pjit_p.bind(
-      *primals_and_nz_cts_in,
-      jaxpr=transpose_jaxpr,
-      in_shardings=transpose_in_shardings,
-      out_shardings=transpose_out_shardings,
-      in_layouts=transpose_in_layouts,
-      out_layouts=transpose_out_layouts,
-      resource_env=resource_env,
-      donated_invars=(False,) * len(primals_and_nz_cts_in),
-      name=name,
-      keep_unused=keep_unused,
-      inline=inline,
-      compiler_options_kvs=compiler_options_kvs)
+  try:
+    nz_cts_out = pjit_p.bind(
+        *primals_and_nz_cts_in,
+        jaxpr=transpose_jaxpr,
+        in_shardings=transpose_in_shardings,
+        out_shardings=transpose_out_shardings,
+        in_layouts=transpose_in_layouts,
+        out_layouts=transpose_out_layouts,
+        resource_env=resource_env,
+        donated_invars=(False,) * len(primals_and_nz_cts_in),
+        name=name,
+        keep_unused=keep_unused,
+        inline=inline,
+        compiler_options_kvs=compiler_options_kvs)
+  except dispatch.InternalFloatingPointError as e:
+    print("Invalid nan value encountered in the backward pass of a jax.jit "
+          "function. Calling the de-optimized backward pass.")
+    try:
+      _ = ad.closed_backward_pass(jaxpr, None, primals_in, cts_in)
+    except (FloatingPointError, ZeroDivisionError) as e2:
+      raise e2 from None  # great
+    else:
+      # If control reaches this line, we got a NaN on the output of `compiled`
+      # but not `fun.call_wrapped` on the same arguments. Let's tell the user.
+      dispatch._raise_no_nan_in_deoptimized(e)
 
   if attrs_tracked:
     final_states, nz_cts_out = split_list(nz_cts_out, [len(init_states)])

--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -870,6 +870,15 @@ def _match(mesh, check_rep, pspec, x):
 def _rem_singleton(x): return jnp.squeeze(x, axis=0)
 def _add_singleton(x): return jnp.expand_dims(x, axis=0)
 
+def _maybe_check_special(outs):
+  if not config.debug_nans.value and not config.debug_infs.value: return
+  bufs = [s.data for leaf in tree_leaves(outs)
+          for s in getattr(leaf, 'addressable_shards', [])]
+  try:
+    dispatch.check_special('shard_map', bufs)
+  except dispatch.InternalFloatingPointError as e:
+    raise FloatingPointError(f'Invalid value ({e.ty}) encountered in sharded computation.') from None
+
 class ShardMapTrace(core.Trace):
   __slots__ = ("mesh", "check", "context_mesh")
 
@@ -898,9 +907,10 @@ class ShardMapTrace(core.Trace):
       out_vals = eager_rule(self.mesh, *in_vals, **params)
     else:
       f = HashablePartial(_prim_applier, prim, tuple(params.items()), self.mesh)
-      with (core.eval_context(), jax.disable_jit(False),
-            set_abstract_mesh(self.context_mesh)):
+      with (core.eval_context(), jax.disable_jit(False), jax.debug_nans(False),
+            jax.debug_infs(False), set_abstract_mesh(self.context_mesh)):
         out_vals = jax.jit(f)(*in_vals)
+      _maybe_check_special(out_vals)
     rep_rule = _check_rules.get(prim, partial(_rule_missing, prim))
     out_rep = rep_rule(self.mesh, *in_rep, **params) if self.check else set()
     if prim.multiple_results:
@@ -1695,10 +1705,21 @@ def _shard_map_transpose(out_cts, *args, jaxpr, mesh, in_names, out_names,
   def new_out_names_thunk():
     return tuple(names for names, nz in zip(in_names, nz_arg_cts()) if nz)
 
-  out_flat = shard_map_p.bind(
-      fun_trans_flat, *all_args, mesh=mesh, in_names=tuple(new_in_names),
-      out_names_thunk=new_out_names_thunk, check_rep=check_rep, rewrite=rewrite,
-      auto=auto)
+  try:
+    out_flat = shard_map_p.bind(
+        fun_trans_flat, *all_args, mesh=mesh, in_names=tuple(new_in_names),
+        out_names_thunk=new_out_names_thunk, check_rep=check_rep, rewrite=rewrite,
+        auto=auto)
+  except (FloatingPointError, ZeroDivisionError) as e:
+    print("Invalid nan value encountered in the backward pass of a shard_map "
+          "function. Calling the de-optimized backward pass.")
+    try:
+      _ = fun_trans.call_wrapped(out_cts, args)
+    except (FloatingPointError, ZeroDivisionError) as e2:
+      raise e2 from None
+    else:
+      dispatch._raise_no_nan_in_deoptimized(e)
+
   return tree_unflatten(out_tree(), out_flat)
 ad.primitive_transposes[shard_map_p] = _shard_map_transpose
 


### PR DESCRIPTION
Fixes #25299 

With this fix, `debug_nans` again reports the line where the NaN first appeared, including in reverse-mode autodiff and inside of pmap/shard_map. The "de-optimized function did not produce invalid values..." message again only appears when it's true.

The approach is to raise an InternalFloatingPointError when a NaN is detected in output, and catch those exceptions at the spot where we can run the de-optimized function.

Future improvements are tracked in #25643.

Example output:

```python
import jax
import jax.numpy as jnp
import traceback

# (1) NaNs on the forward pass
@jax.jit
def f(x):
  y = jnp.square(x)
  return jnp.log(-y)

# (2) NaNs on the forward pass but nested
@jax.jit
def g(x):
  return f(x - 2.)

x = jnp.array([2., 0.])
z = jnp.zeros_like(x)

# (3) NaNs on the backward pass
out, f_vjp = jax.vjp(f, x)
# (4) ...and nested.
out, g_vjp = jax.vjp(g, x)

# (5) NaNs in forward autodiff
f_jvp = lambda: jax.jvp(f, [z], [jnp.ones_like(x)])

# (6) Grad of pmap
_, f_vjp_pmap = jax.vjp(jax.pmap(f), jnp.zeros([1]))

# (7) Grad of shard map
P = jax.sharding.PartitionSpec
mesh = jax.make_mesh((1,), ('x',))
shmap_f = jax.experimental.shard_map.shard_map(f, mesh=mesh, in_specs=(P('x')), out_specs=P('x'))
_, f_vjp_shmap = jax.vjp(shmap_f, jnp.zeros([1]))

with jax.debug_nans(True):

  one = jnp.ones([1])
  fns = [lambda: f(x), lambda: g(x), lambda: f_vjp(x), lambda: g_vjp(x), 
         lambda: f_jvp(), lambda: f_vjp_pmap(one), lambda: f_vjp_shmap(one)]
  names = ['f', 'g', 'f_vjp', 'g_vjp', 'f_jvp', 'f_vjp_pmap', 'f_vjp_shmap']

  for fun, n in zip(fns, names):
    try:
      fun().block_until_ready()
    except FloatingPointError as e:
      print(f'---------------------- {n} ---------------------')
      print(traceback.format_exc())
      print("\n\n\n")
```

```
Invalid nan value encountered in the output of a C++-jit/pmap function. Calling the de-optimized version.
Invalid nan value encountered in the output of a C++-jit/pmap function. Calling the de-optimized version.
---------------------- f ---------------------
Traceback (most recent call last):
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 45, in <module>
    fun().block_until_ready()
    ^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 39, in <lambda>
    fns = [lambda: f(x), lambda: g(x), lambda: f_vjp(x), lambda: g_vjp(x),
                  ^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 9, in f
    return jnp.log(-y)
           ^^^^^^^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/jax/_src/numpy/ufuncs.py", line 489, in log
    return lax.log(*promote_args_inexact('log', x))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FloatingPointError: invalid value (nan) encountered in log
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.





Invalid nan value encountered in the output of a C++-jit/pmap function. Calling the de-optimized version.
Invalid nan value encountered in the output of a C++-jit/pmap function. Calling the de-optimized version.
Invalid nan value encountered in the output of a C++-jit/pmap function. Calling the de-optimized version.
---------------------- g ---------------------
Traceback (most recent call last):
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 45, in <module>
    fun().block_until_ready()
    ^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 39, in <lambda>
    fns = [lambda: f(x), lambda: g(x), lambda: f_vjp(x), lambda: g_vjp(x),
                                ^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 14, in g
    return f(x - 2.)
           ^^^^^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 9, in f
    return jnp.log(-y)
           ^^^^^^^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/jax/_src/numpy/ufuncs.py", line 489, in log
    return lax.log(*promote_args_inexact('log', x))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FloatingPointError: invalid value (nan) encountered in log
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.





Invalid nan value encountered in the backward pass of a C++-jit/pmap function. Calling the de-optimized backward pass.
---------------------- f_vjp ---------------------
Traceback (most recent call last):
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 20, in <module>
    out, f_vjp = jax.vjp(f, x)
jax._src.source_info_util.JaxStackTraceBeforeTransformation: FloatingPointError: invalid value (nan) encountered in div
When differentiating the code at the top of the callstack:
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:9:9 (f)
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:20:13 (<module>)

The preceding stack trace is the source of the JAX operation that, once transformed by JAX, triggered the following exception.

--------------------

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 45, in <module>
    fun().block_until_ready()
    ^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 39, in <lambda>
    fns = [lambda: f(x), lambda: g(x), lambda: f_vjp(x), lambda: g_vjp(x),
                                              ^^^^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/jax/_src/tree_util.py", line 477, in __call__
    return self.fun(*args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^
FloatingPointError: invalid value (nan) encountered in div
When differentiating the code at the top of the callstack:
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:9:9 (f)
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:20:13 (<module>)
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.





Invalid nan value encountered in the backward pass of a C++-jit/pmap function. Calling the de-optimized backward pass.
Invalid nan value encountered in the backward pass of a C++-jit/pmap function. Calling the de-optimized backward pass.
---------------------- g_vjp ---------------------
Traceback (most recent call last):
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 22, in <module>
    out, g_vjp = jax.vjp(g, x)
jax._src.source_info_util.JaxStackTraceBeforeTransformation: FloatingPointError: invalid value (nan) encountered in mul
When differentiating the code at the top of the callstack:
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:8:6 (f)
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:14:9 (g)
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:22:13 (<module>)

The preceding stack trace is the source of the JAX operation that, once transformed by JAX, triggered the following exception.

--------------------

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 45, in <module>
    fun().block_until_ready()
    ^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 39, in <lambda>
    fns = [lambda: f(x), lambda: g(x), lambda: f_vjp(x), lambda: g_vjp(x),
                                                                ^^^^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/jax/_src/tree_util.py", line 477, in __call__
    return self.fun(*args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^
FloatingPointError: invalid value (nan) encountered in mul
When differentiating the code at the top of the callstack:
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:8:6 (f)
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:14:9 (g)
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:22:13 (<module>)
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.





Invalid nan value encountered in the output of a C++-jit/pmap function. Calling the de-optimized version.
Invalid nan value encountered in the output of a C++-jit/pmap function. Calling the de-optimized version.
---------------------- f_jvp ---------------------
Traceback (most recent call last):
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 45, in <module>
    fun().block_until_ready()
    ^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 40, in <lambda>
    lambda: f_jvp(), lambda: f_vjp_pmap(one), lambda: f_vjp_shmap(one)]
            ^^^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 25, in <lambda>
    f_jvp = lambda: jax.jvp(f, [z], [jnp.ones_like(x)])
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 9, in f
    return jnp.log(-y)
           ^^^^^^^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/jax/_src/numpy/ufuncs.py", line 489, in log
    return lax.log(*promote_args_inexact('log', x))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FloatingPointError: invalid value (nan) encountered in div
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.





Invalid nan value encountered in the backward pass of a C++-jit/pmap function. Calling the de-optimized backward pass.
Invalid nan value encountered in the backward pass of a C++-jit/pmap function. Calling the de-optimized backward pass.
---------------------- f_vjp_pmap ---------------------
Traceback (most recent call last):
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 28, in <module>
    _, f_vjp_pmap = jax.vjp(jax.pmap(f), jnp.zeros([1]))
jax._src.source_info_util.JaxStackTraceBeforeTransformation: FloatingPointError: invalid value (nan) encountered in mul
When differentiating the code at the top of the callstack:
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:8:6 (f)
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:28:16 (<module>)

The preceding stack trace is the source of the JAX operation that, once transformed by JAX, triggered the following exception.

--------------------

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 45, in <module>
    fun().block_until_ready()
    ^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 40, in <lambda>
    lambda: f_jvp(), lambda: f_vjp_pmap(one), lambda: f_vjp_shmap(one)]
                             ^^^^^^^^^^^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/jax/_src/tree_util.py", line 477, in __call__
    return self.fun(*args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^
FloatingPointError: invalid value (nan) encountered in mul
When differentiating the code at the top of the callstack:
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:8:6 (f)
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:28:16 (<module>)
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.





---------------------- f_vjp_shmap ---------------------
Traceback (most recent call last):
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 34, in <module>
    _, f_vjp_shmap = jax.vjp(shmap_f, jnp.zeros([1]))
jax._src.source_info_util.JaxStackTraceBeforeTransformation: FloatingPointError: Invalid value (nan) encountered in sharded computation.
When differentiating the code at the top of the callstack:
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:34:17 (<module>)
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:34:17 (<module>)

The preceding stack trace is the source of the JAX operation that, once transformed by JAX, triggered the following exception.

--------------------

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 45, in <module>
    fun().block_until_ready()
    ^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py", line 40, in <lambda>
    lambda: f_jvp(), lambda: f_vjp_pmap(one), lambda: f_vjp_shmap(one)]
                                                      ^^^^^^^^^^^^^^^^
  File "/usr/local/google/home/emilyaf/jax-fork/jax/jax/_src/tree_util.py", line 477, in __call__
    return self.fun(*args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^
FloatingPointError: Invalid value (nan) encountered in sharded computation.
When differentiating the code at the top of the callstack:
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:34:17 (<module>)
/usr/local/google/home/emilyaf/jax-fork/jax/copy_debug_nans.py:34:17 (<module>)
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.

```