### PR TITLE
Fix bug in argnums_partial_except when static_argnums is unsorted

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -259,7 +259,7 @@ def argnums_partial_except(f: lu.WrappedFun, static_argnums: tuple[int, ...],
   dyn_args = tuple(args[i] for i in dyn_argnums)
 
   fixed_args = []
-  for i in static_argnums:
+  for i in sorted(static_argnums):
     # TODO(shoyer): set allow_invalid=True permanently after static_argnames.
     if allow_invalid and i >= len(args):
       continue


### PR DESCRIPTION
Fixes https://github.com/jax-ml/jax/issues/28065