### PR TITLE
[jaxpr consts] Propagate closed-over constants to the top-level jit

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4546,11 +4546,14 @@ class APITest(jtu.JaxTestCase):
       return x
 
     state = jnp.arange(5, dtype=jnp.uint32)
-    inner_fn(state)
-    outer_fn(state)
 
+    outer_fn(state)
+    outer_fn(state)
     self.assertEqual(inner_count, 1)
     self.assertEqual(outer_count, 1)
+
+    inner_fn(state)
+    self.assertEqual(inner_count, 2)  # retraced when top-level
 
   def test_grad_conj_symbolic_zeros(self):
     # https://github.com/jax-ml/jax/issues/15400

--- a/tests/debug_info_test.py
+++ b/tests/debug_info_test.py
@@ -882,11 +882,10 @@ class DebugInfoTest(jtu.JaxTestCase):
         x, y,
         expected_jaxpr_debug_infos=[
             "traced_for=jit, fun=my_f, arg_names=x,y, result_paths=result",
-            "traced_for=jit, fun=my_g, arg_names=u,v, result_paths=result",
+            "traced_for=jit, fun=my_g, arg_names=,u,v, result_paths=result",
         ],
         expected_lowering_lines=[
             re.compile(r".*func.func public @main\(%arg0: tensor<8xf..> loc\(\"x\"\)\)"),
-            re.compile(r".*call @my_g\(%arg.\) : \(tensor<8xf..>\)"),
         ]
     )
 
@@ -1389,10 +1388,10 @@ class DebugInfoTest(jtu.JaxTestCase):
     if config.use_direct_linearize.value:
       expected_jaxpr_debug_infos = [
           "traced_for=jit, fun=the_grad, arg_names=c,as_, result_paths=result[0],result[1]",
-          "traced_for=jit, fun=my_f, arg_names=x,as_, result_paths=,,",
+          "traced_for=jit, fun=my_f, arg_names=,x,as_, result_paths=,",
+          "traced_for=jit, fun=my_f, arg_names=,,, result_paths=result[0],result[1]",
           "traced_for=for_loop, fun=f, arg_names=,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=i,refs[0],refs[1],refs[2], result_paths=",
-          "traced_for=jit, fun=my_f, arg_names=as_,,, result_paths=result[0],result[1]",
           "traced_for=checkpoint / remat, fun=to_remat, arg_names=,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=,,,,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=i,refs[0],refs[1],refs[2], result_paths=",
@@ -1402,10 +1401,10 @@ class DebugInfoTest(jtu.JaxTestCase):
     else:
       expected_jaxpr_debug_infos = [
           "traced_for=jit, fun=the_grad, arg_names=c,as_, result_paths=result[0],result[1]",
-          "traced_for=jit, fun=my_f, arg_names=x,as_, result_paths=result[0],result[1]",
+          "traced_for=jit, fun=my_f, arg_names=,x,as_, result_paths=result[0],result[1]",
+          "traced_for=jit, fun=my_f, arg_names=,,,x,as_, result_paths=result[0],result[1]",
           "traced_for=for_loop, fun=f, arg_names=,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=i,refs[0],refs[1],refs[2], result_paths=",
-          "traced_for=jit, fun=my_f, arg_names=,,x,as_, result_paths=result[0],result[1]",
           "traced_for=checkpoint / remat, fun=to_remat, arg_names=,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=,,,,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=i,refs[0],refs[1],refs[2], result_paths=",


### PR DESCRIPTION
We want to move all closed-over constants from `pjit_p` primitives to the enclosing scope. The top-level `pjit_p` will contain all the closed-over constants in the program.

See #29679 for background.

**This is still WIP**

I had to add a check for `core.unsafe_am_i_under_jit` to detect if we are in the top-level jit. To make this work with the `_create_pjit_jaxpr` cache, I moved the code that creates the pjit `ClosedJaxpr` at the call site for `_create_pjit_jaxpr`.

Then I ran into a situation where we a jit-ed function that closes over an array, and that is used both nested (e.g., in the body of a `scan`) and later is called directly. When we call it directly, we will hit a cache that contains some data pertaining to the function called nested. For now, I added an argument `args_flat_contains_consts` to `get_fastpath_data`, to achieve the effect that we don't hit the fastpath data. Perhaps this is Ok, it should only matter when we use a jit function both directly and under some other jit. But I want to understand better how this caching works, there should be a better solution.
