### PR TITLE
[OneAPI GPU] Introducing OneAPI PJRT plugin.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -265,6 +265,15 @@ common:tsan_shared --config=tsan
 common:tsan_shared --copt=-shared-libsan
 common:tsan_shared --linkopt=-shared-libsan
 
+# Build with oneAPI support
+common:oneapi --@rules_ml_toolchain//common:enable_sycl=True
+common:oneapi --repo_env=TF_NEED_SYCL=1
+common:oneapi --define=tensorflow_mkldnn_contraction_kernel=0
+
+# oneAPI Hermetic setup
+common:oneapi --repo_env=SYCL_BUILD_HERMETIC=1
+
+
 # #############################################################################
 # Cache options below.
 # #############################################################################

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -82,6 +82,9 @@ use_repo(rocm, "local_config_rocm")
 python_version_ext = use_extension("@rules_ml_toolchain//extensions:python_version.bzl", "python_version_ext")
 use_repo(python_version_ext, "python_version_repo")
 
+sycl = use_extension("@rules_ml_toolchain//extensions:sycl_configure.bzl", "sycl_configure_ext")
+use_repo(sycl, "local_config_sycl")
+
 ### RBE
 rbe_config = use_extension("@xla//third_party/extensions:rbe_config.bzl", "rbe_config_ext")
 use_repo(rbe_config, "ml_build_config_platform")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,6 +32,8 @@ register_toolchains("@rules_ml_toolchain//cc:linux_x86_64_linux_x86_64")
 
 register_toolchains("@rules_ml_toolchain//cc:linux_x86_64_linux_x86_64_cuda")
 
+register_toolchains("@rules_ml_toolchain//cc:linux_x86_64_linux_x86_64_sycl")
+
 register_toolchains("@rules_ml_toolchain//cc:linux_aarch64_linux_aarch64")
 
 register_toolchains("@rules_ml_toolchain//cc:linux_aarch64_linux_aarch64_cuda")

--- a/build/build.py
+++ b/build/build.py
@@ -68,6 +68,7 @@ WHEEL_BUILD_TARGET_DICT = {
     "jax-rocm-plugin": "//jaxlib/tools:jax_rocm_plugin_wheel",
     "jax-rocm-pjrt": "//jaxlib/tools:jax_rocm_pjrt_wheel",
     "mosaic-gpu-cuda": "//jaxlib/tools:mosaic_gpu_wheel_cuda{cuda_major_version}",
+    "jax-oneapi-pjrt": "//jaxlib/tools:jax_oneapi_pjrt_wheel",
 }
 
 def add_global_arguments(parser: argparse.ArgumentParser):
@@ -149,7 +150,8 @@ def add_artifact_subcommand_arguments(parser: argparse.ArgumentParser):
         A comma separated list of JAX wheels to build. E.g: --wheels="jaxlib",
         --wheels="jaxlib,jax-cuda-plugin", etc.
         Valid options are: jaxlib, jax-cuda-plugin or cuda-plugin, jax-cuda-pjrt or cuda-pjrt,
