### PR TITLE
[hijax] prototype hijax pieces

### DIFF
--- a/jax/_src/ad_util.py
+++ b/jax/_src/ad_util.py
@@ -31,6 +31,9 @@ T = TypeVar('T')
 map = safe_map
 
 def add_jaxvals(x: ArrayLike, y: ArrayLike) -> Array:
+  ty = core.typeof(x)
+  if hasattr(ty, 'vspace_add'):  # TODO(mattjj,dougalm): revise away hasattr
+    return ty.vspace_add(x, y)
   x, y = core.standard_insert_pvary(x, y)
   return add_jaxvals_p.bind(x, y)
 
@@ -48,6 +51,8 @@ def add_abstract(x, y):
   return x
 
 def zeros_like_aval(aval: core.AbstractValue) -> Array:
+  if hasattr(aval, 'vspace_zero'):  # TODO(mattjj,dougalm): revise away hasattr
+    return aval.vspace_zero()
   return aval_zeros_likers[type(aval)](aval)
 aval_zeros_likers: dict[type, Callable[[Any], Array]] = {}
 

--- a/tests/attrs_test.py
+++ b/tests/attrs_test.py
@@ -15,7 +15,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import partial
 import itertools as it
+import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -25,6 +27,10 @@ import jax
 import jax.numpy as jnp
 
 from jax._src import config
+from jax._src import core
+from jax._src import dtypes
+from jax._src.interpreters import ad
+from jax._src.interpreters import partial_eval as pe
 from jax._src import test_util as jtu
 from jax._src.util import safe_zip, safe_map
 
@@ -1324,6 +1330,293 @@ class ListTest(jtu.JaxTestCase):
     b = List([])
     with self.assertRaisesRegex(ValueError, "a List instance can't be passed"):
       f(b, b)
