### PR TITLE
add aval_property.setter

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1063,6 +1063,30 @@ class Tracer(typing.Array, metaclass=StrictABCMeta):
       else:
         return attr
 
+  def __setattr__(self, name, value):
+    # hardcoding 'value' for now, a more general mechanism
+    # could be added in the future
+    if name == "value":
+      try:
+        attr = getattr(self.aval, name)
+      except AttributeError as err:
+        raise AttributeError(
+          f"Cannot set attribute '{type(self).__name__}.{name}' because it "
+          "conflicts with a named reserved for aval setter properties."
+        ) from err
+      if type(attr) is aval_property:
+        if attr.fset is None:
+          raise AttributeError(
+            f"Cannot set aval property '{name}' because it is a "
+            "read-only property."
+          )
+        return attr.fset(self, value)
+      raise AttributeError(
+        f"Cannot set attribute '{type(self).__name__}.{name}' because it "
+        "conflicts with a named reserved for aval setter properties."
+      )
+    object.__setattr__(self, name, value)
+
   def _short_repr(self) -> str:
     return f'{self.__class__.__name__}<{self.aval}>'
 
@@ -1164,8 +1188,12 @@ class Tracer(typing.Array, metaclass=StrictABCMeta):
 
 # these can be used to set up forwarding of properties and instance methods from
 # Tracer instances to the underlying avals
-aval_property = namedtuple("aval_property", ["fget"])
 aval_method = namedtuple("aval_method", ["fun"])
+class aval_property(NamedTuple):
+  fget: Any = None
+  fset: Any = None
+  def setter(self, fset) -> "aval_property":
+    return aval_property(self.fget, fset)
 
 pytype_aval_mappings[Tracer] = lambda x: x.aval
 

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -442,6 +442,49 @@ class CoreTest(jtu.JaxTestCase):
     jax.grad(f)(jnp.float16(1.0))
     self.assertRegex(x_repr, r"^Traced<float16\[\]>with<(JVP)|(Linearize)Trace>")
 
+  def test_aval_property_setter(self):
+    test = self
+    val = 1
+    class SomeAval:
+      @core.aval_property
+      def value(self):
+        nonlocal val
+        test.assertIsInstance(self, FakeTracer)
+        return val
+      @value.setter
+      def value(self, new_value):
+        nonlocal val
+        val = new_value
+        test.assertIsInstance(self, FakeTracer)
+
+    class FakeTracer(core.Tracer):
+      def __init__(self, aval):
+        self._aval = aval
+      @property
+      def aval(self):
+        return self._aval
+
+    tracer = FakeTracer(SomeAval())
+    self.assertEqual(tracer.value, 1)
+    tracer.value = 2
+    self.assertEqual(tracer.value, 2)
+
+  def test_aval_property_setter_conflict(self):
+    """test that 'value' cannot be used as a Tracer attribute name"""
+    class FakeTracer(core.Tracer):
+      def __init__(self):
+        self.value = 1
+
+      @property
+      def aval(self):
+        return None
+
+    with self.assertRaisesRegex(
+        AttributeError,
+        "Cannot set attribute 'FakeTracer.value' because it conflicts",
+    ):
+      FakeTracer()
+
 
 @jtu.with_config(jax_pprint_use_color=False)
 class JaxprTypeChecks(jtu.JaxTestCase):


### PR DESCRIPTION
# Description
Currently `Tracer` allows abstract value types to expose certain functions as tracer getter properties via the `aval_property` mechanism. However this mechanism currently doesn't support setter properties, this limits what custom `HiType`s can express. In particular, it doesn't allow implementing a `Variable`-like abstraction with a getter and setter for a `.value` property e.g.

```python
val = variable_tracer.value      # possible
variable_tracer.value = new_val  # not possible
```

## Proposal

Extend `aval_property` to allow for setters and implement `Tracer.__setattr__` to forward the computation to the underlaying `aval_property`'s setter if available. Abstract values would now be able to express property setters like this:

```python
@aval_property
def value(self): ...

@value.setter
def value(self, val): ...
```
such that the original example above works.

## Costs and Limitations

* Currently `value` is being hardcoded as the only name that will be forwarded from `Tracer` to the underlying `aval`, this is being done to avoid RecursionErrors that would arise if `Tracer.__setattr__` would try to access the `aval` property when setting its own attributes e.g. `_trace`. A more general registration mechanism to allow for names other than `value` could be implemented in the future.
* `value` or any other registered aval property setter name cannot be used as a Tracer attribute name as assignment would be ambiguous.