### PR TITLE
[Draft] cudnn sdpa flex attention

### DIFF
--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -35,6 +35,7 @@ from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import hlo
 from jax._src.sharding_impls import NamedSharding, PartitionSpec
 from jax._src.typing import Array
+from jax._src.api import make_jaxpr, vjp
 
 import numpy as np
 
@@ -552,8 +553,8 @@ def _dot_product_attention_fwd_impl(
     else:
       B, T, N, _ = query.shape
       _, S, _, _ = key.shape
-    attn_score = jax.core.ShapedArray((B, N, T, S), jnp.float32)
-    fwd_jaxpr = jax.make_jaxpr(score_mod)(attn_score, *score_mod_args)
+    attn_score = core.ShapedArray((B, N, T, S), np.float32)
+    fwd_jaxpr = make_jaxpr(score_mod)(attn_score, *score_mod_args)
     jaxpr = (score_mod.__name__, fwd_jaxpr)
   q_seqlen, kv_seqlen, q_offsets, kv_offsets = \
       _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key)
@@ -579,14 +580,14 @@ def _dot_product_attention_bwd_impl(
       B, T, N, _ = query.shape
       _, S, _, _ = key.shape
 
-    attn_score = jax.core.ShapedArray((B, N, T, S), jnp.float32)
-    grad = jax.core.ShapedArray((B, N, T, S), jnp.float32)
+    attn_score = core.ShapedArray((B, N, T, S), np.float32)
+    grad = core.ShapedArray((B, N, T, S), np.float32)
 
     def wrapped_func(grad, *args):
-      _, grad_score_mod = jax.vjp(score_mod, *args)
+      _, grad_score_mod = vjp(score_mod, *args)
       return grad_score_mod(grad)[0]
 
-    bwd_jaxpr = jax.make_jaxpr(wrapped_func)(grad, attn_score, *score_mod_args)
+    bwd_jaxpr = make_jaxpr(wrapped_func)(grad, attn_score, *score_mod_args)
     jaxpr = (score_mod.__name__, bwd_jaxpr)
   q_seqlen, kv_seqlen, q_offsets, kv_offsets = \
       _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key)
@@ -1154,9 +1155,9 @@ _dot_product_attention_bwd_lower = custom_partitioning(
 
 def _dot_product_attention_bwd_lower_wrapper(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    activation, fwd_output, grad_output, *score_mod_args, scale, seed,
-    dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
-    score_mod):
+    page_table_k, page_table_v, activation, fwd_output, grad_output,
+    *score_mod_args, scale, seed, dropout_rate, variadic_args, mask_type,
+    layout, sliding_window_length, score_mod):
   return _dot_product_attention_bwd_lower(query, key, value, bias, q_seqlen,
     kv_seqlen, q_offsets, kv_offsets, page_table_k, page_table_v, activation,
     fwd_output, grad_output, score_mod_args, scale, seed, dropout_rate,

--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -1075,11 +1075,13 @@ _dot_product_attention_fwd_lower = custom_partitioning(
 
 def _dot_product_attention_fwd_lower_wrapper(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    *score_mod_args, scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, score_mod, is_training):
-  return _dot_product_attention_fwd_lower(query, key, value, bias, q_seqlen, kv_seqlen,
-    q_offsets, kv_offsets, score_mod_args, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, score_mod, is_training)
+    page_table_k, page_table_v, *score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length, score_mod,
+    is_training):
+  return _dot_product_attention_fwd_lower(query, key, value, bias, q_seqlen,
+    kv_seqlen, q_offsets, kv_offsets, page_table_k, page_table_v,
+    score_mod_args, scale, seed, dropout_rate, variadic_args, mask_type, layout,
+    sliding_window_length, score_mod, is_training)
 
 def _dot_product_attention_fwd_infer_sharding_from_operands(
     scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
@@ -1152,12 +1154,13 @@ _dot_product_attention_bwd_lower = custom_partitioning(
 
 def _dot_product_attention_bwd_lower_wrapper(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    activation, fwd_output, grad_output, *score_mod_args, scale, seed, dropout_rate,
-    variadic_args, mask_type, layout, sliding_window_length, score_mod):
+    activation, fwd_output, grad_output, *score_mod_args, scale, seed,
+    dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
+    score_mod):
   return _dot_product_attention_bwd_lower(query, key, value, bias, q_seqlen,
-    kv_seqlen, q_offsets, kv_offsets, activation, fwd_output, grad_output,
-    score_mod_args, scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, score_mod)
+    kv_seqlen, q_offsets, kv_offsets, page_table_k, page_table_v, activation,
+    fwd_output, grad_output, score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length, score_mod)
 
 def _dot_product_attention_bwd_infer_sharding_from_operands(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,

--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -671,7 +671,9 @@ def convert_jaxpr_to_computation(ctx, name, jaxpr, score_mod_args, is_bwd=False)
   output_aval = jaxpr.out_avals[0]
   attn_score = mlir.ir_constant(np.zeros(output_aval.shape, dtype=output_aval.dtype))
   aval_out = ctx.avals_out
+  aval_in = ctx.avals_in
   ctx.avals_out = jaxpr.out_avals
+  ctx.avals_in = jaxpr.in_avals
   if is_bwd:
     impl = mlir.core_call_lowering(
       ctx, attn_score, attn_score, *score_mod_args, name=name + "_bwd", call_jaxpr=jaxpr
@@ -681,6 +683,7 @@ def convert_jaxpr_to_computation(ctx, name, jaxpr, score_mod_args, is_bwd=False)
       ctx, attn_score, *score_mod_args, name=name, call_jaxpr=jaxpr
     )
   ctx.avals_out = aval_out
+  ctx.avals_in = aval_in
   call_op = impl[0].owner
   called_fn = call_op.attributes["callee"]
   return called_fn.value

--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -425,8 +425,8 @@ def is_cuda_compute_capability_equal(capability):
 
 def _dot_product_attention_fwd(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, modifier_args, scale, seed, dropout_rate,
-    variadic_args, mask_type, layout, sliding_window_length, attn_score_modifier,
+    page_table_k, page_table_v, score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length, score_mod,
     cudnn_version, return_residual):
   # check if flash attention is supported for this attention pattern
   check_is_flash_attention(
@@ -434,10 +434,10 @@ def _dot_product_attention_fwd(
       get_max_seg_per_batch(q_offsets) > 1, check_is_paged_attention(page_table_k))
   outputs = _dot_product_attention_fwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, *modifier_args, scale=scale, seed=seed,
+      page_table_k, page_table_v, *score_mod_args, scale=scale, seed=seed,
       dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
       layout=layout, sliding_window_length=sliding_window_length,
-      attn_score_modifier=attn_score_modifier, is_training=False or return_residual)
+      score_mod=score_mod, is_training=False or return_residual)
   if return_residual:
     return tuple(outputs)
   else:
@@ -445,21 +445,21 @@ def _dot_product_attention_fwd(
 
 def _dot_product_attention_fwd_rule(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, modifier_args, scale, seed, dropout_rate,
+    page_table_k, page_table_v, score_mod_args, scale, seed, dropout_rate,
     variadic_args, mask_type, layout, sliding_window_length,
-    attn_score_modifier, cudnn_version, return_residual):
+    score_mod, cudnn_version, return_residual):
   # check if flash attention is supported for this attention pattern
   check_is_flash_attention(
       query, key, value, layout, cudnn_version, bias is not None, True,
       get_max_seg_per_batch(q_offsets) > 1)
   outputs = _dot_product_attention_fwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, *modifier_args, scale=scale, seed=seed,
+      page_table_k, page_table_v, *score_mod_args, scale=scale, seed=seed,
       dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
       layout=layout, sliding_window_length=sliding_window_length,
-      attn_score_modifier=attn_score_modifier, is_training=True)
+      score_mod=score_mod, is_training=True)
   res = (query, key, value, bias, q_seqlen, kv_seqlen, q_offsets,
-         kv_offsets, page_table_k, page_table_v, modifier_args, outputs[1], outputs[0])
+         kv_offsets, page_table_k, page_table_v, score_mod_args, outputs[1], outputs[0])
   if return_residual:
     return tuple(outputs), res
   else:
@@ -467,18 +467,18 @@ def _dot_product_attention_fwd_rule(
 
 def _dot_product_attention_bwd_rule(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, attn_score_modifier, is_training, res, grad_output):
+    sliding_window_length, score_mod, is_training, res, grad_output):
   (query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-   page_table_k, page_table_v, activation, fwd_output) = res
+   page_table_k, page_table_v, score_mod_args, activation, fwd_output) = res
   if return_residual:
     grad_output = grad_output[0]
   grads = _dot_product_attention_bwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       page_table_k, page_table_v, activation, fwd_output, grad_output,
-      *modifier_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
+      *score_mod_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
       variadic_args=variadic_args, mask_type=mask_type, layout=layout,
       sliding_window_length=sliding_window_length,
-      attn_score_modifier=attn_score_modifier
+      score_mod=score_mod
   )
   grads = (*grads,) + (None,) * (11 - len(grads))
   return grads
@@ -539,38 +539,38 @@ def _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key):
 
 def _dot_product_attention_fwd_impl(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, modifier_args, scale, seed, dropout_rate,
+    page_table_k, page_table_v, score_mod_args, scale, seed, dropout_rate,
     variadic_args, mask_type, layout, sliding_window_length,
-    attn_score_modifier, is_training):
+    score_mod, is_training):
   # args: {Q, K, V, mask*, bias*}
   jaxpr = None
-  if attn_score_modifier is not None:
+  if score_mod is not None:
     if layout == AttentionLayout.BNTH.value:
       B, N, T, _ = query.shape
       _, _, S, _ = key.shape
     else:
       B, T, N, _ = query.shape
       _, S, _, _ = key.shape
