### PR TITLE
Remove core.concrete_aval and replace with abstractify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 
 ## Unreleased
 
+* Deprecations
+  * From {mod}`jax.interpreters.xla`, `abstractify` and `pytype_aval_mappings`
+    are now deprecated, having been replaced by symbols of the same name
+    in {mod}`jax.core`. 
+
 ## jax 0.4.38 (Dec 17, 2024)
 
 * Changes:

--- a/jax/_src/abstract_arrays.py
+++ b/jax/_src/abstract_arrays.py
@@ -49,7 +49,6 @@ def masked_array_error(*args, **kwargs):
                    "Use arr.filled() to convert the value to a standard numpy array.")
 
 core.pytype_aval_mappings[np.ma.MaskedArray] = masked_array_error
-core.xla_pytype_aval_mappings[np.ma.MaskedArray] = masked_array_error
 
 
 def _make_shaped_array_for_numpy_array(x: np.ndarray) -> ShapedArray:
@@ -58,7 +57,6 @@ def _make_shaped_array_for_numpy_array(x: np.ndarray) -> ShapedArray:
   return ShapedArray(x.shape, dtypes.canonicalize_dtype(dtype))
 
 core.pytype_aval_mappings[np.ndarray] = _make_shaped_array_for_numpy_array
-core.xla_pytype_aval_mappings[np.ndarray] = _make_shaped_array_for_numpy_array
 
 
 def _make_shaped_array_for_numpy_scalar(x: np.generic) -> ShapedArray:
@@ -68,7 +66,6 @@ def _make_shaped_array_for_numpy_scalar(x: np.generic) -> ShapedArray:
 
 for t in numpy_scalar_types:
   core.pytype_aval_mappings[t] = _make_shaped_array_for_numpy_scalar
-  core.xla_pytype_aval_mappings[t] = _make_shaped_array_for_numpy_scalar
 
 core.literalable_types.update(array_types)
 
@@ -81,6 +78,5 @@ def _make_abstract_python_scalar(typ, val):
 
 for t in dtypes.python_scalar_dtypes:
   core.pytype_aval_mappings[t] = partial(_make_abstract_python_scalar, t)
-  core.xla_pytype_aval_mappings[t] = partial(_make_abstract_python_scalar, t)
 
 core.literalable_types.update(dtypes.python_scalar_dtypes.keys())

--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -1038,7 +1038,6 @@ def _get_aval_array(self):
 
 api_util._shaped_abstractify_handlers[ArrayImpl] = _get_aval_array
 core.pytype_aval_mappings[ArrayImpl] = _get_aval_array
-core.xla_pytype_aval_mappings[ArrayImpl] = _get_aval_array
 
 # TODO(jakevdp) replace this with true inheritance at the C++ level.
 basearray.Array.register(ArrayImpl)

--- a/jax/_src/export/shape_poly.py
+++ b/jax/_src/export/shape_poly.py
@@ -1205,7 +1205,6 @@ def _geq_decision(e1: DimSize, e2: DimSize, cmp_str: Callable[[], str]) -> bool:
       f"Symbolic dimension comparison {cmp_str()} is inconclusive.{describe_scope}")
 
 core.pytype_aval_mappings[_DimExpr] = _DimExpr._get_aval
-core.xla_pytype_aval_mappings[_DimExpr] = _DimExpr._get_aval
 dtypes._weak_types.append(_DimExpr)
 
 def _convertible_to_int(p: DimSize) -> bool:

--- a/jax/_src/interpreters/xla.py
+++ b/jax/_src/interpreters/xla.py
@@ -146,13 +146,6 @@ canonicalize_dtype_handlers[core.Token] = identity
 canonicalize_dtype_handlers[core.DArray] = identity
 canonicalize_dtype_handlers[core.MutableArray] = identity
 
-# TODO(jakevdp): deprecate and remove this.
-def abstractify(x) -> Any:
-  return core.abstractify(x)
-
-# TODO(jakevdp): deprecate and remove this.
-pytype_aval_mappings: dict[Any, Callable[[Any], core.AbstractValue]] = core.xla_pytype_aval_mappings
-
 initial_style_primitives: set[core.Primitive] = set()
 
 def register_initial_style_primitive(prim: core.Primitive):

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -463,7 +463,6 @@ class KeyTy(dtypes.ExtendedDType):
 
 
 core.pytype_aval_mappings[PRNGKeyArray] = lambda x: x.aval
