### PR TITLE
[test] use explicit version checks rather than hasattr checks

### DIFF
--- a/tests/lax_metal_test.py
+++ b/tests/lax_metal_test.py
@@ -1312,7 +1312,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jnp_fun = lambda x: jnp.asarray(x).mT
     else:
       jnp_fun = jnp.matrix_transpose
-    if hasattr(np, 'matrix_transpose'):
+    if jtu.numpy_version() >= (2, 0, 0):
       np_fun = np.matrix_transpose
     else:
       np_fun = lambda x: np.swapaxes(x, -1, -2)
@@ -3785,7 +3785,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testAstype(self, from_dtype, to_dtype, use_method):
     rng = self.rng()
     args_maker = lambda: [rng.randn(3, 4).astype(from_dtype)]
-    if (not use_method) and hasattr(np, "astype"):  # Added in numpy 2.0
+    if (not use_method) and jtu.numpy_version() >= (2, 0, 0):
       np_op = lambda x: np.astype(x, to_dtype)
     else:
       np_op = lambda x: np.asarray(x).astype(to_dtype)
@@ -4296,10 +4296,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       return x, i
 
     jnp_op = lambda x, i: jnp.take_along_axis(x, i, axis=axis)
-
-    if hasattr(np, "take_along_axis"):
-      np_op = lambda x, i: np.take_along_axis(x, i, axis=axis)
-      self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
+    np_op = lambda x, i: np.take_along_axis(x, i, axis=axis)
+    self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
     self._CompileAndCheck(jnp_op, args_maker)
 
   def testTakeAlongAxisWithUint8IndicesDoesNotOverflow(self):

--- a/tests/lax_numpy_operators_test.py
+++ b/tests/lax_numpy_operators_test.py
@@ -326,8 +326,7 @@ JAX_BITWISE_OP_RECORDS = [
     op_record("bitwise_xor", 2, int_dtypes + unsigned_dtypes, all_shapes,
               jtu.rand_fullrange, []),
 ]
-if hasattr(np, "bitwise_count"):
-  # Numpy versions after 1.26
+if jtu.numpy_version() >= (2, 0, 0):
   JAX_BITWISE_OP_RECORDS.append(
     op_record("bitwise_count", 1, int_dtypes, all_shapes, jtu.rand_fullrange, []))
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1539,7 +1539,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jnp_fun = lambda x: jnp.asarray(x).mT
     else:
       jnp_fun = jnp.matrix_transpose
-    if hasattr(np, 'matrix_transpose'):
+    if jtu.numpy_version() >= (2, 0, 0):
       np_fun = np.matrix_transpose
     else:
       np_fun = lambda x: np.swapaxes(x, -1, -2)
@@ -4234,7 +4234,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testAstype(self, from_dtype, to_dtype, use_method):
     rng = self.rng()
     args_maker = lambda: [rng.randn(3, 4).astype(from_dtype)]
-    if (not use_method) and hasattr(np, "astype"):  # Added in numpy 2.0
+    if (not use_method) and jtu.numpy_version() >= (2, 0, 0):
       np_op = lambda x: np.astype(x, to_dtype)
     else:
       np_op = lambda x: np.asarray(x).astype(to_dtype)
@@ -4252,7 +4252,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testAstypeBool(self, from_dtype, use_method, to_dtype='bool'):
     rng = jtu.rand_some_zero(self.rng())
     args_maker = lambda: [rng((3, 4), from_dtype)]
-    if (not use_method) and hasattr(np, "astype"):  # Added in numpy 2.0
+    if (not use_method) and jtu.numpy_version() >= (2, 0, 0):
       np_op = lambda x: np.astype(x, to_dtype)
     else:
       np_op = lambda x: np.asarray(x).astype(to_dtype)

--- a/tests/string_array_test.py
+++ b/tests/string_array_test.py
@@ -28,10 +28,10 @@ class StringArrayTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
-    if not hasattr(np.dtypes, "StringDType"):
+    if jtu.numpy_version() < (2, 0, 0):
       self.skipTest(
           "Skipping this test because the numpy.dtype.StringDType is not"
-          " available."
+          " available in NumPy v1.X."
       )
 
   def make_test_string_array(self, device=None):


### PR DESCRIPTION
This is less error-prone, and will be more discoverable for cleanup when the minimum NumPy version is increased.