### PR TITLE
refactor: replace assert False with proper ValueError in serialization

### DIFF
--- a/jax/_src/export/serialization.py
+++ b/jax/_src/export/serialization.py
@@ -377,7 +377,8 @@ def _deserialize_pytreedef_to_pytree(p: ser_flatbuf.PyTreeDef):
     auxdata = deserialize_auxdata(p.CustomAuxdataAsNumpy().tobytes())
     return from_iter(auxdata, children)
   else:
-    assert False, kind
+    raise ValueError(
+        f"Cannot deserialize PyTreeDef with unknown kind: {kind}")
 
 
 _dtype_to_dtype_kind = {
@@ -718,4 +719,4 @@ def _deserialize_disabled_safety_check(
     # TODO(necula): remove this after June 2025, when we should not have any
     # more serialized artifacts with shape_assertions.
     return _export.DisabledSafetyCheck.custom_call("no op")
-  assert False, kind
+  raise ValueError(f"Cannot deserialize DisabledSafetyCheck with unknown kind: {kind}")


### PR DESCRIPTION
## Summary

This PR replaces two `assert False, kind` statements in `jax/_src/export/serialization.py` with proper `ValueError` exceptions.

Fixes #34828

## Problem

The current code uses `assert False, kind` in two deserialization functions:
- `_deserialize_pytreedef_to_pytree()` (line 380)
- `_deserialize_disabled_safety_check()` (line 721)

This is problematic because:
1. **Assertions can be disabled** with `python -O` flag, which would cause silent failures
2. **AssertionError is not semantic** - for invalid data, `ValueError` is more appropriate
3. **Error messages are minimal** - just shows the kind value with no context

## Solution

Replace each `assert False, kind` with `raise ValueError(...)` that provides:
- Proper exception type (`ValueError`)
- Clear error message explaining what went wrong
- The invalid kind value for debugging

This matches the existing error handling pattern in the same file (e.g., line 371).

## Changes

| Location | Before | After |
|----------|--------|-------|
| Line 380 | `assert False, kind` | `raise ValueError(f"Cannot deserialize PyTreeDef with unknown kind: {kind}")` |
| Line 721 | `assert False, kind` | `raise ValueError(f"Cannot deserialize DisabledSafetyCheck with unknown kind: {kind}")` |

## Testing

This is a code quality refactoring with no change in behavior for valid inputs. All existing tests should continue to pass.