### PR TITLE
Implement gaussian_filter1d and gaussian_filter

### DIFF
--- a/jax/scipy/ndimage.py
+++ b/jax/scipy/ndimage.py
@@ -17,4 +17,7 @@
 
 from jax._src.scipy.ndimage import (
   map_coordinates as map_coordinates,
+  gaussian_filter1d as gaussian_filter1d,
+  gaussian_filter as gaussian_filter,
 )
+


### PR DESCRIPTION
This PR implements `jax.scipy.ndimage.gaussian_filter1d` and `jax.scipy.ndimage.gaussian_filter`, addresses #7284. The implementation is mostly along the lines of what is done in scipy, whoever with some smaller differences:

- No support for the `output` argument
- No support for boundary modes other than `"constant"`, `"wrap"` and `"reflect"`, however they become available once they are supported by `jnp.pad`
-  Support of a `method` option to choose between `"direct"` and `"fft"` based convolutions.
 
Here you can find a notebook doing some comparisons of the accuracy and performance:
https://github.com/adonath/notebooks-public/blob/master/jax-vs-scipy-gaussian-filter.ipynb

The takeaways are:
 - The direct mode is asymptotically ~3x times slower than Scipy
 - The FFT is the same performance for the 1d case as Scipy (would need to check why this make sense...)
 - The ND-FFT option is asymptotically faster than Scipy, which makes sense, as Scipy relies on direct convolution (`correlate1d` I think...)

ToDo:
- [ ] Implement tests
- [ ] Investigate difference in the "`reflect`" mode