### PR TITLE
[debug_info] Safer arg_names and result_paths.

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2192,10 +2192,10 @@ def saved_input_vjp(f: Callable, which: Sequence[bool], *primals,
     if len(unused) == 1:
       (i, a), = unused
       start, was = "an input value", "was"
-      msg = f" {dbg.arg_names[i]} of type {a.str_short()}"
+      msg = f" {dbg.arg_names[i] if dbg.arg_names is not None else 'unknown'} of type {a.str_short()}"
     else:
       start, was = "multiple input values", "were"
-      msg = "\n" + "\n".join(f"  * {dbg.arg_names[i]} of type {a.str_short()}"
+      msg = "\n" + "\n".join(f"  * {dbg.arg_names[i] if dbg.arg_names is not None else 'unknown'} of type {a.str_short()}"
                              for i, a in unused)
     raise Exception(f"with {allow_unused=}, {start} marked to be saved {was} "
                     f"not used by the backward pass:{msg}")

--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -598,14 +598,14 @@ def debug_info(
     *,
     static_argnums: Sequence[int] = (),
     static_argnames: Sequence[str] = (),
-    result_paths_thunk: Callable[[], tuple[str, ...]] | None = None,
+    result_paths_thunk: Callable[[], tuple[str, ...]] | core.InitialResultPaths = core.initial_result_paths,
     # TODO(necula): check if we really need this, e.g., to speed up tracing?
     sourceinfo: str | None = None,
     signature: inspect.Signature | None = None,
 ) -> core.DebugInfo:
-  """Constructd core.DebugInfo for a function given example args and kwargs.
+  """Construct core.DebugInfo for a function given example args and kwargs.
 
-  `args` and `kwargs` are example positional and keyword arguments, users with
+  `args` and `kwargs` are example positional and keyword arguments, used with
   `inspect.Signature` to get the names of arguments. The arguments that are
   considered static for tracing purposes should be included, and designated
   using `static_argnums` and `static_argnames`.
@@ -730,7 +730,8 @@ def _check_no_aliased_ref_args(dbg: core.DebugInfo, maybe_avals, args):
         "only one reference to a mutable array may be passed as an argument "
         f"to a function, but when tracing {dbg.func_src_info} for {dbg.traced_for} "
         f"the mutable array reference of type {a.str_short()} appeared at both "
-        f"{dbg.arg_names[dup_idx]} and {dbg.arg_names[i]}."
+        f"{dbg.arg_names[dup_idx] if dbg.arg_names is not None else 'unknown'} "
+        f"and {dbg.arg_names[i] if dbg.arg_names is not None else 'unknown'}."
         if dbg else
         f"at both flat index {dup_idx} and flat index {i}") from None
 

--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -757,7 +757,8 @@ def jaxpr_to_checkify_jaxpr(
   checkify_jaxpr_partial = functools.partial(checkify_jaxpr_flat, jaxpr.jaxpr,
                                              jaxpr.consts, enabled_errors,
                                              err_tree)
-  fun = lu.wrap_init(checkify_jaxpr_partial, debug_info=jaxpr.jaxpr.debug_info)
+  fun = lu.wrap_init(checkify_jaxpr_partial,
+                     debug_info=jaxpr.jaxpr.debug_info.with_unknown_names())
   fun, metadata = _flatten_and_get_error_metadata_thunk(fun)
 
   new_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(fun, flat_err_and_in_vals)
@@ -844,7 +845,9 @@ def checkify_while_body_jaxpr(
     # This checks if the next cond application will error
     lax.dce_sink(cond_f(*c_consts, *out))
     return out
-  new_body_f_ = lu.wrap_init(new_body_f, debug_info=body_jaxpr.jaxpr.debug_info)
+  new_body_f_ = lu.wrap_init(
+      new_body_f,
+      debug_info=body_jaxpr.jaxpr.debug_info.with_unknown_names())
   c_consts_avals = cond_jaxpr.in_avals[:c_consts_num]
   jaxpr, _, () = pe.trace_to_jaxpr_dynamic(
       new_body_f_, [*c_consts_avals, *body_jaxpr.in_avals])
@@ -1234,7 +1237,7 @@ def checkify(f: Callable[..., Out],
     # stage:
     debug = api_util.debug_info("checkify", f, args, kwargs)
     fun_, out_tree = api_util.flatten_fun(
-        lu.wrap_init(closed_f, debug_info=debug), in_tree)
+        lu.wrap_init(closed_f, debug_info=debug.with_unknown_names()), in_tree)
     jaxpr_, _, consts = pe.trace_to_jaxpr_dynamic(fun_, ())
     jaxpr = pe.close_jaxpr(pe.convert_constvars_jaxpr(jaxpr_))
     # checkify:

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -90,6 +90,8 @@ no_effects: Effects = effects.no_effects
 
 
 DebugInfo = lu.DebugInfo
+InitialResultPaths = lu.InitialResultPaths
+initial_result_paths = lu.initial_result_paths
 
 class Jaxpr:
   __slots__ = ['__weakref__', '_constvars', '_invars', '_outvars', '_eqns',
@@ -160,11 +162,9 @@ class Jaxpr:
     # TODO(https://github.com/jax-ml/jax/issues/26480)
     debug_info = debug_info or lu._missing_debug_info("core.Jaxpr")
     self._debug_info = debug_info.resolve_result_paths()
-    # TODO(necula): re-enable these safety checks
-    # assert (len(debug_info.arg_names) == len(invars)), (debug_info, invars)
-    # assert (len(debug_info.result_paths) == len(outvars)), (debug_info, outvars)
+    config.enable_checks.value and self._debug_info.assert_arg_names(len(invars))
+    config.enable_checks.value and self._debug_info.assert_result_paths(len(outvars))
     self._is_high = is_high
-    num_vars = len(constvars) + len(invars)
 
   def __str__(self):
     return str(self.pretty_print())

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -1474,7 +1474,8 @@ def linear_call(fun: Callable,
 
   @pe._memoize
   def transpose_thunk():
-    t_jaxpr, t_consts = _initial_style_jaxpr(t, (*res_avals, *out_avals))
+    t_jaxpr, t_consts = _initial_style_jaxpr(t.with_unknown_names(),
+                                             (*res_avals, *out_avals))
     if t_out_tree() != lin_tree:
       raise TypeError(
           'transpose output pytree structure must match that of linear inputs, '
@@ -1646,7 +1647,6 @@ def optimize_remat_of_custom_vjp_fwd(
   def wrapped_fwd(*args, **kwargs) -> tuple[ReturnValue, Any]:
     # TODO(dfm): This initial logic is duplicated from custom_vjp.__call__
     # above and it would be good to consolidate it.
-    fwd_name = debug_fwd.func_name if debug_fwd else str(fwd)
     # Note: we use `fun` instead of `fwd` here for consistency with
     # custom_vjp.__call__ above.
     args = resolve_kwargs(fun, args, kwargs)
@@ -1670,7 +1670,8 @@ def optimize_remat_of_custom_vjp_fwd(
     flat_fwd = _fix_fwd_args(flat_fwd)
 
     in_avals = [core.get_aval(x) for x in args_flat]
-    fwd_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(flat_fwd, in_avals)
+    fwd_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(flat_fwd.with_unknown_names(),
+                                                     in_avals)
     fwd_jaxpr = pe.close_jaxpr(pe.convert_constvars_jaxpr(fwd_jaxpr))
     prim_tree, res_tree, fwds = out_trees()
     num_res_out = res_tree.num_leaves - sum(f is not None for f in fwds)

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -111,7 +111,7 @@ def linearize_subtrace(_f: Callable, _store: lu.Store, _tag: core.TraceTag,
   nzs_out = tuple(type(t) is not Zero for t in out_tangents)
   out_tangents = tuple(t for t, nz in zip(out_tangents, nzs_out) if nz)
   out_tangents = map(partial(tangent_trace.to_jaxpr_tracer, source_info=source_info), out_tangents)  # type: ignore[assignment]
-  jaxpr, consts = tangent_trace.to_jaxpr(out_tangents, debug_info, source_info)
+  jaxpr, consts = tangent_trace.to_jaxpr(out_tangents, debug_info.with_unknown_names(), source_info)
   which_env = [(isinstance(c, pe.DynamicJaxprTracer) and
                 getattr(c._trace, 'tag', None) is _tag) for c in consts]
   jaxpr = pe.move_envvars(jaxpr, tuple(which_env))
@@ -175,6 +175,7 @@ def _linearize_jaxpr(
     allow_fwds: tuple[bool, ...],
 ) -> tuple[core.ClosedJaxpr, int, Sequence[bool], Sequence[int | None], core.ClosedJaxpr]:
   dbg = jaxpr.jaxpr.debug_info
+  config.enable_checks.value and dbg.assert_arg_names(len(nonzeros))
   primal_trace = pe.DynamicJaxprTrace(dbg)
   tangent_trace = pe.DynamicJaxprTrace(dbg, auto_dce=True)
   lin_trace = LinearizeTrace(primal_trace, tangent_trace)
@@ -198,14 +199,12 @@ def _linearize_jaxpr(
                     for t, inst in zip(out_tangents, instantiate)]
     del lin_trace, ans, new_arg, tracers
 
-  debug_info = jaxpr.jaxpr.debug_info
-
   # pe._check_no_returned_refs(debug_info, out_tangents)
   nzs_out = [type(t) is not Zero for t in out_tangents]
   out_tangents = [tangent_trace.to_jaxpr_tracer(t, source_info)
                   for (nz, t) in zip(nzs_out, out_tangents) if nz]
   tangent_jaxpr, tangent_consts = tangent_trace.to_jaxpr(
-      out_tangents, debug_info, source_info)
+      out_tangents, dbg.with_unknown_names(), source_info)
   tangent_trace.invalidate()
   tangent_jaxpr, tangent_consts = _dce_consts(tangent_jaxpr, tangent_consts)
   tangent_jaxpr = pe.close_jaxpr(pe.convert_constvars_jaxpr(tangent_jaxpr))
@@ -220,7 +219,9 @@ def _linearize_jaxpr(
   primals_and_residuals = *out_primals, *tangent_consts
   primals_and_residuals = map(partial(primal_trace.to_jaxpr_tracer, source_info=source_info),
                               primals_and_residuals)
-  primal_jaxpr, primal_consts = primal_trace.to_jaxpr(primals_and_residuals, debug_info, source_info)
+  primal_jaxpr, primal_consts = primal_trace.to_jaxpr(
+      primals_and_residuals, dbg.with_unknown_names(),
+      source_info)
   primal_trace.invalidate()
   primal_jaxpr, primal_consts = _dce_consts(primal_jaxpr, primal_consts)
   primal_jaxpr = core.ClosedJaxpr(primal_jaxpr, primal_consts)
@@ -236,8 +237,7 @@ def _dce_consts(jaxpr, consts):
 
 def direct_linearize(traceable: lu.WrappedFun, primals, kwargs, *,
                      has_aux=False, tag=None):
-  # TODO(mattjj): correct arg names in presence of symbolic zeros
-  dbg = traceable.debug_info._replace(arg_names=(), result_paths=())
+  dbg = traceable.debug_info.with_unknown_names()
   with core.take_current_trace() as parent_trace:
     source_info = source_info_util.current()
     tangent_trace = pe.DynamicJaxprTrace(dbg, auto_dce=True)
@@ -1113,7 +1113,8 @@ def linearize_from_jvp(jvp: lu.WrappedFun,
                       for (r, nz) in zip(out_tangents, out_nzs) if nz]
     in_tracers = [t for t, nz in zip(tangent_args, nonzeros) if nz]
     jaxpr, out_consts, _ = pe.tracers_to_jaxpr(
-        in_tracers, out_nz_tracers, trace.effect_handles, jvp.debug_info)
+        in_tracers, out_nz_tracers, trace.effect_handles,
+        jvp.debug_info.with_unknown_names())
     jaxpr, used_consts, _ = pe.dce_jaxpr_consts(
         jaxpr, [True] * len(jaxpr.outvars),
         [False] * len(jaxpr.constvars) + [True] * len(jaxpr.invars))
@@ -1405,7 +1406,7 @@ def _jvp_jaxpr(jaxpr: core.ClosedJaxpr,
                nonzeros: Sequence[bool], instantiate: Sequence[bool]):
   assert len(jaxpr.in_avals) == len(nonzeros)
   f = lu.wrap_init(core.jaxpr_as_fun(jaxpr),
-                   debug_info=jaxpr.jaxpr.debug_info)
+                   debug_info=jaxpr.jaxpr.debug_info.with_unknown_names())
   f_jvp, out_nonzeros = f_jvp_traceable(
       jvp(f, instantiate=instantiate, transform_stack=False), nonzeros)
   tangent_avals = [aval.to_tangent_aval()
@@ -1431,10 +1432,16 @@ def f_jvp_traceable(f, store, nonzeros, *primals_and_nztangents):
 def rearrange_binders(jaxpr: core.ClosedJaxpr, primals_in, tangents_in, primals_out, tangents_out):
   new_invars = _perm(primals_in, tangents_in, jaxpr.jaxpr.invars)
   new_outvars = _perm(primals_out, tangents_out, jaxpr.jaxpr.outvars)
-  arg_names = jaxpr.jaxpr.debug_info.safe_arg_names(len(jaxpr.in_avals))
-  result_paths = jaxpr.jaxpr.debug_info.safe_result_paths(len(jaxpr.out_avals))
-  new_arg_names = tuple(_perm(primals_in, tangents_in, arg_names))
-  new_result_paths = tuple(_perm(primals_out, tangents_out, result_paths))
+  if jaxpr.jaxpr.debug_info.arg_names is None:
+    new_arg_names = None
+  else:
+    new_arg_names = tuple(_perm(primals_in, tangents_in,
+                                jaxpr.jaxpr.debug_info.arg_names))
+  if jaxpr.jaxpr.debug_info.result_paths is None:
+    new_result_paths = None
+  else:
+    new_result_paths = tuple(_perm(primals_out, tangents_out,
+                                   jaxpr.jaxpr.debug_info.result_paths))
   new_debug_info = jaxpr.jaxpr.debug_info._replace(
       arg_names=new_arg_names, result_paths=new_result_paths)
   constvars = jaxpr.jaxpr.constvars

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -2542,7 +2542,7 @@ def lower_fun(fun: Callable, multiple_results: bool = True) -> Callable:
   def f_lowered(ctx: LoweringRuleContext, *args, **params):
     f = fun if multiple_results else lambda *args, **kw: (fun(*args, **kw),)
     wrapped_fun = lu.wrap_init(f, params,
-        debug_info=api_util.debug_info("lower_fun", fun, args, params))
+        debug_info=api_util.debug_info("lower_fun", fun, args, {}))
     manager = (contextlib.nullcontext() if ctx.jaxpr_eqn_ctx is None else
                ctx.jaxpr_eqn_ctx.manager)
 

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -940,7 +940,7 @@ def _transpose_jaxpr_fancy(jaxpr, in_tree, in_avals, specs, inst_out):
                else None for x, inst in zip(args, inst_out)]
     cts_out, cell.out_tree = tree_flatten(cts_out)  # type: ignore
     return cts_out
-  dbg = jaxpr.jaxpr.debug_info._replace(arg_names=(), result_paths=())
+  dbg = jaxpr.jaxpr.debug_info.with_unknown_names()
   trans_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
       lu.wrap_init(transposed, debug_info=dbg), in_avals)
   return core.ClosedJaxpr(trans_jaxpr, consts), cell.out_tree  # type: ignore

--- a/jax/_src/lax/control_flow/solves.py
+++ b/jax/_src/lax/control_flow/solves.py
@@ -112,13 +112,11 @@ def custom_root(f: Callable,
     unchecked_zeros, f_jvp = api.linearize(f, x)
     return tangent_solve(f_jvp, b)
 
-  tangent_solve_debug = api_util.debug_info("custom_root tangent_solve",
-                                            tangent_solve,
-                                            (f, initial_guess), {},
-                                            static_argnums=(0,))
+  linearize_and_solve_dbg = api_util.debug_info("custom_root tangent_solve",
+      tangent_solve, (initial_guess, initial_guess), {})
   l_and_s_jaxpr, l_and_s_consts, out_tree = _initial_style_jaxpr(
       linearize_and_solve, treedef_tuple((in_tree,) * 2), guess_avals * 2,
-      tangent_solve_debug)
+      linearize_and_solve_dbg)
   _check_tree("tangent_solve", "x", out_tree, in_tree, False)
 
   all_consts = [f_consts, solve_consts, l_and_s_consts]

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1862,7 +1862,7 @@ def composite(
   @functools.wraps(decomposition)
   def _decorator(*args, **kwargs):
     debug_info = api_util.debug_info("composite", decomposition,
-                                     args, kwargs)
+                                     args, {})
     flat_args, in_tree = tree_util.tree_flatten(args)
     in_avals = tuple(core.get_aval(x) for x in flat_args)
     if any(isinstance(v, core.Tracer) for v in kwargs.values()):

--- a/jax/_src/pallas/fuser/block_spec.py
+++ b/jax/_src/pallas/fuser/block_spec.py
@@ -358,7 +358,7 @@ def _pull_block_spec(
           jaxpr.invars,
           needed_invars,
           jaxpr.eqns[: jaxpr.eqns.index(eqn)],
-          debug_info=jaxpr.debug_info,
+          debug_info=jaxpr.debug_info._replace(result_paths=None),
       )
       scalar_prefetch_jaxpr, used_consts, used_invars = pe.dce_jaxpr_consts(
           scalar_prefetch_jaxpr_no_dce,
@@ -368,6 +368,7 @@ def _pull_block_spec(
       scalar_prefetch_jaxpr = scalar_prefetch_jaxpr.replace(
           constvars=[],
           invars=jaxpr.constvars,
+          debug_info=scalar_prefetch_jaxpr.debug_info.with_unknown_names()
       )
 
       def _scalar_prefetch_fn(jaxpr):

--- a/jax/_src/pallas/fuser/fusible_dtype.py
+++ b/jax/_src/pallas/fuser/fusible_dtype.py
@@ -164,7 +164,7 @@ def physicalize_closed_jaxpr(jaxpr: core.ClosedJaxpr) -> core.ClosedJaxpr:
   flat_avals, treedef = tree_util.tree_flatten(in_avals)
   debug_info = api_util.debug_info("physicalize_closed_jaxpr", fun, (), {})
   wrapped_fun, _ = api_util.flatten_fun_nokwargs(
-      lu.wrap_init(fun, debug_info=debug_info), treedef
+      lu.wrap_init(fun, debug_info=debug_info.with_unknown_names()), treedef
   )
   new_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(wrapped_fun, flat_avals)
   assert len(new_jaxpr.constvars) == len(consts), "Mismatched consts"

--- a/jax/_src/pallas/fuser/jaxpr_fusion.py
+++ b/jax/_src/pallas/fuser/jaxpr_fusion.py
@@ -79,6 +79,7 @@ def _construct_fusion_jaxpr(
       outvars=flat_outvars,
       constvars=jaxpr.constvars + jaxpr.invars,
       invars=flat_invars,
+      debug_info=jaxpr.debug_info.with_unknown_names()
   )
   new_jaxpr, used_consts, used_invars = pe.dce_jaxpr_consts(
       new_jaxpr_no_dce,
@@ -273,7 +274,8 @@ def fuse_jaxpr(
           eqns=(jaxpr.eqns[:fusion_eqn_index]
                 + jaxpr.eqns[fusion_eqn_index + 1 :]),
           constvars=jaxpr.constvars + jaxpr.invars,
-          invars=fusion_eqn.outvars),
+          invars=fusion_eqn.outvars,
+          debug_info=jaxpr.debug_info.with_unknown_names()),
       in_unknowns=[True] * len(fusion_eqn.outvars),
       in_inst=[True] * len(fusion_eqn.outvars),
       ensure_out_unknowns=False,

--- a/jax/_src/pallas/mosaic_gpu/lowering.py
+++ b/jax/_src/pallas/mosaic_gpu/lowering.py
@@ -814,7 +814,7 @@ def lower_pipelined_jaxpr_to_module(
 
   with grid_mapping.trace_env():
     new_jaxpr, _, new_consts = pe.trace_to_jaxpr_dynamic(
-        lu.wrap_init(pipeline_fn, debug_info=jaxpr.debug_info),
+        lu.wrap_init(pipeline_fn, debug_info=jaxpr.debug_info.with_unknown_names()),
         [
             gpu_core.GMEM(
                 bm.array_shape_dtype.shape, bm.array_shape_dtype.dtype

--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -248,7 +248,7 @@ def _batch_block_mapping(
 
   block_mapping_flat_fn, out_tree_thunk = api_util.flatten_fun_nokwargs(
       lu.wrap_init(_block_map_function,
-                   debug_info=block_mapping.index_map_jaxpr.jaxpr.debug_info),
+                   debug_info=block_mapping.index_map_jaxpr.jaxpr.debug_info.with_unknown_names()),
       tree_util.tree_structure(idx_avals))
   with grid_mapping.trace_env():
     block_mapping_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -1401,8 +1401,9 @@ def _batch_out_specs(spmd_name, explicit_mesh_axis, dims, out_specs):
 
 # Autodiff
 
-def _shard_map_jvp(trace, shard_map_p, f, tracers, mesh, in_specs,
+def _shard_map_jvp(trace, shard_map_p, f: lu.WrappedFun, tracers, mesh, in_specs,
                    out_specs_thunk, check_vma, manual_axes):
+  f = f.with_unknown_names()
   primals, tangents = unzip2(map(trace.to_primal_tangent_pair, tracers))
   which_nz = [     type(t) is not ad.Zero           for t in tangents]
   tangents = [t if type(t) is not ad.Zero else None for t in tangents]
@@ -1502,6 +1503,7 @@ def _shard_map_linearize(trace, shard_map_p, f: lu.WrappedFun,
                          manual_axes):
   primals, tangents = unzip2(map(trace.to_primal_tangent_pair, tracers))
   nzs_in = tuple(type(t) is not ad.Zero for t in tangents)
+  f = f.with_unknown_names()
   f_primal, linearize_outs_thunk = ad.linearize_subtrace(f, trace.tag, nzs_in, f.debug_info)
   f_primal = _promote_scalar_residuals_lin(f_primal, linearize_outs_thunk)
   all_names = _all_newly_manual_mesh_names(mesh, manual_axes)

--- a/jax/_src/state/discharge.py
+++ b/jax/_src/state/discharge.py
@@ -75,7 +75,7 @@ def discharge_state(jaxpr: core.Jaxpr, consts: Sequence[Any], * ,
               else v.aval for v, d in zip(jaxpr.invars, should_discharge)]
   eval_jaxpr = lu.wrap_init(partial(_eval_jaxpr_discharge_state, jaxpr,
                                     should_discharge, consts),
-                            debug_info=jaxpr.debug_info)
+                            debug_info=jaxpr.debug_info.with_unknown_names())
   new_jaxpr, _ , new_consts = pe.trace_to_jaxpr_dynamic(eval_jaxpr, in_avals)
   return new_jaxpr, new_consts
 

--- a/jax/_src/state/utils.py
+++ b/jax/_src/state/utils.py
@@ -74,7 +74,8 @@ def hoist_consts_to_refs(
     return core.eval_jaxpr(jaxpr, all_consts, *args0, *args1)
 
   hoisted_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
-      lu.wrap_init(_hoist, debug_info=jaxpr.debug_info), in_avals)
+      lu.wrap_init(_hoist, debug_info=jaxpr.debug_info.with_unknown_names()),
+      in_avals)
   assert not consts, "All consts should have been converted to refs"
   return hoisted_jaxpr
 

--- a/jax/experimental/fused.py
+++ b/jax/experimental/fused.py
@@ -145,7 +145,7 @@ def _transpose_jaxpr(jaxpr, in_tree, in_avals):
     out = [ct if not isinstance(ct, ad.Zero) else None for ct in out]
     cts_out, cell.out_tree = tree_flatten(out)  # type: ignore
     return cts_out
-  dbg = jaxpr.jaxpr.debug_info._replace(arg_names=(), result_paths=())
+  dbg = jaxpr.jaxpr.debug_info.with_unknown_names()
   trans_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
       lu.wrap_init(transposed, debug_info=dbg), in_avals)
   return core.ClosedJaxpr(trans_jaxpr, consts), cell.out_tree  # type: ignore

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -734,7 +734,8 @@ jet_rules[lax.scatter_add_p] = _scatter_add_rule
 def _jet_jaxpr(
     jaxpr: core.ClosedJaxpr, order: int, primals_and_series_avals, in_tree_def
 ) -> tuple[core.ClosedJaxpr, Any]:
-  f = lu.wrap_init(core.jaxpr_as_fun(jaxpr), debug_info=jaxpr.jaxpr.debug_info)
+  f = lu.wrap_init(core.jaxpr_as_fun(jaxpr),
+                   debug_info=jaxpr.jaxpr.debug_info.with_unknown_names())
   f_jet, out_tree_def = traceable(jet_fun(jet_subtrace(f), order), in_tree_def)
   jaxpr_jet, _, consts = pe.trace_to_jaxpr_dynamic(
       f_jet, primals_and_series_avals)

--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -1043,7 +1043,7 @@ def _bcoo_dot_general_sampled_impl(A, B, indices, *, dimension_numbers):
 @bcoo_dot_general_sampled_p.def_abstract_eval
 def _bcoo_dot_general_sampled_abstract_eval(A, B, indices, *, dimension_numbers):
   dbg = api_util.debug_info("bcoo_dot_general_sampled_abstract_eval",
-                            lax.dot_general, (A, B), dict(dimension_numbers=dimension_numbers))
+                            lax.dot_general, (A, B), {})
   dense_result, = pe.abstract_eval_fun(lambda *args: [lax.dot_general(*args, dimension_numbers=dimension_numbers)], A, B,
                                        debug_info=dbg)
   dbg = api_util.debug_info("bcoo_dot_general_sampled_abstract_eval",

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -448,7 +448,8 @@ def sparsify_raw(f):
         lu.wrap_init(
             f, params,
             debug_info=api_util.debug_info("sparsify", f,
-                                           spvalues_to_arrays(spenv, spvalues), {})),
+                                           in_tree.unflatten([True] * len(in_avals_flat)),
+                                           {})),
         in_tree)
     jaxpr, out_avals_flat, consts = pe.trace_to_jaxpr_dynamic(wrapped_fun, in_avals_flat)
     result = eval_sparse(jaxpr, consts, spvalues_flat, spenv)
@@ -751,7 +752,7 @@ def _sparsify_jaxpr(spenv: SparsifyEnv,
   args_flat, in_tree = tree_flatten(args)
   avals_flat = [core.get_aval(arg) for arg in args_flat]
   sp_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
-      lu.wrap_init(wrapped, debug_info=jaxpr.jaxpr.debug_info), avals_flat)
+      lu.wrap_init(wrapped, debug_info=jaxpr.jaxpr.debug_info.with_unknown_names()), avals_flat)
   sp_jaxpr = pe.ClosedJaxpr(sp_jaxpr, consts)
   assert out_tree is not None
   return sp_jaxpr, out_tree

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -222,7 +222,7 @@ class PythonPmapTest(jtu.JaxTestCase):
         TypeError,
         r"Argument types differ .*"
         r"The mismatches are:\n"
-        r"Argument 'x' compiled with.*float32.*and called with.*int32.*",
+        r"Argument '' compiled with.*float32.*and called with.*int32.*",
         lambda: f_exe(x_i32))
 
   def testLowerCompileMultiArg(self):

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -588,7 +588,7 @@ class StateDischargeTest(jtu.JaxTestCase):
       return []
     in_avals = [shaped_array_ref((), jnp.dtype('float32')),
                 core.ShapedArray((), jnp.dtype('float32'))]
-    stateful_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(wrap_init(f, 1),
+    stateful_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(wrap_init(f, 2),
                                                               in_avals)
     # Discharging should just turn this into a jaxpr that ignores the first
     # value and returns second value plus 1.


### PR DESCRIPTION
There are still cases in JAX where the arg_names and result_paths for transformed functions are not properly tracked. To handle those cases, allow arg_names and result_paths to be `None` to denote unknown values.

I tried to find all the places in the code where the debug info is incorrect, by adding assertions that 
arg_names and result_paths are either None or have the correct length. I found several places and
I have set the arg_names and the result_paths to None there. This results in dropping too much
debug info (see changes in debug_info_test.py), but it is better to be conservative in this direction.

Also, clean up debug_info_test to remove the testing for when JAX_USE_DIRECT_LINEARIZE is false.