### PR TITLE
Update the JAX version to 0.5.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 
 ## Unreleased
 
+As of this release, JAX now uses
+[effort-based versioning](https://jax.readthedocs.io/en/latest/jep/25516-effver.html).
+Since this release makes a small but breaking change to PRNG key semantics that
+may require users to update their code, we are bumping the "meso" version of JAX
+to signify this.
+
 * Breaking changes
   * Enable `jax_threefry_partitionable` by default (see
     [the update note](https://github.com/jax-ml/jax/discussions/18480)).

--- a/jax/version.py
+++ b/jax/version.py
@@ -21,7 +21,7 @@ import os
 import pathlib
 import subprocess
 
-_version = "0.4.39"
+_version = "0.5.0"
 # The following line is overwritten by build scripts in distributions &
 # releases. Do not modify this manually, or jax/jaxlib build will fail.
 _release_version: str | None = None


### PR DESCRIPTION
This is because of the breaking change to PRNG key semantics, and the version follows JAX's new effver versioning scheme (https://jax.readthedocs.io/en/latest/jep/25516-effver.html).