### PR TITLE
Deprecate jax.scipy.special.sph_harm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 * Deprecations:
   * {obj}`jax.dlpack.SUPPORTED_DTYPES` is deprecated; please use the new
     {func}`jax.dlpack.is_supported_dtype` function.
+  * {func}`jax.scipy.special.sph_harm` has been deprecated following a similar
+    deprecation in SciPy; use {func}`jax.scipy.special.sph_harm_y` instead.
 
 ## JAX 0.6.2 (June 17, 2025)
 

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -57,7 +57,7 @@ from jax._src.scipy.special import (
   rel_entr as rel_entr,
   softmax as softmax,
   spence as spence,
-  sph_harm as sph_harm,
+  sph_harm as _deprecated_sph_harm,
   sph_harm_y as sph_harm_y,
   xlog1py as xlog1py,
   xlogy as xlogy,
@@ -78,12 +78,18 @@ _deprecations = {
         "jax.scipy.special.lpmn_values is deprecated; no replacement is planned.",
         _deprecated_lpmn_values,
     ),
+    # Added Jul 7 2025
+    "sph_harm": (
+        "jax.scipy.special.sph_harm is deprecated; use sph_harm_y instead.",
+        _deprecated_sph_harm
+    )
 }
 
 import typing as _typing
 if _typing.TYPE_CHECKING:
   lpmn = _deprecated_lpmn
   lpmn_values = _deprecated_lpmn_values
+  sph_harm = _deprecated_sph_harm
 else:
   from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
   __getattr__ = _deprecation_getattr(__name__, _deprecations)

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -343,6 +343,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     dtype=float_dtypes,
   )
   @jtu.ignore_warning(category=DeprecationWarning, message=".*scipy.special.lpmn.*")
+  @unittest.skipIf(scipy_version >= (1, 17, 0), "scipy.special.lpmn has been removed.")
   def testLpmn(self, l_max, shape, dtype):
     if jtu.is_device_tpu_at_least(6):
       self.skipTest("TODO(b/364258243): fails on TPU v6+")
@@ -366,6 +367,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     dtype=float_dtypes,
   )
   @jtu.ignore_warning(category=DeprecationWarning, message=".*scipy.special.lpmn.*")
+  @unittest.skipIf(scipy_version >= (1, 17, 0), "scipy.special.lpmn_values has been removed.")
   def testNormalizedLpmnValues(self, l_max, shape, dtype):
     rng = jtu.rand_uniform(self.rng(), low=-0.2, high=0.9)
     args_maker = lambda: [rng(shape, dtype)]
@@ -395,6 +397,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
 
   @jtu.ignore_warning(category=DeprecationWarning,
                       message=".*scipy.special.sph_harm.*")
+  @unittest.skipIf(scipy_version >= (1, 17, 0), "scipy.special.sph_harm has been removed.")
   @jax.numpy_dtype_promotion('standard')  # This test explicitly exercises dtype promotion
   def testSphHarmAccuracy(self):
     m = jnp.arange(-3, 3)[:, None]
@@ -411,6 +414,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
 
   @jtu.ignore_warning(category=DeprecationWarning,
                       message=".*scipy.special.sph_harm.*")
+  @unittest.skipIf(scipy_version >= (1, 17, 0), "scipy.special.sph_harm has been removed.")
   @jax.numpy_dtype_promotion('standard')  # This test explicitly exercises dtype promotion
   def testSphHarmOrderZeroDegreeZero(self):
     """Tests the spherical harmonics of order zero and degree zero."""
@@ -426,6 +430,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
 
   @jtu.ignore_warning(category=DeprecationWarning,
                       message=".*scipy.special.sph_harm.*")
+  @unittest.skipIf(scipy_version >= (1, 17, 0), "scipy.special.sph_harm has been removed.")
   @jax.numpy_dtype_promotion('standard')  # This test explicitly exercises dtype promotion
   def testSphHarmOrderZeroDegreeOne(self):
     """Tests the spherical harmonics of order one and degree zero."""
@@ -441,6 +446,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
 
   @jtu.ignore_warning(category=DeprecationWarning,
                       message=".*scipy.special.sph_harm.*")
+  @unittest.skipIf(scipy_version >= (1, 17, 0), "scipy.special.sph_harm has been removed.")
   @jax.numpy_dtype_promotion('standard')  # This test explicitly exercises dtype promotion
   def testSphHarmOrderOneDegreeOne(self):
     """Tests the spherical harmonics of order one and degree one."""
@@ -463,6 +469,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
   )
   @jtu.ignore_warning(category=DeprecationWarning,
                       message=".*scipy.special.sph_harm.*")
+  @unittest.skipIf(scipy_version >= (1, 17, 0), "scipy.special.sph_harm has been removed.")
   @jax.numpy_dtype_promotion('standard')  # This test explicitly exercises dtype promotion
   def testSphHarmForJitAndAgainstNumpy(self, l_max, num_z, dtype):
     """Tests against JIT compatibility and Numpy."""
@@ -489,6 +496,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
 
   @jtu.ignore_warning(category=DeprecationWarning,
                       message=".*scipy.special.sph_harm.*")
+  @unittest.skipIf(scipy_version >= (1, 17, 0), "scipy.special.sph_harm has been removed.")
   @jax.numpy_dtype_promotion('standard')  # This test explicitly exercises dtype promotion
   def testSphHarmCornerCaseWithWrongNmax(self):
     """Tests the corner case where `n_max` is not the maximum value of `n`."""


### PR DESCRIPTION
Also update related tests to skip with newer scipy releases.

Fixes #29807