### PR TITLE
fix Initializer protocol

### DIFF
--- a/jax/_src/nn/initializers.py
+++ b/jax/_src/nn/initializers.py
@@ -46,8 +46,8 @@ RealNumeric = Any  # Scalar jnp array or float
 @export
 @typing.runtime_checkable
 class Initializer(Protocol):
-  @staticmethod
-  def __call__(key: Array,
+  def __call__(self,
+               key: Array,
                shape: core.Shape,
                dtype: DTypeLikeInexact = jnp.float_) -> Array:
     raise NotImplementedError


### PR DESCRIPTION
The initializer protocol is currently defined in terms of a static `__call__` method. 
However that definition does not interact correctly with callable classes. For example this raises a mypy error (but no pytype error):

``` python
import jax

class MyInit:
  def __call__(self, key, shape, dtype=None):
    pass

def foo(init: jax.nn.Initializer):
  return

foo(MyInit())
```

After this PR the above code passes the mypy check, and passing plain functions still works as before:
``` python
import jax

def my_init(key, shape, dtype=None):
  return

def foo(init: jax.nn.Initializer):
  return

foo(my_init)
```
