### PR TITLE
Fixed lapack kernel null pointer issue

### DIFF
--- a/jax/_src/export/_export.py
+++ b/jax/_src/export/_export.py
@@ -1446,6 +1446,7 @@ def has_sdy_mesh(symtab: ir.SymbolTable, submodule: ir.Module) -> bool:
 
 def _call_exported_lowering(ctx: mlir.LoweringRuleContext, *args,
                             exported: Exported):
+  _ensure_backends_initialized(exported.platforms)
   if exported.uses_global_constants:
     ctx.module_context.shape_poly_state.uses_dim_vars = True
   submodule = ir.Module.parse(exported.mlir_module())
@@ -1609,6 +1610,11 @@ def _call_exported_lowering(ctx: mlir.LoweringRuleContext, *args,
 
 mlir.register_lowering(call_exported_p, _call_exported_lowering)
 
+def _ensure_backends_initialized(platforms: tuple[str,...]):
+  """Ensure FFI handlers are initialized for the given platforms"""
+  if "cpu" in platforms:
+    from jaxlib.cpu import _lapack
+    _lapack.initialize()
 
 def wrap_with_sharding(
     ctx: mlir.LoweringRuleContext,


### PR DESCRIPTION
Closes #29610 - Fixes segfault when exporting choleksy and svd functions

### **Example Code**

**test.py**
```python
import jax
import jax.numpy as jnp

with open("tmp.bin", "rb") as file:
    exported_fn = bytearray(file.read())
    rehydrated_fn = jax.export.deserialize(exported_fn)
    data = jnp.array([[2.0, 1.0], [1.0, 2.0]])
    out = rehydrated_fn.call(data)  # seg-fault
    print(out)
```

**main.py**
```python
import jax.export
import jax
import jax.numpy as jnp

chol = jax.jit(jax.lax.linalg.cholesky)
data = jnp.array([[2.0, 1.0], [1.0, 2.0]])
exported_main = jax.export.export(chol)(data)
with open("tmp.bin", "wb") as file:
    file.write(exported_main.serialize())
```

**Working Output**
```bash
(jax-dev) jha@MAGICIAN:~/workspace/opensource/reports/jax-bug-choskley$ python test.py
WARNING:2025-11-25 10:56:18,160:jax._src.xla_bridge:854: An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.
[[1.4142135  0.        ]
 [0.70710677 1.2247449 ]]
(jax-dev) jha@MAGICIAN:~/workspace/opensource/reports/jax-bug-choskley$ 
```

## Reason behind the error:

- These functions ( choleksy , svd , and about in total 15 functions in that particular file where they are defined ) use ffi handlers to get the kernels to perform the operation.
- These kernel functions are initialized as nullptr and are statically loaded when calling these functions - during normal computation, hence no error.
- When we export we also correctly embeed the information regarding where they should be.
- But when we deseralize them again - like load them from the tmp.bin file - the mlir script ( subscript of mlir ) - we do not initialize the lapack kernels ( backends )  and they keep on pointing at the nullptr and hence fail.
- This does not happen in GPU because they are not statically linked but dynamically so they are always initialized at runtime.
- The trace also causes them to be initialized hence running the trace functions on them causes them to not give segfault 