### PR TITLE
[better_errors] Continue adding debug info to Jaxprs (step 5)

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -610,10 +610,17 @@ def fun_signature(fun: Callable) -> inspect.Signature | None:
   except (ValueError, TypeError):
     return None
 
-def save_wrapped_fun_sourceinfo(wrapper: Callable, wrapped: Callable):
+def save_wrapped_fun_sourceinfo(wrapper: Callable,
+                                wrapped: Callable | core.DebugInfo | None) -> None:
   # Prefer this to functools.wraps because it does not create a reference to
   # the wrapped function.
-  setattr(wrapper, "__fun_sourceinfo__", fun_sourceinfo(wrapped))
+  if isinstance(wrapped, core.DebugInfo):
+    func_src_info = wrapped.func_src_info
+  elif callable(wrapped):
+    func_src_info = fun_sourceinfo(wrapped)
+  else:
+    return
+  setattr(wrapper, "__fun_sourceinfo__", func_src_info)
 
 _fun_name_re = re.compile(r"(?:<built-in function (\S+)>)")
 

--- a/jax/_src/custom_batching.py
+++ b/jax/_src/custom_batching.py
@@ -141,25 +141,28 @@ class custom_vmap:
 
   @traceback_util.api_boundary
   def __call__(self, *args, **kwargs):
+    debug_fun = api_util.debug_info("custom_vmap fun", self.fun,
+                                    args, kwargs)
     args = api_util.resolve_kwargs(self.fun, args, kwargs)
-    fun_name = getattr(self.fun, "__name__", str(self.fun))
     if not self.vmap_rule:
       raise AttributeError(
-          f"No batching rule defined for custom_vmap function {fun_name} "
+          f"No batching rule defined for custom_vmap function {debug_fun.func_name} "
           "using def_vmap.")
-    debug = api_util.debug_info("custom_vmap", self.fun, args, {})
     args_flat, in_tree = tree_flatten(args)
     flat_fun, out_tree = api_util.flatten_fun_nokwargs(
-        lu.wrap_init(self.fun, debug_info=debug),
+        lu.wrap_init(self.fun, debug_info=debug_fun),
         in_tree)
     in_avals = [core.get_aval(x) for x in args_flat]
     jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(flat_fun, in_avals)
     closed_call = core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
     in_tree = treedef_tuple((tree_structure(consts), in_tree))
     assert self.vmap_rule is not None
+    debug_rule = api_util.debug_info("custom_vmap rule", self.vmap_rule,
+                                     (0, args, args), {})
     out_flat = custom_vmap_p.bind(*consts, *args_flat,
                                   call=closed_call,
-                                  rule=ClosedRule(self.vmap_rule),
+                                  rule=ClosedRule(self.vmap_rule,
+                                                  debug_rule),
                                   in_tree=in_tree,
                                   out_tree=out_tree())
     return tree_unflatten(out_tree(), out_flat)
@@ -170,9 +173,10 @@ class custom_vmap:
 # Define a class, instead of making a function closing over `rule`, so
 # that we can override __str__
 class ClosedRule:
-  def __init__(self, rule):
+  def __init__(self, rule: Callable, debug: core.DebugInfo):
     functools.update_wrapper(self, rule)
     self.rule = rule
+    self.debug = debug
 
   def __call__(self, axis_size, all_in_batched, *all_args):
     _, args = all_args
@@ -252,8 +256,11 @@ def custom_vmap_abstract_eval(*in_avals, call, **_):
   return call.out_avals
 
 
-def custom_vmap_jvp(primals, tangents, *, call, rule, in_tree, out_tree):
-  def jvp_of_rule_rule(axis_size, in_batched, primals, tangents):
+def custom_vmap_jvp(primals, tangents, *,
+                    call: core.ClosedJaxpr,
+                    rule: ClosedRule,
+                    in_tree: tree_util.PyTreeDef, out_tree: tree_util.PyTreeDef):
+  def jvp_of_rule_rule(axis_size: int, in_batched, primals, tangents):
     in_batched_ps, in_batched_ts = in_batched
 
     mutually_batched = tree_map(operator.and_, in_batched_ps, in_batched_ts)
