### PR TITLE
Fix typo in `test_util` function parameter documentation

### DIFF
--- a/jax/_src/public_test_util.py
+++ b/jax/_src/public_test_util.py
@@ -250,8 +250,8 @@ def check_jvp(f, f_jvp, args, atol=None, rtol=None, eps=EPS, err_msg=''):
 
   Args:
     f: function to check at ``f(*args)``.
-    f_vjp: function that calculates ``jax.jvp`` applied to ``f``. Typically this
-      should be ``functools.partial(jax.jvp, f))``.
+    f_jvp: function that calculates ``jax.jvp`` applied to ``f``. Typically this
+      should be ``functools.partial(jax.jvp, f)``.
     args: tuple of argument values.
     atol: absolute tolerance for gradient equality.
     rtol: relative tolerance for gradient equality.
@@ -289,7 +289,7 @@ def check_vjp(f, f_vjp, args, atol=None, rtol=None, eps=EPS, err_msg=''):
   Args:
     f: function to check at ``f(*args)``.
     f_vjp: function that calculates ``jax.vjp`` applied to ``f``. Typically this
-      should be ``functools.partial(jax.jvp, f))``.
+      should be ``functools.partial(jax.vjp, f)``.
     args: tuple of argument values.
     atol: absolute tolerance for gradient equality.
     rtol: relative tolerance for gradient equality.


### PR DESCRIPTION
- `check_jvp` takes `f_jvp`
- Example `f_vjp` in `check_vjp` should be `functools.partial(jax.vjp, f)`