### PR TITLE
[ROCm] Remove incorrect ROCm lowering for scaled_matmul to prevent segfault

### DIFF
--- a/jax/_src/cudnn/scaled_matmul_stablehlo.py
+++ b/jax/_src/cudnn/scaled_matmul_stablehlo.py
@@ -122,11 +122,6 @@ mlir.register_lowering(
     _scaled_matmul_gpu_lowering,
     platform="cuda",
 )
-mlir.register_lowering(
-    _scaled_matmul_p,
-    _scaled_matmul_gpu_lowering,
-    platform="rocm",
-)
 
 _scaled_matmul_p_wrapper = core.Primitive("scaled_matmul_wrapper")
 _scaled_matmul_p_wrapper.multiple_results = True

--- a/tests/scaled_matmul_stablehlo_test.py
+++ b/tests/scaled_matmul_stablehlo_test.py
@@ -455,7 +455,9 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
   def setUp(self):
     super().setUp()
     # cuDNN and Blackwell checks only apply to CUDA devices.
-    # ROCm uses XLA's fallback path (dequantize + standard dot) for MXFP8/NVFP4.
+    # ROCm does not support the cuDNN block scaled dot operation used by scaled_matmul.
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("scaled_matmul requires cuDNN which is not available on ROCm")
     if jtu.test_device_matches(["cuda"]):
       try:
         check_cudnn_version()


### PR DESCRIPTION
The scaled_matmul primitive was incorrectly registering a cuDNN-specific
GPU lowering for the ROCm platform. This lowering creates a custom call
to `__op$block_scaled_dot`, which is a cuDNN operation that only exists
on NVIDIA GPUs. When running on ROCm, XLA would crash with a segfault
when attempting to execute this operation.

Changes:
- Remove ROCm platform lowering registration from scaled_matmul_stablehlo.py
- Add ROCm skip check in ScaledDotGeneralTest.setUp() to skip tests that
  require cuDNN block scaled dot operations

This fix resolves the segfault seen during parallel pytest execution on
8-GPU ROCm systems.