### PR TITLE
Fix EigImplementation docstring

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -123,7 +123,7 @@ def cholesky_update(r_matrix: ArrayLike, w_vector: ArrayLike) -> Array:
 
 
 class EigImplementation(enum.Enum):
-  """Enum for SVD algorithm."""
+  """Enum for eigendecomposition algorithm."""
   CUSOLVER = "cusolver"
   MAGMA = "magma"
   LAPACK = "lapack"


### PR DESCRIPTION
The newly-added `EigImplementation` enum docstring refers to SVD algorithm; this PR corrects it to refer to eigendecomposition.