### PR TITLE
Add jax.nn.min_max_normalize.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * `jax.extend.core.primitives.pjit_p` has been renamed to `jit_p`, although
     `pjit_p` is still exported as an alias for the time being.
   * Added {func}`jax.tree.reduce_associative`.
+  * Added {func}`jax.nn.min_max_normalize`, which implements min-max normalization.
 
 * Breaking changes:
   * {func}`jax.jit` now requires `fun` to be passed by position, and additional

--- a/docs/jax.nn.rst
+++ b/docs/jax.nn.rst
@@ -52,6 +52,7 @@ Other functions
     log_softmax
     logsumexp
     standardize
+    min_max_normalize
     one_hot
     dot_product_attention
     scaled_matmul

--- a/jax/nn/__init__.py
+++ b/jax/nn/__init__.py
@@ -33,6 +33,7 @@ from jax._src.nn.functions import (
   log_softmax as log_softmax,
   logsumexp as logsumexp,
   standardize as standardize,
+  min_max_normalize as min_max_normalize,
   one_hot as one_hot,
   relu as relu,
   identity as identity,

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -627,6 +627,27 @@ class NNFunctionsTest(jtu.JaxTestCase):
 
     self.assertAllClose(out_masked, out_filtered)
 
+  def testMinMaxNormalizeWhereMask(self):
+    x = jnp.array([5.5, 1.3, -4.2, 0.9])
+    m = jnp.array([True, False, True, True])
+    x_filtered = jnp.take(x, jnp.array([0, 2, 3]))
+
+    out_masked = jnp.take(nn.min_max_normalize(x, where=m), jnp.array([0, 2, 3]))
+    out_filtered = nn.min_max_normalize(x_filtered)
+
+    self.assertAllClose(out_masked, out_filtered)
+
+  def testMinMaxNormalize(self):
+    x = jnp.array([5.5, 1.3, -4.2, 0.9])
+    m = jnp.array([True, False, True, True])
+    y = nn.min_max_normalize(x, where=m)
+
+    y_min = y.min(where=m, initial=jnp.inf)
+    y_max = y.max(where=m, initial=-jnp.inf)
+
+    self.assertAllClose(y_min, 0.0)
+    self.assertAllClose(y_max, 1.0)
+
   def testOneHot(self):
     actual = nn.one_hot(jnp.array([0, 1, 2]), 3)
     expected = jnp.array([[1., 0., 0.],


### PR DESCRIPTION
Adds a function `min_max_normalize` to [jax.nn](https://docs.jax.dev/en/latest/jax.nn.html) that applies [min-max normalization](https://en.wikipedia.org/wiki/Feature_scaling#Rescaling_(min-max_normalization)).

For context, see https://github.com/jax-ml/jax/issues/20556#issuecomment-2954329518.