### PR TITLE
[attrs] allow setattr on a previously non-existent attr

### DIFF
--- a/jax/experimental/attrs.py
+++ b/jax/experimental/attrs.py
@@ -36,6 +36,7 @@ JaxVal = Any
 Pytree = Any
 
 register = api_util.register_class_with_attrs
+dne_sentinel = pe.dne_sentinel
 
 def jax_getattr(obj: Any, attr: str):
   with core.take_current_trace() as t:
@@ -65,7 +66,7 @@ def _ensure_tracked(trace: pe.DynamicJaxprTrace, obj: Any, attr: str):
     return tracer
 
   if (obj, attr) not in frame.attrs_tracked:
-    init_val = getattr(obj, attr)
+    init_val = getattr(obj, attr, dne_sentinel)
     frame.attrs_inits.append(init_val)
     init_vals, init_tree = tree_flatten(init_val)
     tracers = map(new_tracer, init_vals)


### PR DESCRIPTION
Before this change, we handled attrs for initial-style primitives like jit/scan like this:
1. the traceable would form a jaxpr and see what attrs were touched (by jax_getattr or jax_setattr),
2. for each such attr, the traceable would do jax_getattr to get the current value, tree-flatten, pass the flat valuesinto the (pure) bind, get the new values out, tree-unflatten, then jax_setattr the result.

That approach would error if the function called `jax_setattr` to set a previously non-existent attr. That is, this would work at the top level, but not under a `jit`:

```python
from jax.experimental.attrs import jax_setattr
class Thing: ...
thing = Thing()
jax_setattr(thing, 'x', 1.0)
```

This commit makes the same code work under a jit. In short, we use a special value to indicate "does not exist". We just
1. in partial_eval.py's `to_jaxpr`, ensure attrs added during jaxpr formation are deleted, using a special sentinel value `dne_sentinel` to indicate the attribute initially did not exist before tracing;
2. in pjit.py's `_get_states`, when reading initial attr values before the pjit_p bind, if the attribute does not exist we don't try to read it and instead just use `dne_sentinel` as the value, which is a convenient empty pytree;
3. in pjit.py's `_attr_token` for jit caching, when forming the cache key based on the current attr states, we map attrs that don't exist to `dne_sentinel` (rather than just erroring when the attr doesn't exist, as before).

This PR only makes setattr-to-nonexistent-attr work with jit. We'll add scan etc in follow-ups.

(If `jax_getattr` supported the 'default' argument, the code would be a little cleaner since we could avoid the `if hasattr` stuff. And that's probably a useful feature to have anyway. We can add that in a follow-up.)