### PR TITLE
Simplify tree_reduce signature using Unspecified bare class.

### DIFF
--- a/jax/_src/tree.py
+++ b/jax/_src/tree.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar
 
 from jax._src import tree_util
 
@@ -155,21 +155,9 @@ def map(f: Callable[..., Any],
   return tree_util.tree_map(f, tree, *rest, is_leaf=is_leaf)
 
 
-@overload
 def reduce(function: Callable[[T, Any], T],
            tree: Any,
-           *,
-           is_leaf: Callable[[Any], bool] | None = None) -> T:
-    ...
-@overload
-def reduce(function: Callable[[T, Any], T],
-           tree: Any,
-           initializer: T,
-           is_leaf: Callable[[Any], bool] | None = None) -> T:
-    ...
-def reduce(function: Callable[[T, Any], T],
-           tree: Any,
-           initializer: Any = tree_util.no_initializer,
+           initializer: T | tree_util.Unspecified = tree_util.Unspecified(),
            is_leaf: Callable[[Any], bool] | None = None) -> T:
   """Call reduce() over the leaves of a tree.
 

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -21,7 +21,7 @@ import functools
 from functools import partial
 import operator as op
 import textwrap
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar
 
 from jax._src import traceback_util
 from jax._src.lib import pytree
@@ -420,39 +420,21 @@ _registry: dict[type[Any], _RegistryEntry] = {
     type(None): _RegistryEntry(lambda z: ((), None), lambda _, xs: None),
 }
 
-no_initializer = object()
 
-
-@overload
-def tree_reduce(function: Callable[[T, Any], T],
-                tree: Any,
-                *,
-                is_leaf: Callable[[Any], bool] | None = None) -> T:
-    ...
-
-
-@overload
-def tree_reduce(function: Callable[[T, Any], T],
-                tree: Any,
-                initializer: T,
-                is_leaf: Callable[[Any], bool] | None = None) -> T:
-    ...
+class Unspecified:
+  pass
 
 
 @export
 def tree_reduce(function: Callable[[T, Any], T],
                 tree: Any,
-                initializer: Any = no_initializer,
+                initializer: T | Unspecified = Unspecified(),
                 is_leaf: Callable[[Any], bool] | None = None) -> T:
   """Alias of :func:`jax.tree.reduce`."""
-  if initializer is no_initializer:
+  if isinstance(initializer, Unspecified):
     return functools.reduce(function, tree_leaves(tree, is_leaf=is_leaf))
   else:
     return functools.reduce(function, tree_leaves(tree, is_leaf=is_leaf), initializer)
-
-
-class Unspecified:
-  pass
 
 
 def _parallel_reduce(


### PR DESCRIPTION
Simplifies the signature for [`jax.tree_util.tree_reduce`](https://docs.jax.dev/en/latest/_autosummary/jax.tree_util.tree_reduce.html) and [`jax.tree.reduce`](https://docs.jax.dev/en/latest/_autosummary/jax.tree.reduce.html) using the `Unspecified` bare class [defined](https://github.com/jax-ml/jax/blob/7a06933d7426f1b8c6f59cf690906f8479c0cd34/jax/_src/tree_util.py#L461) in `tree_util`. This removes the need for the overloads.

For context, see https://github.com/jax-ml/jax/pull/29997#discussion_r2193302032.