### PR TITLE
[imports] avoid top-level imports in jax.numpy sources

### DIFF
--- a/jax/_src/lax/fft.py
+++ b/jax/_src/lax/fft.py
@@ -21,8 +21,6 @@ import math
 
 import numpy as np
 
-from jax import lax
-
 from jax._src import dispatch
 from jax._src import dtypes
 from jax._src.api import jit, linear_transpose, ShapeDtypeStruct
@@ -30,6 +28,7 @@ from jax._src.core import Primitive, is_constant_shape
 from jax._src.interpreters import ad
 from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
+from jax._src.lax import lax
 from jax._src.lib.mlir.dialects import hlo
 
 __all__ = [

--- a/jax/_src/numpy/array_api_metadata.py
+++ b/jax/_src/numpy/array_api_metadata.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 from types import ModuleType
 
-import jax
 from jax._src.sharding import Sharding
 from jax._src.lib import xla_client as xc
 from jax._src import config
@@ -40,6 +39,7 @@ def __array_namespace__(self, *, api_version: None | str = None) -> ModuleType:
   if api_version is not None and api_version != __array_api_version__:
     raise ValueError(f"{api_version=!r} is not available; "
                      f"available versions are: {[__array_api_version__]}")
+  import jax.numpy  # pytype: disable=import-error
   return jax.numpy
 
 
@@ -77,7 +77,7 @@ class ArrayNamespaceInfo:
   def devices(self):
     out = [None]  # None indicates "uncommitted"
     for backend in xb.backends():
-        out.extend(jax.devices(backend))
+        out.extend(xb.devices(backend))
     return out
 
   def capabilities(self):

--- a/jax/_src/numpy/array_methods.py
+++ b/jax/_src/numpy/array_methods.py
@@ -29,9 +29,8 @@ import math
 from typing import Any, Callable, Sequence
 
 import numpy as np
-import jax
+
 from jax import lax
-from jax.sharding import Sharding
 from jax._src import api
 from jax._src import core
 from jax._src import dtypes
@@ -44,6 +43,7 @@ from jax._src.numpy import indexing
 from jax._src.numpy import lax_numpy
 from jax._src.numpy import tensor_contractions
 from jax._src.pjit import PartitionSpec
+from jax._src.sharding import Sharding
 from jax._src.sharding_impls import canonicalize_sharding, NamedSharding
 from jax._src.numpy import reductions
 from jax._src.numpy import ufuncs
@@ -612,12 +612,13 @@ _HANDLED_ARRAY_TYPES = _JAX_ARRAY_TYPES + (np.ndarray,)
 
 def __array_module__(self, types):
   if all(issubclass(t, _HANDLED_ARRAY_TYPES) for t in types):
+    import jax.numpy  # pytype: disable=import-error
     return jax.numpy
   else:
     return NotImplemented
 
 
-@partial(jax.jit, static_argnums=(1,2,3))
+@partial(api.jit, static_argnums=(1,2,3))
 def _multi_slice(self: Array,
                  start_indices: tuple[tuple[int, ...]],
                  limit_indices: tuple[tuple[int, ...]],
@@ -637,7 +638,7 @@ def _multi_slice(self: Array,
 
 # The next two functions are related to iter(array), implemented here to
 # avoid circular imports.
-@jax.jit
+@api.jit
 def _unstack(x: Array) -> list[Array]:
   dims = (0,)
   return [lax.squeeze(t, dims) for t in lax.split(x, (1,) * x.shape[0])]
@@ -776,7 +777,7 @@ class _IndexUpdateRef:
     return f"_IndexUpdateRef({self.array!r}, {self.index!r})"
 
   def get(self, *, indices_are_sorted: bool = False, unique_indices: bool = False,
-          mode: str | jax.lax.GatherScatterMode | None = None,
+          mode: str | lax.GatherScatterMode | None = None,
           fill_value: ArrayLike | None = None, out_sharding: Sharding | None = None):
     """Equivalent to ``x[idx]``.
 
@@ -798,7 +799,7 @@ class _IndexUpdateRef:
 
   def set(self, values: ArrayLike, *, indices_are_sorted: bool = False,
           unique_indices: bool = False,
-          mode: str | jax.lax.GatherScatterMode | None = None) -> None:
+          mode: str | lax.GatherScatterMode | None = None) -> None:
     """Pure equivalent of ``x[idx] = y``.
 
     Returns the value of ``x`` that would result from the NumPy-style
@@ -816,7 +817,7 @@ class _IndexUpdateRef:
 
   def apply(self, func: Callable[[ArrayLike], Array], *,
             indices_are_sorted: bool = False, unique_indices: bool = False,
-            mode: str | jax.lax.GatherScatterMode | None = None) -> Array:
+            mode: str | lax.GatherScatterMode | None = None) -> Array:
     """Pure equivalent of ``func.at(x, idx)`` for a unary ufunc ``func``.
 
     Returns the value of ``x`` that would result from applying the unary
@@ -840,7 +841,7 @@ class _IndexUpdateRef:
 
   def add(self, values: ArrayLike, *,
           indices_are_sorted: bool = False, unique_indices: bool = False,
-          mode: str | jax.lax.GatherScatterMode | None = None) -> Array:
+          mode: str | lax.GatherScatterMode | None = None) -> Array:
     """Pure equivalent of ``x[idx] += y``.
 
     Returns the value of ``x`` that would result from the NumPy-style
@@ -855,7 +856,7 @@ class _IndexUpdateRef:
 
   def subtract(self, values: ArrayLike, *,
                indices_are_sorted: bool = False, unique_indices: bool = False,
-               mode: str | jax.lax.GatherScatterMode | None = None) -> Array:
+               mode: str | lax.GatherScatterMode | None = None) -> Array:
     """Pure equivalent of ``x[idx] -= y``.
 
     Returns the value of ``x`` that would result from the NumPy-style
@@ -870,7 +871,7 @@ class _IndexUpdateRef:
 
   def multiply(self, values: ArrayLike, *,
                indices_are_sorted: bool = False, unique_indices: bool = False,
-               mode: str | jax.lax.GatherScatterMode | None = None) -> Array:
+               mode: str | lax.GatherScatterMode | None = None) -> Array:
     """Pure equivalent of ``x[idx] *= y``.
 
     Returns the value of ``x`` that would result from the NumPy-style
@@ -887,7 +888,7 @@ class _IndexUpdateRef:
 
   def divide(self, values: ArrayLike, *,
              indices_are_sorted: bool = False, unique_indices: bool = False,
-             mode: str | jax.lax.GatherScatterMode | None = None) -> Array:
+             mode: str | lax.GatherScatterMode | None = None) -> Array:
     """Pure equivalent of ``x[idx] /= y``.
 
     Returns the value of ``x`` that would result from the NumPy-style
@@ -904,7 +905,7 @@ class _IndexUpdateRef:
 
   def power(self, values: ArrayLike, *,
             indices_are_sorted: bool = False, unique_indices: bool = False,
-            mode: str | jax.lax.GatherScatterMode | None = None) -> Array:
+            mode: str | lax.GatherScatterMode | None = None) -> Array:
     """Pure equivalent of ``x[idx] **= y``.
 
     Returns the value of ``x`` that would result from the NumPy-style
