### PR TITLE
jax.random.bernoulli: fix broken sampling for 16-bit inputs

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -948,6 +948,10 @@ def bernoulli(key: ArrayLike,
     msg = "bernoulli probability `p` must have a floating dtype, got {}."
     raise TypeError(msg.format(dtype))
   p = lax.convert_element_type(p, dtype)
+  # Sample in at least float32 precision, because the method used below
+  # overflows for narrower float types.
+  if dtypes.finfo(p.dtype).bits < 32:
+    p = p.astype('float32')
   return _bernoulli(key, p, shape)
 
 @partial(jit, static_argnums=(2,))

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -467,6 +467,12 @@ class DistributionsTest(RandomTestBase):
     samples = jax.random.bernoulli(key, p=1E-10, shape=int(1E8))
     self.assertEqual(samples.sum(), 0)
 
+  def testBernoulliFloat16(self):
+    # Regression test for https://github.com/jax-ml/jax/pull/28039
+    key = jax.random.key(0)
+    samples = jax.random.bernoulli(key, np.float16(0.5), 1000)
+    self.assertLess(samples.sum(), 1000)
+
   @jtu.sample_product(
     a=[0.2, 5.],
     b=[0.2, 5.],


### PR DESCRIPTION
Followup to #28022. We need this because `np.float16(2 ** 16)` overflows.

Without this fix, bernoulli samples for `p` with dtype `float16` are always True.