### PR TITLE
[hijax] handle symbolic zeros generically in hijax lin rule

### DIFF
--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -598,11 +598,10 @@ class ValAccum(GradAccum):
   def freeze(self):
     return self.val
 
-# class NullAccum(GradAccum):
-#   aval: core.AbstractValue
-#   def __init__(self, aval): self.aval = aval
-#   def accum(self, x): return
-#   def freeze(self): assert False
+class NullAccum(GradAccum):
+  def __init__(self): pass
+  def accum(self, x): return
+  def freeze(self): assert False
 
 fancy_transposes: dict[core.Primitive, Callable] = {}
 


### PR DESCRIPTION
Soon we'll upgrade the user-facing rule api to support symbolic zeros. That's in the custom-vjp3 branch.

But to unblock things now, and as a convenience wrapper later, we can support not differentiating with respect to some inputs without the user rule being aware: we just use the black-hole /dev/null NullAccum in the right places, where the right places are indicated by the in_nz on the linearize pass. This is less good than telling the user rule about in_nz because it doesn't let the user rule save any work or memory.

(At first we tried just instantiating zeros, but that was worse because we lose information as to whether those zeros are linear or nonlinear, complicating things downstream.)