### PR TITLE
[dep] Deprecate jax.numpy.fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     `jax.pmap`ped function `f` sees inputs of the same rank as the input to
     `jax.pmap(f)`. For example, if `jax.pmap(f)` receives shape `(8, 128)` on
     8 devices, then `f` receives shape `(1, 128)`.
+  * {func}`jax.numpy.fix` is deprecated, anticipating the deprecation of
+    {func}`numpy.fix` in NumPy v2.5.0. {func}`jax.numpy.trunc` is a drop-in
+    replacement.
 
 ## JAX 0.8.2 (December 18, 2025)
 

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3473,6 +3473,11 @@ def fix(x: ArrayLike, out: None = None) -> Array:
 
   JAX implementation of :func:`numpy.fix`.
 
+  .. warning::
+
+     :func:`jax.numpy.fix` is deprecated and will be removed
+     in JAX v0.10.0. Use :func:`jax.numpy.trunc` instead.
+
   Args:
     x: input array.
     out: unused by JAX.
@@ -3493,7 +3498,7 @@ def fix(x: ArrayLike, out: None = None) -> Array:
     [[ 4.48  4.79 -1.68]
      [-0.31  0.7  -3.34]
      [-1.9   1.89  2.47]]
-    >>> jnp.fix(x)
+    >>> jnp.fix(x)  # doctest: +SKIP
     Array([[ 4.,  4., -1.],
            [-0.,  0., -3.],
            [-1.,  1.,  2.]], dtype=float32)

--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -3156,7 +3156,7 @@ def fmod(x1: ArrayLike, x2: ArrayLike, /) -> Array:
     operation of ``x1`` and ``x2`` with same sign as the elements of ``x1``.
 
   Note:
-    The result of ``jnp.fmod`` is equivalent to ``x1 - x2 * jnp.fix(x1 / x2)``.
+    The result of ``jnp.fmod`` is equivalent to ``x1 - x2 * jnp.trunc(x1 / x2)``.
 
   See also:
     - :func:`jax.numpy.mod` and :func:`jax.numpy.remainder`: Returns the element-wise
@@ -3171,7 +3171,7 @@ def fmod(x1: ArrayLike, x2: ArrayLike, /) -> Array:
     >>> jnp.fmod(x1, x2)
     Array([[ 1, -1,  4],
            [ 0,  2, -2]], dtype=int32)
-    >>> x1 - x2 * jnp.fix(x1 / x2)
+    >>> x1 - x2 * jnp.trunc(x1 / x2)
     Array([[ 1., -1.,  4.],
            [ 0.,  2., -2.]], dtype=float32)
   """

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -82,7 +82,7 @@ from jax._src.numpy.lax_numpy import (
     eye as eye,
     fill_diagonal as fill_diagonal,
     finfo as finfo,
-    fix as fix,
+    fix as _deprecated_fix,
     flatnonzero as flatnonzero,
     flip as flip,
     fliplr as fliplr,
@@ -495,3 +495,25 @@ from jax._src.numpy.vectorize import vectorize as vectorize
 from jax._src.numpy.array_methods import register_jax_array_methods
 register_jax_array_methods()
 del register_jax_array_methods
+
+
+_deprecations = {
+  # Deprecated in v0.9.0
+  "fix": (
+    (
+      "jax.numpy.fix was deprecated in JAX v0.9.0, and will be"
+      " removed in JAX v0.10.0. Use jax.numpy.trunc instead."
+    ),
+    _deprecated_fix,
+  ),
+}
+
+import typing as _typing
+if _typing.TYPE_CHECKING:
+  fix = _deprecated_fix
+else:
+  from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
+  __getattr__ = _deprecation_getattr(__name__, _deprecations)
+  del _deprecation_getattr
+del _typing
+del _deprecated_fix

--- a/tests/array_extensibility_test.py
+++ b/tests/array_extensibility_test.py
@@ -340,7 +340,6 @@ NUMPY_APIS = [
   NumPyAPI.sig(jnp.fft.ifft, Float[5]),
   NumPyAPI.sig(jnp.fft.ifft2, Float[5, 5]),
   NumPyAPI.sig(jnp.fill_diagonal, Float[5, 5], Float[()], inplace=False),
-  NumPyAPI.sig(jnp.fix, Float[5]),
   NumPyAPI.sig(jnp.flatnonzero, Float[5]),
   NumPyAPI.sig(jnp.flip, Float[5]),
   NumPyAPI.sig(jnp.fliplr, Float[5, 5]),

--- a/tests/lax_numpy_operators_test.py
+++ b/tests/lax_numpy_operators_test.py
@@ -212,9 +212,6 @@ JAX_COMPOUND_OP_RECORDS = [
               test_name="expm1_large", tolerance={np.float64: 1e-8}, inexact=True),
     op_record("expm1", 1, number_dtypes, all_shapes, jtu.rand_small_positive,
               [], tolerance={np.float64: 1e-8}, inexact=True),
-    op_record("fix", 1, float_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("fix", 1, int_dtypes + unsigned_dtypes, all_shapes,
-              jtu.rand_default, [], check_dtypes=False),
     op_record("floor_divide", 2, default_dtypes + unsigned_dtypes,
               all_shapes, jtu.rand_nonzero, ["rev"]),
     op_record("fmin", 2, number_dtypes, all_shapes, jtu.rand_some_nan, []),
@@ -475,7 +472,7 @@ class JaxNumpyOperatorTests(jtu.JaxTestCase):
         "arccosh", "arcsinh", "sinh", "cosh", "tanh", "sin", "cos", "tan",
         "log", "log1p", "log2", "log10", "exp", "expm1", "exp2", "pow",
         "power", "logaddexp", "logaddexp2", "i0", "acosh", "asinh"):
-      tol = jtu.join_tolerance(tol, 1e-4)
+      tol = jtu.join_tolerance(tol, 2e-4)
     tol = functools.reduce(jtu.join_tolerance,
                            [tolerance, tol, jtu.default_tolerance()])
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6230,6 +6230,7 @@ class NumpySignaturesTest(jtu.JaxTestCase):
             'datetime_as_string',
             'datetime_data',
             'errstate',
+            'fix',
             'flatiter',
             'format_float_positional',
             'format_float_scientific',


### PR DESCRIPTION
`numpy.fix` is is [slated for deprecation](https://numpy.org/devdocs/release/2.5.0-notes.html#numpy-fix-is-deprecated) in NumPy v2.5. `jax.numpy.trunc` is identical to `jax.numpy.fix`, so this is a fairly easy deprecation.