### PR TITLE
Add entry to .gitignore to ignore build produced by 'pip install --config-settings editable-mode=strict -e .'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.whl
 /build/lib
 /build/bazel*
+/build/__editable__.jax-*
 /dist/
 .ipynb_checkpoints
 /bazel-*


### PR DESCRIPTION
Adds an entry to the [gitignore](https://github.com/jax-ml/jax/blob/main/.gitignore) file to ignore the folder created by

```shell
pip install --config-settings editable-mode=strict -e .
```

(for example, `build/__editable__.jax-0.6.3.dev20250618+8522175-py3-none-any/`) under the [build](https://github.com/jax-ml/jax/tree/main/build) folder.