### PR TITLE
Fix #33649: Persist 'memory_kind' in jax.export

### DIFF
--- a/jax/_src/export/serialization.fbs
+++ b/jax/_src/export/serialization.fbs
@@ -104,6 +104,7 @@ enum ShardingKind: byte {
 table Sharding {
   kind: ShardingKind;
   hlo_sharding_proto: [byte];
+  memory_kind: string;
 }
 
 table Effect {

--- a/jax/_src/export/serialization_generated.py
+++ b/jax/_src/export/serialization_generated.py
@@ -355,8 +355,15 @@ class Sharding(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         return o == 0
 
+    # Sharding
+    def MemoryKind(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
+        if o != 0:
+            return self._tab.String(o + self._tab.Pos)
+        return None
+
 def ShardingStart(builder):
-    builder.StartObject(2)
+    builder.StartObject(3)
 
 def ShardingAddKind(builder, kind):
     builder.PrependInt8Slot(0, kind, 0)
@@ -366,6 +373,9 @@ def ShardingAddHloShardingProto(builder, hloShardingProto):
 
 def ShardingStartHloShardingProtoVector(builder, numElems):
     return builder.StartVector(1, numElems, 1)
+
+def ShardingAddMemoryKind(builder, memoryKind):
+    builder.PrependUOffsetTRelativeSlot(2, flatbuffers.number_types.UOffsetTFlags.py_type(memoryKind), 0)
 
 def ShardingEnd(builder):
     return builder.EndObject()

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -188,6 +188,8 @@ class JaxExportTest(jtu.JaxTestCase):
       # Verify the export object retained the input memory_kind metadata
       restored_in = exported.in_shardings_jax(mesh)[0]
       self.assertEqual(restored_in.memory_kind, 'pinned_host')
+      restored_out = exported.out_shardings_jax(mesh)[0]
+      self.assertEqual(restored_out.memory_kind, 'pinned_host')
 
   def test_export_class_reconstructs_output_memory_kind(self):
     # Unit test for the plumbing in Exported.out_shardings_jax.
@@ -205,8 +207,8 @@ class JaxExportTest(jtu.JaxTestCase):
     # We fill required fields with dummy values
     exp = export.Exported(
         fun_name="test_fun",
-        in_tree=None, in_avals=(),
-        out_tree=None, out_avals=(),
+        in_tree=tree_util.tree_structure(None), in_avals=(),
+        out_tree=tree_util.tree_structure(None), out_avals=(),
         in_shardings_hlo=(),
         out_shardings_hlo=(hlo_sharding,),
         nr_devices=1,

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -182,7 +182,7 @@ class JaxExportTest(jtu.JaxTestCase):
         return x
 
       # Export the function with pinned_host input
-      exported = export.export(jax.jit(f, in_shardings=shd, out_shardings=shd))(
+      exported = get_exported(jax.jit(f, in_shardings=shd, out_shardings=shd))(
           jax.ShapeDtypeStruct((2,), np.float32, sharding=shd))
 
       # Verify the export object retained the input memory_kind metadata


### PR DESCRIPTION
## Description
Fixes #33649.

Previously, `jax.export` would drop the `memory_kind` attribute (e.g., `pinned_host`) during the export process because the underlying `HloSharding` format does not support this metadata. This caused exported functions to lose critical memory placement information when re-imported.

## Changes
- Modified the `Exported` class in `jax/_src/export/_export.py` to store `in_memory_kinds` and `out_memory_kinds`.
- Updated `export()` to extract `memory_kind` from input/output shardings before lowering to HLO.
- Updated `in_shardings_jax()` and `_hlo_sharding_to_named_sharding` to restore the correct `memory_kind` upon reconstruction.

## Tests
- Added `test_export_preserves_memory_kind` to `tests/export_test.py` which verifies that `pinned_host` is preserved after an export roundtrip.