### PR TITLE
[ROCm] Use rocm plugin and pjrt wheels for pytest job in continuous wheel build pipeline

### DIFF
--- a/.github/actions/download-jax-rocm-wheels/action.yml
+++ b/.github/actions/download-jax-rocm-wheels/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: "GCS location prefix from where the artifacts should be downloaded"
     default: 'gs://general-ml-ci-transient/jax-github-actions/jax/${{ github.workflow }}/${{ github.run_number }}/${{ github.run_attempt }}'
     type: string
+  skip-download-rocm-plugins:
+    description: "Whether to skip downloading ROCm plugins from GitHub releases (when already downloaded as artifacts)"
+    default: false
+    type: boolean
 permissions: {}
 runs:
   using: "composite"
@@ -86,25 +90,30 @@ runs:
           if [[ ${INPUTS_JAXLIB_VERSION} == "head" ]]; then
             gcloud storage cp -r "${INPUTS_GCS_DOWNLOAD_URI}/jaxlib*${PYTHON_MAJOR_MINOR}*${OS}*${ARCH}*.whl" $(pwd)/dist/
 
-            # Get the latest release tag (including pre-releases) from ROCm/jax-plugin
-            echo "Finding latest ROCm plugin release (including pre-releases)..."
-            LATEST_PLUGIN_TAG=$(gh release list -R ROCm/jax-plugin --limit 10 --json tagName,publishedAt \
-                                --jq 'sort_by(.publishedAt) | reverse | .[0].tagName')
-            echo "Latest plugin release: $LATEST_PLUGIN_TAG"
+            # Skip downloading ROCm plugins if they're already available (e.g., from GitHub artifacts)
+            if [[ "${INPUTS_SKIP_DOWNLOAD_ROCM_PLUGINS}" == "true" ]]; then
+              echo "Skipping ROCm plugin download - using pre-downloaded artifacts."
+            else
+              # Get the latest release tag (including pre-releases) from ROCm/jax-plugin
+              echo "Finding latest ROCm plugin release (including pre-releases)..."
+              LATEST_PLUGIN_TAG=$(gh release list -R ROCm/jax-plugin --limit 10 --json tagName,publishedAt \
+                                  --jq 'sort_by(.publishedAt) | reverse | .[0].tagName')
+              echo "Latest plugin release: $LATEST_PLUGIN_TAG"
 
-            # Download ROCm PJRT plugin from latest release
-            echo "Downloading ROCm PJRT plugin from release $LATEST_PLUGIN_TAG..."
-            gh release download "$LATEST_PLUGIN_TAG" \
-              --repo ROCm/jax-plugin \
-              --pattern "jax_rocm${JAXCI_ROCM_VERSION}_pjrt-*-py3-none-manylinux*.whl" \
-              --dir $(pwd)/dist/
+              # Download ROCm PJRT plugin from latest release
+              echo "Downloading ROCm PJRT plugin from release $LATEST_PLUGIN_TAG..."
+              gh release download "$LATEST_PLUGIN_TAG" \
+                --repo ROCm/jax-plugin \
+                --pattern "jax_rocm${JAXCI_ROCM_VERSION}_pjrt-*-py3-none-manylinux*.whl" \
+                --dir $(pwd)/dist/
 
-            # Download ROCm plugin from latest release
-            echo "Downloading ROCm plugin from release $LATEST_PLUGIN_TAG..."
-            gh release download "$LATEST_PLUGIN_TAG" \
-              --repo ROCm/jax-plugin \
-              --pattern "jax_rocm${JAXCI_ROCM_VERSION}_plugin-*-${PYTHON_MAJOR_MINOR}*manylinux*.whl" \
-              --dir $(pwd)/dist/
+              # Download ROCm plugin from latest release
+              echo "Downloading ROCm plugin from release $LATEST_PLUGIN_TAG..."
+              gh release download "$LATEST_PLUGIN_TAG" \
+                --repo ROCm/jax-plugin \
+                --pattern "jax_rocm${JAXCI_ROCM_VERSION}_plugin-*-${PYTHON_MAJOR_MINOR}*manylinux*.whl" \
+                --dir $(pwd)/dist/
+            fi
           elif [[ ${INPUTS_JAXLIB_VERSION} == "pypi_latest" ]]; then
             PYTHON=python${INPUTS_PYTHON}
             $PYTHON -m pip download jaxlib jax-rocm${JAXCI_ROCM_VERSION}-pjrt jax-rocm${JAXCI_ROCM_VERSION}-plugin --dest $(pwd)/dist/
