### PR TITLE
Skip a multi-device test earlier if there's only one device

### DIFF
--- a/tests/pallas/gpu_pallas_distributed_test.py
+++ b/tests/pallas/gpu_pallas_distributed_test.py
@@ -59,6 +59,10 @@ class TestCase(jt_multiprocess.MultiProcessTest if is_nvshmem_used() is None els
     if os.environ.get("XLA_PYTHON_CLIENT_ALLOCATOR", "") == "platform":
       self.skipTest("NVSHMEM doesn't work with the platform allocator.")
 
+    # Skipping here avoids attempting communicator initialization on 1-device systems
+    if jax.device_count() == 1:
+      self.skipTest("Test requires multiple devices")
+
     super().setUp()
 
 


### PR DESCRIPTION
This makes it more convenient/efficient to run the whole test suite on single-GPU systems.