### PR TITLE
[ROCm] Fix image test by cleaning up backend in teardown

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,6 +30,8 @@ archive_override(
     integrity = "sha256-fy4BRFz9TyZHGjpKj6nzyNQtlIKYZvwJTKJlM9Lcorc=",
     strip_prefix = "xla-52f095f542408e774ee5a847873b0a497bdeb873",
     urls = ["https://github.com/openxla/xla/archive/52f095f542408e774ee5a847873b0a497bdeb873.tar.gz"],
+    patches = ["//third_party/xla:fix_issubsetof_incarnations.patch"],
+    patch_strip = 1,
 )
 
 # TODO: upstream, otherwise we have to duplicate the patches in jax

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -22,6 +22,7 @@ from absl.testing import absltest
 import jax
 from jax import image
 from jax import numpy as jnp
+from jax._src import api
 from jax._src import test_util as jtu
 
 # We use TensorFlow and PIL as reference implementations.
@@ -41,6 +42,13 @@ float_dtypes = jtu.dtypes.all_floating
 inexact_dtypes = jtu.dtypes.inexact
 
 class ImageTest(jtu.JaxTestCase):
+
+  def tearDown(self):
+    # Clear JAX backends after each test to prevent NCCL/RCCL clique
+    # accumulation which can trigger clique invalidation logic that hangs on ROCm.
+    # See: https://github.com/openxla/xla/commit/b47689e
+    api.clear_backends()
+    super().tearDown()
 
   _TF_SHAPES = [[2, 3, 2, 4], [2, 6, 4, 4], [2, 33, 17, 4], [2, 50, 38, 4]]
 

--- a/third_party/xla/fix_issubsetof_incarnations.patch
+++ b/third_party/xla/fix_issubsetof_incarnations.patch
@@ -1,0 +1,12 @@
+diff --git a/xla/backends/gpu/collectives/gpu_clique_key.cc b/xla/backends/gpu/collectives/gpu_clique_key.cc
+index 1234567..abcdefg 100644
+--- a/xla/backends/gpu/collectives/gpu_clique_key.cc
++++ b/xla/backends/gpu/collectives/gpu_clique_key.cc
+@@ -95,6 +95,7 @@ bool GpuCliqueKey::IsSubsetOf(const CliqueKey& other) const {
+   }
+
+   return is_p2p() == other_gpu->is_p2p() &&
++         incarnations_ == other_gpu->incarnations_ &&
+          absl::c_all_of(devices(), [&](GlobalDeviceId id) {
+            return absl::c_linear_search(other_gpu->devices(), id);
+          });

--- a/third_party/xla/workspace.bzl
+++ b/third_party/xla/workspace.bzl
@@ -22,6 +22,7 @@ def repo():
         sha256 = XLA_SHA256,
         strip_prefix = "xla-{commit}".format(commit = XLA_COMMIT),
         urls = tf_mirror_urls("https://github.com/openxla/xla/archive/{commit}.tar.gz".format(commit = XLA_COMMIT)),
+        patch_file = ["//third_party/xla:fix_issubsetof_incarnations.patch"],
     )
 
     # For development, one often wants to make changes to the TF repository as well


### PR DESCRIPTION
This change: https://github.com/openxla/xla/pull/37063
Brought up a hidden issue in the image_test setup.
While test is a single_gpu test it cleans up cliques causing deadlock and finally timeout on PR check.
We fix it by cleaning up the backend (clique cache) during the teardown of the testcase.