### PR TITLE
[fused] fix fused prototype to use customcall backend_config

### DIFF
--- a/jax/experimental/fused.py
+++ b/jax/experimental/fused.py
@@ -74,9 +74,9 @@ def _fused_lowering(ctx, *args, out_spaces, jaxpr):
       result_types=func_op.type.results,
       operands=mlir.flatten_ir_values([*const_arg_values, *args]),
       called_computations=[func_op.name.value],
-      extra_attributes=dict(out_spaces=ir.ArrayAttr.get(out_spaces_),
-                            inlineable=ir.BoolAttr.get(False),
-                            MUST_FUSE=ir.BoolAttr.get(True)),
+      backend_config=dict(out_spaces=ir.ArrayAttr.get(out_spaces_),
+                          inlineable=ir.BoolAttr.get(False),
+                          MUST_FUSE=ir.BoolAttr.get(True)),
   )
   return fused.results
 mlir.register_lowering(fused_p, _fused_lowering, platform="cuda")

--- a/tests/fused_test.py
+++ b/tests/fused_test.py
@@ -35,7 +35,11 @@ class FusedTest(jtu.JaxTestCase):
     x_host = jax.device_put(x, jax.memory.Space.Host)
     y_device = jnp.arange(3.)
     low = jax.jit(f).trace(x_host, y_device).lower(lowering_platforms=('cuda',))
-    self.assertIn('custom_call', low.as_text('hlo'))
+    txt = low._lowering.hlo().as_hlo_module().to_string()
+    self.assertIn('custom_call', txt)
+    self.assertIn('inlineable', txt)
+    self.assertIn('MUST_FUSE', txt)
+    self.assertIn('out_spaces', txt)
 
   def test_vmap_basic(self):
     x = jnp.arange(3.)


### PR DESCRIPTION
Apparently the `extra_attributes` field is just dropped on SHLO->HLO conversion. We should use `backend_config` instead.