### PR TITLE
Add python 3.14 nightly tests

### DIFF
--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -47,13 +47,13 @@ jobs:
           # Runner OS and Python values need to match the matrix stategy of our internal CI jobs
           # that build the wheels.
           runner: ["linux-x86-n2-64", "linux-arm64-t2a-48", "windows-x86-n2-64"]
-          python: ["3.11", "3.12", "3.13", "3.13-nogil", "3.14"]
+          python: ["3.11", "3.12", "3.13", "3.13-nogil", "3.14", "3.14-nogil"]
           enable-x64: [0]
           exclude:
             - runner: "windows-x86-n2-64"
               python: "3.13-nogil"
             - runner: "windows-x86-n2-64"
-              python: "3.14"
+              python: "3.14-nogil"
     name: "Pytest CPU (JAX artifacts version = ${{ startsWith(github.ref_name, 'release/') && 'latest release' || 'nightly' }})"
     with:
       runner: ${{ matrix.runner }}
@@ -71,7 +71,7 @@ jobs:
           # Runner OS and Python values need to match the matrix stategy of our internal CI jobs
           # that build the wheels.
           runner: ["linux-x86-n2-64", "linux-arm64-t2a-48"]
-          python: ["3.11", "3.12", "3.13", "3.13-nogil", "3.14"]
+          python: ["3.11", "3.12", "3.13", "3.13-nogil", "3.14", "3.14-nogil"]
           enable-x64: [0]
     name: "Bazel CPU tests with ${{ format('{0}', 'build_jaxlib=false') }}"
     with:
@@ -90,7 +90,7 @@ jobs:
           # Runner OS and Python values need to match the matrix stategy of our internal CI jobs
           # that build the wheels.
           runner: ["linux-x86-g2-48-l4-4gpu",  "linux-x86-a3-8g-h100-8gpu", "linux-x86-a4-224-b200-1gpu"]
-          python: ["3.11", "3.12", "3.13", "3.13-nogil", "3.14"]
+          python: ["3.11", "3.12", "3.13", "3.13-nogil", "3.14", "3.14-nogil"]
           cuda: [
             {cuda-version: "12.1", use-nvidia-pip-wheels: false},
             {cuda-version: "12.8", use-nvidia-pip-wheels: true}
@@ -107,6 +107,8 @@ jobs:
               python: "3.13"
             - runner: "linux-x86-a3-8g-h100-8gpu"
               python: "3.13-nogil"
+            - runner: "linux-x86-a3-8g-h100-8gpu"
+              python: "3.14-nogil"
             # B200 runs only CUDA 12.8 and min and max Python versions.
             - runner: "linux-x86-a4-224-b200-1gpu"
               cuda:
@@ -117,6 +119,8 @@ jobs:
               python: "3.13"
             - runner: "linux-x86-a4-224-b200-1gpu"
               python: "3.13-nogil"
+            - runner: "linux-x86-a4-224-b200-1gpu"
+              python: "3.14-nogil"
     name: "Pytest CUDA (JAX artifacts version = ${{ startsWith(github.ref_name, 'release/') && 'latest release' || 'nightly' }}, CUDA Pip packages = ${{ matrix.cuda.use-nvidia-pip-wheels }})"
     with:
       runner: ${{ matrix.runner }}
@@ -136,7 +140,7 @@ jobs:
           # Runner OS and Python values need to match the matrix stategy of our internal CI jobs
           # that build the wheels.
           runner: ["linux-x86-g2-48-l4-4gpu"]
-          python: ["3.11", "3.12", "3.13", "3.13-nogil", "3.14"]
+          python: ["3.11", "3.12", "3.13", "3.13-nogil", "3.14", "3.14-nogil"]
           enable-x64: [0]
     name: "Bazel CUDA Non-RBE with ${{ format('{0}', 'build_jaxlib=false') }}"
     with:


### PR DESCRIPTION
Add the following tests:
- linux x86 and aarch64 python 3.14t cpu tests
- linux x86 and aarch64 python 3.14t bazel cpu tests
- linux x86 python 3.14t cuda tests
- linux x86 python 3.14t bazel cuda tests
- windows x86 python 3.14 cpu test
