### PR TITLE
Add NSA Attention implementation

### DIFF
--- a/jax/experimental/pallas/ops/gpu/nsa_attention.py
+++ b/jax/experimental/pallas/ops/gpu/nsa_attention.py
@@ -1,0 +1,596 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NSA Attention implementation."""
+
+import functools
+import math
+from typing import Any
+
+import jax
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import triton as plgpu
+import jax.numpy as jnp
+import numpy as np
+
+DEFAULT_MASK_VALUE = -0.7 * float(np.finfo(np.dtype("float32")).max)
+
+def nsa_attention_forward_kernel(
+    q_ref,
+    k_ref,
+    v_ref,
+    segment_ids_ref: jax.Array | None,
+    o_ref: Any,
+    *residual_refs: Any,
+    num_heads: int,
+    sm_scale: float,
+    causal: bool,
+    block_q: int,
+    block_d: int,
+    block_k: int,
+):
+  seq_len = k_ref.shape[0]
+  start_q = pl.program_id(0)
+
+  m_i = jnp.zeros(block_q, dtype=jnp.float32) - float('inf')
+  l_i = jnp.zeros(block_q, dtype=jnp.float32)
+  o = jnp.zeros((block_q, block_d), dtype=jnp.float32)
+
+  curr_q_slice = pl.dslice(start_q * block_q, block_q)
+  q = q_ref[...]
+  q_segment_ids = (
+      None
+      if segment_ids_ref is None
+      else pl.load(segment_ids_ref, (curr_q_slice,))
+  )
+
+  def body(start_k, carry):
+    o_prev, m_prev, l_prev = carry
+    curr_k_slice = pl.dslice(start_k * block_k, block_k)
+
+    k = pl.load(k_ref, (curr_k_slice, slice(None)))
+    qk = pl.dot(q, k.T)
+
+    qk_scale = math.log2(math.e)
+    if sm_scale != 1.:
+      qk_scale *= sm_scale
+    qk *= qk_scale
+
+    if causal or segment_ids_ref is not None:
+      mask = None
+      if segment_ids_ref is not None:
+        kv_segment_ids = pl.load(segment_ids_ref, (curr_k_slice,))
+        mask = segment_mask(q_segment_ids, kv_segment_ids)
+      if causal:
+        span_q = start_q * block_q + jnp.arange(block_q)
+        span_k = start_k * block_k + jnp.arange(block_k)
+        causal_mask = span_q[:, None] >= span_k[None, :]
+        mask = (
+            causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+        )
+      qk = jnp.where(mask, qk, DEFAULT_MASK_VALUE)
+
+    m_curr = qk.max(axis=-1)
+    m_next = jnp.maximum(m_prev, m_curr)
+    correction = jnp.exp2(m_prev - m_next)
+    l_prev_corr = correction * l_prev
+    s_curr = jnp.exp2(
+        qk - m_next[:, None]
+    )
+    l_curr = s_curr.sum(axis=-1)
+    l_next = l_prev_corr + l_curr
+    o_prev_corr = correction[:, None] * o_prev
+    v = pl.load(v_ref, (curr_k_slice, pl.dslice(block_d)))
+    o_curr = pl.dot(s_curr.astype(v.dtype), v)
+
+    o_next = o_prev_corr + o_curr
+    return o_next, m_next, l_next
+
+  if causal:
+    upper_bound = lax.div(block_q * (start_q + 1) + block_k - 1, block_k)
+  else:
+    upper_bound = pl.cdiv(seq_len, block_k)
+  o, m_i, l_i = lax.fori_loop(0, upper_bound, body, (o, m_i, l_i))
+
+  o /= l_i[:, None]
+
+  if residual_refs:
+    lse_ref = residual_refs[0]
+    lse_ref[...] = m_i + jnp.log2(l_i)
+  o_ref[...] = o.astype(o_ref.dtype)
+
+def segment_mask(
+    q_segment_ids: jax.Array,
+    kv_segment_ids: jax.Array,
+):
+  q_segment_ids = jnp.expand_dims(q_segment_ids, axis=-1)
+  if kv_segment_ids.ndim == 1:
+    kv_segment_ids = jnp.expand_dims(kv_segment_ids, axis=0)
+  else:
+    kv_segment_ids = jnp.expand_dims(kv_segment_ids, axis=1)
+  return jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)
+
+@functools.partial(
+    jax.custom_vjp, nondiff_argnums=[4, 5, 6, 7, 8, 9, 10, 11, 12]
+)
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "sm_scale",
+        "causal",
+        "block_sizes",
+        "backward_pass_impl",
+        "num_warps",
+        "num_stages",
+        "grid",
+        "interpret",
+        "debug",
+    ],
+)
+def nsa_attention(
+    q,
+    k,
+    v,
+    segment_ids: jnp.ndarray | None,
+    sm_scale: float = 1.0,
+    causal: bool = False,
+    block_sizes: BlockSizes = BlockSizes.get_default(),
+    backward_pass_impl: str = "triton",
+    num_warps: int | None = None,
+    num_stages: int = 2,
+    grid: tuple[int, ...] | None = None,
+    interpret: bool = False,
+    debug: bool = False,
+):
+  del backward_pass_impl
+  batch_size, q_seq_len, num_heads, head_dim = q.shape
+  kv_seq_len = k.shape[1]
+  block_q = min(block_sizes.block_q, q_seq_len)
+  block_k = min(block_sizes.block_k, kv_seq_len)
+  grid_ = grid
+  if grid_ is None:
+    grid_ = (pl.cdiv(q_seq_len, block_q), batch_size, num_heads)
+
+  num_warps_ = num_warps
+  if num_warps_ is None:
+    num_warps_ = 4 if head_dim <= 64 else 8
+  kernel = functools.partial(nsa_attention_forward_kernel, num_heads=num_heads,
+                             sm_scale=sm_scale, block_q=block_q,
+                             block_k=block_k, block_d=head_dim,
+                             causal=causal)
+
+  in_specs = [
+      pl.BlockSpec(
+          (None, block_q, None, head_dim), lambda i, j, k: (j, i, k, 0)
+      ),
+      pl.BlockSpec(
+          (None, kv_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)
+      ),
+      pl.BlockSpec(
+          (None, kv_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)
+      ),
+  ]
+  in_specs.append(
+      None
+      if segment_ids is None
+      else pl.BlockSpec((None, kv_seq_len), lambda _, j, k: (j, 0))
+  )
+  out_shape = jax.ShapeDtypeStruct(shape=q.shape, dtype=q.dtype)
+  return pl.pallas_call(
+      kernel,
+      grid=grid_,
+      in_specs=in_specs,
+      out_specs=pl.BlockSpec(
+          (None, block_q, None, head_dim), lambda i, j, k: (j, i, k, 0)
+      ),
+      compiler_params=plgpu.TritonCompilerParams(
+          num_warps=num_warps_, num_stages=num_stages),
+      out_shape=out_shape,
+      debug=debug,
+      interpret=interpret,
+      name="nsa_attention_forward",
+  )(q, k, v, segment_ids)
+
+def _nsa_attention_forward(
+    q,
+    k,
+    v,
+    segment_ids: jax.Array | None,
+    sm_scale: float,
+    causal: bool,
+    block_sizes: BlockSizes,
+    backward_pass_impl: str,
+    num_warps: int | None,
+    num_stages: int,
+    grid: Any,
+    interpret: bool,
+    debug: bool,
+):
+  del backward_pass_impl
+  batch_size, q_seq_len, num_heads, head_dim = q.shape
+  kv_seq_len = k.shape[1]
+  block_q = min(block_sizes.block_q, q_seq_len)
+  block_k = min(block_sizes.block_k, kv_seq_len)
+  grid_ = grid
+  if grid_ is None:
+    grid_ = (pl.cdiv(q_seq_len, block_q), batch_size, num_heads)
+
+  num_warps_ = num_warps
+  if num_warps_ is None:
+    num_warps_ = 4 if head_dim <= 64 else 8
+  kernel = functools.partial(nsa_attention_forward_kernel, num_heads=num_heads,
+                             sm_scale=sm_scale, causal=causal, block_q=block_q,
+                             block_k=block_k, block_d=head_dim)
+  out_shape = [
+      jax.ShapeDtypeStruct(shape=q.shape, dtype=q.dtype),
+      jax.ShapeDtypeStruct(
+          shape=(batch_size, num_heads, q_seq_len), dtype=jnp.float32
+      ),
+  ]
+  in_specs = [
+      pl.BlockSpec(
+          (None, block_q, None, head_dim), lambda i, j, k: (j, i, k, 0)
+      ),
+      pl.BlockSpec(
+          (None, kv_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)
+      ),
+      pl.BlockSpec(
+          (None, kv_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)
+      ),
+  ]
+  in_specs.append(
+      None
+      if segment_ids is None
+      else pl.BlockSpec((None, kv_seq_len), lambda _, j, k: (j, 0))
+  )
+  out, lse = pl.pallas_call(
+      kernel,
+      grid=grid_,
+      in_specs=in_specs,
+      out_specs=[
+          pl.BlockSpec(
+              (None, block_q, None, head_dim), lambda i, j, k: (j, i, k, 0)
+          ),
+          pl.BlockSpec((None, None, block_q), lambda i, j, k: (j, k, i)),
+      ],
+      compiler_params=plgpu.TritonCompilerParams(
+          num_warps=num_warps_, num_stages=num_stages
+      ),
+      out_shape=out_shape,
+      debug=debug,
+      interpret=interpret,
+      name="nsa_attention_forward",
+  )(q, k, v, segment_ids)
+  return out, (q, k, v, segment_ids, out, lse)
+
+def _preprocess_backward_kernel(out_ref, dout_ref, delta_ref):
+  o = out_ref[...].astype(jnp.float32)
+  do = dout_ref[...].astype(jnp.float32)
+  delta = jnp.sum(o * do, axis=1)
+  delta_ref[...] = delta.astype(delta_ref.dtype)
+
+@jax.named_scope("preprocess_backward")
+def _preprocess_backward(out, do, lse, block_q: int,
+                         debug: bool, interpret: bool):
+  batch_size, seq_len, num_heads, head_dim = out.shape
+  out_shape = jax.ShapeDtypeStruct(lse.shape, lse.dtype)
+  delta = pl.pallas_call(
+      _preprocess_backward_kernel,
+      grid=(pl.cdiv(seq_len, block_q), batch_size, num_heads),
+      in_specs=[
+          pl.BlockSpec(
+              (None, block_q, None, head_dim), lambda i, j, k: (j, i, k, 0)
+          ),
+          pl.BlockSpec(
+              (None, block_q, None, head_dim), lambda i, j, k: (j, i, k, 0)
+          ),
+      ],
+      out_specs=pl.BlockSpec((None, None, block_q), lambda i, j, k: (j, k, i)),
+      compiler_params=plgpu.TritonCompilerParams(num_warps=4, num_stages=3),
+      out_shape=out_shape,
+      debug=debug,
+      interpret=interpret,
+      name="nsa_attention_preprocess_backward",
+  )(out, do)
+  return delta
+
+def nsa_attention_backward_kernel(
+    q_ref,
+    k_ref,
+    v_ref,
+    segment_ids_ref: jax.Array | None,
+    out_ref,
+    do_scaled_ref,
+    lse_ref,
+    delta_ref,
+    dq_ref,
+    dk_ref,
+    dv_ref,
+    *,
+    sm_scale: float,
+    causal: bool,
+    block_q_dkv: int,
+    block_kv_dkv: int,
+    block_q_dq: int,
+    block_kv_dq: int,
+    block_d: int,
+):
+  del out_ref
+  q_seq_len = q_ref.shape[0]
+  kv_seq_len = k_ref.shape[0]
+
+  start_k = pl.program_id(2)
+  curr_k_slice = pl.dslice(start_k * block_kv_dkv, block_kv_dkv)
+
+  dv = jnp.zeros([block_kv_dkv, block_d], dtype=jnp.float32)
+  dk = jnp.zeros([block_kv_dkv, block_d], dtype=jnp.float32)
+
+  v = pl.load(v_ref, (curr_k_slice, slice(None)))
+  k = pl.load(k_ref, (curr_k_slice, slice(None)))
+  span_k = start_k * block_kv_dkv + jnp.arange(block_kv_dkv)
+  kv_segment_ids = (
+      None
+      if segment_ids_ref is None
+      else pl.load(segment_ids_ref, (curr_k_slice,))
+  )
+
+  def inner_loop_dkdv(start_q, carry):
+    dv, dk = carry
+    curr_q_slice = pl.dslice(start_q * block_q_dkv, block_q_dkv)
+
+    q = pl.load(q_ref, (curr_q_slice, slice(None)))
+    qk = pl.dot(q, k.T)
+    qk_scale = math.log2(math.e)
+    if sm_scale != 1.:
+      qk_scale *= sm_scale
+    qk *= qk_scale
+
+    if causal or segment_ids_ref is not None:
+      mask = None
+      if segment_ids_ref is not None:
+        q_segment_ids = pl.load(segment_ids_ref, (curr_q_slice,))
+        mask = segment_mask(q_segment_ids, kv_segment_ids)
+
+      if causal:
+        span_q = start_q * block_q_dkv + jnp.arange(block_q_dkv)
+        causal_mask = span_q[:, None] >= span_k[None, :]
+        mask = (
+            causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+        )
+      qk = jnp.where(mask, qk, DEFAULT_MASK_VALUE)
+
+    lse = pl.load(lse_ref, (curr_q_slice,))
+    di = pl.load(delta_ref, (curr_q_slice,))
+    do = pl.load(do_scaled_ref, (curr_q_slice, slice(None)))
+
+    p = jnp.exp2(qk - lse[:, None])
+    dv = dv + pl.dot(p.astype(do.dtype).T, do)
+    dp = jnp.zeros((block_q_dkv, block_kv_dkv), dtype=jnp.float32) - di[:, None]
+    dp = dp + pl.dot(do, v.T)
+    ds = p * dp
+    if sm_scale != 1.0:
+      ds = ds * sm_scale
+    dk = dk + pl.dot(ds.astype(q_ref.dtype).T, q)
+
+    return dv, dk
+
+  lower_bound = lax.div(start_k * block_kv_dkv, block_q_dkv) if causal else 0
+  dv, dk = lax.fori_loop(
+      lower_bound, pl.cdiv(q_seq_len, block_q_dkv), inner_loop_dkdv, (dv, dk)
+  )
+  dv_ref[...] = dv.astype(dv_ref.dtype)
+  dk_ref[...] = dk.astype(dk_ref.dtype)
+
+  start_q = pl.program_id(2)
+  curr_q_slice = pl.ds(start_q * block_q_dq, block_q_dq)
+  span_q = start_q * block_q_dq + jnp.arange(block_q_dq)
+  dq = jnp.zeros([block_q_dq, block_d], dtype=jnp.float32)
+
+  q = pl.load(q_ref, (curr_q_slice, slice(None)))
+  q_segment_ids = (
+      None
+      if segment_ids_ref is None
+      else pl.load(segment_ids_ref, (curr_q_slice,))
+  )
+  lse = pl.load(lse_ref, (curr_q_slice,))
+  do = pl.load(do_scaled_ref, (curr_q_slice, slice(None)))
+  di = pl.load(delta_ref, (curr_q_slice,))
+
+  def inner_loop_dq(start_k, dq):
+    curr_k_slice = pl.dslice(start_k * block_kv_dq, block_kv_dq)
+    k = pl.load(k_ref, (curr_k_slice, slice(None)))
+    v = pl.load(v_ref, (curr_k_slice, slice(None)))
+
+    qk = pl.dot(q, k.T)
+    qk_scale = math.log2(math.e)
+    if sm_scale != 1.:
+      qk_scale *= sm_scale
+    qk *= qk_scale
+
+    if causal or segment_ids_ref is not None:
+      mask = None
+      if segment_ids_ref is not None:
+        kv_segment_ids = pl.load(segment_ids_ref, (curr_k_slice,))
+        mask = segment_mask(q_segment_ids, kv_segment_ids)
+
+      if causal:
+        span_k = start_k * block_kv_dq + jnp.arange(block_kv_dq)
+        causal_mask = span_q[:, None] >= span_k[None, :]
+        mask = (
+            causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+        )
+      qk = jnp.where(mask, qk, DEFAULT_MASK_VALUE)
+
+    p = jnp.exp2(qk - lse[:, None])
+    dp = jnp.zeros((block_q_dq, block_kv_dq), dtype=jnp.float32) - di[:, None]
+    dp = dp + pl.dot(do, v.T)
+    ds = p * dp
+    if sm_scale != 1.0:
+      ds = ds * sm_scale
+
+    dq = dq + pl.dot(ds.astype(k.dtype), k).astype(dq.dtype)
+
+    return dq
+
+  if causal:
+    upper_bound = pl.cdiv((start_q + 1) * block_q_dq, block_kv_dq)
+  else:
+    upper_bound = pl.cdiv(kv_seq_len, block_kv_dq)
+
+  dq = lax.fori_loop(0, upper_bound, inner_loop_dq, (dq))
+  dq_ref[...] = dq.astype(dq_ref.dtype)
+
+def _nsa_attention_backward(sm_scale: float, causal: bool, block_sizes: BlockSizes,
+                            backward_pass_impl: str, num_warps: int | None,
+                            num_stages: int, grid: Any, interpret: bool,
+                            debug: bool, res, do):
+  del num_stages, grid
+  q, k, v, segment_ids, out, lse = res
+
+  if backward_pass_impl == "xla":
+    return jax.vjp(
+        functools.partial(nsa_attention_reference, sm_scale=sm_scale, causal=causal),
+        q,
+        k,
+        v,
+        segment_ids,
+    )[1](do)
+  elif backward_pass_impl == "triton":
+    if not block_sizes.has_backward_blocks:
+      raise ValueError("Backward block sizes must all be set.")
+
+    batch_size, q_seq_len, num_heads, head_dim = q.shape
+    kv_seq_len = k.shape[1]
+    block_q = min(block_sizes.block_q, q_seq_len)
+    block_q_dkv = min(block_sizes.block_q_dkv, q_seq_len)
+    block_kv_dkv = min(block_sizes.block_kv_dkv, kv_seq_len)
+    block_q_dq = min(block_sizes.block_q_dq, q_seq_len)
+    block_kv_dq = min(block_sizes.block_kv_dq, kv_seq_len)
+
+    if q_seq_len // block_q_dq != kv_seq_len // block_kv_dkv:
+      raise ValueError(
+          "q_seq_len and kv_seq_len must be divided into the same "
+          "number of blocks for the fused backward pass."
+      )
+
+    delta = _preprocess_backward(out, do, lse, block_q, debug, interpret)
+    out_shapes = [
+        jax.ShapeDtypeStruct(q.shape, q.dtype),
+        jax.ShapeDtypeStruct(k.shape, k.dtype),
+        jax.ShapeDtypeStruct(v.shape, v.dtype),
+    ]
+
+    in_specs = [
+        pl.BlockSpec(
+            (None, q_seq_len, None, head_dim), lambda i, j, _: (i, 0, j, 0)
+        ),
+        pl.BlockSpec(
+            (None, kv_seq_len, None, head_dim), lambda i, j, _: (i, 0, j, 0)
+        ),
+        pl.BlockSpec(
+            (None, kv_seq_len, None, head_dim), lambda i, j, _: (i, 0, j, 0)
+        ),
+        pl.BlockSpec(
+            (None, q_seq_len, None, head_dim), lambda i, j, _: (i, 0, j, 0)
+        ),
+        pl.BlockSpec(
+            (None, q_seq_len, None, head_dim), lambda i, j, _: (i, 0, j, 0)
+        ),
+        pl.BlockSpec((None, None, q_seq_len), lambda i, j, _: (i, j, 0)),
+        pl.BlockSpec((None, None, q_seq_len), lambda i, j, _: (i, j, 0)),
+    ]
+    if segment_ids is None:
+      in_specs.insert(3, None)
+    else:
+      in_specs.insert(3, pl.BlockSpec((None, kv_seq_len), lambda i, j, _: (i, 0)))
+
+    grid = (batch_size, num_heads, pl.cdiv(kv_seq_len, block_kv_dkv))
+    num_warps_ = num_warps
+    if num_warps_ is None:
+      if (
+          block_q_dkv * block_kv_dkv < 128 * 128
+          or block_q_dq * block_kv_dq < 128 * 128
+      ):
+        num_warps_ = 4
+      else:
+        num_warps_ = 8
+
+    dq, dk, dv = pl.pallas_call(
+        functools.partial(
+            nsa_attention_backward_kernel,
+            sm_scale=sm_scale,
+            causal=causal,
+            block_q_dkv=block_q_dkv,
+            block_kv_dkv=block_kv_dkv,
+            block_q_dq=block_q_dq,
+            block_kv_dq=block_kv_dq,
+            block_d=head_dim,
+        ),
+        out_shape=out_shapes,
+        in_specs=in_specs,
+        grid=grid,
+        out_specs=[
+            pl.BlockSpec(
+                (None, block_q_dq, None, head_dim),
+                lambda i, j, k: (i, k, j, 0),
+            ),
+            pl.BlockSpec(
+                (None, block_kv_dkv, None, head_dim),
+                lambda i, j, k: (i, k, j, 0),
+            ),
+            pl.BlockSpec(
+                (None, block_kv_dkv, None, head_dim),
+                lambda i, j, k: (i, k, j, 0),
+            ),
+        ],
+        name="nsa_attention_backward",
+        debug=debug,
+        interpret=interpret,
+        compiler_params=plgpu.TritonCompilerParams(
+            num_warps=num_warps_, num_stages=2
+        ),
+    )(q, k, v, segment_ids, out, do, lse, delta)
+  else:
+    raise ValueError(f"Invalid backward pass implementation: {backward_pass_impl}")
+  return dq.astype(q.dtype), dk, dv, None
+nsa_attention.defvjp(_nsa_attention_forward, _nsa_attention_backward)
+
+@functools.partial(jax.jit, static_argnames=['sm_scale', 'causal'])
+def nsa_attention_reference(
+    q,
+    k,
+    v,
+    segment_ids: jnp.ndarray | None,
+    sm_scale=1.0,
+    causal: bool = False,
+):
+  q_seq_len = q.shape[1]
+  kv_seq_len = k.shape[1]
+  logits = jnp.einsum(
+      'bqhc,bkhc->bhqk', q, k, preferred_element_type=jnp.float32
+  )
+  mask = None
+  if segment_ids is not None:
+    mask = jnp.expand_dims(segment_mask(segment_ids, segment_ids), 1)
+    mask = jnp.broadcast_to(mask, logits.shape)
+  if causal:
+    causal_mask = jnp.tril(jnp.ones((1, 1, q_seq_len, kv_seq_len), dtype=bool))
+    causal_mask = jnp.broadcast_to(causal_mask, logits.shape)
+    mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+  logits = logits if mask is None else jnp.where(mask, logits, float("-inf"))
+  weights = jax.nn.softmax(logits * sm_scale)
+  return jnp.einsum(
+      'bhqk,bkhc->bqhc', weights, v, preferred_element_type=jnp.float32
+  )

--- a/tests/pallas/nsa_attention_test.py
+++ b/tests/pallas/nsa_attention_test.py
@@ -1,0 +1,51 @@
+import unittest
+import jax
+import jax.numpy as jnp
+from jax.experimental.pallas.ops.gpu.nsa_attention import nsa_attention, nsa_attention_reference
+
+class TestNSAAttention(unittest.TestCase):
+
+    def setUp(self):
+        self.key = jax.random.PRNGKey(0)
+        self.batch_size = 2
+        self.seq_len = 16
+        self.num_heads = 4
+        self.head_dim = 8
+        self.q = jax.random.normal(self.key, (self.batch_size, self.seq_len, self.num_heads, self.head_dim))
+        self.k = jax.random.normal(self.key, (self.batch_size, self.seq_len, self.num_heads, self.head_dim))
+        self.v = jax.random.normal(self.key, (self.batch_size, self.seq_len, self.num_heads, self.head_dim))
+        self.segment_ids = jax.random.randint(self.key, (self.batch_size, self.seq_len), 0, 2)
+
+    def test_forward_pass(self):
+        out = nsa_attention(self.q, self.k, self.v, self.segment_ids)
+        out_ref = nsa_attention_reference(self.q, self.k, self.v, self.segment_ids)
+        self.assertTrue(jnp.allclose(out, out_ref, atol=1e-5))
+
+    def test_backward_pass(self):
+        def loss_fn(q, k, v):
+            out = nsa_attention(q, k, v, self.segment_ids)
+            return jnp.sum(out)
+
+        grad_fn = jax.grad(loss_fn, argnums=(0, 1, 2))
+        grads = grad_fn(self.q, self.k, self.v)
+        self.assertEqual(len(grads), 3)
+        for grad in grads:
+            self.assertEqual(grad.shape, (self.batch_size, self.seq_len, self.num_heads, self.head_dim))
+
+    def test_edge_cases(self):
+        # Test with empty input
+        q_empty = jnp.zeros((self.batch_size, 0, self.num_heads, self.head_dim))
+        k_empty = jnp.zeros((self.batch_size, 0, self.num_heads, self.head_dim))
+        v_empty = jnp.zeros((self.batch_size, 0, self.num_heads, self.head_dim))
+        out_empty = nsa_attention(q_empty, k_empty, v_empty, self.segment_ids)
+        self.assertEqual(out_empty.shape, (self.batch_size, 0, self.num_heads, self.head_dim))
+
+        # Test with different sequence lengths
+        q_diff_len = jax.random.normal(self.key, (self.batch_size, self.seq_len + 1, self.num_heads, self.head_dim))
+        k_diff_len = jax.random.normal(self.key, (self.batch_size, self.seq_len + 2, self.num_heads, self.head_dim))
+        v_diff_len = jax.random.normal(self.key, (self.batch_size, self.seq_len + 2, self.num_heads, self.head_dim))
+        out_diff_len = nsa_attention(q_diff_len, k_diff_len, v_diff_len, self.segment_ids)
+        self.assertEqual(out_diff_len.shape, (self.batch_size, self.seq_len + 1, self.num_heads, self.head_dim))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Related to #26681

Add Pallas implementation of NSA Attention by deepseek.

* **New Implementation**:
  - Add `nsa_attention.py` in `jax/experimental/pallas/ops/gpu/` with the implementation of NSA Attention mechanism.
  - Implement `nsa_attention_forward_kernel` function to handle the forward pass of NSA Attention.
  - Implement `nsa_attention_backward_kernel` function to handle the backward pass of NSA Attention.
  - Define `nsa_attention` function with custom VJP for forward and backward passes.
  - Include utility functions like `segment_mask` and `nsa_attention_reference`.

* **Testing**:
  - Add `nsa_attention_test.py` in `tests/pallas/` with unit tests for NSA Attention.
  - Implement tests for forward pass, backward pass, and edge cases.
  - Use JAX's random number generation and gradient computation for testing.

