### PR TITLE
Rocm/s3 wheel downloads

### DIFF
--- a/.github/actions/download-jax-rocm-wheels/action.yml
+++ b/.github/actions/download-jax-rocm-wheels/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: "GCS location prefix from where the artifacts should be downloaded"
     default: 'gs://general-ml-ci-transient/jax-github-actions/jax/${{ github.workflow }}/${{ github.run_number }}/${{ github.run_attempt }}'
     type: string
+  s3_download_uri:
+    description: "S3 URI for ROCm plugin/PJRT wheels (use 'latest' to resolve via LATEST pointer)"
+    default: 'latest'
+    type: string
 permissions: {}
 runs:
   using: "composite"
@@ -86,25 +90,19 @@ runs:
           if [[ ${INPUTS_JAXLIB_VERSION} == "head" ]]; then
             gcloud storage cp -r "${INPUTS_GCS_DOWNLOAD_URI}/jaxlib*${PYTHON_MAJOR_MINOR}*${OS}*${ARCH}*.whl" $(pwd)/dist/
 
-            # Get the latest release tag (including pre-releases) from ROCm/jax-plugin
-            echo "Finding latest ROCm plugin release (including pre-releases)..."
-            LATEST_PLUGIN_TAG=$(gh release list -R ROCm/jax-plugin --limit 10 --json tagName,publishedAt \
-                                --jq 'sort_by(.publishedAt) | reverse | .[0].tagName')
-            echo "Latest plugin release: $LATEST_PLUGIN_TAG"
+            # Resolve the S3 URI for ROCm plugin/PJRT wheels.
+            if [[ "${INPUTS_S3_DOWNLOAD_URI}" == "latest" ]]; then
+              S3_URI=$(aws s3 cp "s3://jax-ci-amd/rocm-wheels/LATEST" -)
+              echo "Resolved LATEST pointer to: ${S3_URI}"
+            else
+              S3_URI="${INPUTS_S3_DOWNLOAD_URI}"
+            fi
 
-            # Download ROCm PJRT plugin from latest release
-            echo "Downloading ROCm PJRT plugin from release $LATEST_PLUGIN_TAG..."
-            gh release download "$LATEST_PLUGIN_TAG" \
-              --repo ROCm/jax-plugin \
-              --pattern "jax_rocm${JAXCI_ROCM_VERSION}_pjrt-*-py3-none-manylinux*.whl" \
-              --dir $(pwd)/dist/
-
-            # Download ROCm plugin from latest release
-            echo "Downloading ROCm plugin from release $LATEST_PLUGIN_TAG..."
-            gh release download "$LATEST_PLUGIN_TAG" \
-              --repo ROCm/jax-plugin \
-              --pattern "jax_rocm${JAXCI_ROCM_VERSION}_plugin-*-${PYTHON_MAJOR_MINOR}*manylinux*.whl" \
-              --dir $(pwd)/dist/
+            echo "Downloading ROCm wheels from ${S3_URI}..."
+            aws s3 cp --recursive "${S3_URI}/" $(pwd)/dist/ \
+              --exclude "*" \
+              --include "jax_rocm${JAXCI_ROCM_VERSION}_pjrt-*-py3-none-manylinux*.whl" \
+              --include "jax_rocm${JAXCI_ROCM_VERSION}_plugin-*-${PYTHON_MAJOR_MINOR}*manylinux*.whl"
           elif [[ ${INPUTS_JAXLIB_VERSION} == "pypi_latest" ]]; then
             PYTHON=python${INPUTS_PYTHON}
             $PYTHON -m pip download jaxlib jax-rocm${JAXCI_ROCM_VERSION}-pjrt jax-rocm${JAXCI_ROCM_VERSION}-plugin --dest $(pwd)/dist/
@@ -119,6 +117,7 @@ runs:
         INPUTS_SKIP_DOWNLOAD_JAXLIB_AND_PLUGINS_FROM_GCS: ${{ inputs.skip-download-jaxlib-and-plugins-from-gcs }}
         INPUTS_JAXLIB_VERSION: ${{ inputs.jaxlib-version }}
         INPUTS_PYTHON: ${{ inputs.python }}
