### PR TITLE
[shape_poly] Improve threefry with symbolic shapes

### DIFF
--- a/jax/_src/export/shape_poly_decision.py
+++ b/jax/_src/export/shape_poly_decision.py
@@ -306,18 +306,21 @@ class _DecisionByElimination:
                                                                scope=scope):
       # `c =[eq] 0` AND `t*t_k*t_s + c*c_s` contains only terms smaller than t
       # AND c_s > 0.
-      # rest = e[i:]*t_s + c*c_s` AND `rest_ub >= rest >= rest_lb`
+      # `rest = e[i:]*t_s + c*c_s` AND `rest_ub >= rest >= rest_lb`
+      # `rest` contains only terms smaller than `t`.
       rest = _DimExpr._linear_combination_sorted_pairs(e, i, t_s,
                                                        c._sorted_terms, 0, c_s)
       rest_lb, rest_ub = self._bounds_for_sorted_terms(scope, rest, 0,
                                                        BoundsPrecision.BEST)
       if rest_ub < np.inf:
+        # We have: e[i:]*t_s = rest - c*c_s <= rest_ub
         if t_s > 0:
           ub = min(ub, int(np.floor(rest_ub / t_s)))
         else:
           lb = max(lb, int(np.ceil(rest_ub / t_s)))
 
       if rest_lb > - np.inf and c_eq == Comparator.EQ:
+        # We have: e[i:]*t_s = rest - c*c_s = rest >= rest_lb
         if t_s > 0:
           lb = max(lb, int(np.ceil(rest_lb / t_s)))
         else:

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -2086,10 +2086,7 @@ _POLY_SHAPE_TEST_HARNESSES = [
         PolyHarness("random_uniform", f"error_not_even_{flags_name}",
                     lambda key, a: jax.random.uniform(key, a.shape, dtype=_f32),
                     arg_descriptors=[RandArg((key_size,), np.uint32), RandArg((3, 5), _f32)],
-                    polymorphic_shapes=[None, "b0, ..."],
-                    expect_error=(
-                        (core.InconclusiveDimensionOperation,
-                         "array size .* must be even") if flags_name == "threefry_non_partitionable" else (None, None)),
+                    polymorphic_shapes=[None, "b0, b1"],
                     override_jax_config_flags=override_jax_config_flags)  # type: ignore
       ]
         for key_size, flags_name, override_jax_config_flags in [


### PR DESCRIPTION
Previously, we could only handle threefry with symbolic shapes when it was possible to tell statically that the size of the `count` array is even or odd. This meant that often we had to add a constraint that one of the dimensions is even.

Here we rewrite the handling of threefry to not require a Python conditional for the evenness of the size of the count array. We use a couple of `lax.dynamic_slice` rather than a `lax.split`.

We also generalize the tests to test the cases when the size if fully symbolic, and we cannot tell statically that it is even.