### PR TITLE
Adjust deprecation messages to note that jax.extend must be explicitly imported

### DIFF
--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -40,8 +40,8 @@ _deprecations = {
     # Finalized for v0.8.0; remove in v0.9.0
     "custom_jvp_call_jaxpr_p": (
       ("jax.custom_derivatives.custom_jvp_call_jaxpr_p was deprecated in v0.7.0"
-       " and removed in v0.8.0."
-       "use jax.extend.core.primitives.custom_jvp_call_p instead."),
+       " and removed in v0.8.0. use jax.extend.core.primitives.custom_jvp_call_p"
+       " instead, and please note that you must `import jax.extend` explicitly."),
       None,
     ),
 }

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -75,7 +75,11 @@ _deprecations = {
     _pe_src.FreeVar,
   ),
   "Jaxpr": (
-    "jax.interpreters.partial_eval.Jaxpr is deprecated. Use jax.extend.core.Jaxpr.",
+    (
+        "jax.interpreters.partial_eval.Jaxpr is deprecated. Use"
+        " jax.extend.core.Jaxpr, and please note that you must"
+        " `import jax.extend` explicitly."
+    ),
     _core_src.Jaxpr,
   ),
   "JaxprEqnRecipe": (

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -28,7 +28,8 @@ _deprecations = {
     "get_backend": (
         (
             "jax.lib.xla_bridge.get_backend is deprecated and will be removed"
-            " in JAX v0.8.0; use jax.extend.backend.get_backend."
+            " in JAX v0.8.0; use jax.extend.backend.get_backend, and please"
+            " note that you must `import jax.extend` explicitly."
         ),
         None,
     ),
@@ -36,7 +37,8 @@ _deprecations = {
         (
             "jax.lib.xla_bridge.get_compile_options is deprecated in JAX v0.7.0"
             " and will be removed in JAX v0.8.0. Use"
-            " jax.extend.backend.get_compile_options."
+            " jax.extend.backend.get_compile_options, and please note that you"
+            " must `import jax.extend` explicitly."
         ),
         None,
     ),


### PR DESCRIPTION
Fixes https://github.com/jax-ml/jax/pull/32727#discussion_r2441083480