### PR TITLE
Deprecate a number of jax.interpreters.ad APIs

### DIFF
--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from jax._src import ad_util as _src_ad_util
+from jax._src.interpreters import ad as _src_ad
 
 from jax._src.interpreters.ad import (
   JVPTrace as JVPTrace,
@@ -27,67 +28,163 @@ from jax._src.interpreters.ad import (
   add_jaxvals as add_jaxvals,
   add_jaxvals_p as add_jaxvals_p,
   add_tangents as add_tangents,
-  backward_pass as backward_pass_internal,
-  bilinear_transpose as bilinear_transpose,
-  call_param_updaters as call_param_updaters,
-  call_transpose as call_transpose,
-  call_transpose_param_updaters as call_transpose_param_updaters,
-  closed_backward_pass as closed_backward_pass,
-  custom_lin_p as custom_lin_p,
   defbilinear as defbilinear,
   defjvp as defjvp,
   defjvp2 as defjvp2,
-  defjvp_zero as defjvp_zero,
   deflinear as deflinear,
   deflinear2 as deflinear2,
-  f_jvp_traceable as f_jvp_traceable,
   get_primitive_transpose as get_primitive_transpose,
   instantiate_zeros as instantiate_zeros,
   is_undefined_primal as is_undefined_primal,
   jvp as jvp,
-  jvp_jaxpr as jvp_jaxpr,
-  jvp_subtrace as jvp_subtrace,
-  jvp_subtrace_aux as jvp_subtrace_aux,
-  jvpfun as jvpfun,
-  linear_jvp as linear_jvp,
-  linear_transpose as linear_transpose,
-  linear_transpose2 as linear_transpose2,
   linearize as linearize,
-  map_transpose as map_transpose,
-  nonzero_outputs as nonzero_outputs,
-  nonzero_tangent_outputs as nonzero_tangent_outputs,
   primitive_jvps as primitive_jvps,
   primitive_transposes as primitive_transposes,
-  rearrange_binders as rearrange_binders,
   reducing_transposes as reducing_transposes,
-  standard_jvp as standard_jvp,
-  standard_jvp2 as standard_jvp2,
-  traceable as traceable,
   vjp as vjp,
-  zero_jvp as zero_jvp,
   zeros_like_aval as zeros_like_aval,
 )
 
 
-def backward_pass(jaxpr, reduce_axes, transform_stack,
-                  consts, primals_in, cotangents_in):
+def _deprecated_backward_pass(jaxpr, reduce_axes, transform_stack,
+                              consts, primals_in, cotangents_in):
   if reduce_axes:
     raise NotImplementedError("reduce_axes on ad.backward_pass is deprecated")
   del reduce_axes
-  return backward_pass_internal(
+  return _src_ad.backward_pass(
       jaxpr, transform_stack, consts, primals_in, cotangents_in)
 
 
 _deprecations = {
     # Added 2024-12-11
     "zeros_like_p": (
-        "jax.core.zeros_like_p is deprecated in JAX v0.7.1. It has been unused since v0.4.24.",
+        "jax.interpreters.ad.zeros_like_p is deprecated in JAX v0.7.1. It has been unused since v0.4.24.",
         _src_ad_util.zeros_like_p,
+    ),
+    "backward_pass": (
+        "jax.interpreters.ad.backward_pass is deprecated.",
+        _deprecated_backward_pass
+    ),
+    "bilinear_transpose": (
+        "jax.interpreters.ad.bilinear_transpose is deprecated.",
+        _src_ad.bilinear_transpose,
+    ),
+    "call_param_updaters": (
+        "jax.interpreters.ad.call_param_updaters is deprecated.",
+        _src_ad.call_param_updaters,
+    ),
+    "call_transpose": (
+        "jax.interpreters.ad.call_transpose is deprecated.",
+        _src_ad.call_transpose,
+    ),
+    "call_transpose_param_updaters": (
+        "jax.interpreters.ad.call_transpose_param_updaters is deprecated.",
+        _src_ad.call_transpose_param_updaters,
+    ),
+    "closed_backward_pass": (
+        "jax.interpreters.ad.closed_backward_pass is deprecated.",
+        _src_ad.closed_backward_pass,
+    ),
+    "custom_lin_p": (
+        "jax.interpreters.ad.custom_lin_p is deprecated.",
+        _src_ad.custom_lin_p,
+    ),
+    "defjvp_zero": (
+        "jax.interpreters.ad.defjvp_zero is deprecated.",
+        _src_ad.defjvp_zero,
+    ),
+    "f_jvp_traceable": (
+        "jax.interpreters.ad.f_jvp_traceable is deprecated.",
+        _src_ad.f_jvp_traceable,
+    ),
+    "jvp_jaxpr": (
+        "jax.interpreters.ad.jvp_jaxpr is deprecated.",
+        _src_ad.jvp_jaxpr,
+    ),
+    "jvp_subtrace": (
+        "jax.interpreters.ad.jvp_subtrace is deprecated.",
+        _src_ad.jvp_subtrace,
+    ),
+    "jvp_subtrace_aux": (
+        "jax.interpreters.ad.jvp_subtrace_aux is deprecated.",
+        _src_ad.jvp_subtrace_aux,
+    ),
+    "jvpfun": (
+        "jax.interpreters.ad.jvpfun is deprecated.",
+        _src_ad.jvpfun,
+    ),
+    "linear_jvp": (
+        "jax.interpreters.ad.linear_jvp is deprecated.",
+        _src_ad.linear_jvp,
+    ),
+    "linear_transpose": (
+        "jax.interpreters.ad.linear_transpose is deprecated.",
+        _src_ad.linear_transpose,
+    ),
+    "linear_transpose2": (
+        "jax.interpreters.ad.linear_transpose2 is deprecated.",
+        _src_ad.linear_transpose2,
+    ),
+    "map_transpose": (
+        "jax.interpreters.ad.map_transpose is deprecated.",
+        _src_ad.map_transpose,
+    ),
+    "nonzero_outputs": (
+        "jax.interpreters.ad.nonzero_outputs is deprecated.",
+        _src_ad.nonzero_outputs,
+    ),
+    "nonzero_tangent_outputs": (
+        "jax.interpreters.ad.nonzero_tangent_outputs is deprecated.",
+        _src_ad.nonzero_tangent_outputs,
+    ),
+    "rearrange_binders": (
+        "jax.interpreters.ad.rearrange_binders is deprecated.",
+        _src_ad.rearrange_binders,
+    ),
+    "standard_jvp": (
+        "jax.interpreters.ad.standard_jvp is deprecated.",
+        _src_ad.standard_jvp,
+    ),
+    "standard_jvp2": (
+        "jax.interpreters.ad.standard_jvp2 is deprecated.",
+        _src_ad.standard_jvp2,
+    ),
+    "traceable": (
+        "jax.interpreters.ad.traceable is deprecated.",
+        _src_ad.traceable,
+    ),
+    "zero_jvp": (
+        "jax.interpreters.ad.zero_jvp is deprecated.",
+        _src_ad.zero_jvp,
     ),
 }
 
 import typing
 if typing.TYPE_CHECKING:
+  backward_pass = _deprecated_backward_pass
+  bilinear_transpose = _src_ad.bilinear_transpose
+  call_param_updaters = _src_ad.call_param_updaters
+  call_transpose = _src_ad.call_transpose
+  call_transpose_param_updaters = _src_ad.call_transpose_param_updaters
+  closed_backward_pass = _src_ad.closed_backward_pass
+  custom_lin_p = _src_ad.custom_lin_p
+  defjvp_zero = _src_ad.defjvp_zero
+  f_jvp_traceable = _src_ad.f_jvp_traceable
+  jvp_jaxpr = _src_ad.jvp_jaxpr
+  jvp_subtrace = _src_ad.jvp_subtrace
+  jvp_subtrace_aux = _src_ad.jvp_subtrace_aux
+  jvpfun = _src_ad.jvpfun
+  linear_jvp = _src_ad.linear_jvp
+  linear_transpose = _src_ad.linear_transpose
+  linear_transpose2 = _src_ad.linear_transpose2
+  map_transpose = _src_ad.map_transpose
+  nonzero_outputs = _src_ad.nonzero_outputs
+  nonzero_tangent_outputs = _src_ad.nonzero_tangent_outputs
+  rearrange_binders = _src_ad.rearrange_binders
+  standard_jvp = _src_ad.standard_jvp
+  standard_jvp2 = _src_ad.standard_jvp2
+  traceable = _src_ad.traceable
+  zero_jvp = _src_ad.zero_jvp
   zeros_like_p = _src_ad_util.zeros_like_p
 else:
   from jax._src.deprecations import deprecation_getattr as _deprecation_getattr


### PR DESCRIPTION
All of these have little if any downstream usage, as determined by code search.