### PR TITLE
Fix duplicate word typos in documentation

### DIFF
--- a/docs/autodidax2_part1.py
+++ b/docs/autodidax2_part1.py
@@ -144,7 +144,7 @@ print(foo(2.00001))
 # Ordinary evaluation of `foo(2.00001)` propagates this primal-tangent pair,
 # producing `10.0000700001` as the result. The primal and tangent components are
 # well separated in scale so we can visually interpret the result as the
-# primal-tangent pair (10.0, 7.0), ignoring the the ~1e-10 truncation error at
+# primal-tangent pair (10.0, 7.0), ignoring the ~1e-10 truncation error at
 # the end.
 
 # The idea with forward-mode differentiation is to do the same thing but exactly

--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -1264,7 +1264,7 @@ def check(pred: Bool, msg: str,
     pred: if False, a FailedCheckError error is added.
     msg: error message if error is added. Can be a format string.
     debug: Whether to turn on debugging mode. If True, check will be removed
-      during execution. If False, the the check must be functionalized using
+      during execution. If False, the check must be functionalized using
       checkify.checkify.
     fmt_args, fmt_kwargs: Positional and keyword formatting arguments for
       `msg`, eg.:

--- a/jax/_src/pallas/hlo_interpreter.py
+++ b/jax/_src/pallas/hlo_interpreter.py
@@ -375,7 +375,7 @@ def pallas_call_hlo_interpret(
   discharged_jaxpr, discharged_consts, scratch_avals = kernel_to_hlo_jaxpr(
       jaxpr, (), grid_mapping, backend=backend)
   if debug:
-    print(f"\nJaxpr of the the kernel in pallas_call {debug_info.func_src_info}:")
+    print(f"\nJaxpr of the kernel in pallas_call {debug_info.func_src_info}:")
     print(discharged_jaxpr)
   out = _initialize_output_vals(grid_mapping.block_mappings_output,
                                 args, input_output_aliases)


### PR DESCRIPTION
This PR fixes duplicate word typos in documentation.

Changes:
- Fixed "the the" -> "the" in checkify.py docstring (line 1267)
- Fixed "the the" -> "the" in hlo_interpreter.py debug message (line 378)
