### PR TITLE
Let axis=-1 by default in take_along_axis to match NumPy.

### DIFF
--- a/jax/_src/numpy/indexing.py
+++ b/jax/_src/numpy/indexing.py
@@ -207,7 +207,7 @@ def _normalize_index(index, axis_size):
 def take_along_axis(
     arr: ArrayLike,
     indices: ArrayLike,
-    axis: int | None,
+    axis: int | None = -1,
     mode: str | slicing.GatherScatterMode | None = None,
     fill_value: StaticScalar | None = None,
 ) -> Array:

--- a/jax/numpy/__init__.pyi
+++ b/jax/numpy/__init__.pyi
@@ -918,7 +918,7 @@ def take(
 def take_along_axis(
     arr: ArrayLike,
     indices: ArrayLike,
-    axis: int | None,
+    axis: int | None = ...,
     mode: str | GatherScatterMode | None = ...,
     fill_value: StaticScalar | None = None,
 ) -> Array: ...

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -4810,6 +4810,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_op, args_maker)
     self._CompileAndCheck(jnp_one_hot_op, args_maker)
 
+  def testTakeAlongAxisDefaultAxis(self):
+    arr = jtu.rand_default(self.rng())((10, 20), np.float32)
+    indices = jtu.rand_int(self.rng(), 0, 100)((10, 30), np.uint8)
+    q0 = jnp.take_along_axis(arr, indices, axis=-1)
+    q1 = jnp.take_along_axis(arr, indices)
+    np.testing.assert_array_equal(q0, q1)
+
   def testTakeAlongAxisWithUint8IndicesDoesNotOverflow(self):
     # https://github.com/jax-ml/jax/issues/5088
     h = jtu.rand_default(self.rng())((256, 256, 100), np.float32)


### PR DESCRIPTION
Let `axis=-1` by default in [`take_along_axis`](https://docs.jax.dev/en/latest/_autosummary/jax.numpy.take_along_axis.html) to match [NumPy](https://numpy.org/doc/stable/reference/generated/numpy.take_along_axis.html).

This change happened in NumPy 2.3.0, as stated [here](https://numpy.org/doc/stable/release/2.3.0-notes.html):

> The parameter `axis` in `numpy.take_along_axis` function has now a default value of `-1`. ([gh-28615](https://github.com/numpy/numpy/pull/28615))
