### PR TITLE
Expose checkpoint name in cuDNN SDPA

### DIFF
--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -32,6 +32,7 @@ from jax.interpreters.mlir import hlo
 from jax.interpreters.mlir import ir
 import jax.numpy as jnp
 from jax.sharding import NamedSharding, PartitionSpec
+from jax.ad_checkpoint import checkpoint_name
 
 Array = jnp.ndarray
 
@@ -388,7 +389,7 @@ def check_compute_capability(capability):
 def _dot_product_attention_fwd(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, cudnn_version):
+    sliding_window_length, cudnn_version, outputs_checkpoint_name):
   # check if flash attention is supported for this attention pattern
   check_is_flash_attention(
       query, key, layout, cudnn_version, bias is not None, False,
@@ -404,7 +405,7 @@ def _dot_product_attention_fwd(
 def _dot_product_attention_fwd_rule(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, cudnn_version):
+    sliding_window_length, cudnn_version, outputs_checkpoint_name):
   # check if flash attention is supported for this attention pattern
   check_is_flash_attention(
       query, key, layout, cudnn_version, bias is not None, True,
@@ -414,13 +415,19 @@ def _dot_product_attention_fwd_rule(
       scale=scale, seed=seed, dropout_rate=dropout_rate,
       variadic_args=variadic_args, mask_type=mask_type, layout=layout,
       sliding_window_length=sliding_window_length, is_training=True)
+  if outputs_checkpoint_name:
+    output = checkpoint_name(outputs[0], outputs_checkpoint_name)
+    softmax_stat = checkpoint_name(outputs[1], outputs_checkpoint_name)
+  else:
+    output, softmax_stat = outputs
   res = (query, key, value, bias, q_seqlen, kv_seqlen, q_offsets,
-         kv_offsets, outputs[1], outputs[0])
-  return outputs[0], res
+         kv_offsets, softmax_stat, output)
+  return output, res
 
 def _dot_product_attention_bwd_rule(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, is_training, res, grad_output):
+    sliding_window_length, cudnn_version, outputs_checkpoint_name,
+    res, grad_output):
   (query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
    activation, fwd_output) = res
   grads = _dot_product_attention_bwd_p_wrapper.bind(
@@ -1090,7 +1097,7 @@ dispatch.prim_requires_devices_during_lowering.add(
   _dot_product_attention_bwd_p_wrapper
 )
 
-@functools.partial(jax.custom_vjp, nondiff_argnums=(8, 9, 10, 11, 12, 13, 14, 15))
+@functools.partial(jax.custom_vjp, nondiff_argnums=(8, 9, 10, 11, 12, 13, 14, 15, 16))
 def _dot_product_attention(query: Array,
                            key: Array,
                            value: Array,
@@ -1106,13 +1113,15 @@ def _dot_product_attention(query: Array,
                            mask_type: bool,
                            layout: int,
                            sliding_window_length: int | None,
-                           cudnn_version: int):
+                           cudnn_version: int,
+                           outputs_checkpoint_name: str):
   output = _dot_product_attention_fwd(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       scale=scale, seed=seed, dropout_rate=dropout_rate,
       variadic_args=variadic_args, mask_type=mask_type, layout=layout,
       sliding_window_length=sliding_window_length,
-      cudnn_version=cudnn_version)
+      cudnn_version=cudnn_version,
+      outputs_checkpoint_name=outputs_checkpoint_name)
   return output
 
 _dot_product_attention.defvjp(
@@ -1712,7 +1721,8 @@ def dot_product_attention(
     dropout_rate: float = 0.,
     qkv_layout: str = "BTNH",
     sliding_window_length: int | None = None,
-    use_fp8: bool = False
+    use_fp8: bool = False,
+    outputs_checkpoint_name: str = ""
 ):
   """Computes dot-product attention given query (Q), key (K), and value (V).
 
@@ -1768,6 +1778,8 @@ def dot_product_attention(
       is the index of each token. E.g., if sliding_window_length == 3 and the
       sequence is [0, 1, 2, 3, c, 4, 5], token `c` can attend to [4, 5, c].
     use_fp8: Whether to use FP8 attention mechanism.
+    outputs_checkpoint_name: checkpoint name for output tensor and softmax stat
+      tensor.
   Returns:
     Output of the same shape as the query.
     amax_s: amax of state. (fp8 only)
@@ -1843,5 +1855,5 @@ def dot_product_attention(
     output = _dot_product_attention(
         query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
         scale, seed, dropout_rate, variadic_args, mask_type, layout.value,
-        sliding_window_length, cudnn_version)
+        sliding_window_length, cudnn_version, outputs_checkpoint_name)
     return output


### PR DESCRIPTION
This allows users to specify SDPA outputs checkpoint in JAX to avoid recomputation if jax.remat is used.