### PR TITLE
Make jnp.asarray lower to asarray_p in the simplest cases.

### DIFF
--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -46,6 +46,7 @@ from jax._src import dispatch
 from jax._src.interpreters import ad
 from jax._src.interpreters import batching
 from jax._src.interpreters import partial_eval as pe
+from jax._src.lax import lax as lax_internal
 from jax._src.lax.lax import (
   _const, ranges_like, remaining, _dot_general_batch_dim_nums, DotDimensionNumbers)
 from jax._src.lax.slicing import GatherDimensionNumbers, GatherScatterMode
@@ -2490,7 +2491,7 @@ class BCOO(JAXSparse):
 
   def __init__(self, args: tuple[Array, Array], *, shape: Sequence[int],
                indices_sorted: bool = False, unique_indices: bool = False):
-    self.data, self.indices = map(jnp.asarray, args)
+    self.data, self.indices = map(lax_internal.asarray, args)
     self.indices_sorted = indices_sorted
     self.unique_indices = unique_indices
     super().__init__(args, shape=tuple(shape))

--- a/jax/experimental/sparse/bcsr.py
+++ b/jax/experimental/sparse/bcsr.py
@@ -38,6 +38,7 @@ from jax._src import api_util
 from jax._src import config
 from jax._src import core
 from jax._src import dispatch
+from jax._src.lax import lax as lax_internal
 from jax._src.lax.lax import DotDimensionNumbers, _dot_general_batch_dim_nums
 from jax._src.lib import gpu_sparse
 from jax._src.lib.mlir.dialects import hlo
@@ -762,7 +763,7 @@ class BCSR(JAXSparse):
 
   def __init__(self, args: tuple[Array, Array, Array], *, shape: Sequence[int],
                indices_sorted: bool = False, unique_indices: bool = False):
-    self.data, self.indices, self.indptr = map(jnp.asarray, args)
+    self.data, self.indices, self.indptr = map(lax_internal.asarray, args)
     self.indices_sorted = indices_sorted
     self.unique_indices = unique_indices
     super().__init__(args, shape=shape)

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -64,6 +64,7 @@ from jax._src import sharding_impls
 from jax.experimental.sparse.bcoo import bcoo_multiply_dense, bcoo_multiply_sparse
 import jax.numpy as jnp
 from jax._src.api_util import flatten_fun_nokwargs
+from jax._src.lax import lax as lax_internal
 from jax._src.lib import pytree
 from jax._src.interpreters import partial_eval as pe
 from jax.tree_util import tree_flatten, tree_map, tree_unflatten
@@ -77,6 +78,7 @@ sparse_rules_bcoo : dict[core.Primitive, Callable] = {}
 sparse_rules_bcsr : dict[core.Primitive, Callable] = {}
 
 _zero_preserving_linear_unary_primitives = [
+  lax.asarray_p,
   lax.conj_p,
   lax.copy_p,
   lax.imag_p,
@@ -145,7 +147,7 @@ class SparsifyEnv:
     self._buffers = list(bufs)
 
   def _push(self, arr: Array) -> int:
-    self._buffers.append(jnp.asarray(arr))
+    self._buffers.append(lax_internal.asarray(arr))
     return len(self._buffers) - 1
 
   def data(self, spvalue: SparsifyValue) -> Array:

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -38,6 +38,7 @@ from jax._src.lax.lax import (
   argmax_p as argmax_p,
   argmin as argmin,
   argmin_p as argmin_p,
+  asarray_p as asarray_p,
   asin as asin,
   asin_p as asin_p,
   asinh as asinh,


### PR DESCRIPTION
This is an experiment toward a fix to #25745 and #18020.

Basically, we currently lower `jnp.asarray` to nothing in many cases, and this leads to strange behavior under some transformations; for example:
```python
In [1]: import jax

In [2]: import numpy as np

In [3]: out = jax.vmap(jax.numpy.asarray)(np.arange(4))

In [4]: type(out)
Out[4]: numpy.ndarray
```
The fix here ensures that `asarray` lowers to a primitive, so that these kinds of corner cases behave as expected.

Many of the test failures here should be fixed by work related to #25931, which removes calls to `jnp.asarray` from JAX API implementations.