### PR TITLE
Remove broken jax/jaxlib version test.

### DIFF
--- a/jaxlib/xla_client.py
+++ b/jaxlib/xla_client.py
@@ -43,7 +43,7 @@ ifrt_programs = _xla.ifrt_programs
 
 # Just an internal arbitrary increasing number to help with backward-compatible
 # changes. In JAX, reference this via jax._src.lib.jaxlib_extension_version.
-_version = 336
+_version = 337
 
 # An internal increasing version number for protecting jaxlib code against
 # ifrt changes.

--- a/tests/mosaic/gpu_dialect_test.py
+++ b/tests/mosaic/gpu_dialect_test.py
@@ -86,8 +86,8 @@ def workgroup_ptr_ty() -> ir.Type:
 class MosaicGpuTest(parameterized.TestCase):
 
   def setUp(self):
-    if jax.version._version != jax.lib.__version__:
-      raise self.skipTest("Test requires matching jax and jaxlib versions")
+    if jax._src.lib.jaxlib_extension_version < 337:
+      raise self.skipTest("Test requires jaxlib 0.6.1")
     super().setUp()
     self.enter_context(_make_ir_context())
     self.enter_context(ir.Location.unknown())

--- a/tests/mosaic/gpu_layout_inference_test.py
+++ b/tests/mosaic/gpu_layout_inference_test.py
@@ -17,7 +17,6 @@
 # pylint: disable=g-complex-comprehension
 
 from absl.testing import parameterized
-import jax
 from jax._src import config
 from jax._src import lib as jaxlib
 from jax._src import test_util as jtu
@@ -44,8 +43,6 @@ def _make_ir_context():
 class LayoutInferenceTest(parameterized.TestCase):
 
   def setUp(self):
-    if jax.version._version != jax.lib.__version__:
-      raise self.skipTest("Test requires matching jax and jaxlib versions")
     super().setUp()
     self.enter_context(_make_ir_context())
     self.enter_context(ir.Location.unknown())

--- a/tests/mosaic/gpu_transform_inference_test.py
+++ b/tests/mosaic/gpu_transform_inference_test.py
@@ -17,7 +17,6 @@
 # pylint: disable=g-complex-comprehension
 
 from absl.testing import parameterized
-import jax
 from jax import numpy as jnp
 from jax._src import config
 from jax._src import test_util as jtu
@@ -49,8 +48,6 @@ def _make_ir_context():
 class TransformInferenceTest(parameterized.TestCase):
 
   def setUp(self):
-    if jax.version._version != jax.lib.__version__:
-      raise self.skipTest("Test requires matching jax and jaxlib versions")
     super().setUp()
     self.enter_context(_make_ir_context())
     self.enter_context(ir.Location.unknown())


### PR DESCRIPTION
This test has the effect of completely disabling these tests in CI because jaxlib versions currently have a .dev... suffix if built not at a release.