### PR TITLE
[export] Fix forward compatibility for exporting nr_devices

### DIFF
--- a/jax/_src/export/serialization.py
+++ b/jax/_src/export/serialization.py
@@ -132,6 +132,7 @@ def _serialize_exported(
   ser_flatbuf.ExportedAddOutTree(builder, out_tree)
   ser_flatbuf.ExportedAddOutAvals(builder, out_avals)
   ser_flatbuf.ExportedAddNrDevices(builder, exp.nr_devices)
+  ser_flatbuf.ExportedAddNrDevicesShort(builder, exp.nr_devices)  # For forward compatibility, can remove after January 2026
   ser_flatbuf.ExportedAddInShardings(builder, in_shardings)
   ser_flatbuf.ExportedAddOutShardings(builder, out_shardings)
   ser_flatbuf.ExportedAddPlatforms(builder, platforms)


### PR DESCRIPTION
In #33492 I have added a new 32-bit field to store the nr_devices, and renamed the old 16-bit field to nr_devices_short. However, that change mistakenly stops populating the 16-bit field, which means that when the export is read by old code, it will have a nr_devices == 0.