@@ -921,7 +922,7 @@ class _IndexUpdateRef:
 
   def min(self, values: ArrayLike, *,
           indices_are_sorted: bool = False, unique_indices: bool = False,
-          mode: str | jax.lax.GatherScatterMode | None = None) -> Array:
+          mode: str | lax.GatherScatterMode | None = None) -> Array:
     """Pure equivalent of ``x[idx] = minimum(x[idx], y)``.
 
     Returns the value of ``x`` that would result from the NumPy-style
@@ -937,7 +938,7 @@ class _IndexUpdateRef:
 
   def max(self, values: ArrayLike, *,
           indices_are_sorted: bool = False, unique_indices: bool = False,
-          mode: str | jax.lax.GatherScatterMode | None = None) -> Array:
+          mode: str | lax.GatherScatterMode | None = None) -> Array:
     """Pure equivalent of ``x[idx] = maximum(x[idx], y)``.
 
     Returns the value of ``x`` that would result from the NumPy-style

--- a/jax/_src/numpy/error.py
+++ b/jax/_src/numpy/error.py
@@ -15,9 +15,11 @@
 import contextlib
 from typing import Literal, Sequence
 
-import jax
+import numpy as np
+
 from jax._src import config
-from jax._src.typing import ArrayLike
+from jax._src import dtypes
+from jax._src.typing import Array, ArrayLike
 
 Category = Literal["nan", "divide", "oob"]
 
