### PR TITLE
[ROCm] Enable lobpcg tests on ROCm platform

### DIFF
--- a/tests/lobpcg_test.py
+++ b/tests/lobpcg_test.py
@@ -387,7 +387,7 @@ class F32LobpcgTest(LobpcgTest):
       linalg.lobpcg_standard(A[:50, :50], X[:50])
 
   @parameterized.named_parameters(_make_concrete_cases(f64=False))
-  @jtu.skip_on_devices("gpu")
+  @jtu.skip_on_devices("cuda")
   def testLobpcgConsistencyF32(self, matrix_name, n, k, m, tol):
     self.checkLobpcgConsistency(matrix_name, n, k, m, tol, jnp.float32)
 
@@ -404,17 +404,17 @@ class F32LobpcgTest(LobpcgTest):
 class F64LobpcgTest(LobpcgTest):
 
   @parameterized.named_parameters(_make_concrete_cases(f64=True))
-  @jtu.skip_on_devices("tpu", "gpu")
+  @jtu.skip_on_devices("tpu", "cuda")
   def testLobpcgConsistencyF64(self, matrix_name, n, k, m, tol):
     self.checkLobpcgConsistency(matrix_name, n, k, m, tol, jnp.float64)
 
   @parameterized.named_parameters(_make_concrete_cases(f64=True))
-  @jtu.skip_on_devices("tpu", "gpu")
+  @jtu.skip_on_devices("tpu", "cuda")
   def testLobpcgMonotonicityF64(self, matrix_name, n, k, m, tol):
     self.checkLobpcgMonotonicity(matrix_name, n, k, m, tol, jnp.float64)
 
   @parameterized.named_parameters(_make_callable_cases(f64=True))
-  @jtu.skip_on_devices("tpu", "gpu")
+  @jtu.skip_on_devices("tpu", "cuda")
   def testCallableMatricesF64(self, matrix_name):
     self.checkApproxEigs(matrix_name, jnp.float64)
 


### PR DESCRIPTION
Enable previously skipped lobpcg tests on ROCm by changing skip_on_devices from "gpu" to "cuda":
- testLobpcgConsistencyF32
- testLobpcgConsistencyF64
- testLobpcgMonotonicityF64
- testCallableMatricesF64

These tests validate LOBPCG (Locally Optimal Block Preconditioned Conjugate Gradient) eigenvalue solver on ROCm GPUs.

