### PR TITLE
Limit the number of jobs to 30 for ROCm bazel tests

### DIFF
--- a/build/rocm/rocm.bazelrc
+++ b/build/rocm/rocm.bazelrc
@@ -75,8 +75,8 @@ test:rocm_rbe_dynamic --dynamic_remote_strategy=remote
 # Delay before starting local test execution (ms) - adjust to prefer remote or local
 # Lower values = more local execution, higher values = more remote execution
 test:rocm_rbe_dynamic --experimental_local_execution_delay=1000
-# Maximum number of test jobs to run locally in parallel (50% of available CPUs)
-test:rocm_rbe_dynamic --local_resources=cpu=HOST_CPUS*0.5
+test:rocm_rbe_dynamic --local_resources=cpu=4
+test:rocm_rbe_dynamic --remote_local_fallback_strategy=local
 
 # Used for rules_python bootstrap 1.8.0+
 build --@rules_python//python/config_settings:bootstrap_impl=script --repo_env=RULES_PYTHON_ENABLE_PIPSTAR=0

--- a/ci/run_bazel_test_rocm_rbe.sh
+++ b/ci/run_bazel_test_rocm_rbe.sh
@@ -82,24 +82,29 @@ for arg in "$@"; do
     fi
 done
 
-bazel --bazelrc=build/rocm/rocm.bazelrc test \
-    --config=rocm \
-    --config=rocm_rbe_dynamic \
-    --test_env=XLA_PYTHON_CLIENT_ALLOCATOR=platform \
-    --test_output=errors \
-    --test_env=TF_CPP_MIN_LOG_LEVEL=0 \
-    --test_env=JAX_EXCLUDE_TEST_TARGETS=PmapTest.testSizeOverflow \
-    --build_tag_filters=${TAG_FILTERS} \
-    --test_tag_filters=${TAG_FILTERS} \
-    --remote_download_outputs=minimal \
-    --test_env=JAX_SKIP_SLOW_TESTS=true \
-    --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a,gfx942,gfx950" \
-    --color=yes \
-    $@ \
-    -- \
-    //tests:gpu_tests \
-    //tests:backend_independent_tests \
-    //tests/pallas:gpu_tests \
-    //tests/pallas:backend_independent_tests \
-    //jaxlib/tools:check_gpu_wheel_sources_test \
+BAZEL_ARGS=(
+    --config=rocm
+    --config=rocm_rbe_dynamic
+    --test_env=XLA_PYTHON_CLIENT_ALLOCATOR=platform
+    --test_output=errors
+    --test_env=TF_CPP_MIN_LOG_LEVEL=0
+    --test_env=JAX_EXCLUDE_TEST_TARGETS=PmapTest.testSizeOverflow
+    --build_tag_filters=${TAG_FILTERS}
+    --test_tag_filters=${TAG_FILTERS}
+    --remote_download_outputs=minimal
+    --test_env=JAX_SKIP_SLOW_TESTS=true
+    --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a,gfx942,gfx950"
+    --color=yes
+    $@
+    --
+    //tests:gpu_tests
+    //tests:backend_independent_tests
+    //tests/pallas:gpu_tests
+    //tests/pallas:backend_independent_tests
+    //jaxlib/tools:check_gpu_wheel_sources_test
     "${TESTS_TO_IGNORE[@]}"
+)
+
+bazel --bazelrc=build/rocm/rocm.bazelrc build ${BAZEL_ARGS[@]}
+bazel --bazelrc=build/rocm/rocm.bazelrc test --jobs=30 ${BAZEL_ARGS[@]}
+


### PR DESCRIPTION
Limit the number of jobs that a single Bazel command will run on the ROCm RBE cluster to 30 to prevent the cluster from being overwhelmed