### PR TITLE
[mutable-arrays] add cond fancy tranpsose rule

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -2577,10 +2577,9 @@ def _pjit_transpose_fancy(
     compiler_options_kvs):
   primals_ctrefs, specs = ad.project_accums(args)
   in_flat, in_tree = tree_flatten((primals_ctrefs, cts_in))
-  in_aval_qdds = [core.AvalQDD(a, cur_qdd(x)) if (a := typeof(x)).has_qdd  # type: ignore
-                  else a for x in in_flat]
-  trans_jaxpr, out_tree = _transpose_jaxpr_fancy(jaxpr, in_tree,
-                                                 tuple(in_aval_qdds), specs)
+  in_avals = [core.AvalQDD(a, cur_qdd(x)) if (a := typeof(x)).has_qdd  # type: ignore
+              else a for x in in_flat]
+  trans_jaxpr, out_tree = _transpose_jaxpr_fancy(jaxpr, in_tree, (*in_avals,), specs)
 
   trans_in_shardings = (
       [s for x, s in zip(args, in_shardings) if not isinstance(x,ad.ValAccum)] +
@@ -2611,7 +2610,8 @@ def _pjit_transpose_fancy(
       # but not `fun.call_wrapped` on the same arguments. Let's tell the user.
       api_util._raise_no_nan_in_deoptimized(e)
 
-  return tree_unflatten(out_tree, cts_out)
+  for x, ct in zip(args, tree_unflatten(out_tree, cts_out)):
+    if isinstance(x, ad.ValAccum): x.accum(ct)
 
 @weakref_lru_cache
 def _transpose_jaxpr_fancy(jaxpr, in_tree, in_avals, specs):

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -36,6 +36,7 @@ from jax._src import test_util as jtu
 from jax._src import dtypes
 from jax import stages
 from jax import lax
+from jax._src.api import vjp3
 from jax._src.lax import lax as lax_internal
 from jax.lax import with_sharding_constraint
 from jax._src import prng
@@ -1283,6 +1284,12 @@ class PJitTest(jtu.BufferDonationTestCase):
     self.assertDeleted(y)
     self.assertNotDeleted(z)
     self.assertArraysEqual(a, x * 2)
+
+  def test_basic_vjp3(self):
+    f = jax.jit(lambda x: jnp.sin(jnp.sin(x)))
+    _, f_vjp = vjp3(f, 1.)
+    g, = f_vjp(1.0)
+    self.assertAllClose(g, jnp.cos(jnp.sin(1.)) * jnp.cos(1.), check_dtypes=False)
 
 
 @jtu.pytest_mark_if_available('multiaccelerator')


### PR DESCRIPTION
Some upgrades:
* don't always instantiate cts_in
* don't always instantiate cts_out, instead join the results across branches
* handle arbitrary interleavings of linear inputs, not just contiguous suffixes

also fix a bug in pjit fancy transpose, and a test