### PR TITLE
Implement jnp.ndarray.__contains__

### DIFF
--- a/jax/_src/numpy/array_methods.py
+++ b/jax/_src/numpy/array_methods.py
@@ -43,6 +43,7 @@ from jax._src.numpy import array_api_metadata
 from jax._src.numpy import indexing
 from jax._src.numpy import lax_numpy
 from jax._src.numpy import tensor_contractions
+from jax._src.numpy import util
 from jax._src.pjit import PartitionSpec
 from jax._src.sharding_impls import canonicalize_sharding, NamedSharding
 from jax._src.numpy import reductions
@@ -158,6 +159,17 @@ def _conjugate(self: Array) -> Array:
   Refer to :func:`jax.numpy.conjugate` for the full documentation.
   """
   return ufuncs.conjugate(self)
+
+def _contains(self: Array, other: ArrayLike) -> Array:
+  """Implements __contains__ for JAX arrays."""
+  if self.ndim != 1:
+    raise ValueError("Array.__contains__: search array must be one-dimensional,"
+                     f" got arr.shape={self.shape}.")
+  query = util.ensure_arraylike('Array.__contains__', other)
+  if query.ndim != 0:
+    raise ValueError("Array.__contains__: query value must be a scalar,"
+                     f" got {query.shape=}")
+  return reductions.any(self == query)
 
 def _copy(self: Array) -> Array:
   """Return a copy of the array.
@@ -932,6 +944,7 @@ _array_operators = {
   "getitem": _getitem,
   "setitem": _unimplemented_setitem,
   "copy": _copy,
+  "contains": _contains,
   "deepcopy": _deepcopy,
   "neg": lambda self: ufuncs.negative(self),
   "pos": lambda self: ufuncs.positive(self),

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3757,6 +3757,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     y = jax.vmap(f)(x)
     self.assertIsNot(x, y)
 
+  def testArrayContains(self):
+    self.assertTrue(1 in jnp.arange(4))
+    self.assertFalse(100 in jnp.arange(4))
+
+    with self.assertRaisesRegex(
+        ValueError, r"Array.__contains__: search array must be one-dimensional"):
+      1 in jnp.array(1)
+
+    with self.assertRaisesRegex(
+        ValueError, r"Array.__contains__: query value must be a scalar"):
+      jnp.arange(2) in jnp.arange(2)
+
   def testArrayUnsupportedDtypeError(self):
     with self.assertRaisesRegex(
         TypeError, 'JAX only supports number, bool, and string dtypes.*'


### PR DESCRIPTION
Currently this falls back to a linear search via `__iter__`, which is slow and raises unclear error messages in unsupported cases.

Before:
```python
In [1]: import jax.numpy as jnp

In [2]: 1 in jnp.arange(4)  # dispatches O[N] ops
Out[2]: True

In [3]: 1 in jnp.ones((2, 2))
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

In [4]: jnp.ones(2) in jnp.ones(4)
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```
After:
```python
In [1]: import jax.numpy as jnp

In [2]: 1 in jnp.arange(4)  # dispatches O[1] ops
Out[2]: True

In [3]: 1 in jnp.ones((2, 2))
ValueError: Array.__contains__: search array must be one-dimensional, got arr.shape=(2, 2).

In [4]: jnp.ones(2) in jnp.ones(4)
ValueError: Array.__contains__: query value must be a scalar, got query.shape=(2,)
```