### PR TITLE
Simplify handling of closed-over constants in Jaxpr (no. 1)

### DIFF
--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -1111,6 +1111,8 @@ def _array_mlir_constant_handler(val):
 
 mlir.register_constant_handler(ArrayImpl, _array_mlir_constant_handler)
 
+if config.use_simplified_jaxpr_constants.value:
+  core.literalable_types.add(ArrayImpl)
 
 # NOTE(skye): we could refactor to generate _multi_slice parameters directly
 # from the input ShardingSpec, rather than the indices. However, this would

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1106,6 +1106,15 @@ use_direct_linearize = bool_state(
     help=('Use direct linearization instead JVP followed by partial eval'),
     include_in_jit_key=True)
 
+use_simplified_jaxpr_constants = bool_state(
+    name='jax_use_simplified_jaxpr_constants',
+    default=False,
+    help=('Enable a simplification of the handling of closed-over constants '
+          'in Jaxpr. The value `True` enables the new behavior. '
+          'This flag will exist only briefly, while we transition '
+          'users. See https://github.com/jax-ml/jax/pull/29600.'
+          'DO NOT RELY ON THIS FLAG.'))
+
 # TODO make it so people don't use this, this is internal...
 _check_vma = bool_state(
     name='check_vma',

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -505,10 +505,15 @@ class Literal:
   def __repr__(self):
     return f'{self.val}'
 
+# The types of constants that can be used with core.Literal. Other constants
+# end up as `constvars`.
 literalable_types: set[type] = set()
 
 def is_literalable(x: Any) -> bool:
-  return type(x) in dtypes.python_scalar_dtypes or (type(x) in literalable_types and not np.shape(x))
+  for t in type(x).__mro__:
+    if t in literalable_types:
+      return (not np.shape(x) or config.use_simplified_jaxpr_constants.value)
+  return False
 
 Atom = Union[Var, Literal]
 
@@ -3081,7 +3086,7 @@ def _check_jaxpr(
       for eff in eqn.effects:
         if isinstance(eff, effects.JaxprInputEffect):
           eqn_invar = eqn.invars[eff.input_index]
-          if eqn_invar in mut_arrays:
+          if type(eqn_invar) is Literal or eqn_invar in mut_arrays:
             continue
           if (jaxpr_index := in_idx.get(eqn_invar, sentinel)) is sentinel:
             raise JaxprTypeError(

--- a/jax/_src/effects.py
+++ b/jax/_src/effects.py
@@ -62,9 +62,13 @@ class Effect:
 Effects = Set[Effect]
 
 class JaxprInputEffect(Effect):
-  """A side-effect associated with the input of a jaxpr.
+  """A side-effect associated with the input of a `JaxprEqn` or a `Jaxpr`.
 
-  Note that the `input_index` includes constvars.
+  This is used as a base class for effects associated with inputs, e.g.,
+  reading/writing from mutable inputs.
+
+  When used in a `JaxprEqn`, `input_index` refers to `eqn.invars`.
+  When used in a `Jaxpr`, `input_index` refers to `jaxpr.constvars + jaxpr.invars`.
   """
 
   def __init__(self, input_index: Any):

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1733,7 +1733,7 @@ def make_jaxpr_effects(constvars, invars, outvars, eqns) -> effects.Effects:
               "\n Jaxpr: "
               f"{core.Jaxpr(constvars, invars, outvars, eqns, set())}")
         eqn_invar = eqn.invars[eff.input_index]
-        if eqn_invar in mut_arrays:
+        if type(eqn_invar) is core.Literal or eqn_invar in mut_arrays:
           continue
         if (input_index := all_vars.get(eqn_invar, sentinel)) is sentinel:
           # TODO(mattjj): ask for forgiveness

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -1020,7 +1020,9 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
   def test_shared_constants_under_scan(self):
     # See https://github.com/jax-ml/jax/issues/7992.
     if config.jax2tf_default_native_serialization.value:
-      raise unittest.SkipTest("shared constants tests not interesting for native serialization")
+      self.skipTest("shared constants tests not interesting for native serialization")
+    if config.use_simplified_jaxpr_constants.value:
+      self.skipTest("shared constants tests broken with new handling of constants")
     const_size = 512
     const = np.random.uniform(size=const_size).astype(np.float32)  # A shared constant
     xs = np.ones((8, const_size), dtype=np.float32)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6084,7 +6084,10 @@ class RematTest(jtu.JaxTestCase):
     res = saved_residuals(f, (2., 3.), y=4.)
     self.assertLen(res, 6)
     self.assertEqual(res[0][0].shape, (1,))
-    self.assertEqual(res[0][1], "from a constant")
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertEqual(res[0][1], "from a literal")
+    else:
+      self.assertEqual(res[0][1], "from a constant")
     self.assertEqual(res[1][0].shape, ())
     self.assertEqual(res[1][1], "from the argument x[0]")
     self.assertEqual(res[2][0].shape, ())
@@ -6103,18 +6106,22 @@ class RematTest(jtu.JaxTestCase):
       return z * ((x1 * x2) * y) * np.array([3.])
 
     res = saved_residuals(f, (2., 3.), y=4.)
-    self.assertLen(res, 6)
-    self.assertEqual(res[0][0].shape, (1,))
-    self.assertEqual(res[0][1], "from a constant")
+    if config.use_simplified_jaxpr_constants.value:
+      base_res_idx = 0
+    else:
+      self.assertEqual(res[0][1], "from a constant")
+      self.assertEqual(res[0][0].shape, (1,))
+      res.pop(0)
+    self.assertLen(res, 5)
+    self.assertEqual(res[0][0].shape, ())
+    self.assertEqual(res[0][1], "from the argument x[0]")
     self.assertEqual(res[1][0].shape, ())
-    self.assertEqual(res[1][1], "from the argument x[0]")
+    self.assertEqual(res[1][1], "from the argument x[1]")
     self.assertEqual(res[2][0].shape, ())
-    self.assertEqual(res[2][1], "from the argument x[1]")
+    self.assertEqual(res[2][1], "from the argument y")
     self.assertEqual(res[3][0].shape, ())
-    self.assertEqual(res[3][1], "from the argument y")
+    self.assertStartsWith(res[3][1], "output of jitted function 'f'")
     self.assertEqual(res[4][0].shape, ())
-    self.assertStartsWith(res[4][1], "output of jitted function 'f'")
-    self.assertEqual(res[5][0].shape, ())
 
   @parameterized.named_parameters(
       {"testcase_name": f"{suffix}", "remat": remat}
@@ -6779,7 +6786,10 @@ class JaxprTest(jtu.JaxTestCase):
       return (x, 1., np.zeros(1, dtype=jnp.float32))
 
     dtype = "f64" if config.enable_x64.value else "f32"
-    expected = f"{{ lambda a:f32[1]; b:f32[]. let  in (b, 1.0:{dtype}[], a) }}"
+    if config.use_simplified_jaxpr_constants.value:
+      expected = f"{{ lambda ; a:f32[]. let  in (a, 1.0:{dtype}[], [0.]:f32[1]) }}"
+    else:
+      expected = f"{{ lambda a:f32[1]; b:f32[]. let  in (b, 1.0:{dtype}[], a) }}"
     jaxpr = api.make_jaxpr(fun)(jnp.float32(0.))
     self.assertMultiLineStrippedEqual(expected, str(jaxpr))
 

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -1520,7 +1520,7 @@ class JaxExportTest(jtu.JaxTestCase):
     shardings_rev = NamedSharding(mesh_rev, jax.sharding.PartitionSpec(("i",)))
     input_no_shards = jnp.ones(shape=(jax.local_device_count(),))
     input = jnp.ones(shape=(jax.local_device_count(),), device=shardings)
-    input_rev = jax.device_put(input_no_shards, device=shardings_rev)
+    input_rev = jnp.ones(shape=(jax.local_device_count(),), device=shardings_rev)
 
     exp = export.export(pjit.pjit(f, in_shardings=shardings))(input)
     exp_rev = export.export(pjit.pjit(f, in_shardings=shardings_rev))(input_no_shards)

--- a/tests/for_loop_test.py
+++ b/tests/for_loop_test.py
@@ -282,9 +282,6 @@ class ForLoopTransformationTest(jtu.JaxTestCase):
       return for_loop.for_loop(x.shape[0], body, (x, jnp.zeros_like(x)))
     _, f_vjp = jax.linearize(f, jnp.ones((5, 2, 32)))
     jaxpr = jax.make_jaxpr(f_vjp)(jnp.ones((5, 2, 32)))
-    consts = [v.aval for v in jaxpr.jaxpr.constvars
-              if v.aval.shape == (2, 32)]
-    self.assertLen(consts, 2)
 
     def loss(A):
       def step(x, _):

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -29,6 +29,7 @@ import numpy as np
 
 import jax
 from jax._src import core
+from jax._src import config
 from jax import dtypes
 from jax import lax
 from jax import random
@@ -2787,10 +2788,13 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     x = jnp.asarray(rng.randn(32, 2, 32).astype('float32'))
     _, vjp_fun = jax.vjp(cumprod, x)
 
+    # TODO(mattjj): should we re-enable this check? The constants are now
+    # inlined in the Jaxprs, not easy to find them.
     # Need to spelunk into vjp_fun. This is fragile, and if it causes problems
     # just skip this test and make an issue for mattjj.
-    *_, ext_res = vjp_fun.args[0].args[0]
-    self.assertIs(ext_res, x)
+    if not config.use_simplified_jaxpr_constants.value:
+      *_, ext_res = vjp_fun.args[0].args[0]
+      self.assertIs(ext_res, x)
 
     if remat is not None:
       # TODO(mattjj): make the numpy.ndarray test pass w/ remat
@@ -3482,7 +3486,8 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       (final_ref, outs_ref), vjp = jax.vjp(partial(jax.lax.scan, body_fun), init_vals, xs)
       init_vals_bar_ref, xs_bar_ref = vjp((final, outs))
 
-    self.assertAllClose(final, final_ref, check_dtypes=False)
+    self.assertAllClose(final, final_ref, check_dtypes=False,
+                        atol=1e-13)
     self.assertAllClose(outs, outs_ref, check_dtypes=False)
     self.assertAllClose(xs_bar, xs_bar_ref, check_dtypes=False)
 

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -495,6 +495,8 @@ class PallasCallTest(PallasBaseTest):
     self.assertAllClose(pids[0:4], np.array([0] * 4, dtype=np.int32))
 
   def test_hoisted_consts(self):
+    if config.use_simplified_jaxpr_constants.value:
+      self.skipTest("TODO: decide if we want to keep these errors")
     # See https://github.com/jax-ml/jax/issues/21557.
     # to_store will be hoisted as a constant. Choose distinct shapes from in/outs.
     to_store = np.arange(128, dtype=np.float32).reshape((1, 128))
@@ -1173,6 +1175,8 @@ class ApiErrorTest(PallasBaseTest):
       f(a)
 
   def test_pallas_call_index_map_captures_consts(self):
+    if config.use_simplified_jaxpr_constants.value:
+      self.skipTest("TODO: decide if we want to keep these errors")
     a = np.arange(256, dtype=np.int32)
     index_map_result = np.array([0], dtype=np.int32)
     f = self.pallas_call(lambda x_ref, o1_ref: None,

--- a/tests/pallas/pallas_vmap_test.py
+++ b/tests/pallas/pallas_vmap_test.py
@@ -133,6 +133,8 @@ class PallasCallVmapTest(PallasBaseTest):
     np.testing.assert_allclose(out, out_ref)
 
   def test_vmap_with_hoisted_consts(self):
+    if config.use_simplified_jaxpr_constants.value:
+      self.skipTest("TODO: decide if we want to keep these errors")
     to_store = np.arange(128, dtype=np.float32).reshape((1, 128))
     x = np.arange(4 * 16 * 128, dtype=np.float32).reshape((4, 16, 128))
 

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -1674,8 +1674,10 @@ class ShardMapTest(jtu.JaxTestCase):
       self.assertIn('call @shmap_body', hlo_str)
       self.assertIn('call @shmap_body_0', hlo_str)
       self.assertIn('%arg0: tensor<1xf32>', hlo_str)
-      self.assertIn('"[None]"', hlo_str)
-      self.assertIn('%arg1: tensor<1xf32>', hlo_str)
+      if not config.use_simplified_jaxpr_constants.value:
+        # A constvar is turned into an argument with location None in @shmap_body
+        self.assertIn('"[None]"', hlo_str)
+        self.assertIn('%arg1: tensor<1xf32>', hlo_str)
       self.assertIn('"[(\'i\',)]"', hlo_str)
       self.assertIn(
           '-> (tensor<1xf32> {jax.result_info = "[(\'i\',)]"})', hlo_str


### PR DESCRIPTION
For context, see a general description of the issue and various solutions at #29679.

This PR is a partial implementation of "Attempt 1" from #29679. Note that at the moment this attempt is blocked because it ends up embedding constants too deep into `Jaxpr`, as described in #29679. I am keeping this around for a while, as a reference.

The plan is to simplify JAX to eliminate the `ClosedJaxpr` class, as follows:
 
 * introduce a configuration variable `JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS` with the
   default value `False` (to match old behavior). The changes listed below will be activated
   when the configuration variable is set to `True` (in #29600).
 * add support for `core.Literal` containing non-scalar literal constants. Change
   `core.is_literalable` to allow non-scalars `np.ndarray`. Add handling for
    closing over `ArrayImpl` as well. (in #29600)
 * change the tests that verify the actual presence of the constants (starting in #29600).
 * run the test suite to find places that include `ClosedJaxpr`
   with non-empty `constvars`. 
 * change the `Jaxpr` pretty-printing code to skip printing (large) literals. Today, those
   are represented as `constvars` for which we print the name but not the value. (in a future PR).
 * fix the implementation of [`mlir.check_jaxpr_constants`](https://github.com/jax-ml/jax/blob/c057c7cd6e533ec4d0100c89f9e2fe277ae7ec4b/jax/_src/interpreters/mlir.py#L1111) to look for large constants inside `core.Literal` instead of `constvars` (in a future PR).
 * change the code to use `Jaxpr` instead of `ClosedJaxpr` as parameters for
   higher-order primitives (in future PRs)
 * at this point we should not need `ClosedJaxpr`. Remove it (or deprecate it in preparation for removal).
 
Some remaining questions:
  * when we close over `ArrayImpl` with sharding, during lowering [we will extract the `ndarray`](https://github.com/jax-ml/jax/blob/c057c7cd6e533ec4d0100c89f9e2fe277ae7ec4b/jax/_src/array.py#L1098) and inline it into the HLO. Not only do we lose the sharding, but we increase the size of the code, and we will re-materialize the array. This is not a regression, it is already the case even before the changes in this PR.
  * to implement [check_jaxpr_constants](https://github.com/jax-ml/jax/blob/c057c7cd6e533ec4d0100c89f9e2fe277ae7ec4b/jax/_src/interpreters/mlir.py#L1111) we'd have to scan all the eqns to look for input `core.Literal`. Previously, it was easy to find all non-scalar constants at the top-level of a `Jaxpr`. As an optimization, we may want to put the check for large constants at the end of lowering the Jaxpr, and have the lowering code accumulate the total sum of the constants.
  * JAX has an [`JaxprInputEffect`](https://github.com/jax-ml/jax/blob/c057c7cd6e533ec4d0100c89f9e2fe277ae7ec4b/jax/_src/effects.py#L64) that is sensitive to `constvars`. These effects are used to record effects associated with Jaxpr inputs. They are ignored when the input is an array constant.
  * The new Pallas fuser code seems to rely in a significant way on how non-scalars are returned as constants. See, e.g., [get_fusion_values](https://github.com/jax-ml/jax/blob/c057c7cd6e533ec4d0100c89f9e2fe277ae7ec4b/jax/_src/pallas/fuser/block_spec.py#L595). TODO: understand the significance of this.
  * In Pallas we had [added code](https://github.com/jax-ml/jax/blob/c057c7cd6e533ec4d0100c89f9e2fe277ae7ec4b/jax/_src/pallas/pallas_call.py#L1213) to detect that kernels and index maps close over non-scalar constants, and to raise an error. TODO: can we eliminate that check, or should we check in another way whether we close over non-scalar constants?

As a future cleanup enabled by this, we can explore getting rid of `Jaxpr.constvars` which now would be non-empty
only for top-level Jaxprs, where it should be possible to move them over to `invars` (as we do in [autodidax](https://github.com/jax-ml/jax/blob/c057c7cd6e533ec4d0100c89f9e2fe277ae7ec4b/docs/autodidax.py#L1023)).