### PR TITLE
JEP: Stateful Randomness in JAX

### DIFF
--- a/docs/jax.experimental.random.rst
+++ b/docs/jax.experimental.random.rst
@@ -1,0 +1,10 @@
+``jax.experimental.random`` module
+==================================
+
+.. automodule:: jax.experimental.random
+
+.. autosummary::
+  :toctree: _autosummary
+
+  stateful_rng
+  StatefulPRNG

--- a/docs/jax.experimental.rst
+++ b/docs/jax.experimental.rst
@@ -23,5 +23,6 @@ Experimental Modules
     jax.experimental.mesh_utils
     jax.experimental.multihost_utils
     jax.experimental.pallas
+    jax.experimental.random
     jax.experimental.serialize_executable
     jax.experimental.sparse

--- a/docs/jep/28845-stateful-rng.md
+++ b/docs/jep/28845-stateful-rng.md
@@ -1,0 +1,145 @@
+(stateful-randomness-jep)=
+# JEP 28845: Stateful Randomness in JAX
+
+[@jakevdp](http://github.com/jakevdp), *November 2025*
+
+This document explores the addition of an **optional** stateful pseudo-random number generator (PRNG) for use in JAX; this is meant to be used alongside the classic functional PRNGs described in {ref}`pseudorandom-numbers` in cases where statefulness is convenient.
+
+## Background
+
+JAX has always required users to explicitly manage random state as part of its functional programming paradigm (see {ref}`prng-design-jep` for background on this). Although well-motivated, this is a frequently encountered [sharp bit](https://docs.jax.dev/en/latest/notebooks/Common_Gotchas_in_JAX.html#random-numbers) for new users who are accustomed to stateful pseudorandom number APIs.
+
+With the recent introduction of limited-scope [mutable refs](https://docs.jax.dev/en/latest/array_refs.html) in JAX, it is now possible to implement a stateful PRNG in JAX that retains most of the performance benefits of the existing functional PRNG, while providing a much more natural API for users familiar with NumPy, Pytorch, and other numerical computing libraries.
+
+This JAX Enhancement Proposal (or [JEP](https://docs.jax.dev/en/latest/jep/index.html)) proposes the introduction of a Stateful PRNG API into {mod}`jax.experimental.random`, with a goal of eventual inclusino into {mod}`jax.random` itself.
+
+## API Design
+
+To align with best practices developed within the larger numerical Python community, we propose for the stateful PRNG API to align with To align with NumPy’s most recent PRNG API iteration, found in {class}`numpy.random.Generator`, and typically created using the {func}`numpy.random.default_rng` function. A full draft of the proposed implementation can be found at {jax-issue}`#28845`, but here we summarize the main features of the implementation.
+
+A simplified version of the stateful PRNG Generator code looks like this (function and argument names follow the {mod}`numpy.random` APIs):
+
+```python
+def stateful_rng(seed: ArrayLike) -> StatefulPRNG:
+  """Create a stateful PRNG Generator given an integer seed."""
+  return StatefulPRNG(jax.random.key(seed), jax.new_ref(0))
+
+
+@tree_util.register_dataclass
+@dataclass(frozen=True)
+class StatefulPRNG:
+  """Stateful PRNG Generator class."""
+  base_key: jax.Array
+  counter: jax.core.Ref
+
+  def key(self) -> jax.Array:
+    """Generate a new jax PRNG key"""
+    key = jax.random.fold_in(self.base_key, self.counter[...])
+    jax.ref.addupdate(self.counter, ..., 1)  # increment counter
+    return key
+
+  def random(self, size: Sequence[int], dtype: DType = float):
+    """Return random floats in the half-open interval [0, 1)"""
+    return random.uniform(self.key(), shape=size, dtype=dtype)
+
+  # uniform(), normal(), integers(), and others implemented similarly.
+```
+
+With this implementation exposed in the {mod}`jax.experimental.random` namespace, usage is virtually identical to that of {func}`numpy.random.default_rng`:
+
+```python
+>>> from jax.experimental.random import stateful_rng
+>>> rng = stateful_rng(1701)
+>>> rng.random((5,))
+Array([0.09609699, 0.26730824, 0.5619041 , 0.24421775, 0.7715055 ], dtype=float32)
+>>> rng.random((5,))  # state is updated -> new random draws!
+Array([0.8131045 , 0.33873856, 0.88808906, 0.96005905, 0.7616446 ], dtype=float32)
+
+>>> import numpy as np
+>>> rng = np.random.default_rng(1701)
+>>> rng.random((5,))
+array([0.4020733 , 0.30563311, 0.67668051, 0.15821208, 0.79247763])
+>>> rng.random((5,))
+array([0.09419469, 0.36753944, 0.06388928, 0.96431608, 0.35200998])
+
+```
+
+Because the statefulness in {class}`jax.experimental.random.StatefulPRNG` is tracked via mutable refs, the random state will correctly update even if the generator is used in transformations like {func}`jax.jit`, which typically require pure functional semantics.
+
+### Interaction with `vmap` and `shard_map`
+
+The proposed stateful RNG design is based on refs, and so under `vmap` and `shard_map` it inherits the limitations of refs. So, for example, you cannot directly use an un-mapped `rng` within a vmapped function:
+
+```python
+rng = stateful_rng(0)
+
+def f(x):
+  return x + rng.uniform()
+
+jax.vmap(f)(jnp.arange(10))
+```
+```pytb
+Exception: performing an addupdate operation with vmapped value on an unbatched
+           array reference of type Ref{int32[]}. Move the array reference to be
+           an argument to the vmapped function?
+```
+
+For this reason we need the ability to split the generator in order to pass it to mapped or sharded code. For this we add a `split` method to the `StatefulPRNG` class that looks like this:
+
+```python
+class StatefulPRNG:
+  ...
+
+  def split(self, num: int | Sequence[int]) -> StatefulPRNG:
+    return StatefulPRNG(
+      base_key=jax.random.split(self.key(), num),
+      counter=jnp.zeros(num, dtype=int),
+    )
+```
+
+With this method present, the stateful rng can be explicitly split and passed to a vmapped function:
+
+```python
+rng = jax.experimental.random.stateful_rng(0)
+
+def f(x, rng):
+  return x + rng.uniform()
+
+result = jax.vmap(f)(jnp.arange(5), rng.split(5))
+print(result)  # [0.07174575 1.0163325  2.0435536  3.4391735  4.534091  ]
+```
+
+A similar approach would work for sharded computations, though `split` would likely have to grow a `sharding` argument.
+
+This splitting brings up the question of what to do if a user attempts to generate random numbers directly from a split generator, like `rng.split(10).uniform()`. For this we follow the precedent of classic stateless `jax.random` APIs when receiving batched keys, and raise an informative error.
+
+## Statistical Considerations
+
+In the proposed design, the random state is tracked via a base key along with an integer counter that increments each time a key is generated. We chose this approach rather than mutating the key itself in order to avoid the pitfalls of iterative splits (see INSERT_REF_HERE); in particular it means that the stateful generator will always fully explore the 32-bit or 64-bit space of keys before looping back to zero and repeating the initial key.
+
+## Advantages
+
+The main advantage of this approach is familiarity: many users are familiar with NumPy, and familiar with its stateful RNG utilities. This would let them start using JAX more directly, without the learning curve of the unfamiliar functional PRNG API.
+
+This does not just affect JAX users: for convenience, even JAX developers tend to context switch and use stateful NumPy APIs outside of transformations, where the functional PRNG is not necessary. This leads to confusion on the part of JAX users (see for example [this github discussion](https://github.com/jax-ml/jax/issues/30881)). Having a JAX-native stateful API would make it more convenient to always use JAX PRNGs in live demos and written tutorials.
+
+Another pitfall of functional PRNGs is the possibility of accidental key reuse. Users unfamiliar with the need for explicit state may use keys multiple times, inadvertently generating statistically dependent random values (see for example [this StackOverflow question](https://stackoverflow.com/q/76135488)). By encouraging new JAX users to use a stateful PRNG, we avoid this silent trap.
+
+Finally, the API affords the ability to call `rng.key()` in order to create a standard functional PRNG key, which can then be used in the typical functional mode: this is an easy onramp to explicitly-managed state in cases where it is warranted.
+
+## Limitations
+
+Implementing a stateful PRNG key via mutable refs comes with a few inherent limitations; in particular:
+
+**Sequential dependence restricts the compiler:** Programs using such keys impose an inherent sequential dependence within the program, meaning that the compiler would not have the freedom to reorder operations that depend on pseudorandom values. The pitfall in this case is silent: it would be up to the user to recognize where this may become an issue, and instead switch to batched execution modes over pre-generated sequences of keys or values. Note, however, that this sequential dependence pitfall also exists when users follow the current usage recommendations in the JAX docs: [https://docs.jax.dev/en/latest/jax.random.html\#basic-usage](https://docs.jax.dev/en/latest/jax.random.html#basic-usage).
+
+**Sequential dependence restricts the user:** Similarly, just as the compiler cannot reorder operations without changing the randomness, this sequential dependence also means the user cannot easily refactor code without changing the specific random draws. One potential example of this: suppose a stateful RNG is used within a neural network, and the user decides to swap an internal layer with one that has different random draws: this would consume a key and affect the random draws of all subsequent layers.
+
+**Incompatiblity with remat:** Because mutable refs rely on JAX’s effect system, these APIs would not be usable in places where effects are not supported. In particular, this means that in JAX’s current implementation, stateful keys would not be compatible with `remat`, which might limit their usefulness within neural network implementations. The pitfall in this case is loud: attempting to use a mutable ref within remat will lead to an explicit error. There is a possibility that a future redesign of `remat` could remove this incompatibility (see {jax-issue}`#33018` for some progress on this).
+
+**Refs cannot be return values:** Mutable refs cannot be present in the return values of transformed JAX functions, and the proposed stateful RNG object would inherit this limitation. This is also an explicit limitation: attempting to return a `StatefulPRNG` from a transformed function would lead to an explicit error.
+
+## Evaluation
+
+Our judgment is that the advantages of the stateful PRNG API potentially outweigh the limitations, and that we should introduce a new experimental {func}`~jax.experimental.random.stateful_rng` API in the {mod}`jax.experimental.random` module for now.
+Once we get a feel for the usefulness of this, we may evenutally graduate this API to the {mod}`jax.random` module, perhaps with a `default_rng` alias in {mod}`jax.numpy.random`.

--- a/docs/jep/index.rst
+++ b/docs/jep/index.rst
@@ -53,6 +53,7 @@ Then create a pull request that adds a file named
   18137: Scope of JAX NumPy & SciPy Wrappers <18137-numpy-scipy-scope>
   25516: Effort-based versioning <25516-effver>
   28661: Supporting the `__jax_array__` protocol <28661-jax-array-protocol>
+  28845: Stateful Randomness in JAX <28845-stateful-rng>
 
 
 Several early JEPs were converted in hindsight from other documentation,

--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -1586,3 +1586,21 @@ pytype_strict_library(
     srcs = ["ref.py"],
     deps = [":core"],
 )
+
+pytype_strict_library(
+    name = "stateful_rng",
+    srcs = [
+        "stateful_rng.py",
+    ],
+    deps = [
+        ":api_util",
+        ":core",
+        ":dtypes",
+        ":lax",
+        ":numpy",
+        ":random",
+        ":ref",
+        ":tree_util",
+        ":typing",
+    ] + py_deps("numpy"),
+)

--- a/jax/_src/stateful_rng.py
+++ b/jax/_src/stateful_rng.py
@@ -1,0 +1,302 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Stateful, implicitly-updated PRNG implementation based on mutable refs.
+"""
+from __future__ import annotations
+
+import dataclasses
+import operator
+from collections.abc import Sequence
+
+from jax._src import api_util
+from jax._src import core
+from jax._src import dtypes
+from jax._src import numpy as jnp
+from jax._src import random
+from jax._src import ref
+from jax._src import tree_util
+from jax._src import typing
+from jax._src.state import primitives as ref_primitives
+from jax._src.state import types as state_types
+from jax._src.typing import Array, ArrayLike, DTypeLike
+
+import numpy as np
+
+
+def _canonicalize_size(size: int | Sequence[int] | None, *args: ArrayLike) -> tuple[int, ...]:
+  if size is None:
+    return np.broadcast_shapes(*(np.shape(arg) for arg in args))
+  elif isinstance(size, (int, np.number)):
+    return (operator.index(size),)
+  else:
+    return tuple(map(operator.index, size))
+
+
+@tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class StatefulPRNG:
+  """Stateful JAX random generator.
+
+  This should be instantiated using the :func:`jax.experimental.random.stateful_rng` function.
+
+  Attributes:
+    _base_key: a typed JAX PRNG key object (see :func:`jax.random.key`).
+    _counter: a scalar integer wrapped in a :class:`jax.Ref`.
+
+  Examples:
+
+  >>> from jax.experimental import random
+  >>> rng = random.stateful_rng(42)
+  >>> rng
+  StatefulPRNG(_base_key=Array((), dtype=key<fry>) overlaying:
+  [ 0 42], _counter=Ref(0, dtype=int32, weak_type=True))
+  """
+  _base_key: Array
+  _counter: core.Ref
+
+  def __post_init__(self):
+    if self._base_key is api_util.SENTINEL:
+      return
+    if not (isinstance(self._base_key, Array)
+            and dtypes.issubdtype(self._base_key.dtype, dtypes.prng_key)):
+      raise ValueError(f"Expected base_key to be a typed PRNG key; got {self._base_key}")
+
+    # TODO(jakevdp): how to validate a traced mutable array?
+    if not (isinstance(self._counter, core.Ref) or
+            (isinstance(self._counter, core.Tracer)
+             and isinstance(self._counter.aval, state_types.AbstractRef))):
+      raise ValueError(f"Expected counter to be a scalar integer ref; got {self._counter}")
+
+  def key(self, shape: int | Sequence[int] = ()) -> Array:
+    """Generate a new JAX PRNGKey, updating the internal state.
+
+    Args:
+      shape: an optional shape if returning multiple keys.
+
+    Returns:
+      A new, independent PRNG key with the same impl/dtype as
+      ``self._base_key``.
+
+    Examples:
+      >>> from jax.experimental import random
+      >>> rng = random.stateful_rng(0)
+      >>> rng.key()
+      Array((), dtype=key<fry>) overlaying:
+      [1797259609 2579123966]
+      >>> rng.key()
+      Array((), dtype=key<fry>) overlaying:
+      [ 928981903 3453687069]
+    """
+    if self._base_key.shape:
+      # TODO(jakevdp): better error message.
+      raise ValueError("cannot operate on split stateful generator")
+
+    key = random.fold_in(self._base_key, ref_primitives.ref_get(self._counter))
+    ref_primitives.ref_addupdate(self._counter, ..., 1)  # pytype: disable=wrong-arg-types  # pytype bug?
+    shape_tuple = _canonicalize_size(shape)
+    return random.split(key, shape_tuple) if shape_tuple else key
+
+  def random(
+      self,
+      size: int | Sequence[int] | None = None,
+      dtype: DTypeLike = float,
+  ):
+    """Return random floats in the half-open interval [0.0, 1.0)."""
+    # TODO(jakevdp): write docstring
+    return random.uniform(self.key(), shape=_canonicalize_size(size), dtype=dtype)
+
+
+  def uniform(
+      self,
+      low: ArrayLike = 0,
+      high: ArrayLike = 1,
+      size: int | Sequence[int] | None = None,
+      *,
+      dtype: DTypeLike = float,
+  ) -> Array:
+    """Draw uniformly distributed pseudorandom values."""
+    # TODO(jakevdp): write docstring
+    return random.uniform(self.key(), _canonicalize_size(size, low, high),
+                          minval=low, maxval=high, dtype=dtype)
+
+  def normal(
+      self,
+      loc: ArrayLike = 0,
+      scale: ArrayLike = 1,
+      size: int | Sequence[int] | None = None,
+      *,
+      dtype: DTypeLike = float,
+  ) -> Array:
+    """Draw normally-distributed pseudorandom values."""
+    # TODO(jakevdp): write docstring
+    norm = random.normal(self.key(), _canonicalize_size(size, loc, scale), dtype)
+    return (jnp.asarray(loc) + jnp.asarray(scale) * norm).astype(dtype)
+
+  def integers(
+      self,
+      low: ArrayLike,
+      high: ArrayLike | None = None,
+      size: int | Sequence[int] | None = None,
+      *,
+      dtype: DTypeLike = int,
+  ) -> Array:
+    """Draw pseudorandom integers."""
+    # TODO(jakevdp): write docstring
+    if high is None:
+      low, high = 0, low
+    return random.randint(self.key(), _canonicalize_size(size, low, high),
+                          minval=low, maxval=high, dtype=dtype)
+
+  def split(self, num: int | Sequence[int]) -> StatefulPRNG:
+    """Create independent child generators suitable for use in :func:`jax.vmap`.
+
+    Args:
+      num: integer or sequence of integers specifying the split shape
+
+    Returns:
+      a single StatefulPRNG object with split contents, suitable for use
+      with :func:`jax.vmap`
+
+    Examples:
+      >>> import jax
+      >>> from jax.experimental import random
+      >>> rng = random.stateful_rng(123)
+      >>> x = jax.numpy.zeros(3)
+      >>> def f(rng, x):
+      ...   return x + rng.uniform()
+      >>> jax.vmap(f)(rng.split(3), x)
+      Array([0.35525954, 0.21937883, 0.5336956 ], dtype=float32)
+
+    See also:
+      - :meth:`jax.experimental.random.StatefulPRNG.spawn`: This is similar to ``split``, but
+        returns a Python list of :class:`StatefulPRNG`` objects.
+    """
+    return StatefulPRNG(
+      _base_key=self.key(num),
+      _counter=ref.new_ref(jnp.zeros(num, dtype=int))
+    )
+
+  def spawn(self, n_children: int) -> list['StatefulPRNG']:
+    """Create a list of independent child generators.
+
+    Args:
+      n_children: non-negative integer.
+
+    Returns:
+      A list of length ``n_children`` containing new independent ``StatefulPRNG`` instances
+      spawned from the original instance.
+
+    Examples:
+      >>> from jax.experimental import random
+      >>> rng = random.stateful_rng(123)
+      >>> child_rngs = rng.spawn(2)
+      >>> [r.integers(0, 10, 2) for r in child_rngs]
+      [Array([4, 5], dtype=int32), Array([2, 1], dtype=int32)]
+
+    See also:
+      - :meth:`jax.experimental.random.StatefulPRNG.split`: this is similar to spawn, but returns
+        a single mapped :class:`jax.experimental.random.StatefulPRNG`` which can be passed to
+        :func:`jax.vmap`.
+    """
+    return [self.__class__(key, ref.new_ref(0)) for key in self.key(n_children)]
+
+
+def stateful_rng(seed: typing.ArrayLike | None = None, *,
+                 impl: random.PRNGSpecDesc | None = None) -> StatefulPRNG:
+  """
+  Experimental stateful RNG with implicitly-updated state.
+
+  This implements a stateful PRNG API similar to :func:`numpy.random.default_rng`.
+  It is compatible with JAX transformations like :func:`~jax.jit` and others,
+  with a few exceptions mentioned in the Notes below.
+
+  .. note::
+
+    This stateful PRNG API is a convenience wrapper around JAX's classic
+    stateless, explicitly updated PRNG, described in :mod:`jax.random`.
+    For performance-critical applications, it is recommended to use
+    :func:`jax.random.key` with explicit random state semantics.
+
+  For a discussion of design considerations for this API, refer to
+  :ref:`stateful-randomness-jep`.
+
+  Args:
+    seed: an optional 64- or 32-bit integer used as the value of the key.
+      This must be specified if the generator is instantiated within transformed
+      code; when used at the top level of the program, it may be omitted in
+      which case the RNG will be seeded using the default NumPy seeding.
+    impl: optional string specifying the PRNG implementation (e.g.
+      ``'threefry2x32'``)
+
+  Returns:
+    A :class:`~jax.experimental.random.StatefulPRNG` object, with methods for generating
+    random values.
+
+  Notes:
+    The :class:`~jax.experimental.random.StatefulPRNG` object created by this method uses
+    :func:`~jax.Ref` objects to allow implicit updates of state, and thus
+    inherits some of its limitiations. For example:
+
+    - :class:`StatefulPRNG` objects cannot be among the return values of functions
+      wrapped in JIT or other JAX transformations. This means in particular
+      they cannot be used as `carry` values for :func:`jax.lax.scan`,
+      :func:`jax.lax.while_loop`, and other JAX control flow.
+    - :class:`StatefulPRNG` objects cannot be used together with
+      :func:`jax.checkpoint` or :func:`jax.remat`; in these cases it's best to
+      use the :meth:`StatefulPRNG.key` method to produce a standard JAX PRNG key.
+
+  Examples:
+    >>> from jax.experimental import random
+    >>> rng = random.stateful_rng(42)
+
+    Repeated draws implicitly update the key:
+
+    >>> rng.uniform()
+    Array(0.5302608, dtype=float32)
+    >>> rng.uniform()
+    Array(0.72766423, dtype=float32)
+
+    This also works under transformations like :func:`jax.jit`:
+
+    >>> import jax
+    >>> jit_uniform = jax.jit(rng.uniform)
+    >>> jit_uniform()
+    Array(0.6672406, dtype=float32)
+    >>> jit_uniform()
+    Array(0.3890121, dtype=float32)
+
+    Keys can be generated directly if desired:
+
+    >>> rng.key()
+    Array((), dtype=key<fry>) overlaying:
+    [2954079971 3276725750]
+    >>> rng.key()
+    Array((), dtype=key<fry>) overlaying:
+    [2765691542  824333390]
+  """
+  if seed is None:
+    if not core.trace_ctx.is_top_level():
+      raise TypeError(
+        "When used within transformed code, jax.experimental.random.stateful_rng()"
+        " requires an explicit seed to be set.")
+    entropy = np.random.SeedSequence().entropy
+    assert isinstance(entropy, int)
+    seed = np.int64(entropy & np.iinfo(np.int64).max)
+  assert seed is not None
+  return StatefulPRNG(
+    _base_key=random.key(seed, impl=impl),
+    _counter=ref.new_ref(0)
+  )

--- a/jax/experimental/BUILD
+++ b/jax/experimental/BUILD
@@ -537,6 +537,15 @@ pytype_strict_library(
 )
 
 pytype_strict_library(
+    name = "random",
+    srcs = ["random.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//jax/_src:stateful_rng",
+    ]
+)
+
+pytype_strict_library(
     name = "rnn",
     srcs = ["rnn.py"],
     visibility = ["//visibility:public"],

--- a/jax/experimental/random.py
+++ b/jax/experimental/random.py
@@ -1,0 +1,20 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Experimental random APIs."""
+
+from jax._src.stateful_rng import (
+    stateful_rng as stateful_rng,
+    StatefulPRNG as StatefulPRNG,
+)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1874,6 +1874,17 @@ jax_multiplatform_test(
 )
 
 jax_multiplatform_test(
+    name = "stateful_rng_test",
+    srcs = ["stateful_rng_test.py"],
+    deps = [
+        "//jax/experimental:random",
+    ] + py_deps([
+        "absl/testing",
+        "numpy",
+    ]),
+)
+
+jax_multiplatform_test(
     name = "ragged_collective_test",
     srcs = ["ragged_collective_test.py"],
     enable_backends = [

--- a/tests/stateful_rng_test.py
+++ b/tests/stateful_rng_test.py
@@ -1,0 +1,240 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+
+import numpy as np
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import random as exp_random
+from jax._src import config
+from jax._src import test_util as jtu
+
+
+config.parse_flags_with_absl()
+
+class StatefulRNGTest(jtu.JaxTestCase):
+
+  def test_stateful_rng_instantiation(self, seed=547389):
+    rng = exp_random.stateful_rng(seed)
+    key = jax.random.key(seed)
+
+    self.assertEqual(key, rng._base_key)
+    self.assertEqual(rng._counter.shape, ())
+    self.assertEqual(0, rng._counter[...])
+
+  def test_stateful_rng_counter_increment(self, seed=7865943):
+    rng = exp_random.stateful_rng(seed)
+    original_key = rng._base_key
+    self.assertEqual(0, rng._counter[...])
+
+    _ = jax.jit(rng.key)()  # implicit update
+
+    self.assertEqual(original_key, rng._base_key)  # base key does not change
+    self.assertEqual(1, rng._counter[...])  # counter is incremented
+
+  def test_stateful_rng_invalid_instantiation(self):
+    valid_key = jax.random.key(0)
+    valid_counter = jax.new_ref(0)
+    invalid_key = jax.numpy.array([0, 1], dtype='uint32')
+    invalid_counter = 0
+    with self.assertRaisesRegex(ValueError, "Expected base_key to be a typed PRNG key"):
+      exp_random.StatefulPRNG(invalid_key, valid_counter)
+    with self.assertRaisesRegex(ValueError, "Expected counter to be a scalar integer ref"):
+      exp_random.StatefulPRNG(valid_key, invalid_counter)
+
+  def testRepeatedKeys(self, seed=578543):
+    prng = exp_random.stateful_rng(seed)
+    self.assertNotEqual(prng.key(), prng.key())
+
+  def testShapedKeys(self, seed=7589432):
+    prng = exp_random.stateful_rng(seed)
+
+    keys1 = prng.key(10)
+    self.assertEqual(keys1.shape, (10,))
+    self.assertTrue(jax.dtypes.issubdtype(keys1.dtype, jax.dtypes.prng_key))
+
+    keys2 = prng.key(10)
+    self.assertEqual(keys1.shape, (10,))
+    self.assertTrue(jax.dtypes.issubdtype(keys2.dtype, jax.dtypes.prng_key))
+
+    self.assertFalse((keys1 == keys2).any())
+
+  def testRepeatedDraws(self, seed=328090):
+    prng = exp_random.stateful_rng(seed)
+    vals1 = prng.uniform(size=10)
+    vals2 = prng.uniform(size=10)
+    self.assertTrue((vals1 != vals2).all())
+
+  def testRepeatedDrawsJIT(self, seed=328090):
+    prng = exp_random.stateful_rng(seed)
+    @jax.jit
+    def get_values(prng):
+      return prng.uniform(size=10)
+    vals1 = get_values(prng)
+    vals2 = get_values(prng)
+    self.assertTrue((vals1 != vals2).all())
+
+  @jtu.sample_product(
+      size=[None, 2, (5, 2)],
+      dtype=jtu.dtypes.floating,
+  )
+  def testRandom(self, size, dtype):
+    rng = exp_random.stateful_rng(578943)
+    vals = rng.random(size, dtype)
+    shape = np.broadcast_shapes(size or ())
+
+    self.assertEqual(vals.shape, shape)
+    self.assertEqual(vals.dtype, dtype)
+    self.assertTrue((vals < 1).all())
+    self.assertTrue((vals >= 0).all())
+
+  @jtu.sample_product(
+      low=[0, 1, np.array([0, 1])],
+      high=[2, 3, np.array([2, 3])],
+      size=[None, 2, (5, 2)],
+      dtype=jtu.dtypes.floating,
+  )
+  @jax.numpy_dtype_promotion('standard')
+  @jax.numpy_rank_promotion('allow')
+  def testUniform(self, low, high, size, dtype):
+    rng = exp_random.stateful_rng(473289)
+    vals = rng.uniform(low, high, size, dtype=dtype)
+    shape = np.broadcast_shapes(np.shape(low), np.shape(high), size or ())
+
+    self.assertEqual(vals.shape, shape)
+    self.assertEqual(vals.dtype, dtype)
+    self.assertTrue((vals < high).all())
+    self.assertTrue((vals >= low).all())
+
+  @jtu.sample_product(
+      loc=[0, 1, np.array([0, 1])],
+      scale=[2, 3, np.array([2, 3])],
+      size=[None, 2, (5, 2)],
+      dtype=jtu.dtypes.floating,
+  )
+  @jax.numpy_dtype_promotion('standard')
+  @jax.numpy_rank_promotion('allow')
+  def testNormal(self, loc, scale, size, dtype):
+    rng = exp_random.stateful_rng(473289)
+    vals = rng.normal(loc, scale, size, dtype=dtype)
+    shape = np.broadcast_shapes(np.shape(loc), np.shape(scale), size or ())
+
+    self.assertEqual(vals.shape, shape)
+    self.assertEqual(vals.dtype, dtype)
+
+  @jtu.sample_product(
+      low=[0, 1, np.array([0, 1])],
+      high=[10, 15, np.array([10, 15])],
+      size=[None, 2, (5, 2)],
+      dtype=jtu.dtypes.integer,
+  )
+  @jax.numpy_dtype_promotion('standard')
+  @jax.numpy_rank_promotion('allow')
+  def testIntegers(self, low, high, size, dtype):
+    rng = exp_random.stateful_rng(473289)
+    vals = rng.integers(low, high, size, dtype=dtype)
+    shape = np.broadcast_shapes(np.shape(low), np.shape(high), size or ())
+
+    self.assertEqual(vals.shape, shape)
+    self.assertEqual(vals.dtype, dtype)
+    self.assertTrue((vals < high).all())
+    self.assertTrue((vals >= low).all())
+
+  def testSpawn(self):
+    rng = exp_random.stateful_rng(758943)
+    rngs = rng.spawn(4)
+
+    for child_rng in rngs:
+      self.assertNotEqual(rng._base_key, child_rng._base_key)
+      self.assertEqual(0, child_rng._counter[...])
+
+  @jtu.sample_product(shape=[4, (5,), (2, 3)])
+  def testSplit(self, shape):
+    rng = exp_random.stateful_rng(758943)
+    rng_split = rng.split(shape)
+
+    expected_shape = (shape,) if isinstance(shape, int) else shape
+
+    self.assertEqual(rng_split._base_key.dtype, rng._base_key.dtype)
+    self.assertEqual(rng_split._base_key.shape, expected_shape)
+
+    self.assertIsInstance(rng_split._counter, jax.Ref)
+    self.assertEqual(rng_split._counter.shape, expected_shape)
+
+  def testVmapMapped(self):
+    seed = 758943
+    N = 4
+    x = np.arange(N, dtype=float)
+    def f(rng, x):
+      return x + rng.uniform()
+
+    rng = exp_random.stateful_rng(seed)
+    expected = x + jnp.array([rng.uniform() for rng in rng.spawn(N)])
+
+    rng = exp_random.stateful_rng(seed)
+    actual = jax.vmap(f)(rng.split(N), x)
+
+    self.assertArraysEqual(actual, expected)
+
+  def testVmapUnmapped(self):
+    seed = 758943
+    x = np.arange(4, dtype=float)
+    rng = exp_random.stateful_rng(seed)
+    def f(rng, x):
+      return x + rng.uniform()
+    with self.assertRaisesRegex(Exception, "performing an addupdate operation with vmapped value"):
+      jax.vmap(f, in_axes=(None, 0))(rng, x)
+
+  def testScanClosure(self):
+    seed = 432932
+    def f1(seed):
+      rng = exp_random.stateful_rng(seed)
+      def scan_f(_, __):
+        return None, rng.uniform()
+      return jax.lax.scan(scan_f, None, length=10)[1]
+
+    def f2(seed):
+      rng = exp_random.stateful_rng(seed)
+      return jax.numpy.array([rng.uniform() for i in range(10)])
+
+    self.assertArraysAllClose(f1(seed), f2(seed))
+
+  def testDefaultSeed(self):
+    rng = exp_random.stateful_rng()
+    x = rng.uniform(size=10)
+    self.assertEqual(x.shape, (10,))
+
+  def testDefaultSeedErrorUnderJIT(self):
+    def f():
+      return exp_random.stateful_rng().uniform(size=10)
+    with self.assertRaisesRegex(TypeError, "When used within transformed code"):
+      jax.jit(f)()
+
+  def testDefaultSeedErrorUnderGrad(self):
+    def f(x):
+      return x + exp_random.stateful_rng().uniform()
+    with self.assertRaisesRegex(TypeError, "When used within transformed code"):
+      jax.grad(f)(1.0)
+
+  def testDefaultSeedErrorUnderVmap(self):
+    def f(x):
+      return x + exp_random.stateful_rng().uniform()
+    with self.assertRaisesRegex(TypeError, "When used within transformed code"):
+      jax.vmap(f)(jnp.arange(5.0))
+
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This proposes a new experimental stateful PRNG object based on mutable refs, exposed for now at `jax.experimental.random.stateful_rng`. The API is inspired by `numpy.random.default_rng`. See the attached JEP for the full proposal.

Example:
```python
In [1]: from jax.experimental.random import stateful_rng

In [2]: rng = stateful_rng(123456)

# Calling rng.key() repeatedly will generate new keys each time, implicitly updating
# the internal state:
In [3]: rng.key()
Out[3]: 
Array((), dtype=key<fry>) overlaying:
[2376306259 4203193672]

In [4]: rng.key()
Out[4]: 
Array((), dtype=key<fry>) overlaying:
[ 989706967 1551494763]

# The rng object provides methods to generate values based on these implicitly-updated
# keys, inspired by the api of np.random.default_rng()
In [5]: rng.uniform()
Out[5]: Array(0.6851474, dtype=float32)

In [6]: rng.uniform()
Out[6]: Array(0.70181704, dtype=float32)

In [7]: rng.integers(0, 10, size=5)
Out[7]: Array([8, 0, 5, 7, 2], dtype=int32)

In [8]: rng.integers(0, 10, size=5)
Out[8]: Array([9, 0, 6, 7, 1], dtype=int32)

# Even when used under JIT, the implicit update propagates through due to being
# backed by the mutable ArrayRef object.
In [9]: import jax

In [10]: @jax.jit
    ...: def f(rng):
    ...:   return rng.integers(0, 10, size=5)
    ...: 

In [11]: f(rng)
Out[11]: Array([7, 1, 0, 8, 1], dtype=int32)

In [12]: f(rng)
Out[12]: Array([3, 9, 2, 5, 6], dtype=int32)
```