### PR TITLE
Bump the minimum NumPy and SciPy versions.

### DIFF
--- a/.github/workflows/oldest_supported_numpy.yml
+++ b/.github/workflows/oldest_supported_numpy.yml
@@ -42,7 +42,7 @@ jobs:
           $JAXCI_PYTHON -m uv pip install -r build/test-requirements.txt
 
           # Install NumPy and SciPy with the oldest supported versions
-          $JAXCI_PYTHON -m uv pip install numpy==1.25.2 scipy==1.11.1
+          $JAXCI_PYTHON -m uv pip install numpy==1.26.4 scipy==1.12.0
 
           # Install JAX using the changes in the PR
           $JAXCI_PYTHON -m uv pip install -e .[minimum-jaxlib]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 * New features:
   * Added {func}`jax.tree.broadcast` which implements a pytree prefix broadcasting helper.
 
+* Changes
+  * The minimum NumPy version is 1.26 and the minimum SciPy version is 1.12.
+
 ## JAX 0.6.1 (May 21, 2025)
 
 * New features:

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -642,12 +642,7 @@ def use_cpp_method(is_enabled: bool = True) -> Callable[[T], T]:
   return decorator
 
 
-try:
-  # numpy 1.25.0 or newer
-  NumpyComplexWarning: type[Warning] = np.exceptions.ComplexWarning
-except AttributeError:
-  # legacy numpy
-  NumpyComplexWarning = np.ComplexWarning
+NumpyComplexWarning: type[Warning] = np.exceptions.ComplexWarning
 
 
 class StrictABCMeta(abc.ABCMeta):

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -61,9 +61,9 @@ setup(
     packages=['jaxlib'],
     python_requires='>=3.10',
     install_requires=[
-        'scipy>=1.11.1',
-        'numpy>=1.25',
-        'ml_dtypes>=0.2.0',
+        'scipy>=1.12',
+        'numpy>=1.26',
+        'ml_dtypes>=0.5.0',
     ],
     url='https://github.com/jax-ml/jax',
     license='Apache-2.0',

--- a/setup.py
+++ b/setup.py
@@ -63,10 +63,9 @@ setup(
     install_requires=[
         f'jaxlib >={_minimum_jaxlib_version}, <={_jax_version}',
         'ml_dtypes>=0.5.0',
-        'numpy>=1.25',
-        "numpy>=1.26.0; python_version>='3.12'",
+        'numpy>=1.26',
         'opt_einsum',
-        'scipy>=1.11.1',
+        'scipy>=1.12',
     ],
     extras_require={
         # Minimum jaxlib version; used in testing.

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1938,9 +1938,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     rng = jtu.rand_default(self.rng())
     mask_size = np.zeros(shape).size if axis is None else np.zeros(shape).shape[axis]
     mask = jtu.rand_int(self.rng(), low=0, high=2)(mask_size, bool)
-    if numpy_version == (1, 23, 0) and mask.shape == (1,):
-      # https://github.com/numpy/numpy/issues/21840
-      self.skipTest("test fails for numpy v1.23.0")
     args_maker = lambda: [rng(shape, dtype)]
     np_fun = lambda arg: np.delete(arg, mask, axis=axis)
     jnp_fun = lambda arg: jnp.delete(arg, mask, axis=axis)

--- a/tests/scipy_spatial_test.py
+++ b/tests/scipy_spatial_test.py
@@ -123,8 +123,6 @@ class LaxBackedScipySpatialTransformTests(jtu.JaxTestCase):
     shape=[(4,), (num_samples, 4)],
   )
   def testRotationAsQuatCanonical(self, shape, dtype):
-    if scipy_version < (1, 11, 0):
-      self.skipTest("Scipy 1.11.0 added the `canonical` arg.")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: (rng(shape, dtype),)
     jnp_fn = lambda q: jsp_Rotation.from_quat(q).as_quat(canonical=True)
@@ -152,8 +150,6 @@ class LaxBackedScipySpatialTransformTests(jtu.JaxTestCase):
     other_shape=[(num_samples, 4)],
   )
   def testRotationConcatenate(self, shape, other_shape, dtype):
-    if scipy_version < (1, 8, 0):
-      self.skipTest("Scipy 1.8.0 needed for concatenate.")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: (rng(shape, dtype), rng(other_shape, dtype),)
     jnp_fn = lambda q, o: jsp_Rotation.concatenate([jsp_Rotation.from_quat(q), jsp_Rotation.from_quat(o)]).as_rotvec()
@@ -297,8 +293,6 @@ class LaxBackedScipySpatialTransformTests(jtu.JaxTestCase):
     shape=[(4,), (num_samples, 4)],
   )
   def testRotationInvConjugate(self, shape, dtype):
-    if scipy_version < (1, 11, 0):
-      self.skipTest("Scipy prior to 1.11.0 used a negative conjugate.")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: (rng(shape, dtype),)
     jnp_fn = lambda q: jsp_Rotation.from_quat(q).inv().as_quat()


### PR DESCRIPTION
Per Spec 0, we can drop NumPy 1.25 and SciPy 1.11 in June 2025.