### PR TITLE
Merge branch 'release/0.8.2'.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
   - id: mypy
     files: (jax/|tests/typing_test\.py)
     exclude: jax/_src/basearray.py|jax/numpy/__init__.py|jax/nn/__init__.py|jaxlib/_jax/.*  # Use pyi instead
-    additional_dependencies: [types-requests==2.31.0, numpy>=2.2.0, scipy-stubs]
+    additional_dependencies: [types-requests==2.31.0, numpy~=2.3.0, scipy-stubs]
     args: [--config=pyproject.toml]
 
 - repo: https://github.com/mwouts/jupytext

--- a/jax/version.py
+++ b/jax/version.py
@@ -152,7 +152,7 @@ def _get_cmdclass(pkg_source_path):
 
 
 __version__ = _get_version_string()
-_minimum_jaxlib_version = '0.8.1'
+_minimum_jaxlib_version = '0.8.2'
 
 def _version_as_tuple(version_str):
   return tuple(int(i) for i in version_str.split(".") if i.isdigit())

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,11 @@ from setuptools import setup, find_packages
 
 project_name = 'jax'
 
-_current_jaxlib_version = '0.8.1'
+_current_jaxlib_version = '0.8.2'
 # The following should be updated after each new jaxlib release.
 _latest_jaxlib_version_on_pypi = '0.8.1'
 
-_libtpu_version = '0.0.30.*'
+_libtpu_version = '0.0.32.*'
 
 def load_version_module(pkg_path):
   spec = importlib.util.spec_from_file_location(

--- a/tests/pickle_test.py
+++ b/tests/pickle_test.py
@@ -14,6 +14,7 @@
 
 import copy
 import pickle
+import sys
 import unittest
 
 from absl.testing import absltest
@@ -124,6 +125,8 @@ class PickleTest(jtu.JaxTestCase):
     self.assertIsInstance(y, type(x))
     self.assertEqual(x.aval, y.aval)
 
+  @unittest.skipIf(sys.version_info[:2] == (3, 11),
+                   "cannot pickle: b/470129766")
   @jtu.sample_product(prng_name=['threefry2x32', 'rbg', 'unsafe_rbg'])
   def testPickleOfKeyArray(self, prng_name):
     with jax.default_prng_impl(prng_name):


### PR DESCRIPTION
Merge branch 'release/0.8.2'.

- Update the pre-commit type checker to pin NumPy more strictly, to `~=2.3.0`

- Skip PickleTest.testPickleOfKeyArray on Python3.11 due  to issues with pickling (b/470129766)