### PR TITLE
Fix cache leaks for pe._cached_abstract_eval; add util.multi_weakref_lru_cache

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -52,7 +52,8 @@ from jax._src import source_info_util
 from jax._src.util import (safe_zip, safe_map, curry, tuple_insert,
                            tuple_delete, cache,
                            HashableFunction, HashableWrapper, weakref_lru_cache,
-                           partition_list, StrictABCMeta, foreach)
+                           partition_list, StrictABCMeta, foreach,
+                           weakref_cache_key_types)
 import jax._src.pretty_printer as pp
 from jax._src.named_sharding import NamedSharding
 from jax._src.sharding import Sharding
@@ -199,6 +200,7 @@ class Jaxpr:
       raise ValueError(f"Unknown keyword arguments: {kwargs}")
     return jaxpr
 
+weakref_cache_key_types.add(Jaxpr)
 
 def join_effects(*effects: Effects) -> Effects:
   return set().union(*effects) if effects else no_effects
@@ -290,6 +292,9 @@ class ClosedJaxpr:
 
   def _repr_pretty_(self, p, cycle):
     return p.text(self.pretty_print(use_color=True))
+
+weakref_cache_key_types.add(ClosedJaxpr)
+
 
 @curry
 def jaxpr_as_fun(closed_jaxpr: ClosedJaxpr, *args):

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -93,6 +93,11 @@ def apply_primitive(prim, *args, **params):
     lib.jax_jit.swap_thread_local_state_disable_jit(prev)
   return outs
 
+# TODO(necula): this cache will contain strong references to all
+# Jaxprs in `params` (for higher-order primitives).
+# This is not immediately fixable by using
+# util.multi_weakref_lru_cache, because the `params` (including the Jaxpr)
+# are closed over in the `prim_fun` lambda. Leaving this fix for a later PR.
 @util.cache()
 def xla_primitive_callable(prim: core.Primitive, **params):
   util.test_event("xla_primitive_callable_cache_miss")

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -16,13 +16,14 @@ from __future__ import annotations
 
 import abc
 from collections.abc import Callable, Iterable, Iterator, Sequence
+import dataclasses
 import functools
 from functools import partial
 import itertools as it
 import logging
 import math
 import operator
-from typing import (Any, Generic, SupportsIndex, TypeVar, overload, TYPE_CHECKING, cast)
+from typing import (Any, Generic, SupportsIndex, Type, TypeVar, overload, TYPE_CHECKING, cast)
 import weakref
 
 import numpy as np
