### PR TITLE
Deprecate jax.interpreters.xla.canonicalize_dtype.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     deprecation in SciPy; use {func}`jax.scipy.special.sph_harm_y` instead.
   * From {mod}`jax.interpreters.xla`, the previously deprecated symbols
     `abstractify` and `pytype_aval_mappings` have been removed.
+  * {func}`jax.interpreters.xla.canonicalize_dtype` is deprecated. For
+    canonicalizing dtypes, prefer {func}`jax.dtypes.canonicalize_dtype`.
+    For checking whether an object is a valid jax input, prefer
+    {func}`jax.core.valid_jaxtype`.
   * From {mod}`jax.core`, the previously deprecated symbols `AxisName`,
     `ConcretizationTypeError`, `call_p`, `closed_call_p`, `get_type`, and
     `typecheck` have been removed.

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from jax._src.interpreters.xla import (
-  canonicalize_dtype as canonicalize_dtype,
+  canonicalize_dtype as _deprecated_canonicalize_dtype,
   canonicalize_dtype_handlers as canonicalize_dtype_handlers,
 )
 
@@ -44,8 +44,23 @@ _deprecations = {
         ),
         None,
     ),
+    # Added in JAX v0.7.0
+    "canonicalize_dtype": (
+        (
+            "jax.interpreters.xla.canonicalize_dtype was deprecated in JAX"
+            " v0.7.0 and will be removed in JAX v0.8.0. For canonicalizing"
+            " dtypes, prefer jax.dtypes.canonicalize_dtype. For checking whether"
+            " an object is a valid jax input, prefer jax.core.valid_jaxtype."
+        ),
+        _deprecated_canonicalize_dtype,
+    )
 }
 
-from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
-__getattr__ = _deprecation_getattr(__name__, _deprecations)
-del _deprecation_getattr
+import typing as _typing
+if _typing.TYPE_CHECKING:
+  canonicalize_dtype = _deprecated_canonicalize_dtype
+else:
+  from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
+  __getattr__ = _deprecation_getattr(__name__, _deprecations)
+  del _deprecation_getattr
+del _typing


### PR DESCRIPTION
The only downstream uses I can find for this would be better served by jax.core.valid_jaxtype or jax.dtypes.canonicalize_dtype.