### PR TITLE
[export] Add support for override_lowering_rules to jax.export.

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -998,7 +998,7 @@ explain_cache_misses = bool_state(
     name='jax_explain_cache_misses',
     default=False,
     help=('Each time there is a miss on one of the main caches (e.g. the '
-          'tracing cache), log an explanation.. Logging is performed with '
+          'tracing cache), log an explanation. Logging is performed with '
           '`logging`. When this option is set, the log level is WARNING; '
           'otherwise the level is DEBUG.'))
 

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -663,7 +663,7 @@ class ShapePolyLoweringState:
 @dataclasses.dataclass(frozen=True)
 class LoweringParameters:
   # A mapping between primitives and user-defined LoweringRules.
-  # When lowering a primitive, give priorioty to the rule in this map over
+  # When lowering a primitive, give priority to the rule in this map over
   # existing Jax rules.
   override_lowering_rules: tuple[tuple[core.Primitive, LoweringRule]] | None = None
 


### PR DESCRIPTION
This parameter is already part of the internal API for the AOT lowering function, here we just expose it to `jax.export`.