### PR TITLE
Disable warning B903 from ruff.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,8 @@ ignore = [
     "C901",
     # Local variable is assigned to but never used
     "F841",
+    # Class could be dataclass or tuple
+    "B903",
     # Raise with from clause inside except block
     "B904",
     # Zip without explicit strict parameter


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/class-as-data-structure/

I'm not sure this change makes our code better.
