### PR TITLE
[ROCm] Fix and simplify jax rocm plugin init script

### DIFF
--- a/jax/_src/hardware_utils.py
+++ b/jax/_src/hardware_utils.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import enum
+import logging
 import os
 import pathlib
 import glob
+import re
 
 _GOOGLE_PCI_VENDOR_ID = '0x1ae0'
 
@@ -83,3 +85,97 @@ def transparent_hugepages_enabled() -> bool:
   # information about transparent huge pages.
   path = pathlib.Path('/sys/kernel/mm/transparent_hugepage/enabled')
   return path.exists() and path.read_text().strip() == '[always] madvise never'
+
+
+logger = logging.getLogger(__name__)
+
+
+def num_available_amd_gpus(stop_at: int | None = None) -> int:
+  """Count AMD GPUs available via KFD kernel driver.
+
+  This function checks for the presence of AMD GPUs by examining KFD kernel
+  driver entities as a proxy. In WSL setups, if /dev/dxg exists, this check
+  hardcodes the result to 1 GPU for initialization gating. This approach
+  provides a good compromise between performance, reliability and simplicity.
+  Presence of such entities doesn't guarantee that the GPUs are usable
+  through HIP and PJRT, however, we can't do much better without spawning an
+  additional process with a potentially complicated setup to run actual HIP
+  code. And we don't want to initialize HIP right now inside the current
+  process, because doing so might spoil a proper initialization of the
+  rocprofiler-sdk later during PJRT startup.
+
+  Args:
+    stop_at: If provided, stop counting once this many GPUs are found.
+             This allows early exit when only checking for thresholds.
+
+  Returns:
+    The number of AMD GPUs detected (up to stop_at if provided).
+  """
+  try:
+    if os.path.exists("/dev/dxg"):
+      return 1
+
+    kfd_nodes_path = "/sys/class/kfd/kfd/topology/nodes/"
+    if not os.path.exists(kfd_nodes_path):
+      return 0
+
+    gpu_count = 0
+    # the RE matches strings like "simd_count ##" and extracts the number ##
+    r_simd_count = re.compile(r"\bsimd_count\s+(\d+)\b", re.MULTILINE)
+    # we're using a non-zero simd_count as a trait of a GPU following the
+    # KFD implementation
+    # https://github.com/torvalds/linux/blob/ea1013c1539270e372fc99854bc6e4d94eaeff66/drivers/gpu/drm/amd/amdkfd/kfd_topology.c#L941
+
+    for node in os.listdir(kfd_nodes_path):
+      node_props_path = os.path.join(kfd_nodes_path, node, "properties")
+
+      if not os.path.exists(node_props_path):
+        continue
+
+      try:
+        file_size = os.path.getsize(node_props_path)
+        # 16KB is more than a reasonable limit
+        if file_size <= 0 or file_size > 16 * 1024:
+          continue
+
+        with open(node_props_path, "r", encoding="ascii") as f:
+          match = r_simd_count.search(f.read())
+          if match:
+            simd_count = int(match.group(1))
+            if simd_count > 0:
+              gpu_count += 1
+              if stop_at is not None and gpu_count >= stop_at:
+                return gpu_count
+      except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.debug(
+          "Failed to read KFD node file '%s': %s", node_props_path, e
+        )
+        continue
+
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    logger.warning("Failed to count AMD GPUs: %s", e)
+    return -1
+  return gpu_count
+
+
+def get_shm_size_in_mb():
+  """Get /dev/shm size in MB.
+
+  Returns:
+    Size in MB if /dev/shm exists, None if it doesn't exist, 0 on error.
+  """
+  try:
+    shm_path = "/dev/shm"
+    if not os.path.exists(shm_path):
+      return 0
+
+    stat = os.statvfs(shm_path)
+    # Total size in bytes
+    shm_size_bytes = stat.f_blocks * stat.f_frsize
+    shm_size_mb = shm_size_bytes / (1024 * 1024)
+
+    return shm_size_mb
+
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    logger.debug("Failed to check /dev/shm size: %s", e)
+    return 0

