### PR TITLE
[ROCm] Skip test_topology_jit_serialize on ROCm GPU

### DIFF
--- a/tests/aot_test.py
+++ b/tests/aot_test.py
@@ -75,7 +75,7 @@ class JaxAotTest(jtu.JaxTestCase):
 
     if jtu.TEST_WITH_PERSISTENT_COMPILATION_CACHE.value:
       raise unittest.SkipTest('Compilation caching not yet supported.')
-    if jtu.is_device_cuda():
+    if jtu.is_device_cuda() or jtu.is_device_rocm():
       raise unittest.SkipTest('Broken on GPU: b/442353988')
 
     @jax.jit

--- a/tests/aot_test.py
+++ b/tests/aot_test.py
@@ -75,7 +75,7 @@ class JaxAotTest(jtu.JaxTestCase):
 
     if jtu.TEST_WITH_PERSISTENT_COMPILATION_CACHE.value:
       raise unittest.SkipTest('Compilation caching not yet supported.')
-    if jtu.is_device_cuda() or jtu.is_device_rocm():
+    if jtu.test_device_matches(['gpu']):
       raise unittest.SkipTest('Broken on GPU: b/442353988')
 
     @jax.jit


### PR DESCRIPTION
The test is already skipped on CUDA (b/442353988) due to HLO debug
metadata (source column numbers) being embedded in compiled output,
causing semantically identical compilations to produce different
`as_text()` results. The same issue occurs on ROCm.

This change extends the existing skip to also cover ROCm devices.

Test Result:

```bash
root@55df8a2f184b [docker:manju_ci_debug]:/workspace/ci_env/jax (main) # pytest tests/aot_test.py::JaxAotTest::test_topology_jit_serialize
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.12.3, pytest-8.4.2, pluggy-1.6.0
rootdir: /workspace/ci_env/jax
configfile: pyproject.toml
plugins: hypothesis-6.142.1, xdist-3.8.0, timeout-2.4.0, rerunfailures-16.1
collected 1 item                                                                                                                                                                           

tests/aot_test.py s                                                                                                                                                                  [100%]

==================================================================================== 1 skipped in 4.67s ====================================================================================
I0302 21:07:15.752926  335029 rocm_tracer.cc:493] Calling toolFinalize!
```