### PR TITLE
[hijax][boxes] scan over boxes

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -508,6 +508,10 @@ class Var:
   def __repr__(self):
     return f'Var(id={id(self)}):{self.aval.str_short()}'
 
+  @property
+  def has_qdd(self) -> bool:
+    return self.initial_qdd is not None
+
   def pretty_print(self, context: JaxprPpContext, *, print_dtype: bool = True):
     del print_dtype  # unused
     return f"{context.var_names[self]}"
@@ -1733,9 +1737,6 @@ class AbstractValue:
   def inc_rank(self, size, spec):
     return unmapped_aval(size, spec, self)
 
-  def leading_axis_spec(self):
-    return 0
-
   def shard(self, mesh, manual_axes, check_vma, spec):
     return shard_aval(mesh, manual_axes, check_vma, spec, self)
 
@@ -1745,6 +1746,9 @@ class AbstractValue:
   def vspace_add(self, x, y):
     from jax._src.ad_util import add_jaxvals  # pytype: disable=import-error
     return add_jaxvals(x, y)
+
+  def leading_axis_spec(self):
+    raise NotImplementedError("must override")
 
 InputType = tuple[AbstractValue, ...]
 OutputType = tuple[AbstractValue, ...]
@@ -1914,7 +1918,11 @@ class MutableQuasiDynamicData:
     return f'MutableQuasiDynamicData(init_val={self.init_val}, cur_val={self.cur_val})'
 
 class QuasiDynamicData:
-  pass
+  def dec_rank(self, size, spec):
+    raise NotImplementedError("must override")
+
+  def inc_rank(self, size, spec):
+    raise NotImplementedError("must override")
 
 @dataclass(frozen=True)
 class AvalQDD:
@@ -1937,6 +1945,7 @@ class AvalQDD:
       raise ValueError(f"Cannot convert to tangent aval when {self.qdd=}.")
     return AvalQDD(self.aval.to_tangent_aval(), self.qdd.to_tangent_qdd())
 
+
 @dataclass(frozen=True)
 class AvalMutableQDD:
   aval: AbstractValue
@@ -1950,10 +1959,15 @@ def cur_qdd(x):
   finally:
     trace_ctx.set_trace(prev_trace)
 
-def cur_aval_qdd(x):
+def cur_aval_qdd(x) -> AvalQDD:
   aval = typeof(x)
   qdd = cur_qdd(x) if aval.has_qdd else None
   return AvalQDD(aval, qdd)
+
+# TODO(mattjj,dougalm): maybe dedup with above function?
+def cur_aval_maybe_qdd(x) -> AbstractValue | AvalQDD:
+  aval = typeof(x)
+  return AvalQDD(aval, cur_qdd(x)) if aval.has_qdd else aval
 
 ### Extended dtypes
 #
@@ -2424,6 +2438,9 @@ class ShapedArray(AbstractValue):
     u_names = self.mt.unreduced if check_vma else frozenset()
     r_names = self.mt.reduced if check_vma else frozenset()
     return P(sh_names, unreduced=u_names, reduced=r_names) if sh_names else P()
+
+  def leading_axis_spec(self):
+    return 0
 
   _bool    = concretization_function_error(bool)
   _int     = concretization_function_error(int, True)
@@ -3167,8 +3184,8 @@ class MapPrimitive(Primitive):
     return new_params
 
 def mapped_aval(size: AxisSize, axis, aval: AbstractValue) -> AbstractValue:
-  from jax._src.hijax import HiType  # pytype: disable=import-error
-  if isinstance(aval, HiType):
+  from jax._src.hijax import HiType, MutableHiType  # pytype: disable=import-error
+  if isinstance(aval, (HiType, MutableHiType)):
     return aval.dec_rank(size, axis)  # type: ignore
   handler, _ = aval_mapping_handlers.get(type(aval), (None, None))
   if handler is not None:
@@ -3178,6 +3195,16 @@ def mapped_aval(size: AxisSize, axis, aval: AbstractValue) -> AbstractValue:
 
 def mapped_leading_aval(size, aval) -> AbstractValue:
   return mapped_aval(size, aval.leading_axis_spec(), aval)
