### PR TITLE
[debug_info] Improve debug info for loop constructs.

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -612,6 +612,9 @@ def debug_info(
 
   See docstring for linear_util.DebugInfo.
   """
+  res = getattr(fun, "__fun_debug_info__", None)
+  if res is not None:
+    return res
   if sourceinfo is None:
     sourceinfo = fun_sourceinfo(fun)
   if signature is None:
@@ -627,25 +630,15 @@ def fun_signature(fun: Callable) -> inspect.Signature | None:
   except (ValueError, TypeError):
     return None
 
-def save_wrapped_fun_sourceinfo(wrapper: Callable,
-                                wrapped: Callable | core.DebugInfo) -> None:
-  # Prefer this to functools.wraps because it does not create a reference to
-  # the wrapped function.
-  if isinstance(wrapped, core.DebugInfo):
-    func_src_info = wrapped.func_src_info
-  elif callable(wrapped):
-    func_src_info = fun_sourceinfo(wrapped)
-  else:
-    assert False, wrapped  # Unreachable
-  setattr(wrapper, "__fun_sourceinfo__", func_src_info)
+def save_wrapped_fun_debug_info(wrapper: Callable,
+                                dbg: core.DebugInfo) -> None:
+  setattr(wrapper, "__fun_debug_info__", dbg)
 
 _fun_name_re = re.compile(r"(?:<built-in function (\S+)>)")
 
 # TODO(mattjj): make this function internal to this module
 def fun_sourceinfo(fun: Callable) -> str:
   # See DebugInfo.fun_src_info
-  res = getattr(fun, "__fun_sourceinfo__", None)
-  if res is not None: return res
   while isinstance(fun, partial):
     fun = fun.func
   fun = inspect.unwrap(fun)

--- a/jax/_src/custom_batching.py
+++ b/jax/_src/custom_batching.py
@@ -295,7 +295,7 @@ def custom_vmap_jvp(primals, tangents, *,
       out_mutually_batched.store(out_batched)
       return out
 
-    api_util.save_wrapped_fun_sourceinfo(to_jvp, call.jaxpr.debug_info)
+    api_util.save_wrapped_fun_debug_info(to_jvp, call.jaxpr.debug_info)
     def to_vmap_over_extra_batched_dims(primals, tangents):
       return api.jvp(to_jvp, primals, tangents)
 

--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -63,7 +63,7 @@ def _initial_style_open_jaxpr(fun: Callable,
 def _initial_style_jaxpr(fun: Callable,
                          in_tree: PyTreeDef,
                          in_avals: Sequence[core.AbstractValue],
-                         debug_info: core.DebugInfo):
+                         debug_info: core.DebugInfo) -> tuple[core.ClosedJaxpr, Sequence[Any], PyTreeDef]:
   jaxpr, consts, out_tree = _initial_style_open_jaxpr(
       fun, in_tree, in_avals, debug_info)
   closed_jaxpr = pe.close_jaxpr(pe.convert_constvars_jaxpr(jaxpr))

--- a/jax/_src/pallas/core.py
+++ b/jax/_src/pallas/core.py
@@ -502,7 +502,10 @@ class BlockSpec:
   ) -> BlockMapping:
     if self.index_map is None:
       index_map_func = default_index_map(len(array_aval.shape))
-      api_util.save_wrapped_fun_sourceinfo(index_map_func, default_index_map)
+      index_map_dbg = api_util.debug_info("pallas_call index_map",
+                                          default_index_map, (),{}
+                                          )._replace(arg_names=("",) * len(index_map_avals))
+      api_util.save_wrapped_fun_debug_info(index_map_func, index_map_dbg)
     else:
       index_map_func = self.index_map
     if self.block_shape is None:


### PR DESCRIPTION
Several loop constructs (`fori_loop`, `while`) are implemented in terms of scan and we transform internally the user-provided loop body to match the API of scan. We want to make sure that the debug info matches the user-provided function, not the manufactured scan body.

To achieve this we construct the debug info for the user provided function and we attach it to the attribute `__fun_debug_info__` of the manufactured scan body.

Also, refactor for_loop.scan to trace its argument only once.

Previously, the `f` argument for `for_loop.scap` was traced twice, once to process the initial values and then again in the scan loop. Not only is this wastefull, but in the second tracing the `arg_names` part of the debug info is messed up. See, e.g., the change in the escaped tracer debug info in the `debug_info_test::test_grad_scan`.