### PR TITLE
simplify jaxpr builder by not deduping constants on-the-fly

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -463,7 +463,7 @@ def new_jaxpr_eqn(invars, outvars, primitive, params, effects, source_info=None,
 _var_counter = it.count()
 
 class Var:
-  __slots__ = ["count", "aval", "initial_qdd", "final_qdd"]
+  __slots__ = ["count", "aval", "initial_qdd", "final_qdd", "__weakref__"]
 
   count: int
   aval: AbstractValue

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -1816,7 +1816,9 @@ def lower_jaxpr_to_fun(
         [num_dim_vars, num_tokens])
     tokens_in = TokenSet(zip(effects, token_args))
     args: list[IrValues] = unflattened_args
-    consts = [ir_constant(xla.canonicalize_dtype(x)) for x in jaxpr.consts]
+    deduped_consts = {id(c): ir_constant(xla.canonicalize_dtype(c))
+                      for c in jaxpr.consts}
+    consts = [deduped_consts[id(c)] for c in jaxpr.consts]
     out_vals, tokens_out = jaxpr_subcomp(
         ctx, jaxpr.jaxpr, name_stack, tokens_in,
         consts, *args, dim_var_values=dim_var_values)
@@ -2402,12 +2404,8 @@ def lower_per_platform(ctx: LoweringRuleContext,
   return results
 
 def _ir_consts(consts) -> list[IrValues]:
-  unique_consts = {id(const): const for const in consts}
-  ir_consts = {
-      id_: ir_constant(xla.canonicalize_dtype(const))
-      for id_, const in unique_consts.items()
-  }
-  return [ir_consts[id(const)] for const in consts]
+  uniq_consts = {id(c): ir_constant(xla.canonicalize_dtype(c)) for c in consts}
+  return [uniq_consts[id(c)] for c in consts]
 
 
 def lower_fun(fun: Callable, multiple_results: bool = True) -> Callable:

--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -18,11 +18,14 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 import os
 from functools import partial
+import itertools as it
 from typing import Any
 
 from jax._src import ad_util
 from jax._src import api_util
 from jax._src import core
+from jax._src import config
+from jax._src import effects
 from jax._src import linear_util as lu
 from jax._src import state
 from jax._src.util import weakref_lru_cache, safe_map, partition_list
@@ -69,119 +72,54 @@ def _initial_style_jaxprs_with_common_consts(
     funs: Sequence[Callable],
     in_tree: PyTreeDef, in_avals: Sequence[core.AbstractValue],
     debug_infos: Sequence[core.DebugInfo]):
-  # When staging the branches of a conditional into jaxprs, constants are
-  # extracted from each branch and converted to jaxpr arguments. To use the
-  # staged jaxprs as the branches to a conditional *primitive*, we need for
-  # their (input) signatures to match. This function "joins" the staged jaxprs:
-  # for each one, it makes another that accepts *all* constants, but only uses
-  # those that it needs (dropping the rest).
   jaxpr_data = [_initial_style_open_jaxpr(fn, in_tree, in_avals, debug_info)
                 for fn, debug_info in zip(funs, debug_infos)]
-  if not jaxpr_data:
-    return [], [], []
-
+  if not jaxpr_data: return [], [], []
   jaxprs, all_consts, all_out_trees = zip(*jaxpr_data)
-  all_const_avals = [map(core.get_aval, consts) for consts in all_consts]
 
-  # TODO(sharadmv,mattjj): we could dedup *all consts* instead of just the Refs.
+  # Jaxprs must share consts, so we concat consts and pad the jaxprs' constvars.
+  lens = map(len, all_consts)
+  consts = [c for cs in all_consts for c in cs]
+  avals = tuple(map(core.typeof, consts))
+  jaxprs = [_pad_constvars(jaxpr, avals[:sum(lens[:i])], avals[sum(lens[:i+1]):])
+            for i, jaxpr in enumerate(jaxprs)]
+  # De-duplicate shared constants.
+  const_ids = tuple(id(c) for c in consts)
+  seen = set()
+  consts = [c for c in consts if id(c) not in seen and not seen.add(id(c))]
+  jaxprs = [_dedup_consts(jaxpr, const_ids) for jaxpr in jaxprs]
 
-  # We don't want two different Refs in a jaxpr's input to refer to the same
-  # Ref in the caller. We call this the "Ref aliasing problem" and it introduces
-  # difficulties when discharging Refs and when reasoning about programs with
-  # state effects. When unifying the arguments to each branch in a cond,
-  # however, we might naively pass the same Ref in multiple times.
-  #
-  # Here we dedup any `Ref`s that were closed over across the branches and
-  # pad out constants used across different branches.
-  # Let's consider an example case. For the following branch jaxprs, we will
-  # produce the following const lists, where `t_` indicates a tracer (a Ref).
-  # { lambda x:i32[] a:Ref{float64[]} c:Ref[float64[]}; . let
-  #    a[] <- 1.0
-  #    c[] <- 3.14
-  #   in () }
-
-  # { lambda  d:Ref[float64[]} b:Ref{float64[]} y:i32[]; . let
-  #     d[] <- 6.28
-  #     b[] <- 2.0
-  #   in () }
-  # consts = [[0, t_e, t_f], [t_g, t_e, 1]]
-  #
-  # Notice how `t_e` is duplicated. To deduplicate the `Ref`s we first
-  # 1) Detecting duplicate `Ref` tracers. We keep track of duplicates in
-  #    `tracer_id_to_canonical_id.` We store the deduped `Ref` tracers in a
-  #    list called `canonical_refs`. We remove the `Ref`s from the consts.
-  #    We should have the following lists:
-  #    canonical_refs = [t_e, t_f, t_g]
-  #    consts = [[0], [1]]
-  # 2) We need to munge the branch jaxprs to take in *all* the canonical Refs
-  #    and ignore the ones it doesn't actually use. We do this by keeping track
-  #    for each jaxpr for each of its input Refs which canonical_ref it
-  #    corresponds to, producing the following list:
-  #    canonical_ref_indices = [[0, 1], [2, 0]]
-  #
-  # Afterwards, we proceed by rewriting the jaxprs to be the following:
-  # { lambda a:Ref{float64[]} c:Ref[float64[]} b_:Ref{float64[]} x:i32[]; . let
-  #    a[] <- 1.0
-  #    c[] <- 3.14
-  #   in () }
-  # { lambda b:Ref{float64[]} _:Ref{float64[]} d:Ref{float64[]} y:i32[]; . let
-  #     d[] <- 6.28
-  #     b[] <- 2.0
-  #   in () }
-  canonical_ref_indices = []
-  canonical_non_ref_indices = []
-  canonical_refs: list[Any] = []
-  canonical_non_refs: list[Any] = []
-  tracer_id_to_canonical_ref_id = {}
-  tracer_id_to_canonical_non_ref_id = {}
-  canonical_ref_avals = []
-  canonical_non_ref_avals = []
-  for consts, consts_avals in zip(all_consts, all_const_avals):
-    ref_indices = []
-    non_ref_indices = []
-    for c, aval in zip(consts, consts_avals):
-      tracer_id = id(c)
-      if isinstance(aval, state.AbstractRef):
-        if tracer_id not in tracer_id_to_canonical_ref_id:
-          canonical_id = len(canonical_refs)
-          canonical_refs.append(c)
-          tracer_id_to_canonical_ref_id[tracer_id] = canonical_id
-          canonical_ref_avals.append(aval)
-        canonical_id = tracer_id_to_canonical_ref_id[tracer_id]
-        ref_indices.append(canonical_id)
-      else:
-        if tracer_id not in tracer_id_to_canonical_non_ref_id:
-          canonical_id = len(canonical_non_refs)
-          canonical_non_refs.append(c)
-          tracer_id_to_canonical_non_ref_id[tracer_id] = canonical_id
-          canonical_non_ref_avals.append(aval)
-        canonical_id = tracer_id_to_canonical_non_ref_id[tracer_id]
-        non_ref_indices.append(canonical_id)
-    canonical_ref_indices.append(tuple(ref_indices))
-    canonical_non_ref_indices.append(tuple(non_ref_indices))
-
-  consts = [*canonical_refs, *canonical_non_refs]
-  jaxprs = tuple(_pad_jaxpr_constvars(jaxpr, i, (*canonical_ref_avals,), (*canonical_ref_indices,), (*canonical_non_ref_avals,), (*canonical_non_ref_indices,))
-                 for i, jaxpr in enumerate(jaxprs))
-  return jaxprs, consts, all_out_trees
+  closed_jaxprs = [pe.close_jaxpr(pe.convert_constvars_jaxpr(jaxpr))
+                   for jaxpr in jaxprs]
+  return closed_jaxprs, consts, all_out_trees
 
 @weakref_lru_cache
-def _pad_jaxpr_constvars(jaxpr, i, canonical_ref_avals, canonical_ref_indices,
-                         canonical_non_ref_avals, canonical_non_ref_indices):
-  is_ref = [isinstance(v.aval, state.AbstractRef) for v in jaxpr.constvars]
-  nonref_constvars, ref_constvars = partition_list(is_ref, jaxpr.constvars)
-  padded_ref_constvars  = map(core.Var, canonical_ref_avals)
-  padded_non_ref_constvars  = map(core.Var, canonical_non_ref_avals)
-  for canonical_id, ref_var in zip(canonical_ref_indices[i], ref_constvars):
-    padded_ref_constvars[canonical_id] = ref_var
-  for canonical_id, non_ref_var in zip(canonical_non_ref_indices[i], nonref_constvars):
-    padded_non_ref_constvars[canonical_id] = non_ref_var
-  constvars = [*padded_ref_constvars, *padded_non_ref_constvars]
-  jaxpr = jaxpr.replace(constvars=constvars)
-  effects = pe.make_jaxpr_effects(jaxpr.constvars, jaxpr.invars,
-                                  jaxpr.outvars, jaxpr.eqns)
-  jaxpr = jaxpr.replace(effects=effects)
-  return core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
+def _pad_constvars(jaxpr: core.Jaxpr, left: tuple[core.AbstractValue, ...],
+                   right: tuple[core.AbstractValue, ...]) -> core.Jaxpr:
+  constvars = [*map(core.Var, left), *jaxpr.constvars, *map(core.Var, right)]
+  effs = pe._renumber_effects([*constvars, *jaxpr.invars],
+                              [*jaxpr.constvars, *jaxpr.invars], jaxpr.effects)
+  jaxpr = jaxpr.replace(constvars=constvars, effects=effs)
+  config.enable_checks.value and core.check_jaxpr(jaxpr)
+  return jaxpr
+
+@weakref_lru_cache
+def _dedup_consts(jaxpr, const_ids):
+  newvars = {}
+  canonicalize = {v: newvars.setdefault(constid, v)
+                  for constid, v in zip(const_ids, jaxpr.constvars)}
+  eqns = [e.replace(invars=[canonicalize.get(x, x) if isinstance(x, core.Var)
+                            else x for x in e.invars]) for e in jaxpr.eqns]
+  outvars = [canonicalize.get(x, x) if isinstance(x, core.Var) else x
+             for x in jaxpr.outvars]
+  constvars = list(newvars.values())
+  effs = pe._renumber_effects(
+      [*constvars, *jaxpr.invars],
+      [*map(canonicalize.get, jaxpr.constvars), *jaxpr.invars], jaxpr.effects)
+  jaxpr = jaxpr.replace(constvars=constvars, eqns=eqns, outvars=outvars,
+                        effects=effs)
+  config.enable_checks.value and core.check_jaxpr(jaxpr)
+  return jaxpr
 
 def _check_tree_and_avals(what1, tree1, avals1, what2, tree2, avals2):
   """Raises TypeError if (tree1, avals1) does not match (tree2, avals2).

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -441,13 +441,15 @@ class JaxprTypeChecks(jtu.JaxTestCase):
     super().setUp()
     lax_control_flow._initial_style_open_jaxpr.cache_clear()
     lax_control_flow._initial_style_jaxpr.cache_clear()
-    lax_control_flow.common._pad_jaxpr_constvars.cache_clear()
+    lax_control_flow.common._dedup_consts.cache_clear()
+    lax_control_flow.common._pad_constvars.cache_clear()
 
   def tearDown(self):
     super().tearDown()
     lax_control_flow._initial_style_open_jaxpr.cache_clear()
     lax_control_flow._initial_style_jaxpr.cache_clear()
-    lax_control_flow.common._pad_jaxpr_constvars.cache_clear()
+    lax_control_flow.common._dedup_consts.cache_clear()
+    lax_control_flow.common._pad_constvars.cache_clear()
 
   def test_check_jaxpr_correct(self):
     jaxpr = make_jaxpr(lambda x: jnp.sin(x) + jnp.cos(x))(1.).jaxpr

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -178,7 +178,8 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     super().setUp()
     lax_control_flow._initial_style_open_jaxpr.cache_clear()
     lax_control_flow._initial_style_jaxpr.cache_clear()
-    lax_control_flow.common._pad_jaxpr_constvars.cache_clear()
+    lax_control_flow.common._dedup_consts.cache_clear()
+    lax_control_flow.common._pad_constvars.cache_clear()
 
   def testCallableErrors(self):
     not_callable = 42


### PR DESCRIPTION
**EDIT**: looks like this doesn't work with QDDs, because e.g.

```python
box = Box(None)

@jax.jit
def f():
  box.set(1.0)
  return box.get()
```

the way the `get` sees the updated QDD on `box` is by getting a canonical `Tracer` for `box`.

I may switch tack to the `weakref.finalize` approach described below...

---

Before this PR, in jaxpr tracing for jit/scan/cond/... (i.e. in DynamicJaxprTrace) we de-duplicated occurrences of the same const (same by object id) by maintaining a `constid_to_tracer = dict[ConstObjectId, Tracer]` where `ConstObjectId = int` dictionary. When a constant was passed to `bind` and then to `DynamicJaxprTrace.to_jaxpr_tracer`, we would check its object id in `constid_to_tracer` and if found reuse the same Tracer.

The result was that we would always form a jaxpr with de-duplicated consts, e.g.

```python
const = np.ones(3)

@jax.make_jaxpr
def f():
  return jnp.sum(const) + jnp.sum(const)
```

would produce

```
{ lambda a:f32[3]; . let
    b:f32[] = reduce_sum[axes=(0,)] a
    c:f32[] = reduce_sum[axes=(0,)] a
    d:f32[] = add b c
  in (d,) }
```

and not

```
{ lambda a:f32[3] b:f32[3]; . let
    c:f32[] = reduce_sum[axes=(0,)] a
    d:f32[] = reduce_sum[axes=(0,)] b
    e:f32[] = add c d
  in (e,) }
```

However, keeping `constid_to_tracer` meant we had to either
1. maintain strong references to all const objects encountered for the lifetime of the trace (as we do before this PR) so that constant ids could not be reused, or else
2. remove corresponding entries from `constid_to_tracer` when all strong references to constants were dropped (e.g. using `weakref.finalize` on the constant objects).

The former conflicts with our goal to do on-the-fly DCE (#29937), while the latter seems complicated.

So in the name of simplicity, this PR instead gets rid of `constid_to_tracer` entirely. We instead do de-duplication of constants at the end of tracing.

**The main cost** is an extra traversal of the jaxpr eqns; if that proves too costly on trace times, we can maintain a constvar-to-eqn-occurrences table while tracing so that we only need to update a sparse set of eqns. To reclaim a little trace-time efficiency, I tweaked `_drop_unused_vars` so that we don't need to call `make_jaxpr_effects` twice, saving one extra traversal over jaxpr eqns.

Tangentially, we also simplify some logic related to de-duplication of constants across `cond`/`switch` jaxprs in control_flow/common.py. Now the logic is just (a) concatenate all consts across branch jaxprs, then (2) deduplicate them. (We use a different `_dedup_consts` function for that than the one used in `DynamicJaxprTrace.to_jaxpr` because it doesn't modify the jaxprs in-place, to respect caches.)

(Finally, we also change `JaxprStackFrame.constvar_to_val` from a `dict` to a `WeakKeyDict`. We don't actually drop any `Var` occurrences on the fly yet, so that change should be a no-op, but we're just de-risking it now.)
