### PR TITLE
chore: disable legacy external runfiles

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,6 +33,8 @@ build --output_filter=DONT_MATCH_ANYTHING
 build --copt=-DMLIR_PYTHON_PACKAGE_PREFIX=jaxlib.mlir.
 build --copt=-DNB_DOMAIN=jax
 
+build --legacy_external_runfiles=false
+
 # #############################################################################
 # Platform Specific configs below. These are automatically picked up by Bazel
 # depending on the platform that is running the build.


### PR DESCRIPTION
This disables the deprecated behavior of materializing external dependencies under
`$runfiles/external`. They are already created under the runfiles root directory,
so this should (approximately) cut in half the number of external runfiles that need to be
materialized for builds (external content usually makes up the bulk of runfiles).

Bazel 8+ has this disabled by default, so it aids Bazel 8 support.