### PR TITLE
Ensure outputs are tracers when inlining jit

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1921,11 +1921,12 @@ def pjit_staging_rule(trace, *args, **params):
       # shapes are enabled, use eval_jaxpr, which uses the tracing machinery,
       # but redundantly performs abstract evaluation again.
       with core.set_current_trace(trace):
-        return core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, *args,
-                                      propagate_source_info=False)
+        out = core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, *args,
+                              propagate_source_info=False)
     else:
-      return pe.inline_jaxpr_into_trace(
+      out = pe.inline_jaxpr_into_trace(
           trace, jaxpr.jaxpr, jaxpr.consts, *args)
+    return [trace.to_jaxpr_tracer(x) for x in out]
 
   jaxpr = params['jaxpr']
   if config.dynamic_shapes.value:

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -3264,6 +3264,17 @@ class ArrayPjitTest(jtu.JaxTestCase):
     jaxpr = jax.make_jaxpr(g)(3)
     self.assertNotIn('pjit', str(jaxpr))
 
+  def test_pjit_inline_literal(self):
+    # https://github.com/jax-ml/jax/issues/27545
+    def bar(x):
+      return jnp.array(1)
+
+    def foo(x):
+      x = pjit(bar, inline=True)(x)
+      self.assertEqual(x.shape, ())
+
+    pjit(foo)(0)  # doesn't crash
+
   def test_pmap_in_axis_resources_error(self):
     pmap_out = jax.pmap(lambda x: x)(jnp.arange(jax.device_count()))
     self.assertIsInstance(pmap_out.sharding, jax.sharding.PmapSharding)


### PR DESCRIPTION
When staging out an inline jit, all the outputs from the pjit custom staging rule should be tracers, but we weren't correctly handling `Literal`s, as demonstrated by https://github.com/jax-ml/jax/issues/27545. The basic problem is that the Jaxpr input to pjit  has already had the `inline_literals` optimization pass applied, so some of the outputs might be `Literal`s instead of `Var`s. For these outputs, we want to "undo" that inlining, and treat those literals as constants in the outer Jaxpr. We can handle this by explicitly calling `to_jaxpr_tracer` on these outputs since that also covers the case for dynamic shapes.

Fixes https://github.com/jax-ml/jax/issues/27545