### PR TITLE
Break circular import of lowering.py and sc_lowering.py

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -2239,3 +2239,9 @@ jax_collectives_common_channel_id = bool_flag(
     default=True,
     help="Should collectives use a common channel ID? Temporary feature flag.",
 )
+
+jax_pallas_verbose_errors = bool_flag(
+    "jax_pallas_verbose_errors",
+    default=bool_env("JAX_PALLAS_VERBOSE_ERRORS", False),
+    help="If True, print verbose error messages for Pallas kernels.",
+)

--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -29,6 +29,7 @@ from jax import lax
 from jax import tree_util
 from jax._src import ad_util
 from jax._src import checkify
+from jax._src import config
 from jax._src import core as jax_core
 from jax._src import custom_derivatives
 from jax._src import debugging
@@ -61,7 +62,6 @@ from jax._src.lib.mlir.dialects import scf
 from jax._src.lib.mlir.dialects import vector
 from jax._src.pallas import core as pallas_core
 from jax._src.pallas import helpers as pallas_helpers
-from jax._src.pallas import pallas_call
 from jax._src.pallas import primitives
 from jax._src.pallas import utils as pallas_utils
 from jax._src.pallas.mosaic import core as tpu_core
@@ -1200,7 +1200,7 @@ def jaxpr_subcomp(
         except LoweringException:
           raise  # We only add the extra info to the innermost exception.
         except Exception as e:
-          if not pallas_call._verbose_errors_enabled():
+          if not config.jax_pallas_verbose_errors.value:
             raise
           msg = (f"{type(e).__name__}: {e}\n" +
                 "Additional diagnostics: \n" +

--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -1380,19 +1380,6 @@ _PALLAS_USE_MOSAIC_GPU = config.bool_state(
 )
 
 
-_PALLAS_VERBOSE_ERRORS = config.bool_flag(
-    "jax_pallas_verbose_errors",
-    default=config.bool_env("JAX_PALLAS_VERBOSE_ERRORS", False),
-    help=(
-        "If True, print verbose error messages for Pallas kernels."
-    ),
-)
-
-
-def _verbose_errors_enabled() -> bool:
-  return _PALLAS_VERBOSE_ERRORS.value
-
-
 def _unsupported_lowering_error(platform: str) -> Exception:
   return ValueError(
       f"Cannot lower pallas_call on platform: {platform}. To use Pallas on GPU,"


### PR DESCRIPTION
Moved a Pallas config flag from `pallas_call.py` to `config.py` to remove the unnecessary import.

Reproed from `python -c "from jax._src.pallas.mosaic import lowering"`