### PR TITLE
Automatically document `jax.config` options

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,6 +80,7 @@ extensions = [
     "sphinx_remove_toctrees",
     'sphinx_copybutton',
     'jax_extensions',
+    'jax_list_config_options',
     'sphinx_design',
     'sphinxext.rediraffe',
 ]

--- a/docs/config_options.rst
+++ b/docs/config_options.rst
@@ -1,0 +1,66 @@
+.. _jax:
+
+.. This target is required to prevent the Sphinx build error "Unknown target name: jax".
+.. The custom directive list_config_options imports JAX to extract real configuration
+.. data, which causes Sphinx to look for a target named "jax". This dummy target
+.. satisfies that requirement while allowing the actual JAX import to work.
+
+Configuration Options
+=====================
+
+JAX provides various configuration options to customize its behavior. These options control everything from numerical precision to debugging features.
+
+How to Use Configuration Options
+--------------------------------
+
+JAX configuration options can be set in several ways:
+
+1. **Environment variables** (set before running your program):
+
+   .. code-block:: bash
+
+      export JAX_ENABLE_X64=True
+      python my_program.py
+
+2. **Runtime configuration** (in your Python code):
+
+   .. code-block:: python
+
+      import jax
+      jax.config.update("jax_enable_x64", True)
+
+3. **Command-line flags** (using Abseil):
+
+   .. code-block:: python
+
+      # In your code:
+      import jax
+      jax.config.parse_flags_with_absl()
+
+   .. code-block:: bash
+
+      # When running:
+      python my_program.py --jax_enable_x64=True
+
+Common Configuration Options
+----------------------------
+
+Here are some of the most frequently used configuration options:
+
+- ``jax_enable_x64`` -- Enable 64-bit floating-point precision
+- ``jax_disable_jit`` -- Disable JIT compilation for debugging
+- ``jax_debug_nans`` -- Check for and raise errors on NaNs
+- ``jax_platforms`` -- Control which backends (CPU/GPU/TPU) JAX will initialize
+- ``jax_numpy_rank_promotion`` -- Control automatic rank promotion behavior
+- ``jax_default_matmul_precision`` -- Set default precision for matrix multiplication operations
+
+.. raw:: html
+
+   <div style="margin-top: 30px;"></div>
+
+All Configuration Options
+-------------------------
+
+Below is a complete list of all available JAX configuration options:
+
+.. list_config_options::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -165,6 +165,10 @@ maintains an up-to-date list.
    changelog
    glossary
 
+.. toctree::
+   :maxdepth: 2
+
+   config_options
 
 .. _Awesome JAX: https://github.com/n2cholas/awesome-jax
 .. _AXLearn: https://github.com/apple/axlearn

