### PR TITLE
feat(gh-13291): Add Pareto distribution functions: `cdf`, `logcdf`, `logsf`, `sf`, `ppf`, and corresponding tests

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -446,8 +446,13 @@ jax.scipy.stats.pareto
 .. autosummary::
   :toctree: _autosummary
 
+   logcdf
    logpdf
+   logsf
+   cdf
    pdf
+   ppf
+   sf
 
 jax.scipy.stats.poisson
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/jax/_src/scipy/stats/pareto.py
+++ b/jax/_src/scipy/stats/pareto.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import numpy as np
 
 from jax._src import lax
@@ -21,7 +22,9 @@ from jax._src.numpy.util import promote_args_inexact
 from jax._src.typing import Array, ArrayLike
 
 
-def logpdf(x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+def logpdf(
+  x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1
+) -> Array:
   r"""Pareto log probability distribution function.
 
   JAX implementation of :obj:`scipy.stats.pareto` ``logpdf``.
@@ -47,17 +50,26 @@ def logpdf(x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1)
     array of logpdf values.
 
   See Also:
-    :func:`jax.scipy.stats.pareto.pdf`
+    - :func:`jax.scipy.stats.pareto.logcdf`
+    - :func:`jax.scipy.stats.pareto.logsf`
+    - :func:`jax.scipy.stats.pareto.cdf`
+    - :func:`jax.scipy.stats.pareto.pdf`
+    - :func:`jax.scipy.stats.pareto.ppf`
+    - :func:`jax.scipy.stats.pareto.sf`
   """
   x, b, loc, scale = promote_args_inexact("pareto.logpdf", x, b, loc, scale)
   one = _lax_const(x, 1)
   scaled_x = lax.div(lax.sub(x, loc), scale)
   normalize_term = lax.log(lax.div(scale, b))
-  log_probs = lax.neg(lax.add(normalize_term, lax.mul(lax.add(b, one), lax.log(scaled_x))))
+  log_probs = lax.neg(
+    lax.add(normalize_term, lax.mul(lax.add(b, one), lax.log(scaled_x)))
+  )
   return jnp.where(lax.lt(x, lax.add(loc, scale)), -np.inf, log_probs)
 
 
-def pdf(x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+def pdf(
+  x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1
+) -> Array:
   r"""Pareto probability distribution function.
 
   JAX implementation of :obj:`scipy.stats.pareto` ``pdf``.
@@ -83,6 +95,219 @@ def pdf(x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) ->
     array of pdf values.
 
   See Also:
-    :func:`jax.scipy.stats.pareto.logpdf`
+    - :func:`jax.scipy.stats.pareto.logcdf`
+    - :func:`jax.scipy.stats.pareto.logpdf`
+    - :func:`jax.scipy.stats.pareto.logsf`
+    - :func:`jax.scipy.stats.pareto.cdf`
+    - :func:`jax.scipy.stats.pareto.ppf`
+    - :func:`jax.scipy.stats.pareto.sf`
   """
   return lax.exp(logpdf(x, b, loc, scale))
+
+
+def cdf(
+  x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1
+) -> Array:
+  r"""Pareto cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.pareto` ``cdf``.
+
+  The Pareto cumulative distribution function is given by
+
+  .. math::
+
+     F(x, b) = \begin{cases}
+       1 - x^{-b} & x \ge 1\\
+       0 & x < 1
+     \end{cases}
+
+  and is defined for :math:`b > 0`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of CDF values.
+
+  See Also:
+    - :func:`jax.scipy.stats.pareto.logcdf`
+    - :func:`jax.scipy.stats.pareto.logpdf`
+    - :func:`jax.scipy.stats.pareto.logsf`
+    - :func:`jax.scipy.stats.pareto.pdf`
+    - :func:`jax.scipy.stats.pareto.ppf`
+    - :func:`jax.scipy.stats.pareto.sf`
+  """
+  x, b, loc, scale = promote_args_inexact("pareto.cdf", x, b, loc, scale)
+  one = _lax_const(x, 1)
+  zero = _lax_const(x, 0)
+  scaled_x = lax.div(lax.sub(x, loc), scale)
+  cdf = lax.sub(one, lax.pow(scaled_x, lax.neg(b)))
+  return jnp.where(lax.lt(x, lax.add(loc, scale)), zero, cdf)
+
+
+def logcdf(
+  x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1
+) -> Array:
+  r"""Pareto log cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.pareto` ``logcdf``.
+
+  The Pareto cumulative distribution function is given by
+
+  .. math::
+
+     F(x, b) = \begin{cases}
+       1 - x^{-b} & x \ge 1\\
+       0 & x < 1
+     \end{cases}
+
+  and is defined for :math:`b > 0`.
+
+  Args:
+    x: arraylike, value at which to evaluate the CDF
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logCDF values.
+
+  See Also:
+    - :func:`jax.scipy.stats.pareto.logpdf`
+    - :func:`jax.scipy.stats.pareto.logsf`
+    - :func:`jax.scipy.stats.pareto.cdf`
+    - :func:`jax.scipy.stats.pareto.pdf`
+    - :func:`jax.scipy.stats.pareto.ppf`
+    - :func:`jax.scipy.stats.pareto.sf`
+  """
+  x, b, loc, scale = promote_args_inexact("pareto.logcdf", x, b, loc, scale)
+  scaled_x = lax.div(lax.sub(x, loc), scale)
+  logcdf_val = lax.log1p(lax.neg(lax.pow(scaled_x, lax.neg(b))))
+  return jnp.where(lax.lt(x, lax.add(loc, scale)), -np.inf, logcdf_val)
+
+
+def logsf(
+  x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1
+) -> Array:
+  r"""Pareto log survival function.
+
+  JAX implementation of :obj:`scipy.stats.pareto` ``logsf``.
+
+  The Pareto survival function is given by
+
+  .. math::
+
+     S(x, b) = \begin{cases}
+       x^{-b} & x \ge 1\\
+       1 & x < 1
+     \end{cases}
+
+  and is defined for :math:`b > 0`.
+
+  Args:
+    x: arraylike, value at which to evaluate the survival function
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of log survival function values.
+
+  See Also:
+    - :func:`jax.scipy.stats.pareto.logcdf`
+    - :func:`jax.scipy.stats.pareto.logpdf`
+    - :func:`jax.scipy.stats.pareto.cdf`
+    - :func:`jax.scipy.stats.pareto.pdf`
+    - :func:`jax.scipy.stats.pareto.ppf`
+    - :func:`jax.scipy.stats.pareto.sf`
+  """
+  x, b, loc, scale = promote_args_inexact("pareto.logsf", x, b, loc, scale)
+  zero = _lax_const(x, 0)
+  scaled_x = lax.div(lax.sub(x, loc), scale)
+  logsf_val = lax.neg(lax.mul(b, lax.log(scaled_x)))
+  return jnp.where(lax.lt(x, lax.add(loc, scale)), zero, logsf_val)
+
+
+def sf(
+  x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1
+) -> Array:
+  r"""Pareto survival function.
+
+  JAX implementation of :obj:`scipy.stats.pareto` ``sf``.
+
+  The Pareto survival function is given by
+
+  .. math::
+
+     S(x, b) = \begin{cases}
+       x^{-b} & x \ge 1\\
+       1 & x < 1
+     \end{cases}
+
+  and is defined for :math:`b > 0`.
+
+  Args:
+    x: arraylike, value at which to evaluate the survival function
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of survival function values.
+
+  See Also:
+    - :func:`jax.scipy.stats.pareto.logcdf`
+    - :func:`jax.scipy.stats.pareto.logpdf`
+    - :func:`jax.scipy.stats.pareto.logsf`
+    - :func:`jax.scipy.stats.pareto.cdf`
+    - :func:`jax.scipy.stats.pareto.pdf`
+    - :func:`jax.scipy.stats.pareto.ppf`
+  """
+  return lax.exp(logsf(x, b, loc, scale))
+
+
+def ppf(
+  q: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1
+) -> Array:
+  r"""Pareto percent point function (inverse CDF).
+
+  JAX implementation of :obj:`scipy.stats.pareto` ``ppf``.
+
+  The Pareto percent point function is the inverse of the Pareto CDF, and is
+  given by
+
+  .. math::
+
+     F^{-1}(q, b) = \begin{cases}
+       (1 - q)^{-1/b} & 0 \le q < 1\\
+       \text{NaN} & \text{otherwise}
+     \end{cases}
+
+  and is defined for :math:`b > 0`.
+
+  Args:
+    q: arraylike, value at which to evaluate the inverse CDF
+    b: arraylike, distribution shape parameter
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of percent point function values.
+
+  See Also:
+    - :func:`jax.scipy.stats.pareto.logcdf`
+    - :func:`jax.scipy.stats.pareto.logpdf`
+    - :func:`jax.scipy.stats.pareto.logsf`
+    - :func:`jax.scipy.stats.pareto.cdf`
+    - :func:`jax.scipy.stats.pareto.pdf`
+    - :func:`jax.scipy.stats.pareto.sf`
+  """
+  q, b, loc, scale = promote_args_inexact("pareto.ppf", q, b, loc, scale)
+  one = _lax_const(q, 1)
+  ppf_val = lax.add(
+    loc, lax.mul(scale, lax.pow(lax.sub(one, q), lax.neg(lax.div(one, b))))
+  )
+  return jnp.where(jnp.isnan(q) | (q < 0) | (q > 1), np.nan, ppf_val)

--- a/jax/scipy/stats/pareto.py
+++ b/jax/scipy/stats/pareto.py
@@ -16,6 +16,11 @@
 # See PEP 484 & https://github.com/jax-ml/jax/issues/7570
 
 from jax._src.scipy.stats.pareto import (
+  logcdf as logcdf,
   logpdf as logpdf,
+  logsf as logsf,
+  cdf as cdf,
   pdf as pdf,
+  ppf as ppf,
+  sf as sf,
 )

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -1104,6 +1104,103 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
                               tol=1e-3)
       self._CompileAndCheck(lax_fun, args_maker)
 
+  @genNamedParametersNArgs(4)
+  def testParetoPdf(self, shapes, dtypes):
+    rng = jtu.rand_positive(self.rng())
+    scipy_fun = osp_stats.pareto.pdf
+    lax_fun = lsp_stats.pareto.pdf
+
+    def args_maker():
+      x, b, loc, scale = map(rng, shapes, dtypes)
+      return [x, b, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(
+        scipy_fun, lax_fun, args_maker, check_dtypes=False, tol=1e-3
+      )
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(4)
+  def testParetoLogCdf(self, shapes, dtypes):
+    rng = jtu.rand_positive(self.rng())
+    scipy_fun = osp_stats.pareto.logcdf
+    lax_fun = lsp_stats.pareto.logcdf
+
+    def args_maker():
+      x, b, loc, scale = map(rng, shapes, dtypes)
+      return [x, b, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(
+        scipy_fun, lax_fun, args_maker, check_dtypes=False, tol=1e-3
+      )
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(4)
+  def testParetoCdf(self, shapes, dtypes):
+    rng = jtu.rand_positive(self.rng())
+    scipy_fun = osp_stats.pareto.cdf
+    lax_fun = lsp_stats.pareto.cdf
+
+    def args_maker():
+      x, b, loc, scale = map(rng, shapes, dtypes)
+      return [x, b, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(
+        scipy_fun, lax_fun, args_maker, check_dtypes=False, tol=1e-3
+      )
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(4)
+  def testParetoPpf(self, shapes, dtypes):
+    rng_positive = jtu.rand_positive(self.rng())
+    rng_uniform = jtu.rand_uniform(self.rng())
+    scipy_fun = osp_stats.pareto.ppf
+    lax_fun = lsp_stats.pareto.ppf
+
+    def args_maker():
+      q = rng_uniform(shapes[0], dtypes[0])
+      b, loc, scale = map(rng_positive, shapes[1:], dtypes[1:])
+      return [q, b, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(
+        scipy_fun, lax_fun, args_maker, check_dtypes=False, tol=1e-3
+      )
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(4)
+  def testParetoSf(self, shapes, dtypes):
+    rng = jtu.rand_positive(self.rng())
+    scipy_fun = osp_stats.pareto.sf
+    lax_fun = lsp_stats.pareto.sf
+
+    def args_maker():
+      x, b, loc, scale = map(rng, shapes, dtypes)
+      return [x, b, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(
+        scipy_fun, lax_fun, args_maker, check_dtypes=False, tol=1e-3
+      )
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(4)
+  def testParetoLogSf(self, shapes, dtypes):
+    rng = jtu.rand_positive(self.rng())
+    scipy_fun = osp_stats.pareto.logsf
+    lax_fun = lsp_stats.pareto.logsf
+
+    def args_maker():
+      x, b, loc, scale = map(rng, shapes, dtypes)
+      return [x, b, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(
+        scipy_fun, lax_fun, args_maker, check_dtypes=False, tol=1e-3
+      )
+      self._CompileAndCheck(lax_fun, args_maker)
 
   @genNamedParametersNArgs(4)
   def testTLogPdf(self, shapes, dtypes):


### PR DESCRIPTION
I have implemented the following functions along with their test cases.

- `jax.scipy.stats.pareto.logcdf`
- `jax.scipy.stats.pareto.logppf`
- `jax.scipy.stats.pareto.logsf`
- `jax.scipy.stats.pareto.cdf`
- `jax.scipy.stats.pareto.ppf`
- `jax.scipy.stats.pareto.sf`