### PR TITLE
[better_errors] Refactor more uses of pe.tracing_debug_info (part 1)

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -84,7 +84,8 @@ def apply_flat_fun(fun, io_tree, *py_args):
   return tree_unflatten(out_tree, ans)
 
 @lu.transformation_with_aux2
-def flatten_fun_nokwargs(f, store, in_tree, *args_flat):
+def flatten_fun_nokwargs(f: Callable, store: lu.Store,
+                         in_tree: PyTreeDef, *args_flat):
   py_args = tree_unflatten(in_tree, args_flat)
   ans = f(*py_args)
   ans, out_tree = tree_flatten(ans)

--- a/jax/_src/custom_batching.py
+++ b/jax/_src/custom_batching.py
@@ -28,7 +28,7 @@ from jax._src import source_info_util
 from jax._src import traceback_util
 from jax._src import tree_util
 from jax._src import util
-from jax._src.api_util import flatten_fun_nokwargs, resolve_kwargs
+from jax._src import api_util
 from jax._src.interpreters import ad
 from jax._src.interpreters import batching
 from jax._src.interpreters.batching import not_mapped
@@ -141,16 +141,18 @@ class custom_vmap:
 
   @traceback_util.api_boundary
   def __call__(self, *args, **kwargs):
-    args = resolve_kwargs(self.fun, args, kwargs)
+    args = api_util.resolve_kwargs(self.fun, args, kwargs)
     fun_name = getattr(self.fun, "__name__", str(self.fun))
     if not self.vmap_rule:
       raise AttributeError(
           f"No batching rule defined for custom_vmap function {fun_name} "
           "using def_vmap.")
+    debug = api_util.tracing_debug_info("custom_vmap", self.fun, args, {})
     args_flat, in_tree = tree_flatten(args)
-    flat_fun, out_tree = flatten_fun_nokwargs(lu.wrap_init(self.fun), in_tree)
+    flat_fun, out_tree = api_util.flatten_fun_nokwargs(
+        lu.wrap_init(self.fun, debug_info=debug),
+        in_tree)
     in_avals = [core.get_aval(x) for x in args_flat]
-    debug = pe.tracing_debug_info(self.fun, in_tree, out_tree, False, "custom_vmap")
     jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(flat_fun, in_avals, debug)
     closed_call = core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
     in_tree = treedef_tuple((tree_structure(consts), in_tree))
@@ -282,7 +284,7 @@ def custom_vmap_jvp(primals, tangents, *, call, rule, in_tree, out_tree):
     def to_vmap_over_extra_batched_dims(primals, tangents):
       return api.jvp(to_jvp, primals, tangents)
 
-    to_vmap_over_extra_batched_dims_flat, out_tree2 = flatten_fun_nokwargs(
+    to_vmap_over_extra_batched_dims_flat, out_tree2 = api_util.flatten_fun_nokwargs(
         lu.wrap_init(to_vmap_over_extra_batched_dims),
         tree_ps_ts)
 

--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -20,6 +20,7 @@ import os
 from functools import partial
 from typing import Any
 
+from jax._src import api_util
 from jax._src import core
 from jax._src import linear_util as lu
 from jax._src.lax import lax
@@ -28,9 +29,8 @@ from jax._src import ad_util
 from jax._src import state
 from jax._src import util
 from jax._src.util import weakref_lru_cache, safe_map, partition_list
-from jax.api_util import flatten_fun_nokwargs
 from jax._src.interpreters import partial_eval as pe
-from jax.tree_util import tree_map, tree_unflatten, keystr
+from jax.tree_util import tree_map, tree_unflatten, keystr, PyTreeDef
 from jax._src.tree_util import equality_errors_pytreedef
 
 map, unsafe_map = safe_map, map
@@ -50,41 +50,48 @@ def _typecheck_param(prim, param, name, msg_required, pred):
     raise core.JaxprTypeError(msg)
 
 @weakref_lru_cache
-def _initial_style_open_jaxpr(fun: Callable, in_tree, in_avals,
-                              primitive_name: str | None = None):
-  wrapped_fun, out_tree = flatten_fun_nokwargs(lu.wrap_init(fun), in_tree)
-  debug = pe.tracing_debug_info(fun, in_tree, out_tree, False,
-                                primitive_name or "<unknown>")
+def _initial_style_open_jaxpr(fun: Callable,
+                              in_tree: PyTreeDef,
+                              in_avals: Sequence[core.AbstractValue],
+                              debug_info: api_util.TracingDebugInfo):
+  wrapped_fun, out_tree = api_util.flatten_fun_nokwargs(
+      lu.wrap_init(fun, debug_info=debug_info),
+      in_tree)
   jaxpr, _, consts, attrs_tracked = pe.trace_to_jaxpr_dynamic(
-      wrapped_fun, in_avals, debug)
+      wrapped_fun, in_avals, debug_info)
   return jaxpr, consts, out_tree(), attrs_tracked
 
 @weakref_lru_cache
