### PR TITLE
Fixed the way to skip tests using optional python dependencies

### DIFF
--- a/tests/colocated_python_test.py
+++ b/tests/colocated_python_test.py
@@ -18,7 +18,6 @@ import tempfile
 import threading
 import time
 from typing import Sequence
-import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -36,8 +35,9 @@ jtu.request_cpu_devices(8)
 
 try:
   import cloudpickle  # noqa
+  HAS_CLOUDPICKLE = True
 except (ModuleNotFoundError, ImportError):
-  raise unittest.SkipTest("tests depend on cloudpickle library")
+  HAS_CLOUDPICKLE = False
 
 
 def _colocated_cpu_devices(
@@ -68,10 +68,14 @@ class ColocatedPythonTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
+    if not HAS_CLOUDPICKLE:
+      self.skipTest(
+        "ColocatedPythonTest depends on cloudpickle library"
+      )
     if np.lib.NumpyVersion(np.__version__) < "2.0.0":
       self.skipTest(
-          "Serialization in Colocated Python needs StringDType, and thus"
-          " requires NumPy 2.0.0 or later"
+        "Serialization in Colocated Python needs StringDType, and thus"
+        " requires NumPy 2.0.0 or later"
       )
 
   def testMakeColocatedPythonProgram(self):

--- a/tests/mosaic/matmul_test.py
+++ b/tests/mosaic/matmul_test.py
@@ -15,12 +15,15 @@
 """Test different parameterizations of a matmul."""
 
 import os
-import unittest
 
 from absl.testing import absltest, parameterized
 from jax._src import config
 from jax._src import test_util as jtu
 import jax.numpy as jnp
+
+import hypothesis as hp
+import hypothesis.strategies as hps
+
 try:
   # We only import this to see if Mosaic is available.
   import jax.experimental.mosaic.gpu  # noqa: F401
@@ -28,11 +31,6 @@ except ImportError:
   matmul = None
 else:
   from jax.experimental.mosaic.gpu.examples import matmul
-try:
-  import hypothesis as hp
-  import hypothesis.strategies as hps
-except (ModuleNotFoundError, ImportError):
-  raise unittest.SkipTest("these tests require hypothesis")
 
 
 config.parse_flags_with_absl()

--- a/tests/pallas/indexing_test.py
+++ b/tests/pallas/indexing_test.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 import sys
-import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -32,11 +31,7 @@ if sys.platform != "win32":
 else:
   pltpu = None
 
-try:
-  import hypothesis as hp
-except (ModuleNotFoundError, ImportError):
-  raise unittest.SkipTest("tests depend on hypothesis library")
-
+import hypothesis as hp
 import hypothesis.extra.numpy as hnp
 import hypothesis.strategies as hps
 
@@ -95,7 +90,7 @@ def array_indexer_strategy(draw, shape) -> jax.Array:
 
 @hps.composite
 def indexer_strategy(draw, dim, int_indexer_shape
-                     ) -> int | Slice | jax.Array:
+                    ) -> int | Slice | jax.Array:
   return draw(hps.one_of(
       int_indexer_strategy(dim),
       slice_indexer_strategy(dim),
@@ -372,7 +367,7 @@ class IndexerOpsTest(PallasBaseTest):
   def test_vmap_nd_indexing(self, data):
     self.skipTest("TODO(necula): enable this test; was in jax_triton.")
     vmap_shape = data.draw(hnp.array_shapes(min_dims=1, max_dims=3, min_side=2),
-                           label="vmap_shape")
+                          label="vmap_shape")
     el_shape = data.draw(hnp.array_shapes(min_dims=2), label="el_shape")
     # TODO(sharadmv,apaszke): enable rank 0 and rank 1 Refs
     # hp.assume(len(el_shape) >= 2)
@@ -389,7 +384,7 @@ class IndexerOpsTest(PallasBaseTest):
     shape = el_shape
     for vmap_dim in vmap_shape[::-1]:
       index = data.draw(hps.integers(min_value=0,
-                                     max_value=max(0, len(shape) - 2)),
+                                    max_value=max(0, len(shape) - 2)),
                         label="index")
       # hp.assume(index <= max(0, len(shape) - 2))
       # TODO(sharadmv,apaszke): enable vmapping over batch axes in 2 minormost
@@ -649,9 +644,9 @@ class IndexerOpsTest(PallasBaseTest):
       # Use scalar_val in both async_copy and store.
       o_ref[scalar_val] = jnp.ones_like(o_ref[0]) * scalar_val
       desc = pltpu.make_async_copy(
-         o_ref.at[scalar_val],
-         o_ref.at[scalar_val + 1],
-         sem_ref,
+        o_ref.at[scalar_val],
+        o_ref.at[scalar_val + 1],
+        sem_ref,
       )
       desc.start()
       desc.wait()

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -48,13 +48,10 @@ else:
   plgpu_triton = None
   pltpu = None
 
-try:
-  import hypothesis as hp
-except (ModuleNotFoundError, ImportError):
-  raise unittest.SkipTest("tests depend on hypothesis library")
-
+import hypothesis as hp
 import hypothesis.extra.numpy as hnp
 import hypothesis.strategies as hps
+
 
 # There are many inherited redefinitions of _
 # ruff: noqa: F811
@@ -188,7 +185,7 @@ def select_n_strategy(
   else:
     pred_dtype = np.int32
   pred = draw(arrays(shape=pred_shape, dtype=pred_dtype,
-                     elements=allowed_elements))
+                    elements=allowed_elements))
   cases = (
       draw(
           arrays(shape=case_shape_dtype.shape, dtype=case_shape_dtype.dtype)
@@ -332,7 +329,7 @@ class OpsTest(PallasBaseTest):
 
     x = jnp.full((8, 128), 4, dtype=dtype)
     y = jnp.full((8, 128), 2 if jnp.issubdtype(dtype, jnp.integer) else 2.0,
-                 dtype=dtype)
+                dtype=dtype)
     np.testing.assert_allclose(kernel(x, y), fn(x, y))
 
   @parameterized.named_parameters(
@@ -1071,8 +1068,8 @@ class OpsTest(PallasBaseTest):
       (
           # fmt: off
           [jnp.expm1, jnp.log1p, jnp.cbrt, lax.rsqrt, jnp.tan, jnp.asin,
-           jnp.acos, jnp.atan, jnp.sinh, jnp.cosh, jnp.tanh, jnp.asinh,
-           jnp.acosh, jnp.atanh],
+          jnp.acos, jnp.atan, jnp.sinh, jnp.cosh, jnp.tanh, jnp.asinh,
+          jnp.acosh, jnp.atanh],
           # fmt: on
           ["bfloat16", "float32", "float64"],
       ),
@@ -1096,7 +1093,7 @@ class OpsTest(PallasBaseTest):
         self.skipTest("int16 and float16 are not supported on TPU")
       if (
           fn in (jnp.ceil, jnp.floor, jnp.negative, jnp.exp, jnp.exp2, jnp.log,
-                 jnp.sqrt, lax.rsqrt)
+                jnp.sqrt, lax.rsqrt)
           and dtype == "bfloat16"
           and not jtu.is_device_tpu_at_least(6)
       ):
@@ -1474,7 +1471,7 @@ class OpsTest(PallasBaseTest):
       (
           # fmt: off
           [jnp.bitwise_and, jnp.bitwise_or, jnp.bitwise_xor,
-           jnp.bitwise_left_shift, jnp.bitwise_right_shift],
+          jnp.bitwise_left_shift, jnp.bitwise_right_shift],
           # fmt: on
           ["int32", "uint32"],
       ),
@@ -1918,7 +1915,7 @@ class OpsTest(PallasBaseTest):
     # Pallas always accumulates in FP32, so we are explicit about
     # preferred_element_type here.
     expected = jnp.dot(x.T if trans_x else x, y.T if trans_y else y,
-                       preferred_element_type=jnp.float32).astype(dtype)
+                      preferred_element_type=jnp.float32).astype(dtype)
     np.testing.assert_allclose(
         out.astype(jnp.float32),
         expected.astype(jnp.float32),
@@ -2107,7 +2104,7 @@ class OpsTest(PallasBaseTest):
     @functools.partial(
         self.pallas_call,
         out_shape=(jax.ShapeDtypeStruct((n,), floatx),
-                   jax.ShapeDtypeStruct((m,), floatx)),
+                  jax.ShapeDtypeStruct((m,), floatx)),
         input_output_aliases={0: 0, 1: 1},
     )
     def masked_oob_swap_slice(_, _2, mask_ref, start_idx_ref, x_ref, y_ref):
@@ -2237,7 +2234,7 @@ class OpsTest(PallasBaseTest):
 
     lock, out = swap(init_value)
     np.testing.assert_allclose(lock, new_value if cmp == init_value else
-                               init_value)
+                              init_value)
     np.testing.assert_allclose(out, init_value)
 
   @parameterized.parameters(1, 2, 3, 4, 8)
@@ -2603,15 +2600,15 @@ class PallasPrimitivesTest(PallasBaseTest):
 
   @parameterized.parameters(*[
     (lambda: (pl.dslice(0, 4), slice(None), slice(None)),
-     "c:i32[4,3,2], a[:,:,:] <-"),
+    "c:i32[4,3,2], a[:,:,:] <-"),
     (lambda: (pl.dslice(0, 3), slice(None), slice(None)),
-     "c:i32[3,3,2], a[:3,:,:] <-"),
+    "c:i32[3,3,2], a[:3,:,:] <-"),
     (lambda: (pl.dslice(1, 3), slice(None), pl.dslice(0, 4)),
-     "c:i32[3,3,4], a[1:,:,:4] <-"),
+    "c:i32[3,3,4], a[1:,:,:4] <-"),
     (lambda: (jnp.arange(5), slice(None), pl.dslice(0, 4)),
-     "e:i32[5,3,4], a[b,:,:4] <-"),
+    "e:i32[5,3,4], a[b,:,:4] <-"),
     (lambda: (jnp.arange(5)[:, None], jnp.arange(3)[None], pl.dslice(4)),
-     "o:i32[5,3,4], a[m,n,:4] <-"),
+    "o:i32[5,3,4], a[m,n,:4] <-"),
   ])
   def test_swap_pretty_print(self, expr, expected):
     def body(x_ref):

--- a/tests/pallas/tpu_all_gather_test.py
+++ b/tests/pallas/tpu_all_gather_test.py
@@ -25,115 +25,109 @@ from jax.experimental.pallas.ops.tpu import all_gather
 import jax.numpy as jnp
 import numpy as np
 
-try:
-  import hypothesis as hp
-  import hypothesis.strategies as hps
-  CAN_USE_HYPOTHESIS = True
-except (ModuleNotFoundError, ImportError):
-  CAN_USE_HYPOTHESIS = False
+import hypothesis as hp
+import hypothesis.strategies as hps
 
 
 jax.config.parse_flags_with_absl()
 P = jax.sharding.PartitionSpec
 
-if CAN_USE_HYPOTHESIS:
+hp.settings.register_profile(
+    "deterministic",
+    database=None,
+    derandomize=True,
+    deadline=None,
+    max_examples=50,
+    print_blob=True,
+    verbosity=hp.Verbosity.verbose,
+)
+hp.settings.load_profile("deterministic")
 
