### PR TITLE
[ROCm] Set release rpaths to rocm so targets

### DIFF
--- a/jax_plugins/rocm/BUILD.bazel
+++ b/jax_plugins/rocm/BUILD.bazel
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-licenses(["notice"])
-
 load(
-  "//jaxlib:jax.bzl",
-  "py_library_providing_imports_info",
-  "pytype_library",
+    "//jaxlib:jax.bzl",
+    "py_library_providing_imports_info",
+    "pytype_library",
 )
+load("//jaxlib/rocm:rocm_rpath.bzl", "rocm_cc_binary")
+
+licenses(["notice"])
 
 package(
     default_applicable_licenses = [],
@@ -33,7 +34,7 @@ exports_files([
     "setup.py",
 ])
 
-cc_binary(
+rocm_cc_binary(
     name = "pjrt_c_api_gpu_plugin.so",
     linkopts = [
         "-Wl,--version-script,$(location :gpu_version_script.lds)",

--- a/jaxlib/rocm/BUILD
+++ b/jaxlib/rocm/BUILD
@@ -22,6 +22,7 @@ load(
     "nanobind_extension",
     "rocm_library",
 )
+load("//jaxlib/rocm:rocm_rpath.bzl", "rocm_nanobind_extension")
 
 licenses(["notice"])
 
@@ -108,7 +109,7 @@ cc_library(
     ],
 )
 
-nanobind_extension(
+rocm_nanobind_extension(
     name = "_rnn",
     srcs = ["//jaxlib/gpu:rnn.cc"],
     copts = [
@@ -180,7 +181,7 @@ cc_library(
     ],
 )
 
-nanobind_extension(
+rocm_nanobind_extension(
     name = "_solver",
     srcs = ["//jaxlib/gpu:solver.cc"],
     copts = [
@@ -232,7 +233,7 @@ cc_library(
     ],
 )
 
-nanobind_extension(
+rocm_nanobind_extension(
     name = "_sparse",
     srcs = ["//jaxlib/gpu:sparse.cc"],
     copts = [
@@ -292,7 +293,7 @@ rocm_library(
     ],
 )
 
-nanobind_extension(
+rocm_nanobind_extension(
     name = "_linalg",
     srcs = ["//jaxlib/gpu:linalg.cc"],
     copts = [
@@ -342,7 +343,7 @@ rocm_library(
     ],
 )
 
-nanobind_extension(
+rocm_nanobind_extension(
     name = "_prng",
     srcs = ["//jaxlib/gpu:prng.cc"],
     copts = [
@@ -383,7 +384,7 @@ cc_library(
     ],
 )
 
-nanobind_extension(
+rocm_nanobind_extension(
     name = "_hybrid",
     srcs = ["//jaxlib/gpu:hybrid.cc"],
     copts = [
@@ -451,7 +452,7 @@ cc_library(
     ],
 )
 
-nanobind_extension(
+rocm_nanobind_extension(
     name = "_triton",
     srcs = ["//jaxlib/gpu:triton.cc"],
     copts = [
@@ -527,7 +528,7 @@ cc_library(
     ],
 )
 
-nanobind_extension(
+rocm_nanobind_extension(
     name = "rocm_plugin_extension",
     srcs = ["rocm_plugin_extension.cc"],
     module_name = "rocm_plugin_extension",

--- a/jaxlib/rocm/rocm_rpath.bzl
+++ b/jaxlib/rocm/rocm_rpath.bzl
@@ -1,0 +1,88 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wrapper macros for ROCm wheel RPATH configuration.
+
+When building wheels with rocm_path_type=link_only, Bazel sandbox rpaths
+are stripped and replaced with wheel-relative paths so that .so files
+find ROCm libraries at install time.
+
+Usage in BUILD files:
+
+    load("//jaxlib/rocm:rpath.bzl", "rocm_nanobind_extension")
+
+    rocm_nanobind_extension(
+        name = "_my_ext",
+        srcs = ["my_ext.cc"],
+        ...
+    )
+"""
+
+load("//jaxlib:jax.bzl", "nanobind_extension")
+
+_ROCM_LINK_ONLY = "@local_config_rocm//rocm:link_only"
+
+_WHEEL_RPATHS = [
+    "-Wl,-rpath,$$ORIGIN/../rocm/lib",
+    "-Wl,-rpath,$$ORIGIN/../../rocm/lib",
+    "-Wl,-rpath,/opt/rocm/lib",
+]
+
+def _wheel_features():
+    return select({
+        _ROCM_LINK_ONLY: ["no_solib_rpaths"],
+        "//conditions:default": [],
+    })
+
+def _wheel_linkopts():
+    return select({
+        _ROCM_LINK_ONLY: _WHEEL_RPATHS,
+        "//conditions:default": [],
+    })
+
+def rocm_nanobind_extension(name, features = [], linkopts = [], **kwargs):
+    """nanobind_extension that automatically strips solib rpaths and embeds wheel RPATHs.
+
+    When built with --@local_config_rocm//rocm:rocm_path_type=link_only,
+    the no_solib_rpaths feature is enabled and wheel-specific RPATHs are
+    added. Otherwise the target behaves identically to nanobind_extension.
+
+    Args:
+        name: Target name.
+        features: Additional features (rpath features are appended automatically).
+        linkopts: Additional linkopts (wheel RPATHs are appended automatically).
+        **kwargs: Passed through to nanobind_extension.
+    """
+    nanobind_extension(
+        name = name,
+        features = features + _wheel_features(),
+        linkopts = linkopts + _wheel_linkopts(),
+        **kwargs
+    )
+
+def rocm_cc_binary(name, features = [], linkopts = [], **kwargs):
+    """cc_binary that automatically strips solib rpaths and embeds wheel RPATHs.
+
+    Args:
+        name: Target name.
+        features: Additional features (rpath features are appended automatically).
+        linkopts: Additional linkopts (wheel RPATHs are appended automatically).
+        **kwargs: Passed through to native.cc_binary.
+    """
+    native.cc_binary(
+        name = name,
+        features = features + _wheel_features(),
+        linkopts = linkopts + _wheel_linkopts(),
+        **kwargs
+    )


### PR DESCRIPTION
Introduce release wheel rpaths based on rpath_type config from xla.
This change is based on this PR in xla: https://github.com/openxla/xla/pull/37513

If rpath is set to link_only then all solib and custom rpaths are stripped out and specific wheel rpaths are added instead 
into the relased binaries.