### PR TITLE
Speed up `scipy.signal.stft` by using `lax.dynamic_slice_in_dim` for windowing

### DIFF
--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -566,13 +566,9 @@ def _fft_helper(x: Array, win: Array, detrend_func: Callable[[Array], Array],
     result = x[..., np.newaxis]
   else:
     step = nperseg - noverlap
-    batch_shape = list(batch_shape)
-    x = x.reshape((math.prod(batch_shape), signal_length, 1))
-    result = jax.lax.conv_general_dilated_patches(
-        x, (nperseg,), (step,),
-        'VALID',
-        dimension_numbers=('NTC', 'OIT', 'NTC'))
-    result = result.reshape(*batch_shape, *result.shape[-2:])
+    starts = jnp.arange(signal_length - nperseg + 1, step=step)
+    slice_func = partial(jax.lax.dynamic_slice_in_dim, operand=x, slice_size=nperseg, axis=-1)
+    result = jax.vmap(slice_func, out_axes=-2)(start_index=starts)
 
   # Detrend each data segment individually
   result = detrend_func(result)


### PR DESCRIPTION
Hi! I recently noticed that `stft` was performing noticeably worse in JAX than in PyTorch (#28614). I did some profiling (thanks for making this very easy!) and it turns out that generating the sliding window view was the bottleneck. This fix seems to result in a pretty drastic speedup. I've used the following code to benchmark it:

```python
import jax
import jax.numpy as jnp
from time import perf_counter

n_samples = 100000

batch_size = 256

n_fft = 2048

hann_window = jax.numpy.hanning(n_fft)

def stft(x):
    _, _, out = jax.scipy.signal.stft(x, window=hann_window, nperseg=n_fft, noverlap=n_fft // 2)
    return jnp.abs(out)

n_loops = 200

noise = jax.random.uniform(key=jax.random.PRNGKey(0), shape=(batch_size, n_samples))

stft_jit = jax.jit(stft)
stft_vmap = jax.jit(jax.vmap(stft))

# pre-compile
stft_jit(noise).block_until_ready()
stft_vmap(noise).block_until_ready()

def time(fun, arg):
    start = perf_counter()
    for _ in range(n_loops):
        fun(arg)
    end = perf_counter()
    return 1000 * (end - start) / n_loops

print(f"unjitted: {time(stft, noise):.2f} ms/it avg")
print(f"jitted: {time(stft_jit, noise):.2f} ms/it avg")
print(f"jitted + vmap: {time(stft_vmap, noise):.2f} ms/it avg")
```

I've put the results that I got from running this before and after applying the patch in a table below and it looks like the effect is pretty big. CPU results on an M4 Mac (no jax-metal), GPU results on an RTX 2080 Ti. I've checked for these platforms that the tests in `tests/scipy_signal_test.py` still pass.

| | CPU (before) | CPU (after) || GPU (before) | GPU (after) |
| --- | --- | --- | --- | --- | --- |
| unjitted | 295.00 | 78.03 || 39.21 | 16.15 | 
| jitted | 237.56 | 50.27 || 22.50 | 1.72 |
| jitted + vmap | 277.31 | 74.68 || 26.74  | 2.00 |

(Numbers given are milliseconds)
