### PR TITLE
fix(docs): corrected the name of the function call in the document

### DIFF
--- a/docs/gradient-checkpointing.md
+++ b/docs/gradient-checkpointing.md
@@ -341,7 +341,7 @@ def predict(params, x):
   return x
 ```
 
-By itself, {func}`jax.ad_checkpoint import.checkpoint_name` is just an identity function. But because some policy functions know to look for them, you can use the names to control whether certain values output by {func}`jax.ad_checkpoint import.checkpoint_name` are considered saveable:
+By itself, {func}`jax.ad_checkpoint.checkpoint_name` is just an identity function. But because some policy functions know to look for them, you can use the names to control whether certain values output by {func}`jax.ad_checkpoint.checkpoint_name` are considered saveable:
 
 ```{code-cell}
 print_saved_residuals(loss, params, x, y)


### PR DESCRIPTION
An invalid name of the function was in the docs of gradient checkpointing. This PR fixes it.