### PR TITLE
Switch to a new thread-safe utility for catching warnings.

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -120,6 +120,7 @@ py_library(
     testonly = 1,
     srcs = [
         "_src/test_util.py",
+        "_src/test_warning_util.py",
     ],
     visibility = [
         ":internal",

--- a/jax/_src/test_warning_util.py
+++ b/jax/_src/test_warning_util.py
@@ -1,0 +1,132 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Thread-safe utilities for catching and testing for warnings.
+#
+# The Python warnings module, at least as of Python 3.13, is not thread-safe.
+# The catch_warnings() feature is inherently racy, see
+# https://py-free-threading.github.io/porting/#the-warnings-module-is-not-thread-safe
+#
+# This module offers a thread-safe way to catch and record warnings. We install
+# a custom showwarning hook with the Python warning module, and then rely on
+# the CPython warnings module to call our show warning function. We then use it
+# to create our own thread-safe warning filtering utilities.
+
+import contextlib
+import re
+import threading
+import warnings
+
+
+class _WarningContext(threading.local):
+  "Thread-local state that contains a list of warning handlers."
+
+  def __init__(self):
+    self.handlers = []
+
+
+_context = _WarningContext()
+
+
+# Callback that applies the handlers in reverse order. If no handler matches,
+# we raise an error.
+def _showwarning(message, category, filename, lineno, file=None, line=None):
+  for handler in reversed(_context.handlers):
+    if handler(message, category, filename, lineno, file, line):
+      return
+  raise category(message)
+
+
+@contextlib.contextmanager
+def raise_on_warnings():
+  "Context manager that raises an exception if a warning is raised."
+  if warnings.showwarning is not _showwarning:
+    with warnings.catch_warnings():
+      warnings.simplefilter("error")
+      yield
+    return
+
+  def handler(message, category, filename, lineno, file=None, line=None):
+    raise category(message)
+
+  _context.handlers.append(handler)
+  try:
+    yield
+  finally:
+    _context.handlers.pop()
+
+
+@contextlib.contextmanager
+def record_warnings():
+  "Context manager that yields a list of warnings that are raised."
+  if warnings.showwarning is not _showwarning:
+    with warnings.catch_warnings(record=True) as w:
+      warnings.simplefilter("always")
+      yield w
+    return
+
+  log = []
+
+  def handler(message, category, filename, lineno, file=None, line=None):
+    log.append(warnings.WarningMessage(message, category, filename, lineno, file, line))
+    return True
+
+  _context.handlers.append(handler)
+  try:
+    yield log
+  finally:
+    _context.handlers.pop()
+
+
+@contextlib.contextmanager
+def ignore_warning(*, message: str | None = None, category: type = Warning):
+  "Context manager that ignores any matching warnings."
+  if warnings.showwarning is not _showwarning:
+    with warnings.catch_warnings():
+      warnings.filterwarnings(
+        "ignore", message="" if message is None else message, category=category)
+      yield
+    return
+
+  if message:
+    message_re = re.compile(message)
+  else:
+    message_re = None
+
+  category_cls = category
+
+  def handler(message, category, filename, lineno, file=None, line=None):
+    text = str(message) if isinstance(message, Warning) else message
+    if (message_re is None or message_re.match(text)) and issubclass(
+        category, category_cls
+    ):
+      return True
+    return False
+
+  _context.handlers.append(handler)
+  try:
+    yield
+  finally:
+    _context.handlers.pop()
+
+
+def install_threadsafe_warning_handlers():
+  # Hook the showwarning method. The warnings module explicitly notes that
+  # this is a function that users may replace.
+  warnings.showwarning = _showwarning
+
+  # Set the warnings module to always display warnings. We hook into it by
+  # overriding the "showwarning" method, so it's important that all warnings
+  # are "shown" by the usual mechanism.
+  warnings.simplefilter("always")

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1154,6 +1154,14 @@ jax_py_test(
 )
 
 jax_py_test(
+    name = "warnings_util_test",
+    srcs = ["warnings_util_test.py"],
+    deps = [
+        "//jax:test_util",
+    ] + py_deps("absl/testing"),
+)
+
+jax_py_test(
     name = "xla_bridge_test",
     srcs = ["xla_bridge_test.py"],
     data = ["testdata/example_pjrt_plugin_config.json"],

--- a/tests/deprecation_test.py
+++ b/tests/deprecation_test.py
@@ -12,18 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
-
 from absl.testing import absltest
 from jax._src import deprecations
 from jax._src import test_util as jtu
+from jax._src import test_warning_util
 from jax._src.internal_test_util import deprecation_module as m
 
 class DeprecationTest(absltest.TestCase):
 
   def testModuleDeprecation(self):
-    with warnings.catch_warnings():
-      warnings.simplefilter("error")
+    with test_warning_util.raise_on_warnings():
       self.assertEqual(m.x, 42)
 
     with self.assertWarnsRegex(DeprecationWarning, "Please use x"):

--- a/tests/lax_numpy_reducers_test.py
+++ b/tests/lax_numpy_reducers_test.py
@@ -212,7 +212,7 @@ class JaxNumpyReducerTests(jtu.JaxTestCase):
     rng = rng_factory(self.rng())
     @jtu.ignore_warning(category=NumpyComplexWarning)
     @jtu.ignore_warning(category=RuntimeWarning,
-                        message="mean of empty slice.*")
+                        message="Mean of empty slice.*")
     @jtu.ignore_warning(category=RuntimeWarning,
                         message="overflow encountered.*")
     def np_fun(x):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -5581,8 +5581,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jnp.ones(2) + 3  # don't want to raise for scalars
 
     with jax.numpy_rank_promotion('warn'):
-      self.assertWarnsRegex(UserWarning, "Following NumPy automatic rank promotion for add on "
-                            r"shapes \(2,\) \(1, 2\).*", lambda: jnp.ones(2) + jnp.ones((1, 2)))
+      with self.assertWarnsRegex(
+        UserWarning,
+        "Following NumPy automatic rank promotion for add on shapes "
+        r"\(2,\) \(1, 2\).*"
+      ):
+        jnp.ones(2) + jnp.ones((1, 2))
       jnp.ones(2) + 3  # don't want to warn for scalars
 
   @unittest.skip("Test fails on CI, perhaps due to JIT caching")

--- a/tests/warnings_util_test.py
+++ b/tests/warnings_util_test.py
@@ -1,0 +1,86 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+
+from absl.testing import absltest
+
+from jax._src import config
+from jax._src import test_warning_util
+from jax._src import test_util as jtu
+
+
+config.parse_flags_with_absl()
+
+class WarningsUtilTest(jtu.JaxTestCase):
+
+  @test_warning_util.raise_on_warnings()
+  def test_warning_raises(self):
+    with self.assertRaises(UserWarning, msg="hello"):
+      warnings.warn("hello", category=UserWarning)
+
+    with self.assertRaises(DeprecationWarning, msg="hello"):
+      warnings.warn("hello", category=DeprecationWarning)
+
+  @test_warning_util.raise_on_warnings()
+  def test_ignore_warning(self):
+    with test_warning_util.ignore_warning(message="h.*o"):
+      warnings.warn("hello", category=UserWarning)
+
+    with self.assertRaises(UserWarning, msg="hello"):
+      with test_warning_util.ignore_warning(message="h.*o"):
+        warnings.warn("goodbye", category=UserWarning)
+
+    with test_warning_util.ignore_warning(category=UserWarning):
+      warnings.warn("hello", category=UserWarning)
+
+    with self.assertRaises(UserWarning, msg="hello"):
+      with test_warning_util.ignore_warning(category=DeprecationWarning):
+        warnings.warn("goodbye", category=UserWarning)
+
+  def test_record_warning(self):
+    with test_warning_util.record_warnings() as w:
+      warnings.warn("hello", category=UserWarning)
+      warnings.warn("goodbye", category=DeprecationWarning)
+    self.assertLen(w, 2)
+    self.assertIs(w[0].category, UserWarning)
+    self.assertIn("hello", str(w[0].message))
+    self.assertIs(w[1].category, DeprecationWarning)
+    self.assertIn("goodbye", str(w[1].message))
+
+  def test_record_warning_nested(self):
+    with test_warning_util.record_warnings() as w:
+      warnings.warn("aa", category=UserWarning)
+      with test_warning_util.record_warnings() as v:
+        warnings.warn("bb", category=UserWarning)
+      warnings.warn("cc", category=DeprecationWarning)
+    self.assertLen(w, 2)
+    self.assertIs(w[0].category, UserWarning)
+    self.assertIn("aa", str(w[0].message))
+    self.assertIs(w[1].category, DeprecationWarning)
+    self.assertIn("cc", str(w[1].message))
+    self.assertLen(v, 1)
+    self.assertIs(v[0].category, UserWarning)
+    self.assertIn("bb", str(v[0].message))
+
+
+  def test_raises_warning(self):
+    with self.assertRaises(UserWarning, msg="hello"):
+      with test_warning_util.ignore_warning():
+        with test_warning_util.raise_on_warnings():
+          warnings.warn("hello", category=UserWarning)
+
+
+if __name__ == '__main__':
+  absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/xla_bridge_test.py
+++ b/tests/xla_bridge_test.py
@@ -14,8 +14,6 @@
 
 import os
 import platform
-import time
-import warnings
 
 from absl import logging
 from absl.testing import absltest
@@ -125,31 +123,6 @@ class XlaBridgeTest(jtu.JaxTestCase):
       xb.local_devices(100)
     with self.assertRaisesRegex(RuntimeError, "Unknown backend foo"):
       xb.local_devices(backend="foo")
-
-  def test_timer_tpu_warning(self):
-    with warnings.catch_warnings(record=True) as w:
-      warnings.simplefilter("always")
-
-      def _mock_tpu_client_with_options(library_path=None, options=None):
-        time_to_wait = 5
-        start = time.time()
-        while not w:
-          if time.time() - start > time_to_wait:
-            raise ValueError(
-                "This test should not hang for more than "
-                f"{time_to_wait} seconds.")
-          time.sleep(0.1)
-
-        self.assertLen(w, 1)
-        msg = str(w[-1].message)
-        self.assertIn("Did you run your code on all TPU hosts?", msg)
-
-      def _mock_tpu_client(library_path=None):
-        _mock_tpu_client_with_options(library_path=library_path, options=None)
-
-      with mock.patch.object(xc, "make_tpu_client",
-                            side_effect=_mock_tpu_client_with_options):
-        xb.tpu_client_timer_callback(0.01)
 
   def test_register_plugin(self):
     with self.assertLogs(level="WARNING") as log_output:


### PR DESCRIPTION
The Python warnings.catch_warnings() functionality is not thread-safe (https://py-free-threading.github.io/porting/#the-warnings-module-is-not-thread-safe), so we cannot use it during tests that use free-threading. This change introduces a private warnings test helper (test_warning_util.py), which hooks the CPython warning infrastructure and uses it to implement thread-safe warnings infrastructure.

This requires a handful of small modifications to tests to remove direct uses of the warnings module. We also sadly have to delete one TPU test that checks for a warning raised on another thread; there's no easy way for us to catch that in a thread-safe way, but that test seems like overkill anyway.