### PR TITLE
Disable logsumexp test under SciPy 1.15.

### DIFF
--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -113,6 +113,11 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
                     keepdims, return_sign, use_b):
     if jnp.issubdtype(dtype, jnp.complexfloating) and scipy_version < (1, 13, 0):
       self.skipTest("logsumexp of complex input uses scipy 1.13.0 semantics.")
+    if use_b and scipy_version >= (1, 15) and scipy_version < (1, 15, 3):
+      self.skipTest(
+          "TODO(https://github.com/scipy/scipy/issues/22903): logsumexp with a"
+          " b scale array is buggy in scipy 1.15"
+      )
     if not jtu.test_device_matches(["cpu", "gpu"]):
       rng = jtu.rand_some_inf_and_nan(self.rng())
     else:


### PR DESCRIPTION
I found https://github.com/scipy/scipy/issues/22903 to reproduce in JAX's CI in the right environment.