### PR TITLE
Fix IndexError in raise_if_error when receiving invalid error_code

### DIFF
--- a/jax/_src/error_check.py
+++ b/jax/_src/error_check.py
@@ -245,9 +245,10 @@ def raise_if_error() -> None:
   )  # clear the error code
 
   with _error_list_lock:
-    if error_code >= len(_error_list):
+    if error_code < 0 or error_code >= len(_error_list):
       # Handle invalid error codes gracefully with a standard error message.
-      # This can happen with corrupted AOT serialization data.
+      # This can happen with corrupted AOT serialization data or negative
+      # error codes that could lead to incorrect indexing.
       msg, traceback = _INVALID_ERROR_CODE_MSG, _INVALID_ERROR_CODE_TRACEBACK
     else:
       msg, traceback = _error_list[error_code]

--- a/tests/error_check_test.py
+++ b/tests/error_check_test.py
@@ -20,7 +20,6 @@ from absl.testing import parameterized
 import jax
 from jax._src import config
 from jax._src import error_check
-from jax._src.error_check import _ErrorClass, _INVALID_ERROR_CODE_MSG, _INVALID_ERROR_CODE_TRACEBACK, unwrap_from_import
 from jax._src import mesh as mesh_lib
 from jax._src import test_util as jtu
 import jax.export
@@ -391,12 +390,12 @@ class ErrorCheckTests(jtu.JaxTestCase):
         # that is out of bounds of the error_list (which is empty here)
         invalid_error_code = jnp.uint32(999)
         empty_error_list = []
-        return x + 1, _ErrorClass(invalid_error_code, empty_error_list)
+        return x + 1, error_check._ErrorClass(invalid_error_code, empty_error_list)
 
       return corrupted_fn
 
     corrupted_fn = make_corrupted_function()
-    unwrapped_fn = unwrap_from_import(corrupted_fn)
+    unwrapped_fn = error_check.unwrap_from_import(corrupted_fn)
 
     x = jnp.float32(1.0)
     _ = unwrapped_fn(x)
@@ -408,8 +407,8 @@ class ErrorCheckTests(jtu.JaxTestCase):
 
   def test_error_check_invalid_error_code_constants(self):
     """Test that the standard error message constants are defined correctly."""
-    self.assertIn("unknown error", _INVALID_ERROR_CODE_MSG)
-    self.assertIn("Traceback not available", _INVALID_ERROR_CODE_TRACEBACK)
+    self.assertIn("unknown error", error_check._INVALID_ERROR_CODE_MSG)
+    self.assertIn("Traceback not available", error_check._INVALID_ERROR_CODE_TRACEBACK)
 
 
 if __name__ == "__main__":

--- a/tests/error_check_test.py
+++ b/tests/error_check_test.py
@@ -20,6 +20,7 @@ from absl.testing import parameterized
 import jax
 from jax._src import config
 from jax._src import error_check
+from jax._src.error_check import _ErrorClass, _INVALID_ERROR_CODE_MSG, _INVALID_ERROR_CODE_TRACEBACK, unwrap_from_import
 from jax._src import mesh as mesh_lib
 from jax._src import test_util as jtu
 import jax.export
@@ -382,8 +383,6 @@ class ErrorCheckTests(jtu.JaxTestCase):
 
     https://github.com/jax-ml/jax/issues/34370
     """
-    from jax._src.error_check import _ErrorClass, unwrap_from_import
-
     def make_corrupted_function():
       """Create a function that simulates corrupted AOT import data."""
 
@@ -409,11 +408,6 @@ class ErrorCheckTests(jtu.JaxTestCase):
 
   def test_error_check_invalid_error_code_constants(self):
     """Test that the standard error message constants are defined correctly."""
-    from jax._src.error_check import (
-        _INVALID_ERROR_CODE_MSG,
-        _INVALID_ERROR_CODE_TRACEBACK,
-    )
-
     self.assertIn("unknown error", _INVALID_ERROR_CODE_MSG)
     self.assertIn("Traceback not available", _INVALID_ERROR_CODE_TRACEBACK)
 

--- a/tests/error_check_test.py
+++ b/tests/error_check_test.py
@@ -373,5 +373,50 @@ class ErrorCheckTests(jtu.JaxTestCase):
       error_check.raise_if_error()
 
 
+  def test_error_check_aot_invalid_error_code_regression(self):
+    """Regression test for issue #34370.
+
+    Verifies that invalid error codes from corrupted AOT serialization data
+    are handled gracefully with a standard error message, rather than causing
+    an IndexError.
+
+    https://github.com/jax-ml/jax/issues/34370
+    """
+    from jax._src.error_check import _ErrorClass, unwrap_from_import
+
+    def make_corrupted_function():
+      """Create a function that simulates corrupted AOT import data."""
+
+      def corrupted_fn(x):
+        # Return an _ErrorClass with an invalid error code (999)
+        # that is out of bounds of the error_list (which is empty here)
+        invalid_error_code = jnp.uint32(999)
+        empty_error_list = []
+        return x + 1, _ErrorClass(invalid_error_code, empty_error_list)
+
+      return corrupted_fn
+
+    corrupted_fn = make_corrupted_function()
+    unwrapped_fn = unwrap_from_import(corrupted_fn)
+
+    x = jnp.float32(1.0)
+    _ = unwrapped_fn(x)
+
+    # Should raise JaxValueError with the standard error message for
+    # invalid error codes, NOT an IndexError
+    with self.assertRaisesRegex(JaxValueError, "unknown error"):
+      error_check.raise_if_error()
+
+  def test_error_check_invalid_error_code_constants(self):
+    """Test that the standard error message constants are defined correctly."""
+    from jax._src.error_check import (
+        _INVALID_ERROR_CODE_MSG,
+        _INVALID_ERROR_CODE_TRACEBACK,
+    )
+
+    self.assertIn("unknown error", _INVALID_ERROR_CODE_MSG)
+    self.assertIn("Traceback not available", _INVALID_ERROR_CODE_TRACEBACK)
+
+
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Fixes #34370

This PR fixes an IndexError that occurs in raise_if_error when unwrap_from_import receives an invalid error_code from corrupted AOT serialization data.

Changes:
- Added bounds checking in raise_if_error before accessing _error_list
- Added validation in unwrap_from_import to check error_code is within valid range