### PR TITLE
Fix ravel_pytree to Return 1D Empty Array for Empty Pytrees (#30645)

### DIFF
--- a/jax/_src/flatten_util.py
+++ b/jax/_src/flatten_util.py
@@ -49,7 +49,7 @@ def unravel_pytree(treedef, unravel_list, flat):
   return tree_unflatten(treedef, unravel_list(flat))
 
 def _ravel_list(lst):
-  if not lst: return lax.full([], 0, 'float32'), lambda _: []
+  if not lst: return lax.full((0,), 0, 'float32'), lambda _: []
   from_dtypes = tuple(dtypes.dtype(l) for l in lst)
   to_dtype = dtypes.result_type(*from_dtypes)
   sizes, shapes = unzip2((np.size(x), np.shape(x)) for x in lst)


### PR DESCRIPTION
(#30645)
This PR restores the previous and documented behavior of [ravel_pytree] so that when called with an empty pytree (including None), it returns a 1D empty array of shape (0,) with dtype float32.

Please let me know if my approach or fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.

Thankyou!