### PR TITLE
gumbel distribution implementation

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -323,6 +323,34 @@ jax.scipy.stats.gamma
    sf
    logsf
 
+jax.scipy.stats.gumbel_l
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: jax.scipy.stats.gumbel_l
+.. autosummary::
+  :toctree: _autosummary
+
+   logpdf
+   pdf
+   cdf
+   logcdf
+   sf
+   logsf
+   ppf
+
+jax.scipy.stats.gumbel_r
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: jax.scipy.stats.gumbel_r
+.. autosummary::
+  :toctree: _autosummary
+
+   logpdf
+   pdf
+   cdf
+   logcdf
+   sf
+   logsf
+   ppf
+
 jax.scipy.stats.gennorm
 ~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: jax.scipy.stats.gennorm

--- a/jax/_src/scipy/stats/gumbel_l.py
+++ b/jax/_src/scipy/stats/gumbel_l.py
@@ -1,0 +1,256 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from jax._src import lax
+from jax._src import numpy as jnp
+from jax._src.lax.lax import _const as _lax_const
+from jax._src.numpy.util import promote_args_inexact
+from jax._src.typing import Array, ArrayLike
+from jax._src.scipy.special import xlogy, xlog1py
+
+
+def logpdf(x: ArrayLike,
+           loc: ArrayLike = 0,
+           scale: ArrayLike = 1) -> Array:
+  r"""
+  Gumbel Distribution (Left Skewed) log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.gumbel_l` ``logpdf``.
+
+   .. math::
+
+      f_{pdf}(x; \mu, \beta) = \frac{1}{\beta} \exp\left( \frac{x - \mu}{\beta} - \exp\left( \frac{x - \mu}{\beta} \right) \right)
+
+  Args:
+    x: ArrayLike, value at which to evaluate log(pdf)
+    loc: ArrayLike, distribution offset (:math:`\mu`) (defaulted to 0)
+    scale: ArrayLike, distribution scaling (:math:`\beta`) (defaulted to 1)
+
+  Returns:
+    array of logpdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.gumbel_l.pdf`
+    - :func:`jax.scipy.stats.gumbel_l.logcdf`
+    - :func:`jax.scipy.stats.gumbel_l.cdf`
+    - :func:`jax.scipy.stats.gumbel_l.ppf`
+    - :func:`jax.scipy.stats.gumbel_l.logsf`
+    - :func:`jax.scipy.stats.gumbel_l.sf`
+  """
+
+  x, loc, scale = promote_args_inexact("gumbel_l.logpdf", x, loc, scale)
+  ok = lax.gt(scale, _lax_const(scale, 0))
+  # logpdf = -log(scale) + z - exp(z)
+  z = lax.div(lax.sub(x, loc), scale)
+  neg_log_scale = xlogy(-1, scale)
+  t2 = lax.sub(z, lax.exp(z))
+  log_pdf = lax.add(neg_log_scale, t2)
+  return jnp.where(ok, log_pdf, np.nan)
+
+
+def pdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""
+  Gumbel Distribution (Left Skewed) probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.gumbel_l` ``pdf``.
+
+  .. math::
+
+      f_{pdf}(x; \mu, \beta) = \frac{1}{\beta} \exp\left( \frac{x - \mu}{\beta} - \exp\left( \frac{x - \mu}{\beta} \right) \right)
+
+  Args:
+    x: ArrayLike, value at which to evaluate pdf
+    loc: ArrayLike, distribution offset (:math:`\mu`) (defaulted to 0)
+    scale: ArrayLike, distribution scaling (:math:`\beta`) (defaulted to 1)
+
+  Returns:
+    array of pdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.gumbel_l.logpdf`
+    - :func:`jax.scipy.stats.gumbel_l.logcdf`
+    - :func:`jax.scipy.stats.gumbel_l.cdf`
+    - :func:`jax.scipy.stats.gumbel_l.ppf`
+    - :func:`jax.scipy.stats.gumbel_l.logsf`
+    - :func:`jax.scipy.stats.gumbel_l.sf`
+  """
+  return lax.exp(logpdf(x, loc, scale))
+
+
+def logcdf(x: ArrayLike,
+           loc: ArrayLike = 0,
+           scale: ArrayLike = 1) -> Array:
+  r"""
+  Gumbel Distribution (Left Skewed) log cumulative density function.
+
+  JAX implementation of :obj:`scipy.stats.gumbel_l` ``logcdf``.
+
+  .. math::
+
+      f_{cdf}(x; \mu, \beta) = 1 - \exp\left( -\exp\left( \frac{x - \mu}{\beta} \right) \right)
+
+  Args:
+    x: ArrayLike, value at which to evaluate log(cdf)
+    loc: ArrayLike, distribution offset (:math:`\mu`) (defaulted to 0)
+    scale: ArrayLike, distribution scaling (:math:`\beta`) (defaulted to 1)
+
+  Returns:
+    array of logcdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.gumbel_l.logpdf`
+    - :func:`jax.scipy.stats.gumbel_l.pdf`
+    - :func:`jax.scipy.stats.gumbel_l.cdf`
+    - :func:`jax.scipy.stats.gumbel_l.ppf`
+    - :func:`jax.scipy.stats.gumbel_l.logsf`
+    - :func:`jax.scipy.stats.gumbel_l.sf`
+  """
+  x, loc, scale = promote_args_inexact("gumbel_l.logcdf", x, loc, scale)
+  ok = lax.gt(scale, _lax_const(scale, 0))
+  z = lax.div(lax.sub(x, loc), scale)
+  neg_exp_z = lax.neg(lax.exp(z))
+  # xlog1p fails here, that's why log1p is used here
+  # even log1p fails for some cases when using float64 mode
+  # so we're using this formula which is stable
+  log_cdf = lax.log(-lax.expm1(neg_exp_z))
+  return jnp.where(ok, log_cdf, np.nan)
+
+
+def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""
+  Gumbel Distribution (Left Skewed) cumulative density function.
+
+  JAX implementation of :obj:`scipy.stats.gumbel_l` ``cdf``.
+
+  .. math::
+
+      f_{cdf}(x; \mu, \beta) = 1 - \exp\left( -\exp\left( \frac{x - \mu}{\beta} \right) \right)
+
+  Args:
+    x: ArrayLike, value at which to evaluate cdf
+    loc: ArrayLike, distribution offset (:math:`\mu`) (defaulted to 0)
+    scale: ArrayLike, distribution scaling (:math:`\beta`) (defaulted to 1)
+
+  Returns:
+    array of cdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.gumbel_l.logpdf`
+    - :func:`jax.scipy.stats.gumbel_l.pdf`
+    - :func:`jax.scipy.stats.gumbel_l.logcdf`
+    - :func:`jax.scipy.stats.gumbel_l.ppf`
+    - :func:`jax.scipy.stats.gumbel_l.logsf`
+    - :func:`jax.scipy.stats.gumbel_l.sf`
+  """
+  return lax.exp(logcdf(x, loc, scale))
+
+
+def ppf(p: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""
+  Gumbel Distribution (Left Skewed) percent point function (inverse of CDF)
+
+  JAX implementation of :obj:`scipy.stats.gumbel_l` ``ppf``.
+
+  .. math::
+
+      F_{ppf}}(p; \mu, \beta) = \mu + \beta \log\left( -\log(1 - p) \right)
+
+  Args:
+    p: ArrayLike, probability value (quantile) at which to evaluate ppf
+    loc: ArrayLike, distribution offset (:math:`\mu`) (defaulted to 0)
+    scale: ArrayLike, distribution scaling (:math:`\beta`) (defaulted to 1)
+
+  Returns:
+    array of ppf values
+
+  See Also:
+    - :func:`jax.scipy.stats.gumbel_l.logpdf`
+    - :func:`jax.scipy.stats.gumbel_l.pdf`
+    - :func:`jax.scipy.stats.gumbel_l.logcdf`
+    - :func:`jax.scipy.stats.gumbel_l.cdf`
+    - :func:`jax.scipy.stats.gumbel_l.logsf`
+    - :func:`jax.scipy.stats.gumbel_l.sf`
+  """
+  p, loc, scale = promote_args_inexact("gumbel_l.ppf", p, loc, scale)
+  ok = lax.bitwise_and(lax.gt(p, _lax_const(p, 0)),
+                       lax.lt(p, _lax_const(p, 1)))
+  # quantile = loc + (scale)*log(-log(1 - p))
+  t1 = xlog1py(-1, lax.neg(p))
+  # xlogp failed here too, that's why log is used
+  t = lax.mul(scale, lax.log(t1))
+  quantile = lax.add(loc, t)
+  return jnp.where(ok, quantile, np.nan)
+
+
+def sf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""
+  Gumbel Distribution (Left Skewed) survival function.
+
+  JAX implementation of :obj:`scipy.stats.gumbel_l` ``sf``.
+
+  .. math::
+
+      f_{sf}(x; \mu, \beta) = 1 - f_{cdf}(x, \mu, \beta)
+
+  Args:
+    x: ArrayLike, value at which to evaluate survival function
+    loc: ArrayLike, distribution offset (:math:`\mu`) (defaulted to 0)
+    scale: ArrayLike, distribution scaling (:math:`\beta`) (defaulted to 1)
+
+  Returns:
+    array of sf values (1 - cdf)
+
+  See Also:
+    - :func:`jax.scipy.stats.gumbel_l.logpdf`
+    - :func:`jax.scipy.stats.gumbel_l.pdf`
+    - :func:`jax.scipy.stats.gumbel_l.logcdf`
+    - :func:`jax.scipy.stats.gumbel_l.cdf`
+    - :func:`jax.scipy.stats.gumbel_l.logsf`
+  """
+  return jnp.exp(logsf(x, loc, scale))
+
+
+def logsf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""
+  Gumbel Distribution (Left Skewed) log survival function.
+
+  JAX implementation of :obj:`scipy.stats.gumbel_l` ``logsf``.
+
+  .. math::
+
+      f_{sf}(x; \mu, \beta) = 1 - f_{cdf}(x, \mu, \beta)
+
+  Args:
+    x: ArrayLike, value at which to evaluate log survival function
+    loc: ArrayLike, distribution offset (:math:`\mu`) (defaulted to 0)
+    scale: ArrayLike, distribution scaling (:math:`\beta`) (defaulted to 1)
+
+  Returns:
+    array of logsf values
+
+  See Also:
+    - :func:`jax.scipy.stats.gumbel_l.logpdf`
+    - :func:`jax.scipy.stats.gumbel_l.pdf`
+    - :func:`jax.scipy.stats.gumbel_l.logcdf`
+    - :func:`jax.scipy.stats.gumbel_l.cdf`
+    - :func:`jax.scipy.stats.gumbel_l.sf`
+  """
+  x, loc, scale = promote_args_inexact("gumbel_l.logsf", x, loc, scale)
+  ok = lax.gt(scale, _lax_const(scale, 0))
+  # logsf = -exp(z)
+  z = lax.div(lax.sub(x, loc), scale)
+  log_sf = lax.neg(lax.exp(z))
+  return jnp.where(ok, log_sf, np.nan)

