### PR TITLE
[refs] fix ref indexing corner case

### DIFF
--- a/jax/_src/state/indexing.py
+++ b/jax/_src/state/indexing.py
@@ -242,7 +242,7 @@ class NDIndexer:
       if num_ellipsis > 1:
         raise ValueError("Only one ellipsis is supported.")
       # Expand ... so that `indices` has the same length as `shape`.
-      ip = indices.index(...)
+      ip = next(i for i, idx in enumerate(indices) if idx is ...)
       indices = list(indices)
       indices[ip:ip+1] = [slice(None)] * (len(shape) - len(indices) + 1)
       indices = tuple(indices)

--- a/tests/mutable_array_test.py
+++ b/tests/mutable_array_test.py
@@ -1111,6 +1111,19 @@ class MutableArrayTest(jtu.JaxTestCase):
     y_bar = jax.grad(f)(3.)
     self.assertAllClose(y_bar, 2., check_dtypes=False)
 
+  @jtu.sample_product([
+    dict(shape=(3, 4), indexer=np.index_exp[1]),
+    dict(shape=(3, 4), indexer=np.index_exp[1:4]),
+    dict(shape=(2, 3, 4), indexer=np.index_exp[..., 0]),
+    dict(shape=(2, 3, 4), indexer=np.index_exp[:, 1]),
+    dict(shape=(3, 4), indexer=np.index_exp[np.arange(2), np.arange(2)]),
+    dict(shape=(3, 4), indexer=np.index_exp[np.arange(2), ..., np.arange(2)]),
+  ])
+  def test_indexing_patterns(self, shape, indexer):
+    x = self.rng().uniform(size=shape)
+    x_ref = jax.new_ref(x)
+    self.assertArraysAllClose(x[indexer], x_ref[indexer])
+
 
 @jtu.with_config(jax_mutable_array_checks=True)
 class MutableArrayErrorsTest(jtu.JaxTestCase):


### PR DESCRIPTION
The final new test case fails without the code change here.

Related to #33322.