### PR TITLE
repro multi axes of mgpu collective matmul

### DIFF
--- a/tests/pallas/mgpu_collective_matmul_test.py
+++ b/tests/pallas/mgpu_collective_matmul_test.py
@@ -55,7 +55,10 @@ class CollectiveMatmulTestCase(jtu.JaxTestCase):
     context_stack.enter_context(pallas_call._PALLAS_USE_MOSAIC_GPU(True))
     num_devices = jax.device_count()
     mesh = jax.make_mesh(
-        (num_devices,), ("x",), axis_types=(jax.sharding.AxisType.Explicit,)
+        (1, num_devices,), ("x", "y",), axis_types=(
+          jax.sharding.AxisType.Explicit,
+          jax.sharding.AxisType.Explicit,
+        )
     )
     context_stack.enter_context(jax.sharding.use_mesh(mesh))
 
@@ -96,24 +99,24 @@ class CollectiveMatmulTestCase(jtu.JaxTestCase):
     k1, k2 = random.split(random.key(1234), num=2)
     lhs = random.normal(k1, (num_devices * m_shard, k), dtype)
     rhs = random.normal(k2, (k, num_devices * n_shard), dtype)
-    lhs = jax.sharding.reshard(lhs, P("x", None))
-    rhs = jax.sharding.reshard(rhs, P(None, "x"))
+    lhs = jax.sharding.reshard.reshard(lhs, P((("x", "y",)), None))
+    rhs = jax.sharding.reshard.reshard(rhs, P(None, (("x", "y",))))
 
     def run(body):
       out = jax.jit(
-          jax.shard_map(body, out_specs=P(None, "x"), check_vma=False)
+          jax.shard_map(body, out_specs=P(None, (("x", "y",))), check_vma=False)
       )(lhs, rhs)
       # Gather output, for NumPy comparison on the host.
-      out = jax.shard_map(
-          lambda x: lax.all_gather(x, "x", axis=1, tiled=True),
-          out_specs=P(None), check_vma=False,
-      )(out)
+      # out = jax.shard_map(
+      #     lambda x: lax.all_gather(x, (("x", "y",)), axis=1, tiled=True),
+      #     out_specs=P(None), check_vma=False,
+      # )(out)
       return out
 
     out = run(
         functools.partial(
             collective_matmul_mgpu.all_gather_lhs_matmul,
-            axis_name="x",
+            axis_name=(("x", "y",)),
             block_m=block_m,
             block_n=block_n,
             block_k=block_k,
@@ -121,8 +124,8 @@ class CollectiveMatmulTestCase(jtu.JaxTestCase):
             dtype=dtype,
         )
     )
-    ref_out = run(lambda x, y: lax.all_gather(x, "x", axis=0, tiled=True) @ y)
-    np.testing.assert_allclose(out, ref_out)
+    # ref_out = run(lambda x, y: lax.all_gather(x, ("x", "y",), axis=0, tiled=True) @ y)
+    # np.testing.assert_allclose(out, ref_out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* we want to use collective matmul cross all devices but under a mesh of multi axes
* In the real case we also need mesh = (2, 4), here we use (1, 8)
* Error

