### PR TITLE
Support NVFP4 in scaled_matmul and scaled_dot_general

### DIFF
--- a/jax/_src/cudnn/scaled_matmul_stablehlo.py
+++ b/jax/_src/cudnn/scaled_matmul_stablehlo.py
@@ -367,6 +367,7 @@ def scaled_matmul_wrapper(
     preferred_element_type = dtypes.canonicalize_dtype(
         np.dtype(preferred_element_type)
     )
+
     out = _scaled_matmul(
         lhs,
         rhs,
@@ -374,6 +375,7 @@ def scaled_matmul_wrapper(
         rhs_scales,
         preferred_element_type=preferred_element_type,
     )
+
     return out
 
 def shape_normalization(x, dimension_numbers):
@@ -489,12 +491,14 @@ def quantize(x, config):
     scaled_x = x / e8m0_to_dtype(scales_q, scales.dtype)
   elif config.mode == "nvfp4":
     assert config.scale_type == jnp.float8_e4m3fn
-    # shuw(TODO): Add when XLA is ready and e2m1fn is available.
-    scales_q = scales
-    scales_x = x
+    assert config.global_scale.dtype == jnp.float32
+
+    scales = scales / config.global_scale
+    scales_q = jax.lax.optimization_barrier(scales.astype(jnp.float8_e4m3fn))
+    scaled_x = x / (scales_q.astype(jnp.float32) *
+                    config.global_scale).astype(x.dtype)
   else:
     raise ValueError(f"Unrecognized mode: {config.mode}.")
-
   clipped_x = jnp.clip(scaled_x, -MAX, MAX)
   x_q = clipped_x.astype(config.data_type)
 
@@ -503,10 +507,6 @@ def quantize(x, config):
       config.scale_type
   )
   return x_q, scales_q
-
-
-
-
 
 def scaled_dot_impl(lhs, rhs, dimension_numbers, preferred_element_type,
                     configs):
@@ -529,9 +529,17 @@ def scaled_dot_impl(lhs, rhs, dimension_numbers, preferred_element_type,
   lhs_q, lhs_scales = quantize(lhs_3d, lhs_config)
   rhs_q, rhs_scales = quantize(rhs_3d, rhs_config)
 
+  out_dtype = preferred_element_type
+  if configs[0].mode == 'nvfp4':
+    out_dtype = jnp.float32
+
   out = scaled_matmul_wrapper(
-      lhs_q, rhs_q, lhs_scales, rhs_scales, preferred_element_type
+      lhs_q, rhs_q, lhs_scales, rhs_scales, preferred_element_type=out_dtype
   )
+
+  if configs[0].mode == 'nvfp4':
+    out *= (configs[0].global_scale * configs[1].global_scale)
+    out = out.astype(preferred_element_type)
 
   expanded_out_shape = compute_dot_output_shape(
       lhs.shape, rhs.shape, lhs_dn, rhs_dn
@@ -564,13 +572,15 @@ def scaled_dot_general_transpose_lhs(
   g_3d = shape_normalization(g, g_dn)
 
   g_config, y_config = configs[0], configs[1]
+  if configs[0].mode != 'nvfp4':
+    g_q, g_scales = quantize(g_3d, g_config)
+    y_q, y_scales = quantize(y_3d, y_config)
 
-  g_q, g_scales = quantize(g_3d, g_config)
-  y_q, y_scales = quantize(y_3d, y_config)
-
-  out = scaled_matmul_wrapper(
-      g_q, y_q, g_scales, y_scales, preferred_element_type
-  )
+    out = scaled_matmul_wrapper(
+        g_q, y_q, g_scales, y_scales, preferred_element_type
+    )
+  else:
+    out = jnp.matmul(g_3d, jnp.permute_dims(y_3d, (0, 2, 1)), preferred_element_type=preferred_element_type)
 
   expanded_out_shape = compute_dot_output_shape(g.shape, y.shape, g_dn, y_dn)
   expanded_out = jnp.reshape(out, expanded_out_shape)


### PR DESCRIPTION
Add support for NVFP4 as a configuration option in scaled_matmul and scaled_dot_general. NVFP4 introduces a global scaling factor and a double quantization process. NVFP4 is only designed to be used for inference. @nouiz @kaixih 