### PR TITLE
Add clarification to softmax and log_softmax regarding masked-out elements.

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -534,7 +534,8 @@ def log_softmax(x: ArrayLike,
     x : input array
     axis: the axis or axes along which the :code:`log_softmax` should be
       computed. Either an integer or a tuple of integers.
-    where: Elements to include in the :code:`log_softmax`.
+    where: Elements to include in the :code:`log_softmax`. The output for any
+      masked-out element is minus infinity.
 
   Returns:
     An array.
@@ -577,7 +578,8 @@ def softmax(x: ArrayLike,
     axis: the axis or axes along which the softmax should be computed. The
       softmax output summed across these dimensions should sum to :math:`1`.
       Either an integer or a tuple of integers.
-    where: Elements to include in the :code:`softmax`.
+    where: Elements to include in the :code:`softmax`. The output for any
+      masked-out element is zero.
 
   Returns:
     An array.


### PR DESCRIPTION
Adds a minor clarification to the documentation for [`softmax`](https://docs.jax.dev/en/latest/_autosummary/jax.nn.softmax.html) and [`log_softmax`](https://docs.jax.dev/en/latest/_autosummary/jax.nn.log_softmax.html) explaining the output behavior for masked-out elements.