### PR TITLE
[ROCm] Enable miscellaneous tests on ROCm

### DIFF
--- a/tests/svd_test.py
+++ b/tests/svd_test.py
@@ -274,13 +274,16 @@ class SvdTest(jtu.JaxTestCase):
       start=[0, 1, 64, 126, 127],
       end=[1, 2, 65, 127, 128],
   )
-  @jtu.run_on_devices('tpu')  # TODO(rmlarsen: enable on other devices)
+  @jtu.run_on_devices('tpu', 'rocm')
   def testSvdSubsetByIndex(self, start, end):
     if start >= end:
       return
     dtype = np.float32
     m = 256
     n = 128
+    # subset_by_index is only implemented for TPU; on ROCm only full range works
+    if jtu.is_device_rocm() and not (start == 0 and end == min(m, n)):
+      self.skipTest("subset_by_index not implemented for ROCm")
     rng = jtu.rand_default(self.rng())
     tol = np.maximum(n, 80) * np.finfo(dtype).eps
     args_maker = lambda: [rng((m, n), dtype)]


### PR DESCRIPTION
Changes:
- layout_test.py: Unskip test_layout_donation_mismatching_in_and_out_fails for GPU/ROCm. On GPU, tiling is not enforced so layouts are compatible and donation succeeds (unlike TPU where it fails).
- svd_test.py: Enable testSvdSubsetByIndex on ROCm for full range cases (start=0, end=128). Actual subsetting is still TPU-only.

Related commits from ROCm/jax PRs #630, #603

