### PR TITLE
[hijax] Make JIT inference cache sensitive to QDD state (#33448)

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -581,7 +581,7 @@ class InferParamsCacheEntry:
 @weakref_lru_cache
 def _infer_params_cached(
     fun: Callable, jit_info: PjitInfo, signature: jax_jit.ArgumentSignature,
-    in_avals: tuple[core.AbstractValue, ...], ctx_mesh: mesh_lib.Mesh
+    in_avals: tuple[core.AbstractValue, ...], qdd_token: int, ctx_mesh: mesh_lib.Mesh
     ) -> InferParamsCacheEntry:
   return InferParamsCacheEntry()
 
@@ -599,14 +599,15 @@ def _infer_params(
       args, tuple(kwargs.values()), tuple(kwargs.keys()), ji.static_argnums,
       ji.static_argnames, tree_util.default_registry)
   avals = _infer_input_type(fun, dbg_fn, dynargs)
-  entry = _infer_params_cached(fun, ji, arg_signature, avals, ctx_mesh)
+  in_avals_qdd = tuple(core.AvalQDD(a, cur_qdd(x)) if a.has_qdd else a
+                       for a, x in zip(avals, dynargs))
+  qdd_token = _qdd_cache_index(fun, in_avals_qdd)
+  entry = _infer_params_cached(fun, ji, arg_signature, in_avals_qdd, qdd_token, ctx_mesh)
 
   if entry.pjit_params is not None:
     return entry.pjit_params, entry.pjit_params.consts + dynargs
 
   p = _trace_for_jit(fun, ji, ctx_mesh, dbg_fn(), avals, args, kwargs)
-  if p.params['jaxpr'].jaxpr.is_high:
-    return p, p.consts + dynargs
   entry.pjit_params = p
   return p, p.consts + dynargs
 


### PR DESCRIPTION
Fixes jax-ml#33448

cc @mattjj - I noticed your open issue on the HiJAX caching dropping QDD state and decided to take a stab at fixing it natively in `_infer_params`.

### Summary
The JIT cache (`_infer_params_cached`) previously relied on `in_avals` which drops the quasi-dynamic data (QDD) state for mutable `Box`es. If a `Box` changed its internal type, the cache could serve stale compiled `jaxpr`s because the cache key remained identical.

After looking into how `_trace_for_jit` computes the `qdd_token`, this PR lifts that logic into `_infer_params`. By wrapping the `avals` in `AvalQDD` and computing the `qdd_token` *before* querying the cache, we ensure the cache correctly misses when the mutable state changes.

Additionally, this enables caching of `is_high` jaxprs since their mutable dependency is now properly captured in the cache key.

Ref: https://github.com/jax-ml/jax/issues/33448
