### PR TITLE
Add a custom_partitioning helper to support batch partitioning

### DIFF
--- a/jax/experimental/custom_partitioning.py
+++ b/jax/experimental/custom_partitioning.py
@@ -18,6 +18,7 @@
 from jax._src.custom_partitioning import (
     custom_partitioning as custom_partitioning,
     custom_partitioning_p as custom_partitioning_p,
+    batch_partitionable as batch_partitionable,
 )
 
 from jax._src.custom_partitioning_sharding_rule import (


### PR DESCRIPTION
This PR adds a `batch_partitionable` helper function to `experimental.custom_partitioning` to support the common use case where a JAX traceable function supports trivial partitioning along some number of leading batch dimensions.