### PR TITLE
Fix typo in jax.lax.linalg.symmetric_product description

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -528,7 +528,7 @@ def symmetric_product(
 
   Computes the symmetric product
 
-  ..math::
+  .. math::
     \alpha \, A \, A^T + \beta \, C
 
   where :math:`A` is a rectangular matrix and :math:`C` is a symmetric matrix.


### PR DESCRIPTION
Missing space in '..math::' meant that the math wasn't rendering correctly.