### PR TITLE
Add heartbeat argument to distributed.initialize.

### DIFF
--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -191,6 +191,7 @@ def initialize(coordinator_address: str | None = None,
                local_device_ids: int | Sequence[int] | None = None,
                cluster_detection_method: str | None = None,
                initialization_timeout: int = 300,
+               heartbeat_timeout_seconds: int = 100,
                coordinator_bind_address: str | None = None,
                slice_index: int | None = None):
   """Initializes the JAX distributed system.
@@ -248,6 +249,9 @@ def initialize(coordinator_address: str | None = None,
     initialization_timeout: Time period (in seconds) for which connection will
       be retried. If the initialization takes more than the timeout specified,
       the initialization will error. Defaults to 300 secs i.e. 5 mins.
+    heartbeat_timeout_seconds: The time (in seconds) after which a process is
+      considered dead if it hasn't successfully sent any heartbeats. Defaults
+      to 100 seconds.
     coordinator_bind_address: the address and port to which the coordinator service
       on process `0` should bind. If this is not specified, the default is to bind to
       all available addresses on the same port as ``coordinator_address``. On systems
@@ -281,6 +285,7 @@ def initialize(coordinator_address: str | None = None,
   global_state.initialize(coordinator_address, num_processes, process_id,
                           local_device_ids, cluster_detection_method,
                           initialization_timeout, coordinator_bind_address,
+                          heartbeat_timeout_seconds=heartbeat_timeout_seconds,
                           slice_index=slice_index)
 
 


### PR DESCRIPTION
This PR adds a new `heartbeat_timeout_seconds` argument to `jax.distributed.initialize` that allows users to customize how long a process can fail to send a heartbeat before being considered dead.