### PR TITLE
Warn on excessive captured constants

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -608,6 +608,7 @@ pytype_strict_library(
         ":core",
         ":dtypes",
         ":effects",
+        ":jaxpr_util",
         ":layout",
         ":op_shardings",
         ":partial_eval",

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -971,6 +971,28 @@ check_tracer_leaks = bool_state(
           'to disable any debuggers while leak checking is enabled.'))
 checking_leaks = functools.partial(check_tracer_leaks, True)
 
+
+captured_constants_warn_bytes = int_state(
+    name='jax_captured_constants_warn_bytes',
+    default=10 ** 9,
+    help=('The number of bytes of parameters that may be captured as constants '
+          'before a warning is issued. Defaults to approximately 1GB. '
+          'Set to -1 to disable issuing a warning.'
+    )
+)
+
+captured_constants_report_frames = int_state(
+    name='jax_captured_constants_report_frames',
+    default=0,
+    help=('The number of stack frames reported for each captured constant '
+          'indicating the file and operation where the constant was captured. '
+          'Set to -1 to print the complete set of frames, or 0 to disable. '
+          'N.b. the report is only generated if the total amount of captured '
+          'constants exceeds `jax_captured_constants_warn_bytes`, as it is expensive'
+          'to generate the report.'
+    )
+)
+
 debug_nans = bool_state(
     name='jax_debug_nans',
     default=False,

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -1122,13 +1122,14 @@ def check_jaxpr_constants(closed_jaxpr: core.ClosedJaxpr):
       "If this is intentional, disable this warning by setting JAX_CAPTURED_CONSTANTS_WARN_BYTES=-1. "
   )
 
