### PR TITLE
[Pallas] Support the new TPU interpret mode with pl.core_map.

### DIFF
--- a/jax/_src/pallas/mosaic/core.py
+++ b/jax/_src/pallas/mosaic/core.py
@@ -196,12 +196,16 @@ class TensorCoreMesh:
 
 
 def create_tensorcore_mesh(
-    axis_name: str, devices: Sequence[jax.Device] | None = None
+    axis_name: str,
+    devices: Sequence[jax.Device] | None = None,
+    num_cores: int | None = None,
 ) -> TensorCoreMesh:
-  # TODO(b/355036384): emit a better error if we don't have tensorcores.
-  if devices is None:
-    devices = jax.devices()
-  num_cores = devices[0].num_cores
+  if devices is not None and num_cores is not None:
+    raise ValueError('cannot specify both devices and num_cores')
+  if num_cores is None:
+    if devices is None:
+      devices = jax.devices()
+    num_cores = devices[0].num_cores
   return TensorCoreMesh(
       np.array([TensorCore(i) for i in range(num_cores)]),
       [axis_name],


### PR DESCRIPTION
NOTE: The new TPU interpret mode does not yet support Megacore, so this only enables pl.core_map over a TensorCoreMesh with shape (axis_name, 1).

Also tweaks pltpu.create_tensorcore_mesh to create a mesh with shape (axis_name, 1) when jax.devices() does not report multiple cores.