### PR TITLE
Tweak documentation of jnp.cov to include scalar return for M = 1

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -12894,7 +12894,7 @@ def cov(m: ArrayLike, y: ArrayLike | None = None, rowvar: bool = True,
       observation.
 
   Returns:
-    A covariance matrix of shape ``(M, M)``.
+    A covariance matrix of shape ``(M, M)``, or a scalar with shape ``()`` if ``M = 1``.
 
   See also:
     - :func:`jax.numpy.corrcoef`: compute the correlation coefficient, a normalized


### PR DESCRIPTION
Fixes https://github.com/jax-ml/jax/issues/25951