### PR TITLE
[scan] when a carry is read-only, move it to be a const

### DIFF
--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -1187,10 +1187,12 @@ def rearrange_binders(jaxpr: core.ClosedJaxpr, primals_in, tangents_in, primals_
       arg_names=new_arg_names,
       result_paths=new_result_paths,
   )
-  new_jaxpr = core.Jaxpr(jaxpr.jaxpr.constvars,
-                         new_invars, new_outvars, jaxpr.jaxpr.eqns,
-                         jaxpr.jaxpr.effects,
-                         new_debug_info)
+  constvars = jaxpr.jaxpr.constvars
+  new_effects = pe._renumber_effects(
+      (*constvars, *new_invars), (*constvars, *jaxpr.jaxpr.invars),
+      jaxpr.jaxpr.effects)
+  new_jaxpr = core.Jaxpr(constvars, new_invars, new_outvars, jaxpr.jaxpr.eqns,
+                         new_effects, new_debug_info)
   return core.ClosedJaxpr(new_jaxpr, jaxpr.consts)
 
 def _perm(primal_counts: Sequence[int], tangent_counts: Sequence[int],

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1558,17 +1558,21 @@ def move_binders_to_front(closed_jaxpr: ClosedJaxpr, to_move: Sequence[bool]
 def _move_binders_to_front(closed_jaxpr: ClosedJaxpr, to_move: tuple[bool, ...]
                            ) -> ClosedJaxpr:
   assert len(closed_jaxpr.in_avals) == len(to_move)
-  new_invars = _move_to_front(closed_jaxpr.jaxpr.invars, to_move)
-  id_map = {id(v): i for i, v in enumerate(new_invars)}
-  idx_map = {i: id_map[id(v)] for i, v in enumerate(closed_jaxpr.jaxpr.invars)}
-  new_effs = {e.replace(input_index=idx_map[e.input_index])
-              if isinstance(e, effects.JaxprInputEffect) else e
-              for e in closed_jaxpr.jaxpr.effects}
-  new_jaxpr = Jaxpr(closed_jaxpr.jaxpr.constvars, new_invars,
-                    closed_jaxpr.jaxpr.outvars, closed_jaxpr.jaxpr.eqns,
-                    new_effs, closed_jaxpr.jaxpr.debug_info)
+  constvars, invars = closed_jaxpr.jaxpr.constvars, closed_jaxpr.jaxpr.invars
+  new_invars = _move_to_front(invars, to_move)
+  new_effs = _renumber_effects(
+      (*constvars, *new_invars), (*constvars, *invars), closed_jaxpr.jaxpr.effects)
+  new_jaxpr = Jaxpr(constvars, new_invars, closed_jaxpr.jaxpr.outvars,
+                    closed_jaxpr.jaxpr.eqns, new_effs,
+                    closed_jaxpr.jaxpr.debug_info)
   new_closed_jaxpr = core.ClosedJaxpr(new_jaxpr, closed_jaxpr.consts)
   return new_closed_jaxpr
+
+def _renumber_effects(new_vars, old_vars, effs):
+  newvar_idxs = {id(v): i for i, v in enumerate(new_vars)}
+  old_to_new = {i: newvar_idxs[id(v)] for i, v in enumerate(old_vars)}
+  return {e.replace(input_index=old_to_new[e.input_index])
+          if isinstance(e, effects.JaxprInputEffect) else e for e in effs}
 
 def _move_to_front(lst: Sequence, to_move: Sequence[bool]) -> Sequence:
   return ([elt for elt, move in zip(lst, to_move) if move] +
@@ -1587,7 +1591,6 @@ def _move_outvars_to_back(jaxpr, to_move):
   new_outvars = ([e for e, m in zip(jaxpr.jaxpr.outvars, to_move) if not m] +
                  [e for e, m in zip(jaxpr.jaxpr.outvars, to_move) if     m])
   return jaxpr.replace(jaxpr=jaxpr.jaxpr.replace(outvars=new_outvars))
-
 
 
 class DynamicJaxprTracer(core.Tracer):
@@ -1670,16 +1673,19 @@ def make_jaxpr_effects(constvars, invars, outvars, eqns) -> effects.Effects:
               f"\n Equation: {eqn}\n"
               "\n Jaxpr: "
               f"{core.Jaxpr(constvars, invars, outvars, eqns, set())}")
-        invar = eqn.invars[eff.input_index]
-        if invar in mut_arrays:
+        eqn_invar = eqn.invars[eff.input_index]
+        if eqn_invar in mut_arrays:
           continue
-        if (input_index := all_vars.get(invar, sentinel)) is sentinel:
+        if (input_index := all_vars.get(eqn_invar, sentinel)) is sentinel:
+          # TODO(mattjj): ask for forgiveness
+          dbg = type('Fake', (), {'resolve_result_paths': lambda _: None})()
           raise ValueError(
                 f"`JaxprInputEffect` {eff} does not have "
-                f"corresponding input: {invar}."
+                f"corresponding jaxpr input: {eqn_invar=}."
                 f"\n Equation: {eqn}\n"
+                f"\n Effects: {eqn.effects}\n"
                 "\n Jaxpr: "
-                f"{core.Jaxpr(constvars, invars, outvars, eqns, set())}")
+                f"{core.Jaxpr(constvars, invars, outvars, eqns, set(), dbg)}")  # type: ignore
         eff = eff.replace(input_index=input_index)
       jaxpr_effects.add(eff)
   return jaxpr_effects

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6853,13 +6853,13 @@ class DCETest(jtu.JaxTestCase):
     self.assert_dce_result(
         jaxpr,   used_outputs=used_outputs,
         expected_used_inputs=expected_used_inputs,
-        expected_num_eqns=1)  # 1 b/c scan doesn't have fwding rule
+        expected_num_eqns=0)
     used_outputs[7] = expected_used_inputs[7] = True
     used_outputs[6] = expected_used_inputs[6] = True
     self.assert_dce_result(
         jaxpr,   used_outputs=used_outputs,
         expected_used_inputs=expected_used_inputs,
-        expected_num_eqns=1)
+        expected_num_eqns=0)
 
     # If we use the value at index 3 only, some of the hidden sequence must be
     # kept but the rest pruned.

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -357,15 +357,15 @@ class CoreTest(jtu.JaxTestCase):
   def test_dropvar_avals(self):
     def f(x):
       def body(c, _):
