### PR TITLE
[jaxpr consts] Update code for JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS

### DIFF
--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -850,7 +850,7 @@ def lower_parallel_callable(
     num_const_args = len(const_arg_avals)
     in_axes = (None,) * num_const_args + in_axes  # type: ignore
     donated_invars = (False,) * num_const_args + donated_invars  # type: ignore
-    jaxpr_avals = const_arg_avals + closed_jaxpr.in_avals  # type: ignore
+    jaxpr_avals = list(const_arg_avals) + closed_jaxpr.in_avals  # type: ignore
     shards = ShardInfo(
         tuple(const_arg_avals) + shards.sharded_avals,  # type: ignore
         shards.out_sharded_avals,
@@ -2160,7 +2160,7 @@ def hoist_constants_as_args(
   )
   num_const_args = len(const_args)
   if num_const_args:
-    global_in_avals = const_arg_avals + global_in_avals  # type: ignore
+    global_in_avals = list(const_arg_avals) + global_in_avals  # type: ignore
     ca_shardings = pjit.const_args_shardings(const_args)
     in_shardings = ca_shardings + in_shardings  # type: ignore
     ca_layouts = pjit.const_args_layouts(const_args, const_arg_avals,
@@ -2182,7 +2182,7 @@ def hoist_constants_as_args(
     else:
       arg_names = (("",) * num_const_args + all_args_info.debug_info.arg_names)
     all_args_info = AllArgsInfo(
-        const_arg_avals + all_args_info.in_avals,  # type: ignore
+        list(const_arg_avals) + all_args_info.in_avals,  # type: ignore
         all_args_info.debug_info._replace(arg_names=arg_names))
 
   return (const_args, global_in_avals, in_shardings, in_layouts, donated_invars,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -5268,7 +5268,12 @@ class APITest(jtu.JaxTestCase):
               yield inv.val
 
     def uniq(lst):
-      return {id(v): v for v in lst}.values()
+      def key(a):
+        if isinstance(a, literals.TypedNdArray):
+          return np.asarray(a)
+        else:
+          return a
+      return {id(key(v)): v for v in lst}.values()
 
     @jax.make_jaxpr
     def f():

--- a/tests/debug_info_test.py
+++ b/tests/debug_info_test.py
@@ -1393,7 +1393,6 @@ class DebugInfoTest(jtu.JaxTestCase):
     ]
     if config.use_simplified_jaxpr_constants.value:
       expected_jaxpr_debug_infos.extend([
-          "traced_for=jit, fun=my_f, arg_names=x,as_, result_paths=result[0],result[1]",
           "traced_for=jit, fun=my_f, arg_names=None, result_paths=None",
       ])
 


### PR DESCRIPTION
I got back to trying to enable JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS and I discovered that there were changes in JAX that regressed some tests.