### PR TITLE
Default auto_axes not over manual axes

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -3055,8 +3055,11 @@ def auto_axes(fun, *, axes: str | tuple[str, ...] | None = None,
         raise TypeError("Missing required keyword argument: 'out_sharding'")
     else:
       _out_sharding = out_sharding
+    axes_ = axes
+    if axes_ is None:
+      axes_ = mesh_lib.get_abstract_mesh().explicit_axes
     new_mesh = _get_new_mesh(
-        axes, mesh_lib.AxisType.Auto, 'auto_axes', shardings=_out_sharding,
+        axes_, mesh_lib.AxisType.Auto, 'auto_axes', shardings=_out_sharding,
         error_on_manual_to_auto_explicit=True)
     with mesh_lib.use_abstract_mesh(new_mesh):
       in_specs = tree_map(lambda a: core.modify_spec_for_auto_manual(


### PR DESCRIPTION
Alter auto_axes so that when axes=None in the function call it only acts over the explicit axes. Allowing examples like below, where high level shard_maps are used.

```python
# !pip install -U --pre jax jaxlib -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/

import functools

import jax
import jax.numpy as jnp

from jax.experimental import mesh_utils
from jax.sharding import Mesh, PartitionSpec as P

@functools.partial(jax.sharding.auto_axes, out_sharding=P()) # as expected, axes=('model',) does fix it
def simple_func(inputs):
    # simple gather
    return inputs[(0,0), (1,1)]

device_mesh = mesh_utils.create_device_mesh(mesh_shape=(1,1))
mesh = Mesh(
    device_mesh,
    axis_names=("data", "model"),
    axis_types=(jax.sharding.AxisType.Explicit, jax.sharding.AxisType.Explicit)
)
func = jax.shard_map(
    simple_func,
    out_specs=P("data"),
    axis_names={'data'},
    check_vma=False,
)
func = jax.jit(func)

with jax.sharding.use_mesh(mesh):
  inputs = jnp.zeros((16, 16, 16), out_sharding=P('data'))
  out = func(inputs).block_until_ready()
```