### PR TITLE
Avoid adding conflicting `--repo_env=HERMETIC_PYTHON_VERSION=` to bazel command

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -69,7 +69,6 @@ def add_global_arguments(parser: argparse.ArgumentParser):
   parser.add_argument(
       "--python_version",
       type=str,
-      choices=["3.10", "3.11", "3.12", "3.13"],
       default=f"{sys.version_info.major}.{sys.version_info.minor}",
       help=
         """
@@ -381,6 +380,14 @@ async def main():
   bazel_command_base.append("run")
 
   if args.python_version:
+    # Do not add --repo_env=HERMETIC_PYTHON_VERSION with default args.python_version
+    # if bazel_options override it
+    python_version_opt = "--repo_env=HERMETIC_PYTHON_VERSION="
+    if any([python_version_opt in opt for opt in args.bazel_options]):
+      raise RuntimeError(
+        "Please use python_version to set hermetic python version instead of "
+        "setting --repo_env=HERMETIC_PYTHON_VERSION=<python version> bazel option"
+      )
     logging.debug("Hermetic Python version: %s", args.python_version)
     bazel_command_base.append(
         f"--repo_env=HERMETIC_PYTHON_VERSION={args.python_version}"


### PR DESCRIPTION
Description:

Be default, this code https://github.com/jax-ml/jax/blob/7dd401cb2aedcee723bd24888ffbdfc1a6458367/build/build.py#L383-L387 adds `--repo_env=HERMETIC_PYTHON_VERSION=<default python version>` option to the bazel command. This can be misleading if `--bazel_options=--repo_env=HERMETIC_PYTHON_VERSION=<another version>` is provided explicitly in the build command, for example: `python build/build.py build --wheels=jaxlib --bazel_options=--repo_env=HERMETIC_PYTHON_VERSION=3.13-ft ...`

All these options are also written to `.jax_configure.bazelrc`.

So, finally bazel reports the following command executed:
```
2024-12-17 01:33:38,490 - INFO - [EXECUTING] ./bazel-6.5.0-linux-x86_64 run --repo_env=HERMETIC_PYTHON_VERSION=3.13 ... --repo_env=HERMETIC_PYTHON_VERSION=3.13-ft --repo_env=HERMETIC_PYTHON_URL=file:///__w/jax/jax/python-tsan.tgz --repo_env=HERMETIC_PYTHON_SHA256=80323bf90444dac4c75c367a5e050595ae20c3b6ae126bf333a5014b01b6e9db --repo_env=HERMETIC_PYTHON_PREFIX=cpython-tsan/ ...
```

In this PR, we skip adding the default python version option to the command


cc @vam-google 