### PR TITLE
[TSAN CI] Removed fixed cpython suppressions

### DIFF
--- a/.github/workflows/tsan-suppressions_3.13.txt
+++ b/.github/workflows/tsan-suppressions_3.13.txt
@@ -34,9 +34,6 @@ race:scal_k_
 race:gemm_beta
 race:gemm_oncopy
 
-# https://github.com/python/cpython/issues/132245
-race:split_keys_entry_added
-race_top:dict_dict_merge
-
 # https://github.com/python/cpython/issues/132214
+# Fixed in Python 3.15, but not backported to 3.13, 3.14.
 race:type_update_dict

--- a/.github/workflows/tsan-suppressions_3.14.txt
+++ b/.github/workflows/tsan-suppressions_3.14.txt
@@ -16,6 +16,6 @@ race:scal_k_
 race:gemm_beta
 race:gemm_oncopy
 
-# https://github.com/python/cpython/issues/132245
-race:split_keys_entry_added
-race_top:dict_dict_merge
+# https://github.com/python/cpython/issues/132214
+# Fixed in Python 3.15, but not backported to 3.13, 3.14.
+race:type_update_dict


### PR DESCRIPTION
Description:
- Removed fixed cpython suppressions
- Added a suppression to 3.14 FT on the race which was not backported to 3.13, 3.14