### PR TITLE
[hijax] a jaxpr is high if any inputs or outputs are hi types

### DIFF
--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -75,6 +75,7 @@ class HiPrimitive(core.Primitive):
 
 
 class HiType(core.AbstractValue):
+  is_high = True
   has_qdd = False  # immutable
 
   # type equality
@@ -101,6 +102,7 @@ class HiType(core.AbstractValue):
     assert False, "must override"
 
 class MutableHiType(core.AbstractValue):
+  is_high = True
   has_qdd = True  # mutable and potentially type-changing
   type_state = core.aval_method(core.cur_qdd)
 

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1853,8 +1853,10 @@ class JaxprStackFrame:
     for v, qdd in self.mutable_qdds:
       v.final_qdd = qdd.cur_val
 
-    jaxpr = Jaxpr(constvars, self.invars, outvars, eqns, effs, debug_info,
-                  self.is_high)
+    all_vars = it.chain(constvars, self.invars, outvars)
+    is_high = self.is_high or any(v.aval.is_high for v in all_vars)
+
+    jaxpr = Jaxpr(constvars, self.invars, outvars, eqns, effs, debug_info, is_high)
     return jaxpr, list(constvals)
 
   def to_jaxpr2(self, out_tracers: Sequence[core.Tracer],


### PR DESCRIPTION
We already had `is_high = False` on the `core.AbstractValue` class definition; we just forgot to populate the attribute on `HiType`.