### PR TITLE
In `jax.scipy.fftconvolve`, compute the convolution with multiplication when possible.

### DIFF
--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -130,13 +130,16 @@ def _fftconvolve_unbatched(in1: Array, in2: Array, mode: str) -> Array:
     if swap:
       in1, in2 = in2, in1
 
-  if jnp.iscomplexobj(in1):
-    fft, ifft = jnp.fft.fftn, jnp.fft.ifftn
+  if (all(s1 == 1 or s2 == 1 for s1, s2 in zip(in1.shape, in2.shape))):
+    conv = in1 * in2
   else:
-    fft, ifft = jnp.fft.rfftn, jnp.fft.irfftn
-  sp1 = fft(in1, fft_shape)
-  sp2 = fft(in2, fft_shape)
-  conv = ifft(sp1 * sp2, fft_shape)
+    if jnp.iscomplexobj(in1):
+      fft, ifft = jnp.fft.fftn, jnp.fft.ifftn
+    else:
+      fft, ifft = jnp.fft.rfftn, jnp.fft.irfftn
+    sp1 = fft(in1, fft_shape)
+    sp2 = fft(in2, fft_shape)
+    conv = ifft(sp1 * sp2, fft_shape)
 
   if mode == "full":
     out_shape = full_shape


### PR DESCRIPTION
This PR adds a check to `jax.scipy.fftconvolve` to detect if, for each input dimension, at least one of the inputs has dimension size 1. If so, the convolution is computed with multiplication instead of fft. This avoids `nan`s and `inf`s propagating as reported in the linked issue.

This follows Scipy (https://github.com/scipy/scipy/blob/v1.16.1/scipy/signal/_signaltools.py#L542, https://github.com/scipy/scipy/blob/v1.16.1/scipy/signal/_signaltools.py#L493).

closes #31619