--- a/jax_plugins/rocm/__init__.py
+++ b/jax_plugins/rocm/__init__.py
@@ -15,11 +15,14 @@
 import functools
 import importlib
 import logging
-import os
 import pathlib
 
+from jax._src import hardware_utils
 from jax._src.lib import xla_client
 import jax._src.xla_bridge as xb
+
+_MIN_SHM_SIZE_MB = 64
+logger = logging.getLogger(__name__)
 
 # rocm_plugin_extension locates inside jaxlib. `jaxlib` is for testing without
 # preinstalled jax rocm plugin packages.
@@ -33,44 +36,16 @@ for pkg_name in ['jax_rocm7_plugin', 'jax_rocm60_plugin', 'jaxlib.rocm']:
   else:
     break
 
-logger = logging.getLogger(__name__)
-
 
 def _get_library_path():
   base_path = pathlib.Path(__file__).resolve().parent
-  installed_path = (
-      base_path / 'xla_rocm_plugin.so'
-  )
-  if installed_path.exists():
-    return installed_path
-
-  local_path = (
-      base_path / 'pjrt_c_api_gpu_plugin.so'
-  )
-  if not local_path.exists():
-    runfiles_dir = os.getenv('RUNFILES_DIR', None)
-    if runfiles_dir:
-      local_path = pathlib.Path(
-          os.path.join(runfiles_dir, '__main__/jax_plugins/rocm/pjrt_c_api_gpu_plugin.so')
-      )
-
-  if local_path.exists():
-    logger.debug(
-        'Native library %s does not exist. This most likely indicates an issue'
-        ' with how %s was built or installed. Fallback to local test'
-        ' library %s',
-        installed_path,
-        __package__,
-        local_path,
-    )
-    return local_path
-
+  library_path = base_path / 'xla_rocm_plugin.so'
+  if library_path.exists():
+    return library_path
   logger.debug(
-      'WARNING: Native library %s and local test library path %s do not'
-      ' exist. This most likely indicates an issue with how %s was built or'
-      ' installed or missing src files.',
-      installed_path,
-      local_path,
+      'Native library %s does not exist. This most likely indicates an issue'
+      ' with how %s was built or installed.',
+      library_path,
       __package__,
   )
   return None
@@ -80,6 +55,22 @@ def initialize():
   path = _get_library_path()
   if path is None:
     return
