### PR TITLE
Fix Ref indexing discrepancies with array indexing

### DIFF
--- a/jax/_src/state/discharge.py
+++ b/jax/_src/state/discharge.py
@@ -40,8 +40,8 @@ from jax._src.lax import slicing as lax_slicing
 from jax._src.state import indexing
 from jax._src.state.primitives import addupdate_p, get_p, swap_p, pin, unpin
 from jax._src.state.types import (
-    AbstractRef, RefBitcaster, RefEffect, RefReshaper, get_ref_aval_from_value,
-    uninitialized,)
+    AbstractRef, RefBitcaster, RefEffect, RefFlip, RefNewAxis, RefReshaper,
+    get_ref_aval_from_value, uninitialized,)
 from jax._src.state.utils import bitcast, hoist_consts_to_refs
 from jax._src.typing import Array
 from jax._src.util import (foreach, safe_map, safe_zip, split_list, unzip2,
@@ -466,6 +466,11 @@ def transform_array(x, transforms):
         result = bitcast(result, transform.dtype)
       case RefReshaper():
         result = result.reshape(transform.shape)
+      case RefFlip():
+        result = lax.rev(result, transform.axes)
+      case RefNewAxis():
+        # Insert new axes at specified positions
+        result = lax.expand_dims(result, sorted(transform.positions))
       case _:
         raise NotImplementedError(f"Unsupported transform: {transform}")
   return result
@@ -509,9 +514,17 @@ def transform_swap_array(x, transforms, val):
           # was indexed into.
         intermediates.append(new_val)
       case RefBitcaster():
-        intermediates.append(bitcast(new_val, transform.dtype))
+        new_val = bitcast(new_val, transform.dtype)
+        intermediates.append(new_val)
       case RefReshaper():
-        intermediates.append(new_val.reshape(transform.shape))
+        new_val = new_val.reshape(transform.shape)
+        intermediates.append(new_val)
+      case RefFlip():
+        new_val = lax.rev(new_val, transform.axes)
+        intermediates.append(new_val)
+      case RefNewAxis():
+        new_val = lax.expand_dims(new_val, sorted(transform.positions))
+        intermediates.append(new_val)
       case _:
         raise NotImplementedError(f"Unsupported transform: {transform}")
 
@@ -520,7 +533,7 @@ def transform_swap_array(x, transforms, val):
   new_x = val
 
   # Write phase (reversed loop)
-  for intermediate, transform in reversed(zip(intermediates[:-1], transforms)):
+  for intermediate, transform in reversed(list(zip(intermediates[:-1], transforms))):
     if isinstance(transform, indexing.NDIndexer):
       indexer = transform
       if _is_trivial_indexer(indexer):
@@ -541,6 +554,18 @@ def transform_swap_array(x, transforms, val):
         if transpose_order is not None:
           transpose_order_inversed = np.argsort(transpose_order)
           new_x = new_x.transpose(transpose_order_inversed)
+    elif isinstance(transform, RefFlip):
+      # Reverse the flip
+      new_x = lax.rev(new_x, transform.axes)
+    elif isinstance(transform, RefNewAxis):
+      # Squeeze the added axes
+      new_x = lax.squeeze(new_x, sorted(transform.positions))
+    elif isinstance(transform, RefReshaper):
+      # Reshape back to the shape of the intermediate array
+      new_x = new_x.reshape(intermediate.shape)
+    elif isinstance(transform, RefBitcaster):
+      # Bitcast back to the dtype of the intermediate array
+      new_x = bitcast(new_x, intermediate.dtype)
     else:
       raise NotImplementedError(f"Unsupported transform: {transform}")
 


### PR DESCRIPTION
This addresses the issues raised in #33322 where Ref indexing behaves differently from regular JAX array indexing.

**Changes:**

- Fixed OOB slice validation to allow empty slices (e.g., `slice(11, 12, 1)` on size-10 array now returns empty result instead of erroring)
- Added support for `None` indexing to insert new axes (e.g., `x[None]`, `x[..., None]`)
- Added support for negative step slices (e.g., `x[::-1]`) by converting them to positive steps and applying a flip transform
- Refactored `RefIndexer.__getitem__` into helper functions for better maintainability

For `None` indexing, added a `RefNewAxis` transform that tracks where new axes should be inserted. For negative steps, added a `RefFlip` transform that reverses the specified axes after indexing with the positive-step equivalent.

Fixes #33322.