-  hp.settings.register_profile(
-      "deterministic",
-      database=None,
-      derandomize=True,
-      deadline=None,
-      max_examples=50,
-      print_blob=True,
-      verbosity=hp.Verbosity.verbose,
+
+@hps.composite
+def _array_shapes(draw):
+  # TODO(sharadmv, apaszke): enable this on a wider variety of shapes
+  valid_shapes = [
+      (128, 128),
+      (256, 128),
+      (256, 512),
+      (256, 1024),
+      # TODO(sharadmv,apaszke): enable these shapes
+      # (256, 129),
+      # (129, 128),
+      # (64, 64),
+      # (1, 1),
+  ]
+  return draw(hps.sampled_from(valid_shapes))
+
+
+@hps.composite
+def _array_dtypes(draw):
+  return draw(
+      hps.sampled_from([
+          jnp.float32,
+          jnp.bfloat16,
+          jnp.int32,
+          # jnp.float16,  # TODO(sharadmv,apaszke): enable float16 all gather
+          # jnp.int16,  # TODO(sharadmv,apaszke): enable int16 all gather
+          # jnp.int8,  # TODO(sharadmv,apaszke): enable int8 all gather
+      ])
   )
-  hp.settings.load_profile("deterministic")
 
 
-  @hps.composite
-  def _array_shapes(draw):
-    # TODO(sharadmv, apaszke): enable this on a wider variety of shapes
-    valid_shapes = [
-        (128, 128),
-        (256, 128),
-        (256, 512),
-        (256, 1024),
-        # TODO(sharadmv,apaszke): enable these shapes
-        # (256, 129),
-        # (129, 128),
-        # (64, 64),
-        # (1, 1),
-    ]
-    return draw(hps.sampled_from(valid_shapes))
+@jtu.thread_unsafe_test_class()  # hypothesis is not thread safe
+class AllGatherTest(jtu.JaxTestCase):
 
+  def setUp(self):
+    if not jtu.test_device_matches(["tpu"]):
+      self.skipTest("Need TPU devices")
+    if not jtu.is_device_tpu(version=5, variant="e"):
+      # TODO(sharadmv,apaszke): expand support to more versions
+      self.skipTest("Currently only supported on TPU v5e")
 
-  @hps.composite
-  def _array_dtypes(draw):
-    return draw(
-        hps.sampled_from([
-            jnp.float32,
-            jnp.bfloat16,
-            jnp.int32,
-            # jnp.float16,  # TODO(sharadmv,apaszke): enable float16 all gather
-            # jnp.int16,  # TODO(sharadmv,apaszke): enable int16 all gather
-            # jnp.int8,  # TODO(sharadmv,apaszke): enable int8 all gather
-        ])
+    super().setUp()
+
+  @hp.given(hps.booleans(), _array_shapes(), _array_dtypes())
+  def test_all_gather_1d_mesh(self, is_vmem, shape, dtype):
+    if jax.device_count() < 2:
+      self.skipTest("Need more devices")
+    memory_space = pltpu.VMEM if is_vmem else pltpu.ANY
+    mesh_shape = (jax.device_count(),)
+    mesh = jax.sharding.Mesh(
+        mesh_utils.create_device_mesh(mesh_shape, jax.devices()), ["x"]
     )
+    leading, *rest = shape
+    shape = (mesh.shape["x"] * leading, *rest)
+    x = random.normal(random.key(0), shape, dtype=jnp.float32).astype(dtype)
+    x_sharded = jax.device_put(x, jax.sharding.NamedSharding(mesh, P("x")))
+    y = all_gather.all_gather(x_sharded, mesh=mesh, axis_name="x",
+                              memory_space=memory_space)
+    np.testing.assert_array_equal(y, x)
 
-
-  @jtu.thread_unsafe_test_class()  # hypothesis is not thread safe
-  class AllGatherTest(jtu.JaxTestCase):
-
-    def setUp(self):
-      if not jtu.test_device_matches(["tpu"]):
-        self.skipTest("Need TPU devices")
-      if not jtu.is_device_tpu(version=5, variant="e"):
-        # TODO(sharadmv,apaszke): expand support to more versions
-        self.skipTest("Currently only supported on TPU v5e")
-
-      super().setUp()
-
-    @hp.given(hps.booleans(), _array_shapes(), _array_dtypes())
-    def test_all_gather_1d_mesh(self, is_vmem, shape, dtype):
-      if jax.device_count() < 2:
-        self.skipTest("Need more devices")
-      memory_space = pltpu.VMEM if is_vmem else pltpu.ANY
-      mesh_shape = (jax.device_count(),)
-      mesh = jax.sharding.Mesh(
-          mesh_utils.create_device_mesh(mesh_shape, jax.devices()), ["x"]
-      )
-      leading, *rest = shape
-      shape = (mesh.shape["x"] * leading, *rest)
-      x = random.normal(random.key(0), shape, dtype=jnp.float32).astype(dtype)
-      x_sharded = jax.device_put(x, jax.sharding.NamedSharding(mesh, P("x")))
-      y = all_gather.all_gather(x_sharded, mesh=mesh, axis_name="x",
-                                memory_space=memory_space)
-      np.testing.assert_array_equal(y, x)
-
-    @hp.given(hps.booleans(), _array_shapes(), _array_dtypes(),
-              hps.sampled_from(["x", "y"]))
-    def test_all_gather_2d_mesh(self, is_vmem, shape, dtype,
-                                axis_name):
-      if jax.device_count() < 2:
-        self.skipTest("Need more devices")
-      if jax.device_count() % 2:
-        self.skipTest("Need an even number of devices")
-      memory_space = pltpu.VMEM if is_vmem else pltpu.ANY
-      mesh_shape = (2, jax.device_count() // 2)
-      mesh = jax.sharding.Mesh(
-          mesh_utils.create_device_mesh(mesh_shape, jax.devices()), ["x", "y"]
-      )
-      if axis_name == "x":
-        sharding = jax.sharding.NamedSharding(mesh, P("x", None))
-      else:
-        sharding = jax.sharding.NamedSharding(mesh, P("y", None))
-      leading, *rest = shape
-      shape = (mesh.shape[axis_name] * leading, *rest)
-      x = random.normal(random.key(0), shape, dtype=jnp.float32).astype(dtype)
-      x_sharded = jax.device_put(x, sharding)
-      y = all_gather.all_gather(x_sharded, mesh=mesh, axis_name=axis_name,
-                                memory_space=memory_space)
-      np.testing.assert_array_equal(y, x)
+  @hp.given(hps.booleans(), _array_shapes(), _array_dtypes(),
+            hps.sampled_from(["x", "y"]))
+  def test_all_gather_2d_mesh(self, is_vmem, shape, dtype,
+                              axis_name):
+    if jax.device_count() < 2:
+      self.skipTest("Need more devices")
+    if jax.device_count() % 2:
+      self.skipTest("Need an even number of devices")
+    memory_space = pltpu.VMEM if is_vmem else pltpu.ANY
+    mesh_shape = (2, jax.device_count() // 2)
+    mesh = jax.sharding.Mesh(
+        mesh_utils.create_device_mesh(mesh_shape, jax.devices()), ["x", "y"]
+    )
+    if axis_name == "x":
+      sharding = jax.sharding.NamedSharding(mesh, P("x", None))
+    else:
+      sharding = jax.sharding.NamedSharding(mesh, P("y", None))
+    leading, *rest = shape
+    shape = (mesh.shape[axis_name] * leading, *rest)
+    x = random.normal(random.key(0), shape, dtype=jnp.float32).astype(dtype)
+    x_sharded = jax.device_put(x, sharding)
+    y = all_gather.all_gather(x_sharded, mesh=mesh, axis_name=axis_name,
+                              memory_space=memory_space)
+    np.testing.assert_array_equal(y, x)
 
 
 if __name__ == "__main__":

--- a/tests/pallas/tpu_gmm_test.py
+++ b/tests/pallas/tpu_gmm_test.py
@@ -24,12 +24,8 @@ import jax.experimental.pallas.ops.tpu.megablox as mblx
 import jax.numpy as jnp
 import numpy as np
 
-try:
-  import hypothesis as hp
-  import hypothesis.strategies as hps
-  CAN_USE_HYPOTHESIS = True
-except (ModuleNotFoundError, ImportError):
-  CAN_USE_HYPOTHESIS = False
+import hypothesis as hp
+import hypothesis.strategies as hps
 
 jax.config.parse_flags_with_absl()
 
@@ -37,327 +33,326 @@ P = jax.sharding.PartitionSpec
 
 partial = functools.partial
 
-if CAN_USE_HYPOTHESIS:
-  hp.settings.register_profile(
-      "deterministic",
-      database=None,
-      derandomize=True,
-      deadline=None,
-      max_examples=10,
-      print_blob=True,
+hp.settings.register_profile(
+    "deterministic",
+    database=None,
+    derandomize=True,
+    deadline=None,
+    max_examples=10,
+    print_blob=True,
+)
+hp.settings.load_profile("deterministic")
+
+def seed_strategy() -> hps.SearchStrategy[int]:
+  return hps.integers(min_value=0, max_value=4)
+
+@hps.composite
+def group_strategy(
+    draw: hps.DrawFn,
+    max_groups: int = 32,
+    max_stride: int = 32,
+    min_groups: int = 1,
+) -> tuple[int, int]:
+  assert max_stride <= max_groups
+
+  # Sample the number of groups owned by each shard.
+  group_stride = draw(hps.integers(min_value=1, max_value=max_stride))
+
+  # Sample the number of groups as a multiple of the stride to ensure that we
+  # have an equal number of groups per shard. Round down s.t. num_groups <=
+  # max_groups.
+  num_groups = group_stride * draw(
+      hps.integers(min_value=min_groups, max_value=max_groups // group_stride)
   )
-  hp.settings.load_profile("deterministic")
+  return num_groups, group_stride
 
-  def seed_strategy() -> hps.SearchStrategy[int]:
-    return hps.integers(min_value=0, max_value=4)
+@hps.composite
+def group_sizes_strategy(
+    draw: hps.DrawFn, m: int, num_groups: int
+) -> jnp.ndarray:
+  # Randomly sample the ends of the groups in the m-dimension. Let the fuzzer
+  # sample with replacement so that it's possible to get zero-sized groups. Get
+  # 'num_groups - 1' run ends. The final group will end at 'm'.
+  ends_no_final = np.sort(
+      np.array(
+          [
+              draw(hps.integers(min_value=0, max_value=m))
+              for _ in range(num_groups - 1)
+          ],
+          dtype=np.int32,
+      ),
+  )
+  ends = np.concatenate([ends_no_final, np.array([m], dtype=np.int32)])
 
-  @hps.composite
-  def group_strategy(
-      draw: hps.DrawFn,
-      max_groups: int = 32,
-      max_stride: int = 32,
-      min_groups: int = 1,
-  ) -> tuple[int, int]:
-    assert max_stride <= max_groups
+  # Calculate the run starts by shifting ends 1 to the right. The first run
+  # starts at zero.
+  starts = np.concatenate([np.zeros(1, dtype=np.int32), ends_no_final])
+  return jnp.array(ends - starts, dtype=jnp.int32)
 
-    # Sample the number of groups owned by each shard.
-    group_stride = draw(hps.integers(min_value=1, max_value=max_stride))
+GROUPED_MATMUL_TESTS = (
+    (128, 128, 128),  # Small
+    (512, 2048, 256),  # Big
+    (128, 8, 16),  # Test partial tiles.
+)
 
-    # Sample the number of groups as a multiple of the stride to ensure that we
-    # have an equal number of groups per shard. Round down s.t. num_groups <=
-    # max_groups.
-    num_groups = group_stride * draw(
-        hps.integers(min_value=min_groups, max_value=max_groups // group_stride)
+def random_dense(
+    shape: tuple[int, ...],
+    key: jax.Array,
+    dtype: jnp.dtype,
+    limit: int | None = None,
+) -> jnp.ndarray:
+  if limit is None:
+    limit = 1 / np.prod(shape)
+  x = jax.random.uniform(key, shape, dtype, minval=-limit, maxval=limit)  # pylint: disable=invalid-unary-operand-type
+  return x.astype(jnp.bfloat16).astype(dtype)
+
+def dot(
+    lhs: jnp.ndarray,
+    rhs: jnp.ndarray,
+    transpose_lhs: bool = False,
+    transpose_rhs: bool = False,
+    preferred_element_type: jnp.dtype = jnp.float32,
+) -> jnp.ndarray:
+  lhs = jnp.transpose(lhs) if transpose_lhs else lhs
+  rhs = jnp.transpose(rhs) if transpose_rhs else rhs
+  return jax.lax.dot(lhs, rhs, preferred_element_type=preferred_element_type)
+
+def reference_gmm(
+    lhs: jnp.ndarray,
+    rhs: jnp.ndarray,
+    group_sizes: jnp.ndarray,
+    preferred_element_type: jnp.dtype = jnp.float32,
+) -> jnp.ndarray:
+
+  start = 0
+  out = []
+  for i, size in enumerate(group_sizes):
+    result = dot(
+        lhs[start : start + size, :],
+        rhs[i, :, :],
+        preferred_element_type=preferred_element_type,
     )
-    return num_groups, group_stride
 
-  @hps.composite
-  def group_sizes_strategy(
-      draw: hps.DrawFn, m: int, num_groups: int
-  ) -> jnp.ndarray:
-    # Randomly sample the ends of the groups in the m-dimension. Let the fuzzer
-    # sample with replacement so that it's possible to get zero-sized groups. Get
-    # 'num_groups - 1' run ends. The final group will end at 'm'.
-    ends_no_final = np.sort(
-        np.array(
-            [
-                draw(hps.integers(min_value=0, max_value=m))
-                for _ in range(num_groups - 1)
-            ],
-            dtype=np.int32,
+    out.append(result)
+    start += group_sizes[i]
+  return jnp.concatenate(out, axis=0)
+
+def with_dtype_arguments(xs: tuple[Any, ...]) -> tuple[Any, ...]:
+  dtypes = [jnp.float32, jnp.bfloat16]
+
+  result = []
+  for x in xs:
+    for dtypes_tuple in itertools.product(dtypes, dtypes, dtypes):
+      result.append(x + dtypes_tuple)
+  return tuple(result)
+
+def with_transpose_argument(xs: tuple[Any, ...]) -> tuple[Any, ...]:
+  flags = [False, True]
+  result = []
+  for x in xs:
+    for flag in flags:
+      result.append(x + (flag,))
+  return tuple(result)
+
+def tolerances(
+    lhs_dtype: jnp.dtype, rhs_dtype: jnp.dtype, out_dtype: jnp.dtype
+) -> tuple[float, float]:
+  if (
+      lhs_dtype == jnp.bfloat16
+      or rhs_dtype == jnp.bfloat16
+      or out_dtype == jnp.bfloat16
+  ):
+    return 1e-3, 1e-2  # atol, rtol
+  return 1e-3, 1e-5  # atol, rtol
+
+# TODO(tgale): Fix errors with strict dtype promotion.
+@jtu.with_config(jax_numpy_dtype_promotion="standard")
+@jtu.thread_unsafe_test_class()  # hypothesis is not thread safe
+class GroupedMatmulTest(jtu.JaxTestCase):
+
+  def setUp(self):
+    if not jtu.test_device_matches(["tpu"]):
+      self.skipTest("Test requires TPU device.")
+
+    super().setUp()
+    self.key = jax.random.PRNGKey(1234)
+
+  def assert_allclose(
+      self,
+      out: jnp.ndarray,
+      expected_out: jnp.ndarray,
+      *,
+      atol: float = 1e-5,
+      rtol: float = 1e-5,
+  ):
+    self.assertEqual(out.dtype, expected_out.dtype)
+    np.testing.assert_allclose(
+        out.astype(jnp.float32),
+        expected_out.astype(jnp.float32),
+        atol=atol,
+        rtol=rtol,
+    )
+
+  def gmm_test(
+      self,
+      m: int,
+      k: int,
+      n: int,
+      data: hps.SearchStrategy[hps.DataObject],
+      interpret: bool = False,
+  ):
+    seed = data.draw(seed_strategy())
+    num_groups, _ = data.draw(group_strategy(max_stride=1))
+    lhs_dtype, rhs_dtype, out_dtype = [
+        data.draw(hps.sampled_from([jnp.float32, jnp.bfloat16]))
+        for _ in range(3)
+    ]
+    transpose_rhs = data.draw(hps.booleans())
+
+    key = jax.random.key(seed)
+    k1, k2 = jax.random.split(key, 2)
+    lhs = random_dense((m, k), k1, lhs_dtype, limit=1)
+    rhs = random_dense((num_groups, k, n), k2, rhs_dtype, limit=1)
+    group_sizes = data.draw(group_sizes_strategy(m=m, num_groups=num_groups))
+
+    out, vjpfun = jax.vjp(
+        partial(
+            mblx.gmm,
+            preferred_element_type=out_dtype,
+            transpose_rhs=transpose_rhs,
+            interpret=interpret,
         ),
+        lhs,
+        rhs.swapaxes(1, 2) if transpose_rhs else rhs,
+        group_sizes,
     )
-    ends = np.concatenate([ends_no_final, np.array([m], dtype=np.int32)])
 
-    # Calculate the run starts by shifting ends 1 to the right. The first run
-    # starts at zero.
-    starts = np.concatenate([np.zeros(1, dtype=np.int32), ends_no_final])
-    return jnp.array(ends - starts, dtype=jnp.int32)
-
-  GROUPED_MATMUL_TESTS = (
-      (128, 128, 128),  # Small
-      (512, 2048, 256),  # Big
-      (128, 8, 16),  # Test partial tiles.
-  )
-
-  def random_dense(
-      shape: tuple[int, ...],
-      key: jax.Array,
-      dtype: jnp.dtype,
-      limit: int | None = None,
-  ) -> jnp.ndarray:
-    if limit is None:
-      limit = 1 / np.prod(shape)
-    x = jax.random.uniform(key, shape, dtype, minval=-limit, maxval=limit)  # pylint: disable=invalid-unary-operand-type
-    return x.astype(jnp.bfloat16).astype(dtype)
-
-  def dot(
-      lhs: jnp.ndarray,
-      rhs: jnp.ndarray,
-      transpose_lhs: bool = False,
-      transpose_rhs: bool = False,
-      preferred_element_type: jnp.dtype = jnp.float32,
-  ) -> jnp.ndarray:
-    lhs = jnp.transpose(lhs) if transpose_lhs else lhs
-    rhs = jnp.transpose(rhs) if transpose_rhs else rhs
-    return jax.lax.dot(lhs, rhs, preferred_element_type=preferred_element_type)
-
-  def reference_gmm(
-      lhs: jnp.ndarray,
-      rhs: jnp.ndarray,
-      group_sizes: jnp.ndarray,
-      preferred_element_type: jnp.dtype = jnp.float32,
-  ) -> jnp.ndarray:
-
-    start = 0
-    out = []
-    for i, size in enumerate(group_sizes):
-      result = dot(
-          lhs[start : start + size, :],
-          rhs[i, :, :],
-          preferred_element_type=preferred_element_type,
+    def reference_fn(lhs, rhs, group_sizes, preferred_element_type):
+      rhs = rhs.swapaxes(1, 2) if transpose_rhs else rhs
+      return reference_gmm(
+          lhs, rhs, group_sizes, preferred_element_type=preferred_element_type
       )
 
-      out.append(result)
-      start += group_sizes[i]
-    return jnp.concatenate(out, axis=0)
+    expected_out, reference_vjpfun = jax.vjp(
+        partial(reference_fn, preferred_element_type=out_dtype),
+        lhs,
+        rhs.swapaxes(1, 2) if transpose_rhs else rhs,
+        group_sizes,
+    )
+    self.assertEqual(out.dtype, out_dtype)
+    self.assertEqual(expected_out.dtype, out_dtype)
 
-  def with_dtype_arguments(xs: tuple[Any, ...]) -> tuple[Any, ...]:
-    dtypes = [jnp.float32, jnp.bfloat16]
+    atol, rtol = tolerances(lhs_dtype, rhs_dtype, out_dtype)
+    self.assert_allclose(out, expected_out, atol=atol, rtol=rtol)
 
-    result = []
-    for x in xs:
-      for dtypes_tuple in itertools.product(dtypes, dtypes, dtypes):
-        result.append(x + dtypes_tuple)
-    return tuple(result)
+    cotangent = random_dense((m, n), k1, out_dtype, limit=1)
+    grad_lhs, grad_rhs, *_ = vjpfun(cotangent)
+    expected_grad_lhs, expected_grad_rhs, *_ = reference_vjpfun(cotangent)
+    self.assert_allclose(grad_lhs, expected_grad_lhs, atol=atol, rtol=rtol)
+    self.assert_allclose(grad_rhs, expected_grad_rhs, atol=atol, rtol=rtol)
 
-  def with_transpose_argument(xs: tuple[Any, ...]) -> tuple[Any, ...]:
-    flags = [False, True]
-    result = []
-    for x in xs:
-      for flag in flags:
-        result.append(x + (flag,))
-    return tuple(result)
+  @parameterized.parameters(*GROUPED_MATMUL_TESTS)
+  @hp.given(hps.data())
+  def test_gmm(
+      self,
+      m: int,
+      k: int,
+      n: int,
+      data: hps.SearchStrategy[hps.DataObject],
+  ):
+    self.gmm_test(m, k, n, data)
 
-  def tolerances(
-      lhs_dtype: jnp.dtype, rhs_dtype: jnp.dtype, out_dtype: jnp.dtype
-  ) -> tuple[float, float]:
-    if (
-        lhs_dtype == jnp.bfloat16
-        or rhs_dtype == jnp.bfloat16
-        or out_dtype == jnp.bfloat16
-    ):
-      return 1e-3, 1e-2  # atol, rtol
-    return 1e-3, 1e-5  # atol, rtol
+  # NOTE: Run fewer tests with interpret mode. We just want to sanity check that
+  # changes do not break running these kernels with interpret=True.
+  @parameterized.parameters(*GROUPED_MATMUL_TESTS[0:1])
+  @hp.given(hps.data())
+  def test_gmm_interpret(
+      self,
+      m: int,
+      k: int,
+      n: int,
+      data: hps.SearchStrategy[hps.DataObject],
+  ):
+    self.skipTest("interpret mode with dynamic grids is unsupported")
+    self.gmm_test(
+        m,
+        k,
+        n,
+        data=data,
+        interpret=True,
+    )
 
-  # TODO(tgale): Fix errors with strict dtype promotion.
-  @jtu.with_config(jax_numpy_dtype_promotion="standard")
-  @jtu.thread_unsafe_test_class()  # hypothesis is not thread safe
-  class GroupedMatmulTest(jtu.JaxTestCase):
+  @parameterized.parameters(*GROUPED_MATMUL_TESTS)
+  @hp.given(hps.data())
+  def test_gmm_sharded_groups(
+      self,
+      m: int,
+      k: int,
+      n: int,
+      data: hps.SearchStrategy[hps.DataObject],
+  ):
+    seed = data.draw(seed_strategy())
+    num_groups, group_stride = data.draw(group_strategy())
+    lhs_dtype, rhs_dtype, out_dtype = [
+        data.draw(hps.sampled_from([jnp.float32, jnp.bfloat16]))
+        for _ in range(3)
+    ]
 
-    def setUp(self):
-      if not jtu.test_device_matches(["tpu"]):
-        self.skipTest("Test requires TPU device.")
+    key = jax.random.key(seed)
+    k1, k2 = jax.random.split(key, 2)
+    lhs = random_dense((m, k), k1, lhs_dtype, limit=1)
+    rhs = random_dense((num_groups, k, n), k2, rhs_dtype, limit=1)
+    group_sizes = data.draw(group_sizes_strategy(m=m, num_groups=num_groups))
 
-      super().setUp()
-      self.key = jax.random.PRNGKey(1234)
-
-    def assert_allclose(
-        self,
-        out: jnp.ndarray,
-        expected_out: jnp.ndarray,
-        *,
-        atol: float = 1e-5,
-        rtol: float = 1e-5,
-    ):
-      self.assertEqual(out.dtype, expected_out.dtype)
-      np.testing.assert_allclose(
-          out.astype(jnp.float32),
-          expected_out.astype(jnp.float32),
-          atol=atol,
-          rtol=rtol,
-      )
-
-    def gmm_test(
-        self,
-        m: int,
-        k: int,
-        n: int,
-        data: hps.SearchStrategy[hps.DataObject],
-        interpret: bool = False,
-    ):
-      seed = data.draw(seed_strategy())
-      num_groups, _ = data.draw(group_strategy(max_stride=1))
-      lhs_dtype, rhs_dtype, out_dtype = [
-          data.draw(hps.sampled_from([jnp.float32, jnp.bfloat16]))
-          for _ in range(3)
-      ]
-      transpose_rhs = data.draw(hps.booleans())
-
-      key = jax.random.key(seed)
-      k1, k2 = jax.random.split(key, 2)
-      lhs = random_dense((m, k), k1, lhs_dtype, limit=1)
-      rhs = random_dense((num_groups, k, n), k2, rhs_dtype, limit=1)
-      group_sizes = data.draw(group_sizes_strategy(m=m, num_groups=num_groups))
-
-      out, vjpfun = jax.vjp(
-          partial(
-              mblx.gmm,
-              preferred_element_type=out_dtype,
-              transpose_rhs=transpose_rhs,
-              interpret=interpret,
+    out, shard_vjpfun = jax.vjp(
+        partial(mblx.gmm, preferred_element_type=out_dtype),
+        lhs,
+        rhs[0:group_stride],
+        group_sizes,
+    )
+    vjpfuns = [shard_vjpfun]
+    for group_offset in range(group_stride, num_groups, group_stride):
+      out, shard_vjpfun = jax.vjp(
+          lambda lhs, rhs, group_sizes, out: mblx.gmm(
+              lhs,
+              rhs,
+              group_sizes,
+              out_dtype,
+              group_offset=jnp.array(group_offset, dtype=jnp.int32),  # pylint: disable=cell-var-from-loop
+              existing_out=out,
           ),
           lhs,
-          rhs.swapaxes(1, 2) if transpose_rhs else rhs,
+          rhs[group_offset : group_offset + group_stride],
           group_sizes,
+          out,
       )
+      vjpfuns.append(shard_vjpfun)
 
-      def reference_fn(lhs, rhs, group_sizes, preferred_element_type):
-        rhs = rhs.swapaxes(1, 2) if transpose_rhs else rhs
-        return reference_gmm(
-            lhs, rhs, group_sizes, preferred_element_type=preferred_element_type
-        )
+    expected_out, reference_vjpfun = jax.vjp(
+        partial(reference_gmm, preferred_element_type=out_dtype),
+        lhs,
+        rhs,
+        group_sizes,
+    )
+    self.assertEqual(out.dtype, out_dtype)
+    self.assertEqual(expected_out.dtype, out_dtype)
+    atol, rtol = tolerances(lhs_dtype, rhs_dtype, out_dtype)
+    self.assert_allclose(out, expected_out, atol=atol, rtol=rtol)
 
-      expected_out, reference_vjpfun = jax.vjp(
-          partial(reference_fn, preferred_element_type=out_dtype),
-          lhs,
-          rhs.swapaxes(1, 2) if transpose_rhs else rhs,
-          group_sizes,
-      )
-      self.assertEqual(out.dtype, out_dtype)
-      self.assertEqual(expected_out.dtype, out_dtype)
-
-      atol, rtol = tolerances(lhs_dtype, rhs_dtype, out_dtype)
-      self.assert_allclose(out, expected_out, atol=atol, rtol=rtol)
-
-      cotangent = random_dense((m, n), k1, out_dtype, limit=1)
-      grad_lhs, grad_rhs, *_ = vjpfun(cotangent)
-      expected_grad_lhs, expected_grad_rhs, *_ = reference_vjpfun(cotangent)
-      self.assert_allclose(grad_lhs, expected_grad_lhs, atol=atol, rtol=rtol)
-      self.assert_allclose(grad_rhs, expected_grad_rhs, atol=atol, rtol=rtol)
-
-    @parameterized.parameters(*GROUPED_MATMUL_TESTS)
-    @hp.given(hps.data())
-    def test_gmm(
-        self,
-        m: int,
-        k: int,
-        n: int,
-        data: hps.SearchStrategy[hps.DataObject],
+    cotangent = random_dense((m, n), k1, out_dtype, limit=1)
+    shard_grad_lhs, shard_grad_rhs, *_ = vjpfuns[0](cotangent)
+    grad_lhs = shard_grad_lhs
+    grad_rhs = [shard_grad_rhs]
+    for i, group_offset in enumerate(
+        range(group_stride, num_groups, group_stride)
     ):
-      self.gmm_test(m, k, n, data)
-
-    # NOTE: Run fewer tests with interpret mode. We just want to sanity check that
-    # changes do not break running these kernels with interpret=True.
-    @parameterized.parameters(*GROUPED_MATMUL_TESTS[0:1])
-    @hp.given(hps.data())
-    def test_gmm_interpret(
-        self,
-        m: int,
-        k: int,
-        n: int,
-        data: hps.SearchStrategy[hps.DataObject],
-    ):
-      self.skipTest("interpret mode with dynamic grids is unsupported")
-      self.gmm_test(
-          m,
-          k,
-          n,
-          data=data,
-          interpret=True,
-      )
-
-    @parameterized.parameters(*GROUPED_MATMUL_TESTS)
-    @hp.given(hps.data())
-    def test_gmm_sharded_groups(
-        self,
-        m: int,
-        k: int,
-        n: int,
-        data: hps.SearchStrategy[hps.DataObject],
-    ):
-      seed = data.draw(seed_strategy())
-      num_groups, group_stride = data.draw(group_strategy())
-      lhs_dtype, rhs_dtype, out_dtype = [
-          data.draw(hps.sampled_from([jnp.float32, jnp.bfloat16]))
-          for _ in range(3)
-      ]
-
-      key = jax.random.key(seed)
-      k1, k2 = jax.random.split(key, 2)
-      lhs = random_dense((m, k), k1, lhs_dtype, limit=1)
-      rhs = random_dense((num_groups, k, n), k2, rhs_dtype, limit=1)
-      group_sizes = data.draw(group_sizes_strategy(m=m, num_groups=num_groups))
-
-      out, shard_vjpfun = jax.vjp(
-          partial(mblx.gmm, preferred_element_type=out_dtype),
-          lhs,
-          rhs[0:group_stride],
-          group_sizes,
-      )
-      vjpfuns = [shard_vjpfun]
-      for group_offset in range(group_stride, num_groups, group_stride):
-        out, shard_vjpfun = jax.vjp(
-            lambda lhs, rhs, group_sizes, out: mblx.gmm(
-                lhs,
-                rhs,
-                group_sizes,
-                out_dtype,
-                group_offset=jnp.array(group_offset, dtype=jnp.int32),  # pylint: disable=cell-var-from-loop
-                existing_out=out,
-            ),
-            lhs,
-            rhs[group_offset : group_offset + group_stride],
-            group_sizes,
-            out,
-        )
-        vjpfuns.append(shard_vjpfun)
-
-      expected_out, reference_vjpfun = jax.vjp(
-          partial(reference_gmm, preferred_element_type=out_dtype),
-          lhs,
-          rhs,
-          group_sizes,
-      )
-      self.assertEqual(out.dtype, out_dtype)
-      self.assertEqual(expected_out.dtype, out_dtype)
-      atol, rtol = tolerances(lhs_dtype, rhs_dtype, out_dtype)
-      self.assert_allclose(out, expected_out, atol=atol, rtol=rtol)
-
-      cotangent = random_dense((m, n), k1, out_dtype, limit=1)
-      shard_grad_lhs, shard_grad_rhs, *_ = vjpfuns[0](cotangent)
-      grad_lhs = shard_grad_lhs
-      grad_rhs = [shard_grad_rhs]
-      for i, group_offset in enumerate(
-          range(group_stride, num_groups, group_stride)
-      ):
-        shard_grad_lhs, shard_grad_rhs, *_ = vjpfuns[i + 1](cotangent)
-        grad_lhs += shard_grad_lhs
-        grad_rhs.append(shard_grad_rhs)
-      grad_rhs = jnp.concatenate(grad_rhs, axis=0)
-      expected_grad_lhs, expected_grad_rhs, *_ = reference_vjpfun(cotangent)
-      self.assert_allclose(grad_lhs, expected_grad_lhs, atol=atol, rtol=rtol)
-      self.assert_allclose(grad_rhs, expected_grad_rhs, atol=atol, rtol=rtol)
+      shard_grad_lhs, shard_grad_rhs, *_ = vjpfuns[i + 1](cotangent)
+      grad_lhs += shard_grad_lhs
+      grad_rhs.append(shard_grad_rhs)
+    grad_rhs = jnp.concatenate(grad_rhs, axis=0)
+    expected_grad_lhs, expected_grad_rhs, *_ = reference_vjpfun(cotangent)
+    self.assert_allclose(grad_lhs, expected_grad_lhs, atol=atol, rtol=rtol)
+    self.assert_allclose(grad_rhs, expected_grad_rhs, atol=atol, rtol=rtol)
 
 
 if __name__ == "__main__":

--- a/tests/pallas/tpu_ops_test.py
+++ b/tests/pallas/tpu_ops_test.py
@@ -15,7 +15,6 @@
 import functools
 import math
 import sys
-import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -32,12 +31,9 @@ if sys.platform != "win32":
 else:
   pltpu = None
 
-try:
-  import hypothesis as hp
-except (ModuleNotFoundError, ImportError):
-  raise unittest.SkipTest("tests depend on hypothesis library")
-
+import hypothesis as hp
 import hypothesis.strategies as hps
+
 
 jax.config.parse_flags_with_absl()
 jtu.setup_hypothesis(max_examples=100)

--- a/tests/pallas/tpu_splash_attention_kernel_test.py
+++ b/tests/pallas/tpu_splash_attention_kernel_test.py
@@ -32,11 +32,9 @@ import jax.numpy as jnp
 import numpy as np
 
 
-try:
-  import hypothesis as hp
-  import hypothesis.strategies as hps
-except (ModuleNotFoundError, ImportError):
-  raise unittest.SkipTest("these tests require hypothesis")
+import hypothesis as hp
+import hypothesis.strategies as hps
+
 
 jax.config.parse_flags_with_absl()
 jtu.setup_hypothesis(max_examples=5)
@@ -515,9 +513,9 @@ class SplashAttentionTest(PallasBaseTest):
     masks = data.draw(mha_mask_strategy(q_seq_len, kv_seq_len, 1))
     mask = jnp.array(masks[0].get_mask()[:, :])
     attn_logits_soft_cap = data.draw(attn_logits_soft_cap_strategy(),
-                                     label="logit_cap")
+                                    label="logit_cap")
     attn_ref = partial(splash.attention_reference, mask,
-                       attn_logits_soft_cap=attn_logits_soft_cap)
+                      attn_logits_soft_cap=attn_logits_soft_cap)
     attn_custom = partial(splash.attention_reference_custom, mask,
                           attn_logits_soft_cap=attn_logits_soft_cap)
     attn_custom_vanilla = partial(splash.attention_reference_custom, mask,
@@ -525,7 +523,7 @@ class SplashAttentionTest(PallasBaseTest):
                                   attn_logits_soft_cap=attn_logits_soft_cap)
     o_ref, attn_vjp_ref = jax.vjp(attn_ref, q, k, v, segment_ids)
     q32, k32, v32 = jax.tree.map(lambda x: x.astype(jnp.float32),
-                                       (q, k, v))
+                                      (q, k, v))
     o_custom = attn_custom(q32, k32, v32, segment_ids)
     _, attn_vjp = jax.vjp(attn_custom, q32, k32, v32, segment_ids)
     _, attn_vanilla_vjp = jax.vjp(attn_custom_vanilla, q32, k32, v32,
@@ -624,7 +622,7 @@ class SplashAttentionTest(PallasBaseTest):
       mask = jnp.array(mask[:, :, :])
     block_sizes = data.draw(
         block_sizes_strategy(q_seq_len, kv_seq_len, include_bwd_blocks=True,
-                             use_fused_bwd_kernel=use_fused_bwd_kernel)
+                            use_fused_bwd_kernel=use_fused_bwd_kernel)
     )
     if is_mqa:
       attn_ref = splash.make_masked_mqa_reference(mask, backward_impl="custom")

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -37,13 +37,9 @@ from jax._src.util import tuple_insert
 import jax.numpy as jnp
 from jax._src.lax.control_flow import for_loop
 
-try:
-  import hypothesis as hp
-  import hypothesis.extra.numpy as hnp
-  import hypothesis.strategies as hps
-  CAN_USE_HYPOTHESIS = True
-except (ModuleNotFoundError, ImportError):
-  CAN_USE_HYPOTHESIS = False
+import hypothesis as hp
+import hypothesis.extra.numpy as hnp
+import hypothesis.strategies as hps
 
 from jax._src.state.discharge import (run_state, run_state_reference,
                                       discharge_state)
@@ -798,305 +794,303 @@ class StateDischargeTest(jtu.JaxTestCase):
     self.assertLen(jaxpr.outvars, 3)
 
 
-if CAN_USE_HYPOTHESIS:
+def index_arrays(size, idx_shape):
+  valid_idx = hps.integers(min_value=-size, max_value=size - 1)
+  return hnp.arrays(np.int32, idx_shape, elements=valid_idx)
 
-  def index_arrays(size, idx_shape):
-    valid_idx = hps.integers(min_value=-size, max_value=size - 1)
-    return hnp.arrays(np.int32, idx_shape, elements=valid_idx)
+Shape = tuple[int, ...]
 
-  Shape = tuple[int, ...]
+class IndexParam(NamedTuple):
+  ref_aval: shaped_array_ref
+  ref_shape: Shape
+  indexed_dims: list[bool]
+  idx_avals: tuple[core.ShapedArray, ...]
+  idx_shape: Shape
+  slice_aval: core.ShapedArray
+  slice_shape: Shape
 
-  class IndexParam(NamedTuple):
-    ref_aval: shaped_array_ref
-    ref_shape: Shape
-    indexed_dims: list[bool]
-    idx_avals: tuple[core.ShapedArray, ...]
-    idx_shape: Shape
-    slice_aval: core.ShapedArray
-    slice_shape: Shape
-
-  @hps.composite
-  def index_params(draw):
-    ref_shape = draw(hnp.array_shapes(max_dims=4, max_side=7), label='ref_shape')
-    indexed_dims = draw(hps.lists(hps.booleans(),
-                                  min_size=len(ref_shape),
-                                  max_size=len(ref_shape)))
-    idx_shape = draw(hnp.array_shapes(max_dims=3, max_side=5))
-    if not any(indexed_dims):
-      slice_shape = ref_shape
+@hps.composite
+def index_params(draw):
+  ref_shape = draw(hnp.array_shapes(max_dims=4, max_side=7), label='ref_shape')
+  indexed_dims = draw(hps.lists(hps.booleans(),
+                                min_size=len(ref_shape),
+                                max_size=len(ref_shape)))
+  idx_shape = draw(hnp.array_shapes(max_dims=3, max_side=5))
+  if not any(indexed_dims):
+    slice_shape = ref_shape
+  else:
+    sliced_shape = tuple(s for s, b in zip(ref_shape, indexed_dims) if not b)
+    int_indexers_contiguous = bool(
+        np.all(np.diff(np.where(indexed_dims)[0]) == 1)
+    )
+    if not int_indexers_contiguous:
+      slice_shape = (*idx_shape, *sliced_shape)
     else:
-      sliced_shape = tuple(s for s, b in zip(ref_shape, indexed_dims) if not b)
-      int_indexers_contiguous = bool(
-          np.all(np.diff(np.where(indexed_dims)[0]) == 1)
+      insert_pos = indexed_dims.index(True)
+      slice_shape = (
+        *sliced_shape[:insert_pos],
+        *idx_shape,
+        *sliced_shape[insert_pos:],
       )
-      if not int_indexers_contiguous:
-        slice_shape = (*idx_shape, *sliced_shape)
-      else:
-        insert_pos = indexed_dims.index(True)
-        slice_shape = (
-          *sliced_shape[:insert_pos],
-          *idx_shape,
-          *sliced_shape[insert_pos:],
-        )
-    ref_aval = shaped_array_ref(ref_shape, np.float32)
-    idx_avals = tuple(core.ShapedArray(idx_shape, np.int32) for _ in
-        range(sum(indexed_dims)))
-    slice_aval = core.ShapedArray(slice_shape, np.float32)
-    return IndexParam(ref_aval, ref_shape, indexed_dims, idx_avals, idx_shape,
-                      slice_aval, slice_shape)
+  ref_aval = shaped_array_ref(ref_shape, np.float32)
+  idx_avals = tuple(core.ShapedArray(idx_shape, np.int32) for _ in
+      range(sum(indexed_dims)))
+  slice_aval = core.ShapedArray(slice_shape, np.float32)
+  return IndexParam(ref_aval, ref_shape, indexed_dims, idx_avals, idx_shape,
+                    slice_aval, slice_shape)
 
-  class VmappableIndexParam(NamedTuple):
-    index_param: IndexParam
-    ref_bdim: int | None
-    non_slice_idx_bdims: tuple[int | None, ...]
-    slice_bdim: int
-    bat_ref_aval: shaped_array_ref
-    bat_ref_shape: Shape
-    bat_non_slice_idx_avals: tuple[core.ShapedArray, ...]
-    bat_non_slice_idx_shapes: tuple[Shape, ...]
-    bat_slice_aval: core.ShapedArray
-    bat_slice_shape: Shape
+class VmappableIndexParam(NamedTuple):
+  index_param: IndexParam
+  ref_bdim: int | None
+  non_slice_idx_bdims: tuple[int | None, ...]
+  slice_bdim: int
+  bat_ref_aval: shaped_array_ref
+  bat_ref_shape: Shape
+  bat_non_slice_idx_avals: tuple[core.ShapedArray, ...]
+  bat_non_slice_idx_shapes: tuple[Shape, ...]
+  bat_slice_aval: core.ShapedArray
+  bat_slice_shape: Shape
 
-  def maybe_tuple_insert(t: tuple[Any, ...], idx: int | None,
-                         val: Any) -> tuple[Any, ...]:
-    if idx is None:
-      return t
-    return tuple_insert(t, idx, val)
+def maybe_tuple_insert(t: tuple[Any, ...], idx: int | None,
+                        val: Any) -> tuple[Any, ...]:
+  if idx is None:
+    return t
+  return tuple_insert(t, idx, val)
 
-  @hps.composite
-  def vmappable_index_params(draw, *, op_type: str):
-    axis_size = draw(hps.integers(min_value=1, max_value=7), label='axis_size')
-    index_param: IndexParam = draw(index_params())
-    non_slice_idx_bdims = tuple(
-        draw(hps.one_of(
-          hps.none(),
-          hps.integers(min_value=0, max_value=len(index_param.idx_shape))))
-        for b in index_param.indexed_dims if b)
-    bat_non_slice_idx_shapes = tuple(
-        maybe_tuple_insert(index_param.idx_shape, idx_bdim, axis_size)
-        for idx_bdim in non_slice_idx_bdims)
-    if op_type == "swap":
-      # In a swap, the ref *must* be batched
-      ref_bdim = draw(hps.integers(min_value=0,
-                                   max_value=len(index_param.ref_shape)))
-      if any(idx_bdim is not None for idx_bdim in non_slice_idx_bdims):
-        # If it's a swap, if indices are batched, val must be batched.
-        slice_bdim = draw(hps.integers(
-          min_value=0, max_value=len(index_param.slice_shape)))
-      else:
-        slice_bdim = draw(hps.one_of(hps.none(), hps.integers(
-          min_value=0, max_value=len(index_param.slice_shape))))
-    elif op_type == "get":
-      # In a get, the indices must be batched or ref is batched
-      if all(idx_bdim is None for idx_bdim in non_slice_idx_bdims):
-        ref_bdim = draw(hps.integers(min_value=0,
-                                     max_value=len(index_param.ref_shape)))
-      else:
-        ref_bdim = draw(hps.one_of(hps.none(),
-          hps.integers(min_value=0, max_value=len(index_param.ref_shape))))
+@hps.composite
+def vmappable_index_params(draw, *, op_type: str):
+  axis_size = draw(hps.integers(min_value=1, max_value=7), label='axis_size')
+  index_param: IndexParam = draw(index_params())
+  non_slice_idx_bdims = tuple(
+      draw(hps.one_of(
+        hps.none(),
+        hps.integers(min_value=0, max_value=len(index_param.idx_shape))))
+      for b in index_param.indexed_dims if b)
+  bat_non_slice_idx_shapes = tuple(
+      maybe_tuple_insert(index_param.idx_shape, idx_bdim, axis_size)
+      for idx_bdim in non_slice_idx_bdims)
+  if op_type == "swap":
+    # In a swap, the ref *must* be batched
+    ref_bdim = draw(hps.integers(min_value=0,
+                                  max_value=len(index_param.ref_shape)))
+    if any(idx_bdim is not None for idx_bdim in non_slice_idx_bdims):
+      # If it's a swap, if indices are batched, val must be batched.
       slice_bdim = draw(hps.integers(
         min_value=0, max_value=len(index_param.slice_shape)))
+    else:
+      slice_bdim = draw(hps.one_of(hps.none(), hps.integers(
+        min_value=0, max_value=len(index_param.slice_shape))))
+  elif op_type == "get":
+    # In a get, the indices must be batched or ref is batched
+    if all(idx_bdim is None for idx_bdim in non_slice_idx_bdims):
+      ref_bdim = draw(hps.integers(min_value=0,
+                                    max_value=len(index_param.ref_shape)))
+    else:
+      ref_bdim = draw(hps.one_of(hps.none(),
+        hps.integers(min_value=0, max_value=len(index_param.ref_shape))))
+    slice_bdim = draw(hps.integers(
+      min_value=0, max_value=len(index_param.slice_shape)))
 
-    bat_ref_shape = maybe_tuple_insert(index_param.ref_shape, ref_bdim, axis_size)
-    bat_ref_aval = shaped_array_ref(bat_ref_shape, np.float32)
-    bat_non_slice_idx_avals = tuple(
-        core.ShapedArray(shape, np.int32) for shape in bat_non_slice_idx_shapes)
-    bat_slice_shape = maybe_tuple_insert(index_param.slice_shape, slice_bdim, axis_size)
-    bat_slice_aval = core.ShapedArray(bat_slice_shape, np.float32)
-    return VmappableIndexParam(index_param, ref_bdim, non_slice_idx_bdims,
-                               slice_bdim, bat_ref_aval, bat_ref_shape,
-                               bat_non_slice_idx_avals, bat_non_slice_idx_shapes,
-                               bat_slice_aval, bat_slice_shape)
+  bat_ref_shape = maybe_tuple_insert(index_param.ref_shape, ref_bdim, axis_size)
+  bat_ref_aval = shaped_array_ref(bat_ref_shape, np.float32)
+  bat_non_slice_idx_avals = tuple(
+      core.ShapedArray(shape, np.int32) for shape in bat_non_slice_idx_shapes)
+  bat_slice_shape = maybe_tuple_insert(index_param.slice_shape, slice_bdim, axis_size)
+  bat_slice_aval = core.ShapedArray(bat_slice_shape, np.float32)
+  return VmappableIndexParam(index_param, ref_bdim, non_slice_idx_bdims,
+                              slice_bdim, bat_ref_aval, bat_ref_shape,
+                              bat_non_slice_idx_avals, bat_non_slice_idx_shapes,
+                              bat_slice_aval, bat_slice_shape)
 
-  class GetVmapParams(NamedTuple):
-    vmap_index_param: VmappableIndexParam
-    bat_ref: np.ndarray
-    bat_idxs: tuple[np.ndarray, ...]
+class GetVmapParams(NamedTuple):
+  vmap_index_param: VmappableIndexParam
+  bat_ref: np.ndarray
+  bat_idxs: tuple[np.ndarray, ...]
 
-  @hps.composite
-  def get_vmap_params(draw):
-    vmap_index_param: VmappableIndexParam = draw(
-        vmappable_index_params(op_type="get"))
-    bat_ref = draw(hnp.arrays(np.float32, vmap_index_param.bat_ref_shape))
-    bat_idx_shapes_ = iter(vmap_index_param.bat_non_slice_idx_shapes)
-    bat_idxs = tuple(
-        draw(index_arrays(size, next(bat_idx_shapes_)))
-        for size, indexed in zip(
-          vmap_index_param.index_param.ref_shape,
-          vmap_index_param.index_param.indexed_dims)
-        if indexed)
-    assert next(bat_idx_shapes_, None) is None
-    return GetVmapParams(vmap_index_param, bat_ref, bat_idxs)
+@hps.composite
+def get_vmap_params(draw):
+  vmap_index_param: VmappableIndexParam = draw(
+      vmappable_index_params(op_type="get"))
+  bat_ref = draw(hnp.arrays(np.float32, vmap_index_param.bat_ref_shape))
+  bat_idx_shapes_ = iter(vmap_index_param.bat_non_slice_idx_shapes)
+  bat_idxs = tuple(
+      draw(index_arrays(size, next(bat_idx_shapes_)))
+      for size, indexed in zip(
+        vmap_index_param.index_param.ref_shape,
+        vmap_index_param.index_param.indexed_dims)
+      if indexed)
+  assert next(bat_idx_shapes_, None) is None
+  return GetVmapParams(vmap_index_param, bat_ref, bat_idxs)
 
-  class SetVmapParams(NamedTuple):
-    vmap_index_param: VmappableIndexParam
-    bat_ref: np.ndarray
-    bat_val: np.ndarray
-    bat_idxs: tuple[np.ndarray, ...]
+class SetVmapParams(NamedTuple):
+  vmap_index_param: VmappableIndexParam
+  bat_ref: np.ndarray
+  bat_val: np.ndarray
+  bat_idxs: tuple[np.ndarray, ...]
 
-  @hps.composite
-  def set_vmap_params(draw):
-    vmap_index_param: VmappableIndexParam = draw(vmappable_index_params(
-      op_type="swap"))
-    bat_ref = draw(hnp.arrays(np.float32, vmap_index_param.bat_ref_shape))
-    bat_idx_shapes_ = iter(vmap_index_param.bat_non_slice_idx_shapes)
-    bat_idxs = tuple(
-        draw(index_arrays(size, next(bat_idx_shapes_)))
-        for size, indexed in zip(
-          vmap_index_param.index_param.ref_shape,
-          vmap_index_param.index_param.indexed_dims)
-        if indexed)
-    assert next(bat_idx_shapes_, None) is None
-    bat_val = draw(hnp.arrays(np.float32, vmap_index_param.bat_slice_shape))
-    return SetVmapParams(vmap_index_param, bat_ref, bat_val, bat_idxs)
+@hps.composite
+def set_vmap_params(draw):
+  vmap_index_param: VmappableIndexParam = draw(vmappable_index_params(
+    op_type="swap"))
+  bat_ref = draw(hnp.arrays(np.float32, vmap_index_param.bat_ref_shape))
+  bat_idx_shapes_ = iter(vmap_index_param.bat_non_slice_idx_shapes)
+  bat_idxs = tuple(
+      draw(index_arrays(size, next(bat_idx_shapes_)))
+      for size, indexed in zip(
+        vmap_index_param.index_param.ref_shape,
+        vmap_index_param.index_param.indexed_dims)
+      if indexed)
+  assert next(bat_idx_shapes_, None) is None
+  bat_val = draw(hnp.arrays(np.float32, vmap_index_param.bat_slice_shape))
+  return SetVmapParams(vmap_index_param, bat_ref, bat_val, bat_idxs)
 
-  Indexer = tuple[Union[int, slice, np.ndarray]]
+Indexer = tuple[Union[int, slice, np.ndarray]]
 
-  def _unpack_idx(idx: Indexer
-      ) -> tuple[Sequence[int | np.ndarray], Sequence[bool]]:
-    indexed_dims = [type(i) != slice for i in idx]
-    non_slice_idx = [i for i, b in zip(idx, indexed_dims) if b]
-    return non_slice_idx, indexed_dims
+def _unpack_idx(idx: Indexer
+    ) -> tuple[Sequence[int | np.ndarray], Sequence[bool]]:
+  indexed_dims = [type(i) != slice for i in idx]
+  non_slice_idx = [i for i, b in zip(idx, indexed_dims) if b]
+  return non_slice_idx, indexed_dims
 
-  def _pack_idx(non_slice_idx: Sequence[int | np.ndarray],
-      indexed_dims: Sequence[bool]) -> Indexer:
-    idx_ = iter(non_slice_idx)
-    idx = tuple(next(idx_) if b else slice(None) for b in indexed_dims)
-    assert next(idx_, None) is None
-    return idx
+def _pack_idx(non_slice_idx: Sequence[int | np.ndarray],
+    indexed_dims: Sequence[bool]) -> Indexer:
+  idx_ = iter(non_slice_idx)
+  idx = tuple(next(idx_) if b else slice(None) for b in indexed_dims)
+  assert next(idx_, None) is None
+  return idx
 
-  @jtu.thread_unsafe_test_class()  # hypothesis isn't thread-safe
-  class StateHypothesisTest(jtu.JaxTestCase):
+@jtu.thread_unsafe_test_class()  # hypothesis isn't thread-safe
+class StateHypothesisTest(jtu.JaxTestCase):
 
-    @hp.given(get_vmap_params())
-    @hp.settings(deadline=None, print_blob=True,
-                 max_examples=jtu.NUM_GENERATED_CASES.value)
-    def test_get_vmap(self, get_vmap_param: GetVmapParams):
+  @hp.given(get_vmap_params())
+  @hp.settings(deadline=None, print_blob=True,
+                max_examples=jtu.NUM_GENERATED_CASES.value)
+  def test_get_vmap(self, get_vmap_param: GetVmapParams):
 
-      indexed_dims = get_vmap_param.vmap_index_param.index_param.indexed_dims
+    indexed_dims = get_vmap_param.vmap_index_param.index_param.indexed_dims
 
-      def f(ref, *non_slice_idx):
-        idx = _pack_idx(non_slice_idx, indexed_dims)
-        return [ref_get(ref, idx)]
-      ref_aval = get_vmap_param.vmap_index_param.index_param.ref_aval
-      bat_ref_aval = get_vmap_param.vmap_index_param.bat_ref_aval
-      bat_non_slice_idx_avals = get_vmap_param.vmap_index_param.bat_non_slice_idx_avals
-      ref_bdim = get_vmap_param.vmap_index_param.ref_bdim
-      idx_bdims = get_vmap_param.vmap_index_param.non_slice_idx_bdims
-      out_bdim = get_vmap_param.vmap_index_param.slice_bdim
-      non_slice_idx = get_vmap_param.bat_idxs
-      idx_avals = get_vmap_param.vmap_index_param.index_param.idx_avals
-      ref = get_vmap_param.bat_ref
+    def f(ref, *non_slice_idx):
+      idx = _pack_idx(non_slice_idx, indexed_dims)
+      return [ref_get(ref, idx)]
+    ref_aval = get_vmap_param.vmap_index_param.index_param.ref_aval
+    bat_ref_aval = get_vmap_param.vmap_index_param.bat_ref_aval
+    bat_non_slice_idx_avals = get_vmap_param.vmap_index_param.bat_non_slice_idx_avals
+    ref_bdim = get_vmap_param.vmap_index_param.ref_bdim
+    idx_bdims = get_vmap_param.vmap_index_param.non_slice_idx_bdims
+    out_bdim = get_vmap_param.vmap_index_param.slice_bdim
+    non_slice_idx = get_vmap_param.bat_idxs
+    idx_avals = get_vmap_param.vmap_index_param.index_param.idx_avals
+    ref = get_vmap_param.bat_ref
 
-      f_batched = jax.vmap(f, in_axes=(ref_bdim, *idx_bdims), out_axes=[out_bdim])
-      stateful_jaxpr, _, stateful_consts, () = pe.trace_to_jaxpr_dynamic(
-          wrap_init(f_batched, 1 + len(bat_non_slice_idx_avals)),
-          [bat_ref_aval, *bat_non_slice_idx_avals])
-      jaxpr, consts = discharge_state(stateful_jaxpr, stateful_consts)
-      discharge_of_vmap_ans = core.eval_jaxpr(jaxpr, consts, ref, *non_slice_idx)
+    f_batched = jax.vmap(f, in_axes=(ref_bdim, *idx_bdims), out_axes=[out_bdim])
+    stateful_jaxpr, _, stateful_consts, () = pe.trace_to_jaxpr_dynamic(
+        wrap_init(f_batched, 1 + len(bat_non_slice_idx_avals)),
+        [bat_ref_aval, *bat_non_slice_idx_avals])
+    jaxpr, consts = discharge_state(stateful_jaxpr, stateful_consts)
+    discharge_of_vmap_ans = core.eval_jaxpr(jaxpr, consts, ref, *non_slice_idx)
 
-      # vmap-of-discharge
-      stateful_jaxpr, _, stateful_consts, () = pe.trace_to_jaxpr_dynamic(
-          wrap_init(f, 1 + len(idx_avals)), [ref_aval, *idx_avals])
-      jaxpr_, consts_ = discharge_state(stateful_jaxpr, stateful_consts)
-      f_batched = jax.vmap(partial(core.eval_jaxpr, jaxpr_, consts_),
-                           in_axes=(ref_bdim, *idx_bdims),
-                           out_axes=[out_bdim, ref_bdim])
-      vmap_of_discharge_ans = f_batched(ref, *non_slice_idx)
+    # vmap-of-discharge
+    stateful_jaxpr, _, stateful_consts, () = pe.trace_to_jaxpr_dynamic(
+        wrap_init(f, 1 + len(idx_avals)), [ref_aval, *idx_avals])
+    jaxpr_, consts_ = discharge_state(stateful_jaxpr, stateful_consts)
+    f_batched = jax.vmap(partial(core.eval_jaxpr, jaxpr_, consts_),
+                          in_axes=(ref_bdim, *idx_bdims),
+                          out_axes=[out_bdim, ref_bdim])
+    vmap_of_discharge_ans = f_batched(ref, *non_slice_idx)
 
-      self.assertAllClose(discharge_of_vmap_ans, vmap_of_discharge_ans,
-                          check_dtypes=False)
-
-
-    @hp.given(set_vmap_params())
-    @hp.settings(deadline=None, print_blob=True,
-                 max_examples=jtu.NUM_GENERATED_CASES.value)
-    def test_set_vmap(self, set_vmap_param: SetVmapParams):
-      if jtu.test_device_matches(["gpu"]):
-        self.skipTest("Scatter is nondeterministic on GPU")
-      indexed_dims = set_vmap_param.vmap_index_param.index_param.indexed_dims
-
-      def f(ref, val, *non_slice_idx):
-        idx = _pack_idx(non_slice_idx, indexed_dims)
-        ref_set(ref, idx, val)
-        return []
-      ref_aval = set_vmap_param.vmap_index_param.index_param.ref_aval
-      bat_ref_aval = set_vmap_param.vmap_index_param.bat_ref_aval
-      bat_non_slice_idx_avals = set_vmap_param.vmap_index_param.bat_non_slice_idx_avals
-      ref_bdim = set_vmap_param.vmap_index_param.ref_bdim
-      idx_bdims = set_vmap_param.vmap_index_param.non_slice_idx_bdims
-      non_slice_idx = set_vmap_param.bat_idxs
-      idx_avals = set_vmap_param.vmap_index_param.index_param.idx_avals
-      ref = set_vmap_param.bat_ref
-      val = set_vmap_param.bat_val
-      bat_val_aval = set_vmap_param.vmap_index_param.bat_slice_aval
-      val_aval = set_vmap_param.vmap_index_param.index_param.slice_aval
-      val_bdim = set_vmap_param.vmap_index_param.slice_bdim
-
-      f_batched = jax.vmap(f, in_axes=(ref_bdim, val_bdim, *idx_bdims),
-                           out_axes=[])
-      stateful_jaxpr, _, stateful_consts, () = pe.trace_to_jaxpr_dynamic(
-          wrap_init(f_batched, 2 + len(bat_non_slice_idx_avals)),
-          [bat_ref_aval, bat_val_aval, *bat_non_slice_idx_avals])
-      jaxpr, consts = discharge_state(stateful_jaxpr, stateful_consts)
-      discharge_of_vmap_ans = core.eval_jaxpr(jaxpr, consts, ref, val, *non_slice_idx)
-
-      # vmap-of-discharge
-      stateful_jaxpr, _, stateful_consts, () = pe.trace_to_jaxpr_dynamic(
-          wrap_init(f, 2 + len(idx_avals)), [ref_aval, val_aval, *idx_avals])
-      jaxpr_, consts_ = discharge_state(stateful_jaxpr, stateful_consts)
-      f_batched = jax.vmap(partial(core.eval_jaxpr, jaxpr_, consts_),
-                           in_axes=(ref_bdim, val_bdim, *idx_bdims),
-                           out_axes=[ref_bdim])
-      vmap_of_discharge_ans = f_batched(ref, val, *non_slice_idx)
-
-      self.assertAllClose(discharge_of_vmap_ans, vmap_of_discharge_ans,
-                          check_dtypes=False)
+    self.assertAllClose(discharge_of_vmap_ans, vmap_of_discharge_ans,
+                        check_dtypes=False)
 
 
-    @hp.given(set_vmap_params())
-    @hp.settings(deadline=None, print_blob=True,
-                 max_examples=jtu.NUM_GENERATED_CASES.value)
-    def test_addupdate_vmap(self, set_vmap_param: SetVmapParams):
+  @hp.given(set_vmap_params())
+  @hp.settings(deadline=None, print_blob=True,
+                max_examples=jtu.NUM_GENERATED_CASES.value)
+  def test_set_vmap(self, set_vmap_param: SetVmapParams):
+    if jtu.test_device_matches(["gpu"]):
+      self.skipTest("Scatter is nondeterministic on GPU")
+    indexed_dims = set_vmap_param.vmap_index_param.index_param.indexed_dims
 
-      indexed_dims = set_vmap_param.vmap_index_param.index_param.indexed_dims
+    def f(ref, val, *non_slice_idx):
+      idx = _pack_idx(non_slice_idx, indexed_dims)
+      ref_set(ref, idx, val)
+      return []
+    ref_aval = set_vmap_param.vmap_index_param.index_param.ref_aval
+    bat_ref_aval = set_vmap_param.vmap_index_param.bat_ref_aval
+    bat_non_slice_idx_avals = set_vmap_param.vmap_index_param.bat_non_slice_idx_avals
+    ref_bdim = set_vmap_param.vmap_index_param.ref_bdim
+    idx_bdims = set_vmap_param.vmap_index_param.non_slice_idx_bdims
+    non_slice_idx = set_vmap_param.bat_idxs
+    idx_avals = set_vmap_param.vmap_index_param.index_param.idx_avals
+    ref = set_vmap_param.bat_ref
+    val = set_vmap_param.bat_val
+    bat_val_aval = set_vmap_param.vmap_index_param.bat_slice_aval
+    val_aval = set_vmap_param.vmap_index_param.index_param.slice_aval
+    val_bdim = set_vmap_param.vmap_index_param.slice_bdim
 
-      def f(ref, val, *non_slice_idx):
-        idx = _pack_idx(non_slice_idx, indexed_dims)
-        ref_addupdate(ref, idx, val)
-        return []
-      ref_aval = set_vmap_param.vmap_index_param.index_param.ref_aval
-      bat_ref_aval = set_vmap_param.vmap_index_param.bat_ref_aval
-      bat_non_slice_idx_avals = set_vmap_param.vmap_index_param.bat_non_slice_idx_avals
-      ref_bdim = set_vmap_param.vmap_index_param.ref_bdim
-      idx_bdims = set_vmap_param.vmap_index_param.non_slice_idx_bdims
-      non_slice_idx = set_vmap_param.bat_idxs
-      idx_avals = set_vmap_param.vmap_index_param.index_param.idx_avals
-      ref = set_vmap_param.bat_ref
-      val = set_vmap_param.bat_val
-      bat_val_aval = set_vmap_param.vmap_index_param.bat_slice_aval
-      val_aval = set_vmap_param.vmap_index_param.index_param.slice_aval
-      val_bdim = set_vmap_param.vmap_index_param.slice_bdim
+    f_batched = jax.vmap(f, in_axes=(ref_bdim, val_bdim, *idx_bdims),
+                          out_axes=[])
+    stateful_jaxpr, _, stateful_consts, () = pe.trace_to_jaxpr_dynamic(
+        wrap_init(f_batched, 2 + len(bat_non_slice_idx_avals)),
+        [bat_ref_aval, bat_val_aval, *bat_non_slice_idx_avals])
+    jaxpr, consts = discharge_state(stateful_jaxpr, stateful_consts)
+    discharge_of_vmap_ans = core.eval_jaxpr(jaxpr, consts, ref, val, *non_slice_idx)
 
-      f_batched = jax.vmap(f, in_axes=(ref_bdim, val_bdim, *idx_bdims),
-                           out_axes=[])
-      stateful_jaxpr, _, stateful_consts, () = pe.trace_to_jaxpr_dynamic(
-          wrap_init(f_batched, 2 + len(bat_non_slice_idx_avals)),
-          [bat_ref_aval, bat_val_aval, *bat_non_slice_idx_avals])
-      jaxpr, consts = discharge_state(stateful_jaxpr, stateful_consts)
-      discharge_of_vmap_ans = core.eval_jaxpr(jaxpr, consts, ref, val, *non_slice_idx)
+    # vmap-of-discharge
+    stateful_jaxpr, _, stateful_consts, () = pe.trace_to_jaxpr_dynamic(
+        wrap_init(f, 2 + len(idx_avals)), [ref_aval, val_aval, *idx_avals])
+    jaxpr_, consts_ = discharge_state(stateful_jaxpr, stateful_consts)
+    f_batched = jax.vmap(partial(core.eval_jaxpr, jaxpr_, consts_),
+                          in_axes=(ref_bdim, val_bdim, *idx_bdims),
+                          out_axes=[ref_bdim])
+    vmap_of_discharge_ans = f_batched(ref, val, *non_slice_idx)
 
-      # vmap-of-discharge
-      stateful_jaxpr, _, stateful_consts, () = pe.trace_to_jaxpr_dynamic(
-          wrap_init(f, 2 + len(idx_avals)), [ref_aval, val_aval, *idx_avals])
-      jaxpr_, consts_ = discharge_state(stateful_jaxpr, stateful_consts)
-      f_batched = jax.vmap(partial(core.eval_jaxpr, jaxpr_, consts_),
-                           in_axes=(ref_bdim, val_bdim, *idx_bdims),
-                           out_axes=[ref_bdim])
-      vmap_of_discharge_ans = f_batched(ref, val, *non_slice_idx)
+    self.assertAllClose(discharge_of_vmap_ans, vmap_of_discharge_ans,
+                        check_dtypes=False)
 
-      self.assertAllClose(discharge_of_vmap_ans, vmap_of_discharge_ans,
-                          check_dtypes=False)
+
+  @hp.given(set_vmap_params())
+  @hp.settings(deadline=None, print_blob=True,
+                max_examples=jtu.NUM_GENERATED_CASES.value)
+  def test_addupdate_vmap(self, set_vmap_param: SetVmapParams):
+
+    indexed_dims = set_vmap_param.vmap_index_param.index_param.indexed_dims
+
+    def f(ref, val, *non_slice_idx):
+      idx = _pack_idx(non_slice_idx, indexed_dims)
+      ref_addupdate(ref, idx, val)
+      return []
+    ref_aval = set_vmap_param.vmap_index_param.index_param.ref_aval
+    bat_ref_aval = set_vmap_param.vmap_index_param.bat_ref_aval
+    bat_non_slice_idx_avals = set_vmap_param.vmap_index_param.bat_non_slice_idx_avals
+    ref_bdim = set_vmap_param.vmap_index_param.ref_bdim
+    idx_bdims = set_vmap_param.vmap_index_param.non_slice_idx_bdims
+    non_slice_idx = set_vmap_param.bat_idxs
+    idx_avals = set_vmap_param.vmap_index_param.index_param.idx_avals
+    ref = set_vmap_param.bat_ref
+    val = set_vmap_param.bat_val
+    bat_val_aval = set_vmap_param.vmap_index_param.bat_slice_aval
+    val_aval = set_vmap_param.vmap_index_param.index_param.slice_aval
+    val_bdim = set_vmap_param.vmap_index_param.slice_bdim
+
+    f_batched = jax.vmap(f, in_axes=(ref_bdim, val_bdim, *idx_bdims),
+                          out_axes=[])
+    stateful_jaxpr, _, stateful_consts, () = pe.trace_to_jaxpr_dynamic(
+        wrap_init(f_batched, 2 + len(bat_non_slice_idx_avals)),
+        [bat_ref_aval, bat_val_aval, *bat_non_slice_idx_avals])
+    jaxpr, consts = discharge_state(stateful_jaxpr, stateful_consts)
+    discharge_of_vmap_ans = core.eval_jaxpr(jaxpr, consts, ref, val, *non_slice_idx)
+
+    # vmap-of-discharge
+    stateful_jaxpr, _, stateful_consts, () = pe.trace_to_jaxpr_dynamic(
+        wrap_init(f, 2 + len(idx_avals)), [ref_aval, val_aval, *idx_avals])
+    jaxpr_, consts_ = discharge_state(stateful_jaxpr, stateful_consts)
+    f_batched = jax.vmap(partial(core.eval_jaxpr, jaxpr_, consts_),
+                          in_axes=(ref_bdim, val_bdim, *idx_bdims),
+                          out_axes=[ref_bdim])
+    vmap_of_discharge_ans = f_batched(ref, val, *non_slice_idx)
+
+    self.assertAllClose(discharge_of_vmap_ans, vmap_of_discharge_ans,
+                        check_dtypes=False)
 
 
 class StateControlFlowTest(jtu.JaxTestCase):
@@ -1634,220 +1628,218 @@ class RunStateTest(jtu.JaxTestCase):
     jtu.check_grads(f, (0.5,), order=3)
 
 
-if CAN_USE_HYPOTHESIS:
+class FuncSpec(NamedTuple):
+  fun: Callable[..., Any]
+  name: str
+  min_rank: int = 0
+  max_rank: int = 4
+  min_dim: int = 0
+  max_dim: int = 4
 
-  class FuncSpec(NamedTuple):
-    fun: Callable[..., Any]
-    name: str
-    min_rank: int = 0
-    max_rank: int = 4
-    min_dim: int = 0
-    max_dim: int = 4
+  def call(self, *args):
+    return run_state(self.fun)(*args)
 
-    def call(self, *args):
-      return run_state(self.fun)(*args)
+  def ref(self, *args):
+    return run_state_reference(self.fun)(*args)
 
-    def ref(self, *args):
-      return run_state_reference(self.fun)(*args)
+def sin_stateful(refs):
+  x_ref, y_ref = refs
+  y_ref[...] = jnp.sin(x_ref[...])
 
-  def sin_stateful(refs):
+sin_spec = FuncSpec(sin_stateful, "sin")
+
+def cos_stateful(refs):
+  x_ref, y_ref = refs
+  y_ref[...] = jnp.cos(x_ref[...])
+
+cos_spec = FuncSpec(cos_stateful, "cos")
+
+def mul2_stateful(refs):
+  x_ref, y_ref = refs
+  y_ref[...] = x_ref[...]
+  y_ref[...] = y_ref[...] + x_ref[...]
+
+mul2_spec = FuncSpec(mul2_stateful, "mul2")
+
+def mul2_stateful_with_constant(refs):
+  x_ref, y_ref = refs
+  y_ref[...] = (2. * np.ones(x_ref.shape, x_ref.dtype)) * x_ref[...]
+
+mul2_constant_spec = FuncSpec(mul2_stateful_with_constant, "mul2_c")
+
+def crazy_identity_stateful(refs):
+  x_ref, y_ref = refs
+  x = x_ref[...]
+  x_ref[...] = (x + x) / 2
+  y_ref[...] = x_ref[...]
+  y = y_ref[...]
+  y_ref[...] = (y + y) / 2
+
+crazy_identity_spec = FuncSpec(crazy_identity_stateful, "id")
+
+def func_spec(depth: int = 4):
+  raw_specs = hps.sampled_from([sin_spec, cos_spec, mul2_spec,
+                                mul2_constant_spec, crazy_identity_spec])
+  if depth > 0:
+    return hps.one_of([raw_specs, nest_spec(depth - 1), add_spec(depth - 1),
+                        compose_spec(depth - 1)])
+  return raw_specs
+
+@hps.composite
+def compose_spec(draw, depth):
+  f1 = draw(func_spec(depth))
+  f2 = draw(func_spec(depth))
+  def wrapped_impl(*args):
+    f1.fun(*args)
+    f2.fun(*args)
+  return FuncSpec(wrapped_impl,
+                  f"({f2.name} . {f1.name})",
+                  min_rank=max(f1.min_rank, f2.min_rank),
+                  max_rank=min(f1.max_rank, f2.max_rank),
+                  min_dim=max(f1.min_dim, f2.min_dim),
+                  max_dim=min(f1.max_dim, f2.max_dim))
+
+@hps.composite
+def nest_spec(draw, depth):
+  f = draw(func_spec(depth))
+  def wrapped_impl(refs):
     x_ref, y_ref = refs
-    y_ref[...] = jnp.sin(x_ref[...])
+    x, y = x_ref[...], y_ref[...]
+    x, y = run_state(f.fun)((x, y))
+    x_ref[...], y_ref[...] = x, y
+  return FuncSpec(wrapped_impl,
+                  f"nest({f.name})",
+                  min_rank=f.min_rank,
+                  max_rank=f.max_rank,
+                  min_dim=f.min_dim,
+                  max_dim=f.max_dim)
 
-  sin_spec = FuncSpec(sin_stateful, "sin")
 
-  def cos_stateful(refs):
+@hps.composite
+def add_spec(draw, depth):
+  f1 = draw(func_spec(depth))
+  f2 = draw(func_spec(depth))
+  def wrapped_impl(refs):
     x_ref, y_ref = refs
-    y_ref[...] = jnp.cos(x_ref[...])
+    x, y = x_ref[...], y_ref[...]
+    x1, y1 = run_state(f1.fun)((x, y))
+    x2, y2 = run_state(f2.fun)((x, y))
+    x_ref[...], y_ref[...] = x1 + x2, y1 + y2
+  return FuncSpec(wrapped_impl,
+                  f"({f2.name} + {f1.name})",
+                  min_rank=max(f1.min_rank, f2.min_rank),
+                  max_rank=min(f1.max_rank, f2.max_rank),
+                  min_dim=max(f1.min_dim, f2.min_dim),
+                  max_dim=min(f1.max_dim, f2.max_dim))
 
-  cos_spec = FuncSpec(cos_stateful, "cos")
+@jtu.thread_unsafe_test_class()  # because of hypothesis
+class RunStateHypothesisTest(jtu.JaxTestCase):
 
-  def mul2_stateful(refs):
-    x_ref, y_ref = refs
-    y_ref[...] = x_ref[...]
-    y_ref[...] = y_ref[...] + x_ref[...]
+  @jax.legacy_prng_key('allow')
+  @hp.given(hps.data())
+  @hp.settings(deadline=None, print_blob=True,
+                max_examples=jtu.NUM_GENERATED_CASES.value)
+  def test_jvp(self, data):
 
-  mul2_spec = FuncSpec(mul2_stateful, "mul2")
+    spec = data.draw(func_spec())
 
-  def mul2_stateful_with_constant(refs):
-    x_ref, y_ref = refs
-    y_ref[...] = (2. * np.ones(x_ref.shape, x_ref.dtype)) * x_ref[...]
+    def impl(x):
+      return spec.call((x, jnp.zeros_like(x)))[1]
 
-  mul2_constant_spec = FuncSpec(mul2_stateful_with_constant, "mul2_c")
+    def ref(x):
+      return spec.ref((x, jnp.zeros_like(x)))[1]
 
-  def crazy_identity_stateful(refs):
-    x_ref, y_ref = refs
-    x = x_ref[...]
-    x_ref[...] = (x + x) / 2
-    y_ref[...] = x_ref[...]
-    y = y_ref[...]
-    y_ref[...] = (y + y) / 2
+    k1, k2 = random.split(random.PRNGKey(0))
+    shape = data.draw(hnp.array_shapes(min_dims=spec.min_rank,
+                      max_dims=spec.max_rank, min_side=spec.min_dim,
+                      max_side=spec.max_dim))
+    x = random.normal(k1, shape)
+    t = random.normal(k2, x.shape)
+    y, y_t = jax.jvp(impl, (x,), (t,))
+    y_ref, y_ref_t = jax.jvp(ref, (x,), (t,))
+    self.assertAllClose(y, y_ref)
+    self.assertAllClose(y_t, y_ref_t)
 
-  crazy_identity_spec = FuncSpec(crazy_identity_stateful, "id")
+  @jax.legacy_prng_key('allow')
+  @hp.given(hps.data())
+  @hp.settings(deadline=None, print_blob=True,
+                max_examples=jtu.NUM_GENERATED_CASES.value)
+  def test_linearize(self, data):
 
-  def func_spec(depth: int = 4):
-    raw_specs = hps.sampled_from([sin_spec, cos_spec, mul2_spec,
-                                  mul2_constant_spec, crazy_identity_spec])
-    if depth > 0:
-      return hps.one_of([raw_specs, nest_spec(depth - 1), add_spec(depth - 1),
-                         compose_spec(depth - 1)])
-    return raw_specs
+    spec = data.draw(func_spec())
 
-  @hps.composite
-  def compose_spec(draw, depth):
-    f1 = draw(func_spec(depth))
-    f2 = draw(func_spec(depth))
-    def wrapped_impl(*args):
-      f1.fun(*args)
-      f2.fun(*args)
-    return FuncSpec(wrapped_impl,
-                    f"({f2.name} . {f1.name})",
-                    min_rank=max(f1.min_rank, f2.min_rank),
-                    max_rank=min(f1.max_rank, f2.max_rank),
-                    min_dim=max(f1.min_dim, f2.min_dim),
-                    max_dim=min(f1.max_dim, f2.max_dim))
+    def impl(x):
+      return spec.call((x, jnp.zeros_like(x)))[1]
 
-  @hps.composite
-  def nest_spec(draw, depth):
-    f = draw(func_spec(depth))
-    def wrapped_impl(refs):
-      x_ref, y_ref = refs
-      x, y = x_ref[...], y_ref[...]
-      x, y = run_state(f.fun)((x, y))
-      x_ref[...], y_ref[...] = x, y
-    return FuncSpec(wrapped_impl,
-                    f"nest({f.name})",
-                    min_rank=f.min_rank,
-                    max_rank=f.max_rank,
-                    min_dim=f.min_dim,
-                    max_dim=f.max_dim)
+    def ref(x):
+      return spec.ref((x, jnp.zeros_like(x)))[1]
 
 
-  @hps.composite
-  def add_spec(draw, depth):
-    f1 = draw(func_spec(depth))
-    f2 = draw(func_spec(depth))
-    def wrapped_impl(refs):
-      x_ref, y_ref = refs
-      x, y = x_ref[...], y_ref[...]
-      x1, y1 = run_state(f1.fun)((x, y))
-      x2, y2 = run_state(f2.fun)((x, y))
-      x_ref[...], y_ref[...] = x1 + x2, y1 + y2
-    return FuncSpec(wrapped_impl,
-                    f"({f2.name} + {f1.name})",
-                    min_rank=max(f1.min_rank, f2.min_rank),
-                    max_rank=min(f1.max_rank, f2.max_rank),
-                    min_dim=max(f1.min_dim, f2.min_dim),
-                    max_dim=min(f1.max_dim, f2.max_dim))
+    k1, k2 = random.split(random.PRNGKey(0))
+    shape = data.draw(hnp.array_shapes(min_dims=spec.min_rank,
+                      max_dims=spec.max_rank, min_side=spec.min_dim,
+                      max_side=spec.max_dim))
+    x = random.normal(k1, shape)
+    y, impl_lin = jax.linearize(impl, x)
+    y_ref, ref_lin = jax.linearize(ref, x)
+    self.assertAllClose(y, y_ref, atol=1e-2, rtol=1e-2)
+    t = random.normal(k2, x.shape)
+    self.assertAllClose(impl_lin(t), ref_lin(t), atol=1e-2, rtol=1e-2)
 
-  @jtu.thread_unsafe_test_class()  # because of hypothesis
-  class RunStateHypothesisTest(jtu.JaxTestCase):
+  @jax.legacy_prng_key('allow')
+  @hp.given(hps.data())
+  @hp.settings(deadline=None, print_blob=True,
+                max_examples=jtu.NUM_GENERATED_CASES.value)
+  def test_vjp(self, data):
 
-    @jax.legacy_prng_key('allow')
-    @hp.given(hps.data())
-    @hp.settings(deadline=None, print_blob=True,
-                 max_examples=jtu.NUM_GENERATED_CASES.value)
-    def test_jvp(self, data):
+    spec = data.draw(func_spec())
 
-      spec = data.draw(func_spec())
+    def impl(x):
+      return spec.call((x, jnp.zeros_like(x)))[1]
 
-      def impl(x):
-        return spec.call((x, jnp.zeros_like(x)))[1]
-
-      def ref(x):
-        return spec.ref((x, jnp.zeros_like(x)))[1]
-
-      k1, k2 = random.split(random.PRNGKey(0))
-      shape = data.draw(hnp.array_shapes(min_dims=spec.min_rank,
-                        max_dims=spec.max_rank, min_side=spec.min_dim,
-                        max_side=spec.max_dim))
-      x = random.normal(k1, shape)
-      t = random.normal(k2, x.shape)
-      y, y_t = jax.jvp(impl, (x,), (t,))
-      y_ref, y_ref_t = jax.jvp(ref, (x,), (t,))
-      self.assertAllClose(y, y_ref)
-      self.assertAllClose(y_t, y_ref_t)
-
-    @jax.legacy_prng_key('allow')
-    @hp.given(hps.data())
-    @hp.settings(deadline=None, print_blob=True,
-                 max_examples=jtu.NUM_GENERATED_CASES.value)
-    def test_linearize(self, data):
-
-      spec = data.draw(func_spec())
-
-      def impl(x):
-        return spec.call((x, jnp.zeros_like(x)))[1]
-
-      def ref(x):
-        return spec.ref((x, jnp.zeros_like(x)))[1]
+    def ref(x):
+      return spec.ref((x, jnp.zeros_like(x)))[1]
 
 
-      k1, k2 = random.split(random.PRNGKey(0))
-      shape = data.draw(hnp.array_shapes(min_dims=spec.min_rank,
-                        max_dims=spec.max_rank, min_side=spec.min_dim,
-                        max_side=spec.max_dim))
-      x = random.normal(k1, shape)
-      y, impl_lin = jax.linearize(impl, x)
-      y_ref, ref_lin = jax.linearize(ref, x)
-      self.assertAllClose(y, y_ref, atol=1e-2, rtol=1e-2)
-      t = random.normal(k2, x.shape)
-      self.assertAllClose(impl_lin(t), ref_lin(t), atol=1e-2, rtol=1e-2)
+    key, k1, k2 = random.split(random.PRNGKey(0), 3)
+    shape = data.draw(hnp.array_shapes(min_dims=spec.min_rank,
+                      max_dims=spec.max_rank, min_side=spec.min_dim,
+                      max_side=spec.max_dim))
+    x = random.normal(k1, shape)
 
-    @jax.legacy_prng_key('allow')
-    @hp.given(hps.data())
-    @hp.settings(deadline=None, print_blob=True,
-                 max_examples=jtu.NUM_GENERATED_CASES.value)
-    def test_vjp(self, data):
+    # First order
+    y, impl_lin = jax.linearize(impl, x)
+    y_ref, ref_lin = jax.linearize(ref, x)
+    self.assertAllClose(y, y_ref)
+    t = random.normal(k2, x.shape)
+    self.assertAllClose(impl_lin(t), ref_lin(t))
 
-      spec = data.draw(func_spec())
+    y, impl_vjp = jax.vjp(impl, x)
+    y_ref, ref_vjp = jax.vjp(ref, x)
+    self.assertAllClose(y, y_ref)
+    t = random.normal(jax.random.clone(k2), x.shape)
+    y2 = random.normal(jax.random.clone(k1), y.shape)
+    self.assertAllClose(impl_vjp(t), ref_vjp(t))
 
-      def impl(x):
-        return spec.call((x, jnp.zeros_like(x)))[1]
+    if jtu.SKIP_SLOW_TESTS.value:
+      # Skip second order tests if JAX_SKIP_SLOW_TESTS=true
+      return
 
-      def ref(x):
-        return spec.ref((x, jnp.zeros_like(x)))[1]
+    # Second order
+    key, k1, k2 = random.split(key, 3)
+    t2 = random.normal(k2, t.shape)
 
+    (x,), impl_lin2 = jax.linearize(impl_vjp, t2)
+    (x_ref,), ref_lin2 = jax.linearize(ref_vjp, t2)
+    self.assertAllClose(x, x_ref)
+    y2 = random.normal(k1, y.shape)
+    self.assertAllClose(impl_lin2(y2), ref_lin2(y2))
 
-      key, k1, k2 = random.split(random.PRNGKey(0), 3)
-      shape = data.draw(hnp.array_shapes(min_dims=spec.min_rank,
-                        max_dims=spec.max_rank, min_side=spec.min_dim,
-                        max_side=spec.max_dim))
-      x = random.normal(k1, shape)
-
-      # First order
-      y, impl_lin = jax.linearize(impl, x)
-      y_ref, ref_lin = jax.linearize(ref, x)
-      self.assertAllClose(y, y_ref)
-      t = random.normal(k2, x.shape)
-      self.assertAllClose(impl_lin(t), ref_lin(t))
-
-      y, impl_vjp = jax.vjp(impl, x)
-      y_ref, ref_vjp = jax.vjp(ref, x)
-      self.assertAllClose(y, y_ref)
-      t = random.normal(jax.random.clone(k2), x.shape)
-      y2 = random.normal(jax.random.clone(k1), y.shape)
-      self.assertAllClose(impl_vjp(t), ref_vjp(t))
-
-      if jtu.SKIP_SLOW_TESTS.value:
-        # Skip second order tests if JAX_SKIP_SLOW_TESTS=true
-        return
-
-      # Second order
-      key, k1, k2 = random.split(key, 3)
-      t2 = random.normal(k2, t.shape)
-
-      (x,), impl_lin2 = jax.linearize(impl_vjp, t2)
-      (x_ref,), ref_lin2 = jax.linearize(ref_vjp, t2)
-      self.assertAllClose(x, x_ref)
-      y2 = random.normal(k1, y.shape)
-      self.assertAllClose(impl_lin2(y2), ref_lin2(y2))
-
-      (x,), impl_vjp2 = jax.vjp(impl_vjp, t2)
-      (x_ref,), ref_vjp2 = jax.vjp(ref_vjp, t2)
-      self.assertAllClose(x, x_ref)
-      y2 = random.normal(jax.random.clone(k1), y.shape)
-      self.assertAllClose(impl_vjp2((y2,)), ref_vjp2((y2,)))
+    (x,), impl_vjp2 = jax.vjp(impl_vjp, t2)
+    (x_ref,), ref_vjp2 = jax.vjp(ref_vjp, t2)
+    self.assertAllClose(x, x_ref)
+    y2 = random.normal(jax.random.clone(k1), y.shape)
+    self.assertAllClose(impl_vjp2((y2,)), ref_vjp2((y2,)))
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Description:
- Fixed the way to skip tests using optional python dependencies
  - for example when have hypothesis or cloudpickle
- Removed try/except and CAN_USE_HYPOTHESIS for hypothesis dependency

and for cloudpickle we skip it in setUp method:
```python
    if not HAS_CLOUDPICKLE:
      self.skipTest(
        "ColocatedPythonTest depends on cloudpickle library"
      )
```