### PR TITLE
[mutable arrays] deprecate old public aliases for new_ref and Ref.

### DIFF
--- a/docs/array_refs.ipynb
+++ b/docs/array_refs.ipynb
@@ -55,7 +55,7 @@
     "import jax\n",
     "import jax.numpy as jnp\n",
     "\n",
-    "x_ref = jax.array_ref(jnp.zeros(3))  # new array ref, with initial value [0., 0., 0.]\n",
+    "x_ref = jax.new_ref(jnp.zeros(3))  # new array ref, with initial value [0., 0., 0.]\n",
     "\n",
     "@jax.jit\n",
     "def f():\n",
@@ -85,7 +85,7 @@
    "outputs": [],
    "source": [
     "def g(x):\n",
-    "  x_ref = jax.array_ref(0.)\n",
+    "  x_ref = jax.new_ref(0.)\n",
     "  x_ref[...] = jnp.sin(x)\n",
     "  return x_ref[...]\n",
     "\n",
@@ -110,7 +110,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x_ref = jax.array_ref(1.0)\n",
+    "x_ref = jax.new_ref(1.0)\n",
     "try:\n",
     "  jnp.sin(x_ref)  # error! can't do math on refs\n",
     "except Exception as e:\n",
@@ -132,7 +132,7 @@
     "If you've ever used\n",
     "[Pallas](https://docs.jax.dev/en/latest/pallas/quickstart.html), then `Ref`\n",
     "should look familiar. A big difference is that you can create new `Ref`s\n",
-    "yourself directly using `jax.array_ref`:"
+    "yourself directly using `jax.new_ref`:"
    ]
   },
   {
@@ -211,7 +211,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x_ref = jax.array_ref(jnp.arange(12.).reshape(3, 4))\n",
+    "x_ref = jax.new_ref(jnp.arange(12.).reshape(3, 4))\n",
     "\n",
     "# int indexing\n",
     "row = x_ref[0]\n",
@@ -258,7 +258,7 @@
     "  x_ref[...] = y_ref[...]\n",
     "\n",
     "# closes over ref => impure\n",
-    "y_ref = jax.array_ref(0)\n",
+    "y_ref = jax.new_ref(0)\n",
     "\n",
     "@jax.jit\n",
     "def impure2(x):\n",
@@ -284,7 +284,7 @@
     "# internal refs => still pure\n",
     "@jax.jit\n",
     "def pure1(x):\n",
-    "  ref = jax.array_ref(x)\n",
+    "  ref = jax.new_ref(x)\n",
     "  ref[...] = ref[...] + ref[...]\n",
     "  return ref[...]"
    ]
@@ -323,7 +323,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x_ref = jax.array_ref(0.)\n",
+    "x_ref = jax.new_ref(0.)\n",
     "\n",
     "# can't return refs\n",
     "@jax.jit\n",
@@ -396,7 +396,7 @@
     "  out_ref[...] = jnp.sum((x - y) ** 2)\n",
     "\n",
     "vecs = jnp.arange(12.).reshape(3, 4)\n",
-    "out_ref = jax.array_ref(jnp.zeros((3, 3)))\n",
+    "out_ref = jax.new_ref(jnp.zeros((3, 3)))\n",
     "jax.vmap(jax.vmap(dist, (0, None, 0)), (None, 0, 0))(vecs, vecs, out_ref)  # ok!\n",
     "print(out_ref)"
    ]
