### PR TITLE
Add `mean` argument to `jnp.std` and `jnp.var` families

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6278,8 +6278,8 @@ class NumpySignaturesTest(jtu.JaxTestCase):
       'load': ['mmap_mode', 'allow_pickle', 'fix_imports', 'encoding', 'max_header_size'],
       'nanpercentile': ['weights'],
       'nanquantile': ['weights'],
-      'nanstd': ['correction', 'mean'],
-      'nanvar': ['correction', 'mean'],
+      'nanstd': ['correction'],
+      'nanvar': ['correction'],
       'ones': ['order', 'like'],
       'ones_like': ['subok', 'order'],
       'partition': ['kind', 'order'],
@@ -6287,9 +6287,7 @@ class NumpySignaturesTest(jtu.JaxTestCase):
       'quantile': ['weights'],
       'row_stack': ['casting'],
       'stack': ['casting'],
-      'std': ['mean'],
       'tri': ['like'],
-      'var': ['mean'],
       'vstack': ['casting'],
       'zeros_like': ['subok', 'order']
     }


### PR DESCRIPTION
### Add `mean` argument to `jnp.std` and `jnp.var` families

### Description:

This change introduces a `mean` keyword argument to `jnp.std`, `jnp.var`, `jnp.nanstd`, and `jnp.nanvar`. This enhancement allows users to provide a pre-computed mean for use in the variance and standard deviation calculations. This addition also brings the API of these JAX functions into closer alignment with their modern NumPy counterparts.

### Motivation:

https://github.com/jax-ml/jax/issues/32648

### Implementation:

The implementations of `jnp.std`, `jnp.var`, `jnp.nanstd`, and `jnp.nanvar` in `jax/_src/numpy/reductions.py` have been updated to check for the presence of the `mean` keyword argument. If it is provided, the internal mean calculation is bypassed, and the supplied array is used instead.

### Testing:

A new parameterized test method, `testReducerWithMean`, has been added to `tests/lax_numpy_reducers_test.py`. This test:
-   Covers all four affected functions: `var`, `std`, `nanvar`, and `nanstd`.
-   Compares the JAX implementation against the equivalent NumPy functions, which also accept a `mean` argument.
-   Runs on a matrix of test cases, including different shapes, dtypes (inexact and complex), axes, `ddof` values, and `keepdims` settings.
-   Validates that JAX's default type-inference logic produces the correct output dtypes. There is one small caveat here, where JAX returns a complex data type when computing variance of a complex number, while np returns a real data type. To maintain symmetry, perhaps JAX should return a real data type here as well?

note: this is my first pull request to Jax, apologies in advance if I am missing any pre-requisites.