### PR TITLE
fused api prototype for fine-grained memory control

### DIFF
--- a/jax/_src/cudnn/fusion.py
+++ b/jax/_src/cudnn/fusion.py
@@ -51,12 +51,7 @@ def call_cudnn_fusion(f, *args, **kwargs):
   return tree_util.tree_unflatten(out_tree, out_flat)
 
 
-def _cudnn_fusion_stablehlo_lowering(
-  ctx,
-  *args,
-  name,
-  jaxpr,
-):
+def _cudnn_fusion_stablehlo_lowering(ctx, *args, name, jaxpr):
   """Make cudnn_fusion which calls the implementation function.
   Currently this leaks a CallOp since we're using the `core_call_lowering`
   function, but this should get cleaned up by DCE easily.

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -784,11 +784,6 @@ def batch_jaxpr2(
     axis_data,
     in_axes: tuple[int | NotMapped | RaggedAxis, ...],
   ) -> tuple[core.ClosedJaxpr, tuple[int | NotMapped | RaggedAxis, ...]]:
-  # This is only ever used in pjit.  The difference vs batch_jaxpr is that
-  # batch_jaxpr2 lets the callee decide which outputs are batched and what
-  # their batch axes are; whereas batch_jaxpr has to obey caller-imposed
-  # consistency constraints, such as type-agreement across arms of a
-  # `lax.cond`, or input-output agreement for the body of a `lax.scan`.
   return _batch_jaxpr2(closed_jaxpr, axis_data, tuple(in_axes))
 
 @weakref_lru_cache

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -2272,6 +2272,8 @@ def _pjit_linearize(nzs, *primals_in, jaxpr, in_shardings, out_shardings,
   primal_out_layouts = keep_where(primal_out_layouts, keep)
   del keep
 
+  tangent_avals_out = [a.to_tangent_aval() for a in jaxpr.out_avals]
+
   def tangent_fun(residuals, *tangents):
     tangents_nz = _filter_zeros(nzs, tangents)
     nz_tangents_out = jit_p.bind(
@@ -2286,7 +2288,6 @@ def _pjit_linearize(nzs, *primals_in, jaxpr, in_shardings, out_shardings,
         keep_unused=keep_unused,
         inline=inline,
         compiler_options_kvs=compiler_options_kvs)
-    tangent_avals_out = [v.aval.to_tangent_aval() for v in jaxpr.jaxpr.outvars]
     nz_tangents_out_ = iter(nz_tangents_out)
     tangents_out = [next(nz_tangents_out_) if nz else ad.Zero(aval)
                    for (aval, nz) in zip(tangent_avals_out, nzs_out)]

--- a/jax/experimental/BUILD
+++ b/jax/experimental/BUILD
@@ -555,6 +555,15 @@ pytype_strict_library(
 )
 
 pytype_strict_library(
+    name = "fused",
+    srcs = ["fused.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//jax/_src:api",
+    ],
+)
+
+pytype_strict_library(
     name = "source_mapper",
     srcs = glob(include = ["source_mapper/**/*.py"]),
     visibility = [
@@ -680,6 +689,7 @@ filegroup(
         "multihost_utils.py",
         "pjit.py",
         "scheduling_groups.py",
+        "fused.py",
         "shard_map.py",
     ],
     visibility = ["//jax:internal"],

--- a/jax/experimental/BUILD
+++ b/jax/experimental/BUILD
@@ -559,7 +559,16 @@ pytype_strict_library(
     srcs = ["fused.py"],
     visibility = ["//visibility:public"],
     deps = [
+        "//jax/_src:ad",
         "//jax/_src:api",
+        "//jax/_src:api_util",
+        "//jax/_src:batching",
+        "//jax/_src:core",
+        "//jax/_src/lib",
+        "//jax/_src:mlir",
+        "//jax/_src:partial_eval",
+        "//jax/_src:tree_util",
+        "//jax/_src:util",
     ],
 )
 

--- a/jax/experimental/fused.py
+++ b/jax/experimental/fused.py
@@ -1,0 +1,149 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from jax._src import core
+from jax._src import linear_util as lu
+from jax._src import dispatch
+from jax._src.core import typeof
+from jax._src.tree_util import tree_flatten, tree_unflatten
+from jax._src.util import safe_map, safe_zip, weakref_lru_cache
+from jax._src.api_util import debug_info, flatten_fun_nokwargs
+from jax._src.interpreters import ad
+from jax._src.interpreters import batching
+from jax._src.interpreters import mlir
+from jax._src.interpreters import partial_eval as pe
+from jax._src.lib.mlir import ir
+
+map, unsafe_map = safe_map, map
+zip, unsafe_zip = safe_zip, zip
+
+def fused(*, out_spaces):
+  def wrap(f):
+    def wrapped(*args):
+      dbg = debug_info('fused', f, args, {})
+      args_flat, in_tree = tree_flatten(args)
+      in_avals = [typeof(x).update(memory_space=core.MemorySpace.Any)
+                  for x in args_flat]
+      jaxpr, out_tree = _trace_to_jaxpr(f, in_tree, tuple(in_avals), dbg)
+      outs_flat = fused_p.bind(*args_flat, jaxpr=jaxpr, out_spaces=out_spaces)
+      return tree_unflatten(out_tree, outs_flat)
+    return wrapped
+  return wrap
+
+@weakref_lru_cache
+def _trace_to_jaxpr(fun, in_tree, in_avals, dbg):
+  f = lu.wrap_init(fun, debug_info=dbg)
+  f, out_tree = flatten_fun_nokwargs(f, in_tree)
+  jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(f, in_avals)
+  return core.ClosedJaxpr(jaxpr, consts), out_tree()
+
+fused_p = core.Primitive('fused_call')
+fused_p.multiple_results = True
+
+@fused_p.def_abstract_eval
+def _fused_abstract_eval(*in_avals, out_spaces, jaxpr):
+  return [a.update(memory_space=s)
+          for a, s in zip(jaxpr.out_avals, out_spaces)]
+
+dispatch.simple_impl(fused_p)
+
+def _fused_lowering(ctx, *args, out_spaces, jaxpr):
+  const_args = core.jaxpr_const_args(jaxpr.jaxpr)
+  const_arg_values = [
+      mlir.ir_constant(c, ctx.const_lowering, canonicalize_dtype=True)
+      for c in const_args]
+  in_avals = [core.shaped_abstractify(c) for c in const_args] + [*ctx.avals_in]
+  func_op, _, _ = mlir.lower_called_computation(
+      "fused", jaxpr, ctx.module_context, len(const_args), in_avals,
+      ctx.avals_out, ctx.tokens_in)
+  out_spaces_ = [ir.StringAttr.get(str(s)) for s in out_spaces]
+  fused = mlir.custom_call(
+      "fused",
+      result_types=func_op.type.results,
+      operands=mlir.flatten_ir_values([*const_arg_values, *args]),
+      called_computations=[func_op.name.value],
+      extra_attributes=dict(out_spaces=ir.ArrayAttr.get(out_spaces_)),
+  )
+  return fused.results
+mlir.register_lowering(fused_p, _fused_lowering, platform="cuda")
+
+def _fused_batcher(axis_data, vals_in, dims_in, *, jaxpr, out_spaces):
+  batched_jaxpr, dims_out = batching.batch_jaxpr2(jaxpr, axis_data, dims_in)
+  outs = fused_p.bind(*vals_in, jaxpr=batched_jaxpr, out_spaces=out_spaces)
+  return outs, dims_out
+batching.fancy_primitive_batchers[fused_p] = _fused_batcher
+
+def _fused_jvp(primals, tangents, *, jaxpr, out_spaces):
+  nzs = [not isinstance(t, ad.Zero) for t in tangents]
+  jaxpr_jvp, out_nzs = ad.jvp_jaxpr(jaxpr, nzs, False)
+  nz_tangents = [t for t in tangents if not isinstance(t, ad.Zero)]
+  spaces_jvp = (*out_spaces, *[s for s, nz in zip(out_spaces, out_nzs) if nz])
+  outs = fused_p.bind(*primals, *nz_tangents, jaxpr=jaxpr_jvp,
+                      out_spaces=spaces_jvp)
+  primals_out, nz_tangents_out = outs[:len(out_nzs)], outs[len(out_nzs):]
+  nz_outs = iter(nz_tangents_out)
+  tangents_out = [next(nz_outs) if nz else ad.Zero(aval.to_tangent_aval())
+                  for aval, nz in zip(jaxpr.out_avals, out_nzs)]
+  assert next(nz_outs, None) is None
+  return primals_out, tangents_out
+ad.primitive_jvps[fused_p] = _fused_jvp
+
+def _fused_lin(nzs, *primals, jaxpr, out_spaces):
+  jaxpr_jvp, out_nzs = ad.jvp_jaxpr(jaxpr, nzs, False)
+  lin_outs = [False] * len(out_nzs) + [True] * sum(out_nzs)
+  jaxpr_lin_, used_inputs = pe.dce_jaxpr(jaxpr_jvp.jaxpr, lin_outs, False)
+  jaxpr_lin = pe.close_jaxpr(jaxpr_lin_)
+  spaces_lin = tuple(s for s, nz in zip(out_spaces, out_nzs) if nz)
+  primals_out = fused_p.bind(*primals, jaxpr=jaxpr, out_spaces=out_spaces)
+  tangent_avals_out = [a.to_tangent_aval() for a in jaxpr.out_avals]
+
+  def fused_lin(primals, *tangents):
+    nz_tangents = [t for t in tangents if not isinstance(t, ad.Zero)]
+    inputs = [x for x, u in zip([*primals, *nz_tangents], used_inputs) if u]
+    nz_outs = fused_p.bind(*inputs, jaxpr=jaxpr_lin, out_spaces=spaces_lin)
+    nz_outs_ = iter(nz_outs)
+    outs = [next(nz_outs_) if nz else ad.Zero(a)
+            for nz, a in zip(out_nzs, tangent_avals_out)]
+    assert next(nz_outs_, None) is None
+    return outs
+
+  return primals_out, out_nzs, primals, fused_lin
+ad.primitive_linearizations[fused_p] = _fused_lin
+
+def _fused_transpose(cts_in, *primals_in, jaxpr, out_spaces):
+  in_flat, in_tree = tree_flatten((primals_in, cts_in))
+  in_avals = [typeof(x).update(memory_space=core.MemorySpace.Any)
+              for x in in_flat]
+  trans_jaxpr, out_tree = _transpose_jaxpr(jaxpr, in_tree, (*in_avals,))
+  in_spaces = [x.aval.memory_space if isinstance(x, ad.UndefinedPrimal)
+               else typeof(x).memory_space for x in primals_in]
+  cts_out_ = tree_unflatten(out_tree, trans_jaxpr.out_avals)
+  trans_spaces = tuple(s for x, s in zip(cts_out_, in_spaces) if x)
+  cts_out = fused_p.bind(*in_flat, jaxpr=trans_jaxpr, out_spaces=trans_spaces)
+  return tree_unflatten(out_tree, cts_out)
+
+@weakref_lru_cache
+def _transpose_jaxpr(jaxpr, in_tree, in_avals):
+  cell = lambda: None
+  def transposed(*in_flat):
+    primals_in, cts_in = tree_unflatten(in_tree, in_flat)
+    out = ad.backward_pass(jaxpr.jaxpr, False, jaxpr.consts, primals_in, cts_in)
+    out = [ct if not isinstance(ct, ad.Zero) else None for ct in out]
+    cts_out, cell.out_tree = tree_flatten(out)  # type: ignore
+    return cts_out
+  dbg = jaxpr.jaxpr.debug_info._replace(arg_names=(), result_paths=())
+  trans_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
+      lu.wrap_init(transposed, debug_info=dbg), in_avals)
+  return core.ClosedJaxpr(trans_jaxpr, consts), cell.out_tree  # type: ignore
+ad.primitive_transposes[fused_p] = _fused_transpose

--- a/jax/experimental/fused.py
+++ b/jax/experimental/fused.py
@@ -73,7 +73,9 @@ def _fused_lowering(ctx, *args, out_spaces, jaxpr):
       result_types=func_op.type.results,
       operands=mlir.flatten_ir_values([*const_arg_values, *args]),
       called_computations=[func_op.name.value],
-      extra_attributes=dict(out_spaces=ir.ArrayAttr.get(out_spaces_)),
+      extra_attributes=dict(out_spaces=ir.ArrayAttr.get(out_spaces_),
+                            inlineable=ir.BoolAttr.get(False),
+                            MUST_FUSE=ir.BoolAttr.get(True)),
   )
   return fused.results
 mlir.register_lowering(fused_p, _fused_lowering, platform="cuda")

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1480,6 +1480,12 @@ jax_multiplatform_test(
 )
 
 jax_multiplatform_test(
+    name = "fused_test",
+    srcs = ["fused_test.py"],
+    deps = py_deps("absl/testing"),
+)
+
+jax_multiplatform_test(
     name = "stax_test",
     srcs = ["stax_test.py"],
     deps = ["//jax:stax"] + py_deps([

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1482,7 +1482,11 @@ jax_multiplatform_test(
 jax_multiplatform_test(
     name = "fused_test",
     srcs = ["fused_test.py"],
-    deps = py_deps("absl/testing"),
+    deps = [
+        "//jax/experimental:fused",
+    ] + py_deps([
+        "absl/testing",
+    ]),
 )
 
 jax_multiplatform_test(

--- a/tests/fused_test.py
+++ b/tests/fused_test.py
@@ -1,0 +1,66 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+
+import jax
+import jax.numpy as jnp
+from jax._src import test_util as jtu
+
+from jax.experimental.fused import fused
+
+@fused(out_spaces=(jax.memory.Space.Host, jax.memory.Space.Device))
+def f(x, y):
+  z = x + y
+  w = x * y
+  return z, w
+
+class FusedTest(jtu.JaxTestCase):
+
+  def test_basic(self):
+    # TODO(mattjj): make this work without the jit
+    x = jnp.arange(3.)
+    x_host = jax.jit(lambda: jax.device_put(x, jax.memory.Space.Host))()
+    y_device = jnp.arange(3.)
+    low = jax.jit(f).trace(x_host, y_device).lower(lowering_platforms=('cuda',))
+    print(low.as_text())
+    self.assertIn('custom_call', low.as_text())
+
+  def test_vmap_basic(self):
+    x = jnp.arange(3.)
+    x_host = jax.jit(lambda: jax.device_put(x, jax.memory.Space.Host))()
+    y_device = jnp.arange(3.)
+    f_ = jax.jit(jax.vmap(f))
+    # don't crash
+    low = f_.trace(x_host, y_device).lower(lowering_platforms=('cuda',))
+
+  def test_jvp_basic(self):
+    x = jnp.arange(3.)
+    x_host = jax.jit(lambda: jax.device_put(x, jax.memory.Space.Host))()
+    y_device = jnp.arange(3.)
+    f_ = jax.jit(lambda x, y: jax.jvp(f, (x, y), (x, y)))
+    # don't crash
+    low = f_.trace(x_host, y_device).lower(lowering_platforms=('cuda',))
+
+  def test_grad_basic(self):
+    x = jnp.arange(3.)
+    x_host = jax.jit(lambda: jax.device_put(x, jax.memory.Space.Host))()
+    y_device = jnp.arange(3.)
+    f_ = jax.jit(jax.grad(lambda x, y: f(x, y)[1].sum()))
+    # don't crash
+    low = f_.trace(x_host, y_device).lower(lowering_platforms=('cuda',))
+
+
+if __name__ == '__main__':
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
For collaboration with @zhenying-liu and @jreiffers.

We can build the CustomCall however is needed. Does this look good, or should we change it?

```python
x = jnp.arange(3.)
x_host = jax.jit(lambda: jax.device_put(x, jax.memory.Space.Host))()
y_device = jnp.arange(3.)

@fused(out_spaces=(jax.memory.Space.Host, jax.memory.Space.Device))
def f(x, y):
  z = x + y
  w = x * y
  return z, w

print(jax.jit(f).trace(x_host, y_device).lower(lowering_platforms=('cuda',))
```

```
module @jit_wrapped attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
  func.func public @main(%arg0: tensor<3xf32>, %arg1: tensor<3xf32>) -> (tensor<3xf32> {jax.result_info = "result[0]"}, tensor<3xf32> {jax.result_info = "result[1]"}) {
    %0:2 = stablehlo.custom_call @fused(%arg0, %arg1) {api_version = 2 : i32, backend_config = "", called_computations = [@fused], out_spaces = ["Space.Host", "Space.Device"]} : (tensor<3xf32>, tensor<3xf32>) -> (tensor<3xf32>, tensor<3xf32>)
    return %0#0, %0#1 : tensor<3xf32>, tensor<3xf32>
  }
  func.func private @fused(%arg0: tensor<3xf32>, %arg1: tensor<3xf32>) -> (tensor<3xf32>, tensor<3xf32>) {
    %0 = stablehlo.add %arg0, %arg1 : tensor<3xf32>
    %1 = stablehlo.multiply %arg0, %arg1 : tensor<3xf32>
    return %0, %1 : tensor<3xf32>, tensor<3xf32>
  }
}
```

The transformation rules are only very lightly tested, but it looks like we should be able to support vmap and autodiff no problem.

We should abstract this so it's not so heavyweight to make new call-like primitives. #30585 shows another way to do this which is much more terse, piggybacking on `closed_call_p`. We couldn't immediately use that technique here because of the `out_spaces` argument, which rules need to update based on how outputs are transformed. But we could probably handle those kinds of attributes generically.