### PR TITLE
Assign explicit type ids to transpose plan caches

### DIFF
--- a/jaxlib/gpu/py_client_gpu.cc
+++ b/jaxlib/gpu/py_client_gpu.cc
@@ -60,7 +60,8 @@ struct GpuTransposePlanCache {
   xla::TransposePlanCache cache;
 };
 
-xla::ffi::TypeId GpuTransposePlanCache::id = {};
+xla::ffi::TypeId GpuTransposePlanCache::id =
+    xla::ffi::TypeId{reinterpret_cast<intptr_t>(&GpuTransposePlanCache::id)};
 xla::ffi::TypeInfo GpuTransposePlanCache::info =
     xla::ffi::MakeTypeInfo<GpuTransposePlanCache>();
 

--- a/jaxlib/py_client_cpu.cc
+++ b/jaxlib/py_client_cpu.cc
@@ -55,7 +55,8 @@ struct CpuTransposePlanCache {
   xla::TransposePlanCache cache;
 };
 
-ffi::TypeId CpuTransposePlanCache::id = {};
+ffi::TypeId CpuTransposePlanCache::id =
+    ffi::TypeId{reinterpret_cast<intptr_t>(&CpuTransposePlanCache::id)};
 ffi::TypeInfo CpuTransposePlanCache::info =
     ffi::MakeTypeInfo<CpuTransposePlanCache>();
 


### PR DESCRIPTION
Today we have double registration of `TransposePlanCache` in different type registries, and it leads to run time conflicts and crashes. Generate unique type id explicitly to avoid that. This is not a proper fix, this is a work around the linking hell we are in today.

Should fix https://github.com/openxla/xla/issues/37752