### PR TITLE
fix: replace 61 bare except clauses with except Exception

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -367,7 +367,7 @@ def linkcode_resolve(domain, info):
         obj = obj.__wrapped__
     filename = inspect.getsourcefile(obj)
     source, linenum = inspect.getsourcelines(obj)
-  except:
+  except Exception:
     return None
   try:
     filename = Path(filename).relative_to(Path(jax.__file__).parent)

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -439,7 +439,7 @@ class WrapHashably:
     try:
       self.hash = hash(val)
       self.hashable = True
-    except:
+    except Exception:
       self.hash = id(val)
       self.hashable = False
   def __hash__(self):
@@ -675,7 +675,7 @@ def remat_partial_eval(trace: pe.JaxprTrace, *tracers: core.Tracer,
                 '  %s from %s\n' * len(body_res),
                 *[v.aval.str_short() for v in res_invars],
                 *[elt for (a, s) in body_res for elt in [a.str_short(), s]])
-    except:
+    except Exception:
       pass  # just don't log anything on failure
 
   for t in out_jaxpr_tracers: t.recipe = recipe

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2276,7 +2276,7 @@ def _is_ref(x):
   from jax._src.state.types import AbstractRef
   try:
     return isinstance(typeof(x), AbstractRef)
-  except:
+  except Exception:
     return False
 
 

--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -590,7 +590,7 @@ def fun_sourceinfo(fun: Callable) -> str:
   except AttributeError:
     try:
       fun_str = str(fun)
-    except:
+    except Exception:
       return "<unknown>"
     # By contract, the function name has no spaces; also, we want to avoid
     # fun_sourceinfo of the form "<object Foo at 0x1234>", because it makes

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2759,7 +2759,7 @@ def is_constant_dim(d: DimSize) -> bool:
   try:
     operator.index(d)
     return True
-  except:
+  except Exception:
     return False
 
 def is_dim(v: Any) -> bool:
