### PR TITLE
Relax test to fix freethreaded test CI failure.

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -698,7 +698,10 @@ class JitTest(jtu.BufferDonationTestCase):
     f.clear_cache()
     gc.collect()
     num_live = len(client.live_executables())
-    self.assertEqual(num_live_initial, num_live)
+    # You would hope that these would be equal, but in practice we sometimes
+    # observe *fewer* live executables after this code runs in threaded tests.
+    # I suspect this is an artifact of other caches and garbage collection.
+    self.assertGreaterEqual(num_live_initial, num_live)
 
   def test_pe_close_jaxpr_cache_leak(self):
     @jax.jit


### PR DESCRIPTION
We sometimes see the following failure in CI:
```
FAIL: test_jit_cache_clear (__main__.JitTest)
JitTest.test_jit_cache_clear
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/.cache/bazel/bazel/_bazel_root/a40625930fdef4f0a3483cd60aa1bb86/external/python_x86_64-unknown-linux-gnu-freethreaded/lib/python3.14t/contextlib.py", line 85, in inner
    return func(*args, **kwds)
  File "/__w/.cache/bazel/bazel/_bazel_root/a40625930fdef4f0a3483cd60aa1bb86/execroot/__main__/bazel-out/k8-opt/bin/tests/api_test_cpu.runfiles/__main__/tests/api_test.py", line 701, in test_jit_cache_clear
    self.assertEqual(num_live_initial, num_live)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 101 != 98
```