### PR TITLE
Merge `tuple_replace` and `tuple_update` in `jax._src.util`.

### DIFF
--- a/jax/_src/numpy/indexing.py
+++ b/jax/_src/numpy/indexing.py
@@ -39,7 +39,7 @@ from jax._src.numpy import util
 from jax._src.pjit import auto_axes
 from jax._src.tree_util import tree_flatten
 from jax._src.typing import Array, ArrayLike, StaticScalar
-from jax._src.util import canonicalize_axis, safe_zip, set_module, tuple_replace
+from jax._src.util import canonicalize_axis, safe_zip, set_module, tuple_update
 import numpy as np
 
 export = set_module('jax.numpy')
@@ -397,7 +397,9 @@ def take_along_axis(
 
 
 def _make_along_axis_idx(shape, indices, axis):
-  return tuple_replace(lax_numpy.indices(shape, sparse=True), axis, indices)
+  if axis < 0:
+    axis += len(shape)
+  return tuple_update(lax_numpy.indices(shape, sparse=True), axis, indices)
 
 
 @export

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -441,10 +441,6 @@ def tuple_update(t, idx, val):
   assert 0 <= idx < len(t), (idx, len(t))
   return t[:idx] + (val,) + t[idx+1:]
 
-def tuple_replace(tupl, index, item):
-  # unlike tuple_update, works with negative indices as well
-  return tupl[:index] + (item,) + tupl[index:][1:]
-
 class HashableFunction:
   """Decouples function equality and hash from its identity.
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -50,7 +50,7 @@ from jax._src import core
 from jax._src import dtypes
 from jax._src import test_util as jtu
 from jax._src.lax import lax as lax_internal
-from jax._src.util import safe_zip, NumpyComplexWarning, tuple_replace
+from jax._src.util import safe_zip, NumpyComplexWarning, tuple_update
 
 config.parse_flags_with_absl()
 
@@ -6038,7 +6038,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       dict(a_shape=a_shape, i_shape=i_shape, v_shape=v_shape, axis=axis)
       for a_shape in nonempty_array_shapes
       for axis in list(range(-len(a_shape), len(a_shape)))
-      for i_shape in [tuple_replace(a_shape, axis, J) for J in range(a_shape[axis] + 1)]
+      for i_shape in [
+        tuple_update(a_shape, axis if axis >= 0 else axis + len(a_shape), J)
+        for J in range(a_shape[axis] + 1)
+      ]
       for v_shape in [(), (1,), i_shape]
     ] + [
       dict(a_shape=a_shape, i_shape=i_shape, v_shape=v_shape, axis=None)


### PR DESCRIPTION
Merge [`tuple_update`](https://github.com/jax-ml/jax/blob/f95f6a8bdbc357bd4f5cd7d2274667b2ef50c7d4/jax/_src/util.py#L440) and [`tuple_replace`](https://github.com/jax-ml/jax/blob/f95f6a8bdbc357bd4f5cd7d2274667b2ef50c7d4/jax/_src/util.py#L444) in [`jax._src.util`](https://github.com/jax-ml/jax/blob/f95f6a8bdbc357bd4f5cd7d2274667b2ef50c7d4/jax/_src/util.py).

I added the latter in https://github.com/jax-ml/jax/pull/24871, but it's somewhat redundant given the former.