### PR TITLE
[hijax] start implementing custom_vjp on top of hijax primitives

### DIFF
--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -1189,6 +1189,9 @@ pytype_strict_library(
         ":partial_eval",
         ":tree_util",
         ":util",
+        ":api_util",
+        ":custom_derivatives",
+        ":api",
     ],
 )
 

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -747,6 +747,7 @@ def tracers_to_jaxpr(
 
   processed_eqn_ids = set()
   eqns: list[core.JaxprEqn] = []
+  is_high = False
 
   reachable = toposort
   tracers = reachable((*in_tracers, *out_tracers, *effect_handles))
@@ -765,6 +766,8 @@ def tracers_to_jaxpr(
                    for a, rf in zip(r.out_avals, r.out_tracer_refs)]
         eqns.append(new_jaxpr_eqn(in_atoms, outvars, r.primitive, r.params,
                                   r.effects, r.source_info, r.ctx))
+        in_avals = [x.aval for x in in_atoms]
+        is_high |= r.primitive.is_high(*in_avals, **r.params)
         processed_eqn_ids.add(r.eqn_id)
     elif isinstance(r, LambdaBinding):
       if not any(t is in_tracer for in_tracer in in_tracers):
@@ -790,9 +793,9 @@ def tracers_to_jaxpr(
   const_vars, const_vals = unzip2(consts.items())
   outvars = map(get_atom, out_tracers)  # type: ignore[arg-type]
   jaxpr_effects = make_jaxpr_effects(const_vars, invars, outvars, eqns)
+  is_high |= any(x.aval.is_high for x in it.chain(const_vars, invars, outvars))
   jaxpr = Jaxpr(const_vars, invars,  # type: ignore[arg-type]
-                outvars, eqns, jaxpr_effects,
-                debug_info)
+                outvars, eqns, jaxpr_effects, debug_info, is_high)
   config.enable_checks.value and core.check_jaxpr(jaxpr)
   # del getvar  # needed to avoid cyclic-reference closure, apparently!
   return jaxpr, const_vals, env_vals

--- a/jax/_src/stages.py
+++ b/jax/_src/stages.py
@@ -427,6 +427,12 @@ class Traced(Stage):
   def out_avals(self):
     return tree_unflatten(self.out_tree, self.jaxpr.out_avals)
 
+  def __call__(self, *args, **kwargs):
+    args_flat = tree_util.tree_leaves_checked(self.in_tree, (args, kwargs))
+    out_flat = core.jaxpr_as_fun(self.jaxpr)(*args_flat)
+    return tree_unflatten(self.out_tree, out_flat)
+
+
   @property
   def lojax(self) -> LoJax:
     if self._lojax is not None:


### PR DESCRIPTION
We currently expect Hijax primitives to provide the most general way to write custom autodiff rules. They'll work with hijax types (like boxes), they'll let us separately define JVP, linearize, and VJP rules. They'll even have a simpler implementation!

Given that hijax-primitive-based custom AD, we also want to implement `custom_jvp` and `custom_vjp` on top of it, for a few reasons:
1. keep existing code working (while still letting us delete the old complicated custom_jvp/vjp implementations);
2. as convenience wrappers for simple cases, even in new code;
3. implementing `custom_jvp` and `custom_vjp` on top of the new path, and making all tests (and google code) pass, is a good way to build confidence that the new path is correct!

This PR is about starting to implement `custom_vjp` in this way. It doesn't yet support: eager, vmap, remat.

The implementation roughly looks like:
* `jax._src.hijax.custom_vjp3` is the drop-in replacement for `jax.custom_vjp`, which in turn is a thin wrapper for the hijax primitive `CustomVJPTraced`
* `CustomVJPTraced.__init__` traces the primal function to a jaxpr, and keeps the rules as callables (under the assumption that they can't close over any tracers, which is a clearer/stricter requirement than we've had for custom_jvp/vjp, and we think it's a big win)
* `CustomVJPTraced.expand` is after AD, so it just runs the primal (and drops the rules)
* `CustomVJPTraced.vjp_fwd` and `vjp_bwd_retval` just make the hijax rule vs custom_jvp/vjp rule interfaces align, in particular around symbolic zeros
* A test class that runs all the custom_jvp/vjp tests except for explicit skips, which we'll whittle down
