### PR TITLE
Deprecate jax.lib.xla_bridge.get_compile_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     have been removed.
   * `jax.extend.ffi` was removed after being deprecated in v0.5.0.
     Use {mod}`jax.ffi` instead.
+  * {func}`jax.lib.xla_bridge.get_compile_options` is deprecated, and replaced by
+    {func}`jax.extend.backend.get_compile_options`.
 
 ## JAX 0.6.2 (June 17, 2025)
 

--- a/jax/extend/BUILD
+++ b/jax/extend/BUILD
@@ -64,6 +64,7 @@ pytype_strict_library(
     srcs = ["backend.py"],
     deps = [
         "//jax:api",
+        "//jax:compiler",
         "//jax:util",
         "//jax:xla_bridge",
     ],

--- a/jax/extend/backend.py
+++ b/jax/extend/backend.py
@@ -18,6 +18,9 @@
 from jax._src.api import (
   clear_backends as clear_backends,
 )
+from jax._src.compiler import (
+    get_compile_options as get_compile_options,
+)
 from jax._src.xla_bridge import (
   backends as backends,
   backend_xla_version as backend_xla_version,

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -18,7 +18,7 @@ from jax._src.xla_bridge import (
 )
 
 from jax._src.compiler import (
-  get_compile_options as get_compile_options,
+  get_compile_options as _deprecated_get_compile_options,
 )
 
 _deprecations = {
@@ -27,11 +27,20 @@ _deprecations = {
     "jax.lib.xla_bridge.get_backend is deprecated; use jax.extend.backend.get_backend.",
     _deprecated_get_backend
   ),
+  # Added for JAX v0.7.0
+  "get_compile_options": (
+    (
+      "jax.lib.xla_bridge.get_compile_options is deprecated in JAX v0.7.0 and"
+      " will be removed in JAX v0.8.0. Use jax.extend.backend.get_compile_options."
+    ),
+    _deprecated_get_compile_options
+  )
 }
 
 import typing as _typing
 if _typing.TYPE_CHECKING:
   from jax._src.xla_bridge import get_backend as get_backend
+  from jax._src.compiler import get_compile_options as get_compile_options
 else:
   from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
   __getattr__ = _deprecation_getattr(__name__, _deprecations)


### PR DESCRIPTION
Add jax.extend.backend.get_compile_options as a semi-public replacement.

This is the last public API in `jax.lib.xla_bridge`; once this deprecation is finalized we can remove that submodule.