### PR TITLE
[explain-cache-miss] Improve tracing-cache-miss explanations

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4466,66 +4466,6 @@ class APITest(jtu.JaxTestCase):
       self.assertEqual(tracing_add_count, 2)
 
   @jtu.thread_unsafe_test()  # logging is not thread-safe
-  def test_cache_miss_explanations(self):
-    @jax.jit
-    def f(x, y):
-      return jnp.sin(x) * y['hi']
-
-    x = jnp.float32(1.)
-    y = {'hi': jnp.arange(3., dtype='float32')}
-
-    expected_log_len = 1 if not is_persistent_cache_enabled() else 3
-
-    # print on first miss, not on hit
-    with config.explain_cache_misses(True):
-      with self.assertLogs(level='WARNING') as cm:
-        f(x, y)
-        f(x, y)
-    self.assertLen(cm.output, expected_log_len)
-    msg = cm.output[0]
-    self.assertIn('TRACING CACHE MISS', msg)
-    self.assertIn('never seen function', msg)
-
-    # shape change
-    y_ = {'hi': jnp.arange(4, dtype='float32')}
-    with config.explain_cache_misses(True):
-      with self.assertLogs(level='WARNING') as cm:
-        f(x, y_)
-    self.assertLen(cm.output, expected_log_len)
-    msg = cm.output[0]
-    self.assertIn('never seen input type signature', msg)
-    self.assertIn('closest seen input type signature has 1 mismatches', msg)
-    self.assertIn('seen f32[3], but now given f32[4]', msg)
-
-    # weak type change (assuming no x64)
-    if not config.enable_x64.value:
-      with config.explain_cache_misses(True):
-        with self.assertLogs(level='WARNING') as cm:
-          f(1., y)
-      self.assertLen(cm.output, expected_log_len)
-      msg = cm.output[0]
-      self.assertIn('weak_type=True', msg)
-      self.assertIn('https://docs.jax.dev/en/latest/type_promotion.html#weak-types', msg)
-
-    # kwarg change
-    with config.explain_cache_misses(True):
-      with self.assertLogs(level='WARNING') as cm:
-        f(1, y=y)
-    self.assertLen(cm.output, expected_log_len)
-    msg = cm.output[0]
-    self.assertIn('never seen passing 1 positional args and 1 keyword args', msg)
-
-    # tracing config change
-    with config.explain_cache_misses(True):
-      with self.assertLogs(level='WARNING') as cm:
-        with jax.numpy_rank_promotion('warn'):
-          f(x, y)
-    # depending on the backend, we may or may not get persistent cache warnings
-    self.assertTrue(1 <= len(cm.output) <= expected_log_len)
-    msg = cm.output[0]
-    self.assertIn("tracing context doesn't match", msg)
-
-  @jtu.thread_unsafe_test()  # logging is not thread-safe
   def test_cache_miss_explanations_skip_internals(self):
     if is_persistent_cache_enabled():
       self.skipTest('With persistent cache, we see the cache misses')
