### PR TITLE
Attempt to fix flaky test

### DIFF
--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -3171,6 +3171,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       gc.collect()
 
     nbufs = lambda: len(jax.live_arrays())
+    gc.collect()
     base = nbufs()
     leak()
     self.assertEqual(base, nbufs())


### PR DESCRIPTION
We are seeing flakyness in lax_control_flow_test::test_cond_memory_leak. The failures are in the conditional `assertEqual(base, nbufs())` of the form `7 != 2` and `8 != 2`. It seems that the value `base` includes too many live buffers. My best guess is that since this started when I added `gc.collect()` inside `leak()`, this may be fixable if we also call `gc.collect()` just before computing `base`.