### PR TITLE
Mosaic GPU: pre-launch check for multicast support

### DIFF
--- a/jax/experimental/mosaic/gpu/launch_context.py
+++ b/jax/experimental/mosaic/gpu/launch_context.py
@@ -67,6 +67,8 @@ ORIGINAL_KERNEL_ARG_ATTR = "mosaic_gpu.original_kernel_arg"
 # Attribute used to identify an operation used to load the current device id.
 # Needed for _recompute_peer_device_id in TMA descriptor construction.
 DEVICE_ID_ATTR = "mosaic_gpu.device_id_load"
+# Attribute used to mark that a kernel requires multicast support
+USES_MULTIMEM_ATTR = "mosaic_gpu.multimem_used"
 
 
 def uses_collective_metadata(module):
@@ -680,6 +682,9 @@ class LaunchContext:
         f"Unrecognized op can't be recomputed on the host: {op}"
     )
 
+  def _flag_multimem_usage(self):
+    self.module.operation.attributes[USES_MULTIMEM_ATTR] = ir.UnitAttr.get()
+
   def _get_tma_desc(
       self,
       gmem_ref: ir.Value,
@@ -724,6 +729,7 @@ class LaunchContext:
         if isinstance(gmem_peer_id, GlobalBroadcast):
           if self.host_collective_metadata is None:
             self._ensure_nvshmem_decls()
+            self._flag_multimem_usage()
             world_team = arith.constant(i32, 0)
             base_ptr = llvm.call(
                 base_ptr.type,
@@ -1775,6 +1781,7 @@ class LaunchContext:
       )
 
     self._ensure_nvshmem_decls()
+    self._flag_multimem_usage()
     if not isinstance(ref.type, ir.MemRefType):
       raise ValueError(f"Unsupported type for to_remote_multicast: {ref.type}")
       # We replace the offset in the ref type by 0, because memref_ptr always

--- a/jaxlib/cuda/versions.cc
+++ b/jaxlib/cuda/versions.cc
@@ -45,6 +45,7 @@ NB_MODULE(_versions, m) {
   m.def("cublas_get_version", &CublasGetVersion);
   m.def("cusparse_get_version", &CusparseGetVersion);
   m.def("cuda_compute_capability", &CudaComputeCapability);
+  m.def("cuda_supports_multicast", &CudaSupportsMulticast);
   m.def("cuda_device_count", &CudaDeviceCount);
 }
 

--- a/jaxlib/cuda/versions_helpers.cc
+++ b/jaxlib/cuda/versions_helpers.cc
@@ -118,6 +118,14 @@ int CudaComputeCapability(int device) {
   return major * 10 + minor;
 }
 
+bool CudaSupportsMulticast(int device) {
+  int supports_multicast;
+  JAX_THROW_IF_ERROR(JAX_AS_STATUS(gpuDeviceGetAttribute(
+      &supports_multicast, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, device)));
+  ABSL_ANNOTATE_MEMORY_IS_INITIALIZED(&supports_multicast, sizeof supports_multicast);
+  return supports_multicast;
+}
+
 int CudaDeviceCount() {
   int device_count = 0;
   {

--- a/jaxlib/cuda/versions_helpers.h
+++ b/jaxlib/cuda/versions_helpers.h
@@ -30,6 +30,7 @@ int CublasGetVersion();
 int CusparseGetVersion();
 size_t CudnnGetVersion();
 int CudaComputeCapability(int);
+bool CudaSupportsMulticast(int);
 int CudaDeviceCount();
 
 }  // namespace jax::cuda

--- a/jaxlib/mosaic/gpu/BUILD
+++ b/jaxlib/mosaic/gpu/BUILD
@@ -248,6 +248,7 @@ cc_library(
     linkopts = [
         "-Wl,--export-dynamic-symbol='mosaic_gpu_*'",
         "-Wl,--export-dynamic-symbol='nvshmem_my_pe'",
+        "-Wl,--export-dynamic-symbol='nvshmem_n_pes'",
         "-Wl,--export-dynamic-symbol='nvshmem_ptr'",
         "-Wl,--export-dynamic-symbol='nvshmemx_barrier_all_on_stream'",
         "-Wl,--export-dynamic-symbol='nvshmemx_cumodule_finalize'",

--- a/jaxlib/mosaic/gpu/custom_call.cc
+++ b/jaxlib/mosaic/gpu/custom_call.cc
@@ -366,6 +366,10 @@ bool is_nvshmem_used(mlir::ModuleOp module) {
   return false;
 }
 
+bool is_multimem_used(mlir::ModuleOp mod) {
+  return static_cast<bool>(mod->getAttr("mosaic_gpu.multimem_used"));
+}
+
 absl::StatusOr<std::string> get_nvshmem_llvm_lib_path() {
   const char* nvshmem_path_ptr = getenv("MOSAIC_GPU_NVSHMEM_BC_PATH");
   if (!nvshmem_path_ptr)
@@ -475,12 +479,13 @@ absl::StatusOr<std::pair<std::string, std::string>> GetHostAndInitFuncNames(
 struct CompiledKernel {
   CompiledKernel(std::unique_ptr<llvm::orc::LLJIT> lljit,
                  MosaicHostFunc* host_launch, MosaicInitFunc* init,
-                 bool is_nvshmem_used, std::string object_file,
+                 bool is_nvshmem_used, bool is_multimem_used, std::string object_file,
                  std::string host_func_name, std::string init_func_name)
       : lljit(std::move(lljit)),
         host_launch(host_launch),
         init(init),
         is_nvshmem_used(is_nvshmem_used),
+        is_multimem_used(is_multimem_used),
         object_file(std::move(object_file)),
         host_func_name(std::move(host_func_name)),
         init_func_name(std::move(init_func_name)) {}
@@ -494,6 +499,7 @@ struct CompiledKernel {
   MosaicHostFunc* host_launch = nullptr;
   MosaicInitFunc* init = nullptr;
   bool is_nvshmem_used = false;
+  bool is_multimem_used = false;
   // The following fields are used for de/serialization of CompiledKernel.
   std::string object_file;
   std::string host_func_name;
@@ -598,7 +604,7 @@ absl::StatusOr<std::unique_ptr<llvm::MemoryBuffer>> CompileModuleToObject(
 
 absl::StatusOr<std::unique_ptr<CompiledKernel>> CreateAndInitJIT(
     std::unique_ptr<llvm::MemoryBuffer> object_file, std::string host_func_name,
-    std::string init_func_name, bool is_nvshmem_used) {
+    std::string init_func_name, bool is_nvshmem_used, bool is_multimem_used) {
   EnsureNativeLLVMisInitialized();
   std::string object_file_str = object_file->getBuffer().str();
   auto lljit_builder = llvm::orc::LLJITBuilder();
@@ -716,7 +722,7 @@ absl::StatusOr<std::unique_ptr<CompiledKernel>> CreateAndInitJIT(
   VLOG(5) << "Successfully JIT-linked Mosaic GPU kernel";
   return std::make_unique<CompiledKernel>(
       std::move(lljit), host_sym->toPtr<MosaicHostFunc*>(),
-      init_sym->toPtr<MosaicInitFunc*>(), is_nvshmem_used,
+      init_sym->toPtr<MosaicInitFunc*>(), is_nvshmem_used, is_multimem_used,
       std::move(object_file_str), std::move(host_func_name),
       std::move(init_func_name));
 }
@@ -783,6 +789,7 @@ absl::StatusOr<std::unique_ptr<CompiledKernel>> Compile(
   mosaic::gpu::EnsureLLVMNVPTXTargetIsRegistered();
 
   bool use_nvshmem = is_nvshmem_used(*module);
+  bool multimem_used = is_multimem_used(*module);
   mosaic::gpu::DumpOptions dump_opts =
       mosaic::gpu::GetOrSetDumpOptionsForModule(*module);
   TF_RETURN_IF_ERROR(RunMlirPasses(*module, cc, use_nvshmem, dump_opts));
@@ -802,7 +809,7 @@ absl::StatusOr<std::unique_ptr<CompiledKernel>> Compile(
 
   return CreateAndInitJIT(
       std::move(object_file), std::move(host_and_init_func_names.first),
-      std::move(host_and_init_func_names.second), use_nvshmem);
+      std::move(host_and_init_func_names.second), use_nvshmem, multimem_used);
 }
 
 struct KernelCache {
@@ -843,6 +850,25 @@ absl::StatusOr<void*> InitKernel(const CompiledKernel& kernel) {
     return absl::InternalError(
         "Failed to load the NVSHMEM library. Make sure it is installed (e.g. "
         "`pip install nvidia-nvshmem-cu12`).");
+  }
+  if (kernel.is_multimem_used) {
+    CUdevice device;
+    CUDA_RETURN_IF_ERROR(cuCtxGetDevice(&device));
+    int supports_multicast;
+    CUDA_RETURN_IF_ERROR(cuDeviceGetAttribute(&supports_multicast, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, device));
+    int nvshmem_world_size = NvshmemApi::Default().n_pes();
+    // multimem instructions require multicast memory; mgpu will emit device-side calls
+    // to nvshmemx_mc_ptr to translate unicast->multicast addresses, which will return
+    // nullptr and lead to memory errors if multicast is not supported on the device
+    // https://docs.nvidia.com/nvshmem/api/using.html#communication-model
+    // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-multimem
+    // https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/virtual-memory-management.html#multicast-memory-sharing
+    if (supports_multicast == 0) {
+      return absl::FailedPreconditionError("System does not support multicast memory; multimem instructions cannot be used.");
+    } else if (nvshmem_world_size == 1) {
+      // There is only one device, so NVSHMEM will not configure multicast mappings and nvshmemx_mc_ptr will return nullptr.
+      return absl::FailedPreconditionError("Multicast memory mappings are not configured with only one device; multimem instructions cannot be used.");
+    }
   }
   void* module_ptr = nullptr;
   void* kernel_ptr = nullptr;
@@ -930,6 +956,7 @@ absl::StatusOr<std::string> CustomCallResources::Serialize(
   kernel_proto.set_version(1);
   kernel_proto.set_object_file(kernel->object_file);
   kernel_proto.set_is_nvshmem_used(kernel->is_nvshmem_used);
+  kernel_proto.set_is_multimem_used(kernel->is_multimem_used);
   kernel_proto.set_kernel_hash(resources.hash.data(), sizeof(KernelHash));
   kernel_proto.set_host_func_name(kernel->host_func_name);
   kernel_proto.set_init_func_name(kernel->init_func_name);
@@ -966,7 +993,8 @@ CustomCallResources::Deserialize(absl::string_view data) {
                                         kernel_proto.object_file(), "kernel"),
                                     std::move(host_func_name),
                                     std::move(init_func_name),
-                                    kernel_proto.is_nvshmem_used());
+                                    kernel_proto.is_nvshmem_used(),
+                                    kernel_proto.is_multimem_used());
           }));
   return resources;
 }

--- a/jaxlib/mosaic/gpu/mosaic_gpu.proto
+++ b/jaxlib/mosaic/gpu/mosaic_gpu.proto
@@ -12,4 +12,5 @@ message MosaicGpuKernelProto {
   bytes kernel_hash = 4;
   string host_func_name = 5;
   string init_func_name = 6;
+  bool is_multimem_used = 7;
 }

--- a/jaxlib/mosaic/gpu/nvshmem.h
+++ b/jaxlib/mosaic/gpu/nvshmem.h
@@ -67,6 +67,10 @@ class NvshmemApi {
     return nvshmemx_init_status != nullptr && nvshmemx_init_status() == 2;
   }
 
+  int n_pes() {
+    return nvshmem_n_pes();
+  }
+
   NvshmemApi(NvshmemApi const&)     = delete;
   void operator=(NvshmemApi const&) = delete;
 
@@ -85,12 +89,14 @@ class NvshmemApi {
     NVSHMEM_SET_FN(nvshmemx_cumodule_finalize)
     NVSHMEM_SET_FN(nvshmemx_cumodule_init)
     NVSHMEM_SET_FN(nvshmemx_init_status)
+    NVSHMEM_SET_FN(nvshmem_n_pes);
   }
 
   int (*nvshmemx_barrier_all_on_stream)(cudaStream_t);
   int (*nvshmemx_cumodule_finalize)(CUmodule);
   int (*nvshmemx_cumodule_init)(CUmodule);
   int (*nvshmemx_init_status)();
+  int (*nvshmem_n_pes)();
 
   std::mutex mutex_;
 };

--- a/tests/pallas/gpu_pallas_distributed_test.py
+++ b/tests/pallas/gpu_pallas_distributed_test.py
@@ -25,6 +25,7 @@ from jax import lax
 from jax._src import test_multiprocess as jt_multiprocess
 from jax._src import test_util as jtu
 from jax._src.config import config
+from jax._src.lib import cuda_versions
 from jax.experimental import multihost_utils
 from jax.experimental import pallas as pl
 import jax.experimental.mosaic.gpu as mgpu
@@ -66,6 +67,10 @@ class TestCase(jt_multiprocess.MultiProcessTest if is_nvshmem_used() is None els
 
 
 class PallasCallRemoteDMATest(TestCase):
+  def setUp(self):
+    if jax.device_count() < 2:
+      self.skipTest("Needs at least two devices")
+    super().setUp()
 
   def test_remote_dma_basic(self):
     if jax.process_index() > 2:
@@ -582,6 +587,10 @@ class PallasCallMultimemTest(TestCase):
   def setUp(self):
     if jax.local_device_count() > 1:
       self.skipTest("Multimem not supported in multi-thread mode yet.")
+    if jax.device_count() < 2:
+      self.skipTest("Needs at least two devices")
+    if any(not cuda_versions.cuda_supports_multicast(d.local_hardware_id) for d in jax.local_devices()):
+      self.skipTest("Not all local devices support multicast")
     super().setUp()
 
   def _get_reduction_impl(self, reduction):


### PR DESCRIPTION
This gives a much better error message from kernels using multimem PTX instructions on incompatible systems, and makes the test suite pass on single-GPU and multi-GPU-without-multicast systems.

- https://docs.nvidia.com/nvshmem/api/using.html#communication-model
- https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-multimem
- https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/virtual-memory-management.html#multicast-memory-sharing

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->