### PR TITLE
fix: make build.py use /usr/bin/env python3 as shebang

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright 2018 The JAX Authors.
 #


### PR DESCRIPTION
The `/usr/bin/python` path isn't valid on all systems. Typically that refers to python 2,
which most systems no longer provide.

To fix, use `/usr/bin/env python3`. This uses the python version from the caller's
environment, which matches how the docs say to invoke it.