### PR TITLE
Document and test order and stability properties of lax.top_k.

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3327,6 +3327,11 @@ def top_k(operand: ArrayLike, k: int) -> tuple[Array, Array]:
     - ``values`` is an array containing the top k values along the last axis.
     - ``indices`` is an array containing the indices corresponding to values.
 
+  ``values[..., i]`` is the ``i``-th largest entry in ``operand`` along the last
+  axis, and its index is ``indices[..., i]``.
+
+  If two elements are equal, the lower-index element appears first.
+
   See also:
     - :func:`jax.lax.approx_max_k`
     - :func:`jax.lax.approx_min_k`

--- a/jax/_src/lax_reference.py
+++ b/jax/_src/lax_reference.py
@@ -528,3 +528,10 @@ def _reducer_from_pyfunc(py_binop, init_val):
       result[out_idx] = py_binop(result[out_idx], operand[idx])
     return result
   return reducer
+
+def top_k(operand, k):
+  indices = operand.shape[-1] - 1 - np.argsort(operand[..., ::-1], kind="stable").astype(np.int32)[..., ::-1]
+  values = np.take_along_axis(operand, indices, axis=-1)
+  indices = indices[..., :k]
+  values = values[..., :k]
+  return values, indices


### PR DESCRIPTION
Document and test the order and stability properties of [`lax.top_k`](https://docs.jax.dev/en/latest/_autosummary/jax.lax.top_k.html).

Fixes https://github.com/jax-ml/jax/issues/27594.