### PR TITLE
Make tree_util.register_dataclass a decorator factory

### DIFF
--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -21,7 +21,7 @@ import functools
 from functools import partial
 import operator as op
 import textwrap
-from typing import Any, TypeVar
+from typing import Any, TypeVar, overload
 
 from jax._src import traceback_util
 from jax._src.lib import pytree
@@ -35,6 +35,7 @@ traceback_util.register_exclusion(__file__)
 
 T = TypeVar("T")
 Typ = TypeVar("Typ", bound=type[Any])
+Typ2 = TypeVar("Typ2", bound=type[Any])
 H = TypeVar("H", bound=Hashable)
 
 Leaf = Any
@@ -982,13 +983,25 @@ def register_pytree_with_keys_class(cls: Typ) -> Typ:
   return cls
 
 
-@export
+@overload
 def register_dataclass(
     nodetype: Typ,
     data_fields: Sequence[str] | None = None,
     meta_fields: Sequence[str] | None = None,
+    drop_fields: Sequence[str] = ()) -> Typ: ...
+@overload
+def register_dataclass(
+    nodetype: None,
+    data_fields: Sequence[str] | None = None,
+    meta_fields: Sequence[str] | None = None,
+    drop_fields: Sequence[str] = ()) -> Callable[[Typ], Typ]: ...
+@export
+def register_dataclass(
+    nodetype: Typ | None = None,
+    data_fields: Sequence[str] | None = None,
+    meta_fields: Sequence[str] | None = None,
     drop_fields: Sequence[str] = (),
-) -> Typ:
+) -> Typ | Callable[[Typ2], Typ2]:
   """Extends the set of types that are considered internal nodes in pytrees.
 
   This differs from ``register_pytree_with_keys_class`` in that the C++
@@ -1086,6 +1099,13 @@ def register_dataclass(
     >>> compiled_func(m)
     Array([1., 2., 3.], dtype=float32)
   """
+  if nodetype is None:
+    return lambda nodetype: register_dataclass(
+        nodetype,
+        data_fields=data_fields,
+        meta_fields=meta_fields,
+        drop_fields=drop_fields)
+
   if data_fields is None or meta_fields is None:
     if (data_fields is None) != (meta_fields is None):
       raise TypeError("register_dataclass: data_fields and meta_fields must both be specified"

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -1721,6 +1721,21 @@ class RegistrationTest(jtu.JaxTestCase):
     # ``y`` is missing, but no validation is done for plain classes.
     tree_util.register_dataclass(Foo, data_fields=["x"], meta_fields=[])
 
+  def test_register_dataclass_decorator_factory(self):
+    @tree_util.register_dataclass(data_fields=["x"], meta_fields=["y"])
+    @dataclasses.dataclass
+    class Foo:
+      x: jax.Array
+      y: int
+
+    f = Foo(jnp.arange(4), 2)
+
+    flattened_x, = tree_util.tree_leaves(f)
+    self.assertArraysEqual(flattened_x, f.x)
+
+    pytreedef = jax.tree.structure(f)
+    self.assertEqual(pytreedef.node_data(), (Foo, (f.y,)))
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This lets you avoid using `@partial` and instead define dataclass pytrees like this:
```python
import jax
import dataclasses

@jax.tree_util.register_dataclass(data_fields=['x'], meta_fields=["y"])
@dataclasses.dataclass
class Foo:
  x: jax.Array
  y: int
```