### PR TITLE
Simplify the handling of closed-over constants in Jaxprs

### DIFF
--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -1113,6 +1113,8 @@ def _array_mlir_constant_handler(val):
 
 mlir.register_constant_handler(ArrayImpl, _array_mlir_constant_handler)
 
+if config.use_simplified_jaxpr_constants.value:
+  core.literalable_types.add(ArrayImpl)
 
 # NOTE(skye): we could refactor to generate _multi_slice parameters directly
 # from the input ShardingSpec, rather than the indices. However, this would

--- a/jax/_src/effects.py
+++ b/jax/_src/effects.py
@@ -62,9 +62,13 @@ class Effect:
 Effects = Set[Effect]
 
 class JaxprInputEffect(Effect):
-  """A side-effect associated with the input of a jaxpr.
+  """A side-effect associated with the input of a `JaxprEqn` or a `Jaxpr`.
 
-  Note that the `input_index` includes constvars.
+  This is used as a base class for effects associated with inputs, e.g.,
+  reading/writing from mutable inputs.
+
+  When used in a `JaxprEqn`, `input_index` refers to `eqn.invars`.
+  When used in a `Jaxpr`, `input_index` refers to `jaxpr.constvars + jaxpr.invars`.
   """
 
   def __init__(self, input_index: Any):

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1745,7 +1745,7 @@ def make_jaxpr_effects(constvars, invars, outvars, eqns) -> effects.Effects:
               "\n Jaxpr: "
               f"{core.Jaxpr(constvars, invars, outvars, eqns, set())}")
         eqn_invar = eqn.invars[eff.input_index]
-        if eqn_invar in mut_arrays:
+        if type(eqn_invar) is core.Literal or eqn_invar in mut_arrays:
           continue
         if (input_index := all_vars.get(eqn_invar, sentinel)) is sentinel:
           # TODO(mattjj): ask for forgiveness

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -1020,7 +1020,9 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
   def test_shared_constants_under_scan(self):
     # See https://github.com/jax-ml/jax/issues/7992.
     if config.jax2tf_default_native_serialization.value:
-      raise unittest.SkipTest("shared constants tests not interesting for native serialization")
+      self.skipTest("shared constants tests not interesting for native serialization")
+    if config.use_simplified_jaxpr_constants.value:
+      self.skipTest("shared constants tests broken with new handling of constants")
     const_size = 512
     const = np.random.uniform(size=const_size).astype(np.float32)  # A shared constant
     xs = np.ones((8, const_size), dtype=np.float32)

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -1592,7 +1592,7 @@ class JaxExportTest(jtu.JaxTestCase):
     shardings_rev = NamedSharding(mesh_rev, jax.sharding.PartitionSpec(("i",)))
     input_no_shards = jnp.ones(shape=(jax.local_device_count(),))
     input = jnp.ones(shape=(jax.local_device_count(),), device=shardings)
-    input_rev = jax.device_put(input_no_shards, device=shardings_rev)
+    input_rev = jnp.ones(shape=(jax.local_device_count(),), device=shardings_rev)
 
     exp = export.export(pjit.pjit(f, in_shardings=shardings))(input)
     exp_rev = export.export(pjit.pjit(f, in_shardings=shardings_rev))(input_no_shards)

--- a/tests/for_loop_test.py
+++ b/tests/for_loop_test.py
@@ -282,9 +282,6 @@ class ForLoopTransformationTest(jtu.JaxTestCase):
       return for_loop.for_loop(x.shape[0], body, (x, jnp.zeros_like(x)))
     _, f_vjp = jax.linearize(f, jnp.ones((5, 2, 32)))
     jaxpr = jax.make_jaxpr(f_vjp)(jnp.ones((5, 2, 32)))
-    consts = [v.aval for v in jaxpr.jaxpr.constvars
-              if v.aval.shape == (2, 32)]
-    self.assertLen(consts, 2)
 
     def loss(A):
       def step(x, _):

--- a/tests/jaxpr_effects_test.py
+++ b/tests/jaxpr_effects_test.py
@@ -880,7 +880,10 @@ class JaxprInputEffectTest(jtu.JaxTestCase):
     def f(y):
       return input_effect(x, y, index=0)
     jaxpr = jax.make_jaxpr(f)(0)
-    self.assertIn(InputEffect(0), jaxpr.effects)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertEmpty(jaxpr.effects)
+    else:
+      self.assertIn(InputEffect(0), jaxpr.effects)
 
   def test_jaxpr_input_effect_is_tracked_through_partial_eval_custom(self):
     def f(_, y):
@@ -922,9 +925,15 @@ class JaxprInputEffectTest(jtu.JaxTestCase):
     def f(_):
       input_effect(x, index=0)
     jaxpr = jax.make_jaxpr(f)(0)
-    self.assertIn(InputEffect(0), jaxpr.effects)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertEmpty(jaxpr.effects)
+    else:
+      self.assertIn(InputEffect(0), jaxpr.effects)
     jaxpr3, _ = pe.dce_jaxpr(jaxpr.jaxpr, [], instantiate=[False])
-    self.assertIn(InputEffect(0), jaxpr3.effects)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertEmpty(jaxpr3.effects)
+    else:
+      self.assertIn(InputEffect(0), jaxpr3.effects)
 
   def test_jaxpr_input_effect_is_tracked_through_while_loop(self):
 
@@ -938,10 +947,16 @@ class JaxprInputEffectTest(jtu.JaxTestCase):
         lax.while_loop(lambda _: True, body, y)
       return f
     jaxpr = jax.make_jaxpr(make_fun(0))(0)
-    self.assertIn(InputEffect(1), jaxpr.effects)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertIn(InputEffect(0), jaxpr.effects)
+    else:
+      self.assertIn(InputEffect(1), jaxpr.effects)
 
     jaxpr = jax.make_jaxpr(make_fun(1))(0)
-    self.assertIn(InputEffect(0), jaxpr.effects)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertEmpty(jaxpr.effects)
+    else:
+      self.assertIn(InputEffect(0), jaxpr.effects)
 
     def f(x):
       def body(y):
@@ -949,7 +964,10 @@ class JaxprInputEffectTest(jtu.JaxTestCase):
         return 2 * y
       lax.while_loop(lambda _: (x > 0).all(), body, y)
     jaxpr = jax.make_jaxpr(f)(0)
-    self.assertIn(InputEffect(0), jaxpr.effects)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertEmpty(jaxpr.effects)
+    else:
+      self.assertIn(InputEffect(0), jaxpr.effects)
 
   def test_jaxpr_input_effect_is_tracked_through_scan(self):
     c = np.ones(2)
@@ -961,13 +979,22 @@ class JaxprInputEffectTest(jtu.JaxTestCase):
         lax.scan(body, z, xs)
       return f
     jaxpr = jax.make_jaxpr(make_fun(0))(jnp.arange(8), 0)
-    self.assertIn(InputEffect(1), jaxpr.effects)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertIn(InputEffect(0), jaxpr.effects)
+    else:
+      self.assertIn(InputEffect(1), jaxpr.effects)
 
     jaxpr = jax.make_jaxpr(make_fun(1))(jnp.arange(8), 0)
-    self.assertIn(InputEffect(2), jaxpr.effects)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertIn(InputEffect(1), jaxpr.effects)
+    else:
+      self.assertIn(InputEffect(2), jaxpr.effects)
 
     jaxpr = jax.make_jaxpr(make_fun(2))(jnp.arange(8), 0)
-    self.assertIn(InputEffect(0), jaxpr.effects)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertEmpty(jaxpr.effects)
+    else:
+      self.assertIn(InputEffect(0), jaxpr.effects)
 
   def test_jaxpr_input_effect_is_tracked_through_scan_with_dce(self):
     c = np.ones(2)
@@ -980,15 +1007,24 @@ class JaxprInputEffectTest(jtu.JaxTestCase):
       return f
     jaxpr = jax.make_jaxpr(make_fun(0))(jnp.arange(8), 0)
     jaxpr, _ = pe.dce_jaxpr(jaxpr.jaxpr, [])
-    self.assertIn(InputEffect(1), jaxpr.effects)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertIn(InputEffect(0), jaxpr.effects)
+    else:
+      self.assertIn(InputEffect(1), jaxpr.effects)
 
     jaxpr = jax.make_jaxpr(make_fun(1))(jnp.arange(8), 0)
     jaxpr, _ = pe.dce_jaxpr(jaxpr.jaxpr, [])
-    self.assertIn(InputEffect(2), jaxpr.effects)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertIn(InputEffect(1), jaxpr.effects)
+    else:
+      self.assertIn(InputEffect(2), jaxpr.effects)
 
     jaxpr = jax.make_jaxpr(make_fun(2))(jnp.arange(8), 0)
     jaxpr, _ = pe.dce_jaxpr(jaxpr.jaxpr, [])
-    self.assertIn(InputEffect(0), jaxpr.effects)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertEmpty(jaxpr.effects)
+    else:
+      self.assertIn(InputEffect(0), jaxpr.effects)
 
   def test_jaxpr_input_effect_is_tracked_through_cond(self):
 
@@ -1005,10 +1041,16 @@ class JaxprInputEffectTest(jtu.JaxTestCase):
       return f
     # [c, pred, x]
     jaxpr = jax.make_jaxpr(make_fun(0))(0)
-    self.assertIn(InputEffect(1), jaxpr.effects)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertIn(InputEffect(0), jaxpr.effects)
+    else:
+      self.assertIn(InputEffect(1), jaxpr.effects)
 
     jaxpr = jax.make_jaxpr(make_fun(1))(0)
-    self.assertIn(InputEffect(0), jaxpr.effects)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertEmpty(jaxpr.effects)
+    else:
+      self.assertIn(InputEffect(0), jaxpr.effects)
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -29,6 +29,7 @@ import numpy as np
 
 import jax
 from jax._src import core
+from jax._src import config
 from jax import dtypes
 from jax import lax
 from jax import random
@@ -2788,10 +2789,13 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     x = jnp.asarray(rng.randn(32, 2, 32).astype('float32'))
     _, vjp_fun = jax.vjp(cumprod, x)
 
+    # TODO(mattjj): should we re-enable this check? The constants are now
+    # inlined in the Jaxprs, not easy to find them.
     # Need to spelunk into vjp_fun. This is fragile, and if it causes problems
     # just skip this test and make an issue for mattjj.
-    *_, ext_res = vjp_fun.args[0].args[0]
-    self.assertIs(ext_res, x)
+    if not config.use_simplified_jaxpr_constants.value:
+      *_, ext_res = vjp_fun.args[0].args[0]
+      self.assertIs(ext_res, x)
 
     if remat is not None:
       # TODO(mattjj): make the numpy.ndarray test pass w/ remat

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -4806,9 +4806,14 @@ class CompositeTest(jtu.JaxTestCase):
 
     # The constant must not appear as an extra input argument to the composite.
     mlir_module = jax.jit(partial(my_consts, scale=scale)).lower(x).as_text()
-    self.assertIn(
-        "@my.consts(%arg0: tensor<3xf32>, %arg1: tensor<3xf32>) -> tensor<3xf32>", mlir_module
-    )
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertIn(
+          "@my.consts(%arg0: tensor<3xf32>) -> tensor<3xf32>", mlir_module
+      )
+    else:
+      self.assertIn(
+          "@my.consts(%arg0: tensor<3xf32>, %arg1: tensor<3xf32>) -> tensor<3xf32>", mlir_module
+      )
 
   def test_composite_with_tracer_consts(self):
     def fun(x, scale):

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -493,6 +493,8 @@ class PallasCallTest(PallasBaseTest):
     self.assertAllClose(pids[0:4], np.array([0] * 4, dtype=np.int32))
 
   def test_hoisted_consts(self):
+    if config.use_simplified_jaxpr_constants.value:
+      self.skipTest("TODO: decide if we want to keep these errors")
     # See https://github.com/jax-ml/jax/issues/21557.
     # to_store will be hoisted as a constant. Choose distinct shapes from in/outs.
     to_store = np.arange(128, dtype=np.float32).reshape((1, 128))
@@ -1171,6 +1173,8 @@ class ApiErrorTest(PallasBaseTest):
       f(a)
 
   def test_pallas_call_index_map_captures_consts(self):
+    if config.use_simplified_jaxpr_constants.value:
+      self.skipTest("TODO: decide if we want to keep these errors")
     a = np.arange(256, dtype=np.int32)
     index_map_result = np.array([0], dtype=np.int32)
     f = self.pallas_call(lambda x_ref, o1_ref: None,

--- a/tests/pallas/pallas_vmap_test.py
+++ b/tests/pallas/pallas_vmap_test.py
@@ -131,6 +131,8 @@ class PallasCallVmapTest(PallasBaseTest):
     np.testing.assert_allclose(out, out_ref)
 
   def test_vmap_with_hoisted_consts(self):
+    if config.use_simplified_jaxpr_constants.value:
+      self.skipTest("TODO: decide if we want to keep these errors")
     to_store = np.arange(128, dtype=np.float32).reshape((1, 128))
     x = np.arange(4 * 16 * 128, dtype=np.float32).reshape((4, 16, 128))
 

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -3987,7 +3987,7 @@ class ArrayPjitTest(jtu.JaxTestCase):
     pjit_e, = [e for e in jaxpr.jaxpr.eqns if e.primitive.name == "jit"]
     inner_pjit_jaxpr = pjit_e.params["jaxpr"]
     if config.use_simplified_jaxpr_constants.value:
-      self.assertIs(const, jaxpr.consts[0])
+      self.assertEmpty(jaxpr.consts)
       self.assertEmpty(inner_pjit_jaxpr.consts)
     else:
       self.assertEmpty(jaxpr.consts)

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -1744,8 +1744,10 @@ class ShardMapTest(jtu.JaxTestCase):
       self.assertIn('call @shmap_body(', hlo_str)
       self.assertIn('call @shmap_body_', hlo_str)
       self.assertIn('%arg0: tensor<1xf32>', hlo_str)
-      self.assertIn('"[None]"', hlo_str)
-      self.assertIn('%arg1: tensor<1xf32>', hlo_str)
+      if not config.use_simplified_jaxpr_constants.value:
+        # A constvar is turned into an argument with location None in @shmap_body
+        self.assertIn('"[None]"', hlo_str)
+        self.assertIn('%arg1: tensor<1xf32>', hlo_str)
       self.assertIn('"[(\'i\',)]"', hlo_str)
       self.assertIn(
           '-> (tensor<1xf32> {jax.result_info = "[(\'i\',)]"})', hlo_str


### PR DESCRIPTION
We make more non-scalar arrays literable, so that the constants get embedded directly into the equations. 

The motivation is described in #29679. We use a flag so that we can land this change without actually making it the default. There are a few follow-up change before we can turn this on.

With this change the closed-over constants are kept with the primitives that use them. This removes the need for ClosedJaxpr in most (or perhaps all) places.

This undoes some of the changes from #29743 (no need for all that machinery to move constants to the top-level Jaxpr, because they are now kept in the Jaxpr equations). We keep the same flag though.
