### PR TITLE
[ROCm] Enable reduce_window tests on ROCm

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2213,7 +2213,7 @@ class LaxTest(jtu.JaxTestCase):
           )
       ],
   )
-  @jtu.skip_on_devices('gpu') # jax.lax.mul has an XLA bug on GPU b/339071103
+  @jtu.skip_on_devices('cuda') # jax.lax.mul has an XLA bug on CUDA GPU b/339071103
   @jtu.skip_on_devices('tpu') # b/39342488
   def testReduceWindowGeneralJVP(
       self,
@@ -2309,7 +2309,7 @@ class LaxTest(jtu.JaxTestCase):
           )
       ],
   )
-  @jtu.skip_on_devices('gpu') # jax.lax.mul has an XLA bug on GPU b/339071103
+  @jtu.skip_on_devices('cuda') # jax.lax.mul has an XLA bug on CUDA GPU b/339071103
   @jtu.skip_on_devices('tpu') # b/39342488
   def testReduceWindowCustomSameAsMonoid(
       self,
@@ -2432,7 +2432,7 @@ class LaxTest(jtu.JaxTestCase):
       ],
       dtype=[np.float32],
   )
-  @jtu.skip_on_devices('gpu')
+  @jtu.skip_on_devices('cuda')
   def testReduceWindowVariadic(self, dtype, shape, dims, strides, padding,
                                base_dilation, window_dilation):
     if (jtu.test_device_matches(["tpu"]) and


### PR DESCRIPTION
Change skip decorator from 'gpu' to 'cuda' for testReduceWindowGeneralJVP, testReduceWindowCustomSameAsMonoid, and testReduceWindowVariadic to allow these tests to run on ROCm GPUs.

Test Result
Below is the test results on ROCm with the changes.
<img width="1797" height="966" alt="reduce window test" src="https://github.com/user-attachments/assets/ab206670-d145-4108-9279-38da0b53030a" />
