### PR TITLE
[Pallas] Add missing docstrings and clean up mis-renderings.

### DIFF
--- a/docs/jax.experimental.pallas.mosaic_gpu.rst
+++ b/docs/jax.experimental.pallas.mosaic_gpu.rst
@@ -14,6 +14,7 @@ Classes
    CompilerParams
    MemorySpace
    Layout
+   SemaphoreType
    SwizzleTransform
    TilingTransform
    TransposeTransform

--- a/docs/jax.experimental.pallas.rst
+++ b/docs/jax.experimental.pallas.rst
@@ -47,6 +47,7 @@ Functions
   debug_check
   debug_print
   dot
+  get_global
   loop
   max_contiguous
   multiple_of

--- a/jax/_src/pallas/core.py
+++ b/jax/_src/pallas/core.py
@@ -101,7 +101,7 @@ class semaphore_dtype(dtypes.extended):
   """Common dtype for all kinds of semaphore dtypes.
 
   This is an abstract class that should never be instantiated, but rather
-  exists for the sake of `jnp.issubdtype`.
+  exists for the sake of ``jnp.issubdtype``.
   """
 
 class semaphore(semaphore_dtype):
@@ -355,7 +355,7 @@ class Blocked:
 class BoundedSlice:
   """Allows to specify a bounded slice of a dimension.
 
-  Specifically, the index_map need to return a `pl.Slice/pl.ds` for this
+  Specifically, the index_map need to return a ``pl.Slice/pl.ds`` for this
   dimension. The start and size may be dynamic, as long as the size <=
   block_size.
   """

--- a/jax/_src/pallas/helpers.py
+++ b/jax/_src/pallas/helpers.py
@@ -36,6 +36,19 @@ empty = api.named_call(lax.empty)
 
 @api.named_call
 def empty_like(x: object):
+  """Create an empty PyTree of possibly uninitialized values.
+
+  Args:
+    x: A PyTree with leaves specifying the shape and dtype of
+      the uninitialized object.
+
+  Returns:
+    A PyTree with the same structure as ``x``, but with uninitialized
+    values.
+
+  See Also:
+    :func:`jax.lax.empty`
+  """
   return tree_util.tree_map(lambda leaf: empty(leaf.shape, leaf.dtype), x)
 
 

--- a/jax/_src/pallas/mosaic/error_handling.py
+++ b/jax/_src/pallas/mosaic/error_handling.py
@@ -36,7 +36,7 @@ FRAME_PATTERN = re.compile(
     r'( to (?P<endlineno>[0-9]+)?:(?P<endcolno>[0-9]+))?\)'
 )
 MLIR_ERR_PREFIX = (
-    'Pallas encountered an internal verification error.'
+    'Pallas encountered an internal verification error. '
     'Please file a bug at https://github.com/jax-ml/jax/issues. '
     'Error details: '
 )

--- a/jax/_src/pallas/mosaic/primitives.py
+++ b/jax/_src/pallas/mosaic/primitives.py
@@ -749,7 +749,16 @@ def _get_ref_and_transforms(ref):
 
 
 def make_async_copy(src_ref, dst_ref, sem) -> AsyncCopyDescriptor:
-  """Issues a DMA copying from src_ref to dst_ref."""
+  """Creates a description of an asynchronous copy operation.
+
+  Args:
+    src_ref: The source Reference.
+    dst_ref: The destination Reference.
+    sem: The semaphore used to track completion of the copy.
+
+  Returns:
+    An AsyncCopyDescriptor.
+  """
   src_ref, src_transforms = _get_ref_and_transforms(src_ref)
   dst_ref, dst_transforms = _get_ref_and_transforms(dst_ref)
   sem, sem_transforms = _get_ref_and_transforms(sem)
@@ -835,6 +844,7 @@ def async_remote_copy(
     device_id,
     device_id_type: primitives.DeviceIdType = primitives.DeviceIdType.MESH,
 ) -> AsyncCopyDescriptor:
+  """Issues a remote DMA copying from src_ref to dst_ref."""
   copy_descriptor = make_async_remote_copy(src_ref, dst_ref, send_sem, recv_sem,
                                            device_id, device_id_type)
   copy_descriptor.start()
@@ -1029,7 +1039,7 @@ def with_memory_space_constraint(
 ) -> jax.Array:
   """Constrains the memory space of an array.
 
-  This primitive does not change the value of `x`, but it constrains the
+  This primitive does not change the value of ``x``, but it constrains the
   memory space where it should be allocated. This is useful to force
   Pallas to allocate an array in a specific memory space.
 
@@ -1042,7 +1052,7 @@ def with_memory_space_constraint(
     memory_space: The memory space to constrain to.
 
   Returns:
-    The array `x` with the memory space constraint.
+    The array ``x`` with the memory space constraint.
   """
   if memory_space in {tpu_core.MemorySpace.ANY, pl_core.MemorySpace.ANY}:
     return x

