### PR TITLE
Fix s3 path normalization and add regression test

### DIFF
--- a/jax/experimental/array_serialization/serialization_test.py
+++ b/jax/experimental/array_serialization/serialization_test.py
@@ -607,6 +607,15 @@ class CheckpointTest(jtu.JaxTestCase):
     else:
       self.assertEqual(spec['kvstore']['base']['path'], expected_path)
 
+  def test_get_tensorstore_spec_ocdbt_s3_path(self):
+    path = 's3://my-bucket/ckpt/dir/array_name'
+    spec = ts_impl.get_tensorstore_spec(path, ocdbt=True)
+
+    self.assertEqual(spec['kvstore']['base']['driver'], 's3')
+    self.assertEqual(spec['kvstore']['base']['bucket'], 'my-bucket')
+    self.assertEqual(spec['kvstore']['base']['path'], 'ckpt/dir')
+    self.assertEqual(spec['kvstore']['path'], 'array_name')
+
   def test_get_tensorstore_spec_not_absolute_path(self):
     path = 'my/ckpt/path'
     with self.assertRaisesRegex(ValueError,

--- a/jax/experimental/array_serialization/tensorstore_impl.py
+++ b/jax/experimental/array_serialization/tensorstore_impl.py
@@ -252,7 +252,7 @@ def get_tensorstore_spec(
   # replace a the double '//' with a single '/' and we need to restore the
   # filesystem type:// prefix for GCS (gs://) and S3 paths (s3://)
   ckpt_path = os.path.normpath(str(ckpt_path))
-  ckpt_path = re.sub(r"^([a-z]+):/", r"\1://", ckpt_path)
+  ckpt_path = re.sub(r"^(gs|s3):/", r"\1://", ckpt_path)
 
   # in cases of multi-process writes, we need to write to a different location
   # for each process and finally created a combined symlink to the final


### PR DESCRIPTION
## Summary

This fixes S3 checkpoint path handling in TensorStore spec construction.

- In `get_tensorstore_spec()`, path normalization can collapse `s3://...` to `s3:/...`.
- The old restore regex was `^([a-z]+):/`, which does not match `s3` (contains a digit), so S3 paths were left malformed and could fall through to file-driver handling.
- Updated the regex to only restore supported remote prefixes: `^(gs|s3):/ -> \1://`.
- Added a regression test that verifies an S3 path produces an S3 OCDBT base kvstore (driver/bucket/path) and preserves the entry key.

## Root Cause

`os.path.normpath()` collapses double slashes in URI-like strings.
For `s3://bucket/dir/name`, this becomes `s3:/bucket/dir/name`.
The prior regex restored `gs:/...` but not `s3:/...` due to `[a-z]+`.


## Testing

I only ran tests that look directly related to this fix.

cc @rdyro 

cf. https://github.com/marin-community/marin/issues/2938