### PR TITLE
Update missed ml_dtypes version check to 0.5.0

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -44,8 +44,8 @@ try:
 except:
   pass
 else:
-  if _ml_dtypes_version < (0, 2, 0):
-    raise ValueError("JAX requires ml_dtypes version 0.2.0 or newer; "
+  if _ml_dtypes_version < (0, 5, 0):
+    raise ValueError("JAX requires ml_dtypes version 0.5.0 or newer; "
                      f"installed version is {ml_dtypes.__version__}.")
 
 export = set_module('jax.dtypes')
@@ -109,7 +109,6 @@ _float8_e5m2_dtype: np.dtype = np.dtype(float8_e5m2)
 _float8_e5m2fnuz_dtype: np.dtype = np.dtype(float8_e5m2fnuz)
 
 # fp4 support
-# TODO: remove Optional when minimum ml_dtypes version >= 0.5.0
 float4_e2m1fn: type[np.generic] = ml_dtypes.float4_e2m1fn
 
 _float4_e2m1fn_dtype: np.dtype = np.dtype(float4_e2m1fn)


### PR DESCRIPTION
In https://github.com/jax-ml/jax/pull/27525, it says that JAX requires ml_dtypes >= 0.5.0,
but in build/requirements.in it's >= 0.4.0.
The changelog.md doesn't mention this change.

Since this line in build/requirements.in hasn't been changed in over a year, I decided to trust the pull request.