### PR TITLE
cleanup: load python rules from rules_python

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -15,6 +15,7 @@
 
 load("@python//:defs.bzl", "compile_pip_requirements")
 load("@python_version_repo//:py_version.bzl", "REQUIREMENTS")
+load("@rules_python//python:py_library.bzl", "py_library")
 load("//jaxlib:jax.bzl", "all_py_deps")
 
 licenses(["notice"])

--- a/jaxlib/mlir/BUILD.bazel
+++ b/jaxlib/mlir/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_python//python:py_library.bzl", "py_library")
 load("//jaxlib:symlink_files.bzl", "symlink_files", "symlink_inputs")
 
 package(

--- a/jaxlib/mlir/_mlir_libs/BUILD.bazel
+++ b/jaxlib/mlir/_mlir_libs/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_python//python:py_library.bzl", "py_library")
 load(
     "//jaxlib:jax.bzl",
     "if_windows",


### PR DESCRIPTION
Later versions of Bazel no longer have the py rules built in, so they should be loaded
from rules_python instead.