### PR TITLE
[better_errors] Cleanup use of DebugInfo.arg_names and result_paths

### DIFF
--- a/docs/aot.md
+++ b/docs/aot.md
@@ -56,7 +56,7 @@ some other features along the way. An example:
 >>> # Print lowered HLO
 >>> print(lowered.as_text())
 module @jit_f attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
-  func.func public @main(%arg0: tensor<i32>, %arg1: tensor<i32>) -> (tensor<i32> {jax.result_info = ""}) {
+  func.func public @main(%arg0: tensor<i32>, %arg1: tensor<i32>) -> (tensor<i32> {jax.result_info = "result"}) {
     %c = stablehlo.constant dense<2> : tensor<i32>
     %0 = stablehlo.multiply %c, %arg0 : tensor<i32>
     %1 = stablehlo.add %0, %arg1 : tensor<i32>
@@ -140,7 +140,7 @@ to invoke the resulting compiled function. Continuing with our example above:
 >>> # Lowered HLO, specialized to the *value* of the first argument (7)
 >>> print(lowered_with_x.as_text())
 module @jit_f attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
-  func.func public @main(%arg0: tensor<i32>) -> (tensor<i32> {jax.result_info = ""}) {
+  func.func public @main(%arg0: tensor<i32>) -> (tensor<i32> {jax.result_info = "result"}) {
     %c = stablehlo.constant dense<14> : tensor<i32>
     %0 = stablehlo.add %c, %arg0 : tensor<i32>
     return %0 : tensor<i32>

--- a/docs/export/export.md
+++ b/docs/export/export.md
@@ -44,7 +44,7 @@ Here is an example:
 (ShapedArray(float32[]),)
 
 >>> print(re.search(r".*@main.*", exported.mlir_module()).group(0))
-  func.func public @main(%arg0: tensor<f32> loc("x")) -> (tensor<f32> {jax.result_info = ""}) {
+  func.func public @main(%arg0: tensor<f32> loc("x")) -> (tensor<f32> {jax.result_info = "result"}) {
 
 >>> # And you can serialize the Exported to a bytearray.
 >>> serialized: bytearray = exported.serialize()
@@ -206,7 +206,7 @@ as in the following example:
 >>> _ = mlir.register_lowering(new_prim, lambda ctx, o: mlir.custom_call("my_new_prim", operands=[o], result_types=[o.type]).results)
 >>> print(jax.jit(new_prim.bind).lower(1.).compiler_ir())
 module @jit_bind attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
-  func.func public @main(%arg0: tensor<f32>) -> (tensor<f32> {jax.result_info = ""}) {
+  func.func public @main(%arg0: tensor<f32>) -> (tensor<f32> {jax.result_info = "result"}) {
     %0 = stablehlo.custom_call @my_new_prim(%arg0) {api_version = 2 : i32, backend_config = ""} : (tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -458,7 +458,7 @@ def saved_residuals(f: Callable,
   return _saved_residuals(jaxpr, debug_info.arg_names)
 
 def _saved_residuals(jaxpr: core.Jaxpr,
-                     arg_names: tuple[str | None, ...]) -> list[tuple[core.AbstractValue, str]]:
+                     arg_names: Sequence[str]) -> list[tuple[core.AbstractValue, str]]:
   res_lits = [x for x in jaxpr.outvars if     isinstance(x, core.Literal)]
   res_vars = {x for x in jaxpr.outvars if not isinstance(x, core.Literal)}
 
@@ -473,7 +473,7 @@ def _saved_residuals(jaxpr: core.Jaxpr,
 
   for i, v in enumerate(jaxpr.invars):
     if v in res_vars:
-      if arg_names[i] is not None:
+      if arg_names[i]:
         src = f'from the argument {arg_names[i]}'
       else:
         src = 'from the argument at flattened index {i}'

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2274,7 +2274,7 @@ def _check_sharding(aval, s):
       aval = core.get_token_aval()
     if not isinstance(s, PmapSharding):
       pjit.pjit_check_aval_sharding(
-          (s,), (aval,), None, "device_put args", allow_uneven_sharding=False)
+          (s,), (aval,), ("",), "device_put args", allow_uneven_sharding=False)
     s.shard_shape(aval.shape)  # should raise an Error if incompatible
 
 

--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -662,7 +662,7 @@ def _non_static_arg_names(fn_signature: inspect.Signature | None,
                           args: Sequence[Any], kwargs: dict[str, Any],
                           static_argnums: Sequence[int],
                           static_argnames: Sequence[str],
-                          ) -> tuple[str | None, ...]:
+                          ) -> tuple[str, ...]:
   """Returns the names of the non-static arguments.
 
   If the `fn_signature` is given then we get from it the names of the

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -149,8 +149,8 @@ class Jaxpr:
     debug_info = debug_info or lu._missing_debug_info("core.Jaxpr")
     self._debug_info = debug_info.resolve_result_paths()
     # TODO(necula): re-enable these safety checks
-    # assert (not debug_info or len(debug_info.arg_names) == len(invars)), (debug_info, invars)
-    # assert (not debug_info or len(debug_info.result_paths) == len(outvars)), (debug_info, outvars)
+    # assert (len(debug_info.arg_names) == len(invars)), (debug_info, invars)
+    # assert (len(debug_info.result_paths) == len(outvars)), (debug_info, outvars)
 
   def __str__(self):
     return str(self.pretty_print())

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -135,7 +135,7 @@ def jvp_subtrace_aux(f, store, tag, primals, tangents):
 
 def convert_constvars_jaxpr_constvars_at_end(jaxpr: core.Jaxpr) -> core.Jaxpr:
   dbg = jaxpr.debug_info._replace(
-      arg_names=jaxpr.debug_info.arg_names + (None,) * len(jaxpr.constvars))
+      arg_names=jaxpr.debug_info.arg_names + ("",) * len(jaxpr.constvars))
   return core.Jaxpr(constvars=(),
                     invars=jaxpr.invars + jaxpr.constvars,
                     outvars=jaxpr.outvars, eqns=jaxpr.eqns,

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -1113,7 +1113,7 @@ def lower_jaxpr_to_module(
     result_shardings: Sequence[JSharding | AUTO | None] | None = None,
     in_layouts: Sequence[DeviceLocalLayout | None | AutoLayout] | None = None,
     out_layouts: Sequence[DeviceLocalLayout | None | AutoLayout] | None = None,
-    arg_names: Sequence[str | None] | None = None,
+    arg_names: Sequence[str] | None = None,
     result_names: Sequence[str] | None = None,
     num_replicas: int = 1,
     num_partitions: int = 1,

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -842,7 +842,7 @@ def convert_constvars_jaxpr(jaxpr: Jaxpr) -> Jaxpr:
   """Moves the constvars to the start of invars."""
   config.enable_checks.value and core.check_jaxpr(jaxpr)
   dbg = jaxpr.debug_info._replace(
-      arg_names=(None,) * len(jaxpr.constvars) + jaxpr.debug_info.arg_names)
+      arg_names=("",) * len(jaxpr.constvars) + jaxpr.debug_info.arg_names)
   lifted_jaxpr = Jaxpr(constvars=(),
                        invars=jaxpr.constvars + jaxpr.invars,
                        outvars=jaxpr.outvars, eqns=jaxpr.eqns,
@@ -1574,7 +1574,7 @@ class DynamicJaxprTracer(core.Tracer):
 
     origin = ("The error occurred while tracing the function "
               f"{dbg.func_src_info} for {dbg.traced_for}. ")
-    if invar_pos and dbg.arg_names:
+    if invar_pos:
       try:
         arg_names = [dbg.arg_names[i] for i in invar_pos]
       except IndexError:

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -3260,7 +3260,7 @@ def check_array_xla_sharding_layout_match(
   from jax._src.array import ArrayImpl
   # jaxpr_debug_info.arg_names are before DCE, so need to DCE them.
   arg_names = (
-      [a for i, a in enumerate(jaxpr_debug_info.arg_names)  # type: ignore
+      [a for i, a in enumerate(jaxpr_debug_info.arg_names)
        if i in kept_var_idx]
   )
   errors = []

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1554,7 +1554,7 @@ def _while_loop_jvp(primals, tangents, cond_nconsts, cond_jaxpr, body_nconsts,
   cond_debug = cond_jaxpr.jaxpr.debug_info
   augmented_debug = cond_debug and (
       cond_debug._replace(
-          arg_names=cond_debug.arg_names + (None,) * len(init_dot)
+          arg_names=cond_debug.arg_names + ("",) * len(init_dot)
       )
   )
   cond_jaxpr_augmented = core.Jaxpr(cond_jaxpr.jaxpr.constvars,

--- a/tests/mutable_array_test.py
+++ b/tests/mutable_array_test.py
@@ -274,13 +274,13 @@ class MutableArrayErrorsTest(jtu.JaxTestCase):
   def test_return_from_jit_pytree(self):
     with self.assertRaisesRegex(
         ValueError,
-        r"tree path \['hi'\]"):
+        r"tree path result\['hi'\]"):
       jax.jit(lambda x_ref: {'hi': x_ref})(core.mutable_array(jnp.arange(3)))
 
   def test_return_from_jit_closure(self):
     with self.assertRaisesRegex(
         ValueError,
-        r"tree path \['hi'\]"):
+        r"tree path result\['hi'\]"):
       x_ref = core.mutable_array(jnp.arange(3))
       jax.jit(lambda: {'hi': x_ref})()
 

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -6846,7 +6846,7 @@ class PJitErrorTest(jtu.JaxTestCase):
     spec = P(resources, None)
     mesh_size = str(math.prod([dim[1] for dim in mesh]))
     error = re.compile(
-        r"One of pjit outputs with pytree key path \['rrr'\].*" + spec_regex(spec) + r".*"
+        r"One of pjit outputs with pytree key path result\['rrr'\].*" + spec_regex(spec) + r".*"
         r"implies that the global size of its dimension 0 should be "
         r"divisible by " + mesh_size + r", but it is equal to 3", re.M | re.S)
     with self.assertRaisesRegex(ValueError, error):


### PR DESCRIPTION
Previously, we represented a missing arg name with `None`,
and a missing result path with the empty string. We now
adopt the same convention for arg names and use empty strings.
This simplifies the typing, and prevents the string "None" from
appearing in error messages.

I changed how we encode the result paths. Previously for a
function that returns a single array the path was the empty
string (the same as for an unknown path). And for a function
that returns a pair of arrays it was `([0], [1])`. Now we
add the "res" prefix: `("res",)` for a function returning a
single array and `(res[0], res[1])` for a function returning
a pair of arrays.

Finally, in debug_info_test, I removed the `check_tracer_arg_name`
so that all spied tracers are printed with the argument name they
depend on.