### PR TITLE
[test] future-proof x64_context_test

### DIFF
--- a/tests/x64_context_test.py
+++ b/tests/x64_context_test.py
@@ -31,9 +31,13 @@ from jax._src.lib import jaxlib_extension_version
 
 jax.config.parse_flags_with_absl()
 
-# TODO(jakevdp): rewrite these tests in terms of jax.enable_x64.
+# TODO(jakevdp): remove this check for JAX v0.9.0 and test jax.enable_x64 directly.
 with jtu.ignore_warning(message=".* is deprecated", category=DeprecationWarning):
-  from jax.experimental import enable_x64, disable_x64
+  if hasattr(jax.experimental, "enable_x64"):
+    from jax.experimental import enable_x64, disable_x64
+  else:
+    enable_x64 = jax.enable_x64
+    disable_x64 = lambda: jax.enable_x64(False)
 
 
 class X64ContextTests(jtu.JaxTestCase):


### PR DESCRIPTION
`jax.experimental.enable_x64` and `jax.experimental.disable_x64` are deprecated as of JAX v0.8.0, and slated for removal in JAX v0.9.0. This test change will make sure the test continues passing during this deprecation; once we're ready to finalize these deprecations in JAX v0.9.0 we can clean this up and test `jax.enable_x64` directly.