### PR TITLE
Updated links in NamedSharding and Mesh docstrings

### DIFF
--- a/jax/_src/mesh.py
+++ b/jax/_src/mesh.py
@@ -223,9 +223,8 @@ _mesh_object_dict = {}  # type: ignore
 class Mesh(BaseMesh, contextlib.ContextDecorator):
   """Declare the hardware resources available in the scope of this manager.
 
-  See the Distributed arrays and automatic parallelization tutorial
-  (https://docs.jax.dev/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html)
-  and Explicit sharding tutorial (https://docs.jax.dev/en/latest/notebooks/explicit-sharding.html)
+  See `Distributed arrays and automatic parallelization`_ and
+  `Explicit Sharding`_ tutorials.
 
   Args:
     devices: A NumPy ndarray object containing JAX device objects (as
@@ -250,6 +249,7 @@ class Mesh(BaseMesh, contextlib.ContextDecorator):
     >>> out = jax.jit(lambda x: x * 2)(arr)
     >>> assert out.sharding == NamedSharding(mesh, P('x', 'y'))
 
+  .. _Distributed arrays and automatic parallelization: https://docs.jax.dev/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html
   .. _Explicit Sharding:  https://docs.jax.dev/en/latest/notebooks/explicit-sharding.html
   """
 

--- a/jax/_src/named_sharding.py
+++ b/jax/_src/named_sharding.py
@@ -97,10 +97,9 @@ class NamedSharding(JSharding.Sharding):
   is sharded across ``x`` axis of the mesh, and the second dimension is sharded
   across ``y`` axis of the mesh.
 
-  The Distributed arrays and automatic parallelization
-  (https://docs.jax.dev/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html#namedsharding-gives-a-way-to-express-shardings-with-names)
-  tutorial has more details and diagrams that explain how
-  :class:`Mesh` and :class:`PartitionSpec` are used.
+  The `Distributed arrays and automatic parallelization`_
+  and `Explicit Sharding`_ tutorials have more details and diagrams that
+  explain how :class:`Mesh` and :class:`PartitionSpec` are used.
 
   Args:
     mesh: A :class:`jax.sharding.Mesh` object.
@@ -113,6 +112,9 @@ class NamedSharding(JSharding.Sharding):
     >>> mesh = Mesh(np.array(jax.devices()).reshape(2, 4), ('x', 'y'))
     >>> spec = P('x', 'y')
     >>> named_sharding = jax.sharding.NamedSharding(mesh, spec)
+
+  .. _Distributed arrays and automatic parallelization: https://docs.jax.dev/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html
+  .. _Explicit Sharding:  https://docs.jax.dev/en/latest/notebooks/explicit-sharding.html
   """
 
   mesh: mesh_lib.Mesh | mesh_lib.AbstractMesh


### PR DESCRIPTION
Fixed links in NamedSharding and Mesh docstrings:

 On main:
<img width="648" alt="image" src="https://github.com/user-attachments/assets/64c6e5bf-0acf-406f-a8e7-a12af95f61bd" />
- https://docs.jax.dev/en/latest/jax.sharding.html#jax.sharding.NamedSharding

<img width="625" alt="image" src="https://github.com/user-attachments/assets/64591644-738e-4099-a627-79d47036ff14" />

- https://docs.jax.dev/en/latest/jax.sharding.html#jax.sharding.Mesh

With the PR:

<img width="618" alt="image" src="https://github.com/user-attachments/assets/8eec3f27-efcf-47ee-a779-bab93ab3dd90" />

- https://jax--29977.org.readthedocs.build/en/29977/jax.sharding.html#jax.sharding.NamedSharding

<img width="628" alt="image" src="https://github.com/user-attachments/assets/06b1556e-d034-4056-ac72-9cb5bf1ef53d" />

- https://jax--29977.org.readthedocs.build/en/29977/jax.sharding.html#jax.sharding.Mesh

