### PR TITLE
fix member access to packed CUDA struct

### DIFF
--- a/jaxlib/mosaic/gpu/mosaic_gpu_ext.cc
+++ b/jaxlib/mosaic/gpu/mosaic_gpu_ext.cc
@@ -182,8 +182,9 @@ void callback_complete(CUcontext context, uint32_t streamId,
         // Convert integer nanoseconds to floating point milliseconds to match
         // the interface of the events-based profiler.
         double duration_ms = (kernel->end - kernel->start) / 1e6;
+        const char* kernel_name = kernel->name;
         profiler_state.timings.push_back(
-            std::make_tuple(kernel->name, duration_ms));
+            std::make_tuple(kernel_name, duration_ms));
       }
     } else if (status == CUPTI_ERROR_MAX_LIMIT_REACHED) {
       // no more records available


### PR DESCRIPTION
The mosaic code uses the CUDA `CUpti_ActivityKernel9` struct, which (at least as of CUDA 12.6) has been declared with `__attribute__((packed))`. This makes it UB to access a reference to a potentially unaligned field, causing GCC 13 to raise an error:
```
jaxlib/mosaic/gpu/mosaic_gpu_ext.cc: In function 'void jax::cuda::{anonymous}::callback_complete(CUcontext, uint32_t, uint8_t*, size_t, size_t)':
jaxlib/mosaic/gpu/mosaic_gpu_ext.cc:185:37: error: cannot bind packed field 'kernel->CUpti_ActivityKernel9::name' to 'const char*&'
  185 |             std::make_tuple(kernel->name, duration_ms));
      |                             ~~~~~~~~^~~~
```

Work around this by separating out the member access, which avoids the packed struct reference issue because then it's just a copy of the pointer, not a reference. We needed this to unblock the distribution of jax in conda-forge (where we're currently on GCC 13.3 & CUDA 12.6): https://github.com/conda-forge/jaxlib-feedstock/pull/295