@@ -281,11 +288,14 @@ def custom_vmap_jvp(primals, tangents, *, call, rule, in_tree, out_tree):
       out_mutually_batched.store(out_batched)
       return out
 
+    api_util.save_wrapped_fun_sourceinfo(to_jvp, call.jaxpr.debug_info)
     def to_vmap_over_extra_batched_dims(primals, tangents):
       return api.jvp(to_jvp, primals, tangents)
 
     to_vmap_over_extra_batched_dims_flat, out_tree2 = api_util.flatten_fun_nokwargs(
-        lu.wrap_init(to_vmap_over_extra_batched_dims),
+        lu.wrap_init(to_vmap_over_extra_batched_dims,
+                     # TODO(necula): fix the debug_info calling convention
+                     debug_info=call.jaxpr.debug_info),
         tree_ps_ts)
 
     flat_out_ps_ts, flat_out_axes = vmap_unrestricted(

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1102,7 +1102,6 @@ def _scan_partial_eval_custom(saveable, unks_in, inst_in, eqn):
                       num_carry=len(carry_uk)-sum(carry_uk),
                       linear=tuple(linear_known))
 
-  @lu.wrap_init
   def known(*ins_known):
     consts_known_hoist, ins_known_lp = split_list(ins_known, [num_const_known])
     out_hoist = core.jaxpr_as_fun(jaxpr_known_hoist)(*consts_known_hoist)
