### PR TITLE
Enable rocm devices in psend lowering.

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -1191,7 +1191,7 @@ single_side_collective_effect = SingleSideCollectiveEffect()
 core.effects.control_flow_allowed_effects.add_type(SingleSideCollectiveEffect)
 
 def _psend_lowering_gpu(ctx, x, *, axis_name, perm):
-  if ("cuda" not in ctx.module_context.platforms):
+  if all(p not in ctx.module_context.platforms for p in ("cuda", "rocm")):
     raise NotImplementedError("psend is currently only implemented on GPUs")
 
   full_perm, other_args = _pcollectives_lowering_common(


### PR DESCRIPTION
The tests in `tests/shard_map_test.py` were throwing a NotImplementedError for ROCm devices complaining that psend is only implemented for GPUs.

This patch fixes the issue by enabling the lowering also for ROCm devices.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->