@@ -336,14 +337,143 @@ def weakref_lru_cache(call: Callable, maxsize=2048,
   Least recently used cache decorator with weakref support.
 
   The cache will take a weakref to the first argument of the wrapped function
-  and strong refs to all subsequent operations. In all other respects it should
-  behave similar to `functools.lru_cache`.
+  and strong refs to all other arguments. In all other respects it should
+  behave similar to `functools.lru_cache`. The cache is thread local.
   """
   cached_call = _weakref_lru_cache.weakref_lru_cache(
       config.trace_context if trace_context_in_key else _ignore, call, maxsize
   )
   register_cache(cached_call, str(call))
   return cached_call
+
+
+@dataclasses.dataclass(frozen=True, slots=True, weakref_slot=True)
+class MultiWeakRefCacheKey:
+  weakrefs: tuple[weakref.ref, ...]  # Used only when len(weakrefs) >= 2
+
+
+class MultiWeakRefPlaceholder:
+  # Stands for an arg/kwarg that was replaced with a weakref
+  pass
+_multi_weakref_placeholder = MultiWeakRefPlaceholder()
+
+# The types of arguments for which `multi_weakref_lru_cache` should keep
+# weak references.
+weakref_cache_key_types: set[Type] = set()
+def is_weakref_cache_key_type(v):
+  return callable(v) or (type(v) in weakref_cache_key_types)
+
+
+def multi_weakref_lru_cache(
+      call: Callable, *,
+      maxsize=2048,
+      trace_context_in_key: bool = True):
+    """
+    Least recently used cache decorator with weakref support.
+
+    Similar to `weakref_lru_cache`, except that it keeps weak references
+    to all positional and keyword arguments for which
+    `is_weakref_cache_key_type()` is true, and strong references to
+    other arguments. The cache entry is removed if any of the weakref
+    arguments dies.
+    """
+    # Keep strong references to the MultiWeakRefCacheKeys that resulted in
+    # cache misses, and are cache keys. Indexed by id. Only keys with all
+    # included weakrefs live are present.
+    id_to_key: dict[int, MultiWeakRefCacheKey] = {}
+    # For each `wr: weakref.ref` present in `key: MultiWeakRefCacheKey` we have
+    # `id(key) in weakref_to_key_ids[wr]`.
+    weakref_to_key_ids: dict[weakref.ref, set[int]] = {}
+
+    def remove_weakref(wr: weakref.ref):
+      key_ids = weakref_to_key_ids.get(wr, set())
+      for key_id in key_ids:
+        try:
+          del id_to_key[key_id]
+        except KeyError:
+          pass
+      try:
+        del weakref_to_key_ids[wr]
+      except KeyError:
+        pass
+
+    def weakrefs_to_sentinel(v, acc: list[Any]):
+      if type(v) is tuple:
+        return tuple(weakrefs_to_sentinel(v1, acc) for v1 in v)
+      elif type(v) is dict:
+        return {k: weakrefs_to_sentinel(v1, acc) for k, v1 in v.items()}
+      elif is_weakref_cache_key_type(v):
+        acc.append(v)
+        return _multi_weakref_placeholder
+      else:
+        return v
+
+    def sentinel_to_referrents(v,
+                               it: Iterator[weakref.ref],
+                               key_id: int | None):
+      # key_id is not None iff we use a MultiWeakRefCacheKey (>= 2 weakrefs)
+      if type(v) is tuple:
+        return tuple(sentinel_to_referrents(v1, it, key_id) for v1 in v)
+      elif type(v) is dict:
+        return {k: sentinel_to_referrents(v1, it, key_id)
+                for k, v1 in v.items()}
+      elif v is _multi_weakref_placeholder:
+        wr = next(it)
+        if key_id is not None:
+          weakref_to_key_ids.setdefault(wr, set()).add(key_id)
+        return wr()
+      else:
+        return v
+
+    def cache_miss(key: MultiWeakRefCacheKey | MultiWeakRefPlaceholder | Any,
+                   *args, **kwargs):
+      if isinstance(key, MultiWeakRefCacheKey):  # had at least 2 weakrefs
+        # We know `key` is in `cached_call` cache, so store strong references
+        key_id = id(key)
+        id_to_key[key_id] = key
+        orig_args, orig_kwargs = sentinel_to_referrents(
+            (args, kwargs), iter(key.weakrefs), key_id)
+      elif key is _multi_weakref_placeholder:  # had 0 weakrefs
+        orig_args = args
+        orig_kwargs = kwargs
+      else:  # had 1 weakref, we had put it first as the `key`
+        orig_args, orig_kwargs = sentinel_to_referrents(
+            (args, kwargs), iter([weakref.ref(key)]), None)
+      return call(*orig_args, **orig_kwargs)
+
+
+    cached_call = _weakref_lru_cache.weakref_lru_cache(
+        config.trace_context if trace_context_in_key else _ignore,
+        cache_miss, maxsize
+    )
+    register_cache(cached_call, str(call))
+
+    @functools.wraps(call)
+    def wrapper(*orig_args, **orig_kwargs):
+      acc_weakrefs: list[Any] = []
+      args, kwargs = weakrefs_to_sentinel((orig_args, orig_kwargs),
+                                          acc_weakrefs)
+      nr_weakrefs = len(acc_weakrefs)
+      if nr_weakrefs == 0:
+        return cached_call(_multi_weakref_placeholder,
+                           *orig_args, **orig_kwargs)
+      elif nr_weakrefs == 1:
+        # Put the single weakref first, and skip the MultiWeakRefCacheKey
+        return cached_call(acc_weakrefs[0],
+                           *args, **kwargs)
+      else:
+        value_to_weakref = {v: weakref.ref(v, remove_weakref)
+                            for v in set(acc_weakrefs)}
+        key = MultiWeakRefCacheKey(weakrefs=tuple(value_to_weakref[v]
+                                                  for v in acc_weakrefs))
+        return cached_call(key, *args, **kwargs)
+
+    wrapper.cache_info = cached_call.cache_info
+    wrapper.cache_clear = cached_call.cache_clear
+    wrapper.cache_keys = cached_call.cache_keys
+    wrapper._multi_weakref_id_to_key = id_to_key  # stays alive as long as wrapper
+    wrapper._multi_weakref_to_key_ids = weakref_to_key_ids
+    return wrapper
 
 
 class Unhashable:

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -11,11 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import dataclasses
+import random
 from functools import partial
+import gc
 import operator
+import threading
 
-from absl.testing import absltest
+from absl.testing import absltest, parameterized
 import jax
 from jax import api_util
 from jax._src import linear_util as lu
@@ -154,6 +157,128 @@ class UtilTest(jtu.JaxTestCase):
 
     for _ in range(4097):
       reference_loop_generator(lambda x: x)
+
+  @parameterized.named_parameters(
+      dict(weakref_count=weakref_count,
+           testcase_name=f"_{weakref_count=}")
+      for weakref_count in [0, 1, 3])
+  def test_multi_weak_ref_cache(self, *, weakref_count=1):
+
+    class Key:  # hashed by id
+      def __init__(self, x):
+        self.x = x
+
+    if weakref_count > 0:
+      util.weakref_cache_key_types.add(Key)
+
+    @partial(util.multi_weakref_lru_cache, trace_context_in_key=False)
+    def myfun(a, k1, *, k2, k3):
+      return f"{a=}, {k1=}, {k2=}, {k3=}"
+
+    def check_invariant(expected_live_keys: int):
+      self.assertLen(myfun._multi_weakref_id_to_key, expected_live_keys if weakref_count > 1 else 0)
+      for key_id, key in myfun._multi_weakref_id_to_key.items():
+        for wr in key.weakrefs:
+          self.assertIn(wr, myfun._multi_weakref_to_key_ids)
+          self.assertIn(key_id, myfun._multi_weakref_to_key_ids[wr])
+
+    k1 = Key(1)
+    k3 = (k1, k1) if weakref_count > 1 else 4
+    util.clear_all_caches()
+    r1 = myfun(2, k1, k2=3, k3=k3)  # miss
+    c1 = myfun.cache_info()
+    self.assertEqual((0, 1, 1), (c1.hits, c1.misses, c1.currsize))
+    check_invariant(1)
+
+    for i in range(10):
+      r2 = myfun(2, k1, k2=3, k3=k3)  # all hits
+      self.assertIs(r1, r2)
+      c2 = myfun.cache_info()
+      self.assertEqual((1 + i, 1, 1), (c2.hits, c2.misses, c2.currsize))
+      check_invariant(1)
+
+    del k1, k3  # expect that the cache entries are removed (if weakref_count > 0)
+    gc.collect()
+    c3 = myfun.cache_info()
+    self.assertEqual(c3.currsize, 0 if weakref_count > 0 else 1)
+    check_invariant(0)
+
+    k1_2 = Key(2)
+    k3_2 = (Key(3), Key(3)) if weakref_count > 1 else (3, 3)
+    r4 = myfun(2, k1_2, k2=3, k3=k3_2)  # miss
+    c4 = myfun.cache_info()
+    self.assertEqual((10, 2, (1 if weakref_count > 0 else 2)), (c4.hits, c4.misses, c4.currsize))
+    check_invariant(1)
+
+    if weakref_count > 1:
+      del k3_2  # clear the cache entry
+      gc.collect()
+      c5 = myfun.cache_info()
+      self.assertEqual((10, 2, 0), (c5.hits, c5.misses, c5.currsize))
+      check_invariant(0)
+
+      k3_3 = (Key(3), Key(3))
+      r6 = myfun(2, k1_2, k2=3, k3=k3_3)  # miss because Key hashed by it
+      self.assertIsNot(r4, r6)
+      c6 = myfun.cache_info()
+      self.assertEqual((10, 3, 1), (c6.hits, c6.misses, c6.currsize))
+      check_invariant(1)
+
+    del k1_2
+    gc.collect()
+    c7 = myfun.cache_info()
+    self.assertEqual(0 if weakref_count > 0 else 2, c7.currsize )
+    check_invariant(0)
+
+  def test_multi_weak_ref_cache_custom_tuple(self):
+    class MyTuple(tuple):
+      pass
+
+    class Key:  # hashed by id
+      def __init__(self, x):
+        self.x = x
+
+    util.weakref_cache_key_types.add(Key)
+
+    @partial(util.multi_weakref_lru_cache, trace_context_in_key=False)
+    def my_fun(a):
+      self.assertIsInstance(a, MyTuple)
+      return str(a)
+
+    key = Key(1)
+    my_fun(MyTuple([key, key]))
+    self.assertLen(my_fun._multi_weakref_id_to_key, 0)  # key was not picked up
+
+    del key
+    self.assertEqual(1, my_fun.cache_info().currsize)  # cache is not cleaned
+
+  def test_multi_weakref_lru_cache_threads(self):
+    num_workers = 5
+    num_live_keys_per_worker = 16
+    size_key_space = 32
+    @dataclasses.dataclass(frozen=True)
+    class WRKey:
+      f: int
+
+    util.weakref_cache_key_types.add(WRKey)
+
+    @partial(util.multi_weakref_lru_cache, maxsize=size_key_space // 2)
+    def myfun(k: WRKey):
+      return None
+
+    def Worker():
+      keys = [None] * num_live_keys_per_worker  # These are the live keys for this worker
+      for i in range(1000):
+        key_idx = random.randint(0, num_live_keys_per_worker - 1)
+        key = WRKey(random.randint(0, size_key_space))
+        myfun(key)
+        keys[key_idx] = key  # Kill some previous key and keep this live
+
+    workers = [threading.Thread(target=Worker()) for _ in range(num_workers)]
+    for t in workers:
+      t.start()
+    for t in workers:
+      t.join()
 
 
 class SafeMapTest(jtu.JaxTestCase):


### PR DESCRIPTION
The function `pe._cached_abstract_eval` uses `util.cache`, while most other cached functions in JAX use `weakref_lru_cache`. The main difference is that `util.cache` keeps strong references to the function arguments.

The modified test `lax_control_flow_test::test_cond_memory_leak` (added a jit for one of the branches) is failing without this fix. This is because the Jaxpr including the closed-over constant leaks due to the strong references to `**params` kept by the `util.cache` used in `pe._cached_abstract_eval`.

We cannot use directly `weakref_lru_cache` because it keeps weak references only to the first positional argument. We add here a variant `multi_weakref_lru_cache` that uses weak references for all the positional and keyword arguments for which `util.is_weakref_cache_key_type` is true. This is currently set for `Jaxpr`, `ClosedJaxpr` and `Callable`. 

The `multi_weakref_lru_cache` is a wrapper around `weakref_lru_cache`, and in fact if there is exactly one
weakref, it behaves exactly like `weakref_lru_cache`. Eventually, we can decide to generalize the existing `weakref_lru_cache` to have this behavior.
