### PR TITLE
[jaxlib] Build MLIR .pyis and include them into the wheel

### DIFF
--- a/jaxlib/jax.bzl
+++ b/jaxlib/jax.bzl
@@ -137,10 +137,11 @@ jax_extra_deps = []
 jax_gpu_support_deps = []
 jax2tf_deps = []
 
-def pytype_library(name, pytype_srcs = None, **kwargs):
-    _ = pytype_srcs  # @unused
-    kwargs.pop("lazy_imports", None)
-    py_library(name = name, **kwargs)
+def pytype_library(name, pytype_srcs = [], **kwargs):
+    data = pytype_srcs + (kwargs["data"] if "data" in kwargs else [])
+    new_kwargs = {k: v for k, v in kwargs.items() if k != "data"}
+    new_kwargs.pop("lazy_imports", None)
+    py_library(name = name, data = data, **new_kwargs)
 
 def pytype_strict_library(name, pytype_srcs = [], **kwargs):
     data = pytype_srcs + (kwargs["data"] if "data" in kwargs else [])

--- a/jaxlib/mlir/_mlir_libs/BUILD.bazel
+++ b/jaxlib/mlir/_mlir_libs/BUILD.bazel
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 load("@rules_python//python:py_library.bzl", "py_library")
+load("//jaxlib:jax.bzl", "if_windows", "pytype_library")
 load(
-    "//jaxlib:jax.bzl",
-    "if_windows",
+    "//jaxlib:pywrap.bzl",
+    "nanobind_pywrap_extension",
+    "pywrap_binaries",
+    "pywrap_library",
 )
-load("//jaxlib:pywrap.bzl", "nanobind_pywrap_extension")
-load("//jaxlib:symlink_files.bzl", "symlink_inputs")
+load("//jaxlib:symlink_files.bzl", "symlink_files", "symlink_inputs")
 
 package(
     default_visibility = [
@@ -45,6 +47,53 @@ nanobind_pywrap_extension(
         "@llvm-project//mlir:MLIRBindingsPythonNanobindHeaders",
         "@nanobind",
     ],
+)
+
+pywrap_library(
+    name = "mlir_for_stubgen",
+    common_lib_def_files_or_filters = {
+        "jaxlib/mlir/_mlir_libs/mlir_for_stubgen_common": "mlir_for_stubgen.json",
+    },
+    visibility = ["//visibility:private"],
+    deps = [
+        ":_mlir",
+    ],
+)
+
+pywrap_binaries(
+    name = "mlir_for_stubgen_binaries",
+    dep = ":mlir_for_stubgen",
+    visibility = ["//visibility:private"],
+)
+
+symlink_files(
+    name = "stubgen_py",
+    srcs = ["@nanobind//:src/stubgen.py"],
+    dst = ".",
+    flatten = True,
+    visibility = ["//visibility:private"],
+)
+
+py_binary(
+    name = "stubgen",
+    srcs = [":stubgen_py"],
+    data = [":mlir_for_stubgen_binaries"],
+    main = "stubgen.py",
+    visibility = ["//visibility:private"],
+)
+
+genrule(
+    name = "_mlir_pyi",
+    outs = [
+        "_mlir/__init__.pyi",
+        "_mlir/ir.pyi",
+        "_mlir/passmanager.pyi",
+        "_mlir/rewrite.pyi",
+    ],
+    cmd = """
+        $(location :stubgen) -m jaxlib.mlir._mlir_libs._mlir -r -O $(RULEDIR)
+    """,
+    tools = [":stubgen"],
 )
 
 nanobind_pywrap_extension(
@@ -213,7 +262,8 @@ nanobind_pywrap_extension(
 
 symlink_inputs(
     name = "_mlir_libs",
-    rule = py_library,
+    pytype_srcs = ["_mlir_pyi"],
+    rule = pytype_library,
     symlinked_inputs = {"srcs": {
         ".": [
             "@llvm-project//mlir/python:MlirLibsPyFiles",

--- a/jaxlib/mlir/_mlir_libs/mlir_for_stubgen.json
+++ b/jaxlib/mlir/_mlir_libs/mlir_for_stubgen.json
@@ -1,0 +1,8 @@
+{
+  "global": [
+    "Wrapped_PyInit_*"
+  ],
+  "local": [
+    "*"
+  ]
+}

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -102,6 +102,7 @@ setup(
             'mlir/_mlir_libs/*.pyd',
             'mlir/_mlir_libs/*.py',
             'mlir/_mlir_libs/*.pyi',
+            'mlir/_mlir_libs/**/*.pyi',
             'rocm/*',
             'triton/*.py',
             'triton/*.pyi',

--- a/jaxlib/tools/BUILD.bazel
+++ b/jaxlib/tools/BUILD.bazel
@@ -155,6 +155,7 @@ wheel_sources(
         "//jaxlib",
         "//jaxlib:jaxlib_binaries",
         "//jaxlib:_jax",
+        "//jaxlib/mlir/_mlir_libs",
     ],
     hdr_srcs = [
         "@xla//xla/ffi/api:ffi",

--- a/jaxlib/tools/build_wheel.py
+++ b/jaxlib/tools/build_wheel.py
@@ -372,6 +372,15 @@ def prepare_wheel(wheel_sources_path: pathlib.Path, *, cpu, wheel_sources):
           ]
       ),
   )
+  copy_files(
+      dst_dir=mlir_libs_dir / "_mlir",
+      src_files=[
+          f"{source_file_prefix}jaxlib/mlir/_mlir_libs/_mlir/__init__.pyi",
+          f"{source_file_prefix}jaxlib/mlir/_mlir_libs/_mlir/ir.pyi",
+          f"{source_file_prefix}jaxlib/mlir/_mlir_libs/_mlir/passmanager.pyi",
+          f"{source_file_prefix}jaxlib/mlir/_mlir_libs/_mlir/rewrite.pyi",
+      ]
+  )
 
   triton_dir = jaxlib_dir / "triton"
   copy_files(


### PR DESCRIPTION
The .pyis used to be bundled with jaxlib, but disappeared due to llvm/llvm-project#155741.