-    attn_score = jax.core.ShapedArray((B, N, T, S), query.dtype)
-    fwd_jaxpr = jax.make_jaxpr(attn_score_modifier)(attn_score, *modifier_args)
-    jaxpr = (attn_score_modifier.__name__, fwd_jaxpr)
+    attn_score = jax.core.ShapedArray((B, N, T, S), jnp.float32)
+    fwd_jaxpr = jax.make_jaxpr(score_mod)(attn_score, *score_mod_args)
+    jaxpr = (score_mod.__name__, fwd_jaxpr)
   q_seqlen, kv_seqlen, q_offsets, kv_offsets = \
       _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key)
   outputs = _dot_product_attention_fwd_p.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, *modifier_args, scale=scale, seed=seed,
+      page_table_k, page_table_v, *score_mod_args, scale=scale, seed=seed,
       dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
       layout=layout, sliding_window_length=sliding_window_length,
-      attn_score_modifier=jaxpr, is_training=is_training)
+      score_mod=jaxpr, is_training=is_training)
   return outputs
 
 def _dot_product_attention_bwd_impl(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, activation, fwd_output, grad_output, modifier_args,
+    page_table_k, page_table_v, activation, fwd_output, grad_output, score_mod_args,
     scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
-    attn_score_modifier):
+    score_mod):
   jaxpr = None
-  if attn_score_modifier is not None:
+  if score_mod is not None:
     if layout == AttentionLayout.BNTH.value:
       B, N, T, _ = query.shape
       _, _, S, _ = key.shape
@@ -578,31 +578,31 @@ def _dot_product_attention_bwd_impl(
       B, T, N, _ = query.shape
       _, S, _, _ = key.shape
 
-    attn_score = jax.core.ShapedArray((B, N, T, S), query.dtype)
-    grad = jax.core.ShapedArray((B, N, T, S), query.dtype)
+    attn_score = jax.core.ShapedArray((B, N, T, S), jnp.float32)
+    grad = jax.core.ShapedArray((B, N, T, S), jnp.float32)
 
     def wrapped_func(grad, *args):
-      _, grad_attn_score_modifier = jax.vjp(attn_score_modifier, *args)
-      return grad_attn_score_modifier(grad)[0]
+      _, grad_score_mod = jax.vjp(score_mod, *args)
+      return grad_score_mod(grad)[0]
 
-    bwd_jaxpr = jax.make_jaxpr(wrapped_func)(grad, attn_score, *modifier_args)
-    jaxpr = (attn_score_modifier.__name__, bwd_jaxpr)
+    bwd_jaxpr = jax.make_jaxpr(wrapped_func)(grad, attn_score, *score_mod_args)
+    jaxpr = (score_mod.__name__, bwd_jaxpr)
   q_seqlen, kv_seqlen, q_offsets, kv_offsets = \
       _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key)
   grads = _dot_product_attention_bwd_p.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       page_table_k, page_table_v, activation, fwd_output, grad_output,
-      *modifier_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
+      *score_mod_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
       variadic_args=variadic_args, mask_type=mask_type, layout=layout,
       sliding_window_length=sliding_window_length,
-      attn_score_modifier=jaxpr)
+      score_mod=jaxpr)
   return grads
 
 def _dot_product_attention_fwd_abstract(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, *modifier_args, scale, seed, dropout_rate,
+    page_table_k, page_table_v, *score_mod_args, scale, seed, dropout_rate,
     variadic_args, mask_type, layout, sliding_window_length,
-    attn_score_modifier, is_training):
+    score_mod, is_training):
   query_dtype = dtypes.canonicalize_dtype(query.dtype)
   if layout == AttentionLayout.BNTH.value:
     B, N, T, _ = query.shape
@@ -629,8 +629,8 @@ def _dot_product_attention_fwd_abstract(
 def _dot_product_attention_bwd_abstract(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
     page_table_k, page_table_v, activation, fwd_output, grad_output,
-    *modifier_args, scale, seed, dropout_rate, variadic_args, mask_type,
-    layout, sliding_window_length, attn_score_modifier):
+    *score_mod_args, scale, seed, dropout_rate, variadic_args, mask_type,
+    layout, sliding_window_length, score_mod):
   query_dtype = dtypes.canonicalize_dtype(query.dtype)
   key_dtype = dtypes.canonicalize_dtype(key.dtype)
   value_dtype = dtypes.canonicalize_dtype(value.dtype)
@@ -665,18 +665,18 @@ def _dot_product_attention_bwd_abstract(
       ),  # grad value
     )
 
-def convert_jaxpr_to_computation(ctx, name, jaxpr, modifier_args, is_bwd=False):
+def convert_jaxpr_to_computation(ctx, name, jaxpr, score_mod_args, is_bwd=False):
   output_aval = jaxpr.out_avals[0]
   attn_score = mlir.ir_constant(np.zeros(output_aval.shape, dtype=output_aval.dtype))
   aval_out = ctx.avals_out
   ctx.avals_out = jaxpr.out_avals
   if is_bwd:
     impl = mlir.core_call_lowering(
-      ctx, attn_score, attn_score, *modifier_args, name=name + "_bwd", call_jaxpr=jaxpr
+      ctx, attn_score, attn_score, *score_mod_args, name=name + "_bwd", call_jaxpr=jaxpr
     )
   else:
     impl = mlir.core_call_lowering(
-      ctx, attn_score, *modifier_args, name=name, call_jaxpr=jaxpr
+      ctx, attn_score, *score_mod_args, name=name, call_jaxpr=jaxpr
     )
   ctx.avals_out = aval_out
   call_op = impl[0].owner
@@ -685,9 +685,9 @@ def convert_jaxpr_to_computation(ctx, name, jaxpr, modifier_args, is_bwd=False):
 
 def _dot_product_attention_fwd_cuda_lowering(
     ctx, query, key, value, bias, q_seqlen, kv_seqlen, q_offsets,
-    kv_offsets, page_table_k, page_table_v, *modifier_args, scale, seed,
+    kv_offsets, page_table_k, page_table_v, *score_mod_args, scale, seed,
     dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
-    attn_score_modifier, is_training):
+    score_mod, is_training):
   query_type = ir.RankedTensorType(query.type)
   query_shape = query_type.shape
   value_type = ir.RankedTensorType(value.type)
@@ -717,7 +717,7 @@ def _dot_product_attention_fwd_cuda_lowering(
       B, N, T, S, query_type.element_type, scale, seed, dropout_rate,
       mask_type, layout, sliding_window_length, max_seg_per_batch,
       is_paged_attention, is_bwd=False)
-  # {Q, K, V, bias*, q_seqlen*, kv_seqlen*,  q_offsets*, kv_offsets*}}
+  # {Q, K, V, bias*, q_seqlen*, kv_seqlen*, q_offsets*, kv_offsets*, score_mod_args*}
   # {output, activation*, workspace}
   has_dropout = dropout_rate > 0
   operands = [query, key, value]
@@ -733,10 +733,10 @@ def _dot_product_attention_fwd_cuda_lowering(
     operands.append(page_table_k)
     operands.append(page_table_v)
 
-  if attn_score_modifier is not None:
-    operands += modifier_args
-    name, call_jaxpr = attn_score_modifier
-    called_fn = convert_jaxpr_to_computation(ctx, name, call_jaxpr, modifier_args)
+  if score_mod is not None:
+    operands += score_mod_args
+    name, call_jaxpr = score_mod
+    called_fn = convert_jaxpr_to_computation(ctx, name, call_jaxpr, score_mod_args)
     called_computations = [called_fn]
   else:
     called_computations = []
@@ -775,9 +775,9 @@ def _dot_product_attention_fwd_cuda_lowering(
 
 def _dot_product_attention_bwd_cuda_lowering(
     ctx, query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, activation, fwd_output, grad_output, *modifier_args,
+    page_table_k, page_table_v, activation, fwd_output, grad_output, *score_mod_args,
     scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
-    attn_score_modifier):
+    score_mod):
   query_type = ir.RankedTensorType(query.type)
   query_shape = query_type.shape
   key_type = ir.RankedTensorType(key.type)
@@ -809,7 +809,7 @@ def _dot_product_attention_bwd_cuda_lowering(
       mask_type, layout, sliding_window_length, max_seg_per_batch,
       False, is_bwd=True)
   # {Q, K, V, activation, dO, bias*, O, q_seqlen*, kv_seqlen*,
-  #  q_offsets*, kv_offsets*, modifier_args*}
+  #  q_offsets*, kv_offsets*, score_mod_args*}
   # {dQ, dK, dV, dbias*, workspace}
   has_dropout = dropout_rate > 0
   # create operands
@@ -825,10 +825,10 @@ def _dot_product_attention_bwd_cuda_lowering(
     operands.append(q_offsets)
     operands.append(kv_offsets)
 
-  if attn_score_modifier is not None:
-    operands += modifier_args
-    name, bwd_jaxpr = attn_score_modifier
-    bwd_called_fn = convert_jaxpr_to_computation(ctx, name, bwd_jaxpr, modifier_args, True)
+  if score_mod is not None:
+    operands += score_mod_args
+    name, bwd_jaxpr = score_mod
+    bwd_called_fn = convert_jaxpr_to_computation(ctx, name, bwd_jaxpr, score_mod_args, True)
     called_computations = [bwd_called_fn]
   else:
     called_computations = []
@@ -881,10 +881,10 @@ def _check_valid_batch_dims(bdims):
 
 def _dot_product_attention_fwd_batcher(
     batched_args, batch_dims, *, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, attn_score_modifier, is_training):
+    mask_type, layout, sliding_window_length, score_mod, is_training):
   _check_valid_batch_dims(batch_dims)
   query, key, value, bias, q_seqlen, kv_seqlen, \
-    q_offsets, kv_offsets, page_table_k, page_table_v, modifier_args = batched_args
+    q_offsets, kv_offsets, page_table_k, page_table_v, score_mod_args = batched_args
   query_bdim = batch_dims[0]
   if is_training:
     out_bdims = query_bdim, query_bdim
@@ -912,10 +912,10 @@ def _dot_product_attention_fwd_batcher(
 
   outputs = _dot_product_attention_fwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, *modifier_args, scale=scale, seed=seed,
+      page_table_k, page_table_v, *score_mod_args, scale=scale, seed=seed,
       dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
       layout=layout, sliding_window_length=sliding_window_length,
-      attn_score_modifier=attn_score_modifier, is_training=is_training)
+      score_mod=score_mod, is_training=is_training)
 
   # reshape to original shape
   output = outputs[0]
