### PR TITLE
Remove internal uses of api_util.shaped_abstractify

### DIFF
--- a/benchmarks/api_benchmark.py
+++ b/benchmarks/api_benchmark.py
@@ -21,7 +21,6 @@ import operator
 import google_benchmark
 import jax
 from jax import lax
-from jax._src.api_util import shaped_abstractify  # technically not an api fn
 from jax._src.ad_checkpoint import checkpoint  # new jax.remat implementation
 from jax._src import core
 from jax._src.lib import xla_client as xc
@@ -422,7 +421,7 @@ def bench_shaped_abstractify(state):
   device, *_ = jax.devices()
   args = [jax.device_put_replicated(1, [device])] * 1000
   while state:
-    _ = [shaped_abstractify(x) for x in args]
+    _ = [core.shaped_abstractify(x) for x in args]
 
 
 def _run_benchmark_for_xla_abstractify(arg, state):

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -33,7 +33,7 @@ from jax._src import effects
 from jax._src import source_info_util
 from jax._src import traceback_util
 from jax._src.api_util import (
-    flatten_fun, shaped_abstractify, debug_info, fun_sourceinfo, fun_signature)
+    flatten_fun, debug_info, fun_sourceinfo, fun_signature)
 from jax._src.interpreters import ad
 from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
@@ -328,7 +328,7 @@ def checkpoint(fun: Callable, *, prevent_cse: bool = True,
                        fun_signature(fun), args, kwargs, static_argnums, ())
     fun_, args = _remat_static_argnums(fun, static_argnums, args)
     args_flat, in_tree = tree_flatten((args, kwargs))
-    in_avals = [shaped_abstractify(x) for x in args_flat]
+    in_avals = [core.shaped_abstractify(x) for x in args_flat]
     jaxpr, consts, out_tree = _trace_to_jaxpr(fun_, in_tree, tuple(in_avals), debug)
     out_flat = remat_p.bind(
         *consts, *args_flat, jaxpr=jaxpr, prevent_cse=prevent_cse,

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -56,12 +56,12 @@ from jax._src import source_info_util
 from jax._src import traceback_util
 from jax._src import pjit
 from jax._src import xla_bridge as xb
-from jax._src.core import eval_jaxpr, ShapedArray
+from jax._src.core import eval_jaxpr, shaped_abstractify, ShapedArray
 from jax._src.api_util import (
     flatten_fun, flatten_fun_nokwargs, flatten_fun_nokwargs2, argnums_partial,
     flatten_axes, donation_vector,
     rebase_donate_argnums, _ensure_index, _ensure_index_tuple,
-    shaped_abstractify, apply_flat_fun_nokwargs, check_callable, debug_info,
+    apply_flat_fun_nokwargs, check_callable, debug_info,
     result_paths, flat_out_axes, debug_info_final, fun_sourceinfo)
 from jax._src.lax import lax as lax_internal
 from jax._src.lib import jax_jit

--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -583,12 +583,8 @@ def _dtype(x):
   except ValueError:
     return dtypes.result_type(getattr(x, 'dtype'))
 
-# TODO(mattjj,yashkatariya): replace core.abstractify with this, same behavior
-# TODO(jakevdp): fix downstream consumers and remove this.
-def shaped_abstractify(x):
-  return core.shaped_abstractify(x)
-
-# TODO(jakevdp): fix downstream consumers and remove this.
+# TODO(jakevdp): fix downstream consumers and remove these aliases.
+shaped_abstractify = core.shaped_abstractify
 _shaped_abstractify_handlers = core.shaped_abstractify_handlers
 
 # This decorator exists to make it easier to monkey-patch APIs in JAX.
@@ -716,7 +712,7 @@ def _check_no_aliased_closed_over_refs(dbg, consts, args) -> None:
                     if isinstance(core.get_aval(c), AbstractRef)}
   for i, x in enumerate(args):
     if id(core.get_referent(x)) in refs:
