### PR TITLE
[ROCm] Skip test_tridiagonal_solve_grad on ROCm due to rocSparse issue

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2407,6 +2407,10 @@ class LaxLinalgTest(jtu.JaxTestCase):
 
   @jtu.sample_product(shape=[(3,), (3, 4)], dtype=float_types + complex_types)
   def test_tridiagonal_solve_grad(self, shape, dtype):
+    if jtu.is_device_rocm() and shape == (3, 4) and dtype == np.float32:
+      # numerical errors seen as of ROCm 7.2 due to rocSparse issue for grad0 variant
+      # TODO: re-enable the test once the rocSparse issue is fixed
+      self.skipTest("test_tridiagonal_solve_grad0 not supported on ROCm due to rocSparse issue")
     if dtype not in float_types and jtu.test_device_matches(["gpu"]):
       self.skipTest("Data type not supported on GPU")
     rng = self.rng()


### PR DESCRIPTION
## Motivation

The `test_tridiagonal_solve_grad0` variant (with `shape=(3, 4)` and `dtype=float32`) fails on ROCm devices due to numerical precision errors in the underlying rocSparse library (observed as of ROCm 7.2). Other variants of this parameterized test pass successfully, so we only skip the failing variant to preserve test coverage.

## Technical Details

- Added conditional skip logic in `tests/linalg_test.py` using `jtu.is_device_rocm()` combined with checks for `shape == (3, 4)` and `dtype == np.float32` to skip only the `test_tridiagonal_solve_grad0` variant on ROCm devices

## Test Result

<img width="2771" height="493" alt="image" src="https://github.com/user-attachments/assets/c1eb8bab-45ea-4c08-8d65-b590cc615d43" />

## Submission Checklist
Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.