### PR TITLE
Updated TSAN suppressions files to get traceback of crashed process

### DIFF
--- a/.github/workflows/tsan-suppressions_3.13.txt
+++ b/.github/workflows/tsan-suppressions_3.13.txt
@@ -8,9 +8,6 @@ race:dnnl_sgemm
 # https://github.com/python/cpython/issues/128050
 race:partial_vectorcall_fallback
 
-# Likely only happens when the process is crashing.
-race:dump_traceback
-
 # https://github.com/python/cpython/issues/128137
 # Fixed in Python 3.14, but not backported to 3.13.
 race:immortalize_interned

--- a/.github/workflows/tsan-suppressions_3.14.txt
+++ b/.github/workflows/tsan-suppressions_3.14.txt
@@ -8,9 +8,6 @@ race:dnnl_sgemm
 # https://github.com/python/cpython/issues/128050
 race:partial_vectorcall_fallback
 
-# Likely only happens when the process is crashing.
-race:dump_traceback
-
 # https://github.com/python/cpython/issues/129748
 race:mi_block_set_nextx
 


### PR DESCRIPTION
Removed `dump_traceback` suppression to see the full traceback when we have a crashed process.