### PR TITLE
[remat] add prototype partial cse prevention for remat

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -5255,7 +5255,7 @@ class APITest(jtu.JaxTestCase):
 
     self.assertNotIn('mul', str(f_vjp))
 
-  # TODO(mattjj,dougalm): re-enable when we set auto_dce=True by default
+  # TODO(mattjj,dougalm): re-enable if we set auto_dce=True by default
   # @jtu.run_on_devices('cpu')
   # def test_implicit_dce(self):
   #   @api.jit
@@ -6993,6 +6993,59 @@ class RematTest(jtu.JaxTestCase):
 
     s = vjp.jaxpr.pretty_print(name_stack=True)
     self.assertEqual(s.count('rematted_computation'), 1)
+
+  def test_remat_partial_cse_prevention(self):
+    @partial(jax.remat, prevent_cse=(False, True))
+    def layer(W, x):
+      return x @ W
+
+    def net(Ws, x):
+      for W in Ws:
+        x = layer(W, x)
+      return x
+
+    def loss(Ws, x):
+      return jnp.sum(net(Ws, x)**2)
+
+    Ws = [jnp.ones((3, 3)) for _ in range(2)]
+    x = jnp.ones(3)
+    txt = jax.jit(jax.grad(loss, (0, 1))).lower(Ws, x).as_text()
+    self.assertRegex(txt, r'optimization_barrier %[a-z0-9]+, %[a-z0-9]+ :')
+
+  def test_remat_partial_cse_prevention_all_false(self):
+    @partial(jax.remat, prevent_cse=(False, False))
+    def layer(W, x):
+      return x @ W
+
+    def net(Ws, x):
+      for W in Ws:
+        x = layer(W, x)
+      return x
+
+    def loss(Ws, x):
+      return jnp.sum(net(Ws, x)**2)
+
+    Ws = [jnp.ones((3, 3)) for _ in range(2)]
+    x = jnp.ones(3)
+    txt = jax.jit(jax.grad(loss, (0, 1))).lower(Ws, x).as_text()  # don't crash
+
+  def test_remat_partial_cse_prevention_pytree(self):
+    @partial(jax.remat, prevent_cse=({'W': False, 'x': True},))
+    def layer(dct):
+      return dct['x'] @ dct['W']
+
+    def net(Ws, x):
+      for W in Ws:
+        x = layer(dict(W=W, x=x))
+      return x
+
+    def loss(Ws, x):
+      return jnp.sum(net(Ws, x)**2)
+
+    Ws = [jnp.ones((3, 3)) for _ in range(2)]
+    x = jnp.ones(3)
+    txt = jax.jit(jax.grad(loss, (0, 1))).lower(Ws, x).as_text()
+    self.assertRegex(txt, r'optimization_barrier %[a-z0-9]+, %[a-z0-9]+ :')
 
 
 @jtu.with_config(jax_pprint_use_color=False)


### PR DESCRIPTION
This from @gspschmid doesn't crash:

```python
from functools import partial
import jax
import jax.numpy as jnp
from jax._src.api import vjp3

DATA_PARALLEL = False  # Set to True to also produce reduce-scatters (via DS(AR(...)))

num_devices = min(2, len(jax.devices()))
jax.set_mesh(jax.make_mesh((num_devices,), ('data',)))
sharding_Ws = jax.P('data')
sharding_xs = jax.P('data') if DATA_PARALLEL else jax.P()


@partial(jax.checkpoint, prevent_cse=(False, True))
def layer(W, xs):
  W = jax.lax.with_sharding_constraint(W, jax.P())  # force all-gather
  return jnp.dot(xs, W)

def layer_loop(Ws, xs):
  for i, W in enumerate(Ws):
    with jax.named_scope(f"layer{i}"):
      xs = layer(W, xs)
  return xs

@partial(jax.jit, in_shardings=(sharding_Ws, sharding_xs), out_shardings=(sharding_Ws, None), donate_argnums=(0,))
def step(Ws, xs):
  def loss(Ws, xs):
    return jnp.mean(layer_loop(Ws, xs))

  loss, vjp = vjp3(lambda Ws, _: loss(Ws, xs), Ws, 999.)
  assert len(vjp.args_res) == 2 and isinstance(vjp.args_res[1], jax._src.api.NotNeeded)
  vjp.args_res, loss = jax.lax.optimization_barrier((vjp.args_res, loss))
  grad_acc, _ = vjp(jnp.ones_like(loss))

  return jax.tree.map(lambda W, g: W - g * 0.01, Ws, grad_acc), jnp.mean(loss)


NUM_LAYERS = 5
EMB_SIZE = 4
BATCH_SIZE = 7*2
Ws = tuple(jnp.ones((EMB_SIZE, EMB_SIZE)) for _ in range(NUM_LAYERS))
xs = jnp.ones((BATCH_SIZE, EMB_SIZE))

# print(step(Ws, xs))

lowered = step.lower(Ws, xs)
lowered_hlo = lowered.as_text()
compiled_hlo = lowered.compile().as_text()

# print("\n--- JAXPR ---\n")
# print(jax.make_jaxpr(step)(Ws, xs))
# print("\n--- StableHLO ---\n")
# print(lowered_hlo)
print("\n--- Optimized HLO ---\n")
print(compiled_hlo)
```