### PR TITLE
Fixup doc `Potential solution 2` for custom pytree init

### DIFF
--- a/docs/custom_pytrees.md
+++ b/docs/custom_pytrees.md
@@ -260,7 +260,7 @@ class MyTree:
 def tree_unflatten(aux_data, children):
   del aux_data  # Unused in this class.
   obj = object.__new__(MyTree)
-  obj.a = a
+  obj.a = children[0]
   return obj
 ```
 


### PR DESCRIPTION
From https://docs.jax.dev/en/latest/working-with-pytrees.html#custom-pytrees-and-initialization-with-unexpected-values

Otherwise the example code fails with:

> NameError: name 'a' is not defined