### PR TITLE
[ROCm] Use dynamic spawn strategy for rocm rbe ci test execution

### DIFF
--- a/build/rocm/rocm.bazelrc
+++ b/build/rocm/rocm.bazelrc
@@ -61,6 +61,23 @@ test:rocm_rbe --strategy=TestRunner=remote,local
 test:rocm_rbe --worker_sandboxing=false
 test:rocm_rbe --repo_env=REMOTE_GPU_TESTING=1
 
+# Dynamic execution config for ROCm RBE - builds locally, tests use hybrid mode
+common:rocm_rbe_dynamic --config=rocm_rbe
+# Keep builds local (inherit from rocm_rbe)
+build:rocm_rbe_dynamic --spawn_strategy=local
+# Enable dynamic execution for tests only
+test:rocm_rbe_dynamic --experimental_spawn_scheduler
+test:rocm_rbe_dynamic --strategy=TestRunner=dynamic
+test:rocm_rbe_dynamic --dynamic_mode=default
+# Configure local and remote strategies for dynamic test execution
+test:rocm_rbe_dynamic --dynamic_local_strategy=worker,standalone,local
+test:rocm_rbe_dynamic --dynamic_remote_strategy=remote
+# Delay before starting local test execution (ms) - adjust to prefer remote or local
+# Lower values = more local execution, higher values = more remote execution
+test:rocm_rbe_dynamic --experimental_local_execution_delay=1000
+# Maximum number of test jobs to run locally in parallel (50% of available CPUs)
+test:rocm_rbe_dynamic --local_resources=cpu=HOST_CPUS*0.5
+
 # Used for rules_python bootstrap 1.8.0+
 build --@rules_python//python/config_settings:bootstrap_impl=script --repo_env=RULES_PYTHON_ENABLE_PIPSTAR=0
 test --@rules_python//python/config_settings:bootstrap_impl=script --repo_env=RULES_PYTHON_ENABLE_PIPSTAR=0

--- a/ci/run_bazel_test_rocm_rbe.sh
+++ b/ci/run_bazel_test_rocm_rbe.sh
@@ -83,8 +83,8 @@ for arg in "$@"; do
 done
 
 bazel --bazelrc=build/rocm/rocm.bazelrc test \
-    --config=rocm_rbe \
     --config=rocm \
+    --config=rocm_rbe_dynamic \
     --test_env=XLA_PYTHON_CLIENT_ALLOCATOR=platform \
     --test_output=errors \
     --test_env=TF_CPP_MIN_LOG_LEVEL=0 \


### PR DESCRIPTION
Use dynamic spawn strategy for test actions with rbe. If the rbe pool is too busy we do run the test locally and accept it if it finishes faster than rbe