### PR TITLE
split out some cleanup from #29967

### DIFF
--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -23,9 +23,9 @@ from typing import Any
 from jax._src import ad_util
 from jax._src import api_util
 from jax._src import core
+from jax._src import config
 from jax._src import linear_util as lu
-from jax._src import state
-from jax._src.util import weakref_lru_cache, safe_map, partition_list
+from jax._src.util import weakref_lru_cache, safe_map
 from jax._src.interpreters import partial_eval as pe
 from jax._src.tree_util import (equality_errors_pytreedef, tree_map,
                                 tree_unflatten, keystr, PyTreeDef)
@@ -69,119 +69,54 @@ def _initial_style_jaxprs_with_common_consts(
     funs: Sequence[Callable],
     in_tree: PyTreeDef, in_avals: Sequence[core.AbstractValue],
     debug_infos: Sequence[core.DebugInfo]):
-  # When staging the branches of a conditional into jaxprs, constants are
-  # extracted from each branch and converted to jaxpr arguments. To use the
-  # staged jaxprs as the branches to a conditional *primitive*, we need for
-  # their (input) signatures to match. This function "joins" the staged jaxprs:
-  # for each one, it makes another that accepts *all* constants, but only uses
-  # those that it needs (dropping the rest).
   jaxpr_data = [_initial_style_open_jaxpr(fn, in_tree, in_avals, debug_info)
                 for fn, debug_info in zip(funs, debug_infos)]
-  if not jaxpr_data:
-    return [], [], []
-
+  if not jaxpr_data: return [], [], []
   jaxprs, all_consts, all_out_trees = zip(*jaxpr_data)
-  all_const_avals = [map(core.get_aval, consts) for consts in all_consts]
 
-  # TODO(sharadmv,mattjj): we could dedup *all consts* instead of just the Refs.
+  # Jaxprs must share consts, so we concat consts and pad the jaxprs' constvars.
+  lens = map(len, all_consts)
+  consts = [c for cs in all_consts for c in cs]
+  avals = tuple(map(core.typeof, consts))
+  jaxprs = [_pad_constvars(jaxpr, avals[:sum(lens[:i])], avals[sum(lens[:i+1]):])
+            for i, jaxpr in enumerate(jaxprs)]
+  # De-duplicate shared constants.
+  const_ids = tuple(id(c) for c in consts)
+  seen = set()
+  consts = [c for c in consts if id(c) not in seen and not seen.add(id(c))]  # type: ignore
+  jaxprs = [_dedup_consts(jaxpr, const_ids) for jaxpr in jaxprs]
 
