### PR TITLE
Fix float64 type degradation in reciprocal primitive lowering

### DIFF
--- a/jax/_src/pallas/primitives.py
+++ b/jax/_src/pallas/primitives.py
@@ -579,7 +579,7 @@ def _reciprocal_lowering_rule(
 
   def _reciprocal(x, *, approx=False):
     if approx:
-      return jnp.reciprocal(x.astype(jnp.bfloat16)).astype(jnp.float32)
+      return jnp.reciprocal(x.astype(jnp.bfloat16)).astype(x.dtype)
     return jnp.reciprocal(x)
 
   return mlir.lower_fun(_reciprocal, multiple_results=False)(

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -2849,12 +2849,12 @@ class PallasPrimitivesTest(PallasBaseTest):
         wrap_init(body, 1), [state.shaped_array_ref((4, 3, 2), jnp.int32)])
     self.assertIn(expected, jaxpr.pretty_print(use_color=False))
 
-  @parameterized.product(approx=[False, True], full_range=[False, True])
-  def test_reciprocal(self, approx, full_range):
+  @parameterized.product(approx=[False, True], full_range=[False, True], dtype=[jnp.float32, jnp.float16])
+  def test_reciprocal(self, approx, full_range, dtype):
     if not jtu.test_device_matches(["tpu"]):
       self.skipTest("Not implemented on non-TPU devices")
     shape = (32, 256)
-    x = jnp.arange(np.prod(shape), dtype=jnp.float32).reshape(shape)
+    x = jnp.arange(np.prod(shape), dtype=dtype).reshape(shape)
     if not full_range:
       x = jnp.where(x == 0, -1.0, x)
 
@@ -2864,7 +2864,7 @@ class PallasPrimitivesTest(PallasBaseTest):
       )
 
     out = self.pallas_call(
-        kernel, out_shape=jax.ShapeDtypeStruct(shape, jnp.float32)
+        kernel, out_shape=jax.ShapeDtypeStruct(shape, dtype)
     )(x)
     kwargs = {}
     if approx:


### PR DESCRIPTION
Fixed a precision degradation bug in the Pallas `reciprocal` primitive where `float64` inputs were being naively downcast to `float32` during MLIR lowering when `approx=True`. Added test coverage.