### PR TITLE
Replaced blanket `type: ignore`s with `pyrefly` directives

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -577,7 +577,7 @@ def _remat_bind(*args, jaxpr, prevent_cse, differentiated, policy):
   assert isinstance(prevent_cse, bool) or len(prevent_cse) == len(args)
   return core.Primitive.bind(remat_p, *args, jaxpr=jaxpr, prevent_cse=prevent_cse,
                              differentiated=differentiated, policy=policy)
-remat_p.bind = _remat_bind  # type: ignore
+remat_p.bind = _remat_bind
 
 @remat_p.def_impl
 def remat_impl(*args, jaxpr, prevent_cse, differentiated, policy):
@@ -892,7 +892,7 @@ def _remat_lowering(
         mlir.flatten_ir_values(barrier_args))
     barrier_results = mlir.unflatten_ir_values_like_types(
         barrier_op.results, map(mlir.aval_to_ir_type, barrier_avals))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
-    args = merge_lists(prevent_cse, other_args, barrier_results)  # type: ignore
+    args = merge_lists(prevent_cse, other_args, barrier_results)
   outs, tokens_out = mlir.jaxpr_subcomp(
       ctx.module_context, jaxpr, ctx.name_stack.extend('checkpoint'),
       ctx.tokens_in, (), *args, dim_var_values=ctx.dim_var_values,
@@ -905,7 +905,7 @@ mlir.register_lowering(remat_p, _remat_lowering)
 
 def _remat_is_high(*_, jaxpr, **__) -> bool:
   return jaxpr.is_high
-remat_p.is_high = _remat_is_high  # type: ignore
+remat_p.is_high = _remat_is_high
 
 
 def _remat_to_lojax(*hi_args, jaxpr, **kwds):
@@ -1017,7 +1017,7 @@ class RematTraced(VJPHiPrimitive):
     super().__init__()
 
   def expand(self, *args):
-    return self.traced(*args)  # type: ignore
+    return self.traced(*args)
 
   def vjp_fwd(self, _nzs_in, *primals):
     primals_out, fwd2 = remat_transform(self.policy, self.traced, *primals)

--- a/jax/_src/ad_util.py
+++ b/jax/_src/ad_util.py
@@ -45,7 +45,7 @@ add_any_p = add_jaxvals_p
 @add_jaxvals_p.def_impl
 def add_impl(x, y):
   return raw_jaxval_adders[type(x)](x, y)
-raw_jaxval_adders = {}  # type: ignore
+raw_jaxval_adders = {}
 
 @add_jaxvals_p.def_abstract_eval
 def add_abstract(x, y):

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1901,7 +1901,7 @@ def _cpp_mapped_lower(pmap_f, *args, **kwargs):
       lowering_parameters=pxla.mlir.LoweringParameters())
   args_info = stages.make_args_info(p.in_tree, abstract_args, pmap_f._donate_tuple)
   return stages.Lowered(lowering, args_info, p.out_tree())
-_pmap_cache_clears = weakref.WeakSet()  # type: ignore
+_pmap_cache_clears = weakref.WeakSet()
 
 
 @partial(api_boundary, repro_api_name="jax.jvp")

--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -611,7 +611,7 @@ class ArrayImpl(basearray.Array):
     return self
 
   @use_cpp_method()
-  def _single_device_array_to_np_array_did_copy(self) -> tuple[np.ndarray, bool]:  # type: ignore
+  def _single_device_array_to_np_array_did_copy(self) -> tuple[np.ndarray, bool]:
     ...  # pytype: disable=bad-return-type
 
   @use_cpp_method()

--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -463,7 +463,7 @@ def _reduce_any_error(error: Error):
 ## check_p primitive
 
 check_p = core.Primitive('check')
-check_p.is_effectful = lambda _: True  # type: ignore
+check_p.is_effectful = lambda _: True
 check_p.multiple_results = True  # zero results
 
 

--- a/jax/_src/compiler.py
+++ b/jax/_src/compiler.py
@@ -336,9 +336,9 @@ def backend_compile_and_load(
       if host_callbacks:
         return backend.compile(  # type: ignore
             module,
-            executable_devices=executable_devices,  # type: ignore
+            executable_devices=executable_devices,
             compile_options=options,
-            host_callbacks=host_callbacks,  # type: ignore
+            host_callbacks=host_callbacks,
         )
       # Some backends don't have `host_callbacks` option yet
       # TODO(sharadmv): remove this fallback when all backends allow `compile`
@@ -724,7 +724,7 @@ def _compile_and_share_module(
         serialized_executable
     )
     executable = backend.deserialize_executable(
-        serialized_executable, executable_devices, compile_options)  # type: ignore
+        serialized_executable, executable_devices, compile_options)
 
   _compile_and_share_module.modules_cache[cache_key] = executable  # type: ignore[missing-attribute]
   return executable

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -220,7 +220,7 @@ class Config:
       self.complete_absl_config(absl.flags)
       already_configured_with_absl = True
 
-register_trace_context_callback = []  # type: ignore
+register_trace_context_callback = []
 
 trace_context = config_ext.trace_context
 

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -549,7 +549,7 @@ class Literal:
         except (TypeError, AttributeError, ValueError):
           return None
 
-  __hash__ = None  # type: ignore
+  __hash__ = None
 
   def pretty_print(self, context: JaxprPpContext, *, print_dtype: bool = True):
     del context  # unused
@@ -587,13 +587,13 @@ def jaxpr_const_args(jaxpr: Jaxpr) -> list[tuple[ArrayLike, AbstractValue]]:
     return []
   consts_by_id: dict[int, tuple[ArrayLike, AbstractValue]] = {}
   for v in jaxpr.outvars:
-    if type(v) is Literal and np.shape(v.val):  # type: ignore
-      consts_by_id[id(v)] = (v.val, v.aval)  # type: ignore
+    if type(v) is Literal and np.shape(v.val):
+      consts_by_id[id(v)] = (v.val, v.aval)
 
   for eqn in jaxpr.eqns:
     for v in eqn.invars:
-      if type(v) is Literal and np.shape(v.val):  # type: ignore
-        consts_by_id[id(v)] = (v.val, v.aval)  # type: ignore
+      if type(v) is Literal and np.shape(v.val):
+        consts_by_id[id(v)] = (v.val, v.aval)
     consts_by_id.update({id(v_aval[0]): v_aval
                          for v_aval in eqn_params_const_args(eqn.params)})
   return list(consts_by_id.values())
@@ -912,7 +912,7 @@ else:
 class Tracer(TracerBase, metaclass=TracerMeta):
   __array_priority__ = 1000
   __slots__ = ['__weakref__', '_trace', '_line_info']
-  __hash__ = None  # type: ignore
+  __hash__ = None
 
   _trace: Trace
   _line_info: source_info_util.SourceInfo | None
@@ -1753,7 +1753,7 @@ class AbstractValue:
     return unshard_aval(mesh, check_vma, spec, self)
 
   def vspace_add(self, x, y):
-    from jax._src.ad_util import add_jaxvals  # type: ignore
+    from jax._src.ad_util import add_jaxvals  # pytype: disable=import-error
     return add_jaxvals(x, y)
 
 InputType = tuple[AbstractValue, ...]
@@ -1942,7 +1942,7 @@ class AvalQDD:
 
   has_qdd = True
   def lo_ty(self):
-    return self.aval.lo_ty_qdd(self.qdd)  # type: ignore
+    return self.aval.lo_ty_qdd(self.qdd)
 
   def read_loval(self, val):
     return self.aval.read_loval(self.qdd, val)  # type: ignore
@@ -1998,7 +1998,7 @@ def physical_aval(aval):
   if (isinstance(aval, ShapedArray) and
       isinstance(aval.dtype, dtypes.ExtendedDType)):
     elt_aval = physical_element_aval(aval.dtype)
-    from jax._src.sharding_impls import physical_sharding  # type: ignore
+    from jax._src.sharding_impls import physical_sharding  # pytype: disable=import-error
     return ShapedArray((*aval.shape, *elt_aval.shape), elt_aval.dtype,
                        sharding=physical_sharding(aval, aval.sharding),
                        vma=aval.vma)
@@ -2009,7 +2009,7 @@ def physical_shape(logical_shape, dtype):
   return (*logical_shape, *elt_aval.shape)
 
 def physical_element_aval(edtype: dtypes.ExtendedDType) -> ShapedArray:
-  duck = edtype._rules.physical_element_aval(edtype)  # type: ignore
+  duck = edtype._rules.physical_element_aval(edtype)
   return ShapedArray(duck.shape, dtypes.dtype(duck.dtype))
 
 
@@ -2612,16 +2612,16 @@ def new_ref(init_val: Any, *, memory_space: Any = None, kind: Any = None):
   """
   return ref_p.bind(init_val, memory_space=memory_space, kind=kind)
 ref_p = Primitive('new_ref')
-ref_p.is_effectful = lambda params: True  # type: ignore
+ref_p.is_effectful = lambda params: True
 ref_p.ref_primitive = True
 
-ref_p.is_high = lambda aval, *, memory_space, kind: aval.is_high  # type: ignore
+ref_p.is_high = lambda aval, *, memory_space, kind: aval.is_high
 def _ref_to_lojax(init_val, *, memory_space, kind):
   from jax._src.state.types import AbstractRef  # pytype: disable=import-error
   val_ty = typeof(init_val)
-  hival_of_refs = val_ty.raise_val(*map(new_ref, val_ty.lower_val(init_val)))  # type: ignore
+  hival_of_refs = val_ty.raise_val(*map(new_ref, val_ty.lower_val(init_val)))
   return Ref(AbstractRef(val_ty), hival_of_refs)
-ref_p.to_lojax = _ref_to_lojax  # type: ignore
+ref_p.to_lojax = _ref_to_lojax
 
 
 # TODO(mattjj,dougalm): merge with ref_p
@@ -2630,7 +2630,7 @@ def empty_ref(ty, memory_space=None):
   return empty_ref_p.bind(ty=aval, memory_space=memory_space)
 empty_ref_p = Primitive('empty_ref')
 empty_ref_p.ref_primitive = True
-empty_ref_p.is_effectful = lambda _: True  # type: ignore
+empty_ref_p.is_effectful = lambda _: True
 
 
 @empty_ref_p.def_effectful_abstract_eval
@@ -2648,7 +2648,7 @@ def free_ref(ref: Ref):
 
 free_ref_p = Primitive('free_ref')
 free_ref_p.multiple_results = True
-free_ref_p.is_effectful = lambda _: True  # type: ignore
+free_ref_p.is_effectful = lambda _: True
 free_ref_p.ref_primitive = True
 
 
@@ -2712,7 +2712,7 @@ def freeze(ref: Ref) -> Array:
   """
   return freeze_p.bind(ref)
 freeze_p = Primitive('freeze')
