### PR TITLE
Fix use of deprecated jax_platform_name

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -185,6 +185,6 @@ jobs:
     - name: Run CPU tests
       run: python -m pytest examples/ffi/tests
       env:
-        JAX_PLATFORM_NAME: cpu
+        JAX_PLATFORMS: cpu
     - name: Run GPU tests
       run: python -m pytest examples/ffi/tests

--- a/docs/the-training-cookbook.py
+++ b/docs/the-training-cookbook.py
@@ -245,6 +245,6 @@ def train_loop(config: Config):
 
 
 if __name__ == "__main__":
-  jax.config.update("jax_platform_name", "cpu")
+  jax.config.update("jax_platforms", "cpu")
   jax.config.update("jax_num_cpu_devices", 8)
   train_loop(config=Config())

--- a/jax/tools/build_defs.bzl
+++ b/jax/tools/build_defs.bzl
@@ -150,14 +150,14 @@ EOF
 
     # Create a genrule which invokes the py_binary created above.
     #
-    # Set JAX_PLATFORM_NAME to "cpu" to silence the "no GPU/TPU backend found,
+    # Set JAX_PLATFORMS to "cpu" to silence the "no GPU/TPU backend found,
     # falling back to CPU" warning.
     native.genrule(
         name = name + "_jax_to_ir_genrule",
         outs = [name + ".pb", name + ".txt"],
         tools = [runner],
         cmd = """
-        JAX_PLATFORM_NAME=cpu \
+        JAX_PLATFORMS=cpu \
         '$(location {runner})' \
           --fn {fn} \
           --input_shapes {input_shapes} \

--- a/jaxlib/jax.bzl
+++ b/jaxlib/jax.bzl
@@ -278,7 +278,7 @@ def jax_multiplatform_test(
             test_shards = test_shard_count.get(backend, 1)
         test_args = list(args) + [
             "--jax_test_dut=" + backend,
-            "--jax_platform_name=" + backend,
+            "--jax_platforms=" + backend,
         ]
         test_args += backend_variant_args.get(backend, [])
         test_tags = list(tags) + ["jax_test_%s" % backend] + backend_tags.get(backend, [])

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -7691,7 +7691,7 @@ class BackendsTest(jtu.JaxTestCase):
   def test_no_backend_warning_on_cpu_if_platform_specified(self):
     warning_not_expected = (
       "import jax; "
-      "jax.config.update('jax_platform_name', 'cpu'); "
+      "jax.config.update('jax_platforms', 'cpu'); "
       "jax.numpy.arange(10)")
 
     result = subprocess.run([sys.executable, '-c', warning_not_expected],


### PR DESCRIPTION
This PR fixes the following error:
```
______ BackendsTest.test_no_backend_warning_on_cpu_if_platform_specified _______
[gw0] linux -- Python 3.12.11 /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-python3-3.12.11/bin/python3.12

self = <tests.api_test.BackendsTest testMethod=test_no_backend_warning_on_cpu_if_platform_specified>

    @unittest.skipIf(not sys.executable, "test requires sys.executable")
    @jtu.run_on_devices("cpu")
    def test_no_backend_warning_on_cpu_if_platform_specified(self):
      warning_not_expected = (
        "import jax; "
        "jax.config.update('jax_platform_name', 'cpu'); "
        "jax.numpy.arange(10)")

      result = subprocess.run([sys.executable, '-c', warning_not_expected],
                              check=True, capture_output=True)
>     assert "may be present" not in result.stderr.decode()
E     AssertionError: assert 'may be present' not in 'ERROR:2025-...ck to cpu.\n'
E
E       'may be present' is contained here:
E         VIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.
E       ?           ++++++++++++++

tests/api_test.py:7632: AssertionError
=========================== short test summary info ============================
FAILED tests/api_test.py::BackendsTest::test_no_backend_warning_on_cpu_if_platform_specified - AssertionError: assert 'may be present' not in 'ERROR:2025-...ck to cpu.\n'

  'may be present' is contained here:
    VIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.
  ?           ++++++++++++++
========= 1 failed, 29959 passed, 20204 skipped in 2379.18s (0:39:39) ==========
```