### PR TITLE
Reimplement `custom_vjp.optimize_remat` using `custom_dce`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     true, matching the current behavior. If set to false, JAX does not need to
     emit code clamping negative indices, which improves code size.
 
+* Breaking changes
+  * The ``jax.custom_derivatives.remat_opt_p`` helper primitive was removed.
+
 ## jax 0.5.1 (Feb 24, 2025)
 
 * New Features

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -30,7 +30,6 @@ from jax._src.custom_derivatives import (
   custom_vjp_primal_tree_values as custom_vjp_primal_tree_values,
   CustomVJPPrimal as CustomVJPPrimal,
   linear_call as linear_call,
-  remat_opt_p as remat_opt_p,
 )
 
 from jax._src.ad_util import (

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -45,6 +45,7 @@ from jax._src import api
 from jax._src import api_util
 from jax._src import config
 from jax._src import core
+from jax._src import custom_dce
 from jax._src import dispatch
 from jax._src import dtypes
 from jax._src import linear_util as lu
@@ -3473,15 +3474,14 @@ def _custom_lin(*args: TfVal, **_) -> Sequence[TfVal]:
 tf_impl[ad.custom_lin_p] = _custom_lin
 
 
-def _remat_opt(*args: TfVal, num_consts: int, num_res: int,
-                    fwd_jaxpr: core.ClosedJaxpr,
-                    fun_jaxpr_thunk: Callable) -> Sequence[TfVal]:
-  del num_consts, num_res, fun_jaxpr_thunk
-  return _interpret_jaxpr(fwd_jaxpr, *args, extra_name_stack="remat_opt",
+def _custom_dce(*args: TfVal, num_consts: int, fun_jaxpr: core.ClosedJaxpr,
+                dce_jaxpr_thunk: Callable) -> Sequence[TfVal]:
+  del num_consts, dce_jaxpr_thunk
+  return _interpret_jaxpr(fun_jaxpr, *args, extra_name_stack="custom_dce_call",
                           fresh_constant_cache=False)
 
 
-tf_impl[custom_derivatives.remat_opt_p] = _remat_opt
+tf_impl[custom_dce.custom_dce_p] = _custom_dce
 
 
 PartitionsOrReplicated = Union[tuple[int, ...], None]

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -9576,10 +9576,7 @@ class CustomVJPTest(jtu.JaxTestCase):
       return np.array([2.0])*x*x/np.array([1.0]), (x,)
 
     x = jnp.linspace(0, 5.0, 10)
-    fwd = custom_derivatives.optimize_remat_of_custom_vjp_fwd(
-        fun, api_util.debug_info("custom_vjp fun", fun, (x,), {}),
-        fwd, api_util.debug_info("custom_vjp fwd", fwd, (x,), {}))
-
+    fwd = custom_derivatives.optimize_remat_of_custom_vjp_fwd(fun, fwd)
     self.assertAllClose(jax.jit(fwd)(x)[0], 2*x*x)  # Shouldn't hit custom DCE
     self.assertAllClose(jax.jit(lambda x: fwd(x)[0])(x), x)  # Should be DCEed
 
@@ -9589,9 +9586,7 @@ class CustomVJPTest(jtu.JaxTestCase):
     def fwd(x):
       return (np.array([2.0])*x*x/np.array([1.0]))[0], (x,)
     x = jnp.linspace(0, 5.0, 10)
-    fwd = custom_derivatives.optimize_remat_of_custom_vjp_fwd(
-        fun, api_util.debug_info("custom_vjp fun", fun, (x,), {}),
-        fwd, api_util.debug_info("custom_vjp fwd", fwd, (x,), {}))
+    fwd = custom_derivatives.optimize_remat_of_custom_vjp_fwd(fun, fwd)
     self.assertAllClose(jax.jit(jax.vmap(fwd))(x)[0], 2*x*x)
     self.assertAllClose(jax.jit(lambda x: jax.vmap(fwd)(x)[0])(x), x)
 
@@ -9602,9 +9597,7 @@ class CustomVJPTest(jtu.JaxTestCase):
       return x*x, (x,)
 
     x = jnp.linspace(0, 5.0, 10)
-    fwd = custom_derivatives.optimize_remat_of_custom_vjp_fwd(
-        fun, api_util.debug_info("custom_vjp fun", fun, (x,), {}),
-        fwd, api_util.debug_info("custom_vjp fwd", fwd, (x,), {}))
+    fwd = custom_derivatives.optimize_remat_of_custom_vjp_fwd(fun, fwd)
 
     def g(x):
       return jax.lax.cond(True, fwd, lambda x: (2.0 * x, (x,)), x)
@@ -9618,9 +9611,7 @@ class CustomVJPTest(jtu.JaxTestCase):
     def fwd_(x):
       return x*x, (x,)
 
-    fwd = custom_derivatives.optimize_remat_of_custom_vjp_fwd(
-        fun, api_util.debug_info("custom_vjp fun", fun, (3.2,), {}),
-        fwd_, api_util.debug_info("custom_vjp fwd", fwd_, (3.2,), {}))
+    fwd = custom_derivatives.optimize_remat_of_custom_vjp_fwd(fun, fwd_)
     calc = jax.jvp(fwd, (3.2,), (1.0,))
     expected = jax.jvp(fwd_, (3.2,), (1.0,))
     self.assertAllClose(calc, expected)
@@ -9716,6 +9707,31 @@ class CustomVJPTest(jtu.JaxTestCase):
     f.defvjp(f_fwd, f_bwd, optimize_remat=True)
     x, y = jnp.linspace(0.0, 1.0, 5), jnp.linspace(2.0, 5.0, 5)
     jax.jit(jax.vmap(jax.grad(f)))(x, y)  # Doesn't error
+
+  def test_optimize_remat_nondiff_argnums(self):
+    @partial(jax.custom_vjp, nondiff_argnums=(0,))
+    def f(fun, x, y):
+      return fun(x, y)
+
+    def f_fwd(fun, x, y):
+      del fun
+      return jnp.cos(x) * y, (jnp.cos(x), jnp.sin(x), y)
+
+    def f_bwd(fun, res, g):
+      del fun
+      cos_x, sin_x, y = res
+      return (cos_x * g * y, sin_x * g)
+
+    def fun(x, y):
+      return jnp.sin(x) * y
+
+    f.defvjp(f_fwd, f_bwd, optimize_remat=True)
+    x, y = 0.5, 0.1
+    res = jax.value_and_grad(lambda *args: f(fun, *args))(x, y)[0]
+    self.assertAllClose(res, f_fwd(fun, x, y)[0])
+    res = jax.jit(lambda *args: jax.value_and_grad(
+        lambda *args: f(fun, *args))(*args)[0])(x, y)
+    self.assertAllClose(res, fun(x, y))
 
   def test_dce(self):
     @jax.custom_vjp


### PR DESCRIPTION
The "optimize remat" feature of `jax.custom_vjp` was just a special case of [`custom_dce`](https://docs.jax.dev/en/latest/_autosummary/jax.experimental.custom_dce.custom_dce.html), so we can delete a lot of duplicated code by reimplementing that feature using `custom_dce`. I don't anticipate that this will change any behavior.