### PR TITLE
[doc] Remove outdated link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ perex_grads = jax.jit(jax.vmap(grad_loss, in_axes=(None, 0, 0)))  # fast per-exa
 * [Scaling](#scaling)
 * [Current gotchas](#gotchas-and-sharp-bits)
 * [Installation](#installation)
-* [Neural net libraries](#neural-network-libraries)
 * [Citing JAX](#citing-jax)
 * [Reference documentation](#reference-documentation)
 


### PR DESCRIPTION
It seems this section in README has been removed in #28239 but the link remains unchanged.