### PR TITLE
docs: Use self-documenting f-string exprs in thinking_with_jax

### DIFF
--- a/docs/notebooks/thinking_in_jax.ipynb
+++ b/docs/notebooks/thinking_in_jax.ipynb
@@ -616,9 +616,9 @@
      "output_type": "stream",
      "text": [
       "Running f():\n",
-      "  x = Traced<ShapedArray(float32[3,4])>with<DynamicJaxprTrace(level=1/0)>\n",
-      "  y = Traced<ShapedArray(float32[4])>with<DynamicJaxprTrace(level=1/0)>\n",
-      "  result = Traced<ShapedArray(float32[3])>with<DynamicJaxprTrace(level=1/0)>\n"
+      "  x = JitTracer<float32[3,4]>\n",
+      "  y = JitTracer<float32[4]>\n",
+      "  result = JitTracer<float32[3]>\n"
      ]
     },
     {
@@ -636,10 +636,10 @@
     "@jit\n",
     "def f(x, y):\n",
     "  print(\"Running f():\")\n",
-    "  print(f\"  x = {x}\")\n",
-    "  print(f\"  y = {y}\")\n",
+    "  print(f\"  {x = }\")\n",
+    "  print(f\"  {y = }\")\n",
     "  result = jnp.dot(x + 1, y + 1)\n",
-    "  print(f\"  result = {result}\")\n",
+    "  print(f\"  {result = }\")\n",
     "  return result\n",
     "\n",
     "x = np.random.randn(3, 4)\n",

--- a/docs/notebooks/thinking_in_jax.md
+++ b/docs/notebooks/thinking_in_jax.md
@@ -305,10 +305,10 @@ To use `jax.jit` effectively, it is useful to understand how it works. Let's put
 @jit
 def f(x, y):
   print("Running f():")
-  print(f"  x = {x}")
-  print(f"  y = {y}")
+  print(f"  {x = }")
+  print(f"  {y = }")
   result = jnp.dot(x + 1, y + 1)
-  print(f"  result = {result}")
+  print(f"  {result = }")
   return result
 
 x = np.random.randn(3, 4)


### PR DESCRIPTION
This less-known feature was introduced in [Python 3.8] and simplifies the code examples a bit (and could teach readers about the feature).

[Python 3.8]: https://docs.python.org/3/whatsnew/3.8.html#bpo-36817-whatsnew