### PR TITLE
[ROCm] Skip test_batch_axis_sharding_jvp

### DIFF
--- a/tests/linalg_sharding_test.py
+++ b/tests/linalg_sharding_test.py
@@ -158,6 +158,12 @@ class LinalgShardingTest(jtu.JaxTestCase):
   )
   @jtu.run_on_devices("gpu", "cpu")
   def test_batch_axis_sharding_jvp(self, fun_and_shapes, dtype):
+    if (jtu.is_device_rocm() and
+        fun_and_shapes[0] is lax.linalg.qr and
+        dtype == np.complex64):
+      # numerical errors seen as of ROCm 7.2 due to rocSolver issue for qr with complex64
+      # TODO: re-enable the test once the rocSolver issue is fixed
+      self.skipTest("test_batch_axis_sharding_jvp13 not supported on ROCm due to rocSolver issue")
     fun, shapes = self.get_fun_and_shapes(fun_and_shapes, grad=True)
     primals = self.get_args(shapes, dtype, batch_size=8)
     tangents = tuple(map(jnp.ones_like, primals))


### PR DESCRIPTION
### Motivation
The test_batch_axis_sharding_jvp13 test (qr with complex64) fails on ROCm devices due to numerical precision issues in rocSolver as of ROCm 7.2.

### Technical Details
Added a conditional skip in tests/linalg_sharding_test.py for test_batch_axis_sharding_jvp that only skips when:
Running on ROCm devices (jtu.is_device_rocm())
Function is lax.linalg.qr (fun_and_shapes[0] is lax.linalg.qr)
Dtype is np.complex64 (dtype == np.complex64)
This targets only the failing test case (test_batch_axis_sharding_jvp13). All other test cases continue to run normally.

### Test Result
The test is now skipped on ROCm for the specific failing case, preventing test failures while preserving coverage for other variants.
<img width="1065" height="843" alt="image" src="https://github.com/user-attachments/assets/ef8ac150-52cb-4bf7-9bbf-d23a917dbd51" />


