### PR TITLE
[ROCm][pallas:triton] Fix atomic min/max lowering for uint and float types

### DIFF
--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -501,7 +501,6 @@ def _atomic_rmw(
       result_type, op, ptr, val, mask=mask, sem=semantic, scope=sync_scope
   )
 
-
 def _associative_scan_lowering(body, ctx: LoweringRuleContext, args, axes):
   flat_args = tree_util.tree_leaves(args)
   (axis,) = axes
@@ -1085,6 +1084,20 @@ def _is_triton_pointer_type(t):
     return tt_dialect.PointerType.isinstance(t)
   return isinstance(t, tt_dialect.PointerType)
 
+def _fp_bits_type(t: ir.Type) -> ir.Type:
+  if isinstance(t, ir.RankedTensorType):
+    t_type = ir.RankedTensorType(t)
+    return ir.RankedTensorType.get(
+      t_type.shape, _fp_bits_type(t_type.element_type), t_type.encoding
+    )
+  elif _is_triton_pointer_type(t):
+    ptr_type = tt_dialect.PointerType(t)
+    return tt_dialect.PointerType.get(
+      _fp_bits_type(ptr_type.pointee_type), ptr_type.address_space
+    )
+  else:
+    assert isinstance(t, ir.FloatType)
+    return ir.IntegerType.get_signless(t.width)
 
 def _minus(x: ir.Value) -> ir.Value:
   if _is_triton_pointer_type(x.type):

--- a/jax/_src/pallas/triton/primitives.py
+++ b/jax/_src/pallas/triton/primitives.py
@@ -387,6 +387,58 @@ def _atomic_rmw(
       *args_flat, args_tree=args_tree, atomic_type=atomic_type
   )
 
