### PR TITLE
scipy.linalg: add hankel special matrix

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -64,6 +64,7 @@ jax.scipy.linalg
    expm_frechet
    funm
    hessenberg
+   hankel
    hilbert
    inv
    lu

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -2162,6 +2162,73 @@ def _toeplitz(c: Array, r: Array) -> Array:
       precision=lax.Precision.HIGHEST)[0]
   return jnp.flip(patches, axis=0)
 
+def hankel(c: ArrayLike, r: ArrayLike | None = None) -> Array:
+  r"""Construct a Hankel matrix.
+
+  JAX implementation of :func:`scipy.linalg.hankel`.
+
+  A Hankel matrix has constant anti-diagonals: ``H[i, j] = v[i + j]``, where
+  ``v = concatenate([c, r[1:]])``. Notice this implies that ``r[0]`` is ignored.
+
+  Args:
+    c: array of shape ``(..., N)`` specifying the first column.
+    r: (optional) array of shape ``(..., M)`` specifying the last row. Leading
+      dimensions must be broadcast-compatible with those of ``c``. If not
+      specified, ``r`` defaults to ``zeros_like(c)``.
+
+  Returns:
+    A Hankel matrix of shape ``(..., N, M)``.
+
+  Examples:
+    >>> c = jnp.array([1, 2, 3])
+    >>> jax.scipy.linalg.hankel(c)
+    Array([[1, 2, 3],
+           [2, 3, 0],
+           [3, 0, 0]], dtype=int32)
+
+    >>> r = jnp.array([999, 4, 5, 6]) # Note r[0] is ignored
+    >>> jax.scipy.linalg.hankel(c, r)
+    Array([[1, 2, 3, 4],
+           [2, 3, 4, 5],
+           [3, 4, 5, 6]], dtype=int32)
+
+    For N-dimensional ``c`` and/or ``r``, the result is a batch of Hankel matrices.
+  """
+  if r is None:
+    check_arraylike("hankel", c)
+    c = jnp.asarray(c)
+    r = jnp.zeros_like(c)
+  else:
+    check_arraylike("hankel", c, r)
+    c = jnp.asarray(c)
+    r = jnp.asarray(r)
+  if c.ndim == 0:
+    raise ValueError("hankel: c must be at least 1-dimensional, got a scalar.")
+  if r.ndim == 0:
+    raise ValueError("hankel: r must be at least 1-dimensional, got a scalar.")
+
+  # Align batch ranks so jnp.vectorize doesn't need implicit rank promotion.
+  if c.ndim < r.ndim:
+    c = lax.expand_dims(c, range(r.ndim - c.ndim))
+  elif r.ndim < c.ndim:
+    r = lax.expand_dims(r, range(c.ndim - r.ndim))
+
+  return _hankel(c, r)
+
+@partial(jnp_vectorize.vectorize, signature="(m),(n)->(m,n)")
+def _hankel(c: Array, r: Array) -> Array:
+  ncols, = c.shape
+  nrows, = r.shape
+  if ncols == 0 or nrows == 0:
+    return jnp.empty((ncols, nrows), dtype=jnp.result_type(c, r))
+  v = jnp.concatenate((c, r[1:]))
+  return lax.conv_general_dilated_patches(
+      v.reshape((1, ncols + nrows - 1, 1)),
+      (nrows,), (1,), 'VALID',
+      dimension_numbers=('NTC', 'IOT', 'NTC'),
+      precision=lax.Precision.HIGHEST)[0]
+
+
 @jit(static_argnames=("n",))
 def hilbert(n: int) -> Array:
   r"""Create a Hilbert matrix of order n.

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -26,6 +26,7 @@ from jax._src.scipy.linalg import (
   expm as expm,
   expm_frechet as expm_frechet,
   hessenberg as hessenberg,
+  hankel as hankel,
   hilbert as hilbert,
   inv as inv,
   lu as lu,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -99,6 +99,17 @@ def osp_linalg_toeplitz(c: np.ndarray, r: np.ndarray | None = None) -> np.ndarra
     return np.vectorize(
       scipy.linalg.toeplitz, signature="(m),(n)->(m,n)", otypes=(np.result_type(c, r),))(c, r)
 
+def osp_linalg_hankel(c: np.ndarray, r: np.ndarray | None = None) -> np.ndarray:
+  """Batched scipy hankel for testing."""
+  if scipy_version >= (1, 19):
+    if r is None:
+      return scipy.linalg.hankel(c)
+    return scipy.linalg.hankel(c, r)
+  if r is None:
+    r = np.zeros_like(c)
+  return np.vectorize(
+      scipy.linalg.hankel, signature="(m),(n)->(m,n)",
+      otypes=(np.result_type(c.dtype, r.dtype),))(c, r)
 
 def svd_algorithms():
   algorithms = [None]
@@ -2193,6 +2204,42 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       [1, 4, 5, 6],
       [2, 1, 4, 5],
       [3, 2, 1, 4]], dtype=np.float32))
+  def testHankelConstructionWithKnownCases(self):
+    # r=None should default to zeros_like(c)
+    c = np.array([1, 2, 3], dtype=np.float32)
+    expected = osp_linalg_hankel(c, None)
+    actual = jsp.linalg.hankel(c)
+    self.assertAllClose(expected, actual)
+
+    # r[0] is ignored (changing it should not change output)
+    r1 = np.array([999, 4, 5, 6], dtype=np.float32)
+    r2 = np.array([c[-1], 4, 5, 6], dtype=np.float32)
+    out1 = jsp.linalg.hankel(c, r1)
+    out2 = jsp.linalg.hankel(c, r2)
+    self.assertAllClose(out1, out2)
+
+  @jtu.sample_product(
+     cshape = [(3,), (0,), (2, 3), (1, 2, 3)],
+     rshape = [(4,), (0,), (1, 4), (2, 4), (1, 1, 4)],
+     cdtype=float_types + complex_types + int_types,
+     rdtype=float_types + complex_types + int_types,
+  )
+  def testHankelConstruction(self, cshape, cdtype, rshape, rdtype):
+    int_types_excl_i8 = set(int_types) - {np.int8}
+    if ((rdtype in int_types_excl_i8 or cdtype in int_types_excl_i8)
+        and jtu.test_device_matches(["gpu"])):
+      self.skipTest("Integer (except int8) hankel is not supported on GPU")
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(cshape, cdtype), rng(rshape, rdtype)]
+    with jtu.strict_promotion_if_dtypes_match([rdtype, cdtype]):
+      self._CheckAgainstNumpy(
+          jtu.promote_like_jnp(osp_linalg_hankel),
+          jsp.linalg.hankel,
+          args_maker,
+          check_dtypes=False,
+      )
+      self._CompileAndCheck(jsp.linalg.hankel, args_maker)
+
 
   @jtu.sample_product(
     shape=[(2, 3), (4, 6), (50, 7), (100, 110)],


### PR DESCRIPTION
Adds `jax.scipy.linalg.hankel` + tests.

Refs #10144.