### PR TITLE
[better_errors] Add debug_info to DynamicJaxprTrace and JaxprStackFrame

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -453,8 +453,12 @@ def value_and_grad(fun: Callable, argnums: int | Sequence[int] = 0,
       raise TypeError(f"differentiating with respect to {argnums=} requires at least "
                       f"{max_argnum + 1} positional arguments to be passed by the caller, "
                       f"but got only {len(args)} positional arguments.")
+    fun_src_info = fun_sourceinfo(fun)
+    fun_signature = api_util.fun_signature(fun)
+    dbg = debug_info('value_and_grad', fun_src_info, fun_signature,
+                     args, kwargs, (), ())
 
-    f = lu.wrap_init(fun, kwargs)
+    f = lu.wrap_init(fun, params=kwargs, debug_info=dbg)
     f_partial, dyn_args = argnums_partial(f, argnums, args,
                                           require_static_args_hashable=False)
     for leaf in tree_leaves(dyn_args):

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -672,6 +672,9 @@ class Tracer(typing.Array, metaclass=StrictABCMeta):
   __slots__ = ['_trace', '_line_info']
   __hash__ = None  # type: ignore
 
+  _trace: Trace
+  _line_info: source_info_util.SourceInfo | None
+
   dtype = _aval_property('dtype')
   ndim = _aval_property('ndim')
   size = _aval_property('size')

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1332,7 +1332,9 @@ def _create_pjit_jaxpr(
 @util.cache(max_size=4096, trace_context_in_key=False)
 def _check_and_canonicalize_out_shardings(
     out_shardings_treedef, out_shardings_leaves, out_layouts_treedef,
-    out_layouts_leaves, out_tree, out_avals, debug_info, device_or_backend_set):
+    out_layouts_leaves, out_tree, out_avals,
+    debug_info: core.JaxprDebugInfo | None,
+    device_or_backend_set):
   orig_out_shardings = tree_unflatten(out_shardings_treedef, out_shardings_leaves)
   if isinstance(orig_out_shardings, (UnspecifiedValue, Sharding)):
     out_shardings_flat = (orig_out_shardings,) * len(out_avals)


### PR DESCRIPTION
This is part of a sequence of changes to ensure that the debugging information is propagated properly.

Additional cleanup:
* Rename `result_paths` to `result_paths_thunk` in `TracingDebugInfo` to clarify the difference from the similar field in `JaxprDebugInfo`
* Added more type declarations