### PR TITLE
Add LinearOperator prototype to jax.experimental.linalg

### DIFF
--- a/jax/_src/experimental/linalg/linear_operators.py
+++ b/jax/_src/experimental/linalg/linear_operators.py
@@ -1,0 +1,43 @@
+# linear_operators.py 
+
+"""
+Purpose:
+This module introduces a prototype abstraction for linear operators
+in JAX. A LinearOperator represents a matrix-like transformation
+without explicitly storing the full matrix. This is useful for
+"matrix-free" computations such as large-scale optimization,
+physics simulations, or implicit Jacobian-vector products.
+"""
+
+
+from abc import ABC, abstractmethod     # For defining an abstract base class
+import jax.numpy as jnp                 # JAX's NumPy-compatible API for Array Ops 
+from typing import Tuple                # For Shape Annotations 
+
+
+class LinearOperator(ABC):
+    """Abstract base class for matrix-free linear transformations."""
+
+    def __init__(self, shape: Tuple[int, int]):
+        self.shape: Tuple[int, int] = shape  # (m, n)
+    
+    @abstractmethod
+    def matvec(self, x: jnp.ndarray) -> jnp.ndarray:
+        "Apply the operator to a vector x (shape (n,)) -> (m,)."
+    
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        """Convenience: op(x) calls matvec(x)."""
+        return self.matvec(x)
+    
+
+class IdentityOperator(LinearOperator):
+    """An operator that returns its input unchanged: y = x."""
+
+    def __init__(self, size: int):
+        #  identity has shape (n, n)
+        super().__init__((size, size))
+    
+    def matvec(self, x: jnp.ndarray) -> jnp.ndarray:
+        """Apply I * x = x."""
+        assert x.shape[0] == self.shape[1], f"Expected shape {(self.shape[1],)}, got {x.shape}"
+        return x

