### PR TITLE
Make nvidia version data optional for ROCm builds

### DIFF
--- a/jaxlib/tools/build_gpu_kernels_wheel.py
+++ b/jaxlib/tools/build_gpu_kernels_wheel.py
@@ -72,6 +72,9 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
+if args.enable_cuda and not args.nvidia_wheel_versions_data:
+  parser.error('argument --nvidia_wheel_versions_data is required for CUDA builds')
+
 r = runfiles.Create()
 pyext = "pyd" if build_utils.is_windows() else "so"
 

--- a/jaxlib/tools/build_gpu_kernels_wheel.py
+++ b/jaxlib/tools/build_gpu_kernels_wheel.py
@@ -67,7 +67,7 @@ parser.add_argument(
 parser.add_argument(
     "--nvidia_wheel_versions_data",
     default=None,
-    required=True,
+    required=False,
     help="NVIDIA wheel versions data",
 )
 args = parser.parse_args()

--- a/jaxlib/tools/build_gpu_plugin_wheel.py
+++ b/jaxlib/tools/build_gpu_plugin_wheel.py
@@ -73,7 +73,7 @@ parser.add_argument(
 parser.add_argument(
     "--nvidia_wheel_versions_data",
     default=None,
-    required=True,
+    required=False,
     help="NVIDIA wheel versions data",
 )
 args = parser.parse_args()

--- a/jaxlib/tools/build_gpu_plugin_wheel.py
+++ b/jaxlib/tools/build_gpu_plugin_wheel.py
@@ -77,7 +77,8 @@ parser.add_argument(
     help="NVIDIA wheel versions data",
 )
 args = parser.parse_args()
-
+if args.enable_cuda and not args.nvidia_wheel_versions_data:
+  parser.error('argument --nvidia_wheel_versions_data is required for CUDA builds')
 r = runfiles.Create()
 
 


### PR DESCRIPTION
This argument is only needed for NVIDIA/CUDA builds, not for ROCm builds.
Changed required=True to required=False to allow ROCm builds to proceed
without providing NVIDIA-specific data.