### PR TITLE
pytest: use importlib mode by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ doctest_optionflags = [
     "NUMBER",
     "NORMALIZE_WHITESPACE"
 ]
-addopts = "--doctest-glob='*.rst' --ignore='examples/ffi'"
+addopts = "--doctest-glob='*.rst' --ignore='examples/ffi' --import-mode=importlib"
 
 [tool.ruff]
 preview = true


### PR DESCRIPTION
Otherwise the default (prepend) mode will add `<jax_src_dir>/tests` and `<jax_src_dir>` to the start of `sys.path`.
This is (has always been) fragile, because `<jax_src_dir>` has `jax/` and `jaxlib/` subdirectories, but it recently broke as `setuptools` 80 has a change in behaviour for editable installations, with the result that if `jaxlib` is installed editable then `import jaxlib` with `<jax_src_dir>` in `sys.path` will try to import from `<jax_src_dir>/jaxlib` instead of the editable install location, and fail.

See also:
- https://docs.pytest.org/en/stable/explanation/pythonpath.html#import-modes
- https://docs.pytest.org/en/stable/explanation/goodpractices.html#tests-outside-application-code (JAX does not follow the advice here, as there is not a `src/` directory alongside `tests/` at the top level)