### PR TITLE
[mutable-arrays] add a custom_vjp discharge rule

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -957,9 +957,10 @@ def _flatten_bwd(f: Callable,
         raise ValueError(msg)
       results.append(Zero(ct.aval))
     else:
-      if (not core.typecompat(a.to_tangent_aval(), a_ := core.get_aval(ct))
-          and not (_temporary_dtype_exception(a, a_) or
-                   _temporary_shape_exception(a, a_))):
+      if (not core.typecompat(a.to_tangent_aval(), a_ := core.get_aval(ct)) and
+          not _ref_typecompat(a.to_tangent_aval(), a_) and
+          not (_temporary_dtype_exception(a, a_) or
+               _temporary_shape_exception(a, a_))):
         msg = ("Custom VJP bwd rule must produce an output with the same "
                "shape/dtypes as the args tuple of the primal function, but at "
                f"output{keystr(kp)} the bwd rule produced an output of "
@@ -969,6 +970,10 @@ def _flatten_bwd(f: Callable,
         raise ValueError(msg)
       results.append(ct)
   return results
+
+def _ref_typecompat(a, a_):
+  return (isinstance(a, AbstractRef) and
+          core.typecompat(a.to_tangent_aval().inner_aval, a_))
 
 # TODO(mattjj): remove both these exceptions to cotangent compatibility check
 def _temporary_dtype_exception(a, a_) -> bool:

--- a/jax/_src/state/types.py
+++ b/jax/_src/state/types.py
@@ -76,6 +76,8 @@ class AccumEffect(RefEffect):
   name: str = "Accum"
 
 effects.control_flow_allowed_effects.add_type(RefEffect)
+effects.custom_derivatives_allowed_effects.add_type(RefEffect)
+effects.custom_derivatives_allowed_effects.add_type(core.InternalMutableArrayEffect)
 effects.partial_eval_kept_effects.add_type(RefEffect)
 
 StateEffect = Union[ReadEffect, WriteEffect, AccumEffect]


### PR DESCRIPTION
The discharge rule discards the AD rule because we only discharge after all AD has happened. At least, that's our current belief!

(I snuck in a prototype way that `custom_vjp` can work with `vjp3`, via the fallback: just return pure values in places corresponding to ref args, and the `backward_pass3` fallback will accumulate them into the refs. We can of course change this behavior if Dougal notices it.)