### PR TITLE
[caches] Simplifications in the management of caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * The `name` attribute of the `pjit_p` primitive (exported as
     `jax.extend.core.primitives.pjit_p`) has changed from `"pjit"` to `"jit"`.
     This affects the string representations of jaxprs.
+  * The (undocumented) function `jax.extend.backend.add_clear_backends_callback`
+    has been removed. Users should use `jax.extend.backend.register_backend_cache`
+    instead.
 
 * Deprecations:
   * {obj}`jax.dlpack.SUPPORTED_DTYPES` is deprecated; please use the new

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -3131,11 +3131,7 @@ def clear_backends():
   xb._clear_backends()
   xb.local_devices.cache_clear()
   xb.process_count.cache_clear()
-  dispatch.xla_primitive_callable.cache_clear()
   util.clear_all_caches()
-  pjit._infer_params_cached.cache_clear()
-  pjit._pjit_lower_cached.cache_clear()
-  pjit._create_pjit_jaxpr.cache_clear()  # pytype: disable=attribute-error
   pjit._cpp_pjit_cache_fun_only.clear()
   pjit._cpp_pjit_cache_explicit_attributes.clear()
   xc._xla.PjitFunctionCache.clear_all()
@@ -3166,7 +3162,6 @@ def clear_caches():
   # Clear all lu.cache, util.cache and util.weakref_lru_cache instances
   # (used for staging and Python-dispatch compiled executable caches).
   util.clear_all_caches()
-  util.clear_all_weakref_lru_caches()
 
   # Clear all C++ compiled executable caches for pjit
   pjit._cpp_pjit_cache_fun_only.clear()
@@ -3177,6 +3172,3 @@ def clear_caches():
   # Clear all C++ compiled executable caches for pmap
   for fun in _pmap_cache_clears:
     fun._cache_clear()
-
-  # Clear particular util.cache instances.
-  dispatch.xla_primitive_callable.cache_clear()

--- a/jax/_src/linear_util.py
+++ b/jax/_src/linear_util.py
@@ -77,7 +77,7 @@ from jax._src import config
 from jax._src import core
 from jax._src import traceback_util
 from jax._src.tree_util import KeyPath, generate_key_paths, keystr
-from jax._src.util import HashableFunction, cache_clearing_funs, curry, fun_name
+from jax._src.util import HashableFunction, curry, fun_name, register_cache
 
 
 traceback_util.register_exclusion(__file__)
@@ -481,7 +481,7 @@ def cache(call: Callable, *,
 
   memoized_fun.cache_clear = fun_caches.clear  # type: ignore
   memoized_fun.evict_function = _evict_function  # type: ignore
-  cache_clearing_funs.add(memoized_fun.cache_clear)
+  register_cache(memoized_fun, str(call))
   return memoized_fun
 
 @transformation2

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -300,16 +300,28 @@ def cache(max_size=4096, trace_context_in_key=True):
 
     wrapper.cache_clear = cached.cache_clear
     wrapper.cache_info = cached.cache_info
-    cache_clearing_funs.add(wrapper.cache_clear)
+    register_cache(wrapper, str(f))
     return wrapper
   return wrap
 
-cache_clearing_funs = weakref.WeakSet()  # type: ignore
+# Maps caches to the name of the callable they apply to. All caches in
+# this dictionary support `cache_clear()`.
+_caches: weakref.WeakKeyDictionary[Any, str] = weakref.WeakKeyDictionary()
+
+def register_cache(cache: Any, for_what: str):
+  """Registers a cache with JAX's cache management.
+
+  Args:
+    cache: an object supporting `cache_clear()`, `cache_info()`, and
+    `cache_keys()`, like the result of `functools.lru_cache()`.
+    for_what: a string to identify what this cache is used for. This is
+     used for debugging.
+"""
+  _caches[cache] = for_what
 
 def clear_all_caches():
-  global cache_clearing_funs
-  for clear in cache_clearing_funs:
-    clear()
+  for cache in _caches.keys():
+    cache.cache_clear()
 
 memoize = cache(max_size=None)
 


### PR DESCRIPTION
Instead of keeping `util.cache_clearing_funs` and `util._weakref_lru_caches` we just have `util._caches` that has both a reference to the cache, and also the name of the function for which it is used. The name has been useful for investigating memory leaks due to caches.

I am removing a few redundant cache clearing invocations, they are were already subsumed by `util.clear_all_caches`.