### PR TITLE
[JAX][DOC] memory_kind, with_memory_kind and out_shardings

### DIFF
--- a/docs/sharded-computation.ipynb
+++ b/docs/sharded-computation.ipynb
@@ -270,7 +270,7 @@
    "source": [
     "The device numbers here are not in numerical order, because the mesh reflects the underlying toroidal topology of the device.\n",
     "\n",
-    "For all different sharding types such as {class}`~jax.sharding.NamedSharding`, {class}`~jax.sharding.SingleDeviceSharding`, {class}`~jax.sharding.PositionalSharding` and {class}`~jax.sharding.GSPMDSharding`, there is a parameter called `memory_kind`, which defaults to `device`. You can set this parameter to `pinned_host` if you prefer to place it on the host.\n",
+    "The {class}`~jax.sharding.NamedSharding` includes a parameter called `memory_kind`. This parameter determines the type of memory to be used and defaults to `device`. You can set this parameter to `pinned_host` if you prefer to place it on the host.\n",
     "\n",
     "To create a new sharding that only differs from an existing sharding in terms of its memory kind, you can use the `with_memory_kind` method on the existing sharding."
    ]

--- a/docs/sharded-computation.ipynb
+++ b/docs/sharded-computation.ipynb
@@ -264,10 +264,52 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "UEObolTqw4pp"
+   },
    "source": [
     "The device numbers here are not in numerical order, because the mesh reflects the underlying toroidal topology of the device.\n",
     "\n",
+    "For all different sharding types such as {class}`~jax.sharding.NamedSharding`, {class}`~jax.sharding.SingleDeviceSharding`, {class}`~jax.sharding.PositionalSharding` and {class}`~jax.sharding.GSPMDSharding`, there is a parameter called `memory_kind`, which defaults to `device`. You can set this parameter to `pinned_host` if you prefer to place it on the host.\n",
+    "\n",
+    "To create a new sharding that only differs from an existing sharding in terms of its memory kind, you can use the `with_memory_kind` method on the existing sharding."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "aKNeOHTJnqmS",
+    "outputId": "847c53ec-8b2e-4be0-f993-7fde7d77c0f2"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pinned_host\n",
+      "device\n"
+     ]
+    }
+   ],
+   "source": [
+    "s_host = jax.NamedSharding(mesh, P('x', 'y'), memory_kind='pinned_host')\n",
+    "s_dev = s_host.with_memory_kind('device')\n",
+    "arr_host = jax.device_put(arr, s_host)\n",
+    "arr_dev = jax.device_put(arr, s_dev)\n",
+    "print(arr_host.sharding.memory_kind)\n",
+    "print(arr_dev.sharding.memory_kind)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jDHYnVqHwaST"
+   },
+   "source": [
     "## 1. Automatic parallelism via `jit`\n",
     "\n",
     "Once you have sharded data, the easiest way to do parallel computation is to simply pass the data to a {func}`jax.jit`-compiled function! In JAX, you need to only specify how you want the input and output of your code to be partitioned, and the compiler will figure out how to: 1) partition everything inside; and 2) compile inter-device communications.\n",
@@ -354,10 +396,98 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "Q4N5mrr9i_ki"
+   },
    "source": [
     "The result is partially replicated: that is, the first two elements of the array are replicated on devices `0` and `6`, the second on `1` and `7`, and so on.\n",
     "\n",
+    "### 1.1 Sharding transformation between memory types\n",
+    "\n",
+    "The output sharding of a {func}`jax.jit` function can differ from the input sharding if you specify the output sharding using the `out_shardings` parameter. Specifically, the `memory_kind` of the output can be different from that of the input array.\n",
+    "\n",
+    "#### Example 1: Pinned host to device memory\n",
+    "\n",
+    "In the example below, the {func}`jax.jit` function `f` takes an array sharded in `pinned_host` memory and generates an array in `device` memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "PXu3MhafyRHo",
+    "outputId": "7bc6821f-a4a9-4cf8-8b21-e279d516d27b"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[ 0.  1.  2.  3.  4.  5.  6.  7.]\n",
+      " [ 8.  9. 10. 11. 12. 13. 14. 15.]\n",
+      " [16. 17. 18. 19. 20. 21. 22. 23.]\n",
+      " [24. 25. 26. 27. 28. 29. 30. 31.]]\n",
+      "device\n"
+     ]
+    }
+   ],
+   "source": [
+    "f = jax.jit(lambda x: x, out_shardings=s_dev)\n",
+    "out_dev = f(arr_host)\n",
+    "print(out_dev)\n",
+    "print(out_dev.sharding.memory_kind)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LuYFqpcBySiX"
+   },
+   "source": [
+    "#### Example 2: Device to pinned_host memory\n",
+    "\n",
+    "In the example below, the {func}`jax.jit` function `g` takes an array sharded in `device` memory and generates an array in `pinned_host` memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "qLsgNlKfybRw",
+    "outputId": "a16448b9-7e39-408f-b200-505f65ad4464"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[ 0.  1.  2.  3.  4.  5.  6.  7.]\n",
+      " [ 8.  9. 10. 11. 12. 13. 14. 15.]\n",
+      " [16. 17. 18. 19. 20. 21. 22. 23.]\n",
+      " [24. 25. 26. 27. 28. 29. 30. 31.]]\n",
+      "pinned_host\n"
+     ]
+    }
+   ],
+   "source": [
+    "g = jax.jit(lambda x: x, out_shardings=s_host)\n",
+    "out_host = g(arr_dev)\n",
+    "print(out_host)\n",
+    "print(out_host.sharding.memory_kind)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7BGD31-owaSU"
+   },
+   "source": [
     "## 2. Semi-automated sharding with constraints\n",
     "\n",
     "If you'd like to have some control over the sharding used within a particular computation, JAX offers the {func}`~jax.lax.with_sharding_constraint` function. You can use {func}`jax.lax.with_sharding_constraint` (in place of {func}`jax.device_put()`) together with {func}`jax.jit` for more control over how the compiler constraints how the intermediate values and outputs are distributed.\n",

--- a/docs/sharded-computation.md
+++ b/docs/sharded-computation.md
@@ -94,7 +94,7 @@ jax.debug.visualize_array_sharding(arr_sharded)
 
 The device numbers here are not in numerical order, because the mesh reflects the underlying toroidal topology of the device.
 
-For all different sharding types such as {class}`~jax.sharding.NamedSharding`, {class}`~jax.sharding.SingleDeviceSharding`, {class}`~jax.sharding.PositionalSharding` and {class}`~jax.sharding.GSPMDSharding`, there is a parameter called `memory_kind`, which defaults to `device`. You can set this parameter to `pinned_host` if you prefer to place it on the host.
+The {class}`~jax.sharding.NamedSharding` includes a parameter called `memory_kind`. This parameter determines the type of memory to be used and defaults to `device`. You can set this parameter to `pinned_host` if you prefer to place it on the host.
 
 To create a new sharding that only differs from an existing sharding in terms of its memory kind, you can use the `with_memory_kind` method on the existing sharding.
 

--- a/docs/sharded-computation.md
+++ b/docs/sharded-computation.md
@@ -90,7 +90,30 @@ print(arr_sharded)
 jax.debug.visualize_array_sharding(arr_sharded)
 ```
 
++++ {"id": "UEObolTqw4pp"}
+
 The device numbers here are not in numerical order, because the mesh reflects the underlying toroidal topology of the device.
+
+For all different sharding types such as {class}`~jax.sharding.NamedSharding`, {class}`~jax.sharding.SingleDeviceSharding`, {class}`~jax.sharding.PositionalSharding` and {class}`~jax.sharding.GSPMDSharding`, there is a parameter called `memory_kind`, which defaults to `device`. You can set this parameter to `pinned_host` if you prefer to place it on the host.
+
+To create a new sharding that only differs from an existing sharding in terms of its memory kind, you can use the `with_memory_kind` method on the existing sharding.
+
+```{code-cell}
+---
+colab:
+  base_uri: https://localhost:8080/
+id: aKNeOHTJnqmS
+outputId: 847c53ec-8b2e-4be0-f993-7fde7d77c0f2
+---
+s_host = jax.NamedSharding(mesh, P('x', 'y'), memory_kind='pinned_host')
+s_dev = s_host.with_memory_kind('device')
+arr_host = jax.device_put(arr, s_host)
+arr_dev = jax.device_put(arr, s_dev)
+print(arr_host.sharding.memory_kind)
+print(arr_dev.sharding.memory_kind)
+```
+
++++ {"id": "jDHYnVqHwaST"}
 
 ## 1. Automatic parallelism via `jit`
 
@@ -129,7 +152,51 @@ jax.debug.visualize_array_sharding(result)
 print(result)
 ```
 
++++ {"id": "Q4N5mrr9i_ki"}
+
 The result is partially replicated: that is, the first two elements of the array are replicated on devices `0` and `6`, the second on `1` and `7`, and so on.
+
+### 1.1 Sharding transformation between memory types
+
+The output sharding of a {func}`jax.jit` function can differ from the input sharding if you specify the output sharding using the `out_shardings` parameter. Specifically, the `memory_kind` of the output can be different from that of the input array.
+
+#### Example 1: Pinned host to device memory
+
+In the example below, the {func}`jax.jit` function `f` takes an array sharded in `pinned_host` memory and generates an array in `device` memory.
+
+```{code-cell}
+---
+colab:
+  base_uri: https://localhost:8080/
+id: PXu3MhafyRHo
+outputId: 7bc6821f-a4a9-4cf8-8b21-e279d516d27b
+---
+f = jax.jit(lambda x: x, out_shardings=s_dev)
+out_dev = f(arr_host)
+print(out_dev)
+print(out_dev.sharding.memory_kind)
+```
+
++++ {"id": "LuYFqpcBySiX"}
+
+#### Example 2: Device to pinned_host memory
+
+In the example below, the {func}`jax.jit` function `g` takes an array sharded in `device` memory and generates an array in `pinned_host` memory.
+
+```{code-cell}
+---
+colab:
+  base_uri: https://localhost:8080/
+id: qLsgNlKfybRw
+outputId: a16448b9-7e39-408f-b200-505f65ad4464
+---
+g = jax.jit(lambda x: x, out_shardings=s_host)
+out_host = g(arr_dev)
+print(out_host)
+print(out_host.sharding.memory_kind)
+```
+
++++ {"id": "7BGD31-owaSU"}
 
 ## 2. Semi-automated sharding with constraints
 


### PR DESCRIPTION
Add documentation for the `memory_kind` parameter in sharding, the `with_memory_kind` method, and the `out_shardings` parameter for specifying output sharding in the {func}`jax.jit` function.