### PR TITLE
Remove casting from jax.nn.one_hot

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -710,7 +710,6 @@ def one_hot(x: Any, num_classes: int, *,
       'jax-nn-one-hot-float-input',
       f"jax.nn.one_hot input should be integer-typed; got dtype={x_arr.dtype}",
       stacklevel=1)
-    x_arr = x_arr.astype('int32')
   return _one_hot(x_arr, num_classes, dtype=dtype, axis=axis)
 
 


### PR DESCRIPTION
This change was made after the most recent release, so is safe to remove. Casting float to int potentially changes intentional behavior: e.g. NaN casts to 0. Some downstream users currently use NaN to mark rows which should have no one-hot entry.

Fixes issue introduced in #25590.