### PR TITLE
DOC: link to ai-stack tutorials from JAX's front page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,8 +63,9 @@ JAX: High performance array computing
       :link-type: ref
       :class-card: user-guides
 
-If you're looking to train neural networks, use Flax_ and start with its tutorials.
-For an end-to-end transformer library built on JAX, see MaxText_.
+If you're looking to use JAX to train neural networks, start with the
+`JAX AI Stack Tutorials`_, and then check out the `JAX AI Stack Examples`_
+to see how JAX models can be implemented using the Flax_ framework.
 
 Ecosystem
 ---------
@@ -183,6 +184,8 @@ maintains an up-to-date list.
 .. _Grain: https://github.com/google/grain
 .. _Hugging Face Datasets: https://huggingface.co/docs/datasets/
 .. _JAX MD: https://jax-md.readthedocs.io/
+.. _JAX AI Stack Tutorials: https://docs.jaxstack.ai/en/latest/tutorials.html
+.. _JAX AI Stack Examples: https://docs.jaxstack.ai/en/latest/examples.html
 .. _Keras: https://keras.io/
 .. _Levanter: https://github.com/stanford-crfm/levanter
 .. _Lineax: https://github.com/patrick-kidger/lineax


### PR DESCRIPTION
Rendered preview: https://jax--28182.org.readthedocs.build/en/28182/