### PR TITLE
[bug] fix grad-of-vmap-of-dynamic_slice with out-of-bound indices

### DIFF
--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -1607,7 +1607,7 @@ def _dynamic_slice_batching_rule(batched_args, batch_dims, *, slice_sizes):
     [operand, index, *dyn_slice_sizes],
     [operand_bd, index_bdim, *dyn_slice_size_bds], dimension_numbers=dnums,
     slice_sizes=slice_sizes, unique_indices=True, indices_are_sorted=True,
-    mode=GatherScatterMode.PROMISE_IN_BOUNDS, fill_value=None)
+    mode=GatherScatterMode.CLIP, fill_value=None)
 
 def _dynamic_slice_staging_rule(trace, source_info, x, *start_indices,
                                 slice_sizes):


### PR DESCRIPTION
Fixes #34228

The issue stems from the fact that autodiff of `gather` with `mode=PROMISE_IN_BOUNDS` does not behave correctly when the index is out-of-bounds. The semantics of `dynamic_slice` are to clip out-of-bound indices, so we should do this explicitly in the batching rule, so that the gradient of the batching rule reflects the clipping behavior.