### PR TITLE
Account for versioned clang binaries

### DIFF
--- a/build/tools/utils.py
+++ b/build/tools/utils.py
@@ -206,8 +206,13 @@ def get_clangpp_path(clang_path):
   clang_path = pathlib.Path(clang_path)
   clang_exec_name = clang_path.name
   clangpp_exec_name = clang_exec_name
-  if "clang++" not in clang_exec_name:
-    clangpp_exec_name = clang_exec_name.replace("clang", "clang++")
+  clangpp_path = clang_path.parent / clang_exec_name
+  # Try and match what the user passed in (either clang-18 or clang)
+  if "clang++" not in clangpp_exec_name:
+    clangpp_exec_name = clangpp_exec_name.replace("clang", "clang++")
+    clangpp_path = clang_path.parent / clangpp_exec_name
+    if not clangpp_path.exists():
+      clangpp_exec_name = "clang++"
   clangpp_path = clang_path.parent / clangpp_exec_name
   if not clangpp_path.exists():
     raise FileNotFoundError(


### PR DESCRIPTION
Not every path to the clang executable ends with `clang`. Sometimes users might pass in a versioned clang, like `clang-18` or `clang-19` (usually `clang` is just a symlink to one of those). When this happens `get_clangpp_path` will set `clangpp_exec_name` to `"clang++-18"`, which doesn't exist, and the build will fail. Use `re.sub` to replace anything that looks like a versioned clang or a simple clang with `clang++`.