### PR TITLE
Refactor: move shaped_abstractify to core

### DIFF
--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -1036,7 +1036,7 @@ def _get_aval_array(self):
   else:
     return self.aval
 
-api_util._shaped_abstractify_handlers[ArrayImpl] = _get_aval_array
+core.shaped_abstractify_handlers[ArrayImpl] = _get_aval_array
 core.pytype_aval_mappings[ArrayImpl] = _get_aval_array
 
 # TODO(jakevdp) replace this with true inheritance at the C++ level.

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1400,6 +1400,29 @@ def check_valid_jaxtype(x):
       f"Value {x!r} of type {type(x)} is not a valid JAX type")
 
 
+def _shaped_abstractify_slow(x):
+  try:
+    return x if isinstance(x, AbstractValue) else get_aval(x)
+  except TypeError:
+    pass
+
+  weak_type = getattr(x, 'weak_type', False)
+  if hasattr(x, 'dtype'):
+    dtype = dtypes.canonicalize_dtype(x.dtype, allow_extended_dtype=True)
+  else:
+    raise TypeError(
+        f"Cannot interpret value of type {type(x)} as an abstract array; it "
+        "does not have a dtype attribute")
+  return ShapedArray(np.shape(x), dtype, weak_type=weak_type)
+
+# TODO(jakevdp): deduplicate this with abstractify
+def shaped_abstractify(x):
+  # This was originally api_util.shaped_abstractify; temporarily moved
+  # here in order to facilitate combining it with abstractify.
+  handler = shaped_abstractify_handlers.get(type(x), None)
+  return handler(x) if handler is not None else _shaped_abstractify_slow(x)
+
+
 def abstractify(x):
   for typ in type(x).__mro__:
     aval_fn = pytype_aval_mappings.get(typ)
@@ -1809,7 +1832,11 @@ class DShapedArray(UnshapedArray):
                         self.weak_type)
 
 pytype_aval_mappings: dict[type, Callable[[Any], AbstractValue]] = {}
+shaped_abstractify_handlers: dict[Any, Callable[[Any], ShapedArray]] = {}
 
+def _str_abstractify(x):
+  raise TypeError(f"Argument '{x}' of type {type(x)} is not a valid JAX type")
+shaped_abstractify_handlers[str] = _str_abstractify
 
 class DArray:
   _aval: DShapedArray

--- a/jax/_src/earray.py
+++ b/jax/_src/earray.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import math
 
-from jax._src import api_util
 from jax._src import basearray
 from jax._src import core
 from jax._src import tree_util
@@ -116,7 +115,7 @@ def _earray_shard_arg_handler(xs, shardings, layouts, copy_semantics):
   return pxla.shard_args(phys_shardings, layouts, copy_semantics, arrs)
 pxla.shard_arg_handlers[EArray] = _earray_shard_arg_handler
 
-api_util._shaped_abstractify_handlers[EArray] = lambda self: self.aval
+core.shaped_abstractify_handlers[EArray] = lambda self: self.aval
 core.pytype_aval_mappings[EArray] = lambda x: x.aval
 xla.canonicalize_dtype_handlers[EArray] = lambda x: x
 tree_util.dispatch_registry.register_node(

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1572,7 +1572,7 @@ class DynamicJaxprTracer(core.Tracer):
 
 def _dynamic_jaxpr_tracer_shaped_abstractify(x):
   return x.aval
-api_util._shaped_abstractify_handlers[DynamicJaxprTracer] = _dynamic_jaxpr_tracer_shaped_abstractify
+core.shaped_abstractify_handlers[DynamicJaxprTracer] = _dynamic_jaxpr_tracer_shaped_abstractify
 
 def make_jaxpr_effects(constvars, invars, outvars, eqns) -> effects.Effects:
   sentinel = object()

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -43,7 +43,6 @@ import jax
 from jax import errors
 from jax import jit
 from jax import lax
-from jax._src import api_util
 from jax._src import config
 from jax._src import core
 from jax._src import deprecations
@@ -192,7 +191,7 @@ class _ScalarMeta(type):
 
 def _abstractify_scalar_meta(x):
   raise TypeError(f"JAX scalar type {x} cannot be interpreted as a JAX array.")
-api_util._shaped_abstractify_handlers[_ScalarMeta] = _abstractify_scalar_meta
+core.shaped_abstractify_handlers[_ScalarMeta] = _abstractify_scalar_meta
 
 def _make_scalar_type(np_scalar_type: type) -> _ScalarMeta:
   meta = _ScalarMeta(np_scalar_type.__name__, (object,),

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -26,7 +26,6 @@ from jax import lax
 from jax import numpy as jnp
 from jax import tree_util
 
-from jax._src import api_util
 from jax._src import api
 from jax._src import config as config
 from jax._src import core
@@ -303,7 +302,6 @@ _set_array_base_attributes(PRNGKeyArray, include=[
     'at', 'flatten', 'ravel', 'reshape',
     'squeeze', 'swapaxes', 'take', 'transpose', 'T'])
 
-api_util._shaped_abstractify_handlers[PRNGKeyArray] = op.attrgetter('aval')
 
 def prngkeyarray_flatten(x):
   return (x._base_array,), x._impl
@@ -463,6 +461,7 @@ class KeyTy(dtypes.ExtendedDType):
 
 
 core.pytype_aval_mappings[PRNGKeyArray] = lambda x: x.aval
+core.shaped_abstractify_handlers[PRNGKeyArray] = op.attrgetter('aval')
 
 xla.canonicalize_dtype_handlers[PRNGKeyArray] = lambda x: x
 


### PR DESCRIPTION
This is in preparation for merging `shaped_abstractify` and `core.abstractify`. By design this change should be a no-op: all previous registrations are unchanged, but are now located adjacent to the `core.abstractify` registrations so that they can more easily be compared and aligned.