### PR TITLE
[ROCm] Fix and enable Pallas ops tests on ROCm

### DIFF
--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -96,7 +96,7 @@ def get_rocm_shared_memory_limit() -> int:
           if match:
             size_kb = int(match.group(1))
             return size_kb * 1024  # Convert KB to bytes
-  except Exception:
+  except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
     pass
   # Default for AMD GPUs (MI100/MI200/MI300 all have 64KB LDS)
   return 64 * 1024

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -74,6 +74,34 @@ def is_power_of_two(n: int) -> bool:
   return (n > 0) and (n & (n - 1) == 0)
 
 
+def get_rocm_shared_memory_limit() -> int:
+  """Get the shared memory (LDS) limit in bytes for ROCm devices.
+
+  Queries rocminfo to get the GROUP segment size dynamically.
+  Returns 64KB as default if rocminfo fails (MI100/MI200/MI300 all have 64KB LDS).
+  """
+  try:
+    result = subprocess.run(
+        ['rocminfo'], capture_output=True, text=True, timeout=10
+    )
+    if result.returncode != 0:
+      return 64 * 1024  # Default if rocminfo fails
+    lines = result.stdout.split('\n')
+    for i, line in enumerate(lines):
+      if 'Segment:' in line and 'GROUP' in line:
+        if i + 1 < len(lines):
+          size_line = lines[i + 1]
+          # Match "Size: <number>(<hex>) KB" with case-insensitive KB check
+          match = re.search(r'Size:\s+(\d+)\s*\([^)]+\)\s*KB', size_line, re.IGNORECASE)
+          if match:
+            size_kb = int(match.group(1))
+            return size_kb * 1024  # Convert KB to bytes
+  except Exception:
+    pass
+  # Default for AMD GPUs (MI100/MI200/MI300 all have 64KB LDS)
+  return 64 * 1024
+
+
 def smem_on_tpu():
   if jtu.test_device_matches(["tpu"]):
     return pltpu.SMEM
@@ -1002,6 +1030,8 @@ class OpsTest(PallasBaseTest):
     if jtu.test_device_matches(["cuda"]):
       # The original test worked only on fp32@TPU, have no way to test CUDA
       self.skipTest("Not tested on CUDA, todo for the respective team")
+    if jtu.is_device_rocm():
+      self.skipTest("is_finite not in Triton lowering for jax 0.8.0")
 
     size = len(self.IS_FINITE_TEST_VALUES)
 
@@ -1052,6 +1082,8 @@ class OpsTest(PallasBaseTest):
     if jtu.test_device_matches(["cuda"]):
       # The original test worked only on fp32@TPU, have no way to test CUDA
       self.skipTest("Not tested on CUDA, todo for the respective team")
+    if jtu.is_device_rocm():
+      self.skipTest("is_finite not in Triton lowering for jax 0.8.0")
 
     size = len(self.IS_FINITE_TEST_VALUES)
 
@@ -1348,7 +1380,7 @@ class OpsTest(PallasBaseTest):
       self.skipTest("float16 is not supported on TPU")
 
     if (
-        jtu.test_device_matches(["gpu"])
+        jtu.test_device_matches(["cuda"])
         and not jtu.is_cuda_compute_capability_at_least("8.0")
     ):
       self.skipTest("Only works on GPUs with capability >= sm80")
@@ -2085,11 +2117,21 @@ class OpsTest(PallasBaseTest):
     if jtu.test_device_matches(["gpu"]):
       if dtype == jnp.bfloat16:
         self.skipTest("bfloat16 type are not supported on GPU")
