### PR TITLE
[mosaic-gpu] add utility to get number of SMs

### DIFF
--- a/jaxlib/mosaic/gpu/mosaic_gpu_ext.cc
+++ b/jaxlib/mosaic/gpu/mosaic_gpu_ext.cc
@@ -262,6 +262,16 @@ NB_MODULE(_mosaic_gpu_ext, m) {
         return profiler_state.timings;
       },
       nb::arg("finalize") = true);
+  m.def("_get_gpu_sm_count", []() {
+    int dev = 0;
+    gpuDeviceProp deviceProp;
+    gpuError_t err = gpuGetDeviceProperties(&deviceProp, dev);
+    if (err != gpuSuccess) {
+      throw std::runtime_error("Failed to get GPU properties!");
+    }
+    int sm_count = deviceProp.multiProcessorCount;
+    return sm_count;
+  });
 }
 
 }  // namespace


### PR DESCRIPTION
`_get_gpu_sm_count` returns the number of Streaming Multiprocessors(SMs) for the gpu, which can be used in mosaic-gpu to create persistent kernels or better control the number of SMs taken by kernel.

there is an underlying assumption that all the GPUs are the same so we query `int dev = 0;` 

cc @apaszke 