### PR TITLE
Improve jax.nn.standardize numerical stability

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -648,10 +648,10 @@ def standardize(x: ArrayLike,
 
   .. math::
 
-     x_{std} = \frac{x - \langle x\rangle}{\sqrt{\langle(x - \langle x\rangle)^2\rangle + \epsilon}}
+     x_{std} = \frac{x - \langle x\rangle}{\sqrt{\max(\langle(x - \langle x\rangle)^2\rangle, \epsilon)}}
 
   where :math:`\langle x\rangle` indicates the mean of :math:`x`, and :math:`\epsilon` is
-  a small correction factor introduced to avoid division by zero.
+  a small correction factor used as a lower bound on the variance to avoid division by zero.
 
   Args:
     x: input array to be standardized.
@@ -661,8 +661,8 @@ def standardize(x: ArrayLike,
       then ``x.mean(axis, where=where)`` will be used.
     variance: optionally specify the variance used for standardization. If not
       specified, then ``x.var(axis, where=where)`` will be used.
-    epsilon: correction factor added to variance to avoid division by zero; defaults
-      to ``1E-5``.
+    epsilon: correction factor used as a lower bound on variance to avoid division by zero;
+      defaults to ``1E-5``.
     where: optional boolean mask specifying which elements to use when computing
       the mean and variance.
 
@@ -680,8 +680,8 @@ def standardize(x: ArrayLike,
     # when used in neural network normalization layers
     variance = jnp.mean(
         jnp.square(x), axis, keepdims=True, where=where) - jnp.square(mean)
-  return jnp.subtract(x, jnp.asarray(mean)) * lax.rsqrt(jnp.asarray(variance) + epsilon)
-
+  return jnp.subtract(x, jnp.asarray(mean)) * lax.rsqrt(jnp.maximum(jnp.asarray(variance), epsilon))
+    
 # TODO(slebedev): Change the type of `x` to `ArrayLike`.
 @partial(api.jit, static_argnames=("num_classes", "dtype", "axis"))
 def _one_hot(x: Array, num_classes: int, *,

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -38,6 +38,24 @@ from jax import random
 import jax
 import jax.numpy as jnp
 
+def test_standardize_nan_protection():
+    # Test case from issue: near-constant input with tiny noise
+    x = -11. * jnp.ones((3,))
+    noise = jax.random.normal(jax.random.key(0)) * 2e-6
+    result = jax.nn.standardize(x + noise)
+    assert not jnp.isnan(result).any(), "standardize should not return NaNs for near-constant input"
+
+    # Additional test cases
+    # Test with exactly constant input
+    x_const = jnp.ones((3,))
+    result_const = jax.nn.standardize(x_const)
+    assert not jnp.isnan(result_const).any(), "standardize should not return NaNs for constant input"
+    
+    # Test with very small variance
+    x_small = jnp.array([1.0, 1.0 + 1e-10, 1.0 - 1e-10])
+    result_small = jax.nn.standardize(x_small)
+    assert not jnp.isnan(result_small).any(), "standardize should not return NaNs for input with very small variance"
+
 config.parse_flags_with_absl()
 
 def _is_required_cudnn_version_satisfied(min_cc, min_cudnn_version):


### PR DESCRIPTION
- Replace variance + epsilon with maximum(variance, epsilon)
- Update documentation to clarify epsilon is now a lower bound
- Add comprehensive test cases for near-constant inputs
- Fix potential NaN outputs with very small variances