### PR TITLE
Pass list rather than generator to donate_argnums

### DIFF
--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -1788,7 +1788,7 @@ def pmap(f, axis_name=None, *, in_axes=0, out_axes=0,
         p.flat_args, mesh, list(in_specs))
     jitted_f = jax.jit(
         _pmapped,
-        donate_argnums=(i for i, val in enumerate(p.donated_invars) if val))
+        donate_argnums=[i for i, val in enumerate(p.donated_invars) if val])
     return jitted_f, flat_global_args, p.out_tree, mesh, out_specs
 
   def wrapped(*args, **kwargs):


### PR DESCRIPTION
The parameter is annotated as `Sequence[int]`, so a generator expression is invalid (this error was revealed after some unrelated refactoring).