### PR TITLE
[better_errors] Continue adding debug info to Jaxprs (step 7)

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -610,10 +610,17 @@ def fun_signature(fun: Callable) -> inspect.Signature | None:
   except (ValueError, TypeError):
     return None
 
-def save_wrapped_fun_sourceinfo(wrapper: Callable, wrapped: Callable):
+def save_wrapped_fun_sourceinfo(wrapper: Callable,
+                                wrapped: Callable | core.DebugInfo | None) -> None:
   # Prefer this to functools.wraps because it does not create a reference to
   # the wrapped function.
-  setattr(wrapper, "__fun_sourceinfo__", fun_sourceinfo(wrapped))
+  if isinstance(wrapped, core.DebugInfo):
+    func_src_info = wrapped.func_src_info
+  elif callable(wrapped):
+    func_src_info = fun_sourceinfo(wrapped)
+  else:
+    return
+  setattr(wrapper, "__fun_sourceinfo__", func_src_info)
 
 _fun_name_re = re.compile(r"(?:<built-in function (\S+)>)")
 

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -1823,7 +1823,7 @@ def _move_mutable_consts(
   invars = (*jaxpr.invars, *mutvars)
   effects = pe.make_jaxpr_effects(constvars, invars, jaxpr.outvars, jaxpr.eqns)
   jaxpr = core.Jaxpr(constvars, invars, jaxpr.outvars, jaxpr.eqns,
-                     effects, None)
+                     effects, closed_jaxpr.jaxpr.debug_info)
   return core.ClosedJaxpr(jaxpr, consts), in_mut
 
 @weakref_lru_cache

