### PR TITLE
instantiate symbolic zero cotangents in _linear_solve_transpose_rule

### DIFF
--- a/jax/_src/lax/control_flow/solves.py
+++ b/jax/_src/lax/control_flow/solves.py
@@ -395,13 +395,17 @@ def _linear_solve_transpose_rule(cotangent, *primals, const_lengths, jaxprs):
                     'differentiation of custom_linear_solve')
 
   params, b = _split_linear_solve_args(primals, const_lengths)
-  # split off symbolic zeros in the cotangent if present
-  x_cotangent, _ = split_list(cotangent, [len(b)])
-  assert all(ad.is_undefined_primal(x) for x in b)
+  if any(ad.is_undefined_primal(x) for xs in params for x in xs):
+    raise NotImplementedError("open an issue at https://github.com/google/jax !!")
+  assert all(ad.is_undefined_primal(x) for x in b)  # TODO(mattjj): why?
+  x_cotangent, other_cotangents = split_list(cotangent, [len(b)])
+  if any(type(ct) is not ad_util.Zero for ct in other_cotangents):
+    raise NotImplementedError("open an issue at https://github.com/google/jax !!")
+  del other_cotangents
+  x_cotangent_ = _map(ad_util.instantiate, x_cotangent)
   cotangent_b_full = linear_solve_p.bind(
-      *(_flatten(params.transpose()) + x_cotangent),
+      *_flatten(params.transpose()), *x_cotangent_,
       const_lengths=const_lengths.transpose(), jaxprs=jaxprs.transpose())
-  # drop aux values in cotangent computation
   cotangent_b, _ = split_list(cotangent_b_full, [len(b)])
   return [None] * sum(const_lengths) + cotangent_b
 

--- a/tests/custom_linear_solve_test.py
+++ b/tests/custom_linear_solve_test.py
@@ -502,6 +502,21 @@ class CustomLinearSolveTest(jtu.JaxTestCase):
     self.assertEqual(output(), "mat_vec\n")
     self.assertAllClose(computed, expected)
 
+  def test_symbolic_zero_cotangents(self):
+    # https://github.com/jax-ml/jax/issues/29342
+    def g(x):
+      def p(z):
+        return jnp.linalg.solve(z.sum()*jnp.eye(3), jnp.array([1., 0., 0.]))[0]
+      h = lambda y: jax.jvp(jax.vmap(p), (x,), (y,))[1]
+      return h
+
+    def f(x):
+      return jax.vjp(g(x), jnp.ones_like(x))[1](x)[0]
+
+    x = jnp.array([200.0])
+    f_x = f(x)
+    grad_f_x = jax.jacrev(f)(x)  # don't crash
+
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
it'd be better to skip processing the symbolic zeros, but I'd need to understand the OOP logic involved...

fixes #29342