### PR TITLE
[hijax] add failing test of call_p with hijax primitive

### DIFF
--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -27,9 +27,11 @@ import jax
 import jax.numpy as jnp
 from jax import typeof
 
+from jax._src import api_util
 from jax._src import config
 from jax._src import core
 from jax._src import dtypes
+from jax._src import linear_util as lu
 from jax._src import state
 from jax._src.state import indexing
 from jax._src.state import primitives as state_primitives
@@ -1110,6 +1112,17 @@ class HijaxTest(jtu.JaxTestCase):
       with Square.assert_jvp_rule_called_once():
         actual_grad = jax.jit(jax.grad(jax.remat(square)))(x)
       self.assertArraysAllClose(actual_grad, expected_grad)
+
+  def test_hijax_primitive_under_core_call(self):
+    @jax.jit(static_argnames=['f'])
+    def core_call(f, *args):
+      args, in_tree = jax.tree.flatten(args)
+      dbg = api_util.debug_info("core_call", f, args, {})
+      f, out_tree = api_util.flatten_fun_nokwargs(lu.wrap_init(f, debug_info=dbg), in_tree)
+      out = core.call_p.bind(f, *args)
+      return jax.tree.unflatten(out_tree(), out)
+
+    core_call(square, jnp.arange(4.))
 
 
 class BoxTest(jtu.JaxTestCase):


### PR DESCRIPTION
This test is modeled after `test_jit()` in `core_test.py`: https://github.com/jax-ml/jax/blob/27274db2d353a6e00aa45f743c99d18c7c0ffe22/tests/core_test.py#L212-L215

<details>
<summary>Test traceback</summary>

