### PR TITLE
Add a pretty printing rule for custom_lin_p.

### DIFF
--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -1243,6 +1243,14 @@ def _custom_lin_transpose(cts_out, *invals, num_res,
   return [None] * num_res + nz_cts_in
 primitive_transposes[custom_lin_p] = _custom_lin_transpose
 
+def _custom_lin_pp_rule(eqn: core.JaxprEqn, context: core.JaxprPpContext,
+                        settings: core.JaxprPpSettings) -> core.pp.Doc:
+  params = dict(eqn.params)
+  params.pop("out_avals")
+  params["bwd"] = params.pop("bwd").debug_info.func_name
+  return core._pp_eqn(eqn.replace(params=params), context, settings)
+core.pp_eqn_rules[custom_lin_p] = _custom_lin_pp_rule
+
 
 class CustomJVPException(Exception):
   def __init__(self):


### PR DESCRIPTION
Like https://github.com/jax-ml/jax/pull/28608 and https://github.com/jax-ml/jax/pull/28715

This comes up when debugging `custom_vjp`.

Before:

```
{ lambda ; a:f32[1]. let
    b:f32[1] = custom_lin[
      bwd=Wrapped function:
0   : _flatten_bwd   <unnamed function>
1   : _get_result_paths_thunk   <unnamed function>
Core: f_bwd

      in_zeros=[False]
      num_res=0
      out_avals=[ShapedArray(float32[1])]
      symbolic_zeros=False
    ] a
  in (b,) }
```

After:

```
{ lambda ; a:f32[1]. let
    b:f32[1] = custom_lin[
      bwd=f_bwd
      in_zeros=[False]
      num_res=0
      symbolic_zeros=False
    ] a
  in (b,) }
```