### PR TITLE
support cudnn sdpa on gb300 (compute_cap=10.3) with cudnn > 9.11

### DIFF
--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -367,9 +367,10 @@ def check_is_flash_attention(
         _, T, _, qH = query.shape
         _, S, _, vH = value.shape
 
-    if is_cuda_compute_capability_equal("10.3"):
-      # cudnn will fallback to ampere kernels on 10.3 which is not ideal
-      raise NotImplementedError("Unsupported compute capability 10.3.")
+    if is_cuda_compute_capability_equal("10.3") and cudnn_version < 91100:
+      # cudnn support compute_cap 10.3 on cudnn 9.11+
+      raise NotImplementedError(
+        "Compute capability 10.3 requires cuDNN version >= 9.11.")
 
     # Flash attention conditions
     if is_fp8:

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -265,8 +265,6 @@ class DotProductAttentionTest(jtu.JaxTestCase):
       return
     if cudnn_version < 8904:
       self.skipTest("Requires >= cuDNN 8.9.4")
-    if jtu.is_cuda_compute_capability_equal("10.3"):
-      self.skipTest("Cudnn doesn't support compute_cap 10.3.")
     if not jtu.is_cuda_compute_capability_at_least("8.0"):
       self.skipTest("Requires at least Ampere arch")
 
@@ -977,8 +975,6 @@ class DotProductAttentionF8Test(jtu.JaxTestCase):
       return
     if cudnn_version < 90100:
       self.skipTest("Requires >= cuDNN 9.1.0")
-    if jtu.is_cuda_compute_capability_equal("10.3"):
-      self.skipTest("Cudnn doesn't support compute_cap 10.3.")
     if not jtu.is_cuda_compute_capability_at_least("9.0"):
       self.skipTest("Requires at least Hopper arch")
 

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -201,8 +201,6 @@ class NNFunctionsTest(jtu.JaxTestCase):
       impl=['cudnn', 'xla'],
   )
   def testDotProductAttention(self, dtype, group_num, use_vmap, impl):
-    if jtu.is_cuda_compute_capability_equal("10.3"):
-      raise unittest.SkipTest("Cudnn doesn't support compute_cap 10.3.")
     if impl == 'cudnn' and not _is_required_cudnn_version_satisfied("8.0", 8904):
       raise unittest.SkipTest("CUDA or cuDNN versions are not compatible.")
     if impl == 'cudnn' and dtype == jnp.float32:
@@ -252,8 +250,6 @@ class NNFunctionsTest(jtu.JaxTestCase):
     if isinstance(mask_mode, str):
       mask_mode = (mask_mode,)
     min_cudnn_version = 90200 if 'sliding_window' in mask_mode else 8904
-    if jtu.is_cuda_compute_capability_equal("10.3"):
-      raise unittest.SkipTest("Cudnn doesn't support compute_cap 10.3.")
     if not _is_required_cudnn_version_satisfied("8.0", min_cudnn_version):
       raise unittest.SkipTest("CUDA or cuDNN versions are not compatible.")
 
@@ -317,8 +313,6 @@ class NNFunctionsTest(jtu.JaxTestCase):
       use_vmap=[False, True],
   )
   def testDotProductAttentionBiasGradient(self, batch_size, use_vmap):
-    if jtu.is_cuda_compute_capability_equal("10.3"):
-      raise unittest.SkipTest("Cudnn doesn't support compute_cap 10.3.")
     if not _is_required_cudnn_version_satisfied("8.0", 8904):
       raise unittest.SkipTest("CUDA or cuDNN versions are not compatible.")
 


### PR DESCRIPTION
cudnn 9.11 now has support for gb300(compute_cap=10.3). 