### PR TITLE
don't pass `self` to `raise AttributeError(...)`

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -840,7 +840,6 @@ class Tracer(typing.Array, metaclass=StrictABCMeta):
     # Raising a ConcretizationTypeError would make sense, but for backward compatibility
     # we raise an AttributeError so that hasattr() and getattr() work as expected.
     raise AttributeError(
-        self,
         f"The 'sharding' attribute is not available on {self._error_repr()}."
         f"{self._origin_msg()}")
 
@@ -856,7 +855,7 @@ class Tracer(typing.Array, metaclass=StrictABCMeta):
     # This attribute is part of the jax.Array API, but only defined on concrete arrays.
     # Raising a ConcretizationTypeError would make sense, but for backward compatibility
     # we raise an AttributeError so that hasattr() and getattr() work as expected.
-    raise AttributeError(self,
+    raise AttributeError(
       f"The 'device' attribute is not available on {self._error_repr()}."
       f"{self._origin_msg()}")
 
@@ -928,7 +927,6 @@ class Tracer(typing.Array, metaclass=StrictABCMeta):
 
     if name == 'sharding':
       raise AttributeError(
-        self,
         f"The 'sharding' attribute is not available on {self._error_repr()}."
         f"{self._origin_msg()}")
 
@@ -980,14 +978,14 @@ class Tracer(typing.Array, metaclass=StrictABCMeta):
   @property
   def block_until_ready(self):
     # Raise AttributeError for backward compatibility with hasattr() and getattr() checks.
-    raise AttributeError(self,
+    raise AttributeError(
       f"The 'block_until_ready' method is not available on {self._error_repr()}."
       f"{self._origin_msg()}")
 
   @property
   def copy_to_host_async(self):
     # Raise AttributeError for backward compatibility with hasattr() and getattr() checks.
-    raise AttributeError(self,
+    raise AttributeError(
       f"The 'copy_to_host_async' method is not available on {self._error_repr()}."
       f"{self._origin_msg()}")
 


### PR DESCRIPTION
Before this PR, if we did `print(x.sharding)` under a `jit`, then we'd get

AttributeError: (Traced<float32[3]>with<DynamicJaxprTrace>, "The 'sharding' attribute is not available on traced array with shape float32[3].\nThe error occurred while tracing the function f at <ipython-input-5-130359cd9f89>:1 for jit. This concrete value was not available in Python because it depends on the value of the argument x.")

Notice how we see an explicit "\n" and things print like a tuple.

After this PR we get

AttributeError: The 'sharding' attribute is not available on traced array with shape float32[3].
The error occurred while tracing the function f at <ipython-input-2-130359cd9f89>:1 for jit. This concrete value was not available in Python because it depends on the value of the argument x.