### PR TITLE
[no-thunks] Reduce stack frames when tracing initial-style primitives.

### DIFF
--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -2394,6 +2394,7 @@ def _jvp_jaxpr_zeros(f, store, in_zeros, zero_avals, *primal_tangent_avals):
   store.store(out_zeros)
   return [*out_primals, *out_nz_tangents]
 
+@weakref_lru_cache
 def trace_to_jaxpr(
     fun: Callable,
     in_tree: PyTreeDef,

--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -43,6 +43,7 @@ def _typecheck_param(prim, param, name, msg_required, pred):
     msg = sep.join([msg, param_str])
     raise core.JaxprTypeError(msg)
 
+# TODO(dougalm): this is a silly wrapper now. Delete it.
 @weakref_lru_cache
 def _initial_style_open_jaxpr(fun: Callable,
                               in_tree: PyTreeDef,
@@ -51,6 +52,7 @@ def _initial_style_open_jaxpr(fun: Callable,
   jaxpr, out_tree, consts = pe.trace_to_jaxpr(fun, in_tree, in_avals, debug_info)
   return jaxpr, consts, out_tree
 
+# TODO(dougalm): Delete. Make `trace_to_jaxpr` do the jaxpr-closing thing instead.
 @weakref_lru_cache
 def _initial_style_jaxpr(fun: Callable,
                          in_tree: PyTreeDef,


### PR DESCRIPTION
Along with https://github.com/jax-ml/jax/commit/10a153e6ce3714a84e463efb0f4af84b4626951c, this reduces the stack depth due to `scan` from 11 frames to 5.

Also adds a regression test for traceback depths.