### PR TITLE
[ROCm] Fix GPU handle pool singleton aliasing using opaque handle typ…

### DIFF
--- a/jaxlib/gpu/vendor.h
+++ b/jaxlib/gpu/vendor.h
@@ -448,10 +448,10 @@ typedef hipDoubleComplex gpuDoubleComplex;
 
 typedef hipblasComplex gpublasComplex;
 typedef hipblasDoubleComplex gpublasDoubleComplex;
-typedef hipsolverHandle_t gpusolverDnHandle_t;
+typedef struct hipsolverHandle_* gpusolverDnHandle_t;
 typedef hipblasFillMode_t gpublasFillMode_t;
 typedef hipsolverFillMode_t gpusolverFillMode_t;
-typedef hipblasHandle_t gpublasHandle_t;
+typedef struct hipblasHandle_* gpublasHandle_t;
 typedef hipblasOperation_t gpublasOperation_t;
 typedef hipblasStatus_t gpublasStatus_t;
 typedef hipCtx_t gpuContext_t;
@@ -497,7 +497,8 @@ typedef hipsparseDnVecDescr_t gpusparseDnVecDescr_t;
 #define GPU_C_64F HIP_C_64F
 #define GPU_R_64F HIP_R_64F
 
-#define gpublasCreate hipblasCreate
+// Wrapper functions for BLAS handles to ensure unique types
+#define gpublasCreate(handle) hipblasCreate(reinterpret_cast<hipblasHandle_t*>(handle))
 #define gpublasSetStream hipblasSetStream
 #define gpublasSgeqrfBatched hipblasSgeqrfBatched
 #define gpublasDgeqrfBatched hipblasDgeqrfBatched
@@ -548,7 +549,8 @@ typedef hipsparseDnVecDescr_t gpusparseDnVecDescr_t;
 #define GPUDNN_LSTM miopenLSTM
 #define GPUDNN_BIDIRECTIONAL miopenRNNbidirection
 
-#define gpusolverDnCreate hipsolverCreate
+// Wrapper functions for SOLVER handles to ensure unique types
+#define gpusolverDnCreate(handle) hipsolverCreate(reinterpret_cast<hipsolverHandle_t*>(handle))
 #define gpusolverDnSetStream hipsolverSetStream
 #define gpusolverDnCreateSyevjInfo hipsolverCreateSyevjInfo
 #define gpusolverDnDestroySyevjInfo hipsolverDestroySyevjInfo


### PR DESCRIPTION
…e separation

Problem:
- hipBLAS, hipSOLVER, and other GPU libraries were unintentionally sharing the same singleton instance of `HandlePool`
- This occurred because all pools used the same template type signature (e.g. `HandlePool<hipblasHandle_t, Stream>`), leading to a single static instantiation
- As a result, using FFI to call hipSOLVER followed by hipBLAS could lead to overlapping internal state
- This caused potential memory corruption and unpredictable behavior, especially in mixed or concurrent workloads