### PR TITLE
Tracer is now generic parameterized by Trace

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -765,9 +765,9 @@ def check_avals_context_mesh(avals, prim_name):
 
 # -------------------- tracing --------------------
 
-TracerType = TypeVar('TracerType', bound='Tracer')
+TraceType = TypeVar('TraceType', bound='Trace')
 
-class Trace(Generic[TracerType]):
+class Trace:
   __slots__ = ("__weakref__", "_invalidated", "_weakref", "requires_low")
 
   def __init__(self):
@@ -900,12 +900,12 @@ else:
   TracerBase = object
   TracerMeta = type
 
-class Tracer(TracerBase, metaclass=TracerMeta):
+class Tracer(Generic[TraceType], TracerBase, metaclass=TracerMeta):
   __array_priority__ = 1000
   __slots__ = ['__weakref__', '_trace', '_line_info']
   __hash__ = None
 
-  _trace: Trace
+  _trace: TraceType
   _line_info: source_info_util.SourceInfo | None
 
   dtype = _aval_property('dtype')
@@ -913,7 +913,7 @@ class Tracer(TracerBase, metaclass=TracerMeta):
   size = _aval_property('size')
   shape = _aval_property('shape')
 
-  def __init__(self, trace: Trace):
+  def __init__(self, trace: TraceType):
     self._trace = trace
 
   def _error_repr(self):

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -140,7 +140,7 @@ def jvp_subtrace_aux(f, store, tag, primals, tangents):
     with core.set_current_trace(trace):
       ans, aux = f(*(map(partial(maybe_jvp_tracer, trace), primals, tangents)))
     out_primals, out_tangents = unzip2(map(trace.to_primal_tangent_pair, ans))
-    aux_primals = [x.primal if isinstance(x, JVPTracer) and x._trace.tag is tag  # pyrefly: ignore[missing-attribute]
+    aux_primals = [x.primal if isinstance(x, JVPTracer) and x._trace.tag is tag
                    else x for x in aux]
   store.store(aux_primals)
   return out_primals, out_tangents
@@ -251,7 +251,7 @@ def direct_linearize(traceable, primals, *, has_aux, is_vjp):
           source_info_util.transform_name_stack('jvp')):
       if has_aux:
         ans, aux = traceable.call_wrapped(*tracers)
