### PR TITLE
Fixed TSAN CI NumPy build step

### DIFF
--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -120,7 +120,6 @@ jobs:
       - name: Build TSAN Numpy wheel
         if: steps.cache-numpy-tsan-restore.outputs.cache-hit != 'true'
         run: |
-          set -eux
           cd numpy
 
           # If we restored cpython from cache, we need to get python interpreter from python-tsan.tgz
@@ -138,7 +137,9 @@ jobs:
           python3 -m pip install uv~=0.5.30
           python3 -m uv pip install -r requirements/build_requirements.txt
 
-          CC=clang-18 CXX=clang++-18 python3 -m pip wheel --wheel-dir dist -v . --no-build-isolation -Csetup-args=-Db_sanitize=thread -Csetup-args=-Dbuildtype=debugoptimized
+          # Run build process in background and show a spinner to avoid crash on the runner:
+          CC=clang-18 CXX=clang++-18 python3 -m pip wheel --wheel-dir dist -v . --no-build-isolation -Csetup-args=-Db_sanitize=thread -Csetup-args=-Dbuildtype=debugoptimized &
+          pid=$! && s='-\|/'; i=0; while kill -0 $pid; do i=$(( (i+1) %4 )); printf "\r${s:$i:1}"; sleep 1; done
 
           # Create simple index and copy the wheel
           mkdir -p ${GITHUB_WORKSPACE}/wheelhouse/numpy
@@ -209,9 +210,9 @@ jobs:
 
           python3 -m uv pip list | grep -E "(numpy|pythran|cython|pybind11)"
 
-          export CC=clang-18
-          export CXX=clang++-18
-          python3 -m pip wheel --wheel-dir dist -vvv . --no-build-isolation --no-deps -Csetup-args=-Dbuildtype=debugoptimized
+          # Run build process in background and show a spinner to avoid crash on the runner:
+          CC=clang-18 CXX=clang++-18 python3 -m pip wheel --wheel-dir dist -vvv . --no-build-isolation --no-deps -Csetup-args=-Dbuildtype=debugoptimized &
+          pid=$! && s='-\|/'; i=0; while kill -0 $pid; do i=$(( (i+1) %4 )); printf "\r${s:$i:1}"; sleep 1; done
 
           # Create simple index and copy the wheel
           mkdir -p ${GITHUB_WORKSPACE}/wheelhouse/scipy


### PR DESCRIPTION
## Description:

I tested TSAN CI with various runners:
- [linux-arm64-c4a-64](https://github.com/jax-ml/jax/pull/29160/commits/3c02d2cf3cacbddfb1c1b28644189a4b9e54f6ec)
- [linux-x86-c4-96](https://github.com/jax-ml/jax/pull/29160/commits/c2e9b802aaf4712e41d9799bd4aed1f40c66f8db)


### Arm64 runner

Numpy was succesfully built in both options: 3.13-ft and 3.14-ft
Scipy was succesfully built in 3.14-ft option

The CI runs were still failing due other reasons:
- 3.13-ft could not install Pillow as it tried to build to from source and libjpeg is missing. This can fixed by installing it with apt-get.
- 3.14-ft failed when tried to build jaxlib: https://github.com/jax-ml/jax/actions/runs/15387660837/job/43289707878?pr=29160#step:18:403 with
```
ERROR: /__w/.cache/bazel/bazel/_bazel_root/a40625930fdef4f0a3483cd60aa1bb86/external/compute_library/BUILD.bazel:254:11: Compiling src/cpu/kernels/elementwise_binary/generic/sve2/qasymm8.cpp failed: (Exit 1): clang failed: error executing CppCompile command (from target @@compute_library//:arm_compute_sve2) 
  (cd /__w/.cache/bazel/bazel/_bazel_root/a40625930fdef4f0a3483cd60aa1bb86/execroot/__main__ && \
  exec env - \
    CLANG_COMPILER_PATH=/usr/bin/clang-18 \
    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
    *** \
...
# Configuration: 3288e24cc63142d45fe3b56e642c34265269cdfa1aa1c3b7a0634632cad7e03f
# Execution platform: @@local_execution_config_platform//:platform
fatal error: error in backend: Invalid size request on a scalable vector.
```

### c4-96 runner 

one of 3.13, 3.14 jobs had a similar issue as n2-64. 

## This PR

I tried to add a spinner to send chars like `\|/-` to stdout while building numpy and scipy.
Finally, seems like the build is going under the hood but somehow is not directly flushed to the stdout (and something was terminating it after 5 minutes of no output).

Now, coming back to the old n2-64 runners I can build numpy wheel (but with a spinner)
https://github.com/jax-ml/jax/actions/runs/15414182334?pr=29160

