### PR TITLE
Fix dropping sharding on 0-sized boolean masks (#35273)

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -31,7 +31,11 @@ import inspect
 import typing
 from typing import (Any, Literal, NamedTuple, Optional, TypeVar, overload,
                     cast, TYPE_CHECKING)
+from typing_extensions import ParamSpec
 import weakref
+
+_P_jit = ParamSpec("_P_jit")
+_T_jit = TypeVar("_T_jit")
 
 import numpy as np
 from contextlib import contextmanager
@@ -161,7 +165,7 @@ class NotSpecified:
 
 @overload
 def jit(
-  fun: Callable, /, *,
+  fun: Callable[_P_jit, _T_jit], /, *,
   in_shardings: Any = ...,
   out_shardings: Any = ...,
   static_argnums: int | Sequence[int] | None = ...,
@@ -189,10 +193,10 @@ def jit(
   backend: str | None = ...,
   inline: bool = ...,
   compiler_options: dict[str, Any] | None = ...,
-) -> Callable[[Callable], pjit.JitWrapped]: ...
+) -> Callable[[Callable[_P_jit, _T_jit]], pjit.JitWrapped]: ...
 
 def jit(
-  fun: Callable | NotSpecified = NotSpecified(), /, *,
+  fun: Callable[_P_jit, _T_jit] | NotSpecified = NotSpecified(), /, *,
   in_shardings: Any = sharding_impls.UNSPECIFIED,
   out_shardings: Any = sharding_impls.UNSPECIFIED,
   static_argnums: int | Sequence[int] | None = None,
@@ -204,7 +208,7 @@ def jit(
   backend: str | None = None,
   inline: bool = False,
   compiler_options: dict[str, Any] | None = None,
-) -> pjit.JitWrapped | Callable[[Callable], pjit.JitWrapped]:
+) -> pjit.JitWrapped | Callable[[Callable[_P_jit, _T_jit]], pjit.JitWrapped]:
   """Sets up ``fun`` for just-in-time compilation with XLA.
 
   Args:

--- a/jax/_src/custom_partitioning.py
+++ b/jax/_src/custom_partitioning.py
@@ -192,13 +192,18 @@ def _custom_partitioning_partition(arg_shapes, arg_shardings, result_shape,
     )
   axis_context = sharding_impls.SPMDAxisContext(mesh)
   with core.extend_axis_env_nd(mesh.shape.items()):
-    module = mlir.build_mlir_module_helper(
+    lowering_result = mlir.build_mlir_module_helper(
         closed_jaxpr,
         name="tmp_xla_computation",
         platforms=module_context.platforms,
         backend=module_context.backend,
         axis_context=axis_context.extend_manual(frozenset(mesh.axis_names)),
     )
+    for hc in lowering_result.host_callbacks:
+      module_context.add_host_callback(hc)
+    for ka in lowering_result.keepalives:
+      module_context.add_keepalive(ka)
+    module = lowering_result.module
   result_sharding = _pack_result_sharding(result_shape, result_shardings)
   return mlir.module_to_bytecode(module), arg_shardings, result_sharding
 

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -1026,7 +1026,7 @@ def eval_dynamic_shape_as_tensor(ctx: LoweringRuleContext,
 
 class LoweringResult(NamedTuple):
   module: ir.Module
-  keepalive: Any | None
+  keepalives: list[Any]
   host_callbacks: list[Any]
   shape_poly_state: ShapePolyLoweringState
 
@@ -3062,7 +3062,7 @@ def build_mlir_module_helper(
     closed_jaxpr: core.ClosedJaxpr, *, name: str,
     platforms: Sequence[str],
     backend: xc.Client | None,
-    axis_context: AxisContext) -> ir.Module:
+    axis_context: AxisContext) -> LoweringResult:
   """Helper to generate pmap-style XLA computations for custom partitioners."""
   unlowerable_effects = effects_lib.lowerable_effects.filter_not_in(
       closed_jaxpr.effects)
@@ -3075,7 +3075,7 @@ def build_mlir_module_helper(
       donated_args=[False] * len(closed_jaxpr.jaxpr.invars),
       axis_context=axis_context, platforms=platforms,
       lowering_parameters=LoweringParameters(hoist_constants_as_args=False))
-  return lowering_result.module
+  return lowering_result
 
 def custom_call(
     call_target_name: str,

--- a/jax/_src/numpy/indexing.py
+++ b/jax/_src/numpy/indexing.py
@@ -1205,8 +1205,14 @@ def _gather(arr, dynamic_idx, *, treedef, indices_are_sorted,
   # Avoid calling gather if the slice shape is empty, both as a fast path and to
   # handle cases like zeros(0)[array([], int32)].
   if core.is_empty_shape(indexer.slice_shape):
+    slice_sharding = indexer.slice_sharding
+    # If the abstract sharding has an empty mesh (e.g. from SingleDeviceSharding),
+    # drop it to allow full_like to fall back to the concrete `y.sharding`.
+    if slice_sharding is not None and getattr(slice_sharding.mesh, "empty", False):
+      slice_sharding = None
+
     return lax.full_like(y, 0, shape=indexer.slice_shape,
-                         sharding=indexer.slice_sharding)
+                         sharding=slice_sharding)
 
   # We avoid generating a gather when indexer.gather_indices.size is empty.
   if not core.is_empty_shape(indexer.gather_indices.shape):


### PR DESCRIPTION
Fixes #35273.

This fixes an issue where boolean masking resulting in a 0-sized dimension would drop the array's sharding and device placement, falling back to the default device (e.g., CUDA instead of CPU).

The root cause was in `jax.lax.gather`'s empty-slice fast-path (`jax/_src/numpy/indexing.py`). It deliberately delegates to `jax.lax.full_like` and passes `indexer.slice_sharding`, which is derived from the array's abstract `ShapedArray` sharding. For single-device arrays, this is equivalent to `NamedSharding(empty_mesh)`. By explicitly passing an empty mesh sharding to `full_like`, it overrides the normal fallback to the original array's physical `SingleDeviceSharding`.

This fix drops the abstract `slice_sharding` if its mesh is empty before calling `full_like`, ensuring it falls back correctly to the inheritance of the original array's physical device.
