### PR TITLE
fixed the behavior of `jnp.cov` when `rowvar=True`

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -9104,7 +9104,7 @@ def cov(m: ArrayLike, y: ArrayLike | None = None, rowvar: bool = True,
     raise ValueError("m has more than 2 dimensions")  # same as numpy error
 
   X = atleast_2d(m)
-  if not rowvar and X.shape[0] != 1:
+  if not rowvar and m.ndim != 1:
     X = X.T
   if X.shape[0] == 0:
     return array([]).reshape(0, 0)

--- a/tests/lax_numpy_reducers_test.py
+++ b/tests/lax_numpy_reducers_test.py
@@ -690,6 +690,12 @@ class JaxNumpyReducerTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, atol=tol,
                           rtol=tol)
 
+  def testCovSingleRow(self):
+    x = jnp.ones((3, 1))
+    expected = jnp.cov(x, ddof=0, rowvar=True)
+    actual = jnp.cov(x.T, ddof=0, rowvar=False)
+    self.assertAllClose(actual, expected, atol=0, rtol=0)
+
   @jtu.sample_product(
     [dict(op=op, q_rng=q_rng)
       for (op, q_rng) in (


### PR DESCRIPTION
solves this issue: https://github.com/jax-ml/jax/issues/29571
The changes are completely similar to changing numpy: https://github.com/numpy/numpy/pull/27661