### PR TITLE
[ROCm] Resolve undefined behavior in bitshift unit test

### DIFF
--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -1753,7 +1753,7 @@ class OpsTest(PallasBaseTest):
       o_ref[...] = f(x_ref[...], y_ref[...])
 
     x = jnp.array([1, 3, -4, -6, 2, 5, 4, -7]).astype(dtype)
-    if f == jnp.bitwise_left_shift:
+    if "shift" in f.__name__:
       y = jnp.array([3, 1, 4, 5, 2, 2, 2, 4]).astype(dtype)
     else:
       y = jnp.array([3, 1, -4, -5, 2, -2, 2, 4]).astype(dtype)


### PR DESCRIPTION
Bitshift operations exhibit undefined behavior when the shift amount exceeds the bit width of the operand.

This issue caused test failures on ROCm due to differences in how the pallas kernel and the JAX reference implementation are compiled. The JAX path lowers shifts via HLO into operations with saturation semantics, while the pallas kernel uses Triton, which lowers shifts through the arith dialect into hardware instructions.

Since the arith dialect does not guarantee defined behavior for out-of-range shift amounts, the two compilation paths may produce inconsistent results. This change ensures the test avoids such undefined behavior, allowing consistent outcomes across both paths.