### PR TITLE
Improve error message when custom_vjp functions close over Tracers.

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -1211,7 +1211,8 @@ def custom_gradient(fun):
 
 @register_pytree_node_class
 class Residuals:
-  def __init__(self, jaxpr, in_tree, out_tree, consts):
+  def __init__(self, jaxpr: core.Jaxpr,
+              in_tree: PyTreeDef, out_tree: PyTreeDef, consts: list[Any]):
     self.jaxpr = jaxpr
     self.in_tree = in_tree
     self.out_tree = out_tree

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1645,6 +1645,7 @@ def _pjit_linearize(nzs, *primals_in, jaxpr, in_shardings, out_shardings,
     return tuple(x for nz, x in zip(is_nz_l, l) if nz)
 
   assert len(in_shardings) == len(primal_jaxpr.in_avals)
+  check_closed_over_tracers(primal_jaxpr.consts)
   ans = jit_p.bind(*primals_in, jaxpr=primal_jaxpr,
                    in_shardings=in_shardings,
                    out_shardings=primal_out_shardings,
@@ -1869,7 +1870,7 @@ def _pjit_transpose_fancy(
                               if isinstance(x, core.AbstractValue))
   trans_out_layouts   = tuple(l for x, l in zip(cts_out_, in_layouts  )
                               if isinstance(x, core.AbstractValue))
-
+  check_closed_over_tracers(trans_jaxpr.consts)
   try:
     cts_out = jit_p.bind(
         *in_flat, jaxpr=trans_jaxpr, in_shardings=tuple(trans_in_shardings),
@@ -1907,6 +1908,18 @@ def _transpose_jaxpr_fancy(jaxpr, in_tree, in_avals, specs):
       lu.wrap_init(transposed, debug_info=dbg), in_avals)
   return core.ClosedJaxpr(trans_jaxpr, consts), cell.out_tree  # type: ignore
 ad.fancy_transposes[jit_p] = _pjit_transpose_fancy
+
+
+def check_closed_over_tracers(consts: list[Any]):
+  for c in consts:
+    if isinstance(c, core.Tracer):
+      msg = ('Encountered a tracer that was closed-over in a custom_vjp, '
+             'custom_jvp, or custom_gradient function or their rules. '
+             'The tracer references a value '
+             f'with type {c.aval.str_short()} wrapped in a {type(c).__name__}. '
+             'Try passing the closed-over value into the function as an '
+             'argument, and adapting the custom_vjp fwd and bwd rules.\n')
+      raise ValueError(msg + core.tracer_provenance(c))
 
 @weakref_lru_cache
 def _dce_jaxpr_pjit(


### PR DESCRIPTION
We raise an error when a custom_vjp rule closes over a Tracer. Previously we would get an error `No constant handler for type Tracer` when trying to lower a jit whose Jaxpr contains Tracer constants.

There are multiple places where one can place the check for closed-over tracers. The placement I chose is close to where we form a jit, to ensure we never form jit with a Jaxpr that has Tracer constants. This placement will allow closing over constants in custom vjp functions in eager mode.

We refactor the escaped tracer error message to be able to share the same tracer provenance description code.