### PR TITLE
[ROCm] Add ROCm encoding for test_struct_encoding_determinism

### DIFF
--- a/tests/experimental_rnn_test.py
+++ b/tests/experimental_rnn_test.py
@@ -222,6 +222,11 @@ class RnnTest(jtu.JaxTestCase):
       self.assertIn(cuda_encoding, stablehlo)
     elif jtu.test_device_matches(["rocm"]):
       self.assertIn(rocm_encoding, stablehlo)
+    else:
+      self.fail(
+          "Running on an unsupported GPU backend for this test. "
+          "Please add the expected RnnDescriptor encoding."
+      )
 
   @jtu.run_on_devices("cuda")
   def test_no_workspace_overflow(self):

--- a/tests/experimental_rnn_test.py
+++ b/tests/experimental_rnn_test.py
@@ -216,7 +216,7 @@ class RnnTest(jtu.JaxTestCase):
     # Platform-specific binary encodings for RnnDescriptor
     cuda_encoding = '"\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\00\\00\\00\\00\\00\\00\\00\\00\\01\\00\\00\\00@\\03\\80\\00\\00\\00\\00\\00@\\01\\00\\00\\00\\00\\00\\00"'
     rocm_encoding = '"\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\00\\00\\00\\00\\00\\00\\00\\00\\01\\00\\00\\008\\00\\00\\00\\00\\00\\00\\00\\1C\\00\\00\\00\\00\\00\\00\\00"'
-    
+
     # Check that one of the expected encodings is present
     if jtu.test_device_matches(["cuda"]):
       self.assertIn(cuda_encoding, stablehlo)


### PR DESCRIPTION
## Motivation
This PR fixes the test_struct_encoding_determinism test to support ROCm by adding platform-specific assertions for the RnnDescriptor binary encoding in StableHLO output.  Previously this test hardcoded a CUDA-specific binary string representing the RnnDescriptor struct that gets embedded in the StableHLO IR. This encoding differs between cuDNN (CUDA) and MIOpen (ROCm) backends.

## Technical Details
Added platform-specific assertions for ROCm and CUDA since they produce different binary encodings in the StableHLO output.


## Test Result
<img width="2075" height="415" alt="image" src="https://github.com/user-attachments/assets/20ac292f-0a67-48c2-814b-f58c0a56504e" />



