### PR TITLE
Wait for coordinator pod in K8s

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -1130,6 +1130,7 @@ pytype_strict_library(
         "_src/clusters/mpi4py_cluster.py",
         "_src/clusters/ompi_cluster.py",
         "_src/clusters/slurm_cluster.py",
+        "_src/clusters/util.py",
         "_src/distributed.py",
         "_src/xla_bridge.py",
     ],

--- a/jax/_src/clusters/k8s_cluster.py
+++ b/jax/_src/clusters/k8s_cluster.py
@@ -21,6 +21,7 @@ import socket
 import textwrap
 import warnings
 from jax._src import clusters
+from .util import wait_for_host
 
 
 class K8sCluster(clusters.ClusterEnv):
@@ -34,7 +35,7 @@ class K8sCluster(clusters.ClusterEnv):
     if 'KUBERNETES_SERVICE_HOST' in os.environ:
       try:
         import kubernetes as k8s  # pytype: disable=import-error
-      except ImportError as e:
+      except ImportError:
         warnings.warn(
           '\n'.join([
             textwrap.fill(
@@ -104,9 +105,17 @@ class K8sCluster(clusters.ClusterEnv):
 
   @classmethod
   def get_coordinator_address(cls, timeout_secs: int | None) -> str:
-    return '{job_name}-0.{jobset_name}:{port}'.format(
+    coordinator_hostname = '{job_name}-0.{jobset_name}'.format(
       job_name=cls._pod().metadata.labels['job-name'],
-      jobset_name=cls._job().metadata.labels['jobset.sigs.k8s.io/jobset-name'],
+      jobset_name=cls._job().metadata.labels['jobset.sigs.k8s.io/jobset-name']
+    )
+    if timeout_secs:
+        # The host pod may not be up before the other hosts try to
+        # communicate with it. We check for its existence with retries.
+        wait_for_host(coordinator_hostname, timeout_secs, retry_secs=0.1,
+        retry_exp=1.4, retry_max=5)
+    return '{hostname}:{port}'.format(
+      hostname=coordinator_hostname,
       port=cls._coordinator_port
     )
 

--- a/jax/_src/clusters/util.py
+++ b/jax/_src/clusters/util.py
@@ -1,0 +1,42 @@
+# Copyright 2022 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import socket
+import time
+
+
+logger = logging.getLogger(__name__)
+
+
+def wait_for_host(
+  host_address, timeout_secs, retry_secs=5, retry_exp=1, retry_max=None
+):
+  # wait for a host to come online
+  host_found = False
+  max_time = time.time() + timeout_secs
+  while not host_found and time.time() < max_time:
+    try:
+      socket.gethostbyname(host_address)
+      host_found = True
+      logger.debug("Found host with address %s", host_address)
+    except socket.gaierror:
+      logger.debug(
+          "Failed to recognize host address %s"
+          " retrying...", host_address
+      )
+      time.sleep(retry_secs)
+      retry_secs = min(retry_secs * retry_exp, retry_max or timeout_secs)
+  if not host_found:
+    raise RuntimeError(f"Failed to recognize host address {host_address}")


### PR DESCRIPTION
Add a wait period (similar to that for TPU) when JAX is automatically bootstrapping via `jax.distributed.initialize` in K8s. This is because sometimes K8s creates the coordinator pod (pod 0) **after** other pods.