### PR TITLE
Use uv for installing packages on Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,15 +6,23 @@
 version: 2
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.10"
+    python: "3.12"
   jobs:
     post_checkout:
       # Skip building PRs unless tagged with the "documentation" label.
       - |
         [ "${READTHEDOCS_VERSION_TYPE}" != "external" ] && echo "Building latest" && exit 0
         (curl -sL https://api.github.com/repos/jax-ml/jax/issues/${READTHEDOCS_VERSION}/labels | grep -q "https://api.github.com/repos/jax-ml/jax/labels/documentation") && echo "Building PR with label" || exit 183
+    create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+      - uv venv $READTHEDOCS_VIRTUALENV_PATH
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv pip install -r docs/requirements.txt
+    install:
+      - "true"  # skip
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -24,8 +32,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
   - htmlzip
-
-# Optionally set the version of Python and requirements required to build your docs
-python:
-  install:
-    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,11 +38,11 @@ sys.path.insert(0, os.path.abspath('..'))
 from typing import ForwardRef
 
 def _do_not_evaluate_in_jax(
-    self, globalns, *args, _evaluate=ForwardRef._evaluate,
+    self, globalns, *args, _evaluate=ForwardRef._evaluate, **kwargs,
 ):
   if globalns.get('__name__', '').startswith('jax'):
     return self
-  return _evaluate(self, globalns, *args)
+  return _evaluate(self, globalns, *args, **kwargs)
 
 ForwardRef._evaluate = _do_not_evaluate_in_jax
 


### PR DESCRIPTION
Based on advice from https://github.com/astral-sh/uv/issues/10074

This speeds up the environment set up on Read the Docs from ~30s to ~10s. This isn't a huge win compared to the total runtime of the docs build, but it doesn't seem like a bad idea.

Rendered docs here: https://jax--28887.org.readthedocs.build/en/28887/