### PR TITLE
[ROCm] Enable ToeplitzSymmetricConstruction and condition number tests

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1153,7 +1153,12 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     pnorm=[jnp.inf, -jnp.inf, 1, -1, 2, -2, 'fro'],
     dtype=float_types + complex_types,
   )
-  @jtu.skip_on_devices("gpu")  # TODO(#2203): numerical errors
+  # Unskipping test for ROCm while leaving
+  # original skip in place for other GPUs as per
+  # commit: e81024f5053def119eddb7fb06ff6c4f7b5948a8
+  #
+  # Original note: TODO(#2203): numerical errors
+  @jtu.skip_on_devices("cuda")
   def testCond(self, shape, pnorm, dtype):
     def gen_mat():
       # arr_gen = jtu.rand_some_nan(self.rng())
@@ -2159,7 +2164,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   @jtu.sample_product(
     shape=[(), (3,), (1, 4), (1, 5, 9), (11, 0, 13)],
     dtype=float_types + complex_types + int_types)
-  @jtu.skip_on_devices("rocm")
   def testToeplitzSymmetricConstruction(self, shape, dtype):
     if (dtype in [np.float64, np.complex128]
         and not config.enable_x64.value):


### PR DESCRIPTION
## Motivation
The ToeplitzSymmetricConstruction and condition number unit tests were being entirely skipped on ROCm. The skip condition has been altered to allow more tests to run on ROCm.

## Technical details 
- The condition number unit test (`testCond`) has been enabled only for ROCm devices as a prior commit had disabled the test for all GPUs (https://github.com/jax-ml/jax/commit/e81024f5053def119eddb7fb06ff6c4f7b5948a8). Further testing is required to ensure they work on other platforms before removing the skip entirely.
- The ToeplitzSymmetricConstruction unit test has been enabled for ROCm devices and all tests are passing for ROCm.

## Test plan
The tests in question are:
- `tests/linalg_test.py::ScipyLinalgTest::testToeplitzSymmetricConstruction`
- `tests/linalg_test.py::NumpyLinalgTest::testCond`

## Test Results
- The tests for Toeplitz Symmetric Construction are all either passing or skipping for certain data types on ROCm
- The tests for the condition number are all passing on ROCm devices.