### PR TITLE
Emit DeprecationWarning for integer overflow in `convert_element_type`

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -179,7 +179,9 @@ class LaxTest(jtu.JaxTestCase):
     self.assertEqual(out.aval.weak_type, weak_type)
 
   def testConvertElementTypeOOB(self):
-    out = lax.convert_element_type(2 ** 32, 'int32')
+    # Overflow emits DeprecationWarning but still produces wrapped result
+    with self.assertWarnsRegex(DeprecationWarning, "Python integer 4294967296 overflows when cast to int32"):
+      out = lax.convert_element_type(2 ** 32, 'int32')
     self.assertEqual(out, 0)
 
   @jtu.sample_product(


### PR DESCRIPTION
This PR adds a `DeprecationWarning` to `lax.convert_element_type` when converting values that overflow the target `new_dtype`.

The goal is to prevent silent reliance on overflowed (garbage) values and make unsafe dtype conversions more visible to users.

Includes tests to ensure the warning is emitted.

Fixes #31426.
