### PR TITLE
[vjp3] make args_res contain tuple trees

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -7817,11 +7817,26 @@ class InputSavedVJPTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(Exception, "not used by the backward pass: x"):
       _ = api.si_vjp(f, [True], *primals, allow_unused=False)
 
+  def test_basic_unused_vjp3(self):
+    f = jnp.sin
+    primals = 3.,
+    y, f_vjp = api.vjp3(f, *primals)
+    x_ct, = f_vjp(1.)
+    self.assertAllClose(y, jnp.sin(3.))
+    self.assertAllClose(x_ct, jnp.cos(3.))
+    self.assertIsInstance(f_vjp.args_res[0], api.NotNeeded)  # can check if unused
+
   def test_basic_opaque(self):
     f = jnp.sin
     primals = 3.,
     with self.assertRaisesRegex(Exception, "the backward pass requires opaque"):
       _ = api.si_vjp(f, [True], *primals, allow_opaque=False)
+
+  def test_basic_opaque_vjp3(self):
+    f = jnp.sin
+    primals = 3.,
+    _, f_vjp = api.vjp3(f, *primals)
+    assert f_vjp.opaque_residuals  # can detect if opaque res are used
 
   def test_basic_pytree_error(self):
     def f(x):
@@ -7834,6 +7849,20 @@ class InputSavedVJPTest(jtu.JaxTestCase):
 
     with self.assertRaisesRegex(ValueError, "but the structures differ"):
       f_vjp(1., {'hi': 2.})
+
+  # TODO(mattjj): improve this vjp3 error message
+  # def test_basic_pytree_error_vjp3(self):
+  #   def f(x):
+  #     return [x['hi'] * x['bye']]
+
+  #   y, f_vjp = api.vjp3(f, {'hi': 2., 'bye': 3.})
+  #   arg_ct, = f_vjp([1.], {'hi': 2., 'bye': 3.})
+  #   self.assertAllClose(y, [6.])
+  #   self.assertAllClose(arg_ct, {'hi': 3., 'bye': 2.})
+
+  #   f_vjp.args_res[0] = {'hi': 2.}
+  #   with self.assertRaisesRegex(ValueError, "but the structures differ"):
+  #     f_vjp(1.)
 
   def test_fsdp(self):
     # see https://github.com/jax-ml/jax/pull/27017 for why this is called "fsdp"
@@ -7849,6 +7878,24 @@ class InputSavedVJPTest(jtu.JaxTestCase):
     y_grad = jnp.ones_like(y)
     x_grad, w_grad = f2_sivjp(y_grad, w)
     self.assertAllClose(x_grad, 2. * y_grad @ w.T)
+
+  def test_fsdp_vjp3(self):
+    # see https://github.com/jax-ml/jax/pull/27017 for why this is called "fsdp"
+    def f2(x, w):
+      x = 1. * x
+      x = x @ w
+      x = 2. * x
+      return x
+
+    x = jnp.ones((3, 4))
+    w = jnp.ones((4, 4))
+    y, f2_vjp = api.vjp3(f2, x, w)
+    f2_vjp.args_res[1] = None
+    y_grad = jnp.ones_like(y)
+    f2_vjp.args_res[1] = w
+    x_grad, w_grad = f2_vjp(y_grad)
+    self.assertAllClose(x_grad, 2. * y_grad @ w.T)
+    self.assertAllClose(w_grad, 2. * x.T @ y_grad)
     self.assertAllClose(w_grad, 2. * x.T @ y_grad)
 
   def test_doesnt_leak_symbolic_zeros(self):


### PR DESCRIPTION
The goal here is to avoid stuffing our sentinels, like NotNeeded, into users' pytree nodes. Not all user-defined pytree nodes are sufficiently polymorphic in the type of their contents to accept arbitrary sentinels.