### PR TITLE
Add support for N-D FFTs with N>3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     are now deprecated, having been replaced by symbols of the same name
     in {mod}`jax.core`.
 
+* New Features
+  * {func}`jax.numpy.fft.fftn`, {func}`jax.numpy.fft.rfftn`,
+    {func}`jax.numpy.fft.ifftn`, and {func}`jax.numpy.fft.irfftn` now support
+    transforms in more than 3 dimensions, which was previously the limit. See
+    {jax-issue}`#25606` for more details.
+
 ## jax 0.4.38 (Dec 17, 2024)
 
 * Changes:

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -41,12 +41,9 @@ all_dtypes = real_dtypes + jtu.dtypes.complex
 
 
 def _get_fftn_test_axes(shape):
-  axes = [[]]
+  axes = [[], None]
   ndims = len(shape)
-  # XLA's FFT op only supports up to 3 innermost dimensions.
-  if ndims <= 3:
-    axes.append(None)
-  for naxes in range(1, min(ndims, 3) + 1):
+  for naxes in range(1, ndims + 1):
     axes.extend(itertools.combinations(range(ndims), naxes))
   for index in range(1, ndims + 1):
     axes.append((-index,))
@@ -145,7 +142,7 @@ class FftTest(jtu.JaxTestCase):
      for dtype in (real_dtypes if real and not inverse else all_dtypes)
     ],
     [dict(shape=shape, axes=axes, s=s)
-     for shape in [(10,), (10, 10), (9,), (2, 3, 4), (2, 3, 4, 5)]
+     for shape in [(10,), (10, 10), (9,), (2, 3, 4), (2, 3, 4, 5), (2, 3, 4, 5, 6)]
      for axes in _get_fftn_test_axes(shape)
      for s in _get_fftn_test_s(shape, axes)
     ],
@@ -203,11 +200,6 @@ class FftTest(jtu.JaxTestCase):
     if inverse:
       name = 'i' + name
     func = _get_fftn_func(jnp.fft, inverse, real)
-    self.assertRaisesRegex(
-        ValueError,
-        "jax.numpy.fft.{} only supports 1D, 2D, and 3D FFTs. "
-        "Got axes None with input rank 4.".format(name),
-        lambda: func(rng([2, 3, 4, 5], dtype=np.float64), axes=None))
     self.assertRaisesRegex(
         ValueError,
         f"jax.numpy.fft.{name} does not support repeated axes. Got axes \\[1, 1\\].",


### PR DESCRIPTION
The current implementation of `jax.numpy.fft.fftn` (and related) don't support N-D transforms with `N > 3` because that's all that XLA supports. However, we can (like in the numpy implementation) support higher dimensional transforms by repeatedly applying the supported low order transforms. In this PR, I add that logic for `N > 3`, but the behavior remains unchanged for `N <= 3` transforms.