### PR TITLE
Support setting process id in `get_process_index_and_count`

### DIFF
--- a/jax/_src/sharding_impls.py
+++ b/jax/_src/sharding_impls.py
@@ -729,7 +729,7 @@ class NonUniformShardingError(ValueError):
 
 @util.cache(max_size=4096, trace_context_in_key=False)
 def get_process_index_and_count(
-    tensor_sharding: jsharding.Sharding, dim: int, ndims: int) -> tuple[int, int]:
+    tensor_sharding: jsharding.Sharding, dim: int, ndims: int, process_id: int | None = None) -> tuple[int, int]:
   """Get current process index and number of unique processes for given dimension.
 
   This function facilitates mapping of process-level data to individual
@@ -821,7 +821,7 @@ def get_process_index_and_count(
 
   # Get the set of slices for the current process which we will use to compute
   # the index of the current process.
-  current_pid = next(iter(tensor_sharding.addressable_devices)).process_index
+  current_pid = next(iter(tensor_sharding.addressable_devices)).process_index if process_id is None else process_id
   addressable_slices = frozenset(process_to_slice[current_pid])
 
   # Verify that all processes have the same number of slices.


### PR DESCRIPTION
Existing implementation returns the `index` and `count` of current process by default. This makes sense because in most cases we'll build the global array based on local data.

In some specific cases, we still want to know the `index` of other processes so that we can have more fine-grained control over how to load the data cooperatively. This PR adds an extra argument of `process_id` to the `get_process_index_and_count`. It should be a non-breaking change.