### PR TITLE
[direct-linearize] fix tests to pass under JAX_USE_DIRECT_LINEARIZE=1

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1487,7 +1487,6 @@ def _to_lojax(*hi_args, jaxpr, **params):
   hi_args = [*closed_over_himutables, *hi_args]
   params = _converted_mutables_add_params(len(closed_over_himutables), **params)
 
-
   # expand pjit params that must match number of lo inputs/outputs
   lo_nums_in = [len(aval.lo_ty()) for aval in jaxpr.in_aval_qdds]
   lo_nums_out = [len(t.lo_ty()) for t in jaxpr.out_avals]

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4354,9 +4354,6 @@ class APITest(jtu.JaxTestCase):
     # from https://github.com/jax-ml/jax/issues/7613
     import numpy.random as npr
 
-    def sigmoid(x):
-      return 1. / (1. + jnp.exp(-x))
-
     x = jnp.ones((1, 50))
     A = jnp.array(npr.randn(50, 50), dtype=x.dtype)
 

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -408,13 +408,13 @@ class CoreTest(jtu.JaxTestCase):
     self.assertEqual(x_repr, "VmapTracer<int32[]>")
 
     jax.grad(f)(jnp.float16(1.0))
-    self.assertEqual(x_repr, "GradTracer<float16[]>")
+    self.assertRegex(x_repr, r"(Grad)|(Linearize)Tracer<float16\[\]>")
 
     jax.jacrev(f)(jnp.arange(12, dtype='float32'))
-    self.assertEqual(x_repr, "GradTracer<float32[12]>")
+    self.assertRegex(x_repr, r"(Grad)|(Linearize)Tracer<float32\[12\]>")
 
     jax.jacfwd(f)(jnp.arange(14, dtype='float32'))
-    self.assertEqual(x_repr, "GradTracer<float32[14]>")
+    self.assertRegex(x_repr, r"(Grad)|(Linearize)Tracer<float32\[14\]>")
 
   def test_verbose_tracer_reprs(self):
     # Verbose reprs, avaiable via tracer._pretty_print()
@@ -431,7 +431,7 @@ class CoreTest(jtu.JaxTestCase):
     self.assertRegex(x_repr, r"^Traced<int32\[\]>with<BatchTrace>")
 
     jax.grad(f)(jnp.float16(1.0))
-    self.assertRegex(x_repr, r"^Traced<float16\[\]>with<JVPTrace>")
+    self.assertRegex(x_repr, r"^Traced<float16\[\]>with<(JVP)|(Linearize)Trace>")
 
 
 @jtu.with_config(jax_pprint_use_color=False)

--- a/tests/mutable_array_test.py
+++ b/tests/mutable_array_test.py
@@ -826,7 +826,7 @@ class MutableArrayErrorsTest(jtu.JaxTestCase):
       x_ref[...] += val
 
     vals = jnp.arange(3, dtype='int32')
-    with self.assertRaisesRegex(Exception, "unbatched mutable array"):
+    with self.assertRaisesRegex(Exception, "unbatched array reference"):
       jax.vmap(f)(vals)
 
   def test_vmap_aliased_arguments(self):
@@ -838,6 +838,16 @@ class MutableArrayErrorsTest(jtu.JaxTestCase):
         ValueError,
         "only one reference to a mutable array may be passed as an argument"):
       jax.vmap(f)(x_ref, x_ref)
+
+  def test_jvp_closed_over_ref_error(self):
+    ref = core.mutable_array(0.)
+    def f(x):
+      ref[...] = x
+      return x
+    with self.assertRaisesRegex(
+        Exception, "Move the array reference"):
+      jax.jvp(f, [1.], [1.])
+
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Small fixes to make tests pass under JAX_USE_DIRECT_LINEARIZE=1 again.

Also include a simple error message for this:

```python
ref = core.mutable_array(0.)
def f(x):
  ref[...] = x
  return x
jax.jvp(f, [1.], [1.])
```