-      a = shaped_abstractify(x)
+      a = core.shaped_abstractify(x)
       raise ValueError(
           f"when tracing {dbg.func_src_info} for {dbg.traced_for}, a mutable "
           f"array reference of type {a.str_short()} was both closed over and "

--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -23,7 +23,6 @@ import operator as op
 from typing import Any, TYPE_CHECKING, cast
 
 from jax._src import api
-from jax._src import api_util
 from jax._src import basearray
 from jax._src import config
 from jax._src import core
@@ -1095,7 +1094,7 @@ def shard_device_array(x, devices, indices, sharding):
     shards = [x] * len(devices)
   else:
     shards = x._multi_slice(start_indices, limit_indices, removed_dims)
-  aval = api_util.shaped_abstractify(x)
+  aval = core.shaped_abstractify(x)
   return pxla.batched_device_put(aval, sharding, shards, devices)
 
 

--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -46,7 +46,6 @@ from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import hlo
 from jax._src.sharding import Sharding
 from jax._src.sharding_impls import NamedSharding, parse_flatten_op_sharding
-from jax._src.api_util import shaped_abstractify
 from jax._src.state import discharge as state_discharge
 
 logger = logging.getLogger(__name__)
@@ -260,7 +259,7 @@ def debug_callback(callback: Callable[..., None], *args: Any,
   static_args, dyn_args = {}, []
   for i, a in enumerate(flat_args):
     try:
-      shaped_abstractify(a)
+      core.shaped_abstractify(a)
       dyn_args.append(a)
     except (AssertionError, TypeError):
       static_args[i] = a

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -205,7 +205,7 @@ def _shard_np_array(xs, shardings, layouts, copy_semantics):
     devices = sharding._addressable_device_assignment
     if x.dtype == dtypes.float0:
       x = np.zeros(x.shape, dtype=np.dtype(bool))
-    aval = api_util.shaped_abstractify(x)
+    aval = core.shaped_abstractify(x)
     if layout is not None:
       results.append(api.device_put(x, Layout(layout, sharding)))
     else:

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -35,8 +35,7 @@ from jax._src import source_info_util
 from jax._src import state
 from jax._src import util
 from jax._src.api_util import (
-    shaped_abstractify, _check_no_aliased_ref_args,
-    _check_no_aliased_closed_over_refs)
+    _check_no_aliased_ref_args, _check_no_aliased_closed_over_refs)
 from jax._src.core import ShapedArray
 from jax._src.interpreters import ad
 from jax._src.interpreters import batching
@@ -731,7 +730,7 @@ def _scan_partial_eval(trace, *tracers, reverse, length, num_consts, num_carry,
 
 def _maybe_put(x):
   if isinstance(x, np.ndarray):
-    aval = shaped_abstractify(x)
+    aval = core.shaped_abstractify(x)
     s = sharding.SingleDeviceSharding(xb.local_devices(backend='cpu')[0])
     result_handler = pxla.global_aval_to_result_handler(aval, s, False)
     return result_handler(pxla.shard_args([s], [None], [None], [x]))

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -23,7 +23,6 @@ from jax._src import api
 from jax._src import config
 from jax._src import core
 from jax._src import dtypes
-from jax._src import api_util
 from jax._src.lax import lax
 from jax._src.util import safe_zip, safe_map
 from jax._src.typing import Array, ArrayLike, DimSize, DType, DTypeLike, Shape
@@ -214,7 +213,7 @@ def promote_args_inexact(fun_name: str, *args: ArrayLike) -> list[Array]:
 @partial(api.jit, inline=True)
 def _broadcast_arrays(*args: ArrayLike) -> list[Array]:
   """Like Numpy's broadcast_arrays but doesn't return views."""
-  avals = [api_util.shaped_abstractify(arg) for arg in args]
+  avals = [core.shaped_abstractify(arg) for arg in args]
   shapes = [a.shape for a in avals]
   if not shapes or all(core.definitely_equal_shape(shapes[0], s) for s in shapes):
     return [lax.asarray(arg) for arg in args]

--- a/jax/_src/shard_alike.py
+++ b/jax/_src/shard_alike.py
@@ -24,7 +24,6 @@ from jax._src.tree_util import tree_flatten, tree_unflatten
 from jax._src.interpreters import batching
 from jax._src.util import safe_zip
 from jax._src.lib import xla_client as xc
-from jax._src.api_util import shaped_abstractify
 from jax._src.lib.mlir import dialects, ir
 
 _next_shard_group_id = itertools.count()
@@ -39,8 +38,8 @@ def shard_alike(x, y):
                      f'Got x_tree: {x_tree}, y_tree: {y_tree}')
 
   for x_, y_ in safe_zip(x_flat, y_flat):
-    x_aval = shaped_abstractify(x_)
-    y_aval = shaped_abstractify(y_)
+    x_aval = core.shaped_abstractify(x_)
+    y_aval = core.shaped_abstractify(y_)
     if x_aval.shape != y_aval.shape:
       raise ValueError(
           'The leaves shapes of `x` and `y` should match. Got `x` leaf shape:'

--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 
+from jax._src.core import (
+  shaped_abstractify as shaped_abstractify
+)
+
 from jax._src.api_util import (
   argnums_partial as argnums_partial,
   donation_vector as donation_vector,
@@ -21,5 +25,4 @@ from jax._src.api_util import (
   flatten_fun_nokwargs as flatten_fun_nokwargs,
   rebase_donate_argnums as rebase_donate_argnums,
   safe_map as safe_map,
-  shaped_abstractify as shaped_abstractify,
 )

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -70,7 +70,6 @@ from jax._src import core
 from jax._src import dispatch
 from jax._src import linear_util as lu
 from jax._src import sharding_impls
-from jax._src.api_util import shaped_abstractify
 from jax._src.interpreters import partial_eval as pe
 from jax._src.lax import lax as lax_internal
 from jax._src.util import unzip2, weakref_lru_cache, safe_zip
@@ -733,7 +732,7 @@ def _jet_jaxpr(
 def _pjit_jet_rule(primals_in, series_in, **params):
   primals_and_series, in_tree_def = tree_flatten((primals_in, series_in))
   order = len(series_in[0])
-  primals_and_series_avals = tuple(shaped_abstractify(x) for x in primals_and_series)
+  primals_and_series_avals = tuple(core.shaped_abstractify(x) for x in primals_and_series)
   jaxpr_jet, out_tree_def = _jet_jaxpr(params['jaxpr'], order,
                                        primals_and_series_avals, in_tree_def)
   num_series_in = len(primals_in) * order

--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -58,7 +58,7 @@ from jax._src.lib.mlir.dialects import sdy
 from jax._src.util import (HashableFunction, HashablePartial, unzip2,
                            as_hashable_function, memoize, partition_list,
                            split_list, subs_list2)
-from jax.api_util import flatten_fun_nokwargs, shaped_abstractify, argnums_partial
+from jax.api_util import flatten_fun_nokwargs, argnums_partial
 from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
 from jax._src.interpreters import partial_eval as pe
@@ -273,7 +273,7 @@ def _check_specs_vs_args(
     f: Callable, mesh: Mesh, in_tree: PyTreeDef, in_specs: Specs,
     dyn_argnums: Sequence[int], in_specs_flat: Sequence[P],
     xs: Sequence) -> None:
-  in_avals = map(shaped_abstractify, xs)
+  in_avals = map(core.shaped_abstractify, xs)
   fail = [a if not len(p) <= a.ndim else no_fail
           for p, a in zip(in_specs_flat, in_avals)]
   if any(f is not no_fail for f in fail):
@@ -763,7 +763,7 @@ def get_mesh_from_args(args_flat, mesh):
   for a in args_flat:
     if hasattr(a, 'sharding') and isinstance(a.sharding, NamedSharding):
       if a.sharding.mesh.shape_tuple != mesh.shape_tuple:
-        aval = shaped_abstractify(a)
+        aval = core.shaped_abstractify(a)
         raise ValueError(
             f"Mesh shape of the input {a.sharding.mesh.shape_tuple} does not"
             " match the mesh shape passed to shard_map "

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -19,7 +19,6 @@ from absl.testing import parameterized
 import jax
 from jax import dtypes
 from jax import numpy as jnp
-from jax._src import api_util
 from jax._src import config
 from jax._src import core
 from jax._src import lib as jaxlib
@@ -30,7 +29,7 @@ import numpy as np
 config.parse_flags_with_absl()
 
 def _cpp_device_put(value, device):
-  aval = api_util.shaped_abstractify(value)
+  aval = core.shaped_abstractify(value)
   return pxla.batched_device_put(
       aval, jax.sharding.SingleDeviceSharding(device), [value], [device])
 


### PR DESCRIPTION
Followup to #25595. This is a purely internal refactoring, and should not result in any externally-visible change.