-        aux = [x.primal if type(x) is LinearizeTracer and x._trace.tag is tag  # pyrefly: ignore[missing-attribute]
+        aux = [x.primal if type(x) is LinearizeTracer and x._trace.tag is tag
                else x for x in aux]
       else:
         ans = traceable.call_wrapped(*tracers)
@@ -559,7 +559,7 @@ class JVPTrace(Trace):
     self.requires_low = False
 
   def to_primal_tangent_pair(self, val):
-    if isinstance(val, JVPTracer) and val._trace.tag is self.tag:  # pyrefly: ignore[missing-attribute]
+    if isinstance(val, JVPTracer) and val._trace.tag is self.tag:
       return (val.primal, val.tangent)
     else:
       tangent_zero = p2tz(val)
@@ -715,7 +715,7 @@ def maybe_jvp_tracer(trace, primal, tangent):
   else:
     return JVPTracer(trace, primal, tangent)
 
-class JVPTracer(Tracer):
+class JVPTracer(Tracer[JVPTrace]):
   __slots__ = ['primal', 'tangent']
 
   def __init__(self, trace, primal, tangent):
@@ -795,13 +795,14 @@ class LinearizeTrace(Trace):
 
   @property
   def tag(self) -> core.TraceTag:
-    return self.tangent_trace.tag  # pyrefly: ignore[missing-attribute]
+    assert hasattr(self.tangent_trace, "tag")
+    return self.tangent_trace.tag
 
   def _name_stack_suffix(self):
     return source_info_util.current_name_stack()[self._name_stack_prefix_len:]
 
   def to_primal_tangent_pair(self, val):
-    if isinstance(val, LinearizeTracer) and val._trace.tag is self.tag:  # pyrefly: ignore[missing-attribute]
+    if isinstance(val, LinearizeTracer) and val._trace.tag is self.tag:
       return (val.primal, val.tangent)
     else:
       tangent_zero = p2tz(val)
@@ -1082,7 +1083,7 @@ def linearize_from_jvp(jvp: lu.WrappedFun,
     out_nz, = out_nzs
     return out_primal, out_nz, out_consts, linearized
 
-class LinearizeTracer(Tracer):
+class LinearizeTracer(Tracer[LinearizeTrace]):
   __slots__ = ['primal', 'tangent']
 
   def __init__(self, trace, primal, tangent):

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -130,10 +130,10 @@ NotMapped = type(None)
 not_mapped = None
 
 
-class BatchTracer(Tracer):
+class BatchTracer(Tracer['BatchTrace']):
   __slots__ = ['val', 'batch_dim', 'source_info']
 
-  _trace: BatchTrace  # pyrefly: ignore[bad-override]
+  _trace: BatchTrace
 
   def __init__(self, trace: BatchTrace, val, batch_dim: NotMapped | int,
                source_info: source_info_util.SourceInfo | None = None):

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -116,7 +116,7 @@ class EffectHandle:
   parents : list[Tracer]
   recipe : JaxprEqnRecipe
 
-class JaxprTrace(Trace['JaxprTracer']):
+class JaxprTrace(Trace):
 
   def __init__(self, parent_trace:Trace, name_stack: source_info_util.NameStack, tag:TraceTag):
     super().__init__()
@@ -483,10 +483,10 @@ JaxprTracerRecipe = Union[
     'JaxprEqnRecipe', 'LambdaBinding', 'FreeVar', 'ConstVar', Literal,
 ]
 
-class JaxprTracer(Tracer):
+class JaxprTracer(Tracer[JaxprTrace]):
   __slots__ = ['pval', 'recipe']
 
-  _trace: JaxprTrace  # pyrefly: ignore[bad-override]
+  _trace: JaxprTrace
 
   def __init__(self, trace: JaxprTrace, pval: PartialVal,
                recipe: JaxprTracerRecipe | None):
@@ -1601,10 +1601,10 @@ def move_binders_to_back(closed_jaxpr: ClosedJaxpr, to_move: Sequence[bool]
   return move_binders_to_front(closed_jaxpr, map(op.not_, to_move))
 
 
-class DynamicJaxprTracer(core.Tracer):
+class DynamicJaxprTracer(core.Tracer['DynamicJaxprTrace']):
   __slots__ = ['_aval', 'val', 'mutable_qdd', 'parent', '_debug_info']
 
-  _trace: DynamicJaxprTrace  # pyrefly: ignore[bad-override]
+  _trace: DynamicJaxprTrace
 
   def __init__(self, trace: DynamicJaxprTrace,
                aval: core.AbstractValue | core.AvalQDD,

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -593,7 +593,7 @@ def _moveaxis(ndim: int, shard_axes: dict[core.AxisName, int],
   lst.insert(dst - (src < dst), name)
   return {name: i for i, name in enumerate(lst) if name is not None}
 
-class MapTracer(core.Tracer):
+class MapTracer(core.Tracer[MapTrace]):
   __slots__ = ["val", "shard_axes"]
 
   def __init__(self, trace: MapTrace, val, shard_axes: dict[core.AxisName, int]):

--- a/jax/_src/interpreters/remat.py
+++ b/jax/_src/interpreters/remat.py
@@ -58,8 +58,8 @@ def remat_transform(policy, f, *args):
     return tree_unflatten(out_tree, out_flat)
   return out_ft.unflatten(), Partial(f_rem, map(reduce_precision, rs))
 
-class RematTracer(core.Tracer):
-  _trace: RematTrace  # pyrefly: ignore[bad-override]
+class RematTracer(core.Tracer['RematTrace']):
+  _trace: RematTrace
 
   def __init__(self, trace, x, jaxpr_tracer):
     self._trace = trace  # pytype: disable=name-error

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -1401,7 +1401,7 @@ class ShardMapTrace(core.Trace):
     return map(partial(ShardMapTracer, self), out_vma, out_vals)
 
 
-class ShardMapTracer(core.Tracer):
+class ShardMapTracer(core.Tracer[ShardMapTrace]):
   vma: frozenset[AxisName]
   val: JaxType
 
@@ -1416,24 +1416,24 @@ class ShardMapTracer(core.Tracer):
   @property
   def aval(self):
     aval = core.typeof(self.val)
-    vma = self.vma if self._trace.check else self._trace.manual_axes  # pyrefly: ignore[missing-attribute]
-    size = prod(self._trace.mesh.shape[n] for n in vma)  # pyrefly: ignore[missing-attribute]
+    vma = self.vma if self._trace.check else self._trace.manual_axes
+    size = prod(self._trace.mesh.shape[n] for n in vma)
     out = core.mapped_aval(size, 0, aval)
     new_sharding = NamedSharding(
-        _as_manual_mesh(self._trace.amesh, self._trace.manual_axes),  # pyrefly: ignore[missing-attribute]
+        _as_manual_mesh(self._trace.amesh, self._trace.manual_axes),
         out.sharding.spec)  # type: ignore[missing-attribute]
     vma = self.vma if config._check_vma.value else frozenset()
     return out.update(sharding=new_sharding, vma=vma)
 
   def to_concrete_value(self):
-    if self._trace.check and self.vma == frozenset():  # pyrefly: ignore[missing-attribute]
-      with core.eval_context(), use_abstract_mesh(self._trace.amesh):  # pyrefly: ignore[missing-attribute]
+    if self._trace.check and self.vma == frozenset():
+      with core.eval_context(), use_abstract_mesh(self._trace.amesh):
         return core.to_concrete_value(self.val[0])
     else:
       return None
 
   def __str__(self) -> str:
-    pb_names = set(self._trace.mesh.axis_names) - self.vma  # pyrefly: ignore[missing-attribute]
+    pb_names = set(self._trace.mesh.axis_names) - self.vma
     self = pvary(self, tuple(pb_names))
     with core.eval_context(), use_abstract_mesh(self._trace.amesh):
       blocks = list(self.val)

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -200,7 +200,7 @@ def traceable(f, store, in_tree_def, *primals_and_series):
   return out_flat
 
 
-class JetTracer(core.Tracer):
+class JetTracer(core.Tracer['JetTrace']):
   __slots__ = ["primal", "terms"]
 
   def __init__(self, trace, primal, terms):
@@ -229,7 +229,7 @@ class JetTrace(core.Trace):
     self.order = order
 
   def to_primal_terms_pair(self, val):
-    if isinstance(val, JetTracer) and val._trace.tag is self.tag:  # pyrefly: ignore[missing-attribute]
+    if isinstance(val, JetTracer) and val._trace.tag is self.tag:
       return val.primal, val.terms
     else:
       return val, zero_series

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -279,8 +279,8 @@ def spvalues_to_avals(
 # ------------------------------------------------------------------------------
 # Implementation of sparsify() using tracers.
 
-class SparseTracer(core.Tracer):
-  def __init__(self, trace: core.Trace, *, spvalue):
+class SparseTracer(core.Tracer['SparseTrace']):
+  def __init__(self, trace: SparseTrace, *, spvalue):
     self._spvalue = spvalue
     self._trace = trace
 


### PR DESCRIPTION
Specializing the type of `Tracer._trace` propagates more accurate type annotations, allowing us to clean up some `ignore` comments.