### PR TITLE
[mutable-arrays] make partial_eval_jaxpr forward input-residuals

### DIFF
--- a/jax/_src/pallas/fuser/fusible_dtype.py
+++ b/jax/_src/pallas/fuser/fusible_dtype.py
@@ -338,7 +338,7 @@ def _custom_vjp_call_physicalize_rule(
   new_jaxpr = physicalize_closed_jaxpr(call_jaxpr)
   fun = lu.wrap_init(core.jaxpr_as_fun(new_jaxpr),
                      debug_info=call_jaxpr.jaxpr.debug_info)
-  fwd = custom_derivatives.lift_fwd(num_consts, fwd_jaxpr_thunk)
+  fwd = custom_derivatives.lift_fwd(num_consts, kwargs['out_trees'](), fwd_jaxpr_thunk)
   fwd_physicalized = _physicalize_transform(fwd)
   const_avals, _ = util.split_list(new_jaxpr.in_avals, [num_consts])
   bwd_physicalized = _physicalize_transform_bwd(bwd, const_avals)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6104,17 +6104,17 @@ class RematTest(jtu.JaxTestCase):
 
     res = saved_residuals(f, (2., 3.), y=4.)
     self.assertLen(res, 6)
-    self.assertEqual(res[0][0].shape, ())
-    self.assertEqual(res[0][1], "from the argument x[0]")
+    self.assertEqual(res[0][0].shape, (1,))
+    self.assertEqual(res[0][1], "from a constant")
     self.assertEqual(res[1][0].shape, ())
-    self.assertEqual(res[1][1], "from the argument x[1]")
+    self.assertEqual(res[1][1], "from the argument x[0]")
     self.assertEqual(res[2][0].shape, ())
-    self.assertEqual(res[2][1], "from the argument y")
+    self.assertEqual(res[2][1], "from the argument x[1]")
     self.assertEqual(res[3][0].shape, ())
-    self.assertStartsWith(res[3][1], "output of jitted function 'f'")
+    self.assertEqual(res[3][1], "from the argument y")
     self.assertEqual(res[4][0].shape, ())
-    self.assertEqual(res[5][0].shape, (1,))
-    self.assertStartsWith(res[5][1], "output of jitted function 'f'")
+    self.assertStartsWith(res[4][1], "output of jitted function 'f'")
+    self.assertEqual(res[5][0].shape, ())
 
   @parameterized.named_parameters(
       {"testcase_name": f"{suffix}", "remat": remat}

--- a/tests/custom_api_test.py
+++ b/tests/custom_api_test.py
@@ -2954,7 +2954,7 @@ class CustomVJPTest(jtu.JaxTestCase):
       return np.array([1.0])*x
 
     def fwd(x):
-      return np.array([2.0])*x*x/np.array([1.0]), (x,)
+      return np.array([2.0])*x*x/np.array([1.0]), (2 * x,)
 
     x = jnp.linspace(0, 5.0, 10)
     fwd = custom_derivatives.optimize_remat_of_custom_vjp_fwd(
@@ -2968,7 +2968,7 @@ class CustomVJPTest(jtu.JaxTestCase):
     def fun(x):
       return (np.array([1.0])*x)[0]
     def fwd(x):
-      return (np.array([2.0])*x*x/np.array([1.0]))[0], (x,)
+      return (np.array([2.0])*x*x/np.array([1.0]))[0], (2 * x,)
     x = jnp.linspace(0, 5.0, 10)
     fwd = custom_derivatives.optimize_remat_of_custom_vjp_fwd(
         fun, api_util.debug_info("custom_vjp fun", fun, (x,), {}),
@@ -2980,7 +2980,7 @@ class CustomVJPTest(jtu.JaxTestCase):
     def fun(x):
       return x
     def fwd(x):
-      return x*x, (x,)
+      return x*x, (2 * x,)
 
     x = jnp.linspace(0, 5.0, 10)
     fwd = custom_derivatives.optimize_remat_of_custom_vjp_fwd(
@@ -2997,7 +2997,7 @@ class CustomVJPTest(jtu.JaxTestCase):
     def fun(x):
       return x**2
     def fwd_(x):
-      return x*x, (x,)
+      return x*x, (2 * x,)
 
     fwd = custom_derivatives.optimize_remat_of_custom_vjp_fwd(
         fun, api_util.debug_info("custom_vjp fun", fun, (3.2,), {}),

--- a/tests/debug_info_test.py
+++ b/tests/debug_info_test.py
@@ -965,8 +965,7 @@ class DebugInfoTest(jtu.JaxTestCase):
     else:
       expected_jaxpr_debug_infos = [
           "traced_for=jit, fun=<lambda>, arg_names=x,y,res_ct, result_paths=result[0],result[1]",
-          # TODO(necula): result_paths
-          "traced_for=jit, fun=my_g, arg_names=u,v, result_paths=",
+          "traced_for=jit, fun=my_g, arg_names=u,v, result_paths=result['c']",
             # TODO(necula): arg_names
           "traced_for=jit, fun=my_g, arg_names=,,u,v, result_paths=result['c'],result['d']",
       ]
@@ -1403,7 +1402,7 @@ class DebugInfoTest(jtu.JaxTestCase):
     else:
       expected_jaxpr_debug_infos = [
           "traced_for=jit, fun=the_grad, arg_names=c,as_, result_paths=result[0],result[1]",
-          "traced_for=jit, fun=my_f, arg_names=x,as_, result_paths=,,",
+          "traced_for=jit, fun=my_f, arg_names=x,as_, result_paths=result[0],result[1]",
           "traced_for=for_loop, fun=f, arg_names=,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=i,refs[0],refs[1],refs[2], result_paths=",
           "traced_for=jit, fun=my_f, arg_names=,,x,as_, result_paths=result[0],result[1]",

--- a/tests/mutable_array_test.py
+++ b/tests/mutable_array_test.py
@@ -317,6 +317,53 @@ class MutableArrayTest(jtu.JaxTestCase):
     jax.grad(f)(1.0)
     self.assertAllClose(x_ref[...], 12, check_dtypes=False)
 
+  @parameterized.parameters([False, True])
+  def test_custom_vjp_grad_stats_plumbing(self, jit):
+
+   @jax.custom_vjp
+   def gradient_history_calculator(x, ref):
+     del ref
+     return x
+
+   def gradient_history_calculator_fwd(x, ref):
+     return x, ref
+
+   def gradient_history_calculator_bwd(amax_history, grad_output):
+     amax_update = jnp.max(jnp.abs(grad_output))
+     shifted = jnp.roll(amax_history[:], 1)
+     shifted = shifted.at[0].set(amax_update)
+     amax_history[:] = shifted
+     amax_from_history = jnp.max(amax_history[:])
+     grad_output = grad_output / amax_from_history
+     return grad_output, None
+
+   gradient_history_calculator.defvjp(
+     gradient_history_calculator_fwd,
+     gradient_history_calculator_bwd)
+
+   class DotOp:
+     def __init__(self):
+       self.amax_history = core.mutable_array(jnp.zeros(5,))
+
+     def forward(self, x, y):
+       out = jnp.dot(x, y)
+       out = gradient_history_calculator(out, self.amax_history)
+       return out
+
+   dot_op = DotOp()
+   x_top = jnp.ones((5,))
+   y_top = jnp.ones((5,))
+
+   def loss(x, y):
+     return dot_op.forward(x, y).sum()
+
+   if jit:
+     loss = jax.jit(loss)
+
+   for i in range(3):
+     jax.grad(loss, (0,1))(x_top, y_top)
+     self.assertAllClose(dot_op.amax_history[:], jnp.zeros((5,)).at[:i+1].set(1.0), check_dtypes=False)
+
 
 @jtu.with_config(jax_mutable_array_checks=True)
 class MutableArrayErrorsTest(jtu.JaxTestCase):
@@ -418,9 +465,23 @@ class MutableArrayErrorsTest(jtu.JaxTestCase):
     if jit:
       f = jax.jit(f)
     x_ref = core.mutable_array(0.)
+
+    jax.vjp(f, 3., x_ref)  # returning input ref, okay
+
+    @jax.custom_vjp
+    def g(x, ref):
+      return x
+    def g_fwd(x, _):
+      y_ref = core.mutable_array(0)
+      return x, y_ref
+    g.defvjp(g_fwd, lambda ref, g: g)
+    if jit:
+      g = jax.jit(g)
+    x_ref = core.mutable_array(0.)
+
     with self.assertRaisesRegex(
         ValueError, "custom_vjp fwd function"):
-      jax.vjp(f, 3., x_ref)
+      jax.vjp(g, 3., x_ref)
 
   @parameterized.parameters([False, True])
   def test_argument_aliases_custom_vjp_primal(self, jit):


### PR DESCRIPTION
The main goal here is to make `partial_eval_jaxpr`, or rather the new `partial_eval_jaxpr_fwd` variant of it, tell its caller about primal inputs that are residuals and must be forwarded to the unknown/linearized computation. That is, while `partial_eval_jaxpr` has all residuals come out of the known/fwd jaxpr as outputs, `partial_eval_jaxpr_fwd` does not, and instead returns to its caller a `list[int | None]` indicating which inputs should be forwarded (and where).

The connection to mutable arrays is that we don't want to return mutable arrays from jaxprs in general, or from forward passes in particular, and instead want them to be common inputs between the forward and backward passes. This forwarding mechanism, which is a critical optimization for values, is handily exactly what we need for mutable arrays.

Before this PR, we would handle this kind of forwarding as an optimization applied after running `partial_eval_jaxpr`. For example, in `_pjit_partial_eval` we would take the output known_jaxpr of `partial_eval_jaxpr` and process it to compute the forwards, then prune the corresponding outputs. However, that approach, where we form the jaxpr first and then prune it later, isn't so great for mutable arrays because it means we can't raise an error as soon as we form a jaxpr that returns a mutable array; instead, we'd have to defer such an error until after applying the forwarding optimization.

Hence the central motivation for this change: build forwarding into `partial_eval_jaxpr_fwd` such that we never in the first place form jaxprs that return the to-be-forwarded values or mutable arrays.

Why and how would we get mutable arrays that are shared by both the forward and backward passes? That doesn't always come up when we're just differentiating through code using mutable arrays, where we essentially generate separate primal and tangent mutable arrays. Instead, the main motivation for the forward and backward passes to share a mutable array is to plumb out backward-pass data, like gradient statistics.

As for the how, we could imagine setting up plumbing primitives, and we can also imagine letting users set up such plumbing via `custom_vjp`. This PR takes the latter approach (see the new test in mutable_array_test.py). Logically, we need to extend `custom_vjp` with a way for users to define common inputs for the fwd and bwd rules. We already have one such mechanism, namely `nondiff_argnums` aka non-Tracer-argnums, but we can't just use that because we need to handle Tracer-y inputs here in general. Moreover, adding another argnums-style parameter is a bit of a pain; it's clunky to use (where do the inputs go in the bwd rule signature? at the front, or perhaps after the nondiff_argnums args?), and someone's going to ask us to add an "argnames" version next. So instead we take another approach: we allow `custom_vjp` fwd rules to return argument mutable arrays as part of their residual outputs. That's just a syntactic convenience: internally we represent the rules as having common inputs, by detecting forwarding.

So after this PR, gradient plumbing can look like this:
```python
import jax
import jax.numpy as jnp
from jax._src.core import mutable_array

grads_ref = mutable_array(0.)

@jax.jit
def primal(grads_ref, x):  # note: jit-abstracted!
  x = jnp.sin(x)
  x = stash_grads(grads_ref, x)
  x = jnp.sin(x)
  return x

@jax.custom_vjp
def stash_grads(grads_ref, x):
  return x
def stash_grads_fwd(grads_ref, x):
  return x, grads_ref
def stash_grads_bwd(grads_ref, g):
  grads_ref[...] = g
  return None, g
stash_grads.defvjp(stash_grads_fwd, stash_grads_bwd)


jax.grad(primal, 1)(grads_ref, 1.0)
print(grads_ref[...])  # 0.66636676
```

The main changes to upgrade `partial_eval_jaxpr` with forwarding were:
* in partial_eval.py, add `partial_eval_jaxpr_nounits_fwd` and a `fwd: bool` parameter to the underlying `_partial_eval_jaxpr_nounits`, which now uses `trace_to_subjaxpr_nounits_fwd` and returns `input_fwds: list[int | None]`;
* in `_pjit_partial_eval`, call `partial_eval_jaxpr_nounits_fwd`, while additionally still performing input-to-nonresidual-output forwarding using `pe._jaxpr_forwarding` to preserve current behavior;
* update api_test.py and debug_info_test.py just to reflect tweaked (improved!) partial eval behavior;
* update custom_api_test.py because the tests effectively baked in an assumption that the residuals would not be forwarded.

The main changes to enable the new `custom_vjp` behavior were:
* in custom_derivatives.py, we upgrade the store to include not just `out_tree` and `res_tree` but also `input_fwds: list[int | None]`;
* in custom_derivatives.py, upgrade `_check_for_returned_refs` not to mind residuals (~TODO not primal outputs~) that are forwards;
* in custom_derivatives.py, change `_flatten_fwd` to do the "syntax conversion" of pruning out returned residuals and indicating them instead as forwards / common inputs with the bwd rule;
* in ad.py, in `JVPTrace.process_custom_vjp_call` and `LinearizeTrace.process_custom_vjp_call`, we pass the full set of residuals (including forwards) to `custom_lin_p.bind`;
* in partial-eval.py, in `DynamicJaxprTrace.process_custom_vjp_call`, we re-number the `input_fwds` because we also pass the primal function's consts to bind.

TODO
* [x] I don't think we should be re-inserting the forwards in optimize_remat_of_custom_vjp_fwd's wrapped_fwd... EDIT: actually, that was correct, because it happens before we apply `_flatten_fwd`!
* [ ] put back the checks I deleted in `_partial_eval_jaxpr_nounits` out of laziness...

In this PR we only call `partial_eval_jaxpr_fwd` in `_pjit_partial_eval`. In follow-up work we should update ~all call sites of `partial_eval_jaxpr` to use `partial_eval_jaxpr_fwd`, then delete the former.