### PR TITLE
Examine `partial.func` when trying to find function names

### DIFF
--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -376,7 +376,7 @@ def wrap_name(name, transform_name):
   return transform_name + '(' + name + ')'
 
 def fun_name(fun: Callable):
-  fun_name = getattr(fun, "__name__")
+  fun_name = getattr(fun, "__name__", None)
   if fun_name is not None:
     return fun_name
   if isinstance(fun, partial):
@@ -384,7 +384,7 @@ def fun_name(fun: Callable):
   return "<unnamed function>"
 
 def fun_qual_name(fun: Callable):
-  fun_qual_name = getattr(fun, "__qualname__")
+  fun_qual_name = getattr(fun, "__qualname__", None)
   if fun_qual_name is not None:
     return fun_qual_name
   if isinstance(fun, partial):

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -376,11 +376,20 @@ def wrap_name(name, transform_name):
   return transform_name + '(' + name + ')'
 
 def fun_name(fun: Callable):
-  return getattr(fun, "__name__", "<unnamed function>")
+  fun_name = getattr(fun, "__name__")
+  if fun_name is not None:
+    return fun_name
+  if isinstance(fun, partial):
+    return fun_name(fun.func)
+  return "<unnamed function>"
 
 def fun_qual_name(fun: Callable):
-  return getattr(fun, "__qualname__",
-                 getattr(fun, "__name__", "<unnamed function>"))
+  fun_qual_name = getattr(fun, "__qualname__")
+  if fun_qual_name is not None:
+    return fun_qual_name
+  if isinstance(fun, partial):
+    return fun_qual_name(fun.func)
+  return fun_name(fun)
 
 def canonicalize_axis(axis, num_dims) -> int:
   """Canonicalize an axis in [-num_dims, num_dims) to [0, num_dims)."""


### PR DESCRIPTION
Make utils for reporting function name work with `functools.partial` by using the inner `.func` attribute if the object doesn't have a `__name__` attribute. `functools.partial` objects do not have `__name__` attributes by default.