### PR TITLE
Add client as a property to Sharding.

### DIFF
--- a/jax/_src/sharding.py
+++ b/jax/_src/sharding.py
@@ -167,6 +167,11 @@ class Sharding:
     return common_devices_indices_map(self, global_shape)
 
   @functools.cached_property
+  def client(self) -> xc.Client:
+    platform = next(iter(self.device_set)).platform
+    return xb.get_backend(platform)
+
+  @functools.cached_property
   def _addressable_device_assignment(self) -> XLADeviceAssignment:
     if self.is_fully_addressable:
       return self._device_assignment


### PR DESCRIPTION
This is to support shardings with no local devices. Eventually XLA tries to [grab the client](https://github.com/openxla/xla/blob/a7e0233eba82901b895a62d35bfbec161bb48b33/xla/python/py_array.cc#L203) from a PyArray shard, but this isn't possible if there are no local shards.