### PR TITLE
Fix grep used for skipping PR builds on Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,10 +13,8 @@ build:
     post_checkout:
       # Skip building PRs unless tagged with the "documentation" label.
       - |
-        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && (curl -s "https://api.github.com/repos/jax-ml/jax/issues/$READTHEDOCS_VERSION/labels" | grep -vq "https://api.github.com/repos/jax-ml/jax/labels/documentation")
-        then
-          exit 183;
-        fi
+        [ "${READTHEDOCS_VERSION_TYPE}" != "external" ] && echo "Building latest" && exit 0
+        (curl -sL https://api.github.com/repos/jax-ml/jax/issues/${READTHEDOCS_VERSION}/labels | grep -q "https://api.github.com/repos/jax-ml/jax/labels/documentation") && echo "Building PR with label" || exit 183
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
In https://github.com/jax-ml/jax/pull/27917, I got the logic used to skip builds slightly wrong. The `-v` flag inverted the search, which I wanted to mean that no match was found, but it just meant that every PR was skipped. This change updates the logic to properly run PRs with the label.

Here's a build that was properly triggered by the label: https://app.readthedocs.org/projects/jax/builds/27817910/