### PR TITLE
[RFC] Enabled unused-variable in Ruff's config

### DIFF
--- a/docs/autodidax.ipynb
+++ b/docs/autodidax.ipynb
@@ -2334,7 +2334,7 @@
     "    @func.func(*(aval_to_ir_type(aval) for aval in in_avals))\n",
     "    def inner_xla_call(*params):\n",
     "      return jaxpr_subcomp(c, jaxpr, params)\n",
-    "    name = c.symbol_table.insert(inner_xla_call.func_op)\n",
+    "    c.symbol_table.insert(inner_xla_call.func_op)\n",
     "  return func.CallOp(inner_xla_call.func_op, in_vals).results\n",
     "hlo_translations[xla_call_p] = xla_call_translation"
    ]

--- a/docs/autodidax.md
+++ b/docs/autodidax.md
@@ -1831,7 +1831,7 @@ def xla_call_translation(c, in_avals, out_avals, in_vals, *, jaxpr, num_consts):
     @func.func(*(aval_to_ir_type(aval) for aval in in_avals))
     def inner_xla_call(*params):
       return jaxpr_subcomp(c, jaxpr, params)
-    name = c.symbol_table.insert(inner_xla_call.func_op)
+    c.symbol_table.insert(inner_xla_call.func_op)
   return func.CallOp(inner_xla_call.func_op, in_vals).results
 hlo_translations[xla_call_p] = xla_call_translation
 ```

--- a/docs/autodidax.py
+++ b/docs/autodidax.py
@@ -1825,7 +1825,7 @@ def xla_call_translation(c, in_avals, out_avals, in_vals, *, jaxpr, num_consts):
     @func.func(*(aval_to_ir_type(aval) for aval in in_avals))
     def inner_xla_call(*params):
       return jaxpr_subcomp(c, jaxpr, params)
-    name = c.symbol_table.insert(inner_xla_call.func_op)
+    c.symbol_table.insert(inner_xla_call.func_op)
   return func.CallOp(inner_xla_call.func_op, in_vals).results
 hlo_translations[xla_call_p] = xla_call_translation
 

--- a/docs/notebooks/autodiff_remat.ipynb
+++ b/docs/notebooks/autodiff_remat.ipynb
@@ -579,7 +579,7 @@
    "source": [
     "def f_grad_bad2(x):\n",
     "  y, g_vjp = jax.vjp(g, x)  # step 1\n",
-    "  z = h(y)                  # step 2\n",
+    "  _z = h(y)                 # step 2\n",
     "  _, h_vjp = jax.vjp(h, y)  # step 3\n",
     "  y_bar, = h_vjp(1.0)       # step 3\n",
     "  x_bar, = g_vjp(y_bar)     # step 5\n",

--- a/docs/notebooks/autodiff_remat.md
+++ b/docs/notebooks/autodiff_remat.md
@@ -296,7 +296,7 @@ That is, in code we'd have something like:
 ```{code-cell}
 def f_grad_bad2(x):
   y, g_vjp = jax.vjp(g, x)  # step 1
-  z = h(y)                  # step 2
+  _z = h(y)                 # step 2
   _, h_vjp = jax.vjp(h, y)  # step 3
   y_bar, = h_vjp(1.0)       # step 3
   x_bar, = g_vjp(y_bar)     # step 5

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -779,9 +779,9 @@ def _transpose_jaxpr(jaxpr: core.ClosedJaxpr,
 
     # Evaluate nonlinear parts using partial evaluation to get a linear jaxpr.
     ins_iter = iter(ins_flat)
-    in_pvals = [pe.PartialVal.unknown(aval) if lin else
-                pe.PartialVal.known(next(ins_iter))
-                for aval, lin in zip(jaxpr.in_avals, in_lin)]
+    _in_pvals = [pe.PartialVal.unknown(aval) if lin else
+                 pe.PartialVal.known(next(ins_iter))
+                 for aval, lin in zip(jaxpr.in_avals, in_lin)]
     assert next(ins_iter, None) is None
 
     # TODO(mattjj): revise not to require disabling checks

--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -643,7 +643,7 @@ def fun_sourceinfo(fun: Callable) -> str:
     filename = fun.__code__.co_filename
     lineno = fun.__code__.co_firstlineno
     return f"{fun.__name__} at {filename}:{lineno}"
-  except AttributeError as e:
+  except AttributeError:
     try:
       fun_str = str(fun)
     except:

--- a/jax/_src/clusters/cloud_tpu_cluster.py
+++ b/jax/_src/clusters/cloud_tpu_cluster.py
@@ -120,7 +120,7 @@ class BaseTpuCluster(clusters.ClusterEnv):
     coordinator_retry_secs = 5
     while not coordinator_found and time.time() < max_time:
       try:
-        ip_address = socket.gethostbyname(coordinator_address)
+        socket.gethostbyname(coordinator_address)
         coordinator_found = True
         logger.debug("Found coordinator with address %s", coordinator_address)
       except socket.gaierror:

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2574,7 +2574,6 @@ def _ref_to_lojax(init_val, *, memory_space, kind):
   from jax._src.state.types import AbstractRef  # pytype: disable=import-error
   val_ty = typeof(init_val)
   hival_of_refs = val_ty.raise_val(*map(new_ref, val_ty.lower_val(init_val)))  # type: ignore
-  aval = AbstractRef(typeof(init_val))
   return Ref(AbstractRef(val_ty), hival_of_refs)
 ref_p.to_lojax = _ref_to_lojax  # type: ignore
 
@@ -3454,7 +3453,6 @@ def _check_call(ctx_factory, prim, in_atoms, params):
 
   check_jaxpr(call_jaxpr)
 
-  invars, outvars = call_jaxpr.invars, call_jaxpr.outvars
   out_avals = [x.aval for x in call_jaxpr.outvars]
   out_type = out_avals
   # jaxpr input effects are indexed to include jaxpr.constvars, but the eqn

--- a/jax/_src/cudnn/scaled_matmul_stablehlo.py
+++ b/jax/_src/cudnn/scaled_matmul_stablehlo.py
@@ -318,7 +318,6 @@ def _scaled_matmul_batcher(batched_args, batch_dims, *, preferred_element_type):
       and batch_dims[0] == batch_dims[2]
       and batch_dims[0] == batch_dims[3]
   )
-  lhs_bdims = batch_dims[0]
   out_bdims = (batch_dims[0],)
   lhs, rhs, lhs_scales, rhs_scales = batched_args
   *batch, lhs_non_contracting, contracting = lhs.shape
