### PR TITLE
Add reminder to run tests in 64-bit mode to contributing.md.

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -81,6 +81,12 @@ Follow these steps to contribute code:
    pytest -n auto tests/
    ```
 
+   Run them in 64-bit mode as well, by setting the environment variable `JAX_ENABLE_X64=True`:
+
+   ```bash
+   JAX_ENABLE_X64=True pytest -n auto tests/
+   ```
+
    JAX's test suite is quite large, so if you know the specific test file that covers your
    changes, you can limit the tests to that; for example:
 


### PR DESCRIPTION
Add a reminder to run tests in [64-bit mode](https://docs.jax.dev/en/latest/notebooks/Common_Gotchas_in_JAX.html#double-64bit-precision) to the [contributing](https://docs.jax.dev/en/latest/contributing.html) doc.

Context: https://github.com/jax-ml/jax/pull/30995#issuecomment-3188523090