### PR TITLE
Improve error messages when input argument resolution fails in custom_* APIs.

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -564,8 +564,9 @@ def resolve_kwargs(fun: Callable, args, kwargs) -> tuple[Any, ...]:
     passed_kwargs = [k for k in ba.kwargs if k in kwargs]
     if passed_kwargs:
       raise TypeError(
-          f"keyword arguments ({passed_kwargs}) could not be resolved to "
-          "positions")
+          "The following keyword arguments could not be resolved to positions: "
+          f"{', '.join(passed_kwargs)}"
+      )
   return ba.args
 
 

--- a/jax/_src/custom_batching.py
+++ b/jax/_src/custom_batching.py
@@ -143,7 +143,15 @@ class custom_vmap:
   def __call__(self, *args, **kwargs):
     debug_fun = api_util.debug_info("custom_vmap fun", self.fun,
                                     args, kwargs)
-    args = api_util.resolve_kwargs(self.fun, args, kwargs)
+    try:
+      args = api_util.resolve_kwargs(self.fun, args, kwargs)
+    except TypeError as e:
+      raise TypeError(
+          "The input arguments to the custom_vmap-decorated function "
+          f"{debug_fun.func_name} could not be resolved to positional-only "
+          f"arguments. Binding failed with the error:\n{e}"
+      ) from e
+
     if not self.vmap_rule:
       raise AttributeError(
           f"No batching rule defined for custom_vmap function {debug_fun.func_name} "

--- a/jax/_src/custom_dce.py
+++ b/jax/_src/custom_dce.py
@@ -133,7 +133,15 @@ class custom_dce:
     debug_rule = api_util.debug_info("custom_dce_rule", self.dce_rule,
                                      args, {},
                                      static_argnums=self.static_argnums)
-    args = api_util.resolve_kwargs(self.fun, args, kwargs)
+    try:
+      args = api_util.resolve_kwargs(self.fun, args, kwargs)
+    except TypeError as e:
+      raise TypeError(
+          "The input arguments to the custom_dce-decorated function "
+          f"{debug.func_name} could not be resolved to positional-only "
+          f"arguments. Binding failed with the error:\n{e}"
+      ) from e
+
     if self.static_argnums:
       static_argnums = set(self.static_argnums)
       for i in static_argnums:

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -250,7 +250,15 @@ class custom_jvp(Generic[ReturnValue]):
       msg = f"No JVP defined for custom_jvp function {primal_name} using defjvp."
       raise AttributeError(msg)
 
-    args = resolve_kwargs(self.fun, args, kwargs)
+    try:
+      args = resolve_kwargs(self.fun, args, kwargs)
+    except TypeError as e:
+      raise TypeError(
+          "The input arguments to the custom_jvp-decorated function "
+          f"{primal_name} could not be resolved to positional-only arguments. "
+          f"Binding failed with the error:\n{e}"
+      ) from e
+
     if self.nondiff_argnums:
       nondiff_argnums = set(self.nondiff_argnums)
       args = tuple(_stop_gradient(x) if i in nondiff_argnums else x
@@ -634,7 +642,16 @@ class custom_vjp(Generic[ReturnValue]):
     if not self.fwd or not self.bwd:
       msg = f"No VJP defined for custom_vjp function {debug_fun.func_name} using defvjp."
       raise AttributeError(msg)
-    args = resolve_kwargs(self.fun, args, kwargs)
+
+    try:
+      args = resolve_kwargs(self.fun, args, kwargs)
+    except TypeError as e:
+      raise TypeError(
+          "The input arguments to the custom_vjp-decorated function "
+          f"{debug_fun.func_name} could not be resolved to positional-only "
+          f"arguments. Binding failed with the error:\n{e}"
+      ) from e
+
     debug_fwd = debug_info("custom_vjp fwd", self.fwd, args, kwargs,
                            static_argnums=self.nondiff_argnums)
     # TODO(necula): figure out how to construct the debug_bwd args


### PR DESCRIPTION
In debugging an issue with custom_vjp deep within a larger program, I found myself confused by the error messages we current produce when passing the wrong input arguments to a function wrapped by these customization helpers. This change makes the error messages a little clearer about what's going on.