### PR TITLE
Refined Fix for sharding on 0-sized boolean masks (#35273)

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3582,9 +3582,19 @@ def full_like(x: ArrayLike | DuckTypedArray,
   if dtypes.issubdtype(dtype, dtypes.extended):
     return dtype._rules.full(fill_shape, fill_value, dtype)  # type: ignore[union-attr]
 
+  # If a NamedSharding with an empty mesh is passed, treat it as None
+  # to allow fallback to the source array's physical sharding. This
+  # happens when indexing.py passes an abstract sharding from an aval.
+  # We do this before the Tracer check to ensure both physical arrays
+  # and tracers use the correct inherited sharding.
+  if (isinstance(sharding, NamedSharding) and
+      sharding.mesh.empty and not getattr(sharding, '_is_concrete', False)):
+    sharding = None
+
   if sharding is None and shape is None and isinstance(x, core.Tracer):
     sharding = x.aval.sharding
   else:
+
     # If `x` has a sharding but no `_committed` attribute
     # (in case of ShapeDtypeStruct), default it to True.
     use_x_sharding = (


### PR DESCRIPTION
Fixes jax-ml#35273

This PR provides the final refined fix for the boolean mask sharding issue, incorporating feedback from `@yashk2810` and `@gemini-code-assist`.

### Root Cause
When indexing arrays with boolean masks that evaluate to size 0, JAX propagates an abstract `NamedSharding` with an empty mesh during the lowering process. Inside `lax.full_like`, this abstract sharding previously overrode the physical device ID of the source array.

### Fix
This refined fix modifies `lax.full_like` to recognize abstract empty-mesh shardings and treat them as unspecified. 

**Key refinements in this version:**
1. **Tracer Support**: The check is now placed before the Tracer-specific sharding lookup, ensuring both physical arrays and Tracers correctly fall back to their source shardings.
2. **Robust Attribute Check**: Uses `getattr(sharding, '_is_concrete', False)` instead of accessing `mesh._is_concrete`, avoiding potential `AttributeError` on Mesh objects.
3. **Architectural Consistency**: This approach naturally leverages JAX's existing sharding propagation logic in `lax.py` rather than applying high-level hacks in `indexing.py`.
