### PR TITLE
[Pallas] A few fixes for TPU interpret mode:

### DIFF
--- a/jax/_src/pallas/mosaic/BUILD
+++ b/jax/_src/pallas/mosaic/BUILD
@@ -158,6 +158,7 @@ py_library(
     deps = [
         ":core",
         ":primitives",
+        ":verification",
         "//jax",
         "//jax:core",
         "//jax:source_info_util",


### PR DESCRIPTION
 - Actually de-allocate buffers after a pl.run_scoped.

 - Periodically run an explicit garbage collection after de-allocating buffers.

 - Add no-op implementations for a few internal/testing mosaic primitives (prng_seed_p, prng_random_bits_p, assume_p, random_p).