### PR TITLE
Pass accuracy param through erf and atan2 primitives

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -719,7 +719,8 @@ def cos(x: ArrayLike, accuracy=None) -> Array:
   return cos_p.bind(x, accuracy=accuracy)
 
 @export
-def atan2(x: ArrayLike, y: ArrayLike) -> Array:
+def atan2(x: ArrayLike, y: ArrayLike, *,
+          accuracy: Tolerance | AccuracyMode | None = None) -> Array:
   r"""Elementwise two-term arc tangent: :math:`\mathrm{atan}({x \over y})`.
 
   This function lowers directly to the `stablehlo.atan2`_ operation.
@@ -728,6 +729,12 @@ def atan2(x: ArrayLike, y: ArrayLike) -> Array:
     x, y: input arrays. Must have a matching floating-point or complex dtypes. If
       neither is a scalar, the two arrays must have the same number of dimensions
       and be broadcast-compatible.
+    accuracy: Optional `lax.Tolerance` or `lax.AccuracyMode` object that
+      selects the implementation of the op based on the requested accuracy. If
+      the implementation cannot satisfy the requested tolerance, the
+      compiler will return an error. If mode is specified and there are no
+      multiple implementations available, the default implementation will be
+      used.
 
   Returns:
     Array of the same shape and dtype as ``x`` and ``y`` containing the element-wise
@@ -741,7 +748,7 @@ def atan2(x: ArrayLike, y: ArrayLike) -> Array:
   .. _stablehlo.atan2: https://openxla.org/stablehlo/spec#atan2
   """
   x, y = core.standard_insert_pvary(x, y)
-  return atan2_p.bind(x, y)
+  return atan2_p.bind(x, y, accuracy=accuracy)
 
 @export
 def real(x: ArrayLike) -> Array:
@@ -3968,14 +3975,14 @@ def naryop_dtype_rule(result_dtype, accepted_dtypes, name, *avals,
   return result_dtype(*avals, **kwargs)
 
 
-def broadcasting_shape_rule(name, *avals):
+def broadcasting_shape_rule(name, *avals, **kwargs):
   shapes = [aval.shape for aval in avals if aval.shape]
   if not shapes:
     return ()
   return _try_broadcast_shapes(*shapes, name=name)
 
 
-def broadcasting_sharding_rule(name, *avals):
+def broadcasting_sharding_rule(name, *avals, **kwargs):
   mesh = None
   for a in avals:
     if a.sharding is not None and not a.sharding.mesh.empty:
@@ -4339,9 +4346,10 @@ mlir.register_lowering(atan_p, partial(_nary_lower_hlo, chlo.atan))
 
 atan2_p = standard_naryop([_float | _complex, _float | _complex], 'atan2')
 ad.defjvp(atan2_p,
-          lambda g, x, y: mul(g, div(y, add(square(x), square(y)))),
-          lambda g, x, y: mul(g, div(neg(x), add(square(x), square(y)))))
+          lambda g, x, y, **kwargs: mul(g, div(y, add(square(x), square(y)))),
+          lambda g, x, y, **kwargs: mul(g, div(neg(x), add(square(x), square(y)))))
 mlir.register_lowering(atan2_p, partial(_nary_lower_hlo, hlo.atan2))
+core.pp_eqn_rules[atan2_p] = _unary_with_accuracy_pp_rule
 
 sinh_p = standard_unop(_float | _complex, 'sinh')
 ad.defjvp(sinh_p, lambda g, x: mul(g, cosh(x)))

--- a/jax/_src/lax/special.py
+++ b/jax/_src/lax/special.py
@@ -22,14 +22,16 @@ import numpy as np
 from functools import partial, reduce as _reduce
 
 from jax._src import core
-from jax._src.lax.lax import (add, bitwise_and, bitwise_not, bitwise_or,
+from jax._src.lax.lax import (AccuracyMode, Tolerance,
+                              add, bitwise_and, bitwise_not, bitwise_or,
                               broadcast_in_dim, broadcast_shapes,
                               convert_element_type, div, eq, exp, full_like, ge,
                               gt, le, log, log1p, lt, mul, ne, neg, reciprocal,
                               reduce, select, sign, sqrt, square,
                               standard_naryop, standard_unop, sub,
                               _const, _dtype,
-                              _float, _nary_lower_hlo, _ones, _isnan)
+                              _float, _nary_lower_hlo, _ones, _isnan,
+                              _unary_with_accuracy_pp_rule)
 from jax._src.lax.control_flow.loops import while_loop
 
 from jax._src import dtypes
