### PR TITLE
Revert pytest: use importlib mode by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ doctest_optionflags = [
     "NUMBER",
     "NORMALIZE_WHITESPACE"
 ]
-addopts = "--doctest-glob='*.rst' --ignore='examples/ffi' --import-mode=importlib"
+addopts = "--doctest-glob='*.rst' --ignore='examples/ffi'"
 
 [tool.ruff]
 preview = true


### PR DESCRIPTION
Rolls back #28650, because it broke our nightly tests.

Fixes #28671.