@@ -4534,6 +4474,211 @@ class APITest(jtu.JaxTestCase):
       with self.assertNoLogs(level='WARNING'):
         for i in range(2):
           jnp.sin(jnp.arange(i + 1, dtype=np.float32))
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_first_miss(self):
+    @jax.jit
+    def f(x): return x
+    x = jnp.float32(1.)
+
+    expected_log_len = 1 if not is_persistent_cache_enabled() else 3
+    # print on first miss, not on hit
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        f(x)
+        f(x)
+    self.assertLen(cm.output, expected_log_len)
+    msg = cm.output[0]
+    self.assertIn("TRACING CACHE MISS", msg)
+    self.assertIn("never seen function", msg)
+    self.assertNotIn("explanation unavailable!", msg)
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_other_in_tree(self):
+    @jax.jit
+    def f(*args, **kwargs): return args[0]
+
+    f(0., 1., y=(2., 2.1))
+
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        # Same number of leaves but different trees
+        f(0., (1., 1.1), y=2.)
+    expected_log_len = 1 if not is_persistent_cache_enabled() else 3
+    self.assertLen(cm.output, expected_log_len)
+    msg = cm.output[0]
+    self.assertIn("different input pytree", msg)
+    self.assertNotIn("explanation unavailable!", msg)
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_other_arg_passed_as_kwarg(self):
+    @jax.jit
+    def f(x, y): return jnp.sin(x) + y
+
+    f(0., 1.)
+
+    # kwarg change
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        f(0., y=1.)
+    expected_log_len = 1 if not is_persistent_cache_enabled() else 3
+    self.assertLen(cm.output, expected_log_len)
+    msg = cm.output[0]
+    self.assertIn("different number of args and kwargs, but same total number", msg)
+    self.assertIn("now 1 args and kwargs with keys ['y']", msg)
+    self.assertIn("before 1 args and kwargs with keys []", msg)
+    self.assertNotIn("explanation unavailable!", msg)
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_other_static_argnums(self):
+    @partial(jax.jit, static_argnums=(0, 2))
+    def f(x, y, z):
+      return y
+
+    f(1., 2., "foo")
+
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        f(1., 2., "bar")
+    expected_log_len = 1 if not is_persistent_cache_enabled() else 3
+    self.assertLen(cm.output, expected_log_len)
+    msg = cm.output[0]
+    self.assertIn("different value of static args", msg)
+    self.assertIn("now 1.0, 'bar' and before 1.0, 'foo'", msg)
+    self.assertNotIn('explanation unavailable!', msg)
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_other_static_argnames(self):
+    @partial(jax.jit, static_argnames='foo')
+    def f(*, foo):
+      return 1
+
+    f(foo="foo")
+
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        f(foo="bar")
+    expected_log_len = 1 if not is_persistent_cache_enabled() else 3
+    self.assertLen(cm.output, expected_log_len)
+    msg = cm.output[0]
+    self.assertIn("different value of static kwargs", msg)
+    self.assertIn("now {foo: 'bar'} and before {foo: 'foo'}", msg)
+    self.assertNotIn('explanation unavailable!', msg)
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_other_dtype(self):
+    @jax.jit
+    def f(x, y): return x
+    f(np.float32(0), np.float32(1))
+
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level='WARNING') as cm:
+        f(np.float32(0), np.int32(1))
+    expected_log_len = 1 if not is_persistent_cache_enabled() else 3
+    self.assertLen(cm.output, expected_log_len)
+    msg = cm.output[0]
+    self.assertIn("different input types", msg)
+    self.assertIn("at y, now i32[] and before f32[]", msg)
+    self.assertNotIn("explanation unavailable!", msg)
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_other_weak_type(self):
+    @jax.jit
+    def f(x, y): return jnp.sin(x) + y
+
+    y = jnp.arange(4, dtype="float32")
+    f(jnp.float32(0.), y)
+    # weak type change (assuming no x64)
+    if config.enable_x64.value:
+      self.skipTest("Work only for 32 bit mode")
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        f(0., y)
+    expected_log_len = 1 if not is_persistent_cache_enabled() else 3
+    self.assertLen(cm.output, expected_log_len)
+    msg = cm.output[0]
+    self.assertIn("different input types", msg)
+    self.assertIn("at x, now f32[]{weak_type=True} and before f32[]{weak_type=False}", msg)
+    self.assertIn("https://docs.jax.dev/en/latest/type_promotion.html#weak-types", msg)
+    self.assertNotIn("explanation unavailable!", msg)
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_other_shape(self):
+    @jax.jit
+    def f(x, y): return jnp.sin(x) + y
+    f(np.float32(0), np.arange(1, dtype=np.float32))
+
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level='WARNING') as cm:
+        f(np.float32(0), np.arange(2, dtype=np.float32))
+    expected_log_len = 1 if not is_persistent_cache_enabled() else 3
+    self.assertLen(cm.output, expected_log_len)
+    msg = cm.output[0]
+    self.assertIn("different input types", msg)
+    self.assertIn("at y, now f32[2] and before f32[1]", msg)
+    self.assertNotIn("explanation unavailable!", msg)
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_other_shape_explain_closest(self):
+    @jax.jit
+    def f(x): return x
+    f(np.ones((1, 2), dtype=np.float32))
+    f(np.ones((10, 20, 30), dtype=np.float32))
+    f(np.ones((1, 2, 3), dtype=np.float32))
+
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level='WARNING') as cm:
+        f(np.ones((10, 2, 30), dtype=np.float32))
+    expected_log_len = 1 if not is_persistent_cache_enabled() else 3
+    self.assertLen(cm.output, expected_log_len)
+    msg = cm.output[0]
+    self.assertIn("key with different input types", msg)
+    self.assertIn("at x, now f32[10,2,30] and before f32[10,20,30]", msg)
+    self.assertNotIn("explanation unavailable!", msg)
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_other_tracing_config(self):
+    @jax.jit
+    def f(x, y): return jnp.sin(x) + y
+
+    f(0., 1.)
+    # tracing config change
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        with jax.numpy_rank_promotion("warn"):
+          with jax.default_matmul_precision("high"):
+            f(0., 1.)
+
+    expected_log_len = 1 if not is_persistent_cache_enabled() else 3
+    self.assertTrue(1 <= len(cm.output) <= expected_log_len)
+    msg = cm.output[0]
+    self.assertIn("key with different tracing context", msg)
+    self.assertIn("now warn and before", msg)
+    self.assertIn("now high and before", msg)
+    self.assertNotIn("explanation unavailable!", msg)
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_multiple_changes(self):
+    @jax.jit
+    def f(x): return jnp.sin(x)
+
+    call_1 = f(np.arange(4, dtype=np.float32))
+    with jax.numpy_rank_promotion("warn"):
+      call_2 = f(np.arange(8, dtype=np.float32))
+
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level='WARNING') as cm:
+        # Matches call_2 in shape but not context, and call_1 in context but
+        # not in shape.
+        f(np.arange(8, dtype=np.float32))
+
+    expected_log_len = 1 if not is_persistent_cache_enabled() else 3
+    self.assertLen(cm.output, expected_log_len)
+    msg = cm.output[0]
+    self.assertIn("key with different input types", msg)
+    self.assertIn("at x, now f32[8] and before f32[4]", msg)
+    self.assertIn("key with different tracing context", msg)
+    self.assertNotIn("explanation unavailable!", msg)
 
   @jtu.thread_unsafe_test()  # logging is not thread-safe
   def test_cache_miss_explanations_new_function_in_loop(self):

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -3467,9 +3467,8 @@ class ArrayPjitTest(jtu.JaxTestCase):
         f(x_, y)
     self.assertLen(cm.output, expected_log_len)
     msg = cm.output[0]
