### PR TITLE
[better_errors] Continue adding debug info to Jaxprs (step 8)

### DIFF
--- a/jax/_src/custom_partitioning.py
+++ b/jax/_src/custom_partitioning.py
@@ -476,7 +476,7 @@ class custom_partitioning:
       args = tuple(x if i in static_argnums else x for i, x in enumerate(args))
       dyn_argnums = [i for i in range(len(args)) if i not in static_argnums]
       f_, dyn_args = api_util.argnums_partial(
-          lu.wrap_init(self.fun),
+          lu.wrap_init(self.fun, debug_info=debug),
           dyn_argnums,
           args,
           require_static_args_hashable=False,

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -3127,7 +3127,12 @@ class MeshExecutable(stages.XlaExecutable):
     if self._all_args_info is None:
       kept_args = args_after_dce
       ref_avals = self.in_avals
-      debug_info = None
+      # TODO(necula): ensure we have actual debug info; need debug info
+      # before DCE.
+      # See https://github.com/jax-ml/jax/issues/26480.
+      debug_info = core.DebugInfo(
+          "MeshExecutable", "<unknown>",
+          tuple(f"args[{i}]" for i in range(len(args))), ())
     else:
       kept_args = args
       ref_avals = self._all_args_info.in_avals

--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -1626,7 +1626,8 @@ def _shard_map_linearize(trace, shard_map_p, f: lu.WrappedFun,
 
   nz_tangents_in = [t for (t, nz) in zip(tangents, nzs_in) if nz]
   nz_tangents_out = shard_map_p.bind_with_trace(trace.tangent_trace,
-      (lu.wrap_init(f_tangent), *residuals, *nz_tangents_in), tangent_params)
+      (lu.wrap_init(f_tangent, debug_info=lin_jaxpr.debug_info),
+       *residuals, *nz_tangents_in), tangent_params)
   nz_tangents_out_iter = iter(nz_tangents_out)
   tangents_out = [next(nz_tangents_out_iter) if nz else ad.Zero.from_primal_value(primal)
                   for nz, primal in zip(nzs_out, primals_out)]


### PR DESCRIPTION
This follows in a series, starting with #26078 and #26313, adding debug_info to more calls to lu.wrap_init.

These are some leftover changes, in particular those needed when running with `JAX_USE_DIRECT_LINEARIZE=1`.