### PR TITLE
Add jax_sort_devices_by_process_index flag to control device assignment order

### DIFF
--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -115,6 +115,14 @@ FORCE_DCN_CROSS_HOST_TRANSFERS = config.bool_flag(
          "even when the plugin supports cross-host transfers."
 )
 
+SORT_DEVICES_BY_PROCESS_INDEX = config.bool_flag(
+    name="jax_sort_devices_by_process_index",
+    default=True,
+    help="Sort JAX devices by process index first, then by device id. "
+         "If False, sort devices only by device id, which preserves the "
+         "global device ordering assigned by the PJRT client."
+)
+
 CROSS_HOST_TRANSFER_SOCKET_ADDRESS = config.string_flag(
     name="jax_cross_host_transfer_socket_address",
     default="",
@@ -202,6 +210,7 @@ def make_tpu_client(
       distributed.global_state.client,
       _make_transfer_server_factory(),
       FORCE_DCN_CROSS_HOST_TRANSFERS.value,
+      SORT_DEVICES_BY_PROCESS_INDEX.value,
   )
 
 
@@ -555,6 +564,7 @@ def make_pjrt_c_api_client(
       distributed.global_state.client,
       _make_transfer_server_factory(),
       FORCE_DCN_CROSS_HOST_TRANSFERS.value,
+      SORT_DEVICES_BY_PROCESS_INDEX.value,
   )
 
 

--- a/jaxlib/_jax/__init__.pyi
+++ b/jaxlib/_jax/__init__.pyi
@@ -993,6 +993,7 @@ def get_c_api_client(
     distributed_client: DistributedRuntimeClient | None = ...,
     transfer_server_factory: TransferServerInterfaceFactory | None = ...,
     force_dcn_cross_host_transfers: bool = ...,
+    sort_devices_by_process_index: bool = ...,
 ) -> Client: ...
 def get_default_c_api_topology(
     arg0: str,

--- a/jaxlib/jax.cc
+++ b/jaxlib/jax.cc
@@ -416,7 +416,8 @@ NB_MODULE(_jax, m) {
          std::shared_ptr<xla::DistributedRuntimeClient> distributed_client,
          std::optional<xla::ifrt::TransferServerInterfaceFactory>
              transfer_server_factory,
-         bool force_dcn_cross_host_transfers) -> nb_class_ptr<PyClient> {
+         bool force_dcn_cross_host_transfers,
+         bool sort_devices_by_process_index) -> nb_class_ptr<PyClient> {
         std::unique_ptr<xla::ifrt::PjRtClient> ifrt_client;
         {
           nb::gil_scoped_release gil_release;
@@ -440,6 +441,8 @@ NB_MODULE(_jax, m) {
           }
           ifrt_options.force_dcn_cross_host_transfers =
               force_dcn_cross_host_transfers;
+          ifrt_options.sort_devices_by_process_index =
+              sort_devices_by_process_index;
           ifrt_client = xla::ValueOrThrow(
               xla::ifrt::PjRtClient::Create(std::move(ifrt_options)));
         }
@@ -450,7 +453,8 @@ NB_MODULE(_jax, m) {
           absl::flat_hash_map<std::string, xla::PjRtValueType>(),
       nb::arg("distributed_client").none() = nullptr,
       nb::arg("transfer_server_factory").none() = std::nullopt,
-      nb::arg("force_dcn_cross_host_transfers") = false);
+      nb::arg("force_dcn_cross_host_transfers") = false,
+      nb::arg("sort_devices_by_process_index") = true);
   // TODO(b/322357665): Delete this method after TPU plugin changes to use the
   // standard registration.
   m.def("get_default_c_api_topology",

--- a/jaxlib/xla_client.py
+++ b/jaxlib/xla_client.py
@@ -142,6 +142,7 @@ def make_c_api_client(
     distributed_client: _xla.DistributedRuntimeClient | None = None,
     transfer_server_factory: _xla.TransferServerInterfaceFactory | None = None,
     force_dcn_cross_host_transfers: bool = False,
+    sort_devices_by_process_index: bool = True,
 ):
   """Creates a PJRT C API client for a PJRT plugin.
 
@@ -164,6 +165,7 @@ def make_c_api_client(
       distributed_client,
       transfer_server_factory,
       force_dcn_cross_host_transfers,
+      sort_devices_by_process_index,
   )
 
 


### PR DESCRIPTION
JAX support for: https://github.com/openxla/xla/pull/37906

XLA will assign global device ids using network topology and optimize for process locality that minimizes network traffic, sorting devices by process id doesn't work with this device assignment strategy. Add a JAX flag to control existing IFRT options.