### PR TITLE
jax-cuda12-plugin: require nvidia-cublas-cu12<12.9

### DIFF
--- a/jax_plugins/cuda/plugin_setup.py
+++ b/jax_plugins/cuda/plugin_setup.py
@@ -53,7 +53,8 @@ setup(
     install_requires=[f"jax-cuda{cuda_version}-pjrt=={__version__}"],
     extras_require={
       'with-cuda': [
-          "nvidia-cublas-cu12>=12.1.3.1",
+          # cudnn has a bug with mxfp8 with multiple GPUs per process and cublas 12.9
+          "nvidia-cublas-cu12>=12.1.3.1,<12.9",
           "nvidia-cuda-cupti-cu12>=12.1.105",
           "nvidia-cuda-nvcc-cu12>=12.6.85",
           "nvidia-cuda-runtime-cu12>=12.1.105",


### PR DESCRIPTION
This avoids a bug in cuDNN when used with cuBLAS 12.9 and multiple GPUs are driven by the same process.
See the release notes for the 25.04 container: https://docs.nvidia.com/deeplearning/frameworks/jax-release-notes/rel-25-04.html.

The dependency lockfiles still use cuBLAS 12.8:
https://github.com/jax-ml/jax/blob/842170be05cf57f9088d569f5d9f65350468016e/build/requirements_lock_3_12.txt#L431