### PR TITLE
Clarify argument order for lax.associative_scan when reverse=True.

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -2656,6 +2656,9 @@ def associative_scan(fn: Callable, elems, reverse: bool = False, axis: int = 0):
     of ``elems`` along ``axis``. For example, given ``elems = [a, b, c, ...]``,
     the result would be ``[a, fn(a, b), fn(fn(a, b), c), ...]``.
 
+    If ``elems = [..., x, y, z]`` and ``reverse`` is true, the result is
+    ``[..., f(f(z, y), x), f(z, y), z]``.
+
   Example 1: partial sums of an array of numbers:
 
   >>> lax.associative_scan(jnp.add, jnp.arange(0, 4))


### PR DESCRIPTION
Extends the documentation for [lax.associative_scan](https://docs.jax.dev/en/latest/_autosummary/jax.lax.associative_scan.html) to clarify the argument order when `reverse=True`.

Example to illustrate:

```python3
from jax import lax, random
from jax import numpy as jnp

f = jnp.matmul

key = random.key(0)
a, b, c = random.randint(key, [3, 2, 2], -10, 10)

y1 = lax.associative_scan(f, jnp.stack([a, b, c]))
y2 = jnp.stack([a, f(a, b), f(f(a, b), c)])
assert jnp.array_equal(y1, y2)

y1 = lax.associative_scan(f, jnp.stack([a, b, c]), reverse=True)
y2 = jnp.stack([f(f(c, b), a), f(c, b), c])
y3 = jnp.stack([f(a, f(b, c)), f(b, c), c])
assert jnp.array_equal(y1, y2)
assert not jnp.array_equal(y1, y3)
```