### PR TITLE
Added mxschmitt/action-tmate@v3 to tsan ci job

### DIFF
--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -243,6 +243,9 @@ jobs:
             ./wheelhouse
           key: ${{ runner.os }}-scipy-${{ matrix.python-version }}-${{ hashFiles('scipy/pyproject.toml') }}-${{ steps.get-date.outputs.date }}
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Build Jax and run tests
         timeout-minutes: 120
         env:


### PR DESCRIPTION

> mxschmitt/action-tmate@v3 is not allowed to be used in jax-ml/jax. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub, or matching the following: google-ml-infra/actions/*, jayqi/failed-build-issue-action@*, medyagh/setup-minikube@*.