### PR TITLE
[test] fix deprecated mpmath import

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1954,7 +1954,7 @@ class vectorize_with_mpmath(np.vectorize):
         dtype = None
       if dtype is not None:
         return np.fromiter(map(self.mptonp, x_flat), dtype=dtype).reshape(x.shape)
-    elif isinstance(x, self.mpmath.ctx_mp.mpnumeric):
+    elif isinstance(x, self.mpmath.ctx_mp_python.mpnumeric):
       ctx = x.context
       if isinstance(x, ctx.mpc):
         fp_format = self.contexts_inv[ctx]
@@ -2004,13 +2004,13 @@ class vectorize_with_mpmath(np.vectorize):
       lst = []
       for r in result:
         if ((isinstance(r, np.ndarray) and r.dtype.kind == 'O')
-            or isinstance(r, self.mpmath.ctx_mp.mpnumeric)):
+            or isinstance(r, self.mpmath.ctx_mp_python.mpnumeric)):
           r = self.mptonp(r)
         lst.append(r)
       return tuple(lst)
 
     if ((isinstance(result, np.ndarray) and result.dtype.kind == 'O')
-        or isinstance(result, self.mpmath.ctx_mp.mpnumeric)):
+        or isinstance(result, self.mpmath.ctx_mp_python.mpnumeric)):
       return self.mptonp(result)
 
     return result

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -4454,7 +4454,7 @@ class FunctionAccuracyTest(jtu.JaxTestCase):
     is_complex = dtype().dtype.kind == 'c'
 
     def func(x):
-      assert isinstance(x, mpmath.ctx_mp.mpnumeric)
+      assert isinstance(x, mpmath.ctx_mp_python.mpnumeric)
       assert x.context.prec == prec
       assert isinstance(x, x.context.mpc if is_complex else x.context.mpf)
       return x


### PR DESCRIPTION
mpmath v1.4.0 was released this morning, which added a deprecation that causes test failures for JAX: https://github.com/jax-ml/jax/actions/runs/22305373512/job/64523126750

This altered import path fixes the issue.