### PR TITLE
fix(nn): fix debug_infs error in dot_product_attention with float64

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -902,9 +902,7 @@ def _apply_masks(logits, mask, is_causal, q_seqlen, kv_seqlen,
     mask = _get_padding_mask_logits(T, S, q_seqlen, kv_seqlen)
     combined_mask = jnp.logical_and(combined_mask, mask)
 
-  safe_dtype = mask_dtype or logits.dtype
-  large_negative_number = _get_large_negative(safe_dtype)
-  large_negative_number = large_negative_number.astype(logits.dtype)
+  large_negative_number = _get_large_negative(mask_dtype or logits.dtype).astype(logits.dtype)
   padded_logits = jnp.where(combined_mask, logits, large_negative_number)
   return padded_logits
 

--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -879,7 +879,7 @@ def _get_padding_mask_encoded(T, q_seqlen):
   return mask[:, :, None, None]
 
 def _apply_masks(logits, mask, is_causal, q_seqlen, kv_seqlen,
-                 local_window_size, mask_dtype=None):
+                 local_window_size):
   if mask is None and not is_causal and q_seqlen is None and kv_seqlen is None and local_window_size is None:
     return logits
 
@@ -902,7 +902,7 @@ def _apply_masks(logits, mask, is_causal, q_seqlen, kv_seqlen,
     mask = _get_padding_mask_logits(T, S, q_seqlen, kv_seqlen)
     combined_mask = jnp.logical_and(combined_mask, mask)
 
-  large_negative_number = _get_large_negative(mask_dtype or logits.dtype).astype(logits.dtype)
+  large_negative_number = _get_large_negative(logits.dtype)
   padded_logits = jnp.where(combined_mask, logits, large_negative_number)
   return padded_logits
 
@@ -947,8 +947,11 @@ def _dot_product_attention_core(query, key, value, bias, mask, is_causal,
   if bias is not None:
     logits = (logits + bias).astype(logits.dtype)
 
+  if logits.dtype == jnp.float64:
+    logits = logits.astype(jnp.float32)
+
   padded_logits = _apply_masks(logits, mask, is_causal, q_seqlen, kv_seqlen,
-                              local_window_size, mask_dtype=np.float32)
+                              local_window_size)
 
   # Softmax and it is always carried out in fp32.
   padded_logits = padded_logits.astype(np.float32)

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -380,9 +380,9 @@ class NNFunctionsTest(jtu.JaxTestCase):
     _, dbias_ans, _ = bwd_ans(x, bias, mask)
     self.assertAllClose(dbias_ans, dbias_ref, rtol=0.1, atol=0.1)
 
-  def testDotProductAttentionDebugInfsFloat64(self):
+  @parameterized.product(dtype=[jnp.float16, jnp.float32, jnp.float64])
+  def testDotProductAttentionDebugInfs(self, dtype):
     with jax.enable_x64(True), jax.debug_infs(True):
-      dtype = jnp.float64
       shape = (1, 2, 4)
       q = jnp.zeros(shape, dtype=dtype)
       k = jnp.zeros(shape, dtype=dtype)

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -380,6 +380,17 @@ class NNFunctionsTest(jtu.JaxTestCase):
     _, dbias_ans, _ = bwd_ans(x, bias, mask)
     self.assertAllClose(dbias_ans, dbias_ref, rtol=0.1, atol=0.1)
 
+  def testDotProductAttentionDebugInfsFloat64(self):
+    with jax.enable_x64(True), jax.debug_infs(True):
+      dtype = jnp.float64
+      shape = (1, 2, 4)
+      q = jnp.zeros(shape, dtype=dtype)
+      k = jnp.zeros(shape, dtype=dtype)
+      v = jnp.zeros(shape, dtype=dtype)
+      mask = jnp.array([[True, False]])
+
+      nn.dot_product_attention(q, k, v, mask=mask)
+
   def testSoftplusGrad(self):
     check_grads(nn.softplus, (1e-8,), order=4,
                 rtol=1e-2 if jtu.test_device_matches(["tpu"]) else None,


### PR DESCRIPTION
## Description

Fixes #34107 

This PR addresses an issue where `dot_product_attention` raises a `FloatingPointError` when using `float64` inputs with `jax.debug_infs(True)`.
The error occurred because the mask values generated based on `float64` limits overflowed when cast to `float32`.

## Changes

- Updated `_apply_masks` to accept an optional `mask_dtype` argument.
- Modified `_dot_product_attention_core` to pass `mask_dtype=np.float32`.
- Added a regression test case in `tests/nn_test.py`.

## Verification

- Verified the fix locally with the reproduction script.
- Added `testDotProductAttentionDebugInfsFloat64` to `tests/nn_test.py`.