### PR TITLE
[ref] Define get_aval on RefAccum and ValAccum

### DIFF
--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -644,6 +644,12 @@ def unproject_accums(specs, result):
   assert next(result_, None) is None
   return args
 
+def accum_typeof(x):
+  if isinstance(x, GradAccum):
+    return x.aval
+  else:
+    return core.typeof(x)
+
 
 @lu.transformation_with_aux2
 def nonzero_tangent_outputs(f, store, *args, **kwargs):

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1147,9 +1147,9 @@ def _scan_transpose_fancy(cts, *args, reverse, length, num_consts,
   trans_in = [x.inst().ref if l else x for l, x in zip(lin_refs, trans_in)]
 
   # prepare transposed jaxpr
-  trans_avals, ext_avals = split_list(_map(typeof, trans_in), [num_consts+num_carry])
+  trans_avals, ext_avals = split_list(_map(ad.accum_typeof, trans_in), [num_consts+num_carry])
   trans_avals = trans_avals + [core.mapped_aval(length, 0, a) for a in ext_avals]
-  xs_avals = tuple(core.mapped_aval(length, 0, typeof(x)) for x in immut_xs_dot)
+  xs_avals = tuple(core.mapped_aval(length, 0, ad.accum_typeof(x)) for x in immut_xs_dot)
   jaxpr_trans = _transpose_scan_jaxpr_fancy(
       jaxpr, trans_tree, tuple(trans_avals), lin_refs, xs_avals)
 


### PR DESCRIPTION
Fixes an issue encountered with vjp3 on maxtext. The fancy_transpose rule of scans tries to take `typeof(x) = core.get_aval(x)` of `x: ValAccum` here (https://github.com/jax-ml/jax/blob/ffc0afb04b15a79f90e8b66f52d79b37604e296c/jax/_src/lax/control_flow/loops.py#L1152), but `get_aval` was so far not defined on `GradAccum`s.