@@ -2889,7 +2889,7 @@ def canonicalize_slice(
     # Convert np.array and jax.Array to int, leave symbolic dimensions alone
     try:
       return operator.index(d)
-    except:
+    except Exception:
       return d
 
   # Must resolve statically if step is {<0, ==0, >0}
@@ -2968,7 +2968,7 @@ def evaluate_shape(shape: Shape, dim_vars: Sequence[str],
   def eval_one_dim(d: DimSize):
     try:
       return operator.index(d)
-    except:
+    except Exception:
       # Is a _DimExpr
       return d._evaluate(env)  # type: ignore
   return tuple(eval_one_dim(d) for d in shape)

--- a/jax/_src/debugger/cli_debugger.py
+++ b/jax/_src/debugger/cli_debugger.py
@@ -51,7 +51,7 @@ class CliDebugger(cmd.Cmd):
     """Evaluates an expression."""
     try:
       print(repr(self.evaluate(line)), file=self.stdout)
-    except:
+    except Exception:
       self._error_message()
 
   def print_backtrace(self):
@@ -91,7 +91,7 @@ class CliDebugger(cmd.Cmd):
     """
     try:
       print(repr(self.evaluate(arg)), file=self.stdout)
-    except:
+    except Exception:
       self._error_message()
 
   def do_pp(self, arg):
@@ -100,7 +100,7 @@ class CliDebugger(cmd.Cmd):
     """
     try:
       print(pprint.pformat(self.evaluate(arg)), file=self.stdout)
-    except:
+    except Exception:
       self._error_message()
 
   def do_up(self, arg, /):

--- a/jax/_src/debugger/core.py
+++ b/jax/_src/debugger/core.py
@@ -59,7 +59,7 @@ def _safe_flatten_dict(dct: dict[Any, Any]
   for key, value in dct.items():
     try:
       tree_util.tree_leaves(value)
-    except:
+    except Exception:
       # If flattening fails, we substitute a sentinel object.
       value = cant_flatten
     keys.append(key)

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -41,7 +41,7 @@ traceback_util.register_exclusion(__file__)
 
 try:
   _ml_dtypes_version = tuple(map(int, ml_dtypes.__version__.split('.')[:3]))
-except:
+except Exception:
   pass
 else:
   if _ml_dtypes_version < (0, 5):

--- a/jax/_src/export/serialization.py
+++ b/jax/_src/export/serialization.py
@@ -671,7 +671,7 @@ def _deserialize_effect(eff: ser_flatbuf.Effect) -> core.Effect:
     if str(existing_effect_type) == effect_type_name:
       try:
         return existing_effect_type()
-      except:
+      except Exception:
         # TODO: add test
         raise NotImplementedError(
             f"deserializing effect {effect_type_name} that does not have a "

--- a/jax/_src/export/shape_poly.py
+++ b/jax/_src/export/shape_poly.py
@@ -1205,7 +1205,7 @@ def _convertible_to_int(p: Any) -> bool:
   try:
     op.index(p)
     return True
-  except:
+  except Exception:
     return False
 
 def _ensure_poly(p: DimSize,
@@ -1700,12 +1700,12 @@ def _evaluate_add(v1, v2):
   try:
     if op.index(v1) == 0:
       return v2
-  except:
+  except Exception:
     pass
   try:
     if op.index(v2) == 0:
       return v1
-  except:
+  except Exception:
     pass
   return v1 + v2
 
@@ -1713,12 +1713,12 @@ def _evaluate_multiply(v1, v2):
   try:
     if op.index(v1) == 1:
       return v2
-  except:
+  except Exception:
     pass
   try:
     if op.index(v2) == 1:
       return v1
-  except:
+  except Exception:
     pass
   return v1 * v2
 

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -283,7 +283,7 @@ class JaxprTrace(Trace['JaxprTracer']):
     update_params = call_param_updaters.get(primitive) or (lambda p, _, __: p)
     in_knowns, in_avals, in_consts = partition_pvals([t.pval for t in tracers])
 
-    # This method is like process_call above, except:
+    # This method is like process_call above, except Exception:
     #   1. we delete an axis from mapped-over input avals' shapes, and
     #      analogously add an axis to mapped-over output avals' shapes;
     #   2. we update the in_axes and out_axes/out_axes_thunk parameters to

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -2572,7 +2572,7 @@ def get_out_shardings_from_executable(
     omk = xla_executable.get_output_memory_kinds()[0]
     if num_ordered_effects > 0:
       omk = omk[num_ordered_effects:]
-  except:
+  except Exception:
     omk = [None] * num_out_avals
 
   assert len(omk) == num_out_avals, (len(omk), num_out_avals)
@@ -2689,7 +2689,7 @@ def _get_out_sharding_from_orig_sharding(
           out.append(orig_handler(o, out_aval, orig_in_s))
         except IndivisibleError:
           raise
-        except:
+        except Exception:
           out.append(o)
     else:
       out.append(o)
@@ -2740,7 +2740,7 @@ def _get_layouts_from_executable(
   try:
     in_layouts_xla = xla_executable.get_parameter_layouts()
     out_layouts_xla = xla_executable.get_output_layouts()
-  except:
+  except Exception:
     return (None,) * len(in_layouts), (None,) * len(out_layouts)
 
   if num_ordered_effects > 0:
@@ -2914,7 +2914,7 @@ def _maybe_get_and_check_out_shardings(
         xla_s = sharding_impls.logical_sharding(aval.shape, aval.dtype, xla_s)
       try:
         new_out_shardings.append(_gspmd_to_named_sharding(xla_s, aval, orig))  # pytype: disable=wrong-arg-types
-      except:
+      except Exception:
         new_out_shardings.append(xla_s)
     else:
       xla_hlo_s = xla_s._to_xla_hlo_sharding(aval.ndim)

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -331,7 +331,7 @@ def _check_branch_outputs(
   info2 = api_util.fun_sourceinfo(f2)
   try:
     outs1 = out_avals1.unflatten()
-  except:
+  except Exception:
     paths = [None] * len(out_avals1)
     component = lambda _: ''
   else:

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -398,7 +398,7 @@ def _check_carry_type(name, body_fun, in_carry, out_carry):
   if in_carry.tree != out_carry.tree:
     try:
       out_carry_unflat = out_carry.unflatten()
-    except:
+    except Exception:
       out_carry_unflat = None
 
     if out_carry_unflat is None:

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -191,7 +191,7 @@ def broadcast_shapes(*shapes):
   # NOTE: We have both cached and uncached versions to handle Tracers in shapes.
   try:
     return _broadcast_shapes_cached(*shapes)
-  except:
+  except Exception:
     return _broadcast_shapes_uncached(*shapes)
 
 @cache()

--- a/jax/_src/linear_util.py
+++ b/jax/_src/linear_util.py
@@ -132,7 +132,7 @@ class EqualStore:
     except StoreException as e:
       try:
         okay = bool(self._store._val == val)
-      except:
+      except Exception:
         raise e from None
       else:
         if not okay:

--- a/jax/_src/mesh_utils.py
+++ b/jax/_src/mesh_utils.py
@@ -773,7 +773,7 @@ def _canonicalize_axis_sizes(axis_sizes: Sequence[int]
   for s in axis_sizes:
     try:
       new_sizes.append(int(s))
-    except:
+    except Exception:
       return None
   return tuple(new_sizes)
 

--- a/jax/_src/numpy/array_methods.py
+++ b/jax/_src/numpy/array_methods.py
@@ -457,7 +457,7 @@ def _compute_newshape(arr: Array, newshape: DimSize | Shape) -> Shape:
   orig_newshape = newshape  # for error messages
   try:
     iter(newshape)  # type: ignore[arg-type]
-  except:
+  except Exception:
     newshape = [newshape]
   newshape = core.canonicalize_shape(newshape)  # type: ignore[arg-type]
   neg1s = [i for i, d in enumerate(newshape) if type(d) is int and d == -1]

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -299,7 +299,7 @@ def _where(condition: ArrayLike, x: ArrayLike, y: ArrayLike) -> Array:
     condition, x_arr, y_arr = _broadcast_arrays(condition, x, y)
   try:
     is_always_empty = core.is_empty_shape(x_arr.shape)
-  except:
+  except Exception:
     is_always_empty = False  # can fail with dynamic shapes
   return lax.select(condition, x_arr, y_arr) if not is_always_empty else x_arr
 

--- a/jax/_src/pallas/mosaic/interpret/interpret_pallas_call.py
+++ b/jax/_src/pallas/mosaic/interpret/interpret_pallas_call.py
@@ -247,7 +247,7 @@ def _check_for_revisiting(device_id, local_core_id, loop_idx, output_blocks):
   loop_idx = tuple(int(x) for x in loop_idx)
   try:
     output_blocks = jax.tree.map(int, output_blocks)
-  except:
+  except Exception:
     raise ValueError('Advanced indexers are not supported on TPU')
   output_ranges = [
       interpret_utils.to_range(b) if b is not None else None
@@ -509,7 +509,7 @@ def get(
   buffer_id = int(buffer_id)
   try:
     transforms = jax.tree.map(int, transforms)
-  except:
+  except Exception:
     raise ValueError('Advanced indexers are not supported on TPU')
   src_device_id = _to_int(src_device_id)
   src_local_core_id = _to_int(src_local_core_id)
@@ -633,7 +633,7 @@ def store(
   buffer_id = int(buffer_id)
   try:
     transforms = jax.tree.map(int, transforms)
-  except:
+  except Exception:
     raise ValueError('Advanced indexers are not supported on TPU')
   val = np.array(val)
   src_device_id = _to_int(src_device_id)
@@ -711,7 +711,7 @@ def swap(
   buffer_id = int(buffer_id)
   try:
     transforms = jax.tree.map(int, transforms)
-  except:
+  except Exception:
     raise ValueError('Advanced indexers are not supported on TPU')
   val = np.array(val)
   mask = np.array(mask) if mask is not None else None

--- a/jax/_src/pallas/mosaic/interpret/shared_memory.py
+++ b/jax/_src/pallas/mosaic/interpret/shared_memory.py
@@ -485,7 +485,7 @@ class SharedMemory:
 
       try:
         result = array[rnge].copy()
-      except:
+      except Exception:
         result = None
 
     shape_and_dtype = ShapeAndDtype(array.shape, array.dtype)

--- a/jax/_src/scipy/sparse/linalg.py
+++ b/jax/_src/scipy/sparse/linalg.py
@@ -560,7 +560,7 @@ def _gmres_solve(A, b, x0, atol, ptol, restart, maxiter, M, gmres_func):
   The main function call wrapped by custom_linear_solve. Repeatedly calls GMRES
   to find the projected solution within the order-``restart``
   Krylov space K(A, x0, restart), using the result of the previous projection
-  in place of x0 each time. Parameters are the same as in ``gmres`` except:
+  in place of x0 each time. Parameters are the same as in ``gmres`` except Exception:
 
   atol: Tolerance for norm(A(x) - b), used between restarts.
   ptol: Tolerance for norm(M(A(x) - b)), used within a restart.

--- a/jax/_src/sharding_impls.py
+++ b/jax/_src/sharding_impls.py
@@ -301,7 +301,7 @@ class PmapSharding(jsharding.Sharding):
   def memory_kind(self) -> str | None:
     try:
       return self._internal_device_list.default_memory_kind
-    except:
+    except Exception:
       return None
 
   def with_memory_kind(self, kind: str):

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -794,7 +794,7 @@ def _equality_errors(path, t1, t2, is_leaf):
   try:
     diff = ' '.join(repr(k.key) for k in
                     set(t1_keys).symmetric_difference(set(t2_keys)))
-  except:
+  except Exception:
     diff = ''
   if len(t1_children) != len(t2_children):
     yield (path,
@@ -1313,7 +1313,7 @@ def _prefix_error(
     # Next we handle the general case of checking child keys.
     try:
       diff = set(prefix_tree_keys).symmetric_difference(set(full_tree_keys))
-    except:
+    except Exception:
       diff = None
     if len(prefix_tree_children) != len(full_tree_children):
       yield lambda name: ValueError(
@@ -1516,7 +1516,7 @@ class FlatTree:
       paths, _ = unzip2(tree_leaves_with_path(self.unflatten()))
       assert len(paths) == len(self.vals)
       return self.update(paths)
-    except:
+    except Exception:
       return self.update([()] * len(self.vals))  # not our fault
 
   def __len__(self):

--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -495,7 +495,7 @@ def discover_pjrt_plugins() -> None:
     if plugin_module:
       try:
         plugin_module.initialize()
-      except:
+      except Exception:
         logger.exception("Jax plugin configuration error: Exception when "
                          "calling %s.initialize()", plugin_module_name)
 

--- a/jax/experimental/jax2tf/examples/tf_js/quickdraw/input_pipeline.py
+++ b/jax/experimental/jax2tf/examples/tf_js/quickdraw/input_pipeline.py
@@ -42,7 +42,7 @@ def download_dataset(dir_path, nb_classes):
         response = requests.get(url + cls_filename.replace('_', ' '), timeout=60)
         save_file.write(response.content)
         print(f'Successfully fetched {cls_filename}')
-      except:
+      except Exception:
         print(f'Failed to fetch {cls_filename}')
   return classes
 

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -80,7 +80,7 @@ def _is_tfval(v: TfVal) -> bool:
     with tf.device("CPU"):
       tf.constant(v)
     return True
-  except:
+  except Exception:
     return False
 
 class _DefaultNativeSerialization:

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -657,7 +657,7 @@ class Jax2TfTest(JaxToTfTestCase):
         e = e.numpy() if isinstance(e, tf.Tensor) else e
         try:
           self.assertAllClose(e, w, err_msg=k)
-        except:
+        except Exception:
           print(f"Failed at {k}")
           raise
 

--- a/jax/experimental/multihost_utils.py
+++ b/jax/experimental/multihost_utils.py
@@ -560,7 +560,7 @@ class _LiveDevices:
         with jax.live_devices(jax.devices()) as devices:
           # Run JAX code here with devices.
           pass
-      except:
+      except Exception:
         # A device died while executing the with statement above.
         pass
       else:
@@ -618,7 +618,7 @@ class _LiveDevices:
       try:
         with jax.live_devices(...) as devices:
           pass
-      except:
+      except Exception:
         pass # A
       else:
         pass # B

--- a/jax/experimental/sparse/_base.py
+++ b/jax/experimental/sparse/_base.py
@@ -53,7 +53,7 @@ class JAXSparse(util.StrictABC):
       nse = self.nse
       dtype = self.dtype
       shape = list(self.shape)
-    except:
+    except Exception:
       repr_ = f"{name}(<invalid>)"
     else:
       repr_ = f"{name}({dtype}{shape}, {nse=})"

--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -2509,7 +2509,7 @@ class BCOO(JAXSparse):
       n_dense = self.n_dense
       dtype = self.dtype
       shape = list(self.shape)
-    except:
+    except Exception:
       repr_ = f"{name}(<invalid>)"
     else:
       extra = f", {nse=}"

--- a/jax/version.py
+++ b/jax/version.py
@@ -59,7 +59,7 @@ def _version_from_git_tree(base_version: str) -> str | None:
     datestring = datetime.date.fromtimestamp(int(timestamp)).strftime("%Y%m%d")
     assert datestring.isnumeric()
     assert commit_hash.isalnum()
-  except:
+  except Exception:
     return None
   else:
     version = f"{base_version}.dev{datestring}+{commit_hash}"

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -7716,7 +7716,7 @@ class CleanupTest(jtu.JaxTestCase):
   def test_call_wrapped_second_phase_cleanup(self):
     try:
       jax.vmap(lambda x: x, out_axes=None)(jnp.arange(3))
-    except:
+    except Exception:
       assert core.trace_state_clean()  # this is the hard one
     assert core.trace_state_clean()
 

--- a/tests/generated_fun_test.py
+++ b/tests/generated_fun_test.py
@@ -246,7 +246,7 @@ class GeneratedFunTest(jtu.JaxTestCase):
     ans_jitted = maybe_jit(fun, len(vals))(*vals)
     try:
       check_all_close(ans, ans_jitted)
-    except:
+    except Exception:
       print(fun)
       raise
 

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -4949,7 +4949,7 @@ class LayoutTest(TestCase):
         used_regs = {get_reg(addr) for addr in addrs}
         try:
           self.assertLessEqual(len(used_regs), expected_regs)
-        except:
+        except Exception:
           problematic_device_patterns = ("RTX PRO 6000 Blackwell", "GB10$")
           if match := jtu.device_kind_match(problematic_device_patterns):
             self.skipTest(f"{match} uses more registers for an unknown reason")
@@ -5093,7 +5093,7 @@ class LayoutTest(TestCase):
     np.testing.assert_array_equal(yt_kernel, yt)
     try:
       self.assertEqual(sass().count("SHFL.BFLY"), regs_per_thread * shfl_per_reg)
-    except:
+    except Exception:
       problematic_device_patterns = ("RTX PRO 6000 Blackwell", "GB10$")
       if match := jtu.device_kind_match(problematic_device_patterns):
         self.skipTest(f"{match} requires more SHFL.BFLY for an unknown reason")

--- a/tests/pallas/mosaic_gpu_test.py
+++ b/tests/pallas/mosaic_gpu_test.py
@@ -2373,7 +2373,7 @@ class PallasCallTest(PallasTest, jtu.CudaArchSpecificTest):
           out_shape=x,
           scratch_shapes=[plgpu.Barrier()],
       )(x)
-    except:
+    except Exception:
       # assertRaisesRegex raises does not let us match the traceback.
       self.assertIn(offending_line, traceback.format_exc())
     else:

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -1909,7 +1909,7 @@ class ArrayPjitTest(jtu.JaxTestCase):
   def test_pjit_mixed_device_cache_miss(self):
     try:
       tpu_device = jax.devices('tpu')[0]
-    except:
+    except Exception:
       raise unittest.SkipTest('Only a bug on TPU.')
 
     with jax.default_device('cpu'):

--- a/tests/python_callback_test.py
+++ b/tests/python_callback_test.py
@@ -850,7 +850,7 @@ class PureCallbackTest(jtu.JaxTestCase):
 
     try:
       np.array(f(2.0))
-    except:
+    except Exception:
       # Only should not deadlock.
       pass
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -29,7 +29,7 @@ jax.config.parse_flags_with_absl()
 
 try:
   from jax._src.lib import utils as jaxlib_utils
-except:
+except Exception:
   jaxlib_utils = None
 
 class UtilTest(jtu.JaxTestCase):


### PR DESCRIPTION
## What
Replace 61 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors.