### PR TITLE
[docs] Correct typo in docstring for with_sharding_constraint

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -193,8 +193,7 @@ def jit(
     out_shardings: optional, a :py:class:`Sharding` or pytree with
       :py:class:`Sharding` leaves and structure that is a tree prefix of the
       output of ``fun``. If provided, it has the same effect as applying
-      corresponding :py:func:`jax.lax.with_sharding_constraint`s to the output
-      of ``fun``.
+      :py:func:`jax.lax.with_sharding_constraint` to the output of ``fun``.
     static_argnums: optional, an int or collection of ints that specify which
       positional arguments to treat as static (trace- and compile-time
       constant).


### PR DESCRIPTION
Fix typo in docstring regarding with_sharding_constraint.

<img width="569" height="68" alt="image" src="https://github.com/user-attachments/assets/03a6d247-7334-4c58-b874-fe3b4627cd4a" />
https://docs.jax.dev/en/latest/_autosummary/jax.jit.html#jax.jit

vs 
<img width="580" height="75" alt="image" src="https://github.com/user-attachments/assets/f0dc7785-b6dd-42fb-9381-99176d8bb2a5" />

https://jax--32777.org.readthedocs.build/en/32777/_autosummary/jax.jit.html#jax.jit