### PR TITLE
[Pallas] Update TPU pipelining docs

### DIFF
--- a/docs/pallas/design/async_note.md
+++ b/docs/pallas/design/async_note.md
@@ -1,3 +1,4 @@
+(pallas_async)=
 # Pallas Async Operations
 
 ## Background \+ Motivation

--- a/docs/pallas/pipelining.ipynb
+++ b/docs/pallas/pipelining.ipynb
@@ -6,11 +6,14 @@
     "id": "C93Xlf0DRW9H"
    },
    "source": [
+    "\n",
+    "(pallas_software_pipelining)=\n",
+    "\n",
     "# Software Pipelining\n",
     "\n",
     "Software pipelining is an important technique in performance optimization by overlapping multiple asynchronous operations even if there are data dependencies between them. In the context of kernel writing, the most common form of pipelining involves overlapping communication and memory transfers with compute such that the hardware accelerator never stalls while waiting for data to arrive. Therefore, we will solely focus on the problem of communication-compute pipelining in this tutorial. We will begin by covering the problem conceptually, outlining the Pallas API for writing pipelines, and going over some realistic examples using the API.\n",
     "\n",
-    "This tutorial only covers the conceptual foundations of pipelining. For platform-specific references, please see the [TPU](https://docs.jax.dev/en/latest/pallas/tpu/pipelining.html), or GPU (coming soon!) specific pipelining references.\n"
+    "This tutorial only covers the conceptual foundations of pipelining. For platform-specific references, please see {ref}`pallas_tpu_pipelining`, or GPU (coming soon!) specific pipelining references.\n"
    ]
   },
   {
@@ -391,7 +394,7 @@
    "source": [
     "## Pallas Pipelining API\n",
     "\n",
-    "Pallas offers a pipelining API that abstracts away the boilerplate of maintaining multiple buffers and overlapping asynchronous communication with computation. The basics of this API are covered in the [quickstart](https://docs.jax.dev/en/latest/pallas/quickstart.html), so we will go over the API briefly here for completeness and discuss some sharp edges that arise from the use of pipelining.\n",
+    "Pallas offers a pipelining API that abstracts away the boilerplate of maintaining multiple buffers and overlapping asynchronous communication with computation. The basics of this API are covered in {ref}`pallas_quickstart`, so we will go over the API briefly here for completeness and discuss some sharp edges that arise from the use of pipelining.\n",
     "\n",
     "\n",
     "### Grid\n",
@@ -574,7 +577,7 @@
     "**Reduction/accumulation should only be performed over the last (innermost) dimensions of the grid, and the buffer should be initialized manually first.**\n",
     "\n",
     "Reductions are one of the few cases where the pipeline supports both reading and writing to an output buffer, but the reason it works is subtle.\n",
-    "The Pallas pipeline emitter performs an optimization where if the data slices between two consecutive iterations are the same, the pipeline will not issue a `copy_in`/`copy_out` on that buffer. This means the same SRAM buffer used in a previous iteration will be passed into the kernel again on the following iteration, and thus any writes that were issued to the output buffer will become visible on the next iteration. Once the grid index changes, the final accumulated SRAM buffer will be written out to HBM. This is also why reductions must be performed over the last dimensions of the grid -- we want to finish all of the accumulation while the output buffer is in SRAM in the innermost loop, then write it to HBM and never touch that output block again.\n",
+    "The Pallas pipeline emitter performs an optimization where if the data slices between two consecutive iterations are the same, the pipeline will not issue a `copy_in`/`copy_out` on that buffer. This means the same SRAM buffer used in a previous iteration will be passed into the kernel again on the following iteration, and thus any writes that were issued to the output buffer will become visible on the next iteration. Once the data slice changes, the final accumulated SRAM buffer will be written out to HBM. This is also why reductions must be performed over the last dimensions of the grid -- we want to finish all of the accumulation while the output buffer is in SRAM in the innermost loop, then write it to HBM and never touch that output block again.\n",
     "\n",
     "As a concrete example, let's consider performing the following computation for reducing an `(8, 1024, 1024)` array along the first axies into a `(1024, 1024)` array.\n",
     "\n",
@@ -799,7 +802,7 @@
     "id": "HFWcaAudW4z1"
    },
    "source": [
-    "In a **memory-bound** regime it is useful to identify if the problem is the latency versus the bandwidth. If the bandwidth is the bottleneck, then the total runtime would take $\\alpha + X / \\beta$ seconds. In contrast with a latency-bound regime, the memory copies happen serially because the bandwidth is already saturated. Being memory-bound is generally not ideal as there will be gaps in time where the processor is idle, and in most hardware configurations the memory bandwidth $\\beta$ is orders of magnitude slower than the processing speed $F$."
+    "In a **memory-bound** regime it is useful to identify if the problem is the latency versus the bandwidth. If the bandwidth is the bottleneck, then the total runtime would take $\\alpha + N(X / \\beta)$ seconds. In contrast with a latency-bound regime, the memory copies happen serially because the bandwidth is already saturated. Being memory-bound is generally not ideal as there will be gaps in time where the processor is idle, and in most hardware configurations the memory bandwidth $\\beta$ is orders of magnitude slower than the processing speed $F$."
    ]
   },
   {
@@ -818,7 +821,7 @@
     "id": "V4YQCZf1W7X5"
    },
    "source": [
-    "If the bottleneck is specifically the latency and not the bandwidth, it is possible to fix the problem by inserting additional pipeline stages at the cost of additional SRAM required to store more buffers. With sufficient stages, the problem will either become compute or latency bound again depending on which bottleneck we hit first during the steady-stage stage of the pipeline. The downside, however, of a multi-stage pipeline is that the size of the bubble is proportional to the number of stages so it is important to make sure the pipeline is long enough such that the bubble does not take up a substantial amount of the total runtime.\n"
+    "If the bottleneck is specifically the latency and not the bandwidth, it is possible to fix the problem by inserting additional pipeline stages at the cost of additional SRAM required to store more buffers. With sufficient stages, the problem will either become compute or bandwidth bound again depending on which bottleneck we hit first during the steady-stage stage of the pipeline. The downside, however, of a multi-stage pipeline is that the size of the bubble is proportional to the number of stages so it is important to make sure the pipeline is long enough such that the bubble does not take up a substantial amount of the total runtime.\n"
    ]
   },
   {

--- a/docs/pallas/quickstart.ipynb
+++ b/docs/pallas/quickstart.ipynb
@@ -5,6 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "(pallas_quickstart)=\n",
     "# Pallas Quickstart\n",
     "\n",
     "<!--* freshness: { reviewed: '2024-04-08' } *-->\n",

--- a/docs/pallas/quickstart.md
+++ b/docs/pallas/quickstart.md
@@ -12,6 +12,7 @@ kernelspec:
   name: python3
 ---
 
+(pallas_quickstart)=
 # Pallas Quickstart
 
 <!--* freshness: { reviewed: '2024-04-08' } *-->

--- a/docs/pallas/tpu/pipelining.ipynb
+++ b/docs/pallas/tpu/pipelining.ipynb
@@ -2,8 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7704d3bb",
-   "metadata": {},
+   "metadata": {
+    "id": "7704d3bb"
+   },
    "source": [
     "(pallas_tpu_pipelining)="
    ]
@@ -14,7 +15,7 @@
     "id": "teoJ_fUwlu0l"
    },
    "source": [
-    "# Pipelining\n",
+    "# TPU Pipelining\n",
     "\n",
     "<!--* freshness: { reviewed: '2024-04-08' } *-->"
    ]
