### PR TITLE
[tree_util] raise more informative error when pytree equality check fails

### DIFF
--- a/jaxlib/pytree.cc
+++ b/jaxlib/pytree.cc
@@ -281,8 +281,16 @@ bool PyTreeDef::operator==(const PyTreeDef& other) const {
         a.custom != b.custom) {
       return false;
     }
-    if (a.node_data && a.node_data.not_equal(b.node_data)) {
-      return false;
+    try {
+      if (a.node_data && a.node_data.not_equal(b.node_data)) {
+        return false;
+      }
+    } catch (nb::python_error& e) {
+      nb::raise_from(e, PyExc_ValueError,
+                     "Exception raised while checking equality of metadata "
+                     "fields of pytree. Make sure that metadata fields are "
+                     "hashable and have simple equality semantics. (Note: "
+                     "arrays cannot be passed as metadata fields!)");
     }
     if (!IsSortedPyDictKeysEqual(a.sorted_dict_keys, b.sorted_dict_keys)) {
       return false;

--- a/jaxlib/xla_client.py
+++ b/jaxlib/xla_client.py
@@ -43,7 +43,7 @@ ifrt_programs = _xla.ifrt_programs
 
 # Just an internal arbitrary increasing number to help with backward-compatible
 # changes. In JAX, reference this via jax._src.lib.jaxlib_extension_version.
-_version = 345
+_version = 346
 
 # An internal increasing version number for protecting jaxlib code against
 # ifrt changes.


### PR DESCRIPTION
Addresses #28659

Before:
```python
In [1]: import jax
   ...: import dataclasses
   ...: import numpy as np
   ...: 
   ...: @jax.tree_util.register_dataclass
   ...: @dataclasses.dataclass
   ...: class Tree:
   ...:     x : np.ndarray = dataclasses.field(metadata={'static': True})
   ...: 
   ...: f = jax.jit(lambda x: x)
   ...: f(Tree(np.arange(4)))
   ...: f(Tree(np.arange(4)))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[1], line 12
     10 f = jax.jit(lambda x: x)
     11 f(Tree(np.arange(4)))
---> 12 f(Tree(np.arange(4)))

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```
After (requires jaxlib built from source):
```python
In [1]: import jax
   ...: import dataclasses
   ...: import numpy as np
   ...: 
   ...: @jax.tree_util.register_dataclass
   ...: @dataclasses.dataclass
   ...: class Tree:
   ...:     x : np.ndarray = dataclasses.field(metadata={'static': True})
   ...: 
   ...: f = jax.jit(lambda x: x)
   ...: f(Tree(np.arange(4)))
   ...: f(Tree(np.arange(4)))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[1], line 12
     10 f = jax.jit(lambda x: x)
     11 f(Tree(np.arange(4)))
---> 12 f(Tree(np.arange(4)))

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

The above exception was the direct cause of the following exception:

Traceback (most recent call last)
Cell In[1] line 12
     10 f = jax.jit(lambda x: x)
     11 f(Tree(np.arange(4)))
---> 12 f(Tree(np.arange(4)))

ValueError: Exception raised while checking equality of metadata fields of pytree. Make sure that metadata fields are hashable and have simple equality semantics. (Note: arrays cannot be passed as metadata fields!)
```