### PR TITLE
Enable skipped tcgen05 tests

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -568,6 +568,12 @@ class CudaArchSpecificTest:
       if target_major not in (10, 11):
         self.skipTest("Only works on GPU with tcgen05 instructions")  # pytype: disable=attribute-error
 
+  def skip_unless_tcgen05_int8(self):
+    self.skip_unless_tcgen05()
+    if not any(map(is_cuda_compute_capability_equal, ("10.0", "10.1", "11.0"))):
+      # https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-mma-instructions-mma-ws
+      self.skipTest("tcgen05 in int8 only works on GPU with capability sm100a/sm101a/sm110a")  # pytype: disable=attribute-error
+
 def _get_device_tags():
   """returns a set of tags defined for the device under test"""
   if is_device_rocm():

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -1203,9 +1203,6 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
 
   def setUp(self):
     self.skip_unless_tcgen05()
-    if jtu.is_cuda_compute_capability_equal("10.3"):
-      # nvbug/5809460: spurious LLVM/MLIR errors with tcgen05+sm_103a
-      self.skipTest("Mosaic GPU tcgen05 tests do not pass on sm_103a")
     # No artificially lowered limit for arch-specific tests
     super().setUp(artificial_shared_memory_limit=None)
 
@@ -1353,6 +1350,7 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
       swizzle=(32, 64, 128,),
   )
   def test_mma_basic_int(self, **kwargs):
+    self.skip_unless_tcgen05_int8()
     in_bytewidth = jnp.dtype(kwargs["in_jax_dtype"]).itemsize
     lhs_transpose = kwargs["lhs_transpose"]
     swizzle = kwargs["swizzle"]
@@ -1534,6 +1532,7 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
       n=(64, 128, 256),
   )
   def test_mma_lhs_tmem_integer(self, m, n, in_jax_dtype, out_jax_dtype):
+    self.skip_unless_tcgen05_int8()
     self._basic_mma_lhs_tmem_test(
         m, n, in_jax_dtype, out_jax_dtype, fa.tmem_native_layout(vector_length=4),
         swizzle=math.gcd(n, 128)
@@ -1923,6 +1922,8 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
       rhs_swizzle=(64, 128),  # 32 is too small and unsuported.
   )
   def test_mma_sparse(self, m, n, in_jax_dtype, lhs_swizzle, rhs_swizzle, lhs_transpose, rhs_transpose):
+    if in_jax_dtype == jnp.int8:
+      self.skip_unless_tcgen05_int8()
     if jnp.issubdtype(in_jax_dtype, jnp.floating):
       out_jax_dtype = jnp.float32
     else:
