### PR TITLE
Fix new_reference / _Py_IsOwnedByCurrentThread race suppression for 3.13

### DIFF
--- a/.github/workflows/tsan-suppressions_3.13.txt
+++ b/.github/workflows/tsan-suppressions_3.13.txt
@@ -23,7 +23,8 @@ race_top:PyMember_GetOne
 
 # https://github.com/python/cpython/issues/131680
 # Fixed in Python 3.14, but not backported to 3.13.
-race_top: new_reference
+race_top:new_reference
+race:_Py_IsOwnedByCurrentThread
 
 # https://github.com/python/cpython/issues/129748
 race:mi_block_set_nextx


### PR DESCRIPTION
TSAN CI 3.13 (https://github.com/jax-ml/jax/actions/runs/14426384229/job/40455879756) once again reported a race that should be suppressed as fixed on 3.14 and not backported to 3.13: 

```
WARNING: ThreadSanitizer: data race (pid=149502)
   Atomic read of size 8 at 0x7d25cc8bee80 by thread T64 (mutexes: read M0):
     #0 _Py_atomic_load_uintptr_relaxed /__w/jax/jax/cpython/./Include/cpython/pyatomic_gcc.h:347:10 (python3.13+0x260a2f) (BuildId: ba5aae135607a24f44962252680484d72d0be570)
     #1 _Py_IsOwnedByCurrentThread /__w/jax/jax/cpython/./Include/object.h:309:12 (python3.13+0x260a2f)
     #2 _Py_TryIncrefFast /__w/jax/jax/cpython/./Include/internal/pycore_object.h:444:9 (python3.13+0x260a2f)
     #3 _Py_TryIncrefCompare /__w/jax/jax/cpython/./Include/internal/pycore_object.h:483:9 (python3.13+0x260a2f)
     #4 compare_generic_threadsafe /__w/jax/jax/cpython/Objects/dictobject.c:1437:34 (python3.13+0x260a2f)
     #5 do_lookup /__w/jax/jax/cpython/Objects/dictobject.c:1066:23 (python3.13+0x260a2f)
     #6 dictkeys_generic_lookup_threadsafe /__w/jax/jax/cpython/Objects/dictobject.c:1460:12 (python3.13+0x260a2f)
     #7 _Py_dict_lookup_threadsafe /__w/jax/jax/cpython/Objects/dictobject.c:1523:14 (python3.13+0x260a2f)
     #8 dict_subscript /__w/jax/jax/cpython/Objects/dictobject.c:3311:10 (python3.13+0x275e96) (BuildId: ba5aae135607a24f44962252680484d72d0be570)
     #9 PyObject_GetItem /__w/jax/jax/cpython/Objects/abstract.c:158:26 (python3.13+0x1b8f4c) (BuildId: ba5aae135607a24f44962252680484d72d0be570)
     #10 _PyEval_EvalFrameDefault /__w/jax/jax/cpython/Python/generated_cases.c.h:446:23 (python3.13+0x3e1fdf) (BuildId: ba5aae135607a24f44962252680484d72d0be570)
     #11 _PyEval_EvalFrame /__w/jax/jax/cpython/./Include/internal/pycore_ceval.h:119:16 (python3.13+0x3dfa0a) (BuildId: ba5aae135607a24f44962252680484d72d0be570)
     #12 _PyEval_Vector /__w/jax/jax/cpython/Python/ceval.c:1816:12 (python3.13+0x3dfa0a)
     #13 _PyFunction_Vectorcall /__w/jax/jax/cpython/Objects/call.c (python3.13+0x1eb76f) (BuildId: ba5aae135607a24f44962252680484d72d0be570)
 ...

   Previous write of size 8 at 0x7d25cc8bee80 by thread T65 (mutexes: read M0):
     #0 new_reference /__w/jax/jax/cpython/Objects/object.c:2464:16 (python3.13+0x29a612) (BuildId: ba5aae135607a24f44962252680484d72d0be570)
     #1 _Py_NewReference /__w/jax/jax/cpython/Objects/object.c:2483:5 (python3.13+0x29a612)
     #2 maybe_freelist_pop /__w/jax/jax/cpython/Objects/tupleobject.c:1151:13 (python3.13+0x2e0768) (BuildId: ba5aae135607a24f44962252680484d72d0be570)
     #3 tuple_alloc /__w/jax/jax/cpython/Objects/tupleobject.c:45:25 (python3.13+0x2e0768)
     #4 _PyTuple_FromArraySteal /__w/jax/jax/cpython/Objects/tupleobject.c:399:28 (python3.13+0x2e0768)
     #5 _PyEval_EvalFrameDefault /__w/jax/jax/cpython/Python/generated_cases.c.h:728:19 (python3.13+0x3e35dc) (BuildId: ba5aae135607a24f44962252680484d72d0be570)
     #6 _PyEval_EvalFrame /__w/jax/jax/cpython/./Include/internal/pycore_ceval.h:119:16 (python3.13+0x3dfa0a) (BuildId: ba5aae135607a24f44962252680484d72d0be570)
     #7 _PyEval_Vector /__w/jax/jax/cpython/Python/ceval.c:1816:12 (python3.13+0x3dfa0a)
     #8 _PyFunction_Vectorcall /__w/jax/jax/cpython/Objects/call.c (python3.13+0x1eb76f) (BuildId: ba5aae135607a24f44962252680484d72d0be570)

```

This PR fixes the suppression file to correctly ignore the race
