### PR TITLE
[XProf] Change tensorboard-plugin-profile to new xprof package

### DIFF
--- a/build/collect-profile-requirements.txt
+++ b/build/collect-profile-requirements.txt
@@ -1,5 +1,5 @@
 # TF hasn't released 3.13 wheels yet (b/402590302)
 tensorflow; python_version<"3.13"
-tensorboard-plugin-profile<=2.19.0
-# Needed for the profile plugin to work without error
+xprof>=2.19.0
+# Needed for XProf to work without error
 protobuf

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -8,7 +8,7 @@ We can use the JAX profiler to generate traces of a JAX program that can be
 visualized using the [Perfetto visualizer](https://ui.perfetto.dev). Currently,
 this method blocks the program until a link is clicked and the Perfetto UI loads
 the trace. If you wish to get profiling information without any interaction,
-check out the Tensorboard profiler below.
+check out the XProf profiler below.
 
 ```python
 with jax.profiler.trace("/tmp/jax-trace", create_perfetto_link=True):
@@ -64,37 +64,37 @@ Also, by default, the program will prompt you to open a link to
 file and open a visualizer. This feature is disabled by passing in
 `--no_perfetto_link` into the command. Alternatively, you can also point
 Tensorboard to the `log_dir` to analyze the trace (see the
-"Tensorboard Profiling" section below).
+"XProf (Tensorboard Profiling)" section below).
 
 (tensorboard-profiling)=
-## TensorBoard profiling
+## XProf (TensorBoard profiling)
 
-[TensorBoard's
-profiler](https://www.tensorflow.org/tensorboard/tensorboard_profiling_keras)
-can be used to profile JAX programs. Tensorboard is a great way to acquire and
+[XProf](https://www.tensorflow.org/tensorboard/tensorboard_profiling_keras)
+can be used to profile JAX programs. XProf is a great way to acquire and
 visualize performance traces and profiles of your program, including activity on
 GPU and TPU. The end result looks something like this:
 
-![TensorBoard profiler example](_static/tensorboard_profiler.png)
+![XProf example](_static/tensorboard_profiler.png)
 
 ### Installation
 
-The TensorBoard profiler is available as a plugin to TensorBoard
+XProf is available as a plugin to TensorBoard, as well as an independently
+run program.
 ```shell
-pip install tensorboard tensorboard-plugin-profile
+pip install xprof
 ```
 
-If you already have TensorBoard installed, you only need to install the
-`tensorboard-plugin-profile` pip package. Be careful to only install one version
-of TensorFlow or TensorBoard, otherwise you may encounter the "duplicate
-plugins" error described {ref}`below <multiple_installs>`. See
+If you have TensorBoard installed, the `xprof` pip package will also install
+the TensorBoard Profiler plugin. Be careful to only install one version of
+TensorFlow or TensorBoard, otherwise you may encounter the "duplicate plugins"
+error described {ref}`below <multiple_installs>`. See
 <https://www.tensorflow.org/guide/profiler> for more information on installing
 TensorBoard.
 
 Profiling with the nightly version of TensorBoard requires the nightly
-tensorboard profiler plugin
+XProf.
 ```shell
-pip install tb-nightly tbp-nightly
+pip install tb-nightly xprof-nightly
 ```
 
 ### Programmatic capture
@@ -138,29 +138,54 @@ with jax.profiler.trace("/tmp/tensorboard"):
   y.block_until_ready()
 ```
 
+### Viewing the trace
+
+After capturing a trace, you can view it using either the standalone XProf
+tool or the TensorBoard UI. The profiler interface is the same in both cases.
+
+#### Using Standalone XProf
+
+You can launch the profiler UI directly using the standalone XProf command by
+pointing it to your log directory:
+
+```
+$ xprof --port 8791 /tmp/tensorboard
+Attempting to start XProf server:
+  Log Directory: /tmp/tensorboard
+  Port: 8791
+XProf at http://localhost:8791/ (Press CTRL+C to quit)
+```
+
+Navigate to the provided URL (e.g., http://localhost:8791/) in your browser
+to view the profile.
+
+Available traces appear in the "Runs" dropdown menu on the left. Select the
+run you're interested in, and then under the "Tools" dropdown, select
+trace_viewer. You should now see a timeline of the execution. You can use the
+WASD keys to navigate the trace, and click or drag to select events for more
+details. See
+[these TensorFlow docs](https://www.tensorflow.org/tensorboard/tensorboard_profiling_keras#use_the_tensorflow_profiler_to_profile_model_training_performance)=
+for more details on using the trace viewer.
+
+#### With TensorBoard
+
 To view the trace, first start TensorBoard if you haven't already:
 
 ```shell
 $ tensorboard --logdir=/tmp/tensorboard
 [...]
 Serving TensorBoard on localhost; to expose to the network, use a proxy or pass --bind_all
-TensorBoard 2.5.0 at http://localhost:6006/ (Press CTRL+C to quit)
+TensorBoard 2.20.0 at http://localhost:6006/ (Press CTRL+C to quit)
 ```
 
-You should be able to load TensorBoard at <http://localhost:6006/> in this
-example. You can specify a different port with the `--port` flag. See
-{ref}`remote_profiling` below if running JAX on a remote server.
+You should be able to load TensorBoard at http://localhost:6006/ in this
+example. Then, select "Profile" from the dropdown menu in the upper-right,
+or navigate directly to http://localhost:6006/#profile.
 
-Then, either select "Profile" in the upper-right dropdown menu, or go directly
-to <http://localhost:6006/#profile>. Available traces appear in the "Runs"
-dropdown menu on the left. Select the run you're interested in, and then under
-"Tools", select `trace_viewer`. You should now see a timeline of the
-execution. You can use the WASD keys to navigate the trace, and click or drag to
-select events to see more details at the bottom. See [these TensorFlow
-docs](https://www.tensorflow.org/tensorboard/tensorboard_profiling_keras#use_the_tensorflow_profiler_to_profile_model_training_performance)
-for more details on using the trace viewer.
-
-You can also use the `memory_viewer`, `op_profile`, and `graph_viewer` tools.
+From there, the experience is the same as the standalone tool: available
+traces appear in the "Runs" dropdown menu on the left. Select the run
+you're interested in, and then under "Tools", select trace_viewer to see the
+timeline.
 
 ### Manual capture via TensorBoard
 
@@ -306,8 +331,8 @@ replace, so it may be necessary to uninstall everything and reinstall a single
 version:
 
 ```shell
-pip uninstall tensorflow tf-nightly tensorboard tb-nightly tensorboard-plugin-profile tbp-nightly
-pip install tensorboard tensorboard-plugin-profile
+pip uninstall tensorflow tf-nightly tensorboard tb-nightly xprof xprof-nightly tensorboard-plugin-profile tbp-nightly
+pip install tensorboard xprof
 ```
 
 ## Nsight

--- a/jax/collect_profile.py
+++ b/jax/collect_profile.py
@@ -23,15 +23,11 @@ import tempfile
 # pytype: disable=import-error
 from jax._src import profiler as jax_profiler
 try:
-  from tensorflow.python.profiler import profiler_v2 as profiler
-  from tensorflow.python.profiler import profiler_client
-except ImportError:
-  raise ImportError("This script requires `tensorflow` to be installed.")
-try:
-  from tensorboard_plugin_profile.convert import raw_to_tool_data as convert
+  from xprof.convert import _pywrap_profiler_plugin
+  from xprof.convert import raw_to_tool_data as convert
 except ImportError:
   raise ImportError(
-      "This script requires `tensorboard_plugin_profile` to be installed.")
+      "This script requires `xprof` to be installed.")
 # pytype: enable=import-error
 
 
@@ -69,13 +65,13 @@ def collect_profile(port: int, duration_in_ms: int, host: str,
                     log_dir: os.PathLike | str | None, host_tracer_level: int,
                     device_tracer_level: int, python_tracer_level: int,
                     no_perfetto_link: bool):
-  options = profiler.ProfilerOptions(
-      host_tracer_level=host_tracer_level,
-      device_tracer_level=device_tracer_level,
-      python_tracer_level=python_tracer_level,
-  )
+  options = {
+      "host_tracer_level": host_tracer_level,
+      "device_tracer_level": device_tracer_level,
+      "python_tracer_level": python_tracer_level,
+  }
   log_dir_ = pathlib.Path(log_dir if log_dir is not None else tempfile.mkdtemp())
-  profiler_client.trace(
+  _pywrap_profiler_plugin.trace(
       f"{host}:{port}",
       str(log_dir_),
       duration_in_ms,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ module = [
     "rich.*",
     "scipy.*",
     "setuptools.*",
-    "tensorboard_plugin_profile.convert.*",
+    "xprof.convert.*",
     "tensorflow.*",
     "tensorflow.io.*",
     "tensorflowjs.*",

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,11 @@ setup(
         'k8s': [
           'kubernetes',
         ],
+
+        # For including XProf server
+        'xprof': [
+          'xprof',
+        ],
     },
     url='https://github.com/jax-ml/jax',
     license='Apache-2.0',

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -44,11 +44,11 @@ except ImportError:
   profiler_client = None
   tf_profiler = None
 
-TBP_ENABLED = False
+XPROF_ENABLED = False
 try:
-  import tensorboard_plugin_profile
-  del tensorboard_plugin_profile
-  TBP_ENABLED = True
+  import xprof
+  del xprof
+  XPROF_ENABLED = True
 except ImportError:
   pass
 
@@ -296,7 +296,7 @@ class ProfilerTest(unittest.TestCase):
     self._check_xspace_pb_exist(logdir)
 
   @unittest.skipIf(
-      not (portpicker and profiler_client and tf_profiler and TBP_ENABLED),
+      not (portpicker and profiler_client and tf_profiler and XPROF_ENABLED),
     "Test requires tensorflow.profiler, portpicker and "
     "tensorboard_profile_plugin")
   def test_remote_profiler(self):


### PR DESCRIPTION
BACKGROUND: The tensorboard-plugin-profile package is being renamed to xprof. Behind the scenes, the `xprof` pypi package currently installs `tensorboard-plugin-profile` and exports all of it's files https://github.com/openxla/xprof/blob/master/xprof_pypi_package/xprof/__init__.py.  In an upcoming PR, this functionality is being swapped, where `xprof` will be the primary package, and `tensorboard-plugin-profile` will be the mirror (https://github.com/openxla/xprof/pull/1485).
XProf remains compatible with Tensorboard.


This PR replaces references to Tensorboard Profiler with xprof, as well as adds xprof as an optional dependency.