### PR TITLE
Use more numerically stable computation for `jax.random.logistic`.

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -1766,8 +1766,8 @@ def logistic(key: ArrayLike,
 @partial(jit, static_argnums=(1, 2))
 def _logistic(key, shape, dtype):
   _check_shape("logistic", shape)
-  x = uniform(key, shape, dtype, minval=dtypes.finfo(dtype).eps, maxval=1.)
-  return lax.log(lax.div(x, lax.sub(lax._const(x, 1), x)))
+  x = uniform(key, shape, dtype, minval=dtypes.finfo(dtype).tiny, maxval=1.)
+  return lax.sub(lax.log(x), lax.log1p(lax.neg(x)))
 
 
 def pareto(key: ArrayLike,


### PR DESCRIPTION
The current implementation samples a value `x` uniformly in the range `[finfo(...).eps, 1)` and computes `log(x / 1 - x)`.

This PR proposes to sample a value `x` uniformly in the range `[finfo(...).tiny, 1)` and compute `log(x) - log1p(-x)`. Doing this computation in log-space should be more numerically stable.

Note that [distrax](https://github.com/google-deepmind/distrax), a dedicated library for modelling probability distributions, [uses this log-space computation for sampling from a logistic distribution](https://github.com/google-deepmind/distrax/blob/7fc5bd7efff4a7144d175199159f115c3e68a3cf/distrax/_src/distributions/logistic.py#L79-L85).