### PR TITLE
[indexing] support pallas-like dynamic slicing in jax.numpy indexing

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -265,6 +265,7 @@ Miscellaneous
     live_arrays
     clear_caches
     typeof
+    ds
 
 .. _checkpoint-policies:
 

--- a/jax/BUILD
+++ b/jax/BUILD
@@ -204,6 +204,7 @@ py_library_providing_imports_info(
         "//jax/_src:hashable_array",
         "//jax/_src:hijax",
         "//jax/_src:image",
+        "//jax/_src:indexing",
         "//jax/_src:init",
         "//jax/_src:internal_mesh_utils",
         "//jax/_src:jaxpr_util",

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -135,6 +135,7 @@ from jax._src.core import ShapeDtypeStruct as ShapeDtypeStruct
 from jax._src.api import value_and_grad as value_and_grad
 from jax._src.api import vjp as vjp
 from jax._src.api import vmap as vmap
+from jax._src.indexing import ds as ds
 from jax._src.sharding_impls import NamedSharding as NamedSharding
 from jax._src.sharding_impls import make_mesh as make_mesh
 from jax._src.sharding_impls import set_mesh as set_mesh

--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -82,6 +82,16 @@ pytype_strict_library(
     ] + py_deps("absl/testing") + py_deps("numpy"),
 )
 