Test Results:
with this fix below tests pass:
```bash
root@0db19fc140b0:/workspace/debug_session_MI300/rocm-jax/jax# pytest -v tests/lobpcg_test.py
Test session starting on GPU ?
=================================================== test session starts ===================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.11.13', 'Platform': 'Linux-6.8.0-87-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'json-report': '1.5.0', 'rerunfailures': '16.1', 'reportlog': '1.0.0', 'hypothesis': '6.150.0', 'html': '4.1.1', 'metadata': '3.1.1'}}
rootdir: /workspace/debug_session_MI300/rocm-jax/jax
configfile: pyproject.toml
plugins: json-report-1.5.0, rerunfailures-16.1, reportlog-1.0.0, hypothesis-6.150.0, html-4.1.1, metadata-3.1.1
collected 55 items                                                                                                        

tests/lobpcg_test.py::F32LobpcgTest::testCallableMatricesF32geom_cond_100k PASSED                                   [  1%]
tests/lobpcg_test.py::F32LobpcgTest::testCallableMatricesF32geom_cond_1k PASSED                                     [  3%]
tests/lobpcg_test.py::F32LobpcgTest::testCallableMatricesF32id PASSED                                               [  5%]
tests/lobpcg_test.py::F32LobpcgTest::testCallableMatricesF32linear_cond_100k PASSED                                 [  7%]
tests/lobpcg_test.py::F32LobpcgTest::testCallableMatricesF32linear_cond_1k PASSED                                   [  9%]
tests/lobpcg_test.py::F32LobpcgTest::testCallableMatricesF32randn PASSED                                            [ 10%]
tests/lobpcg_test.py::F32LobpcgTest::testCallableMatricesF32ring_laplacian PASSED                                   [ 12%]
tests/lobpcg_test.py::F32LobpcgTest::testCallableMatricesF32sparse_10_ PASSED                                       [ 14%]
tests/lobpcg_test.py::F32LobpcgTest::testCallableMatricesF32sparse_1_ PASSED                                        [ 16%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgConsistencyF32cluster_k_1__n100 PASSED                               [ 18%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgConsistencyF32cluster_k_2__n100 PASSED                               [ 20%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgConsistencyF32cluster_k__n100 PASSED                                 [ 21%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgConsistencyF32geom_cond_100k_n100 PASSED                             [ 23%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgConsistencyF32geom_cond_1k_n100 PASSED                               [ 25%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgConsistencyF32id_n100 PASSED                                         [ 27%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgConsistencyF32linear_cond_100k_n100 PASSED                           [ 29%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgConsistencyF32linear_cond_1k_n100 PASSED                             [ 30%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgConsistencyF32ring_laplacian_n100 PASSED                             [ 32%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgMonotonicityF32cluster_k_1__n100 PASSED                              [ 34%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgMonotonicityF32cluster_k_2__n100 PASSED                              [ 36%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgMonotonicityF32cluster_k__n100 PASSED                                [ 38%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgMonotonicityF32geom_cond_100k_n100 PASSED                            [ 40%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgMonotonicityF32geom_cond_1k_n100 PASSED                              [ 41%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgMonotonicityF32id_n100 PASSED                                        [ 43%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgMonotonicityF32linear_cond_100k_n100 PASSED                          [ 45%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgMonotonicityF32linear_cond_1k_n100 PASSED                            [ 47%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgMonotonicityF32ring_laplacian_n100 PASSED                            [ 49%]
tests/lobpcg_test.py::F32LobpcgTest::testLobpcgValidatesArguments PASSED                                            [ 50%]
tests/lobpcg_test.py::F64LobpcgTest::testCallableMatricesF64geom_cond_100k PASSED                                   [ 52%]
tests/lobpcg_test.py::F64LobpcgTest::testCallableMatricesF64geom_cond_1k PASSED                                     [ 54%]
tests/lobpcg_test.py::F64LobpcgTest::testCallableMatricesF64id PASSED                                               [ 56%]
tests/lobpcg_test.py::F64LobpcgTest::testCallableMatricesF64linear_cond_100k PASSED                                 [ 58%]
tests/lobpcg_test.py::F64LobpcgTest::testCallableMatricesF64linear_cond_1k PASSED                                   [ 60%]
tests/lobpcg_test.py::F64LobpcgTest::testCallableMatricesF64randn PASSED                                            [ 61%]
tests/lobpcg_test.py::F64LobpcgTest::testCallableMatricesF64ring_laplacian PASSED                                   [ 63%]
tests/lobpcg_test.py::F64LobpcgTest::testCallableMatricesF64sparse_10_ PASSED                                       [ 65%]
tests/lobpcg_test.py::F64LobpcgTest::testCallableMatricesF64sparse_1_ PASSED                                        [ 67%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgConsistencyF64cluster_k_1__n100 PASSED                               [ 69%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgConsistencyF64cluster_k_2__n100 PASSED                               [ 70%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgConsistencyF64cluster_k__n100 PASSED                                 [ 72%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgConsistencyF64geom_cond_100k_n100 PASSED                             [ 74%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgConsistencyF64geom_cond_1k_n100 PASSED                               [ 76%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgConsistencyF64id_n100 PASSED                                         [ 78%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgConsistencyF64linear_cond_100k_n100 PASSED                           [ 80%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgConsistencyF64linear_cond_1k_n100 PASSED                             [ 81%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgConsistencyF64ring_laplacian_n100 PASSED                             [ 83%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgMonotonicityF64cluster_k_1__n100 PASSED                              [ 85%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgMonotonicityF64cluster_k_2__n100 PASSED                              [ 87%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgMonotonicityF64cluster_k__n100 PASSED                                [ 89%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgMonotonicityF64geom_cond_100k_n100 PASSED                            [ 90%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgMonotonicityF64geom_cond_1k_n100 PASSED                              [ 92%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgMonotonicityF64id_n100 PASSED                                        [ 94%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgMonotonicityF64linear_cond_100k_n100 PASSED                          [ 96%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgMonotonicityF64linear_cond_1k_n100 PASSED                            [ 98%]
tests/lobpcg_test.py::F64LobpcgTest::testLobpcgMonotonicityF64ring_laplacian_n100 PASSED                            [100%]

=================================================== 55 passed in 36.24s ===================================================
```
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->