-  # We don't want two different Refs in a jaxpr's input to refer to the same
-  # Ref in the caller. We call this the "Ref aliasing problem" and it introduces
-  # difficulties when discharging Refs and when reasoning about programs with
-  # state effects. When unifying the arguments to each branch in a cond,
-  # however, we might naively pass the same Ref in multiple times.
-  #
-  # Here we dedup any `Ref`s that were closed over across the branches and
-  # pad out constants used across different branches.
-  # Let's consider an example case. For the following branch jaxprs, we will
-  # produce the following const lists, where `t_` indicates a tracer (a Ref).
-  # { lambda x:i32[] a:Ref{float64[]} c:Ref[float64[]}; . let
-  #    a[] <- 1.0
-  #    c[] <- 3.14
-  #   in () }
-
-  # { lambda  d:Ref[float64[]} b:Ref{float64[]} y:i32[]; . let
-  #     d[] <- 6.28
-  #     b[] <- 2.0
-  #   in () }
-  # consts = [[0, t_e, t_f], [t_g, t_e, 1]]
-  #
-  # Notice how `t_e` is duplicated. To deduplicate the `Ref`s we first
-  # 1) Detecting duplicate `Ref` tracers. We keep track of duplicates in
-  #    `tracer_id_to_canonical_id.` We store the deduped `Ref` tracers in a
-  #    list called `canonical_refs`. We remove the `Ref`s from the consts.
-  #    We should have the following lists:
-  #    canonical_refs = [t_e, t_f, t_g]
-  #    consts = [[0], [1]]
-  # 2) We need to munge the branch jaxprs to take in *all* the canonical Refs
-  #    and ignore the ones it doesn't actually use. We do this by keeping track
-  #    for each jaxpr for each of its input Refs which canonical_ref it
-  #    corresponds to, producing the following list:
-  #    canonical_ref_indices = [[0, 1], [2, 0]]
-  #
-  # Afterwards, we proceed by rewriting the jaxprs to be the following:
-  # { lambda a:Ref{float64[]} c:Ref[float64[]} b_:Ref{float64[]} x:i32[]; . let
-  #    a[] <- 1.0
-  #    c[] <- 3.14
-  #   in () }
-  # { lambda b:Ref{float64[]} _:Ref{float64[]} d:Ref{float64[]} y:i32[]; . let
-  #     d[] <- 6.28
-  #     b[] <- 2.0
-  #   in () }
-  canonical_ref_indices = []
-  canonical_non_ref_indices = []
-  canonical_refs: list[Any] = []
-  canonical_non_refs: list[Any] = []
-  tracer_id_to_canonical_ref_id = {}
-  tracer_id_to_canonical_non_ref_id = {}
-  canonical_ref_avals = []
-  canonical_non_ref_avals = []
-  for consts, consts_avals in zip(all_consts, all_const_avals):
-    ref_indices = []
-    non_ref_indices = []
-    for c, aval in zip(consts, consts_avals):
-      tracer_id = id(c)
-      if isinstance(aval, state.AbstractRef):
-        if tracer_id not in tracer_id_to_canonical_ref_id:
-          canonical_id = len(canonical_refs)
-          canonical_refs.append(c)
-          tracer_id_to_canonical_ref_id[tracer_id] = canonical_id
-          canonical_ref_avals.append(aval)
-        canonical_id = tracer_id_to_canonical_ref_id[tracer_id]
-        ref_indices.append(canonical_id)
-      else:
-        if tracer_id not in tracer_id_to_canonical_non_ref_id:
-          canonical_id = len(canonical_non_refs)
-          canonical_non_refs.append(c)
-          tracer_id_to_canonical_non_ref_id[tracer_id] = canonical_id
-          canonical_non_ref_avals.append(aval)
-        canonical_id = tracer_id_to_canonical_non_ref_id[tracer_id]
-        non_ref_indices.append(canonical_id)
-    canonical_ref_indices.append(tuple(ref_indices))
-    canonical_non_ref_indices.append(tuple(non_ref_indices))
-
-  consts = [*canonical_refs, *canonical_non_refs]
-  jaxprs = tuple(_pad_jaxpr_constvars(jaxpr, i, (*canonical_ref_avals,), (*canonical_ref_indices,), (*canonical_non_ref_avals,), (*canonical_non_ref_indices,))
-                 for i, jaxpr in enumerate(jaxprs))
-  return jaxprs, consts, all_out_trees
+  closed_jaxprs = [pe.close_jaxpr(pe.convert_constvars_jaxpr(jaxpr))
+                   for jaxpr in jaxprs]
+  return closed_jaxprs, consts, all_out_trees
 
 @weakref_lru_cache
