### PR TITLE
improve error message with when custom_vjp bwd rule produces wrong shape/dtype

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2777,6 +2777,26 @@ def typematch(t1: AbstractValue, t2: AbstractValue) -> bool:
   else:
     return False
 
+def aval_mismatch_extra(a1: AbstractValue, a2: AbstractValue) -> str:
+  assert not typematch(a1, a2)
+  if isinstance(a1, ShapedArray) and isinstance(a2, ShapedArray):
+    mismatches = []
+    if a1.dtype != a2.dtype:
+      mismatches.append('the dtypes do not match')
+    if a1.shape != a2.shape:
+      mismatches.append('the shapes do not match')
+    if a1.vma != a2.vma:
+      mismatches.append('the varying manual axes do not match')
+    # TODO(yashkatariya,mattjj): add check for sharding-in-types mismatch
+
+    if len(mismatches) == 0:
+      return ''
+    elif len(mismatches) == 1:
+      return ', so ' + mismatches[0]
+    else:
+      return ', so ' + ', '.join(mismatches[:-1]) + ', and ' + mismatches[-1]
+  return ''
+
 class JaxprTypeError(TypeError): pass
 
 custom_typechecks: dict[Primitive, Callable] = {}

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -917,7 +917,8 @@ def _flatten_bwd(f: Callable,
                "shape/dtypes as the args tuple of the primal function, but at "
                f"output{keystr(kp)} the bwd rule produced an output of "
                f"shape/dtype {a_.str_short()} corresponding "
-               f"to an input of shape/dtype {a.str_short()}.")
+               f"to an input of shape/dtype {a.str_short()}"
+               f"{core.aval_mismatch_extra(a, a_)}")
         raise ValueError(msg)
       results.append(ct)
   return results

--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -260,23 +260,3 @@ def _show_diff(array1, array2):
 def _avals_short(avals):
   to_str = lambda aval: getattr(aval, 'str_short', partial(str, aval))()
   return ' '.join(map(to_str, avals))
-
-def _aval_mismatch_extra(a1: core.AbstractValue, a2: core.AbstractValue) -> str:
-  assert not core.typematch(a1, a2)
-  if isinstance(a1, core.ShapedArray) and isinstance(a2, core.ShapedArray):
-    mismatches = []
-    if a1.dtype != a2.dtype:
-      mismatches.append('the dtypes do not match')
-    if a1.shape != a2.shape:
-      mismatches.append('the shapes do not match')
-    if a1.vma != a2.vma:
-      mismatches.append('the varying manual axes do not match')
-    # TODO(yashkatariya,mattjj): add check for sharding-in-types mismatch
-
-    if len(mismatches) == 0:
-      return ''
-    elif len(mismatches) == 1:
-      return ', so ' + mismatches[0]
-    else:
-      return ', so ' + ', '.join(mismatches[:-1]) + ', and ' + mismatches[-1]
-  return ''

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -53,8 +53,8 @@ from jax._src.lib.mlir.dialects import hlo
 import numpy as np
 
 from jax._src.lax.control_flow.common import (
-    _avals_short, _typecheck_param, _aval_mismatch_extra,
-    _initial_style_jaxprs_with_common_consts, _make_closed_jaxpr, _prune_zeros)
+    _avals_short, _typecheck_param, _initial_style_jaxprs_with_common_consts,
+    _make_closed_jaxpr, _prune_zeros)
 
 map, unsafe_map = safe_map, map
 
@@ -351,7 +351,7 @@ def _check_branch_outputs(
   if not all(map(core.typematch, out_avals1, out_avals2)):
     diffs = [f'the output of {name1}{component(p)} has type {a1.str_short()}'
              f' but the corresponding output of {name2} has type '
-             f'{a2.str_short()}{_aval_mismatch_extra(a1, a2)}'
+             f'{a2.str_short()}{core.aval_mismatch_extra(a1, a2)}'
              for p, a1, a2 in zip(paths, out_avals1, out_avals2)
              if not core.typematch(a1, a2)]
     if len(diffs) == 0:

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -51,7 +51,7 @@ from jax._src.lax import windowed_reductions
 from jax._src.lax.control_flow.common import (
     _avals_short, _initial_style_jaxpr,
     _initial_style_jaxpr_attrs, _make_closed_jaxpr_attrs, _prune_zeros,
-    _typecheck_param, _aval_mismatch_extra)
+    _typecheck_param)
 from jax._src.lax.other import logaddexp
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import hlo
@@ -478,7 +478,7 @@ def _check_carry_type(name, body_fun, in_carry, out_carry_tree, out_avals):
   if not all(_map(core.typematch, in_avals, out_avals)):
     diffs = [f'{component(path)} has type {in_aval.str_short()}'
              ' but the corresponding output carry component has type '
-             f'{out_aval.str_short()}{_aval_mismatch_extra(in_aval, out_aval)}'
+             f'{out_aval.str_short()}{core.aval_mismatch_extra(in_aval, out_aval)}'
              for path, in_aval, out_aval in zip(paths, in_avals, out_avals)
              if not core.typematch(in_aval, out_aval)]
 


### PR DESCRIPTION
Even the best of us can miss important error information, like noticing when shapes disagree. So let's make things better.

```python
import jax
import jax.numpy as jnp

@jax.custom_vjp
def f(x):
  return x

def f_fwd(x):
  return x, ()

def f_bwd(_, g):
  return jnp.ones((10,), g.dtype),

f.defvjp(f_fwd, f_bwd)

jax.grad(f)(3.14)
```

Before:
Traceback (most recent call last):
  File "/usr/local/google/home/mattjj/packages/jax/rahul11.py", line 16, in <module>
    jax.grad(f)(3.14)
ValueError: Custom VJP bwd rule must produce an output with the same shape/dtypes as the args tuple of the primal function, but at output[0] the bwd rule produced an output of shape/dtype float32[10] corresponding to an input of shape/dtype float32[].

After (emphasis added):
Traceback (most recent call last):
  File "/usr/local/google/home/mattjj/packages/jax/rahul11.py", line 16, in <module>
    jax.grad(f)(3.14)
ValueError: Custom VJP bwd rule must produce an output with the same shape/dtypes as the args tuple of the primal function, but at output[0] the bwd rule produced an output of shape/dtype float32[10] corresponding to an input of shape/dtype float32[], **so the shapes do not match**