### PR TITLE
[jaxpr consts] Fix const args handling in shard_map shardy lowering

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6251,21 +6251,24 @@ class RematTest(jtu.JaxTestCase):
       return z * ((x1 * x2) * y) * np.array([3.])
 
     res = saved_residuals(f, (2., 3.), y=4.)
-    self.assertLen(res, 6)
-    self.assertEqual(res[0][0].shape, (1,))
     if config.use_simplified_jaxpr_constants.value:
-      self.assertEqual(res[0][1], "from a literal")
+      self.assertLen(res, 5)
+      start_idx = 0
     else:
+      self.assertLen(res, 6)
+      self.assertEqual(res[0][0].shape, (1,))
       self.assertEqual(res[0][1], "from a constant")
-    self.assertEqual(res[1][0].shape, ())
-    self.assertEqual(res[1][1], "from the argument x[0]")
-    self.assertEqual(res[2][0].shape, ())
-    self.assertEqual(res[2][1], "from the argument x[1]")
-    self.assertEqual(res[3][0].shape, ())
-    self.assertEqual(res[3][1], "from the argument y")
-    self.assertEqual(res[4][0].shape, ())
-    self.assertStartsWith(res[4][1], "named 'z'")
-    self.assertEqual(res[5][0].shape, ())
+      start_idx = 1
+
+    self.assertEqual(res[start_idx][0].shape, ())
+    self.assertEqual(res[start_idx][1], "from the argument x[0]")
+    self.assertEqual(res[start_idx + 1][0].shape, ())
+    self.assertEqual(res[start_idx + 1][1], "from the argument x[1]")
+    self.assertEqual(res[start_idx + 2][0].shape, ())
+    self.assertEqual(res[start_idx + 2][1], "from the argument y")
+    self.assertEqual(res[start_idx + 3][0].shape, ())
+    self.assertStartsWith(res[start_idx + 3][1], "named 'z'")
+    self.assertEqual(res[start_idx + 4][0].shape, ())
 
   def test_saved_residuals_utility_jit(self):
     @jax.jit


### PR DESCRIPTION
The shardy lowering for shard map was also broken for shape polymorphism. When we enter the block for SdyManualComputation we need to pass the dim var values and the const arg values to the block as arguments.

Drive-by fixing of a test in api_test
(for JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS=True)