### PR TITLE
[jaxpr consts] Disable captured constants warnings when we hoist constants as arguments

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -559,7 +559,7 @@ def jaxpr_const_args(jaxpr: Jaxpr) -> list[ArrayLike]:
   # See https://docs.jax.dev/en/latest/internals/constants.html
   if not config.use_simplified_jaxpr_constants.value:
     return []
-  consts_by_id: dict[int, Any] = {}
+  consts_by_id: dict[int, ArrayLike] = {}
   for v in jaxpr.outvars:
     if type(v) is Literal and np.shape(v.val):  # type: ignore
       consts_by_id[id(v)] = v.val  # type: ignore
@@ -573,7 +573,7 @@ def jaxpr_const_args(jaxpr: Jaxpr) -> list[ArrayLike]:
   return list(consts_by_id.values())
 
 def eqn_params_const_args(params) -> list[ArrayLike]:
-  consts_by_id: dict[int, Any] = {}
+  consts_by_id: dict[int, ArrayLike] = {}
   for j in jaxprs_in_params(params):
     consts_by_id.update({id(v): v for v in jaxpr_const_args(j)})
 

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -1169,6 +1169,8 @@ def _get_unconstrained_variants(s, aval) -> UnconstrainedVariants:
 
 def check_jaxpr_constants(closed_jaxpr: core.ClosedJaxpr):
   """Check if a JAXPR contains an excessive amount of constants, if so, report where they were captured"""
+  if config.use_simplified_jaxpr_constants.value:
+    return
   if (threshold := config.captured_constants_warn_bytes.value) == -1:
     return
 
@@ -1564,7 +1566,8 @@ def lower_jaxpr_to_fun(
     MLIR func op
   """
   util.test_event("lower_jaxpr_to_fun", name)
-  check_jaxpr_constants(jaxpr)
+  if not config.use_simplified_jaxpr_constants.value:
+    check_jaxpr_constants(jaxpr)
 
   # The first dimension variable may be the platform index
   num_dim_vars = len(ctx.shape_poly_state.dim_vars)

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1360,7 +1360,7 @@ class JaxTestCase(parameterized.TestCase):
 
   @contextmanager
   def assertWarnsRegex(self, warning, regex):
-    if regex is not None:
+    if regex is not None and not isinstance(regex, re.Pattern):
         regex = re.compile(regex)
 
     with test_warning_util.record_warnings() as ws:
@@ -1371,8 +1371,8 @@ class JaxTestCase(parameterized.TestCase):
       if regex is not None and not regex.search(str(w.message)):
         continue
       return
-    self.fail(f"Expected warning not found {warning}:'{regex}', got "
-              f"{ws}")
+    self.fail(f"Expected warning not found {warning}:'{regex}', "
+              f"got warnings: {[str(w.message) for w in ws]}")
 
 
   def _CompileAndCheck(self, fun, args_maker, *, check_dtypes=True, tol=None,

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -227,6 +227,7 @@ class JaxJitTest(jtu.JaxTestCase):
     self.assertArraysEqual(v1, v1_expected)
     self.assertArraysEqual(v2, v2_expected)
 
+  @jtu.skip_on_flag("jax_use_simplified_jaxpr_constants", True)
   def test_check_for_large_number_of_constants(self):
     y = jnp.ones((128, 128))
     x = jnp.zeros((128,))


### PR DESCRIPTION
Prepare the captured constants warning implementation for when we turn on the new handling of constants.
See https://docs.jax.dev/en/latest/internals/constants.html.

One difference from the previous implementation is that we now check for captured constants only once per MLIR module, while below we did the check for each MLIR function. This is because we use `core.jaxpr_const_args` which finds the constant in the whole Jaxpr, and if we did this for every MLIR function we would end up reporting duplicates. Note that this changes the behavior in that the warning threshold is now applied for the entire module. I think this should be Ok.

Also, drive-by fixes in test_util.assertWarnRegexp (allow use with `re.compile` patterns, and print a better error message on failure).