### PR TITLE
Remove mentions of jax-metal

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,6 @@ Notebook](https://docs.jax.dev/en/latest/notebooks/Common_Gotchas_in_JAX.html).
 | NVIDIA GPU      | `pip install -U "jax[cuda13]"`                                                                                  |
 | Google TPU      | `pip install -U "jax[tpu]"`                                                                                     |
 | AMD GPU (Linux) | Follow [AMD's instructions](https://github.com/jax-ml/jax/blob/main/build/rocm/README.md).                      |
-| Mac GPU         | Follow [Apple's instructions](https://developer.apple.com/metal/jax/).                                          |
 | Intel GPU       | Follow [Intel's instructions](https://github.com/intel/intel-extension-for-openxla/blob/main/docs/acc_jax.md).  |
 
 See [the documentation](https://docs.jax.dev/en/latest/installation.html)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -232,20 +232,7 @@ using *TPU v2* and not the older, deprecated TPU runtime.
 (install-mac-gpu)=
 ## Mac GPU
 
-### pip installation
-
-Apple provides an experimental Metal plugin. For details,
-refer to
-[Apple's JAX on Metal documentation](https://developer.apple.com/metal/jax/).
-
-**Note:** There are several caveats with the Metal plugin:
-
-* The Metal plugin is new and experimental and has a number of
-  [known issues](https://github.com/jax-ml/jax/issues?q=is%3Aissue+is%3Aopen+label%3A%22Apple+GPU+%28Metal%29+plugin%22).
-  Please report any issues on the JAX issue tracker.
-* The Metal plugin currently requires very specific versions of `jax` and
-  `jaxlib`. This restriction will be relaxed over time as the plugin API
-  matures.
+JAX is not supported on Mac/OSX GPU; instead use the standard {ref}`CPU installation <install-cpu>` commands.
 
 (install-amd-gpu)=
 ## AMD GPU (Linux)

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -2849,8 +2849,6 @@ def _cumulative_reduction_primitive(name, reduce_fn, reduce_window_fn):
         platform=platform,
         inline=False)
 
-  # For jax-metal, until reduce_window legalization is better supported.
-  register_lowering(partial(associative_scan, reduce_fn), 'METAL')
   # In XLA, there's a rewriter for an O(N^2) reduce-window implementation.
   register_lowering(
       partial(cumred_reduce_window_impl, reduce_window_fn)

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -387,8 +387,6 @@ def supported_dtypes():
              _dtypes.bfloat16, np.float16, np.float32, np.float64,
              np.complex64, np.complex128, _dtypes.float8_e4m3fn,
              _dtypes.float8_e5m2}
-  elif device_under_test() == "METAL":
-    types = {np.int32, np.uint32, np.float32}
   else:
     types = {np.bool_, _dtypes.int4, np.int8, np.int16, np.int32, np.int64,
              _dtypes.uint4, np.uint8, np.uint16, np.uint32, np.uint64,
@@ -575,8 +573,6 @@ def _get_device_tags():
     return {device_under_test(), "rocm"}
   elif is_device_cuda():
     return {device_under_test(), "cuda"}
-  elif device_under_test() == "METAL":
-    return {device_under_test(), "gpu"}
   else:
     return {device_under_test()}
 

--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -287,9 +287,6 @@ _plugin_callback_lock = threading.Lock()
 # for unimplemented features. Wrong outputs are not acceptable.
 _nonexperimental_plugins: set[str] = {'cuda', 'rocm'}
 
-# The set of known experimental plugins that have registrations in JAX codebase.
-_experimental_plugins: set[str] = {"METAL"}
-
 def register_backend_factory(name: str, factory: BackendFactory, *,
                              priority: int = 0,
                              fail_quietly: bool = True,
@@ -708,7 +705,6 @@ for _platform, _alias in _platform_aliases.items():
 def known_platforms() -> set[str]:
   platforms = set()
   platforms |= set(_nonexperimental_plugins)
-  platforms |= set(_experimental_plugins)
   platforms |= set(_backend_factories.keys())
   platforms |= set(_platform_aliases.values())
   return platforms


### PR DESCRIPTION
The jax-metal project appears to be effectively dead; its last release was in 2024 (https://pypi.org/project/jax-metal/#history).

This removes mentions of it from JAX's installation docs, and removes a couple metal-related special cases in our lowering code.