### PR TITLE
[Shmap/PartialAuto] Fix debug.print in shard_map partial auto

### DIFF
--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -134,11 +134,13 @@ def debug_callback_lowering(ctx, *args, effect, callback, **params):
 
   axis_context = ctx.module_context.axis_context
   if (isinstance(axis_context, sharding_impls.SPMDAxisContext) and
-        set(axis_context.manual_axes) == set(axis_context.mesh.axis_names)):
-    # If we have fully manual sharding during lowering, that means the JAX
-    # program has per-device semantics, so we run the callback on each device.
-    sharding = xc.OpSharding()
-    sharding.type = xc.OpSharding.Type.MANUAL
+        axis_context.manual_axes):
+      # If we have fully manual sharding during lowering, that means the JAX
+      # program has per-device semantics, so we run the callback on each device.
+      # If we have partial auto sharding, we should also allow running debug
+      # callback with the data shard each device holds.
+      sharding = xc.OpSharding()
+      sharding.type = xc.OpSharding.Type.MANUAL
   elif isinstance(
       axis_context,
       (sharding_impls.ShardingContext, sharding_impls.SPMDAxisContext),

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -2224,6 +2224,30 @@ class ShardMapTest(jtu.JaxTestCase):
     self.assertAllClose(jax.random.key_data(y), jax.random.key_data(keys),
                         check_dtypes=False)
 
+  def test_partial_auto_debug_print(self):
+    if config.use_shardy_partitioner.value:
+      self.skipTest('Shardy does not support full-to-shard.')
+
+    mesh = jtu.create_mesh((4, 2), ('i', 'j'))
+
+    def g(x):
+      jax.debug.print("input value {x}", x=x)
+      return x
+
+    @jax.jit
+    def f(x):
+      return shard_map(g,
+                       mesh, in_specs=P('i'), out_specs=P('i'),
+                       check_rep=False, auto=frozenset({'j'}))(x)
+
+    with jtu.capture_stdout() as output:
+      _ = f(jnp.arange(8)) # don't crash
+      jax.effects_barrier()
+
+    output_shards = np.arange(8).reshape(4, 2)
+    for i in range(8):
+      self.assertIn(f'input value {output_shards[i % 4]}', output())
+
   def test_vmap_grad_shmap_spmd_axis_name_residuals(self):
     # https://github.com/jax-ml/jax/pull/21032
     mesh = jtu.create_mesh((4, 2), ('i', 'j'))


### PR DESCRIPTION
This is my attempt to fix `debug.print` inside the partial auto env.

Now what's going on is that everything wrapped inside a `shard_map` partial auto env will crash when printing with `jax.debug.print`.

I have a feeling that it is generally safe to set manual sharding for the custom call instruction that invokes debug print callback. In that case, each device will just print out what they have regardless of what XLA GSPMD will do with the inputs.