-core.xla_pytype_aval_mappings[PRNGKeyArray] = lambda x: x.aval
 
 xla.canonicalize_dtype_handlers[PRNGKeyArray] = lambda x: x
 

--- a/jax/core.py
+++ b/jax/core.py
@@ -122,7 +122,7 @@ _deprecations = {
                _src_core.call_p),
     "closed_call_p": ("jax.core.closed_call_p is deprecated. Use jax.extend.core.primitives.closed_call_p",
                       _src_core.closed_call_p),
-    "concrete_aval": ("jax.core.concrete_aval is deprecated.", _src_core.concrete_aval),
+    "concrete_aval": ("jax.core.concrete_aval is deprecated.", _src_core.abstractify),
     "dedup_referents": ("jax.core.dedup_referents is deprecated.", _src_core.dedup_referents),
     "escaped_tracer_error": ("jax.core.escaped_tracer_error is deprecated.",
                              _src_core.escaped_tracer_error),
@@ -207,7 +207,7 @@ if typing.TYPE_CHECKING:
   axis_frame = _src_core.axis_frame
   call_p = _src_core.call_p
   closed_call_p = _src_core.closed_call_p
-  concrete_aval = _src_core.concrete_aval
+  concrete_aval = _src_core.abstractify
   dedup_referents = _src_core.dedup_referents
   escaped_tracer_error = _src_core.escaped_tracer_error
   extend_axis_env_nd = _src_core.extend_axis_env_nd

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 from jax._src.interpreters.xla import (
-  abstractify as abstractify,
   canonicalize_dtype as canonicalize_dtype,
   canonicalize_dtype_handlers as canonicalize_dtype_handlers,
-  pytype_aval_mappings as pytype_aval_mappings,
 )
 
 from jax._src.dispatch import (
@@ -27,8 +25,19 @@ from jax._src.lib import xla_client as _xc
 Backend = _xc._xla.Client
 del _xc
 
+from jax._src import core as _src_core
+
 # Deprecations
 _deprecations = {
+    # Added 2024-12-17
+    "abstractify": (
+        "jax.interpreters.xla.abstractify is deprecated.",
+        _src_core.abstractify
+    ),
+    "pytype_aval_mappings": (
+        "jax.interpreters.xla.pytype_aval_mappings is deprecated.",
+        _src_core.pytype_aval_mappings
+    ),
     # Finalized 2024-10-24; remove after 2025-01-24
     "xb": (
         ("jax.interpreters.xla.xb was removed in JAX v0.4.36. "
@@ -44,6 +53,13 @@ _deprecations = {
     ),
 }
 
+import typing as _typing
 from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
-__getattr__ = _deprecation_getattr(__name__, _deprecations)
+if _typing.TYPE_CHECKING:
+  abstractify = _src_core.abstractify
+  pytype_aval_mappings = _src_core.pytype_aval_mappings
+else:
+  __getattr__ = _deprecation_getattr(__name__, _deprecations)
 del _deprecation_getattr
+del _typing
+del _src_core

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -3959,8 +3959,6 @@ class CustomElementTypesTest(jtu.JaxTestCase):
     core.pytype_aval_mappings[FooArray] = \
         lambda x: core.ShapedArray(x.shape, FooTy())
     xla.canonicalize_dtype_handlers[FooArray] = lambda x: x
-    core.xla_pytype_aval_mappings[FooArray] = \
-        lambda x: core.ShapedArray(x.shape, FooTy())
     pxla.shard_arg_handlers[FooArray] = shard_foo_array_handler
     mlir._constant_handlers[FooArray] = foo_array_constant_handler
     mlir.register_lowering(make_p, mlir.lower_fun(make_lowering, False))
@@ -3973,7 +3971,6 @@ class CustomElementTypesTest(jtu.JaxTestCase):
   def tearDown(self):
     del core.pytype_aval_mappings[FooArray]
     del xla.canonicalize_dtype_handlers[FooArray]
-    del core.xla_pytype_aval_mappings[FooArray]
     del mlir._constant_handlers[FooArray]
     del mlir._lowerings[make_p]
     del mlir._lowerings[bake_p]


### PR DESCRIPTION
Culmination of the work in #25456, #25534, and #25544.

Because of the work in those PRs, this change should not involve any change of behavior, aside from the deprecations of the now-obsolete APIs.