### PR TITLE
Fix log10(10) == 1 equality

### DIFF
--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -2835,13 +2835,14 @@ def log10(x: ArrayLike, /) -> Array:
     [-2. -1.  0.  1.  2.  3.]
   """
   x, = promote_args_inexact("log10", x)
+  one_over_log10 = np.array(0.4342944819032518,  # exact value of 1 / log(10)
+                            dtype=dtypes.finfo(x.dtype).dtype)
   if dtypes.issubdtype(x.dtype, np.complexfloating):
     r = lax.log(x)
     re = lax.real(r)
     im = lax.imag(r)
-    ln10 = lax.log(_constant_like(re, 10))
-    return lax.complex(lax.div(re, ln10), lax.div(im, ln10))
-  out = lax.div(lax.log(x), lax.log(_constant_like(x, 10)))
+    return lax.complex(lax.mul(re, one_over_log10), lax.mul(im, one_over_log10))
+  out = lax.mul(lax.log(x), one_over_log10)
   jnp_error._set_error_if_nan(out)
   return out
 


### PR DESCRIPTION
This PR ensures that
```
jnp.log10(dtype(10)) == dtype(1)
```
holds for all `dtype` in `{jnp.float16, jnp.float32, jnp.float64, jnp.complex64, jnp.complex128}`.

Fixes #31102 