+
+  # Count GPUs (stop at 2 since that's all we need to know)
+  gpu_count = hardware_utils.num_available_amd_gpus(stop_at=2)
+  if gpu_count <= 0:
+    raise ValueError("No AMD GPUs were found, skipping ROCm plugin initialization")
+  elif gpu_count > 1:
+    shm_size_mb = hardware_utils.get_shm_size_in_mb()
+    if shm_size_mb <= _MIN_SHM_SIZE_MB:
+      logger.warning(
+          "Detected multiple GPUs but /dev/shm size is only %.1f MB. "
+          "RCCL may exhaust shared memory during multi-GPU operations, "
+          "causing runtime failures. Consider increasing /dev/shm size. "
+          "For example in Docker, use: --shm-size=64g",
+          shm_size_mb,
+      )
+
   options = xla_client.generate_pjrt_gpu_plugin_options()
   options["platform_name"] = "ROCM"
   c_api = xb.register_plugin(

--- a/jaxlib/jax.bzl
+++ b/jaxlib/jax.bzl
@@ -231,11 +231,10 @@ def _cpu_test_deps():
 def _gpu_test_deps():
     """Returns the additional dependencies needed for a GPU test."""
     return select({
-        "//jax:config_build_jaxlib_true": [
+        "//jax:config_build_jaxlib_true": if_cuda_is_configured([
             "//jaxlib/cuda:gpu_only_test_deps",
-            "//jaxlib/rocm:gpu_only_test_deps",
             "//jax_plugins:gpu_plugin_only_test_deps",
-        ],
+        ]) + if_rocm_is_configured(EXTERNAL_DEPS),
         "//jax:config_build_jaxlib_false": if_cuda_is_configured([
             "//jaxlib/tools:pypi_jax_cuda_plugin_with_cuda_deps",
             "//jaxlib/tools:pypi_jax_cuda_pjrt_with_cuda_deps",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_python//python:defs.bzl", "py_test")
 load(
     "//jaxlib:jax.bzl",
     "jax_generate_backend_suites",
@@ -2342,4 +2343,15 @@ jax_py_test(
         "absl/testing",
         "hypothesis",
     ]),
+)
+
+jax_py_test(
+    name = "hardware_utils_test",
+    srcs = ["hardware_utils_test.py"],
+    deps = [
+        "//jax",
+        "//jax/_src:test_util",
+    ] + py_deps([
+        "absl/testing",
+    ])
 )

--- a/tests/hardware_utils_test.py
+++ b/tests/hardware_utils_test.py
@@ -1,0 +1,86 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for jax._src.hardware_utils.
+
+These tests verify the hardware utility functions for GPU detection
+and shared memory checking.
+"""
+
+from unittest.mock import Mock, patch
+from absl.testing import absltest
+from jax._src import config
+from jax._src import test_util as jtu
+
+from jax._src.hardware_utils import (
+  num_available_amd_gpus as count_amd_gpus_impl,
+)
+from jax._src.hardware_utils import get_shm_size_in_mb as get_shm_size_impl
+
+config.parse_flags_with_absl()
+
+
+class TestCountAmdGpus(absltest.TestCase):
+  """Test GPU counting logic exists and has correct signature."""
+
+  def test_count_amd_gpus_callable(self):
+    """count_amd_gpus should be callable."""
+    self.assertTrue(callable(count_amd_gpus_impl))
+
+  def test_count_amd_gpus_with_stop_at(self):
+    """count_amd_gpus should accept stop_at parameter."""
+    # Just verify it can be called with stop_at - don't check the result
+    # since that would require real GPUs or complex mocking
+    count = count_amd_gpus_impl(stop_at=1)
+    self.assertIsInstance(count, int)
+    self.assertGreaterEqual(count, 0)
+
+  def test_count_amd_gpus_returns_int(self):
+    """count_amd_gpus should return an integer."""
+    count = count_amd_gpus_impl()
+    self.assertIsInstance(count, int)
+    self.assertGreaterEqual(count, 0)
+
+
+class TestGetShmSize(absltest.TestCase):
+  """Test shared memory size checking."""
+
+  def test_dev_shm_exists(self):
+    """Should return shm size in MB when /dev/shm exists."""
+    with patch("os.path.exists", return_value=True):
+      with patch("os.statvfs") as mock_statvfs:
+        mock_stat = Mock()
+        mock_stat.f_blocks = 128 * 1024
+        mock_stat.f_frsize = 1024
+        mock_statvfs.return_value = mock_stat
+
+        size_mb = get_shm_size_impl()
+        self.assertEqual(size_mb, 128.0)
+
+  def test_dev_shm_not_exists(self):
+    """Should return 0 when /dev/shm doesn't exist."""
+    with patch("os.path.exists", return_value=False):
+      size = get_shm_size_impl()
+      self.assertEqual(size, 0)
+
+  def test_statvfs_exception(self):
+    """Should return 0 on statvfs exception."""
+    with patch("os.path.exists", return_value=True):
+      with patch("os.statvfs", side_effect=OSError("Error")):
+        size = get_shm_size_impl()
+        self.assertEqual(size, 0)
+
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This pr will add a necessary system requirements handling into the init script of jax rocm plugins
Init script will check the number of the available gpus, and will quite if there is no gpu available.
It will also create useful logs for rocm plugin initialization.