@@ -929,10 +929,10 @@ def _dot_product_attention_fwd_batcher(
 
 def _dot_product_attention_bwd_batcher(
      batched_args, batch_dims, *, scale, seed, dropout_rate, variadic_args,
-     mask_type, layout, sliding_window_length, attn_score_modifier):
+     mask_type, layout, sliding_window_length, score_mod):
   _check_valid_batch_dims(batch_dims)
   query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets, \
-    page_table_k, page_table_v, modifier_args, activation, fwd_output, grad_output = batched_args
+    page_table_k, page_table_v, score_mod_args, activation, fwd_output, grad_output = batched_args
   query_bdim = batch_dims[0]
   out_bdims = query_bdim, query_bdim, query_bdim
 
@@ -965,10 +965,10 @@ def _dot_product_attention_bwd_batcher(
   grads = _dot_product_attention_bwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       page_table_k, page_table_v, activation, fwd_output, grad_output,
-      *modifier_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
+      *score_mod_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
       variadic_args=variadic_args, mask_type=mask_type, layout=layout,
       sliding_window_length=sliding_window_length,
-      attn_score_modifier=attn_score_modifier,
+      score_mod=score_mod,
   )
 
   # reshape to original shape
@@ -1074,15 +1074,15 @@ _dot_product_attention_fwd_lower = custom_partitioning(
 
 def _dot_product_attention_fwd_lower_wrapper(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    *modifier_args, scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, attn_score_modifier, is_training):
+    *score_mod_args, scale, seed, dropout_rate, variadic_args, mask_type, layout,
+    sliding_window_length, score_mod, is_training):
   return _dot_product_attention_fwd_lower(query, key, value, bias, q_seqlen, kv_seqlen,
-    q_offsets, kv_offsets, modifier_args, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, attn_score_modifier, is_training)
+    q_offsets, kv_offsets, score_mod_args, scale, seed, dropout_rate, variadic_args,
+    mask_type, layout, sliding_window_length, score_mod, is_training)
 
 def _dot_product_attention_fwd_infer_sharding_from_operands(
     scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
-    attn_score_modifier, is_training, mesh, arg_shapes, result_shape):
+    score_mod, is_training, mesh, arg_shapes, result_shape):
   return _infer_fwd_output_sharding(mesh, arg_shapes, variadic_args, is_training, layout)
 
 def _dot_product_attention_fwd_shardy_rule(
@@ -1092,7 +1092,7 @@ def _dot_product_attention_fwd_shardy_rule(
 
 def _dot_product_attention_fwd_partition(
     scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
-    attn_score_modifier, is_training, mesh, arg_shapes, result_shape):
+    score_mod, is_training, mesh, arg_shapes, result_shape):
   # args sharding
   arg_shardings = tuple(arg_i.sharding for arg_i in arg_shapes)
   out_shardings = _infer_fwd_output_sharding(
@@ -1106,7 +1106,7 @@ def _dot_product_attention_fwd_partition(
       mask_type=mask_type,
       layout=layout,
       sliding_window_length=sliding_window_length,
-      attn_score_modifier=attn_score_modifier,
+      score_mod=score_mod,
       is_training=is_training,
   )
   return mesh, impl, out_shardings, arg_shardings
@@ -1151,16 +1151,16 @@ _dot_product_attention_bwd_lower = custom_partitioning(
 
 def _dot_product_attention_bwd_lower_wrapper(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    activation, fwd_output, grad_output, *modifier_args, scale, seed, dropout_rate,
-    variadic_args, mask_type, layout, sliding_window_length, attn_score_modifier):
+    activation, fwd_output, grad_output, *score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length, score_mod):
   return _dot_product_attention_bwd_lower(query, key, value, bias, q_seqlen,
     kv_seqlen, q_offsets, kv_offsets, activation, fwd_output, grad_output,
-    modifier_args, scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, attn_score_modifier)
+    score_mod_args, scale, seed, dropout_rate, variadic_args, mask_type, layout,
+    sliding_window_length, score_mod)
 
 def _dot_product_attention_bwd_infer_sharding_from_operands(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, attn_score_modifier, mesh, arg_shapes, result_shape):
+    sliding_window_length, score_mod, mesh, arg_shapes, result_shape):
   return _infer_bwd_output_sharding(mesh, arg_shapes, layout, variadic_args)
 
 def _dot_product_attention_bwd_shardy_rule(
@@ -1171,7 +1171,7 @@ def _dot_product_attention_bwd_shardy_rule(
 
 def _dot_product_attention_bwd_partition(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, attn_score_modifier, mesh, arg_shapes, result_shape):
+    sliding_window_length, score_mod, mesh, arg_shapes, result_shape):
   out_shardings = _infer_bwd_output_sharding(mesh, arg_shapes, layout, variadic_args)
   # args sharding
   arg_shardings = [arg_i.sharding for arg_i in arg_shapes]
@@ -1197,7 +1197,7 @@ def _dot_product_attention_bwd_partition(
       mask_type=mask_type,
       layout=layout,
       sliding_window_length=sliding_window_length,
-      attn_score_modifier=attn_score_modifier,
+      score_mod=score_mod,
     )
     grads = impl(*args)
     _, has_dbias = variadic_args
@@ -1318,7 +1318,7 @@ def _dot_product_attention(query: Array,
                            kv_offsets: Array,
                            page_table_k: Array,
                            page_table_v: Array,
-                           modifier_args: Tuple[Array] | None,
+                           score_mod_args: Tuple[Array] | None,
                            scale: float,
                            seed: int,
                            dropout_rate: float,
@@ -1326,15 +1326,15 @@ def _dot_product_attention(query: Array,
                            mask_type: bool,
                            layout: int,
                            sliding_window_length: int | None,
-                           attn_score_modifier,
+                           score_mod,
                            cudnn_version: int,
                            return_residual: bool):
   output = _dot_product_attention_fwd(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, modifier_args, scale=scale, seed=seed,
+      page_table_k, page_table_v, score_mod_args, scale=scale, seed=seed,
       dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
       layout=layout, sliding_window_length=sliding_window_length,
-      attn_score_modifier=attn_score_modifier, cudnn_version=cudnn_version,
+      score_mod=score_mod, cudnn_version=cudnn_version,
       return_residual=return_residual)
   return output
 
@@ -2045,7 +2045,7 @@ def dot_product_attention(
     q_offsets: Array | None = None,
     kv_offsets: Array | None = None,
     fp8_params: FP8Params | None = None,
-    modifier_args: Tuple[Array] = (),
+    score_mod_args: Tuple[Array] = (),
     *,
     scale: float = 1.0,
     mask_type: MaskType = MaskType.NO_MASK,
@@ -2053,7 +2053,7 @@ def dot_product_attention(
     dropout_rate: float = 0.,
     qkv_layout: str = "BTNH",
     sliding_window_length: int | None = None,
-    attn_score_modifier: Callable[[Array], Array] | None = None,
+    score_mod: Callable[[Array], Array] | None = None,
     use_fp8: bool = False,
     return_residual: bool = False
 ):
@@ -2155,11 +2155,11 @@ def dot_product_attention(
     bias = combine_bias_and_mask(bias, mask, query.dtype)
 
     # check if the number of arg matches
-    if attn_score_modifier is not None:
-      num_args_required = len(inspect.signature(attn_score_modifier).parameters) -1
-      if num_args_required != len(modifier_args):
+    if score_mod is not None:
+      num_args_required = len(inspect.signature(score_mod).parameters) -1
+      if num_args_required != len(score_mod_args):
         raise ValueError(
-          f"attn_score_modifier requires {num_args_required} arguments, got {len(modifier_args)}.")
+          f"score_mod requires {num_args_required} arguments, got {len(score_mod_args)}.")
 
     # check if input shape and data type is compatiable
     check_layout(query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
@@ -2183,7 +2183,7 @@ def dot_product_attention(
 
     output = _dot_product_attention(
         query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-        _not_used, _not_used, modifier_args, scale, seed, dropout_rate, variadic_args,
-        mask_type, layout.value, sliding_window_length, attn_score_modifier,
+        _not_used, _not_used, score_mod_args, scale, seed, dropout_rate, variadic_args,
+        mask_type, layout.value, sliding_window_length, score_mod,
         cudnn_version, return_residual)
     return output

--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -467,7 +467,8 @@ def _dot_product_attention_fwd_rule(
 
 def _dot_product_attention_bwd_rule(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, score_mod, is_training, res, grad_output):
+    sliding_window_length, score_mod, cudnn_version, return_residual, res,
+    grad_output):
   (query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
    page_table_k, page_table_v, score_mod_args, activation, fwd_output) = res
   if return_residual:

--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -16,7 +16,8 @@ import enum
 import functools
 import json
 import math
-from typing import TypedDict
+import inspect
+from typing import TypedDict, Callable, Tuple
 
 from jax._src import core
 from jax._src import custom_derivatives
@@ -69,7 +70,6 @@ class MaskType(enum.Enum):
   CAUSAL = 2
   PADDING_CAUSAL = 3
   ALIBI = 4
-
 
 def convert_mask_type_to_string(mask_type: MaskType) -> str:
   if mask_type == MaskType.NO_MASK:
@@ -425,18 +425,19 @@ def is_cuda_compute_capability_equal(capability):
 
 def _dot_product_attention_fwd(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v,
-    scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, cudnn_version, return_residual):
+    page_table_k, page_table_v, modifier_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length, attn_score_modifier,
+    cudnn_version, return_residual):
   # check if flash attention is supported for this attention pattern
   check_is_flash_attention(
       query, key, value, layout, cudnn_version, bias is not None, False,
       get_max_seg_per_batch(q_offsets) > 1, check_is_paged_attention(page_table_k))
   outputs = _dot_product_attention_fwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length, is_training=False or return_residual)
+      page_table_k, page_table_v, *modifier_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      attn_score_modifier=attn_score_modifier, is_training=False or return_residual)
   if return_residual:
     return tuple(outputs)
   else:
@@ -444,20 +445,21 @@ def _dot_product_attention_fwd(
 
 def _dot_product_attention_fwd_rule(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, cudnn_version,
-    return_residual):
+    page_table_k, page_table_v, modifier_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length,
+    attn_score_modifier, cudnn_version, return_residual):
   # check if flash attention is supported for this attention pattern
   check_is_flash_attention(
       query, key, value, layout, cudnn_version, bias is not None, True,
       get_max_seg_per_batch(q_offsets) > 1)
   outputs = _dot_product_attention_fwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length, is_training=True)
+      page_table_k, page_table_v, *modifier_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      attn_score_modifier=attn_score_modifier, is_training=True)
   res = (query, key, value, bias, q_seqlen, kv_seqlen, q_offsets,
-         kv_offsets, page_table_k, page_table_v, outputs[1], outputs[0])
+         kv_offsets, page_table_k, page_table_v, modifier_args, outputs[1], outputs[0])
   if return_residual:
     return tuple(outputs), res
   else:
