### PR TITLE
[Mosaic GPU] Print instead of warning when skipping flash_attention test

### DIFF
--- a/jax/experimental/mosaic/gpu/examples/flash_attention.py
+++ b/jax/experimental/mosaic/gpu/examples/flash_attention.py
@@ -17,7 +17,6 @@ import contextlib
 import dataclasses
 import enum
 import itertools
-import warnings
 
 import jax
 from jax import random
@@ -601,7 +600,7 @@ def benchmark_and_verify(
 if __name__ == "__main__":
   if (not jtu.test_device_matches(["cuda"]) or
       not jtu.is_cuda_compute_capability_equal("9.0")):
-    warnings.warn(
+    print(
       "Mosaic GPU Flash Attention requires compute capability 9.0a to run, "
       "skipping.")
     exit(0)


### PR DESCRIPTION
https://github.com/jax-ml/jax/pull/28403 made all warnings trigger test failures which is not appropriate in this case.