+
+def mapped_leading_aval_qdd(size, a: AbstractValue | AvalQDD) -> AbstractValue | AvalQDD:
+  if isinstance(a, AvalQDD):
+    aval, qdd = a.aval, a.qdd
+    return AvalQDD(mapped_aval(size, aval.leading_axis_spec(), aval),
+                  qdd.dec_rank(size, qdd.leading_axis_spec()))
+  elif isinstance(a, AbstractValue):
+    return mapped_aval(size, a.leading_axis_spec(), a)
+  else:
+    assert False
 
 # TODO(yashkatariya): take axis data
 def unmapped_aval(size: AxisSize, axis: int | None,
@@ -3193,6 +3220,11 @@ def unmapped_aval(size: AxisSize, axis: int | None,
 
 def unmapped_leading_aval(size, aval) -> AbstractValue:
   return unmapped_aval(size, aval.leading_axis_spec(), aval)
+
+def unmapped_leading_aval_qdd(size, aval_qdd) -> AvalQDD:
+  aval, qdd = aval_qdd.aval, aval_qdd.qdd
+  return AvalQDD(unmapped_aval(size, aval.leading_axis_spec(), aval),
+                 qdd.inc_rank(size, qdd.leading_axis_spec()))
 
 def _map_shaped_array(
     size: int, axis: int | None, aval: ShapedArray) -> ShapedArray:

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -206,6 +206,17 @@ class BoxTypeState(QDD):
     leaf_avals = tuple(a.to_tangent_aval() for a in self.leaf_avals)
     return BoxTypeState(leaf_avals, self.treedef)
 
+  def leading_axis_spec(self):
+    return tuple(a.leading_axis_spec() for a in self.leaf_avals)
+
+  def dec_rank(self, size, spec):
+    leaf_avals = [a.dec_rank(size, spec) for a, spec in zip(self.leaf_avals, spec)]
+    return BoxTypeState(tuple(leaf_avals), self.treedef)
+
+  def inc_rank(self, size, spec):
+    leaf_avals = [a.inc_rank(size, spec) for a, spec in zip(self.leaf_avals, spec)]
+    return BoxTypeState(tuple(leaf_avals), self.treedef)
+
   def normalize(self):
     leaf_types = tuple(a.normalize() for a in self.leaf_avals)
     return BoxTypeState(leaf_types, self.treedef)
@@ -249,6 +260,13 @@ class BoxTy(MutableHiType):
     box_set(box, tree_unflatten(box_state.treedef, hi_vals))
 
   def to_tangent_aval(self):
+    return BoxTy()
+
+  def leading_axis_spec(self):
+    return None
+
+  def dec_rank(self, size, spec):
+    assert spec is None
     return BoxTy()
 
 # Override isinstance checks under tracing

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -577,7 +577,7 @@ def accum_typeof(x):
   if isinstance(x, GradAccum):
     return x.aval
   else:
-    return typeof(x)
+    return core.cur_aval_maybe_qdd(x)
 
 # TODO(mattjj): this is for for backward (get it?) compatibility. Remove, maybe.
 def backward_pass(jaxpr, transform_stack: bool, consts, primals_in, cts_in):

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1603,10 +1603,17 @@ def _move_to_front(lst: Sequence, to_move: Sequence[bool]) -> Sequence:
   return ([elt for elt, move in zip(lst, to_move) if move] +
           [elt for elt, move in zip(lst, to_move) if not move])
 
-def move_binders_to_back(closed_jaxpr: ClosedJaxpr, to_move: Sequence[bool]
-                         ) -> ClosedJaxpr:
+def move_binders_to_back(jaxpr: ClosedJaxpr, to_move: Sequence[bool]) -> ClosedJaxpr:
   """Reorder `invars` by moving those indicated in `to_move` to the back."""
-  return move_binders_to_front(closed_jaxpr, map(op.not_, to_move))
+  return move_binders_to_front(jaxpr, map(op.not_, to_move))
+
+def move_outvars_to_back(jaxpr: ClosedJaxpr, to_move: Sequence[bool]) -> ClosedJaxpr:
+  return _move_outvars_to_back(jaxpr, tuple(to_move))
+
+@weakref_lru_cache
+def _move_outvars_to_back(jaxpr, to_move: tuple[bool, ...]) -> ClosedJaxpr:
+  new_outvars = _move_to_front(jaxpr.jaxpr.outvars, map(op.not_, to_move))
+  return core.ClosedJaxpr(jaxpr.jaxpr.replace(outvars=new_outvars), jaxpr.consts)
 
 
 class DynamicJaxprTracer(core.Tracer['DynamicJaxprTrace']):
@@ -2642,8 +2649,8 @@ def lower_traceable(jaxpr, *lo_args):
              for aval in jaxpr.in_aval_qdds]
   assert (_problem := next(lo_args_, None)) is None
   hi_outs = core.jaxpr_as_fun(jaxpr)(*hi_args)
-  mut_outs = [lo_val for aval, hi_arg in zip(jaxpr.final_aval_qdds, hi_args) if aval.has_qdd
-              for lo_val in aval.read_loval(hi_arg)]
+  mut_outs = [lo_val for aval, hi_arg in zip(jaxpr.final_aval_qdds, hi_args)
+              if aval.has_qdd for lo_val in aval.read_loval(hi_arg)]
   lo_outs = [lo_val for v, hi_val in zip(jaxpr.jaxpr.outvars, hi_outs)
              for lo_val in v.aval.lower_val(hi_val)]
   return mut_outs + lo_outs

--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -54,7 +54,7 @@ def _merge_common_consts(
   consts = [c for cs in all_consts for c in cs]
   avalqdds = tuple(map(core.cur_aval_qdd, consts))
   num_constss = [len(cs) for cs in all_consts]
-  jaxprs = [_pad_constvars(jaxpr, num_consts, avalqdds[:sum(lens[:i])], avalqdds[sum(lens[:i+1]):])
+  jaxprs = [_pad_constvars(jaxpr, num_consts, avalqdds[:sum(lens[:i])], avalqdds[sum(lens[:i+1]):])  # type: ignore
             for i, (jaxpr, num_consts) in enumerate(zip(jaxprs, num_constss))]
   # De-duplicate shared constants.
   const_ids = tuple(id(c) for c in consts)

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -211,11 +211,11 @@ def scan(f: Callable[[Carry, X], tuple[Carry, Y]],
   check_no_transformed_refs_args(lambda: dbg_body, args.vals)
   del init, xs
 
-  args_avals = args.map(core.typeof)
+  args_avals = args.map(core.cur_aval_maybe_qdd)
   init_avals, xs_avals = args_avals.unpack()
 
   from jax._src.hijax import HiType
-  if any(isinstance(a, HiType) for a in xs_avals):
+  if any(isinstance(a, (HiType, core.AvalQDD)) for a in xs_avals):
     if length is None:
       raise ValueError("must provide `length` to `scan`")
   else:
@@ -239,7 +239,7 @@ def scan(f: Callable[[Carry, X], tuple[Carry, Y]],
   if config.mutable_array_checks.value:
     check_no_aliased_ref_args(lambda: dbg_body, list(args_avals), list(args))
 
-  x_avals = xs_avals.map(lambda aval: core.mapped_leading_aval(length, aval))
+  x_avals = xs_avals.map(lambda a: core.mapped_leading_aval_qdd(length, a))
   def _create_jaxpr(carry_avals):
     new_arg_avals = FlatTree.pack(((carry_avals, x_avals), {}))
     jaxpr, out_avals = pe.trace_to_jaxpr(f, new_arg_avals, dbg_body)
@@ -598,7 +598,8 @@ def _scan_abstract_eval(*args, reverse, length, num_consts, num_carry, jaxpr,
     raise ValueError("scan number of arguments doesn't match the number "
                      "of jaxpr arguments: {len(args)} vs {len(jaxpr.in_avals)}")
   out_carry_avals, y_avals = split_list(jaxpr.out_avals, [num_carry])
-  _, in_carry_avals, _ = split_list(args, [num_consts, num_carry])
+  in_const_avals, in_carry_avals, in_ext_avals = split_list(args, [num_consts, num_carry])
+  in_const_vars, _, in_ext_vars = split_list(jaxpr.invars, [num_consts, num_carry])
   if [i.vma for i in in_carry_avals] != [o.vma for o in out_carry_avals]:
     raise ValueError(
         'Scan carry input and output got mismatched varying manual axes '
@@ -607,6 +608,16 @@ def _scan_abstract_eval(*args, reverse, length, num_consts, num_carry, jaxpr,
         'temporary workaround pass the check_vma=False argument to '
         '`jax.shard_map`')
   ys_avals = _map(partial(core.unmapped_leading_aval, length), y_avals)
+
+  inc_rank = lambda qdd: qdd.inc_rank(length, qdd.leading_axis_spec())
+  for v, a in zip(in_const_vars, in_const_avals):
+    if v.has_qdd:
+      assert v.initial_qdd == v.final_qdd == a.mutable_qdd.cur_val
+  for v, a in zip(in_ext_vars, in_ext_avals):
+    if v.has_qdd:
+      assert inc_rank(v.initial_qdd) == a.mutable_qdd.cur_val
+      a.mutable_qdd.update(inc_rank(v.final_qdd))
+
   return out_carry_avals + ys_avals, core.eqn_effects(jaxpr)
 
 def _scan_jvp(primals, tangents, reverse, length, jaxpr, num_consts, num_carry,
@@ -758,6 +769,10 @@ def _scan_linearize(is_vjp, nzs, *primals_in, reverse: bool, length: int, num_co
 def _scan_known_hoisting(jaxpr_known, known_consts, num_res):
   # To disable:
   # return jaxpr_known, known_consts, [False] * num_res, []
+
+  # TODO(mattjj): don't always disable in the hijax case
+  if any(a.has_qdd for a in jaxpr_known.in_avals):
+    return jaxpr_known, known_consts, [False] * num_res, []
 
   consts = [pe.PartialVal.unknown(a) if isinstance(a := typeof(c), AbstractRef)
             else pe.PartialVal.known(c) for c in known_consts]
@@ -952,11 +967,13 @@ def _scan_transpose_fancy(cts, *args, reverse, length, num_consts,
   ires, consts_dot, carry_dot, xs_dot, eres = split_list(
       args, [num_ires, num_consts - num_ires, num_carry, sum(xs_lin)])
   is_mutable = [isinstance(x, ad.RefAccum) or not isinstance(x, ad.GradAccum)
-                and isinstance(typeof(x), AbstractRef) for x in consts_dot]
+                and (isinstance(a := typeof(x), AbstractRef) or a.has_qdd)
+                for x in consts_dot]
   immut_consts_dot, mut_consts_bar = partition_list(is_mutable, consts_dot)
   jaxpr = _rearrange_mutable_binders(jaxpr, num_ires, num_consts - num_ires)
   is_mutable_ = [isinstance(x, ad.RefAccum) or not isinstance(x, ad.GradAccum)
-                 and isinstance(typeof(x), AbstractRef) for x in xs_dot]
+                 and (isinstance(a := typeof(x), AbstractRef) or a.has_qdd)
+                 for x in xs_dot]
   immut_xs_dot, mut_xs_bar = partition_list(is_mutable_, xs_dot)
   jaxpr = _rearrange_mutable_binders(jaxpr, num_consts + num_carry, sum(xs_lin))
   del consts_dot, xs_dot, args
@@ -978,7 +995,7 @@ def _scan_transpose_fancy(cts, *args, reverse, length, num_consts,
 
   # prepare transposed jaxpr
   trans_avals, ext_avals = split_list(_map(ad.accum_typeof, trans_in), [num_consts+num_carry])
-  trans_avals = trans_avals + [core.mapped_leading_aval(length, a) for a in ext_avals]
+  trans_avals = trans_avals + [core.mapped_leading_aval_qdd(length, a) for a in ext_avals]
   xs_avals = tuple(core.mapped_leading_aval(length, ad.accum_typeof(x)) for x in immut_xs_dot)
   jaxpr_trans = _transpose_scan_jaxpr_fancy(
       jaxpr, trans_tree, tuple(trans_avals), lin_refs, xs_avals)
@@ -1104,11 +1121,9 @@ def _scan_dce_rule(used_outputs: list[bool], eqn: core.JaxprEqn
   # TODO(mattjj,sharadmv): don't assume effects are never DCE'd?
   new_invars = [v for v, used in zip(eqn.invars, used_inputs) if used]
   new_outvars = [v for v, used in zip(eqn.outvars, used_outputs) if used]
-  _, new_effects = eqn.primitive.abstract_eval(
-      *[v.aval for v in new_invars], **new_params)
+  new_effects = core.eqn_effects(jaxpr_dce)
   new_eqn = pe.new_jaxpr_eqn(
-      new_invars,
-      new_outvars,
+      new_invars, new_outvars,
       eqn.primitive, new_params, new_effects, eqn.source_info, eqn.ctx)
   assert len(new_eqn.invars ) == len(new_params['jaxpr'].in_avals )
   assert len(new_eqn.outvars) == len(new_params['jaxpr'].out_avals)
@@ -1394,12 +1409,25 @@ def _scan_to_lojax(*hi_args, jaxpr, num_carry, num_consts, linear, **params):
              for lo_val in (aval.read_loval(x) if aval.has_qdd
                             else aval.lower_val(x))]
 
-  # lower the jaxpr and bind it using lo input values
+  # lower the jaxpr and move extensive outputs to match scan convention
   lo_jaxpr = pe.lower_jaxpr(jaxpr)
+  const_qdds, carry_qdds, ext_qdds = split_list(jaxpr.final_aval_qdds, [num_consts, num_carry])
+  num_const_mut = sum(len(a.lo_ty()) for a in const_qdds if a.has_qdd)
+  num_carry_mut = sum(len(a.lo_ty()) for a in carry_qdds if a.has_qdd)
+  num_ext_mut = sum(len(a.lo_ty()) for a in ext_qdds if a.has_qdd)
+  num_rest = len(lo_jaxpr.out_avals) - num_const_mut - num_carry_mut - num_ext_mut
+  assert num_const_mut == 0
+  to_move = [False] * num_carry_mut + [True] * num_ext_mut + [False] * num_rest
+  lo_jaxpr = pe.move_outvars_to_back(lo_jaxpr, to_move)
+
+  # bind on lo inputs
   all_outs = scan_p.bind(*lo_args, jaxpr=lo_jaxpr, num_consts=num_consts,
                          num_carry=num_carry, linear=tuple(linear), **params)
-  out_mut, lo_outs = split_list(all_outs, [pe.num_himuts_out(jaxpr)])
-  pe.apply_himut(jaxpr, hi_args, out_mut)
+
+  # split out mutable outputs and apply them
+  out_mut1, lo_outs, out_mut2 = split_list(all_outs, [num_carry_mut, num_rest])
+  pe.apply_himut(jaxpr, hi_args, [*out_mut1, *out_mut2])
+
   return pe.raise_lo_outs(jaxpr.out_avals, lo_outs)
 scan_p.to_lojax = _scan_to_lojax
 

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1294,7 +1294,7 @@ def pjit_staging_rule(trace, source_info, *args, **params):
         jit_p, args, params, source_info=source_info)
     # TODO(mattjj): handle qdd in the presence of refs
     for v, x in zip(it.chain(jaxpr.constvars, jaxpr.invars), it.chain(jaxpr.consts, args)):
-      if v.initial_qdd:
+      if v.has_qdd:
         assert core.cur_qdd(x) == v.initial_qdd
         x.aval_mutable_qdd.mutable_qdd.update(v.final_qdd)
   return out_tracers

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -1648,6 +1648,51 @@ class BoxTest(jtu.JaxTestCase):
 
     self.assertAllClose(box.get(), 1024., check_dtypes=False)
 
+  @parameterized.parameters([False, True])
+  def test_scan_extensive(self, jit):
+    def body(_, box: Box):
+      x = box.get()
+      y = (x, 2 * x)
+      box.set(y)
+      return (), ()
+
+    box = Box(jnp.arange(3.))
+    f = lambda: jax.lax.scan(body, (), box, length=3)
+    if jit:
+      f = jax.jit(f)
+    (), () = f()
+    ys = box.get()
+    self.assertAllClose(ys, (jnp.arange(3.), 2 * jnp.arange(3.)))
+
+  @parameterized.parameters([False, True])
+  def test_custom_vjp_plumbing_scan(self, jit):
+    box = Box()
+
+    @jax.custom_vjp
+    def foo(box, x):
+      return x
+    def foo_fwd(box, x):
+      return x, box
+    def foo_bwd(box, g):
+      box.set(g)
+      return None, g
+    foo.defvjp(foo_fwd, foo_bwd)
+
+    def body(x, box):
+      x = 2 * x
+      x = foo(box, x)
+      return x, ()
+
+    def f(box, x):
+      x, () = jax.lax.scan(body, x, box, length=3)
+      return x
+
+    if jit:
+      f = jax.jit(f)
+
+    jax.grad(partial(f, box))(1.0)
+    self.assertAllClose(box.get(), jnp.array([4., 2., 1.]))
+
   def test_cond_box_internally_pure(self):
     @jax.jit
     def doubleit(x):


### PR DESCRIPTION
The goal is to make scanning over a Box work. We can over the contents, kind of like pytrees (ie over the leading axes of leaves), and lower to targeting the extensive input and output.

The changes are:
1. added `inc_rank` and `dec_rank` to QDD
2. since we need to trace jaxprs on AvalQDDs not just avals, and since we need to decrement their ranks, we added some helpers in core.py to do that
3. small fixes

One outstanding TODO is that because partial eval doesn't work with QDD yet, [we disable the scan residual hoisting optimization](https://github.com/jax-ml/jax/compare/jax-ml:a231d35...mattjj:6cc1518#diff-62dc946cc9e78b32dd090edd3a485e48a4dfa68ca7be90df90bc9744c4866bf6R773) when QDD are present.