### PR TITLE
Add jax.tree.static()

### DIFF
--- a/docs/jax.tree.rst
+++ b/docs/jax.tree.rst
@@ -21,6 +21,7 @@ List of Functions
    map_with_path
    reduce
    reduce_associative
+   static
    structure
    transpose
    unflatten

--- a/jax/tree.py
+++ b/jax/tree.py
@@ -28,6 +28,7 @@ from jax._src.tree import (
     map as map,
     reduce as reduce,
     reduce_associative as reduce_associative,
+    static as static,
     structure as structure,
     transpose as transpose,
     unflatten as unflatten,

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -1736,6 +1736,25 @@ class RegistrationTest(jtu.JaxTestCase):
     # ``y`` is missing, but no validation is done for plain classes.
     tree_util.register_dataclass(Foo, data_fields=["x"], meta_fields=[])
 
+  def test_static(self):
+    with self.subTest("simple static"):
+      static = jax.tree.static()
+      self.assertEqual(static.default, dataclasses.MISSING)
+      self.assertEqual(static.metadata, {"static": True})
+
+    with self.subTest("with default"):
+      static = jax.tree.static(default="abc")
+      self.assertEqual(static.default, "abc")
+      self.assertEqual(static.metadata, {"static": True})
+
+    with self.subTest("with extra metadata"):
+      static = jax.tree.static(metadata={"somekey": "someval"})
+      self.assertEqual(static.metadata, {"static": True, "somekey": "someval"})
+
+    with self.subTest("with static False"):
+      static = jax.tree.static(metadata={"static": False})
+      self.assertEqual(static.metadata, {"static": False})
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This makes it more convenient to specify static arguments with jax.tree_util.register_dataclass.
