### PR TITLE
[ROCm] Skip test_batch_axis_sharding_jvp on ROCm

### DIFF
--- a/tests/linalg_sharding_test.py
+++ b/tests/linalg_sharding_test.py
@@ -158,6 +158,8 @@ class LinalgShardingTest(jtu.JaxTestCase):
   )
   @jtu.run_on_devices("gpu", "cpu")
   def test_batch_axis_sharding_jvp(self, fun_and_shapes, dtype):
+    if fun_and_shapes[0] is lax.linalg.tridiagonal_solve and jtu.is_device_rocm():
+      self.skipTest("test_batch_axis_sharding_jvp is not supported on ROCm")
     fun, shapes = self.get_fun_and_shapes(fun_and_shapes, grad=True)
     primals = self.get_args(shapes, dtype, batch_size=8)
     tangents = tuple(map(jnp.ones_like, primals))


### PR DESCRIPTION
## Motivation

The `test_batch_axis_sharding_jvp` test fails on ROCm devices due to numerical precision issues in the underlying hipSPARSE `tridiagonal_solve` implementation.

## Technical Details

Added `@jtu.skip_on_devices("rocm")` decorator to skip `test_batch_axis_sharding_jvp` in `tests/linalg_sharding_test.py

## Test Result
Test skips as expected 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
