### PR TITLE
Fix the memory space for gradients when parameters are offloaded.

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2326,14 +2326,14 @@ class ShapedArray(AbstractValue):
     return ShapedArray(
         self.shape, primal_dtype_to_tangent_dtype(self.dtype),
         self.weak_type, sharding=self.sharding, vma=self.vma,
-        memory_space=self.memory_space)
+        memory_space=MemorySpace.Device)
 
   def to_ct_aval(self):
     dtype = primal_dtype_to_tangent_dtype(self.dtype)
     sharding = primal_sharding_to_cotangent_sharding(self.sharding)
     return ShapedArray(
         self.shape, dtype, self.weak_type, sharding=sharding, vma=self.vma,
-        memory_space=self.memory_space)
+        memory_space=MemorySpace.Device)
 
   def str_short(self, short_dtypes=False, mesh_axis_types=False):
     return str_short_aval(

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -369,6 +369,18 @@ class CoreTest(jtu.JaxTestCase):
                             memory_space=jax.memory.Space.Device)
     self.assertEqual(aval.str_short(True), "f32[8]")
 
+  def test_grad_memory_space_is_device(self):
+    # Gradients should always be on device, even when parameters carry a
+    # pinned_host memory space (e.g. parameter_memory_host_offload=True
+    # in MaxText).
+    # to_tangent_aval / to_ct_aval must not propagate the host memory space.
+    host_aval = core.ShapedArray((4,), jnp.float32,
+                                 memory_space=jax.memory.Space.Host)
+    self.assertEqual(host_aval.to_tangent_aval().memory_space,
+                     jax.memory.Space.Device)
+    self.assertEqual(host_aval.to_ct_aval().memory_space,
+                     jax.memory.Space.Device)
+
   def test_dropvar_avals(self):
     def f(x):
       def body(c, _):


### PR DESCRIPTION
When parameter_memory_host_offload=True in MaxText, parameters carry a pinned_host memory space in their JAX abstract values. JAX's AD machinery propagates this host memory space to gradients via to_tangent_aval / to_ct_aval where both functions pass memory_space=self.memory_space to the returned ShapedArray. It causes a ValueError when gradient clipping computes the global norm. The add in jnp.sqrt(sum(g\*\*2 for g in grads)) receives a mix of pinned_host gradients (from host-offloaded parameters) and device gradients, resulting in mismatched memory spaces.

This commit forces to return the ShapedArray with the explicit device memory space.