### PR TITLE
Add jax_check_static_indices configuration

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1157,6 +1157,15 @@ check_tracer_leaks = bool_state(
           'to disable any debuggers while leak checking is enabled.'))
 checking_leaks = functools.partial(check_tracer_leaks, True)
 
+check_static_indices = bool_state(
+    name='jax_check_static_indices',
+    default=False,
+    help=('Turn on bounds checks for static indices during array indexing operations.'
+          ' These will only be checked when indexing mode is PROMISE_IN_BOUNDS, which'
+          ' is the default for gather-type operations.'),
+    include_in_jit_key=True,
+    include_in_trace_context=True,
+)
 
 captured_constants_warn_bytes = int_state(
     name='jax_captured_constants_warn_bytes',


### PR DESCRIPTION
This adds an experimental `jax_check_static_indices` configuration, which enables bound checks for *static* indices. For example:
```python
In [1]: import jax

In [2]: import jax.numpy as jnp

In [3]: jax.config.update('jax_check_static_indices', True)

In [4]: x = jnp.arange(5)

In [5]: x[6]
IndexError: index 6 out of bounds for axis 0 with size 5 (normalize_indices=True)

In [6]: @jax.jit
    ...: def f(x):
    ...:   return x[6]
    ...: f(x)
IndexError: index 6 out of bounds for axis 0 with size 5 (normalize_indices=True)
```
Note that for non-static (i.e. traced) indices, this does not raise, because the index value is not known at trace-time (as detailed in [JAX Sharp Bits: out-of-bound indexing](https://docs.jax.dev/en/latest/notebooks/Common_Gotchas_in_JAX.html#out-of-bounds-indexing)):
```python
In [7]: @jax.jit
    ...: def f(x, i):
    ...:   return x[i]
    ...: f(x, 6)
Out[7]: Array(4, dtype=int32)
```