### PR TITLE
[ROCm] Fix KeyError for bytes_reservable_limit on ROCm

### DIFF
--- a/tests/multi_device_test.py
+++ b/tests/multi_device_test.py
@@ -304,7 +304,10 @@ class MultiDeviceTest(jtu.JaxTestCase):
       self.skipTest('Only can run test on device with mem_stats')
     mesh = Mesh(devices, axis_names=("i"))
     sharding = NamedSharding(mesh, P('i'))
-    available_memory = mem_stats['bytes_reservable_limit']
+    if jtu.is_device_rocm():
+      available_memory = mem_stats['bytes_limit']
+    else:
+      available_memory = mem_stats['bytes_reservable_limit']
     array_size = available_memory // (6 * len(devices)) * len(devices)
     # Set up tracemalloc to track memory usage.
     tm.start()


### PR DESCRIPTION
ROCm's memory_stats() returns 'bytes_limit' instead of 'bytes_reservable_limit'. Add platform-specific handling to test_lax_full_like_efficient to support both CUDA and ROCm.

Motivation
The test tests/multi_device_test.py::MultiDeviceTest::test_lax_full_like_efficient fails on ROCm with KeyError: 'bytes_reservable_limit'. This occurs because ROCm's memory_stats() API returns different keys than CUDA's implementation. The goal is to make the test platform-agnostic and work correctly on both CUDA and ROCm platforms.

Technical Details
The change adds platform detection using jtu.is_device_rocm() to select the appropriate memory statistics key:

ROCm: Uses mem_stats['bytes_limit']
CUDA: Uses mem_stats['bytes_reservable_limit']
Below is the screenshot of my test run results without and with fix.
<img width="1366" height="367" alt="without_keyerror_fix" src="https://github.com/user-attachments/assets/3f49a19c-e18a-46c8-bd90-7123bf91820d" />
<img width="1360" height="355" alt="with_keyerror_fix" src="https://github.com/user-attachments/assets/4e932ade-3d9f-4d19-88fd-1d5b3a7d0a2c" />
