### PR TITLE
Fix: Fixed the axes inference when s is provided and axes is None

### DIFF
--- a/jax/_src/scipy/fft.py
+++ b/jax/_src/scipy/fft.py
@@ -155,8 +155,7 @@ def dctn(x: Array, type: int = 2,
     type: integer, default = 2. Currently only type 2 is supported.
     s: integer or sequence of integers. Specifies the shape of the result. If not
       specified, it will default to the shape of ``x`` along the specified ``axes``.
-    axes: integer or sequence of integers. Specifies the axes along which the
-      transform will be computed.
+    axes: integer or sequence of integers. Specifies the axes along which the transform will be computed. If not specified, the transform is computed along the last ``len(s)`` axes if ``s`` is provided, otherwise along all axes.
     norm: string. The normalization mode: one of ``[None, "backward", "ortho"]``.
       The default is ``None``, which is equivalent to ``"backward"``.
 
@@ -180,23 +179,23 @@ def dctn(x: Array, type: int = 2,
      [  8.84   9.65  -3.54]
      [ 11.25  -1.54  -0.88]]
 
-    When ``s=[2]``, dimension of the transform along ``axis 0`` will be ``2``
-    and dimension along ``axis 1`` will be same as that of input.
+    When ``s=[2]``, dimension of the transform along ``axis 1`` will be ``2``
+    and dimension along ``axis 0`` will be same as that of input.
 
     >>> with jnp.printoptions(precision=2, suppress=True):
     ...   print(jax.scipy.fft.dctn(x, s=[2]))
-    [[ 9.36 10.22 -8.53]
-     [11.57  2.85 -2.06]]
-
-    When ``s=[2]`` and ``axes=[1]``, dimension of the transform along ``axis 1`` will
-    be ``2`` and dimension along ``axis 0`` will  be same as that of input.
-    Also when ``axes=[1]``, transform will be computed only along ``axis 1``.
-
-    >>> with jnp.printoptions(precision=2, suppress=True):
-    ...   print(jax.scipy.fft.dctn(x, s=[2], axes=[1]))
     [[ 7.3  -0.57]
      [ 0.19 -0.36]
      [-0.   -1.4 ]]
+
+    When ``s=[2]`` and ``axes=[0]``, dimension of the transform along ``axis 0`` will
+    be ``2`` and dimension along ``axis 1`` will  be same as that of input.
+    Also when ``axes=[0]``, transform will be computed only along ``axis 0``.
+
+    >>> with jnp.printoptions(precision=2, suppress=True):
+    ...   print(jax.scipy.fft.dctn(x, s=[2], axes=[0]))
+    [[ 3.09 4.4  -2.81]
+     [ 2.41 2.62 0.76]]
 
     When ``s=[2, 4]``, shape of the transform will be ``(2, 4)``.
 
@@ -205,7 +204,7 @@ def dctn(x: Array, type: int = 2,
     [[  9.36  11.23   2.12 -10.97]
      [ 11.57   5.86  -1.37  -1.58]]
   """
-  x = ensure_arraylike("idctn", x)
+  x = ensure_arraylike("dctn", x)
 
   if type != 2:
     raise NotImplementedError('Only DCT type 2 is implemented.')
@@ -219,7 +218,14 @@ def dctn(x: Array, type: int = 2,
       assert not isinstance(s, Sequence)
       s = [operator.index(s)]
 
+  if axes is None and s is not None:
+    if len(s) > x.ndim:
+      raise ValueError("s has more dimensions than x")
+    axes = tuple(range(x.ndim - len(s), x.ndim))
   axes = canonicalize_axis_tuple(axes, x.ndim)
+
+  if s is not None and len(s) != len(axes):
+    raise ValueError("len(s) must match len(axes)")
 
   if len(axes) == 1:
     return dct(x, n=s[0] if s is not None else None, axis=axes[0], norm=norm)
@@ -346,8 +352,7 @@ def idctn(x: Array, type: int = 2,
     type: integer, default = 2. Currently only type 2 is supported.
     s: integer or sequence of integers. Specifies the shape of the result. If not
       specified, it will default to the shape of ``x`` along the specified ``axes``.
-    axes: integer or sequence of integers. Specifies the axes along which the
-      transform will be computed.
+    axes: integer or sequence of integers. Specifies the axes along which the transform will be computed. If not specified, the transform is computed along the last ``len(s)`` axes if ``s`` is provided, otherwise along all axes.
     norm: string. The normalization mode: one of ``[None, "backward", "ortho"]``.
       The default is ``None``, which is equivalent to ``"backward"``.
 
@@ -371,23 +376,23 @@ def idctn(x: Array, type: int = 2,
      [ 0.07  0.17 -0.03]
      [ 0.19 -0.07 -0.02]]
 
-    When ``s=[2]``, dimension of the transform along ``axis 0`` will be ``2``
-    and dimension along ``axis 1`` will be the same as that of input.
+    When ``s=[2]``, dimension of the transform along ``axis 1`` will be ``2``
+    and dimension along ``axis 0`` will be the same as that of input.
 
     >>> with jnp.printoptions(precision=2, suppress=True):
     ...  print(jax.scipy.fft.idctn(x, s=[2]))
-    [[ 0.15  0.21 -0.18]
-     [ 0.24 -0.01 -0.02]]
-
-    When ``s=[2]`` and ``axes=[1]``, dimension of the transform along ``axis 1`` will
-    be ``2`` and dimension along ``axis 0`` will  be same as that of input.
-    Also when ``axes=[1]``, transform will be computed only along ``axis 1``.
-
-    >>> with jnp.printoptions(precision=2, suppress=True):
-    ...  print(jax.scipy.fft.idctn(x, s=[2], axes=[1]))
     [[ 1.12 -0.31]
      [ 0.04 -0.08]
      [ 0.05 -0.3 ]]
+
+    When ``s=[2]`` and ``axes=[0]``, dimension of the transform along ``axis 0`` will
+    be ``2`` and dimension along ``axis 1`` will  be same as that of input.
+    Also when ``axes=[0]``, transform will be computed only along ``axis 0``.
+
+    >>> with jnp.printoptions(precision=2, suppress=True):
+    ...  print(jax.scipy.fft.idctn(x, s=[2], axes=[0]))
+    [[ 0.38  0.57 -0.45]
+     [ 0.43  0.44  0.24]]
 
     When ``s=[2, 4]``, shape of the transform will be ``(2, 4)``
 
@@ -417,7 +422,14 @@ def idctn(x: Array, type: int = 2,
       assert not isinstance(s, Sequence)
       s = [operator.index(s)]
 
+  if axes is None and s is not None:
+    if len(s) > x.ndim:
+      raise ValueError("s has more dimensions than x")
+    axes = tuple(range(x.ndim - len(s), x.ndim))
   axes = canonicalize_axis_tuple(axes, x.ndim)
+
+  if s is not None and len(s) != len(axes):
+    raise ValueError("len(s) must match len(axes)")
 
   if len(axes) == 1:
     return idct(x, n=s[0] if s is not None else None, axis=axes[0], norm=norm)

--- a/tests/scipy_fft_test.py
+++ b/tests/scipy_fft_test.py
@@ -138,6 +138,17 @@ class LaxBackedScipyFftTests(jtu.JaxTestCase):
     rtol = {np.float64: 1E-12, np.float32: 1E-4}
     self.assertArraysAllClose(actual, expected, rtol=rtol)
 
+  @jtu.sample_product(func=['idctn', 'dctn'])
+  def testDctnAxesInference(self, func):
+    # Test for https://github.com/jax-ml/jax/issues/29426
+    x = np.array([[1,2,3]])
+    kwds = dict(s=(5,))
+    ops_func = getattr(osp_fft, func)
+    jsp_func = getattr(jsp_fft, func)
+    expected = ops_func(x, **kwds)
+    actual = jsp_func(x, **kwds)
+    rtol = {np.float64: 1E-12, np.float32: 1E-4}
+    self.assertArraysAllClose(actual, expected, rtol=rtol)
 
 if __name__ == "__main__":
     absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Closes #29426 `jax.scipy.ff.t.idctn` now returns the same safe and axis behavior as scipy does.

### Reason Behind the bug:

- when axes=None and s is given - JAX treated s as targeting the first axes instead of the last len(s) axes.
- Example in the issue linked - shape was (1,3) with s = (5,) ( shape parameter ), Scipy transforms and resizes the last axis and returns shape ( 1, 5) while JAX right now is transforming the first axis and reshapes the input into ( 5, 3 )

All the tests are passing alongside linting: 

```bash
╰─ pytest tests/scipy_fft_test.py
=================================================================== test session starts ====================================================================
platform linux -- Python 3.11.14, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/jha/workspace/opensource/jax
configfile: pyproject.toml
plugins: xdist-3.8.0, hypothesis-6.142.1
collected 44 items

tests/scipy_fft_test.py ......................s.....................                                                                                 [100%]

============================================================== 43 passed, 1 skipped in 32.98s ==============================================================
╭─ bash   jax   idctn-axes-s ≢   35s 132ms⠀                                                jax-dev 3.11.14  WSL at    98   30,12:26 
╰─ JAX_ENABLE_X64=1 pytest tests/scipy_fft_test.py
=================================================================== test session starts ====================================================================
platform linux -- Python 3.11.14, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/jha/workspace/opensource/jax
configfile: pyproject.toml
plugins: xdist-3.8.0, hypothesis-6.142.1
collected 44 items

tests/scipy_fft_test.py ............................................                                                                                 [100%]

=================================================================== 44 passed in 32.88s ====================================================================
```