### PR TITLE
[better_errors] Continue adding debug info to Jaxprs (step 4)

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2060,10 +2060,9 @@ def linear_transpose(fun: Callable, *primals, reduce_axes=()) -> Callable:
     shape/dtypes/structure as ``primals``.
 
   >>> import jax
-  >>> import types
   >>>
   >>> f = lambda x, y: 0.5 * x - 0.5 * y
-  >>> scalar = types.SimpleNamespace(shape=(), dtype=np.dtype(np.float32))
+  >>> scalar = jax.ShapeDtypeStruct(shape=(), dtype=np.dtype(np.float32))
   >>> f_transpose = jax.linear_transpose(f, scalar, scalar)
   >>> f_transpose(1.0)
   (Array(0.5, dtype=float32), Array(-0.5, dtype=float32))

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -640,7 +640,8 @@ class Trace(Generic[TracerType]):
            "to handle custom_jvp primitives")
     raise NotImplementedError(msg)
 
-  def process_custom_transpose(self, prim, call, tracers, **params):
+  def process_custom_transpose(self, prim: Primitive,
+                               call: lu.WrappedFun, tracers, **params):
     msg = (f"{type(self)} must override process_custom_transpose "
            "to handle custom_transpose_call primitives")
     raise NotImplementedError(msg)

--- a/jax/_src/custom_transpose.py
+++ b/jax/_src/custom_transpose.py
@@ -31,7 +31,8 @@ from jax._src.interpreters import mlir
 from jax._src.interpreters import partial_eval as pe
 from jax._src.interpreters import xla
 from jax._src.tree_util import (tree_flatten, tree_leaves, tree_map,
-                                tree_structure, treedef_tuple, tree_unflatten)
+                                tree_structure, treedef_tuple, tree_unflatten,
+                                PyTreeDef)
 
 
 source_info_util.register_exclusion(__file__)
@@ -90,10 +91,20 @@ class custom_transpose:
     # TODO(frostig,mattjj): could, and should, we avoid flattening
     # self.fun at this point?
 
-    flat_fun, out_tree2 = flatten_fun_nokwargs(lu.wrap_init(self.fun), in_tree)
+    flat_fun, out_tree2 = flatten_fun_nokwargs(
+        lu.wrap_init(
+            self.fun,
+            debug_info=api_util.debug_info("custom_transpose fun", self.fun,
+                                           (res_arg, lin_arg), {})),
+        in_tree)
     out_types_flat, out_tree = tree_flatten(out_types)
