### PR TITLE
Add pascal matrix to jax.scipy.linalg

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -69,6 +69,7 @@ jax.scipy.linalg
    lu
    lu_factor
    lu_solve
+   pascal
    polar
    qr
    rsf2csf

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -31,6 +31,7 @@ from jax._src.scipy.linalg import (
   lu as lu,
   lu_factor as lu_factor,
   lu_solve as lu_solve,
+  pascal as pascal,
   polar as polar,
   qr as qr,
   rsf2csf as rsf2csf,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2329,6 +2329,22 @@ class LaxLinalgTest(jtu.JaxTestCase):
     self.assertAllClose(
         new_product_with_batching, old_product, atol=atol)
 
+  @jtu.sample_product(
+    n=[0, 1, 5, 10, 20],
+    kind=["symmetric", "lower", "upper"],
+  )
+  @jax.default_matmul_precision("float32")
+  def testPascal(self, n, kind):
+    args_maker = lambda: []
+    osp_fun = partial(osp.linalg.pascal, n=n, kind=kind, exact=False)
+    jsp_fun = partial(jsp.linalg.pascal, n=n, kind=kind)
+    self._CheckAgainstNumpy(osp_fun,
+                            jsp_fun, args_maker,
+                            atol=1e-3,
+                            rtol=1e-2 if jtu.test_device_matches(['tpu']) else 1e-3,
+                            check_dtypes=False)
+    self._CompileAndCheck(jsp_fun, args_maker)
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This PR adds an implementation of the Pascal matrices to `jax.scipy.linalg`. The output approximates the binomial coefficients, but for higher values of `n` (greater than about 10), the output diverges more dramatically from the `scipy` output. I thought this might be ok as it's documented [here](https://docs.jax.dev/en/latest/_autosummary/jax.scipy.special.factorial.html) that JAX does not support exact factorials, but I'm open to other ideas if we want to get the output closer to the exact coefficients.

Addresses part of the request in #10144 