-def _initial_style_jaxpr(fun: Callable, in_tree, in_avals,
-                         primitive_name: str | None = None):
+def _initial_style_jaxpr(fun: Callable,
+                         in_tree: PyTreeDef,
+                         in_avals: Sequence[core.AbstractValue],
+                         debug_info: api_util.TracingDebugInfo):
   jaxpr, consts, out_tree, () = _initial_style_open_jaxpr(
-      fun, in_tree, in_avals, primitive_name)
+      fun, in_tree, in_avals, debug_info)
   closed_jaxpr = pe.close_jaxpr(pe.convert_constvars_jaxpr(jaxpr))
   return closed_jaxpr, consts, out_tree
 
-def _initial_style_jaxpr_attrs(fun: Callable, in_tree, in_avals,
-                               primitive_name: str | None = None):
+def _initial_style_jaxpr_attrs(fun: Callable,
+                               in_tree: PyTreeDef,
+                               in_avals: Sequence[core.AbstractValue],
+                               debug_info: api_util.TracingDebugInfo):
   jaxpr, consts, out_tree, attrs_tracked = _initial_style_open_jaxpr(
-      fun, in_tree, in_avals, primitive_name)
+      fun, in_tree, in_avals, debug_info)
   closed_jaxpr = pe.close_jaxpr(pe.convert_constvars_jaxpr(jaxpr))
   return closed_jaxpr, consts, out_tree, attrs_tracked
 
 def _initial_style_jaxprs_with_common_consts(
-    funs: Sequence[Callable], in_tree, in_avals, primitive_name: str):
+    funs: Sequence[Callable],
+    in_tree: PyTreeDef, in_avals: Sequence[core.AbstractValue],
+    debug_infos: Sequence[api_util.TracingDebugInfo]):
   # When staging the branches of a conditional into jaxprs, constants are
   # extracted from each branch and converted to jaxpr arguments. To use the
   # staged jaxprs as the branches to a conditional *primitive*, we need for
   # their (input) signatures to match. This function "joins" the staged jaxprs:
   # for each one, it makes another that accepts *all* constants, but only uses
   # those that it needs (dropping the rest).
-
-  jaxpr_data = [_initial_style_open_jaxpr(fn, in_tree, in_avals, primitive_name)
-                for fn in funs]
+  jaxpr_data = [_initial_style_open_jaxpr(fn, in_tree, in_avals, debug_info)
+                for fn, debug_info in zip(funs, debug_infos)]
   if not jaxpr_data:
     return [], [], []
 

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -25,8 +25,7 @@ from typing import Any, TypeVar
 
 from jax.tree_util import tree_flatten, tree_unflatten
 from jax._src import ad_util
-from jax._src.api_util import (
-    _check_no_aliased_ref_args, _check_no_aliased_closed_over_refs)
+from jax._src import api_util
 from jax._src import config
 from jax._src import core
 from jax._src import dispatch
@@ -135,17 +134,18 @@ def switch(index, branches: Sequence[Callable], *operands,
   if (config.disable_jit.value and core.is_concrete(index)):
     return branches[int(index)](*operands)
 
+  dbgs = [api_util.tracing_debug_info("switch", branch, operands, {})
+          for branch in branches]
   ops, ops_tree = tree_flatten(operands)
   ops_avals = tuple(map(core.get_aval, ops))
 
   if config.mutable_array_checks.value:
-    dbg = pe.tracing_debug_info(branches[0], ops_tree, None, False, 'switch')  # type: ignore
-    _check_no_aliased_ref_args(dbg, ops_avals, ops)
+    api_util._check_no_aliased_ref_args(dbgs[0], ops_avals, ops)
 
   jaxprs, consts, out_trees = _initial_style_jaxprs_with_common_consts(
-      branches, ops_tree, ops_avals, primitive_name='switch')
+      branches, ops_tree, ops_avals, dbgs)
   if config.mutable_array_checks.value:
