### PR TITLE
[ROCm] Add lowering for ScaledMatmul, ScaledDot

### DIFF
--- a/jax/_src/cudnn/scaled_matmul_stablehlo.py
+++ b/jax/_src/cudnn/scaled_matmul_stablehlo.py
@@ -23,6 +23,7 @@ from jax._src import api
 from jax._src import core
 from jax._src import dispatch
 from jax._src import dtypes
+from jax._src import lax as lax_internal
 from jax._src import numpy as jnp
 from jax._src import tree_util
 from jax._src.custom_derivatives import custom_vjp
@@ -104,6 +105,27 @@ def _scaled_matmul_gpu_lowering(
   return [out.result]
 
 
+def _scaled_matmul_rocm_lowering(
+    ctx, a, b, a_scales, b_scales, preferred_element_type
+  ):
+  # Lower `scaled_matmul` to `lax.scaled_dot` on ROCm so the backend can match
+  # the `xla.scaled_dot` composite while preserving `scaled_matmul` semantics.
+  def _scaled_dot_lowering_impl(lhs, rhs, lhs_scales, rhs_scales):
+    return lax_internal.scaled_dot(
+        lhs,
+        rhs,
+        lhs_scale=lhs_scales,
+        rhs_scale=rhs_scales,
+        #  `scaled_matmul` is canonicalized to (B, M, K) x (B, N, K), so we
+        # contract over K (axis 2) and batch over B (axis 0), yielding (B, M, N).
+        dimension_numbers=(((2,), (2,)), ((0,), (0,))),
+        preferred_element_type=preferred_element_type,
+    )
+  return mlir.lower_fun(_scaled_dot_lowering_impl, multiple_results=False)(
+      ctx, a, b, a_scales, b_scales
+  )
+
+
 def _scaled_matmul_abstract(a, b, a_scale, b_scale, *, preferred_element_type):
   batch, non_contracting_lhs, contracting_lhs = a.shape
   _, non_contracting_rhs, _ = b.shape
@@ -121,6 +143,16 @@ mlir.register_lowering(
     _scaled_matmul_p,
     _scaled_matmul_gpu_lowering,
     platform="cuda",
+)
+
+# Keep CUDA lowering on the existing `__op$block_scaled_dot` custom call.
+# ROCm is registered separately because AMD's backend does not support that
+# custom call; instead, lowering through `lax.scaled_dot` lets XLA emit
+# `kScaledDot`, which ROCm can then fuse via Triton or hipBLASLt when possible.
+mlir.register_lowering(
+    _scaled_matmul_p,
+    _scaled_matmul_rocm_lowering,
+    platform="rocm",
 )
 
 _scaled_matmul_p_wrapper = core.Primitive("scaled_matmul_wrapper")


### PR DESCRIPTION
 PR fixes failing ScaledMatmul and ScaledDot tests on ROCm caused by:
`MLIR translation rule for primitive 'scaled_matmul' not found for platform rocm`

On ROCm, we now register a dedicated lowering for scaled_matmul that uses a composite approach: it lowers through lax.scaled_dot instead of relying on direct fusion.
The resulting HLO can then be fused later by XLA, which matches the intended backend behavior and avoids the missing primitive translation path on ROCm.

What changed
- Implemented ROCm lowering by delegating to lax.scaled_dot.
- Kept existing CUDA lowering unchanged.

