### PR TITLE
Need to raise rtol/atol for Mosaic attn bfloat16 

### DIFF
--- a/jax/experimental/pallas/ops/gpu/attention_mgpu.py
+++ b/jax/experimental/pallas/ops/gpu/attention_mgpu.py
@@ -533,7 +533,7 @@ def _attention_bwd(config: TuningConfig, save_residuals: bool, res, do):
     pipeline(q_ref, do_ref, lse_ref, delta_ref)
 
   q_scratch = plgpu.SMEM(
-      (compute_wgs, config.block_q_dq, head_dim), q_ref.dtype,
+      (compute_wgs, config.block_q_dq, head_dim), q.dtype,
       transforms=(tiling, swizzle),
   )
   do_scratch = q_scratch

--- a/jax/experimental/pallas/ops/gpu/attention_mgpu.py
+++ b/jax/experimental/pallas/ops/gpu/attention_mgpu.py
@@ -554,12 +554,12 @@ def _attention_bwd(config: TuningConfig, save_residuals: bool, res, do):
   )(q, k, v, do, lse, delta)
 
   k_scratch = plgpu.SMEM(
-          (compute_wgs, config.block_kv_dkv, head_dim), k_ref.dtype,
+          (compute_wgs, config.block_kv_dkv, head_dim), k.dtype,
           transforms=(tiling, swizzle),
       )
   v_scratch = k_scratch
   out_shape_kv = jax.ShapeDtypeStruct(
-      (batch_size, kv_seq_len, num_q_heads, head_dim), k_ref.dtype)
+      (batch_size, kv_seq_len, num_q_heads, head_dim), k.dtype)
   dk, dv = plgpu.kernel(
     partial(kernel_dkv, block_q=config.block_q_dkv, block_kv=config.block_kv_dkv),
     out_shape=[out_shape_kv, out_shape_kv],

--- a/tests/pallas/mgpu_attention_test.py
+++ b/tests/pallas/mgpu_attention_test.py
@@ -79,6 +79,7 @@ class FlashAttentionTestCase(jtu.JaxTestCase):
       head_dim,
       attention_impl,
       save_residuals,
+      dtype,
   ):
     num_q_heads, num_kv_heads = num_q_and_kv_heads
     k1, k2, k3 = jax.random.split(jax.random.key(42), 3)

--- a/tests/pallas/mgpu_attention_test.py
+++ b/tests/pallas/mgpu_attention_test.py
@@ -96,11 +96,11 @@ class FlashAttentionTestCase(jtu.JaxTestCase):
         save_residuals=save_residuals,
     )
     out_ref, *res_ref = attention_mgpu.attention_reference(q, k, v, save_residuals=save_residuals)
-    np.testing.assert_allclose(out, out_ref, atol=2e-3, rtol=1e-3)
+    np.testing.assert_allclose(out, out_ref, atol=1e-2, rtol=8e-3)
     if save_residuals:
       (lse,) = res[0]
       (lse_ref,) = res_ref[0]
-      np.testing.assert_allclose(lse, lse_ref, atol=2e-3, rtol=1e-3)
+      np.testing.assert_allclose(lse, lse_ref, atol=1e-2, rtol=8e-3)
 
   @parameterized.product(
       batch_size=(3,),

--- a/tests/pallas/mgpu_attention_test.py
+++ b/tests/pallas/mgpu_attention_test.py
@@ -68,6 +68,7 @@ class FlashAttentionTestCase(jtu.JaxTestCase):
           attention_mgpu.attention_with_pipeline_emitter,
       ),
       save_residuals=(True,),
+      dtype=(jnp.float16, jnp.bfloat16),
   )
   def test_flash_attention(
       self,
@@ -81,9 +82,9 @@ class FlashAttentionTestCase(jtu.JaxTestCase):
   ):
     num_q_heads, num_kv_heads = num_q_and_kv_heads
     k1, k2, k3 = jax.random.split(jax.random.key(42), 3)
-    q = jax.random.normal(k1, (batch_size, q_seq_len, num_q_heads, head_dim), jnp.float16)
-    k = jax.random.normal(k2, (batch_size, kv_seq_len, num_kv_heads, head_dim), jnp.float16)
-    v = jax.random.normal(k3, (batch_size, kv_seq_len, num_kv_heads, head_dim), jnp.float16)
+    q = jax.random.normal(k1, (batch_size, q_seq_len, num_q_heads, head_dim), dtype)
+    k = jax.random.normal(k2, (batch_size, kv_seq_len, num_kv_heads, head_dim), dtype)
+    v = jax.random.normal(k3, (batch_size, kv_seq_len, num_kv_heads, head_dim), dtype)
     out, *res = attention_impl(
         q,
         k,


### PR DESCRIPTION
1. change attention_mgpu.py hard coded float16 type
2. add dtype for q k v in mgpu_attention_test.py
3. raise atol / rtol 
```
bazel test  --override_repository=xla=/data/zhonglin/oss/xla    \
                   --config=ci_linux_x86_64_cuda   \
                   --test_env=JAX_NUM_GENERATED_CASES=1   \
                   --//jax:build_jaxlib=true --jobs=8  \
                   --test_env=XLA_PYTHON_CLIENT_ALLOCATOR=platform   \
                   --test_tag_filters=multiaccelerator  \
                    --test_env=JAX_ENABLE_X64=true    \
                    --test_env=JAX_SKIP_SLOW_TESTS=true    \
                    --test_env=PYTHON_GIL=0     \
                    --test_env=JAX_TEST_NUM_THREADS=8      \
                    --local_test_jobs=8    \
                    --test_timeout=600   \
                    --define xnn_enable_avxvnniint8=false   \
                    --define xnn_enable_avx512fp16=false    \
                    --test_tag_filters=-multiaccelerator. \
                    //tests/pallas:mgpu_attention_test_gpu --test_output=all
```