```------------------------------- Process 1 stderr -------------------------------
INFO:2025-06-30 14:23:06,732:jax._src.distributed:149: Connecting to JAX distributed service on localhost:9876
I0630 14:23:06.732591 140649164094336 distributed.py:149] Connecting to JAX distributed service on localhost:9876
Running tests under Python 3.10.15: /proc/self/exe
[ RUN      ] CollectiveMatmulTestCase.test_all_gather_lhs_matmul0 (m_shard=1024, n_shard=64, k=256, block_m=64, block_n=64, block_k=64, max_concurrent_steps=2, dtype=<class 'jax.numpy.float16'>)
INFO:2025-06-30 14:23:06,783:jax._src.xla_bridge:752: Unable to initialize backend 'tpu': INTERNAL: Failed to open libtpu.so: libtpu.so: cannot open shared object file: No such file or directory
I0630 14:23:06.783609 140649164094336 xla_bridge.py:752] Unable to initialize backend 'tpu': INTERNAL: Failed to open libtpu.so: libtpu.so: cannot open shared object file: No such file or directory
[  FAILED  ] CollectiveMatmulTestCase.test_all_gather_lhs_matmul0 (m_shard=1024, n_shard=64, k=256, block_m=64, block_n=64, block_k=64, max_concurrent_steps=2, dtype=<class 'jax.numpy.float16'>)
======================================================================
ERROR: test_all_gather_lhs_matmul0 (m_shard=1024, n_shard=64, k=256, block_m=64, block_n=64, block_k=64, max_concurrent_steps=2, dtype=<class 'jax.numpy.float16'>) (__main__.CollectiveMatmulTestCase)
CollectiveMatmulTestCase.test_all_gather_lhs_matmul0 (m_shard=1024, n_shard=64, k=256, block_m=64, block_n=64, block_k=64, max_concurrent_steps=2, dtype=<class 'jax.numpy.float16'>)
test_all_gather_lhs_matmul(m_shard=1024, n_shard=64, k=256, block_m=64, block_n=64, block_k=64, max_concurrent_steps=2, dtype=<class 'jax.numpy.float16'>)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 446, in init_tma_desc
    peer_id = _recompute_peer_id(gmem_peer_id)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in _recompute_peer_id
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in <listcomp>
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in _recompute_peer_id
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in <listcomp>
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in _recompute_peer_id
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in <listcomp>
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in _recompute_peer_id
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in <listcomp>
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in _recompute_peer_id
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in <listcomp>
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in _recompute_peer_id
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in <listcomp>
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in _recompute_peer_id
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in <listcomp>
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in _recompute_peer_id
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 937, in <listcomp>
    new_operands = [_recompute_peer_id(x, fuel - 1) for x in op.operands]
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/mosaic/gpu/launch_context.py", line 929, in _recompute_peer_id
    raise ReplicationError(
jax.experimental.mosaic.gpu.launch_context.ReplicationError: gmem_peer_id computation is too complicated to recompute on the host

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/tests/pallas/mgpu_collective_matmul_test.py", line 141, in <module>
    jt_multiprocess.main()
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/_src/test_multiprocess.py", line 67, in main
    app.run(_main)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/pypi_absl_py/site-packages/absl/app.py", line 308, in run
    _run_main(main, args)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/pypi_absl_py/site-packages/absl/app.py", line 254, in _run_main
    sys.exit(main(argv))
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/_src/test_multiprocess.py", line 93, in _main
    absltest.main(testLoader=jtu.JaxTestLoader())
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/pypi_absl_py/site-packages/absl/testing/absltest.py", line 2131, in main
    _run_in_app(run_tests, args, kwargs)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/pypi_absl_py/site-packages/absl/testing/absltest.py", line 2226, in _run_in_app
    function(argv, args, kwargs)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/pypi_absl_py/site-packages/absl/testing/absltest.py", line 2689, in run_tests
    result, fail_when_no_tests_ran = _run_and_get_tests_result(
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/pypi_absl_py/site-packages/absl/testing/absltest.py", line 2653, in _run_and_get_tests_result
    test_program = unittest.TestProgram(*args, **kwargs)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/external/python_x86_64-unknown-linux-gnu/lib/python3.10/unittest/main.py", line 101, in __init__
    self.runTests()
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/external/python_x86_64-unknown-linux-gnu/lib/python3.10/unittest/main.py", line 271, in runTests
    self.result = testRunner.run(self.test)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/external/python_x86_64-unknown-linux-gnu/lib/python3.10/unittest/runner.py", line 184, in run
    test(result)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/external/python_x86_64-unknown-linux-gnu/lib/python3.10/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/_src/test_loader.py", line 184, in run
    return super().run(result)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/external/python_x86_64-unknown-linux-gnu/lib/python3.10/unittest/suite.py", line 122, in run
    test(result)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/external/python_x86_64-unknown-linux-gnu/lib/python3.10/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/_src/test_loader.py", line 184, in run
    return super().run(result)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/external/python_x86_64-unknown-linux-gnu/lib/python3.10/unittest/suite.py", line 122, in run
    test(result)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/external/python_x86_64-unknown-linux-gnu/lib/python3.10/unittest/case.py", line 650, in __call__
    return self.run(*args, **kwds)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/external/python_x86_64-unknown-linux-gnu/lib/python3.10/unittest/case.py", line 591, in run
    self._callTestMethod(testMethod)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/external/python_x86_64-unknown-linux-gnu/lib/python3.10/unittest/case.py", line 549, in _callTestMethod
    method()
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/pypi_absl_py/site-packages/absl/testing/parameterized.py", line 319, in bound_param_test
    return test_method(self, **testcase_params)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/tests/pallas/mgpu_collective_matmul_test.py", line 117, in test_all_gather_lhs_matmul
    out = run(
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/tests/pallas/mgpu_collective_matmul_test.py", line 107, in run
    out = jax.jit(
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/experimental/pallas/ops/gpu/collective_matmul_mgpu.py", line 178, in all_gather_lhs_matmul
    result, _ = plgpu.kernel(
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/_src/pallas/mosaic_gpu/core.py", line 208, in wrapper
    _, outs = state_discharge.run_state(stateful)(
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/_src/state/discharge.py", line 1116, in wrapped
    jaxpr_, consts, _ = initial_style_jaxpr(f, in_tree, ref_avals, dbg)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/_src/state/discharge.py", line 1095, in initial_style_jaxpr
    return _initial_style_jaxpr(fun, in_tree, tuple(in_avals), dbg)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/_src/state/discharge.py", line 1105, in _initial_style_jaxpr
    jaxpr, _, consts, () = pe.trace_to_jaxpr_dynamic(fun_, in_avals)
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/_src/pallas/mosaic_gpu/core.py", line 205, in stateful
    pallas_core.core_map(
  File "/root/.cache/bazel/_bazel_root/deb80d6610824a92deeac7b7fd0f3e3c/execroot/__main__/bazel-out/k8-opt/bin/tests/pallas/mgpu_collective_matmul_test_gpu.runfiles/__main__/jax/_src/pallas/core.py", line 1232, in wrapped
    out = core_map_p.bind(*consts, jaxpr=jaxpr, mesh=mesh,
jax._src.source_info_util.JaxStackTraceBeforeTransformation: ValueError: Failed to recompute the async_copy peer id on the host

The preceding stack trace is the source of the JAX operation that, once transformed by JAX, triggered the following exception.
```