-    self.assertIn('never seen input type signature', msg)
-    self.assertIn('closest seen input type signature has 1 mismatches', msg)
-    self.assertIn("seen f32[8]({}), but now given f32[8]({Auto: ('x',)})", msg)
+    self.assertIn("different input types", msg)
+    self.assertIn("at x, now f32[8]({Auto: ('x',)}) and before f32[8]({})", msg)
 
   def test_pjit_function_cache_cpp(self):
     def f(x):


### PR DESCRIPTION
The previous approach was to report, for several elements of the cache key, the closest mismatch w.r.t existing keys.
Some parts of the cache key were ignored, which led to "explanation unavailable". The same happened when we had two keys close to the current one, each differing in a different part of the key. No explanation was produced because for each part of the key, there was a matching key already in the cache, even though the key taken as a whole did not match.

Now, we scan *all* parts of they key and compute the differences. We keep track of the "size" of the differences, and we explain the differences to those keys that are closest (possibly more than one key if equidistant).
For example, for shape differences we'll report the closest matching shape. If a type differs in both the dtype and some parts of the shape, or sharding, it is considered farther away.

We add new tests and explanations for  different static argnums and argnames.

There are still cases when we do not produce an explanation, but now the "explanation unavailable" includes a description of which component of the key is different, and what the difference is. This may still be hard to understand by the user but at least they can file a clearer bug.

Refactored the tests, and added a few new ones.

To see the changes in the explanations, I run the tests containing "explanation" in `api_test.py` before and after:

```
pytest --verbosity 1 -s tests/api_test.py -k explanation
```

**BEFORE**

