### PR TITLE
Add CI to run ty on a selection of JAX source files

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -200,6 +200,6 @@ jobs:
         python-version: '3.14'
     - run: |
         pip install uv~=0.9.14
-        uv pip install --system -r build/test-requirements.txt
+        uv pip install --system .
         uv pip install --system --pre ty==0.0.1a29
     - run: uv run ty check jax

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -200,6 +200,7 @@ jobs:
         python-version: '3.14'
     - run: |
         pip install uv~=0.9.14
-        uv pip install --system .
-        uv pip install --system --pre ty==0.0.1a29
+        uv venv
+        uv pip install .
+        uv pip install --pre ty==0.0.1a29
     - run: uv run ty check jax

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -189,3 +189,16 @@ jobs:
         JAX_PLATFORM_NAME: cpu
     - name: Run GPU tests
       run: python -m pytest examples/ffi/tests
+
+  ty_typecheck:
+    name: TypeCheck with ty
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
+    - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
+      with:
+        python-version: '3.14'
+    - run: |
+        pip install uv~=0.5.30
+        uv pip install --system ty
+    - run: uv run ty check .

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -199,6 +199,6 @@ jobs:
       with:
         python-version: '3.14'
     - run: |
-        pip install uv~=0.5.30
-        uv pip install --system ty
-    - run: uv run ty check .
+        pip install uv~=0.9.14
+        uv pip install --pre ty==0.0.1a29
+    - run: uv run ty check jax

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -200,5 +200,6 @@ jobs:
         python-version: '3.14'
     - run: |
         pip install uv~=0.9.14
+        uv pip install --system -r build/test-requirements.txt
         uv pip install --system --pre ty==0.0.1a29
     - run: uv run ty check jax

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -200,5 +200,5 @@ jobs:
         python-version: '3.14'
     - run: |
         pip install uv~=0.9.14
-        uv pip install --pre ty==0.0.1a29
+        uv pip install --system --pre ty==0.0.1a29
     - run: uv run ty check jax

--- a/jax/_src/ad_util.py
+++ b/jax/_src/ad_util.py
@@ -52,7 +52,7 @@ def add_abstract(x, y):
 
 def zeros_like_aval(aval: core.AbstractValue) -> Array:
   if hasattr(aval, 'vspace_zero'):  # TODO(mattjj,dougalm): revise away hasattr
-    return aval.vspace_zero()
+    return aval.vspace_zero()  # ty: ignore[call-non-callable]
   return aval_zeros_likers[type(aval)](aval)
 aval_zeros_likers: dict[type, Callable[[Any], Array]] = {}
 

--- a/jax/_src/basearray.py
+++ b/jax/_src/basearray.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 import sys
-from typing import Any, Union
+from typing import Any, Union, TYPE_CHECKING
 
 from jax._src import literals
 from jax._src.lib import xla_client as xc
@@ -171,8 +171,8 @@ class Array:
     """
     raise NotImplementedError
 
-
-Array = use_cpp_class(xc.Array)(Array)
+if not TYPE_CHECKING:
+  Array = use_cpp_class(xc.Array)(Array)
 Array.__module__ = "jax"
 
 

--- a/jax/_src/blocked_sampler.py
+++ b/jax/_src/blocked_sampler.py
@@ -28,10 +28,10 @@ class SampleFn(Protocol):
     ...
 
 
-def _compute_tile_index(block_index: Sequence[int],
+def _compute_tile_index(block_index: Sequence[ArrayLike],
                         block_size_in_tiles: Shape,
                         total_size_in_tiles: Shape,
-                        tile_index_in_block: Sequence[int]) -> int:
+                        tile_index_in_block: Sequence[int]) -> ArrayLike:
   ndims = len(block_index)
   dim_size = 1
   total_idx = 0

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -22,6 +22,7 @@
 from __future__ import annotations
 
 import abc
+import builtins
 import dataclasses
 import functools
 import types
@@ -86,7 +87,7 @@ class ExtendedDType(StrictABC):
   """Abstract Base Class for extended dtypes"""
   @property
   @abc.abstractmethod
-  def type(self) -> type: ...
+  def type(self) -> builtins.type: ...
 
 
 # fp8 support
@@ -634,7 +635,7 @@ def isdtype(dtype: DTypeLike, kind: str | DTypeLike | tuple[str | DTypeLike, ...
     True or False
   """
   the_dtype = np.dtype(dtype)
-  kind_tuple: tuple[str | DTypeLike, ...] = (
+  kind_tuple: tuple[str | DTypeLike, ...] = (  # ty: ignore[invalid-assignment]
     kind if isinstance(kind, tuple) else (kind,)
   )
   options: set[DType] = set()
@@ -914,7 +915,7 @@ def check_valid_dtype(dtype: DType) -> None:
     raise TypeError(f"Dtype {dtype} is not a valid JAX array "
                     "type. Only arrays of numeric types are supported by JAX.")
 
-def _maybe_canonicalize_explicit_dtype(dtype: DType, fun_name: str) -> DType:
+def _maybe_canonicalize_explicit_dtype(dtype: DType, fun_name: str | None) -> DType:
   "Canonicalizes explicitly requested dtypes, per explicit_x64_dtypes."
   allow = config.explicit_x64_dtypes.value
   if allow == config.ExplicitX64Mode.ALLOW or config.enable_x64.value:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,4 +161,12 @@ max-complexity = 18
 "docs/autodidax.ipynb" = ["F811"]
 
 [tool.ty.src]
-include = ["jax/_src/dtypes.py"]
+include = [
+    "jax/_src/abstract_arrays.py",
+    "jax/_src/ad_util.py",
+    "jax/_src/api_util.py",
+    "jax/_src/basearray.py",
+    "jax/_src/blocked_sampler.py",
+    "jax/_src/buffer_callback.py",
+    "jax/_src/dtypes.py",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,3 +159,6 @@ max-complexity = 18
 "docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb" = ["F811"]
 "docs/jep/9407-type-promotion.ipynb" = ["F811"]
 "docs/autodidax.ipynb" = ["F811"]
+
+[tool.ty.src]
+include = ["jax/_src/dtypes.py"]


### PR DESCRIPTION
A first step toward running `ty` on the full codebase. I selected a few source files on which `ty` reveals just a handful of errors.

#jax-fixit