### PR TITLE
add options to compute interpolation using a dot product and to select search algorithm

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2629,7 +2629,9 @@ def isclose(a: ArrayLike, b: ArrayLike, rtol: ArrayLike = 1e-05, atol: ArrayLike
 def _interp(x: ArrayLike, xp: ArrayLike, fp: ArrayLike,
            left: ArrayLike | str | None = None,
            right: ArrayLike | str | None = None,
-           period: ArrayLike | None = None) -> Array:
+           period: ArrayLike | None = None,
+           search_method: str = 'scan',
+           use_dot_product: bool = False) -> Array:
   util.check_arraylike("interp", x, xp, fp)
   if np.shape(xp) != np.shape(fp) or np.ndim(xp) != 1:
     raise ValueError("xp and fp must be one-dimensional arrays of equal size")
@@ -2665,7 +2667,22 @@ def _interp(x: ArrayLike, xp: ArrayLike, fp: ArrayLike,
     xp_arr = concatenate([xp_arr[-1:] - period, xp_arr, xp_arr[:1] + period])
     fp_arr = concatenate([fp_arr[-1:], fp_arr, fp_arr[:1]])
 
-  i = clip(searchsorted(xp_arr, x_arr, side='right'), 1, len(xp_arr) - 1)
+  if use_dot_product:
+    if np.ndim(x_arr) == 0:
+      return reshape(_dot_interp(x_arr, xp_arr, fp_arr, search_method),
+                     np.shape(x_arr))
+    if np.ndim(x_arr) > 1:
+      return reshape(jax.vmap(_interp, in_axes=(0, None, None, None,
+                                                None, None, None, None))(
+        x_arr, xp_arr, fp_arr, None, None, None, search_method, use_dot_product
+      ), np.shape(x_arr))
+
+    return reshape(jax.vmap(_dot_interp, in_axes=(0, None, None, None))(
+      x_arr, xp_arr, fp_arr, search_method
+    ), np.shape(x_arr))
+
+  i = clip(searchsorted(xp_arr, x_arr, side='right', method=search_method),
+           1, len(xp_arr) - 1)
   df = fp_arr[i] - fp_arr[i - 1]
   dx = xp_arr[i] - xp_arr[i - 1]
   delta = x_arr - xp_arr[i - 1]
@@ -2688,11 +2705,37 @@ def _interp(x: ArrayLike, xp: ArrayLike, fp: ArrayLike,
   return f
 
 
+def _dot_interp(x, xp, fp, search_method):
+  """Interpolate with a dot product instead of indexing.
+
+  This is often much faster than the default jnp.interp on TPUs.
+
+  Note: This function expects a scalar `x`. If you need multiple `x`
+  values, use vmap over the first argument.
+  """
+  n = len(xp)
+  i = arange(n)
+  dx = xp[1:] - xp[:-1]
+  delta = x - xp[:-1]
+  w = delta / dx
+  w_left = pad(1 - w, [(0, 1)])
+  w_right = pad(w, [(1, 0)])
+  u = searchsorted(xp, x, side='right', method=search_method)
+  u = clip(u, 1, n - 1)
+  weights = w_left * (i == (u - 1)).astype(np.float32)
+  weights += w_right * (i == u).astype(np.float32)
+  weights = where(x < xp[0], (i == 0).astype(np.float32), weights)
+  weights = where(x > xp[-1], (i == (n - 1)).astype(np.float32), weights)
+  return tensor_contractions.dot(weights, fp, precision='highest')
+
+
 @export
 def interp(x: ArrayLike, xp: ArrayLike, fp: ArrayLike,
            left: ArrayLike | str | None = None,
            right: ArrayLike | str | None = None,
-           period: ArrayLike | None = None) -> Array:
+           period: ArrayLike | None = None,
+           search_method: str = 'scan',
+           use_dot_product: bool = False) -> Array:
   """One-dimensional linear interpolation.
 
   JAX implementation of :func:`numpy.interp`.
@@ -2704,13 +2747,18 @@ def interp(x: ArrayLike, xp: ArrayLike, fp: ArrayLike,
     left: specify how to handle points ``x < xp[0]``. Default is to return ``fp[0]``.
       If ``left`` is a scalar value, it will return this value. if ``left`` is the string
       ``"extrapolate"``, then the value will be determined by linear extrapolation.
-      ``left`` is ignored if ``period`` is specified.
+      ``left`` is ignored if ``period`` is specified or if ``use_dot_product`` is ``True``.
     right: specify how to handle points ``x > xp[-1]``. Default is to return ``fp[-1]``.
       If ``right`` is a scalar value, it will return this value. if ``right`` is the string
       ``"extrapolate"``, then the value will be determined by linear extrapolation.
-      ``right`` is ignored if ``period`` is specified.
+      ``right`` is ignored if ``period`` is specified or if ``use_dot_product`` is ``True``.
     period: optionally specify the period for the *x* coordinates, for e.g. interpolation
       in angular space.
+    search_method: one of ``'scan'`` (default), ``'scan_unrolled'``, ``'sort'`` or
+      ``'compare_all'``; controls the algorithm used to compute the insertion indices.
+    use_dot_product: if ``False`` (default), use array indexing to compute the linear
+      interpolation; if ``True``, use a dot product. This tends to be more performant on
+      TPU's.
 
   Returns:
     an array of shape ``x.shape`` containing the interpolated function at values ``x``.
@@ -2748,8 +2796,11 @@ def interp(x: ArrayLike, xp: ArrayLike, fp: ArrayLike,
     static_argnames.append('right')
   if period is None:
     static_argnames.append('period')
+  if isinstance(search_method, str) or search_method is None:
+    static_argnames.append('search_method')
+  static_argnames.append('use_dot_product')
   jitted_interp = jit(_interp, static_argnames=static_argnames)
-  return jitted_interp(x, xp, fp, left, right, period)
+  return jitted_interp(x, xp, fp, left, right, period, search_method, use_dot_product)
 
 
 @overload

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2661,12 +2661,36 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     # Note: skip 8-bit and 16-bit types due to insufficient precision.
     dtype=jtu.dtypes.integer + jtu.dtypes.floating,
     target_dtype=jtu.dtypes.inexact,
+    search_method=['scan', 'scan_unrolled', 'sort', 'compare_all'],
   )
-  def testInterp(self, shape, dtype, period, left, right, target_dtype):
+  def testInterp(self, shape, dtype, period, left, right, target_dtype, search_method):
     rng = jtu.rand_default(self.rng(), scale=10)
-    kwds = dict(period=period, left=left, right=right)
-    np_fun = partial(np.interp, **kwds)
-    jnp_fun = partial(jnp.interp, **kwds)
+    np_kwds = dict(period=period, left=left, right=right)
+    jnp_kwds = dict(period=period, left=left, right=right, search_method=search_method)
+    np_fun = partial(np.interp, **np_kwds)
+    jnp_fun = partial(jnp.interp, **jnp_kwds)
+
+    args_maker = lambda: [rng(shape, dtype), np.unique(rng((100,), dtype))[:20],
+                          rng((20,), target_dtype)]
+
+    with jtu.strict_promotion_if_dtypes_match([dtype, target_dtype]):
+      self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False,
+                              rtol=3e-3, atol=1e-3)
+      self._CompileAndCheck(jnp_fun, args_maker)
+
+  @jtu.sample_product(
+    shape=nonempty_shapes,
+    period=[None, 0.59],
+    #Note: skip 8-bit and 16-bit types due to insufficient precision.
+    dtype=jtu.dtypes.integer + jtu.dtypes.floating,
+    target_dtype=jtu.dtypes.inexact,
+  )
+  def testInterpDotProduct(self, shape, period, dtype, target_dtype):
+    rng = jtu.rand_default(self.rng(), scale=10)
+    np_kwds = dict(period=period)
+    jnp_kwds = dict(period=period, search_method='compare_all', use_dot_product=True)
+    np_fun = partial(np.interp, **np_kwds)
+    jnp_fun = partial(jnp.interp, **jnp_kwds)
 
     args_maker = lambda: [rng(shape, dtype), np.unique(rng((100,), dtype))[:20],
                           rng((20,), target_dtype)]


### PR DESCRIPTION
Fixes #16182 

Adds the `search_method` and `use_dot_product` parameters to `jnp.interp`. `search_method` sets the algorithm used by `jnp.searchsorted` for [computing insertion indices](https://docs.jax.dev/en/latest/_autosummary/jax.numpy.searchsorted.html). `use_dot_product` specifices whether the linear interpolation should be computed using array indexing (if `False`) or a dot product (if `True`). Using the dot product along with `search_method='compare_all'` should yield much faster results on TPU for interpolations along smaller dimensions - approx. 100 elements.

Implementation is based on this [comment](https://github.com/jax-ml/jax/issues/16182#issuecomment-1571360668) by @shoyer 

Currently, if `use_dot_product` is `True`, the values passed in via the `left` and `right` parameters are ignored. I was unsure how to reconcile them with the suggested fix, but I am open to ideas.