### PR TITLE
[export] Fix export back compat serialization test.

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1554,7 +1554,7 @@ def with_explicit_mesh(sizes, names, axis_types=None, iota_order=False):
 def create_mesh(mesh_shape, axis_names, iota_order=False, axis_types=None):
   size = math.prod(mesh_shape)
   if len(xla_bridge.devices()) < size:
-    raise unittest.SkipTest(f"Test requires {size} global devices.")
+    raise unittest.SkipTest(f"Test requires {size} global devices and found {len(xla_bridge.devices())}.")
   if iota_order:
     devices = sorted(xla_bridge.devices(), key=lambda d: d.id)
     mesh_devices = np.array(devices[:size]).reshape(mesh_shape)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -2071,6 +2071,11 @@ jax_multiplatform_test(
 jax_multiplatform_test(
     name = "export_serialization_back_compat_test",
     srcs = ["export_serialization_back_compat_test.py"],
+    enable_backends = ["cpu", "gpu", "tpu"],
+    enable_configs = [
+        "tpu_v3_x4",
+        "gpu_h100x2",
+    ],
     tags = [],
     deps = [
         "//jax/_src:internal_export_back_compat_test_data",

--- a/tests/export_serialization_back_compat_test.py
+++ b/tests/export_serialization_back_compat_test.py
@@ -117,6 +117,8 @@ class CompatTest(jtu.JaxTestCase):
     ]
   )
   def test_with_specified_sharding(self, testdata: dict[str, Any] | None):
+    if jtu.device_under_test() != "cpu":
+      self.skipTest("Testing only the CPU serialization")
     a = np.arange(16 * 4, dtype=np.float32).reshape((16, 4))
     mesh = jtu.create_mesh((2,), "x")
     with jax.set_mesh(mesh):
@@ -146,6 +148,8 @@ class CompatTest(jtu.JaxTestCase):
     ]
   )
   def test_with_unspecified_sharding(self, testdata: dict[str, Any] | None):
+    if jtu.device_under_test() != "cpu":
+      self.skipTest("Testing only the CPU serialization")
     a = np.arange(16 * 4, dtype=np.float32).reshape((16, 4))
 
     # Output sharding is not specified
@@ -197,7 +201,7 @@ class CompatTest(jtu.JaxTestCase):
     if jtu.device_under_test() in ("tpu", "gpu"):
       b = exported.call(a)
       self.assertEqual(b.aval.memory_space, core.MemorySpace.Host)
-      self.assertEqual(b.sharding, a.sharding)
+      self.assertEqual(b.sharding.memory_kind, a.sharding.memory_kind)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Make sure that the tests run only on the platform for which they were serialized.