--- a/docs/sphinxext/jax_list_config_options.py
+++ b/docs/sphinxext/jax_list_config_options.py
@@ -1,0 +1,160 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from operator import itemgetter
+from typing import Any, List
+
+from docutils import nodes
+from sphinx.util import logging
+from sphinx.util.docutils import SphinxDirective
+
+logger = logging.getLogger(__name__)
+
+_deprecations = (
+  'jax_default_dtype_bits', # an experiment that we never documented, but we can't remove it because Keras depends on its existing broken behavior
+  'jax_serialization_version'
+)
+
+def create_field_item(label, content):
+  """Create a field list item with a label and content side by side.
+
+  Args:
+    label: The label text for the field name
+    content: The content to add (a node or text)
+
+  Returns:
+    A field list item with the label and content side by side.
+  """
+  # Create a field list item
+  field = nodes.field()
+
+  # Create the field name (label)
+  field_name = nodes.field_name()
+  field_name += nodes.Text(label)
+  field += field_name
+
+  # Create the field body (content)
+  field_body = nodes.field_body()
+
+  if isinstance(content, str):
+    para = nodes.paragraph()
+    para += nodes.Text(content)
+    field_body += para
+  elif isinstance(content, nodes.Node):
+    field_body += content
+
+  field += field_body
+  return field
+
+class ConfigOptionDirective(SphinxDirective):
+  required_arguments = 0
+  optional_arguments = 0
+  has_content = False
+
+  def run(self) -> List[nodes.Node]:
+    from jax._src.config import config as jax_config
+
+    config_options = sorted(jax_config.meta.items(), key=itemgetter(0))
+    result = []
+
+    for name, (opt_type, meta_args, meta_kwargs) in config_options:
+      if name in _deprecations:
+        continue
+
+      holder = jax_config._value_holders[name]
+
+      # Create target for linking
+      target = nodes.target()
+      target['ids'].append(name)
+      result.append(target)
+
+      # Create a section for this option
+      option_section = nodes.section()
+      option_section['ids'].append(name)
+      option_section['classes'].append('config-option-section')
+
+      # Create a title with the option name (important for TOC)
+      title = nodes.title()
+      title['classes'] = ['h4']
+      title += nodes.Text(name.replace("jax_", "").replace("_", " ").title())
+      option_section += title
+
+      # Create a field list for side-by-side display
+      field_list = nodes.field_list()
+      field_list['classes'].append('config-field-list')
+
+      # Add type information as a field item
+      if opt_type == "enum":
+        type_para = nodes.paragraph()
+        emphasis_node = nodes.emphasis()
+        emphasis_node += nodes.Text("Enum values: ")
+        type_para += emphasis_node
+
+        for i, value in enumerate(enum_values := meta_kwargs.get('enum_values', [])):
+          type_para += nodes.literal(text=repr(value))
+          if i < len(enum_values) - 1:
+            type_para += nodes.Text(", ")
+      else:
+        type_para = nodes.paragraph()
+        type_para += nodes.literal(text=opt_type.__name__)
+
+      field_list += create_field_item("Type", type_para)
+
+      # Add default value information
+      default_para = nodes.paragraph()
+      default_para += nodes.literal(text=repr(holder.value))
+      field_list += create_field_item("Default Value", default_para)
+
+      # Add configuration string information
+      string_para = nodes.paragraph()
+      string_para += nodes.literal(text=repr(name))
+      field_list += create_field_item("Configuration String", string_para)
+
+      string_para = nodes.paragraph()
+      string_para += nodes.literal(text=name.upper())
+      field_list += create_field_item("Environment Variable", string_para)
+
+      # Add the field list to the section
+      option_section += field_list
+
+      # Add help text in a description box
+      if (help_text := meta_kwargs.get('help')):
+        help_para = nodes.paragraph()
+        # logger.error(name)
+        # logger.warning(help_text)
+
+        # If we get here, help text seems valid - proceed with normal parsing
+        # parsed = nodes.Text(help_text)
+        help_para += self.parse_text_to_nodes(help_text)
+
+        option_section += help_para
+
+      result.append(option_section)
+      # Add an extra paragraph to ensure proper separation
+      result.append(nodes.paragraph())
+      result.append(nodes.paragraph()) # ensure new line
+
+    return result
+
+  def get_location(self) -> Any:
+    return (self.env.docname, self.lineno)
+
+def setup(app):
+  app.add_directive("list_config_options", ConfigOptionDirective)
+
+  return {
+    "version": "0.1",
+    "parallel_read_safe": True,
+    "parallel_write_safe": True,
+  }

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1020,13 +1020,13 @@ spmd_mode = enum_state(
     name='jax_spmd_mode',
     enum_values=['allow_all', 'allow_jit'],
     default='allow_jit',
-    help=("Decides whether Math on `jax.Array`'s that are not fully addressable "
-          "(i.e. spans across multiple processes) is allowed. The options are: "
-          "* allow_jit: Default, `pjit` and `jax.jit` computations are allowed "
-          "    to execute on non-fully addressable `jax.Array`s\n"
-          "* allow_all: `jnp`, normal math (like `a + b`, etc), `pjit`, "
-          "    `jax.jit` and all other operations are allowed to "
-          "    execute on non-fully addressable `jax.Array`s."))
+    help=("Decides whether Math on ``jax.Array`` objects that are not fully addressable "
+          "(i.e. spans across multiple processes) is allowed. The options are:\n\n"
+          "* ``allow_jit``: Default, ``pjit`` and ``jax.jit`` computations are allowed "
+          "  to execute on non-fully addressable ``jax.Array`` objects\n"
+          "* ``allow_all``: ``jnp``, normal math (like ``a + b``, etc), ``pjit``, "
+          "  ``jax.jit`` and all other operations are allowed to "
+          "  execute on non-fully addressable ``jax.Array`` objects."))
 
 
 distributed_debug = bool_state(
@@ -1469,18 +1469,17 @@ traceback_filtering = enum_state(
     enum_values=["off", "tracebackhide", "remove_frames", "quiet_remove_frames",
                  "auto"],
     default="auto",
-    help="Controls how JAX filters internal frames out of tracebacks.\n\n"
-         "Valid values are:\n"
-         " * \"off\": disables traceback filtering.\n"
-         " * \"auto\": use \"tracebackhide\" if running under a sufficiently"
-         " new IPython, or \"remove_frames\" otherwise.\n"
-         " * \"tracebackhide\": adds \"__tracebackhide__\" annotations to"
-         " hidden stack frames, which some traceback printers support.\n"
-         " * \"remove_frames\": removes hidden frames from tracebacks, and adds"
-         " the unfiltered traceback as a __cause__ of the exception.\n"
-         " * \"quiet_remove_frames\": removes hidden frames from tracebacks, and adds"
-         " a brief message (to the __cause__ of the exception) describing that this has"
-         " happened.\n")
+    help="Controls how JAX filters internal frames out of tracebacks. Valid values are:\n"
+         "- ``off``: disables traceback filtering.\n"
+         "- ``auto``: use ``tracebackhide`` if running under a sufficiently "
+         "new IPython, or ``remove_frames`` otherwise.\n"
+         "- ``tracebackhide``: adds ``__tracebackhide__`` annotations to "
+         "hidden stack frames, which some traceback printers support.\n"
+         "- ``remove_frames``: removes hidden frames from tracebacks, and adds "
+         "the unfiltered traceback as a ``__cause__`` of the exception.\n"
+         "- ``quiet_remove_frames``: removes hidden frames from tracebacks, and adds "
+         "a brief message (to the ``__cause__`` of the exception) describing that this has "
+         "happened.\n\n")
 
 # This flag is for internal use.
 # TODO(tianjianlu): Removes once we always enable cusparse lowering.
