### PR TITLE
[ROCm] Add hip_threefry2x32_ffi to stable custom call targets

### DIFF
--- a/jax/_src/export/_export.py
+++ b/jax/_src/export/_export.py
@@ -1174,6 +1174,7 @@ _CUSTOM_CALL_TARGETS_GUARANTEED_STABLE = {
     "Sharding", "SPMDFullToShardShape", "SPMDShardToFullShape",
     "annotate_device_placement",
     "cu_threefry2x32_ffi",
+    "hip_threefry2x32_ffi",
     # Triton IR does not guarantee stability.
     # "__gpu$xla.gpu.triton",
     # eigh on TPU


### PR DESCRIPTION
Adds hip_threefry2x32_ffi to _CUSTOM_CALL_TARGETS_GUARANTEED_STABLE to enable export compatibility for ROCm random number generation.

This is required for #34875 (ROCm threefry2x32 backward compatibility test) to pass.