### PR TITLE
disable cudnn sdpa on blackwell gb300

### DIFF
--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -363,6 +363,10 @@ def check_is_flash_attention(
         _, T, _, H = query.shape
         _, S, _, _ = key.shape
 
+    if is_cuda_compute_capability_equal("10.3"):
+      # cudnn will fallback to ampere kernels on 10.3 which is not ideal
+      raise NotImplementedError("Unsupported compute capability 10.3.")
+
     # Flash attention conditions
     if is_fp8:
         # FP8 specific conditions

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -265,6 +265,8 @@ class DotProductAttentionTest(jtu.JaxTestCase):
       return
     if cudnn_version < 8904:
       self.skipTest("Requires >= cuDNN 8.9.4")
+    if jtu.is_cuda_compute_capability_equal("10.3"):
+      self.skipTest("Cudnn doesn't support compute_cap 10.3.")
     if not jtu.is_cuda_compute_capability_at_least("8.0"):
       self.skipTest("Requires at least Ampere arch")
 
@@ -922,6 +924,8 @@ class DotProductAttentionF8Test(jtu.JaxTestCase):
       return
     if cudnn_version < 90100:
       self.skipTest("Requires >= cuDNN 9.1.0")
+    if jtu.is_cuda_compute_capability_equal("10.3"):
+      self.skipTest("Cudnn doesn't support compute_cap 10.3.")
     if not jtu.is_cuda_compute_capability_at_least("9.0"):
       self.skipTest("Requires at least Hopper arch")
 


### PR DESCRIPTION
cudnn sdpa kernels on blackwell is not forward compatible on gb300(sm103). 