### PR TITLE
[CI] Add bazel TPU presubmit testing

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -301,17 +301,23 @@ build:ci_windows_amd64 --color=yes
 common --experimental_repo_remote_exec
 
 # Allow creation of resultstore URLs for any bazel invocation
-build:resultstore --google_default_credentials
-build:resultstore --bes_backend=buildeventservice.googleapis.com
+
+build:resultstore_base --google_default_credentials
+build:resultstore_base --bes_backend=buildeventservice.googleapis.com
+build:resultstore_base --bes_timeout=600s
+build:resultstore_base --bes_results_url="https://source.cloud.google.com/results/invocations"
+
+build:resultstore --config=resultstore_base
 build:resultstore --bes_instance_name="tensorflow-testing"
-build:resultstore --bes_results_url="https://source.cloud.google.com/results/invocations"
-build:resultstore --bes_timeout=600s
 
 # Configs for RBE cache. When using resultstore, we need to use these configs
 # as well to ensure that the logs that get uploaded to resultstore can be read
 # without any errors.
-build:rbe_cache --remote_cache=remotebuildexecution.googleapis.com
-build:rbe_cache --remote_instance_name=projects/tensorflow-testing/instances/default_instance
+build:ci_rbe_cache --config=resultstore_base
+build:ci_rbe_cache --remote_upload_local_results=true
+build:ci_rbe_cache --bes_instance_name="ml-oss-rbe-testing"
+build:ci_rbe_cache --remote_cache="grpcs://remotebuildexecution.googleapis.com"
+build:ci_rbe_cache --remote_instance_name=projects/ml-oss-rbe-testing/instances/default_instance
 
 build:rbe --config=resultstore
 build:rbe --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1

--- a/.github/workflows/bazel_optional_h100_b200.yml
+++ b/.github/workflows/bazel_optional_h100_b200.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Run Bazel single B200 CUDA Tests
         run: |
             nvidia-smi
-            bazel test --config=rbe_linux_x86_64_cuda \
-            --config=resultstore \
-            --config=rbe_cache \
+            bazel test \
+            --config=ci_linux_x86_64_cuda \
+            --config=ci_rbe_cache \
             --repo_env=HERMETIC_CUDA_VERSION="12.8.0" \
             --repo_env=HERMETIC_CUDNN_VERSION="9.8.0" \
             --repo_env=HERMETIC_PYTHON_VERSION="3.13" \
@@ -53,7 +53,6 @@ jobs:
             --test_tag_filters=-multiaccelerator \
             --test_env=JAX_ACCELERATOR_COUNT=1 \
             --test_env=JAX_TESTS_PER_ACCELERATOR=8 \
-            --strategy=TestRunner=local \
             --local_test_jobs=8 \
             --test_env=JAX_EXCLUDE_TEST_TARGETS='PmapTest.testSizeOverflow|.*InterpretTest.*' \
             --test_env=TF_CPP_MIN_LOG_LEVEL=0 \
@@ -85,15 +84,14 @@ jobs:
       - name: Run Bazel multiple H100 CUDA Tests
         run: |
             nvidia-smi
-            bazel test --config=rbe_linux_x86_64_cuda \
-            --config=resultstore \
-            --config=rbe_cache \
+            bazel test \
+            --config=ci_linux_x86_64_cuda \
+            --config=ci_rbe_cache \
             --repo_env=HERMETIC_CUDA_VERSION="12.8.0" \
             --repo_env=HERMETIC_CUDNN_VERSION="9.8.0" \
             --repo_env=HERMETIC_PYTHON_VERSION="3.13" \
             --test_env=XLA_PYTHON_CLIENT_ALLOCATOR=platform \
             --test_output=errors \
-            --strategy=TestRunner=local \
             --local_test_jobs=8 \
             --test_env=JAX_EXCLUDE_TEST_TARGETS='PmapTest.testSizeOverflow|.*InterpretTest.*' \
             --test_tag_filters=multiaccelerator \

--- a/.github/workflows/cloud-tpu-ci-presubmit.yml
+++ b/.github/workflows/cloud-tpu-ci-presubmit.yml
@@ -46,7 +46,80 @@ jobs:
         clone_main_xla: 1
         upload_artifacts_to_gcs: true
         gcs_upload_uri: 'gs://general-ml-ci-transient/jax-github-actions/jax/${{ github.workflow }}/${{ github.run_number }}/${{ github.run_attempt }}'
+  run-bazel-tpu:
+    name: "TPU bazel tests"
+    defaults:
+      run:
+        shell: bash
+    runs-on: "linux-x86-ct6e-180-8tpu"
+    container: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest"
+    env:
+      JAXCI_HERMETIC_PYTHON_VERSION: "3.13-ft"
+      JAXCI_PYTHON: "python3.13t"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+         persist-credentials: false
+      - name: Wait For Connection
+        uses: google-ml-infra/actions/ci_connection@7f5ca0c263a81ed09ea276524c1b9192f1304e3c
+        with:
+          halt-dispatch-input: ${{ inputs.halt-for-connection }}
+      - name: Install nightly libtpu
+        run: |
+          $JAXCI_PYTHON -m uv pip install --pre libtpu -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+      - name: Run Bazel Tests
+        run: |
+          git clone --depth=1 https://github.com/openxla/xla.git $(pwd)/xla
 
