### PR TITLE
[test] explicitly specify gather mode in roofline test

### DIFF
--- a/tests/roofline_test.py
+++ b/tests/roofline_test.py
@@ -965,6 +965,7 @@ class RooflineTest(jtu.JaxTestCase):
         y,
         dimension_numbers=dimension_numbers,
         slice_sizes=(1, 1, 3),
+        mode=lax.GatherScatterMode.PROMISE_IN_BOUNDS,
     )
 
     _, result = roofline.roofline(f)(operand, indices)


### PR DESCRIPTION
We are experimenting with changing the default mode for gather; this will make the test robust to that change.