### PR TITLE
Fix jupytext lint at head

### DIFF
--- a/docs/autodidax.ipynb
+++ b/docs/autodidax.ipynb
@@ -2040,7 +2040,7 @@
     "  a = np.asarray(x)\n",
     "  if a.dtype == np.bool_:\n",
     "    return hlo.constant(ir.DenseElementsAttr.get(\n",
-    "      np.packbits(a, bitorder='little'), type=ir.IntegerType.get_signless(1),\n",
+    "      np.array(a, np.bool_), type=ir.IntegerType.get_signless(1),\n",
     "      shape=a.shape))\n",
     "  else:\n",
     "    return hlo.constant(ir.DenseElementsAttr.get(a))\n",

--- a/docs/autodidax.py
+++ b/docs/autodidax.py
@@ -1601,13 +1601,9 @@ def aval_to_ir_type(aval: ShapedArray) -> ir.Type:
 def _hlo_const(x: Any) -> ir.Value:
   a = np.asarray(x)
   if a.dtype == np.bool_:
-    return hlo.constant(
-        ir.DenseElementsAttr.get(
-            np.array(a, np.bool_),
-            type=ir.IntegerType.get_signless(1),
-            shape=a.shape,
-        )
-    )
+    return hlo.constant(ir.DenseElementsAttr.get(
+      np.array(a, np.bool_), type=ir.IntegerType.get_signless(1),
+      shape=a.shape))
   else:
     return hlo.constant(ir.DenseElementsAttr.get(a))
 


### PR DESCRIPTION
This morning's LLVM integrate introduced inconsistencies between `autodidax.py`, `autodidax.md`, and `autodidax.ipynb`. This PR rectifies them.