### PR TITLE
Add memory-efficient fused linear cross-entropy loss (solves issue #35906)

### DIFF
--- a/jax/experimental/fused_linear_cross_entropy.py
+++ b/jax/experimental/fused_linear_cross_entropy.py
@@ -1,0 +1,261 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Memory-efficient fused linear cross-entropy loss.
+
+Implements the algorithm from "Cut Your Losses in Large-Vocabulary Language
+Models" (https://arxiv.org/abs/2411.09009), which avoids materializing the
+full [N, V] logits matrix by processing the vocabulary in chunks via
+``lax.scan``.
+
+Typical LLM training:
+
+  logits = hidden @ weight.T   # shape [N, V] — multi-GB for 128K+ vocab
+  loss   = cross_entropy(logits, labels)
+
+This module replaces those two steps with a single call that never allocates
+the [N, V] tensor.  Memory complexity is O(N·D + V·D) instead of O(N·V).
+"""
+from __future__ import annotations
+
+import functools
+from typing import Callable
+
+import jax
+from jax import lax
+import jax.numpy as jnp
+
+
+def fused_linear_cross_entropy_loss(
+    x: jax.Array,
+    w: jax.Array,
+    labels: jax.Array,
+    *,
+    chunk_size: int = 4096,
+) -> jax.Array:
+  """Memory-efficient fused linear + cross-entropy loss.
+
+  Computes ``mean(cross_entropy(x @ w.T, labels))`` without materializing the
+  full ``[N, V]`` logits matrix.  The vocabulary dimension is processed in
+  chunks of size *chunk_size* using ``lax.scan``, so peak memory usage is
+  proportional to ``chunk_size`` rather than to ``V``.
+
+  The backward pass is implemented via ``jax.custom_vjp``.  Only ``x``, ``w``
+  and the per-sample log-sum-exp vector (shape ``[N]``) are saved as
+  residuals; the full logits are recomputed chunk by chunk during the backward
+  pass.
+
+  Compatible with ``jax.jit``, ``jax.grad``, and ``jax.value_and_grad``.
+  Both ``float32`` and ``bfloat16`` inputs are supported; internal
+  accumulation is always performed in ``float32``.
+
+  Args:
+    x: Input activations, shape ``[N, D]``.
+    w: Vocabulary weight matrix, shape ``[V, D]``.
+    labels: Integer class labels in ``[0, V)``, shape ``[N]``.
+    chunk_size: Number of vocabulary entries processed per scan step.
+      Must be a positive Python ``int``.  Larger values trade memory for
+      fewer kernel launches; defaults to ``4096``.
+
+  Returns:
+    Scalar mean cross-entropy loss.  The dtype matches ``float32``
+    regardless of the input dtype (consistent with numerically-stable loss
+    computations in mixed-precision training).
+
+  References:
+    "Cut Your Losses in Large-Vocabulary Language Models",
+    arxiv.org/abs/2411.09009
+  """
+  if chunk_size <= 0:
+    raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+  return _fused_linear_cross_entropy(x, w, labels, chunk_size)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _pad_w(w: jax.Array, chunk_size: int) -> tuple[jax.Array, int, int]:
+  """Return (w_padded, num_chunks, padded_V).
+
+  w_padded is reshaped to [num_chunks, chunk_size, D].
+  Padding rows are zero so they contribute nothing to dot products.
+  """
+  V, D = w.shape
+  num_chunks = (V + chunk_size - 1) // chunk_size
+  padded_V = num_chunks * chunk_size
+  if padded_V > V:
+    w = jnp.concatenate(
+        [w, jnp.zeros((padded_V - V, D), dtype=w.dtype)], axis=0
+    )
+  return w.reshape(num_chunks, chunk_size, D), num_chunks, padded_V
+
+
+def _valid_mask(V: int, num_chunks: int, chunk_size: int) -> jax.Array:
+  """Boolean mask [num_chunks, chunk_size]: True for real vocab entries."""
+  return jnp.arange(num_chunks * chunk_size).reshape(num_chunks, chunk_size) < V
+
+
+def _compute_lse(
+    x: jax.Array, w: jax.Array, chunk_size: int
+) -> jax.Array:
+  """Compute log-sum-exp of ``x @ w.T`` via online softmax.
+
+  Returns shape ``[N]`` float32, without ever allocating ``[N, V]``.
+  """
+  N = x.shape[0]
+  V = w.shape[0]
+  w_chunks, num_chunks, _ = _pad_w(w, chunk_size)
+  mask = _valid_mask(V, num_chunks, chunk_size)  # [num_chunks, chunk_size]
+
+  x_f32 = x.astype(jnp.float32)
+  w_chunks_f32 = w_chunks.astype(jnp.float32)
+
+  def scan_fn(
+      carry: tuple[jax.Array, jax.Array],
+      inputs: tuple[jax.Array, jax.Array],
+  ) -> tuple[tuple[jax.Array, jax.Array], None]:
+    running_max, running_sum_exp = carry  # both [N]
+    chunk_w, chunk_mask = inputs          # [C, D], [C]
+
+    logits_chunk = x_f32 @ chunk_w.T     # [N, C]
+    # Mask padding to -inf so padded positions don't affect the max or sum.
+    logits_chunk = jnp.where(chunk_mask[None, :], logits_chunk, -jnp.inf)
+
+    chunk_max = jnp.max(logits_chunk, axis=-1)  # [N]
+    new_max = jnp.maximum(running_max, chunk_max)  # [N]
+
+    # Rescale accumulated sum to the new max, then add current chunk.
+    rescale = jnp.exp(running_max - new_max)       # [N]  (0 when running_max=-inf)
+    exp_chunk = jnp.where(
+        chunk_mask[None, :],
+        jnp.exp(logits_chunk - new_max[:, None]),
+        0.0,
+    )  # [N, C]
+    new_sum_exp = running_sum_exp * rescale + jnp.sum(exp_chunk, axis=-1)
+
+    return (new_max, new_sum_exp), None
+
+  init = (
+      jnp.full((N,), -jnp.inf, dtype=jnp.float32),
+      jnp.zeros((N,), dtype=jnp.float32),
+  )
+  (final_max, final_sum_exp), _ = lax.scan(
+      scan_fn, init, (w_chunks_f32, mask)
+  )
+  return final_max + jnp.log(final_sum_exp)  # [N]
+
+
+# ---------------------------------------------------------------------------
+# custom_vjp implementation
+# ---------------------------------------------------------------------------
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=(3,))
+def _fused_linear_cross_entropy(
+    x: jax.Array,
+    w: jax.Array,
+    labels: jax.Array,
+    chunk_size: int,
+) -> jax.Array:
+  """Primal: used when gradients are not required."""
+  lse = _compute_lse(x, w, chunk_size)
+  target_logit = jnp.sum(
+      x.astype(jnp.float32) * w[labels].astype(jnp.float32), axis=-1
+  )  # [N]
+  return jnp.mean(-target_logit + lse)
+
+
+def _fused_linear_cross_entropy_fwd(
+    x: jax.Array,
+    w: jax.Array,
+    labels: jax.Array,
+    chunk_size: int,
+) -> tuple[jax.Array, tuple]:
+  """Forward pass: same output as primal, plus residuals for backward."""
+  lse = _compute_lse(x, w, chunk_size)
+  target_logit = jnp.sum(
+      x.astype(jnp.float32) * w[labels].astype(jnp.float32), axis=-1
+  )
+  loss = jnp.mean(-target_logit + lse)
+  # Save only x, w, labels, lse — never the full [N, V] logits.
+  return loss, (x, w, labels, lse)
+
+
+def _fused_linear_cross_entropy_bwd(
+    chunk_size: int,
+    residuals: tuple,
+    g: jax.Array,
+) -> tuple[jax.Array, jax.Array, None]:
+  """Backward pass: chunked recomputation of logits, no [N, V] allocation."""
+  x, w, labels, lse = residuals
+  N, D = x.shape
+  V = w.shape[0]
+
+  w_chunks, num_chunks, padded_V = _pad_w(w, chunk_size)
+  mask = _valid_mask(V, num_chunks, chunk_size)         # [num_chunks, chunk_size]
+  chunk_starts = jnp.arange(num_chunks, dtype=labels.dtype) * chunk_size
+
+  x_f32 = x.astype(jnp.float32)
+  w_chunks_f32 = w_chunks.astype(jnp.float32)
+  lse_f32 = lse.astype(jnp.float32)
+  # Scale by upstream gradient and 1/N (gradient through jnp.mean).
+  g_scale = g.astype(jnp.float32) / N  # scalar
+
+  def bwd_chunk(
+      dx_acc: jax.Array,
+      inputs: tuple[jax.Array, jax.Array, jax.Array],
+  ) -> tuple[jax.Array, jax.Array]:
+    chunk_w, chunk_start, chunk_mask = inputs  # [C, D], [], [C]
+
+    # Recompute softmax for this vocab chunk — O(N*C) not O(N*V).
+    logits_chunk = x_f32 @ chunk_w.T            # [N, C]
+    softmax_chunk = jnp.exp(logits_chunk - lse_f32[:, None])  # [N, C]
+    # Zero out padded positions (their w rows are zero, giving logit=0, but
+    # exp(0 - lse) is nonzero so we must mask explicitly).
+    softmax_chunk = jnp.where(chunk_mask[None, :], softmax_chunk, 0.0)
+
+    # Build sparse one-hot for labels that fall within [chunk_start, chunk_start+C).
+    local_idx = labels - chunk_start            # [N]  (may be negative/out-of-range)
+    in_chunk = (local_idx >= 0) & (local_idx < chunk_size)  # [N]
+    safe_idx = jnp.where(in_chunk, local_idx, 0)            # [N]  safe for gather
+
+    one_hot = (
+        (jnp.arange(chunk_size, dtype=labels.dtype)[None, :] == safe_idx[:, None])
+        & in_chunk[:, None]
+    ).astype(jnp.float32)  # [N, C]
+
+    # dL/d(logits[i,k]) = (softmax[i,k] - 1[k==labels[i]]) * g / N
+    dlogits = (softmax_chunk - one_hot) * g_scale  # [N, C]
+
+    dx_acc = dx_acc + dlogits @ chunk_w          # [N, D]
+    dw_chunk = dlogits.T @ x_f32                 # [C, D]
+    # Ensure no gradient flows into padding rows.
+    dw_chunk = jnp.where(chunk_mask[:, None], dw_chunk, 0.0)
+
+    return dx_acc, dw_chunk
+
+  dx_init = jnp.zeros((N, D), dtype=jnp.float32)
+  dx, dw_chunks = lax.scan(
+      bwd_chunk, dx_init, (w_chunks_f32, chunk_starts, mask)
+  )
+  # dw_chunks: [num_chunks, chunk_size, D] → [padded_V, D] → [V, D]
+  dw = dw_chunks.reshape(padded_V, D)[:V]
+
+  return dx.astype(x.dtype), dw.astype(w.dtype), None  # None: no grad for labels
+
+
+_fused_linear_cross_entropy.defvjp(
+    _fused_linear_cross_entropy_fwd,
+    _fused_linear_cross_entropy_bwd,
+)

--- a/jax/experimental/fused_linear_cross_entropy.py
+++ b/jax/experimental/fused_linear_cross_entropy.py
@@ -42,6 +42,9 @@ def fused_linear_cross_entropy_loss(
     labels: jax.Array,
     *,
     chunk_size: int = 4096,
+    shift: int = 0,
+    vocab_sort_indices: jax.Array | None = None,
+    filter_eps: float | None = None,
 ) -> jax.Array:
   """Memory-efficient fused linear + cross-entropy loss.
 
@@ -50,35 +53,107 @@ def fused_linear_cross_entropy_loss(
   chunks of size *chunk_size* using ``lax.scan``, so peak memory usage is
   proportional to ``chunk_size`` rather than to ``V``.
 
-  The backward pass is implemented via ``jax.custom_vjp``.  Only ``x``, ``w``
-  and the per-sample log-sum-exp vector (shape ``[N]``) are saved as
-  residuals; the full logits are recomputed chunk by chunk during the backward
-  pass.
+  The backward pass is implemented via ``jax.custom_vjp``.  Only ``x``, ``w``,
+  the per-sample log-sum-exp vector (shape ``[N]``), and the per-sample
+  global-max vector (shape ``[N]``) are saved as residuals; the full logits
+  are recomputed chunk by chunk during the backward pass.
 
   Compatible with ``jax.jit``, ``jax.grad``, and ``jax.value_and_grad``.
   Both ``float32`` and ``bfloat16`` inputs are supported; internal
   accumulation is always performed in ``float32``.
 
   Args:
-    x: Input activations, shape ``[N, D]``.
+    x: Input activations.  Shape ``[N, D]``, or a batched sequence
+      ``[..., T, D]`` when *shift* > 0.
     w: Vocabulary weight matrix, shape ``[V, D]``.
-    labels: Integer class labels in ``[0, V)``, shape ``[N]``.
+    labels: Integer class labels in ``[0, V)``.  Shape ``[N]``, or
+      ``[..., T]`` when *shift* > 0.
     chunk_size: Number of vocabulary entries processed per scan step.
       Must be a positive Python ``int``.  Larger values trade memory for
       fewer kernel launches; defaults to ``4096``.
+    shift: When > 0, apply a causal sequence shift before computing the
+      loss.  Specifically, ``x[..., :-shift, :]`` is used to predict
+      ``labels[..., shift:]``, both reshaped to ``[-1, D]`` / ``[-1]``.
+      ``shift=1`` implements standard next-token prediction.  Defaults to
+      ``0`` (no shift).
+    vocab_sort_indices: Optional integer array of shape ``[V]``.  When
+      provided, weight rows are reordered as ``w[vocab_sort_indices]``
+      before chunking, grouping related tokens for better cache locality.
+      Labels are remapped from original to sorted vocabulary space
+      internally so the loss value is identical to the unsorted case.
+      JAX's gather VJP automatically scatters ``dw`` back to the original
+      (unsorted) row order.  Defaults to ``None`` (no reordering).
+    filter_eps: Optional float threshold for gradient filtering.  When
+      set, chunks whose per-sample maximum logit falls more than
+      *filter_eps* below the global per-sample maximum are zeroed out in
+      the backward pass (their ``softmax`` contribution is negligible by
+      construction).  The forward loss is always exact regardless of this
+      setting.  Use ``float('inf')`` to request the filter code path with
+      no actual filtering (useful for benchmarking).  Defaults to
+      ``None`` (no filtering).
 
   Returns:
-    Scalar mean cross-entropy loss.  The dtype matches ``float32``
-    regardless of the input dtype (consistent with numerically-stable loss
-    computations in mixed-precision training).
+    Scalar mean cross-entropy loss in ``float32``.
 
   References:
     "Cut Your Losses in Large-Vocabulary Language Models",
     arxiv.org/abs/2411.09009
+
+    Apple CCE reference implementation:
+    github.com/apple/ml-cross-entropy
   """
   if chunk_size <= 0:
     raise ValueError(f"chunk_size must be positive, got {chunk_size}")
-  return _fused_linear_cross_entropy(x, w, labels, chunk_size)
+  if shift < 0:
+    raise ValueError(f"shift must be non-negative, got {shift}")
+
+  # --- Feature 1: causal sequence shift -----------------------------------
+  # x[t] predicts labels[t + shift].  Slice off the unmatched prefix/suffix
+  # then flatten the leading dimensions so the core function sees [N, D].
+  if shift > 0:
+    x = x[..., :-shift, :].reshape(-1, x.shape[-1])
+    labels = labels[..., shift:].reshape(-1)
+
+  # --- Feature 2: vocab sorting -------------------------------------------
+  # Reorder weight rows so that frequently-used tokens cluster together,
+  # improving cache locality during chunk matmuls and enabling filter_eps
+  # to skip more chunks in the backward pass.
+  #
+  # Labels are remapped from original→sorted vocab space so that the loss
+  # value is bit-for-bit identical to the unsorted computation.
+  #
+  # Gradient unsort is free: JAX's lax.gather VJP uses lax.scatter_add to
+  # map dw_sorted[i] → dw_original[vocab_sort_indices[i]], which is the
+  # correct inverse permutation.
+  if vocab_sort_indices is not None:
+    w = w[vocab_sort_indices]
+    rank = jnp.argsort(vocab_sort_indices)   # rank[k] = sorted pos of token k
+    labels = rank[labels]
+
+  return _fused_linear_cross_entropy(x, w, labels, chunk_size, filter_eps)
+
+
+# ---------------------------------------------------------------------------
+# Memory note: buffer donation / in-place gradient accumulation
+#
+# The CCE Triton kernel (github.com/apple/ml-cross-entropy) overwrites the
+# forward logit buffer with gradient values in-place, so each chunk needs
+# only one O(N·C) allocation that is reused for both passes.
+#
+# JAX's functional model does not permit in-place mutation inside
+# custom_vjp.  However, XLA's buffer-assignment pass performs liveness
+# analysis on the compiled HLO and will automatically reuse the memory of
+# dead buffers — including consumed residuals — when they fall out of scope,
+# so peak allocation is often comparable without any user intervention.
+#
+# At the JIT boundary, callers may additionally pass donate_argnums to
+# jax.jit to donate the input arrays' backing buffers to outputs:
+#
+#   train_step = jax.jit(train_step, donate_argnums=(0,))  # donate params
+#
+# This lets XLA overwrite e.g. the old parameter buffer with the updated
+# parameters in a gradient-descent step, cutting one full-model allocation.
+# ---------------------------------------------------------------------------
 
 
 # ---------------------------------------------------------------------------
@@ -86,9 +161,9 @@ def fused_linear_cross_entropy_loss(
 # ---------------------------------------------------------------------------
 
 def _pad_w(w: jax.Array, chunk_size: int) -> tuple[jax.Array, int, int]:
-  """Return (w_padded, num_chunks, padded_V).
+  """Return (w_chunks, num_chunks, padded_V).
 
-  w_padded is reshaped to [num_chunks, chunk_size, D].
+  w_chunks has shape [num_chunks, chunk_size, D].
   Padding rows are zero so they contribute nothing to dot products.
   """
   V, D = w.shape
@@ -108,10 +183,11 @@ def _valid_mask(V: int, num_chunks: int, chunk_size: int) -> jax.Array:
 
 def _compute_lse(
     x: jax.Array, w: jax.Array, chunk_size: int
-) -> jax.Array:
+) -> tuple[jax.Array, jax.Array]:
   """Compute log-sum-exp of ``x @ w.T`` via online softmax.
 
-  Returns shape ``[N]`` float32, without ever allocating ``[N, V]``.
+  Returns ``(lse, global_max)`` both of shape ``[N]`` float32, without ever
+  allocating ``[N, V]``.
   """
   N = x.shape[0]
   V = w.shape[0]
@@ -129,7 +205,7 @@ def _compute_lse(
     chunk_w, chunk_mask = inputs          # [C, D], [C]
 
     logits_chunk = x_f32 @ chunk_w.T     # [N, C]
-    # Mask padding to -inf so padded positions don't affect the max or sum.
+    # Mask padding to -inf so padded positions don't affect max or sum.
     logits_chunk = jnp.where(chunk_mask[None, :], logits_chunk, -jnp.inf)
 
     chunk_max = jnp.max(logits_chunk, axis=-1)  # [N]
@@ -150,25 +226,29 @@ def _compute_lse(
       jnp.full((N,), -jnp.inf, dtype=jnp.float32),
       jnp.zeros((N,), dtype=jnp.float32),
   )
-  (final_max, final_sum_exp), _ = lax.scan(
+  (global_max, final_sum_exp), _ = lax.scan(
       scan_fn, init, (w_chunks_f32, mask)
   )
-  return final_max + jnp.log(final_sum_exp)  # [N]
+  lse = global_max + jnp.log(final_sum_exp)  # [N]
+  return lse, global_max
 
 
 # ---------------------------------------------------------------------------
 # custom_vjp implementation
+# nondiff_argnums=(3, 4): chunk_size (int) and filter_eps (float | None)
+# are static Python values; JAX retraces when they change.
 # ---------------------------------------------------------------------------
 
-@functools.partial(jax.custom_vjp, nondiff_argnums=(3,))
+@functools.partial(jax.custom_vjp, nondiff_argnums=(3, 4))
 def _fused_linear_cross_entropy(
     x: jax.Array,
     w: jax.Array,
     labels: jax.Array,
     chunk_size: int,
+    filter_eps: float | None,
 ) -> jax.Array:
   """Primal: used when gradients are not required."""
-  lse = _compute_lse(x, w, chunk_size)
+  lse, _ = _compute_lse(x, w, chunk_size)
   target_logit = jnp.sum(
       x.astype(jnp.float32) * w[labels].astype(jnp.float32), axis=-1
   )  # [N]
@@ -180,24 +260,39 @@ def _fused_linear_cross_entropy_fwd(
     w: jax.Array,
     labels: jax.Array,
     chunk_size: int,
+    filter_eps: float | None,
 ) -> tuple[jax.Array, tuple]:
   """Forward pass: same output as primal, plus residuals for backward."""
-  lse = _compute_lse(x, w, chunk_size)
+  lse, global_max = _compute_lse(x, w, chunk_size)
   target_logit = jnp.sum(
       x.astype(jnp.float32) * w[labels].astype(jnp.float32), axis=-1
   )
   loss = jnp.mean(-target_logit + lse)
-  # Save only x, w, labels, lse — never the full [N, V] logits.
-  return loss, (x, w, labels, lse)
+  # Save only x, w, labels, lse, global_max — never the full [N, V] logits.
+  return loss, (x, w, labels, lse, global_max)
 
 
 def _fused_linear_cross_entropy_bwd(
     chunk_size: int,
+    filter_eps: float | None,
     residuals: tuple,
     g: jax.Array,
 ) -> tuple[jax.Array, jax.Array, None]:
-  """Backward pass: chunked recomputation of logits, no [N, V] allocation."""
-  x, w, labels, lse = residuals
+  """Backward pass: chunked recomputation of logits, no [N, V] allocation.
+
+  --- Feature 3: gradient filtering (filter_eps) ---
+  When filter_eps is set, chunks whose per-sample maximum logit falls more
+  than filter_eps below the global per-sample maximum are zeroed out.
+  Their softmax contribution is exp(chunk_max - global_max) < exp(-filter_eps),
+  which is negligible for large filter_eps values.
+
+  Because lax.scan requires uniform computation per step, we multiply by 0
+  (masking) rather than truly branching.  The matmul still executes, but its
+  results are discarded for filtered samples/chunks.  The one-hot correction
+  term is preserved even for filtered chunks so that labels in low-probability
+  chunks still receive the correct −1/N gradient signal.
+  """
+  x, w, labels, lse, global_max = residuals
   N, D = x.shape
   V = w.shape[0]
 
@@ -208,6 +303,7 @@ def _fused_linear_cross_entropy_bwd(
   x_f32 = x.astype(jnp.float32)
   w_chunks_f32 = w_chunks.astype(jnp.float32)
   lse_f32 = lse.astype(jnp.float32)
+  global_max_f32 = global_max.astype(jnp.float32)      # [N], always cheap to keep
   # Scale by upstream gradient and 1/N (gradient through jnp.mean).
   g_scale = g.astype(jnp.float32) / N  # scalar
 
@@ -219,10 +315,23 @@ def _fused_linear_cross_entropy_bwd(
 
     # Recompute softmax for this vocab chunk — O(N*C) not O(N*V).
     logits_chunk = x_f32 @ chunk_w.T            # [N, C]
-    softmax_chunk = jnp.exp(logits_chunk - lse_f32[:, None])  # [N, C]
-    # Zero out padded positions (their w rows are zero, giving logit=0, but
-    # exp(0 - lse) is nonzero so we must mask explicitly).
+    # Use masked logits so padded slots don't pollute chunk_max.
+    logits_masked = jnp.where(chunk_mask[None, :], logits_chunk, -jnp.inf)
+    softmax_chunk = jnp.exp(logits_masked - lse_f32[:, None])  # [N, C]
+    # Zero out padded positions (exp(0 - lse) is nonzero for zero-padded w).
     softmax_chunk = jnp.where(chunk_mask[None, :], softmax_chunk, 0.0)
+
+    # --- gradient filtering (filter_eps) ---
+    # Evaluated at Python level (filter_eps is a nondiff arg), so the
+    # filtering ops are only included in the compiled graph when needed.
+    if filter_eps is not None:
+      chunk_max = jnp.max(logits_masked, axis=-1)          # [N]
+      active = chunk_max >= global_max_f32 - filter_eps    # [N] bool
+      softmax_chunk = jnp.where(active[:, None], softmax_chunk, 0.0)
+      # Note: we do NOT filter the one_hot below.  Even if the softmax
+      # contribution is negligible, the label correction term (−1/N) must
+      # still be applied so that samples with labels in low-logit chunks
+      # receive the correct gradient signal.
 
     # Build sparse one-hot for labels that fall within [chunk_start, chunk_start+C).
     local_idx = labels - chunk_start            # [N]  (may be negative/out-of-range)

--- a/jax/experimental/fused_linear_cross_entropy.py
+++ b/jax/experimental/fused_linear_cross_entropy.py
@@ -30,7 +30,6 @@ the [N, V] tensor.  Memory complexity is O(N·D + V·D) instead of O(N·V).
 from __future__ import annotations
 
 import functools
-from typing import Callable
 
 import jax
 from jax import lax

--- a/tests/fused_linear_cross_entropy_test.py
+++ b/tests/fused_linear_cross_entropy_test.py
@@ -37,8 +37,7 @@ jax.config.parse_flags_with_absl()
 def _naive_loss(x, w, labels):
   """Cross-entropy via full [N, V] logits — reference only."""
   logits = x.astype(jnp.float32) @ w.astype(jnp.float32).T  # [N, V]
-  log_z = jnp.log(jnp.sum(jnp.exp(logits - jnp.max(logits, axis=-1, keepdims=True)), axis=-1))
-  log_z += jnp.max(logits, axis=-1)  # log-sum-exp
+  log_z = logsumexp(logits, axis=-1)
   N = x.shape[0]
   target_logit = logits[jnp.arange(N), labels]
   return jnp.mean(-target_logit + log_z)

--- a/tests/fused_linear_cross_entropy_test.py
+++ b/tests/fused_linear_cross_entropy_test.py
@@ -23,6 +23,7 @@ from jax._src import test_util as jtu
 from jax.experimental.fused_linear_cross_entropy import (
     fused_linear_cross_entropy_loss,
 )
+from jax.nn import logsumexp
 import jax.numpy as jnp
 import numpy as np
 
@@ -325,6 +326,334 @@ class FusedLinearCrossEntropyTest(jtu.JaxTestCase):
     labels = jnp.zeros((4,), dtype=jnp.int32)
     with self.assertRaises(ValueError):
       fused_linear_cross_entropy_loss(x, w, labels, chunk_size=0)
+
+  # ==================================================================
+  # Feature 1: shift parameter
+  # ==================================================================
+
+  def test_shift_1_flat_input(self):
+    """shift=1 on a flat [T, D] input matches manual slice."""
+    T, D, V, chunk_size = 16, 8, 32, 8
+    key = jax.random.key(100)
+    x = jax.random.normal(key, (T, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (T,), 0, V)
+
+    # fused with shift=1
+    fused = fused_linear_cross_entropy_loss(x, w, labels, chunk_size=chunk_size, shift=1)
+    # naive: manually slice
+    naive = _naive_loss(x[:-1], w, labels[1:])
+
+    np.testing.assert_allclose(fused, naive, rtol=1e-5, atol=1e-5)
+
+  def test_shift_1_batched_input(self):
+    """shift=1 on a batched [B, T, D] input matches manual slice + reshape."""
+    B, T, D, V, chunk_size = 3, 10, 8, 32, 8
+    key = jax.random.key(101)
+    x = jax.random.normal(key, (B, T, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (B, T), 0, V)
+
+    fused = fused_linear_cross_entropy_loss(x, w, labels, chunk_size=chunk_size, shift=1)
+    # naive: slice then flatten
+    x_s = x[:, :-1, :].reshape(-1, D)
+    labels_s = labels[:, 1:].reshape(-1)
+    naive = _naive_loss(x_s, w, labels_s)
+
+    np.testing.assert_allclose(fused, naive, rtol=1e-5, atol=1e-5)
+
+  def test_shift_greater_than_1(self):
+    """shift=2 slices off two positions."""
+    T, D, V, chunk_size = 12, 8, 16, 4
+    key = jax.random.key(102)
+    x = jax.random.normal(key, (T, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (T,), 0, V)
+
+    fused = fused_linear_cross_entropy_loss(x, w, labels, chunk_size=chunk_size, shift=2)
+    naive = _naive_loss(x[:-2], w, labels[2:])
+    np.testing.assert_allclose(fused, naive, rtol=1e-5, atol=1e-5)
+
+  def test_shift_0_unchanged(self):
+    """shift=0 is a no-op."""
+    N, D, V, chunk_size = 8, 8, 16, 4
+    key = jax.random.key(103)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    fused_shift0 = fused_linear_cross_entropy_loss(x, w, labels, chunk_size=chunk_size, shift=0)
+    fused_no_shift = fused_linear_cross_entropy_loss(x, w, labels, chunk_size=chunk_size)
+    np.testing.assert_allclose(fused_shift0, fused_no_shift, rtol=0, atol=0)
+
+  def test_shift_gradient_x(self):
+    """Gradients w.r.t. x with shift=1 are correct."""
+    T, D, V, chunk_size = 12, 8, 16, 4
+    key = jax.random.key(104)
+    x = jax.random.normal(key, (T, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (T,), 0, V)
+
+    dx_fused = jax.grad(
+        lambda x_: fused_linear_cross_entropy_loss(x_, w, labels, chunk_size=chunk_size, shift=1)
+    )(x)
+    # Naive: gradient of loss w.r.t. x, accounting for the slice x[:-1].
+    # jax.grad will correctly give zero gradient for x[-1] since it's sliced off.
+    dx_naive = jax.grad(
+        lambda x_: _naive_loss(x_[:-1], w, labels[1:])
+    )(x)
+
+    np.testing.assert_allclose(dx_fused, dx_naive, rtol=1e-4, atol=1e-5)
+
+  def test_shift_gradient_w(self):
+    """Gradients w.r.t. w with shift=1 are correct."""
+    T, D, V, chunk_size = 12, 8, 16, 4
+    key = jax.random.key(105)
+    x = jax.random.normal(key, (T, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (T,), 0, V)
+
+    dw_fused = jax.grad(
+        lambda w_: fused_linear_cross_entropy_loss(x, w_, labels, chunk_size=chunk_size, shift=1)
+    )(w)
+    dw_naive = jax.grad(lambda w_: _naive_loss(x[:-1], w_, labels[1:]))(w)
+
+    np.testing.assert_allclose(dw_fused, dw_naive, rtol=1e-4, atol=1e-5)
+
+  def test_shift_invalid_raises(self):
+    x = jnp.ones((8, 8))
+    w = jnp.ones((16, 8))
+    labels = jnp.zeros((8,), dtype=jnp.int32)
+    with self.assertRaises(ValueError):
+      fused_linear_cross_entropy_loss(x, w, labels, shift=-1)
+
+  # ==================================================================
+  # Feature 2: vocab_sort_indices
+  # ==================================================================
+
+  def test_vocab_sort_identity_permutation(self):
+    """Identity permutation is a no-op."""
+    N, D, V, chunk_size = 8, 16, 32, 8
+    key = jax.random.key(200)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    identity = jnp.arange(V)
+    fused_sorted = fused_linear_cross_entropy_loss(
+        x, w, labels, chunk_size=chunk_size, vocab_sort_indices=identity
+    )
+    fused_plain = fused_linear_cross_entropy_loss(x, w, labels, chunk_size=chunk_size)
+    np.testing.assert_allclose(fused_sorted, fused_plain, rtol=1e-5, atol=1e-5)
+
+  def test_vocab_sort_loss_unchanged(self):
+    """Arbitrary permutation does not change the loss value."""
+    N, D, V, chunk_size = 8, 16, 32, 8
+    key = jax.random.key(201)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    # Random permutation of vocabulary
+    perm = jax.random.permutation(jax.random.fold_in(key, 3), V)
+
+    fused_sorted = fused_linear_cross_entropy_loss(
+        x, w, labels, chunk_size=chunk_size, vocab_sort_indices=perm
+    )
+    naive = _naive_loss(x, w, labels)
+    np.testing.assert_allclose(fused_sorted, naive, rtol=1e-5, atol=1e-5)
+
+  def test_vocab_sort_gradient_x_unchanged(self):
+    """dx is unaffected by vocab sorting (labels still in original space)."""
+    N, D, V, chunk_size = 8, 16, 32, 8
+    key = jax.random.key(202)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    perm = jax.random.permutation(jax.random.fold_in(key, 3), V)
+
+    dx_sorted = jax.grad(
+        lambda x_: fused_linear_cross_entropy_loss(
+            x_, w, labels, chunk_size=chunk_size, vocab_sort_indices=perm
+        )
+    )(x)
+    dx_naive = jax.grad(lambda x_: _naive_loss(x_, w, labels))(x)
+
+    np.testing.assert_allclose(dx_sorted, dx_naive, rtol=1e-4, atol=1e-5)
+
+  def test_vocab_sort_gradient_w_correctly_unsorded(self):
+    """dw is correctly scattered back to original weight row order."""
+    N, D, V, chunk_size = 8, 16, 32, 8
+    key = jax.random.key(203)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    perm = jax.random.permutation(jax.random.fold_in(key, 3), V)
+
+    dw_sorted_call = jax.grad(
+        lambda w_: fused_linear_cross_entropy_loss(
+            x, w_, labels, chunk_size=chunk_size, vocab_sort_indices=perm
+        )
+    )(w)
+    dw_naive = jax.grad(lambda w_: _naive_loss(x, w_, labels))(w)
+
+    # Both dw arrays should be in original vocabulary order.
+    np.testing.assert_allclose(dw_sorted_call, dw_naive, rtol=1e-4, atol=1e-5)
+
+  def test_vocab_sort_combined_with_shift(self):
+    """Vocab sorting and shift can be combined."""
+    T, D, V, chunk_size = 12, 8, 16, 4
+    key = jax.random.key(204)
+    x = jax.random.normal(key, (T, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (T,), 0, V)
+
+    perm = jax.random.permutation(jax.random.fold_in(key, 3), V)
+
+    fused = fused_linear_cross_entropy_loss(
+        x, w, labels, chunk_size=chunk_size, shift=1, vocab_sort_indices=perm
+    )
+    naive = _naive_loss(x[:-1], w, labels[1:])
+    np.testing.assert_allclose(fused, naive, rtol=1e-5, atol=1e-5)
+
+  # ==================================================================
+  # Feature 3: filter_eps gradient filtering
+  # ==================================================================
+
+  def test_filter_eps_no_effect_on_forward_loss(self):
+    """filter_eps never changes the forward loss value."""
+    N, D, V, chunk_size = 8, 16, 32, 8
+    key = jax.random.key(300)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    loss_no_filter = fused_linear_cross_entropy_loss(x, w, labels, chunk_size=chunk_size)
+    loss_small_eps = fused_linear_cross_entropy_loss(
+        x, w, labels, chunk_size=chunk_size, filter_eps=0.0
+    )
+    loss_large_eps = fused_linear_cross_entropy_loss(
+        x, w, labels, chunk_size=chunk_size, filter_eps=100.0
+    )
+    loss_inf_eps = fused_linear_cross_entropy_loss(
+        x, w, labels, chunk_size=chunk_size, filter_eps=float("inf")
+    )
+
+    # Forward is always exact regardless of filter_eps.
+    np.testing.assert_allclose(loss_small_eps, loss_no_filter, rtol=0, atol=0)
+    np.testing.assert_allclose(loss_large_eps, loss_no_filter, rtol=0, atol=0)
+    np.testing.assert_allclose(loss_inf_eps, loss_no_filter, rtol=0, atol=0)
+
+  def test_filter_eps_inf_exact_gradients(self):
+    """filter_eps=inf keeps all chunks active → exact gradients."""
+    N, D, V, chunk_size = 8, 16, 32, 8
+    key = jax.random.key(301)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    dx_no_filter = jax.grad(
+        lambda x_: fused_linear_cross_entropy_loss(x_, w, labels, chunk_size=chunk_size)
+    )(x)
+    dx_inf_eps = jax.grad(
+        lambda x_: fused_linear_cross_entropy_loss(
+            x_, w, labels, chunk_size=chunk_size, filter_eps=float("inf")
+        )
+    )(x)
+
+    # filter_eps=inf → all chunks active, must be numerically identical.
+    np.testing.assert_allclose(dx_inf_eps, dx_no_filter, rtol=1e-6, atol=1e-6)
+
+  def test_filter_eps_inf_exact_gradients_w(self):
+    """filter_eps=inf gives exact dw."""
+    N, D, V, chunk_size = 8, 16, 32, 8
+    key = jax.random.key(302)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    dw_no_filter = jax.grad(
+        lambda w_: fused_linear_cross_entropy_loss(x, w_, labels, chunk_size=chunk_size)
+    )(w)
+    dw_inf_eps = jax.grad(
+        lambda w_: fused_linear_cross_entropy_loss(
+            x, w_, labels, chunk_size=chunk_size, filter_eps=float("inf")
+        )
+    )(w)
+    np.testing.assert_allclose(dw_inf_eps, dw_no_filter, rtol=1e-6, atol=1e-6)
+
+  def test_filter_eps_approximate_peaked_distribution(self):
+    """Moderate filter_eps gives close gradients on a peaked distribution.
+
+    We construct a case where the first vocab chunk has logits ~100× larger
+    than all others.  With filter_eps=50, every other chunk is filtered in
+    the backward.  Because their softmax contributions are exp(-100)≈0, the
+    gradient error is negligible.
+    """
+    N, D, V, chunk_size = 8, 16, 64, 8
+    key = jax.random.key(303)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    # Small weights for all tokens, then massively boost the first chunk.
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32) * 0.01
+    w = w.at[:chunk_size].set(
+        jax.random.normal(jax.random.fold_in(key, 2), (chunk_size, D)) * 10.0
+    )
+    # Labels in the high-logit chunk so that the label correction is not filtered.
+    labels = jax.random.randint(jax.random.fold_in(key, 3), (N,), 0, chunk_size)
+
+    dx_exact = jax.grad(
+        lambda x_: fused_linear_cross_entropy_loss(x_, w, labels, chunk_size=chunk_size)
+    )(x)
+    dx_filtered = jax.grad(
+        lambda x_: fused_linear_cross_entropy_loss(
+            x_, w, labels, chunk_size=chunk_size, filter_eps=50.0
+        )
+    )(x)
+
+    # The first chunk dominates; other chunks contribute < exp(-50) ≈ 0.
+    np.testing.assert_allclose(dx_filtered, dx_exact, rtol=1e-4, atol=1e-4)
+
+  def test_filter_eps_combined_with_vocab_sort(self):
+    """filter_eps and vocab_sort_indices can be used together."""
+    N, D, V, chunk_size = 8, 16, 32, 8
+    key = jax.random.key(304)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+    perm = jax.random.permutation(jax.random.fold_in(key, 3), V)
+
+    # With filter_eps=inf both features are active; loss must be exact.
+    loss = fused_linear_cross_entropy_loss(
+        x, w, labels,
+        chunk_size=chunk_size,
+        vocab_sort_indices=perm,
+        filter_eps=float("inf"),
+    )
+    naive = _naive_loss(x, w, labels)
+    np.testing.assert_allclose(loss, naive, rtol=1e-5, atol=1e-5)
+
+  def test_filter_eps_jit(self):
+    """filter_eps works under jax.jit."""
+    N, D, V, chunk_size = 8, 16, 32, 8
+    key = jax.random.key(305)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    jit_grad = jax.jit(
+        jax.grad(
+            lambda x_: fused_linear_cross_entropy_loss(
+                x_, w, labels, chunk_size=chunk_size, filter_eps=float("inf")
+            )
+        )
+    )
+    dx_jit = jit_grad(x)
+    dx_ref = jax.grad(
+        lambda x_: fused_linear_cross_entropy_loss(x_, w, labels, chunk_size=chunk_size)
+    )(x)
+    np.testing.assert_allclose(dx_jit, dx_ref, rtol=1e-6, atol=1e-6)
 
 
 if __name__ == "__main__":

--- a/tests/fused_linear_cross_entropy_test.py
+++ b/tests/fused_linear_cross_entropy_test.py
@@ -1,0 +1,332 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for jax.experimental.fused_linear_cross_entropy."""
+
+from __future__ import annotations
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+from jax._src import test_util as jtu
+from jax.experimental.fused_linear_cross_entropy import (
+    fused_linear_cross_entropy_loss,
+)
+import jax.numpy as jnp
+import numpy as np
+
+
+jax.config.parse_flags_with_absl()
+
+
+# ---------------------------------------------------------------------------
+# Reference (naive) implementation
+# ---------------------------------------------------------------------------
+
+def _naive_loss(x, w, labels):
+  """Cross-entropy via full [N, V] logits — reference only."""
+  logits = x.astype(jnp.float32) @ w.astype(jnp.float32).T  # [N, V]
+  log_z = jnp.log(jnp.sum(jnp.exp(logits - jnp.max(logits, axis=-1, keepdims=True)), axis=-1))
+  log_z += jnp.max(logits, axis=-1)  # log-sum-exp
+  N = x.shape[0]
+  target_logit = logits[jnp.arange(N), labels]
+  return jnp.mean(-target_logit + log_z)
+
+
+# ---------------------------------------------------------------------------
+# Test class
+# ---------------------------------------------------------------------------
+
+class FusedLinearCrossEntropyTest(jtu.JaxTestCase):
+
+  # ------------------------------------------------------------------
+  # Forward accuracy
+  # ------------------------------------------------------------------
+
+  @parameterized.named_parameters(
+      dict(testcase_name="tiny", N=4, D=8, V=16, chunk_size=4),
+      dict(testcase_name="small_exact", N=8, D=16, V=32, chunk_size=8),
+      dict(testcase_name="small_remainder", N=8, D=16, V=30, chunk_size=8),
+      dict(testcase_name="V_lt_chunk", N=4, D=8, V=5, chunk_size=16),
+      dict(testcase_name="V_eq_chunk", N=4, D=8, V=16, chunk_size=16),
+      dict(testcase_name="medium", N=32, D=64, V=256, chunk_size=64),
+      dict(testcase_name="one_chunk", N=8, D=16, V=4, chunk_size=128),
+      dict(testcase_name="N1", N=1, D=8, V=16, chunk_size=4),
+  )
+  def test_forward_float32(self, N, D, V, chunk_size):
+    key = jax.random.key(0)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    fused = fused_linear_cross_entropy_loss(x, w, labels, chunk_size=chunk_size)
+    naive = _naive_loss(x, w, labels)
+
+    np.testing.assert_allclose(fused, naive, rtol=1e-5, atol=1e-5)
+
+  @parameterized.named_parameters(
+      dict(testcase_name="small", N=8, D=16, V=32, chunk_size=8),
+      dict(testcase_name="remainder", N=8, D=16, V=30, chunk_size=8),
+      dict(testcase_name="medium", N=32, D=64, V=256, chunk_size=64),
+  )
+  def test_forward_bfloat16(self, N, D, V, chunk_size):
+    key = jax.random.key(42)
+    x = jax.random.normal(key, (N, D), dtype=jnp.bfloat16)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.bfloat16)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    fused = fused_linear_cross_entropy_loss(x, w, labels, chunk_size=chunk_size)
+    naive = _naive_loss(x, w, labels)
+
+    # bfloat16 has ~2 decimal digits of precision; use generous tolerances.
+    np.testing.assert_allclose(
+        float(fused), float(naive), rtol=1e-2, atol=1e-2
+    )
+
+  # ------------------------------------------------------------------
+  # Gradient accuracy
+  # ------------------------------------------------------------------
+
+  @parameterized.named_parameters(
+      dict(testcase_name="tiny", N=4, D=8, V=16, chunk_size=4),
+      dict(testcase_name="exact", N=8, D=16, V=32, chunk_size=8),
+      dict(testcase_name="remainder", N=8, D=16, V=30, chunk_size=8),
+      dict(testcase_name="V_lt_chunk", N=4, D=8, V=5, chunk_size=16),
+      dict(testcase_name="medium", N=16, D=32, V=128, chunk_size=32),
+  )
+  def test_gradients_x_float32(self, N, D, V, chunk_size):
+    key = jax.random.key(7)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    dx_fused = jax.grad(
+        lambda x_: fused_linear_cross_entropy_loss(x_, w, labels, chunk_size=chunk_size)
+    )(x)
+    dx_naive = jax.grad(lambda x_: _naive_loss(x_, w, labels))(x)
+
+    np.testing.assert_allclose(dx_fused, dx_naive, rtol=1e-4, atol=1e-5)
+
+  @parameterized.named_parameters(
+      dict(testcase_name="tiny", N=4, D=8, V=16, chunk_size=4),
+      dict(testcase_name="exact", N=8, D=16, V=32, chunk_size=8),
+      dict(testcase_name="remainder", N=8, D=16, V=30, chunk_size=8),
+      dict(testcase_name="medium", N=16, D=32, V=128, chunk_size=32),
+  )
+  def test_gradients_w_float32(self, N, D, V, chunk_size):
+    key = jax.random.key(13)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    dw_fused = jax.grad(
+        lambda w_: fused_linear_cross_entropy_loss(x, w_, labels, chunk_size=chunk_size),
+    )(w)
+    dw_naive = jax.grad(lambda w_: _naive_loss(x, w_, labels))(w)
+
+    np.testing.assert_allclose(dw_fused, dw_naive, rtol=1e-4, atol=1e-5)
+
+  def test_gradients_both_float32(self):
+    """value_and_grad returns correct loss and gradients simultaneously."""
+    N, D, V, chunk_size = 8, 16, 32, 8
+    key = jax.random.key(99)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    def fused_fn(x_, w_):
+      return fused_linear_cross_entropy_loss(x_, w_, labels, chunk_size=chunk_size)
+
+    def naive_fn(x_, w_):
+      return _naive_loss(x_, w_, labels)
+
+    (loss_f, (dx_f, dw_f)) = jax.value_and_grad(fused_fn, argnums=(0, 1))(x, w)
+    (loss_n, (dx_n, dw_n)) = jax.value_and_grad(naive_fn, argnums=(0, 1))(x, w)
+
+    np.testing.assert_allclose(loss_f, loss_n, rtol=1e-5)
+    np.testing.assert_allclose(dx_f, dx_n, rtol=1e-4, atol=1e-5)
+    np.testing.assert_allclose(dw_f, dw_n, rtol=1e-4, atol=1e-5)
+
+  def test_gradients_bfloat16(self):
+    N, D, V, chunk_size = 8, 16, 32, 8
+    key = jax.random.key(3)
+    x = jax.random.normal(key, (N, D), dtype=jnp.bfloat16)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.bfloat16)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    dx_fused = jax.grad(
+        lambda x_: fused_linear_cross_entropy_loss(x_, w, labels, chunk_size=chunk_size)
+    )(x)
+    dx_naive = jax.grad(lambda x_: _naive_loss(x_, w, labels))(x)
+
+    # Cast both to float32 for comparison (bfloat16 has low precision)
+    np.testing.assert_allclose(
+        dx_fused.astype(jnp.float32),
+        dx_naive.astype(jnp.float32),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+
+  # ------------------------------------------------------------------
+  # JIT compatibility
+  # ------------------------------------------------------------------
+
+  def test_jit_forward(self):
+    N, D, V, chunk_size = 8, 16, 32, 8
+    key = jax.random.key(5)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    jit_fn = jax.jit(
+        lambda x_, w_: fused_linear_cross_entropy_loss(
+            x_, w_, labels, chunk_size=chunk_size
+        )
+    )
+    fused = jit_fn(x, w)
+    naive = _naive_loss(x, w, labels)
+    np.testing.assert_allclose(fused, naive, rtol=1e-5, atol=1e-5)
+
+  def test_jit_grad(self):
+    N, D, V, chunk_size = 8, 16, 32, 8
+    key = jax.random.key(6)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    jit_grad = jax.jit(
+        jax.grad(
+            lambda x_: fused_linear_cross_entropy_loss(
+                x_, w, labels, chunk_size=chunk_size
+            )
+        )
+    )
+    dx_fused = jit_grad(x)
+    dx_naive = jax.grad(lambda x_: _naive_loss(x_, w, labels))(x)
+    np.testing.assert_allclose(dx_fused, dx_naive, rtol=1e-4, atol=1e-5)
+
+  # ------------------------------------------------------------------
+  # Edge cases
+  # ------------------------------------------------------------------
+
+  def test_V_equals_one(self):
+    """Single-class vocabulary: loss should be near zero."""
+    N, D, V, chunk_size = 4, 8, 1, 4
+    key = jax.random.key(10)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jnp.zeros((N,), dtype=jnp.int32)  # only class 0
+
+    fused = fused_linear_cross_entropy_loss(x, w, labels, chunk_size=chunk_size)
+    naive = _naive_loss(x, w, labels)
+    np.testing.assert_allclose(fused, naive, rtol=1e-5, atol=1e-5)
+    # With V=1, softmax is trivially 1 at label 0, so loss is 0.
+    np.testing.assert_allclose(fused, 0.0, atol=1e-5)
+
+  def test_chunk_size_larger_than_V(self):
+    """chunk_size > V: single chunk with partial masking."""
+    N, D, V, chunk_size = 4, 8, 7, 64
+    key = jax.random.key(11)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    fused = fused_linear_cross_entropy_loss(x, w, labels, chunk_size=chunk_size)
+    naive = _naive_loss(x, w, labels)
+    np.testing.assert_allclose(fused, naive, rtol=1e-5, atol=1e-5)
+
+  def test_single_sample(self):
+    """N=1 edge case."""
+    N, D, V, chunk_size = 1, 8, 16, 4
+    key = jax.random.key(12)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    fused = fused_linear_cross_entropy_loss(x, w, labels, chunk_size=chunk_size)
+    naive = _naive_loss(x, w, labels)
+    np.testing.assert_allclose(fused, naive, rtol=1e-5, atol=1e-5)
+
+  def test_chunk_size_1(self):
+    """Degenerate chunk_size=1: one vocab entry per scan step."""
+    N, D, V, chunk_size = 4, 8, 8, 1
+    key = jax.random.key(14)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    fused = fused_linear_cross_entropy_loss(x, w, labels, chunk_size=chunk_size)
+    naive = _naive_loss(x, w, labels)
+    np.testing.assert_allclose(fused, naive, rtol=1e-5, atol=1e-5)
+
+  def test_gradient_x_chunk_size_1(self):
+    N, D, V, chunk_size = 4, 8, 8, 1
+    key = jax.random.key(15)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    dx_f = jax.grad(
+        lambda x_: fused_linear_cross_entropy_loss(x_, w, labels, chunk_size=chunk_size)
+    )(x)
+    dx_n = jax.grad(lambda x_: _naive_loss(x_, w, labels))(x)
+    np.testing.assert_allclose(dx_f, dx_n, rtol=1e-4, atol=1e-5)
+
+  def test_large_vocab_forward(self):
+    """Larger V to exercise multi-chunk behaviour."""
+    N, D, V, chunk_size = 16, 64, 1024, 128
+    key = jax.random.key(20)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    fused = fused_linear_cross_entropy_loss(x, w, labels, chunk_size=chunk_size)
+    naive = _naive_loss(x, w, labels)
+    np.testing.assert_allclose(fused, naive, rtol=1e-4, atol=1e-4)
+
+  def test_large_vocab_grad(self):
+    N, D, V, chunk_size = 8, 32, 512, 64
+    key = jax.random.key(21)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    dx_f = jax.grad(
+        lambda x_: fused_linear_cross_entropy_loss(x_, w, labels, chunk_size=chunk_size)
+    )(x)
+    dx_n = jax.grad(lambda x_: _naive_loss(x_, w, labels))(x)
+    np.testing.assert_allclose(dx_f, dx_n, rtol=1e-4, atol=1e-4)
+
+  def test_default_chunk_size(self):
+    """Calling without chunk_size uses the default (4096)."""
+    N, D, V = 4, 8, 16
+    key = jax.random.key(30)
+    x = jax.random.normal(key, (N, D), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.fold_in(key, 1), (V, D), dtype=jnp.float32)
+    labels = jax.random.randint(jax.random.fold_in(key, 2), (N,), 0, V)
+
+    fused = fused_linear_cross_entropy_loss(x, w, labels)
+    naive = _naive_loss(x, w, labels)
+    np.testing.assert_allclose(fused, naive, rtol=1e-5, atol=1e-5)
+
+  def test_invalid_chunk_size_raises(self):
+    x = jnp.ones((4, 8))
+    w = jnp.ones((16, 8))
+    labels = jnp.zeros((4,), dtype=jnp.int32)
+    with self.assertRaises(ValueError):
+      fused_linear_cross_entropy_loss(x, w, labels, chunk_size=0)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
Closes #35906 

## What
 
Adds `jax.experimental.fused_linear_cross_entropy_loss` — computes `cross_entropy(x @ w.T, labels)` without materializing the full `[N, V]` logits tensor.
 
## Why
 
For large vocabularies (128K+ tokens in Llama-3, 202K in Llama-4), the intermediate logits tensor dominates training memory. At typical LLM training scale:
 
| Config | Full logits | Chunked (cs=4096) | Reduction |
|---|---|---|---|
| Llama-3 (V=128K, N=8192, bf16) | 4.0 GB | 128 MB | 97% |
| Llama-4 (V=202K, N=8192, bf16) | 6.3 GB | 128 MB | 98% |
 
This is a solved problem in PyTorch (Apple CCE, Liger-Kernel) but JAX has no equivalent.
 
## How
 
Based on "Cut Your Losses in Large-Vocabulary Language Models" ([Wijmans et al., 2024](https://arxiv.org/abs/2411.09009)):
 
- **Forward:** Computes target logit directly in O(N·D). Log-sum-exp denominator computed via `lax.scan` over vocabulary chunks with online max + sum(exp) accumulators.
- **Backward:** `custom_vjp` recomputes logits per-chunk (trading compute for memory). Accumulates `dx` and `dw` without ever storing `[N, V]` tensors. Only residuals saved: `x`, `w`, and per-position `lse` (shape `[N]`).
- Pure JAX — no Pallas or Triton dependency. Works on CPU, GPU, and TPU.
 
## Tests
 
33 tests covering:
 
- Forward accuracy vs naive full-matmul implementation (float32 + bfloat16, multiple shapes)
- Gradient accuracy for `dx` and `dw`
- `jit` compilation (forward + backward)
- Edge cases: V=1, V < chunk\_size, chunk\_size=1, N=1, large vocab, non-divisible sizes
- Invalid input validation
 
## Disclosure
 
This implementation was developed with AI assistance (Claude). I have reviewed all code, verified correctness across all test cases, and understand the algorithm and design decisions. Happy to discuss any part of the implementation in review.

cc @pillow37