### PR TITLE
[pyrefly] Excluded jax/_src/internal_test_util/export_back_compat_test_data

### DIFF
--- a/jax/_src/internal_test_util/export_back_compat_test_data/cpu_triangular_solve_blas_trsm.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_data/cpu_triangular_solve_blas_trsm.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pyrefly: ignore-errors
 # ruff: noqa
 
 import datetime

--- a/jax/_src/internal_test_util/export_back_compat_test_data/cpu_tridiagonal_solve_lapack_gtsv.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_data/cpu_tridiagonal_solve_lapack_gtsv.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pyrefly: ignore-errors
 # ruff: noqa
 
 import datetime

--- a/jax/_src/internal_test_util/export_back_compat_test_data/cuda_cholesky_solver_potrf.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_data/cuda_cholesky_solver_potrf.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pyrefly: ignore-errors
 # ruff: noqa
 
 import datetime

--- a/jax/_src/internal_test_util/export_back_compat_test_data/cuda_eigh_cusolver_syev.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_data/cuda_eigh_cusolver_syev.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pyrefly: ignore-errors
 # ruff: noqa
 
 import datetime

--- a/jax/_src/internal_test_util/export_back_compat_test_data/cuda_lu_cusolver_getrf.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_data/cuda_lu_cusolver_getrf.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pyrefly: ignore-errors
 # ruff: noqa
 
 import datetime

--- a/jax/_src/internal_test_util/export_back_compat_test_data/cuda_qr_cusolver_geqrf.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_data/cuda_qr_cusolver_geqrf.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pyrefly: ignore-errors
 # ruff: noqa
 
 import datetime

--- a/jax/_src/internal_test_util/export_back_compat_test_data/cuda_tridiagonal_cusolver_sytrd.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_data/cuda_tridiagonal_cusolver_sytrd.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pyrefly: ignore-errors
 # ruff: noqa
 
 import datetime

--- a/jax/_src/internal_test_util/export_back_compat_test_data/rocm_cholesky_solver_potrf.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_data/rocm_cholesky_solver_potrf.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pyrefly: ignore-errors
 # ruff: noqa
 
 import datetime

--- a/jax/_src/internal_test_util/export_back_compat_test_data/rocm_lu_rocsolver_getrf.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_data/rocm_lu_rocsolver_getrf.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pyrefly: ignore-errors
 import datetime
 import numpy
 array = numpy.array

--- a/jax/_src/internal_test_util/export_back_compat_test_data/rocm_qr_hipsolver_geqrf.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_data/rocm_qr_hipsolver_geqrf.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pyrefly: ignore-errors
 # ruff: noqa
 
 import datetime

--- a/jax/_src/internal_test_util/export_back_compat_test_data/rocm_tridiagonal_hipsolver_sytrd.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_data/rocm_tridiagonal_hipsolver_sytrd.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pyrefly: ignore-errors
 # ruff: noqa
 
 import datetime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ project-includes = [
     # "tests/**/*.py",
 ]
 project-excludes = [
+    "jax/_src/internal_test_util/export_back_compat_test_data/*.py",
     "jax/example_libraries/**/*.py",
     # TODO(slebedev): Opt in jax/experimental and remove these excludes.
     "jax/experimental/*.py",


### PR DESCRIPTION
This is now done via glob in pyproject.toml, so that we don't have to add `#pyrefly: ignore-errors` to every file.
