### PR TITLE
chore(jax): improve type hints for `jax.jit`

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -28,7 +28,7 @@ from collections.abc import Callable, Hashable, Iterable, Sequence
 import dataclasses
 from functools import partial
 import inspect
-from typing import (Any, Literal, Optional, TypeVar, overload,
+from typing import (Any, Literal, Optional, ParamSpec, TypeVar, overload,
                     cast, TYPE_CHECKING)
 import weakref
 
@@ -154,9 +154,13 @@ class NotSpecified:
   def __repr__(self):
     return "<not-specified>"
 
+
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
+
 @overload
 def jit(
-  fun: Callable, /, *,
+  fun: Callable[_P, _T], /, *,
   in_shardings: Any = ...,
   out_shardings: Any = ...,
   static_argnums: int | Sequence[int] | None = ...,
@@ -185,11 +189,11 @@ def jit(
   backend: str | None = ...,
   inline: bool = ...,
   compiler_options: dict[str, Any] | None = ...,
-) -> Callable[[Callable], pjit.JitWrapped]:
+) -> Callable[[Callable[_P, _T]], pjit.JitWrapped]:
   ...
 
 def jit(
-  fun: Callable | NotSpecified = NotSpecified(), /, *,
+  fun: Callable[_P, _T] | NotSpecified = NotSpecified(), /, *,
   in_shardings: Any = sharding_impls.UNSPECIFIED,
   out_shardings: Any = sharding_impls.UNSPECIFIED,
   static_argnums: int | Sequence[int] | None = None,
@@ -201,7 +205,7 @@ def jit(
   backend: str | None = None,
   inline: bool = False,
   compiler_options: dict[str, Any] | None = None,
-) -> pjit.JitWrapped | Callable[[Callable], pjit.JitWrapped]:
+) -> pjit.JitWrapped | Callable[[Callable[_P, _T]], pjit.JitWrapped]:
   """Sets up ``fun`` for just-in-time compilation with XLA.
 
   Args:


### PR DESCRIPTION
Closes #34697

Hi! This is a patch as discussed in https://github.com/jax-ml/jax/issues/34697#issuecomment-3822647977.

I think this solves the type checker problem raised in #34697, with very minimal changes on the JAX side.