### PR TITLE
[ROCm] Add rocm_sysdeps/lib to wheel RUNPATH

### DIFF
--- a/jaxlib/rocm/rocm_rpath.bzl
+++ b/jaxlib/rocm/rocm_rpath.bzl
@@ -35,8 +35,11 @@ _ROCM_LINK_ONLY = "@local_config_rocm//rocm:link_only"
 
 _WHEEL_RPATHS = [
     "-Wl,-rpath,$$ORIGIN/../rocm/lib",
+    "-Wl,-rpath,$$ORIGIN/../rocm/lib/rocm_sysdeps/lib",
     "-Wl,-rpath,$$ORIGIN/../../rocm/lib",
+    "-Wl,-rpath,$$ORIGIN/../../rocm/lib/rocm_sysdeps/lib",
     "-Wl,-rpath,/opt/rocm/lib",
+    "-Wl,-rpath,/opt/rocm/lib/rocm_sysdeps/lib",
 ]
 
 def _wheel_features():


### PR DESCRIPTION
## Summary

JAX wheel .so files directly link 25 `librocm_sysdeps_*.so` libraries via XLA's `system_libs` target, but the wheel RUNPATH only covers `/opt/rocm/lib`. The `rocm_sysdeps` libraries live in a subdirectory (`lib/rocm_sysdeps/lib/`), so the dynamic linker cannot find them without `LD_LIBRARY_PATH`.

This adds `rocm_sysdeps/lib` to each existing RPATH entry in `rocm_rpath.bzl`.

Fixes https://github.com/ROCm/TheRock/issues/3627

## Changes

  - `jaxlib/rocm/rocm_rpath.bzl`: Add 3 RPATH entries for `rocm_sysdeps/lib`
    subdirectory (`$ORIGIN/../rocm/lib/rocm_sysdeps/lib`,
    `$ORIGIN/../../rocm/lib/rocm_sysdeps/lib`, `/opt/rocm/lib/rocm_sysdeps/lib`)
