### PR TITLE
Faster `jnp.trapezoid` when `dx` is a scalar

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -6528,6 +6528,9 @@ def trapezoid(y: ArrayLike, x: ArrayLike | None = None, dx: ArrayLike = 1.0,
     y = util.ensure_arraylike('trapezoid', y)
     y_arr, = util.promote_dtypes_inexact(y)
     dx_array = asarray(dx)
+    if dx_array.ndim > 0:
+      dx_array = lax.expand_dims(dx_array, range(y_arr.ndim - dx_array.ndim))
+      dx_array = moveaxis(dx_array, axis, -1)
   else:
     y, x = util.ensure_arraylike('trapezoid', y, x)
     y_arr, x_arr = util.promote_dtypes_inexact(y, x)
@@ -6536,6 +6539,10 @@ def trapezoid(y: ArrayLike, x: ArrayLike | None = None, dx: ArrayLike = 1.0,
     else:
       dx_array = moveaxis(diff(x_arr, axis=axis), axis, -1)
   y_arr = moveaxis(y_arr, axis, -1)
+  # Fast path: dx is constant along the integration axis.
+  if dx_array.ndim == 0 or dx_array.shape[-1] == 1:
+    dx_reduced = dx_array if dx_array.ndim == 0 else dx_array[..., 0]
+    return dx_reduced * (y_arr.sum(-1) - 0.5 * (y_arr[..., 0] + y_arr[..., -1]))
   return 0.5 * (dx_array * (y_arr[..., 1:] + y_arr[..., :-1])).sum(-1)
 
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -5972,11 +5972,40 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(yshape, dtype), rng(xshape, dtype) if xshape is not None else None]
     np_fun = partial(np.trapezoid, dx=dx, axis=axis)
     jnp_fun = partial(jnp.trapezoid, dx=dx, axis=axis)
-    tol = jtu.tolerance(dtype, {np.float16: 2e-3, np.float64: 1e-12,
+    tol = jtu.tolerance(dtype, {np.float16: 4e-3, np.float64: 1e-12,
                                 jax.dtypes.bfloat16: 4e-2})
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, tol=tol,
                             check_dtypes=False)
     self._CompileAndCheck(jnp_fun, args_maker, atol=tol, rtol=tol,
+                          check_dtypes=False)
+
+  @jtu.sample_product(
+    [dict(yshape=yshape, dxshape=dxshape, axis=axis)
+      for yshape, dxshape, axis in [
+        ((3, 10), (3, 1), -1),
+        ((10,), (1,), -1),
+        ((2, 3, 4, 10), (2, 3, 4, 1), -1),
+        ((2, 3), (3,), 0),
+        ((3, 4, 5), (4, 5), 0),
+        ((3, 4, 5), (3, 5), 1),
+        ((3, 4, 5), (5,), 1),
+        ((2, 3, 4, 5), (2, 4, 5), 1),
+        ((2, 3, 4, 5), (2, 1, 3, 5), 2),
+        # slow path: varies along integration axis
+        ((3, 4, 5), (2, 4, 5), 0),
+        ((3, 4, 5), (3, 3, 5), 1),
+      ]
+    ],
+  )
+  @jtu.skip_on_devices("tpu")
+  def test_trapezoid_array_dx(self, yshape, dxshape, axis):
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(yshape, np.float32), rng(dxshape, np.float32)]
+    np_fun = lambda y, dx: np.trapezoid(y, dx=dx, axis=axis)
+    jnp_fun = lambda y, dx: jnp.trapezoid(y, dx=dx, axis=axis)
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, tol=1e-5,
+                            check_dtypes=False)
+    self._CompileAndCheck(jnp_fun, args_maker, atol=1e-5, rtol=1e-5,
                           check_dtypes=False)
 
   @jtu.sample_product(


### PR DESCRIPTION
Addressing https://github.com/jax-ml/jax/issues/34915 

**Microbenchmark before**:
`jnp.trapezoid` have the same performance when using `x` or `dx`. For comparison `jnp.sum * dx` is significantly faster.
<img width="1200" height="500" alt="Image" src="https://github.com/user-attachments/assets/1fbccfe1-6010-41bd-afa0-40ab1c6d4715" />

**Microbenchmark after**:
`jnp.trapezoid` is faster when using `dx` and in line with the performance of `jnp.sum * dx`.
<img width="1200" height="500" alt="Image" src="https://github.com/user-attachments/assets/22812969-bc94-442e-96bd-49dd62c43483" />


`dx_reduced * (y_arr.sum(-1) - 0.5 * (y_arr[..., 0] + y_arr[..., -1]))`
also seems to be faster than
`dx_reduced * 0.5 * (y_arr[..., 1:] + y_arr[..., :-1]).sum(-1)` 