### PR TITLE
Document all checkpoint policies in one place, on the JAX public API page.

### DIFF
--- a/docs/gradient-checkpointing.md
+++ b/docs/gradient-checkpointing.md
@@ -411,22 +411,7 @@ The code defines a function `f` that which applies checkpointing with a custom p
 
 #### List of policies
 
-The policies are:
-* `everything_saveable` (the default strategy, as if `jax.checkpoint` were not being used at all)
-* `nothing_saveable` (i.e. rematerialize everything, as if a custom policy were not being used at all)
-* `dots_saveable` or its alias `checkpoint_dots`
-* `dots_with_no_batch_dims_saveable` or its alias `checkpoint_dots_with_no_batch_dims`
-* `save_anything_but_these_names` (save any values except for the output of
-  `checkpoint_name` with any of the names given)
-* `save_any_names_but_these` (save only named values, i.e. any outputs of
-  `checkpoint_name`, except for those with the names given)
-* `save_only_these_names` (save only named values, and only among the names
-  given)
-* `offload_dot_with_no_batch_dims` same as `dots_with_no_batch_dims_saveable`,
-  but offload to CPU memory instead of recomputing.
-* `save_and_offload_only_these_names` same as `save_only_these_names`, but
-  offload to CPU memory instead of recomputing.
-* `save_from_both_policies(policy_1, policy_2)` (like a logical `or`, so that a residual is saveable if it is saveable according to `policy_1` _or_ `policy_2`)
+The policies can be found [here](https://docs.jax.dev/en/latest/jax.html#checkpoint-policies).
 
 Policies only indicate what is saveable; a value is only saved if it's actually needed by the backward pass.
 

--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -265,3 +265,21 @@ Miscellaneous
     print_environment_info
     live_arrays
     clear_caches
+
+Checkpoint policies
+-------------------
+
+.. autosummary::
+  :toctree: _autosummary
+
+    checkpoint_policies.everything_saveable
+    checkpoint_policies.nothing_saveable
+    checkpoint_policies.dots_saveable
+    checkpoint_policies.checkpoint_dots
+    checkpoint_policies.dots_with_no_batch_dims_saveable
+    checkpoint_policies.checkpoint_dots_with_no_batch_dims
+    checkpoint_policies.save_any_names_but_these
+    checkpoint_policies.save_only_these_names
+    checkpoint_policies.offload_dot_with_no_batch_dims
+    checkpoint_policies.save_and_offload_only_these_names
+    checkpoint_policies.save_from_both_policies

--- a/docs/notebooks/autodiff_remat.ipynb
+++ b/docs/notebooks/autodiff_remat.ipynb
@@ -812,17 +812,7 @@
    "source": [
     "Another policy which refers to names is `jax.checkpoint_policies.save_only_these_names`.\n",
     "\n",
-    "Some of the policies are:\n",
-    "* `everything_saveable` (the default strategy, as if `jax.checkpoint` were not being used at all)\n",
-    "* `nothing_saveable` (i.e. rematerialize everything, as if a custom policy were not being used at all)\n",
-    "* `dots_saveable` or its alias `checkpoint_dots`\n",
-    "* `dots_with_no_batch_dims_saveable` or its alias `checkpoint_dots_with_no_batch_dims`\n",
-    "* `save_anything_but_these_names` (save any values except for the output of\n",
-    "  `checkpoint_name` with any of the names given)\n",
-    "* `save_any_names_but_these` (save only named values, i.e. any outputs of\n",
-    "  `checkpoint_name`, except for those with the names given)\n",
-    "* `save_only_these_names` (save only named values, and only among the names\n",
-    "  given)\n",
+    "A list of policies can be found [here](https://docs.jax.dev/en/latest/jax.html#checkpoint-policies).\n",
     "\n",
     "Policies only indicate what is saveable; a value is only saved if it's actually needed by the backward pass."
    ]

--- a/docs/notebooks/autodiff_remat.md
+++ b/docs/notebooks/autodiff_remat.md
@@ -396,17 +396,7 @@ print_saved_residuals(loss_checkpoint2, params, x, y)
 
 Another policy which refers to names is `jax.checkpoint_policies.save_only_these_names`.
 
-Some of the policies are:
-* `everything_saveable` (the default strategy, as if `jax.checkpoint` were not being used at all)
-* `nothing_saveable` (i.e. rematerialize everything, as if a custom policy were not being used at all)
-* `dots_saveable` or its alias `checkpoint_dots`
-* `dots_with_no_batch_dims_saveable` or its alias `checkpoint_dots_with_no_batch_dims`
-* `save_anything_but_these_names` (save any values except for the output of
-  `checkpoint_name` with any of the names given)
-* `save_any_names_but_these` (save only named values, i.e. any outputs of
-  `checkpoint_name`, except for those with the names given)
-* `save_only_these_names` (save only named values, and only among the names
-  given)
+A list of policies can be found [here](https://docs.jax.dev/en/latest/jax.html#checkpoint-policies).
 
 Policies only indicate what is saveable; a value is only saved if it's actually needed by the backward pass.
 


### PR DESCRIPTION
Document all checkpoint policies (separately listed [here](https://docs.jax.dev/en/latest/notebooks/autodiff_remat.html#custom-policies-for-what-s-saveable) and [here](https://docs.jax.dev/en/latest/gradient-checkpointing.html#list-of-policies), currently) in one place: The JAX [public API page](file:///Users/carlos/Desktop/jax/docs/build/html/jax.html).

Fixes https://github.com/jax-ml/jax/issues/12417.