### PR TITLE
Fix formatting in docs for transposing pytrees

### DIFF
--- a/docs/working-with-pytrees.md
+++ b/docs/working-with-pytrees.md
@@ -490,7 +490,7 @@ This section covers some of the most common patterns with JAX pytrees.
 
 ### Transposing pytrees with `jax.tree.map` and `jax.tree.transpose`
 
-To transpose a pytree (turn a list of trees into a tree of lists), JAX has two functions: {func} `jax.tree.map` (more basic) and {func}`jax.tree.transpose` (more flexible, complex and verbose).
+To transpose a pytree (turn a list of trees into a tree of lists), JAX has two functions: {func}`jax.tree.map` (more basic) and {func}`jax.tree.transpose` (more flexible, complex and verbose).
 
 **Option 1:** Use {func}`jax.tree.map`. Here's an example:
 


### PR DESCRIPTION
`{func}` is currently present in the rendered docs. There should be no space between `{func}` and following word.

How it is currently rendered:

https://jax.readthedocs.io/en/latest/working-with-pytrees.html#transposing-pytrees-with-jax-tree-map-and-jax-tree-transpose 

> To transpose a pytree (turn a list of trees into a tree of lists), JAX has two functions: {func} jax.tree.map (more basic) and [jax.tree.transpose](https://jax.readthedocs.io/en/latest/_autosummary/jax.tree.transpose.html#jax.tree.transpose) (more flexible, complex and verbose).