+          SRCDIR=$(pwd)
+          # Run bazel test, room for improvement by either using prebuilt jaxlib, using a cache, or using an RBE instance
+          # Test envs must be passed in due to not having access to the TPU metadata information
+
+          echo "TPU_SKIP_MDS_QUERY: true"
+          echo "CHIPS_PER_HOST_BOUNDS: $CHIPS_PER_HOST_BOUNDS"
+          echo "HOST_BOUNDS: $HOST_BOUNDS"
+          echo "ALT: false"
+          echo "WRAP: $WRAP"
+          echo "TPU_WORKER_ID: $TPU_WORKER_ID"
+          echo "TPU_ACCELERATOR_TYPE: $TPU_ACCELERATOR_TYPE"
+          echo "TPU_WORKER_HOSTNAMES: $TPU_WORKER_HOSTNAMES"
+          echo "TPU_RUNTIME_METRICS_PORTS: $TPU_RUNTIME_METRICS_PORTS"
+          echo "TPU_HOST_BOUNDS: $TPU_HOST_BOUNDS"
+          echo "TPU_TOPOLOGY_ALT: $TPU_TOPOLOGY_ALT"
+          echo "TPU_TOPOLOGY_WRAP: $TPU_TOPOLOGY_WRAP"
+          echo "VBAR_CONTROL_SERVICE_URL: $VBAR_CONTROL_SERVICE_URL"
+
+          bazel test \
+            --config=ci_linux_x86_64 \
+            --config=ci_rbe_cache \
+            --override_repository=xla="./xla" \
+            --repo_env=HERMETIC_PYTHON_VERSION=3.13-ft \
+            --@rules_python//python/config_settings:py_freethreaded='yes' \
+            --run_under ${SRCDIR}/build/parallel_accelerator_execute.sh \
+            --test_env=JAX_ACCELERATOR_COUNT=8 \
+            --test_env=JAX_TESTS_PER_ACCELERATOR=1 \
+            --local_test_jobs=8 \
+            --test_tag_filters=-multiaccelerator  \
+            --test_sharding_strategy=disabled \
+            --generate_json_trace_profile  \
+            --test_timeout=600 \
+            --test_env=ALLOW_MULTIPLE_LIBTPU_LOAD=1 \
+            --test_env=JAX_TEST_NUM_THREADS=16 \
+            --test_env=JAX_SKIP_SLOW_TESTS=1 \
+            --test_env=TPU_SKIP_MDS_QUERY=true \
+            --test_env=CHIPS_PER_HOST_BOUNDS="$CHIPS_PER_HOST_BOUNDS" \
+            --test_env=HOST_BOUNDS="$HOST_BOUNDS" \
+            --test_env=ALT=false \
+            --test_env=WRAP="$WRAP" \
+            --test_env=TPU_WORKER_ID="$TPU_WORKER_ID" \
+            --test_env=TPU_ACCELERATOR_TYPE="$TPU_ACCELERATOR_TYPE" \
+            --test_env=TPU_WORKER_HOSTNAMES="$TPU_WORKER_HOSTNAMES" \
+            --test_env=TPU_RUNTIME_METRICS_PORTS="$TPU_RUNTIME_METRICS_PORTS" \
+            --test_env=TPU_HOST_BOUNDS="$TPU_HOST_BOUNDS" \
+            --test_env=TPU_TOPOLOGY_ALT="$TPU_TOPOLOGY_ALT" \
+            --test_env=TPU_TOPOLOGY_WRAP="$TPU_TOPOLOGY_WRAP" \
+            --test_env=VBAR_CONTROL_SERVICE_URL="$VBAR_CONTROL_SERVICE_URL" \
+            -- //tests:tpu_tests
   run-pytest-tpu:
     if: github.event.repository.fork == false
     needs: [build-jax-artifacts]

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -321,6 +321,5 @@ jobs:
               --test_output=errors \
               --local_test_jobs=32 \
               --test_timeout=1800 \
-              --config=resultstore \
-              --config=rbe_cache \
+              --config=ci_rbe_cache \
               //tests:cpu_tests

--- a/ci/run_bazel_test_cuda_non_rbe.sh
+++ b/ci/run_bazel_test_cuda_non_rbe.sh
@@ -72,8 +72,7 @@ set +e
 # The product of the `JAX_ACCELERATOR_COUNT`` and `JAX_TESTS_PER_ACCELERATOR`
 # should match the VM's CPU core count (set in `--local_test_jobs`).
 bazel test --config=ci_linux_x86_64_cuda \
-      --config=resultstore \
-      --config=rbe_cache \
+      --config=ci_rbe_cache \
       --repo_env=HERMETIC_PYTHON_VERSION="$JAXCI_HERMETIC_PYTHON_VERSION" \
       --//jax:build_jaxlib=false \
       --//jax:build_jax=false \
@@ -99,8 +98,7 @@ first_bazel_cmd_retval=$?
 echo "Running multi-accelerator tests (without RBE)..."
 # Runs multiaccelerator tests with all GPUs directly on the VM without RBE..
 bazel test --config=ci_linux_x86_64_cuda \
-      --config=resultstore \
-      --config=rbe_cache \
+      --config=ci_rbe_cache \
       --repo_env=HERMETIC_PYTHON_VERSION="$JAXCI_HERMETIC_PYTHON_VERSION" \
       --//jax:build_jaxlib=false \
       --//jax:build_jax=false \


### PR DESCRIPTION
Add a new TPU bazel presubmit using 3.13 free threading to increase coverage of our TPU presubmits.  This will be introduced as non blocking and be made blocking once reliability is confirmed.

Additionally refactor use of resultstore and rbe cache in jobs that do not use RBE for testing or building.  This should allow for use of resultstore and a cache that can allow for testing cache hits. 

