### PR TITLE
[ROCm] Add offload-compress flag to reduce rocm wheel size

### DIFF
--- a/build/rocm/rocm.bazelrc
+++ b/build/rocm/rocm.bazelrc
@@ -14,6 +14,7 @@ common:rocm --config=rocm_base
 common:rocm --action_env=TF_HIPCC_CLANG="1"
 common:rocm --action_env=TF_ROCM_CLANG="1"
 common:rocm --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"
+common:rocm --action_env=HIPCC_COMPILE_FLAGS_APPEND=--offload-compress
 common:rocm --copt=-Wno-gnu-offsetof-extensions
 common:rocm --copt=-Qunused-arguments
 common:rocm --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1200,gfx1201"


### PR DESCRIPTION
# Description
Add HIPCC_COMPILE_FLAGS_APPEND=--offload-compress to the ROCm Bazel config. This compresses offloaded device code in the compiled binaries, reducing the PJRT wheel size by ~40% (from ~230MB to ~140MB) with no runtime performance impact.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->