### PR TITLE
Fix ensure_compile_time_eval context after stackless

### DIFF
--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1964,7 +1964,7 @@ class DynamicJaxprTrace(core.Trace):
     return self.frame.tracer_to_var.get(id(tracer)) is None
 
   def process_primitive(self, primitive, tracers, params):
-    if (config.eager_constant_folding.value and all(map(self.is_const, tracers))):
+    if config.eager_constant_folding.value and not any(isinstance(x, Tracer) for x in tracers):
       return primitive.bind_with_trace(core.eval_trace, tracers, params)
     jaxpr_tracers = map(self.to_jaxpr_tracer, tracers)
     if primitive in custom_staging_rules:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4955,6 +4955,11 @@ class APITest(jtu.JaxTestCase):
     with config.use_direct_linearize(True):
       jax.grad(my_sin_p.bind)(1.0)  # doesn't crash
 
+  def test_ensure_compile_time_eval_no_leaks(self):
+    # https://github.com/jax-ml/jax/issues/25847
+    with jax.ensure_compile_time_eval():
+      jnp.linalg.solve(jnp.eye(3), jnp.ones(3))  # doesn't crash
+
 
 class RematTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
As reported in https://github.com/jax-ml/jax/issues/25847, some usage of the `ensure_compile_time_eval` context manager broke with the "stackless" change. The problem is that the check for whether or not inputs to a primitive are "constants" was a little too lenient in the case of nested jits. We can only do eager constant folding with inputs that aren't tracers, but sometimes closed over tracers can appear as jaxpr "constants", so checking `is_const` wasn't sufficient.

Fixes https://github.com/jax-ml/jax/issues/25847