### PR TITLE
[mutable-arrays] add discharge_state2 for ClosedJaxprs, with caching

### DIFF
--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -1810,9 +1810,9 @@ class MutationData(NamedTuple):
 def _discharge_refs(
     jaxpr: core.ClosedJaxpr
 ) -> tuple[core.ClosedJaxpr, Sequence[int | None], MutationData]:
-  from jax._src.state.discharge import discharge_state  # pytype: disable=import-error
+  from jax._src.state.discharge import discharge_state2  # pytype: disable=import-error
   jaxpr, in_mut = _move_mutable_consts(jaxpr)
-  new_jaxpr = core.ClosedJaxpr(*discharge_state(jaxpr.jaxpr, jaxpr.consts))
+  new_jaxpr = discharge_state2(jaxpr)
   count = it.count(len(jaxpr.out_avals))  # new outputs are appended to the end
   inout_map = {i: next(count) for i, a in enumerate(jaxpr.in_avals)
                if isinstance(a, AbstractRef)}

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1459,9 +1459,7 @@ def _scan_state_partial_discharge_rule(
   if jaxpr.consts: raise NotImplementedError("open an issue!")  # TODO(mattjj)
   # jaxpr: [*consts, *pure_carry, *xs] -> [*pure_carry, *pure_ys]
   # jaxpr_: [*consts, *pure_carry, *xs] -> [*pure_carry, *pure_ys, *ref_outs]
-  jaxpr_, consts_ = state_discharge.discharge_state(
-      jaxpr.jaxpr, jaxpr.consts, should_discharge=should_discharge)
-  discharged_jaxpr = core.ClosedJaxpr(jaxpr_, consts_)
+  discharged_jaxpr = state_discharge.discharge_state2(jaxpr, should_discharge)
 
   num_xs = len(args) - num_consts - num_carry
   is_ref = [isinstance(a, AbstractRef) and s for a, s in zip(jaxpr.in_avals, should_discharge)]


### PR DESCRIPTION
This helper function follows our usual pattern of caching on ClosedJaxprs, which handles jaxprs and const lists together by id, and also keeps weak references to both.

We can probably update most or all callers to use discharge_state2 instead of discharge_state, at which point we can delete the latter.

This PR only updates the jit lowering rule, jit discharge rule, and scan discharge rule to use the new helper.