### PR TITLE
add experimental lax.optimization_barrier autodiff rules

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -8422,3 +8422,13 @@ mlir.register_lowering(optimization_barrier_p,
 def _optimization_barrier_batcher(batched_args, batch_dims, **params):
   return optimization_barrier_p.bind(*batched_args, **params), batch_dims
 batching.primitive_batchers[optimization_barrier_p] = _optimization_barrier_batcher
+
+def _opt_barrier_jvp(primals, tangents):
+  tangents = [ad.instantiate_zeros(t) for t in tangents]
+  return optimization_barrier(primals), optimization_barrier(tangents)
+ad.primitive_jvps[optimization_barrier_p] = _opt_barrier_jvp
+
+def _opt_barrier_transpose(cts, *primals):
+  cts = [ad.instantiate_zeros(ct) for ct in cts]
+  return optimization_barrier(cts)
+ad.primitive_transposes[optimization_barrier_p] = _opt_barrier_transpose

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -3618,6 +3618,15 @@ class LaxTest(jtu.JaxTestCase):
     x = lax.optimization_barrier((2, 3))
     self.assertEqual((2, 3), x)
 
+  def test_optimization_barrier_autodiff(self):
+    def f(x):
+      y = 1. * x
+      x, y = lax.optimization_barrier((x, y))
+      z = 2. * x
+      return y + z
+    g = jax.grad(f)(5.)  # doesn't crash
+    self.assertAllClose(g, 3., check_dtypes=False)
+
 
 class LazyConstantTest(jtu.JaxTestCase):
   def _Check(self, make_const, expected):


### PR DESCRIPTION
If you write this:
```python
def f(x):
  y = 1. * x
  x, y = jax.lax.optimization_barrier((x, y))
  z = 2. * x
  return y + z
```

You get this backward pass:
```
{ lambda ; a:f32[]. let
    b:f32[] = mul 2.0 a
    c:f32[] d:f32[] = optimization_barrier b a
    e:f32[] = mul 1.0 d
    f:f32[] = add_any c e
  in (f,) }
```

Nice!

Interestingly, if we write this:
```python
def f(x):
  y = 1. * x
  x, _ = jax.lax.optimization_barrier((x, y))  # underscore!
  z = 2. * x
  return y + z
```

we get this backward pass, in which we still have the right ordering by data dependence but only thanks to the addition with zero:
```
{ lambda a:f32[] b:f32[]; c:f32[]. let
    d:f32[] = mul c a
    e:f32[] f:f32[] = optimization_barrier d 0.0
    g:f32[] = add_any c f
    h:f32[] = mul g b
    i:f32[] = add_any e h
  in (i,) }
```

I am told that XLA will eliminate the extra add-to-zeros.