### PR TITLE
Summarize large constants that may appear in Jaxpr literals

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -527,10 +527,11 @@ class Literal:
   def pretty_print(self, context: JaxprPpContext, *, print_dtype: bool = True):
     del context  # unused
     dtype = getattr(self.aval, 'dtype', None)
+    val_str = str(self.val) if not np.shape(self.val) else "[...]"
     if print_dtype and dtype:
-      return f'{self.val}:{self.aval.str_short(short_dtypes=True)}'
+      return f'{val_str}:{self.aval.str_short(short_dtypes=True)}'
     else:
-      return f'{self.val}'
+      return f'{val_str}'
 
   def __repr__(self):
     return f'Literal({self.val})'

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6927,6 +6927,15 @@ class JaxprTest(jtu.JaxTestCase):
     jaxpr = api.make_jaxpr(fun)(jnp.float32(0.))
     self.assertMultiLineStrippedEqual(expected, str(jaxpr))
 
+  @config.use_simplified_jaxpr_constants(True)
+  def test_non_scalar_const(self):
+    def fun(x):
+      return (x, np.zeros(3, dtype=jnp.float32))
+
+    expected = "{ lambda ; a:f32[]. let  in (a, [...]:f32[3]) }"
+    jaxpr = api.make_jaxpr(fun)(jnp.float32(0.))
+    self.assertMultiLineStrippedEqual(expected, str(jaxpr))
+
   def test_cond(self):
     def f(x):
       return lax.cond(x >= 0.,


### PR DESCRIPTION
Once we enable `config.use_simplified_jaxpr_constants` (see #29679) we can end up with potentially large constants in Jaxprs. Instead of printing non-scalars we summarize them as `[...]`.

For example, if before a Jaxpr with constants would be printed as:

```
{ lambda a:f32[256]; b:f32[]. let  in (b, 1.0:f32[], a) }
```

now would be printed as

```
{ lambda a:f32[]. let  in (a, 1.0:f32[], [...]:f32[256) }
```

In particular, this summarization does not increse the number of lines in Jaxpr printing.