### PR TITLE
jnp.linalg: add symmetrize_input argument & docs

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -96,7 +96,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       a = rng(factor_shape, dtype)
       return [np.matmul(a, jnp.conj(T(a)))]
 
-    jnp_fun = partial(jnp.linalg.cholesky, upper=upper)
+    jnp_fun = partial(jnp.linalg.cholesky, upper=upper, symmetrize_input=True)
 
     def np_fun(x, upper=upper):
       # Upper argument added in NumPy 2.0.0


### PR DESCRIPTION
Fixes #9473.

At this point I think a change in default behavior is probably not in the cards, but now the functions document the difference in APIs with respect to NumPy, and allow for control over this via the `symmetrize_input` argument.