### PR TITLE
Update scaled matmul test.

### DIFF
--- a/tests/scaled_matmul_stablehlo_test.py
+++ b/tests/scaled_matmul_stablehlo_test.py
@@ -53,7 +53,7 @@ expected_hlos = [
     [(c_name,)],
     [("all-gather", "f8e4m3fn[256,1024]", "replica_groups=[2,2]<=[4]"), (c_name,)],
     [(c_name,)],
-    [("all-gather", "f8e4m3fn[2,512,1024]", "replica_groups=[2,2]<=[4]"), (c_name,)],
+    [("all-gather", "f8e4m3fn", "replica_groups=[2,2]<=[4]"), ("f8e4m3fn[2,512,1024]", c_name)],
     [("all-gather", "f8e4m3fn[2,512,512]", "replica_groups=[2,2]<=[4]"), (c_name,)],
     [("all-gather", "f8e4m3fn[2,256,1024]", "replica_groups=[2,2]<=[2,2]"), (c_name,)],
 ]


### PR DESCRIPTION
All-gathers are optimized differently after https://github.com/openxla/xla/pull/33260.