### PR TITLE
[jaxpr consts] Propagate closed-over constants to the top-level jit (take 2)

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -248,7 +248,8 @@ def trace_context():
           use_high_dynamic_range_gumbel.value,
           error_checking_behavior_nan.value,
           error_checking_behavior_divide.value,
-          error_checking_behavior_oob.value)
+          error_checking_behavior_oob.value,
+          use_simplified_jaxpr_constants.value)
 
 config = Config()
 
@@ -1104,6 +1105,16 @@ use_direct_linearize = bool_state(
     name='jax_use_direct_linearize',
     default=False,
     help=('Use direct linearization instead JVP followed by partial eval'),
+    include_in_jit_key=True)
+
+use_simplified_jaxpr_constants = bool_state(
+    name='jax_use_simplified_jaxpr_constants',
+    default=False,
+    help=('Enable a simplification of the handling of closed-over constants '
+          'in Jaxpr. The value `True` enables the new behavior. '
+          'This flag will exist only briefly, while we transition '
+          'users. See https://github.com/jax-ml/jax/pull/29679.'
+          'DO NOT RELY ON THIS FLAG.'),
     include_in_jit_key=True)
 
 # TODO make it so people don't use this, this is internal...

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1566,6 +1566,10 @@ def dce_jaxpr_closed_call_rule(used_outputs: list[bool], eqn: JaxprEqn
   return used_inputs, new_eqn
 dce_rules[core.closed_call_p] = dce_jaxpr_closed_call_rule
 
+# TODO(necula): this cache is not really working as a weakref cache: the key
+# is a weakref, but it points to a value that has a strong ref to the same
+# jaxpr. So, we have a cycle with a strong ref, and these keys are never
+# collected.
 @weakref_lru_cache
 def close_jaxpr(jaxpr: Jaxpr) -> ClosedJaxpr:
   return ClosedJaxpr(jaxpr, ())

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -474,7 +474,12 @@ def make_jit(fun: Callable,
 
 
 class PjitParams(NamedTuple):
-  consts: list[Any]  # Only jaxpr constants, we can't keep other arguments alive
+  jaxpr_for_top_jit: core.ClosedJaxpr  # See comments in _params_for_top_jit
+  # Only jaxpr constants, we can't keep other arguments alive. These go as
+  # first arguments for `params['jaxpr']`.
+  consts: list[Any]
+  # Everything we need to trace, lower, and compile the jit function; passed
+  # to `pjit_call_impl_python`, along with the `args_flat`
   params: dict[str, Any]
   in_avals: tuple[core.AbstractValue, ...]
   in_tree: PyTreeDef
@@ -557,8 +562,8 @@ def _infer_params_impl(
       ji.in_layouts_treedef, ji.in_layouts_leaves,
       in_avals, in_tree, flat_fun.debug_info, device_or_backend_set, have_kwargs)
 
-  jaxpr, consts, out_avals = _create_pjit_jaxpr(flat_fun, in_type, IgnoreKey(ji.inline))
-
+  jaxpr, consts, jaxpr_for_top_jit, out_avals = _create_pjit_jaxpr(
+      flat_fun, in_type, IgnoreKey(ji.inline))
   if config.mutable_array_checks.value:
     _check_no_aliased_closed_over_refs(dbg, (*jaxpr.consts, *consts), explicit_args)
 
@@ -596,8 +601,9 @@ def _infer_params_impl(
       inline=ji.inline,
       compiler_options_kvs=ji.compiler_options_kvs,
   )
-  return (PjitParams(consts, params, in_avals, in_tree, out_tree(),
-                     dbg.arg_names), args_flat)
+  return (PjitParams(jaxpr_for_top_jit, consts, params, in_avals,
+                     in_tree, out_tree(), dbg.arg_names),
+          args_flat)
 
 
 class InferParamsCacheEntry:
@@ -626,13 +632,47 @@ def _infer_params_cached(
 
 def _infer_params(
     fun: Callable, ji: PjitInfo, args: tuple[Any, ...], kwargs: dict[str, Any]
-  ) -> tuple[PjitParams, list[Any]]:
+  ) -> tuple[PjitParams, list[core.Value]]:
   if ji.use_resource_env:  # pjit
     phys_mesh = mesh_lib.thread_resources.env.physical_mesh
     with (_internal_use_concrete_mesh(phys_mesh),
           mesh_lib.use_abstract_mesh(phys_mesh.abstract_mesh)):
-      return _infer_params_internal(fun, ji, args, kwargs)
-  return _infer_params_internal(fun, ji, args, kwargs)
+      return _params_for_top_jit(_infer_params_internal(fun, ji, args, kwargs))
+  else:
+    return _params_for_top_jit(_infer_params_internal(fun, ji, args, kwargs))
+
+def _params_for_top_jit(
+    p_and_args_flat: tuple[PjitParams, list[core.Value]]
+  ) -> tuple[PjitParams, list[core.Value]]:
+  if not config.use_simplified_jaxpr_constants.value:
+    return p_and_args_flat
+  # Normally for pjit we want to pass closed-over constants as inputs, not
+  # as `consts` in the embedded ClosedJaxpr. The `p.params['jaxpr']` contains
+  # such a ClosedJaxpr. But for the top-level jit, for now, we want to keep
+  # the calling convention where the consts are passed inside the ClosedJaxpr
+  # and are lowered as HLO constants, and only the actual inputs are passed
+  # as inputs. We have prepared such a ClosedJaxpr in `p.jaxpr_for_top_jit`,
+  # but we also need to adjust some other parameters and the `args_flat`.
+
+  # We cannot do this down the stack in `_infer_params_impl` because that
+  # function is under a cache which we don't want to be keyed on whether
+  # `core.trace_state_clean()`.
+  p, args_flat = p_and_args_flat
+  if (core.trace_state_clean() and
+      p.consts and
+      not any(isinstance(c, core.Tracer) or core.typeof(c).has_qdd for c in p.consts)):
+    new_jaxpr = p.jaxpr_for_top_jit
+    nr_consts = len(p.consts)
+    assert all(c is a for c, a in zip(new_jaxpr.consts, args_flat[:nr_consts]))
+    args_flat = args_flat[nr_consts:]
+    new_params = dict(p.params,
+                      jaxpr=new_jaxpr,
+                      in_shardings=p.params['in_shardings'][nr_consts:],
+                      in_layouts=p.params['in_layouts'][nr_consts:],
+                      donated_invars=p.params['donated_invars'][nr_consts:])
+    p = p._replace(consts=[], params=new_params)
+
+  return p, args_flat
 
 def _infer_params_internal(
     fun: Callable, ji: PjitInfo, args: tuple[Any, ...], kwargs: dict[str, Any]
@@ -1336,7 +1376,8 @@ def _create_pjit_jaxpr(
     fun: lu.WrappedFun,
     in_type: core.InputType | Sequence[core.AbstractValue],
     ignored_inline: IgnoreKey
-) -> tuple[core.ClosedJaxpr, list[Any], list[core.AbstractValue]]:
+) -> tuple[core.ClosedJaxpr, list[core.Value], core.ClosedJaxpr,
+           list[core.AbstractValue]]:
   util.test_event("create_pjit_jaxpr")
   del ignored_inline  # just for explain_cache_miss
   if config.no_tracing.value:
@@ -1356,15 +1397,24 @@ def _create_pjit_jaxpr(
     from jax.experimental.key_reuse._core import check_key_reuse_jaxpr  # pytype: disable=import-error
     check_key_reuse_jaxpr(jaxpr)
 
-  # TODO(mattjj,yashkatariya): if we take the 'true' path then we *must* fall
-  # off the C++ dispatch fast path for correctness. Ensure that happens.
-  if any(isinstance(c, core.Tracer) or core.typeof(c).has_qdd for c in consts):
-    closed_jaxpr = pe.close_jaxpr(pe.convert_constvars_jaxpr(jaxpr))
-    final_consts = consts
+  if not config.use_simplified_jaxpr_constants.value:
+    # TODO(mattjj,yashkatariya): if we take the 'true' path then we *must* fall
+    # off the C++ dispatch fast path for correctness. Ensure that happens.
+    if any(isinstance(c, core.Tracer) or core.typeof(c).has_qdd for c in consts):
+      closed_jaxpr = pe.close_jaxpr(pe.convert_constvars_jaxpr(jaxpr))
+      final_consts = consts
+    else:
+      closed_jaxpr = core.ClosedJaxpr(jaxpr, consts)
+      final_consts = []
+    return closed_jaxpr, final_consts, closed_jaxpr, global_out_avals
   else:
-    closed_jaxpr = core.ClosedJaxpr(jaxpr, consts)
-    final_consts = []
-  return closed_jaxpr, final_consts, global_out_avals
+    # See comments in _params_for_top_jit for why we need two ClosedJaxpr. We
+    # prepare them both here, because this is under a cache, to ensure that
+    # we use the same exact ClosedJaxpr in future calls, which in turn will enable
+    # downstream lowering and compilation caches.
+    # TODO(necula): we can use `pe.close_jaxpr` once we fix https://github.com/jax-ml/jax/issues/29803
+    closed_jaxpr = core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
+    return closed_jaxpr, consts, core.ClosedJaxpr(jaxpr, consts), global_out_avals
 
 
 @util.cache(max_size=4096, trace_context_in_key=False)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4546,11 +4546,14 @@ class APITest(jtu.JaxTestCase):
       return x
 
     state = jnp.arange(5, dtype=jnp.uint32)
-    inner_fn(state)
-    outer_fn(state)
 
+    outer_fn(state)
+    outer_fn(state)
     self.assertEqual(inner_count, 1)
     self.assertEqual(outer_count, 1)
+
+    inner_fn(state)
+    self.assertEqual(inner_count, 1)  # not retraced when top-level
 
   def test_grad_conj_symbolic_zeros(self):
     # https://github.com/jax-ml/jax/issues/15400

--- a/tests/debug_info_test.py
+++ b/tests/debug_info_test.py
@@ -877,16 +877,23 @@ class DebugInfoTest(jtu.JaxTestCase):
       return x + jax.jit(my_g)(y, x)
 
     x = y = np.ones((8,), dtype=np.float32)
+    expected_jaxpr_debug_infos = [
+        "traced_for=jit, fun=my_f, arg_names=x,y, result_paths=result",
+    ]
+    if config.use_simplified_jaxpr_constants.value:
+      expected_jaxpr_debug_infos.extend([
+          "traced_for=jit, fun=my_g, arg_names=,u,v, result_paths=result",
+      ])
+    else:
+      expected_jaxpr_debug_infos.extend([
+          "traced_for=jit, fun=my_g, arg_names=u,v, result_paths=result",
+      ])
     self._check_tracers_and_jaxprs(
         jax.jit(my_f),
         x, y,
-        expected_jaxpr_debug_infos=[
-            "traced_for=jit, fun=my_f, arg_names=x,y, result_paths=result",
-            "traced_for=jit, fun=my_g, arg_names=u,v, result_paths=result",
-        ],
+        expected_jaxpr_debug_infos=expected_jaxpr_debug_infos,
         expected_lowering_lines=[
             re.compile(r".*func.func public @main\(%arg0: tensor<8xf..> loc\(\"x\"\)\)"),
-            re.compile(r".*call @my_g\(%arg.\) : \(tensor<8xf..>\)"),
         ]
     )
 
@@ -1389,29 +1396,46 @@ class DebugInfoTest(jtu.JaxTestCase):
     if config.use_direct_linearize.value:
       expected_jaxpr_debug_infos = [
           "traced_for=jit, fun=the_grad, arg_names=c,as_, result_paths=result[0],result[1]",
-          "traced_for=jit, fun=my_f, arg_names=x,as_, result_paths=,,",
+
           "traced_for=for_loop, fun=f, arg_names=,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=i,refs[0],refs[1],refs[2], result_paths=",
-          "traced_for=jit, fun=my_f, arg_names=as_,,, result_paths=result[0],result[1]",
           "traced_for=checkpoint / remat, fun=to_remat, arg_names=,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=,,,,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=i,refs[0],refs[1],refs[2], result_paths=",
           "traced_for=for_loop, fun=f, arg_names=,,,,,,,,,,,,,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=,,,,,,,,,,, result_paths=",
       ]
+      if config.use_simplified_jaxpr_constants.value:
+        expected_jaxpr_debug_infos.extend([
+            "traced_for=jit, fun=my_f, arg_names=,x,as_, result_paths=,",
+            "traced_for=jit, fun=my_f, arg_names=,,, result_paths=result[0],result[1]",
+        ])
+      else:
+        expected_jaxpr_debug_infos.extend([
+            "traced_for=jit, fun=my_f, arg_names=x,as_, result_paths=,,",
+            "traced_for=jit, fun=my_f, arg_names=as_,,, result_paths=result[0],result[1]",
+        ])
     else:
       expected_jaxpr_debug_infos = [
           "traced_for=jit, fun=the_grad, arg_names=c,as_, result_paths=result[0],result[1]",
-          "traced_for=jit, fun=my_f, arg_names=x,as_, result_paths=result[0],result[1]",
           "traced_for=for_loop, fun=f, arg_names=,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=i,refs[0],refs[1],refs[2], result_paths=",
-          "traced_for=jit, fun=my_f, arg_names=,,x,as_, result_paths=result[0],result[1]",
           "traced_for=checkpoint / remat, fun=to_remat, arg_names=,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=,,,,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=i,refs[0],refs[1],refs[2], result_paths=",
           "traced_for=for_loop, fun=f, arg_names=,,,,,,,,,,,,,,, result_paths=,",
           "traced_for=for_loop, fun=f, arg_names=,,,,,,,,,,, result_paths=",
       ]
+      if config.use_simplified_jaxpr_constants.value:
+        expected_jaxpr_debug_infos.extend([
+            "traced_for=jit, fun=my_f, arg_names=,x,as_, result_paths=result[0],result[1]",
+            "traced_for=jit, fun=my_f, arg_names=,,,x,as_, result_paths=result[0],result[1]",
+        ])
+      else:
+        expected_jaxpr_debug_infos.extend([
+            "traced_for=jit, fun=my_f, arg_names=x,as_, result_paths=result[0],result[1]",
+            "traced_for=jit, fun=my_f, arg_names=,,x,as_, result_paths=result[0],result[1]",
+        ])
     self._check_tracers_and_jaxprs(
         jax.jit(the_grad),
         c, as_,


### PR DESCRIPTION
We want to move all closed-over constants from `pjit_p` primitives to the enclosing scope, similarly to what we do for `scan_p`, and `cond_p`.

The top-level `pjit_p` will contain all the closed-over constants in the program. We don't change the behavior for the top-level `jit` because that would require changing the calling convention for executables.

Since forming of the Jaxpr for jit is under several caches, we form from the start both a Jaxpr suitable for top-level (with the constants in a ClosedJaxpr, to be lowered to HLO constants), and a Jaxpr to be used when nested (with the constants passed as additional front inputs). Higher-up the stack we pick the right Jaxpr depending on whether we are
the top jit or not.

See #29679 for background.