### PR TITLE
Update the trove classifiers for JAX packages.

### DIFF
--- a/jax_plugins/cuda/plugin_setup.py
+++ b/jax_plugins/cuda/plugin_setup.py
@@ -78,10 +78,12 @@ setup(
     url="https://github.com/jax-ml/jax",
     license="Apache-2.0",
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: Free Threading :: 3 - Stable",
     ],
     package_data={
         package_name: [

--- a/jax_plugins/cuda/setup.py
+++ b/jax_plugins/cuda/setup.py
@@ -51,8 +51,9 @@ setup(
     url="https://github.com/jax-ml/jax",
     license="Apache-2.0",
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: Free Threading :: 3 - Stable",
     ],
     package_data={
         package_name: ["xla_cuda_plugin.so"],

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -68,10 +68,12 @@ setup(
     url='https://github.com/jax-ml/jax',
     license='Apache-2.0',
     classifiers=[
+        "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: Free Threading :: 3 - Stable",
     ],
     package_data={
         'jaxlib': [

--- a/setup.py
+++ b/setup.py
@@ -118,10 +118,12 @@ setup(
     url='https://github.com/jax-ml/jax',
     license='Apache-2.0',
     classifiers=[
+        "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: Free Threading :: 3 - Stable",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
* Don't tag packages as alpha.
* Tag free-threading as supported.
* Update some python version lists.