### PR TITLE
jax.checkpoint: deprecate the concrete argument

### DIFF
--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -437,6 +437,7 @@ py_library_providing_imports_info(
         ":core",
         ":custom_derivatives",
         ":custom_partitioning_sharding_rule",
+        ":deprecations",
         ":dtypes",
         ":effects",
         ":ffi",

--- a/jax/_src/deprecations.py
+++ b/jax/_src/deprecations.py
@@ -124,6 +124,7 @@ def warn(deprecation_id: str, message: str, stacklevel: int) -> None:
 # Register a number of deprecations: we do this here to ensure they're
 # always registered by the time `accelerate` and `is_acelerated` are called.
 register('default-dtype-bits-config')
+register('jax-checkpoint-concrete')
 register('jax-lax-dot-positional-args')
 register('jax-lib-module')
 register('jax-nn-one-hot-float-input')


### PR DESCRIPTION
Followup to #33660

#jax-fixit