### PR TITLE
Implement `nbytes` for `PRNGKeyArray`

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -189,6 +189,10 @@ class PRNGKeyArray(jax.Array):
     return KeyTy(self._impl)
 
   @property
+  def nbytes(self):
+    return self.itemsize * self.size
+
+  @property
   def itemsize(self):
     return self.dtype.itemsize
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -657,6 +657,11 @@ class KeyArrayTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError, "PRNG key seed must be an integer"):
       random.key(seed)
 
+  def test_nbytes_property(self):
+    key = self.make_keys()
+    self.assertEqual(key.nbytes, key._base_array.nbytes)
+    self.assertEqual(key.nbytes, key.itemsize * key.size)
+
   def test_dtype_property(self):
     k1, k2 = self.make_keys(), self.make_keys()
     self.assertEqual(k1.dtype, k2.dtype)


### PR DESCRIPTION
This PR addresses the lack of an implementation of `nbytes` for `PRNGKeyArray`. 