### PR TITLE
Add logmeanexp.

### DIFF
--- a/docs/jax.nn.rst
+++ b/docs/jax.nn.rst
@@ -50,6 +50,7 @@ Other functions
 
     softmax
     log_softmax
+    logmeanexp
     logsumexp
     standardize
     one_hot

--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -44,6 +44,7 @@ from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
 from jax._src.numpy import einsum as jnp_einsum
 from jax._src.numpy import util as numpy_util
+from jax._src.numpy.reductions import _count
 from jax._src.numpy.reductions import Axis
 from jax._src.sharding_impls import NamedSharding, PartitionSpec as P
 from jax._src.typing import Array, ArrayLike, DType, DTypeLike
@@ -516,6 +517,35 @@ def glu(x: ArrayLike, axis: int = -1) -> Array:
 # other functions
 
 logsumexp = _logsumexp
+
+
+@partial(api.jit, static_argnames=("axis", "keepdims"))
+def logmeanexp(
+    x: ArrayLike,
+    axis: int | tuple[int, ...] | None = None,
+    where: ArrayLike | None = None,
+    keepdims: bool = False,
+) -> Array:
+  r"""Log mean exp.
+
+  Computes the function:
+
+  .. math::
+    \text{logmeanexp}(x) = \log \frac{1}{n} \sum_{i=1}^n \exp x_i = \text{logsumexp}(x) - \log n
+
+  Args:
+    x: Input array.
+    axis: Axis or axes along which to reduce.
+    where: Elements to include in the reduction. Optional.
+    keepdims: Preserve the dimensions of the input.
+  Returns:
+    An array.
+  See also:
+    :func:`jax.nn.logsumexp`
+  """
+  lse = _logsumexp(x, axis=axis, where=where, keepdims=keepdims)
+  count = _count(x, axis=axis, where=where, keepdims=keepdims, dtype=lse.dtype)
+  return lse - jnp.log(count)
 
 
 @partial(api.jit, static_argnames=("axis",))

