### PR TITLE
[ROCm] ROCm7 Plugin Updates

### DIFF
--- a/jaxlib/plugin_support.py
+++ b/jaxlib/plugin_support.py
@@ -23,7 +23,7 @@ from .version import __version__ as jaxlib_version
 
 _PLUGIN_MODULE_NAMES = {
     "cuda": ["jax_cuda13_plugin", "jax_cuda12_plugin"],
-    "rocm": ["jax_rocm60_plugin"],
+    "rocm": ["jax_rocm7_plugin", "jax_rocm60_plugin"],
 }
 
 

--- a/jaxlib/rocm/BUILD
+++ b/jaxlib/rocm/BUILD
@@ -356,6 +356,7 @@ nanobind_extension(
         ":hip_vendor",
         "//jaxlib:kernel_nanobind_helpers",
         "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:hip_runtime",
         "@nanobind",
     ],
 )
@@ -398,6 +399,7 @@ nanobind_extension(
         "//jaxlib/cpu:lapack_kernels",
         "@com_google_absl//absl/base",
         "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:hip_runtime",
         "@nanobind",
         "@xla//xla/ffi/api:ffi",
     ],
@@ -466,6 +468,7 @@ nanobind_extension(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:string_view",
+        "@local_config_rocm//rocm:hip_runtime",
         "@nanobind",
     ],
 )
@@ -532,7 +535,7 @@ nanobind_extension(
         "//jaxlib/gpu:gpu_plugin_extension",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings",
-        "@local_config_rocm//rocm:hip",
+        "@local_config_rocm//rocm:hip_runtime",
         "@local_config_rocm//rocm:rocm_headers",
         "@nanobind",
     ],


### PR DESCRIPTION
In preparation for the imminent release of ROCm 7.x, I have this set of changes, some of which are required for jax/jaxlib to load the new plugin namespace.

This seemed to be the simplest fix for loading multiple name/versions for the plugin, but I think it might be worth exploring something more dynamic like a callback or single entrypoint that jaxlib could call to discover plugin namespace from the `jax_rocmN_plugin` wheel itself. Maybe even using the python setuptools registrations like we do with PJRT, to do the discovery.

I am pushing this up now so we could get them into the next JAX release (presumably 0.6.2) and have support for the ROCm7 when it is published.

The bazel build changes are to fix an issue with missing symbols at load time, but also there is another problem with the rocm_config:hip target requiring amd_comgr which isn't correct either, but I have a PR in XLA to fix that. See https://github.com/openxla/xla/pull/27498