### PR TITLE
[WIP ROCm] Migrate rocm wheel build

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -231,4 +231,8 @@ external_deps_repository = use_repo_rule(
 
 external_deps_repository(
     name = "rocm_external_test_deps",
+    deps = [
+        "//jaxlib/tools:jax_rocm_pjrt_py_import",
+        "//jaxlib/tools:jax_rocm_plugin_py_import",
+    ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -102,7 +102,13 @@ flatbuffers()
 
 load("//third_party/external_deps:workspace.bzl", "external_deps_repository")
 
-external_deps_repository(name = "rocm_external_test_deps")
+external_deps_repository(
+    name = "rocm_external_test_deps",
+    deps = [
+        "//jaxlib/tools:jax_rocm_pjrt_py_import",
+        "//jaxlib/tools:jax_rocm_plugin_py_import",
+    ],
+)
 
 load("//:test_shard_count.bzl", "test_shard_count_repository")
 

--- a/jax_plugins/rocm/BUILD.bazel
+++ b/jax_plugins/rocm/BUILD.bazel
@@ -43,6 +43,7 @@ cc_binary(
     deps = [
         ":gpu_version_script.lds",
         "@xla//xla/pjrt/c:pjrt_c_api_gpu",
+        "@xla//xla/pjrt/c:pjrt_c_api_gpu_version_script.lds",
         "@xla//xla/service:gpu_plugin",
         "@xla//xla/stream_executor:rocm_platform",
     ],

--- a/jax_plugins/rocm/__init__.py
+++ b/jax_plugins/rocm/__init__.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""JAX ROCm plugin initialization module."""
+
 import functools
 import importlib
 import logging
 import os
+import os.path
 import pathlib
+import re
 
 from jax._src.lib import triton
 from jax._src.lib import xla_client
@@ -24,7 +28,7 @@ import jax._src.xla_bridge as xb
 
 # rocm_plugin_extension locates inside jaxlib. `jaxlib` is for testing without
 # preinstalled jax rocm plugin packages.
-for pkg_name in ['jax_rocm60_plugin', 'jaxlib.cuda']:
+for pkg_name in ['jax_rocm7_plugin', 'jax_rocm60_plugin', 'jaxlib.rocm']:
   try:
     rocm_plugin_extension = importlib.import_module(
         f'{pkg_name}.rocm_plugin_extension'
@@ -39,20 +43,16 @@ logger = logging.getLogger(__name__)
 
 def _get_library_path():
   base_path = pathlib.Path(__file__).resolve().parent
-  installed_path = (
-      base_path / 'xla_rocm_plugin.so'
-  )
+  installed_path = base_path / 'xla_rocm_plugin.so'
   if installed_path.exists():
     return installed_path
 
-  local_path = (
-      base_path / 'pjrt_c_api_gpu_plugin.so'
-  )
+  local_path = base_path / 'pjrt_c_api_gpu_plugin.so'
   if not local_path.exists():
     runfiles_dir = os.getenv('RUNFILES_DIR', None)
     if runfiles_dir:
       local_path = pathlib.Path(
-          os.path.join(runfiles_dir, '__main__/jax_plugins/rocm/pjrt_c_api_gpu_plugin.so')
+          os.path.join(runfiles_dir, 'xla/xla/pjrt/c/pjrt_c_api_gpu_plugin.so')
       )
 
   if local_path.exists():
@@ -77,10 +77,151 @@ def _get_library_path():
   return None
 
 
+def set_rocm_paths(path):
+  """Set ROCm environment paths for bitcode and linker."""
+  rocm_lib = None
+  try:
+    import rocm  # pylint: disable=import-outside-toplevel
+    rocm_lib = os.path.join(rocm.__path__[0], "lib")
+  except ImportError:
+    sp = path.parent.parent.parent
+    maybe_rocm_lib = os.path.join(sp, "rocm/lib")
+    if os.path.exists(maybe_rocm_lib):
+      rocm_lib = maybe_rocm_lib
+
+  if not rocm_lib:
+    logger.info("No ROCm wheel installation found")
+    return
+
+  logger.info("ROCm wheel install found at %r", rocm_lib)
+
+  bitcode_path = ""
+  lld_path = ""
+
+  for root, _dirs, files in os.walk(os.path.join(rocm_lib, "llvm")):
+    for f in files:
+      if f == "ocml.bc":
+        bitcode_path = root
+      if f == "ld.lld":
+        lld_path = root
+
+    if bitcode_path and lld_path:
+      break
+
+  if not bitcode_path:
+    logger.warning("jax_rocm_plugin couldn't locate amdgpu bitcode")
+  else:
+    logger.info("jax_rocm_plugin using bitcode found at %r", bitcode_path)
+
+  if not lld_path:
+    logger.warning("jax_rocm_plugin couldn't locate amdgpu ld.lld")
+  else:
+    logger.info("jax_rocm_plugin using ld.lld found at %r", lld_path)
+
+  os.environ["JAX_ROCM_PLUGIN_INTERNAL_BITCODE_PATH"] = bitcode_path
+  os.environ["HIP_DEVICE_LIB_PATH"] = bitcode_path
+  os.environ["JAX_ROCM_PLUGIN_INTERNAL_LLD_PATH"] = lld_path
+
+
+def count_amd_gpus(stop_at: int = None) -> int:
+  """Count AMD GPUs available via KFD kernel driver.
+
+  Checks for the presence of AMD GPUs by examining KFD kernel driver topology
+  nodes as a proxy. We use a non-zero simd_count as the trait of a GPU,
+  following the KFD implementation. We avoid initializing HIP here because
+  doing so might spoil a proper initialization of the rocprofiler-sdk later
+  during PJRT startup.
+
+  Args:
+      stop_at: If provided, stop counting once this many GPUs are found.
+
+  Returns:
+      The number of AMD GPUs detected (up to stop_at if provided).
+  """
+  try:
+    kfd_nodes_path = "/sys/class/kfd/kfd/topology/nodes/"
+    if not os.path.exists(kfd_nodes_path):
+      return 0
+
+    gpu_count = 0
+    r_simd_count = re.compile(r"\bsimd_count\s+(\d+)\b", re.MULTILINE)
+
+    for node in os.listdir(kfd_nodes_path):
+      node_props_path = os.path.join(kfd_nodes_path, node, "properties")
+      if not os.path.exists(node_props_path):
+        continue
+
+      try:
+        file_size = os.path.getsize(node_props_path)
+        if file_size <= 0 or file_size > 16 * 1024:
+          continue
+
+        with open(node_props_path, "r", encoding="ascii") as f:
+          match = r_simd_count.search(f.read())
+          if match:
+            simd_count = int(match.group(1))
+            if simd_count > 0:
+              gpu_count += 1
+              if stop_at is not None and gpu_count >= stop_at:
+                return gpu_count
+      except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.debug(
+            "Failed to read KFD node file '%s': %s", node_props_path, e
+        )
+        continue
+
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    logger.warning("Failed to count AMD GPUs: %s", e)
+  return gpu_count
+
+
+def check_shm_size(gpu_count: int = None):
+  """Check /dev/shm size and warn if it's too small for multi-GPU setups."""
+  try:
+    if gpu_count is None:
+      gpu_count = count_amd_gpus(stop_at=2)
+
+    if gpu_count < 2:
+      return
+
+    shm_path = "/dev/shm"
+    if not os.path.exists(shm_path):
+      return
+
+    stat = os.statvfs(shm_path)
+    shm_size_bytes = stat.f_blocks * stat.f_frsize
+    shm_size_mb = shm_size_bytes / (1024 * 1024)
+
+    if shm_size_mb <= 64:
+      logger.warning(
+          "Detected multiple GPUs but /dev/shm size is only %.1f MB. "
+          "RCCL may exhaust shared memory during multi-GPU operations, "
+          "causing runtime failures. Consider increasing /dev/shm size. "
+          "For example in Docker, use: --shm-size=64g",
+          shm_size_mb,
+      )
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    logger.debug("Failed to check /dev/shm size: %s", e)
+
+
 def initialize():
   path = _get_library_path()
   if path is None:
     return
+
+  set_rocm_paths(path)
+
+  if rocm_plugin_extension is None:
+    logger.warning('rocm_plugin_extension not found')
+    return
+
+  gpu_count = count_amd_gpus(stop_at=2)
+
+  if gpu_count == 0:
+    raise ValueError("No AMD GPUs were found, skipping ROCm plugin initialization")
+
+  check_shm_size(gpu_count)
+
   options = xla_client.generate_pjrt_gpu_plugin_options()
   options["platform_name"] = "ROCM"
   c_api = xb.register_plugin(

--- a/jax_plugins/rocm/plugin_setup.py
+++ b/jax_plugins/rocm/plugin_setup.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Setup script for JAX ROCm plugin package."""
+
 import importlib
 import os
 from setuptools import setup
@@ -26,6 +28,7 @@ package_name = f"jax_rocm{rocm_version}_plugin"
 default_rocm_path = "/opt/rocm"
 rocm_path = os.getenv("ROCM_PATH", default_rocm_path)
 rocm_detected_version = rocm_path.split('-')[-1] if '-' in rocm_path else "unknown"
+rocm_tag = os.getenv("ROCM_VERSION_EXTRA")
 
 def load_version_module(pkg_path):
   spec = importlib.util.spec_from_file_location(
@@ -36,6 +39,8 @@ def load_version_module(pkg_path):
 
 _version_module = load_version_module(package_name)
 __version__ = _version_module._get_version_for_build()
+if rocm_tag:
+  __version__ = __version__ + "+rocm" + rocm_tag
 _cmdclass = _version_module._get_cmdclass(package_name)
 
 class BinaryDistribution(Distribution):
@@ -72,4 +77,20 @@ setup(
     },
     zip_safe=False,
     distclass=BinaryDistribution,
+    extras_require={
+        "with_rocm": [
+            "amd_rocm_hip_runtime_devel_instinct",
+            "amd_rocm_hip_runtime_instinct",
+            "amd_hipblas_instinct",
+            "amd_hipsparse_instinct",
+            "amd_hipsolver_instinct",
+            "amd_miopen_hip_instinct",
+            "amd_rocm_llvm_instinct",
+            "amd_rocm_language_runtime_instinct",
+            "amd_rccl_instinct",
+            "amd_hipfft_instinct",
+            "amd_rocm_device_libs_instinct",
+            "amd_hipsparselt_instinct",
+        ],
+    },
 )

--- a/jax_plugins/rocm/setup.py
+++ b/jax_plugins/rocm/setup.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Setup script for JAX ROCm PJRT plugin package."""
+
 import importlib
 import os
 from setuptools import setup, find_namespace_packages
@@ -25,6 +27,7 @@ package_name = f"jax_plugins.xla_rocm{rocm_version}"
 default_rocm_path = "/opt/rocm"
 rocm_path = os.getenv("ROCM_PATH", default_rocm_path)
 rocm_detected_version = rocm_path.split('-')[-1] if '-' in rocm_path else "unknown"
+rocm_tag = os.getenv("ROCM_VERSION_EXTRA")
 
 def load_version_module(pkg_path):
   spec = importlib.util.spec_from_file_location(
@@ -35,6 +38,8 @@ def load_version_module(pkg_path):
 
 _version_module = load_version_module(f"jax_plugins/xla_rocm{rocm_version}")
 __version__ = _version_module._get_version_for_build()
+if rocm_tag:
+  __version__ = __version__ + "+rocm" + rocm_tag
 
 packages = find_namespace_packages(
     include=[

--- a/jaxlib/tools/BUILD.bazel
+++ b/jaxlib/tools/BUILD.bazel
@@ -285,20 +285,20 @@ jax_wheel(
     name = "jax_rocm_plugin_wheel",
     enable_rocm = True,
     no_abi = False,
-    platform_version = "60",
+    platform_version = "7",
     source_files = [":jax_plugin_sources"],
     wheel_binary = ":build_gpu_kernels_wheel_tool",
-    wheel_name = "jax_rocm60_plugin",
+    wheel_name = "jax_rocm7_plugin",
 )
 
 jax_wheel(
     name = "jax_rocm_plugin_wheel_editable",
     editable = True,
     enable_rocm = True,
-    platform_version = "60",
+    platform_version = "7",
     source_files = [":jax_plugin_sources"],
     wheel_binary = ":build_gpu_kernels_wheel_tool",
-    wheel_name = "jax_rocm60_plugin",
+    wheel_name = "jax_rocm7_plugin",
 )
 
 # JAX PJRT wheel targets.
@@ -394,20 +394,20 @@ jax_wheel(
     name = "jax_rocm_pjrt_wheel",
     enable_rocm = True,
     no_abi = True,
-    platform_version = "60",
+    platform_version = "7",
     source_files = [":jax_pjrt_sources"],
     wheel_binary = ":build_gpu_plugin_wheel_tool",
-    wheel_name = "jax_rocm60_pjrt",
+    wheel_name = "jax_rocm7_pjrt",
 )
 
 jax_wheel(
     name = "jax_rocm_pjrt_wheel_editable",
     editable = True,
     enable_rocm = True,
-    platform_version = "60",
+    platform_version = "7",
     source_files = [":jax_pjrt_sources"],
     wheel_binary = ":build_gpu_plugin_wheel_tool",
-    wheel_name = "jax_rocm60_pjrt",
+    wheel_name = "jax_rocm7_pjrt",
 )
 
 # Py_import targets.
@@ -463,6 +463,16 @@ py_import(
     name = "jax_cuda_pjrt_py_import",
     wheel = ":jax_cuda{cuda}_pjrt_wheel".format(cuda = cuda_major_version),
     wheel_deps = if_pypi_cuda_wheel_deps([":nvidia_wheel_deps"]),
+)
+
+py_import(
+    name = "jax_rocm_plugin_py_import",
+    wheel = ":jax_rocm_plugin_wheel",
+)
+
+py_import(
+    name = "jax_rocm_pjrt_py_import",
+    wheel = ":jax_rocm_pjrt_wheel",
 )
 
 # The targets below are used for GPU tests with `--//jax:build_jaxlib=false`.


### PR DESCRIPTION
Migrate changes from rocm-jax repo into upstream jax, so we are able to build the rocm plugin/pjrt wheels from within the jax repository itself.