### PR TITLE
DOC: use scipy's dev docs site as a work around to stable website issue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,8 +92,8 @@ intersphinx_mapping = {
     'array_api': ('https://data-apis.org/array-api/2023.12/', None),
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    # TODO(phawkins,jakevdp): readd scipy when it is up again.
-    # 'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    # TODO(phawkins,jakevdp): revert to stable scipy docs when it is up again.
+    'scipy': ('https://scipy.github.io/devdocs/', None),
 }
 
 suppress_warnings = [


### PR DESCRIPTION
Follow up from #32698 

Just FYI I don't think you need to disable hyperlinking for Scipy entirely, we can use their development docs site for the registry!

For example on the stable doc build, the scipy hyperlink is disabled here: https://docs.jax.dev/en/latest/default_dtypes.html

But If you build the docs on this branch and check the same page at `/jax/docs/build/html/default_dtypes.html`, the hyperlink should work fine.

