### PR TITLE
Fix dtype issue in stirling approximation

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -2432,7 +2432,7 @@ def _stirling_approx_tail(k):
       dtype=k.dtype,
   )
   use_tail_values = k <= 9
-  k = lax.clamp(0.0, k, 9.0)
+  k = lax.clamp(_lax_const(k, 0.0), k, _lax_const(k, 9.0))
   kp1sq = (k + 1) * (k + 1)
   approx = (1.0 / 12 - (1.0 / 360 - 1.0 / 1260 / kp1sq) / kp1sq) / (k + 1)
   k = jnp.floor(k)

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -1243,6 +1243,13 @@ class LaxRandomTest(jtu.JaxTestCase):
     self.assertArraysAllClose(samples2, jnp.array([jnp.nan, 0., jnp.nan, jnp.nan]), check_dtypes=False)
     self.assertArraysAllClose(samples3, jnp.array([jnp.nan, jnp.nan, jnp.nan]), check_dtypes=False)
 
+  def test_binomial_dtypes(self):
+    # Regression test for https://github.com/jax-ml/jax/pull/25688#discussion_r1938010569
+    key = jax.random.key(0)
+    n = jax.numpy.float16(100)
+    p = jax.numpy.float16(0.5)
+    jax.random.binomial(key, n, p)  # doesn't error
+
   def test_batched_key_errors(self):
     keys = lambda: jax.random.split(self.make_key(0))
     msg = "{} accepts a single key, but was given a key array of shape.*"


### PR DESCRIPTION
Fixes the following repro:
```python
python -c "import jax; jax.random.binomial(jax.random.key(0), jax.numpy.float16(1), jax.numpy.float16(0.5))"
```
Related to https://github.com/jax-ml/jax/pull/25688#discussion_r1938010569