### PR TITLE
[ROCm] Fix ROCm builds not finding numa library

### DIFF
--- a/build/rocm/build_wheels/Dockerfile.manylinux_2_28_x86_64.rocm
+++ b/build/rocm/build_wheels/Dockerfile.manylinux_2_28_x86_64.rocm
@@ -9,7 +9,7 @@ ARG ROCM_BUILD_NUM
 #  manylinux base image. However, adding this does fix an issue where Bazel isn't able
 #  to find them.
 RUN --mount=type=cache,target=/var/cache/dnf \
-    dnf install -y gcc-c++-8.5.0-22.el8_10.x86_64
+    dnf install -y gcc-c++-8.5.0-22.el8_10.x86_64 numactl-devel
 
 RUN --mount=type=cache,target=/var/cache/dnf \
     --mount=type=bind,source=build/rocm/tools/get_rocm.py,target=get_rocm.py \


### PR DESCRIPTION
ROCm builds are failing with an error about not being able to link to the NUMA library: `/usr/bin/ld.gold: error: cannot find -lnuma
`. Install the library with `dnf` inside of the manylinux image that does ROCm builds.