### PR TITLE
Fix scipy nightly CI failures caused by toeplitz

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -70,7 +70,9 @@ def _axis_for_ndim(ndim: int) -> Iterator[None | int | tuple[int, ...]]:
 
 def osp_linalg_toeplitz(c: np.ndarray, r: np.ndarray | None = None) -> np.ndarray:
   """scipy.linalg.toeplitz with v1.17+ batching semantics."""
-  if scipy_version >= (1, 17, 0):
+  # TODO(dfm,jakevdp): Remove dev check after upstream PR is merged:
+  # https://github.com/scipy/scipy/issues/21466.
+  if scipy_version >= (1, 17, 0) and "dev0" not in scipy.version.version:
     return scipy.linalg.toeplitz(c, r)
   elif r is None:
     c = np.atleast_1d(c)


### PR DESCRIPTION
Fixes https://github.com/jax-ml/jax/issues/28817

The scipy nightly version is now `1.17.0.dev0...`, but https://github.com/scipy/scipy/issues/21466 hasn't been merged, so `toeplitz` still has the pre-`1.17.0` behavior. Once https://github.com/scipy/scipy/issues/21466 is merged, we can switch to the scipy version of `toeplitz` for our comparisons.

Ref: https://github.com/jax-ml/jax/pull/24842