### PR TITLE
Add support for NumPy 2.4 __numpy_dtype__ protocol

### DIFF
--- a/jax/_src/basearray.py
+++ b/jax/_src/basearray.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 import sys
 from typing import Any, Union
+import warnings
 
 from jax._src import literals
 from jax._src.lib import xla_client as xc
@@ -59,6 +60,16 @@ class Array:
 
   __slots__ = ['__weakref__']
   __hash__ = None
+
+  # TODO(jakevdp): set __numpy_dtype__ = None after deprecation period.
+  @property
+  def __numpy_dtype__(self) -> np.dtype:
+    # __numpy_dtype__ protocol added in NumPy v2.4.0.
+    warnings.warn(
+      "Implicit conversion of an array to a dtype is deprecated;"
+      " rather than dtype=arr use dtype=arr.dtype. In the future"
+      " this will result in an error.", DeprecationWarning, stacklevel=2)
+    return self.dtype
 
   @property
   def dtype(self) -> np.dtype:

--- a/jax/_src/basearray.pyi
+++ b/jax/_src/basearray.pyi
@@ -47,6 +47,10 @@ class Array:
   @property
   def dtype(self) -> np.dtype: ...
 
+  # TODO(jakevdp) set to None after deprecation period.
+  @property
+  def __numpy_dtype__(self) -> np.dtype: ...
+
   @property
   def ndim(self) -> int: ...
 

--- a/jax/_src/numpy/scalar_types.py
+++ b/jax/_src/numpy/scalar_types.py
@@ -37,6 +37,11 @@ _PUBLIC_MODULE_NAME = "jax.numpy"
 class _ScalarMeta(type):
   dtype: np.dtype
 
+  @property
+  def __numpy_dtype__(self) -> np.dtype:
+    # __numpy_dtype__ protocol added in NumPy v2.4.0.
+    return self.dtype
+
   def __hash__(self) -> int:
     return hash(self.dtype.type)
 


### PR DESCRIPTION
NumPy v2.4.0 will add the `__numpy_dtype__` protocol for objects which can be implicitly converted to dtypes. This will eventually replace the current mechanism, which uses the `dtype` attribute (see https://github.com/numpy/numpy/pull/30179).

The current PR adds a `__numpy_dtype__` property to JAX scalar types (e.g. `jnp.int32`, `jnp.float32`) as well as JAX arrays.

- For scalar types, `__numpy_dtype__` will eventually be the primary way that these objects are recognized by `np.dtype` as dtype-like objects. No user-visible changes are intended; this will ensure JAX scalar types continue to function as dtype stand-ins in future NumPy versions.
- For arrays, this adds a deprecation warning that will arise starting in NumPy 2.4 when a JAX array is used in place of a dtype within NumPy APIs. After a deprecation period, we can eventually set `__numpy_dtype__ = None` to prevent JAX arrays from being implicitly converted to dtypes.

Note that within JAX APIs, implicit conversion of a JAX array to a dtype is already diallowed; e.g.
```python
>>> import jax.numpy as jnp
>>> x = jnp.arange(4)
>>> y = jnp.arange(10, dtype=x)
ValueError: Passing an array as a dtype argument is no longer supported; instead of dtype=arr use dtype=arr.dtype.
```
In NumPy, this is not yet an error, because the `x.dtype` property means that JAX arrays are silently converted to dtypes:
```python
>>> import numpy as np
>>> np.arange(4, dtype=x)
array([0, 1, 2, 3], dtype=int32)
```
After this change, the above will raise a warning under NumPy v2.4 and newer; eventually we will set `__numpy_dtype__ = None` to make this an error.

#jax-fixit