### PR TITLE
Add documentation to lax.reduce and lax.reduce_window stating that init_values and init_value must consist of scalars

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2963,6 +2963,8 @@ def reduce(operands: Any,
   ``computation``, and ``computation`` must be associative. XLA may exploit both
   of these properties during code generation; if either is violated the result
   is undefined.
+
+  ``init_values`` must consist of scalars.
   """
   flat_operands, operand_tree = tree_util.tree_flatten(operands)
   comp_debug = api_util.debug_info("reduce comp", computation,

--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -130,7 +130,7 @@ def reduce_window(
   Args:
     operand: input array or tree of arrays.
     init_value: value or tree of values. Tree structure must match that
-      of ``operand``.
+      of ``operand``. The values in ``init_value`` must be scalars.
     computation: callable function over which to reduce. Input and output must be
       a tree of the same structure as ``operand``.
     window_dimensions: sequence of integers specifying the window size.


### PR DESCRIPTION
Add documentation to [`lax.reduce`](https://docs.jax.dev/en/latest/_autosummary/jax.lax.reduce.html) and [`lax.reduce_window`](https://docs.jax.dev/en/latest/_autosummary/jax.lax.reduce_window.html) stating that the arguments `init_values` and `init_value` must consist of scalars.

Example:

```python3
from jax import lax
from jax import numpy as jnp

operand = jnp.arange(12).reshape((3, 4))

for init_value in [0, jnp.zeros(operand.shape[1:], int)]:
  try:
    lax.reduce(
      {"key": operand},
      {"key": init_value},
      lambda a, b: {"key": lax.add(a["key"], b["key"])},
      dimensions=[0],
    )
  except ValueError as e:
    print(e)

  try:
    lax.reduce_window(operand, init_value, lax.add, window_dimensions=(2, 2))
  except TypeError as e:
    print(e)
```

Output:

```
reduce found non-scalar initial value: [(4,)]
reduce_window expected init_values to be scalars but init_values have shapes [(4,)].
```

Another example:

```python3
from jax import lax, numpy as jnp
lax.reduce(jnp.ones([10]), jnp.zeros([]), lax.add, [0])
lax.reduce(jnp.ones([10, 3]), jnp.zeros([3]), lax.add, [0])
```

```
Array(10., dtype=float32)
ValueError: reduce found non-scalar initial value: [(3,)]
```