### PR TITLE
Add batch_size=0 support to jax.lax.map.

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -2708,7 +2708,10 @@ def _batch_and_remainder(x, batch_size: int):
   leaves, treedef = tree_flatten(x)
   if not leaves:
     return x, None
-  num_batches, remainder = divmod(leaves[0].shape[0], batch_size)
+  if batch_size == 0:
+    num_batches, remainder = 0, leaves[0].shape[0]
+  else:
+    num_batches, remainder = divmod(leaves[0].shape[0], batch_size)
   batch_elems = num_batches * batch_size
   if num_batches == 0:
     remainder_leaves = [_remainder_leaf(leaf, batch_elems) for leaf in leaves]
@@ -2748,6 +2751,8 @@ def map(f, xs, *, batch_size: int | None = None):
   version of ``map`` or as a memory-efficient version of ``vmap``. If the axis is not
   divisible by the batch size, the remainder is processed in a separate ``vmap`` and
   concatenated to the result.
+
+  ``batch_size=0`` is equivalent to applying a ``vmap``. That is, it uses a full batch.
 
     >>> x = jnp.ones((10, 3, 4))
     >>> def f(x):

--- a/tests/custom_api_test.py
+++ b/tests/custom_api_test.py
@@ -4591,6 +4591,7 @@ class CustomVmapTest(jtu.JaxTestCase):
     self.assertEqual(str(jaxpr), str(jaxpr_ref))
 
   @parameterized.named_parameters(
+    ("0", 0),
     ("1", 1),
     ("8", 4),
     ("12", 8),
@@ -4607,6 +4608,7 @@ class CustomVmapTest(jtu.JaxTestCase):
     np.testing.assert_array_equal(y, x**2)
 
   @parameterized.named_parameters(
+    ("0", 0),
     ("1", 1),
     ("8", 4),
     ("12", 8),


### PR DESCRIPTION
Add `batch_size=0` (full batch) support to [`jax.lax.map`](https://docs.jax.dev/en/latest/_autosummary/jax.lax.map.html).

Same reasoning as https://github.com/jax-ml/jax/issues/29588.

Example:
```
$ py -c "import jax; print(jax.lax.map(lambda x: x, jax.numpy.arange(10), batch_size=0))"
```

Current behavior:
```
ZeroDivisionError: integer division or modulo by zero
```

New behavior:
```
[0 1 2 3 4 5 6 7 8 9]
```