### PR TITLE
[better_errors] Port the Pallas debug info mechanisms to the new JAX debugging info

### DIFF
--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -931,6 +931,11 @@ def unflatten_ir_values_like_types(xs: Iterable[ir.Value],
 
 _module_name_regex = re.compile(r"[^\w.-]")
 
+def sanitize_name(name: str) -> str:
+  """Ensure a name is usable as module or function name."""
+  return _module_name_regex.sub("_", name)
+
+
 def sharded_aval(aval: core.AbstractValue,
                  sharding: JSharding | AUTO | None) -> core.AbstractValue:
   """Returns the new aval sharded based on sharding proto."""
@@ -1211,7 +1216,7 @@ def lower_jaxpr_to_module(
     # Remove module name characters that XLA would alter. This ensures that
     # XLA computation preserves the module name.
     attrs = ctx.module.operation.attributes
-    module_name = _module_name_regex.sub("_", module_name)
+    module_name = sanitize_name(module_name)
     attrs["sym_name"] = ir.StringAttr.get(module_name)
     attrs["mhlo.num_replicas"] = i32_attr(num_replicas)
     attrs["mhlo.num_partitions"] = i32_attr(num_partitions)

--- a/jax/_src/linear_util.py
+++ b/jax/_src/linear_util.py
@@ -321,6 +321,11 @@ class DebugInfo(NamedTuple):
   def func_name(self) -> str:
     return self.func_src_info.split(" ")[0]
 
+  def replace_func_name(self, name: str) -> DebugInfo:
+    func_src_comps = self.func_src_info.split(" ")
+    func_src_comps[0] = name
+    return self._replace(func_src_info=" ".join(func_src_comps))
+
   def safe_arg_names(self, expected: int) -> tuple[str, ...]:
     """Get the arg_names with a safety check."""
     if len(self.arg_names) == expected:

--- a/jax/_src/pallas/hlo_interpreter.py
+++ b/jax/_src/pallas/hlo_interpreter.py
@@ -336,7 +336,6 @@ def pallas_call_hlo_interpret(
     *args,
     backend: str | None,
     jaxpr: jax_core.Jaxpr,
-    name_and_src_info: pallas_core.NameAndStrInfo,
     debug: bool,
     input_output_aliases: tuple[tuple[int, int], ...],
     grid_mapping: GridMapping,
@@ -345,6 +344,7 @@ def pallas_call_hlo_interpret(
     out_avals: tuple[jax_core.AbstractValue, ...],
 ):
   del compiler_params, cost_estimate, out_avals
+  debug_info = jaxpr.debug_info
   # If we're in interpret mode, we *scan* over the grid and eval the
   # discharged jaxpr.
   dynamic_grid_args, args = split_list(
@@ -360,7 +360,7 @@ def pallas_call_hlo_interpret(
   discharged_jaxpr, discharged_consts, scratch_avals = kernel_to_hlo_jaxpr(
       jaxpr, (), grid_mapping, backend=backend)
   if debug:
-    print(f"\nJaxpr of the the kernel in pallas_call {name_and_src_info}:")
+    print(f"\nJaxpr of the the kernel in pallas_call {debug_info.func_src_info}:")
     print(discharged_jaxpr)
   out = _initialize_output_vals(grid_mapping.block_mappings_output,
                                 args, input_output_aliases)

--- a/jax/_src/pallas/mosaic/interpret.py
+++ b/jax/_src/pallas/mosaic/interpret.py
@@ -796,7 +796,6 @@ def get_interpret_effects():
 def interpret_pallas_call(
     *args,
     jaxpr: jax_core.Jaxpr,
-    name_and_src_info: pallas_core.NameAndSrcInfo,
     debug: bool,
     input_output_aliases: tuple[tuple[int, int], ...],
     grid_mapping: GridMapping,

--- a/jax/_src/pallas/mosaic/pallas_call_registration.py
+++ b/jax/_src/pallas/mosaic/pallas_call_registration.py
@@ -107,7 +107,6 @@ def pallas_call_tpu_lowering_rule(
     ctx: mlir.LoweringRuleContext,
     *in_nodes,
     jaxpr: jax_core.Jaxpr,
-    name_and_src_info: core.NameAndSrcInfo,
     grid_mapping: core.GridMapping,
     input_output_aliases: tuple[tuple[int, int], ...],
     debug: bool,
@@ -118,8 +117,9 @@ def pallas_call_tpu_lowering_rule(
 ):
   """Lowers a pallas_call to a Mosaic TPU custom call."""
   del interpret
+  debug_info = jaxpr._debug_info
   if debug:
-    print(f"\nThe kernel jaxpr for pallas_call {name_and_src_info}:")
+    print(f"\nThe kernel jaxpr for pallas_call {debug_info.func_src_info}:")
     print(jaxpr)
   if "mosaic" in compiler_params:
     mosaic_params = compiler_params["mosaic"]
@@ -149,13 +149,12 @@ def pallas_call_tpu_lowering_rule(
           dimension_semantics=dimension_semantics,
           mesh=mesh,
           for_verification=for_verification,
-          name_and_src_info=name_and_src_info,
           dynamic_shape_replacement_enabled=pallas_core.dynamic_shapes_export_enabled(),
       )
 
   mosaic_module, extra_args = lower_module(for_verification=False)
   if debug:
-    print(f"\nThe Mosaic module for pallas_call {name_and_src_info}:")
+    print(f"\nThe Mosaic module for pallas_call {debug_info.func_src_info}:")
     print(mosaic_module)
   num_extra_args = len(extra_args)
   num_dyn_bounds = grid_mapping.num_dynamic_grid_bounds
@@ -176,7 +175,7 @@ def pallas_call_tpu_lowering_rule(
         verification_module, num_devices, num_cores
     )
     if promela_dump_path == "stdout":
-      print(f"The Promela model for pallas_call {name_and_src_info}:")
+      print(f"The Promela model for pallas_call {debug_info.func_src_info}:")
       print(model)
     else:
       if promela_dump_path == "sponge":
@@ -188,7 +187,7 @@ def pallas_call_tpu_lowering_rule(
           )
       dump_ctx = tempfile.NamedTemporaryFile(
           mode="w",
-          prefix=name_and_src_info.name + "-",
+          prefix=mlir.sanitize_name(debug_info.func_name) + "-",
           suffix=".pml",
           dir=promela_dump_path, delete=False,
       )
@@ -230,7 +229,7 @@ def pallas_call_tpu_lowering_rule(
       module=mosaic_module,
       out_type=kernel_out_avals,
       backend="tpu",
-      kernel_name=name_and_src_info.name,
+      kernel_name=mlir.sanitize_name(debug_info.func_name),
       cost_estimate=mosaic_cost_estimate,
       vmem_limit_bytes=mosaic_params.get("vmem_limit_bytes"),
       flags=mosaic_params.get("flags"),

--- a/jax/_src/pallas/mosaic_gpu/pallas_call_registration.py
+++ b/jax/_src/pallas/mosaic_gpu/pallas_call_registration.py
@@ -34,7 +34,6 @@ def pallas_call_lowering(
     ctx: mlir.LoweringRuleContext,
     *args,
     jaxpr: jax_core.Jaxpr,
-    name_and_src_info: pallas_core.NameAndSrcInfo,
     interpret: bool,
     debug: bool,
     input_output_aliases: tuple[tuple[int, int], ...],
@@ -43,6 +42,7 @@ def pallas_call_lowering(
     cost_estimate: pallas_core.CostEstimate | None,
     out_avals: tuple[jax_core.AbstractValue, ...],
 ):
+  debug_info = jaxpr.debug_info
   del interpret, out_avals
   if grid_mapping.num_dynamic_grid_bounds:
     raise NotImplementedError(
@@ -50,9 +50,9 @@ def pallas_call_lowering(
     )
 
   if debug:
-    print(f"\nThe kernel jaxpr for pallas_call {name_and_src_info}:")
+    print(f"\nThe kernel jaxpr for pallas_call {debug_info.func_src_info}:")
     print(jaxpr)
-    print(f"The grid mapping for pallas_call {name_and_src_info}:")
+    print(f"The grid mapping for pallas_call {debug_info.func_src_info}:")
     print(grid_mapping)
 
   thread_semantics = compiler_params.get("mosaic_gpu", {}).get(
@@ -64,12 +64,11 @@ def pallas_call_lowering(
   lowering_result = lowering.lower_pipelined_jaxpr_to_module(
       grid_mapping,
       jaxpr,
-      name_and_src_info,
       compiler_params,
       cost_estimate,
   )
   if debug:
-    print(f"\nThe Mosaic GPU module for pallas_call {name_and_src_info}:")
+    print(f"\nThe Mosaic GPU module for pallas_call {debug_info.func_src_info}:")
     print(lowering_result.module.operation)
 
   module = lowering_result.module
@@ -88,7 +87,7 @@ def pallas_call_lowering(
     if (dump_path := prof_ctx.dump_path) == "sponge":
       dump_path = os.getenv("TEST_UNDECLARED_OUTPUTS_DIR")  # type: ignore
     out_file = os.path.join(
-        dump_path, f"{name_and_src_info.name}-{time.time_ns()}-trace.json"
+        dump_path, f"{mlir.sanitize_name(debug_info.func_name)}-{time.time_ns()}-trace.json"
     )
     def dump_profile(prof_buffer):
       try:
@@ -101,7 +100,7 @@ def pallas_call_lowering(
           )
       except FileExistsError:
         warnings.warn(
-            f"Failed to dump profile for pallas_call {name_and_src_info}, "
+            f"Failed to dump profile for pallas_call {debug_info.func_src_info}, "
             f"profile already exists at {out_file}"
         )
     def do_callback(prof_buffer):

--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -116,9 +116,8 @@ def _pallas_call_jvp_rule(
     tangents,
     *,
     jaxpr: jax_core.Jaxpr,
-    name_and_src_info,
     input_output_aliases: tuple[tuple[int, int], ...],
-    grid_mapping,
+    grid_mapping: GridMapping,
     debug: bool,
     interpret: bool,
     compiler_params: Any,
@@ -126,6 +125,7 @@ def _pallas_call_jvp_rule(
     out_avals: tuple[jax_core.AbstractValue, ...],
     backend: _Backend | None,
 ):
+  debug_info = jaxpr.debug_info
   if grid_mapping.num_dynamic_grid_bounds:
     raise NotImplementedError("interpret with dynamic grid bounds unsupported")
   if grid_mapping.num_index_operands:
@@ -158,7 +158,7 @@ def _pallas_call_jvp_rule(
     effs.append(eff)
   jvp_jaxpr = jvp_jaxpr.replace(invars=invars, effects=effs)
   if debug:
-    print(f"\nThe jaxpr for the jvp of pallas_call {name_and_src_info}:")
+    print(f"\nThe jaxpr for the jvp of pallas_call {debug_info.func_src_info}:")
     print(jvp_jaxpr)
   in_bms, out_bms = split_list(grid_mapping.block_mappings, [len(primals)])
   jvp_bms = (*in_bms, *in_bms, *out_bms, *out_bms)
@@ -179,9 +179,6 @@ def _pallas_call_jvp_rule(
       *primals,
       *tangents,
       jaxpr=jvp_jaxpr,
-      name_and_src_info=name_and_src_info.replace(
-          name=f"{name_and_src_info.name}_jvp"
-      ),
       grid_mapping=jvp_grid_mapping,
       interpret=interpret,
       debug=debug,
@@ -318,7 +315,6 @@ def _batch_with_explicit_loop(
     dims: Sequence[int | batching.NotMapped],
     *,
     jaxpr: jax_core.Jaxpr,
-    name_and_src_info: pallas_core.NameAndSrcInfo,
     grid_mapping: GridMapping,
     input_output_aliases: tuple[tuple[int, int], ...],
     debug: bool,
@@ -386,7 +382,6 @@ def _batch_with_explicit_loop(
     batch_out = pallas_call_p.bind(
         *batch_args,
         jaxpr=jaxpr,
-        name_and_src_info=name_and_src_info,
         grid_mapping=grid_mapping,
         input_output_aliases=input_output_aliases,
         debug=debug,
@@ -416,7 +411,6 @@ def _pallas_call_batching_rule(
     dims,
     *,
     jaxpr: jax_core.Jaxpr,
-    name_and_src_info: pallas_core.NameAndSrcInfo,
     grid_mapping: GridMapping,
     input_output_aliases: tuple[tuple[int, int], ...],
     debug: bool,
@@ -449,7 +443,6 @@ def _pallas_call_batching_rule(
     out = pallas_call_p.bind(
         *args,
         jaxpr=jaxpr,
-        name_and_src_info=name_and_src_info,
         grid_mapping=grid_mapping,
         input_output_aliases=input_output_aliases,
         debug=debug,
@@ -483,7 +476,6 @@ def _pallas_call_batching_rule(
         args=dynamic_grid_args + args,
         dims=dynamic_grid_dims + dims,
         jaxpr=jaxpr,
-        name_and_src_info=name_and_src_info,
         grid_mapping=grid_mapping,
         input_output_aliases=input_output_aliases,
         debug=debug,
@@ -518,7 +510,6 @@ def _pallas_call_batching_rule(
           args=scalar_args + args,
           dims=scalar_bdims + bdims,
           jaxpr=jaxpr,
-          name_and_src_info=name_and_src_info,
           grid_mapping=grid_mapping,
           input_output_aliases=input_output_aliases,
           debug=debug,
@@ -837,10 +828,9 @@ def _pallas_call_batching_rule(
             batched_block_mapping.index_map_jaxpr.consts,
             *nargs,
         )
-
       index_jaxpr, _ = _trace_kernel_to_jaxpr(
           index_rewrite_kernel,
-          "index_rewrite_kernel",
+          batched_block_mapping.index_map_jaxpr.jaxpr.debug_info,
           batched_grid_mapping,
           tuple(flat_indexer_avals),
           indexer_in_tree,
@@ -864,11 +854,9 @@ def _pallas_call_batching_rule(
           block_mappings=tuple(batched_block_mappings),
       )
 
-      kernel_src_info: pallas_core.SrcInfoStr = "<Wrapped outer kernel>"
-
       jaxpr, consts = _trace_kernel_to_jaxpr(
           when_wrapped_kernel,
-          kernel_src_info,
+          jaxpr.debug_info,
           batched_grid_mapping,
           tuple(flat_kernel_avals),
           kernel_in_tree,
@@ -900,9 +888,6 @@ def _pallas_call_batching_rule(
       *dynamic_grid_args,
       *args,
       jaxpr=jaxpr,
-      name_and_src_info=name_and_src_info.replace(
-          name=f"{name_and_src_info.name}_batched"
-      ),
       grid_mapping=batched_grid_mapping,
       input_output_aliases=input_output_aliases,
       debug=debug,
@@ -1173,17 +1158,15 @@ checkify.error_checks[pallas_call_p] = pallas_call_checkify_rule
 @weakref_lru_cache
 def _trace_kernel_to_jaxpr(
     fun: Callable,
-    name_and_src_info: pallas_core.NameAndSrcInfo,
+    debug_info: jax_core.DebugInfo,
     grid_mapping: GridMapping,
     kernel_avals: tuple[pallas_core.AbstractMemRef, ...],
     kernel_in_tree: tree_util.PyTreeDef,
     kernel_in_transforms: tuple[tuple[pallas_core.Transform, ...], ...],
     indexer: bool = False,
 ) -> tuple[jax_core.ClosedJaxpr, tuple[jax.Array, ...]]:
-  fake_kernel_args = kernel_in_tree.unflatten(kernel_avals)
-  debug = api_util.debug_info("pallas_call", fun, fake_kernel_args, {})
   wrapped_kernel_fun, out_tree_thunk = api_util.flatten_fun_nokwargs(
-      lu.wrap_init(fun, debug_info=debug), kernel_in_tree)
+      lu.wrap_init(fun, debug_info=debug_info), kernel_in_tree)
   wrapped_kernel_fun = primitives.wrap_with_transforms(
       wrapped_kernel_fun, kernel_in_transforms
   )
@@ -1194,14 +1177,14 @@ def _trace_kernel_to_jaxpr(
       consts_avals = [jax_core.get_aval(c) for c in consts]
       if any(not isinstance(aval, state.AbstractRef) for aval in consts_avals):
         raise ValueError(
-            f"The kernel function in the pallas_call {name_and_src_info} "
+            f"The kernel function in the pallas_call {debug_info.func_src_info} "
             f"captures constants {consts_avals}. "
             "You should pass them as inputs")
 
   kernel_out_tree = out_tree_thunk()
   if not indexer and kernel_out_tree != tree_util.tree_structure(None):
     raise ValueError(
-        f"The kernel function in the pallas_call {name_and_src_info} "
+        f"The kernel function in the pallas_call {debug_info.func_src_info} "
         f"should return None. It returns a PyTree: {kernel_out_tree}")
   return jaxpr, tuple(consts)
 
@@ -1352,7 +1335,6 @@ def _pallas_call_state_discharge_rule(
     *args,
     jaxpr: jax_core.Jaxpr,
     input_output_aliases: tuple[tuple[int, int], ...],
-    name_and_src_info: pallas_core.NameAndSrcInfo,
     grid_mapping: GridMapping,
     debug: bool,
     interpret: bool,
@@ -1455,7 +1437,6 @@ def _pallas_call_state_discharge_rule(
       jaxpr=new_jaxpr,
       input_output_aliases=new_input_output_aliases,
       grid_mapping=new_grid_mapping,
-      name_and_src_info=name_and_src_info,
       debug=debug,
       interpret=interpret,
       compiler_params=compiler_params,
@@ -1542,9 +1523,6 @@ def pallas_call(
     invoke the Pallas kernel.
 
   """
-  kernel_src_info = api_util.fun_sourceinfo(kernel)
-  name_and_src_info = pallas_core.NameAndSrcInfo.from_pallas_call(
-      name, kernel_src_info)
   if compiler_params is None:
     compiler_params = {}
   if isinstance(compiler_params, pallas_core.CompilerParams):
@@ -1593,17 +1571,7 @@ def pallas_call(
     flat_out_avals = tuple(_convert_out_shape_to_aval(v)
                            for v in flat_out_shapes)
 
-    kernel_fun_sig = api_util.fun_signature(kernel)
-    arg_names = None
-    if kernel_fun_sig:
-      kernel_debug_info = api_util.debug_info(
-          "pallas_call kernel",
-           kernel,
-           [1] * len(kernel_fun_sig.parameters), {})
-      arg_names = kernel_debug_info.arg_names
-      del kernel_debug_info
-    in_origins = tuple(in_path_to_input_origin(p, arg_names)
-                       for p in in_paths)
+    in_origins = tuple(f"args{tree_util.keystr(p)}" for p in in_paths)
     out_origins = tuple(f"outputs{tree_util.keystr(p)}" for p in out_paths)
     # TODO(necula): check that input_output_aliases is well-formed: no duplicates, etc.
     kernel_args, grid_mapping = pallas_core.get_grid_mapping(
@@ -1616,13 +1584,17 @@ def pallas_call(
         for x in flat_kernel_args
     )
     # Note that only a subset of all transforms can be found here, and they are
-    # never expected to contains any arrays.
+    # never expected to contain any arrays.
     kernel_arg_transforms = tuple(
         x.transforms if isinstance(x, state_types.TransformedRef) else ()
         for x in flat_kernel_args
     )
+    kernel_dbg = api_util.debug_info("pallas_call kernel", kernel,
+                                      kernel_args, {})
+    if name is not None:
+      kernel_dbg = kernel_dbg.replace_func_name(mlir.sanitize_name(name))
     jaxpr, consts = _trace_kernel_to_jaxpr(
-        kernel, kernel_src_info, grid_mapping, tuple(flat_kernel_avals),
+        kernel, kernel_dbg, grid_mapping, tuple(flat_kernel_avals),
         kernel_in_tree, kernel_arg_transforms)
     for i_idx, o_idx in input_output_aliases.items():
       if i_idx not in range(len(flat_in_avals)):
@@ -1665,7 +1637,6 @@ def pallas_call(
         *rest_args,
         out_avals=flat_out_avals,
         jaxpr=jaxpr,
-        name_and_src_info=name_and_src_info,
         debug=debug,
         interpret=interpret,
         grid_mapping=grid_mapping,

--- a/jax/_src/pallas/triton/pallas_call_registration.py
+++ b/jax/_src/pallas/triton/pallas_call_registration.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import io
-import re
 from typing import Any
 import zlib
 
@@ -48,7 +47,6 @@ def pallas_call_lowering(
     ctx: mlir.LoweringRuleContext,
     *in_nodes,
     jaxpr: jax_core.Jaxpr,
-    name_and_src_info: pallas_core.NameAndSrcInfo,
     interpret: bool,
     debug: bool,
     input_output_aliases: tuple[tuple[int, int], ...],
@@ -57,7 +55,8 @@ def pallas_call_lowering(
     cost_estimate: pallas_core.CostEstimate | None,
     out_avals: tuple[jax_core.AbstractValue, ...],
 ):
-  del interpret, cost_estimate, out_avals
+  del interpret, out_avals, cost_estimate
+  debug_info = jaxpr.debug_info
   if grid_mapping.num_dynamic_grid_bounds:
     raise NotImplementedError(
         "dynamic grid bounds not supported in the Triton backend"
@@ -78,22 +77,20 @@ def pallas_call_lowering(
     num_stages = 3 if num_stages is None else num_stages
 
   if debug:
-    print(f"\nThe kernel jaxpr for pallas_call {name_and_src_info}:")
+    print(f"\nThe kernel jaxpr for pallas_call {debug_info.func_src_info}:")
     print(jaxpr)
-    print("The grid mapping for pallas_call {name_and_src_info}:")
+    print(f"The grid mapping for pallas_call {debug_info.func_src_info}:")
     print(grid_mapping)
 
   # Sanitize the name to conform to NVPTX requirements. We do this here
   # to avoid the need to fetch the new name from PTX post compilation.
-  name_and_src_info = name_and_src_info.replace(
-      name=re.sub(r"[^a-zA-Z0-9_$]", "_", name_and_src_info.name)
-  )
+  name = mlir.sanitize_name(debug_info.func_name)
   lowering_result = lowering.lower_jaxpr_to_triton_module(
-      jaxpr, grid_mapping, name_and_src_info, lowering_platform
+      jaxpr, grid_mapping, lowering_platform
   )
   module_op = lowering_result.module.operation
   if debug:
-    print(f"\nThe Triton module for pallas_call {name_and_src_info}:")
+    print(f"\nThe Triton module for pallas_call {debug_info.func_src_info}:")
     print(module_op.get_asm(enable_debug_info=True, pretty_debug_info=True))
 
   grid_x, grid_y, grid_z = normalize_grid(lowering_result.grid)
@@ -109,7 +106,7 @@ def pallas_call_lowering(
       for bm in grid_mapping.block_mappings_output
     ]
     backend_config = dict(
-        name=ir.StringAttr.get(name_and_src_info.name),
+        name=ir.StringAttr.get(name),
         ir=ir.StringAttr.get(buf.getvalue()),
         num_stages=mlir.i32_attr(num_stages),
         num_warps=mlir.i32_attr(num_warps),
@@ -156,7 +153,7 @@ def pallas_call_lowering(
       num_stages=num_stages,
   )
   kernel = triton_kernel_call_lib.TritonKernel(
-      name_and_src_info.name,
+      debug_info.func_name,
       num_warps,
       compilation_result.smem_bytes,
       compilation_result.asm,
@@ -181,7 +178,7 @@ def pallas_call_lowering(
       operands=in_nodes,
        backend_config=zlib.compress(
           kernel_call.to_proto(
-              name_and_src_info.name,
+              debug_info.func_name,
               triton_params.get("serialized_metadata") or b"",
           )
       ),


### PR DESCRIPTION
Now that we carry debug informatiion in Jaxpr we can remove the Pallas-specific tracking of debugging info. We remove `NameAndSrcInfo` and its usage.
