### PR TITLE
Skip ragged collective tests on CPU

### DIFF
--- a/tests/ragged_collective_test.py
+++ b/tests/ragged_collective_test.py
@@ -33,6 +33,11 @@ config.parse_flags_with_absl()
 
 class RaggedCollectiveTest(jtu.JaxTestCase):
 
+  def setUp(self):
+    super().setUp()
+    if jtu.test_device_matches(["cpu"]):
+      self.skipTest("ragged-all-to-all is not supported on CPU")
+
   @parameterized.named_parameters(
       dict(
           testcase_name='_single_axis_name', axis_name='x', mesh_axes=dict(x=2)


### PR DESCRIPTION
The ragged-all-to-all op isn't supported on CPU. The CPU test isn't executed by bazel, but when running with pytest, it looks like we need to explicitly skip.

Fixes https://github.com/jax-ml/jax/issues/26203