### PR TITLE
[Will not merge] Show the IR of the partial-auto boundary.

### DIFF
--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -2184,9 +2184,12 @@ class ShardMapTest(jtu.JaxTestCase):
 
     @jax.jit
     def f(x):
-      return shard_map(g,
+      x = jax.lax.with_sharding_constraint(x, NamedSharding(mesh, P(('i', 'j'))))  # Working
+      re = shard_map(g,
                        mesh, in_specs=P('i'), out_specs=P('i'),
                        check_rep=False, auto=frozenset({'j'}))(x)
+      re = jax.lax.with_sharding_constraint(re, NamedSharding(mesh, P(('i', 'j'))))  # All gathering + DS
+      return re
 
     print("Optimized IR: ", f.lower(x).compile().as_text())
     y = f(x)  # don't crash

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -2188,6 +2188,7 @@ class ShardMapTest(jtu.JaxTestCase):
                        mesh, in_specs=P('i'), out_specs=P('i'),
                        check_rep=False, auto=frozenset({'j'}))(x)
 
+    print("Optimized IR: ", f.lower(x).compile().as_text())
     y = f(x)  # don't crash
     self.assertAllClose(y, jnp.array([6., 7., 0., 1., 2., 3., 4., 5.]),
                         check_dtypes=False)


### PR DESCRIPTION
Command to run:

bazel test -c opt --test_filter="*test_partial_auto_ppermute" --test_output=all //tests:shard_map_test_gpu