### PR TITLE
Show Literal dtypes when pretty printing Jaxprs

### DIFF
--- a/docs/aot.md
+++ b/docs/aot.md
@@ -49,7 +49,11 @@ some other features along the way. An example:
 
 >>> # Print the specialized, staged-out representation (as Jaxpr IR)
 >>> print(traced.jaxpr)
-{ lambda ; a:i32[] b:i32[]. let c:i32[] = mul 2 a; d:i32[] = add c b in (d,) }
+{ lambda ; a:i32[] b:i32[]. let
+    c:i32[] = mul 2:i32 a
+    d:i32[] = add c b
+  in (d,) }
+
 
 >>> lowered = traced.lower()
 

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2396,7 +2396,7 @@ def make_jaxpr(
       c:f32[] = sin a
       _:f32[] = sin b
       d:f32[] = cos b
-      e:f32[] = mul 1.0 d
+      e:f32[] = mul 1.0:f32 d
       f:f32[] = neg e
       g:f32[] = mul f c
     in (g,) }

--- a/jax/_src/state/indexing.py
+++ b/jax/_src/state/indexing.py
@@ -324,5 +324,5 @@ class NDIndexer:
       if isinstance(idx, Slice):
         indices.append(_pp_slice(context, dim, idx))
       else:
-        indices.append(core.pp_var(idx, context))  # type: ignore
+        indices.append(core.pp_var(idx, context, print_literal_dtype=False))  # type: ignore
     return pp.concat([pp.text("["), pp.text(",".join(indices)), pp.text("]")])

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6657,7 +6657,8 @@ class JaxprTest(jtu.JaxTestCase):
     def fun(x):
       return (x, 1., np.zeros(1, dtype=jnp.float32))
 
-    expected = "{ lambda a:f32[1]; b:f32[]. let  in (b, 1.0, a) }"
+    dtype = "f64" if config.enable_x64.value else "f32"
+    expected = f"{{ lambda a:f32[1]; b:f32[]. let  in (b, 1.0:{dtype}, a) }}"
     jaxpr = api.make_jaxpr(fun)(jnp.float32(0.))
     self.assertMultiLineStrippedEqual(expected, str(jaxpr))
 
@@ -6669,9 +6670,9 @@ class JaxprTest(jtu.JaxTestCase):
                       x + 2.,
                       lambda xf: xf - x)
     expected = """{ lambda ; a:f32[]. let
-    b:bool[] = ge a 0.0
-    c:f32[] = add a 1.0
-    d:f32[] = add a 2.0
+    b:bool[] = ge a 0.0:f32
+    c:f32[] = add a 1.0:f32
+    d:f32[] = add a 2.0:f32
     e:i32[] = convert_element_type[new_dtype=int32 weak_type=False] b
     f:f32[] = cond[
       branches=(

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -1274,7 +1274,7 @@ class PJitTest(jtu.BufferDonationTestCase):
                 b:f32[1] = pjit[
                   name=<lambda>
                   jaxpr={ lambda ; a:f32[1] c:f32[]. let b:f32[1] = mul a c in (b,) }
-                ] a 1.0
+                ] a 1.0:f32
               in (b,) }
         """).strip(),
     )
@@ -1308,7 +1308,7 @@ class PJitTest(jtu.BufferDonationTestCase):
             { lambda ; a:f32[1]. let
                 b:i32[] c:f32[1] = pjit[
                   name=<lambda>
-                  jaxpr={ lambda ; a:f32[1]. let  in (2, a) }
+                  jaxpr={ lambda ; a:f32[1]. let  in (2:i32, a) }
                 ] a
               in (b, c) }
         """).strip(),

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -361,7 +361,7 @@ class StatePrimitivesTest(jtu.JaxTestCase):
       return []
     jaxpr, _ , _, () = pe.trace_to_jaxpr_dynamic(
         wrap_init(body, 1), [shaped_array_ref((), jnp.int32)])
-    self.assertIn("a[] <- 2", jaxpr.pretty_print(use_color=False))
+    self.assertIn("a[] <- 2:i32", jaxpr.pretty_print(use_color=False))
 
     def body(x_ref, val):
       x_ref[:, 0] = val
@@ -377,7 +377,7 @@ class StatePrimitivesTest(jtu.JaxTestCase):
       return [x]
     jaxpr, _ , _, () = pe.trace_to_jaxpr_dynamic(
         wrap_init(body, 1), [shaped_array_ref((), jnp.int32)])
-    self.assertIn("b:i32[], a[] <- a[], 2", jaxpr.pretty_print(use_color=False))
+    self.assertIn("b:i32[], a[] <- a[], 2:i32", jaxpr.pretty_print(use_color=False))
 
     def body(x_ref, val):
       x = ref_swap(x_ref, (slice(None), 0), val)


### PR DESCRIPTION
Before this change:

```python
>>> jax.make_jaxpr(lambda x: x + 1.0)(0.5)
{ lambda ; a:f32[]. let b:f32[] = add a 1.0 in (b,) }
```

After:

```python
>>> jax.make_jaxpr(lambda x: x + 1.0)(0.5)
{ lambda ; a:f32[]. let b:f32[] = add a 1.0:f32 in (b,) }
```

This came up when debugging x64 behavior, and has been requested informally in some other contexts.

A literal's dtype can typically be inferred from the context, so this isn't necessarily always useful, and it does make the output a little busier. If folks object, perhaps we could put this under a flag? But, I'd probably just enable this unconditionally otherwise.