### PR TITLE
Simplifiy numpy_collate in PyTorch data loading example

### DIFF
--- a/docs/notebooks/Neural_Network_and_Data_Loading.ipynb
+++ b/docs/notebooks/Neural_Network_and_Data_Loading.ipynb
@@ -316,16 +316,16 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from jax.tree_util import tree_map\n",
-    "from torch.utils.data import DataLoader, default_collate\n",
+    "from torch.utils.data import DataLoader\n",
     "from torchvision.datasets import MNIST\n",
     "\n",
     "def numpy_collate(batch):\n",
     "  \"\"\"\n",
-    "  Collate function specifies how to combine a list of data samples into a batch.\n",
-    "  default_collate creates pytorch tensors, then tree_map converts them into numpy arrays.\n",
+    "  Collate function specifies how to combine a list of (input, label) tuples into a batch.\n",
+    "  Separates the inputs and labels, then stacks them into NumPy arrays along a new leading batch dimension.\n",
     "  \"\"\"\n",
-    "  return tree_map(np.asarray, default_collate(batch))\n",
+    "  inputs, labels = zip(*batch)\n",
+    "  return np.stack(inputs), np.stack(labels)\n",
     "\n",
     "def flatten_and_cast(pic):\n",
     "  \"\"\"Convert PIL image to flat (1-dimensional) numpy array.\"\"\"\n",
@@ -338,105 +338,7 @@
    "metadata": {
     "id": "l314jsfP4TN4"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz\n",
-      "Failed to download (trying next):\n",
-      "HTTP Error 404: Not Found\n",
-      "\n",
-      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz\n",
-      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz to /tmp/mnist/MNIST/raw/train-images-idx3-ubyte.gz\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100.0%\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Extracting /tmp/mnist/MNIST/raw/train-images-idx3-ubyte.gz to /tmp/mnist/MNIST/raw\n",
-      "\n",
-      "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz\n",
-      "Failed to download (trying next):\n",
-      "HTTP Error 404: Not Found\n",
-      "\n",
-      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz\n",
-      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz to /tmp/mnist/MNIST/raw/train-labels-idx1-ubyte.gz\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100.0%\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Extracting /tmp/mnist/MNIST/raw/train-labels-idx1-ubyte.gz to /tmp/mnist/MNIST/raw\n",
-      "\n",
-      "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz\n",
-      "Failed to download (trying next):\n",
-      "HTTP Error 404: Not Found\n",
-      "\n",
-      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz\n",
-      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz to /tmp/mnist/MNIST/raw/t10k-images-idx3-ubyte.gz\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100.0%\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Extracting /tmp/mnist/MNIST/raw/t10k-images-idx3-ubyte.gz to /tmp/mnist/MNIST/raw\n",
-      "\n",
-      "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz\n",
-      "Failed to download (trying next):\n",
-      "HTTP Error 404: Not Found\n",
-      "\n",
-      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz\n",
-      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz to /tmp/mnist/MNIST/raw/t10k-labels-idx1-ubyte.gz\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100.0%"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Extracting /tmp/mnist/MNIST/raw/t10k-labels-idx1-ubyte.gz to /tmp/mnist/MNIST/raw\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define our dataset, using torch datasets\n",
     "mnist_dataset = MNIST('/tmp/mnist/', download=True, transform=flatten_and_cast)\n",
@@ -499,30 +401,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch 0 in 5.53 sec\n",
-      "Training set accuracy 0.9156666994094849\n",
-      "Test set accuracy 0.9199000000953674\n",
-      "Epoch 1 in 1.13 sec\n",
-      "Training set accuracy 0.9370499849319458\n",
-      "Test set accuracy 0.9383999705314636\n",
-      "Epoch 2 in 1.12 sec\n",
-      "Training set accuracy 0.9490833282470703\n",
-      "Test set accuracy 0.9467999935150146\n",
-      "Epoch 3 in 1.21 sec\n",
-      "Training set accuracy 0.9568833708763123\n",
+      "Epoch 0 in 5.44 sec\n",
+      "Training set accuracy 0.9157000184059143\n",
+      "Test set accuracy 0.9200999736785889\n",
+      "Epoch 1 in 1.06 sec\n",
+      "Training set accuracy 0.9371166825294495\n",
+      "Test set accuracy 0.9384999871253967\n",
+      "Epoch 2 in 1.04 sec\n",
+      "Training set accuracy 0.9492166638374329\n",
+      "Test set accuracy 0.946899950504303\n",
+      "Epoch 3 in 1.08 sec\n",
+      "Training set accuracy 0.9569000005722046\n",
       "Test set accuracy 0.9532999992370605\n",
-      "Epoch 4 in 1.17 sec\n",
-      "Training set accuracy 0.9631666541099548\n",
-      "Test set accuracy 0.9574999809265137\n",
-      "Epoch 5 in 1.17 sec\n",
-      "Training set accuracy 0.9675000309944153\n",
-      "Test set accuracy 0.9615999460220337\n",
-      "Epoch 6 in 1.11 sec\n",
-      "Training set accuracy 0.9709500074386597\n",
-      "Test set accuracy 0.9652999639511108\n",
-      "Epoch 7 in 1.17 sec\n",
-      "Training set accuracy 0.9736999869346619\n",
-      "Test set accuracy 0.967199981212616\n"
+      "Epoch 4 in 1.11 sec\n",
+      "Training set accuracy 0.9630166888237\n",
+      "Test set accuracy 0.9575999975204468\n",
+      "Epoch 5 in 1.04 sec\n",
+      "Training set accuracy 0.9673666954040527\n",
+      "Test set accuracy 0.9614999890327454\n",
+      "Epoch 6 in 1.02 sec\n",
+      "Training set accuracy 0.9708499908447266\n",
+      "Test set accuracy 0.9648999571800232\n",
+      "Epoch 7 in 1.07 sec\n",
+      "Training set accuracy 0.9736666679382324\n",
+      "Test set accuracy 0.9668999910354614\n"
      ]
     }
    ],