-        jax-rocm-plugin or rocm-plugin, jax-rocm-pjrt or rocm-pjrt
+        jax-rocm-plugin or rocm-plugin, jax-rocm-pjrt or rocm-pjrt,
+        jax-oneapi-pjrt or oneapi-pjrt.
         """,
   )
 
@@ -276,6 +278,21 @@ def add_artifact_subcommand_arguments(parser: argparse.ArgumentParser):
       type=str,
       default="",
       help="Path to the ROCm toolkit.",
+  )
+
+  oneapi_group = parser.add_argument_group('OneAPI Options')
+  oneapi_group.add_argument(
+      "--oneapi_version",
+      type=str,
+      default="2025.1",
+      help="OneAPI version to use. E.g. 2025.1",
+  )
+
+  oneapi_group.add_argument(
+      "--oneapi_intelgpu_targets",
+      type=str,
+      default="",
+      help="A comma-separated list of OneAPI intelgpu targets to support.",
   )
 
   # Compile Options
@@ -497,6 +514,7 @@ async def main():
           " jax-cuda-plugin or cuda-plugin, jax-cuda-pjrt or cuda-pjrt,"
           " jax-rocm-plugin or rocm-plugin, jax-rocm-pjrt or rocm-pjrt,"
           " or mosaic-gpu",
+          " jax-oneapi-pjrt or oneapi-pjrt",
           wheel,
       )
       sys.exit(1)
@@ -590,8 +608,18 @@ async def main():
   else:
     logging.debug("Using default cpu features")
 
-  if "cuda" in args.wheels and "rocm" in args.wheels:
-    logging.error("CUDA and ROCm cannot be enabled at the same time.")
+  enabled_platforms = []
+  if "cuda" in args.wheels:
+    enabled_platforms.append("CUDA")
+  if "rocm" in args.wheels:
+    enabled_platforms.append("ROCm")
+  if "oneapi" in args.wheels:
+    enabled_platforms.append("OneAPI")
+
+  if len(enabled_platforms) > 1:
+    logging.error(
+        "%s cannot be enabled at the same time.", " and ".join(sorted(enabled_platforms))
+    )
     sys.exit(1)
 
   if args.cuda_version:
@@ -651,6 +679,19 @@ async def main():
           f"--action_env=TF_ROCM_AMDGPU_TARGETS={args.rocm_amdgpu_targets}"
       )
 
+  if "oneapi" in args.wheels:
+    wheel_build_command_base.append("--config=oneapi")
+    if args.oneapi_version:
+      logging.debug("OneAPI version: %s", args.oneapi_version)
+      wheel_build_command_base.append(
+          f"--repo_env=ONEAPI_VERSION={args.oneapi_version}"
+      )
+    if args.oneapi_intelgpu_targets:
+      logging.debug("Oneapi Intel GPU targets: %s", args.oneapi_intelgpu_targets)
+      wheel_build_command_base.append(
+          f"--action_env=TF_ONEAPI_INTELGPU_TARGETS={args.oneapi_intelgpu_targets}"
+      )
+
   # Append additional build options at the end to override any options set in
   # .bazelrc or above.
   if args.bazel_options:
@@ -689,7 +730,7 @@ async def main():
       output_path = args.output_path
       logger.debug("Artifacts output directory: %s", output_path)
 
-      # Allow CUDA/ROCm wheels without the "jax-" prefix.
+      # Allow CUDA/ROCm/OneAPI wheels without the "jax-" prefix.
       if ("plugin" in wheel or "pjrt" in wheel) and "jax" not in wheel:
         wheel = "jax-" + wheel
 
@@ -749,6 +790,13 @@ async def main():
       else:
         # For non-editable builds, use wildcard pattern to match any ROCm version in glob patterns
         wheel_dir = wheel.replace("rocm", "rocm*").replace("-", "_")
+    elif "oneapi" in wheel:
+      if args.editable:
+        # For editable builds, use the actual oneAPI version since directory paths cannot contain wildcards
+        wheel_dir = wheel.replace("oneapi", f"oneapi{args.oneapi_version}").replace("-", "_")
+      else:
+        # For non-editable builds, use wildcard pattern to match any oneAPI version in glob patterns
+        wheel_dir = wheel.replace("oneapi", "oneapi*").replace("-", "_")
     else:
       wheel_dir = wheel
 
@@ -766,7 +814,7 @@ async def main():
           wheel_version_suffix += (
               f"+{wheel_git_hash}{custom_wheel_version_suffix}"
           )
-      if wheel in ["jax", "jax-cuda-pjrt", "jax-rocm-pjrt"]:
+      if wheel in ["jax", "jax-cuda-pjrt", "jax-rocm-pjrt", "jax-oneapi-pjrt"]:
         python_tag = "py"
       else:
         python_tag = "cp"

--- a/jax/_src/xla_bridge.py
+++ b/jax/_src/xla_bridge.py
@@ -86,6 +86,11 @@ _ROCM_VISIBLE_DEVICES = config.string_flag(
     help=(
       'Restricts the set of ROCM devices that JAX will use. Either "all", or a '
       'comma-separate list of integer device IDs.'))
+_ONEAPI_VISIBLE_DEVICES = config.string_flag(
+    'jax_oneapi_visible_devices', 'all',
+    help=(
+      'Restricts the set of ONEAPI devices that JAX will use. Either "all", or a '
+      'comma-separate list of integer device IDs.'))
 
 MOCK_NUM_GPU_PROCESSES = config.int_flag(
     name="mock_num_gpu_processes",
@@ -287,6 +292,9 @@ _plugin_callback_lock = threading.Lock()
 # that a reasonable feature set is implemented and the plugin fails gracefully
 # for unimplemented features. Wrong outputs are not acceptable.
 _nonexperimental_plugins: set[str] = {'cuda', 'rocm'}
+
+# The set of known experimental plugins that have registrations in JAX codebase.
+_experimental_plugins: set[str] = {"oneapi"}
 
 def register_backend_factory(name: str, factory: BackendFactory, *,
                              priority: int = 0,
@@ -510,9 +518,13 @@ def _options_from_jax_configs(plugin_name):
   elif isinstance(pjrt_client_options, dict):
     options.update(pjrt_client_options)
 
-  if plugin_name in ("cuda", "rocm"):
-    visible_devices = (CUDA_VISIBLE_DEVICES.value if plugin_name == "cuda"
-        else _ROCM_VISIBLE_DEVICES.value)
+  _visible_device_configs = {
+      "cuda": CUDA_VISIBLE_DEVICES,
+      "rocm": _ROCM_VISIBLE_DEVICES,
+      "oneapi": _ONEAPI_VISIBLE_DEVICES,
+  }
+  if plugin_name in _visible_device_configs:
+    visible_devices = _visible_device_configs[plugin_name].value
     if visible_devices != 'all':
       options['visible_devices'] = [int(x) for x in visible_devices.split(',')]
     mock_gpu_topology = MOCK_GPU_TOPOLOGY.value or None
@@ -690,6 +702,7 @@ def _discover_and_register_pjrt_plugins():
 _platform_aliases = {
   "cuda": "gpu",
   "rocm": "gpu",
+  "oneapi": "gpu",
 }
 
 _alias_to_platforms: dict[str, list[str]] = {}
@@ -702,6 +715,7 @@ def known_platforms() -> set[str]:
   platforms |= set(_nonexperimental_plugins)
   platforms |= set(_backend_factories.keys())
   platforms |= set(_platform_aliases.values())
+  platforms |= set(_platform_aliases.keys())
   return platforms
 
 
@@ -715,8 +729,8 @@ def is_known_platform(platform: str) -> bool:
 def canonicalize_platform(platform: str) -> str:
   """Replaces platform aliases with their concrete equivalent.
 
