### PR TITLE
Deprecate the jax.experimental.host_callback module

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -119,7 +119,7 @@ jobs:
         PY_COLORS: 1
       run: |
         pytest -n auto --tb=short --doctest-glob='*.md' --doctest-glob='*.rst' docs --doctest-continue-on-failure --ignore=docs/multi_process.md
-        pytest -n auto --tb=short --doctest-modules jax --ignore=jax/config.py --ignore=jax/experimental/jax2tf --ignore=jax/_src/lib/mlir --ignore=jax/_src/lib/triton.py --ignore=jax/_src/lib/mosaic_gpu.py --ignore=jax/interpreters/mlir.py --ignore=jax/experimental/array_serialization --ignore=jax/collect_profile.py --ignore=jax/_src/tpu_custom_call.py --ignore=jax/experimental/mosaic --ignore=jax/experimental/pallas --ignore=jax/_src/pallas --ignore=jax/lib/xla_extension.py
+        pytest -n auto --tb=short --doctest-modules jax --ignore=jax/config.py --ignore=jax/experimental/jax2tf --ignore=jax/_src/lib/mlir --ignore=jax/_src/lib/triton.py --ignore=jax/_src/lib/mosaic_gpu.py --ignore=jax/interpreters/mlir.py --ignore=jax/experimental/array_serialization --ignore=jax/collect_profile.py --ignore=jax/_src/tpu_custom_call.py --ignore=jax/experimental/mosaic --ignore=jax/experimental/pallas --ignore=jax/_src/pallas --ignore=jax/lib/xla_extension.py --ignore=jax/experimental/host_callback.py
 
 
   documentation_render:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 
   * {func}`jax.lax.zeros_like_array` is deprecated. Please use
     {func}`jax.numpy.zeros_like` instead.
+  * Attempting to import {mod}`jax.experimental.host_callback` now results in
+    a `DeprecationWarning`, and will result in an `ImportError` starting in JAX
+    v0.8.0. Its APIs have raised `NotImplementedError` since JAX version 0.4.35.
 
 ## JAX 0.7.0 (July 22, 2025)
 

--- a/jax/_src/deprecations.py
+++ b/jax/_src/deprecations.py
@@ -125,6 +125,7 @@ def warn(deprecation_id: str, message: str, stacklevel: int) -> None:
 # always registered by the time `accelerate` and `is_acelerated` are called.
 register('jax-aval-named-shape')
 register('jax-dlpack-import-legacy')
+register('jax-experimental-host-callback')
 register('jax-nn-one-hot-float-input')
 register("jax-numpy-astype-complex-to-real")
 register('jax-numpy-clip-args')

--- a/jax/experimental/BUILD
+++ b/jax/experimental/BUILD
@@ -200,6 +200,7 @@ pytype_strict_library(
         "//jax/_src:callback",
         "//jax/_src:config",
         "//jax/_src:core",
+        "//jax/_src:deprecations",
         "//jax/_src:dtypes",
         "//jax/_src:earray",
     ],

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -22,6 +22,13 @@
 """
 
 from __future__ import annotations
+from jax._src import deprecations as _deprecations
+
+_deprecations.warn(
+  'jax-experimental-host-callback',
+  'jax.experimental.host_callback is deprecated and will be removed in JAX v0.8.0',
+  stacklevel=1,
+)
 
 def call(*_, **__):
   raise NotImplementedError(


### PR DESCRIPTION
All its contents have been rasing `NotImplementedError` since JAX v0.4.35 (released October 2024), so I think a slightly abbreviated deprecation period for the module itself is appropriate.