### PR TITLE
[pyrefly] add coverage for jax2tf, excluding tests

### DIFF
--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -188,7 +188,7 @@ def call_tf(
       checked_res_tf_flat = [
           check_tf_result(i, r_tf, r_aval)
           for i, (r_tf, r_aval) in enumerate(
-              zip(res_tf_flat,
+              zip(res_tf_flat,  # pyrefly: ignore[bad-argument-type]
                   (output_avals
                    if output_avals is not None
                    else (None,) * len(res_tf_flat))))]
@@ -422,7 +422,7 @@ def _call_tf_abstract_eval(
     **__,
 ):
   # Called only when we form a Jaxpr, i.e., under jit, scan, etc.
-  effects = set()
+  effects: set[effects.Effect] = set()
   if ordered:
     effects.add(call_tf_ordered_effect)
   elif has_side_effects:
@@ -603,7 +603,7 @@ def _call_tf_lowering(
                                dst_symtab=ctx.module_context.symbol_table)
   call = func_dialect.CallOp(callee_result_types,
                              ir.FlatSymbolRefAttr.get(fn),
-                             tuple(args_op) + captured_ops)
+                             [*args_op, *captured_ops])
   flat_results = call.results
 
   if ordered:

--- a/jax/experimental/jax2tf/examples/mnist_lib.py
+++ b/jax/experimental/jax2tf/examples/mnist_lib.py
@@ -310,11 +310,11 @@ def plot_images(ds,
   fig = plt.figure(figsize=(8., 4.), num=title)
   # Get the first batch
   (images, labels), = list(tfds.as_numpy(ds.take(1)))
-  if inference_fn:
-    inferred_labels = inference_fn(images)
+  inferred_labels = inference_fn(images) if inference_fn else None
   for i, image in enumerate(images[:count]):
     digit = fig.add_subplot(nr_rows, nr_cols, i + 1)
     if inference_fn:
+      assert inferred_labels is not None
       digit_title = f"infer: {np.argmax(inferred_labels[i])}\n"
     else:
       digit_title = ""

--- a/jax/experimental/jax2tf/examples/saved_model_main.py
+++ b/jax/experimental/jax2tf/examples/saved_model_main.py
@@ -202,6 +202,8 @@ def tf_accelerator_and_tolerances():
     tolerances = dict(atol=1e-6, rtol=1e-4)
   elif tf_accelerator.device_type == "CPU":
     tolerances = dict(atol=1e-5, rtol=1e-5)
+  else:
+    raise RuntimeError(f"Unrecognized {tf_accelerator.device_type=}")
   logging.info("Using tolerances %s", tolerances)
   return tf_accelerator, tolerances
 

--- a/jax/experimental/jax2tf/examples/serving/model_server_request.py
+++ b/jax/experimental/jax2tf/examples/serving/model_server_request.py
@@ -111,7 +111,7 @@ def main(_):
   images_and_labels = tfds.as_numpy(test_ds.take(
       _COUNT_IMAGES.value // _SERVING_BATCH_SIZE.value))
 
-  accurate_count = 0
+  accurate_count = np.array(0)
   for batch_idx, (images, labels) in enumerate(images_and_labels):
     predictions_one_hot = serving_call_mnist(images)
     predictions_digit = np.argmax(predictions_one_hot, axis=1)

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -237,7 +237,7 @@ def convert(fun_jax: Callable,
           "native_serialization_platforms must be a sequence "
           "containing a subset of {'cpu', 'cuda', 'rocm', 'tpu'}. "
           f"Got: {native_serialization_platforms}")
-    native_serialization_platforms = tuple(native_serialization_platforms)
+    native_serialization_platforms = tuple(native_serialization_platforms)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2607
 
   api.check_callable(fun_jax)
 
@@ -528,6 +528,7 @@ def _make_custom_gradient_fn_tf(fun_jax,
       fun_vjp_jax, vjp_in_avals = impl.get_vjp_fun()
 
       vjp_polymorphic_shapes = tuple(
+        # pyrefly: ignore[missing-attribute]
         str(a.shape)  # Note: may be _DimExpr, not just DimVar
         for a in vjp_in_avals)
       in_cts_flat = convert(
@@ -595,7 +596,7 @@ def _run_exported_as_tf(args_flat_tf: Sequence[TfVal],
       "You should upgrade TensorFlow, e.g., to tf_nightly."
     )
 
-  call_module_attrs = dict(
+  call_module_attrs: dict[str, Any] = dict(
       version=version,
       Tout=out_types,
       Sout=out_shapes_tf,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ project-includes = [
 project-excludes = [
     "jax/_src/internal_test_util/export_back_compat_test_data/*.py",
     "jax/example_libraries/**/*.py",
+    "jax/experimental/jax2tf/tests/**/*.py",
     # TODO(slebedev): Opt in jax/experimental and remove these excludes.
-    "jax/experimental/jax2tf/**/*.py",
     "jax/experimental/mosaic/**/*.py",
     "jax/experimental/slab/**/*.py",
 ]


### PR DESCRIPTION
Skipped tests because we've never had type checker coverage for test files (currently `jax2tf/tests` reports 487 failures with pyrefly).