### PR TITLE
Restore scan length check

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -352,16 +352,18 @@ def _infer_scan_length(
 
   if length is not None:
     try:
-      return int(length)
+      length = int(length)
     except core.ConcretizationTypeError:
       msg = ('The `length` argument to `scan` expects a concrete `int` value.'
              ' For scan-like iteration with a dynamic length, use `while_loop`'
              ' or `fori_loop`.')
       raise core.ConcretizationTypeError(length, msg) from None  # type: ignore[arg-type]
-    if not all(length == l for l in lengths):
-      msg = ("scan got `length` argument of {} which disagrees with "
-             "leading axis sizes {}.")
-      raise ValueError(msg.format(length, [x.shape[0] for x in xs_flat]))
+    else:
+      if not all(length == l for l in lengths):
+        msg = ("scan got `length` argument of {} which disagrees with "
+              "leading axis sizes {}.")
+        raise ValueError(msg.format(length, [x.shape[0] for x in xs_flat]))
+      return length
   else:
     unique_lengths = set(lengths)
     if len(unique_lengths) > 1:

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2051,6 +2051,13 @@ class LaxControlFlowTest(jtu.JaxTestCase):
                                   x[2]), None),
                    (jnp.array(0, 'int32'),) * 3, None, length=1)
 
+  def testScanLengthError(self):
+    x = jnp.arange(10)
+    with self.assertRaisesWithLiteralMatch(
+        ValueError,
+        "scan got `length` argument of 5 which disagrees with leading axis sizes [10]."):
+      jax.lax.scan(lambda *args: args, 0, x, length=5)
+
   @jax.enable_checks(False)
   def testScanInvalidUnrollRaises(self):
     with self.assertRaisesRegex(ValueError, "`unroll` must be"):


### PR DESCRIPTION
It looks like this was inadvertently lost during the course of the refactor in #33890