### PR TITLE
Set an upper limit on McCabe code complexity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,8 +109,6 @@ ignore = [
     "C417",
     # Unnecessary dict comprehension for iterable
     "C420",
-    # Object names too complex
-    "C901",
     # Local variable is assigned to but never used
     "F841",
     # Class could be dataclass or namedtuple
@@ -121,12 +119,10 @@ ignore = [
     "B905",
 ]
 select = [
-    "B9",
-    "C",
-    "F",
-    "W",
-    "YTT",
     "ASYNC",
+    "B9",
+    "C4",
+    "C90",
     "E101",
     "E112",
     "E113",
@@ -135,10 +131,13 @@ select = [
     "E225",
     "E227",
     "E228",
+    "F",
+    "W",
+    "YTT",
 ]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 18
+max-complexity = 76
 
 [tool.ruff.lint.per-file-ignores]
 # F811: Redefinition of unused name.


### PR DESCRIPTION
Ruff rules C4 and C90 are two separate categories, as can be seen by running:
% `ruff linter | grep -e C4 -e C90`
```
  C4 flake8-comprehensions
 C90 mccabe
```

It does not make sense to `ignore` C90 rules and also set a `max-complexity`, so let's do one or the other.
* https://docs.astral.sh/ruff/rules/#mccabe-c90