### PR TITLE
[ROCm] Skip test_tridiagonal_solve on ROCm

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2367,6 +2367,7 @@ class LaxLinalgTest(jtu.JaxTestCase):
 
   @jtu.sample_product(shape=[(3,), (3, 4), (3, 4, 5)],
                       dtype=float_types + complex_types)
+  @jtu.skip_on_devices("rocm") # Numerical errors on ROCm
   def test_tridiagonal_solve(self, shape, dtype):
     if dtype not in float_types and jtu.test_device_matches(["gpu"]):
       self.skipTest("Data type not supported on GPU")


### PR DESCRIPTION
## Skip test_tridiagonal_solve on ROCm

### Motivation
The `test_tridiagonal_solve` unit test fails on ROCm devices due to numerical precision issues in the underlying hipSPARSE implementation when handling poorly-conditioned tridiagonal matrices.

### Technical Details
Added `@jtu.skip_on_devices("rocm")` decorator to skip `test_tridiagonal_solve` in `tests/linalg_test.py`. 

### Test Results
The test is now correctly skipped on ROCm: `tests/linalg_test.py::LaxLinalgTest::test_tridiagonal_solve` (SKIPPED on rocm).