### PR TITLE
[hijax] add a hijax primitive for jnp.nonzero

### DIFF
--- a/jax/_src/numpy/hijax.py
+++ b/jax/_src/numpy/hijax.py
@@ -24,9 +24,11 @@ from jax._src import api
 from jax._src import core
 from jax._src import dtypes
 from jax._src import numpy as jnp
+from jax._src import tree_util
 from jax._src.hijax import VJPHiPrimitive
 from jax._src.lax import control_flow
 from jax._src.lax import lax
+from jax._src.numpy import util
 from jax._src.typing import Array, ArrayLike, DTypeLike
 
 
@@ -161,6 +163,124 @@ class SearchSorted(VJPHiPrimitive):
   def vjp_bwd_retval(self, res: Any, g: Any):
     return (ad_util.zeros_like_aval(self.in_avals[0]),
             ad_util.zeros_like_aval(self.in_avals[1]))
+
+
+class Nonzero(VJPHiPrimitive):
+  """HiJAX primitive for nonzero."""
+
+  size: int
+  axes: tuple[int, ...]
+  out_dtype: np.dtype
+
+  def __init__(
+      self,
+      a_aval: core.ShapedArray,
+      *,
+      size: int,
+      axes: tuple[int, ...],
+      out_dtype: np.dtype):
+    size = operator.index(size)
+    if size < 0:
+      raise ValueError(f"size must be a positive integer; got {size=}")
+    if not dtypes.issubdtype(out_dtype, np.integer):
+      raise ValueError(f"out_dtype must be integer typed; got {out_dtype=}")
+    if not all(0 <= ax < a_aval.ndim for ax in axes):
+      raise ValueError(f"axes out of range for array with {a_aval.ndim} dimensions:  {axes=}")
+    if len(axes) != len(set(axes)):
+      raise ValueError(f"duplicate axes are not allowed: {axes=}")
+    self.in_avals = (a_aval,)
+
+    # Evaluate shape to set out_aval
+    self.out_aval = tree_util.tree_map(core.typeof, api.eval_shape(
+        functools.partial(_nonzero_impl, size=size, axes=axes, out_dtype=out_dtype), a_aval))
+
+    self.params = dict(
+        size=size,
+        axes=axes,
+        out_dtype=out_dtype,
+    )
+    super().__init__()
+
+  def expand(self, a: ArrayLike) -> tuple[Array, ...]:  # pyrefly: ignore[bad-override]
+    return _nonzero_impl(a, size=self.size, axes=self.axes, out_dtype=self.out_dtype)
+
+  def batch(
+      self,
+      axis_data: Any,
+      args: tuple[Array],
+      dims: tuple[int | None]
+  ) -> tuple[tuple[Array, ...], int | tuple[int, ...] | None]:
+    del axis_data  # unused
+    a, = args
+    d, = dims
+
+    if d is None:
+      return self(a), None
+
+    # Adjust axes for the inserted batch dimension d at the front/elsewhere
+    new_axes = tuple(ax + 1 if ax >= d else ax for ax in self.axes)
+
+    batched_prim = Nonzero(
+        core.typeof(a),
+        size=self.size,
+        axes=new_axes,
+        out_dtype=self.out_dtype,
+    )
+
+    batch_axes = [ax for ax in range(a.ndim) if ax not in new_axes]
+    out_bdim = batch_axes.index(d)
+
+    out_dims = (out_bdim,) * len(new_axes)
+    return batched_prim(a), out_dims
+
+  def jvp(self, primals: tuple[Array], tangents: Any) -> tuple[tuple[Array, ...], tuple[Array | np.ndarray, ...]]:
+    del tangents  # unused
+    primal_out = self(*primals)
+    tangents_out = tuple(np.empty(p.shape, dtype=dtypes.float0) for p in primal_out)
+    return primal_out, tangents_out
+
+  def vjp_fwd(self, nzs_in: Any, *args: Array) -> tuple[tuple[Array, ...], None]:
+    return (self(*args), None)
+
+  def vjp_bwd_retval(self, res: Any, g: Any):
+    return (ad_util.zeros_like_aval(self.in_avals[0]),)
+
+
+def _nonzero_impl(a: ArrayLike, *, size: int, axes: tuple[int, ...], out_dtype: np.dtype) -> tuple[Array, ...]:
+  """Main implementation of nonzero primitive."""
+  a = jnp.asarray(a)
+  out_dtype = dtypes._maybe_canonicalize_explicit_dtype(out_dtype, "nonzero")
+  axes = tuple(sorted(axes))
+
+  if not axes:
+    return ()
+
+  batch_axes = [ax for ax in range(a.ndim) if ax not in axes]
+  if a.size == 0 or size == 0:
+    return tuple(jnp.empty((*batch_axes, size), dtype=out_dtype)
+                 for _ in axes)
+
+  transposed_a = jnp.transpose(a, (*batch_axes, *axes))
+
+  batch_shape = transposed_a.shape[:len(batch_axes)]
+  sub_shape = transposed_a.shape[len(batch_axes):]
+  strides = np.cumprod(sub_shape[::-1])[::-1] // sub_shape
+  strides = tuple(strides.tolist())
+
+  flattened_a = transposed_a.reshape(*batch_shape, -1)
+  mask = flattened_a if flattened_a.dtype == bool else (flattened_a != 0)
+  cs_mask = jnp.cumsum(mask, axis=-1)
+
+  bincount = jnp.zeros((*batch_shape, size), dtype=cs_mask.dtype)
+  mesh_dims = jnp.ogrid[tuple(slice(None, sz) for sz in batch_shape)]
+  mesh_dims = [lax.expand_dims(m, [m.ndim]) for m in mesh_dims]
+  bincount = bincount.at[(*mesh_dims, cs_mask)].add(1, mode='drop')
+  flat_indices = jnp.cumsum(bincount, axis=-1)
+
+  out = [(flat_indices // stride) % sz for stride, sz in zip(strides, sub_shape)]
+  counts = mask.sum(axis=-1, keepdims=True)
+  fill_mask = lax.expand_dims(jnp.arange(size), range(counts.ndim - 1)) >= counts
+  return tuple(lax.convert_element_type(jnp.where(fill_mask, 0, entry), out_dtype) for entry in out)
 
 
 def _searchsorted_impl(sorted_arr: ArrayLike, query: ArrayLike, *, dimension: int,
@@ -333,3 +453,38 @@ def searchsorted_via_expand(
     out_dtype=out_dtype,
   )
   return prim.expand(sorted_arr, query)
+
+
+def nonzero(
+    a: ArrayLike,
+    /,
+    *,
+    size: int,
+    axes: tuple[int, ...] | None = None,
+    dtype: DTypeLike = 'int32',
+) -> tuple[Array, ...]:
+  """Return indices of nonzero elements.
+
+  This is a batch-aware implementation of :func:`numpy.nonzero` built on a
+  HiJAX primitive.
+
+  Args:
+    a: N-dimensional array.
+    size: static integer specifying the number of nonzero entries to return.
+    axes: optional tuple of integers specifying the axes to compute the result over.
+      Defaults to None (all axes).
+    dtype: optional datatype for the returned indices. Defaults to int32.
+
+  Returns:
+    Tuple of length ``len(axes)`` containing the indices of each nonzero value.
+  """
+  a, = core.standard_insert_pvary(a)
+  out_dtype = dtypes._maybe_canonicalize_explicit_dtype(np.dtype(dtype), "nonzero")
+  axes = util.canonicalize_axis_tuple(axes, np.ndim(a))
+  prim = Nonzero(
+    core.typeof(a),
+    size=size,
+    axes=axes,
+    out_dtype=out_dtype,
+  )
+  return prim(a)

--- a/tests/lax_numpy_hijax_test.py
+++ b/tests/lax_numpy_hijax_test.py
@@ -103,7 +103,61 @@ def searchsorted_reference(
 
   # Base case: batched query handled by numpy.
   assert sorted_arr.ndim == 1
+
   return np.searchsorted(sorted_arr, query, side=side).astype(dtype)
+
+def nonzero_reference(
+    a: np.ndarray,
+    size: int, *,
+    axes: tuple[int, ...] | None = None,
+    dtype: np.dtype | str = 'int32',
+) -> tuple[np.ndarray, ...]:
+  """Reference implementation for hijax.nonzero in terms of np.nonzero.
+
+  Args:
+    a: n-dimensional array
+    size: integer specifying size of output
+    axes: optional set of axes over which to compute the indices.
+      Defaults to range(a.ndim).
+
+  Returns:
+    A tuple of indices corresponding to axes
+  """
+  a = np.asarray(a)
+  if axes is None:
+    axes = tuple(range(a.ndim))
+  else:
+    axes = tuple(sorted(ax % a.ndim for ax in axes))
+
+  batch_axes = [ax for ax in range(a.ndim) if ax not in axes]
+  transposed_a = np.transpose(a, (*batch_axes, *axes))
+  batch_dims = transposed_a.shape[:len(batch_axes)]
+
+  res = []
+  for idx in np.ndindex(batch_dims):
+    sub_a = transposed_a[idx]
+    nz = np.nonzero(sub_a)
+
+    true_size = len(nz[0])
+    nz_padded = []
+    for axis_nz in nz:
+      if true_size >= size:
+        nz_padded.append(axis_nz[:size])
+      else:
+        # Pad with zeros
+        nz_padded.append(np.pad(axis_nz, (0, size - true_size), mode='constant'))
+    res.append(nz_padded)
+
+  out = []
+  for axis_idx in range(len(axes)):
+    axis_res = [r[axis_idx] for r in res]
+    if batch_dims:
+      axis_res_array = np.array(axis_res).reshape(*batch_dims, size)
+    else:
+      axis_res_array = np.array(axis_res).reshape(size)
+    out.append(axis_res_array.astype(dtype))
+
+  return tuple(out)
 
 
 class SearchsortedTest(jtu.JaxTestCase):
@@ -410,6 +464,74 @@ class SearchsortedTest(jtu.JaxTestCase):
           sorted_arr, query, batch_dims=1, dimension=1
       )
 
+
+class NonzeroTest(jtu.JaxTestCase):
+
+  def test_1D_against_numpy(self):
+    a = self.rng().randint(0, 2, size=(100,))
+    expected = tuple(i.astype('int32') for i in np.nonzero(a))
+    actual = hijax.nonzero(a, size=np.sum(a != 0))
+
+    self.assertEqual(len(expected), len(actual))
+    for e, a_i in zip(expected, actual):
+      self.assertArraysEqual(e, a_i)
+
+  @jtu.sample_product(
+      axes=[None, (0,), (1,), (0, 1)],
+  )
+  def test_2D_against_reference(self, axes):
+    a = self.rng().randint(0, 2, size=(10, 20))
+    size = 5
+    expected = nonzero_reference(a, size=size, axes=axes)
+    actual = hijax.nonzero(a, size=size, axes=axes)
+
+    self.assertEqual(len(expected), len(actual))
+    for e, a_i in zip(expected, actual):
+      self.assertArraysEqual(e, a_i)
+
+  def test_vmap(self):
+    a = self.rng().randint(0, 2, size=(3, 4, 5))
+    size = 2
+
+    def f(x):
+      return hijax.nonzero(x, size=size, axes=(1,))[0]
+
+    vmapped = jax.vmap(f)(a)
+
+    expected = []
+    for sub_a in a:
+      expected.append(nonzero_reference(sub_a, size=size, axes=(1,))[0])
+    expected = np.array(expected)
+
+    self.assertArraysEqual(expected, vmapped)
+
+  def test_jit(self):
+    a = self.rng().randint(0, 2, size=(10,))
+    size = 2
+
+    @jax.jit
+    def f(x):
+      return hijax.nonzero(x, size=size)
+
+    actual = f(a)
+    expected = nonzero_reference(a, size=size)
+
+    for e, a_i in zip(expected, actual):
+      self.assertArraysEqual(e, a_i)
+
+  def test_autodiff(self):
+    a = jax.numpy.array([0.0, 1.0, 0.0, 1.0])
+    size = 2
+
+    def f(x):
+      return hijax.nonzero(x, size=size)[0]
+
+    primal_out, tangent_out = jax.jvp(f, (a,), (jax.numpy.ones_like(a),))
+    self.assertEqual(tangent_out.dtype, jax.dtypes.float0)
+
+    _, f_vjp = jax.vjp(f, a)
+    tangent_in = f_vjp(jax.numpy.ones_like(primal_out))
+    self.assertArraysEqual(tangent_in[0], jax.numpy.zeros_like(a))
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Similar to the existing `searchsorted` primitive: this is a primitive that implements the API of `jnp.nonzero` with simpler batching and autodiff rules.

Why? Like with #34332, this is part of an experiment with implementing compound NumPy ops in terms of well-defined hijax primitives. `nonzero` is a good candidate because it is often used downstream (both within JAX as well as in other projects) and has well-defined semantics that can be extended to be closed under batching and autodiff.

The jaxpr for the new hijax primitive is simple:
```python
In [1]: import jax

In [2]: x = jax.numpy.array([1, 0, 2, 0, 3, 0, 0])

In [3]: jax.make_jaxpr(lambda x: jax._src.numpy.hijax.nonzero(x, size=3))(x)
Out[3]: 
{ lambda ; a:i32[7]. let
    b:i32[3] = call_hi_primitive[
      _prim=Nonzero[{'size': 3, 'axes': (0,), 'out_dtype': dtype('int32')}]
    ] a
  in (b,) }
```
Compare this to the jaxpr for the existing `nonzero` implementation:
```python
In [4]: jax.make_jaxpr(lambda x: jax.numpy.nonzero(x, size=3))(x)
Out[4]: 
{ lambda ; a:i32[7]. let
    b:bool[7] = ne a 0:i32[]
    c:i32[7] = jit[
      name=cumsum
      jaxpr={ lambda ; b:bool[7]. let
          d:i32[7] = convert_element_type[new_dtype=int32 weak_type=False] b
          c:i32[7] = cumsum[axis=0 reverse=False] d
        in (c,) }
    ] b
    e:i32[3] = broadcast_in_dim 0:i32[]
    f:i32[7] = jit[
      name=clip
      jaxpr={ lambda ; c:i32[7] g:i32[]. let
          h:i32[] = convert_element_type[new_dtype=int32 weak_type=False] g
          f:i32[7] = max h c
        in (f,) }
    ] c 0:i32[]
    i:bool[7] = lt f 0:i32[]
    j:i32[7] = add f 3:i32[]
    k:i32[7] = select_n i f j
    l:i32[7,1] = broadcast_in_dim[broadcast_dimensions=(0,)] k
    m:i32[7] = broadcast_in_dim 1:i32[]
    n:i32[3] = scatter-add[
      dimension_numbers=ScatterDimensionNumbers(update_window_dims=(), inserted_window_dims=(0,), scatter_dims_to_operand_dims=(0,), operand_batching_dims=(), scatter_indices_batching_dims=())
      indices_are_sorted=False
      mode=GatherScatterMode.FILL_OR_DROP
      unique_indices=False
      update_consts=()
      update_jaxpr={ lambda ; o:i32[] p:i32[]. let q:i32[] = add o p in (q,) }
    ] e l m
    r:i32[3] = jit[
      name=cumsum
      jaxpr={ lambda ; n:i32[3]. let
          r:i32[3] = cumsum[axis=0 reverse=False] n
        in (r,) }
    ] n
    s:i32[3] = jit[
      name=floor_divide
      jaxpr={ lambda ; r:i32[3] t:i32[]. let
          u:i32[3] = div r t
          v:i32[3] = sign r
          w:i32[] = sign t
          x:bool[3] = ne v w
          y:i32[3] = rem r t
          z:bool[3] = ne y 0:i32[]
          ba:bool[3] = and x z
          bb:i32[3] = sub u 1:i32[]
          s:i32[3] = jit[
            name=_where
            jaxpr={ lambda ; ba:bool[3] bb:i32[3] u:i32[3]. let
                s:i32[3] = select_n ba u bb
              in (s,) }
          ] ba bb u
        in (s,) }
    ] r 1:i32[]
    bc:i32[3] = jit[
      name=remainder
      jaxpr={ lambda ; s:i32[3] bd:i32[]. let
          be:i32[] = convert_element_type[new_dtype=int32 weak_type=False] bd
          bf:bool[] = eq be 0:i32[]
          bg:i32[] = jit[
            name=_where
            jaxpr={ lambda ; bf:bool[] bh:i32[] be:i32[]. let
                bg:i32[] = select_n bf be bh
              in (bg,) }
          ] bf 1:i32[] be
          bi:i32[3] = rem s bg
          bj:bool[3] = ne bi 0:i32[]
          bk:bool[3] = lt bi 0:i32[]
          bl:bool[] = lt bg 0:i32[]
          bm:bool[3] = ne bk bl
          bn:bool[3] = and bm bj
          bo:i32[3] = add bi bg
          bc:i32[3] = select_n bn bi bo
        in (bc,) }
    ] s 7:i32[]
  in (bc,) }
```