### PR TITLE
jnp.diagonal: avoid negative index overhead

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -7278,7 +7278,9 @@ def diagonal(a: ArrayLike, offset: int = 0, axis1: int = 0,
     )
     i = arange(diag_size)
     j = arange(abs(offset), abs(offset) + diag_size)
-    return a[..., i, j] if offset >= 0 else a[..., j, i]
+    if offset < 0:
+      i, j = j, i
+    return a.at[..., i, j].get(wrap_negative_indices=False)
 
 
   # The mosaic lowering rule for diag is only defined for square arrays.


### PR DESCRIPTION
Related to #29705

I don't think this is the full fix for that issue, but I was looking at the jaxpr and realized there are six primitive ops related to negative index checks that aren't necessary, and are now possible to remove after the changes in #29434.