### PR TITLE
Avoid calls to warnings.catch_warnings in JAX core code.

### DIFF
--- a/jax/_src/flatten_util.py
+++ b/jax/_src/flatten_util.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
-
 import numpy as np
 
 from jax import lax
 import jax.numpy as jnp
 
+from jax._src.lax import lax as lax_internal
 from jax._src import dtypes
 from jax._src.tree_util import tree_flatten, tree_unflatten
 from jax._src.util import safe_zip, unzip2, HashablePartial
@@ -83,7 +82,8 @@ def _unravel_list(indices, shapes, from_dtypes, to_dtype, arr):
     raise TypeError(f"unravel function given array of dtype {arr_dtype}, "
                     f"but expected dtype {to_dtype}")
   chunks = jnp.split(arr, indices[:-1])
-  with warnings.catch_warnings():
-    warnings.simplefilter("ignore")  # ignore complex-to-real cast warning
-    return [lax.convert_element_type(chunk.reshape(shape), dtype)
-            for chunk, shape, dtype in zip(chunks, shapes, from_dtypes)]
+  return [
+    lax_internal._convert_element_type(chunk.reshape(shape), dtype,
+                                       warn_on_complex_to_real_cast=False)
+    for chunk, shape, dtype in zip(chunks, shapes, from_dtypes)
+  ]

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -5732,10 +5732,9 @@ def astype(x: ArrayLike, dtype: DTypeLike | None,
 
   # We offer a more specific warning than the usual ComplexWarning so we prefer
   # to issue our warning.
-  with warnings.catch_warnings():
-    warnings.simplefilter("ignore", ComplexWarning)
-    result = lax_internal._convert_element_type(
-      x_arr, dtype, sharding=_normalize_to_sharding(device))
+  result = lax_internal._convert_element_type(
+    x_arr, dtype, sharding=_normalize_to_sharding(device),
+    warn_on_complex_to_real_cast=False)
   return _array_copy(result) if copy else result
 
 

--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -20,7 +20,6 @@ from functools import partial
 import math
 import operator
 from typing import overload, Any, Literal, Protocol, Union
-import warnings
 
 import numpy as np
 
@@ -37,7 +36,7 @@ from jax._src.lax import lax as lax_internal
 from jax._src.typing import Array, ArrayLike, DType, DTypeLike, DeprecatedArg
 from jax._src.util import (
     canonicalize_axis as _canonicalize_axis, maybe_named_axis,
-    set_module, NumpyComplexWarning)
+    set_module)
 
 
 export = set_module('jax.numpy')
@@ -100,7 +99,7 @@ ReductionOp = Callable[[Any, Any], Any]
 
 def _reduction(a: ArrayLike, name: str, op: ReductionOp, init_val: ArrayLike,
                *, has_identity: bool = True,
-               preproc: Callable[[ArrayLike], ArrayLike] | None = None,
+               preproc: Callable[[Array], Array] | None = None,
                bool_op: ReductionOp | None = None,
                upcast_f16_for_computation: bool = False,
                axis: Axis = None, dtype: DTypeLike | None = None, out: None = None,
@@ -201,16 +200,15 @@ def _reduction_init_val(a: ArrayLike, init_val: Any) -> np.ndarray:
     sign, info = np.sign(init_val), dtypes.iinfo(a_dtype)
     return np.array(info.min if sign < 0 else info.max, dtype=a_dtype)
 
-def _cast_to_bool(operand: ArrayLike) -> Array:
-  with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=NumpyComplexWarning)
-    return lax.convert_element_type(operand, np.bool_)
+def _cast_to_bool(operand: Array) -> Array:
+  if dtypes.issubdtype(operand.dtype, np.complexfloating):
+    operand = operand.real
+  return lax.convert_element_type(operand, np.bool_)
 
-def _cast_to_numeric(operand: ArrayLike) -> Array:
+def _cast_to_numeric(operand: Array) -> Array:
   return promote_dtypes_numeric(operand)[0]
 
-def _require_integer(operand: ArrayLike) -> Array:
-  arr = lax_internal.asarray(operand)
+def _require_integer(arr: Array) -> Array:
   if not dtypes.isdtype(arr, ("bool", "integral")):
     raise ValueError(f"integer argument required; got dtype={arr.dtype}")
   return arr


### PR DESCRIPTION
warnings.catch_warnings is not thread-safe. However it is always used to avoid complex-to-real conversion warnings, which we can avoid in other ways.