### PR TITLE
Increase the minimum NumPy version to v1.25.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 
 ## Unreleased
 
+* Changes:
+  * The minimum NumPy version is now 1.25. NumPy 1.25 will remain the minimum
+    supported version until June 2025.
+
 ## jax 0.4.38 (Dec 17, 2024)
 
 * Changes:

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -63,7 +63,7 @@ setup(
     install_requires=[
         'scipy>=1.10',
         "scipy>=1.11.1; python_version>='3.12'",
-        'numpy>=1.24',
+        'numpy>=1.25',
         'ml_dtypes>=0.2.0',
     ],
     url='https://github.com/jax-ml/jax',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     install_requires=[
         f'jaxlib >={_minimum_jaxlib_version}, <={_jax_version}',
         'ml_dtypes>=0.4.0',
-        'numpy>=1.24',
+        'numpy>=1.25',
         "numpy>=1.26.0; python_version>='3.12'",
         'opt_einsum',
         'scipy>=1.10',

--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -25,8 +25,6 @@ from jax._src import test_util as jtu
 
 import numpy as np
 
-numpy_version = jtu.numpy_version()
-
 config.parse_flags_with_absl()
 
 try:
@@ -47,10 +45,6 @@ dlpack_dtypes = sorted(jax.dlpack.SUPPORTED_DTYPES, key=lambda x: x.__name__)
 numpy_dtypes = sorted(
     [dt for dt in jax.dlpack.SUPPORTED_DTYPES if dt != jnp.bfloat16],
     key=lambda x: x.__name__)
-
-# NumPy didn't support bool as a dlpack type until 1.25.
-if jtu.numpy_version() < (1, 25, 0):
-  numpy_dtypes = [dt for dt in numpy_dtypes if dt != jnp.bool_]
 
 cuda_array_interface_dtypes = [dt for dt in dlpack_dtypes if dt != jnp.bfloat16]
 


### PR DESCRIPTION
Per SPEC 0, we drop NumPy v1.24 support on Dec 18, 2024.