+def _expand_atomic_fp_min_max(
+  atomic_type: AtomicOpType,
+  ptr: ir.Value,
+  val: ir.Value,
+  mask: ir.Value | None = None,
+  semantic: tt_dialect.MemSemantic = tt_dialect.MemSemantic.ACQUIRE_RELEASE,
+  sync_scope: tt_dialect.MemSyncScope = tt_dialect.MemSyncScope.GPU,
+) -> ir.Value:
+  """
+  Expands floating point min/max via sequence of integer min/max. Does not handle NaNs.
+
+  min:
+     return atomic_smin(i_ptr, i_val) if i_val >= 0 else atomic_umax(i_ptr, i_val)
+
+  max:
+     return atomic_smax(i_ptr, i_val) if i_val >= 0 else atomic_umin(i_ptr, i_val)
+
+  """
+
+  if isinstance(ptr.type, ir.RankedTensorType):
+    ptr_type = ir.RankedTensorType(ptr.type)
+    element_type = tt_dialect.PointerType(ptr_type.element_type)
+    result_type = ir.RankedTensorType.get(
+      ptr_type.shape, element_type.pointee_type, ptr_type.encoding
+    )
+  else:
+    result_type = tt_dialect.PointerType(ptr.type).pointee_type
+
+  ptr_cast = tt_dialect.bitcast(lowering._fp_bits_type(ptr.type), ptr)
+  val_cast = tt_dialect.bitcast(lowering._fp_bits_type(val.type), val)
+
+  zero = lowering._full(val_cast.type, 0)
+  pos_cmp = lowering._greater_equal(val_cast, zero, signed=True)
+  neg_cmp = lowering._less_than(val_cast, zero, signed=True)
+
+  pos_mask = pos_cmp if mask is None else arith_dialect.andi(mask, pos_cmp)
+  neg_mask = neg_cmp if mask is None else arith_dialect.andi(mask, neg_cmp)
+
+  pos_op, neg_op = (
+    (tt_dialect.RMWOp.MAX, tt_dialect.RMWOp.UMIN)
+    if atomic_type == AtomicOpType.MAX
+    else (tt_dialect.RMWOp.MIN, tt_dialect.RMWOp.UMAX)
+  )
+
+  pos_val = lowering._atomic_rmw(
+    pos_op, ptr_cast, val_cast, mask=pos_mask, semantic=semantic, sync_scope=sync_scope
+  )
+  neg_val = lowering._atomic_rmw(
+    neg_op, ptr_cast, val_cast, mask=neg_mask, semantic=semantic, sync_scope=sync_scope
+  )
+  result = arith_dialect.select(pos_cmp, pos_val, neg_val)
+  return tt_dialect.bitcast(result_type, result)
 
 @lowering.register_lowering(atomic_rmw_p)
 def _atomic_lowering_rule(
@@ -419,9 +471,23 @@ def _atomic_lowering_rule(
     else:
       op = tt_dialect.RMWOp.FADD
   elif atomic_type == AtomicOpType.MIN:
-    op = tt_dialect.RMWOp.MIN
+    if isinstance(val.type, ir.IntegerType):
+      op = (
+        tt_dialect.RMWOp.MIN
+        if jnp.issubdtype(value_aval.dtype, jnp.signedinteger)
+        else tt_dialect.RMWOp.UMIN
+      )
+    else:
+      return _expand_atomic_fp_min_max(atomic_type, ptr, val, mask=mask)
   elif atomic_type == AtomicOpType.MAX:
-    op = tt_dialect.RMWOp.MAX
+    if isinstance(val.type, ir.IntegerType):
+      op = (
+        tt_dialect.RMWOp.MAX
+        if jnp.issubdtype(value_aval.dtype, jnp.signedinteger)
+        else tt_dialect.RMWOp.UMAX
+      )
+    else:
+      return _expand_atomic_fp_min_max(atomic_type, ptr, val, mask=mask)
   elif atomic_type == AtomicOpType.AND:
     op = tt_dialect.RMWOp.AND
   elif atomic_type == AtomicOpType.OR:

--- a/tests/pallas/triton_pallas_test.py
+++ b/tests/pallas/triton_pallas_test.py
@@ -96,8 +96,8 @@ class TritonPallasTest(PallasBaseTest):
       ("min_i32", "atomic_min", np.array([1, 2, 3, 4], np.int32), np.min),
       ("add_f16", "atomic_add", np.array([1, 2, 3, 4], np.float16), np.sum),
       ("add_f32", "atomic_add", np.array([1, 2, 3, 4], np.float32), np.sum),
-      ("max_f32", "atomic_max", np.array([1, 2, 3, 4], np.float32), np.max),
-      ("min_f32", "atomic_min", np.array([1, 2, 3, 4], np.float32), np.min),
+      ("max_f32", "atomic_max", np.array([-2, -1, 0, 1], np.float32), np.max),
+      ("min_f32", "atomic_min", np.array([-2, -1, 0, 1], np.float32), np.min),
   )
   def test_scalar_atomic(self, op, value, numpy_op):
     op = getattr(plgpu, op)
@@ -118,17 +118,11 @@ class TritonPallasTest(PallasBaseTest):
       if np.issubdtype(value.dtype, np.integer):
         neutral = np.array(np.iinfo(value.dtype).min, value.dtype)
       else:
-        # JAX on ROCm does not currently handle atomic fmin/fmax correctly
-        if jtu.test_device_matches(["rocm"]):
-          self.skipTest("Atomic fmin/fmax not currently supported on ROCm.")
         neutral = np.array(-float("inf"), value.dtype)
     elif op == plgpu.atomic_min:
       if np.issubdtype(value.dtype, np.integer):
         neutral = np.array(np.iinfo(value.dtype).max, value.dtype)
       else:
-        # JAX on ROCm does not currently handle atomic fmin/fmax correctly
-        if jtu.test_device_matches(["rocm"]):
-          self.skipTest("Atomic fmin/fmax not currently supported on ROCm.")
         neutral = np.array(float("inf"), value.dtype)
     elif op == plgpu.atomic_or:
       neutral = np.array(False, value.dtype)


### PR DESCRIPTION
Floating point implementation is lifted from triton frontend itself. It has somewhat inconsistent semantics with regards to nan values. Should we leave it as is? Or implement it via cas loop matching np.max or np.maxnum semantics? Or should we allow min and max on fp types at all?