### PR TITLE
[ROCm] Enabled testTridiagonal for ROCm devices.

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1890,7 +1890,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       dtype=float_types + complex_types,
       lower=[False, True],
   )
-  @jtu.skip_on_devices("tpu","rocm")
+  @jtu.skip_on_devices("tpu")
   def testTridiagonal(self, shape, dtype, lower):
     rng = jtu.rand_default(self.rng())
     def jax_func(a):


### PR DESCRIPTION
## Summary

Enabled testTridiagonal unit test to run on ROCm devices.

## Motivation

`tests/linalg_test.py::ScipyLinalgTest::testTridiagonal` had the relevant FFI calls implemented but was disabled for ROCm devices.

## Changes
The skip statement for the unit test has been modified to remove ROCm from the skippable platforms.

## Testing
The testTridiagonal unit tests are all passing on a ROCm device.