### PR TITLE
Bump the minimum Mac OS X version for x86 builds to 11.0.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -233,7 +233,7 @@ build:ci_linux_aarch64_cuda --config=cuda --config=build_cuda_with_nvcc
 build:ci_linux_aarch64_cuda --action_env=CLANG_CUDA_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"
 
 # Mac x86 CI configs
-build:ci_darwin_x86_64 --macos_minimum_os=10.14
+build:ci_darwin_x86_64 --macos_minimum_os=11.0
 build:ci_darwin_x86_64 --config=macos_cache_push
 build:ci_darwin_x86_64 --verbose_failures=true
 build:ci_darwin_x86_64 --color=yes

--- a/jaxlib/jax.bzl
+++ b/jaxlib/jax.bzl
@@ -57,7 +57,7 @@ PLATFORM_TAGS_DICT = {
     ("Linux", "x86_64"): ("manylinux2014", "x86_64"),
     ("Linux", "aarch64"): ("manylinux2014", "aarch64"),
     ("Linux", "ppc64le"): ("manylinux2014", "ppc64le"),
-    ("Darwin", "x86_64"): ("macosx_10_14", "x86_64"),
+    ("Darwin", "x86_64"): ("macosx_11_0", "x86_64"),
     ("Darwin", "arm64"): ("macosx_11_0", "arm64"),
     ("Windows", "AMD64"): ("win", "amd64"),
 }


### PR DESCRIPTION
The x86 build stopped building completely due to a use of std::filesystem::path, which was added in 10.15. We've dropped x86 support, but this is an easy enough fix to make and moves x86 to parity with ARM.