### PR TITLE
implement aval_property.setter

### DIFF
--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -1259,6 +1259,7 @@ class ShardMapTrace(core.Trace):
 
 
 class ShardMapTracer(core.Tracer):
+  __slots__ = ["vma", "val"]
   vma: frozenset[AxisName]
   val: JaxType
 

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -279,6 +279,7 @@ def spvalues_to_avals(
 # Implementation of sparsify() using tracers.
 
 class SparseTracer(core.Tracer):
+  __slots__ = ["_spvalue"]
   def __init__(self, trace: core.Trace, *, spvalue):
     self._spvalue = spvalue
     self._trace = trace


### PR DESCRIPTION
# Description

Extends the `aval_property` decorator to allow for property `setter`s e.g.

```python
@aval_property
def value(self): ...

@value.setter
def value(self, val): ...
```

To support this `Tracer.__setattr__` was added in order to forward the computation of `fset` to the `aval`.
