### PR TITLE
Fixed printing order of results in `jax.debug.print` documentation

### DIFF
--- a/docs/debugging/print_breakpoint.md
+++ b/docs/debugging/print_breakpoint.md
@@ -91,8 +91,8 @@ def f(x):
   jax.debug.print("x: {}", x)
   return x
 jax.pmap(f)(xs)
-# Prints: x: 1.0
-#         x: 0.0
+# Prints: x: 0.0
+#         x: 1.0
 # OR
 # Prints: x: 1.0
 #         x: 0.0


### PR DESCRIPTION
Here: https://docs.jax.dev/en/latest/debugging/print_breakpoint.html#printing-under-jax-pmap
It mentions that when `jax.pmap`-ed, `jax.debug.prints` outputs might be reordered!
But, in the comments, they show printing in the same order 2 times. I initially got confused reading that.

I think the comments should show the printing order in both ways like it is shown here: https://docs.jax.dev/en/latest/debugging/print_breakpoint.html#ordering-of-printed-results