### PR TITLE
Add scalar_first parameter to jax.scipy.spatial.transform.Rotation.from_quat

### DIFF
--- a/jax/_src/scipy/spatial/transform.py
+++ b/jax/_src/scipy/spatial/transform.py
@@ -99,8 +99,24 @@ class Rotation(typing.NamedTuple):
     return cls(_from_mrp(mrp))
 
   @classmethod
-  def from_quat(cls, quat: Array):
-    """Initialize from quaternions."""
+  def from_quat(cls, quat: Array, *, scalar_first: bool = False):
+    """Initialize from quaternions.
+    
+    Args:
+      quat: Quaternions as (N, 4) or (4,) array. Each quaternion will be
+        normalized to unit norm.
+      scalar_first: Whether the scalar component comes first or last. 
+        Default is False, i.e. the scalar-last order (x, y, z, w) is assumed.
+        If True, the scalar-first order (w, x, y, z) is assumed.
+    
+    Returns:
+      A Rotation instance containing the rotations represented by input
+      quaternions.
+    """
+    quat = jnp.asarray(quat)
+    if scalar_first:
+      # Convert from (w, x, y, z) to (x, y, z, w)
+      quat = jnp.roll(quat, shift=-1, axis=-1)
     return cls(_normalize_quaternion(quat))
 
   @classmethod


### PR DESCRIPTION

Fixes #25491

Summary
This PR adds the missing `scalar_first` parameter to `jax.scipy.spatial.transform.Rotation.from_quat()` to match the scipy API (scipy 1.14.0+).

Changes Made
- Added `scalar_first: bool = False` parameter (keyword-only) to `from_quat()`
- When `scalar_first=True`, converts input from `(w, x, y, z)` to internal `(x, y, z, w)` format using `jnp.roll(shift=-1, axis=-1)`
- Added comprehensive tests for the new parameter
- Maintains backward compatibility (default behavior unchanged)

Testing
- Added `testRotationFromQuatScalarFirst`: Tests against scipy reference implementation
- Added `testRotationFromQuatScalarFirstBasic`: Tests basic functionality with known values
- Tests are version-gated to skip when scipy < 1.14.0

Compatibility
- Backward compatible: Default behavior unchanged
- API compatible: Matches scipy 1.14.0+ exactly
- Works with both single quaternions and arrays of quaternions
Files Changed
- `jax/_src/scipy/spatial/transform.py` - Implementation
- `tests/scipy_spatial_test.py` - Tests
