### PR TITLE
Improve the documentation of dot_product_attention. Add bias matrix to the formula.

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -1074,14 +1074,18 @@ def dot_product_attention(
 ):
   r"""Scaled dot product attention function.
 
-  Computes the attention function on Query, Key, and Value tensors:
+  Computes the following for each head:
 
   .. math::
 
-    \mathrm{Attention}(Q, K, V)=\mathrm{softmax}(\frac{QK^T}{\sqrt{d_k}})V
+    \mathrm{Attention}(Q, K, V) = \mathrm{softmax}\left( \frac{QK^T}{\sqrt{d}} + B \right) V
 
-  If we define :code:`logits` as the output of :math:`QK^T` and the
-  :code:`probs` as the output of :math:`softmax`.
+  where
+  :math:`Q` is the query matrix,
+  :math:`K` is the key matrix,
+  :math:`V` is the value matrix,
+  :math:`d` is the dimension of each individual query and key,
+  and :math:`B` is the bias matrix (optional).
 
   Throughout this function, we utilize the following uppercase letters to
   represent the shape of array::


### PR DESCRIPTION
Improve the documentation for [dot_product_attention](https://docs.jax.dev/en/latest/_autosummary/jax.nn.dot_product_attention.html). Add the bias matrix to the displayed formula (computation [here](https://github.com/jax-ml/jax/blob/a43badd8a30402519d024dbf74c1e576673c1050/jax/_src/nn/functions.py#L957)).