### PR TITLE
[ROCm] Unskip supported dtypes for testConvolutionsPreferredElementType on ROCm

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1982,8 +1982,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     xshape=one_dim_array_shapes,
     yshape=one_dim_array_shapes,
   )
-  @jtu.skip_on_devices("cuda", "rocm")  # backends don't support all dtypes.
+  @jtu.skip_on_devices("cuda")  # backends don't support all dtypes.
   def testConvolutionsPreferredElementType(self, xshape, yshape, dtype, mode, op):
+    if jtu.test_device_matches(["rocm"]) and not dtypes.issubdtype(dtype, np.inexact):
+      self.skipTest(f"preferred_element_type={dtype} unsupported for ROCm GPU convolutions")
     jnp_op = getattr(jnp, op)
     np_op = getattr(np, op)
     rng = jtu.rand_default(self.rng())


### PR DESCRIPTION
## Motivation

The inexact data types are supported by ROCm convolution are unskipped and are passing. 
Note: (cherry picked from commit 63468231e38650985b6af4f72c842437257fa785)

## Technical Details

The unsupported data types are:
numpy.uint8
numpy.uint16
numpy.uint32
numpy.int8
numpy.int32
The tests with these dtypes are remaining as skipped. 

## Test Plan

pytest -vv tests/lax_numpy_test.py -k testConvolutionsPreferredElementType
 
## Test Result

```
tests/lax_numpy_test.py::LaxBackedNumpyTests::testConvolutionsPreferredElementType0 SKIPPED (preferred_element_type=<class
'numpy.uint16'> unsupported for ROCm GPU convolutions)                                                                                [ 10%]
tests/lax_numpy_test.py::LaxBackedNumpyTests::testConvolutionsPreferredElementType1 PASSED                                            [ 20%]
tests/lax_numpy_test.py::LaxBackedNumpyTests::testConvolutionsPreferredElementType2 SKIPPED (preferred_element_type=<class
'numpy.int32'> unsupported for ROCm GPU convolutions)                                                                                 [ 30%]
tests/lax_numpy_test.py::LaxBackedNumpyTests::testConvolutionsPreferredElementType3 SKIPPED (preferred_element_type=<class
'numpy.int8'> unsupported for ROCm GPU convolutions)                                                                                  [ 40%]
tests/lax_numpy_test.py::LaxBackedNumpyTests::testConvolutionsPreferredElementType4 SKIPPED (preferred_element_type=<class
'numpy.uint16'> unsupported for ROCm GPU convolutions)                                                                                [ 50%]
tests/lax_numpy_test.py::LaxBackedNumpyTests::testConvolutionsPreferredElementType5 PASSED                                            [ 60%]
tests/lax_numpy_test.py::LaxBackedNumpyTests::testConvolutionsPreferredElementType6 SKIPPED (preferred_element_type=<class
'numpy.uint32'> unsupported for ROCm GPU convolutions)                                                                                [ 70%]
tests/lax_numpy_test.py::LaxBackedNumpyTests::testConvolutionsPreferredElementType7 SKIPPED (preferred_element_type=<class
'numpy.uint32'> unsupported for ROCm GPU convolutions)                                                                                [ 80%]
tests/lax_numpy_test.py::LaxBackedNumpyTests::testConvolutionsPreferredElementType8 SKIPPED (preferred_element_type=<class
'numpy.uint8'> unsupported for ROCm GPU convolutions)                                                                                 [ 90%]
tests/lax_numpy_test.py::LaxBackedNumpyTests::testConvolutionsPreferredElementType9 PASSED                                            [100%]

=============================================== 3 passed, 7 skipped
```

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->