### PR TITLE
[jaxpr consts] Propagate closed-over constants in lax.composite

### DIFF
--- a/tests/debug_info_test.py
+++ b/tests/debug_info_test.py
@@ -2072,7 +2072,7 @@ class DebugInfoTest(jtu.JaxTestCase):
         tracer_spy=tracer_spy,
         expected_jaxpr_debug_infos=[
             "traced_for=jit, fun=my_consts, arg_names=x, result_paths=result",
-            "traced_for=composite, fun=my_consts, arg_names=x, result_paths=result",
+            "traced_for=composite, fun=my_consts, arg_names=,x, result_paths=result",
         ],
         expected_tracer_debug_infos=[
             "traced_for=composite, fun=my_consts, arg_names=x, from x"])

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -4807,7 +4807,7 @@ class CompositeTest(jtu.JaxTestCase):
     # The constant must not appear as an extra input argument to the composite.
     mlir_module = jax.jit(partial(my_consts, scale=scale)).lower(x).as_text()
     self.assertIn(
-        "@my.consts(%arg0: tensor<3xf32>) -> tensor<3xf32>", mlir_module
+        "@my.consts(%arg0: tensor<3xf32>, %arg1: tensor<3xf32>) -> tensor<3xf32>", mlir_module
     )
 
   def test_composite_with_tracer_consts(self):


### PR DESCRIPTION
This is part of an effort to lift closed-over constants to the top-level pjit. We apply the same strategy like for other higher-order primitives such as `cond`, `scan`.

See #29679 for background.