-freeze_p.is_effectful = lambda params: True  # type: ignore
+freeze_p.is_effectful = lambda params: True
 freeze_p.ref_primitive = True
 
 @freeze_p.def_effectful_abstract_eval
@@ -2727,10 +2727,10 @@ def accum_grad_in_ref(x):
   return accum_grad_in_ref_p.bind(x)
 
 accum_grad_in_ref_p = Primitive('accum_grad_in_ref')
-accum_grad_in_ref_p.is_high = lambda *_: True  # type: ignore
-accum_grad_in_ref_p.to_lojax = lambda x: x  # type: ignore
-accum_grad_in_ref_p.def_abstract_eval(lambda x: x)  # type: ignore
-accum_grad_in_ref_p.def_impl(lambda x: x)  # type: ignore
+accum_grad_in_ref_p.is_high = lambda *_: True
+accum_grad_in_ref_p.to_lojax = lambda x: x
+accum_grad_in_ref_p.def_abstract_eval(lambda x: x)
+accum_grad_in_ref_p.def_impl(lambda x: x)
 
 
 class AbstractToken(AbstractValue):
@@ -3084,7 +3084,7 @@ class MapPrimitive(Primitive):
     return [subfun], new_params
 
 def mapped_aval(size: AxisSize, axis, aval: AbstractValue) -> AbstractValue:
-  from jax._src.hijax import HiType  # type: ignore
+  from jax._src.hijax import HiType  # pytype: disable=import-error
   if isinstance(aval, HiType):
     return aval.dec_rank(size, axis)  # type: ignore
   handler, _ = aval_mapping_handlers.get(type(aval), (None, None))
@@ -3099,7 +3099,7 @@ def mapped_leading_aval(size, aval) -> AbstractValue:
 # TODO(yashkatariya): take axis data
 def unmapped_aval(size: AxisSize, axis: int | None,
                   aval: AbstractValue, explicit_mesh_axis=None) -> AbstractValue:
-  from jax._src.hijax import HiType  # type: ignore
+  from jax._src.hijax import HiType  # pytype: disable=import-error
   if isinstance(aval, HiType):
     return aval.inc_rank(size, axis)  # type: ignore
   _, handler = aval_mapping_handlers.get(type(aval), (None, None))
