### PR TITLE
[Mosaic] Update logistic lowering to correctly handle bf16 input

### DIFF
--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -2821,19 +2821,7 @@ def _exp2_lowering_rule(ctx: LoweringRuleContext, x, accuracy):
 def _logistic_lowering_rule(ctx: LoweringRuleContext, x, accuracy):
   if accuracy is not None:
     raise NotImplementedError("Not implemented: accuracy")
-  neg_x = arith.negf(x)
-  exp_neg_x = math.exp(neg_x)
-  aval_out = ctx.avals_out[0]
-  out_type = aval_to_ir_type(
-      ctx.lowering_context.dynamic_shape_replacement_fn, aval_out
-  )
-  if not aval_out.shape:
-    one = ir_constant(1.0, mlir_type=out_type)
-  else:
-    one = vector.broadcast(out_type, ir_constant(1.0))
-  denom = arith.addf(one, exp_neg_x)
-  return arith.divf(one, denom)
-
+  return lower_fun(lambda x: 1 / (1 + jnp.exp(-x)), multiple_results=False)(ctx, x)
 
 @register_lowering_rule(lax.sin_p)
 def _sin_lowering_rule(ctx: LoweringRuleContext, x, accuracy):


### PR DESCRIPTION
Using bf16 input will trigger a lowering error. 

<details>
<summary>Error output</summary>

```
Traceback (most recent call last):
  File "/mnt/disks/persist/nhatt/jax/jax/_src/pallas/mosaic/lowering.py", line 1082, in lower_jaxpr_to_func
    body.func_op.verify()
jaxlib.mlir._mlir_libs._site_initialize.<locals>.MLIRError: Verification failed:
error: "logistic:"("logistic"(callsite("kernel"("/mnt/disks/persist/nhatt/jax/test.py":6:17 to :43) at "<module>"("/mnt/disks/persist/nhatt/jax/test.py":9:9 to 12:4)))): 'vector.broadcast' op failed to verify that source operand and result have same element type
 note: "logistic:"("logistic"(callsite("kernel"("/mnt/disks/persist/nhatt/jax/test.py":6:17 to :43) at "<module>"("/mnt/disks/persist/nhatt/jax/test.py":9:9 to 12:4)))): see current operation: %6 = "vector.broadcast"(%5) : (f32) -> vector<32x128xbf16>

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/mnt/disks/persist/nhatt/jax/test.py", line 9, in <module>
    result = pl.pallas_call(
  File "/mnt/disks/persist/nhatt/jax/jax/_src/pallas/pallas_call.py", line 1612, in wrapped
    out_flat = pallas_call_p.bind(
jax._src.source_info_util.JaxStackTraceBeforeTransformation: jax._src.pallas.mosaic.error_handling.VerificationError: Pallas encountered an internal verification error. Please file a bug at https://github.com/jax-ml/jax/issues. Error details: 'vector.broadcast' op failed to verify that source operand and result have same element type
 see current operation: %6 = "vector.broadcast"(%5) : (f32) -> vector<32x128xbf16>

The preceding stack trace is the source of the JAX operation that, once transformed by JAX, triggered the following exception.

--------------------

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/mnt/disks/persist/nhatt/jax/test.py", line 9, in <module>
    result = pl.pallas_call(
             ^^^^^^^^^^^^^^^
  File "/mnt/disks/persist/nhatt/jax/jax/_src/pallas/pallas_call.py", line 1162, in _pallas_call_lowering
    return mlir.lower_per_platform(ctx, "pallas_call",
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/disks/persist/nhatt/jax/jax/_src/pallas/pallas_call.py", line 1135, in tpu_lowering
    return mosaic_tpu_backend.pallas_call_tpu_lowering_rule(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/disks/persist/nhatt/jax/jax/_src/pallas/mosaic/pallas_call_registration.py", line 162, in pallas_call_tpu_lowering_rule
    mosaic_module = lower_jaxpr_to_module(
                    ^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/disks/persist/nhatt/jax/jax/_src/pallas/mosaic/lowering.py", line 778, in lower_jaxpr_to_module
    func_op = lower_jaxpr_to_func(
              ^^^^^^^^^^^^^^^^^^^^
  File "/mnt/disks/persist/nhatt/jax/jax/_src/pallas/mosaic/lowering.py", line 1084, in lower_jaxpr_to_func
    raise error_handling.mlir_error_to_verification_error(e) from e
  File "/mnt/disks/persist/nhatt/jax/test.py", line 9, in <module>
    result = pl.pallas_call(
  File "/mnt/disks/persist/nhatt/jax/test.py", line 6, in logistic"(callsite("kernel
    o_ref[...] = jax.nn.sigmoid(x_ref[...])
jax._src.pallas.mosaic.error_handling.VerificationError: Pallas encountered an internal verification error. Please file a bug at https://github.com/jax-ml/jax/issues. Error details: 'vector.broadcast' op failed to verify that source operand and result have same element type
 see current operation: %6 = "vector.broadcast"(%5) : (f32) -> vector<32x128xbf16>
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
```
</details>

