### PR TITLE
Replace `safe_zip(*)` with `zip(*, strict=True)` in cases where list output is not necessary

### DIFF
--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -649,7 +649,7 @@ def vtile(f_flat: lu.WrappedFun,
 
   @lu.transformation2
   def _map_to_tile(f, *args_flat):
-    sizes = (x.shape[i] for x, i in safe_zip(args_flat, in_axes_flat) if i is not None)
+    sizes = (x.shape[i] for x, i in unsafe_zip(args_flat, in_axes_flat, strict=True) if i is not None)
     tile_size_ = tile_size or next(sizes, None)
     assert tile_size_ is not None, "No mapped arguments?"
     outputs_flat = f(*map(tile_axis(tile_size=tile_size_), args_flat, in_axes_flat))

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -7077,7 +7077,7 @@ def _get_spec_size(sp, mesh):
 def _split_an_axis_sharding_rule(operand, out_split, new_sizes, dimensions):
   new_spec = []
   mesh = operand.sharding.mesh
-  for out, sp in safe_zip(out_split, operand.sharding.spec):
+  for out, sp in unsafe_zip(out_split, operand.sharding.spec, strict=True):
     if isinstance(out, list):
       if sp is None:
         new_spec.extend([None] * len(out))
@@ -7492,7 +7492,7 @@ def _reduce_dtype_rule(*avals, computation, jaxpr, dimensions):
 def _reduce_weak_type_rule(*avals, computation, jaxpr, dimensions):
   operand_avals, init_val_avals = split_list(avals, [len(avals) // 2])
   return [op.weak_type and init_val.weak_type
-          for op, init_val in safe_zip(operand_avals, init_val_avals)]
+          for op, init_val in unsafe_zip(operand_avals, init_val_avals, strict=True)]
 
 def _reduce_batch_rule(batched_args, batch_dims, *, computation, jaxpr,
                        dimensions):
@@ -7589,7 +7589,7 @@ def _reduce_lower(ctx, *values, computation, jaxpr, dimensions):
                                       dim_var_values=ctx.dim_var_values)
     hlo.return_(mlir.flatten_ir_values(out_nodes))
   return [mlir.lower_with_sharding_in_types(ctx, r, aval)
-          for r, aval in safe_zip(op.results, ctx.avals_out)]
+          for r, aval in unsafe_zip(op.results, ctx.avals_out, strict=True)]
 
 mlir.register_lowering(reduce_p, _reduce_lower)
 

--- a/jax/_src/mesh.py
+++ b/jax/_src/mesh.py
@@ -187,17 +187,17 @@ class _BaseMesh:
 
   @functools.cached_property
   def auto_axes(self):
-    return tuple(n for n, t in safe_zip(self.axis_names, self._axis_types)
+    return tuple(n for n, t in unsafe_zip(self.axis_names, self._axis_types, strict=True)
                  if t == AxisType.Auto)
 
   @functools.cached_property
   def explicit_axes(self):
-    return tuple(n for n, t in safe_zip(self.axis_names, self._axis_types)
+    return tuple(n for n, t in unsafe_zip(self.axis_names, self._axis_types, strict=True)
                  if t == AxisType.Explicit)
 
   @functools.cached_property
   def manual_axes(self):
-    return tuple(n for n, t in safe_zip(self.axis_names, self._axis_types)
+    return tuple(n for n, t in unsafe_zip(self.axis_names, self._axis_types, strict=True)
                  if t == AxisType.Manual)
 
   @functools.cached_property
@@ -205,13 +205,13 @@ class _BaseMesh:
     if not self.axis_names:
       return {}
     d = collections.defaultdict(list)
-    for n, t in safe_zip(self.axis_names, self._axis_types):
+    for n, t in unsafe_zip(self.axis_names, self._axis_types, strict=True):
       d[t].append(n)
     return {t: tuple(n) for t, n in d.items()}
 
   @functools.cached_property
   def _name_to_type(self):
-    return dict(safe_zip(self.axis_names, self._axis_types))
+    return dict(unsafe_zip(self.axis_names, self._axis_types, strict=True))
 
 
 _mesh_object_dict = {}  # type: ignore
@@ -340,13 +340,13 @@ class Mesh(_BaseMesh, contextlib.ContextDecorator):
   def shape(self):
     return collections.OrderedDict(
         (name, size)
-        for name, size in safe_zip(self.axis_names, self.devices.shape))
+        for name, size in unsafe_zip(self.axis_names, self.devices.shape, strict=True))
 
   @functools.cached_property
   def shape_tuple(self):
     return tuple(
         (name, size)
-        for name, size in safe_zip(self.axis_names, self.devices.shape))
+        for name, size in unsafe_zip(self.axis_names, self.devices.shape, strict=True))
 
   @property
   def axis_sizes(self) -> tuple[int, ...]:
@@ -485,7 +485,7 @@ class AbstractMesh(_BaseMesh):
   def shape_tuple(self):
     return tuple(
         (name, size)
-        for name, size in safe_zip(self.axis_names, self.axis_sizes))
+        for name, size in unsafe_zip(self.axis_names, self.axis_sizes, strict=True))
 
   @property
   def _internal_device_list(self):

