### PR TITLE
Use the builtin `isinstance` with MLIR types

### DIFF
--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -2629,7 +2629,7 @@ def compare_hlo(x, y, direction: str, comparison_type: str | None = None):
 def _minmax_hlo(op, cmp, x, y):
   """Min/max that compares complex values lexicographically as pairs."""
   tensor_type = ir.RankedTensorType(x.type)
-  if ir.ComplexType.isinstance(tensor_type.element_type):
+  if isinstance(tensor_type.element_type, ir.ComplexType):
     rx = hlo.real(x)
     ry = hlo.real(y)
     real_eq = compare_hlo(rx, ry, "EQ", "FLOAT")

--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -2034,7 +2034,7 @@ def _dot_general_lowering_rule(
   )
   val_type = out_type.element_type
   if any(
-      cls.isinstance(val_type)
+      isinstance(val_type, cls)
       for cls in [
           ir.BF16Type,
           ir.F32Type,
@@ -2044,7 +2044,7 @@ def _dot_general_lowering_rule(
       ]
   ):
     val = ir.FloatAttr.get(val_type, 0.0)
-  elif ir.IntegerType.isinstance(val_type):
+  elif isinstance(val_type, ir.IntegerType):
     val = ir.IntegerAttr.get(val_type, 0)
   else:
     raise NotImplementedError(ctx.avals_out[0].dtype)
@@ -2453,9 +2453,9 @@ def _fold_and_get_constant_value(x):
         "arith.minsi": min,
     }
     if op_name == "arith.constant":
-      if ir.IntegerType.isinstance(x.type):
+      if isinstance(x.type, ir.IntegerType):
         return ir.IntegerAttr(x.owner.attributes["value"]).value
-      elif ir.FloatType.isinstance(x.type):
+      elif isinstance(x.type, ir.FloatType):
         return ir.FloatAttr(x.owner.attributes["value"]).value
       else:
         raise ValueError(f"Unsupported constant type: {x.type}")

--- a/jax/_src/pallas/mosaic/verification.py
+++ b/jax/_src/pallas/mosaic/verification.py
@@ -250,7 +250,7 @@ def _print_op(ctx, op):
     case "tpu.device_id":
       return ctx.device_id
     case "arith.constant":
-      if ir.IntegerType.isinstance(op.result.type):
+      if isinstance(op.result.type, ir.IntegerType):
         return str(ir.IntegerAttr(op.value).value)
       else:
         return
@@ -447,7 +447,7 @@ def _print_op(ctx, op):
     case "scf.for":
       carrys = [
           ctx.emit("int", ctx.get(arg))
-          if ir.IntegerType.isinstance(arg.type) else None
+          if isinstance(arg.type, ir.IntegerType) else None
           for arg in op.initArgs
       ]
       bounds = (op.lowerBound, op.upperBound, op.step)
@@ -504,7 +504,7 @@ def bin_op(ctx, result_ty, op, lhs, rhs):
 
 
 def _model_type(ty):
-  if ir.IntegerType.isinstance(ty):
+  if isinstance(ty, ir.IntegerType):
     if ir.IntegerType(ty).width == 1:
       return "bool"
     else:
