### PR TITLE
Fix defaults overriding each other in tests/mutliprocess_gpu_test

### DIFF
--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -106,29 +106,17 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
         env["JAX_PORT"] = str(port)
         env["NUM_TASKS"] = str(num_tasks)
         env["TASK"] = str(task)
-        visible_devices = ",".join(
-            str((task * num_gpus_per_task) + i) for i in range(num_gpus_per_task))
-
-        if jtu.is_device_rocm():
-          program = (
-            'import jax, os; '
-            f'jax.config.update("jax_rocm_visible_devices", "{visible_devices}"); '
-            'jax.distributed.initialize('
-            'f\'localhost:{os.environ["JAX_PORT"]}\', '
-            'int(os.environ["NUM_TASKS"]), int(os.environ["TASK"])); '
-            's = jax.pmap(lambda x: jax.lax.psum(x, "i"), axis_name="i")(jax.numpy.ones(jax.local_device_count())); '
-            'print(f\'{jax.local_device_count()},{jax.device_count()},{s}\', end=""); '
-          )
-        else:
-          program = (
-            'import jax, os; '
-            f'jax.config.update("jax_cuda_visible_devices", "{visible_devices}"); '
-            'jax.distributed.initialize('
-            'f\'localhost:{os.environ["JAX_PORT"]}\', '
-            'int(os.environ["NUM_TASKS"]), int(os.environ["TASK"])); '
-            's = jax.pmap(lambda x: jax.lax.psum(x, "i"), axis_name="i")(jax.numpy.ones(jax.local_device_count())); '
-            'print(f\'{jax.local_device_count()},{jax.device_count()},{s}\', end=""); '
-          )
+        visible_devices = [
+            (task * num_gpus_per_task) + i for i in range(num_gpus_per_task)
+        ]
+        program = (
+          'import jax, os; '
+          'jax.distributed.initialize('
+          'f\'localhost:{os.environ["JAX_PORT"]}\', '
+          f'int(os.environ["NUM_TASKS"]), int(os.environ["TASK"]), {visible_devices}); '
+          's = jax.pmap(lambda x: jax.lax.psum(x, "i"), axis_name="i")(jax.numpy.ones(jax.local_device_count())); '
+          'print(f\'{jax.local_device_count()},{jax.device_count()},{s}\', end=""); '
+        )
         args = [sys.executable, "-c", program]
         proc = subprocess.Popen(args, env=env, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE, universal_newlines=True)


### PR DESCRIPTION
There was a issue discovered in our internal CI that would cause this test to fail.

What was specifically happening in our configuration was that the `auto_detect_unset_distributed_params` was picking up `SLURM_PROCID` from our CI and setting the default `local_device_ids` to be `[0]` on all processes.
https://github.com/jax-ml/jax/blob/8f17a552528da9a2f66587933756c33a463d27ce/jax/_src/clusters/cluster.py#L81-L85

This then would override both the `jax_cuda_device_ids` and `jax_rocm_device_ids` later in the distributed initialization setup. 
https://github.com/jax-ml/jax/blob/8f17a552528da9a2f66587933756c33a463d27ce/jax/_src/distributed.py#L107-L111


In this PR, we remove the `jax.config` calls and just set `local_device_ids` explicitly in `jax.distributed.initialize`. Since that eventually calls `jax.config.update` on both configurations anyway, this more generalizes the test and we can remove the arch specific test logic.  