### PR TITLE
Fix deprecated use of arrays in place of dtypes

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -995,7 +995,11 @@ def dtype(x: Any) -> DType:
     dt = x.dtype
   else:
     try:
-      dt = np.result_type(x)
+      with warnings.catch_warnings():
+        # Ignore warning associated with __numpy_dtype__ change in NumPy 2.4.
+        # TODO(jakevdp): remove this warning context after change is finalized.
+        warnings.simplefilter("ignore", DeprecationWarning)
+        dt = np.result_type(x)
     except TypeError as err:
       raise TypeError(f"Cannot determine dtype of {x}") from err
   if dt not in _jax_dtype_set and not issubdtype(dt, extended):

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -856,7 +856,7 @@ class NNInitializersTest(jtu.JaxTestCase):
     val = initializer(rng, shape, dtype)
 
     self.assertEqual(shape, jnp.shape(val))
-    self.assertEqual(jax.dtypes.canonicalize_dtype(dtype), jnp.dtype(val))
+    self.assertEqual(jax.dtypes.canonicalize_dtype(dtype), val.dtype)
 
   @parameterized.parameters(itertools.chain.from_iterable(
     jtu.sample_product_testcases(
@@ -872,7 +872,7 @@ class NNInitializersTest(jtu.JaxTestCase):
     val = initializer(rng, shape)
 
     self.assertEqual(shape, jnp.shape(val))
-    self.assertEqual(jax.dtypes.canonicalize_dtype(dtype), jnp.dtype(val))
+    self.assertEqual(jax.dtypes.canonicalize_dtype(dtype), val.dtype)
 
   def testVarianceScalingMultiAxis(self):
     rng = random.PRNGKey(0)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -654,8 +654,14 @@ class KeyArrayTest(jtu.JaxTestCase):
 
     self.assertFalse(jnp.issubdtype(key.dtype, np.integer))
     self.assertFalse(jnp.issubdtype(key.dtype, np.number))
-    with self.assertRaisesRegex(TypeError, "Cannot interpret"):
-      jnp.issubdtype(key, dtypes.prng_key)
+    if jtu.numpy_version() < (2, 4, 0):
+      with self.assertRaisesRegex(TypeError, "Cannot interpret"):
+        jnp.issubdtype(key, dtypes.prng_key)
+    else:
+      with jtu.ignore_warning(category=DeprecationWarning,
+                              message="Implicit conversion of an array to a dtype"):
+        with self.assertRaisesRegex(ValueError, "Could not convert Array"):
+          jnp.issubdtype(key, dtypes.prng_key)
 
   @skipIf(not config.enable_custom_prng.value, 'relies on typed key upgrade flag')
   def test_construction_upgrade_flag(self):

--- a/tests/stax_test.py
+++ b/tests/stax_test.py
@@ -40,7 +40,7 @@ def _CheckShapeAgreement(test_case, init_fun, apply_fun, input_shape):
   result_shape, params = init_fun(init_key, input_shape)
   inputs = random_inputs(test_case.rng(), input_shape)
   if params:
-    inputs = inputs.astype(np.dtype(params[0]))
+    inputs = inputs.astype(dtypes.dtype(params[0]))
   result = apply_fun(params, inputs, rng=rng_key)
   test_case.assertEqual(result.shape, result_shape)
 


### PR DESCRIPTION
A few additional cases that I missed in #33688.