### PR TITLE
Fix handling of `SymbolicZero` output when batching `custom_jvp`

### DIFF
--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -941,11 +941,11 @@ def _matchaxis_symzeros(axis_name, sz, mesh_axis, src, dst, x, sum_match=False):
       return x
     elif type(src) == type(dst) == int:
       aval = core.mapped_aval(sz, src, x.aval)
-      return Zero(core.unmapped_aval(sz, dst, aval, mesh_axis))
+      return type(x)(core.unmapped_aval(sz, dst, aval, mesh_axis))
     elif src is not_mapped and dst is not not_mapped:
-      return Zero(core.unmapped_aval(sz, dst, x.aval, mesh_axis))
+      return type(x)(core.unmapped_aval(sz, dst, x.aval, mesh_axis))
     elif dst is not_mapped and sum_match:
-      return Zero(core.mapped_aval(sz, src, x.aval))
+      return type(x)(core.mapped_aval(sz, src, x.aval))
     else:
       raise ValueError((axis_name, x, src, dst))
   else:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -8375,6 +8375,22 @@ class CustomJVPTest(jtu.JaxTestCase):
 
     jax.jvp(jax.vmap(g), (jnp.ones(3),), (jnp.ones(3),))  # don't crash
 
+  def test_symbolic_zero_under_vmap_of_jit(self):
+    # https://github.com/jax-ml/jax/issues/28144
+    @jax.custom_jvp
+    def f(x):
+        return x + 1
+
+    @f.defjvp
+    def f_jvp(x, t):
+        (x,) = x
+        (t,) = t
+        z = custom_derivatives_public.zero_from_primal(x, symbolic_zeros=True)
+        return f(x), z
+
+    x = jnp.arange(3.0)
+    jax.jvp(jax.vmap(jax.jit(f)), (x,), (x,))  # doesn't crash
+
 
 class CustomVJPTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
The "also" part of https://github.com/jax-ml/jax/pull/27886 means that the `vmap` of a `custom_jvp` can return `SymbolicZero` tangent outputs. When composed with `jit`, this results in the error reported in https://github.com/jax-ml/jax/issues/28144. The problem is that we should be returning `SymbolicZero` instead of `Zero`. Fixed!

Fixes https://github.com/jax-ml/jax/issues/28144