--- a/jax/_src/pallas/mosaic/random.py
+++ b/jax/_src/pallas/mosaic/random.py
@@ -171,13 +171,13 @@ def sample_block(sampler_fn: SampleFnType,
                  **kwargs) -> jax.Array:
   """Samples a block of random values with invariance guarantees.
 
-  `sample_block` allows the sampling of identical blocks of random values
+  ``sample_block`` allows the sampling of identical blocks of random values
   across kernels with different block shapes and iteration orders. Each call
   to `sample_block` returns a `block_size`-shaped array of random samples
   corresponding to the `block_index`.
 
-  `tile_size` should be chosen such that it is a divisor to all block sizes
-  one needs to be invariant to. The larger the `tile_size`, the more
+  ``tile_size`` should be chosen such that it is a divisor to all block sizes
+  one needs to be invariant to. The larger the ``tile_size``, the more
   efficient the sampling process will be and therefore the best choice is
   typically the greatest common divisor between all possible block sizes.
 
@@ -186,7 +186,7 @@ def sample_block(sampler_fn: SampleFnType,
       random samples.
     global_key: The global key to use for sampling.
     block_size: The shape of an individual block.
-    tile_size: The shape of a `tile`, which is the smallest unit at
+    tile_size: The shape of a ``tile``, which is the smallest unit at
       which samples are generated. This should be selected to be a divisor
       of all block sizes one needs to be invariant to.
     total_size: The total size of the array to sample.
@@ -195,8 +195,8 @@ def sample_block(sampler_fn: SampleFnType,
     **kwargs: Additional arguments to pass to the sampler_fn.
 
   Returns:
-    A `block_size` shaped array of samples for the current block corresponding
-    to `block_index`.
+    A ``block_size`` shaped array of samples for the current block corresponding
+    to ``block_index``.
   """
   if len(block_size) != len(tile_size):
     raise ValueError(f"block_size ({len(block_size)}) and tile_size "

--- a/jax/_src/pallas/mosaic/tpu_info.py
+++ b/jax/_src/pallas/mosaic/tpu_info.py
@@ -154,6 +154,7 @@ class TpuInfo:
 
 
 def is_tpu_device() -> bool:
+  """Returns whether the current device is a TPU."""
   return core.get_device_kind() in {
       "TPU v2",
       "TPU v3",

--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -1668,7 +1668,10 @@ def pallas_call(
     backend: Backend | None = None,
     metadata: dict[str, str] | None = None,
 ) -> Callable[..., Any]:
-  """Invokes a Pallas kernel on some inputs.
+  """Entry point for creating a Pallas kernel.
+
+  In contrast to :func:`jax.experimental.pallas.kernel`, this entry point
+  assumes that the kernel will be executed over a ``grid``.
 
   See `Pallas Quickstart <https://docs.jax.dev/en/latest/pallas/quickstart.html>`_.
 

--- a/jax/_src/pallas/utils.py
+++ b/jax/_src/pallas/utils.py
@@ -45,6 +45,14 @@ def cdiv(a: jax_typing.Array, b: jax_typing.Array) -> jax_typing.Array:
   ...
 
 def cdiv(a: int | jax_typing.Array, b: int | jax_typing.Array) -> int | jax_typing.Array:
+  """Computes the ceiling division of a divided by b.
+
+  Examples:
+    >>> cdiv(8, 2)
+    4
+    >>> cdiv(9, 2)  # 9 / 2 = 4.5, which rounds up to 5
+    5
+  """
   if isinstance(a, int) and isinstance(b, int):
     return (a + b - 1) // b
   return lax.div(a + (b - 1), b)

--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -1079,6 +1079,18 @@ batching.fancy_primitive_batchers[addupdate_p] = _addupdate_vmap
 broadcast_to_p = core.Primitive('broadcast_to')
 
 def broadcast_to(a: Array, shape: tuple[int, ...]) -> Array:
+  """Broadcasts an array to a new shape.
+
+  Args:
+    a: The array to broadcast.
+    shape: The desired shape to broadcast to.
+
+  Returns:
+    An array of shape ``shape``.
+
+  See Also:
+    :func:`jax.numpy.broadcast_to`
+  """
   import jax.numpy as jnp  # pytype: disable=import-error
   a = jnp.asarray(a)
   if a.shape == shape:


### PR DESCRIPTION
- Adds docstrings for functions that didn't have them.
- Clean up the rendering (many docstrings using single backticks instead of double-backticks)

#jax-fixit