### PR TITLE
Fix variance_scaling division by zero error.

### DIFF
--- a/jax/_src/nn/initializers.py
+++ b/jax/_src/nn/initializers.py
@@ -242,7 +242,8 @@ def _compute_fans(shape: Sequence[int],
     batch_size = shape[batch_axis]
   else:
     batch_size = math.prod([shape[i] for i in batch_axis])
-  receptive_field_size = math.prod(shape) / in_size / out_size / batch_size
+  denominator = in_size * out_size * batch_size
+  receptive_field_size = math.prod(shape) / denominator if denominator != 0 else 0
   fan_in = in_size * receptive_field_size
   fan_out = out_size * receptive_field_size
   return fan_in, fan_out
@@ -345,7 +346,7 @@ def variance_scaling(
     else:
       raise ValueError(
         f"invalid mode for variance scaling initializer: {mode}")
-    variance = jnp.array(scale / denominator, dtype=dtype)
+    variance = jnp.array(scale / denominator if denominator != 0 else 0, dtype=dtype)
 
     if distribution == "truncated_normal":
       if dtypes.issubdtype(dtype, np.floating):

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -922,6 +922,22 @@ class NNInitializersTest(jtu.JaxTestCase):
     ):
       initializer(rng, shape)
 
+  @jtu.sample_product(
+    initializer=[
+      nn.initializers.he_normal(),
+      nn.initializers.lecun_normal(),
+      nn.initializers.glorot_normal(),
+    ],
+    shape=[
+      (8, 0),
+      (0, 8),
+      (0, 0),
+    ],
+  )
+  def testVarianceScalingDivisionByZero(self, initializer, shape):
+    rng = random.PRNGKey(0)
+    initializer(rng, shape)
+
   def testIdentity(self):
     x  = jnp.array([1., 2., 3.])
     self.assertAllClose(nn.identity(x), x, check_dtypes=False)


### PR DESCRIPTION
Edit [`variance_scaling`](https://docs.jax.dev/en/latest/_autosummary/jax.nn.initializers.variance_scaling.html) to avoid a `ZeroDivisionError` when the input shapes have zeros.

There are real cases where one wants zero-size input or output dimensions. For example, in an RL setting, one could use `memory_size = 0` for the recurrent cell to represent a memory-less agent.

This PR allows such cases to be handled seamlessly, improving user-friendliness.

(There are [good reasons](https://carlosgmartin.com/division-by-zero) to define division by zero as zero, as this PR incidentally does, but that's tangential.)