### PR TITLE
Add file and zip to tsan.yaml

### DIFF
--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -35,7 +35,7 @@ jobs:
           apt install -y clang-18 libstdc++-14-dev build-essential libssl-dev \
             zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev curl git \
             libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
-            libffi-dev liblzma-dev
+            libffi-dev liblzma-dev file zip
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: jax


### PR DESCRIPTION
Tsan logs were reporting the following failures:
```
[ RUN      ] CompatTest.test_stablehlo_dynamic_rbg_bit_generator
[       OK ] CompatTest.test_stablehlo_dynamic_rbg_bit_generator
----------------------------------------------------------------------
Ran 91 tests in 66.331s

OK (skipped=40)
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
...
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
external/bazel_tools/tools/test/test-setup.sh: line 428: zip: command not found
Could not create "/__w/.cache/bazel/bazel/_bazel_root/a40625930fdef4f0a3483cd60aa1bb86/execroot/__main__/bazel-out/k8-opt/testlogs/tests/export_back_compat_test_cpu/test.outputs/outputs.zip":
```

We suppose that CI environment is missing these tools and thus failing the tests.
As test-setup.sh part looks like the following:
```bash
# Add all of the files from the undeclared outputs directory to the manifest.
if [[ -n "$TEST_UNDECLARED_OUTPUTS_DIR" && -n "$TEST_UNDECLARED_OUTPUTS_MANIFEST" ]]; then
  undeclared_outputs="$(find -L "$TEST_UNDECLARED_OUTPUTS_DIR" -type f | sort)"
  # Only write the manifest if there are any undeclared outputs.
  if [[ ! -z "$undeclared_outputs" ]]; then
    # For each file, write a tab-separated line with name (relative to
    # TEST_UNDECLARED_OUTPUTS_DIR), size, and mime type to the manifest. e.g.
    # foo.txt   9       text/plain
    while read -r undeclared_output; do
      rel_path="${undeclared_output#$TEST_UNDECLARED_OUTPUTS_DIR/}"
      # stat has different flags for different systems. -c is supported by GNU,
      # and -f by BSD (and thus OSX). Try both.
      file_size="$(stat -f%z "$undeclared_output" 2>/dev/null || stat -c%s "$undeclared_output" 2>/dev/null || echo "Could not stat $undeclared_output")"
      file_type="$(file -L -b --mime-type "$undeclared_output")"

      printf "$rel_path\t$file_size\t$file_type\n"
    done <<< "$undeclared_outputs" \
      > "$TEST_UNDECLARED_OUTPUTS_MANIFEST"
    if [[ ! -s "$TEST_UNDECLARED_OUTPUTS_MANIFEST" ]]; then
      rm "$TEST_UNDECLARED_OUTPUTS_MANIFEST"
    fi
  fi
fi
```


cc @hawkinsp 