--- a/jax/_src/numpy/fft.py
+++ b/jax/_src/numpy/fft.py
@@ -21,7 +21,6 @@ import numpy as np
 from jax import lax
 from jax._src import dtypes
 from jax._src.lib import xla_client
-from jax._src.util import safe_zip
 from jax._src.numpy.util import ensure_arraylike, promote_dtypes_inexact
 from jax._src.numpy import lax_numpy as jnp
 from jax._src.numpy import ufuncs, reductions
@@ -78,7 +77,7 @@ def _fft_core(func_name: str, fft_type: lax.FftType, a: ArrayLike,
 
   if s is not None:
     in_s = list(arr.shape)
-    for axis, x in safe_zip(axes, s):
+    for axis, x in zip(axes, s, strict=True):
       in_s[axis] = x
     if fft_type == lax.FftType.IRFFT:
       in_s[-1] = (in_s[-1] // 2 + 1)

--- a/jax/_src/numpy/indexing.py
+++ b/jax/_src/numpy/indexing.py
@@ -38,7 +38,7 @@ from jax._src.numpy import util
 from jax._src.pjit import auto_axes
 from jax._src.tree_util import tree_flatten
 from jax._src.typing import Array, ArrayLike, StaticScalar
-from jax._src.util import canonicalize_axis, safe_zip, set_module, tuple_update
+from jax._src.util import canonicalize_axis, set_module, tuple_update
 import numpy as np
 
 export = set_module('jax.numpy')
@@ -576,7 +576,7 @@ def _attempt_rewriting_take_via_slice(arr: Array, idx: Any, mode: str | None,
   slice_sizes: list[int] = []
   allow_negative_indices: list[bool] = []
 
-  for ind, size in safe_zip(idx, arr.shape):
+  for ind, size in zip(idx, arr.shape, strict=True):
     if isinstance(ind, slice):
       start, stop, step = ind.indices(size)
       assert step == 1  # checked above

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -63,7 +63,7 @@ from jax._src.typing import (
 )
 from jax._src.util import (
     NumpyComplexWarning, canonicalize_axis as _canonicalize_axis,
-    ceil_of_ratio, safe_zip, set_module, unzip2)
+    ceil_of_ratio, set_module, unzip2)
 from jax.sharding import Sharding
 from jax.tree_util import tree_flatten, tree_map
 import numpy as np
@@ -2231,7 +2231,7 @@ def unravel_index(indices: ArrayLike, shape: Shape) -> tuple[Array, ...]:
   oob_pos = indices_arr > 0
   oob_neg = indices_arr < -1
   return tuple(where(oob_pos, s - 1, where(oob_neg, 0, i))
-               for s, i in safe_zip(shape, out_indices))
+               for s, i in zip(shape, out_indices, strict=True))
 
 
 @export
@@ -3779,7 +3779,7 @@ def nonzero(a: ArrayLike, *, size: int | None = None,
     if any(np.shape(val) != () for val in fill_value_tup):
       raise ValueError(f"fill_value must be a scalar or a tuple of length {arr.ndim}; got {fill_value}")
     fill_mask = arange(calculated_size) >= mask.sum()
-    out = tuple(where(fill_mask, fval, entry) for fval, entry in safe_zip(fill_value_tup, out))
+    out = tuple(where(fill_mask, fval, entry) for fval, entry in zip(fill_value_tup, out, strict=True))
   return out
 
 

--- a/jax/_src/pallas/mosaic_gpu/primitives.py
+++ b/jax/_src/pallas/mosaic_gpu/primitives.py
@@ -965,13 +965,13 @@ def _wgmma_lowering(
       if len(rhs_tiling) != 2 or len(new_shape) != 2:
         raise ValueError("WGMMA expects shapes 2D tiled into 2D tiles.")
 
-      if any(d % t != 0 for d, t in util.safe_zip(new_shape, rhs_tiling)):
+      if any(d % t != 0 for d, t in zip(new_shape, rhs_tiling, strict=True)):
         raise ValueError(
             f"The last reshape {new_shape} is not divisible by the tiling"
             f" {rhs_tiling}."
         )
 
-      high_dims = [d // t for d, t in util.safe_zip(new_shape, rhs_tiling)]
+      high_dims = [d // t for d, t in zip(new_shape, rhs_tiling, strict=True)]
       b = mgpu.memref_reshape(b, (*high_dims, *rhs_tiling))
       rhs_transpose = False
     case _:

--- a/jax/_src/shard_alike.py
+++ b/jax/_src/shard_alike.py
@@ -22,7 +22,6 @@ from jax._src.interpreters import mlir
 from jax._src.dispatch import apply_primitive
 from jax._src.tree_util import tree_flatten, tree_unflatten
 from jax._src.interpreters import batching
-from jax._src.util import safe_zip
 from jax._src.lib import xla_client as xc
 from jax._src.lib.mlir import dialects, ir
 
@@ -37,7 +36,7 @@ def shard_alike(x, y):
     raise ValueError('Trees should be equal. '
                      f'Got x_tree: {x_tree}, y_tree: {y_tree}')
 
-  for x_, y_ in safe_zip(x_flat, y_flat):
+  for x_, y_ in zip(x_flat, y_flat, strict=True):
     x_aval = core.shaped_abstractify(x_)
     y_aval = core.shaped_abstractify(y_)
     if x_aval.shape != y_aval.shape:
@@ -46,7 +45,7 @@ def shard_alike(x, y):
           f' {x_aval.shape} and `y` leaf shape: {y_aval.shape}. File an issue at'
           ' https://github.com/jax-ml/jax/issues if you want this feature.')
 
-  outs = [shard_alike_p.bind(x_, y_) for x_, y_ in safe_zip(x_flat, y_flat)]
+  outs = [shard_alike_p.bind(x_, y_) for x_, y_ in zip(x_flat, y_flat, strict=True)]
   x_out_flat, y_out_flat = zip(*outs)
   return tree_unflatten(x_tree, x_out_flat), tree_unflatten(y_tree, y_out_flat)
 

--- a/jax/_src/sharding_impls.py
+++ b/jax/_src/sharding_impls.py
@@ -42,7 +42,7 @@ from jax._src.named_sharding import (  # noqa: F401
 from jax._src.op_shardings import (
     are_op_shardings_equal, get_num_ways_dim_sharded, is_op_sharding_replicated)
 from jax._src.partition_spec import PartitionSpec
-from jax._src.util import safe_map, safe_zip, use_cpp_class, use_cpp_method
+from jax._src.util import safe_map, use_cpp_class, use_cpp_method
 import numpy as np
 
 config_ext = xc._xla.config
@@ -207,7 +207,7 @@ def pmap_sharding_devices_indices_map(
     self, global_shape: Shape) -> Mapping[Device, Index]:
   self.shard_shape(global_shape)  # raises a good error message
   indices = sharding_specs.spec_to_indices(global_shape, self.sharding_spec)
-  return dict(safe_zip(self.devices.flat, indices))  # type: ignore[arg-type]
+  return dict(zip(self.devices.flat, indices, strict=True))  # type: ignore[arg-type]
 
 
 @use_cpp_class(xc.PmapSharding)

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -25,7 +25,7 @@ from typing import Any, TypeVar, overload
 
 from jax._src import traceback_util
 from jax._src.lib import pytree
-from jax._src.util import safe_zip, set_module
+from jax._src.util import set_module
 from jax._src.util import unzip2
 
 
@@ -1044,7 +1044,7 @@ def register_dataclass(
 register_pytree_with_keys(
     collections.OrderedDict,
     lambda x: (tuple((DictKey(k), x[k]) for k in x.keys()), tuple(x.keys())),
-    lambda keys, values: collections.OrderedDict(safe_zip(keys, values)),
+    lambda keys, values: collections.OrderedDict(zip(keys, values, strict=True)),
 )
 
 def _flatten_defaultdict_with_keys(d):
@@ -1054,7 +1054,7 @@ def _flatten_defaultdict_with_keys(d):
 register_pytree_with_keys(
     collections.defaultdict,
     _flatten_defaultdict_with_keys,
-    lambda s, values: collections.defaultdict(s[0], safe_zip(s[1], values)),
+    lambda s, values: collections.defaultdict(s[0], zip(s[1], values, strict=True)),
 )
 
 

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -41,7 +41,6 @@ from jax._src import api_util
 from jax._src import config
 from jax._src import core
 from jax._src import test_util as jtu
-from jax._src import util
 from jax._src.export import shape_poly
 from jax._src.lax import lax as lax_internal
 from jax._src.lax import control_flow as lax_control_flow
@@ -188,8 +187,8 @@ class PolyHarness(Harness):
         assert not isinstance(self.expected_output_signature, (tuple, list))
         expected_output_signature = [self.expected_output_signature]
         concrete_output_tf_shape = [concrete_output_tf_shape]
-      for expected, found in util.safe_zip(expected_output_signature,
-                                           concrete_output_tf_shape):
+      for expected, found in zip(expected_output_signature,
+                                 concrete_output_tf_shape, strict=True):
         tst.assertEqual(tuple(expected.shape), tuple(found))
 
     # Run the JAX and the TF functions and compare the results

--- a/jax/experimental/key_reuse/_core.py
+++ b/jax/experimental/key_reuse/_core.py
@@ -32,7 +32,6 @@ from jax._src import prng
 from jax._src import random
 from jax._src import source_info_util
 from jax._src import traceback_util
-from jax._src import util
 from jax._src.ad_checkpoint import remat_p
 from jax._src.debugging import debug_callback_p
 from jax._src.interpreters import partial_eval as pe
@@ -428,7 +427,7 @@ def _slice_signature(eqn):
   start_indices = eqn.params['start_indices']
   limit_indices = eqn.params['limit_indices']
   strides = eqn.params['strides'] or (1,) * len(start_indices)
-  idx = tuple(slice(*tup) for tup in util.safe_zip(start_indices, limit_indices, strides))
+  idx = tuple(slice(*tup) for tup in zip(start_indices, limit_indices, strides, strict=True))
   sink = np.zeros(in_aval.shape, dtype=bool)
   sink[idx] = True
   return KeyReuseSignature(Sink(0, sink), Source(0))

--- a/jax/experimental/mosaic/gpu/dialect_lowering.py
+++ b/jax/experimental/mosaic/gpu/dialect_lowering.py
@@ -35,7 +35,6 @@ from jax._src.lib.mlir.dialects import memref
 from jax._src.lib.mlir.dialects import nvvm
 from jax._src.lib.mlir.dialects import scf
 from jax._src.lib.mlir.dialects import vector
-from jax._src.util import safe_zip
 from jax.experimental.mosaic.gpu import layouts as layouts_lib
 import numpy as np
 
@@ -227,7 +226,7 @@ def _optimization_barrier_op_lowering_rule(
     )
 
   fragmented_arrays = []
-  for operand, layout in safe_zip(op.operands, inference_utils.in_layouts(op)):
+  for operand, layout in zip(op.operands, inference_utils.in_layouts(op), strict=True):
     ty = ir.VectorType(operand.type)
     is_signed = False if ir.IntegerType.isinstance(ty.element_type) else None
     fragmented_arrays.append(
@@ -240,7 +239,7 @@ def _optimization_barrier_op_lowering_rule(
 
   return [
       _fragmented_array_to_ir(arr, result.type)
-      for arr, result in safe_zip(lowered_fragmented_arrays, op.results)
+      for arr, result in zip(lowered_fragmented_arrays, op.results, strict=True)
   ]
 
 

--- a/jax/experimental/mosaic/gpu/transform_inference.py
+++ b/jax/experimental/mosaic/gpu/transform_inference.py
@@ -30,7 +30,6 @@ from jax._src.lib.mlir.dialects import builtin
 from jax._src.lib.mlir.dialects import gpu
 from jax._src.lib.mlir.dialects import memref
 from jax._src.lib.mlir.dialects import vector
-from jax._src.util import safe_zip
 
 from . import fragmented_array as fa
 from . import inference_utils
@@ -321,7 +320,7 @@ def _infer_memref_subview_transforms(
   num_tiled_axes = len(mgpu.TileTransformAttr(tile_transform).tiling)
   last_n_dims = op.source.type.shape[-num_tiled_axes:]
   last_n_sizes = list(op.static_sizes)[-num_tiled_axes:]
-  for slice_size, dim_size in safe_zip(last_n_sizes, last_n_dims):
+  for slice_size, dim_size in zip(last_n_sizes, last_n_dims, strict=True):
     if slice_size != dim_size:
       raise NotImplementedError(
           "Tile transforms are only propagated if the tiled axes are not "

--- a/jax/experimental/multihost_utils.py
+++ b/jax/experimental/multihost_utils.py
@@ -33,7 +33,6 @@ from jax.interpreters import xla
 from jax._src import pjit as pjit_lib
 from jax.sharding import PartitionSpec as P
 from jax._src import distributed
-from jax._src.util import safe_zip
 from jax._src import xla_bridge
 from jax._src.lib import xla_client
 import numpy as np
@@ -349,7 +348,7 @@ def host_local_array_to_global_array(
   out_flat = [
       host_local_array_to_global_array_p.bind(inp, global_mesh=global_mesh,
                                               pspec=in_spec)
-      for inp, in_spec in safe_zip(flat_inps, in_pspecs)
+      for inp, in_spec in zip(flat_inps, in_pspecs, strict=True)
   ]
   return tree_unflatten(in_tree, out_flat)
 
@@ -455,7 +454,7 @@ def global_array_to_host_local_array(
   out_flat = [
       global_array_to_host_local_array_p.bind(inp, global_mesh=global_mesh,
                                               pspec=o)
-      for inp, o in safe_zip(flat_inps, out_pspecs)
+      for inp, o in zip(flat_inps, out_pspecs, strict=True)
   ]
   return tree_unflatten(out_tree, out_flat)
 

--- a/jax/experimental/sparse/ad.py
+++ b/jax/experimental/sparse/ad.py
@@ -22,7 +22,6 @@ import jax
 from jax._src import core
 from jax import tree_util
 from jax._src.api_util import _ensure_index, _ensure_index_tuple
-from jax._src.util import safe_zip
 from jax._src.util import split_list, wraps
 from jax._src.traceback_util import api_boundary
 from jax.experimental.sparse._base import JAXSparse
@@ -51,7 +50,7 @@ def flatten_fun_for_sparse_ad(fun, argnums: int | tuple[int, ...], args: tuple[A
   assert not end
   # For sparse args, we only mark the first buffer (the data) for differentiation.
   leaf_argnums2 = [nums[:1] if is_sparse(arg) else nums
-                   for arg, nums in safe_zip(args_flat1, leaf_argnums2)]
+                   for arg, nums in zip(args_flat1, leaf_argnums2, strict=True)]
   argnums_flat = tuple(itertools.chain.from_iterable(
       nums for i, nums in enumerate(leaf_argnums2) if i in argnums_flat1))
 
@@ -68,7 +67,7 @@ def flatten_fun_for_sparse_ad(fun, argnums: int | tuple[int, ...], args: tuple[A
 
   def postprocess_gradients(grads_out):
     leaf_grads = [None] * tree1.num_leaves
-    for i, grad in safe_zip(argnums_flat1, grads_out):
+    for i, grad in zip(argnums_flat1, grads_out, strict=True):
       leaf_grads[i] = reconstruct(i, grad)
     grad_tree = tree_util.tree_unflatten(tree1, leaf_grads)
     grad_tree = tuple(filter(lambda x: jax.tree.leaves(x), grad_tree))

--- a/jax/experimental/sparse/bcsr.py
+++ b/jax/experimental/sparse/bcsr.py
@@ -33,7 +33,7 @@ from jax.experimental.sparse import bcoo
 from jax.experimental.sparse.util import (
     nfold_vmap, _count_stored_elements,
     _csr_to_coo, CuSparseEfficiencyWarning, SparseInfo, Shape)
-from jax._src.util import split_list, safe_zip
+from jax._src.util import split_list
 
 from jax._src import api_util
 from jax._src import config
@@ -96,7 +96,7 @@ class BCSRProperties(NamedTuple):
 
 
 def _compatible(shape1: Sequence[int], shape2: Sequence[int]) -> bool:
-  return all(s1 in (1, s2) for s1, s2 in safe_zip(shape1, shape2))
+  return all(s1 in (1, s2) for s1, s2 in zip(shape1, shape2, strict=True))
 
 
 def _validate_bcsr_indices(indices: jax.Array, indptr: jax.Array,

--- a/jax/experimental/sparse/test_util.py
+++ b/jax/experimental/sparse/test_util.py
@@ -29,7 +29,7 @@ from jax._src.lax.lax import DotDimensionNumbers
 from jax._src.typing import DTypeLike
 from jax.experimental import sparse
 import jax.numpy as jnp
-from jax._src.util import safe_zip, split_list
+from jax._src.util import split_list
 import numpy as np
 
 MATMUL_TOL = {
@@ -134,7 +134,7 @@ class SparseTestCase(jtu.JaxTestCase):
     def batched_args_maker():
       args = list(zip(*(args_maker() for _ in range(batch_size))))
       return [arg[0] if bdim is None else concat([expand(x, bdim) for x in arg], bdim)
-              for arg, bdim in safe_zip(args, bdims)]
+              for arg, bdim in zip(args, bdims, strict=True)]
     self._CheckAgainstDense(jax.vmap(dense_fun, bdims), jax.vmap(sparse_fun, bdims), batched_args_maker,
                             check_dtypes=check_dtypes, tol=tol, atol=atol, rtol=rtol, check_jit=check_jit,
                             canonicalize_dtypes=canonicalize_dtypes)

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -68,7 +68,7 @@ from jax._src.api_util import flatten_fun_nokwargs
 from jax._src.lib import pytree
 from jax._src.interpreters import partial_eval as pe
 from jax.tree_util import tree_flatten, tree_map, tree_unflatten
-from jax._src.util import safe_map, safe_zip, split_list
+from jax._src.util import safe_map, split_list
 from jax._src.lax.control_flow import _check_tree_and_avals
 from jax._src.numpy import indexing as jnp_indexing
 from jax.experimental import sparse
@@ -428,7 +428,7 @@ def eval_sparse(
       out_bufs = prim.bind(*(spenv.data(val) for val in invals), **eqn.params)
       out_bufs = out_bufs if prim.multiple_results else [out_bufs]
       out = []
-      for buf, outvar in safe_zip(out_bufs, eqn.outvars):
+      for buf, outvar in zip(out_bufs, eqn.outvars, strict=True):
         if isinstance(outvar, core.DropVar):
           out.append(None)
         else:
@@ -821,7 +821,7 @@ sparse_rules_bcoo[pjit.pjit_p] = _pjit_sparse
 
 
 def _duplicate_for_sparse_spvalues(spvalues, params):
-  for spvalue, param in safe_zip(spvalues, params):
+  for spvalue, param in zip(spvalues, params, strict=True):
     yield from [param, param] if spvalue.is_sparse() else [param]
 
 def _scan_sparse(spenv, *spvalues, jaxpr, num_consts, num_carry, **params):

--- a/jax/experimental/sparse/util.py
+++ b/jax/experimental/sparse/util.py
@@ -25,7 +25,6 @@ from jax import vmap
 from jax._src import core
 from jax._src.api_util import flatten_axes
 import jax.numpy as jnp
-from jax._src.util import safe_zip
 from jax._src.lax.lax import _dot_general_shape_rule, DotDimensionNumbers
 from jax._src.typing import Array
 
@@ -62,10 +61,10 @@ def broadcasting_vmap(fun, in_axes=0, out_axes=0):
   def batched_fun(*args):
     args_flat, in_tree  = tree_util.tree_flatten(args)
     in_axes_flat = flatten_axes("vmap in_axes", in_tree, in_axes, kws=False)
-    size = max(arg.shape[i] for arg, i in safe_zip(args_flat, in_axes_flat) if i is not None)
+    size = max(arg.shape[i] for arg, i in zip(args_flat, in_axes_flat, strict=True) if i is not None)
     if size > 1:
       if any(i is not None and arg.shape[i] not in (1, size)
-             for arg, i in safe_zip(args_flat, in_axes_flat)):
+             for arg, i in zip(args_flat, in_axes_flat, strict=True)):
         raise ValueError("broadcasting_vmap: mismatched input shapes")
       args_flat, in_axes_flat = zip(*(
           (arg, None) if i is None else (lax.squeeze(arg, (i,)), None) if arg.shape[i] == 1 else (arg, i)

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -30,7 +30,6 @@ from jax._src import test_util as jtu
 from jax._src import xla_bridge as xb
 from jax._src.lib import xla_client as xc
 from jax._src.lib.mlir import dialects, ir
-from jax._src.util import safe_zip
 from jax._src.mesh import AxisType, AbstractMesh
 from jax._src.sharding import common_devices_indices_map
 from jax._src.sharding_impls import (
@@ -133,7 +132,7 @@ class JaxArrayTest(jtu.JaxTestCase):
       self.assertArraysEqual(s.data, global_input_data[s.index])
       self.assertArraysEqual(s.data, arr.addressable_data(i))
 
-    for g, l in safe_zip(arr.global_shards, arr.addressable_shards):
+    for g, l in zip(arr.global_shards, arr.addressable_shards, strict=True):
       self.assertEqual(g.device, l.device)
       self.assertEqual(g.index, l.index)
       self.assertEqual(g.replica_id, l.replica_id)
@@ -574,7 +573,7 @@ class JaxArrayTest(jtu.JaxTestCase):
     c_arr = jnp.array(arr, copy=True)
     self.assertArraysEqual(arr, c_arr)
     self.assertEqual(arr._committed, c_arr._committed)
-    for a, c in safe_zip(arr.addressable_shards, c_arr.addressable_shards):
+    for a, c in zip(arr.addressable_shards, c_arr.addressable_shards, strict=True):
       self.assertArraysEqual(a.data, c.data)
       self.assertEqual(a.index, c.index)
       self.assertEqual(a.replica_id, c.replica_id)

--- a/tests/lax_metal_test.py
+++ b/tests/lax_metal_test.py
@@ -48,7 +48,7 @@ from jax._src import dtypes
 from jax._src import test_util as jtu
 from jax._src.lax import lax as lax_internal
 
-from jax._src.util import safe_zip, NumpyComplexWarning
+from jax._src.util import NumpyComplexWarning
 
 try:
   from jax_plugins import metal_plugin
@@ -326,7 +326,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       else:
         fillvals = fill_value if np.ndim(fill_value) else len(result) * [fill_value or 0]
         return tuple(np.concatenate([arg, np.full(size - len(arg), fval, arg.dtype)])
-                     for fval, arg in safe_zip(fillvals, result))
+                     for fval, arg in zip(fillvals, result, strict=True))
     jnp_fun = lambda x: jnp.nonzero(x, size=size, fill_value=fill_value)
     with jtu.ignore_warning(category=DeprecationWarning,
                             message="Calling nonzero on 0d arrays.*"):
@@ -397,7 +397,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       else:
         fillvals = fill_value if np.ndim(fill_value) else result.shape[-1] * [fill_value or 0]
         return np.empty((size, 0), dtype=int) if np.ndim(x) == 0 else np.stack([np.concatenate([arg, np.full(size - len(arg), fval, arg.dtype)])
-                        for fval, arg in safe_zip(fillvals, result.T)]).T
+                        for fval, arg in zip(fillvals, result.T, strict=True)]).T
     jnp_fun = lambda x: jnp.argwhere(x, size=size, fill_value=fill_value)
 
     with jtu.ignore_warning(category=DeprecationWarning,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -50,7 +50,7 @@ from jax._src import core
 from jax._src import dtypes
 from jax._src import test_util as jtu
 from jax._src.lax import lax as lax_internal
-from jax._src.util import safe_zip, NumpyComplexWarning, tuple_update
+from jax._src.util import NumpyComplexWarning, tuple_update
 
 config.parse_flags_with_absl()
 
@@ -402,7 +402,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       else:
         fillvals = fill_value if np.ndim(fill_value) else len(result) * [fill_value or 0]
         return tuple(np.concatenate([arg, np.full(size - len(arg), fval, arg.dtype)])
-                     for fval, arg in safe_zip(fillvals, result))
+                     for fval, arg in zip(fillvals, result, strict=True))
     jnp_fun = lambda x: jnp.nonzero(x, size=size, fill_value=fill_value)
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
     self._CompileAndCheck(jnp_fun, args_maker)
@@ -468,7 +468,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       else:
         fillvals = fill_value if np.ndim(fill_value) else result.shape[-1] * [fill_value or 0]
         return np.empty((size, 0), dtype=int) if np.ndim(x) == 0 else np.stack([np.concatenate([arg, np.full(size - len(arg), fval, arg.dtype)])
-                        for fval, arg in safe_zip(fillvals, result.T)]).T
+                        for fval, arg in zip(fillvals, result.T, strict=True)]).T
     jnp_fun = lambda x: jnp.argwhere(x, size=size, fill_value=fill_value)
 
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -48,7 +48,7 @@ from jax._src.interpreters import mlir
 from jax._src.interpreters import pxla
 from jax._src.internal_test_util import lax_test_util
 from jax._src.lax import lax as lax_internal
-from jax._src.util import NumpyComplexWarning, safe_zip
+from jax._src.util import NumpyComplexWarning
 from jax._src.tree_util import tree_map
 
 config.parse_flags_with_absl()
@@ -3935,7 +3935,7 @@ class FooArray:
 
 def shard_foo_array_handler(xs, shardings, layouts, copy_semantics):
   results = []
-  for x, sharding in safe_zip(xs, shardings):
+  for x, sharding in zip(xs, shardings, strict=True):
     device, = sharding._addressable_device_assignment
     aval = core.get_aval(x.data)
     results.append(pxla.batched_device_put(

--- a/tests/layout_test.py
+++ b/tests/layout_test.py
@@ -22,7 +22,6 @@ import jax.numpy as jnp
 from jax.sharding import NamedSharding, PartitionSpec as P, SingleDeviceSharding
 from jax._src import config
 from jax._src import test_util as jtu
-from jax._src.util import safe_zip
 from jax.experimental.layout import (with_dll_constraint, Layout,
                                      DeviceLocalLayout as DLL)
 from jax.experimental.compute_on import compute_on
@@ -193,7 +192,7 @@ class LayoutTest(jtu.JaxTestCase):
     compiled2 = jax.jit(f, in_shardings=arg_layouts).lower(*inps).compile()
     out3, out4 = compiled2(*inps)
 
-    for l1, l2 in safe_zip(arg_layouts, compiled2.input_layouts[0]):
+    for l1, l2 in zip(arg_layouts, compiled2.input_layouts[0], strict=True):
       self.assertEqual(l1, l2)
 
     self.assertArraysEqual(out1, out3)

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -2539,7 +2539,7 @@ def set_in_transforms(
 
   in_transforms = []
   smem_refs = filter(inference_utils.is_transformable_smem_memref, op.operands)  # pylint: disable=undefined-variable
-  for _, result_transforms in jax._src.util.safe_zip(smem_refs, transforms):
+  for _, result_transforms in zip(smem_refs, transforms, strict=True):
     in_transforms.append(
         ir.ArrayAttr.get([t.attr() for t in result_transforms])
     )

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -50,7 +50,7 @@ from jax._src.internal_test_util import lax_test_util
 from jax._src.interpreters import pxla
 from jax._src.lax import parallel
 from jax._src.lib import _jax
-from jax._src.util import safe_map, safe_zip
+from jax._src.util import safe_map
 
 config.parse_flags_with_absl()
 jtu.request_cpu_devices(8)
@@ -3040,7 +3040,7 @@ class ArrayPmapTest(jtu.JaxTestCase):
 
     self.assertIsInstance(out1, array.ArrayImpl)
     self.assertIsInstance(out2, array.ArrayImpl)
-    for s1, s2 in safe_zip(out1.addressable_shards, out2.addressable_shards):
+    for s1, s2 in zip(out1.addressable_shards, out2.addressable_shards, strict=True):
       self.assertArraysEqual(s1.data, input_data[s1.index])
       self.assertArraysEqual(s2.data, input_data[s2.index])
     self.assertArraysEqual(out1, input_data)
@@ -3065,7 +3065,7 @@ class ArrayPmapTest(jtu.JaxTestCase):
     self.assertIsInstance(out2, array.ArrayImpl)
     self.assertEqual(out1.shape, (2,))
     self.assertEqual(out2.shape, (dc, dc, 2))
-    for i, (s1, s2) in enumerate(safe_zip(out1.addressable_shards, out2.addressable_shards)):
+    for i, (s1, s2) in enumerate(zip(out1.addressable_shards, out2.addressable_shards, strict=True)):
       self.assertArraysEqual(s1.data, input_data[i])
       if config.pmap_no_rank_reduction.value:
         self.assertArraysEqual(s2.data, input_data[None])
@@ -3151,7 +3151,7 @@ class ArrayPmapTest(jtu.JaxTestCase):
       self.assertArraysEqual(out, out_copy)
       self.assertIsInstance(out_copy.sharding, jax.sharding.PmapSharding)
       self.assertEqual(out.sharding, out_copy.sharding)
-      for o, o_copy in safe_zip(out.addressable_shards, out_copy.addressable_shards):
+      for o, o_copy in zip(out.addressable_shards, out_copy.addressable_shards, strict=True):
         self.assertArraysEqual(o.data, o_copy.data)
         self.assertEqual(o.device, o_copy.device)
         self.assertEqual(o.index, o_copy.index)


### PR DESCRIPTION
The main difference between `safe_zip(*)` and `zip(*, strict=True)` is that `safe_zip` eagerly evaluates and returns a list, while `zip` returns a lazily-evaluated iterator. Eager evaluation is useful in many cases, but when we immediately iterate over the results, this eager list creation is wasteful. Since JAX now requires Python 3.10 or newer, we can use the `strict=True` argument to validate the lengths of inputs without having to eagerly construct the list.

Note that this for the most part only touches cases where `safe_zip` was used explicitly; we have many places where we overwrite the built-in `zip` with `safe_zip`; I've not changed those here, but I will likely do so in a followup.