### PR TITLE
implement _replace_with for PRNGKeyArray

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -173,6 +173,9 @@ class PRNGKeyArray(jax.Array):
                                          [key_data], [device], committed=False)
     self._base_array = key_data
 
+  def _replace_with(self, value: PRNGKeyArray):
+    self._base_array._replace_with(value._base_array)
+
   def block_until_ready(self):
     _ = self._base_array.block_until_ready()
     return self

--- a/tests/mutable_array_test.py
+++ b/tests/mutable_array_test.py
@@ -259,6 +259,11 @@ class MutableArrayTest(jtu.JaxTestCase):
     v = core.mutable_array(jnp.array(0, dtype='bfloat16'))
     v[...] += 1.0  # don't crash
 
+  def test_rng_key(self):
+    key = core.mutable_array(jax.random.key(0))
+    # test read/write
+    key[...] = jax.random.fold_in(key[...], 1) # don't crash
+
 
 @jtu.with_config(jax_mutable_array_checks=True)
 class MutableArrayErrorsTest(jtu.JaxTestCase):


### PR DESCRIPTION
# What does this PR do?

Implements `_replace_with` for `PRNGKeyArray` so that it works with `MutableArray`.