### PR TITLE
[DOC] Fix link in register_dataclass docstring

### DIFF
--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -967,7 +967,7 @@ def register_dataclass(
       as keywords to the class constructor to create a copy of the object.
       All defined attributes should be listed among ``meta_fields`` or ``data_fields``.
     meta_fields: metadata field names: these are attributes which will be treated as
-      {term}`static` when this pytree is passed to :func:`jax.jit`. ``meta_fields`` is
+      :term:`static` when this pytree is passed to :func:`jax.jit`. ``meta_fields`` is
       optional only if ``nodetype`` is a dataclass, in which case individual fields can
       be marked static via :func:`dataclasses.field` (see examples below).
       Metadata fields *must* be static, hashable, immutable objects, as these objects


### PR DESCRIPTION
Prior to this fix the [register_dataclass doc](https://docs.jax.dev/en/latest/_autosummary/jax.tree_util.register_dataclass.html) renders like this:
<img width="744" height="163" alt="Screenshot 2025-08-14 at 09 13 52" src="https://github.com/user-attachments/assets/261fe199-0717-4ffd-b595-5f13832d9952" />

Afterwards the link renders properly:
<img width="653" height="187" alt="Screenshot 2025-08-14 at 09 16 46" src="https://github.com/user-attachments/assets/3d12089a-b71a-408a-913f-9250606d2991" />
