### PR TITLE
docs: document that buffer donation is disabled under debug_nans

### DIFF
--- a/docs/debugging/flags.md
+++ b/docs/debugging/flags.md
@@ -84,6 +84,7 @@ with jax.debug_nans(False):
 ##### Limitations
 * Re-running functions eagerly can be slow. You shouldn't have the NaN-checker on if you're not debugging, as it can introduce lots of device-host round-trips and performance regressions.
 * Errors on false positives (e.g. intentionally created NaNs)
+* Disables buffer donation (`donate_argnums`/`donate_argnames` in `jax.jit` and `jax.pmap`). This is because debug mode needs to inspect intermediate values that would be invalidated by donation. See {ref}`buffer-donation` for more details.
 
 ## `jax_debug_infs` configuration option and context manager
 

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -274,6 +274,10 @@ def jit(
       parameters listed in either ``donate_argnums`` or ``donate_argnames`` will
       be donated.
 
+      Note: Buffer donation is disabled when ``jax_debug_nans`` is enabled.
+      This is because debug mode needs to inspect intermediate values that
+      would be invalidated by donation.
+
       For more details on buffer donation see the
       `FAQ <https://docs.jax.dev/en/latest/faq.html#buffer-donation>`_.
     donate_argnames: optional, a string or collection of strings specifying

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1195,7 +1195,8 @@ debug_nans = bool_state(
     help=('Add nan checks to every operation. When a nan is detected on the '
           'output of a jit-compiled computation, call into the un-compiled '
           'version in an attempt to more precisely identify the operation '
-          'which produced the nan.'))
+          'which produced the nan. Note: enabling this option disables buffer '
+          'donation (donate_argnums/donate_argnames).'))
 
 debug_infs = bool_state(
     name='jax_debug_infs',


### PR DESCRIPTION
Fixes #33949

As requested, this PR updates the documentation to clarify that buffer donation is disabled when jax_debug_nans is enabled.