### PR TITLE
Format sourcemap directory names to work on windows

### DIFF
--- a/jax/experimental/source_mapper/generate_map.py
+++ b/jax/experimental/source_mapper/generate_map.py
@@ -42,7 +42,8 @@ def generate_sourcemaps(
     with tempfile.TemporaryDirectory() as work_dir:
       for pass_to_eval in passes:
         if pass_to_eval.compile_fn not in compile_cache:
-          pass_work_dir = os.path.join(work_dir, pass_to_eval.name)
+          dirname = pass_to_eval.name.replace(":", "__")
+          pass_work_dir = os.path.join(work_dir, dirname)
           os.makedirs(pass_work_dir, exist_ok=False)
           compile_result = pass_to_eval.compile_fn(
               pass_work_dir, f, args, kwargs


### PR DESCRIPTION
Fixes formatting errors for directory names on windows:

```
tests\source_mapper_test.py:64: in test_hlo_passes
    source_maps = source_mapper.generate_sourcemaps(
jax\experimental\source_mapper\generate_map.py:46: in wrapper
    os.makedirs(pass_work_dir, exist_ok=False)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\os.py:225: in makedirs
    mkdir(name, mode)
E   NotADirectoryError: [WinError 267] The directory name is invalid: 'C:\\Users\\RUNNER~1.RUN\\AppData\\Local\\Temp\\tmpsnp35v61\\hlo:stable-hlo'
```