### PR TITLE
roll-forward: optimize while_loop by moving readonly carry components to be consts

### DIFF
--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -492,8 +492,8 @@ class CheckifyTransformTests(jtu.JaxTestCase):
   def test_while_loop_body_and_cond_error(self):
     def while_cond(val):
       i, cond_val, _ = val
-      _ = jnp.sin(cond_val)
-      return i < 2
+      j = jnp.sin(cond_val)
+      return i + (0. * j) < 2  # don't let the sin value be dead code
 
     def while_body(val):
       i, cond_val, body_val = val

--- a/tests/jaxpr_effects_test.py
+++ b/tests/jaxpr_effects_test.py
@@ -947,7 +947,7 @@ class JaxprInputEffectTest(jtu.JaxTestCase):
       def f(x):
         def body(y):
           input_effect(x, y, index=index)
-          return y
+          return 2 * y
         lax.while_loop(lambda _: True, body, y)
       return f
     jaxpr = jax.make_jaxpr(make_fun(0))(0)
@@ -959,7 +959,7 @@ class JaxprInputEffectTest(jtu.JaxTestCase):
     def f(x):
       def body(y):
         input_effect(x, y, index=1)
-        return y
+        return 2 * y
       lax.while_loop(lambda _: (x > 0).all(), body, y)
     jaxpr = jax.make_jaxpr(f)(0)
     self.assertIn(InputEffect(0), jaxpr.effects)

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -3153,7 +3153,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       num_inplace_fwds_cond_doesnt_use,
       num_noninplace_fwds):
 
-    num_fwds = (num_inplace_fwds_cond_uses + num_inplace_fwds_cond_doesnt_use + 
+    num_fwds = (num_inplace_fwds_cond_uses + num_inplace_fwds_cond_doesnt_use +
                 num_noninplace_fwds)
     num_carry = num_fwds + 4
 


### PR DESCRIPTION
Re-landing #27937

There was a bug in #27937: we forgot to offset by `len(body_consts)` in the expression `[len(body_consts) + i != f for i, f in enumerate(body_fwd)]`.

In this PR we added combinatorial tests (set to generate 243 cases) that would've caught the original bug.