### PR TITLE
[ROCm] Implement Mosaic GPU detection and Auto-Skips

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -465,7 +465,9 @@ common:rbe_windows_amd64 --platforms="@xla//tools/toolchains/win2022:windows_lts
 # Test configs for ROCm (pytest run_under wrapper)
 build:rocm_single_gpu --run_under=//build/rocm:parallel_gpu_pytest
 build:rocm_multi_gpu --run_under=//build/rocm:parallel_gpu_pytest
+
 build:rocm_pytest --run_under=//build/rocm:parallel_gpu_pytest
+
 # #############################################################################
 # Cross-compile config options below. Native RBE support does not exist for
 # Linux Aarch64 and Mac x86. So, we use a cross-compile toolchain to build

--- a/.bazelrc
+++ b/.bazelrc
@@ -462,6 +462,10 @@ common:rbe_windows_amd64 --host_platform="@xla//tools/toolchains/win2022:windows
 common:rbe_windows_amd64 --extra_execution_platforms="@xla//tools/toolchains/win2022:windows_ltsc2022_clang_new"
 common:rbe_windows_amd64 --platforms="@xla//tools/toolchains/win2022:windows_ltsc2022_clang_new"
 
+# Test configs for ROCm (pytest run_under wrapper)
+build:rocm_single_gpu --run_under=//build/rocm:parallel_gpu_pytest
+build:rocm_multi_gpu --run_under=//build/rocm:parallel_gpu_pytest
+build:rocm_pytest --run_under=//build/rocm:parallel_gpu_pytest
 # #############################################################################
 # Cross-compile config options below. Native RBE support does not exist for
 # Linux Aarch64 and Mac x86. So, we use a cross-compile toolchain to build

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,11 @@ load(
     "wheel_sources",
 )
 
+exports_files(
+    ["conftest.py"],
+    visibility = ["//visibility:public"],
+)
+
 wheel_sources(
     name = "jax_sources",
     data_srcs = ["//jax"],

--- a/build/rocm/BUILD
+++ b/build/rocm/BUILD
@@ -1,0 +1,28 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "parallel_gpu_pytest",
+    srcs = ["parallel_gpu_pytest.sh"],
+    data = [
+        "@local_config_rocm//rocm:rocminfo",
+        "@pypi//pytest",
+    ],
+)

