### PR TITLE
Fix dropping sharding on 0-sized boolean masks (#35273)

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3585,6 +3585,13 @@ def full_like(x: ArrayLike | DuckTypedArray,
   if sharding is None and shape is None and isinstance(x, core.Tracer):
     sharding = x.aval.sharding
   else:
+    # If a NamedSharding with an empty mesh is passed, treat it as None
+    # to allow fallback to the source array's physical sharding. This
+    # happens when indexing.py passes an abstract sharding from an aval.
+    if (isinstance(sharding, NamedSharding) and
+        sharding.mesh.empty and not sharding.mesh._is_concrete):
+      sharding = None
+
     # If `x` has a sharding but no `_committed` attribute
     # (in case of ShapeDtypeStruct), default it to True.
     use_x_sharding = (


### PR DESCRIPTION
Fixes jax-ml#35273

This PR replaces earlier PR attempts (#35292, #35293).

### Root Cause
When indexing arrays with boolean masks that evaluate to size 0, JAX propagates an abstract `NamedSharding` with an empty mesh during the lowering process. Inside `lax.full_like` (which powers the zero-filling for the unused mask entries), this abstract sharding overrides the physical device ID of the source array. Thus, memory gets allocated on the default device instead of the intended one.

### Fix
Instead of intercepting this at the top `indexing.py` layer (as done in older, closed PRs), this fix makes `lax.full_like` architecturally immune to empty-mesh shardings. 
It checks if `type(sharding) is NamedSharding and sharding.mesh.empty` and if so, treats the sharding as unspecified. This correctly trips the fallback logic, propagating the true concrete `sharding` (with device IDs intact) from the original array.