+        INPUTS_S3_DOWNLOAD_URI: ${{ inputs.s3_download_uri }}
     - name: Skip the test run if the wheel artifacts were not downloaded successfully
       shell: bash
       if: steps.download-wheel-artifacts.outcome == 'failure'

--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -156,6 +156,9 @@ jobs:
           ls -lh $JAXCI_OUTPUT_DIR/*.whl
           aws s3 cp --only-show-errors --recursive $JAXCI_OUTPUT_DIR/ "${INPUTS_S3_UPLOAD_URI}"/
           echo "Upload complete."
+
+          echo "${INPUTS_S3_UPLOAD_URI}" | \
+            aws s3 cp --only-show-errors - "s3://jax-ci-amd/rocm-wheels/LATEST"
         env:
           INPUTS_S3_UPLOAD_URI: ${{ inputs.s3_upload_uri }}
       - name: Store the S3 upload URI as an output

--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -7,7 +7,7 @@
 # It consists of the following job:
 # run-tests:
 #    - Runs in ROCm team's container (ghcr.io/rocm/jax-base-ubu24-rocm*:latest)
-#    - Downloads the JAX and jaxlib wheels from GCS, and ROCm plugins from latest release.
+#    - Downloads the JAX and jaxlib wheels from GCS, and ROCm plugins from S3.
 #    - Executes the `run_pytest_rocm.sh` script, which performs the following actions:
 #      - Installs the downloaded wheel artifacts.
 #      - Runs the ROCm tests with Pytest.
@@ -59,6 +59,10 @@ on:
         description: "GCS location prefix from where the artifacts should be downloaded"
         type: string
         default: 'gs://jax-nightly-artifacts/latest'
+      s3_download_uri:
+        description: "S3 URI for ROCm plugin/PJRT wheels (use 'latest' to resolve via LATEST pointer)"
+        type: string
+        default: 'latest'
       halt-for-connection:
         description: 'Should this workflow run wait for a remote connection?'
         type: string
@@ -92,6 +96,10 @@ on:
       gcs_download_uri:
         description: "GCS location prefix from where the artifacts should be downloaded"
         default: 'gs://jax-nightly-artifacts/latest'
+        type: string
+      s3_download_uri:
+        description: "S3 URI for ROCm plugin/PJRT wheels (use 'latest' to resolve via LATEST pointer)"
+        default: 'latest'
         type: string
 permissions:
   id-token: write
@@ -128,6 +136,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # ratchet:aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::661452401056:role/jax-ci-amd-s3-oidc
+          aws-region: us-east-1
       - name: Download JAX ROCm wheels
         uses: ./.github/actions/download-jax-rocm-wheels
         with:
@@ -136,8 +149,7 @@ jobs:
           jaxlib-version: ${{ inputs.jaxlib-version }}
           skip-download-jaxlib-and-plugins-from-gcs: ${{ inputs.skip-download-jaxlib-and-plugins-from-gcs }}
           gcs_download_uri: ${{ inputs.gcs_download_uri }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          s3_download_uri: ${{ inputs.s3_download_uri }}
       - name: Install Python dependencies
         run: |
           $JAXCI_PYTHON -m pip install uv~=0.5.30
@@ -156,12 +168,6 @@ jobs:
         run: |
           set -euo pipefail
           tar -czf logs.tar.gz logs
-      - name: Configure AWS Credentials
-        if: ${{ !cancelled() }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # ratchet:aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws:iam::661452401056:role/jax-ci-amd-s3-oidc
-          aws-region: us-east-1
       - name: Upload test-artifacts to AMD S3
         if: ${{ !cancelled() }}
         env:

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -305,8 +305,15 @@ jobs:
         matrix:
           runner: ["linux-x86-64-1gpu-amd"]
           artifact: ["jax-rocm-plugin", "jax-rocm-pjrt"]
-          python: ["3.11"]
+          python: ["3.11", "3.12", "3.13", "3.14"]
           rocm-version: ["7"]
+          exclude:
+            - artifact: "jax-rocm-pjrt"
+              python: "3.12"
+            - artifact: "jax-rocm-pjrt"
+              python: "3.13"
+            - artifact: "jax-rocm-pjrt"
+              python: "3.14"
     name: "Build ${{ format('{0}', 'ROCm') }} artifacts"
     with:
       runner: ${{ matrix.runner }}

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -344,6 +344,7 @@ jobs:
       rocm-tag: ${{ matrix.rocm.tag }}
       jaxlib-version: "head"
       gcs_download_uri: ${{ needs.build-jaxlib-artifact.outputs.gcs_upload_uri }}
+      s3_download_uri: 's3://jax-ci-amd/rocm-wheels/wheel-tests-continuous/${{ github.run_number }}/${{ github.run_attempt }}'
 
   run-bazel-test-rocm:
     if: ${{ !cancelled() }}

--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -11,7 +11,7 @@
 # 4. run-bazel-test-cuda: Calls the `bazel_cuda.yml` workflow which downloads the JAX wheels
 #                     that were built by internal CI jobs and runs Bazel CUDA tests.
 # 5. run-pytest-rocm: Calls the `pytest_rocm.yml` workflow which downloads the JAX wheels and
-#                     ROCm plugins from PyPI/GitHub releases and runs ROCm tests.
+#                     ROCm plugins from S3 and runs ROCm tests.
 # 6. run-pytest-tpu: Calls the `pytest_tpu.yml` workflow which downloads the JAX wheels that were
 #                    built by internal CI jobs and runs TPU tests.
 # 7. run-bazel-test-tpu: Calls the `bazel_test_tpu.yml` workflow which downloads the JAX wheels that


### PR DESCRIPTION
## Summary

Replace the use of `gh` (GitHub CLI) for downloading ROCm plugin and PJRT wheels
from `ROCm/jax-plugin` GitHub Releases with direct S3 downloads from the
`jax-ci-amd` bucket where the build workflow already uploads them.

This eliminates the dependency on `GH_TOKEN` and the `ROCm/jax-plugin` release
cadence for CI, giving us a self-contained build-and-test pipeline where the
continuous workflow builds wheels, uploads them to S3, and the test workflow
downloads them from the same location.

## Changes

- **`build_rocm_artifacts.yml`**: After uploading wheels to S3, write a `LATEST`
  pointer file (`s3://jax-ci-amd/rocm-wheels/LATEST`) containing the full S3
  upload URI. This allows downstream consumers to resolve the most recent build
  without enumerating bucket contents.

- **`wheel_tests_continuous.yml`**: Expand the ROCm build matrix from Python
  3.11 only to `[3.11, 3.12, 3.13, 3.14]`, matching the versions tested by the
  nightly workflow. The `jax-rocm-pjrt` wheel is Python-agnostic (`py3-none`) so
  it is excluded from the extra Python versions to avoid redundant builds (5 jobs
  instead of 8). Pass the run-specific S3 URI to the test job.

- **`download-jax-rocm-wheels/action.yml`**: Add `s3_download_uri` input
  (default: `latest`). Replace `gh release list` + `gh release download` with
  `aws s3 cp`. When `s3_download_uri` is `latest`, resolve the `LATEST` pointer
  to get the full URI. The `pypi_latest` code path is unchanged.

- **`pytest_rocm.yml`**: Add `s3_download_uri` input to both `workflow_dispatch`
  and `workflow_call`, pass it through to the composite action, and remove the
  now-unnecessary `GH_TOKEN` env. Move AWS credentials setup before the download
  step so it serves both wheel download and log upload.

- **`wheel_tests_nightly_release.yml`**: Update comment to reflect S3 instead of
  GitHub Releases. The `s3_download_uri` defaults to `latest`, resolving via the
  `LATEST` pointer at download time.
