### PR TITLE
fix(custom_partitioning): preserve axis_types when reconstructing mesh (#34811)

### DIFF
--- a/jax/_src/custom_partitioning.py
+++ b/jax/_src/custom_partitioning.py
@@ -588,7 +588,7 @@ def _custom_partitioning_lowering_rule(ctx: mlir.LoweringRuleContext, *values,
     am = axis_context.abstract_mesh
     if am is not None:
       mesh = mesh_lib.Mesh(np.array(devices).reshape(am.axis_sizes),
-                           am.axis_names)
+                           am.axis_names, am.axis_types)
   elif isinstance(axis_context, sharding_impls.SPMDAxisContext):
     devices = axis_context.mesh._flat_devices_tuple
   else:


### PR DESCRIPTION
Fixes #34811

## Summary

When `custom_partitioning` callbacks receive the mesh during lowering, the mesh is reconstructed from the `AbstractMesh` on line 590 of `custom_partitioning.py`. However, the reconstruction only passed `axis_sizes` and `axis_names` -- **dropping `axis_types`**. This caused the `Mesh` constructor to default all axes to `AxisType.Auto`, even when the original mesh used `AxisType.Explicit`.

## Root Cause

```python
# Before (drops axis_types -> defaults to Auto):
mesh = mesh_lib.Mesh(np.array(devices).reshape(am.axis_sizes),
                     am.axis_names)

# After (preserves original axis_types):
mesh = mesh_lib.Mesh(np.array(devices).reshape(am.axis_sizes),
                     am.axis_names, am.axis_types)
```

## Impact

This 1-line fix restores correct `AxisType` propagation to `custom_partitioning` callbacks, unblocking libraries like [jaxDecomp](https://github.com/DifferentiableUniverseInitiative/jaxDecomp) that rely on `custom_partitioning` with `AxisType.Explicit` meshes.

Without this fix, the `partition` callback sees `(Auto, Auto)` for axis types regardless of the actual mesh configuration, causing shape mismatches when Shardy/XLA's SPMD partitioner makes decisions based on the real `Explicit` axis types.
