### PR TITLE
Implement custom derivatives for hyp2f1

### DIFF
--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -160,7 +160,7 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
     ),
     op_record(
         "hyp2f1", 4, float_dtypes,
-        functools.partial(jtu.rand_uniform, low=0.1, high=0.9), False
+        functools.partial(jtu.rand_uniform, low=0.1, high=0.9), True
     ),
     op_record("log_softmax", 1, float_dtypes, jtu.rand_default, True),
     op_record("softmax", 1, float_dtypes, jtu.rand_default, True),


### PR DESCRIPTION
Fixes #30195 

Added custom derivatives for `scipy.special.hyp2f1`. Taylor series representations should be consistent with these [formulas](https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/20/01/)