### PR TITLE
Swap absl logging for Python logging

### DIFF
--- a/jax/_src/export/_export.py
+++ b/jax/_src/export/_export.py
@@ -27,7 +27,7 @@ import json
 import re
 from typing import Any, Protocol, TypeVar, Union, cast
 
-from absl import logging
+import logging
 import numpy as np
 
 import jax

--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -30,7 +30,7 @@ import dataclasses
 import functools
 from typing import Any
 
-from absl import logging
+import logging
 import jax
 from jax import dlpack
 from jax import dtypes

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -26,7 +26,7 @@ import threading
 from typing import Any, Union
 import warnings
 
-from absl import logging
+import logging
 import numpy as np
 
 import jax


### PR DESCRIPTION
We don't depend on `absl.logging` (aside from unit tests), but we're still importing it in a couple places. This PR just replaces a `absl.logging` in a few places with Python logging.

```
  File "/home/zcrank/mosaictest/.venv/lib/python3.10/site-packages/jax/_src/export/_export.py", line 30, in <module>
    from absl import logging
ModuleNotFoundError: No module named 'absl'
```

