### PR TITLE
Fix #26998:debug_print for float4_e2m1fn

### DIFF
--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -370,11 +370,23 @@ def debug_print(fmt: str, *args, ordered: bool = False, **kwargs) -> None:
     **kwargs: Additional keyword arguments to be formatted, as if passed to
       ``fmt.format``.
   """
+  processed_args = []
+  for arg in args:
+    if isinstance(arg, jnp.ndarray) and arg.dtype == jnp.float4_e2m1fn:
+        arg = arg.astype(jnp.float32)
+    processed_args.append(arg)
+
+  processed_kwargs = {}
+  for key, value in kwargs.items():
+    if isinstance(value, jnp.ndarray) and value.dtype == jnp.float4_e2m1fn:
+        processed_kwargs[key] = value.astype(jnp.float32)
+    else:
+        processed_kwargs[key] = value
   # Check that we provide the correct arguments to be formatted.
-  formatter.format(fmt, *args, **kwargs)
+  formatter.format(fmt, *processed_args, **processed_kwargs)
 
   debug_callback(partial(_format_print_callback, fmt, np.get_printoptions()),
-                 *args, **kwargs, ordered=ordered)
+                 *processed_args, **processed_kwargs, ordered=ordered)
 
 
 # Sharding visualization


### PR DESCRIPTION
-This PR fixes `jax.debug.print` to correctly handle `float4_e2m1fn` arrays by casting them to `float32` before printing,  addressing the misleading output reported in [Issue #26998]

-The `float4_e2m1fn` type is introduced in [PR #26525], which adds support for this 4-bit floating-point format (1 sign bit, 2 exponent bits, 1 mantissa bit) but remains unmerged. This PR is a proactive companion fix: by casting `float4_e2m1fn` to `float32`, it ensures correct printing once #26525 is merged, directly addressing #26998.