### PR TITLE
[ci] add pyrefly pre-commit hook

### DIFF
--- a/.github/workflows/pyrefly.yml
+++ b/.github/workflows/pyrefly.yml
@@ -1,0 +1,18 @@
+name: Pyrefly type checking (non-blocking)
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Run pre-commit hook
+      uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: pyrefly-check --hook-stage=manual --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,14 @@ repos:
   - id: jupytext
     files: docs/
     args: [--sync]
+
+# This is a manual-only pre-commit hook to run pyrefly type checks. To run it:
+# $ pre-commit run --hook-stage manual pyrefly-check --all-files
+- repo: https://github.com/facebook/pyrefly-pre-commit
+  rev: 099622e491908f1e032f6fa734057ea1e5b6058b  # frozen: v0.50.0
+  hooks:
+    - id: pyrefly-check
+      name: Pyrefly (type checking)
+      pass_filenames: false
+      additional_dependencies: [types-requests==2.31.0, numpy~=2.3.0, ml_dtypes~=0.5.0, scipy-stubs]
+      stages: [manual]

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -1,0 +1,41 @@
+python-version = "3.12"
+
+project-includes = [
+    "jax/**/*.py*",
+    # "tests/**/*.py",
+]
+
+ignore-missing-imports = [
+    "absl.*",
+    "flatbuffers.*",
+    "flax.*",
+    "google.colab.*",
+    "hypothesis.*",
+    "IPython.*",
+    "jax_cuda12_plugin.*",
+    "jax_cuda13_plugin.*",
+    "jaxlib.*",
+    "jraph.*",
+    "kubernetes.*",
+    "libtpu.*",
+    "matplotlib.*",
+    "mpi4py.*",
+    "nvidia.*",
+    "optax.*",
+    "opt_einsum.*",
+    "portpicker.*",
+    "pygments.*",
+    "pytest.*",
+    "rich.*",
+    "setuptools.*",
+    "tensorflow.*",
+    "tensorflowjs.*",
+    "tensorflow_serving.*",
+    "tensorstore.*",
+    "web_pdb.*",
+    "xprof.*",
+    "zstandard.*",
+]
+
+permissive-ignores = true
+untyped-def-behavior = "check-and-infer-return-any"


### PR DESCRIPTION
The pyrefly pre-commit is only run in the manual stage, meaning it will be skipped unless explicitly opted-in.

Run locally with
```
$ uv run pre-commit run --hook-stage=manual pyrefly-check --all-files
```
Currently this flags 3,158 typing errors. Once this lands, we can begin adding fixes and suppressions, and work toward enabling this by default.