### PR TITLE
always compile Pallas calls, enabling `pallas_call` under `disable_jit`

### DIFF
--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -77,16 +77,12 @@ pallas_call_p.multiple_results = True
 
 def _pallas_call_impl(*args, **params):
   # Call the lowering path
-  if config.disable_jit.value:
-    raise NotImplementedError(
-        "pallas_call not supported with disable_jit. Consider invoking under a"
-        " local context of `jax.disable_jit(False)`."
-    )
-
   @partial(jax.jit, inline=True)
   def _jit_run(*args):
     return pallas_call_p.bind(*args, **params)
-  return _jit_run(*args)
+
+  with config.disable_jit(False):
+    return _jit_run(*args)
 
 pallas_call_p.def_impl(_pallas_call_impl)
 


### PR DESCRIPTION
How should `pallas_call` behave under `disable_jit`? We could:

a) Error because we don't know what's expected.
b) Run `pallas_call` as we would in eager mode.
c) Run `pallas_call` in interpret mode.

Today we do (a). This change implements (b) instead, where by "eager mode" we mean the behavior under no `jit` (and no `disable_jit` under it). Choice (c) seems to take things too far. On the one hand, it would execute the Pallas kernel "op-by-op," which may seem desirable. On the other hand, it would execute each individual such op on the host (CPU) rather than the device. If we could do the first "half" of (c) alone somehow—executing op-by-op, dispatching each op on the device, that may be ideal. Until then, (b) seems closer to expectations.

To implement (b), this change simply re-enables jit only for the duration of the pallas call.