### PR TITLE
lax.mul: add out_dtype argument

### DIFF
--- a/jax/_src/internal_test_util/lax_test_util.py
+++ b/jax/_src/internal_test_util/lax_test_util.py
@@ -173,6 +173,14 @@ def lax_named_reduce_ops():
   ]
 
 
+def lax_out_dtype_ops():
+  return [
+      op_record(
+          "mul", 2, default_dtypes + complex_dtypes, test_util.rand_small
+      ),
+  ]
+
+
 def lax_ops():
   return [
       op_record(

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1186,7 +1186,7 @@ def sub(x: ArrayLike, y: ArrayLike) -> Array:
   return sub_p.bind(x, y)
 
 @export
-def mul(x: ArrayLike, y: ArrayLike) -> Array:
+def mul(x: ArrayLike, y: ArrayLike, *, out_dtype: DTypeLike | None = None) -> Array:
   r"""Elementwise multiplication: :math:`x \times y`.
 
   This function lowers directly to the `stablehlo.multiply`_ operation.
@@ -1195,6 +1195,11 @@ def mul(x: ArrayLike, y: ArrayLike) -> Array:
     x, y: Input arrays. Must have matching numerical dtypes. If neither
       is a scalar, ``x`` and ``y`` must have the same number of dimensions
       and be broadcast compatible.
+    out_dtype: Optional. Either ``None`` (default), or a dtype. If
+      it is a dtype, the output will be of the specified dtype. Typically, this
+      is accomplished by casting the inputs to the specified dtype before the
+      multiplication is performed, but on some backends this may be done via
+      a custom kernel.
 
   Returns:
     An array of the same dtype as ``x`` and ``y`` containing the product
@@ -1207,7 +1212,7 @@ def mul(x: ArrayLike, y: ArrayLike) -> Array:
   .. _stablehlo.multiply: https://openxla.org/stablehlo/spec#multiply
   """
   x, y = core.standard_insert_pvary(x, y)
-  return mul_p.bind(x, y)
+  return mul_p.bind(x, y, out_dtype=out_dtype)
 
 @export
 def div(x: ArrayLike, y: ArrayLike) -> Array:
@@ -3963,18 +3968,19 @@ def naryop_dtype_rule(result_dtype, accepted_dtypes, name, *avals,
         typename = dtype_to_string(aval.dtype)
         typenames = ', '.join(t.__name__ for t in types)
         raise TypeError(msg.format(name, typename, i, i, typenames))
-  if require_same: check_same_dtypes(name, *avals)
+  if require_same and kwargs.get('out_dtype') is None:
+    check_same_dtypes(name, *avals)
   return result_dtype(*avals, **kwargs)
 
 
-def broadcasting_shape_rule(name, *avals):
+def broadcasting_shape_rule(name, *avals, **kwargs):
   shapes = [aval.shape for aval in avals if aval.shape]
   if not shapes:
     return ()
   return _try_broadcast_shapes(*shapes, name=name)
 
 
-def broadcasting_sharding_rule(name, *avals):
+def broadcasting_sharding_rule(name, *avals, **kwargs):
   mesh = None
   for a in avals:
     if a.sharding is not None and not a.sharding.mesh.empty:
@@ -4114,10 +4120,15 @@ def _nary_lower_hlo(
 ) -> Sequence[ir.Value]:
   """Lowers an elementwise operator to its MLIR equivalent.
   """
+  out_dtype = params.pop('out_dtype', None)
   del params
   avals_in, (aval_out,) = ctx.avals_in, ctx.avals_out
   args = tuple(mlir.multi_broadcast_in_dim(ctx, args, avals_in, aval_out.shape,
                                            aval_out.sharding))
+
+  if out_dtype is not None:
+    ir_type = mlir.aval_to_ir_type(aval_out)
+    args = tuple(hlo.convert(ir_type, a) for a in args)
 
   out = op(*args)
   if accuracy:
@@ -4693,7 +4704,8 @@ ad.primitive_jvps[sub_p] = _sub_jvp
 ad.primitive_transposes[sub_p] = _sub_transpose
 mlir.register_lowering(sub_p, partial(_nary_lower_hlo, hlo.subtract))
 
-def _mul_ur_rule(x, y):
+def _mul_ur_rule(x, y, *, out_dtype=None):
+  del out_dtype  # unused
   out_reduced = default_nary_reduced_rule(x, y)
   x_ur, y_ur = getu(x), getu(y)
   if x_ur and y_ur:
@@ -4720,15 +4732,25 @@ def _mul_ur_rule(x, y):
     out_reduced = frozenset()  # if both are equal, set difference is empty.
   return out_unreduced, out_reduced
 
+
+def _binary_with_out_dtype_pp_rule(eqn, context, settings):
+  params = dict(eqn.params)
+  if params['out_dtype'] is None:
+    del params['out_dtype']  # don't show trivial case
+  return core._pp_eqn(eqn.replace(params=params), context, settings)
+
+
 mul_p = standard_naryop([_num, _num], 'mul', ur_rule=_mul_ur_rule)
 ad.defjvp(mul_p,
-          lambda xdot, x, y: mul(xdot, y),
-          lambda ydot, x, y: mul(x, ydot))
+          lambda xdot, x, y, **kwargs: mul(xdot, y, **kwargs),
+          lambda ydot, x, y, **kwargs: mul(x, ydot, **kwargs))
+
 ad.defbilinear(
     mul_p,
-    lambda ct, x, y: _unbroadcast(x.aval.to_ct_aval(), mul(ct, y)),
-    lambda ct, x, y: _unbroadcast(y.aval.to_ct_aval(), mul(x, ct)))
+    lambda ct, x, y, *, out_dtype: _unbroadcast(x.aval.to_ct_aval(), mul(ct, y, out_dtype=None if out_dtype is None else x.aval.dtype)),
+    lambda ct, x, y, *, out_dtype: _unbroadcast(y.aval.to_ct_aval(), mul(x, ct, out_dtype=None if out_dtype is None else y.aval.dtype)))
 mlir.register_lowering(mul_p, partial(_nary_lower_hlo, hlo.multiply))
+core.pp_eqn_rules[mul_p] = _binary_with_out_dtype_pp_rule
 
 def _div_transpose_rule(cotangent, x, y):
   assert ad.is_undefined_primal(x) and not ad.is_undefined_primal(y)

--- a/jax/_src/lax/utils.py
+++ b/jax/_src/lax/utils.py
@@ -34,7 +34,9 @@ from jax._src.typing import DimSize, DType, Shape
 zip, unsafe_zip = safe_zip, zip
 
 
-def input_dtype(x, *_, **__):
+def input_dtype(x, *_, out_dtype=None, **__):
+  if out_dtype is not None:
+    return dtypes.canonicalize_dtype(out_dtype)
   return x.dtype
 
 def _argnum_weak_type(*argnums):

--- a/jax/_src/lax_reference.py
+++ b/jax/_src/lax_reference.py
@@ -102,7 +102,12 @@ bitwise_xor = np.bitwise_xor
 
 add = np.add
 sub = np.subtract
-mul = np.multiply
+
+def mul(x, y, /, *, out_dtype=None):
+  if out_dtype is not None:
+    x = np.astype(x, out_dtype)
+    y = np.astype(y, out_dtype)
+  return np.multiply(x, y)
 
 def div(lhs, rhs):
   if dtypes.issubdtype(dtypes.result_type(lhs), np.integer):

--- a/jax/_src/pallas/fuser/block_spec.py
+++ b/jax/_src/pallas/fuser/block_spec.py
@@ -861,8 +861,9 @@ def _push_bcast_block_spec(
   return pallas_core.BlockSpec(new_block_shape, block_spec.index_map)
 
 
-def _binop_usage_rule(prim, ctx, used_out: set[Usage]):
+def _binop_usage_rule(prim, ctx, used_out: set[Usage], **params):
   del prim
+  del params  # unused
   if used_out == {Usage.SCALAR_PREFETCH}:
     return [{Usage.SCALAR_PREFETCH}, {Usage.SCALAR_PREFETCH}]
   elif used_out == {Usage.REGULAR}:
@@ -872,13 +873,14 @@ def _binop_usage_rule(prim, ctx, used_out: set[Usage]):
     return [set()] * len(ctx.avals_in)
 
 
-def _binop_eval_rule(prim, ctx, x, y):
+def _binop_eval_rule(prim, ctx, x, y, **params):
   del ctx
-  return prim.bind(x, y)
+  return prim.bind(x, y, **params)
 
 
-def _binop_pull_rule(prim, ctx: PullRuleContext, block_transform):
+def _binop_pull_rule(prim, ctx: PullRuleContext, block_transform, **params):
   del prim
+  del params  # unused
   l_block_transform = block_transform
   r_block_transform = block_transform
   left_aval, right_aval = ctx.avals_in

--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -2846,7 +2846,7 @@ def _sub_lowering_rule(ctx: LoweringRuleContext, x, y):
 @register_lowering_rule(
     lax.mul_p, kernel_types=[*tpu_core.CoreType], ensure_mlir_values=False
 )
-def _mul_lowering_rule(ctx: LoweringRuleContext, x, y):
+def _mul_lowering_rule(ctx: LoweringRuleContext, x, y, *, out_dtype):
   x, y = _bcast(
       x,
       y,
@@ -2855,6 +2855,10 @@ def _mul_lowering_rule(ctx: LoweringRuleContext, x, y):
       ctx.avals_out[0],
       ctx.lowering_context.dynamic_shape_replacement_fn,
   )
+  if out_dtype is not None:
+    convert_to_out_dtype = lower_fun(lambda x: x.astype(out_dtype))
+    x = convert_to_out_dtype(ctx, x)
+    y = convert_to_out_dtype(ctx, y)
   (aval_out,) = ctx.avals_out
   if jnp.issubdtype(aval_out.dtype, jnp.integer):
     return arith.muli(x, y)

--- a/jax/_src/pallas/mosaic_gpu/lowering.py
+++ b/jax/_src/pallas/mosaic_gpu/lowering.py
@@ -2400,7 +2400,8 @@ mosaic_lowering_rules[gpu_core.WGxWG_SEMANTICS].update({
 })
 
 
-def _binary_op_lowering_rule(ctx: LoweringRuleContext, x, y, *, impl):
+def _binary_op_lowering_rule(ctx: LoweringRuleContext, x, y, *, impl, out_dtype=None):
+  del out_dtype  # unused here.
   if ctx.module_ctx.primitive_semantics == gpu_core.PrimitiveSemantics.Warp:
     if not all(aval_in.shape == () for aval_in in ctx.avals_in):
       raise NotImplementedError(
@@ -2434,8 +2435,10 @@ for semantics in [gpu_core.LANExWG_SEMANTICS, gpu_core.LANExWARP_SEMANTICS]:
   })
 
 def _binary_op_lowering_rule_wg(
-    ctx: LoweringRuleContext, x, y, *, ui_impl, si_impl, f_impl=None
+    ctx: LoweringRuleContext, x, y, *, ui_impl, si_impl, f_impl=None, **kwargs,
 ):
+  if kwargs.get('out_dtype') is not None:
+    raise NotImplementedError("out_dtype argument in binary_op_lowering_rule_wg")
   if ctx.module_ctx.primitive_semantics == gpu_core.PrimitiveSemantics.Warp:
     if any(aval_in.shape for aval_in in ctx.avals_in):
       raise NotImplementedError(

--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -1137,7 +1137,9 @@ def _sub(x: ir.Value, y: ir.Value) -> ir.Value:
   raise NotImplementedError(f"unsupported dtype: {y.type}")
 
 
-def _mul(x: ir.Value, y: ir.Value) -> ir.Value:
+def _mul(x: ir.Value, y: ir.Value, *, out_dtype=None) -> ir.Value:
+  if out_dtype is not None:
+    raise NotImplementedError("out_dtype is not supported..")
   assert x.type == y.type, (str(x.type), str(y.type))
   x_element_type = _element_type(x.type)
   if isinstance(x_element_type, ir.IntegerType):
@@ -1261,9 +1263,9 @@ _JAX_TO_TRITON_BINARY = {
 
 for prim, fn in _JAX_TO_TRITON_BINARY.items():
 
-  def signless_rule(ctx: LoweringRuleContext, x, y, fn=fn):
+  def signless_rule(ctx: LoweringRuleContext, x, y, fn=fn, **kwargs):
     x, y = _bcast(x, y, *ctx.avals_in, *ctx.avals_out)
-    return fn(x, y)
+    return fn(x, y, **kwargs)
 
   triton_lowering_rules[prim] = signless_rule
 

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -661,25 +661,31 @@ def _sub_sparse(spenv, *spvalues):
 
 sparse_rules_bcoo[lax.sub_p] = _sub_sparse
 
-def _mul_sparse(spenv, *spvalues):
+def _mul_sparse(spenv, *spvalues, out_dtype=None):
   X, Y = spvalues
   if X.is_sparse() and Y.is_sparse():
     if X.indices_ref == Y.indices_ref and X.unique_indices:
       if config.enable_checks.value:
         assert X.indices_sorted == Y.indices_sorted
         assert X.unique_indices == Y.unique_indices
-      out_data = lax.mul(spenv.data(X), spenv.data(Y))
+      out_data = lax.mul(spenv.data(X), spenv.data(Y), out_dtype=out_dtype)
       out_spvalue = spenv.sparse(X.shape, out_data, indices_ref=X.indices_ref,
                                  indices_sorted=X.indices_sorted,
                                  unique_indices=True)
     else:
       X_promoted, Y_promoted = spvalues_to_arrays(spenv, spvalues)
+      if out_dtype is not None:
+        X_promoted = X_promoted.astype(out_dtype)
+        Y_promoted = Y_promoted.astype(out_dtype)
       mat = bcoo_multiply_sparse(X_promoted, Y_promoted)
       out_spvalue = spenv.sparse(mat.shape, mat.data, mat.indices)
   else:
     if Y.is_sparse():
       X, Y = Y, X
     X_promoted = spvalues_to_arrays(spenv, X)
+    if out_dtype is not None:
+      X_promoted = X_promoted.astype(out_dtype)
+      Y = Y.astype(out_dtype)
     out_data = bcoo_multiply_dense(X_promoted, spenv.data(Y))
     out_spvalue = spenv.sparse(X.shape, out_data, indices_ref=X.indices_ref,
                                indices_sorted=X.indices_sorted,

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -51,6 +51,11 @@ grad_float_dtypes = jtu.dtypes.floating
 grad_complex_dtypes = jtu.dtypes.complex
 grad_inexact_dtypes = jtu.dtypes.inexact
 
+LAX_GRAD_OPS_WITH_OUT_DTYPE = [
+    grad_test_spec(lax.mul, nargs=2, order=2, rng_factory=jtu.rand_default,
+                   dtypes=grad_float_dtypes),
+]
+
 LAX_GRAD_OPS = [
     grad_test_spec(lax.neg, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=grad_inexact_dtypes),
@@ -190,6 +195,28 @@ def check_grads_bilinear(f, args, order,
 
 
 class LaxAutodiffTest(jtu.JaxTestCase):
+
+  @parameterized.parameters(itertools.chain.from_iterable(
+    jtu.sample_product_testcases(
+      [dict(op=rec.op, rng_factory=rec.rng_factory, order=rec.order, tol=rec.tol)],
+      shapes=[
+        shapes for shape_group in compatible_shapes
+        for shapes in itertools.combinations_with_replacement(shape_group, rec.nargs)
+      ],
+      lhs_dtype=rec.dtypes,
+      rhs_dtype=rec.dtypes,
+      out_dtype=rec.dtypes,
+    )
+    for rec in LAX_GRAD_OPS_WITH_OUT_DTYPE
+  ))
+  def testOpGradOutDtype(self, op, rng_factory, shapes, lhs_dtype, rhs_dtype, out_dtype, order, tol):
+    rng = rng_factory(self.rng())
+
+    dtypes = [lhs_dtype, rhs_dtype]
+    bits = min(jtu.num_float_bits(dtype) for dtype in [lhs_dtype, rhs_dtype, out_dtype])
+    tol = jtu.join_tolerance(1.5e-1, tol) if bits == 32 else tol
+    args = tuple(rng(shape, dtype) for shape, dtype in zip(shapes, dtypes))
+    check_grads(partial(op, out_dtype=out_dtype), args, order, ["fwd", "rev"], tol, tol)
 
   @parameterized.parameters(itertools.chain.from_iterable(
     jtu.sample_product_testcases(

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -135,6 +135,24 @@ class LaxTest(jtu.JaxTestCase):
       tol = jtu.join_tolerance(tol, 2e-15)
     self._CheckAgainstNumpy(numpy_op, op, args_maker, tol=tol)
 
+  @parameterized.parameters(itertools.chain.from_iterable(
+      jtu.sample_product_testcases(
+          [dict(op_name=rec.op, rng_factory=rec.rng_factory)],
+          [dict(dtype=dtype, out_dtype=preferred)
+           for dtype, preferred in preferred_type_combinations],
+          shapes=itertools.chain.from_iterable(
+              itertools.combinations_with_replacement(shape_group, rec.nargs)
+              for shape_group in lax_test_util.compatible_shapes))
+      for rec in lax_test_util.lax_out_dtype_ops()))
+  def testOpOutDtype(self, op_name, rng_factory, shapes, dtype, out_dtype):
+    rng = rng_factory(self.rng())
+    args_maker = lambda: [rng(shape, dtype) for shape in shapes]
+    op = partial(getattr(lax, op_name), out_dtype=out_dtype)
+    numpy_op = partial(getattr(lax_reference, op_name), out_dtype=out_dtype)
+
+    self._CheckAgainstNumpy(numpy_op, op, args_maker)
+    self._CompileAndCheck(op, args_maker)
+
   @parameterized.parameters(["logistic", "tanh"])
   def testEvenFunctionGrads(self, op_name):
     op = getattr(lax, op_name)


### PR DESCRIPTION
Why? For pallas it would be useful to have a `dot_general`-like `preferred_element_type` argument in the `lax.mul` primitive. This is a quick implementation of this which leaves the default behavior of `lax.mul` unchanged, but allows optionally specifying `preferred_element_type`.