### PR TITLE
Skip Read the Docs builds unless the 'documentation' label is added.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,14 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.10"
+  jobs:
+    post_checkout:
+      # Skip building PRs unless tagged with the "documentation" label.
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && (curl -s "https://api.github.com/repos/jax-ml/jax/issues/$READTHEDOCS_VERSION/labels" | grep -vq "https://api.github.com/repos/jax-ml/jax/labels/documentation")
+        then
+          exit 183;
+        fi
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
The idea here is to skip builds on Read the Docs unless explicitly requested by adding the "documentation" label (we could add a new one!), following these docs: https://docs.readthedocs.com/platform/stable/build-customization.html#cancel-build-based-on-a-condition

This should free up the Read the Docs queue for the "latest" builds and reviews that really need a preview of the docs for that PR.

One slight UX awkwardness is that the label must be applied before the Read the Docs build starts, and adding the label doesn't automatically trigger the build. I guess that the recommended approach would be to add the label when creating the PR if you know it will be relevant, or add the label and ask the contributor to force push.

#jax-fixit 