### PR TITLE
[Docs] lax.conv_transpose: improved the clarity of TensorFlow/Keras kernel convention in lax.conv_transpose (#14337)

### DIFF
--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -294,6 +294,13 @@ def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
   This function directly calculates a fractionally strided conv rather than
   indirectly calculating the gradient (transpose) of a forward convolution.
 
+  Notes:
+    TensorFlow/Keras Compatibility: By default, JAX does NOT reverse the
+    kernel's spatial dimensions. This differs from TensorFlow's "Conv2DTranspose"
+    and similar frameworks, which flip spatial axes and swap input/output channels.
+
+    To match TensorFlow/Keras behavior, set "transpose_kernel=True" .
+
   Args:
     lhs: a rank `n+2` dimensional input array.
     rhs: a rank `n+2` dimensional array of kernel weights.


### PR DESCRIPTION
**#14337**

Documented the difference in reversing the spatial axes of the kernel between popular frameworks and lax.conv_transpose
and explained how to to match TensorFlow/Keras behavior by setting the existing parameter: **transpose_kernel=True**.

**Changes:**
The docstring for `lax.conv_transpose` in 'jax/_src/lax/convolution.py,'
The documentation now explicitly guides users.
<img width="665" height="475" alt="Screenshot 2025-11-19 at 10 41 41 PM" src="https://github.com/user-attachments/assets/96d0aaa9-2b4b-4f23-8e6b-1dbe024168e8" />