@@ -614,7 +613,6 @@ def scaled_dot_general_transpose_lhs(
   else:
     ans_batch, _, ans_y = ranges_like(x_batch, x_kept, y_kept)
 
-  dims = ((ans_y, y_kept), (ans_batch, y_batch))
   x_contract_sorted_by_y = list(np.take(x_contract, np.argsort(y_contract)))
   out_axes = np.argsort(list(x_batch) + x_kept + x_contract_sorted_by_y)
 

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -761,7 +761,6 @@ def _check_primal_refs(
 
 def _check_for_aliased_refs(
     f: Callable, nondiff_argnums: Sequence[int], debug: core.DebugInfo, args):
-  nondiff_argnums_ = set(nondiff_argnums)
   argnums = [x for i, arg in enumerate(args)
              for x in [i] * tree_structure(arg).num_leaves]
   leaves = tree_leaves(args)

--- a/jax/_src/export/serialization.py
+++ b/jax/_src/export/serialization.py
@@ -176,8 +176,6 @@ def _serialize_array(
 
 
 def _deserialize_exported(exp: ser_flatbuf.Exported) -> _export.Exported:
-  serialization_version = exp.SerializationVersion()
-
   fun_name = exp.FunctionName().decode("utf-8")
   in_tree = tree_util.tree_structure(
       _deserialize_pytreedef_to_pytree(exp.InTree())

--- a/jax/_src/export/shape_poly_decision.py
+++ b/jax/_src/export/shape_poly_decision.py
@@ -385,8 +385,8 @@ class _DecisionByElimination:
       return
 
     # It is a factor, is it a variable?
-    if (v := f.to_var()) is not None:
-      self.combine_and_add_constraint(Comparator.GEQ, t_e, 1)  # v >= 1
+    if f.to_var() is not None:
+      self.combine_and_add_constraint(Comparator.GEQ, t_e, 1)  # f.to_var() >= 1
       return
 
     for oper in f.operands:

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1857,7 +1857,6 @@ def _drop_unused_vars(constvars, constvals, eqns, outvars
   def vars(atom: Atom) -> list[Var]:
     if isinstance(atom, Literal):
       return []
-    aval = atom.aval
     return [atom]
   used: set[Var] = {v for atom in outvars for v in vars(atom)}
   for eqn in eqns[::-1]:
@@ -2060,7 +2059,7 @@ class DynamicJaxprTrace(core.Trace):
     else:
       try:
         out_avals, effs = _cached_abstract_eval(primitive, *aval_qdds, **params)
-      except Exception as e:
+      except Exception:
         # TODO(phawkins): remove this 3 months after the release of JAX v0.7.
         _verify_params_are_hashable(primitive, params)
         raise
@@ -2597,7 +2596,7 @@ def lower_traceable(jaxpr, *lo_args):
              if not aval.has_qdd else
              aval.new_from_loval(*it.islice(lo_args_, len(aval.lo_ty())))
              for aval in jaxpr.in_aval_qdds]
-  assert (problem := next(lo_args_, None)) is None
+  assert (_problem := next(lo_args_, None)) is None
   hi_outs = core.jaxpr_as_fun(jaxpr)(*hi_args)
   mut_outs = [lo_val for aval, hi_arg in zip(jaxpr.final_aval_qdds, hi_args) if aval.has_qdd
               for lo_val in aval.read_loval(hi_arg)]

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -491,7 +491,6 @@ class MapTrace(core.Trace):
                            (primitive, tuple(params.items())))
     tracers = map(self.to_map_tracer, tracers)
     vals, shard_axes = unzip2([(t.val, t.shard_axes) for t in tracers])
-    info = self.emap_info
     names = core.get_axis_env().axis_names()
     all_axes = tuple(_map_schedule(map(s.get, names)) for s in shard_axes)  # pytype: disable=wrong-arg-types  # always-use-return-annotations
     f_mapped, out_shard_axes = _multi_pmap(f, self.emap_info, names, all_axes)
@@ -750,7 +749,6 @@ def stage_parallel_callable(
       _shard_aval(pci.axis_size, axis, aval) if axis is not None else aval
       for axis, aval in safe_zip(pci.in_axes, pci.avals))
 
-  orig_fun = fun
   fun = _change_argument_ranks(fun, pci.in_axes, pci.out_axes_thunk)
   with core.extend_axis_env_nd([(pci.axis_name, pci.global_axis_size)]):
     with dispatch.log_elapsed_time(

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -529,7 +529,6 @@ def _cond_linearize(nzs, *primals_in, branches, **params):
     branch_res_avals.append(res_avals)
 
   all_res_avals, res_avals_per_branch = _merge_branch_residuals(branch_res_avals)
-  num_res = len(all_res_avals)
   primal_jaxprs = _join_cond_outputs(
       primal_jaxprs, all_res_avals, res_avals_per_branch, len(nzs_out))
   tangent_jaxprs = _join_cond_pe_staged_jaxpr_inputs(

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -345,7 +345,7 @@ def _infer_scan_length(
   if length is not None:
     try:
       return int(length)
-    except core.ConcretizationTypeError as err:
+    except core.ConcretizationTypeError:
       msg = ('The `length` argument to `scan` expects a concrete `int` value.'
              ' For scan-like iteration with a dynamic length, use `while_loop`'
              ' or `fori_loop`.')
@@ -804,7 +804,6 @@ def _scan_partial_eval(trace, *tracers, reverse: bool,
   tracers = [trace.instantiate_const(t) if uk else t
              for t, uk in zip(tracers, unknowns)]
   known_ins   = [t.pval.get_known() for t in tracers if     t.pval.is_known()]
-  unknown_ins = [t                  for t in tracers if not t.pval.is_known()]
 
   # At this point all non-forwarded residuals are treated as extensive outputs
   # of jaxpr_known. Hoist out those that only depend on consts.

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -7065,8 +7065,6 @@ def _reshape_shape_rule(operand, *, new_sizes, dimensions, sharding):
     msg = 'reshape new_sizes must all be positive, got {}.'
     raise TypeError(msg.format(new_sizes))
   # TODO(necula): re-enable this check
-  operand_size = math.prod(np.shape(operand))
-  new_size = math.prod(new_sizes)
   if dimensions is not None:
     if set(dimensions) != set(range(np.ndim(operand))):
       msg = ('reshape dimensions must be a permutation of operand dimensions, '

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -2040,7 +2040,6 @@ def _gather_spec_computation(operand, indices, dimension_numbers, slice_sizes):
   operand_batching_dims = dimension_numbers.operand_batching_dims
   start_indices_batching_dims = dimension_numbers.start_indices_batching_dims
   output_shape_rank = len(offset_dims) + indices.ndim - 1
-  index_vector_dim = indices.ndim - 1
 
   operand_spec = operand.sharding.spec
   indices_spec = list(indices.sharding.spec)

--- a/jax/_src/numpy/array_constructors.py
+++ b/jax/_src/numpy/array_constructors.py
@@ -47,7 +47,7 @@ for pkg_name in ['jax_cuda13_plugin', 'jax_cuda12_plugin', 'jaxlib.cuda']:
 
 def _supports_buffer_protocol(obj):
   try:
-    view = memoryview(obj)
+    memoryview(obj)
   except TypeError:
     return False
   else:

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -6388,7 +6388,7 @@ def repeat(a: ArrayLike, repeats: ArrayLike, axis: int | None = None, *,
   try:
     return _repeat(repeats, a, axis=axis,
                    total_repeat_length=total_repeat_length)
-  except core.ShardingTypeError as e:
+  except core.ShardingTypeError:
     raise ValueError(
         "Please pass sharding to `jnp.repeat` via `out_sharding` parameter.")
 

--- a/jax/_src/pallas/hlo_interpreter.py
+++ b/jax/_src/pallas/hlo_interpreter.py
@@ -409,8 +409,6 @@ def pallas_call_hlo_interpret(
   # Pad values to evenly divide into block dimensions. This matches the
   # behavior of the non-interpret mode. We pad with NaN, to make it easier
   # to catch OOB accesses.
-  for carry_element in carry:
-    aval = carry_element.aval
 
   carry = map(_pad_to_block_dimension, carry, block_shapes)
   carry.extend(scratch_values)

--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -1740,7 +1740,6 @@ def _prng_key_load_lowering_rule(ctx: LoweringRuleContext, *args_flat, args_tree
   key_shape = aval_out.dtype._impl.key_shape
   ref_block_shape, *_ = ctx.block_shapes
   idx = cast(NDIndexer, idx)
-  inner_aval = jax_core.physical_aval(ref_aval.inner_aval)  # pytype: disable=wrong-arg-types
   ref, ref_block_shape = _transform_ref(
       ref, ref_aval, ref_block_shape, prev_transforms
   )
@@ -1900,9 +1899,6 @@ def _masked_swap_lowering_rule(
   ]
   mem_aval = aval_out.update(
       shape=tuple(mem_slice_shape), sharding=jax_core.get_cur_mesh_sharding()
-  )
-  mem_aval_shape = ctx.lowering_context.dynamic_shape_replacement_fn(
-      mem_aval.shape
   )
   mem_aval_vec_type = ir.VectorType.get(
       ctx.lowering_context.dynamic_shape_replacement_fn(mem_aval.shape),
@@ -2512,9 +2508,6 @@ def _gather_lowering_rule(
   if in_aval.shape != indices_aval.shape[:-1] != out_aval.shape:
     raise ValueError("Shape mismatch in input, indices and output")
 
-  out_type = aval_to_ir_type(
-      ctx.lowering_context.dynamic_shape_replacement_fn, out_aval
-  )
   # During lowering jnp.take_along_axis to lax.gather, we append extra dimension
   # to the end of the indices array. We should reshape it back to the original
   # shape before lowering to Mosaic and rely on MLIR canonicalization to remove

--- a/jax/_src/pallas/mosaic_gpu/lowering.py
+++ b/jax/_src/pallas/mosaic_gpu/lowering.py
@@ -1577,7 +1577,7 @@ def _handle_transforms(
         else:
           new_transforms.append(t)
           new_transforms_avals.append(t_aval)
-      case ReshapeTransform(shape=shape) if handle_reshapes:
+      case ReshapeTransform() if handle_reshapes:
         t, _, new_transforms, new_transforms_avals = _bubble_up_transform(
             ctx, ref_aval, new_transforms, new_transforms_avals, t, t_aval
         )

--- a/jax/_src/pallas/mosaic_gpu/primitives.py
+++ b/jax/_src/pallas/mosaic_gpu/primitives.py
@@ -525,7 +525,6 @@ def _copy_gmem_to_smem_lowering(
   barrier_ref_aval = ctx.avals_in[2]
   src_transforms = src_transforms_treedef.unflatten(flat_src_transforms)
   dst_transforms = dst_transforms_treedef.unflatten(flat_dst_transforms)
-  barrier_transforms = barrier_transforms_treedef.unflatten(flat_barrier_transforms)
   handle_transposes = (
       ctx.module_ctx.lowering_semantics == mgpu.LoweringSemantics.Warpgroup
   )
@@ -1736,9 +1735,9 @@ def _tcgen05_mma_lowering(
   avals = list(ctx.avals_in[4:])
   if arrive:
     barrier_ref, leaves = leaves[0], leaves[1:]
-    barrier_ref_aval, avals = avals[0], avals[1:]
+    _barrier_ref_aval, avals = avals[0], avals[1:]
   else:
-    barrier_ref = barrier_ref_aval = None
+    barrier_ref = None
   if scaled:
     a_scale_ref, b_scale_ref, leaves = leaves[0], leaves[1], leaves[2:]
     a_scale_ref_aval, b_scale_ref_aval, avals = avals[0], avals[1], avals[2:]
@@ -2009,9 +2008,9 @@ def _tcgen05_mma_lowering_wg(
   avals = list(ctx.avals_in[4:])
   if arrive:
     barrier_ref, leaves = leaves[0], leaves[1:]
-    barrier_ref_aval, avals = avals[0], avals[1:]
+    _barrier_ref_aval, avals = avals[0], avals[1:]
   else:
-    barrier_ref = barrier_ref_aval = None
+    barrier_ref = None
 
   if scaled:
     # Scales are not supported for WG semantics, but we still need to unpack them

--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -1148,7 +1148,7 @@ def _pallas_call_lowering(
             from jax._src.pallas.triton import pallas_call_registration  # type: ignore
         case _:
           raise ValueError(f"Unsupported backend: {backend}")
-    except ImportError as e:
+    except ImportError:
       raise _unsupported_lowering_error("gpu")
 
     return pallas_call_registration.pallas_call_lowering(

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -3213,12 +3213,6 @@ def hyp2f1(a: ArrayLike, b: ArrayLike, c: ArrayLike, x: ArrayLike) -> Array:
   cb = c - b
 
   id = jnp.round(d)
-  ica = jnp.round(ca)
-  icb = jnp.round(cb)
-
-  neg_int_ca = jnp.logical_and(ca <= 0, jnp.abs(ca - ica) < eps)
-  neg_int_cb = jnp.logical_and(cb <= 0, jnp.abs(cb - icb) < eps)
-  neg_int_ca_or_cb = jnp.logical_or(neg_int_ca, neg_int_cb)
 
   index = jnp.where(jnp.logical_or(x == 0, jnp.logical_and(jnp.logical_or(a == 0, b == 0), c != 0)), 0,
             jnp.where(jnp.logical_or(c == 0, jnp.logical_and(c < 0, c % 1 == 0)), 1,

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1799,7 +1799,7 @@ def complex_plane_sample(dtype, size_re=10, size_im=None):
 
   def make_axis_points(size):
     prec_dps_ratio = 3.3219280948873626
-    logmin = logmax = finfo.maxexp / prec_dps_ratio
+    logmin = finfo.maxexp / prec_dps_ratio
     logtiny = finfo.minexp / prec_dps_ratio
     axis_points = np.zeros(3 + 2 * size, dtype=finfo.dtype)
 

--- a/jax/experimental/jax2tf/tests/sharding_test.py
+++ b/jax/experimental/jax2tf/tests/sharding_test.py
@@ -134,7 +134,6 @@ class ShardingTest(tf_test_util.JaxToTfTestCase):
     logging.info("[%s] Got TF graph %s",
                  self._testMethodName,
                  f_tf_fun.get_concrete_function(*args_tf).graph.as_graph_def())
-    device_name = f"/device:{jtu.device_under_test().upper()}:0"
     tf_hlo_generator = f_tf_fun.experimental_get_compiler_ir(*args_tf)
     tf_hlo = tf_hlo_generator(
         stage="hlo", platform_name=jtu.device_under_test().upper()
@@ -426,8 +425,6 @@ class ShardingTest(tf_test_util.JaxToTfTestCase):
     count_in_replicated = self.GEQ(2) if in_shardings in [None, "missing"] else 0
     # Annotation count for the contangent input
     count_out_P = self.GEQ(1) if out_shardings == "P" else 0
-    # With native serialization even unspecified shardings turn into replicated
-    count_out_replicated = self.GEQ(1) if out_shardings in [None, "missing"] else 0
 
     self.check_sharding(f_grad_tf, [x, x.T],
         checks=[

--- a/jax/experimental/mosaic/gpu/examples/matmul.py
+++ b/jax/experimental/mosaic/gpu/examples/matmul.py
@@ -118,7 +118,6 @@ def build_kernel(
     wgmma_impl=WGMMADefaultImpl,
     profiler_spec: profiler.ProfilerSpec | None = None,
 ):
-  f32 = ir.F32Type.get()
   if tile_m % 64 != 0:
     raise ValueError(f"{tile_m=} must be divisible by 64")
   if m % tile_m != 0:

--- a/jax/experimental/mosaic/gpu/tcgen05.py
+++ b/jax/experimental/mosaic/gpu/tcgen05.py
@@ -185,7 +185,6 @@ def mma(
   if a_swizzle == 16 or b_swizzle == 16:
     raise NotImplementedError("No swizzle is not supported")
   i32 = ir.IntegerType.get_signless(32)
-  i64 = ir.IntegerType.get_signless(64)
   if isinstance(accumulate, bool):
     accumulate = arith.constant(ir.IntegerType.get_signless(1), accumulate)
   num_cta = 2 if collective else 1
@@ -579,7 +578,6 @@ def _do_mma(
 ) -> None:
   i1 = ir.IntegerType.get_signless(1)
   i32 = ir.IntegerType.get_signless(32)
-  i64 = ir.IntegerType.get_signless(64)
   a_k_idx_tiling, a_k_strides = a_k_strides or (None, None)
   b_k_idx_tiling, b_k_strides = b_k_strides
   assert all(s % 16 == 0 for s in itertools.chain(a_k_strides or (), b_k_strides))

--- a/jax/experimental/mosaic/gpu/utils.py
+++ b/jax/experimental/mosaic/gpu/utils.py
@@ -157,7 +157,6 @@ def debug_print(fmt, *args, uniform=True, scope=None):
   new_args = []
   for arg in args:
     if isinstance(arg.type, ir.VectorType):
-      index = ir.IndexType.get()
       vec_ty = ir.VectorType(arg.type)
       if len(vec_ty.shape) > 1:
         raise NotImplementedError(
@@ -1711,7 +1710,6 @@ def dyn_dot(x, y):
 
 def shfl_bfly(x: ir.Value, distance: int | ir.Value):
   i32 = ir.IntegerType.get_signless(32)
-  index = ir.IndexType.get()
   if isinstance(distance, int):
     distance = c(distance, i32)
   if (result_type := x.type) != i32:

--- a/jax/experimental/pallas/ops/gpu/decode_attention.py
+++ b/jax/experimental/pallas/ops/gpu/decode_attention.py
@@ -325,7 +325,7 @@ def gqa(
     )
   sm_scale = sm_scale if sm_scale is not None else (1 / math.sqrt(q.shape[-1]))
   batch_size, q_heads, head_dim = q.shape
-  k_seq_len, kv_heads = k.shape[1], k.shape[2]
+  _k_seq_len, kv_heads = k.shape[1], k.shape[2]
   assert kv_heads == v.shape[2]
   assert q_heads % kv_heads == 0
   if start_idx is not None:

--- a/jax/experimental/pallas/ops/gpu/ragged_dot_mgpu.py
+++ b/jax/experimental/pallas/ops/gpu/ragged_dot_mgpu.py
@@ -127,10 +127,6 @@ def ragged_dot(
     grid_m = pl.cdiv(m, block_m) + g - 1
     grid_n = pl.cdiv(n, block_n)
     grid = (grid_m * grid_n,)
-    if load_group_sizes_to_register:
-      rows_per_expert = [rows_per_expert_gmem[i] for i in range(len(rows_per_expert_gmem))]
-    else:
-      rows_per_expert = rows_per_expert_gmem
 
     @plgpu.nd_loop(grid, collective_axes="sm")
     def mn_loop(loop_info: plgpu.NDLoopInfo):  # pylint: disable=unused-variable

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -336,7 +336,7 @@ class SparseTrace(core.Trace):
     if any(params['donated_invars']):
       raise NotImplementedError("sparsify does not support donated_invars")
     params = dict(params, donated_invars=tuple(False for buf in in_bufs))
-    bufs_out = call_primitive.bind(fun, *in_bufs, **params)
+    _bufs_out = call_primitive.bind(fun, *in_bufs, **params)
     return [SparseTracer(self, spvalue=spvalue) for spvalue in out_spvalues()]
 
   def process_custom_jvp_call(self, primitive, fun, jvp, tracers, *, symbolic_zeros):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,6 @@ ignore = [
     "C420",
     # Object names too complex
     "C901",
-    # Local variable is assigned to but never used
-    "F841",
     # Class could be dataclass or namedtuple
     "B903",
     # Raise with from clause inside except block

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1382,7 +1382,7 @@ class JitTest(jtu.BufferDonationTestCase):
     def f(x):
       return jnp.sqrt(x ** 2) + 1.
 
-    f_jit = jit(
+    jit(
         f,
         compiler_options={
             "xla_embed_ir_in_executable": True,
@@ -1394,14 +1394,14 @@ class JitTest(jtu.BufferDonationTestCase):
     def f(x):
       return jnp.sqrt(x ** 2) + 1.
 
-    f_jit = jit(
+    jit(
         f,
         compiler_options={
             "exec_time_optimization_effort": 0.0,
         })(1.0)  # doesn't crash.
 
     with self.assertRaisesRegex(jax.errors.JaxRuntimeError, "No such"):
-      f_jit = jit(
+      jit(
           f,
           compiler_options={
               "exec_time_compilation_effort": 0.0,
@@ -1411,7 +1411,7 @@ class JitTest(jtu.BufferDonationTestCase):
     def f(x):
       return jnp.sqrt(x**2) + 1.0
 
-    f_jit = jit(
+    jit(
         f,
         compiler_options={
             "optimization_level": config.EffortLevel.O1.value,
@@ -1424,7 +1424,7 @@ class JitTest(jtu.BufferDonationTestCase):
     def f(x):
       return jnp.sqrt(x**2) + 1.0
 
-    f_jit = jit(
+    jit(
         f,
         compiler_options={
             "memory_fitting_level": config.EffortLevel.O0.value,
@@ -4944,9 +4944,9 @@ class APITest(jtu.JaxTestCase):
     @jax.jit
     def f(x): return jnp.sin(x)
 
-    call_1 = f(np.arange(4, dtype=np.float32))
+    f(np.arange(4, dtype=np.float32))
     with jax.numpy_rank_promotion("warn"):
-      call_2 = f(np.arange(8, dtype=np.float32))
+      f(np.arange(8, dtype=np.float32))
 
     with config.explain_cache_misses(True):
       with self.assertLogs(level='WARNING') as cm:
@@ -4967,7 +4967,6 @@ class APITest(jtu.JaxTestCase):
     def f(x, y):
       return jnp.sin(x) * y['hi']
 
-    x = jnp.float32(1.)
 
     with config.explain_cache_misses(True):
       with self.assertLogs(level='WARNING') as cm:
@@ -5261,7 +5260,6 @@ class APITest(jtu.JaxTestCase):
 
     self.assertLen(consts, 1)
 
-    d = np.zeros(3)
 
     # TODO(mattjj,phawkins): we broke this on purpose, as it probably isn't
     # load-bearing (see above comment). If we wanted to fix it, we might share
@@ -5295,7 +5293,6 @@ class APITest(jtu.JaxTestCase):
     def foo(x):
       const = np.zeros((300,))
       x * const
-      r = weakref.ref(const)
       del const
       return x
 
@@ -6389,7 +6386,7 @@ class RematTest(jtu.JaxTestCase):
 
     res = saved_residuals(f, (2., 3.), y=4.)
     if config.use_simplified_jaxpr_constants.value:
-      base_res_idx = 0
+      pass
     else:
       self.assertEqual(res[0][1], "from a constant")
       self.assertEqual(res[0][0].shape, (1,))
@@ -7121,7 +7118,7 @@ class RematTest(jtu.JaxTestCase):
 
     Ws = [jnp.ones((3, 3)) for _ in range(2)]
     x = jnp.ones(3)
-    txt = jax.jit(jax.grad(loss, (0, 1))).lower(Ws, x).as_text()  # don't crash
+    jax.jit(jax.grad(loss, (0, 1))).lower(Ws, x).as_text()  # don't crash
 
   def test_remat_partial_cse_prevention_pytree(self):
     @partial(jax.remat, prevent_cse=({'W': False, 'x': True},))
@@ -7757,7 +7754,6 @@ class InputSavedVJPTest(jtu.JaxTestCase):
     primals = [2., 3.]
     y, f_vjp = jax.vjp(f, *primals)
     f_vjp.args_res = [None, None]
-    y_grad = 1.
     f_vjp.args_res = primals
     arg_cts = f_vjp(1.)
     self.assertAllClose(y, 6.)

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -766,7 +766,7 @@ class JaxArrayTest(jtu.JaxTestCase):
     x = rng((64, 64), np.float32)
     y = jax.device_put(x)
     # holds ref.
-    y_bytes = memoryview(y)
+    memoryview(y)
     # doesn't crash
     self.assertArraysEqual(add_one(y), x + 1)
 

--- a/tests/custom_api_test.py
+++ b/tests/custom_api_test.py
@@ -1411,7 +1411,7 @@ class CustomJVPTest(jtu.JaxTestCase):
       return y
 
     def f_jvp(primals, tangents):
-      (x, y), (x_dot, y_dot) = primals, tangents
+      (_x, y), (_x_dot, y_dot) = primals, tangents
       assert type(y_dot) is jax.custom_derivatives.SymbolicZero
       return y, y_dot
 
@@ -1483,7 +1483,7 @@ class CustomJVPTest(jtu.JaxTestCase):
       return x
     @f.defjvp
     def f_jvp(primals, tangents):
-      (x,), (x_dot,) = primals, tangents
+      (x,), (_x_dot,) = primals, tangents
       assert x == 0.  # concrete!
 
     @jax.jit

--- a/tests/custom_linear_solve_test.py
+++ b/tests/custom_linear_solve_test.py
@@ -514,8 +514,8 @@ class CustomLinearSolveTest(jtu.JaxTestCase):
       return jax.vjp(g(x), jnp.ones_like(x))[1](x)[0]
 
     x = jnp.array([200.0])
-    f_x = f(x)
-    grad_f_x = jax.jacrev(f)(x)  # don't crash
+    f(x)
+    jax.jacrev(f)(x)  # don't crash
 
 
 if __name__ == '__main__':

--- a/tests/debug_info_test.py
+++ b/tests/debug_info_test.py
@@ -397,7 +397,6 @@ class DebugInfoTest(jtu.JaxTestCase):
     def f(x, y):
       return jnp.sin(x) * y['hi']
 
-    x = jnp.float32(1.)
 
     with config.explain_cache_misses(True):
       with self.assertLogs(level='WARNING') as cm:

--- a/tests/debugging_primitives_test.py
+++ b/tests/debugging_primitives_test.py
@@ -1160,16 +1160,16 @@ class VisualizeShardingTest(jtu.JaxTestCase):
       debugging.visualize_array_sharding(a)
       return a
 
-    with jtu.capture_stdout() as output:
+    with jtu.capture_stdout():
       f()  # doesn't crash
 
-    with jtu.capture_stdout() as output:
+    with jtu.capture_stdout():
       jax.jit(f, out_shardings=jax.NamedSharding(mesh, P('x')))()  # doesn't crash
 
-    with jtu.capture_stdout() as output:
+    with jtu.capture_stdout():
       jax.shard_map(f, mesh=mesh, in_specs=P(None), out_specs=P("x"))()  # doesn't crash
 
-    with jtu.capture_stdout() as output:
+    with jtu.capture_stdout():
       jax.shard_map(f, mesh=mesh, in_specs=P(None), out_specs=P("x"),
                     check_vma=False)()  # doesn't crash
 
@@ -1306,7 +1306,7 @@ class PartitionedDebugCallbackTest(jtu.JaxTestCase):
     mesh = jtu.create_mesh((2,), ("x",))
     arr = jax.device_put(np.arange(8), jax.NamedSharding(mesh, jax.P("x")))
 
-    with jtu.capture_stdout() as output:
+    with jtu.capture_stdout():
       with jax.set_mesh(mesh):
         f(arr)
       jax.effects_barrier()

--- a/tests/export_back_compat_test.py
+++ b/tests/export_back_compat_test.py
@@ -334,7 +334,6 @@ class CompatTest(bctu.CompatTestBase):
     rtol = dict(f32=1e-3, f64=1e-5, c64=1e-3, c128=1e-5)[dtype_name]
     atol = dict(f32=1e-4, f64=1e-12, c64=1e-4, c128=1e-12)[dtype_name]
 
-    info = cpu_eigh_lapack_syev.data_2024_08_19[dtype_name]
     data = self.load_testdata(cpu_eigh_lapack_syev.data_2024_08_19[dtype_name])
     self.run_one_test(func, data, rtol=rtol, atol=atol,
                       check_results=partial(self.check_eigh_results, operand))
@@ -755,7 +754,6 @@ class CompatTest(bctu.CompatTestBase):
     if not config.enable_x64.value and dtype_name == "f64":
       self.skipTest("Test disabled for x32 mode")
 
-    dtype = dict(f32=np.float32, f64=np.float64)[dtype_name]
     def func(dl, d, du, b):
       return lax.linalg.tridiagonal_solve(dl, d, du, b)
 

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -1459,8 +1459,6 @@ class JaxExportTest(jtu.JaxTestCase):
     self.assertEqual(exported.out_avals[0].memory_space, core.MemorySpace.Host)
 
     empty_mesh = jax.sharding.AbstractMesh((), ())
-    shd_ns = jax.sharding.NamedSharding(empty_mesh, P(None, None),
-                                        memory_kind="pinned_host")
 
     self.assertEqual(exported.in_avals[0].sharding,
                      jax.sharding.NamedSharding(empty_mesh, P(None, None)))
@@ -1673,7 +1671,7 @@ class JaxExportTest(jtu.JaxTestCase):
         sharding_d_None if out_shardings == "P" else None)
     f_jax_jit = jax.jit(f_jax, **jit_kwargs)
 
-    with contextlib.ExitStack() as stack:
+    with contextlib.ExitStack():
       # Serialize higher-order gradiends
       exp = get_exported(f_jax_jit, vjp_order=2)(x)
       exp_vjp = exp.vjp()

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -853,7 +853,7 @@ class DotProductAttentionTest(jtu.JaxTestCase):
         sdpa_ref, scale=1.0, mask_type=MaskType.NO_MASK, dropout_rate=0)
     )
 
-    out = sdpa_infer(q, k_container, v_container, q_seqlen=q_seqlen,
+    sdpa_infer(q, k_container, v_container, q_seqlen=q_seqlen,
       kv_seqlen=kv_seqlen, page_table_k=page_table_k, page_table_v=page_table_v)
     out_ref = sdpa_infer_ref(q, k, v)
     self.assertArraysAllClose(out_ref, out_ref, rtol=1e-2, atol=1e-2)

--- a/tests/gpu_memory_flags_test.py
+++ b/tests/gpu_memory_flags_test.py
@@ -40,7 +40,7 @@ class GpuMemoryAllocationTest(absltest.TestCase):
     device = jax.devices()[0]
     mem_stats = device.memory_stats()
     self.assertEqual(mem_stats["pool_bytes"], 0)
-    x = jax.lax.add(1, 2).block_until_ready()
+    jax.lax.add(1, 2).block_until_ready()
 
     mem_stats = device.memory_stats()
     if preallocate:

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -891,7 +891,7 @@ class HijaxTest(jtu.JaxTestCase):
       return jnp.sum(dq(q(x)))
 
     x = jax.random.normal(jax.random.key(0), (3, 3), dtype='float32')
-    g = jax.grad(f)(x)
+    jax.grad(f)(x)
 
   def test_symbolic_zeros(self):
 
@@ -1626,7 +1626,7 @@ class HijaxTransformCoverageTest(jtu.JaxTestCase):
     def loss_fn(box):
       return box.get() ** 2
 
-    grads = jax.grad(loss_fn)(box)
+    jax.grad(loss_fn)(box)
     # NOTE: unclear what the tangent type will be here
 
   # with non-differentiable mutable hijax arguments

--- a/tests/jaxpr_effects_test.py
+++ b/tests/jaxpr_effects_test.py
@@ -261,7 +261,6 @@ class HigherOrderPrimitiveTest(jtu.JaxTestCase):
     def bar(x, w):
         def scan_fn(x, _):
             c = jnp.array([])
-            o = w[...] @ x
             x = jnp.concatenate([x, c], axis=-1)
             return x, None
 

--- a/tests/key_reuse_test.py
+++ b/tests/key_reuse_test.py
@@ -140,7 +140,7 @@ class KeyReuseUnitTestWithForwarding(jtu.JaxTestCase):
   def test_unwrap(self):
     def f(key):
       assert_unconsumed(key)
-      key_data = jax.random.key_data(key)
+      jax.random.key_data(key)
       assert_unconsumed(key)
     self.check_key_reuse(f, jax.random.key(0))
 

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -313,7 +313,6 @@ class LaxControlFlowTest(jtu.JaxTestCase):
   def testWhileTypeErrors(self):
     """Test typing error messages for while."""
     tuple_treedef = jax.tree.structure((1., 1.))
-    leaf_treedef = jax.tree.structure(0.)
     with self.assertRaisesRegex(
         TypeError,
         re.escape(f"cond_fun must return a boolean scalar, but got pytree {tuple_treedef}.")):
@@ -3440,7 +3439,6 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     f = np.arange(num_xs)
     f = [f[i] if idx < num_input_fwds else None for idx, i in enumerate(xs_perm)]
     f += [None]
-    in_fwd = [f[i] for i in ys_perm]
 
     body_consts = [jnp.array(rng.randn(3)) for _ in range(num_const)]
     init_vals = list(map(jnp.array, rng.uniform(size=(num_carry, 3))))

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -3673,7 +3673,7 @@ class LaxTest(jtu.JaxTestCase):
           g,
           jax.random.normal(jax.random.key(0), (9, 8), dtype=jnp.complex64),
       )
-      out = f_vjp(np.array(1.0 + 0j, 'complex64'))[0]
+      f_vjp(np.array(1.0 + 0j, 'complex64'))[0]
       return carry, carry
 
     a, b = jax.lax.scan(_step, 0, jnp.arange(4, dtype=jnp.complex64))
@@ -4521,10 +4521,9 @@ class FunctionAccuracyTest(jtu.JaxTestCase):
       self.skipTest(f'could not import mpmath: {msg}')
 
     is_cpu = jtu.test_device_matches(["cpu"])
-    machine = platform.machine()
+    platform.machine()
     # TODO: remove is_arm_cpu as previously arm cpu related failures
     # were due to numpy issues. Confirm?
-    is_arm_cpu = machine.startswith('aarch') or machine.startswith('arm')
     is_cuda = jtu.test_device_matches(["cuda"])
 
     size_re = 11
@@ -4693,13 +4692,13 @@ class FunctionAccuracyTest(jtu.JaxTestCase):
     for region_name, region_slice in s_dict_parts.items():
       region = args[0][region_slice]
       if region_name.endswith('.real'):
-        result_slice, expected_slice = result[region_slice].real, expected[region_slice].real
+        _result_slice, _expected_slice = result[region_slice].real, expected[region_slice].real
         normalized_result_slice, normalized_expected_slice = normalized_result[region_slice].real, normalized_expected[region_slice].real
       elif region_name.endswith('.imag'):
-        result_slice, expected_slice = result[region_slice].imag, expected[region_slice].imag
+        _result_slice, _expected_slice = result[region_slice].imag, expected[region_slice].imag
         normalized_result_slice, normalized_expected_slice = normalized_result[region_slice].imag, normalized_expected[region_slice].imag
       else:
-        result_slice, expected_slice = result[region_slice], expected[region_slice]
+        _result_slice, _expected_slice = result[region_slice], expected[region_slice]
         normalized_result_slice, normalized_expected_slice = normalized_result[region_slice], normalized_expected[region_slice]
 
       inexact_indices = np.where(normalized_result_slice != normalized_expected_slice)

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -288,7 +288,6 @@ class TestUtilTest(TestCase):
   def test_iota_tensor(self):
     m = n = 64
     def kernel(ctx, dst, _):
-      f32 = ir.F32Type.get()
       index = ir.IndexType.get()
       registers = iota_tensor(m, n, jnp.float32).registers
       assert registers.size == 16, registers.size
@@ -494,7 +493,7 @@ class MemRefTest(TestCase):
       cluster_idx = tuple(gpu.cluster_block_id(dim) for dim in dims)
       peer_idx = arith.subi(arith.constant(index, 1), cluster_idx[dim])
       peer_smem = ctx.get_cluster_ref(smem, dim, peer_idx)
-      a = mgpu.FragmentedArray.load_strided(memref_slice(src, cluster_idx)).store_untiled(smem)
+      mgpu.FragmentedArray.load_strided(memref_slice(src, cluster_idx)).store_untiled(smem)
       utils.warpgroup_barrier()
       barrier.arrive()
       barrier.wait()
@@ -4287,7 +4286,6 @@ class FragmentedArrayTest(TestCase):
   def test_convert_int_uint(self, from_dtype, to_dtype, value):
     m, n = 1, 128
     def kernel(ctx, dst, _):
-      i8 = ir.IntegerType.get_signless(8)
       from_mlir_dtype = utils.dtype_to_ir_type(from_dtype)
       to_mlir_dtype = utils.dtype_to_ir_type(to_dtype)
       from_arr = mgpu.FragmentedArray.splat(
@@ -6582,8 +6580,7 @@ class ApiTest(TestCase):
       f = mgpu.as_gpu_kernel(
           kernel, (1, 1, 1), (128, 1, 1), x, x, (),
       )
-      bytecode_stablehlo = jax.jit(f).lower(x).as_text()
-      module_prefix = "module = \"ML\\EFR"
+      jax.jit(f).lower(x).as_text()
 
 if hp is not None:
   @hps.composite

--- a/tests/mosaic/gpu_torch_test_distributed.py
+++ b/tests/mosaic/gpu_torch_test_distributed.py
@@ -121,7 +121,7 @@ class TorchTest(parameterized.TestCase):
     )
     gathered = torch.empty((2,), dtype=torch.int32)
     sem = symm_mem.empty((1,), dtype=torch.int32)
-    sem_symm = symm_mem.rendezvous(sem, dist.group.WORLD)
+    symm_mem.rendezvous(sem, dist.group.WORLD)
     (sem_again,) = kernel(sem)
     self.assertEqual(sem_again.data_ptr(), sem.data_ptr())
     dist.all_gather_into_tensor(gathered, sem)

--- a/tests/mutable_array_test.py
+++ b/tests/mutable_array_test.py
@@ -319,7 +319,7 @@ class MutableArrayTest(jtu.JaxTestCase):
     with jax.set_mesh(mesh):
       x = jnp.zeros((4, 4), jnp.int32, device=sharding)
       x_ref = core.new_ref(x)
-      y = f(x_ref)
+      f(x_ref)
 
   def test_vmap_basic(self):
     @jax.vmap
@@ -1364,9 +1364,9 @@ class MutableArrayErrorsTest(jtu.JaxTestCase):
       jax.lax.cond(pred, true_fun, false_fun)
     if jit:
       f = jax.jit(f)
-    out_true = f(True)
+    f(True)
     self.assertAllClose(x_ref[...], 1.)
-    out_false = f(False)
+    f(False)
     self.assertAllClose(x_ref[...], 2.)
 
   def test_vmap_closed_over_ref_write(self):

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -29,7 +29,6 @@ from jax._src import dtypes as _dtypes
 from jax._src import test_util as jtu
 from jax._src.cudnn.scaled_matmul_stablehlo import (
     quantize,
-    shape_normalization,
 )
 from jax.test_util import check_grads
 from jax import nn
@@ -89,9 +88,6 @@ def _generate_quantized_tensors(
       configs[1].data_type,
   )
 
-  dn = ((2,), (0,))
-  a_3d = shape_normalization(a, dn)
-  b_3d = shape_normalization(b, dn)
   a_q, a_scales = quantize(a, configs[0])
   b_q, b_scales = quantize(b, configs[1])
 
@@ -216,9 +212,6 @@ class NNFunctionsTest(jtu.JaxTestCase):
     sdpa_ans_lse = partial(sdpa, implementation=impl, return_residual=True)
     if use_vmap:
       sdpa_ans = jax.vmap(sdpa_ans, in_axes=(0, 0, 0, None, None), out_axes=0)
-      spda_ans_lse = jax.vmap(
-          sdpa_ans_lse, in_axes=(0, 0, 0, None, None), out_axes=0
-      )
 
     # For testing purposes, we call the non-GQA version without vmap in the
     # reference code

--- a/tests/pallas/mosaic_gpu_test.py
+++ b/tests/pallas/mosaic_gpu_test.py
@@ -5264,7 +5264,6 @@ class WarpSpecializedPipelineTest(PallasTest):
     blk_m = blk_n = 32
 
     def copy_kernel(_, x_smem, o_smem, o_last_block_smem, *consumed_barriers):
-      wg_idx = lax.axis_index("wg")
       o_smem[...] = x_smem[...]
       o_last_block_smem[...] = x_smem[...]
       if manual_consumed_barriers:

--- a/tests/pallas/tpu_pallas_interpret_distributed_test.py
+++ b/tests/pallas/tpu_pallas_interpret_distributed_test.py
@@ -1089,7 +1089,6 @@ class InterpretDistributedTest(jtu.JaxTestCase):
     num_devices = jax.device_count()
     partition = P('x', None)
     mesh = jtu.create_mesh((num_devices,), ('x',))
-    sharding = jax.sharding.NamedSharding(mesh, partition)
 
     core_mesh = pltpu.create_tensorcore_mesh('core', num_cores=num_cores)
     interpret = pltpu.InterpretParams(detect_races=True)

--- a/tests/pallas/tpu_pallas_interpret_test.py
+++ b/tests/pallas/tpu_pallas_interpret_test.py
@@ -303,7 +303,6 @@ class InterpretTest(jtu.JaxTestCase):
     ref = jax.lax.dynamic_slice(
         x, start_indices=(128, 256), slice_sizes=(128, 128)
     )
-    diff = jnp.max(jnp.abs(result - ref))
     np.testing.assert_allclose(result, ref)
 
   def test_dynamic_grid_and_aliasing(self):

--- a/tests/pallas/tpu_pallas_test.py
+++ b/tests/pallas/tpu_pallas_test.py
@@ -3812,7 +3812,6 @@ class MiscellaneousTest(ptu.PallasTPUTest):
         out_shape=jax.ShapeDtypeStruct((q, m * n), dtype),
     )(x)
     jax.numpy.set_printoptions(threshold=jax.numpy.inf)
-    expected = x.reshape([q, m * n])
     np.testing.assert_array_equal(out, x.reshape([q, m * n]))
 
   # (q, m, n, k) -> (q, m, n * k) where k % 128 == 0

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -391,7 +391,7 @@ class PJitTest(jtu.BufferDonationTestCase):
     z = np.ones((2, 11))
     z_tree = jax.device_put({'a': {'b': z}, 'c': z}, s)
 
-    out = f(x_tree, y_tree, z_tree)
+    f(x_tree, y_tree, z_tree)
     jax.tree.map(self.assertNotDeleted, x_tree)
     jax.tree.map(self.assertDeleted, y_tree)
     jax.tree.map(self.assertDeleted, z_tree)
@@ -3343,7 +3343,6 @@ class ArrayPjitTest(jtu.JaxTestCase):
 
     with jtu.count_pjit_cpp_cache_miss() as count:
       out = f(arr)
-      cache_info1 = pxla._cached_compilation.cache_info()
       self.assertIsInstance(out.sharding, NamedSharding)
 
       out = f(arr)
@@ -4065,7 +4064,6 @@ class ArrayPjitTest(jtu.JaxTestCase):
 
   def test_spmd_preserves_input_sharding_vmap_grad(self):
     # https://github.com/jax-ml/jax/issues/20710
-    n_devices = jax.device_count()
     mesh = Mesh(jax.devices(), 'x')
     sharding = NamedSharding(mesh, P('x'))
 
@@ -8745,7 +8743,7 @@ class ShardingInTypesTest(jtu.JaxTestCase):
         return out
       return g(x, y)
 
-    out = jax.jit(jax.vmap(f, spmd_axis_name='x'))(arr1, arr2)  # doesn't crash
+    jax.jit(jax.vmap(f, spmd_axis_name='x'))(arr1, arr2)  # doesn't crash
 
   @parameterized.named_parameters(
       ('replicated', None),

--- a/tests/qdwh_test.py
+++ b/tests/qdwh_test.py
@@ -81,7 +81,6 @@ class QdwhTest(jtu.JaxTestCase):
   )
   def testQdwhWithUpperTriangularInputAllOnes(self, shape, dtype):
     """Tests qdwh with upper triangular input of all ones."""
-    eps = jnp.finfo(dtype).eps
     m, n = shape
     a = jnp.triu(jnp.ones((m, n))).astype(dtype)
     self._testQdwh(a)

--- a/tests/scaled_matmul_stablehlo_test.py
+++ b/tests/scaled_matmul_stablehlo_test.py
@@ -19,7 +19,6 @@ import re
 import numpy as np
 import jax
 import jax.numpy as jnp
-import jax.ad_checkpoint
 from jax.sharding import Mesh
 from jax.sharding import PartitionSpec, NamedSharding
 from jax._src import config
@@ -126,9 +125,6 @@ def generate_quantized_tensors(
       configs[1].data_type,
   )
 
-  dn = ((2,), (0,))
-  a_3d = shape_normalization(a, dn)
-  b_3d = shape_normalization(b, dn)
   a_q, a_scales = quantize(a, configs[0])
   b_q, b_scales = quantize(b, configs[1])
 

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -2448,7 +2448,7 @@ class ShardMapTest(jtu.JaxTestCase):
 
   def test_custom_jvp_inside_jit(self):
     mesh = jtu.create_mesh((4,), ('batch',))
-    x = shard_map(jax.jit(jax.nn.relu),
+    shard_map(jax.jit(jax.nn.relu),
                   mesh=mesh, in_specs=P('batch'),
                   out_specs=P('batch'))(jnp.arange(16.))  # don't crash
 
@@ -3922,9 +3922,9 @@ class ShardMapTest(jtu.JaxTestCase):
       v = v.sum()
       return v * xs.sum(axis=-1).astype(v.dtype)
 
-    res = fun(variables, xs)
+    fun(variables, xs)
     fun_shard_map = shard_map(fun, mesh=mesh, in_specs=in_specs, out_specs=out_specs)
-    res = fun_shard_map(variables, xs)  # don't crash
+    fun_shard_map(variables, xs)  # don't crash
 
   def test_rep_none_canonicalization_again(self):
     # https://github.com/jax-ml/jax/issues/24762


### PR DESCRIPTION
I inspected all existing instances of unused variables and either removed them or prefixed their name with with an `_`.