### PR TITLE
Use 1d register shape for SC example

### DIFF
--- a/docs/pallas/tpu/core_map.ipynb
+++ b/docs/pallas/tpu/core_map.ipynb
@@ -1,34 +1,19 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "last_runtime": {
-        "build_target": "//third_party/py/jax_triton/google/pallas_tpu:notebook",
-        "kind": "private"
-      }
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
-      "source": [
-        "# Pallas Core-specific Programming"
-      ],
       "metadata": {
         "id": "YIt0Za36LYg9"
-      }
+      },
+      "source": [
+        "# Pallas Core-specific Programming"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "khDWSc7aOVts"
+      },
       "source": [
         "In this guide, we explore using `pl.core_map` to write Pallas kernels. Compared with `pallas_call`, `core_map` offers a few key characteristics:\n",
         "\n",
@@ -37,54 +22,51 @@
         "* **Collectives**: `core_map` explicitly models physical cores, so inter-core communication can be expressed safely.\n",
         "\n",
         "* **Platform generic**: `core_map` programming model works for TPU (TensorCore and SparseCore) and GPU with minimal boilerplate changes."
-      ],
-      "metadata": {
-        "id": "khDWSc7aOVts"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "This guide focuses on TPU. For how to use `core_map` on GPU to achieve higher thread flexibility, check out our [Pallas GPU `core_map` tutorial](https://docs.jax.dev/en/latest/pallas/gpu/reference.html#using-core-map)."
-      ],
       "metadata": {
         "id": "i8pl0CLqTVvL"
-      }
+      },
+      "source": [
+        "This guide focuses on TPU. For how to use `core_map` on GPU to achieve higher thread flexibility, check out our [Pallas GPU `core_map` tutorial](https://docs.jax.dev/en/latest/pallas/gpu/reference.html#using-core-map)."
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "bsOPXdJkzC-x"
+      },
       "source": [
         "## Environment setup\n",
         "\n",
         "Modern accelerators often have multiple cores under a device. For recent TPU chips (v4, v5p), every JAX device may contains 2 TensorCores (aka. a [Megacore](https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#chips)). Some TPUs (v5p, v6e, 7x) also contain [SparseCores](https://openxla.org/xla/sparsecore#specifications_at_a_glance), each of which consists of many subcores.\n",
         "\n",
         "This guide was written on a v5p chip, which contains 4 devices (2 TensorCores each) and 4 SparseCores, each with 16 subcores."
-      ],
-      "metadata": {
-        "id": "bsOPXdJkzC-x"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 1,
       "metadata": {
-        "id": "14PNaMVsLUur",
         "executionInfo": {
+          "elapsed": 2087,
           "status": "ok",
           "timestamp": 1764795546418,
-          "user_tz": 480,
-          "elapsed": 2087,
           "user": {
             "displayName": "Ivy Zheng",
             "userId": "15297372265856137303"
-          }
+          },
+          "user_tz": 480
         },
+        "id": "14PNaMVsLUur",
         "outputId": "01976bb1-2f2f-40e9-ca23-f0e480a82ab3"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Running on 4 TPU v5p devices.\n"
           ]
