### PR TITLE
Deprecate jax.interpreters.ad.zeros_like_p

### DIFF
--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -33,7 +33,7 @@ from jax._src import source_info_util
 from jax._src.ad_util import (
     add_jaxvals, replace_internal_symbolic_zeros,
     replace_rule_output_symbolic_zeros, Zero, zeros_like_aval, SymbolicZero)
-from jax._src.ad_util import zeros_like_p, add_jaxvals_p  # noqa: F401
+from jax._src.ad_util import add_jaxvals_p
 from jax._src.api_util import flatten_fun, flatten_fun_nokwargs, debug_info
 from jax._src.core import (Trace, Tracer, get_aval, call_p, Primitive, Literal,
                            typeof)

--- a/jax/extend/core/primitives.py
+++ b/jax/extend/core/primitives.py
@@ -32,7 +32,6 @@ from jax._src.dispatch import device_put_p as device_put_p
 from jax._src.interpreters.ad import (
   add_jaxvals_p as add_jaxvals_p,
   custom_lin_p as custom_lin_p,
-  zeros_like_p as zeros_like_p,
 )
 
 from jax._src.interpreters.pxla import xla_pmap_p as xla_pmap_p

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from jax._src import ad_util as _src_ad_util
+
 from jax._src.interpreters.ad import (
   JVPTrace as JVPTrace,
   JVPTracer as JVPTracer,
@@ -64,7 +66,6 @@ from jax._src.interpreters.ad import (
   vjp as vjp,
   zero_jvp as zero_jvp,
   zeros_like_aval as zeros_like_aval,
-  zeros_like_p as zeros_like_p,
 )
 
 
@@ -75,3 +76,21 @@ def backward_pass(jaxpr, reduce_axes, transform_stack,
   del reduce_axes
   return backward_pass_internal(
       jaxpr, transform_stack, consts, primals_in, cotangents_in)
+
+
+_deprecations = {
+    # Added 2024-12-11
+    "zeros_like_p": (
+        "jax.core.zeros_like_p is deprecated in JAX v0.7.1. It has been unused since v0.4.24.",
+        _src_ad_util.zeros_like_p,
+    ),
+}
+
+import typing
+if typing.TYPE_CHECKING:
+  zeros_like_p = _src_ad_util.zeros_like_p
+else:
+  from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
+  __getattr__ = _deprecation_getattr(__name__, _deprecations)
+  del _deprecation_getattr
+del typing


### PR DESCRIPTION
Also remove from jax.extend.primitives. It has not been used since JAX v0.4.24