### PR TITLE
fix(shard_map): add return type hint and overloads for type checker compatibility (#35101)

### DIFF
--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -19,7 +19,7 @@ from functools import partial
 import inspect
 from math import prod
 import operator as op
-from typing import Any, TypeVar, Union
+from typing import Any, TypeVar, Union, overload
 
 import numpy as np
 
@@ -83,11 +83,25 @@ def _get_default_infer():
 
 # See https://github.com/jax-ml/jax/pull/30753 to understand why `in_specs`
 # defaults to `Infer`.
-def shard_map(f=None, /, *, out_specs: Specs,
+F = TypeVar("F", bound=Callable)
+
+@overload
+def shard_map(f: F, /, *, out_specs: Specs,
+              in_specs: Specs | None | InferFromArgs = ...,
+              mesh: Mesh | AbstractMesh | None = ...,
+              axis_names: Set[AxisName] = ...,
+              check_vma: bool = ...) -> F: ...
+@overload
+def shard_map(f: None = ..., /, *, out_specs: Specs,
+              in_specs: Specs | None | InferFromArgs = ...,
+              mesh: Mesh | AbstractMesh | None = ...,
+              axis_names: Set[AxisName] = ...,
+              check_vma: bool = ...) -> Callable[[F], F]: ...
+def shard_map(f: F | None = None, /, *, out_specs: Specs,
               in_specs: Specs | None | InferFromArgs = Infer,
               mesh: Mesh | AbstractMesh | None = None,
               axis_names: Set[AxisName] = frozenset(),
-              check_vma: bool = True):
+              check_vma: bool = True) -> F | Callable[[F], F]:
   """Map a function over shards of data using a mesh of devices.
 
   See the docs at https://docs.jax.dev/en/latest/notebooks/shard_map.html.
@@ -202,9 +216,9 @@ def _smap(f, *, in_axes, out_axes, axis_name: AxisName):
 
 
 @partial(traceback_util.api_boundary, repro_api_name="jax.shard_map")
-def _shard_map(f: Callable, *, mesh: Mesh | AbstractMesh | None,
+def _shard_map(f: F, *, mesh: Mesh | AbstractMesh | None,
                in_specs: Specs, out_specs: Specs, axis_names: Set[AxisName],
-               check_vma: bool, _smap: bool = False) -> Callable:
+               check_vma: bool, _smap: bool = False) -> F:
   if not callable(f):
     raise TypeError("shard_map requires a callable for its first argument, "
                     f"but got {f} of type {type(f)}.")


### PR DESCRIPTION
Fixes #35101

## Summary

`shard_map` was missing return type hints and type annotations for its `f` parameter, causing type checkers like Pyright to lose the callable's signature after wrapping. This PR adds proper `@overload` definitions and a `TypeVar` bound to `Callable`, following the same pattern used by `vmap` in `api.py`.

## Changes

- Added `F = TypeVar("F", bound=Callable)` (same as `vmap`)
- Added two `@overload` definitions for `shard_map`:
  - When `f` is provided: returns `F` (preserves the callable type)
  - When `f` is `None`: returns `Callable[[F], F]` (decorator factory pattern)
- Updated `_shard_map` to use `F` instead of raw `Callable` for both input and return types

## Before

```python
# Type checkers lose the signature
mapped_fn = shard_map(my_fn, out_specs=P('x'))
# mapped_fn: ??? (no type info)
```

## After

```python
# Type checkers preserve the signature
mapped_fn = shard_map(my_fn, out_specs=P('x'))
# mapped_fn: type of my_fn (signature preserved)
```

This is consistent with how `vmap` (line 98 of `api.py`) and `pmap` handle type preservation.
