### PR TITLE
Add `pjit_p` to `jax.extend.core.primitives`

### DIFF
--- a/jax/extend/core/primitives.py
+++ b/jax/extend/core/primitives.py
@@ -223,7 +223,10 @@ from jax._src.lax.linalg import (
   schur_p as schur_p,
 )
 
-from jax._src.pjit import sharding_constraint_p as sharding_constraint_p
+from jax._src.pjit import (
+    pjit_p as pjit_p,
+    sharding_constraint_p as sharding_constraint_p,
+)
 
 from jax._src.prng import (
   random_bits_p as random_bits_p,


### PR DESCRIPTION
I'm not sure the exact purpose of `jax.extend.core.primitives`, but I'm guessing it is there for convenience for people defining their own JAX transformation who want to define rules for all of JAX's primitives.

The only JAX primitives I've so far found which are not already in `jax.extend.core.primitives` are `split_p` (which I've added in https://github.com/jax-ml/jax/pull/29452) and `pjit_p`.