### PR TITLE
[ROCm] Add jax[rocm-local] extra and relax plugin version check for post releases

### DIFF
--- a/build/rocm/README.md
+++ b/build/rocm/README.md
@@ -1,6 +1,28 @@
 # JAX on ROCm
 This directory provides setup instructions and necessary files to build, test, and run JAX with ROCm support in a Docker environment, suitable for both runtime and CI workflows. Explore the following methods to use or build JAX on ROCm!
 
+## 0. Install via `pip` (JAX extras)
+
+JAX supports ROCm via pip extras:
+
+```bash
+pip install --upgrade "jax[rocm7-local]"
+```
+
+### ROCm fixes via post-releases
+
+ROCm-specific fixes are shipped as *post-releases* of the ROCm plugin/PJRT
+packages (for example, `jax-rocm7-plugin==0.9.1.post1`). Upgrading
+`jax[rocm7-local]` will pick up the newest compatible post-release 
+available from your configured package indexes.
+
+### Important: ROCm must already be installed (for now)
+
+Until ROCm wheels are distributed via TheRock, the `jax[rocm7-local]` extra 
+installs the JAX ROCm plugin packages, but **do not install ROCm itself**. 
+You must run in an environment where ROCm is already installed (for example, 
+a ROCm Docker container).
+
 ## 1. Using Prebuilt Docker Images
 
 The ROCm JAX team provides prebuilt Docker images, which the simplest way to use JAX on ROCm. These images are available on Docker Hub and come with JAX configured for ROCm.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,10 @@ different builds for different operating systems and accelerators.
   ```
   pip install -U "jax[cuda13]"
   ```
+* **GPU (AMD, ROCm)**
+  ```
+  pip install -U "jax[rocm7-local]"
+  ```
 
 * **TPU (Google Cloud TPU VM)**
   ```
@@ -239,8 +243,20 @@ JAX is not supported on Mac/OSX GPU; instead use the standard {ref}`CPU installa
 
 AMD GPU support is provided by a ROCm JAX plugin supported by AMD.
 
-There are several ways to use JAX on AMDGPU devices.
-Please see [AMD's instructions](https://github.com/jax-ml/jax/blob/main/build/rocm/README.md) for details.
+### pip installation: AMD GPU (ROCm)
+
+JAX supports a ROCm install via:
+
+```bash
+pip install --upgrade "jax[rocm7-local]"
+```
+
+ROCm-specific fixes are shipped as *post-releases* of the ROCm plugin/PJRT
+packages (for example, `jax-rocm7-plugin==0.9.1.post1`). Upgrading
+`jax[rocm7-local]` will pick up the newest compatible post-release available from
+your configured package indexes.
+
+For prerequisites (ROCm/Docker), and for ROCm-specific extras such as `jax[rocm7-local]`, please see [AMD's Instructions](https://github.com/jax-ml/jax/blob/main/build/rocm/README.md) for details.
 
 **Note**: ROCm support on Windows WSL2 is experimental. For WSL installation, you may need to:
 1. Install [ROCm for WSL](https://rocm.docs.amd.com/projects/install-on-windows/en/latest/tutorial/quick-start.html) following AMD's official guide

--- a/setup.py
+++ b/setup.py
@@ -113,10 +113,13 @@ setup(
           f"jax-cuda13-plugin>={_current_jaxlib_version},<={_jax_version}",
         ],
 
-        # ROCm support for ROCm 7.0 and above.
-        'rocm': [
+        # Target that does not depend on ROCm runtime pip wheels, until
+        # ROCm wheels are distributed.
+        # TODO(gulsumgudukbay): add rocm and rocm8 extras once they are
+        # distributed.
+        'rocm7-local': [
           f"jaxlib>={_current_jaxlib_version},<={_jax_version}",
-          f"jax-rocm7-plugin>={_current_jaxlib_version},<={_jax_version}",
+          f"jax-rocm7-plugin=={_jax_version}.*",
         ],
 
         # For automatic bootstrapping distributed jobs in Kubernetes


### PR DESCRIPTION
# Description

- Add ROCm pip extras jax[rocm-local] and jax[rocm7-local]
- Relax ROCm plugin version constraint to allow same-version post-releases: jax-rocm7-plugin=={jax_version}.*.
- Update installation docs to reference rocm-local extras only.
- Document that ROCm-specific fixes ship as plugin/PJRT post-releases; remove index-url guidance.
- TODO: will add [rocm] extra in the future once we ship ROCm wheels. 

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->