### PR TITLE
Add uv Installation Instructions to Documentation (GH#29451)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,20 +7,37 @@ Using JAX requires installing two packages: `jax`, which is pure Python and
 cross-platform, and `jaxlib` which contains compiled binaries, and requires
 different builds for different operating systems and accelerators.
 
+**Note:**  
+[uv](https://github.com/astral-sh/uv) is a fast, modern Python package manager that can be used as a drop-in replacement for pip.  
+To use it, simply replace `pip` with `uv pip` in the installation commands below.
+
 **Summary:** For most users, a typical JAX installation may look something like this:
 
 * **CPU-only (Linux/macOS/Windows)**
   ```
   pip install -U jax
   ```
+  Or with uv:
+  ```
+  uv pip install -U jax
+  ```
+
 * **GPU (NVIDIA, CUDA 12)**
   ```
   pip install -U "jax[cuda12]"
+  ```
+  Or with uv:
+  ```
+  uv pip install -U "jax[cuda12]"
   ```
 
 * **TPU (Google Cloud TPU VM)**
   ```
   pip install -U "jax[tpu]"
+  ```
+  Or with uv:
+  ```
+  uv pip install -U "jax[tpu]"
   ```
 
 (install-supported-platforms)=


### PR DESCRIPTION
(GH#29451)
This PR updates the JAX installation documentation to include instructions for installing JAX with uv, a modern and fast Python package manager.

Added a brief note introducing uv and highlighting that it can be used as a drop-in replacement for pip.

Included uv-based installation commands alongside existing pip commands for CPU, GPU, and TPU setups.

Please let me know if this fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou!