### PR TITLE
Finalize a number of deprecations for JAX v0.7.0

### DIFF
--- a/jax/dlpack.py
+++ b/jax/dlpack.py
@@ -24,13 +24,13 @@ from jax._src.dlpack import (
 _deprecations = {
     "to_dlpack": (
         (
-            "jax.dlpack.to_dlpack was deprecated in JAX v0.6.0 and will be"
+            "jax.dlpack.to_dlpack was deprecated in JAX v0.6.0 and"
             " removed in JAX v0.7.0. Please use the newer DLPack API based on"
             " __dlpack__ and __dlpack_device__ instead. Typically, you can pass"
             " a JAX array directly to the `from_dlpack` function of another"
             " framework without using `to_dlpack`."
         ),
-        jax._src.dlpack.to_dlpack,
+        None,
     ),
 }
 

--- a/jax/lib/xla_client.py
+++ b/jax/lib/xla_client.py
@@ -78,6 +78,14 @@ _deprecations = {
         ),
         None,
     ),
+    # Finalized for JAX v0.7.0
+    "heap_profile": (
+        (
+            "jax.lib.xla_client.heap_profile was deprecated in JAX v0.6.0 and"
+            " removed in JAX v0.7.0"
+        ),
+        None,
+    ),
     # Added April 4 2025.
     "get_topology_for_devices": (
         (
@@ -85,13 +93,6 @@ _deprecations = {
             " v0.6.0 and will be removed in JAX v0.7.0"
         ),
         _xc.get_topology_for_devices,
-    ),
-    "heap_profile": (
-        (
-            "jax.lib.xla_client.heap_profile was deprecated in JAX v0.6.0 and"
-            " will be removed in JAX v0.7.0"
-        ),
-        _heap_profile,
     ),
     "mlir_api_version": (
         (

--- a/jax/lib/xla_extension.py
+++ b/jax/lib/xla_extension.py
@@ -16,6 +16,7 @@ import jax._src.lib
 from jax._src.lib import _jax
 
 _deprecations = {
+    # Finalized for JAX v0.6.0
     "ArrayImpl": (
         (
             "jax.lib.xla_extension.ArrayImpl has been removed; use jax.Array"
@@ -30,53 +31,77 @@ _deprecations = {
         ),
         None,
     ),
-    # Deprecated March 26 2025.
+    # Finalized for JAX v0.7.0
+    "Device": (
+        (
+            "jax.lib.xla_extension.Device was deprecated in JAX v0.6.0"
+            " and removed in JAX v0.7.0; use jax.Device instead."
+        ),
+        None,
+    ),
     "DistributedRuntimeClient": (
         (
-            "jax.lib.xla_extension.DistributedRuntimeClient is"
-            " deprecated; use jax.distributed instead."
+            "jax.lib.xla_extension.DistributedRuntimeClient deprecated in JAX"
+            " v0.6.0 and removed in JAX v0.7.0; use jax.distributed instead."
         ),
-        _jax.DistributedRuntimeClient,
+        None,
+    ),
+    "HloModule": (
+        (
+            "jax.lib.xla_extension.HloModule deprecated in JAX v0.6.0"
+            " and removed in JAX v0.7.0."
+        ),
+        None,
+    ),
+    "OpSharding": (
+        (
+            "jax.lib.xla_extension.OpSharding deprecated in JAX v0.6.0"
+            " and removed in JAX v0.7.0."
+        ),
+        None,
+    ),
+    "PjitFunctionCache": (
+        (
+            "jax.lib.xla_extension.PjitFunctionCache was deprecated in JAX v0.6.0"
+            " and removed in JAX v0.7.0."
+        ),
+        None,
     ),
     "get_distributed_runtime_client": (
         (
-            "jax.lib.xla_extension.get_distributed_runtime_client is"
-            " deprecated; use jax.distributed instead."
+            "jax.lib.xla_extension.get_distributed_runtime_client was deprecated"
+            " in JAX v0.6.0 and removed in JAX v0.7.0; use jax.distributed instead."
         ),
-        _jax.get_distributed_runtime_client,
+       None,
     ),
     "get_distributed_runtime_service": (
         (
-            "jax.lib.xla_extension.get_distributed_runtime_service is"
-            " deprecated; use jax.distributed instead."
+            "jax.lib.xla_extension.get_distributed_runtime_service was deprecated"
+            " in JAX v0.6.0 and removed in JAX v0.7.0; use jax.distributed instead."
         ),
-        _jax.get_distributed_runtime_service,
+        None,
     ),
-    "Device": (
-        "jax.lib.xla_extension.Device is deprecated; use jax.Device instead.",
-        _jax.Device,
+    "jax_jit": (
+        "jax.lib.xla_extension.jax_jit deprecated in JAX v0.6.0 and removed in JAX v0.7.0.",
+        None,
     ),
-    "PjitFunctionCache": (
-        "jax.lib.xla_extension.PjitFunctionCache is deprecated.",
-        _jax.PjitFunctionCache,
+    "pmap_lib": (
+        "jax.lib.xla_extension.pmap_lib deprecated in JAX v0.6.0 and removed in JAX v0.7.0.",
+       None
     ),
+    "pytree": (
+        "jax.lib.xla_extension.pytree deprecated in JAX v0.6.0 and removed in JAX v0.7.0.",
+        None,
+    ),
+    # Deprecated March 26 2025.
     "ifrt_proxy": (
         "jax.lib.xla_extension.ifrt_proxy is deprecated.",
         _jax.ifrt_proxy,
     ),
-    "jax_jit": (
-        "jax.lib.xla_extension.jax_jit is deprecated.",
-        _jax.jax_jit,
-    ),
     "mlir": ("jax.lib.xla_extension.mlir is deprecated.", _jax.mlir),
-    "pmap_lib": ("jax.lib.xla_extension.pmap_lib is deprecated.", _jax.pmap_lib),
     "profiler": (
         "jax.lib.xla_extension.profiler is deprecated.",
         jax._src.lib._profiler,
-    ),
-    "pytree": (
-        "jax.lib.xla_extension.pytree is deprecated.",
-        _jax.pytree,
     ),
     "hlo_module_cost_analysis": (
         "jax.lib.xla_extension.hlo_module_cost_analysis is deprecated.",
@@ -86,17 +111,9 @@ _deprecations = {
         "jax.lib.xla_extension.hlo_module_to_dot_graph is deprecated.",
         _jax.hlo_module_to_dot_graph,
     ),
-    "HloModule": (
-        "jax.lib.xla_extension.HloModule is deprecated.",
-        _jax.HloModule,
-    ),
     "HloPrintOptions": (
         "jax.lib.xla_extension.HloPrintOptions is deprecated.",
         _jax.HloPrintOptions,
-    ),
-    "OpSharding": (
-        "jax.lib.xla_extension.OpSharding is deprecated.",
-        _jax.OpSharding,
     ),
     "PjitFunction": (
         "jax.lib.xla_extension.PjitFunction is deprecated.",

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -48,7 +48,6 @@ from jax._src.tree_util import (
     PyTreeDef as PyTreeDef,
     SequenceKey as SequenceKey,
     all_leaves as all_leaves,
-    build_tree as _deprecated_build_tree,
     default_registry as default_registry,
     keystr as keystr,
     register_dataclass as register_dataclass,
@@ -78,10 +77,10 @@ _deprecations = {
     # Added March 21, 2025:
     "build_tree": (
         (
-            "jax.tree_util.build_tree is deprecated. Use jax.tree.unflatten"
-            " instead."
+            "jax.tree_util.build_tree was deprecated in JAX v0.6.0 and removed in"
+            " JAX v0.7.0. Use jax.tree.unflatten instead."
         ),
-        _deprecated_build_tree,
+        None
     ),
 }
 

--- a/jax/util.py
+++ b/jax/util.py
@@ -20,107 +20,83 @@ import jax._src.util
 
 
 _deprecations = {
+    # Finalized in JAX v0.7.0; remove entries in JAX v0.8.0
     "to_dlpack": (
         (
-            "jax.dlpack.to_dlpack was deprecated in JAX v0.6.0 and will be"
+            "jax.dlpack.to_dlpack was deprecated in JAX v0.6.0 and"
             " removed in JAX v0.7.0. Please use the newer DLPack API based on"
             " __dlpack__ and __dlpack_device__ instead. Typically, you can pass"
             " a JAX array directly to the `from_dlpack` function of another"
             " framework without using `to_dlpack`."
         ),
-        jax._src.dlpack.to_dlpack,
+        None,
     ),
     "HashableFunction": (
         (
-            "HashableFunction was deprecated in JAX v0.6.0 and will be removed"
+            "HashableFunction was deprecated in JAX v0.6.0 and removed"
             " in JAX v0.7.0."
         ),
-        jax._src.util.HashableFunction,
+        None,
     ),
     "as_hashable_function": (
         (
-            "as_hashable_function was deprecated in JAX v0.6.0 and will be"
+            "as_hashable_function was deprecated in JAX v0.6.0 and"
             " removed in JAX v0.7.0."
         ),
-        jax._src.util.as_hashable_function,
+        None,
     ),
     "cache": (
-        "cache was deprecated in JAX v0.6.0 and will be removed in JAX v0.7.0.",
-        jax._src.util.cache,
+        "cache was deprecated in JAX v0.6.0 and removed in JAX v0.7.0.",
+        None,
     ),
     "safe_map": (
-        (
-            "safe_map was deprecated in JAX v0.6.0 and will be removed in JAX"
-            " v0.7.0."
-        ),
-        jax._src.util.safe_map,
+        "safe_map was deprecated in JAX v0.6.0 and removed in JAX v0.7.0.",
+        None,
     ),
     "safe_zip": (
         (
-            "safe_zip was deprecated in JAX v0.6.0 and will be removed in JAX"
-            " v0.7.0."
+            "safe_zip was deprecated in JAX v0.6.0 and removed in JAX v0.7.0."
         ),
-        jax._src.util.safe_zip,
+        None,
     ),
     "split_dict": (
-        (
-            "split_dict was deprecated in JAX v0.6.0 and will be removed in JAX"
-            " v0.7.0."
-        ),
-        jax._src.util.split_dict,
+        "split_dict was deprecated in JAX v0.6.0 and removed in JAX v0.7.0.",
+        None,
     ),
     "split_list": (
-        (
-            "split_list was deprecated in JAX v0.6.0 and will be removed in JAX"
-            " v0.7.0."
-        ),
-        jax._src.util.split_list,
+        "split_list was deprecated in JAX v0.6.0 and removed in JAX v0.7.0.",
+        None,
     ),
     "split_list_checked": (
         (
-            "split_list_checked was deprecated in JAX v0.6.0 and will be"
+            "split_list_checked was deprecated in JAX v0.6.0 and"
             " removed in JAX v0.7.0."
         ),
-        jax._src.util.split_list_checked,
+        None,
     ),
     "split_merge": (
-        (
-            "split_merge was deprecated in JAX v0.6.0 and will be removed in"
-            " JAX v0.7.0."
-        ),
-        jax._src.util.split_merge,
+        "split_merge was deprecated in JAX v0.6.0 and removed in JAX v0.7.0.",
+        None,
     ),
     "subvals": (
-        (
-            "subvals was deprecated in JAX v0.6.0 and will be removed in JAX"
-            " v0.7.0."
-        ),
-        jax._src.util.subvals,
+        "subvals was deprecated in JAX v0.6.0 and removed in JAX v0.7.0.",
+        None,
     ),
     "toposort": (
-        (
-            "toposort was deprecated in JAX v0.6.0 and will be removed in JAX"
-            " v0.7.0."
-        ),
-        jax._src.util.toposort,
+        "toposort was deprecated in JAX v0.6.0 and removed in JAX v0.7.0.",
+        None,
     ),
     "unzip2": (
-        (
-            "unzip2 was deprecated in JAX v0.6.0 and will be removed in JAX"
-            " v0.7.0."
-        ),
-        jax._src.util.unzip2,
+        "unzip2 was deprecated in JAX v0.6.0 and removed in JAX v0.7.0.",
+        None,
     ),
     "wrap_name": (
-        (
-            "wrap_name was deprecated in JAX v0.6.0 and will be removed in JAX"
-            " v0.7.0."
-        ),
-        jax._src.util.wrap_name,
+        "wrap_name was deprecated in JAX v0.6.0 and removed in JAX v0.7.0.",
+        None,
     ),
     "wraps": (
-        "wraps was deprecated in JAX v0.6.0 and will be removed in JAX v0.7.0.",
-        jax._src.util.wraps,
+        "wraps was deprecated in JAX v0.6.0 and removed in JAX v0.7.0.",
+        None,
     ),
 }
 


### PR DESCRIPTION
This PR deliberately leaves type registrations untouched; I'll remove those in a followup after ensuring their removal doesn't lead to build breakages.