### PR TITLE
[better_errors] Continue adding debug info to Jaxprs (step 6)

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -27,7 +27,7 @@ from jax._src import dtypes
 from jax._src.state.types import AbstractRef
 from jax._src.tree_util import (
     PyTreeDef, tree_flatten, tree_unflatten, tree_map,
-    treedef_children, generate_key_paths, keystr, broadcast_prefix,
+    treedef_children, generate_key_paths, broadcast_prefix,
     prefix_errors)
 from jax._src.tree_util import _replace_nones
 from jax._src import linear_util as lu
@@ -595,6 +595,15 @@ def debug_info(
     sourceinfo: str | None = None,
     signature: inspect.Signature | None = None,
 ) -> core.DebugInfo:
+  """Constructd core.DebugInfo for a function given example args and kwargs.
+
+  `args` and `kwargs` are example positional and keyword arguments, users with
+  `inspect.Signature` to get the names of argments. The arguments that are
+  considered static for tracing purposes should be included, and designated
+  using `static_argnums` and `static_argnames`.
+
+  See docstring for linear_util.DebugInfo.
+  """
   if sourceinfo is None:
     sourceinfo = fun_sourceinfo(fun)
   if signature is None:
@@ -671,12 +680,13 @@ def _non_static_arg_names(fn_signature: inspect.Signature | None,
     except (ValueError, TypeError):
       pass
     else:
-      return tuple(f'{name}{keystr(path)}' for name, x in ba.arguments.items()
+      return tuple(f'{name}{lu._clean_keystr_arg_names(path)}'
+                   for name, x in ba.arguments.items()
                    for path, l in generate_key_paths(x) if l is not static)
-  args_arg_names = tuple(f'args{keystr(path)}'
+  args_arg_names = tuple(f'args{lu._clean_keystr_arg_names(path)}'
                          for path, l in generate_key_paths(args_)
                          if l is not static)
-  kwargs_arg_names = tuple(f'kwargs{keystr(path)}'
+  kwargs_arg_names = tuple(f'kwargs{lu._clean_keystr_arg_names(path)}'
                            for path, l in generate_key_paths(kwargs_)
                            if l is not static)
   arg_names = args_arg_names + kwargs_arg_names

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -502,7 +502,7 @@ def _closed_call_param_updater(params, _, __):
   return dict(params, call_jaxpr=core.ClosedJaxpr(jaxpr, ()))
 call_param_updaters[core.closed_call_p] = _closed_call_param_updater
 
-def abstract_eval_fun(fun, *avals, debug_info=None, **params):
+def abstract_eval_fun(fun: Callable, *avals, debug_info=None, **params):
   _, avals_out, _, () = trace_to_jaxpr_dynamic(
       lu.wrap_init(fun, params, debug_info=debug_info), avals)
   assert all(isinstance(aval, AbstractValue) for aval in avals_out)
@@ -1992,7 +1992,9 @@ class DynamicJaxprTrace(core.Trace):
       self.frame.add_eqn(eqn)
     return out_tracers
 
-  def process_custom_jvp_call(self, prim, fun, jvp, tracers, symbolic_zeros):
+  def process_custom_jvp_call(self, prim, fun: lu.WrappedFun,
+                              jvp: lu.WrappedFun, tracers,
+                              symbolic_zeros: bool):
     tracers = map(self.to_jaxpr_tracer, tracers)
     in_avals = [t.aval for t in tracers]
     in_tangent_avals = [t.to_tangent_aval() for t in in_avals]
@@ -2014,7 +2016,8 @@ class DynamicJaxprTrace(core.Trace):
     outvars = map(self.makevar, out_tracers)
     eqn = new_jaxpr_eqn([*constvars, *invars], outvars, prim,
                         dict(call_jaxpr=closed_fun_jaxpr,
-                             jvp_jaxpr_thunk=jvp_jaxpr_thunk,
+                             jvp_jaxpr_fun=lu.wrap_init(jvp_jaxpr_thunk,
+                                                        debug_info=jvp.debug_info),
                              num_consts=len(consts),
                              symbolic_zeros=symbolic_zeros),
                         fun_jaxpr.effects,

--- a/jax/_src/lax/control_flow/solves.py
+++ b/jax/_src/lax/control_flow/solves.py
@@ -159,7 +159,8 @@ def _root_jvp(const_lengths, jaxprs, primals, tangents):
   linearize_and_solve = partial(
       core.jaxpr_as_fun(jaxprs.l_and_s), *params.l_and_s)
   f_at_solution = lambda *params: f(*params, *solution)
-  _, rhs = ad.jvp(lu.wrap_init(f_at_solution)).call_wrapped(
+  _, rhs = ad.jvp(lu.wrap_init(f_at_solution,
+                               debug_info=jaxprs.f.jaxpr.debug_info)).call_wrapped(
       params.f, params_dot.f)
   solution_dot = _map(
       operator.neg, linearize_and_solve(*solution, *rhs))

--- a/jax/_src/linear_util.py
+++ b/jax/_src/linear_util.py
@@ -65,13 +65,14 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from functools import partial
+import re
 from typing import Any, NamedTuple
 import weakref
 
 from jax._src import config
 from jax._src import core
 from jax._src import traceback_util
-from jax._src.tree_util import keystr, generate_key_paths
+from jax._src.tree_util import keystr, KeyPath, generate_key_paths
 from jax._src.util import curry, cache_clearing_funs, HashableFunction
 
 
@@ -266,13 +267,17 @@ class DebugInfo(NamedTuple):
   # The paths of the flattened non-static argnames,
   # e.g. ('x', 'dict_arg["a"]', ... ).
   # Uses `None` for the args that do not correspond to user-named arguments,
-  # e.g., tangent args in jax.jvp.
+  # e.g., tangent args in jax.jvp. At the moment, `arg_names` accuracy is
+  # best-effort. Use `safe_arg_names` to detect and handle an unexpected
+  # number of elements in `arg_names`.
   arg_names: tuple[str | None, ...]
 
   # The result paths are not available while we are tracing the function,
   # instead we keep a thunk. Once we are done tracing, we use
   # `self.resolve_result_paths()` to execute the thunk and replace the
-  # actual result paths.
+  # actual result paths. At the moment, `result_paths` accuracy is
+  # best-effort. Use `safe_result_paths` to detect and handle an unexpected
+  # number of elements in `result_paths`.
   # e.g. ('[0]', '[1]', ...)
   result_paths: tuple[str, ...] | Callable[[], tuple[str, ...]] | None
 
@@ -329,10 +334,16 @@ def wrap_init(f: Callable, params=None, *,
   return fun
 
 
+# We replace <flat index 0> with 0
+_re_clean_keystr_arg_names = re.compile(r"<flat index ([^>]+)>")
+def _clean_keystr_arg_names(k: KeyPath) -> str:
+  res = keystr(k)
+  return _re_clean_keystr_arg_names.sub(r"\1", res)
+
 @transformation_with_aux2
 def _get_result_paths_thunk(_fun: Callable, _store: Store, *args, **kwargs):
   ans = _fun(*args, **kwargs)
-  result_paths = [keystr(path) for path, _ in generate_key_paths(ans)]
+  result_paths = [_clean_keystr_arg_names(path) for path, _ in generate_key_paths(ans)]
   if _store:
     # In some instances a lu.WrappedFun is called multiple times, e.g.,
     # the bwd function in a custom_vjp

--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -3044,11 +3044,11 @@ def _custom_jvp_call_lowering_rule(
     ctx: LoweringRuleContext,
     *args,
     call_jaxpr: jax_core.Jaxpr,
-    jvp_jaxpr_thunk: Callable,
+    jvp_jaxpr_fun: lu.WrappedFun,
     num_consts: int,
     symbolic_zeros: bool,
 ):
-  del jvp_jaxpr_thunk
+  del jvp_jaxpr_fun
   if symbolic_zeros: raise NotImplementedError
   if num_consts: raise NotImplementedError
   if call_jaxpr.consts: raise NotImplementedError

--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -242,7 +242,9 @@ def _batch_block_mapping(
 
   with grid_mapping.trace_env():
     block_mapping_jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(
-        lu.wrap_init(_block_map_function), idx_avals)
+        lu.wrap_init(_block_map_function,
+                     debug_info=block_mapping.index_map_jaxpr.jaxpr.debug_info),
+        idx_avals)
   shape = block_mapping.block_shape
   if dim is batching.not_mapped:
     new_block_shape = shape

--- a/jax/_src/state/utils.py
+++ b/jax/_src/state/utils.py
@@ -73,7 +73,7 @@ def hoist_consts_to_refs(
     return core.eval_jaxpr(jaxpr, all_consts, *args0, *args1)
 
   hoisted_jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(
-      lu.wrap_init(_hoist), in_avals)
+      lu.wrap_init(_hoist, debug_info=jaxpr.debug_info), in_avals)
   assert not consts, "All consts should have been converted to refs"
   return hoisted_jaxpr
 

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -599,6 +599,8 @@ class GraphSerializationImpl(SerializationImpl):
     name_stack = util.wrap_name(fun_name, "jax2tf")
     self.name_stack = name_stack
     self.args_flat_tf = args_flat_tf
+    self.debug = api_util.debug_info("jax2tf", fun_jax,
+                                      args_specs, kwargs_specs)
 
   def before_conversion(self):
     prev_enable_xla = _thread_local_state.enable_xla
@@ -623,7 +625,10 @@ class GraphSerializationImpl(SerializationImpl):
     dim_values, _ = _interpret_fun_jax(
         partial(shape_poly.compute_dim_vars_from_arg_shapes,
                 self.args_avals_flat, args_kwargs_tree=self.in_tree),
-        self.args_flat_tf, self.args_avals_flat, self.name_stack)
+        self.args_flat_tf, self.args_avals_flat, self.name_stack,
+        debug_info=api_util.debug_info("jax2tf dim_vars",
+                                       shape_poly.compute_dim_vars_from_arg_shapes,
+                                       self.args_specs, self.kwargs_specs))
 
     _thread_local_state.shape_env = zip(dim_vars, dim_values)
 
@@ -639,7 +644,8 @@ class GraphSerializationImpl(SerializationImpl):
         fun_flat_jax,
         args_flat_tf, self.args_avals_flat,
         self.name_stack,
-        fresh_constant_cache=True)
+        fresh_constant_cache=True,
+        debug_info=self.debug)
     return outs_tf, self.outs_avals, out_tree_thunk()
 
   def get_vjp_fun(self) -> tuple[Callable,
@@ -849,10 +855,12 @@ def _interpret_fun_jax(
     fun_jax: Callable,
     args_tf: Sequence[TfVal],
     args_avals: Sequence[core.ShapedArray],
-    extra_name_stack: str | None,
+    extra_name_stack: str | None, *,
     fresh_constant_cache: bool = False,
+    debug_info: core.DebugInfo,
 ) -> tuple[tuple[TfVal, ...], tuple[core.ShapedArray, ...]]:
-  subtrace_fun = _interpret_subtrace(lu.wrap_init(fun_jax), args_avals)
+  subtrace_fun = _interpret_subtrace(
+      lu.wrap_init(fun_jax, debug_info=debug_info), args_avals)
   with _extended_name_stack(extra_name_stack):
     out_vals: Sequence[tuple[TfVal, core.ShapedArray]] = \
         _call_wrapped_with_new_constant_cache(subtrace_fun, args_tf,
@@ -1033,7 +1041,9 @@ def _convert_jax_impl(impl_jax: Callable, *,
 
     results_tf, _ = _interpret_fun_jax(
         impl_multiple_results_jax, args_tf, _in_avals,
-        extra_name_stack)
+        extra_name_stack,
+        debug_info=api_util.debug_info("jax2tf", impl_jax,
+                                       args_tf, kwargs))
     return results_tf if multiple_results else results_tf[0]
 
   return wrapped_tf
@@ -1066,7 +1076,8 @@ def _interpret_jaxpr(jaxpr: core.ClosedJaxpr, *args_tf: TfVal,
   """
   outs_tf, _ = _interpret_fun_jax(core.jaxpr_as_fun(jaxpr),
                                   args_tf, jaxpr.in_avals, extra_name_stack,
-                                  fresh_constant_cache=fresh_constant_cache)
+                                  fresh_constant_cache=fresh_constant_cache,
+                                  debug_info=jaxpr.jaxpr.debug_info)
   return outs_tf
 
 
@@ -1197,7 +1208,9 @@ def _eval_shape(shape: Sequence[shape_poly.DimSize], dtype=None) -> Sequence[TfV
   dim_vars, dim_values = util.unzip2(_thread_local_state.shape_env)
   shape_values_tf, _ = _interpret_fun_jax(
       partial(core.evaluate_shape, shape, dim_vars),
-      dim_values, [core.dim_value_aval()] * len(dim_values), "")  # type: ignore
+      dim_values, [core.dim_value_aval()] * len(dim_values), "",  # type: ignore
+      debug_info=api_util.debug_info("jax2tf evaluate_shape", core.evaluate_shape,
+                                     (0, 0, *dim_values), {}))
   # Keep only the non-constant dimensions
   return tuple(operator.index(d) if core.is_constant_dim(d) else d_tf  # type: ignore
                for d, d_tf in zip(shape, shape_values_tf))
@@ -3431,10 +3444,10 @@ def _tridiagonal_solve(*args: TfVal, _in_avals, _out_aval, **params):
 tf_impl_with_avals[lax.linalg.tridiagonal_solve_p] = _tridiagonal_solve
 
 def _custom_jvp_call(*args: TfVal, call_jaxpr: core.ClosedJaxpr,
-                           jvp_jaxpr_thunk: Callable,
+                           jvp_jaxpr_fun: Callable,
                            num_consts: int) -> Sequence[TfVal]:
   # TODO(necula): ensure that there is no AD transformation in scope
-  del jvp_jaxpr_thunk, num_consts
+  del jvp_jaxpr_fun, num_consts
   return _interpret_jaxpr(call_jaxpr, *args, extra_name_stack="custom_jvp",
                           fresh_constant_cache=False)
 

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -38,6 +38,7 @@ from jax import lax
 import jax.numpy as jnp
 from jax import random
 from jax import tree_util
+from jax._src import api_util
 from jax._src import config
 from jax._src import core
 from jax._src import test_util as jtu
@@ -442,7 +443,10 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
             partial(shape_poly.compute_dim_vars_from_arg_shapes,
                     avals,
                     args_kwargs_tree=tree_util.tree_flatten((avals, {}))[1]),
-            args_tf, avals, "")
+            args_tf, avals, "",
+        debug_info=api_util.debug_info("jax2tf dim_vars",
+                                       shape_poly.compute_dim_vars_from_arg_shapes,
+                                       avals, {}))
         if expected_shapes is not None:
           expected_avals = tree_util.tree_map(
               lambda shape_str: core.ShapedArray(

--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -1042,8 +1042,14 @@ def _bcoo_dot_general_sampled_impl(A, B, indices, *, dimension_numbers):
 
 @bcoo_dot_general_sampled_p.def_abstract_eval
 def _bcoo_dot_general_sampled_abstract_eval(A, B, indices, *, dimension_numbers):
-  dense_result, = pe.abstract_eval_fun(lambda *args: [lax.dot_general(*args, dimension_numbers=dimension_numbers)], A, B)
-  sparse_result, = pe.abstract_eval_fun(lambda *args: [_bcoo_extract(*args)], indices, dense_result)
+  dbg = api_util.debug_info("bcoo_dot_general_sampled_abstract_eval",
+                            lax.dot_general, (A, B), dict(dimension_numbers=dimension_numbers))
+  dense_result, = pe.abstract_eval_fun(lambda *args: [lax.dot_general(*args, dimension_numbers=dimension_numbers)], A, B,
+                                       debug_info=dbg)
+  dbg = api_util.debug_info("bcoo_dot_general_sampled_abstract_eval",
+                            _bcoo_extract, (indices, dense_result), {})
+  sparse_result, = pe.abstract_eval_fun(lambda *args: [_bcoo_extract(*args)], indices, dense_result,
+                                        debug_info=dbg)
   return sparse_result
 
 def _bcoo_dot_general_sampled_transpose(ct, A, B, indices, *, dimension_numbers):

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -55,6 +55,7 @@ import numpy as np
 
 import jax
 from jax import lax
+from jax._src import api_util
 from jax._src import config
 from jax._src import core
 from jax._src.custom_derivatives import lift_jvp
@@ -365,12 +366,15 @@ def sparsify_fun(wrapped_fun, args: list[ArrayOrSparse]):
   spenv = SparsifyEnv(out_bufs)
   return spvalues_to_arrays(spenv, out_spvalues())
 
-def _sparsify_with_tracer(fun):
+def _sparsify_with_tracer(fun: Callable):
   """Implementation of sparsify() using tracers."""
   @functools.wraps(fun)
   def _wrapped(*args):
     args_flat, in_tree = tree_flatten(args, is_leaf=_is_sparse_obj)
-    wrapped_fun, out_tree = flatten_fun_nokwargs(lu.wrap_init(fun), in_tree)
+    wrapped_fun, out_tree = flatten_fun_nokwargs(
+        lu.wrap_init(fun,
+                     debug_info=api_util.debug_info("sparsify", fun, args, {})),
+        in_tree)
     out = sparsify_fun(wrapped_fun, args_flat)
     return tree_unflatten(out_tree(), out)
   return _wrapped
@@ -439,7 +443,12 @@ def sparsify_raw(f):
   ) -> tuple[Sequence[SparsifyValue], pytree.PyTreeDef]:
     spvalues_flat, in_tree = tree_flatten(spvalues, is_leaf=_is_spvalue)
     in_avals_flat = spvalues_to_avals(spenv, spvalues_flat)
-    wrapped_fun, out_tree = flatten_fun_nokwargs(lu.wrap_init(f, params), in_tree)
+    wrapped_fun, out_tree = flatten_fun_nokwargs(
+        lu.wrap_init(
+            f, params,
+            debug_info=api_util.debug_info("sparsify", f,
+                                           spvalues_to_arrays(spenv, spvalues), {})),
+        in_tree)
     jaxpr, out_avals_flat, consts, () = pe.trace_to_jaxpr_dynamic(wrapped_fun, in_avals_flat)
     result = eval_sparse(jaxpr, consts, spvalues_flat, spenv)
     if len(out_avals_flat) != len(result):
@@ -716,14 +725,14 @@ def _gather_sparse_rule(spenv, *args, dimension_numbers, slice_sizes, unique_ind
 
 sparse_rules_bcoo[lax.gather_p] = _gather_sparse_rule
 
-def _sparsify_jaxpr(spenv, jaxpr, *spvalues):
+def _sparsify_jaxpr(spenv: SparsifyEnv,
+                    jaxpr: core.ClosedJaxpr, *spvalues):
   # TODO(jakevdp): currently this approach discards all information about
   #   shared data & indices when generating the sparsified jaxpr. The
   #   current approach produces valid sparsified while loops, but they
   #   don't work in corner cases (see associated TODO in sparsify_test.py)
   out_tree: pytree.PyTreeDef | None = None
 
-  @lu.wrap_init
   def wrapped(*args_flat):
     # TODO(frostig,jakevdp): This closes over `spenv`, which can bring
     # in buffers from the "outer scope" as constants. Is this a
@@ -740,7 +749,8 @@ def _sparsify_jaxpr(spenv, jaxpr, *spvalues):
   args = spvalues_to_arrays(spenv, spvalues)
   args_flat, in_tree = tree_flatten(args)
   avals_flat = [core.get_aval(arg) for arg in args_flat]
-  sp_jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(wrapped, avals_flat)
+  sp_jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(
+      lu.wrap_init(wrapped, debug_info=jaxpr.jaxpr.debug_info), avals_flat)
   sp_jaxpr = pe.ClosedJaxpr(sp_jaxpr, consts)
   assert out_tree is not None
   return sp_jaxpr, out_tree
@@ -866,17 +876,18 @@ sparse_rules_bcsr[sparse.todense_p] = _todense_sparse_rule
 
 def _custom_jvp_sparse_rule(spenv, *spvalues, **params):
   call_jaxpr: core.ClosedJaxpr = params.pop('call_jaxpr')
-  jvp_jaxpr_thunk = params.pop('jvp_jaxpr_thunk')
-  num_consts = params.pop('num_consts')
+  jvp_jaxpr_fun: lu.WrappedFun = params.pop('jvp_jaxpr_fun')
+  num_consts: int = params.pop('num_consts')
   sp_call_jaxpr, out_tree = _sparsify_jaxpr(spenv, call_jaxpr, *spvalues)
-  @lu.wrap_init
   def fun(*arrs):
     sparrs = arrays_to_spvalues(spenv, arrs)
     out = eval_sparse(call_jaxpr.jaxpr, call_jaxpr.consts, sparrs, spenv)
     return spvalues_to_arrays(spenv, out)
-  jvp = lift_jvp(num_consts, jvp_jaxpr_thunk, call_jaxpr.jaxpr.debug_info)
+  jvp = lift_jvp(num_consts, jvp_jaxpr_fun)
   invals = spvalues_to_arrays(spenv, spvalues)
-  outvals = jax.custom_derivatives.custom_jvp_call_p.bind(fun, jvp, *invals, **params)
+  outvals = jax.custom_derivatives.custom_jvp_call_p.bind(
+      lu.wrap_init(fun, debug_info=call_jaxpr.jaxpr.debug_info),
+      jvp, *invals, **params)
   return arrays_to_spvalues(spenv, outvals)
 
 sparse_rules_bcoo[jax.custom_derivatives.custom_jvp_call_p] = _custom_jvp_sparse_rule

--- a/tests/debug_info_test.py
+++ b/tests/debug_info_test.py
@@ -901,7 +901,7 @@ class DebugInfoTest(jtu.JaxTestCase):
         tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
             # TODO(necula): what are these flat_index components?
-            "traced_for=jit, fun=apply_fn, arg_names=inp, result_paths=[0],[1][<flat index 0>][0][<flat index 0>][0][0]",
+            "traced_for=jit, fun=apply_fn, arg_names=inp, result_paths=[0],[1][0][0][0][0][0]",
             re.compile(r"traced_for=custom_jvp fun, fun=relu at .*nn.functions.py:.*, arg_names=x, result_paths="),
             re.compile(r"traced_for=jit, fun=relu at .*nn.functions.py:.*, arg_names=x, result_paths="),
         ],
@@ -1091,8 +1091,7 @@ class DebugInfoTest(jtu.JaxTestCase):
         expected_jaxpr_debug_infos=[
             "traced_for=cond, fun=my_f, arg_names=x['c'], result_paths=",
             "traced_for=cond, fun=<lambda>, arg_names=x['c'], result_paths=",
-            # TODO(necula): flat_index?
-            "traced_for=jit, fun=<lambda>, arg_names=x, result_paths=[<flat index 0>][0][0],[<flat index 0>][0][1]",
+            "traced_for=jit, fun=<lambda>, arg_names=x, result_paths=[0][0][0],[0][0][1]",
         ],
         check_tracer_arg_name=True,
         expected_tracer_debug_infos=[


### PR DESCRIPTION
This follows in a series, starting with #26078 and #26313, adding debug_info to more calls to lu.wrap_init.

Here I changed the `custom_jvp_call` to replace the parameter
`jvp_jaxpr_thunk` (a callable) with `jvp_jaxpr_fun` (a `lu.WrappedFun`
that can carry debug info).

Fixes uses in shard_map, checkify, attrs, sparse, and jax2tf.