### PR TITLE
Edit _count function to emit overflow warning.

### DIFF
--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -20,6 +20,7 @@ from functools import partial
 import math
 import operator
 from typing import overload, Any, Literal, Protocol, Union
+import warnings
 
 import numpy as np
 
@@ -883,7 +884,15 @@ def _count(
       count = core.dimension_as_value(np.size(a))
     else:
       count = core.dimension_as_value(_axis_size(a, axis))
-    count = lax.convert_element_type(count, dtype)
+    try:
+      count = np.asarray(count, dtype)
+    except OverflowError:
+      warnings.warn(
+        f"Overflow occurred in _count function for {count=} and {dtype=}. "
+        "Future versions will raise an error.",
+        DeprecationWarning,
+      )
+      count = lax.convert_element_type(count, dtype)
   else:
     count = sum(_broadcast_to(where, np.shape(a)), axis, dtype=dtype, keepdims=keepdims)
   return count

--- a/tests/lax_numpy_reducers_test.py
+++ b/tests/lax_numpy_reducers_test.py
@@ -808,6 +808,12 @@ class JaxNumpyReducerTests(jtu.JaxTestCase):
     x = jax.ShapeDtypeStruct((1 << 32,), jnp.dtype('float32'))
     jax.eval_shape(jnp.mean, x)
 
+  def testMeanVeryLargeArrayOverflow(self):
+    # https://github.com/jax-ml/jax/pull/30769
+    x = jax.ShapeDtypeStruct((1 << 33,), jnp.dtype('float32'))
+    with self.assertRaisesRegex(DeprecationWarning, "Overflow"):
+      jax.eval_shape(partial(jnp.mean, dtype='int16'), x)
+
   def testStdLargeArray(self):
     # https://github.com/jax-ml/jax/issues/15068
     raise unittest.SkipTest("test is slow, but it passes!")


### PR DESCRIPTION
Addresses https://github.com/jax-ml/jax/pull/30769#issuecomment-3188797489.

Edits the [`_count`](https://github.com/jax-ml/jax/blob/895fc9962482337e244bd73cad445dbd5d8b0a6b/jax/_src/numpy/reductions.py#L874) function used by [`mean`](https://docs.jax.dev/en/latest/_autosummary/jax.numpy.mean.html) and [`logmeanexp`](https://docs.jax.dev/en/latest/_autosummary/jax.nn.logmeanexp.html) to emit a warning when `count` overflows under the given `dtype`.