### PR TITLE
fix aliased arg in async pallas docs

### DIFF
--- a/docs/pallas/design/async_note.md
+++ b/docs/pallas/design/async_note.md
@@ -261,7 +261,7 @@ First, we rewrite `ppermute_start` to return `x`, aliasing it through the kernel
 
 ```py
 def ppermute_start_kernel(
-    in_ref, send_sem, recv_sem, out_ref, _, *, axis_name,
+    in_ref, send_sem, recv_sem, _, out_ref, *, axis_name,
 ):
   axis_size = jax.lax.psum(1, axis_name)
   left_neighbor = jax.lax.rem(


### PR DESCRIPTION
This was needed in order to get it to work, as the input-output alias is `{0: 2}`.

I also needed to add `compiler_params=pltpu.TPUCompilerParams(collective_id=0)` to the `pallas_call` for `ppermute_start_kernel` though maybe there is some setup where that wouldn't be necessary?