### PR TITLE
fix grad(logsumexp) to produce 0s where `where` is False

### DIFF
--- a/jax/_src/ops/special.py
+++ b/jax/_src/ops/special.py
@@ -69,6 +69,8 @@ def logsumexp(a: ArrayLike, axis: Axis = None, b: ArrayLike | None = None,
     Either an array ``result`` or a pair of arrays ``(result, sign)``, depending
     on the value of the ``return_sign`` argument.
   """
+  if where is not None:
+    a = jnp.where(where, a, 0)
   if b is not None:
     a_arr, b_arr = promote_args_inexact("logsumexp", a, b)
     a_arr = jnp.where(b_arr != 0, a_arr, -jnp.inf)

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -202,6 +202,11 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     y_actual = lsp_special.logsumexp(x, where=mask)
     self.assertAllClose(y_expected, y_actual, check_dtypes=False)
 
+  def testLogSumExpWhereGrad(self):
+    x = jnp.array([0., 0., 0., 0., 100.])
+    g = jax.grad(lambda x: lsp_special.logsumexp(x, where=jnp.arange(5) < 4))(x)
+    self.assertAllClose(g, jnp.array([0.25, 0.25, 0.25, 0.25, 0.]))
+
   @jtu.sample_product(
     shape=all_shapes,
     dtype=float_dtypes,


### PR DESCRIPTION
Thanks @epiqueras for noticing and diagnosing this issue:

```python
x = jnp.array([0., 0. 100.])
where = jnp.array([True, True, False])
g = jax.grad(lambda x: lsp_special.logsumexp(x, where=where))(x)  # [0.5, 0.5, nan]
```

The fix here is just to project the input. (Alternatively we could write a custom_jvp.)