### PR TITLE
jnp.setdiff1d: handle non-1D inputs with assume_unique=True

### DIFF
--- a/jax/_src/numpy/setops.py
+++ b/jax/_src/numpy/setops.py
@@ -157,6 +157,9 @@ def setdiff1d(ar1: ArrayLike, ar2: ArrayLike, assume_unique: bool = False,
     Array([1, 2, 0, 0], dtype=int32)
   """
   arr1, arr2 = ensure_arraylike("setdiff1d", ar1, ar2)
+  arr1 = arr1.ravel()
+  arr2 = arr2.ravel()
+
   if size is None:
     core.concrete_or_error(None, ar1, "The error arose in setdiff1d()")
   else:

--- a/tests/lax_numpy_setops_test.py
+++ b/tests/lax_numpy_setops_test.py
@@ -147,6 +147,18 @@ class LaxNumpySetopsTest(jtu.JaxTestCase):
       self._CompileAndCheck(jnp_fun, args_maker)
 
   @jtu.sample_product(
+      shape1=all_shapes,
+      shape2=all_shapes,
+  )
+  def testSetdiff1dAssumeUnique(self, shape1, shape2):
+    # regression test for https://github.com/jax-ml/jax/issues/32335
+    args_maker = lambda: (jnp.arange(math.prod(shape1), dtype='int32').reshape(shape1),
+                          jnp.arange(math.prod(shape2), dtype='int32').reshape(shape2))
+    np_op = partial(np.setdiff1d, assume_unique=True)
+    jnp_op = partial(jnp.setdiff1d, assume_unique=True)
+    self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
+
+  @jtu.sample_product(
     dtype1=[s for s in default_dtypes if s != jnp.bfloat16],
     dtype2=[s for s in default_dtypes if s != jnp.bfloat16],
     shape1=all_shapes,


### PR DESCRIPTION
Fixes #32335