### PR TITLE
Add hyp2f1 to the docs.

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -172,6 +172,7 @@ jax.scipy.special
    gammaln
    gammasgn
    hyp1f1
+   hyp2f1
    i0
    i0e
    i1


### PR DESCRIPTION
Documentation for [jax.scipy.special.hyp2f1](https://github.com/jax-ml/jax/blob/902ec22823b73eae1b43379f4b5e44032534a950/jax/_src/scipy/special.py#L2843), which was created in [this PR](https://github.com/jax-ml/jax/pull/28168), is currently [missing](https://docs.jax.dev/en/latest/_autosummary/jax.scipy.special.hyp2f1.html). This PR fixes that.