### PR TITLE
[pyrefly] suppress errors related to np.iinfo

### DIFF
--- a/jax/_src/abstract_arrays.py
+++ b/jax/_src/abstract_arrays.py
@@ -85,10 +85,10 @@ core.literalable_types.update(array_types)
 
 core.literalable_types.add(literals.TypedNdArray)
 
-_int32_min = np.iinfo(np.int32).min
-_int32_max = np.iinfo(np.int32).max
-_int64_min = np.iinfo(np.int64).min
-_int64_max = np.iinfo(np.int64).max
+_int32_min = np.iinfo(np.int32).min  # pyrefly: ignore[no-matching-overload]  # pyrefly#2398
+_int32_max = np.iinfo(np.int32).max  # pyrefly: ignore[no-matching-overload]  # pyrefly#2398
+_int64_min = np.iinfo(np.int64).min  # pyrefly: ignore[no-matching-overload]  # pyrefly#2398
+_int64_max = np.iinfo(np.int64).max  # pyrefly: ignore[no-matching-overload]  # pyrefly#2398
 
 # Note: all python scalar types are weak except bool, because bool only
 # comes in a single width.

--- a/jax/_src/error_check.py
+++ b/jax/_src/error_check.py
@@ -47,7 +47,7 @@ class JaxValueError(ValueError):
 #:
 #: This value is chosen because we can use `jnp.min()` to obtain the
 #: first error when performing reductions.
-_NO_ERROR = np.iinfo(np.uint32).max
+_NO_ERROR = np.iinfo(np.uint32).max  # pyrefly: ignore[no-matching-overload]  # pyrefly#2398
 
 
 _error_list_lock = threading.RLock()

--- a/jax/_src/lax/utils.py
+++ b/jax/_src/lax/utils.py
@@ -243,8 +243,8 @@ def dtype_to_string(dtype):
     pass
   return str(dtype)
 
-_int32_max = np.iinfo(np.int32).max
-_uint32_max = np.iinfo(np.uint32).max
+_int32_max = np.iinfo(np.int32).max  # pyrefly: ignore[no-matching-overload]  # pyrefly#2398
+_uint32_max = np.iinfo(np.uint32).max  # pyrefly: ignore[no-matching-overload]  # pyrefly#2398
 
 def int_dtype_for_dim(d: DimSize, *, signed: bool) -> DType:
   """Returns a integer dtype large enough to contain indices in dimension d."""

--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -96,7 +96,7 @@ MLIR_DYNAMIC = -9223372036854775808
 
 # TODO(mvoz): Find a way to make this a contract we can share with the
 # export specialization step in XLA export.
-DIM_UPPER_BOUND = np.iinfo(np.int32).max
+DIM_UPPER_BOUND = np.iinfo(np.int32).max  # pyrefly: ignore[no-matching-overload]  # pyrefly#2398
 DIM_LOWER_BOUND = -128
 
 partial = functools.partial
@@ -2030,7 +2030,7 @@ REDUCE_MAX_KINDS = {
 }
 REDUCE_MAX_IDENTITY = {
     jnp.floating: float("-inf"),
-    jnp.signedinteger: np.iinfo(np.int32).min,
+    jnp.signedinteger: np.iinfo(np.int32).min,  # pyrefly: ignore[no-matching-overload]  # pyrefly#2398
 }
 _reduce_max_lowering_rule = reduce_lowering_rule(
     jnp.max, REDUCE_MAX_KINDS, REDUCE_MAX_IDENTITY)
@@ -2044,7 +2044,7 @@ REDUCE_MIN_KINDS = {
 }
 REDUCE_MIN_IDENTITY = {
     jnp.floating: float("inf"),
-    jnp.signedinteger: np.iinfo(np.int32).max,
+    jnp.signedinteger: np.iinfo(np.int32).max,  # pyrefly: ignore[no-matching-overload]  # pyrefly#2398
 }
 _reduce_min_lowering_rule = reduce_lowering_rule(
     jnp.min, REDUCE_MIN_KINDS, REDUCE_MIN_IDENTITY)

--- a/jax/_src/stateful_rng.py
+++ b/jax/_src/stateful_rng.py
@@ -294,7 +294,7 @@ def stateful_rng(seed: typing.ArrayLike | None = None, *,
         " requires an explicit seed to be set.")
     entropy = np.random.SeedSequence().entropy
     assert isinstance(entropy, int)
-    seed = np.int64(entropy & np.iinfo(np.int64).max)
+    seed = np.int64(entropy & np.iinfo(np.int64).max)  # pyrefly: ignore[no-matching-overload]  # pyrefly#2398
   assert seed is not None
   return StatefulPRNG(
     _base_key=random.key(seed, impl=impl),

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -818,7 +818,7 @@ def rand_fullrange(rng, standardize_nans=False):
   def gen(shape, dtype, post=lambda x: x):
     dtype = np.dtype(dtype)
     size = dtype.itemsize * math.prod(_dims_of_shape(shape))
-    vals = rng.randint(0, np.iinfo(np.uint8).max, size=size, dtype=np.uint8)
+    vals = rng.randint(0, np.iinfo(np.uint8).max, size=size, dtype=np.uint8)  # pyrefly: ignore[no-matching-overload]  # pyrefly#2398
     vals = post(vals).view(dtype)
     if shape is PYTHON_SCALAR_SHAPE:
       # Sampling from the full range of the largest available uint type


### PR DESCRIPTION
These errors are related to the pyrefly bug filed at https://github.com/facebook/pyrefly/issues/2398

I labeled each suppression with this bug number so that we can remove them if and when this is fixed.