### PR TITLE
remove the annoying closed_call in scan lowering

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -544,16 +544,13 @@ def _empty_array(prefix, length_spec, aval):
 
 eval_jaxpr_p = core.Primitive('eval_jaxpr')
 eval_jaxpr_p.multiple_results = True
-def _stage_jaxpr(trace: pe.DynamicJaxprTrace, source_info, *tracers,
-                 jaxpr: ClosedJaxpr):
-  params = dict(call_jaxpr=jaxpr)
-  return trace.default_process_primitive(core.closed_call_p, tracers, params,
-                                         source_info=source_info)
-pe.custom_staging_rules[eval_jaxpr_p] = _stage_jaxpr
-
-@eval_jaxpr_p.def_effectful_abstract_eval  # abstract eval only used for jax2tf
+@eval_jaxpr_p.def_effectful_abstract_eval
 def _stage_jaxpr_abstract_eval(*_, jaxpr):
   return jaxpr.out_avals, jaxpr.effects
+def _eval_jaxpr_impl(*args, jaxpr):
+  return core.jaxpr_as_fun(jaxpr)(*args)
+mlir.register_lowering(
+    eval_jaxpr_p, mlir.lower_fun(_eval_jaxpr_impl, multiple_results=True))
 
 def _prepend_dim_to_aval(sz, aval):
   return core.unmapped_aval(sz, 0, aval)


### PR DESCRIPTION
```python
import jax
import jax.numpy as jnp

@jax.jit
def f():
  def body(c, x):
    return c + 1, x * 2
  return jax.lax.scan(body, 0, jnp.arange(3.))
print(f.lower().as_text())
```

Before:
```
module @jit_f attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
  func.func public @main() -> (tensor<i32> {jax.result_info = "result[0]"}, tensor<3xf32> {jax.result_info = "result[1]"}) {
    %0 = stablehlo.iota dim = 0 : tensor<3xf32>
    %c = stablehlo.constant dense<0> : tensor<i32>
    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
    %1 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<f32>) -> tensor<3xf32>
    %c_0 = stablehlo.constant dense<0> : tensor<i32>
    %2:4 = stablehlo.while(%iterArg = %0, %iterArg_1 = %c_0, %iterArg_2 = %c, %iterArg_3 = %1) : tensor<3xf32>, tensor<i32>, tensor<i32>, tensor<3xf32>
    cond {
      %c_4 = stablehlo.constant dense<3> : tensor<i32>
      %3 = stablehlo.compare  LT, %iterArg_1, %c_4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
      stablehlo.return %3 : tensor<i1>
    } do {
      %3 = stablehlo.dynamic_slice %iterArg, %iterArg_1, sizes = [1] : (tensor<3xf32>, tensor<i32>) -> tensor<1xf32>
      %4 = stablehlo.reshape %3 : (tensor<1xf32>) -> tensor<f32>
      %5:2 = func.call @closed_call(%iterArg_2, %4) : (tensor<i32>, tensor<f32>) -> (tensor<i32>, tensor<f32>)
      %6 = stablehlo.broadcast_in_dim %5#1, dims = [] : (tensor<f32>) -> tensor<1xf32>
      %7 = stablehlo.dynamic_update_slice %iterArg_3, %6, %iterArg_1 : (tensor<3xf32>, tensor<1xf32>, tensor<i32>) -> tensor<3xf32>
      %c_4 = stablehlo.constant dense<1> : tensor<i32>
      %8 = stablehlo.add %iterArg_1, %c_4 : tensor<i32>
      stablehlo.return %iterArg, %8, %5#0, %7 : tensor<3xf32>, tensor<i32>, tensor<i32>, tensor<3xf32>
    }
    return %2#2, %2#3 : tensor<i32>, tensor<3xf32>
  }
  func.func private @closed_call(%arg0: tensor<i32>, %arg1: tensor<f32>) -> (tensor<i32>, tensor<f32>) {
    %c = stablehlo.constant dense<1> : tensor<i32>
    %0 = stablehlo.add %arg0, %c : tensor<i32>
    %cst = stablehlo.constant dense<2.000000e+00> : tensor<f32>
    %1 = stablehlo.multiply %arg1, %cst : tensor<f32>
    return %0, %1 : tensor<i32>, tensor<f32>
  }
}
```


After:
```
module @jit_f attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
  func.func public @main() -> (tensor<i32> {jax.result_info = "result[0]"}, tensor<3xf32> {jax.result_info = "result[1]"}) {
    %0 = stablehlo.iota dim = 0 : tensor<3xf32>
    %c = stablehlo.constant dense<0> : tensor<i32>
    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
    %1 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<f32>) -> tensor<3xf32>
    %c_0 = stablehlo.constant dense<0> : tensor<i32>
    %2:4 = stablehlo.while(%iterArg = %0, %iterArg_1 = %c_0, %iterArg_2 = %c, %iterArg_3 = %1) : tensor<3xf32>, tensor<i32>, tensor<i32>, tensor<3xf32>
    cond {
      %c_4 = stablehlo.constant dense<3> : tensor<i32>
      %3 = stablehlo.compare  LT, %iterArg_1, %c_4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
      stablehlo.return %3 : tensor<i1>
    } do {
      %3 = stablehlo.dynamic_slice %iterArg, %iterArg_1, sizes = [1] : (tensor<3xf32>, tensor<i32>) -> tensor<1xf32>
      %4 = stablehlo.reshape %3 : (tensor<1xf32>) -> tensor<f32>
      %c_4 = stablehlo.constant dense<1> : tensor<i32>
      %5 = stablehlo.add %iterArg_2, %c_4 : tensor<i32>
      %cst_5 = stablehlo.constant dense<2.000000e+00> : tensor<f32>
      %6 = stablehlo.multiply %4, %cst_5 : tensor<f32>
      %7 = stablehlo.broadcast_in_dim %6, dims = [] : (tensor<f32>) -> tensor<1xf32>
      %8 = stablehlo.dynamic_update_slice %iterArg_3, %7, %iterArg_1 : (tensor<3xf32>, tensor<1xf32>, tensor<i32>) -> tensor<3xf32>
      %c_6 = stablehlo.constant dense<1> : tensor<i32>
      %9 = stablehlo.add %iterArg_1, %c_6 : tensor<i32>
      stablehlo.return %iterArg, %9, %5, %8 : tensor<3xf32>, tensor<i32>, tensor<i32>, tensor<3xf32>
    }
    return %2#2, %2#3 : tensor<i32>, tensor<3xf32>
  }
}
```

Explanation: the `eval_jaxpr_p` primitive exists so we don't round-trip through eval_jaxpr when we trace the scan impl as part of the scan lowering rule. We don't want to rebuild an expensive jaxpr; just keep it. But it was using `core.closed_call_p` and that was leading to an annoying Call in the HLO. This PR avoids the Call.