### PR TITLE
[Pallas] Fix potential barrier race condition in Pallas TPU docs

### DIFF
--- a/docs/pallas/tpu/distributed.ipynb
+++ b/docs/pallas/tpu/distributed.ipynb
@@ -17,12 +17,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 6,
    "metadata": {
     "executionInfo": {
-     "elapsed": 1978,
+     "elapsed": 52,
      "status": "ok",
-     "timestamp": 1722904801801,
+     "timestamp": 1744390458993,
      "user": {
       "displayName": "Justin Fu",
       "userId": "17543197034567316452"
@@ -30,18 +30,19 @@
      "user_tz": 420
     },
     "id": "PyAGnWc9yI8T",
-    "outputId": "1d8229bd-cab5-495f-93e9-fff2e41db480"
+    "outputId": "c5912653-c34b-4810-c373-4a2787691317"
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Running with 4 TPU v5 lite devices.\n"
+      "Running with 4 TPU v4 devices.\n"
      ]
     }
    ],
    "source": [
+    "import functools\n",
     "import jax\n",
     "from jax import lax\n",
     "from jax import numpy as jnp\n",
@@ -215,12 +216,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 7,
    "metadata": {
     "executionInfo": {
-     "elapsed": 1606,
+     "elapsed": 152,
      "status": "ok",
-     "timestamp": 1722904803566,
+     "timestamp": 1744390459367,
      "user": {
       "displayName": "Justin Fu",
       "userId": "17543197034567316452"
@@ -228,7 +229,7 @@
      "user_tz": 420
     },
     "id": "YkyIKN2thZ-V",
-    "outputId": "9b7ed142-d161-4237-fed8-cbce41adc5f0"
+    "outputId": "26719bb9-87ff-46dd-af90-a114ce332417"
    },
    "outputs": [
     {
@@ -338,12 +339,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
    "metadata": {
     "executionInfo": {
-     "elapsed": 812,
+     "elapsed": 209,
      "status": "ok",
-     "timestamp": 1722904804531,
+     "timestamp": 1744390459789,
      "user": {
       "displayName": "Justin Fu",
       "userId": "17543197034567316452"
@@ -351,7 +352,7 @@
      "user_tz": 420
     },
     "id": "ojQEZB5mBRqM",
-    "outputId": "e1648f54-737c-4921-ca3b-b4c639a38d2b"
+    "outputId": "3a4373f8-1fb5-4a6b-b88e-3461c2609021"
    },
    "outputs": [
     {
@@ -483,7 +484,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "KgU7HI2pS4om"
+    "id": "EDCmAaHVtY7x"
    },
    "source": [
     "## Advanced Techniques\n",
@@ -651,12 +652,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 9,
    "metadata": {
     "executionInfo": {
-     "elapsed": 254,
+     "elapsed": 248,
      "status": "ok",
-     "timestamp": 1722904804952,
+     "timestamp": 1744390460289,
      "user": {
       "displayName": "Justin Fu",
       "userId": "17543197034567316452"
@@ -664,7 +665,7 @@
      "user_tz": 420
     },
     "id": "XrY5bMlvBroQ",
-    "outputId": "77497000-4496-462e-cc3c-73fb640cc14c"
+    "outputId": "9216e749-48d2-43ff-d64b-bd419acf3e11"
    },
    "outputs": [
     {
@@ -674,7 +675,7 @@
       "Input =  [0.9858954  0.11763906 0.9955574  0.775211  ]\n",
       "Pallas result =  [2.8743029 2.8743029 2.8743029 2.8743029]\n",
       "lax.psum result =  [2.8743029 2.8743029 2.8743029 2.8743029]\n",
-      "Difference |Pallas - lax.psum| =  1.4959369e-08\n"
+      "Difference |Pallas - lax.psum| =  1.0535587e-08\n"
      ]
     }
    ],
@@ -685,6 +686,41 @@
     "\n",
     "input_arr = jax.random.uniform(jax.random.key(0), shape=(8, 128 * num_devices))\n",
     "input_arr = jax.device_put(input_arr, sharding)\n",
+    "\n",
+    "\n",
+    "def local_barrier(left_neighbor, right_neighbor, double_barrier=True):\n",
+    "  \"\"\"Performs a barrier with neighbors on the global barrier semaphore.\n",
+    "\n",
+    "  Optionally performs a second barrier, which prevents a potential race\n",
+    "  when re-using the same collective_id across kernel invocations.\n",
+    "  \"\"\"\n",
+    "  barrier_sem = pltpu.get_barrier_semaphore()\n",
+    "  for neighbor in [left_neighbor, right_neighbor]:\n",
+    "    pltpu.semaphore_signal(\n",
+    "      barrier_sem,\n",
+    "      inc=1,\n",
+    "      device_id=(neighbor,),\n",
+    "      device_id_type=pltpu.DeviceIdType.MESH,\n",
+    "    )\n",
+    "  pltpu.semaphore_wait(barrier_sem, 2)\n",
+    "  if double_barrier:\n",
+    "    # The double-barrier prevents a race condition where one neighbor can\n",
+    "    # re-enter the kernel again on a subsequent call and increment the\n",
+    "    # barrier semaphore a second time. This would unblock the current device\n",
+    "    # even if the other neighbor is not ready yet.\n",
+    "    # To implement a double-barrier, we stack-allocate a second REGULAR\n",
+    "    # semaphore using run_scoped.\n",
+    "    @functools.partial(pl.run_scoped,\n",
+    "                       second_barrier=pltpu.SemaphoreType.REGULAR)\n",
+    "    def _(second_barrier):\n",
+    "      for neighbor in [left_neighbor, right_neighbor]:\n",
+    "        pltpu.semaphore_signal(\n",
+    "          second_barrier,\n",
+    "          inc=1,\n",
+    "          device_id=(neighbor,),\n",
+    "          device_id_type=pltpu.DeviceIdType.MESH,\n",
+    "        )\n",
+    "      pltpu.semaphore_wait(second_barrier, 2)\n",
     "\n",
     "\n",
     "def all_reduce_kernel(\n",
@@ -709,20 +745,7 @@
     "  def _():\n",
     "    # Barrier with both neighbors at the start, since we will be\n",
     "    # communicating with both.\n",
-    "    barrier_sem = pltpu.get_barrier_semaphore()\n",
-    "    pltpu.semaphore_signal(\n",
-    "        barrier_sem,\n",
-    "        inc=1,\n",
-    "        device_id=(left_neighbor,),\n",
-    "        device_id_type=pltpu.DeviceIdType.MESH,\n",
-    "    )\n",
-    "    pltpu.semaphore_signal(\n",
-    "        barrier_sem,\n",
-    "        inc=1,\n",
-    "        device_id=(right_neighbor,),\n",
-    "        device_id_type=pltpu.DeviceIdType.MESH,\n",
-    "    )\n",
-    "    pltpu.semaphore_wait(barrier_sem, 2)\n",
+    "    local_barrier(left_neighbor, right_neighbor)\n",
     "\n",
     "    # Initialize o_ref, acc_scratch, and hbm_scratch.\n",
     "    o_ref[...] = jnp.zeros_like(o_ref)\n",
@@ -892,12 +915,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 10,
    "metadata": {
     "executionInfo": {
-     "elapsed": 544,
+     "elapsed": 362,
      "status": "ok",
-     "timestamp": 1722904805699,
+     "timestamp": 1744390460871,
      "user": {
       "displayName": "Justin Fu",
       "userId": "17543197034567316452"
@@ -1017,20 +1040,7 @@
     "  def _():\n",
     "    # Barrier with both neighbors at the start, since we will be\n",
     "    # communicating with both.\n",
-    "    barrier_sem = pltpu.get_barrier_semaphore()\n",
-    "    pltpu.semaphore_signal(\n",
-    "        barrier_sem,\n",
-    "        inc=1,\n",
-    "        device_id=(left_neighbor,),\n",
-    "        device_id_type=pltpu.DeviceIdType.MESH,\n",
-    "    )\n",
-    "    pltpu.semaphore_signal(\n",
-    "        barrier_sem,\n",
-    "        inc=1,\n",
-    "        device_id=(right_neighbor,),\n",
-    "        device_id_type=pltpu.DeviceIdType.MESH,\n",
-    "    )\n",
-    "    pltpu.semaphore_wait(barrier_sem, 2)\n",
+    "    local_barrier(left_neighbor, right_neighbor)\n",
     "\n",
     "    # Initialize o_ref, acc_scratch, and hbm_scratch with initial copies.\n",
     "    o_ref[...] = jnp.zeros_like(o_ref[...])\n",
@@ -1179,12 +1189,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "metadata": {
     "executionInfo": {
-     "elapsed": 596,
+     "elapsed": 917,
      "status": "ok",
-     "timestamp": 1722904806442,
+     "timestamp": 1744390461967,
      "user": {
       "displayName": "Justin Fu",
       "userId": "17543197034567316452"
@@ -1192,7 +1202,7 @@
      "user_tz": 420
     },
     "id": "E-NMh-_teoi4",
-    "outputId": "24beb42f-1bdd-4c34-e8d2-681dd7f2e9c0"
+    "outputId": "6c8b82bc-ed64-4cc1-8c5f-65e29cdb333c"
    },
    "outputs": [
     {
@@ -1356,12 +1366,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 12,
    "metadata": {
     "executionInfo": {
-     "elapsed": 1341,
+     "elapsed": 997,
      "status": "ok",
-     "timestamp": 1722904807930,
+     "timestamp": 1744390463178,
      "user": {
       "displayName": "Justin Fu",
       "userId": "17543197034567316452"
@@ -1474,20 +1484,7 @@
     "  def _():\n",
     "    # Barrier with both neighbors at the start, since we will be\n",
     "    # communicating with both.\n",
-    "    barrier_sem = pltpu.get_barrier_semaphore()\n",
-    "    pltpu.semaphore_signal(\n",
-    "        barrier_sem,\n",
-    "        inc=1,\n",
-    "        device_id=(left_neighbor,),\n",
-    "        device_id_type=pltpu.DeviceIdType.MESH,\n",
-    "    )\n",
-    "    pltpu.semaphore_signal(\n",
-    "        barrier_sem,\n",
-    "        inc=1,\n",
-    "        device_id=(right_neighbor,),\n",
-    "        device_id_type=pltpu.DeviceIdType.MESH,\n",
-    "    )\n",
-    "    pltpu.semaphore_wait(barrier_sem, 2)\n",
+    "    local_barrier(left_neighbor, right_neighbor)\n",
     "\n",
     "    initial_left_copy.start()\n",
     "    initial_left_copy.wait()\n",
@@ -1635,12 +1632,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 13,
    "metadata": {
     "executionInfo": {
-     "elapsed": 768,
+     "elapsed": 1132,
      "status": "ok",
-     "timestamp": 1722904808851,
+     "timestamp": 1744390464532,
      "user": {
       "displayName": "Justin Fu",
       "userId": "17543197034567316452"
@@ -1648,7 +1645,7 @@
      "user_tz": 420
     },
     "id": "cTEyiMDyx9Y0",
-    "outputId": "1de26695-3713-430e-9ab4-4ea646691680"
+    "outputId": "70ce154e-dab2-4ae0-e297-c4774d29da85"
    },
    "outputs": [
     {
@@ -1710,6 +1707,13 @@
   }
  ],
  "metadata": {
+  "colab": {
+   "last_runtime": {
+    "build_target": "//experimental/users/justinfu/pallas:colab",
+    "kind": "private"
+   },
+   "provenance": []
+  },
   "jupytext": {
    "formats": "ipynb,md:myst",
    "main_language": "python"
@@ -1733,5 +1737,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
This update fixes a subtle race condition in the barrier used by the examples in the TPU distributed tutorial.

The race only happens across multiple kernel calls when re-using the same collective_id, and thus would never present in the tutorial examples in colab, but users could run into the issue when deploying kernels in a real application.