### PR TITLE
avoid top-level imports in source_info_util

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -1839,7 +1839,6 @@ pytype_strict_library(
     visibility = [":internal"] + jax_visibility("source_info_util"),
     deps = [
         ":traceback_util",
-        ":version",
         "//jax/_src/lib",
     ],
 )

--- a/jax/_src/source_info_util.py
+++ b/jax/_src/source_info_util.py
@@ -26,7 +26,6 @@ import threading
 import types
 from typing import NamedTuple
 
-import jax.version
 from jax._src.lib import xla_client
 
 from jax._src import traceback_util
@@ -47,7 +46,7 @@ class Frame(NamedTuple):
 _exclude_paths: list[str] = [
     # Attach the separator to make sure that .../jax does not end up matching
     # .../jax_triton and other packages that might have a jax prefix.
-    os.path.dirname(jax.version.__file__) + os.sep,
+    os.path.dirname(os.path.dirname(__file__)) + os.sep,
     # Also exclude stdlib as user frames. In a non-standard Python runtime,
     # the following two may be different.
     sysconfig.get_path('stdlib'),


### PR DESCRIPTION
Working toward isolating the bazel build rules for files in `jax/_src`.