### PR TITLE
Defensively batch array refs created under vmap.

### DIFF
--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -634,6 +634,16 @@ def _array_ref_partial_eval_custom(saveable, unks_in, inst_in, eqn):
     return eqn, eqn, [False], [True], res  # full remat
 pe.partial_eval_jaxpr_custom_rules[core.array_ref_p] = _array_ref_partial_eval_custom
 
+def _array_ref_batched(axis_data, vals_in, dims_in, memory_space):
+  val, = vals_in
+  dim, = dims_in
+  if dim is None:
+    val2 = batching.broadcast(val, axis_data.size, 0)
+    return core.array_ref_p.bind(val2, memory_space=memory_space), 0
+  else:
+    return core.array_ref_p.bind(val, memory_space=memory_space), dim
+batching.fancy_primitive_batchers[core.array_ref_p] = _array_ref_batched
+
 def _state_partial_eval_custom(saveable, unks_in, inst_in, eqn):
   del saveable  # ignored, always full remat state ops on known inputs
   ref_unk, *_ = unks_in

--- a/tests/mutable_array_test.py
+++ b/tests/mutable_array_test.py
@@ -877,6 +877,16 @@ class MutableArrayTest(jtu.JaxTestCase):
     f = lambda x: jax.array_ref(x)[0]
     jax.grad(f)(jnp.array([3.]))  # don't crash
 
+  def test_vmap_create_ref_from_unbatched_value(self):
+    @jax.jit
+    def internally_pure(x):
+      ref = jax.array_ref(1.)
+      ref[...] += x
+      return ref[...]
+
+    ans = jax.vmap(internally_pure)(jnp.arange(4.))
+    self.assertAllClose(ans, jnp.array([1., 2., 3., 4.]))
+
 
 @jtu.with_config(jax_mutable_array_checks=True)
 class MutableArrayErrorsTest(jtu.JaxTestCase):


### PR DESCRIPTION
Fixes #31670