### PR TITLE
[ROCm] Add wheel version suffix support for ROCm post-release builds

### DIFF
--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -40,6 +40,10 @@ on:
         options:
         - "1"
         - "0"
+      wheel-version-suffix:
+        description: "Version suffix for post-releases (e.g., .post3). Leave empty for normal builds."
+        type: string
+        default: ""
       halt-for-connection:
         description: 'Should this workflow run wait for a remote connection?'
         type: choice
@@ -77,6 +81,10 @@ on:
         description: "S3 location prefix to where the artifacts should be uploaded"
         default: 's3://jax-ci-amd/jax-rocm-plugin-wheels'
         type: string
+      wheel-version-suffix:
+        description: "Version suffix for post-releases (e.g., .post3). Leave empty for normal builds."
+        type: string
+        default: ""
       halt-for-connection:
         description: 'Should this workflow run wait for a remote connection?'
         type: string
@@ -140,6 +148,7 @@ jobs:
                 --config=rocm_release_wheel \
                 --config=rocm_rbe \
                 --repo_env=HERMETIC_PYTHON_VERSION="${{ inputs.python }}" \
+                ${{ inputs.wheel-version-suffix && format('--action_env=WHEEL_VERSION_SUFFIX={0}', inputs.wheel-version-suffix) || '' }} \
                 $DEPLOY_TARGET -- $JAXCI_OUTPUT_DIR/
         env:
           DEPLOY_TARGET: ${{ inputs.artifact == 'jax-rocm-plugin' && '//jaxlib/tools:deploy_rocm_plugin_wheel' || '//jaxlib/tools:deploy_rocm_pjrt_wheel' }}


### PR DESCRIPTION
# Description
Add a wheel-version-suffix input to the ROCm artifact build workflow. When set (e.g., .post3), it passes WHEEL_VERSION_SUFFIX to the Bazel build, producing wheels versioned 0.9.1.post3 for PyPI hotfix releases. Empty by default — no change to existing builds.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->