-      if (
-          math.prod(lhs_shape) + math.prod(rhs_shape) + math.prod(out_shape)
-          > (256 * 256) * 2
-      ):
-        self.skipTest("Shared memory size limit exceeded")
+      # Check shared memory limit: Triton loads lhs + rhs into shared memory
+      if jtu.is_device_rocm():
+        # ROCm: use correct formula with dynamic limit from rocminfo
+        dtype_size = jnp.dtype(dtype).itemsize
+        shared_mem_bytes = (math.prod(lhs_shape) + math.prod(rhs_shape)) * dtype_size
+        shared_mem_limit = get_rocm_shared_memory_limit()
+        if shared_mem_bytes > shared_mem_limit:
+          self.skipTest("Shared memory size limit exceeded")
+      else:
+        # NVIDIA: keep original check
+        if (
+            math.prod(lhs_shape) + math.prod(rhs_shape) + math.prod(out_shape)
+            > (256 * 256) * 2
+        ):
+          self.skipTest("Shared memory size limit exceeded")
       if (jax.local_devices()[0].shared_memory_per_block_optin == 99 * 1024 and
           dtype == jnp.float32 and
           lhs_and_rhs_shape in [

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -16,6 +16,8 @@ from collections.abc import Callable, Sequence
 import functools
 import itertools
 import math
+import re
+import subprocess
 import sys
 from typing import Any
 import unittest

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -2119,19 +2119,11 @@ class OpsTest(PallasBaseTest):
         self.skipTest("bfloat16 type are not supported on GPU")
       # Check shared memory limit: Triton loads lhs + rhs into shared memory
       if jtu.is_device_rocm():
-        # ROCm: use correct formula with dynamic limit from rocminfo
         dtype_size = jnp.dtype(dtype).itemsize
-        shared_mem_bytes = (math.prod(lhs_shape) + math.prod(rhs_shape)) * dtype_size
-        shared_mem_limit = get_rocm_shared_memory_limit()
-        if shared_mem_bytes > shared_mem_limit:
+        if (math.prod(lhs_shape) + math.prod(rhs_shape)) * dtype_size > get_rocm_shared_memory_limit():
           self.skipTest("Shared memory size limit exceeded")
-      else:
-        # NVIDIA: keep original check
-        if (
-            math.prod(lhs_shape) + math.prod(rhs_shape) + math.prod(out_shape)
-            > (256 * 256) * 2
-        ):
-          self.skipTest("Shared memory size limit exceeded")
+      elif math.prod(lhs_shape) + math.prod(rhs_shape) + math.prod(out_shape) > (256 * 256) * 2:
+        self.skipTest("Shared memory size limit exceeded")
       if (jax.local_devices()[0].shared_memory_per_block_optin == 99 * 1024 and
           dtype == jnp.float32 and
           lhs_and_rhs_shape in [

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -1030,7 +1030,7 @@ class OpsTest(PallasBaseTest):
     if jtu.test_device_matches(["cuda"]):
       # The original test worked only on fp32@TPU, have no way to test CUDA
       self.skipTest("Not tested on CUDA, todo for the respective team")
-    if jtu.is_device_rocm():
+    if jtu.is_device_rocm() and jtu.parse_version(jax.__version__) == (0, 8, 0):
       self.skipTest("is_finite not in Triton lowering for jax 0.8.0")
 
     size = len(self.IS_FINITE_TEST_VALUES)
@@ -1082,7 +1082,7 @@ class OpsTest(PallasBaseTest):
     if jtu.test_device_matches(["cuda"]):
       # The original test worked only on fp32@TPU, have no way to test CUDA
       self.skipTest("Not tested on CUDA, todo for the respective team")
-    if jtu.is_device_rocm():
+    if jtu.is_device_rocm() and jtu.parse_version(jax.__version__) == (0, 8, 0):
       self.skipTest("is_finite not in Triton lowering for jax 0.8.0")
 
     size = len(self.IS_FINITE_TEST_VALUES)


### PR DESCRIPTION
Changes:
- Add get_rocm_shared_memory_limit() helper that queries rocminfo for the actual LDS (shared memory) limit, defaulting to 64KB for MI100/MI200/MI300
- Fix test_dot shared memory check for ROCm: use correct formula (lhs_elements + rhs_elements) * dtype_size in bytes
- Skip test_is_finite and test_is_finite_scalar on ROCm (is_finite not in Triton lowering for jax 0.8.0)
- Enable test_comparison_scalar on ROCm by changing skip condition from "gpu" to "cuda" (CUDA compute capability check doesn't apply to ROCm)

Related commits from ROCm/jax PRs #596, #597, #610

