### PR TITLE
Add vmap for hijax Box

### DIFF
--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -331,9 +331,17 @@ class BoxSet(HiPrimitive):
     box_set_p.bind(box_dot, *val_dots, treedef=treedef)
     return [], []
 
+  def batch(_, axis_data, args, dims, *, treedef):
+    box, *vals = args
+    box_dim, *val_dims = dims
+    assert box_dim is None, "box itself cannot be batched"
+    box_set_p.bind(box, *vals, treedef=treedef)
+    return [], []
+
   def transpose(_, *args, treedef):
     assert False  # TODO
 box_set_p = BoxSet('box_set')
+batching.fancy_primitive_batchers[box_set_p] = lambda axis_data, args, dims, **params: box_set_p.batch(axis_data, args, dims, **params)
 
 
 class BoxGet(HiPrimitive):

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -458,12 +458,14 @@ def _batch_jaxpr2(
   f, out_axes = _batch_jaxpr_inner(f, axis_data)
   f = _batch_jaxpr_outer(f, axis_data, in_axes)
   avals_in2 = []
-  for aval, b in unsafe_zip(closed_jaxpr.in_avals, in_axes):
+  for aval, b in unsafe_zip(closed_jaxpr.in_aval_qdds, in_axes):
     if b is not_mapped:
       avals_in2.append(aval)
     else:
+      # Unwrap AvalQDD to get the base aval for unmapping
+      base_aval = aval.aval if isinstance(aval, core.AvalQDD) else aval
       aval = core.unmapped_aval(
-          axis_data.size, b, aval, axis_data.explicit_mesh_axis)
+          axis_data.size, b, base_aval, axis_data.explicit_mesh_axis)
       if axis_data.spmd_name is not None:
         if config._check_vma.value:
           aval = aval.update(vma=aval.vma | frozenset(axis_data.spmd_name))  # type: ignore

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -1674,8 +1674,10 @@ class BoxTest(jtu.JaxTestCase):
         return jnp.sum(a)
     if jit:
       f = jax.jit(f)
-    jax.vmap(f, in_axes=(None, 0))(b, jnp.ones((4,5)))
-    assert 'forward' in b.get()
+    arr = jnp.ones((4,5))
+    jax.vmap(f, in_axes=(None, 0))(b, arr)
+    self.assertIn('forward', b.get())
+    self.assertArraysAllClose(b.get()['forward'], arr)
 
   def test_vmap_closure(self):
     b = Box({})
@@ -1683,8 +1685,10 @@ class BoxTest(jtu.JaxTestCase):
     def f(a):
         log_to_box(b, "forward", a)
         return jnp.sum(a)
-    jax.vmap(f, in_axes=(0))(jnp.ones((4,5)))
-    assert 'forward' in b.get()
+    arr = jnp.ones((4,5))
+    jax.vmap(f, in_axes=(0))(arr)
+    self.assertIn('forward', b.get())
+    self.assertArraysAllClose(b.get()['forward'], arr)
 
   @parameterized.parameters([False, True])
   def test_while_loop(self, jit):

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -1144,6 +1144,8 @@ class HijaxTest(jtu.JaxTestCase):
     self.assertEqual(f(2.0), 8.0)
     self.assertEqual(jax.linearize(f, 2.0)[1](1.0), 12.0)
 
+def log_to_box(box, name, value):
+    box.set({**box.get(), f'{name}': jax.lax.stop_gradient(value)})
 
 class BoxTest(jtu.JaxTestCase):
 
@@ -1663,6 +1665,26 @@ class BoxTest(jtu.JaxTestCase):
     f()
     self.assertEqual(box.get(), dict(a=5, b=3))
     self.assertEqual(box2.get(), 3)
+
+  @parameterized.parameters([False, True])
+  def test_vmap(self, jit):
+    b = Box({})
+    def f(b, a):
+        log_to_box(b, "forward", a)
+        return jnp.sum(a)
+    if jit:
+      f = jax.jit(f)
+    jax.vmap(f, in_axes=(None, 0))(b, jnp.ones((4,5)))
+    assert 'forward' in b.get()
+
+  def test_vmap_closure(self):
+    b = Box({})
+    @jax.jit
+    def f(a):
+        log_to_box(b, "forward", a)
+        return jnp.sum(a)
+    jax.vmap(f, in_axes=(0))(jnp.ones((4,5)))
+    assert 'forward' in b.get()
 
   @parameterized.parameters([False, True])
   def test_while_loop(self, jit):


### PR DESCRIPTION
This PR adds vmap support for the hijax Box type. Although Boxes themselves can't have axes to vmap, they can be broadcast as part of a vmap on another argument's axes. This PR adds tests to verify this.