### PR TITLE
Fix(cpu_client): preserve exception context in pure_callback cache hits

### DIFF
--- a/jaxlib/py_client_cpu.cc
+++ b/jaxlib/py_client_cpu.cc
@@ -128,8 +128,13 @@ ffi::Error XlaFfiPythonCpuCallback(xla::FfiLoadedHostCallbacks* callbacks,
       auto result_object = callback(*nb::borrow<nb::args>(nb_args));
       result_tuple = nb::cast<nb::tuple>(result_object);
     } catch (nb::python_error& e) {
-      return ffi::Error::Internal(
-          absl::StrFormat("CpuCallback error calling callback: %s", e.what()));
+      // 1. Save the message for the status (just in case)
+      std::string msg = e.what();
+      // 2. Restore the exception to the Python interpreter state
+      e.restore();
+      // 3. Return error. The JAX runtime *should* check PyErr_Occured90 on failure.
+      return ffi::Error(ffi::ErrorCode::kUnknown,
+          absl::StrFormat("CpuCallback error calling callback: %s", msg));
     }
   }
 

--- a/jaxlib/py_client_cpu.cc
+++ b/jaxlib/py_client_cpu.cc
@@ -132,7 +132,7 @@ ffi::Error XlaFfiPythonCpuCallback(xla::FfiLoadedHostCallbacks* callbacks,
       std::string msg = e.what();
       // 2. Restore the exception to the Python interpreter state
       e.restore();
-      // 3. Return error. The JAX runtime *should* check PyErr_Occured90 on failure.
+      // 3. Return error. The JAX runtime *should* check PyErr_Occured() on failure.
       return ffi::Error(ffi::ErrorCode::kUnknown,
           absl::StrFormat("CpuCallback error calling callback: %s", msg));
     }

--- a/tests/issue_34083_test.py
+++ b/tests/issue_34083_test.py
@@ -1,0 +1,40 @@
+# tests/issue_34083_test.py
+import jax
+import jax.numpy as jnp
+from absl.testing import absltest
+# You can remove 'from jax import test_util as jtu' if you want, strictly not needed here.
+
+# CHANGE: Inherit directly from absltest.TestCase
+class Issue34083Test(absltest.TestCase):
+  
+  def test_pure_callback_exception_cached(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/34083
+    # ... (rest of the code remains exactly the same) ...
+
+    def error_callback(x):
+      raise RuntimeError("CRITICAL_FAILURE_MESSAGE")
+
+    def conditional_error(x):
+      def _cb(operand):
+        shape = jax.ShapeDtypeStruct(operand.shape, operand.dtype)
+        return jax.pure_callback(error_callback, shape, operand)
+
+      return jax.lax.cond(
+          x > 0,
+          _cb,
+          lambda o: o,
+          x
+      )
+
+    jit_f = jax.jit(conditional_error)
+
+    # 1. Prime the cache (Safe path)
+    res = jit_f(jnp.array(-1.0))
+    self.assertEqual(res, -1.0)
+
+    # 2. Trigger the error (Error path)
+    with self.assertRaisesRegex(Exception, "CRITICAL_FAILURE_MESSAGE"):
+      jit_f(jnp.array(1.0))
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
Fixes #34083

This fixes a regression where `pure_callback` would swallow exception types when hitting the XLA compilation cache.

Previously, the first run of a JIT-compiled function would correctly raise a `RuntimeError`, but subsequent cached calls would fail with a generic `ValueError` (due to `Internal` status). This happened because `jaxlib/py_client_cpu.cc` was catching `nb::python_error` and immediately wrapping it in `ffi::Error::Internal`, which JAX binds to `ValueError`. This broke downstream exception handling in libraries like Equinox.

**Changes:**
I've updated the C++ CPU client to:

* Use `e.restore()` to ensure the Python error indicator remains set on the worker thread.
* Return `ffi::ErrorCode::kUnknown` instead of `Internal`. `Internal` implies a bug in JAX itself, whereas `Unknown` is semantically better for user-land callback failures and avoids the aggressive `ValueError` mapping.

**Verification:**
Used the reproduction script from the issue. Cached executions now correctly expose the original `RuntimeError` message and context instead of the generic internal error.

## Checklist

* [x] I have signed the [[Contributor License Agreement](https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement)](https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement).
* [x] I have run the reproduction script locally and verified the fix.
* [x] I have added tests.