-def _pad_jaxpr_constvars(jaxpr, i, canonical_ref_avals, canonical_ref_indices,
-                         canonical_non_ref_avals, canonical_non_ref_indices):
-  is_ref = [isinstance(v.aval, state.AbstractRef) for v in jaxpr.constvars]
-  nonref_constvars, ref_constvars = partition_list(is_ref, jaxpr.constvars)
-  padded_ref_constvars  = map(core.Var, canonical_ref_avals)
-  padded_non_ref_constvars  = map(core.Var, canonical_non_ref_avals)
-  for canonical_id, ref_var in zip(canonical_ref_indices[i], ref_constvars):
-    padded_ref_constvars[canonical_id] = ref_var
-  for canonical_id, non_ref_var in zip(canonical_non_ref_indices[i], nonref_constvars):
-    padded_non_ref_constvars[canonical_id] = non_ref_var
-  constvars = [*padded_ref_constvars, *padded_non_ref_constvars]
-  jaxpr = jaxpr.replace(constvars=constvars)
-  effects = pe.make_jaxpr_effects(jaxpr.constvars, jaxpr.invars,
-                                  jaxpr.outvars, jaxpr.eqns)
-  jaxpr = jaxpr.replace(effects=effects)
-  return core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
+def _pad_constvars(jaxpr: core.Jaxpr, left: tuple[core.AbstractValue, ...],
+                   right: tuple[core.AbstractValue, ...]) -> core.Jaxpr:
+  constvars = [*map(core.Var, left), *jaxpr.constvars, *map(core.Var, right)]
+  effs = pe._renumber_effects([*constvars, *jaxpr.invars],
+                              [*jaxpr.constvars, *jaxpr.invars], jaxpr.effects)
+  jaxpr = jaxpr.replace(constvars=constvars, effects=effs)
+  config.enable_checks.value and core.check_jaxpr(jaxpr)
+  return jaxpr
+
+@weakref_lru_cache
+def _dedup_consts(jaxpr, const_ids):
+  newvars = {}
+  canonicalize = {v: newvars.setdefault(constid, v)
+                  for constid, v in zip(const_ids, jaxpr.constvars)}
+  eqns = [e.replace(invars=[canonicalize.get(x, x) if isinstance(x, core.Var)
+                            else x for x in e.invars]) for e in jaxpr.eqns]
+  outvars = [canonicalize.get(x, x) if isinstance(x, core.Var) else x
+             for x in jaxpr.outvars]
+  constvars = list(newvars.values())
+  effs = pe._renumber_effects(
+      [*constvars, *jaxpr.invars],
+      [*map(canonicalize.get, jaxpr.constvars), *jaxpr.invars], jaxpr.effects)
+  jaxpr = jaxpr.replace(constvars=constvars, eqns=eqns, outvars=outvars,
+                        effects=effs)
+  config.enable_checks.value and core.check_jaxpr(jaxpr)
+  return jaxpr
 
 def _check_tree_and_avals(what1, tree1, avals1, what2, tree2, avals2):
   """Raises TypeError if (tree1, avals1) does not match (tree2, avals2).

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -441,13 +441,15 @@ class JaxprTypeChecks(jtu.JaxTestCase):
     super().setUp()
     lax_control_flow._initial_style_open_jaxpr.cache_clear()
     lax_control_flow._initial_style_jaxpr.cache_clear()
-    lax_control_flow.common._pad_jaxpr_constvars.cache_clear()
+    lax_control_flow.common._dedup_consts.cache_clear()
+    lax_control_flow.common._pad_constvars.cache_clear()
 
   def tearDown(self):
     super().tearDown()
     lax_control_flow._initial_style_open_jaxpr.cache_clear()
     lax_control_flow._initial_style_jaxpr.cache_clear()
-    lax_control_flow.common._pad_jaxpr_constvars.cache_clear()
+    lax_control_flow.common._dedup_consts.cache_clear()
+    lax_control_flow.common._pad_constvars.cache_clear()
 
   def test_check_jaxpr_correct(self):
     jaxpr = make_jaxpr(lambda x: jnp.sin(x) + jnp.cos(x))(1.).jaxpr

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -178,7 +178,8 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     super().setUp()
     lax_control_flow._initial_style_open_jaxpr.cache_clear()
     lax_control_flow._initial_style_jaxpr.cache_clear()
-    lax_control_flow.common._pad_jaxpr_constvars.cache_clear()
+    lax_control_flow.common._dedup_consts.cache_clear()
+    lax_control_flow.common._pad_constvars.cache_clear()
 
   def testCallableErrors(self):
     not_callable = 42


### PR DESCRIPTION
Splits out some cleanup from #29967, since we probably won't merge that PR: We also simplify some logic related to de-duplication of constants across cond/switch jaxprs in control_flow/common.py. Now the logic is just (a) concatenate all consts across branch jaxprs, then (2) deduplicate them.

