### PR TITLE
In `jax.numpy.fft`, error immediately if any element of `shape` <= 0.

### DIFF
--- a/jax/_src/numpy/fft.py
+++ b/jax/_src/numpy/fft.py
@@ -54,8 +54,8 @@ def _fft_core(func_name: str, fft_type: lax_fft.FftType, a: ArrayLike,
 
   if s is not None:
     s = tuple(map(operator.index, s))
-    if np.any(np.less(s, 0)):
-      raise ValueError("Shape should be non-negative.")
+    if np.any(np.less_equal(s, 0)):
+      raise ValueError("Shape should be positive.")
 
   if s is not None and axes is not None and len(s) != len(axes):
     # Same error as numpy.


### PR DESCRIPTION
This makes `jax.numpy.fft` more consistent with `np.fft`, which errors for FFT data points <= 0. It also avoids a confusing lowering error in `jnp.fft.rfft`.

fixes #31618