### PR TITLE
[hijax] add vmap suport to CustomVJP hijax primitive

### DIFF
--- a/tests/custom_api_test.py
+++ b/tests/custom_api_test.py
@@ -3295,20 +3295,6 @@ class CustomVJP3Test(CustomVJPTest):
   def tearDown(self):
     jax.custom_vjp = self.prev
 
-  # vmap support (to be added in the next PR)
-  def test_bwd_nones_vmap(self): pass
-  def test_custom_vjp_closure_4521(self): pass
-  def test_custom_vjp_scan_batching_edge_case(self): pass
-  def test_initial_style_vmap(self): pass
-  def test_initial_style_vmap_2(self): pass
-  def test_initial_style_vmap_3(self): pass
-  def test_initial_style_vmap_with_collective(self): pass
-  def test_symbolic_zero_custom_vjp_jit_vmap(self): pass
-  def test_symbolic_zero_custom_vjp_vmap(self): pass
-  def test_symbolic_zero_custom_vjp_vmap_output(self): pass
-  def test_vmap(self): pass
-  def test_vmap_vjp_called_twice(self): pass
-
   # closure, which ones of these do we care about?
   def test_closed_over_vmap_tracer(self): pass  # not sure if we care
   def test_bwd_closes_over_tracer(self): pass  # not sure if we care


### PR DESCRIPTION
With the original `custom_vjp`, we built in bespoke `vmap` support: see `BatchTrace.process_custom_jvp`/`vjp` and their helper functions.

For the hijax `CustomVJP` version, we'll define a more general mechanism: a hijax primitive called `VmapOf`. This hijax-only primitive essentially instantiates `vmap` in the hijax IR so that it can be delayed until after AD (effectively the same behavior custom_vjp's besoke mechanism got us). Its `expand`-to-lojax rule is just to run `jax.vmap`.

In general, using `VmapOf` to delay batching to after AD does **not** produce numerically identical results to performing batching before AD because it changes where gradient reduce-sums corresponding to implicit primal broadcasts are performed. In particular, with `VmapOf` they're delayed until the end of transposing the `VmapOf`, while when we apply `vmap` before AD they can occur in the body of the mapped function. In infinite precision, addition is associative and commutes with multiplication, but in floats the placement of the reduce-sums matters.

Having `VmapOf` gives us a generic way to implement batching of hijax primitives **if** the user specifies a `batch_dim_rule`, which essentially computes how outputs are batched given how inputs are batched. We added that to `VJPHiPrimitive`, and that's what `CustomVJPTraced` uses. For `CustomVJPTraced`, we implement `batch_dim_rule` by applying `batch_jaxpr2` to the `CustomVJPTraced` instance's jaxpr. Then `CustomVJPTraced`'s `batch` function just wraps a `VmapOf` around the `CustomVJPTraced` instance, thus allowing the batching to get run at expand-hijax-to-lojax time, after AD.

(But wait, you say, that requires a jaxpr, so what about eager vmap support, like `custom_jvp`/`custom_vjp` provided? That is, how are we going to implement` CustomVJP` and not just `CustomVJPTraced`? Well, it's not a forgone conclusion that we want to provide this eager support: we could say that if you want eager vmap of your custom AD functions and rules, you need to write your own hijax primitive. That said, we _could_ do the same thing we did with `custom_jvp`/`custom_vjp` here, and with less obscure machinery: like other output data (eg pytree and output type), we don't really need to compute output bdims in advance of running the function, thus giving us the option to infer it rather than requiring it be specified. That is, we can compute them just-in-time. But as usual that relies on a tricky implementation: linear_util aux data (and merge_linear_aux) for `custom_jvp`/`vjp`, though for hijax we could just set an `out_bdim` attribute on the `CustomVJP` instance just in time. We've prototyped that, but it's not included here.)

---

In keeping with hijax conventions, instead of relying on internal functionality, we can implement `VmapOf` at the user level, just using the hijax api and `jax.vmap`. However, to do that we had to add to `vmap` a couple of (not really public yet) features that were internal-only until now, namely (1) the ability to request a reduce-sum rather than error when a batched output is provided an unbatched out_axes spec, and (2) the ability for the `vmap` caller to infer rather than specify where the batch dimensions end up.

For (1), it looks like this:
```python
from jax._src.batching import sum_axis  # not a public api yet
xs = jnp.arange(4.)
ys = jax.vmap(lambda x: x, in_axes=0, out_axes=None)(xs)  # error!
ys = jax.vmap(lambda x: x, in_axes=0, out_axes=sum_axis)(xs)  # ok!
print(ys)  # 6.0
```

We also added the `sum_match: bool` arg on `jax.vmap` to say "treat all out_axes of `None` as `sum_axis`", which is convenient for transposition.

For (2), it looks like this:
```python
from jax._src.batching import infer  # not a public api yet
xs = jnp.arange(6.).reshape(2, 3)
(ys, zs), (ys_bdim, zs_bdim) = jax.vmap(lambda x: (x, x), in_axes=0, out_axes=(1, infer))(xs)
print(ys, ys_bdim)
# [[0. 3.]
#  [1. 4.]
#  [2. 5.]] 1
print(zs, zs_bdim)
# [[0. 1. 2.]
#  [3. 4. 5.]] 0
```

Please don't tell anyone about these features yet. It'll be our secret.