-        return c, None
+        x1, x2 = c
+        return (2 * x1, 2 * x2), None
       (x1, x2), _ = jax.lax.scan(body, (x, x), None, length=1)
       return [x2]
 
     aval = core.ShapedArray((), jnp.dtype('int32'))
     pval = pe.PartialVal.unknown(aval)
     jaxpr, _, _ = pe.trace_to_jaxpr_nounits(
-        lu.wrap_init(f,
-                     debug_info=debug_info("test", f, (0,), {})),
+        lu.wrap_init(f, debug_info=debug_info("test", f, (0,), {})),
         [pval], False)
     dropvar, b = jaxpr.eqns[0].outvars
     self.assertEqual(dropvar.aval, aval)

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -3122,7 +3122,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       return x + y
     jax.linearize(f, 1., 2.)  # don't crash
 
-  def test_readonly_carry_optimization(self):
+  def test_while_readonly_carry_optimization(self):
     # https://github.com/google/flax/issues/4700
     def foo(w, x, c_max):
       def while_cond(val):
@@ -3203,6 +3203,53 @@ class LaxControlFlowTest(jtu.JaxTestCase):
 
     outs = jax.lax.while_loop(cond_fun, body_fun, (5., 0., 3.14))
     self.assertAllClose(outs, (0., 1., 5.))
+
+  def test_scan_readonly_carry_optimization(self):
+    # https://github.com/google/flax/issues/4709
+    def f(x, y):
+      def g(_, y):
+        y, _ = jax.lax.scan(lambda y, _: (y, None), y, None, length=1)
+        return y
+      return jax.lax.cond(x < 0, g, g, x, y)
+    xs = jnp.arange(3.)
+    y = 3.
+    jax.vmap(f, (0, None), None)(xs, y)  # don't crash
+
+  @parameterized.parameters(itertools.product(range(3), repeat=4))
+  @jtu.run_on_devices("cpu")
+  def test_scan_constification_correctness(
+      self,
+      seed,
+      num_body_consts,
+      num_inplace_fwds,
+      num_noninplace_fwds):
+
+    num_fwds = num_inplace_fwds + num_noninplace_fwds
+    num_carry = num_fwds + 4
+    num_xs = 2
+    num_ys = 3
+
+    rng = np.random.RandomState(seed)
+    perm = rng.permutation(num_carry)
+    iperm = np.argsort(perm)
+
+    body_consts = [rng.randn(3) for _ in range(num_body_consts)]
+    init_vals = list(rng.uniform(size=num_carry))
+
+    def body_fun(c, _):
+      c = [c[i] for i in iperm]
+      inplace_fwds, noninplace_fwds, dont_fwd = split_list(
+          c, [num_inplace_fwds, num_noninplace_fwds])
+      dont_fwd = [jnp.sin(x) * sum(jnp.sum(c) for c in body_consts)
+                  for x in dont_fwd]
+      new_c_perm = [*inplace_fwds, *dont_fwd, *noninplace_fwds]
+      new_c = [new_c_perm[i] for i in perm]
+      return new_c, [0 for _ in range(num_ys)]
+
+    xs = [jnp.arange(2.) for _ in range(num_xs)]
+    outs = jax.lax.scan(body_fun, init_vals, xs)[0]
+    outs_ref = body_fun(body_fun(init_vals, [x[0] for x in xs])[0], [x[1] for x in xs])[0]
+    self.assertAllClose(outs, outs_ref, check_dtypes=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is like the scan version of #27970, which applied to while_loop.

Fixes google/flax#4709

I'm not sure if relying on these optimizations is a good idea for NNX, but they seem nice and lightweight...

---

There are more forwarding-like optimizations we _could_ do to scan, though I'm not sure if we _should_. Here are some tentative notes:

Forwarding must account for scan having different kinds of inputs/outputs (const-, carry-, and extensive-inputs; carry- and extensive-outputs), and the loop structure (where carry-outputs are consumed by carry-inputs):
  1. carry-to-carry forwarding *in the same place* means the var is actually      read-only, so the carry input can be moved to a const input and the     carry output can be pruned;
  2. extensive-input-to-extensive-output forwarding means the var is     read-only but being sliced as part of the scan, so we can prune the     output (and not change the input kind);
  3. const-to-extensive-output forwarding means the caller's input is     effectively being broadcast, so we can prune the output but insert a     broadcast in the caller (i.e. it's not a forward of the input value);
  4. const-to-carry and extensive-input-to-carry forwarding don't have a     clear optimization in general, since the first iteration might use the     initial carry values;
  5. carry-to-extensive-output forwarding, representing a delayed output     like extensive-input-to-carry forwarding represents a delayed input,     doesn't have a clear optimization in general, and these delayed     inputs/outputs may be intentional pipelining.