### PR TITLE
Fix `jax.extend` module import

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -180,6 +180,7 @@ from jax import sharding as sharding
 from jax import memory as memory
 from jax import stages as stages
 from jax import tree_util as tree_util
+from jax import extend as extend
 
 # Also circular dependency.
 from jax._src.array import Shard as Shard

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -166,6 +166,7 @@ from jax import dlpack as dlpack
 from jax import dtypes as dtypes
 from jax import errors as errors
 from jax import export as export
+from jax import extend as extend
 from jax import ffi as ffi
 from jax import image as image
 from jax import lax as lax
@@ -180,7 +181,6 @@ from jax import sharding as sharding
 from jax import memory as memory
 from jax import stages as stages
 from jax import tree_util as tree_util
-from jax import extend as extend
 
 # Also circular dependency.
 from jax._src.array import Shard as Shard


### PR DESCRIPTION
```
>>> import jax
>>> jax.lib.xla_bridge.get_backend().platform_version
<stdin>:1: DeprecationWarning: jax.lib.xla_bridge module will be removed in JAX v0.9.0; all its APIs were deprecated and removed by JAX v0.8.0.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.12/dist-packages/jax/_src/deprecations.py", line 54, in getattr
    raise AttributeError(message)
AttributeError: jax.lib.xla_bridge.get_backend is deprecated and will be removed in JAX v0.8.0; use jax.extend.backend.get_backend.
```

However, when trying the suggested change, we get:

```
>>> jax.extend.backend.get_backend().platform_version
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.12/dist-packages/jax/_src/deprecations.py", line 57, in getattr
    raise AttributeError(f"module {module!r} has no attribute {name!r}")
AttributeError: module 'jax' has no attribute 'extend'
```

This PR fixes this import:

```
>>> import jax
>>> jax.extend.backend.get_backend().platform_version
'gpu'
```
