### PR TITLE
Fix/dot product attention float64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ jax.iml
 
 # virtualenv/venv directories
 /venv/
+/venv_new/
 /bin/
 /include/
 /lib/

--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -947,11 +947,11 @@ def _dot_product_attention_core(query, key, value, bias, mask, is_causal,
   if bias is not None:
     logits = (logits + bias).astype(logits.dtype)
 
+  # Softmax and it is always carried out in fp32.
+  logits = logits.astype(np.float32)
   padded_logits = _apply_masks(logits, mask, is_causal, q_seqlen, kv_seqlen,
                                local_window_size)
 
-  # Softmax and it is always carried out in fp32.
-  padded_logits = padded_logits.astype(np.float32)
   probs = softmax(padded_logits, axis=-1).astype(key.dtype)
 
   encoded = jnp_einsum.einsum('BNTS,BSNH->BTNH', probs, value)


### PR DESCRIPTION
This PR fixes a FloatingPointError in jax.nn.dot_product_attention that occurs when using float64 inputs with jax.debug_infs(True).

The issue was caused by mask generation using float64 "large negative values" (approx -1e308), which overflow to -inf when subsequently cast to float32 for softmax. This change moves the float32 cast to occur before masking, ensuring the mask values remain finite and within the float32 range.