### PR TITLE
scaled_matmul_stablehlo_test: add multiaccelerator tag

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -2134,6 +2134,9 @@ jax_multiplatform_test(
     shard_count = {
         "gpu": 4,
     },
+    tags = [
+        "multiaccelerator",
+    ],
     deps = py_deps([
         "absl/testing",
         "numpy",


### PR DESCRIPTION
Several tests are skipped if <4 local devices are visible:
https://github.com/jax-ml/jax/blob/8d903a986ea099d4cb90baceef00f8c09809620b/tests/scaled_matmul_stablehlo_test.py#L298-L300
https://github.com/jax-ml/jax/blob/8d903a986ea099d4cb90baceef00f8c09809620b/tests/scaled_matmul_stablehlo_test.py#L412-L414
https://github.com/jax-ml/jax/blob/8d903a986ea099d4cb90baceef00f8c09809620b/tests/scaled_matmul_stablehlo_test.py#L723-L725