### PR TITLE
Fix attention  backwards  pass

### DIFF
--- a/tests/pallas/gpu_ops_test.py
+++ b/tests/pallas/gpu_ops_test.py
@@ -41,6 +41,7 @@ else:
 import jax.numpy as jnp
 import numpy as np
 
+BlockSizes = attention.BlockSizes
 
 # TODO(sharadmv): Update signatures of pallas_call to correct inputs/outputs.
 # pylint: disable=no-value-for-parameter
@@ -153,8 +154,11 @@ class FusedAttentionTest(PallasBaseTest):
       seq_len=(128, 384),
       num_heads=(1, 2, 8),
       head_dim=(32, 64, 128),
-      block_q=(64, 128),
-      block_k=(64, 128),
+      block_sizes=(
+        BlockSizes.get_default(),
+        BlockSizes(block_q=64,block_k=64),
+        BlockSizes(block_q=64,block_k=128),
+      ),
       causal=(True, False),
       use_fwd=(True, False),
       use_segment_ids=(True, False),
@@ -166,8 +170,7 @@ class FusedAttentionTest(PallasBaseTest):
       seq_len,
       num_heads,
       head_dim,
-      block_q,
-      block_k,
+      block_sizes,
       causal,
       use_fwd,
       use_segment_ids,
@@ -196,8 +199,7 @@ class FusedAttentionTest(PallasBaseTest):
         v, _ = jax.vjp(
             functools.partial(
                 attention.mha,
-                block_q=block_q,
-                block_k=block_k,
+                block_sizes=block_sizes,
                 causal=causal,
                 segment_ids=segment_ids,
                 interpret=self.INTERPRET,
@@ -211,8 +213,7 @@ class FusedAttentionTest(PallasBaseTest):
     else:
       impl = functools.partial(
           attention.mha,
-          block_q=block_q,
-          block_k=block_k,
+          block_sizes=block_sizes,
           causal=causal,
           segment_ids=segment_ids,
           interpret=self.INTERPRET,
@@ -226,6 +227,25 @@ class FusedAttentionTest(PallasBaseTest):
       seq_len=(128, 384),
       num_heads=(1, 2),
       head_dim=(32, 64, 128,),
+      block_sizes=(
+        BlockSizes.get_default(),
+        BlockSizes(
+          block_q=128,
+          block_k=128,
+          block_q_dkv=64,
+          block_kv_dkv=64,
+          block_q_dq=64,
+          block_kv_dq=64,
+        ),
+        BlockSizes(
+          block_q=128,
+          block_k=128,
+          block_q_dkv=64,
+          block_kv_dkv=128,
+          block_q_dq=128,
+          block_kv_dq=64,
+        ),
+      ),
       causal=(True, False),
       use_segment_ids=(True, False),
   )
@@ -236,6 +256,7 @@ class FusedAttentionTest(PallasBaseTest):
       seq_len,
       num_heads,
       head_dim,
+      block_sizes,
       causal,
       use_segment_ids,
   ):
@@ -257,8 +278,12 @@ class FusedAttentionTest(PallasBaseTest):
       segment_ids = None
 
     def f(q, k, v):
-      return attention.mha(q, k, v, segment_ids, causal=causal,
-                           interpret=self.INTERPRET).sum()
+      return attention.mha(
+          q, k, v,
+          block_sizes=block_sizes,
+          causal=causal,
+          segment_ids=segment_ids,
+          interpret=self.INTERPRET).sum()
 
     def f_ref(q, k, v):
       return attention.mha_reference(q, k, v, segment_ids, causal=causal).sum()


### PR DESCRIPTION
This PR fixes the backwards pass for non-default block sizes, and a bug when causal=True. Also made a small refactoring to pass around a BlockSizes object with all the tunable params.