@@ -1110,7 +1109,8 @@ def _scan_partial_eval_custom(saveable, unks_in, inst_in, eqn):
     out_loop = scan_p.bind(*consts_known_lp, *ins_known_lp, **params_known)
     return [*intensive_res, *out_loop]
   call_jaxpr_, _, call_jaxpr_consts, () = pe.trace_to_jaxpr_dynamic(
-      known, [v.aval for v in ins_known])
+      lu.wrap_init(known, debug_info=jaxpr_known_hoist.jaxpr.debug_info),
+      [v.aval for v in ins_known])
   call_jaxpr = core.ClosedJaxpr(call_jaxpr_, call_jaxpr_consts)
   eqn_known = pe.new_jaxpr_eqn(
       ins_known, [*intensive_res, *out_binders_known, *extensive_res],
@@ -1550,11 +1550,18 @@ def _while_loop_jvp(primals, tangents, cond_nconsts, cond_jaxpr, body_nconsts,
   newvar = core.gensym()
   invars_aug = (
       cond_jaxpr.jaxpr.invars + [newvar(core.get_aval(x)) for x in init_dot])
+  cond_debug = cond_jaxpr.jaxpr.debug_info
+  augmented_debug = cond_debug and (
+      cond_debug._replace(
+          arg_names=cond_debug.arg_names + (None,) * len(init_dot)
+      )
+  )
   cond_jaxpr_augmented = core.Jaxpr(cond_jaxpr.jaxpr.constvars,
                                     invars_aug,
                                     cond_jaxpr.jaxpr.outvars,
                                     cond_jaxpr.jaxpr.eqns,
-                                    cond_jaxpr.jaxpr.effects)
+                                    cond_jaxpr.jaxpr.effects,
+                                    augmented_debug)
   cond_jaxpr_augmented = core.ClosedJaxpr(cond_jaxpr_augmented, cond_jaxpr.consts)
 
   out = while_p.bind(

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -5174,7 +5174,9 @@ class RematTest(jtu.JaxTestCase):
     # NOTE(mattjj): after #3370, this test doesn't actually call remat...
     def named_call(f):
       def named_f(*args):
-        f_ = lu.wrap_init(lambda: (f(*args),))
+        my_f = lambda: (f(*args),)
+        f_ = lu.wrap_init(
+            my_f, debug_info=api_util.debug_info("test_remat", my_f, args, {}))
         out, = core.call_p.bind(f_)
         return out
       return named_f
@@ -5234,8 +5236,11 @@ class RematTest(jtu.JaxTestCase):
 
     @jax_util.curry
     def call(f, *args):
+      my_f = lambda *args: [f(*args)]
       return core.call(
-          lu.wrap_init(lambda *args: [f(*args)]),
+          lu.wrap_init(my_f,
+                       debug_info=api_util.debug_info("test_remat", my_f,
+                                                      args, {})),
           *args, name='foo')[0]
 
     f = call(add_one)

--- a/tests/debug_info_test.py
+++ b/tests/debug_info_test.py
@@ -75,9 +75,9 @@ def _debug_info_to_string(dbg: core.DebugInfo | None) -> list[str]:
   if dbg is None: return "None"
   # Strip the absolute path and the line number but check that it references
   # this file (to catch errors when the source info points in JAX internals)
-  fun_src_info = re.sub(r"^(\S+)( at .*/debug_info_test.py:.*)?", "\\1", dbg.func_src_info)
+  func_src_info = re.sub(r"^(\S+)( at .*/debug_info_test.py:.*)?", "\\1", dbg.func_src_info)
   arg_names_str = ",".join([str(a) for a in dbg.arg_names])
-  res = f"traced_for={dbg.traced_for}, fun={fun_src_info}, arg_names={arg_names_str}"
+  res = f"traced_for={dbg.traced_for}, fun={func_src_info}, arg_names={arg_names_str}"
   if isinstance(dbg.result_paths, tuple):
     res += f", result_paths={','.join(dbg.result_paths)}"
   elif dbg.result_paths is None:
@@ -288,6 +288,26 @@ class DebugInfoTest(jtu.JaxTestCase):
     dbg = api_util.debug_info("jit", lambda my_arg: False, (1,), {})
     self.assertRegex(dbg.func_src_info, r"^<lambda> at .*debug_info_test.py:\d+")
     self.assertEqual(dbg.arg_names, ("my_arg",))
+
+  def test_debug_info_save_wrapped_fun_source_info(self):
+    def wrapper(x, y):
+      return x
+
+    api_util.save_wrapped_fun_sourceinfo(wrapper, None)  # No effect
+    dbg = api_util.debug_info("test", wrapper, (1, 2), {})
+    self.assertEqual("wrapper", dbg.func_name)
+
+    api_util.save_wrapped_fun_sourceinfo(wrapper, lambda x, y: x)
+    dbg = api_util.debug_info("test", wrapper, (1, 2), {})
+    self.assertEqual("<lambda>", dbg.func_name)
+
+    def other_f():
+      pass
+    dbg_other = api_util.debug_info("test other", other_f, (), {})
+    api_util.save_wrapped_fun_sourceinfo(wrapper, dbg_other)
+    dbg = api_util.debug_info("test", wrapper, (1, 2), {})
+    self.assertEqual("other_f", dbg.func_name)
+    self.assertEqual("test", dbg.traced_for)
 
   def test_debug_info_no_source_info_not_callable(self):
     # built-in function "int" does not have an inspect.Signature
@@ -1076,7 +1096,7 @@ class DebugInfoTest(jtu.JaxTestCase):
             "traced_for=jit, fun=my_f, arg_names=xdict['x'],xdict['y'], result_paths=['a']",
         ],
         expected_tracer_debug_infos=[
-            "traced_for=custom_vmap, fun=my_f, arg_names=xdict['x'],xdict['y']",
+            "traced_for=custom_vmap fun, fun=my_f, arg_names=xdict['x'],xdict['y']",
             "traced_for=jit, fun=my_f, arg_names=xdict['x'],xdict['y']"
         ])
 


### PR DESCRIPTION
This follows in a series, starting with #26078 and #26313, adding debug_info to more calls to lu.wrap_init.

These changes ensure that all the lu.wrap_init and Jaxpr are called with debug_info in the api_test.py:CustomTransposeTest, api_test.py:CustomVmapTest and api_test.py:RematTest.