### PR TITLE
Fix test failure in PGLE tests.

### DIFF
--- a/tests/pgle_test.py
+++ b/tests/pgle_test.py
@@ -55,6 +55,7 @@ class PgleTest(jtu.JaxTestCase):
 
   def tearDown(self):
     cc.set_cache_dir(None)
+    cc.reset_cache()
     super().tearDown()
 
   def testPGLEProfilerGetFDOProfile(self):


### PR DESCRIPTION
We weren't completely resetting the compilation cache.