### PR TITLE
docs(pallas): Fix broken link to pallas documentation section

### DIFF
--- a/jax/experimental/pallas/__init__.py
+++ b/jax/experimental/pallas/__init__.py
@@ -15,7 +15,7 @@
 """Module for Pallas, a JAX extension for custom kernels.
 
 See the Pallas documentation at
-https://docs.jax.dev/en/latest/pallas.html.
+https://docs.jax.dev/en/latest/pallas/index.html.
 """
 
 from jax._src.pallas.core import BlockDim as BlockDim


### PR DESCRIPTION
Not much to say here - I wanted to start with pallas, and tried to access the docs from this link, which turned out to be stale.