### PR TITLE
[CI] Add upload to resultstore to tsan bazel test run

### DIFF
--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -198,4 +198,8 @@ jobs:
               --test_output=errors \
               --local_test_jobs=32 \
               --test_timeout=600 \
+              --config=resultstore \
+              --spawn_strategy=local \
+              --remote_cache=remotebuildexecution.googleapis.com \
+              --remote_instance_name=projects/tensorflow-testing/instances/default_instance \
               //tests:cpu_tests


### PR DESCRIPTION
Add uploading to result store for the tsan bazel test runs. 