### PR TITLE
Optimize lpmn_values via O(n^2) recurrence

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -1671,7 +1671,7 @@ def _gen_associated_legendre(l_max: int,
   row_init_expanded = jnp.expand_dims(row_init, 0)
   out = jnp.concatenate([row_init_expanded, stacked_rows], axis=0)
 
-  return out
+  return out.transpose((1, 0) + tuple(range(2, out.ndim)))
 
 
 def lpmn(m: int, n: int, z: Array) -> tuple[Array, Array]:

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -1607,7 +1607,7 @@ def _gen_associated_legendre(l_max: int,
   # Initial state for l=0
   if is_normalized:
     # Orthonormal convention: P_0^0 = 1/sqrt(4*pi)
-    p00 = jnp.full_like(x, 0.28209479177387814)
+    p00 = jnp.full_like(x, 1 / jnp.sqrt(4 * np.pi))
   else:
     p00 = jnp.ones_like(x)
 


### PR DESCRIPTION
Fixes #33370.

Replaces the cubic-time implementation of associated Legendre functions with the standard O(n^2) recurrence relation (Bonnet's recursion).

**Changes:**
* Replaced the previous implementation (which generated a large 3D mask, scaling as $O(n^3)$ ) with a `lax.scan` based implementation that scales as $O(n^2)$.
* Implemented both normalized and unnormalized recurrences using standard stable formulas.
* Fixed the memory overhead issue that caused OOMs on accelerators for large `l_max`.

**Performance:**
* **Complexity:** Reduced from $O(n^3)$ to $O(n^2)$. 
* **Results:** As shown in the benchmark below (generated using the reproduction script from the issue), the new implementation tracks the $O(n^2)$ slope and matches Scipy's scaling.

  <img width="640" height="480" alt="benchmark_baseline1" src="https://github.com/user-attachments/assets/8dd603a4-bf03-4d89-9a26-753b0e1e4b4a" />

* **Compile Time:** Constant compile time regarding `l_max` (due to `lax.scan`), resolving the graph explosion observed in previous loop-based attempts.

**Verification:**
* Verified correctness against analytic Spherical Harmonic values ($Y_l^m$) for low degrees (matched to 4 decimal places).
* Verified gradient stability (finite gradients).