### PR TITLE
Disable source mapper test for optimized hlo

### DIFF
--- a/tests/source_mapper_test.py
+++ b/tests/source_mapper_test.py
@@ -52,7 +52,8 @@ class SourceMapperTest(jtu.JaxTestCase):
   @parameterized.parameters(
       ("hlo:stable-hlo", "stablehlo.add", 13),
       ("hlo:original", "add", 0),
-      ("hlo:optimized", "add", 0),
+      # TODO(justinfu): Make the hlo:optimized test less strict.
+      # ("hlo:optimized", "add", 0),
   )
   def test_hlo_passes(self, pass_name, expected_hlo_op, expected_col):
     del expected_col


### PR DESCRIPTION
This test is too strict and breaks depending on the behavior of the compiler.