### PR TITLE
[doc] specify help string by keyword in configs.

### DIFF
--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -68,24 +68,26 @@ MIN_COMPUTE_CAPABILITY = 52
 # TODO(phawkins): Remove jax_xla_backend.
 _XLA_BACKEND = config.string_flag(
     'jax_xla_backend', '',
-    'Deprecated, please use --jax_platforms instead.')
+    help='Deprecated, please use --jax_platforms instead.')
 BACKEND_TARGET = config.string_flag(
     'jax_backend_target',
     os.getenv('JAX_BACKEND_TARGET', '').lower(),
-    'Either "local" or "rpc:address" to connect to a remote service target.')
+    help='Either "local" or "rpc:address" to connect to a remote service target.')
 # TODO(skye): warn when this is used once we test out --jax_platforms a bit
 _PLATFORM_NAME = config.string_flag(
     'jax_platform_name',
     os.getenv('JAX_PLATFORM_NAME', '').lower(),
-    'Deprecated, please use --jax_platforms instead.')
+    help='Deprecated, please use --jax_platforms instead.')
 CUDA_VISIBLE_DEVICES = config.string_flag(
     'jax_cuda_visible_devices', 'all',
-    'Restricts the set of CUDA devices that JAX will use. Either "all", or a '
-    'comma-separate list of integer device IDs.')
+    help=(
+      'Restricts the set of CUDA devices that JAX will use. Either "all", or a '
+      'comma-separate list of integer device IDs.'))
 _ROCM_VISIBLE_DEVICES = config.string_flag(
     'jax_rocm_visible_devices', 'all',
-    'Restricts the set of ROCM devices that JAX will use. Either "all", or a '
-    'comma-separate list of integer device IDs.')
+    help=(
+      'Restricts the set of ROCM devices that JAX will use. Either "all", or a '
+      'comma-separate list of integer device IDs.'))
 
 MOCK_NUM_GPU_PROCESSES = config.int_flag(
     name="mock_num_gpu_processes",
@@ -127,14 +129,16 @@ CROSS_HOST_TRANSPORT_ADDRESSES = config.string_flag(
 CROSS_HOST_TRANSFER_TIMEOUT_SECONDS = config.int_flag(
     "jax_cross_host_transfer_timeout_seconds",
     None,
-    "Timeout for cross host transfer metadata exchange through KV store. "
-    "Default is one minute.",
+    help=(
+      "Timeout for cross host transfer metadata exchange through KV store. "
+      "Default is one minute."
+    ),
 )
 
 CROSS_HOST_TRANSFER_TRANSFER_SIZE = config.int_flag(
     "jax_cross_host_transfer_transfer_size",
     None,
-    "Chunk size for chunked transfer requests."
+    help="Chunk size for chunked transfer requests."
 )
 
 # Warn the user if they call fork(), because it's not going to go well for them.


### PR DESCRIPTION
This will ensure the help strings appear in the rendered docs.

Before:
<img width="815" height="202" alt="Screenshot 2025-10-29 at 2 22 35 PM" src="https://github.com/user-attachments/assets/0a94ef45-dbb6-4e62-95e5-5ca644115288" />


After:
<img width="802" height="249" alt="Screenshot 2025-10-29 at 2 22 45 PM" src="https://github.com/user-attachments/assets/8fa58f67-4b7c-464c-b57d-6ec09305ac65" />