--- a/jax/_src/pallas/core.py
+++ b/jax/_src/pallas/core.py
@@ -1062,7 +1062,11 @@ def core_map(
   """
   def wrapped(f):
     flat_args, in_tree = tree_util.tree_flatten(((), {}))
-    flat_fun, out_tree_thunk = api_util.flatten_fun(lu.wrap_init(f), in_tree)
+    flat_fun, out_tree_thunk = api_util.flatten_fun(
+        lu.wrap_init(f,
+                     debug_info=api_util.debug_info("pallas_core_map", f,
+                                                    (), {})),
+        in_tree)
     with jax_core.extend_axis_env_nd(mesh.shape.items()):
       jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(flat_fun, flat_args)
     out = core_map_p.bind(*consts, jaxpr=jaxpr, mesh=mesh,

--- a/jax/_src/pallas/cost_estimate.py
+++ b/jax/_src/pallas/cost_estimate.py
@@ -91,8 +91,11 @@ def estimate_cost(fun, *args, **kwargs) -> pallas_core.CostEstimate:
   """
   flattened_args, treedef = jax.tree.flatten(args)
   partial_fun = functools.partial(fun, **kwargs)
-  wrapped_fun, _ = api_util.flatten_fun_nokwargs(lu.wrap_init(partial_fun),
-                                                 treedef)
+  wrapped_fun, _ = api_util.flatten_fun_nokwargs(
+      lu.wrap_init(partial_fun,
+                   debug_info=api_util.debug_info("cost_estimate", fun,
+                                                  args, kwargs)),
+      treedef)
   avals = [jax_core.ShapedArray(a.shape, a.dtype) for a in flattened_args]
   jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(wrapped_fun, avals)
   estimate = cost_estimate_jaxpr(jax_core.ClosedJaxpr(jaxpr, consts))

--- a/jax/_src/pallas/mosaic/interpret.py
+++ b/jax/_src/pallas/mosaic/interpret.py
@@ -476,7 +476,9 @@ def _interpret_jaxpr(jaxpr, *args, compiler_params):
         return _interpret_jaxpr(pjit_jaxpr.jaxpr, *pjit_jaxpr.consts, *args,
                                 compiler_params=compiler_params)
       in_avals = tuple(jax_core.shaped_abstractify(i) for i in invals)
-      new_jaxpr = _to_jaxpr(lu.wrap_init(f), in_avals)
+      new_jaxpr = _to_jaxpr(lu.wrap_init(f,
+                                         debug_info=pjit_jaxpr.jaxpr.debug_info),
+                            in_avals)
       out = pjit.pjit_p.bind(*invals, **(eqn.params | {'jaxpr': new_jaxpr}))
 
     elif prim is primitives.run_scoped_p:

--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -23,6 +23,7 @@ import string
 from typing import Any, Hashable
 
 import jax
+from jax import api_util
 from jax import lax
 from jax import tree_util
 from jax._src import ad_util
@@ -845,7 +846,10 @@ def lower_jaxpr_to_func(
 def lower_fun(fun: Callable, *, multiple_results: bool) -> Callable:
   def f_lowered(ctx: LoweringRuleContext, *args, **params):
     f = fun if multiple_results else lambda *args, **kw: (fun(*args, **kw),)
-    wrapped_fun = lu.wrap_init(f, params)
+    wrapped_fun = lu.wrap_init(
+        f, params,
+        debug_info=api_util.debug_info("mosaic lower_fun", f,
+                                       args, params))
     jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(wrapped_fun, ctx.avals_in)
     if consts:
       raise NotImplementedError

--- a/jax/_src/pallas/mosaic_gpu/pipeline.py
+++ b/jax/_src/pallas/mosaic_gpu/pipeline.py
@@ -24,6 +24,7 @@ import math
 from typing import Any
 
 import jax
+from jax import api_util
 from jax import lax
 from jax._src import core
 from jax._src import linear_util as lu
@@ -94,7 +95,12 @@ def _uses_arguments(
     index_map: Callable[..., Any], num_args: int
 ) -> Sequence[bool]:
   jaxpr, _, _, () = pe.trace_to_jaxpr_dynamic(
-      lu.wrap_init(index_map), (core.ShapedArray((), jnp.int32),) * num_args
+      lu.wrap_init(
+          index_map,
+          debug_info=api_util.debug_info("pallas index_map",
+                                         index_map,
+                                         (0,) * num_args, {})),
+      (core.ShapedArray((), jnp.int32),) * num_args
   )
   _, used_inputs = pe.dce_jaxpr(jaxpr, used_outputs=[True] * len(jaxpr.outvars))
   return used_inputs

--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -1001,7 +1001,10 @@ def pallas_call_checkify_oob_grid(error: checkify.Error,
     )
   flat_args, jaxpr_in_tree = jax.tree_util.tree_flatten((jnp.int32(0),))
   wrapped_loop, _ = api_util.flatten_fun_nokwargs(
-      lu.wrap_init(f), jaxpr_in_tree)
+      lu.wrap_init(f,
+                   debug_info=api_util.debug_info("checkify oob_grid_access",
+                                                  f, (0,), {})),
+      jaxpr_in_tree)
   with pallas_core.tracing_grid_env(grid_mapping.grid, ()):
     avals_in = map(jax_core.get_aval, flat_args)
     traced_loop, _, consts, () = pe.trace_to_jaxpr_dynamic(
@@ -1426,7 +1429,7 @@ def _pallas_call_state_discharge_rule(
       )
   )
   new_jaxpr, _, consts, _ = pe.trace_to_jaxpr_dynamic(
-      lu.wrap_init(_rewritten_body),
+      lu.wrap_init(_rewritten_body, debug_info=jaxpr.debug_info),
       [
           *index_map_avals,
           *ref_avals,

--- a/jax/_src/pallas/primitives.py
+++ b/jax/_src/pallas/primitives.py
@@ -848,7 +848,11 @@ def run_scoped(f: Callable[..., Any], *types: Any, **kw_types: Any) -> Any:
   types in addition to :class:`jax.experimental.pallas.MemoryRef`.
   """
   flat_types, in_tree = tree_util.tree_flatten((types, kw_types))
-  flat_fun, out_tree_thunk = api_util.flatten_fun(lu.wrap_init(f), in_tree)
+  flat_fun, out_tree_thunk = api_util.flatten_fun(
+      lu.wrap_init(f,
+                   debug_info=api_util.debug_info("pallas run_scoped",
+                                                  f, types, kw_types)),
+      in_tree)
   # We allow ref avals to be transformed references.
   ref_avals = [t.get_ref_aval() for t in flat_types]
   avals = [

--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -415,7 +415,10 @@ def lower_fun(
   fn = fun if multiple_results else lambda *args, **kw: (fun(*args, **kw),)
 
   def f_lowered(ctx: LoweringRuleContext, *args, **params):
-    wrapped_fun = lu.wrap_init(fn, params)
+    wrapped_fun = lu.wrap_init(
+        fn, params,
+        debug_info=api_util.debug_info("pallas triton lower_fun", fun,
+                                       args, params))
     jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(wrapped_fun, ctx.avals_in)
     jaxpr = jax_core.ClosedJaxpr(jaxpr, consts)
     out = _closed_call_lowering_rule(ctx, *args, call_jaxpr=jaxpr)
@@ -539,7 +542,11 @@ def _associative_scan_lowering(body, ctx: LoweringRuleContext, args, axes):
   ]
   in_tree = tree_util.tree_structure((args, args))
   flat_fun, out_tree_thunk = api_util.flatten_fun_nokwargs(
-      lu.wrap_init(body), in_tree
+      lu.wrap_init(
+          body,
+          debug_info=api_util.debug_info("pallas triton associative_scan",
+                                         body, (args, args), {})),
+      in_tree
   )
   combine_jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(
       flat_fun, in_avals
@@ -2185,7 +2192,11 @@ def _reduction_lowering(body, ctx: LoweringRuleContext, a, axes):
   mapped_avals = [jax_core.ShapedArray((), aval.dtype) for aval in ctx.avals_in]
   in_tree = tree_util.tree_structure((a, a))
   flat_fun, out_tree_thunk = api_util.flatten_fun_nokwargs(
-      lu.wrap_init(body), in_tree
+      lu.wrap_init(
+          body,
+          debug_info=api_util.debug_info("pallas triton reduction",
+                                         body, (a, a), {})),
+      in_tree
   )
   combine_jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(
       flat_fun, [*mapped_avals, *mapped_avals]

--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -19,6 +19,7 @@ from jax._src.core import (
 
 from jax._src.api_util import (
   argnums_partial as argnums_partial,
+  debug_info as debug_info,
   donation_vector as donation_vector,
   flatten_axes as flatten_axes,
   flatten_fun as flatten_fun,

--- a/jax/experimental/key_reuse/_core.py
+++ b/jax/experimental/key_reuse/_core.py
@@ -397,7 +397,10 @@ def jaxpr_type_signature(jaxpr: core.Jaxpr) -> KeyReuseSignature:
 def function_type_signature(fun: Callable[..., Any], *args: Any) -> KeyReuseSignature:
   args_flat, in_tree = tree_util.tree_flatten(args)
   in_avals_flat = [core.get_aval(arg) for arg in args_flat]
-  wrapped_fun, _ = api_util.flatten_fun_nokwargs(lu.wrap_init(fun), in_tree)
+  wrapped_fun, _ = api_util.flatten_fun_nokwargs(
+      lu.wrap_init(fun,
+                   debug_info=api_util.debug_info("key_reuse", fun, args, {})),
+      in_tree)
   jaxpr, _, _, () = pe.trace_to_jaxpr_dynamic(wrapped_fun, in_avals_flat)
   return jaxpr_type_signature(jaxpr)
 

--- a/tests/name_stack_test.py
+++ b/tests/name_stack_test.py
@@ -15,6 +15,7 @@ import functools
 
 from absl.testing import absltest
 import jax
+from jax import api_util
 import jax.numpy as jnp
 from jax._src import core
 from jax import lax
@@ -85,11 +86,12 @@ class NameStackTest(jtu.JaxTestCase):
   def test_call_primitive_jaxpr_should_not_store_outer_name_stack(self):
     @jax.named_scope('foo')
     def f(x):
-      @lu.wrap_init
       @jax.named_scope('bar')
       def _f(x):
         return [x + 1]
-      return core.call(_f, x)[0]
+      return core.call(lu.wrap_init(
+          _f,
+          debug_info=api_util.debug_info("test", _f, (0,), {})), x)[0]
 
     jaxpr = jax.make_jaxpr(f)(2).jaxpr
     self.assertEqual(str(jaxpr.eqns[0].params['call_jaxpr'].eqns[0].source_info.name_stack), 'bar')

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -17,6 +17,7 @@ import operator
 from absl.testing import absltest
 
 import jax
+from jax import api_util
 from jax._src import linear_util as lu
 from jax._src import test_util as jtu
 from jax._src import util
@@ -62,7 +63,10 @@ class UtilTest(jtu.JaxTestCase):
       store.store(aux_output)
       return (results[0:len(args)], dict(zip(kwargs_keys, results[len(args):])))
 
-    wf = lu.wrap_init(f)  # Wraps `f` as a `WrappedFun`.
+    # Wraps `f` as a `WrappedFun`.
+    wf = lu.wrap_init(
+        f,
+        debug_info=api_util.debug_info("test", f, (1, 2), dict(three=3, four=4)))
     wf, out_thunk = kw_to_positional(wf, 2)
     # Call the transformed function.
     scaled_positional, scaled_kwargs = wf.call_wrapped(1, 2, three=3, four=4)


### PR DESCRIPTION
This follows in a series, starting with #26078 and #26313, adding debug_info to more calls to lu.wrap_init.

Fixes in jet, stateful, key_reuse, ode, pallas, tests.