### PR TITLE
Move DropVar annotation into Jaxpr pretty printer

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2709,6 +2709,7 @@ def broadcast_in_dim(operand: ArrayLike, shape: Shape,
   See Also:
     jax.lax.broadcast : simpler interface to add new leading dimensions.
   """
+  # TODO(dfm): Re-write this as a "reshard" when only the sharding changes.
   out_sharding = canonicalize_sharding(out_sharding, 'broadcast_in_dim')
   if (np.ndim(operand) == len(shape) and not len(broadcast_dimensions) and
       isinstance(operand, Array) and out_sharding is None):
@@ -4854,11 +4855,11 @@ def _convert_elt_type_folding_rule(consts, eqn):
 
 def _convert_elt_type_fwd_rule(eqn):
   v, = eqn.invars
-  if (not dtypes.issubdtype(eqn.params['new_dtype'], dtypes.extended) and
+  if (v.aval.dtype == eqn.params['new_dtype'] and
+      v.aval.weak_type == eqn.params['weak_type'] and
       not dtypes.issubdtype(v.aval.dtype, dtypes.extended) and
-      v.aval.dtype == eqn.params['new_dtype'] and
-      v.aval.weak_type == eqn.params['weak_type']):
-    return [v], None
+      (eqn.params['sharding'] is None or eqn.params['sharding'] == v.aval.sharding)):
+    return [0], None
   else:
     return [None], eqn
 
@@ -6451,8 +6452,10 @@ def _broadcast_in_dim_batch_rule(axis_data, batched_args, batch_dims, shape,
 
 def _broadcast_in_dim_fwd_rule(eqn):
   v, *dyn = eqn.invars
-  if not dyn and core.definitely_equal_shape(eqn.params['shape'], v.aval.shape):
-    return [v], None
+  if (not dyn and core.definitely_equal_shape(eqn.params['shape'], v.aval.shape)
+      and (eqn.params['sharding'] is None or
+           eqn.params['sharding'] == v.aval.sharding)):
+    return [0], None
   else:
     return [None], eqn
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6767,6 +6767,13 @@ class JaxprTest(jtu.JaxTestCase):
     self.assertEqual(jaxpr.eqns[0].primitive, debugging.debug_callback_p)
     self.assertStartsWith(str(jaxpr.eqns[0]), "debug_callback[", )
 
+  def test_unused_consts(self):
+    def f():
+      jnp.asarray(np.arange(5), dtype=np.float32)
+
+    jaxpr = jax.make_jaxpr(f)()
+    self.assertEmpty(jaxpr.consts)
+
 
 class DCETest(jtu.JaxTestCase):
 

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -1778,7 +1778,7 @@ class ShardMapTest(jtu.JaxTestCase):
     x = jnp.arange(16.)
     jaxpr_ = jax.make_jaxpr(jax.grad(g))(x)
     jaxpr, _ = pe.dce_jaxpr(jaxpr_.jaxpr, [True] * len(jaxpr_.out_avals))
-    e1, _, e2 = jaxpr.eqns
+    e1, *_, e2 = jaxpr.eqns
     self.assertLen(e1.outvars, 1)  # only primal output
     self.assertLen(e2.invars, 2)   # res and cotangent inputs
     self.assertEqual(sum(e1.outvars[0] is v for v in e2.invars), 1)
@@ -1801,7 +1801,7 @@ class ShardMapTest(jtu.JaxTestCase):
     x = jnp.arange(16.)
     jaxpr_ = jax.make_jaxpr(jax.grad(g))(x)
     jaxpr, _ = pe.dce_jaxpr(jaxpr_.jaxpr, [True] * len(jaxpr_.out_avals))
-    e1, _, e2 = jaxpr.eqns
+    e1, *_, e2 = jaxpr.eqns
     self.assertLen(e1.outvars, 2)  # one primal and one res output
     self.assertLen(e2.invars, 4)   # two res and two cotangent inputs
     self.assertEqual(sum(e1.outvars[-1] is v for v in e2.invars), 1)


### PR DESCRIPTION
Diffbase: https://github.com/jax-ml/jax/pull/28396

While building a `Jaxpr`, we currently label unused variables by replacing them with `DropVar` objects. This is implemented as an optimization pass after the jaxpr is built, and requires iterating through all the equations. In practice, these `DropVar` annotations only seem to be used for pretty printing (the variables are labelled with a `_` instead of a name), and this pass can be somewhat costly for large jaxprs.

In this PR, I've move the `DropVar` logic into the pretty printer so that the pass isn't executed until it is required.