### PR TITLE
Add DCE rules for custom_jvp and custom_vjp

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -45,7 +45,8 @@ from jax._src.tree_util import (
     tree_flatten, tree_unflatten, tree_map, treedef_is_leaf, treedef_tuple,
     register_pytree_node_class, tree_leaves, tree_flatten_with_path,
     tree_leaves_with_path, keystr, treedef_children)
-from jax._src.util import (cache, safe_zip, safe_map, split_list, unzip2)
+from jax._src.util import (cache, safe_zip, safe_map, split_list, unzip2,
+                           weakref_lru_cache)
 
 
 traceback_util.register_exclusion(__file__)
@@ -415,6 +416,46 @@ def _custom_jvp_call_transpose(params, jaxpr, args, ct, _):
   del params
   return ad.backward_pass(jaxpr.jaxpr, None, jaxpr.consts, args, ct)
 ad.primitive_transposes[custom_jvp_call_p] = _custom_jvp_call_transpose
+
+@weakref_lru_cache
+def _cached_closed_call_dce_instantiate(jaxpr_, used_outputs: tuple[bool, ...]
+                            ) -> tuple[core.ClosedJaxpr, list[bool]]:
+  jaxpr, consts = jaxpr_.jaxpr, jaxpr_.consts
+  new_jaxpr, used_inputs = pe.dce_jaxpr(jaxpr, used_outputs, True)
+  return core.ClosedJaxpr(new_jaxpr, consts), used_inputs
+
+def _custom_jvp_call_dce(
+    used_outs: Sequence[bool], eqn: core.JaxprEqn
+) -> tuple[list[bool], core.JaxprEqn | None]:
+  if not any(used_outs) and not pe.has_effects(eqn):
+    return [False] * len(eqn.invars), None
+
+  call_jaxpr = eqn.params["call_jaxpr"]
+  jvp_jaxpr_thunk = eqn.params["jvp_jaxpr_thunk"]
+  # We must set instantiate=True because some inputs that are unused by the
+  # DCE'ed primal might be used in the JVP rule.
+  dce_call_jaxpr, used_ins = _cached_closed_call_dce_instantiate(
+      call_jaxpr, tuple(used_outs))
+  assert all(used_ins)
+
+  @pe._memoize
+  def dce_jvp_jaxpr_thunk(*in_zeros):
+    jvp_jaxpr, consts, out_zeros = jvp_jaxpr_thunk(*in_zeros)
+    dce_jvp_jaxpr, _ = pe.dce_jaxpr(jvp_jaxpr, [*used_outs, *used_outs], True)
+    dce_out_zeros = [v for used, v in zip(used_outs, out_zeros) if used]
+    return dce_jvp_jaxpr, consts, dce_out_zeros
+
+  outvars = [v for used, v in zip(used_outs, eqn.outvars) if used]
+  new_params = dict(
+      eqn.params,
+      call_jaxpr=dce_call_jaxpr,
+      jvp_jaxpr_thunk=dce_jvp_jaxpr_thunk,
+  )
+  new_eqn = pe.new_jaxpr_eqn(
+      eqn.invars, outvars, eqn.primitive, new_params, dce_call_jaxpr.effects,
+      eqn.source_info, eqn.ctx)
+  return used_ins, new_eqn
+pe.dce_rules[custom_jvp_call_p] = _custom_jvp_call_dce
 
 
 ### VJPs
@@ -907,6 +948,61 @@ def _custom_vjp_call_jaxpr_vmap(
   out_dims = out_dims2[0] if out_dims2 else out_dims1
   return batched_outs, out_dims
 batching.fancy_primitive_batchers[custom_vjp_call_jaxpr_p] = _custom_vjp_call_jaxpr_vmap
+
+def _custom_vjp_call_jaxpr_dce(
+    used_outs: Sequence[bool], eqn: core.JaxprEqn
+) -> tuple[list[bool], core.JaxprEqn | None]:
+  if not any(used_outs) and not pe.has_effects(eqn):
+    return [False] * len(eqn.invars), None
+
+  fun_jaxpr = eqn.params["fun_jaxpr"]
+  fwd_jaxpr_thunk = eqn.params["fwd_jaxpr_thunk"]
+  bwd = eqn.params["bwd"]
+  out_trees = eqn.params["out_trees"]
+  symbolic_zeros = eqn.params["symbolic_zeros"]
+  dce_fun_jaxpr, used_ins = _cached_closed_call_dce_instantiate(
+      fun_jaxpr, tuple(used_outs))
+  assert all(used_ins)
+
+  @pe._memoize
+  def dce_fwd_jaxpr_thunk(*zeros):
+    fwd_jaxpr = core.ClosedJaxpr(*fwd_jaxpr_thunk(*zeros))
+    _, res_tree = out_trees()
+    num_res = res_tree.num_leaves
+    dce_fwd_jaxpr, _ = _cached_closed_call_dce_instantiate(
+        fwd_jaxpr, (True,) * num_res + tuple(used_outs))
+    return dce_fwd_jaxpr.jaxpr, dce_fwd_jaxpr.consts
+
+  @lu.wrap_init
+  def dce_bwd(*args):
+    _, res_tree = out_trees()
+    res, cts = split_list(args, [res_tree.num_leaves])
+    cts_ = iter(cts)
+    all_cts = []
+    for used, aval in zip(used_outs, fun_jaxpr.out_avals):
+      if used:
+        all_cts.append(next(cts_))
+      else:
+        ct_aval = aval.to_tangent_aval()
+        if symbolic_zeros:
+          all_cts.append(SymbolicZero(ct_aval))
+        else:
+          all_cts.append(zeros_like_aval(ct_aval))
+    assert next(cts_, None) is None
+    return bwd(*res, *all_cts)
+
+  outvars = [v for used, v in zip(used_outs, eqn.outvars) if used]
+  new_params = dict(
+      eqn.params,
+      fun_jaxpr=dce_fun_jaxpr,
+      fwd_jaxpr_thunk=dce_fwd_jaxpr_thunk,
+      bwd=dce_bwd.call_wrapped,
+  )
+  new_eqn = pe.new_jaxpr_eqn(
+      eqn.invars, outvars, eqn.primitive, new_params, dce_fun_jaxpr.effects,
+      eqn.source_info, eqn.ctx)
+  return used_ins, new_eqn
+pe.dce_rules[custom_vjp_call_jaxpr_p] = _custom_vjp_call_jaxpr_dce
 
 xla.register_initial_style_primitive(custom_vjp_call_jaxpr_p)
 


### PR DESCRIPTION
All of the `custom_*` primitives are currently treated as opaque by DCE but, in some cases, it would be useful to make sure that DCE passes through these ops properly. This PR adds DCE rules for `custom_jvp` and `custom_vjp`.

Related to https://github.com/jax-ml/jax/pull/25956