### PR TITLE
Update scipy.signal.welch tests to be compatible with upstream dev version

### DIFF
--- a/jax/_src/third_party/scipy/signal_helper.py
+++ b/jax/_src/third_party/scipy/signal_helper.py
@@ -57,7 +57,7 @@ def _triage_segments(window: ArrayLike | str | tuple[Any, ...], nperseg: int | N
       win = get_window(window, nperseg_int)
     win = jnp.array(win, dtype=dtype)
   else:
-    win = jnp.asarray(window)
+    win = jnp.asarray(window, dtype=dtype)
     nperseg_int = win.size if nperseg is None else int(nperseg)
     if win.ndim != 1:
       raise ValueError('window must be 1-D')

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -357,12 +357,11 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
     if use_nperseg:
       kwargs['nperseg'] = nperseg
     if use_window:
-      kwargs['window'] = jnp.array(osp_signal.get_window('hann', nperseg),
-                                   dtype=dtypes.to_complex_dtype(dtype))
+      kwargs['window'] = jnp.array(osp_signal.get_window('hann', nperseg))
     if use_noverlap:
       kwargs['noverlap'] = noverlap
 
-    @jtu.ignore_warning(message="nperseg = 256 is greater than")
+    @jtu.ignore_warning(message="nperseg")
     def osp_fun(x):
       freqs, Pxx = osp_signal.welch(x, **kwargs)
       return freqs.astype(_real_dtype(dtype)), Pxx.astype(_real_dtype(dtype))


### PR DESCRIPTION
The upstream PR https://github.com/scipy/scipy/pull/22460 made some changes to the behavior of `scipy.signal.welch` that we [started hitting as CI failures](https://github.com/jax-ml/jax/actions/runs/15133523737/job/42539894766). There were 2 issues that we were seeing:

1. The formatting of a warning was changed, so our existing warning ignore filter wasn't triggering.

2. The new version of the csd function is more restrictive about the allowed dtypes for the `window` array. (I think there is actually a bug in `scipy` wrt the handling of real data and complex window in the latest version. I'll report there!)