### PR TITLE
[ROCm] Enable test deviceless aot compile test on ROCm

### DIFF
--- a/tests/aot_test.py
+++ b/tests/aot_test.py
@@ -265,7 +265,7 @@ class JaxAotTest(jtu.JaxTestCase):
   @jtu.run_on_devices('gpu')
   def test_deviceless_aot_compile(self):
     target_config = xc.get_topology_for_devices(jax.devices()).target_config
-    gpu_platform = jax.default_backend()  # Capture before switching to cpu
+    gpu_platform = jax.devices()[0].platform  # Capture before switching to cpu
     with jtu.global_config_context(jax_platforms="cpu"):
       topology = topologies.get_topology_desc(
         platform=gpu_platform,

--- a/tests/aot_test.py
+++ b/tests/aot_test.py
@@ -265,9 +265,10 @@ class JaxAotTest(jtu.JaxTestCase):
   @jtu.run_on_devices('gpu')
   def test_deviceless_aot_compile(self):
     target_config = xc.get_topology_for_devices(jax.devices()).target_config
+    gpu_platform = jax.default_backend()  # Capture before switching to cpu
     with jtu.global_config_context(jax_platforms="cpu"):
       topology = topologies.get_topology_desc(
-        platform="cuda",
+        platform=gpu_platform,
         target_config=target_config,
         topology="1x1x1",
       )
@@ -287,7 +288,7 @@ class JaxAotTest(jtu.JaxTestCase):
         serialized_executable,
         in_tree,
         out_tree,
-        backend="cuda",
+        backend=gpu_platform,
         execution_devices=jax.devices()[:1]
     )
     input = jnp.array([[0., 1.], [2., 3.]], dtype=jnp.float32, device=jax.devices()[0])


### PR DESCRIPTION
Use jax.devices()[0].platform to dynamically detect the GPU platform instead of hardcoding "cuda". This allows the test to run on both CUDA and ROCm GPUs.

Test Result:
Below is my test result with the fix
```bash
root@181fc0e37fc6:/workspace/debug_session_MI300/rocm-jax/jax# pytest tests/aot_test.py::JaxAotTest::test_deviceless_aot_compile -v
Test session starting on GPU ?
====================================================================================== test session starts ======================================================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.11.13', 'Platform': 'Linux-6.8.0-87-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'json-report': '1.5.0', 'rerunfailures': '16.1', 'reportlog': '1.0.0', 'hypothesis': '6.151.5', 'html': '4.2.0', 'metadata': '3.1.1'}}
rootdir: /workspace/debug_session_MI300/rocm-jax/jax
configfile: pyproject.toml
plugins: json-report-1.5.0, rerunfailures-16.1, reportlog-1.0.0, hypothesis-6.151.5, html-4.2.0, metadata-3.1.1
collected 1 item                                                                                                                                                                                

tests/aot_test.py::JaxAotTest::test_deviceless_aot_compile PASSED                                                                                                                         [100%]

======================================================================================= 1 passed in 2.30s =======================================================================================
```
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->