### PR TITLE
don't use defvectorized for dce_sink batcher

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -8619,7 +8619,7 @@ dce_sink_p.def_effectful_abstract_eval(lambda _: ([], {no_dce_effect}))
 mlir.register_lowering(dce_sink_p, lambda ctx, _: [])
 ad.deflinear(dce_sink_p, lambda _: [])
 pe.def_trivial_padding(dce_sink_p)
-batching.defvectorized(dce_sink_p)
+batching.primitive_batchers[dce_sink_p] = lambda x, bd: (x, bd)
 
 def rng_bit_generator(key, shape, dtype=np.uint32,
                       algorithm=RandomAlgorithm.RNG_DEFAULT,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -5367,6 +5367,13 @@ class APITest(jtu.JaxTestCase):
   #     return x + x
   #   foo(1.0)
 
+  def test_dce_sink_vmap(self):
+    def f(x):
+      jax.lax.dce_sink(x)
+      return x
+
+    jax.vmap(f)(jnp.arange(3.))  # don't crash
+
 
 class RematTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
(it assumes there are >1 args)