### PR TITLE
host_callback deprecation: raise ImportError rather than ValueError

### DIFF
--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -22,13 +22,20 @@
 """
 
 from __future__ import annotations
+import warnings
 from jax._src import deprecations as _deprecations
 
-_deprecations.warn(
-  'jax-experimental-host-callback',
-  'jax.experimental.host_callback is deprecated and will be removed in JAX v0.8.0',
-  stacklevel=1,
-)
+if _deprecations.is_accelerated('jax-experimental-host-callback'):
+  raise ImportError(
+      'jax.experimental.host_callback has been deprecated and'
+      ' is no longer supported.'
+  )
+else:
+  warnings.warn(
+      'jax.experimental.host_callback is deprecated and will be removed in JAX'
+      ' v0.8.0',
+      stacklevel=1,
+  )
 
 def call(*_, **__):
   raise NotImplementedError(


### PR DESCRIPTION
The ValueError was causing issues when attemping to accelerate the deprecation.