### PR TITLE
[ROCm] Enabled ROCm devices to default to Jacobi SVD on smaller matrices.

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -2197,7 +2197,8 @@ def _svd_gpu_sub_lowering(ctx, operand, *, full_matrices, compute_uv,
   use_polar = False
   if algorithm is None or algorithm == SvdAlgorithm.DEFAULT:
     try:
-      use_jacobi = target_name_prefix == "cu" and m <= 1024 and n <= 1024
+      use_jacobi = target_name_prefix in ["cu", "hip"] and \
+                   m <= 1024 and n <= 1024
     except core.InconclusiveDimensionOperation:
       use_jacobi = False
   elif algorithm == SvdAlgorithm.JACOBI:


### PR DESCRIPTION
## Motivation

ShapePolyHarness SVD unit tests were expecting SVD on smaller matrices to default to the Jacobi version. This was not enabled for ROCm devices and was causing certain unit tests to fail on ROCm.

## Technical Details

The relevant SVD GPU lowering rule in `jax/_src/lax/linalg.py` has been fixed. It now defaults to Jacobi SVD for smaller matrices on ROCm devices. Please note that the actual implementation of Jacobi SVD (GESVDJ) for ROCm is in a separate pull request: https://github.com/jax-ml/jax/pull/34474

## Test Plan

This is tested in the ShapePolyHarnessesTest class in `tests/shape_poly_test.py`. 

## Test Results

The SVD shape tests (`tests/shape_poly_test.py::ShapePolyHarnessesTest::test_harness_svd_shape*`) are now passing on ROCm devices.