### PR TITLE
[ROCm] ToT ROCm Unit Test Skips

### DIFF
--- a/tests/linalg_sharding_test.py
+++ b/tests/linalg_sharding_test.py
@@ -162,7 +162,7 @@ class LinalgShardingTest(jtu.JaxTestCase):
         fun_and_shapes[0] is lax.linalg.qr and
         dtype == np.complex64):
       # numerical errors seen as of ROCm 7.2 due to rocSolver issue for qr with complex64
-      # TODO: re-enable the test once the rocSolver issue is fixed
+      # TODO(AratiGanesh): re-enable the test once the rocSolver issue is fixed
       self.skipTest("test_batch_axis_sharding_jvp13 not supported on ROCm due to rocSolver issue")
     fun, shapes = self.get_fun_and_shapes(fun_and_shapes, grad=True)
     primals = self.get_args(shapes, dtype, batch_size=8)

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -571,6 +571,10 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       )
 
   def testEighTinyNorm(self):
+    # Skip test on ROCm due to numerical error. Issue #34711
+    # TODO(GulsumGudukbay): Unskip once fixed.
+    if jtu.is_device_rocm():
+      self.skipTest("Skipped on ROCm due to numerical error.")
     rng = jtu.rand_default(self.rng())
     a = rng((300, 300), dtype=np.float32)
     eps = jnp.finfo(a.dtype).eps
@@ -2372,6 +2376,10 @@ class LaxLinalgTest(jtu.JaxTestCase):
   @jtu.sample_product(shape=[(3,), (3, 4), (3, 4, 5)],
                       dtype=float_types + complex_types)
   def test_tridiagonal_solve(self, shape, dtype):
+    # Skip test on ROCm due to numerical error. Issue #575788
+    # TODO(AratiGanesh): Unskip once fixed.
+    if jtu.is_device_rocm() and dtype == np.float32 and shape in [(3, 4), (3, 4, 5)]:
+      self.skipTest("test_tridiagonal_solve not supported on ROCm for these shapes/dtype due to rocSparse issue")
     if dtype not in float_types and jtu.test_device_matches(["gpu"]):
       self.skipTest("Data type not supported on GPU")
     rng = self.rng()
@@ -2411,10 +2419,6 @@ class LaxLinalgTest(jtu.JaxTestCase):
 
   @jtu.sample_product(shape=[(3,), (3, 4)], dtype=float_types + complex_types)
   def test_tridiagonal_solve_grad(self, shape, dtype):
-    if jtu.is_device_rocm() and shape == (3, 4) and dtype == np.float32:
-      # numerical errors seen as of ROCm 7.2 due to rocSparse issue for grad0 variant
-      # TODO: re-enable the test once the rocSparse issue is fixed
-      self.skipTest("test_tridiagonal_solve_grad0 not supported on ROCm due to rocSparse issue")
     if dtype not in float_types and jtu.test_device_matches(["gpu"]):
       self.skipTest("Data type not supported on GPU")
     rng = self.rng()

--- a/tests/pallas/gpu_ops_test.py
+++ b/tests/pallas/gpu_ops_test.py
@@ -100,6 +100,19 @@ class FusedAttentionTest(PallasBaseTest):
       use_fwd,
       use_segment_ids,
   ):
+    # Skip specific failing tests due to autotuner issue on ROCm. Issue #34711
+    # TODO(GulsumGudukbay): Unskip once fixed.
+    if jtu.is_device_rocm():
+      key = (batch_size, seq_len, num_heads, head_dim, tuple(block_sizes),
+             causal, use_fwd, use_segment_ids)
+
+      if (key in {
+            (1, 384, 1, 72, (("block_q", 64), ("block_k", 64)),  False, True,  True),   # fwd5
+            (1, 384, 1, 72, (("block_q", 64), ("block_k", 128)), False, False, True),   # fwd7
+            (2, 384, 1, 64, (("block_q", 64), ("block_k", 64)),  True,  False, True),   # fwd8
+            (1, 384, 2, 72, (("block_q", 128), ("block_k", 128)), False, True, True),   # fwd0
+          }):
+        self.skipTest("Skipped on ROCm due to autotuner issue.")
     k1, k2, k3 = random.split(random.key(0), 3)
     q = random.normal(
         k1, (batch_size, seq_len, num_heads, head_dim), dtype=jnp.float16
@@ -192,6 +205,28 @@ class FusedAttentionTest(PallasBaseTest):
       causal,
       use_segment_ids,
   ):
