### PR TITLE
[indexing] use strides=None for all unit strides

### DIFF
--- a/jax/_src/numpy/indexing.py
+++ b/jax/_src/numpy/indexing.py
@@ -441,12 +441,13 @@ class NDIndexer:
       else:
         raise TypeError(f"static_slice: unrecognized index {pidx.index}")
     result = arr
-    is_trivial_slice = all(
-      (start, stop, step) == (0, size, 1)
-      for start, stop, step, size in zip(start_indices, limit_indices, strides, arr.shape)
+    optional_strides: list[int] | None = None if all(s == 1 for s in strides) else strides
+    is_trivial_slice = optional_strides is None and all(
+      (start, stop) == (0, size)
+      for start, stop, size in zip(start_indices, limit_indices, arr.shape)
     )
     if not is_trivial_slice:
-      result = slicing.slice(result, start_indices, limit_indices, strides)
+      result = slicing.slice(result, start_indices, limit_indices, optional_strides)
     if rev_axes:
       result = lax.rev(result, rev_axes)
     if squeeze_axes:


### PR DESCRIPTION
Why? Dispatch is specialized on this case in a few places, for example here: https://github.com/jax-ml/jax/blob/695eac8e55dc27c63add6fe430a623d14a1b75a6/jax/_src/lax/slicing.py#L1487-L1493

This helps unblock #34231