### PR TITLE
[ROCm] Add support of executing jax tests from withing a parent workspace as…

### DIFF
--- a/jax/_src/ffi.py
+++ b/jax/_src/ffi.py
@@ -163,7 +163,16 @@ def pycapsule(funcptr):
 
 def include_dir() -> str:
   """Get the path to the directory containing header files bundled with jaxlib"""
-  jaxlib_dir = os.path.dirname(os.path.abspath(jaxlib.__file__))
+  # Handle both regular packages (__file__ is set) and namespace packages
+  # (__file__ is None but __path__ is available)
+  if jaxlib.__file__ is not None:
+    jaxlib_dir = os.path.dirname(os.path.abspath(jaxlib.__file__))
+  elif hasattr(jaxlib, '__path__') and jaxlib.__path__:
+    # For namespace packages, use the first path entry
+    jaxlib_dir = jaxlib.__path__[0]
+  else:
+    raise RuntimeError(
+        "Cannot determine jaxlib directory: neither __file__ nor __path__ is available")
   return os.path.join(jaxlib_dir, "include")
 
 

--- a/jaxlib/jax.bzl
+++ b/jaxlib/jax.bzl
@@ -68,7 +68,6 @@ PLATFORM_TAGS_DICT = {
     ("Windows", "AMD64"): ("win", "amd64"),
 }
 
-
 def get_optional_dep(package, excluded_py_versions = ["3.14", "3.14-ft"]):
     py_ver = HERMETIC_PYTHON_VERSION
     if HERMETIC_PYTHON_VERSION_KIND == "ft":

--- a/jaxlib/jax.bzl
+++ b/jaxlib/jax.bzl
@@ -68,6 +68,7 @@ PLATFORM_TAGS_DICT = {
     ("Windows", "AMD64"): ("win", "amd64"),
 }
 
+
 def get_optional_dep(package, excluded_py_versions = ["3.14", "3.14-ft"]):
     py_ver = HERMETIC_PYTHON_VERSION
     if HERMETIC_PYTHON_VERSION_KIND == "ft":
@@ -311,6 +312,7 @@ def jax_multiplatform_test(
             main = main,
             exec_properties = tf_exec_properties({"tags": test_tags}),
             visibility = jax_visibility(name),
+            legacy_create_init = 0,
         )
 
 def get_test_suite_list(paths, backends = []):


### PR DESCRIPTION
Add support of building jax targets under the umbrella workspace.
Assume a project which has as a dependency jax.
It is helpful to be able to create jaxlib out of the workspace of this project.
Also it is helpful to execute tests under the same workspace bazel test --config=rocm @jax//tests:gpu_tests
This simplifies the testing and integration of the rocm_plugins with jax.