### PR TITLE
fix getting gcc major version

### DIFF
--- a/build/tools/utils.py
+++ b/build/tools/utils.py
@@ -208,7 +208,7 @@ def get_gcc_major_version(gcc_path: str):
     capture_output=True,
     text=True,
   )
-  major_version = int(gcc_version_proc.stdout)
+  major_version = int(gcc_version_proc.stdout.split(".")[0])
 
   return major_version
 


### PR DESCRIPTION
The call to `gcc -dumpversion`
https://github.com/jax-ml/jax/blob/908ff49e22deafe6b05c257f7eb5760208ef4029/build/tools/utils.py#L204-L210

will not always return an integer, depending on how the compiler has been packaged/prepared. In particular, gcc will by default return something like
```
$ gcc -dumpversion
13.3.0
```
which then predictably leads to
```
  File "$SRC_DIR/build/tools/utils.py", line 211, in get_gcc_major_version
    major_version = int(gcc_version_proc.stdout)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '13.3.0\n'
```

Make this processing more robust