@@ -409,7 +409,7 @@
    "outputs": [],
    "source": [
     "# vmap with a closed-over ref is not\n",
-    "x_ref = jax.array_ref(0.)\n",
+    "x_ref = jax.new_ref(0.)\n",
     "\n",
     "def err5(x):\n",
     "  x_ref[...] = x\n",
@@ -443,7 +443,7 @@
    "source": [
     "@jax.jit\n",
     "def pure2(x):\n",
-    "  ref = jax.array_ref(x)\n",
+    "  ref = jax.new_ref(x)\n",
     "  ref[...] = ref[...] + ref[...]\n",
     "  return ref[...]\n",
     "\n",
@@ -525,7 +525,7 @@
     "  x = stash_grads(grads_ref, x)\n",
     "  return x\n",
     "\n",
-    "grads_ref = jax.array_ref(0.)\n",
+    "grads_ref = jax.new_ref(0.)\n",
     "f(1., grads_ref)\n",
     "print(grads_ref)"
    ]
@@ -557,7 +557,7 @@
     "def sin_inplace(x_ref):\n",
     "  x_ref[...] = jnp.sin(x_ref[...])\n",
     "\n",
-    "x_ref = jax.array_ref(jnp.arange(3.))\n",
+    "x_ref = jax.new_ref(jnp.arange(3.))\n",
     "print(x_ref.unsafe_buffer_pointer(), x_ref)\n",
     "sin_inplace(x_ref)\n",
     "print(x_ref.unsafe_buffer_pointer(), x_ref)"
@@ -621,7 +621,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "r = jax.array_ref(0)\n",
+    "r = jax.new_ref(0)\n",
     "xs = jnp.arange(10)\n",
     "\n",
     "@foreach(xs)\n",

--- a/docs/array_refs.md
+++ b/docs/array_refs.md
@@ -50,7 +50,7 @@ in-place. These array references are compatible with JAX transformations, like
 import jax
 import jax.numpy as jnp
 
-x_ref = jax.array_ref(jnp.zeros(3))  # new array ref, with initial value [0., 0., 0.]
+x_ref = jax.new_ref(jnp.zeros(3))  # new array ref, with initial value [0., 0., 0.]
 
 @jax.jit
 def f():
@@ -68,7 +68,7 @@ entire value using `x_ref[...] = A` for some `Array`-valued expression `A`:
 
 ```{code-cell}
 def g(x):
-  x_ref = jax.array_ref(0.)
+  x_ref = jax.new_ref(0.)
   x_ref[...] = jnp.sin(x)
   return x_ref[...]
 
@@ -81,7 +81,7 @@ about the *only* thing you can do with an `Ref`. References can't be passed
 where `Array`s are expected:
 
 ```{code-cell}
-x_ref = jax.array_ref(1.0)
+x_ref = jax.new_ref(1.0)
 try:
   jnp.sin(x_ref)  # error! can't do math on refs
 except Exception as e:
@@ -98,7 +98,7 @@ recipes.
 If you've ever used
 [Pallas](https://docs.jax.dev/en/latest/pallas/quickstart.html), then `Ref`
 should look familiar. A big difference is that you can create new `Ref`s
-yourself directly using `jax.array_ref`:
+yourself directly using `jax.new_ref`:
 
 ```{code-cell}
 from jax import Array, Ref
@@ -134,7 +134,7 @@ def swap(ref: Ref, idx: Indexer, val: Array) -> Array:
 Here, `Indexer` can be any NumPy indexing expression:
 
 ```{code-cell}
-x_ref = jax.array_ref(jnp.arange(12.).reshape(3, 4))
+x_ref = jax.new_ref(jnp.arange(12.).reshape(3, 4))
 
 # int indexing
 row = x_ref[0]
@@ -169,7 +169,7 @@ def impure1(x_ref, y_ref):
   x_ref[...] = y_ref[...]
 
 # closes over ref => impure
-y_ref = jax.array_ref(0)
+y_ref = jax.new_ref(0)
 
 @jax.jit
 def impure2(x):
@@ -183,7 +183,7 @@ is in the eye of the caller. For example:
 # internal refs => still pure
 @jax.jit
 def pure1(x):
-  ref = jax.array_ref(x)
+  ref = jax.new_ref(x)
   ref[...] = ref[...] + ref[...]
   return ref[...]
 ```
@@ -210,7 +210,7 @@ use:
 For example, these are errors:
 
 ```{code-cell}
-x_ref = jax.array_ref(0.)
+x_ref = jax.new_ref(0.)
 
 # can't return refs
 @jax.jit
@@ -271,14 +271,14 @@ def dist(x, y, out_ref):
   out_ref[...] = jnp.sum((x - y) ** 2)
 
 vecs = jnp.arange(12.).reshape(3, 4)
-out_ref = jax.array_ref(jnp.zeros((3, 3)))
+out_ref = jax.new_ref(jnp.zeros((3, 3)))
 jax.vmap(jax.vmap(dist, (0, None, 0)), (None, 0, 0))(vecs, vecs, out_ref)  # ok!
 print(out_ref)
 ```
 
 ```{code-cell}
 # vmap with a closed-over ref is not
-x_ref = jax.array_ref(0.)
+x_ref = jax.new_ref(0.)
 
 def err5(x):
   x_ref[...] = x
@@ -300,7 +300,7 @@ internally. For example:
 ```{code-cell}
 @jax.jit
 def pure2(x):
-  ref = jax.array_ref(x)
+  ref = jax.new_ref(x)
   ref[...] = ref[...] + ref[...]
   return ref[...]
 
@@ -352,7 +352,7 @@ def f(x, grads_ref):
   x = stash_grads(grads_ref, x)
   return x
 
-grads_ref = jax.array_ref(0.)
+grads_ref = jax.new_ref(0.)
 f(1., grads_ref)
 print(grads_ref)
 ```
@@ -372,7 +372,7 @@ the need for donation, since they are effectively always donated:
 def sin_inplace(x_ref):
   x_ref[...] = jnp.sin(x_ref[...])
 
-x_ref = jax.array_ref(jnp.arange(3.))
+x_ref = jax.new_ref(jnp.arange(3.))
 print(x_ref.unsafe_buffer_pointer(), x_ref)
 sin_inplace(x_ref)
 print(x_ref.unsafe_buffer_pointer(), x_ref)
@@ -418,7 +418,7 @@ def foreach(*args):
 ```
 
 ```{code-cell}
-r = jax.array_ref(0)
+r = jax.new_ref(0)
 xs = jnp.arange(10)
 
 @foreach(xs)

--- a/docs/array_refs.py
+++ b/docs/array_refs.py
@@ -44,7 +44,7 @@
 import jax
 import jax.numpy as jnp
 
-x_ref = jax.array_ref(jnp.zeros(3))  # new array ref, with initial value [0., 0., 0.]
+x_ref = jax.new_ref(jnp.zeros(3))  # new array ref, with initial value [0., 0., 0.]
 
 @jax.jit
 def f():
@@ -64,7 +64,7 @@ print(x_ref)  # Ref([0., 2., 0.])
 
 # +
 def g(x):
-  x_ref = jax.array_ref(0.)
+  x_ref = jax.new_ref(0.)
   x_ref[...] = jnp.sin(x)
   return x_ref[...]
 
@@ -76,7 +76,7 @@ print(jax.grad(g)(1.0))  # 0.54
 # about the *only* thing you can do with an `Ref`. References can't be passed
 # where `Array`s are expected:
 
-x_ref = jax.array_ref(1.0)
+x_ref = jax.new_ref(1.0)
 try:
   jnp.sin(x_ref)  # error! can't do math on refs
 except Exception as e:
@@ -92,7 +92,7 @@ except Exception as e:
 # If you've ever used
 # [Pallas](https://docs.jax.dev/en/latest/pallas/quickstart.html), then `Ref`
 # should look familiar. A big difference is that you can create new `Ref`s
-# yourself directly using `jax.array_ref`:
+# yourself directly using `jax.new_ref`:
 
 # +
 from jax import Array, Ref
@@ -131,7 +131,7 @@ def swap(ref: Ref, idx: Indexer, val: Array) -> Array:
 # Here, `Indexer` can be any NumPy indexing expression:
 
 # +
-x_ref = jax.array_ref(jnp.arange(12.).reshape(3, 4))
+x_ref = jax.new_ref(jnp.arange(12.).reshape(3, 4))
 
 # int indexing
 row = x_ref[0]
@@ -168,7 +168,7 @@ def impure1(x_ref, y_ref):
   x_ref[...] = y_ref[...]
 
 # closes over ref => impure
-y_ref = jax.array_ref(0)
+y_ref = jax.new_ref(0)
 
 @jax.jit
 def impure2(x):
@@ -183,7 +183,7 @@ def impure2(x):
 # internal refs => still pure
 @jax.jit
 def pure1(x):
-  ref = jax.array_ref(x)
+  ref = jax.new_ref(x)
   ref[...] = ref[...] + ref[...]
   return ref[...]
 
@@ -210,7 +210,7 @@ def pure1(x):
 # For example, these are errors:
 
 # +
-x_ref = jax.array_ref(0.)
+x_ref = jax.new_ref(0.)
 
 # can't return refs
 @jax.jit
@@ -273,13 +273,13 @@ def dist(x, y, out_ref):
   out_ref[...] = jnp.sum((x - y) ** 2)
 
 vecs = jnp.arange(12.).reshape(3, 4)
-out_ref = jax.array_ref(jnp.zeros((3, 3)))
+out_ref = jax.new_ref(jnp.zeros((3, 3)))
 jax.vmap(jax.vmap(dist, (0, None, 0)), (None, 0, 0))(vecs, vecs, out_ref)  # ok!
 print(out_ref)
 
 # +
 # vmap with a closed-over ref is not
-x_ref = jax.array_ref(0.)
+x_ref = jax.new_ref(0.)
 
 def err5(x):
   x_ref[...] = x
@@ -303,7 +303,7 @@ except Exception as e:
 # +
 @jax.jit
 def pure2(x):
-  ref = jax.array_ref(x)
+  ref = jax.new_ref(x)
   ref[...] = ref[...] + ref[...]
   return ref[...]
 
@@ -359,7 +359,7 @@ def f(x, grads_ref):
   x = stash_grads(grads_ref, x)
   return x
 
-grads_ref = jax.array_ref(0.)
+grads_ref = jax.new_ref(0.)
 f(1., grads_ref)
 print(grads_ref)
 
@@ -381,7 +381,7 @@ print(grads_ref)
 def sin_inplace(x_ref):
   x_ref[...] = jnp.sin(x_ref[...])
 
-x_ref = jax.array_ref(jnp.arange(3.))
+x_ref = jax.new_ref(jnp.arange(3.))
 print(x_ref.unsafe_buffer_pointer(), x_ref)
 sin_inplace(x_ref)
 print(x_ref.unsafe_buffer_pointer(), x_ref)
@@ -427,7 +427,7 @@ def foreach(*args):
 
 
 # +
-r = jax.array_ref(0)
+r = jax.new_ref(0)
 xs = jnp.arange(10)
 
 @foreach(xs)

--- a/docs/jax.ref.rst
+++ b/docs/jax.ref.rst
@@ -12,9 +12,7 @@ API
    :toctree: _autosummary
 
    AbstractRef
-   ArrayRef
    Ref
-   array_ref
    freeze
    get
    new_ref

--- a/docs/the-training-cookbook.py
+++ b/docs/the-training-cookbook.py
@@ -164,7 +164,7 @@ def init_adam_state(param: jax.Array) -> dot_dict:
 
 
 # tag: adam-apply
-def adam_update(config: Config, param: jax.ArrayRef, grad: jax.Array, adam_state: dot_dict):
+def adam_update(config: Config, param: jax.Ref, grad: jax.Array, adam_state: dot_dict):
   adam_state.mu[...] = (1 - config.beta_1) * adam_state.mu[...] + config.beta_1 * grad
   adam_state.nu[...] = (1 - config.beta_2) * adam_state.nu[...] + config.beta_2 * grad**2
   adam_state.count[...] += 1

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -140,9 +140,7 @@ from jax._src.shard_map import shard_map as shard_map
 from jax._src.shard_map import smap as smap
 
 from jax.ref import new_ref as new_ref
-from jax.ref import array_ref as array_ref
 from jax.ref import Ref as Ref
-from jax.ref import ArrayRef as ArrayRef
 
 # Force import, allowing jax.interpreters.* to be used after import jax.
 from jax.interpreters import ad, batching, mlir, partial_eval, pxla, xla
@@ -187,6 +185,15 @@ import jax.experimental.compilation_cache.compilation_cache as _ccache
 del _ccache
 
 _deprecations = {
+  # Added for v0.8.0
+  "array_ref": (
+    "jax.array_ref is deprecated; use jax.new_ref instead.",
+    new_ref
+  ),
+  "ArrayRef": (
+    "jax.ArrayRef is deprecated; use jax.Ref instead.",
+    Ref
+  ),
   # Finalized 2025-03-25; remove after 2025-06-25
   "treedef_is_leaf": (
     "jax.treedef_is_leaf was removed in JAX v0.6.0: use jax.tree_util.treedef_is_leaf.",
@@ -226,7 +233,8 @@ _deprecations = {
 
 import typing as _typing
 if _typing.TYPE_CHECKING:
-  pass
+  array_ref = new_ref
+  ArrayRef = Ref
 else:
   from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
   __getattr__ = _deprecation_getattr(__name__, _deprecations)

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2569,7 +2569,7 @@ class Ref:
   """Mutable array reference.
 
   In most cases this should not be constructed directly, but rather
-  via :func:`jax.ref.array_ref`. For examples of how this can be
+  via :func:`jax.ref.new_ref`. For examples of how this can be
   used, refer to the `Ref guide`_.
 
   .. _Ref guide: https://docs.jax.dev/en/latest/array_refs.html
@@ -2695,7 +2695,7 @@ def freeze(ref: ArrayRef) -> Array:
 
   Examples:
     >>> import jax
-    >>> ref = jax.array_ref(jax.numpy.arange(5))
+    >>> ref = jax.new_ref(jax.numpy.arange(5))
     >>> ref[3] = 100
     >>> ref
     Ref([  0,   1,   2, 100,   4], dtype=int32)

--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -129,7 +129,7 @@ def ref_get(
 
   Examples:
     >>> import jax
-    >>> ref = jax.array_ref(jax.numpy.arange(5))
+    >>> ref = jax.new_ref(jax.numpy.arange(5))
     >>> jax.ref.get(ref, slice(1, 3))
     Array([1, 2], dtype=int32)
 
@@ -223,7 +223,7 @@ def ref_swap(
 
   Examples:
     >>> import jax
-    >>> ref = jax.array_ref(jax.numpy.arange(5))
+    >>> ref = jax.new_ref(jax.numpy.arange(5))
     >>> jax.ref.swap(ref, 3, 10)
     Array(3, dtype=int32)
     >>> ref
@@ -231,7 +231,7 @@ def ref_swap(
 
     Equivalent operation via indexing syntax:
 
-    >>> ref = jax.array_ref(jax.numpy.arange(5))
+    >>> ref = jax.new_ref(jax.numpy.arange(5))
     >>> ref[3], prev = 10, ref[3]
     >>> prev
     Array(3, dtype=int32)
@@ -240,7 +240,7 @@ def ref_swap(
 
     Use ``...`` to swap the value of a scalar ref:
 
-    >>> ref = jax.array_ref(jax.numpy.int32(5))
+    >>> ref = jax.new_ref(jax.numpy.int32(5))
     >>> jax.ref.swap(ref, ..., 10)
     Array(5, dtype=int32)
     >>> ref
@@ -291,21 +291,21 @@ def ref_set(
 
   Examples:
     >>> import jax
-    >>> ref = jax.array_ref(jax.numpy.zeros(5))
+    >>> ref = jax.new_ref(jax.numpy.zeros(5))
     >>> jax.ref.set(ref, 1, 10.0)
     >>> ref
     Ref([ 0., 10.,  0.,  0.,  0.], dtype=float32)
 
     Equivalent operation via indexing syntax:
 
-    >>> ref = jax.array_ref(jax.numpy.zeros(5))
+    >>> ref = jax.new_ref(jax.numpy.zeros(5))
     >>> ref[1] = 10.0
     >>> ref
     Ref([ 0., 10.,  0.,  0.,  0.], dtype=float32)
 
     Use ``...`` to set the value of a scalar ref:
 
-    >>> ref = jax.array_ref(jax.numpy.int32(0))
+    >>> ref = jax.new_ref(jax.numpy.int32(0))
     >>> ref[...] = 4
     >>> ref
     Ref(4, dtype=int32)
@@ -357,21 +357,21 @@ def ref_addupdate(
 
   Examples:
     >>> import jax
-    >>> ref = jax.array_ref(jax.numpy.arange(5))
+    >>> ref = jax.new_ref(jax.numpy.arange(5))
     >>> jax.ref.addupdate(ref, 2, 10)
     >>> ref
     Ref([ 0,  1, 12,  3,  4], dtype=int32)
 
     Equivalent operation via indexing syntax:
 
-    >>> ref = jax.array_ref(jax.numpy.arange(5))
+    >>> ref = jax.new_ref(jax.numpy.arange(5))
     >>> ref[2] += 10
     >>> ref
     Ref([ 0,  1, 12,  3,  4], dtype=int32)
 
     Use ``...`` to add to a scalar ref:
 
-    >>> ref = jax.array_ref(jax.numpy.int32(2))
+    >>> ref = jax.new_ref(jax.numpy.int32(2))
     >>> ref[...] += 10
     >>> ref
     Ref(12, dtype=int32)

--- a/jax/experimental/__init__.py
+++ b/jax/experimental/__init__.py
@@ -38,7 +38,27 @@ from jax._src.dtypes import (
 from jax._src.earray import (
     EArray as EArray
 )
-from jax._src.core import (
-    mutable_array as mutable_array,
-    MutableArray as MutableArray,
-)
+from jax._src import core as _src_core
+
+_deprecations = {
+  # Added for v0.8.0
+  "mutable_array": (
+    "jax.experimental.mutable_array is deprecated; use jax.new_ref instead.",
+    _src_core.new_ref
+  ),
+  "MutableArray": (
+    "jax.experimental.MutableArray is deprecated; use jax.Ref instead.",
+    _src_core.Ref
+  ),
+}
+
+import typing as _typing
+if _typing.TYPE_CHECKING:
+  mutable_array = _src_core.new_ref
+  MutableArray = _src_core.Ref
+else:
+  from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
+  __getattr__ = _deprecation_getattr(__name__, _deprecations)
+  del _deprecation_getattr
+del _typing
+del _src_core

--- a/jax/ref.py
+++ b/jax/ref.py
@@ -15,8 +15,8 @@
 __all__ = ['AbstractRef', 'Ref', 'ArrayRef', 'addupdate', 'new_ref', 'array_ref',
            'freeze', 'get', 'set', 'swap']
 
-from jax._src.core import Ref, ArrayRef, freeze
-from jax._src.ref import new_ref, array_ref
+from jax._src.core import Ref, freeze
+from jax._src.ref import new_ref
 from jax._src.state.types import AbstractRef
 from jax._src.state.primitives import (
     ref_get as get,
@@ -24,3 +24,26 @@ from jax._src.state.primitives import (
     ref_swap as swap,
     ref_addupdate as addupdate,
 )
+
+
+_deprecations = {
+  # Added for v0.8.0
+  "array_ref": (
+    "jax.array_ref is deprecated; use jax.new_ref instead.",
+    new_ref
+  ),
+  "ArrayRef": (
+    "jax.ArrayRef is deprecated; use jax.Ref instead.",
+    Ref
+  ),
+}
+
+import typing as _typing
+if _typing.TYPE_CHECKING:
+  array_ref = new_ref
+  ArrayRef = Ref
+else:
+  from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
+  __getattr__ = _deprecation_getattr(__name__, _deprecations)
+  del _deprecation_getattr
+del _typing

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -1031,7 +1031,7 @@ class RefTest(jtu.JaxTestCase):
 
     @jax.jit
     def f(q):
-      ref = jax.array_ref(q)
+      ref = jax.new_ref(q)
       return ref[:, 0:2]
 
     qarray = QArray(jnp.ones((2, 2), dtype='int8'), jnp.ones(2, 'float32'))
@@ -1043,7 +1043,7 @@ class RefTest(jtu.JaxTestCase):
 
     @jax.jit
     def f(q1, q2):
-      ref = jax.array_ref(q1)
+      ref = jax.new_ref(q1)
       ref[:, :] = q2
       return ref.get()
 

--- a/tests/mutable_array_test.py
+++ b/tests/mutable_array_test.py
@@ -790,7 +790,7 @@ class MutableArrayTest(jtu.JaxTestCase):
       return jnp.mean(act)
 
     def process_batch(Ws, xs_batch):
-      grad_acc = jax.array_ref(jnp.zeros_like(Ws))               # CHANGED
+      grad_acc = jax.new_ref(jnp.zeros_like(Ws))               # CHANGED
 
       def process_mubatch(_, xs):
         loss, f_vjp = vjp3(lambda Ws: mubatch_loss(Ws, xs), Ws)  # CHANGED
@@ -813,7 +813,7 @@ class MutableArrayTest(jtu.JaxTestCase):
   def test_custom_vjp_internal_ref(self, jit):
     @jax.custom_vjp
     def f(x):
-      x_ref = jax.array_ref(jnp.zeros_like(x))
+      x_ref = jax.new_ref(jnp.zeros_like(x))
       x_ref[...] = x
       return x_ref[...]
     def f_fwd(x):
@@ -834,7 +834,7 @@ class MutableArrayTest(jtu.JaxTestCase):
   def test_custom_vjp_ad_after_discharge_error(self):
     @jax.custom_vjp
     def f(x):
-      x_ref = jax.array_ref(jnp.zeros_like(x))
+      x_ref = jax.new_ref(jnp.zeros_like(x))
       x_ref[...] = x
       return x_ref[...]
     def f_fwd(x):
@@ -864,23 +864,23 @@ class MutableArrayTest(jtu.JaxTestCase):
     if jit:
       f = jax.jit(f)
 
-    y = f(jax.array_ref(3.14))
+    y = f(jax.new_ref(3.14))
     self.assertAllClose(y, 3.14, check_dtypes=False)
 
     # this exercises the fallback path, not a fancy transpose
-    _, f_vjp = vjp3(lambda x: f(jax.array_ref(x)), 3.14)
+    _, f_vjp = vjp3(lambda x: f(jax.new_ref(x)), 3.14)
     g, = f_vjp(1.)
     self.assertAllClose(g, 1., check_dtypes=False)
 
   def test_get_transpose_uninstantiated_grad_ref(self):
     # from https://github.com/jax-ml/jax/pull/31412#discussion_r2308151559
-    f = lambda x: jax.array_ref(x)[0]
+    f = lambda x: jax.new_ref(x)[0]
     jax.grad(f)(jnp.array([3.]))  # don't crash
 
   def test_vmap_create_ref_from_unbatched_value(self):
     @jax.jit
     def internally_pure(x):
-      ref = jax.array_ref(1.)
+      ref = jax.new_ref(1.)
       ref[...] += x
       return ref[...]
 

--- a/tests/pallas/mosaic_gpu_test.py
+++ b/tests/pallas/mosaic_gpu_test.py
@@ -5857,7 +5857,7 @@ class HelpersTest(PallasTest):
 #   def test_basic(self):
 #     @jax.jit
 #     def f(x):
-#       x_ref = jax.array_ref(x)  # lowers to pin
+#       x_ref = jax.new_ref(x)  # lowers to pin
 #       mesh = plgpu.Mesh(grid=(1,), grid_names=('x',))
 
 #       @pl.core_map(mesh)

--- a/tests/pallas/tpu_pallas_memory_space_test.py
+++ b/tests/pallas/tpu_pallas_memory_space_test.py
@@ -171,10 +171,8 @@ class TPUCoreMapMemorySpaceTest(jtu.JaxTestCase):
       self.skipTest('Needs a newer libTPU')
     @jax.jit
     def f(x):
-      x_ref = jax.experimental.mutable_array(x, memory_space=memory_space)
-      y_ref = jax.experimental.mutable_array(
-          pl.empty_like(x), memory_space=memory_space
-      )
+      x_ref = jax.new_ref(x, memory_space=memory_space)
+      y_ref = jax.new_ref(pl.empty_like(x), memory_space=memory_space)
 
       self.assertEqual(jax.typeof(x_ref).memory_space, memory_space)
       self.assertEqual(jax.typeof(y_ref).memory_space, memory_space)

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -1351,7 +1351,7 @@ class StateControlFlowTest(jtu.JaxTestCase):
       x_ref[...] += 1
       return (), ()
 
-    x_ref = jax.array_ref(jnp.arange(3.))
+    x_ref = jax.new_ref(jnp.arange(3.))
     jaxpr = jax.make_jaxpr(lambda x_ref: jax.lax.scan(body, (), x_ref))(x_ref)
     jaxpr, () = discharge_state(jaxpr.jaxpr, jaxpr.consts)
     scan_eqn = jaxpr.eqns[0]


### PR DESCRIPTION
Also update public-facing docs to use the new preferred names.