+    transpose_wrapped = lu.wrap_init(
+        self.transpose,
+        debug_info=api_util.debug_info("custom_transpose transpose_fun",
+                                       self.transpose,
+                                       (res_arg, out_types), {})                             )
     out_flat = custom_transpose_p.bind(flat_fun, *args_flat,
-                                       transpose=self.transpose,
+                                       transpose=transpose_wrapped,
                                        out_types=out_types_flat,
                                        lin_tree=lin_tree,
                                        res_tree=res_tree,
@@ -125,19 +136,20 @@ def is_treedef_prefix(entire, prefix):
 def rule_name(rule):
   return getattr(rule, '__name__', '<unnamed transpose rule>')
 
-def check_transpose_rule_trees(rule, lin_tree, rule_out_tree):
+def check_transpose_rule_trees(rule: lu.WrappedFun,
+                               lin_tree: PyTreeDef,
+                               rule_out_tree: PyTreeDef):
   if not is_treedef_prefix(lin_tree, rule_out_tree):
-    if hasattr(rule, '_transpose_type_error'):
-      raise rule._transpose_type_error(lin_tree, rule_out_tree)
-    else:
-      raise TypeError(
-          'structure of custom transpose rule\'s output does not prefix-match '
-          'structure of primal function\'s linear inputs under '
-          f'custom transpose rule ({rule_name(rule)}).\n'
-          f'Transpose rule output: {rule_out_tree}\n'
-          f'Linear primal inputs: {lin_tree}')
+    rule_name = rule.debug_info.func_src_info if rule.debug_info else "<unknown>"
+    raise TypeError(
+        'structure of custom transpose rule\'s output does not prefix-match '
+        'structure of primal function\'s linear inputs under '
+        f'custom transpose rule ({rule_name}).\n'
+        f'Transpose rule output: {rule_out_tree}\n'
+        f'Linear primal inputs: {lin_tree}')
 
-def make_transpose_from_thunk(thunk, lin_tree):
+def make_transpose_from_thunk(thunk: Callable,
+                              lin_tree: PyTreeDef) -> lu.WrappedFun:
   transpose_jaxpr, transpose_consts = thunk()
   transpose_jaxpr = core.ClosedJaxpr(
       pe.convert_constvars_jaxpr(transpose_jaxpr), ())
@@ -145,7 +157,7 @@ def make_transpose_from_thunk(thunk, lin_tree):
     args_flat = tree_leaves((res_arg, ct_out))
     ct_ins = core.jaxpr_as_fun(transpose_jaxpr)(*transpose_consts, *args_flat)
     return tree_unflatten(lin_tree, ct_ins)
-  return transpose
+  return lu.wrap_init(transpose, debug_info=transpose_jaxpr.jaxpr.debug_info)
 
 
 ### custom_transpose primitive and rules
@@ -167,11 +179,13 @@ class CustomTransposePrimitive(core.Primitive):
   def get_bind_params(self, params):
     assert 'call_jaxpr' in params
     assert 'transpose_jaxpr_thunk' in params
-    new_params = dict(params)
+    new_params: dict[str, Any] = dict(params)
     new_params['transpose'] = make_transpose_from_thunk(
         new_params.pop('transpose_jaxpr_thunk'),
         new_params['lin_tree'])
-    call = lu.wrap_init(core.jaxpr_as_fun(new_params.pop('call_jaxpr')))
+    call_jaxpr: core.ClosedJaxpr = new_params.pop('call_jaxpr')
+    call = lu.wrap_init(core.jaxpr_as_fun(call_jaxpr),
+                        debug_info=call_jaxpr.jaxpr.debug_info)
     return [call], new_params
 
 
@@ -183,7 +197,7 @@ def custom_transpose_typecheck(_, *in_atoms, out_types, **params):
 
 def custom_transpose_transpose_rule(
     cts, *args, out_types, res_tree, lin_tree, out_tree, **params):
-
+  transpose: lu.WrappedFun
   if 'transpose_jaxpr_thunk' in params:
     assert 'call_jaxpr' in params
     transpose = make_transpose_from_thunk(
@@ -205,7 +219,7 @@ def custom_transpose_transpose_rule(
   cts = [ad_util.zeros_like_aval(ct.aval) if type(ct) is ad_util.Zero else ct
          for ct in cts]
   ct_out = tree_unflatten(out_tree, cts)
-  ct_lin = transpose(res_arg, ct_out)
+  ct_lin = transpose.call_wrapped(res_arg, ct_out)
   check_transpose_rule_trees(transpose, lin_tree, tree_structure(ct_lin))
   ct_lin_flat, _ = tree_flatten(
       tree_broadcast(lin_tree, ct_lin, is_leaf=lambda x: x is None),

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -2056,9 +2056,12 @@ class DynamicJaxprTrace(core.Trace):
     self.frame.add_eqn(eqn)
     return out_tracers
 
-  def process_custom_transpose(self, prim, call, tracers, *,
-                               transpose, out_types,
-                               lin_tree, res_tree, out_tree):
+  def process_custom_transpose(self, prim: core.Primitive,  # type: ignore[override]
+                               call: lu.WrappedFun, tracers, *,
+                               transpose: lu.WrappedFun,
+                               out_types,
+                               lin_tree: PyTreeDef,
+                               res_tree: PyTreeDef, out_tree: PyTreeDef):
     tracers = map(self.to_jaxpr_tracer, tracers)
     tracers_res, tracers_lin = split_list(tracers, [res_tree.num_leaves])
 
@@ -2070,7 +2073,7 @@ class DynamicJaxprTrace(core.Trace):
         convert_constvars_jaxpr(call_jaxpr), ())
 
     transpose_flat, in_tree2 = api_util.flatten_fun_nokwargs(
-        lu.wrap_init(transpose), treedef_tuple((res_tree, out_tree)))
+        transpose, treedef_tuple((res_tree, out_tree)))
 
     # the following thunk evaluates to a pair: transpose_jaxpr, transpose_consts
     @_memoize

--- a/jax/_src/linear_util.py
+++ b/jax/_src/linear_util.py
@@ -318,7 +318,7 @@ def wrap_init(f: Callable, params=None, *,
   """Wraps function `f` as a `WrappedFun`, suitable for transformation."""
   params_dict = {} if params is None else params
   params = () if params is None else tuple(sorted(params.items()))
-  fun = WrappedFun(f, partial(f, **params_dict), (), (), params, None, None)
+  fun = WrappedFun(f, partial(f, **params_dict), (), (), params, None, debug_info)
   if debug_info:
     if debug_info.result_paths is None:
       fun, result_paths_thunk = _get_result_paths_thunk(fun)

--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -19,6 +19,7 @@ from jax._src.core import (
 
 from jax._src.api_util import (
   argnums_partial as argnums_partial,
+  debug_info as debug_info,
   donation_vector as donation_vector,
   flatten_axes as flatten_axes,
   flatten_fun as flatten_fun,

--- a/tests/debug_info_test.py
+++ b/tests/debug_info_test.py
@@ -27,7 +27,6 @@ from jax import lax
 
 import jax.custom_batching
 import jax.custom_derivatives
-import jax.custom_transpose
 from jax.experimental import checkify
 import jax.experimental.custom_dce
 from jax.experimental import pallas as pl
@@ -42,6 +41,7 @@ from jax._src import api_util
 from jax._src.ad_checkpoint import saved_residuals
 from jax._src import config
 from jax._src import core
+from jax._src import custom_transpose
 from jax._src import test_util as jtu
 from jax._src.compilation_cache import is_persistent_cache_enabled
 from jax._src.lax.control_flow import for_loop
@@ -96,17 +96,18 @@ class TracerSpy:
   def __init__(self):
     self.tracers = []
 
-  def append(self, t: Any):
-    try:
-      # We plan to do boolean conversion and catch the exception, but this works
-      # only for scalars
-      if isinstance(t, core.Tracer) and t.shape:
-        t = jnp.sum(t)
-      if t:
-        pass
-      assert False, t
-    except Exception as e:
-      self.tracers.append((t, e))
+  def append(self, t: Any) -> None:
+    if isinstance(t, core.Tracer):
+      try:
+        # We plan to do boolean conversion and catch the exception, but this works
+        # only for scalars
+        if t.shape:
+          t = jnp.sum(t)
+        if t:
+          pass
+        assert False, t
+      except Exception as e:
+        self.tracers.append((t, e))
 
 
 @jtu.with_config(jax_mutable_array_checks=True)
@@ -120,7 +121,7 @@ class DebugInfoTest(jtu.JaxTestCase):
                                 check_lowering: bool = True,
                                 check_tracer_arg_name: bool = False,
                                 expected_lowering_lines: list[str | re.Pattern] = [],
-                                **kwargs):
+                                **kwargs) -> None:
     """Checks for expected debug info in all jaxprs, and in inspected tracers.
 
     `traceable` will be traced as `traceable.trace(*args, **kwargs)` if it has
@@ -204,7 +205,7 @@ class DebugInfoTest(jtu.JaxTestCase):
                      expected: list[str | re.Pattern],
                      found: list[str],
                      what: str,
-                     report_found_unexpected: bool = True):
+                     report_found_unexpected: bool = True) -> None:
     expected_and_found: set[str | re.Pattern] = set()
     found_and_expected: set[str] = set()
     for exp_re in expected:
@@ -695,14 +696,12 @@ class DebugInfoTest(jtu.JaxTestCase):
         (1.,), {"hi": 2.}, 3., 4., 5., 6.,  # x, y, z, args[0], args[1], args[2]
         t=11., w=12.,  # kwargs
         expected_jaxpr_debug_infos=[
-            # TODO(necula): the arg_names include the dead ones
             "traced_for=jit, fun=my_f, arg_names=y['hi'],z,args[0],args[1],kwargs['t'],kwargs['w'], result_paths=",
         ],
         tracer_spy=tracer_spy,
         check_tracer_arg_name=True,
         expected_tracer_debug_infos=[
             "traced_for=jit, fun=my_f, arg_names=y['hi'],z,args[0],args[1],kwargs['t'],kwargs['w'], from kwargs['w']",
-            "None",  # TODO(necula) missing debug info
         ],
         expected_lowering_lines=[
             re.compile(r".*func.func public @main\(%arg0: tensor<f..> loc\(\"y\['hi'\]\"\)"),
@@ -1025,30 +1024,98 @@ class DebugInfoTest(jtu.JaxTestCase):
             "traced_for=jit, fun=<lambda>, arg_names=xy[0],xy[1], from None",
         ])
 
-  def test_vmap_of_nested_jit(self):
+  def test_custom_transpose(self):
+    # Helpers from api_test.py
+    class _custom_transpose:
+      def __init__(self, out_types, fun):
+        self.out_types = out_types
+        self.fun = custom_transpose.custom_transpose(fun)
+
+      def __getattr__(self, name):
+        return getattr(self.fun, name)
+
+      def __call__(self, *args):
+        return self.fun(self.out_types, *args)
+
+    def custom_transpose_with_example_out(example_out):
+      return functools.partial(
+          _custom_transpose,
+          jax.tree.map(
+              lambda x: core.get_aval(x).to_tangent_aval(), example_out))
+
     tracer_spy = TracerSpy()
-    def my_f(x, y):
-      tracer_spy.append(x)
+    def my_f_with_cond(i, x):
+      def my_f(x):
+        tracer_spy.append(x)
+        @custom_transpose_with_example_out(jnp.ones(2))
+        def fn(r, x):
+          tracer_spy.append(r)
+          tracer_spy.append(x["c"])
+          return dict(b=x["c"] / r)
 
-      def my_g(u, v):
-        tracer_spy.append(u)
-        return dict(c=u * v, d=v)
+        @fn.def_transpose
+        def fn_tp(r, t):
+          tracer_spy.append(r)
+          return dict(c=2 * t / r)
 
-      return jax.jit(my_g)(y, x)["c"]
+        return x["c"] + fn(jnp.ones(2) * 3., x)
 
+      return lax.cond(i > 0, my_f, lambda x: x["c"], dict(c=x))
+
+    x = jnp.ones(2) * 6.
     self._check_tracers_and_jaxprs(
-        jax.jit(jax.vmap(my_f)),
-        np.ones((8,), dtype=np.float32), np.zeros((8,), dtype=np.float32),
+        jax.jit(lambda x: jax.linear_transpose(functools.partial(my_f_with_cond, 7.),
+                                               x)),
+        x,
         tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=x,y, result_paths=",
-            "traced_for=jit, fun=my_g, arg_names=u,v, result_paths=['c']",
+            "traced_for=cond, fun=my_f, arg_names=x['c'], result_paths=",
+            "traced_for=cond, fun=<lambda>, arg_names=x['c'], result_paths=",
+            # TODO(necula): flat_index?
+            "traced_for=jit, fun=<lambda>, arg_names=x, result_paths=[<flat index 0>][0][0],[<flat index 0>][0][1]",
         ],
+        check_tracer_arg_name=True,
         expected_tracer_debug_infos=[
-            # TODO(necula): missing debug info
-            "None",
-            "traced_for=jit, fun=my_g, arg_names=u,v"
+            "traced_for=custom_transpose fun, fun=fn, arg_names=r,x['c'], from r",
+            "traced_for=custom_transpose fun, fun=fn, arg_names=r,x['c'], from x['c']",
+            "traced_for=custom_transpose transpose_fun, fun=fn_tp, arg_names=r,t, from r",
         ])
+
+  def test_linear_call(self):
+    tracer_spy = TracerSpy()
+    def my_f(x, y):
+      tracer_spy.append(y)
+      def fn(r, x):
+        tracer_spy.append(r)
+        tracer_spy.append(x["c"])
+        return dict(b=x["c"] * r)
+      def fn_tp(r, t):
+        tracer_spy.append(t["b"])
+        return dict(c=t["b"] * r)
+      return dict(a=x["c"] + jax.custom_derivatives.linear_call(fn, fn_tp, y, x)["b"])
+
+    f1 = lambda x: my_f(x, jnp.ones(2) * 3.)
+    x = jnp.ones(2) * 6.
+
+    self._check_tracers_and_jaxprs(
+        jax.jit(lambda x: jax.linear_transpose(f1, dict(c=x))(dict(a=x))),
+        x,
+        tracer_spy=tracer_spy,
+        expected_jaxpr_debug_infos=[
+            "traced_for=jit, fun=<lambda>, arg_names=x, result_paths=[0]['c']",
+            "traced_for=linear_call fun, fun=fn, arg_names=r,x['c'], result_paths=['b']",
+            "traced_for=linear_call fun_transpose, fun=fn_tp, arg_names=r,t['c'], result_paths=['c']",
+        ],
+        check_tracer_arg_name=True,
+        expected_tracer_debug_infos=[
+            # TODO(necula): from None?
+            "traced_for=jit, fun=<lambda>, arg_names=x, from None",
+            "traced_for=linear_call fun, fun=fn, arg_names=r,x['c'], from r",
+            "traced_for=linear_call fun, fun=fn, arg_names=r,x['c'], from x['c']",
+            "traced_for=linear_call fun_transpose, fun=fn_tp, arg_names=r,t['c'], from t['c']",
+        ]),
+
+
 
   def test_custom_vmap(self):
     tracer_spy = TracerSpy()
@@ -1341,6 +1408,31 @@ class DebugInfoTest(jtu.JaxTestCase):
         expected_tracer_debug_infos=[
             "traced_for=jit, fun=my_f, arg_names=x"],
     )
+
+  def test_vmap_of_nested_jit(self):
+    tracer_spy = TracerSpy()
+    def my_f(x, y):
+      tracer_spy.append(x)
+
+      def my_g(u, v):
+        tracer_spy.append(u)
+        return dict(c=u * v, d=v)
+
+      return jax.jit(my_g)(y, x)["c"]
+
+    self._check_tracers_and_jaxprs(
+        jax.jit(jax.vmap(my_f)),
+        np.ones((8,), dtype=np.float32), np.zeros((8,), dtype=np.float32),
+        tracer_spy=tracer_spy,
+        expected_jaxpr_debug_infos=[
+            "traced_for=jit, fun=my_f, arg_names=x,y, result_paths=",
+            "traced_for=jit, fun=my_g, arg_names=u,v, result_paths=['c']",
+        ],
+        expected_tracer_debug_infos=[
+            # TODO(necula): missing debug info
+            "None",
+            "traced_for=jit, fun=my_g, arg_names=u,v"
+        ])
 
   def test_pmap(self):
     tracer_spy = TracerSpy()


### PR DESCRIPTION
This follows after #26078, #26313, #26348, adding `debug_info` to more calls to `lu.wrap_init`.

As part of this I have changed the primitive `custom_transpose` to take the `transpose` parameter as a `lu.WrappedFun`, which carries debug info. Previously, this was a `Callable`.

These changes ensure that all the `lu.wrap_init` and `Jaxpr` are called with debug_info in the `api_test.py:CustomTransposeTest`.