@@ -465,7 +467,7 @@ def _dot_product_attention_fwd_rule(
 
 def _dot_product_attention_bwd_rule(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, is_training, return_residual, res, grad_output):
+    sliding_window_length, attn_score_modifier, is_training, res, grad_output):
   (query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
    page_table_k, page_table_v, activation, fwd_output) = res
   if return_residual:
@@ -473,11 +475,12 @@ def _dot_product_attention_bwd_rule(
   grads = _dot_product_attention_bwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       page_table_k, page_table_v, activation, fwd_output, grad_output,
-      scale=scale, seed=seed, dropout_rate=dropout_rate, variadic_args=variadic_args,
-      mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length
+      *modifier_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
+      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
+      sliding_window_length=sliding_window_length,
+      attn_score_modifier=attn_score_modifier
   )
-  grads = (*grads,) + (None,) * (10 - len(grads))
+  grads = (*grads,) + (None,) * (11 - len(grads))
   return grads
 
 def _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key):
@@ -536,37 +539,71 @@ def _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key):
 
 def _dot_product_attention_fwd_impl(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, is_training):
+    page_table_k, page_table_v, modifier_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length,
+    attn_score_modifier, is_training):
   # args: {Q, K, V, mask*, bias*}
+  jaxpr = None
+  if attn_score_modifier is not None:
+    if layout == AttentionLayout.BNTH.value:
+      B, N, T, _ = query.shape
+      _, _, S, _ = key.shape
+    else:
+      B, T, N, _ = query.shape
+      _, S, _, _ = key.shape
+    attn_score = jax.core.ShapedArray((B, N, T, S), query.dtype)
+    fwd_jaxpr = jax.make_jaxpr(attn_score_modifier)(attn_score, *modifier_args)
+    jaxpr = (attn_score_modifier.__name__, fwd_jaxpr)
   q_seqlen, kv_seqlen, q_offsets, kv_offsets = \
       _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key)
   outputs = _dot_product_attention_fwd_p.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length, is_training=is_training)
+      page_table_k, page_table_v, *modifier_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      attn_score_modifier=jaxpr, is_training=is_training)
   return outputs
 
 def _dot_product_attention_bwd_impl(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, activation, fwd_output, grad_output, scale,
-    seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length):
+    page_table_k, page_table_v, activation, fwd_output, grad_output, modifier_args,
+    scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
+    attn_score_modifier):
+  jaxpr = None
+  if attn_score_modifier is not None:
+    if layout == AttentionLayout.BNTH.value:
+      B, N, T, _ = query.shape
+      _, _, S, _ = key.shape
+    else:
+      B, T, N, _ = query.shape
+      _, S, _, _ = key.shape
+
+    attn_score = jax.core.ShapedArray((B, N, T, S), query.dtype)
+    grad = jax.core.ShapedArray((B, N, T, S), query.dtype)
+
+    def wrapped_func(grad, *args):
+      _, grad_attn_score_modifier = jax.vjp(attn_score_modifier, *args)
+      return grad_attn_score_modifier(grad)[0]
+
+    bwd_jaxpr = jax.make_jaxpr(wrapped_func)(grad, attn_score, *modifier_args)
+    jaxpr = (attn_score_modifier.__name__, bwd_jaxpr)
   q_seqlen, kv_seqlen, q_offsets, kv_offsets = \
       _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key)
   grads = _dot_product_attention_bwd_p.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       page_table_k, page_table_v, activation, fwd_output, grad_output,
-      scale=scale, seed=seed,
-      dropout_rate=dropout_rate, variadic_args=variadic_args,
-      mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length)
+      *modifier_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
+      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
+      sliding_window_length=sliding_window_length,
+      attn_score_modifier=jaxpr)
   return grads
 
 def _dot_product_attention_fwd_abstract(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, *, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, is_training):
+    page_table_k, page_table_v, *modifier_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length,
+    attn_score_modifier, is_training):
+  query_dtype = dtypes.canonicalize_dtype(query.dtype)
   if layout == AttentionLayout.BNTH.value:
     B, N, T, _ = query.shape
     _, _, S, H = value.shape
@@ -591,8 +628,13 @@ def _dot_product_attention_fwd_abstract(
 
 def _dot_product_attention_bwd_abstract(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, activation, fwd_output, grad_output, *,
-    scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length):
+    page_table_k, page_table_v, activation, fwd_output, grad_output,
+    *modifier_args, scale, seed, dropout_rate, variadic_args, mask_type,
+    layout, sliding_window_length, attn_score_modifier):
+  query_dtype = dtypes.canonicalize_dtype(query.dtype)
+  key_dtype = dtypes.canonicalize_dtype(key.dtype)
+  value_dtype = dtypes.canonicalize_dtype(value.dtype)
+
   _, has_dbias = variadic_args
   if has_dbias:
     # cuDNN supports bias for this case
@@ -623,10 +665,29 @@ def _dot_product_attention_bwd_abstract(
       ),  # grad value
     )
 
+def convert_jaxpr_to_computation(ctx, name, jaxpr, modifier_args, is_bwd=False):
+  output_aval = jaxpr.out_avals[0]
+  attn_score = mlir.ir_constant(np.zeros(output_aval.shape, dtype=output_aval.dtype))
+  aval_out = ctx.avals_out
+  ctx.avals_out = jaxpr.out_avals
+  if is_bwd:
+    impl = mlir.core_call_lowering(
+      ctx, attn_score, attn_score, *modifier_args, name=name + "_bwd", call_jaxpr=jaxpr
+    )
+  else:
+    impl = mlir.core_call_lowering(
+      ctx, attn_score, *modifier_args, name=name, call_jaxpr=jaxpr
+    )
+  ctx.avals_out = aval_out
+  call_op = impl[0].owner
+  called_fn = call_op.attributes["callee"]
+  return called_fn.value
+
 def _dot_product_attention_fwd_cuda_lowering(
     ctx, query, key, value, bias, q_seqlen, kv_seqlen, q_offsets,
-    kv_offsets, page_table_k, page_table_v, scale, seed, dropout_rate,
-    variadic_args, mask_type, layout, sliding_window_length, is_training):
+    kv_offsets, page_table_k, page_table_v, *modifier_args, scale, seed,
+    dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
+    attn_score_modifier, is_training):
   query_type = ir.RankedTensorType(query.type)
   query_shape = query_type.shape
   value_type = ir.RankedTensorType(value.type)
