### PR TITLE
Update array api tests

### DIFF
--- a/.github/workflows/jax-array-api.yml
+++ b/.github/workflows/jax-array-api.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
       with:
         repository: data-apis/array-api-tests
-        ref: '2025.05.23'
+        ref: 3249a739f8ce9be95e5210ed90ea5d8d62045eec
         submodules: 'true'
         path: 'array-api-tests'
         persist-credentials: false


### PR DESCRIPTION
This PR updates the ref of array-api-tests used in the github CI workflow to see if the new Array API standard works with jax. 