-  In particular, replaces "gpu" with either "cuda" or "rocm", depending on which
-  hardware is actually present. We want to distinguish "cuda" and "rocm" for
+  In particular, replaces "gpu" with either "cuda", "oneapi" or "rocm", depending on which
+  hardware is actually present. We want to distinguish "cuda", "oneapi" and "rocm" for
   purposes such as MLIR lowering rules, but in many cases we don't want to
   force users to care.
   """
@@ -734,7 +748,7 @@ def canonicalize_platform(platform: str) -> str:
 
 
 def expand_platform_alias(platform: str) -> list[str]:
-  """Expands, e.g., "gpu" to ["cuda", "rocm"].
+  """Expands, e.g., "gpu" to ["cuda", "rocm", "oneapi"].
 
   This is used for convenience reasons: we expect cuda and rocm to act similarly
   in many respects since they share most of the same code.

--- a/jax_plugins/BUILD.bazel
+++ b/jax_plugins/BUILD.bazel
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 load(
-    "//jaxlib:jax.bzl",
-    "if_cuda_is_configured",
-    "if_rocm_is_configured",
-    "py_library_providing_imports_info",
+  "//jaxlib:jax.bzl",
+  "if_cuda_is_configured",
+  "if_rocm_is_configured",
+  "if_oneapi_is_configured",
+  "py_library_providing_imports_info",
 )
 
 package(
@@ -37,5 +38,7 @@ py_library(
         "//jax_plugins/cuda:cuda_plugin",
     ]) + if_rocm_is_configured([
         "//jax_plugins/rocm:rocm_plugin",
+    ]) + if_oneapi_is_configured([
+        "//jax_plugins/oneapi:oneapi_plugin",
     ]),
 )

--- a/jax_plugins/oneapi/BUILD.bazel
+++ b/jax_plugins/oneapi/BUILD.bazel
@@ -1,0 +1,58 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])
+
+load(
+  "//jaxlib:jax.bzl",
+  "py_library_providing_imports_info",
+  "pytype_library",
+)
+
+package(
+    default_applicable_licenses = [],
+    default_visibility = ["//:__subpackages__"],
+)
+
+exports_files([
+    "__init__.py",
+    "plugin_pyproject.toml",
+    "plugin_setup.py",
+    "pyproject.toml",
+    "setup.py",
+])
+
+cc_binary(
+    name = "pjrt_c_api_gpu_plugin.so",
+    linkopts = [
+        "-Wl,--version-script,$(location :gpu_version_script.lds)",
+        "-Wl,--no-undefined",
+    ],
+    linkshared = True,
+    deps = [
+        ":gpu_version_script.lds",
+        "@xla//xla/pjrt/c:pjrt_c_api_gpu",
+        "@xla//xla/service:gpu_plugin",
+        "@xla//xla/stream_executor:sycl_platform",
+    ],
+)
+
+py_library_providing_imports_info(
+    name = "oneapi_plugin",
+    srcs = [
+        "__init__.py",
+    ],
+    data = [":pjrt_c_api_gpu_plugin.so"],
+    lib_rule = pytype_library,
+)

--- a/jax_plugins/oneapi/__init__.py
+++ b/jax_plugins/oneapi/__init__.py
@@ -1,0 +1,72 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import pathlib
+
+from jax._src.lib import xla_client
+import jax._src.xla_bridge as xb
+
+logger = logging.getLogger(__name__)
+
+def _get_library_path():
+  base_path = pathlib.Path(__file__).resolve().parent
+  installed_path = (
+      base_path / 'xla_oneapi_plugin.so'
+  )
+  if installed_path.exists():
+    return installed_path
+
+  local_path = (
+      base_path / 'pjrt_c_api_gpu_plugin.so'
+  )
+  if not local_path.exists():
+    runfiles_dir = os.getenv('RUNFILES_DIR', None)
+    if runfiles_dir:
+      local_path = pathlib.Path(
+          os.path.join(runfiles_dir, 'xla/xla/pjrt/c/pjrt_c_api_gpu_plugin.so')
+      )
+
+  if local_path.exists():
+    logger.debug(
+        'Native library %s does not exist. This most likely indicates an issue'
+        ' with how %s was built or installed. Fallback to local test'
+        ' library %s',
+        installed_path,
+        __package__,
+        local_path,
+    )
+    return local_path
+
+  logger.debug(
+      'WARNING: Native library %s and local test library path %s do not'
+      ' exist. This most likely indicates an issue with how %s was built or'
+      ' installed or missing src files.',
+      installed_path,
+      local_path,
+      __package__,
+  )
+  return None
+
+
+def initialize():
+  path = _get_library_path()
+  if path is None:
+    return
+  options = xla_client.generate_pjrt_gpu_plugin_options()
+  options["platform_name"] = "SYCL"
+  xb.register_plugin(
+      'oneapi', priority=500, library_path=str(path), options=options
+  )

--- a/jax_plugins/oneapi/gpu_version_script.lds
+++ b/jax_plugins/oneapi/gpu_version_script.lds
@@ -1,0 +1,9 @@
+VERS_1.0 {
+  global:
+    extern "C" {
+      GetPjrtApi;
+    };
+
+  local:
+    *;
+};

--- a/jax_plugins/oneapi/pyproject.toml
+++ b/jax_plugins/oneapi/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/jax_plugins/oneapi/setup.py
+++ b/jax_plugins/oneapi/setup.py
@@ -1,0 +1,66 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import os
+from setuptools import setup, find_namespace_packages
+
+__version__ = None
+oneapi_version = 0  # placeholder
+project_name = f"jax-oneapi{oneapi_version}-pjrt"
+package_name = f"jax_plugins.xla_oneapi{oneapi_version}"
+
+def load_version_module(pkg_path):
+  spec = importlib.util.spec_from_file_location(
+    'version', os.path.join(pkg_path, 'version.py'))
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+_version_module = load_version_module(f"jax_plugins/xla_oneapi{oneapi_version}")
+__version__ = _version_module._get_version_for_build()
+
+packages = find_namespace_packages(
+    include=[
+        package_name,
+        f"{package_name}.*",
+    ]
+)
+
+setup(
+    name=project_name,
+    version=__version__,
+    description=f"JAX XLA PJRT Plugin for Intel GPUs (OneAPI:{oneapi_version})",
+    long_description="",
+    long_description_content_type="text/markdown",
+    author="MiniGoel",
+    author_email="mini.goel@intel.com",
+    packages=packages,
+    install_requires=[],
+    url="https://github.com/jax-ml/jax",
+    license="Apache-2.0",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Programming Language :: Python :: 3",
+    ],
+    package_data={
+        package_name: ["xla_oneapi_plugin.so"],
+    },
+    zip_safe=False,
+    entry_points={
+        "jax_plugins": [
+            f"xla_oneapi{oneapi_version} = {package_name}",
+        ],
+    },
+)

--- a/jaxlib/jax.bzl
+++ b/jaxlib/jax.bzl
@@ -23,6 +23,8 @@ load("@jax_wheel_version_suffix//:wheel_version_suffix.bzl", "WHEEL_VERSION_SUFF
 load("@local_config_cuda//cuda:build_defs.bzl", _cuda_library = "cuda_library", _if_cuda_is_configured = "if_cuda_is_configured")
 load("@local_config_rocm//rocm:build_defs.bzl", _if_rocm_is_configured = "if_rocm_is_configured", _rocm_library = "rocm_library")
 load("@nvidia_wheel_versions//:versions.bzl", "NVIDIA_WHEEL_VERSIONS")
+# TODO(Intel-tf): Update `sycl` with `oneapi` when xla changes to use `oneapi`.
+load("@local_config_sycl//sycl:build_defs.bzl", _if_oneapi_is_configured = "if_sycl_is_configured", _oneapi_library = "sycl_library")
 load("@python_version_repo//:py_version.bzl", "HERMETIC_PYTHON_VERSION", "HERMETIC_PYTHON_VERSION_KIND")
 load("@rocm_external_test_deps//:external_deps.bzl", "EXTERNAL_DEPS")
 load("@rocm_prebuilt_test_deps//:external_deps.bzl", PREBUILT_EXTERNAL_DEPS = "EXTERNAL_DEPS")
@@ -37,9 +39,11 @@ load("@xla//xla/tsl/platform:build_config_root.bzl", _tf_cuda_tests_tags = "tf_c
 cc_proto_library = _cc_proto_library
 cuda_library = _cuda_library
 rocm_library = _rocm_library
+oneapi_library = _oneapi_library
 proto_library = _proto_library
 if_cuda_is_configured = _if_cuda_is_configured
 if_rocm_is_configured = _if_rocm_is_configured
+if_oneapi_is_configured = _if_oneapi_is_configured
 if_windows = _if_windows
 flatbuffer_cc_library = _flatbuffer_cc_library
 tf_exec_properties = _tf_exec_properties
@@ -495,6 +499,11 @@ def _jax_wheel_impl(ctx):
         if ctx.attr.platform_version == "":
             fail("platform_version must be set to a valid rocm version for rocm wheels")
         args.add("--platform_version", ctx.attr.platform_version)  # required for gpu wheels
+    if ctx.attr.enable_oneapi:
+        args.add("--enable-oneapi", "True")
+        if ctx.attr.platform_version == "":
+            fail("platform_version must be set to a valid oneapi version for oneapi wheels")
+        args.add("--platform_version", ctx.attr.platform_version)  # required for gpu wheels
     if ctx.attr.skip_gpu_kernels:
         args.add("--skip_gpu_kernels")
 
@@ -536,11 +545,12 @@ _jax_wheel = rule(
         "source_files": attr.label_list(allow_files = True),
         "output_path": attr.label(default = Label("//jaxlib/tools:output_path")),
         "enable_cuda": attr.bool(default = False),
-        # A cuda/rocm version is required for gpu wheels; for cpu wheels, it can be an empty string.
+        # A cuda/rocm/oneapi version is required for gpu wheels; for cpu wheels, it can be an empty string.
         "platform_version": attr.string(),
         "skip_gpu_kernels": attr.bool(default = False),
         "enable_rocm": attr.bool(default = False),
         "reproducible": attr.bool(default = False),
+        "enable_oneapi": attr.bool(default = False),
         "include_cuda_libs": attr.label(default = Label("@local_config_cuda//cuda:include_cuda_libs")),
         "override_include_cuda_libs": attr.label(default = Label("@local_config_cuda//cuda:override_include_cuda_libs")),
         "py_freethreaded": attr.label(default = Label("@rules_python//python/config_settings:py_freethreaded")),
@@ -559,6 +569,7 @@ def jax_wheel(
         editable = False,
         enable_cuda = False,
         enable_rocm = False,
+        enable_oneapi = False,
         platform_version = "",
         reproducible = False,
         source_files = []):
@@ -575,6 +586,7 @@ def jax_wheel(
       platform_independent: whether to build a wheel without platform tag
       enable_cuda: whether to build a cuda wheel
       enable_rocm: whether to build a rocm wheel
+      enable_oneapi: whether to build a oneapi wheel
       platform_version: the cuda version to use for the wheel
       reproducible: whether to produce a reproducible wheel by fixing timestamps
       source_files: the source files to include in the wheel
@@ -593,6 +605,7 @@ def jax_wheel(
         editable = editable,
         enable_cuda = enable_cuda,
         enable_rocm = enable_rocm,
+        enable_oneapi = enable_oneapi,
         platform_version = platform_version,
         reproducible = reproducible,
         # git_hash is empty by default. Use `--//jaxlib/tools:jaxlib_git_hash=$(git rev-parse HEAD)`

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -43,6 +43,10 @@ rocm_version = os.environ.get("JAX_ROCM_VERSION")
 if rocm_version:
     __version__ += f"+rocm{rocm_version.replace('.', '')}"
 
+oneapi_version = os.environ.get("JAX_ONEAPI_VERSION")
+if oneapi_version:
+    __version__ += f"+oneapi{oneapi_version.replace('.', '')}"
+
 class BinaryDistribution(Distribution):
   """This class makes 'bdist_wheel' include an ABI tag on the wheel."""
 
@@ -104,6 +108,7 @@ setup(
             'mlir/_mlir_libs/*.pyi',
             'mlir/_mlir_libs/**/*.pyi',
             'rocm/*',
+            'oneapi/*',
             'triton/*.py',
             'triton/*.pyi',
             'triton/*.pyd',

--- a/jaxlib/tools/BUILD.bazel
+++ b/jaxlib/tools/BUILD.bazel
@@ -19,6 +19,9 @@ load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 load("@cuda_cudart//:version.bzl", cuda_major_version = "VERSION")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
 load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
+
+# TODO(Intel-tf): Update `sycl` with `oneapi` when xla changes to use `oneapi`.
+load("@local_config_sycl//sycl:build_defs.bzl", "if_sycl")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 load(
     "@xla//third_party/py:py_import.bzl",
@@ -328,6 +331,8 @@ wheel_sources(
     ]) + if_rocm([
         "//jax_plugins/rocm:rocm_plugin",
         "//jaxlib/rocm:rocm_gpu_support",
+    ]) + if_sycl([
+        "//jax_plugins/oneapi:oneapi_plugin",
     ]),
     py_srcs = [
         ":version",
@@ -346,6 +351,10 @@ wheel_sources(
         "//jax_plugins/rocm:pyproject.toml",
         "//jax_plugins/rocm:setup.py",
         "//jax_plugins/rocm:__init__.py",
+    ]) + if_sycl([
+        "//jax_plugins/oneapi:pyproject.toml",
+        "//jax_plugins/oneapi:setup.py",
+        "//jax_plugins/oneapi:__init__.py",
     ]),
 )
 
@@ -424,6 +433,26 @@ deploy_wheel(
 deploy_wheel(
     name = "deploy_rocm_pjrt_wheel",
     wheel = ":jax_rocm_pjrt_wheel",
+)
+
+jax_wheel(
+    name = "jax_oneapi_pjrt_wheel",
+    enable_oneapi = True,
+    no_abi = True,
+    platform_version = "2025.1",
+    source_files = [":jax_pjrt_sources"],
+    wheel_binary = ":build_gpu_plugin_wheel_tool",
+    wheel_name = "jax_oneapi2025_1_pjrt",
+)
+
+jax_wheel(
+    name = "jax_oneapi_pjrt_wheel_editable",
+    editable = True,
+    enable_oneapi = True,
+    platform_version = "2025.1",
+    source_files = [":jax_pjrt_sources"],
+    wheel_binary = ":build_gpu_plugin_wheel_tool",
+    wheel_name = "jax_oneapi2025_1_pjrt",
 )
 
 # Py_import targets.

--- a/jaxlib/tools/build_gpu_plugin_wheel.py
+++ b/jaxlib/tools/build_gpu_plugin_wheel.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Script that builds a jax cuda/rocm plugin wheel, intended to be run via bazel run
-# as part of the jax cuda/rocm plugin build process.
+# Script that builds a jax cuda/rocm/oneapi plugin wheel, intended to be run via bazel run
+# as part of the jax cuda/rocm/oneapi plugin build process.
 
 # Most users should not run this script directly; use build.py instead.
 
@@ -52,12 +52,12 @@ parser.add_argument(
     "--platform_version",
     default=None,
     required=True,
-    help="Target CUDA/ROCM version. Required.",
+    help="Target CUDA/ROCM/ONEAPI version. Required.",
 )
 parser.add_argument(
     "--editable",
     action="store_true",
-    help="Create an 'editable' jax cuda/rocm plugin build instead of a wheel.",
+    help="Create an 'editable' jax cuda/rocm/oneapi plugin build instead of a wheel.",
 )
 parser.add_argument(
     "--enable-cuda",
@@ -67,6 +67,10 @@ parser.add_argument(
     "--enable-rocm",
     default=False,
     help="Should we build with ROCM enabled?")
+parser.add_argument(
+    "--enable-oneapi",
+    default=False,
+    help="Should we build with ONEAPI enabled?")
 parser.add_argument(
     "--srcs", help="source files for the wheel", action="append"
 )
@@ -178,6 +182,45 @@ def prepare_rocm_plugin_wheel(
       dst_filename="xla_rocm_plugin.so",
   )
 
+def prepare_oneapi_plugin_wheel(
+    wheel_sources_path: pathlib.Path, *, cpu, oneapi_version, wheel_sources
+):
+  """Assembles a source tree for the ONEAPI wheel in `wheel_sources_path`."""
+  source_file_prefix = build_utils.get_source_file_prefix(wheel_sources)
+  wheel_sources_map = build_utils.create_wheel_sources_map(
+      wheel_sources, root_packages=["jax_plugins", "jaxlib"]
+  )
+  copy_files = functools.partial(
+      build_utils.copy_file,
+      runfiles=r,
+      wheel_sources_map=wheel_sources_map,
+  )
+
+  # Sanitize oneapi_version for directory names (replace dots with underscores)
+  sanitized_version = oneapi_version.replace(".", "_")
+  plugin_dir = wheel_sources_path / "jax_plugins" / f"xla_oneapi{sanitized_version}"
+  copy_files(
+      dst_dir=wheel_sources_path,
+        src_files=[
+          f"{source_file_prefix}jax_plugins/oneapi/pyproject.toml",
+          f"{source_file_prefix}jax_plugins/oneapi/setup.py",
+      ],
+  )
+  build_utils.update_setup_with_oneapi_version(wheel_sources_path, oneapi_version)
+  write_setup_cfg(wheel_sources_path, cpu)
+  copy_files(
+      dst_dir=plugin_dir,
+      src_files=[
+          f"{source_file_prefix}jax_plugins/oneapi/__init__.py",
+          f"{source_file_prefix}jaxlib/version.py",
+      ],
+  )
+  copy_files(
+      f"{source_file_prefix}jax_plugins/oneapi/pjrt_c_api_gpu_plugin.so",
+      dst_dir=plugin_dir,
+      dst_filename="xla_oneapi_plugin.so",
+  )
+
 
 tmpdir = None
 sources_path = args.sources_path
@@ -205,8 +248,16 @@ try:
         wheel_sources=args.srcs,
     )
     package_name = "jax rocm plugin"
+  elif args.enable_oneapi:
+    prepare_oneapi_plugin_wheel(
+        pathlib.Path(sources_path),
+        cpu=args.cpu,
+        oneapi_version=args.platform_version,
+        wheel_sources=args.srcs,
+    )
+    package_name = "jax oneapi plugin"
   else:
-    raise ValueError("Unsupported backend. Choose either 'cuda' or 'rocm'.")
+    raise ValueError("Unsupported backend. Choose either 'cuda' or 'rocm' or 'oneapi'.")
 
   if args.editable:
     build_utils.build_editable(sources_path, args.output_path, package_name)

--- a/jaxlib/tools/build_utils.py
+++ b/jaxlib/tools/build_utils.py
@@ -200,3 +200,15 @@ def update_setup_with_rocm_version(file_dir: pathlib.Path, rocm_version: str):
   )
   with open(src_file, "w") as f:
     f.write(content)
+
+def update_setup_with_oneapi_version(file_dir: pathlib.Path, oneapi_version: str):
+  src_file = file_dir / "setup.py"
+  with open(src_file) as f:
+    content = f.read()
+  # Sanitize oneapi_version to replace dots with underscores for package names
+  sanitized_version = oneapi_version.replace(".", "_")
+  content = content.replace(
+      "oneapi_version = 0  # placeholder", f"oneapi_version = '{sanitized_version}'"
+  )
+  with open(src_file, "w") as f:
+    f.write(content)

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -36,6 +36,9 @@ class DeviceTest(jtu.JaxTestCase):
           repr(device),
           'TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0)',
       )
+    elif jtu.test_device_matches(['oneapi']):
+      self.assertEqual(device.platform, 'oneapi')
+      self.assertEqual(repr(device), 'OneapiDevice(id=0)')
     elif jtu.test_device_matches(['cpu']):
       self.assertEqual(device.platform, 'cpu')
       self.assertEqual(repr(device), 'CpuDevice(id=0)')
@@ -49,6 +52,8 @@ class DeviceTest(jtu.JaxTestCase):
       self.assertEqual(str(device), 'rocm:0')
     elif jtu.test_device_matches(['tpu']):
       self.assertEqual(str(device), 'TPU_0(process=0,(0,0,0,0))')
+    elif jtu.test_device_matches(['oneapi']):
+      self.assertEqual(str(device), 'oneapi:0')
     elif jtu.test_device_matches(['cpu']):
       # TODO(phawkins): remove TFRT_CPU_0 once jaxlib 0.10 is the minimum
       # version.


### PR DESCRIPTION
**This PR introduces the OneAPI PJRT plugin, for Intel GPUs.**

- Adds the OneAPI plugin package under `jax_plugins/oneapi/` for plugin discovery and initialization.
- Adds `--config=oneapi` Bazel configuration in `.bazelrc` and registers the SYCL toolchain in `WORKSPACE`.
- Adds setup and runtime support for the OneAPI PJRT plugin.
- Adds build targets for the OneAPI PJRT plugin wheel in `jaxlib/tools/BUILD.bazel.`
- Adds `jax-oneapi-pjrt` wheel option in `build/build.py`.
- Updates `jaxlib/tools/build_gpu_plugin_wheel.py` assembly script to handle the OneAPI PJRT wheel.
- Updates `jax/_src/xla_bridge.py`: registers `"oneapi"` as an experimental plugin.
- Adds OneAPI device discovery test in `device_test.py.`

**Limitations**

- OneAPI PJRT plugin is experimental and does not implement every feature that JAX uses. Future PRs will add additional features.
- The XLA repository currently uses `sycl` as the internal platform identifier. These items in this PR will be updated to use `oneapi` instead of `sycl` in future revisions when XLA changes to use `oneapi`.


**Contributors**

@kranipa
@mini-goel

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->