### PR TITLE
Fix 'Invalid Notebook' error in GitHub Preview of 'collab_cpu.ipynb'

### DIFF
--- a/tests/notebooks/colab_cpu.ipynb
+++ b/tests/notebooks/colab_cpu.ipynb
@@ -54,16 +54,16 @@
         "print(jax.__version__)\n",
         "print(jaxlib.__version__)"
       ],
-      "execution_count": 6,
+      "execution_count": 1,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "m-s-1p12yf76kgzz\n",
             "0.1.64\n",
             "0.1.45\n"
-          ],
-          "name": "stdout"
+          ]
         }
       ]
     },
@@ -91,14 +91,15 @@
       "execution_count": 2,
       "outputs": [
         {
+          "name": "stderr",
           "output_type": "stream",
           "text": [
             "/usr/local/lib/python3.6/dist-packages/jax/lib/xla_bridge.py:123: UserWarning: No GPU/TPU found, falling back to CPU.\n",
             "  warnings.warn('No GPU/TPU found, falling back to CPU.')\n"
-          ],
-          "name": "stderr"
+          ]
         },
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "JAX device type: cpu:0\n"
@@ -148,11 +149,11 @@
       "execution_count": 3,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "1.0216691\n"
-          ],
-          "name": "stdout"
+          ]
         }
       ]
     },
@@ -194,12 +195,12 @@
       "execution_count": 4,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[6.9178133 5.9580317 5.581113  4.506963  4.111582  3.973543  3.3307292\n",
             " 2.8664916 1.8229378 1.5478933]\n"
-          ],
-          "name": "stdout"
+          ]
         }
       ]
     },
@@ -235,12 +236,12 @@
       "execution_count": 5,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[ 0.34676832 -0.7532232   1.7060695  ...  2.1208048  -0.42621925\n",
             "  0.13093236]\n"
-          ],
-          "name": "stdout"
+          ]
         }
       ]
     }


### PR DESCRIPTION
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->
This PR fixes an issue due to malformed cell output.
Notebook cell outputs require `name` property the stream that the output will be written to, otherwise a generic error is shown during github preview due to validation error.
<img width="1254" height="335" alt="Invalid_Notebook" src="https://github.com/user-attachments/assets/e82797a8-1ebb-4329-a414-fa2aff636ff2" />


You can recreate this issue locally this way:
```bash
$ python
Python 3.14.0 (main, Oct  7 2025, 09:34:52) [Clang 17.0.0 (clang-1700.0.13.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import nbformat
>>> import json
>>> with open('colab_cpu.ipynb', encoding='utf-8') as fh:
...     nb = json.load(fh)
... nbformat.validate(nb)
... 
Traceback (most recent call last):
  File "<python-input-2>", line 3, in <module>
    nbformat.validate(nb)
    ~~~~~~~~~~~~~~~~~^^^^
  File "jax/.venv/lib/python3.14/site-packages/nbformat/validator.py", line 509, in validate
    raise error
nbformat.validator.NotebookValidationError: 'name' is a required property

Failed validating 'required' in stream:

On instance['cells'][4]['outputs'][1]:
{'output_type': 'stream', 'text': ['JAX device type: cpu:0\n']}
>>> exit()
```
