### PR TITLE
Docs fixes here and there

### DIFF
--- a/docs/advanced-autodiff.md
+++ b/docs/advanced-autodiff.md
@@ -38,7 +38,7 @@ key = random.key(0)
 
 JAX's autodiff makes it easy to compute higher-order derivatives, because the functions that compute derivatives are themselves differentiable. Thus, higher-order derivatives are as easy as stacking transformations.
 
-The single-variable case was covered in the {ref}`automatic-differentiation` tutorial, where the example showed how to use {func}`jax.grad` to compute the the derivative of $f(x) = x^3 + 2x^2 - 3x + 1$.
+The single-variable case was covered in the {ref}`automatic-differentiation` tutorial, where the example showed how to use {func}`jax.grad` to compute the derivative of $f(x) = x^3 + 2x^2 - 3x + 1$.
 
 In the multivariable case, higher-order derivatives are more complicated. The second-order derivative of a function is represented by its [Hessian matrix](https://en.wikipedia.org/wiki/Hessian_matrix), defined according to:
 

--- a/docs/gradient-checkpointing.md
+++ b/docs/gradient-checkpointing.md
@@ -49,7 +49,7 @@ x = jnp.ones(4)
 # Inspect the 'residual' values to be saved on the forward pass
 # if you were to evaluate `jax.grad(f)(W1, W2, W3, x)`
 from jax.ad_checkpoint import print_saved_residuals
-jax.ad_checkpoint.print_saved_residuals(f, W1, W2, W3, x)
+print_saved_residuals(f, W1, W2, W3, x)
 ```
 
 By applying {func}`jax.checkpoint` to sub-functions, as a decorator or at specific application sites, you force JAX not to save any of that sub-function's residuals. Instead, only the inputs of a {func}`jax.checkpoint`-decorated function might be saved, and any residuals consumed on the backward pass are re-computed from those inputs as needed:
@@ -61,7 +61,7 @@ def f2(W1, W2, W3, x):
   x = jax.checkpoint(g)(W3, x)
   return x
 
-jax.ad_checkpoint.print_saved_residuals(f2, W1, W2, W3, x)
+print_saved_residuals(f2, W1, W2, W3, x)
 ```
 
 Here, the values of two `sin` applications are saved because they are arguments
@@ -73,7 +73,7 @@ To control which values are saveable without having to edit the definition of th
 
 ```{code-cell}
 f3 = jax.checkpoint(f, policy=jax.checkpoint_policies.dots_with_no_batch_dims_saveable)
-jax.ad_checkpoint.print_saved_residuals(f3, W1, W2, W3, x)
+print_saved_residuals(f3, W1, W2, W3, x)
 ```
 
 You can also use policies to refer to intermediate values you name using {func}`jax.ad_checkpoint.checkpoint_name`:
@@ -88,7 +88,7 @@ def f4(W1, W2, W3, x):
   return x
 
 f4 = jax.checkpoint(f4, policy=jax.checkpoint_policies.save_only_these_names('a'))
-jax.ad_checkpoint.print_saved_residuals(f4, W1, W2, W3, x)
+print_saved_residuals(f4, W1, W2, W3, x)
 ```
 
 When playing around with these toy examples, you can get a closer look at what's going on using a custom `print_fwd_bwd` utility defined in this notebook:

--- a/docs/gradient-checkpointing.md
+++ b/docs/gradient-checkpointing.md
@@ -288,7 +288,7 @@ As shown so far, using {func}`jax.checkpoint` switches from one extreme to anoth
 
 To operate between these two extremes, saving some things and not others, you can carefully place {func}`jax.checkpoint` decorators on sub-functions. But that requires editing the function to be differentiated, e.g. model code, which may be inconvenient. It can also be hard to experiment with variations.
 
-So an alternative is to use the `policy` argument to {func}`jax.checkpoint`. A policy is a callable (i.e. a function) which takes as input a type-level specification of a first order primitive application and returns a boolean indicating whether the corresponding output value(s) are allowed to be saved as residuals (or instead must be recomputed in the (co)tangent computation as needed). To write robust code, a policy should be selected from the attributes on {func}`jax.checkpoint_policies`, like {func}`jax.checkpoint_policies.dots_with_no_batch_dims_saveable`, since the API for writing custom policy callables is considered internal.
+So an alternative is to use the `policy` argument to {func}`jax.checkpoint`. A policy is a callable (i.e. a function) which takes as input a type-level specification of a first order primitive application and returns a boolean indicating whether the corresponding output value(s) are allowed to be saved as residuals (or instead must be recomputed in the (co)tangent computation as needed). To write robust code, a policy should be selected from the attributes on {obj}`jax.checkpoint_policies`, like {func}`jax.checkpoint_policies.dots_with_no_batch_dims_saveable`, since the API for writing custom policy callables is considered internal.
 
 For example, consider this function to be differentiated:
 

--- a/docs/notebooks/autodiff_remat.ipynb
+++ b/docs/notebooks/autodiff_remat.ipynb
@@ -544,11 +544,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def f_grad_bad(x):\n",
+    "def f_grad_bad1(x):\n",
     "  _ = f(x)                  # step 1\n",
     "  _, f_vjp = jax.vjp(f, x)  # step 2\n",
     "  x_bar, = f_vjp(1.0)       # step 3\n",

--- a/docs/notebooks/autodiff_remat.md
+++ b/docs/notebooks/autodiff_remat.md
@@ -275,7 +275,7 @@ Notice that if `f = lambda x: h(g(x))` is the function we want to differentiate,
 That is, in code we'd have something like:
 
 ```{code-cell}
-def f_grad_bad(x):
+def f_grad_bad1(x):
   _ = f(x)                  # step 1
   _, f_vjp = jax.vjp(f, x)  # step 2
   x_bar, = f_vjp(1.0)       # step 3


### PR DESCRIPTION
I came across a few mal-formatting in the docs here and there
- "compute the the" in [advanced aut-diff](https://docs.jax.dev/en/latest/advanced-autodiff.html)
- `print_saved_residuals` were imported from `jax.ad_checkpoint` then we kept calling it like jax.ad_checkpoint.print_saved_residuals` in [gradient-checkpointint](https://docs.jax.dev/en/latest/gradient-checkpointing.html) (this one may be a preference )
- checkpoint_policies namespace were mentioned like `jax.checkpoint_policies()` (as a function) in [gradient-checkpointint](https://docs.jax.dev/en/latest/gradient-checkpointing.html) 
- first function was called f_grad_bad, and second one f_grad_bad2 (renamed first one to f_grad_bad1) in [auto-diff remat](https://docs.jax.dev/en/latest/notebooks/autodiff_remat.html)