### PR TITLE
Load nvjitlink library version 12

### DIFF
--- a/jax_plugins/cuda/__init__.py
+++ b/jax_plugins/cuda/__init__.py
@@ -135,6 +135,8 @@ def _load_nvidia_libraries():
   _load("nccl", ["libnccl.so.2"])
   _load("cuda_cupti", ["libcupti.so.12"])
   _load("cu13", ["libcupti.so.13"])
+  _load("nvjitlink", ["libnvJitLink.so.12"])
+  _load("cu13", ["libnvJitLink.so.13"])
   _load("cusparse", ["libcusparse.so.12"])
   _load("cu13", ["libcusparse.so.12"])
   _load("cusolver", ["libcusolver.so.11"])


### PR DESCRIPTION
Added loading for nvjitlink library version 12.

On GB200, if we don't do this, sometimes we will get,

```
Traceback (most recent call last):
RuntimeError: jaxlib/cuda/versions_helpers.cc:81: operation cusparseGetProperty(MAJOR_VERSION, &major) failed: The cuSPARSE library was not found.
```

The reason is that `cuSPARSE` depends on some symbols in `nvjitlink` and so the nvjitlink should be loaded before cuSPARSE.