### PR TITLE
Warn on import for jax.lib.xla_bridge, xla_client, xla_extensions

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -119,7 +119,7 @@ jobs:
         PY_COLORS: 1
       run: |
         pytest -n auto --tb=short --doctest-glob='*.md' --doctest-glob='*.rst' docs --doctest-continue-on-failure --ignore=docs/multi_process.md
-        pytest -n auto --tb=short --doctest-modules jax --ignore=jax/config.py --ignore=jax/experimental/jax2tf --ignore=jax/_src/lib/mlir --ignore=jax/_src/lib/triton.py --ignore=jax/_src/lib/mosaic_gpu.py --ignore=jax/interpreters/mlir.py --ignore=jax/experimental/array_serialization --ignore=jax/collect_profile.py --ignore=jax/_src/tpu_custom_call.py --ignore=jax/experimental/mosaic --ignore=jax/experimental/pallas --ignore=jax/_src/pallas --ignore=jax/lib/xla_extension.py --ignore=jax/experimental/host_callback.py
+        pytest -n auto --tb=short --doctest-modules jax --ignore=jax/config.py --ignore=jax/experimental/jax2tf --ignore=jax/_src/lib/mlir --ignore=jax/_src/lib/triton.py --ignore=jax/_src/lib/mosaic_gpu.py --ignore=jax/interpreters/mlir.py --ignore=jax/experimental/array_serialization --ignore=jax/collect_profile.py --ignore=jax/_src/tpu_custom_call.py --ignore=jax/experimental/mosaic --ignore=jax/experimental/pallas --ignore=jax/_src/pallas --ignore=jax/lib
 
 
   documentation_render:

--- a/jax/_src/deprecations.py
+++ b/jax/_src/deprecations.py
@@ -125,6 +125,7 @@ def warn(deprecation_id: str, message: str, stacklevel: int) -> None:
 # always registered by the time `accelerate` and `is_acelerated` are called.
 register('default-dtype-bits-config')
 register('jax-lax-dot-positional-args')
+register('jax-lib-module')
 register('jax-nn-one-hot-float-input')
 register("jax-numpy-astype-complex-to-real")
 register('jax-numpy-clip-args')

--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -16,8 +16,11 @@
 from jax._src.lib import (
   version_str as __version__,
 )
-from jax.lib import (
-  xla_bridge as xla_bridge,
-  xla_client as xla_client,
-  xla_extension as xla_extension,
-)
+
+# Dynamically load submodules because they warn on import.
+# TODO(jakevdp): remove this in JAX v0.9.0.
+def __getattr__(attr):
+  if attr in {'xla_bridge', 'xla_client', 'xla_extension'}:
+    import importlib
+    return importlib.import_module(f'jax.lib.{attr}')
+  raise AttributeError(f"module 'jax.lib' has no attribute {attr!r}")

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -12,10 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ruff: noqa: F401
+from jax._src import deprecations as _deps
 
-_deprecations = {  # pylint: disable=g-statement-before-imports
-    # Added July 31, 2024
+_deps.warn(
+    'jax-lib-module',
+    (
+        'jax.lib.xla_bridge module will be removed in JAX v0.9.0;'
+        ' all its APIs were deprecated and removed by JAX v0.8.0.'
+    ),
+    stacklevel=4
+)
+
+_deprecations = {
+    # Finalized in JAX v0.8.0; remove these messages in v0.9.0.
     "get_backend": (
         (
             "jax.lib.xla_bridge.get_backend is deprecated and will be removed"
@@ -23,7 +32,6 @@ _deprecations = {  # pylint: disable=g-statement-before-imports
         ),
         None,
     ),
-    # Added for JAX v0.7.0
     "get_compile_options": (
         (
             "jax.lib.xla_bridge.get_compile_options is deprecated in JAX v0.7.0"
@@ -34,6 +42,5 @@ _deprecations = {  # pylint: disable=g-statement-before-imports
     ),
 }
 
-from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
-__getattr__ = _deprecation_getattr(__name__, _deprecations)
-del _deprecation_getattr
+__getattr__ = _deps.deprecation_getattr(__name__, _deprecations)
+del _deps

--- a/jax/lib/xla_client.py
+++ b/jax/lib/xla_client.py
@@ -12,8 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-_deprecations = {  # pylint: disable=g-statement-before-imports
-    # Added April 4 2025.
+from jax._src import deprecations as _deps
+
+_deps.warn(
+    'jax-lib-module',
+    (
+        'jax.lib.xla_client module will be removed in JAX v0.9.0;'
+        ' all its APIs were deprecated and removed by JAX v0.8.0.'
+    ),
+    stacklevel=4
+)
+
+_deprecations = {
+    # Finalized in JAX v0.8.0; remove these messages in v0.9.0.
     "Client": (
         (
             "jax.lib.xla_client.Client was deprecated in JAX v0.6.0 and will be"
@@ -58,6 +69,5 @@ _deprecations = {  # pylint: disable=g-statement-before-imports
     ),
 }
 
-from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
-__getattr__ = _deprecation_getattr(__name__, _deprecations)
-del _deprecation_getattr
+__getattr__ = _deps.deprecation_getattr(__name__, _deprecations)
+del _deps

--- a/jax/lib/xla_extension.py
+++ b/jax/lib/xla_extension.py
@@ -12,8 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-_deprecations = {  # pylint: disable=g-statement-before-imports
-    # Deprecated March 26 2025.
+from jax._src import deprecations as _deps
+
+_deps.warn(
+    'jax-lib-module',
+    (
+        'jax.lib.xla_extension module will be removed in JAX v0.9.0;'
+        ' all its APIs were deprecated and removed by JAX v0.8.0.'
+    ),
+    stacklevel=4
+)
+
+_deprecations = {
+    # Finalized in JAX v0.8.0; remove these messages in v0.9.0.
     "ifrt_proxy": (
         "jax.lib.xla_extension.ifrt_proxy is deprecated.",
         None,
@@ -45,6 +56,5 @@ _deprecations = {  # pylint: disable=g-statement-before-imports
     ),
 }
 
-from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
-__getattr__ = _deprecation_getattr(__name__, _deprecations)
-del _deprecation_getattr
+__getattr__ = _deps.deprecation_getattr(__name__, _deprecations)
+del _deps


### PR DESCRIPTION
This deprecation in v0.8.0 prepares to remove these modules in v0.9.0.