### PR TITLE
Allow return out hitype in make jaxpr

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -57,6 +57,7 @@ from jax._src import sharding_specs
 from jax._src import source_info_util
 from jax._src import traceback_util
 from jax._src import pjit
+from jax._src import hijax
 from jax._src import xla_bridge as xb
 from jax._src.core import eval_jaxpr, shaped_abstractify, ShapedArray, typeof
 from jax._src.api_util import (
@@ -2587,7 +2588,10 @@ def make_jaxpr(
     else:
       jaxpr = traced.jaxpr
     if return_shape:
-      out = [ShapeDtypeStruct(o.shape, o.dtype) for o in jaxpr.out_avals]
+      out = [
+        o if isinstance(o, hijax.HiType) else ShapeDtypeStruct(o.shape, o.dtype)
+        for o in jaxpr.out_avals
+      ]
       return jaxpr, tree_unflatten(tree_structure(traced.out_info), out)
     return jaxpr
 

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -938,6 +938,17 @@ class HijaxTest(jtu.JaxTestCase):
     g(x)
     jax.jit(g)(x)
 
+  def test_make_jaxpr_return_out(self):
+    def f():
+      return make_tup(1, 2)
+
+    jaxpr, shape = jax.make_jaxpr(f, return_shape=True)()
+    self.assertIsInstance(shape, TupTy)
+    self.assertEqual(len(shape.tys), 2)
+    expected_aval = core.get_aval(1)
+    self.assertEqual(shape.tys[0], expected_aval)
+    self.assertEqual(shape.tys[1], expected_aval)
+
 
 class BoxTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->
Resolves #34193 
- Add a test that call jax.make_jaxpr with `return_shape=True` on a functions that return a HiType.
- Fix the test by returning directly the value if it's an instance of HiType otherwise create a ShapeDtypeStruct as before.