### PR TITLE
Add tip to tree reduce and reduce_associative about how to exclude leaves from the reduction.

### DIFF
--- a/jax/_src/tree.py
+++ b/jax/_src/tree.py
@@ -191,6 +191,11 @@ def reduce(function: Callable[[T, Any], T],
     >>> jax.tree.reduce(operator.add, [1, (2, 3), [4, 5, 6]])
     21
 
+  Notes:
+    **Tip**: You can exclude leaves from the reduction by first mapping them to
+    ``None`` using :func:`jax.tree.map`. This causes them to not be counted as
+    leaves after that.
+
   See Also:
     - :func:`jax.tree.reduce_associative`
     - :func:`jax.tree.leaves`
@@ -229,6 +234,11 @@ def reduce_associative(
     >>> import operator
     >>> jax.tree.reduce_associative(operator.add, [1, (2, 3), [4, 5, 6]])
     21
+
+  Notes:
+    **Tip**: You can exclude leaves from the reduction by first mapping them to
+    ``None`` using :func:`jax.tree.map`. This causes them to not be counted as
+    leaves after that.
 
   See Also:
     - :func:`jax.tree.reduce`


### PR DESCRIPTION
Adds a tip to [`tree.reduce`](https://docs.jax.dev/en/latest/_autosummary/jax.tree.reduce.html) and [`tree.reduce_associative`](https://docs.jax.dev/en/latest/_autosummary/jax.tree.reduce_associative.html) about how to exclude leaves from the reduction.

Context: https://github.com/jax-ml/jax/issues/30156.