### PR TITLE
Fix the triton autotuning crashes when input_output_aliases is used

### DIFF
--- a/jaxlib/gpu/triton_kernels.cc
+++ b/jaxlib/gpu/triton_kernels.cc
@@ -773,10 +773,10 @@ jax_triton::TritonAutotunedKernelCall AutotunedKernelCall::ToProto() const {
             << " best config " << kernel_call.configs_[0].description;
 
   // Restore aliased inputs to their original values.
-  for (auto [input_idx, _, size] : kernel_call.input_output_aliases_) {
+  for (const auto& [input_idx, input_copy] : input_copies) {
     GPU_RETURN_IF_ERROR(
         gpuMemcpyHtoDAsync(reinterpret_cast<gpuDevicePtr_t>(buffers[input_idx]),
-                           input_copies[input_idx].data(), size, stream));
+                           input_copy.data(), input_copy.size(), stream));
   }
 
   // Synchronize stream to ensure copies are complete before the host copy


### PR DESCRIPTION
 AutotunedKernelCall::Autotune saves the contents of any input buffer that aliases an output buffer, so that each candidate config is benchmarked against the original input rather than data overwritten by a previous config's run. The save step
 (input_copies) only populates an entry when the runtime buffers actually match (buffers[input_idx] == buffers[output_idx]). However, when the aliased input remains live after the kernel call, XLA assigns separate buffers at runtime, so the save condition is false and the entry is never created.

The old restore loop iterated over input_output_aliases_ (all declared aliases) and unconditionally accessed input_copies[input_idx].data(). For a non-populated entry this returns nullptr, causing gpuMemcpyHtoDAsync to be called with a null source pointer and crash.

The fix changes the restore loop to iterate over input_copies directly, which only contains entries for aliases where the buffers were actually shared at runtime.

A test is added to exercise this code path by using the aliased input after the kernel call, forcing XLA to allocate separate buffers, and verifying that autotuning completes correctly.