### PR TITLE
CI: skip execution of convolutions.ipynb

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -222,6 +222,8 @@ nb_execution_excludepatterns = [
     # TODO(jakevdp): enable execution on the following if possible:
     'notebooks/Distributed_arrays_and_automatic_parallelization.*',
     'notebooks/autodiff_remat.*',
+    # Fails on readthedocs with Kernel Died
+    'notebooks/convolutions.ipynb',
     # Requires accelerators
     'pallas/quickstart.*',
     'pallas/tpu/pipelining.*',


### PR DESCRIPTION
This is failing on readthedocs with a dead kernel error: for example https://readthedocs.org/projects/jax/builds/27261561/