### PR TITLE
add `scipy-stubs` as test dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
   - id: mypy
     files: (jax/|tests/typing_test\.py)
     exclude: jax/_src/basearray.py|jax/numpy/__init__.py|jax/nn/__init__.py|jaxlib/_jax/.*  # Use pyi instead
-    additional_dependencies: [types-requests==2.31.0, numpy>=2.2.0]
+    additional_dependencies: [types-requests==2.31.0, numpy>=2.2.0, scipy-stubs]
     args: [--config=pyproject.toml]
 
 - repo: https://github.com/mwouts/jupytext

--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -12,3 +12,4 @@ rich
 # TODO(phawkins): enable matplotlib once it ships a 3.14 wheel.
 matplotlib; python_version<"3.14"
 auditwheel
+scipy-stubs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ module = [
     "pygments.*",
     "pytest.*",
     "rich.*",
-    "scipy.*",
     "setuptools.*",
     "xprof.convert.*",
     "tensorflow.*",


### PR DESCRIPTION
I noticed that `scipy` is used quite a bit, and you're using mypy. SciPy doesn't support type-checking on its own, so you'll need [scipy-stubs](https://github.com/scipy/scipy-stubs/) to get the full static typing benefits, such as improved IDE support (e.g. import autocompletion and inline documentation). 