### PR TITLE
Add `debug.capture()` callback wrapper for argument-free debug printing

### DIFF
--- a/jax/debug.py
+++ b/jax/debug.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__all__ = ["callback", "print", "DebugEffect", "visualize_array_sharding",
+__all__ = ["callback", "capture", "print", "DebugEffect", "visualize_array_sharding",
            "inspect_array_sharding", "visualize_sharding", "breakpoint"]
 from jax._src.debugging import debug_callback as callback
+from jax._src.debugging import debug_capture as capture
 from jax._src.debugging import debug_print as print
 from jax._src.debugging import DebugEffect
 from jax._src.debugging import visualize_array_sharding


### PR DESCRIPTION
This adds a wrapper around `debug.callback()` that automatically converts captured local variables to callback arguments for staging, and reconstructing with runtime values. The motivation and constraints on staging out things like f-strings in `debug.print` were discussed in #26296, instead this solution is based on "lambda capture" (closures) to remove the need for manually maintaining a separate list of arguments.

Closes: #26296