### PR TITLE
Tweak code example in TPU Pipelining tutorial

### DIFF
--- a/docs/pallas/tpu/pipelining.ipynb
+++ b/docs/pallas/tpu/pipelining.ipynb
@@ -377,7 +377,7 @@
     "  block_spec = pl.BlockSpec((256, 512), lambda i: (i, 0))\n",
     "  return pl.pallas_call(\n",
     "      add_matrices_kernel,\n",
-    "      out_shape=x,\n",
+    "      out_shape=jax.ShapeDtypeStruct(x.shape, x.dtype),\n",
     "      in_specs=[block_spec, block_spec],\n",
     "      out_specs=block_spec,\n",
     "      grid=(2,),\n",

--- a/docs/pallas/tpu/pipelining.md
+++ b/docs/pallas/tpu/pipelining.md
@@ -290,7 +290,7 @@ def add_matrices_pipelined_megacore(x: jax.Array, y: jax.Array) -> jax.Array:
   block_spec = pl.BlockSpec((256, 512), lambda i: (i, 0))
   return pl.pallas_call(
       add_matrices_kernel,
-      out_shape=x,
+      out_shape=jax.ShapeDtypeStruct(x.shape, x.dtype),
       in_specs=[block_spec, block_spec],
       out_specs=block_spec,
       grid=(2,),


### PR DESCRIPTION
For the sake of cohesiveness, `out_shape` should be a `ShapeDtypeStruct`.