### PR TITLE
[mlir] Added a shim for `T.isinstance`

### DIFF
--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -116,6 +116,11 @@ def shape_tensor(sizes: Sequence[int | ir.RankedTensorType]
   else:
     return hlo.concatenate(ds, i64_attr(0))
 
+def isinstance(t: ir.Type, cls: type) -> bool:
+  # TODO(slebedev): Inline this shim once jaxlib contains the MLIR version
+  # which allows builtin ``isinstance``.
+  return cls.isinstance(t)
+
 
 def delegate_lowering(ctx, lowering_fun, *args, **ctx_override_kwargs):
   """Side-effects on `ctx`"""

--- a/jax/_src/pallas/mosaic/sc_lowering.py
+++ b/jax/_src/pallas/mosaic/sc_lowering.py
@@ -553,7 +553,7 @@ def _debug_print_lowering_rule(
   match args:
     case []:
       tpu.log(inputs=[], tag=fmt)
-    case [arg] if ir.MemRefType.isinstance(arg.type):
+    case [arg] if mlir.isinstance(arg.type, ir.MemRefType):
       tpu.log_buffer(arg, ctx.avals_in[0].shape, fmt)  # pytype: disable=attribute-error
     case [arg]:
       tpu.log(inputs=[arg], tag=fmt)
@@ -783,8 +783,8 @@ def _extract_indirect_offsets_from_indexer(
   match indexer.indices:
     case [ir.Value() as offsets, *_] if (
         # fmt: off
-        ir.MemRefType.isinstance(offsets.type) or
-        ir.VectorType.isinstance(offsets.type)
+        mlir.isinstance(offsets.type, ir.MemRefType) or
+        mlir.isinstance(offsets.type, ir.VectorType)
     ):  # fmt: on
       shape = indexer.get_indexer_shape()
       if expected_shape is not None and shape != expected_shape:
@@ -809,7 +809,7 @@ def _extract_indirect_offsets_from_indexer(
     case _:
       return None
 
-  if ir.MemRefType.isinstance(offsets.type):
+  if mlir.isinstance(offsets.type, ir.MemRefType):
     offsets_memory_space = _memref_memory_space(offsets)
     if offsets_memory_space is not MemorySpace.VMEM:
       raise NotImplementedError(

--- a/jax/_src/pallas/mosaic_gpu/primitives.py
+++ b/jax/_src/pallas/mosaic_gpu/primitives.py
@@ -33,6 +33,7 @@ from jax._src import pretty_printer as pp
 from jax._src import state
 from jax._src import tree_util
 from jax._src import util
+from jax._src.interpreters import mlir
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import arith as arith_dialect
 from jax._src.lib.mlir.dialects import builtin as builtin_dialect
@@ -294,13 +295,13 @@ def _split_gmem_slice(gmem_slice):
       case mgpu.DynamicSlice():
         indices.append(arith_dialect.index_cast(i32, idx.base))
         slice_lengths.append(idx.length)
-      case ir.Value() if ir.IndexType.isinstance(idx.type):
+      case ir.Value() if mlir.isinstance(idx.type, ir.IndexType):
         indices.append(arith_dialect.index_cast(i32, idx))
         slice_lengths.append(-1)
-      case ir.Value() if ir.IntegerType.isinstance(idx.type):
+      case ir.Value() if mlir.isinstance(idx.type, ir.IntegerType):
         indices.append(idx)
         slice_lengths.append(-1)
-      case ir.Value() if ir.VectorType.isinstance(idx.type):
+      case ir.Value() if mlir.isinstance(idx.type, ir.VectorType):
         indices.append(idx)
         [length] = ir.VectorType(idx.type).shape
         slice_lengths.append(length)
@@ -2520,7 +2521,7 @@ def _inline_mgpu_discharge(*args, **kwargs):
 
 def _type_check_mgpu_lane_semantics(v, ty):
   match (ty, v):
-    case (RefType(), ir.Value()) if ir.MemRefType.isinstance(v.type):
+    case (RefType(), ir.Value()) if mlir.isinstance(v.type, ir.MemRefType):
       pass
     case (ShapeDtypeStruct(), mgpu.FragmentedArray()):
       mlir_dtype = mgpu_utils.dtype_to_ir_type(ty.dtype)
@@ -2670,9 +2671,9 @@ def _clone_custom_op_with_extra_args(
   with this function is therefore required to restore the isolation property.
   """
   for arg in extra_args:
-    if ir.MemRefType.isinstance(arg.type) and mgpu_utils.is_smem_ref(arg.type):
+    if mlir.isinstance(arg.type, ir.MemRefType) and mgpu_utils.is_smem_ref(arg.type):
       raise ValueError(f"Extra arg {arg} must not be an SMEM ref.")
-    if ir.VectorType.isinstance(arg.type):
+    if mlir.isinstance(arg.type, ir.VectorType):
       raise ValueError(f"Extra arg {arg} must not have a vector type.")
 
   new_operands = list(custom_op.operands) + list(extra_args)
@@ -2785,7 +2786,7 @@ def _populate_custom_primitive_op_block(
     in_transforms_it = iter(in_transforms)
     avals_in = ctx.avals_in[:pytree_args.num_leaves]
     for arg, aval in zip(block.arguments, avals_in, strict=True):
-      if ir.MemRefType.isinstance(arg.type):
+      if mlir.isinstance(arg.type, ir.MemRefType):
         memref_ty = ir.MemRefType(arg.type)
         if not mgpu_utils.is_smem_ref(memref_ty):
           fn_inputs.append(arg)
@@ -2807,7 +2808,7 @@ def _populate_custom_primitive_op_block(
             [transformed_type], [arg]
         )
         fn_inputs.append(conversion_cast.result)
-      elif ir.VectorType.isinstance(arg.type):
+      elif mlir.isinstance(arg.type, ir.VectorType):
         layout_attr = next(in_layouts_it)
         layout = mgpu.layouts.from_layout_attr(layout_attr)
 
@@ -2849,7 +2850,7 @@ def _populate_custom_primitive_op_block(
     ):
       if not isinstance(fa, mgpu.FragmentedArray):
         raise ValueError(f"Expected a FragmentedArray, but got: {fa}")
-      if ir.VectorType.isinstance(result_ty):
+      if mlir.isinstance(result_ty, ir.VectorType):
         result_shape = ir.VectorType(result_ty).shape
         if fa.shape != tuple(result_shape):
           raise ValueError(f"Expected {result_shape} but got {fa.shape}")
@@ -3090,7 +3091,7 @@ def _async_load_tmem_lowering_rule_wg(
     ctx: lowering.LoweringRuleContext, x_ref: ir.Value, *leaves, tree
 ):
   assert isinstance(x_ref, ir.Value)
-  assert ir.MemRefType.isinstance(x_ref.type)
+  assert mlir.isinstance(x_ref.type, ir.MemRefType)
 
   transforms = jax.tree.unflatten(tree, leaves)
   x_tmem, transforms = lowering._handle_transforms(
@@ -3192,9 +3193,9 @@ def _async_store_tmem_lowering_rule_wg(
     tree,
 ):
   assert isinstance(x_ref, ir.Value)
-  assert ir.MemRefType.isinstance(x_ref.type)
+  assert mlir.isinstance(x_ref.type, ir.MemRefType)
   assert isinstance(value, ir.Value)
-  assert ir.VectorType.isinstance(value.type)
+  assert mlir.isinstance(value.type, ir.VectorType)
 
   transforms = jax.tree.unflatten(tree, leaves)
   x_tmem, transforms = lowering._handle_transforms(

--- a/jax/_src/pallas/mosaic_gpu/torch.py
+++ b/jax/_src/pallas/mosaic_gpu/torch.py
@@ -26,6 +26,7 @@ import weakref
 import jax
 import jax.numpy as jnp
 from jax._src import util
+from jax._src.interpreters import mlir
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir import passmanager
 from jax._src.lib.mlir.dialects import func
@@ -96,7 +97,7 @@ def _mlir_to_torch_dtype(torch, mlir_dtype: ir.Type):
     return torch.float16
   if mlir_dtype == ir.BF16Type.get():
     return torch.bfloat16
-  if ir.IntegerType.isinstance(mlir_dtype):
+  if mlir.isinstance(mlir_dtype, ir.IntegerType):
     int_type = ir.IntegerType(mlir_dtype)
     if int_type.is_signed or int_type.is_signless:
       return getattr(torch, f"int{int_type.width}")

--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -159,7 +159,7 @@ def _get_index_alignment(block_mapping: BlockMapping) -> tuple[int, ...]:
 
 
 def _bcast_to(a: ir.Value, shape: tuple[int, ...]) -> ir.Value:
-  if not ir.RankedTensorType.isinstance(a.type):
+  if not mlir.isinstance(a.type, ir.RankedTensorType):
     if not shape:
       return a
     return tt_dialect.splat(ir.RankedTensorType.get(shape, a.type), a)
@@ -485,7 +485,7 @@ def _atomic_rmw(
     semantic: tt_dialect.MemSemantic = tt_dialect.MemSemantic.ACQUIRE_RELEASE,
     sync_scope: tt_dialect.MemSyncScope = tt_dialect.MemSyncScope.GPU,
 ) -> ir.Value:
-  if ir.RankedTensorType.isinstance(ptr.type):
+  if mlir.isinstance(ptr.type, ir.RankedTensorType):
     ptr_type = ir.RankedTensorType(ptr.type)
     element_type = tt_dialect.PointerType(ptr_type.element_type)
     result_type = ir.RankedTensorType.get(
@@ -545,7 +545,7 @@ def _atomic_lowering_rule(
 @register_lowering(primitives.atomic_cas_p)
 def _atomic_cas_lowering_rule(ctx: LoweringRuleContext, ptr, cmp, val):
   _, cmp_aval, val_aval = ctx.avals_in
-  if ir.RankedTensorType.isinstance(ptr.type):
+  if mlir.isinstance(ptr.type, ir.RankedTensorType):
     ptr_type = ir.RankedTensorType(ptr.type)
     element_type = tt_dialect.PointerType(ptr_type.element_type)
     result_type = ir.RankedTensorType.get(
@@ -1142,7 +1142,7 @@ triton_lowering_rules.update({
 
 
 def _minus(x: ir.Value) -> ir.Value:
-  if tt_dialect.PointerType.isinstance(_element_type(x.type)):
+  if mlir.isinstance(_element_type(x.type), tt_dialect.PointerType):
     raise NotImplementedError(f"unsupported type: {x.type}")
   return _sub(_zeros_like(x), x)
 
@@ -1151,10 +1151,10 @@ def _add(x: ir.Value, y: ir.Value):
   x_element_type = _element_type(x.type)
   y_element_type = _element_type(y.type)
 
-  if tt_dialect.PointerType.isinstance(x_element_type):
-    assert not tt_dialect.PointerType.isinstance(y_element_type)
+  if mlir.isinstance(x_element_type, tt_dialect.PointerType):
+    assert not mlir.isinstance(y_element_type, tt_dialect.PointerType)
     return tt_dialect.addptr(x.type, x, y)
-  if tt_dialect.PointerType.isinstance(y_element_type):
+  if mlir.isinstance(y_element_type, tt_dialect.PointerType):
     return tt_dialect.addptr(y.type, y, x)
 
   assert x.type == y.type, (str(x.type), str(y.type))
@@ -1168,9 +1168,9 @@ def _add(x: ir.Value, y: ir.Value):
 def _sub(x: ir.Value, y: ir.Value) -> ir.Value:
   x_element_type = _element_type(x.type)
   y_element_type = _element_type(y.type)
-  if tt_dialect.PointerType.isinstance(x_element_type):
+  if mlir.isinstance(x_element_type, tt_dialect.PointerType):
     return tt_dialect.addptr(x.type, x, _minus(y))
-  elif not tt_dialect.PointerType.isinstance(y_element_type):
+  elif not mlir.isinstance(y_element_type, tt_dialect.PointerType):
     assert x.type == y.type, (str(x.type), str(y.type))
     if isinstance(x_element_type, ir.IntegerType):
       return arith_dialect.subi(x, y)
@@ -1368,7 +1368,7 @@ def debug_print_lowering_rule(
 
 
 def _set_attr(v: ir.Value, name: str, attr: ir.Attribute) -> None:
-  if not ir.BlockArgument.isinstance(v):
+  if not mlir.isinstance(v, ir.BlockArgument):
     v.owner.attributes[name] = attr
     return
 
@@ -1522,7 +1522,7 @@ def _iota_lowering_rule(ctx: LoweringRuleContext, *, dtype, shape, dimension,
 
 
 def _element_type(t: ir.Type) -> ir.Type:
-  if ir.RankedTensorType.isinstance(t):
+  if mlir.isinstance(t, ir.RankedTensorType):
     return ir.RankedTensorType(t).element_type
   else:
     return t
@@ -1551,7 +1551,7 @@ def _full(t: ir.Type, v: object) -> ir.Type:
   else:
     raise NotImplementedError
 
-  if ir.RankedTensorType.isinstance(t):
+  if mlir.isinstance(t, ir.RankedTensorType):
     return tt_dialect.splat(t, result)
   else:
     return result
@@ -1574,7 +1574,7 @@ def _ones_like(x: ir.Value) -> ir.Value:
 
 
 def _splat(x: ir.value, shape: Sequence[int]) -> ir.Value:
-  if ir.RankedTensorType.isinstance(x.type):
+  if mlir.isinstance(x.type, ir.RankedTensorType):
     raise TypeError("cannot splat a tensor")
   if not shape:
     return x
@@ -1582,7 +1582,7 @@ def _splat(x: ir.value, shape: Sequence[int]) -> ir.Value:
 
 
 def _expand_dims(x: ir.Value, axis: int) -> ir.Value:
-  if not ir.RankedTensorType.isinstance(x.type):
+  if not mlir.isinstance(x.type, ir.RankedTensorType):
     shape = list(ir.RankedTensorType(x.type).shape)
     shape.insert(axis, 1)
     return _splat(x, shape)
@@ -1679,9 +1679,7 @@ def _cast(
 
 def _ir_cast(src: ir.Value, dst_type: ir.Type, *,
              signed: bool, dst_signed: bool = False) -> ir.Value:
-  if ir.RankedTensorType.isinstance(
-      src.type
-  ) and not ir.RankedTensorType.isinstance(dst_type):
+  if mlir.isinstance(src.type, ir.RankedTensorType) and not mlir.isinstance(dst_type, ir.RankedTensorType):
     src_type = ir.RankedTensorType(src.type)
     dst_type = ir.RankedTensorType.get(
         src_type.shape,
@@ -1726,7 +1724,7 @@ def _ir_cast(src: ir.Value, dst_type: ir.Type, *,
   ):
     return _int_float_cast(src, dst_type, signed=signed)
 
-  if tt_dialect.PointerType.isinstance(src_element_type) and isinstance(
+  if mlir.isinstance(src_element_type, tt_dialect.PointerType) and isinstance(
       dst_element_type, ir.IntegerType
   ):
     if dst_element_type.width == 64:
@@ -1737,11 +1735,9 @@ def _ir_cast(src: ir.Value, dst_type: ir.Type, *,
       return _ir_cast(_not_equal(x, zero, signed=signed), dst_type, signed=signed)
   if isinstance(
       src_element_type, ir.IntegerType
-  ) and tt_dialect.PointerType.isinstance(dst_element_type):
+  ) and mlir.isinstance(dst_element_type, tt_dialect.PointerType):
     return tt_dialect.int_to_ptr(dst_type, src)
-  if tt_dialect.PointerType.isinstance(
-      src_element_type
-  ) and tt_dialect.PointerType.isinstance(dst_element_type):
+  if mlir.isinstance(src_element_type, tt_dialect.PointerType) and mlir.isinstance(dst_element_type, tt_dialect.PointerType):
     return tt_dialect.bitcast(dst_type, src)
 
   raise NotImplementedError(f"cannot cast {src} to {dst_type}")
@@ -1773,7 +1769,7 @@ def _broadcast_in_dim_lowering_rule(
 ):
   del sharding
   x = _ensure_ir_value(x, *ctx.avals_in)
-  if not ir.RankedTensorType.isinstance(x.type):
+  if not mlir.isinstance(x.type, ir.RankedTensorType):
     return _bcast_to(x, shape)
   expand_dims = [i for i in range(len(shape)) if i not in broadcast_dimensions]
   for dim in expand_dims:
@@ -1805,7 +1801,7 @@ def _reshape_lowering_rule(
 
 
 def _reshape(a: ir.Value, shape: Sequence[int]) -> ir.Value:
-  if not ir.RankedTensorType.isinstance(a.type):
+  if not mlir.isinstance(a.type, ir.RankedTensorType):
     assert all(dim_size == 1 for dim_size in shape)
     return _splat(a, shape)
 
@@ -1929,12 +1925,12 @@ def _compute_offsets_from_indices(
         dim_offsets = _ir_constant(dim_offsets, offset_eltype)
       dim_offsets = _ir_cast(dim_offsets, offset_eltype, signed=False)
 
-      if ir.RankedTensorType.isinstance(dim_offsets.type):
+      if mlir.isinstance(dim_offsets.type, ir.RankedTensorType):
         for _ in other_shape:
           rank = ir.RankedTensorType(dim_offsets.type).rank
           dim_offsets = _expand_dims(dim_offsets, rank)
 
-    if ir.RankedTensorType.isinstance(dim_offsets.type):
+    if mlir.isinstance(dim_offsets.type, ir.RankedTensorType):
       rank = ir.RankedTensorType(dim_offsets.type).rank
       for _ in range(len(indexer_shape) - rank):
         dim_offsets = _expand_dims(dim_offsets, 0)
@@ -1960,7 +1956,7 @@ def _compute_pointers_from_indices(
 @register_lowering(sp.get_p)
 def _get_lowering_rule(ctx: LoweringRuleContext, ptr, *idx, tree):
   indexers = tree_util.tree_unflatten(tree, idx)
-  if not tt_dialect.PointerType.isinstance(ptr.type):
+  if not mlir.isinstance(ptr.type, tt_dialect.PointerType):
     assert len(indexers) == 0
     return ptr
   args_flat, args_tree = tree_util.tree_flatten((ptr, indexers, None, None))
@@ -2003,21 +1999,21 @@ def _load(
           f"unsupported eviction policy: {eviction_policy}"
       ) from None
 
-  if tt_dialect.PointerType.isinstance(ptr.type):
+  if mlir.isinstance(ptr.type, tt_dialect.PointerType):
     ptr_type = tt_dialect.PointerType(ptr.type)
-    if ir.RankedTensorType.isinstance(ptr_type.pointee_type):
+    if mlir.isinstance(ptr_type.pointee_type, ir.RankedTensorType):
       raise NotImplementedError("loading from a block pointer is not supported")
 
   ptr_type = _element_type(ptr.type)
-  if not tt_dialect.PointerType.isinstance(ptr_type):
+  if not mlir.isinstance(ptr_type, tt_dialect.PointerType):
     raise ValueError(f"unsupported pointer type: {ptr_type}")
   ptr_type = tt_dialect.PointerType(ptr_type)
   if other is not None and mask is None:
     raise ValueError("other requires mask to be provided")
-  if not ir.RankedTensorType.isinstance(ptr.type):
-    if other is not None and ir.RankedTensorType.isinstance(other.type):
+  if not mlir.isinstance(ptr.type, ir.RankedTensorType):
+    if other is not None and mlir.isinstance(other.type, ir.RankedTensorType):
       raise ValueError("other cannot be a block if pointer is not a block")
-    if mask is not None and ir.RankedTensorType.isinstance(mask.type):
+    if mask is not None and mlir.isinstance(mask.type, ir.RankedTensorType):
       raise ValueError("mask cannot be a block if pointer is not a block")
 
   pointee_type = ptr_type.pointee_type
@@ -2108,7 +2104,7 @@ def _masked_load_lowering_rule(
     idx = NDIndexer.make_trivial_indexer(ref_shape)
   else:
     idx = indexers[0]
-  if not tt_dialect.PointerType.isinstance(ptr.type):
+  if not mlir.isinstance(ptr.type, tt_dialect.PointerType):
     assert len(ctx.avals_in) == 1
     return ptr
 
@@ -2164,7 +2160,7 @@ def _masked_load_lowering_rule(
 @register_lowering(sp.swap_p)
 def _swap_lowering_rule(ctx: LoweringRuleContext, ptr, value, *idx, tree):
   indexers = tree_util.tree_unflatten(tree, idx)
-  if not tt_dialect.PointerType.isinstance(ptr.type):
+  if not mlir.isinstance(ptr.type, tt_dialect.PointerType):
     assert len(indexers) == 0
     return ptr
   if len(indexers) > 1:
@@ -2199,19 +2195,19 @@ def _store(
           f"unsupported eviction policy: {eviction_policy}"
       ) from None
 
-  if tt_dialect.PointerType.isinstance(ptr.type):
+  if mlir.isinstance(ptr.type, tt_dialect.PointerType):
     ptr_type = tt_dialect.PointerType(ptr.type)
-    if ir.RankedTensorType.isinstance(ptr_type.pointee_type):
+    if mlir.isinstance(ptr_type.pointee_type, ir.RankedTensorType):
       raise NotImplementedError("loading from a block pointer is not supported")
 
   ptr_type = _element_type(ptr.type)
-  if not tt_dialect.PointerType.isinstance(ptr_type):
+  if not mlir.isinstance(ptr_type, tt_dialect.PointerType):
     raise ValueError(f"unsupported pointer type: {ptr_type}")
   ptr_type = tt_dialect.PointerType(ptr_type)
-  if not ir.RankedTensorType.isinstance(ptr.type):
-    if ir.RankedTensorType.isinstance(value.type):
+  if not mlir.isinstance(ptr.type, ir.RankedTensorType):
+    if mlir.isinstance(value.type, ir.RankedTensorType):
       raise ValueError("value cannot be a block if pointer is not a block")
-    if mask is not None and ir.RankedTensorType.isinstance(mask.type):
+    if mask is not None and mlir.isinstance(mask.type, ir.RankedTensorType):
       raise ValueError("mask cannot be a block if pointer is not a block")
 
   pointee_type = ptr_type.pointee_type
@@ -2263,7 +2259,7 @@ def _addupdate_lowering_rule(ctx: LoweringRuleContext, ptr, value, *idx, tree):
   block_info, *_ = ctx.block_infos
   assert block_info is not None
   indexers = tree_util.tree_unflatten(tree, idx)
-  if not tt_dialect.PointerType.isinstance(ptr.type):
+  if not mlir.isinstance(ptr.type, tt_dialect.PointerType):
     assert len(indexers) == 0
     return ptr
   if len(indexers) > 1:
@@ -2911,7 +2907,7 @@ def _bitcast_convert_type_lowering_rule(
     raise NotImplementedError(
         f"cannot cast {operand} to {new_dtype} because of different widths"
     )
-  if ir.RankedTensorType.isinstance(operand.type):
+  if mlir.isinstance(operand.type, ir.RankedTensorType):
     shape = ir.RankedTensorType(operand.type).shape
     result_type = ir.RankedTensorType.get(shape, dst_elem_type)
   else:

--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -468,7 +468,7 @@ call_tf_p.def_effectful_abstract_eval(_call_tf_abstract_eval)
 def _mlir_type_to_numpy_dtype(type: ir.Type) -> np.dtype:
   """Converts an MLIR scalar type to a NumPy dtype."""
 
-  if ir.IntegerType.isinstance(type):
+  if mlir.isinstance(type, ir.IntegerType):
     type = ir.IntegerType(type)
     width = type.width
     if width == 1:
@@ -484,20 +484,20 @@ def _mlir_type_to_numpy_dtype(type: ir.Type) -> np.dtype:
     else:
       raise ValueError(f"Unsupported integer width: {width}")
 
-  elif ir.F16Type.isinstance(type):
+  elif mlir.isinstance(type, ir.F16Type):
     return np.dtype(np.float16)
-  elif ir.F32Type.isinstance(type):
+  elif mlir.isinstance(type, ir.F32Type):
     return np.dtype(np.float32)
-  elif ir.F64Type.isinstance(type):
+  elif mlir.isinstance(type, ir.F64Type):
     return np.dtype(np.float64)
-  elif ir.BF16Type.isinstance(type):
+  elif mlir.isinstance(type, ir.BF16Type):
     return np.dtype(ml_dtypes.bfloat16)
 
-  elif ir.ComplexType.isinstance(type):
+  elif mlir.isinstance(type, ir.ComplexType):
     element_type = ir.ComplexType(type).element_type
-    if ir.F32Type.isinstance(element_type):
+    if mlir.isinstance(element_type, ir.F32Type):
       return np.dtype(np.complex64)
-    elif ir.F64Type.isinstance(element_type):
+    elif mlir.isinstance(element_type, ir.F64Type):
       return np.dtype(np.complex128)
     else:
       raise ValueError(f"Unsupported complex element type: {element_type}")

--- a/jax/experimental/jax2tf/tests/call_tf_test.py
+++ b/jax/experimental/jax2tf/tests/call_tf_test.py
@@ -29,6 +29,7 @@ from jax import numpy as jnp
 from jax._src import config
 from jax._src import dlpack
 from jax._src import test_util as jtu
+from jax._src.interpreters import mlir
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import hlo
 from jax.experimental import jax2tf
@@ -1646,8 +1647,8 @@ class RoundTripToTfTest(tf_test_util.JaxToTfTestCase):
 
           # Verify that the first argument/result of the custom call op is a token
           # type. This is a calling convention defined by `has_token_input_output`.
-          self.assertTrue(hlo.TokenType.isinstance(op.operands[0].type))
-          self.assertTrue(hlo.TokenType.isinstance(op.results[0].type))
+          self.assertTrue(mlir.isinstance(op.operands[0].type, hlo.TokenType))
+          self.assertTrue(mlir.isinstance(op.results[0].type, hlo.TokenType))
 
       stablehlo_module = None
       with self.assertRaisesRegex(

--- a/jax/experimental/mosaic/gpu/dialect_lowering.py
+++ b/jax/experimental/mosaic/gpu/dialect_lowering.py
@@ -26,7 +26,7 @@ import math
 import operator
 from typing import Any, Protocol, cast
 
-from jax._src.interpreters import mlir as mlir_interpreter
+from jax._src.interpreters import mlir
 from jax._src.lib import mosaic_gpu_dialect as mgpu
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import _gpu_ops_gen
@@ -186,7 +186,7 @@ def _default_is_signed(dtype: ir.Type) -> bool | None:
   When converting from Pallas dtype to IR type, we lose the `is_signed`
   information. We can default to `False` for most use cases.
   """
-  return False if ir.IntegerType.isinstance(dtype) else None
+  return False if mlir.isinstance(dtype, ir.IntegerType) else None
 
 
 def _fragmented_array_from_ir(
@@ -212,7 +212,7 @@ def _fragmented_array_from_ir(
     [attr.value for attr in conversion_cast.attributes["registers_shape"]]
   )
 
-  if ir.IntegerType.isinstance(conversion_cast.outputs[0].type.element_type):
+  if mlir.isinstance(conversion_cast.outputs[0].type.element_type, ir.IntegerType):
     is_signed = False if is_signed is None else is_signed
 
   return fa.FragmentedArray(
@@ -298,7 +298,7 @@ def _optimization_barrier_op_lowering_rule(
     _: LoweringContext,
     op: mgpu.OptimizationBarrierOp,
 ) -> Sequence[ir.Value]:
-  if not all(ir.VectorType.isinstance(operand.type) for operand in op.operands):
+  if not all(mlir.isinstance(operand.type, ir.VectorType) for operand in op.operands):
     raise NotImplementedError(
         f"Optimization barrier op {op} has non-vector operands."
     )
@@ -321,7 +321,7 @@ def _optimization_barrier_op_lowering_rule(
 def _arith_constant_op_lowering_rule(
     _: LoweringContext, op: arith.ConstantOp
 ) -> Sequence[ir.Value]:
-  if not ir.DenseElementsAttr.isinstance(op.value):
+  if not mlir.isinstance(op.value, ir.DenseElementsAttr):
     raise NotImplementedError(f"Unsupported constant op: {op}")
 
   value = ir.DenseElementsAttr(op.value)
@@ -582,7 +582,7 @@ def _print_layout_op_lowering_rule(
     ctx: LoweringContext, op: mgpu.PrintLayoutOp
 ) -> Sequence[ir.Value]:
   del ctx
-  if ir.VectorType.isinstance(op.value.type):
+  if mlir.isinstance(op.value.type, ir.VectorType):
     (layout,) = inference_utils.in_layouts(op)
     a = _fragmented_array_from_ir(op.value, layout)
     print(op.format.value.format(pprint_layout(a)))
@@ -674,7 +674,7 @@ def _vector_extract_op_lowering_rule(
   [in_layout] = inference_utils.in_layouts(op)
   a = _fragmented_array_from_ir(op.source, in_layout)
 
-  if not ir.VectorType.isinstance(op.result.type):  # scalar result
+  if not mlir.isinstance(op.result.type, ir.VectorType):  # scalar result
     result = a[tuple(op.static_position)]
     assert isinstance(result.layout, fa.WGSplatFragLayout)
     return [result.registers.item()]
@@ -811,15 +811,15 @@ def swizzle_and_transforms_from_transforms_attr(
   for transform in transforms:
     if swizzle is not None:
       raise ValueError(f"{transforms} contain more transforms after swizzle.")
-    if mgpu.SwizzleTransformAttr.isinstance(transform):
+    if mlir.isinstance(transform, mgpu.SwizzleTransformAttr):
       # TODO(dasenov): Swizzling can change if the ref is sliced in certain
       # ways. We might want to enforce some restrictions here.
       swizzle = mgpu.SwizzleTransformAttr(transform).swizzle
-    elif mgpu.TileTransformAttr.isinstance(transform):
+    elif mlir.isinstance(transform, mgpu.TileTransformAttr):
       tiling = mgpu.TileTransformAttr(transform).tiling
       tiling_transform = launch_context.TileTransform(tuple(tiling))
       gmem_transforms.append(tiling_transform)
-    elif mgpu.TransposeTransformAttr.isinstance(transform):
+    elif mlir.isinstance(transform, mgpu.TransposeTransformAttr):
       permutation = mgpu.TransposeTransformAttr(transform).permutation
       transpose_transform = launch_context.TransposeTransform(
           tuple(permutation)
@@ -921,11 +921,11 @@ def _gmem_slice_and_predicate(
   gmem_slice = []
   predicate = dict(predicate=ctx.single_thread_per_warpgroup_predicate)
   for idx, size in zip(op.indices, op.slice_lengths, strict=True):
-    if ir.IntegerType.isinstance(idx.type):
+    if mlir.isinstance(idx.type, ir.IntegerType):
       idx_int = arith.index_cast(ir.IndexType.get(), idx)
       v = idx_int if size < 0 else utils.DynamicSlice(idx_int, size)
       gmem_slice.append(v)
-    elif ir.VectorType.isinstance(idx.type):
+    elif mlir.isinstance(idx.type, ir.VectorType):
       layout = inference_utils.in_layouts(op)[0]
       assert layouts.from_layout_attr(layout) == fa.TMA_GATHER_INDICES_LAYOUT
       idx_fa = _fragmented_array_from_ir(idx, layout)
@@ -1297,7 +1297,7 @@ def _mgpu_wgmma_op_lowering_rule(
 
   # s8/i8 WGMMA expects signed integer accumulator.
   element_type = wgmma_op.a.type.element_type
-  is_signed = True if ir.IntegerType.isinstance(element_type) else None
+  is_signed = True if mlir.isinstance(element_type, ir.IntegerType) else None
   # TODO(dasenov): Move the value -> accumulator conversion outside of wgmma.
   # The associated fence could be a little expensive and is not needed if the
   # result a wgmma feeds into another wgmma (even in another loop step).
@@ -1306,7 +1306,7 @@ def _mgpu_wgmma_op_lowering_rule(
   )
   acc = wgmma.WGMMAAccumulator.from_registers(regs)
 
-  if ir.VectorType.isinstance(wgmma_op.a.type):
+  if mlir.isinstance(wgmma_op.a.type, ir.VectorType):
     a_transforms = None
     b_transforms = inference_utils.in_transforms(wgmma_op)[0]
     unwrapped_a_ref = None
@@ -1324,7 +1324,7 @@ def _mgpu_wgmma_op_lowering_rule(
       ir.MemRefType(wgmma_op.b.type), b_transforms, b_swizzle, minimum_swizzle
   )
 
-  if ir.VectorType.isinstance(wgmma_op.a.type):
+  if mlir.isinstance(wgmma_op.a.type, ir.VectorType):
     expected_a_layout = (
         fa.WGMMA_LAYOUT_8BIT
         if element_type == ir.IntegerType.get_signless(8)
@@ -1449,7 +1449,7 @@ def _slice_smem(result: ir.Type, offset: ir.Value):
   )
   offset = arith.index_cast(ir.IndexType.get(), offset)
   lowered_result_type = result
-  if ir.MemRefType.isinstance(result):
+  if mlir.isinstance(result, ir.MemRefType):
     memref_ty = ir.MemRefType(result)
     if memref_ty.element_type == ir.Type.parse("!mosaic_gpu.barrier"):
       lowered_result_type = ir.MemRefType.get(
@@ -1878,7 +1878,7 @@ def _swizzle(attrs: Sequence[ir.Attribute]) -> mgpu.SwizzlingMode:
   """Returns the swizzle transform from the given attributes."""
   swizzle = None
   for attr in attrs:
-    if mgpu.SwizzleTransformAttr.isinstance(attr):
+    if mlir.isinstance(attr, mgpu.SwizzleTransformAttr):
       if swizzle is not None:
         raise ValueError("Multiple swizzle transforms are not supported.")
       swizzle = mgpu.SwizzleTransformAttr(attr).swizzle
@@ -1892,7 +1892,7 @@ def _tmem_ref_from_ir(
 
   Throws an error if the annotated layout does not match the expected layout.
   """
-  if not ir.MemRefType.isinstance(ref.type):
+  if not mlir.isinstance(ref.type, ir.MemRefType):
     raise ValueError(f"{ref} is not a memref.")
   mem_ref_ty = ir.MemRefType(ref.type)
 
@@ -2047,7 +2047,7 @@ def _flatten_ir_values(
   result: list[ir.Value] = []
   templates: list[_VectorTemplate | None] = []
   for v in values:
-    if ir.VectorType.isinstance(v.type):
+    if mlir.isinstance(v.type, ir.VectorType):
       fa = _fragmented_array_from_ir(v, next(fa_layouts_it))
       result.extend(fa.registers.flat)
       templates.append((fa.registers.shape, fa.layout, ir.VectorType(v.type)))
@@ -2237,7 +2237,7 @@ def _infer_flat_result_types(
   result_types: list[ir.Type] = []
   out_layouts_it = iter(out_layouts)
   for r in op.results:
-    if not ir.VectorType.isinstance(r.type):
+    if not mlir.isinstance(r.type, ir.VectorType):
       result_types.append(r.type)
       continue
     vec_type = ir.VectorType(r.type)
@@ -2365,7 +2365,7 @@ def lower_mgpu_dialect(
   #
   # A `LaunchContext` should have all the information needed to lower a single
   # kernel.
-  module.context.append_dialect_registry(mlir_interpreter.upstream_dialects)
+  module.context.append_dialect_registry(mlir.upstream_dialects)
   module.context.load_all_available_dialects()
   ctx = _lowering_context(module, launch_context, auto_barriers)
   with ir.InsertionPoint(module.body):

--- a/jax/experimental/mosaic/gpu/inference_utils.py
+++ b/jax/experimental/mosaic/gpu/inference_utils.py
@@ -18,6 +18,7 @@ from collections.abc import Sequence
 from functools import partial
 from typing import cast, Union
 
+from jax._src.interpreters import mlir
 from jax._src.lib.mlir import ir
 
 from . import fragmented_array as fa
@@ -95,7 +96,7 @@ def out_tmem_layouts(op: MlirOperation) -> Sequence[ir.Attribute]:
 def should_have_in_tmem_layout(op: MlirOperation) -> bool:
   """Returns 'true' if the operation operands should be assigned a TMEM layout."""
   return any(
-      ir.MemRefType.isinstance(v.type) and utils.is_tmem_ref(v)
+      mlir.isinstance(v.type, ir.MemRefType) and utils.is_tmem_ref(v)
       for v in op.operands
   )
 
@@ -103,7 +104,7 @@ def should_have_in_tmem_layout(op: MlirOperation) -> bool:
 def should_have_out_tmem_layout(op: MlirOperation) -> bool:
   """Returns 'true' if the operation results should be assigned a TMEM layout."""
   return any(
-      ir.MemRefType.isinstance(v.type) and utils.is_tmem_ref(v)
+      mlir.isinstance(v.type, ir.MemRefType) and utils.is_tmem_ref(v)
       for v in op.results
   )
 
@@ -123,12 +124,12 @@ def has_out_tmem_layouts_set(op: MlirOperation) -> bool:
 
 def should_have_in_layout(op: MlirOperation) -> bool:
   """Returns 'true' if the operation operands should be assigned a layout."""
-  return any(ir.VectorType.isinstance(v.type) for v in op.operands)
+  return any(mlir.isinstance(v.type, ir.VectorType) for v in op.operands)
 
 
 def should_have_out_layout(op: MlirOperation) -> bool:
   """Returns 'true' if the operation results should be assigned a layout."""
-  return any(ir.VectorType.isinstance(v.type) for v in op.results)
+  return any(mlir.isinstance(v.type, ir.VectorType) for v in op.results)
 
 
 def should_have_layout(op: MlirOperation) -> bool:
@@ -178,7 +179,7 @@ def _in_attr_for_operand(
     attr_name: str,
 ) -> ir.Attribute | None:
   if attr_name == "in_layouts":
-    predicate = lambda v: ir.VectorType.isinstance(v.type)
+    predicate = lambda v: mlir.isinstance(v.type, ir.VectorType)
   elif attr_name == "in_transforms":
     predicate = is_transformable_smem_memref
   else:
@@ -216,7 +217,7 @@ def is_transformable_smem_memref(v: ir.Value) -> bool:
   """Whether the value is a memref in SMEM on which transforms should be applied."""
   barrier_ty = ir.Type.parse("!mosaic_gpu.barrier")
   return (
-      ir.MemRefType.isinstance(v.type)
+      mlir.isinstance(v.type, ir.MemRefType)
       # barriers have no business being transformed
       and v.type.element_type != barrier_ty  # pylint: disable=attribute-error
       and utils.is_smem_ref(v)
@@ -225,7 +226,7 @@ def is_transformable_smem_memref(v: ir.Value) -> bool:
 
 def _value_attr(value: ir.Value, attr_type: str) -> ir.Attribute | None:
   if attr_type == "layouts":
-    predicate = lambda v: ir.VectorType.isinstance(v.type)
+    predicate = lambda v: mlir.isinstance(v.type, ir.VectorType)
   elif attr_type == "transforms":
     predicate = is_transformable_smem_memref
   else:
@@ -264,7 +265,7 @@ def value_layout(value: ir.Value) -> ir.Attribute | None:
   Raises:
     ValueError: If `result` is not a Vector.
   """
-  if not ir.VectorType.isinstance(value.type):
+  if not mlir.isinstance(value.type, ir.VectorType):
     raise ValueError(f"{value} is not a vector.")
 
   return _value_attr(value, "layouts")
@@ -276,7 +277,7 @@ def value_transforms(value: ir.Value) -> ir.Attribute | None:
   Raises:
     ValueError: If `result` is not a memref.
   """
-  if not ir.MemRefType.isinstance(value.type):
+  if not mlir.isinstance(value.type, ir.MemRefType):
     raise ValueError(f"{value} is not a memref.")
 
   return _value_attr(value, "transforms")

--- a/jax/experimental/mosaic/gpu/launch_context.py
+++ b/jax/experimental/mosaic/gpu/launch_context.py
@@ -21,6 +21,7 @@ import functools
 import math
 from typing import Any, Literal
 
+from jax._src.interpreters import mlir
 from jax._src.lib import mosaic_gpu_dialect as mgpu_dialect
 from jaxlib.mlir import ir
 from jaxlib.mlir.dialects import _gpu_ops_gen
@@ -482,7 +483,7 @@ def _tma_dma_type(
     reduction_op: TMAReductionOp | None,
 ) -> int:
   """Returns the TMA DMA type for the given element type and signedness."""
-  if ir.IntegerType.isinstance(element_type):
+  if mlir.isinstance(element_type, ir.IntegerType):
     bitwidth = utils.bitwidth_impl(element_type)
     if bitwidth == 2:
       tma_dtype = 8
@@ -498,20 +499,20 @@ def _tma_dma_type(
       tma_dtype = 10 if reduction_op in ("smin", "smax") else 4
     else:
       raise ValueError(f"Unsupported integer bitwidth: {bitwidth}")
-  elif ir.F16Type.isinstance(element_type):
+  elif mlir.isinstance(element_type, ir.F16Type):
     tma_dtype = 5
-  elif ir.F32Type.isinstance(element_type):
+  elif mlir.isinstance(element_type, ir.F32Type):
     tma_dtype = 6
-  elif ir.BF16Type.isinstance(element_type):
+  elif mlir.isinstance(element_type, ir.BF16Type):
     tma_dtype = 7
   # We treat narrow floats as integers
-  elif ir.Float8E5M2Type.isinstance(element_type):
+  elif mlir.isinstance(element_type, ir.Float8E5M2Type):
     tma_dtype = 1
-  elif ir.Float8E4M3FNType.isinstance(element_type):
+  elif mlir.isinstance(element_type, ir.Float8E4M3FNType):
     tma_dtype = 1
-  elif ir.Float8E8M0FNUType.isinstance(element_type):
+  elif mlir.isinstance(element_type, ir.Float8E8M0FNUType):
     tma_dtype = 1
-  elif ir.Float4E2M1FNType.isinstance(element_type):
+  elif mlir.isinstance(element_type, ir.Float4E2M1FNType):
     tma_dtype = 0
   else:
     raise ValueError(f"unsupported TMA dtype {element_type}")
@@ -732,7 +733,7 @@ class LaunchContext:
       if len(gather_indices.shape) != 1:
         raise ValueError("Gather/scatter indices must be 1D")
       idx_dtype = gather_indices.mlir_dtype
-      if not ir.IntegerType.isinstance(idx_dtype) or utils.bitwidth(idx_dtype) > 32:
+      if not mlir.isinstance(idx_dtype, ir.IntegerType) or utils.bitwidth(idx_dtype) > 32:
         raise ValueError("Gather/scatter indices must be integers that are at most 32-bit wide")
       if gather_indices.is_signed:
         raise ValueError("Gather/scatter indices must be unsigned")
@@ -1105,7 +1106,7 @@ class LaunchContext:
       offset_scale = 1 if element_bitwidth >= 8 else 8 // element_bitwidth
       if element_bitwidth < 8:
         gep_type = i8
-      elif ir.FloatType.isinstance(element_type) and ir.FloatType(element_type).width == 8:
+      elif mlir.isinstance(element_type, ir.FloatType) and ir.FloatType(element_type).width == 8:
         gep_type = i8  # LLVM has no support for f8.
       else:
         gep_type = element_type
@@ -1506,7 +1507,7 @@ class LaunchContext:
 
   def to_remote(self, ref: ir.Value, peer: ir.Value):
     self._ensure_nvshmem_decls()
-    if ir.MemRefType.isinstance(ref.type):
+    if mlir.isinstance(ref.type, ir.MemRefType):
       # We replace the offset in the ref type by 0, because memref_ptr always
       # folds the offset into the pointer.
       ref_ty = ir.MemRefType(ref.type)
@@ -1529,7 +1530,7 @@ class LaunchContext:
   def to_remote_multicast(self, ref: ir.Value):
     i32 = ir.IntegerType.get_signless(32)
     self._ensure_nvshmem_decls()
-    if not ir.MemRefType.isinstance(ref.type):
+    if not mlir.isinstance(ref.type, ir.MemRefType):
       raise ValueError(f"Unsupported type for to_remote_multicast: {ref.type}")
       # We replace the offset in the ref type by 0, because memref_ptr always
       # folds the offset into the pointer.

--- a/jax/experimental/mosaic/gpu/layout_inference.py
+++ b/jax/experimental/mosaic/gpu/layout_inference.py
@@ -29,6 +29,7 @@ import re
 from typing import assert_never, cast
 
 from absl import logging
+from jax._src.interpreters import mlir
 from jax._src.lib import mosaic_gpu_dialect as mgpu  # noqa: F401
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import arith
@@ -124,9 +125,9 @@ class ValueSite:
   def memory_space(self) -> MemorySpace:
     """Returns the memory space associated with this value."""
     type = self.value.type
-    if ir.VectorType.isinstance(type):
+    if mlir.isinstance(type, ir.VectorType):
       return MemorySpace.REG
-    assert ir.MemRefType.isinstance(type)
+    assert mlir.isinstance(type, ir.MemRefType)
     if utils.is_tmem_ref(type):
       return MemorySpace.TMEM
     elif utils.is_smem_ref(type):
@@ -178,7 +179,7 @@ def _strided_layout_for_variable(
   # TODO(bchetioui): should we make variables carry a shape as well, to make
   # things easier?
   type = variable.key.value.type
-  assert ir.VectorType.isinstance(type)
+  assert mlir.isinstance(type, ir.VectorType)
   return fa.WGStridedFragLayout.from_shaped_type(type)
 
 
@@ -487,15 +488,15 @@ def _add_constraint_system_derivation_rule(op: type[ir.OpView]):
 
 
 def is_vector(v: ir.Value) -> bool:
-  return ir.VectorType.isinstance(v.type)
+  return mlir.isinstance(v.type, ir.VectorType)
 
 
 def _is_smem_ref(v: ir.Value) -> bool:
-  return ir.MemRefType.isinstance(v.type) and utils.is_smem_ref(v)
+  return mlir.isinstance(v.type, ir.MemRefType) and utils.is_smem_ref(v)
 
 
 def _is_tmem_ref(v: ir.Value) -> bool:
-  return ir.MemRefType.isinstance(v.type) and utils.is_tmem_ref(v)
+  return mlir.isinstance(v.type, ir.MemRefType) and utils.is_tmem_ref(v)
 
 
 def _pointwise_op_constraint_system(
@@ -691,7 +692,7 @@ def _constant_constraint_system(
   variable = cs.Variable(result)
   shape = tuple(ir.ShapedType(constant_op.result.type).shape)
   if (
-      ir.DenseElementsAttr.isinstance(value)
+      mlir.isinstance(value, ir.DenseElementsAttr)
       and ir.DenseElementsAttr(value).is_splat
   ):
     layout = fa.WGSplatFragLayout(shape=shape)
@@ -770,11 +771,11 @@ def prime_decomposition(n: int) -> list[int]:
 def dynamic_gcd(a: int, b: ir.Value) -> int:
   if a <= 0:
     raise ValueError("a must be strictly positive")
-  if ir.VectorType.isinstance(b.type):
+  if mlir.isinstance(b.type, ir.VectorType):
     # We don't actually know the values of the vector elements, so we pick 1
     # as the only safe value.
     return 1
-  if not ir.IntegerType.isinstance(b.type) and not ir.IndexType.isinstance(b.type):
+  if not mlir.isinstance(b.type, ir.IntegerType) and not mlir.isinstance(b.type, ir.IndexType):
     raise ValueError(f"Expected an integer dynamic value, got a {b.type}")
   if isinstance(b.owner, arith.ConstantOp):
     return math.gcd(a, b.owner.literal_value)
@@ -913,7 +914,7 @@ def _infer_wgmma_tiling(
       b_type, max_swizzle=mgpu.SwizzlingMode.k128ByteSwizzle
   )
   b_swizzle = _compute_swizzle(b_type, lc.TileTransform(b_tiling))
-  if not ir.MemRefType.isinstance(a_type):
+  if not mlir.isinstance(a_type, ir.MemRefType):
     return None, b_tiling
 
   a_tiling = _infer_tiling_for_mma_ref(
@@ -985,7 +986,7 @@ def _vector_broadcast_constraint_system(
   del ctx
   # This is not expected to be necessary at the moment. We should be using
   # mgpu.BroadcastInDimOp instead when dealing with broadcasting vectors.
-  if ir.ShapedType.isinstance(op.source.type):
+  if mlir.isinstance(op.source.type, ir.ShapedType):
     raise NotImplementedError("Only vector broadcasts from scalars are supported.")
   out_variable = cs.Variable(ValueSite(op, VariableType.RESULT, 0))
   layout = cs.RegisterLayout(fa.WGSplatFragLayout(tuple(op.result.type.shape)))
@@ -1142,7 +1143,7 @@ def _vector_extract_constraint_system(
     ctx: DerivationContext, op: vector.ExtractOp
 ) -> tuple[cs.ConstraintSystem, ValueSitesForVariable]:
   del ctx
-  if not ir.VectorType.isinstance(op.result.type):  # scalar result
+  if not mlir.isinstance(op.result.type, ir.VectorType):  # scalar result
     operand = ValueSite(op, VariableType.OPERAND, 0)
     variable = cs.Variable(operand)
     layout = fa.WGSplatFragLayout(tuple(op.source.type.shape))
@@ -1207,7 +1208,7 @@ def _custom_primitive_constraint_system(
 
   out_layouts = iter(op.out_layouts)
   for i, result in enumerate(op.results):
-    if ir.VectorType.isinstance(result.type):
+    if mlir.isinstance(result.type, ir.VectorType):
       v = cs.Variable(ValueSite(op, VariableType.RESULT, i))
       variables.append(v)
       assignments[v] = cs.RegisterLayout(
@@ -1609,7 +1610,7 @@ def _vector_value_sites_and_assignments_for_async_ops(
       raise ValueError(f"Unsupported op type: {op}")  # make pytype happy
 
   for i, idx in enumerate(op.indices):
-    if ir.VectorType.isinstance(idx.type):
+    if mlir.isinstance(idx.type, ir.VectorType):
       value_site = ValueSite(op, VariableType.OPERAND, base_operand_index + i)
       value_site_var = cs.Variable(value_site)
       layout = cs.RegisterLayout(value=fa.TMA_GATHER_INDICES_LAYOUT)
@@ -1698,7 +1699,7 @@ def _compute_swizzle(
     # TODO(b/447079781): Revisit if this is the behavior we want.
     return mgpu.SwizzlingMode.kNoSwizzle
 
-  if not ir.MemRefType.isinstance(type):
+  if not mlir.isinstance(type, ir.MemRefType):
     raise ValueError(f"Expected a MemRefType, got {type}.")
   ref_ty = ir.MemRefType(type)
   strides, _ = ref_ty.get_strides_and_offset()

--- a/jax/experimental/mosaic/gpu/tcgen05.py
+++ b/jax/experimental/mosaic/gpu/tcgen05.py
@@ -21,6 +21,7 @@ import itertools
 import math
 from typing import Any, Callable, Iterator, cast
 
+from jax._src.interpreters import mlir
 from jaxlib.mlir import ir
 from jaxlib.mlir.dialects import arith
 from jaxlib.mlir.dialects import llvm
@@ -196,7 +197,7 @@ def mma(
     raise NotImplementedError("Block-scaled sparse matmuls unsupported")
 
   # Step 1. Establish the shape and element type of the operation.
-  if not ir.MemRefType.isinstance(b.type):
+  if not mlir.isinstance(b.type, ir.MemRefType):
     raise ValueError(f"B must be a memref, got: {b.type}")
   (k, n), element_type = mma_utils.tiled_memref_shape(b)
   if isinstance(a, TMEMRef):
@@ -218,7 +219,7 @@ def mma(
           f"A layout mismatch: expected {expected_layout}, got {a.layout}"
       )
   else:
-    if not ir.MemRefType.isinstance(a.type):
+    if not mlir.isinstance(a.type, ir.MemRefType):
       raise ValueError(f"A must be a memref, got {a.type}")
     (m, k2), element_type2 = mma_utils.tiled_memref_shape(a)
   if is_sparse:
@@ -294,7 +295,7 @@ def mma(
           f" type f32 or f16, but got: {d.dtype}"
       )
   elif any(
-      t.isinstance(element_type)
+      mlir.isinstance(element_type, t)
       for t in {ir.Float8E5M2Type, ir.Float8E4M3FNType}
   ):
     if d.dtype != f16 and d.dtype != f32:
@@ -308,7 +309,7 @@ def mma(
           f" accumulators, but got: {d.dtype}"
       )
   elif any(
-      t.isinstance(element_type) for t in {ir.Float4E2M1FNType}
+      mlir.isinstance(element_type, t) for t in {ir.Float4E2M1FNType}
   ):
     if is_sparse:
       raise NotImplementedError("Sparse MMA unsupported for f4e2m1fn")
@@ -595,8 +596,8 @@ def _do_mma(
   scale_steps = None
   if is_scaled:
     assert not is_sparse
-    if (ir.Float8E5M2Type.isinstance(element_type) or
-        ir.Float8E4M3FNType.isinstance(element_type)):
+    if (mlir.isinstance(element_type, ir.Float8E5M2Type) or
+        mlir.isinstance(element_type, ir.Float8E4M3FNType)):
       if scale_element_type != ir.Float8E8M0FNUType.get():
         raise ValueError(
             f"Scale element type mismatch: expected f8e8m0fnu, got {scale_element_type}"
@@ -606,7 +607,7 @@ def _do_mma(
       create_scaled_instr_descriptor = functools.partial(
           create_scaled_f8f6f4_instr_descriptor, scale_type=scale_element_type
       )
-    elif ir.Float4E2M1FNType.isinstance(element_type):
+    elif mlir.isinstance(element_type, ir.Float4E2M1FNType):
       assert not a_transpose and not b_transpose
       create_scaled_instr_descriptor = functools.partial(
           create_scaled_f4_instr_descriptor,
@@ -623,13 +624,13 @@ def _do_mma(
     extra_ptx = "[$5], [$6], "
     extra_constraints = ",r,r"
   else:
-    if ir.F16Type.isinstance(element_type) or ir.BF16Type.isinstance(element_type):
+    if mlir.isinstance(element_type, ir.F16Type) or mlir.isinstance(element_type, ir.BF16Type):
       kind = "f16"
-    elif ir.Float8E5M2Type.isinstance(element_type):
+    elif mlir.isinstance(element_type, ir.Float8E5M2Type):
       kind = "f8f6f4"
-    elif ir.Float8E4M3FNType.isinstance(element_type):
+    elif mlir.isinstance(element_type, ir.Float8E4M3FNType):
       kind = "f8f6f4"
-    elif ir.IntegerType.get_signless(8).isinstance(element_type):
+    elif mlir.isinstance(element_type, ir.IntegerType.get_signless(8)):
       kind = "i8"
     else:
       raise NotImplementedError(f"Unsupported input element type: {element_type}")
@@ -777,7 +778,7 @@ def tmem_alloc_exact_ncols(ncols: int, exact: bool) -> int:
 
 
 def tmem_alloc(tmem_addr: ir.Value, ncols: int, collective: bool = False, exact: bool = True) -> tuple[ir.Value, int]:
-  if ir.MemRefType.isinstance(tmem_addr.type):
+  if mlir.isinstance(tmem_addr.type, ir.MemRefType):
     ref_ty = ir.MemRefType(tmem_addr.type)
     if ref_ty.element_type != ir.IntegerType.get_signless(32):
       raise ValueError(f"tmem_addr must be an i32 memref, got: {ref_ty}")
@@ -1070,7 +1071,7 @@ class TMEMRef:
       layout: TMEMLayout | None = None,
   ) -> TMEMRef:
     i32 = ir.IntegerType.get_signless(32)
-    if not ir.MemRefType.isinstance(tmem_addr_ref.type):
+    if not mlir.isinstance(tmem_addr_ref.type, ir.MemRefType):
       raise ValueError(f"tmem_addr_ref must be a memref or a pointer, got: {tmem_addr_ref.type}")
     addr_ref_ty = ir.MemRefType(tmem_addr_ref.type)
     if not utils.is_smem_ref(addr_ref_ty):

--- a/jax/experimental/mosaic/gpu/utils.py
+++ b/jax/experimental/mosaic/gpu/utils.py
@@ -25,7 +25,7 @@ from typing import Any, Literal
 import jax
 from jax import numpy as jnp
 from jax._src.lib import mosaic_gpu_dialect as dialect  # noqa: F401
-from jax.interpreters import mlir
+from jax._src.interpreters import mlir
 from jaxlib.mlir import ir
 from jaxlib.mlir.dialects import _gpu_ops_gen
 from jaxlib.mlir.dialects import arith
@@ -121,13 +121,13 @@ def get_contiguous_strides(xs):
 
 
 def c(val: int | float, ty):
-  if ir.IntegerType.isinstance(ty) or ir.IndexType.isinstance(ty):
+  if mlir.isinstance(ty, ir.IntegerType) or mlir.isinstance(ty, ir.IndexType):
     if not isinstance(val, (int, np.integer)):
       raise TypeError(type(val))
     attr = ir.IntegerAttr.get(ty, val)
-  elif ir.FloatType.isinstance(ty):
+  elif mlir.isinstance(ty, ir.FloatType):
     attr = ir.FloatAttr.get(ty, val)
-  elif ir.VectorType.isinstance(ty):
+  elif mlir.isinstance(ty, ir.VectorType):
     return vector.broadcast(ty, c(val, ir.VectorType(ty).element_type))
   else:
     raise NotImplementedError(ty)
@@ -135,15 +135,15 @@ def c(val: int | float, ty):
 
 
 def _debug_scalar_ty_format(arg):
-  if ir.IndexType.isinstance(arg.type):
+  if mlir.isinstance(arg.type, ir.IndexType):
     return "%llu", arg
-  if ir.IntegerType.isinstance(arg.type):
+  if mlir.isinstance(arg.type, ir.IntegerType):
     if ir.IntegerType(arg.type).width < 64:
       arg = arith.extui(ir.IntegerType.get_signless(64), arg)
     return "%llu", arg
-  if ir.F32Type.isinstance(arg.type):
+  if mlir.isinstance(arg.type, ir.F32Type):
     return "%f", arg
-  if ir.BF16Type.isinstance(arg.type) or ir.F16Type.isinstance(arg.type):
+  if mlir.isinstance(arg.type, ir.BF16Type) or mlir.isinstance(arg.type, ir.F16Type):
     arg = arith.extf(ir.F32Type.get(), arg)
     return "%f", arg
   raise NotImplementedError(f"Can't print the type {arg.type}")
@@ -157,7 +157,7 @@ def debug_print(fmt, *args, uniform=True, scope=None):
   type_formats = []
   new_args = []
   for arg in args:
-    if ir.VectorType.isinstance(arg.type):
+    if mlir.isinstance(arg.type, ir.VectorType):
       index = ir.IndexType.get()
       vec_ty = ir.VectorType(arg.type)
       if len(vec_ty.shape) > 1:
@@ -244,13 +244,13 @@ def multimem_load_reduce(
   i32 = ir.IntegerType.get_signless(32)
   if bitwidth(ty) not in {32, 64, 128}:
     raise ValueError("Only 32-, 64- and 128-bit loads are supported")
-  if ir.VectorType.isinstance(ty):
+  if mlir.isinstance(ty, ir.VectorType):
     vty = ir.VectorType(ty)
     if len(vty.shape) > 1:
       raise ValueError("Only 1D vectors are supported")
     vector_length = vty.shape[0]
     vector_i32_length = vector_length * bitwidth(vty.element_type) // 32
-    if ir.IntegerType.isinstance(vty.element_type):
+    if mlir.isinstance(vty.element_type, ir.IntegerType):
       # TODO(apaszke): Emulate this by unrolling.
       if vector_length != 1:
         raise NotImplementedError(
@@ -271,20 +271,20 @@ def multimem_load_reduce(
         ptx_ty = f"{'s' if is_signed else 'u'}{bitwidth(vty.element_type)}"
       else:
         raise ValueError(f"Unsupported reduction operation: {reduction}")
-    elif ir.FloatType.isinstance(vty.element_type):
+    elif mlir.isinstance(vty.element_type, ir.FloatType):
       if reduction not in {"add", "min", "max"}:
         raise ValueError("Only add, min and max are supported for floats")
-      if ir.F32Type.isinstance(vty.element_type):
+      if mlir.isinstance(vty.element_type, ir.F32Type):
         if reduction != "add":
           raise ValueError("Only add is supported for f32")
         ptx_ty = "f32"
-      elif ir.BF16Type.isinstance(vty.element_type):
+      elif mlir.isinstance(vty.element_type, ir.BF16Type):
         ptx_ty = "bf16x2"
-      elif ir.F16Type.isinstance(vty.element_type):
+      elif mlir.isinstance(vty.element_type, ir.F16Type):
         ptx_ty = "f16x2"
-      elif ir.Float8E5M2Type.isinstance(vty.element_type):
+      elif mlir.isinstance(vty.element_type, ir.Float8E5M2Type):
         ptx_ty = "e5m2x4"
-      elif ir.Float8E4M3FNType.isinstance(vty.element_type):
+      elif mlir.isinstance(vty.element_type, ir.Float8E4M3FNType):
         ptx_ty = "e4m3x4"
       else:
         raise NotImplementedError(vty.element_type)
@@ -517,15 +517,15 @@ def bitwidth_impl(ty: ir.Type):
   # 32 bits for compatibility reasons. TF32 used to be 32 bits wide in upstream
   # MLIR, but it changed in
   # https://github.com/llvm/llvm-project/commit/67a1fdb014790a38a205d28e1748634de34471dd.
-  if ir.FloatTF32Type.isinstance(ty):
+  if mlir.isinstance(ty, ir.FloatTF32Type):
     return 32
-  if ir.IntegerType.isinstance(ty):
+  if mlir.isinstance(ty, ir.IntegerType):
     return ir.IntegerType(ty).width
-  if ir.FloatType.isinstance(ty):
+  if mlir.isinstance(ty, ir.FloatType):
     return ir.FloatType(ty).width
   if dialect is not None and ty == ir.Type.parse("!mosaic_gpu.barrier"):
     return MBARRIER_BYTES * 8
-  if ir.VectorType.isinstance(ty):
+  if mlir.isinstance(ty, ir.VectorType):
     vty = ir.VectorType(ty)
     return math.prod(vty.shape) * bitwidth(vty.element_type)
   raise NotImplementedError(ty)
@@ -591,7 +591,7 @@ def _is_contiguous_shape_slice(
     ref_ty: ir.MemRefType, dim_slice: slice | None = slice(None)
 ):
   # If it's not a strided layout then we are definitely contiguous.
-  if not ir.StridedLayoutAttr.isinstance(ref_ty.layout):
+  if not mlir.isinstance(ref_ty.layout, ir.StridedLayoutAttr):
     return True
 
   strides = ir.StridedLayoutAttr(ref_ty.layout).strides[dim_slice]
@@ -921,7 +921,7 @@ def parse_indices(
       slice_shape.append(idx.length)
       is_squeezed.append(False)
     elif isinstance(idx, ir.Value):
-      if not ir.IndexType.isinstance(idx.type):
+      if not mlir.isinstance(idx.type, ir.IndexType):
         raise ValueError("Expected an index-typed index")
       base_indices.append(idx)
       slice_shape.append(1)
@@ -999,7 +999,7 @@ class BarrierRef:
       if offset >= self.num_barriers:
         raise IndexError(f"Barrier offset {offset} is out of bounds")
       offset = c(offset, i32)
-    elif ir.IndexType.isinstance(offset.type):
+    elif mlir.isinstance(offset.type, ir.IndexType):
       offset = arith.index_castui(i32, offset)
     elif offset.type != i32:
       raise ValueError(f"Expected a dynamic index or an integer, got {offset}")
@@ -1080,7 +1080,7 @@ class BarrierRef:
   ):
     if isinstance(bytes, int):
       bytes = c(bytes, ir.IntegerType.get_signless(32))
-    elif ir.IndexType.isinstance(bytes.type):
+    elif mlir.isinstance(bytes.type, ir.IndexType):
       i32 = ir.IntegerType.get_signless(32)
       bytes = arith.index_cast(i32, bytes)
     nvvm_mbarrier_arrive_expect_tx(
@@ -1767,7 +1767,7 @@ def bitcast(x: ir.Value, new_type: ir.Type):
         f"Can't bitcast {x.type} (of bitwidth {x_bw}) to {new_type} (of"
         f" bitwidth {new_bw})"
     )
-  if ir.VectorType.isinstance(x.type) and ir.IntegerType.isinstance(new_type):
+  if mlir.isinstance(x.type, ir.VectorType) and mlir.isinstance(new_type, ir.IntegerType):
     new_type = ir.IntegerType(new_type)
     x_ty = ir.VectorType(x.type)
     assert new_type.width == bitwidth(x_ty.element_type) * math.prod(x_ty.shape)
@@ -1776,7 +1776,7 @@ def bitcast(x: ir.Value, new_type: ir.Type):
         dynamic_position=[],
         static_position=ir.DenseI64ArrayAttr.get([0]),
     )
-  if ir.IntegerType.isinstance(x.type) and ir.VectorType.isinstance(new_type):
+  if mlir.isinstance(x.type, ir.IntegerType) and mlir.isinstance(new_type, ir.VectorType):
     new_type = ir.VectorType(new_type)
     x_ty = ir.IntegerType(x.type)
     assert x_ty.width == bitwidth(new_type.element_type) * math.prod(
@@ -1785,17 +1785,17 @@ def bitcast(x: ir.Value, new_type: ir.Type):
     return vector.bitcast(
         new_type, vector.broadcast(ir.VectorType.get((1,), x_ty), x)
     )
-  if ir.VectorType.isinstance(x.type) and ir.VectorType.isinstance(new_type):
+  if mlir.isinstance(x.type, ir.VectorType) and mlir.isinstance(new_type, ir.VectorType):
     x_ty = ir.VectorType(x.type)
     new_ty = ir.VectorType(new_type)
     if bitwidth(x_ty) != bitwidth(new_ty):
       raise ValueError(f"Can't bitcast {x.type} to {new_type}")
     return vector.bitcast(new_type, x)
-  if ir.IntegerType.isinstance(x.type) and ir.FloatType.isinstance(new_type):
+  if mlir.isinstance(x.type, ir.IntegerType) and mlir.isinstance(new_type, ir.FloatType):
     return arith.bitcast(new_type, x)
-  if ir.FloatType.isinstance(x.type) and ir.IntegerType.isinstance(new_type):
+  if mlir.isinstance(x.type, ir.FloatType) and mlir.isinstance(new_type, ir.IntegerType):
     return arith.bitcast(new_type, x)
-  if ir.FloatType.isinstance(x.type) and ir.FloatType.isinstance(new_type):
+  if mlir.isinstance(x.type, ir.FloatType) and mlir.isinstance(new_type, ir.FloatType):
     return arith.bitcast(new_type, x)
   raise ValueError(f"Can't bitcast {x.type} to {new_type}")
 
@@ -1823,7 +1823,7 @@ def vector_concat(vectors: Sequence[ir.Value]) -> ir.Value:
   if not vectors:
     raise ValueError("Cannot concatenate an empty list of vectors")
   vty = vectors[0].type
-  if not ir.VectorType.isinstance(vty):
+  if not mlir.isinstance(vty, ir.VectorType):
     raise ValueError("Cannot concatenate non-vector values")
   vty = ir.VectorType(vty)
   if vty.rank != 1:
@@ -1913,7 +1913,7 @@ def is_smem_ref(ref: ir.Value | ir.Type) -> bool:
   """
   if isinstance(ref, ir.Value):
     ref = ref.type
-  if not ir.MemRefType.isinstance(ref):
+  if not mlir.isinstance(ref, ir.MemRefType):
     raise ValueError(f"Expected a memref type but got {ref}")
   ref = ir.MemRefType(ref)
   return ref.memory_space is not None and ref.memory_space == smem()
@@ -1926,7 +1926,7 @@ def is_tmem_ref(ref: ir.Value | ir.Type) -> bool:
   """
   if isinstance(ref, ir.Value):
     ref = ref.type
-  if not ir.MemRefType.isinstance(ref):
+  if not mlir.isinstance(ref, ir.MemRefType):
     raise ValueError(f"Expected a memref type but got {ref}")
   ref = ir.MemRefType(ref)
   return ref.memory_space is not None and ref.memory_space == tmem()

--- a/jax/experimental/mosaic/gpu/wgmma.py
+++ b/jax/experimental/mosaic/gpu/wgmma.py
@@ -18,6 +18,7 @@ import itertools
 import math
 
 import jax
+from jax._src.interpreters import mlir
 from jaxlib.mlir import ir
 from jaxlib.mlir.dialects import arith
 from jaxlib.mlir.dialects import llvm
@@ -72,7 +73,7 @@ class WGMMAAccumulator:
     f32 = ir.F32Type.get()
     if dtype is None:
       dtype = f32
-    if ir.IntegerType.isinstance(dtype):
+    if mlir.isinstance(dtype, ir.IntegerType):
       zero = arith.constant(dtype, ir.IntegerAttr.get(dtype, 0))
     else:
       zero = arith.constant(dtype, ir.FloatAttr.get(dtype, 0.0))
@@ -100,13 +101,13 @@ class WGMMAAccumulator:
 
 
 def _supported_wgmma_types(dtype, abtype) -> bool:
-  input_types_are = lambda ty: ty.isinstance(abtype)
+  input_types_are = lambda ty: mlir.isinstance(abtype, ty)
   f16_acc_types = (ir.F16Type, ir.Float8E5M2Type, ir.Float8E4M3FNType)
-  if ir.F32Type.isinstance(dtype):
+  if mlir.isinstance(dtype, ir.F32Type):
     return any(input_types_are(ty) for ty in (ir.FloatTF32Type, ir.BF16Type, *f16_acc_types))
-  elif ir.F16Type.isinstance(dtype):
+  elif mlir.isinstance(dtype, ir.F16Type):
     return any(input_types_are(ty) for ty in f16_acc_types)
-  elif ir.IntegerType.get_signless(32).isinstance(dtype):
+  elif mlir.isinstance(dtype, ir.IntegerType.get_signless(32)):
     return input_types_are(ir.IntegerType.get_signless(8))
   else:
     return False
@@ -161,14 +162,14 @@ def wgmma_m64(
     if a_transpose is None:
       raise ValueError
 
-  if ir.F32Type.isinstance(out_ty) or out_ty == i32:
+  if mlir.isinstance(out_ty, ir.F32Type) or out_ty == i32:
     num_acc_regs = n // 2
     out_ty_field = ir.VectorType.get((1,), out_ty)
     acc_regs = list(acc.flat)
     assert acc_regs[0].type == ir.VectorType.get((1,), out_ty)
     to_acc_vec_regs = lambda regs: np.array(regs).reshape(acc.shape)
-    acc_constraint = "r" if ir.IntegerType.isinstance(out_ty) else "f"
-  elif ir.F16Type.isinstance(out_ty):
+    acc_constraint = "r" if mlir.isinstance(out_ty, ir.IntegerType) else "f"
+  elif mlir.isinstance(out_ty, ir.F16Type):
     num_acc_regs = n // 4
     out_ty_field = i32
     acc_regs = [_as_i32_reg(reg) for reg in acc.flat]
@@ -220,11 +221,11 @@ def wgmma_m64(
   assert next(reg_count) == len(reg_constraints_list)
   k_instr = 32 // bytewidth(element_type)
   el_ty = str(element_type)
-  if ir.Float8E5M2Type.isinstance(element_type):
+  if mlir.isinstance(element_type, ir.Float8E5M2Type):
     el_ty = "e5m2"
-  elif ir.Float8E4M3FNType.isinstance(element_type):
+  elif mlir.isinstance(element_type, ir.Float8E4M3FNType):
     el_ty = "e4m3"
-  elif ir.IntegerType.get_signless(8).isinstance(element_type):
+  elif mlir.isinstance(element_type, ir.IntegerType.get_signless(8)):
     # TODO(bchetioui): add u8 support in the future. Currently we always assume
     # that 8-bit integers are s8, and we would need to change the signature of
     # `wgmma` to indicate whether the input should be treated as signed or not.
@@ -319,7 +320,7 @@ def wgmma(
   if swizzle == 16:
     raise NotImplementedError("No swizzle is not supported")
   # Step 1. Establish the shape and element type of the operation.
-  if not ir.MemRefType.isinstance(b.type):
+  if not mlir.isinstance(b.type, ir.MemRefType):
     raise ValueError(f"B must be a memref, got: {b.type}")
   bf16 = ir.BF16Type.get()
   f32 = ir.F32Type.get()
@@ -342,7 +343,7 @@ def wgmma(
       # optimizations eliminate MMA instructions, leading to only the first tile
       # of the result being computed correctly.
       raise NotImplementedError("swizzle=32 not supported for s8 lhs in registers")
-  elif ir.MemRefType.isinstance(a.type):
+  elif mlir.isinstance(a.type, ir.MemRefType):
     (m, k2), element_type2 = mma_utils.tiled_memref_shape(a)
   else:
     raise ValueError(f"Unsupported A type: {type(a)}")
@@ -367,7 +368,7 @@ def wgmma(
           f" of type f32, but got: {acc._value.mlir_dtype}"
       )
   elif any(
-      t.isinstance(element_type)
+      mlir.isinstance(element_type, t)
       for t in {ir.F16Type, ir.Float8E5M2Type, ir.Float8E4M3FNType}
   ):
     if acc._value.mlir_dtype != f16 and acc._value.mlir_dtype != f32:

--- a/tests/ffi_test.py
+++ b/tests/ffi_test.py
@@ -156,8 +156,8 @@ class FfiTest(jtu.JaxTestCase):
     # Ensure that token inputs and outputs are translated to the correct type
     module = jax.jit(fun).lower().compiler_ir("stablehlo")
     op = self.find_custom_call_in_module(module)
-    self.assertTrue(hlo.TokenType.isinstance(op.operands[0].type))
-    self.assertTrue(hlo.TokenType.isinstance(op.results[0].type))
+    self.assertTrue(mlir.isinstance(op.operands[0].type, hlo.TokenType))
+    self.assertTrue(mlir.isinstance(op.results[0].type, hlo.TokenType))
 
   def test_effects_hlo(self):
     # The target name must exist on the current platform, but we don't actually

--- a/tests/mosaic/gpu_dialect_test.py
+++ b/tests/mosaic/gpu_dialect_test.py
@@ -21,7 +21,7 @@ import jax
 from jax import numpy as jnp
 from jax._src import config
 from jax._src import test_util as jtu
-from jax._src.interpreters import mlir as mlir_interpreter
+from jax._src.interpreters import mlir
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import arith
 from jax._src.lib.mlir.dialects import builtin
@@ -45,7 +45,7 @@ config.parse_flags_with_absl()
 
 def _make_ir_context():
   context = ir.Context()
-  context.append_dialect_registry(mlir_interpreter.upstream_dialects)
+  context.append_dialect_registry(mlir.upstream_dialects)
   context.load_all_available_dialects()
   mgpu.dialect.register_dialect(context)
   return context
@@ -1309,7 +1309,7 @@ class DialectLoweringTest(MosaicGpuTest):
     self.assertLen(all_stores, 2)
 
     def check_type(ty: ir.Type):
-      self.assertTrue(ir.VectorType.get((4,), elt_ty).isinstance(ty))
+      self.assertTrue(mlir.isinstance(ty, ir.VectorType.get((4,), elt_ty)))
 
     load1, load2, *_ = all_loads  # Variadic unpacking to silence linter.
     check_type(load1.result.type)
@@ -1396,7 +1396,7 @@ class DialectLoweringTest(MosaicGpuTest):
       scalar_out_ty = mgpu_utils.dtype_to_ir_type(out_dtype)
       in_ty = ir.VectorType.get(shape, scalar_in_ty)
       out_ty = ir.VectorType.get(shape, scalar_out_ty)
-      if ir.IntegerType.isinstance(scalar_in_ty):
+      if mlir.isinstance(scalar_in_ty, ir.IntegerType):
         zero = ir.IntegerAttr.get(scalar_in_ty, 0)
       else:
         zero = ir.FloatAttr.get(scalar_in_ty, 0)

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -912,16 +912,16 @@ class WGMMATest(TestCase):
     out_mlir_dtype = utils.dtype_to_ir_type(jax_out_dtype)
     if (lhs_transpose or not rhs_transpose) and bytewidth(in_mlir_dtype) != 2:
       self.skipTest("Transpose only supported in 16-bit WGMMA")
-    if ir.F32Type.isinstance(in_mlir_dtype):  # We actually use tf32 instead
+    if mlir.isinstance(in_mlir_dtype, ir.F32Type):  # We actually use tf32 instead
       in_jax_dtype = jnp.float32
       exponent_bits, mantissa_bits = 8, 10  # Use tf32
     elif bytewidth(in_mlir_dtype) == 2:
       if n % 64 != 0:
         self.skipTest("16-bit WGMMA only supports n % 64 == 0")
-      if ir.F16Type.isinstance(in_mlir_dtype):
+      if mlir.isinstance(in_mlir_dtype, ir.F16Type):
         in_jax_dtype = jnp.float16
         exponent_bits, mantissa_bits = 5, 10
-      elif ir.BF16Type.isinstance(in_mlir_dtype):
+      elif mlir.isinstance(in_mlir_dtype, ir.BF16Type):
         in_jax_dtype = jnp.bfloat16
         exponent_bits, mantissa_bits = 8, 7
       else:
@@ -974,7 +974,7 @@ class WGMMATest(TestCase):
       )
       for i in range(2):
         barriers[i].wait()
-      is_signed = True if ir.IntegerType.isinstance(in_mlir_dtype) else None
+      is_signed = True if mlir.isinstance(in_mlir_dtype, ir.IntegerType) else None
       init_acc = mgpu.WGMMAAccumulator.zero(m=m, n=n, dtype=out_mlir_dtype, is_signed=is_signed)
       if lhs_transpose:
         perm = (0, 1, 3, 2) if transpose_lhs_tiles else (1, 0, 3, 2)
@@ -1021,7 +1021,7 @@ class WGMMATest(TestCase):
     x32, y32 = x.astype(np.float32), y.astype(np.float32)
     ref = (x32.T if lhs_transpose else x32) @ (y32.T if rhs_transpose else y32)
     atol = 2e-2 if jax_out_dtype == jnp.float16 else 5e-6
-    if ir.IntegerType.isinstance(in_mlir_dtype) and ir.IntegerType.isinstance(out_mlir_dtype):
+    if mlir.isinstance(in_mlir_dtype, ir.IntegerType) and mlir.isinstance(out_mlir_dtype, ir.IntegerType):
       atol = 0
     elif utils.bitwidth(in_mlir_dtype) == 8:
       atol = 3e-2


### PR DESCRIPTION
Future MLIR versions will allow using builtin `isinstance` and we will need to briefly support both forms (branching on the jaxlib version).

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->