### PR TITLE
[Pallas][Mosaic GPU] Add MGPU splash attention implementation

### DIFF
--- a/jax/experimental/BUILD
+++ b/jax/experimental/BUILD
@@ -406,7 +406,9 @@ pytype_strict_library(
 
 pytype_strict_library(
     name = "pallas_experimental_gpu_ops",
-    srcs = ["//jax/experimental/pallas/ops/gpu:mgpu_ops"],
+    srcs = ["//jax/experimental/pallas/ops/gpu:mgpu_ops",
+            "//jax/experimental/pallas/ops/gpu/splash_attention:splash_attention",
+    ],
     visibility = [
         ":mosaic_gpu_users",
     ],

--- a/jax/experimental/pallas/ops/gpu/splash_attention/BUILD
+++ b/jax/experimental/pallas/ops/gpu/splash_attention/BUILD
@@ -1,0 +1,30 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(
+    default_applicable_licenses = [],
+    default_visibility = ["//jax:__subpackages__"],
+)
+
+exports_files(
+    srcs = glob(["*.py"]),
+)
+
+filegroup(
+    name = "splash_attention",
+    srcs = glob(
+        ["*.py"],
+    ),
+)
+

--- a/jax/experimental/pallas/ops/gpu/splash_attention/__init__.py
+++ b/jax/experimental/pallas/ops/gpu/splash_attention/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/jax/experimental/pallas/ops/gpu/splash_attention/attention_mask.py
+++ b/jax/experimental/pallas/ops/gpu/splash_attention/attention_mask.py
@@ -1,0 +1,386 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import dataclasses
+import enum
+import functools
+import math
+
+import jax
+import numpy as np
+from jax import numpy as jnp
+
+
+class MaskType(enum.Enum):
+  ZEROS = 0
+  PARTIAL = 1
+  ONES = 2
+
+
+@functools.partial(jax.tree_util.register_dataclass,
+                   data_fields=["data_next",
+                                "mask_next",
+                                "block_mask",
+                                "num_nonzero_blocks",
+                                "partial_mask_blocks"],
+                   meta_fields=["data_tiling", "is_dkv"])
+@dataclasses.dataclass(frozen=True)
+class MaskInfo:
+  """Contains runtime masking information for the attention kernel.
+
+  The ``data_next`` and ``num_nonzero_blocks`` fields are tiled according
+  to the number of compute warpgroups used by the kernel. This is because when using
+  warp specialization, the data blocks are shared between all of the compute
+  warpgroups, so each warpgroup will receive the same data block and then decide
+  whether to keep or skip the block based on ``block_mask``.
+  However, the mask data is not tiled since the mask typically varies
+  between q_blocks, and therefore cannot be shared between the compute warpgroups.
+
+  The ``data_next``, ``mask_next``, and ``block_mask`` tensors are compressed such that
+  all non-zero blocks are sorted to the front (for fwd/dq kernels) or to the end (for dkv).
+  The ``num_nonzero_blocks`` tensor indicates how many non-zero blocks there are, so it
+  is sufficient to loop from 0 to ``num_nonzero_blocks`` to visit all non-zero blocks
+  in the mask.
+
+  Attributes:
+    data_next: An integer[batch_size, heads=1, num_q_blocks // q_tiling, num_kv_blocks // kv_tiling]
+      array where each entry contains the next ``kv`` block index to
+      prefetch. This tensor is either tiled along the q or kv dimension, depending
+      on which kernel this mask is for. For forward/dq kernels, the tiling is done
+      along the ``num_q_blocks`` dimension. For the dkv kernel, the tiling is done
+      along the ``num_kv_blocks`` dimension.
+    mask_next: An integer[batch_size, heads=1, num_q_blocks, num_kv_blocks]
+      array where each entry contains the next mask block index in
+      `partial_mask_blocks` to prefetch.
+    block_mask: An integer[batch_size, heads=1, num_q_blocks, num_kv_blocks]
+      array whose entries can be 0, 1 or 2. An entry of 0 indicates that
+      the corresponding block in the full mask was all zeros. An entry of 1
+      indicates that the corresponding block in the full mask contained both
+      zeros and ones. An entry of 2 indicates the corresponding block was
+      entirely ones.
+    num_nonzero_blocks: An integer[batch_size, heads=1, num_q_or_kv_blocks // q_or_kv_tiling]
+      array containing the number of non-zero blocks along each q-block dimension (or kv dimension
+      if computing the dkv mask).
+    partial_mask_blocks: A bool[batch_size, 1, num_partial_blocks, block_q, block_kv]
+      array that contains the blocks of the original mask that contained both
+      zeros and ones. The entries in `mask_next` point to indices in the first
+      axis of this array.
+    data_tiling: The tiling factor (q_tiling or kv_tiling)
+    is_dkv: Whether this mask is for the dkv kernel. If False, this mask is constructed
+      for the forward/dq kernels.
+  """
+
+  data_next: jax.Array
+  mask_next: jax.Array
+  block_mask: jax.Array
+  num_nonzero_blocks: jax.Array
+  partial_mask_blocks: jax.Array
+  data_tiling: int
+  is_dkv: bool
+
+  @property
+  def q_block_size(self) -> int:
+    return self.partial_mask_blocks.shape[3]
+
+  @property
+  def kv_block_size(self) -> int:
+    return self.partial_mask_blocks.shape[4]
+
+
+@jax.jit(static_argnames=("axis", "placeholder", "flip"))
+def compress_array(x: jax.Array, axis=-1, placeholder=-1, flip: bool = False) -> tuple[jax.Array, jax.Array]:
+  """Compress array by shifting non-placeholder entries to the left along the specified axis.
+
+  Placeholder entries are pushed to the right while preserving relative order of non-placeholder elements.
+
+  Args:
+      x: Input JAX array
+      axis: Axis along which to compress (default: -1, last axis)
+      placeholder: Value to treat as placeholder (default: -1)
+      flip: If True, will compress to the right instead of to the left.
+
+  Returns:
+      A tuple containing (compressed_array, sort_indices).
+  """
+  # Mask of valid (non-placeholder) elements
+  mask = x != placeholder
+
+  # Size along compression axis
+  n = x.shape[axis]
+
+  # Create indices along the compression axis, broadcast to input shape
+  shape = [1] * x.ndim
+  shape[axis] = n
+  indices = jnp.arange(n).reshape(shape)
+  indices = jnp.broadcast_to(indices, x.shape)
+
+  # Sort key: valid elements keep original index, invalid get large values
+  # This ensures valid elements sort first while preserving relative order
+  if flip:
+    key = jnp.where(mask, n + indices, indices)
+  else:
+    key = jnp.where(mask, indices, n + indices)
+
+  # Get sorted indices and apply
+  sorted_indices = jnp.argsort(key, axis=axis)
+  return jnp.take_along_axis(x, sorted_indices, axis=axis), sorted_indices
+
+
+def tiled_max(x: jax.Array, tile_size: int, axis: int = -2) -> jax.Array:
+  """Computes a max over tiles along an axis.
+
+  For example, for an array [0, 1, 2, 3, 4, 5]:
+    with tile_size=2, the result would be [1, 3, 5]
+    with tile_size=3, the result would be [2, 5]
+    with tile_size=6, the result would be [5] (equivalent to a non-tiled max)
+  """
+  if tile_size == 1:
+    return x
+  if axis < 0:
+    axis += x.ndim
+  axis_size = x.shape[axis]
+  new_axis_size = axis_size // tile_size
+
+  # Tile to group rows: (X, Y) -> (X // num_compute_wgs, num_compute_wgs, Y)
+  new_shape = x.shape[:axis] + (new_axis_size, tile_size) + x.shape[axis + 1:]
+  x_reshaped = x.reshape(new_shape)
+
+  # Take max along the grouping axis
+  return jnp.max(x_reshaped, axis=axis + 1)
+
+
+def process_dynamic_mask(
+    mask: jax.Array,
+    block_shape: tuple[int, int],
+    is_dkv: bool,
+    *,
+    data_tiling: int = 1,
+    downcast_block_mask_data: bool = True,
+) -> MaskInfo:
+  """Processes a dense attention mask into a sparse ``MaskInfo`` representation.
+
+  Since the mask is dynamic, we can't know the exact number of partial mask
+  blocks at trace time. Therefore, the entire mask is materialized in
+  ``partial_mask_blocks``.
+
+  Args:
+    mask: A [batch_size, heads=1, q_seq_len, kv_seq_len] jax.Array representing the dense
+      mask to process.
+    block_shape: A tuple of (q_block_size, kv_block_size).
+    is_dkv: True if we are processing the dKV mask
+    data_tiling: The tiling factor to apply to the data blocks. This should be set to
+      the number of compute warpgroups used by the kernel.
+    downcast_block_mask_data: If True, downcast the scalar-memory data of MaskInfo to
+      a data type smaller than np.int32 (if possible).
+
+  Returns:
+    `MaskInfo`, a sparse representation of the dense mask.
+
+  Raises:
+    ValueError: if the input mask is invalid or the block sizes are not
+    compatible with the mask sizes.
+  """
+  if len(mask.shape) != 4:
+    raise ValueError(f"Expected a 4-dim mask, instead got: {mask.shape}.")
+
+  if mask.dtype != jnp.bool:
+    raise ValueError(f"Expected a bool mask, instead got: {mask.dtype}.")
+
+  batch_size, head_count, q_seq_len, kv_seq_len = mask.shape
+  if head_count != 1:
+    raise ValueError(
+        f"Expected head dimension to be 1, instead got: {head_count}.")
+  q_block_size, kv_block_size = block_shape
+  q_blocks_count, q_mod = divmod(q_seq_len, q_block_size)
+  kv_blocks_count, kv_mod = divmod(kv_seq_len, kv_block_size)
+
+  if q_mod != 0:
+    raise ValueError(f"{q_block_size=} should divide {q_seq_len=}.")
+  if kv_mod != 0:
+    raise ValueError(f"{kv_block_size=} should divide {kv_seq_len=}.")
+
+  block_mask_shape = (
+      batch_size,
+      head_count,
+      q_blocks_count,
+      kv_blocks_count,
+  )
+
+  # Tile the last 2 dimensions of the mask into 2D tiles of size `block_shape`.
+  partial_mask_blocks = (
+      mask.reshape(
+          batch_size,
+          head_count,
+          q_blocks_count,
+          q_block_size,
+          kv_blocks_count,
+          kv_block_size,
+      )
+      .swapaxes(-2, -3)
+      .astype(np.bool_)
+  )
+
+  # The block mask is 2 for all blocks with all entries set to True and 1 for
+  # blocks with a mix of True and False entries.
+  is_full_mask = jnp.all(partial_mask_blocks, axis=(-1, -2))
+  is_empty_mask = jnp.logical_not(jnp.any(partial_mask_blocks, axis=(-1, -2)))
+
+  block_mask = jnp.ones(block_mask_shape, dtype=np.int32) * \
+      MaskType.PARTIAL.value
+  block_mask = jnp.where(is_full_mask, MaskType.ONES.value, block_mask)
+  block_mask = jnp.where(is_empty_mask, MaskType.ZEROS.value, block_mask)
+
+  mask_info_slice_shape = (batch_size, 1, q_blocks_count, kv_blocks_count)
+  mask_info_slice_shape_per_batch = (1, *mask_info_slice_shape[1:])
+  mask_next_slice = jnp.arange(math.prod(mask_info_slice_shape_per_batch), dtype=np.int32).reshape(
+      mask_info_slice_shape_per_batch
+  )
+  mask_next_slice = jnp.tile(mask_next_slice, (batch_size, 1, 1, 1))
+  mask_next_slice = jnp.where(block_mask == 1, mask_next_slice, -1)
+
+  # data_next stores the index of the next non-empty data block in the sequence.
+  # The indices of empty blocks are set to 0 to avoid copying extra data when
+  # pipeling.
+  if is_dkv:
+    data_next = jnp.arange(q_blocks_count, dtype=np.int32)[None, None, :, None]
+  else:
+    data_next = jnp.arange(kv_blocks_count, dtype=np.int32)[
+        None, None, None, :]
+  data_next = jnp.broadcast_to(data_next, mask_info_slice_shape)
+  data_next = jnp.where(block_mask == 0, -1, data_next)
+
+  # Compress and tile mask data.
+  # The mask_info is structured such that data blocks are shared between compute warpgroups.
+  # This is due to the structure of a warp-specialized kernel where there is a single memory
+  # warpgroup loading data that can be shared between multiple compute warpgroups, reducing
+  # the overall amount of data copied from HBM.
+  # We do not share the mask between compute warpgroups since the masking pattern typically
+  # differs between different Q-blocks and therefore cannot be shared.
+  #
+  # Consider the simple case with a single compute warpgroup. Before compression, we could have:
+  #   block_mask = [ 0  0  2  2  1  0  0]
+  #   data_next  = [-1 -1  2  3  4 -1 -1]
+  # Compression will move all non-zero blocks to the beginning of the array, resulting in:
+  #   block_mask = [ 2  2  1  0  0  0  0]
+  #   data_next  = [ 2  3  4 -1 -1 -1 -1]
+  # Additionally, we will compute `num_nonzero_blocks=3` to indicate to the kernel that it only
+  # needs to loop from 0 to 3 to visit all non-masked blocks. This operation prevents the kernel
+  # from wasting time while iterating through empty blocks.
+  #
+  # Now consider the case where we have 2 compute warpgroups and one memory warpgroup. We
+  # have 2 `block_mask` rows (handled by the compute warpgroup) per `data_next` row (handled by
+  # the memory warpgroup).
+  #   block_mask = [ 0  0  2  2  1  0  0]
+  #                [ 0  0  0  2  2  1  0]
+  #   data_next  = [-1 -1  2  3  4  5 -1]
+  # In this case, we cannot compress each row of block_mask individually and can only ignore
+  # a block if both warpgroups have that block masked. Therefore, the result of compression should
+  # yield:
+  #   block_mask = [ 2  2  1  0  0  0  0]
+  #                [ 0  2  2  1  0  0  0]
+  #   data_next  = [ 2  3  4  5 -1 -1 -1]
+  # And we have `num_nonzero_blocks=4`. Now, it is up to the compute warpgroup 0 to zero-out its
+  # mask on iteration 3 and compute warpgroup 1 to zero-out its mask on iteration 0.
+  # For the dkv mask we apply the same logic but on the q-dimension instead of the kv-dimension.
+
+  if is_dkv:
+    tile_axis = -1  # kv dim
+    compress_axis = -2  # q dim
+    # For dkv we compress entires to the end of the array instead of the beginning.
+    # This matches the behavior of the TPU splash attention masking logic.
+    flip_compress = True
+  else:
+    tile_axis = -2  # q dim
+    compress_axis = -1  # kv dim
+    flip_compress = False
+  if data_next.shape[tile_axis] % data_tiling != 0:
+    raise ValueError(
+        f"data_tiling={data_tiling} must divide tile axis={data_next.shape[tile_axis]}")
+  data_next = tiled_max(data_next, data_tiling, axis=tile_axis)
+  data_next, permutation = compress_array(
+      data_next, axis=compress_axis, placeholder=-1, flip=flip_compress)
+  if data_tiling > 1:
+    permutation = jnp.repeat(permutation, data_tiling, axis=tile_axis)
+  block_mask = jnp.take_along_axis(block_mask, permutation, axis=compress_axis)
+  mask_next = jnp.take_along_axis(
+      mask_next_slice, permutation, axis=compress_axis)
+  num_nonzero_blocks = jnp.sum(data_next >= 0, axis=compress_axis)
+
+  if is_dkv:
+    partial_mask_blocks = partial_mask_blocks.swapaxes(-1, -2)
+
+  def _downcast(array: jax.Array, max_value: int) -> jax.Array:
+    if array.size == 0:
+      return array
+
+    if array.dtype != np.int32:
+      raise ValueError(f"Expected int32 input, but got {array.dtype}.")
+
+    if max_value <= np.iinfo(np.int8).max:
+      return array.astype(np.int8)
+    elif max_value <= np.iinfo(np.int16).max:
+      return array.astype(np.int16)
+    else:
+      return array.astype(np.int32)
+
+  if downcast_block_mask_data:
+    # values are in the range [0, 1, 2]
+    block_mask = block_mask.astype(np.int8)
+    data_next = _downcast(
+        data_next, q_blocks_count if is_dkv else kv_blocks_count)
+    mask_next = _downcast(mask_next, q_blocks_count * kv_blocks_count)
+  partial_mask_blocks = partial_mask_blocks.reshape(
+      [batch_size, 1, -1, q_block_size, kv_block_size])
+
+  if is_dkv:
+    assert data_next.shape == (
+        batch_size, 1, q_blocks_count, kv_blocks_count // data_tiling), data_next.shape
+    assert mask_next.shape == (
+        batch_size, 1, q_blocks_count, kv_blocks_count), mask_next.shape
+    assert block_mask.shape == (
+        batch_size, 1, q_blocks_count, kv_blocks_count), block_mask.shape
+    assert num_nonzero_blocks.shape == (
+        batch_size, 1, kv_blocks_count // data_tiling), num_nonzero_blocks.shape
+    assert partial_mask_blocks.shape == (
+        batch_size,
+        1,
+        q_blocks_count * kv_blocks_count,
+        q_block_size,
+        kv_block_size,
+    ), partial_mask_blocks.shape
+  else:
+    assert data_next.shape == (
+        batch_size, 1, q_blocks_count // data_tiling, kv_blocks_count), data_next.shape
+    assert mask_next.shape == (
+        batch_size, 1, q_blocks_count, kv_blocks_count), mask_next.shape
+    assert block_mask.shape == (
+        batch_size, 1, q_blocks_count, kv_blocks_count), block_mask.shape
+    assert num_nonzero_blocks.shape == (
+        batch_size, 1, q_blocks_count // data_tiling), num_nonzero_blocks.shape
+    assert partial_mask_blocks.shape == (
+        batch_size,
+        1,
+        q_blocks_count * kv_blocks_count,
+        q_block_size,
+        kv_block_size,
+    ), partial_mask_blocks.shape
+
+  return MaskInfo(
+      data_next=data_next,
+      mask_next=mask_next,
+      block_mask=block_mask,
+      num_nonzero_blocks=num_nonzero_blocks,
+      partial_mask_blocks=partial_mask_blocks,
+      data_tiling=data_tiling,
+      is_dkv=is_dkv,
+  )

--- a/jax/experimental/pallas/ops/gpu/splash_attention/hopper_splash_attention.py
+++ b/jax/experimental/pallas/ops/gpu/splash_attention/hopper_splash_attention.py
@@ -1,0 +1,1098 @@
+# ruff: noqa: E731, E741
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Splash attention implementation (using Mosaic GPU as the backend, based on FA3)."""
+
+import dataclasses
+import math
+from functools import partial
+
+import jax
+import jax.experimental.pallas as pl
+import jax.experimental.pallas.mosaic_gpu as plgpu
+from jax.experimental.pallas.ops.gpu.splash_attention import attention_mask
+import jax.numpy as jnp
+from jax import lax
+from jax._src import dtypes
+from jax._src.lib import cuda_versions  # noqa: F401
+
+
+@dataclasses.dataclass(frozen=True)
+class TuningConfig:
+  block_q: int
+  block_kv: int
+  max_concurrent_steps: int
+  use_schedule_barrier: bool = True
+
+  block_q_dkv: int | None = None
+  block_kv_dkv: int | None = None
+  block_q_dq: int | None = None
+  block_kv_dq: int | None = None
+
+  def __post_init__(self):
+    if self.block_q % 64:
+      raise ValueError(f"{self.block_q=} must be a multiple of 64")
+    if self.block_kv % 64:
+      raise ValueError(f"{self.block_kv=} must be a multiple of 64")
+    if self.max_concurrent_steps < 2:
+      raise ValueError(f"{self.max_concurrent_steps=} must be at least 2")
+
+    backward_blocks = [self.block_q_dkv,
+                       self.block_kv_dkv, self.block_q_dq, self.block_kv_dq]
+    block_is_set = [blk is not None for blk in backward_blocks]
+    if any(block_is_set) and not all(block_is_set):
+      raise ValueError(
+          "Backward block sizes (block_q_dkv, block_kv_dkv, block_q_dq, "
+          "block_kv_dq) must either all be specified or all be None."
+      )
+
+  @property
+  def has_backward_blocks(self) -> bool:
+    return self.block_q_dkv is not None
+
+
+def _get_large_negative(dtype):
+  dtype_max = dtypes.finfo(dtype).max
+  return jnp.asarray(-0.7 * dtype_max, dtype=dtype)
+
+
+def maybe_apply_mask(qk, num_nonzeros, block_mask_value, mask_smem_ref, barriers=None, wg_key="wg"):
+  """Conditionally applies a mask to QK given the block mask value.
+
+  Args:
+      qk: The QK (logits) matrix to mask.
+      num_nonzeros: The number of non-zero blocks encountered along the reduction dimension.
+          Has shape of ``qk.shape[0]``.
+      block_mask_value: The value indicating the type of block. If 0, the block is
+          all masked. If 1, the block is partially masked (and ``mask_smem_ref`` will be applied).
+          If 2, the block is unmasked.
+      mask_smem_ref: The shared memory reference to the mask to apply for partially masked blocks.
+      barriers: Optional list of barriers to wait on before loading the mask from shared memory.
+      wg_key: The axis name for the warpgroup index.
+
+  Returns:
+      Masked QK matrix and updated ``num_nonzeros`` tensor.
+  """
+  large_negative = _get_large_negative(qk.dtype)
+
+  if barriers:
+    # TODO(justinjfu): Only issue and wait the mask TMA if `block_mask_value=1`
+    for wg in range(len(barriers)):
+
+      @pl.when(lax.axis_index(wg_key) == wg)
+      def _() -> None:
+        plgpu.barrier_wait(barriers[wg])
+
+  def apply_smem_mask(qk, num_nonzeros):
+    mask = plgpu.load(mask_smem_ref, (), layout=plgpu.Layout.WGMMA)
+    assert mask.shape == qk.shape, f"{mask.shape=} != {qk.shape=}"
+    return jnp.where(mask, qk, large_negative), num_nonzeros + mask.sum(axis=1)
+
+  def _nonzero_mask(qk, num_nonzeros):
+    return lax.cond(
+        block_mask_value == attention_mask.MaskType.PARTIAL.value,
+        lambda qk, num_nonzeros: apply_smem_mask(
+            qk, num_nonzeros),  # Masked block
+        lambda qk, num_nonzeros: (qk, num_nonzeros + 1),  # Full block
+        qk,
+        num_nonzeros,
+    )
+
+  qk, num_nonzeros = lax.cond(
+      block_mask_value == attention_mask.MaskType.ZEROS.value,
+      # Note: jnp.full is slower than jnp.minimum here
+      lambda qk, num_nonzeros: (jnp.minimum(
+          qk, large_negative), num_nonzeros),  # Zero block
+      _nonzero_mask,
+      qk,
+      num_nonzeros,
+  )
+  return qk, num_nonzeros
+
+
+def _attention_forward(
+    q,
+    k,
+    v,
+    mask_info: attention_mask.MaskInfo,
+    config: TuningConfig,
+    scale: float | None,
+    save_residuals: bool = False,
+):
+  if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+    raise ValueError(
+        f"q, k, and v should all be 4D, got: {q.ndim=}, {k.ndim=}, {v.ndim=}")
+  batch_size, q_seq_len, num_q_heads, head_dim = q.shape
+  _, kv_seq_len, num_kv_heads, _ = k.shape
+  kv_shape = (batch_size, kv_seq_len, num_kv_heads, head_dim)
+  if k.shape != kv_shape:
+    raise ValueError(f"Expected {k.shape=} to be {kv_shape} (inferred from q)")
+  if v.shape != kv_shape:
+    raise ValueError(f"Expected {v.shape=} to be {kv_shape} (inferred from q)")
+  if (dtype := q.dtype) != k.dtype or dtype != v.dtype:
+    raise ValueError(
+        f"q, k, and v should all have the same dtype, got: {q.dtype}, {k.dtype}, {v.dtype}")
+  if num_q_heads % num_kv_heads:
+    raise ValueError(
+        f"{num_q_heads=} must be divisible by and {num_kv_heads=}")
+  q_heads_per_kv_head = num_q_heads // num_kv_heads
+  if head_dim % 64:
+    raise ValueError(f"{head_dim=} must be divisible by 64")
+  if jnp.dtype(dtype) not in map(jnp.dtype, [jnp.float16, jnp.bfloat16]):
+    raise NotImplementedError(
+        f"Only f16 and bf16 are supported, got dtype: {dtype}")
+  if scale is None:
+    scale = 1.0
+
+  compute_wgs = 2
+  max_concurrent_steps = min(
+      config.max_concurrent_steps, kv_seq_len // config.block_kv)
+  if max_concurrent_steps < 2:
+    raise NotImplementedError(
+        "Splash attention requires max_concurrent_steps > 2.")
+  block_q, block_kv = config.block_q, config.block_kv
+  if kv_seq_len % block_kv:
+    raise ValueError(f"{kv_seq_len=} must be a multiple of {block_kv=}")
+  if mask_info and mask_info.q_block_size != config.block_q:
+    raise ValueError(f"{mask_info.q_block_size=} must match {config.block_q=}")
+  if mask_info and mask_info.kv_block_size != config.block_kv:
+    raise ValueError(
+        f"{mask_info.kv_block_size=} must match {config.block_kv=}")
+
+  def kernel(
+      q_ref,
+      k_ref,
+      v_ref,
+      out_ref,
+      num_nonzero_blocks_ref,
+      block_mask_ref,
+      mask_next_ref,
+      data_next_ref,
+      partial_mask_blocks_ref,
+      lse_ref,
+      scoped,
+  ):
+    batch = lax.axis_index("batch")
+    q_head = lax.axis_index("heads")
+    scratch_buffers, buffer_barriers, consumed_barriers, schedule_barrier = scoped
+    wg_idx = lax.axis_index("wg")
+    q_seq = lax.axis_index("q_seq")
+    qo_smem2, k_smem, v_smem, lse_smem2, mask_smem = scratch_buffers
+    k_barriers, v_barriers, q_barriers, mask_barriers = buffer_barriers
+    k_consumed_barriers, v_consumed_barriers, mask_consumed_barriers = consumed_barriers
+
+    def perform_schedule_barrier():
+      plgpu.barrier_arrive(schedule_barrier)
+      plgpu.barrier_wait(schedule_barrier)
+
+    num_nonzero_blocks = num_nonzero_blocks_ref[batch, 0, q_seq]
+    # Need at least max_concurrent_steps, or else we issue OOB TMAs in the memory wg prologue.
+    block_max_kv_steps = jnp.maximum(num_nonzero_blocks, max_concurrent_steps)
+
+    @pl.when(wg_idx < 2)
+    def _compute_wg():
+      plgpu.set_max_registers(232, action="increase")
+      qo_smem = qo_smem2.at[wg_idx]
+      lse_smem = lse_smem2.at[wg_idx] if lse_smem2 is not None else None
+      q_seq_base = q_seq * (2 * block_q) + wg_idx * block_q
+      kv_steps = block_max_kv_steps
+
+      plgpu.copy_gmem_to_smem(
+          q_ref.at[batch, pl.ds(q_seq_base, block_q), q_head],
+          qo_smem,
+          q_barriers.at[wg_idx],
+      )
+      plgpu.barrier_wait(q_barriers.at[wg_idx])
+
+      @pl.when(kv_steps > 0)
+      def _():
+        plgpu.barrier_wait(k_barriers.at[0])
+
+      pl.when(wg_idx == 1)(perform_schedule_barrier)
+
+      def kv_loop(kv_step, carry):
+        acc, m_i, l_i, num_nonzeros = carry
+        slot = lax.rem(kv_step, jnp.array(max_concurrent_steps, kv_step.dtype))
+
+        # QK
+        def compute_qk(acc_ref):
+          plgpu.wgmma(acc_ref, qo_smem, plgpu.transpose_ref(
+              k_smem.at[slot], (1, 0)))
+          perform_schedule_barrier()
+          return acc_ref[...]
+
+        qk = pl.run_scoped(compute_qk, plgpu.ACC(
+            (block_q, block_kv), jnp.float32))
+        plgpu.barrier_arrive(k_consumed_barriers.at[slot])
+        qk = qk * scale
+
+        block_mask_value = block_mask_ref[batch,
+                                          0, q_seq * 2 + wg_idx, kv_step]
+
+        qk, num_nonzeros = maybe_apply_mask(
+            qk,
+            num_nonzeros,
+            block_mask_value,
+            mask_smem.at[slot, wg_idx],
+            barriers=[barrier.at[slot] for barrier in mask_barriers],
+        )
+
+        for wg in range(compute_wgs):
+
+          @pl.when(wg_idx == wg)
+          def _():
+            plgpu.barrier_arrive(mask_consumed_barriers[wg].at[slot])
+
+        # Softmax
+        # We keep m scaled by log2e to use FMA instructions when computing p.
+        log2e = math.log2(math.e)
+        m_ij = jnp.maximum(m_i, qk.max(axis=1) * log2e)
+        alpha = jnp.exp2(m_i - m_ij)
+        m_i = m_ij
+        p = jnp.exp2(qk * log2e - lax.broadcast_in_dim(m_ij, qk.shape, [0]))
+        acc *= lax.broadcast_in_dim(alpha, acc.shape, [0])
+        l_i *= alpha
+        p16 = p.astype(dtype)
+
+        def end_softmax_barriers():
+          plgpu.barrier_arrive(schedule_barrier)  # Done with softmax!
+          plgpu.barrier_wait(v_barriers.at[slot])
+          # Wait until TensorCore is free.
+          plgpu.barrier_wait(schedule_barrier)
+
+        # Can't fully explain why, but empirically the ordering here influences
+        # the performance of the final kernel quite significantly.
+        if head_dim <= 128:
+          l_i += p.sum(axis=1)
+          acc, l_i, m_i, p16 = lax.optimization_barrier((acc, l_i, m_i, p16))
+          end_softmax_barriers()
+        else:
+          end_softmax_barriers()
+          l_i += p.sum(axis=1)
+
+        # PV
+        def compute_pv(acc_ref):
+          plgpu.wgmma(acc_ref, p16, v_smem.at[slot])
+
+          wait_step = kv_step + 1
+          wait_slot = lax.rem(wait_step, jnp.array(
+              max_concurrent_steps, kv_step.dtype))
+
+          @pl.when(wait_step < kv_steps)
+          def _wait():
+            plgpu.barrier_wait(k_barriers.at[wait_slot])
+
+        acc = pl.run_state(compute_pv)(plgpu.ACC.init(acc))
+        plgpu.barrier_arrive(v_consumed_barriers.at[slot])
+        return acc, m_i, l_i, num_nonzeros
+
+      num_nonzeros = plgpu.layout_cast(
+          jnp.full((block_q,), 0, dtype=jnp.int32),
+          plgpu.Layout.WGMMA_ROW,
+      )
+      l_i = plgpu.layout_cast(
+          jnp.full((block_q,), 0, dtype=jnp.float32),
+          plgpu.Layout.WGMMA_ROW,
+      )
+      m_i = plgpu.layout_cast(
+          jnp.full((block_q,), _get_large_negative(
+              jnp.float32), dtype=jnp.float32),
+          plgpu.Layout.WGMMA_ROW,
+      )
+      acc = plgpu.layout_cast(
+          jnp.full((block_q, head_dim), 0, dtype=jnp.float32),
+          plgpu.Layout.WGMMA,
+      )
+      acc, m_i, l_i, num_nonzeros = lax.fori_loop(
+          0, kv_steps, kv_loop, (acc, m_i, l_i, num_nonzeros))
+      pl.when(wg_idx == 0)(perform_schedule_barrier)
+
+      # TODO(apaszke): Invert and multiply to avoid expensive divisions.
+      acc /= lax.broadcast_in_dim(l_i, (block_q, head_dim), [0])
+      acc = jnp.where(lax.broadcast_in_dim(
+          num_nonzeros > 0, acc.shape, [0]), acc, 0)
+      qo_smem[...] = acc.astype(dtype)
+      if lse_smem is not None:
+        RCP_LN2 = 1.4426950408889634
+        def log2(x): return jnp.log(x) * RCP_LN2
+        lse_smem[...] = jnp.where(
+            num_nonzeros > 0, m_i + log2(l_i), _get_large_negative(l_i.dtype))
+
+      plgpu.commit_smem()
+      plgpu.copy_smem_to_gmem(
+          qo_smem,
+          out_ref.at[batch, pl.ds(q_seq_base, block_q), q_head],
+      )
+      if lse_smem is not None:
+        plgpu.copy_smem_to_gmem(
+            lse_smem,
+            lse_ref.at[batch, q_head, pl.ds(q_seq_base, block_q)],
+        )
+      plgpu.wait_smem_to_gmem(0)
+
+    @pl.when(wg_idx == 2)
+    def _memory_wg():
+      plgpu.set_max_registers(40, action="decrease")
+      kv_head = lax.div(q_head, jnp.array(q_heads_per_kv_head, q_head.dtype))
+      for i in range(max_concurrent_steps):
+        block_idx = data_next_ref[batch, 0, q_seq, i]
+        block_idx = jnp.maximum(block_idx, 0)
+        s = (batch, pl.ds(block_idx * block_kv, block_kv), kv_head)
+        plgpu.copy_gmem_to_smem(k_ref.at[s], k_smem.at[i], k_barriers.at[i])
+        plgpu.copy_gmem_to_smem(v_ref.at[s], v_smem.at[i], v_barriers.at[i])
+        for wg in range(compute_wgs):
+          block_idx = mask_next_ref[batch, 0, q_seq * 2 + wg, i]
+          # TODO(justinjfu): Only issue tma when block_idx >= 0
+          block_idx = jnp.maximum(block_idx, 0)
+          s = (batch, 0, block_idx, pl.ds(0, block_q), pl.ds(0, block_kv))
+          plgpu.copy_gmem_to_smem(
+              partial_mask_blocks_ref.at[s], mask_smem.at[i,
+                                                          wg], mask_barriers[wg].at[i]
+          )
+
+      @pl.loop(0, block_max_kv_steps - max_concurrent_steps)
+      def _kv_loop(kv_step):
+        tma_step = kv_step + max_concurrent_steps
+        tma_slot = lax.rem(kv_step, jnp.array(
+            max_concurrent_steps, kv_step.dtype))
+        block_idx = data_next_ref[batch, 0, q_seq, tma_step]
+        block_idx = jnp.maximum(block_idx, 0)
+        s = (batch, pl.ds(block_idx * block_kv, block_kv), kv_head)
+        plgpu.barrier_wait(k_consumed_barriers.at[tma_slot])
+        plgpu.copy_gmem_to_smem(
+            k_ref.at[s], k_smem.at[tma_slot], k_barriers.at[tma_slot])
+        plgpu.barrier_wait(v_consumed_barriers.at[tma_slot])
+        plgpu.copy_gmem_to_smem(
+            v_ref.at[s], v_smem.at[tma_slot], v_barriers.at[tma_slot])
+
+        for wg in range(compute_wgs):
+          block_idx = mask_next_ref[batch, 0, q_seq * 2 + wg, tma_step]
+          plgpu.barrier_wait(mask_consumed_barriers[wg].at[tma_slot])
+          # TODO(justinjfu): Only issue tma when block_idx >= 0
+          block_idx = jnp.maximum(block_idx, 0)
+          s = (batch, 0, block_idx, pl.ds(0, block_q), pl.ds(0, block_kv))
+          plgpu.copy_gmem_to_smem(
+              partial_mask_blocks_ref.at[s],
+              mask_smem.at[tma_slot, wg],
+              mask_barriers[wg].at[tma_slot],
+          )
+
+  def entry(
+      q_ref,
+      k_ref,
+      v_ref,
+      num_nozero_blocks_ref,
+      block_mask_ref,
+      mask_next_ref,
+      data_next_ref,
+      partial_mask_blocks_ref,
+      out_ref,
+      lse_ref,
+  ):
+    tiling = plgpu.TilingTransform((8, 64))
+    swizzle = plgpu.SwizzleTransform(128)
+    qo_scratch = plgpu.SMEM(
+        (compute_wgs, block_q, head_dim),
+        jnp.bfloat16,
+        transforms=(tiling, swizzle),
+    )
+    k_scratch = plgpu.SMEM(
+        (max_concurrent_steps, block_kv, head_dim),
+        jnp.bfloat16,
+        transforms=(tiling, swizzle),
+    )
+    v_scratch = plgpu.SMEM(
+        (max_concurrent_steps, block_kv, head_dim),
+        jnp.bfloat16,
+        transforms=(tiling, swizzle),
+    )
+    scratch = [qo_scratch, k_scratch, v_scratch, None, None]
+    if save_residuals:
+      scratch[3] = plgpu.SMEM((compute_wgs, block_q), jnp.float32)
+    scratch[4] = plgpu.SMEM(
+        (max_concurrent_steps, compute_wgs, block_q, block_kv),
+        jnp.int16,
+        transforms=(tiling, swizzle),
+    )
+
+    barriers = [
+        plgpu.Barrier(num_barriers=max_concurrent_steps),  # K barrier
+        plgpu.Barrier(num_barriers=max_concurrent_steps),  # V barrier
+        plgpu.Barrier(num_barriers=compute_wgs),  # Q barrier
+        [plgpu.Barrier(num_barriers=max_concurrent_steps)] *
+        compute_wgs  # Mask barriers
+    ]
+    consumed_barriers = [
+        plgpu.Barrier(num_arrivals=compute_wgs,
+                      num_barriers=max_concurrent_steps),  # K consumed
+        plgpu.Barrier(num_arrivals=compute_wgs,
+                      num_barriers=max_concurrent_steps),  # V consumed
+        # Mask consumed barriers
+        [plgpu.Barrier(
+            num_arrivals=1, num_barriers=max_concurrent_steps)] * compute_wgs
+    ]
+
+    pl.run_scoped(
+        lambda *args: kernel(
+            q_ref,
+            k_ref,
+            v_ref,
+            out_ref,
+            num_nozero_blocks_ref,
+            block_mask_ref,
+            mask_next_ref,
+            data_next_ref,
+            partial_mask_blocks_ref,
+            lse_ref,
+            args,
+        ),
+        scratch,
+        barriers,
+        consumed_barriers,
+        plgpu.Barrier(num_arrivals=compute_wgs),
+        collective_axes="wg",
+    )
+
+  num_q_tiles, rem = divmod(q_seq_len, block_q * 2)
+  if rem:
+    raise NotImplementedError(
+        f"{q_seq_len=} must be a multiple of {block_q * 2=}")
+
+  out_shape = [q, None]
+  if save_residuals:
+    # Note that we keep seq_len in the minor-most dimension so that we can do
+    # 1D TMAs on chunks of `block_q`.
+    out_shape[1] = jax.ShapeDtypeStruct(
+        (batch_size, num_q_heads, q_seq_len), jnp.float32)
+
+  out, lse = plgpu.kernel(
+      entry,
+      out_shape=out_shape,
+      grid=(num_q_heads, num_q_tiles, batch_size),
+      grid_names=("heads", "q_seq", "batch"),
+      num_threads=compute_wgs + 1,
+      thread_name="wg",
+      compiler_params=plgpu.CompilerParams(approx_math=True),
+      kernel_name="mgpu_splash_attn_fwd",
+  )(
+      q,
+      k,
+      v,
+      mask_info.num_nonzero_blocks,
+      mask_info.block_mask,
+      mask_info.mask_next.astype(jnp.int16),
+      mask_info.data_next.astype(jnp.int16),
+      mask_info.partial_mask_blocks.astype(jnp.int16),
+  )
+
+  if save_residuals:
+    assert lse is not None
+    return out, (lse,)
+
+  return out
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(5, 6, 7))
+@partial(jax.jit, static_argnames=["config", "scale", "save_residuals"])
+def attention(
+    q,
+    k,
+    v,
+    mask_info: attention_mask.MaskInfo,
+    mask_info_dkv: attention_mask.MaskInfo | None = None,
+    config: TuningConfig | None = None,
+    scale: float | None = None,
+    save_residuals: bool = False,
+):
+  del mask_info_dkv
+  if config is None:
+    config = TuningConfig(
+        block_q=64,
+        block_kv=128,
+        max_concurrent_steps=2,
+        block_q_dkv=64,
+        block_kv_dkv=64,
+        block_q_dq=64,
+        block_kv_dq=64,
+    )
+  return _attention_forward(q, k, v, mask_info, config, scale, save_residuals)
+
+
+def _attention_fwd(
+    q,
+    k,
+    v,
+    mask_info: attention_mask.MaskInfo,
+    mask_info_dkv: attention_mask.MaskInfo | None,
+    config: TuningConfig,
+    scale: float | None,
+    save_residuals: bool,
+):
+  del save_residuals
+  out, (lse,) = _attention_forward(q, k, v, mask_info, config, scale, True)
+  return out, (q, k, v, mask_info, mask_info_dkv, out, lse)
+
+
+def _attention_bwd(config: TuningConfig, scale: float | None, save_residuals: bool, res, do):
+  del save_residuals
+  q, k, v, mask_info, mask_info_dkv, out, lse = res
+  if mask_info_dkv is None:
+    raise ValueError("Need to specify mask_info_dkv for backwards pass.")
+
+  if not config.has_backward_blocks:
+    raise ValueError("Need to specify backward blocks.")
+
+  assert config.block_q_dq is not None
+  assert config.block_kv_dq is not None
+  assert config.block_q_dkv is not None
+  assert config.block_kv_dkv is not None
+  if scale is None:
+    scale = 1.0
+
+  batch_size, q_seq_len, num_q_heads, head_dim = q.shape
+  _, kv_seq_len, num_kv_heads, _ = k.shape
+  q_heads_per_kv_head = num_q_heads // num_kv_heads
+  dtype = q.dtype
+  compute_wgs = 2
+  if compute_wgs != 2:
+    raise NotImplementedError(
+        f"Only 2 compute wgs supported in backwards pass. Got {compute_wgs=}")
+
+  num_q_tiles, rem = divmod(q_seq_len, config.block_q_dq * compute_wgs)
+  if rem:
+    raise NotImplementedError(
+        f"{q_seq_len=} must be a multiple of {config.block_q_dq=} * {compute_wgs=}")
+
+  num_kv_tiles, rem = divmod(kv_seq_len, config.block_kv_dkv * compute_wgs)
+  if rem:
+    raise NotImplementedError(
+        f"{kv_seq_len=} must be a multiple of {config.block_kv_dkv=} * {compute_wgs=}")
+
+  num_q_tiles_in_dkv, rem = divmod(q_seq_len, config.block_q_dkv)
+  if rem:
+    raise NotImplementedError(
+        f"{q_seq_len=} must be a multiple of {config.block_q_dkv=}")
+
+  num_kv_tiles_in_dq, rem = divmod(kv_seq_len, config.block_kv_dq)
+  if rem:
+    raise NotImplementedError(
+        f"{kv_seq_len=} must be a multiple of {config.block_kv_dq=}")
+
+  tiling = plgpu.TilingTransform((8, 64))
+  swizzle = plgpu.SwizzleTransform(128)
+
+  delta = jnp.einsum(
+      "bqhd,bqhd->bhq", out.astype(jnp.float32), do.astype(jnp.float32))
+  del out  # Not needed anymore.
+  dq_max_concurrent_steps = min([config.max_concurrent_steps, num_q_tiles])
+  dkv_max_concurrent_steps = min([config.max_concurrent_steps, num_kv_tiles])
+  if dq_max_concurrent_steps < 2:
+    raise ValueError("Need at least 2 concurrent steps for dq kernel.")
+  if dkv_max_concurrent_steps < 2:
+    raise ValueError("Need at least 2 concurrent steps for dkv kernel.")
+  if mask_info.q_block_size != config.block_q_dq:
+    raise ValueError(
+        f"{mask_info.q_block_size=} must match {config.block_q_dq=}")
+  if mask_info.kv_block_size != config.block_kv_dq:
+    raise ValueError(
+        f"{mask_info.kv_block_size=} must match {config.block_kv_dq=}")
+  if mask_info_dkv.q_block_size != config.block_q_dkv:
+    raise ValueError(
+        f"{mask_info_dkv.q_block_size=} must match {config.block_q_dkv=}")
+  if mask_info_dkv.kv_block_size != config.block_kv_dkv:
+    raise ValueError(
+        f"{mask_info_dkv.kv_block_size=} must match {config.block_kv_dkv=}")
+
+  def kernel_dq(
+      q_ref,
+      k_ref,
+      v_ref,
+      num_nonzero_blocks_ref,
+      block_mask_ref,
+      mask_next_ref,
+      data_next_ref,
+      partial_mask_blocks_ref,
+      do_ref,
+      lse_ref,
+      delta_ref,
+      dq_ref,
+      smem_buffers,
+      buffer_barriers,
+      block_q,
+      block_kv,
+  ):
+    batch = lax.axis_index("batch")
+    q_head = lax.axis_index("heads")
+    wg_idx = lax.axis_index("wg")
+    q_seq = lax.axis_index("q_seq")
+    kv_head = lax.div(q_head, jnp.array(q_heads_per_kv_head, q_head.dtype))
+    q_smem2, do_smem2, lse_smem2, delta_smem2 = smem_buffers
+    q_barriers, do_barriers, lse_barriers, delta_barriers = buffer_barriers
+
+    num_nonzero_blocks = num_nonzero_blocks_ref[batch, 0, q_seq]
+    block_max_kv_steps = jnp.maximum(
+        num_nonzero_blocks, dq_max_concurrent_steps)
+
+    def _compute_thread(pipeline_callback):
+      q_smem, do_smem, lse_smem, delta_smem = (
+          q_smem2.at[wg_idx],
+          do_smem2.at[wg_idx],
+          lse_smem2.at[wg_idx],
+          delta_smem2.at[wg_idx],
+      )
+      q_seq_base = q_seq * (compute_wgs * block_q) + wg_idx * block_q
+      q_slice = (batch, pl.ds(q_seq_base, block_q), q_head)
+      plgpu.copy_gmem_to_smem(q_ref.at[q_slice], q_smem, q_barriers.at[wg_idx])
+      plgpu.copy_gmem_to_smem(
+          do_ref.at[q_slice], do_smem, do_barriers.at[wg_idx])
+      plgpu.copy_gmem_to_smem(
+          delta_ref.at[batch, q_head, pl.ds(q_seq_base, block_q)],
+          delta_smem,
+          delta_barriers.at[wg_idx],
+      )
+      plgpu.copy_gmem_to_smem(
+          lse_ref.at[batch, q_head, pl.ds(q_seq_base, block_q)],
+          lse_smem,
+          lse_barriers.at[wg_idx],
+      )
+      for buffer in buffer_barriers:
+        plgpu.barrier_wait(buffer.at[wg_idx])
+
+      delta = plgpu.load(delta_smem, (), layout=plgpu.Layout.WGMMA_ROW)
+      lse = plgpu.load(lse_smem, (), layout=plgpu.Layout.WGMMA_ROW)
+      num_nonzeros = plgpu.layout_cast(
+          jnp.full((block_q,), 0, dtype=jnp.int32),
+          plgpu.Layout.WGMMA_ROW,
+      )
+      dq_acc = plgpu.layout_cast(
+          jnp.full((block_q, head_dim), 0, dtype=jnp.float32),
+          plgpu.Layout.WGMMA,
+      )
+      dq, num_nonzeros, _, _ = pipeline_callback(
+          (dq_acc, num_nonzeros, lse, delta))
+      dq = jnp.where(lax.broadcast_in_dim(
+          num_nonzeros > 0, dq.shape, [0]), dq, 0)
+      q_smem[...] = dq.astype(dtype)
+      plgpu.commit_smem()
+      plgpu.copy_smem_to_gmem(q_smem, dq_ref.at[q_slice])
+      plgpu.wait_smem_to_gmem(0)
+
+    def kv_pipeline(
+        indices, k_smem, v_smem, masks_smem, k_consumed_barrier, v_consumed_barrier, masks_consumed, carry
+    ):
+      (kv_step,) = indices
+      q_smem, do_smem = q_smem2.at[wg_idx], do_smem2.at[wg_idx]
+      (dq_acc, num_nonzeros, lse, delta) = carry
+
+      def compute_qk(acc_ref):
+        plgpu.wgmma(acc_ref, q_smem, plgpu.transpose_ref(k_smem, (1, 0)))
+        return acc_ref[...]
+
+      qk = pl.run_scoped(compute_qk, plgpu.ACC(
+          (block_q, block_kv), jnp.float32))
+      qk = qk * scale
+
+      qk, num_nonzeros = lax.cond(
+          wg_idx == 0,
+          lambda qk, num_nonzeros: maybe_apply_mask(  # first compute wg
+              qk, num_nonzeros, block_mask_ref[batch, 0,
+                                               q_seq * compute_wgs, kv_step], masks_smem[0]
+          ),
+          lambda qk, num_nonzeros: maybe_apply_mask(  # second compute wg
+              qk, num_nonzeros, block_mask_ref[batch, 0,
+                                               q_seq * compute_wgs + 1, kv_step], masks_smem[1]
+          ),
+          qk,
+          num_nonzeros,
+      )
+      for wg in range(compute_wgs):
+        plgpu.barrier_arrive(masks_consumed[wg])
+      p = jnp.exp2(qk * math.log2(math.e) -
+                   lax.broadcast_in_dim(lse, (block_q, block_kv), [0]))
+
+      # dP
+      def compute_dp(acc_ref):
+        plgpu.wgmma(acc_ref, do_smem, plgpu.transpose_ref(v_smem, (1, 0)))
+        return acc_ref[...]
+
+      dp = pl.run_scoped(compute_dp, plgpu.ACC(
+          (block_q, block_kv), jnp.float32))
+      plgpu.barrier_arrive(v_consumed_barrier)
+
+      # dS
+      ds = p * (dp - lax.broadcast_in_dim(delta, (block_q, block_kv), [0]))
+      ds *= scale
+
+      # dQ
+      def compute_dq(acc_ref):
+        plgpu.wgmma(acc_ref, ds.astype(k_ref.dtype), k_smem)
+
+      dq_acc = pl.run_state(compute_dq)(plgpu.ACC.init(dq_acc))
+      plgpu.barrier_arrive(k_consumed_barrier)
+      return (dq_acc, num_nonzeros, lse, delta)
+
+    k_spec = plgpu.BlockSpec(
+        block_shape=(block_kv, head_dim),
+        index_map=lambda i: (jnp.maximum(
+            data_next_ref[batch, 0, q_seq, i], 0), 0),
+        transforms=[tiling, swizzle],
+    )
+    v_spec = plgpu.BlockSpec(
+        block_shape=(block_kv, head_dim),
+        index_map=lambda i: (jnp.maximum(
+            data_next_ref[batch, 0, q_seq, i], 0), 0),
+        transforms=[tiling, swizzle],
+    )
+    mask_spec = [
+        plgpu.BlockSpec(
+            block_shape=(pl.Squeezed(), block_q, block_kv),
+            index_map=lambda i: (jnp.maximum(
+                mask_next_ref[batch, 0, q_seq * compute_wgs + 0, i], 0), 0, 0),
+            transforms=[tiling, swizzle],
+        ),
+        plgpu.BlockSpec(
+            block_shape=(pl.Squeezed(), block_q, block_kv),
+            index_map=lambda i: (jnp.maximum(
+                mask_next_ref[batch, 0, q_seq * compute_wgs + 1, i], 0), 0, 0),
+            transforms=[tiling, swizzle],
+        ),
+    ]
+    pipeline = plgpu.emit_pipeline_warp_specialized(
+        kv_pipeline,
+        grid=(block_max_kv_steps,),
+        max_concurrent_steps=dq_max_concurrent_steps,
+        num_compute_wgs=compute_wgs,
+        memory_registers=40,
+        wg_axis="wg",
+        manual_consumed_barriers=True,
+        compute_context=_compute_thread,
+        in_specs=[k_spec, v_spec, mask_spec],
+    )
+    k_ref = k_ref.at[batch, :, kv_head, :]
+    v_ref = v_ref.at[batch, :, kv_head, :]
+    partial_mask_blocks_ref = partial_mask_blocks_ref.at[batch, 0, :, :, :]
+    pipeline(k_ref, v_ref, [partial_mask_blocks_ref] * compute_wgs)
+
+  def kernel_dkv(
+      q_ref,
+      k_ref,
+      v_ref,
+      num_nonzero_blocks_ref,
+      block_mask_ref,
+      mask_next_ref,
+      data_next_ref,
+      partial_mask_blocks_ref,
+      do_ref,
+      lse_ref,
+      delta_ref,
+      dk_ref,
+      dv_ref,
+      smem_buffers,
+      buffer_barriers,
+      block_q: int,
+      block_kv: int,
+  ):
+    batch = lax.axis_index("batch")
+    q_head = lax.axis_index("heads")
+    wg_idx = lax.axis_index("wg")
+    kv_seq = lax.axis_index("kv_seq")
+    (k_smem2, v_smem2) = smem_buffers
+    (k_barriers, v_barriers) = buffer_barriers
+
+    block_max_q_steps = num_nonzero_blocks_ref[batch, 0, kv_seq]
+    block_max_q_steps = jnp.maximum(
+        block_max_q_steps, dkv_max_concurrent_steps)
+
+    def _compute_thread(pipeline_callback):
+      k_smem, v_smem = k_smem2.at[wg_idx], v_smem2.at[wg_idx]
+      kv_seq_base = kv_seq * (compute_wgs * block_kv) + wg_idx * block_kv
+      kv_head = lax.div(q_head, jnp.array(q_heads_per_kv_head, q_head.dtype))
+      plgpu.copy_gmem_to_smem(
+          k_ref.at[(batch, pl.ds(kv_seq_base, block_kv), kv_head)
+                   ], k_smem, k_barriers.at[wg_idx]
+      )
+      plgpu.copy_gmem_to_smem(
+          v_ref.at[(batch, pl.ds(kv_seq_base, block_kv), kv_head)
+                   ], v_smem, v_barriers.at[wg_idx]
+      )
+      plgpu.barrier_wait(k_barriers.at[wg_idx])
+      plgpu.barrier_wait(v_barriers.at[wg_idx])
+      dk_acc = plgpu.layout_cast(
+          jnp.full((block_kv, head_dim), 0, dtype=jnp.float32),
+          plgpu.Layout.WGMMA,
+      )
+      dv_acc = plgpu.layout_cast(
+          jnp.full((block_kv, head_dim), 0, dtype=jnp.float32),
+          plgpu.Layout.WGMMA,
+      )
+
+      num_nonzeros = plgpu.layout_cast(
+          jnp.full((block_kv,), 0, dtype=jnp.int32),
+          plgpu.Layout.WGMMA_ROW,
+      )
+      (dk, dv, num_nonzeros) = pipeline_callback((dv_acc, dk_acc, num_nonzeros))
+      dk = jnp.where(lax.broadcast_in_dim(
+          num_nonzeros > 0, dk.shape, [0]), dk, 0)
+      dv = jnp.where(lax.broadcast_in_dim(
+          num_nonzeros > 0, dv.shape, [0]), dv, 0)
+      k_smem[...] = dk.astype(dtype)
+      v_smem[...] = dv.astype(dtype)
+
+      plgpu.commit_smem()
+      plgpu.copy_smem_to_gmem(
+          k_smem, dk_ref.at[(batch, pl.ds(
+              kv_seq_base, block_kv), q_head)], commit_group=False
+      )
+      plgpu.copy_smem_to_gmem(
+          v_smem, dv_ref.at[(batch, pl.ds(
+              kv_seq_base, block_kv), q_head)], commit_group=False
+      )
+      plgpu.commit_smem_to_gmem_group()
+      plgpu.wait_smem_to_gmem(0)
+
+    def q_pipeline(
+        indices,
+        q_smem,
+        masks_smem,
+        do_smem,
+        lse_smem,
+        delta_smem,
+        q_consumed_barrier,
+        masks_consumed,
+        do_consumed_barrier,
+        lse_consumed_barrier,
+        delta_consumed_barrier,
+        carry,
+    ):
+      (q_step,) = indices
+      k_smem, v_smem = k_smem2.at[wg_idx], v_smem2.at[wg_idx]
+      dk_acc, dv_acc, num_nonzeros = carry
+
+      def _compute_qkT(acc_ref):
+        plgpu.wgmma(acc_ref, k_smem, plgpu.transpose_ref(q_smem, (1, 0)))
+        return acc_ref[...]
+
+      qkT = pl.run_scoped(_compute_qkT, plgpu.ACC(
+          (block_kv, block_q), jnp.float32))
+      qkT, num_nonzeros = lax.cond(
+          wg_idx == 0,
+          lambda qk, num_nonzeros: maybe_apply_mask(  # first compute wg
+              qk,
+              num_nonzeros,
+              block_mask_ref[batch, 0, num_q_tiles_in_dkv -
+                             1 - q_step, kv_seq * compute_wgs],
+              masks_smem[0],
+          ),
+          lambda qk, num_nonzeros: maybe_apply_mask(  # second compute wg
+              qk,
+              num_nonzeros,
+              block_mask_ref[batch, 0, num_q_tiles_in_dkv -
+                             1 - q_step, kv_seq * compute_wgs + 1],
+              masks_smem[1],
+          ),
+          qkT,
+          num_nonzeros,
+      )
+      for wg in range(compute_wgs):
+        plgpu.barrier_arrive(masks_consumed[wg])
+
+      lse = plgpu.load(lse_smem, (), layout=plgpu.Layout.WGMMA_COL)
+      plgpu.barrier_arrive(lse_consumed_barrier)
+      pT = jnp.exp2(qkT * math.log2(math.e) * scale -
+                    lax.broadcast_in_dim(lse, (block_kv, block_q), [1]))
+
+      def _compute(refs):
+        # Combining two WGMMA calls in one block to avoid the unnecessary
+        # synchronization from two `wgmma.wait_group` calls.
+        dv_acc_ref, dpT_acc_ref = refs
+        plgpu.wgmma(dv_acc_ref, pT.astype(dtype), do_smem)  # dV
+        plgpu.wgmma(dpT_acc_ref, v_smem,
+                    plgpu.transpose_ref(do_smem, (1, 0)))  # dpT
+
+      zeros = plgpu.layout_cast(
+          jnp.full((block_kv, block_q), 0, dtype=jnp.float32),
+          plgpu.Layout.WGMMA,
+      )
+      dv_acc, dpT = pl.run_state(_compute)(
+          (plgpu.ACC.init(dv_acc), plgpu.ACC.init(zeros)))
+      plgpu.barrier_arrive(do_consumed_barrier)
+
+      delta = plgpu.load(delta_smem, (), layout=plgpu.Layout.WGMMA_COL)
+      plgpu.barrier_arrive(delta_consumed_barrier)
+
+      dqkT = pT * (
+          dpT - lax.broadcast_in_dim(delta, (block_kv, block_q), [1])
+      )  # pytype: disable=wrong-arg-types  # jax-operator-types
+      dqkT *= scale
+
+      def compute_dk(acc_ref):
+        plgpu.wgmma(acc_ref, dqkT.astype(dtype), q_smem)
+
+      dk_acc = pl.run_state(compute_dk)(plgpu.ACC.init(dk_acc))
+      plgpu.barrier_arrive(q_consumed_barrier)
+
+      return (dk_acc, dv_acc, num_nonzeros)
+
+    q_spec = plgpu.BlockSpec(
+        block_shape=(block_kv, head_dim),
+        index_map=lambda i: (jnp.maximum(
+            data_next_ref[batch, 0, num_q_tiles_in_dkv - 1 - i, kv_seq], 0), 0),
+        transforms=[tiling, swizzle],
+    )
+    do_spec = plgpu.BlockSpec(
+        block_shape=(block_kv, head_dim),
+        index_map=lambda i: (jnp.maximum(
+            data_next_ref[batch, 0, num_q_tiles_in_dkv - 1 - i, kv_seq], 0), 0),
+        transforms=[tiling, swizzle],
+    )
+    lse_spec = plgpu.BlockSpec(
+        block_shape=(block_kv,),
+        index_map=lambda i: (jnp.maximum(
+            data_next_ref[batch, 0, num_q_tiles_in_dkv - 1 - i, kv_seq], 0),),
+    )
+    delta_spec = plgpu.BlockSpec(
+        block_shape=(block_kv,),
+        index_map=lambda i: (jnp.maximum(
+            data_next_ref[batch, 0, num_q_tiles_in_dkv - 1 - i, kv_seq], 0),),
+    )
+    mask_spec = [
+        plgpu.BlockSpec(
+            block_shape=(pl.Squeezed(), block_kv, block_q),
+            index_map=lambda i: (
+                jnp.maximum(
+                    mask_next_ref[batch, 0, num_q_tiles_in_dkv - 1 - i, kv_seq * compute_wgs + 0], 0),
+                0,
+                0,
+            ),
+            transforms=[tiling, swizzle],
+        ),
+        plgpu.BlockSpec(
+            block_shape=(pl.Squeezed(), block_kv, block_q),
+            index_map=lambda i: (
+                jnp.maximum(
+                    mask_next_ref[batch, 0, num_q_tiles_in_dkv - 1 - i, kv_seq * compute_wgs + 1], 0),
+                0,
+                0,
+            ),
+            transforms=[tiling, swizzle],
+        ),
+    ]
+    pipeline = plgpu.emit_pipeline_warp_specialized(
+        q_pipeline,
+        grid=(block_max_q_steps,),
+        max_concurrent_steps=dkv_max_concurrent_steps,
+        num_compute_wgs=compute_wgs,
+        memory_registers=40,
+        wg_axis="wg",
+        manual_consumed_barriers=True,
+        compute_context=_compute_thread,
+        in_specs=[
+            q_spec,
+            mask_spec,
+            do_spec,
+            lse_spec,
+            delta_spec,
+        ],
+    )
+    q_ref = q_ref.at[batch, :, q_head, :]
+    do_ref = do_ref.at[batch, :, q_head, :]
+    lse_ref = lse_ref.at[batch, q_head, :]
+    delta_ref = delta_ref.at[batch, q_head, :]
+    partial_mask_blocks_ref = partial_mask_blocks_ref.at[batch, 0, :, :, :]
+    pipeline(q_ref, [partial_mask_blocks_ref] *
+             compute_wgs, do_ref, lse_ref, delta_ref)
+
+  q_scratch = plgpu.SMEM(
+      (compute_wgs, config.block_q_dq, head_dim),
+      jnp.bfloat16,
+      transforms=(tiling, swizzle),
+  )
+  do_scratch = q_scratch
+  lse_scratch = plgpu.SMEM((compute_wgs, config.block_q_dq), jnp.float32)
+  delta_scratch = plgpu.SMEM((compute_wgs, config.block_q_dq), jnp.float32)
+  dq = plgpu.kernel(
+      partial(kernel_dq, block_q=config.block_q_dq,
+              block_kv=config.block_kv_dq),
+      out_shape=q,
+      scratch_shapes=[
+          (q_scratch, do_scratch, lse_scratch, delta_scratch),  # type: ignore
+          (plgpu.Barrier(num_barriers=compute_wgs),) * 4,  # type: ignore
+      ],
+      compiler_params=plgpu.CompilerParams(approx_math=True),
+      grid=(num_q_heads, num_q_tiles, batch_size),
+      grid_names=("heads", "q_seq", "batch"),
+      num_threads=compute_wgs + 1,
+      thread_name="wg",
+      kernel_name="mgpu_splash_attn_bwd_dq",
+  )(
+      q,
+      k,
+      v,
+      mask_info.num_nonzero_blocks,
+      mask_info.block_mask,
+      mask_info.mask_next.astype(jnp.int16),
+      mask_info.data_next.astype(jnp.int16),
+      mask_info.partial_mask_blocks.astype(jnp.int16),
+      do,
+      lse,
+      delta,
+  )
+
+  k_scratch = plgpu.SMEM(
+      (compute_wgs, config.block_kv_dkv, head_dim),
+      jnp.bfloat16,
+      transforms=(tiling, swizzle),
+  )
+  v_scratch = k_scratch
+  out_shape_kv = jax.ShapeDtypeStruct(
+      (batch_size, kv_seq_len, num_q_heads, head_dim), dtype=jnp.bfloat16)
+  dk, dv = plgpu.kernel(
+      partial(kernel_dkv, block_q=config.block_q_dkv,
+              block_kv=config.block_kv_dkv),
+      out_shape=[out_shape_kv, out_shape_kv],
+      scratch_shapes=[
+          (k_scratch, v_scratch),  # type: ignore
+          (plgpu.Barrier(num_barriers=compute_wgs),) * 2,  # type: ignore
+      ],
+      compiler_params=plgpu.CompilerParams(approx_math=True),
+      grid=(num_q_heads, num_kv_tiles, batch_size),
+      grid_names=("heads", "kv_seq", "batch"),
+      num_threads=compute_wgs + 1,
+      thread_name="wg",
+      kernel_name="mgpu_splash_attn_bwd_dkv",
+  )(
+      q,
+      k,
+      v,
+      mask_info_dkv.num_nonzero_blocks,
+      mask_info_dkv.block_mask,
+      mask_info_dkv.mask_next.astype(jnp.int16),
+      mask_info_dkv.data_next.astype(jnp.int16),
+      mask_info_dkv.partial_mask_blocks.astype(jnp.int16),
+      do,
+      lse,
+      delta,
+  )
+
+  if q_heads_per_kv_head > 1:
+    sum_shape = (*k.shape[:-1], q_heads_per_kv_head, head_dim)
+    dk = dk.reshape(sum_shape).astype(
+        jnp.float32).sum(axis=-2).astype(dk.dtype)
+    dv = dv.reshape(sum_shape).astype(
+        jnp.float32).sum(axis=-2).astype(dv.dtype)
+
+  return dq, dk, dv, None, None
+
+
+attention.defvjp(_attention_fwd, _attention_bwd)

--- a/tests/pallas/mgpu_attention_test.py
+++ b/tests/pallas/mgpu_attention_test.py
@@ -14,7 +14,9 @@
 # ==============================================================================
 """Test different parameterizations of FlashAttention."""
 
+import math
 import os
+from typing import Literal
 
 import numpy as np
 from absl.testing import absltest, parameterized
@@ -30,13 +32,21 @@ try:
   import jax.experimental.mosaic.gpu  # noqa: F401
 except ImportError:
   attention_mgpu = None
+  attention_mask = None
+  hopper_splash_attention = None
 else:
   from jax.experimental.pallas.ops.gpu import attention_mgpu
-
+  from jax.experimental.pallas.ops.gpu.splash_attention import attention_mask
+  from jax.experimental.pallas.ops.gpu.splash_attention import hopper_splash_attention
 
 config.parse_flags_with_absl()
 os.environ["XLA_FLAGS"] = (
     os.environ.get("XLA_FLAGS", "") + " --xla_gpu_autotune_level=0")
+
+MaskType = Literal[
+    "full", "zeros", "causal", "random", "multidoc", "sliding_window", "zeroed_partial_blocks", "realistic"
+]
+
 
 
 @jtu.with_config(jax_traceback_filtering="off")
@@ -176,6 +186,441 @@ class FlashAttentionTestCase(jtu.JaxTestCase):
     except ValueError as e:
       if "exceeds available shared memory" in e.args[0]:
         self.skipTest("Not enough SMEM for this configuration.")
+
+
+@jtu.with_config(jax_traceback_filtering="off")
+class AttentionMaskTest(jtu.JaxTestCase):
+
+  def setUp(self):
+    super().setUp()
+    if attention_mgpu is None:
+      self.skipTest("Mosaic GPU not available.")
+
+  def test_fwd_mask_2_tiling(self):
+    mask = jnp.array(
+        [
+            [1, 1, 1, 0, 0, 0, 0, 0, 1, 1],
+            [1, 1, 1, 1, 0, 0, 0, 0, 1, 1],
+            [1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+            [1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+            [1, 1, 1, 1, 0, 0, 0, 0, 1, 0],
+            [1, 1, 1, 0, 0, 0, 0, 0, 1, 1],
+            [0, 0, 0, 0, 1, 1, 0, 0, 0, 0],
+            [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
+        ]
+    )
+    mask = mask.reshape((1, 1, mask.shape[0], mask.shape[1])).astype(bool)
+    mask_info = attention_mask.process_dynamic_mask(
+        mask=mask,
+        block_shape=(2, 2),
+        is_dkv=False,
+        data_tiling=2,
+    )
+    np.testing.assert_array_equal(
+        mask_info.block_mask[0, 0],
+        jnp.array(
+            [
+                [2, 1, 2, 0, 0],
+                [2, 2, 0, 0, 0],
+                [2, 1, 0, 1, 0],
+                [0, 0, 1, 0, 0],
+            ]
+        ),
+    )
+    np.testing.assert_array_equal(
+        mask_info.data_next[0, 0],
+        jnp.array(
+            [
+                [0, 1, 4, -1, -1],
+                [0, 1, 2, 4, -1],
+            ]
+        ),
+    )
+    np.testing.assert_array_equal(
+        mask_info.mask_next[0, 0],
+        jnp.array(
+            [
+                [-1, 1, -1, -1, -1],
+                [-1, -1, -1, -1, -1],
+                [-1, 11, -1, 14, -1],
+                [-1, -1, 17, -1, -1],
+            ]
+        ),
+    )
+
+  def test_dkv_mask_2_tiling(self):
+    mask = jnp.array(
+        [
+            [1, 1, 1, 1, 1, 1, 0, 0],
+            [1, 1, 1, 1, 1, 1, 0, 0],
+            [1, 1, 1, 1, 1, 1, 0, 0],
+            [0, 1, 1, 1, 1, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 1, 1],
+            [0, 0, 0, 0, 0, 0, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [1, 1, 0, 0, 1, 1, 0, 0],
+            [1, 1, 0, 0, 0, 1, 0, 0],
+        ]
+    )
+    mask = mask.reshape((1, 1, mask.shape[0], mask.shape[1])).astype(bool)
+    mask_info = attention_mask.process_dynamic_mask(
+        mask=mask,
+        block_shape=(2, 2),
+        is_dkv=True,
+        data_tiling=2,
+    )
+    np.testing.assert_array_equal(
+        mask_info.block_mask[0, 0],
+        jnp.array(
+            [
+                [0, 0, 0, 0],
+                [0, 0, 2, 0],
+                [2, 2, 1, 0],
+                [1, 2, 0, 1],
+                [2, 0, 1, 0],
+            ]
+        ),
+    )
+    np.testing.assert_array_equal(
+        mask_info.data_next[0, 0],
+        jnp.array(
+            [
+                [-1, -1],
+                [-1, 0],
+                [0, 1],
+                [1, 2],
+                [4, 4],
+            ]
+        ),
+    )
+    np.testing.assert_array_equal(
+        mask_info.mask_next[0, 0],
+        jnp.array(
+            [
+                [-1, -1, -1, -1],
+                [-1, -1, -1, -1],
+                [-1, -1, 6, -1],
+                [4, -1, -1, 11],
+                [-1, -1, 18, -1],
+            ]
+        ),
+    )
+
+  def test_compress(self):
+    x = jnp.array(
+        [
+            [0, 1, 2, -1, -1, 10, 6, 7, -1, -1, -1, 9, -1],
+            [-1, -1, -1, -1, 0, 1, 2, -1, -1, -1, -1, -1, -1],
+        ]
+    )
+    expected = jnp.array(
+        [
+            [0, 1, 2, 10, 6, 7, 9, -1, -1, -1, -1, -1, -1],
+            [0, 1, 2, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1],
+        ]
+    )
+    np.testing.assert_array_equal(
+        attention_mask.compress_array(x, placeholder=-1)[0], expected)
+
+  def test_tiled_max(self):
+    x = jnp.array([[0, 1, 2, -1, -1, -1], [-1, -1, 2, 3, 4, -1],
+                  [-1, 1, 2, 3, -1, -1], [-1, -1, 2, 3, 4, -1]])
+    expected = jnp.array([[0, 1, 2, 3, 4, -1], [-1, 1, 2, 3, 4, -1]])
+    np.testing.assert_array_equal(
+        attention_mask.tiled_max(x, tile_size=2, axis=-2), expected)
+
+
+@jtu.with_config(jax_traceback_filtering="off")
+class SplashAttentionTest(jtu.JaxTestCase):
+
+  def setUp(self):
+    super().setUp()
+    if attention_mgpu is None:
+      self.skipTest("Mosaic GPU not available.")
+    if (not jtu.test_device_matches(["cuda"]) or
+            not jtu.is_cuda_compute_capability_equal("9.0")):
+      self.skipTest("Only works on GPU with capability sm90a")
+
+    self.tuning_config = hopper_splash_attention.TuningConfig(
+        block_q=64,
+        block_kv=64,
+        max_concurrent_steps=2,
+        block_q_dkv=64,
+        block_kv_dkv=64,
+        block_q_dq=64,
+        block_kv_dq=64,
+    )
+
+  def _generate_mask(self, mask_type: MaskType, batch_size: int, seq_len: int) -> jax.Array:
+    def build_mask(
+        *,
+        position_ids: jax.Array,
+        segment_ids: jax.Array,
+        kv_token_mask: jax.Array,
+        kv_position_ids: jax.Array,
+        kv_segment_ids: jax.Array,
+        causal: bool,
+        sliding_window_length: int | None = None,
+    ) -> jax.Array:
+      mask = jnp.ones((1, 1, 1, 1), dtype=bool)
+      if causal:
+        position_ids_ = position_ids[:, None, :, None]
+        kv_position_ids_ = kv_position_ids[:, None, None, :]
+        causal_mask = position_ids_ >= kv_position_ids_
+        mask = jnp.logical_and(mask, causal_mask)
+
+      if sliding_window_length:
+        if not causal:
+          raise NotImplementedError("Sliding window mask must also be causal")
+        position_ids_ = position_ids[:, None, :, None]
+        kv_position_ids_ = kv_position_ids[:, None, None, :]
+        local_window_mask = jnp.abs(
+            position_ids_ - kv_position_ids_) < sliding_window_length
+        mask = jnp.logical_and(mask, local_window_mask)
+
+      segment_ids = segment_ids[:, None, :, None]
+      kv_segment_ids = kv_segment_ids[:, None, None, :]
+      document_mask = segment_ids == kv_segment_ids
+      mask = jnp.logical_and(mask, document_mask)
+
+      kv_token_mask = kv_token_mask[:, None, None, :]
+      mask = jnp.logical_and(mask, kv_token_mask)
+      return mask
+
+    if mask_type == "full":
+      mask = jnp.ones((batch_size, 1, seq_len, seq_len), dtype=jnp.bool_)
+    elif mask_type == "zeros":
+      mask = jnp.zeros((batch_size, 1, seq_len, seq_len), dtype=jnp.bool_)
+    elif mask_type == "random":
+      mask = jax.random.bernoulli(jax.random.key(
+          0), 128.0 / seq_len, shape=(batch_size, 1, seq_len, seq_len))
+    elif mask_type == "causal":
+      position_ids = jnp.arange(seq_len).reshape((1, seq_len))
+      kv_position_ids = jnp.arange(seq_len).reshape((1, seq_len))
+      segment_ids = jnp.zeros((1, seq_len), dtype=jnp.int32)
+      kv_token_mask = jnp.ones((1, seq_len), dtype=jnp.bool_)
+      mask = build_mask(
+          position_ids=position_ids,
+          segment_ids=segment_ids,
+          kv_token_mask=kv_token_mask,
+          kv_position_ids=kv_position_ids,
+          kv_segment_ids=segment_ids,
+          causal=True,
+      )
+      mask = jnp.tile(mask, (batch_size, 1, 1, 1))
+    elif mask_type == "multidoc":
+      masks = []
+      for batch_idx in range(batch_size):
+        position_ids = jnp.arange(seq_len).reshape((1, seq_len))
+        kv_position_ids = jnp.arange(seq_len).reshape((1, seq_len))
+        num_docs = 2 ** (batch_idx + 1)
+        segment_ids = np.repeat(jnp.arange(num_docs), seq_len // num_docs)
+        segment_ids = jnp.reshape(segment_ids, (1, seq_len))
+        kv_token_mask = jnp.ones((1, seq_len), dtype=jnp.bool_)
+        mask = build_mask(
+            position_ids=position_ids,
+            segment_ids=segment_ids,
+            kv_token_mask=kv_token_mask,
+            kv_position_ids=kv_position_ids,
+            kv_segment_ids=segment_ids,
+            causal=True,
+        )
+        mask = jnp.tile(mask, (batch_size, 1, 1, 1))
+        masks.append(mask)
+      mask = jnp.concatenate(masks, axis=0)
+    elif mask_type == "sliding_window":
+      # Create sliding window mask
+      masks = []
+      for batch_idx in range(batch_size):
+        position_ids = jnp.arange(seq_len).reshape((1, seq_len))
+        kv_position_ids = position_ids
+        segment_ids = jnp.zeros((1, seq_len), dtype=jnp.int32)
+        kv_token_mask = jnp.ones((1, seq_len), dtype=jnp.bool_)
+
+        mask = build_mask(
+            position_ids=position_ids,
+            segment_ids=segment_ids,
+            kv_token_mask=kv_token_mask,
+            kv_position_ids=kv_position_ids,
+            kv_segment_ids=segment_ids,
+            causal=True,
+        )
+        position_ids_ = position_ids[:, None, :, None]
+        kv_position_ids_ = kv_position_ids[:, None, None, :]
+        sliding_window_mask = jnp.abs(
+            position_ids_ - kv_position_ids_) < (2 ** (6 + batch_idx))
+        mask = jnp.logical_and(mask, sliding_window_mask)
+        masks.append(mask)
+      mask = jnp.concatenate(masks, axis=0)
+    elif mask_type == "zeroed_partial_blocks":
+      mask = jnp.ones((1, 1, seq_len, seq_len), dtype=jnp.bool_)
+      mask = mask.at[:, :, 0:96, 0:96].set(False)
+      mask = jnp.tile(mask, (batch_size, 1, 1, 1))
+    elif mask_type == "realistic":
+      # Generate a "realistic" mask with multiple documents of varying sizes that are also "masked" with padding tokens
+      # at the end of each document.
+      masks = []
+      temp = 10.0
+      for batch in range(batch_size):
+        num_docs = 2 * (batch + 2)
+        probs_key, sample_key, pad_key = jax.random.split(
+            jax.random.key(batch), 3)
+        position_ids = jnp.arange(seq_len).reshape((1, seq_len))
+        kv_position_ids = jnp.arange(seq_len).reshape((1, seq_len))
+        probs = jax.random.dirichlet(probs_key, jnp.ones((num_docs,)) * temp)
+        doc_sizes = jax.random.multinomial(
+            sample_key, seq_len, probs).astype(jnp.int32)
+        segment_ids = jnp.concatenate([jnp.array([i] * int(n)) for (i, n) in enumerate(doc_sizes)]).reshape(
+            (1, seq_len)
+        )
+
+        n_keep = [
+            int(jax.random.binomial(jax.random.fold_in(pad_key, i), doc_sizes[i], 0.8)) for i in range(num_docs)
+        ]
+        kv_token_mask = jnp.concatenate(
+            [
+                jnp.concatenate([jnp.ones((n_keep[i],)), jnp.zeros(
+                    (int(doc_sizes[i]) - n_keep[i],))])
+                for i in range(num_docs)
+            ]
+        )
+        kv_token_mask = kv_token_mask.reshape((1, seq_len)).astype(jnp.bool_)
+        mask = build_mask(
+            position_ids=position_ids,
+            segment_ids=segment_ids,
+            kv_token_mask=kv_token_mask,
+            kv_position_ids=kv_position_ids,
+            kv_segment_ids=segment_ids,
+            causal=True,
+        )
+        masks.append(mask)
+      mask = jnp.concatenate(masks, axis=0)
+    assert mask.shape == (batch_size, 1, seq_len, seq_len)
+    return mask
+
+  def _generate_qkv(self, shape, seed=0, q_heads_per_kv_head=1):
+    q_rng, k_rng, v_rng = jax.random.split(jax.random.key(seed), 3)
+    q_shape = shape
+    if q_heads_per_kv_head != 1:
+      q_shape = (shape[0], shape[1], shape[2] * q_heads_per_kv_head, shape[3])
+    q = jax.random.normal(q_rng, q_shape, dtype=jnp.float32)
+    k = jax.random.normal(k_rng, shape, dtype=jnp.float32)
+    v = jax.random.normal(v_rng, shape, dtype=jnp.float32)
+    # RMS norm
+    q = q / jnp.sqrt(jnp.sum(q * q, axis=-1, keepdims=True) + 1e-6)
+    k = k / jnp.sqrt(jnp.sum(k * k, axis=-1, keepdims=True) + 1e-6)
+    return q, k, v
+
+  @parameterized.product(
+      batch_size=(1, 2),
+      q_heads_per_kv_head=(1, 2),
+      mask_type=("realistic", "full", "causal", "random",
+                 "sliding_window", "zeroed_partial_blocks")
+  )
+  def test_mgpu_masked_fwd(self, batch_size: int, q_heads_per_kv_head: int, mask_type: MaskType):
+    if not jtu.is_cuda_compute_capability_equal("9.0"):
+      self.skipTest("Test only runs on H100 GPUs.")
+    seq_len = 2 * 1024
+    q, k, v = self._generate_qkv(
+        (batch_size, seq_len, 1, 128), q_heads_per_kv_head=q_heads_per_kv_head)
+    q = q.astype(jnp.bfloat16)
+    k = k.astype(jnp.bfloat16)
+    v = v.astype(jnp.bfloat16)
+    scale = 1.0 / np.sqrt(q.shape[-1])
+    mask = self._generate_mask(mask_type, batch_size, seq_len)
+    mask_info = attention_mask.process_dynamic_mask(
+        mask=mask,
+        block_shape=(self.tuning_config.block_q, self.tuning_config.block_kv),
+        is_dkv=False,
+        data_tiling=2,
+    )
+
+    ref_result, ref_lse = jax.nn.dot_product_attention(
+        q.astype(jnp.float32),
+        k.astype(jnp.float32),
+        v.astype(jnp.float32),
+        mask=mask,
+        scale=scale,
+        return_residual=True,
+    )
+    ref_lse = ref_lse.swapaxes(-1, -2)  # Swap from BTN -> BNT
+    # MGPU scales lse by log2(e) but JAX does not.
+    ref_lse *= math.log2(math.e)
+    mgpu_result, (lse,) = hopper_splash_attention.attention(
+        q, k, v, mask_info=mask_info, config=self.tuning_config, scale=scale, save_residuals=True
+    )
+    np.testing.assert_allclose(mgpu_result, ref_result, atol=1e-2)
+    np.testing.assert_allclose(lse, ref_lse, atol=5e-4)
+
+  @parameterized.product(
+      batch_size=(1, 2),
+      q_heads_per_kv_head=(1, 2),
+      mask_type=("realistic", "full", "causal", "random",
+                 "sliding_window", "zeroed_partial_blocks")
+  )
+  def test_mgpu_masked_bwd(self, batch_size: int, q_heads_per_kv_head: int, mask_type: MaskType):
+    if not jtu.is_cuda_compute_capability_equal("9.0"):
+      self.skipTest("Test only runs on H100 GPUs.")
+    seq_len = 2 * 1024
+    q, k, v = self._generate_qkv(
+        (batch_size, seq_len, 1, 128), q_heads_per_kv_head=q_heads_per_kv_head)
+    q = q.astype(jnp.bfloat16)
+    k = k.astype(jnp.bfloat16)
+    v = v.astype(jnp.bfloat16)
+    scale = 1.0 / np.sqrt(q.shape[-1])
+    mask = self._generate_mask(mask_type, batch_size, seq_len)
+    mask_info = attention_mask.process_dynamic_mask(
+        mask=mask,
+        block_shape=(self.tuning_config.block_q, self.tuning_config.block_kv),
+        is_dkv=False,
+        data_tiling=2,
+    )
+    mask_info_dkv = attention_mask.process_dynamic_mask(
+        mask=mask,
+        block_shape=(self.tuning_config.block_q, self.tuning_config.block_kv),
+        is_dkv=True,
+        data_tiling=2,
+    )
+
+    def run_mgpu(q, k, v):
+      result = hopper_splash_attention.attention(
+          q,
+          k,
+          v,
+          mask_info=mask_info,
+          mask_info_dkv=mask_info_dkv,
+          config=self.tuning_config,
+          scale=scale,
+          save_residuals=False,
+      )
+      return jnp.sum(result)
+
+    @jax.jit
+    def run_reference(q, k, v):
+      result = jax.nn.dot_product_attention(
+          q.astype(jnp.float32),
+          k.astype(jnp.float32),
+          v.astype(jnp.float32),
+          mask=mask,
+          scale=scale,
+          return_residual=False,
+      )
+      return jnp.sum(result)
+
+    result_grad = jax.grad(run_mgpu, argnums=[0, 1, 2])(q, k, v)
+    ref_grad = jax.grad(run_reference, argnums=[0, 1, 2])(q, k, v)
+
+    np.testing.assert_allclose(result_grad[0], ref_grad[0], atol=2e-3)  # dq
+    np.testing.assert_allclose(result_grad[1], ref_grad[1], atol=2e-3)  # dk
+    if mask_type == "zeros":
+      # For zeros mask, reference outputs 1 but the kernel outputs 0, so
+      # we manually check against zero.
+      np.testing.assert_array_equal(result_grad[2], 0)
+    else:
+      np.testing.assert_allclose(
+          result_grad[2], ref_grad[2], atol=5e-2, rtol=5e-2)  # dv
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Adds a splash attention implementation for Mosaic GPU.

The kernel itself is based on the existing FA3 kernel: [attention_mgpu.py](https://github.com/jax-ml/jax/blob/main/jax/experimental/pallas/ops/gpu/attention_mgpu.py)
The masking logic is based on TPU splash attention, but modified heavily to accommodate the GPU kernel: [splash_attention_mask_info.py](https://github.com/jax-ml/jax/blob/main/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py)

Some sample profiling results using a causal mask. The kernel time include both the time to generate the mask and run the kernel (as measure by the cupti profiler), and in practice the mask time could be amortized over multiple layers. Note that the CUDNN implementation `jax.nn.dot_product_attention` performs very poorly with an explicitly passed-in mask. The underlying kernel supports generating a mask from IDs inside the kernel without materializing the whole mask, but this isn't exposed in JAX.

Forwards pass:
```
==== batch_size=1      kv_seq_len=4096   q_seq_len=4096  num_q_heads=16   head_dim=128    masked=True ====
CUDNN REFERENCE:  435.6  us = 15.8% TC utilization
block_q=64  block_kv=128 max_concurrent_steps=2   :  169.4  us = 40.6% TC utilization
block_q=64  block_kv=64  max_concurrent_steps=2   :  199.7  us = 34.4% TC utilization
block_q=64  block_kv=64  max_concurrent_steps=4   :  202.0  us = 34.0% TC utilization
Best: 169.4  us = 40.6% TC utilization
==== batch_size=1      kv_seq_len=8192   q_seq_len=8192  num_q_heads=16   head_dim=128    masked=True ====
CUDNN REFERENCE:  1723.2 us = 16.0% TC utilization
block_q=64  block_kv=128 max_concurrent_steps=2   :  519.9  us = 52.9% TC utilization
block_q=64  block_kv=64  max_concurrent_steps=2   :  653.0  us = 42.1% TC utilization
block_q=64  block_kv=64  max_concurrent_steps=4   :  658.4  us = 41.8% TC utilization
Best: 519.9  us = 52.9% TC utilization
```

Backwards pass:
```
==== batch_size=1      kv_seq_len=4096   q_seq_len=4096  num_q_heads=16   head_dim=128    masked=True ====
CUDNN REFERENCE:  1548.4 us = 11.1% TC utilization
block_q_dkv=64  block_q_dq=64  block_kv_dq=64  block_kv_dkv=64  max_concurrent_steps=2   :  567.3  us = 30.3% TC utilization
Best: 567.3  us = 30.3% TC utilization
==== batch_size=1      kv_seq_len=8192   q_seq_len=8192  num_q_heads=16   head_dim=128    masked=True ====
CUDNN REFERENCE:  6044.2 us = 11.4% TC utilization
block_q_dkv=64  block_q_dq=64  block_kv_dq=64  block_kv_dkv=64  max_concurrent_steps=2   :  1821.7 us = 37.7% TC utilization
```


