### PR TITLE
Add type annotation for zero_from_primal

### DIFF
--- a/jax/_src/ad_util.py
+++ b/jax/_src/ad_util.py
@@ -120,7 +120,7 @@ class SymbolicZero:
   def from_primal_value(val: Any) -> SymbolicZero:
     return SymbolicZero(get_aval(val).to_tangent_aval())
 
-def zero_from_primal(val, symbolic_zeros=False):
+def zero_from_primal(val: T, symbolic_zeros: bool = False) -> T:
   def f(x):
     tangent_aval = get_aval(x).to_tangent_aval()
     if symbolic_zeros:


### PR DESCRIPTION
Would be nice to also change the signature to:
```python
def zero_from_primal(val: T, /, *, symbolic_zeros: bool = False) -> T:
```
Generally, Boolean parameters should be keyword-only arguments since passing a Boolean value is inscrutable.  And `val` should probably be positional-only since its name is unuseful.

I believe this function can transform `jax.Array` to `np.NDArray[jax.numpy.float0]`, but I believe that the latter array is for all intents and purposes a `jax.Array` as discussed in various issues.