### PR TITLE
Add prototype of accumulators.

### DIFF
--- a/jax/_src/accumulator.py
+++ b/jax/_src/accumulator.py
@@ -1,0 +1,259 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+from collections.abc import Sequence
+
+from jax._src import core
+from jax._src import dispatch
+from jax._src.interpreters import batching
+from jax._src.interpreters import pxla
+from jax._src.interpreters import xla
+from jax._src.state import discharge
+from jax._src.state import indexing
+from jax._src.state import primitives
+from jax._src.state import types
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+# Indexing #####################################################################
+
+def _ndindexer_to_index(ndidx):
+  """Converts an indexing.NDIndexer into a regular Python index."""
+  index = []
+  for idx in ndidx.indices:
+    if isinstance(idx, indexing.Slice):
+      index.append(slice(idx.start, idx.size, idx.stride))
+    else:
+      index.append(idx)
+  return tuple(index)
+
+# Accumulator ##################################################################
+
+class Accumulator:
+  """An ArrayRef that you can only accumulate into.
+
+  An Accumulator is like an ArrayRef, but you cannot arbitrarily read from it
+  or write to it. Instead, you can only accumulate into it. Intuitively,
+  accumulating into an Accumulator is like executing a `+=` operation. More
+  formally, the operation can be any elementwise monoidal operation.
+  """
+  _aval: AbstractAccumulator
+  _buf: jax.Array
+  def __init__(self, aval, buf):
+    self._aval = aval
+    self._buf = buf
+  aval = property(lambda self: self._aval)
+  shape = property(lambda self: self._aval.shape)
+  dtype = property(lambda self: self._aval.dtype)
+  sharding = property(lambda self: self._buf.sharding)
+  @property
+  def at(self): return self._aval.at.fget(self)
+  def accumulate(self, val, idx): return self._aval._accumulate(self, val, idx)
+  def __getitem__(self, idx): return self._aval._getitem(self, idx)
+  def __repr__(self) -> str: return 'Accumulator' + repr(self._buf)
+  def __len__(self) -> int: return self._aval._len(self)
+
+core.pytype_aval_mappings[Accumulator] = lambda x: x._aval
+
+accumulator_p = core.Primitive('accumulator')
+accumulator_p.is_effectful = lambda params: True  # type: ignore
+accumulator_p.ref_primitive = True
+
+def accumulator(init_val, identity, f):
+  return accumulator_p.bind(init_val, identity=identity, f=f)
+
+@accumulator_p.def_effectful_abstract_eval
+def accumulator_abstract_eval(init_aval, identity, f):
+  effects = {core.internal_mutable_array_effect}
+  return AbstractAccumulator(init_aval, identity, f), effects
+
+@accumulator_p.def_impl
+def _accumulator_impl(init_val, identity, f):
+  from jax._src.lax.lax import _array_copy  # pytype: disable=import-error
+  aval = AbstractAccumulator(core.get_aval(init_val), identity, f)
+  return Accumulator(aval, _array_copy(init_val))
+
+batching.defvectorized(accumulator_p)
+xla.canonicalize_dtype_handlers[Accumulator] = lambda x: x
+
+def _shard_accumulator(xs, shardings, layouts, copy_semantics):
+  return pxla.shard_args(shardings, layouts, copy_semantics, [x._buf for x in xs])
+pxla.shard_arg_handlers[Accumulator] = _shard_accumulator
+
+# AbstractAccumulator ##########################################################
+
+class AbstractAccumulator(types.AbstractRef):
+  """The aval of an Accumulator."""
+  __slots__ = ["inner_aval", "identity", "f", "memory_space", "foo"]
+
+  def __init__(self, inner_aval: core.AbstractValue, identity, f):
+    self.inner_aval = inner_aval
+    self.identity = identity
+    self.f = f
+    self.memory_space = None
+
+  def _accumulate(self, tracer, val, idx):
+    ndidx = indexing.NDIndexer.from_indices_shape(idx, tracer.shape)
+    flat, tree = jax.tree.flatten(ndidx)
+    return accumulate_p.bind(tracer, val, self.identity, *flat, tree=tree, f=self.f)
+
+  def _getitem(self, tracer, idx) -> jax.Array:
+    ndidx = indexing.NDIndexer.from_indices_shape(idx, tracer.shape)
+    flat, tree = jax.tree.flatten(ndidx)
+    return accumulator_get_p.bind(tracer, *flat, tree=tree)
+
+  @core.aval_property
+  def at(self):
+    return _At(self)
+
+  def __repr__(self) -> str:
+    return f'Accumulator[{self.inner_aval.str_short()}]'
+
+core.pytype_aval_mappings[AbstractAccumulator] = lambda x: x
+
+class _At:
+  def __init__(self, acc):
+    self.acc = acc
+
+  def __getitem__(self, idx):
+    return _AtAccumulator(self.acc, idx)
+
+class _AtAccumulator:
+  def __init__(self, acc, idx):
+    self.acc = acc
+    self.idx = idx
+
+  def accumulate(self, val):
+    return self.acc.accumulate(val, self.idx)
+
+# accumulator_get ##############################################################
+
+accumulator_get_p = core.Primitive('accumulator_get')
+accumulator_get_p.ref_primitive = True
+dispatch.simple_impl(accumulator_get_p)
+
+@accumulator_get_p.def_effectful_abstract_eval
+def accumulator_get_abstract_eval(acc, *flat, tree):
+  ndidx = jax.tree.unflatten(tree, flat)
+  new_shape = ndidx.transform_shape(acc.inner_aval.shape)
+  return acc.inner_aval.update(shape=new_shape), {types.ReadEffect(0)}
+
+@discharge.register_discharge_rule(accumulator_get_p)
+def _accumulator_get_discharge_rule(in_avals: Sequence[core.AbstractValue],
+                                    out_avals: Sequence[core.AbstractValue],
+                                    x, *flat, tree):
+  del in_avals, out_avals
+  idx = _ndindexer_to_index(jax.tree.unflatten(tree, flat))
+  return (None,) * (1 + len(flat)), x[idx]
+
+def _accumulator_get_vmap(batched_args, batched_dims, *, tree):
+  raise ValueError("You can't read accumulators inside a vmap")
+
+batching.primitive_batchers[accumulator_get_p] = _accumulator_get_vmap
+
+# accumulate ###################################################################
+
+accumulate_p = core.Primitive("accumulate")
+accumulate_p.multiple_results = True
+
+dispatch.simple_impl(accumulate_p)
+
+@accumulate_p.def_effectful_abstract_eval
+def accumulate_abstract_eval(acc, val, identity, *flat, tree, f):
+  return [], {types.AccumEffect(0), core.internal_mutable_array_effect}
+
+@discharge.register_discharge_rule(accumulate_p)
+def _accumulate_discharge_rule(in_avals: Sequence[core.AbstractValue],
+                               out_avals: Sequence[core.AbstractValue],
+                               x, val, identity, *flat, tree, f):
+  aval = in_avals[0]
+  assert isinstance(aval, AbstractAccumulator)
+  idx = _ndindexer_to_index(jax.tree.unflatten(tree, flat))
+  result = jnp.vectorize(aval.f)(x[idx], val)
+  return (x.at[idx].set(result),) + (None,) * (2 + len(flat)), []
+
+def _accumulate_vmap(batched_args, batched_dims, *, trace, tree, f):
+  # Extract arguments.
+  ref, val, identity, *flat_idx = batched_args
+  ref_dim, val_dim, identity_dim, *flat_idx_dims = batched_dims
+  assert identity_dim is None
+  idx = jax.tree.unflatten(tree, flat_idx)
+  idx_dims = jax.tree.unflatten(tree, flat_idx_dims)
+
+  # Extract aval.
+  aval = core.get_aval(ref)
+  assert isinstance(aval, AbstractAccumulator)
+
+  # Check what's batched.
+  ref_is_batched = ref_dim is not batching.not_mapped
+  val_is_batched = val_dim is not batching.not_mapped
+  idx_is_batched = any(i_dim is not batching.not_mapped
+                       for i_dim in flat_idx_dims)
+
+  # If ref is not batched, pretend it is. We'll accumulate into a mapped
+  # accumulator and reduce the mapped accumulator at the end of vmap.
+  if not ref_is_batched:
+    if ref not in trace.accumulator_states:
+      init_val = jnp.full((trace.axis_data.size,) + ref.shape, identity, dtype=aval.dtype)
+      trace.accumulator_states[ref] = accumulator(init_val, identity, f=aval.f)
+    ref = trace.accumulator_states[ref]
+    ref_dim = 0
+    ref_is_batched = True
+
+  # Update the index.
+  new_idx = primitives._batch_indexer(
+      idx, idx_dims, trace.axis_data.size, ref.shape, ref_dim, idx_is_batched)
+
+  # Find the batching dimension. This depends on whether the non-slice indexers
+  # are contigious or not.
+  is_int_indexing, _, _ = indexing.unpack_ndindexer(new_idx)
+  int_indexers_contiguous = (
+      any(is_int_indexing) and
+      bool(np.all(np.diff(np.where(is_int_indexing)[0]) == 1))
+  )
+  if not int_indexers_contiguous:
+    batched_dim_in_result = 0
+  else:
+    batched_dim_in_result = is_int_indexing.index(True)
+
+  # Batch or reshape val.
+  if val_is_batched:
+    val = batching.moveaxis(
+        val, val_dim, batched_dim_in_result)
+  else:
+    val = batching.broadcast(
+        val, trace.axis_data.size, batched_dim_in_result)
+
+  # Perform the index.
+  flat, tree = jax.tree.flatten(new_idx)
+  accumulate_p.bind(ref, val, identity, *flat, tree=tree, f=aval.f)
+
+  # TODO: mwhittaker - Allow returning mutable arrays?
+  return [], []
+
+batching.primitive_batchers[accumulate_p] = _accumulate_vmap
+
+def _map_accumulator(size, axis, aval):
+  mapped = core.mapped_aval(size, axis, aval.inner_aval)
+  return AbstractAccumulator(mapped, aval.identity, aval.f)
+
+def _unmap_accumulator(size, axis, explicit_mesh_axis, aval):
+  unmapped = core.unmapped_aval(size, axis, aval.inner_aval, explicit_mesh_axis)
+  return AbstractAccumulator(unmapped, aval.identity, aval.f)
+
+core.aval_mapping_handlers[AbstractAccumulator] = (_map_accumulator, _unmap_accumulator)
+
+core.Tracer.accumulate = lambda self, val, idx: self.aval._accumulate(self, val, idx)

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -500,6 +500,7 @@ class BatchTrace(Trace):
     assert isinstance(axis_data, AxisData)
     self.axis_data = axis_data
     self.tag = tag
