### PR TITLE
Explicitly deprecate jax_default_dtype_bits config.

### DIFF
--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -471,6 +471,7 @@ pytype_strict_library(
     name = "config",
     srcs = ["config.py"],
     deps = [
+        ":deprecations",
         ":logging_config",
         "//jax/_src/lib",
     ],

--- a/jax/_src/deprecations.py
+++ b/jax/_src/deprecations.py
@@ -123,6 +123,7 @@ def warn(deprecation_id: str, message: str, stacklevel: int) -> None:
 
 # Register a number of deprecations: we do this here to ensure they're
 # always registered by the time `accelerate` and `is_acelerated` are called.
+register('default-dtype-bits-config')
 register('jax-aval-named-shape')
 register('jax-dlpack-import-legacy')
 register('jax-experimental-host-callback')


### PR DESCRIPTION
This was an experiment that was never fully fleshed-out, and has never been suitably supported or tested. We can't just remove the flag, because a few downstream project depend on it. This starts an official deprecation process for the flag.