### PR TITLE
[doc] replace tensorflow.org/xla with openxla.org/xla

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ derivatives. It supports reverse-mode differentiation (a.k.a. backpropagation)
 via [`jax.grad`](#automatic-differentiation-with-grad) as well as forward-mode differentiation,
 and the two can be composed arbitrarily to any order.
 
-JAX uses [XLA](https://www.tensorflow.org/xla)
+JAX uses [XLA](https://www.openxla.org/xla)
 to compile and scale your NumPy programs on TPUs, GPUs, and other hardware accelerators.
 You can compile your own pure functions with [`jax.jit`](#compilation-with-jit).
 Compilation and automatic differentiation can be composed arbitrarily.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -92,7 +92,7 @@ Glossary of terms
     XLA
       Short for *Accelerated Linear Algebra*, XLA is a domain-specific compiler for linear
       algebra operations that is the primary backend for :term:`JIT`-compiled JAX code.
-      See https://www.tensorflow.org/xla/.
+      See https://www.openxla.org/xla/.
 
     weak type
       A JAX data type that has the same type promotion semantics as Python scalars;

--- a/docs/jax.lax.rst
+++ b/docs/jax.lax.rst
@@ -9,7 +9,7 @@ are typically defined as transformations on :mod:`jax.lax` primitives.
 
 Many of the primitives are thin wrappers around equivalent XLA operations,
 described by the `XLA operation semantics
-<https://www.tensorflow.org/xla/operation_semantics>`_ documentation. In a few
+<https://www.openxla.org/xla/operation_semantics>`_ documentation. In a few
 cases JAX diverges from XLA, usually to ensure that the set of operations is
 closed under the operation of JVP and transpose rules.
 

--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -1337,7 +1337,7 @@
     "Many such cases are discussed in detail in the sections above; here we list several other known places where the APIs diverge.\n",
     "\n",
     "- For binary operations, JAX's type promotion rules differ somewhat from those used by NumPy. See [Type Promotion Semantics](https://docs.jax.dev/en/latest/type_promotion.html) for more details.\n",
-    "- When performing unsafe type casts (i.e. casts in which the target dtype cannot represent the input value), JAX's behavior may be backend dependent, and in general may diverge from NumPy's behavior. Numpy allows control over the result in these scenarios via the `casting` argument (see [`np.ndarray.astype`](https://numpy.org/devdocs/reference/generated/numpy.ndarray.astype.html)); JAX does not provide any such configuration, instead directly inheriting the behavior of [XLA:ConvertElementType](https://www.tensorflow.org/xla/operation_semantics#convertelementtype).\n",
+    "- When performing unsafe type casts (i.e. casts in which the target dtype cannot represent the input value), JAX's behavior may be backend dependent, and in general may diverge from NumPy's behavior. Numpy allows control over the result in these scenarios via the `casting` argument (see [`np.ndarray.astype`](https://numpy.org/devdocs/reference/generated/numpy.ndarray.astype.html)); JAX does not provide any such configuration, instead directly inheriting the behavior of [XLA:ConvertElementType](https://www.openxla.org/xla/operation_semantics#convertelementtype).\n",
     "\n",
     "  Here is an example of an unsafe cast with differing results between NumPy and JAX:\n",
     "  ```python\n",

--- a/docs/notebooks/Common_Gotchas_in_JAX.md
+++ b/docs/notebooks/Common_Gotchas_in_JAX.md
@@ -687,7 +687,7 @@ While `jax.numpy` makes every attempt to replicate the behavior of numpy's API, 
 Many such cases are discussed in detail in the sections above; here we list several other known places where the APIs diverge.
 
 - For binary operations, JAX's type promotion rules differ somewhat from those used by NumPy. See [Type Promotion Semantics](https://docs.jax.dev/en/latest/type_promotion.html) for more details.
-- When performing unsafe type casts (i.e. casts in which the target dtype cannot represent the input value), JAX's behavior may be backend dependent, and in general may diverge from NumPy's behavior. Numpy allows control over the result in these scenarios via the `casting` argument (see [`np.ndarray.astype`](https://numpy.org/devdocs/reference/generated/numpy.ndarray.astype.html)); JAX does not provide any such configuration, instead directly inheriting the behavior of [XLA:ConvertElementType](https://www.tensorflow.org/xla/operation_semantics#convertelementtype).
+- When performing unsafe type casts (i.e. casts in which the target dtype cannot represent the input value), JAX's behavior may be backend dependent, and in general may diverge from NumPy's behavior. Numpy allows control over the result in these scenarios via the `casting` argument (see [`np.ndarray.astype`](https://numpy.org/devdocs/reference/generated/numpy.ndarray.astype.html)); JAX does not provide any such configuration, instead directly inheriting the behavior of [XLA:ConvertElementType](https://www.openxla.org/xla/operation_semantics#convertelementtype).
 
   Here is an example of an unsafe cast with differing results between NumPy and JAX:
   ```python

--- a/docs/notebooks/thinking_in_jax.ipynb
+++ b/docs/notebooks/thinking_in_jax.ipynb
@@ -286,7 +286,7 @@
     "\n",
     "- `jax.numpy` is a high-level wrapper that provides a familiar interface.\n",
     "- `jax.lax` is a lower-level API that is stricter and often more powerful.\n",
-    "- All JAX operations are implemented in terms of operations in [XLA](https://www.tensorflow.org/xla/) – the Accelerated Linear Algebra compiler."
+    "- All JAX operations are implemented in terms of operations in [XLA](https://www.openxla.org/xla/) – the Accelerated Linear Algebra compiler."
    ]
   },
   {
@@ -463,7 +463,7 @@
    "source": [
     "This is a batched convolution operation designed to be efficient for the types of convolutions often used in deep neural nets. It requires much more boilerplate, but is far more flexible and scalable than the convolution provided by NumPy (See [Convolutions in JAX](https://docs.jax.dev/en/latest/notebooks/convolutions.html) for more detail on JAX convolutions).\n",
     "\n",
-    "At their heart, all `jax.lax` operations are Python wrappers for operations in XLA; here, for example, the convolution implementation is provided by [XLA:ConvWithGeneralPadding](https://www.tensorflow.org/xla/operation_semantics#convwithgeneralpadding_convolution).\n",
+    "At their heart, all `jax.lax` operations are Python wrappers for operations in XLA; here, for example, the convolution implementation is provided by [XLA:ConvWithGeneralPadding](https://www.openxla.org/xla/operation_semantics#convwithgeneralpadding_convolution).\n",
     "Every JAX operation is eventually expressed in terms of these fundamental XLA operations, which is what enables just-in-time (JIT) compilation."
    ]
   },

--- a/docs/notebooks/thinking_in_jax.md
+++ b/docs/notebooks/thinking_in_jax.md
@@ -136,7 +136,7 @@ print(y)
 
 - `jax.numpy` is a high-level wrapper that provides a familiar interface.
 - `jax.lax` is a lower-level API that is stricter and often more powerful.
-- All JAX operations are implemented in terms of operations in [XLA](https://www.tensorflow.org/xla/) – the Accelerated Linear Algebra compiler.
+- All JAX operations are implemented in terms of operations in [XLA](https://www.openxla.org/xla/) – the Accelerated Linear Algebra compiler.
 
 +++ {"id": "BjE4m2sZy4hh"}
 
@@ -208,7 +208,7 @@ result[0, 0]
 
 This is a batched convolution operation designed to be efficient for the types of convolutions often used in deep neural nets. It requires much more boilerplate, but is far more flexible and scalable than the convolution provided by NumPy (See [Convolutions in JAX](https://docs.jax.dev/en/latest/notebooks/convolutions.html) for more detail on JAX convolutions).
 
-At their heart, all `jax.lax` operations are Python wrappers for operations in XLA; here, for example, the convolution implementation is provided by [XLA:ConvWithGeneralPadding](https://www.tensorflow.org/xla/operation_semantics#convwithgeneralpadding_convolution).
+At their heart, all `jax.lax` operations are Python wrappers for operations in XLA; here, for example, the convolution implementation is provided by [XLA:ConvWithGeneralPadding](https://www.openxla.org/xla/operation_semantics#convwithgeneralpadding_convolution).
 Every JAX operation is eventually expressed in terms of these fundamental XLA operations, which is what enables just-in-time (JIT) compilation.
 
 +++ {"id": "NJfWa2PktD5_"}

--- a/jax/_src/internal_test_util/test_harnesses.py
+++ b/jax/_src/internal_test_util/test_harnesses.py
@@ -3131,7 +3131,7 @@ _make_conv_harness(
 # feature_group_count is supported for enable_xla=False only if we are doing a
 # depthwise convolution, i.e.: in_channels == feature_group_count.
 # See explanation of depthwise convolution at
-# https://www.tensorflow.org/xla/operation_semantics#conv_convolution.
+# https://www.openxla.org/xla/operation_semantics#conv_convolution.
 _make_conv_harness(
     "depthwise2d",
     lhs_shape=(2, 3, 9, 9),  # "NCHW": in_channels == 3

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -78,7 +78,7 @@ def switch(index, branches: Sequence[Callable], *operands,
       return branches[index](*operands)
 
   Internally this wraps XLA's `Conditional
-  <https://www.tensorflow.org/xla/operation_semantics#conditional>`_
+  <https://www.openxla.org/xla/operation_semantics#conditional>`_
   operator. However, when transformed with :func:`~jax.vmap` to operate over a
   batch of predicates, ``cond`` is converted to :func:`~jax.lax.select`.
 
@@ -188,7 +188,7 @@ def _cond(pred, true_fun: Callable, false_fun: Callable, *operands,
   """Conditionally apply ``true_fun`` or ``false_fun``.
 
   Wraps XLA's `Conditional
-  <https://www.tensorflow.org/xla/operation_semantics#conditional>`_
+  <https://www.openxla.org/xla/operation_semantics#conditional>`_
   operator.
 
   Provided arguments are correctly typed, ``cond()`` has equivalent

--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -67,7 +67,7 @@ def conv_general_dilated(
   """General n-dimensional convolution operator, with optional dilation.
 
   Wraps XLA's `Conv
-  <https://www.tensorflow.org/xla/operation_semantics#conv_convolution>`_
+  <https://www.openxla.org/xla/operation_semantics#conv_convolution>`_
   operator.
 
   Args:

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1982,7 +1982,7 @@ def concatenate(operands: Array | Sequence[ArrayLike], dimension: int) -> Array:
   """Concatenates a sequence of arrays along `dimension`.
 
   Wraps XLA's `Concatenate
-  <https://www.tensorflow.org/xla/operation_semantics#concatenate>`_
+  <https://www.openxla.org/xla/operation_semantics#concatenate>`_
   operator.
 
   Args:
@@ -2417,7 +2417,7 @@ def dot(lhs: Array, rhs: Array, precision: PrecisionLike = None,
         preferred_element_type: DTypeLike | None = None) -> Array:
   """Vector/vector, matrix/vector, and matrix/matrix multiplication.
 
-  Wraps XLA's `Dot <https://www.tensorflow.org/xla/operation_semantics#dot>`_
+  Wraps XLA's `Dot <https://www.openxla.org/xla/operation_semantics#dot>`_
   operator.
 
   For more general contraction, see the :func:`jax.lax.dot_general` operator.
@@ -2468,7 +2468,7 @@ def dot_general(lhs: ArrayLike, rhs: ArrayLike, dimension_numbers: DotDimensionN
   """General dot product/contraction operator.
 
   Wraps XLA's `DotGeneral
-  <https://www.tensorflow.org/xla/operation_semantics#dotgeneral>`_
+  <https://www.openxla.org/xla/operation_semantics#dotgeneral>`_
   operator.
 
   The semantics of ``dot_general`` are complicated, but most users should not have to
@@ -2476,7 +2476,7 @@ def dot_general(lhs: ArrayLike, rhs: ArrayLike, dimension_numbers: DotDimensionN
   :func:`jax.numpy.matmul`, :func:`jax.numpy.tensordot`, :func:`jax.numpy.einsum`,
   and others which will construct appropriate calls to ``dot_general`` under the hood.
   If you really want to understand ``dot_general`` itself, we recommend reading XLA's
-  `DotGeneral  <https://www.tensorflow.org/xla/operation_semantics#dotgeneral>`_
+  `DotGeneral  <https://www.openxla.org/xla/operation_semantics#dotgeneral>`_
   operator documentation.
 
   Args:
@@ -2692,7 +2692,7 @@ def broadcast_in_dim(operand: ArrayLike, shape: Shape,
                      broadcast_dimensions: Sequence[int], *, out_sharding=None
                      ) -> Array:
   """Wraps XLA's `BroadcastInDim
-  <https://www.tensorflow.org/xla/operation_semantics#broadcastindim>`_
+  <https://www.openxla.org/xla/operation_semantics#broadcastindim>`_
   operator.
 
   Args:
@@ -2735,7 +2735,7 @@ def reshape(operand: ArrayLike, new_sizes: Shape,
             dimensions: Sequence[int] | None = None,
             *, out_sharding: NamedSharding | P | None = None) -> Array:
   """Wraps XLA's `Reshape
-  <https://www.tensorflow.org/xla/operation_semantics#reshape>`_
+  <https://www.openxla.org/xla/operation_semantics#reshape>`_
   operator.
 
   For inserting/removing dimensions of size 1, prefer using ``lax.squeeze`` /
@@ -2795,7 +2795,7 @@ def pad(operand: ArrayLike, padding_value: ArrayLike,
   """Applies low, high, and/or interior padding to an array.
 
   Wraps XLA's `Pad
-  <https://www.tensorflow.org/xla/operation_semantics#pad>`_
+  <https://www.openxla.org/xla/operation_semantics#pad>`_
   operator.
 
   Args:
@@ -2845,7 +2845,7 @@ def pad(operand: ArrayLike, padding_value: ArrayLike,
 
 def rev(operand: ArrayLike, dimensions: Sequence[int]) -> Array:
   """Wraps XLA's `Rev
-  <https://www.tensorflow.org/xla/operation_semantics#rev_reverse>`_
+  <https://www.openxla.org/xla/operation_semantics#rev_reverse>`_
   operator.
   """
   return rev_p.bind(operand, dimensions=tuple(dimensions))
@@ -2854,7 +2854,7 @@ def select(pred: ArrayLike, on_true: ArrayLike, on_false: ArrayLike) -> Array:
   """Selects between two branches based on a boolean predicate.
 
   Wraps XLA's `Select
-  <https://www.tensorflow.org/xla/operation_semantics#select>`_
+  <https://www.openxla.org/xla/operation_semantics#select>`_
   operator.
 
   In general :func:`~jax.lax.select` leads to evaluation of both branches, although
@@ -2881,7 +2881,7 @@ def select_n(which: ArrayLike, *cases: ArrayLike) -> Array:
   """Selects array values from multiple cases.
 
   Generalizes XLA's `Select
-  <https://www.tensorflow.org/xla/operation_semantics#select>`_
+  <https://www.openxla.org/xla/operation_semantics#select>`_
   operator. Unlike XLA's version, the operator is variadic and can select
   from many cases using an integer `pred`.
 
@@ -2907,7 +2907,7 @@ def select_n(which: ArrayLike, *cases: ArrayLike) -> Array:
 def transpose(operand: ArrayLike,
               permutation: Sequence[int] | np.ndarray) -> Array:
   """Wraps XLA's `Transpose
-  <https://www.tensorflow.org/xla/operation_semantics#transpose>`_
+  <https://www.openxla.org/xla/operation_semantics#transpose>`_
   operator.
   """
   permutation = tuple(operator.index(d) for d in permutation)
@@ -2934,7 +2934,7 @@ def reduce(operands: Any,
            computation: Callable[[Any, Any], Any],
            dimensions: Sequence[int]) -> Any:
   """Wraps XLA's `Reduce
-  <https://www.tensorflow.org/xla/operation_semantics#reduce>`_
+  <https://www.openxla.org/xla/operation_semantics#reduce>`_
   operator.
 
   ``init_values`` and ``computation`` together must form a `monoid
@@ -3240,7 +3240,7 @@ def sort(operand: Sequence[Array], dimension: int = -1,
 def sort(operand: Array | Sequence[Array], dimension: int = -1,
          is_stable: bool = True, num_keys: int = 1) -> Array | tuple[Array, ...]:
   """Wraps XLA's `Sort
-  <https://www.tensorflow.org/xla/operation_semantics#sort>`_ operator.
+  <https://www.openxla.org/xla/operation_semantics#sort>`_ operator.
 
   For floating point inputs, -0.0 and 0.0 are treated as equivalent, and NaN values
   are sorted to the end of the array. For complex inputs, the sort order is
@@ -3375,7 +3375,7 @@ ad_util.aval_zeros_likers[state.AbstractRef] = zeros_like_abstract_ref  # type: 
 
 def iota(dtype: DTypeLike, size: int) -> Array:
   """Wraps XLA's `Iota
-  <https://www.tensorflow.org/xla/operation_semantics#iota>`_
+  <https://www.openxla.org/xla/operation_semantics#iota>`_
   operator.
   """
   return broadcasted_iota(dtype, (size,), 0)
@@ -3490,7 +3490,7 @@ def reduce_precision(operand: float | ArrayLike,
                      exponent_bits: int,
                      mantissa_bits: int) -> Array:
   """Wraps XLA's `ReducePrecision
-  <https://www.tensorflow.org/xla/operation_semantics#reduceprecision>`_
+  <https://www.openxla.org/xla/operation_semantics#reduceprecision>`_
   operator.
   """
   exponent_bits = core.concrete_or_error(
@@ -8485,7 +8485,7 @@ def rng_bit_generator(key, shape, dtype=np.uint32,
   default algorithm or the one specified.
 
   It provides direct access to the RngBitGenerator primitive exposed by XLA
-  (https://www.tensorflow.org/xla/operation_semantics#rngbitgenerator) for low
+  (https://www.openxla.org/xla/operation_semantics#rngbitgenerator) for low
   level API access.
 
   Most users should use `jax.random` instead for a stable and more user

--- a/jax/_src/lax/other.py
+++ b/jax/_src/lax/other.py
@@ -54,7 +54,7 @@ def conv_general_dilated_patches(
   Docstring below adapted from `jax.lax.conv_general_dilated`.
 
   See Also:
-    https://www.tensorflow.org/xla/operation_semantics#conv_convolution
+    https://www.openxla.org/xla/operation_semantics#conv_convolution
 
   Args:
     lhs: a rank `n+2` dimensional input array.
@@ -141,7 +141,7 @@ def conv_general_dilated_local(
   spatial location. Docstring below adapted from `jax.lax.conv_general_dilated`.
 
   See Also:
-    https://www.tensorflow.org/xla/operation_semantics#conv_convolution
+    https://www.openxla.org/xla/operation_semantics#conv_convolution
 
   Args:
     lhs: a rank `n+2` dimensional input array.

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -61,7 +61,7 @@ def slice(operand: ArrayLike, start_indices: Sequence[int],
           limit_indices: Sequence[int],
           strides: Sequence[int] | None = None) -> Array:
   """Wraps XLA's `Slice
-  <https://www.tensorflow.org/xla/operation_semantics#slice>`_
+  <https://www.openxla.org/xla/operation_semantics#slice>`_
   operator.
 
   Args:
@@ -121,7 +121,7 @@ def dynamic_slice(
     allow_negative_indices: bool | Sequence[bool] = True
 ) -> Array:
   """Wraps XLA's `DynamicSlice
-  <https://www.tensorflow.org/xla/operation_semantics#dynamicslice>`_
+  <https://www.openxla.org/xla/operation_semantics#dynamicslice>`_
   operator.
 
   Args:
@@ -189,7 +189,7 @@ def dynamic_update_slice(
     allow_negative_indices: bool | Sequence[bool] = True
 ) -> Array:
   """Wraps XLA's `DynamicUpdateSlice
-  <https://www.tensorflow.org/xla/operation_semantics#dynamicupdateslice>`_
+  <https://www.openxla.org/xla/operation_semantics#dynamicupdateslice>`_
   operator.
 
   Args:
@@ -247,7 +247,7 @@ def dynamic_update_slice(
 class GatherDimensionNumbers(NamedTuple):
   """
   Describes the dimension number arguments to an `XLA's Gather operator
-  <https://www.tensorflow.org/xla/operation_semantics#gather>`_. See the XLA
+  <https://www.openxla.org/xla/operation_semantics#gather>`_. See the XLA
   documentation for more details of what the dimension numbers mean.
 
   Args:
@@ -336,7 +336,7 @@ def gather(operand: ArrayLike, start_indices: ArrayLike,
   """Gather operator.
 
   Wraps `XLA's Gather operator
-  <https://www.tensorflow.org/xla/operation_semantics#gather>`_.
+  <https://www.openxla.org/xla/operation_semantics#gather>`_.
 
   :func:`gather` is a low-level operator with complicated semantics, and most JAX
   users will never need to call it directly. Instead, you should prefer using
@@ -436,7 +436,7 @@ def gather(operand: ArrayLike, start_indices: ArrayLike,
 class ScatterDimensionNumbers(NamedTuple):
   """
   Describes the dimension number arguments to an `XLA's Scatter operator
-  <https://www.tensorflow.org/xla/operation_semantics#scatter>`_. See the XLA
+  <https://www.openxla.org/xla/operation_semantics#scatter>`_. See the XLA
   documentation for more details of what the dimension numbers mean.
 
   Args:
@@ -481,7 +481,7 @@ def scatter_add(
   """Scatter-add operator.
 
   Wraps `XLA's Scatter operator
-  <https://www.tensorflow.org/xla/operation_semantics#scatter>`_, where
+  <https://www.openxla.org/xla/operation_semantics#scatter>`_, where
   addition is used to combine updates and values from `operand`.
 
   The semantics of scatter are complicated, and its API might change in the
@@ -574,7 +574,7 @@ def scatter_sub(
   """Scatter-sub operator.
 
   Wraps `XLA's Scatter operator
-  <https://www.tensorflow.org/xla/operation_semantics#scatter>`_, where
+  <https://www.openxla.org/xla/operation_semantics#scatter>`_, where
   subtraction is used to combine updates and values from `operand`.
 
   The semantics of scatter are complicated, and its API might change in the
@@ -632,7 +632,7 @@ def scatter_mul(
   """Scatter-multiply operator.
 
   Wraps `XLA's Scatter operator
-  <https://www.tensorflow.org/xla/operation_semantics#scatter>`_, where
+  <https://www.openxla.org/xla/operation_semantics#scatter>`_, where
   multiplication is used to combine updates and values from `operand`.
 
   The semantics of scatter are complicated, and its API might change in the
@@ -681,7 +681,7 @@ def scatter_min(
   """Scatter-min operator.
 
   Wraps `XLA's Scatter operator
-  <https://www.tensorflow.org/xla/operation_semantics#scatter>`_, where
+  <https://www.openxla.org/xla/operation_semantics#scatter>`_, where
   the `min` function is used to combine updates and values from `operand`.
 
   The semantics of scatter are complicated, and its API might change in the
@@ -730,7 +730,7 @@ def scatter_max(
   """Scatter-max operator.
 
   Wraps `XLA's Scatter operator
-  <https://www.tensorflow.org/xla/operation_semantics#scatter>`_, where
+  <https://www.openxla.org/xla/operation_semantics#scatter>`_, where
   the `max` function is used to combine updates and values from `operand`.
 
   The semantics of scatter are complicated, and its API might change in the
@@ -784,7 +784,7 @@ def scatter_apply(
   """Scatter-apply operator.
 
   Wraps `XLA's Scatter operator
-  <https://www.tensorflow.org/xla/operation_semantics#scatter>`_, where values
+  <https://www.openxla.org/xla/operation_semantics#scatter>`_, where values
   from ``operand`` are replaced with ``func(operand)``, with duplicate indices
   resulting in multiple applications of ``func``.
 
@@ -848,7 +848,7 @@ def scatter(
   """Scatter-update operator.
 
   Wraps `XLA's Scatter operator
-  <https://www.tensorflow.org/xla/operation_semantics#scatter>`_, where updates
+  <https://www.openxla.org/xla/operation_semantics#scatter>`_, where updates
   replace values from `operand`.
 
   If multiple updates are performed to the same index of operand, they may be
@@ -1807,7 +1807,7 @@ def _gather_shape_rule(operand, indices, *, dimension_numbers,
   """Validates the well-formedness of the arguments to Gather.
 
   The code implements the checks based on the detailed operation semantics of
-  XLA's `Gather <https://www.tensorflow.org/xla/operation_semantics#gather>`_
+  XLA's `Gather <https://www.openxla.org/xla/operation_semantics#gather>`_
   operator and following the outline of the implementation of
   ShapeInference::InferGatherShape in TensorFlow.
   """
@@ -2392,7 +2392,7 @@ def _scatter_shape_rule(operand, indices, updates, *, update_jaxpr,
   Scatter.
 
   The code implements the checks based on the detailed operation semantics of
-  XLA's `Scatter <https://www.tensorflow.org/xla/operation_semantics#scatter>`_
+  XLA's `Scatter <https://www.openxla.org/xla/operation_semantics#scatter>`_
   operator and following the outline of the implementation of
   ShapeInference::InferScatterShape in TensorFlow.
   """

--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -123,7 +123,7 @@ def reduce_window(
     window_dilation: Sequence[int] | None = None,
 ) -> Array:
   """Wraps XLA's `ReduceWindowWithGeneralPadding
-  <https://www.tensorflow.org/xla/operation_semantics#reducewindow>`_
+  <https://www.openxla.org/xla/operation_semantics#reducewindow>`_
   operator.
   """
   return _reduce_window(
@@ -281,7 +281,7 @@ def _select_and_gather_add(tangents: Array, operand: Array,
   each window of the `operand` array.
 
   Wraps XLA's `ReduceWindow
-  <https://www.tensorflow.org/xla/operation_semantics#reducewindow>`_
+  <https://www.openxla.org/xla/operation_semantics#reducewindow>`_
   operator, which applies a reduction function to all elements in each window of
   the input multi-dimensional array. In this case, the input multi-dimensional
   array is built by packing each element in the `operand` array with its

--- a/jax/_src/lax_reference.py
+++ b/jax/_src/lax_reference.py
@@ -319,7 +319,7 @@ def reshape(operand, new_sizes, dimensions=None):
   return np.reshape(np.transpose(operand, dimensions), new_sizes)
 
 def pad(operand, padding_value, padding_config):
-  # https://www.tensorflow.org/xla/operation_semantics#pad
+  # https://www.openxla.org/xla/operation_semantics#pad
   lo, hi, interior = util.unzip3(padding_config)
   # Handle first the positive edge padding and interior
   lo_pos, hi_pos = np.clip(lo, 0, None), np.clip(hi, 0, None)

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -1246,7 +1246,7 @@ register_prng(threefry_prng_impl)
 # -- RngBitGenerator PRNG implementation
 
 # This code is experimental!
-# https://www.tensorflow.org/xla/operation_semantics#rngbitgenerator
+# https://www.openxla.org/xla/operation_semantics#rngbitgenerator
 # Notice that the RngBitGenerator operations are not guaranteed to be
 # stable/deterministic across backends or compiler versions. Correspondingly, we
 # reserve the right to change any of these implementations at any time!

--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -1441,7 +1441,7 @@ may be slightly different for small matrices.
 Applies to non-native serialization only.
 
 Operations like ``jax.numpy.cumsum`` are lowered by JAX differently based
-on the platform. For TPU, the lowering uses the [HLO ReduceWindow](https://www.tensorflow.org/xla/operation_semantics#reducewindow)
+on the platform. For TPU, the lowering uses the [HLO ReduceWindow](https://www.openxla.org/xla/operation_semantics#reducewindow)
 operation, which has an efficient implementation for the cases when the
 reduction function is associative. For CPU and GPU, JAX uses an alternative
 lowering using [associative scans](https://github.com/jax-ml/jax/blob/f08bb50bfa9f6cf2de1f3f78f76e1aee4a78735d/jax/_src/lax/control_flow.py#L2801).
@@ -1467,7 +1467,7 @@ For most JAX primitives there is a natural TensorFlow op that fits the needed se
 There are a few (listed in [no_xla_limitations.md](g3doc/no_xla_limitations.md)) JAX primitives
 for which there is no single TensorFlow op with matching semantics.
 This is not so surprising, because JAX primitives have been designed
-to be compiled to [HLO ops](https://www.tensorflow.org/xla/operation_semantics),
+to be compiled to [HLO ops](https://www.openxla.org/xla/operation_semantics),
 while the corresponding TensorFlow ops are sometimes higher-level.
 For the cases when there is no matching canonical TensorFlow op,
 we use a set of special TensorFlow ops that are thin wrappers over HLO ops
@@ -1509,7 +1509,7 @@ deterministic PRNG](https://github.com/jax-ml/jax/blob/main/docs/design_notes/pr
 and it has an internal JAX primitive for it.
 This primitive is at the moment lowered to a soup of tf.bitwise operations,
 which has a clear performance penalty. We plan to look into using the
-HLO [RNGBitGenerator](https://www.tensorflow.org/xla/operation_semantics#rngbitgenerator)
+HLO [RNGBitGenerator](https://www.openxla.org/xla/operation_semantics#rngbitgenerator)
 (exposed as a TFXLA op), which does implement
 the same basic Threefry algorithm as JAX’s PRNG, although that would
 result in different results than JAX’s PRNG.

--- a/jax/experimental/jax2tf/g3doc/no_xla_limitations.md
+++ b/jax/experimental/jax2tf/g3doc/no_xla_limitations.md
@@ -22,9 +22,9 @@ In the next section we provide more details on the ops for which we provide
 partial support.
 
 For a detailed description of these XLA ops, please see the
-[XLA Operation Semantics documentation](https://www.tensorflow.org/xla/operation_semantics).
+[XLA Operation Semantics documentation](https://www.openxla.org/xla/operation_semantics).
 
-| XLA ops ([documentation](https://www.tensorflow.org/xla/operation_semantics)) | JAX primitive(s) ([documentation](https://docs.jax.dev/en/latest/jax.lax.html)) | Supported |
+| XLA ops ([documentation](https://www.openxla.org/xla/operation_semantics)) | JAX primitive(s) ([documentation](https://docs.jax.dev/en/latest/jax.lax.html)) | Supported |
 | ------- | ---------------- | ------- |
 | XlaDot  | `lax.dot_general` | Full |
 | XlaDynamicSlice | `lax.dynamic_slice` | Full |

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2422,7 +2422,7 @@ class LaxTest(jtu.JaxTestCase):
                                window_dimensions=window_dimensions)
     # With a stride of 1 in each direction and a padding of 'SAME', the
     # shape of the input should be equal to the shape of the result according
-    # to https://www.tensorflow.org/xla/operation_semantics#reducewindow.
+    # to https://www.openxla.org/xla/operation_semantics#reducewindow.
     self.assertEqual(shape, result.shape)
 
   def testReduceWindowWithEmptyOutput(self):


### PR DESCRIPTION
I spot-checked a dozen of these and they all looked to be correct.