```
tests/api_test.py::APITest::test_cache_miss_explanations WARNING:2025-04-13 17:55:12,326:jax._src.pjit:1180: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4482:8 (APITest.test_cache_miss_explanations) because:
  never seen function:
    f id=5036821056 defined at /Users/necula/Source/jax/tests/api_test.py:4470
WARNING:2025-04-13 17:55:12,361:jax._src.pjit:1180: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4493:8 (APITest.test_cache_miss_explanations) because:
  for f defined at /Users/necula/Source/jax/tests/api_test.py:4470
  never seen input type signature:
    x: f32[],  y['hi']: f32[4]
  closest seen input type signature has 1 mismatches, including:
    * at y['hi'], seen f32[3], but now given f32[4]
WARNING:2025-04-13 17:55:12,379:jax._src.pjit:1180: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4504:10 (APITest.test_cache_miss_explanations) because:
  for f defined at /Users/necula/Source/jax/tests/api_test.py:4470
  never seen input type signature:
    x: f32[],  y['hi']: f32[3]
  closest seen input type signature has 1 mismatches, including:
    * at x, seen f32[]{weak_type=False}, but now given f32[]{weak_type=True}
where weak_type=True often means a Python builtin numeric value, and
weak_type=False means a jax.Array.
See https://docs.jax.dev/en/latest/type_promotion.html#weak-types
WARNING:2025-04-13 17:55:12,396:jax._src.pjit:1180: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4513:8 (APITest.test_cache_miss_explanations) because:
  for f defined at /Users/necula/Source/jax/tests/api_test.py:4470
  never seen passing 1 positional args and 1 keyword args with keys:
    'y'
  closest seen is passing no keyword args
WARNING:2025-04-13 17:55:12,415:jax._src.pjit:1180: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4522:10 (APITest.test_cache_miss_explanations) because:
  for f defined at /Users/necula/Source/jax/tests/api_test.py:4470
  tracing context doesn't match, e.g. due to config or context manager
  closest seen context tuple differs at positions:
    6
  compare to tuple returned by config._trace_context() in jax/_src/config.py.
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_new_function_in_loop WARNING:2025-04-13 17:55:12,434:jax._src.pjit:1180: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4549:10 (APITest.test_cache_miss_explanations_new_function_in_loop) because:
  never seen function:
    <lambda> id=5036820896 defined at /Users/necula/Source/jax/tests/api_test.py:4549
WARNING:2025-04-13 17:55:12,451:jax._src.pjit:1180: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4549:10 (APITest.test_cache_miss_explanations_new_function_in_loop) because:
  never seen function:
    <lambda> id=5036820896 defined at /Users/necula/Source/jax/tests/api_test.py:4549
  but seen another function defined on the same line; maybe the function is
  being re-defined repeatedly, preventing caching?
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_no_source_info WARNING:2025-04-13 17:55:12,469:jax._src.pjit:1180: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4563:6 (APITest.test_cache_miss_explanations_no_source_info) because:
  never seen function:
    add id=4308995424
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_skip_internals PASSED
```

**AFTER**

