### PR TITLE
Use more concise tracer reprs by default.

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -325,8 +325,8 @@ def disable_jit(disable: bool = True):
   ...   print("Value of y is", y)
   ...   return y + 3
   ...
-  >>> print(f(jax.numpy.array([1, 2, 3])))  # doctest:+ELLIPSIS
-  Value of y is Traced<int32[3]>with<DynamicJaxprTrace...>
+  >>> print(f(jax.numpy.array([1, 2, 3])))
+  Value of y is JitTracer<int32[3]>
   [5 7 9]
 
   Here ``y`` has been abstracted by :py:func:`jit` to a :py:class:`ShapedArray`,

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -945,7 +945,13 @@ class Tracer(typing.Array, metaclass=StrictABCMeta):
       else:
         return attr
 
-  def _pretty_print(self):
+  def _short_repr(self) -> str:
+    return f'{self.__class__.__name__}<{self.aval}>'
+
+  def _pretty_print(self, verbose: bool = False) -> pp.Doc:
+    if not verbose:
+      return pp.text(self._short_repr())
+
     base = pp.text(f'Traced<{self.aval}>with<{self._trace}>')
     contents = [(name, attr._pretty_print() if isinstance(attr, Tracer)
                  else pp.text(repr(attr))) for name, attr in self._contents()]
@@ -958,7 +964,7 @@ class Tracer(typing.Array, metaclass=StrictABCMeta):
     return base
 
   def __repr__(self):
-    return self._pretty_print().format()
+    return self._pretty_print(verbose=False).format()
 
   def _contents(self):
     try:

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -638,6 +638,9 @@ class JVPTracer(Tracer):
     self.primal = primal
     self.tangent = tangent
 
+  def _short_repr(self):
+    return f"GradTracer<{self.aval}>"
+
   @property
   def aval(self):
     return get_aval(self.primal)

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -405,6 +405,9 @@ class BatchTracer(Tracer):
     self.batch_dim = batch_dim
     self.source_info = source_info
 
+  def _short_repr(self):
+    return f"VmapTracer<{self.aval}>"
+
   @property
   def aval(self):
     aval = core.get_aval(self.val)

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1652,6 +1652,9 @@ class DynamicJaxprTracer(core.Tracer):
     self.aval = aval  # type: ignore[misc]
     self.mutable_qdd = core.MutableQuasiDynamicData(qdd)
 
+  def _short_repr(self):
+    return f"JitTracer<{self.aval}>"
+
   @property
   def aval_mutable_qdd(self):
     aval = self.aval

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -532,7 +532,7 @@ class Partial(functools.partial):
   >>> print_zero()
   0
   >>> call_func(print_zero)  # doctest:+ELLIPSIS
-  Traced<~int32[]>with<DynamicJaxprTrace...>
+  JitTracer<~int32[]>
   """
 
   def __new__(klass, func, *args, **kw):


### PR DESCRIPTION
Rationale: most users do not benefit from seeing something like this when they print an array within a transformation:
```python
In [1]: import jax
   ...: import numpy as np
   ...: 
   ...: def f(x):
   ...:   print(x)
   ...:   return x
   ...: 
   ...: x = np.random.randn(5, 8).round(2)
   ...: out = jax.vmap(jax.jacobian(f))(x)
Traced<float32[8]>with<JVPTrace> with
  primal = Traced<float32[8]>with<BatchTrace> with
    val = array([[-1.33, -1.38, -1.49,  2.45, -0.28,  0.34, -0.69,  0.52],
       [-0.41, -0.97,  0.74, -0.23, -0.77,  1.31,  1.52, -0.37],
       [ 1.22,  1.04,  0.15, -0.52, -1.28,  0.79, -1.66, -1.  ],
       [ 1.42, -0.1 , -0.92,  0.09, -0.76, -0.42,  0.74, -0.41],
       [ 0.3 ,  1.02,  1.55,  0.64, -0.73, -0.39, -1.27, -1.08]])
    batch_dim = 0
  tangent = Traced<float32[8]>with<JaxprTrace> with
    pval = (ShapedArray(float32[8]), None)
    recipe = LambdaBinding()
```
With this change, the default repr from the above code becomes this:
```
GradTracer<float32[8]>
```
~Because the full repr is useful for JAX developers, it can be recovered by setting the `jax_dev_mode` configuration to `True`.~ Removed this after chatting with @mattjj.