### PR TITLE
Fix: local_window_size ignored when mask is None in dot_product_attention

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -893,7 +893,7 @@ def _get_padding_mask_encoded(T, q_seqlen):
 
 def _apply_masks(logits, mask, is_causal, q_seqlen, kv_seqlen,
                  local_window_size):
-  if mask is None and not is_causal and q_seqlen is None and kv_seqlen is None:
+  if mask is None and not is_causal and q_seqlen is None and kv_seqlen is None and local_window_size is None:
     return logits
 
   combined_mask = jnp.ones_like(logits, dtype=bool)

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -763,6 +763,27 @@ class NNFunctionsTest(jtu.JaxTestCase):
         atol=1e-3,
     )
 
+  def testDotProductAttention_localWindowSizeWithoutMask(self):
+    dtype = jnp.float32
+    B, S, T, N, H = 2, 128, 128, 4, 32
+    keys = random.split(random.PRNGKey(0), 3)
+    Q = random.normal(keys[0], (B, T, N, H), dtype)
+    K = random.normal(keys[1], (B, S, N, H), dtype)
+    V = random.normal(keys[2], (B, S, N, H), dtype)
+
+    output_large_window = nn.dot_product_attention(
+        Q, K, V, mask=None, local_window_size=(32, 32)
+    )
+
+    output_small_window = nn.dot_product_attention(
+        Q, K, V, mask=None, local_window_size=(1, 1)
+    )
+
+    self.assertFalse(
+        jnp.allclose(output_large_window, output_small_window),
+        "Attention output should differ with different local_window_size, even without a mask.",
+    )
+
 
 InitializerRecord = collections.namedtuple(
   "InitializerRecord",


### PR DESCRIPTION
Fixes #32300

The `local_window_size` parameter was being ignored when `mask=None` in `nn.dot_product_attention`. 

The `_apply_masks` function had an early return that only checked for `mask`, `is_causal`, `q_seqlen`, and `kv_seqlen`, but not `local_window_size`. This caused the function to skip masking entirely when no explicit mask was provided, even if a local window was specified.

**Changes:**
- Added `local_window_size is None` check to the early return condition in `_apply_masks`
- Added test `testDotProductAttention_localWindowSizeWithoutMask` to verify the fix

Thanks for reviewing!