### PR TITLE
Update JVP rule for abs to fix behavior for complex infinite inputs

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2769,14 +2769,13 @@ ad.primitive_transposes[conj_p] = _conj_transpose_rule
 abs_p = unop(_complex_basetype, _signedint | _float | _complex, 'abs')
 mlir.register_lowering(abs_p, partial(_nary_lower_hlo, hlo.abs))
 
-def _abs_jvp_rule(g, ans, x):
+def _abs_jvp_rule(g, x):
   if _iscomplex(x):
-    return _maybe_real(mul(g, div(_maybe_conj(x),
-           _replace_zero(convert_element_type(ans, _dtype(x))))))
+    a = atan2(imag(x), real(x))
+    return _maybe_real(mul(g, complex(cos(a), neg(sin(a)))))
   else:
     return select(ge(x, _zero(x)), g, neg(g))
-ad.defjvp2(abs_p, _abs_jvp_rule)
-_maybe_conj = lambda x: conj(x) if _iscomplex(x) else x
+ad.defjvp(abs_p, _abs_jvp_rule)
 _maybe_real = lambda x: real(x) if _iscomplex(x) else x
 
 sqrt_p = standard_unop(_float | _complex, 'sqrt')

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6285,6 +6285,30 @@ class NumpyGradTests(jtu.JaxTestCase):
     x = rng((), dtype)
     check_grads(lambda x: jnp.ldexp(x, n), (x,), 1)
 
+  @parameterized.parameters(
+      [
+          (*parts, dtype)
+          for parts in [
+              ((0.0, 0.0), (1.0, 0.0)),
+              ((np.inf, 0.0), (1.0, 0.0)),
+              ((-np.inf, 0.0), (-1.0, 0.0)),
+              ((0.0, np.inf), (0.0, -1.0)),
+              ((0.0, -np.inf), (0.0, 1.0)),
+              ((np.inf, np.inf), (0.5 * np.sqrt(2), -0.5 * np.sqrt(2))),
+              ((np.inf, -np.inf), (0.5 * np.sqrt(2), 0.5 * np.sqrt(2))),
+              ((-np.inf, np.inf), (-0.5 * np.sqrt(2), -0.5 * np.sqrt(2))),
+              ((-np.inf, -np.inf), (-0.5 * np.sqrt(2), 0.5 * np.sqrt(2))),
+          ]
+          for dtype in complex_dtypes
+      ]
+  )
+  def testComplexAbsGradInf(self, input_parts, grad_parts, dtype):
+    # https://github.com/jax-ml/jax/issues/25681
+    x = jax.lax.complex(*input_parts).astype(dtype)
+    expected = jax.lax.complex(*grad_parts).astype(dtype)
+    g = jax.grad(jnp.abs)(x)
+    self.assertAllClose(g, expected)
+
 
 class NumpySignaturesTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
As discussed in https://github.com/jax-ml/jax/issues/25681, the gradients of `abs` don't have the correct behavior at complex infinities. As discussed in that issue, and combined with the notation from [here](https://jax.readthedocs.io/en/latest/advanced-autodiff.html#complex-numbers-and-differentiation), the JVP rule can be re-written as:

```
f(z) = abs(z) = abs(x + j y)
t = atan2(y, x)
df * (dx + j dx) = Re[(cos(t) - j sin(t)) * (dx + j dx)]
```

(Note that this isn't quite the same result as what @pearu reports in https://github.com/jax-ml/jax/issues/25681, but it's what I found when working it through myself, and it has the correct behavior.)

This is straightforward to implement, and at the cost of a performance hit (3 new trig functions), we get stable JVPs throughout the complex plane. I don't expect this is a performance critical computation in many applications, so I think it's probably worth updating the implementation here, but I'd love to hear otherwise if people disagree!

I should note that this also changes the gradient at complex zero (as discussed in https://github.com/jax-ml/jax/issues/10515#issuecomment-1135105817) to give `grad(abs)(0+0j) = 1+0j`. I think this is sensible behavior, but there's some chance that this breaks some downstream behavior. (@mattjj may want to comment, having thought about this before!)