### PR TITLE
Execute tutorials as part of documentation presubmit checks

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -140,7 +140,7 @@ jobs:
     - name: Image Setup
       run: |
         apt update
-        apt install -y libssl-dev libsqlite3-dev
+        apt install -y libssl-dev libsqlite3-dev build-essential
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
       with:
@@ -151,7 +151,7 @@ jobs:
         uv pip install --system -r docs/requirements.txt
     - name: Render documentation
       run: |
-        sphinx-build -j auto --color -W --keep-going -b html -D nb_execution_mode=off docs docs/build/html
+        sphinx-build -j auto --color -W --keep-going -b html docs docs/build/html
 
   jax2tf_test:
     name: "jax2tf_test (py ${{ matrix.python-version }} on ${{ matrix.os }}, x64=${{ matrix.enable-x64}})"


### PR DESCRIPTION
Currently, we have a presubmit workflow that builds the docs on GitHub actions, but it doesn't run the tutorials:

https://github.com/jax-ml/jax/blob/160bbe12d31217e0a90a00e072c3a3b300519e69/.github/workflows/ci-build.yaml#L129-L154

This means that the only CI for the tutorials runs on Read the Docs, and that build frequently ends up in a broken state. One simple mitigation is to execute the tutorials as part of our existing presubmit workflow. This ends up repeating some work, and in the long run we may want to consider alternative doc deployment options, but in this PR I did the experiment of seeing the runtime required to make this change. Before this PR, the docs workflow takes about 2.5 min to run ([a recent run, for example](https://github.com/jax-ml/jax/actions/runs/14384032801/job/40334798618)). On this PR branch, the same workflow seems to take about [4 min](https://github.com/jax-ml/jax/actions/runs/14384162835/job/40335232344), so the cost of running the tutorials seems marginal and well within SLO.

With all this in mind, I think it's probably worth enabling tutorial execution as part of this presubmit to help avoid ending up in a broken state on Read the Docs.

#jax-fixit 