### PR TITLE
Fixed deadlock in NamedSharding::type() static method

### DIFF
--- a/jaxlib/xla/sharding.h
+++ b/jaxlib/xla/sharding.h
@@ -84,9 +84,11 @@ class NamedSharding : public Sharding {
     return logical_device_ids_;
   }
 
-  static nanobind::handle type() {
-    static auto type = nanobind::type<NamedSharding>();
-    return type;
+  static nanobind::handle & type() {
+    static absl::Mutex mu;
+    absl::MutexLock lock(&mu);
+    static nanobind::handle* type = new nanobind::handle(nanobind::type<NamedSharding>());
+    return *type;
   }
 
   absl::StatusOr<xla::nb_class_ptr<PyDeviceList>> internal_device_list() const {
@@ -120,9 +122,11 @@ class SingleDeviceSharding : public Sharding {
   const nanobind::object& device() const { return device_; }
   const nanobind::object& memory_kind() const { return memory_kind_; }
 
-  static nanobind::handle type() {
-    static auto type = nanobind::type<SingleDeviceSharding>();
-    return type;
+  static nanobind::handle & type() {
+    static absl::Mutex mu;
+    absl::MutexLock lock(&mu);
+    static nanobind::handle* type = new nanobind::handle(nanobind::type<SingleDeviceSharding>());
+    return *type;
   }
 
   xla::nb_class_ptr<PyDeviceList> internal_device_list() const {
@@ -147,9 +151,11 @@ class PmapSharding : public Sharding {
 
   const ShardingSpec& sharding_spec() const { return sharding_spec_; }
 
-  static nanobind::handle type() {
-    static auto type = nanobind::type<PmapSharding>();
-    return type;
+  static nanobind::handle & type() {
+    static absl::Mutex mu;
+    absl::MutexLock lock(&mu);
+    static nanobind::handle* type = new nanobind::handle(nanobind::type<PmapSharding>());
+    return *type;
   }
 
   xla::nb_class_ptr<PyDeviceList> internal_device_list() const {
@@ -184,9 +190,11 @@ class GSPMDSharding : public Sharding {
     return *hash_;
   }
 
-  static nanobind::handle type() {
-    static auto type = nanobind::type<GSPMDSharding>();
-    return type;
+  static nanobind::handle & type() {
+    static absl::Mutex mu;
+    absl::MutexLock lock(&mu);
+    static nanobind::handle* type = new nanobind::handle(nanobind::type<GSPMDSharding>());
+    return *type;
   }
 
   const xla::HloSharding& hlo_sharding() const { return hlo_sharding_; }


### PR DESCRIPTION
Description:
- Deadlock seen in //tests:lax_numpy_einsum_test_cpu tests
  - GDB report: https://gist.github.com/vfdev-5/826ef16c6cbc9f4d85466e8a348c3b5a
- Added mutexes to NamedSharding::type(), SingleDeviceSharding::type(), PmapSharding::type(), GSPMDSharding::type()

Test command:
```bash
./bazel test     \
    --test_env=JAX_NUM_GENERATED_CASES=$JAX_NUM_GENERATED_CASES     \
    --test_env=JAX_ENABLE_X64=$JAX_ENABLE_X64     \
    --test_env=JAX_SKIP_SLOW_TESTS=$JAX_SKIP_SLOW_TESTS     \
    --test_env=PYTHON_GIL=0     \
    --test_env=TSAN_OPTIONS=suppressions=$PWD/.github/workflows/tsan-suppressions_3.14.txt     \
    --test_env=JAX_TEST_NUM_THREADS=32 \
    --test_output=errors     \
    --test_timeout=1800     \
    --nocache_test_results  \
    --runs_per_test=20    \
    //tests:lax_numpy_einsum_test_cpu
```

cc @hawkinsp 