### PR TITLE
tpu_pallas_distributed_test: skip unless on TPU

### DIFF
--- a/tests/pallas/tpu_pallas_distributed_test.py
+++ b/tests/pallas/tpu_pallas_distributed_test.py
@@ -255,6 +255,11 @@ class PallasCallRemoteDMATest(parameterized.TestCase):
 
 class PallasCallRemoteDMAInterpretTest(parameterized.TestCase):
 
+  def setUp(self):
+    super().setUp()
+    if not jtu.is_device_tpu():
+      self.skipTest('Test requires TPU')
+
   @parameterized.parameters(('left',), ('right',))
   def test_interpret_remote_dma_ppermute(self, permutation):
     if jax.device_count() <= 1:


### PR DESCRIPTION
Running tests via bazel, this only runs on TPU. But pytest does not use these BUILD definitions, so it attempts to run this test on CPU and GPU as well.

Fixes #26115