### PR TITLE
Enable ROCm testing for threefry_partitionable PRNG tests

### DIFF
--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -1590,7 +1590,8 @@ class RngShardingTest(jtu.JaxTestCase):
   # tests that the PRNGs are automatically sharded as expected
 
   @parameterized.named_parameters(("3", 3), ("4", 4), ("5", 5))
-  @jtu.skip_on_devices("gpu")
+  # TODO(#34358): Test on ROCm hardware to verify threefry_partitionable support
+  @jtu.skip_on_devices("cuda")
   def test_random_bits_is_pure_map_1d(self, num_devices):
     @jax.jit
     def f(x):
@@ -1624,7 +1625,8 @@ class RngShardingTest(jtu.JaxTestCase):
        "mesh_shape": mesh_shape, "pspec": pspec}
       for mesh_shape in [(3, 2), (4, 2), (2, 3)]
       for pspec in [P('x', None), P(None, 'y'), P('x', 'y')])
-  @jtu.skip_on_devices("gpu")
+  # TODO(#34358): Test on ROCm hardware to verify threefry_partitionable support
+  @jtu.skip_on_devices("cuda")
   def test_random_bits_is_pure_map_2d(self, mesh_shape, pspec):
     @jax.jit
     def f(x):


### PR DESCRIPTION
## Summary

Enables ROCm hardware to test threefry PRNG partitioning support by changing test skip decorator from generic `"gpu"` to CUDA-specific `"cuda"`.

## Motivation

Issue #34358 identified that tests in `tests/array_test.py` were being skipped on all GPU devices (CUDA, ROCm, Metal), preventing proper triage of ROCm support for threefry PRNG partitioning features.

## Changes

Modified two test methods in `tests/array_test.py`:

1. `test_random_bits_is_pure_map_1d` (line ~1595)
2. `test_random_bits_is_pure_map_2d` (line ~1630)

**Before:**
```python
@jtu.skip_on_devices("gpu")
def test_random_bits_is_pure_map_1d(self, num_devices):
```

**After:**
```python
# TODO(#34358): Test on ROCm hardware to verify threefry_partitionable support
@jtu.skip_on_devices("cuda")
def test_random_bits_is_pure_map_1d(self, num_devices):
```

## What These Tests Verify

These tests ensure that PRNG operations using `jax.threefry_partitionable(True)`:
- Are fully partitioned across multiple devices
- Don't require communication operations (all-reduce or collective-permute)
- Produce correct results matching single-device reference implementations

## Rationale

1. **Enable ROCm Testing**: Allows ROCm hardware (e.g., MI300 accelerator) to attempt running these tests
2. **Proper Triage**: Enables CI and users to determine if threefry PRNG partitioning is supported on ROCm
3. **Preserve CUDA Skip**: Keeps tests skipped on CUDA (likely has known issues)
4. **Clear Documentation**: Added TODO comments with issue reference for tracking

## Next Steps

- ROCm CI/users will run these tests on ROCm hardware
- If tests **pass** → ROCm supports the feature ✅
- If tests **fail** → Add ROCm-specific skip with detailed error message about missing features
- If partially supported → May need ROCm version-specific conditional skips

## Testing

Verified changes using verification script:
- ✅ No generic 'gpu' skips remain
- ✅ CUDA-specific skips properly added
- ✅ TODO comments with issue reference present
- ✅ Test functions exist and have correct decorators

## Pattern Consistency

This follows existing patterns in the JAX codebase:
- `@jtu.skip_on_devices("cuda")` - Skip only on NVIDIA CUDA GPUs
- `@jtu.skip_on_devices("rocm")` - Skip only on AMD ROCm GPUs
- `@jtu.skip_on_devices("cuda", "rocm")` - Skip on both (explicit)

See examples in:
- `tests/sparse_test.py` (lines 225, 253)
- `tests/linalg_test.py` (lines 1893, 2162)
- `tests/experimental_rnn_test.py` (line 43)

Fixes #34358