### PR TITLE
Added CPython cache steps in tsan.yaml CI workflow

### DIFF
--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -44,7 +44,17 @@ jobs:
           repository: python/cpython
           path: cpython
           ref: "3.13"
+
+      - name: Restore cached CPython with TSAN
+        id: cache-cpython-tsan-restore
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ./python-tsan.tgz
+          key: ${{ runner.os }}-cpython-tsan-${{ hashFiles('cpython/configure.ac') }}
+
       - name: Build CPython with TSAN enabled
+        if: steps.cache-cpython-tsan-restore.outputs.cache-hit != 'true'
         run: |
           cd cpython
           mkdir ${GITHUB_WORKSPACE}/cpython-tsan
@@ -56,6 +66,16 @@ jobs:
 
           # Create archive to be used with bazel as hermetic python:
           cd ${GITHUB_WORKSPACE} && tar -czpf python-tsan.tgz cpython-tsan
+
+      - name: Save CPython with TSAN
+        id: cache-cpython-tsan-save
+        if: steps.cache-cpython-tsan-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ./python-tsan.tgz
+          key: ${{ runner.os }}-cpython-tsan-${{ hashFiles('cpython/configure.ac') }}
+
       - name: Build Jax and run tests
         timeout-minutes: 120
         env:
@@ -69,7 +89,8 @@ jobs:
           export PYTHON_SHA256=($(sha256sum ${GITHUB_WORKSPACE}/python-tsan.tgz))
           echo "Python sha256: ${PYTHON_SHA256}"
 
-          ${GITHUB_WORKSPACE}/cpython-tsan/bin/python3 build/build.py build --configure_only \
+          python3 -VV
+          python3 build/build.py build --configure_only \
             --python_version=3.13-ft \
             --bazel_options=--repo_env=HERMETIC_PYTHON_URL="file://${GITHUB_WORKSPACE}/python-tsan.tgz" \
             --bazel_options=--repo_env=HERMETIC_PYTHON_SHA256=${PYTHON_SHA256} \


### PR DESCRIPTION
- Building and saving CPython: https://github.com/jax-ml/jax/actions/runs/13040079056/job/36379730440?pr=26189 
![image](https://github.com/user-attachments/assets/ea96b0d3-104d-4eef-8b0b-5ca31953e245)


- Using cache: https://github.com/jax-ml/jax/actions/runs/13040868693/job/36382209911?pr=26189

![image](https://github.com/user-attachments/assets/742a6d85-9e07-4acb-a769-01aa4f7cb6e4)
