### PR TITLE
Warn when __jax_array__ is seen in xla dtype canonicalization

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -1180,6 +1180,7 @@ pytype_strict_library(
         ":abstract_arrays",
         ":config",
         ":core",
+        ":deprecations",
         ":dtypes",
         ":sharding_impls",
         ":source_info_util",

--- a/jax/_src/interpreters/xla.py
+++ b/jax/_src/interpreters/xla.py
@@ -23,6 +23,7 @@ from typing import Any, Union
 import numpy as np
 
 from jax._src import core
+from jax._src import deprecations
 from jax._src import dtypes
 from jax._src.abstract_arrays import numpy_scalar_types
 from jax._src.util import safe_zip, safe_map
@@ -100,6 +101,12 @@ def canonicalize_dtype(x):
     handler = canonicalize_dtype_handlers.get(typ)
     if handler: return handler(x)
   if hasattr(x, '__jax_array__'):
+    deprecations.warn(
+      'jax-abstract-dunder-array',
+      ('Triggering of __jax_array__() during abstractification is deprecated.'
+       ' To avoid this error, either explicitly convert your object using'
+       ' jax.numpy.array(), or register your object as a pytree.'),
+      stacklevel=6)
     return canonicalize_dtype(x.__jax_array__())
   raise InvalidInputException(
       f"Argument '{x}' of type {type(x)} is not a valid JAX type.")


### PR DESCRIPTION
Part of #28661

Confirmed this is covered in existing tests, at `tests/api_test.py::APITest::test_dunder_jax_array_warnings`