### PR TITLE
Fix doc string for PmapSharding

### DIFF
--- a/jax/_src/sharding_impls.py
+++ b/jax/_src/sharding_impls.py
@@ -610,7 +610,7 @@ class PmapSharding(jsharding.Sharding):
       shape: The shape of the input array.
       sharded_dim: Dimension the input array is sharded on. Defaults to 0.
       devices: Optional sequence of devices to use. If omitted, the implicit
-      device order used by pmap is used, which is the order of
+        device order used by pmap is used, which is the order of
         :func:`jax.local_devices`.
     """
     if sharded_dim is None:


### PR DESCRIPTION
Lack of indent was resulting in extra parameter being shown in the HTML generated docs
![Captura de pantalla 2025-02-12 a la(s) 13 42 16](https://github.com/user-attachments/assets/23393c55-861b-4d97-83df-584a81442824)