@@ -3227,9 +3227,12 @@ def typematch(t1: AbstractValue, t2: AbstractValue,
     return t1.dtype == t2.dtype and cmp_shape_shd_vma_memsp(t1, t2)
   elif isinstance(t1, AbstractRef) and isinstance(t2, AbstractRef):
     # We want to use the regular typecheck for ShapedArray here.
-    return (typematch(t1.inner_aval, t2.inner_aval, no_dtype_check) and  # type: ignore
-            (t1.memory_space is None or t2.memory_space is None or  # type: ignore
-             t1.memory_space == t2.memory_space))  # type: ignore
+    # TODO(slebedev): Remove these aliases once we migrate off pytype.
+    t1_any: Any = t1
+    t2_any: Any = t2
+    return (typematch(t1_any.inner_aval, t2_any.inner_aval, no_dtype_check) and
+            (t1_any.memory_space is None or t2_any.memory_space is None or
+             t1_any.memory_space == t2_any.memory_space))
   else:
     return False
 
@@ -3714,7 +3717,7 @@ def _sds_aval_mapping(x):
   aval = update_aval_with_sharding(
       aval, x.sharding, vma=(frozenset() if x.vma is None else x.vma))
   if x.is_ref:
-    from jax._src.state.types import AbstractRef  # type: ignore
+    from jax._src.state.types import AbstractRef  # pytype: disable=import-error
     return AbstractRef(aval)
   return aval
 pytype_aval_mappings[ShapeDtypeStruct] = _sds_aval_mapping
@@ -4021,12 +4024,12 @@ def clean_up_dead_vars(eqn: JaxprEqn, env: dict[Var, Any],
       del env[v]
 
 # Used in shard_map for converting avals
-shard_aval_handlers = {}  # type: ignore
-unshard_aval_handlers = {}  # type: ignore
+shard_aval_handlers = {}
+unshard_aval_handlers = {}
 
 def shard_aval(mesh, manual_axes, check_vma, spec, aval: AbstractValue
                ) -> AbstractValue:
-  from jax._src.hijax import HiType  # type: ignore
+  from jax._src.hijax import HiType  # pytype: disable=import-error
   if isinstance(aval, HiType):
     return aval.shard(mesh, manual_axes, check_vma, spec)
   if (handler := shard_aval_handlers.get(type(aval))):
@@ -4035,7 +4038,7 @@ def shard_aval(mesh, manual_axes, check_vma, spec, aval: AbstractValue
 
 def unshard_aval(mesh, check_vma, spec, aval: AbstractValue
                  ) -> AbstractValue:
-  from jax._src.hijax import HiType  # type: ignore
+  from jax._src.hijax import HiType  # pytype: disable=import-error
   if isinstance(aval, HiType):
     return aval.unshard(mesh, check_vma, spec)
   if (handler := unshard_aval_handlers.get(type(aval))):

--- a/jax/_src/custom_partitioning.py
+++ b/jax/_src/custom_partitioning.py
@@ -86,7 +86,7 @@ class _ShardingCallbackInfo:
     )
 
 
-_sharding_callbacks = weakref.WeakValueDictionary()  # type: ignore
+_sharding_callbacks = weakref.WeakValueDictionary()
 
 _CUSTOM_PARTITIONING_CALL_NAME = "CustomSPMDPartitioning"
 

--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -628,7 +628,7 @@ def _inspect_sharding_jvp_rule(primals, _, **params):
   return inspect_sharding_p.bind(*primals, **params), []
 ad.primitive_jvps[inspect_sharding_p] = _inspect_sharding_jvp_rule
 
-sharding_callbacks = weakref.WeakValueDictionary()  # type: ignore
+sharding_callbacks = weakref.WeakValueDictionary()
 _INSPECT_SHARDING_CALL_NAME = "InspectSharding"
 
 class ShardingCallbackInfo:

--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -178,7 +178,7 @@ class State:
       jax_partition_index = os.environ.get('JAX_PARTITION_INDEX')
       jax_slice_index = os.environ.get('JAX_SLICE_INDEX')
       if jax_partition_index is not None:
-        partition_index = int(jax_partition_index)  # type: ignore
+        partition_index = int(jax_partition_index)
       elif jax_slice_index is not None:
         # Deprecation added 2025-08-05. Should be removed after 3 months.
         warnings.warn(
@@ -186,7 +186,7 @@ class State:
             ' JAX_PARTITION_INDEX instead.',
             DeprecationWarning,
         )
-        partition_index = int(jax_slice_index)  # type: ignore
+        partition_index = int(jax_slice_index)
     self.partition_index = partition_index
 
   def shutdown(self):

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -599,7 +599,7 @@ _complex_types: list[JAXType] = [
 # StringDType to be used in there.
 _string_types: list[JAXType] = []
 if hasattr(np.dtypes, 'StringDType'):
-  _string_types: list[JAXType] = [np.dtypes.StringDType()]  # type: ignore
+  _string_types: list[JAXType] = [np.dtypes.StringDType()]
 
 _jax_dtype_set = {
     float0,

--- a/jax/_src/export/_export.py
+++ b/jax/_src/export/_export.py
@@ -1389,10 +1389,10 @@ def _get_vjp_fun(
     else:
       assert device_assignment is not None
       vjp_in_shardings = tuple(
-          _hlo_sharding_to_gspmd_sharding(s, device_assignment)  # type: ignore
+          _hlo_sharding_to_gspmd_sharding(s, device_assignment)
           for s in itertools.chain(in_shardings_hlo, out_shardings_hlo))
       vjp_out_shardings = tuple(
-          _hlo_sharding_to_gspmd_sharding(s, device_assignment)  # type: ignore
+          _hlo_sharding_to_gspmd_sharding(s, device_assignment)
           for s in in_shardings_hlo)
     return pjit.pjit(fun_vjp_jax,
                      in_shardings=vjp_in_shardings,

--- a/jax/_src/export/serialization.py
+++ b/jax/_src/export/serialization.py
@@ -479,7 +479,7 @@ def _serialize_partition_spec_one_axis(builder: flatbuffers.Builder,
   if spec is None:
     axes = ()
   else:
-    axes = (spec,) if isinstance(spec, str) else spec  # type: ignore
+    axes = (spec,) if isinstance(spec, str) else spec
 
   axes_offset = _serialize_array(builder,
                                  lambda builder, ps: builder.CreateString(ps),

--- a/jax/_src/export/shape_poly.py
+++ b/jax/_src/export/shape_poly.py
@@ -233,9 +233,9 @@ class _DimFactor:
     else:
       operand_values = [opnd._evaluate(env) for opnd in self.operands]
       if self.operation == _DimFactor.FLOORDIV:
-        return divmod(*operand_values)[0]  # type: ignore
+        return divmod(*operand_values)[0]
       elif self.operation == _DimFactor.MOD:
-        return divmod(*operand_values)[1]  # type: ignore
+        return divmod(*operand_values)[1]
       elif self.operation == _DimFactor.MAX:
         op1, op2 = operand_values
         if core.is_constant_dim(op1) and core.is_constant_dim(op2):
@@ -1277,7 +1277,7 @@ def _einsum_contract_path(*operands, **kwargs):
 shape_assertion_p = core.Primitive("shape_assertion")
 shape_assertion_p.multiple_results = True
 shape_assertion_p.def_effectful_abstract_eval(
-  lambda *_, **__: ((), {shape_assertion_effect}))  # type: ignore
+  lambda *_, **__: ((), {shape_assertion_effect}))
 
 def _shape_assertion_lowering_rule(ctx: mlir.LoweringRuleContext,
                                    assert_what: mlir.ir.Value,

--- a/jax/_src/ffi.py
+++ b/jax/_src/ffi.py
@@ -338,7 +338,7 @@ def _result_avals(results: Sequence[ResultMetadata]) -> tuple[core.AbstractValue
   avals: list[core.AbstractValue] = []
   for idx, result in enumerate(results):
     if result is core.abstract_token:
-      avals.append(result)  # type: ignore
+      avals.append(result)
     else:
       if not hasattr(result, "shape") or not hasattr(result, "dtype"):
         raise ValueError(

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -300,7 +300,7 @@ effects.control_flow_allowed_effects.add_type(BoxEffect)
 effects.custom_derivatives_allowed_effects.add_type(BoxEffect)
 
 class NewBox(HiPrimitive):
-  def is_high(self, *, treedef) -> bool: return True  # type: ignore
+  def is_high(self, *, treedef) -> bool: return True
 
   def abstract_eval(self, *, treedef):
     leaves, treedef = tree_flatten(None)
@@ -320,7 +320,7 @@ new_box_p = NewBox('new_box')
 class BoxSet(HiPrimitive):
   multiple_results = True
 
-  def is_high(self, *leaf_avals, treedef) -> bool: return True  # type: ignore
+  def is_high(self, *leaf_avals, treedef) -> bool: return True
 
   def abstract_eval(self, box_ty, *leaf_avals, treedef):
     box_ty.mutable_qdd.update(BoxTypeState(leaf_avals, treedef))
@@ -485,8 +485,8 @@ class VmapOf(VJPHiPrimitive):
 
   @property
   def _vmap_params(self):
-    return dict(axis_size=self.axis_data.size, axis_name=self.axis_data.name,  # type: ignore
-                spmd_axis_name=self.axis_data.spmd_name or self.axis_data.explicit_mesh_axis)  # type: ignore
+    return dict(axis_size=self.axis_data.size, axis_name=self.axis_data.name,
+                spmd_axis_name=self.axis_data.spmd_name or self.axis_data.explicit_mesh_axis)
 
   def expand(self, *args):
     return api.vmap(self.prim.expand, in_axes=self.in_dims, out_axes=self.out_dim,  # type: ignore
@@ -495,8 +495,8 @@ class VmapOf(VJPHiPrimitive):
   def jvp(self, primals, tangents):
     # TODO probably gonna get non-pytree-prefix errors because of sym zeros...
     return api.vmap(self.prim.jvp, in_axes=(self.in_dims, self.in_dims),  # type: ignore
-                    out_axes=(self.out_dim, self.out_dim),  # type: ignore
-                    **self._vmap_params)(primals, tangents)  # type: ignore
+                    out_axes=(self.out_dim, self.out_dim),
+                    **self._vmap_params)(primals, tangents)
 
   def vjp_fwd(self, in_nzs, *args):
     store = lambda: None
@@ -505,25 +505,25 @@ class VmapOf(VJPHiPrimitive):
       store.out_nzs = maybe_out_nzs  # pyrefly: ignore[missing-attribute]
       return primal_out, res
     (primal_out, res), (_, res_axes) = api.vmap(
-        fwd, in_axes=self.in_dims, out_axes=(self.out_dim, batching.infer),  # type: ignore
+        fwd, in_axes=self.in_dims, out_axes=(self.out_dim, batching.infer),
         **self._vmap_params)(*args)
     return primal_out, (res, Static(res_axes)), *store.out_nzs  # type: ignore
 
   def vjp_bwd_retval(self, res_, g):
     # TODO probably gonna get non-pytree-prefix errors because of sym zeros...
     res, res_axes = res_[0], res_[1].val
-    in_dims = tree_map(lambda x: batching.sum_axis if x is None else x, self.in_dims,  # type: ignore
+    in_dims = tree_map(lambda x: batching.sum_axis if x is None else x, self.in_dims,
                        is_leaf=lambda x: x is None)
-    g = tree_map(partial(map_zero, self.axis_data), self.out_dim, g, is_leaf=lambda x: x is None)  # type: ignore
+    g = tree_map(partial(map_zero, self.axis_data), self.out_dim, g, is_leaf=lambda x: x is None)
     out = api.vmap(self.prim.vjp_bwd_retval, in_axes=(res_axes, self.out_dim),  # type: ignore
                    out_axes=in_dims, **self._vmap_params, sum_match=True)(res, g)
-    return tree_map(partial(unmap_zero, self.axis_data), self.in_dims, out, is_leaf=lambda x: x is None)  # type: ignore
+    return tree_map(partial(unmap_zero, self.axis_data), self.in_dims, out, is_leaf=lambda x: x is None)
 
   def batch_dim_rule(self, axis_data, in_dims):
-    fix = lambda d, d_: d if (d is None or d_ is None) else d - (d_ < d)  # type: ignore
-    in_dims_ = tree_map(fix, in_dims, self.in_dims, is_leaf=lambda x: x is None)  # type: ignore
+    fix = lambda d, d_: d if (d is None or d_ is None) else d - (d_ < d)
+    in_dims_ = tree_map(fix, in_dims, self.in_dims, is_leaf=lambda x: x is None)
     out_dim = self.prim.batch_dim_rule(axis_data, in_dims_)  # type: ignore
-    return tree_map(lambda d, d_: d + (d_ < d), out_dim, self.out_dim)  # type: ignore
+    return tree_map(lambda d, d_: d + (d_ < d), out_dim, self.out_dim)
 
 def map_zero(axis_data, d, ct):
   if isinstance(ct, ad_util.Zero):
@@ -539,7 +539,7 @@ def unmap_zero(axis_data, d, ct):
 
 call_hi_primitive_p = core.Primitive("call_hi_primitive")
 call_hi_primitive_p.multiple_results = True
-call_hi_primitive_p.is_high = lambda *args, _prim: True  # type: ignore
+call_hi_primitive_p.is_high = lambda *args, _prim: True
 @call_hi_primitive_p.def_abstract_eval
 def _call_hi_primitive_abstract_eval(*_args, _prim):
   return _prim.out_avals_flat
@@ -597,7 +597,7 @@ def flatten_user_linearized(prim, residuals, *tangents_flat):
 
 call_hi_primitive_linearized_p = core.Primitive("call_hi_primitive_linearized")
 call_hi_primitive_linearized_p.multiple_results = True
-call_hi_primitive_linearized_p.is_high = lambda *args, _prim, **_: True  # type: ignore
+call_hi_primitive_linearized_p.is_high = lambda *args, _prim, **_: True
 @call_hi_primitive_linearized_p.def_abstract_eval
 def _call_hi_primitive_linearized_abstract_eval(*_args, _prim, residuals_tree, nz_in_flat):
   return [t.to_tangent_aval() for t in _prim.out_avals_flat]  # TODO(dougalm): handle nonzeros
@@ -677,18 +677,18 @@ class CustomVJPTraced(VJPHiPrimitive):
 
   def expand(self, *args):
     args = [x for x in args if not isinstance(x, Static)]
-    return self.traced(*args)  # type: ignore
+    return self.traced(*args)
 
   def vjp_fwd(self, in_nzs, *args):
     in_nzs = tuple(x.val if isinstance(x, Static) else x for x in in_nzs)
     args = tuple(x.val if isinstance(x, Static) else x for x in args)
-    if self.symbolic_zeros:  # type: ignore
+    if self.symbolic_zeros:
       args = tree_map(CustomVJPPrimal, args, in_nzs)
-    out, res = self.fwd(*args)  # type: ignore
+    out, res = self.fwd(*args)
     if ((tree := tree_structure(out)) != self.out_tree):
       raise TypeError(_vjp_primal_fwd_tree_mismatch_err(self, tree))
     tree_map_with_path(_vjp_fwd_aval_mismatch_err, self.out_aval, out)
-    if self.symbolic_zeros:  # type: ignore
+    if self.symbolic_zeros:
       out_pairs_flat = tree_leaves_checked(self.out_tree, out)
       out_flat, out_nzs_flat = unzip2(
           (x.value, x.perturbed) if isinstance(x, CustomVJPPrimal) else
@@ -703,34 +703,34 @@ class CustomVJPTraced(VJPHiPrimitive):
     static_args = tuple(x.val for x in self.in_avals if isinstance(x, Static))
     in_avals_ = tuple(x for x in self.in_avals if not isinstance(x, Static))
     leaf = lambda x: isinstance(x, ad_util.Zero)
-    if self.symbolic_zeros:  # type: ignore
+    if self.symbolic_zeros:
       out_ct = tree_map(ad_util.replace_internal_symbolic_zeros, out_ct, is_leaf=leaf)
     else:
       out_ct = tree_map(ad_util.instantiate, out_ct, is_leaf=leaf)
-    in_cts = self.bwd(*static_args, res, out_ct)  # type: ignore
+    in_cts = self.bwd(*static_args, res, out_ct)
     if isinstance(in_cts, list):
       in_cts = tuple(in_cts)
     if not isinstance(in_cts, tuple):
-      raise TypeError(f"Custom VJP bwd rule {self.bwd} must produce a tuple "  # type: ignore
-                      f"but got {type(in_cts)}.")  # type: ignore
-    if len(in_cts) != len(self.in_tree.children()) - len(self.static_argnums):  # type: ignore
-      raise ValueError(f"Custom VJP bwd rule {self.bwd} must produce a tuple "  # type: ignore
+      raise TypeError(f"Custom VJP bwd rule {self.bwd} must produce a tuple "
+                      f"but got {type(in_cts)}.")
+    if len(in_cts) != len(self.in_tree.children()) - len(self.static_argnums):
+      raise ValueError(f"Custom VJP bwd rule {self.bwd} must produce a tuple "
                        "of length equal to the primal args tuple, but got "
-                       f"length {len(in_cts)}")  # type: ignore
+                       f"length {len(in_cts)}")
     in_cts = broadcast_prefix(in_cts, in_avals_, is_leaf=lambda x: x is None)
     in_cts = tree_unflatten(self.in_tree, map(_replace_none, self.in_avals_flat, in_cts))
     tree_map_with_path(_vjp_bwd_aval_mismatch_err, self.in_avals, in_cts)
-    if self.symbolic_zeros:  # type: ignore
+    if self.symbolic_zeros:
       in_cts = tree_map(ad_util.replace_rule_output_symbolic_zeros, in_cts)
     return in_cts
 
   def jvp(self, primals, tangents):
-    if self.symbolic_zeros: raise NotImplementedError  # type: ignore
+    if self.symbolic_zeros: raise NotImplementedError
     zero = lambda x: isinstance(x, ad_util.Zero)
     tangents = tree_map(ad_util.instantiate, tangents, is_leaf=zero)
-    if self.opt_remat:  # type: ignore
+    if self.opt_remat:
       fwd_traced = api.jit(partial(self.vjp_fwd, (True,) * len(primals))).trace(*primals)
-      primals_out, residuals = OptRemat(self, fwd_traced)(*primals)  # type: ignore
+      primals_out, residuals = OptRemat(self, fwd_traced)(*primals)
     else:
       primals_out, residuals, *_ = self.vjp_fwd((True,) * len(primals), *primals)
     tangents_out_flat = fake_linear_op(self, [True] * len(tangents), residuals, *tangents)
@@ -739,23 +739,23 @@ class CustomVJPTraced(VJPHiPrimitive):
 
   def batch_dim_rule(self, axis_data, in_dims):
     in_dims_flat = self.in_tree.flatten_up_to(in_dims)
-    _, out_dims = batching.batch_jaxpr2(self.traced.jaxpr, axis_data, tuple(in_dims_flat))  # type: ignore
+    _, out_dims = batching.batch_jaxpr2(self.traced.jaxpr, axis_data, tuple(in_dims_flat))
     return tree_unflatten(self.out_tree, out_dims)
 
 def _vjp_primal_fwd_tree_mismatch_err(self, tree):
-  return (f"Custom VJP fwd rule {self.fwd.__name__} for function {self.traced.fun_name} "  # type: ignore
+  return (f"Custom VJP fwd rule {self.fwd.__name__} for function {self.traced.fun_name} "
           "must produce a pair (list or tuple of length two) where the first "
           "element represents the primal output "
           "(equal to the output of the custom_vjp-decorated function "
-          f"{self.traced.fun_name}) and the "  # type: ignore
+          f"{self.traced.fun_name}) and the "
           "second element represents residuals (i.e. values stored from the "
           "forward pass for use on the backward pass), but "
           f"instead the fwd rule output's first element had container/pytree "
           "structure:\n"
-          f"""    {str(tree ).replace("'", "")}\n"""  # type: ignore
-          f"while the custom_vjp-decorated function {self.traced.fun_name} had output "  # type: ignore
+          f"""    {str(tree ).replace("'", "")}\n"""
+          f"while the custom_vjp-decorated function {self.traced.fun_name} had output "
           "container/pytree structure:\n"
-          f"""    {str(self.out_tree).replace("'", "")}.""")  # type: ignore
+          f"""    {str(self.out_tree).replace("'", "")}.""")
 
 def _vjp_fwd_aval_mismatch_err(path, primal_aval, fwd_val):
   if not core.typematch(ty := typeof(fwd_val), primal_aval):
@@ -788,6 +788,8 @@ def _replace_none(primal_in_aval, maybe_ct):
 class custom_vjp3:
   fwd: Callable | None = None
   bwd: Callable | None = None
+  symz: bool = False
+  opt_remat: bool = False
 
   def __init__(self, f, nondiff_argnums=(), nondiff_argnames=()):
     self.f = f
@@ -819,8 +821,8 @@ class custom_vjp3:
       raise Exception  # TODO(mattjj):error tracer type, value type, primal name
     args = tuple(Static(x) if i in self.static_argnums else x for i, x in enumerate(args))
     in_avals = tree_map(typeof, args)
-    prim = CustomVJPTraced(traced, self.fwd, self.bwd, in_avals, self.symz,  # type: ignore
-                           self.static_argnums, self.opt_remat)  # type: ignore
+    prim = CustomVJPTraced(traced, self.fwd, self.bwd, in_avals, self.symz,
+                           self.static_argnums, self.opt_remat)
     return prim(*args)
 
 class OptRemat(VJPHiPrimitive):

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -103,7 +103,7 @@ def linearize_subtrace(_f: Callable, _store: lu.Store, _is_vjp: bool,
       del linearize_trace, ans, tracers
   nzs_out = tuple(type(t) is not Zero for t in out_tangents)
   out_tangents = tuple(t for t, nz in zip(out_tangents, nzs_out) if nz)
-  out_tangents = map(partial(tangent_trace.to_jaxpr_tracer, source_info=source_info),    # type: ignore
+  out_tangents = map(partial(tangent_trace.to_jaxpr_tracer, source_info=source_info),
                      out_tangents)
   jaxpr, consts = tangent_trace.to_jaxpr(
       out_tangents, debug_info.with_unknown_names(), source_info)  # type: ignore
@@ -370,7 +370,7 @@ def backward_pass3(
       ans = ans if eqn.primitive.multiple_results else [ans]
       foreach(env.setdefault, eqn.outvars, ans)
 
-  ctx = (source_info_util.transform_name_stack('transpose') if transform_stack  # type: ignore
+  ctx = (source_info_util.transform_name_stack('transpose') if transform_stack
          else contextlib.nullcontext())
   for acc, ct in zip(map(read, jaxpr.outvars), cotangents_in):
     if isinstance(acc, GradAccum):
@@ -1206,7 +1206,7 @@ def instantiate_zeros(tangent):
     if hasattr(tangent.aval, 'sharding'):
       # TODO(dougalm, yashkatariya): Delete this context manager once we figure
       # out how to ensure jaxpr arguments always have the context mesh.
-      with mesh_lib.use_abstract_mesh(tangent.aval.sharding.mesh):  # type: ignore
+      with mesh_lib.use_abstract_mesh(tangent.aval.sharding.mesh):
         return zeros_like_aval(tangent.aval)
     return zeros_like_aval(tangent.aval)
   return tangent

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -368,14 +368,14 @@ def _numpy_array_attribute(x: np.ndarray | np.generic) -> ir.Attribute:
   shape = x.shape
   x = np.ascontiguousarray(x)
   try:
-    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)  # type: ignore
+    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)
   except ValueError:
     # Backwards compatibility fallback for old MLIR versions.
     # Delete once minimum supported jaxlib version is 0.9.1.
     if x.dtype != np.bool_:
       raise
     x = np.ascontiguousarray(np.packbits(x, bitorder='little'))
-    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)  # type: ignore
+    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)
 
 def _numpy_array_attribute_handler(val: np.ndarray | np.generic) -> ir.Attribute:
   if 0 in val.strides and val.size > 0:
@@ -1092,7 +1092,7 @@ def _to_physical_op_sharding(
     sharding = add_manual_axes(axis_ctx, sharding, aval.ndim)
   if config.use_shardy_partitioner.value:
     return sharding._to_sdy_sharding(aval.ndim)
-  return sharding._to_xla_hlo_sharding(aval.ndim).to_proto()  # type: ignore
+  return sharding._to_xla_hlo_sharding(aval.ndim).to_proto()
 
 
 def _to_xla_layout(layout: Layout | None | AutoLayout,
@@ -1693,7 +1693,7 @@ def lower_jaxpr_to_fun(
       if pom is not None and mk is None:
         res.append([pom] * len_ir_types(types))
       else:
-        res.append([mk] * len_ir_types(types))  # type: ignore
+        res.append([mk] * len_ir_types(types))
       # To add the custom call on the output to signal a transfer, only do it
       # if memory kind comes from out_shardings on `jit` and result_memory_kinds
       # comes from out_shardings on `jit`.
@@ -1805,7 +1805,7 @@ def lower_jaxpr_to_fun(
 
   if use_sharding_annotations and ir_result_shardings is not None:
     for attrs, sharding, uv in zip(result_attrs, ir_result_shardings,  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
-                                   unconstrained_variants):  # type: ignore
+                                   unconstrained_variants):
       if sharding is not None and not uv.contains_unconstrained:
         if config.use_shardy_partitioner.value:
           attrs["sdy.sharding"] = get_sharding_attr(sharding)
@@ -1880,7 +1880,7 @@ def lower_jaxpr_to_fun(
               dtypes.issubdtype(a.dtype, dtypes.extended) and
               (s is None or all_unconstrained(rs, a))) else o  # pytype: disable=attribute-error
           for o, s, a, rs in zip(flat_args, ir_arg_shardings, input_avals,  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
-                                 arg_shardings)  # type: ignore
+                                 arg_shardings)
       ]
 
     _, token_args, _, unflattened_args = util.split_list(
@@ -1913,7 +1913,7 @@ def lower_jaxpr_to_fun(
     if ir_result_shardings is not None:
       temp_flat_outputs = []
       for o, s, o_aval, uv in zip(flat_outputs, ir_result_shardings,  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
-                                  output_avals, unconstrained_variants):  # type: ignore
+                                  output_avals, unconstrained_variants):
         if (s is not None and uv.contains_unconstrained and
             not uv.all_unconstrained):
           if config.use_shardy_partitioner.value:
@@ -1945,7 +1945,7 @@ def lower_jaxpr_to_fun(
               dtypes.issubdtype(a.dtype, dtypes.extended) and
               (s is None or all_unconstrained(rs, a))) else o  # pytype: disable=attribute-error
           for o, s, a, rs in zip(flat_outputs, ir_result_shardings, output_avals,  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
-                                 result_shardings)  # type: ignore
+                                 result_shardings)
       ]
 
     func_dialect.return_(flat_outputs)

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1054,7 +1054,7 @@ def _partial_eval_jaxpr_custom_cached(
     rule = partial_eval_jaxpr_custom_rules.get(eqn.primitive)
     if rule:
       eqn1, eqn2, unks_out, inst_out, res = rule(saveable, unks_in, inst_in, eqn)
-      eqn1 and known_eqns.append(eqn1); eqn2 and staged_eqns.append(eqn2)  # type: ignore
+      eqn1 and known_eqns.append(eqn1); eqn2 and staged_eqns.append(eqn2)
       for r in res:
         if isinstance(r.aval, AbstractRef):
           residual_refs.add(r)

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -81,8 +81,8 @@ class WeakRefList(list):
   pass
 
 
-unsafe_map, map = map, safe_map  # type: ignore
-zip, unsafe_zip = safe_zip, zip  # type: ignore
+unsafe_map, map = map, safe_map
+zip, unsafe_zip = safe_zip, zip
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +124,7 @@ def shard_args(
 
   # type(arg) -> (list[indices], list[args], list[shardings], list[layouts],
   #               list[copy_semantics])
-  batches = collections.defaultdict(lambda: ([], [], [], [], []))  # type: ignore
+  batches = collections.defaultdict(lambda: ([], [], [], [], []))
   for i, (arg, sharding, layout, cs) in enumerate(
       safe_zip(args, shardings, layouts, copy_semantics)):
     if canonicalize:
@@ -834,9 +834,9 @@ def lower_parallel_callable(
     const_args_and_avals = core.jaxpr_const_args(jaxpr)
     const_args, const_arg_avals = unzip2(const_args_and_avals)
     num_const_args = len(const_arg_avals)
-    in_axes = (None,) * num_const_args + in_axes  # type: ignore
-    donated_invars = (False,) * num_const_args + donated_invars  # type: ignore
     jaxpr_avals = list(const_arg_avals) + closed_jaxpr.in_avals  # type: ignore
+    donated_invars = (False,) * num_const_args + donated_invars  # type: ignore
+    jaxpr_avals = list(const_arg_avals) + closed_jaxpr.in_avals
     shards = ShardInfo(
         tuple(const_arg_avals) + shards.sharded_avals,  # type: ignore
         shards.out_sharded_avals,
@@ -1194,7 +1194,7 @@ class PmapExecutable(stages.Executable):
   def unsafe_call(self) -> Callable[..., Any]:
     if self._unsafe_call is None:
       self._unsafe_call = self.build_unsafe_call()
-    return self._unsafe_call  # type: ignore
+    return self._unsafe_call
 
   # -- stages.Executable overrides
 
@@ -1377,7 +1377,7 @@ class ExecuteReplicated:
       out_ = []
       for i, o in zip(self.mut.out_mut, out):
         if i is not None:
-          try: args[i]._refs._buf._replace_with(o)  # type: ignore
+          try: args[i]._refs._buf._replace_with(o)
           except AttributeError: pass  # TODO(mattjj): remove float0
         else:
           out_.append(o)
@@ -1773,7 +1773,7 @@ def _get_and_check_device_assignment(
   elif first_sharding_info is None:
     device_assignment = (get_default_device(),)
   else:
-    device_assignment = first_sharding_info[0]  # type: ignore
+    device_assignment = first_sharding_info[0]
 
   backend = xb.get_device_backend(device_assignment[0])
 
@@ -2026,13 +2026,13 @@ def _create_device_list(
     device_assignment: tuple[xc.Device, ...] | xc.DeviceList | None
     ) -> xc.DeviceList | None:
   if device_assignment is None or isinstance(device_assignment, xc.DeviceList):
-    return device_assignment  # type: ignore
+    return device_assignment  # pytype: disable=bad-return-type
   return _create_device_list_cached(device_assignment)
 
 
 @weakref_lru_cache
 def jaxpr_transfer_mem_kinds(jaxpr: core.Jaxpr):
-  out = []  # type: ignore
+  out = []
   for eqn in jaxpr.eqns:
     if eqn.primitive is dispatch.device_put_p:
       out.extend(d for d in eqn.params['devices']
@@ -2063,7 +2063,7 @@ def are_all_shardings_default_mem_kind(shardings):
 @weakref_lru_cache
 def get_out_layouts_via_propagation(closed_jaxpr: core.ClosedJaxpr
                                     ) -> tuple[None | Layout]:
-  env = {}  # type: ignore
+  env = {}
   jaxpr = closed_jaxpr.jaxpr
 
   def read(var):
@@ -2138,12 +2138,12 @@ def hoist_constants_as_args(
   )
   num_const_args = len(const_args)
   if num_const_args:
-    global_in_avals = list(const_arg_avals) + global_in_avals  # type: ignore
+    global_in_avals = list(const_arg_avals) + global_in_avals
     ca_shardings = pjit.const_args_shardings(const_args)
-    in_shardings = ca_shardings + in_shardings  # type: ignore
+    in_shardings = (*ca_shardings, *in_shardings)
     ca_layouts = pjit.const_args_layouts(const_args, const_arg_avals,
                                           ca_shardings)
-    in_layouts = ca_layouts + in_layouts  # type: ignore
+    in_layouts = (*ca_layouts, *in_layouts)
 
     donated_invars = (False,) * num_const_args + donated_invars
     kept_var_idx = set(range(num_const_args)).union(
@@ -2353,7 +2353,7 @@ def lower_sharding_computation(
     propagated_out_mem_kinds = (None,) * len(global_out_avals)
   else:
     propagated_out_mem_kinds = tuple(
-        core.mem_space_to_kind(o.memory_space) for o in closed_jaxpr.out_avals)  # type: ignore
+        core.mem_space_to_kind(o.memory_space) for o in closed_jaxpr.out_avals)
 
   out_shardings = _concretize_abstract_out_shardings(
       out_shardings, global_out_avals, device_assignment,
@@ -3070,9 +3070,9 @@ class UnloadedMeshExecutable:
       assert mesh is not None
       in_shardings_xla, out_shardings_xla = _get_mesh_pspec_shardings_from_executable(
           xla_executable, mesh)
-      in_shardings = [x if isinstance(i, AUTO) else i  # type: ignore
+      in_shardings = [x if isinstance(i, AUTO) else i
                       for x, i in safe_zip(in_shardings_xla, in_shardings)]
-      out_shardings = [x if isinstance(o, AUTO) else o  # type: ignore
+      out_shardings = [x if isinstance(o, AUTO) else o
                        for x, o in safe_zip(out_shardings_xla, out_shardings)]
     else:
       if pmap_nreps == 1:
@@ -3224,7 +3224,7 @@ class MeshExecutable(stages.Executable):
   def unsafe_call(self) -> Callable[..., Any]:
     if self._unsafe_call is None:
       self._unsafe_call = self.build_unsafe_call()
-    return self._unsafe_call  # type: ignore
+    return self._unsafe_call
 
   # -- stages.Executable overrides
 
@@ -3421,5 +3421,5 @@ def batch_spec(spec, dim, val):
   too_short = dim - len(spec)
   if too_short > 0:
     spec += (None,) * too_short
-  new_partitions = tuple_insert(spec, dim, val)  # type: ignore
+  new_partitions = tuple_insert(spec, dim, val)
   return PartitionSpec(*new_partitions)

--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -59,7 +59,7 @@ def _merge_common_consts(
   # De-duplicate shared constants.
   const_ids = tuple(id(c) for c in consts)
   seen = set()
-  dd_consts = [c for c in consts if id(c) not in seen and not seen.add(id(c))]  # type: ignore
+  dd_consts = [c for c in consts if id(c) not in seen and not seen.add(id(c))]
   jaxprs = [_dedup_consts(jaxpr, len(consts), const_ids) for jaxpr in jaxprs]
   return jaxprs, dd_consts
 

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -336,7 +336,7 @@ def _check_branch_outputs(
     component = lambda _: ''
   else:
     leaves_and_paths, _ = tree_flatten_with_path(outs1)
-    paths, _ = unzip2(leaves_and_paths)  # type: ignore
+    paths, _ = unzip2(leaves_and_paths)
     component = lambda p: f' at path {keystr(p)}' if p else ''
 
   if out_avals1.tree != out_avals2.tree:
@@ -840,7 +840,7 @@ def _cond_transpose_fancy(cts_in, index, *args, branches, **params):
   assert not isinstance(index, ad.GradAccum)
   primals_ctrefs, specs = ad.project_accums(args)
   in_flat, in_tree = tree_flatten((primals_ctrefs, cts_in))
-  in_avals = tuple(core.AvalQDD(a, cur_qdd(x)) if (a := typeof(x)).has_qdd  # type: ignore
+  in_avals = tuple(core.AvalQDD(a, cur_qdd(x)) if (a := typeof(x)).has_qdd
                    else a for x in in_flat)
   trans_branches, out_trees = unzip2(
       _transpose_jaxpr_fancy(j, in_tree, in_avals, specs, (False,) * len(args))
@@ -955,7 +955,7 @@ pe.dce_rules[cond_p] = _cond_dce_rule
 
 def _cond_is_high(*_, branches, **__) -> bool:
   return any(j.jaxpr.is_high for j in branches)
-cond_p.is_high = _cond_is_high  # type: ignore
+cond_p.is_high = _cond_is_high
 
 def _cond_to_lojax(pred, *hi_args, branches, **kwds):
   jaxpr = branches[0]
@@ -1171,7 +1171,7 @@ def platform_dependent(*args: Any,
       raise TypeError("lax.platform_dependent: the 'default' branch must "
                       "be a callable.")
     branches = branches + (default,)
-    branches_platforms = branches_platforms + (None,)  # type: ignore
+    branches_platforms = branches_platforms + (None,)
   platform_index = platform_index_p.bind(platforms=branches_platforms)
 
   if core.is_concrete(platform_index):

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1353,7 +1353,7 @@ def _scan_state_partial_discharge_rule(
   return refvals_out, [*carry, *ys]
 
 scan_p = core.Primitive("scan")
-scan_p.is_effectful = lambda params: bool(params['jaxpr'].effects)  # type: ignore
+scan_p.is_effectful = lambda params: bool(params['jaxpr'].effects)
 scan_p.multiple_results = True
 scan_p.skip_canonicalization = True
 scan_p.def_impl(partial(dispatch.apply_primitive, scan_p))
@@ -1373,7 +1373,7 @@ state_discharge.register_partial_discharge_rule(scan_p)(_scan_state_partial_disc
 
 def _scan_is_high(*_, jaxpr, **__) -> bool:
   return jaxpr.jaxpr.is_high
-scan_p.is_high = _scan_is_high  # type: ignore
+scan_p.is_high = _scan_is_high
 
 def _scan_to_lojax(*hi_args, jaxpr, num_carry, num_consts, linear, **params):
   # move qdd binders and corresponding hi_args from consts slots to carry slots
@@ -1592,12 +1592,12 @@ def _while_loop_abstract_eval(*avals, cond_jaxpr, body_jaxpr, body_nconsts,
         f"while_loop {len(body_jaxpr.in_avals)=} but {len(body_consts_avals) + len(in_avals)=}")
   # TODO(mattjj): check body carry type
   # TODO(mattjj): make these typecompat checks work with bints
-  # if not all(_map(core.typecompat, [*cond_consts_avals, *in_avals], cond_jaxpr.in_avals)):  # type: ignore
+  # if not all(_map(core.typecompat, [*cond_consts_avals, *in_avals], cond_jaxpr.in_avals)):
   #   cond_avals = [*cond_consts_avals, *in_avals]
   #   a1, a2 = next((a1, a2) for a1, a2 in zip(cond_avals, cond_jaxpr.in_avals)
   #                 if not core.typecompat(a1, a2))
   #   raise core.JaxprTypeError(f"while_loop cond function input type error: {a1} != {a2}")
-  # if not all(_map(core.typecompat, [*body_consts_avals, *in_avals], body_jaxpr.in_avals)):  # type: ignore
+  # if not all(_map(core.typecompat, [*body_consts_avals, *in_avals], body_jaxpr.in_avals)):
   #   body_avals = [*body_consts_avals, *in_avals]
   #   a1, a2 = next((a1, a2) for a1, a2 in zip(body_avals, body_jaxpr.in_avals)
   #                 if not core.typecompat(a1, a2))
@@ -2237,7 +2237,7 @@ state_discharge.register_partial_discharge_rule(while_p)(_while_partial_discharg
 
 def _while_is_high(*_, cond_jaxpr, body_jaxpr, **__):
   return cond_jaxpr.is_high or body_jaxpr.is_high
-while_p.is_high = _while_is_high  # type: ignore
+while_p.is_high = _while_is_high
 
 def _while_to_lojax(*hi_args, cond_jaxpr, body_jaxpr, cond_nconsts, body_nconsts):
   if any(a.has_qdd for a in cond_jaxpr.in_avals[:cond_nconsts]):
@@ -2512,7 +2512,7 @@ def _batch_and_remainder(x, batch_size: int):
     remainder_leaves = [_remainder_leaf(leaf, batch_elems) for leaf in leaves]
     return None, treedef.unflatten(remainder_leaves)
   elif remainder:
-    scan_leaves, remainder_leaves = unzip2(  # type: ignore
+    scan_leaves, remainder_leaves = unzip2(
         [(_scan_leaf(leaf, batch_elems, num_batches, batch_size),
           _remainder_leaf(leaf, batch_elems)) for leaf in leaves])
     return treedef.unflatten(scan_leaves), treedef.unflatten(remainder_leaves)

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -5081,7 +5081,7 @@ ad.defjvp(to_edtype_p,
           lambda t, x, edtype:
           convert_element_type(t, core.primal_dtype_to_tangent_dtype(edtype)))
 ad.primitive_transposes[to_edtype_p] = \
-    lambda ct, x, edtype: [from_edtype_p.bind(ct, dtype=x.aval.dtype)]  # type: ignore
+    lambda ct, x, edtype: [from_edtype_p.bind(ct, dtype=x.aval.dtype)]
 batching.defvectorized(to_edtype_p)
 mlir.register_lowering(to_edtype_p, lambda _, x, **__: [x])
 

--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -922,7 +922,7 @@ def _select_and_gather_add_lowering(
     # 2k-bit unsigned integer using bit tricks.
     word_dtype = lax._UINT_DTYPES[nbits]
     double_word_dtype = lax._UINT_DTYPES[nbits * 2]
-    word_type = mlir.dtype_to_ir_type(word_dtype)  # type: ignore
+    word_type = mlir.dtype_to_ir_type(word_dtype)
     # Packs two values into a double_word_type.
     def pack(a, b, ab_aval):
       word_type_ab_aval = ab_aval.update(dtype=word_dtype)

--- a/jax/_src/linear_util.py
+++ b/jax/_src/linear_util.py
@@ -450,7 +450,7 @@ def cache(call: Callable, *,
   fun_caches: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
   def memoized_fun(fun: WrappedFun, *args):
-    cache = fun_caches.setdefault(fun.f, new_cache := {})  # type: ignore
+    cache = fun_caches.setdefault(fun.f, new_cache := {})
     key = (fun.transforms, fun.params, fun.in_type, args, config.trace_context())
     result = cache.get(key, None)
     if result is not None:
@@ -469,8 +469,8 @@ def cache(call: Callable, *,
   def _evict_function(f):
     fun_caches.pop(f, None)
 
-  memoized_fun.cache_clear = fun_caches.clear  # type: ignore
   memoized_fun.evict_function = _evict_function  # type: ignore
+  memoized_fun.cache_clear = fun_caches.clear  # type: ignore
   register_cache(memoized_fun, str(call))
   return memoized_fun
 

--- a/jax/_src/mesh.py
+++ b/jax/_src/mesh.py
@@ -213,7 +213,7 @@ class BaseMesh:
 def _unpicke_mesh(devices, axis_names, axis_types):
   return Mesh(devices, axis_names, axis_types)
 
-_mesh_object_dict = {}  # type: ignore
+_mesh_object_dict = {}
 
 
 class Mesh(BaseMesh, contextlib.ContextDecorator):

--- a/jax/_src/named_sharding.py
+++ b/jax/_src/named_sharding.py
@@ -380,7 +380,7 @@ class SdyArray:
 # parameter to it `_to_sdy_sharding(self, ndim, modify_wrt_axis_types=False)`
 def modify_sdy_sharding_wrt_axis_types(sdy_sharding: SdyArray, mesh):
   if mesh._any_axis_auto:
-    dim_shardings, used_axes = [], []  # type: ignore
+    dim_shardings, used_axes = [], []
     for d in sdy_sharding.dim_shardings:
       dim_shardings.append(SdyDim(axes=d.axes, is_open=True))
       used_axes.extend(d.axes)
@@ -431,7 +431,7 @@ def named_sharding_to_xla_hlo_sharding(
   last_tile_dims = []
   if replicated_mesh_axes:
     axes_by_type: dict[Any, list[int]] = collections.defaultdict(list)
-    size_by_type = collections.defaultdict(lambda: 1)  # type: ignore
+    size_by_type = collections.defaultdict(lambda: 1)
     assert {x[0] for x in replicated_mesh_axes}.issuperset(set(special_axes.keys()))
     for i, size in replicated_mesh_axes:
       ty = special_axes.get(i, xc.OpSharding.Type.REPLICATED)

--- a/jax/_src/numpy/array_constructors.py
+++ b/jax/_src/numpy/array_constructors.py
@@ -42,7 +42,7 @@ for pkg_name in ['jax_cuda13_plugin', 'jax_cuda12_plugin', 'jaxlib.cuda']:
         f'{pkg_name}.cuda_plugin_extension'
     )
   except ImportError:
-    cuda_plugin_extension = None  # type: ignore
+    cuda_plugin_extension = None
   else:
     break
 

--- a/jax/_src/numpy/array_creation.py
+++ b/jax/_src/numpy/array_creation.py
@@ -189,7 +189,7 @@ def empty(shape: Any, dtype: DTypeLike | None = None, *,
   return zeros(shape, dtype, device=device, out_sharding=out_sharding)
 
 
-def _check_forgot_shape_tuple(name, shape, dtype) -> str | None:  # type: ignore
+def _check_forgot_shape_tuple(name, shape, dtype) -> str | None:
   if isinstance(dtype, int) and isinstance(shape, int):
     return (f"Cannot interpret '{dtype}' as a data type."
             f"\n\nDid you accidentally write "

--- a/jax/_src/numpy/array_methods.py
+++ b/jax/_src/numpy/array_methods.py
@@ -1188,7 +1188,7 @@ class _IndexUpdateRef:
     return scatter._scatter_update(
         self.array, self.index, values, lax_slicing.scatter,
         indices_are_sorted=indices_are_sorted, unique_indices=unique_indices,
-        mode=mode, out_sharding=out_sharding,  # type: ignore
+        mode=mode, out_sharding=out_sharding,
         normalize_indices=wrap_negative_indices)
 
   def apply(self, func: Callable[[ArrayLike], Array], *,
@@ -1233,7 +1233,7 @@ class _IndexUpdateRef:
     return scatter._scatter_update(
         self.array, self.index, values, lax_slicing.scatter_add,
         indices_are_sorted=indices_are_sorted, unique_indices=unique_indices,
-        mode=mode, out_sharding=out_sharding,  # type: ignore
+        mode=mode, out_sharding=out_sharding,
         normalize_indices=wrap_negative_indices)
 
   def subtract(self, values: ArrayLike, *,

--- a/jax/_src/numpy/indexing.py
+++ b/jax/_src/numpy/indexing.py
@@ -1132,7 +1132,7 @@ def rewriting_take(
   if out_sharding is not None:
     out_sharding = canonicalize_sharding(out_sharding, 'take')
     return auto_axes(internal_gather, out_sharding=out_sharding,
-                     axes=out_sharding.mesh.explicit_axes,  # type: ignore
+                     axes=out_sharding.mesh.explicit_axes,
                      )(arr, dynamic_idx)
   return internal_gather(arr, dynamic_idx)
 

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -7738,7 +7738,7 @@ def delete(
     obj = asarray(obj).ravel()
     obj = clip(where(obj < 0, obj + a.shape[axis], obj), 0, a.shape[axis])
     obj = sort(obj)
-    obj -= arange(len(obj), dtype=obj.dtype)  # type: ignore
+    obj -= arange(len(obj), dtype=obj.dtype)
     i = arange(a.shape[axis] - obj.size, dtype=obj.dtype)
     i += (i[None, :] >= obj[:, None]).sum(0, dtype=i.dtype)
     return a[(slice(None),) * axis + (i,)]

--- a/jax/_src/pallas/einshape.py
+++ b/jax/_src/pallas/einshape.py
@@ -327,7 +327,7 @@ def _einshape_lo_abstract_eval(
 ):
   del assert_is_tile_preserving
   out_sds = api.eval_shape(
-      functools.partial(_einshape, equation, **dict(sizes)), x_aval  # type: ignore
+      functools.partial(_einshape, equation, **dict(sizes)), x_aval
   )
   return x_aval.update(shape=out_sds.shape, dtype=out_sds.dtype)
 
@@ -365,7 +365,7 @@ class Einshape(hijax.VJPHiPrimitive):
   ):
     self.in_avals = (x_aval,)
     out_type = api.eval_shape(
-        functools.partial(_einshape, equation, **sizes), x_aval  # type: ignore
+        functools.partial(_einshape, equation, **sizes), x_aval
     )
     self.out_aval = hijax.ShapedArray(out_type.shape, out_type.dtype)
     self.equation = equation
@@ -493,7 +493,7 @@ def _init_dims(shape: tuple[int, ...], t1: int, t2: int) -> list[list[Factor]]:
     if s // t_size > 1:
       current_dim.append(Factor(s // t_size, "outer"))
     if t_size > 1 or kind != "outer":
-      current_dim.append(Factor(t_size, kind))  # type: ignore
+      current_dim.append(Factor(t_size, kind))
     dims.append(_consolidate(current_dim))
   return dims
 

--- a/jax/_src/pallas/fuser/fusible.py
+++ b/jax/_src/pallas/fuser/fusible.py
@@ -35,7 +35,7 @@ def _fusible_is_high(*_, jaxpr, **params):
   del params
   return jaxpr.is_high
 
-fusible_p.is_high = _fusible_is_high # type: ignore
+fusible_p.is_high = _fusible_is_high
 
 
 def _make_trivial_fusion(x: jax.Array) -> fusion_lib.Fusion:

--- a/jax/_src/pallas/mosaic/random.py
+++ b/jax/_src/pallas/mosaic/random.py
@@ -156,10 +156,10 @@ def _make_stateful_sampler(sampler: SampleFnType) -> KeylessSampleFnType:
     new_sampler.__doc__ = "\n".join(doc_lines)
   return new_sampler
 
-stateful_bits = _make_stateful_sampler(jax_api_random.bits)  # type: ignore
-stateful_uniform = _make_stateful_sampler(jax_api_random.uniform)  # type: ignore
-stateful_bernoulli = _make_stateful_sampler(jax_api_random.bernoulli)  # type: ignore
-stateful_normal = _make_stateful_sampler(jax_api_random.normal)  # type: ignore
+stateful_bits = _make_stateful_sampler(jax_api_random.bits)
+stateful_uniform = _make_stateful_sampler(jax_api_random.uniform)
+stateful_bernoulli = _make_stateful_sampler(jax_api_random.bernoulli)
+stateful_normal = _make_stateful_sampler(jax_api_random.normal)
 
 
 def sample_block(sampler_fn: SampleFnType,

--- a/jax/_src/pallas/mosaic/sc_lowering.py
+++ b/jax/_src/pallas/mosaic/sc_lowering.py
@@ -176,7 +176,7 @@ def lower_pipelined_jaxpr_into_module(
   block_mappings = grid_mapping.block_mappings
 
   if dimension_semantics is None:
-    dimension_semantics = ("arbitrary",) * len(grid)  # type: ignore
+    dimension_semantics = ("arbitrary",) * len(grid)
   dimension_semantics: Sequence[tpu_core.LiteralDimensionSemantics] = tuple(  # pyrefly: ignore[redefinition]  # pytype: disable=annotation-type-mismatch
       map(tc_lowering._canonicalize_dimension_semantic, dimension_semantics)
   )

--- a/jax/_src/pallas/mosaic/sc_primitives.py
+++ b/jax/_src/pallas/mosaic/sc_primitives.py
@@ -52,7 +52,7 @@ Ref: TypeAlias = state_types.AbstractRef | TransformedRef
 _T = TypeVar("_T")
 
 load_p = jax_core.Primitive("load")
-load_p.is_effectful = lambda params: True  # type: ignore
+load_p.is_effectful = lambda params: True
 
 
 @load_p.def_effectful_abstract_eval
@@ -112,7 +112,7 @@ def load_expanded(ref: Ref, *, mask: jax.Array) -> jax.Array:
 
 
 swap_p = jax_core.Primitive("swap")
-swap_p.is_effectful = lambda params: True  # type: ignore
+swap_p.is_effectful = lambda params: True
 
 
 @swap_p.def_effectful_abstract_eval
@@ -240,7 +240,7 @@ def _indexed_shape(ref: Ref, indices: Sequence[jax.Array]) -> tuple[int, ...]:
 
 
 gather_p = jax_core.Primitive("gather")
-gather_p.is_effectful = lambda params: True  # type: ignore
+gather_p.is_effectful = lambda params: True
 
 
 @gather_p.def_effectful_abstract_eval
@@ -305,7 +305,7 @@ def load_gather(
 
 
 scatter_p = jax_core.Primitive("scatter")
-scatter_p.is_effectful = lambda params: True  # type: ignore
+scatter_p.is_effectful = lambda params: True
 scatter_p.multiple_results = True
 
 
@@ -737,7 +737,7 @@ def sort_key_val(
 
 
 parallel_loop_p = jax_core.Primitive("parallel_loop")
-parallel_loop_p.is_effectful = lambda params: bool(params["jaxpr"].effects)  # type: ignore
+parallel_loop_p.is_effectful = lambda params: bool(params["jaxpr"].effects)
 parallel_loop_p.multiple_results = True
 
 

--- a/jax/_src/pallas/mosaic_gpu/primitives.py
+++ b/jax/_src/pallas/mosaic_gpu/primitives.py
@@ -569,7 +569,7 @@ def _copy_gmem_to_smem_lowering(
     # Bytes is the destination size, which is only half of the total
     # size of the partitioned transfer so we need to double it.
     bytes *= 2
-    if len(collective) != 1:  # type: ignore
+    if len(collective) != 1:
       raise ValueError(
           f"Expected exactly one collective axis, got {collective_axes=}"
       )
@@ -598,7 +598,7 @@ def _copy_gmem_to_smem_lowering(
       if is_partitioned_copy:
         first_block = arith_dialect.cmpi(
             arith_dialect.CmpIPredicate.eq,
-            mgpu.utils.cluster_idx(collective[0]),  # type: ignore
+            mgpu.utils.cluster_idx(collective[0]),
             mgpu.c(0, ir.IndexType.get()),
         )
         barrier.arrive_expect_tx(bytes, predicate=first_block)
@@ -614,7 +614,7 @@ def _copy_gmem_to_smem_lowering(
       if is_partitioned_copy:
         first_block = arith_dialect.cmpi(
             arith_dialect.CmpIPredicate.eq,
-            mgpu.utils.cluster_idx(collective[0]),  # type: ignore
+            mgpu.utils.cluster_idx(collective[0]),
             mgpu.c(0, ir.IndexType.get()),
         )
         with mgpu.when(first_block):
@@ -1397,7 +1397,7 @@ def _wgmma_warpgroup_lowering(
     a_transforms_num_leaves = a_transforms_tree.num_leaves
   else:
     a_transforms_num_leaves = 0
-    b_transforms_leaves = transforms_leaves  # type: ignore
+    b_transforms_leaves = transforms_leaves
 
   if b_transforms_tree is not None:
     b_transforms = b_transforms_tree.unflatten(b_transforms_leaves)
@@ -1883,7 +1883,7 @@ def _tcgen05_mma_lowering(
       ):
         lhs_transpose = True
       case () if isinstance(a_ref, tcgen05.TMEMRef):
-        lhs_tiling = None  # type: ignore
+        lhs_tiling = None
       case _:
         raise NotImplementedError(
             f"Unsupported transforms for LHS: {a_transforms}."
@@ -3761,7 +3761,7 @@ def try_cluster_cancel_lowering(
           f"Unimplemented transforms for result ref: {res_transforms}"
       )
   else:
-    barrier_transforms_leaves = transforms_leaves  # type: ignore
+    barrier_transforms_leaves = transforms_leaves
 
   if barrier_transforms_tree is not None:
     base_index = _extract_barrier_slice_base(

--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -149,7 +149,7 @@ pallas_call_p.def_effectful_abstract_eval(_pallas_call_abstract_eval)
 def _pallas_call_is_high(*_, jaxpr, **params):
   del params
   return jaxpr.is_high
-pallas_call_p.is_high = _pallas_call_is_high  # type: ignore
+pallas_call_p.is_high = _pallas_call_is_high
 
 
 def _get_index_mapping(avals) -> dict[int, tuple[int, ...]]:
@@ -250,7 +250,7 @@ def _pallas_call_to_lojax(
   return pe.raise_lo_outs(out_avals, lo_outs)
 
 
-pallas_call_p.to_lojax = _pallas_call_to_lojax  # type: ignore
+pallas_call_p.to_lojax = _pallas_call_to_lojax
 
 
 def _pallas_call_jvp_rule(
@@ -1585,30 +1585,30 @@ def _pallas_call(
 try:
   from jax._src.pallas.mosaic import pallas_call_registration as mosaic_tpu_backend
 except ImportError:
-  mosaic_tpu_backend = None  # type: ignore
+  mosaic_tpu_backend = None
 
 
 try:
   from jax._src.pallas.mosaic_gpu import pallas_call_registration as mosaic_gpu_backend
 except ImportError:
-  mosaic_gpu_backend = None  # type: ignore
+  mosaic_gpu_backend = None
 
 
 try:
   from jax._src.pallas.triton import pallas_call_registration as triton_backend
 except ImportError:
-  triton_backend = None  # type: ignore
+  triton_backend = None
 
 try:
   from jax._src.pallas.mosaic.interpret import interpret_pallas_call as mosaic_tpu_interpret
 except ImportError:
-  mosaic_tpu_interpret = types.SimpleNamespace(  # type: ignore
+  mosaic_tpu_interpret = types.SimpleNamespace(
       InterpretParams=types.new_class("_NoInstances", (enum.Enum,)),
   )
 
 try:
   from jax._src.pallas.mosaic_gpu.interpret import interpret_pallas_call as mosaic_gpu_interpret
 except ImportError:
-  mosaic_gpu_interpret = types.SimpleNamespace(  # type: ignore
+  mosaic_gpu_interpret = types.SimpleNamespace(
       InterpretParams=types.new_class("_NoInstances", (enum.Enum,)),
   )

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -788,7 +788,7 @@ def _check_and_canonicalize_out_shardings(
       "jit outputs")
   return out_shardings_flat, out_layouts_flat
 
-_seen_qdds = weakref.WeakKeyDictionary()  # type: ignore
+_seen_qdds = weakref.WeakKeyDictionary()
 
 def _seen_qdds_get(fun, in_type) -> list:
   cache = _seen_qdds.setdefault(fun, defaultdict(list))
@@ -855,13 +855,13 @@ def check_aval_layout_compatibility(
 # -------------------- pjit rules --------------------
 
 jit_p = core.Primitive("jit")
-jit_p.is_effectful = lambda params: bool(params['jaxpr'].effects)  # type: ignore
+jit_p.is_effectful = lambda params: bool(params['jaxpr'].effects)
 jit_p.multiple_results = True
 jit_p.skip_canonicalization = True
 
 def _is_high(*_, jaxpr, **__) -> bool:
   return jaxpr.jaxpr.is_high
-jit_p.is_high = _is_high  # type: ignore
+jit_p.is_high = _is_high
 
 def _to_lojax(*hi_args, jaxpr, **params):
   # convert closed-over boxes to explicit args
@@ -1079,7 +1079,7 @@ def _resolve_and_lower(
       lowering_parameters=lowering_parameters,
       pgle_profiler=pgle_profiler)
 
-_pgle_profiler_dict = weakref.WeakKeyDictionary()  # type: ignore
+_pgle_profiler_dict = weakref.WeakKeyDictionary()
 
 
 @dataclass(frozen=True)

--- a/jax/_src/profiler.py
+++ b/jax/_src/profiler.py
@@ -239,10 +239,10 @@ def stop_trace():
   :func:`start_trace` call. Raises a RuntimeError if a trace hasn't been started.
   """
   with _profile_state.lock:
-    if _profile_state.profile_session is None:
+    profile_session = _profile_state.profile_session
+    if profile_session is None:
       raise RuntimeError("No profile started")
-    sess = _profile_state.profile_session
-    sess.stop_and_export(str(_profile_state.log_dir))  # type: ignore
+    profile_session.stop_and_export(str(_profile_state.log_dir))  # pytype: disable=attribute-error
     if _profile_state.create_perfetto_trace:
       abs_filename = _write_perfetto_trace_file(_profile_state.log_dir)  # type: ignore[bad-argument-type]
       if _profile_state.create_perfetto_link:
@@ -258,9 +258,10 @@ def stop_and_get_fdo_profile() -> bytes | str:
   Raises a RuntimeError if a trace hasn't been started.
   """
   with _profile_state.lock:
-    if _profile_state.profile_session is None:
+    profile_session = _profile_state.profile_session
+    if profile_session is None:
       raise RuntimeError("No profile started")
-    xspace = _profile_state.profile_session.stop()
+    xspace = profile_session.stop()
     fdo_profile = _profiler.get_fdo_profile(xspace)
     _profile_state.reset()
     clear_metadata()

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -863,7 +863,7 @@ def _unshard_shaped_array(mesh: Mesh, check_vma, spec, aval: core.AbstractValue
   if aval.ndim == 0:
     out_spec = P(unreduced=spec.unreduced, reduced=spec.reduced)
   else:
-    out_spec = []  # type: ignore
+    out_spec = []
     for name_s, aval_s in zip(names_spec, aval.sharding.spec):
       if name_s and not aval_s:
         out_spec.append(name_s)
@@ -1026,7 +1026,7 @@ def _shard_map_lowering_shardy(
 
   with (ir.InsertionPoint(block), _extend_axis_env(mesh, manual_axes),
         config._check_vma(check_vma)):
-    dim_var_values, token_arg_values, const_arg_values, in_args = util.split_list(  # type: ignore
+    dim_var_values, token_arg_values, const_arg_values, in_args = util.split_list(
         block.arguments, [num_dim_vars, num_tokens, num_const_args])
     out_nodes_, tokens_out = mlir.jaxpr_subcomp(
         sub_ctx, jaxpr, ctx.name_stack,

--- a/jax/_src/sharding_impls.py
+++ b/jax/_src/sharding_impls.py
@@ -156,7 +156,7 @@ class SingleDeviceSharding(jsharding.Sharding):
   def with_memory_kind(self, kind: str) -> SingleDeviceSharding:
     return SingleDeviceSharding(self._device, memory_kind=kind)
 
-  def devices_indices_map(self, global_shape: Shape) -> Mapping[Device, Index]:  # type: ignore
+  def devices_indices_map(self, global_shape: Shape) -> Mapping[Device, Index]:
     return {self._device: (slice(None),) * len(global_shape)}
 
   @property
@@ -1042,7 +1042,7 @@ def logical_sharding(logical_shape, dtype, phys_sharding) -> jsharding.Sharding:
       phys_spec = (*phys_sharding.spec,
                    *[None] * (len(phys_shape) - len(phys_sharding.spec)))
     else:
-      phys_spec = phys_sharding.spec  # type: ignore
+      phys_spec = phys_sharding.spec
     return phys_sharding.update(spec=phys_spec[:-elt_aval.ndim])
   else:
     return get_logical_gspmd_sharding(logical_shape, dtype, phys_sharding)

--- a/jax/_src/sharding_specs.py
+++ b/jax/_src/sharding_specs.py
@@ -119,7 +119,7 @@ def _sharding_spec_repr(self):
 
 ShardingSpec.indices = _sharding_spec_indices
 # mypy raises: error: Cannot assign to a method  [assignment]
-ShardingSpec.__repr__ = _sharding_spec_repr  # type: ignore
+ShardingSpec.__repr__ = _sharding_spec_repr
 
 
 Index = Union[int, slice, tuple[Union[int, slice], ...]]

--- a/jax/_src/stages.py
+++ b/jax/_src/stages.py
@@ -480,7 +480,7 @@ class Traced(Stage):
     if _private_parameters is None:
       _private_parameters = mlir.LoweringParameters()
     try:
-      from jax._src.pjit import _resolve_and_lower  # type: ignore
+      from jax._src.pjit import _resolve_and_lower  # pytype: disable=import-error
       lowering = _resolve_and_lower(
           lo._meta_tys_flat, **lo._params, lowering_platforms=lowering_platforms,
           lowering_parameters=_private_parameters, pgle_profiler=None)
@@ -495,7 +495,7 @@ class Traced(Stage):
 
 
 def lojax_expand_params(jaxpr, params):
-  from jax._src.pjit import _lojax_expand_params  # type: ignore
+  from jax._src.pjit import _lojax_expand_params  # pytype: disable=import-error
   lo_nums_in = [len(aval.lo_ty()) for aval in jaxpr.in_aval_qdds]
   lo_nums_out = [len(t.lo_ty()) for t in jaxpr.out_avals]
   lo_muts_out = sum(len(aval.lo_ty()) for aval in jaxpr.final_aval_qdds
@@ -556,8 +556,8 @@ class Lowered(Stage):
     self.args_info = args_info
     self.out_tree = out_tree
     self._no_kwargs = no_kwargs
-    self._in_types = in_types  # type: ignore
-    self._out_types = out_types  # type: ignore
+    self._in_types = in_types
+    self._out_types = out_types
 
   @property
   def in_avals(self):
@@ -592,7 +592,7 @@ class Lowered(Stage):
     """Compile, returning a corresponding ``Compiled`` instance."""
     kw: dict[str, Any] = {"compiler_options": compiler_options,
                           "device_assignment": device_assignment}
-    return Compiled(self._lowering.compile(**kw), self._lowering.const_args,  # type: ignore
+    return Compiled(self._lowering.compile(**kw), self._lowering.const_args,
                     self.args_info, self.out_tree, self._no_kwargs,
                     self._in_types, self._out_types)
 
@@ -886,7 +886,7 @@ class Compiled(Stage):
     return self._call(*args, **kwargs)
 
 def _raise_lo_outs(avals, lo_outs):
-  from jax._src.interpreters import partial_eval as pe  # type: ignore
+  from jax._src.interpreters import partial_eval as pe
   return pe.raise_lo_outs(avals, lo_outs)
 
 # TODO(mattjj): de-dup with partial_eval.py

--- a/jax/_src/state/discharge.py
+++ b/jax/_src/state/discharge.py
@@ -678,7 +678,7 @@ run_state_p.multiple_results = True
 
 def _run_state_is_high(*_, jaxpr, **__):
   return jaxpr.is_high
-run_state_p.is_high = _run_state_is_high  # type: ignore
+run_state_p.is_high = _run_state_is_high
 
 def _run_state_to_lojax(*args, jaxpr, is_initialized, **params):
   assert not jaxpr.constvars

--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -70,10 +70,10 @@ traceback_util.register_exclusion(__file__)
 # `Ref((3,), np.dtype('float32'))` leads to a jaxpr eqn printed like
 #   a:f32[3] <- x[]
 get_p = core.Primitive("get")
-get_p.is_effectful = lambda params: True  # type: ignore
+get_p.is_effectful = lambda params: True
 get_p.def_impl(partial(dispatch.apply_primitive, get_p))
 
-get_p.is_high = lambda ref_aval, *_, tree: ref_aval.is_high  # type: ignore
+get_p.is_high = lambda ref_aval, *_, tree: ref_aval.is_high
 def _get_to_lojax(ref, *idx, tree):
   val_ty = core.typeof(ref._refs)
   transforms = tree_util.tree_unflatten(tree, idx)
@@ -173,10 +173,10 @@ def ref_get(
 # are `ShapedArray((), np.dtype('int32'))` leads to a jaxpr eqn printed like
 #   x:Ref{f32[3]}[i, j] <- a
 swap_p = core.Primitive("swap")
-swap_p.is_effectful = lambda params: True  # type: ignore
+swap_p.is_effectful = lambda params: True
 swap_p.def_impl(partial(dispatch.apply_primitive, swap_p))
 
-swap_p.is_high = lambda ref_aval, *_, tree: ref_aval.is_high  # type: ignore
+swap_p.is_high = lambda ref_aval, *_, tree: ref_aval.is_high
 def _swap_to_lojax(ref, val, *idx, tree):
   ref_val_ty = core.typeof(ref._refs)
   val_ty = core.typeof(val)
@@ -324,7 +324,7 @@ def ref_set(
 # _ = swap ref c *idx
 # ```
 addupdate_p = core.Primitive('addupdate')
-addupdate_p.is_effectful = lambda params: True  # type: ignore
+addupdate_p.is_effectful = lambda params: True
 addupdate_p.multiple_results = True
 addupdate_p.def_impl(partial(dispatch.apply_primitive, addupdate_p))
 
@@ -783,7 +783,7 @@ def _batch_indexer(
       batch_idx = lax.broadcasted_iota(
           np.dtype('int32'), new_integer_indexer_shape, 0)
     else:
-      batch_idx = indexing.Slice(0, axis_size)  # type: ignore
+      batch_idx = indexing.Slice(0, axis_size)
       new_integer_indexer_shape = ()
 
     new_indices.insert(ref_dim, batch_idx)

--- a/jax/_src/state/types.py
+++ b/jax/_src/state/types.py
@@ -592,6 +592,6 @@ class AbstractLinVal(core.AbstractValue):
   inner_aval: core.AbstractValue
   memory_space: Any = None
 
-  shape = property(lambda self: self.inner_aval.shape)  # type: ignore
-  dtype = property(lambda self: self.inner_aval.dtype)  # type: ignore
-  ndim = property(lambda self: self.inner_aval.ndim)  # type: ignore
+  shape = property(lambda self: self.inner_aval.shape)  # pytype: disable=attribute-error
+  dtype = property(lambda self: self.inner_aval.dtype)  # pytype: disable=attribute-error
+  ndim = property(lambda self: self.inner_aval.ndim)  # pytype: disable=attribute-error

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -720,7 +720,7 @@ def flatten_one_level_with_keys(
     tree: Any,
 ) -> tuple[Iterable[KeyLeafPair], Hashable]:
   """Flatten the given pytree node by one level, with keys."""
-  out = default_registry.flatten_one_level_with_keys(tree)  # type: ignore
+  out = default_registry.flatten_one_level_with_keys(tree)
   if out is None:
     raise ValueError(f"can't tree-flatten type: {type(tree)}")
   else:

--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -187,7 +187,7 @@ def _make_transfer_server_factory(
   if CROSS_HOST_TRANSFER_TRANSFER_SIZE.value is not None:
     transfer_server_kwargs["transfer_size"] = (
         CROSS_HOST_TRANSFER_TRANSFER_SIZE.value)
-  return _jax.make_transfer_server_interface_factory(**transfer_server_kwargs)  # type: ignore
+  return _jax.make_transfer_server_interface_factory(**transfer_server_kwargs)
 
 
 def make_tpu_client(


### PR DESCRIPTION
Note that many `type: ignore`s were not in fact necessary and are now gone.