--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -863,6 +863,23 @@ def mean(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
   return _mean(a, _ensure_optional_axes(axis), dtype, out, keepdims,
                where=where, upcast_f16_for_computation=(dtype is None))
 
+def _count(
+    a: ArrayLike,
+    axis: Axis,
+    keepdims: bool,
+    where: ArrayLike | None,
+    dtype: DTypeLike,
+):
+  if where is None:
+    if axis is None:
+      count = core.dimension_as_value(np.size(a))
+    else:
+      count = core.dimension_as_value(_axis_size(a, axis))
+    count = lax.convert_element_type(count, dtype)
+  else:
+    count = sum(_broadcast_to(where, np.shape(a)), axis, dtype=dtype, keepdims=keepdims)
+  return count
+
 @partial(api.jit, static_argnames=('axis', 'dtype', 'keepdims', 'upcast_f16_for_computation'),
          inline=True)
 def _mean(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
@@ -885,18 +902,17 @@ def _mean(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
   else:
     computation_dtype = result_dtype
 
-  if where is None:
-    if axis is None:
-      normalizer = core.dimension_as_value(np.size(a))
-    else:
-      normalizer = core.dimension_as_value(_axis_size(a, axis))
-  else:
-    normalizer = sum(_broadcast_to(where, np.shape(a)), axis,
-                     dtype=computation_dtype, keepdims=keepdims)
+  normalizer = _count(
+      a,
+      axis=axis,
+      keepdims=keepdims,
+      where=where,
+      dtype=computation_dtype,
+  )
 
   return lax.div(
       sum(a, axis, dtype=computation_dtype, keepdims=keepdims, where=where),
-      lax.convert_element_type(normalizer, computation_dtype)
+      normalizer,
   ).astype(result_dtype)
 
 @overload
@@ -1123,15 +1139,14 @@ def _var(a: Array, axis: Axis = None, dtype: DTypeLike | None = None,
   else:
     centered = lax.square(centered)
 
-  if where is None:
-    if axis is None:
-      normalizer = core.dimension_as_value(np.size(a))
-    else:
-      normalizer = core.dimension_as_value(_axis_size(a, axis))
-    normalizer = lax.convert_element_type(normalizer, computation_dtype)
-  else:
-    normalizer = sum(_broadcast_to(where, np.shape(a)), axis,
-                     dtype=computation_dtype, keepdims=keepdims)
+  normalizer = _count(
+      a,
+      axis=axis,
+      keepdims=keepdims,
+      where=where,
+      dtype=computation_dtype,
+  )
+
   normalizer = lax.sub(normalizer, lax.convert_element_type(correction, computation_dtype))
   result = sum(centered, axis, dtype=computation_dtype, keepdims=keepdims, where=where)
   result = lax.div(result, normalizer).astype(dtype)

--- a/jax/_src/ops/special.py
+++ b/jax/_src/ops/special.py
@@ -70,6 +70,9 @@ def logsumexp(a: ArrayLike, axis: Axis = None, b: ArrayLike | None = None,
   Returns:
     Either an array ``result`` or a pair of arrays ``(result, sign)``, depending
     on the value of the ``return_sign`` argument.
+
+  See also:
+    :func:`jax.nn.logmeanexp`
   """
   if where is not None:
     a = jnp.where(where, a, 0)

--- a/jax/nn/__init__.py
+++ b/jax/nn/__init__.py
@@ -31,6 +31,7 @@ from jax._src.nn.functions import (
   leaky_relu as leaky_relu,
   log_sigmoid as log_sigmoid,
   log_softmax as log_softmax,
+  logmeanexp as logmeanexp,
   logsumexp as logsumexp,
   standardize as standardize,
   one_hot as one_hot,

--- a/tests/lax_numpy_reducers_test.py
+++ b/tests/lax_numpy_reducers_test.py
@@ -802,6 +802,11 @@ class JaxNumpyReducerTests(jtu.JaxTestCase):
     self.assertEqual(1.0, jnp.mean(x))
     self.assertEqual(1.0, jnp.mean(x, where=True))
 
+  def testMeanVeryLargeArray(self):
+    # https://github.com/jax-ml/jax/pull/30769
+    x = jax.ShapeDtypeStruct((1 << 32,), jnp.dtype('float32'))
+    jax.eval_shape(jnp.mean, x)
+
   def testStdLargeArray(self):
     # https://github.com/jax-ml/jax/issues/15068
     raise unittest.SkipTest("test is slow, but it passes!")

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -720,6 +720,22 @@ class NNFunctionsTest(jtu.JaxTestCase):
     with jax.checking_leaks():
       fwd()  # doesn't crash
 
+  @parameterized.product(
+      shape=[(5,), (3, 5), (2, 3, 5)],
+      use_where=[True, False],
+      keepdims=[True, False],
+  )
+  def testLogMeanExp(self, shape, use_where, keepdims):
+    x = self.rng().rand(*shape) * 2 - 1
+    axis = self.rng().randint(0, x.ndim)
+    if use_where:
+      where = self.rng().randint(0, 2, size=shape).astype(bool)
+    else:
+      where = None
+    got = nn.logmeanexp(x, axis=axis, where=where, keepdims=keepdims)
+    expected = jnp.log(jnp.mean(jnp.exp(x), axis=axis, where=where, keepdims=keepdims))
+    self.assertAllClose(got, expected, atol=1e-3)
+
 
 InitializerRecord = collections.namedtuple(
   "InitializerRecord",


### PR DESCRIPTION
Relanding https://github.com/jax-ml/jax/pull/30206 due to https://github.com/jax-ml/jax/pull/30266.

@jakevdp Could you describe the error in more detail, and how it should be solved? The sum inside `_count` is computed using the specified `dtype`. Inside `_mean`, we pass `dtype=computation_dtype`, just as before, to `_count`. Thus `sum` ultimately should receive `dtype=computation_dtype`, just as before.