### PR TITLE
[Pallas/Triton, ROCm] Add lax.is_finite_p() lowering with tests

### DIFF
--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -1443,6 +1443,7 @@ def _integer_pow_rule(ctx: LoweringRuleContext, x, *, y: int):
 _JAX_FN_MAPPING = {
     lax.clamp_p: lambda min, a, max: jnp.minimum(jnp.maximum(min, a), max),
     lax.logistic_p: lambda a, accuracy: 1 / (1 + jnp.exp(-a)),
+    lax.is_finite_p: lambda x: jnp.logical_and(~jnp.isnan(x), ~jnp.isinf(x)),
 }
 
 for prim, fn in _JAX_FN_MAPPING.items():

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -998,9 +998,18 @@ class OpsTest(PallasBaseTest):
       -0.2, jnp.inf, -jnp.inf, jnp.nan, 0.0, 1.0, -1.0, 0.5,
   ]
 
-  def test_is_finite(self):
-    if jtu.test_device_matches(["gpu"]):
-      self.skipTest("Not supported on GPU")
+  @parameterized.named_parameters(
+      (dtype.__name__, dtype)
+      for dtype in (jnp.float32, jnp.float16, jnp.bfloat16)
+      # other dtypes are TBD once is_nan and is_inf supports them
+  )
+  def test_is_finite(self, dtype):
+    if jtu.test_device_matches(["tpu"]) and dtype != jnp.float32:
+      # The original test worked only fp32@TPU. Have no way to test TPU with other types.
+      self.skipTest("Not tested on TPU, todo for the respective team")
+    if jtu.test_device_matches(["cuda"]):
+      # The original test worked only on fp32@TPU, have no way to test CUDA
+      self.skipTest("Not tested on CUDA, todo for the respective team")
 
     size = len(self.IS_FINITE_TEST_VALUES)
 
@@ -1011,14 +1020,23 @@ class OpsTest(PallasBaseTest):
     def kernel(x_ref, o_ref):
       o_ref[...] = lax.is_finite(x_ref[...])
 
-    x = jnp.array(self.IS_FINITE_TEST_VALUES, dtype=jnp.float32)
+    x = jnp.array(self.IS_FINITE_TEST_VALUES, dtype=dtype)
     out = kernel(x)
     expected = lax.is_finite(x)
     self.assertArraysEqual(out, expected)
 
-  def test_is_finite_scalar(self):
-    if jtu.test_device_matches(["gpu"]):
-      self.skipTest("Not supported on GPU")
+  @parameterized.named_parameters(
+      (dtype.__name__, dtype)
+      for dtype in (jnp.float32, jnp.float16, jnp.bfloat16)
+      # other dtypes are TBD once is_nan and is_inf supports them
+  )
+  def test_is_finite_scalar(self, dtype):
+    if jtu.test_device_matches(["tpu"]) and dtype != jnp.float32:
+      # The original test worked only fp32@TPU. Have no way to test TPU with other types.
+      self.skipTest("Not tested on TPU, todo for the respective team")
+    if jtu.test_device_matches(["cuda"]):
+      # The original test worked only on fp32@TPU, have no way to test CUDA
+      self.skipTest("Not tested on CUDA, todo for the respective team")
 
     size = len(self.IS_FINITE_TEST_VALUES)
 
@@ -1032,7 +1050,7 @@ class OpsTest(PallasBaseTest):
       for i in range(8):
         o_ref[i] = jnp.isfinite(x_ref[i])
 
-    x = jnp.array(self.IS_FINITE_TEST_VALUES, dtype=jnp.float32)
+    x = jnp.array(self.IS_FINITE_TEST_VALUES, dtype=dtype)
     out = kernel(x)
     expected = lax.is_finite(x)
     self.assertArraysEqual(out, expected)


### PR DESCRIPTION
This PR implements lowering of lax.is_finite() operation in Pallas for Triton backend as a composition of `jnp.logical_and(~jnp.isnan(x), ~jnp.isinf(x))`, which already have a working lowering.

Resolves https://github.com/jax-ml/jax/issues/32551

I've also explored a possibility to express that lowering in terms of `math.is_finite()` MLIR operation by modifying Triton backend compilation passes to lower that operation properly. At least on ROCm (gfx942 specifically) the composition used in the PR produces exactly the same GPU kernel bytecode as a specially modified to support `math.is_finite()` Triton backend would produce for at least for fp32 and bf16 data types (most likely for fp16 also, though not tested), so thanks to a great job done by LLVM, this composition is the simplest and most concise effective solution for lowering `isfinite()`.

I don't have an ability to test lowering on TPU and on CUDA, so I skipped all newly added tests on these platforms and assume respective teams would modify that as needed.