### PR TITLE
Remove deprecated symbol jax.interpreters.xla.canonicalize_dtype

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from jax._src.dtypes import (
-  canonicalize_value_handlers as _canonicalize_value_handlers,
-)
+__all__ = ["apply_primitive", "canonicalize_dtype_handlers", "Backend"]
 
-canonicalize_dtype_handlers = _canonicalize_value_handlers
+from jax._src.dtypes import (
+  canonicalize_value_handlers as canonicalize_dtype_handlers
+)
 
 from jax._src.dispatch import (
   apply_primitive as apply_primitive,
@@ -25,26 +25,3 @@ from jax._src.dispatch import (
 from jax._src.lib import xla_client as _xc
 Backend = _xc._xla.Client
 del _xc
-
-# Deprecations
-_deprecations = {
-    # Finalized in JAX v0.8.0; remove in v0.9.0
-    "canonicalize_dtype": (
-        (
-            "jax.interpreters.xla.canonicalize_dtype was deprecated in JAX"
-            " v0.7.0 and removed in JAX v0.8.0. For canonicalizing dtypes,"
-            " prefer jax.dtypes.canonicalize_dtype. For checking whether an"
-            " object is a valid jax input, prefer jax.core.valid_jaxtype."
-        ),
-        None,
-    )
-}
-
-import typing as _typing
-if _typing.TYPE_CHECKING:
-  pass
-else:
-  from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
-  __getattr__ = _deprecation_getattr(__name__, _deprecations)
-  del _deprecation_getattr
-del _typing


### PR DESCRIPTION
This has been raising a custom AttributeError since JAX v0.8.0; with this change it will raise a generic AttributeError.