### PR TITLE
Automatically initialize distributed runs in K8s indexed jobs

### DIFF
--- a/.github/workflows/k8s.yaml
+++ b/.github/workflows/k8s.yaml
@@ -31,18 +31,25 @@ jobs:
 
   distributed-initialize:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        controller: [jobset, indexed-job]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           path: jax
-
+          
       - name: Start Minikube cluster
         uses: medyagh/setup-minikube@cea33675329b799adccc9526aa5daccc26cd5052 # ratchet:medyagh/setup-minikube@v0.0.19
 
       - name: Install K8s Jobset
+        if: matrix.controller == 'jobset'
         run: |
-          kubectl apply --server-side -f https://github.com/kubernetes-sigs/jobset/releases/download/v0.6.0/manifests.yaml
+          kubectl apply --server-side -f https://github.com/kubernetes-sigs/jobset/releases/download/v0.8.0/manifests.yaml
+          kubectl wait --for=condition=established crd/jobsets.jobset.x-k8s.io --timeout=60s
+          kubectl rollout status -n jobset-system deploy/jobset-controller-manager --timeout=120s
 
       - name: Build image
         run: |
@@ -56,43 +63,44 @@ jobs:
           minikube image build -t local/jax:latest .
 
       - name: Create service account for K8s job introspection
-        run: |
-          kubectl apply -f jax/examples/k8s/svc-acct.yaml
-
-      - name: Prepare test job
-        run: |
-          export VERSION=v4.44.3
-          export BINARY=yq_linux_amd64
-          wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY} -O /usr/bin/yq && chmod +x /usr/bin/yq
-
-          cat jax/examples/k8s/example.yaml |\
-            yq '.spec.replicatedJobs[0].template.spec.template.spec.containers[0].image = "local/jax:latest"' |\
-            yq '.spec.replicatedJobs[0].template.spec.template.spec.containers[0].imagePullPolicy = "Never"' |\
-            tee example.yaml
+        run: kubectl apply -f jax/examples/k8s/svc-acct.yaml
 
       - name: Submit test job
-        run: |
-          kubectl apply -f example.yaml
+        run: kubectl apply -f jax/.github/workflows/k8s/${{ matrix.controller }}.yaml
 
       - name: Check job status
         shell: bash -e -o pipefail {0}
         run: |
           while true; do
-            status=$(kubectl get jobset example -o yaml | yq .status.conditions[0].type)
+
+            completion_time=$(
+              kubectl get jobs -o yaml | \
+              yq '.items[] | select(.metadata.name | test("^jaxjob")) | .status.completionTime'
+            )
             timestamp=$(date +"%Y-%m-%d %H:%M:%S")
             echo "[$timestamp] Checking job status..."
 
-            if [ "$status" == "Completed" ]; then
-              echo "[$timestamp] Job has completed successfully!"
-              exit 0
-            elif [ "$status" == "Failed" ]; then
-              echo "[$timestamp] Job has failed!"
-              exit 1
-            else
+            if [ "$completion_time" == "null" ]; then
               echo "[$timestamp] Job is still running. Current pod status:"
               kubectl get pods --no-headers
               echo "[$timestamp] Waiting for 3 seconds before checking again..."
               sleep 3
+            else
+              succeeded=$(
+                kubectl get jobs -o yaml | \
+                yq '.items[] | select(.metadata.name | test("^jaxjob")) | .status.succeeded'
+              )
+              parallelism=$(
+                kubectl get jobs -o yaml | \
+                yq '.items[] | select(.metadata.name | test("^jaxjob")) | .spec.parallelism'
+              )
+              if [ "$succeeded" == "$parallelism" ]; then
+                echo "[$timestamp] Job has completed successfully!"
+                exit 0
+              else
+                echo "[$timestamp] Job has failed!"
+                exit 1
+              fi
             fi
           done
 

--- a/.github/workflows/k8s/indexed-job.yaml
+++ b/.github/workflows/k8s/indexed-job.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaxpods
+spec:
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector:
+    job-name: jaxjob
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: jaxjob
+spec:
+  parallelism: 8
+  completions: 8
+  completionMode: Indexed
+  backoffLimit: 0
+  template:
+    spec:
+      subdomain: jaxpods  # must match headless service name
+      serviceAccountName: jax-job-sa
+      restartPolicy: Never
+      containers:
+      - name: main
+        image: local/jax:latest
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+        command: 
+          - python
+        args:
+          - -c
+          - |
+            import jax
+            jax.distributed.initialize()
+            print(jax.devices())
+            print(jax.local_devices())
+            assert jax.process_count() > 1
+            assert len(jax.devices()) > len(jax.local_devices())

--- a/.github/workflows/k8s/jobset.yaml
+++ b/.github/workflows/k8s/jobset.yaml
@@ -7,26 +7,21 @@ spec:
   - name: workers
     template:
       spec:
-        parallelism: 2
-        completions: 2
+        parallelism: 8
+        completions: 8
         backoffLimit: 0
         template:
           spec:
-            serviceAccountName: jax-job-sa  # kubectl apply -f svc-acct.yaml
+            serviceAccountName: jax-job-sa
             restartPolicy: Never
-            imagePullSecrets:
-              # https://k8s.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-            - name: null
             containers:
             - name: main
-              image: null  # e.g. ghcr.io/nvidia/jax:jax
-              imagePullPolicy: Always
+              image: local/jax:latest
+              imagePullPolicy: Never
               resources:
                 limits:
-                  cpu: 900m
-                  # https://k8s.io/docs/tasks/manage-gpus/scheduling-gpus/
-                  nvidia.com/gpu: null
-              command: 
+                  cpu: 100m
+              command:
                 - python
               args:
                 - -c

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,11 @@ repos:
   - id: check-merge-conflict
   - id: check-toml
   - id: check-yaml
