### PR TITLE
docs: Add note about computation perturbation in debug.print/breakpoint

### DIFF
--- a/docs/debugging/print_breakpoint.md
+++ b/docs/debugging/print_breakpoint.md
@@ -177,6 +177,10 @@ Why? Under the hood, the compiler gets a functional representation of the staged
 
 To preserve the original order of `jax.debug.print`s as written in your Python function, you can use `jax.debug.print(..., ordered=True)`, which will ensure the relative order of prints is preserved. But using `ordered=True` will raise an error under `jax.pmap` and other JAX transformations involving parallelism, since ordering can't be guaranteed under parallel execution.
 
+#### Computation perturbation
+
+Adding `jax.debug.print` or `jax.debug.breakpoint` statements will change the computation that XLA is asked to compile. This can potentially result in numeric discrepancies compared to the same code without debug statements because XLA might perform different operation fusions during compilation. Keep this in mind when debugging numerical issues, as the act of adding debug statements might affect the behavior you're trying to investigate.
+
 #### Asynchronous callbacks
 
 Depending on the backend, `jax.debug.print`s may happen asynchronously, i.e. not in your main program thread. This means that values could be printed to your screen even after your JAX function has returned a value.


### PR DESCRIPTION
This commit adds documentation about how using jax.debug.print and jax.debug.breakpoint can perturb the computation that XLA compiles, potentially leading to numeric discrepancies.

Fixes #26370