### PR TITLE
[ROCm] Enable optimizer tests on ROCm

### DIFF
--- a/tests/optimizers_test.py
+++ b/tests/optimizers_test.py
@@ -41,7 +41,7 @@ class OptimizerTests(jtu.JaxTestCase):
     self.assertEqual(jax.tree.structure(opt_state),
                      jax.tree.structure(opt_state2))
 
-  @jtu.skip_on_devices('gpu')
+  @jtu.skip_on_devices('cuda')
   def _CheckRun(self, optimizer, loss, x0, num_steps, *args, **kwargs):
     init_fun, update_fun, get_params = optimizer(*args)
 


### PR DESCRIPTION
Change skip decorator from 'gpu' to 'cuda' to allow optimizer tests to run on ROCm GPUs while still skipping on CUDA devices.

Test Result:
<img width="1807" height="258" alt="optimizers_test_pass" src="https://github.com/user-attachments/assets/5824a362-1802-4956-bd3d-786e5a5468b1" />

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->