### PR TITLE
[hijax] add test of custom_root of hijax function

### DIFF
--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -983,6 +983,14 @@ class HijaxTest(jtu.JaxTestCase):
         actual_grad = jax.jit(jax.grad(jax.remat(square)))(x)
       self.assertArraysAllClose(actual_grad, expected_grad)
 
+  def test_hijax_custom_root(self):
+    result = jax.lax.custom_root(
+      square,
+      initial_guess=jnp.ones(2),
+      solve=lambda _, y: jnp.zeros_like(y),
+      tangent_solve=lambda g, y: jnp.linalg.solve(jax.jacfwd(g)(y), y))
+    self.assertArraysEqual(result, jnp.zeros(2))
+
 
 class BoxTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Currently the PR just contains the failing test. TODO: fix the error!

<details>
<summary> test failure</summary>

```
________________________ HijaxTest.test_hijax_custom_root ________________________
[gw1] darwin -- Python 3.14.0 /Users/vanderplas/github/google/jax/.venv/bin/python3

>   result = jax.lax.custom_root(
      square,
      initial_guess=jnp.ones(2),
      solve=lambda _, y: jnp.zeros_like(y),
      tangent_solve=lambda g, y: jnp.linalg.solve(jax.jacfwd(g)(y), y))

tests/hijax_test.py:987: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/hijax_test.py:433: in square
    return Square(jax.typeof(x))(x)
jax/_src/hijax.py:404: in __call__
    ans_flat = call_hi_primitive_p.bind(*args_flat, prim=self)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   return call_hi_primitive_linearized_p.bind(
        *residuals_flat, *nz_tangents, residuals_tree=residuals_tree, prim=prim,
        nz_in_flat=tuple(nz_in_flat))
E   jax._src.source_info_util.JaxStackTraceBeforeTransformation: NotImplementedError: Differentiation rule for 'call_hi_primitive_linearized' not implemented
E   
E   The preceding stack trace is the source of the JAX operation that, once transformed by JAX, triggered the following exception.
E   
E   --------------------

jax/_src/hijax.py:531: JaxStackTraceBeforeTransformation

The above exception was the direct cause of the following exception:

self = <tests.hijax_test.HijaxTest testMethod=test_hijax_custom_root>

    def test_hijax_custom_root(self):
>     result = jax.lax.custom_root(
        square,
        initial_guess=jnp.ones(2),
        solve=lambda _, y: jnp.zeros_like(y),
        tangent_solve=lambda g, y: jnp.linalg.solve(jax.jacfwd(g)(y), y))

tests/hijax_test.py:987: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
jax/_src/lax/control_flow/solves.py:120: in custom_root
    l_and_s_jaxpr, out_avals = pe.trace_to_jaxpr(
jax/_src/interpreters/partial_eval.py:2410: in trace_to_jaxpr
    ans_pytree = fun(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^
jax/_src/lax/control_flow/solves.py:113: in linearize_and_solve
    return tangent_solve(f_jvp, b)
           ^^^^^^^^^^^^^^^^^^^^^^^
tests/hijax_test.py:991: in <lambda>
    tangent_solve=lambda g, y: jnp.linalg.solve(jax.jacfwd(g)(y), y))
                                                ^^^^^^^^^^^^^^^^
jax/_src/api.py:741: in jacfun
    y, jac = vmap(pushfwd, out_axes=(None, -1))(_std_basis(dyn_args))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/api.py:1211: in vmap_f
    out_flat, inferred_out_axes = batching.batch(
jax/_src/linear_util.py:212: in call_wrapped
    return self.f_transformed(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/interpreters/batching.py:368: in _batch_outer
    outs, out_dim_srcs, trace = f(tag, in_dims, *in_vals)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/interpreters/batching.py:387: in _batch_inner
    outs = f(*in_tracers)
           ^^^^^^^^^^^^^^
jax/_src/interpreters/batching.py:127: in flatten_fun_for_vmap
    ans = f(*py_args, **py_kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/api.py:1972: in _jvp
    out_primals, out_tangents = ad.jvp(flat_fun).call_wrapped(ps_flat, ts_flat)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/linear_util.py:212: in call_wrapped
    return self.f_transformed(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/interpreters/ad.py:79: in jvpfun
    out_primals, out_tangents = f(tag, primals, tangents)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/interpreters/ad.py:132: in jvp_subtrace
    ans = f(*in_tracers)
          ^^^^^^^^^^^^^^
jax/_src/api_util.py:91: in flatten_fun_nokwargs
    ans = f(*py_args)
          ^^^^^^^^^^^
jax/_src/api_util.py:293: in _argnums_partial
    return _fun(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
jax/_src/tree_util.py:493: in __call__
    return self.fun(*args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^
jax/_src/api.py:2122: in _lift_linearized
    return apply_flat_fun_nokwargs(fun, io_tree, py_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/api_util.py:101: in apply_flat_fun_nokwargs
    ans = fun(*args)
          ^^^^^^^^^^
jax/_src/api.py:2115: in fun
    tangents_out = eval_jaxpr(jaxpr, consts, *tangents)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/core.py:747: in eval_jaxpr
    ans = eqn.primitive.bind(*subfuns, *map(read, eqn.invars), **bind_params)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/core.py:632: in bind
    return self._true_bind(*args, **params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/core.py:648: in _true_bind
    return self.bind_with_trace(prev_trace, args, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/core.py:660: in bind_with_trace
    return trace.process_primitive(self, args, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = JVPTrace, primitive = call_hi_primitive_linearized
tracers = (JitTracer(float32[2]), JVPTracer(primal=JitTracer(float32[2]), tangent=VmapTracer(aval=float32[2], batched=float32[2,2])))
params = {'nz_in_flat': (True,), 'prim': Square[{}], 'residuals_tree': PyTreeDef(*)}

    def process_primitive(self, primitive, tracers, params):
      primals_in, tangents_in = unzip2(map(self.to_primal_tangent_pair, tracers))
      if (all(type(t) is Zero for t in tangents_in) and
          primitive is not core.ref_p and
          not any(isinstance(typeof(x), AbstractRef) for x in primals_in)):
        return primitive.bind_with_trace(self.parent_trace, primals_in, params)
      jvp = primitive_jvps.get(primitive)
      if not jvp:
        msg = f"Differentiation rule for '{primitive}' not implemented"
>       raise NotImplementedError(msg)
E       NotImplementedError: Differentiation rule for 'call_hi_primitive_linearized' not implemented

jax/_src/interpreters/ad.py:557: NotImplementedError
============================ short test summary info =============================
FAILED tests/hijax_test.py::HijaxTest::test_hijax_custom_root - NotImplementedError: Differentiation rule for 'call_hi_primitive_linearized' ...
==================== 1 failed, 73 passed, 3 skipped in 3.07s =====================
```

</details>