@@ -40,7 +42,7 @@ def _is_category_disabled(
 
 
 def _set_error_if_with_category(
-    pred: jax.Array,
+    pred: Array,
     /,
     msg: str,
     category: Category | None = None,
@@ -65,7 +67,7 @@ def _set_error_if_with_category(
   error_check_lib.set_error_if(pred, msg)
 
 
-def _set_error_if_nan(pred: jax.Array, /):
+def _set_error_if_nan(pred: Array, /):
   """Set the internal error state if any element of `pred` is `NaN`.
 
   This function is disabled if the `jax_error_checking_behavior_nan` flag is
@@ -74,17 +76,17 @@ def _set_error_if_nan(pred: jax.Array, /):
   if config.error_checking_behavior_nan.value == "ignore":
     return
 
-  # TODO(mattjj): fix the circular import issue.
-  import jax.numpy as jnp
-  if not jnp.issubdtype(pred.dtype, jnp.floating):  # only check floats
+  if not dtypes.issubdtype(pred.dtype, np.floating):  # only check floats
     return
 
   # TODO(mattjj): fix the circular import issue.
   from jax._src import error_check as error_check_lib
+  import jax.numpy as jnp
+
   error_check_lib.set_error_if(jnp.isnan(pred), "NaN encountered")
 
 
-def _set_error_if_divide_by_zero(pred: jax.Array, /):
+def _set_error_if_divide_by_zero(pred: Array, /):
   """Set the internal error state if any element of `pred` is zero.
 
   This function is intended for checking if the denominator of a division is

--- a/jax/_src/numpy/index_tricks.py
+++ b/jax/_src/numpy/index_tricks.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, Union
 
-import jax
+import numpy as np
+
+from jax._src import config
 from jax._src import core
 from jax._src.numpy.util import promote_dtypes
 from jax._src.numpy.lax_numpy import (
@@ -25,8 +27,6 @@ from jax._src.numpy.lax_numpy import (
 )
 from jax._src.typing import Array, ArrayLike
 from jax._src.util import set_module
-
-import numpy as np
 
 
 export = set_module('jax.numpy')
@@ -83,7 +83,7 @@ class _Mgrid:
     if isinstance(key, slice):
       return _make_1d_grid_from_slice(key, op_name="mgrid")
     output: Iterable[Array] = (_make_1d_grid_from_slice(k, op_name="mgrid") for k in key)
-    with jax.numpy_dtype_promotion('standard'):
+    with config.numpy_dtype_promotion('standard'):
       output = promote_dtypes(*output)
     output_arr = meshgrid(*output, indexing='ij', sparse=False)
     if len(output_arr) == 0:
@@ -128,7 +128,7 @@ class _Ogrid:
     if isinstance(key, slice):
       return _make_1d_grid_from_slice(key, op_name="ogrid")
     output: Iterable[Array] = (_make_1d_grid_from_slice(k, op_name="ogrid") for k in key)
-    with jax.numpy_dtype_promotion('standard'):
+    with config.numpy_dtype_promotion('standard'):
       output = promote_dtypes(*output)
     return meshgrid(*output, indexing='ij', sparse=True)
 

--- a/jax/_src/numpy/indexing.py
+++ b/jax/_src/numpy/indexing.py
@@ -20,7 +20,8 @@ import operator
 import string
 from typing import Any, NamedTuple, Sequence
 
-import jax
+import numpy as np
+
 from jax import lax
 from jax._src import array
 from jax._src import config
@@ -39,7 +40,6 @@ from jax._src.pjit import auto_axes
 from jax._src.tree_util import tree_flatten
 from jax._src.typing import Array, ArrayLike, StaticScalar
 from jax._src.util import canonicalize_axis, safe_zip, set_module, tuple_update
-import numpy as np
 
 export = set_module('jax.numpy')
 
@@ -314,8 +314,10 @@ def take_along_axis(
     return lax.full(out_shape, 0, a.dtype)
 
   if mode == "one_hot":
+    from jax import nn  # pytype: disable=import-error
+
     indices = _normalize_index(indices, axis_size)
-    hot = jax.nn.one_hot(indices, axis_size, dtype=np.bool_)
+    hot = nn.one_hot(indices, axis_size, dtype=np.bool_)
     if a.ndim == 1:
       return einsum.einsum("...b,b->...", hot, a, preferred_element_type=a.dtype)
     if axis_int > len(string.ascii_letters) - 2:

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -23,10 +23,11 @@ import numpy as np
 import operator
 from typing import Literal, NamedTuple, overload
 
-import jax
-from jax import jit, custom_jvp
 from jax import lax
 
+from jax._src.api import jit
+from jax._src import config
+from jax._src.custom_derivatives import custom_jvp
 from jax._src import deprecations
 from jax._src.lax import lax as lax_internal
 from jax._src.lax.lax import PrecisionLike
@@ -44,24 +45,24 @@ export = set_module('jax.numpy.linalg')
 
 
 class EighResult(NamedTuple):
-  eigenvalues: jax.Array
-  eigenvectors: jax.Array
+  eigenvalues: Array
+  eigenvectors: Array
 
 
 class QRResult(NamedTuple):
-  Q: jax.Array
-  R: jax.Array
+  Q: Array
+  R: Array
 
 
 class SlogdetResult(NamedTuple):
-  sign: jax.Array
-  logabsdet: jax.Array
+  sign: Array
+  logabsdet: Array
 
 
 class SVDResult(NamedTuple):
-  U: jax.Array
-  S: jax.Array
-  Vh: jax.Array
+  U: Array
+  S: Array
+  Vh: Array
 
 
 def _H(x: ArrayLike) -> Array:
@@ -995,7 +996,7 @@ def _pinv(a: ArrayLike, rtol: ArrayLike | None = None, hermitian: bool = False) 
 
 
 @_pinv.defjvp
-@jax.default_matmul_precision("float32")
+@config.default_matmul_precision("float32")
 def _pinv_jvp(rtol, hermitian, primals, tangents):
   # The Differentiation of Pseudo-Inverses and Nonlinear Least Squares Problems
   # Whose Variables Separate. Author(s): G. H. Golub and V. Pereyra. SIAM
@@ -1617,7 +1618,7 @@ def matrix_transpose(x: ArrayLike, /) -> Array:
   ndim = x_arr.ndim
   if ndim < 2:
     raise ValueError(f"matrix_transpose requres at least 2 dimensions; got {ndim=}")
-  return jax.lax.transpose(x_arr, (*range(ndim - 2), ndim - 1, ndim - 2))
+  return lax.transpose(x_arr, (*range(ndim - 2), ndim - 1, ndim - 2))
 
 
 @export

--- a/jax/_src/numpy/polynomial.py
+++ b/jax/_src/numpy/polynomial.py
@@ -19,8 +19,8 @@ import operator
 
 import numpy as np
 
-from jax import jit
 from jax import lax
+from jax._src.api import jit
 from jax._src import dtypes
 from jax._src import core
 from jax._src.lax import lax as lax_internal

--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -23,9 +23,9 @@ from typing import overload, Any, Literal, Protocol, Union
 
 import numpy as np
 
-import jax
 from jax import lax
 from jax._src import api
+from jax._src import config
 from jax._src import core
 from jax._src import deprecations
 from jax._src import dtypes
@@ -793,7 +793,7 @@ def _axis_size(a: ArrayLike, axis: int | Sequence[int]):
   size = 1
   a_shape = np.shape(a)
   for a in axis_seq:
-    size *= maybe_named_axis(a, lambda i: a_shape[i], jax.lax.axis_size)
+    size *= maybe_named_axis(a, lambda i: a_shape[i], lax.axis_size)
   return size
 
 
@@ -1136,7 +1136,7 @@ def _var(a: Array, axis: Axis = None, dtype: DTypeLike | None = None,
   normalizer = lax.sub(normalizer, lax.convert_element_type(correction, computation_dtype))
   result = sum(centered, axis, dtype=computation_dtype, keepdims=keepdims, where=where)
   result = lax.div(result, normalizer).astype(dtype)
-  with jax.debug_nans(False):
+  with config.debug_nans(False):
     result = _where(normalizer > 0, result, np.nan)
   return result
 
@@ -2513,7 +2513,7 @@ def _quantile(a: Array, q: Array, axis: int | tuple[int, ...] | None,
     index[axis] = high
     high_value = a[tuple(index)]
   else:
-    with jax.debug_nans(False):
+    with config.debug_nans(False):
       a = _where(any(lax_internal._isnan(a), axis=axis, keepdims=True), np.nan, a)
     a = lax.sort(a, dimension=axis)
     n = lax.convert_element_type(a_shape[axis], lax_internal._dtype(q))

--- a/jax/_src/numpy/scalar_types.py
+++ b/jax/_src/numpy/scalar_types.py
@@ -22,11 +22,11 @@
 
 from typing import Any
 
-import jax
+import numpy as np
+
 from jax._src.typing import Array
 from jax._src import core
 from jax._src import dtypes
-import numpy as np
 
 
 # Some objects below rewrite their __module__ attribute to this name.
@@ -46,7 +46,8 @@ class _ScalarMeta(type):
     return not (self == other)
 
   def __call__(self, x: Any) -> Array:
-    return jax.numpy.asarray(x, dtype=self.dtype)
+    from jax._src.numpy.lax_numpy import asarray
+    return asarray(x, dtype=self.dtype)
 
   def __instancecheck__(self, instance: Any) -> bool:
     return isinstance(instance, self.dtype.type)

--- a/jax/_src/numpy/setops.py
+++ b/jax/_src/numpy/setops.py
@@ -21,10 +21,9 @@ from typing import cast, NamedTuple
 
 import numpy as np
 
-import jax
-from jax import jit
 from jax import lax
 
+from jax._src.api import jit
 from jax._src import core
 from jax._src import dtypes
 from jax._src.lax import lax as lax_internal
@@ -59,8 +58,10 @@ def _in1d(ar1: ArrayLike, ar2: ArrayLike, invert: bool,
     else:
       return (arr1[:, None] == arr2[None, :]).any(-1)
   elif method == 'binary_search':
+    from jax._src.numpy.lax_numpy import searchsorted
+
     arr2 = lax.sort(arr2)
-    ind = jax.numpy.searchsorted(arr2, arr1)
+    ind = searchsorted(arr2, arr1)
     if invert:
       return arr1 != arr2[ind]
     else:

--- a/jax/_src/numpy/vectorize.py
+++ b/jax/_src/numpy/vectorize.py
@@ -23,7 +23,7 @@ import numpy as np
 
 from jax._src import api
 from jax._src import config
-from jax import lax
+from jax._src.lax import lax
 from jax._src.numpy import lax_numpy as jnp
 from jax._src.util import set_module, safe_map as map, safe_zip as zip
 

--- a/jax/_src/numpy/window_functions.py
+++ b/jax/_src/numpy/window_functions.py
@@ -16,11 +16,11 @@ import numpy as np
 
 from jax._src import core
 from jax._src import dtypes
+from jax._src.lax import lax
 from jax._src.numpy import lax_numpy
 from jax._src.numpy import ufuncs
 from jax._src.typing import Array, ArrayLike
 from jax._src.util import set_module
-from jax import lax
 
 export = set_module('jax.numpy')
 


### PR DESCRIPTION
This is toward the goal of removing circular dependencies from our import graphs.

This removes nearly all top-level `jax` imports from within `jax/_src/numpy/*.py`.