### PR TITLE
[ROCm] Enable neural network tests on ROCm

### DIFF
--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -114,7 +114,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
   )
   def testScaledMatmul(self, contract, lhs_non_contract, dtype):
     # ROCm: scaled_matmul works, skip only CUDA compute capability check
-    if not jtu.is_device_rocm() and not jtu.is_cuda_compute_capability_at_least("10.0"):
+    if jtu.is_device_cuda() and not jtu.is_cuda_compute_capability_at_least("10.0"):
       raise unittest.SkipTest("Needs compute capability 10.0 or higher.")
     # Check if float8_e8m0fnu is available
     configs = create_mxfp8_configs_if_available()
@@ -138,7 +138,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
   def testScaledDotGeneral(
       self, is_training, output_type):
     # ROCm: scaled_dot_general works, skip only CUDA compute capability check
-    if not jtu.is_device_rocm() and not jtu.is_cuda_compute_capability_at_least("10.0"):
+    if jtu.is_device_cuda() and not jtu.is_cuda_compute_capability_at_least("10.0"):
       raise unittest.SkipTest("Needs compute capability 10.0 or higher.")
 
     configs = create_mxfp8_configs_if_available()
@@ -270,7 +270,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
     if isinstance(mask_mode, str):
       mask_mode = (mask_mode,)
     # ROCm: use XLA implementation instead of cuDNN
-    use_cudnn = not jtu.is_device_rocm()
+    use_cudnn = jtu.is_device_cuda()
     if use_cudnn:
       if not jtu.is_cuda_compute_capability_at_least("8.0"):
         raise unittest.SkipTest("Requires compute capability 8.0 or higher.")
@@ -340,7 +340,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
   )
   def testDotProductAttentionBiasGradient(self, batch_size, use_vmap):
     # ROCm: use XLA implementation instead of cuDNN
-    use_cudnn = not jtu.is_device_rocm()
+    use_cudnn = jtu.is_device_cuda()
     if use_cudnn:
       if not jtu.is_cuda_compute_capability_at_least("8.0"):
         raise unittest.SkipTest("Requires compute capability 8.0 or higher.")

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -113,7 +113,8 @@ class NNFunctionsTest(jtu.JaxTestCase):
       dtype=[jnp.float16, jnp.bfloat16, jnp.float32],
   )
   def testScaledMatmul(self, contract, lhs_non_contract, dtype):
-    # ROCm: scaled_matmul works, skip only CUDA compute capability check
+    if not jtu.test_device_matches(["gpu"]):
+      raise unittest.SkipTest("Test requires GPU.")
     if jtu.is_device_cuda() and not jtu.is_cuda_compute_capability_at_least("10.0"):
       raise unittest.SkipTest("Needs compute capability 10.0 or higher.")
     # Check if float8_e8m0fnu is available
@@ -137,7 +138,8 @@ class NNFunctionsTest(jtu.JaxTestCase):
   )
   def testScaledDotGeneral(
       self, is_training, output_type):
-    # ROCm: scaled_dot_general works, skip only CUDA compute capability check
+    if not jtu.test_device_matches(["gpu"]):
+      raise unittest.SkipTest("Test requires GPU.")
     if jtu.is_device_cuda() and not jtu.is_cuda_compute_capability_at_least("10.0"):
       raise unittest.SkipTest("Needs compute capability 10.0 or higher.")
 


### PR DESCRIPTION
Enable NN tests to run on ROCm by using XLA implementation instead of cuDNN (which is NVIDIA-only) and fixing compute capability skip checks.

Changes:
- testScaledMatmul: skip compute capability check on ROCm (works on ROCm)
- testScaledDotGeneral: skip compute capability check on ROCm (works on ROCm)
- testDotProductAttention: add ROCm skip for cuDNN impl (XLA impl still runs)
- testDotProductAttentionMask: use XLA instead of cuDNN on ROCm
- testDotProductAttentionBiasGradient: use XLA instead of cuDNN on ROCm

Related commits from ROCm/jax PRs #604, #637, #640
