### PR TITLE
Fixed docstring of make_array_from_process_local_data

### DIFF
--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -903,14 +903,14 @@ def make_array_from_process_local_data(
     >>> assert output_global_array.addressable_data(0).shape == per_device_shape
     >>> assert output_global_array.shape == global_shape
 
-  NB: While most shardings are uniform, It is possible to design am exotic
+  NB: While most shardings are uniform, It is possible to design an exotic
   sharding mesh where each process's  devices will be arranged in a non-grid
   like pattern in some dimensions, or for indices to overlap non-trivially.
   Such sharding is called "non-uniform" in those dimensions. In that case,
   the global shape along those directions must match local shape as there is
   no meaningful way to represent all needed
   per-process data in non-overlapping fashion. For example for global_shape 4x4
-  if sharding looks like this:
+  if sharding looks like this::
 
       0123
       2103
@@ -918,7 +918,7 @@ def make_array_from_process_local_data(
       4567
 
   with 4 processes, containing devices (0,1), (2, 3), (4, 5), (6, 7) respectively.
-  Then the data for each host look like
+  Then the data for each host look like::
 
       xx..    ..xx     ....    ....
       .xx.    x..x     ....    ....
@@ -932,7 +932,7 @@ def make_array_from_process_local_data(
   In this case user must provide global_shape explicitly and for
   local_shape=(2, 4), potentially valid global shapes are (2, 4) and (4, 4).
 
-  On the other hand for sharding:
+  On the other hand for sharding::
 
       0213   x.x.  .x.x.  ....  ....
       0213   x.x.  .x.x.  ....  ....


### PR DESCRIPTION
Fixed a typo and text block rendering:

Before:
<img width="614" height="405" alt="image" src="https://github.com/user-attachments/assets/bec1574c-60a0-412d-88ab-c9c333a20ab6" />

https://docs.jax.dev/en/latest/_autosummary/jax.make_array_from_process_local_data.html#jax.make_array_from_process_local_data

After:

<img width="608" height="518" alt="image" src="https://github.com/user-attachments/assets/91ad159c-e5d5-44b9-9384-4aa7883a021f" />


https://jax--33537.org.readthedocs.build/en/33537/_autosummary/jax.make_array_from_process_local_data.html#jax.make_array_from_process_local_data
