### PR TITLE
Use triple overloads of TargetRegistry functions

### DIFF
--- a/jaxlib/mosaic/gpu/target.cc
+++ b/jaxlib/mosaic/gpu/target.cc
@@ -51,7 +51,7 @@ absl::StatusOr<std::string> GetSmVersion(int major, int minor) {
   {
     // generic subtarget
     std::unique_ptr<const llvm::MCSubtargetInfo> subtarget_info{
-        target->createMCSubtargetInfo(triple, "", "")};
+        target->createMCSubtargetInfo(llvm::Triple(triple), "", "")};
     if (subtarget_info == nullptr) {
       return absl::InternalError(absl::StrFormat(
           "Failed to get generic LLVM subtarget info for triple %s", triple));
@@ -79,7 +79,7 @@ absl::StatusOr<int> GetLatestLlvmPtxIsaVersion() {
   }
   // generic subtarget
   std::unique_ptr<const llvm::MCSubtargetInfo> subtarget_info{
-      target->createMCSubtargetInfo(triple, "", "")};
+      target->createMCSubtargetInfo(llvm::Triple(triple), "", "")};
   if (subtarget_info == nullptr) {
     return absl::InternalError(absl::StrFormat(
         "Failed to get generic LLVM subtarget info for triple %s", triple));


### PR DESCRIPTION
The overloads accepting triples as strings are deprecated and will be removed soon.