### PR TITLE
Add name field to K8sCluster

### DIFF
--- a/jax/_src/clusters/k8s_cluster.py
+++ b/jax/_src/clusters/k8s_cluster.py
@@ -63,6 +63,8 @@ def retry(
 
 class K8sCluster(clusters.ClusterEnv):
 
+  name: str = 'k8s'
+  
   # Use an arbitrarily chosen port for the coordinator since we cannot
   # rely on communication to choose one in real time.
   _coordinator_port = '55527'


### PR DESCRIPTION
name field was absent which causes a crash in this line: https://github.com/jax-ml/jax/blob/8572231e45768c6b5e19f2afa28a6aa0f6f52de3/jax/_src/clusters/cluster.py#L56

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->