### PR TITLE
Experiment: preserve dict key order in tree.map

### DIFF
--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -911,6 +911,11 @@ class TreeTest(jtu.JaxTestCase):
     ):
       tree_util.tree_flatten(t)
 
+  def testTreeMapPreservesKeyOrder(self):
+    dct = {'b': 1, 'a': 2}
+    dct2 = tree_util.tree_map(lambda x: x + 1, dct)
+    self.assertEqual(list(dct.keys()), list(dct2.keys()))
+
 
 class TreeKeyTest(absltest.TestCase):
 


### PR DESCRIPTION
Just a proof-of-concept; we'd probably have to push this logic into `pytree.cc` if we wanted to actually land this.