### PR TITLE
Fix build for clang >=19

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -132,6 +132,8 @@ build:clang --copt=-Wno-gnu-offsetof-extensions
 build:clang --copt=-Qunused-arguments
 # Error on struct/class mismatches, since this causes link failures on Windows.
 build:clang --copt=-Werror=mismatched-tags
+# Required when building with clang>=19, see jax-ml/jax#27091
+build:clang --copt=-Wno-error=c23-extensions
 
 # Configs for CUDA
 build:cuda --repo_env TF_NEED_CUDA=1


### PR DESCRIPTION
This will fix [this issue](https://github.com/jax-ml/jax/issues/27091).