### PR TITLE
Remove linear_util.cache

### DIFF
--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -611,7 +611,6 @@ class MapTracer(core.Tracer):
     named_axes = [f"{k}={v}" for k, v in self.shard_axes.items()]
     return f"{self.val}{{{','.join(named_axes)}}}"
 
-@lu.cache
 def parallel_callable(fun: lu.WrappedFun,
                       backend_name: str | None,
                       axis_name: core.AxisName,

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -2336,7 +2336,6 @@ pe.partial_eval_jaxpr_custom_rules[pjit_p] = \
             _pjit_partial_eval_custom_params_updater)
 
 
-@lu.cache
 def _pjit_transpose_trace(fun, in_avals):
   transpose_jaxpr, _, consts, attrs_tracked = pe.trace_to_jaxpr_dynamic(
       fun, in_avals)

--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -1836,7 +1836,6 @@ def pmap(f, axis_name=None, *, in_axes=0, out_axes=0,
   return wrapped
 
 
-@lu.cache
 def _cached_shard_map(flat_fun, mesh, in_axes_flat, out_axes_thunk, axis_name):
   in_specs = tuple(map(partial(_axis_to_spec, axis_name), in_axes_flat))
   out_specs = lambda: map(partial(_axis_to_spec, axis_name), out_axes_thunk())


### PR DESCRIPTION
Another step towards removing `linear_util` altogether.