### PR TITLE
[shard-map] canonicalize rep=None to be rep={all possible axes}

### DIFF
--- a/jax/experimental/shard_map.py
+++ b/jax/experimental/shard_map.py
@@ -646,7 +646,7 @@ def _check_rep(mesh: Mesh, jaxpr: core.Jaxpr, in_rep: Sequence[RepType]
   env: dict[core.Var, RepType] = {}
 
   def read(x: core.Atom) -> RepType:
-    return env[x] if type(x) is core.Var else None
+    return env[x] if type(x) is core.Var else set(mesh.axis_names)
 
   def write(v: core.Var, val: RepType) -> None:
     env[v] = val
@@ -942,7 +942,7 @@ class ShardMapTrace(core.Trace):
       raise Exception(f"Shouldn't have any non-shard_map tracers: {val}")
     else:
       val_ = _unmatch_spec(self.mesh, {}, val, self.context_mesh)
-      return val_, None
+      return val_, set(self.mesh.axis_names) - set(self.auto)
 
   def process_primitive(self, prim, tracers, params):
     in_vals, in_rep = unzip2(map(self.to_val_rep_pair, tracers))
@@ -1008,6 +1008,7 @@ class ShardMapTracer(core.Tracer):
   val: JaxType
 
   def __init__(self, trace, rep, val):
+    rep = set(trace.mesh.axis_names) - set(trace.auto) if rep is None else rep
     self._trace = trace
     self.rep = rep
     self.val = val
@@ -2151,7 +2152,7 @@ def _efficient_transpose_rewrite(fun, mesh, in_names, out_names_thunk):
 def _efficient_transpose_rewrite_nomatch(f, store, mesh, in_reps, *args):
   with core.take_current_trace() as parent:
     tag = core.TraceTag()
-    t = RewriteTrace(parent_trace = parent, tag = tag, mesh=mesh)
+    t = RewriteTrace(parent_trace=parent, tag=tag, mesh=mesh)
     in_tracers = map(partial(RewriteTracer, t), in_reps, args)
     with core.set_current_trace(t):
       ans = f(*in_tracers)

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -2749,6 +2749,8 @@ class ShardMapTest(jtu.JaxTestCase):
 
   def test_rep_none_canonicalization(self):
     # https://github.com/jax-ml/jax/issues/26621
+    if config.use_shardy_partitioner.value:
+      self.skipTest('complex values fail under shardy')
     N = 8
     xs = jnp.ones((8, N), dtype=jnp.int32)
     variables = jax.random.normal(jax.random.key(1), (N, N), jnp.complex64)

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -2747,6 +2747,28 @@ class ShardMapTest(jtu.JaxTestCase):
 
     f(x)  # doesn't crash
 
+  def test_rep_none_canonicalization(self):
+    # https://github.com/jax-ml/jax/issues/26621
+    N = 8
+    xs = jnp.ones((8, N), dtype=jnp.int32)
+    variables = jax.random.normal(jax.random.key(1), (N, N), jnp.complex64)
+    mesh = jtu.create_mesh((2,), ('i',))
+    in_specs = (P(), P("i"),)
+    out_specs = P("i")
+
+    variables = jax.lax.with_sharding_constraint(variables, NamedSharding(mesh, P()))
+    xs = jax.lax.with_sharding_constraint(xs, NamedSharding(mesh, P('i')))
+
+    def fun(v, xs):
+        # Commenting this single line below makes everything work
+        v = jax.scipy.linalg.expm(v)
+        v = v.sum()
+        return v * xs.sum(axis=-1).astype(v.dtype)
+
+    res = fun(variables, xs)
+    fun_shard_map = shard_map(fun, mesh=mesh, in_specs=in_specs, out_specs=out_specs)
+    res = fun_shard_map(variables, xs)  # don't crash
+
 
 class FunSpec(NamedTuple):
   name: str


### PR DESCRIPTION
~None is meant to represent the same thing as {replicated over all possible axes}. But without this canonicalization, we could compare None as not equal to {all possible axes}.~

See https://github.com/jax-ml/jax/pull/18711 for why the above approach didn't work. Changing tack...

check_rep uses rep=None to indicate when an argument is a constant, and that's useful specifically when checking the backward pass for integer_pow, which has a multiplication by a constant that didn't get a pbroadcast applied to it. That is, we use rep=None as a special carve-out for constants.

The standard rules were compatible with rep=None, but the rules for higher-order primitives like scan and cond were not. So we had to upgrade them.

fixes #26621

Unrelated: in several places, including the _check_rep path, we don't handle partial auto correctly, since we treat {all possible axes} as {all mesh axes}, but actually it should be more like {all mesh axes} - auto. We'll leave that fix for a follow-up...