### PR TITLE
[pyrefly] test with opt-einsum

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,7 @@ repos:
         - types-requests~=2.32.0
         - numpy~=2.4.0
         - ml_dtypes~=0.5.0
+        - opt-einsum~=3.4.0
         - scipy-stubs
         - --pre
         - --extra-index-url

--- a/jax/_src/numpy/einsum.py
+++ b/jax/_src/numpy/einsum.py
@@ -422,6 +422,7 @@ def einsum_path(
     optimize2: Any = 'optimal' if optimize else Unoptimized()
   else:
     optimize2 = optimize
+  # pyrefly: ignore[no-matching-overload]
   return opt_einsum.contract_path(subscripts, *operands, optimize=optimize2)
 
 def _removechars(s, chars):


### PR DESCRIPTION
If `pyrefly` is run with `opt_einsum` installed in the environment, there is one overloaded signature error. This PR silences that, and adds `opt_einsum` to the configuration to ensure it's checked by CI.