### PR TITLE
Add C++ flattening registration for objects that specify fields in a mapping

### DIFF
--- a/docs/jax.tree_util.rst
+++ b/docs/jax.tree_util.rst
@@ -14,6 +14,7 @@ List of Functions
    Partial
    all_leaves
    register_dataclass
+   register_object
    register_pytree_node
    register_pytree_node_class
    register_pytree_with_keys
@@ -46,4 +47,3 @@ These APIs are now accessed via :mod:`jax.tree`.
    tree_structure
    tree_transpose
    tree_unflatten
-

--- a/docs/pytrees.md
+++ b/docs/pytrees.md
@@ -21,6 +21,7 @@ kernelspec:
 
 (pytrees)=
 (working-with-pytrees)=
+
 # Pytrees
 
 <!--* freshness: { reviewed: '2025-10-15' } *-->

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -1198,19 +1198,6 @@ def register_object(
   Returns:
     The input class ``nodetype`` is returned unchanged after being added to JAX's
     pytree registry, so that :func:`register_object` can be used as a decorator.
-
-  Examples:
-
-    >>> import jax
-    >>> from functools import partial
-    ...
-    >>> @partial(jax.tree_util.register_object,
-    ...          mapping_attr='__mapping__')
-    ... class MyStruct:
-    ...   def __init__(self, x: jax.Array, y: str):
-    ...     self.x = x
-    ...     self.y = y
-    ...     self.__mapping__ = {'x': True, 'y': False}
   """
   def object_unflatten_func(meta, data):
     (meta_fields, meta_data, data_fields) = meta

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -51,6 +51,7 @@ from jax._src.tree_util import (
     default_registry as default_registry,
     keystr as keystr,
     register_dataclass as register_dataclass,
+    register_object as register_object,
     register_pytree_node_class as register_pytree_node_class,
     register_pytree_node as register_pytree_node,
     register_pytree_with_keys_class as register_pytree_with_keys_class,

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -292,8 +292,27 @@ TREES_WITH_KEYPATH = (
     (BlackBox(value=2),),
 )
 
+class RegisteredObject:
+  def __init__(self, x, y):
+    self.x = x
+    self.y = y
+    self.__mapping__ = {'x': True, 'y': False, '__mapping__': False}
+
+  def __eq__(self, other):
+    return self.y == other.y and jnp.array_equal(self.x, other.x)
+
 
 class TreeTest(jtu.JaxTestCase):
+
+  try:
+    jax.tree_util.register_object(RegisteredObject, '__mapping__')
+    def testObject(self):
+      obj = RegisteredObject(jnp.arange(5), "hello")
+      xs, tree = tree_util.tree_flatten(obj)
+      actual = tree_util.tree_unflatten(tree, xs)
+      self.assertEqual(actual, obj)
+  except NotImplementedError:
+    pass
 
   @parameterized.parameters(*(TREES + LEAVES))
   def testRoundtrip(self, inputs):


### PR DESCRIPTION
This is a WIP PR to allow Flax Modules to be flattened more quickly. Currently, the python flattening and unflattening code imposes a nontrivial overhead on Flax Modules. This PR ports this functionality to C++, giving it the same fast path as `register_dataclass`. 