### PR TITLE
[typing] add a type signature to weakref_lru_cache

### DIFF
--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -419,14 +419,14 @@ def batch_jaxpr2(
     closed_jaxpr: core.ClosedJaxpr,
     axis_data,
     in_axes: tuple[int | NotMapped, ...],
-  ) -> tuple[core.ClosedJaxpr, tuple[int | NotMapped ]]:
+  ) -> tuple[core.ClosedJaxpr, tuple[int | NotMapped, ...]]:
   return _batch_jaxpr2(closed_jaxpr, axis_data, tuple(in_axes))
 
 @weakref_lru_cache
 def _batch_jaxpr2(
     closed_jaxpr: core.ClosedJaxpr,
     axis_data,
-    in_axes: tuple[int | NotMapped ],
+    in_axes: tuple[int | NotMapped, ...],
   ) -> tuple[core.ClosedJaxpr, tuple[int | NotMapped, ...]]:
   f = lu.wrap_init(core.jaxpr_as_fun(closed_jaxpr),
                    debug_info=closed_jaxpr.jaxpr.debug_info)

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -1043,7 +1043,7 @@ _platforms_with_donation = ["cpu", "cuda", "rocm", "tpu", "neuron"]
 
 def add_manual_axes(axis_ctx: sharding_impls.SPMDAxisContext, sharding, ndim):
   mesh = axis_ctx.mesh.abstract_mesh
-  sharding_mesh = sharding.mesh.abstract_mesh
+  sharding_mesh = sharding.mesh.abstract_mesh  # pytype: disable=attribute-error
   if (isinstance(sharding, sharding_impls.NamedSharding) and
       sharding_mesh.shape == mesh.shape):
     out_mesh, spec = sharding_mesh, sharding.spec

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -469,7 +469,7 @@ def partial_eval_wrapper_nounits2(
 
 custom_partial_eval_rules: dict[Primitive, Callable] = {}
 call_partial_eval_rules: dict[Primitive, Callable] = {}
-call_param_updaters: dict[Primitive, Callable] = {}
+call_param_updaters: dict[Primitive, Callable[..., dict[str, Any]]] = {}
 
 def abstract_eval_fun(fun: Callable, *avals,
                       debug_info: core.DebugInfo, **params):
@@ -1303,7 +1303,7 @@ def closed_call_partial_eval_custom_rule(
   new_inst = [x for x, inst in zip(eqn.invars, inst_in)
               if type(x) is Var and not inst]
   new_vars = [*new_inst, *res_val_vars, *res_ref_binders]
-  return eqn_known, eqn_staged, unks_out, inst_out, new_vars
+  return eqn_known, eqn_staged, unks_out, inst_out, new_vars  # pyrefly: ignore[bad-return]
 
 @weakref_lru_cache
 def _closed_jaxpr_partial_eval_custom_cached(

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -2150,7 +2150,7 @@ def hoist_constants_as_args(
     kept_var_idx = set(range(num_const_args)).union(
         {kv + num_const_args for kv in kept_var_idx})
     if inout_aliases is not None:
-      inout_aliases = (None,) * num_const_args + inout_aliases
+      inout_aliases = (None,) * num_const_args + inout_aliases  # pytype: disable=unsupported-operands
     if mut is not None:
       mut = MutationData(
           in_mut=mut.in_mut,

--- a/jax/_src/pallas/fuser/block_spec.py
+++ b/jax/_src/pallas/fuser/block_spec.py
@@ -1895,7 +1895,7 @@ def _reshape_pull_rule(
           'reshape with non-matching block size on lanes not supported yet:'
           f' {block_shape}'
       )
-    new_block_shape = block_shape[:-2] + (total_block_size,)
+    new_block_shape = (*block_shape[:-2], total_block_size)
 
     def new_block_index_transform(*idxs):  # pylint: disable=function-redefined
       *idx, second_to_last, last = block_transform.block_index_transform(*idxs)
@@ -1907,7 +1907,7 @@ def _reshape_pull_rule(
       return *idx, second_to_last
 
     return [block_transform.replace(
-                block_shape=tuple(new_block_shape),
+                block_shape=new_block_shape,
                 block_index_transform=new_block_index_transform,)]
 
   raise NotImplementedError(f'reshape not supported yet: {aval_in}, {aval_out}')
@@ -2316,7 +2316,7 @@ def _binop_push_rule(
     left_block_spec: pallas_core.BlockSpec,
     right_block_spec: pallas_core.BlockSpec,
     **params: Any,
-) -> Sequence[pallas_core.BlockSpec]:
+) -> pallas_core.BlockSpec | tuple[pallas_core.BlockSpec, ...]:
   del prim, params
   left_aval, right_aval = ctx.avals_in
   assert isinstance(left_aval, core.ShapedArray)

--- a/jax/_src/pallas/mosaic/tpu_info.py
+++ b/jax/_src/pallas/mosaic/tpu_info.py
@@ -570,7 +570,7 @@ def infer_tiling(
       return (*(1,) * len(leading_dims), factor, tiling.shape[1])
     case Tiling.SPARSE_CORE:
       [tile_size] = tiling.shape
-      return (*(1,) * len(leading_dims), tile_size * packing)
+      return (*(1,) * len(leading_dims), tile_size * packing)  # pytype: disable=bad-return-type
 
 
 def get_device_kind() -> str:

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -23,7 +23,8 @@ import itertools as it
 import logging
 import math
 import operator
-from typing import (Any, Generic, SupportsIndex, Type, TypeVar, overload, TYPE_CHECKING, cast)
+from typing import (Any, Generic, ParamSpec, Protocol, SupportsIndex,
+                    Type, TypeVar, overload, TYPE_CHECKING, cast)
 import weakref
 
 import numpy as np
@@ -305,9 +306,32 @@ memoize = cache(max_size=None)
 
 def _ignore(): return None
 
+P = ParamSpec("P")
+R = TypeVar("R", covariant=True)  # pytype: disable=not-supported-yet
+
+class WeakrefCachedFunc(Protocol, Generic[P, R]):
+  def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R: ...
+  def cache_clear(self) -> None: ...
+  def cache_info(self) -> lib_weakref_lru_cache.WeakrefLRUCache.WeakrefLRUCacheInfo: ...
+  def cache_keys(self) -> list[Any]: ...
+  def evict_weakref(self, arg0: Any) -> None: ...
+
+@overload
 def weakref_lru_cache(
-    f=None, *, maxsize: int | None = 2048,
-    trace_context_in_key: bool = True, explain: Callable | None = None):
+    f: Callable[P, R], /, *, maxsize: int | None = 2048,
+    trace_context_in_key: bool = True, explain: Callable | None = None
+) -> WeakrefCachedFunc[P, R]: ...
+
+@overload
+def weakref_lru_cache(
+    f: None = None, /, *, maxsize: int | None = 2048,
+    trace_context_in_key: bool = True, explain: Callable | None = None
+) -> Callable[[Callable[P, R]], WeakrefCachedFunc[P, R]]: ...
+
+def weakref_lru_cache(
+    f: Callable[P, R] | None = None, *, maxsize: int | None = 2048,
+    trace_context_in_key: bool = True, explain: Callable | None = None
+):
   """
   Least recently used cache decorator with weakref support.
 


### PR DESCRIPTION
Why? This is frequently used internally, and without a proper type signature static analysis tools like type checkers and smart autocomplete do not know the signature of wrapped functions. Adding this information will make type checkers more useful, and code editors better at supporting JAX internal development.

The main change is in `jax/_src/util.py`; other changes here are correcting incorrect annotations revealed by the more accurate `weakref_lru_cache` signature.