-    _check_no_aliased_closed_over_refs(dbg, (*jaxprs[0].consts, *consts), ops)
+    api_util._check_no_aliased_closed_over_refs(dbgs[0], (*jaxprs[0].consts, *consts), ops)
   for i, (out_tree, jaxpr) in enumerate(zip(out_trees[1:], jaxprs[1:])):
     _check_tree_and_avals("branch 0 output",
                           out_trees[0], jaxprs[0].out_avals,
@@ -237,14 +237,16 @@ def _cond(pred, true_fun: Callable, false_fun: Callable, *operands,
   ops, ops_tree = tree_flatten(operands)
   ops_avals = tuple(map(core.get_aval, ops))
 
+  dbg_true_fun = api_util.tracing_debug_info("cond", true_fun, operands, {})
   if config.mutable_array_checks.value:
-    dbg = pe.tracing_debug_info(true_fun, ops_tree, None, False, 'cond')  # type: ignore
-    _check_no_aliased_ref_args(dbg, ops_avals, ops)
+    api_util._check_no_aliased_ref_args(dbg_true_fun, ops_avals, ops)
+  dbg_false_fun = api_util.tracing_debug_info("cond", false_fun, operands, {})
   jaxprs, consts, out_trees = _initial_style_jaxprs_with_common_consts(
-      (true_fun, false_fun), ops_tree, ops_avals, 'cond')
+      (true_fun, false_fun), ops_tree, ops_avals,
+      [dbg_true_fun, dbg_false_fun])
   true_jaxpr, false_jaxpr = jaxprs
   if config.mutable_array_checks.value:
-    _check_no_aliased_closed_over_refs(dbg, (*true_jaxpr.consts, *consts), ops)
+    api_util._check_no_aliased_closed_over_refs(dbg_true_fun, (*true_jaxpr.consts, *consts), ops)
 
   out_tree, false_out_tree = out_trees
   if any(isinstance(out_aval, AbstractRef) for out_aval in

--- a/jax/_src/lax/control_flow/for_loop.py
+++ b/jax/_src/lax/control_flow/for_loop.py
@@ -21,7 +21,7 @@ import operator
 from typing import Any, Generic, TypeVar
 
 from jax import lax
-from jax.api_util import flatten_fun_nokwargs
+from jax._src import api_util
 from jax._src.interpreters import ad
 from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
@@ -73,7 +73,7 @@ for_p.multiple_results = True
 def _trace_to_jaxpr_with_refs(f, state_tree: PyTreeDef,
                               state_avals: Sequence[core.AbstractValue]
                               ) -> tuple[core.Jaxpr, list[Any], PyTreeDef]:
-  f, out_tree_thunk = flatten_fun_nokwargs(
+  f, out_tree_thunk = api_util.flatten_fun_nokwargs(
       lu.wrap_init(f), treedef_tuple((tree_structure(0), state_tree)))
   jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(
       f, state_avals)
@@ -195,10 +195,10 @@ def scan(f: Callable[[Carry, X], tuple[Carry, Y]],
   def _create_jaxpr(init):
     init_flat = tree_leaves(init)
     _, in_tree = tree_flatten((init, xs))
-
+    dbg = api_util.tracing_debug_info("scan", f, (init, xs), {})
     carry_avals = tuple(map(core.get_aval, init_flat))
     jaxpr, _, out_tree = _initial_style_jaxpr(
-        f, in_tree, carry_avals + x_avals, "scan")
+        f, in_tree, carry_avals + x_avals, dbg)
     return jaxpr, out_tree
   jaxpr, out_tree = _create_jaxpr(init)
   _, ys_avals = tree_unflatten(out_tree, jaxpr.out_avals)

--- a/jax/_src/lax/control_flow/solves.py
+++ b/jax/_src/lax/control_flow/solves.py
@@ -15,11 +15,13 @@
 import collections
 from functools import partial
 import operator
+from typing import Any, Callable
 
 from jax.tree_util import (tree_flatten, treedef_children, tree_leaves,
                            tree_unflatten, treedef_tuple)
 from jax._src import ad_util
 from jax._src import api
+from jax._src import api_util
 from jax._src import core
 from jax._src import custom_derivatives
 from jax._src import linear_util as lu
@@ -47,7 +49,11 @@ def _split_root_args(args, const_lengths):
 
 
 @api_boundary
-def custom_root(f, initial_guess, solve, tangent_solve, has_aux=False):
+def custom_root(f: Callable,
+                initial_guess: Any,
+                solve: Callable[[Callable, Any], Any],
+                tangent_solve: Callable[[Callable, Any], Any],
+                has_aux=False):
   """Differentiably solve for the roots of a function.
 
   This is a low-level routine, mostly intended for internal use in JAX.
@@ -87,22 +93,31 @@ def custom_root(f, initial_guess, solve, tangent_solve, has_aux=False):
   """
   guess_flat, in_args_tree = tree_flatten((initial_guess,))
   guess_avals = tuple(_map(core.get_aval, guess_flat))
+  f_debug = api_util.tracing_debug_info("custom_root", f, (initial_guess,), {})
   f_jaxpr, f_consts, out_tree = _initial_style_jaxpr(
-      f, in_args_tree, guess_avals)
+      f, in_args_tree, guess_avals, f_debug)
 
   in_tree, = treedef_children(in_args_tree)
   _check_tree("f", "initial_guess", out_tree, in_tree, False)
 
+  solve_debug = api_util.tracing_debug_info("custom_root solve", solve,
+                                            (f, initial_guess), {},
+                                            static_argnums=(0,))
   solve_jaxpr, solve_consts, solution_tree = _initial_style_jaxpr(
-      partial(solve, f), in_args_tree, guess_avals)
+      partial(solve, f), in_args_tree, guess_avals, solve_debug)
   _check_tree("solve", "initial_guess", solution_tree, in_tree, has_aux)
 
   def linearize_and_solve(x, b):
     unchecked_zeros, f_jvp = api.linearize(f, x)
     return tangent_solve(f_jvp, b)
 
+  tangent_solve_debug = api_util.tracing_debug_info("custom_root tangent_solve",
+                                                    tangent_solve,
+                                                    (f, initial_guess), {},
+                                                    static_argnums=(0,))
   l_and_s_jaxpr, l_and_s_consts, out_tree = _initial_style_jaxpr(
-      linearize_and_solve, treedef_tuple((in_tree,) * 2), guess_avals * 2)
+      linearize_and_solve, treedef_tuple((in_tree,) * 2), guess_avals * 2,
+      tangent_solve_debug)
   _check_tree("tangent_solve", "x", out_tree, in_tree, False)
 
   all_consts = [f_consts, solve_consts, l_and_s_consts]
