### PR TITLE
WIP: no special treatment for ShapeDtypeStruct

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2559,12 +2559,6 @@ class ShapeDtypeStruct:
     # https://github.com/jax-ml/jax/issues/8182
     return hash((self.shape, self.dtype, self.sharding, self.layout, self.weak_type))
 
-def _sds_aval_mapping(x):
-  return ShapedArray(
-      x.shape, dtypes.canonicalize_dtype(x.dtype, allow_extended_dtype=True),
-      weak_type=x.weak_type)
-core.pytype_aval_mappings[ShapeDtypeStruct] = _sds_aval_mapping
-
 
 @api_boundary
 def eval_shape(fun: Callable, *args, **kwargs):

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1436,10 +1436,17 @@ def abstractify(x):
 
 
 def get_aval(x):
+  # get_aval() is like abstractify(), but more flexible: for example, it will
+  # return an aval for inputs of type Tracer or for duck-typed arrays.
   if isinstance(x, Tracer):
     return x.aval
-  else:
+  try:
     return concrete_aval(x)
+  except TypeError:
+    if hasattr(x, "shape") and hasattr(x, "dtype"):
+      return ShapedArray(x.shape, x.dtype,
+                         weak_type=getattr(x, "weak_type", False))
+    raise
 
 get_type = get_aval
 


### PR DESCRIPTION
I'm confused as to why we need to register this, because `ShapeDtypeStruct` should behave exactly the same as any duck-typed value with a `shape` and `dtype`.

This registration recently led to the rollback of #25555 because a downstream library was relying on this behavior in a dubious way.