### PR TITLE
Add a pretty printing rule for custom_jvp

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -487,6 +487,21 @@ def _custom_jvp_call_dce(
 pe.dce_rules[custom_jvp_call_p] = _custom_jvp_call_dce
 
 
+def _custom_jvp_call_pp_rule(eqn: core.JaxprEqn,
+                             context: core.JaxprPpContext,
+                             settings: core.JaxprPpSettings) -> core.pp.Doc:
+  params = dict(eqn.params)
+  if not params["num_consts"]:
+    params.pop("num_consts")
+  params["jvp"] = params.pop("jvp_jaxpr_fun").debug_info.func_name
+  names = sorted(params)
+  params["name"] = params["call_jaxpr"].jaxpr.debug_info.func_name
+  return core._pp_eqn(eqn.replace(params=params), context, settings,
+                      params=["name"] + names)
+
+
+core.pp_eqn_rules[custom_jvp_call_p] = _custom_jvp_call_pp_rule
+
 ### VJPs
 
 @custom_api_util.register_custom_decorator_type


### PR DESCRIPTION
Printing jaxprs with `custom_jvp`s in them is a bit unwieldy. For example, the program in [the docs](https://docs.jax.dev/en/latest/_autosummary/jax.custom_jvp.html) prints:

```
{ lambda ; a:f32[] b:f32[]. let
    c:f32[] = custom_jvp_call[
      call_jaxpr={ lambda ; d:f32[] e:f32[]. let
          f:f32[] = sin d
          g:f32[] = mul f e
        in (g,) }
      jvp_jaxpr_fun=Wrapped function:

Core: memoized

      symbolic_zeros=False
    ] a b
  in (c,) }
```

which doesn't really tell us what we need.

After this change, we get:

```
{ lambda ; a:f32[] b:f32[]. let
    c:f32[] = custom_jvp_call[
      name=f
      call_jaxpr={ lambda ; d:f32[] e:f32[]. let
          f:f32[] = sin d
          g:f32[] = mul f e
        in (g,) }
      jvp=f_jvp
      symbolic_zeros=False
    ] a b
  in (c,) }
```

which shows us the names of the primal and JVP rule functions, and doesn't mess up the layout by printing the repr of a `lu.WrappedFun`.