### PR TITLE
clarify usage and guarantees of jax.clear_caches()

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -3185,8 +3185,18 @@ def live_arrays(platform=None):
 def clear_caches():
   """Clear all compilation and staging caches.
 
-  This doesn't clear the persistent cache; to disable it (e.g. for benchmarks),
-  set the jax_enable_compilation_cache config option to False.
+  This function clear internal caches used for tracing , staging, and JIT compilation.
+  
+  This does not clear the persistent compilation cache; to disable it (e.g. for becnhmarks), set the ``jax_enable_compilation_cache`` config option to False.
+  
+  This function is primarily intended for debugging, benchmarking, or
+  development workflows. In normal usage, user code should not need to call``jax.clear_caches()``. If a program requires repeated calls to thisfunction to work correctly, this likely indicates a bug either in JAX or in the user code.
+  
+  This function is Python-thread-safe, as it is called while holding the
+  Python GIL.
+
+  ``jax.clear_caches()`` is the supported API for clearing all of JAX's
+  internal caches.
   """
   # Clear all lu.cache, util.cache and util.weakref_lru_cache instances
   # (used for staging and Python-dispatch compiled executable caches).

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -3185,12 +3185,12 @@ def live_arrays(platform=None):
 def clear_caches():
   """Clear all compilation and staging caches.
 
-  This function clear internal caches used for tracing , staging, and JIT compilation.
+  This function clears internal caches used for tracing, staging, and JIT compilation.
   
-  This does not clear the persistent compilation cache; to disable it (e.g. for becnhmarks), set the ``jax_enable_compilation_cache`` config option to False.
+  This does not clear the persistent compilation cache; to disable it (e.g. for benchmarks), set the ``jax_enable_compilation_cache`` config option to False.
   
   This function is primarily intended for debugging, benchmarking, or
-  development workflows. In normal usage, user code should not need to call``jax.clear_caches()``. If a program requires repeated calls to thisfunction to work correctly, this likely indicates a bug either in JAX or in the user code.
+  development workflows. In normal usage, user code should not need to call ``jax.clear_caches()``. If a program requires repeated calls to this function to work correctly, this likely indicates a bug either in JAX or in the user code.
   
   This function is Python-thread-safe, as it is called while holding the
   Python GIL.


### PR DESCRIPTION
This PR clarifies the intended usage of `jax.clear_caches()` based on
maintainer guidance, including:

- when the function should and should not be used
- thread-safety guarantees
- confirmation that it is the supported API for clearing JAX caches

Fixes #19590