### PR TITLE
Deprecate jax.dtypes.SUPPORTED_DTYPES and add is_supported_dtype()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
       renamed to `Format`, `.format`, `.input_formats` and `.output_formats`
     * `DeviceLocalLayout`, `.device_local_layout` have been renamed to `Layout`
       and `.layout`
+* Deprecations:
+  * {obj}`jax.dlpack.SUPPORTED_DTYPES` is deprecated; please use the new
+    {func}`jax.dlpack.is_supported_dtype` function.
 
 ## JAX 0.6.2 (June 17, 2025)
 

--- a/docs/jax.dlpack.rst
+++ b/docs/jax.dlpack.rst
@@ -9,3 +9,4 @@
     :toctree: _autosummary
 
     from_dlpack
+    is_supported_dtype

--- a/jax/_src/dlpack.py
+++ b/jax/_src/dlpack.py
@@ -24,8 +24,9 @@ from jax._src.api import device_put
 from jax._src.lax.lax import _array_copy
 from jax._src.lib import xla_client
 from jax._src.sharding import Sharding
-from jax._src.typing import Array
-from jax._src.typing import DLDeviceType
+from jax._src.typing import Array, DLDeviceType, DTypeLike
+
+import numpy as np
 
 
 DLPACK_VERSION = (0, 8)
@@ -37,11 +38,22 @@ MIN_DLPACK_VERSION = (0, 5)
 # For example,
 # hash(jnp.float32) != hash(jnp.dtype(jnp.float32))
 # hash(jnp.float32) == hash(jnp.dtype(jnp.float32).type)
-# TODO(phawkins): Migrate to using dtypes instead of the scalar type objects.
+
+# TODO(vanderplas): remove this set
 SUPPORTED_DTYPES = frozenset({
     jnp.int8, jnp.int16, jnp.int32, jnp.int64, jnp.uint8, jnp.uint16,
     jnp.uint32, jnp.uint64, jnp.float16, jnp.bfloat16, jnp.float32,
     jnp.float64, jnp.complex64, jnp.complex128, jnp.bool_})
+
+SUPPORTED_DTYPES_SET = frozenset({np.dtype(dt) for dt in SUPPORTED_DTYPES})
+
+
+def is_supported_dtype(dtype: DTypeLike) -> bool:
+  """Check if dtype is supported by jax.dlpack."""
+  if dtype is None:
+    # NumPy will silently cast this to float64, which may be surprising.
+    raise TypeError(f"Expected a string or dtype-like object; got {dtype=}")
+  return np.dtype(dtype) in SUPPORTED_DTYPES_SET
 
 
 def _to_dlpack(x: Array, stream: int | Any | None,

--- a/jax/dlpack.py
+++ b/jax/dlpack.py
@@ -18,10 +18,20 @@ import jax._src.deprecations
 
 from jax._src.dlpack import (
   from_dlpack as from_dlpack,
+  is_supported_dtype as is_supported_dtype,
   SUPPORTED_DTYPES as SUPPORTED_DTYPES,
 )
 
 _deprecations = {
+    # Deprecated in JAX v0.7.0
+    "SUPPORTED_DTYPES": (
+        (
+            "jax.SUPPORTED_DTYPES is deprecated in JAX v0.7.0 and will be removed"
+            " in JAX v0.8.0. Use jax.dlpack.is_supported_dtype() instead."
+        ),
+        jax._src.dlpack.SUPPORTED_DTYPES
+    ),
+    # Finalized in JAX v0.7.0; remove in JAX v0.8.0
     "to_dlpack": (
         (
             "jax.dlpack.to_dlpack was deprecated in JAX v0.6.0 and"
@@ -38,7 +48,7 @@ _deprecations = {
 import typing as _typing
 
 if _typing.TYPE_CHECKING:
-  pass
+  SUPPORTED_DTYPES = jax._src.dlpack.SUPPORTED_DTYPES
 else:
   __getattr__ = jax._src.deprecations.deprecation_getattr(
       __name__, _deprecations

--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -345,7 +345,7 @@ def _call_tf_impl(*args_jax_flat, callable_flat_tf, **_):
   def _arg_jax_to_tf(arg_jax):
     if (isinstance(arg_jax, jax.Array) and
         list(arg_jax.devices())[0].platform in _DLPACK_PLATFORMS and
-        arg_jax.dtype.type in dlpack.SUPPORTED_DTYPES):
+        dlpack.is_supported_dtype(arg_jax.dtype)):
       return tf.experimental.dlpack.from_dlpack(arg_jax.__dlpack__())
     # The following avoids copies to the host on CPU, always for Array
     # and even for ndarray if they are sufficiently aligned.
@@ -362,7 +362,7 @@ def _call_tf_impl(*args_jax_flat, callable_flat_tf, **_):
 
   def _res_tf_to_jax(res_tf: TfVal):
     res_tf, jax_dtype = jax2tf_internal._tfval_to_tensor_jax_dtype(res_tf)
-    if isinstance(res_tf, tf.Tensor) and jax_dtype.type in dlpack.SUPPORTED_DTYPES:
+    if isinstance(res_tf, tf.Tensor) and dlpack.is_supported_dtype(jax_dtype):
       res_tf_platform = tf.DeviceSpec.from_string(res_tf.backing_device).device_type
       res_jax_platform = res_tf_platform.lower()
       if res_jax_platform in _DLPACK_PLATFORMS:

--- a/jax/experimental/jax2tf/tests/call_tf_test.py
+++ b/jax/experimental/jax2tf/tests/call_tf_test.py
@@ -22,12 +22,12 @@ from absl import logging
 from absl.testing import absltest
 from absl.testing import parameterized
 import jax
-from jax import dlpack
 from jax import dtypes
 from jax import export
 from jax import lax
 from jax import numpy as jnp
 from jax._src import config
+from jax._src import dlpack
 from jax._src import test_util as jtu
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import hlo
@@ -836,8 +836,8 @@ class CallTfTest(tf_test_util.JaxToTfTestCase):
         self.assertAllClose(res, f_jax(x))
 
   @parameterized.named_parameters(
-      {"testcase_name": f"_type={type_.__name__}", "type_": type_}
-      for type_ in dlpack.SUPPORTED_DTYPES
+      {"testcase_name": f"_type={type_.name}", "type_": type_}
+      for type_ in dlpack.SUPPORTED_DTYPES_SET
   )
   def test_avoid_copy_between_gpu_and_cpu(self, type_):
     try:
@@ -848,7 +848,7 @@ class CallTfTest(tf_test_util.JaxToTfTestCase):
       raise unittest.SkipTest("Test requires a GPU device.")
 
     def tf_fun(x):
-      if type_ == jnp.bool_:
+      if type_ == np.dtype('bool'):
         return tf.math.logical_or(x, True)
       else:
         return x + 1


### PR DESCRIPTION
The current set confusingly contains jax `ScalarMeta` objects instead of actual dtypes. This means for example that `jnp.float32 in SUPPORTED_DTYPES` returns `True`, but `np.dtype('float32') in SUPPORTED_DTYPES` returns `False`. Because dtypes are so commonly duck-typed, it's better for us to provide an API that handles dtype conversions automatically.