### PR TITLE
add hijax coverage tests

### DIFF
--- a/tests/mutable_array_test.py
+++ b/tests/mutable_array_test.py
@@ -970,6 +970,11 @@ class MutableArrayTest(jtu.JaxTestCase):
     self.assertIn('+=', str(jaxpr))
     self.assertNotIn('0.0', str(jaxpr))
 
+  @absltest.skip("Not yet implemented")
+  def test_none_index(self):
+    ref = jax.new_ref(jnp.array([1, 2, 3]))
+    y = ref[None]
+    self.assertEqual(y.shape, (1, 3))
 
 @jtu.with_config(jax_mutable_array_checks=True)
 class MutableArrayErrorsTest(jtu.JaxTestCase):


### PR DESCRIPTION
Initial set of tests to check coverage of hijax types among transforms. This PR introduces tests for `grad` using `HiTup` and `Box`. Also adds a test showing that `None` broadcasting doesn't work with `Ref` yet.