### PR TITLE
Support explicit integer padding in lax.conv_transpose

### DIFF
--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -357,7 +357,7 @@ def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
   if rhs_dilation is None:
     rhs_dilation = (1,) * (rhs.ndim - 2)
   pads: str | Sequence[tuple[int, int]]
-  if use_consistent_padding or padding in {'SAME', 'VALID'}:
+  if use_consistent_padding or (isinstance(padding, str) and padding in {'SAME', 'VALID'}):
     effective_k_size = map(lambda k, r: core.dilate_dim(k, r), k_sdims, rhs_dilation)
     replicated_padding = [padding] * len(strides) if isinstance(padding, str) else padding
     pads = tuple(_conv_transpose_padding(k, s, p)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -888,6 +888,9 @@ class LaxTest(jtu.JaxTestCase):
                  for i in range(nspatial)]
     elif padding == 'SAME':
       o_sdims = [in_sdims[i]*strides[i] for i in range(nspatial)]
+    else:
+      o_sdims = [in_sdims[i]*strides[i] + max(e_k_sdims[i]-strides[i],0) - np.sum(p)
+                 for i, p in enumerate(padding)]
     o_shape =  [in_shape[0], k_shape[1]] + o_sdims
     out_spec_inv = [x[0] for x in
                     sorted(enumerate(dn.out_spec), key=lambda x: x[1])]
@@ -923,7 +926,9 @@ class LaxTest(jtu.JaxTestCase):
       ],
       dtype=lax_test_util.float_dtypes,
       strides=[(1, 1), (1, 2), (2, 1), (2, 2), (3, 3)],
-      padding=["VALID", "SAME"],
+      padding=list(itertools.product(
+        itertools.product([0,1,2], [0,1,2]),
+        itertools.product([0,1,2], [0,1,2]))) + ["VALID", "SAME"],
       dspec=[
           ("NHWC", "HWIO", "NHWC"),
       ],
@@ -963,7 +968,9 @@ class LaxTest(jtu.JaxTestCase):
       ],
       dtype=lax_test_util.float_dtypes,
       strides=[(1, 1), (1, 2), (2, 1), (2, 2), (3, 3)],
-      padding=["VALID", "SAME"],
+      padding=list(itertools.product(
+        itertools.product([0,1,2], [0,1,2]),
+        itertools.product([0,1,2], [0,1,2]))) + ["VALID", "SAME"],
       dspec=[
           ("NHWC", "HWIO", "NHWC"),
       ],

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -946,7 +946,8 @@ class LaxTest(jtu.JaxTestCase):
       return lax.conv_transpose(lhs, rhs, strides, padding,
                                 rhs_dilation=rhs_dilation,
                                 dimension_numbers=dspec,
-                                transpose_kernel=True)
+                                transpose_kernel=True,
+                                use_consistent_padding=True)
 
     def fun_via_grad(lhs, rhs):
       return self._conv_transpose_via_grad(lhs, rhs, strides, padding,
@@ -986,7 +987,8 @@ class LaxTest(jtu.JaxTestCase):
       return lax.conv_transpose(lhs, rhs, strides, padding,
                                 rhs_dilation=rhs_dilation,
                                 dimension_numbers=dspec,
-                                transpose_kernel=False)
+                                transpose_kernel=False,
+                                use_consistent_padding=True)
 
     def fun_via_grad(lhs, rhs):
       rhs_t = self._transpose_conv_kernel(lhs, rhs, dimension_numbers=dspec)


### PR DESCRIPTION
This PR fixes the handling of integer padding arguments to `lax.conv_transpose`. It addresses #32267 and google/flax#4593 by computing the padding necessary for a conv-transpose when the input padding argument is interpreted as the padding used by the ordinary convolution, as described in https://arxiv.org/abs/1603.07285