### PR TITLE
Fix make_jaxpr with return_shape=True for HiType outputs

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2588,9 +2588,9 @@ def make_jaxpr(
       jaxpr = traced.jaxpr
     if return_shape:
       def aval_to_shape_struct(aval):
-        if hasattr(aval, 'shape') and hasattr(aval, 'dtype'):
+        try:
           return ShapeDtypeStruct(aval.shape, aval.dtype)
-        else:
+        except AttributeError:
           # For HiType and other abstract values without shape/dtype,
           # return the aval itself as it already describes the type
           return aval

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2587,7 +2587,14 @@ def make_jaxpr(
     else:
       jaxpr = traced.jaxpr
     if return_shape:
-      out = [ShapeDtypeStruct(o.shape, o.dtype) for o in jaxpr.out_avals]
+      def aval_to_shape_struct(aval):
+        if hasattr(aval, 'shape') and hasattr(aval, 'dtype'):
+          return ShapeDtypeStruct(aval.shape, aval.dtype)
+        else:
+          # For HiType and other abstract values without shape/dtype,
+          # return the aval itself as it already describes the type
+          return aval
+      out = [aval_to_shape_struct(o) for o in jaxpr.out_avals]
       return jaxpr, tree_unflatten(tree_structure(traced.out_info), out)
     return jaxpr
 


### PR DESCRIPTION
Fixes #34193

This PR fixes an AttributeError that occurs when using `jax.make_jaxpr` with `return_shape=True` on functions that return a HiType.

The issue was that the code assumed all output avals have `shape` and `dtype` attributes, but HiType (and similar abstract value types) do not have these attributes directly.

Changes:
- Added a helper function `aval_to_shape_struct` that checks whether an aval has `shape` and `dtype` attributes before creating a ShapeDtypeStruct
- For avals without these attributes (like HiType), the function returns the aval itself as it already describes the type
