### PR TITLE
[Shmap/PartialAuto] Temporary solution for `debug.print` inside a partial-auto shard map.

### DIFF
--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -134,11 +134,13 @@ def debug_callback_lowering(ctx, *args, effect, callback, **params):
 
   axis_context = ctx.module_context.axis_context
   if (isinstance(axis_context, sharding_impls.SPMDAxisContext) and
-        set(axis_context.manual_axes) == set(axis_context.mesh.axis_names)):
-    # If we have fully manual sharding during lowering, that means the JAX
-    # program has per-device semantics, so we run the callback on each device.
-    sharding = xc.OpSharding()
-    sharding.type = xc.OpSharding.Type.MANUAL
+        axis_context.manual_axes):
+      # If we have fully manual sharding during lowering, that means the JAX
+      # program has per-device semantics, so we run the callback on each device.
+      # If we have partial auto sharding, we should also allow running debug
+      # callback with the data shard each device holds.
+      sharding = xc.OpSharding()
+      sharding.type = xc.OpSharding.Type.MANUAL
   elif isinstance(
       axis_context,
       (sharding_impls.ShardingContext, sharding_impls.SPMDAxisContext),

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -2224,6 +2224,30 @@ class ShardMapTest(jtu.JaxTestCase):
     self.assertAllClose(jax.random.key_data(y), jax.random.key_data(keys),
                         check_dtypes=False)
 
+  def test_partial_auto_debug_print(self):
+    if config.use_shardy_partitioner.value:
+      self.skipTest('Shardy does not support full-to-shard.')
+
+    mesh = jtu.create_mesh((4, 2), ('i', 'j'))
+
+    def g(x):
+      jax.debug.print("input value {x}", x=x)
+      return x
+
+    @jax.jit
+    def f(x):
+      return shard_map(g,
+                       mesh, in_specs=P('i'), out_specs=P('i'),
+                       check_rep=False, auto=frozenset({'j'}))(x)
+
+    with jtu.capture_stdout() as output:
+      _ = f(jnp.arange(8)) # don't crash
+      jax.effects_barrier()
+
+    output_shards = np.arange(8).reshape(4, 2)
+    for i in range(8):
+      self.assertIn(f'input value {output_shards[i % 4]}', output())
+
   def test_vmap_grad_shmap_spmd_axis_name_residuals(self):
     # https://github.com/jax-ml/jax/pull/21032
     mesh = jtu.create_mesh((4, 2), ('i', 'j'))

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -2231,6 +2231,7 @@ class ShardMapTest(jtu.JaxTestCase):
     mesh = jtu.create_mesh((4, 2), ('i', 'j'))
 
     def g(x):
+      x = jax.lax.with_sharding_constraint(x, NamedSharding(mesh, P('j')))
       jax.debug.print("input value {x}", x=x)
       return x
 
@@ -2244,9 +2245,8 @@ class ShardMapTest(jtu.JaxTestCase):
       _ = f(jnp.arange(8)) # don't crash
       jax.effects_barrier()
 
-    output_shards = np.arange(8).reshape(4, 2)
     for i in range(8):
-      self.assertIn(f'input value {output_shards[i % 4]}', output())
+      self.assertIn(f'input value [{i}', output())
 
   def test_vmap_grad_shmap_spmd_axis_name_residuals(self):
     # https://github.com/jax-ml/jax/pull/21032


### PR DESCRIPTION
This commit needs the XLA commit: https://github.com/openxla/xla/pull/20944 to work.

However this is not the ultimate fix for this. We want some solution that works in very short term as this feature is crucial for debugging.

The issue with debug.print not working inside a partial-auto shard map is because,

1) The tensor will be further partitioned in GSPMD however the host callback is created during IR lowering time with the shape traced in shard map.
2) based on 1), a permanent fix would be serializing the args info into the opaque string and after SPMD partitioning, XLA should pack the partitioned args info into the backend config opaque string.
