### PR TITLE
[ROCm] Only run core tests for ROCm post-build checks

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -55,5 +55,5 @@ jobs:
       - name: Run tests
         run: |
           cd $WORKSPACE_DIR
-          python3 build/rocm/ci_build test $TEST_IMAGE
+          python3 build/rocm/ci_build test $TEST_IMAGE --test-cmd "pytest tests/core_test.py"
 


### PR DESCRIPTION
We are running a bunch of tests for the new [ROCm post-build check](https://github.com/jax-ml/jax/actions/workflows/rocm-ci.yml). We probably don't need to run all of these and some of these are failing. This reduces the tests we run to just the core tests, and we're good at keeping these stable-ish.