### PR TITLE
[export] Remove code to serialize HloSharding

### DIFF
--- a/docs/export/export.md
+++ b/docs/export/export.md
@@ -364,8 +364,8 @@ devices in the mesh are ignored for tracing and lowering:
 
 >>> # and it knows the shardings for the inputs. These will be applied
 >>> # when the exported is called.
->>> exp.in_shardings_hlo
-({devices=[4]<=[4]},)
+>>> exp.in_shardings_jax(export_mesh)
+(NamedSharding(mesh=AbstractMesh('a': 4, axis_types=(Auto,)), spec=P('a',)),)
 
 >>> # You can also use a concrete set of devices for exporting
 >>> concrete_devices = jax.local_devices()[:4]
@@ -374,14 +374,11 @@ devices in the mesh are ignored for tracing and lowering:
 ...    jax.ShapeDtypeStruct((32,), dtype=np.int32,
 ...                         sharding=NamedSharding(concrete_mesh, P("a"))))
 
->>> # You can expect the same results
->>> assert exp.in_shardings_hlo == exp2.in_shardings_hlo
-
 >>> # When you call an Exported, you must use a concrete set of devices
->>> arg = jnp.arange(8 * 4)
->>> res1 = exp.call(jax.device_put(arg,
-...                                NamedSharding(concrete_mesh, P("a"))))
+>>> arg = jax.device_put(jnp.arange(8 * 4),
+...                      NamedSharding(concrete_mesh, P("a")))
 
