### PR TITLE
Fixes minor typos in Pallas documentation

### DIFF
--- a/docs/pallas/pipelining.ipynb
+++ b/docs/pallas/pipelining.ipynb
@@ -143,7 +143,7 @@
     "\n",
     "`add_matrices_kernel` operates using `Refs` that live in SRAM. Loading from a SRAM Ref produces a value that lives in registers. Values in registers behave like jax.Arrays in that we can use `jnp` and `jax.lax` operations on them to produce new values that live in registers. When we produce the values we'd like to return, we store them in the output SRAM `Ref`.\n",
     "\n",
-    "The `add_matrices` function acts on `jax.Array`s and returns a `jax.Array`. Inside it, we pass `x` and `y` into pallas_call. `pallas_call` is responsible for copying `x` and `y` into SRAM and for allocating the SRAM buffers that the kernel operates on (including allocating `z_vmem_ref`, the output SRAM buffer). After the kernel function is finished running, `pallas_call` will also copy the value in `z_vmem_ref` to HBM, resulting in an output `jax.Array`.\n",
+    "The `add_matrices` function acts on `jax.Array`s and returns a `jax.Array`. Inside it, we pass `x` and `y` into `pallas_call`. `pallas_call` is responsible for copying `x` and `y` into SRAM and for allocating the SRAM buffers that the kernel operates on (including allocating `z_sram_ref`, the output SRAM buffer). After the kernel function is finished running, `pallas_call` will also copy the value in `z_sram_ref` to HBM, resulting in an output `jax.Array`.\n",
     "\n",
     "Pallas exposes access to lower level memory spaces like SRAM but writing performant kernels requires more care in utilizing the various memory spaces. For example, we need to consider both:\n",
     "\n",

--- a/docs/pallas/pipelining.md
+++ b/docs/pallas/pipelining.md
@@ -96,7 +96,7 @@ We've written two functions: `add_matrices_kernel` and `add_matrices`.
 
 `add_matrices_kernel` operates using `Refs` that live in SRAM. Loading from a SRAM Ref produces a value that lives in registers. Values in registers behave like jax.Arrays in that we can use `jnp` and `jax.lax` operations on them to produce new values that live in registers. When we produce the values we'd like to return, we store them in the output SRAM `Ref`.
 
-The `add_matrices` function acts on `jax.Array`s and returns a `jax.Array`. Inside it, we pass `x` and `y` into pallas_call. `pallas_call` is responsible for copying `x` and `y` into SRAM and for allocating the SRAM buffers that the kernel operates on (including allocating `z_vmem_ref`, the output SRAM buffer). After the kernel function is finished running, `pallas_call` will also copy the value in `z_vmem_ref` to HBM, resulting in an output `jax.Array`.
+The `add_matrices` function acts on `jax.Array`s and returns a `jax.Array`. Inside it, we pass `x` and `y` into `pallas_call`. `pallas_call` is responsible for copying `x` and `y` into SRAM and for allocating the SRAM buffers that the kernel operates on (including allocating `z_sram_ref`, the output SRAM buffer). After the kernel function is finished running, `pallas_call` will also copy the value in `z_sram_ref` to HBM, resulting in an output `jax.Array`.
 
 Pallas exposes access to lower level memory spaces like SRAM but writing performant kernels requires more care in utilizing the various memory spaces. For example, we need to consider both:
 


### PR DESCRIPTION
Corrected a parameter name mismatch: documentation text mistakenly references `z_vmem_ref` instead of the `z_sram_ref` used in the code examples.