### PR TITLE
add jax.experimental.saved_input_vjp to let user pass primal inputs to bwd pass

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import atexit
 import collections
 from collections.abc import Callable, Hashable, Iterable, Sequence
+import dataclasses
 from functools import partial, lru_cache
 import inspect
 import math
@@ -41,7 +42,8 @@ from jax._src import stages
 from jax._src.tree_util import (
     tree_map, tree_flatten, tree_unflatten, tree_structure, tree_transpose,
     tree_leaves, Partial, PyTreeDef, all_leaves, keystr, broadcast_prefix,
-    prefix_errors, generate_key_paths, tree_flatten_with_path)
+    prefix_errors, generate_key_paths, tree_flatten_with_path,
+    equality_errors_pytreedef)
 from jax._src import config
 from jax._src import core
 from jax._src import dispatch
@@ -2029,6 +2031,82 @@ def _vjp(fun: lu.WrappedFun, *primals, has_aux=False):
     return out_primal_py, vjp_py
   else:
     return out_primal_py, vjp_py, tree_unflatten(aux_tree, aux)
+
+
+def saved_input_vjp(f: Callable, which: Sequence[bool], *primals,
+                    allow_unused: bool = True, allow_opaque: bool = True):
+  if len(which) != len(primals):
+    raise ValueError(
+    "length of 'which' argument must equal the number of primal input values, "
+    f"but got {len(which)=} and {len(primals)=}")
+
+  dbg = debug_info("saved_input_vjp", f, primals, {})
+  fun = lu.wrap_init(f, debug_info=dbg)
+  primals_flat, in_tree = tree_flatten(primals)
+  fun, out_tree = flatten_fun_nokwargs(fun, in_tree)
+  out_primals_flat, _, jaxpr, residuals = ad.linearize(fun, *primals_flat)
+  primals_filt, filt_tree = tree_flatten(tuple(p for w, p in zip(which, primals) if w))
+  id_map = {id(x): i for i, x in enumerate(primals_filt)}
+  opaque_residuals = []
+  res_spec = [RSpec(id_map[id(r)], True) if id(r) in id_map else
+              RSpec(opaque_residuals.append(r) or (len(opaque_residuals) - 1), False)  # type: ignore
+              for r in residuals]
+  f_vjp = Partial(_saved_input_vjpfun, res_spec, filt_tree, in_tree, out_tree(),
+                  jaxpr, opaque_residuals)
+
+  if not allow_unused and not set(id_map).issubset(res_ids := {id(r) for r in residuals}):
+    unused = [(i, core.get_aval(x)) for i, (x, w) in enumerate(zip(primals, which))
+              if w and id(x) not in res_ids]
+    assert unused
+    if len(unused) == 1:
+      (i, a), = unused
+      start, was = "an input value", "was"
+      msg = f" {dbg.arg_names[i]} of type {a.str_short()}"
+    else:
+      start, was = "multiple input values", "were"
+      msg = "\n" + "\n".join(f"  * {dbg.arg_names[i]} of type {a.str_short()}"
+                             for i, a in unused)
+    raise Exception(f"with {allow_unused=}, {start} marked to be saved {was} "
+                    f"not used by the backward pass:{msg}")
+
+  if not allow_opaque and opaque_residuals:
+    msg = ", ".join(core.get_aval(x).str_short() for x in opaque_residuals)
+    raise Exception(f"with {allow_opaque=}, the backward pass requires opaque "
+                    f"(non-input) residuals: {msg}")
+
+  out_primals = tree_unflatten(out_tree(), out_primals_flat)
+  return out_primals, f_vjp
+
+def _saved_input_vjpfun(res_spec, filtered_tree, in_tree, out_tree, jaxpr,
+                        opaque_residuals, ct, *saved_primals):
+  primals_filtered, filtered_tree_ = tree_flatten(saved_primals)
+  if filtered_tree != filtered_tree_:
+    raise ValueError(
+        "inputs passed to f_vjp must be a tuple of (pytrees of) "
+        "arrays with the same structure as\n"
+        "  tuple(x for x, w in zip(inputs, which) if w)\n"
+        "given the original call\n"
+        "  _, f_vjp = saved_input_vjp(f, which, *inputs, ...)\n"
+        "but the structures differ:\n" +
+        "\n".join(f"  * inputs{keystr(path)} was a {thing1} in the original "
+                  f"call, but a {thing2} here, so {explanation}"
+                  for path, thing1, thing2, explanation
+                  in equality_errors_pytreedef(filtered_tree, filtered_tree_)))
+
+  residuals = [primals_filtered[i.idx] if i.primal else opaque_residuals[i.idx]
+               for i in res_spec]
+  dummy_args = [ad.UndefinedPrimal(v.aval) for v in jaxpr.invars]
+  cts_flat, out_tree_ = tree_flatten(ct)
+  assert out_tree_ == out_tree
+  arg_cts = ad.backward_pass(jaxpr, True, residuals, dummy_args, cts_flat)
+  return tree_unflatten(in_tree, arg_cts)
+
+@dataclasses.dataclass(frozen=True)
+class RSpec:
+  idx: int
+  primal: bool
+
+si_vjp = saved_input_vjp
 
 
 def linear_transpose(fun: Callable, *primals, reduce_axes=()) -> Callable:

--- a/jax/experimental/__init__.py
+++ b/jax/experimental/__init__.py
@@ -19,6 +19,10 @@ from jax.experimental.x64_context import (
   enable_x64 as enable_x64,
   disable_x64 as disable_x64,
 )
+from jax._src.api import (
+  saved_input_vjp as saved_input_vjp,
+  si_vjp as si_vjp
+)
 from jax._src.callback import (
   io_callback as io_callback
 )


### PR DESCRIPTION
The problem we're trying to solve is user control over how VJP residuals (values from the forward pass needed during the backward pass) are passed to the backward pass, namely whether they're passed implicitly or explicitly by the caller of the VJP function.

When a user writes `y, f_vjp = jax.vjp(f, *args)`, the callable `f_vjp` holds onto values from the forward pass, including input values (components of `args`) and intermediates. The values held onto include things like the matrices needed for backward pass matmuls. But sometimes the user doesn't want the `f_vjp` to hold onto such values, and instead wants to pass them in as arguments to the backward pass.

For example, say we're doing something like FSDP, and we don't want autodiff to hold onto our gathered weights. If we have a function like
```python
def f(x, w_sharded):
  w = reshard(w_sharded, P())  # induces an all-gather
  x = fancy_normalization(x)
  return fancy_nonlinearity(x @ w)
```
we might want to compute the VJP automatically, especially to handle `fancy_normalization` and `fancy_nonlinearity` for us. But applying `jax.vjp` to `f` will result in the gathered `w` being saved as a residual in `f_vjp`.

Here's what we do instead. Write `f2` that takes the all-gathered weight as an argument (so that the caller must do the all-gather):
```python
def f2(x, w):
  x = fancy_normalization(x)
  return fancy_nonlinearity(x @ w)
```
Then, instead of applying `jax.vjp` to `f2`, we apply the new (in this PR) `saved_input_vjp` aka `si_vjp`:
```python
y, f2_sivjp = si_vjp(f2, [False, True], x, reshard(w_shard, P()))
```
We pass a list of booleans to `si_vjp` of the same length as the primal input arguments (here, `x` and the gathered `w`). Each entry in the list of booleans indicates whether the corresponding input will be passed as an explicit argument to the VJP function `f2_sivjp` (after the output cotangent argument):
```python
x_grad, w_grad = f2_sivjp(jnp.ones_like(y), reshard(w_shard, P()))
```
That is, instead of the VJP callable holding onto inputs as opaque residuals, we are responsible for passing back in the marked inputs. That way, the weights aren't saved at all, and we're responsible for gathering them again at the right time to be passed into the VJP callable.