--- a/docs/notebooks/Neural_Network_and_Data_Loading.ipynb
+++ b/docs/notebooks/Neural_Network_and_Data_Loading.ipynb
@@ -329,7 +329,7 @@
     "\n",
     "def flatten_and_cast(pic):\n",
     "  \"\"\"Convert PIL image to flat (1-dimensional) numpy array.\"\"\"\n",
-    "  return np.ravel(np.array(pic, dtype=jnp.float32))"
+    "  return np.ravel(np.array(pic, dtype=np.float32))"
    ]
   },
   {
@@ -401,30 +401,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch 0 in 5.44 sec\n",
-      "Training set accuracy 0.9157000184059143\n",
-      "Test set accuracy 0.9200999736785889\n",
+      "Epoch 0 in 5.35 sec\n",
+      "Training set accuracy 0.9157333374023438\n",
+      "Test set accuracy 0.9197999835014343\n",
       "Epoch 1 in 1.06 sec\n",
-      "Training set accuracy 0.9371166825294495\n",
+      "Training set accuracy 0.9373166561126709\n",
       "Test set accuracy 0.9384999871253967\n",
-      "Epoch 2 in 1.04 sec\n",
-      "Training set accuracy 0.9492166638374329\n",
+      "Epoch 2 in 1.02 sec\n",
+      "Training set accuracy 0.94923335313797\n",
       "Test set accuracy 0.946899950504303\n",
-      "Epoch 3 in 1.08 sec\n",
-      "Training set accuracy 0.9569000005722046\n",
+      "Epoch 3 in 1.04 sec\n",
+      "Training set accuracy 0.9568833708763123\n",
       "Test set accuracy 0.9532999992370605\n",
-      "Epoch 4 in 1.11 sec\n",
-      "Training set accuracy 0.9630166888237\n",
-      "Test set accuracy 0.9575999975204468\n",
-      "Epoch 5 in 1.04 sec\n",
+      "Epoch 4 in 1.02 sec\n",
+      "Training set accuracy 0.9631333351135254\n",
+      "Test set accuracy 0.9577999711036682\n",
+      "Epoch 5 in 1.03 sec\n",
       "Training set accuracy 0.9673666954040527\n",
-      "Test set accuracy 0.9614999890327454\n",
-      "Epoch 6 in 1.02 sec\n",
-      "Training set accuracy 0.9708499908447266\n",
-      "Test set accuracy 0.9648999571800232\n",
-      "Epoch 7 in 1.07 sec\n",
-      "Training set accuracy 0.9736666679382324\n",
-      "Test set accuracy 0.9668999910354614\n"
+      "Test set accuracy 0.9617999792098999\n",
+      "Epoch 6 in 1.07 sec\n",
+      "Training set accuracy 0.9709166884422302\n",
+      "Test set accuracy 0.9645999670028687\n",
+      "Epoch 7 in 1.08 sec\n",
+      "Training set accuracy 0.9737666845321655\n",
+      "Test set accuracy 0.967199981212616\n"
      ]
     }
    ],

--- a/docs/notebooks/Neural_Network_and_Data_Loading.md
+++ b/docs/notebooks/Neural_Network_and_Data_Loading.md
@@ -204,7 +204,7 @@ def numpy_collate(batch):
 
 def flatten_and_cast(pic):
   """Convert PIL image to flat (1-dimensional) numpy array."""
-  return np.ravel(np.array(pic, dtype=jnp.float32))
+  return np.ravel(np.array(pic, dtype=np.float32))
 ```
 
 ```{code-cell} ipython3

--- a/docs/notebooks/Neural_Network_and_Data_Loading.md
+++ b/docs/notebooks/Neural_Network_and_Data_Loading.md
@@ -191,16 +191,16 @@ JAX is laser-focused on program transformations and accelerator-backed NumPy, so
 :id: 94PjXZ8y3dVF
 
 import numpy as np
-from jax.tree_util import tree_map
-from torch.utils.data import DataLoader, default_collate
+from torch.utils.data import DataLoader
 from torchvision.datasets import MNIST
 
 def numpy_collate(batch):
   """
-  Collate function specifies how to combine a list of data samples into a batch.
-  default_collate creates pytorch tensors, then tree_map converts them into numpy arrays.
+  Collate function specifies how to combine a list of (input, label) tuples into a batch.
+  Separates the inputs and labels, then stacks them into NumPy arrays along a new leading batch dimension.
   """
-  return tree_map(np.asarray, default_collate(batch))
+  inputs, labels = zip(*batch)
+  return np.stack(inputs), np.stack(labels)
 
 def flatten_and_cast(pic):
   """Convert PIL image to flat (1-dimensional) numpy array."""


### PR DESCRIPTION
This PR simplifies ```numpy_collate``` function in PyTorch data loading example notebook.
- Removed call to PyTorch ```default_collate``` avoiding unnecessary conversion to PyTorch tensors.
- Simplified ```PIL -> NumPy -> PyTorch -> NumPy``` conversions to ```PIL -> NumPy``` (for combined ```flatten_and_cast``` and ```numpy_collate```).
