### PR TITLE
Add Sici Function

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -190,6 +190,7 @@ jax.scipy.special
    poch
    polygamma
    rel_entr
+   sici
    softmax
    spence
    sph_harm

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -55,6 +55,7 @@ from jax._src.scipy.special import (
   poch as poch,
   polygamma as polygamma,
   rel_entr as rel_entr,
+  sici as sici,
   softmax as softmax,
   spence as spence,
   sph_harm as _deprecated_sph_harm,


### PR DESCRIPTION
Adds in [Scipy sici function] which calculates the integrals of sine and cosine (https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.sici.html). Closes jax-ml/jax#31121

Note: Scipy's implementation uses complex exponentials to allow for complex numbers as input. This implementation only allows for real numbers. To fix this difference, we would need to allow for the exponential integral functional (expi) to accept complex input.