### PR TITLE
Make jax.jit return a real object (JitWrapped).

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -297,7 +297,7 @@ def jit(
 def disable_jit(disable: bool = True):
   """Context manager that disables :py:func:`jit` behavior under its dynamic context.
 
-  For debugging it is useful to have a mechanism that disables :py:func:`jit`
+  For debugging, it is useful to have a mechanism that disables :py:func:`jit`
   everywhere in a dynamic context. Note that this not only disables explicit
   uses of :func:`jit` by the user, but will also remove any implicit JIT compilation
   used by the JAX library: this includes implicit JIT computation of `body` and

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1611,7 +1611,7 @@ class APITest(jtu.JaxTestCase):
     assert grad(f)(2.0) == 4.0
     assert len(side) == 1
 
-  @jtu.thread_unsafe_test()  # Concurrent ache eviction means we may retrace.
+  @jtu.thread_unsafe_test()  # Concurrent cache eviction means we may retrace.
   def test_jit_of_grad(self):
     side = []
 


### PR DESCRIPTION
Previously, jax.jit returned a function with extra attributes, e.g., `trace`, and `lower`, such that we can use:

```
jax.jit(f).trace(...)
```

The new attributes create problems when `jax.jit` is used along `functools.wraps`. Essentially, `functools.wraps(jax.jit(f))(wrapper)` is supposed to result in a function that when invoked will invoke `wrapper` and then presumably `jax.jit(f)`.
This works as expected if you just call the result, but if you try to use it with AOT, the `wrapper` is bypassed. This is because `wraps` copies the attributes `trace` and `lower` from `jax.jit(f)` onto the resulting function, so when `trace` is invoked the `wrapper` is bypassed entirely.

See #27829 and #27825.

The solution proposed here is to have `jit` return an object of class `JitWrapped`, with methods `lower`, and `trace` and `__call__`. If a `functools.wraps(jax.jit(f))()` is called, the result can be called but you will get an error when trying to invoke it with the AOT APIs. That is better than silently ignoring the wrapper. The solution is to apply `jax.jit` last among your wrappers.

Fixes: #27829