### PR TITLE
Relax constraints in `jnp.vectorize` for output shapes with default signature

### DIFF
--- a/tests/lax_numpy_vectorize_test.py
+++ b/tests/lax_numpy_vectorize_test.py
@@ -287,6 +287,15 @@ class VectorizeTest(jtu.JaxTestCase):
       with self.assertNoWarnings():
         f2(rank2, rank1)
 
+  def test_non_scalar_outputs_and_default_signature(self):
+    def f(x):
+      self.assertEqual(np.shape(x), ())
+      return x + jnp.linspace(-1, 1, out_dim)
+
+    out_dim = 5
+    self.assertEqual(jnp.vectorize(f)(0.5).shape, (out_dim,))
+    self.assertEqual(jnp.vectorize(f)(jnp.ones(3)).shape, (3, out_dim))
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
The docs for both [`jnp.vectorize`](https://docs.jax.dev/en/latest/_autosummary/jax.numpy.vectorize.html) and [`np.vectorize`](https://numpy.org/doc/stable/reference/generated/numpy.vectorize.html) say that if `signature is None`:

> By default, `pyfunc` is assumed to take scalars as input and output.

But, it turns out that numpy is a little less strict than JAX here. As described in https://github.com/jax-ml/jax/issues/28294, for the default signature, numpy assumes scalar inputs, but arbitrary shapes of outputs. I came across this difference when helping a user debug some issues, and realized that I had always assumed the more flexible behavior, and I think it would be reasonable to support this use case.

This PR updates JAX's behavior to match numpy's implicit behavior and updated the JAX docstring.

Fixes https://github.com/jax-ml/jax/issues/28294