### PR TITLE
[ROCm]Unskip testMultivariateNormalSingularCovariance on ROCm

### DIFF
--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -963,7 +963,7 @@ class DistributionsTest(RandomTestBase):
                         check_dtypes=False)
 
   @jtu.sample_product(method=['cholesky', 'eigh', 'svd'])
-  @jtu.skip_on_devices('gpu', 'tpu')  # Some NaNs on accelerators.
+  @jtu.skip_on_devices('cuda', 'tpu')  # Some NaNs on accelerators. Passing on ROCm
   def testMultivariateNormalSingularCovariance(self, method):
     # Singular covariance matrix https://github.com/jax-ml/jax/discussions/13293
     mu = jnp.zeros((2,))


### PR DESCRIPTION
## Enable testMultivariateNormalSingularCovariance on ROCm

### Motivation
The `testMultivariateNormalSingularCovariance` unit test was skipped on all GPU accelerators due to NaN issues. With hipSOLVER Jacobi SVD support now available on ROCm, all decomposition methods work correctly on AMD GPUs.

### Technical Details
Updated the test decorator comment in `tests/random_lax_test.py` to document ROCm support. The test validates that `jax.random.multivariate_normal` correctly handles singular covariance matrices using `cholesky`, `eigh`, and `svd` methods. The test remains skipped on CUDA and TPU.

### Test Plan
Tested in `tests/random_lax_test.py::DistributionsTest::testMultivariateNormalSingularCovariance`.

### Test Results
All three parameterized test variants (cholesky, eigh, svd) now pass on ROCm devices.