@@ -1703,16 +1702,17 @@ array_garbage_collection_guard = optional_enum_state(
     # The default is applied by guard_lib.
     default=None,
     help=(
-        'Select garbage collection guard level for "jax.Array" objects.\nThis'
-        ' option can be used to control what happens when a "jax.Array"'
-        ' object is garbage collected. It is desirable for "jax.Array"'
-        ' objects to be freed by Python reference couting rather than garbage'
+        'Select garbage collection guard level for ``jax.Array`` objects.\n\n'
+        'This option can be used to control what happens when a ``jax.Array``'
+        ' object is garbage collected. It is desirable for ``jax.Array``'
+        ' objects to be freed by Python reference counting rather than garbage'
         ' collection in order to avoid device memory being held by the arrays'
-        ' until garbage collection occurs.\n\nValid values are:\n * "allow":'
-        ' do not log garbage collection of "jax.Array" objects.\n * "log":'
-        ' log an error when a "jax.Array" is garbage collected.\n * "fatal":'
-        ' fatal error if a "jax.Array" is garbage collected.\nDefault is'
-        ' "allow". Note that not all cycles may be detected.'
+        ' until garbage collection occurs.\n\n'
+        'Valid values are:\n\n'
+        '* ``allow``: do not log garbage collection of ``jax.Array`` objects.\n'
+        '* ``log``: log an error when a ``jax.Array`` is garbage collected.\n'
+        '* ``fatal``: fatal error if a ``jax.Array`` is garbage collected.\n\n'
+        'Default is ``allow``. Note that not all cycles may be detected.'
     ),
     update_global_hook=lambda val: _update_garbage_collection_guard(
         guard_lib.global_state(), 'garbage_collect_array', val


### PR DESCRIPTION
This PR introduces a new sphinx extension that indexes all of the options in `jax._src.config` and documents them using the help text, type, and default value.

Rendered preview: https://jax--27849.org.readthedocs.build/en/27849/config_options.html