### PR TITLE
[pallas] Make the LoweringDynamicShapeEnv use local mappings

### DIFF
--- a/jax/_src/export/shape_poly.py
+++ b/jax/_src/export/shape_poly.py
@@ -227,6 +227,7 @@ class _DimFactor:
           return normalized_var._evaluate(env)  # type: ignore
         err_msg = (
             f"Encountered dimension variable '{self.var}' that is not appearing in the shapes of the function arguments.\n"
+            f"The following dimension variables are appearing in the shapes of the function arguments: {list(env.keys())}.\n"
             "Please see https://docs.jax.dev/en/latest/export/shape_poly.html#dimension-variables-must-be-solvable-from-the-input-shapes for more details.")
         raise UnexpectedDimVar(err_msg)
     else:

--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -146,8 +146,10 @@ def _maybe_physicalize_block_shape(aval, block_shape):
 # SHLO functions that compute the symbolic dimension expression for the
 # placeholder.
 class LoweringDynamicShapeEnv:
-  dim_expr_to_placeholder: dict[shape_poly._DimExpr, int] = {}
-  placeholder_to_dim_expr: dict[int, shape_poly._DimExpr] = {}
+
+  def __init__(self):
+    self.dim_expr_to_placeholder: dict[shape_poly._DimExpr, int] = {}
+    self.placeholder_to_dim_expr: dict[int, shape_poly._DimExpr] = {}
 
   def to_placeholder(self, dim_expr: Any) -> ir.Value:
     if jax_core.is_constant_dim(dim_expr):


### PR DESCRIPTION
This fixes Pallas behavior in presence of shape polymorphism.

Previously, the LoweringDynamicShapeEnv was using global mappings dim_expr_to_placeholder and placeholder_to_dim_expr. This results in errors where we carry-over dim_expr from one lowering to the next.

Concretely, this resulted in failures of the form

```
Encountered dimension variable 'b' that is not appearing in the shapes of the function arguments.
```

because the symbolic variable 'b' is carried over from a previous test with Pallas and shape polymorphism.
