### PR TITLE
Revert "jax-cuda12-plugin: require nvidia-cublas-cu12<12.9"

### DIFF
--- a/jax_plugins/cuda/plugin_setup.py
+++ b/jax_plugins/cuda/plugin_setup.py
@@ -53,8 +53,7 @@ setup(
     install_requires=[f"jax-cuda{cuda_version}-pjrt=={__version__}"],
     extras_require={
       'with-cuda': [
-          # cudnn has a bug with mxfp8 with multiple GPUs per process and cublas 12.9
-          "nvidia-cublas-cu12>=12.1.3.1,<12.9",
+          "nvidia-cublas-cu12>=12.1.3.1",
           "nvidia-cuda-cupti-cu12>=12.1.105",
           "nvidia-cuda-nvcc-cu12>=12.6.85",
           "nvidia-cuda-runtime-cu12>=12.1.105",


### PR DESCRIPTION
Reverts jax-ml/jax#28513

The latest version of `nvidia-cudnn-cu12` (9.10.1.4) is expected to work with the newer 12.9 version of `nvidia-cublas-cu12`. See the cuDNN release notes: https://docs.nvidia.com/deeplearning/cudnn/backend/latest/release-notes.html#cudnn-9-10-1 describing the issue.