@@ -5948,9 +5949,6 @@ class MosaicGpuDialectTCGen05Test(TestCase, jtu.JaxTestCase, jtu.CudaArchSpecifi
 
   def setUp(self):
     self.skip_unless_tcgen05()
-    if jtu.is_cuda_compute_capability_equal("10.3"):
-      # nvbug/5809460: spurious LLVM/MLIR errors with tcgen05+sm_103a
-      self.skipTest("Mosaic GPU tcgen05 tests do not pass on sm_103a")
     # No artificially lowered limit for arch-specific tests
     super().setUp(artificial_shared_memory_limit=None)
 

--- a/tests/mosaic/matmul_test.py
+++ b/tests/mosaic/matmul_test.py
@@ -143,10 +143,6 @@ class MatmulTestCase(jtu.JaxTestCase, jtu.CudaArchSpecificTest):
   @hp.given(hps.data())
   def test_matmul_sm100(self, data):
     self.skip_unless_tcgen05()
-    if jtu.is_cuda_compute_capability_equal("10.3"):
-      # nvbug/5809460: spurious LLVM/MLIR errors with tcgen05+sm_103a
-      self.skipTest("Mosaic GPU tcgen05 tests do not pass on sm_103a")
-
     dtype = data.draw(
         hps.sampled_from([jnp.float16, jnp.bfloat16]),
         label="dtype",

--- a/tests/pallas/mgpu_examples_test.py
+++ b/tests/pallas/mgpu_examples_test.py
@@ -862,9 +862,6 @@ class MatmulTutorialTCGen05Test(jtu.JaxTestCase, jtu.CudaArchSpecificTest):
     if not jtu.test_device_matches(["cuda"]):
       self.skipTest("Test requires an NVIDIA GPU")
     self.skip_unless_tcgen05()
-    if jtu.is_cuda_compute_capability_equal("10.3"):
-      # nvbug/5809460: spurious LLVM/MLIR errors with tcgen05+sm_103a
-      self.skipTest("Mosaic GPU tcgen05 tests do not pass on sm_103a")
     self.enter_context(pallas_call._PALLAS_USE_MOSAIC_GPU(True))
 
   def benchmark(self, matmul_impl, a, b, config_search_space):

--- a/tests/pallas/mgpu_matmul_test.py
+++ b/tests/pallas/mgpu_matmul_test.py
@@ -64,9 +64,6 @@ class MatrixMultiplicationTCGen05Test(jtu.JaxTestCase, jtu.CudaArchSpecificTest)
       dtype,
   ):
     self.skip_unless_tcgen05()
-    if jtu.is_cuda_compute_capability_equal("10.3"):
-      # nvbug/5809460: spurious LLVM/MLIR errors with tcgen05+sm_103a
-      self.skipTest("Mosaic GPU tcgen05 tests do not pass on sm_103a")
     k1, k2, = jax.random.split(jax.random.key(42), 2)
     a = jax.random.normal(k1, (m, k), dtype)
     b = jax.random.normal(k2, (k, n), dtype)

--- a/tests/pallas/mgpu_ragged_dot_test.py
+++ b/tests/pallas/mgpu_ragged_dot_test.py
@@ -180,9 +180,6 @@ class RaggedDotTCGen05TestCase(jtu.JaxTestCase, jtu.CudaArchSpecificTest):
     if blackwell_ragged_dot_mgpu is None:
       self.skipTest("Mosaic GPU not available.")
     self.skip_unless_tcgen05()
-    if jtu.is_cuda_compute_capability_equal("10.3"):
-      # nvbug/5809460: spurious LLVM/MLIR errors with tcgen05+sm_103a
-      self.skipTest("Mosaic GPU tcgen05 tests do not pass on sm_103a")
     self.enter_context(pallas_call._PALLAS_USE_MOSAIC_GPU(True))
 
   @parameterized.product(

--- a/tests/pallas/mosaic_gpu_test.py
+++ b/tests/pallas/mosaic_gpu_test.py
@@ -195,9 +195,6 @@ class PallasTCGen05Test(PallasTest, jtu.CudaArchSpecificTest):
 
   def setUp(self):
     self.skip_unless_tcgen05()
-    if jtu.is_cuda_compute_capability_equal("10.3"):
-      # nvbug/5809460: spurious LLVM/MLIR errors with tcgen05+sm_103a
-      self.skipTest("Mosaic GPU tcgen05 tests do not pass on sm_103a")
     # No artificially lowered limit for arch-specific tests
     super().setUp(artificial_shared_memory_limit=None)
 
@@ -3830,6 +3827,7 @@ class PallasCallTCGen05Test(PallasTCGen05Test):
       lhs_tmem=[False, True],
   )
   def test_integer_matmul(self, m, n, swizzle, dtype, lhs_tmem):
+    self.skip_unless_tcgen05_int8()
     if n * jnp.dtype(dtype).itemsize <= swizzle:
       self.skipTest("swizzle too big")
     if lhs_tmem and m == 64:


### PR DESCRIPTION
Disable NVVM verification for some architectures instead of skipping the tests entirely. Add some new, more targeted, test skips for cases not supported on `sm_103a`.