### PR TITLE
Fix the doc error: module 'scipy.misc' has no attribute 'face'

### DIFF
--- a/docs/notebooks/convolutions.ipynb
+++ b/docs/notebooks/convolutions.ipynb
@@ -121,13 +121,13 @@
     }
    ],
    "source": [
-    "from scipy import misc\n",
+    "from scipy import datasets\n",
     "import jax.scipy as jsp\n",
     "\n",
     "fig, ax = plt.subplots(1, 3, figsize=(12, 5))\n",
     "\n",
     "# Load a sample image; compute mean() to convert from RGB to grayscale.\n",
-    "image = jnp.array(misc.face().mean(-1))\n",
+    "image = jnp.array(datasets.face().mean(-1))\n",
     "ax[0].imshow(image, cmap='binary_r')\n",
     "ax[0].set_title('original')\n",
     "\n",

--- a/docs/notebooks/convolutions.md
+++ b/docs/notebooks/convolutions.md
@@ -75,13 +75,13 @@ For example, here is a simple approach to de-noising an image based on convoluti
 :id: Jk5qdnbv6QgT
 :outputId: 292205eb-aa09-446f-eec2-af8c23cfc718
 
-from scipy import misc
+from scipy import datasets
 import jax.scipy as jsp
 
 fig, ax = plt.subplots(1, 3, figsize=(12, 5))
 
 # Load a sample image; compute mean() to convert from RGB to grayscale.
-image = jnp.array(misc.face().mean(-1))
+image = jnp.array(datasets.face().mean(-1))
 ax[0].imshow(image, cmap='binary_r')
 ax[0].set_title('original')
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,6 +17,7 @@ pytest-xdist
 # Packages used for notebook execution
 matplotlib
 scikit-learn
+pooch
 numpy
 rich[jupyter]
 cmake


### PR DESCRIPTION
The error we have is due to recent changes in the SciPy library, upgrading from 1.15.0 to 1.17.0. The scipy.misc.face() function has been deprecated and removed from the scipy.misc module. To resolve this issue, we use the updated method for accessing the face image dataset. And add the dependency of pooch for scipy.datasets module.