+>>> res1 = exp.call(arg)
 >>> # Check out the first 2 shards of the result
 >>> [f"device={s.device} index={s.index}" for s in res1.addressable_shards[:2]]
 ['device=TFRT_CPU_0 index=(slice(0, 8, None),)',
@@ -461,7 +458,6 @@ As a special facility, if a function was exported for 1 device and if it contain
 sharding annotations, then it can be invoked on an argument of the same shape but sharded
 on multiple devices, and the compiler will shard the function appropriately:
 
-```python
 ```python
 >>> import jax
 >>> from jax import export

--- a/jax/_src/export/_export.py
+++ b/jax/_src/export/_export.py
@@ -147,13 +147,15 @@ class Exported:
         sharding.
         See https://docs.jax.dev/en/latest/notebooks/explicit-sharding.html#concrete-array-shardings-can-mention-auto-mesh-axis
         for more details.
-    in_shardings_hlo: the flattened input shardings, a sequence as long
+    in_shardings_hlo: (Not used for exports created after 3/17/2026.) the
+        flattened input shardings, a sequence as long
         as ``in_avals``. ``None`` means unspecified sharding.
         Note that these do not include the mesh or the actual devices used in
         the mesh, and in general you should avoid using this field directly.
         See ``in_shardings_jax`` for a way to turn these
         into sharding specification that can be used with JAX APIs.
-    out_shardings_hlo: the flattened output shardings, a sequence as long
+    out_shardings_hlo: (Not used for exports created after 3/17/2026.) the
+        flattened output shardings, a sequence as long
         as ``out_avals``. ``None`` means unspecified sharding.
         Note that these do not include the mesh or the actual devices used in
         the mesh, and in general you should avoid using this field directly.
@@ -210,8 +212,8 @@ class Exported:
   _has_named_shardings: bool
   _in_named_shardings: tuple[NamedSharding | None, ...]  # all None if not _has_named_shardings
   _out_named_shardings: tuple[NamedSharding | None, ...]  # all None if not _has_named_shardings
-  in_shardings_hlo: tuple[HloSharding | None, ...]
-  out_shardings_hlo: tuple[HloSharding | None, ...]
+  in_shardings_hlo: tuple[HloSharding | None, ...]  # all None for exports created after 3/17/2026
+  out_shardings_hlo: tuple[HloSharding | None, ...]  # all None for exports created after 3/17/2026
 
   nr_devices: int
   platforms: tuple[str, ...]
@@ -254,8 +256,8 @@ class Exported:
       >>> exp = export.export(jax.jit(lambda x: jax.numpy.add(x, x),
       ...                             in_shardings=sharding.NamedSharding(exp_mesh, sharding.PartitionSpec("a")))
       ...     )(np.arange(jax.device_count()))
-      >>> exp.in_shardings_hlo
-      ({devices=[8]<=[8]},)
+      >>> exp.in_shardings_jax(exp_mesh)
+      (NamedSharding(mesh=Mesh('a': 8, axis_types=(Auto,)), spec=P('a',), memory_kind=device),)
       >>> # Create a mesh for running the exported object
       >>> run_mesh = sharding.Mesh(jax.devices()[::-1], ("a",))
       >>> # Put the args and kwargs on the appropriate devices
@@ -717,6 +719,9 @@ def to_named_sharding_with_abstract_mesh(
 
   assert False, f"Unsupported sharding: {s}"
 
+
+# TODO(b/489569164): move to jax2tf 6 months after 1/15/2026,
+# when we don't need to support HloSharding in the serialized exports.
 def named_to_hlo_sharding(s: NamedSharding | None,
                           aval: core.ShapedArray) -> HloSharding | None:
   if s is None: return None
@@ -839,14 +844,14 @@ def _export_lowered(
     # the VJP. Note that jaxpr_as_fun produces a function with flat arguments
     assert(jaxpr is not None)  # None only when the lowered was created outside JAX
     fun_jax = core.jaxpr_as_fun(jaxpr)
-
+    assert exp_primal._has_named_shardings
     fun_vjp_jax, vjp_in_avals = _get_vjp_fun(
         fun_jax,
         in_tree=exp_primal.in_tree,
         in_avals=exp_primal.in_avals,
-        has_named_shardings=exp_primal._has_named_shardings,
-        in_shardings_hlo=exp_primal.in_shardings_hlo,
-        out_shardings_hlo=exp_primal.out_shardings_hlo,
+        has_named_shardings=True,
+        in_shardings_hlo=(None,) * len(exp_primal._in_named_shardings),
+        out_shardings_hlo=(None,) * len(exp_primal._out_named_shardings),
         in_named_shardings=exp_primal._in_named_shardings,
         out_named_shardings=exp_primal._out_named_shardings,
         out_avals=exp_primal.out_avals,
@@ -867,10 +872,8 @@ def _export_lowered(
       _has_named_shardings=True,
       _in_named_shardings=in_named_shardings,
       _out_named_shardings=out_named_shardings,
-      in_shardings_hlo=tuple(named_to_hlo_sharding(s, aval)
-                             for s, aval in zip(in_named_shardings, args_avals_flat)),
-      out_shardings_hlo=tuple(named_to_hlo_sharding(s, aval)
-                              for s, aval in zip(out_named_shardings, out_avals_flat)),
+      in_shardings_hlo=(None,) * len(in_named_shardings),
+      out_shardings_hlo=(None,) * len(out_named_shardings),
 
       nr_devices=nr_devices,
       platforms=lowering._platforms,  # type: ignore

--- a/jax/_src/export/serialization.fbs
+++ b/jax/_src/export/serialization.fbs
@@ -135,6 +135,7 @@ table AbstractValue {
   memory_space: MemorySpace;
 }
 
+// Deprecated 3/17/2026
 enum ShardingKind: byte {
   unspecified = 0,
   hlo_sharding = 1,
@@ -142,9 +143,9 @@ enum ShardingKind: byte {
 }
 
 table Sharding {
-  kind: ShardingKind;
-  hlo_sharding_proto: [byte];  // if kind == hlo_sharding
-  named_sharding: NamedSharding;  // if kind == named_sharding; added 1/15/2026
+  kind: ShardingKind;  // Deprecated 3/17/2026
+  hlo_sharding_proto: [byte];  // unused for exports created after 3/17/2026
+  named_sharding: NamedSharding;  // added 1/15/2026
 }
 
 table Effect {

--- a/jax/_src/export/serialization.py
+++ b/jax/_src/export/serialization.py
@@ -59,11 +59,15 @@ SerT = TypeVar("SerT")
 #   This version is backwards compatible with Version 2 to 4.
 # Version 6, January 15th, 2026, adds serialization for sharding as
 #   NamedSharding, including the abstract mesh, and the partition spec.
+#   Contains also HloSharding serialization, for forward compatibility.
 #   This version is backwards compatible with Version 2 to 5.
 # Version 7 was briefly live but pulled back due to breaking compatiblity.
-# Version 8, March 12th, 2026, add serializatoon for AbstractMesh.abstract_device.
+# Version 8, March 12th, 2026, add serializaton for AbstractMesh.abstract_device.
 #   This version is backwards compatible with Version 2 to 7.
-_SERIALIZATION_VERSION = 8
+# Version 9, March 17th, 2026, removes HloSharding serialization.
+#   This is another attempt at what Version 7 was supposed to be.
+#   This version is backwards compatible with Version 2 to 8.
+_SERIALIZATION_VERSION = 9
 
 def serialize(exp: _export.Exported, vjp_order: int = 0) -> bytearray:
   """Serializes an Exported.
@@ -90,23 +94,19 @@ def deserialize(ser: bytearray) -> _export.Exported:
 def _serialize_exported(
     builder: flatbuffers.Builder, exp: _export.Exported, vjp_order: int
 ) -> int:
+  if not exp._has_named_shardings:
+    raise ValueError(
+      "Exported being serialized must have named shardings after 3/17/2026.")
   # Serialize bottom-up
   fun_name = builder.CreateString(exp.fun_name)
   in_tree = _serialize_pytreedef(builder, exp.in_tree)
   in_avals = _serialize_array(builder, _serialize_aval, exp.in_avals)
   out_tree = _serialize_pytreedef(builder, exp.out_tree)
   out_avals = _serialize_array(builder, _serialize_aval, exp.out_avals)
-  # TODO(necula): For 30 days after 1/15/2026 we must serialize the HLO
-  # shardings. After that we can error out when serialized Exported with not
-  # _has_named_shardings.
   in_shardings = _serialize_array(
-      builder, partial(_serialize_sharding, has_named_sharding=exp._has_named_shardings),
-      zip(exp._in_named_shardings, exp.in_shardings_hlo)
-  )
+      builder, _serialize_sharding, exp._in_named_shardings)
   out_shardings = _serialize_array(
-      builder, partial(_serialize_sharding, has_named_sharding=exp._has_named_shardings),
-      zip(exp._out_named_shardings, exp.out_shardings_hlo)
-  )
+      builder, _serialize_sharding, exp._out_named_shardings)
   ordered_effects = _serialize_array(
       builder, _serialize_effect, exp.ordered_effects
   )
@@ -199,7 +199,8 @@ def _deserialize_exported(exp: ser_flatbuf.Exported) -> _export.Exported:
   out_shardings = _deserialize_tuple(
       exp.OutShardingsLength, exp.OutShardings, _deserialize_sharding
   )
-  # has_named_sharding will be True for all exports after 1/15/2026
+  # has_named_sharding will be True for all exports created after 1/15/2026
+  # TODO(b/489569164): remove has_named_sharding 6 months after 1/15/2026
   has_named_shardings = not any(isinstance(s, _export.HloSharding)
                                 for s in itertools.chain(in_shardings, out_shardings))
   if has_named_shardings:
@@ -625,33 +626,13 @@ def _deserialize_aval(aval: ser_flatbuf.AbstractValue, *,
 
 
 def _serialize_sharding(
-    builder: flatbuffers.Builder, s: tuple[_export.NamedSharding | None, _export.HloSharding | None],
-    has_named_sharding: bool,
-) -> int:
-  named_s, hlo_s = s
-  is_unspecified = (named_s is None) if has_named_sharding else (hlo_s is None)
+    builder: flatbuffers.Builder, s: _export.NamedSharding | None) -> int:
   named_sharding = None
-  hlo_sharding = None
-  if is_unspecified:
-    kind = ser_flatbuf.ShardingKind.unspecified
-  else:
-    # TODO(necula): We must use the hlo_sharding kind for at least 30 days after
-    # 1/15/2026 because old deserializers check the kind and abort if they
-    # do not recognize it. After that date, we can stop using the kind.
-    kind = ser_flatbuf.ShardingKind.hlo_sharding
 
-  if has_named_sharding and named_s is not None:
-    named_sharding = _serialize_named_sharding(builder, named_s)
-
-  # TODO(necula): We must serialize the hlo_sharding for at least 30 days after
-  # 1/15/2026 because old deserializers can only deserialize this sharding.
-  if hlo_s is not None:
-    hlo_sharding = builder.CreateByteVector(hlo_s.to_proto().SerializeToString())
+  if s is not None:
+    named_sharding = _serialize_named_sharding(builder, s)
 
   ser_flatbuf.ShardingStart(builder)
-  ser_flatbuf.ShardingAddKind(builder, kind)
-  if hlo_sharding is not None:
-    ser_flatbuf.ShardingAddHloShardingProto(builder, hlo_sharding)
   if named_sharding is not None:
     ser_flatbuf.ShardingAddNamedSharding(builder, named_sharding)
   return ser_flatbuf.ShardingEnd(builder)
@@ -662,7 +643,7 @@ def _deserialize_sharding(s: ser_flatbuf.Sharding) -> _export.HloSharding | name
     # After 1/15/26 all exports will have named shardings (or None)
     return _deserialize_named_sharding(named_sharding_off)
 
-  # TODO(necula): We must keep reading the HloSharding for 6 months after 1/15/2026.
+  # TODO(b/489569164): We must keep reading the HloSharding for 6 months after 1/15/2026.
   if not s.HloShardingProtoIsNone():
     proto = xla_client.OpSharding()
     proto.ParseFromString(s.HloShardingProtoAsNumpy().tobytes())


### PR DESCRIPTION
This creates the export serialization version 9, removing from the serialized exports the fields `in_hlo_shardings` and `out_hlo_shardings`. On 1/15/2026 we have added the fields `in_named_shardings` and `out_named_shardings` to the serialization and since the 30-day forward compatibility window has passed we can assume that all readers of exports will now be able to operate with the named shardings.

Note that we need to still keep the support for `in_hlo_shardings` and `out_hlo_shardings` when **deserializing** old exports, until 6 months after 1/15/2026. But at least we can avoid constructing the HloShardings when creating and serializing exports.

I have added new versions for the export_serialization_back_compat_test.py.

This is another attempt at landing #35557, which had to be rolled back due to compatibility failures.
