### PR TITLE
[CI] Lock down more permissions and update default usage for some workflows

### DIFF
--- a/.github/workflows/bazel_cpu_py_import_rbe.yml
+++ b/.github/workflows/bazel_cpu_py_import_rbe.yml
@@ -16,22 +16,18 @@ on:
       runner:
         description: "Which runner should the workflow run on?"
         type: string
-        required: true
         default: "linux-x86-n2-16"
       python:
         description: "Which python version to test?"
         type: string
-        required: true
         default: "3.12"
       enable-x64:
         description: "Should x64 mode be enabled?"
         type: string
-        required: true
         default: "0"
       halt-for-connection:
         description: 'Should this workflow run wait for a remote connection?'
         type: string
-        required: false
         default: 'no'
 
 jobs:

--- a/.github/workflows/bazel_cuda_non_rbe.yml
+++ b/.github/workflows/bazel_cuda_non_rbe.yml
@@ -17,33 +17,28 @@ on:
       runner:
         description: "Which runner should the workflow run on?"
         type: string
-        required: true
         default: "linux-x86-n2-16"
       python:
         description: "Which python version to test?"
         type: string
-        required: true
         default: "3.12"
       enable-x64:
         description: "Should x64 mode be enabled?"
         type: string
-        required: true
         default: "0"
       jaxlib-version:
         description: "Which jaxlib version to test? (head/pypi_latest)"
         type: string
-        required: true
         default: "head"
       gcs_download_uri:
         description: "GCS location URI from where the artifacts should be downloaded"
-        required: true
         default: 'gs://general-ml-ci-transient/jax-github-actions/jax/${{ github.workflow }}/${{ github.run_number }}/${{ github.run_attempt }}'
         type: string
       halt-for-connection:
         description: 'Should this workflow run wait for a remote connection?'
         type: string
-        required: false
         default: 'no'
+permissions: {}
 jobs:
   run-tests:
     defaults:

--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -12,7 +12,6 @@ on:
       runner:
         description: "Which runner should the workflow run on?"
         type: choice
-        required: true
         default: "linux-x86-n2-16"
         options:
         - "linux-x86-n2-16"
@@ -21,7 +20,6 @@ on:
       artifact:
         description: "Which JAX artifact to build?"
         type: choice
-        required: true
         default: "jaxlib"
         options:
         - "jax"
@@ -31,7 +29,6 @@ on:
       python:
         description: "Which python version should the artifact be built for?"
         type: choice
-        required: false
         default: "3.12"
         options:
         - "3.10"
@@ -41,7 +38,6 @@ on:
       clone_main_xla:
         description: "Should latest XLA be used?"
         type: choice
-        required: false
         default: "0"
         options:
         - "1"
@@ -49,7 +45,6 @@ on:
       halt-for-connection:
         description: 'Should this workflow run wait for a remote connection?'
         type: choice
-        required: false
         default: 'no'
         options:
         - 'yes'
@@ -59,31 +54,25 @@ on:
       runner:
         description: "Which runner should the workflow run on?"
         type: string
-        required: true
         default: "linux-x86-n2-16"
       artifact:
         description: "Which JAX artifact to build?"
         type: string
-        required: true
         default: "jaxlib"
       python:
         description: "Which python version should the artifact be built for?"
         type: string
-        required: false
         default: "3.12"
       clone_main_xla:
         description: "Should latest XLA be used?"
         type: string
-        required: false
         default: "0"
       upload_artifacts_to_gcs:
         description: "Should the artifacts be uploaded to a GCS bucket?"
-        required: true
         default: true
         type: boolean
       gcs_upload_uri:
         description: "GCS location prefix to where the artifacts should be uploaded"
-        required: true
         default: 'gs://general-ml-ci-transient/jax-github-actions/jax/${{ github.workflow }}/${{ github.run_number }}/${{ github.run_attempt }}'
         type: string
     outputs:

--- a/.github/workflows/pytest_cpu.yml
+++ b/.github/workflows/pytest_cpu.yml
@@ -17,34 +17,28 @@ on:
       runner:
         description: "Which runner should the workflow run on?"
         type: string
-        required: true
         default: "linux-x86-n2-16"
       python:
         description: "Which python version should the artifact be built for?"
         type: string