--- a/jax/_src/scipy/stats/gumbel_r.py
+++ b/jax/_src/scipy/stats/gumbel_r.py
@@ -1,0 +1,269 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from jax._src import lax
+from jax._src import numpy as jnp
+from jax._src.lax.lax import _const as _lax_const
+from jax._src.numpy.util import promote_args_inexact
+from jax._src.typing import Array, ArrayLike
+from jax._src.scipy.special import xlogy
+
+
+def logpdf(x: ArrayLike,
+           loc: ArrayLike = 0,
+           scale: ArrayLike = 1) -> Array:
+  r"""
+  Gumbel Distribution (Right Skewed) log probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.gumbel_l` ``logpdf``.
+
+  .. math::
+
+      f_{pdf}(x; \mu, \beta) = \frac{1}{\beta} \exp\left( -\frac{x - \mu}{\beta} - \exp\left( -\frac{x - \mu}{\beta} \right) \right)
+
+  Args:
+    x: ArrayLike, value at which to evaluate log(pdf)
+    loc: ArrayLike, distribution offset (:math:`\mu`) (defaulted to 0)
+    scale: ArrayLike, distribution scaling (:math:`\beta`) (defaulted to 1)
+
+  Returns:
+    array of logpdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.gumbel_r.pdf`
+    - :func:`jax.scipy.stats.gumbel_r.logcdf`
+    - :func:`jax.scipy.stats.gumbel_r.cdf`
+    - :func:`jax.scipy.stats.gumbel_r.ppf`
+    - :func:`jax.scipy.stats.gumbel_r.sf`
+    - :func:`jax.scipy.stats.gumbel_r.logsf`
+  """
+
+  x, loc, scale = promote_args_inexact("gumbel_r.logpdf", x, loc, scale)
+  ok = lax.gt(scale, _lax_const(scale, 0))
+  z = lax.div(lax.sub(x, loc), scale)
+  # logpdf = -log(beta) - (z + exp(-z))
+  neg_log_scale = xlogy(-1, scale)
+  t2 = lax.neg(lax.add(z, lax.exp(lax.neg(z))))
+  log_pdf = lax.add(neg_log_scale, t2)
+  return jnp.where(ok, log_pdf, np.nan)
+
+
+def pdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""
+  Gumbel Distribution (Right Skewed) probability distribution function.
+
+  JAX implementation of :obj:`scipy.stats.gumbel_r` ``pdf``.
+
+  .. math::
+
+      f_{pdf}(x; \mu, \beta) = \frac{1}{\beta} \exp\left( -\frac{x - \mu}{\beta} - \exp\left( -\frac{x - \mu}{\beta} \right) \right)
+
+  Args:
+    x: ArrayLike, value at which to evaluate pdf
+    loc: ArrayLike, distribution offset (:math:`\mu`) (defaulted to 0)
+    scale: ArrayLike, distribution scaling (:math:`\beta`) (defaulted to 1)
+
+  Returns:
+    array of pdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.gumbel_r.logpdf`
+    - :func:`jax.scipy.stats.gumbel_r.logcdf`
+    - :func:`jax.scipy.stats.gumbel_r.cdf`
+    - :func:`jax.scipy.stats.gumbel_r.ppf`
+    - :func:`jax.scipy.stats.gumbel_r.sf`
+    - :func:`jax.scipy.stats.gumbel_r.logsf`
+  """
+  return lax.exp(logpdf(x, loc, scale))
+
+
+def logcdf(x: ArrayLike,
+           loc: ArrayLike = 0,
+           scale: ArrayLike = 1) -> Array:
+  r"""
+  Gumbel Distribution (Right Skewed) log cumulative density function.
+
+  JAX implementation of :obj:`scipy.stats.gumbel_r` ``logcdf``.
+
+  .. math::
+
+      f_{cdf}(x; \mu, \beta) = \exp\left( -\exp\left( -\frac{x - \mu}{\beta} \right) \right)
+
+  Args:
+    x: ArrayLike, value at which to evaluate log(cdf)
+    loc: ArrayLike, distribution offset (:math:`\mu`) (defaulted to 0)
+    scale: ArrayLike, distribution scaling (:math:`\beta`) (defaulted to 1)
+
+  Returns:
+    array of logcdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.gumbel_r.logpdf`
+    - :func:`jax.scipy.stats.gumbel_r.pdf`
+    - :func:`jax.scipy.stats.gumbel_r.cdf`
+    - :func:`jax.scipy.stats.gumbel_r.ppf`
+    - :func:`jax.scipy.stats.gumbel_r.sf`
+    - :func:`jax.scipy.stats.gumbel_r.logsf`
+  """
+  x, loc, scale = promote_args_inexact("gumbel_r.logcdf", x, loc, scale)
+  ok = lax.gt(scale, _lax_const(scale, 0))
+  z = lax.div(lax.sub(x, loc), scale)
+  # log cdf = -exp(-z)
+  log_cdf = lax.neg(lax.exp(lax.neg(z)))
+  return jnp.where(ok, log_cdf, np.nan)
+
+
+def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""
+  Gumbel Distribution (Right Skewed) cumulative density function.
+
+  JAX implementation of :obj:`scipy.stats.gumbel_r` ``cdf``.
+
+  .. math::
+
+      f_{cdf}(x; \mu, \beta) = \exp\left( -\exp\left( -\frac{x - \mu}{\beta} \right) \right)
+
+  Args:
+    x: ArrayLike, value at which to evaluate cdf
+    loc: ArrayLike, distribution offset (:math:`\mu`) (defaulted to 0)
+    scale: ArrayLike, distribution scaling (:math:`\beta`) (defaulted to 1)
+
+  Returns:
+    array of cdf values
+
+  See Also:
+    - :func:`jax.scipy.stats.gumbel_r.logpdf`
+    - :func:`jax.scipy.stats.gumbel_r.pdf`
+    - :func:`jax.scipy.stats.gumbel_r.logcdf`
+    - :func:`jax.scipy.stats.gumbel_r.ppf`
+    - :func:`jax.scipy.stats.gumbel_r.sf`
+    - :func:`jax.scipy.stats.gumbel_r.logsf`
+  """
+  return lax.exp(logcdf(x, loc, scale))
+
+
+def ppf(p: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""
+  Gumbel Distribution (Right Skewed) percent point function.
+
+  JAX implementation of :obj:`scipy.stats.gumbel_r` ``ppf``.
+
+  .. math::
+
+      F(p; \mu, \beta) = \mu - \beta \log\left( -\log(p) \right)
+
+  Args:
+    p: ArrayLike, probability value (quantile) at which to evaluate ppf
+    loc: ArrayLike, distribution offset (:math:`\mu`) (defaulted to 0)
+    scale: ArrayLike, distribution scaling (:math:`\beta`) (defaulted to 1)
+
+  Returns:
+    array of ppf values
+
+  See Also:
+    - :func:`jax.scipy.stats.gumbel_r.logpdf`
+    - :func:`jax.scipy.stats.gumbel_r.pdf`
+    - :func:`jax.scipy.stats.gumbel_r.logcdf`
+    - :func:`jax.scipy.stats.gumbel_r.cdf`
+    - :func:`jax.scipy.stats.gumbel_r.sf`
+    - :func:`jax.scipy.stats.gumbel_r.logsf`
+  """
+  p, loc, scale = promote_args_inexact("gumbel_r.ppf", p, loc, scale)
+  # 0 < p < 1
+  ok = lax.bitwise_and(lax.gt(p, _lax_const(p, 0)),
+                       lax.lt(p, _lax_const(p, 1)))
+
+  # quantile = loc - (scale)*log(-log(p))
+  t1 = xlogy(-1, p)
+  t = lax.mul(scale, lax.log(t1))
+  quantile = lax.sub(loc, t)
+  return jnp.where(ok, quantile, np.nan)
+
+
+def sf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""
+  Gumbel Distribution (Right Skewed) survival function.
+
+  JAX implementation of :obj:`scipy.stats.gumbel_r` ``sf``.
+
+  .. math::
+
+      f_{sf}(x; \mu, \beta) = 1 - F_{cdf}(x; \mu, \beta)
+
+  Args:
+    x: ArrayLike, value at which to evaluate survival function
+    loc: ArrayLike, distribution offset (:math:`\mu`) (defaulted to 0)
+    scale: ArrayLike, distribution scaling (:math:`\beta`) (defaulted to 1)
+
+  Returns:
+    array of sf values (1 - cdf)
+
+  See Also:
+    - :func:`jax.scipy.stats.gumbel_r.logpdf`
+    - :func:`jax.scipy.stats.gumbel_r.pdf`
+    - :func:`jax.scipy.stats.gumbel_r.logcdf`
+    - :func:`jax.scipy.stats.gumbel_r.cdf`
+    - :func:`jax.scipy.stats.gumbel_r.logsf`
+  """
+  x, loc, scale = promote_args_inexact("gumbel_r.sf", x, loc, scale)
+  ok = lax.gt(scale, _lax_const(scale, 0))
+  # sf = 1 - exp(-exp(-z))
+  neg_z = lax.div(lax.sub(loc, x), scale)
+  t1 = lax.exp(lax.neg(lax.exp(neg_z)))
+  _sf = lax.sub(_lax_const(x, 1), t1)
+  return jnp.where(ok, _sf, np.nan)
+
+
+def _log1mexp(x: ArrayLike) -> Array:
+  """Numerically stable calculation of log(1 - exp(x))."""
+  # referring tensorflow's implementation
+  # https://github.com/tensorflow/probability/blob/v0.23.0/tensorflow_probability/python/math/generic.py#L685-L709
+  return jnp.where(
+      x < -lax.log(2.0),  # switching point
+      lax.log1p(-lax.exp(x)),
+      lax.log(-lax.expm1(x)),
+  )
+
+
+def logsf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""
+  Gumbel Distribution (Right Skewed) log survival function.
+
+  JAX implementation of :obj:`scipy.stats.gumbel_r` ``logsf``.
+
+  Args:
+    x: ArrayLike, value at which to evaluate log survival function
+    loc: ArrayLike, distribution offset (:math:`\mu`) (defaulted to 0)
+    scale: ArrayLike, distribution scaling (:math:`\beta`) (defaulted to 1)
+
+  Returns:
+    array of logsf values
+
+  See Also:
+    - :func:`jax.scipy.stats.gumbel_r.logpdf`
+    - :func:`jax.scipy.stats.gumbel_r.pdf`
+    - :func:`jax.scipy.stats.gumbel_r.logcdf`
+    - :func:`jax.scipy.stats.gumbel_r.cdf`
+    - :func:`jax.scipy.stats.gumbel_r.sf`
+  """
+  x, loc, scale = promote_args_inexact("gumbel_r.logsf", x, loc, scale)
+  ok = lax.gt(scale, _lax_const(scale, 0))
+  # logsf = log(1 - exp(-exp(-z)))
+  neg_z = lax.div(lax.sub(loc, x), scale)
+  t1 = lax.neg(lax.exp(neg_z))
+  # numerical stability
+  log_sf = _log1mexp(t1)
+  return jnp.where(ok, log_sf, np.nan)

--- a/jax/scipy/stats/__init__.py
+++ b/jax/scipy/stats/__init__.py
@@ -41,3 +41,5 @@ from jax._src.scipy.stats.kde import gaussian_kde as gaussian_kde
 from jax._src.scipy.stats._core import mode as mode, rankdata as rankdata, sem as sem
 from jax.scipy.stats import vonmises as vonmises
 from jax.scipy.stats import wrapcauchy as wrapcauchy
+from jax.scipy.stats import gumbel_r as gumbel_r
+from jax.scipy.stats import gumbel_l as gumbel_l

--- a/jax/scipy/stats/gumbel_l.py
+++ b/jax/scipy/stats/gumbel_l.py
@@ -1,0 +1,26 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: import <name> as <name> is required for names to be exported.
+# See PEP 484 & https://github.com/jax-ml/jax/issues/7570
+
+from jax._src.scipy.stats.gumbel_l import (
+  logpdf as logpdf,
+  pdf as pdf,
+  logcdf as logcdf,
+  cdf as cdf,
+  ppf as ppf,
+  sf as sf,
+  logsf as logsf
+)

--- a/jax/scipy/stats/gumbel_r.py
+++ b/jax/scipy/stats/gumbel_r.py
@@ -1,0 +1,26 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: import <name> as <name> is required for names to be exported.
+# See PEP 484 & https://github.com/jax-ml/jax/issues/7570
+
+from jax._src.scipy.stats.gumbel_r import (
+  logpdf as logpdf,
+  pdf as pdf,
+  logcdf as logcdf,
+  cdf as cdf,
+  ppf as ppf,
+  sf as sf,
+  logsf as logsf
+)

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -1435,6 +1435,248 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     result2 = jax.vmap(lsp_stats.multivariate_normal.logpdf)(x, mean, cov)
     self.assertArraysAllClose(result1, result2, check_dtypes=False)
 
+
+  @genNamedParametersNArgs(3)
+  def testGumbelRLogPdf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.gumbel_r.logpdf
+    lax_fun = lsp_stats.gumbel_r.logpdf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.abs(scale) + np.array(0.1, dtype=scale.dtype)  # Ensure scale > 0
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol=5e-3)
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testGumbelRPdf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.gumbel_r.pdf
+    lax_fun = lsp_stats.gumbel_r.pdf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.abs(scale) + np.array(0.1, dtype=scale.dtype)  # Ensure scale > 0
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol=5e-3)
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testGumbelRLogCdf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.gumbel_r.logcdf
+    lax_fun = lsp_stats.gumbel_r.logcdf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.abs(scale) + np.array(0.1, dtype=scale.dtype)  # Ensure scale > 0
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol=5e-3)
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testGumbelRCdf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.gumbel_r.cdf
+    lax_fun = lsp_stats.gumbel_r.cdf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.abs(scale) + np.array(0.1, dtype=scale.dtype)  # Ensure scale > 0
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol=5e-3)
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testGumbelRPpf(self, shapes, dtypes):
+    rng_p = jtu.rand_uniform(self.rng(), low=0.01, high=0.99)
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.gumbel_r.ppf
+    lax_fun = lsp_stats.gumbel_r.ppf
+
+    def args_maker():
+      p = rng_p(shapes[0], dtypes[0])
+      loc = rng(shapes[1], dtypes[1])
+      scale = rng(shapes[2], dtypes[2])
+      scale = np.abs(scale) + np.array(0.1, dtype=scale.dtype)  # Ensure scale > 0
+      return [p, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol=5e-3)
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testGumbelRSf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.gumbel_r.sf
+    lax_fun = lsp_stats.gumbel_r.sf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.abs(scale) + np.array(0.1, dtype=scale.dtype)  # Ensure scale > 0
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol=5e-3)
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testGumbelRLogSf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.gumbel_r.logsf
+    lax_fun = lsp_stats.gumbel_r.logsf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.abs(scale) + np.array(0.1, dtype=scale.dtype)  # Ensure scale > 0
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol=5e-3)
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testGumbelLLogPdf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.gumbel_l.logpdf
+    lax_fun = lsp_stats.gumbel_l.logpdf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.abs(scale) + np.array(0.1, dtype=scale.dtype)  # Ensure scale > 0
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol=5e-3)
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testGumbelLPdf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.gumbel_l.pdf
+    lax_fun = lsp_stats.gumbel_l.pdf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.abs(scale) + np.array(0.1, dtype=scale.dtype)  # Ensure scale > 0
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol=5e-3)
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testGumbelLLogCdf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.gumbel_l.logcdf
+    lax_fun = lsp_stats.gumbel_l.logcdf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.abs(scale) + np.array(0.1, dtype=scale.dtype)  # Ensure scale > 0
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol=5e-3)
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testGumbelLCdf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.gumbel_l.cdf
+    lax_fun = lsp_stats.gumbel_l.cdf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.abs(scale) + np.array(0.1, dtype=scale.dtype)  # Ensure scale > 0
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol=5e-3)
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testGumbelLPpf(self, shapes, dtypes):
+    rng_p = jtu.rand_uniform(self.rng(), low=0.01, high=0.99)
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.gumbel_l.ppf
+    lax_fun = lsp_stats.gumbel_l.ppf
+
+    def args_maker():
+      p = rng_p(shapes[0], dtypes[0])
+      loc = rng(shapes[1], dtypes[1])
+      scale = rng(shapes[2], dtypes[2])
+      scale = np.abs(scale) + np.array(0.1, dtype=scale.dtype)  # Ensure scale > 0
+      return [p, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol=5e-3)
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testGumbelLSf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.gumbel_l.sf
+    lax_fun = lsp_stats.gumbel_l.sf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.abs(scale) + np.array(0.1, dtype=scale.dtype)  # Ensure scale > 0
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol=5e-3)
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testGumbelLLogSf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.gumbel_l.logsf
+    lax_fun = lsp_stats.gumbel_l.logsf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.abs(scale) + np.array(0.1, dtype=scale.dtype)  # Ensure scale > 0
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol=5e-3)
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  # Edge case tests
+  def testGumbelRPdfZero(self):
+    # Test at specific values
+    self.assertAllClose(
+      osp_stats.gumbel_r.pdf(0.0, 0.0, 1.0), lsp_stats.gumbel_r.pdf(0.0, 0.0, 1.0), atol=1E-6)
+
+  def testGumbelLPdfZero(self):
+    # Test at specific values
+    self.assertAllClose(
+      osp_stats.gumbel_l.pdf(0.0, 0.0, 1.0), lsp_stats.gumbel_l.pdf(0.0, 0.0, 1.0), atol=1E-6)
+
   @jtu.sample_product(
     inshape=[(50,), (3, 50), (2, 12)],
     dtype=jtu.dtypes.floating,


### PR DESCRIPTION
Implementation of gumbel distribution. [issue](https://github.com/jax-ml/jax/issues/29319).
Scipy uses 64-bit floating point integers, so i set the tolerance in tests to 5e-3 (I was getting errors when it was 5e-4).
Whenever I faced numerical issues with `xlogpy` and `xlog1py`, I replaced them with `lax.log1p` and `lax.log`. However `sf`, particularly in `gumbel_r` had issues due to calculation of `log(1 - exp(exp(-z)))` so I implemented `_log1mexp` utilising the [Tensorflow](https://www.tensorflow.org/probability/api_docs/python/tfp/math/log1mexp) implementation.

cc @jakevdp 