### PR TITLE
[CI]Always run B200 tests on PRs that modify higher risk mosaic paths

### DIFF
--- a/.github/workflows/bazel_cuda_h100_b200.yml
+++ b/.github/workflows/bazel_cuda_h100_b200.yml
@@ -1,4 +1,9 @@
-name: CI - Bazel Optional H100 and B200 CUDA tests
+name: CI - Bazel H100 and B200 CUDA tests
+# This runs if any of the following conditions are met
+# H100 and B200 on Workflow dispatch
+# H100 and B200 on scheduled every two hours
+# B200 on PR to main that modifies mosaic files or this file, see below for list
+# H100 and B200 on PR to main that has the 'CI Optional GPU Presubmit' label
 on:
   # Runs on PR if label "CI Optional GPU Presubmit" is present.
   workflow_dispatch:
@@ -14,18 +19,45 @@ on:
   pull_request:
     branches:
       - main
-    types: [ labeled, synchronize ]
+    types: [ labeled, synchronize, opened, reopened ]
   schedule:
     - cron: "0 */2 * * *" # Run once every 2 hours
-permissions:
-  contents: read
+permissions: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   # Don't cancel in-progress jobs for main/release branches.
   cancel-in-progress: ${{ !contains(github.ref, 'release/') && github.ref != 'main' }}
 jobs:
-  run_tests:
-    if: ${{ github.event.repository.fork == false && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'CI Optional GPU Presubmit')) }}
+  changed_files:
+    permissions: {} # No permissions given
+    runs-on: ubuntu-latest # Do not run tj-actions on self-hosted runners
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Get and filter changed files # We only run this if it is a pull request, do not run tj-actions on non PR event
+        if: ${{ github.event_name == 'pull_request' }}
+        id: changed-files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
+        with:
+          files: |
+            jax/jax/_src/pallas/mosaic_gpu/**
+            jax/jax/experimental/mosaic/gpu/**
+            jax/jaxlib/mosaic/dialect/gpu/**
+            jax/jaxlib/mosaic/gpu/**
+            .github/workflows/bazel_cuda_h100_b200.yml
+      - name: List all changed files
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed || 'false' }}
+  run_tests: 
+    needs: changed_files 
+    if: ${{ github.event.repository.fork == false && (github.event_name == 'schedule' || needs.changed_files.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'CI Optional GPU Presubmit')) }}
     runs-on: linux-x86-a4-224-b200-1gpu
     container: 'us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest'
     name: "Bazel single B200 CUDA tests"


### PR DESCRIPTION
Always run B200 tests on the following path changes:
```
            jax/jax/_src/pallas/mosaic_gpu/**
            jax/jax/experimental/mosaic/gpu/**
            jax/jaxlib/mosaic/dialect/gpu/**
            jax/jaxlib/mosaic/gpu/**
            .github/workflows/bazel_cuda_h100_b200.yml
```

This will be made blocking in a follow up while the test is green. 