--- a/build/rocm/parallel_gpu_pytest.sh
+++ b/build/rocm/parallel_gpu_pytest.sh
@@ -25,12 +25,82 @@ ROCMINFO=$(find "external/local_config_rocm/rocm/rocm_dist/" -name "rocminfo" -p
 TF_GPU_COUNT=$($ROCMINFO | grep "Name: *gfx*" | wc -l)
 TF_TESTS_PER_GPU=${TF_TESTS_PER_GPU:-8}
 
+# Helper functions for `--config=rocm_pytest`: rules_python test stubs embed
+# runfiles-relative paths for the hermetic Python (`PYTHON_BINARY`) and test
+# entrypoint (`MAIN`). We resolve those paths across runfiles layouts so pytest
+# can apply node-level filtering like `-m "not mosaic_gpu"` reliably.
+extract_python_stub_var() {
+  # `--config=rocm_pytest` sets `--run_under=//build/rocm:parallel_gpu_pytest`.
+  # Not every Bazel "test" target is a Python/pytest test, so we first detect
+  # rules_python-generated stubs and extract the embedded Python entrypoints.
+  local var_name="$1"
+  local stub_file="$2"
+  # Typical rules_python stubs embed values like:
+  #   PYTHON_BINARY = '...'
+  #   MAIN = '...'
+  local line=""
+  local val=""
+  line="$(grep -m1 -E "^[[:space:]]*${var_name} = " "$stub_file" 2>/dev/null || true)"
+  # Newer rules_python stubs may not define `MAIN = ...`; instead they embed the
+  # entrypoint as `main_rel_path = '__main__/path/to/test.py'`.
+  if [[ -z "${line}" && "${var_name}" == "MAIN" ]]; then
+    line="$(grep -m1 -E "^[[:space:]]*main_rel_path = " "$stub_file" 2>/dev/null || true)"
+  fi
+  [[ -z "${line}" ]] && return 0
+  # Handle common forms like:
+  #   VAR = '...'
+  #   VAR = "..."
+  #   VAR = r'...'
+  #   VAR = r"..."
+  # and allow trailing comments.
+  if [[ "${var_name}" == "MAIN" && "${line}" =~ ^[[:space:]]*main_rel_path[[:space:]]*= ]]; then
+    val="$(printf '%s\n' "${line}" | sed -E "s/^[[:space:]]*main_rel_path = r?['\\\"](.*)['\\\"][[:space:]]*(#.*)?$/\\1/" || true)"
+  else
+    val="$(printf '%s\n' "${line}" | sed -E "s/^[[:space:]]*${var_name} = r?['\\\"](.*)['\\\"][[:space:]]*(#.*)?$/\\1/" || true)"
+  fi
+  [[ "${val}" == "${line}" ]] && val=""
+  printf '%s' "${val}"
+}
+
+resolve_runfiles_path() {
+  # Resolve a stub-provided runfiles-relative path to an absolute path.
+  # We prefer `${TEST_SRCDIR}/<rel>` but fall back to `${TEST_SRCDIR}/__main__/<rel>`
+  # since some stubs refer to paths rooted at the main repo.
+  local rel="$1"
+  if [[ -z "$rel" ]]; then
+    return 1
+  fi
+  if [[ -e "${TEST_SRCDIR}/${rel}" ]]; then
+    echo "${TEST_SRCDIR}/${rel}"
+    return 0
+  fi
+  if [[ -e "${TEST_SRCDIR}/__main__/${rel}" ]]; then
+    echo "${TEST_SRCDIR}/__main__/${rel}"
+    return 0
+  fi
+  return 1
+}
+
 # Resolve hermetic Python, test .py file, and PYTHONPATH from runfiles.
 setup_pytest_env() {
   local test_bin="$1"
-  HERMETIC_PY_REL=$(grep "^PYTHON_BINARY = " "$test_bin" | sed "s/PYTHON_BINARY = '\\(.*\\)'/\\1/")
-  HERMETIC_PY="${TEST_SRCDIR}/${HERMETIC_PY_REL}"
-  TEST_PY=$(echo "$test_bin" | sed -E 's/_(gpu|cpu|tpu)$//').py
+  HERMETIC_PY_REL="$(extract_python_stub_var "PYTHON_BINARY" "$test_bin" || true)"
+  MAIN_REL="$(extract_python_stub_var "MAIN" "$test_bin" || true)"
+
+  # If this isn't a rules_python stub, we can't run it via pytest.
+  if [[ -z "${HERMETIC_PY_REL}" ]]; then
+    return 1
+  fi
+
+  HERMETIC_PY="$(resolve_runfiles_path "${HERMETIC_PY_REL}")"
+  if [[ -z "${HERMETIC_PY:-}" || ! -x "${HERMETIC_PY}" ]]; then
+    return 1
+  fi
+
+  TEST_PY="$(resolve_runfiles_path "${MAIN_REL}")"
+  if [[ -z "${TEST_PY:-}" || ! -f "${TEST_PY}" ]]; then
+    return 1
+  fi
 
   PYPATH="${TEST_SRCDIR}/__main__"
   for d in "${TEST_SRCDIR}"/pypi_*/site-packages; do
@@ -46,29 +116,85 @@ setup_pytest_env() {
 # Separate pytest args (-k, -v, -x, etc.) from absltest/JAX flags.
 # JAX flags are exported as environment variables instead.
 parse_pytest_args() {
+  # Split args into:
+  # - `PYTEST_ARGS`: forwarded to `pytest` (supports node-level filtering, e.g.
+  #   `-m "not mosaic_gpu"` to skip Mosaic GPU tests on ROCm).
+  # - `PASSTHRU_ARGS`: forwarded to non-python test binaries (so `--config=rocm_pytest`
+  #   doesn't break non-pytest targets by passing `-m/-k/...`).
   PYTEST_ARGS=()
+  PASSTHRU_ARGS=()
   local skip_next=false
+  local saw_marker=false
   for arg in "$@"; do
     if $skip_next; then
       PYTEST_ARGS+=("$arg")
       skip_next=false
-    elif [[ "$arg" == "-k" || "$arg" == "-v" || "$arg" == "-x" || "$arg" == "-s" ]]; then
+    elif [[ "$arg" == "-k" || "$arg" == "-m" || "$arg" == "-v" || "$arg" == "-x" || "$arg" == "-s" || "$arg" == -r* ]]; then
       PYTEST_ARGS+=("$arg")
-      [[ "$arg" == "-k" ]] && skip_next=true
+      [[ "$arg" == "-m" ]] && saw_marker=true
+      [[ "$arg" == "-k" || "$arg" == "-m" ]] && skip_next=true
     elif [[ "$arg" == --jax_test_dut=* ]]; then
       export JAX_TEST_DUT="${arg#*=}"
     elif [[ "$arg" == --jax_platform_name=* ]]; then
-      export JAX_PLATFORMS="${arg#*=}"
+      export JAX_PLATFORM_NAME="${arg#*=}"
+    else
+      PASSTHRU_ARGS+=("$arg")
     fi
   done
+}
+
+run_pytest() {
+  # Run the underlying Python test under pytest so marker/node-level filtering
+  # from `--config=rocm_pytest` works uniformly on ROCm.
+  # Ensure pytest discovers the repo-level `conftest.py` in runfiles. Without
+  # this, `-m "not mosaic_gpu"` can become a no-op because the `mosaic_gpu`
+  # marker is applied by `conftest.py`.
+  # Bazel sharding support: when a test target is sharded (shard_count > 1),
+  # Bazel expects the test runner to indicate sharding support by touching
+  # TEST_SHARD_STATUS_FILE. We only do this when we actually run pytest.
+  if [[ -n "${TEST_SHARD_STATUS_FILE:-}" ]]; then
+    touch "${TEST_SHARD_STATUS_FILE}" 2>/dev/null || true
+  fi
+
+  local pytest_rootdir=""
+  if [[ -n "${TEST_SRCDIR:-}" && -f "${TEST_SRCDIR}/__main__/conftest.py" ]]; then
+    pytest_rootdir="${TEST_SRCDIR}/__main__"
+  elif [[ -n "${TEST_SRCDIR:-}" && -f "${TEST_SRCDIR}/conftest.py" ]]; then
+    pytest_rootdir="${TEST_SRCDIR}"
+  fi
+
+  if [[ -n "${pytest_rootdir}" ]]; then
+    "$HERMETIC_PY" -m pytest --rootdir="${pytest_rootdir}" --confcutdir="${pytest_rootdir}" "$TEST_PY" "${PYTEST_ARGS[@]}"
+  else
+    "$HERMETIC_PY" -m pytest "$TEST_PY" "${PYTEST_ARGS[@]}"
+  fi
+  local rc=$?
+  # pytest uses exit code 5 when no tests were selected/collected (e.g. marker
+  # filters deselect everything). Treat that as success for Bazel runs.
+  if [[ $rc -eq 5 ]]; then
+    return 0
+  fi
+  return $rc
+}
+
+run_passthru() {
+  # For non-python tests we still run under the GPU lock, but we must not pass
+  # pytest-only arguments (-m/-k/...) that came from --config=rocm_pytest.
+  "$TEST_BINARY" "${PASSTHRU_ARGS[@]}"
 }
 
 if [[ $TF_GPU_COUNT == 0 ]]; then
     echo "Execute with no GPU support (pytest mode)"
     TEST_BIN="$1"; shift
-    setup_pytest_env "$TEST_BIN"
     parse_pytest_args "$@"
-    exec "$HERMETIC_PY" -m pytest "$TEST_PY" "${PYTEST_ARGS[@]}"
+    if setup_pytest_env "$TEST_BIN"; then
+      run_pytest
+      exit $?
+    else
+      TEST_BINARY="$TEST_BIN"
+      run_passthru
+      exit $?
+    fi
 fi
 
 function is_absolute {
@@ -100,9 +226,12 @@ for j in $(seq 0 $((TF_TESTS_PER_GPU-1))); do
         export CUDA_VISIBLE_DEVICES=$i
         export HIP_VISIBLE_DEVICES=$i
         echo "Running test $TEST_BINARY $* on GPU $CUDA_VISIBLE_DEVICES (pytest mode)"
-        setup_pytest_env "$TEST_BINARY"
         parse_pytest_args "$@"
-        "$HERMETIC_PY" -m pytest "$TEST_PY" "${PYTEST_ARGS[@]}"
+        if setup_pytest_env "$TEST_BINARY"; then
+          run_pytest
+        else
+          run_passthru
+        fi
       )
       return_code=$?
       flock -u "$lock_fd"

--- a/build/rocm/parallel_gpu_pytest.sh
+++ b/build/rocm/parallel_gpu_pytest.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# A script to run GPU tests via pytest in parallel, controlled with an
+# environment variable. Wraps the Bazel test binary to invoke pytest with the
+# hermetic Python interpreter, enabling pytest-style negative filtering (-k).
+#
+# Required environment variables:
+#     TF_GPU_COUNT = Number of GPUs available (auto-detected via rocminfo).
+
+ROCMINFO=$(find "external/local_config_rocm/rocm/rocm_dist/" -name "rocminfo" -path "*/bin/rocminfo")
+TF_GPU_COUNT=$($ROCMINFO | grep "Name: *gfx*" | wc -l)
+TF_TESTS_PER_GPU=${TF_TESTS_PER_GPU:-8}
+
+# Resolve hermetic Python, test .py file, and PYTHONPATH from runfiles.
+setup_pytest_env() {
+  local test_bin="$1"
+  HERMETIC_PY_REL=$(grep "^PYTHON_BINARY = " "$test_bin" | sed "s/PYTHON_BINARY = '\\(.*\\)'/\\1/")
+  HERMETIC_PY="${TEST_SRCDIR}/${HERMETIC_PY_REL}"
+  TEST_PY=$(echo "$test_bin" | sed -E 's/_(gpu|cpu|tpu)$//').py
+
+  PYPATH="${TEST_SRCDIR}/__main__"
+  for d in "${TEST_SRCDIR}"/pypi_*/site-packages; do
+    [[ -d "$d" ]] && PYPATH="${PYPATH}:${d}"
+  done
+  for d in "${TEST_SRCDIR}"/__main__/jaxlib/tools/*_py_import_unpacked_wheel; do
+    [[ -d "$d" ]] && PYPATH="${PYPATH}:${d}"
+  done
+  export PYTHONPATH="${PYPATH}${PYTHONPATH:+:$PYTHONPATH}"
+  export RUNFILES_DIR="${TEST_SRCDIR}"
+}
+
+# Separate pytest args (-k, -v, -x, etc.) from absltest/JAX flags.
+# JAX flags are exported as environment variables instead.
+parse_pytest_args() {
+  PYTEST_ARGS=()
+  local skip_next=false
+  for arg in "$@"; do
+    if $skip_next; then
+      PYTEST_ARGS+=("$arg")
+      skip_next=false
+    elif [[ "$arg" == "-k" || "$arg" == "-v" || "$arg" == "-x" || "$arg" == "-s" ]]; then
+      PYTEST_ARGS+=("$arg")
+      [[ "$arg" == "-k" ]] && skip_next=true
+    elif [[ "$arg" == --jax_test_dut=* ]]; then
+      export JAX_TEST_DUT="${arg#*=}"
+    elif [[ "$arg" == --jax_platform_name=* ]]; then
+      export JAX_PLATFORMS="${arg#*=}"
+    fi
+  done
+}
+
+if [[ $TF_GPU_COUNT == 0 ]]; then
+    echo "Execute with no GPU support (pytest mode)"
+    TEST_BIN="$1"; shift
+    setup_pytest_env "$TEST_BIN"
+    parse_pytest_args "$@"
+    exec "$HERMETIC_PY" -m pytest "$TEST_PY" "${PYTEST_ARGS[@]}"
+fi
+
+function is_absolute {
+  [[ "$1" = /* ]] || [[ "$1" =~ ^[a-zA-Z]:[/\\].* ]]
+}
+
+export TF_PER_DEVICE_MEMORY_LIMIT_MB=${TF_PER_DEVICE_MEMORY_LIMIT_MB:-4096}
+
+RUNFILES_MANIFEST_FILE="${TEST_SRCDIR}/MANIFEST"
+function rlocation() {
+  if is_absolute "$1" ; then
+    echo "$1"
+  elif [[ -e "$TEST_SRCDIR/$1" ]]; then
+    echo "$TEST_SRCDIR/$1"
+  elif [[ -e "$RUNFILES_MANIFEST_FILE" ]]; then
+    echo "$(grep "^$1 " "$RUNFILES_MANIFEST_FILE" | sed 's/[^ ]* //')"
+  fi
+}
+
+TEST_BINARY="$(rlocation $TEST_WORKSPACE/${1#./})"
+shift
+
+mkdir -p /var/lock
+for j in $(seq 0 $((TF_TESTS_PER_GPU-1))); do
+  for i in $(seq 0 $((TF_GPU_COUNT-1))); do
+    exec {lock_fd}>/var/lock/gpulock${i}_${j} || exit 1
+    if flock -n "$lock_fd"; then
+      (
+        export CUDA_VISIBLE_DEVICES=$i
+        export HIP_VISIBLE_DEVICES=$i
+        echo "Running test $TEST_BINARY $* on GPU $CUDA_VISIBLE_DEVICES (pytest mode)"
+        setup_pytest_env "$TEST_BINARY"
+        parse_pytest_args "$@"
+        "$HERMETIC_PY" -m pytest "$TEST_PY" "${PYTEST_ARGS[@]}"
+      )
+      return_code=$?
+      flock -u "$lock_fd"
+      exit $return_code
+    fi
+  done
+done
+
+echo "Cannot find a free GPU to run the test $* on, exiting with failure..."
+exit 1

--- a/build/rocm/rocm_tag_filters.sh
+++ b/build/rocm/rocm_tag_filters.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Helper for ROCm CI scripts to compute Bazel tag filters and pytest args.
+#
+# Intended usage:
+#   source build/rocm/rocm_tag_filters.sh "$@"
+#
+# Exports:
+#   ROCM_TAG_FILTERS: Bazel tag filter string.
+#   ROCM_PYTEST_MARKER_EXPR: Optional pytest marker expression to pass via `-m`.
+#     When unset/empty, pytest will collect all tests and rely on `conftest.py`
+#     to mark Mosaic GPU tests and skip them on ROCm (so CI reports explicit
+#     SKIPPED instead of deselection).
+#   ROCM_LOCAL_TEST_JOBS: Optional Bazel concurrency cap for tests. If unset,
+#     the caller can pass Bazel flags like --test_jobs=N / --local_test_jobs=N
+#     explicitly. For multiaccelerator runs we default to 1 unless overridden.
+set -euo pipefail
+
+: "${ROCM_PYTEST_MARKER_EXPR:=}"
+: "${ROCM_LOCAL_TEST_JOBS:=}"
+
+ROCM_TAG_FILTERS="jax_test_gpu,-config-cuda-only,-manual"
+
+_saw_multi=0
+_saw_single=0
+for arg in "$@"; do
+  case "$arg" in
+    --config=multi_gpu|--config=rocm_multi_gpu)
+      _saw_multi=1
+      ;;
+    --config=single_gpu|--config=rocm_single_gpu)
+      _saw_single=1
+      ;;
+  esac
+done
+
+if [[ $_saw_multi -eq 1 ]]; then
+  ROCM_TAG_FILTERS="${ROCM_TAG_FILTERS},multiaccelerator"
+elif [[ $_saw_single -eq 1 ]]; then
+  ROCM_TAG_FILTERS="${ROCM_TAG_FILTERS},gpu,-multiaccelerator"
+fi
+
+if [[ -z "$ROCM_LOCAL_TEST_JOBS" && $_saw_multi -eq 1 ]]; then
+  # Multiaccelerator tests typically consume all GPUs on the machine.
+  ROCM_LOCAL_TEST_JOBS=1
+fi
+
+export ROCM_TAG_FILTERS
+export ROCM_PYTEST_MARKER_EXPR
+export ROCM_LOCAL_TEST_JOBS
+

--- a/ci/run_bazel_test_rocm_rbe.sh
+++ b/ci/run_bazel_test_rocm_rbe.sh
@@ -29,16 +29,28 @@ source ci/envs/default.env
 # Run Bazel GPU tests with RBE (single accelerator tests with one GPU apiece).
 echo "Running RBE GPU tests..."
 
-TAG_FILTERS="jax_test_gpu,-config-cuda-only,-manual"
+source build/rocm/rocm_tag_filters.sh "$@"
+TAG_FILTERS="${ROCM_TAG_FILTERS}"
 
-for arg in "$@"; do
-    if [[ "$arg" == "--config=multi_gpu" ]]; then
-        TAG_FILTERS="${TAG_FILTERS},multiaccelerator"
-    fi
-    if [[ "$arg" == "--config=single_gpu" ]]; then
-        TAG_FILTERS="${TAG_FILTERS},gpu,-multiaccelerator"
-    fi
-done
+BAZEL_ARGS=(
+    --config=rocm_rbe
+    --config=rocm
+    --config=rocm_pytest
+    --repo_env=HERMETIC_PYTHON_VERSION="$JAXCI_HERMETIC_PYTHON_VERSION"
+    --test_env=XLA_PYTHON_CLIENT_ALLOCATOR=platform
+    --test_output=errors
+    --test_env=TF_CPP_MIN_LOG_LEVEL=0
+    --test_env=JAX_EXCLUDE_TEST_TARGETS=PmapTest.testSizeOverflow
+    --build_tag_filters="${TAG_FILTERS}"
+    --test_tag_filters="${TAG_FILTERS}"
+    --remote_download_outputs=minimal
+    --test_env=JAX_SKIP_SLOW_TESTS=true
+    --action_env=JAX_ENABLE_X64="$JAXCI_ENABLE_X64"
+    --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a,gfx942,gfx950"
+    --color=yes
+    --//jax:build_jaxlib=$JAXCI_BUILD_JAXLIB
+    --//jax:build_jax=$JAXCI_BUILD_JAX
+)
 
 # Set up the build environment which sets XLA_DIR if needed.
 # Useful for matching the XLA version to the JAX version and debugging/testing.
@@ -49,26 +61,15 @@ if [[ "$JAXCI_CLONE_MAIN_XLA" == 1 ]]; then
   OVERRIDE_XLA_REPO="--override_repository=xla=${JAXCI_XLA_GIT_DIR}"
 fi
 
+if [[ -n "${ROCM_LOCAL_TEST_JOBS:-}" ]]; then
+  BAZEL_ARGS+=(--jobs="${ROCM_LOCAL_TEST_JOBS}")
+  BAZEL_ARGS+=(--local_test_jobs="${ROCM_LOCAL_TEST_JOBS}")
+fi
 
 bazel --bazelrc=build/rocm/rocm.bazelrc test \
-    --config=rocm_rbe \
-    --config=rocm \
-    --repo_env=HERMETIC_PYTHON_VERSION="$JAXCI_HERMETIC_PYTHON_VERSION" \
+    "${BAZEL_ARGS[@]}" \
     $OVERRIDE_XLA_REPO \
-    --test_env=XLA_PYTHON_CLIENT_ALLOCATOR=platform \
-    --test_output=errors \
-    --test_env=TF_CPP_MIN_LOG_LEVEL=0 \
-    --test_env=JAX_EXCLUDE_TEST_TARGETS=PmapTest.testSizeOverflow \
-    --build_tag_filters=${TAG_FILTERS} \
-    --test_tag_filters=${TAG_FILTERS} \
-    --remote_download_outputs=minimal \
-    --test_env=JAX_SKIP_SLOW_TESTS=true \
-    --action_env=JAX_ENABLE_X64="$JAXCI_ENABLE_X64" \
-    --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a,gfx942,gfx950" \
-    --color=yes \
-    --//jax:build_jaxlib=$JAXCI_BUILD_JAXLIB \
-    --//jax:build_jax=$JAXCI_BUILD_JAX \
-    $@ \
+    "$@" \
     -- \
     //tests:gpu_tests \
     //tests:backend_independent_tests \

--- a/conftest.py
+++ b/conftest.py
@@ -13,8 +13,89 @@
 # limitations under the License.
 """pytest configuration"""
 
+import inspect
 import os
+
 import pytest
+
+from jax._src.internal_test_util import mosaic_gpu_test_filter as _mosaic_filter
+
+
+def _is_mosaic_gpu_item(
+    item: pytest.Item,
+    cache: dict[object, bool],
+    *,
+    running_on_rocm: bool,
+    pallas_defaults_to_mosaic: bool,
+) -> bool:
+  """Returns True if this test item uses Mosaic GPU."""
+  path_obj = getattr(item, "path", None) or getattr(item, "fspath", None)
+  path_str = str(path_obj) if path_obj is not None else ""
+
+  if _mosaic_filter.looks_like_mosaic_gpu_path(path_str):
+    return True
+
+  obj = getattr(item, "obj", None)
+  if obj is None:
+    return False
+  if obj in cache:
+    return cache[obj]
+  try:
+    src = inspect.getsource(obj)
+  except (TypeError, OSError):
+    cache[obj] = False
+    return False
+
+  cls_src = None
+  cls_obj = getattr(item, "cls", None)
+  if cls_obj is not None:
+    try:
+      cls_src = inspect.getsource(cls_obj)
+    except (TypeError, OSError):
+      cls_src = None
+
+  is_mosaic = _mosaic_filter.is_mosaic_gpu_test_source(
+      path_str=path_str,
+      test_src=src,
+      cls_src=cls_src,
+      running_on_rocm=running_on_rocm,
+      pallas_defaults_to_mosaic=pallas_defaults_to_mosaic,
+  )
+  cache[obj] = is_mosaic
+  return is_mosaic
+
+
+def pytest_configure(config: pytest.Config) -> None:
+  """Register custom pytest markers."""
+  config.addinivalue_line(
+      "markers",
+      "mosaic_gpu: tests that use Mosaic GPU (skipped on ROCm)",
+  )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+  """Mark Mosaic GPU tests and skip them on ROCm."""
+  running_on_rocm = _mosaic_filter.running_on_rocm()
+  pallas_defaults_to_mosaic = (
+      _mosaic_filter.pallas_defaults_to_mosaic_gpu() if running_on_rocm else False
+  )
+  cache: dict[object, bool] = {}
+  for item in items:
+    is_mosaic_gpu = _is_mosaic_gpu_item(
+        item,
+        cache,
+        running_on_rocm=running_on_rocm,
+        pallas_defaults_to_mosaic=pallas_defaults_to_mosaic,
+    )
+    if not is_mosaic_gpu:
+      continue
+    item.add_marker(pytest.mark.mosaic_gpu)
+    if running_on_rocm:
+      item.add_marker(pytest.mark.skip(
+          reason="Mosaic GPU tests are not supported on ROCm"
+      ))
 
 
 @pytest.fixture(autouse=True)

--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -99,11 +99,13 @@ pytype_strict_library(
         "internal_test_util/__init__.py",
         "internal_test_util/deprecation_module.py",
         "internal_test_util/lax_test_util.py",
+        "internal_test_util/mosaic_gpu_test_filter.py",
     ] + glob(
         [
             "internal_test_util/lazy_loader_module/*.py",
         ],
     ),
+    data = ["//:conftest.py"],
     visibility = ["//jax:internal"],
     deps = if_building_jaxlib(
         if_building = [

--- a/jax/_src/internal_test_util/mosaic_gpu_test_filter.py
+++ b/jax/_src/internal_test_util/mosaic_gpu_test_filter.py
@@ -1,0 +1,137 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Mosaic GPU test filter used to automatically mark tests as Mosaic GPU
+tests and skip them on ROCm.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+
+
+# Keep these heuristics lightweight: they are used during test execution.
+_MOSAIC_GPU_PATH_NEEDLES = (
+    f"{os.sep}tests{os.sep}mosaic{os.sep}",
+    f"{os.sep}tests{os.sep}pallas{os.sep}mgpu_",
+    f"{os.sep}tests{os.sep}pallas{os.sep}mosaic_gpu",
+    f"{os.sep}tests{os.sep}pallas{os.sep}mosaic",
+)
+
+_MOSAIC_GPU_SOURCE_NEEDLES = (
+    # Mosaic GPU usage substrings (avoid import-only signals).
+    "inline_mgpu",
+    "plgpu_mgpu.",
+    "mosaic_gpu_interpret",
+    "mosaic_gpu_backend",
+    "jax.experimental.mosaic.gpu",
+    "jax.experimental.pallas.mosaic_gpu",
+)
+
+
+def looks_like_mosaic_gpu_path(path_str: str) -> bool:
+  lowered = path_str.lower()
+  return any(n.lower() in lowered for n in _MOSAIC_GPU_PATH_NEEDLES)
+
+
+def source_mentions_mosaic_gpu(src_lowered: str) -> bool:
+  return any(n in src_lowered for n in _MOSAIC_GPU_SOURCE_NEEDLES)
+
+
+@functools.lru_cache(maxsize=None)
+def class_mosaic_override_from_source(cls_src_lowered: str) -> bool | None:
+  """Detects explicit class-level Mosaic enable/disable.
+
+  Returns:
+    - True if the class forces Mosaic GPU (`_PALLAS_USE_MOSAIC_GPU(True)`).
+    - False if it forces Triton (`_PALLAS_USE_MOSAIC_GPU(False)`).
+    - None if no explicit override is found.
+  """
+  if "_pallas_use_mosaic_gpu(true" in cls_src_lowered:
+    return True
+  if "_pallas_use_mosaic_gpu(false" in cls_src_lowered:
+    return False
+  return None
+
+
+def is_mosaic_gpu_test_source(
+    *,
+    path_str: str,
+    test_src: str,
+    cls_src: str | None,
+    running_on_rocm: bool,
+    pallas_defaults_to_mosaic: bool,
+) -> bool:
+  """Best-effort detection of Mosaic GPU usage for a single test case."""
+  if looks_like_mosaic_gpu_path(path_str):
+    return True
+
+  lowered = (test_src or "").lower()
+  if source_mentions_mosaic_gpu(lowered):
+    return True
+
+  cls_src_lowered = (cls_src or "").lower()
+  cls_override = class_mosaic_override_from_source(cls_src_lowered) if cls_src else None
+  if cls_override is True:
+    return True
+  if cls_override is False:
+    return False
+
+  if running_on_rocm and pallas_defaults_to_mosaic:
+    uses_pallas_call = (
+        ".pallas_call" in lowered
+        or "pl.pallas_call" in lowered
+        or "pallas_call(" in lowered
+    )
+    explicitly_selects_compiler = "compiler_params=" in lowered
+    if uses_pallas_call and not explicitly_selects_compiler:
+      return True
+
+  return False
+
+
+def running_on_rocm() -> bool:
+  """Best-effort ROCm detection.
+
+  First tries to check rocm in jaxlib version, falls back to checking backend
+  platform_version so that it works for ROCm PJRT plugin installs where jaxlib's
+  version tag may not contain rocm.
+  """
+  try:
+    import jaxlib.version as jaxlib_version  # pytype: disable=import-error
+    version_str = getattr(jaxlib_version, "__version__", "")
+  except ImportError:
+    version_str = ""
+  if "rocm" in str(version_str).lower():
+    return True
+
+  try:
+    import jax  # pytype: disable=import-error  # noqa: F401
+    from jax._src import xla_bridge  # pytype: disable=import-error
+    backend = xla_bridge.get_backend()
+    pv = getattr(backend, "platform_version", "") or ""
+    return "rocm" in str(pv).lower()
+  except (ImportError, RuntimeError):
+    return False
+
+
+def pallas_defaults_to_mosaic_gpu() -> bool:
+  """Returns True if Pallas GPU lowering defaults to Mosaic GPU."""
+  try:
+    from jax._src.pallas import pallas_call as pallas_call_lib  # pytype: disable=import-error
+    return bool(pallas_call_lib._PALLAS_USE_MOSAIC_GPU.value)  # pylint: disable=protected-access
+  except (ImportError, AttributeError):
+    return False

--- a/jaxlib/jax.bzl
+++ b/jaxlib/jax.bzl
@@ -278,6 +278,12 @@ def jax_multiplatform_test(
     env = dict(env)
     env.setdefault("PYTHONWARNINGS", "error")
 
+    internal_test_util = "//jax/_src:internal_test_util"
+    if type(deps) == type([]) or type(deps) == type(()):
+        deps = list(deps)
+        if internal_test_util not in deps:
+            deps.append(internal_test_util)
+
     for backend in ALL_BACKENDS:
         test_shard_count = minimal_shard_count if USE_MINIMAL_SHARD_COUNT else shard_count
         if test_shard_count == None or type(test_shard_count) == type(0):
@@ -628,7 +634,14 @@ def jax_py_test(
         **kwargs):
     env = dict(env)
     env.setdefault("PYTHONWARNINGS", "error")
+
     deps = kwargs.get("deps", [])
+    internal_test_util = "//jax/_src:internal_test_util"
+    if type(deps) == type([]) or type(deps) == type(()):
+        deps = list(deps)
+        if internal_test_util not in deps:
+            deps.append(internal_test_util)
+        kwargs["deps"] = deps
     test_deps = _cpu_test_deps() + _get_jax_test_deps(deps)
     kwargs["deps"] = test_deps
     py_test(name = name, env = env, **kwargs)


### PR DESCRIPTION
# Motivation
This change makes ROCm test runs more reliable by proactively marking and skipping Mosaic GPU tests only when running on ROCm.

# Description

**Pytest conftest.py (auto-skip behavior)**

- Registers mosaic_gpu marker in pytest_configure, so Mosaic tests have a marker.
- Classifies each collected test item in pytest_collection_modifyitems using a Mosaic detector (path + source heuristics).
- Marks Mosaic tests by adding pytest.mark.mosaic_gpu to those items during collection.
- On ROCm, auto-skips Mosaic tests by also adding pytest.mark.skip(reason="Mosaic GPU tests are not supported on ROCm") to the same items.
- Produces visible skip outcomes: in pytest output this shows up as s/SKIPPED, and with -rs you get the skip reason printed.

NOTE: Both the pytest hook and the Bazel runner rely on the same underlying Mosaic detection logic: jax/_src/internal_test_util/mosaic_gpu_test_filter.py. That shared utility provides ROCm detection and "looks-like-mosaic" heuristics so behavior is consistent across runs.

**Bazel (ROCm CI: absltest converted to pytest + why it enables auto-skips)**

- Replaces direct absltest execution with pytest execution by running Bazel tests under a run_under wrapper (--config=rocm_pytest -> //build/rocm:parallel_gpu_pytest), so the test entrypoint becomes python -m pytest ... instead of the raw absltest binary.
- Ensures pytest loads the repo conftest.py inside Bazel runfiles by setting pytest --rootdir/--confcutdir to the runfiles repo root, so the collection hook runs in Bazel too.
- Makes conftest.py available in Bazel runfiles (exported as a Bazel file target and pulled into common test runfiles), so pytest always has the plugin to apply Mosaic marking/skipping.
- Enables node-level selection/auto-skip uniformly because pytest is now the collector: Mosaic items get marked/skipped at collection time, which works the same for single targets and large Bazel suites.
- Keeps Bazel semantics working under pytest (e.g. sharding support via TEST_SHARD_STATUS_FILE, and safe forwarding of pytest-only flags), so switching to pytest doesn’t break ROCm CI execution mechanics.


# Test plan
**Pytest test plan (auto-skip)**
Run a Mosaic-selecting pytest/Bazel invocation and confirm SKIPPED lines appear for Mosaic tests (optionally add -rs to print the skip reason).
Verify the summary shows skipped count > 0 (e.g. … skipped …) and the run exits successfully.

**Bazel test plan (ROCm CI / RBE)**
Run the ROCm RBE Bazel suite via ci/run_bazel_test_rocm_rbe.sh with --test_output=streamed and confirm Mosaic-heavy targets (e.g. //tests/pallas:mosaic_gpu_test_gpu) report many skips (s/… skipped …) instead of failures.
Run a small targeted RBE test (e.g. //tests/pallas:export_back_compat_pallas_test_gpu with -k selecting Mosaic tests) and confirm selected Mosaic tests are SKIPPED and the Bazel target PASSED.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->