### PR TITLE
[ROCm] Add ROCm pytest results collection

### DIFF
--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -93,7 +93,9 @@ on:
         description: "GCS location prefix from where the artifacts should be downloaded"
         default: 'gs://jax-nightly-artifacts/latest'
         type: string
-permissions: {}
+permissions:
+  id-token: write
+  contents: read
 
 env:
   UV_DEFAULT_INDEX: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
@@ -140,6 +142,7 @@ jobs:
         run: |
           $JAXCI_PYTHON -m pip install uv~=0.5.30
           $JAXCI_PYTHON -m uv pip install -r build/test-requirements.txt
+          $JAXCI_PYTHON -m pip install pytest-json-report
       # Halt for testing
       - name: Wait For Connection
         uses: google-ml-infra/actions/ci_connection@7f5ca0c263a81ed09ea276524c1b9192f1304e3c
@@ -148,3 +151,25 @@ jobs:
       - name: Run Pytest ROCm tests
         timeout-minutes: 120
         run: ./ci/run_pytest_rocm.sh
+      - name: Archive test logs
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          tar -czf logs.tar.gz logs
+      - name: Configure AWS Credentials
+        if: ${{ !cancelled() }}
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # ratchet:aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::661452401056:role/jax-ci-amd-s3-oidc
+          aws-region: us-east-1
+      - name: Upload test-artifacts to AMD S3
+        if: ${{ !cancelled() }}
+        env:
+          S3_BUCKET_NAME: jax-ci-amd
+          INPUT_PYTHON: ${{ inputs.python }}
+          INPUT_ROCM_VERSION: ${{ inputs.rocm-version }}
+          INPUT_RUNNER: ${{ inputs.runner }}
+          INPUT_ROCM_TAG: ${{ inputs.rocm-tag }}
+          IS_NIGHTLY: ${{ contains(github.workflow, 'Nightly/Release') && 'nightly' || 'continuous' }}
+        run: |
+          ./ci/upload_rocm_logs.sh

--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -173,6 +173,9 @@ jobs:
       clone_main_xla: 0
 
   run-pytest-rocm:
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/pytest_rocm.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure

--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -115,7 +115,10 @@ echo "Running ROCm tests..."
 # TODO: Verify if CSV/HTML report generation should be kept (unique to ROCm)
 # TODO: Verify if log file output should be kept (unique to ROCm)
 export NPROC=32
+LOGS_DIR="logs"
+mkdir -p "${LOGS_DIR}"
 "$JAXCI_PYTHON" -m pytest -n $num_processes --tb=short \
+--json-report --json-report-file=${LOGS_DIR}/pytest_results.json \
 tests \
 --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
 --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \

