### PR TITLE
[mutable-arrays] instantiate zeros in vjp3

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2277,6 +2277,7 @@ def _vjp3_bwd(in_tree, out_tree, out_known, jaxpr, residuals, maybe_refs, out_ct
   ad.backward_pass3(jaxpr, True, residuals, maybe_refs, cts_flat)
   arg_cts = [x.freeze() if isinstance(x, ad.ValAccum) else GradRef()
              for x in maybe_refs]
+  arg_cts = map(ad.instantiate_zeros, arg_cts)
   return tree_unflatten(in_tree, arg_cts)
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3081,6 +3081,14 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(value, 1.)
     self.assertEqual(grd, np.zeros(shape=(), dtype=float0))
 
+  def test_grad_of_bool_vjp3(self):
+    def cond(pred):
+      return lax.cond(pred, lambda _: 1., lambda _: 2., 1.)
+    value, f_vjp = api.vjp3(cond, True)
+    grd, = f_vjp(1.)
+    self.assertEqual(value, 1.)
+    self.assertEqual(grd, np.zeros(shape=(), dtype=float0))
+
   def test_grad_of_int_index(self):
     grad_x, grad_i = api.grad(lambda x, i: x[i], argnums=(0, 1),
                               allow_int=True)(np.ones(2), 1)


### PR DESCRIPTION
We probably want to expose a user option of getting back symbolic zeros, in which case this instantiation would be under a conditional. I didn't add that, but nothing precludes us from adding it later.

Should fix some of the errors #31033 uncovered!