### PR TITLE
Add [query,key_value]_seq_offsets arguments to dot_product_attention

### DIFF
--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -337,7 +337,7 @@ def check_layout(query, key, value, bias, q_seqlen, kv_seqlen,
         f"Bias must have same seq length as QKV, got {bT} and {bS}")
 
   # check q_seqlen/kv_seqlen/q_offsets/kv_offsets
-  expected_rank = 2 if q_offsets is not None else 1
+  expected_rank = 1
   def check_seqlen_offsets(tensor, name):
     if tensor is not None:
       dtype = tensor.dtype

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -244,7 +244,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
   @parameterized.product(
       mask_mode=['bias', 'causal', 'padding', 'custom', ('causal', 'padding'),
                  ('custom', 'padding'), ('bias', 'causal'),
-                 ('causal', 'sliding_window')],
+                 ('causal', 'sliding_window'), ('padding', 'segment_id')],
   )
   def testDotProductAttentionMask(self, mask_mode):
     if isinstance(mask_mode, str):
@@ -262,12 +262,16 @@ class NNFunctionsTest(jtu.JaxTestCase):
     grad = random.normal(keys[3], (B, T, N, H), dtype)
     bias, mask = None, None
     q_seqlen, kv_seqlen = None, None
+    q_seq_offsets, kv_seq_offsets = None, None
     window_size = None
 
     is_causal = 'causal' in mask_mode
     if 'padding' in mask_mode:
       q_seqlen = jnp.array([T // 2, T // 4], dtype=jnp.int32)
       kv_seqlen = jnp.array([S // 4, S // 2], dtype=jnp.int32)
+    if 'segment_id' in mask_mode:
+      q_seq_offsets = jnp.array([0, 0], dtype=jnp.int32)
+      kv_seq_offsets = jnp.array([0, 0], dtype=jnp.int32)
     if 'custom' in mask_mode:
       # Use a generated causal mask as the custom mask.
       custom_mask = jnp.tril(jnp.ones((T, S), dtype=jnp.bool_))
@@ -282,19 +286,27 @@ class NNFunctionsTest(jtu.JaxTestCase):
     sdpa_ans = partial(sdpa, is_causal=is_causal, implementation='cudnn')
 
     args = (Q, K, V, bias, mask)
-    kwargs = {'query_seq_lengths': q_seqlen, 'key_value_seq_lengths': kv_seqlen}
+    kwargs = {
+        'query_seq_lengths': q_seqlen,
+        'key_value_seq_lengths': kv_seqlen,
+        'query_seq_offsets': q_seq_offsets,
+        'key_value_seq_offsets': kv_seq_offsets,
+    }
 
     # Convert the kargs to positional args for the jax.vjp.
-    fn_ref = lambda q, k, v, b, m, qs, kvs: sdpa_ref(
+    fn_ref = lambda q, k, v, b, m, qs, kvs, qo, kvo: sdpa_ref(
         q, k, v, b, m, query_seq_lengths=qs, key_value_seq_lengths=kvs,
+        query_seq_offsets=qo, key_value_seq_offsets=kvo,
         local_window_size=window_size,
     )
-    fn_ans = lambda q, k, v, b, m, qs, kvs: sdpa_ans(
+    fn_ans = lambda q, k, v, b, m, qs, kvs, qo, kvo: sdpa_ans(
         q, k, v, b, m, query_seq_lengths=qs, key_value_seq_lengths=kvs,
+        query_seq_offsets=qo, key_value_seq_offsets=kvo,
         local_window_size=window_size,
     )
-    out_ref, sdpa_vjp_ref = jax.vjp(fn_ref, *args, q_seqlen, kv_seqlen)
-    out_ans, sdpa_vjp_ans = jax.vjp(fn_ans, *args, q_seqlen, kv_seqlen)
+
+    out_ref, sdpa_vjp_ref = jax.vjp(fn_ref, *args, q_seqlen, kv_seqlen, q_seq_offsets, kv_seq_offsets)
+    out_ans, sdpa_vjp_ans = jax.vjp(fn_ans, *args, q_seqlen, kv_seqlen, q_seq_offsets, kv_seq_offsets)
     dQ_ref, dK_ref, dV_ref, dbias_ref = sdpa_vjp_ref(grad)[:4]
     dQ_ans, dK_ans, dV_ans, dbias_ans = sdpa_vjp_ans(grad)[:4]
 


### PR DESCRIPTION
This PR adds the arguments `query_seq_offsets` and `key_value_seq_offsets` to the `jax.nn.dot_product_attention` API. This allows users to access the feature that is already supported in cudnn, and exists in the `dot_product_attention` method from `fused_attention_stablehlo.py`. 