### PR TITLE
Updated Pyrefly to 0.56

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
   - id: ruff
 
 - repo: https://github.com/facebook/pyrefly-pre-commit
-  rev: 30778c6e83a71508a62b7297f8b22660ce4496fc  # frozen: v0.55.0
+  rev: 17b22cbf6722a3b9593b8874d9d67ca89f363b0e  # frozen: v0.56.0
   hooks:
     - id: pyrefly-check
       name: Pyrefly (type checking)

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -650,7 +650,7 @@ def remat_partial_eval(trace: pe.JaxprTrace, *tracers: core.Tracer,
                        for x in jaxpr_unknown.outvars]
   if isinstance(prevent_cse, tuple):
     _, prevent_cse_ = partition_list(in_used_staged, prevent_cse)
-    prevent_cse = (True,) * len(res_tracers) + tuple(prevent_cse_)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+    prevent_cse = (True,) * len(res_tracers) + tuple(prevent_cse_)
   new_params = dict(params, jaxpr=jaxpr_unknown, differentiated=True,
                     prevent_cse=prevent_cse)
   recipe = pe.new_eqn_recipe(trace, in_jaxpr_tracers, out_jaxpr_tracers, remat_p,
@@ -891,7 +891,7 @@ def _remat_lowering(
     barrier_op = hlo.OptimizationBarrierOp(
         mlir.flatten_ir_values(barrier_args))
     barrier_results = mlir.unflatten_ir_values_like_types(
-        barrier_op.results, map(mlir.aval_to_ir_type, barrier_avals))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+        barrier_op.results, map(mlir.aval_to_ir_type, barrier_avals))
     args = merge_lists(prevent_cse, other_args, barrier_results)
   outs, tokens_out = mlir.jaxpr_subcomp(
       ctx.module_context, jaxpr, ctx.name_stack.extend('checkpoint'),

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -987,7 +987,7 @@ def _unravel_array_into_pytree(pytree, axis, example, arr, specs):
   leaves, treedef = tree_flatten(pytree)
   specs, _ = tree_flatten(specs)
   shapes = [arr.shape[:axis] + np.shape(l) + arr.shape[axis+1:] for l in leaves]
-  parts = _split(arr, np.cumsum(map(np.size, leaves[:-1])), axis)  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+  parts = _split(arr, np.cumsum(map(np.size, leaves[:-1])), axis)
   reshaped_parts = [
       _possible_downcast(np.reshape(x, shape),
                          leaf if example is None else example,
@@ -2443,9 +2443,9 @@ def linear_transpose(fun: Callable, *primals, reduce_axes=()) -> Callable:
   jaxpr, _ = pe.dce_jaxpr(jaxpr, [True] * len(jaxpr.outvars), True)
   out_avals, _ = unzip2(out_pvals)
   out_dtypes = map(lambda a: a.dtype, out_avals)
-  if not (all(dtypes.issubdtype(d, np.inexact) for d in in_dtypes + out_dtypes)  # pyrefly: ignore[unsupported-operation]  # pyrefly#2385
+  if not (all(dtypes.issubdtype(d, np.inexact) for d in in_dtypes + out_dtypes)
           or all(dtypes.issubdtype(d, np.integer)
-                 for d in in_dtypes + out_dtypes)):  # pyrefly: ignore[unsupported-operation]  # pyrefly#2385
+                 for d in in_dtypes + out_dtypes)):
     raise TypeError("linear_transpose only supports [float or complex] -> "
                     "[float or complex], and integer -> integer functions, "
                     f"but got {in_dtypes} -> {out_dtypes}.")

--- a/jax/_src/buffer_callback.py
+++ b/jax/_src/buffer_callback.py
@@ -136,7 +136,7 @@ def buffer_callback(
     flat_args, in_tree = tree_util.tree_flatten((args, kwargs))
 
     in_avals = [core.typeof(x) for x in flat_args]
-    static_input_output_aliases: tuple[tuple[int, int], ...] = ()
+    static_input_output_aliases: list[tuple[int, int]] = []
     if input_output_aliases is not None:
       for i_idx, o_idx in sorted(input_output_aliases.items()):
         i_idx, o_idx = int(i_idx), int(o_idx)
@@ -157,7 +157,7 @@ def buffer_callback(
               f"input_output_aliases contains the mapping '{i_idx}:{o_idx}' "
               f"referring to an input with abstract value {in_aval} and an "
               f"output with a different abstract value {out_aval}.")
-        static_input_output_aliases += ((i_idx, o_idx),)
+        static_input_output_aliases.append((i_idx, o_idx))
 
     out_flat = buffer_callback_p.bind(
         *flat_args,
@@ -167,7 +167,7 @@ def buffer_callback(
         out_tree=out_tree,
         vmap_method=vmap_method,
         has_side_effect=has_side_effect,
-        input_output_aliases=static_input_output_aliases,
+        input_output_aliases=tuple(static_input_output_aliases),
         command_buffer_compatible=command_buffer_compatible,
     )
     return tree_util.tree_unflatten(out_tree, out_flat)

--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -432,7 +432,7 @@ def checkify_jaxpr_flat(jaxpr: core.Jaxpr, consts: Sequence[core.Value],
       write_env(eqn.outvars[0], outvals)
     core.clean_up_dead_vars(eqn, env, last_used)
 
-  return error, map(read_env, jaxpr.outvars)  # pyrefly: ignore[bad-return]  # pyrefly#2385
+  return error, map(read_env, jaxpr.outvars)
 
 def checkify_jaxpr_flat_hashable(jaxpr, hashable_consts, enabled_errors,
                                  err_tree, *args):
@@ -807,7 +807,7 @@ def scan_error_check(error, enabled_errors, *in_flat, reverse, length, jaxpr,
   # Query body effects to create a merged error containing all effects (such
   # that in and out carried error are of the same type).
   err_vals, err_tree = jtu.tree_flatten(error)
-  new_in_aval = map(core.typeof, [*err_vals, *consts, *carry]) + xs_mapped  # pyrefly: ignore[unsupported-operation]  # pyrefly#2385
+  new_in_aval = map(core.typeof, [*err_vals, *consts, *carry]) + xs_mapped
   _, _, effects = jaxpr_to_checkify_jaxpr(jaxpr, enabled_errors,
                                           err_tree, *new_in_aval)
 
@@ -815,7 +815,7 @@ def scan_error_check(error, enabled_errors, *in_flat, reverse, length, jaxpr,
   err_vals, err_tree = jtu.tree_flatten(merged_error)
 
   # Create checked-jaxpr, with the needed pre-processing on the inputs.
-  new_in_aval = map(core.typeof, [*err_vals, *consts, *carry]) + xs_mapped  # pyrefly: ignore[unsupported-operation]  # pyrefly#2385
+  new_in_aval = map(core.typeof, [*err_vals, *consts, *carry]) + xs_mapped
   checked_jaxpr_, out_tree, _ = jaxpr_to_checkify_jaxpr(jaxpr, enabled_errors,
                                                         err_tree, *new_in_aval)
 

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Sequence
 import contextlib
 import enum
 import functools
@@ -22,7 +22,7 @@ import itertools
 import logging
 import os
 import sys
-from typing import Any, Generic, NoReturn, Optional, Protocol, Type, TypeVar, cast
+from typing import Any, Generic, Generator, NoReturn, Optional, Protocol, Type, TypeVar, cast
 import warnings
 
 from jax._src import deprecations
@@ -1889,7 +1889,7 @@ jax_xla_profile_version = int_state(
 )
 
 @contextlib.contextmanager
-def explicit_device_put_scope() -> Iterator[None]:
+def explicit_device_put_scope() -> Generator[None, None, None]:
   """Indicates that the current context is an explicit device_put*() call."""
   state = guard_lib.thread_local_state()
   prev = state.explicit_device_put
@@ -1900,7 +1900,7 @@ def explicit_device_put_scope() -> Iterator[None]:
     state.explicit_device_put = prev
 
 @contextlib.contextmanager
-def explicit_device_get_scope() -> Iterator[None]:
+def explicit_device_get_scope() -> Generator[None, None, None]:
   """Indicates that the current context is an explicit device_get() call."""
   state = guard_lib.thread_local_state()
   prev = state.explicit_device_get
@@ -1994,7 +1994,7 @@ _transfer_guard = optional_enum_state(
     update_global_hook=_update_all_transfer_guard_global)
 
 @contextlib.contextmanager
-def transfer_guard(new_val: str) -> Iterator[None]:
+def transfer_guard(new_val: str) -> Generator[None, None, None]:
   """A contextmanager to control the transfer guard level for all transfers.
 
   For more information, see

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -744,7 +744,7 @@ def eval_jaxpr(jaxpr: Jaxpr, consts, *args, propagate_source_info=True) -> list[
     else:
       write(eqn.outvars[0], ans)
     clean_up_dead_vars(eqn, env, lu)
-  return map(read, jaxpr.outvars)  # pyrefly: ignore[bad-return]  # pyrefly#2385
+  return map(read, jaxpr.outvars)
 
 def check_avals_context_mesh(avals, prim_name):
   cur_mesh = mesh_lib.get_abstract_mesh()
@@ -3048,7 +3048,7 @@ class ClosedCallPrimitive(CallPrimitive):
     jaxpr: ClosedJaxpr = new_params.pop('call_jaxpr')
     subfun = lu.wrap_init(partial(eval_jaxpr, jaxpr.jaxpr, jaxpr.consts),
                           debug_info=jaxpr.jaxpr.debug_info)
-    new_params['subfuns'] = (subfun,)  # pyrefly: ignore[unsupported-operation]
+    new_params['subfuns'] = (subfun,)
     return new_params
 
 closed_call_p: ClosedCallPrimitive = ClosedCallPrimitive('closed_call')
@@ -3974,7 +3974,7 @@ def pp_jaxprs(jaxprs: Sequence[ClosedJaxpr | Jaxpr],
   jaxprs = [j.jaxpr if isinstance(j, ClosedJaxpr) else j for j in jaxprs]
   return pp.group(pp.concat([pp.nest(2, pp.concat([
       pp.text('('), pp.brk(""),
-      pp.join(pp.brk(), map(lambda x: pp_jaxpr(x, context, settings), jaxprs))]  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      pp.join(pp.brk(), map(lambda x: pp_jaxpr(x, context, settings), jaxprs))]
     )), pp.brk(""), pp.text(')')])
   )
 

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -398,12 +398,12 @@ class CustomJVPCallPrimitive(core.Primitive):
   def get_bind_params(self, params):
     new_params = dict(params)
     call_jaxpr: core.ClosedJaxpr = new_params.pop('call_jaxpr')
-    num_consts: int = new_params.pop('num_consts')  # pyrefly: ignore[bad-assignment]  # pyrefly#2449
+    num_consts: int = new_params.pop('num_consts')
     jvp_jaxpr_fun = new_params.pop('jvp_jaxpr_fun')
     fun = lu.wrap_init(core.jaxpr_as_fun(call_jaxpr),
                        debug_info=call_jaxpr.jaxpr.debug_info)
-    jvp = lift_jvp(num_consts, jvp_jaxpr_fun)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2449
-    new_params['subfuns'] = (fun, jvp)  # pyrefly: ignore[unsupported-operation]
+    jvp = lift_jvp(num_consts, jvp_jaxpr_fun)
+    new_params['subfuns'] = (fun, jvp)
     return new_params
 
 def lift_jvp(num_consts: int, jvp_jaxpr_fun: lu.WrappedFun) -> lu.WrappedFun:
@@ -947,7 +947,7 @@ def _flatten_bwd(f: Callable,
            "number of arguments to the primal function, but got bwd output "
            "structure {} for primal input structure {}.")
     raise TypeError(msg.format(in_tree2, in_tree)) from None
-  results = []
+  results: list[Any] = []
   for kp, a, ct in zip(keypaths, in_avals, cts_in_flat):
     if ct is zero or getattr(a.to_tangent_aval(), 'dtype') == dtypes.float0:
       results.append(Zero(a.to_tangent_aval()))
@@ -1006,14 +1006,14 @@ class CustomVJPCallPrimitive(core.Primitive):
   def get_bind_params(self, params):
     new_params = dict(params)
     call_jaxpr: core.ClosedJaxpr = new_params.pop('call_jaxpr')
-    num_consts: int = new_params.pop('num_consts')  # pyrefly: ignore[bad-assignment]  # pyrefly#2449
+    num_consts: int = new_params.pop('num_consts')
     fwd_jaxpr_thunk = new_params.pop('fwd_jaxpr_thunk')
     fun = lu.wrap_init(core.jaxpr_as_fun(call_jaxpr),
                        debug_info=call_jaxpr.jaxpr.debug_info)
-    fwd = lift_fwd(num_consts, fwd_jaxpr_thunk)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2449
+    fwd = lift_fwd(num_consts, fwd_jaxpr_thunk)
     const_avals, _ = split_list(call_jaxpr.in_avals, [num_consts])
     bwd = _handle_consts_in_bwd(new_params.pop('bwd'), const_avals)
-    new_params['subfuns'] = (fun, fwd, bwd)  # pyrefly: ignore[unsupported-operation]
+    new_params['subfuns'] = (fun, fwd, bwd)
     return new_params
 
 def lift_fwd(num_consts: int, fwd_jaxpr_thunk: lu.WrappedFun) -> lu.WrappedFun:
@@ -1772,12 +1772,12 @@ def _remat_opt_jvp(
   tangents = map(ad.instantiate_zeros, tangents)
   consts_nz = [not isinstance(t, Zero) for t in consts_dot]
   consts_dot = [c for nz, c in zip(consts_nz, consts_dot) if nz]
-  in_nz = consts_nz + [True] * len(tangents)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+  in_nz = consts_nz + [True] * len(tangents)
   fwd_jaxpr_jvp_, out_nz = ad.jvp_jaxpr(fwd_jaxpr, in_nz, True)
   num_out = len(out_nz) - num_res
   fwd_jaxpr_jvp_ = ad.rearrange_binders(
       fwd_jaxpr_jvp_, [num_consts, len(primals)],
-      [len(consts_dot), len(tangents)], [num_res, num_out], [num_res, num_out])  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      [len(consts_dot), len(tangents)], [num_res, num_out], [num_res, num_out])
   fwd_jaxpr_jvp = pe.close_jaxpr(pe.convert_constvars_jaxpr(fwd_jaxpr_jvp_.jaxpr))
 
   # @pe._memoize

--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -663,7 +663,7 @@ def _inspect_sharding_lowering_rule(ctx: mlir.LoweringRuleContext, value, *,
   def _hlo_sharding_callback(hlo_sharding: xc.HloSharding):
     if mesh.empty:
       return callback(
-          sharding_impls.GSPMDSharding(devices, hlo_sharding))  # pyrefly: ignore[bad-argument-type]
+          sharding_impls.GSPMDSharding(devices, hlo_sharding))
     pspec = (P() if hlo_sharding.is_manual() else
              parse_flatten_op_sharding(hlo_sharding, mesh)[0])
     return callback(NamedSharding(mesh, pspec))

--- a/jax/_src/ffi.py
+++ b/jax/_src/ffi.py
@@ -531,7 +531,7 @@ def ffi_call(
       static_output_layouts = _convert_layouts_for_ffi_call(result_avals,
                                                             output_layouts_)
 
-    static_input_output_aliases: tuple[tuple[int, int], ...] = ()
+    static_input_output_aliases: list[tuple[int, int]] = []
     if input_output_aliases is not None:
       for i_idx, o_idx in sorted(input_output_aliases.items()):
         i_idx, o_idx = int(i_idx), int(o_idx)
@@ -558,7 +558,7 @@ def ffi_call(
               f"referring to an input with layout {static_input_layouts[i_idx]} "
               "and an output with a different layout "
               f"{static_output_layouts[o_idx]}.")
-        static_input_output_aliases += ((i_idx, o_idx),)
+        static_input_output_aliases.append((i_idx, o_idx))
     args = core.standard_insert_pvary(*args)
     results = ffi_call_p.bind(
         *args,
@@ -568,7 +568,7 @@ def ffi_call(
         has_side_effect=has_side_effect,
         input_layouts=static_input_layouts,
         output_layouts=static_output_layouts,
-        input_output_aliases=static_input_output_aliases,
+        input_output_aliases=tuple(static_input_output_aliases),
         custom_call_api_version=custom_call_api_version,
         legacy_backend_config=legacy_backend_config,
         attributes=_wrap_kwargs_hashable(kwargs),

--- a/jax/_src/internal_test_util/export_back_compat_test_data/gpu_eigh_solver_syev.py
+++ b/jax/_src/internal_test_util/export_back_compat_test_data/gpu_eigh_solver_syev.py
@@ -268,7 +268,7 @@ module @jit__lambda attributes {jax.uses_shape_polymorphism = false, mhlo.num_pa
 
 
 # c64 data
-data_2026_02_16["c64"] = dict(  # pyrefly: ignore[unsupported-operation]  # pyrefly#2449
+data_2026_02_16["c64"] = dict(
   testdata_version=1,
   platform="rocm",
   custom_call_targets=["hipsolver_syevd_ffi"],

--- a/jax/_src/internal_test_util/test_harnesses.py
+++ b/jax/_src/internal_test_util/test_harnesses.py
@@ -2375,7 +2375,7 @@ def _make_select_and_scatter_add_harness(name,
       padding=padding)
 
 
-for dtype in set(jtu.dtypes.all) - {np.complex64, np.complex128}:  # pyrefly: ignore[unsupported-operation]
+for dtype in set(jtu.dtypes.all) - {np.complex64, np.complex128}:
   _make_select_and_scatter_add_harness("dtypes", dtype=dtype)
 
 # Validate different reduction primitives
@@ -2399,7 +2399,7 @@ _make_select_and_scatter_add_harness(
 _make_select_and_scatter_add_harness("window_strides", window_strides=(1, 2, 3))
 
 # Validate dtypes on TPU
-for dtype in set(jtu.dtypes.all) - {  # pyrefly: ignore[unsupported-operation]
+for dtype in set(jtu.dtypes.all) - {
     np.bool_, np.complex64, np.complex128, np.int8, np.uint8}:
   for window_strides, window_dimensions, nb_inactive_dims in [((1, 2, 1),
                                                                (1, 3, 1), 2)]:

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -218,7 +218,7 @@ def _linearize_jaxpr(
   primals_and_residuals = map(partial(primal_trace.to_jaxpr_tracer, source_info=source_info),
                               primals_and_residuals)
   primal_jaxpr, primal_consts = primal_trace.to_jaxpr(
-      primals_and_residuals, dbg.with_unknown_names(),  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      primals_and_residuals, dbg.with_unknown_names(),
       source_info)
   primal_trace.invalidate()
   primal_jaxpr, primal_consts = _dce_consts(primal_jaxpr, primal_consts)
@@ -262,7 +262,7 @@ def direct_linearize(traceable, primals, *, has_aux, is_vjp):
   out_nz_tangents = [t for t, nz in zip(out_tangents, out_nzs) if nz]
   out_nz_tangents = map(partial(tangent_trace.to_jaxpr_tracer,
                                 source_info=source_info), out_nz_tangents)
-  jaxpr, consts = tangent_trace.to_jaxpr(out_nz_tangents, dbg, source_info)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+  jaxpr, consts = tangent_trace.to_jaxpr(out_nz_tangents, dbg, source_info)
   tangent_trace.invalidate()
   config.enable_checks.value and core.check_jaxpr(jaxpr)
   jaxpr, used_consts, _ = pe.dce_jaxpr_consts(
@@ -1440,7 +1440,7 @@ def _custom_lin_transpose(cts_out, *invals, num_res,
     cts_out = map(instantiate_zeros, cts_out)
   cts_in = bwd.call_wrapped(*res, *cts_out)
   cts_in = map(replace_rule_output_symbolic_zeros, cts_in)
-  nz_cts_in, _ = partition_list(in_zeros, cts_in)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+  nz_cts_in, _ = partition_list(in_zeros, cts_in)
   return [None] * num_res + nz_cts_in
 primitive_transposes[custom_lin_p] = _custom_lin_transpose
 

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -106,8 +106,8 @@ def shape_tensor(sizes: Sequence[int | ir.RankedTensorType]) -> IrValues:
   ds = map(lower_dim, sizes)
   if not ds:
     return ir_constant(np.array([], np.int32))
-  elif len(ds) == 1:  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
-    return ds[0]  # pyrefly: ignore[bad-index]  # pyrefly#2385
+  elif len(ds) == 1:
+    return ds[0]
   else:
     return hlo.concatenate(ds, i64_attr(0))
 
@@ -1322,8 +1322,8 @@ def lower_jaxpr_to_module(
         xla_donated_args=xla_donated_args,
         arg_names=arg_names,
         result_names=result_names,
-        arg_memory_kinds=arg_memory_kinds,  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
-        result_memory_kinds=result_memory_kinds,  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+        arg_memory_kinds=arg_memory_kinds,
+        result_memory_kinds=result_memory_kinds,
         arg_layouts=in_layouts,
         result_layouts=out_layouts,
         propagated_out_mem_kinds=propagated_out_mem_kinds)
@@ -1383,8 +1383,8 @@ def _set_up_aliases(input_output_aliases, avals_in, avals_out,
   if (arg_memory_kinds is None or result_memory_kinds is None or
       any(a is None for a in arg_memory_kinds) or
       any(r is None for r in result_memory_kinds)):
-    arg_memory_kinds = [None] * len(avals_in)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
-    result_memory_kinds = [None] * len(avals_out)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+    arg_memory_kinds = [None] * len(avals_in)
+    result_memory_kinds = [None] * len(avals_out)
 
   donations = collections.defaultdict(collections.deque)
   for i, (aval, am, donated, aliased) in enumerate(
@@ -1429,7 +1429,7 @@ def _set_up_aliases(input_output_aliases, avals_in, avals_out,
       else:
         # Fallback to xla donation if layouts don't match.
         if xla_donated_args is None:
-          xla_donated_args = [False] * len(avals_in)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+          xla_donated_args = [False] * len(avals_in)
         xla_donated_args[input_id] = True
 
   aliased_output_ids = {i for i in input_output_aliases if i is not None}
@@ -1449,10 +1449,10 @@ def _set_up_aliases(input_output_aliases, avals_in, avals_out,
     # If the argument is not a token and hasn't been aliased or donated to XLA,
     # then try to find an output array with matching size.
     if (out_donated_args[input_idx]
-        and avals_in[input_idx] is not core.abstract_token):  # pyrefly: ignore[bad-index]  # pyrefly#2385
+        and avals_in[input_idx] is not core.abstract_token):
       key = (
           # pyrefly: ignore[missing-attribute]
-          avals_in[input_idx].size,  # pyrefly: ignore[bad-index]  # pyrefly#2385
+          avals_in[input_idx].size,
           arg_memory_kinds[input_idx],
       )
       if results_not_matched.get(key, ()):
@@ -1460,7 +1460,7 @@ def _set_up_aliases(input_output_aliases, avals_in, avals_out,
         results_not_matched[key].popleft()
         out_donated_args[input_idx] = False
         if xla_donated_args is None:
-          xla_donated_args = [False] * len(avals_in)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+          xla_donated_args = [False] * len(avals_in)
         xla_donated_args[input_idx] = True
 
   return input_output_aliases, out_donated_args, xla_donated_args
@@ -1755,7 +1755,7 @@ def lower_jaxpr_to_fun(
 
     if input_output_aliases is not None:
       output_ids = util.unflatten(
-        list(range(len(flat_output_types))), map(len_ir_types, output_types))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+        list(range(len(flat_output_types))), map(len_ir_types, output_types))
       aliases: list[int | None] = []
       for itypes, alias in zip(input_types, input_output_aliases):
         if alias is None:
@@ -1804,7 +1804,7 @@ def lower_jaxpr_to_fun(
         attrs['jax.result_info'] = ir.StringAttr.get(name_)
 
   if use_sharding_annotations and ir_result_shardings is not None:
-    for attrs, sharding, uv in zip(result_attrs, ir_result_shardings,  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+    for attrs, sharding, uv in zip(result_attrs, ir_result_shardings,  # pyrefly: ignore[no-matching-overload]
                                    unconstrained_variants):
       if sharding is not None and not uv.contains_unconstrained:
         if config.use_shardy_partitioner.value:
@@ -2159,7 +2159,7 @@ def _cached_lowering(
     avals_out = map(lambda v: v.aval, eqn.outvars)
     cache_entry = _emit_lowering_rule_as_fun(
         partial(_uncached_lowering, eqn.primitive, eqn.ctx, eqn.effects),
-        ctx, eqn.ctx, eqn.primitive, ordered_effects, avals_in, avals_out,  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+        ctx, eqn.ctx, eqn.primitive, ordered_effects, avals_in, avals_out,
         **params,
     )
     ctx.lowering_cache[cache_key] = cache_entry
@@ -2479,7 +2479,7 @@ def lower_per_platform(ctx: LoweringRuleContext,
   results = case_op.results
   if ordered_effects:
     tokens, results = util.split_list(
-      unflatten_ir_values_like_types(results, output_types),  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      unflatten_ir_values_like_types(results, output_types),
       [len(ordered_effects)])
     tokens_out = ctx.tokens_in.update_tokens(TokenSet(zip(ordered_effects,
                                                           tokens)))
@@ -2581,7 +2581,7 @@ def lower_called_computation(
   check_backend_matches(backend, ctx.platforms)
   effects = list(tokens_in.effects())
   output_types = map(aval_to_ir_type, out_avals)
-  output_types = [token_type()] * len(effects) + output_types  # pyrefly: ignore[unsupported-operation]  # pyrefly#2385
+  output_types = [token_type()] * len(effects) + output_types
   func_op = _lower_jaxpr_to_fun_cached(
       ctx, fn_name, call_jaxpr, num_const_args, effects, in_avals=in_avals,
       arg_names=arg_names, result_names=result_names)

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -257,7 +257,7 @@ class JaxprTrace(Trace['JaxprTracer']):
     env_tracers = map(self.to_jaxpr_tracer, env)
     unknown_arg_tracers = [t for t in tracers if not t.is_known()]
     # Adjust parameters (e.g. donated_invars) for the staged-out call's args.
-    num_new_args = len(res_tracers) + len(env_tracers)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+    num_new_args = len(res_tracers) + len(env_tracers)
     new_jaxpr = convert_constvars_jaxpr(jaxpr)
     if isinstance(primitive, core.ClosedCallPrimitive):
       new_jaxpr = close_jaxpr(new_jaxpr)
@@ -326,7 +326,7 @@ class JaxprTrace(Trace['JaxprTracer']):
     env_tracers = map(self.to_jaxpr_tracer, env)
     unknown_arg_tracers = [t for t in tracers if not t.is_known()]
     # Adjust params for staged-out call on unknown values.
-    num_new_args = len(const_tracers) + len(env_tracers)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+    num_new_args = len(const_tracers) + len(env_tracers)
     staged_params = update_params(params, map(op.not_, in_knowns), num_new_args)
     staged_params = dict(staged_params, in_axes=staged_in_axes,
                          out_axes=tuple(staged_out_axes), call_jaxpr=call_jaxpr)
@@ -361,7 +361,7 @@ class JaxprTrace(Trace['JaxprTracer']):
 
   def process_custom_transpose(self, prim, call, tracers, /, **params):
     tracers = map(self.to_jaxpr_tracer, tracers)
-    res_ts, lin_ts = split_list(tracers, [params['res_tree'].num_leaves])  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+    res_ts, lin_ts = split_list(tracers, [params['res_tree'].num_leaves])
     assert all(t.is_known()     for t in res_ts)
     lin_all_known   = all(t.is_known()     for t in lin_ts)
     if lin_all_known:
@@ -373,7 +373,7 @@ class JaxprTrace(Trace['JaxprTracer']):
                      for aval in params['out_types']]
       in_tracers = map(self.instantiate_const, tracers)
       new_params = dict(params, subfuns=(call,))
-      eqn = new_eqn_recipe(self, in_tracers, out_tracers, prim, new_params,  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      eqn = new_eqn_recipe(self, in_tracers, out_tracers, prim, new_params,
           core.no_effects, source_info_util.current())
       for t in out_tracers: t.recipe = eqn
       return out_tracers
@@ -387,7 +387,7 @@ class JaxprTrace(Trace['JaxprTracer']):
                          symbolic_zeros=symbolic_zeros)
 
     tracers = map(self.instantiate_const, tracers)
-    in_knowns = (False,) * len(tracers)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+    in_knowns = (False,) * len(tracers)
     in_avals = tuple(t.aval for t in tracers)
     f_ = trace_to_subjaxpr_nounits2(f, self.tag, f.debug_info, True)
     f_, aux = partial_eval_wrapper_nounits(f_, in_knowns, in_avals)
@@ -707,7 +707,7 @@ def new_eqn_recipe(trace: JaxprTrace,
       config.threefry_partitionable.value,
       xla_metadata_lib.current_xla_metadata(),
   )
-  return JaxprEqnRecipe(next(trace.counter), tuple(in_tracers), map(ref, out_tracers),  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+  return JaxprEqnRecipe(next(trace.counter), tuple(in_tracers), map(ref, out_tracers),
                         out_avals, primitive, params, effects, source_info,
                         ctx)
 
@@ -1066,7 +1066,7 @@ def _partial_eval_jaxpr_custom_cached(
       foreach(write, unks_out, inst_out, eqn.outvars)
     elif any(unks_in):
       inputs = map(ensure_instantiated, inst_in, eqn.invars)
-      staged_eqns.append(eqn.replace(invars=inputs))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      staged_eqns.append(eqn.replace(invars=inputs))
       foreach(partial(write, True, True), eqn.outvars)
     else:
       known_eqns.append(eqn)
@@ -1110,7 +1110,7 @@ def _partial_eval_jaxpr_custom_cached(
       else:
         assert isinstance(policy, RecomputeType)
         inputs = map(ensure_instantiated, inst_in, eqn.invars)
-        staged_eqns.append(eqn.replace(invars=inputs))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+        staged_eqns.append(eqn.replace(invars=inputs))
         foreach(partial(write, False, True), eqn.outvars)
   unzipped = unzip2(map(read, jaxpr.outvars))
   out_unknowns, out_inst = list(unzipped[0]), list(unzipped[1])
@@ -1122,7 +1122,7 @@ def _partial_eval_jaxpr_custom_cached(
   out_inst     = map(op.or_, out_inst,     ensure_out_inst)
 
   ins_known, _ = partition_list(in_unknowns, jaxpr.invars)
-  outs_known, _ = partition_list(out_unknowns, jaxpr.outvars)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+  outs_known, _ = partition_list(out_unknowns, jaxpr.outvars)
   ref_res_is_input = [r in ins_known for r in residual_refs]
   non_input_res_refs, _ = partition_list(ref_res_is_input, list(residual_refs))
   ins_known_and_ref_res = [*ins_known, *non_input_res_refs]
@@ -1138,7 +1138,7 @@ def _partial_eval_jaxpr_custom_cached(
   config.enable_checks.value and core.check_jaxpr(jaxpr_known)
 
   _, ins_staged = partition_list(in_inst, jaxpr.invars)
-  _, outs_staged = partition_list(out_inst, jaxpr.outvars)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+  _, outs_staged = partition_list(out_inst, jaxpr.outvars)
   staged_invars = [*residuals, *non_input_res_refs, *ins_staged]
   staged_effects = make_jaxpr_effects(jaxpr.constvars, staged_invars,
                                       outs_staged, staged_eqns)
@@ -1149,7 +1149,7 @@ def _partial_eval_jaxpr_custom_cached(
       debug_info=jaxpr.debug_info.with_unknown_names())
   config.enable_checks.value and core.check_jaxpr(jaxpr_staged)
 
-  return (jaxpr_known, jaxpr_staged, out_unknowns, out_inst, len(residuals),  # pyrefly: ignore[bad-return]  # pyrefly#2385
+  return (jaxpr_known, jaxpr_staged, out_unknowns, out_inst, len(residuals),
           len(non_input_res_refs))
 
 
@@ -1226,7 +1226,7 @@ def call_partial_eval_custom_rule(
   params_known = {**eqn.params, jaxpr_param_name: jaxpr_known}
   params_staged = {**eqn.params, jaxpr_param_name: jaxpr_staged}
   params_known, params_staged = params_updater(
-      unks_in, inst_in, map(op.not_, unks_out), inst_out, num_res, params_known,  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      unks_in, inst_in, map(op.not_, unks_out), inst_out, num_res, params_known,
       params_staged)
   residuals = [Var(res_aval(params_known, var.aval))
                for var in jaxpr_staged.invars[:num_res]]
@@ -1275,7 +1275,7 @@ def closed_call_partial_eval_custom_rule(
   params_known = {**eqn.params, jaxpr_param_name: jaxpr_known}
   params_staged = {**eqn.params, jaxpr_param_name: jaxpr_staged}
   params_known, params_staged = params_updater(
-      unks_in, inst_in, map(op.not_, unks_out), inst_out,  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      unks_in, inst_in, map(op.not_, unks_out), inst_out,
       sum(fin is fout is None for fin, fout in zip(in_fwd, out_fwd)),
       num_res, params_known, params_staged)
   res_val_binders, res_ref_binders = split_list(
@@ -1470,7 +1470,7 @@ def _dce_jaxpr(jaxpr: Jaxpr, used_outputs: tuple[bool, ...],
   for eqn in jaxpr.eqns[::-1]:
     used_outs = map(read, eqn.outvars)
     rule = dce_rules.get(eqn.primitive, _default_dce_rule)
-    used_ins, new_eqn = rule(used_outs, eqn)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+    used_ins, new_eqn = rule(used_outs, eqn)
     if new_eqn is not None:
       new_eqns.append(new_eqn)
     foreach(write, eqn.invars, used_ins)
@@ -1484,13 +1484,13 @@ def _dce_jaxpr(jaxpr: Jaxpr, used_outputs: tuple[bool, ...],
 
   dbg = core.DebugInfo(
       jaxpr.debug_info.traced_for, jaxpr.debug_info.func_src_info,
-      jaxpr.debug_info.filter_arg_names(used_inputs),  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      jaxpr.debug_info.filter_arg_names(used_inputs),
       jaxpr.debug_info.filter_result_paths(used_outputs))
   new_jaxpr = jaxpr.replace(invars=invars, outvars=outvars, eqns=eqns,
                             effects=jaxpr_effects, debug_info=dbg)
   config.enable_checks.value and core.check_jaxpr(new_jaxpr)
 
-  return new_jaxpr, used_inputs  # pyrefly: ignore[bad-return]  # pyrefly#2385
+  return new_jaxpr, used_inputs
 
 DCERule = Callable[[list[bool], JaxprEqn],
                    tuple[list[bool], Union[JaxprEqn, None]]]
@@ -1598,7 +1598,7 @@ def _move_to_front(lst: Sequence, to_move: Sequence[bool]) -> Sequence:
 def move_binders_to_back(closed_jaxpr: ClosedJaxpr, to_move: Sequence[bool]
                          ) -> ClosedJaxpr:
   """Reorder `invars` by moving those indicated in `to_move` to the back."""
-  return move_binders_to_front(closed_jaxpr, map(op.not_, to_move))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+  return move_binders_to_front(closed_jaxpr, map(op.not_, to_move))
 
 
 class DynamicJaxprTracer(core.Tracer):
@@ -2125,7 +2125,7 @@ class DynamicJaxprTrace(core.Trace):
     new_params = dict(params, call_jaxpr=new_jaxpr)
     update_params = call_param_updaters.get(call_primitive)
     if update_params:
-      new_params = update_params(new_params, [True] * len(in_tracers),  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      new_params = update_params(new_params, [True] * len(in_tracers),
                                  len(consts))
     const_tracers = map(to_jaxpr_tracer, consts)
     return self.emit_eqn(
@@ -2160,7 +2160,7 @@ class DynamicJaxprTrace(core.Trace):
       del new_params['out_axes_thunk']
       update_params = call_param_updaters.get(map_primitive)
       if update_params:
-        new_params = update_params(new_params, [True] * len(tracers), len(consts))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+        new_params = update_params(new_params, [True] * len(tracers), len(consts))
       effs = core.filter_named_axis_effects(jaxpr.effects, {axis_name})
       out_tracers = self.emit_eqn(
           [*const_tracers, *tracers], out_avals, map_primitive, new_params, effs, source_info=source_info)
@@ -2255,7 +2255,7 @@ class DynamicJaxprTrace(core.Trace):
     source_info = source_info_util.current()
     to_jaxpr_tracer = partial(self.to_jaxpr_tracer, source_info=source_info)
     tracers = map(to_jaxpr_tracer, tracers)
-    tracers_res, tracers_lin = split_list(tracers, [res_tree.num_leaves])  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+    tracers_res, tracers_lin = split_list(tracers, [res_tree.num_leaves])
 
     in_avals_p = [t.aval for t in tracers]
     in_avals_t = [*[t.aval for t in tracers_res], *out_types]
@@ -2318,7 +2318,7 @@ def _memoize(fn):
 def _jvp_jaxpr_zeros(f, store, in_zeros, zero_avals, *primal_tangent_avals):
   in_primals, nz_in_tangents = split_list(primal_tangent_avals, [len(in_zeros)])
   symbolic_zeros = map(ad_util.SymbolicZero, zero_avals)
-  tangents = merge_lists(in_zeros, nz_in_tangents, symbolic_zeros)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+  tangents = merge_lists(in_zeros, nz_in_tangents, symbolic_zeros)
   out = f(*in_primals, *tangents)
   n, ragged = divmod(len(out), 2)
   assert not ragged
@@ -2485,8 +2485,8 @@ def trace_to_jaxpr_dynamic(
       ans = fun.call_wrapped(*in_tracers)
     _check_returned_jaxtypes(fun.debug_info, ans)
     out_tracers = map(partial(trace.to_jaxpr_tracer, source_info=source_info), ans)
-    _check_no_returned_refs(fun.debug_info, out_tracers)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
-    jaxpr, consts = trace.frame.to_jaxpr(trace, out_tracers, fun.debug_info,  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+    _check_no_returned_refs(fun.debug_info, out_tracers)
+    jaxpr, consts = trace.frame.to_jaxpr(trace, out_tracers, fun.debug_info,
                                          source_info)
     del trace, fun, in_tracers, out_tracers, ans
   config.enable_checks.value and core.check_jaxpr(jaxpr)
@@ -2580,7 +2580,7 @@ def inline_jaxpr_into_trace(
                                    eqn.params, eqn.effects, src_, eqn.ctx)
     foreach(env.setdefault, eqn.outvars, out_tracers)
 
-  return map(partial(inline_atom, src), jaxpr.outvars)  # pyrefly: ignore[bad-return]  # pyrefly#2385
+  return map(partial(inline_atom, src), jaxpr.outvars)
 
 
 def try_constant_folding(primitive, tracers, params, out_avals):

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -607,7 +607,7 @@ class MapTracer(core.Tracer):
     aval = core.typeof(self.val)
     shard_axes = dict(self.shard_axes)
     for axis_idx in sorted(shard_axes.values())[::-1]:
-      aval = core.mapped_aval(aval.shape[axis_idx], axis_idx, aval)
+      aval = core.mapped_aval(aval.shape[axis_idx], axis_idx, aval)  # pyrefly: ignore[missing-attribute]
     return aval
 
   def full_lower(self):
@@ -1958,8 +1958,8 @@ def _cached_lowering_to_hlo(closed_jaxpr: core.ClosedJaxpr, module_name, backend
   axis_ctx: mlir.AxisContext
 
   if nreps == 1:
-    in_mlir_shardings = map(_to_logical_sharding, in_avals, in_shardings)  # pyrefly: ignore[bad-assignment]  # pyrefly#2385
-    out_mlir_shardings = map(_to_logical_sharding, out_avals, out_shardings)  # pyrefly: ignore[bad-assignment]  # pyrefly#2385
+    in_mlir_shardings = map(_to_logical_sharding, in_avals, in_shardings)
+    out_mlir_shardings = map(_to_logical_sharding, out_avals, out_shardings)
     replicated_args = [False] * len(in_avals)
     axis_ctx = sharding_impls.ShardingContext(num_devices, device_assignment,
                                               abstract_mesh)

--- a/jax/_src/interpreters/remat.py
+++ b/jax/_src/interpreters/remat.py
@@ -141,4 +141,4 @@ def _remat_jaxpr(jaxpr, policy):
       [*out_primals, *rem_consts], dbg.with_unknown_names(), src)
   fwd_trace.invalidate()
   fwd_jaxpr = core.ClosedJaxpr(fwd_jaxpr_, fwd_consts)
-  return fwd_jaxpr, rem_jaxpr, len(rem_consts)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+  return fwd_jaxpr, rem_jaxpr, len(rem_consts)

--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -54,7 +54,7 @@ def _merge_common_consts(
   consts = [c for cs in all_consts for c in cs]
   avalqdds = tuple(map(core.cur_aval_qdd, consts))
   num_constss = [len(cs) for cs in all_consts]
-  jaxprs = [_pad_constvars(jaxpr, num_consts, avalqdds[:sum(lens[:i])], avalqdds[sum(lens[:i+1]):])  # pyrefly: ignore[bad-index]  # pyrefly#2385
+  jaxprs = [_pad_constvars(jaxpr, num_consts, avalqdds[:sum(lens[:i])], avalqdds[sum(lens[:i+1]):])
             for i, (jaxpr, num_consts) in enumerate(zip(jaxprs, num_constss))]
   # De-duplicate shared constants.
   const_ids = tuple(id(c) for c in consts)

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -177,7 +177,7 @@ def _switch_internal(
   out = cond_p.bind(index, *consts, *args, **params)
   out_ = iter(out)
 
-  all_inputs = [*consts, *args]
+  all_inputs: list[Any] = [*consts, *args]
   out = [
     next(out_) if fwd is None else lax.asarray(all_inputs[fwd])
     for fwd in in_fwd
@@ -523,7 +523,7 @@ def _cond_linearize(is_vjp, nzs, *primals_in, branches, **params):
   primal_jaxprs, tangent_jaxprs, branch_res_avals = [], [], []
   for jaxpr in branches:
     primal_jaxpr, num_res_out, _, _, tangent_jaxpr = \
-        ad.linearize_jaxpr(jaxpr, nzs, instantiate=nzs_out, allow_fwds=False, is_vjp=is_vjp)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+        ad.linearize_jaxpr(jaxpr, nzs, instantiate=nzs_out, allow_fwds=False, is_vjp=is_vjp)
     res_avals = primal_jaxpr.out_avals[len(primal_jaxpr.out_avals)-num_res_out:]
     primal_jaxprs.append(primal_jaxpr)
     tangent_jaxprs.append(tangent_jaxpr)
@@ -531,13 +531,13 @@ def _cond_linearize(is_vjp, nzs, *primals_in, branches, **params):
 
   all_res_avals, res_avals_per_branch = _merge_branch_residuals(branch_res_avals)
   primal_jaxprs = _join_cond_outputs(
-      primal_jaxprs, all_res_avals, res_avals_per_branch, len(nzs_out))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      primal_jaxprs, all_res_avals, res_avals_per_branch, len(nzs_out))
   tangent_jaxprs = _join_cond_pe_staged_jaxpr_inputs(
       tangent_jaxprs, all_res_avals, res_avals_per_branch)
   tangent_avals_out = [a.to_tangent_aval() for a in jaxpr.out_avals]
 
   primals_res_out = cond_p.bind(*primals_in, branches=primal_jaxprs, **params)
-  primals, res = split_list(primals_res_out, [len(nzs_out)])  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+  primals, res = split_list(primals_res_out, [len(nzs_out)])
 
   def tangent_fun(res, *tangents_in):
     nz_tangents_in = [t for t in tangents_in if not isinstance(t, ad.Zero)]
@@ -634,7 +634,7 @@ def _cond_partial_eval(trace, *tracers, branches, **params):
   name_stack = source_info_util.current_name_stack()[len(trace.name_stack):]
   source = source_info_util.current().replace(name_stack=name_stack)
   eqn = pe.new_eqn_recipe(
-      trace, [index_tracer] + res_tracers + ops_tracers, out_tracers, cond_p, params,  # pyrefly: ignore[unsupported-operation]  # pyrefly#2385
+      trace, [index_tracer] + res_tracers + ops_tracers, out_tracers, cond_p, params,
       core.join_effects(*(j.effects for j in branches_unknown)), source)
   for t in out_tracers: t.recipe = eqn
   return util.merge_lists(out_uks, out_consts, out_tracers)
@@ -664,7 +664,7 @@ def _cond_partial_eval_custom(saveable, unks_in, inst_in, eqn):
     _, _, unks_out_, _, _ = pe.partial_eval_jaxpr_custom(
         jaxpr.jaxpr, in_unknowns=ops_uk, in_inst=True,
         ensure_out_unknowns=False, ensure_out_inst=True, saveable=saveable)
-    unks_out = map(operator.or_, unks_out, unks_out_)  # pyrefly: ignore[bad-assignment]  # pyrefly#2385
+    unks_out = map(operator.or_, unks_out, unks_out_)
 
   # Next, use the computed output unknowns to build a known jaxpr and a staged
   # jaxpr for each branch.
@@ -765,7 +765,7 @@ def _join_cond_outputs(jaxprs: Sequence[core.ClosedJaxpr],
       outs_and_residuals = core.jaxpr_as_fun(jaxpr)(*args)
       outs, residuals = split_list(outs_and_residuals, [num_non_res_outputs])
       aug_residuals = map(ad_util.zeros_like_aval, all_res_avals)
-      aug_residuals = util.subvals(aug_residuals, zip(res_indices, residuals))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      aug_residuals = util.subvals(aug_residuals, zip(res_indices, residuals))
       return outs + list(aug_residuals)
 
     wrapped_f_aug = lu.wrap_init(f_aug, debug_info=jaxpr.jaxpr.debug_info)
@@ -786,7 +786,7 @@ def _join_cond_pe_staged_jaxpr_inputs(
     res_vars = jaxpr.jaxpr.invars[:num_res]
     non_res_vars = jaxpr.jaxpr.invars[num_res:]
 
-    aug_res_vars = list(util.subvals(all_res_vars, zip(res_indices, res_vars)))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+    aug_res_vars = list(util.subvals(all_res_vars, zip(res_indices, res_vars)))
     aug_invars = aug_res_vars + non_res_vars
     jaxpr_aug = jaxpr.jaxpr.replace(invars=aug_invars)
     return core.ClosedJaxpr(jaxpr_aug, jaxpr.consts)
@@ -810,7 +810,7 @@ def _cond_dce_rule(used_outputs: list[bool], eqn: core.JaxprEqn,
   used_inputs: list[bool] = [False] * (len(eqn.invars) - 1)  # -1 for pred
   for jaxpr in branches:
     _, used_inputs_ = pe.dce_jaxpr(jaxpr, used_outputs, instantiate=False)
-    used_inputs = map(operator.or_, used_inputs, used_inputs_)  # pyrefly: ignore[bad-assignment]  # pyrefly#2385
+    used_inputs = map(operator.or_, used_inputs, used_inputs_)
 
   # Next, compute DCEd branches, instantiating according to used_inputs.
   dce_branches_ = [pe.dce_jaxpr(jaxpr, used_outputs, instantiate=used_inputs)[0]

--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -928,6 +928,7 @@ def conv_transpose_shape_tuple(lhs_shape, rhs_shape, window_strides, padding,
                      for i, k, s in zip(lhs_trans[2:],
                                         rhs_trans[2:],
                                         window_strides)]
+  # pyrefly: ignore[no-matching-overload]
   out_space = np.sum([unpad_out_space, padding], axis=0).tolist()
   out_trans = tuple((lhs_trans[0], rhs_trans[0]) + tuple(out_space))
   return tuple(np.take(out_trans, np.argsort(out_perm)))

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3433,7 +3433,7 @@ def _eye(dtype: DTypeLike, shape: Shape, offset: DimSize = 0) -> Array:
 
 def _delta(dtype: DTypeLike, shape: Shape, axes: Sequence[int]) -> Array:
   """This utility function exists for creating Kronecker delta arrays."""
-  axes = map(int, axes)  # pyrefly: ignore[bad-assignment]  # pyrefly#2385
+  axes = map(int, axes)
   dtype = dtypes.check_and_canonicalize_user_dtype(dtype, "delta")
   base_shape = tuple(np.take(shape, axes))
   iotas = [broadcasted_iota(np.uint32, base_shape, i)
@@ -9056,7 +9056,7 @@ def _optimization_barrier_lowering_rule(ctx, *args):
   barrier_types = map(mlir.aval_to_ir_type, ctx.avals_in)
   flat_args = mlir.flatten_ir_values(args)
   barrier_op = hlo.OptimizationBarrierOp(flat_args)
-  return mlir.unflatten_ir_values_like_types(barrier_op.results, barrier_types)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+  return mlir.unflatten_ir_values_like_types(barrier_op.results, barrier_types)
 
 
 optimization_barrier_p = core.Primitive('optimization_barrier')

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -1013,7 +1013,7 @@ def slice_in_dim(operand: Array | np.ndarray, start_index: int | None,
   limit_indices[axis] = limit_index_int
   strides[axis] = core._canonicalize_dimension(stride)
 
-  return slice(operand, start_indices, limit_indices, strides)  # pyrefly: ignore[bad-return, no-matching-overload]  # pyrefly#2385
+  return slice(operand, start_indices, limit_indices, strides)
 
 
 def index_in_dim(operand: Array | np.ndarray, index: int, axis: int = 0,
@@ -1446,7 +1446,7 @@ def _slice_transpose_fancy(out_ct, operand, *, start_indices, limit_indices, str
                  np.add(1, np.multiply(np.subtract(out_ct.shape, 1), strides))))
       pads = zip(start_indices, np.subtract(operand_aval.shape, real_limits),
                  np.subtract(strides, 1))
-    operand.accum(lax.pad(out_ct, lax._const(out_ct, 0), pads))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+    operand.accum(lax.pad(out_ct, lax._const(out_ct, 0), pads))
 
 
 def _slice_batching_rule(batched_args, batch_dims, *, start_indices,
@@ -1466,7 +1466,7 @@ def _slice_batching_rule(batched_args, batch_dims, *, start_indices,
     new_strides = list(strides)
     new_strides.insert(bdim, 1)
 
-  out = slice(operand, new_start_indices, new_limit_indices, new_strides)  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+  out = slice(operand, new_start_indices, new_limit_indices, new_strides)
   return out, bdim
 
 slice_p = standard_primitive(_slice_shape_rule, input_dtype, 'slice',

--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -442,7 +442,7 @@ def reduce_window_jvp(
 
   init_value_tangent = map(ad_util.instantiate, init_value_tangent)
   c_reduction_jaxpr = ClosedJaxpr(reduction_jaxpr, consts)
-  jvp_reduction = ad.jvp_jaxpr(c_reduction_jaxpr, (True,) * len(tangents), [False] * len(init_value_tangent))[0]  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+  jvp_reduction = ad.jvp_jaxpr(c_reduction_jaxpr, (True,) * len(tangents), [False] * len(init_value_tangent))[0]
 
   def wrapper(left, right):
     pl, tl = util.split_list(left, [n])

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3487,7 +3487,7 @@ def round(a: ArrayLike, decimals: int = 0, out: None = None) -> Array:
 @api.jit(static_argnames=('decimals',))
 def around(a: ArrayLike, decimals: int = 0, out: None = None) -> Array:
   """Alias of :func:`jax.numpy.round`"""
-  return round(a, decimals, out)  # pyrefly: ignore[no-matching-overload]
+  return round(a, decimals, out)
 
 
 @export

--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -743,7 +743,7 @@ def _logsumexp(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
   where = check_where("logsumexp", where)
   a_arr, = promote_dtypes_inexact(a)
   pos_dims, dims = _reduction_dims(a_arr, axis)
-  amax = max(a_arr.real, axis=dims, keepdims=keepdims, where=where, initial=-np.inf)  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+  amax = max(a_arr.real, axis=dims, keepdims=keepdims, where=where, initial=-np.inf)
   amax = lax.stop_gradient(lax.select(lax.is_finite(amax), amax, lax.full_like(amax, 0)))
   amax_with_dims = amax if keepdims else lax.expand_dims(amax, pos_dims)
   exp_a = lax.exp(lax.sub(a_arr, amax_with_dims.astype(a_arr.dtype)))
@@ -774,7 +774,7 @@ def amin(a: ArrayLike, axis: Axis = None, out: None = None,
         keepdims: bool = False, initial: ArrayLike | None = None,
         where: ArrayLike | None = None) -> Array:
   """Alias of :func:`jax.numpy.min`."""
-  return min(a, axis=axis, out=out, keepdims=keepdims,  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+  return min(a, axis=axis, out=out, keepdims=keepdims,
              initial=initial, where=where)
 
 @export
@@ -782,7 +782,7 @@ def amax(a: ArrayLike, axis: Axis = None, out: None = None,
         keepdims: bool = False, initial: ArrayLike | None = None,
         where: ArrayLike | None = None) -> Array:
   """Alias of :func:`jax.numpy.max`."""
-  return max(a, axis=axis, out=out, keepdims=keepdims,  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+  return max(a, axis=axis, out=out, keepdims=keepdims,
              initial=initial, where=where)
 
 def _axis_size(a: ArrayLike, axis: int | Sequence[int]):
@@ -878,7 +878,7 @@ def _count(
       count = core.dimension_as_value(_axis_size(a, axis))
     count = lax.convert_element_type(count, dtype)
   else:
-    count = sum(_broadcast_to(where, np.shape(a)), axis, dtype=dtype, keepdims=keepdims)  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+    count = sum(_broadcast_to(where, np.shape(a)), axis, dtype=dtype, keepdims=keepdims)
   return count
 
 @api.jit(static_argnames=('axis', 'dtype', 'keepdims', 'upcast_f16_for_computation'),
@@ -911,7 +911,7 @@ def _mean(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
   )
 
   return lax.div(
-      sum(a, axis, dtype=computation_dtype, keepdims=keepdims, where=where),  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+      sum(a, axis, dtype=computation_dtype, keepdims=keepdims, where=where),
       normalizer,
   ).astype(result_dtype)
 
@@ -1008,8 +1008,8 @@ def _average(a: ArrayLike, axis: Axis = None, weights: ArrayLike | None = None,
       new_shape = tuple(dim if i in axis_tuple else 1 for i, dim in enumerate(a.shape))
       weights = lax.reshape(weights, new_shape, dimensions=tuple(np.argsort(axis_tuple)))
 
-    weights_sum = sum(weights, axis=axis, keepdims=keepdims)  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
-    avg = sum(a * weights, axis=axis, keepdims=keepdims) / weights_sum  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+    weights_sum = sum(weights, axis=axis, keepdims=keepdims)
+    avg = sum(a * weights, axis=axis, keepdims=keepdims) / weights_sum
 
   if returned:
     if avg.shape != weights_sum.shape:
@@ -1142,7 +1142,7 @@ def _var(a: Array, *, axis: Axis = None, dtype: DTypeLike | None = None,
   )
 
   normalizer = lax.sub(normalizer, lax.convert_element_type(correction, computation_dtype))
-  result = sum(centered, axis, dtype=computation_dtype, keepdims=keepdims, where=where)  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+  result = sum(centered, axis, dtype=computation_dtype, keepdims=keepdims, where=where)
   result = lax.div(result, normalizer).astype(dtype)
   with config.debug_nans(False):
     result = _where(normalizer > 0, result, np.nan)
@@ -1364,7 +1364,7 @@ def count_nonzero(a: ArrayLike, axis: Axis = None,
            [3]], dtype=int32)
   """
   a = ensure_arraylike("count_nonzero", a)
-  return sum(lax.ne(a, lax._const(a, 0)), axis=axis,  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+  return sum(lax.ne(a, lax._const(a, 0)), axis=axis,
              dtype=dtypes.default_int_dtype(), keepdims=keepdims)
 
 
@@ -1380,7 +1380,7 @@ def _nan_reduction(a: ArrayLike, name: str, jnp_reduction: Callable[..., Array],
   out = jnp_reduction(_where(lax._isnan(a), _reduction_init_val(a, init_val), a),
                       axis=axis, keepdims=keepdims, where=where, **kwargs)
   if nan_if_all_nan:
-    return _where(all(lax._isnan(a), axis=axis, keepdims=keepdims),  # pyrefly: ignore[unexpected-keyword]  # pyrefly#2385
+    return _where(all(lax._isnan(a), axis=axis, keepdims=keepdims),
                   lax._const(a, np.nan), out)
   else:
     return out
@@ -1810,7 +1810,7 @@ def nanmean(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None, out
   else:
     dtype = dtypes.check_and_canonicalize_user_dtype(dtype, "mean")
   nan_mask = lax.bitwise_not(lax._isnan(a))
-  normalizer = sum(nan_mask, axis=axis, dtype=dtype, keepdims=keepdims, where=where)  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+  normalizer = sum(nan_mask, axis=axis, dtype=dtype, keepdims=keepdims, where=where)
   td = lax.div(nansum(a, axis, dtype=dtype, keepdims=keepdims, where=where), normalizer)
   return td
 
@@ -1921,11 +1921,11 @@ def _nanvar(a: Array, *, axis: Axis = None, dtype: DTypeLike | None = None, out:
   else:
     centered = lax.square(centered)
 
-  normalizer = sum(lax.bitwise_not(lax._isnan(a)),  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+  normalizer = sum(lax.bitwise_not(lax._isnan(a)),
                    axis=axis, keepdims=keepdims, where=where)
   normalizer = normalizer - ddof
   normalizer_mask = lax.le(normalizer, lax._zero(normalizer))
-  result = sum(centered, axis, keepdims=keepdims, where=where)  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+  result = sum(centered, axis, keepdims=keepdims, where=where)
   result = _where(normalizer_mask, np.nan, result)
   divisor = _where(normalizer_mask, 1, normalizer)
   result = lax.div(result, lax.convert_element_type(divisor, result.dtype))
@@ -2514,7 +2514,7 @@ def _quantile(a: Array, q: Array, axis: int | tuple[int, ...] | None,
   if squash_nans:
     a = _where(lax._isnan(a), np.nan, a) # Ensure nans are positive so they sort to the end.
     a = lax.sort(a, dimension=axis)
-    counts = sum(lax.bitwise_not(lax._isnan(a)), axis=axis, dtype=q.dtype, keepdims=keepdims)  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+    counts = sum(lax.bitwise_not(lax._isnan(a)), axis=axis, dtype=q.dtype, keepdims=keepdims)
     shape_after_reduction = counts.shape
     q = lax.expand_dims(
       q, tuple(range(q_ndim, len(shape_after_reduction) + q_ndim)))
@@ -2541,7 +2541,7 @@ def _quantile(a: Array, q: Array, axis: int | tuple[int, ...] | None,
     high_value = a[tuple(index)]
   else:
     with config.debug_nans(False):
-      a = _where(any(lax._isnan(a), axis=axis, keepdims=True), np.nan, a)  # pyrefly: ignore[unexpected-keyword]  # pyrefly#2385
+      a = _where(any(lax._isnan(a), axis=axis, keepdims=True), np.nan, a)
     a = lax.sort(a, dimension=axis)
     n = lax.convert_element_type(a_shape[axis], lax._dtype(q))
     q = lax.mul(q, n - 1)

--- a/jax/_src/numpy/setops.py
+++ b/jax/_src/numpy/setops.py
@@ -598,7 +598,7 @@ def _unique_sorted_mask(ar: Array, axis: int, equal_nan: bool) -> tuple[Array, A
       neq = lambda x, y: lax.ne(x, y) & ~(isnan(x) & isnan(y))
     else:
       neq = lax.ne
-    mask = ones(size, dtype=bool).at[1:].set(any(neq(aux[1:], aux[:-1]), tuple(range(1, aux.ndim))))  # pyrefly: ignore[bad-argument-count]  # pyrefly#2385
+    mask = ones(size, dtype=bool).at[1:].set(any(neq(aux[1:], aux[:-1]), tuple(range(1, aux.ndim))))
   else:
     mask = zeros(size, dtype=bool)
   return aux, mask, perm

--- a/jax/_src/pallas/core.py
+++ b/jax/_src/pallas/core.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import collections
-from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping, Sequence, Set
+from collections.abc import Callable, Hashable, Iterable, Generator, Mapping, Sequence, Set
 import contextlib
 import copy
 import dataclasses
@@ -319,7 +319,7 @@ class GridAxis:
 GridEnv = Sequence[GridAxis]
 
 @contextlib.contextmanager
-def grid_env(env: GridEnv) -> Iterator[None]:
+def grid_env(env: GridEnv) -> Generator[None, None, None]:
   _pallas_tracing_env.grid_env_stack.append(env)
   try:
     yield
@@ -945,7 +945,7 @@ class GridMapping:
       axis_env_ctx = contextlib.nullcontext()
     else:
       axis_env_ctx = jax_core.extend_axis_env_nd(
-          zip(self.grid_names, self.grid)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+          zip(self.grid_names, self.grid)  # pyrefly: ignore[bad-argument-type]
       )
     with tracing_grid_env(self.grid, self.vmapped_dims), axis_env_ctx:
       yield

--- a/jax/_src/pallas/hlo_interpreter.py
+++ b/jax/_src/pallas/hlo_interpreter.py
@@ -224,7 +224,7 @@ def eval_jaxpr_recursive(
     else:
       write(eqn.outvars[0], ans)
     jax_core.clean_up_dead_vars(eqn, env, lu)
-  return map(read, jaxpr.outvars)  # pyrefly: ignore[bad-return]  # pyrefly#2385
+  return map(read, jaxpr.outvars)
 
 # Higher-order primitive rules.
 _eval_jaxpr_hop_rules = {}
@@ -407,7 +407,7 @@ def pallas_call_hlo_interpret(
   # to catch OOB accesses.
 
   carry = map(_pad_to_block_dimension, carry, block_shapes)
-  carry.extend(scratch_values)  # pyrefly: ignore[missing-attribute]  # pyrefly#2385
+  carry.extend(scratch_values)
 
   num_inout_blocks = len(block_args) + len(out)
   grid_start_indices = (jnp.int32(0),) * len(grid)
@@ -448,12 +448,12 @@ def pallas_call_hlo_interpret(
     blocks = map(_dynamic_slice, start_indices, block_shapes,
                  carry_consts_ins, is_squeeze_dim)
     with pallas_core.grid_env(local_grid_env):
-      assert len(discharged_jaxpr.invars) == len(scalars) + len(blocks) + len(  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      assert len(discharged_jaxpr.invars) == len(scalars) + len(blocks) + len(
           scratch_values
       ), (
           len(discharged_jaxpr.invars),
           len(scalars),
-          len(blocks),  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+          len(blocks),
           len(scratch_values),
       )
 

--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -429,11 +429,12 @@ def ir_constant(x: Any, mlir_type: ir.Type | None = None) -> ir.Value:
   raise NotImplementedError(x.dtype)
 
 
+lowering_rules: dict[tpu_core.CoreType, dict[jax_core.Primitive, Callable]]
 lowering_rules = {kernel_type: {} for kernel_type in tpu_core.CoreType}
 skip_mlir_conversions = set()
 
 
-T = TypeVar("T")
+T = TypeVar("T", bound=Callable)
 
 
 def register_lowering_rule(
@@ -648,7 +649,6 @@ class MosaicGridMapping:
       return f"#tpu.dimension_semantics<{s}>"
 
     return ir.ArrayAttr.get(
-        # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
         map(
             ir.Attribute.parse,
             map(_get_semantics, self._dimension_semantics),
@@ -1304,7 +1304,7 @@ def jaxpr_subcomp(
             ctx,
             cast(Sequence[ShapedAbstractValue], [v.aval for v in eqn.invars]),
             cast(Sequence[ShapedAbstractValue], [v.aval for v in eqn.outvars]),
-            block_shapes,  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+            block_shapes,
         )
 
         # Insert trace_start and trace_stop ops on named_scope boundaries.
@@ -4272,7 +4272,7 @@ def random_fold_in_lowering(ctx: LoweringRuleContext, keys, msgs):
   else:
     ctx = dataclasses.replace(ctx,
                         avals_in=[_physical_aval(keys_aval), msgs_aval],
-                        avals_out=map(_physical_aval, ctx.avals_out))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+                        avals_out=map(_physical_aval, ctx.avals_out))
     return fold_in_lowering(ctx, keys, msgs)
 
 

--- a/jax/_src/pallas/mosaic/tpu_info.py
+++ b/jax/_src/pallas/mosaic/tpu_info.py
@@ -73,8 +73,8 @@ class ChipVersion(ChipVersionBase, enum.Enum):
     return self.value
 
   @property
-  def _num_physical_tensor_cores_per_chip(self) -> int:  # pyrefly: ignore[bad-return]  # pyrefly#2080
-    match self:  # pyrefly: ignore[non-exhaustive-match]  # pyrefly#2080
+  def num_physical_tensor_cores_per_chip(self) -> int:
+    match self:
       case (
           ChipVersion.TPU_V2
           | ChipVersion.TPU_V3
@@ -86,11 +86,6 @@ class ChipVersion(ChipVersionBase, enum.Enum):
         return 2
       case ChipVersion.TPU_V4I | ChipVersion.TPU_V5E | ChipVersion.TPU_V6E:
         return 1
-
-  @property
-  def num_physical_tensor_cores_per_chip(self) -> int:
-    # TODO(slebedev): Remove this wrapper once pyrefly#2080 is fixed.
-    return cast(int, self._num_physical_tensor_cores_per_chip)
 
   @property
   def supports_megacore(self) -> bool:
@@ -520,8 +515,6 @@ class Tiling(enum.Enum):
         return (8, 128)
       case Tiling.SPARSE_CORE:
         return (8,)
-      case _:
-        raise NotImplementedError  # pyrefly#2080
 
 
 def _get_tiling_factor(src: int, max_tiling: int, packing: int) -> int:

--- a/jax/_src/pallas/mosaic_gpu/core.py
+++ b/jax/_src/pallas/mosaic_gpu/core.py
@@ -182,7 +182,7 @@ class MemorySpace(enum.Enum):
         raise ValueError("packed, collective and layout arguments are only supported for TMEM.")
       mgpu_layout = None
     return GPUMemoryRef(jax_core.ShapedArray(shape, dtype), memory_space=self,
-                        transforms=transforms, layout=mgpu_layout,  # pyrefly: ignore[bad-argument-type]
+                        transforms=transforms, layout=mgpu_layout,
                         collective=collective)
 
 
@@ -1462,7 +1462,7 @@ class ParameterizedLayout(SomeLayout):
   def to_mgpu(self, *args, **kwargs) -> mgpu.FragmentedLayout:
     if args or kwargs:
       raise ValueError(f"Can't instantiate {self} with arguments.")
-    return self.layout_cls.to_mgpu(*self.args, **self.kwargs)  # pyrefly: ignore[bad-return]
+    return self.layout_cls.to_mgpu(*self.args, **self.kwargs)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1507,12 +1507,12 @@ class Layout(SomeLayout, enum.Enum):
   def __call__(self, *args, **kwargs) -> ParameterizedLayout:
     return ParameterizedLayout(self, args, kwargs)
 
-  def to_mgpu(self, *args, **kwargs) -> mgpu.FragmentedLayout:  # pyrefly: ignore[bad-override, bad-return]
+  def to_mgpu(self, *args, **kwargs) -> mgpu.FragmentedLayout:
     def check_no_args():
       if args or kwargs:
         raise ValueError(f"Can't instantiate {self} with arguments.")
 
-    match self:  # pyrefly: ignore[non-exhaustive-match]  # pyrefly#2080
+    match self:
       case Layout.WGMMA_TRANSPOSED:
         check_no_args()
         return mgpu.WGMMA_TRANSPOSED_LAYOUT
@@ -1575,7 +1575,7 @@ class TMEMLayout(enum.Enum):
     return ParameterizedLayout(self, args, kwargs)
 
   def to_mgpu(self, *args, **kwargs) -> tcgen05.TMEMLayout:
-    match self:  # pyrefly: ignore[non-exhaustive-match]  # pyrefly#2080
+    match self:
       case TMEMLayout.SCALES_LAYOUT:
         return tcgen05.scales_layout(*args, **kwargs)
       case TMEMLayout.SPARSE_METADATA_LAYOUT:

--- a/jax/_src/pallas/mosaic_gpu/lowering.py
+++ b/jax/_src/pallas/mosaic_gpu/lowering.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import collections
-from collections.abc import Callable, Hashable, Iterator, MutableMapping, MutableSequence, Sequence
+from collections.abc import Callable, Hashable, Iterator, Generator, MutableMapping, MutableSequence, Sequence
 import contextlib
 import dataclasses
 import functools
@@ -456,8 +456,10 @@ class ModuleContext:
   @contextlib.contextmanager
   def reserve_barrier(
       self, barrier: mgpu.Barrier | mgpu.ClusterBarrier
-  ) -> Iterator[
-      mgpu.BarrierRef | mgpu.DialectBarrierRef | mgpu.CollectiveBarrierRef
+  ) -> Generator[
+      mgpu.BarrierRef | mgpu.DialectBarrierRef | mgpu.CollectiveBarrierRef,
+      None,
+      None,
   ]:
     """Reserves a barrier.
 
@@ -472,10 +474,9 @@ class ModuleContext:
     available.append(barrier_ref)
 
   @contextlib.contextmanager
-  def reserve_semaphores(self,
-                         shape: tuple[int, ...],
-                         collective_axes: CollectiveAxesType
-                         ) -> Iterator[ir.Value]:
+  def reserve_semaphores(
+      self, shape: tuple[int, ...], collective_axes: CollectiveAxesType
+  ) -> Generator[ir.Value, None, None]:
     allocated_sems = math.prod(shape)
     ref = mgpu.memref_slice(
         self.scoped_gmem_semaphore_base_ptr[collective_axes],
@@ -495,7 +496,7 @@ class ModuleContext:
       struct: jax.ShapeDtypeStruct,
       *,
       layout: tcgen05.TMEMLayout,
-  ) -> Iterator[tcgen05.TMEMRef | ir.Value]:
+  ) -> Generator[tcgen05.TMEMRef | ir.Value, None, None]:
     if self.lowering_semantics == mgpu.LoweringSemantics.Lane:
       off = arith_dialect.addi(
           self.tmem_base, _i32_constant(self.tmem_used_cols)
@@ -526,7 +527,9 @@ class ModuleContext:
     self.tmem_used_cols -= cols_used
 
   @contextlib.contextmanager
-  def scratch_view(self, struct: jax.ShapeDtypeStruct) -> Iterator[ir.Value]:
+  def scratch_view(
+      self, struct: jax.ShapeDtypeStruct
+  ) -> Generator[ir.Value, None, None]:
     """Creates a view into the runtime scratch buffer for the given struct.
 
     This is a low-level API. Use it only if you know what you are doing.
@@ -1269,7 +1272,7 @@ def lower_jaxpr_to_mosaic_gpu(
         write_env(eqn.outvars[0], outvals)
   while named_regions:  # Drain the name stack.
     named_regions.pop().close()
-  return map(read_env, jaxpr.outvars)  # pyrefly: ignore[bad-return]  # pyrefly#2385
+  return map(read_env, jaxpr.outvars)
 
 
 @register_lowering_rule(primitives.program_id_p, mgpu.LoweringSemantics.Lane)
@@ -1490,7 +1493,7 @@ def _extract_aliased_ref(
           ref = slice_op.result
         else:
           ref_bytes = ref_bits // 8
-          ref = mgpu.memref_slice(ref, slice(offset, offset + ref_bytes))  # pyrefly: ignore[bad-argument-type]
+          ref = mgpu.memref_slice(ref, slice(offset, offset + ref_bytes))
           ref = _handle_dtype_bitcast(
               ref,
               ir.MemRefType(ref.type).element_type,
@@ -1589,7 +1592,7 @@ def _bubble_up_transform(
 ) -> tuple[T, T, list[state_types.Transform], list[state_types.Transform]]:
   new_transforms_rev = []
   new_transforms_avals_rev = []
-  for transform, transform_aval in reversed(zip(transforms, transforms_avals)):  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+  for transform, transform_aval in reversed(zip(transforms, transforms_avals)):
     avals = (transform_aval, t_aval)
     (t, new_transform), (t_aval, new_transform_aval) = _lower_fn_with_avals(
         functools.partial(_commute_transform, aval), avals
@@ -1724,10 +1727,10 @@ def _handle_transforms(
           " primitive."
       )
     transformed_ref = ctx.launch_ctx.to_remote(
-        transformed_ref, _ensure_ir_value(peer_device_id, jnp.int32)  # pyrefly: ignore[bad-argument-type]
+        transformed_ref, _ensure_ir_value(peer_device_id, jnp.int32)
     )
   if is_multicast:
-    transformed_ref = ctx.launch_ctx.to_remote_multicast(transformed_ref)  # pyrefly: ignore[bad-argument-type]
+    transformed_ref = ctx.launch_ctx.to_remote_multicast(transformed_ref)
   assert isinstance(ref_aval, state_types.AbstractRef)
   return transformed_ref, ref_aval, new_transforms
 
@@ -1794,7 +1797,6 @@ def _get_lowering_rule(
       ctx, ctx.avals_in[0], x_ref, transform_avals, transforms,
       handle_transposes=not transposed, allow_peer_refs=True
   )
-  x_smem = cast(ir.Value, x_smem)
   del x_ref  # Don't use x_ref anymore. Use x_smem instead!
 
   is_signed = mgpu_utils.is_signed(dtype)

--- a/jax/_src/pallas/mosaic_gpu/primitives.py
+++ b/jax/_src/pallas/mosaic_gpu/primitives.py
@@ -1368,6 +1368,7 @@ def _wgmma_lowering(
       raise NotImplementedError("WGMMA rhs tiling does not fit swizzle")
 
   if lhs_transpose:
+    assert isinstance(a, ir.Value)
     a = mgpu.memref_transpose(a, (1, 0, 3, 2))
   if rhs_transpose:
     b = mgpu.memref_transpose(b, (1, 0, 3, 2))
@@ -2041,8 +2042,8 @@ def _tcgen05_mma_lowering(
               b_ref,
               a_swizzle=int(lhs_swizzle),
               b_swizzle=int(rhs_swizzle),
-              a_scale=a_scale_ref,
-              b_scale=b_scale_ref,
+              a_scale=a_scale_ref,  # pyrefly: ignore[bad-argument-type]
+              b_scale=b_scale_ref,  # pyrefly: ignore[bad-argument-type]
               a_sparse_metadata=a_sparse_metadata_ref,
               accumulate=accumulate,
               collective=collective,

--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -117,7 +117,7 @@ def _pallas_call_abstract_eval(
                      f"{missing}")
   outin_aliases = {out_idx: in_idx for in_idx, out_idx in inout_aliases.items()}
   out_avals = tuple(
-      avals[outin_aliases[out_idx]] if out_idx in outin_aliases else a  # pyrefly: ignore[bad-index]
+      avals[outin_aliases[out_idx]] if out_idx in outin_aliases else a
       for out_idx, a in enumerate(out_avals)
   )
   # Make sure we don't return ShapedArrayWithMemorySpace to the outside world.
@@ -1003,7 +1003,7 @@ def pallas_call_checkify_rule(error: checkify.Error,
 
   # Prepare pallas_call inputs. We need to create new block specs
   # for the new error inputs and outputs.
-  error_block_specs = [pallas_core.BlockSpec(None, None)] * len(shaped_err_avals)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+  error_block_specs = [pallas_core.BlockSpec(None, None)] * len(shaped_err_avals)
   error_paths, _ = unzip2(tree_util.tree_flatten_with_path(error_block_specs)[0])
   error_origins = tuple(f"errors[{tree_util.keystr(p)}" for p in error_paths)
   error_block_mappings = map(
@@ -1024,8 +1024,8 @@ def pallas_call_checkify_rule(error: checkify.Error,
   grid_mapping_with_error = grid_mapping.replace(
       block_mappings=(*error_block_mappings, *input_block_mappings,
                       *error_block_mappings, *output_block_mappings),
-      num_inputs=grid_mapping.num_inputs + len(error_block_mappings),  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
-      num_outputs=grid_mapping.num_outputs + len(error_block_mappings)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      num_inputs=grid_mapping.num_inputs + len(error_block_mappings),
+      num_outputs=grid_mapping.num_outputs + len(error_block_mappings)
   )
   # Bump all input_output_aliases by num_err_vals to make room for error
   # TODO(justinfu): Don't bump scalars here.

--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -437,7 +437,7 @@ def lower_jaxpr_to_triton_ir(
     else:
       write_env(eqn.outvars[0], outvals)
 
-  return map(read_env, jaxpr.outvars)  # pyrefly: ignore[bad-return]  # pyrefly#2385
+  return map(read_env, jaxpr.outvars)
 
 
 def lower_fun(
@@ -2603,7 +2603,7 @@ def _scan_lowering_rule(
       pallas_utils.pattern_match_scan_to_fori_loop(jaxpr, num_consts, num_carry)
   )
   args = map(_ensure_ir_value, args, ctx.avals_in)
-  consts, args = util.split_list(args, [num_consts])  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+  consts, args = util.split_list(args, [num_consts])
   if has_loop_index:
     lower_bound, *args = args
     upper_bound = _add(lower_bound, _ir_constant(length, lower_bound.type))
@@ -2724,7 +2724,7 @@ def _while_lowering_rule(
     return result
   # Fall back to default while lowering
   cond_consts, body_consts, carry = util.split_list(
-      args, [cond_nconsts, body_nconsts]  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      args, [cond_nconsts, body_nconsts]
   )
   cond_const_block_infos, body_const_block_infos, carry_block_infos = (
       util.split_list(ctx.block_infos, [cond_nconsts, body_nconsts])

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -792,6 +792,7 @@ _seen_qdds = weakref.WeakKeyDictionary()
 
 def _seen_qdds_get(fun, in_type) -> list:
   cache = _seen_qdds.setdefault(fun, defaultdict(list))
+  assert cache is not None  # pyrefly#2407
   return cache[in_type]
 
 def _qdd_cache_index(fun, in_type) -> int:
@@ -1363,7 +1364,7 @@ def _pjit_lowering(ctx: mlir.LoweringRuleContext, *args, name: str,
                    ctx_mesh, keep_unused, inline, compiler_options_kvs):
   effects = list(ctx.tokens_in.effects())
   output_types = map(mlir.aval_to_ir_type, ctx.avals_out)
-  output_types = [mlir.token_type()] * len(effects) + output_types  # pyrefly: ignore[unsupported-operation]  # pyrefly#2385
+  output_types = [mlir.token_type()] * len(effects) + output_types
   flat_output_types = mlir.flatten_ir_types(output_types)
 
   const_args_and_avals = core.jaxpr_const_args(jaxpr.jaxpr)
@@ -1741,11 +1742,11 @@ def _pjit_partial_eval(trace: pe.JaxprTrace,
 
   # Set up staged-out 'unknown' eqn
   unknown_in_shardings = (keep_where(in_shardings, unknown_ins)
-                          + (UNSPECIFIED,) * len(residual_tracers))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+                          + (UNSPECIFIED,) * len(residual_tracers))
   unknown_in_layouts = (keep_where(in_layouts, unknown_ins)
-                        + (None,) * len(residual_tracers))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+                        + (None,) * len(residual_tracers))
   unknown_donated_invars = (keep_where(donated_invars, unknown_ins)
-                            + (False,) * len(residual_tracers))  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+                            + (False,) * len(residual_tracers))
   unknown_params = dict(
       jaxpr=unknown_jaxpr,
       in_shardings=unknown_in_shardings,

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -543,7 +543,7 @@ def iterated_vmap_binary_bcast(shape1, shape2, f):
     else:
       return lambda x, y: iterated_vmap_unary(ndim1, lambda x: f(x, y))(x)
   assert len(shape1) == len(shape2)
-  for sz1, sz2 in reversed(zip(shape1, shape2)):  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+  for sz1, sz2 in reversed(zip(shape1, shape2)):
     if sz1 == sz2:
       f = api.vmap(f, out_axes=0)
     else:

--- a/jax/_src/source_info_util.py
+++ b/jax/_src/source_info_util.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Generator
 import contextlib
 import dataclasses
 import functools
@@ -306,7 +306,7 @@ set_name_stack = SetNameStackContextManager
 # the performance shouldn't matter. See blame commit message for repro.
 # reset_name_stack = lambda: SetNameStackContextManager(NameStack())
 @contextlib.contextmanager
-def reset_name_stack() -> Iterator[None]:
+def reset_name_stack() -> Generator[None, None, None]:
   with set_name_stack(NameStack()):
     yield
 

--- a/jax/_src/state/discharge.py
+++ b/jax/_src/state/discharge.py
@@ -535,7 +535,7 @@ def transform_swap_array(x, transforms, val):
   new_x = val
 
   # Write phase (reversed loop)
-  for intermediate, transform in reversed(zip(intermediates[:-1], transforms)):  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385
+  for intermediate, transform in reversed(zip(intermediates[:-1], transforms)):
     if isinstance(transform, indexing.NDIndexer):
       indexer = transform
       if _is_trivial_indexer(indexer):
@@ -773,7 +773,7 @@ def _run_state_jvp(primals: Sequence[Any], tangents: Sequence[Any], *,
         nonzero_tangents, instantiate=nonzero_tangents)
     if out_nonzero_tangents == nonzero_tangents:
       break
-    nonzero_tangents = map(operator.or_, nonzero_tangents, out_nonzero_tangents)  # pyrefly: ignore[bad-assignment]  # pyrefly#2385
+    nonzero_tangents = map(operator.or_, nonzero_tangents, out_nonzero_tangents)
   else:
     raise Exception("Invalid fixpoint")
   del discharged_jaxpr, body_consts, out_nonzero_tangents

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 import collections
-from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
+from collections.abc import Callable, Generator, Iterable, Sequence
 from contextlib import ExitStack, contextmanager
 import datetime
 import functools
@@ -325,8 +325,11 @@ def count_subjaxpr_to_hlo_conversion(fun_name):
 
 
 @contextmanager
-def collect_lowered_jaxprs() -> Iterator[Sequence[tuple[core.ClosedJaxpr,
-                                                         mlir.ir.Module]]]:
+def collect_lowered_jaxprs() -> Generator[
+    Sequence[tuple[core.ClosedJaxpr, mlir.ir.Module]],
+    None,
+    None,
+]:
   """
   Collects all the pairs of (jaxpr, mlir_module) that are lowered.
   """

--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -422,11 +422,11 @@ def _call_tf_abstract_eval(
     **__,
 ):
   # Called only when we form a Jaxpr, i.e., under jit, scan, etc.
-  effects: set[effects.Effect] = set()
+  effs: set[effects.Effect] = set()
   if ordered:
-    effects.add(call_tf_ordered_effect)
+    effs.add(call_tf_ordered_effect)
   elif has_side_effects:
-    effects.add(call_tf_effect)
+    effs.add(call_tf_effect)
 
   # If no output_avals is given, then we ask TF to infer the output shapes.
   # We call this even if output_avals is given because it will ensure that
@@ -437,10 +437,10 @@ def _call_tf_abstract_eval(
 
   # In the case that the tf.function has no return value
   if len(concrete_function_flat_tf.outputs) == 0:
-    return (), effects
+    return (), effs
 
   if output_avals is not None:
-    return output_avals, effects
+    return output_avals, effs
 
   def is_fully_known_shape(s):
     return s.rank is not None and all(d is not None for d in s)
@@ -452,7 +452,7 @@ def _call_tf_abstract_eval(
         core.ShapedArray(shape, jax2tf_internal._to_jax_dtype(dtype))
         for dtype, shape in zip(concrete_function_flat_tf.output_dtypes,
                                 concrete_function_flat_tf.output_shapes))
-    return avals_from_tf, effects
+    return avals_from_tf, effs
 
   msg = ("call_tf cannot call functions whose output has dynamic shape. "
     f"Found output shapes: {concrete_function_flat_tf.output_shapes}. "
@@ -556,8 +556,9 @@ def _call_tf_lowering(
   # graph scopes, and allows us to read the values of the variables
   with tf.init_scope():
     captured_ops = tuple(
-        mlir.ir_constant(np.asarray(inp))
-        for inp in captured_inputs
+        mlir.flatten_ir_values(
+            mlir.ir_constant(np.asarray(inp)) for inp in captured_inputs
+        )
     )
 
   if call_tf_graph:

--- a/jax/experimental/roofline/roofline.py
+++ b/jax/experimental/roofline/roofline.py
@@ -218,8 +218,8 @@ def _roofline_interpreter(
           RooflineRuleContext(
             name_stack=source_info.name_stack,
             primitive=eqn.primitive,
-            avals_in=map(aval, eqn.invars),  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
-            avals_out=map(aval, eqn.outvars),  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+            avals_in=map(aval, eqn.invars),
+            avals_out=map(aval, eqn.outvars),
             jaxpr_eqn_ctx=eqn.ctx,
             mesh=mesh,
             pin_lhs_in_vmem=pin_lhs_in_vmem,
@@ -231,7 +231,7 @@ def _roofline_interpreter(
 
       # Add bytes for the newly-created output variables.
       outvar_shapes = map(make_roofline_shape, eqn.outvars)
-      current_hbm_bytes += sum_bytes(outvar_shapes)  # pyrefly: ignore[bad-argument-type]  # pyrefly#2385
+      current_hbm_bytes += sum_bytes(outvar_shapes)
       foreach(write, eqn.outvars, outvar_shapes)
 
       # Remove bytes for the no-longer-needed input variables.


### PR DESCRIPTION
This removed quite a few suppressions.

Note that I also migrated all `contextmanager`-decorated functions to return `Generator`, because the `Iterator` overload is deprecated.