```pytb
ctx = ModuleContext(context=<jax._src.interpreters.mlir.JaxIrContext object at 0x121693750>, module=<jaxlib.mlir._mlir_libs....onstant_computation=False, for_export=False, export_ignore_forward_compatibility=False, hoist_constants_as_args=False))
fn_name = 'core_call', call_jaxpr = { lambda ; a:f32[4]. let
    b:f32[4] = call_hi_primitive[prim=Square[{}]] a
  in (b,) }, num_const_args = 0
effects = [], in_avals = (ShapedArray(float32[4]),), arg_names = None, result_names = None

    def _lower_jaxpr_to_fun_cached(
        ctx: ModuleContext, fn_name, call_jaxpr: core.ClosedJaxpr,
        num_const_args: int, effects, in_avals, arg_names=None, result_names=None):
      assert num_const_args + len(call_jaxpr.in_avals) == len(in_avals)
      if not call_jaxpr.consts and arg_names is result_names is None:
        # Cacheable.
        key = (fn_name, call_jaxpr.jaxpr, tuple(effects))
        try:
>         func_op, _, _ = ctx.cached_primitive_lowerings[key]
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E         KeyError: ('core_call', { lambda ; a:f32[4]. let
E             b:f32[4] = call_hi_primitive[prim=Square[{}]] a
E           in (b,) }, ())

jax/_src/interpreters/mlir.py:2489: KeyError

During handling of the above exception, another exception occurred:

>   core_call(square, jnp.arange(4.))

tests/hijax_test.py:1125: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/hijax_test.py:1122: in core_call
    out = core.call_p.bind(f, *args)
tests/hijax_test.py:474: in square
    return Square(jax.typeof(x))(x)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ans_flat = call_hi_primitive_p.bind(*args_flat, prim=self)
E   jax._src.source_info_util.JaxStackTraceBeforeTransformation: NotImplementedError: MLIR translation rule for primitive 'call_hi_primitive' not found for platform cpu
E   
E   The preceding stack trace is the source of the JAX operation that, once transformed by JAX, triggered the following exception.
E   
E   --------------------

jax/_src/hijax.py:412: JaxStackTraceBeforeTransformation

The above exception was the direct cause of the following exception:

self = <tests.hijax_test.HijaxTest testMethod=test_hijax_primitive_under_core_call>

    def test_hijax_primitive_under_core_call(self):
      @jax.jit(static_argnames=['f'])
      def core_call(f, *args):
        args, in_tree = jax.tree.flatten(args)
        dbg = api_util.debug_info("core_call", f, args, {})
        f, out_tree = api_util.flatten_fun_nokwargs(lu.wrap_init(f, debug_info=dbg), in_tree)
        out = core.call_p.bind(f, *args)
        return jax.tree.unflatten(out_tree(), out)
    
>     core_call(square, jnp.arange(4.))

tests/hijax_test.py:1125: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
jax/_src/pjit.py:255: in cache_miss
    executable, pgle_profiler, const_args) = _run_python_pjit(
jax/_src/pjit.py:140: in _run_python_pjit
    out_flat, compiled, profiler, const_args = _pjit_call_impl_python(
jax/_src/pjit.py:1197: in _pjit_call_impl_python
    computation = _resolve_and_lower(
jax/_src/pjit.py:1123: in _resolve_and_lower
    return _pjit_lower(
jax/_src/pjit.py:1303: in _pjit_lower
    return pxla.lower_sharding_computation(
jax/_src/profiler.py:384: in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
jax/_src/interpreters/pxla.py:2394: in lower_sharding_computation
    nreps, tuple_args, shape_poly_state) = _cached_lowering_to_hlo(
jax/_src/interpreters/pxla.py:1988: in _cached_lowering_to_hlo
    lowering_result = mlir.lower_jaxpr_to_module(
jax/_src/interpreters/mlir.py:1306: in lower_jaxpr_to_module
    lower_jaxpr_to_fun(
jax/_src/interpreters/mlir.py:1883: in lower_jaxpr_to_fun
    out_vals, tokens_out = jaxpr_subcomp(
jax/_src/interpreters/mlir.py:2061: in jaxpr_subcomp
    out_nodes, tokens_out = _cached_lowering(
jax/_src/interpreters/mlir.py:2120: in _cached_lowering
    cache_entry = _emit_lowering_rule_as_fun(
jax/_src/interpreters/mlir.py:2199: in _emit_lowering_rule_as_fun
    outs, inline = lowering_rule(sub_ctx, *unflattened_args, **params)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/interpreters/mlir.py:2250: in _uncached_lowering
    ans = lower_per_platform(ctx, str(primitive), platform_rules, default_rule,
jax/_src/interpreters/mlir.py:2368: in lower_per_platform
    output = kept_rules[0](ctx, *rule_args, **rule_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/interpreters/mlir.py:2579: in core_call_lowering
    out_nodes, tokens = call_lowering(
jax/_src/interpreters/mlir.py:2556: in call_lowering
    func_op, output_types, effects = lower_called_computation(
jax/_src/interpreters/mlir.py:2533: in lower_called_computation
    func_op = _lower_jaxpr_to_fun_cached(
jax/_src/interpreters/mlir.py:2491: in _lower_jaxpr_to_fun_cached
    func_op = lower_jaxpr_to_fun(
jax/_src/interpreters/mlir.py:1883: in lower_jaxpr_to_fun
    out_vals, tokens_out = jaxpr_subcomp(
jax/_src/interpreters/mlir.py:2061: in jaxpr_subcomp
    out_nodes, tokens_out = _cached_lowering(
jax/_src/interpreters/mlir.py:2120: in _cached_lowering
    cache_entry = _emit_lowering_rule_as_fun(
jax/_src/interpreters/mlir.py:2199: in _emit_lowering_rule_as_fun
    outs, inline = lowering_rule(sub_ctx, *unflattened_args, **params)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jax/_src/interpreters/mlir.py:2250: in _uncached_lowering
    ans = lower_per_platform(ctx, str(primitive), platform_rules, default_rule,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

ctx = LoweringRuleContext(module_context=ModuleContext(context=<jax._src.interpreters.mlir.JaxIrContext object at 0x12169375...ne, threefry_partitionable=True, cur_abstract_mesh=AbstractMesh((), axis_types=()), xla_metadata=None), platforms=None)
description = 'call_hi_primitive', platform_rules = {}, default_rule = None, effects = set()
rule_args = (<jaxlib.mlir._mlir_libs._mlir.ir.BlockArgument object at 0x1216bc830>,), rule_kwargs = {'prim': Square[{}]}, platforms = ('cpu',)
rule = None

    def lower_per_platform(ctx: LoweringRuleContext,
                           description: str,
                           platform_rules: dict[str, LoweringRule],
                           default_rule: LoweringRule | None,
                           effects: effects_lib.Effects,
                           *rule_args: ir.Value | tuple[ir.Value, ...],
                           **rule_kwargs) -> Sequence[ir.Value]:
      """Emits code for a primitive for the current lowering platform(s).
    
      For example, given
          platform_rules = dict(tpu=rule0, cpu=rule0)
          default_rule = rule1
    
      and
          ctx.module_context.lowering_parameters.platforms = ("cpu",)
    
      emits:
          rule0(ctx, *rule_args, **rule_kwargs)
    
      In case of multi-platform lowering, e.g., if
          ctx.module_context.lowering_parameters.platforms = ("cpu", "cuda", "tpu")
    
      emits:
        rule_idx = case current_platform_idx:
                       0: return 0  # cpu rule index
                       1: return 1  # cuda rule index
                       2: return 0  # tpu rule index
        output = case rule_idx
                   0: return rule0(*rule_args, **rule_kwargs)
                   1: return rule1(*rule_args, **rule_kwargs)
    
      Args:
       ctx: lowering context.
       description: a string to include in error messages.
       platform_rules: map platform names, e.g., "cpu", "cuda", to
         `LoweringRule`s, for the platforms that have non-default lowering.
       default_rule: an optional rule to use for platforms not in `platform_rules`.
       effects: the set of effects for the current primitive.
       rule_args: the args of the lowering rules.
       rule_kwargs: the kwargs of the lowering rules.
      """
      platforms: Sequence[str] = _platforms_for_eqn(ctx)
      # Special case the common case (single-platform lowering)
      if len(platforms) == 1:
        rule = platform_rules.get(platforms[0], default_rule)
        if rule is None:
>         raise NotImplementedError(
            f"MLIR translation rule for primitive '{description}' not "
            f"found for platform {platforms[0]}")
E         NotImplementedError: MLIR translation rule for primitive 'call_hi_primitive' not found for platform cpu

jax/_src/interpreters/mlir.py:2341: NotImplementedError
============================================================= short test summary info =============================================================
FAILED tests/hijax_test.py::HijaxTest::test_hijax_primitive_under_core_call - NotImplementedError: MLIR translation rule for primitive 'call_hi_primitive' not found for platform cpu
===================================================== 1 failed, 80 passed, 3 skipped in 3.19s =====================================================
```

</details>