### PR TITLE
[pallas] Minor cleanup of typing annotations for dynamic_shape_replacement_fn

### DIFF
--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -309,7 +309,7 @@ def _dtype_to_ir_type(dtype: DTypeLike,
 
 
 def aval_to_ir_type(
-    dynamic_shape_replacement_fn,
+    dynamic_shape_replacement_fn: DynamicShapeReplacementFn,
     aval,
     shape=None,
     memory_space: AnyMemorySpace | None = None,
@@ -973,7 +973,7 @@ def lower_jaxpr_to_transform_func(
     kernel_type: tpu_core.KernelType,
     forward_compatible: bool,
     backend: Any | None,
-    dynamic_shape_replacement_fn: DynamicShapeReplacementFn | None = None,
+    dynamic_shape_replacement_fn: DynamicShapeReplacementFn,
 ) -> func.FuncOp:
   num_grid = len(mosaic_grid_mapping.grid_types)
   arg_types = [
@@ -1031,8 +1031,8 @@ def lower_jaxpr_to_func(
     kernel_type: tpu_core.KernelType,
     forward_compatible: bool,
     backend: Any | None,
-    dynamic_shape_replacement_fn: DynamicShapeReplacementFn | None = None,
-    dynamic_shape_replacement_enabled: bool = False,
+    dynamic_shape_replacement_fn: DynamicShapeReplacementFn,
+    dynamic_shape_replacement_enabled: bool,
 ) -> func.FuncOp:
   num_grid = len(mosaic_grid_mapping.grid_types)
   num_scalar_prefetch = len(mosaic_grid_mapping.scalar_prefetch_types)

--- a/jax/_src/pallas/mosaic/sc_lowering.py
+++ b/jax/_src/pallas/mosaic/sc_lowering.py
@@ -112,6 +112,7 @@ def lower_jaxpr_to_module(
     raise NotImplementedError(
         "Dynamic shape replacement is not supported for SparseCore."
     )
+  dynamic_shape_replacement_fn = lambda x: x
   if (
       lowering_context.is_forward_compat()
       or tc_lowering.is_cloud_tpu_older_than(
@@ -210,6 +211,7 @@ def lower_jaxpr_to_module(
         kernel_type=kernel_type,
         forward_compatible=lowering_context.is_forward_compat(),
         backend=backend,
+        dynamic_shape_replacement_fn=dynamic_shape_replacement_fn,
     )
     assert mlir_func.verify(), mlir_func
     m.body.append(mlir_func)


### PR DESCRIPTION
There were a few places where the `dynamic_shape_replacement_fn` was declared as optional, unnecessarily. A better type checker would have caught these.
