### PR TITLE
Skip generating source links for re-exported numpy functions in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@
 import inspect
 import operator
 import os
+from pathlib import Path
 import sys
 
 sys.path.insert(0, os.path.abspath('..'))
@@ -354,7 +355,11 @@ def linkcode_resolve(domain, info):
     source, linenum = inspect.getsourcelines(obj)
   except:
     return None
-  filename = os.path.relpath(filename, start=os.path.dirname(jax.__file__))
+  try:
+    filename = Path(filename).relative_to(Path(jax.__file__).parent)
+  except ValueError:
+    # Source file is not a relative to jax; this must be a re-exported function.
+    return None
   lines = f"#L{linenum}-L{linenum + len(source)}" if linenum else ""
   return f"https://github.com/jax-ml/jax/blob/main/jax/{filename}{lines}"
 


### PR DESCRIPTION
Fixes https://github.com/jax-ml/jax/issues/28885

Some `jnp` functions (e.g. `savez`) link to non-existent URLs when they are re-exported from numpy. We can skip generating these links when the source file doesn't live under the `jax` source root.

At this change, the source link no longer appears for [`savez`](https://jax--28886.org.readthedocs.build/en/28886/_autosummary/jax.numpy.savez.html#jax.numpy.savez), but it does for [`linspace`](https://jax--28886.org.readthedocs.build/en/28886/_autosummary/jax.numpy.linspace.html#jax.numpy.linspace), for example.