### PR TITLE
Fixes Typo in Pseudocode Example

### DIFF
--- a/docs/pallas/pipelining.ipynb
+++ b/docs/pallas/pipelining.ipynb
@@ -366,7 +366,7 @@
     "      copy_in_start(in_hbm[in_slices(i+1)], in_sram[next_slot])\n",
     "    copy_in_wait(in_sram[cur_slot])\n",
     "\n",
-    "    kernel(in_sram[cur_slot], out_ram[cur_slot])\n",
+    "    kernel(in_sram[cur_slot], out_sram[cur_slot])\n",
     "\n",
     "    copy_out_start(out_sram[cur_slot], out_hbm[out_slices(i)])\n",
     "    if i > 0:\n",

--- a/docs/pallas/pipelining.md
+++ b/docs/pallas/pipelining.md
@@ -302,7 +302,7 @@ def double_buffered_pipeline(
       copy_in_start(in_hbm[in_slices(i+1)], in_sram[next_slot])
     copy_in_wait(in_sram[cur_slot])
 
-    kernel(in_sram[cur_slot], out_ram[cur_slot])
+    kernel(in_sram[cur_slot], out_sram[cur_slot])
 
     copy_out_start(out_sram[cur_slot], out_hbm[out_slices(i)])
     if i > 0:


### PR DESCRIPTION
Fixes typo where`out_sram` is mistakenly spelled as `out_ram`.