### PR TITLE
Add jax.random.multinomial.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Patch release of 0.5.1
     {func}`jax.lax.reduce_and`, {func}`jax.lax.reduce_or`, and {func}`jax.lax.reduce_xor`.
   * {func}`jax.lax.linalg.qr`, and {func}`jax.scipy.linalg.qr`, now support
     column-pivoting on CPU and GPU. See {jax-issue}`#20282` and
+  * Added {func}`jax.random.multinomial`.
     {jax-issue}`#25955` for more details.
 
 * Changes

--- a/docs/jax.random.rst
+++ b/docs/jax.random.rst
@@ -53,6 +53,7 @@ Random Samplers
     logistic
     lognormal
     maxwell
+    multinomial
     multivariate_normal
     normal
     orthogonal

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -2661,6 +2661,67 @@ random_clone_p.def_abstract_eval(lambda x: x)
 batching.defvectorized(random_clone_p)
 mlir.register_lowering(random_clone_p, lambda _, k: [k])
 
+
+def multinomial(
+    key: Array,
+    n: RealArray,
+    p: RealArray,
+    *,
+    shape: Shape | None = None,
+    dtype: DTypeLikeFloat = float,
+    unroll: int | bool = 1,
+):
+  r"""Sample from a multinomial distribution.
+
+  The probability mass function is
+
+  .. math::
+      f(x;n,p) = \frac{n!}{x_1! \ldots x_k!} p_1^{x_1} \ldots p_k^{x_k}
+
+  Args:
+    key: PRNG key.
+    n: number of trials. Should have shape broadcastable to ``p.shape[:-1]``.
+    p: probability of each outcome, with outcomes along the last axis.
+    shape: optional, a tuple of nonnegative integers specifying the result batch
+      shape, that is, the prefix of the result shape excluding the last axis.
+      Must be broadcast-compatible with ``p.shape[:-1]``. The default (None)
+      produces a result shape equal to ``p.shape``.
+    dtype: optional, a float dtype for the returned values (default float64 if
+      jax_enable_x64 is true, otherwise float32).
+    unroll: optional, unroll parameter passed to :func:`jax.lax.scan` inside the
+      implementation of this function.
+
+  Returns:
+    An array of counts for each outcome with the specified dtype and with shape
+      ``p.shape`` if ``shape`` is None, otherwise ``shape + (p.shape[-1],)``.
+  """
+
+  key, _ = _check_prng_key("multinomial", key)
+  check_arraylike("multinomial", n, p)
+  n, p = promote_dtypes_inexact(n, p)
+
+  if shape is None:
+    shape = p.shape
+  n = jnp.broadcast_to(n, shape[:-1])
+  p = jnp.broadcast_to(p, shape)
+
+  def f(remainder, ratio_key):
+    ratio, key = ratio_key
+    count = binomial(key, remainder, ratio.clip(0, 1), dtype=remainder.dtype)
+    return remainder - count, count
+
+  p = jnp.moveaxis(p, -1, 0)
+
+  remaining_probs = lax.cumsum(p, 0, reverse=True)
+  ratios = p / jnp.where(remaining_probs == 0, 1, remaining_probs)
+
+  keys = split(key, ratios.shape[0])
+  remainder, counts = lax.scan(f, n, (ratios, keys), unroll=unroll)
+  # final remainder should be zero
+
+  return jnp.moveaxis(counts, 0, -1).astype(dtype)
+
+
 def clone(key):
   """Clone a key for reuse
 

--- a/jax/random.py
+++ b/jax/random.py
@@ -232,6 +232,7 @@ from jax._src.random import (
   loggamma as loggamma,
   lognormal as lognormal,
   maxwell as maxwell,
+  multinomial as multinomial,
   multivariate_normal as multivariate_normal,
   normal as normal,
   orthogonal as orthogonal,


### PR DESCRIPTION
Relanding https://github.com/jax-ml/jax/pull/25688 due to https://github.com/jax-ml/jax/pull/26336.

Reduced the value of the `trials` argument to `multinomial` in the tests, and increased the error tolerance accordingly.

Fixes #13327