### PR TITLE
[ROCm] Enable cuda array interface test on ROCm

### DIFF
--- a/jaxlib/ffi.cc
+++ b/jaxlib/ffi.cc
@@ -328,9 +328,9 @@ absl::StatusOr<xla::nb_numpy_ndarray> PyFfiAnyBuffer::NumpyArray() const {
 }
 
 absl::StatusOr<nb::dict> PyFfiAnyBuffer::CudaArrayInterface() const {
-  if (device_type_ != kDLCUDA) {
+  if (device_type_ != kDLCUDA && device_type_ != kDLROCM) {
     return absl::UnimplementedError(
-        "Buffer.__cuda_array_interface__ is only supported on CUDA.");
+        "Buffer.__cuda_array_interface__ is only supported on CUDA and ROCm.");
   }
 
   nb::dict result;

--- a/tests/buffer_callback_test.py
+++ b/tests/buffer_callback_test.py
@@ -19,6 +19,7 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from jax._src import test_util as jtu
+from jax._src.lib import jaxlib_extension_version
 from jax.experimental import buffer_callback
 
 jax.config.parse_flags_with_absl()
@@ -95,9 +96,9 @@ class BufferCallbackTest(jtu.JaxTestCase):
   @parameterized.product(
       dtype=jtu.dtypes.all, command_buffer_compatible=[True, False]
   )
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def test_cuda_array_interface(self, dtype, command_buffer_compatible):
-    if command_buffer_compatible:
+    if command_buffer_compatible and jaxlib_extension_version < 337:
       self.skipTest("Requires jaxlib extension version of at least 337.")
 
     def callback(ctx, out, arg):


### PR DESCRIPTION
Motivation
test_cuda_array_interface is currently fully skipped on ROCm. This fix enables support for cuda_array_interface on ROCm devices.

Change details:
- Add ROCm device type (kDLROCM) to the supported devices for
__cuda_array_interface__ in PyFfiAnyBuffer::CudaArrayInterface().
- Change decorator from @jtu.run_on_devices("cuda") to
  @jtu.run_on_devices("gpu") to allow the test to run on
  both CUDA and ROCm devices.
- Fix skip condition to properly check jaxlib_extension_version >= 337
  instead of unconditionally skipping command_buffer_compatible=True.

Below is my test run result with the fix:
```bash
root@a3c1f1fad18e:/workspace/debug_session_MI300/rocm-jax/jax# pytest 'tests/buffer_callback_test.py::BufferCallbackTest' -k 'cuda_array_interface'   
Test session starting on GPU ?
======================================================================================== test session starts =========================================================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/debug_session_MI300/rocm-jax/jax
configfile: pyproject.toml
plugins: json-report-1.5.0, rerunfailures-16.1, reportlog-1.0.0, hypothesis-6.150.0, html-4.1.1, metadata-3.1.1
collected 51 items / 29 deselected / 22 selected                                                                                                                                                     

tests/buffer_callback_test.py ......................                                                                                                                                           [100%]

================================================================================= 22 passed, 29 deselected in 2.61s ==================================================================================
```
