### PR TITLE
Update editorconfig to the Python line length of 88

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,18 +5,7 @@ indent_style = space
 end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
+indent_size = 2
 
 [*.py]
-max_line_length = 79
-indent_size = 2
-
-[*.rst]
-max_line_length = 79
-indent_size = 2
-
-[*.md]
-max_line_length = 79
-indent_size = 2
-
-[*.yml]
-indent_size = 2
+max_line_length = 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,9 +98,9 @@ exclude = [
     "build",
     "__pycache__",
 ]
-line-length = 88
+line-length = 80
 indent-width = 2
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 ignore = [


### PR DESCRIPTION
The line length was incorrect in both pyproject.toml (88) and
.editorconfig (79).

Also, remove the line length from .rst and .md files since no files were
respecting it.

Finally, update the target version for Ruff to 3.11.