### PR TITLE
Validate that data_fields and meta_fields are disjoint in register_dataclass

### DIFF
--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -1119,7 +1119,7 @@ def register_dataclass(
   if overlap := set(meta_fields) & set(data_fields):
     raise ValueError(
         f"data_fields and meta_fields must be disjoint, but the following "
-        f"fields appear in both: {overlap}."
+        f"fields appear in both: {sorted(overlap)}."
     )
 
   if dataclasses.is_dataclass(nodetype):

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -1115,6 +1115,13 @@ def register_dataclass(
   meta_fields = tuple(meta_fields)
   data_fields = tuple(data_fields)
 
+  # Check for overlapping fields
+  if overlap := set(meta_fields) & set(data_fields):
+    raise ValueError(
+        f"data_fields and meta_fields must be disjoint, but the following "
+        f"fields appear in both: {overlap}."
+    )
+
   if dataclasses.is_dataclass(nodetype):
     init_fields = {f.name for f in dataclasses.fields(nodetype) if f.init}
     init_fields.difference_update(*drop_fields)

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -1698,6 +1698,51 @@ class RegistrationTest(jtu.JaxTestCase):
           Foo, data_fields=["x"], meta_fields=["y", "z"]
       )
 
+  def test_register_dataclass_overlapping_fields(self):
+    @dataclasses.dataclass
+    class Foo:
+      x: int
+      y: int
+
+    with self.assertRaisesRegex(
+        ValueError,
+        "data_fields and meta_fields must be disjoint.*"
+        "fields appear in both: {'x'}",
+    ):
+      tree_util.register_dataclass(
+          Foo, data_fields=["x", "y"], meta_fields=["x"]
+      )
+
+    # Also test with a plain class (non-dataclass)
+    class Bar:
+      def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+    with self.assertRaisesRegex(
+        ValueError,
+        "data_fields and meta_fields must be disjoint.*"
+        "fields appear in both: {'y'}",
+    ):
+      tree_util.register_dataclass(
+          Bar, data_fields=["x", "y"], meta_fields=["y"]
+      )
+
+    # Test with multiple overlapping fields (all fields overlap)
+    class Baz:
+      def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    with self.assertRaisesRegex(
+        ValueError,
+        "data_fields and meta_fields must be disjoint.*"
+        "fields appear in both:",
+    ):
+      tree_util.register_dataclass(
+          Baz, data_fields=["a", "b"], meta_fields=["a", "b"]
+      )
+
   def test_register_dataclass_drop_fields(self):
     @dataclasses.dataclass
     class Foo:

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -1706,8 +1706,8 @@ class RegistrationTest(jtu.JaxTestCase):
 
     with self.assertRaisesRegex(
         ValueError,
-        "data_fields and meta_fields must be disjoint.*"
-        "fields appear in both: {'x'}",
+        r"data_fields and meta_fields must be disjoint.*"
+        r"fields appear in both: \['x'\]",
     ):
       tree_util.register_dataclass(
           Foo, data_fields=["x", "y"], meta_fields=["x"]
@@ -1721,8 +1721,8 @@ class RegistrationTest(jtu.JaxTestCase):
 
     with self.assertRaisesRegex(
         ValueError,
-        "data_fields and meta_fields must be disjoint.*"
-        "fields appear in both: {'y'}",
+        r"data_fields and meta_fields must be disjoint.*"
+        r"fields appear in both: \['y'\]",
     ):
       tree_util.register_dataclass(
           Bar, data_fields=["x", "y"], meta_fields=["y"]
@@ -1736,8 +1736,8 @@ class RegistrationTest(jtu.JaxTestCase):
 
     with self.assertRaisesRegex(
         ValueError,
-        "data_fields and meta_fields must be disjoint.*"
-        "fields appear in both:",
+        r"data_fields and meta_fields must be disjoint.*"
+        r"fields appear in both: \['a', 'b'\]",
     ):
       tree_util.register_dataclass(
           Baz, data_fields=["a", "b"], meta_fields=["a", "b"]


### PR DESCRIPTION
Fixes #34079

When using `register_dataclass`, specifying the same field in both `data_fields` 
and `meta_fields` was silently accepted. This is problematic because:

1. The field gets stored twice (once in leaves, once in aux_data)
2. During unflatten, the data value overwrites the meta value
3. It's semantically incorrect - a field can't be both static and dynamic

I've added a check that raises a `ValueError` with a clear message listing 
the overlapping fields. The check runs before the C++ registration, so invalid 
configurations never reach the pytree registry.

Added tests covering:
- Single overlapping field (dataclass)
- Single overlapping field (plain class)  
- Multiple overlapping fields