### PR TITLE
build.py: avoid repeating Bazel flags

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -693,7 +693,9 @@ async def main():
       if ("plugin" in wheel or "pjrt" in wheel) and "jax" not in wheel:
         wheel = "jax-" + wheel
 
-      wheel_build_command = copy.deepcopy(wheel_build_command_base)
+      # Don't copy `wheel_build_command_base` because its contents are already saved in .jax_configure.bazelrc
+      wheel_build_command = copy.deepcopy(bazel_command_base)
+      # Always pass this explicitly to make sure it wins.
       if "cuda" in args.wheels:
         wheel_build_command.append("--config=cuda_libraries_from_stubs")
 


### PR DESCRIPTION
This also makes it easier to run plain `bazel` commands later, after a JAX build, and pick up the same configuration.

Without this, JAX invokes something like
```
bazel build --repo_env=HERMETIC_PYTHON_VERSION=3.12 --verbose_failures=true --override_repository=xla="/opt/xla" --define=xnn_enable_avxvnniint8=false --config=mkl_open_source_only --config=avx_posix --config=cuda13 --config=build_cuda_with_nvcc --repo_env=HERMETIC_CUDA_COMPUTE_CAPABILITIES=sm_75,sm_80,sm_86,sm_90,sm_100,compute_120 ... //jaxlib/tools:jaxlib_wheel_editable
```
and Bazel prints
```
WARNING: The following configs were expanded more than once: [mkl_open_source_only, avx_posix, cuda13, cuda_common, cuda_v13, build_cuda_with_nvcc]. For repeatable flags, repeats are counted twice and may lead to unexpected behavior.
```
because the above flags are found both on the command line and in the `.jax_configure.bazelrc` file.
It also means that if you want to run other Bazel commands after building JAX and take advantage of the hot local cache (e.g. to build some extra XLA utilities), you need to copy/paste some long and unwieldy command line.

It can also be harder to avoid things like
```
WARNING: Build options --@@local_config_cuda//cuda:include_cuda_libs, --copt, --host_copt, and 1 more have changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).
```

With this change, JAX just does things like
```
bazel build --repo_env=HERMETIC_PYTHON_VERSION=3.12 --verbose_failures=true //jaxlib/tools:jax_cuda13_plugin_wheel_editable
```

The logic behind `HERMETIC_PYTHON_VERSION` seemed a little special, so I didn't touch it.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->