### PR TITLE
Added PyObjectType support for pure_callback and py_traced_argnums for jit

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -132,6 +132,8 @@ from jax._src.xla_bridge import process_count as process_count
 from jax._src.xla_bridge import process_index as process_index
 from jax._src.xla_bridge import process_indices as process_indices
 from jax._src.callback import pure_callback as pure_callback
+from jax._src.callback import PyObjectType as PyObjectType
+from jax._src.core import PyObjectHandle as PyObjectHandle
 from jax._src.core import ShapeDtypeStruct as ShapeDtypeStruct
 from jax._src.api import value_and_grad as value_and_grad
 from jax._src.api import vjp as vjp

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -173,6 +173,7 @@ def jit(
   backend: str | None = ...,
   inline: bool = ...,
   compiler_options: dict[str, Any] | None = ...,
+  py_traced_argnums: int | Sequence[int] = ...,
 ) -> pjit.JitWrapped: ...
 
 @overload
@@ -189,6 +190,7 @@ def jit(
   backend: str | None = ...,
   inline: bool = ...,
   compiler_options: dict[str, Any] | None = ...,
+  py_traced_argnums: int | Sequence[int] = ...,
 ) -> Callable[[Callable], pjit.JitWrapped]: ...
 
 def jit(
@@ -204,6 +206,7 @@ def jit(
   backend: str | None = None,
   inline: bool = False,
   compiler_options: dict[str, Any] | None = None,
+  py_traced_argnums: int | Sequence[int] = (),
 ) -> pjit.JitWrapped | Callable[[Callable], pjit.JitWrapped]:
   """Sets up ``fun`` for just-in-time compilation with XLA.
 
@@ -342,6 +345,9 @@ def jit(
     >>> g(jnp.arange(4), 3)
     Array([   0,    1,  256, 6561], dtype=int32)
   """
+  if isinstance(py_traced_argnums, int):
+    py_traced_argnums = (py_traced_argnums,)
+  py_traced_argnums = tuple(py_traced_argnums)
   kwds = dict(
       in_shardings=in_shardings, out_shardings=out_shardings,
       static_argnums=static_argnums, static_argnames=static_argnames,
@@ -349,9 +355,28 @@ def jit(
       keep_unused=keep_unused, device=device, backend=backend, inline=inline,
       compiler_options=compiler_options, use_resource_env=False)
   if isinstance(fun, NotSpecified):
-    return lambda fun: pjit.make_jit(fun, **kwds)
+    return lambda fun: _make_jit_with_pyobj(fun, py_traced_argnums, kwds)
   else:
-    return pjit.make_jit(fun, **kwds)
+    return _make_jit_with_pyobj(fun, py_traced_argnums, kwds)
+
+
+def _make_jit_with_pyobj(fun, py_traced_argnums, jit_kwds):
+  inner = pjit.make_jit(fun, **jit_kwds)
+  if not py_traced_argnums:
+    return inner
+
+  import functools
+
+  @functools.wraps(fun)
+  def wrapper(*args, **kwargs):
+    from jax._src.core import PyObjectHandle  # lazy import to avoid circularity
+    new_args = list(args)
+    for i in py_traced_argnums:
+      if i < len(args):
+        new_args[i] = PyObjectHandle(args[i])
+    return inner(*new_args, **kwargs)
+
+  return wrapper
 
 if not TYPE_CHECKING:
   # TODO(slebedev): This ought to be a decorator, but it seems it makes

--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -1338,3 +1338,24 @@ def _token_global_result_handler(global_aval, out_sharding, committed):
     return core.Token(array)
   return array_handler.wrap(wrapper)
 pxla.global_result_handlers[core.AbstractToken] = _token_global_result_handler
+
+
+def _pyobj_global_result_handler(global_aval, out_sharding, committed):
+  uint32_aval = core.ShapedArray((), np.dtype(np.uint32))
+  return _array_global_result_handler(uint32_aval, out_sharding, committed)
+
+pxla.global_result_handlers[core.AbstractPyObject] = _pyobj_global_result_handler
+
+
+def _pyobj_shard_arg(xs, shardings, layouts, copy_semantics):
+  import numpy as _np
+  results = []
+  for x, sharding, layout, sem in safe_zip(xs, shardings, layouts, copy_semantics):
+    uint32_arr = _np.array(int(x), dtype=_np.uint32)
+    uint32_aval = core.ShapedArray((), _np.dtype(_np.uint32))
+    devices = sharding._addressable_device_assignment
+    results.append(pxla.batched_device_put(
+        uint32_aval, sharding, [uint32_arr] * len(devices), devices))
+  return results
+
+pxla.shard_arg_handlers[core.PyObjectHandle] = _pyobj_shard_arg

--- a/jax/_src/callback.py
+++ b/jax/_src/callback.py
@@ -53,6 +53,8 @@ map, unsafe_map = util.safe_map, map
 zip, unsafe_zip = util.safe_zip, zip
 
 
+PyObjectType = core.abstract_pyobject
+
 @dataclasses.dataclass(frozen=True)
 class _FlatCallback:
   """A Python function callable with flat arguments and results.
@@ -64,10 +66,24 @@ class _FlatCallback:
   """
   callback_func: Callable[..., Any]
   in_tree: tree_util.PyTreeDef  # (args, kwargs) pytree for `callback_func`.
+  result_avals: tuple[core.AbstractValue, ...] = ()
+  input_pyobj_mask: tuple[bool, ...] = ()
 
   def __call__(self, *flat_args: Array) -> Sequence[Array]:
+    if self.input_pyobj_mask:
+      flat_args = tuple(
+          core._unwrap_pyobj(int(np.asarray(a))) if is_po else a
+          for a, is_po in zip(flat_args, self.input_pyobj_mask)
+      )
     args, kwargs = tree_util.tree_unflatten(self.in_tree, flat_args)
-    return tree_util.tree_leaves(self.callback_func(*args, **kwargs))
+    results = tree_util.tree_leaves(self.callback_func(*args, **kwargs))
+    if self.result_avals and any(
+        isinstance(a, core.AbstractPyObject) for a in self.result_avals):
+      results = [
+          core._wrap_pyobj(r) if isinstance(aval, core.AbstractPyObject) else r
+          for r, aval in zip(results, self.result_avals)
+      ]
+    return results
 
 
 def pure_callback_impl(
@@ -249,6 +265,8 @@ def pure_callback_lowering(
 mlir.register_lowering(pure_callback_p, pure_callback_lowering, cacheable=False)
 
 def _check_shape_dtype(shape_dtype):
+  if shape_dtype is PyObjectType:
+    return
   dt = np.dtype(shape_dtype.dtype)
   if dtypes.canonicalize_dtype(dt) != dt:
     raise ValueError(
@@ -382,13 +400,24 @@ def pure_callback(
         f"but got: {vmap_method}")
 
   flat_args, in_tree = tree_util.tree_flatten((args, kwargs))
-  tree_util.tree_map(_check_shape_dtype, result_shape_dtypes)
+  tree_util.tree_map(
+      _check_shape_dtype, result_shape_dtypes,
+      is_leaf=lambda x: x is PyObjectType)
   result_avals = tree_util.tree_map(
-      lambda x: core.ShapedArray(x.shape, x.dtype), result_shape_dtypes)
-  flat_result_avals, out_tree = tree_util.tree_flatten(result_avals)
+      lambda x: core.abstract_pyobject if x is PyObjectType
+                else core.ShapedArray(x.shape, x.dtype),
+      result_shape_dtypes,
+      is_leaf=lambda x: x is PyObjectType)
+  flat_result_avals, out_tree = tree_util.tree_flatten(
+      result_avals, is_leaf=lambda x: isinstance(x, core.AbstractPyObject))
+  input_pyobj_mask = tuple(
+      isinstance(core.shaped_abstractify(a), core.AbstractPyObject)
+      for a in flat_args)
   out_flat = pure_callback_p.bind(
       *flat_args,
-      callback=_FlatCallback(callback, in_tree),
+      callback=_FlatCallback(callback, in_tree,
+                             result_avals=tuple(flat_result_avals),
+                             input_pyobj_mask=input_pyobj_mask),
       result_avals=tuple(flat_result_avals),
       sharding=sharding,
       vmap_method=vmap_method,
@@ -689,6 +718,9 @@ _xla_shape_handlers[core.ShapedArray] = _make_array_shape
 
 _xla_shape_handlers[core.AbstractToken] = lambda _: xc.Shape.token_shape()
 
+_xla_shape_handlers[core.AbstractPyObject] = lambda _: xc.Shape.array_shape(
+    np.dtype(np.uint32), ())
+
 
 def _emit_tpu_python_callback(
     backend: xc.Client,
@@ -819,17 +851,22 @@ def emit_python_callback(
       raise RuntimeError(
           "Mismatched number of outputs from callback. "
           "Expected: {}, Actual: {}".format(len(result_avals), len(out_vals)))
-    # Handle Python literals, and custom arrays, e.g., tf.Tensor.
-    out_vals = tuple(dtypes.canonicalize_value(np.asarray(a)) for a in out_vals)
+    processed = []
     for i, (out_val, out_aval) in enumerate(zip(out_vals, result_avals)):
-      if out_val.shape != out_aval.shape:
-        raise RuntimeError(
-            f"Incorrect output shape for return value #{i}: "
-            f"Expected: {out_aval.shape}, Actual: {out_val.shape}")
-      if out_val.dtype != out_aval.dtype:
-        raise RuntimeError(
-            f"Incorrect output dtype for return value #{i}: "
-            f"Expected: {out_aval.dtype}, Actual: {out_val.dtype}")
+      if isinstance(out_aval, core.AbstractPyObject):
+        processed.append(np.asarray(out_val, dtype=np.uint32))
+      else:
+        out_val = dtypes.canonicalize_value(np.asarray(out_val))
+        if out_val.shape != out_aval.shape:
+          raise RuntimeError(
+              f"Incorrect output shape for return value #{i}: "
+              f"Expected: {out_aval.shape}, Actual: {out_val.shape}")
+        if out_val.dtype != out_aval.dtype:
+          raise RuntimeError(
+              f"Incorrect output dtype for return value #{i}: "
+              f"Expected: {out_aval.dtype}, Actual: {out_val.dtype}")
+        processed.append(out_val)
+    out_vals = tuple(processed)
 
     if platform == "tpu":
       # On TPU we cannot receive empty arrays. So, we return from the wrapped
@@ -839,7 +876,8 @@ def emit_python_callback(
       non_empty_out_vals = tuple(
           out_val
           for out_val, result_aval in zip(out_vals, result_avals)
-          if not is_empty_shape(result_aval.shape))
+          if isinstance(result_aval, core.AbstractPyObject)
+          or not is_empty_shape(result_aval.shape))
       return non_empty_out_vals
     else:
       return out_vals
@@ -848,7 +886,7 @@ def emit_python_callback(
     non_empty_result_avals, non_empty_result_shapes = util.unzip2([
         (aval, shape)
         for aval, shape in zip(result_avals, result_shapes)
-        if not is_empty_shape(aval.shape)])
+        if isinstance(aval, core.AbstractPyObject) or not is_empty_shape(aval.shape)])
     non_empty_outputs, token = _emit_tpu_python_callback(
         backend, ctx, _wrapped_callback,  token,
         operands, operand_avals, operand_shapes,
@@ -857,7 +895,8 @@ def emit_python_callback(
     non_empty_outputs_iter = iter(non_empty_outputs)
     outputs = [
         mlir.ir_constant(np.zeros(result_aval.shape, dtype=result_aval.dtype))
-        if is_empty_shape(result_aval.shape) else next(non_empty_outputs_iter)
+        if not isinstance(result_aval, core.AbstractPyObject)
+        and is_empty_shape(result_aval.shape) else next(non_empty_outputs_iter)
         for result_aval in result_avals]
     return outputs, token, None
 

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2768,6 +2768,57 @@ class Token:
 pytype_aval_mappings[Token] = lambda _: abstract_token
 dtypes.canonicalize_value_handlers[Token] = lambda x: x
 
+_pyobj_registry: dict[int, Any] = {}
+_pyobj_next_id: int = 0
+
+
+class AbstractPyObject(AbstractValue):
+  dtype = np.dtype(np.uint32)
+  shape = ()
+  ndim = 0
+  size = 1
+  weak_type = False
+
+  def str_short(self, short_dtypes=False, mesh_axis_types=False): return 'PyObject'
+  def to_tangent_aval(self): raise TypeError("PyObject has no tangent aval")
+  def to_ct_aval(self): raise TypeError("PyObject has no cotangent aval")
+  def update(self, **kwargs): return self
+  def strip_weak_type(self): return self
+
+abstract_pyobject: AbstractPyObject = AbstractPyObject()
+
+
+def _wrap_pyobj(obj: Any) -> np.ndarray:
+  global _pyobj_next_id
+  idx = _pyobj_next_id
+  _pyobj_next_id += 1
+  _pyobj_registry[idx] = obj
+  return np.array(idx, dtype=np.uint32)
+
+
+def _unwrap_pyobj(idx: int) -> Any:
+  obj = _pyobj_registry.get(idx)
+  if obj is None:
+    raise RuntimeError(
+        f"PyObject handle {idx} is not registered; "
+        "the object may have been garbage collected")
+  return obj
+
+
+class PyObjectHandle(np.ndarray):
+  """A uint32 numpy scalar representing an opaque Python object by index."""
+
+  def __new__(cls, obj: Any):
+    global _pyobj_next_id
+    idx = _pyobj_next_id
+    _pyobj_next_id += 1
+    _pyobj_registry[idx] = obj
+    instance = np.array(idx, dtype=np.uint32).view(cls)
+    return instance
+
+
+pytype_aval_mappings[PyObjectHandle] = lambda _: abstract_pyobject
+
 
 class AbstractTodo(AbstractValue):
   def __init__(self, inner_aval):

--- a/jax/_src/ffi.py
+++ b/jax/_src/ffi.py
@@ -177,7 +177,9 @@ def include_dir() -> str:
 
 
 def _aval_shape(aval: core.AbstractValue) -> Shape:
-  return () if aval is core.abstract_token else core.physical_aval(aval).shape  # pytype: disable=attribute-error  # pyrefly: ignore[missing-attribute]
+  if aval is core.abstract_token or isinstance(aval, core.AbstractPyObject):
+    return ()
+  return core.physical_aval(aval).shape  # pytype: disable=attribute-error  # pyrefly: ignore[missing-attribute]
 
 
 def _convert_layout_for_lowering(

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -212,6 +212,8 @@ def aval_to_ir_type(aval: core.AbstractValue) -> IrTypes:
 ir_type_handlers[core.ShapedArray] = _array_ir_types
 ir_type_handlers[core.AbstractToken] = lambda _: hlo.TokenType.get()
 ir_type_handlers[core.AbstractTodo] = lambda x: _array_ir_types(x.inner_aval)
+ir_type_handlers[core.AbstractPyObject] = lambda _: ir.RankedTensorType.get(
+    [], ir.IntegerType.get_unsigned(32))
 
 # This is a backwards compatibility shim for external users of jax.mlir apis.
 def aval_to_ir_types(aval: core.AbstractValue) -> tuple[ir.Type, ...]:
@@ -1366,7 +1368,8 @@ def _set_up_aliases(input_output_aliases, avals_in, avals_out,
     input_output_aliases = list(input_output_aliases)
   # To match-up in-avals to out-avals we only care about the number of
   # bytes, so we strip off unrelated aval metadata (eg. the named shape)
-  strip_metadata = lambda a: (a if a is core.abstract_token else
+  strip_metadata = lambda a: (a if a is core.abstract_token
+                              or isinstance(a, core.AbstractPyObject) else
                               core.ShapedArray(a.shape, a.dtype))
   avals_in = map(strip_metadata, avals_in)
   avals_out = map(strip_metadata, avals_out)
@@ -1433,7 +1436,8 @@ def _set_up_aliases(input_output_aliases, avals_in, avals_out,
 
   results_not_matched = collections.defaultdict(collections.deque)
   for i, (aval, rm) in enumerate(zip(avals_out, result_memory_kinds)):
-    if i not in aliased_output_ids and aval is not core.abstract_token:
+    if (i not in aliased_output_ids and aval is not core.abstract_token
+        and not isinstance(aval, core.AbstractPyObject)):
       results_not_matched[(aval.size, rm)].append(i)  # pyrefly: ignore[missing-attribute]
 
   # For each donated argument that hasn't been aliased or donated to XLA, try to
@@ -1939,6 +1943,7 @@ def lower_jaxpr_to_fun(
       flat_outputs = [
           replicate_trailing_dims(entry_lowering_ctx, o, a)
           if (a is not core.abstract_token and
+              not isinstance(a, core.AbstractPyObject) and
               dtypes.issubdtype(a.dtype, dtypes.extended) and
               (s is None or all_unconstrained(rs, a))) else o  # pytype: disable=attribute-error
           for o, s, a, rs in zip(flat_outputs, ir_result_shardings, output_avals,  # pyrefly: ignore[no-matching-overload]  # pyrefly#2385

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -2319,7 +2319,9 @@ def lower_sharding_computation(
         else s for s, aval in zip(in_shardings, global_in_avals))
 
   for a in global_out_avals:
-    if (a is not core.abstract_token and not a.sharding.mesh.empty and
+    if (a is not core.abstract_token and
+        not isinstance(a, core.AbstractPyObject) and
+        not a.sharding.mesh.empty and
         a.sharding.mesh.are_all_axes_explicit and
         device_assignment is not None and
         len(device_assignment) != a.sharding.mesh.size):

--- a/tests/pyobj_callback_test.py
+++ b/tests/pyobj_callback_test.py
@@ -1,0 +1,150 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+import jax
+from jax._src import test_util as jtu
+from jax._src.core import _pyobj_registry
+import numpy as np
+
+
+class Tree:
+  def __init__(self, children=()):
+    self.children = children
+
+  def add_child(self, child):
+    return Tree(self.children + (child,))
+
+  def __eq__(self, other):
+    return isinstance(other, Tree) and self.children == other.children
+
+  def __repr__(self):
+    return f"Tree({self.children!r})"
+
+
+class PyObjCallbackTest(jtu.JaxTestCase):
+
+  def setUp(self):
+    super().setUp()
+    if not jtu.test_device_matches(["cpu", "gpu"]):
+      self.skipTest("PyObject callbacks only supported on CPU/GPU")
+
+  def test_pure_callback_returns_pyobj(self):
+    @jax.jit
+    def f():
+      return jax.pure_callback(lambda: Tree(), jax.PyObjectType)
+
+    result = f()
+    ptr = int(np.asarray(result))
+    obj = _pyobj_registry[ptr]
+    self.assertIsInstance(obj, Tree)
+    self.assertEqual(obj.children, ())
+
+  def test_pure_callback_pyobj_passthrough(self):
+    @jax.jit
+    def f():
+      root = jax.pure_callback(lambda: Tree(), jax.PyObjectType)
+      child = jax.pure_callback(lambda: Tree(), jax.PyObjectType)
+      return jax.pure_callback(
+          lambda r, c: r.add_child(c), jax.PyObjectType, root, child)
+
+    result = f()
+    ptr = int(np.asarray(result))
+    obj = _pyobj_registry[ptr]
+    self.assertIsInstance(obj, Tree)
+    self.assertEqual(len(obj.children), 1)
+    self.assertIsInstance(obj.children[0], Tree)
+
+  def test_py_traced_argnums_basic(self):
+    @jax.jit(py_traced_argnums=(0,))
+    def f(tree):
+      return jax.pure_callback(
+          lambda t: t.add_child(Tree()), jax.PyObjectType, tree)
+
+    root = Tree()
+    result = f(root)
+    ptr = int(np.asarray(result))
+    obj = _pyobj_registry[ptr]
+    self.assertIsInstance(obj, Tree)
+    self.assertEqual(len(obj.children), 1)
+
+  def test_py_traced_argnums_full_example(self):
+    @jax.jit(py_traced_argnums=(0,))
+    def foo(bar):
+      baz = jax.pure_callback(lambda: Tree(), jax.PyObjectType)
+      return jax.pure_callback(
+          lambda r, z: r.add_child(z), jax.PyObjectType, bar, baz)
+
+    bar = Tree()
+    result = foo(bar)
+    ptr = int(np.asarray(result))
+    obj = _pyobj_registry[ptr]
+    self.assertIsInstance(obj, Tree)
+    self.assertEqual(len(obj.children), 1)
+    self.assertIsInstance(obj.children[0], Tree)
+
+  def test_py_traced_argnums_no_recompile(self):
+    compile_count = [0]
+
+    @jax.jit(py_traced_argnums=(0,))
+    def f(tree):
+      compile_count[0] += 1
+      return jax.pure_callback(
+          lambda t: t.add_child(Tree()), jax.PyObjectType, tree)
+
+    f(Tree())
+    f(Tree((Tree(),)))
+    self.assertEqual(compile_count[0], 1,
+                     "Function should compile once for all Tree instances")
+
+  def test_pure_callback_mixed_results(self):
+    import jax.numpy as jnp
+
+    @jax.jit
+    def f(x):
+      arr_result = jnp.sum(x)
+      obj_result = jax.pure_callback(lambda: Tree(), jax.PyObjectType)
+      return arr_result, obj_result
+
+    arr, obj_handle = f(jnp.array([1.0, 2.0, 3.0]))
+    self.assertAlmostEqual(float(arr), 6.0)
+    ptr = int(np.asarray(obj_handle))
+    obj = _pyobj_registry[ptr]
+    self.assertIsInstance(obj, Tree)
+
+  def test_pyobjecttype_is_sentinel(self):
+    self.assertIs(jax.PyObjectType, jax.PyObjectType)
+
+  def test_pyobj_registry_keeps_objects_alive(self):
+    import gc
+    results = []
+
+    @jax.jit
+    def f():
+      return jax.pure_callback(lambda: Tree((Tree(),)), jax.PyObjectType)
+
+    for _ in range(3):
+      r = f()
+      results.append(r)
+      gc.collect()
+
+    for r in results:
+      ptr = int(np.asarray(r))
+      obj = _pyobj_registry[ptr]
+      self.assertIsInstance(obj, Tree)
+      self.assertEqual(len(obj.children), 1)
+
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This PR solves issue #35950

### Solution
Pointer-registry mechanism: Python objects are stored in a global dict keyed by a `uint32` counter index. That index flows through XLA as a `tensor<ui32>` and is looked up on the other side to recover the original object.

**Why `uint32` counter, not `id(obj)`?** `jax_enable_x64=False` silently downcasts 64-bit integers — using raw pointer addresses caused silent truncation and broken lookups.

**Why Python-level `py_traced_argnums`?** Implemented as a wrapper around `make_jit` that converts specified args to `PyObjectHandle` before JIT sees them — no C++ changes needed.

### What This Enables

Return opaque Python object from callback
```python 
@jax.jit
def f():
    return jax.pure_callback(lambda: MyObject(), jax.PyObjectType)
```

Pass Python objects as JIT args without recompilation
```python 
@jax.jit(py_traced_argnums=(0,))
def h(tree):
    return jax.pure_callback(lambda t: t.transform(), jax.PyObjectType, tree)

h(Tree())        # compiles once
h(Tree((1, 2)))  # reuses compilation
```

## File Changes
- `core.py` — `AbstractPyObject`, `PyObjectHandle`, registry globals
- `mlir.py` — maps `AbstractPyObject` → `tensor<ui32>`
- `callback.py` — wrap/unwrap logic in `_FlatCallback`, `PyObjectType` sentinel
- `api.py` — `py_traced_argnums` param on `jit`
- `array.py`, `pxla.py`, `ffi.py` — `AbstractPyObject` guards mirroring `abstract_token` pattern

## 8 New Tests Created and Passed

| Test | Description |
|---|---|
| `test_pure_callback_returns_pyobj` | Basic sanity: callback returns a Python object, JIT unwraps it correctly |
| `test_pure_callback_pyobj_passthrough` | Chaining: output of callbacks 1 & 2 passed as inputs to callback 3 — verifies registry round-trip across multiple hops |
| `test_py_traced_argnums_basic` | Python object passed *in* via `py_traced_argnums`, consumed inside JIT |
| `test_py_traced_argnums_full_example` | End-to-end: `py_traced_argnums` input + callback-returned PyObject used together |
| `test_py_traced_argnums_no_recompile` | Different object instances with same `py_traced_argnums` → abstract type is identical → no recompilation triggered |
| `test_pure_callback_mixed_results` | Callback returns `(Array, PyObject)` tuple — ensures mixed-type outputs don't break shape/dtype validation |
| `test_pyobjecttype_is_sentinel` | `jax.PyObjectType` is a singleton (`is` check) — guards against accidental copies breaking identity comparisons |
| `test_pyobj_registry_keeps_objects_alive` | GC safety: objects in the registry aren't collected even when no other references exist |

All 177 existing `python_callback_test.py` tests continue to pass (no regressions to callback, sharding or TPU paths).