### PR TITLE
Fix pivoted qr jvp rule, which was broken when vmapped

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1863,12 +1863,15 @@ def qr_jvp_rule(primals, tangents, *, pivoting, full_matrices, use_magma):
   x, = primals
   dx, = tangents
   q, r, *p = qr_p.bind(x, pivoting=pivoting, full_matrices=False, use_magma=use_magma)
-  *_, m, n = x.shape
+  *batch_dims, m, n = x.shape
   if m < n or (full_matrices and m != n):
     raise NotImplementedError(
       "Unimplemented case of QR decomposition derivative")
   if pivoting:
-    dx = dx[..., p[0]]
+    permute_fn = lambda dx, p: dx[..., p]
+    for _ in range(len(batch_dims)):
+      permute_fn = api.vmap(permute_fn)
+    dx = permute_fn(dx, p[0])
   dx_rinv = triangular_solve(r, dx)  # Right side solve by default
   qt_dx_rinv = _H(q) @ dx_rinv
   qt_dx_rinv_lower = _tril(qt_dx_rinv, -1)


### PR DESCRIPTION
The old qr jvp rule was broken when vmapped, see the following test:

```python
import jax
import jax.numpy as jnp
from functools import partial

m = jnp.arange(18,dtype=jnp.float64).reshape(2,3,3)
mt = jnp.arange(18,36,dtype=jnp.float64).reshape(2,3,3)

res1 = jax.jvp(jax.vmap(partial(jax.scipy.linalg.qr, pivoting=True, mode='economic')), (m,), (mt,))
res2 = jax.vmap(lambda m,mt: jax.jvp(partial(jax.scipy.linalg.qr, pivoting=True, mode='economic'), (m,), (mt,) )) ((m,), (mt,))
```

The fix is a single line.