### PR TITLE
vmap mismatch size error message: handle *args

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1094,6 +1094,9 @@ def _mapped_axis_size(fn, tree, vals, dims, name):
       return f"args{keystr(key_path)}"
     # args is a tuple, so key_path[0].idx is the index into args.
     i = key_path[0].idx
+    # This can happen with star arguments (*args)
+    if i >= len(signature_parameters):
+      return f"args{keystr(key_path)}"
     res = f"argument {signature_parameters[i]}"
     if len(key_path) > 1:
       res += keystr(key_path[1:])

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1974,6 +1974,17 @@ class APITest(jtu.JaxTestCase):
         x2=jnp.ones(2, dtype=jnp.float32)
       )
 
+  def test_vmap_inconsistent_sizes_constructs_proper_error_message_starargs(self):
+    # regression test for https://github.com/jax-ml/jax/issues/26908
+    def f(x, *args):
+      return x - functools.reduce(jnp.add, args)
+
+    with self.assertRaisesRegex(
+      ValueError,
+      "vmap got inconsistent sizes for array axes to be mapped:"
+    ):
+      jax.vmap(f)(jnp.ones(4), jnp.ones(2), jnp.ones(2))
+
   def test_device_get_scalar(self):
     x = np.arange(12.).reshape((3, 4)).astype("float32")
     x = api.device_put(x)


### PR DESCRIPTION
Fixes: https://github.com/jax-ml/jax/issues/26908