+
+
+class HiPrimitive(core.Primitive):
+  def __init__(self, name):
+    self.name = name
+    ad.primitive_jvps[self] = self.jvp
+    ad.primitive_transposes[self] = self.transpose
+    pe.custom_staging_rules[self] = self.staging
+
+  def staging(self, trace, *args, **kwargs):
+    trace.frame.is_high = True
+    return trace.default_process_primitive(self, args, kwargs)
+
+  def is_high(self, **params):
+    return True
+
+  def abstract_eval(self, *arg_avals, **params):
+    assert False, "must override"
+
+  def to_lojax(self, *lotypes_wrapped_in_hitypes, **params):
+    assert False, "must override"
+
+  def jvp(self, primals, tangents, **params):
+    assert False, "must override"
+
+  def transpose(self, *args, **params):
+    assert False  # TODO
+
+
+class HijaxTest(jtu.JaxTestCase):
+
+  def test_custom_types_and_primitive(self):
+    if config.enable_x64.value: raise unittest.SkipTest("no x64")
+
+    @dataclass(frozen=True)
+    class MyArray:
+      arr: jax.Array  # always f32
+
+    @dataclass(frozen=True)
+    class MyTy(core.AbstractValue):
+      mutable = False
+
+      def to_tangent_aval(self):
+        return MyTy()
+      def str_short(self, short_dtypes=False):
+        return 'MyTy'
+      def lo_ty(self):
+        return [core.ShapedArray((), jnp.dtype('float32'))]
+      def lower_val(self, hi_val: MyArray) -> list[jax.Array]:
+        return [hi_val.arr]
+      def raise_val(self, val) -> MyArray:
+        return MyArray(val)
+
+      def __eq__(self, other): return isinstance(other, MyTy)
+
+      def vspace_zero(self):
+        return MyArray(jnp.zeros((), 'float32'))
+      def vspace_add(self, x, y):
+        return add(x, y)
+
+      def strip_weak_type(self): return self
+      def normalize(self): return self
+    core.pytype_aval_mappings[MyArray] = lambda _: MyTy()
+
+    class ToMy(HiPrimitive):
+      def is_high(self): return True
+
+      def abstract_eval(_, lo_aval):
+        return MyTy(), set()
+
+      def to_lojax(_, lo):
+        return MyArray(lo)
+
+      def jvp(_, primals, tangents):
+        x, x_dot = *primals, *tangents
+        return to(x), to(x_dot)
+
+      def transpose(self, out_bar, _):
+        return from_(out_bar),
+
+    class FromMy(HiPrimitive):
+      def is_high(self): return True
+
+      def abstract_eval(_, hi_aval):
+        return hi_aval.lo_ty()[0], set()
+
+      def to_lojax(_, hi):
+        return hi.arr
+
+      def jvp(_, primals, tangents):
+        x, x_dot = *primals, *tangents
+        return from_(x), from_(x_dot)
+
+      def transpose(self, out_bar, _):
+        return to(out_bar),
+
+    def to(x): return to_p.bind(x)
+    to_p = ToMy('to_my')
+
+    def from_(x): return from_p.bind(x)
+    from_p = FromMy('from_my')
+
+    def mul(x, y): return mul_p.bind(x, y)
+    def add(x, y): return add_p.bind(x, y)
+
+    class MyMul(HiPrimitive):
+      def is_high(self): return True
+
+      def abstract_eval(_, hi_x, hi_y):
+        if hi_x != hi_y: raise Exception
+        return hi_x, set()
+
+      def to_lojax(_, hi_x, hi_y):
+        return MyArray(hi_x.arr * hi_y.arr)
+
+      def jvp(_, primals, tangents):
+        (x, y), (x_dot, y_dot) = primals, tangents
+        return mul(x, y), add(mul(x, y_dot), mul(x_dot, y))
+
+      def transpose(self, out_bar, x, y):
+        assert ad.is_undefined_primal(x) ^ ad.is_undefined_primal(y)
+        if ad.is_undefined_primal(x):
+          return mul(out_bar, y), None
+        else:
+          return None, mul(x, out_bar)
+
+    class MyAdd(HiPrimitive):
+      def is_high(self): return True
+
+      def abstract_eval(_, hi_x, hi_y):
+        if hi_x != hi_y: raise Exception
+        return hi_x, set()
+
+      def to_lojax(_, hi_x, hi_y):
+        return MyArray(hi_x.arr + hi_y.arr)
+
+      def jvp(_, primals, tangents):
+        assert False  # TODO
+
+      def transpose(self, out_bar, x, y):
+        return out_bar, out_bar
+
+    mul_p = MyMul('my_mul')
+    add_p = MyAdd('my_add')
+
+
+    @jax.jit
+    def f(x):
+      return to(from_(x))
+
+    # test basic to/from jit
+    a = MyArray(jnp.ones(()))
+    b = f(a)  # don't crash
+    self.assertIsInstance(b, MyArray)
+    self.assertAllClose(b.arr, jnp.ones(()))
+
+    # test basic to/from autodiff
+    b, b_dot = jax.jvp(f, (a,), (a,))
+    self.assertIsInstance(b, MyArray)
+    self.assertIsInstance(b_dot, MyArray)
+
+    # test mul jit and backward pass
+
+    @jax.jit
+    def f(x):
+      return mul(x, x)
+
+    b, f_vjp = jax.vjp(f, a)
+    self.assertIn('MyTy', str(f_vjp))
+    a_grad, = f_vjp(b)
+    self.assertIsInstance(a_grad, MyArray)
+    self.assertAllClose(a_grad.arr, 2.0, check_dtypes=False)
+
+  def test_box_autodiff(self):
+    if config.enable_x64.value: raise unittest.SkipTest("no x64")
+    class BoxTy(core.AbstractValue):
+      mutable = True
+
+      def to_tangent_aval(self):
+        # NOTE not really used, for some reason we had to write it anyway
+        return core.ShapedArray((), dtypes.float0)
+
+      def str_short(self, short_dtypes=False):
+        return 'BoxTy'
+
+      def lower_val(self, box):
+        return [box._val]
+
+      def raise_val(self, val):
+        return Box(val)  # we're gonna mutate this
+
+      def lo_ty(self):
+        return [core.ShapedArray((), jnp.dtype('float32'))]
+
+      def get(self, box):
+        return [box._val]
+
+      def set(self, box, val):
+        box._val = val
+
+    class Box:
+      def __init__(self, val):
+        self._val = val
+      ty = BoxTy()
+    core.pytype_aval_mappings[Box] = lambda b: b.ty
+
+
+    class BoxSet(HiPrimitive):
+      multiple_results = True
+      def is_high(self) -> bool: return True
+
+      def abstract_eval(*_, **__):
+        return [], set()
+
+      def to_lojax(_, box, val):
+        box._val = val
+        return []
+
+      def jvp(_, primals, tangents):
+        assert False  # TODO
+
+      def transpose(_, *args):
+        assert False  # TODO
+    box_set_p = BoxSet('box_set')
+
+    class BoxGet(HiPrimitive):
+      def is_high(self) -> bool: return True
+
+      def abstract_eval(*_, **__):
+        return jnp.dtype('float32'), set()
+
+      def to_lojax(_, box):
+        return box._val
+
+      def jvp(_, primals, tangents):
+        assert False  # TODO
+
+      def transpose(_, *args):
+        assert False  # TODO
+    box_get_p = BoxGet('box_get')
+
+    class StashTangents(HiPrimitive):
+      def is_high(self):
+        return True
+
+      def abstract_eval(_, box_aval, x_aval):
+        del box_aval
+        return x_aval, set()
+
+      def to_lojax(_, box, x):
+        assert False  # TODO
+
+      def jvp(_, primals, tangents):
+        box, x = primals
+        _, x_dot = tangents
+        box_set(box, x_dot)
+        return x, x_dot
+
+      def transpose(self, *args):
+        assert False  # TODO
+    stash_tangents_p = StashTangents('stash_tangents')
+
+    def box_set(box, val):
+      box_set_p.bind(box, val)
+
+    def box_get(box):
+      return box_get_p.bind(box)
+
+    def stash_tangents(box, x):
+      return stash_tangents_p.bind(box, x)
+
+    @jax.jit
+    def f(box, x):
+      box_set(box, x)
+
+    box = Box(0.0)
+    f(box, 1.)
+    self.assertAllClose(box_get(box), 1.0, check_dtypes=False)
+
+    @jax.jit
+    def f(box, x):
+      x = stash_tangents(box, x)
+      return x
+
+    box = Box(0.0)
+    jax.jvp(partial(f, box), (3.,), (5.,))
+    self.assertAllClose(box_get(box), 5.0, check_dtypes=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This shouldn't affect any existing behaviors, and it shouldn't regress tracing time noticeably.

The main problem we're trying to solve is `grad`-of-`jit` where the `jit` abstracts a `Box`. In that case, we must pass a reference to the abstracted box to the backward pass. To do that, we make it part of the AD jaxpr. And to avoid polluting all jaxprs, we introduce a new (currently AD-specific) hijax jaxpr, which has more types/primitives than the existing (lojax) jaxprs.

The main implementation ideas:
* each Trace is tagged with a `requires_low: bool`
* each Jaxpr
  * is tagged with an `is_high: bool`, default False but set True while tracing if any hijax primitives are encountered
  * includes an `mut_types: dict[Var, HijaxType]` indicating final types for type-changing mutable hijax types
* each AbstractValue is tagged by a `mutable: bool` which is read to populate `mut_types`
* each Primitive
  * has an `is_high(**params) -> bool` method (depends on params for HOPs)
  * has a `to_lojax(*args, **params)` method taking and returning hijaxtypes-wrapping-lowtracers
* in `Primitive.bind`, we check if `prim.is_high(**params) and trace.requires_low`, and if so we call `prim.to_lojax`

We plan to revise the implementation to look like having a ToLojax trace that sits above the default EvalTrace instance at the top level.

Co-implemented with @dougalm. Design explanation forthcoming.