@@ -111,15 +93,41 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "In addition to the typical TPU device mesh, you need to make a mesh of cores. Consider this as an addition dimension called `core`, with length 2, in addition to the 4-device mesh you work with. That is 8 cores in total."
-      ],
       "metadata": {
         "id": "3f0XEhaYnGyk"
-      }
+      },
+      "source": [
+        "In addition to the typical TPU device mesh, you need to make a mesh of cores. Consider this as an addition dimension called `core`, with length 2, in addition to the 4-device mesh you work with. That is 8 cores in total."
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "executionInfo": {
+          "elapsed": 57,
+          "status": "ok",
+          "timestamp": 1764795546665,
+          "user": {
+            "displayName": "Ivy Zheng",
+            "userId": "15297372265856137303"
+          },
+          "user_tz": 480
+        },
+        "id": "jr5MARD-mIlC",
+        "outputId": "1ea63c2f-3aec-4cdd-9674-d0e2df32460c"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Mesh('device': 4, axis_types=(Explicit,))\n",
+            "TensorCoreMesh(devices=array([TensorCore(id=0), TensorCore(id=1)], dtype=object), axis_names=('core',))\n",
+            "There are 4 devices, and 2 cores each.\n"
+          ]
+        }
+      ],
       "source": [
         "# Mesh of devices\n",
         "mesh = jax.make_mesh((jax.device_count(),), ('device',))\n",
@@ -132,36 +140,13 @@
         "num_devices = mesh.size\n",
         "num_cores = len(tc_mesh.devices)\n",
         "print(f\"There are {num_devices} devices, and {num_cores} cores each.\")"
-      ],
-      "metadata": {
-        "id": "jr5MARD-mIlC",
-        "executionInfo": {
-          "status": "ok",
-          "timestamp": 1764795546665,
-          "user_tz": 480,
-          "elapsed": 57,
-          "user": {
-            "displayName": "Ivy Zheng",
-            "userId": "15297372265856137303"
-          }
-        },
-        "outputId": "1ea63c2f-3aec-4cdd-9674-d0e2df32460c"
-      },
-      "execution_count": 2,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Mesh('device': 4, axis_types=(Explicit,))\n",
-            "TensorCoreMesh(devices=array([TensorCore(id=0), TensorCore(id=1)], dtype=object), axis_names=('core',))\n",
-            "There are 4 devices, and 2 cores each.\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "CYxwiULfndlh"
+      },
       "source": [
         "## A simple per-core kernel\n",
         "\n",
@@ -174,13 +159,25 @@
         "Before communicating between cores, it is good practice to perform a barrier (using `pltpu.semaphore_signal`) to ensure resources have been allocated and both cores are at the same point during the program.\n",
         "\n",
         "Once the cores are synchronized, use `pltpu.make_async_remote_copy` to send data between them. The `device_id` keyword argument generically allows sending to any core on any device, but if you just pass in `{'core': other_core_id}`, it will perform a intra-device inter-core copy (the other axis names are held constant).\n"
-      ],
-      "metadata": {
-        "id": "CYxwiULfndlh"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "executionInfo": {
+          "elapsed": 53,
+          "status": "ok",
+          "timestamp": 1764795546946,
+          "user": {
+            "displayName": "Ivy Zheng",
+            "userId": "15297372265856137303"
+          },
+          "user_tz": 480
+        },
+        "id": "GkGRT2HRJOUU"
+      },
+      "outputs": [],
       "source": [
         "# This runs on every core\n",
         "def swap_cores_kernel(in_hbm, out_hbm,\n",
@@ -213,25 +210,13 @@
         "\n",
         "  # Copy out the output\n",
         "  pltpu.async_copy(out_vmem, out_hbm.at[:, slc], sem).wait()\n"
-      ],
-      "metadata": {
-        "id": "GkGRT2HRJOUU",
-        "executionInfo": {
-          "status": "ok",
-          "timestamp": 1764795546946,
-          "user_tz": 480,
-          "elapsed": 53,
-          "user": {
-            "displayName": "Ivy Zheng",
-            "userId": "15297372265856137303"
-          }
-        }
-      },
-      "execution_count": 3,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "2T0tSkFmoFLI"
+      },
       "source": [
         "Once you have the local kernel:\n",
         "\n",
@@ -242,13 +227,25 @@
         "    * You will need `collective_id` for the barrier semaphore.\n",
         "\n",
         " * Inside `pl.core_map`, invoke `pl.run_scoped` to allocate per-core scratch spaces (VMEM and semaphores) and run the local kernel."
-      ],
-      "metadata": {
-        "id": "2T0tSkFmoFLI"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "executionInfo": {
+          "elapsed": 1800,
+          "status": "ok",
+          "timestamp": 1764795548996,
+          "user": {
+            "displayName": "Ivy Zheng",
+            "userId": "15297372265856137303"
+          },
+          "user_tz": 480
+        },
+        "id": "KT6zkEKi1Sbc"
+      },
+      "outputs": [],
       "source": [
         "input_shape = (32, 256)\n",
         "local_vmem_shape = (32 // num_devices, 256 // num_cores)\n",
@@ -279,38 +276,38 @@
         "\n",
         "np.testing.assert_array_equal(y[:, 128:], x[:, :128] * 2)\n",
         "np.testing.assert_array_equal(y[:, :128], x[:, 128:] * 2)"
-      ],
-      "metadata": {
-        "id": "KT6zkEKi1Sbc",
-        "executionInfo": {
-          "status": "ok",
-          "timestamp": 1764795548996,
-          "user_tz": 480,
-          "elapsed": 1800,
-          "user": {
-            "displayName": "Ivy Zheng",
-            "userId": "15297372265856137303"
-          }
-        }
-      },
-      "execution_count": 4,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "dLV8sKa4HuSX"
+      },
       "source": [
         "### Save the boilerplate\n",
         "\n",
         "You can use the `pl.kernel` decorator to wrap boilerplate such as `core_map`, `run_scoped`, and output buffer allocation.\n",
         "\n",
         "Note that this should run inside any `jax.shard_map` you may have at the top level."
-      ],
-      "metadata": {
-        "id": "dLV8sKa4HuSX"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "executionInfo": {
+          "elapsed": 106,
+          "status": "ok",
+          "timestamp": 1764795549347,
+          "user": {
+            "displayName": "Ivy Zheng",
+            "userId": "15297372265856137303"
+          },
+          "user_tz": 480
+        },
+        "id": "7cHnsRHPHyfH"
+      },
+      "outputs": [],
       "source": [
         "@jax.jit\n",
         "@partial(jax.shard_map, mesh=mesh, in_specs=in_spec, out_specs=in_spec, check_vma=False)\n",
@@ -323,25 +320,13 @@
         "y = swap_cores(x)\n",
         "np.testing.assert_array_equal(y[:, 128:], x[:, :128] * 2)\n",
         "np.testing.assert_array_equal(y[:, :128], x[:, 128:] * 2)"
-      ],
-      "metadata": {
-        "id": "7cHnsRHPHyfH",
-        "executionInfo": {
-          "status": "ok",
-          "timestamp": 1764795549347,
-          "user_tz": 480,
-          "elapsed": 106,
-          "user": {
-            "displayName": "Ivy Zheng",
-            "userId": "15297372265856137303"
-          }
-        }
-      },
-      "execution_count": 5,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "4-G--Wnysdjs"
+      },
       "source": [
         "## Pipelining with `core_map`\n",
         "\n",
@@ -356,13 +341,25 @@
         "**Scratch shapes allocation**\n",
         "\n",
         "Note that in the example below, the top level `pl.run_scoped` (wrapped inside `kernel`) did not allocate any VMEM scratch buffers. Instead, `pltpu.emit_pipeline` allocates its own scratch buffers in VMEM and use them for its multiple buffering.\n"
-      ],
-      "metadata": {
-        "id": "4-G--Wnysdjs"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "executionInfo": {
+          "elapsed": 518,
+          "status": "ok",
+          "timestamp": 1764795550106,
+          "user": {
+            "displayName": "Ivy Zheng",
+            "userId": "15297372265856137303"
+          },
+          "user_tz": 480
+        },
+        "id": "xUMRPLxb1rEH"
+      },
+      "outputs": [],
       "source": [
         "def add_one_body(in_vmem, out_vmem):\n",
         "  out_vmem[...] = in_vmem[...] + 1\n",
@@ -397,25 +394,13 @@
         "y = add_one(x)\n",
         "\n",
         "np.testing.assert_array_equal(y, x + 1)"
-      ],
-      "metadata": {
-        "id": "xUMRPLxb1rEH",
-        "executionInfo": {
-          "status": "ok",
-          "timestamp": 1764795550106,
-          "user_tz": 480,
-          "elapsed": 518,
-          "user": {
-            "displayName": "Ivy Zheng",
-            "userId": "15297372265856137303"
-          }
-        }
-      },
-      "execution_count": 6,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "Cq5rYyvL2Tte"
+      },
       "source": [
         "## Scalar prefetch\n",
         "\n",
@@ -428,13 +413,25 @@
         "The code example below also shows how `core_map` allows you to customize exactly how the work is split between cores, without relying on the automatic API shown above.\n",
         "\n",
         "To achieve that, customize your `index_map` to use the core index to work on different slices on different cores.\n"
-      ],
-      "metadata": {
-        "id": "Cq5rYyvL2Tte"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "executionInfo": {
+          "elapsed": 378,
+          "status": "ok",
+          "timestamp": 1764795550778,
+          "user": {
+            "displayName": "Ivy Zheng",
+            "userId": "15297372265856137303"
+          },
+          "user_tz": 480
+        },
+        "id": "SE8pTStHeSWB"
+      },
+      "outputs": [],
       "source": [
         "input_shape = (1024, 1024)\n",
         "in_spec = jax.P('device', None)\n",
@@ -478,38 +475,47 @@
         "y = indexed_add_one(xs, jnp.array([idx]))\n",
         "\n",
         "np.testing.assert_array_equal(y, xs[:, idx:(idx+512)] + 1)"
-      ],
-      "metadata": {
-        "id": "SE8pTStHeSWB",
-        "executionInfo": {
-          "status": "ok",
-          "timestamp": 1764795550778,
-          "user_tz": 480,
-          "elapsed": 378,
-          "user": {
-            "displayName": "Ivy Zheng",
-            "userId": "15297372265856137303"
-          }
-        }
-      },
-      "execution_count": 7,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "B8qeo-4A2KRm"
+      },
       "source": [
         "## Mapping over SparseCores\n",
         "\n",
         "TPU v5p contains 4 [SparseCores](https://openxla.org/xla/sparsecore), which are specialized for sparse memory access and operations. This guide will not dive into the full capabilities of SparseCore, but rather show how to run a program on SparseCore with the same semantics and minimal changes from the TensorCore code.\n",
         "\n",
         "Start with knowing the basic SparseCore specs of your chip, and create a `VectorSubcoreMesh` for vector operations. Note that each SparseCore has 16 (or other number) subcores on TPU v5p, and `core_map` will run your code SPMD on each of them."
-      ],
-      "metadata": {
-        "id": "B8qeo-4A2KRm"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "executionInfo": {
+          "elapsed": 55,
+          "status": "ok",
+          "timestamp": 1764795551102,
+          "user": {
+            "displayName": "Ivy Zheng",
+            "userId": "15297372265856137303"
+          },
+          "user_tz": 480
+        },
+        "id": "AHurx-yyYVvs",
+        "outputId": "aa4a45da-dd9a-4f57-de1a-bc9b5872b2df"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "SparseCoreInfo(num_cores=4, num_subcores=16, num_lanes=8)\n"
+          ]
+        }
+      ],
       "source": [
         "sc_info = pltpu.get_tpu_info().sparse_core\n",
         "assert sc_info is not None\n",
@@ -521,50 +527,41 @@
         ")\n",
         "sc_num_cores = sc_info.num_cores\n",
         "sc_num_subcores = sc_info.num_subcores"
-      ],
-      "metadata": {
-        "id": "AHurx-yyYVvs",
-        "executionInfo": {
-          "status": "ok",
-          "timestamp": 1764795551102,
-          "user_tz": 480,
-          "elapsed": 55,
-          "user": {
-            "displayName": "Ivy Zheng",
-            "userId": "15297372265856137303"
-          }
-        },
-        "outputId": "aa4a45da-dd9a-4f57-de1a-bc9b5872b2df"
-      },
-      "execution_count": 8,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "SparseCoreInfo(num_cores=4, num_subcores=16, num_lanes=8)\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "n2_dfsUWFgwU"
+      },
       "source": [
         "The code below is very similar to the `add_one_kernel` we wrote earlier, except for a few differences:\n",
         "\n",
         "1. You need to split the work amongst all subcores, so a few lines to compute the specific slice for each subcore.\n",
         "\n",
-        "1. SparseCore register computation allows smaller slices (`4x16` max for int32), so you need nested loops to iterate the slice during computation phase."
-      ],
-      "metadata": {
-        "id": "n2_dfsUWFgwU"
-      }
+        "1. SparseCore register computation requires smaller slices, so you need nested loops to iterate the slice during computation phase."
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "executionInfo": {
+          "elapsed": 1117,
+          "status": "ok",
+          "timestamp": 1764795552411,
+          "user": {
+            "displayName": "Ivy Zheng",
+            "userId": "15297372265856137303"
+          },
+          "user_tz": 480
+        },
+        "id": "6fNShx6k2kxi"
+      },
+      "outputs": [],
       "source": [
         "input_shape = (4096, 128)\n",
-        "SC_REG_OP_SHAPE = (4, 16)\n",
+        "SC_REG_OP_SHAPE = (1, sc_info.num_lanes)\n",
         "\n",
         "def sc_add_one_body(in_vmem, out_vmem):\n",
         "  @pl.loop(0, in_vmem.shape[0], step=SC_REG_OP_SHAPE[0])\n",
@@ -607,22 +604,18 @@
         "y = sc_add_one(x)\n",
         "\n",
         "np.testing.assert_array_equal(y, x + 1)"
-      ],
-      "metadata": {
-        "id": "6fNShx6k2kxi",
-        "executionInfo": {
-          "status": "ok",
-          "timestamp": 1764795552411,
-          "user_tz": 480,
-          "elapsed": 1117,
-          "user": {
-            "displayName": "Ivy Zheng",
-            "userId": "15297372265856137303"
-          }
-        }
-      },
-      "execution_count": 9,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/docs/pallas/tpu/core_map.md
+++ b/docs/pallas/tpu/core_map.md
@@ -312,12 +312,12 @@ The code below is very similar to the `add_one_kernel` we wrote earlier, except 
 
 1. You need to split the work amongst all subcores, so a few lines to compute the specific slice for each subcore.
 
-1. SparseCore register computation allows smaller slices (`4x16` max for int32), so you need nested loops to iterate the slice during computation phase.
+1. SparseCore register computation requires smaller slices, so you need nested loops to iterate the slice during computation phase.
 
 
 ```python
 input_shape = (4096, 128)
-SC_REG_OP_SHAPE = (4, 16)
+SC_REG_OP_SHAPE = (1, sc_info.num_lanes)
 
 def sc_add_one_body(in_vmem, out_vmem):
   @pl.loop(0, in_vmem.shape[0], step=SC_REG_OP_SHAPE[0])


### PR DESCRIPTION
There's known bug on 2d register operations on SparseCore, so changing the code to work on `(num_lanes,)`.