### PR TITLE
Handle extended dtypes in FFI lowering

### DIFF
--- a/jax/_src/ffi.py
+++ b/jax/_src/ffi.py
@@ -135,7 +135,7 @@ def include_dir() -> str:
 
 
 def _aval_shape(aval: core.AbstractValue) -> Shape:
-  return () if aval is core.abstract_token else aval.shape  # pytype: disable=attribute-error
+  return () if aval is core.abstract_token else core.physical_aval(aval).shape  # pytype: disable=attribute-error
 
 
 def _convert_layout_for_lowering(

--- a/tests/debugging_primitives_test.py
+++ b/tests/debugging_primitives_test.py
@@ -290,6 +290,13 @@ class DebugPrintTest(jtu.JaxTestCase):
     actual = tuple(sorted(map(int, output().splitlines())))
     self.assertEqual(actual, tuple(range(4)))
 
+  def test_debug_print_extended_dtype(self):
+    def f(k):
+      jax.debug.print("{}", k)
+    with jtu.capture_stdout():
+      f(jax.random.key(0))  # doesn't crash
+      jax.effects_barrier()
+
 
 @jtu.thread_unsafe_test_class()  # printing isn't thread-safe
 class DebugPrintTransformationTest(jtu.JaxTestCase):

--- a/tests/ffi_test.py
+++ b/tests/ffi_test.py
@@ -286,6 +286,11 @@ class FfiTest(jtu.JaxTestCase):
   def test_extend_import_shim(self):
     ffi_call_geqrf(jnp.ones((4, 5), dtype=np.float32), _use_extend=True)
 
+  def test_extended_dtype_lowering(self):
+    def f(x):
+      return jax.ffi.ffi_call("edtype", (), has_side_effect=True)(x)
+    jax.jit(f).lower(jax.random.key(0))   # doesn't crash
+
 
 def ffi_call_geqrf(x, _use_extend=False, **kwargs):
   if jtu.test_device_matches(["cpu"]):


### PR DESCRIPTION
As reported in https://github.com/jax-ml/jax/issues/28095, the FFI migration of our callbacks regressed support for extended dtypes. This is because the default layouts used in the FFI path didn't properly support extended dtypes. This fixes that change by adding support for these types, and the callback behavior now matches earlier JAX versions.

That being said, it might be useful to add special handling of random keys into callbacks so that they get re-wrapped back into a key type rather than a uint array.