### PR TITLE
Improve error message in polygamma for non-integer n

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -790,7 +790,10 @@ def polygamma(n: ArrayLike, x: ArrayLike) -> Array:
     - :func:`jax.scipy.special.gamma`
     - :func:`jax.scipy.special.digamma`
   """
-  assert dtypes.issubdtype(lax.dtype(n), np.integer)
+  if not dtypes.issubdtype(lax.dtype(n), np.integer):
+    raise ValueError(
+        f"Argument `n` to polygamma must be of integer type. Got dtype {lax.dtype(n)}."
+    )
   n_arr, x_arr = promote_args_inexact("polygamma", n, x)
   return lax.polygamma(n_arr, x_arr)
 


### PR DESCRIPTION
This PR replaces the bare `AssertionError` in `polygamma` with a descriptive `ValueError` when the argument `n` is not of integer type. The new error message clearly states the `dtype` requirement.

No functionality is changed — this is a usability improvement for better error clarity.

closes #31657 