### PR TITLE
[test] add test of advanced indexing with empty lists

### DIFF
--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -237,6 +237,11 @@ ADVANCED_INDEXING_TESTS = [
     IndexSpec(shape=(3,), indexer=np.array([0, 1, 0]), out_shape=(3,)),
     IndexSpec(shape=(3, 4, 5), indexer=np.array([ 0, -1]), out_shape=(2, 4, 5)),
   ]),
+  ("TupleOfEmptyList", [
+    IndexSpec(shape=(3, 4), indexer=([],), out_shape=(0, 4)),
+    IndexSpec(shape=(3, 4), indexer=([], 0), out_shape=(0,)),
+    IndexSpec(shape=(3, 4), indexer=([], []), out_shape=(0,)),
+  ]),
   ("TupleOfListsOfPythonInts", [
     IndexSpec(shape=(3, 4, 5), indexer=([0, 1],), out_shape=(2, 4, 5)),
     IndexSpec(shape=(3, 4, 5), indexer=([[0], [-1]], [[2, 3, 0, 3]]),


### PR DESCRIPTION
I discovered this lack of test coverage in the process of creating #33752. Empty lists when converted to array are assumed to be floating point type, so indexing implementations may lead to invalid index arrays if they don't account for this case. Our only tests of this currently are indirect, within `tests/sparse_bcoo_bcsr_test.py`, but it would be better to test this corner case directly.