### PR TITLE
[jaxprs] Hoist large constants as arguments during lowering

### DIFF
--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -953,6 +953,7 @@ pytype_strict_library(
         ":sharding_impls",
         ":source_info_util",
         ":state_types",
+        ":typing",
         ":util",
         ":xla",
         ":xla_bridge",

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -783,7 +783,7 @@ def _remat_translation_using_opt_barrier(*args, jaxpr: core.Jaxpr):
 
 
 def _remat_lowering(
-    ctx,
+    ctx: mlir.LoweringRuleContext,
     *args,
     jaxpr: core.Jaxpr,
     prevent_cse: bool,
@@ -801,7 +801,8 @@ def _remat_lowering(
     jaxpr_args = args
   outs, tokens_out = mlir.jaxpr_subcomp(
       ctx.module_context, jaxpr, ctx.name_stack.extend('checkpoint'),
-      ctx.tokens_in, (), *jaxpr_args, dim_var_values=ctx.dim_var_values)
+      ctx.tokens_in, (), *jaxpr_args, dim_var_values=ctx.dim_var_values,
+      const_lowering=ctx.const_lowering)
   ctx.set_tokens_out(tokens_out)
   return outs
 

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1690,8 +1690,8 @@ def _cpp_pmap(
     with core.take_current_trace() as trace:
       try:
         if isinstance(trace, core.EvalTrace):
-          execute = pxla.xla_pmap_impl_lazy(p.flat_fun, *p.flat_args, **params)
-          out = execute(*p.flat_args)
+          execute, const_args = pxla.xla_pmap_impl_lazy(p.flat_fun, *p.flat_args, **params)
+          out = execute(*const_args, *p.flat_args)
         else:
           out = pxla.xla_pmap_p.bind_with_trace(trace, (p.flat_fun, *p.flat_args), params)
       except api_util.InternalFloatingPointError as e:

--- a/jax/_src/export/_export.py
+++ b/jax/_src/export/_export.py
@@ -617,6 +617,7 @@ def _export_internal(
         _private_parameters=mlir.LoweringParameters(
             override_lowering_rules=override_lowering_rules,
             for_export=True,
+            hoist_constants_as_args=False,
             export_ignore_forward_compatibility=config.export_ignore_forward_compatibility.value))
     return _export_lowered(
         lowered, traced.jaxpr, traced.fun_name,
@@ -954,7 +955,7 @@ def _wrap_main_func(
           host_callbacks=[], module=wrapped_module, context=context,
           lowering_parameters=mlir.LoweringParameters(
               global_constant_computation=True,
-              for_export=True,
+              for_export=True, hoist_constants_as_args=False,
               export_ignore_forward_compatibility=config.export_ignore_forward_compatibility.value,
           ))
       ctx = mlir.LoweringRuleContext(
@@ -962,7 +963,8 @@ def _wrap_main_func(
         name_stack=source_info_util.new_name_stack(), traceback=None,
         primitive=None,
         avals_in=args_avals_flat, avals_out=None,
-        tokens_in=mlir.TokenSet(), tokens_out=None)
+        tokens_in=mlir.TokenSet(), tokens_out=None,
+        const_lowering={})
       # We compute dim_values from the array arguments.
       new_main_op_array_args = new_main_op.arguments[-nr_array_args:]
       if shape_poly.all_dim_vars(args_avals_flat):

--- a/jax/_src/frozen_dict.py
+++ b/jax/_src/frozen_dict.py
@@ -47,3 +47,6 @@ class FrozenDict(Mapping[K, V]):
 
   def __len__(self) -> int:
     return len(self._d)
+
+  def get(self, key: K) -> V | None:  # type: ignore
+    return self._d.get(key, None)

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -1004,7 +1004,7 @@ def _cond_lowering(ctx, index, *args, branches,
       out_vals, tokens_out = mlir.jaxpr_subcomp(
           ctx.module_context, jaxpr.jaxpr, name_stack.extend(f'branch_{i}_fun'),
           tokens_in, consts, *args,
-          dim_var_values=ctx.dim_var_values)
+          dim_var_values=ctx.dim_var_values, const_lowering=ctx.const_lowering)
       out_tokens = [tokens_out.get(eff) for eff in ordered_effects]
       out_vals = [*out_tokens, *out_vals]
       hlo.return_(mlir.flatten_ir_values(out_vals))

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -3255,8 +3255,8 @@ def _scatter_lower_opaque(ctx, operand, indices, updates, *,
   return res
 
 
-def _scatter_lower(ctx, operand, indices, updates, *,
-                   update_jaxpr, update_consts, dimension_numbers,
+def _scatter_lower(ctx: mlir.LoweringRuleContext, operand, indices, updates, *,
+                   update_jaxpr: core.Jaxpr, update_consts, dimension_numbers,
                    indices_are_sorted, unique_indices, mode):
   if update_jaxpr is None:
     assert not update_consts
@@ -3301,7 +3301,7 @@ def _scatter_lower(ctx, operand, indices, updates, *,
     out_nodes, _ = mlir.jaxpr_subcomp(
         ctx.module_context, update_jaxpr, name_stack, mlir.TokenSet(),
         update_consts, update.arguments[0], update.arguments[1],
-        dim_var_values=ctx.dim_var_values)
+        dim_var_values=ctx.dim_var_values, const_lowering=ctx.const_lowering)
     hlo.return_(mlir.flatten_ir_values(out_nodes))
   return [mlir.lower_with_sharding_in_types(ctx, r, aval)
           for r, aval in safe_zip(op.results, ctx.avals_out)]

--- a/jax/_src/stages.py
+++ b/jax/_src/stages.py
@@ -731,11 +731,13 @@ class Traced(Stage):
       lowering = self._lower_callable(
           lowering_platforms=lowering_platforms,
           lowering_parameters=_private_parameters)
+      assert not lowering._const_args
     except DeviceAssignmentMismatchError as e:
       fails, = e.args
       msg = _device_assignment_mismatch_error(
           self.fun_name, fails, self._args_flat, 'jit', self._arg_names)
       raise ValueError(msg) from None
+    # TODO(necula): add the hoisted consts to the Lowered
     return Lowered(lowering, self.args_info, self._out_tree)
 
 

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1431,6 +1431,22 @@ class JaxTestCase(parameterized.TestCase):
                         atol=atol or tol, rtol=rtol or tol,
                         canonicalize_dtypes=canonicalize_dtypes)
 
+  def assertCacheMisses(self,
+                        func: Callable[[], Any], *,
+                        cpp: int | None = None,
+                        tracing: int | None = None,
+                        lowering: int | None = None):
+    with (count_pjit_cpp_cache_miss() as cpp_count,
+          count_jit_tracing_cache_miss() as tracing_count,
+          count_jit_and_pmap_lowerings() as lowering_count):
+      func()
+    if cpp is not None:
+      self.assertEqual(cpp, cpp_count())
+    if tracing is not None:
+      self.assertEqual(tracing, tracing_count())
+    if lowering is not None:
+      self.assertEqual(lowering, lowering_count())
+
 _PJIT_IMPLEMENTATION = api.jit
 _PJIT_IMPLEMENTATION._name = "jit"
 _NOOP_JIT_IMPLEMENTATION = lambda x, *args, **kwargs: x

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -492,7 +492,7 @@ class PallasCallTest(PallasBaseTest):
     self.assertEqual(o_ref_shape, (4,))
     self.assertAllClose(pids[0:4], np.array([0] * 4, dtype=np.int32))
 
-  def test_hoisted_consts(self):
+  def test_const_args(self):
     if config.use_simplified_jaxpr_constants.value:
       self.skipTest("TODO: decide if we want to keep these errors")
     # See https://github.com/jax-ml/jax/issues/21557.

--- a/tests/pallas/pallas_vmap_test.py
+++ b/tests/pallas/pallas_vmap_test.py
@@ -130,7 +130,7 @@ class PallasCallVmapTest(PallasBaseTest):
     out_ref = jnp.arange(1, 9).reshape((4, 2))
     np.testing.assert_allclose(out, out_ref)
 
-  def test_vmap_with_hoisted_consts(self):
+  def test_vmap_with_const_args(self):
     if config.use_simplified_jaxpr_constants.value:
       self.skipTest("TODO: decide if we want to keep these errors")
     to_store = np.arange(128, dtype=np.float32).reshape((1, 128))


### PR DESCRIPTION
After #29882 non-scalar constants appear as `core.Literal` in `Jaxpr.eqns.invars`, and `ClosedJaxpr` are mostly empty of `consts`. While this simplifies the Jaxprs, there are several problems with the current lowering where we serialize the constants as HLO constants:

  * if the constant is on a device, it gets copied to the host and is embedded in the lowered HLO. This increases memory usage, and if the constant was sharded on multiple devices it will now become replicated. Several large Google-internal tests are OOMing.
  * if a constant appears in multiple places in the Jaxpr, we will make copies.
  * if the constants are inlined in the HLO the XLA constant folding starts to constant-fold them, and we see warnings due to very slow constant folding.
  * the constant folding changes the numerical behavior compared to current lowering strategy.

With the change in this PR, during lowering we hoist the constant args out of the Jaxpr (the new function `jaxpr_const_args`), we pass them as arguments to the top-level HLO function and we thread them to other functions that need them.

I tried several places in the call stack where to hoist the constants as arguments, and update the avals, sharding, layouts for the arguments to reflect the newly added arguments. I found that it is easiest to do this fairly high up the call stack, in `pxla.lower_sharding_computation` because the new avals/sharding/layouts are then passed down to the lowering functions from there, but are also put in `MeshComputation`.  I had to add several arguments to lowering functions to pass `avals` (they were before picked from the Jaxpr) and `num_const_args`. The latter makes some sense to have as an argument because it specifies the calling convention desired from the lowered functions.

This change has no effect, unless `JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS=True`. If the flag is `False` (still the default) then `jaxpr_const_args` returns the empty list, and throughout this change `num_const_args` is 0. The code behavior should not change.

There are a few more tests to fix before we can flip the default for `JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS`, to be done in several smaller follow-up PRs.
