### PR TITLE
Add sharding rules for argsort/bincount

### DIFF
--- a/jax/_src/numpy/sorting.py
+++ b/jax/_src/numpy/sorting.py
@@ -17,6 +17,7 @@ from collections.abc import Sequence
 import numpy as np
 
 from jax._src import api
+from jax._src import core
 from jax._src import dtypes
 from jax._src.lax import lax
 from jax._src.lax import utils as lax_utils
@@ -164,7 +165,7 @@ def argsort(
     # match NumPy type semantics if x64 mode is enabled for now.
     if idx_dtype == np.dtype(np.int32):
       idx_dtype = dtypes.default_int_dtype()
-  iota = lax.broadcasted_iota(idx_dtype, arr.shape, dimension)
+  iota = lax.broadcasted_iota(idx_dtype, arr.shape, dimension, out_sharding=core.typeof(arr).sharding)
   # For stable descending sort, we reverse the array and indices to ensure that
   # duplicates remain in their original order when the final indices are reversed.
   # For non-stable descending sort, we can avoid these extra operations.

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -10576,6 +10576,12 @@ class ShardingInTypesTest(jtu.JaxTestCase):
     out2 = jax.jit(jax.grad(f))(arr2)
     self.assertArraysEqual(reshard(out, P()), out2)
 
+  @jtu.with_explicit_mesh((2,), "x")
+  def test_argsort(self, mesh):
+    x = jnp.array([4, 3, 2, 5, 6, 0])
+    x = reshard(x, P("x"))
+    np.testing.assert_array_equal(jnp.argsort(x), np.array([5, 2, 1, 0, 3, 4]))
+
 
 @jtu.pytest_mark_if_available('multiaccelerator')
 class PJitErrorTest(jtu.JaxTestCase):


### PR DESCRIPTION
Adds some missing explicit sharding rules for 2 ops (argsort/bincount).

I also added some tests to make sure they work, but there wasn't an existing place to put explicit sharding tests (?) so I created a new class `ExplicitShardingTests` in `lax_numpy_test.py`