### PR TITLE
[mutable-arrays] when discharging scanned-over refs, put them in carry

### DIFF
--- a/jax/_src/pallas/mosaic_gpu/primitives.py
+++ b/jax/_src/pallas/mosaic_gpu/primitives.py
@@ -1787,6 +1787,21 @@ def broadcasted_iota(
   return result
 
 
+@lowering.register_lowering_rule(jax_core.closed_call_p, mgpu.LoweringSemantics.Lane)
+@lowering.register_lowering_rule(jax_core.closed_call_p, mgpu.LoweringSemantics.Warpgroup)
+def _closed_call_lowering_rule(ctx, *args, call_jaxpr: jax_core.ClosedJaxpr):
+  if call_jaxpr.consts: raise NotImplementedError
+  return lowering.lower_jaxpr_to_mosaic_gpu(
+      ctx.module_ctx, ctx.launch_ctx, call_jaxpr.jaxpr, args)
+
+
+@lowering._register_resource_estimator(jax_core.closed_call_p)
+def _closed_call_resource_estimator(ctx, *args, call_jaxpr):
+  del args  # Unused.
+  if call_jaxpr.consts: raise NotImplementedError
+  return lowering._estimate_resources(ctx, call_jaxpr.jaxpr)
+
+
 jaxpr_call_p = jax_core.Primitive("jaxpr_call")
 jaxpr_call_p.multiple_results = True
 


### PR DESCRIPTION
The motivation is to ensure the HLO we ultimately generate maintains aliasing on the HLO 'values' corresponding to refs.

Previously, when we state-discharge (i.e. lower away jax-level refs to linear-chain-of-use values, as a pass before converting to HLO) a scanned-over refs, the scan discharge rule would produce a scan over corresponding values. But scanning over values doesn't alias with anything useful in the caller; it aliases with [a new buffer we create](https://github.com/jax-ml/jax/blob/725c45576926e4489f8e976b0201554af53b3251/jax/_src/lax/control_flow/loops.py#L475) to hold the scanned-over outputs.

To get the right aliasing, we instead want the discharge rule to produce a scan that puts the scanned-over refs in its carry. Those carries ultimately get lowered directly to HLO While carries, and such carries are input/output aliased with the ref buffers in the caller. There's no cost to discharging to carries because we discharge after AD.

This PR adapts the scan discharge rule in that way. It also attempts to preserve debug info (untested, sorry, but the old code was busted) and prevent re-tracing the body jaxpr.