### PR TITLE
[ROCm] Update Skip Reason Outputs

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -616,7 +616,7 @@ def _device_filter(predicate, skip_reason=None):
 
 def skip_on_devices(*disabled_devices, skip_reason=None):
   """A decorator for test methods to skip the test on certain devices.
-  
+
   Args:
     *disabled_devices: Device names that the test should skip on.
     skip_reason: Optional custom skip message when test is skipped.
@@ -627,7 +627,7 @@ def skip_on_devices(*disabled_devices, skip_reason=None):
 
 def run_on_devices(*enabled_devices, skip_reason=None):
   """A decorator for test methods to run the test only on certain devices.
-  
+
   Args:
     *enabled_devices: Device names that the test should run on.
     skip_reason: Optional custom skip message when test is skipped.

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -598,26 +598,63 @@ def test_device_matches(device_types: Iterable[str]) -> bool:
 
 test_device_matches.__test__ = False  # This isn't a test case, pytest.
 
-def _device_filter(predicate):
+def _device_filter(predicate, skip_reason=None):
   def skip(test_method):
     @functools.wraps(test_method)
     def test_method_wrapper(self, *args, **kwargs):
       device_tags = _get_device_tags()
       if not predicate():
-        test_name = getattr(test_method, '__name__', '[unknown test]')
-        raise unittest.SkipTest(
-          f"{test_name} not supported on device with tags {device_tags}.")
+        if skip_reason:
+          raise unittest.SkipTest(skip_reason)
+        else:
+          test_name = getattr(test_method, '__name__', '[unknown test]')
+          raise unittest.SkipTest(
+            f"{test_name} not supported on device with tags {device_tags}.")
       return test_method(self, *args, **kwargs)
     return test_method_wrapper
   return skip
 
-def skip_on_devices(*disabled_devices):
-  """A decorator for test methods to skip the test on certain devices."""
-  return _device_filter(lambda: not test_device_matches(disabled_devices))
+def skip_on_devices(*disabled_devices, skip_reason=None):
+  """A decorator for test methods to skip the test on certain devices.
+  
+  Args:
+    *disabled_devices: Device names that the test should skip on.
+    skip_reason: Optional custom skip message when test is skipped.
+  """
+  if skip_reason is None:
+    skip_messages = {
+      ("gpu",): "Skipped on all GPUs.",
+      ("cpu",): "Skipped on CPU.",
+      ("tpu",): "Skipped on TPU.",
+      ("cuda",): "Skipped on CUDA GPUs.",
+      ("rocm",): "Skipped on ROCm GPUs.",
+    }
+    skip_reason = skip_messages.get(disabled_devices)
+    if skip_reason is None:
+      skip_reason = "Skipped on devices with tags: " + ", ".join(map(str, disabled_devices))
 
-def run_on_devices(*enabled_devices):
-  """A decorator for test methods to run the test only on certain devices."""
-  return _device_filter(lambda: test_device_matches(enabled_devices))
+  return _device_filter(lambda: not test_device_matches(disabled_devices), skip_reason)
+
+def run_on_devices(*enabled_devices, skip_reason=None):
+  """A decorator for test methods to run the test only on certain devices.
+  
+  Args:
+    *enabled_devices: Device names that the test should run on.
+    skip_reason: Optional custom skip message when test is skipped.
+  """
+  if skip_reason is None:
+    device_specific_skip_reasons = {
+        ("cpu",): "Skipped: CPU-only test.",
+        ("tpu",): "Skipped: TPU-only test.",
+        ("gpu",): "Skipped: GPU-only test.",
+        ("rocm",): "Skipped: ROCm-only test.",
+        ("cuda",): "Skipped: CUDA-only test.",
+    }
+    skip_reason = device_specific_skip_reasons.get(enabled_devices)
+    if skip_reason is None:
+      skip_reason = "Skipped unless running on devices with tags: " + ", ".join(map(str, enabled_devices))
+
+  return _device_filter(lambda: test_device_matches(enabled_devices), skip_reason)
 
 def device_supports_buffer_donation():
   """A decorator for test methods to run the test only on devices that support

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -622,17 +622,7 @@ def skip_on_devices(*disabled_devices, skip_reason=None):
     skip_reason: Optional custom skip message when test is skipped.
   """
   if skip_reason is None:
-    skip_messages = {
-      ("gpu",): "Skipped on all GPUs.",
-      ("cpu",): "Skipped on CPU.",
-      ("tpu",): "Skipped on TPU.",
-      ("cuda",): "Skipped on CUDA GPUs.",
-      ("rocm",): "Skipped on ROCm GPUs.",
-    }
-    skip_reason = skip_messages.get(disabled_devices)
-    if skip_reason is None:
-      skip_reason = "Skipped on devices with tags: " + ", ".join(map(str, disabled_devices))
-
+    skip_reason = "Skipped on devices with tags: " + ", ".join(disabled_devices)
   return _device_filter(lambda: not test_device_matches(disabled_devices), skip_reason)
 
 def run_on_devices(*enabled_devices, skip_reason=None):
@@ -643,17 +633,9 @@ def run_on_devices(*enabled_devices, skip_reason=None):
     skip_reason: Optional custom skip message when test is skipped.
   """
   if skip_reason is None:
-    device_specific_skip_reasons = {
-        ("cpu",): "Skipped: CPU-only test.",
-        ("tpu",): "Skipped: TPU-only test.",
-        ("gpu",): "Skipped: GPU-only test.",
-        ("rocm",): "Skipped: ROCm-only test.",
-        ("cuda",): "Skipped: CUDA-only test.",
-    }
-    skip_reason = device_specific_skip_reasons.get(enabled_devices)
-    if skip_reason is None:
-      skip_reason = "Skipped unless running on devices with tags: " + ", ".join(map(str, enabled_devices))
-
+    skip_reason = (
+      "Skipped unless running on devices with tags: " + ", ".join(enabled_devices)
+    )
   return _device_filter(lambda: test_device_matches(enabled_devices), skip_reason)
 
 def device_supports_buffer_donation():

--- a/tests/pallas/gpu_pallas_distributed_test.py
+++ b/tests/pallas/gpu_pallas_distributed_test.py
@@ -48,6 +48,8 @@ def is_nvshmem_used():
 class TestCase(jt_multiprocess.MultiProcessTest if is_nvshmem_used() is None else parameterized.TestCase):
 
   def setUp(self):
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic not supported on ROCm currently.")
     # TODO(b/482756208): Fix this
     if jax.local_device_count() > 1:
       self.skipTest("Collective metadata tests are flaky since right now when "


### PR DESCRIPTION
## Motivation
Update skip reasons for CPU-only and TPU-only tests to reflect they are <device> only, instead of getting not supported on device skip reasons

Previously tests had <test_name> not supported on device with tags {'rocm', 'gpu'}. " skip reason when "run_on" decorator was used. However this skip reason does not reflect real skip reason for multiple tests. If a run_on decorator is used, especially with 'cpu' or 'tpu' argument, that test is CPU-only or TPU-only. Therefore the skip reason should reflect that, instead of stating the test is not supported on a specific device/platform.

Before this change:
```
tests/shard_map_test.py::ShardMapTest::test_forwarding_correctness1 SKIPPEDu'}.)                 [100%] 
                                                                                                        
======================================= short test summary info ========================================
SKIPPED [1] tests/shard_map_test.py:2517: test_forwarding_correctness not supported on device with tags 
{'rocm', 'gpu'}.      
```

After this change:
```
tests/shard_map_test.py::ShardMapTest::test_forwarding_correctness1 SKIPPED (Skipped: CPU-only
test.)                                                                                           [100%]

======================================= short test summary info ========================================
SKIPPED [1] tests/shard_map_test.py:2517: Skipped: CPU-only test.
========================================== 1 skipped in 7.12s =========================================
```
The skip reason change allows us to categorize skips better.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->