### PR TITLE
[Mosaic GPU] Fix a race in test_remote_async_copy

### DIFF
--- a/jax/experimental/mosaic/gpu/__init__.py
+++ b/jax/experimental/mosaic/gpu/__init__.py
@@ -100,6 +100,7 @@ from .utils import (
     memref_unsqueeze as memref_unsqueeze,
     single_thread as single_thread,
     single_thread_predicate as single_thread_predicate,
+    system_memory_barrier as system_memory_barrier,
     thread_idx as thread_idx,
     tile_shape as tile_shape,
     warp_idx as warp_idx,

--- a/jax/experimental/mosaic/gpu/utils.py
+++ b/jax/experimental/mosaic/gpu/utils.py
@@ -748,6 +748,16 @@ def warp_barrier():
   nvvm.bar_warp_sync(c(0xffffffff, ir.IntegerType.get_signless(32)))
 
 
+def system_memory_barrier():
+  llvm.inline_asm(
+      ir.Type.parse("!llvm.void"),
+      [],
+      "fence.sys;",
+      "",
+      has_side_effects=True,
+  )
+
+
 @dataclasses.dataclass(frozen=True)
 class BarrierRef:
   base_address: ir.Value

--- a/tests/mosaic/gpu_test_distributed.py
+++ b/tests/mosaic/gpu_test_distributed.py
@@ -94,28 +94,40 @@ class ProfilerTest(TestCase):
 
   def test_remote_async_copy(self):
     i32 = ir.IntegerType.get_signless(32)
-    def kernel(ctx, src, dst, scratch):
+    def kernel(ctx, src, sem, dst, scratch):
       tmp, barrier = scratch
       other_device = arith.subi(arith.constant(i32, 1), ctx.device_id())
       ctx.async_copy(src_ref=src, dst_ref=tmp, barrier=barrier)
       barrier.wait()
       ctx.async_copy(src_ref=tmp, dst_ref=dst, gmem_peer_id=other_device)
       ctx.await_async_copy(0)
+      # Observe completion of my write to peer's memory.
+      mgpu.system_memory_barrier()
+      # Signal completion (of my write to peer's memory) to the peer.
+      other_sem = mgpu.SemaphoreRef(
+        mgpu.utils.memref_ptr(ctx.to_remote(sem, other_device)))
+      other_sem.signal(1)
+      # Observe completion of peer's write to my memory.
+      my_sem = mgpu.SemaphoreRef(mgpu.utils.memref_ptr(sem))
+      my_sem.wait(1)
+
     mesh = jax.make_mesh(
         (2,), ("x",), axis_types=(jax.sharding.AxisType.Explicit,)
     )
     with jax.sharding.use_mesh(mesh):
       x_np = np.arange(64 * 64, dtype=jnp.float32).reshape(64, 64)
       x = jax.sharding.reshard(x_np, P("x"))
-      y = jax.jit(
+      sem = jax.sharding.reshard(jnp.zeros((1,), dtype=jnp.int32), P())
+      y, _ = jax.jit(
           jax.shard_map(
-              lambda x: mgpu.as_gpu_kernel(
-                  kernel, (1, 1, 1), (128, 1, 1), x, x, (x, mgpu.TMABarrier())
-              )(x),
-              out_specs=P("x"),
+              lambda x, sem: mgpu.as_gpu_kernel(
+                  kernel, (1, 1, 1), (128, 1, 1), x, x, (x, mgpu.TMABarrier()), inout_shape=sem
+              )(x, sem),
+              in_specs=(P("x"), P(None)),
+              out_specs=[P("x"), P(None)],
               check_vma=False,
           )
-      )(x)
+      )(x, sem)
       y_np = multihost_utils.process_allgather(y, tiled=True)
       np.testing.assert_array_equal(
           y_np, np.concatenate(np.split(x_np, 2)[::-1], axis=0)


### PR DESCRIPTION
Previously the kernel in the test would exit without observing the completion of the current GPU's and the peer GPU's writes to each other's memory, which occasionally led to failing correctness checks.

We fix the race by adding a system memory barrier to observe the completion of this GPU's write to the peer GPU's memory, and a semaphore that allows to observe the peer's GPU write to this GPU's memory.