### PR TITLE
docs(lax): Add warning about dot_general batch invariance and floating-point non-associativity

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2426,6 +2426,14 @@ def dot(lhs: ArrayLike, rhs: ArrayLike, *args,
   If you really want to understand ``dot_general`` itself, we recommend reading XLA's
   DotGeneral_ operator documentation.
 
+  .. warning::
+    **Batch Invariance & Floating Point Non-Associativity:**
+    The exact hardware tiling strategy (and thus the order of additions) for ``dot_general``
+    can change depending on the batch and matrix dimensions. Due to floating-point
+    non-associativity, this can result in slight numerical deviations when computing the same
+    operation with different batch sizes. If exact numerical invariance across batch sizes is
+    required (e.g., in LLM serving), consider setting ``precision=jax.lax.Precision.HIGHEST``.
+
   Args:
     lhs: an array
     rhs: an array

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2427,7 +2427,7 @@ def dot(lhs: ArrayLike, rhs: ArrayLike, *args,
   DotGeneral_ operator documentation.
 
   .. warning::
-    **Batch Invariance & Floating Point Non-Associativity:**
+    **Batch Variance and Floating-Point Non-Associativity:**
     The exact hardware tiling strategy (and thus the order of additions) for ``dot_general``
     can change depending on the batch and matrix dimensions. Due to floating-point
     non-associativity, this can result in slight numerical deviations when computing the same


### PR DESCRIPTION
Fixes #34080 by clearly documenting the hardware-level mathematical reality of dot_general batch variance and providing explicit guidance on how to override it when deterministic accuracy is required (e.g., during LLM inference).