<br>
For context, I initially tried changing

```python
one = vector.broadcast(out_type, ir_constant(1.0))
```

to

```python
one = vector.broadcast(out_type, ir_constant(1.0, mlir_type=_dtype_to_ir_type(aval_out.dtype)))
```

but that causes another lowering error. So, I decided to use `lower_fun` as it's the simplest and most maintainable fix.

<details>
<summary>Error output</summary>

```
Traceback (most recent call last):
  File "/mnt/disks/persist/nhatt/jax/jax/_src/compiler.py", line 362, in backend_compile_and_load
    return backend.compile_and_load(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
jax.errors.JaxRuntimeError: INTERNAL: Mosaic failed to compile TPU kernel: failed to legalize operation 'arith.negf'

at location: loc("logistic:"("logistic"(callsite("kernel"("/home/nhatt/jax/test.py":6:17 to :43) at "<module>"("/home/nhatt/jax/test.py":9:9 to 12:4)))))

The MLIR operation involved:
  %57 = "arith.negf"(%27) <{fastmath = #arith.fastmath<none>}> : (vector<8x128x2xbf16>) -> vector<8x128x2xbf16>

Please report a bug at: https://github.com/google/jax/issues/new?assignees=apaszke


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/nhatt/jax/test.py", line 9, in <module>
    result = pl.pallas_call(
             ^^^^^^^^^^^^^^^
  File "/home/nhatt/jax/test.py", line 9, in <module>
    result = pl.pallas_call(
  File "/home/nhatt/jax/test.py", line 6, in logistic"(callsite("kernel
    o_ref[...] = jax.nn.sigmoid(x_ref[...])
jax._src.pallas.mosaic.error_handling.MosaicError: INTERNAL: Mosaic failed to compile TPU kernel: failed to legalize operation 'arith.negf'

The MLIR operation involved:
  %57 = "arith.negf"(%27) <{fastmath = #arith.fastmath<none>}> : (vector<8x128x2xbf16>) -> vector<8x128x2xbf16>

Please report a bug at: https://github.com/google/jax/issues/new?assignees=apaszke

--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
```
</details>

<br>
Reproducing code

```python
import jax
import jax.numpy as jnp
from jax.experimental import pallas as pl

def kernel(x_ref, o_ref):
    o_ref[...] = jax.nn.sigmoid(x_ref[...])

x = jnp.ones((32, 128), dtype=jnp.bfloat16)
result = pl.pallas_call(
    kernel,
    out_shape=jax.ShapeDtypeStruct(x.shape, x.dtype),
)(x)

print(result)
print(result.dtype)
``` 

Output after fix
```
[[0.730469 0.730469 0.730469 ... 0.730469 0.730469 0.730469]
 [0.730469 0.730469 0.730469 ... 0.730469 0.730469 0.730469]
 [0.730469 0.730469 0.730469 ... 0.730469 0.730469 0.730469]
 ...
 [0.730469 0.730469 0.730469 ... 0.730469 0.730469 0.730469]
 [0.730469 0.730469 0.730469 ... 0.730469 0.730469 0.730469]
 [0.730469 0.730469 0.730469 ... 0.730469 0.730469 0.730469]]
bfloat16
```

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->