+    self.accumulator_states = {}
 
   def to_batch_info(self, val):
     if isinstance(val, BatchTracer) and val._trace.tag is self.tag:
@@ -512,6 +513,9 @@ class BatchTrace(Trace):
       p.abstract_eval(*(map(core.get_aval, tracers)), **params)
     vals_in, dims_in = unzip2(map(self.to_batch_info, tracers))
     args_not_mapped = all(bdim is not_mapped for bdim in dims_in)
+    # TODO: mwhittaker - Check against accumulate_p, but avoid cyclic imports.
+    if p.name == "accumulate":
+      params['trace'] = self
     if p in fancy_primitive_batchers:
       if (args_not_mapped
           and p in skippable_batchers
@@ -523,7 +527,8 @@ class BatchTrace(Trace):
         with core.set_current_trace(self.parent_trace):
           val_out, dim_out = fancy_primitive_batchers[p](
               self.axis_data, vals_in, dims_in, **params)
-    elif args_not_mapped:
+    # TODO: mwhittaker - Check against accumulate_p, but avoid cyclic imports.
+    elif p.name != "accumulate" and args_not_mapped:
       # no-op shortcut
       return p.bind_with_trace(self.parent_trace, vals_in, params)
     elif p in primitive_batchers:
@@ -661,6 +666,14 @@ def _batch_inner(f: Callable, axis_data, out_dim_dests, tag, in_dims, *in_vals):
       out_dim_dests = out_dim_dests() if callable(out_dim_dests) else out_dim_dests
       out_vals = map(partial(from_elt, trace, axis_data.size, axis_data.explicit_mesh_axis),
                      range(len(outs)), outs, out_dim_dests)
+
+      # Reduce accumulators.
+      with core.set_current_trace(parent_trace):
+        for ref, state in trace.accumulator_states.items():
+          aval = ref.aval
+          from jax import lax  # pytype: disable=import-error
+          reduced = lax.reduce(state[...], aval.identity, aval.f, [0])
+          aval._accumulate(ref, reduced, Ellipsis)
   return out_vals, trace
 
 # NOTE: This divides the in_axes by the tile_size and multiplies the out_axes by it.

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -672,7 +672,7 @@ def _batch_inner(f: Callable, axis_data, out_dim_dests, tag, in_dims, *in_vals):
         for ref, state in trace.accumulator_states.items():
           aval = ref.aval
           from jax import lax  # pytype: disable=import-error
-          reduced = lax.reduce(state[...], aval.identity, aval.f, [0])
+          reduced = lax.reduce(state[...], aval._identity(), aval._f(), [0])
           aval._accumulate(ref, reduced, Ellipsis)
   return out_vals, trace
 

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1734,7 +1734,8 @@ def make_jaxpr_effects(constvars, invars, outvars, eqns) -> effects.Effects:
   all_vars = {v: i for i, v in enumerate(it.chain(constvars, invars))}
   mut_arrays = set()
   for eqn in eqns:
-    if eqn.primitive is core.mutable_array_p:
+    # TODO: mwhittaker - Check against accumulator_p, but avoid cyclic imports.
+    if eqn.primitive is core.mutable_array_p or eqn.primitive.name == "accumulator":
       outvar, = eqn.outvars
       all_vars[outvar] = None  # type: ignore
       mut_arrays.add(outvar)

--- a/jax/_src/state/discharge.py
+++ b/jax/_src/state/discharge.py
@@ -148,7 +148,8 @@ def _eval_jaxpr_discharge_state(
     with source_info_util.user_context(
         traceback, name_stack=name_stack), eqn.ctx.manager:
       should_discharge = [id(v.aval) in refs_to_discharge for v in eqn.invars]
-      if eqn.primitive is core.mutable_array_p:
+      # TODO: mwhittaker - Check against accumulator_p, but avoid cyclic imports.
+      if eqn.primitive is core.mutable_array_p or eqn.primitive.name == "accumulator":
         [invar], [outvar] = eqn.invars, eqn.outvars
         ans = env.read(invar)
         refs_to_discharge.add(id(outvar.aval))

--- a/tests/accumulator_test.py
+++ b/tests/accumulator_test.py
@@ -22,7 +22,7 @@ import numpy as np
 class AccumulatorTest(jtu.JaxTestCase):
   def test_accumulate(self):
     x = jnp.array([0., 0., 0.])
-    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(x, "add")
     self.assertAllClose(acc[...], x)
 
     acc.at[...].accumulate(x)
@@ -36,7 +36,7 @@ class AccumulatorTest(jtu.JaxTestCase):
       acc.at[...].accumulate(x)
       acc.at[...].accumulate(x)
     x = jnp.arange(3.0)
-    acc = accumulator.accumulator(x, 0, jax.lax.add)
+    acc = accumulator.accumulator(x, "add")
     jax.vmap(f)(acc, x)
     self.assertAllClose(acc[...], x + x + x)
 
@@ -46,13 +46,13 @@ class AccumulatorTest(jtu.JaxTestCase):
       acc.at[...].accumulate(y)
     x = jnp.arange(3.0)
     y = jnp.float32(1.0)
-    acc = accumulator.accumulator(x, 0, jax.lax.add)
+    acc = accumulator.accumulator(x, "add")
     jax.vmap(f, in_axes=[0, None])(acc, y)
     self.assertAllClose(acc[...], x + y + y)
 
   def test_vmap_unbatched_accumulator_batched_data(self):
     x = jnp.arange(3.0)
-    acc = accumulator.accumulator(x, 0, jax.lax.add)
+    acc = accumulator.accumulator(x, "add")
     def f(y):
       acc.at[...].accumulate(y)
       acc.at[...].accumulate(y)
@@ -63,7 +63,7 @@ class AccumulatorTest(jtu.JaxTestCase):
   def test_vmap_unbatched_accumulator_unbatched_data(self):
     x = jnp.arange(3.0)
     y = jnp.arange(3.0)
-    acc = accumulator.accumulator(x, 0, jax.lax.add)
+    acc = accumulator.accumulator(x, "add")
     def f(_):
       acc.at[...].accumulate(y)
       acc.at[...].accumulate(y)
@@ -77,7 +77,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     j = jnp.array([[2, 1, 0]] * 3)
 
     # Basic index.
-    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(x, "add")
     def f(acc):
       acc.at[1, 1].accumulate(y[1, 1])
     jax.vmap(f)(acc)
@@ -88,7 +88,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     self.assertAllClose(acc[...], want)
 
     # Unbatched index.
-    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(x, "add")
     def f(acc):
       acc.at[i, 0].accumulate(y[i, 0])
     jax.vmap(f)(acc)
@@ -99,7 +99,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     self.assertAllClose(acc[...], want)
 
     # Batched index.
-    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(x, "add")
     def f(acc, j):
       acc.at[j, 0].accumulate(y[j, 0])
     jax.vmap(f)(acc, j)
@@ -110,7 +110,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     self.assertAllClose(acc[...], want)
 
     # Mixed index.
-    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(x, "add")
     def f(acc, j):
       acc.at[i, j].accumulate(y[i, j])
     jax.vmap(f)(acc, j)
@@ -127,7 +127,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     j = jnp.array([[2, 1, 0]] * 3)
 
     # Basic index.
-    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(y, "add")
     def f(x):
       acc.at[1, 1].accumulate(y[1, 1])
     jax.vmap(f)(x)
@@ -138,7 +138,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     self.assertAllClose(acc[...], want)
 
     # Unbatched index.
-    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(y, "add")
     def f(x):
       acc.at[i, 0].accumulate(y[i, 0])
     jax.vmap(f)(x)
@@ -149,7 +149,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     self.assertAllClose(acc[...], want)
 
     # Batched index.
-    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(y, "add")
     def f(x, j):
       acc.at[j, 0].accumulate(y[j, 0])
     jax.vmap(f)(x, j)
@@ -160,7 +160,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     self.assertAllClose(acc[...], want)
 
     # Mixed index.
-    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(y, "add")
     def f(x, j):
       acc.at[i, j].accumulate(y[i, j])
     jax.vmap(f)(x, j)
@@ -176,7 +176,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     j = jnp.array([[2, 1, 0]] * 3)
 
     # Basic index.
-    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(x, "add")
     def f(acc, x):
       acc.at[1, 1].accumulate(x[1, 1])
     jax.vmap(f)(acc, x)
@@ -187,7 +187,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     self.assertAllClose(acc[...], want)
 
     # Unbatched index.
-    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(x, "add")
     def f(acc, x):
       acc.at[i, 0].accumulate(x[i, 0])
     jax.vmap(f)(acc, x)
@@ -198,7 +198,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     self.assertAllClose(acc[...], want)
 
     # Batched index.
-    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(x, "add")
     def f(acc, x, j):
       acc.at[j, 0].accumulate(x[j, 0])
     jax.vmap(f)(acc, x, j)
@@ -209,7 +209,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     self.assertAllClose(acc[...], want)
 
     # Mixed index.
-    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(x, "add")
     def f(acc, x, j):
       acc.at[i, j].accumulate(x[i, j])
     jax.vmap(f)(acc, x, j)
@@ -226,7 +226,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     j = jnp.array([[2, 1, 0]] * 3)
 
     # Basic index.
-    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(y, "add")
     def f(x):
       acc.at[1, 1].accumulate(x[1, 1])
     jax.vmap(f)(x)
@@ -237,7 +237,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     self.assertAllClose(acc[...], want)
 
     # Unbatched index.
-    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(y, "add")
     def f(x):
       acc.at[i, 0].accumulate(x[i, 0])
     jax.vmap(f)(x)
@@ -248,7 +248,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     self.assertAllClose(acc[...], want)
 
     # Batched index.
-    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(y, "add")
     def f(x, j):
       acc.at[j, 0].accumulate(x[j, 0])
     jax.vmap(f)(x, j)
@@ -259,7 +259,7 @@ class AccumulatorTest(jtu.JaxTestCase):
     self.assertAllClose(acc[...], want)
 
     # Mixed index.
-    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    acc = accumulator.accumulator(y, "add")
     def f(x, j):
       acc.at[i, j].accumulate(x[i, j])
     jax.vmap(f)(x, j)
@@ -269,73 +269,58 @@ class AccumulatorTest(jtu.JaxTestCase):
       want[i, j[k]] += x[k, i, j[k]]
     self.assertAllClose(acc[...], want)
 
-  def _identity(self, f, dtype):
+  def _get_f(self, f):
     match f:
-      case jax.lax.add:
-        return jax._src.lax.lax._get_sum_identity(dtype)
-      case jax.lax.mul:
-        return jax._src.lax.lax._get_prod_identity(dtype)
-      case jax.lax.bitwise_or:
-        return jax._src.lax.lax._get_bitwise_or_identity(dtype)
-      case jax.lax.bitwise_and:
-        return jax._src.lax.lax._get_bitwise_and_identity(dtype)
-      case jax.lax.bitwise_xor:
-        return jax._src.lax.lax._get_bitwise_or_identity(dtype)
-      case jax.lax.max:
-        return jax._src.lax.lax._get_max_identity(dtype)
-      case jax.lax.min:
-        return jax._src.lax.lax._get_min_identity(dtype)
-      case _:
-        raise ValueError(f'Unexpected function {f}')
+      case "add": return jax.lax.add
+      case "mul": return jax.lax.mul
+      case "bitwise_or": return jax.lax.bitwise_or
+      case "bitwise_and": return jax.lax.bitwise_and
+      case "bitwise_xor": return jax.lax.bitwise_xor
+      case "max": return jax.lax.max
+      case "min": return jax.lax.min
+      case _: raise ValueError(f'Unexpected function {f}')
 
   def test_monoids(self):
     x = jnp.arange(3.0)
     y = x + x
-    for f in [jax.lax.add, jax.lax.mul, jax.lax.max, jax.lax.min]:
-      acc = accumulator.accumulator(x, self._identity(f, x.dtype), f)
+    for f in ["add", "mul", "max", "min"]:
+      acc = accumulator.accumulator(x, f)
       acc.at[...].accumulate(y)
+      f = self._get_f(f)
       self.assertAllClose(acc[...], f(x, y))
 
     x = jnp.arange(3)
     y = x + x
-    for f in [jax.lax.bitwise_or, jax.lax.bitwise_and, jax.lax.bitwise_xor]:
-      acc = accumulator.accumulator(x, self._identity(f, x.dtype), f)
+    for f in ["bitwise_or", "bitwise_and", "bitwise_xor"]:
+      acc = accumulator.accumulator(x, f)
       acc.at[...].accumulate(y)
+      f = self._get_f(f)
       self.assertAllClose(acc[...], f(x, y))
 
   def test_monoids_in_vmap(self):
     x = jnp.arange(3.0)
     y = jnp.arange(9.0).reshape(3, 3)
-    for f in [jax.lax.add, jax.lax.mul, jax.lax.max, jax.lax.min]:
-      acc = accumulator.accumulator(x, self._identity(f, x.dtype), f)
+    for f in ["add", "mul", "max", "min"]:
+      acc = accumulator.accumulator(x, f)
       def g(y):
         acc.at[...].accumulate(y)
       jax.vmap(g)(y)
+      f = self._get_f(f)
       self.assertAllClose(acc[...], f(f(f(x, y[0]), y[1]), y[2]))
 
     x = jnp.arange(3)
     y = jnp.arange(9).reshape(3, 3)
-    for f in [jax.lax.bitwise_or, jax.lax.bitwise_and, jax.lax.bitwise_xor]:
-      acc = accumulator.accumulator(x, self._identity(f, x.dtype), f)
+    for f in ["bitwise_or", "bitwise_and", "bitwise_xor"]:
+      acc = accumulator.accumulator(x, f)
       def g(y):
         acc.at[...].accumulate(y)
       jax.vmap(g)(y)
+      f = self._get_f(f)
       self.assertAllClose(acc[...], f(f(f(x, y[0]), y[1]), y[2]))
 
-  def test_custom_monoid(self):
-    x = jnp.arange(1, 10).reshape(3, 3)
-    y = jnp.arange(1, 4)
-    def take_right(x, y):
-      return jnp.where(jnp.logical_or(x == 0, y == 0), x + y, y)
-    acc = accumulator.accumulator(y, 0, take_right)
-    acc.at[...].accumulate(y)
-    def f(x):
-      acc.at[...].accumulate(x)
-      acc.at[...].accumulate(100*x)
-      acc.at[...].accumulate(10*x)
-    jax.vmap(f)(x)
-    self.assertAllClose(acc[...], 10 * x[2])
-
+  def test_invalid_monoid(self):
+    with self.assertRaisesRegex(ValueError, "Unrecognized"):
+      accumulator.accumulator(jnp.ones(42), "foo")
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/accumulator_test.py
+++ b/tests/accumulator_test.py
@@ -1,0 +1,341 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+from jax._src import accumulator
+from jax._src import test_util as jtu
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+class AccumulatorTest(jtu.JaxTestCase):
+  def test_accumulate(self):
+    x = jnp.array([0., 0., 0.])
+    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    self.assertAllClose(acc[...], x)
+
+    acc.at[...].accumulate(x)
+    self.assertAllClose(acc[...], x + x)
+
+    acc.at[...].accumulate(x)
+    self.assertAllClose(acc[...], x + x + x)
+
+  def test_vmap_batched_accumulator_batched_data(self):
+    def f(acc, x):
+      acc.at[...].accumulate(x)
+      acc.at[...].accumulate(x)
+    x = jnp.arange(3.0)
+    acc = accumulator.accumulator(x, 0, jax.lax.add)
+    jax.vmap(f)(acc, x)
+    self.assertAllClose(acc[...], x + x + x)
+
+  def test_vmap_batched_accumulator_unbatched_data(self):
+    def f(acc, y):
+      acc.at[...].accumulate(y)
+      acc.at[...].accumulate(y)
+    x = jnp.arange(3.0)
+    y = jnp.float32(1.0)
+    acc = accumulator.accumulator(x, 0, jax.lax.add)
+    jax.vmap(f, in_axes=[0, None])(acc, y)
+    self.assertAllClose(acc[...], x + y + y)
+
+  def test_vmap_unbatched_accumulator_batched_data(self):
+    x = jnp.arange(3.0)
+    acc = accumulator.accumulator(x, 0, jax.lax.add)
+    def f(y):
+      acc.at[...].accumulate(y)
+      acc.at[...].accumulate(y)
+    y = jnp.arange(9.0).reshape(3, 3)
+    jax.vmap(f)(y)
+    self.assertAllClose(acc[...], x + jnp.sum(y, axis=0) + jnp.sum(y, axis=0))
+
+  def test_vmap_unbatched_accumulator_unbatched_data(self):
+    x = jnp.arange(3.0)
+    y = jnp.arange(3.0)
+    acc = accumulator.accumulator(x, 0, jax.lax.add)
+    def f(_):
+      acc.at[...].accumulate(y)
+      acc.at[...].accumulate(y)
+    jax.vmap(f)(x)
+    self.assertAllClose(acc[...], x + 6 * y)
+
+  def test_indexing_batched_accumulator_unbatched_val(self):
+    x = jnp.arange(27.0).reshape(3, 3, 3)
+    y = jnp.arange(9.0).reshape(3, 3)
+    i = jnp.array([2, 1, 0])
+    j = jnp.array([[2, 1, 0]] * 3)
+
+    # Basic index.
+    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    def f(acc):
+      acc.at[1, 1].accumulate(y[1, 1])
+    jax.vmap(f)(acc)
+
+    want = np.array(x)
+    for k in range(x.shape[0]):
+      want[k, 1, 1] += y[1, 1]
+    self.assertAllClose(acc[...], want)
+
+    # Unbatched index.
+    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    def f(acc):
+      acc.at[i, 0].accumulate(y[i, 0])
+    jax.vmap(f)(acc)
+
+    want = np.array(x)
+    for k in range(x.shape[0]):
+      want[k, i, 0] += y[i, 0]
+    self.assertAllClose(acc[...], want)
+
+    # Batched index.
+    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    def f(acc, j):
+      acc.at[j, 0].accumulate(y[j, 0])
+    jax.vmap(f)(acc, j)
+
+    want = np.array(x)
+    for k in range(x.shape[0]):
+      want[k, j[k], 0] += y[j[k], 0]
+    self.assertAllClose(acc[...], want)
+
+    # Mixed index.
+    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    def f(acc, j):
+      acc.at[i, j].accumulate(y[i, j])
+    jax.vmap(f)(acc, j)
+
+    want = np.array(x)
+    for k in range(x.shape[0]):
+      want[k, i, j[k]] += y[i, j[k]]
+    self.assertAllClose(acc[...], want)
+
+  def test_indexing_unbatched_accumulator_unbatched_val(self):
+    x = jnp.arange(27.0).reshape(3, 3, 3)
+    y = jnp.arange(9.0).reshape(3, 3)
+    i = jnp.array([2, 1, 0])
+    j = jnp.array([[2, 1, 0]] * 3)
+
+    # Basic index.
+    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    def f(x):
+      acc.at[1, 1].accumulate(y[1, 1])
+    jax.vmap(f)(x)
+
+    want = np.array(y)
+    for _ in range(x.shape[0]):
+      want[1, 1] += y[1, 1]
+    self.assertAllClose(acc[...], want)
+
+    # Unbatched index.
+    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    def f(x):
+      acc.at[i, 0].accumulate(y[i, 0])
+    jax.vmap(f)(x)
+
+    want = np.array(y)
+    for _ in range(x.shape[0]):
+      want[i, 0] += y[i, 0]
+    self.assertAllClose(acc[...], want)
+
+    # Batched index.
+    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    def f(x, j):
+      acc.at[j, 0].accumulate(y[j, 0])
+    jax.vmap(f)(x, j)
+
+    want = np.array(y)
+    for k in range(x.shape[0]):
+      want[j[k], 0] += y[j[k], 0]
+    self.assertAllClose(acc[...], want)
+
+    # Mixed index.
+    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    def f(x, j):
+      acc.at[i, j].accumulate(y[i, j])
+    jax.vmap(f)(x, j)
+
+    want = np.array(y)
+    for k in range(x.shape[0]):
+      want[i, j[k]] += y[i, j[k]]
+    self.assertAllClose(acc[...], want)
+
+  def test_indexing_batched_accumulator_batched_val(self):
+    x = jnp.arange(27.0).reshape(3, 3, 3)
+    i = jnp.array([2, 1, 0])
+    j = jnp.array([[2, 1, 0]] * 3)
+
+    # Basic index.
+    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    def f(acc, x):
+      acc.at[1, 1].accumulate(x[1, 1])
+    jax.vmap(f)(acc, x)
+
+    want = np.array(x)
+    for k in range(x.shape[0]):
+      want[k, 1, 1] += x[k, 1, 1]
+    self.assertAllClose(acc[...], want)
+
+    # Unbatched index.
+    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    def f(acc, x):
+      acc.at[i, 0].accumulate(x[i, 0])
+    jax.vmap(f)(acc, x)
+
+    want = np.array(x)
+    for k in range(x.shape[0]):
+      want[k, i, 0] += x[k, i, 0]
+    self.assertAllClose(acc[...], want)
+
+    # Batched index.
+    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    def f(acc, x, j):
+      acc.at[j, 0].accumulate(x[j, 0])
+    jax.vmap(f)(acc, x, j)
+
+    want = np.array(x)
+    for k in range(x.shape[0]):
+      want[k, j[k], 0] += x[k, j[k], 0]
+    self.assertAllClose(acc[...], want)
+
+    # Mixed index.
+    acc = accumulator.accumulator(x, 0.0, jax.lax.add)
+    def f(acc, x, j):
+      acc.at[i, j].accumulate(x[i, j])
+    jax.vmap(f)(acc, x, j)
+
+    want = np.array(x)
+    for k in range(x.shape[0]):
+      want[k, i, j[k]] += x[k, i, j[k]]
+    self.assertAllClose(acc[...], want)
+
+  def test_indexing_unbatched_accumulator_batched_val(self):
+    x = jnp.arange(27.0).reshape(3, 3, 3)
+    y = jnp.arange(9.0).reshape(3, 3)
+    i = jnp.array([2, 1, 0])
+    j = jnp.array([[2, 1, 0]] * 3)
+
+    # Basic index.
+    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    def f(x):
+      acc.at[1, 1].accumulate(x[1, 1])
+    jax.vmap(f)(x)
+
+    want = np.array(y)
+    for k in range(x.shape[0]):
+      want[1, 1] += x[k, 1, 1]
+    self.assertAllClose(acc[...], want)
+
+    # Unbatched index.
+    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    def f(x):
+      acc.at[i, 0].accumulate(x[i, 0])
+    jax.vmap(f)(x)
+
+    want = np.array(y)
+    for k in range(x.shape[0]):
+      want[i, 0] += x[k, i, 0]
+    self.assertAllClose(acc[...], want)
+
+    # Batched index.
+    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    def f(x, j):
+      acc.at[j, 0].accumulate(x[j, 0])
+    jax.vmap(f)(x, j)
+
+    want = np.array(y)
+    for k in range(x.shape[0]):
+      want[j[k], 0] += x[k, j[k], 0]
+    self.assertAllClose(acc[...], want)
+
+    # Mixed index.
+    acc = accumulator.accumulator(y, 0.0, jax.lax.add)
+    def f(x, j):
+      acc.at[i, j].accumulate(x[i, j])
+    jax.vmap(f)(x, j)
+
+    want = np.array(y)
+    for k in range(x.shape[0]):
+      want[i, j[k]] += x[k, i, j[k]]
+    self.assertAllClose(acc[...], want)
+
+  def _identity(self, f, dtype):
+    match f:
+      case jax.lax.add:
+        return jax._src.lax.lax._get_sum_identity(dtype)
+      case jax.lax.mul:
+        return jax._src.lax.lax._get_prod_identity(dtype)
+      case jax.lax.bitwise_or:
+        return jax._src.lax.lax._get_bitwise_or_identity(dtype)
+      case jax.lax.bitwise_and:
+        return jax._src.lax.lax._get_bitwise_and_identity(dtype)
+      case jax.lax.bitwise_xor:
+        return jax._src.lax.lax._get_bitwise_or_identity(dtype)
+      case jax.lax.max:
+        return jax._src.lax.lax._get_max_identity(dtype)
+      case jax.lax.min:
+        return jax._src.lax.lax._get_min_identity(dtype)
+      case _:
+        raise ValueError(f'Unexpected function {f}')
+
+  def test_monoids(self):
+    x = jnp.arange(3.0)
+    y = x + x
+    for f in [jax.lax.add, jax.lax.mul, jax.lax.max, jax.lax.min]:
+      acc = accumulator.accumulator(x, self._identity(f, x.dtype), f)
+      acc.at[...].accumulate(y)
+      self.assertAllClose(acc[...], f(x, y))
+
+    x = jnp.arange(3)
+    y = x + x
+    for f in [jax.lax.bitwise_or, jax.lax.bitwise_and, jax.lax.bitwise_xor]:
+      acc = accumulator.accumulator(x, self._identity(f, x.dtype), f)
+      acc.at[...].accumulate(y)
+      self.assertAllClose(acc[...], f(x, y))
+
+  def test_monoids_in_vmap(self):
+    x = jnp.arange(3.0)
+    y = jnp.arange(9.0).reshape(3, 3)
+    for f in [jax.lax.add, jax.lax.mul, jax.lax.max, jax.lax.min]:
+      acc = accumulator.accumulator(x, self._identity(f, x.dtype), f)
+      def g(y):
+        acc.at[...].accumulate(y)
+      jax.vmap(g)(y)
+      self.assertAllClose(acc[...], f(f(f(x, y[0]), y[1]), y[2]))
+
+    x = jnp.arange(3)
+    y = jnp.arange(9).reshape(3, 3)
+    for f in [jax.lax.bitwise_or, jax.lax.bitwise_and, jax.lax.bitwise_xor]:
+      acc = accumulator.accumulator(x, self._identity(f, x.dtype), f)
+      def g(y):
+        acc.at[...].accumulate(y)
+      jax.vmap(g)(y)
+      self.assertAllClose(acc[...], f(f(f(x, y[0]), y[1]), y[2]))
+
+  def test_custom_monoid(self):
+    x = jnp.arange(1, 10).reshape(3, 3)
+    y = jnp.arange(1, 4)
+    def take_right(x, y):
+      return jnp.where(jnp.logical_or(x == 0, y == 0), x + y, y)
+    acc = accumulator.accumulator(y, 0, take_right)
+    acc.at[...].accumulate(y)
+    def f(x):
+      acc.at[...].accumulate(x)
+      acc.at[...].accumulate(100*x)
+      acc.at[...].accumulate(10*x)
+    jax.vmap(f)(x)
+    self.assertAllClose(acc[...], 10 * x[2])
+
+
+if __name__ == '__main__':
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Motivation
----------

Consider the following code.

```python
m = jax._src.core.mutable_array(jnp.float32(0))
def f(x):
    m[...] += x
    m[...] *= x
jax.vmap(f)(jnp.array([2., 3., 4.]))
```

Recall that `vmap` has "for-loop-like semantics". The code should behave identically to the following:

```python
for x in jnp.array([2., 3., 4.]):
    m[...] += x
    m[...] *= x
```

However, implementing such semantics efficiently in the presence of mutable arrays is difficult. Recall that the current implementation of `vmap` vectorizes operations in a single call to `f`; it does not repeatedly call `f`. This trick doesn't work with arbitrary mutation.

So how can we mutate stuff inside a `vmap`? Enter accumulators.

Accumulators
------------

Accumulators are like mutable arrays, but they cannot be arbitrarily read from or written to inside a `vmap`. Instead we can only accumulate into them. Here, accumulation is like running `+=`.

```python
 # Construct an accumulator from an array. jax.lax.add is how we
 # accumulate, and 0.0 is the identity element of add.
 x = jnp.array([1., 2., 3.])
 acc = jax._src.accumulator.accumulator(x, 0.0, jax.lax.add)

 # Accumulate (+=) into the array.
 acc.at[...].accumulate(x)
 acc[...] # [2., 4., 6.]
```

Unlike mutable arrays, accumulators can be efficiently accumulated into inside a `vmap`:

```python
acc = jax._src.accumulator.accumulator(jnp.float32(0), 0.0, jax.lax.add)
def f(x):
    acc[...].accumulate(x)
    acc[...].accumulate(x)
jax.vmap(f)(jnp.array([2., 3., 4.]))
```

Accumulators are constructed with an element `id` and accumulation function `f`. `id` and `f` must form a monoid. That is:

- `id` is an identity of `f`: `f(id, x) == x == f(x, id)`.
- `f` is associative: `f(f(x, y), z) == f(x, f(y, z))`.

Example monoids are add, multiplyt, min, max, and so on. Note that `f` does not have to be commutative.

Future Work
-----------

This PR is a prototype of accumulators. I tested them with `vmap` but not with much else. They aren't ready to use for real yet.