### PR TITLE
[mutable-arrays] several fixes for direct-linearize + mutable arrays

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -1124,6 +1124,7 @@ pytype_strict_library(
         ":mesh",
         ":partial_eval",
         ":source_info_util",
+        ":state_types",
         ":tree_util",
         ":util",
     ],

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1802,7 +1802,9 @@ class JaxprStackFrame:
 
     jaxpr = Jaxpr(constvars, self.invars, outvars, self.eqns, jaxpr_effects,
                   debug_info, self.is_high)
+    config.enable_checks.value and core.check_jaxpr(jaxpr)
     jaxpr, constvals = _drop_unused_vars(jaxpr, constvals)
+    config.enable_checks.value and core.check_jaxpr(jaxpr)
     return jaxpr, list(constvals)
 
   def to_jaxpr2(self, out_tracers: Sequence[core.Tracer],
@@ -2017,13 +2019,8 @@ class DynamicJaxprTrace(core.Trace):
     # TODO(mattjj): make custom_lin have hashable params.
     # TODO(dougalm): add an attribute to primitives to mark primitives with
     # effectful abstract_eval rules.
-    if (
-        primitive.name == "custom_lin"
-        or config.dynamic_shapes.value
-        or any(
-            isinstance(aval, core.MutableQuasiDynamicData) for aval in aval_qdds
-        )
-    ):
+    if (primitive.name == "custom_lin" or config.dynamic_shapes.value or
+        primitive.is_effectful and primitive.is_effectful(params)):
       out_avals, effs = primitive.abstract_eval(*aval_qdds, **params)
     else:
       try:

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -2092,7 +2092,8 @@ def to_gspmd_sharding(s: JSharding, ndim: int) -> GSPMDSharding:
 
 def _discharge_refs_jaxpr(closed_jaxpr, in_shardings, in_layouts,
                           donated_invars, out_shardings, out_layouts):
-  if any(isinstance(e, RefEffect) for e in closed_jaxpr.effects):
+  if (any(isinstance(e, RefEffect) for e in closed_jaxpr.effects) or
+      any(isinstance(a, AbstractRef) for a in closed_jaxpr.in_avals)):
     closed_jaxpr, inout_aliases, mut = _discharge_refs(closed_jaxpr)
     in_shardings = (*in_shardings, *(
         pjit.finalize_arg_sharding(c.sharding, c.committed) for c in mut.in_mut))

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -62,7 +62,7 @@ from jax._src.tree_util import equality_errors
 from jax._src.typing import Array
 from jax._src.util import (
     merge_lists, partition_list, safe_map, safe_zip, split_list,
-    split_list_checked, unzip2, weakref_lru_cache,)
+    split_list_checked, unzip2, weakref_lru_cache, subs_list)
 from jax._src import xla_bridge as xb
 from jax._src.tree_util import (
     keystr, tree_flatten, tree_flatten_with_path, tree_map, tree_unflatten,
@@ -628,15 +628,17 @@ def _scan_jvp(primals, tangents, reverse, length, jaxpr, num_consts, num_carry,
                   for p, nz in zip(primals_out, nonzeros_out)]
   return primals_out, tangents_out
 
-def _scan_linearization(nzs, *primals_in, reverse: bool, length: int,
-                        num_consts: int, num_carry: int,
-                        jaxpr: ClosedJaxpr, linear: Sequence[bool],
-                        unroll: int, _split_transpose: bool):
+def _scan_linearize(nzs, *primals_in, reverse: bool, length: int, num_consts:
+                    int, num_carry: int, jaxpr: ClosedJaxpr, linear:
+                    Sequence[bool], unroll: int, _split_transpose: bool):
   const_nz, init_nz, xs_nz = split_list(nzs, [num_consts, num_carry])
   carry_nz = init_nz
+  allow_fwds = [(i < num_consts or i >= num_consts + num_carry) and
+                not isinstance(x, np.ndarray) for i, x in enumerate(primals_in)]
   for _ in range(1 + num_carry):
     nzs = const_nz + carry_nz + xs_nz
-    primal_jaxpr, num_res, nzs_out, tangent_jaxpr = ad.linearize_jaxpr(jaxpr, nzs)
+    primal_jaxpr, num_res_out, nzs_out, in_fwd_res, tangent_jaxpr = \
+        ad.linearize_jaxpr(jaxpr, nzs, allow_fwds=allow_fwds)
     carry_nz_out = nzs_out[:num_carry]
     if carry_nz_out == carry_nz:
       break
@@ -644,62 +646,63 @@ def _scan_linearization(nzs, *primals_in, reverse: bool, length: int,
       carry_nz = _map(operator.or_, carry_nz, carry_nz_out)
   else:
     assert False, "Fixpoint not reached"
+  num_res_in = len(in_fwd_res)
+  num_primals_out = len(primal_jaxpr.out_avals) - num_res_out
 
-  # The linearize_jaxpr function produces primal_jaxpr with num_res residuals
-  # output at the front, and tangent_jaxpr with num_res residuals input at the
-  # back. We could move all the residuals to the back and treat them as
-  # extensive outputs, but this would be wasteful for residuals that are
-  # loop invariant, or forwarded extensive inputs.
+  # At this point all non-forwarded residuals produced by primal_jaxpr are at
+  # the end. We want to hoist out loop-invariant ones:
+  # Before:
+  #  [*const_primals_in , *carry_ext_primals_in] -> [*primals_out, *non_fwd_res]
+  # After:
+  #  [*const_primals_in_, *carry_ext_primals_in] -> [*primals_out, *ext_res]
+  # where, modulo hoisted res not being broadcasted by the scan,
+  #  non_fwd_res = merge_lists(which_hoisted, ext_res, hoisted_res)
+  const_primals_in, carry_ext_primals_in = split_list(primals_in, [num_consts])
+  primal_jaxpr, const_primals_in_, which_hoisted, hoisted_res = \
+      _scan_known_hoisting(primal_jaxpr, const_primals_in, num_res_out)
+  del num_res_out
 
-  # First, for residuals that are forwarded constants, we move those to the
-  # front in the tangent_jaxpr to treat them as intensive inputs.
-  in_fwd = pe._jaxpr_forwarding(primal_jaxpr.jaxpr)
-  primal_jaxpr, tangent_jaxpr, intensive_res, in_fwd = _const_to_intensive_res_forwarding(
-      primal_jaxpr, tangent_jaxpr, num_res, num_consts, primals_in, in_fwd)
-  num_intensive_res = len(intensive_res)
-  num_res -= num_intensive_res
+  # To make tangent_jaxpr match the scan calling convention, move to the back
+  # binders that don't correspond to hoisted or const-forwarded residuals.
+  #   Before: [*res, *tangents_in] -> [*tangents_out]
+  #   After: [*int_res, *tangents_in, *ext_res] -> [*tangents_out]
+  num_tangents_in = len(tangent_jaxpr.in_avals) - num_res_in
+  which_hoisted_ = iter(which_hoisted)
+  res_to_move = [not next(which_hoisted_) if f is None else
+                 f >= len(jaxpr.consts) + num_consts + num_carry
+                 for f in in_fwd_res]
+  assert next(which_hoisted_, None) is None
+  tangent_jaxpr = pe.move_binders_to_back(
+      tangent_jaxpr, res_to_move + [False] * num_tangents_in)
 
-  # After pruning the intensive residuals, the rest get moved to the back and
-  # handled as extensive outputs from the primal.
-  num_out = len(nzs_out)
-  primal_jaxpr = pe.move_outvars_to_back(
-      primal_jaxpr, [True] * num_res + [False] * num_out)
-  in_fwd = in_fwd[num_res:] + in_fwd[:num_res]
+  # Run the primal scan (if it has any outputs or effects).
+  if not primal_jaxpr.out_avals and not primal_jaxpr.effects:
+    out = []
+  else:
+    linear_ = (False,) * len(primal_jaxpr.in_avals)  # TODO conservative
+    out = scan_p.bind(*const_primals_in_, *carry_ext_primals_in,
+                      jaxpr=primal_jaxpr, reverse=reverse, length=length,
+                      num_consts=len(const_primals_in_), num_carry=num_carry,
+                      linear=linear_, unroll=unroll,
+                      _split_transpose=_split_transpose)
+  primals_out, ext_res = split_list(out, [num_primals_out])
 
-  # Then, any residuals or other extensive outputs that are forwarded extensive
-  # inputs, we remove them from the primal jaxpr, and manually forward them.
-  in_fwd = [in_idx if out_idx >= num_carry and in_idx is not None and
-            in_idx >= num_consts + num_carry else None
-            for out_idx, in_idx in enumerate(in_fwd)]
-  primal_jaxpr = pe.prune_closed_jaxpr_outputs(primal_jaxpr,
-                                               [i is None for i in in_fwd])
-
-  out = scan_p.bind(*primals_in, jaxpr=primal_jaxpr, reverse=reverse,
-                    length=length, num_consts=num_consts, num_carry=num_carry,
-                    linear=linear, unroll=unroll, _split_transpose=_split_transpose)
-  out_ = iter(out)
-  all_out = [next(out_) if f is None else _maybe_put(primals_in[f]) for f in in_fwd]
-  assert next(out_, None) is None
-  primals_out, extensive_res = split_list(all_out, [len(all_out) - num_res])
-  res = [*intensive_res, *extensive_res]
+  # Complete res using hoisted_res and input forwards.
+  res = subs_list(in_fwd_res, [*jaxpr.consts, *primals_in],
+                  merge_lists(which_hoisted, ext_res, hoisted_res))
 
   def tangent_fun(res, *tangents):
-    intensive_res, extensive_res = split_list(res, [num_intensive_res])
+    int_res, ext_res = partition_list(res_to_move, res)
     nz_tangents = [ad.instantiate_zeros(x) for nz, x in zip(nzs, tangents) if nz]
-    tangent_linear = (
-        (False,) * len(intensive_res) +
-        (True,) * len(nz_tangents) +
-        (False,) * len(extensive_res)
-    )
-    tangent_num_consts = len(intensive_res) + sum(nzs[:num_consts])
+    tangent_linear = ((False,) * len(int_res) + (True,) * len(nz_tangents) +
+                      (False,) * len(ext_res))
+    tangent_num_consts = len(int_res) + sum(nzs[:num_consts])
     tangent_num_carry = sum(nzs[num_consts:num_consts + num_carry])
-    nz_tangents_out = scan_p.bind(*intensive_res, *nz_tangents, *extensive_res,
-                                  jaxpr=tangent_jaxpr,
-                                  reverse=reverse, length=length,
-                                  num_consts=tangent_num_consts,
-                                  num_carry=tangent_num_carry,
-                                  linear=tangent_linear, unroll=unroll,
-                                  _split_transpose=_split_transpose)
+    nz_tangents_out = scan_p.bind(
+        *int_res, *nz_tangents, *ext_res, jaxpr=tangent_jaxpr, reverse=reverse,
+        length=length, num_consts=tangent_num_consts,
+        num_carry=tangent_num_carry, linear=tangent_linear, unroll=unroll,
+        _split_transpose=_split_transpose)
     tangent_avals_out = [v.aval.to_tangent_aval() for v in jaxpr.jaxpr.outvars]
     nz_tangents_out_ = iter(nz_tangents_out)
     tangents_out = [next(nz_tangents_out_) if nz else ad.Zero(aval)
@@ -708,27 +711,6 @@ def _scan_linearization(nzs, *primals_in, reverse: bool, length: int,
     return tangents_out
 
   return primals_out, nzs_out, res, tangent_fun
-
-def _const_to_intensive_res_forwarding(
-    primal_jaxpr: ClosedJaxpr,
-    tangent_jaxpr: ClosedJaxpr,
-    num_res: int,
-    num_consts: int,
-    primals_in: Sequence[Any],
-    in_fwd: list[int | None]
-) -> tuple[ClosedJaxpr, ClosedJaxpr, list[Any], list[int | None]]:
-  const_to_res = [in_idx if in_idx is not None and in_idx < num_consts else None
-                  for in_idx in in_fwd[:num_res]]
-  new_in_fwd = [f for c, f in zip(const_to_res, in_fwd[:num_res]) if c is None]
-  new_in_fwd += in_fwd[num_res:]
-  intensive_res = [primals_in[f] for f in const_to_res if f is not None]
-  num_out = len(primal_jaxpr.out_avals) - num_res
-  primal_jaxpr = pe.prune_closed_jaxpr_outputs(
-      primal_jaxpr, [i is None for i in const_to_res] + [True] * num_out)
-  num_nz = len(tangent_jaxpr.in_avals) - num_res
-  tangent_jaxpr = pe.move_binders_to_front(
-      tangent_jaxpr, [False] * num_nz + [i is not None for i in const_to_res])
-  return primal_jaxpr, tangent_jaxpr, intensive_res, new_in_fwd
 
 def _scan_known_hoisting(jaxpr_known, known_consts, num_res):
   # To disable:
@@ -799,6 +781,7 @@ def _scan_partial_eval(trace, *tracers, reverse: bool,
   known_consts, known_ins = split_list(known_ins, [num_consts_known])
   jaxpr_known, known_consts_, which_hoisted, hoisted_res = \
       _scan_known_hoisting(jaxpr_known, known_consts, num_res_out)
+  del num_res_out  # changed
 
   # To make jaxpr_unknown match the scan calling convention, move to the back
   # binders that don't correspond to hoisted or const-forwarded residuals.
@@ -1455,13 +1438,14 @@ def _scan_state_partial_discharge_rule(should_discharge, in_avals, out_avals, *a
   return refs_out_matching_in_avals, [*carry_out, *ys]
 
 scan_p = core.Primitive("scan")
+scan_p.is_effectful = lambda params: bool(params['jaxpr'].effects)  # type: ignore
 scan_p.multiple_results = True
 scan_p.skip_canonicalization = True
 scan_p.def_impl(partial(dispatch.apply_primitive, scan_p))
 scan_p.def_effectful_abstract_eval(_scan_abstract_eval)
 ad.primitive_jvps[scan_p] = _scan_jvp
 ad.primitive_transposes[scan_p] = _scan_transpose
-ad.primitive_linearizations[scan_p] = _scan_linearization
+ad.primitive_linearizations[scan_p] = _scan_linearize
 pe.custom_partial_eval_rules[scan_p] = _scan_partial_eval
 xla.register_initial_style_primitive(scan_p)
 mlir.register_lowering(scan_p,

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4209,7 +4209,7 @@ def _sin_lowering(ctx, x, accuracy):
   return _nary_lower_hlo(hlo.sine, ctx, x, accuracy=accuracy)
 
 
-def _sin_p_lin(nzs, x, accuracy):
+def _sin_lin(nzs, x, accuracy):
   nz, = nzs
   cos_x = cos(x) # TODO: allow this to happen in the linearized computation (need to fix backward_pass)
   return (
@@ -4221,7 +4221,7 @@ def _sin_p_lin(nzs, x, accuracy):
 
 sin_p = standard_unop(_float | _complex, 'sin')
 ad.defjvp(sin_p, lambda g, x, accuracy: mul(g, cos(x, accuracy=accuracy)))
-ad.primitive_linearizations[sin_p] = _sin_p_lin
+ad.primitive_linearizations[sin_p] = _sin_lin
 mlir.register_lowering(sin_p, _sin_lowering)
 core.pp_eqn_rules[sin_p] = _unary_with_accuracy_pp_rule
 batching.ragged_prop_rules[sin_p] = batching.ragged_mask_elementwise_rule

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1510,6 +1510,7 @@ def check_aval_layout_compatibility(
 # -------------------- pjit rules --------------------
 
 pjit_p = core.Primitive("jit")
+pjit_p.is_effectful = lambda params: bool(params['jaxpr'].effects)  # type: ignore
 pjit_p.multiple_results = True
 pjit_p.skip_canonicalization = True
 
@@ -2224,56 +2225,61 @@ def _pjit_jvp(primals_in, tangents_in,
 ad.primitive_jvps[pjit_p] = _pjit_jvp
 
 
-def _pjit_linearization(nzs, *primals_in, jaxpr,
-                        in_shardings, out_shardings, in_layouts, out_layouts,
-                        donated_invars, ctx_mesh, name, keep_unused, inline,
-                        compiler_options_kvs):
-  primal_jaxpr, num_residuals, nzs_out, tangent_jaxpr = ad.linearize_jaxpr(jaxpr, nzs)
-  res_shardings = (UNSPECIFIED,) * num_residuals
-  res_layouts = (None,) * num_residuals
-  res_donated = (False,) * num_residuals
-  primal_out_shardings = res_shardings + tuple(out_shardings)
-  primal_out_layouts = res_layouts + tuple(out_layouts)
+def _pjit_linearize(nzs, *primals_in, jaxpr, in_shardings, out_shardings,
+                    in_layouts, out_layouts, donated_invars, ctx_mesh, name,
+                    keep_unused, inline, compiler_options_kvs):
+  primal_jaxpr, num_residuals_out, nzs_out, in_fwd_res, tangent_jaxpr = \
+      ad.linearize_jaxpr(jaxpr, nzs)
+  num_residuals_in = len(in_fwd_res)
+  num_primals_out = len(primal_jaxpr.out_avals) - num_residuals_out
+
+  res_shardings_in = (UNSPECIFIED,) * num_residuals_in
+  res_layouts_in = (None,) * num_residuals_in
+  res_donated = (False,) * num_residuals_in
+  primal_out_shardings = tuple(out_shardings) + (UNSPECIFIED,) * num_residuals_out
+  primal_out_layouts = tuple(out_layouts) + (None,) * num_residuals_out
+
+  config.enable_checks.value and core.check_jaxpr(primal_jaxpr.jaxpr)
+  config.enable_checks.value and core.check_jaxpr(tangent_jaxpr.jaxpr)
 
   def keep_where(l, should_keep):
     return tuple(x for x, keep in zip(l, should_keep) if keep)
 
   # Input-to-output forwarding.
   in_fwd = pe._jaxpr_forwarding(primal_jaxpr.jaxpr)
-  in_fwd_res, in_fwd_primal = split_list(in_fwd, [num_residuals])
-  in_fwd = in_fwd_res + [
+  in_fwd_primal, in_fwd_res_ = split_list(in_fwd, [num_primals_out])
+  assert all(f is None for f in in_fwd_res_)
+  in_fwd = [
       fwd if isinstance(os, UnspecifiedValue) and ol is None else None
       for os, ol, fwd in zip(out_shardings, out_layouts, in_fwd_primal)
-  ]
-  del in_fwd_res, in_fwd_primal
+  ] + in_fwd_res_
+  del in_fwd_res_, in_fwd_primal
   keep = [f is None for f in in_fwd]
   primal_jaxpr = pe.prune_closed_jaxpr_outputs(primal_jaxpr, keep)
   primal_out_shardings = keep_where(primal_out_shardings, keep)
   primal_out_layouts = keep_where(primal_out_layouts, keep)
-  kept_res, _ = split_list(keep, [num_residuals])
+  _, kept_res = split_list(keep, [num_primals_out])
   num_kept_residuals = sum(kept_res)
-  del keep, kept_res
+  del keep, kept_res, num_primals_out
 
   # Output-to-output forwarding.
-  num_out_primals = len(primal_jaxpr.jaxpr.outvars) - num_kept_residuals
-  res_vars, out_vars = split_list(primal_jaxpr.jaxpr.outvars, [num_kept_residuals])
+  num_primals_out = len(primal_jaxpr.out_avals) - num_kept_residuals
+  out_vars, res_vars = split_list(primal_jaxpr.jaxpr.outvars, [num_primals_out])
   idx_map = {id(v): i for i, v in enumerate(out_vars)}
-  offset = sum(id(v) not in idx_map for v in res_vars)
-  idx_map = {k: v + offset for k, v in idx_map.items()}
-  out_fwd = [idx_map.get(id(v)) for v in res_vars] + [None] * num_out_primals
+  out_fwd = [None] * num_primals_out + [idx_map.get(id(v)) for v in res_vars]
   keep = [f is None for f in out_fwd]
   primal_jaxpr = pe.prune_closed_jaxpr_outputs(primal_jaxpr, keep)
   primal_out_shardings = keep_where(primal_out_shardings, keep)
   primal_out_layouts = keep_where(primal_out_layouts, keep)
   del keep
 
-  def tangent_fun(consts_, *tangents):
+  def tangent_fun(residuals, *tangents):
     tangents_nz = _filter_zeros(nzs, tangents)
-    nz_tangents_out = pjit_p.bind(*tangents_nz, *consts_,
-        jaxpr=tangent_jaxpr,
-        in_shardings=_filter_zeros(nzs, in_shardings) + res_shardings,
+    nz_tangents_out = pjit_p.bind(
+        *residuals, *tangents_nz, jaxpr=tangent_jaxpr,
+        in_shardings=_filter_zeros(nzs, in_shardings) + res_shardings_in,
         out_shardings=_filter_zeros(nzs_out, out_shardings),
-        in_layouts=_filter_zeros(nzs, in_layouts) + res_layouts,
+        in_layouts=_filter_zeros(nzs, in_layouts) + res_layouts_in,
         out_layouts=_filter_zeros(nzs_out, out_layouts),
         donated_invars=_filter_zeros(nzs, donated_invars) + res_donated,
         ctx_mesh=ctx_mesh,
@@ -2290,6 +2296,7 @@ def _pjit_linearization(nzs, *primals_in, jaxpr,
   def _filter_zeros(is_nz_l, l):
     return tuple(x for nz, x in zip(is_nz_l, l) if nz)
 
+  assert len(in_shardings) == len(primal_jaxpr.in_avals)
   ans = pjit_p.bind(*primals_in, jaxpr=primal_jaxpr,
                     in_shardings=in_shardings,
                     out_shardings=primal_out_shardings,
@@ -2303,11 +2310,12 @@ def _pjit_linearization(nzs, *primals_in, jaxpr,
                     compiler_options_kvs=compiler_options_kvs)
   ans = subs_list(out_fwd, ans, ans)
   ans = subs_list(in_fwd, primals_in, ans)
-  residuals_ans, primal_ans = split_list(ans, [num_residuals])
+  primal_ans, residuals_ans = split_list(ans, [len(ans) - num_residuals_out])
+  residuals_ans = subs_list(in_fwd_res, [*jaxpr.consts, *primals_in], residuals_ans)
 
   return primal_ans, nzs_out, residuals_ans, tangent_fun
 
-ad.primitive_linearizations[pjit_p] = _pjit_linearization
+ad.primitive_linearizations[pjit_p] = _pjit_linearize
 
 
 def _pjit_partial_eval(trace: pe.JaxprTrace,

--- a/jax/_src/public_test_util.py
+++ b/jax/_src/public_test_util.py
@@ -359,4 +359,15 @@ def check_grads(f, args, order,
           return vjp_py(out_primal_py)
         _check_grads(f_vjp, args, order - 1, rev_msg)
 
+    if "lin" in modes:
+      lin_msg = f'LIN of {err_msg}' if err_msg else 'LIN'
+      _check_jvp(f, partial(_jvp_from_lin, f), args, err_msg=lin_msg)
+      if order > 1:
+        _check_grads(partial(_jvp_from_lin, f), (args, args), order - 1, lin_msg)
+
   _check_grads(f, args, order)
+
+def _jvp_from_lin(f, primals, tangents):
+  primal_out, f_lin = api.linearize(f, *primals)
+  tangent_out = f_lin(*tangents)
+  return primal_out, tangent_out

--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -63,6 +63,7 @@ traceback_util.register_exclusion(__file__)
 # `Ref((3,), np.dtype('float32'))` leads to a jaxpr eqn printed like
 #   a:f32[3] <- x[]
 get_p = core.Primitive("get")
+get_p.is_effectful = lambda params: True  # type: ignore
 get_p.def_impl(partial(dispatch.apply_primitive, get_p))
 batching.ragged_prop_rules[get_p] = batching.ragged_mask_transfer_identity
 
@@ -124,6 +125,7 @@ def ref_get(
 # are `ShapedArray((), np.dtype('int32'))` leads to a jaxpr eqn printed like
 #   x:Ref{f32[3]}[i, j] <- a
 swap_p = core.Primitive("swap")
+swap_p.is_effectful = lambda params: True  # type: ignore
 swap_p.def_impl(partial(dispatch.apply_primitive, swap_p))
 
 
@@ -185,6 +187,7 @@ def ref_set(
 # _ = swap ref c *idx
 # ```
 addupdate_p = core.Primitive('addupdate')
+addupdate_p.is_effectful = lambda params: True  # type: ignore
 addupdate_p.multiple_results = True
 addupdate_p.def_impl(partial(dispatch.apply_primitive, addupdate_p))
 
@@ -383,23 +386,26 @@ core.pp_eqn_rules[addupdate_p] = _addupdate_pp_rule
 
 def _get_jvp(primals: list[Any], tangents: list[Any], **params: Any):
   ref_primal, *idx = primals
-  assert isinstance(ref_primal.aval, AbstractRef)
   ref_tangent, *_ = tangents
-  assert isinstance(ref_tangent.aval, AbstractRef)
-  return (get_p.bind(ref_primal, *idx, **params),
-          get_p.bind(ref_tangent, *idx, **params))
+  out_primal = get_p.bind(ref_primal, *idx, **params)
+  if isinstance(ref_tangent, ad_util.Zero):
+    out_tangent = ad_util.Zero(core.typeof(out_primal).to_tangent_aval())
+  else:
+    out_tangent = get_p.bind(ref_tangent, *idx, **params)
+  return out_primal, out_tangent
 ad.primitive_jvps[get_p] = _get_jvp
 
 def _swap_jvp(primals: list[Any], tangents: list[Any], **params: Any):
   ref_primal, x_primal, *idx = primals
-  assert isinstance(ref_primal.aval, AbstractRef)
   ref_tangent, x_tangent, *_ = tangents
-  # if type(ref_tangent) is ad_util.Zero:
-  #   raise Exception("you're an idiot")
-  assert isinstance(ref_tangent.aval, AbstractRef)
-  x_tangent = ad_util.instantiate(x_tangent)
-  return (swap_p.bind(ref_primal, x_primal, *idx, **params),
-          swap_p.bind(ref_tangent, x_tangent, *idx, **params))
+  out_primal = swap_p.bind(ref_primal, x_primal, *idx, **params)
+  if isinstance(ref_tangent, ad_util.Zero) and isinstance(x_tangent, ad_util.Zero):
+    out_tangent = ad_util.Zero(core.typeof(out_primal).to_tangent_aval())
+  else:
+    assert not isinstance(ref_tangent, ad_util.Zero)
+    x_tangent = ad_util.instantiate(x_tangent)
+    out_tangent = swap_p.bind(ref_tangent, x_tangent, *idx, **params)
+  return out_primal, out_tangent
 ad.primitive_jvps[swap_p] = _swap_jvp
 
 def addupdate_jvp_rule(primals: list[Any], tangents: list[Any], **params: Any):
@@ -421,7 +427,6 @@ def _get_transpose(g, ref, *idx, **params):
 ad.primitive_transposes[get_p] = _get_transpose
 
 def _swap_transpose(g, ref, x, *idx, **params):
-  del x  # old value doesn't matter anymore
   # swap transpose is swap
   x_bar = swap_p.bind(ref, ad_util.instantiate(g), *idx, **params)
   return [None, x_bar] + [None] * len(idx)
@@ -781,5 +786,13 @@ def _mut_jvp(primals, tangents):
     tangent_out = core.mutable_array_p.bind(init_val_dot)
   return primal_out, tangent_out
 
+def _mut_lin(nzs, x):
+  nz, = nzs
+  x_ref = core.mutable_array_p.bind(x)
+  def mut_lin(_, x_dot):
+    return core.mutable_array_p.bind(ad_util.instantiate(x_dot))
+  return x_ref, True, None, mut_lin
+
 ad.primitive_jvps[core.mutable_array_p] = _mut_jvp
 ad.defjvp(core.freeze_p, lambda g, _: core.freeze(g))
+ad.primitive_linearizations[core.mutable_array_p] = _mut_lin

--- a/tests/mutable_array_test.py
+++ b/tests/mutable_array_test.py
@@ -22,6 +22,7 @@ import jax
 from jax._src import core
 from jax._src import config
 from jax._src import test_util as jtu
+from jax._src.util import safe_map, safe_zip
 from jax.sharding import NamedSharding, PartitionSpec as P, AxisType
 import jax.numpy as jnp
 
@@ -31,7 +32,11 @@ config.parse_flags_with_absl()
 
 jtu.request_cpu_devices(8)
 
+map, unsafe_map = safe_map, map
+zip, unsafe_zip = safe_zip, zip
 
+
+@jtu.with_config(jax_use_direct_linearize=True)
 class MutableArrayTest(jtu.JaxTestCase):
 
   @parameterized.parameters([True, False])
@@ -503,6 +508,123 @@ class MutableArrayTest(jtu.JaxTestCase):
     expected = 2. * jnp.cos(2.)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @parameterized.parameters([False, True])
+  def test_grad_jit_readonly(self, jit):
+    def f(x):
+      x_ref = core.mutable_array(jnp.zeros_like(x))
+      x_ref[...] = x
+      return x_ref[...]
+
+    if jit:
+      f = jax.jit(f)
+
+    jtu.check_grads(f, (1.5,), 2, ['fwd', 'rev'])
+
+  def test_grad_jit_readonly_1(self):
+    @jax.jit
+    def f(x):
+      x_ref = core.mutable_array(x)
+
+      def inner():
+        return jnp.sin(x_ref[...])
+
+      return inner()
+
+    jtu.check_grads(f, (1.5,), 2, ['fwd', 'rev'])
+
+  def test_grad_jit_readonly_2(self):
+    def f(x):
+      x_ref = core.mutable_array(x)
+
+      @jax.jit
+      def inner():
+        return jnp.sin(x_ref[...])
+
+      return inner()
+
+    jtu.check_grads(f, (1.5,), 2, ['fwd', 'rev'])
+
+  @jtu.sample_product(
+      seed=range(6),
+      num_consts=range(2, 6),
+      num_args=[0, 3],
+  )
+  @jtu.run_on_devices("cpu")
+  def test_jit_vjp_systematic_readonly(self, seed, num_consts, num_args):
+    num_mut_consts = num_consts // 2
+    num_pure_consts = num_consts - num_mut_consts
+
+    rng = np.random.RandomState(seed)
+    pure_consts = [rng.normal() for _ in range(num_pure_consts)]
+    mut_const_vals = [rng.normal() for _ in range(num_mut_consts)]
+
+    args = [rng.normal() for _ in range(num_args)]
+
+    mutable_bools = rng.permutation([True] * num_mut_consts +
+                                    [False] * num_pure_consts)
+
+    def f(mut_const_vals, pure_consts, args):
+      consts = pure_consts[:], map(core.mutable_array, mut_const_vals)
+
+      @jax.jit
+      def inner(args):
+        tot = 0.
+        for is_mut in mutable_bools:
+          const = consts[int(is_mut)].pop()
+          if is_mut: const = const[...]
+          tot += jnp.sin(const)
+        for x in args:
+          tot += jnp.sin(x)
+        return tot
+
+      return inner(args)
+
+    jtu.check_grads(f, (mut_const_vals, pure_consts, args), 2, ['rev'])
+
+  @jtu.sample_product(
+      seed=range(6),
+      num_consts=range(2, 6),
+      num_carry=[0, 3],
+      num_ext_in=[0, 3],
+      num_iters=[1, 3],
+  )
+  @jtu.run_on_devices("cpu")
+  def test_scan_vjp_systematic_readonly(
+      self, seed, num_consts, num_carry, num_ext_in, num_iters):
+    num_mut_consts = 1 # num_consts // 2
+    num_pure_consts = 0 # num_consts - num_mut_consts
+    num_carry = 1
+    num_ext_in = 0
+    num_iters = 1
+
+    rng = np.random.RandomState(seed)
+    pure_consts = [rng.normal() for _ in range(num_pure_consts)]
+    mut_const_vals = [rng.normal() for _ in range(num_mut_consts)]
+
+    init_carry = [rng.normal() for _ in range(num_carry)]
+    xs = [rng.normal(size=num_iters) for _ in range(num_ext_in)]
+
+    mutable_bools = rng.permutation([True] * num_mut_consts +
+                                    [False] * num_pure_consts)
+
+    def f(mut_const_vals, pure_consts, c, xs):
+      consts = pure_consts[:], map(core.mutable_array, mut_const_vals)
+
+      def body(c, x):
+        tot = 0.
+        for is_mut in mutable_bools:
+          const = consts[int(is_mut)].pop()
+          if is_mut: const = const[...]
+          tot += jnp.sin(const)
+        new_c = [jnp.sin(carry) + tot for carry in c]
+        y = sum(map(jnp.sin, x)) * 1.0
+        return new_c, y
+
+      return jax.lax.scan(body, init_carry, xs, length=num_iters)
+
+    jtu.check_grads(f, (mut_const_vals, pure_consts, init_carry, xs),
+                    2, ['fwd', 'rev'])
+
 
 @jtu.with_config(jax_mutable_array_checks=True)
 class MutableArrayErrorsTest(jtu.JaxTestCase):
@@ -647,18 +769,17 @@ class MutableArrayErrorsTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, "x_ref and y_ref"):
       f(x_ref, x_ref)
 
-  # TODO(mattjj): re-enable test after direct-linearize
-  # @parameterized.parameters([False, True])
-  # def test_argument_aliases_custom_vjp_fwd(self, jit):
-  #   @jax.custom_vjp
-  #   def f(x_ref, y_ref):
-  #     ...
-  #   f.defvjp(lambda x_ref, y_ref: (None, None), lambda _, g: (None, None))
-  #   if jit:
-  #     f = jax.jit(f)
-  #   x_ref = core.mutable_array(0.)
-  #   with self.assertRaisesRegex(ValueError, "x_ref and y_ref"):
-  #     jax.vjp(f, x_ref, x_ref)
+  @parameterized.parameters([False, True])
+  def test_argument_aliases_custom_vjp_fwd(self, jit):
+    @jax.custom_vjp
+    def f(x_ref, y_ref):
+      ...
+    f.defvjp(lambda x_ref, y_ref: (None, None), lambda _, g: (None, None))
+    if jit:
+      f = jax.jit(f)
+    x_ref = core.mutable_array(0.)
+    with self.assertRaisesRegex(ValueError, "x_ref and y_ref"):
+      jax.vjp(f, x_ref, x_ref)
 
   # TODO(mattjj): add test test_closure_and_argument_aliases_custom_vjp
 


### PR DESCRIPTION
* bake forwarding / infer-common-argnums into `ad.linearize_jaxpr`, like we did for `pe.partial_eval_jaxpr`
* change the signature convention of `ad.linearize_jaxpr` to do `primal_jaxpr: [*primals_in] -> [*primals_out, *non_fwd_res]` and `tangent_jaxpr: [*res, *tangents_in] -> [*tangents_out]` because I didn't want to update scan utility functions (and it slightly simplified the code to follow this convention)
* update `_pjit_linearize` and `_scan_linearize` to handle those changes to `ad.linearize_jaxpr`
* in `LinearizeTrace.process_primitive`, don't short-circuit if all tangents are zero, since we still need to bind effectful primitives
* in `fallback_linearize_rule`, respect partial eval effect handles (we can also just write linearize rules for all effectful primitives, but I wanted to make the partial eval path work now instead of leaving it surprising)
* allow symbolic zero Refs in `swap_jvp` and `get_jvp` specifically to handle float0-dtyped refs (basically DCE-ing them via symbolic zeros)
* add tests