### PR TITLE
[docs] Replaced `&#151;` with `---` in remat and checkpointing docs

### DIFF
--- a/docs/gradient-checkpointing.md
+++ b/docs/gradient-checkpointing.md
@@ -205,7 +205,7 @@ Using words, this alternative implementation doesn't compute `g_vjp`, or the res
 
 The cost you pay is redundant work: in `f_bwd2` you must re-evaluate `g(x)` as part of `jax.vjp(g, x)` just to discard its value (in the underscore variable on the line `_, g_vjp = jax.vjp(g, x)`).
 
-You can get this VJP behavior in autodiff &#151; without having to write VJP functions directly &#151; by instead using {func}`jax.checkpoint` in an alternative definition of the original function `f`:
+You can get this VJP behavior in autodiff --- without having to write VJP functions directly --- by instead using {func}`jax.checkpoint` in an alternative definition of the original function `f`:
 
 ```{code-cell}
 def f_checkpoint(x):
@@ -500,7 +500,7 @@ def net(params: ParamsList, x: jnp.ndarray):
 Instead, iterate over the layer application with {func}`jax.lax.scan`:
 
 ```{code-cell}
-params = [(jnp.array([[0.5, 0.5], [1., 1.]]), jnp.array([0.5, 0.5])), 
+params = [(jnp.array([[0.5, 0.5], [1., 1.]]), jnp.array([0.5, 0.5])),
           (jnp.array([[0.5, 0.5], [1., 1.]]), jnp.array([0.5, 0.5]))]
 
 all_weights = jnp.stack([W for W, _ in params])

--- a/docs/notebooks/autodiff_remat.ipynb
+++ b/docs/notebooks/autodiff_remat.ipynb
@@ -473,7 +473,7 @@
     "id": "LqTrjPoGqrK7"
    },
    "source": [
-    "We can get this VJP behavior in autodiff &#151; without having to write VJP functions directly &#151; by instead using `jax.checkpoint` in an alternative definition of the original function `f`:"
+    "We can get this VJP behavior in autodiff --- without having to write VJP functions directly --- by instead using `jax.checkpoint` in an alternative definition of the original function `f`:"
    ]
   },
   {

--- a/docs/notebooks/autodiff_remat.md
+++ b/docs/notebooks/autodiff_remat.md
@@ -231,7 +231,7 @@ The cost we pay is redundant work: in `f_bwd2` we must re-evaluate `g(x)` as par
 
 +++ {"id": "LqTrjPoGqrK7"}
 
-We can get this VJP behavior in autodiff &#151; without having to write VJP functions directly &#151; by instead using `jax.checkpoint` in an alternative definition of the original function `f`:
+We can get this VJP behavior in autodiff --- without having to write VJP functions directly --- by instead using `jax.checkpoint` in an alternative definition of the original function `f`:
 
 ```{code-cell}
 def f_checkpoint(x):


### PR DESCRIPTION
Replaced

<img width="608" height="54" alt="image" src="https://github.com/user-attachments/assets/8299817a-36d6-489a-a755-635612937097" />

into

<img width="602" height="51" alt="image" src="https://github.com/user-attachments/assets/ecf6d4b7-dcb3-467e-8a16-25a48542e5c7" />

https://jax--31809.org.readthedocs.build/en/31809/notebooks/autodiff_remat.html



