### PR TITLE
[mutable arrays] add API docs for `jax.ref` module

### DIFF
--- a/jax/_src/ref.py
+++ b/jax/_src/ref.py
@@ -17,5 +17,17 @@ from jax._src.typing import Array
 
 
 def array_ref(init_val: Array) -> core.ArrayRef:
-  """Create a mutable array reference with initial value `init_val`."""
+  """Create a mutable array reference with initial value ``init_val``.
+
+  For more discussion, see the `ArrayRef guide`_.
+
+  Args:
+    init_val: A :class:`jax.Array` representing the initial state
+      of the buffer.
+
+  Returns:
+    A :class:`jax.ref.ArrayRef` containing a reference to a mutable buffer.
+
+  .. _ArrayRef guide: https://docs.jax.dev/en/latest/array_refs.html
+  """
   return core.array_ref_p.bind(init_val, memory_space=None)

--- a/jax/_src/state/types.py
+++ b/jax/_src/state/types.py
@@ -324,6 +324,12 @@ class TransformedRef:
 
 # We need an aval for `Ref`s so we can represent `get` and `swap` in Jaxprs.
 class AbstractRef(core.AbstractValue):
+  """Abstract mutable array reference.
+
+  Refer to the `ArrayRef guide`_ for more information.
+
+  .. _ArrayRef guide: https://docs.jax.dev/en/latest/array_refs.html
+  """
   __slots__ = ["inner_aval", "memory_space"]
 
   def __init__(self, inner_aval: core.AbstractValue, memory_space: Any = None):


### PR DESCRIPTION
Rendered preview: https://jax--30833.org.readthedocs.build/en/30833/jax.ref.html