### PR TITLE
docs: mention CPU count impact on multi-GPU communication performance

### DIFF
--- a/docs/gpu_performance_tips.md
+++ b/docs/gpu_performance_tips.md
@@ -721,3 +721,22 @@ cases, this can speed up jitted computation. The
 that configuration when run under SLURM. However, this only a rule of
 thumb and it may be useful to test both one process per GPU and one
 process per node on your use case.
+
+### CPU allocation per task
+
+When running one process per GPU, the number of host **CPUs allocated per
+task** can have a major impact on multi-GPU communication performance.  GPU
+collective operations (e.g. all-to-all, especially ragged all-to-all) rely on
+the host CPU for coordination, and under-provisioning CPUs can bottleneck
+communication throughput by as much as 50×.
+
+As a best practice, divide the total number of CPUs on a node by the number of
+GPUs and allocate that many CPUs per task.  For example, on a Slurm cluster
+with 128 CPUs and 8 GPUs per node:
+
+```bash
+srun --ntasks-per-node=8 --cpus-per-task=16 python train.py
+```
+
+See the {doc}`multi_process` guide for additional details on setting up
+multi-process JAX.

--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -262,6 +262,16 @@ def initialize(coordinator_address: str | None = None,
   :func:`~jax.distributed.initialize` may timeout.  You may need to unset these variables
   prior to application launch.
 
+  .. tip::
+
+    **CPU allocation matters for GPU communication performance.** When running
+    one process per GPU (the recommended setup), the number of host CPUs
+    available to each process can significantly affect the throughput of
+    collective communication operations (e.g. all-to-all). Allocate as many
+    CPUs per task as are available on the node — for example, in Slurm set
+    ``--cpus-per-task`` to the total CPU count divided by the number of GPUs.
+    See :doc:`multi_process` for more details.
+
   Args:
     coordinator_address: the IP address of process `0` and a port on which that
       process should launch a coordinator service. The choice of


### PR DESCRIPTION
Addresses #34896 by adding documentation about the significant performance impact that host CPU allocation has on multi-GPU collective communication operations (e.g. all-to-all).

Changes:
- docs/multi_process.md: Added 'CPU resource allocation' subsection under 'Setting up multiple JAX processes' with a tip box showing Slurm examples and the rule of thumb for --cpus-per-task.
- jax/_src/distributed.py: Added a tip note in the jax.distributed.initialize() docstring pointing users to the multi_process guide for CPU allocation advice.
- docs/gpu_performance_tips.md: Added 'CPU allocation per task' subsection under 'Multi-Process' with concrete Slurm example.

Fixes #34896

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->