### PR TITLE
Simplify the Bazel logic used to add dependencies to tests.

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -101,17 +101,22 @@ string_flag(
 )
 
 config_setting(
-    name = "disable_jaxlib_and_jax_build",
+    name = "config_build_jax_true",
     flag_values = {
-        ":build_jaxlib": "false",
+        ":build_jax": "true",
+    },
+)
+
+config_setting(
+    name = "config_build_jax_false",
+    flag_values = {
         ":build_jax": "false",
     },
 )
 
 config_setting(
-    name = "enable_jaxlib_and_jax_py_import",
+    name = "config_build_jax_wheel",
     flag_values = {
-        ":build_jaxlib": "wheel",
         ":build_jax": "wheel",
     },
 )

--- a/jax_plugins/cuda/BUILD.bazel
+++ b/jax_plugins/cuda/BUILD.bazel
@@ -14,7 +14,6 @@
 
 load(
     "//jaxlib:jax.bzl",
-    "if_windows",
     "py_library_providing_imports_info",
     "pytype_library",
 )
@@ -57,36 +56,4 @@ py_library_providing_imports_info(
     ],
     data = [":pjrt_c_api_gpu_plugin.so"],
     lib_rule = pytype_library,
-)
-
-config_setting(
-    name = "disable_jaxlib_for_cpu_build",
-    flag_values = {
-        "//jax:build_jaxlib": "false",
-        "@local_config_cuda//:enable_cuda": "False",
-    },
-)
-
-config_setting(
-    name = "disable_jaxlib_for_cuda12_build",
-    flag_values = {
-        "//jax:build_jaxlib": "false",
-        "@local_config_cuda//:enable_cuda": "True",
-    },
-)
-
-config_setting(
-    name = "enable_py_import_for_cpu_build",
-    flag_values = {
-        "//jax:build_jaxlib": "wheel",
-        "@local_config_cuda//:enable_cuda": "False",
-    },
-)
-
-config_setting(
-    name = "enable_py_import_for_cuda12_build",
-    flag_values = {
-        "//jax:build_jaxlib": "wheel",
-        "@local_config_cuda//:enable_cuda": "True",
-    },
 )

--- a/jax_plugins/rocm/BUILD.bazel
+++ b/jax_plugins/rocm/BUILD.bazel
@@ -16,7 +16,6 @@ licenses(["notice"])
 
 load(
   "//jaxlib:jax.bzl",
-  "if_windows",
   "py_library_providing_imports_info",
   "pytype_library",
 )


### PR DESCRIPTION
A lot of this logic was confusing phrased as conditions over both CPU and GPU build flags. But we can decompose it:
* dependencies we add for CPU tests, and
* additional dependencies we add for GPU tests.

While we are here, also add the necessary pypi dependency for TPU tests.