### PR TITLE
Add jax.test_util to public API docs

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -25,6 +25,7 @@ Subpackages
    jax.ops
    jax.profiler
    jax.stages
+   jax.test_util
    jax.tree
    jax.tree_util
    jax.typing

--- a/docs/jax.test_util.rst
+++ b/docs/jax.test_util.rst
@@ -1,5 +1,5 @@
 ``jax.test_util`` module
-===================
+========================
 
 .. currentmodule:: jax.test_util
 

--- a/docs/jax.test_util.rst
+++ b/docs/jax.test_util.rst
@@ -1,0 +1,16 @@
+``jax.test_util`` module
+===================
+
+.. currentmodule:: jax.test_util
+
+.. automodule:: jax.test_util
+
+List of Functions
+-----------------
+
+.. autosummary::
+   :toctree: _autosummary
+
+   check_grads
+   check_jvp
+   check_vjp

--- a/jax/_src/public_test_util.py
+++ b/jax/_src/public_test_util.py
@@ -247,6 +247,25 @@ def _merge_tolerance(tol, default):
 
 
 def check_jvp(f, f_jvp, args, atol=None, rtol=None, eps=EPS, err_msg=''):
+  """Check a JVP from automatic differentiation against finite differences.
+
+  Gradients are only checked in a single randomly chosen direction, which
+  ensures that the finite difference calculation does not become prohibitively
+  expensive even for large input/output spaces.
+
+  Args:
+    f: function to check at ``f(*args)``.
+    f_vjp: function that calculates ``jax.jvp`` applied to ``f``. Typically this
+      should be ``functools.partial(jax.jvp, f))``.
+    args: tuple of argument values.
+    atol: absolute tolerance for gradient equality.
+    rtol: relative tolerance for gradient equality.
+    eps: step size used for finite differences.
+    err_msg: additional error message to include if checks fail.
+
+  Raises:
+    AssertionError: if gradients do not match.
+  """
   atol = _merge_tolerance(atol, default_gradient_tolerance)
   rtol = _merge_tolerance(rtol, default_gradient_tolerance)
   rng = np.random.RandomState(0)
@@ -266,6 +285,25 @@ def check_jvp(f, f_jvp, args, atol=None, rtol=None, eps=EPS, err_msg=''):
 
 
 def check_vjp(f, f_vjp, args, atol=None, rtol=None, eps=EPS, err_msg=''):
+  """Check a VJP from automatic differentiation against finite differences.
+
+  Gradients are only checked in a single randomly chosen direction, which
+  ensures that the finite difference calculation does not become prohibitively
+  expensive even for large input/output spaces.
+
+  Args:
+    f: function to check at ``f(*args)``.
+    f_vjp: function that calculates ``jax.vjp`` applied to ``f``. Typically this
+      should be ``functools.partial(jax.jvp, f))``.
+    args: tuple of argument values.
+    atol: absolute tolerance for gradient equality.
+    rtol: relative tolerance for gradient equality.
+    eps: step size used for finite differences.
+    err_msg: additional error message to include if checks fail.
+
+  Raises:
+    AssertionError: if gradients do not match.
+  """
   atol = _merge_tolerance(atol, default_gradient_tolerance)
   rtol = _merge_tolerance(rtol, default_gradient_tolerance)
   _rand_like = partial(rand_like, np.random.RandomState(0))


### PR DESCRIPTION
These are documented as public APIs in the [API compatibility](https://jax.readthedocs.io/en/latest/api_compatibility.html) page, but not in the API docs.