### PR TITLE
fix(custom_partitioning): preserve host callbacks and keepalives (#34349)

### DIFF
--- a/jax/_src/custom_partitioning.py
+++ b/jax/_src/custom_partitioning.py
@@ -192,13 +192,17 @@ def _custom_partitioning_partition(arg_shapes, arg_shardings, result_shape,
     )
   axis_context = sharding_impls.SPMDAxisContext(mesh)
   with core.extend_axis_env_nd(mesh.shape.items()):
-    module = mlir.build_mlir_module_helper(
-        closed_jaxpr,
-        name="tmp_xla_computation",
+    lowering_result = mlir.build_mlir_module_helper(
+        closed_jaxpr, name="tmp_xla_computation",
         platforms=module_context.platforms,
         backend=module_context.backend,
-        axis_context=axis_context.extend_manual(frozenset(mesh.axis_names)),
-    )
+        axis_context=axis_context.extend_manual(frozenset(mesh.axis_names)))
+    module = lowering_result.module
+    for hc in lowering_result.host_callbacks:
+      module_context.add_host_callback(hc)
+    if lowering_result.keepalive is not None:
+      for ka in lowering_result.keepalive:
+        module_context.add_keepalive(ka)
   result_sharding = _pack_result_sharding(result_shape, result_shardings)
   return mlir.module_to_bytecode(module), arg_shardings, result_sharding
 

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -3062,20 +3062,19 @@ def build_mlir_module_helper(
     closed_jaxpr: core.ClosedJaxpr, *, name: str,
     platforms: Sequence[str],
     backend: xc.Client | None,
-    axis_context: AxisContext) -> ir.Module:
+    axis_context: AxisContext) -> LoweringResult:
   """Helper to generate pmap-style XLA computations for custom partitioners."""
   unlowerable_effects = effects_lib.lowerable_effects.filter_not_in(
       closed_jaxpr.effects)
   if unlowerable_effects:
     raise ValueError(f'Cannot lower jaxpr with effects: {closed_jaxpr.effects}')
-  lowering_result = lower_jaxpr_to_module(name, closed_jaxpr,
+  return lower_jaxpr_to_module(name, closed_jaxpr,
       num_const_args=0,
       in_avals=closed_jaxpr.in_avals,
       backend=backend, ordered_effects=[],
       donated_args=[False] * len(closed_jaxpr.jaxpr.invars),
       axis_context=axis_context, platforms=platforms,
       lowering_parameters=LoweringParameters(hoist_constants_as_args=False))
-  return lowering_result.module
 
 def custom_call(
     call_target_name: str,


### PR DESCRIPTION
Fixes jax-ml#34349
Fixes internal bug b/367283738

### Summary 
Since PR #33814 refactored standard JIT lowering to use `MLIRLoweringResult` correctly, we noticed that `custom_partitioning` was still bypassing this pipeline and plucking only the MLIR module string. This caused `host_callbacks` and keepalives to be structurally discarded during custom compilation.

This PR refactors `build_mlir_module_helper` inside `mlir.py` to return the full `LoweringResult` holding all metadata, instead of just returning the MLIR module and context. `custom_partitioning.py` has been updated to propagate this `LoweringResult` downstream to `get_compile_options_and_args`. This ensures any keepalives or callbacks generated inside the partitioned function are successfully preserved.
