### PR TITLE
[ROCm] Enable testDotAlgorithm BF16/TF32 tests on ROCm

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1177,7 +1177,7 @@ class LaxTest(jtu.JaxTestCase):
           lax.DotAlgorithmPreset.BF16_BF16_F32_X6,
           lax.DotAlgorithmPreset.BF16_BF16_F32_X9,
       }:
-        if not jtu.is_cuda_compute_capability_at_least("8.0"):
+        if jtu.test_device_matches(["cuda"]) and not jtu.is_cuda_compute_capability_at_least("8.0"):
           raise SkipTest(
               f"The dot algorithm '{algorithm}' requires CUDA compute "
               "capability >= 8.0.")


### PR DESCRIPTION
Modify testDotAlgorithm to only check CUDA compute capability on CUDA devices, allowing ROCm to run these algorithm tests.


Motivation:
Currently testDotAlgorithm checks CUDA compute compatibility for all GPU devices , with this fix we can enable algorithm tests on ROCm

Test Result:
Below is my test result with the fix:
<img width="1817" height="351" alt="testAlgorithm" src="https://github.com/user-attachments/assets/a50abe3d-1be8-4afa-982e-42422eff56d6" />

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->