### PR TITLE
Some codebase fixes required for python 3.14

### DIFF
--- a/jax/_src/basearray.py
+++ b/jax/_src/basearray.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import abc
+import sys
 import numpy as np
 from typing import Any, Union
 from collections.abc import Sequence
@@ -175,7 +176,11 @@ StaticScalar = Union[
   np.bool_, np.number,  # NumPy scalar types
   bool, int, float, complex,  # Python scalar types
 ]
-StaticScalar.__doc__ = "Type annotation for JAX-compatible static scalars."
+
+if sys.version_info[:2] < (3, 14):
+  # Python 3.14 raises
+  # AttributeError: 'typing.Union' object attribute '__doc__' is read-only
+  StaticScalar.__doc__ = "Type annotation for JAX-compatible static scalars."
 
 
 # ArrayLike is a Union of all objects that can be implicitly converted to a
@@ -187,4 +192,8 @@ ArrayLike = Union[
   np.ndarray,  # NumPy array type
   StaticScalar,  # valid scalars
 ]
-ArrayLike.__doc__ = "Type annotation for JAX array-like objects."
+
+if sys.version_info[:2] < (3, 14):
+  # Python 3.14 raises
+  # AttributeError: 'typing.Union' object attribute '__doc__' is read-only
+  ArrayLike.__doc__ = "Type annotation for JAX array-like objects."

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -417,8 +417,9 @@ def wraps(
                      else docstr.format(fun=name, doc=doc, **kwargs))
       fun.__qualname__ = getattr(wrapped, "__qualname__", fun.__name__)
       fun.__wrapped__ = wrapped
-    finally:
-      return fun
+    except Exception:
+      pass
+    return fun
   return wrapper
 
 


### PR DESCRIPTION
- Fix for "SyntaxWarning: 'return' in a 'finally' block"

For example, the following raises `SyntaxWarning: 'return' in a 'finally' block return 0`
```python
def func():
  try:
    print(123)
  finally:
    return 0
```

- Fix for "AttributeError: 'typing.Union' object attribute '__doc__' is read-only"
Decided to remove `StaticScalar.__doc__ = "..."` as there may not be a way to override it in python 3.14. 


cc @jakevdp 