### PR TITLE
[ROCm] Add individual skips to Mosaic tests

### DIFF
--- a/tests/mosaic/flash_attention_test.py
+++ b/tests/mosaic/flash_attention_test.py
@@ -15,6 +15,7 @@
 """Test different parameterizations of FlashAttention."""
 
 import os
+import unittest
 
 from absl.testing import absltest, parameterized
 from jax._src import config
@@ -36,6 +37,10 @@ os.environ["XLA_FLAGS"] = (
 
 
 @jtu.with_config(jax_traceback_filtering="off")
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class FlashAttentionTestCase(jtu.JaxTestCase):
 
   def setUp(self):

--- a/tests/mosaic/flash_attention_test.py
+++ b/tests/mosaic/flash_attention_test.py
@@ -15,7 +15,6 @@
 """Test different parameterizations of FlashAttention."""
 
 import os
-import unittest
 
 from absl.testing import absltest, parameterized
 from jax._src import config
@@ -37,14 +36,12 @@ os.environ["XLA_FLAGS"] = (
 
 
 @jtu.with_config(jax_traceback_filtering="off")
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class FlashAttentionTestCase(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if flash_attention is None:
       self.skipTest("Mosaic GPU not available.")
     if (not jtu.test_device_matches(["cuda"]) or

--- a/tests/mosaic/gpu_constraints_test.py
+++ b/tests/mosaic/gpu_constraints_test.py
@@ -14,8 +14,6 @@
 # ==============================================================================
 """Tests for Mosaic GPU's `constraints` module."""
 
-import unittest
-
 from absl.testing import parameterized
 from jax._src import config
 from jax._src import test_util as jtu
@@ -32,11 +30,12 @@ Eq = cs.Equals
 V = cs.Variable
 
 
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class ConstraintSystemTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
 
   def test_constraint_system_is_unsatisfiable_if_assignments_are_incompatible(
       self,

--- a/tests/mosaic/gpu_constraints_test.py
+++ b/tests/mosaic/gpu_constraints_test.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Tests for Mosaic GPU's `constraints` module."""
 
+import unittest
+
 from absl.testing import parameterized
 from jax._src import config
 from jax._src import test_util as jtu
@@ -30,6 +32,10 @@ Eq = cs.Equals
 V = cs.Variable
 
 
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class ConstraintSystemTest(parameterized.TestCase):
 
   def test_constraint_system_is_unsatisfiable_if_assignments_are_incompatible(

--- a/tests/mosaic/gpu_dialect_test.py
+++ b/tests/mosaic/gpu_dialect_test.py
@@ -16,6 +16,7 @@
 
 from collections.abc import Callable
 import inspect
+import unittest
 
 from absl.testing import parameterized
 import jax
@@ -100,6 +101,10 @@ def undefs(*tys: ir.Type) -> list[ir.Value]:
   return [builtin.unrealized_conversion_cast([ty], []) for ty in tys]
 
 
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class MosaicGpuTest(parameterized.TestCase):
 
   def setUp(self):

--- a/tests/mosaic/gpu_dialect_test.py
+++ b/tests/mosaic/gpu_dialect_test.py
@@ -16,7 +16,6 @@
 
 from collections.abc import Callable
 import inspect
-import unittest
 
 from absl.testing import parameterized
 import jax
@@ -101,16 +100,14 @@ def undefs(*tys: ir.Type) -> list[ir.Value]:
   return [builtin.unrealized_conversion_cast([ty], []) for ty in tys]
 
 
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class MosaicGpuTest(parameterized.TestCase):
 
   def setUp(self):
     if jax.version._version != jax.lib.__version__:
       raise self.skipTest("Test requires matching jax and jaxlib versions")
     super().setUp()
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     self.enter_context(_make_ir_context())
     self.enter_context(ir.Location.unknown())
     self.module = ir.Module.create()

--- a/tests/mosaic/gpu_layout_inference_test.py
+++ b/tests/mosaic/gpu_layout_inference_test.py
@@ -17,7 +17,6 @@
 # pylint: disable=g-complex-comprehension
 
 import inspect
-import unittest
 
 from absl.testing import parameterized
 import jax
@@ -88,10 +87,6 @@ def _undef_constraint_system(
   return cs.ConstraintSystem(), {cs.Variable(result): [result]}
 
 
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class LayoutInferenceTest(parameterized.TestCase):
   @classmethod
   def setUpClass(cls):
@@ -111,6 +106,8 @@ class LayoutInferenceTest(parameterized.TestCase):
     if jax.version._version != jax.lib.__version__:
       raise self.skipTest("Test requires matching jax and jaxlib versions")
     super().setUp()
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     self.enter_context(_make_ir_context())
     self.enter_context(ir.Location.unknown())
     self.module = ir.Module.create()

--- a/tests/mosaic/gpu_layout_inference_test.py
+++ b/tests/mosaic/gpu_layout_inference_test.py
@@ -17,6 +17,7 @@
 # pylint: disable=g-complex-comprehension
 
 import inspect
+import unittest
 
 from absl.testing import parameterized
 import jax
@@ -87,6 +88,10 @@ def _undef_constraint_system(
   return cs.ConstraintSystem(), {cs.Variable(result): [result]}
 
 
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class LayoutInferenceTest(parameterized.TestCase):
   @classmethod
   def setUpClass(cls):

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -24,6 +24,7 @@ import os
 import re
 import sys
 import tempfile
+import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -54,7 +55,6 @@ from jax.experimental.mosaic.gpu import utils
 from jax.experimental.mosaic.gpu.utils import *  # noqa: F403
 import jax.numpy as jnp
 import numpy as np
-
 
 try:
   import jax._src.lib.mosaic_gpu as mosaic_gpu_lib  # noqa: F401
@@ -210,6 +210,10 @@ def iota_tensor(m, n, dtype, layout=mgpu.WGMMA_LAYOUT):
   return ret.astype(mlir_dtype, is_signed=utils.is_signed(dtype))
 
 
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class TestCase(parameterized.TestCase):
 
   def setUp(self, *, artificial_shared_memory_limit=jtu._SMEM_SIZE_BOUND_FOR_TESTS):
@@ -7115,6 +7119,10 @@ class EndToEndTest(TestCase):
     self.assertEqual(ptx().count("\t.param"), 2)
 
 
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class SerializationTest(absltest.TestCase):
 
   def test_pass_is_registered(self):

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -24,7 +24,6 @@ import os
 import re
 import sys
 import tempfile
-import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -210,13 +209,11 @@ def iota_tensor(m, n, dtype, layout=mgpu.WGMMA_LAYOUT):
   return ret.astype(mlir_dtype, is_signed=utils.is_signed(dtype))
 
 
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class TestCase(parameterized.TestCase):
 
   def setUp(self, *, artificial_shared_memory_limit=jtu._SMEM_SIZE_BOUND_FOR_TESTS):
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if not HAS_MOSAIC_GPU:
       self.skipTest("jaxlib built without Mosaic GPU")
     if (not jtu.test_device_matches(["cuda"]) or
@@ -7119,11 +7116,12 @@ class EndToEndTest(TestCase):
     self.assertEqual(ptx().count("\t.param"), 2)
 
 
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class SerializationTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
 
   def test_pass_is_registered(self):
     ctx = mlir.make_ir_context()

--- a/tests/mosaic/gpu_test_distributed.py
+++ b/tests/mosaic/gpu_test_distributed.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 import os
+import unittest
 
 from absl.testing import parameterized
 import jax
@@ -32,12 +33,15 @@ import numpy as np
 import jax.experimental.mosaic.gpu as mgpu
 import jax.experimental.mosaic.gpu.fragmented_array as fa
 
-
 # ruff: noqa: F405
 # pylint: disable=g-complex-comprehension
 P = jax.sharding.PartitionSpec
 
 
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class TestCase(parameterized.TestCase):
 
   def setUp(self):

--- a/tests/mosaic/gpu_test_distributed.py
+++ b/tests/mosaic/gpu_test_distributed.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 
 import os
-import unittest
 
 from absl.testing import parameterized
 import jax
@@ -38,13 +37,11 @@ import jax.experimental.mosaic.gpu.fragmented_array as fa
 P = jax.sharding.PartitionSpec
 
 
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class TestCase(parameterized.TestCase):
 
   def setUp(self):
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if (not jtu.test_device_matches(["cuda"]) or
         not jtu.is_cuda_compute_capability_at_least("9.0")):
       self.skipTest("Only works on GPU with capability >= sm90")

--- a/tests/mosaic/gpu_test_multidevice.py
+++ b/tests/mosaic/gpu_test_multidevice.py
@@ -22,7 +22,6 @@ from jax._src.lib.mlir import ir
 from jax.experimental.mosaic.gpu import dialect as mgpu_dialect  # pylint: disable=g-importing-member
 import jax.numpy as jnp
 import numpy as np
-import unittest
 try:
   import jax._src.lib.mosaic_gpu  # noqa: F401
   HAS_MOSAIC_GPU = True
@@ -36,13 +35,11 @@ else:
 config.parse_flags_with_absl()
 
 
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class TestCase(parameterized.TestCase):
 
   def setUp(self):
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if not HAS_MOSAIC_GPU:
       self.skipTest("jaxlib built without Mosaic GPU")
     if (not jtu.test_device_matches(["cuda"]) or

--- a/tests/mosaic/gpu_test_multidevice.py
+++ b/tests/mosaic/gpu_test_multidevice.py
@@ -22,6 +22,7 @@ from jax._src.lib.mlir import ir
 from jax.experimental.mosaic.gpu import dialect as mgpu_dialect  # pylint: disable=g-importing-member
 import jax.numpy as jnp
 import numpy as np
+import unittest
 try:
   import jax._src.lib.mosaic_gpu  # noqa: F401
   HAS_MOSAIC_GPU = True
@@ -30,12 +31,15 @@ except ImportError:
 else:
   import jax.experimental.mosaic.gpu as mgpu
 
-
 # ruff: noqa: F405
 # pylint: disable=g-complex-comprehension
 config.parse_flags_with_absl()
 
 
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class TestCase(parameterized.TestCase):
 
   def setUp(self):

--- a/tests/mosaic/gpu_torch_test.py
+++ b/tests/mosaic/gpu_torch_test.py
@@ -41,6 +41,10 @@ except ImportError:
 config.parse_flags_with_absl()
 
 
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class TorchTest(parameterized.TestCase):
 
   def setUp(self):

--- a/tests/mosaic/gpu_torch_test.py
+++ b/tests/mosaic/gpu_torch_test.py
@@ -41,13 +41,11 @@ except ImportError:
 config.parse_flags_with_absl()
 
 
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class TorchTest(parameterized.TestCase):
 
   def setUp(self):
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if (not jtu.test_device_matches(["cuda"]) or
         not jtu.is_cuda_compute_capability_at_least("9.0")):
       self.skipTest("Only works on GPU with capability >= sm90")

--- a/tests/mosaic/gpu_torch_test_distributed.py
+++ b/tests/mosaic/gpu_torch_test_distributed.py
@@ -40,13 +40,11 @@ except ImportError:
 # pylint: disable=g-complex-comprehension
 
 
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class TorchTest(parameterized.TestCase):
 
   def setUpClass():
+    if jtu.test_device_matches(["rocm"]):
+      raise unittest.SkipTest("Mosaic GPU is not supported on ROCm.")
     torch.cuda.set_device("cuda:0")
     torch.set_default_device("cuda")
     if torch is None:

--- a/tests/mosaic/gpu_torch_test_distributed.py
+++ b/tests/mosaic/gpu_torch_test_distributed.py
@@ -36,11 +36,14 @@ try:
 except ImportError:
   torch = None
 
-
 # ruff: noqa: F405
 # pylint: disable=g-complex-comprehension
 
 
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class TorchTest(parameterized.TestCase):
 
   def setUpClass():

--- a/tests/mosaic/matmul_test.py
+++ b/tests/mosaic/matmul_test.py
@@ -15,6 +15,7 @@
 """Test different parameterizations of a matmul."""
 
 import os
+import unittest
 
 from absl.testing import absltest, parameterized
 from jax._src import config
@@ -52,6 +53,10 @@ def seed_hypothesis(f):
 
 @jtu.with_config(jax_traceback_filtering="off")
 @jtu.thread_unsafe_test_class()  # hypothesis is not thread safe
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class MatmulTestCase(jtu.JaxTestCase, jtu.CudaArchSpecificTest):
 
   def setUp(self):

--- a/tests/mosaic/matmul_test.py
+++ b/tests/mosaic/matmul_test.py
@@ -15,7 +15,6 @@
 """Test different parameterizations of a matmul."""
 
 import os
-import unittest
 
 from absl.testing import absltest, parameterized
 from jax._src import config
@@ -53,14 +52,12 @@ def seed_hypothesis(f):
 
 @jtu.with_config(jax_traceback_filtering="off")
 @jtu.thread_unsafe_test_class()  # hypothesis is not thread safe
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class MatmulTestCase(jtu.JaxTestCase, jtu.CudaArchSpecificTest):
 
   def setUp(self):
     super().setUp()
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if matmul is None:
       self.skipTest("Mosaic GPU not available.")
     if not jtu.test_device_matches(["cuda"]):

--- a/tests/mosaic/profiler_cupti_test.py
+++ b/tests/mosaic/profiler_cupti_test.py
@@ -17,7 +17,6 @@ from absl.testing import absltest, parameterized
 from jax._src import config
 from jax._src import test_util as jtu
 import jax.numpy as jnp
-import unittest
 try:
   import jax._src.lib.mosaic_gpu  # noqa: F401
   HAS_MOSAIC_GPU = True
@@ -30,13 +29,11 @@ else:
 # pylint: disable=g-complex-comprehension
 config.parse_flags_with_absl()
 
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class ProfilerCuptiTest(parameterized.TestCase):
 
   def setUp(self):
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if not HAS_MOSAIC_GPU:
       self.skipTest("jaxlib built without Mosaic GPU")
     if (not jtu.test_device_matches(["cuda"])):

--- a/tests/mosaic/profiler_cupti_test.py
+++ b/tests/mosaic/profiler_cupti_test.py
@@ -17,6 +17,7 @@ from absl.testing import absltest, parameterized
 from jax._src import config
 from jax._src import test_util as jtu
 import jax.numpy as jnp
+import unittest
 try:
   import jax._src.lib.mosaic_gpu  # noqa: F401
   HAS_MOSAIC_GPU = True
@@ -25,11 +26,14 @@ except ImportError:
 else:
   from jax.experimental.mosaic.gpu import profiler
 
-
 # ruff: noqa: F405
 # pylint: disable=g-complex-comprehension
 config.parse_flags_with_absl()
 
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class ProfilerCuptiTest(parameterized.TestCase):
 
   def setUp(self):

--- a/tests/pallas/export_back_compat_pallas_test.py
+++ b/tests/pallas/export_back_compat_pallas_test.py
@@ -70,6 +70,8 @@ class CompatTest(bctu.CompatTestBase):
     self.run_one_test(func, data)
 
   def test_mosaic_gpu_add_one(self):
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if not jtu.is_cuda_compute_capability_at_least("9.0"):
       self.skipTest("Only works on GPUs with capability >= sm90")
 
@@ -86,6 +88,8 @@ class CompatTest(bctu.CompatTestBase):
     self.run_one_test(add_one, data, expect_current_custom_calls=["mosaic_gpu_v2"])
 
   def test_mosaic_gpu_kernel_add_one(self):
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if not jtu.is_cuda_compute_capability_at_least("9.0"):
       self.skipTest("Only works on GPUs with capability >= sm90")
 

--- a/tests/pallas/gpu_pallas_distributed_test.py
+++ b/tests/pallas/gpu_pallas_distributed_test.py
@@ -53,7 +53,7 @@ class TestCase(jt_multiprocess.MultiProcessTest if is_nvshmem_used() is None els
 
   def setUp(self):
     if jtu.test_device_matches(["rocm"]):
-      self.skipTest("Mosaic not supported on ROCm currently.")
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
 
     if (not jtu.test_device_matches(["cuda"]) or
         not jtu.is_cuda_compute_capability_at_least("9.0")):

--- a/tests/pallas/gpu_pallas_interpret_test.py
+++ b/tests/pallas/gpu_pallas_interpret_test.py
@@ -14,7 +14,6 @@
 
 import functools
 from typing import Any
-import unittest
 from absl.testing import absltest
 import jax
 from jax._src import test_util as jtu
@@ -37,14 +36,12 @@ def _maybe_reverse(arg: tuple[Any], reverse: bool) -> tuple[Any]:
 # TODO(nrink): Figure out how to safely run different instance of GPU
 # interpret mode in parallel, and then remove this decorator.
 @jtu.thread_unsafe_test_class()
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class InterpretTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
 
     if not jtu.test_device_matches(['cpu']):
       self.skipTest('CPU-only test')

--- a/tests/pallas/gpu_pallas_interpret_test.py
+++ b/tests/pallas/gpu_pallas_interpret_test.py
@@ -14,6 +14,7 @@
 
 import functools
 from typing import Any
+import unittest
 from absl.testing import absltest
 import jax
 from jax._src import test_util as jtu
@@ -22,7 +23,6 @@ from jax.experimental import pallas as pl
 from jax.experimental.pallas import mosaic_gpu as plgpu
 import jax.numpy as jnp
 import numpy as np
-
 
 jax.config.parse_flags_with_absl()
 
@@ -37,6 +37,10 @@ def _maybe_reverse(arg: tuple[Any], reverse: bool) -> tuple[Any]:
 # TODO(nrink): Figure out how to safely run different instance of GPU
 # interpret mode in parallel, and then remove this decorator.
 @jtu.thread_unsafe_test_class()
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class InterpretTest(jtu.JaxTestCase):
 
   def setUp(self):

--- a/tests/pallas/mgpu_attention_test.py
+++ b/tests/pallas/mgpu_attention_test.py
@@ -15,6 +15,7 @@
 """Test different parameterizations of FlashAttention."""
 
 import os
+import unittest
 
 import numpy as np
 from absl.testing import absltest, parameterized
@@ -39,6 +40,10 @@ os.environ["XLA_FLAGS"] = (
 
 
 @jtu.with_config(jax_traceback_filtering="off")
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class FlashAttentionTestCase(jtu.JaxTestCase):
 
   def setUp(self):

--- a/tests/pallas/mgpu_attention_test.py
+++ b/tests/pallas/mgpu_attention_test.py
@@ -15,7 +15,6 @@
 """Test different parameterizations of FlashAttention."""
 
 import os
-import unittest
 
 import numpy as np
 from absl.testing import absltest, parameterized
@@ -40,14 +39,12 @@ os.environ["XLA_FLAGS"] = (
 
 
 @jtu.with_config(jax_traceback_filtering="off")
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class FlashAttentionTestCase(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if attention_mgpu is None:
       self.skipTest("Mosaic GPU not available.")
     if (not jtu.test_device_matches(["cuda"]) or

--- a/tests/pallas/mgpu_collective_matmul_test.py
+++ b/tests/pallas/mgpu_collective_matmul_test.py
@@ -16,6 +16,7 @@
 
 import functools
 import os
+import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized  # pylint: disable=g-multiple-import
@@ -30,7 +31,6 @@ from jax.experimental.pallas.ops.gpu import collective_matmul_mgpu
 import jax.numpy as jnp
 import numpy as np
 
-
 P = jax.sharding.PartitionSpec
 
 
@@ -42,6 +42,10 @@ def is_nvshmem_used() -> bool:
 
 
 @jtu.with_config(jax_traceback_filtering="off")
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class CollectiveMatmulTestCase(jtu.JaxTestCase):
 
   def setUp(self):

--- a/tests/pallas/mgpu_collective_matmul_test.py
+++ b/tests/pallas/mgpu_collective_matmul_test.py
@@ -16,7 +16,6 @@
 
 import functools
 import os
-import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized  # pylint: disable=g-multiple-import
@@ -42,14 +41,12 @@ def is_nvshmem_used() -> bool:
 
 
 @jtu.with_config(jax_traceback_filtering="off")
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class CollectiveMatmulTestCase(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if collective_matmul_mgpu is None:
       self.skipTest("Mosaic GPU not available.")
     if (not jtu.test_device_matches(["cuda"]) or

--- a/tests/pallas/mgpu_examples_test.py
+++ b/tests/pallas/mgpu_examples_test.py
@@ -18,6 +18,7 @@ import dataclasses
 import functools
 import itertools
 import statistics
+import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -31,7 +32,6 @@ import jax.experimental.pallas.mosaic_gpu as plgpu
 from jax.extend import backend
 import jax.numpy as jnp
 import numpy as np
-
 
 config.parse_flags_with_absl()
 
@@ -853,6 +853,10 @@ def matmul6(a, b, config: TuningConfig):
 
 
 @jtu.with_config(jax_traceback_filtering="off")
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class MatmulTutorialTCGen05Test(jtu.JaxTestCase, jtu.CudaArchSpecificTest):
   BENCHMARK = False
 

--- a/tests/pallas/mgpu_examples_test.py
+++ b/tests/pallas/mgpu_examples_test.py
@@ -18,7 +18,6 @@ import dataclasses
 import functools
 import itertools
 import statistics
-import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -853,15 +852,13 @@ def matmul6(a, b, config: TuningConfig):
 
 
 @jtu.with_config(jax_traceback_filtering="off")
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class MatmulTutorialTCGen05Test(jtu.JaxTestCase, jtu.CudaArchSpecificTest):
   BENCHMARK = False
 
   def setUp(self):
     super().setUp()
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if not jtu.test_device_matches(["cuda"]):
       self.skipTest("Test requires an NVIDIA GPU")
     self.skip_unless_tcgen05()

--- a/tests/pallas/mgpu_matmul_test.py
+++ b/tests/pallas/mgpu_matmul_test.py
@@ -15,7 +15,6 @@
 """Test different parameterizations of matrix multiplication."""
 
 import os
-import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -41,14 +40,12 @@ def exceeds_h100_smem(alloc_bytes: int) -> bool:
 
 
 @jtu.with_config(jax_traceback_filtering="off")
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class MatrixMultiplicationTCGen05Test(jtu.JaxTestCase, jtu.CudaArchSpecificTest):
 
   def setUp(self):
     super().setUp()
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if not jtu.test_device_matches(["cuda"]):
       self.skipTest("Test requires an NVIDIA GPU")
 
@@ -84,14 +81,12 @@ class MatrixMultiplicationTCGen05Test(jtu.JaxTestCase, jtu.CudaArchSpecificTest)
 
 
 @jtu.with_config(jax_traceback_filtering="off")
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class MatrixMultiplicationSm90ATest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if not jtu.test_device_matches(["cuda"]):
       self.skipTest("Test requires an NVIDIA GPU")
 

--- a/tests/pallas/mgpu_matmul_test.py
+++ b/tests/pallas/mgpu_matmul_test.py
@@ -15,6 +15,7 @@
 """Test different parameterizations of matrix multiplication."""
 
 import os
+import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -29,7 +30,6 @@ from jax.experimental.pallas.ops.gpu import hopper_mixed_type_matmul_mgpu
 import jax.numpy as jnp
 import numpy as np
 
-
 config.parse_flags_with_absl()
 os.environ["XLA_FLAGS"] = (
     os.environ.get("XLA_FLAGS", "") + " --xla_gpu_autotune_level=0")
@@ -41,6 +41,10 @@ def exceeds_h100_smem(alloc_bytes: int) -> bool:
 
 
 @jtu.with_config(jax_traceback_filtering="off")
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class MatrixMultiplicationTCGen05Test(jtu.JaxTestCase, jtu.CudaArchSpecificTest):
 
   def setUp(self):
@@ -80,6 +84,10 @@ class MatrixMultiplicationTCGen05Test(jtu.JaxTestCase, jtu.CudaArchSpecificTest)
 
 
 @jtu.with_config(jax_traceback_filtering="off")
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class MatrixMultiplicationSm90ATest(jtu.JaxTestCase):
 
   def setUp(self):

--- a/tests/pallas/mgpu_ragged_dot_test.py
+++ b/tests/pallas/mgpu_ragged_dot_test.py
@@ -15,6 +15,7 @@
 """Test different parameterizations of our Mosaic GPU ragged dot kernel."""
 
 import os
+import unittest
 
 from absl.testing import absltest, parameterized  # pylint: disable=g-multiple-import
 import jax
@@ -26,7 +27,6 @@ from jax.experimental.pallas.ops.gpu import ragged_dot_mgpu
 from jax.experimental.pallas.ops.gpu import transposed_ragged_dot_mgpu
 import jax.numpy as jnp
 import numpy as np
-
 
 config.parse_flags_with_absl()
 
@@ -59,6 +59,10 @@ def sample_inputs(
 
 
 @jtu.with_config(jax_traceback_filtering="off")
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class RaggedDotTestCase(jtu.JaxTestCase):
 
   def setUp(self):

--- a/tests/pallas/mgpu_ragged_dot_test.py
+++ b/tests/pallas/mgpu_ragged_dot_test.py
@@ -15,7 +15,6 @@
 """Test different parameterizations of our Mosaic GPU ragged dot kernel."""
 
 import os
-import unittest
 
 from absl.testing import absltest, parameterized  # pylint: disable=g-multiple-import
 import jax
@@ -59,14 +58,12 @@ def sample_inputs(
 
 
 @jtu.with_config(jax_traceback_filtering="off")
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class RaggedDotTestCase(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if ragged_dot_mgpu is None:
       self.skipTest("Mosaic GPU not available.")
     if (not jtu.test_device_matches(["cuda"]) or

--- a/tests/pallas/mgpu_torch_test.py
+++ b/tests/pallas/mgpu_torch_test.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 
 import functools
-import unittest
 
 from absl.testing import absltest
 
@@ -43,14 +42,12 @@ else:
 config.parse_flags_with_absl()
 
 
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class TorchTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if torch is None:
       self.skipTest("Test requires PyTorch")
     if attention_mgpu is None:

--- a/tests/pallas/mgpu_torch_test.py
+++ b/tests/pallas/mgpu_torch_test.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 import functools
+import unittest
 
 from absl.testing import absltest
 
@@ -39,10 +40,13 @@ except ImportError:
 else:
   from jax.experimental.pallas.ops.gpu import attention_mgpu
 
-
 config.parse_flags_with_absl()
 
 
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class TorchTest(jtu.JaxTestCase):
 
   def setUp(self):

--- a/tests/pallas/mosaic_gpu_test.py
+++ b/tests/pallas/mosaic_gpu_test.py
@@ -24,6 +24,7 @@ import re
 import sys
 import tempfile
 import traceback
+import unittest
 from typing import ClassVar
 
 from absl.testing import absltest
@@ -57,7 +58,6 @@ try:
   from jax._src.lib import mosaic_gpu as mosaic_gpu_lib
 except ImportError:
   mosaic_gpu_lib = None
-
 
 jax.config.parse_flags_with_absl()
 
@@ -133,6 +133,10 @@ class PallasTestMetaclass(parameterized.TestGeneratorMetaclass):
     return cls
 
 
+@unittest.skipIf(
+    jtu.test_device_matches(["rocm"]),
+    "Mosaic GPU is not supported on ROCm.",
+)
 class PallasTest(jtu.JaxTestCase, metaclass=PallasTestMetaclass):
   LOWERING_SEMANTICS: ClassVar[plgpu.LoweringSemantics]
 

--- a/tests/pallas/mosaic_gpu_test.py
+++ b/tests/pallas/mosaic_gpu_test.py
@@ -24,7 +24,6 @@ import re
 import sys
 import tempfile
 import traceback
-import unittest
 from typing import ClassVar
 
 from absl.testing import absltest
@@ -133,14 +132,12 @@ class PallasTestMetaclass(parameterized.TestGeneratorMetaclass):
     return cls
 
 
-@unittest.skipIf(
-    jtu.test_device_matches(["rocm"]),
-    "Mosaic GPU is not supported on ROCm.",
-)
 class PallasTest(jtu.JaxTestCase, metaclass=PallasTestMetaclass):
   LOWERING_SEMANTICS: ClassVar[plgpu.LoweringSemantics]
 
   def setUp(self, *, artificial_shared_memory_limit=jtu._SMEM_SIZE_BOUND_FOR_TESTS):
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if not jtu.is_cuda_compute_capability_at_least("9.0"):
       self.skipTest("Only works on a GPU with capability >= sm90")
 

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -322,9 +322,9 @@ class PallasBaseTest(ptu.PallasTest):
     return pl.pallas_call(*args, interpret=cls.INTERPRET, **kwargs)
 
   def skip_if_mosaic_gpu(self):
-    if jtu.test_device_matches(["rocm"]) and use_mosaic_gpu:
-      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if jtu.test_device_matches(["gpu"]) and use_mosaic_gpu:
+      if jtu.test_device_matches(["rocm"]):
+        self.skipTest("Mosaic GPU is not supported on ROCm.")
       self.skipTest("TODO: Mosaic GPU does not support this yet")
 
 
@@ -2776,7 +2776,7 @@ class OpsTest(PallasBaseTest):
     if jtu.test_device_matches(["gpu"]):
       if not use_mosaic_gpu:
         self.skipTest("Delay is only implemented on the MGPU backend for GPUs.")
-      elif jtu.is_device_rocm():
+      elif jtu.test_device_matches(["rocm"]):
         self.skipTest("Mosaic GPU is not supported on ROCm.")
     if self.INTERPRET:
       self.skipTest("Not implemented in interpret mode.")

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -19,6 +19,7 @@ import math
 import re
 import subprocess
 import sys
+import unittest
 from typing import Any
 
 from absl.testing import absltest
@@ -307,6 +308,10 @@ class PallasBaseTest(ptu.PallasTest):
 
   @classmethod
   def pallas_call(cls, *args, **kwargs):
+    # Node-level skip: only triggers if a test actually tries to use pallas_call
+    # while Mosaic backend is selected on ROCm.
+    if jtu.test_device_matches(["rocm"]) and use_mosaic_gpu:
+      raise unittest.SkipTest("Mosaic GPU is not supported on ROCm.")
     if jtu.test_device_matches(["cuda"]) and use_mosaic_gpu:
       assert plgpu_mgpu is not None
       compiler_params = plgpu_mgpu.CompilerParams(
@@ -317,6 +322,8 @@ class PallasBaseTest(ptu.PallasTest):
     return pl.pallas_call(*args, interpret=cls.INTERPRET, **kwargs)
 
   def skip_if_mosaic_gpu(self):
+    if jtu.test_device_matches(["rocm"]) and use_mosaic_gpu:
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if jtu.test_device_matches(["gpu"]) and use_mosaic_gpu:
       self.skipTest("TODO: Mosaic GPU does not support this yet")
 
@@ -918,6 +925,8 @@ class OpsTest(PallasBaseTest):
       out[:] = jnp.stack(result, axis=axis).reshape(num_arrays, 128)
 
     def run(interpret=False):
+      if jtu.test_device_matches(["rocm"]) and use_mosaic_gpu:
+        raise unittest.SkipTest("Mosaic GPU is not supported on ROCm.")
       return pl.pallas_call(
           kernel,
           out_shape=jax.ShapeDtypeStruct((num_arrays, 128), jnp.float32),
@@ -2748,6 +2757,8 @@ class OpsTest(PallasBaseTest):
       )
       output_ref[...] = output
 
+    if jtu.test_device_matches(["rocm"]) and use_mosaic_gpu:
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     deq_call = pl.pallas_call(
         kernel,
         out_shape=jax.ShapeDtypeStruct(data.shape, dtype),
@@ -2763,9 +2774,10 @@ class OpsTest(PallasBaseTest):
 
   def test_delay(self):
     if jtu.test_device_matches(["gpu"]):
-      # ROCm always uses Triton (Mosaic GPU doesn't support ROCm).
-      if jtu.is_device_rocm() or not use_mosaic_gpu:
+      if not use_mosaic_gpu:
         self.skipTest("Delay is only implemented on the MGPU backend for GPUs.")
+      elif jtu.is_device_rocm():
+        self.skipTest("Mosaic GPU is not supported on ROCm.")
     if self.INTERPRET:
       self.skipTest("Not implemented in interpret mode.")
     # This is mostly to test that the kernel compiles. It's difficult to

--- a/tests/pallas/pallas_shape_poly_test.py
+++ b/tests/pallas/pallas_shape_poly_test.py
@@ -552,6 +552,8 @@ class ExportTestWithTriton(jtu.JaxTestCase):
 class ExportTestWithMosaicGpu(ExportTestWithTriton):
 
   def setUp(self):
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     # TODO(b/432678342): remove once this is fixed.
     if jtu.is_device_cuda() and not jtu.is_cuda_compute_capability_at_least(
         "9.0"

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -108,6 +108,8 @@ class PallasCallTest(ptu.PallasTest):
   def test_pallas_call_infers_backend_from_compiler_params(self):
     if not jtu.test_device_matches(["gpu"]):
       self.skipTest("Only works on GPU.")
+    if jtu.test_device_matches(["rocm"]):
+      self.skipTest("Mosaic GPU is not supported on ROCm.")
     if not jtu.is_cuda_compute_capability_at_least("9.0"):
       self.skipTest("Only works on a GPU with capability >= sm90")
 


### PR DESCRIPTION
# Description
This PR adds skips to mosaic tests for ROCm. The goal is to skip minimum amount of test nodes (only the ones that use Mosaic GPU). 

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->