### PR TITLE
[ROCm] Added skip for "test_prim_tridiagonal_solve" tests on ROCm.

### DIFF
--- a/tests/export_harnesses_multi_platform_test.py
+++ b/tests/export_harnesses_multi_platform_test.py
@@ -74,6 +74,14 @@ class PrimitiveTest(jtu.JaxTestCase):
       self.skipTest("Eigenvalues are sorted and it is not correct to compare "
                     "decompositions for equality.")
 
+    # Tridiagonal Solve (gtsv2) on ROCm is implemented but produces
+    # numerical errors as of at least ROCm 7.2 so gtsv2 cannot be marked
+    # as stable yet.
+    # TODO Re-enable this test when ROCm numerical errors in gtsv2 are fixed.
+    if "tridiagonal_solve" in harness.fullname and jtu.is_device_rocm():
+        self.skipTest("Tridiagonal Solve (gtsv2) is currently "
+                      "unsupported on ROCm")
+
     if harness.params.get("enable_xla", False):
       self.skipTest("enable_xla=False is not relevant")
 


### PR DESCRIPTION
## Motivation
The unit tests `test_prim_tridiagonal_solve_shape*` were failing for ROCm devices since they required that an FFI call for tridiagonal solve (gtsv2) be marked as stable. There are currently numerical errors in the hipSPARSE library for this function so we cannot mark gtsv2 as stable yet. We can unskip this when the numerical errors in hipSPARSE are resolved.

## Test Plan
The relevant unit tests are:
- `tests/export_harnesses_multi_platform_test.py::PrimitiveTest::test_prim_tridiagonal_solve_shape_float32_3_`
- `tests/export_harnesses_multi_platform_test.py::PrimitiveTest::test_prim_tridiagonal_solve_shape_float64_3_`

## Test Results

The above tridiagonal tests in `export_harnesses_multi_platform_test.py` are now skipped until the numerical issues in hipSPARSE are resolved.