### PR TITLE
[ROCm] Enable test_variadic_reduce_window on GPUs

### DIFF
--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -759,8 +759,6 @@ class LaxVmapTest(jtu.JaxTestCase):
   # TODO Collapse
   # TODO Scatter
 
-  # TODO(b/183233858): variadic reduce-window is not implemented on XLA:GPU
-  @jtu.skip_on_devices("gpu")
   def test_variadic_reduce_window(self):
     # https://github.com/jax-ml/jax/discussions/9818 and
     # https://github.com/jax-ml/jax/issues/9837


### PR DESCRIPTION
This was initially disabled due to missing implementation XLA. Currently XLA supports this for ROCm hence enabling it for ROCm platform. Also, implementation for CUDA and ROCm is same hence enabling it for both GPUs

Test result:
below is the passing result with the change
<img width="1801" height="242" alt="varidiac test" src="https://github.com/user-attachments/assets/54bb4323-8d12-4678-acf4-29672e0992fe" />
