### PR TITLE
[mutable-arrays] allow internal-only refs in remat

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2582,6 +2582,7 @@ class InternalMutableArrayEffect(effects.Effect):
   pass
 array_ref_effect = internal_mutable_array_effect = InternalMutableArrayEffect()
 effects.control_flow_allowed_effects.add_type(InternalMutableArrayEffect)
+effects.remat_allowed_effects.add_type(InternalMutableArrayEffect)
 
 @array_ref_p.def_effectful_abstract_eval
 def array_ref_abstract_eval(init_aval, *, memory_space: Any):

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1193,7 +1193,6 @@ def _partial_eval_jaxpr_custom_cached(
   out_unknowns = map(op.or_, out_unknowns, ensure_out_unknowns)
   out_inst     = map(op.or_, out_inst,     ensure_out_inst)
 
-
   ins_known, _ = partition_list(in_unknowns, jaxpr.invars)
   outs_known, _ = partition_list(out_unknowns, jaxpr.outvars)
   ref_res_is_input = [r in ins_known for r in residual_refs]

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1461,7 +1461,6 @@ def _scan_typecheck(bind_time, *in_atoms, reverse, length, num_consts,
 def _scan_state_partial_discharge_rule(
     should_discharge, in_avals, out_avals, *args, jaxpr, num_consts, num_carry,
     linear, unroll, reverse, length, _split_transpose):
-  if jaxpr.consts: raise NotImplementedError("open an issue!")  # TODO(mattjj)
   # jaxpr: [*consts, *pure_carry, *xs] -> [*pure_carry, *pure_ys]
   # jaxpr_: [*consts, *pure_carry, *xs] -> [*pure_carry, *pure_ys, *ref_outs]
   discharged_jaxpr = state_discharge.discharge_state2(jaxpr, should_discharge)


### PR DESCRIPTION
A few ingredients were needed:
1. in core.py, mark `InternalMutableArrayEffect` as allowed under remat (just whitelisting it)
2. remove a stale `NotImplementedError` in the scan discharge rule, solved when we used the aptly-named `state_discharge2`
3. adapt stateful ops remat partial eval rules, basically to do full remat regardless of remat policy
4. add such a rule for pallas core_map

@dougalm observed a downside to item 3: it means remat with an everything-saveable policy is _not_ the same as AD classic (without the remat decorator). That's because we always remat these internally-stateful operations, regardless of policy. An alternative is to always save such computations (regardless of policy), but then we can't recover full remat. We don't want to risk splitting up stateful operations across the two sides, and it's sufficient to always put them one way or the other (regardless of policy). One way around this would be to statically switch on everything-saveable and/or nothing-saveable policies, represented as something other than an opaque callback.

We still can't handle this code until we redo remat again on top of direct-linearize (remat3):
```python
import jax
import jax.numpy as jnp
jax.config.update('jax_enable_checks', True)

@jax.remat
def f(x):
  x_ref = jax.array_ref(0.)
  x_ref[...] = x
  return x_ref[...]

jax.grad(f)(3.)
```