### PR TITLE
Improve `jax.distributed.initialize` runtime error message

### DIFF
--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -258,7 +258,8 @@ def initialize(coordinator_address: str | None = None,
   """
   if xla_bridge.backends_are_initialized():
     raise RuntimeError("jax.distributed.initialize() must be called before "
-                        "any JAX computations are executed.")
+                        "any JAX calls that might initialise the XLA backend. "
+                        "This includes any computation, but also calls to jax.devices, jax.device_put, and others.")
   global_state.initialize(coordinator_address, num_processes, process_id,
                           local_device_ids, cluster_detection_method,
                           initialization_timeout, coordinator_bind_address)


### PR DESCRIPTION
The existing error thrown when `jax.distributed.initialize` is called improperly can be a bit confusing.  Consider the following example

```python
import jax
jax.devices()
jax.distributed.initialize()
```
currently produces an error message that would indicate a computation was called somewhere.
