### PR TITLE
improve tracer reprs to show a lil concrete info

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -393,7 +393,7 @@ def disable_jit(disable: bool = True):
   ...   return y + 3
   ...
   >>> print(f(jax.numpy.array([1, 2, 3])))
-  Value of y is JitTracer<int32[3]>
+  Value of y is JitTracer(int32[3])
   [5 7 9]
 
   Here ``y`` has been abstracted by :py:func:`jit` to a :py:class:`ShapedArray`,

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -828,7 +828,9 @@ class JVPTracer(Tracer):
     self.tangent = tangent
 
   def _short_repr(self):
-    return f"GradTracer<{self.aval}>"
+    pp = lambda x: x._short_repr() if isinstance(x, Tracer) else str(x)
+    primal, tangent = pp(self.primal), pp(self.tangent)
+    return f'JVPTracer({primal=!s}, {tangent=!s})'
 
   @property
   def aval(self):
@@ -1172,6 +1174,11 @@ class LinearizeTracer(Tracer):
     self._trace = trace
     self.primal = primal
     self.tangent = tangent
+
+  def _short_repr(self):
+    pp = lambda x: x._short_repr() if isinstance(x, Tracer) else str(x)
+    primal, tangent = pp(self.primal), typeof(self.tangent).str_short(True)
+    return f"GradTracer({primal=!s}, typeof(tangent)={tangent!s})"
 
   @property
   def aval(self):

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from jax._src import config
 from jax._src import core
+from jax._src.core import typeof
 from jax._src import source_info_util
 from jax._src import linear_util as lu
 from jax._src.partition_spec import PartitionSpec as P
@@ -406,7 +407,7 @@ class BatchTracer(Tracer):
     self.source_info = source_info
 
   def _short_repr(self):
-    return f"VmapTracer<{self.aval}>"
+    return f"VmapTracer(aval={self.aval}, batched={typeof(self.val)})"
 
   @property
   def aval(self):

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1687,7 +1687,7 @@ class DynamicJaxprTracer(core.Tracer):
     self.parent = parent
 
   def _short_repr(self):
-    return f"JitTracer<{self.aval}>"
+    return f"JitTracer({self.aval})"
 
   def cur_qdd(self):
     return self.mutable_qdd.cur_val

--- a/jax/_src/literals.py
+++ b/jax/_src/literals.py
@@ -51,6 +51,9 @@ class TypedFloat(float):
   def __repr__(self):
     return f'TypedFloat({float(self)}, dtype={self.dtype.name})'
 
+  def __str__(self):
+    return str(float(self))
+
   def __getnewargs__(self):
     return (float(self), self.dtype)
 

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -543,7 +543,7 @@ class Partial(functools.partial):
   >>> print_zero()
   0
   >>> call_func(print_zero)  # doctest:+ELLIPSIS
-  JitTracer<~int32[]>
+  JitTracer(~int32[])
   """
 
   def __new__(klass, func, *args, **kw):

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -411,19 +411,19 @@ class CoreTest(jtu.JaxTestCase):
     x_repr = ""
 
     jax.jit(f)(jnp.arange(10.0, dtype='float32'))
-    self.assertEqual(x_repr, "JitTracer<float32[10]>")
+    self.assertEqual(x_repr, "JitTracer(float32[10])")
 
     jax.vmap(f)(jnp.arange(20, dtype='int32'))
-    self.assertEqual(x_repr, "VmapTracer<int32[]>")
+    self.assertEqual(x_repr, "VmapTracer(aval=int32[], batched=int32[20])")
 
     jax.grad(f)(jnp.float16(1.0))
-    self.assertRegex(x_repr, r"(Grad)|(Linearize)Tracer<float16\[\]>")
+    self.assertEqual(x_repr, "GradTracer(primal=1.0, typeof(tangent)=f16[])")
 
-    jax.jacrev(f)(jnp.arange(12, dtype='float32'))
-    self.assertRegex(x_repr, r"(Grad)|(Linearize)Tracer<float32\[12\]>")
+    jax.jacrev(f)(jnp.arange(4, dtype='float32'))
+    self.assertEqual(x_repr, "GradTracer(primal=[0. 1. 2. 3.], typeof(tangent)=f32[4])")
 
-    jax.jacfwd(f)(jnp.arange(14, dtype='float32'))
-    self.assertRegex(x_repr, r"(Grad)|(Linearize)Tracer<float32\[14\]>")
+    jax.jacfwd(f)(jnp.arange(3, dtype='float32'))
+    self.assertEqual(x_repr, "JVPTracer(primal=[0. 1. 2.], tangent=VmapTracer(aval=float32[3], batched=float32[3,3]))")
 
   def test_verbose_tracer_reprs(self):
     # Verbose reprs, avaiable via tracer._pretty_print()


### PR DESCRIPTION
The idea here is that [#29507](https://github.com/jax-ml/jax/pull/29507), in its noble attempt at concision, may have hidden a bit too much info, especially related to eager autodiff. For example:

```python
import jax
jax.grad(lambda x: print(x) or x)(1.5)  # LinearizeTracer<~float32[]>
```

It's not clear from the printed result that the primal value is available at trace time (for control flow, debugging, etc). A user mentioned that they didn't know eager values were available with autodiff.

In this PR we tweaked the reprs:

```python
import jax
jax.grad(lambda x: print(x) or x)(1.5)  # GradTracer(primal=1.5)
```

The main diff is that we print the primal value, in a way that is suggestive of the `primal` attribute being available. We also say "GradTracer" instead of "LinearizeTracer" since it's more familiar to 98.4% of users. If the tangent type differs from the primal type, we print that too.

Higher-order AD looks like this:

```python
import jax
jax.grad(jax.grad(lambda x: print(x) or x))(1.5)  # GradTracer(primal=GradTracer(primal=1.5))
```

Still pretty short, and still shows the concrete value.

Not directly related to the goal of printing more concrete info, we also tweaked batch vmap tracing to show both the batched and unbatched avals:

```python
import jax
jax.vmap(lambda x: print(x) or x)(jax.numpy.arange(5))  # VmapTracer(aval=int32[], batched=int32[5])
```

This is probably not the last word on improving tracer printing...