### PR TITLE
Increased test timeout in TSAN CI

### DIFF
--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -210,7 +210,7 @@ jobs:
               --test_env=JAX_TEST_NUM_THREADS=8 \
               --test_output=errors \
               --local_test_jobs=32 \
-              --test_timeout=600 \
+              --test_timeout=1800 \
               --config=resultstore \
               --config=rbe_cache \
               //tests:cpu_tests

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -422,6 +422,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
         jax.grad(nn.sparse_plus)(-2.), nn.sparse_sigmoid(-2.),
         check_dtypes=False)
 
+  @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def testSquareplusGrad(self):
     check_grads(nn.squareplus, (1e-8,), order=4,
                 rtol=1e-2 if jtu.test_device_matches(["tpu"]) else None)
@@ -442,6 +443,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
   def testSquareplusZero(self, dtype):
     self.assertEqual(dtype(1), nn.squareplus(dtype(0), dtype(4)))
 
+  @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def testMishGrad(self):
     check_grads(nn.mish, (1e-8,), order=4,
                 rtol=1e-2 if jtu.test_device_matches(["tpu"]) else None)


### PR DESCRIPTION
Description:
- Increased test timeout in TSAN CI
- Skip slow tests with order 4 grad checks: nn_tests: testMishGrad and testSquareplusGrad

Context:

- nn_tests:
```
[ RUN      ] NNFunctionsTest.testDtypeMatchesInput3 (<class 'jax.numpy.float32'>, <PjitFunction of <function softplus at 0x7fffba20ece0>>)
[       OK ] NNFunctionsTest.testDtypeMatchesInput3 (<class 'jax.numpy.float32'>, <PjitFunction of <function softplus at 0x7fffba20ece0>>)
[ RUN      ] NNFunctionsTest.testSquareplusGrad
[       OK ] NNFunctionsTest.testSquareplusGrad
----------------------------------------------------------------------
Ran 4 tests in 145.317s

OK (skipped=2)


[ RUN      ] NNFunctionsTest.testMishGrad
[       OK ] NNFunctionsTest.testMishGrad
----------------------------------------------------------------------
Ran 1 test in 294.531s

OK
```

- linalg tests: running times between 5 - 200 seconds, for example:
```
[ RUN      ] LaxLinalgTest.testRandomUniform0 (n=3, dtype=<class 'numpy.float64'>)
[       OK ] LaxLinalgTest.testRandomUniform0 (n=3, dtype=<class 'numpy.float64'>)
[ RUN      ] NumpyLinalgTest.testInv0 (shape=(5, 5, 5), dtype=<class 'numpy.float64'>)
[       OK ] NumpyLinalgTest.testInv0 (shape=(5, 5, 5), dtype=<class 'numpy.float64'>)
[ RUN      ] ScipyLinalgTest.testExpmFrechet0 (n=5, dtype=<class 'numpy.float64'>)
[       OK ] ScipyLinalgTest.testExpmFrechet0 (n=5, dtype=<class 'numpy.float64'>)
----------------------------------------------------------------------
Ran 3 tests in 203.108s

OK
```




cc @hawkinsp 