### PR TITLE
[Mosaic GPU] Fix `MosaicGpuDialectTest.test_wgmma_row_col_store`

### DIFF
--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -5150,6 +5150,7 @@ class MosaicGpuDialectTest(TestCase, jtu.JaxTestCase):
 
       # Registers -> SMEM
       mgpu_dialect.vector_store(cast, smem)
+      utils.commit_shared()
 
       # SMEM -> GMEM
       zero_i32 = arith.constant(ir.IntegerType.get_signless(32), 0)


### PR DESCRIPTION
This fixes a test failure in `MosaicGpuDialectTest::test_wgmma_row_col_store1` that we saw internally.