### PR TITLE
Suppressed split_keys_entry_added/dict_dict_merge race  in 3.13 TSAN CI

### DIFF
--- a/.github/workflows/tsan-suppressions_3.13.txt
+++ b/.github/workflows/tsan-suppressions_3.13.txt
@@ -67,6 +67,10 @@ race:gemm_oncopy
 # https://github.com/python/cpython/issues/130547
 # race:split_keys_entry_added
 
+# https://github.com/python/cpython/issues/132245
+race:split_keys_entry_added
+race_top:dict_dict_merge
+
 # https://github.com/python/cpython/issues/129547
 # Maybe fixed?
 # race:type_get_annotations


### PR DESCRIPTION
Decsription:
- Suppress occasionally seen race between split_keys_entry_added and dict_dict_merge in 3.13 TSAN CI
  
Related to https://github.com/python/cpython/issues/132245