### PR TITLE
Docs: Align CUDA installation instructions to cuda13

### DIFF
--- a/docs/notebooks/thinking_in_jax.md
+++ b/docs/notebooks/thinking_in_jax.md
@@ -43,7 +43,7 @@ pip install jax
 or, for NVIDIA GPU:
 
 ```
-pip install -U "jax[cuda12]"
+pip install -U "jax[cuda13]"
 ```
 For more detailed platform-specific installation information, check out [Installation](https://docs.jax.dev/en/latest/installation.html).
 


### PR DESCRIPTION
Closes #31907

This PR resolves a minor documentation discrepancy where different CUDA versions were specified in the `pip install` commands across the repository.

The main `README.md` and the installation guide correctly suggest using `jax[cuda13]`, but the `thinking_in_jax.md` notebook still referenced` jax[cuda12]`.

This change updates the notebook to recommend `jax[cuda13]`, ensuring all installation instructions are consistent.