@@ -113,9 +115,23 @@ def bessel_i1e(x: ArrayLike) -> Array:
   """
   return bessel_i1e_p.bind(x)
 
-def erf(x: ArrayLike) -> Array:
-  r"""Elementwise error function: :math:`\mathrm{erf}(x)`."""
-  return erf_p.bind(x)
+def erf(x: ArrayLike, *, accuracy: Tolerance | AccuracyMode | None = None) -> Array:
+  r"""Elementwise error function: :math:`\mathrm{erf}(x)`.
+
+  Args:
+    x: input array. Must have floating-point type.
+    accuracy: Optional `lax.Tolerance` or `lax.AccuracyMode` object that
+      selects the implementation of the op based on the requested accuracy. If
+      the implementation cannot satisfy the requested tolerance, the
+      compiler will return an error. If mode is specified and there are no
+      multiple implementations available, the default implementation will be
+      used.
+
+  Returns:
+    Array of the same shape and dtype as ``x`` containing the element-wise
+    error function.
+  """
+  return erf_p.bind(x, accuracy=accuracy)
 
 def erfc(x: ArrayLike) -> Array:
   r"""Elementwise complementary error function:
@@ -719,9 +735,10 @@ def _bessel_i1e_jvp(g, y, x):
 ad.defjvp2(bessel_i1e_p, _bessel_i1e_jvp)
 
 erf_p = standard_unop(_float, 'erf')
-ad.defjvp(erf_p, lambda g, x: mul(_const(x, 2. / np.sqrt(np.pi)),
-                                  mul(g, exp(neg(square(x))))))
+ad.defjvp(erf_p, lambda g, x, **kwargs: mul(_const(x, 2. / np.sqrt(np.pi)),
+                                            mul(g, exp(neg(square(x))))))
 mlir.register_lowering(erf_p, partial(_nary_lower_hlo, chlo.erf))
+core.pp_eqn_rules[erf_p] = _unary_with_accuracy_pp_rule
 
 erfc_p = standard_unop(_float, 'erfc')
 ad.defjvp(erfc_p, lambda g, x: mul(_const(x, -2. / np.sqrt(np.pi)),

--- a/jax/_src/pallas/mosaic_gpu/lowering.py
+++ b/jax/_src/pallas/mosaic_gpu/lowering.py
@@ -2737,25 +2737,33 @@ def _sign_lowering_rule(ctx: LoweringRuleContext, x):
 
 
 @register_lowering_rule(lax.erf_p, mgpu.LoweringSemantics.Lane)
-def _erf_lowering_rule(ctx: LoweringRuleContext, x):
+def _erf_lowering_rule(ctx: LoweringRuleContext, x, accuracy):
+  if accuracy is not None:
+    raise NotImplementedError("Not implemented: accuracy")
   [x_aval] = ctx.avals_in
   return _ensure_fa(x, x_aval.dtype).erf()
 
 
 @register_lowering_rule(lax.erf_p, mgpu.LoweringSemantics.Warpgroup)
-def _erf_lowering_rule_wg(ctx: LoweringRuleContext, x):
+def _erf_lowering_rule_wg(ctx: LoweringRuleContext, x, accuracy):
+  if accuracy is not None:
+    raise NotImplementedError("Not implemented: accuracy")
   [x_aval] = ctx.avals_in
   return math_dialect.erf(_ensure_ir_value(x, x_aval.dtype))
 
 
 @register_lowering_rule(lax.atan2_p, mgpu.LoweringSemantics.Lane)
-def _atan2_lowering_rule(ctx: LoweringRuleContext, y, x):
+def _atan2_lowering_rule(ctx: LoweringRuleContext, y, x, accuracy):
+  if accuracy is not None:
+    raise NotImplementedError("Not implemented: accuracy")
   y, x = _bcast(y, x, *ctx.avals_in, *ctx.avals_out)
   return y.atan2(x)
 
 
 @register_lowering_rule(lax.atan2_p, mgpu.LoweringSemantics.Warpgroup)
-def _atan2_lowering_rule_wg(ctx: LoweringRuleContext, y, x):
+def _atan2_lowering_rule_wg(ctx: LoweringRuleContext, y, x, accuracy):
+  if accuracy is not None:
+    raise NotImplementedError("Not implemented: accuracy")
   y, x = _bcast_wg(y, x, *ctx.avals_in, *ctx.avals_out)
   return math_dialect.atan2(y, x)
 


### PR DESCRIPTION
erf_p.bind() and atan2_p.bind() do not pass the accuracy parameter,
but their Pallas Mosaic lowering rules require it. This causes a
TypeError when using jax.lax.erf in a Pallas TPU kernel.

Match the pattern used by exp and other math primitives (see lax.py
exp_p.bind(x, accuracy=accuracy)).

Authored with assistance from Claude
