### PR TITLE
Fix line in host offloading docs

### DIFF
--- a/docs/notebooks/host-offloading.ipynb
+++ b/docs/notebooks/host-offloading.ipynb
@@ -540,7 +540,7 @@
    "source": [
     "# Hybrid version: Both activation and parameter offloading\n",
     "def hybrid_layer(x, w):\n",
-    "  # Move model parameters w1 and w2 to host memory via device_put\n",
+    "  # Move model parameters w1 and w2 to device memory via device_put\n",
     "  w1, w2 = jax.tree.map(lambda x: jax.device_put(x, s_dev), w)\n",
     "  x = checkpoint_name(x, \"x\")  # Offload activation x to host memory\n",
     "  y = x @ w1\n",

--- a/docs/notebooks/host-offloading.md
+++ b/docs/notebooks/host-offloading.md
@@ -369,7 +369,7 @@ outputId: 48c09658-f8b6-4be3-ef0e-02e0e2566e10
 ---
 # Hybrid version: Both activation and parameter offloading
 def hybrid_layer(x, w):
-  # Move model parameters w1 and w2 to host memory via device_put
+  # Move model parameters w1 and w2 to device memory via device_put
   w1, w2 = jax.tree.map(lambda x: jax.device_put(x, s_dev), w)
   x = checkpoint_name(x, "x")  # Offload activation x to host memory
   y = x @ w1


### PR DESCRIPTION
I'm fairly certain this should read 'Move parameters to device memory' and not 'host memory'.