### PR TITLE
Bump ml_dtypes>=0.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     python_requires='>=3.10',
     install_requires=[
         f'jaxlib >={_minimum_jaxlib_version}, <={_jax_version}',
-        'ml_dtypes>=0.4.0',
+        'ml_dtypes>=0.5.0',
         'numpy>=1.25',
         "numpy>=1.26.0; python_version>='3.12'",
         'opt_einsum',


### PR DESCRIPTION
To add support for float8_e8m0fnu and float4_e2m1fn, which are introduced in versions later than v0.5.0.