### PR TITLE
[ROCm] Skip ann_test test_pmap on ROCm due to IndivisibleError

### DIFF
--- a/tests/ann_test.py
+++ b/tests/ann_test.py
@@ -121,6 +121,10 @@ class AnnTest(jtu.JaxTestCase):
     num_devices = jax.device_count()
     if num_devices % 2 != 0:
       self.skipTest("Works only when number of devices is a multiple of 2.")
+    # TODO(araganes): Re-enable once upstream HloShardingV3 lands (JAX 0.9.2+).
+    # New pmap's SPMD tiling can't convert back to 1D pmap mesh on ROCm.
+    if jtu.is_device_rocm():
+      self.skipTest("IndivisibleError: SPMD tiling incompatible with 1D pmap mesh on ROCm")
     rng = jtu.rand_default(self.rng())
     qy = rng(qy_shape, dtype)
     db = rng(db_shape, dtype)


### PR DESCRIPTION
## Motivation
The `test_pmap` tests in `tests/ann_test.py` fail on ROCm devices with `IndivisibleError` as of JAX 0.8.0+, due to a sharding conversion mismatch between XLA's SPMD partitioner and JAX's 1D pmap mesh.

## Changes 
Added a conditional skip in `tests/ann_test.py` for `test_pmap` that only skips when -
- Running on ROCm devices (`jtu.is_device_rocm()`)

## Test Result
<img width="817" height="257" alt="image" src="https://github.com/user-attachments/assets/dfef24f2-78a1-44f0-b347-108d56c10874" />