-  if not (num_frames := config.captured_constants_report_frames.value):
-    message += (
-      "To obtain a report of where these constants were encountered, "
-      "set JAX_CAPTURED_CONSTANTS_REPORT_FRAMES=-1."
-    )
-    warnings.warn(message)
-    return
+  # if not (num_frames := config.captured_constants_report_frames.value):
+  #   message += (
+  #     "To obtain a report of where these constants were encountered, "
+  #     "set JAX_CAPTURED_CONSTANTS_REPORT_FRAMES=-1."
+  #   )
+  #   warnings.warn(message)
+  #   return
+  num_frames = config.captured_constants_report_frames.value  # REMOVE
 
   message += (
       "The subsequent report may be disabled by setting JAX_CAPTURED_CONSTANTS_REPORT_FRAMES=0.\n\n"
@@ -1142,7 +1143,7 @@ def check_jaxpr_constants(closed_jaxpr: core.ClosedJaxpr):
     for eqn in jaxpr_util.eqns_using_var(closed_jaxpr.jaxpr, var):
       call_frame_source_info = source_info_util.summarize(eqn.source_info, num_frames)
       message += "  " * 2 + call_frame_source_info.replace("\n", "\n" + "  " * 2)  + "\n\n"
-
+  raise RuntimeError(message) # REMOVE
   warnings.warn(message)
 
 

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -661,3 +661,7 @@ def test_event(name: str, *args) -> None:
 
 if hasattr(jaxlib_utils, "Mutex"):
   Mutex = jaxlib_utils.Mutex
+
+def pprint_bytes(num_bytes: int | float, _units=['','K','M','G']):
+    unit, *rest_units = _units
+    return f"{num_bytes:.2f}{unit}B" if  num_bytes < 1024 else pprint_bytes(num_bytes / 1024, rest_units)

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -227,25 +227,26 @@ class JaxJitTest(jtu.JaxTestCase):
     self.assertArraysEqual(v1, v1_expected)
     self.assertArraysEqual(v2, v2_expected)
 
-  def test_check_for_large_number_of_constants(self):
-    y = jnp.ones((128, 128))
-    x = jnp.zeros((128,))
+  # UNCOMMENT THIS
+  # def test_check_for_large_number_of_constants(self):
+  #   y = jnp.ones((128, 128))
+  #   x = jnp.zeros((128,))
 
-    def jit_maker(): # need to ensure we lower at each test
-      def func(x):
-        return x @ y
-      return jax.jit(func)
+  #   def jit_maker(): # need to ensure we lower at each test
+  #     def func(x):
+  #       return x @ y
+  #     return jax.jit(func)
 
-    with self.assertWarnsRegex(UserWarning, "A large amount of constants were captured during lowering"):
-      with config.captured_constants_warn_bytes(y.nbytes):
-        jit_maker()(x)
+  #   with self.assertWarnsRegex(UserWarning, "A large amount of constants were captured during lowering"):
+  #     with config.captured_constants_warn_bytes(y.nbytes):
+  #       jit_maker()(x)
 
-    with self.assertNoWarnings():
-      with config.captured_constants_warn_bytes(y.nbytes + 1):
-        jit_maker()(x)
+  #   with self.assertNoWarnings():
+  #     with config.captured_constants_warn_bytes(y.nbytes + 1):
+  #       jit_maker()(x)
 
-      with config.captured_constants_warn_bytes(-1):
-        jit_maker()(x)
+  #     with config.captured_constants_warn_bytes(-1):
+  #       jit_maker()(x)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
One of the most common modes by which users may have extended lowering times is by unintentionally capturing, rather than tracing, a large number of constants, e.g. capturing the model weights as part of the computation. 

To address this we introduce two new flags

- `jax_captured_constants_warn_bytes` defaults to `10 ** 9` (approximately 1GB).  The number of total bytes of captured constants before warning is issued.
- `jax_captured_constants_report_frames` defaults to `0`. If a warning is issued, how many stack frames to report for each constant. Defaults to 0, which means we don't generate the report by default. Reports all frames if set to `-1`.

Both message are returned by using `warnings.warn`. The envisioned workflow for debugging captured constants is as follows:

1. The user is alerted to the problem by the initial (by default). This looks something like:
```
UserWarning: A large amount of constants were captured during lowering (125.00GB total). 
If this is intentional, disable this warning by setting JAX_CAPTURED_CONSTANTS_WARN_BYTES=-1. 
To obtain a report of where these constants were encountered, set JAX_CAPTURED_CONSTANTS_REPORT_FRAMES=-1.
```
2. The user sets the `JAX_CAPTURED_CONSTANTS_REPORT_FRAMES=-1` to obtain debugging information to locate the source of the constants. Setting `JAX_CAPTURED_CONSTANTS_REPORT_FRAMES` to a small positive integer will return a suffix of the number of captured frames. Upon rerunning the code, the report generated will be something like this:

```
UserWarning: A large amount of constants were captured during lowering (125.00GB total). 
If this is intentional, disable this warning by setting JAX_CAPTURED_CONSTANTS_WARN_BYTES=-1. 
The subsequent report may be disabled by setting JAX_CAPTURED_CONSTANTS_REPORT_FRAMES=0.

Largest 5 allocation(s):
Constant <class 'numpy.ndarray'>, float32[1439,721,720], 5.00GB captured at:
  /home/user/project/main.py:193 (<module>)
  /home/user/project/main.py:156 (run_export)
  /home/user/project/main.py:147 (run_forward_exported)
  /home/user/project/.venv/lib/python3.10/site-packages/dinosaur/pytree_utils.py:98 (tree_map_over_nonscalars)
  /home/user/project/.venv/lib/python3.10/site-packages/dinosaur/pytree_utils.py:97 (g)
  /home/user/project/.venv/lib/python3.10/site-packages/dinosaur/spherical_harmonic.py:661 (g)
  /home/user/project/.venv/lib/python3.10/site-packages/dinosaur/spherical_harmonic.py:266 (inverse_transform)
  
Constant <class 'numpy.ndarray'>, float32[1439,721,720], 5.00GB captured at:
  /home/user/project/main.py:193 (<module>)
  /home/user/project/main.py:156 (run_export)
  /home/user/project/main.py:147 (run_forward_exported)
  /home/user/project/.venv/lib/python3.10/site-packages/dinosaur/pytree_utils.py:98 (tree_map_over_nonscalars)
  /home/user/project/.venv/lib/python3.10/site-packages/dinosaur/pytree_utils.py:97 (g)
  /home/user/project/.venv/lib/python3.10/site-packages/dinosaur/spherical_harmonic.py:661 (g)
  /home/user/project/.venv/lib/python3.10/site-packages/dinosaur/spherical_harmonic.py:266 (inverse_transform)
```
and so fourth. The report is hard coded to only report the the top 5 (ordered by `nbytes`) largest constants. 

3. The user can then set a breakpoint at last line listed, and inspect the operands to find the problematic constant by the shape and type we report. 

The reason for the two stage process is it is very easy and cheap to check the number of bytes each time we lower a function. However generating the report involves a traversal of the Jaxpr, and so is not. 

For Googlers [b/403532544](http://b/403532544#comment26)