### PR TITLE
[jaxpr consts] Fix AOT execution with 64-bit captured constants

### DIFF
--- a/docs/internals/constants.md
+++ b/docs/internals/constants.md
@@ -153,6 +153,11 @@ itself does not contain them, and needs to take them as const args.
 Whoever is going to deserialize the cached executable will have to pass
 the const args.
 
+In AOT mode, the lowering and execution may
+use different values of the `jax_enable_x64` configuration value.
+If the constants are 64-bit `ndarray` we must use the same value
+of `jax_enable_x64` for lowering and execution.
+
 ## Previous implementation
 
 This describes the current way we handle closed-over constants, as

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -3255,7 +3255,7 @@ class MeshExecutable(stages.Executable):
       return None
 
     def aot_cache_miss(*args, **kwargs):
-      # args do not include the const args
+      # args do not include the const args.
       # See https://docs.jax.dev/en/latest/internals/constants.html.
       outs, out_flat, args_flat = stages.Compiled.call(params, *args, **kwargs)
       out_flat, out_tree_dispatch = reflatten_outputs_for_dispatch(
@@ -3319,7 +3319,9 @@ def check_arg_avals_for_call(ref_avals, arg_avals,
       num_mismatch_str = "The"
     raise TypeError(
         "Argument types differ from the types for which this computation was "
-        f"compiled. {num_mismatch_str} mismatches are:\n{str_errors}")
+        "compiled. Perhaps you are calling the compiled executable with a "
+        "different enable_x64 mode than when it was AOT compiled? "
+        f"{num_mismatch_str} mismatches are:\n{str_errors}")
 
 
 def _get_metadata_jit_pmap(local_devices, num_in_shardings, num_out_shardings):


### PR DESCRIPTION
Account for the posibility that in AOT the code can be lowered with a different value of the `jax_enable_x64` configuration value than at execution time.

Add a test, and improve the error message in case of a mismatch.

This should have no effect while JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS=False (the current default).