### PR TITLE
Readded missing part to use locally built numpy in the build in tsan.yml

### DIFF
--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -50,7 +50,7 @@ jobs:
           path: numpy
           submodules: true
 
-      - name: Restore cached CPython with TSAN
+      - name: Restore cached TSAN CPython
         id: cache-cpython-tsan-restore
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -58,7 +58,7 @@ jobs:
             ./python-tsan.tgz
           key: ${{ runner.os }}-cpython-tsan-${{ hashFiles('cpython/configure.ac') }}
 
-      - name: Build CPython with TSAN enabled
+      - name: Build CPython with enabled TSAN
         if: steps.cache-cpython-tsan-restore.outputs.cache-hit != 'true'
         run: |
           cd cpython
@@ -172,6 +172,10 @@ jobs:
             --bazel_options=--linkopt="-fsanitize=thread" \
             --bazel_options=--copt=-g \
             --clang_path=/usr/bin/clang-18
+
+          # Update the patch to use TSAN instrumented numpy
+          sed -i "s|+--extra-index-url.*|+--extra-index-url file://${GITHUB_WORKSPACE}/wheelhouse/|" .github/workflows/requirements_lock_3_13_ft.patch
+          cat .github/workflows/requirements_lock_3_13_ft.patch
 
           # Apply a patch to numpy in requirements lock 3.13 ft to use the nightly version
           git apply .github/workflows/requirements_lock_3_13_ft.patch


### PR DESCRIPTION
In this PR: https://github.com/jax-ml/jax/pull/26261 when I rebased on main with the revert: https://github.com/jax-ml/jax/pull/26260 the I made an incomplete rebase. 

This PR readds the missing part to use locally built numpy in the build in tsan.yml

cc @hawkinsp 