### PR TITLE
jnp.cov: align behavior with NumPy 2.2 change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 
 * Breaking changes:
 
+  * {func}`jax.numpy.cov` is now returns NaN for empty arrays ({jax-issue}`#32305`),
+    and matches NumPy 2.2 behavior for single-row design matrices ({jax-issue}`#32308`).
   * JAX no longer accepts `Array` values where a `dtype` value is expected. Call
     `.dtype` on these values first.
   * The deprecated function {func}`jax.interpreters.mlir.custom_call` was

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -9111,7 +9111,7 @@ def cov(m: ArrayLike, y: ArrayLike | None = None, rowvar: bool = True,
     raise ValueError("m has more than 2 dimensions")  # same as numpy error
 
   X = atleast_2d(m)
-  if not rowvar and X.shape[0] != 1:
+  if not rowvar and m.ndim != 1:
     X = X.T
   if X.shape[0] == 0:
     return array([]).reshape(0, 0)

--- a/tests/lax_numpy_reducers_test.py
+++ b/tests/lax_numpy_reducers_test.py
@@ -709,6 +709,23 @@ class JaxNumpyReducerTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
     self._CompileAndCheck(jnp_fun, args_maker)
 
+  @unittest.skipIf(jtu.numpy_version() < (2, 2, 0), "test covers NumPy 2.2+ behavior.")
+  @jtu.sample_product(
+      shape=[(1, 3), (3, 1)],
+      rowvar=[True, False]
+  )
+  def testCovTransposeBehavior(self, shape, rowvar):
+    # Tests compatibility with NumPy 2.2 API change:
+    # https://github.com/numpy/numpy/pull/27661
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape, np.float32)]
+    np_fun = partial(np.cov, rowvar=rowvar, ddof=0)
+    jnp_fun = partial(jnp.cov, rowvar=rowvar, ddof=0)
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
+
+
   @jtu.sample_product(
     [dict(op=op, q_rng=q_rng)
       for (op, q_rng) in (


### PR DESCRIPTION
This brings JAX in line with the change mentioned at https://numpy.org/doc/2.3/release/2.2.0-notes.html#compatibility-notes

(will rebase once #32305 is merged)