### PR TITLE
[AArch64 CPU] Cast BFloat16 Gelu to F32

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 # source control.
 Google LLC
 NVIDIA Corporation
+Arm Ltd. and Affiliates


### PR DESCRIPTION
Cast BF16 tensors to F32 before running any ops in Gelu. This avoids multiple upcasts and downcasts when calling XLA ops.

This shows the following speedups for a 2048x2048 tensor:
bf16 jit: 34.1% speed up
bf16 no jit: 5.5% slow down
f32 no jit: no significant change
f32 jit: no significant change

cc: @penpornk @cfRod