### PR TITLE
[ROCm] Added ROCm tests to `device_test.py` unit test file.

### DIFF
--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -24,10 +24,12 @@ class DeviceTest(jtu.JaxTestCase):
   def test_repr(self):
     device = jax.devices()[0]
 
-    # TODO(pobudzey): Add a test for rocm devices when available.
     if jtu.is_device_cuda():
       self.assertEqual(device.platform, 'gpu')
       self.assertEqual(repr(device), 'CudaDevice(id=0)')
+    elif jtu.is_device_rocm():
+      self.assertEqual(device.platform, 'gpu')
+      self.assertEqual(repr(device), 'RocmDevice(id=0)')
     elif jtu.test_device_matches(['tpu']):
       self.assertEqual(device.platform, 'tpu')
       self.assertEqual(
@@ -41,9 +43,10 @@ class DeviceTest(jtu.JaxTestCase):
   def test_str(self):
     device = jax.devices()[0]
 
-    # TODO(pobudzey): Add a test for rocm devices when available.
     if jtu.is_device_cuda():
       self.assertEqual(str(device), 'cuda:0')
+    elif jtu.is_device_rocm():
+      self.assertEqual(str(device), 'rocm:0')
     elif jtu.test_device_matches(['tpu']):
       self.assertEqual(str(device), 'TPU_0(process=0,(0,0,0,0))')
     elif jtu.test_device_matches(['cpu']):


### PR DESCRIPTION
## Motivation
The test file `device_test.py` contained tests for different platforms supported on JAX but not ROCm devices. These have now been added.

## Technical Details
Two ROCm-specific branches have been added to the unit tests checking the results of the `repr` and `str` functions on the device objects.
- `tests/device_test.py::DeviceTest::test_repr`
- `tests/device_test.py::DeviceTest::test_str`

## Test Plan
The unit test file `device_test.py` should now have ROCm-specific checks for all its unit tests.

## Test Results
Both device tests are passing on ROCm devices (`tests/device_test.py::DeviceTest::test_repr` and `tests/device_test.py::DeviceTest::test_str`)