### PR TITLE
[ROCm] Enable hipBLASLt in ROCm pytest CI

### DIFF
--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -101,7 +101,10 @@ echo "Final number of processes to run: $num_processes"
 export JAX_ENABLE_ROCM_XDIST="$gpu_count"
 export XLA_PYTHON_CLIENT_ALLOCATOR=platform
 export XLA_PYTHON_CLIENT_PREALLOCATE=false
-export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1 --xla_gpu_enable_nccl_comm_splitting=false --xla_gpu_enable_command_buffer="
+export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1 \
+    --xla_gpu_enable_nccl_comm_splitting=false \
+    --xla_gpu_enable_command_buffer= \
+    --xla_gpu_enable_cublaslt=true"
 
 # ==============================================================================
 # Run tests


### PR DESCRIPTION
- Add --xla_gpu_enable_cublaslt=true to XLA_FLAGS in run_pytest_rocm.sh
- TF32 GEMM support on ROCm requires hipBLASLt (cuBLASLt path), without this flag the autotuner fails for TF32 dot algorithms

