### PR TITLE
Fix wrong unpacking in the decode attention pallas kernel

### DIFF
--- a/jax/experimental/pallas/ops/gpu/decode_attention.py
+++ b/jax/experimental/pallas/ops/gpu/decode_attention.py
@@ -359,16 +359,18 @@ def gqa(
       normalize_output=normalize_output,
   )
   with_kv_heads = jax.vmap(inner)
-  o, *res = jax.vmap(with_kv_heads)(
+  outputs = jax.vmap(with_kv_heads)(
       q_reshaped, k_transposed, v_transposed, start_idx, kv_seq_len
   )
-  o = o.reshape(batch_size, q_heads, head_dim)
   if return_residuals:
-    l, m = res[0]
+    o, (l, m) = outputs
+    o = o.reshape(batch_size, q_heads, head_dim)
     l = l.reshape(batch_size, q_heads)
     m = m.reshape(batch_size, q_heads)
     return o, (l, m)
   else:
+    o = outputs
+    o = o.reshape(batch_size, q_heads, head_dim)
     return o
 
 

--- a/tests/pallas/gpu_attention_test.py
+++ b/tests/pallas/gpu_attention_test.py
@@ -112,7 +112,7 @@ class DecodeAttentionTest(PallasBaseTest):
     k = random.normal(k2, (batch_size, seq_len, head_dim), dtype=jnp.float16)
     v = random.normal(k3, (batch_size, seq_len, head_dim), dtype=jnp.float16)
 
-    o, *res = decode_attention.mqa(
+    outputs = decode_attention.mqa(
         q,
         k,
         v,
@@ -122,7 +122,7 @@ class DecodeAttentionTest(PallasBaseTest):
         normalize_output=normalize_output,
         interpret=self.INTERPRET,
     )
-    o_ref, *res_ref = decode_attention.mqa_reference(
+    outputs_ref = decode_attention.mqa_reference(
         q,
         k,
         v,
@@ -131,12 +131,17 @@ class DecodeAttentionTest(PallasBaseTest):
         return_residuals=return_residuals,
         normalize_output=normalize_output
     )
-    np.testing.assert_allclose(o, o_ref, atol=0.05)
+
     if return_residuals:
-      l, m = res[0]
-      l_ref, m_ref = res_ref[0]
+      o, (l, m) = outputs
+      o_ref, (l_ref, m_ref) = outputs_ref
       np.testing.assert_allclose(l, l_ref, atol=0.05)
       np.testing.assert_allclose(m, m_ref, atol=0.05)
+    else:
+      o = outputs
+      o_ref = outputs_ref
+    np.testing.assert_allclose(o, o_ref, atol=0.05)
+    self.assertTupleEqual(o.shape, q.shape)
 
   @parameterized.named_parameters(*[
       (
@@ -163,6 +168,7 @@ class DecodeAttentionTest(PallasBaseTest):
           kwargs,
       ) in [
           (1, 1024, 16, 4, 64, {}),
+          (2, 1024, 16, 4, 64, {}),
           (1, 1024, 16, 16, 64, {}),
           (1, 1024, 32, 32, 64, {}),
       ]
@@ -196,7 +202,7 @@ class DecodeAttentionTest(PallasBaseTest):
     v = random.normal(
         k3, (batch_size, seq_len, num_kv_heads, head_dim), dtype=jnp.float16
     )
-    o, *res = decode_attention.gqa(
+    outputs = decode_attention.gqa(
         q,
         k,
         v,
@@ -206,7 +212,7 @@ class DecodeAttentionTest(PallasBaseTest):
         normalize_output=normalize_output,
         interpret=self.INTERPRET,
     )
-    o_ref, *res_ref = decode_attention.gqa_reference(
+    outputs_ref = decode_attention.gqa_reference(
         q,
         k,
         v,
@@ -215,12 +221,16 @@ class DecodeAttentionTest(PallasBaseTest):
         return_residuals=return_residuals,
         normalize_output=normalize_output
     )
-    np.testing.assert_allclose(o, o_ref, atol=0.05)
     if return_residuals:
-      l, m = res[0]
-      l_ref, m_ref = res_ref[0]
+      o, (l, m) = outputs
+      o_ref, (l_ref, m_ref) = outputs_ref
       np.testing.assert_allclose(l, l_ref, atol=0.05)
       np.testing.assert_allclose(m, m_ref, atol=0.05)
+    else:
+      o = outputs
+      o_ref = outputs_ref
+    np.testing.assert_allclose(o, o_ref, atol=0.05)
+    self.assertTupleEqual(o.shape, q.shape)
 
 
 class DecodeAttentionInterpretTest(DecodeAttentionTest):


### PR DESCRIPTION
Previously, the output structure was misaligned, causing potential shape mismatches and incorrect assertions in the test case when batch_size > 1.