### PR TITLE
[better_errors] Expand the tests for debug_info

### DIFF
--- a/jax/_src/jaxpr_util.py
+++ b/jax/_src/jaxpr_util.py
@@ -22,7 +22,7 @@ import gzip
 import itertools
 import json
 import types
-from typing import Any, Union
+from typing import Any, Iterator, Union
 
 from jax._src import core
 from jax._src import util
@@ -33,7 +33,7 @@ map, unsafe_map = util.safe_map, map
 zip, unsafe_zip = util.safe_zip, zip
 
 
-def all_eqns(jaxpr: core.Jaxpr):
+def all_eqns(jaxpr: core.Jaxpr) -> Iterator[tuple[core.Jaxpr, core.JaxprEqn]]:
   for eqn in jaxpr.eqns:
     yield (jaxpr, eqn)
   for subjaxpr in core.subjaxprs(jaxpr):

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -42,6 +42,13 @@ jax_multiplatform_test(
     name = "debug_info_test",
     srcs = ["debug_info_test.py"],
     enable_configs = ["tpu_v3_2x2"],
+    deps = [
+        "//jax:pallas",
+        "//jax:pallas_gpu",
+        "//jax:pallas_gpu_ops",
+        "//jax:pallas_tpu",
+        "//jax:pallas_tpu_ops",
+    ] + py_deps("numpy"),
 )
 
 jax_multiplatform_test(


### PR DESCRIPTION
Debugging info is needed for error messages, and for lowering. For the former, we need debug info inside tracers. For the latter, inside Jaxprs. We add a new set of tests that intentionally leak tracers while tracing and then we check that the tracers have the expected debug info. We also form Jaxprs and we check that they have the expected debug info.

We uncovered a few missing debug infos, those are marked with TODO.