### PR TITLE
jnp.floor_divide: fix output for zero denominator

### DIFF
--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -2523,15 +2523,16 @@ def floor_divide(x1: ArrayLike, x2: ArrayLike, /) -> Array:
   """
   x1, x2 = promote_args_numeric("floor_divide", x1, x2)
   jnp_error._set_error_if_divide_by_zero(x2)
-  dtype = x1.dtype
-  if dtypes.issubdtype(dtype, np.unsignedinteger):
-    return lax.div(x1, x2)
-  elif dtypes.issubdtype(dtype, np.integer):
-    quotient = lax.div(x1, x2)
-    select = logical_and(lax.sign(x1) != lax.sign(x2), lax.rem(x1, x2) != 0)
-    # TODO(mattjj): investigate why subtracting a scalar was causing promotion
-    return _where(select, quotient - 1, quotient)
-  elif dtypes.issubdtype(dtype, np.complexfloating):
+  zero = _lax_const(x2, 0)
+  one = _lax_const(x2, 1)
+  x2_safe = _where(x2 == 0, one, x2)
+  if dtypes.issubdtype(x2.dtype, np.unsignedinteger):
+    return _where(x2 == 0, zero, lax.div(x1, x2_safe))
+  elif dtypes.issubdtype(x2.dtype, np.integer):
+    quotient = _where(x2 == 0, zero, lax.div(x1, x2_safe))
+    select = (x2 != 0) & (lax.sign(x1) != lax.sign(x2)) & (lax.rem(x1, x2) != 0)
+    return _where(select, lax.sub(quotient, one), quotient)
+  elif dtypes.issubdtype(x2.dtype, np.complexfloating):
     raise TypeError("floor_divide does not support complex-valued inputs")
   else:
     return _float_divmod(x1, x2)[0]
@@ -2584,7 +2585,7 @@ def divmod(x1: ArrayLike, x2: ArrayLike, /) -> tuple[Array, Array]:
 def _float_divmod(x1: ArrayLike, x2: ArrayLike) -> tuple[Array, Array]:
   # see float_divmod in floatobject.c of CPython
   mod = lax.rem(x1, x2)
-  div = lax.div(lax.sub(x1, mod), x2)
+  div = lax.div(_where(lax._isnan(mod), x1, lax.sub(x1, mod)), x2)
 
   ind = lax.bitwise_and(mod != 0, lax.sign(x2) != lax.sign(mod))
   mod = lax.select(ind, mod + x2, mod)

--- a/tests/lax_numpy_operators_test.py
+++ b/tests/lax_numpy_operators_test.py
@@ -712,6 +712,18 @@ class JaxNumpyOperatorTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np.spacing, jnp.spacing, args_maker, check_dtypes=True, tol=0)
     self._CompileAndCheck(jnp.spacing, args_maker, tol=0)
 
+  @jtu.sample_product(dtype=float_dtypes + int_dtypes)
+  @jtu.ignore_warning(category=RuntimeWarning, message="(divide by zero|invalid value).*")
+  def testFloorDivideZero(self, dtype):
+    def args_maker():
+      if dtypes.issubdtype(dtype, np.floating):
+        x = jnp.array([-np.inf, -1, 0, 1, np.inf], dtype=dtype)
+      else:
+        x = jnp.array([-1, 0, 1], dtype=dtype)
+      return (x, jnp.zeros_like(x))
+    self._CheckAgainstNumpy(np.floor_divide, jnp.floor_divide, args_maker)
+    self._CompileAndCheck(jnp.floor_divide, args_maker)
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Fixes #31698