### PR TITLE
jnp.linalg.lstsq: correctly handle zero A matrix

### DIFF
--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -1395,7 +1395,7 @@ def _lstsq(a: ArrayLike, b: ArrayLike, rcond: float | None, *,
     else:
       rcond = jnp.where(rcond < 0, jnp.finfo(dtype).eps, rcond)
     u, s, vt = svd(a, full_matrices=False)
-    mask = s >= jnp.array(rcond, dtype=s.dtype) * s[0]
+    mask = (s > 0) & (s >= jnp.array(rcond, dtype=s.dtype) * s[0])
     rank = mask.sum()
     safe_s = jnp.where(mask, s, 1).astype(a.dtype)
     s_inv = jnp.where(mask, 1 / safe_s, 0)[:, np.newaxis]

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1334,6 +1334,16 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     # TODO:
     # jtu.check_grads(lambda *args: jnp_fun(*args)[0], args_maker(), order=2, atol=1e-2, rtol=1e-2)
 
+  @jtu.sample_product(
+      shape=[(2, 1), (2, 2), (1, 2)]
+  )
+  def testLstsqZeroMatrix(self, shape):
+    # Regression test for https://github.com/jax-ml/jax/issues/32666
+    args_maker = lambda: [np.zeros(shape), np.ones((shape))]
+    np_fun = np.linalg.lstsq
+    jnp_fun = partial(jnp.linalg.lstsq, numpy_resid=True)
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
+
   # Regression test for incorrect type for eigenvalues of a complex matrix.
   def testIssue669(self):
     def test(x):


### PR DESCRIPTION
Fixes #32666