### PR TITLE
Simplify `jnp.isclose`

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2602,31 +2602,13 @@ def isclose(a: ArrayLike, b: ArrayLike, rtol: ArrayLike = 1e-05, atol: ArrayLike
     dtype = np.array(0, dtype).real.dtype
   rtol = lax.convert_element_type(rtol, dtype)
   atol = lax.convert_element_type(atol, dtype)
-  out = lax.le(
+  both_nan = ufuncs.logical_and(ufuncs.isnan(a), ufuncs.isnan(b))
+  check_fin = ufuncs.isfinite(b)
+  in_range = lax.le(
     lax.abs(lax.sub(a, b)),
     lax.add(atol, lax.mul(rtol, lax.abs(b))))
-  # This corrects the comparisons for infinite and nan values
-  a_inf = ufuncs.isinf(a)
-  b_inf = ufuncs.isinf(b)
-  any_inf = ufuncs.logical_or(a_inf, b_inf)
-  both_inf = ufuncs.logical_and(a_inf, b_inf)
-  # Make all elements where either a or b are infinite to False
-  out = ufuncs.logical_and(out, ufuncs.logical_not(any_inf))
-  # Make all elements where both a or b are the same inf to True
-  same_value = lax.eq(a, b)
-  same_inf = ufuncs.logical_and(both_inf, same_value)
-  out = ufuncs.logical_or(out, same_inf)
-
-  # Make all elements where either a or b is NaN to False
-  a_nan = ufuncs.isnan(a)
-  b_nan = ufuncs.isnan(b)
-  any_nan = ufuncs.logical_or(a_nan, b_nan)
-  out = ufuncs.logical_and(out, ufuncs.logical_not(any_nan))
-  if equal_nan:
-    # Make all elements where both a and b is NaN to True
-    both_nan = ufuncs.logical_and(a_nan, b_nan)
-    out = ufuncs.logical_or(out, both_nan)
-  return out
+  out = ufuncs.logical_or(lax.eq(a, b), ufuncs.logical_and(check_fin, in_range))
+  return ufuncs.logical_or(out, both_nan) if equal_nan else out
 
 
 def _interp(x: ArrayLike, xp: ArrayLike, fp: ArrayLike,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3964,6 +3964,22 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertTrue(jnp.isclose(key, key))
 
   @jtu.sample_product(
+    atol=[0.0, 1E-4, np.inf],
+    rtol=[0.0, 1E-4, np.inf],
+    equal_nan=[True, False]
+  )
+  def testIsCloseCornerCases(self, atol, rtol, equal_nan):
+    if jtu.numpy_version() < (2, 0, 0) and (np.isinf(atol) or np.isinf(rtol)):
+      self.skipTest("fails on older NumPy")
+    vals = np.array([-np.nan, -np.inf, -1.00001, -1.0, -0.00001, -0.0,
+                     0.0, 0.00001, 1.0, 1.00001, np.inf, np.nan])
+    x, y = np.meshgrid(vals, vals)
+    self.assertArraysEqual(
+      np.isclose(x, y, atol=atol, rtol=rtol, equal_nan=equal_nan),
+      jnp.isclose(x, y, atol=atol, rtol=rtol, equal_nan=equal_nan)
+    )
+
+  @jtu.sample_product(
     x=[1, [1], [1, 1 + 1E-4], [1, np.nan]],
     y=[1, [1], [1, 1 + 1E-4], [1, np.nan]],
     equal_nan=[True, False],


### PR DESCRIPTION
Reattempt #22478.

This could even be considered a bug fix:

```python
# HEAD
jnp.isclose(0, 0, rtol=np.inf, atol=0.1)  # False
np.isclose(0, 0, rtol=np.inf, atol=0.1)   # True
```

<details>
<summary>Proof of equivalence in Z3</summary>

```python
import numpy as np
import z3

def fpIsFinite(x):
  return ~(z3.fpIsInf(x) | z3.fpIsNaN(x))

def isclose_new(a, b, rtol, atol, equal_nan):
  both_nan = z3.fpIsNaN(a) & z3.fpIsNaN(b)
  check_fin = fpIsFinite(b)
  in_range = z3.fpAbs(a - b) <= atol + rtol * z3.fpAbs(b)
  out = z3.fpEQ(a, b) | (check_fin & in_range)
  return z3.If(equal_nan, out | both_nan, out)

def isclose_old(a, b, rtol, atol, equal_nan):
  out = z3.fpAbs(a - b) <= atol + rtol * z3.fpAbs(b)
  a_inf = z3.fpIsInf(a)
  b_inf = z3.fpIsInf(b)
  any_inf = a_inf | b_inf
  both_inf = a_inf & b_inf
  out = out & ~any_inf
  same_value = z3.fpEQ(a, b)
  same_inf = both_inf & same_value
  out = out | same_inf

  a_nan = z3.fpIsNaN(a)
  b_nan = z3.fpIsNaN(b)
  any_nan = a_nan | b_nan
  out = out & ~any_nan
  return z3.If(equal_nan, out | a_nan & b_nan, out)

fp_sort = z3.Float32()
# fp_sort = z3.Float64()

a, b = z3.FPs("a b", fp_sort)
rtol, atol = z3.FPs("rtol atol", fp_sort)
equal_nan = z3.Bool("equal_nan")

new = isclose_new(a, b, rtol, atol, equal_nan)
old = isclose_old(a, b, rtol, atol, equal_nan)

s = z3.Solver()
s.add(rtol >= 0, fpIsFinite(rtol))
s.add(atol >= 0, fpIsFinite(atol))
# s.add(rtol >= 0, atol >= 0)  # this shows the discrepancy with NumPy

s.add(new != old)
if s.check() == z3.unsat:
  print("No counterexample found.")
else:
  print(model := s.model())
```

</details>