### PR TITLE
[export] Add error message when serializating dictionaries with non-string keys

### DIFF
--- a/jax/_src/export/serialization.py
+++ b/jax/_src/export/serialization.py
@@ -266,8 +266,14 @@ def _serialize_pytreedef(
   elif node_type is dict:
     kind = ser_flatbuf.PyTreeDefKind.dict
     assert len(node_data[1]) == len(children)
+    def serialize_key(builder, k):
+      if not isinstance(k, str):
+        raise TypeError(
+            "Serialization is supported only for dictionaries with string keys."
+            f" Found key {k} of type {type(k)}.")
+      return builder.CreateString(k)
     children_names_vector_offset = _serialize_array(
-        builder, lambda b, s: b.CreateString(s), node_data[1]
+        builder, serialize_key, node_data[1]
     )
   elif node_type in _export.serialization_registry:
     kind = ser_flatbuf.PyTreeDefKind.custom

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -288,6 +288,16 @@ class JaxExportTest(jtu.JaxTestCase):
 
     self.assertAllClose(f(x, y), exp_f.call(x, y))
 
+  def test_dict_non_string_key(self):
+    @jax.jit
+    def f(x_dict):
+      return x_dict[(0, 1)] + x_dict[(1, 2)]
+
+    x_dict = {(0, 1): np.float32(42.), (1, 2): np.float32(43.)}
+    with self.assertRaisesRegex(
+        TypeError, "Serialization is supported only for dictionaries with string keys"):
+      get_exported(f)(x_dict)
+
   def test_closed_over_constant(self):
     const_size = 100
     const = jax.random.uniform(jax.random.key(0), (const_size,),


### PR DESCRIPTION
Bug: #32680

The current serialization and deserialization code is written with the unchecked assumption that the dictionary keys are strings. It it not obvious how far it makes sense to relax this assumption. For now, just check this assumption and give an error message.