### PR TITLE
Adjust docs/conf.py to remove prompt when copying docs examples by default

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -307,6 +307,10 @@ epub_exclude_files = ['search.html']
 
 
 # -- Extension configuration -------------------------------------------------
+# Define prompt text pattern to be removed for copybutton
+# See  https://sphinx-copybutton.readthedocs.io/en/latest/use.html#using-regexp-prompt-identifiers
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
 
 # Tell sphinx autodoc how to render type aliases.
 autodoc_typehints = "description"


### PR DESCRIPTION
This PR adjusts `conf.py` to remove the prompt and output of docs examples when copied using the copy button extension. I have also tried the `copybutton_prompt_text = ">>> "` option, however this removes multiline inputs e.g. present when defining functions. It tested locally and it works as intended. Resolves #26210.