### PR TITLE
[pmap] Replace `functools.lru_cache` with `util.cache` to fix stale `PyDevice` caching

### DIFF
--- a/jax/_src/pmap.py
+++ b/jax/_src/pmap.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from functools import lru_cache, partial
+from functools import partial
 from typing import Any, Callable, NamedTuple
 import warnings
 
@@ -197,7 +197,7 @@ def _cached_shard_map(fun, in_tree, in_axes_flat, out_axes_flat, out_axes_tree,
   out_global_shardings = tree_map(
       get_sharding, out_specs, is_leaf=lambda x: x is None)
 
-  @lru_cache
+  @util.cache()
   def out_local_shardings_thunk(pspec):
     return (
         sharding_impls.NamedSharding(mesh.local_mesh, pspec),
@@ -426,7 +426,7 @@ def _get_donated_invars(donate_tuple, in_tree, num_flat_args):
     return (False,) * num_flat_args
 
 
-@lru_cache
+@util.cache()
 def _get_mesh_devices(devices, backend, local_axis_size, axis_size,
                       trace_state_clean):
   """Compute effective mesh devices based on context.
@@ -492,7 +492,7 @@ def _get_mesh_devices(devices, backend, local_axis_size, axis_size,
     return mesh_devices[:global_axis_size]
 
 
-@lru_cache
+@util.cache()
 def _local_to_global_aval(shape, dtype, sharding):
   """Compute global aval from local shape."""
   pspec_prepared = sharding_impls.prepare_axis_resources(sharding.spec, "pspec")
@@ -504,7 +504,7 @@ def _local_to_global_aval(shape, dtype, sharding):
   )
 
 
-@lru_cache
+@util.cache()
 def _global_to_local_aval(shape, dtype, sharding):
   """Compute local aval from global shape."""
   pspec_prepared = sharding_impls.prepare_axis_resources(sharding.spec, "pspec")
@@ -516,19 +516,19 @@ def _global_to_local_aval(shape, dtype, sharding):
   )
 
 
-@lru_cache
+@util.cache()
 def _local_device_indices(local_sharding, shape):
   """Cached device indices for slicing arrays."""
   return tuple(local_sharding.devices_indices_map(shape).values())
 
 
-@lru_cache
+@util.cache()
 def _is_sharding_equivalent(sharding_a, sharding_b, ndim):
   """Check if sharding is equivalent to NamedSharding(mesh.local_mesh, pspec)."""
   return sharding_a.is_equivalent_to(sharding_b, ndim)
 
 
-@lru_cache
+@util.cache()
 def _get_out_shardings(out_tree, pspecs, out_shardings_thunk):
   """Get flattened output shardings, combining pspec flattening and sharding lookup."""
   out_pspecs_flat = pjit_lib.flatten_axis_resources(

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -179,8 +179,24 @@ class PythonPmapTest(jtu.JaxTestCase):
     pmap_sharding = pmap(lambda x: x)(np.arange(jax.device_count())).sharding
     if config.pmap_shmap_merge.value:
       self.assertListEqual(device_order, list(pmap_sharding._device_assignment))
+
+  def testDefaultDeviceOrderingAfterClearBackends(self):
+    # Test that clear_backends() properly drops cached PyDevice objects in pmap
+    # so that pointer-based __eq__ doesn't fail.
+    device_order = jax.devices()
+    # Execute pmap first to populate the cache
+    f = pmap(lambda x: x)
+    f(np.arange(jax.device_count()))
+    
+    src_api.clear_backends()
+    device_order_after = jax.devices()
+    
+    pmap_sharding = pmap(lambda x: x)(np.arange(jax.device_count())).sharding
+    if config.pmap_shmap_merge.value:
+      self.assertListEqual(device_order_after, list(pmap_sharding._device_assignment))
     else:
-      self.assertListEqual(device_order, pmap_sharding.devices.tolist())
+      self.assertListEqual(device_order_after, pmap_sharding.devices.tolist())
+
 
   def testLowerCompile(self):
     f = self.pmap(lambda x: x - lax.pmean(x, 'i'), axis_name='i')


### PR DESCRIPTION
`testDefaultDeviceOrdering` failed intermittently on macOS CI with differing `PyDevices`. `jax.clear_backends()` rebuilt the C++ devices, but pmap used lru_cache, which held onto stale Python wrappers.

Switching `functools.lru_cache` to JAX's internal `util.cache()` properly clears on test teardowns.