### PR TITLE
Fix pmap docstring markup

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1299,8 +1299,8 @@ def pmap(
 
   .. note::
     :py:func:`pmap` is now implemented in terms of :py:func:`jit` and
-    :py:func:`shard_map`. Please see the [migration
-    guide](https://docs.jax.dev/en/latest/migrate_pmap.html) for
+    :py:func:`shard_map`. Please see the `migration
+    guide <https://docs.jax.dev/en/latest/migrate_pmap.html>`_ for
     more information.
 
   The purpose of :py:func:`pmap` is to express single-program multiple-data


### PR DESCRIPTION
RST markup is required for docstrings.