### PR TITLE
Implement higher order interpolations in jax.scipy.ndimage

### DIFF
--- a/jax/_src/scipy/ndimage.py
+++ b/jax/_src/scipy/ndimage.py
@@ -417,4 +417,6 @@ def spline_filter1d(
                      "and use mode 'mirror'".format(mode))
   input = jnp.asarray(input)
   axis = util.canonicalize_axis(axis, input.ndim)
+  if input.shape[axis] < 2:
+    return input
   return _spline_filter1d(input, order, axis, mode)

--- a/jax/_src/scipy/ndimage.py
+++ b/jax/_src/scipy/ndimage.py
@@ -253,30 +253,30 @@ def map_coordinates(
 
 
 def _init_mirror_causal(arr: Array, z: float) -> Array:
-  idx = jnp.arange(0, arr.size - 1)
-  z_n = z**(arr.size - 1)
+  idx = jnp.arange(0, arr.size - 1, dtype=arr.dtype)
+  z_n = z**(arr.dtype.type(arr.size) - 1)
   return (
-    jnp.sum(z**idx * (arr[:-1] + z_n * arr[-2::-1]))
+    jnp.sum(z**idx * (arr[:-1] + z_n * arr[:0:-1]))
   ) / (1 - z_n**2)
 
 def _init_mirror_anticausal(arr: Array, z: float) -> Array:
   return z / (z**2 - 1) * (z * arr[-2] + arr[-1])
 
 def _init_wrap_causal(arr: Array, z: float) -> Array:
-  idx = jnp.arange(1, arr.size)
+  idx = jnp.arange(1, arr.size, dtype=arr.dtype)
   return (
     arr[0] + jnp.sum(z**idx * arr[:0:-1])
   ) / (1 - z**arr.size)
 
 def _init_wrap_anticausal(arr: Array, z: float) -> Array:
-  idx = jnp.arange(1, arr.size)
+  idx = jnp.arange(1, arr.size, dtype=arr.dtype)
   return (
     arr[-1] + jnp.sum(z**idx * arr[:-1])
   ) * z / (z**arr.size - 1)
 
 def _init_reflect_causal(arr: Array, z: float) -> Array:
-  idx = jnp.arange(arr.size)
-  z_n = z**arr.size
+  idx = jnp.arange(arr.size, dtype=arr.dtype)
+  z_n = z**arr.dtype.type(arr.size)
   return arr[0] + z / (1 - z_n**2) * jnp.sum(z**idx * (arr + z_n * arr[::-1]))
 
 def _init_reflect_anticausal(arr: Array, z: float) -> Array:
@@ -317,7 +317,7 @@ def _spline_filter1d(
   gain = functools.reduce(operator.mul, (
     (1.0 - z) * (1.0 - 1.0 / z) for z in poles
   ))
-  arr = input * gain
+  arr = input.astype(float) * gain
 
   # compose an affine transform (y = k*x + b)
   # t1 @ t0 => y = (k0*k1)*x + (b0 + k0*b1)
@@ -333,7 +333,7 @@ def _spline_filter1d(
     #jax.debug.print("causal init: {}", init)
     arr_rest = lax.slicing.slice_in_dim(arr, 1, None, axis=axis)
     K, B = associative_scan(compose_affine, (jnp.full_like(arr_rest, z), arr_rest), axis=axis)
-    arr = lax.concatenate([init, K * jnp.squeeze(init, axis) + B], axis)
+    arr = lax.concatenate([init, K * init + B], axis)
     #jax.debug.print("after causal: {}", arr)
 
     # anticausal
@@ -341,7 +341,7 @@ def _spline_filter1d(
     #jax.debug.print("anticausal init: {}", init)
     arr_rest = lax.slicing.slice_in_dim(arr, None, -1, axis=axis)
     K, B = associative_scan(compose_affine, (jnp.full_like(arr_rest, z), -z * arr_rest), axis=axis, reverse=True)
-    arr = lax.concatenate([K * jnp.squeeze(init, axis) + B, init], axis)
+    arr = lax.concatenate([K * init + B, init], axis)
     #jax.debug.print("after anticausal: {}", arr)
 
   if dtypes.issubdtype(input.dtype, np.integer):
@@ -414,4 +414,4 @@ def spline_filter1d(
                      "and use mode 'mirror'".format(mode))
   input = jnp.asarray(input)
   axis = util.canonicalize_axis(axis, input.ndim)
-  return _spline_filter1d(input, order=order, axis=axis, mode=mode)
+  return _spline_filter1d(input, order, axis, mode)

--- a/jax/scipy/ndimage.py
+++ b/jax/scipy/ndimage.py
@@ -17,4 +17,6 @@
 
 from jax._src.scipy.ndimage import (
   map_coordinates as map_coordinates,
+  spline_filter as spline_filter,
+  spline_filter1d as spline_filter1d,
 )

--- a/tests/scipy_ndimage_test.py
+++ b/tests/scipy_ndimage_test.py
@@ -138,7 +138,7 @@ class NdimageTest(jtu.JaxTestCase):
   @jtu.sample_product(
     order=[3, 4, 5],
     mode=['reflect', 'wrap', 'mirror'],
-    shape=[(5,), (3, 4), (3, 4, 5)],
+    shape=[(5,), (3, 4), (3, 1, 4)],
     dtype=float_dtypes,
   )
   def testSplineFilter(self, order, mode, shape, dtype):

--- a/tests/scipy_ndimage_test.py
+++ b/tests/scipy_ndimage_test.py
@@ -58,7 +58,7 @@ class NdimageTest(jtu.JaxTestCase):
      ]
     ],
     [dict(order=order, prefilter=prefilter)
-     for order in [0, 1, 3]
+     for order in list(range(6))
      for prefilter in ([False] if order > 1 else [True])
     ],
     shape=[(5,), (3, 4), (3, 4, 5)],
@@ -101,7 +101,7 @@ class NdimageTest(jtu.JaxTestCase):
     c = [np.linspace(0, 5, num=3)]
     with self.assertRaisesRegex(
       NotImplementedError, 'does not yet support order'):
-      lsp_ndimage.map_coordinates(x, c, order=2, prefilter=False)
+      lsp_ndimage.map_coordinates(x, c, order=7, prefilter=False)
     with self.assertRaisesRegex(
         NotImplementedError, 'does not yet support mode'):
       lsp_ndimage.map_coordinates(x, c, order=1, mode='grid-wrap')
@@ -110,15 +110,15 @@ class NdimageTest(jtu.JaxTestCase):
 
   @jtu.sample_product(
     dtype=float_dtypes + int_dtypes,
-    order=[0, 1],
+    order=[0, 1, 2, 3],
   )
   def testMapCoordinatesRoundHalf(self, dtype, order):
-    x = np.arange(-3, 3, dtype=dtype)
+    x = np.arange(-3, 8, 2, dtype=dtype)
     c = np.array([[.5, 1.5, 2.5, 3.5]])
     def args_maker():
       return x, c
 
-    lsp_op = lambda x, c: lsp_ndimage.map_coordinates(x, c, order=order, prefilter=False)
+    lsp_op = lambda x, c: lsp_ndimage.map_coordinates(x, c, order=order, prefilter=False, mode='constant')
     osp_op = lambda x, c: osp_ndimage.map_coordinates(x, c, order=order, prefilter=False, mode='grid-constant')
 
     with jtu.strict_promotion_if_dtypes_match([dtype, c.dtype]):


### PR DESCRIPTION
This is a draft PR implementing higher-order interpolations in jax.scipy.ndimage.

The IIR spline prefilters are implemented with an affine associative scan.
This might not be mergeable immediately; it seems like the spline filters have some stability problems with single-precision floats, especially with orders above 3. Therefore, the tests for spline_filter and map_coordinates with order > 3 have significantly reduced precision. Feedback or contributions are welcome.

Closes: #3928