### PR TITLE
Extend pallas paged_attention with kv scales

### DIFF
--- a/jax/experimental/pallas/ops/gpu/paged_attention.py
+++ b/jax/experimental/pallas/ops/gpu/paged_attention.py
@@ -33,7 +33,9 @@ def paged_attention_kernel(
     # inputs
     q_ref,  # [block_h, head_dim]
     k_pages_ref,  # [total_num_pages, page_size, head_dim]
+    k_scales_pages_ref,  # [total_num_pages, page_size]
     v_pages_ref,  # [total_num_pages, page_size, head_dim]
+    v_scales_pages_ref,  # [total_num_pages, page_size]
     block_tables_ref,  # [pages_per_partition]
     lengths_ref,  # [1]
     # outputs
@@ -65,7 +67,16 @@ def paged_attention_kernel(
       block_tables = pl.load(block_tables_ref, block_tables_slice)
       k = k_pages_ref[block_tables].reshape(block_k, head_dim)
       v = v_pages_ref[block_tables].reshape(block_k, head_dim)
+      if k_scales_pages_ref is not None:
+        # dynamic lhs quantized dot is not currently implemented
+        # so we cast rhs to the lhs dtype
+        k = k.astype(q.dtype)
       uncapped_logits = pl.dot(q, k.T)  # [block_h, block_k]
+      if k_scales_pages_ref is not None:
+        # k_scales_pages_ref are one per head
+        # they're laid out across the output dimension, so scale output
+        k_scale = k_scales_pages_ref[block_tables].reshape((1, block_k))
+        uncapped_logits *= k_scale.astype(uncapped_logits.dtype)
       if attn_logits_soft_cap is not None:
         logits = jnp.tanh(uncapped_logits / attn_logits_soft_cap)
         logits = logits * attn_logits_soft_cap
@@ -92,6 +103,14 @@ def paged_attention_kernel(
       l_curr = s_curr.sum(axis=-1)
       l_next = l_prev_corr + l_curr
       o_prev_corr = correction[:, None] * o_prev
+      if v_scales_pages_ref is not None:
+        # v_scales are 1 per head
+        # they're laid out across the reduction dimension, so scale lhs
+        v_scale = v_scales_pages_ref[block_tables].reshape((1, block_k))
+        s_curr *= v_scale.astype(s_curr.dtype)
+        # dynamic lhs quantized dot is not currently implemented
+        # so we cast rhs to the lhs dtype
+        v = v.astype(s_curr.dtype)
       o_curr = pl.dot(s_curr.astype(v.dtype), v)
 
       o_next = o_prev_corr + o_curr
@@ -134,6 +153,8 @@ def paged_attention_unbatched(
     v_pages: jax.Array,  #  [num_kv_heads, total_num_pages, page_size, head_dim]
     block_tables: jax.Array,  #  [pages_per_sequence]
     lengths: jax.Array | None,  #  [1]
+    k_scales_pages: jax.Array | None = None,  # [num_kv_heads, total_num_pages, page_size]
+    v_scales_pages: jax.Array | None = None,  # [num_kv_heads, total_num_pages, page_size]
     *,
     block_h: int,
     pages_per_compute_block: int,
@@ -179,6 +200,19 @@ def paged_attention_unbatched(
       mask_value=mask_value,
       attn_logits_soft_cap=attn_logits_soft_cap,
   )
+  # set up quantization scales
+  if k_scales_pages is not None:
+    assert k_scales_pages.shape == (num_kv_heads, total_num_pages, page_size)
+    k_scales_spec = pl.BlockSpec((None, total_num_pages, page_size),
+                                 lambda h, i, k: (h, 0, 0))
+  else:
+    k_scales_spec = None
+  if v_scales_pages is not None:
+    assert v_scales_pages.shape == (num_kv_heads, total_num_pages, page_size)
+    v_scales_spec = pl.BlockSpec((None, total_num_pages, page_size),
+                                 lambda h, i, k: (h, 0, 0))
+  else:
+    v_scales_spec = None
 
   o, l, m = pl.pallas_call(
       kernel,
@@ -191,10 +225,12 @@ def paged_attention_unbatched(
               (None, total_num_pages, page_size, head_dim),
               lambda h, i, k: (h, 0, 0, 0),
           ),  # k_pages
+          k_scales_spec,  # k_pages_scale
           pl.BlockSpec(
               (None, total_num_pages, page_size, head_dim),
               lambda h, i, k: (h, 0, 0, 0),
           ),  # v_pages
+          v_scales_spec,  # v_pages_scale
           pl.BlockSpec(
               (None, pages_per_partition), lambda h, i, k: (k, 0)
           ),  # block_tables
@@ -226,7 +262,7 @@ def paged_attention_unbatched(
           num_warps=num_warps, num_stages=num_stages
       ),
       name=f"paged_attention_{block_h=}_{pages_per_compute_block=}",
-  )(q_reshaped, k_pages, v_pages, block_tables, lengths)
+  )(q_reshaped, k_pages, k_scales_pages, v_pages, v_scales_pages, block_tables, lengths)
 
   if q_heads_per_kv_head % block_h:
     o = o[..., :q_heads_per_kv_head, :]
@@ -265,6 +301,8 @@ def paged_attention(
     v_pages: jax.Array,
     block_tables: jax.Array,
     lengths: jax.Array | None,
+    k_scales_pages: jax.Array | None = None,
+    v_scales_pages: jax.Array | None = None,
     *,
     block_h: int = 16,
     pages_per_compute_block: int = 8,
@@ -286,6 +324,8 @@ def paged_attention(
       should be in the range of [0, total_num_pages), indicating where to locate
       the page in `k_pages` or `v_pages`.
     lengths: A i32[batch_size] jax.Array the length of each example.
+    k_scales_pages: A [num_kv_heads, total_num_pages, page_size] jax.Array.
+    v_scales_pages: A [num_kv_heads, total_num_pages, page_size] jax.Array.
     block_h: int The block size that partitions the number of head groups.
     pages_per_compute_block: int The maximum number of blocks per compute block.
     k_splits: int Number of partitions used to parallelize key-value sequence
@@ -342,12 +382,14 @@ def paged_attention(
       attn_logits_soft_cap=attn_logits_soft_cap,
   )
 
-  o = jax.vmap(impl, (0, None, None, 0, 0), 0)(
+  o = jax.vmap(impl, (0, None, None, 0, 0, None, None), 0)(
       q,
       k_pages,
       v_pages,
       block_tables,
       lengths[..., None] if lengths is not None else None,
+      k_scales_pages,
+      v_scales_pages,
   )
 
   return o

--- a/tests/pallas/gpu_paged_attention_test.py
+++ b/tests/pallas/gpu_paged_attention_test.py
@@ -44,9 +44,11 @@ def _generate_qkv(
   k_pages = jax.random.normal(
       k1, (num_kv_heads, total_pages, page_size, head_dim), dtype=dtype
   )
+  k_pages = k_pages / jnp.linalg.norm(k_pages, axis=-1)[..., None]
   v_pages = jax.random.normal(
       k2, (num_kv_heads, total_pages, page_size, head_dim), dtype=dtype
   )
+  v_pages = v_pages / jnp.linalg.norm(v_pages, axis=-1)[..., None]
 
   block_tables = jnp.arange(
       batch_size * max_num_blocks_per_seq, dtype=jnp.int32
@@ -54,6 +56,7 @@ def _generate_qkv(
   block_tables = jax.random.permutation(k3, block_tables, independent=True)
   block_tables = block_tables.reshape(batch_size, max_num_blocks_per_seq)
   q = jax.random.normal(k4, (batch_size, num_heads, head_dim), dtype=dtype)
+  q = q / jnp.linalg.norm(q, axis=-1)[..., None]
   return q, k_pages, v_pages, block_tables
 
 
@@ -71,6 +74,17 @@ def _reconstruct_kv(block_tables: jax.Array, pages: jax.Array) -> jax.Array:
   out = jnp.swapaxes(out, 1, 2)
 
   return out
+
+def _quantize(x: jax.Array, dtype=jnp.int8):
+  if isinstance(dtype, jnp.floating):
+    max_val = jnp.astype(jnp.finfo(dtype).max, x.dtype)
+  else:
+    max_val = 127
+  x_scale = jnp.max(jnp.abs(x), axis=-1) / (0.95 * max_val)
+  x_quant = (x / x_scale[..., None])
+  if isinstance(dtype, jnp.floating):
+    x_quant = jnp.rint(x_quant)
+  return x_quant.astype(dtype), x_scale.astype(x.dtype)
 
 
 @jtu.with_config(jax_traceback_filtering="off")
@@ -92,7 +106,6 @@ class PallasBaseTest(jtu.JaxTestCase):
       self.skipTest("Only works on non-Windows platforms")
 
     super().setUp()
-
 
 class PagedAttentionKernelTest(PallasBaseTest):
 
@@ -153,6 +166,80 @@ class PagedAttentionKernelTest(PallasBaseTest):
     o_ref = paged_attention.paged_attention_reference(q, k, v, lengths=seq_lens)
 
     self.assertArraysAllClose(o, o_ref, rtol=5e-2, atol=5e-2)
+
+  @jtu.sample_product(
+      dtype=(jnp.float16,),
+      page_size=(8, 16, 32),
+      num_kv_heads=(1, 2),
+      q_kv_head_ratio=(2, 16, 20),
+      head_dim=(32, 64),
+      block_h=(16, 32),
+      pages_per_compute_block=(4, 8),
+      k_splits=(4, 16),
+      attn_logits_soft_cap=(None,),
+      quantize_k=(True, False),
+      quantize_v=(True, False),
+      quant_dtype=(jnp.float8_e4m3fn, jnp.int8),
+  )
+  def test_quantized_paged_attention(
+      self,
+      dtype,
+      page_size,
+      num_kv_heads,
+      q_kv_head_ratio,
+      head_dim,
+      block_h,
+      pages_per_compute_block,
+      k_splits,
+      attn_logits_soft_cap,
+      quantize_k,
+      quantize_v,
+      quant_dtype,
+  ):
+    if not quantize_k and not quantize_v:
+      self.skipTest("Skipping since neither (k, v) quantization requested.")
+    max_kv_len = 2048
+    seq_lens = np.asarray([3, 256, 513, 1023, 2048], dtype=jnp.int32)
+    q, k_pages, v_pages, block_tables = _generate_qkv(
+        seq_lens.shape[0],
+        page_size,
+        max_kv_len,
+        num_kv_heads,
+        num_kv_heads * q_kv_head_ratio,
+        head_dim,
+        jax.random.key(0),
+        dtype,
+    )
+    k = _reconstruct_kv(block_tables, k_pages)
+    v = _reconstruct_kv(block_tables, v_pages)
+
+    k_, k_scales = (_quantize(k_pages, quant_dtype)
+                    if quantize_k else (k_pages, None))
+    v_, v_scales = (_quantize(k_pages, quant_dtype)
+                    if quantize_v else (v_pages, None))
+
+    o = paged_attention.paged_attention(
+        q,
+        k_,
+        v_,
+        block_tables,
+        seq_lens,
+        k_scales_pages=k_scales,
+        v_scales_pages=v_scales,
+        block_h=block_h,
+        pages_per_compute_block=pages_per_compute_block,
+        k_splits=k_splits,
+        attn_logits_soft_cap=attn_logits_soft_cap,
+        interpret=self.INTERPRET,
+    )
+
+    o_ref = paged_attention.paged_attention_reference(q, k, v, lengths=seq_lens)
+
+    error = (jnp.linalg.norm((o - o_ref).astype(jnp.float32), axis=-1)
+              / jnp.linalg.norm(o_ref.astype(jnp.float32)))
+
+    admissible_error = 3e-1
+    self.assertLessEqual(jnp.mean(error), admissible_error)
 
 
 class PagedAttentionInterpretTest(PagedAttentionKernelTest):


### PR DESCRIPTION
Allow k, v pages to be quantized for HBM BW and VRAM size bound applications.