### PR TITLE
always apply stop_gradient_p, even to exact dtypes

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3546,17 +3546,12 @@ def stop_gradient(x: T) -> T:
     the applicability of ``stop_gradient``.
   """
   def stop(x):
-    # only bind primitive on inexact dtypes, to avoid some staging
     if dtypes.issubdtype(core.get_aval(x).dtype, dtypes.extended):
       return x
-    elif (dtypes.issubdtype(_dtype(x), np.floating) or
-        dtypes.issubdtype(_dtype(x), np.complexfloating)):
-      # break abstractions to support legacy leaked tracer use cases
-      if isinstance(x, ad.JVPTracer):
-        return stop(x.primal)
-      return ad_util.stop_gradient_p.bind(x)
+    elif isinstance(x, ad.JVPTracer):
+      return stop(x.primal)
     else:
-      return x
+      return ad_util.stop_gradient_p.bind(x)
   return tree_util.tree_map(stop, x)
 
 def reduce_precision(operand: float | ArrayLike,

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -3766,6 +3766,22 @@ class LaxTest(jtu.JaxTestCase):
     cts = vjp_fn(jnp.ones((8,), dtype=jnp.float8_e4m3fn))  # Don't crash
     self.assertEqual(cts[0].dtype, jnp.bfloat16)
 
+  def stop_gradient_on_ints(self):
+    # https://github.com/jax-ml/jax/issues/33689
+    @jax.custom_gradient
+    def f(x):
+        def fbwd(g):
+            return jnp.ones_like(x)
+        return (x, jnp.round(x).astype(jnp.int32)), fbwd
+
+    def loss(x):
+        y, i = f(x)
+        y_nograd, i_nograd = jax.lax.stop_gradient((y, i))
+        self.assertEqual(type(y_nograd), type(i_nograd))
+        return jnp.sum(f(y)[0])
+
+    jax.grad(loss)(jnp.ones((3,)));
+
 
 class LazyConstantTest(jtu.JaxTestCase):
   def _Check(self, make_const, expected):


### PR DESCRIPTION
fixes #33689