```
tests/api_test.py::APITest::test_cache_miss_explanations_first_miss WARNING:2025-04-13 17:56:45,045:jax._src.pjit:1365: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4488:8 (APITest.test_cache_miss_explanations_first_miss) because:
  never seen function:
    f id=5904421952 defined at /Users/necula/Source/jax/tests/api_test.py:4480
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_multiple_changes WARNING:2025-04-13 17:56:45,098:jax._src.pjit:1365: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4673:8 (APITest.test_cache_miss_explanations_multiple_changes) because:
  for f defined at /Users/necula/Source/jax/tests/api_test.py:4662
  all previously seen cache keys are different. Several previous keys are closest:
  * key with different input types:
      types now: x: f32[8]
        * at x, now f32[8] and before f32[4]
  * key with different tracing context, e.g. due to config or context manager.
    found differences at positions
      [6]: now raise and before warn
    compare to tuple returned by config.trace_context() in jax/_src/config.py.
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_new_function_in_loop WARNING:2025-04-13 17:56:45,119:jax._src.pjit:1365: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4694:10 (APITest.test_cache_miss_explanations_new_function_in_loop) because:
  never seen function:
    <lambda> id=5904422432 defined at /Users/necula/Source/jax/tests/api_test.py:4694
WARNING:2025-04-13 17:56:45,137:jax._src.pjit:1365: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4694:10 (APITest.test_cache_miss_explanations_new_function_in_loop) because:
  never seen function:
    <lambda> id=5904422432 defined at /Users/necula/Source/jax/tests/api_test.py:4694
  but seen another function defined on the same line; maybe the function is
  being re-defined repeatedly, preventing caching?
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_no_source_info WARNING:2025-04-13 17:56:45,156:jax._src.pjit:1365: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4708:6 (APITest.test_cache_miss_explanations_no_source_info) because:
  never seen function:
    add id=4372663648
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_other_arg_passed_as_kwarg WARNING:2025-04-13 17:56:45,191:jax._src.pjit:1365: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4523:8 (APITest.test_cache_miss_explanations_other_arg_passed_as_kwarg) because:
  for f defined at /Users/necula/Source/jax/tests/api_test.py:4515
  all previously seen cache keys are different. Closest previous key:
  * key with different number of args and kwargs, but same total number.
      now 1 args and kwargs with keys ['y']
      before 1 args and kwargs with keys []
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_other_dtype WARNING:2025-04-13 17:56:45,224:jax._src.pjit:1365: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4576:8 (APITest.test_cache_miss_explanations_other_dtype) because:
  for f defined at /Users/necula/Source/jax/tests/api_test.py:4570
  all previously seen cache keys are different. Closest previous key:
  * key with different input types:
      types now: x: f32[], y: i32[]
        * at y, now i32[] and before f32[]
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_other_in_tree WARNING:2025-04-13 17:56:45,255:jax._src.pjit:1365: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4506:8 (APITest.test_cache_miss_explanations_other_in_tree) because:
  for f defined at /Users/necula/Source/jax/tests/api_test.py:4498
  all previously seen cache keys are different. Closest previous key:
  * key with different input pytree:
      now: PyTreeDef(((*, (*, *)), {'y': *}))
      before: PyTreeDef(((*, *), {'y': (*, *)}))
      * at args[1], now <class 'tuple'> and before pytree leaf, so their Python types differ
      * at kwargs['y'], now pytree leaf and before <class 'tuple'>, so their Python types differ
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_other_shape WARNING:2025-04-13 17:56:45,290:jax._src.pjit:1365: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4613:8 (APITest.test_cache_miss_explanations_other_shape) because:
  for f defined at /Users/necula/Source/jax/tests/api_test.py:4607
  all previously seen cache keys are different. Closest previous key:
  * key with different input types:
      types now: x: f32[], y: f32[2]
        * at y, now f32[2] and before f32[1]
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_other_shape_explain_closest WARNING:2025-04-13 17:56:45,353:jax._src.pjit:1365: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4631:8 (APITest.test_cache_miss_explanations_other_shape_explain_closest) because:
  for f defined at /Users/necula/Source/jax/tests/api_test.py:4623
  all previously seen cache keys are different. Closest previous key:
  * key with different input types:
      types now: x: f32[10,2,30]
        * at x, now f32[10,2,30] and before f32[10,20,30]
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_other_static_argnames WARNING:2025-04-13 17:56:45,383:jax._src.pjit:1365: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4560:8 (APITest.test_cache_miss_explanations_other_static_argnames) because:
  for f defined at /Users/necula/Source/jax/tests/api_test.py:4552
  all previously seen cache keys are different. Closest previous key:
  * key with different value of static kwargs:
      now {foo: 'bar'} and before {foo: 'foo'}
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_other_static_argnums WARNING:2025-04-13 17:56:45,412:jax._src.pjit:1365: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4542:8 (APITest.test_cache_miss_explanations_other_static_argnums) because:
  for f defined at /Users/necula/Source/jax/tests/api_test.py:4534
  all previously seen cache keys are different. Closest previous key:
  * key with different value of static args:
      now 1.0, 'bar' and before 1.0, 'foo'
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_other_tracing_config WARNING:2025-04-13 17:56:45,447:jax._src.pjit:1365: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4650:12 (APITest.test_cache_miss_explanations_other_tracing_config) because:
  for f defined at /Users/necula/Source/jax/tests/api_test.py:4641
  all previously seen cache keys are different. Closest previous key:
  * key with different tracing context, e.g. due to config or context manager.
    found differences at positions
      [6]: now warn and before raise, and
      [7]: now high and before None
    compare to tuple returned by config.trace_context() in jax/_src/config.py.
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_other_weak_type WARNING:2025-04-13 17:56:45,503:jax._src.pjit:1365: TRACING CACHE MISS at /Users/necula/Source/jax/tests/api_test.py:4596:8 (APITest.test_cache_miss_explanations_other_weak_type) because:
  for f defined at /Users/necula/Source/jax/tests/api_test.py:4586
  all previously seen cache keys are different. Closest previous key:
  * key with different input types:
      types now: x: f32[], y: f32[4]
        * at x, now f32[]{weak_type=True} and before f32[]{weak_type=False}
    where weak_type=True often means a Python builtin numeric value, and
    weak_type=False means a jax.Array.
    See https://docs.jax.dev/en/latest/type_promotion.html#weak-types.
PASSED
tests/api_test.py::APITest::test_cache_miss_explanations_skip_internals PASSED
```