-        required: true
         default: "3.12"
       enable-x64:
         description: "Should x64 mode be enabled?"
         type: string
-        required: true
         default: "0"
       download-jax-only-from-gcs:
         description: "Whether to download only the jax wheel from GCS (e.g for testing a jax only release)"
-        required: false
         default: '0'
         type: string
       gcs_download_uri:
         description: "GCS location prefix from where the artifacts should be downloaded"
-        required: true
         default: 'gs://general-ml-ci-transient/jax-github-actions/jax/${{ github.workflow }}/${{ github.run_number }}/${{ github.run_attempt }}'
         type: string
       halt-for-connection:
         description: 'Should this workflow run wait for a remote connection?'
         type: string
-        required: false
         default: 'no'
-
+permissions: {}
 jobs:
   run-tests:
     defaults:

--- a/.github/workflows/pytest_cuda.yml
+++ b/.github/workflows/pytest_cuda.yml
@@ -17,44 +17,36 @@ on:
       runner:
         description: "Which runner should the workflow run on?"
         type: string
-        required: true
         default: "linux-x86-n2-16"
       python:
         description: "Which python version to test?"
         type: string
-        required: true
         default: "3.12"
       cuda-version:
         description: "Which CUDA version to test?"
         type: string
-        required: true
         default: "12.8"
       use-nvidia-pip-wheels:
         description: "Whether to download CUDA packages from PyPI?"
         type: boolean
-        required: false
         default: false
       enable-x64:
         description: "Should x64 mode be enabled?"
         type: string
-        required: true
         default: "0"
       download-jax-only-from-gcs:
         description: "Whether to download only the jax wheel from GCS (e.g for testing a jax only release)"
-        required: false
         default: '0'
         type: string
       gcs_download_uri:
         description: "GCS location prefix from where the artifacts should be downloaded"
-        required: true
         default: 'gs://general-ml-ci-transient/jax-github-actions/jax/${{ github.workflow }}/${{ github.run_number }}/${{ github.run_attempt }}'
         type: string
       halt-for-connection:
         description: 'Should this workflow run wait for a remote connection?'
         type: string
-        required: false
         default: 'no'
-
+permissions: {}
 jobs:
   run-tests:
     defaults:

--- a/.github/workflows/pytest_tpu.yml
+++ b/.github/workflows/pytest_tpu.yml
@@ -22,32 +22,26 @@ on:
       runner:
         description: "Which runner should the workflow run on?"
         type: string
-        required: true
         default: "linux-x86-ct5lp-224-8tpu"
       cores:
         description: "How many TPU cores should the test use?"
         type: string
-        required: true
         default: "8"
       tpu-type:
         description: "Which TPU type is used for testing?"
         type: string
-        required: true
         default: "v5e-8"
       python:
         description: "Which Python version should be used for testing?"
         type: string
-        required: true
         default: "3.12"
       run-full-tpu-test-suite:
         description: "Should the full TPU test suite be run?"
         type: string
-        required: false
         default: "0"
       libtpu-version-type:
         description: "Which libtpu version should be used for testing?"
         type: string
-        required: false
         # Choices are:
         # - "nightly": Use the nightly libtpu wheel.
         # - "pypi_latest": Use the latest libtpu wheel from PyPI.
@@ -55,20 +49,17 @@ on:
         default: "nightly"
       download-jax-only-from-gcs:
         description: "Whether to download only the jax wheel from GCS (e.g for testing a jax only release)"
-        required: false
         default: '0'
         type: string
       gcs_download_uri:
         description: "GCS location prefix from where the artifacts should be downloaded"
-        required: true
         default: 'gs://general-ml-ci-transient/jax-github-actions/jax/${{ github.workflow }}/${{ github.run_number }}/${{ github.run_attempt }}'
         type: string
       halt-for-connection:
         description: 'Should this workflow run wait for a remote connection?'
         type: string
-        required: false
         default: 'no'
-
+permissions: {}
 jobs:
   run-tests:
     defaults:


### PR DESCRIPTION
Update a few files that default permissions were missed in the last PR.

Remove the "required" flag from most action inputs.  "required" is mutually exclusive with the default.  If a variable is required its default will never be used.  In all of these cases we have provided a valid default setting so we choose to remove the required flag rather than remove the default. 