### PR TITLE
[WIP] Provide warning when users capture a large number of constants under JIT

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1281,6 +1281,13 @@ compilation_cache_max_size = int_state(
           'Caching will be disabled if this value is set to 0. A '
           'special value of -1 indicates no limit, allowing the cache '
           'size to grow indefinitely.'),
+    )
+
+captured_constants_warn_bytes = int_state(
+    name='jax_captured_constants_warn_bytes',
+    default=int_env('JAX_CAPTURED_CONSTANTS_WARN_BYTES', 2 ** 24),
+    help=('The number of bytes of parameters that may be captured as constants '
+          'before a warning is issued.')
 )
 
 remove_custom_partitioning_ptr_from_cache_key = bool_state(

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -227,6 +227,25 @@ class JaxJitTest(jtu.JaxTestCase):
     self.assertArraysEqual(v1, v1_expected)
     self.assertArraysEqual(v2, v2_expected)
 
+  def test_check_for_large_number_of_constants(self):
+    y = jnp.ones((128, 128))
+    x = jnp.zeros((128,))
+
+    def jit_maker(): # need to ensure we lower at each test
+      def func(x):
+        return x @ y
+      return jax.jit(func)
+
+    with self.assertWarnsRegex(Warning, "Large amount of captured constants detected"):
+      with config.captured_constants_warn_bytes(y.nbytes):
+        jit_maker()(x)
+
+    with self.assertNoWarnings():
+      with config.captured_constants_warn_bytes(y.nbytes + 1):
+        jit_maker()(x)
+
+      with config.captured_constants_warn_bytes(-1):
+        jit_maker()(x)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
One of the most common modes by which users may have extended compile times is by unintentionally capturing, rather than tracing, a large number of constants, e.g. capturing the model weights as part of the computation.

To address this problem, this PR adds a new configuration option `jax_captured_constants_bytes` which defaults to `2 ** 24 ` = 16 megabytes. With this setting, if the captured constants total 16MB or more, JAX will emit a warning that looks like this 
```
UserWarning: Large amount of captured constants detected during lowering (65536 bytes). Capturing constants is commonly associated with long compile times. If this is intentional, disable this warning by setting JAX_CAPTURED_CONSTANTS_WARN_BYTES=-1.
```

I picked 16MB fairly arbitrarily, there is probably a better value than this! In practice number of bytes of captured constants should be considerably lower. 