@@ -576,7 +576,7 @@ def export_promela_model(
       ctx.set(arg, model)
     del prefetch_args  # We ignore prefetch_args
     for arg in other_args:
-      if ir.MemRefType.isinstance(arg.type):
+      if isinstance(arg.type, ir.MemRefType):
         ty = ir.MemRefType(arg.type)
         if ty.element_type == sem_ty or ty.element_type == dma_sem_ty:
           ctx.set(arg, ctx.emit_global_semaphore_ref(ty.shape))

--- a/jax/_src/pallas/mosaic_gpu/primitives.py
+++ b/jax/_src/pallas/mosaic_gpu/primitives.py
@@ -82,7 +82,7 @@ def _load_abstract_eval(src, *avals_flat, args_tree, layout, optimized):
 def _load_p_lowering_rule(
     ctx: lowering.LoweringRuleContext, x_ref, *leaves, args_tree, layout, optimized
 ):
-  if not isinstance(x_ref, ir.Value) or not ir.MemRefType.isinstance(x_ref.type):
+  if not isinstance(x_ref, ir.Value) or not isinstance(x_ref.type, ir.MemRefType):
     raise TypeError(f"Can only load from references (got {x_ref}).")
 
   out_aval = ctx.avals_out[0]
@@ -1512,7 +1512,7 @@ def _broadcasted_iota_lowering(
 ):
   del ctx  # Unused.
   mlir_dtype = mgpu_utils.dtype_to_ir_type(dtype)
-  if ir.FloatType.isinstance(mlir_dtype):
+  if isinstance(mlir_dtype, ir.FloatType):
     i32 = ir.IntegerType.get_signless(32)
     cast = lambda x: arith_dialect.uitofp(
         mlir_dtype, arith_dialect.index_cast(i32, x)
@@ -1872,7 +1872,7 @@ def _inline_mgpu_discharge(*args, **kwargs):
 
 def _type_check_mgpu(v, ty):
   match (ty, v):
-    case (RefType(), ir.Value()) if ir.MemRefType.isinstance(v.type):
+    case (RefType(), ir.Value()) if isinstance(v.type, ir.MemRefType):
       pass
     case (GPUShapeDtypeStruct(), mgpu.FragmentedArray()):
       mlir_dtype = mgpu_utils.dtype_to_ir_type(ty.dtype)

--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -471,7 +471,7 @@ call_tf_p.def_effectful_abstract_eval(_call_tf_abstract_eval)
 def _mlir_type_to_numpy_dtype(type: ir.Type) -> np.dtype:
   """Converts an MLIR scalar type to a NumPy dtype."""
 
-  if ir.IntegerType.isinstance(type):
+  if isinstance(type, ir.IntegerType):
     type = ir.IntegerType(type)
     width = type.width
     if width == 1:
@@ -487,20 +487,20 @@ def _mlir_type_to_numpy_dtype(type: ir.Type) -> np.dtype:
     else:
       raise ValueError(f"Unsupported integer width: {width}")
 
-  elif ir.F16Type.isinstance(type):
+  elif isinstance(type, ir.F16Type):
     return np.dtype(np.float16)
-  elif ir.F32Type.isinstance(type):
+  elif isinstance(type, ir.F32Type):
     return np.dtype(np.float32)
-  elif ir.F64Type.isinstance(type):
+  elif isinstance(type, ir.F64Type):
     return np.dtype(np.float64)
-  elif ir.BF16Type.isinstance(type):
+  elif isinstance(type, ir.BF16Type):
     return np.dtype(ml_dtypes.bfloat16)
 
-  elif ir.ComplexType.isinstance(type):
+  elif isinstance(type, ir.ComplexType):
     element_type = ir.ComplexType(type).element_type
-    if ir.F32Type.isinstance(element_type):
+    if isinstance(element_type, ir.F32Type):
       return np.dtype(np.complex64)
-    elif ir.F64Type.isinstance(element_type):
+    elif isinstance(element_type, ir.F64Type):
       return np.dtype(np.complex128)
     else:
       raise ValueError(f"Unsupported complex element type: {element_type}")

--- a/jax/experimental/jax2tf/tests/call_tf_test.py
+++ b/jax/experimental/jax2tf/tests/call_tf_test.py
@@ -1755,8 +1755,8 @@ class RoundTripToTfTest(tf_test_util.JaxToTfTestCase):
 
           # Verify that the first argument/result of the custom call op is a token
           # type. This is a calling convention defined by `has_token_input_output`.
-          self.assertTrue(hlo.TokenType.isinstance(op.operands[0].type))
-          self.assertTrue(hlo.TokenType.isinstance(op.results[0].type))
+          self.assertTrue(isinstance(op.operands[0].type, hlo.TokenType))
+          self.assertTrue(isinstance(op.results[0].type, hlo.TokenType))
 
       stablehlo_module = None
       with self.assertRaisesRegex(

--- a/jax/experimental/mosaic/gpu/inference_utils.py
+++ b/jax/experimental/mosaic/gpu/inference_utils.py
@@ -71,7 +71,7 @@ def out_transforms(op: MlirOperation) -> Sequence[ir.Attribute]:
 def should_have_layout(op: MlirOperation) -> bool:
   """Returns 'true' if the operation should be assigned a layout."""
 
-  is_array = lambda v: ir.VectorType.isinstance(v.type)
+  is_array = lambda v: isinstance(v.type, ir.VectorType)
   return any(map(is_array, itertools.chain(op.operands, op.results)))  # type: ignore
 
 
@@ -117,7 +117,7 @@ def _in_attr_for_operand(
     attr_name: str,
 ) -> ir.Attribute | None:
   if attr_name == "in_layouts":
-    predicate = lambda v: ir.VectorType.isinstance(v.type)
+    predicate = lambda v: isinstance(v.type, ir.VectorType)
   elif attr_name == "in_transforms":
     predicate = is_transformable_smem_memref
   else:
@@ -140,7 +140,7 @@ def is_transformable_smem_memref(v: ir.Value) -> bool:
   barrier_ty = ir.Type.parse("!mosaic_gpu.barrier")
   smem = ir.Attribute.parse("#gpu.address_space<workgroup>")
   return (
-      ir.MemRefType.isinstance(v.type)
+      isinstance(v.type, ir.MemRefType)
       # barriers have no business being transformed
       and v.type.element_type != barrier_ty  # pylint: disable=attribute-error
       and v.type.memory_space is not None  # pylint: disable=attribute-error
@@ -150,7 +150,7 @@ def is_transformable_smem_memref(v: ir.Value) -> bool:
 
 def _value_attr(value: ir.Value, attr_type: str) -> ir.Attribute | None:
   if attr_type == "layouts":
-    predicate = lambda v: ir.VectorType.isinstance(v.type)
+    predicate = lambda v: isinstance(v.type, ir.VectorType)
   elif attr_type == "transforms":
     predicate = is_transformable_smem_memref
   else:
@@ -189,7 +189,7 @@ def value_layout(value: ir.Value) -> ir.Attribute | None:
   Raises:
     ValueError: If `result` is not a Vector.
   """
-  if not ir.VectorType.isinstance(value.type):
+  if not isinstance(value.type, ir.VectorType):
     raise ValueError(f"{value} is not a vector.")
 
   return _value_attr(value, "layouts")
@@ -201,7 +201,7 @@ def value_transforms(value: ir.Value) -> ir.Attribute | None:
   Raises:
     ValueError: If `result` is not a memref.
   """
-  if not ir.MemRefType.isinstance(value.type):
+  if not isinstance(value.type, ir.MemRefType):
     raise ValueError(f"{value} is not a memref.")
 
   return _value_attr(value, "transforms")

--- a/jax/experimental/mosaic/gpu/launch_context.py
+++ b/jax/experimental/mosaic/gpu/launch_context.py
@@ -483,16 +483,16 @@ class LaunchContext:
               tma_dtype = 4
             else:
               raise ValueError(f"Unsupported integer bitwidth: {bitwidth}")
-          elif ir.F16Type.isinstance(ref_ty.element_type):
+          elif isinstance(ref_ty.element_type, ir.F16Type):
             tma_dtype = 5
-          elif ir.F32Type.isinstance(ref_ty.element_type):
+          elif isinstance(ref_ty.element_type, ir.F32Type):
             tma_dtype = 6
-          elif ir.BF16Type.isinstance(ref_ty.element_type):
+          elif isinstance(ref_ty.element_type, ir.BF16Type):
             tma_dtype = 7
           # We treat 8 bit floats as 8 bit integers
-          elif ir.Float8E5M2Type.isinstance(ref_ty.element_type):
+          elif isinstance(ref_ty.element_type, ir.Float8E5M2Type):
             tma_dtype = 1
-          elif ir.Float8E4M3FNType.isinstance(ref_ty.element_type):
+          elif isinstance(ref_ty.element_type, ir.Float8E4M3FNType):
             tma_dtype = 1
           else:
             raise ValueError(f"unsupported TMA dtype {ref_ty.element_type}")
@@ -616,9 +616,8 @@ class LaunchContext:
       )
 
     if reduction_op is not None:
-      if not any(
-          t.isinstance(gmem_ref_ty.element_type)
-          for t in (ir.F32Type, ir.BF16Type, ir.F16Type)
+      if not isinstance(
+          gmem_ref_ty.element_type, (ir.F32Type, ir.BF16Type, ir.F16Type)
       ):
         raise ValueError(
             "TMA with reduction is only supported with f32, f16 and bf16"
@@ -892,7 +891,7 @@ class LaunchContext:
 
   def to_remote(self, ref: ir.Value, peer: ir.Value):
     self._ensure_nvshmem_decls()
-    if ir.MemRefType.isinstance(ref.type):
+    if isinstance(ref.type, ir.MemRefType):
       # We replace the offset in the ref type by 0, because memref_ptr always
       # folds the offset into the pointer.
       ref_ty = ir.MemRefType(ref.type)

--- a/jax/experimental/mosaic/gpu/tcgen05.py
+++ b/jax/experimental/mosaic/gpu/tcgen05.py
@@ -143,7 +143,7 @@ def mma(
   num_cta = 2 if collective else 1
 
   # Step 1. Establish the shape and element type of the operation.
-  if not ir.MemRefType.isinstance(b.type):
+  if not isinstance(b.type, ir.MemRefType):
     raise ValueError(f"B must be a memref, got: {b.type}")
   (k, n), element_type = mma_utils.tiled_memref_shape(b)
   if isinstance(a, TMEMRef):
@@ -156,7 +156,7 @@ def mma(
           f"A layout mismatch: expected {expected_layout}, got {a.layout}"
       )
   else:
-    if not ir.MemRefType.isinstance(a.type):
+    if not isinstance(a.type, ir.MemRefType):
       raise ValueError(f"A must be a memref, got {a.type}")
     (m, k2), element_type2 = mma_utils.tiled_memref_shape(a)
   if k != k2:
@@ -186,7 +186,7 @@ def mma(
           f" of type f32, but got: {d.dtype}"
       )
   elif any(
-      t.isinstance(element_type)
+      isinstance(element_type, t)
       for t in {ir.F16Type, ir.Float8E5M2Type, ir.Float8E4M3FNType}
   ):
     if d.dtype != f16 and d.dtype != f32:
@@ -309,11 +309,11 @@ def _do_mma(
   if (a_k_stride is not None and a_k_stride % 16) or b_k_stride % 16:
     raise ValueError
 
-  if ir.F16Type.isinstance(element_type) or ir.BF16Type.isinstance(element_type):
+  if isinstance(element_type, (ir.F16Type, ir.BF16Type)):
     kind = "f16"
-  elif ir.Float8E5M2Type.isinstance(element_type):
+  elif isinstance(element_type, ir.Float8E5M2Type):
     kind = "f8f6f4"
-  elif ir.Float8E4M3FNType.isinstance(element_type):
+  elif isinstance(element_type, ir.Float8E4M3FNType):
     kind = "f8f6f4"
   else:
     raise NotImplementedError(f"Unsupported input element type: {element_type}")
@@ -392,7 +392,7 @@ def _alloc_ncols(ncols: int, exact: bool):
 
 
 def tmem_alloc(tmem_addr: ir.Value, ncols: int, collective: bool = False, exact: bool = True):
-  if ir.MemRefType.isinstance(tmem_addr.type):
+  if isinstance(tmem_addr.type, ir.MemRefType):
     ref_ty = ir.MemRefType(tmem_addr.type)
     if ref_ty.element_type != ir.IntegerType.get_signless(32):
       raise ValueError(f"tmem_addr must be an i32 memref, got: {ref_ty}")
@@ -607,7 +607,7 @@ class TMEMRef:
       layout: TMEMLayout | None = None,
   ):
     i32 = ir.IntegerType.get_signless(32)
-    if not ir.MemRefType.isinstance(tmem_addr_ref.type):
+    if not isinstance(tmem_addr_ref.type, ir.MemRefType):
       raise ValueError(f"tmem_addr_ref must be a memref or a pointer, got: {tmem_addr_ref.type}")
     addr_ref_ty = ir.MemRefType(tmem_addr_ref.type)
     smem = ir.Attribute.parse("#gpu.address_space<workgroup>")

--- a/jax/experimental/mosaic/gpu/transform_inference.py
+++ b/jax/experimental/mosaic/gpu/transform_inference.py
@@ -142,7 +142,7 @@ def infer_transforms_for_wgmma_ref(ref_ty: ir.MemRefType) -> ir.ArrayAttr:
 @partial(_add_transform_inference_rule, mgpu.WGMMAOp)
 def infer_wgmma_transforms(op: mgpu.WGMMAOp) -> OptionalTransforms:
   b_transforms = infer_transforms_for_wgmma_ref(ir.MemRefType(op.b.type))
-  if ir.MemRefType.isinstance(op.a.type):
+  if isinstance(op.a.type, ir.MemRefType):
     a_transforms = infer_transforms_for_wgmma_ref(
         cast(ir.MemRefType, op.a.type)
     )
@@ -272,8 +272,8 @@ def _get_tile_and_swizzle_transforms(
   if len(transforms) == 2:
     tile_transform, swizzle_transform = transforms
     if not (
-        mgpu.TileTransformAttr.isinstance(tile_transform)
-        and mgpu.SwizzleTransformAttr.isinstance(swizzle_transform)
+        isinstance(tile_transform, mgpu.TileTransformAttr)
+        and isinstance(swizzle_transform, mgpu.SwizzleTransformAttr)
     ):
       raise NotImplementedError(f"Unsupported transforms {transforms}.")
     return tile_transform, swizzle_transform

--- a/jax/experimental/mosaic/gpu/utils.py
+++ b/jax/experimental/mosaic/gpu/utils.py
@@ -118,28 +118,28 @@ def get_contiguous_strides(xs):
 
 
 def c(val: int | float, ty):
-  if ir.IntegerType.isinstance(ty) or ir.IndexType.isinstance(ty):
+  if isinstance(ty, (ir.IntegerType, ir.IndexType)):
     if not isinstance(val, (int, np.integer)):
       raise TypeError(type(val))
     attr = ir.IntegerAttr.get(ty, val)
-  elif ir.FloatType.isinstance(ty):
+  elif isinstance(ty, ir.FloatType):
     attr = ir.FloatAttr.get(ty, val)
-  elif ir.VectorType.isinstance(ty):
+  elif isinstance(ty, ir.VectorType):
     return vector.splat(ty, c(val, ir.VectorType(ty).element_type))
   else:
     raise NotImplementedError(ty)
   return arith.constant(ty, attr)
 
 def _debug_scalar_ty_format(arg):
-  if ir.IndexType.isinstance(arg.type):
+  if isinstance(arg.type, ir.IndexType):
     return "%llu", arg
-  if ir.IntegerType.isinstance(arg.type):
+  if isinstance(arg.type, ir.IntegerType):
     if ir.IntegerType(arg.type).width < 64:
       arg = arith.extui(ir.IntegerType.get_signless(64), arg)
     return "%llu", arg
-  if ir.F32Type.isinstance(arg.type):
+  if isinstance(arg.type, ir.F32Type):
     return "%f", arg
-  if ir.BF16Type.isinstance(arg.type) or ir.F16Type.isinstance(arg.type):
+  if isinstance(arg.type, (ir.BF16Type, ir.F16Type)):
     arg = arith.extf(ir.F32Type.get(), arg)
     return "%f", arg
   raise NotImplementedError(f"Can't print the type {arg.type}")
@@ -152,7 +152,7 @@ def debug_print(fmt, *args, uniform=True, scope=None):
   type_formats = []
   new_args = []
   for arg in args:
-    if ir.VectorType.isinstance(arg.type):
+    if isinstance(arg.type, ir.VectorType):
       index = ir.IndexType.get()
       vec_ty = ir.VectorType(arg.type)
       if len(vec_ty.shape) > 1:
@@ -362,15 +362,15 @@ def bitwidth_impl(ty: ir.Type):
   # 32 bits for compatibility reasons. TF32 used to be 32 bits wide in upstream
   # MLIR, but it changed in
   # https://github.com/llvm/llvm-project/commit/67a1fdb014790a38a205d28e1748634de34471dd.
-  if ir.FloatTF32Type.isinstance(ty):
+  if isinstance(ty, ir.FloatTF32Type):
     return 32
-  if ir.IntegerType.isinstance(ty):
+  if isinstance(ty, ir.IntegerType):
     return ir.IntegerType(ty).width
-  if ir.FloatType.isinstance(ty):
+  if isinstance(ty, ir.FloatType):
     return ir.FloatType(ty).width
   if dialect is not None and ty == ir.Type.parse("!mosaic_gpu.barrier"):
     return MBARRIER_BYTES * 8
-  if ir.VectorType.isinstance(ty):
+  if isinstance(ty, ir.VectorType):
     vty = ir.VectorType(ty)
     return math.prod(vty.shape) * bitwidth(vty.element_type)
   raise NotImplementedError(ty)
@@ -433,7 +433,7 @@ def _is_contiguous_shape_slice(
     ref_ty: ir.MemRefType, dim_slice: slice | None = slice(None)
 ):
   # If it's not a strided layout then we are definitely contiguous.
-  if not ir.StridedLayoutAttr.isinstance(ref_ty.layout):
+  if not isinstance(ref_ty.layout, ir.StridedLayoutAttr):
     return True
 
   strides = ir.StridedLayoutAttr(ref_ty.layout).strides[dim_slice]
@@ -713,7 +713,7 @@ def parse_indices(
       slice_shape.append(idx.length)
       is_squeezed.append(False)
     elif isinstance(idx, ir.Value):
-      if not ir.IndexType.isinstance(idx.type):
+      if not isinstance(idx.type, ir.IndexType):
         raise ValueError("Expected an index-typed index")
       base_indices.append(idx)
       slice_shape.append(1)
@@ -779,7 +779,7 @@ class BarrierRef:
     i32 = ir.IntegerType.get_signless(32)
     if isinstance(offset, int):
       offset = c(offset, i32)
-    elif ir.IndexType.isinstance(offset.type):
+    elif isinstance(offset.type, ir.IndexType):
       offset = arith.index_castui(i32, offset)
     elif offset.type != i32:
       raise ValueError(f"Expected a dynamic index or an integer, got {offset}")
@@ -825,7 +825,7 @@ class BarrierRef:
   ):
     if isinstance(bytes, int):
       bytes = c(bytes, ir.IntegerType.get_signless(32))
-    elif ir.IndexType.isinstance(bytes.type):
+    elif isinstance(bytes.type, ir.IndexType):
       i32 = ir.IntegerType.get_signless(32)
       bytes = arith.index_cast(i32, bytes)
     nvvm.mbarrier_arrive_expect_tx_shared(self.get_ptr(), bytes, predicate=predicate)
@@ -1338,7 +1338,7 @@ def bitcast(x: ir.Value, new_type: ir.Type):
         f"Can't bitcast {x.type} (of bitwidth {x_bw}) to {new_type} (of"
         f" bitwidth {new_bw})"
     )
-  if ir.VectorType.isinstance(x.type) and ir.IntegerType.isinstance(new_type):
+  if isinstance(x.type, ir.VectorType) and isinstance(new_type, ir.IntegerType):
     new_type = ir.IntegerType(new_type)
     x_ty = ir.VectorType(x.type)
     assert new_type.width == bitwidth(x_ty.element_type) * math.prod(x_ty.shape)
@@ -1346,22 +1346,22 @@ def bitcast(x: ir.Value, new_type: ir.Type):
     return vector.extractelement(
         vector.bitcast(ir.VectorType.get((1,), new_type), x), position=i0
     )
-  if ir.IntegerType.isinstance(x.type) and ir.VectorType.isinstance(new_type):
+  if isinstance(x.type, ir.IntegerType) and isinstance(new_type, ir.VectorType):
     new_type = ir.VectorType(new_type)
     x_ty = ir.IntegerType(x.type)
     assert x_ty.width == bitwidth(new_type.element_type) * math.prod(new_type.shape)
     return vector.bitcast(new_type, vector.splat(ir.VectorType.get((1,), x_ty), x))
-  if ir.VectorType.isinstance(x.type) and ir.VectorType.isinstance(new_type):
+  if isinstance(x.type, ir.VectorType) and isinstance(new_type, ir.VectorType):
     x_ty = ir.VectorType(x.type)
     new_ty = ir.VectorType(new_type)
     if bitwidth(x_ty) != bitwidth(new_ty):
       raise ValueError(f"Can't bitcast {x.type} to {new_type}")
     return vector.bitcast(new_type, x)
-  if ir.IntegerType.isinstance(x.type) and ir.FloatType.isinstance(new_type):
+  if isinstance(x.type, ir.IntegerType) and isinstance(new_type, ir.FloatType):
     return arith.bitcast(new_type, x)
-  if ir.FloatType.isinstance(x.type) and ir.IntegerType.isinstance(new_type):
+  if isinstance(x.type, ir.FloatType) and isinstance(new_type, ir.IntegerType):
     return arith.bitcast(new_type, x)
-  if ir.FloatType.isinstance(x.type) and ir.FloatType.isinstance(new_type):
+  if isinstance(x.type, ir.FloatType) and isinstance(new_type, ir.FloatType):
     return arith.bitcast(new_type, x)
   raise ValueError(f"Can't bitcast {x.type} to {new_type}")
 
@@ -1387,7 +1387,7 @@ def vector_concat(vectors: Sequence[ir.Value]) -> ir.Value:
   if not vectors:
     raise ValueError("Cannot concatenate an empty list of vectors")
   vty = vectors[0].type
-  if not ir.VectorType.isinstance(vty):
+  if not isinstance(vty, ir.VectorType):
     raise ValueError("Cannot concatenate non-vector values")
   if vty.rank != 1:
     raise NotImplementedError("Only 1D vectors are supported")

--- a/jax/experimental/mosaic/gpu/wgmma.py
+++ b/jax/experimental/mosaic/gpu/wgmma.py
@@ -63,7 +63,7 @@ class WGMMAAccumulator:
     f32 = ir.F32Type.get()
     if dtype is None:
       dtype = f32
-    if ir.IntegerType.isinstance(dtype):
+    if isinstance(dtype, ir.IntegerType):
       zero = arith.constant(dtype, ir.IntegerAttr.get(dtype, 0))
     else:
       zero = arith.constant(dtype, ir.FloatAttr.get(dtype, 0.0))
@@ -87,14 +87,13 @@ class WGMMAAccumulator:
 
 
 def _supported_wgmma_types(dtype, abtype) -> bool:
-  input_types_are = lambda ty: ty.isinstance(abtype)
   f16_acc_types = (ir.F16Type, ir.Float8E5M2Type, ir.Float8E4M3FNType)
-  if ir.F32Type.isinstance(dtype):
-    return any(input_types_are(ty) for ty in (ir.FloatTF32Type, ir.BF16Type, *f16_acc_types))
-  elif ir.F16Type.isinstance(dtype):
-    return any(input_types_are(ty) for ty in f16_acc_types)
-  elif ir.IntegerType.get_signless(32).isinstance(dtype):
-    return input_types_are(ir.IntegerType.get_signless(8))
+  if isinstance(dtype, ir.F32Type):
+    return isinstance(abtype, (ir.FloatTF32Type, ir.BF16Type, *f16_acc_types))
+  elif isinstance(dtype, ir.F16Type):
+    return isinstance(abtype, f16_acc_types)
+  elif isinstance(dtype, ir.IntegerType) and dtype.width == 32:
+    return isinstance(abtype, ir.IntegerType) and abtype.width == 8
   else:
     return False
 
@@ -140,7 +139,7 @@ def wgmma_m64(
     if a_transpose is None:
       raise ValueError
 
-  if ir.F32Type.isinstance(out_ty) or out_ty == i32:
+  if isinstance(out_ty, ir.F32Type) or out_ty == i32:
     num_acc_regs = n // 2
     out_ty_field = out_ty
     acc_regs = [  # pylint: disable=g-complex-comprehension
@@ -150,8 +149,8 @@ def wgmma_m64(
     ]
     to_acc_vec_regs = functools.partial(
         _as_fragmented_reg_ndarray, dtype=out_ty, shape=acc.shape)
-    acc_constraint = "r" if ir.IntegerType.isinstance(out_ty) else "f"
-  elif ir.F16Type.isinstance(out_ty):
+    acc_constraint = "r" if isinstance(out_ty, ir.IntegerType) else "f"
+  elif isinstance(out_ty, ir.F16Type):
     num_acc_regs = n // 4
     out_ty_field = i32
     acc_regs = [_as_i32_reg(reg) for reg in acc.flat]
@@ -202,11 +201,11 @@ def wgmma_m64(
   assert next(reg_count) == len(reg_constraints_list)
   k_instr = 32 // bytewidth(element_type)
   el_ty = str(element_type)
-  if ir.Float8E5M2Type.isinstance(element_type):
+  if isinstance(element_type, ir.Float8E5M2Type):
     el_ty = "e5m2"
-  elif ir.Float8E4M3FNType.isinstance(element_type):
+  elif isinstance(element_type, ir.Float8E4M3FNType):
     el_ty = "e4m3"
-  elif ir.IntegerType.get_signless(8).isinstance(element_type):
+  elif isinstance(element_type, ir.IntegerType.get_signless(8)):
     # TODO(bchetioui): add u8 support in the future. Currently we always assume
     # that 8-bit integers are s8, and we would need to change the signature of
     # `wgmma` to indicate whether the input should be treated as signed or not.
@@ -289,7 +288,7 @@ def wgmma(
   if swizzle == 16:
     raise NotImplementedError("No swizzle is not supported")
   # Step 1. Establish the shape and element type of the operation.
-  if not ir.MemRefType.isinstance(b.type):
+  if not isinstance(b.type, ir.MemRefType):
     raise ValueError(f"B must be a memref, got: {b.type}")
   (k, n), element_type = mma_utils.tiled_memref_shape(b)
   if a_in_regs := isinstance(a, fa.FragmentedArray):
@@ -299,7 +298,7 @@ def wgmma(
       raise ValueError(
           f"Only 16-bit dtypes supported for A in registers, got {a.mlir_dtype}"
       )
-  elif ir.MemRefType.isinstance(a.type):
+  elif isinstance(a.type, ir.MemRefType):
     (m, k2), element_type2 = mma_utils.tiled_memref_shape(a)
   else:
     raise ValueError(f"Unsupported A type: {type(a)}")
@@ -328,7 +327,7 @@ def wgmma(
           f" of type f32, but got: {acc.value.mlir_dtype}"
       )
   elif any(
-      t.isinstance(element_type)
+      isinstance(element_type, t)
       for t in {ir.F16Type, ir.Float8E5M2Type, ir.Float8E4M3FNType}
   ):
     if acc.value.mlir_dtype != f16 and acc.value.mlir_dtype != f32:

--- a/tests/ffi_test.py
+++ b/tests/ffi_test.py
@@ -109,7 +109,7 @@ class FfiTest(jtu.JaxTestCase):
     with mlir.make_ir_context(), mlir.ir.Location.unknown():
       expected = expected_builder(param)
     self.assertEqual(type(config["param"]), type(expected))
-    self.assertTrue(expected.type.isinstance(config["param"].type))
+    self.assertEqual(str(config["param"].type), str(expected.type))
 
   def test_token(self):
     def fun():

--- a/tests/mosaic/gpu_dialect_test.py
+++ b/tests/mosaic/gpu_dialect_test.py
@@ -878,7 +878,7 @@ class DialectLoweringTest(MosaicGpuTest):
     self.assertLen(all_stores, 2)
 
     def check_type(ty: ir.Type):
-      self.assertTrue(ir.VectorType.get((4,), elt_ty).isinstance(ty))
+      self.assertTrue(isinstance(ty, ir.VectorType.get((4,), elt_ty)))
 
     load1, load2, *_ = all_loads  # Variadic unpacking to silence linter.
     check_type(load1.result.type)
@@ -970,7 +970,7 @@ class DialectLoweringTest(MosaicGpuTest):
       scalar_out_ty = mgpu_utils.dtype_to_ir_type(out_dtype)
       in_ty = ir.VectorType.get(shape, scalar_in_ty)
       out_ty = ir.VectorType.get(shape, scalar_out_ty)
-      if ir.IntegerType.isinstance(scalar_in_ty):
+      if isinstance(scalar_in_ty, ir.IntegerType):
         zero = ir.IntegerAttr.get(scalar_in_ty, 0)
       else:
         zero = ir.FloatAttr.get(scalar_in_ty, 0)


### PR DESCRIPTION
`isinstance` should "just work" as long as the dialect is registered and the corresponding type has a `GetTypeID` function, which the types from the standard dialects do.