### PR TITLE
[indexing] refactor to_static_slice & to_dynamic_slice

### DIFF
--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -103,6 +103,8 @@ STATIC_SLICE_TESTS = [
     IndexSpec(shape=(10, 8), indexer=slice(3, 1, -1), out_shape=(2, 8)),
     IndexSpec(shape=(10, 8), indexer=slice(0, 8, -1), out_shape=(0, 8)),
     IndexSpec(shape=(10, 8), indexer=slice(None, None, -1), out_shape=(10, 8)),
+    IndexSpec(shape=(10, 8), indexer=slice(12, 12, -4), out_shape=(0, 8)),
+    IndexSpec(shape=(10, 8), indexer=slice(12, 4, -4), out_shape=(2, 8)),
   ]),
   ("OneSliceIndexNonUnitStride", [
     IndexSpec(shape=(10,), indexer=slice(0, 8, 2), out_shape=(4,)),


### PR DESCRIPTION
This refactor is for a couple of reasons:

- by separating the generation of the indexing recipe from the actual execution of that recipe, the `strategy=AUTO` approach becomes safer and more efficient.
- by separating out functions for generating the indexing recipe, we can eventually reuse this code in the case of `index_update` and `dynamic_update_slice`, similar to how the `index_to_gather` code is used for this currently.
- this also paves the way for reusing this logic for pallas/ref indexing, replacing the incomplete & largely duplicative logic found in those code paths.