### PR TITLE
tree_util.register_dataclass: fix drop_fields bug

### DIFF
--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -1030,6 +1030,9 @@ def register_dataclass(
       Data fields *must* be JAX-compatible objects such as arrays (:class:`jax.Array`
       or :class:`numpy.ndarray`), scalars, or pytrees whose leaves are arrays or scalars.
       Note that ``None`` is a valid data field, as JAX recognizes this as an empty pytree.
+    drop_fields: only referenced if ``nodetype`` is a dataclass. Specify a sequence of
+      field names from among ``dataclasses.fields(nodetype)`` to be excluded from pytree
+      registration.
 
   Returns:
     The input class ``nodetype`` is returned unchanged after being added to JAX's
@@ -1128,7 +1131,7 @@ def register_dataclass(
 
   if dataclasses.is_dataclass(nodetype):
     init_fields = {f.name for f in dataclasses.fields(nodetype) if f.init}
-    init_fields.difference_update(*drop_fields)
+    init_fields.difference_update(drop_fields)
     if {*meta_fields, *data_fields} != init_fields:
       msg = (
           "data_fields and meta_fields must include all dataclass fields with"

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -1718,10 +1718,11 @@ class RegistrationTest(jtu.JaxTestCase):
     class Foo:
       x: int
       y: int = dataclasses.field(default=42)
+      z: int = dataclasses.field(default=42)
 
-    # ``y`` is explicitly excluded.
+    # ``y`` and ``z`` are explicitly excluded.
     tree_util.register_dataclass(
-        Foo, data_fields=["x"], meta_fields=[], drop_fields=["y"]
+        Foo, data_fields=["x"], meta_fields=[], drop_fields=["y", "z"]
     )
 
   def test_register_dataclass_invalid_plain_class(self):


### PR DESCRIPTION
Also document `drop_fields` (fixes #26557).

Previously `drop_fields` would only work correctly if it contained a single length-1 string, which happened to be the only case we tested.