### PR TITLE
Extend numpy.pad to handle pad_width dictionary argument.

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3899,7 +3899,7 @@ def unwrap(p: ArrayLike, discont: ArrayLike | None = None,
 
 ### Padding
 
-PadValueLike = Union[T, Sequence[T], Sequence[Sequence[T]]]
+PadValueLike = Union[T, Sequence[T], Sequence[Sequence[T]], Dict[int, Union[T, Sequence[T]]]]
 PadValue = tuple[tuple[T, T], ...]
 
 class PadStatFunc(Protocol):
@@ -3909,6 +3909,20 @@ class PadStatFunc(Protocol):
 
 
 def _broadcast_to_pairs(nvals: PadValueLike, nd: int, name: str) -> PadValue:
+  if isinstance(nvals, dict):
+    seq = [(0, 0)] * nd
+    for axis, width in nvals.items():
+      if isinstance(width, int):
+        seq[axis] = (width, width)
+      elif (
+        isinstance(width, tuple) and len(width) == 2
+        and isinstance(width[0], int) and isinstance(width[1], int)
+      ):
+        seq[axis] = width
+      else:
+          raise TypeError(f"Invalid pad width {width} for axis {axis}")
+    nvals = seq
+
   try:
     nvals = np.asarray(tree_map(
       lambda x: core.concrete_or_error(None, x, context=f"{name} argument of jnp.pad"),
@@ -4260,6 +4274,9 @@ def pad(array: ArrayLike, pad_width: PadValueLike[int | Array | np.ndarray],
         elements after
       - ``((before_1, after_1), (before_2, after_2), ... (before_N, after_N))``: specify
         distinct ``before`` and ``after`` values for each array dimension.
+      - a ``dict`` where each key is an axis and its corresponding value is an
+        ``int`` or ``int`` pair describing the padding ``(before, after)`` or
+        ``pad`` width for that axis.
 
     mode: a string or callable. Supported pad modes are:
 
@@ -4358,9 +4375,32 @@ def pad(array: ArrayLike, pad_width: PadValueLike[int | Array | np.ndarray],
     >>> x = jnp.array([2, 3, 4])
     >>> jnp.pad(x, 2, custom_pad, before_value=-10, after_value=10)
     Array([-10, -10,   2,   3,   4,  10,  10], dtype=int32)
+
+    Specify padding using a dictionary:
+
+    >>> a = jnp.arange(1, 7).reshape(2, 3)
+    >>> jnp.pad(a, {1: (1, 2)})
+    array([[0, 1, 2, 3, 0, 0],
+           [0, 4, 5, 6, 0, 0]])
+    >>> jnp.pad(a, {-1: 2})
+    array([[0, 0, 1, 2, 3, 0, 0],
+           [0, 0, 4, 5, 6, 0, 0]])
+    >>> jnp.pad(a, {0: (3, 0)})
+    array([[0, 0, 0],
+           [0, 0, 0],
+           [0, 0, 0],
+           [1, 2, 3],
+           [4, 5, 6]])
+    >>> jnp.pad(a, {0: (3, 0), 1: 2})
+    array([[0, 0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0],
+           [0, 0, 1, 2, 3, 0, 0],
+           [0, 0, 4, 5, 6, 0, 0]])
   """
 
   array = util.ensure_arraylike("pad", array)
+
   pad_width = _broadcast_to_pairs(pad_width, np.ndim(array), "pad_width")
   if pad_width and not all(core.is_dim(p[0]) and core.is_dim(p[1])
                            for p in pad_width):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1219,6 +1219,17 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       y = jnp.pad(x, 0, mode=mode)
       self.assertTrue(dtypes.is_weakly_typed(y))
 
+  @jtu.sample_product([
+    dict(input_shape=(3, 4, 5), pad_width={-2: (1, 3)}, expected_shape=(3, 4 + 1 + 3, 5)),
+    dict(input_shape=(3, 4, 5), pad_width={0: (5, 2)}, expected_shape=(3 + 5 + 2, 4, 5)),
+    dict(input_shape=(3, 4, 5), pad_width={0: (5, 2), -1: (3, 4)}, expected_shape=(3 + 5 + 2, 4, 5 + 3 + 4)),
+    dict(input_shape=(3, 4, 5), pad_width={1: 5}, expected_shape=(3, 4 + 2 * 5, 5)),
+  ])
+  def testPadDictPadWidth(self, input_shape, pad_width, expected_shape):
+    a = jnp.zeros(input_shape)
+    result = jnp.pad(a, pad_width)
+    assert result.shape == expected_shape
+
   @jtu.sample_product(
     [dict(shape=shape, dtype=dtype)
       for shape, dtype in _shape_and_dtypes(all_shapes, default_dtypes)],


### PR DESCRIPTION
Extends [`jax.numpy.pad`](https://docs.jax.dev/en/latest/_autosummary/jax.numpy.pad.html) to handle a `pad_width` argument that is a dictionary, like [NumPy](https://numpy.org/doc/stable/reference/generated/numpy.pad.html) does.

- https://github.com/numpy/numpy/issues/29268

- https://github.com/numpy/numpy/pull/29273