### PR TITLE
better error message when lowering a primitive with a custom_partition rule

### DIFF
--- a/jax/_src/custom_partitioning.py
+++ b/jax/_src/custom_partitioning.py
@@ -527,8 +527,16 @@ def _custom_partitioning_lowering_rule(ctx: mlir.LoweringRuleContext, *values,
   if isinstance(axis_context, sharding_impls.ShardingContext):
     devices = axis_context.device_assignment
     if devices is None:
-      raise AssertionError(
-          'Please file a bug at https://github.com/jax-ml/jax/issues')
+        raise AssertionError(
+            "You may be using a primitive in the context of a custom partitioning specialization "
+            "that requires devices during lowering. However, no device assignment was found. "
+            "To fix this issue, ensure that the primitive is added to:\n"
+            "    dispatch.prim_requires_devices_during_lowering\n"
+            "For example:\n"
+            "    dispatch.prim_requires_devices_during_lowering.add(primitive_p)\n"
+            "If you believe this is a bug, please report it at: https://github.com/google/jax/issues"
+        )
+
     am = axis_context.abstract_mesh
     if am is not None:
       mesh = mesh_lib.Mesh(np.array(devices).reshape(am.axis_sizes),


### PR DESCRIPTION
Hello,

A quick PR to improve an error message I got when I was using `custom_partitionning`

Here is a MWE

```py
import os

os.environ["JAX_PLATFORM_NAME"] = "cpu"
os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"

from jax import core, lax
import jax.numpy as jnp
import jax
from jax.experimental.custom_partitioning import custom_partitioning
from jax.interpreters import mlir
import jax.extend as jex

from jax.sharding import NamedSharding
from jax.sharding import PartitionSpec as P

pdims = (8,)
mesh = jax.make_mesh(pdims, axis_names=("x"))
sharding = NamedSharding(mesh, P("x"))

# ================================
# Double Primitive Rules
# ================================

# Step 1: Define the Primitive
double_prim_p = jex.core.Primitive("double_prim")


# dispatch.prim_requires_devices_during_lowering.add(double_prim_p)
# Step 2: Define the Implementation
@custom_partitioning
def double_prim_impl(x):
    return 2 * x  # Linear operation


def infer_sharding_from_operands(mesh, arg_infos, result_infos):
    return arg_infos[0].sharding


def partition(mesh, arg_infos, result_infos):
    input_sharding = arg_infos[0].sharding
    output_sharding = result_infos.sharding
    input_mesh = input_sharding.mesh

    def impl(operand):
        return 2 * operand

    return input_mesh, impl, output_sharding, (input_sharding,)


# Step 3: Define Abstract Evaluation
def double_prim_abstract_eval(x):
    return core.ShapedArray(x.shape, x.dtype)


# Step 4: Register the Primitive
double_prim_p.def_impl(double_prim_impl)  # Implementation
double_prim_p.def_abstract_eval(double_prim_abstract_eval)  # Abstract Eval
double_prim_impl.def_partition(
    infer_sharding_from_operands=infer_sharding_from_operands, partition=partition
)
mlir.register_lowering(
    double_prim_p, mlir.lower_fun(double_prim_impl, multiple_results=False)
)  # Lowering


# Define a Python wrapper for the primitive
@jax.jit
def double_prim_call(x):
    return double_prim_p.bind(x)

# Test Forward Computation
x = jnp.arange(8).astype(jnp.float32)
x = lax.with_sharding_constraint(x, sharding)
print("Double Primitive Forward:\n", double_prim_call(x))
```

I get this error message 
`Please file a bug at https://github.com/jax-ml/jax/issues`

If I uncomment this line 
it is fixed

`dispatch.prim_requires_devices_during_lowering.add(double_prim_p)`

I added a more explicit error message.