### PR TITLE
Replace [with_cuda] by [with-cuda] in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,19 +82,19 @@ setup(
 
         'cuda': [
           f"jaxlib=={_current_jaxlib_version}",
-          f"jax-cuda12-plugin[with_cuda]>={_current_jaxlib_version},<={_jax_version}",
+          f"jax-cuda12-plugin[with-cuda]>={_current_jaxlib_version},<={_jax_version}",
         ],
 
         'cuda12': [
           f"jaxlib=={_current_jaxlib_version}",
-          f"jax-cuda12-plugin[with_cuda]>={_current_jaxlib_version},<={_jax_version}",
+          f"jax-cuda12-plugin[with-cuda]>={_current_jaxlib_version},<={_jax_version}",
         ],
 
         # Deprecated alias for cuda12, kept to avoid breaking users who wrote
         # cuda12_pip in their CI.
         'cuda12_pip': [
           f"jaxlib=={_current_jaxlib_version}",
-          f"jax-cuda12-plugin[with_cuda]>={_current_jaxlib_version},<={_jax_version}",
+          f"jax-cuda12-plugin[with-cuda]>={_current_jaxlib_version},<={_jax_version}",
         ],
 
         # Target that does not depend on the CUDA pip wheels, for those who want


### PR DESCRIPTION
Hello,

I tried to `pip install jax[cuda12-pip]` with python3.10.12 and encountered the following warning:

```
Requirement already satisfied: jax-cuda12-plugin[with_cuda]<=0.5.3,>=0.5.3 in ....
WARNING: jax-cuda12-plugin 0.5.3 does not provide the extra 'with_cuda'
```
After checking https://pypi.org/project/jax-cuda12-plugin/ , it seems that it `Provides-Extra: with-cuda `

This PR intends to fix this warning by replacing the `[with_cuda]` by `[with-cuda]` in setup.py

Best,