### PR TITLE
Enable async oneDNN build by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -155,6 +155,8 @@ common:avx_linux --host_copt=-mavx
 common:avx_windows --copt=/arch:AVX
 
 common:mkl_open_source_only --define=tensorflow_mkldnn_contraction_kernel=1
+# For XLA's thunk runtime we need to use async version of oneDNN
+common:mkl_open_source_only --define=build_with_onednn_async=true
 
 # Config setting to build oneDNN with Compute Library for the Arm Architecture (ACL).
 common:mkl_aarch64_threadpool --define=build_with_mkl_aarch64=true


### PR DESCRIPTION
Since XLA's thunk runtime is only compatible with async version of oneDNN, the changes in this PR modify the build pipeline to always build async version whenever oneDNN is compiled.

Note: This only affects the oneDNN build, users still need to switch on the appropriate XLA flags to dispatch to oneDNN kernels:

1. `--xla_cpu_experimental_onednn_custom_call` : For oneDNN primitive custom calls
2. `--xla_cpu_use_onednn` : For oneDNN graph (experimental) calls