+    # Skip specific failing tests on ROCm due to autotuner issue. Issue #34711
+    # TODO(GulsumGudukbay): Unskip once fixed.
+    if jtu.is_device_rocm():
+      key = (batch_size, seq_len, num_heads, head_dim, tuple(block_sizes),
+             causal, use_segment_ids)
+
+      if key in {
+        (1, 384, 1, 128, (("block_q", 64), ("block_k", 64), ("block_q_dkv", 64),
+                          ("block_kv_dkv", 64), ("block_q_dq", 64), ("block_kv_dq", 64)),
+         True,  False),  # bwd1
+        (2, 384, 1, 32,  (("block_q", 64), ("block_k", 128), ("block_q_dkv", 64),
+                          ("block_kv_dkv", 32), ("block_q_dq", 32), ("block_kv_dq", 64)),
+         False, False),  # bwd2
+        (1, 384, 1, 72,  (("block_q", 128), ("block_k", 128), ("block_q_dkv", 32),
+                          ("block_kv_dkv", 32), ("block_q_dq", 32), ("block_kv_dq", 128)),
+         False, True),   # bwd7
+        (1, 384, 2, 64,  (("block_q", 64), ("block_k", 64), ("block_q_dkv", 64),
+                          ("block_kv_dkv", 64), ("block_q_dq", 64), ("block_kv_dq", 64)),
+         True,  False),  # bwd9
+      }:
+        self.skipTest("Skipped on ROCm due to autotuner issue.")
+
     if jtu.is_cuda_compute_capability_at_least("8.0"):
       # TODO(b/416306534)
       self.skipTest("Precision issues after CUDA 12.8.1 upgrade")

--- a/tests/pallas/triton_pallas_test.py
+++ b/tests/pallas/triton_pallas_test.py
@@ -289,10 +289,6 @@ class TritonPallasTest(PallasBaseTest):
 
   @parameterized.parameters("float16", "bfloat16", "float32")
   def test_approx_tanh(self, dtype):
-    # Skip approx_tanh tests on ROCm due to missing tanh.approx instruction.
-    # TODO(GulsumGudukbay): Will be unskipped once PR 34598 is merged. Issue #34711.
-    if jtu.is_device_rocm() and dtype in ("float16", "float32"):
-      self.skipTest("Skipped on ROCm due to missing tanh.approx instruction.")  # test_approx_tanh0 and test_approx_tanh2
     if self.INTERPRET:
       self.skipTest("approx_tanh is not supported in interpret mode")
 

--- a/tests/pallas/triton_pallas_test.py
+++ b/tests/pallas/triton_pallas_test.py
@@ -289,6 +289,10 @@ class TritonPallasTest(PallasBaseTest):
 
   @parameterized.parameters("float16", "bfloat16", "float32")
   def test_approx_tanh(self, dtype):
+    # Skip approx_tanh tests on ROCm due to missing tanh.approx instruction.
+    # TODO(GulsumGudukbay): Will be unskipped once PR 34598 is merged. Issue #34711.
+    if jtu.is_device_rocm() and dtype in ("float16", "float32"):
+      self.skipTest("Skipped on ROCm due to missing tanh.approx instruction.")  # test_approx_tanh0 and test_approx_tanh2
     if self.INTERPRET:
       self.skipTest("approx_tanh is not supported in interpret mode")
 

--- a/tests/qdwh_test.py
+++ b/tests/qdwh_test.py
@@ -102,6 +102,12 @@ class QdwhTest(jtu.JaxTestCase):
   )
   def testQdwhWithRandomMatrix(self, shape, log_cond, dtype):
     """Tests qdwh with upper triangular input of all ones."""
+    # ROCm: Triton GEMM autotuner cannot compile this specific case.
+    # TODO(gulsumgudukbay): Unskip once fixed. Issue #34711.
+    if (jtu.is_device_rocm()
+        and shape == (300, 300)
+        and dtype == np.float32):
+      self.skipTest("Skipped on ROCm, Triton GEMM autotuner issue.")
     eps = jnp.finfo(dtype).eps
     m, n = shape
     max_cond = np.log10(1.0 / eps)


### PR DESCRIPTION
## ROCm Skips
This PR skips a couple of failing tests for ROCm. These tests are under triage currently and are all linked to https://github.com/jax-ml/jax/issues/34711 and https://github.com/jax-ml/jax/issues/34388

The test skips are all using parameter checks. 

```
# Tests that have PRs

https://github.com/openxla/xla/pull/37992
tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd1
tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd2
tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd7
tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd9
tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd0
tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd5
tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd7
tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd8
tests/pallas/gpu_ops_test.py::FusedAttentionInterpretTest::test_fused_attention_bwd1
tests/pallas/gpu_ops_test.py::FusedAttentionInterpretTest::test_fused_attention_bwd2
tests/pallas/gpu_ops_test.py::FusedAttentionInterpretTest::test_fused_attention_bwd7
tests/pallas/gpu_ops_test.py::FusedAttentionInterpretTest::test_fused_attention_bwd9
tests/pallas/gpu_ops_test.py::FusedAttentionInterpretTest::test_fused_attention_fwd0
tests/pallas/gpu_ops_test.py::FusedAttentionInterpretTest::test_fused_attention_fwd5
tests/pallas/gpu_ops_test.py::FusedAttentionInterpretTest::test_fused_attention_fwd7
tests/pallas/gpu_ops_test.py::FusedAttentionInterpretTest::test_fused_attention_fwd8
tests/qdwh_test.py::QdwhTest::testQdwhWithRandomMatrix1


# Tests that don't have PRs yet

tests/linalg_sharding_test.py::LinalgShardingTest::test_batch_axis_sharding_jvp13
tests/linalg_test.py::NumpyLinalgTest::testEighTinyNorm
tests/linalg_test.py::LaxLinalgTest::test_tridiagonal_solve1
tests/linalg_test.py::LaxLinalgTest::test_tridiagonal_solve3

```
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->