### PR TITLE
Fixes failing FFI example builds.

### DIFF
--- a/examples/ffi/pyproject.toml
+++ b/examples/ffi/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["scikit-build-core", "nanobind", "jax>=0.4.31"]
+# TODO(dsuo): Remove nanobind pin after
+# https://github.com/wjacob/nanobind/pull/980 lands.
+requires = ["scikit-build-core", "nanobind==2.5.0", "jax>=0.4.31"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
Breaking CI: https://github.com/jax-ml/jax/actions/runs/14126719325/job/39577362075?pr=27557

See breaking nanobind PR: https://github.com/wjakob/nanobind/pull/978

See fixing nanobind PR (not landed)
https://github.com/wjakob/nanobind/pull/980