### PR TITLE
Expose client's platform version via jax.backend_version(platform)

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -84,6 +84,7 @@ del _xc
 
 from jax._src.core import typeof as typeof
 from jax._src.api import effects_barrier as effects_barrier
+from jax._src.xla_bridge import backend_version as backend_version
 from jax._src.api import block_until_ready as block_until_ready
 from jax._src.ad_checkpoint import checkpoint_wrapper as checkpoint  # noqa: F401
 from jax._src.ad_checkpoint import checkpoint_policies as checkpoint_policies

--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -1005,6 +1005,11 @@ def default_backend() -> str:
   return get_backend(None).platform
 
 
+def backend_version(platform=None) -> str:
+  """Returns the platform version of the backend."""
+  return get_backend(platform).platform_version
+
+
 def backend_pjrt_c_api_version(platform=None) -> tuple[int, int] | None:
   """Returns the PJRT C API version of the backend.
 


### PR DESCRIPTION
Intended as a stable API that allows users to learn about the version of CUDA the GPU plugin was built against.

Wasn't sure whether to call this `backend_platform_version` or `backend_version`, but the latter seems more in line with `default_backend` which returns the client's `.platform`.