### PR TITLE
[ROCm] Enabled RNN unit test "test_no_workspace_overflow" for ROCm.

### DIFF
--- a/tests/experimental_rnn_test.py
+++ b/tests/experimental_rnn_test.py
@@ -216,6 +216,9 @@ class RnnTest(jtu.JaxTestCase):
     self.assertIn('"\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\00\\00\\00\\00\\00\\00\\00\\00\\01\\00\\00\\00@\\03\\80\\00\\00\\00\\00\\00@\\01\\00\\00\\00\\00\\00\\00"',
                     stablehlo)
 
+  # Note: Other LSTM tests that use `bidirectional=True` on ROCm are skipped
+  # because of current numerical issues (as of ROCm 7.1.1). However, this
+  # test only checks that lowering succeeds so it is enabled on ROCm.
   @jtu.run_on_devices("cuda", "rocm")
   def test_no_workspace_overflow(self):
     # Problem sizes known to cause overflows on older versions.

--- a/tests/experimental_rnn_test.py
+++ b/tests/experimental_rnn_test.py
@@ -216,7 +216,7 @@ class RnnTest(jtu.JaxTestCase):
     self.assertIn('"\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\00\\00\\00\\00\\00\\00\\00\\00\\01\\00\\00\\00@\\03\\80\\00\\00\\00\\00\\00@\\01\\00\\00\\00\\00\\00\\00"',
                     stablehlo)
 
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("cuda", "rocm")
   def test_no_workspace_overflow(self):
     # Problem sizes known to cause overflows on older versions.
     batch_size, max_seq_length, input_size = 256, 500, 512


### PR DESCRIPTION
## Motivation
The RNN unit test `test_no_workspace_overflow` was not enabled for ROCm devices although it is passing. It has now been enabled.

## Technical Details
The test decorator for `test_no_workspace_overflow` has been modified to run on ROCm in addition to other devices.

## Test Plan
The unit test in question is `tests/experimental_rnn_test.py::RnnTest::test_no_workspace_overflow`.

## Test Results
The unit test `test_no_workspace_overflow` is passing on ROCm devices.