### PR TITLE
add aval_property.setter

### DIFF
--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -847,9 +847,9 @@ class JVPTracer(Tracer):
   def __init__(self, trace, primal, tangent):
     if config.enable_checks.value:
       _primal_tangent_shapes_match(primal, tangent)
-    self._trace = trace
-    self.primal = primal
-    self.tangent = tangent
+    object.__setattr__(self, '_trace', trace)
+    object.__setattr__(self, 'primal', primal)
+    object.__setattr__(self, 'tangent', tangent)
 
   def _short_repr(self):
     return f"GradTracer<{self.aval}>"
@@ -1219,9 +1219,9 @@ class LinearizeTracer(Tracer):
   def __init__(self, trace, primal, tangent):
     if config.enable_checks.value:
       _primal_tangent_shapes_match(primal, tangent)
-    self._trace = trace
-    self.primal = primal
-    self.tangent = tangent
+    object.__setattr__(self, '_trace', trace)
+    object.__setattr__(self, 'primal', primal)
+    object.__setattr__(self, 'tangent', tangent)
 
   @property
   def aval(self):

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -458,10 +458,10 @@ class BatchTracer(Tracer):
       if type(batch_dim) is int:
         aval = core.get_aval(val)
         assert 0 <= batch_dim < len(aval.shape)
-    self._trace = trace
-    self.val = val
-    self.batch_dim = batch_dim
-    self.source_info = source_info
+    object.__setattr__(self, '_trace', trace)
+    object.__setattr__(self, 'val', val)
+    object.__setattr__(self, 'batch_dim', batch_dim)
+    object.__setattr__(self, 'source_info', source_info)
 
   def _short_repr(self):
     return f"VmapTracer<{self.aval}>"

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -606,9 +606,9 @@ class JaxprTracer(Tracer):
                recipe: JaxprTracerRecipe | None):
     assert isinstance(pval, PartialVal)
     pv, const = pval
-    self._trace = trace
-    self.pval = pval
-    self.recipe = recipe
+    object.__setattr__(self, '_trace', trace)
+    object.__setattr__(self, 'pval', pval)
+    object.__setattr__(self, 'recipe', recipe)
 
   def __repr__(self):
     return f'Traced<{self.aval}:{self._trace}>'
@@ -1729,13 +1729,13 @@ class DynamicJaxprTracer(core.Tracer):
     else:
       assert not aval.has_qdd
       qdd = None
-    self._trace = trace
-    self._line_info = line_info
-    self._debug_info = self._trace.frame.debug_info  # for UnexpectedTracerError
-    self.aval = aval  # type: ignore[misc]
-    self.val = val
-    self.mutable_qdd = core.MutableQuasiDynamicData(qdd)
-    self.parent = parent
+    object.__setattr__(self, '_trace', trace)
+    object.__setattr__(self, '_line_info', line_info)
+    object.__setattr__(self, '_debug_info', self._trace.frame.debug_info)  # for UnexpectedTracerError
+    object.__setattr__(self, 'aval', aval)  # type: ignore[misc]
+    object.__setattr__(self, 'val', val)
+    object.__setattr__(self, 'mutable_qdd', core.MutableQuasiDynamicData(qdd))
+    object.__setattr__(self, 'parent', parent)
 
   def _short_repr(self):
     return f"JitTracer<{self.aval}>"

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -608,9 +608,9 @@ class MapTracer(core.Tracer):
   __slots__ = ["val", "shard_axes"]
 
   def __init__(self, trace: MapTrace, val, shard_axes: dict[core.AxisName, int]):
-    self._trace = trace
-    self.val = val
-    self.shard_axes = shard_axes
+    object.__setattr__(self, '_trace', trace)
+    object.__setattr__(self, 'val', val)
+    object.__setattr__(self, 'shard_axes', shard_axes)
     assert all(val < self.val.ndim for val in self.shard_axes.values())
 
   @property

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -1262,12 +1262,12 @@ class ShardMapTracer(core.Tracer):
   val: JaxType
 
   def __init__(self, trace, vma, val):
-    self._trace = trace
+    object.__setattr__(self, '_trace', trace)
     if isinstance(vma, set):
       vma = frozenset(vma)
     assert isinstance(vma, frozenset)
-    self.vma = vma
-    self.val = val
+    object.__setattr__(self, 'vma', vma)
+    object.__setattr__(self, 'val', val)
 
   @property
   def aval(self):

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -205,9 +205,9 @@ class JetTracer(core.Tracer):
 
   def __init__(self, trace, primal, terms):
     assert type(terms) in (ZeroSeries, list, tuple)
-    self._trace = trace
-    self.primal = primal
-    self.terms = terms
+    object.__setattr__(self, '_trace', trace)
+    object.__setattr__(self, 'primal', primal)
+    object.__setattr__(self, 'terms', terms)
 
   @property
   def aval(self):

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -280,8 +280,8 @@ def spvalues_to_avals(
 
 class SparseTracer(core.Tracer):
   def __init__(self, trace: core.Trace, *, spvalue):
-    self._spvalue = spvalue
-    self._trace = trace
+    object.__setattr__(self, '_spvalue', spvalue)
+    object.__setattr__(self, '_trace', trace)
 
   @property
   def spenv(self):


### PR DESCRIPTION
# Description
Currently `Tracer` allows abstract value types to expose certain functions as tracer getter properties via the `aval_property` mechanism. However this mechanism currently doesn't support setter properties, this limits what custom `HiType`s can express. In particular, it doesn't allow implementing a `Variable`-like abstraction with a getter and setter for a `.value` property e.g.

```python
val = variable_tracer.value      # possible
variable_tracer.value = new_val  # not possible
```

## Proposal

Extend `aval_property` to allow for setters and implement `Tracer.__setattr__` to forward the computation to the underlaying `aval_property`'s setter if available. Abstract values would now be able to express property setters like this:

```python
@aval_property
def value(self): ...

@value.setter
def value(self, val): ...
```
such that the original example above works.

## Costs

Implementing `__setattr__` in a non-trivial manner has the consequence that attribute initialization for all `Tracer` types will require using `object.__setattr__(self, attr_name, value)` to avoid triggering `__setattr__` as it results in RecursionErrors. This will make the creation of new Tracer types a more verbose and error prone (when you forget to use `object.__setattr__`). To mitigate the later, a RecursionError is re-raised with a custom message that points to the source of the error and suggests a solution:

```
 RecursionError: Got recursion error while trying to set attribute 'BatchTracer._trace'.
 Try using `object.__setattr__(self, '_trace', value)` instead.
```