@@ -190,7 +205,11 @@ def _check_shapes(func_name, expected_name, actual, expected):
 
 @api_boundary
 def custom_linear_solve(
-    matvec, b, solve, transpose_solve=None, symmetric=False, has_aux=False):
+    matvec: Callable,
+    b: Any,
+    solve: Callable[[Callable, Any], Any],
+    transpose_solve: Callable[[Callable, Any], Any] | None = None,
+    symmetric=False, has_aux=False):
   """Perform a matrix-free linear solve with implicitly defined gradients.
 
   This function allows for overriding or defining gradients for a linear
@@ -246,21 +265,29 @@ def custom_linear_solve(
 
     return f_aux if has_aux else f
 
+  matvec_debug = api_util.tracing_debug_info("custom_linear_solve",
+                                             matvec, (b,), {})
   # no auxiliary data assumed for matvec
   matvec_jaxpr, matvec_consts, out_tree = _initial_style_jaxpr(
       _shape_checked(matvec, "matvec", False), in_args_tree, b_avals,
-      'custom_linear_solve')
+      matvec_debug)
   _check_tree("matvec", "b", out_tree, tree, False)
 
+  solve_debug = api_util.tracing_debug_info("custom_linear_solve solve",
+                                            solve, (matvec, b), {},
+                                            static_argnums=(0,))
   solve_jaxpr, solve_consts, out_tree = _initial_style_jaxpr(
       _shape_checked(partial(solve, matvec), "solve", has_aux), in_args_tree, b_avals,
-      'custom_linear_solve')
+      solve_debug)
   _check_tree("solve", "b", out_tree, tree, has_aux)
 
   if transpose_solve is None:
     vecmat_jaxpr = tr_solve_jaxpr = None
     vecmat_consts = tr_solve_consts = []
   else:
+    transpose_solve_debug = api_util.tracing_debug_info(
+        "custom_linear_solve transpose_solve", transpose_solve,
+        (matvec, b), {}, static_argnums=(0,))
     if symmetric:
       vecmat = matvec
       vecmat_jaxpr = matvec_jaxpr
@@ -268,12 +295,12 @@ def custom_linear_solve(
     else:
       vecmat = _transpose_one_output(matvec, b)
       vecmat_jaxpr, vecmat_consts, out_tree = _initial_style_jaxpr(
-          vecmat, in_args_tree, b_avals, 'custom_linear_solve')
+          vecmat, in_args_tree, b_avals, transpose_solve_debug)
       assert out_tree == tree
 
     tr_solve_jaxpr, tr_solve_consts, out_tree = _initial_style_jaxpr(
         _shape_checked(partial(transpose_solve, vecmat), "transpose_solve", has_aux),
-        in_args_tree, b_avals, 'custom_linear_solve')
+        in_args_tree, b_avals, transpose_solve_debug)
     _check_tree("transpose_solve", "b", out_tree, tree, has_aux)
 
   all_consts = [matvec_consts, vecmat_consts, solve_consts, tr_solve_consts]


### PR DESCRIPTION
We replace uses of `pe.tracing_debug_info` with with `api_util.tracing_debug_info`,
which uses the actual args and kwargs, instead of `in_tree` to manufacture fake
args and kwargs. This ends up being more accurate, especially for `arg_names`;
see changes in debug_info_tests.py.
This means that we have to construct the debug info further upstream, before
flattening args. This will later help populate debug info in `WrappedFun` and
`Jaxpr`.

This is part 1 of a series, for: cond, switch, while, scan, composite,
custom_dce, custom_root, custom_linear_solve, saved_residuals.