### PR TITLE
[better_errors] Expand debug info testing with eager mode, and MLIR module checking.

### DIFF
--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -1233,6 +1233,7 @@ def lower_jaxpr_to_module(
           'builtin.module(sdy-lift-inlined-meshes)')
       pipeline.run(ctx.module.operation)
 
+  util.test_event("mlir.collect_lowered_jaxprs", jaxpr, ctx.module)
   return LoweringResult(ctx.module, ctx.keepalives, ctx.host_callbacks,
                         ctx.shape_poly_state)
 

--- a/tests/debug_info_test.py
+++ b/tests/debug_info_test.py
@@ -21,7 +21,7 @@ import operator
 import re
 from typing import Any
 
-from absl.testing import absltest, parameterized
+from absl.testing import absltest
 import jax
 from jax import ad_checkpoint
 from jax import lax
@@ -42,6 +42,7 @@ from jax._src import core
 from jax._src import test_util as jtu
 from jax._src.compilation_cache import is_persistent_cache_enabled
 from jax._src.lax.control_flow import for_loop
+from jax._src.interpreters import mlir
 
 
 import numpy as np
@@ -72,10 +73,33 @@ def _debug_info_to_string(dbg: api_util.TracingDebugInfo | core.JaxprDebugInfo |
   # Strip the absolute path and the line number but check that it references
   # this file (to catch errors when the source info points in JAX internals)
   fun_src_info = re.sub(r"^(\S+)( at .*/debug_info_test.py:.*)?", "\\1", dbg.func_src_info)
-  res = f"traced_for={dbg.traced_for}, fun={fun_src_info}, arg_names={dbg.arg_names}"
+  res = f"traced_for={dbg.traced_for}, fun={fun_src_info}, arg_names={','.join(dbg.arg_names)}"
   if isinstance(dbg, core.JaxprDebugInfo):
-    res += f", result_paths={dbg.result_paths}"
+    if dbg.result_paths:
+      res += f", result_paths={','.join(dbg.result_paths)}"
+    else:
+      res += ", result_paths=<empty>"
   return res
+
+
+class TracerSpy:
+  """Use to inspect tracers.
+
+  We can `append` tracers from tracing contexts to this object. We collect
+  the tracer, along with the error message we get when we try to concretize
+  it. This is meant to simulate errors like concretization or leaking.
+  """
+  tracers: list[tuple[core.Tracer, Exception]]
+  def __init__(self):
+    self.tracers = []
+
+  def append(self, t: core.Tracer):
+    try:
+      if t:
+        pass
+      assert False, t
+    except Exception as e:
+      self.tracers.append((t, e))
 
 
 @jtu.with_config(jax_mutable_array_checks=True)
@@ -84,46 +108,97 @@ class DebugInfoTest(jtu.JaxTestCase):
   def _check_tracers_and_jaxprs(self, traceable: Any,
                                 *args,
                                 expected_jaxpr_debug_infos: list[str | re.Pattern],
-                                leaked_tracers: list[core.Tracer] = [],
+                                tracer_spy: TracerSpy | None = None,
                                 expected_tracer_debug_infos: list[str | re.Pattern] = [],
                                 check_lowering: bool = True,
+                                check_tracer_arg_name: bool = False,
+                                expected_lowering_lines: list[str | re.Pattern] = [],
                                 **kwargs):
-    """Checks for expected debug info in all jaxprs, and in leaked tracers.
+    """Checks for expected debug info in all jaxprs, and in inspected tracers.
 
-    The `traceable.trace(*args, **kwargs)` is traced to a Jaxpr, and the
-    debug infos in the nested Jaxprs are first converted to strings using
-    `_debug_info_to_string` and then compared against `expected_jaxpr_debug_infos`.
+    `traceable` will be traced as `traceable.trace(*args, **kwargs)` if it has
+    a `trace` attribute, or will be called as `traceable(*args, **kwargs)`
+    otherwise. The debug infos in the nested Jaxprs are first converted to
+    strings using `_debug_info_to_string` and then
+    compared against `expected_jaxpr_debug_infos`.
     An element of `expected_jaxpr_debug_infos` can be a string, in which case
     it is looked up by equality, or a `re.Pattern` (the result of `re.compile`)
     in which case it is looked up by `.match()`. All elements of
     `expected_jaxpr_debug_infos` must appear, and all Jaxprs must be matched.
 
-    One way in which the debug info is used in JAX is for leaked tracer
-    description, or for ConcretizationErrors. Optionally,
-    the tracing of `fun` can append tracers to `leaked_tracers`, and those
+    Optionally, we can pass a TracerSpy object into which we have
+    appended tracers from the execution of `traceable`. Those
     tracers must have debugging info matching `expected_tracer_debug_infos`.
+    If the `check_tracer_arg_name` is True, then we append
+    ", from <arg_name>" to the inspected tracer's debug info (to test
+    provenance information).
     """
-    self.assertTrue(hasattr(traceable, "trace"))
-    traced = traceable.trace(*args, **kwargs)
-    all_jaxprs = _collect_jaxprs(traced.jaxpr.jaxpr)
+    if hasattr(traceable, "trace"):
+      traced = traceable.trace(*args, **kwargs)
+      all_jaxprs = _collect_jaxprs(traced.jaxpr.jaxpr)
+    else:
+      # Just run the function and collect the Jaxprs and modules that are
+      # lowered
+      traced = None
+      with jtu.collect_lowered_jaxprs() as collection:
+        traceable(*args, **kwargs)
+
+      all_jaxprs = []
+      for jaxpr, _ in collection:
+        all_jaxprs.extend(_collect_jaxprs(jaxpr.jaxpr))
 
     found_jaxprs_debug_infos = [_debug_info_to_string(j.debug_info)
                                 for j in all_jaxprs]
 
-    self._check_matches(expected_jaxpr_debug_infos, found_jaxprs_debug_infos)
-    self._check_tracers(leaked_tracers, expected_tracer_debug_infos)
-    # Run the lowering because this one exercises more code with debug_info
-    # TODO(necula): check the lowering
-    if check_lowering:
-      traced.lower()
+    self._check_matches(expected_jaxpr_debug_infos, found_jaxprs_debug_infos)  # JAXPRS
 
-  def _check_tracers(self,
-                     leaked_tracers: list[core.Tracer],
-                     expected_tracer_debug_infos: list[str | re.Pattern]):
-    found_leaked_tracer_debug_infos = [
-        _debug_info_to_string(t._debug_info) if hasattr(t, "_debug_info") else "None"
-        for t in leaked_tracers]
-    self._check_matches(expected_tracer_debug_infos, found_leaked_tracer_debug_infos)
+    found_tracer_debug_infos = []
+    if tracer_spy is not None:
+      for t, exc in tracer_spy.tracers:
+        if hasattr(t, "_debug_info"):
+          t_debug_info = _debug_info_to_string(t._debug_info)
+          if check_tracer_arg_name:
+            msg = str(exc)
+            m = re.match(r".* while tracing the function (.+) for (.+)\. .* depends on the value of the argument ([^\n]+)\.",
+                         msg,
+                         re.DOTALL)
+            self.assertIsNotNone(m, msg)
+            self.assertEqual(t._debug_info.func_src_info, m.group(1))
+            self.assertEqual(t._debug_info.traced_for, m.group(2))
+            found_tracer_debug_infos.append(
+                f"{t_debug_info}, from {m.group(3)}")
+          else:
+            found_tracer_debug_infos.append(t_debug_info)
+        else:
+          found_tracer_debug_infos.append("None")
+
+      self._check_matches(expected_tracer_debug_infos, found_tracer_debug_infos)  # INSPECTED TRACERS
+
+    if not check_lowering: return
+    # Collect all the lines in all the MLIR modules
+    mlir_modules_lines = []
+    if traced is not None:
+      mlir_modules_lines.extend(
+          traced.lower().as_text("stablehlo", debug_info=True).split("\n"))
+    else:
+      for _, mod in collection:
+        mlir_modules_lines.extend(
+            mlir.module_to_string(mod, enable_debug_info=True).split("\n"))
+
+    expected_and_found = set()
+    expected_and_not_found = set()
+    for exp in expected_lowering_lines:
+      for l in mlir_modules_lines:
+        ok = exp.match(l) if isinstance(exp, re.Pattern) else exp == l
+        if ok:
+          expected_and_found.add(exp)
+          break
+      else:
+        expected_and_not_found.add(exp)
+
+    if expected_and_not_found:
+      msg = "\n".join(mlir_modules_lines)
+      self.assertEmpty(expected_and_not_found, "\nNot found in the MLIR module lines:\n" + msg)
 
   def _check_matches(self,
                      expected: list[str | re.Pattern],
@@ -238,75 +313,6 @@ class DebugInfoTest(jtu.JaxTestCase):
   def helper_save_tracer(self, x):
     self._saved_tracer = x
     return x
-
-  def test_jit_lower_arg_names(self):
-    def f(x, y, *args, **kwargs):
-      return y['hi'] + args[1] + sum(kwargs.values())
-
-    lowered = jax.jit(f).lower({'hi': 1.}, {'hi': 2.}, 3., 4., z=5., w=6.)
-    hlo_str = lowered.as_text("stablehlo", debug_info=True)
-    self.assertNotIn("\"x\"", hlo_str)
-    self.assertIn("y['hi']", hlo_str)
-    self.assertNotIn("args[0]", hlo_str)
-    self.assertIn("args[1]", hlo_str)
-    self.assertIn("kwargs['z']", hlo_str)
-    self.assertIn("kwargs['w']", hlo_str)
-
-    hlo_str = lowered.as_text("stablehlo", debug_info=False)
-    for s in ("\"x\"", "y['hi']", "args[0]", "args[1]", "kwargs['z']", "kwargs['w']"):
-      self.assertNotIn(s, hlo_str)
-
-  @parameterized.parameters([0, 2, [(0, 2)]])
-  def test_jit_lower_arg_names_static_argnums(self, static_argnums):
-    def f(x, y, *args, **kwargs):
-      return y['hi'] + args[1] + sum(kwargs.values())
-
-    lowered = jax.jit(f, static_argnums=static_argnums).lower(
-        (1.,), {'hi': 2.}, 3., 4., z=5., w=6.)
-
-    hlo_str = lowered.as_text("stablehlo", debug_info=True)
-    self.assertNotIn("\"x\"", hlo_str)
-    self.assertIn("y['hi']", hlo_str)
-    self.assertNotIn("args[0]", hlo_str)
-    self.assertIn("args[1]", hlo_str)
-    self.assertIn("kwargs['z']", hlo_str)
-    self.assertIn("kwargs['w']", hlo_str)
-
-    hlo_str = lowered.as_text("stablehlo", debug_info=False)
-    for s in ("\"x\"", "y['hi']", "args[0]", "args[1]", "kwargs['z']", "kwargs['w']"):
-      self.assertNotIn(s, hlo_str)
-
-  @parameterized.parameters(['a', 'b', [('a', 'b')]])
-  def test_jit_lower_arg_names_static_argnames(self, static_argnames):
-    def f(x, y, *args, **kwargs):
-      return y['hi'] + args[1] + kwargs['z'] + kwargs['w']
-
-    lowered = jax.jit(f, static_argnames=static_argnames).lower(
-        (1.,), {'hi': 2.}, 3., 4., z=5., w=6., a=7., b=8.)
-    hlo_str = lowered.as_text("stablehlo", debug_info=True)
-    self.assertNotIn("\"x\"", hlo_str)
-    self.assertIn("y['hi']", hlo_str)
-    self.assertNotIn("args[0]", hlo_str)
-    self.assertIn("args[1]", hlo_str)
-    self.assertIn("kwargs['z']", hlo_str)
-    self.assertIn("kwargs['w']", hlo_str)
-    self.assertNotIn("kwargs['a']", hlo_str)
-    self.assertNotIn("kwargs['b']", hlo_str)
-
-    hlo_str = lowered.as_text("stablehlo", debug_info=False)
-    for s in (
-        "\"x\"", "y['hi']", "args[0]", "args[1]", "kwargs['z']",
-        "kwargs['w']", "kwargs['a']", "kwargs['b']"
-    ):
-      self.assertNotIn(s, hlo_str)
-
-  def test_jit_lower_result_info(self):
-    def f(x, y, z):
-      return {'a': x, 'b': [y]}
-
-    hlo_str = jax.jit(f).lower(1., (2,), [3]).as_text("stablehlo", debug_info=True)
-    self.assertIn("jax.result_info = \"['a']\"", hlo_str)
-    self.assertIn("jax.result_info = \"['b'][0][0]\"", hlo_str)
 
   def test_jit_lower_arg_names_with_error1(self):
     def f(x):
@@ -593,55 +599,161 @@ class DebugInfoTest(jtu.JaxTestCase):
     self.assertNotIn('static_argnums', msg)
 
   def test_simple_jit(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_f(x_dict, y):
-      leaked_tracers.append(x_dict["a"])
+      tracer_spy.append(x_dict["a"])
       return dict(c=x_dict["a"] + x_dict["b"], d=y)
 
     self._check_tracers_and_jaxprs(
         jax.jit(my_f),
         dict(a=1, b=2), 3,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            'traced_for=jit, fun=my_f, arg_names=(\"x_dict[\'a\']", "x_dict[\'b\']", \'y\'), result_paths=("[\'c\']", "[\'d\']")'
+            "traced_for=jit, fun=my_f, arg_names=x_dict['a'],x_dict['b'],y, result_paths=['c'],['d']"
         ],
+        check_tracer_arg_name=True,
         expected_tracer_debug_infos=[
-            'traced_for=jit, fun=my_f, arg_names=("x_dict[\'a\']", "x_dict[\'b\']", \'y\')',
+            "traced_for=jit, fun=my_f, arg_names=x_dict['a'],x_dict['b'],y, from x_dict['a']",
         ])
 
   def test_jit_with_static_argnums(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     @functools.partial(jax.jit, static_argnums=(1,))
     def my_f(a, d):
-      leaked_tracers.append(a)
+      tracer_spy.append(a)
       return a
 
-    def my_g(a, d=1):
-      leaked_tracers.append(a)
-      return my_f(a, d)
+    def my_g(b, d=1):
+      tracer_spy.append(b)
+      return my_f(b, d)
 
     self._check_tracers_and_jaxprs(
         jax.jit(my_g),
         3,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_g, arg_names=('a',), result_paths=('',)",
-            "traced_for=jit, fun=my_f, arg_names=('a',), result_paths=()"
+            # TODO(necula): bad result names
+            'traced_for=jit, fun=my_f, arg_names=a, result_paths=<empty>',
+            'traced_for=jit, fun=my_g, arg_names=b, result_paths=',
         ],
+        check_tracer_arg_name=True,
         expected_tracer_debug_infos=[
-            "traced_for=jit, fun=my_g, arg_names=('a',)",
+            "traced_for=jit, fun=my_g, arg_names=b, from b",
             # TODO(necula): bad arg name
-            "traced_for=jit, fun=my_f, arg_names=('args[0]',)"
+            "traced_for=jit, fun=my_f, arg_names=args[0], from args[0]"
         ])
 
+  def test_jit_arg_names(self):
+    tracer_spy = TracerSpy()
+    def f(x, y, *args, **kwargs):
+      # args[0] is dead
+      tracer_spy.append(kwargs["w"])
+      tracer_spy.append(args[0])
+      return y['hi'] + args[1] + sum(kwargs.values())
+
+    self._check_tracers_and_jaxprs(
+        jax.jit(f),
+        {"ho": 1.}, {"hi": 2.}, 3., 4., z=5., w=6.,
+        expected_jaxpr_debug_infos=[
+            "traced_for=jit, fun=f, arg_names=x['ho'],y['hi'],args[0],args[1],kwargs['w'],kwargs['z'], result_paths=",
+        ],
+        tracer_spy=tracer_spy,
+        check_tracer_arg_name=True,
+        expected_tracer_debug_infos=[
+            "traced_for=jit, fun=f, arg_names=x['ho'],y['hi'],args[0],args[1],kwargs['w'],kwargs['z'], from kwargs['w']",
+            "traced_for=jit, fun=f, arg_names=x['ho'],y['hi'],args[0],args[1],kwargs['w'],kwargs['z'], from args[0]",
+        ],
+        expected_lowering_lines=[
+            re.compile(r".*func.func public @main\(%arg0: tensor<f..> loc\(\"y\['hi'\]\"\)"),
+            re.compile(r".*func.func public @main\(.*%arg1: tensor<f..> loc\(\"args\[1\]\"\)"),
+            re.compile(r".*func.func public @main\(.*%arg2: tensor<f..> loc\(\"kwargs\['w'\]\"\)"),
+            re.compile(r".*func.func public @main\(.*%arg3: tensor<f..> loc\(\"kwargs\['z'\]\"\)"),
+            re.compile(r".*func.func public @main\(.*\{jax.result_info = \"\"\}"),
+        ]
+    )
+
+  def test_jit_arg_names_static_argnums(self):
+    tracer_spy = TracerSpy()
+    def my_f(x, y, z, *args, **kwargs):
+      # z and args[0] and kwargs["w"] are dead
+      # x and args[2] are static
+      tracer_spy.append(kwargs["w"])
+      tracer_spy.append(x[0])
+      return x[0] + y["hi"] + args[1] + args[2] + kwargs["t"]
+
+    self._check_tracers_and_jaxprs(
+        jax.jit(my_f, static_argnums=(0, 5)),
+        (1.,), {"hi": 2.}, 3., 4., 5., 6.,  # x, y, z, args[0], args[1], args[2]
+        t=11., w=12.,  # kwargs
+        expected_jaxpr_debug_infos=[
+            # TODO(necula): the arg_names include the dead ones
+            "traced_for=jit, fun=my_f, arg_names=y['hi'],z,args[0],args[1],kwargs['t'],kwargs['w'], result_paths=",
+        ],
+        tracer_spy=tracer_spy,
+        check_tracer_arg_name=True,
+        expected_tracer_debug_infos=[
+            # TODO(necula): the arg_names are not right, include static ones, also missing args[1]
+            "traced_for=jit, fun=my_f, arg_names=x['hi'],y,z,args[0],kwargs['t'],kwargs['w'], from kwargs['w']",
+            "None",  # TODO(necula)
+        ],
+        expected_lowering_lines=[
+            re.compile(r".*func.func public @main\(%arg0: tensor<f..> loc\(\"y\['hi'\]\"\)"),
+            re.compile(r".*func.func public @main\(.*%arg1: tensor<f..> loc\(\"args\[1\]\"\)"),
+            re.compile(r".*func.func public @main\(.*%arg2: tensor<f..> loc\(\"kwargs\['t'\]\"\)"),
+            re.compile(r".*func.func public @main\(.*\{jax.result_info = \"\"\}"),
+        ])
+
+  def test_jit_arg_names_static_argnames(self):
+    tracer_spy = TracerSpy()
+    def f(x, y, *args, **kwargs):
+      # x and args[0] and kwargs["z"] are dead
+      # kwargs[a] is static
+      tracer_spy.append(x[0])
+      return y['hi'] + args[1] + kwargs['a'] + kwargs['b'] + kwargs['w']
+
+    self._check_tracers_and_jaxprs(
+        jax.jit(f, static_argnames=("a",)),
+        (1.,), {'hi': 2.}, 3., 4.,  # x, y, args[0], args[1]
+        z=5., w=6., a=7., b=8.,  # kwargs
+        expected_jaxpr_debug_infos=[
+            "traced_for=jit, fun=f, arg_names=x[0],y['hi'],args[0],args[1],kwargs['b'],kwargs['w'],kwargs['z'], result_paths=",
+        ],
+        tracer_spy=tracer_spy,
+        check_tracer_arg_name=True,
+        expected_tracer_debug_infos=[
+            "traced_for=jit, fun=f, arg_names=x[0],y['hi'],args[0],args[1],kwargs['b'],kwargs['w'],kwargs['z'], from x[0]",
+        ],
+        expected_lowering_lines=[
+            re.compile(r".*func.func public @main\(%arg0: tensor<f..> loc\(\"y\['hi'\]\"\)"),
+            re.compile(r".*func.func public @main\(.*%arg1: tensor<f..> loc\(\"args\[1\]\"\)"),
+            re.compile(r".*func.func public @main\(.*%arg2: tensor<f..> loc\(\"kwargs\['b'\]\"\)"),
+            re.compile(r".*func.func public @main\(.*%arg3: tensor<f..> loc\(\"kwargs\['w'\]\"\)"),
+            re.compile(r".*func.func public @main\(.*\{jax.result_info = \"\"\}"),
+        ])
+
+  def test_jit_result_info(self):
+    def f(x, y, z):
+      return {'a': x, 'b': [y]}
+    self._check_tracers_and_jaxprs(
+        jax.jit(f),
+        1., (2.,), [3.],
+        expected_jaxpr_debug_infos=[
+            "traced_for=jit, fun=f, arg_names=x,y[0],z[0], result_paths=['a'],['b'][0][0]",
+        ],
+        expected_lowering_lines=[
+            re.compile(r".*func.func public @main\(%arg0: tensor<f..> loc\(\"x\"\)"),
+            re.compile(r".*func.func public @main\(.*%arg1: tensor<f..> loc\(\"y\[0\]\"\)"),
+            re.compile(r".*func.func public @main\(.*\{jax.result_info = \"\['a'\]\"\}"),
+            re.compile(r".*func.func public @main\(.*\{jax.result_info = \"\['b'\]\[0\]\[0\]\"\}"),
+        ])
 
   def test_nested_jit(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_f(x, y):
-      leaked_tracers.append(x)
+      tracer_spy.append(x)
 
       def my_g(u, v):
-        leaked_tracers.append(u)
+        tracer_spy.append(u)
         return dict(c=u * v, d=v)
 
       return jax.jit(my_g)(y, x)["c"]
@@ -649,23 +761,72 @@ class DebugInfoTest(jtu.JaxTestCase):
     self._check_tracers_and_jaxprs(
         jax.jit(my_f),
         2, 3,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=('x', 'y'), result_paths=('',)",
-            "traced_for=jit, fun=my_g, arg_names=('u', 'v'), result_paths=(\"[\'c\']\",)"
+            "traced_for=jit, fun=my_f, arg_names=x,y, result_paths=",
+            "traced_for=jit, fun=my_g, arg_names=u,v, result_paths=[\'c\']"
         ],
         expected_tracer_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=('x', 'y')",
-            "traced_for=jit, fun=my_g, arg_names=('u', 'v')"
+            "traced_for=jit, fun=my_f, arg_names=x,y",
+            "traced_for=jit, fun=my_g, arg_names=u,v"
+        ])
+
+  def test_jvp_of_jit(self):
+    tracer_spy = TracerSpy()
+    def f(x, y, z):
+      tracer_spy.append(x)
+      return {'a': x, 'b': [y]}
+    self._check_tracers_and_jaxprs(
+        lambda x, y, z: jax.jvp(jax.jit(f), (x, y, z), (x, y, z)),
+        jnp.float32(1.), (jnp.float32(2.),), [jnp.float32(3.)],
+        expected_jaxpr_debug_infos=[
+            "None",  # TODO(necula): missing debug info
+        ],
+        tracer_spy=tracer_spy,
+        expected_tracer_debug_infos=[
+            "traced_for=jit, fun=f, arg_names=x,y[0],z[0]",
+        ],
+        expected_lowering_lines=[
+            # TODO(necula): missing arg_names
+            re.compile(r".*func.func public @main\(%arg0: tensor<f..> loc\(unknown\)"),
+            re.compile(r".*func.func public @main\(.*%arg1: tensor<f..> loc\(unknown\)"),
+            re.compile(r".*func.func public @main\(.*%arg2: tensor<f..> loc\(unknown\)"),
+            re.compile(r".*func.func public @main\(.*%arg3: tensor<f..> loc\(unknown\)"),
+            # TODO(necula): missing result names
+            re.compile(r".*func.func public @main\(.*-> \(tensor<f..>, tensor<f..>, tensor<f..>, tensor<f..>\) {"),
+        ])
+
+  def test_vjp_of_jit(self):
+    tracer_spy = TracerSpy()
+    def my_f(x, y, z):
+      tracer_spy.append(y[0])
+      return {'a': x * y[0], 'b': [y]}
+    self._check_tracers_and_jaxprs(
+        lambda x, y, z: jax.vjp(jax.jit(my_f), x, y, z)[1](dict(a=x, b=[y])),
+        jnp.float32(1.), (jnp.float32(2.),), [jnp.float32(3.)],
+        expected_jaxpr_debug_infos=[
+            "None",  # TODO(necula): missing debug info
+        ],
+        tracer_spy=tracer_spy,
+        check_tracer_arg_name=True,
+        expected_tracer_debug_infos=[
+            "traced_for=jit, fun=my_f, arg_names=x,y[0],z[0], from y[0]",
+        ],
+        expected_lowering_lines=[
+            # TODO(necula): missing arg_names
+            re.compile(r".*func.func public @main\(%arg0: tensor<f..> loc\(unknown\)"),
+            re.compile(r".*func.func public @main\(.*%arg1: tensor<f..> loc\(unknown\)"),
+            # TODO(necula): missing result names
+            re.compile(r".*func.func public @main\(.*-> tensor<f..> {"),
         ])
 
   def test_vjp_of_nested_jit(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_f(x, y):
-      leaked_tracers.append(x)
+      tracer_spy.append(x)
 
       def my_g(u, v):
-        leaked_tracers.append(u)
+        tracer_spy.append(u)
         return dict(c=u * v, d=v)
 
       return jax.jit(my_g)(y, x)["c"]
@@ -673,25 +834,34 @@ class DebugInfoTest(jtu.JaxTestCase):
     self._check_tracers_and_jaxprs(
         jax.jit(lambda x, y, res_ct: jax.vjp(my_f, x, y)[1](res_ct)),
         2., 3., 0.3,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=<lambda>, arg_names=('x', 'y', 'res_ct'), result_paths=('[0]', '[1]')",
+            "traced_for=jit, fun=<lambda>, arg_names=x,y,res_ct, result_paths=[0],[1]",
             # TODO(necula): missing debug info
             "None",
         ],
+        check_tracer_arg_name=True,
         expected_tracer_debug_infos=[
             # TODO(necula): missing debug info
             "None",
-            "traced_for=jit, fun=my_g, arg_names=('u', 'v')"
+            "traced_for=jit, fun=my_g, arg_names=u,v, from u"
+        ],
+        expected_lowering_lines=[
+            re.compile(r".*func.func public @main\(%arg0: tensor<f..> loc\(\"x\"\)"),
+            re.compile(r".*func.func public @main\(.*%arg1: tensor<f..> loc\(\"y\"\)"),
+            re.compile(r".*func.func public @main\(.*%arg2: tensor<f..> loc\(\"res_ct\"\)"),
+            re.compile(r".*func.func public @main\(.*jax.result_info = \"\[0\]\"}"),
+            re.compile(r".*func.func public @main\(.*jax.result_info = \"\[1\]\"}"),
         ])
 
+
   def test_vmap_of_nested_jit(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_f(x, y):
-      leaked_tracers.append(x)
+      tracer_spy.append(x)
 
       def my_g(u, v):
-        leaked_tracers.append(u)
+        tracer_spy.append(u)
         return dict(c=u * v, d=v)
 
       return jax.jit(my_g)(y, x)["c"]
@@ -699,30 +869,30 @@ class DebugInfoTest(jtu.JaxTestCase):
     self._check_tracers_and_jaxprs(
         jax.jit(jax.vmap(my_f)),
         np.ones((8,), dtype=np.float32), np.zeros((8,), dtype=np.float32),
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=('x', 'y'), result_paths=('',)",
+            "traced_for=jit, fun=my_f, arg_names=x,y, result_paths=",
             # TODO(necula): missing debug info
             'None',
         ],
         expected_tracer_debug_infos=[
             # TODO(necula): missing debug info
             "None",
-            "traced_for=jit, fun=my_g, arg_names=('u', 'v')"
+            "traced_for=jit, fun=my_g, arg_names=u,v"
         ])
 
   def test_custom_vmap(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     @jax.custom_batching.custom_vmap
     def my_f(xdict):
       x = xdict["x"]
-      leaked_tracers.append(x)
+      tracer_spy.append(x)
       return dict(a=jnp.sin(x))
 
     @my_f.def_vmap
     def my_rule(axis_size, in_batched, xys):
       xs = xys["x"]
-      leaked_tracers.append(xs)
+      tracer_spy.append(xs)
       xs_batched, = in_batched
       self.assertEqual(xs_batched["x"], True)
       self.assertEqual(axis_size, xs.shape[0])
@@ -732,24 +902,24 @@ class DebugInfoTest(jtu.JaxTestCase):
     self._check_tracers_and_jaxprs(
         jax.jit(jax.vmap(my_f)),
         xy,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=(\"xdict[\'x\']\", \"xdict[\'y\']\"), result_paths=(\"[\'a\']\",)",
+            "traced_for=jit, fun=my_f, arg_names=xdict['x'],xdict['y'], result_paths=['a']",
         ],
         expected_tracer_debug_infos=[
-            "traced_for=custom_vmap, fun=my_f, arg_names=(\"xdict[\'x\']\", \"xdict[\'y\']\")",
-            "traced_for=jit, fun=my_f, arg_names=(\"xdict[\'x\']\", \"xdict[\'y\']\")"
+            "traced_for=custom_vmap, fun=my_f, arg_names=xdict['x'],xdict['y']",
+            "traced_for=jit, fun=my_f, arg_names=xdict['x'],xdict['y']"
         ])
 
   def test_cond(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_f(x):
       def my_true_branch(a, b):
-        leaked_tracers.append(a)
+        tracer_spy.append(a)
         return a + b
 
       def my_false_branch(c, d):
-        leaked_tracers.append(c)
+        tracer_spy.append(c)
         return c - d
 
       return lax.cond(x >= 0, my_true_branch, my_false_branch, x, x)
@@ -757,61 +927,61 @@ class DebugInfoTest(jtu.JaxTestCase):
     self._check_tracers_and_jaxprs(
         jax.jit(my_f),
         0,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=('x',), result_paths=('',)",
+            "traced_for=jit, fun=my_f, arg_names=x, result_paths=",
             # TODO(necula): some Jaxprs without debug info
             "None"],
         expected_tracer_debug_infos=[
-            "traced_for=cond, fun=my_true_branch, arg_names=('a', 'b')",
-            "traced_for=cond, fun=my_false_branch, arg_names=('c', 'd')"
+            "traced_for=cond, fun=my_true_branch, arg_names=a,b",
+            "traced_for=cond, fun=my_false_branch, arg_names=c,d"
         ])
 
   def test_switch(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_f(x):
       def my_branch0(x0):
-        leaked_tracers.append(x0)
+        tracer_spy.append(x0)
         return x0
       def my_branch1(x1):
-        leaked_tracers.append(x1)
+        tracer_spy.append(x1)
         return x1 + 1
       def my_branch2(x2):
-        leaked_tracers.append(x2)
+        tracer_spy.append(x2)
         return x2 + 2
       return lax.switch(x, [my_branch0, my_branch1, my_branch2], x)
 
     self._check_tracers_and_jaxprs(
         jax.jit(my_f),
         2,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=('x',), result_paths=('',)",
+            "traced_for=jit, fun=my_f, arg_names=x, result_paths=",
             # TODO(necula): some Jaxprs without debug info
             "None"],
         expected_tracer_debug_infos=[
-            "traced_for=switch, fun=my_branch0, arg_names=('x0',)",
-            "traced_for=switch, fun=my_branch1, arg_names=('x1',)",
-            "traced_for=switch, fun=my_branch2, arg_names=('x2',)"
+            "traced_for=switch, fun=my_branch0, arg_names=x0",
+            "traced_for=switch, fun=my_branch1, arg_names=x1",
+            "traced_for=switch, fun=my_branch2, arg_names=x2"
         ])
 
   def test_grad_cond_with_remat(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_f(x, y):
       # The cond branches return two things, and only the first is needed
       # in the residuals.
       def my_true_branch(a, b):
-        leaked_tracers.append(a)
+        tracer_spy.append(a)
         return (a + 1, a + b)
 
       def my_false_branch(c, d):
-        leaked_tracers.append(c)
+        tracer_spy.append(c)
         return (c - 1, c - d)
 
       def my_g(x, y):
         # x1 does not depend on y
         x1, y1 = lax.cond(x >= 0, my_true_branch, my_false_branch, x, y)
-        leaked_tracers.append(x1)
+        tracer_spy.append(x1)
         return x1, y1
 
       x2, y2 = jax.remat(my_g)(x, y)
@@ -820,23 +990,23 @@ class DebugInfoTest(jtu.JaxTestCase):
     self._check_tracers_and_jaxprs(
         jax.jit(jax.grad(my_f)),
         1., 2.,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=('x', 'y'), result_paths=('',)",
+            'traced_for=jit, fun=my_f, arg_names=x,y, result_paths=',
             # TODO(necula): some Jaxprs without debug info
             'None',
         ],
         expected_tracer_debug_infos=[
-            "traced_for=cond, fun=my_true_branch, arg_names=('a', 'b')",
-            "traced_for=cond, fun=my_false_branch, arg_names=('c', 'd')",
-            "traced_for=checkpoint / remat, fun=my_g, arg_names=('x', 'y')"
+            'traced_for=cond, fun=my_true_branch, arg_names=a,b',
+            'traced_for=cond, fun=my_false_branch, arg_names=c,d',
+            'traced_for=checkpoint / remat, fun=my_g, arg_names=x,y',
         ])
 
   def test_grad_scan(self):
       # Based on control_flow_test:testScanHigherOrderDifferentiation
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def f(c, a):
-      leaked_tracers.append(c)
+      tracer_spy.append(c)
       d = 0.75
       b = jnp.sin(c * jnp.sum(jnp.cos(d * a)))
       c = 0.9 * jnp.cos(d * jnp.sum(jnp.sin(c * a)))
@@ -847,38 +1017,38 @@ class DebugInfoTest(jtu.JaxTestCase):
 
     @jax.jit
     def my_f(x, as_):
-      leaked_tracers.append(x)
+      tracer_spy.append(x)
       return jax.remat(lambda *args: for_loop.scan(f, *args))(c, as_)
 
     def the_grad(c, as_):
-      leaked_tracers.append(c)
+      tracer_spy.append(c)
       _, pullback = jax.vjp(my_f, c, as_)
       return pullback((c, np.arange(3, dtype=c.dtype)))
 
     self._check_tracers_and_jaxprs(
         jax.jit(the_grad),
         c, as_,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=the_grad, arg_names=('c', 'as_'), result_paths=('[0]', '[1]')",
+            "traced_for=jit, fun=the_grad, arg_names=c,as_, result_paths=[0],[1]",
             'None',  # TODO(necula): some Jaxprs without debug info
         ],
         expected_tracer_debug_infos=[
-            "traced_for=jit, fun=the_grad, arg_names=('c', 'as_')",
-            "traced_for=scan, fun=f, arg_names=('c', 'a')",
-            "traced_for=jit, fun=my_f, arg_names=('x', 'as_')",
+            "traced_for=jit, fun=the_grad, arg_names=c,as_",
+            "traced_for=scan, fun=f, arg_names=c,a",
+            "traced_for=jit, fun=my_f, arg_names=x,as_",
             'None',  # TODO(necula): some missing debug info
         ])
 
   def test_while_loop(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_f(x):
       def my_cond(a):
-        leaked_tracers.append(a)
+        tracer_spy.append(a)
         return a <= 8
 
       def my_body(b):
-        leaked_tracers.append(b)
+        tracer_spy.append(b)
         return b + 1
 
       return lax.while_loop(my_cond, my_body, x)
@@ -886,21 +1056,59 @@ class DebugInfoTest(jtu.JaxTestCase):
     self._check_tracers_and_jaxprs(
         jax.jit(my_f),
         0,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=('x',), result_paths=('',)",
+            "traced_for=jit, fun=my_f, arg_names=x, result_paths=",
+            'None',  # TODO(necula): some missing debug info
+        ],
+        check_tracer_arg_name=True,
+        expected_tracer_debug_infos=[
+            "traced_for=while_cond, fun=my_cond, arg_names=a, from a",
+            "traced_for=while_body, fun=my_body, arg_names=b, from b",
+        ])
+
+  def test_fori(self):
+    # See https://github.com/jax-ml/jax/issues/23637
+    tracer_spy = TracerSpy()
+    def my_body(_, c):
+      tracer_spy.append(c)
+      return 0.
+
+    self._check_tracers_and_jaxprs(
+        jax.jit(lambda x: jax.lax.fori_loop(0, 5, my_body, x)),
+        3.,
+        tracer_spy=tracer_spy,
+        expected_jaxpr_debug_infos=[
+            "traced_for=jit, fun=<lambda>, arg_names=x, result_paths=",
             'None',  # TODO(necula): some missing debug info
         ],
         expected_tracer_debug_infos=[
-            "traced_for=while_cond, fun=my_cond, arg_names=('a',)",
-            "traced_for=while_body, fun=my_body, arg_names=('b',)",
+            # TODO(necula): the arg_names are not right
+            "traced_for=scan, fun=my_body, arg_names=loop_carry[0],loop_carry[1]",
+        ]
+    )
+
+    tracer_spy = TracerSpy()
+
+    # When the ubound is not a constant, we use a while_loop
+    self._check_tracers_and_jaxprs(
+        jax.jit(lambda ub, x: jax.lax.fori_loop(0, ub, my_body, x)),
+        5, 3.,
+        tracer_spy=tracer_spy,
+        expected_jaxpr_debug_infos=[
+            "traced_for=jit, fun=<lambda>, arg_names=ub,x, result_paths=",
+            'None',  # TODO(necula): some missing debug info
+        ],
+        expected_tracer_debug_infos=[
+            # TODO(necula): the arg_names are not right
+            "traced_for=while_body, fun=my_body, arg_names=loop_carry[0],loop_carry[1],loop_carry[2]",
         ])
 
   def test_scan(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_f(x):
       def my_scan_body(carry, inp):
-        leaked_tracers.append(carry)
+        tracer_spy.append(carry)
         return (carry + inp, carry)
 
       return lax.scan(my_scan_body, 0, x)
@@ -908,57 +1116,112 @@ class DebugInfoTest(jtu.JaxTestCase):
     self._check_tracers_and_jaxprs(
         jax.jit(my_f),
         np.arange(8, dtype=np.int32),
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=('x',), result_paths=('[0]', '[1]')",
+            "traced_for=jit, fun=my_f, arg_names=x, result_paths=[0],[1]",
             # TODO(necula): some Jaxprs without debug info
             'None'],
         expected_tracer_debug_infos=[
-            "traced_for=scan, fun=my_scan_body, arg_names=('carry', 'inp')"
+            "traced_for=scan, fun=my_scan_body, arg_names=carry,inp"
         ])
 
   def test_eval_shape(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_f(x):
-      leaked_tracers.append(x)
+      tracer_spy.append(x)
       return x
 
     _ = jax.eval_shape(my_f, 0)
-    self._check_tracers(leaked_tracers, [
-        "traced_for=jit, fun=my_f, arg_names=('x',)"
-    ])
+    self._check_tracers_and_jaxprs(
+        lambda: jax.eval_shape(my_f, 0),
+        tracer_spy=tracer_spy,
+        expected_jaxpr_debug_infos=[],
+        expected_tracer_debug_infos=[
+            "traced_for=jit, fun=my_f, arg_names=x"],
+    )
 
   def test_pmap(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_f(x):
-      leaked_tracers.append(x)
+      tracer_spy.append(x)
       return jnp.sin(x)
 
     self._check_tracers_and_jaxprs(
         jax.pmap(my_f),
         np.ones((jax.device_count(),), dtype=np.float32),
         expected_jaxpr_debug_infos=[
-            "traced_for=pmap, fun=my_f, arg_names=('x',), result_paths=('',)"
+            "traced_for=pmap, fun=my_f, arg_names=x, result_paths="
         ],
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_tracer_debug_infos=[
-            "traced_for=pmap, fun=my_f, arg_names=('x',)"
+            "traced_for=pmap, fun=my_f, arg_names=x"
+        ],
+    )
+
+  def test_pmap_with_arg_and_result_names(self):
+    tracer_spy = TracerSpy()
+    x = np.ones((jax.device_count(),), dtype=np.float32)
+    def my_f(x, y, *args, a, **kwargs):
+      # y and kwargs[c] is dead
+      tracer_spy.append(args[1])
+      s = x + a + args[1] + kwargs["d"]
+      return dict(u=s, v=x)
+
+    self._check_tracers_and_jaxprs(
+        jax.pmap(my_f, static_broadcasted_argnums=(0,)),
+        1., x, x, x,  # x, y, args[0], args[1]
+        d=x, a=x, b=x,  # kwargs
+        expected_jaxpr_debug_infos=[
+            "traced_for=pmap, fun=my_f, arg_names=y,args[0],args[1],a,kwargs['b'],kwargs['d'], result_paths=['u'],['v']",
+        ],
+        tracer_spy=tracer_spy,
+        check_tracer_arg_name=True,
+        expected_tracer_debug_infos=[
+            # TODO(necula): bad tracer provenance
+            "traced_for=pmap, fun=my_f, arg_names=x,y,args[0],a,kwargs['b'],kwargs['d'], from args[0]",
         ],
     )
 
   def test_pmap_of_grad(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_f(x):
-      leaked_tracers.append(x)
+      tracer_spy.append(x)
       return jnp.sin(x)
 
     self._check_tracers_and_jaxprs(
         jax.pmap(jax.grad(my_f)),
         np.ones((jax.device_count(),), dtype=np.float32),
         expected_jaxpr_debug_infos=[
-            "traced_for=pmap, fun=my_f, arg_names=('x',), result_paths=('',)",
+            "traced_for=pmap, fun=my_f, arg_names=x, result_paths=",
         ],
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
+        expected_tracer_debug_infos=[
+            # TODO(necula): missing debug_info
+            'None'
+        ],
+    )
+
+  def test_jvp_pmap_eager(self):
+    tracer_spy = TracerSpy()
+    def my_f(x, y, *args):
+      # y is dead, x is static broadcasted
+      tracer_spy.append(args[1])
+      s = x + args[1]
+      return dict(u=s, v=x)
+
+    x = jnp.ones((jax.device_count(), 1), dtype=np.float32)
+    x_tan = jnp.full_like(x, .1)
+
+    self._check_tracers_and_jaxprs(
+        lambda x, x_tan: jax.jvp(jax.pmap(my_f),
+                                 (x, x, x, x), (x_tan, x_tan, x_tan, x_tan)),
+        x, x_tan,
+        expected_jaxpr_debug_infos=[
+            # TODO(necula): why this?
+            re.compile(r'traced_for=jit, fun=_multi_slice at .*/array_methods.py:.*, arg_names=self, result_paths=.*'),
+            "None",  # TODO(necula): missing debug info
+        ],
+        tracer_spy=tracer_spy,
         expected_tracer_debug_infos=[
             # TODO(necula): missing debug_info
             'None'
@@ -966,11 +1229,11 @@ class DebugInfoTest(jtu.JaxTestCase):
     )
 
   def test_remat(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_f(x):
       @jax.remat
       def my_g(y):
-        leaked_tracers.append(y)
+        tracer_spy.append(y)
         return lax.sin(y)
 
       return my_g(x)
@@ -978,21 +1241,21 @@ class DebugInfoTest(jtu.JaxTestCase):
     self._check_tracers_and_jaxprs(
         jax.jit(my_f),
         0.,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=('x',), result_paths=('',)",
+            "traced_for=jit, fun=my_f, arg_names=x, result_paths=",
             # TODO(necula): some Jaxprs without debug info
             'None'],
         expected_tracer_debug_infos=[
-            "traced_for=checkpoint / remat, fun=my_g, arg_names=('y',)"
+            "traced_for=checkpoint / remat, fun=my_g, arg_names=y"
         ])
 
   def test_grad_remat(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_f(x):
       @jax.remat
       def my_g(y):
-        leaked_tracers.append(y)
+        tracer_spy.append(y)
         return lax.sin(lax.sin(y))
 
       return my_g(my_g(x))
@@ -1000,13 +1263,13 @@ class DebugInfoTest(jtu.JaxTestCase):
     self._check_tracers_and_jaxprs(
         jax.jit(jax.grad(my_f)),
         0.,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=('x',), result_paths=('',)",
+            "traced_for=jit, fun=my_f, arg_names=x, result_paths=",
             # TODO(necula): some Jaxprs without debug info
             "None"],
         expected_tracer_debug_infos=[
-            "traced_for=checkpoint / remat, fun=my_g, arg_names=('y',)"
+            "traced_for=checkpoint / remat, fun=my_g, arg_names=y"
         ])
 
   def test_remat_saved_residuals(self):
@@ -1025,10 +1288,10 @@ class DebugInfoTest(jtu.JaxTestCase):
   def test_checkify_pmap_basic(self):
     if len(jax.devices()) < 2:
       self.skipTest("requires at least 2 devices")
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     @jax.pmap
     def my_f(my_x):
-      leaked_tracers.append(my_x)
+      tracer_spy.append(my_x)
       y1 = jnp.sin(1./my_x)
       y2 = jnp.sin(my_x)
       return (y1 + y2,)
@@ -1036,30 +1299,30 @@ class DebugInfoTest(jtu.JaxTestCase):
     self._check_tracers_and_jaxprs(
         jax.jit(checkify.checkify(my_f, errors=checkify.nan_checks)),
         np.arange(len(jax.devices()), dtype=np.float32),
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
             # TODO(necula): this should not be pointing into the JAX internals
-            re.compile(r"traced_for=jit, fun=checked_fun at .*jax/_src/checkify.py:.*, arg_names=\(\'args\[0\]\',\)"),
-            re.compile(r"traced_for=jit, fun=argsort at .*numpy/lax_numpy.py:.*, arg_names=\('a',\), result_paths=\('',\)"),
+            re.compile(r"traced_for=jit, fun=checked_fun at .*jax/_src/checkify.py:.*, arg_names=args\[0\]"),
+            re.compile(r"traced_for=jit, fun=argsort at .*numpy/lax_numpy.py:.*, arg_names=a, result_paths="),
             "None",  # TODO(necula): missing tracer debug info
         ],
         expected_tracer_debug_infos=[
-            "traced_for=xla_pmap, fun=my_f, arg_names=('my_x',)",
+            "traced_for=xla_pmap, fun=my_f, arg_names=my_x",
         ],
         check_lowering=False,  # TODO(necula): warning during lowering
     )
 
   def test_custom_dce_static_argnums(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     @functools.partial(jax.experimental.custom_dce.custom_dce,
                        static_argnums=(0,))
     def my_g(f, x):
-      leaked_tracers.append(x)
+      tracer_spy.append(x)
       return f(x), 10 * f(x)
 
     @my_g.def_dce
     def my_g_dce(f, used_outs, x):  # note: static_argnums are always passed first
-      leaked_tracers.append(x)
+      tracer_spy.append(x)
       self.assertTrue(callable(f))
       return [2 * v if used else None
               for used, v in zip(used_outs, my_g(f, x))]
@@ -1070,56 +1333,58 @@ class DebugInfoTest(jtu.JaxTestCase):
     self._check_tracers_and_jaxprs(
         jax.jit(lambda x: my_g(my_f, x)[0]),
         0.,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=<lambda>, arg_names=('x',), result_paths=('',)",
+            "traced_for=jit, fun=<lambda>, arg_names=x, result_paths=",
             # TODO(necula): some Jaxprs without debug info
             'None'],
         expected_tracer_debug_infos=[
-            "traced_for=custom_dce, fun=my_g, arg_names=('x',)"
+            "traced_for=custom_dce, fun=my_g, arg_names=x"
         ])
 
   def test_custom_dce_consts(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     @jax.experimental.custom_dce.custom_dce
     def my_f(x):
-      leaked_tracers.append(x)
+      tracer_spy.append(x)
       return np.eye(1) * jnp.sin(x), jnp.cos(x)
 
     @my_f.def_dce
-    def rule(used_outs, x):
-      leaked_tracers.append(x)
+    def rule(used_outs, y):
+      tracer_spy.append(y)
       return (
-          np.full((1, 1), 2.0) * jnp.exp(x) if used_outs[0] else None,
-          jnp.sqrt(x) if used_outs[1] else None,
+          np.full((1, 1), 2.0) * jnp.exp(y) if used_outs[0] else None,
+          jnp.sqrt(y) if used_outs[1] else None,
       )
 
     self._check_tracers_and_jaxprs(
         jax.jit(lambda x: my_f(x)[0]),
         np.array(1.1234),
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=<lambda>, arg_names=('x',), result_paths=('',)",
+            "traced_for=jit, fun=<lambda>, arg_names=x, result_paths=",
             # TODO(necula): some Jaxprs without debug info
             'None'],
+        check_tracer_arg_name=True,
         expected_tracer_debug_infos=[
-            "traced_for=custom_dce, fun=my_f, arg_names=('x',)"
+            "traced_for=custom_dce, fun=my_f, arg_names=x, from x",
+            # TODO(necula): rule.y does not have an inspected tracer?
         ])
 
   def test_custom_linear_solve_complex(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def solve(a, b):
-      leaked_tracers.append(a)
+      tracer_spy.append(a)
       def my_solve(matvec, x):
-        leaked_tracers.append(x)
+        tracer_spy.append(x)
         return jsp.linalg.solve(a, x)
 
       def my_high_precision_dot(a, b):
-        leaked_tracers.append(a)
+        tracer_spy.append(a)
         return lax.dot(a, b, precision=lax.Precision.HIGHEST)
 
       def my_tr_solve(matvec, x):
-        leaked_tracers.append(x)
+        tracer_spy.append(x)
         return jsp.linalg.solve(a.T, x)
       matvec = functools.partial(my_high_precision_dot, a)
       return lax.custom_linear_solve(matvec, b, my_solve, my_tr_solve)
@@ -1131,61 +1396,61 @@ class DebugInfoTest(jtu.JaxTestCase):
     self._check_tracers_and_jaxprs(
         jax.jit(lambda a, b: jax.jvp(solve, (a, b), (a, b))),
         a, b,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=<lambda>, arg_names=('a', 'b'), result_paths=('[0]', '[1]')",
-            re.compile(r"traced_for=jit, fun=_solve at .*scipy/linalg.py:.*, arg_names=\('a', 'b'\), result_paths=\('',\)"),
-            re.compile(r"traced_for=jit, fun=solve at .*/linalg.py:.*, arg_names=\('a', 'b'\), result_paths=\('',\)"),
-            re.compile(r"traced_for=jit, fun=_lu_solve at .*/linalg.py:.*, arg_names=\('lu', 'permutation', 'b'\), result_paths=\('',\)"),
+            "traced_for=jit, fun=<lambda>, arg_names=a,b, result_paths=[0],[1]",
+            re.compile(r"traced_for=jit, fun=_solve at .*scipy/linalg.py:.*, arg_names=a,b, result_paths="),
+            re.compile(r"traced_for=jit, fun=solve at .*/linalg.py:.*, arg_names=a,b, result_paths="),
+            re.compile(r"traced_for=jit, fun=_lu_solve at .*/linalg.py:.*, arg_names=lu,permutation,b, result_paths="),
             "None",  # TODO(necula): there are missing jaxpr debug info
         ],
         expected_tracer_debug_infos=[
-            "traced_for=custom_linear_solve solve, fun=my_solve, arg_names=('x',)",
-            "traced_for=custom_linear_solve transpose_solve, fun=my_tr_solve, arg_names=('x',)",
+            "traced_for=custom_linear_solve solve, fun=my_solve, arg_names=x",
+            "traced_for=custom_linear_solve transpose_solve, fun=my_tr_solve, arg_names=x",
             "None",  # TODO(necula): there are missing debug info
         ])
 
   def test_custom_root_errors(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def dummy_root_usage(x):
-      leaked_tracers.append(x)
+      tracer_spy.append(x)
       def my_f(x):
-        leaked_tracers.append(x)
+        tracer_spy.append(x)
         return x - 3.
       def my_solve(f, x):
-        leaked_tracers.append(x)
+        tracer_spy.append(x)
         return x
       def my_transpose_solve(f, x):
-        leaked_tracers.append(x)
+        tracer_spy.append(x)
         return x
       return lax.custom_root(my_f, 0., my_solve, my_transpose_solve)
 
     self._check_tracers_and_jaxprs(
         jax.jit(lambda x: jax.jvp(dummy_root_usage, (x,), (0.0,))),
         0.,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=<lambda>, arg_names=('x',), result_paths=('[0]', '[1]')",
+            "traced_for=jit, fun=<lambda>, arg_names=x, result_paths=[0],[1]",
             "None",  # TODO(necula): there are missing Jaxpr debug info
         ],
         expected_tracer_debug_infos=[
-            "traced_for=custom_root, fun=my_f, arg_names=('x',)",
-            "traced_for=custom_root solve, fun=my_solve, arg_names=('x',)",
-            "traced_for=custom_root tangent_solve, fun=my_transpose_solve, arg_names=('x',)",
+            "traced_for=custom_root, fun=my_f, arg_names=x",
+            "traced_for=custom_root solve, fun=my_solve, arg_names=x",
+            "traced_for=custom_root tangent_solve, fun=my_transpose_solve, arg_names=x",
             "None",  # TODO(necula): there are missing debug info
         ])
 
   def test_pallas_call(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def my_kernel(x_ref, y_ref, o_ref):
-      leaked_tracers.append(x_ref)
+      tracer_spy.append(x_ref)
       o_ref[...] = x_ref[...] + y_ref[...]
 
     x = np.arange(256 * 16, dtype=np.float32).reshape((256, 16))
 
     def my_f(x):
       def my_index_map(i, j):
-        leaked_tracers.append(i)
+        tracer_spy.append(i)
         return (i, j)
 
       return pl.pallas_call(my_kernel,
@@ -1197,22 +1462,22 @@ class DebugInfoTest(jtu.JaxTestCase):
 
     self._check_tracers_and_jaxprs(
         jax.jit(my_f), x,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=('x',), result_paths=('',)",
+            "traced_for=jit, fun=my_f, arg_names=x, result_paths=",
             # TODO(necula): missing Jaxpr debug info
             "None"],
         expected_tracer_debug_infos=[
-            "traced_for=pallas_call index_map, fun=my_index_map, arg_names=('i', 'j')",
-            "traced_for=pallas_call, fun=my_kernel, arg_names=('x_ref', 'y_ref', 'o_ref')",
+            "traced_for=pallas_call index_map, fun=my_index_map, arg_names=i,j",
+            "traced_for=pallas_call, fun=my_kernel, arg_names=x_ref,y_ref,o_ref",
         ],
         check_lowering=False,  # We need interpret mode on CPU. TODO(necula)
     )
 
   def test_checkify_pallas_call(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     def kernel(x_ref, y_ref):
-      leaked_tracers.append(x_ref)
+      tracer_spy.append(x_ref)
       y_ref[...] = jnp.log(x_ref[...])
 
     def my_f(input):
@@ -1226,23 +1491,23 @@ class DebugInfoTest(jtu.JaxTestCase):
     self._check_tracers_and_jaxprs(
         jax.jit(my_f),
         jnp.arange(4, dtype=jnp.float32) - 2,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=('input',), result_paths=('',)",
+            "traced_for=jit, fun=my_f, arg_names=input, result_paths=",
             "None",  # TODO(necula): missing tracer debug info
         ],
         expected_tracer_debug_infos=[
-            "traced_for=pallas_call, fun=kernel, arg_names=('x_ref', 'y_ref')",
+            "traced_for=pallas_call, fun=kernel, arg_names=x_ref,y_ref",
         ],
         check_lowering=False,  # We need interpret mode on CPU. TODO(necula)
     )
 
   def test_composite(self):
-    leaked_tracers: list[core.Tracer] = []
+    tracer_spy = TracerSpy()
     scale = np.array([0.5, 0.4, 0.3], dtype=np.float32)
     @functools.partial(lax.composite, name="my.consts")
     def my_consts(x):
-      leaked_tracers.append(x)
+      tracer_spy.append(x)
       return x / scale
 
 
@@ -1250,13 +1515,13 @@ class DebugInfoTest(jtu.JaxTestCase):
 
     self._check_tracers_and_jaxprs(
         jax.jit(my_consts), x,
-        leaked_tracers=leaked_tracers,
+        tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_consts, arg_names=('x',), result_paths=('',)",
+            "traced_for=jit, fun=my_consts, arg_names=x, result_paths=",
             "None"
         ],
         expected_tracer_debug_infos=[
-            "traced_for=composite, fun=my_consts, arg_names=('x',)"])
+            "traced_for=composite, fun=my_consts, arg_names=x"])
 
 
 class EagerPmapMixin:


### PR DESCRIPTION
Made several improvements to the debug info tests:

 * added support for eager mode, which sometimes uses
   different code paths for the debug info, e.g., for
   `jvp(pmap)`. To check the debugging info in these cases we add
   instrumentation to collect the lowered Jaxprs and MLIR modules right
   after lowering, and we check the debugging information there.
 * added support for checking for the presence of regular expressions
   and strings in the lowered module, to check that the location
   information and arg_names and result_paths is present. This
   is now enabled only for a subset of the tests.
 * simplified the pretty-printing of the arg_names and result_paths
   in the debug info, to remove a layer of parentheses and string,
   so that instead of `arg_names=("x", "y")` we now pretty-print
   just `arg_names=x,y`
 * added support for checking the provenance information in
   leaked tracers
 * Added more tests, found more missing debug info, left new TODOs