--- a/ci/upload_rocm_logs.sh
+++ b/ci/upload_rocm_logs.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Upload ROCm pytest artifacts to S3.
+#
+# Artifacts:
+#   - logs.tar.gz: archive of the local logs/ directory (pytest JSON + future logs)
+#   - run-manifest.json: small run metadata for indexing/debugging
+#   - _SUCCESS: written last to indicate the upload set is complete
+#
+# S3 layout (deterministic + unique per run/attempt):
+#   <org>/<repo>/<branch>/<nightly|continuous>/<DATE>_<run_id>_<attempt>/<combo>/
+set -euo pipefail
+
+: "${S3_BUCKET_NAME:?}"
+: "${INPUT_PYTHON:?}"
+: "${INPUT_ROCM_VERSION:?}"
+: "${INPUT_ROCM_TAG:?}"
+: "${INPUT_RUNNER:?}"
+: "${IS_NIGHTLY:?}"  # nightly|continuous
+
+TEST_LOGS_ROOT="jax-ci-test-logs"
+
+norm() { printf '%s' "$1" | tr '.-' '_' ; }
+
+# Timestamp: GitHub run_started_at from public Actions API; fall back to system date.
+RUN_STARTED_AT="$(
+  curl -fsSL \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+  | sed -n 's/.*"run_started_at"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+  | head -n1 || true
+)"
+
+DATE="${RUN_STARTED_AT%%T*}"
+[[ -n "${DATE}" ]] || DATE="$(date -u +%F)"
+
+# GPU count from runner name (e.g. linux-x86-64-8gpu-amd -> 8).
+GPU_COUNT=""
+if [[ "${INPUT_RUNNER}" =~ ([0-9]+)gpu ]]; then
+  GPU_COUNT="${BASH_REMATCH[1]}"
+fi
+
+GPU_PART="${GPU_COUNT:+gpu_${GPU_COUNT}}"
+GPU_PART="${GPU_PART:-${INPUT_RUNNER}}"
+
+RUN_KEY="${DATE}_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}"
+COMBO="py$(norm "${INPUT_PYTHON}")-rocm$(norm "${INPUT_ROCM_VERSION}")-${GPU_PART}"
+PREFIX="${GITHUB_REPOSITORY}/${GITHUB_REF_NAME}/${IS_NIGHTLY}/${RUN_KEY}/${COMBO}"
+
+DEST="s3://${S3_BUCKET_NAME}/${TEST_LOGS_ROOT}/${PREFIX}"
+
+echo "Uploading ROCm pytest artifacts"
+
+# Upload archive first (created in YAML)
+ARCHIVE="logs.tar.gz"
+[[ -f "${ARCHIVE}" ]] || { echo "Missing ${ARCHIVE}"; exit 2; }
+
+echo "Uploading logs.tar.gz"
+aws s3 cp --only-show-errors "${ARCHIVE}" "${DEST}/${ARCHIVE}"
+
+PYTHON="${JAXCI_PYTHON:-python3}"
+# Packages/wheels (best-effort)
+PKGS_RAW="$(
+  "${PYTHON}" -m pip list --format=freeze 2>/dev/null \
+  | grep -E '^(jax|jaxlib)==|pjrt|plugin' \
+  || true
+)"
+PKGS_ONE_LINE="$(printf "%s" "${PKGS_RAW}" | tr '\n' '|' | sed 's/|$//')"
+
+WHEELS_RAW="$(sha256sum dist/*.whl 2>/dev/null || true)"
+WHEELS_ONE_LINE="$(printf "%s" "${WHEELS_RAW}" | tr '\n' '|' | sed 's/|$//')"
+
+# Base image digest (best-effort)
+GHCR_REPO="rocm/jax-base-ubu24.${INPUT_ROCM_TAG}"
+IMAGE="ghcr.io/${GHCR_REPO}:latest"
+DIGEST=""
+
+TOKEN="$(
+  curl -fsSL "https://ghcr.io/token?service=ghcr.io&scope=repository:${GHCR_REPO}:pull" \
+  | sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+  || true
+)"
+if [[ -n "${TOKEN}" ]]; then
+  DIGEST="$(
+    curl -fsSL -D - \
+      -H "Authorization: Bearer ${TOKEN}" \
+      -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+      "https://ghcr.io/v2/${GHCR_REPO}/manifests/latest" -o /dev/null \
+    | awk -F': ' 'tolower($1)=="docker-content-digest"{print $2}' \
+    | tr -d $'\r' \
+    | head -n1 || true
+  )"
+fi
+
+RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+echo "Uploading run-manifest.json"
+aws s3 cp --only-show-errors - "${DEST}/run-manifest.json" <<EOF
+{
+  "schema_version": 1,
+  "run_started_at": "${RUN_STARTED_AT}",
+  "run_completed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "github_run_url": "${RUN_URL}",
+  "github_repository": "${GITHUB_REPOSITORY}",
+  "github_ref_name": "${GITHUB_REF_NAME}",
+  "github_ref": "${GITHUB_REF}",
+  "github_sha": "${GITHUB_SHA}",
+  "github_event_name": "${GITHUB_EVENT_NAME}",
+  "github_run_id": "${GITHUB_RUN_ID}",
+  "github_run_attempt": "${GITHUB_RUN_ATTEMPT}",
+  "github_run_number": "${GITHUB_RUN_NUMBER}",
+  "github_workflow": "${GITHUB_WORKFLOW}",
+  "is_nightly": "${IS_NIGHTLY}",
+  "github_job": "${GITHUB_JOB}",
+  "python_version": "${INPUT_PYTHON}",
+  "rocm_version": "${INPUT_ROCM_VERSION}",
+  "rocm_tag": "${INPUT_ROCM_TAG}",
+  "gpu_count": ${GPU_COUNT:-null},
+  "runner": "${INPUT_RUNNER}",
+  "base_image_name": "${IMAGE}",
+  "base_image_digest": "${DIGEST}",
+  "jax_packages_raw": "${PKGS_ONE_LINE}",
+  "wheels_sha_raw": "${WHEELS_ONE_LINE}"
+}
+EOF
+
+echo "Writing _SUCCESS"
+printf '' | aws s3 cp --only-show-errors - "${DEST}/_SUCCESS"


### PR DESCRIPTION
This PR extends ROCm pytest workflow to collect and store test artifacts.

Specifically, it:

- Generates structured `pytest_results.json`
- Archives the `logs/` dir for future extensibility
- Produces a minimal `run-manifest.json`
- Uploads the artifacts to shared S3