### PR TITLE
Fix ROCm lib names copy pattern to use wildcard version

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -722,6 +722,9 @@ async def main():
       wheel_dir = wheel.replace("cuda", f"cuda{cuda_major_version}").replace(
           "-", "_"
       )
+    elif "rocm" in wheel:
+      # Use wildcard pattern to match any ROCm version (rocm60, rocm7, etc.)
+      wheel_dir = wheel.replace("rocm", "rocm*").replace("-", "_")
     else:
       wheel_dir = wheel
 
@@ -739,7 +742,7 @@ async def main():
           wheel_version_suffix += (
               f"+{wheel_git_hash}{custom_wheel_version_suffix}"
           )
-      if wheel in ["jax", "jax-cuda-pjrt"]:
+      if wheel in ["jax", "jax-cuda-pjrt", "jax-rocm-pjrt"]:
         python_tag = "py"
       else:
         python_tag = "cp"

--- a/build/build.py
+++ b/build/build.py
@@ -723,8 +723,12 @@ async def main():
           "-", "_"
       )
     elif "rocm" in wheel:
-      # Use wildcard pattern to match any ROCm version (rocm60, rocm7, etc.)
-      wheel_dir = wheel.replace("rocm", "rocm*").replace("-", "_")
+      if args.editable:
+        # For editable builds, use the actual ROCm version since directory paths cannot contain wildcards
+        wheel_dir = wheel.replace("rocm", f"rocm{args.rocm_version}").replace("-", "_")
+      else:
+        # For non-editable builds, use wildcard pattern to match any ROCm version in glob patterns
+        wheel_dir = wheel.replace("rocm", "rocm*").replace("-", "_")
     else:
       wheel_dir = wheel
 


### PR DESCRIPTION
The build script failed to copy ROCm 7 wheels due to hardcoded version
pattern. Changed to use wildcard (rocm*) to match any ROCm version.
Changes:
Use rocm* wildcard instead of rocm{version} in wheel pattern
Add jax-rocm-pjrt to py-tagged wheels list
Supports jax_rocm60_, jax_rocm7_, and future versions