### PR TITLE
[docs] Add 'Ref' to the documentation reference list

### DIFF
--- a/docs/jax.ref.rst
+++ b/docs/jax.ref.rst
@@ -13,6 +13,7 @@ API
 
    AbstractRef
    ArrayRef
+   Ref
    array_ref
    freeze
    get


### PR DESCRIPTION
Now we can see this https://jax--31909.org.readthedocs.build/en/31909/_autosummary/jax.ref.Ref.html#jax.ref.Ref