### PR TITLE
Finalize deprecation of jax.extend.ffi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     deprecation in SciPy; use {func}`jax.scipy.special.sph_harm_y` instead.
   * From {mod}`jax.interpreters.xla`, the previously deprecated symbols
     `abstractify` and `pytype_aval_mappings` have been removed.
+  * `jax.extend.ffi` was removed after being deprecated in v0.5.0.
+    Use {mod}`jax.ffi` instead.
 
 ## JAX 0.6.2 (June 17, 2025)
 

--- a/docs/jax.ffi.rst
+++ b/docs/jax.ffi.rst
@@ -11,21 +11,3 @@
   pycapsule
   register_ffi_target
   register_ffi_type_id
-
-
-``jax.extend.ffi`` module (deprecated)
-======================================
-
-The ``jax.extend.ffi`` module has been moved to ``jax.ffi``, and that import
-path should be used instead, but these functions remain documented here while
-the legacy import is being deprecated.
-
-.. automodule:: jax.extend.ffi
-
-.. autosummary::
-  :toctree: _autosummary
-
-  ffi_call
-  ffi_lowering
-  pycapsule
-  register_ffi_target

--- a/jax/extend/__init__.py
+++ b/jax/extend/__init__.py
@@ -39,8 +39,26 @@ Breaking changes will be announced via the
 from jax.extend import (
     backend as backend,
     core as core,
-    ffi as ffi,
+    ffi as _ffi,
     linear_util as linear_util,
     random as random,
     source_info_util as source_info_util,
 )
+
+_deprecations = {
+    # Added 2025-7-7
+    "ffi": (
+        "The jax.extend.ffi module was deprecated in JAX v0.5.0, use jax.ffi instead.",
+        _ffi,
+    ),
+}
+
+import typing
+if typing.TYPE_CHECKING:
+  ffi = _ffi
+else:
+  from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
+  __getattr__ = _deprecation_getattr(__name__, _deprecations)
+  del _deprecation_getattr
+del typing
+del _ffi

--- a/jax/extend/ffi.py
+++ b/jax/extend/ffi.py
@@ -17,24 +17,29 @@ from jax._src import ffi as _ffi
 _deprecations = {
     # Added 2024-12-20
     "ffi_call": (
-        "jax.extend.ffi.ffi_call is deprecated, use jax.ffi.ffi_call instead.",
-        _ffi.ffi_call,
+        "jax.extend.ffi.ffi_call was deprecated in JAX v0.5.0 and removed in JAX v0.7.0:"
+        " use jax.ffi.ffi_call instead.",
+        None,
     ),
     "ffi_lowering": (
-        "jax.extend.ffi.ffi_lowering is deprecated, use jax.ffi.ffi_lowering instead.",
-        _ffi.ffi_lowering,
+        "jax.extend.ffi.ffi_lowering was deprecated in JAX v0.5.0 and removed in JAX v0.7.0:"
+        " use jax.ffi.ffi_lowering instead.",
+        None,
     ),
     "include_dir": (
-        "jax.extend.ffi.include_dir is deprecated, use jax.ffi.include_dir instead.",
-        _ffi.include_dir,
+        "jax.extend.ffi.include_dir was deprecated in JAX v0.5.0 and removed in JAX v0.7.0:"
+        " use jax.ffi.include_dir instead.",
+        None,
     ),
     "pycapsule": (
-        "jax.extend.ffi.pycapsule is deprecated, use jax.ffi.pycapsule instead.",
-        _ffi.pycapsule,
+        "jax.extend.ffi.pycapsule was deprecated in JAX v0.5.0 and removed in JAX v0.7.0:"
+        " use jax.ffi.pycapsule instead.",
+        None,
     ),
     "register_ffi_target": (
-        "jax.extend.ffi.register_ffi_target is deprecated, use jax.ffi.register_ffi_target instead.",
-        _ffi.register_ffi_target,
+        "jax.extend.ffi.register_ffi_target was deprecated in JAX v0.5.0 and removed in JAX v0.7.0:"
+        " use jax.ffi.register_ffi_target instead.",
+        None,
     ),
 }
 


### PR DESCRIPTION
The `jax.ffi` module is a direct replacement.