@@ -672,6 +733,13 @@ def _dot_product_attention_fwd_cuda_lowering(
     operands.append(page_table_k)
     operands.append(page_table_v)
 
+  if attn_score_modifier is not None:
+    operands += modifier_args
+    name, call_jaxpr = attn_score_modifier
+    called_fn = convert_jaxpr_to_computation(ctx, name, call_jaxpr, modifier_args)
+    called_computations = [called_fn]
+  else:
+    called_computations = []
   custom_call_name = get_custom_call_name(has_bias, has_dropout, False)
 
   if is_training:
@@ -696,6 +764,7 @@ def _dot_product_attention_fwd_cuda_lowering(
     operand_layouts=default_layouts(
       *[ir.RankedTensorType(operand.type).shape for operand in operands]),
     result_layouts=result_layouts,
+    called_computations=called_computations,
   )
   # drop workspace memory
   # output should be (B, T, N, H) instead of (B, N, T, H)
@@ -706,8 +775,9 @@ def _dot_product_attention_fwd_cuda_lowering(
 
 def _dot_product_attention_bwd_cuda_lowering(
     ctx, query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, activation, fwd_output, grad_output,
-    scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length):
+    page_table_k, page_table_v, activation, fwd_output, grad_output, *modifier_args,
+    scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
+    attn_score_modifier):
   query_type = ir.RankedTensorType(query.type)
   query_shape = query_type.shape
   key_type = ir.RankedTensorType(key.type)
@@ -739,7 +809,7 @@ def _dot_product_attention_bwd_cuda_lowering(
       mask_type, layout, sliding_window_length, max_seg_per_batch,
       False, is_bwd=True)
   # {Q, K, V, activation, dO, bias*, O, q_seqlen*, kv_seqlen*,
-  #  q_offsets*, kv_offsets*}
+  #  q_offsets*, kv_offsets*, modifier_args*}
   # {dQ, dK, dV, dbias*, workspace}
   has_dropout = dropout_rate > 0
   # create operands
@@ -754,6 +824,14 @@ def _dot_product_attention_bwd_cuda_lowering(
   if max_seg_per_batch > 1:
     operands.append(q_offsets)
     operands.append(kv_offsets)
+
+  if attn_score_modifier is not None:
+    operands += modifier_args
+    name, bwd_jaxpr = attn_score_modifier
+    bwd_called_fn = convert_jaxpr_to_computation(ctx, name, bwd_jaxpr, modifier_args, True)
+    called_computations = [bwd_called_fn]
+  else:
+    called_computations = []
   # get custom call name
   custom_call_name = get_custom_call_name(has_bias, has_dropout, True)
 
@@ -783,6 +861,7 @@ def _dot_product_attention_bwd_cuda_lowering(
     operand_layouts=default_layouts(
       *[ir.RankedTensorType(operand.type).shape for operand in operands]),
     result_layouts=result_layouts,
+    called_computations=called_computations,
   )
   dqkv = (hlo.transpose(out.results[0], grad_transpose_perm),
           hlo.transpose(out.results[1], grad_transpose_perm),
@@ -802,10 +881,10 @@ def _check_valid_batch_dims(bdims):
 
 def _dot_product_attention_fwd_batcher(
     batched_args, batch_dims, *, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, is_training):
+    mask_type, layout, sliding_window_length, attn_score_modifier, is_training):
   _check_valid_batch_dims(batch_dims)
   query, key, value, bias, q_seqlen, kv_seqlen, \
-    q_offsets, kv_offsets, page_table_k, page_table_v = batched_args
+    q_offsets, kv_offsets, page_table_k, page_table_v, modifier_args = batched_args
   query_bdim = batch_dims[0]
   if is_training:
     out_bdims = query_bdim, query_bdim
@@ -833,9 +912,10 @@ def _dot_product_attention_fwd_batcher(
 
   outputs = _dot_product_attention_fwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length, is_training=is_training)
+      page_table_k, page_table_v, *modifier_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      attn_score_modifier=attn_score_modifier, is_training=is_training)
 
   # reshape to original shape
   output = outputs[0]
@@ -849,10 +929,10 @@ def _dot_product_attention_fwd_batcher(
 
 def _dot_product_attention_bwd_batcher(
      batched_args, batch_dims, *, scale, seed, dropout_rate, variadic_args,
-     mask_type, layout, sliding_window_length):
+     mask_type, layout, sliding_window_length, attn_score_modifier):
   _check_valid_batch_dims(batch_dims)
   query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets, \
-    page_table_k, page_table_v, activation, fwd_output, grad_output = batched_args
+    page_table_k, page_table_v, modifier_args, activation, fwd_output, grad_output = batched_args
   query_bdim = batch_dims[0]
   out_bdims = query_bdim, query_bdim, query_bdim
 
@@ -885,9 +965,10 @@ def _dot_product_attention_bwd_batcher(
   grads = _dot_product_attention_bwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       page_table_k, page_table_v, activation, fwd_output, grad_output,
-      scale=scale, seed=seed, dropout_rate=dropout_rate, variadic_args=variadic_args,
-      mask_type=mask_type, layout=layout,
+      *modifier_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
+      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
       sliding_window_length=sliding_window_length,
+      attn_score_modifier=attn_score_modifier,
   )
 
   # reshape to original shape
@@ -989,11 +1070,19 @@ def _fwd_shardy_rule(value_types, result_types, layout, is_training, is_fp8):
   return SdyShardingRule(tuple(input_sharding), output_sharding, **factor_sizes)
 
 _dot_product_attention_fwd_lower = custom_partitioning(
-    _dot_product_attention_fwd_impl, static_argnums=(10, 11, 12, 13, 14, 15, 16, 17))
+    _dot_product_attention_fwd_impl, static_argnums=(11, 12, 13, 14, 15, 16, 17, 18, 19))
+
+def _dot_product_attention_fwd_lower_wrapper(
+    query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
+    *modifier_args, scale, seed, dropout_rate, variadic_args, mask_type, layout,
+    sliding_window_length, attn_score_modifier, is_training):
+  return _dot_product_attention_fwd_lower(query, key, value, bias, q_seqlen, kv_seqlen,
+    q_offsets, kv_offsets, modifier_args, scale, seed, dropout_rate, variadic_args,
+    mask_type, layout, sliding_window_length, attn_score_modifier, is_training)
 
 def _dot_product_attention_fwd_infer_sharding_from_operands(
     scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
-    is_training, mesh, arg_shapes, result_shape):
+    attn_score_modifier, is_training, mesh, arg_shapes, result_shape):
   return _infer_fwd_output_sharding(mesh, arg_shapes, variadic_args, is_training, layout)
 
 def _dot_product_attention_fwd_shardy_rule(
@@ -1003,7 +1092,7 @@ def _dot_product_attention_fwd_shardy_rule(
 
 def _dot_product_attention_fwd_partition(
     scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
-    is_training, mesh, arg_shapes, result_shape):
+    attn_score_modifier, is_training, mesh, arg_shapes, result_shape):
   # args sharding
   arg_shardings = tuple(arg_i.sharding for arg_i in arg_shapes)
   out_shardings = _infer_fwd_output_sharding(
@@ -1017,6 +1106,7 @@ def _dot_product_attention_fwd_partition(
       mask_type=mask_type,
       layout=layout,
       sliding_window_length=sliding_window_length,
+      attn_score_modifier=attn_score_modifier,
       is_training=is_training,
   )
   return mesh, impl, out_shardings, arg_shardings
@@ -1056,12 +1146,21 @@ def _bwd_shardy_rule(num_args, has_dbias, is_fp8):
   return SdyShardingRule(input_sharding, output_sharding)
 
 _dot_product_attention_bwd_lower = custom_partitioning(
-    _dot_product_attention_bwd_impl, static_argnums=(13, 14, 15, 16, 17, 18, 19)
+    _dot_product_attention_bwd_impl, static_argnums=(14, 15, 16, 17, 18, 19, 20, 21)
 )
+
+def _dot_product_attention_bwd_lower_wrapper(
+    query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
+    activation, fwd_output, grad_output, *modifier_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length, attn_score_modifier):
+  return _dot_product_attention_bwd_lower(query, key, value, bias, q_seqlen,
+    kv_seqlen, q_offsets, kv_offsets, activation, fwd_output, grad_output,
+    modifier_args, scale, seed, dropout_rate, variadic_args, mask_type, layout,
+    sliding_window_length, attn_score_modifier)
 
 def _dot_product_attention_bwd_infer_sharding_from_operands(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, mesh, arg_shapes, result_shape):
+    sliding_window_length, attn_score_modifier, mesh, arg_shapes, result_shape):
   return _infer_bwd_output_sharding(mesh, arg_shapes, layout, variadic_args)
 
 def _dot_product_attention_bwd_shardy_rule(
@@ -1072,7 +1171,7 @@ def _dot_product_attention_bwd_shardy_rule(
 
 def _dot_product_attention_bwd_partition(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, mesh, arg_shapes, result_shape):
+    sliding_window_length, attn_score_modifier, mesh, arg_shapes, result_shape):
   out_shardings = _infer_bwd_output_sharding(mesh, arg_shapes, layout, variadic_args)
   # args sharding
   arg_shardings = [arg_i.sharding for arg_i in arg_shapes]
@@ -1098,6 +1197,7 @@ def _dot_product_attention_bwd_partition(
       mask_type=mask_type,
       layout=layout,
       sliding_window_length=sliding_window_length,
+      attn_score_modifier=attn_score_modifier,
     )
     grads = impl(*args)
     _, has_dbias = variadic_args
@@ -1184,7 +1284,7 @@ _dot_product_attention_fwd_lower.def_partition(
   sharding_rule=_dot_product_attention_fwd_shardy_rule)
 
 mlir.register_lowering(_dot_product_attention_fwd_p_wrapper,
-                        mlir.lower_fun(_dot_product_attention_fwd_lower, multiple_results=True))
+                        mlir.lower_fun(_dot_product_attention_fwd_lower_wrapper, multiple_results=True))
 
 _dot_product_attention_bwd_lower.def_partition(
   infer_sharding_from_operands=_dot_product_attention_bwd_infer_sharding_from_operands,
@@ -1192,7 +1292,7 @@ _dot_product_attention_bwd_lower.def_partition(
   sharding_rule=_dot_product_attention_bwd_shardy_rule)
 
 mlir.register_lowering(_dot_product_attention_bwd_p_wrapper,
-                        mlir.lower_fun(_dot_product_attention_bwd_lower, multiple_results=True))
+                        mlir.lower_fun(_dot_product_attention_bwd_lower_wrapper, multiple_results=True))
 
 dispatch.prim_requires_devices_during_lowering.add(
   _dot_product_attention_fwd_p
@@ -1207,7 +1307,7 @@ dispatch.prim_requires_devices_during_lowering.add(
   _dot_product_attention_bwd_p_wrapper
 )
 
-@functools.partial(custom_derivatives.custom_vjp, nondiff_argnums=(10, 11, 12, 13, 14, 15, 16, 17, 18))
+@functools.partial(custom_derivatives.custom_vjp, nondiff_argnums=(11, 12, 13, 14, 15, 16, 17, 18, 19, 20))
 def _dot_product_attention(query: Array,
                            key: Array,
                            value: Array,
@@ -1218,6 +1318,7 @@ def _dot_product_attention(query: Array,
                            kv_offsets: Array,
                            page_table_k: Array,
                            page_table_v: Array,
+                           modifier_args: Tuple[Array] | None,
                            scale: float,
                            seed: int,
                            dropout_rate: float,
@@ -1225,14 +1326,16 @@ def _dot_product_attention(query: Array,
                            mask_type: bool,
                            layout: int,
                            sliding_window_length: int | None,
+                           attn_score_modifier,
                            cudnn_version: int,
                            return_residual: bool):
   output = _dot_product_attention_fwd(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length,
-      cudnn_version=cudnn_version, return_residual=return_residual)
+      page_table_k, page_table_v, modifier_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      attn_score_modifier=attn_score_modifier, cudnn_version=cudnn_version,
+      return_residual=return_residual)
   return output
 
 _dot_product_attention.defvjp(
@@ -1942,6 +2045,7 @@ def dot_product_attention(
     q_offsets: Array | None = None,
     kv_offsets: Array | None = None,
     fp8_params: FP8Params | None = None,
+    modifier_args: Tuple[Array] = (),
     *,
     scale: float = 1.0,
     mask_type: MaskType = MaskType.NO_MASK,
@@ -1949,6 +2053,7 @@ def dot_product_attention(
     dropout_rate: float = 0.,
     qkv_layout: str = "BTNH",
     sliding_window_length: int | None = None,
+    attn_score_modifier: Callable[[Array], Array] | None = None,
     use_fp8: bool = False,
     return_residual: bool = False
 ):
@@ -2048,6 +2153,14 @@ def dot_product_attention(
       raise ValueError("Require q_seqlen and kv_seqlen to use packed layout")
 
     bias = combine_bias_and_mask(bias, mask, query.dtype)
+
+    # check if the number of arg matches
+    if attn_score_modifier is not None:
+      num_args_required = len(inspect.signature(attn_score_modifier).parameters) -1
+      if num_args_required != len(modifier_args):
+        raise ValueError(
+          f"attn_score_modifier requires {num_args_required} arguments, got {len(modifier_args)}.")
+
     # check if input shape and data type is compatiable
     check_layout(query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       None, None, layout)
@@ -2070,7 +2183,7 @@ def dot_product_attention(
 
     output = _dot_product_attention(
         query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-        _not_used, _not_used, scale, seed, dropout_rate, variadic_args,
-        mask_type, layout.value, sliding_window_length, cudnn_version,
-        return_residual)
+        _not_used, _not_used, modifier_args, scale, seed, dropout_rate, variadic_args,
+        mask_type, layout.value, sliding_window_length, attn_score_modifier,
+        cudnn_version, return_residual)
     return output

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -768,6 +768,37 @@ class DotProductAttentionTest(jtu.JaxTestCase):
       self.assertArraysAllClose(key_grad_ref, key_grad, rtol=2e-2, atol=2e-2)
       self.assertArraysAllClose(value_grad_ref, value_grad, rtol=2e-2, atol=2e-2)
 
+  def test_sdpa_flex_attention(self):
+    k1, k2, k3, k4 = jax.random.split(jax.random.key(0), 4)
+    query = jax.random.normal(
+        k1, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    key = jax.random.normal(
+        k2, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    value = jax.random.normal(
+        k3, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+
+    soft_cap_scalar = jax.random.normal(
+        k4, (4, 4, 1024, 1024), dtype=jnp.float32)
+
+    def soft_cap(attn_score):
+      return 3.0 * jax.lax.tanh(attn_score / 3.0)
+
+    jitted_sdpa = jax.jit(
+      partial(
+        dot_product_attention, scale=1.0, mask_type=MaskType.NO_MASK,
+        dropout_rate=0, score_mod=soft_cap),
+    )
+
+    jitted_sdpa_ref = jax.jit(
+      partial(
+        sdpa_ref, scale=1.0, mask_type=MaskType.NO_MASK,
+        dropout_rate=0, score_mod=soft_cap),
+    )
+
+    out = jitted_sdpa(query, key, value, score_mod_args=())
+    out_ref = jitted_sdpa_ref(query, key, value, score_mod_args=())
+    self.assertArraysAllClose(out, out_ref, rtol=1e-2, atol=1e-2)
+
   def test_sdpa_flex_attention_train(self):
     k1, k2, k3, k4, k5 = jax.random.split(jax.random.key(0), 5)
     query = jax.random.normal(
@@ -782,8 +813,11 @@ class DotProductAttentionTest(jtu.JaxTestCase):
     soft_cap_scalar = jax.random.normal(
         k5, (4, 4, 1024, 1024), dtype=jnp.float32)
 
-    def soft_cap(attn_score, soft_cap_scalar):
-      return soft_cap_scalar * jax.lax.tanh(attn_score / soft_cap_scalar)
+    # def soft_cap(attn_score, soft_cap_scalar):
+    #   return soft_cap_scalar * jax.lax.tanh(attn_score / soft_cap_scalar)
+
+    def soft_cap(attn_score):
+      return attn_score * 3.0
 
     jitted_sdpa = jax.jit(
       partial(
@@ -798,9 +832,9 @@ class DotProductAttentionTest(jtu.JaxTestCase):
     )
 
     out, (query_grad, key_grad, value_grad) = \
-      jitted_sdpa(query, key, value, grad, score_mod_args=(soft_cap_scalar))
+      jitted_sdpa(query, key, value, grad, score_mod_args=())
     out_ref, (query_grad_ref, key_grad_ref, value_grad_ref) = \
-      jitted_sdpa_ref(query, key, value, grad, score_mod_args=(soft_cap_scalar))
+      jitted_sdpa_ref(query, key, value, grad, score_mod_args=())
     self.assertArraysAllClose(out_ref, out, rtol=1e-2, atol=1e-2)
     self.assertArraysAllClose(query_grad_ref, query_grad, rtol=1e-2, atol=1e-2)
     self.assertArraysAllClose(key_grad_ref, key_grad, rtol=1e-2, atol=1e-2)

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -102,13 +102,13 @@ def sdpa_train(query: Array,
                kv_seqlen: Array | None = None,
                q_offsets: Array | None = None,
                kv_offsets: Array | None = None,
-               modifier_args: Tuple[Array] = (),
+               score_mod_args: Tuple[Array] = (),
                scale: float = 0.5,
                mask_type: MaskType = MaskType.NO_MASK,
                is_bnth: bool = False,
                dropout_rate: float = 0.1,
                sliding_window_length: int | None = None,
-               attn_score_modifier = None) -> Array:
+               score_mod = None) -> Array:
   if mask_type == MaskType.PADDING:
     if is_bnth:
       B, _, S, _ = query.shape
@@ -120,9 +120,9 @@ def sdpa_train(query: Array,
               dropout_rate=dropout_rate,
               qkv_layout="BNTH" if is_bnth else "BTNH",
               sliding_window_length=sliding_window_length,
-              attn_score_modifier=attn_score_modifier),
+              score_mod=score_mod),
       query, key, value, bias, mask, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      None, modifier_args)
+      None, score_mod_args)
   query_grad, key_grad, value_grad, bias_grad = sdpa_vjp(grad)[:4]
   if bias is not None:
     # has dbias
@@ -134,13 +134,13 @@ def sdpa_ref(query: Array,
       value: Array,
       bias: Array | None = None,
       mask: Array | None = None,
-      modifier_args: Tuple[Array] = (),
+      score_mod_args: Tuple[Array] = (),
       scale: float = 0.5,
       mask_type: MaskType = MaskType.NO_MASK,
       is_bnth: bool = False,
       dropout_rate: float = 0.1,
       sliding_window_length: int | None = None,
-      attn_score_modifier = None) -> Array:
+      score_mod = None) -> Array:
 
   def get_causal_mask(logits):
     large_negative_number = get_large_negative_number(logits.dtype)
@@ -209,9 +209,8 @@ def sdpa_ref(query: Array,
     if bias.shape != logits.shape:
       bias = jnp.broadcast_to(bias, logits.shape)
     logits = logits + bias.astype(logits.dtype)
-  if attn_score_modifier is not None:
-    logits = attn_score_modifier(logits.astype(query.dtype), *modifier_args).astype(jnp.float32)
-    #logits = attn_score_modifier(logits, *modifier_args).astype(jnp.float32)
+  if score_mod is not None:
+    logits = score_mod(logits, *score_mod_args).astype(jnp.float32)
   probs = jax.nn.softmax(logits, axis=-1).astype(query.dtype)
   if dropout_rate > 0.:
     keep_prob = 1.0 - dropout_rate
@@ -240,14 +239,14 @@ def sdpa_train_ref(query: Array,
             is_bnth: bool = False,
             dropout_rate: float = 0.1,
             sliding_window_length: int | None = None,
-            attn_score_modifier = None,
-            modifier_args = ()) -> Array:
+            score_mod = None,
+            score_mod_args = ()) -> Array:
   out_ref, sdpa_vjp_ref = jax.vjp(
     partial(
       sdpa_ref, scale=scale, mask_type=mask_type, dropout_rate=dropout_rate,
       sliding_window_length=sliding_window_length, is_bnth=is_bnth,
-      attn_score_modifier=attn_score_modifier),
-    query, key, value, bias, mask, modifier_args)
+      score_mod=score_mod),
+    query, key, value, bias, mask, score_mod_args)
   query_grad_ref, key_grad_ref, value_grad_ref, bias_grad_ref = sdpa_vjp_ref(grad)[:4]
   if bias is not None and len(bias.shape) == 3:
     return out_ref, (query_grad_ref, key_grad_ref, value_grad_ref, bias_grad_ref)
@@ -783,60 +782,29 @@ class DotProductAttentionTest(jtu.JaxTestCase):
     soft_cap_scalar = jax.random.normal(
         k5, (4, 4, 1024, 1024), dtype=jnp.float32)
 
-    def soft_cap(attn_score, soft_cap_scalar, soft_cap_scalar1):
-      return soft_cap_scalar1 * jax.lax.tanh(attn_score / soft_cap_scalar)
+    def soft_cap(attn_score, soft_cap_scalar):
+      return soft_cap_scalar * jax.lax.tanh(attn_score / soft_cap_scalar)
 
     jitted_sdpa = jax.jit(
       partial(
         sdpa_train, scale=1.0, mask_type=MaskType.NO_MASK,
-        dropout_rate=0, attn_score_modifier=soft_cap),
+        dropout_rate=0, score_mod=soft_cap),
     )
 
     jitted_sdpa_ref = jax.jit(
       partial(
         sdpa_train_ref, scale=1.0, mask_type=MaskType.NO_MASK,
-        dropout_rate=0, attn_score_modifier=soft_cap),
+        dropout_rate=0, score_mod=soft_cap),
     )
 
     out, (query_grad, key_grad, value_grad) = \
-      jitted_sdpa(query, key, value, grad, modifier_args=(soft_cap_scalar, soft_cap_scalar))
+      jitted_sdpa(query, key, value, grad, score_mod_args=(soft_cap_scalar))
     out_ref, (query_grad_ref, key_grad_ref, value_grad_ref) = \
-      jitted_sdpa_ref(query, key, value, grad, modifier_args=(soft_cap_scalar, soft_cap_scalar))
+      jitted_sdpa_ref(query, key, value, grad, score_mod_args=(soft_cap_scalar))
     self.assertArraysAllClose(out_ref, out, rtol=1e-2, atol=1e-2)
     self.assertArraysAllClose(query_grad_ref, query_grad, rtol=1e-2, atol=1e-2)
     self.assertArraysAllClose(key_grad_ref, key_grad, rtol=1e-2, atol=1e-2)
     self.assertArraysAllClose(value_grad_ref, value_grad, rtol=1e-2, atol=1e-2)
-
-  def test_sdpa_flex_attention(self):
-    k1, k2, k3, k4 = jax.random.split(jax.random.key(0), 4)
-    query = jax.random.normal(
-        k1, (4, 1024, 4, 64), dtype=jnp.bfloat16)
-    key = jax.random.normal(
-        k2, (4, 1024, 4, 64), dtype=jnp.bfloat16)
-    value = jax.random.normal(
-        k3, (4, 1024, 4, 64), dtype=jnp.bfloat16)
-
-    soft_cap_scalar = jax.random.normal(
-        k4, (4, 4, 1024, 1024), dtype=jnp.bfloat16)
-
-    def soft_cap(attn_score, soft_cap_scalar, soft_cap_scalar1):
-      return soft_cap_scalar1 * jax.lax.tanh(attn_score / soft_cap_scalar)
-
-    jitted_sdpa_inference = jax.jit(
-      partial(
-        dot_product_attention, scale=1.0, mask_type=MaskType.NO_MASK,
-        dropout_rate=0, attn_score_modifier=soft_cap),
-    )
-
-    jitted_sdpa_inference_ref = jax.jit(
-      partial(
-        sdpa_ref, scale=1.0, mask_type=MaskType.NO_MASK, dropout_rate=0,
-        attn_score_modifier=soft_cap),
-    )
-
-    out = jitted_sdpa_inference(query, key, value, modifier_args=(soft_cap_scalar, soft_cap_scalar))
-    out_ref = jitted_sdpa_inference_ref(query, key, value, modifier_args=(soft_cap_scalar, soft_cap_scalar))
-    self.assertArraysAllClose(out_ref, out, rtol=1e-2, atol=1e-2)
 
   @jtu.run_on_devices("cuda")
   def test_sdpa_residual(self):

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -17,7 +17,7 @@ from absl.testing import absltest
 import os
 
 os.environ["XLA_FLAGS"] = \
-  "--xla_dump_to=./hlo --xla_dump_hlo_as_text --xla_dump_hlo_pass_re=.* --xla_disable_hlo_passes=float-normalization-bf16"
+  "--xla_dump_to=./hlo --xla_dump_hlo_as_text"
 
 import numpy as np
 import jax
@@ -780,8 +780,11 @@ class DotProductAttentionTest(jtu.JaxTestCase):
     soft_cap_scalar = jax.random.normal(
         k4, (4, 4, 1024, 1024), dtype=jnp.float32)
 
+    # def soft_cap(attn_score):
+    #   return 3.0 * jax.lax.tanh(attn_score / 3.0)
+
     def soft_cap(attn_score):
-      return 3.0 * jax.lax.tanh(attn_score / 3.0)
+      return soft_cap_scalar * jax.lax.tanh(attn_score / soft_cap_scalar)
 
     jitted_sdpa = jax.jit(
       partial(
@@ -813,11 +816,11 @@ class DotProductAttentionTest(jtu.JaxTestCase):
     soft_cap_scalar = jax.random.normal(
         k5, (4, 4, 1024, 1024), dtype=jnp.float32)
 
-    # def soft_cap(attn_score, soft_cap_scalar):
-    #   return soft_cap_scalar * jax.lax.tanh(attn_score / soft_cap_scalar)
+    def soft_cap(attn_score, soft_cap_scalar):
+      return soft_cap_scalar * jax.lax.tanh(attn_score / soft_cap_scalar)
 
-    def soft_cap(attn_score):
-      return attn_score * 3.0
+    # def soft_cap(attn_score):
+    #   return attn_score * 3.0
 
     jitted_sdpa = jax.jit(
       partial(
@@ -832,9 +835,9 @@ class DotProductAttentionTest(jtu.JaxTestCase):
     )
 
     out, (query_grad, key_grad, value_grad) = \
-      jitted_sdpa(query, key, value, grad, score_mod_args=())
+      jitted_sdpa(query, key, value, grad, score_mod_args=(soft_cap_scalar,))
     out_ref, (query_grad_ref, key_grad_ref, value_grad_ref) = \
-      jitted_sdpa_ref(query, key, value, grad, score_mod_args=())
+      jitted_sdpa_ref(query, key, value, grad, score_mod_args=(soft_cap_scalar,))
     self.assertArraysAllClose(out_ref, out, rtol=1e-2, atol=1e-2)
     self.assertArraysAllClose(query_grad_ref, query_grad, rtol=1e-2, atol=1e-2)
     self.assertArraysAllClose(key_grad_ref, key_grad, rtol=1e-2, atol=1e-2)

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -285,8 +285,8 @@ class DotProductAttentionTest(jtu.JaxTestCase):
     super().setUp()
     if not jtu.is_cuda_compute_capability_at_least("8.0"):
       self.skipTest("Requires at least Ampere arch")
-    if jtu.is_cuda_version_at_least(13, 0):
-      self.skipTest("cuDNN creates no execution plans on CUDA 13.0.")
+    # if jtu.is_cuda_version_at_least(13, 0):
+    #   self.skipTest("cuDNN creates no execution plans on CUDA 13.0.")
 
   @jtu.sample_product(
       batch_size=[4],
@@ -780,10 +780,7 @@ class DotProductAttentionTest(jtu.JaxTestCase):
     soft_cap_scalar = jax.random.normal(
         k4, (4, 4, 1024, 1024), dtype=jnp.float32)
 
-    # def soft_cap(attn_score):
-    #   return 3.0 * jax.lax.tanh(attn_score / 3.0)
-
-    def soft_cap(attn_score):
+    def soft_cap(attn_score, soft_cap_scalar):
       return soft_cap_scalar * jax.lax.tanh(attn_score / soft_cap_scalar)
 
     jitted_sdpa = jax.jit(
@@ -798,8 +795,8 @@ class DotProductAttentionTest(jtu.JaxTestCase):
         dropout_rate=0, score_mod=soft_cap),
     )
 
-    out = jitted_sdpa(query, key, value, score_mod_args=())
-    out_ref = jitted_sdpa_ref(query, key, value, score_mod_args=())
+    out = jitted_sdpa(query, key, value, score_mod_args=(soft_cap_scalar,))
+    out_ref = jitted_sdpa_ref(query, key, value, score_mod_args=(soft_cap_scalar,))
     self.assertArraysAllClose(out, out_ref, rtol=1e-2, atol=1e-2)
 
   def test_sdpa_flex_attention_train(self):
@@ -818,9 +815,6 @@ class DotProductAttentionTest(jtu.JaxTestCase):
 
     def soft_cap(attn_score, soft_cap_scalar):
       return soft_cap_scalar * jax.lax.tanh(attn_score / soft_cap_scalar)
-
-    # def soft_cap(attn_score):
-    #   return attn_score * 3.0
 
     jitted_sdpa = jax.jit(
       partial(

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -14,6 +14,10 @@
 
 from functools import partial
 from absl.testing import absltest
+import os
+
+os.environ["XLA_FLAGS"] = \
+  "--xla_dump_to=./hlo --xla_dump_hlo_as_text --xla_dump_hlo_pass_re=.* --xla_disable_hlo_passes=float-normalization-bf16"
 
 import numpy as np
 import jax
@@ -28,6 +32,7 @@ from jax._src.cudnn.fused_attention_stablehlo import (
     check_cudnn_version,
     MaskType,
 )
+from typing import Callable, Tuple
 
 config.parse_flags_with_absl()
 Array = jnp.ndarray
@@ -97,11 +102,13 @@ def sdpa_train(query: Array,
                kv_seqlen: Array | None = None,
                q_offsets: Array | None = None,
                kv_offsets: Array | None = None,
+               modifier_args: Tuple[Array] = (),
                scale: float = 0.5,
                mask_type: MaskType = MaskType.NO_MASK,
                is_bnth: bool = False,
                dropout_rate: float = 0.1,
-               sliding_window_length: int | None = None) -> Array:
+               sliding_window_length: int | None = None,
+               attn_score_modifier = None) -> Array:
   if mask_type == MaskType.PADDING:
     if is_bnth:
       B, _, S, _ = query.shape
@@ -112,8 +119,10 @@ def sdpa_train(query: Array,
       partial(dot_product_attention, scale=scale, mask_type=mask_type,
               dropout_rate=dropout_rate,
               qkv_layout="BNTH" if is_bnth else "BTNH",
-              sliding_window_length=sliding_window_length),
-      query, key, value, bias, mask, q_seqlen, kv_seqlen, q_offsets, kv_offsets)
+              sliding_window_length=sliding_window_length,
+              attn_score_modifier=attn_score_modifier),
+      query, key, value, bias, mask, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
+      None, modifier_args)
   query_grad, key_grad, value_grad, bias_grad = sdpa_vjp(grad)[:4]
   if bias is not None:
     # has dbias
@@ -125,11 +134,13 @@ def sdpa_ref(query: Array,
       value: Array,
       bias: Array | None = None,
       mask: Array | None = None,
+      modifier_args: Tuple[Array] = (),
       scale: float = 0.5,
       mask_type: MaskType = MaskType.NO_MASK,
       is_bnth: bool = False,
       dropout_rate: float = 0.1,
-      sliding_window_length: int | None = None) -> Array:
+      sliding_window_length: int | None = None,
+      attn_score_modifier = None) -> Array:
 
   def get_causal_mask(logits):
     large_negative_number = get_large_negative_number(logits.dtype)
@@ -198,6 +209,9 @@ def sdpa_ref(query: Array,
     if bias.shape != logits.shape:
       bias = jnp.broadcast_to(bias, logits.shape)
     logits = logits + bias.astype(logits.dtype)
+  if attn_score_modifier is not None:
+    logits = attn_score_modifier(logits.astype(query.dtype), *modifier_args).astype(jnp.float32)
+    #logits = attn_score_modifier(logits, *modifier_args).astype(jnp.float32)
   probs = jax.nn.softmax(logits, axis=-1).astype(query.dtype)
   if dropout_rate > 0.:
     keep_prob = 1.0 - dropout_rate
@@ -225,14 +239,17 @@ def sdpa_train_ref(query: Array,
             mask_type: MaskType = MaskType.NO_MASK,
             is_bnth: bool = False,
             dropout_rate: float = 0.1,
-            sliding_window_length: int | None = None) -> Array:
+            sliding_window_length: int | None = None,
+            attn_score_modifier = None,
+            modifier_args = ()) -> Array:
   out_ref, sdpa_vjp_ref = jax.vjp(
     partial(
       sdpa_ref, scale=scale, mask_type=mask_type, dropout_rate=dropout_rate,
-      sliding_window_length=sliding_window_length, is_bnth=is_bnth),
-    query, key, value, bias, mask)
-  query_grad_ref, key_grad_ref, value_grad_ref, bias_grad_ref, _ = sdpa_vjp_ref(grad)
-  if bias is not None:
+      sliding_window_length=sliding_window_length, is_bnth=is_bnth,
+      attn_score_modifier=attn_score_modifier),
+    query, key, value, bias, mask, modifier_args)
+  query_grad_ref, key_grad_ref, value_grad_ref, bias_grad_ref = sdpa_vjp_ref(grad)[:4]
+  if bias is not None and len(bias.shape) == 3:
     return out_ref, (query_grad_ref, key_grad_ref, value_grad_ref, bias_grad_ref)
   return out_ref, (query_grad_ref, key_grad_ref, value_grad_ref)
 
@@ -748,9 +765,78 @@ class DotProductAttentionTest(jtu.JaxTestCase):
       value_grad_ref = value_grad_ref * mask
 
       self.assertArraysAllClose(out_ref, out, rtol=1e-2, atol=1e-2)
-      self.assertArraysAllClose(query_grad_ref, query_grad, rtol=1e-2, atol=1e-2)
-      self.assertArraysAllClose(key_grad_ref, key_grad, rtol=1e-2, atol=1e-2)
-      self.assertArraysAllClose(value_grad_ref, value_grad, rtol=1e-2, atol=1e-2)
+      self.assertArraysAllClose(query_grad_ref, query_grad, rtol=2e-2, atol=2e-2)
+      self.assertArraysAllClose(key_grad_ref, key_grad, rtol=2e-2, atol=2e-2)
+      self.assertArraysAllClose(value_grad_ref, value_grad, rtol=2e-2, atol=2e-2)
+
+  def test_sdpa_flex_attention_train(self):
+    k1, k2, k3, k4, k5 = jax.random.split(jax.random.key(0), 5)
+    query = jax.random.normal(
+        k1, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    key = jax.random.normal(
+        k2, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    value = jax.random.normal(
+        k3, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    grad = jax.random.normal(
+        k4, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+
+    soft_cap_scalar = jax.random.normal(
+        k5, (4, 4, 1024, 1024), dtype=jnp.float32)
+
+    def soft_cap(attn_score, soft_cap_scalar, soft_cap_scalar1):
+      return soft_cap_scalar1 * jax.lax.tanh(attn_score / soft_cap_scalar)
+
+    jitted_sdpa = jax.jit(
+      partial(
+        sdpa_train, scale=1.0, mask_type=MaskType.NO_MASK,
+        dropout_rate=0, attn_score_modifier=soft_cap),
+    )
+
+    jitted_sdpa_ref = jax.jit(
+      partial(
+        sdpa_train_ref, scale=1.0, mask_type=MaskType.NO_MASK,
+        dropout_rate=0, attn_score_modifier=soft_cap),
+    )
+
+    out, (query_grad, key_grad, value_grad) = \
+      jitted_sdpa(query, key, value, grad, modifier_args=(soft_cap_scalar, soft_cap_scalar))
+    out_ref, (query_grad_ref, key_grad_ref, value_grad_ref) = \
+      jitted_sdpa_ref(query, key, value, grad, modifier_args=(soft_cap_scalar, soft_cap_scalar))
+    self.assertArraysAllClose(out_ref, out, rtol=1e-2, atol=1e-2)
+    self.assertArraysAllClose(query_grad_ref, query_grad, rtol=1e-2, atol=1e-2)
+    self.assertArraysAllClose(key_grad_ref, key_grad, rtol=1e-2, atol=1e-2)
+    self.assertArraysAllClose(value_grad_ref, value_grad, rtol=1e-2, atol=1e-2)
+
+  def test_sdpa_flex_attention(self):
+    k1, k2, k3, k4 = jax.random.split(jax.random.key(0), 4)
+    query = jax.random.normal(
+        k1, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    key = jax.random.normal(
+        k2, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    value = jax.random.normal(
+        k3, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+
+    soft_cap_scalar = jax.random.normal(
+        k4, (4, 4, 1024, 1024), dtype=jnp.bfloat16)
+
+    def soft_cap(attn_score, soft_cap_scalar, soft_cap_scalar1):
+      return soft_cap_scalar1 * jax.lax.tanh(attn_score / soft_cap_scalar)
+
+    jitted_sdpa_inference = jax.jit(
+      partial(
+        dot_product_attention, scale=1.0, mask_type=MaskType.NO_MASK,
+        dropout_rate=0, attn_score_modifier=soft_cap),
+    )
+
+    jitted_sdpa_inference_ref = jax.jit(
+      partial(
+        sdpa_ref, scale=1.0, mask_type=MaskType.NO_MASK, dropout_rate=0,
+        attn_score_modifier=soft_cap),
+    )
+
+    out = jitted_sdpa_inference(query, key, value, modifier_args=(soft_cap_scalar, soft_cap_scalar))
+    out_ref = jitted_sdpa_inference_ref(query, key, value, modifier_args=(soft_cap_scalar, soft_cap_scalar))
+    self.assertArraysAllClose(out_ref, out, rtol=1e-2, atol=1e-2)
 
   @jtu.run_on_devices("cuda")
   def test_sdpa_residual(self):


### PR DESCRIPTION
Support adding arbitrary pointwise operations between bmm1 and softmax to support new variants of cuDNN attention. For example: softcap.

```
def test_sdpa_flex_attention(self):
    k1, k2, k3, k4 = jax.random.split(jax.random.key(0), 4)
    query = jax.random.normal(
        k1, (4, 1024, 4, 64), dtype=jnp.bfloat16)
    key = jax.random.normal(
        k2, (4, 1024, 4, 64), dtype=jnp.bfloat16)
    value = jax.random.normal(
        k3, (4, 1024, 4, 64), dtype=jnp.bfloat16)


    soft_cap_scalar = jax.random.normal(
        k4, (4, 4, 1024, 1024), dtype=jnp.bfloat16)


    def soft_cap(attn_score, soft_cap_scalar):
      return soft_cap_scalar * jax.lax.tanh(attn_score / soft_cap_scalar)


    jitted_sdpa = jax.jit(
      partial(
        dot_product_attention, scale=1.0, mask_type=MaskType.NO_MASK,
        dropout_rate=0, attn_score_modifier=soft_cap),
    )
    out = jitted_sdpa(query, key, value, modifier_args=(soft_cap_scalar,))
```
In this example, users create a soft_cap function and pass to **dot_product_attention** through argument **attn_score_modifier**, soft_cap accepts two arguments and therefore soft_cap_scalar argument needs to be passed to **dot_product_attention** through **modifier_args**.