### PR TITLE
Remove dbias constraints in cudnn `nn.dot_product_attention`.

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -1014,10 +1014,6 @@ def bias_fwd_rule(a, query_head_num):
   return bias_fwd_p.bind(a, query_head_num), a
 def bias_bwd_rule(query_head_num, res, g):
   a = res
-  if a.shape[0] > 1 or a.shape[-3] != query_head_num:
-    raise ValueError("cuDNN only supports bias gradient when the batch size is "
-                     f"1 and the head number matches the query, but got "
-                     f"B={a.shape[0]}, N={a.shape[-3]}.")
   return (bias_bwd_p.bind(g, a, query_head_num),)
 
 # This function uses two custom primitives, `bias_fwd` and `bias_bwd`, to work

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -363,13 +363,9 @@ class NNFunctionsTest(jtu.JaxTestCase):
       _, f_vjp = jax.vjp(attn_ans, x, bias, mask)
       return f_vjp(x)
 
-    if batch_size != 1:
-      with self.assertRaisesRegex(ValueError, _cudnn_dbias_error):
-        _, dbias_ans, _ = bwd_ans(x, bias, mask)
-    else:
-      _, dbias_ref, _ = bwd_ref(x, bias, mask)
-      _, dbias_ans, _ = bwd_ans(x, bias, mask)
-      self.assertAllClose(dbias_ans, dbias_ref, rtol=0.1, atol=0.1)
+    _, dbias_ref, _ = bwd_ref(x, bias, mask)
+    _, dbias_ans, _ = bwd_ans(x, bias, mask)
+    self.assertAllClose(dbias_ans, dbias_ref, rtol=0.1, atol=0.1)
 
   @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def testSoftplusGrad(self):


### PR DESCRIPTION
This commit remove constraints on `nn.dot_product_attention` dbias after successfull constraints removal on XLA side (PR [#30996](https://github.com/openxla/xla/pull/30996).

Merging this PR solves git issues [#31630](https://github.com/jax-ml/jax/issues/31630) and [#30593](https://github.com/jax-ml/jax/issues/30593#issuecomment-3288689087).