### PR TITLE
Harden compilation cache against libtpu version mismatch

### DIFF
--- a/jax/_src/cache_key.py
+++ b/jax/_src/cache_key.py
@@ -111,6 +111,10 @@ def get(
           ),
       ),
       (
+          "backend version",
+          lambda hash_obj: _hash_platform(hash_obj, backend)
+      ),
+      (
           "XLA flags",
           lambda hash_obj: _hash_xla_flags(hash_obj, get_flag_prefixes()),
       ),
@@ -126,7 +130,7 @@ def get(
       ),
       (
           "accelerator_config",
-          lambda hash_obj: _hash_accelerator_config(hash_obj, devices, backend),
+          lambda hash_obj: _hash_accelerator_config(hash_obj, devices),
       ),
       (
           "compression",
@@ -220,7 +224,7 @@ def _hash_devices(hash_obj, devices: np.ndarray) -> None:
     _hash_string(hash_obj, device.device_kind)
 
 
-def _hash_accelerator_config(hash_obj, accelerators: np.ndarray, backend):
+def _hash_accelerator_config(hash_obj, accelerators: np.ndarray):
   accelerator_devices = []
   for accelerator in accelerators.flat:
     accelerator_devices.append(accelerator)
@@ -233,9 +237,8 @@ def _hash_accelerator_config(hash_obj, accelerators: np.ndarray, backend):
     # PjRtTopologyDescription as yet.
     logger.info("get (_hash_accelerator_config): unable to hash "
                 "accelerator config, falling back to hashing "
-                "devices + platform: %s (type %s)", ex, type(ex))
+                "devices %s (type %s)", ex, type(ex))
     _hash_devices(hash_obj, accelerators)
-    _hash_platform(hash_obj, backend)
 
 # LINT.IfChange(xla_flags)
 xla_flags_to_exclude_from_cache_key = [

--- a/tests/cache_key_test.py
+++ b/tests/cache_key_test.py
@@ -83,9 +83,9 @@ class CacheKeyTest(jtu.JaxTestCase):
     self.assertEqual(dev_hash1, dev_hash2)
 
     acc_hash1 = self.get_hashed_value(
-        cache_key._hash_accelerator_config, devices, xla_bridge.get_backend())
+        cache_key._hash_accelerator_config, devices)
     acc_hash2 = self.get_hashed_value(
-        cache_key._hash_accelerator_config, devices, xla_bridge.get_backend())
+        cache_key._hash_accelerator_config, devices)
     self.assertEqual(acc_hash1, acc_hash2)
 
   def test_hash_platform(self):


### PR DESCRIPTION
Under many circumstances, the compilation cache key is currently not using the verison of libtpu to generate key hashes ([b/408065392](https://b.corp.google.com/issues/408065392) for Googlers). This can cause incorrect hit/miss behaviour if the user manages to pair jaxlib with an unblessed version of libtpu. 

The root of the cause was that the xla backend information is only sometimes incorporated into the cache key hash. This change restructures the way the hash is generated so that it *always* makes use of the accompanying backend version. 

Users with the correctly pinned versions of libtpu and jax/jaxlib will be unaffected.

For an example of the disturbing behaviour see
```
$ libtpu_0.0.10/bin/python -m pip freeze | grep -E "libtpu|jax"
jax==0.5.3
jaxlib==0.5.3
libtpu==0.0.10

$libtpu_0.0.11.1/bin/python -m pip freeze | grep -E "libtpu|jax"
jax==0.5.3
jaxlib==0.5.3
libtpu==0.0.11.1
```

```
$ libtpu_0.0.11.1/bin/python main.py
...
WARNING:2025-04-04 00:01:46,023:jax._src.compiler:97: Persistent compilation cache hit for 'jit_foo' with key 'jit_foo-e7e5dd4d3a3c71d67517d04e46533ad41081653e58c72e4d819d5f11fd4e6e59'
WARNING:2025-04-04 00:01:46,023:jax._src.dispatch:190: Finished XLA compilation of jit(foo) in 0.024296045 sec

$ libtpu_0.0.10/bin/python main.py
...
WARNING:2025-04-04 00:08:29,327:jax._src.compiler:97: Persistent compilation cache hit for 'jit_foo' with key 'jit_foo-e7e5dd4d3a3c71d67517d04e46533ad41081653e58c72e4d819d5f11fd4e6e59'
WARNING:2025-04-04 00:08:29,327:jax._src.dispatch:190: Finished XLA compilation of jit(foo) in 0.022633076 sec
```
Jaxlib with both versions of libtpu hit on the same cache key. 