### PR TITLE
Match the MRO and subclass checking behavior of default numpy dtypes

### DIFF
--- a/jax/_src/numpy/scalar_types.py
+++ b/jax/_src/numpy/scalar_types.py
@@ -52,13 +52,19 @@ class _ScalarMeta(type):
   def __instancecheck__(self, instance: Any) -> bool:
     return isinstance(instance, self.dtype.type)
 
+  def __subclasscheck__(self, subclass: type) -> bool:
+    return issubclass(subclass, self.dtype.type)
+
 def _abstractify_scalar_meta(x):
   raise TypeError(f"JAX scalar type {x} cannot be interpreted as a JAX array.")
 core.pytype_aval_mappings[_ScalarMeta] = _abstractify_scalar_meta
 
 def _make_scalar_type(np_scalar_type: type) -> _ScalarMeta:
-  meta = _ScalarMeta(np_scalar_type.__name__, (object,),
-                     {"dtype": np.dtype(np_scalar_type)})
+  meta = _ScalarMeta(
+    np_scalar_type.__name__,
+    (np_scalar_type.__mro__[0],),
+    {"dtype": np.dtype(np_scalar_type)},
+  )
   meta.__module__ = _PUBLIC_MODULE_NAME
   meta.__doc__ =\
   f"""A JAX scalar constructor of type {np_scalar_type.__name__}.

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -511,6 +511,29 @@ class DtypesTest(jtu.JaxTestCase):
     self.assertEqual(dtypes.float_, np.float32 if precision == '32' else np.float64)
     self.assertEqual(dtypes.complex_, np.complex64 if precision == '32' else np.complex128)
 
+  @parameterized.parameters(
+    {"np_scalar_type": np.bool, "jnp_scalar_type": jnp.bool, "np_base_type": np.generic},
+    {"np_scalar_type": np.int8, "jnp_scalar_type": jnp.int8, "np_base_type": np.signedinteger},
+    {"np_scalar_type": np.int16, "jnp_scalar_type": jnp.int16, "np_base_type": np.signedinteger},
+    {"np_scalar_type": np.int32, "jnp_scalar_type": jnp.int32, "np_base_type": np.signedinteger},
+    {"np_scalar_type": np.int64, "jnp_scalar_type": jnp.int64, "np_base_type": np.signedinteger},
+    {"np_scalar_type": np.uint8, "jnp_scalar_type": jnp.uint8, "np_base_type": np.unsignedinteger},
+    {"np_scalar_type": np.uint16, "jnp_scalar_type": jnp.uint16, "np_base_type": np.unsignedinteger},
+    {"np_scalar_type": np.uint32, "jnp_scalar_type": jnp.uint32, "np_base_type": np.unsignedinteger},
+    {"np_scalar_type": np.uint64, "jnp_scalar_type": jnp.uint64, "np_base_type": np.unsignedinteger},
+    {"np_scalar_type": np.float16, "jnp_scalar_type": jnp.float16, "np_base_type": np.floating},
+    {"np_scalar_type": np.float32, "jnp_scalar_type": jnp.float32, "np_base_type": np.floating},
+    {"np_scalar_type": np.float64, "jnp_scalar_type": jnp.float64, "np_base_type": np.floating},
+    {"np_scalar_type": np.complex64, "jnp_scalar_type": jnp.complex64, "np_base_type": np.complexfloating},
+    {"np_scalar_type": np.complex128, "jnp_scalar_type": jnp.complex128, "np_base_type": np.complexfloating},
+  )
+  def testDefaultScalarTypeHierarchy(self, np_scalar_type, jnp_scalar_type, np_base_type):
+    self.assertTrue(issubclass(np_scalar_type, np_base_type)) # sanity check
+    self.assertTrue(issubclass(jnp_scalar_type, np_base_type))
+
+    self.assertTrue(issubclass(jnp_scalar_type, np_scalar_type))
+    self.assertTrue(issubclass(np_scalar_type, jnp_scalar_type))
+
   def test_check_dtype_non_hashable(self):
     # regression test for issue with checking non-hashable custom dtype
     class MyDtype:


### PR DESCRIPTION
Where there is a direct correspondence between `jax.numpy` and existing default `numpy` dtypes (such as `float32` etc), JAX constructs its equivalent dtype by wrapping the original numpy dtype in an instance of  `jax._src.numpy.scalar_types._ScalarMeta`. The `_ScalarMeta` instances pretend to be exactly equivalent to the numpy dtypes by overriding the hash:

https://github.com/jax-ml/jax/blob/489e66080b0f9ebfacc741ee9b6c717e6bc9ce7a/jax/_src/numpy/scalar_types.py#L37-L41

However, they do not actually replicate the behavior of the numpy dtypes. This is a problem, since both default Python functionality (like `typing.Union`) and third-party runtime typechecking libraries rely on caching types based on their hash. Currently, JAX causes collisions between types with the same hash but different behavior, leading to issues discussed [here](https://github.com/beartype/beartype/issues/570) and [here](https://github.com/jax-ml/jax/discussions/32871). 

This relatively small change fixes these issues by ensuring that `issubclass` checks involving JAX dtypes behave exactly like their corresponding numpy dtypes, which is implied by the hash behavior described above. It doesn't break any of the existing tests in `tests/dtypes_test.py`.

A small code snippet demonstrating the updated behavior (which I've added a test for in `tests/dtypes_test.py`):

```python
import numpy as np, jax.numpy as jnp
print(issubclass(np.float32, np.floating))
print(issubclass(jnp.float32, np.floating))
print(issubclass(jnp.float32, np.float32))
print(issubclass(np.float32, jnp.float32))
```

This prints `True False False False` with `jax==0.8.0`, and `True True True True` after applying the patch in this PR.

cc @patrick-kidger: I don't think this should affect `jaxtyping` at all, just to be sure I've checked that the `jaxtyping` tests still pass with this change.

cc @leycec: Thanks for helping me understand the cause of the issue in the first place -- this seems like a relatively straightforward fix, would you have anything to add?