### PR TITLE
[typing] fix pyi type signature for argsort

### DIFF
--- a/jax/numpy/__init__.pyi
+++ b/jax/numpy/__init__.pyi
@@ -165,6 +165,7 @@ def argsort(
     descending: builtins.bool = ...,
     kind: str | None = ...,
     order: None = ...,
+    dtype: DTypeLike | None = ...,
 ) -> Array: ...
 def argwhere(
     a: ArrayLike,


### PR DESCRIPTION
We overlooked this in #34937.