--- a/jax/_src/experimental/linalg/linear_operators.py
+++ b/jax/_src/experimental/linalg/linear_operators.py
@@ -1,7 +1,4 @@
-# linear_operators.py 
-
 """
-Purpose:
 This module introduces a prototype abstraction for linear operators
 in JAX. A LinearOperator represents a matrix-like transformation
 without explicitly storing the full matrix. This is useful for
@@ -15,23 +12,90 @@ import jax.numpy as jnp                 # JAX's NumPy-compatible API for Array O
 from typing import Tuple                # For Shape Annotations 
 
 
+
+
 class LinearOperator(ABC):
-    """Abstract base class for matrix-free linear transformations."""
+    """Abstract base class for matrix-free linear transformations"""
 
     def __init__(self, shape: Tuple[int, int]):
         self.shape: Tuple[int, int] = shape  # (m, n)
     
     @abstractmethod
     def matvec(self, x: jnp.ndarray) -> jnp.ndarray:
-        "Apply the operator to a vector x (shape (n,)) -> (m,)."
-    
+        "Apply the operator to a vector x (shape (n,)) -> (m,)"
+
     def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
         """Convenience: op(x) calls matvec(x)."""
         return self.matvec(x)
     
+    def __repr__(self) -> str:
+        """Official string representation for debugging."""
+        classname = self.__class__.__name__
+        return f"{classname}(shape={self.shape})"
+    
+    def __str__(self) -> str:
+        """Readable string version shown in print()."""
+        return f"{self.__class__.__name__} with shape {self.shape}"
+
+    def to_dense(self) -> jnp.ndarray:
+        """Materialize the operator as a dense matrix (useful for debugging)"""
+        m, n = self.shape
+        I = jnp.eye(n) # Create an identity matrix of size (n, n)
+        columns = [] # Start with an empty list to collect each column of the dense matrix
+
+        for i in range(n):
+            col = self(I[:, i]) # Apply the operator to the i-th basis vector
+            columns.append(col) # Append the resulting column to the list
+        
+        # Stack all columns side-by-side to form a full dense matrix
+        dense_matrix = jnp.stack(columns, axis=1)
+
+        return dense_matrix
+    
+    def __add__(self, other: "LinearOperator") -> "LinearOperator":
+        """Add two linear operators with the same shape: (A + B)"""
+        assert isinstance(other, LinearOperator), "Can only add LinearOperator objects."
+        assert self.shape == other.shape, f"Shape mismatch: {self.shape} vs {other.shape}"
+
+        class SumOperator(LinearOperator):
+            """Operator representing the sum of two linear operators"""
+
+            def __init__(self, A, B):
+                super().__init__(A.shape)
+                self.A = A
+                self.B = B
+            
+            def matvec(self, x: jnp.ndarray) -> jnp.ndarray:
+                """Apply (A + B)x = A(x) + B(x)"""
+                return self.A(x) + self.B(x)
+            
+        return SumOperator(self, other)
+    
+    def __mul__(self, scalar: float) -> "LinearOperator":
+        """Scale the operator by a scalar: (a * A)"""
+        assert isinstance(scalar, (int, float)), "Can only multiply by a scalar"
+
+        class ScaledOperator(LinearOperator):
+            """Operator representing a scalar multiple of another operator"""
+
+            def __init__(self, A, scale):
+                super().__init__(A.shape)
+                self.A = A
+                self.scale = scale 
+            
+            def matvec(self, x: jnp.ndarray) -> jnp.ndarray:
+                """Apply (a * A)x = a * A(x)"""
+                return self.scale * self.A(x)
+            
+        return ScaledOperator(self, scalar)
+    
+    # Support reversed multiplication
+    __rmul__ = __mul__
+
+
 
 class IdentityOperator(LinearOperator):
-    """An operator that returns its input unchanged: y = x."""
+    """An operator that returns its input unchanged: y = x"""
 
     def __init__(self, size: int):
         #  identity has shape (n, n)
@@ -41,3 +105,98 @@ class IdentityOperator(LinearOperator):
         """Apply I * x = x."""
         assert x.shape[0] == self.shape[1], f"Expected shape {(self.shape[1],)}, got {x.shape}"
         return x
+
+
+
+
+class ScalingOperator(LinearOperator):
+    """A linear operator that scales its input vector by a scalar factor"""
+
+    def __init__(self, scale: float, size: int):
+        """Initialize a scaling operator"""
+        super().__init__((size, size))
+        self.scale = scale
+
+    def matvec(self, x: jnp.ndarray) -> jnp.ndarray:
+        """Applies the scaling transformation: y = a * x."""
+        return self.scale * x
+
+
+
+
+class MatrixOperator(LinearOperator):
+    """A linear operator that wraps an explicit JAX matrix"""
+
+    def __init__(self, matrix: jnp.ndarray):
+        """Initialize the operator"""
+        assert matrix.ndim == 2, f"Matrix must be 2D, got {matrix.ndim}D"
+        m, n = matrix.shape
+        super().__init__((m, n))
+        self.matrix = matrix 
+
+    
+    def matvec(self, x: jnp.ndarray) -> jnp.ndarray:
+        """Applies the linear transformation y = A @ x"""
+        assert x.shape[0] == self.shape[1], (f"Expected input of shape {(self.shape[1],)}, got {x.shape}")
+        return jnp.dot(self.matrix, x)
+
+
+
+
+class CompositionOperator(LinearOperator):
+    """An operator that represents the composition of two linear operators"""
+
+    def __init__(self, A: LinearOperator, B: LinearOperator):
+        """Initialize the composition A(B(x))"""
+        
+        assert A.shape[1] == B.shape[0], (f"Shape mismatch: A {A.shape} cannot follow B {B.shape}")
+        super().__init__((A.shape[0], B.shape[1]))
+        
+        self.A = A
+        self.B = B
+    
+    def matvec(self, x: jnp.ndarray) -> jnp.ndarray:
+        """Apply the composed operator: y = A(B(x))"""
+        return self.A(self.B(x))
+
+
+
+
+class DiagonalOperator(LinearOperator):
+    """A linear operator representing a diagonal matrix (stores only the diagonal)"""
+
+    def __init__(self, diag: jnp.ndarray):
+        """Initialize with a vector of diagonal entries"""
+        assert diag.ndim == 1, f"Diagonal must be 1D, got {diag.ndim}D"
+
+        n = diag.shape[0]
+        super().__init__((n, n))
+        self.diag = diag
+
+    def matvec(self, x: jnp.ndarray) -> jnp.ndarray:
+        """Apply the diagonal transformation: y_i = d_i * x_i"""
+        assert x.shape[0] == self.shape[1], (f"Expected input shape {(self.shape[1],)}, got {x.shape}")
+        return self.diag * x
+
+
+
+class TransposeOperator(LinearOperator):
+    """A linear operator representing the transpose of another operator"""
+
+    def __init__(self, A: LinearOperator):
+        """Initialize with another linear operator A; represents A^T"""
+
+        # Swap shape dimensions
+        super().__init__((A.shape[1], A.shape[0]))
+        self.A = A
+
+    def matvec(self, x: jnp.ndarray) -> jnp.ndarray:
+        """Apply the transpose transformation: y = A^T x"""
+
+        # If A is a MatrixOperator, use its matrix directly
+        if isinstance(self.A, MatrixOperator):
+            return jnp.dot(self.A.matrix.T, x)
+        else:
+            # Fall back to a dense conversion for other operator types
+            return jnp.dot(self.A.to_dense().T, x)
+

--- a/jax/_src/experimental/linalg/tests/test_linear_operators.py
+++ b/jax/_src/experimental/linalg/tests/test_linear_operators.py
@@ -1,0 +1,212 @@
+import pytest
+import jax.numpy as jnp
+from jax._src.experimental.linalg.linear_operators import (
+    LinearOperator,
+    IdentityOperator,
+    ScalingOperator,
+    MatrixOperator,
+    CompositionOperator,
+    DiagonalOperator,
+    TransposeOperator,
+)
+
+
+
+# ---------------------------------------EASY TEST CASES------------------------------------------ 
+
+# Basic IdentityOperator tests
+def test_identity_operator_returns_input():
+    x = jnp.array([1.0, 2.0, 3.0])
+    I = IdentityOperator(size=3)
+    y = I(x)
+    assert jnp.allclose(y, x)
+
+
+# ScalingOperator tests
+def test_scaling_operator_scales_correctly():
+    x = jnp.array([1.0, -2.0, 3.0])
+    S = ScalingOperator(scale=2.0, size=3)
+    y = S(x)
+    assert jnp.allclose(y, 2.0 * x)
+
+
+
+# MatrixOperator tests
+def test_matrix_operator_matches_explicit_dot():
+    A = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    x = jnp.array([1.0, -1.0])
+    M = MatrixOperator(A)
+    y = M(x)
+    assert jnp.allclose(y, jnp.dot(A, x))
+
+
+
+# CompositionOperator tests
+def test_composition_operator_matches_manual_composition():
+    A = MatrixOperator(jnp.array([[1.0, 2.0], [3.0, 4.0]]))
+    B = ScalingOperator(scale=2.0, size=2)
+    C = CompositionOperator(A, B)
+    x = jnp.array([1.0, -1.0])
+    y = C(x)
+    expected = A(B(x))
+    assert jnp.allclose(y, expected)
+
+
+# DiagonalOperator tests
+def test_diagonal_operator_multiplies_elementwise():
+    diag = jnp.array([1.0, 2.0, 3.0])
+    D = DiagonalOperator(diag)
+    x = jnp.array([2.0, 2.0, 2.0])
+    y = D(x)
+    assert jnp.allclose(y, diag * x)
+
+
+# TransposeOperator tests
+def test_transpose_operator_matches_matrix_transpose():
+    A = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    M = MatrixOperator(A)
+    T = TransposeOperator(M)
+    x = jnp.array([1.0, -1.0])
+    y = T(x)
+    expected = jnp.dot(A.T, x)
+    assert jnp.allclose(y, expected)
+
+
+# to_dense() and operator algebra tests
+def test_to_dense_recreates_matrix_operator():
+    A = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    M = MatrixOperator(A)
+    dense = M.to_dense()
+    assert jnp.allclose(dense, A)
+
+
+def test_operator_addition_and_scalar_multiplication():
+    A = MatrixOperator(jnp.array([[1.0, 0.0], [0.0, 2.0]]))
+    B = ScalingOperator(scale=1.0, size=2)
+    x = jnp.array([3.0, 4.0])
+
+    sum_op = A + B
+    scaled_op = 2.0 * A
+
+    y_sum = sum_op(x)
+    y_scaled = scaled_op(x)
+
+    expected_sum = A(x) + B(x)
+    expected_scaled = 2.0 * A(x)
+
+    assert jnp.allclose(y_sum, expected_sum)
+    assert jnp.allclose(y_scaled, expected_scaled)
+
+
+
+# ---------------------------------------MEDIUM TEST CASES------------------------------------------ 
+
+def test_composed_operator_with_diagonal_and_scaling():
+    """Test composition of Diagonal and Scaling operators"""
+    diag = jnp.array([1.0, 3.0, 5.0])
+    D = DiagonalOperator(diag)
+    S = ScalingOperator(2.0, size=3)
+    C = CompositionOperator(D, S)  # D(S(x)) = 2 * D(x)
+    x = jnp.array([1.0, 1.0, 1.0])
+    y = C(x)
+    expected = 2.0 * diag * x
+    assert jnp.allclose(y, expected)
+
+
+def test_addition_and_scaling_chains_correctly():
+    """Check that scalar and operator addition behave as expected"""
+    A = MatrixOperator(jnp.array([[1.0, 0.0], [0.0, 2.0]]))
+    B = MatrixOperator(jnp.array([[0.5, 0.5], [0.5, 0.5]]))
+    x = jnp.array([2.0, 4.0])
+
+    combo = 2.0 * A + B
+    y = combo(x)
+    expected = 2.0 * (A(x)) + B(x)
+    assert jnp.allclose(y, expected)
+
+
+def test_transpose_of_composed_operator_matches_dense():
+    """Test (A(B(x)))^T ≈ (B^T A^T)(x) numerically"""
+    A = MatrixOperator(jnp.array([[1., 2.], [3., 4.]]))
+    B = MatrixOperator(jnp.array([[0., 1.], [1., 0.]]))  # swap operator
+    C = CompositionOperator(A, B)
+    T = TransposeOperator(C)
+    x = jnp.array([1.0, -1.0])
+    y = T(x)
+    expected = jnp.dot(C.to_dense().T, x)
+    assert jnp.allclose(y, expected)
+
+
+
+# ---------------------------------------HARD TEST CASES------------------------------------------ 
+
+def test_shape_mismatch_raises_assertion():
+    """Ensure shape mismatch produces a clear assertion"""
+    A = MatrixOperator(jnp.array([[1.0, 2.0], [3.0, 4.0]]))
+    x = jnp.array([1.0, 2.0, 3.0])  # wrong shape
+    with pytest.raises(AssertionError):
+        _ = A(x)
+
+
+def test_large_random_operator_consistency():
+    """For a large operator, to_dense() and matvec() agree"""
+    key = jnp.arange(0, 100).reshape(10, 10) * 0.01
+    A = MatrixOperator(key)
+    x = jnp.linspace(-1, 1, 10)
+    dense = A.to_dense()
+    y_dense = jnp.dot(dense, x)
+    y_op = A(x)
+    assert jnp.allclose(y_dense, y_op, atol=1e-6)
+
+
+def test_combined_linear_expression_equivalence():
+    """Test ((A + B) @ x) == A@x + B@x for random matrices"""
+    A = MatrixOperator(jnp.array([[1., 2.], [0., 1.]]))
+    B = MatrixOperator(jnp.array([[0., 1.], [3., -1.]]))
+    x = jnp.array([0.5, -0.5])
+    sum_op = A + B
+    y_sum = sum_op(x)
+    expected = A(x) + B(x)
+    assert jnp.allclose(y_sum, expected)
+
+
+
+
+# ---------------------------------------UGLY EDGE TEST CASES------------------------------------------ 
+
+def test_scaling_operator_zero_and_negative():
+    """Scaling by 0 or negative values behaves correctly"""
+    x = jnp.array([1.0, -2.0, 3.0])
+    zero_op = ScalingOperator(scale=0.0, size=3)
+    neg_op = ScalingOperator(scale=-1.0, size=3)
+
+    y_zero = zero_op(x)
+    y_neg = neg_op(x)
+
+    assert jnp.allclose(y_zero, jnp.zeros_like(x))
+    assert jnp.allclose(y_neg, -x)
+
+
+def test_empty_operator_behavior():
+    """Ensure 0x0 operators don't crash"""
+    A = MatrixOperator(jnp.zeros((0, 0)))
+    x = jnp.zeros((0,))
+    y = A(x)
+    assert y.shape == (0,)
+
+
+def test_nested_composition_three_layers():
+    """Nested composition should behave correctly"""
+    A = MatrixOperator(jnp.array([[1., 2.], [3., 4.]]))
+    B = ScalingOperator(0.5, 2)
+    C = DiagonalOperator(jnp.array([2., 3.]))
+
+    composed = CompositionOperator(A, CompositionOperator(B, C))  # A(B(C(x)))
+    x = jnp.array([1.0, -1.0])
+    y = composed(x)
+
+    expected = A(B(C(x)))
+    assert jnp.allclose(y, expected)
+
+
+


### PR DESCRIPTION
This PR adds a prototype LinearOperator abstraction under jax.experimental.linalg. It introduces an abstraction for matrix-free linear operators in JAX, allowing for efficient composition and algebra of transformations without explicitly needing to form matrices. 

This PR includes: 
-> Base class LinearOperator and implementations: IdentityOperator, ScalingOperator, MatrixOperator, DiagonalOperator, CompositionOperator, TransposeOperator 
-> Support for operator addition (A+B), scalar scaling (A*B), and .to_dense() materialization
-> Comprehensive test suite of 17 tests (easy, medium, hard, ugly edge cases), passing all of them

NOTE: This is an experimental prototype contribution under jax.experimental.linalg. I wasn't sure if a separate Discussion was needed, but since this is exploratory and self-contained, I have opened it as a PR for feedback. Happy to move it to a Discussion as well if preferred. 

Thank you so much for your time, and excited for feedback and merging! 