### PR TITLE
Update partial eval to avoid DCEing a specific set of effects

### DIFF
--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -69,6 +69,8 @@ effects.remat_allowed_effects.add_type(DebugEffect)
 effects.remat_allowed_effects.add_type(OrderedDebugEffect)
 effects.custom_derivatives_allowed_effects.add_type(DebugEffect)
 effects.custom_derivatives_allowed_effects.add_type(OrderedDebugEffect)
+effects.partial_eval_kept_effects.add_type(DebugEffect)
+effects.partial_eval_kept_effects.add_type(OrderedDebugEffect)
 
 # `debug_callback_p` is the main primitive for staging out Python callbacks.
 debug_callback_p = core.Primitive('debug_callback')
@@ -126,10 +128,10 @@ def debug_callback_jvp_rule(primals, tangents, **params):
   return debug_callback_p.bind(*primals, **params), []
 ad.primitive_jvps[debug_callback_p] = debug_callback_jvp_rule
 
-def debug_callback_transpose_rule(*flat_args, callback: Callable[..., Any],
+def debug_callback_transpose_rule(_, *flat_args, callback: Callable[..., Any],
                                   effect: DebugEffect, partitioned):
-  del flat_args, callback, effect
-  raise ValueError("Transpose doesn't support debugging callbacks.")
+  del callback, effect, partitioned
+  return [None for _ in flat_args]
 ad.primitive_transposes[debug_callback_p] = debug_callback_transpose_rule
 
 def _debug_callback_partial_auto(axis_context, *args, **params):

--- a/jax/_src/effects.py
+++ b/jax/_src/effects.py
@@ -118,3 +118,5 @@ lowerable_effects: EffectTypeSet = EffectTypeSet()
 control_flow_allowed_effects: EffectTypeSet = EffectTypeSet()
 custom_derivatives_allowed_effects: EffectTypeSet = EffectTypeSet()
 remat_allowed_effects: EffectTypeSet = EffectTypeSet()
+
+partial_eval_kept_effects: EffectTypeSet = EffectTypeSet()

--- a/jax/_src/state/types.py
+++ b/jax/_src/state/types.py
@@ -75,6 +75,7 @@ class AccumEffect(RefEffect):
   name: str = "Accum"
 
 effects.control_flow_allowed_effects.add_type(RefEffect)
+effects.partial_eval_kept_effects.add_type(RefEffect)
 
 StateEffect = Union[ReadEffect, WriteEffect, AccumEffect]
 

--- a/tests/debugging_primitives_test.py
+++ b/tests/debugging_primitives_test.py
@@ -442,8 +442,6 @@ class DebugPrintTransformationTest(jtu.JaxTestCase):
     with jtu.capture_stdout() as output:
       jax.linear_transpose(f, 1.)(1.)
       jax.effects_barrier()
-    # `debug_print` should be dropped by `partial_eval` because of no
-    # output data-dependence.
     self.assertEqual(output(), "")
 
   @jtu.sample_product(ordered=[False, True])

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -28,7 +28,6 @@ import numpy as np
 
 import jax
 from jax._src import core
-from jax._src import config
 from jax import dtypes
 from jax import lax
 from jax import random
@@ -3359,8 +3358,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       return c + 1, None
     def g(x):
       return jax.lax.scan(f, x, length=2)[0]
-    with config.use_direct_linearize(True):
-      jaxpr = jax.make_jaxpr(jax.value_and_grad(g))(1.0)
+    jaxpr = jax.make_jaxpr(jax.value_and_grad(g))(1.0)
     eqn_jaxpr = jaxpr.eqns[0].params["jaxpr"]
     self.assertIn("debug_callback", [e.primitive.name for e in eqn_jaxpr.eqns])
 


### PR DESCRIPTION
... instead of just `RefEffect`s. This is a follow up to https://github.com/jax-ml/jax/pull/28955 where the partial eval logic was updated to unconditionally keep equations with `RefEffect`s to improve support for mutable arrays. It turns out that it's worth using the same logic for debugging effects, which similarly get DCE'ed when only data flow is considered. This fixes https://github.com/jax-ml/jax/issues/28738 and https://github.com/jax-ml/jax/issues/16637 without relying on `use_direct_linearize`.