-    exclude: examples/k8s/svc-acct.yaml
+    exclude: |
+      (?x)^(
+          examples/k8s/svc-acct\.yaml |
+          \.github/workflows/k8s/indexed-job\.yaml
+      )$
   - id: end-of-file-fixer
     # only include python files
     files: \.py$

--- a/examples/k8s/svc-acct.yaml
+++ b/examples/k8s/svc-acct.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: training-job-sa
+  name: jax-job-sa
   namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10,7 +10,7 @@ metadata:
   name: pod-reader
 rules:
   - apiGroups: [""]
-    resources: ["pods"]
+    resources: ["pods", "services"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
@@ -23,7 +23,7 @@ metadata:
   namespace: default
 subjects:
   - kind: ServiceAccount
-    name: training-job-sa
+    name: jax-job-sa
     namespace: default
 roleRef: 
   kind: Role

--- a/jax/_src/clusters/k8s_cluster.py
+++ b/jax/_src/clusters/k8s_cluster.py
@@ -103,12 +103,110 @@ class K8sCluster(clusters.ClusterEnv):
       )
 
   @classmethod
-  def get_coordinator_address(cls, timeout_secs: int | None) -> str:
-    return '{job_name}-0.{jobset_name}:{port}'.format(
-      job_name=cls._pod().metadata.labels['job-name'],
-      jobset_name=cls._job().metadata.labels['jobset.sigs.k8s.io/jobset-name'],
-      port=cls._coordinator_port
+  @cache
+  def _headless_svc(cls):
+    with cls._handle_api_exception():
+      services = cls._core_api.list_namespaced_service(cls._namespace()).items
+
+    pod_labels = cls._pod().metadata.labels or {}
+    for svc in services:
+      if svc.spec.cluster_ip == "None":  # if headless service
+        svc_selector = svc.spec.selector or {}
+        if all(pod_labels.get(k) == v for k, v in svc_selector.items()):
+            return svc
+
+    # returns None if no headless service targets the current pod
+    return None
+
+  @classmethod
+  @cache
+  def _controller(cls):
+    # https://github.com/kubernetes/apimachinery/blob/7b4292b/pkg/apis/meta/v1/types.go#L235
+    # states that there cannot be more than one managing controller.
+    for owner in cls._pod().metadata.owner_references:
+      if owner.controller is True:
+        return owner
+
+    raise RuntimeError(
+      'Cannot automatically initialize distributed workload: '
+      f'pod {cls._pod().metadata.name} does not have a controller.'
     )
+
+  @classmethod
+  def get_coordinator_address(cls, timeout_secs: int | None) -> str:
+    controller = cls._controller()
+    job = cls._job()
+    pod = cls._pod()
+    if controller.kind == 'Job':
+      # if job belongs to a jobset
+      if 'jobset.sigs.k8s.io/jobset-name' in job.metadata.labels:
+        return '{job_name}-0.{subdomain}:{port}'.format(
+          job_name=job.metadata.name,
+          subdomain=job.metadata.labels['jobset.sigs.k8s.io/jobset-name'],
+          port=cls._coordinator_port
+        )
+      # if job is standalone
+      else:
+        # check if the job is associated with a headless service, which is
+        # necessary for pods to communicate with each other
+        if pod.spec.subdomain is None:
+          # check if a headless service exists but not specified as subdomain
+          svc = cls._headless_svc()
+          err_msg = (
+            "Pods within a job need a headless service in order to "
+            "communicate with each other. "
+          )
+          if svc:
+            err_msg += (
+              f"A headless service '{svc.metadata.name}' is found that "
+              "targets this job, but it is not specified as the job subdomain. "
+              "Please add the following to the job specification: "
+            )
+            fix_msg = [
+              "```",
+              "kind: Job",
+              "spec:",
+              "  ...",
+              "  template:",
+              "    spec:",
+              f"      subdomain: {svc.metadata.name}",
+              "```",
+            ]
+          else:
+            err_msg += "To fix, add the following to the job specification:"
+            fix_msg = [
+              "```",
+              "apiVersion: v1",
+              "kind: Service",
+              "metadata:",
+              "  name: jaxpods",
+              "spec:",
+              "  publishNotReadyAddresses: true",
+              "  clusterIP: None",
+              "  selector:",
+              f"    job-name: {job.metadata.name}",
+              "---",
+              "kind: Job",
+              "spec:",
+              "  ...",
+              "  template:",
+              "    spec:",
+              "      subdomain: jaxpods",
+              "```",
+            ]
+
+          raise RuntimeError('\n'.join([textwrap.fill(err_msg)] + fix_msg))
+
+        return '{job_name}-0.{subdomain}:{port}'.format(
+          job_name=job.metadata.name,
+          subdomain=pod.spec.subdomain,
+          port=cls._coordinator_port
+        )
+
+    else:
+      raise RuntimeError(
+        'In K8s, cluster automatic bootstrap only supports Job/JobSet.'
+      )
 
   @classmethod
   def get_process_count(cls) -> int:
@@ -122,5 +220,6 @@ class K8sCluster(clusters.ClusterEnv):
       return int(os.environ['JOB_COMPLETION_INDEX'])
     except KeyError:
       raise RuntimeError(
-        'K8s job must be run with `completionMode: "Indexed"`.'
+        'To enable automatic bootstrap in a K8s cluster, '
+        'jobs must be indexed by setting `completionMode: "Indexed"`.'
       )


### PR DESCRIPTION
Note that unlike a `jobset`, which automated the creation of a headless service for inter-pod communication, an indexed `job` requires a headless service to be created by the user. This code in this PR will throw out a helpful error message with instructions on how to do that.