@@ -119,6 +128,7 @@ runs:
         INPUTS_SKIP_DOWNLOAD_JAXLIB_AND_PLUGINS_FROM_GCS: ${{ inputs.skip-download-jaxlib-and-plugins-from-gcs }}
         INPUTS_JAXLIB_VERSION: ${{ inputs.jaxlib-version }}
         INPUTS_PYTHON: ${{ inputs.python }}
+        INPUTS_SKIP_DOWNLOAD_ROCM_PLUGINS: ${{ inputs.skip-download-rocm-plugins }}
     - name: Skip the test run if the wheel artifacts were not downloaded successfully
       shell: bash
       if: steps.download-wheel-artifacts.outcome == 'failure'

--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Create dist dir
         run: mkdir -p $JAXCI_OUTPUT_DIR/
       - name: Build ${{ inputs.artifact }}
+        id: build-wheels
         timeout-minutes: 120
         run: |
           bazel --bazelrc=build/rocm/rocm.bazelrc run \
@@ -164,3 +165,10 @@ jobs:
         run: echo "s3_upload_uri=${INPUTS_S3_UPLOAD_URI}" >> "$GITHUB_OUTPUT"
         env:
           INPUTS_S3_UPLOAD_URI: ${{ inputs.s3_upload_uri }}
+      - name: Upload wheels as GitHub Actions artifact
+        if: always() && steps.build-wheels.outcome == 'success'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: rocm-wheels-${{ inputs.artifact }}-py${{ inputs.python }}-rocm${{ inputs.rocm-version }}
+          path: ${{ env.JAXCI_OUTPUT_DIR }}/*.whl
+          retention-days: 1

--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -59,6 +59,10 @@ on:
         description: "GCS location prefix from where the artifacts should be downloaded"
         type: string
         default: 'gs://jax-nightly-artifacts/latest'
+      download-rocm-from-github-artifacts:
+        description: "Whether to download ROCm wheels from GitHub Actions artifacts instead of releases"
+        default: false
+        type: boolean
       halt-for-connection:
         description: 'Should this workflow run wait for a remote connection?'
         type: string
@@ -93,6 +97,10 @@ on:
         description: "GCS location prefix from where the artifacts should be downloaded"
         default: 'gs://jax-nightly-artifacts/latest'
         type: string
+      download-rocm-from-github-artifacts:
+        description: "Whether to download ROCm wheels from GitHub Actions artifacts instead of releases"
+        default: false
+        type: boolean
 permissions:
   id-token: write
   contents: read
@@ -128,6 +136,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Download ROCm wheels from GitHub Actions artifacts
+        if: ${{ inputs.download-rocm-from-github-artifacts }}
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v7.0.0
+        with:
+          pattern: rocm-wheels-*
+          path: dist/
+          merge-multiple: true
       - name: Download JAX ROCm wheels
         uses: ./.github/actions/download-jax-rocm-wheels
         with:
@@ -136,6 +151,7 @@ jobs:
           jaxlib-version: ${{ inputs.jaxlib-version }}
           skip-download-jaxlib-and-plugins-from-gcs: ${{ inputs.skip-download-jaxlib-and-plugins-from-gcs }}
           gcs_download_uri: ${{ inputs.gcs_download_uri }}
+          skip-download-rocm-plugins: ${{ inputs.download-rocm-from-github-artifacts }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Python dependencies

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -337,6 +337,7 @@ jobs:
       rocm-tag: ${{ matrix.rocm.tag }}
       jaxlib-version: "head"
       gcs_download_uri: ${{ needs.build-jaxlib-artifact.outputs.gcs_upload_uri }}
+      download-rocm-from-github-artifacts: true
 
   run-bazel-test-rocm:
     if: ${{ !cancelled() }}


### PR DESCRIPTION
This PR modifies the continuous wheel test pipeline for rocm.
Instead of downloading the released plugin wheels we use those built in a pas step 
when executing the py test command