### PR TITLE
[ROCm] Support lowering through PJRT_Triton_Extension

### DIFF
--- a/jax/_src/lib/triton.py
+++ b/jax/_src/lib/triton.py
@@ -19,11 +19,9 @@ from jaxlib.triton import dialect  # noqa: F401  # pytype: disable=import-error
 
 
 class CompilationResult(Protocol):
-  asm: str
+  asm: str  # Only set for CUDA (contains PTX)
+  hsaco_path: str  # Only set for ROCm (path to HSACO binary)
   smem_bytes: int
-  cluster_dim_x: int
-  cluster_dim_y: int
-  cluster_dim_z: int
 
 
 class CompilationHandler(Protocol):

--- a/jax/_src/pallas/triton/pallas_call_registration.py
+++ b/jax/_src/pallas/triton/pallas_call_registration.py
@@ -143,7 +143,6 @@ def pallas_call_lowering(
         operand_output_aliases=dict(input_output_aliases),
     ).results
 
-  # TODO(slebedev): Make this work for ROCm.
   try:
     gpu_device, *_ = jax.local_devices(backend="gpu")
   except RuntimeError:
@@ -153,7 +152,11 @@ def pallas_call_lowering(
     cc = 80
   else:
     arch_name = str(gpu_device.compute_capability)
-    cc = int(arch_name.replace(".", ""))
+    cc = (
+        0
+        if lowering_platform == "rocm"
+        else int(arch_name.replace(".", ""))
+    )
 
   compilation_result = triton.compile(
       lowering_platform,
@@ -166,13 +169,15 @@ def pallas_call_lowering(
   kernel = triton_kernel_call_lib.TritonKernel(
       debug_info.func_name,
       num_warps,
+      1,
       compilation_result.smem_bytes,
-      compilation_result.asm,
+      (
+          compilation_result.hsaco_path
+          if lowering_platform == "rocm"
+          else compilation_result.asm
+      ),
       module_op.get_asm(enable_debug_info=True, pretty_debug_info=True),
       cc,
-      compilation_result.cluster_dim_x,
-      compilation_result.cluster_dim_y,
-      compilation_result.cluster_dim_z,
   )
   kernel_call = triton_kernel_call_lib.TritonKernelCall(
       kernel,

--- a/jax_plugins/rocm/__init__.py
+++ b/jax_plugins/rocm/__init__.py
@@ -18,6 +18,7 @@ import logging
 import os
 import pathlib
 
+from jax._src.lib import triton
 from jax._src.lib import xla_client
 import jax._src.xla_bridge as xb
 
@@ -105,6 +106,13 @@ def initialize():
     for _name, _value in rocm_plugin_extension.ffi_handlers().items():
       xla_client.register_custom_call_target(
           _name, _value, platform='ROCM', api_version=1
+      )
+    if hasattr(rocm_plugin_extension, 'compile_triton_to_asm'):
+      triton.register_compilation_handler(
+          "ROCM",
+          functools.partial(
+              rocm_plugin_extension.compile_triton_to_asm, c_api
+          ),
       )
   else:
     logger.warning('rocm_plugin_extension is not found.')

--- a/jaxlib/gpu/triton_kernels.cc
+++ b/jaxlib/gpu/triton_kernels.cc
@@ -136,8 +136,9 @@ absl::StatusOr<ModuleImage*> GetModuleImage(std::string kernel_name,
 #ifdef JAX_GPU_HIP  // For HIP/ROCM just read the hsaco file
   std::string result_blob;
   std::string fname{ptx};
-  TF_RETURN_IF_ERROR(
-      tsl::ReadFileToString(tsl::Env::Default(), fname, &result_blob));
+  tsl::Env* env = tsl::Env::Default();
+  TF_RETURN_IF_ERROR(tsl::ReadFileToString(env, fname, &result_blob));
+  TF_RETURN_IF_ERROR(env->DeleteFile(fname));
   std::vector<uint8_t> module_image(result_blob.begin(), result_blob.end());
 #else
   // TODO(cjfj): Support `TRITON_PTXAS_PATH` environment variable?


### PR DESCRIPTION
This change adds support for lowering Pallas Triton calls to HSACO through PJRT_Triton_Extension for ROCm.

As counterpart of [jax-ml/jax#25903](https://github.com/jax-ml/jax/pull/25903).

PR for XLA is at [openxla/xla#31284](https://github.com/openxla/xla/pull/31284)