+pytype_strict_library(
+    name = "indexing",
+    srcs = ["indexing.py"],
+    deps = [
+        ":core",
+        ":tree_util",
+        ":typing",
+    ]
+)
+
 # TODO(necula): break the internal_test_util into smaller build targets.
 pytype_strict_library(
     name = "internal_test_util",
@@ -1360,6 +1370,7 @@ py_library_providing_imports_info(
         ":dtypes",
         ":error_check",
         ":export",
+        ":indexing",
         ":lax",
         ":literals",
         ":mesh",
@@ -1413,6 +1424,7 @@ pytype_strict_library(
         ":core",
         ":dtypes",
         ":effects",
+        ":indexing",
         ":pretty_printer",
         ":traceback_util",
         ":tree_util",

--- a/jax/_src/indexing.py
+++ b/jax/_src/indexing.py
@@ -1,0 +1,120 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import dataclasses
+
+from jax._src import core
+from jax._src import tree_util
+from jax._src.typing import Array
+
+
+@tree_util.register_pytree_node_class
+@dataclasses.dataclass
+class Slice:
+  """A slice with a start index and a size.
+
+  Both start index and size can either be static, i.e. known at tracing
+  and compilation time, or dynamic.
+  """
+
+  start: int | Array
+  size: int | Array
+  stride: int = 1
+
+  def __post_init__(self):
+    if self.stride < 0:
+      raise ValueError("`stride` must be >= 0.")
+
+  @property
+  def is_dynamic_start(self):
+    return not core.is_dim(self.start)
+
+  @property
+  def is_dynamic_size(self):
+    return not core.is_dim(self.size)
+
+  def tree_flatten(self):
+    # If `start` is statically known, we treat it as static information
+    xs = ()
+    data = ()
+    xs += (self.start,) if self.is_dynamic_start else (None,)
+    data += (None,) if self.is_dynamic_start else (self.start,)
+    xs += (self.size,) if self.is_dynamic_size else (None,)
+    data += (None,) if self.is_dynamic_size else (self.size,)
+    data += (self.stride,)
+    return xs, data
+
+  @classmethod
+  def tree_unflatten(cls, aux_data, children) -> Slice:
+    start, size = (
+        a if a is not None else b for a, b in zip(children, aux_data[:2])
+    )
+    return cls(start, size, aux_data[2])
+
+  @classmethod
+  def from_slice(cls, slc: slice, size: int) -> Slice:
+    start, step, size = core.canonicalize_slice(slc, size)
+    if step < 1:
+      raise ValueError(f"slice must have a step >= 1 (found: {step})")
+    return cls(start, size, step)
+
+
+def dslice(
+    start: int | Array | None,
+    size: int | Array | None = None,
+    stride: int | None = None,
+) -> slice | Slice:
+  """Constructs a ``Slice`` from a start index and a size.
+
+  The semantics of ``dslice`` mirror those of the builtin ``slice`` type:
+
+  * ``dslice(None)`` is ``:``
+  * ``dslice(j)`` is ``:j``
+  * ``dslice(i, j)`` is ``i:i+j``
+  * ``dslice(i, j, stride)`` is ``i:i+j:stride``
+
+  Examples:
+
+    >>> x = jax.numpy.arange(10)
+    >>> i = 4
+    >>> x[i: i + 2]  # standard indexing requires i to be static
+    Array([4, 5], dtype=int32)
+    >>> x[jax.ds(i, 2)]  # equivalent which allows i to be dynamic
+    Array([4, 5], dtype=int32)
+
+    Here is an explicit example of slicing with a dynamic start index:
+
+    >>> @jax.jit(static_argnames='size')
+    ... def f(x, i, size):  # example of when `
+    ...   return x[jax.ds(i, size)]
+    ...
+    >>> f(x, i, 2)
+    Array([4, 5], dtype=int32)
+  """
+  if start is None:
+    return slice(None)
+  if stride is None:
+    stride = 1
+  if not isinstance(stride, int):
+    raise ValueError("Non-static stride in `dslice`")
+  if size is None:
+    if not isinstance(start, int):
+      raise ValueError("Non-static `dslice`")
+    return Slice(0, start, stride)
+  return Slice(start, size, stride)
+
+
+ds = dslice  # Handy alias.

--- a/jax/_src/state/indexing.py
+++ b/jax/_src/state/indexing.py
@@ -22,61 +22,11 @@ from typing import Any, Union
 from jax._src import core
 from jax._src import pretty_printer as pp
 from jax._src import tree_util
+from jax._src.indexing import Slice, dslice, ds  # noqa: F401
 from jax._src.typing import Array
 from jax._src.util import merge_lists
 from jax._src.util import partition_list
 import numpy as np
-
-
-@tree_util.register_pytree_node_class
-@dataclasses.dataclass
-class Slice:
-  """A slice with a start index and a size.
-
-  Both start index and size can either be static, i.e. known at tracing
-  and compilation time, or dynamic.
-  """
-
-  start: int | Array
-  size: int | Array
-  stride: int = 1
-
-  def __post_init__(self):
-    if self.stride < 0:
-      raise ValueError("`stride` must be >= 0.")
-
-  @property
-  def is_dynamic_start(self):
-    return not core.is_dim(self.start)
-
-  @property
-  def is_dynamic_size(self):
-    return not core.is_dim(self.size)
-
-  def tree_flatten(self):
-    # If `start` is statically known, we treat it as static information
-    xs = ()
-    data = ()
-    xs += (self.start,) if self.is_dynamic_start else (None,)
-    data += (None,) if self.is_dynamic_start else (self.start,)
-    xs += (self.size,) if self.is_dynamic_size else (None,)
-    data += (None,) if self.is_dynamic_size else (self.size,)
-    data += (self.stride,)
-    return xs, data
-
-  @classmethod
-  def tree_unflatten(cls, aux_data, children) -> Slice:
-    start, size = (
-        a if a is not None else b for a, b in zip(children, aux_data[:2])
-    )
-    return cls(start, size, aux_data[2])
-
-  @classmethod
-  def from_slice(cls, slc: slice, size: int) -> Slice:
-    start, step, size = core.canonicalize_slice(slc, size)
-    if step < 1:
-      raise ValueError(f"slice must have a step >= 1 (found: {step})")
-    return cls(start, size, step)
 
 
 def _pp_slice(context: core.JaxprPpContext, dim, slc: Slice) -> str:
@@ -101,36 +51,6 @@ def _pp_slice(context: core.JaxprPpContext, dim, slc: Slice) -> str:
       end = start + size
       end_str = "" if end == dim else str(end)
       return f"{start_str}:{end_str}"
-
-
-def dslice(
-    start: int | Array | None,
-    size: int | Array | None = None,
-    stride: int | None = None,
-) -> slice | Slice:
-  """Constructs a ``Slice`` from a start index and a size.
-
-  The semantics of ``dslice`` mirror those of the builtin ``slice`` type:
-
-  * ``dslice(None)`` is ``:``
-  * ``dslice(j)`` is ``:j``
-  * ``dslice(i, j)`` is ``i:i+j``
-  * ``dslice(i, j, stride)`` is ``i:i+j:stride``
-  """
-  if start is None:
-    return slice(None)
-  if stride is None:
-    stride = 1
-  if not isinstance(stride, int):
-    raise ValueError("Non-static stride in `dslice`")
-  if size is None:
-    if not isinstance(start, int):
-      raise ValueError("Non-static `dslice`")
-    return Slice(0, start, stride)
-  return Slice(start, size, stride)
-
-
-ds = dslice  # Handy alias
 
 
 IntIndexer = Union[int, Array]

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -724,7 +724,9 @@ jax_multiplatform_test(
     deps = py_deps([
         "absl/testing",
         "numpy",
-    ]),
+    ]) + [
+        "//jax/_src:indexing",
+    ],
 )
 
 jax_multiplatform_test(


### PR DESCRIPTION
This moves `jax.experimental.pallas.ds` to `jax.ds` and adds support for this indexing mode to standard array indexing. For example:
```python
>>> import jax
>>> import jax.numpy as jnp
>>> x = jnp.arange(10)

>>> x[jax.ds(4, 2)]  # slice of length 2 starting at index 4
Array([4, 5], dtype=int32)

>>> x.at[jax.ds(4, 2)].set(99)  # works for set() and other update operations too
Array([ 0,  1,  2,  3, 99, 99,  6,  7,  8,  9], dtype=int32)

# Show that it handles dynamic start and lowers to `dynamic_slice` plus some negative indexing logic:
>>> jax.make_jaxpr(lambda x, i: x[jax.ds(i, 2)])(x, 4)
{ lambda ; a:i32[10] b:i32[]. let
    c:bool[] = lt b 0:i32[]
    d:i32[] = convert_element_type[new_dtype=int32 weak_type=False] b
    e:i32[] = add d 10:i32[]
    f:i32[] = select_n c b e
    g:i32[2] = dynamic_slice[slice_sizes=(2,)] a f
  in (g,) }

# Complicated mixed indexing modes are supported & lower to dynamic_slice when possible
>>> x = jnp.arange(12).reshape(3, 4)
>>> x[:1, jax.ds(1, 2), ..., None]
Array([[[1],
        [2]]], dtype=int32)
>>> jax.make_jaxpr(lambda x, i: x[:1, jax.ds(i, 2), ..., None])(x, 1)
{ lambda ; a:i32[3,4] b:i32[]. let
    c:bool[] = lt b 0:i32[]
    d:i32[] = convert_element_type[new_dtype=int32 weak_type=False] b
    e:i32[] = add d 4:i32[]
    f:i32[] = select_n c b e
    g:i32[1,2] = dynamic_slice[slice_sizes=(1, 2)] a 0:i32[] f
    h:i32[1,2,1] = broadcast_in_dim[
      broadcast_dimensions=(0, 1)
      shape=(1, 2, 1)
      sharding=None
    ] g
  in (h,) }

# And it lowers to gather in cases where dynamic_slice cannot be applied
# (e.g. when used together with array indices)
>>> x[jnp.arange(2), jax.ds(1, 2)]
Array([[1, 2],
       [5, 6]], dtype=int32)
>>> jax.make_jaxpr(lambda x, i: x[jnp.arange(2), jax.ds(i, 2)])(x, 1)
{ lambda ; a:i32[3,4] b:i32[]. let
    c:i32[2] = iota[dimension=0 dtype=int32 shape=(2,) sharding=None] 
    d:bool[2] = lt c 0:i32[]
    e:i32[2] = add c 3:i32[]
    f:i32[2] = select_n d c e
    g:i32[] = convert_element_type[new_dtype=int32 weak_type=False] b
    h:i32[2,1] = broadcast_in_dim[
      broadcast_dimensions=(0,)
      shape=(2, 1)
      sharding=None
    ] f
    i:i32[2,1] = broadcast_in_dim[
      broadcast_dimensions=()
      shape=(2, 1)
      sharding=None
    ] g
    j:i32[2,2] = concatenate[dimension=1] h i
    k:i32[2,2] = gather[
      dimension_numbers=GatherDimensionNumbers(offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1), operand_batching_dims=(), start_indices_batching_dims=())
      fill_value=None
      indices_are_sorted=False
      mode=GatherScatterMode.PROMISE_IN_BOUNDS
      slice_sizes=(1, 2)
      unique_indices=False
    ] a j
  in (k,) }
```