### PR TITLE
Fix typo in pjit.py

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1738,7 +1738,7 @@ def pjit_staging_rule(trace, source_info, *args, **params):
                   out_layouts=out_layouts)
     outvars = map(trace.frame.newvar, _out_type(jaxpr))
     eqn = core.new_jaxpr_eqn(
-      [arg.var for arg in args], outvars, jit_p, params,
+      [arg.val for arg in args], outvars, jit_p, params,
       jaxpr.effects, source_info)
     trace.frame.add_eqn(eqn)
     out_tracers = [pe.DynamicJaxprTracer(trace, v.aval, v, source_info)


### PR DESCRIPTION
In version 0.7.0, a PR https://github.com/jax-ml/jax/pull/29937 introduced `val` into `DynamicJaxprTracer`, but in `pjit_staging_rule`, `val` was mistakenly written as `var`.

The code in 0.6.2:
```python
eqn = core.new_jaxpr_eqn(
      map(trace.getvar, args), map(trace.makevar, out_tracers), pjit_p, params,
      jaxpr.effects, source_info)
```

0.7.0:
```python
eqn = core.new_jaxpr_eqn(
      [arg.var for arg in args], outvars, jit_p, params,
      jaxpr.effects, source_info)
```