### PR TITLE
[ROCm] Add ROCm wheel build and test pipeline to continuous CI

### DIFF
--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -128,11 +128,6 @@ jobs:
         uses: google-ml-infra/actions/ci_connection@7f5ca0c263a81ed09ea276524c1b9192f1304e3c
         with:
           halt-dispatch-input: ${{ inputs.halt-for-connection }}
-      - name: Set ROCm requirements lock file
-        if: inputs.build_jaxlib == 'false'
-        run: |
-          PY_VERSION="${JAXCI_HERMETIC_PYTHON_VERSION//./_}"
-          echo "JAXCI_ROCM_LOCK_FLAG=--repo_env=HERMETIC_REQUIREMENTS_LOCK=build/requirements_lock_${PY_VERSION}_rocm.txt" >> $GITHUB_ENV
       - name: "Bazel ROCm tests with build_jax=${{ inputs.build_jax }}, build_jaxlib=${{ inputs.build_jaxlib }}"
         timeout-minutes: 120
         run: |

--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -1,0 +1,166 @@
+# CI - Build ROCm Artifacts
+# This workflow builds ROCm wheels (jax-rocm-plugin, jax-rocm-pjrt) in a ROCm container
+# and uploads them to an S3 bucket. It can be triggered manually via workflow_dispatch or
+# called by other workflows via workflow_call.
+name: CI - Build ROCm Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "Which runner should the workflow run on?"
+        type: choice
+        default: "linux-x86-64-1gpu-amd"
+        options:
+        - "linux-x86-64-1gpu-amd"
+      artifact:
+        description: "Which ROCm artifact to build?"
+        type: choice
+        default: "jax-rocm-plugin"
+        options:
+        - "jax-rocm-plugin"
+        - "jax-rocm-pjrt"
+      python:
+        description: "Which python version should the artifact be built for?"
+        type: choice
+        default: "3.12"
+        options:
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
+      rocm-version:
+        description: "Which ROCm version to build for?"
+        type: string
+        default: "7"
+      clone_main_xla:
+        description: "Should latest XLA be used?"
+        type: choice
+        default: "1"
+        options:
+        - "1"
+        - "0"
+      halt-for-connection:
+        description: 'Should this workflow run wait for a remote connection?'
+        type: choice
+        default: 'no'
+        options:
+        - 'yes'
+        - 'no'
+  workflow_call:
+    inputs:
+      runner:
+        description: "Which runner should the workflow run on?"
+        type: string
+        default: "linux-x86-64-1gpu-amd"
+      artifact:
+        description: "Which ROCm artifact to build?"
+        type: string
+        default: "jax-rocm-plugin"
+      python:
+        description: "Which python version should the artifact be built for?"
+        type: string
+        default: "3.12"
+      rocm-version:
+        description: "Which ROCm version to build for?"
+        type: string
+        default: "7"
+      clone_main_xla:
+        description: "Should latest XLA be used?"
+        type: string
+        default: "1"
+      upload_artifacts_to_s3:
+        description: "Should the artifacts be uploaded to S3?"
+        default: true
+        type: boolean
+      s3_upload_uri:
+        description: "S3 location prefix to where the artifacts should be uploaded"
+        default: 's3://jax-ci-amd/rocm-jax-plugin-wheels'
+        type: string
+      halt-for-connection:
+        description: 'Should this workflow run wait for a remote connection?'
+        type: string
+        default: 'no'
+    outputs:
+      s3_upload_uri:
+        description: "S3 location prefix to where the artifacts were uploaded"
+        value: ${{ jobs.build-artifacts.outputs.s3_upload_uri }}
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+jobs:
+  build-artifacts:
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ inputs.runner }}
+    outputs:
+      s3_upload_uri: ${{ steps.store-s3-upload-uri.outputs.s3_upload_uri }}
+    container:
+      image: "rocm/tensorflow-build@sha256:30e7fcfad87b74a4b916565a6156f4d8d01a2f5a4e06d0d0e6c37926a1507d72"
+      volumes:
+        - /data:/data
+      options: >-
+        --device=/dev/kfd
+        --device=/dev/dri
+        --security-opt seccomp=unconfined
+        --group-add video
+        --shm-size 64G
+
+    env:
+      JAXCI_HERMETIC_PYTHON_VERSION: "${{ inputs.python }}"
+      JAXCI_OUTPUT_DIR: "${{ github.workspace }}/dist"
+
+    name: "${{ inputs.artifact }}, py ${{ inputs.python }}, ROCm ${{ inputs.rocm-version }}"
+
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
+      - name: Install Bazelisk
+        run: |
+          curl -fSsL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
+          chmod +x /usr/local/bin/bazel
+      - name: ROCm Info
+        run: rocminfo
+      # Halt for testing
+      - name: Wait For Connection
+        uses: google-ml-infra/actions/ci_connection@7f5ca0c263a81ed09ea276524c1b9192f1304e3c
+        with:
+          halt-dispatch-input: ${{ inputs.halt-for-connection }}
+      - name: Create dist dir
+        run: mkdir -p $JAXCI_OUTPUT_DIR/
+      - name: Build ${{ inputs.artifact }}
+        timeout-minutes: 120
+        run: |
+          bazel --bazelrc=build/rocm/rocm.bazelrc run \
+                --config=rocm_release_wheel \
+                --config=rocm_rbe \
+                --repo_env=HERMETIC_PYTHON_VERSION="${{ inputs.python }}" \
+                $DEPLOY_TARGET -- $JAXCI_OUTPUT_DIR/
+        env:
+          DEPLOY_TARGET: ${{ inputs.artifact == 'jax-rocm-plugin' && '//jaxlib/tools:deploy_rocm_plugin_wheel' || '//jaxlib/tools:deploy_rocm_pjrt_wheel' }}
+      - name: Configure AWS Credentials
+        if: ${{ inputs.upload_artifacts_to_s3 }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::661452401056:role/jax-ci-amd-s3-oidc
+          aws-region: us-east-1
+      - name: Upload artifacts to S3
+        if: ${{ inputs.upload_artifacts_to_s3 }}
+        run: |
+          echo "Uploading wheels to S3..."
+          ls -lh $JAXCI_OUTPUT_DIR/*.whl
+          aws s3 cp --only-show-errors --recursive $JAXCI_OUTPUT_DIR/ "${INPUTS_S3_UPLOAD_URI}"/
+          echo "Upload complete."
+        env:
+          INPUTS_S3_UPLOAD_URI: ${{ inputs.s3_upload_uri }}
+      - name: Store the S3 upload URI as an output
+        if: ${{ inputs.upload_artifacts_to_s3 }}
+        id: store-s3-upload-uri
+        run: echo "s3_upload_uri=${INPUTS_S3_UPLOAD_URI}" >> "$GITHUB_OUTPUT"
+        env:
+          INPUTS_S3_UPLOAD_URI: ${{ inputs.s3_upload_uri }}

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -1,6 +1,6 @@
 # CI - Wheel Tests (Continuous)
 #
-# This workflow builds JAX artifacts and runs CPU/TPU/CUDA tests.
+# This workflow builds JAX artifacts and runs CPU/TPU/CUDA/ROCm tests.
 #
 # It orchestrates the following:
 # 1. build-jaxlib-artifact: Calls the `build_artifacts.yml` workflow to build jaxlib and
@@ -22,15 +22,26 @@
 #                           that was built in the previous step and runs TPU tests.
 # 9. run-bazel-test-tpu:    Calls the `bazel_test_tpu.yml` workflow which
 #                           runs Bazel TPU tests with py_import.
+# 10. build-rocm-artifacts: Calls the `build_rocm_artifacts.yml` workflow to build ROCm plugin/pjrt
+#                           wheels and uploads them to an S3 bucket.
+# 11. run-pytest-rocm:      Calls the `pytest_rocm.yml` workflow which downloads the jaxlib and
+#                           ROCm artifacts and runs the ROCm tests.
+# 12. run-bazel-test-rocm:  Calls the `bazel_rocm.yml` workflow which runs the ROCm Bazel tests.
 
 name: CI - Wheel Tests (Continuous)
 permissions:
-      contents: read
+  id-token: write
+  contents: read
+  actions: read
 
 on:
   schedule:
     - cron: "0 */3 * * *" # Run once every 3 hours
   workflow_dispatch: # allows triggering the workflow run manually
+  pull_request:
+    paths:
+      - '.github/workflows/wheel_tests_continuous.yml'
+      - '.github/workflows/build_rocm_artifacts.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -285,4 +296,72 @@ jobs:
       gcs_download_uri: ${{ needs.build-jaxlib-artifact.outputs.gcs_upload_uri }}
       build_jaxlib: "wheel"
       build_jax: "wheel"
+      clone_main_xla: 1
+
+  build-rocm-artifacts:
+    uses: ./.github/workflows/build_rocm_artifacts.yml
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+    strategy:
+        fail-fast: false
+        matrix:
+          runner: ["linux-x86-64-1gpu-amd"]
+          artifact: ["jax-rocm-plugin", "jax-rocm-pjrt"]
+          python: ["3.11"]
+          rocm-version: ["7"]
+    name: "Build ${{ format('{0}', 'ROCm') }} artifacts"
+    with:
+      runner: ${{ matrix.runner }}
+      artifact: ${{ matrix.artifact }}
+      python: ${{ matrix.python }}
+      rocm-version: ${{ matrix.rocm-version }}
+      clone_main_xla: 1
+      upload_artifacts_to_s3: true
+      s3_upload_uri: 's3://jax-ci-amd/jax-rocm-plugin-wheels/wheel-tests-continuous/${{ github.run_number }}/${{ github.run_attempt }}'
+
+  run-pytest-rocm:
+    if: ${{ !cancelled() }}
+    needs: [build-jax-artifact, build-jaxlib-artifact, build-rocm-artifacts]
+    uses: ./.github/workflows/pytest_rocm.yml
+    strategy:
+        fail-fast: false
+        matrix:
+          runner: ["linux-x86-64-1gpu-amd", "linux-x86-64-4gpu-amd", "linux-x86-64-8gpu-amd"]
+          python: ["3.11"]
+          rocm: [
+            {version: "7.2.0", tag: "rocm720"},
+          ]
+    name: "Pytest ROCm (JAX artifacts version = ${{ format('{0}', 'head') }})"
+    with:
+      runner: ${{ matrix.runner }}
+      python: ${{ matrix.python }}
+      rocm-version: ${{ matrix.rocm.version }}
+      rocm-tag: ${{ matrix.rocm.tag }}
+      jaxlib-version: "head"
+      gcs_download_uri: ${{ needs.build-jaxlib-artifact.outputs.gcs_upload_uri }}
+
+  run-bazel-test-rocm:
+    if: ${{ !cancelled() }}
+    needs: [build-jax-artifact, build-jaxlib-artifact, build-rocm-artifacts]
+    uses: ./.github/workflows/bazel_rocm.yml
+    strategy:
+        fail-fast: false
+        matrix:
+          runner: ["linux-x86-64-4gpu-amd", "linux-x86-64-8gpu-amd"]
+          python: ["3.11"]
+          rocm-version: ["7"]
+          enable-x64: [0]
+    name: "Bazel ROCm tests (JAX artifacts version = ${{ format('{0}', 'head') }})"
+    with:
+      runner: ${{ matrix.runner }}
+      python: ${{ matrix.python }}
+      rocm-version: ${{ matrix.rocm-version }}
+      enable-x64: ${{ matrix.enable-x64 }}
+      gcs_download_uri: ${{ needs.build-jaxlib-artifact.outputs.gcs_upload_uri }}
+      build_jaxlib: "false"
+      build_jax: "false"
+      jaxlib-version: "head"
+      run_multiaccelerator_tests: "false"
       clone_main_xla: 1

--- a/build/rocm/rocm.bazelrc
+++ b/build/rocm/rocm.bazelrc
@@ -20,6 +20,9 @@ common:rocm --copt=-Qunused-arguments
 # Used for @xla//build_tools/rocm:parallel_gpu_execute
 common:rocm --legacy_external_runfiles=true
 
+build:rocm_release_wheel --config=rocm
+build:rocm_release_wheel --@local_config_rocm//rocm:rocm_path_type=link_only
+
 test:rocm --test_timeout=920,2400,7200,9600
 test:rocm --flaky_test_attempts=3
 test:rocm --test_verbose_timeout_warnings

--- a/ci/utilities/run_auditwheel.sh
+++ b/ci/utilities/run_auditwheel.sh
@@ -18,7 +18,7 @@
 
 # Get a list of all the wheels in the output directory. Only look for wheels
 # that need to be verified for manylinux compliance.
-WHEELS=$(find "$JAXCI_OUTPUT_DIR/" -type f \( -name "*jaxlib*whl" -o -name "*jax*cuda*pjrt*whl" -o -name "*jax*cuda*plugin*whl" \))
+WHEELS=$(find "$JAXCI_OUTPUT_DIR/" -type f \( -name "*jaxlib*whl" -o -name "*jax*cuda*pjrt*whl" -o -name "*jax*cuda*plugin*whl" -o -name "*jax*rocm*pjrt*whl" -o -name "*jax*rocm*plugin*whl" \))
 
 if [[ -z "$WHEELS" ]]; then
   echo "ERROR: No wheels found under $JAXCI_OUTPUT_DIR"

--- a/jaxlib/jax.bzl
+++ b/jaxlib/jax.bzl
@@ -587,6 +587,27 @@ def jax_wheel(
         source_files = source_files,
     )
 
+def deploy_wheel(name, wheel):
+    """Creates a runnable target that copies a wheel to a given directory.
+
+    Usage: bazel run <target> -- /output/dir
+
+    Args:
+      name: the target name
+      wheel: the wheel target to deploy
+    """
+    native.genrule(
+        name = name + "_gen",
+        srcs = [wheel],
+        outs = [name + ".sh"],
+        cmd = "echo '#!/bin/bash\ncp $(rootpath {wheel}) $$1' > $@".format(wheel = wheel),
+    )
+    native.sh_binary(
+        name = name,
+        srcs = [name + ".sh"],
+        data = [wheel],
+    )
+
 def jax_source_package(
         name,
         source_package_binary,

--- a/jaxlib/rocm/rocm_version.bzl
+++ b/jaxlib/rocm/rocm_version.bzl
@@ -1,0 +1,29 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ROCm version constants derived from @local_config_rocm.
+
+The rocm_version_number() function from build_defs.bzl returns an integer
+encoded as: major * 10000 + minor * 100 + patch (e.g. 70101 for 7.1.1).
+"""
+
+load(
+    "@local_config_rocm//rocm:build_defs.bzl",
+    "rocm_version_number",
+)
+
+_version = rocm_version_number()
+ROCM_MAJOR_VERSION = str(_version // 10000)
+ROCM_MINOR_VERSION = str((_version % 10000) // 100)
+ROCM_PATCH_VERSION = str(_version % 100)

--- a/jaxlib/tools/BUILD.bazel
+++ b/jaxlib/tools/BUILD.bazel
@@ -32,6 +32,7 @@ load(
     "//jaxlib:jax.bzl",
     "PLATFORM_TAGS_DICT",
     "compare_srcs_and_test_deps_test",
+    "deploy_wheel",
     "get_test_suite_list",
     "if_pypi_cuda_wheel_deps",
     "jax_wheel",
@@ -39,6 +40,7 @@ load(
     "pytype_test",
     "wheel_sources",
 )
+load("//jaxlib/rocm:rocm_version.bzl", "ROCM_MAJOR_VERSION")
 
 licenses(["notice"])  # Apache 2
 
@@ -285,21 +287,21 @@ jax_wheel(
     name = "jax_rocm_plugin_wheel",
     enable_rocm = True,
     no_abi = False,
-    platform_version = "7",
+    platform_version = ROCM_MAJOR_VERSION,
     reproducible = True,
     source_files = [":jax_plugin_sources"],
     wheel_binary = ":build_gpu_kernels_wheel_tool",
-    wheel_name = "jax_rocm7_plugin",
+    wheel_name = "jax_rocm{}_plugin".format(ROCM_MAJOR_VERSION),
 )
 
 jax_wheel(
     name = "jax_rocm_plugin_wheel_editable",
     editable = True,
     enable_rocm = True,
-    platform_version = "7",
+    platform_version = ROCM_MAJOR_VERSION,
     source_files = [":jax_plugin_sources"],
     wheel_binary = ":build_gpu_kernels_wheel_tool",
-    wheel_name = "jax_rocm7_plugin",
+    wheel_name = "jax_rocm{}_plugin".format(ROCM_MAJOR_VERSION),
 )
 
 # JAX PJRT wheel targets.
@@ -395,21 +397,33 @@ jax_wheel(
     name = "jax_rocm_pjrt_wheel",
     enable_rocm = True,
     no_abi = True,
-    platform_version = "7",
+    platform_version = ROCM_MAJOR_VERSION,
     reproducible = True,
     source_files = [":jax_pjrt_sources"],
     wheel_binary = ":build_gpu_plugin_wheel_tool",
-    wheel_name = "jax_rocm7_pjrt",
+    wheel_name = "jax_rocm{}_pjrt".format(ROCM_MAJOR_VERSION),
 )
 
 jax_wheel(
     name = "jax_rocm_pjrt_wheel_editable",
     editable = True,
     enable_rocm = True,
-    platform_version = "7",
+    platform_version = ROCM_MAJOR_VERSION,
     source_files = [":jax_pjrt_sources"],
     wheel_binary = ":build_gpu_plugin_wheel_tool",
-    wheel_name = "jax_rocm7_pjrt",
+    wheel_name = "jax_rocm{}_pjrt".format(ROCM_MAJOR_VERSION),
+)
+
+# ROCm wheel deploy targets.
+# Usage: bazel run //jaxlib/tools:deploy_rocm_plugin_wheel -- /output/dir
+deploy_wheel(
+    name = "deploy_rocm_plugin_wheel",
+    wheel = ":jax_rocm_plugin_wheel",
+)
+
+deploy_wheel(
+    name = "deploy_rocm_pjrt_wheel",
+    wheel = ":jax_rocm_pjrt_wheel",
 )
 
 # Py_import targets.


### PR DESCRIPTION
- Add jax-rocm-plugin and jax-rocm-pjrt to allowed artifacts in build_artifacts.sh with ROCm version flag passthrough.
- Create build_rocm_artifacts.yml reusable workflow that builds ROCm wheels in a ROCm container and uploads them to S3 via OIDC.
- Extend wheel_tests_continuous.yml with build-rocm-artifacts, run-pytest-rocm, and run-bazel-test-rocm jobs.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->