### PR TITLE
[Mosaic:GPU] Fix test hang and re-enable it.

### DIFF
--- a/jaxlib/mosaic/gpu/custom_call.cc
+++ b/jaxlib/mosaic/gpu/custom_call.cc
@@ -1226,11 +1226,6 @@ absl::Status MosaicGpuInitialize(
   // operation initialization. During reruns we can reuse the same buffers for
   // the same operation since multi-device barrier can be called multiple times
   // on the same buffers.
-  // It's important to zero the buffer synchronously to avoid the situation
-  // when peer barrier buffer is not zeroed before the first execution.
-  // We can guarantee a zeroed buffers in all participating devices since
-  // below we are running rendezvous to exchange peer parameters in the
-  // CollectParamToPeers call.
   if (device_state.barrier_signal_buffer_handle.address().is_null()) {
     device_state.barrier_signal_buffer_handle = se::DeviceAddressHandle{
         collective_params->executor,
@@ -1239,7 +1234,7 @@ absl::Status MosaicGpuInitialize(
 
     se::DeviceAddressBase barrier_signal_buffer_address =
         device_state.barrier_signal_buffer_handle.address();
-    TF_RETURN_IF_ERROR(collective_params->executor->SynchronousMemZero(
+    TF_RETURN_IF_ERROR(stream->MemZero(
         &barrier_signal_buffer_address, barrier_signal_buffer_address.size()));
   }
 
@@ -1250,10 +1245,17 @@ absl::Status MosaicGpuInitialize(
             xla::gpu::GetMultiGpuBarrierSignalValueSize())};
     se::DeviceAddressBase barrier_signal_value_buffer_address =
         device_state.barrier_signal_value_buffer_handle.address();
-    TF_RETURN_IF_ERROR(collective_params->executor->SynchronousMemZero(
+    TF_RETURN_IF_ERROR(stream->MemZero(
         &barrier_signal_value_buffer_address,
         barrier_signal_value_buffer_address.size()));
   }
+
+  // It's important to zero the buffer synchronously to avoid the situation
+  // when peer barrier buffer is not zeroed before the first execution.
+  // We can guarantee a zeroed buffers in all participating devices since
+  // below we are running rendezvous to exchange peer parameters in the
+  // CollectParamToPeers call.
+  TF_RETURN_IF_ERROR(stream->BlockHostUntilDone());
 
   // Exchange the adresses of the buffer barriers.
   parameters.push_back(device_state.barrier_signal_buffer_handle.address());

--- a/tests/pallas/BUILD
+++ b/tests/pallas/BUILD
@@ -485,10 +485,6 @@ jax_multiplatform_test(
 jax_multiplatform_test(
     name = "gpu_pallas_distributed_test",
     srcs = ["gpu_pallas_distributed_test.py"],
-    args = if_oss(
-        ["--is_oss=True"],
-        [],
-    ),
     enable_backends = [],
     enable_configs = [
         "gpu_h100x2_full",  # We need a 2 physical GPUs since otherwise the test will be skipped

--- a/tests/pallas/gpu_pallas_distributed_test.py
+++ b/tests/pallas/gpu_pallas_distributed_test.py
@@ -18,7 +18,6 @@ import functools
 import os
 import tempfile
 
-import absl.flags
 from absl.testing import absltest
 from absl.testing import parameterized
 import jax
@@ -39,8 +38,6 @@ import numpy as np
 
 P = jax.sharding.PartitionSpec
 partial = functools.partial
-
-IS_OSS = absl.flags.DEFINE_bool("is_oss", False, "Is test running in OSS.")
 
 
 def is_nvshmem_used():
@@ -73,9 +70,6 @@ class PallasCallRemoteDMATest(TestCase):
   def setUp(self):
     if jax.device_count() < 2:
       self.skipTest("Needs at least two devices")
-    if jax.local_device_count() > 1 and IS_OSS.value:
-      # TODO(b/490026390): Remove this once the bug is fixed.
-      self.skipTest("Test hangs in OSS in a single-process mode.")
     super().setUp()
 
   def test_remote_dma_basic(self):


### PR DESCRIPTION
This reverts commit 909407299b12679e191874546f57d3bbe493cffe, and adds a fix to explicitly use stream-ordered memset operations and an explicit stream synchronisation instead of XLA's misleadingly-named SynchronousMemZero wrapper.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->