### PR TITLE
Remove scipy from the intersphinx configuration.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,8 @@ intersphinx_mapping = {
     'array_api': ('https://data-apis.org/array-api/2023.12/', None),
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    # TODO(phawkins,jakevdp): readd scipy when it is up again.
+    # 'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
 }
 
 suppress_warnings = [


### PR DESCRIPTION
The scipy docs website seems to be having trouble and this is causing all of our doc builds to fail: https://github.com/scipy/scipy/issues/23757