### PR TITLE
Add optional dimension_numbers argument to lax.dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     Removed `jax.sharding.use_mesh` in favor of `jax.set_mesh`.
   * JAX is now built using CUDA 12.9. All versions of CUDA 12.1 or newer remain
     supported.
+  * {func}`jax.lax.dot` now implements the general dot product via the optional
+    ``dimension_numbers`` argument.
 
 * Deprecations:
 
@@ -29,6 +31,9 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * Attempting to import {mod}`jax.experimental.host_callback` now results in
     a `DeprecationWarning`, and will result in an `ImportError` starting in JAX
     v0.8.0. Its APIs have raised `NotImplementedError` since JAX version 0.4.35.
+  * In {func}`jax.lax.dot`, passing the ``precision`` and ``preferred_element_type``
+    arguments by position is deprecated. Pass them by explicit keyword instead.
+
 
 ## JAX 0.7.0 (July 22, 2025)
 

--- a/jax/_src/deprecations.py
+++ b/jax/_src/deprecations.py
@@ -126,6 +126,7 @@ def warn(deprecation_id: str, message: str, stacklevel: int) -> None:
 register('jax-aval-named-shape')
 register('jax-dlpack-import-legacy')
 register('jax-experimental-host-callback')
+register('jax-lax-dot-positional-args')
 register('jax-nn-one-hot-float-input')
 register("jax-numpy-astype-complex-to-real")
 register('jax-numpy-clip-args')

--- a/jax/experimental/sparse/linalg.py
+++ b/jax/experimental/sparse/linalg.py
@@ -264,7 +264,7 @@ def _check_inputs(A, X):
 
 
 def _mm(a, b, precision=jax.lax.Precision.HIGHEST):
-  return jax.lax.dot(a, b, (precision, precision))
+  return jax.lax.dot(a, b, precision=(precision, precision))
 
 def _generate_diagnostics(prev_XPR, X, P, R, theta, converged, adj_resid):
   k = X.shape[1]

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1079,6 +1079,22 @@ class LaxTest(jtu.JaxTestCase):
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     self._CompileAndCheck(partial(lax.dot, precision=precision), args_maker)
 
+  def testDotPositionalArgumentDeprecation(self):
+    lhs = jnp.arange(5.0)
+    rhs = jnp.arange(5.0)
+    msg = "jax.lax.dot: passing precision or preferred_element_type by position"
+
+    with self.assertWarnsRegex(DeprecationWarning, msg):
+      lax.dot(lhs, rhs, lax.Precision.DEFAULT, jnp.float32)
+
+    with self.assertWarnsRegex(DeprecationWarning, msg):
+      with self.assertRaises(TypeError):
+        lax.dot(lhs, rhs, lax.Precision.DEFAULT, precision=lax.Precision.DEFAULT)
+
+    with self.assertWarnsRegex(DeprecationWarning, msg):
+      with self.assertRaises(TypeError):
+        lax.dot(lhs, rhs, lax.Precision.DEFAULT, jnp.float32, preferred_element_type=jnp.float32)
+
   @parameterized.parameters([
       (algorithm, dtype)
       for algorithm, test_dtypes in [


### PR DESCRIPTION
Also, deprecate passing dot parameters by position. This will unblock us eventually deprecating jax.lax.dot_general in favor of jax.lax.dot.