### PR TITLE
Fix failing test in array_interoperability_test.py

### DIFF
--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -312,7 +312,7 @@ class CudaArrayInterfaceTest(jtu.JaxTestCase):
     self.assertFalse(hasattr(x, "__cuda_array_interface__"))
     with self.assertRaisesRegex(
         AttributeError,
-        "__cuda_array_interface__ is only defined for GPU buffers.",
+        "__cuda_array_interface__ is only defined for .*GPU buffers.",
     ):
       _ = x.__cuda_array_interface__
 


### PR DESCRIPTION
Fixes the following error:
```
tests/array_interoperability_test.py:313: in testCudaArrayInterfaceOnNonCudaFails
    with self.assertRaisesRegex(
E   AssertionError: "__cuda_array_interface__ is only defined for GPU buffers." does not match "__cuda_array_interface__ is only defined for NVidia GPU buffers."
```
