### PR TITLE
[Mosaic GPU] Use `num_q_heads=2` in `flash_attention.py`

### DIFF
--- a/jax/experimental/mosaic/gpu/examples/flash_attention.py
+++ b/jax/experimental/mosaic/gpu/examples/flash_attention.py
@@ -607,7 +607,7 @@ if __name__ == "__main__":
     exit(0)
 
   batch_size = 1
-  num_q_heads = 4
+  num_q_heads = 2
   num_kv_heads = 1
   prof_spec = None
   seq_lens = (4096, 32768)


### PR DESCRIPTION
Previously with 4 heads the reference function `ref` would allocate 32 GiB since it materializes large intermediate tensors. That causes CI on an 80GB H100 to run out of memory when 4 tests run in parallel. `num_q_heads=2` allows us to test multiple heads while cutting memory in half.