### PR TITLE
jax._src.numpy: avoid top-level imports

### DIFF
--- a/jax/_src/numpy/array_api_metadata.py
+++ b/jax/_src/numpy/array_api_metadata.py
@@ -21,11 +21,11 @@ from __future__ import annotations
 
 from types import ModuleType
 
-from jax._src.sharding import Sharding
-from jax._src.lib import xla_client as xc
 from jax._src import config
 from jax._src import dtypes as _dtypes
 from jax._src import xla_bridge as xb
+from jax._src.lib import xla_client as xc
+from jax._src.sharding import Sharding
 
 
 __array_api_version__ = '2024.12'

--- a/jax/_src/numpy/array_creation.py
+++ b/jax/_src/numpy/array_creation.py
@@ -19,7 +19,7 @@ from typing import Any, Literal, overload
 
 import numpy as np
 
-from jax._src.api import device_put, jit
+from jax._src import api
 from jax._src import core
 from jax._src import dtypes
 from jax._src.lax import lax
@@ -211,7 +211,7 @@ def full(shape: Any, fill_value: ArrayLike,
     shape = canonicalize_shape(shape)
     return lax.full(shape, fill_value, dtype, sharding=util.normalize_device_to_sharding(device))
   else:
-    return device_put(
+    return api.device_put(
         util._broadcast_to(asarray(fill_value, dtype=dtype), shape), device)
 
 
@@ -407,7 +407,7 @@ def full_like(a: ArrayLike | DuckTypedArray,
   else:
     shape = np.shape(a) if shape is None else shape  # type: ignore[arg-type]
     dtype = dtypes.result_type(a) if dtype is None else dtype
-    return device_put(
+    return api.device_put(
         util._broadcast_to(asarray(fill_value, dtype=dtype), shape), device)
 
 @overload
@@ -502,7 +502,7 @@ def linspace(start: ArrayLike, stop: ArrayLike, num: int = 50,
   axis = core.concrete_or_error(operator.index, axis, "'axis' argument of jnp.linspace")
   return _linspace(start, stop, num, endpoint, retstep, dtype, axis, device=device)
 
-@partial(jit, static_argnames=('num', 'endpoint', 'retstep', 'dtype', 'axis', 'device'))
+@partial(api.jit, static_argnames=('num', 'endpoint', 'retstep', 'dtype', 'axis', 'device'))
 def _linspace(start: ArrayLike, stop: ArrayLike, num: int = 50,
               endpoint: bool = True, retstep: bool = False,
               dtype: DTypeLike | None = None,
@@ -628,7 +628,7 @@ def logspace(start: ArrayLike, stop: ArrayLike, num: int = 50,
   axis = core.concrete_or_error(operator.index, axis, "'axis' argument of jnp.logspace")
   return _logspace(start, stop, num, endpoint, base, dtype, axis)
 
-@partial(jit, static_argnames=('num', 'endpoint', 'dtype', 'axis'))
+@partial(api.jit, static_argnames=('num', 'endpoint', 'dtype', 'axis'))
 def _logspace(start: ArrayLike, stop: ArrayLike, num: int = 50,
               endpoint: bool = True, base: ArrayLike = 10.0,
               dtype: DTypeLike | None = None, axis: int = 0) -> Array:
@@ -699,7 +699,7 @@ def geomspace(start: ArrayLike, stop: ArrayLike, num: int = 50, endpoint: bool =
   axis = core.concrete_or_error(operator.index, axis, "'axis' argument of jnp.geomspace")
   return _geomspace(start, stop, num, endpoint, dtype, axis)
 
-@partial(jit, static_argnames=('num', 'endpoint', 'dtype', 'axis'))
+@partial(api.jit, static_argnames=('num', 'endpoint', 'dtype', 'axis'))
 def _geomspace(start: ArrayLike, stop: ArrayLike, num: int = 50, endpoint: bool = True,
                dtype: DTypeLike | None = None, axis: int = 0) -> Array:
   """Implementation of geomspace differentiable in start and stop args."""

--- a/jax/_src/numpy/einsum.py
+++ b/jax/_src/numpy/einsum.py
@@ -19,13 +19,12 @@ from collections.abc import Callable, Sequence
 import numpy as np
 import opt_einsum
 
+from jax._src import api
 from jax._src import config
 from jax._src import core
 from jax._src import dtypes
-from jax._src.api import jit, named_call
 from jax._src.export import shape_poly
 from jax._src.lax import lax
-from jax._src.lax.lax import PrecisionLike
 from jax._src.numpy import util
 from jax._src.sharding_impls import canonicalize_sharding, NamedSharding
 from jax._src.typing import Array, ArrayLike, DTypeLike
@@ -46,7 +45,7 @@ def einsum(
     *operands: ArrayLike,
     out: None = None,
     optimize: str | bool | list[tuple[int, ...]] = "auto",
-    precision: PrecisionLike = None,
+    precision: lax.PrecisionLike = None,
     preferred_element_type: DTypeLike | None = None,
     _dot_general: Callable[..., Array] = lax.dot_general,
     out_sharding=None,
@@ -59,7 +58,7 @@ def einsum(
     *operands: ArrayLike | Sequence[Any],
     out: None = None,
     optimize: str | bool | list[tuple[int, ...]] = "auto",
-    precision: PrecisionLike = None,
+    precision: lax.PrecisionLike = None,
     preferred_element_type: DTypeLike | None = None,
     _dot_general: Callable[..., Array] = lax.dot_general,
     out_sharding=None,
@@ -71,7 +70,7 @@ def einsum(
     *operands,
     out: None = None,
     optimize: str | bool | list[tuple[int, ...]] = "auto",
-    precision: PrecisionLike = None,
+    precision: lax.PrecisionLike = None,
     preferred_element_type: DTypeLike | None = None,
     _dot_general: Callable[..., Array] = lax.dot_general,
     out_sharding=None,
@@ -310,9 +309,9 @@ def einsum(
 
   contractions = tuple((a, frozenset(b), c) for a, b, c, *_ in contractions)  # pytype: disable=attribute-error
 
-  jit_einsum = jit(_einsum, static_argnums=(1, 2, 3, 4, 5), inline=True)
+  jit_einsum = api.jit(_einsum, static_argnums=(1, 2, 3, 4, 5), inline=True)
   if spec is not None:
-    jit_einsum = named_call(jit_einsum, name=spec)
+    jit_einsum = api.named_call(jit_einsum, name=spec)
   operand_arrays = list(util.ensure_arraylike_tuple("einsum", operands))
   return jit_einsum(operand_arrays, contractions, precision,
                     preferred_element_type, _dot_general, out_sharding)

--- a/jax/_src/numpy/fft.py
+++ b/jax/_src/numpy/fft.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 import operator
+
 import numpy as np
 
 from jax._src import dtypes

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -18,19 +18,16 @@ from collections.abc import Sequence
 from functools import partial
 import itertools
 import math
-
-import numpy as np
 import operator
 from typing import Literal, NamedTuple, overload
 
-from jax import lax
+import numpy as np
 
-from jax._src.api import jit
+from jax._src import api
 from jax._src import config
-from jax._src.custom_derivatives import custom_jvp
 from jax._src import deprecations
-from jax._src.lax import lax as lax_internal
-from jax._src.lax.lax import PrecisionLike
+from jax._src.custom_derivatives import custom_jvp
+from jax._src.lax import lax
 from jax._src.lax import linalg as lax_linalg
 from jax._src.numpy import einsum
 from jax._src.numpy import indexing
@@ -73,7 +70,7 @@ def _symmetrize(x: Array) -> Array: return (x + _H(x)) / 2
 
 
 @export
-@partial(jit, static_argnames=['upper', 'symmetrize_input'])
+@partial(api.jit, static_argnames=['upper', 'symmetrize_input'])
 def cholesky(a: ArrayLike, *, upper: bool = False, symmetrize_input: bool = True) -> Array:
   """Compute the Cholesky decomposition of a matrix.
 
@@ -203,7 +200,7 @@ def svd(
 
 @export
 @partial(
-    jit,
+    api.jit,
     static_argnames=(
         "full_matrices",
         "compute_uv",
@@ -323,7 +320,7 @@ def svd(
 
 
 @export
-@partial(jit, static_argnames=('n',))
+@partial(api.jit, static_argnames=('n',))
 def matrix_power(a: ArrayLike, n: int) -> Array:
   """Raise a square matrix to an integer power.
 
@@ -404,7 +401,7 @@ def matrix_power(a: ArrayLike, n: int) -> Array:
 
 
 @export
-@jit
+@api.jit
 def matrix_rank(
   M: ArrayLike, rtol: ArrayLike | None = None, *,
   tol: ArrayLike | DeprecatedArg | None = DeprecatedArg()) -> Array:
@@ -509,7 +506,7 @@ def _slogdet_qr(a: Array) -> tuple[Array, Array]:
 
 
 @export
-@partial(jit, static_argnames=('method',))
+@partial(api.jit, static_argnames=('method',))
 def slogdet(a: ArrayLike, *, method: str | None = None) -> SlogdetResult:
   """
   Compute the sign and (natural) logarithm of the determinant of an array.
@@ -690,7 +687,7 @@ def _det_jvp(primals, tangents):
 
 
 @export
-@jit
+@api.jit
 def det(a: ArrayLike) -> Array:
   """
   Compute the determinant of an array.
@@ -773,7 +770,7 @@ def eig(a: ArrayLike) -> tuple[Array, Array]:
 
 
 @export
-@jit
+@api.jit
 def eigvals(a: ArrayLike) -> Array:
   """
   Compute the eigenvalues of a general matrix.
@@ -811,7 +808,7 @@ def eigvals(a: ArrayLike) -> Array:
 
 
 @export
-@partial(jit, static_argnames=('UPLO', 'symmetrize_input'))
+@partial(api.jit, static_argnames=('UPLO', 'symmetrize_input'))
 def eigh(a: ArrayLike, UPLO: str | None = None,
          symmetrize_input: bool = True) -> EighResult:
   """
@@ -869,7 +866,7 @@ def eigh(a: ArrayLike, UPLO: str | None = None,
 
 
 @export
-@partial(jit, static_argnames=('UPLO', 'symmetrize_input'))
+@partial(api.jit, static_argnames=('UPLO', 'symmetrize_input'))
 def eigvalsh(a: ArrayLike, UPLO: str | None = 'L', *,
              symmetrize_input: bool = True) -> Array:
   """
@@ -970,7 +967,7 @@ def pinv(a: ArrayLike, rtol: ArrayLike | None = None,
 
 
 @partial(custom_jvp, nondiff_argnums=(1, 2))
-@partial(jit, static_argnames=('hermitian'))
+@partial(api.jit, static_argnames=('hermitian'))
 def _pinv(a: ArrayLike, rtol: ArrayLike | None = None, hermitian: bool = False) -> Array:
   # Uses same algorithm as
   # https://github.com/numpy/numpy/blob/v1.17.0/numpy/linalg/linalg.py#L1890-L1979
@@ -1025,7 +1022,7 @@ def _pinv_jvp(rtol, hermitian, primals, tangents):
 
 
 @export
-@jit
+@api.jit
 def inv(a: ArrayLike) -> Array:
   """Return the inverse of a square matrix
 
@@ -1085,7 +1082,7 @@ def inv(a: ArrayLike) -> Array:
 
 
 @export
-@partial(jit, static_argnames=('ord', 'axis', 'keepdims'))
+@partial(api.jit, static_argnames=('ord', 'axis', 'keepdims'))
 def norm(x: ArrayLike, ord: int | str | None = None,
          axis: None | tuple[int, ...] | int = None,
          keepdims: bool = False) -> Array:
@@ -1226,7 +1223,7 @@ def qr(a: ArrayLike, mode: Literal["r"]) -> Array: ...
 def qr(a: ArrayLike, mode: str = "reduced") -> Array | QRResult: ...
 
 @export
-@partial(jit, static_argnames=('mode',))
+@partial(api.jit, static_argnames=('mode',))
 def qr(a: ArrayLike, mode: str = "reduced") -> Array | QRResult:
   """Compute the QR decomposition of an array
 
@@ -1310,7 +1307,7 @@ def qr(a: ArrayLike, mode: str = "reduced") -> Array | QRResult:
 
 
 @export
-@jit
+@api.jit
 def solve(a: ArrayLike, b: ArrayLike) -> Array:
   """Solve a linear system of equations.
 
@@ -1416,7 +1413,7 @@ def _lstsq(a: ArrayLike, b: ArrayLike, rcond: float | None, *,
     x = x.ravel()
   return x, resid, rank, s
 
-_jit_lstsq = jit(partial(_lstsq, numpy_resid=False))
+_jit_lstsq = api.jit(partial(_lstsq, numpy_resid=False))
 
 
 @export
@@ -1683,14 +1680,14 @@ def vector_norm(x: ArrayLike, /, *, axis: int | tuple[int, ...] | None = None, k
     raise ValueError(msg)
   else:
     abs_x = ufuncs.abs(x)
-    ord_arr = lax_internal._const(abs_x, ord)
-    ord_inv = lax_internal._const(abs_x, 1. / ord_arr)
+    ord_arr = lax._const(abs_x, ord)
+    ord_inv = lax._const(abs_x, 1. / ord_arr)
     out = reductions.sum(abs_x ** ord_arr, axis=axis, keepdims=keepdims)
     return ufuncs.power(out, ord_inv)
 
 @export
 def vecdot(x1: ArrayLike, x2: ArrayLike, /, *, axis: int = -1,
-           precision: PrecisionLike = None,
+           precision: lax.PrecisionLike = None,
            preferred_element_type: DTypeLike | None = None) -> Array:
   """Compute the (batched) vector conjugate dot product of two arrays.
 
@@ -1741,7 +1738,7 @@ def vecdot(x1: ArrayLike, x2: ArrayLike, /, *, axis: int = -1,
 
 @export
 def matmul(x1: ArrayLike, x2: ArrayLike, /, *,
-           precision: PrecisionLike = None,
+           precision: lax.PrecisionLike = None,
            preferred_element_type: DTypeLike | None = None) -> Array:
   """Perform a matrix multiplication.
 
@@ -1803,7 +1800,7 @@ def matmul(x1: ArrayLike, x2: ArrayLike, /, *,
 @export
 def tensordot(x1: ArrayLike, x2: ArrayLike, /, *,
               axes: int | tuple[Sequence[int], Sequence[int]] = 2,
-              precision: PrecisionLike = None,
+              precision: lax.PrecisionLike = None,
               preferred_element_type: DTypeLike | None = None) -> Array:
   """Compute the tensor dot product of two N-dimensional arrays.
 
@@ -2040,7 +2037,7 @@ def tensorsolve(a: ArrayLike, b: ArrayLike, axes: tuple[int, ...] | None = None)
 
 
 @export
-def multi_dot(arrays: Sequence[ArrayLike], *, precision: PrecisionLike = None) -> Array:
+def multi_dot(arrays: Sequence[ArrayLike], *, precision: lax.PrecisionLike = None) -> Array:
   """Efficiently compute matrix products between a sequence of arrays.
 
   JAX implementation of :func:`numpy.linalg.multi_dot`.
@@ -2132,7 +2129,7 @@ def multi_dot(arrays: Sequence[ArrayLike], *, precision: PrecisionLike = None) -
 
 
 @export
-@partial(jit, static_argnames=['p'])
+@partial(api.jit, static_argnames=['p'])
 def cond(x: ArrayLike, p=None):
   """Compute the condition number of a matrix.
 

--- a/jax/_src/numpy/polynomial.py
+++ b/jax/_src/numpy/polynomial.py
@@ -19,11 +19,11 @@ import operator
 
 import numpy as np
 
-from jax import lax
-from jax._src.api import jit
+from jax._src import api
 from jax._src import dtypes
 from jax._src import core
-from jax._src.lax import lax as lax_internal
+from jax._src.lax import control_flow
+from jax._src.lax import lax
 from jax._src.numpy.lax_numpy import (
     arange, argmin, array, atleast_1d, concatenate, convolve,
     diag, finfo, full, ones, roll, trim_zeros,
@@ -41,7 +41,7 @@ from jax._src.util import set_module
 export = set_module('jax.numpy')
 
 
-@jit
+@api.jit
 def _roots_no_zeros(p: Array) -> Array:
   # build companion matrix and find its eigenvalues (the roots)
   if p.size < 2:
@@ -51,7 +51,7 @@ def _roots_no_zeros(p: Array) -> Array:
   return linalg.eigvals(A)
 
 
-@jit
+@api.jit
 def _roots_with_zeros(p: Array, num_leading_zeros: Array | int) -> Array:
   # Avoid lapack errors when p is all zero
   p = _where(len(p) == num_leading_zeros, 1.0, p)
@@ -124,7 +124,7 @@ def roots(p: ArrayLike, *, strip_zeros: bool = True) -> Array:
 
 
 @export
-@partial(jit, static_argnames=('deg', 'rcond', 'full', 'cov'))
+@partial(api.jit, static_argnames=('deg', 'rcond', 'full', 'cov'))
 def polyfit(x: ArrayLike, y: ArrayLike, deg: int, rcond: float | None = None,
             full: bool = False, w: ArrayLike | None = None, cov: bool = False
             ) -> Array | tuple[Array, ...]:
@@ -280,7 +280,7 @@ def polyfit(x: ArrayLike, y: ArrayLike, deg: int, rcond: float | None = None,
 
   if full:
     assert rcond is not None
-    return c, resids, rank, s, lax_internal.asarray(rcond)
+    return c, resids, rank, s, lax.asarray(rcond)
   elif cov:
     Vbase = linalg.inv(dot(lhs.T, lhs))
     Vbase /= outer(scale, scale)
@@ -304,7 +304,7 @@ def polyfit(x: ArrayLike, y: ArrayLike, deg: int, rcond: float | None = None,
     return c
 
 @export
-@jit
+@api.jit
 def poly(seq_of_zeros: ArrayLike) -> Array:
   r"""Returns the coefficients of a polynomial for the given sequence of roots.
 
@@ -387,7 +387,7 @@ def poly(seq_of_zeros: ArrayLike) -> Array:
 
 
 @export
-@partial(jit, static_argnames=['unroll'])
+@partial(api.jit, static_argnames=['unroll'])
 def polyval(p: ArrayLike, x: ArrayLike, *, unroll: int = 16) -> Array:
   r"""Evaluates the polynomial at specific values.
 
@@ -446,12 +446,12 @@ def polyval(p: ArrayLike, x: ArrayLike, *, unroll: int = 16) -> Array:
   del p, x
   shape = lax.broadcast_shapes(p_arr.shape[1:], x_arr.shape)
   y = lax.full_like(x_arr, 0, shape=shape, dtype=x_arr.dtype)
-  y, _ = lax.scan(lambda y, p: (y * x_arr + p, None), y, p_arr, unroll=unroll)  # type: ignore[misc]
+  y, _ = control_flow.scan(lambda y, p: (y * x_arr + p, None), y, p_arr, unroll=unroll)  # type: ignore[misc]
   return y
 
 
 @export
-@jit
+@api.jit
 def polyadd(a1: ArrayLike, a2: ArrayLike) -> Array:
   r"""Returns the sum of the two polynomials.
 
@@ -509,7 +509,7 @@ def polyadd(a1: ArrayLike, a2: ArrayLike) -> Array:
 
 
 @export
-@partial(jit, static_argnames=('m',))
+@partial(api.jit, static_argnames=('m',))
 def polyint(p: ArrayLike, m: int = 1, k: int | ArrayLike | None = None) -> Array:
   r"""Returns the coefficients of the integration of specified order of a polynomial.
 
@@ -578,7 +578,7 @@ def polyint(p: ArrayLike, m: int = 1, k: int | ArrayLike | None = None) -> Array
 
 
 @export
-@partial(jit, static_argnames=('m',))
+@partial(api.jit, static_argnames=('m',))
 def polyder(p: ArrayLike, m: int = 1) -> Array:
   r"""Returns the coefficients of the derivative of specified order of a polynomial.
 
@@ -756,7 +756,7 @@ def polydiv(u: ArrayLike, v: ArrayLike, *, trim_leading_zeros: bool = False) -> 
 
 
 @export
-@jit
+@api.jit
 def polysub(a1: ArrayLike, a2: ArrayLike) -> Array:
   r"""Returns the difference of two polynomials.
 

--- a/jax/_src/numpy/sorting.py
+++ b/jax/_src/numpy/sorting.py
@@ -17,11 +17,10 @@ from collections.abc import Sequence
 
 import numpy as np
 
-from jax import lax
-
 from jax._src import api
 from jax._src import core
 from jax._src import dtypes
+from jax._src.lax import lax
 from jax._src.numpy import util
 from jax._src.util import canonicalize_axis, set_module
 from jax._src.typing import Array, ArrayLike

--- a/jax/_src/numpy/tensor_contractions.py
+++ b/jax/_src/numpy/tensor_contractions.py
@@ -20,12 +20,10 @@ from functools import partial
 
 import numpy as np
 
-from jax import lax
+from jax._src import api
 from jax._src import core
 from jax._src import dtypes
-from jax._src.api import jit
-from jax._src.lax import lax as lax_internal
-from jax._src.lax.lax import PrecisionLike
+from jax._src.lax import lax
 from jax._src.numpy import ufuncs
 from jax._src.numpy import util
 from jax._src.numpy.vectorize import vectorize
@@ -35,10 +33,10 @@ from jax._src.util import canonicalize_axis, set_module
 export = set_module('jax.numpy')
 
 @export
-@partial(jit, static_argnames=('precision', 'preferred_element_type', 'out_sharding'),
+@partial(api.jit, static_argnames=('precision', 'preferred_element_type', 'out_sharding'),
          inline=True)
 def dot(a: ArrayLike, b: ArrayLike, *,
-        precision: PrecisionLike = None,
+        precision: lax.PrecisionLike = None,
         preferred_element_type: DTypeLike | None = None,
         out_sharding=None) -> Array:
   """Compute the dot product of two arrays.
@@ -122,14 +120,14 @@ def dot(a: ArrayLike, b: ArrayLike, *,
                            precision=precision,
                            preferred_element_type=preferred_element_type,
                            out_sharding=out_sharding)
-  return lax_internal._convert_element_type(result, preferred_element_type,
-                                            output_weak_type)
+  return lax._convert_element_type(result, preferred_element_type,
+                                   output_weak_type)
 
 
 @export
-@partial(jit, static_argnames=('precision', 'preferred_element_type'), inline=True)
+@partial(api.jit, static_argnames=('precision', 'preferred_element_type'), inline=True)
 def matmul(a: ArrayLike, b: ArrayLike, *,
-           precision: PrecisionLike = None,
+           precision: lax.PrecisionLike = None,
            preferred_element_type: DTypeLike | None = None,
            ) -> Array:
   """Perform a matrix multiplication.
@@ -246,11 +244,11 @@ def matmul(a: ArrayLike, b: ArrayLike, *,
     a, b, (((np.ndim(a) - 1,), (np.ndim(b) - 1 - b_is_mat,)), (a_batch, b_batch)),
     precision=precision, preferred_element_type=preferred_element_type)
   result = lax.transpose(out, perm)
-  return lax_internal._convert_element_type(result, preferred_element_type, output_weak_type)
+  return lax._convert_element_type(result, preferred_element_type, output_weak_type)
 
 
 @export
-@jit
+@api.jit
 def matvec(x1: ArrayLike, x2: ArrayLike, /) -> Array:
   """Batched matrix-vector product.
 
@@ -291,7 +289,7 @@ def matvec(x1: ArrayLike, x2: ArrayLike, /) -> Array:
 
 
 @export
-@jit
+@api.jit
 def vecmat(x1: ArrayLike, x2: ArrayLike, /) -> Array:
   """Batched conjugate vector-matrix product.
 
@@ -333,10 +331,10 @@ def vecmat(x1: ArrayLike, x2: ArrayLike, /) -> Array:
 
 
 @export
-@partial(jit, static_argnames=('precision', 'preferred_element_type'), inline=True)
+@partial(api.jit, static_argnames=('precision', 'preferred_element_type'), inline=True)
 def vdot(
     a: ArrayLike, b: ArrayLike, *,
-    precision: PrecisionLike = None,
+    precision: lax.PrecisionLike = None,
     preferred_element_type: DTypeLike | None = None,
 ) -> Array:
   """Perform a conjugate multiplication of two 1D vectors.
@@ -383,7 +381,7 @@ def vdot(
 
 @export
 def vecdot(x1: ArrayLike, x2: ArrayLike, /, *, axis: int = -1,
-           precision: PrecisionLike = None,
+           precision: lax.PrecisionLike = None,
            preferred_element_type: DTypeLike | None = None) -> Array:
   """Perform a conjugate multiplication of two batched vectors.
 
@@ -442,7 +440,7 @@ def vecdot(x1: ArrayLike, x2: ArrayLike, /, *, axis: int = -1,
 @export
 def tensordot(a: ArrayLike, b: ArrayLike,
               axes: int | Sequence[int] | Sequence[Sequence[int]] = 2,
-              *, precision: PrecisionLike = None,
+              *, precision: lax.PrecisionLike = None,
               preferred_element_type: DTypeLike | None = None) -> Array:
   """Compute the tensor dot product of two N-dimensional arrays.
 
@@ -551,14 +549,14 @@ def tensordot(a: ArrayLike, b: ArrayLike,
     raise TypeError(msg)
   result = lax.dot_general(a, b, (contracting_dims, ((), ())),
                            precision=precision, preferred_element_type=preferred_element_type)
-  return lax_internal._convert_element_type(result, preferred_element_type, output_weak_type)
+  return lax._convert_element_type(result, preferred_element_type, output_weak_type)
 
 
 
 @export
-@partial(jit, static_argnames=('precision', 'preferred_element_type'), inline=True)
+@partial(api.jit, static_argnames=('precision', 'preferred_element_type'), inline=True)
 def inner(
-    a: ArrayLike, b: ArrayLike, *, precision: PrecisionLike = None,
+    a: ArrayLike, b: ArrayLike, *, precision: lax.PrecisionLike = None,
     preferred_element_type: DTypeLike | None = None,
 ) -> Array:
   """Compute the inner product of two arrays.
@@ -614,7 +612,7 @@ def inner(
 
 
 @export
-@partial(jit, inline=True)
+@partial(api.jit, inline=True)
 def outer(a: ArrayLike, b: ArrayLike, out: None = None) -> Array:
   """Compute the outer product of two arrays.
 

--- a/jax/_src/numpy/ufunc_api.py
+++ b/jax/_src/numpy/ufunc_api.py
@@ -22,18 +22,19 @@ import math
 import operator
 from typing import Any
 
+import numpy as np
+
 from jax._src import api
 from jax._src.typing import Array, ArrayLike, DTypeLike
 from jax._src.lax import control_flow
 from jax._src.lax import slicing
 from jax._src.lax import lax
 from jax._src.numpy import indexing
-import jax._src.numpy.lax_numpy as jnp
+from jax._src.numpy import lax_numpy as jnp
 from jax._src.numpy.reductions import _moveaxis
 from jax._src.numpy.util import check_arraylike, _broadcast_to, _where
 from jax._src.numpy.vectorize import vectorize
 from jax._src.util import canonicalize_axis, set_module
-import numpy as np
 
 
 export = set_module("jax.numpy")

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 from functools import partial
 from typing import Any, overload
-
 import warnings
+
+import numpy as np
 
 from jax._src import api
 from jax._src import config
@@ -27,11 +28,9 @@ from jax._src.lax import lax
 from jax._src.lib import xla_client as xc
 from jax._src.sharding_impls import SingleDeviceSharding
 from jax._src.util import safe_zip, safe_map, set_module
+from jax._src.sharding import Sharding
 from jax._src.typing import (
     Array, ArrayLike, DimSize, Shape, SupportsNdim, SupportsShape, SupportsSize)
-from jax.sharding import Sharding
-
-import numpy as np
 
 zip, unsafe_zip = safe_zip, zip
 map, unsafe_map = safe_map, map


### PR DESCRIPTION
Also clean-up and regularize a few related imports. The main reason for this is to ublock moving `jax._src.numpy` into its own build rule.