### PR TITLE
[jax2tf] Use the exported NamedShardings

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -640,7 +640,13 @@ def _run_exported_as_tf(args_flat_tf: Sequence[TfVal],
   # See b/255511660.
   kept_in_shardings = []
   for i in exported.module_kept_var_idx:
-    kept_in_shardings.append(exported.in_shardings_hlo[i])
+    if exported._has_named_shardings:
+      in_sharding_hlo = _export.named_to_hlo_sharding(
+        exported._in_named_shardings[i],
+        exported.in_avals[i])
+    else:
+      in_sharding_hlo = exported.in_shardings_hlo[i]
+    kept_in_shardings.append(in_sharding_hlo)
   args_flat_tf = tuple(
     map(partial(_shard_value,
                 skip_replicated_sharding=tf.executing_eagerly()),
@@ -655,9 +661,15 @@ def _run_exported_as_tf(args_flat_tf: Sequence[TfVal],
           concrete_fn._inference_function
       )
 
+  if exported._has_named_shardings:
+    out_shardings_hlo = tuple(
+      _export.named_to_hlo_sharding(s, a)
+      for s, a in zip(exported._out_named_shardings, exported.out_avals))
+  else:
+    out_shardings_hlo = exported.out_shardings_hlo
   res = list(map(partial(_shard_value,
                          skip_replicated_sharding=tf.executing_eagerly()),
-                 res, exported.out_shardings_hlo))
+                 res, out_shardings_hlo))
   res = tuple(map(_convert_value, res, exported.out_avals))
   return res
 


### PR DESCRIPTION
On 1/15/2026 we have added the fields _in_named_shardings and _out_named_shardings to the Exported. Since TF cannot handle NamedShardings, we must convert them to HloShardings. We do that conversion instead of relying on the old in_hlo_shardings and out_hlo_shardings. Once we land this, we will be able to remove those old field.

