### PR TITLE
Expose tree prefix broadcasting as a public API in tree utils.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 
 ## Unreleased
 
+* New features:
+  * Added {func}`jax.tree.broadcast` which implements a pytree prefix broadcasting helper.
+
 ## JAX 0.6.1 (May 21, 2025)
 
 * New features:

--- a/docs/jax.tree.rst
+++ b/docs/jax.tree.rst
@@ -12,6 +12,7 @@ List of Functions
    :toctree: _autosummary
 
    all
+   broadcast
    flatten
    flatten_with_path
    leaves

--- a/docs/jax.tree_util.rst
+++ b/docs/jax.tree_util.rst
@@ -38,6 +38,7 @@ These APIs are now accessed via :mod:`jax.tree`.
    :toctree: _autosummary
 
    tree_all
+   tree_broadcast
    tree_flatten
    tree_leaves
    tree_map

--- a/jax/_src/tree.py
+++ b/jax/_src/tree.py
@@ -378,3 +378,34 @@ def map_with_path(
     - :func:`jax.tree_util.register_pytree_with_keys`
   """
   return tree_util.tree_map_with_path(f, tree, *rest, is_leaf=is_leaf)
+
+
+def broadcast(prefix_tree: Any, full_tree: Any,
+              is_leaf: Callable[[Any], bool] | None = None
+              ) -> list[Any]:
+  """Broadcasts a tree prefix into the full structure of a given tree.
+
+    Args:
+      prefix_tree: a pytree that is a tree prefix of full_tree.
+      full_tree: a pytree with the structure to broadcast the prefix leaves into.
+      is_leaf: an optionally specified function that will be called at each
+        flattening step. It should return a boolean, with true stopping the
+        traversal and the whole subtree being treated as a leaf, and false
+        indicating the flattening should traverse the current object.
+
+    Returns:
+      A pytree matching the structure of full_tree where the leaves of prefix_tree have been
+      broadcasted into the leaves of each corresponding subtree.
+
+    Examples:
+      >>> import jax
+      >>> prefix = (1, 2, 3)
+      >>> full = (0, {'a': 0, 'b': 0}, (0, 0))
+      >>> jax.tree.broadcast(prefix, full)
+      (1, {'a': 2, 'b': 2}, (3, 3))
+
+    See Also:
+      - :func:`jax.tree.leaves`
+      - :func:`jax.tree.structure`
+  """
+  return tree_util.tree_broadcast(prefix_tree, full_tree, is_leaf=is_leaf)

--- a/jax/tree.py
+++ b/jax/tree.py
@@ -19,6 +19,7 @@ The :mod:`jax.tree` namespace contains aliases of utilities from :mod:`jax.tree_
 
 from jax._src.tree import (
     all as all,
+    broadcast as broadcast,
     flatten_with_path as flatten_with_path,
     flatten as flatten,
     leaves_with_path as leaves_with_path,

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -58,6 +58,7 @@ from jax._src.tree_util import (
     register_pytree_with_keys as register_pytree_with_keys,
     register_static as register_static,
     tree_all as tree_all,
+    tree_broadcast as tree_broadcast,
     tree_flatten_with_path as tree_flatten_with_path,
     tree_flatten as tree_flatten,
     tree_leaves_with_path as tree_leaves_with_path,


### PR DESCRIPTION
Many of our users end up hand-rolling a tree prefix broadcast function.  Expose our existing tree broadcast functionality as a new verb in tree utils.