### PR TITLE
[random] fix PRNGKeyArray pickle under Python 3.11

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -308,6 +308,12 @@ class PRNGKeyArray(Array):
                     " Use jax.random.key_data(arr) if you wish to extract the underlying"
                     " integer array.")
 
+  # Python 3.11 pickle doesn't find __getstate__ in the parent C class
+  # (See https://github.com/jax-ml/jax/issues/35065).
+  # TODO(jakevdp): remove this when we drop support for Python 3.11.
+  def __getstate__(self):
+    return super().__getstate__()
+
   # Overwritten immediately below
   @property
   def at(self)                  -> _IndexUpdateHelper: assert False  # type: ignore[override]

--- a/tests/pickle_test.py
+++ b/tests/pickle_test.py
@@ -14,7 +14,6 @@
 
 import copy
 import pickle
-import sys
 import unittest
 
 from absl.testing import absltest
@@ -125,8 +124,6 @@ class PickleTest(jtu.JaxTestCase):
     self.assertIsInstance(y, type(x))
     self.assertEqual(x.aval, y.aval)
 
-  @unittest.skipIf(sys.version_info[:2] == (3, 11),
-                   "cannot pickle: b/470129766")
   @jtu.sample_product(prng_name=['threefry2x32', 'rbg', 'unsafe_rbg'])
   def testPickleOfKeyArray(self, prng_name):
     with jax.default_prng_impl(prng_name):


### PR DESCRIPTION
Fixes #35065.

It appears that Python 3.11 has trouble finding the `__getstate__` method in the parent C class. I suspect this was introduced in #33420.