@@ -25,14 +26,24 @@
     "id": "gAJDZh1gBh-h"
    },
    "source": [
-    "In this guide we'll cover how memory spaces in TPU work and how to write\n",
-    "pipelines in Pallas that overlap memory I/O with compute."
+    "This guide serves as a reference for TPU-specific pipelining concerns.\n",
+    "We'll review the memory hierarchy and compute units on TPUs, and TPU-specific features of the pipelining API. For a more general-purpose overview of pipelining, see the {ref}`pallas_software_pipelining`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
+    "executionInfo": {
+     "elapsed": 54,
+     "status": "ok",
+     "timestamp": 1744908474512,
+     "user": {
+      "displayName": "Justin Fu",
+      "userId": "17543197034567316452"
+     },
+     "user_tz": 420
+    },
     "id": "ejAVO6ikUUuF"
    },
    "outputs": [],
@@ -48,9 +59,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e212a5e",
    "metadata": {
-    "id": "TWKESTKAlyjT"
+    "id": "0e212a5e"
    },
    "source": [
     "(tpu_and_its_memory_spaces)=\n",
@@ -60,7 +70,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "NnWW9GV4kW6P"
+   },
    "source": [
     "A TPU and its TensorCore consist of memory spaces (where arrays can reside),\n",
     "registers (which temporarily store scalar and array values) and compute units\n",
@@ -83,568 +95,81 @@
     "  Values can be loaded into memory from their respective caches (VMEM for\n",
     "  VREGs and SMEM for SREGs).\n",
     "* **Compute units**: A TensorCore has a scalar unit, vector unit (VPU) and\n",
-    "  matrix unit (MXU) that can do numerical computation.\n",
+    "  matrix unit (MXU) that can do numerical computation. Each of these compute units can operate asynchronously, but this is managed by the TPU compiler and thus from the programmer's perspective a TPU program is single-threaded.\n",
     "  Compute units operate on values that live in SREGs and VREGs and output\n",
-    "  values into those registers as well.\n",
-    "\n",
-    "In order to do a vectorized computation on our values `x` and `y` that live\n",
-    "in HBM, we need to:\n",
-    "\n",
-    "1. Copy the values `x` and `y` into VMEM.\n",
-    "2. Load the values from VMEM into VREGs.\n",
-    "3. Execute the computation using the VPU or MXU, storing the output in VREGs.\n",
-    "4. Store the values in the output VREGs into VMEM.\n",
-    "5. Copy the output values in VMEM back to HBM."
+    "  values into those registers as well."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "TzctMbNsn3vc"
+    "id": "8Tl3wt5Wk3Ek"
    },
    "source": [
-    "Let's implement a Pallas function that does just that!"
+    "## TPU-specific Pipelining Features\n",
+    "\n",
+    "Pallas TPU supports the following platform-specific features."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1jg5WmExk47l"
+   },
+   "source": [
+    "### TPU Memory Spaces\n",
+    "\n",
+    "Pallas exposes all levels of the TPU memory hierarchy to users. The following table maps from Pallas TPU memory spaces to their standard memory types (DRAM/SRAM):\n",
+    "\n",
+    "| Pallas Enum | TPU Memory Space | Type (DRAM/SRAM) |\n",
+    "| --- | --- | --- |\n",
+    "| `pltpu.TPUMemorySpace.ANY` | HBM (usually) or VMEM | DRAM |\n",
+    "| `pltpu.TPUMemorySpace.VMEM` | VMEM | SRAM |\n",
+    "| `pltpu.TPUMemorySpace.SMEM` | SMEM | SRAM |\n",
+    "| `pltpu.TPUMemorySpace.SEMAPHORE` | Semaphore | SRAM |\n",
+    "\n",
+    "- `TPUMemorySpace.VMEM` denotes vector SRAM. It is the default memory space if nothing is specified.\n",
+    "- `TPUMemorySpace.SMEM` denotes scalar SRAM. Only scalar loads and stores can be performed to/from SMEM.\n",
+    "- `TPUMemorySpace.ANY` is a hint to the compiler that the memory space is unconstrained. In most cases, XLA will place this buffer in HBM. A buffer assigned to the `ANY` memory space cannot be dereferenced normally using array indexing syntax (e.g. `x[...]`). Instead, we must first copy the values into a VMEM or SMEM buffer using `pltpu.sync_copy` or `pltpu.async_copy`.\n",
+    "- `TPUMemorySpace.SEMAPHORE` is used to allocate semaphores for constructing barriers or tracking asynchronous operations. It is also possible to return semaphores from the kernel for building asynchronous kernels - this is an experimental feature; see {ref}`pallas_async` for more details.\n",
+    "\n",
+    "Pipelining on TPUs is typically done between HBM (DRAM) to VMEM (Vector SRAM). The default behavior for `pallas_call` on TPU is that arguments to `pallas_call` are assumed to live in HBM, and inputs to the user kernel body are stored in VMEM.\n",
+    "\n",
+    "While not specific to pipelining, it is possible to gain manual control over the memory space of input and output buffers, you can specify the `memory_space` argument on a `BlockSpec`. Note that pipelining is not allowed unless the `memory_space` is marked as `VMEM`. Memory spaces can also be used to specify scratch arguments to a kernel via the `scratch_shapes` argument on `pallas_call`. Scratch buffers are persistent across kernel iterations and are useful for storing intermediate results such as partial accumulations and reductions. A scratch buffer must reside in `VMEM`, `SMEM`, or `SEMAPHORE`.\n",
+    "\n",
+    "As an example for using multiple manual memory space assignments in a kernel, the following program copies a slice of an HBM buffer `x_hbm_ref` into a scratch VMEM buffer `scratch_vmem_ref` before using it for arithmetic and storing the result into an output VMEM buffer:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
-    "id": "2IXQxNWrKJyb",
-    "outputId": "d62eb493-5f92-4496-f113-d3cd24cb0b9f"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Array([[2., 2., 2., ..., 2., 2., 2.],\n",
-       "       [2., 2., 2., ..., 2., 2., 2.],\n",
-       "       [2., 2., 2., ..., 2., 2., 2.],\n",
-       "       ...,\n",
-       "       [2., 2., 2., ..., 2., 2., 2.],\n",
-       "       [2., 2., 2., ..., 2., 2., 2.],\n",
-       "       [2., 2., 2., ..., 2., 2., 2.]], dtype=float32)"
-      ]
+    "executionInfo": {
+     "elapsed": 65,
+     "status": "ok",
+     "timestamp": 1744908591430,
+     "user": {
+      "displayName": "Justin Fu",
+      "userId": "17543197034567316452"
      },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "def add_matrices_kernel(x_vmem_ref, y_vmem_ref, z_vmem_ref):\n",
-    "  # Load x and y from VMEM into VREGs\n",
-    "  x_vregs = x_vmem_ref[:, :]\n",
-    "  y_vregs = y_vmem_ref[:, :]\n",
-    "  # Execute a vectorized add\n",
-    "  z_vregs = x_vregs + y_vregs\n",
-    "  # Store the output values in VREGs back into VMEM\n",
-    "  z_vmem_ref[:, :] = z_vregs\n",
-    "\n",
-    "\n",
-    "def add_matrices(x: jax.Array, y: jax.Array) -> jax.Array:\n",
-    "  # pallas_call will first allocate scratch buffers for `x` and `y` in VMEM.\n",
-    "  # It will then copy `x` and `y` from HBM into VMEM.\n",
-    "  z = pl.pallas_call(\n",
-    "      add_matrices_kernel, out_shape=jax.ShapeDtypeStruct(x.shape, x.dtype)\n",
-    "  )(x, y)\n",
-    "  # pallas_call will also copy the output from VMEM back into HBM.\n",
-    "  return z\n",
-    "\n",
-    "\n",
-    "x, y = jnp.ones((512, 512)), jnp.ones((512, 512))\n",
-    "add_matrices(x, y)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "HMENNLy8okCL"
-   },
-   "source": [
-    "We've written two functions: `add_matrices_kernel` and `add_matrices`.\n",
-    "\n",
-    "`add_matrices_kernel` operates using `Ref`s that live in VMEM.\n",
-    "Loading from a VMEM `Ref` produces a value that lives in VREGs.\n",
-    "Values in VREGs behave like `jax.Array`s in that we can use `jnp` and\n",
-    "`jax.lax` operations on them to produce new values that live in VREGs.\n",
-    "When we produce the values we'd like to return, we store them in the output\n",
-    "VMEM `Ref`.\n",
-    "\n",
-    "The `add_matrices` function acts on `jax.Array`s and returns a `jax.Array`.\n",
-    "Inside it, we pass `x` and `y` into `pallas_call`.\n",
-    "`pallas_call` is responsible for copying `x` and `y` into VMEM and for\n",
-    "allocating the VMEM buffers that the kernel operates on (including allocating\n",
-    "`z_vmem_ref`, the output VMEM buffer).\n",
-    "After the kernel function is finished running, `pallas_call` will also copy\n",
-    "the value in `z_vmem_ref` to HBM, resulting in an output `jax.Array`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "5kWr-1tKpYro"
-   },
-   "source": [
-    "## Constraints of using VMEM/SMEM\n",
-    "\n",
-    "Pallas exposes access to lower level memory spaces like VMEM and SMEM but\n",
-    "writing kernels utilizing them adds some considerations.\n",
-    "\n",
-    "1. Memory capacity. VMEM and SMEM are *small*! VMEM on v4 TPUs is only 16MiB\n",
-    "  and SMEM ranges in the tens to hundreds of KiB.\n",
-    "  If our arrays are too big, we won't even be able to fit them into VMEM at all.\n",
-    "  For reference, a `f32[2048, 2048]` array is 16MiB, so our above kernel won't\n",
-    "  scale beyond moderately sized arrays.\n",
-    "\n",
-    "2. Memory bandwidth. Copying to/from HBM and VMEM takes a long time, at least\n",
-    "  compared to most compute instructions.\n",
-    "  The `add_matrices` function above will likely spend more time copying\n",
-    "  between HBM and VMEM than actually performing the addition itself.\n",
-    "\n",
-    "With these two constraints in mind, we'll have to rethink our strategy for\n",
-    "getting performance out of our TPUs."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "_NTqvlbetB3P"
-   },
-   "source": [
-    "## Primer: Pipelining\n",
-    "\n",
-    "Pipelining our computation offers a way of dealing with both the memory\n",
-    "capacity and bandwidth constraints in one fell swoop.\n",
-    "What do we mean by pipelining?\n",
-    "\n",
-    "The goal is: *in parallel* copy to/from HBM and VMEM *while* utilizing our\n",
-    "compute units.\n",
-    "Naively this is difficult because in our program above we copy *all* of `x`\n",
-    "and `y` before we start doing any compute with them, creating a dependence\n",
-    "between the copy and the compute.\n",
-    "\n",
-    "However, if we can chunk up our computation into several subcomputations\n",
-    "(e.g. when we add two matrices, we can express that as addition of \"blocks\"\n",
-    "of the original matrices together), we can now overlap the copies of one of\n",
-    "those subcomputations with the compute of the other. Let's walk through a\n",
-    "simple example:\n",
-    "\n",
-    "Let's say we split our arrays `x` and `y` into `x1, x2` and `y1, y2` (for\n",
-    "example, split along the leading axis, resulting in two `(256, 512)` arrays\n",
-    "for each input.\n",
-    "We can now execute the following pipelined computation.\n",
-    "\n",
-    "1. Copy `x1` and `y1` into VMEM.\n",
-    "1. Start copying `x2` and `y2` into VMEM\n",
-    "2. Load `x1, y1` from VMEM into VREGs.\n",
-    "3. Execute the `z1 = x1 + y1` using the compute units.\n",
-    "4. Store `z1` into VMEM.\n",
-    "5. Start copying `z1` from VMEM back into HBM.\n",
-    "6. Wait until `x2, y2` have been copied into VMEM.\n",
-    "7. Load `x2, y2` from VMEM into VREGs.\n",
-    "8. Execute the `z2 = x2 + y2` using the compute units.\n",
-    "9. Store `z2` into VMEM.\n",
-    "10. Wait until `z1` is copied into HBM.\n",
-    "10. Start copying `z2` from VMEM back into HBM.\n",
-    "10. Wait until `z2` is copied into HBM.\n",
-    "\n",
-    "Any time we are doing compute here, we are asynchronously copying something.\n",
-    "This means that some of the time spent copying is not wasted.\n",
-    "\n",
-    "The two most important numbers for determining how efficient a pipelined\n",
-    "computation are a) how many floating point operations (FLOPs) we need to\n",
-    "execute and b) how many bytes we need to copy to execute that computation.\n",
-    "The ratio of these two (FLOPs/memory usage) is called the\n",
-    "*arithmetic intensity* of an operation and determines if our pipeline will\n",
-    "be compute bound or memory bound."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "gutx7y8uvZKH"
-   },
-   "source": [
-    "## Pipelining in Pallas"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "U-dPTjlBverB"
-   },
-   "source": [
-    "How do we implement a pipeline like the one above in Pallas?\n",
-    "It seems like a complex sequence of asynchronous data operations and\n",
-    "executing kernels that would be a pain to implement manually.\n",
-    "Fear not! Pallas offers an API for expressing pipelines without too much\n",
-    "boilerplate, namely through `grid`s and `BlockSpec`s.\n",
-    "\n",
-    "See how in the above pipelined example, we are executing the same logic\n",
-    "multiple times: steps 3-5 and 8-10 both execute the same operations,\n",
-    "only on different inputs.\n",
-    "The {func}`jax.experimental.pallas.pallas_call` provides a way to\n",
-    "execute a kernel multiple times, by using the `grid` argument.\n",
-    "See {ref}`pallas_grid`.\n",
-    "\n",
-    "We also use {class}`jax.experimental.pallas.BlockSpec` to specify\n",
-    "how to construct the input of each kernel invocation.\n",
-    "See {ref}`pallas_blockspec`.\n",
-    "\n",
-    "In the pipelining example above, we had `(512, 512)`-shaped arrays and\n",
-    "split them along the leading dimension into two `(256, 512)`-shaped arrays.\n",
-    "In this pipeline, our `BlockSpec.block_shape` would be `(256, 512)`.\n",
-    "On the 1st iteration we'd\n",
-    "like to select `x1` and on the second iteration we'd like to use `x2`.\n",
-    "This can be expressed with the following `index_map`:\n",
-    "\n",
-    "```python\n",
-    "def x_index_map(i):\n",
-    "  return (i, 0)\n",
-    "```\n",
-    "\n",
-    "We'd then construct the `BlockSpec`:\n",
-    "```python\n",
-    "block_spec = pl.BlockSpec((256, 512), x_index_map)\n",
-    "```\n",
-    "\n",
-    "The `BlockSpec`s for `y` and `z` will be the same as the one for `x`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "noybOKghzjwG"
-   },
-   "source": [
-    "### Putting it together\n",
-    "\n",
-    "We provide these arguments to `pallas_call` via `grid`, `in_specs` and\n",
-    "`out_specs` (`in_specs` corresponds to the tuple of positional arguments,\n",
-    "and `out_specs` corresponds to the output)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "ehKAYAwIojfv",
-    "outputId": "504bab29-83f3-4e1f-8664-1860ad15b6de"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Array([[2., 2., 2., ..., 2., 2., 2.],\n",
-       "       [2., 2., 2., ..., 2., 2., 2.],\n",
-       "       [2., 2., 2., ..., 2., 2., 2.],\n",
-       "       ...,\n",
-       "       [2., 2., 2., ..., 2., 2., 2.],\n",
-       "       [2., 2., 2., ..., 2., 2., 2.],\n",
-       "       [2., 2., 2., ..., 2., 2., 2.]], dtype=float32)"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "def add_matrices_pipelined(x: jax.Array, y: jax.Array) -> jax.Array:\n",
-    "  block_spec = pl.BlockSpec((256, 512), lambda i: (i, 0))\n",
-    "  return pl.pallas_call(\n",
-    "      add_matrices_kernel,\n",
-    "      out_shape=x,\n",
-    "      in_specs=[block_spec, block_spec],\n",
-    "      out_specs=block_spec,\n",
-    "      grid=(2,)\n",
-    "  )(x, y)\n",
-    "\n",
-    "add_matrices_pipelined(x, y)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "rkytgIZYzz4t"
-   },
-   "source": [
-    "We've only added a little bit of code to our original function to add\n",
-    "automatic pipelining but the `BlockSpec`s and `grid` do a lot of heavy\n",
-    "lifting!\n",
-    "\n",
-    "How does it work? Well, the `BlockSpec`s provide enough information to start\n",
-    "*prefetching* blocks of our input from HBM into VMEM.\n",
-    "For example, if we are starting iteration `i` of our `grid`, we can pass\n",
-    "`i + 1` into the `index_map` functions to obtain the blocks needed for the\n",
-    "next iteration. We can then start an asynchronous copy for those blocks.\n",
-    "Similarly for outputs, we can wait for the outputs of the previous iteration\n",
-    "to be copied before starting the copy for the current iteration's outputs."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "7Xtz9oMs0ZRL"
-   },
-   "source": [
-    "### Parameterizing a pipeline"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "esY4GcIB0bqQ"
-   },
-   "source": [
-    "It's common to parameterize the block shapes in our kernel. Block sizes are\n",
-    "perhaps the most important parameter to tune when optimizing the performance\n",
-    "of Pallas kernels! They give us control over the pipeline (for example,\n",
-    "picking smaller blocks adds more iterations to our pipelined loop where each\n",
-    "iteration has less work to do).\n",
-    "\n",
-    "Furthermore, we could also carve up the inputs and outputs along the 2nd\n",
-    "dimension (we are only splitting along the first right now). Let's write a\n",
-    "more general kernel that handles both of these features."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "VartelFd0YfY"
+     "user_tz": 420
+    },
+    "id": "zcqz1CA_o50a"
    },
    "outputs": [],
    "source": [
-    "def add_matrices_pipelined_2d(\n",
-    "    x: jax.Array, y: jax.Array, *, bm: int = 256, bn: int = 256\n",
-    ") -> jax.Array:\n",
-    "  m, n = x.shape\n",
-    "  block_spec = pl.BlockSpec((bm, bn), lambda i, j: (i, j))\n",
-    "  return pl.pallas_call(\n",
-    "      add_matrices_kernel,\n",
-    "      out_shape=x,\n",
-    "      in_specs=[block_spec, block_spec],\n",
-    "      out_specs=block_spec,\n",
-    "      grid=(m // bm, n // bn),\n",
-    "  )(x, y)\n",
+    "def hbm_vmem_kernel(x_hbm_ref, out_vmem_ref, scratch_vmem_ref):\n",
+    "  pltpu.sync_copy(x_hbm_ref.at[0:1], scratch_vmem_ref)\n",
+    "  out_vmem_ref[...] = scratch_vmem_ref[...] + 1\n",
     "\n",
-    "np.testing.assert_array_equal(\n",
-    "    add_matrices_pipelined_2d(x, y, bm=256, bn=256), x + y\n",
-    ")\n",
-    "np.testing.assert_array_equal(\n",
-    "    add_matrices_pipelined_2d(x, y, bm=128, bn=128), x + y\n",
-    ")\n",
-    "np.testing.assert_array_equal(\n",
-    "    add_matrices_pipelined_2d(x, y, bm=512, bn=512), x + y\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "KrfeYwaW1QA-"
-   },
-   "source": [
-    "## Handling reductions"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "P3SqEKDe3Mar"
-   },
-   "source": [
-    "How would you implement something like `jnp.sum` using `pallas_call`?\n",
-    "Specifically, we'd like to pipeline across the reduction dimension.\n",
+    "x = jax.random.uniform(jax.random.key(0), (8, 128), jnp.float32)\n",
+    "out = pl.pallas_call(hbm_vmem_kernel,\n",
+    "  in_specs=[pl.BlockSpec(memory_space=pltpu.TPUMemorySpace.ANY)],\n",
+    "  out_shape=jax.ShapeDtypeStruct((1, 128), jnp.float32),\n",
+    "  scratch_shapes=(pltpu.TPUMemorySpace.VMEM(shape=(1, 128), dtype=jnp.float32),)\n",
+    ")(x)\n",
     "\n",
-    "Take the example of reducing a `(8, 512, 512)`-shaped array to a\n",
-    "`(512, 512)`-shaped one."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "JoT-ZKEk1R7l",
-    "outputId": "fd842223-98a5-4e5c-87fc-5dadc94da4fa"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Array([[8., 8., 8., ..., 8., 8., 8.],\n",
-       "       [8., 8., 8., ..., 8., 8., 8.],\n",
-       "       [8., 8., 8., ..., 8., 8., 8.],\n",
-       "       ...,\n",
-       "       [8., 8., 8., ..., 8., 8., 8.],\n",
-       "       [8., 8., 8., ..., 8., 8., 8.],\n",
-       "       [8., 8., 8., ..., 8., 8., 8.]], dtype=float32)"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "x = jnp.ones((8, 512, 512))\n",
-    "jnp.sum(x, axis=0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "5O3ByvuT3iyC"
-   },
-   "source": [
-    "To do this using `pallas_call`, we could use a grid of size `(8,)` and in\n",
-    "each iteration `i` load `x[i]` into VMEM.\n",
-    "Then we could add `x[i]` to an output VMEM buffer. Let's implement this\n",
-    "naively first."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "hqvv_WRQ3bvP",
-    "outputId": "200648d2-3f4d-4d1a-b95a-d2c1352cd7b8"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Array([[9., 9., 9., ..., 9., 9., 9.],\n",
-       "       [9., 9., 9., ..., 9., 9., 9.],\n",
-       "       [9., 9., 9., ..., 9., 9., 9.],\n",
-       "       ...,\n",
-       "       [9., 9., 9., ..., 9., 9., 9.],\n",
-       "       [9., 9., 9., ..., 9., 9., 9.],\n",
-       "       [9., 9., 9., ..., 9., 9., 9.]], dtype=float32)"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Warning: this implementation is incorrect!\n",
-    "\n",
-    "def naive_sum_kernel(x_ref, o_ref):\n",
-    "  o_ref[...] += x_ref[...]\n",
-    "\n",
-    "def naive_sum(x: jax.Array) -> jax.Array:\n",
-    "  grid, *out_shape = x.shape\n",
-    "  return pl.pallas_call(\n",
-    "      naive_sum_kernel,\n",
-    "      grid=grid,\n",
-    "      # None in `block_shape` means we pick a size of 1 and squeeze it away\n",
-    "      in_specs=[pl.BlockSpec((None, *out_shape), lambda i: (i, 0, 0))],\n",
-    "      out_specs=pl.BlockSpec(out_shape, lambda i: (0, 0)),\n",
-    "      out_shape=jax.ShapeDtypeStruct(out_shape, x.dtype),\n",
-    "  )(x)\n",
-    "naive_sum(x)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Kv9qJYJY4jbK"
-   },
-   "source": [
-    "Notice how we've set up the `BlockSpec`s: we're loading the entirety of\n",
-    "the `(512, 512)` dimension into VMEM (no pipelining there) but selecting\n",
-    "the `i`-th dimension of `x` each iteration in the `index_map`.\n",
-    "We are using a `None` for that dimension in the block shape, which indicates\n",
-    "that we are selecting a singleton dimension from `x` that we would like\n",
-    "to squeeze away in the kernel.\n",
-    "Therefore, `x_ref` is `(512, 512)`-shaped in VMEM as well.\n",
-    "\n",
-    "`out_spec` uses `lambda i: (0, 0)` as its `index_map`, indicating that\n",
-    "`o_ref` is unchanged over the course of the pipeline.\n",
-    "This means that we can update its value each iteration by reading from and\n",
-    "writing to it. Or can it?\n",
-    "Actually there is one catch: *`o_ref` is initially garbage*, meaning we'll\n",
-    "be accumulating into garbage.\n",
-    "This will result in the overall function outputting the incorrect value!\n",
-    "\n",
-    "Therefore, **whenever we do a reduction in a kernel, we need to make sure\n",
-    "to initialize the `Ref` that is storing the reduced value**.\n",
-    "We can accomplish this by conditionally writing a value to `out_ref`\n",
-    "when we're on iteration 0.\n",
-    "We can do this with the helper function `pl.when`, a convenience wrapper\n",
-    "around `jax.lax.cond`, and `pl.program_id`,\n",
-    "which queries which iteration in a grid axis we are in."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "JXN2RthX5cSw",
-    "outputId": "195df19b-a889-479b-95b6-1fb7281f1518"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Array([[8., 8., 8., ..., 8., 8., 8.],\n",
-       "       [8., 8., 8., ..., 8., 8., 8.],\n",
-       "       [8., 8., 8., ..., 8., 8., 8.],\n",
-       "       ...,\n",
-       "       [8., 8., 8., ..., 8., 8., 8.],\n",
-       "       [8., 8., 8., ..., 8., 8., 8.],\n",
-       "       [8., 8., 8., ..., 8., 8., 8.]], dtype=float32)"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "def sum_kernel(x_ref, o_ref):\n",
-    "  @pl.when(pl.program_id(axis=0) == 0)\n",
-    "  def _():\n",
-    "    o_ref[...] = jnp.zeros_like(o_ref)\n",
-    "\n",
-    "  o_ref[...] += x_ref[...]\n",
-    "\n",
-    "def sum(x: jax.Array) -> jax.Array:\n",
-    "  grid, *out_shape = x.shape\n",
-    "  return pl.pallas_call(\n",
-    "      sum_kernel,\n",
-    "      grid=grid,\n",
-    "      # None in `block_shape` means we pick a size of 1 and squeeze it away\n",
-    "      in_specs=[pl.BlockSpec((None, *out_shape), lambda i: (i, 0, 0))],\n",
-    "      out_specs=pl.BlockSpec(out_shape, lambda i: (0, 0)),\n",
-    "      out_shape=jax.ShapeDtypeStruct(out_shape, x.dtype)\n",
-    "  )(x)\n",
-    "\n",
-    "sum(x)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "2828qXBI5ksZ"
-   },
-   "source": [
-    "This `sum` function now outputs the correct values!\n",
-    "\n",
-    "One last thing to note about reductions in Pallas are that **they must be\n",
-    "done in the minormost (rightmost) dimensions of our grid** (our grid is\n",
-    "1-dimensional in the above example so we are reducing over its minormost\n",
-    "dimension). This is because the pipeline that Pallas generates using\n",
-    "the `BlockSpec`s, `grid` and kernel function *does not read outputs back\n",
-    "from HBM*.\n",
-    "Once you've written an output value back to HBM you cannot revisit it.\n",
-    "Therefore, you cannot do a reduction across a grid dimension that has any\n",
-    "revisiting and therefore all reductions need to happen in the rightmost\n",
-    "dimensions."
+    "np.testing.assert_allclose(out, x[0:1] + 1)"
    ]
   },
   {
@@ -655,7 +180,7 @@
    "source": [
     "(pallas_tpu_megacore)=\n",
     "\n",
-    "## TPUs in Megacore configuration"
+    "### TPUs in Megacore configuration"
    ]
   },
   {
@@ -683,10 +208,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
+    "executionInfo": {
+     "elapsed": 106,
+     "status": "ok",
+     "timestamp": 1744910274556,
+     "user": {
+      "displayName": "Justin Fu",
+      "userId": "17543197034567316452"
+     },
+     "user_tz": 420
+    },
     "id": "nQNa8RaQ-TR1",
-    "outputId": "385ed87c-d95c-466c-af77-df3845c979f2"
+    "outputId": "29c0b574-3528-49a5-8a88-b6987efc69ce"
    },
    "outputs": [
     {
@@ -701,12 +236,21 @@
        "       [2., 2., 2., ..., 2., 2., 2.]], dtype=float32)"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "def add_matrices_kernel(x_vmem_ref, y_vmem_ref, z_vmem_ref):\n",
+    "  # Load x and y from VMEM into VREGs\n",
+    "  x_vregs = x_vmem_ref[:, :]\n",
+    "  y_vregs = y_vmem_ref[:, :]\n",
+    "  # Execute a vectorized add\n",
+    "  z_vregs = x_vregs + y_vregs\n",
+    "  # Store the output values in VREGs back into VMEM\n",
+    "  z_vmem_ref[:, :] = z_vregs\n",
+    "\n",
     "def add_matrices_pipelined_megacore(x: jax.Array, y: jax.Array) -> jax.Array:\n",
     "  block_spec = pl.BlockSpec((256, 512), lambda i: (i, 0))\n",
     "  return pl.pallas_call(\n",
@@ -715,7 +259,8 @@
     "      in_specs=[block_spec, block_spec],\n",
     "      out_specs=block_spec,\n",
     "      grid=(2,),\n",
-    "      compiler_params=pltpu.TPUCompilerParams(dimension_semantics=(\"parallel\",))\n",
+    "      compiler_params=pltpu.TPUCompilerParams(\n",
+    "          dimension_semantics=(\"parallel\",))\n",
     "  )(x, y)\n",
     "\n",
     "x, y = jnp.ones((512, 512)), jnp.ones((512, 512))\n",
@@ -737,28 +282,16 @@
     "\n",
     "> Note that Megacore is only currently available on TPU `v4` and TPU `v5p`. Supplying `dimension_semantics` annotations is a no-op on other platforms, but *not* specifying it will result in only one TensorCore being used (even if there are more than one available)."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "1ZJ2rV5W8FAe"
-   },
-   "source": [
-    "## Conclusion\n",
-    "\n",
-    "In this guide we covered how to express TPU pipelines using `pallas_call`,\n",
-    "`grid` and `BlockSpec`s. We covered how to express nested loops via a\n",
-    "multi-dimensional grid and how to handle reductions by initialize our\n",
-    "accumulators at the beginning of the reduction.\n",
-    "We also learned how to handle Megacore by adding annotations to the kernel.\n",
-    "\n",
-    "Exercises left to the reader:\n",
-    "* Try implementing a `sum` kernel that pipelines the other dimensions as well\n",
-    "* Add megacore support to the `add` kernel and the `sum` kernel as well."
-   ]
   }
  ],
  "metadata": {
+  "colab": {
+   "last_runtime": {
+    "build_target": "//experimental/users/justinfu/pallas:colab",
+    "kind": "private"
+   },
+   "provenance": []
+  },
   "jupytext": {
    "formats": "ipynb,md:myst"
   },


### PR DESCRIPTION
Most of the non-TPU stuff was factored out to https://docs.jax.dev/en/latest/pallas/pipelining.html

This PR removes the duplicate parts and adds some TPU-specific information.