### PR TITLE
Fix output of ravel_pytree for empty trees.

### DIFF
--- a/jax/_src/flatten_util.py
+++ b/jax/_src/flatten_util.py
@@ -49,7 +49,7 @@ def unravel_pytree(treedef, unravel_list, flat):
   return tree_unflatten(treedef, unravel_list(flat))
 
 def _ravel_list(lst):
-  if not lst: return lax.full([], 0, 'float32'), lambda _: []
+  if not lst: return lax.full([0], 0, 'float32'), lambda _: []
   from_dtypes = tuple(dtypes.dtype(l) for l in lst)
   to_dtype = dtypes.result_type(*from_dtypes)
   sizes, shapes = unzip2((np.size(x), np.shape(x)) for x in lst)


### PR DESCRIPTION
Fixes https://github.com/jax-ml/jax/issues/30645.

[`ravel_pytree`](https://docs.jax.dev/en/latest/_autosummary/jax.flatten_util.ravel_pytree.html) should always return a 1D array.

However, currently, for empty trees, it returns a scalar:
```python3
from jax.flatten_util import ravel_pytree

for tree in [None, [], (), {}]:
  array, unravel = ravel_pytree(tree)
  assert array.ndim == 0
```

This is because of the following line:

https://github.com/jax-ml/jax/blob/f5107ac87c848f7fb6b7acd5229f188667025d27/jax/_src/flatten_util.py#L52

The `shape` argument to [`lax.full`](https://docs.jax.dev/en/latest/_autosummary/jax.lax.full.html), currently `[]`, should be `[0]`. This PR fixes that.