### PR TITLE
Marked some tests as thread_unsafe_test 

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4424,6 +4424,7 @@ class APITest(jtu.JaxTestCase):
     out = jax.grad(f)(3.0)  # doesn't crash
     self.assertAllClose(out, 1., check_dtypes=False)
 
+  @jtu.thread_unsafe_test()
   def test_cache_clear_pmap(self):
     @jax.pmap
     def f(i):

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -7162,6 +7162,7 @@ class ShardingInTypesTest(jtu.JaxTestCase):
     out = f(np.arange(8))
     self.assertEqual(out.sharding, NamedSharding(mesh, P('x')))
 
+  @jtu.thread_unsafe_test()
   def test_set_mesh(self):
     mesh = jtu.create_mesh((2,), ('x',), axis_types=(AxisType.Explicit,))
     try:


### PR DESCRIPTION
Description:

Marked as thread_unsafe_test:
- ShardingInTypesTest.test_set_mesh
- APITest.test_cache_clear_pmap

This helps to prevent errors like:

1) in pjit_test.py:
```
ValueError: For primitive mul, context mesh AbstractMesh('x': 2, axis_types=(Explicit,)) should match the aval mesh AbstractMesh('x': 2, 'y': 1, axis_types=(Auto, Auto)) for shape float32[8,2]
```
raised for example by ArrayPjitTest.test_pjit_array_multi_input_multi_output_mesh3
and also by ArrayPjitTest.test_convert_element_type_sharding,
when pjit tests are run concurrently with `--local_test_jobs=32` and `--test_env=JAX_TEST_NUM_THREADS=8`

2) in api_test.py
```
AssertionError: Expected exactly 1 XLA compilations, but executed 2
```
raised by APITest.test_pmap_global_cache.

Here is a command that leads to the above failures:
1) 
```bash
bazel test     --test_env=JAX_NUM_GENERATED_CASES=$JAX_NUM_GENERATED_CASES     --test_env=JAX_ENABLE_X64=$JAX_ENABLE_X64     --test_env=JAX_SKIP_SLOW_TESTS=$JAX_SKIP_SLOW_TESTS     --test_env=PYTHON_GIL=0     --test_env=TSAN_OPTIONS=suppressions=$PWD/.github/workflows/tsan-suppressions_3.14.txt     --test_env=JAX_TEST_NUM_THREADS=8     --test_output=all     --local_test_jobs=32     --test_timeout=1800     --test_verbose_timeout_warnings     --test_sharding_strategy=forced=30     --nocache_test_results       //tests:pjit_test_cpu
```

2) 
```bash
bazel test     --test_env=JAX_NUM_GENERATED_CASES=$JAX_NUM_GENERATED_CASES     --test_env=JAX_ENABLE_X64=$JAX_ENABLE_X64     --test_env=JAX_SKIP_SLOW_TESTS=$JAX_SKIP_SLOW_TESTS     --test_env=PYTHON_GIL=0     --test_env=TSAN_OPTIONS=suppressions=$PWD/.github/workflows/tsan-suppressions_3.14.txt     --test_env=JAX_TEST_NUM_THREADS=8     --test_output=errors     --local_test_jobs=32     --test_timeout=1800     --test_verbose_timeout_warnings     --test_sharding_strategy=forced=40     --nocache_test_results     --test_arg=APITest.test_cache_clear_pmap --test_arg=APITest.test_pmap_global_cache     //tests:api_test_cpu
```

cc @hawkinsp 