### PR TITLE
fix(custom_partitioning): preserve host callbacks and explicit mesh axis types

### DIFF
--- a/jax/_src/custom_partitioning.py
+++ b/jax/_src/custom_partitioning.py
@@ -588,7 +588,7 @@ def _custom_partitioning_lowering_rule(ctx: mlir.LoweringRuleContext, *values,
     am = axis_context.abstract_mesh
     if am is not None:
       mesh = mesh_lib.Mesh(np.array(devices).reshape(am.axis_sizes),
-                           am.axis_names)
+                           am.axis_names, axis_types=am.axis_types)
   elif isinstance(axis_context, sharding_impls.SPMDAxisContext):
     devices = axis_context.mesh._flat_devices_tuple
   else:

--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -650,7 +650,7 @@ def _inspect_sharding_lowering_rule(ctx: mlir.LoweringRuleContext, value, *,
     am = axis_context.abstract_mesh
     if am is not None:
       mesh = mesh_lib.Mesh(np.array(devices).reshape(am.axis_sizes),
-                           am.axis_names)
+                           am.axis_names, axis_types=am.axis_types)
   elif isinstance(axis_context, sharding_impls.SPMDAxisContext):
     mesh = axis_context.mesh
     devices = axis_context.mesh._flat_devices_tuple


### PR DESCRIPTION
Fixes #34811: custom_partitioning callbacks incorrectly receive an AxisType.Auto mesh even when the original mesh is AxisType.Explicit.