### PR TITLE
Document that buffer donation is disabled under debug_nans mode

### DIFF
--- a/docs/buffer_donation.md
+++ b/docs/buffer_donation.md
@@ -121,4 +121,7 @@ fx2 = f(x)  # Still no donation (using cached compilation)
 # Clear cache and recompile to restore donation
 f.clear_cache()
 fx3 = f(x)  # Buffer donation now works
+# Using `x` now fails because its buffer was donated:
+x.block_until_ready()
+# >> RuntimeError: Invalid argument: CopyToHostAsync() called on invalid buffer
 ```

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1195,7 +1195,9 @@ debug_nans = bool_state(
     help=('Add nan checks to every operation. When a nan is detected on the '
           'output of a jit-compiled computation, call into the un-compiled '
           'version in an attempt to more precisely identify the operation '
-          'which produced the nan.'))
+          'which produced the nan. Note: enabling this option disables buffer '
+          'donation (see jax.jit donate_argnums) for functions compiled while '
+          'this mode is active.'))
 
 debug_infs = bool_state(
     name='jax_debug_infs',

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1196,7 +1196,7 @@ debug_nans = bool_state(
           'output of a jit-compiled computation, call into the un-compiled '
           'version in an attempt to more precisely identify the operation '
           'which produced the nan. Note: enabling this option disables buffer '
-          'donation (see jax.jit donate_argnums) for functions compiled while '
+          'donation (see the `donate_argnums` argument to `jax.jit`) for functions compiled while '
           'this mode is active.'))
 
 debug_infs = bool_state(


### PR DESCRIPTION
Fixes #33949

This PR documents that buffer donation is disabled when `debug_nans` mode is enabled.

Changes:
- Updated the `jax_debug_nans` config option help text to mention that buffer donation is disabled
- Added a new "Limitations" section to the buffer_donation.md documentation explaining:
  - Why donation is disabled during debug_nans mode
  - That this affects functions compiled while debug_nans is active
  - How to restore buffer donation by clearing the function cache
  - Example code demonstrating the behavior
