### PR TITLE
support scipy-style auto-batching in jsp.linalg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     `manual_type: jax.sharding.ManualAxisType`. The `.vma` property has been
     replaced with `.manual_type.varying`.
   * Removed experimental {func}`jax.experimental.custom_dce.custom_dce`
+  * {func}`jax.scipy.linalg.cho_solve`, {func}`jax.scipy.linalg.lu_solve`, and
+    {func}`jax.scipy.linalg.solve_triangular` now show a deprecation warning for
+    batched 1D solves with `b.ndim > 1`. In the future these will be treated as
+    batched 2D solves.
 
 ## JAX 0.9.2 (March 18, 2026)
 

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from functools import partial
 import textwrap
 from typing import overload, Any, Literal
+import warnings
 
 import numpy as np
 
@@ -158,12 +159,26 @@ def cho_factor(a: ArrayLike, lower: bool = False, overwrite_a: bool = False,
 @jit(static_argnames=('lower',))
 def _cho_solve(c: ArrayLike, b: ArrayLike, lower: bool) -> Array:
   c, b = promote_dtypes_inexact(jnp.asarray(c), jnp.asarray(b))
-  lax_linalg._check_solve_shapes(c, b)
-  b = lax_linalg.triangular_solve(c, b, left_side=True, lower=lower,
-                                  transpose_a=not lower, conjugate_a=not lower)
-  b = lax_linalg.triangular_solve(c, b, left_side=True, lower=lower,
-                                  transpose_a=lower, conjugate_a=lower)
-  return b
+  if b.ndim == 1:
+    signature = "(n,n),(n)->(n)"
+  elif c.ndim == b.ndim + 1 and c.shape[-1] == b.shape[-1]:
+    # Deprecation warning added 2026-03-23
+    warnings.warn(
+        "jax.scipy.linalg.cho_solve: batched 1D solves with b.ndim > 1 are "
+        "deprecated, and in the future will be treated as a batched 2D solve. "
+        "Use cho_solve(c_and_lower, b[..., None]).squeeze(-1) to avoid this warning.",
+        category=FutureWarning)
+    signature = "(n,n),(n)->(n)"
+  else:
+    signature = "(n,n),(n,k)->(n,k)"
+  b = jnp_vectorize.vectorize(
+      partial(lax_linalg.triangular_solve, left_side=True, lower=lower,
+              transpose_a=not lower, conjugate_a=not lower),
+      signature=signature)(c, b)
+  return jnp_vectorize.vectorize(
+      partial(lax_linalg.triangular_solve, left_side=True, lower=lower,
+              transpose_a=lower, conjugate_a=lower),
+      signature=signature)(c, b)
 
 
 def cho_solve(c_and_lower: tuple[ArrayLike, bool], b: ArrayLike,
@@ -177,12 +192,16 @@ def cho_solve(c_and_lower: tuple[ArrayLike, bool], b: ArrayLike,
     c_and_lower: ``(c, lower)``, where ``c`` is an array of shape ``(..., N, N)``
       representing the lower or upper cholesky decomposition of the matrix, and
       ``lower`` is a boolean specifying whether this is the lower or upper decomposition.
-    b: right-hand-side of linear system. Must have shape ``(..., N)``
+    b: right-hand-side of linear system. Array of shape ``(N,)`` (for a
+      1-dimensional right-hand-side) or ``(..., N, M)`` (for a batched
+      2-dimensional right-hand-side).
     overwrite_a: unused by JAX
     check_finite: unused by JAX
 
   Returns:
-    Array of shape ``(..., N)`` representing the solution of the linear system.
+    Array representing the solution of the linear system. The result has
+    shape ``(..., N)`` if ``b`` is of shape ``(N,)``, and has shape
+    ``(..., N, M)`` otherwise.
 
   See Also:
     - :func:`jax.scipy.linalg.cholesky`
@@ -675,7 +694,9 @@ def lu_solve(lu_and_piv: tuple[Array, ArrayLike], b: ArrayLike, trans: int = 0,
       ``lu`` is an array of shape ``(..., M, N)``, containing ``L`` in its lower
       triangle and ``U`` in its upper. ``piv`` is an array of shape ``(..., K)``,
       with ``K = min(M, N)``, which encodes the pivots.
-    b: right-hand-side of linear system. Must have shape ``(..., M)``
+    b: right-hand-side of linear system. Array of shape ``(M,)`` (for a
+      1-dimensional right-hand-side) or ``(..., M, K)`` (for a batched
+      2-dimensional right-hand-side).
     trans: type of system to solve. Options are:
 
       - ``0``: :math:`A x = b`
@@ -686,7 +707,9 @@ def lu_solve(lu_and_piv: tuple[Array, ArrayLike], b: ArrayLike, trans: int = 0,
     check_finite: unused by JAX
 
   Returns:
-    Array of shape ``(..., N)`` representing the solution of the linear system.
+    Array representing the solution of the linear system. The result has
+    shape ``(..., N)`` if ``b`` is of shape ``(M,)``, and has shape
+    ``(..., N, K)`` otherwise.
 
   See Also:
     - :func:`jax.scipy.linalg.lu`
@@ -714,9 +737,24 @@ def lu_solve(lu_and_piv: tuple[Array, ArrayLike], b: ArrayLike, trans: int = 0,
   """
   del overwrite_b, check_finite  # unused
   lu, pivots = lu_and_piv
+  lu, b = promote_dtypes_inexact(jnp.asarray(lu), jnp.asarray(b))
   m, _ = lu.shape[-2:]
   perm = lax_linalg.lu_pivots_to_permutation(pivots, m)
-  return lax_linalg.lu_solve(lu, perm, b, trans)
+  if b.ndim == 1:
+    signature = "(n,n),(n),(n)->(n)"
+  elif lu.ndim == b.ndim + 1 and lu.shape[-1] == b.shape[-1]:
+    # Deprecation warning added 2026-03-23
+    warnings.warn(
+        "jax.scipy.linalg.lu_solve: batched 1D solves with b.ndim > 1 are "
+        "deprecated, and in the future will be treated as a batched 2D solve. "
+        "Use lu_solve(lu_and_piv, b[..., None]).squeeze(-1) to avoid this warning.",
+        category=FutureWarning)
+    signature = "(n,n),(n),(n)->(n)"
+  else:
+    signature = "(n,n),(n),(n,k)->(n,k)"
+  return jnp_vectorize.vectorize(
+      partial(lax_linalg.lu_solve, trans=trans),
+      signature=signature)(lu, perm, b)
 
 @overload
 def _lu(a: ArrayLike, permute_l: Literal[True]) -> tuple[Array, Array]: ...
@@ -1238,18 +1276,24 @@ def _solve_triangular(a: ArrayLike, b: ArrayLike, trans: int | str,
 
   a, b = promote_dtypes_inexact(jnp.asarray(a), jnp.asarray(b))
 
-  # lax_linalg.triangular_solve only supports matrix 'b's at the moment.
-  b_is_vector = np.ndim(a) == np.ndim(b) + 1
-  if b_is_vector:
-    b = b[..., None]
-  out = lax_linalg.triangular_solve(a, b, left_side=True, lower=lower,
-                                    transpose_a=transpose_a,
-                                    conjugate_a=conjugate_a,
-                                    unit_diagonal=unit_diagonal)
-  if b_is_vector:
-    return out[..., 0]
+  if b.ndim == 1:
+    signature = "(n,n),(n)->(n)"
+  elif a.ndim == b.ndim + 1 and a.shape[-1] == b.shape[-1]:
+    # Deprecation warning added 2026-03-23
+    warnings.warn(
+        "jax.scipy.linalg.solve_triangular: batched 1D solves with b.ndim > 1 "
+        "are deprecated, and in the future will be treated as a batched 2D solve. "
+        "Use solve_triangular(a, b[..., None]).squeeze(-1) to avoid this warning.",
+        category=FutureWarning)
+    signature = "(n,n),(n)->(n)"
   else:
-    return out
+    signature = "(n,n),(n,k)->(n,k)"
+
+  return jnp_vectorize.vectorize(
+      partial(lax_linalg.triangular_solve, left_side=True, lower=lower,
+              transpose_a=transpose_a, conjugate_a=conjugate_a,
+              unit_diagonal=unit_diagonal),
+      signature=signature)(a, b)
 
 
 def solve_triangular(a: ArrayLike, b: ArrayLike, trans: int | str = 0, lower: bool = False,
@@ -1265,7 +1309,8 @@ def solve_triangular(a: ArrayLike, b: ArrayLike, trans: int | str = 0, lower: bo
   Args:
     a: array of shape ``(..., N, N)``. Only part of the array will be accessed,
       depending on the ``lower`` and ``unit_diagonal`` arguments.
-    b: array of shape ``(..., N)`` or ``(..., N, M)``
+    b: array of shape ``(N,)`` (for a 1-dimensional right-hand-side) or
+      ``(..., N, M)`` (for a batched 2-dimensional right-hand-side).
     lower: If True, only use the lower triangle of the input, If False (default),
       only use the upper triangle.
     unit_diagonal: If True, ignore diagonal elements of ``a`` and assume they are
@@ -1281,7 +1326,9 @@ def solve_triangular(a: ArrayLike, b: ArrayLike, trans: int | str = 0, lower: bo
     check_finite: unused by JAX
 
   Returns:
-    An array of the same shape as ``b`` containing the solution to the linear system.
+    An array containing the solution to the linear system. The result has
+    shape ``(..., N)`` if ``b`` is of shape ``(N,)``, and has shape
+    ``(..., N, M)`` otherwise.
 
   See also:
     :func:`jax.scipy.linalg.solve`: Solve a general linear system.
@@ -1822,6 +1869,36 @@ def eigh_tridiagonal(d: ArrayLike, e: ArrayLike, *, eigvals_only: bool = False,
 
 @jit(static_argnames=('side', 'method'))
 @config.default_matmul_precision("float32")
+def _polar_2d(a: Array, side: str, method: str, eps: float | None,
+              max_iterations: int | None) -> tuple[Array, Array]:
+  m, n = a.shape
+  if method == "qdwh":
+    # TODO(phawkins): return info also if the user opts in?
+    if m >= n and side == "right":
+      unitary, posdef, _, _ = qdwh.qdwh(a, is_hermitian=False, eps=eps)
+    elif m < n and side == "left":
+      a = a.T.conj()
+      unitary, posdef, _, _ = qdwh.qdwh(a, is_hermitian=False, eps=eps)
+      posdef = posdef.T.conj()
+      unitary = unitary.T.conj()
+    else:
+      raise NotImplementedError("method='qdwh' only supports mxn matrices "
+                                "where m < n where side='right' and m >= n "
+                                f"side='left', got {a.shape} with {side=}")
+  elif method == "svd":
+    u_svd, s_svd, vh_svd = lax_linalg.svd(a, full_matrices=False)
+    s_svd = s_svd.astype(u_svd.dtype)
+    unitary = u_svd @ vh_svd
+    if side == "right":
+      posdef = (vh_svd.T.conj() * s_svd[None, :]) @ vh_svd
+    else:
+      posdef = (u_svd * s_svd[None, :]) @ (u_svd.T.conj())
+  else:
+    raise ValueError(f"Unknown polar decomposition method {method}.")
+  return unitary, posdef
+
+
+@jit(static_argnames=('side', 'method'))
 def polar(a: ArrayLike, side: str = 'right', *, method: str = 'qdwh', eps: float | None = None,
           max_iterations: int | None = None) -> tuple[Array, Array]:
   r"""Computes the polar decomposition.
@@ -1855,7 +1932,7 @@ def polar(a: ArrayLike, side: str = 'right', *, method: str = 'qdwh', eps: float
     Applies the `QDWH`_ (QR-based Dynamically Weighted Halley) algorithm.
 
   Args:
-    a: The :math:`m \times n` input matrix.
+    a: array of shape ``(..., m, n)``.
     side: Determines whether a right or left polar decomposition is computed.
       If ``side`` is ``"right"`` then :math:`a = up`. If ``side`` is ``"left"``
       then :math:`a = pu`. The default is ``"right"``.
@@ -1870,9 +1947,9 @@ def polar(a: ArrayLike, side: str = 'right', *, method: str = 'qdwh', eps: float
 
   Returns:
     A ``(unitary, posdef)`` tuple, where ``unitary`` is the unitary factor
-    (:math:`m \times n`), and ``posdef`` is the positive-semidefinite factor.
-    ``posdef`` is either :math:`n \times n` or :math:`m \times m` depending on
-    whether ``side`` is ``"right"`` or ``"left"``, respectively.
+    of shape ``(..., m, n)``, and ``posdef`` is the positive-semidefinite
+    factor. ``posdef`` has shape ``(..., n, n)`` or ``(..., m, m)`` depending
+    on whether ``side`` is ``"right"`` or ``"left"``, respectively.
 
   Examples:
 
@@ -1907,40 +1984,17 @@ def polar(a: ArrayLike, side: str = 'right', *, method: str = 'qdwh', eps: float
   .. _QDWH: https://epubs.siam.org/doi/abs/10.1137/090774999
   """
   arr = jnp.asarray(a)
-  if arr.ndim != 2:
-    raise ValueError("The input `a` must be a 2-D array.")
+  if arr.ndim < 2:
+    raise ValueError("The input `a` must be at least a 2-D array.")
 
   if side not in ["right", "left"]:
     raise ValueError("The argument `side` must be either 'right' or 'left'.")
 
-  m, n = arr.shape
-  if method == "qdwh":
-    # TODO(phawkins): return info also if the user opts in?
-    if m >= n and side == "right":
-      unitary, posdef, _, _ = qdwh.qdwh(arr, is_hermitian=False, eps=eps)
-    elif m < n and side == "left":
-      arr = arr.T.conj()
-      unitary, posdef, _, _ = qdwh.qdwh(arr, is_hermitian=False, eps=eps)
-      posdef = posdef.T.conj()
-      unitary = unitary.T.conj()
-    else:
-      raise NotImplementedError("method='qdwh' only supports mxn matrices "
-                                "where m < n where side='right' and m >= n "
-                                f"side='left', got {arr.shape} with {side=}")
-  elif method == "svd":
-    u_svd, s_svd, vh_svd = lax_linalg.svd(arr, full_matrices=False)
-    s_svd = s_svd.astype(u_svd.dtype)
-    unitary = u_svd @ vh_svd
-    if side == "right":
-      # a = u * p
-      posdef = (vh_svd.T.conj() * s_svd[None, :]) @ vh_svd
-    else:
-      # a = p * u
-      posdef = (u_svd * s_svd[None, :]) @ (u_svd.T.conj())
-  else:
-    raise ValueError(f"Unknown polar decomposition method {method}.")
-
-  return unitary, posdef
+  sig = "(m,n)->(m,n),(n,n)" if side == "right" else "(m,n)->(m,n),(m,m)"
+  return jnp_vectorize.vectorize(
+      partial(_polar_2d, side=side, method=method, eps=eps,
+              max_iterations=max_iterations),
+      signature=sig)(arr)
 
 
 @jit
@@ -2026,6 +2080,52 @@ def sqrtm(A: ArrayLike, blocksize: int = 1) -> Array:
   return _sqrtm(A)
 
 
+@jit
+def _rsf2csf_2d(T: Array, Z: Array) -> tuple[Array, Array]:
+  T, Z = promote_dtypes_complex(T, Z)
+  eps = dtypes.finfo(T.dtype).eps
+  N = T.shape[0]
+
+  if N == 1:
+    return T, Z
+
+  def _update_T_Z(m, T, Z):
+    mu = jnp_linalg.eigvals(lax.dynamic_slice(T, (m-1, m-1), (2, 2))) - T[m, m]
+    r = jnp_linalg.norm(jnp.array([mu[0], T[m, m-1]])).astype(T.dtype)
+    c = mu[0] / r
+    s = T[m, m-1] / r
+    G = jnp.array([[c.conj(), s], [-s, c]], dtype=T.dtype)
+
+    T_rows = lax.dynamic_slice_in_dim(T, m-1, 2, axis=0)
+    col_mask = jnp.arange(N) >= m-1
+    G_dot_T_zeroed_cols = G @ jnp.where(col_mask, T_rows, 0)
+    T_rows_new = jnp.where(~col_mask, T_rows, G_dot_T_zeroed_cols)
+    T = lax.dynamic_update_slice_in_dim(T, T_rows_new, m-1, axis=0)
+
+    T_cols = lax.dynamic_slice_in_dim(T, m-1, 2, axis=1)
+    row_mask = jnp.arange(N)[:, np.newaxis] < m+1
+    T_zeroed_rows_dot_GH = jnp.where(row_mask, T_cols, 0) @ G.conj().T
+    T_cols_new = jnp.where(~row_mask, T_cols, T_zeroed_rows_dot_GH)
+    T = lax.dynamic_update_slice_in_dim(T, T_cols_new, m-1, axis=1)
+
+    Z_cols = lax.dynamic_slice_in_dim(Z, m-1, 2, axis=1)
+    Z = lax.dynamic_update_slice_in_dim(Z, Z_cols @ G.conj().T, m-1, axis=1)
+    return T, Z
+
+  def _rsf2csf_iter(i, TZ):
+    m = N-i
+    T, Z = TZ
+    T, Z = lax.cond(
+      jnp.abs(T[m, m-1]) > eps*(jnp.abs(T[m-1, m-1]) + jnp.abs(T[m, m])),
+      _update_T_Z,
+      lambda m, T, Z: (T, Z),
+      m, T, Z)
+    T = T.at[m, m-1].set(0.0)
+    return T, Z
+
+  return lax.fori_loop(1, N, _rsf2csf_iter, (T, Z))
+
+
 @jit(static_argnames=('check_finite',))
 def rsf2csf(T: ArrayLike, Z: ArrayLike, check_finite: bool = True) -> tuple[Array, Array]:
   """Convert real Schur form to complex Schur form.
@@ -2035,7 +2135,7 @@ def rsf2csf(T: ArrayLike, Z: ArrayLike, check_finite: bool = True) -> tuple[Arra
   Args:
     T: array of shape ``(..., N, N)`` containing the real Schur form of the input.
     Z: array of shape ``(..., N, N)`` containing the corresponding Schur transformation
-      matrix.
+      matrix. Batch dimensions are broadcast with those of ``T``.
     check_finite: unused by JAX
 
   Returns:
@@ -2081,58 +2181,15 @@ def rsf2csf(T: ArrayLike, Z: ArrayLike, check_finite: bool = True) -> tuple[Arra
   T_arr = jnp.asarray(T)
   Z_arr = jnp.asarray(Z)
 
-  if T_arr.ndim != 2 or T_arr.shape[0] != T_arr.shape[1]:
+  if T_arr.ndim < 2 or T_arr.shape[-1] != T_arr.shape[-2]:
     raise ValueError("Input 'T' must be square.")
-  if Z_arr.ndim != 2 or Z_arr.shape[0] != Z_arr.shape[1]:
+  if Z_arr.ndim < 2 or Z_arr.shape[-1] != Z_arr.shape[-2]:
     raise ValueError("Input 'Z' must be square.")
-  if T_arr.shape[0] != Z_arr.shape[0]:
+  if T_arr.shape[-1] != Z_arr.shape[-1]:
     raise ValueError(f"Input array shapes must match: Z: {Z_arr.shape} vs. T: {T_arr.shape}")
 
-  T_arr, Z_arr = promote_dtypes_complex(T_arr, Z_arr)
-  eps = dtypes.finfo(T_arr.dtype).eps
-  N = T_arr.shape[0]
-
-  if N == 1:
-    return T_arr, Z_arr
-
-  def _update_T_Z(m, T, Z):
-    mu = jnp_linalg.eigvals(lax.dynamic_slice(T, (m-1, m-1), (2, 2))) - T[m, m]
-    r = jnp_linalg.norm(jnp.array([mu[0], T[m, m-1]])).astype(T.dtype)
-    c = mu[0] / r
-    s = T[m, m-1] / r
-    G = jnp.array([[c.conj(), s], [-s, c]], dtype=T.dtype)
-
-    # T[m-1:m+1, m-1:] = G @ T[m-1:m+1, m-1:]
-    T_rows = lax.dynamic_slice_in_dim(T, m-1, 2, axis=0)
-    col_mask = jnp.arange(N) >= m-1
-    G_dot_T_zeroed_cols = G @ jnp.where(col_mask, T_rows, 0)
-    T_rows_new = jnp.where(~col_mask, T_rows, G_dot_T_zeroed_cols)
-    T = lax.dynamic_update_slice_in_dim(T, T_rows_new, m-1, axis=0)
-
-    # T[:m+1, m-1:m+1] = T[:m+1, m-1:m+1] @ G.conj().T
-    T_cols = lax.dynamic_slice_in_dim(T, m-1, 2, axis=1)
-    row_mask = jnp.arange(N)[:, np.newaxis] < m+1
-    T_zeroed_rows_dot_GH = jnp.where(row_mask, T_cols, 0) @ G.conj().T
-    T_cols_new = jnp.where(~row_mask, T_cols, T_zeroed_rows_dot_GH)
-    T = lax.dynamic_update_slice_in_dim(T, T_cols_new, m-1, axis=1)
-
-    # Z[:, m-1:m+1] = Z[:, m-1:m+1] @ G.conj().T
-    Z_cols = lax.dynamic_slice_in_dim(Z, m-1, 2, axis=1)
-    Z = lax.dynamic_update_slice_in_dim(Z, Z_cols @ G.conj().T, m-1, axis=1)
-    return T, Z
-
-  def _rsf2scf_iter(i, TZ):
-    m = N-i
-    T, Z = TZ
-    T, Z = lax.cond(
-      jnp.abs(T[m, m-1]) > eps*(jnp.abs(T[m-1, m-1]) + jnp.abs(T[m, m])),
-      _update_T_Z,
-      lambda m, T, Z: (T, Z),
-      m, T, Z)
-    T = T.at[m, m-1].set(0.0)
-    return T, Z
-
-  return lax.fori_loop(1, N, _rsf2scf_iter, (T_arr, Z_arr))
+  return jnp_vectorize.vectorize(
+      _rsf2csf_2d, signature="(n,n),(n,n)->(n,n),(n,n)")(T_arr, Z_arr)
 
 @overload
 def hessenberg(a: ArrayLike, *, calc_q: Literal[False], overwrite_a: bool = False,
@@ -2519,7 +2576,34 @@ def _solve_sylvester_triangular_scan(R: Array, S: Array, F: Array) -> Array:
   return Y_flat_final.reshape((m, n))
 
 
-@jit(static_argnames=["method", "tol"])
+@jit(static_argnames=["method"])
+def _solve_sylvester_2d(A: Array, B: Array, C: Array, *, method: str, tol: float) -> Array:
+  m, n = C.shape[-2:]
+  if method == "schur":
+    R, U = schur(A, output='complex')
+    S, V = schur(B.conj().T, output='complex')
+    F = U.conj().T @ C.astype(R.dtype) @ V
+    Y = _solve_sylvester_triangular_scan(R, S.conj().T, F)
+    X = U @ Y @ V.conj().T
+  elif method == "eigen":
+    RA, UA = jnp.linalg.eig(A)
+    RB, UB = jnp.linalg.eig(B)
+    F = solve(UA, C.astype(RA.dtype) @ UB)
+    W = RA[:, None] + RB[None, :]
+    Y = F / W
+    X = UA[:m,:m] @ Y[:m,:n] @ inv(UB)[:n,:n]
+  else:
+    raise ValueError(f"Unrecognized method {method}. The two valid methods are either \"schur\" or \"eigen\".")
+  if not dtypes.issubdtype(C.dtype, np.complexfloating):
+    X = X.real
+  return lax.cond(
+    jnp.any(jnp.abs(jnp.linalg.eigvals(A)[:, None] + jnp.linalg.eigvals(B)[None, :]) < tol),
+    lambda: jnp.zeros_like(X) * np.nan,
+    lambda: X,
+  )
+
+
+@jit(static_argnames=["method"])
 def solve_sylvester(A: ArrayLike, B: ArrayLike, C: ArrayLike, *, method: str = "schur", tol: float = 1e-8) -> Array:
   """
   Solves the Sylvester equation
@@ -2541,14 +2625,15 @@ def solve_sylvester(A: ArrayLike, B: ArrayLike, C: ArrayLike, *, method: str = "
   (2) The Eigen decomposition algorithm [CPU and GPU]
 
   Args:
-    A: Matrix of shape m x m
-    B: Matrix of shape n x n
-    C: Matrix of shape m x n
+    A: array of shape ``(..., m, m)``
+    B: array of shape ``(..., n, n)``
+    C: array of shape ``(..., m, n)``. Batch dimensions are broadcast across
+      ``A``, ``B``, and ``C``.
     method: "schur" is the default and is accurate but slow, and "eigen" is an alternative that is faster but less accurate for ill-conditioned matrices.
     tol: How close the sum of the eigenvalues from A and B can be to zero before returning matrix of NaNs
 
   Returns:
-    X: Matrix of shape m x n
+    Array of shape ``(..., m, n)`` representing the solution ``X``.
 
   Examples:
     >>> A = jax.numpy.array([[1, 2], [3, 4]])
@@ -2577,41 +2662,12 @@ def solve_sylvester(A: ArrayLike, B: ArrayLike, C: ArrayLike, *, method: str = "
     can still return good estimates for ill-conditioned matrices depending on how close to zero the sums of the eigenvalues of A and B
     are.
   """
-  A, B, C = promote_args_inexact("solve_sylvester", A, B, C)
+  A, B, C = promote_dtypes_inexact(jnp.asarray(A), jnp.asarray(B), jnp.asarray(C))
 
-  m, n = C.shape
-
-  if A.shape != (m, m) or B.shape != (n, n) or C.shape != (m, n):
+  m, n = C.shape[-2:]
+  if A.shape[-2:] != (m, m) or B.shape[-2:] != (n, n):
     raise ValueError(f"Incompatible shapes for Sylvester equation:\nA: {A.shape}\nB: {B.shape}\nC: {C.shape}")
 
-  if method == "schur":
-    # Schur decomposition
-    R, U = schur(A, output='complex')
-    S, V = schur(B.conj().T, output='complex')
-
-    # Transform right-hand side
-    F = U.conj().T @ C.astype(R.dtype) @ V
-
-    # Solve triangular Sylvester system
-    Y = _solve_sylvester_triangular_scan(R, S.conj().T, F)
-
-    # Transform back
-    X = U @ Y @ V.conj().T
-  elif method == "eigen":
-    RA, UA = jnp.linalg.eig(A)
-    RB, UB = jnp.linalg.eig(B)
-    F = solve(UA, C.astype(RA.dtype) @ UB)
-    W = RA[:, None] + RB[None, :]
-    Y = F / W
-    X = UA[:m,:m] @ Y[:m,:n] @ inv(UB)[:n,:n]
-  else:
-    raise ValueError(f"Unrecognized method {method}. The two valid methods are either \"schur\" or \"eigen\".")
-
-  if not dtypes.issubdtype(C.dtype, np.complexfloating):
-    X = X.real
-
-  return lax.cond(
-    jnp.any(jnp.abs(jnp.linalg.eigvals(A)[:, None] + jnp.linalg.eigvals(B)[None, :]) < tol),
-    lambda: jnp.zeros_like(X) * np.nan,
-    lambda: X,
-  )
+  return jnp_vectorize.vectorize(
+      partial(_solve_sylvester_2d, method=method, tol=tol),
+      signature="(m,m),(n,n),(m,n)->(m,n)")(A, B, C)

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1640,6 +1640,39 @@ class ScipyLinalgTest(jtu.JaxTestCase):
 
   @jtu.sample_product(
     [dict(lhs_shape=lhs_shape, rhs_shape=rhs_shape)
+     for lhs_shape, rhs_shape in [
+       # batched lu, unbatched b (vector)
+       ((3, 4, 4), (4,)),
+       # batched lu, unbatched b (matrix)
+       ((3, 8, 8), (8, 4)),
+       # unbatched lu, batched b (matrix) — broadcast lu -> batch
+       ((4, 4), (3, 4, 2)),
+     ]
+    ],
+    trans=[0, 1, 2],
+    dtype=float_types + complex_types,
+  )
+  @jtu.skip_on_devices("cpu")  # TODO(frostig): Test fails on CPU sometimes
+  @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
+  def testLuSolveBroadcast(self, lhs_shape, rhs_shape, dtype, trans):
+    if scipy_version < (1, 16, 0):
+      self.skipTest("scipy.linalg.lu_solve batch broadcasting requires scipy >= 1.16")
+    rng = jtu.rand_default(self.rng())
+    osp_fun = lambda lu, piv, rhs: osp.linalg.lu_solve((lu, piv), rhs, trans=trans)
+    jsp_fun = lambda lu, piv, rhs: jsp.linalg.lu_solve((lu, piv), rhs, trans=trans)
+    lu_factor_vec = np.vectorize(osp.linalg.lu_factor,
+                                  signature="(n,n)->(n,n),(n)")
+
+    def args_maker():
+      a = rng(lhs_shape, dtype)
+      lu, piv = lu_factor_vec(a) if a.ndim > 2 else osp.linalg.lu_factor(a)
+      return [lu, piv, rng(rhs_shape, dtype)]
+
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, tol=1e-3)
+    self._CompileAndCheck(jsp_fun, args_maker)
+
+  @jtu.sample_product(
+    [dict(lhs_shape=lhs_shape, rhs_shape=rhs_shape)
       for lhs_shape, rhs_shape in [
         ((1, 1), (1, 1)),
         ((4, 4), (4,)),
@@ -1675,7 +1708,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for lhs_shape, rhs_shape in [
         ((4, 4), (4,)),
         ((4, 4), (4, 3)),
-        ((2, 8, 8), (2, 8, 10)),
       ]
     ],
     lower=[False, True],
@@ -1698,20 +1730,48 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       a = l
     a = a if lower else T(a)
 
-    inv = np.linalg.inv(T(a) if transpose_a else a).astype(a.dtype)
-    if len(lhs_shape) == len(rhs_shape):
-      np_ans = np.matmul(inv, b)
-    else:
-      np_ans = np.einsum("...ij,...j->...i", inv, b)
+    osp_fun = partial(osp.linalg.solve_triangular, trans=1 if transpose_a else 0,
+                      lower=lower, unit_diagonal=unit_diagonal)
+    jsp_fun = partial(jsp.linalg.solve_triangular, trans=1 if transpose_a else 0,
+                      lower=lower, unit_diagonal=unit_diagonal)
+    args_maker = lambda: [a, b]
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker,
+                            rtol={np.float32: 1e-4, np.float64: 1e-11})
+    self._CompileAndCheck(jsp_fun, args_maker)
 
-    # The standard scipy.linalg.solve_triangular doesn't support broadcasting.
-    # But it seems like an inevitable extension so we support it.
-    ans = jsp.linalg.solve_triangular(
-        l if lower else T(l), b, trans=1 if transpose_a else 0, lower=lower,
-        unit_diagonal=unit_diagonal)
-
-    self.assertAllClose(np_ans, ans,
-                        rtol={np.float32: 1e-4, np.float64: 1e-11})
+  @jtu.sample_product(
+    [dict(lhs_shape=lhs_shape, rhs_shape=rhs_shape)
+      for lhs_shape, rhs_shape in [
+        # matching batch dims
+        ((2, 8, 8), (2, 8, 10)),
+        # batched a, unbatched b (vector) — broadcast b
+        ((3, 4, 4), (4,)),
+        # batched a, unbatched b (matrix)
+        ((3, 4, 4), (4, 2)),
+        # unbatched a, batched b (matrix) — broadcast a
+        ((4, 4), (3, 4, 2)),
+      ]
+    ],
+    lower=[False, True],
+    dtype=float_types,
+  )
+  @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
+  def testSolveTriangularBroadcast(self, lower, lhs_shape, rhs_shape, dtype):
+    if scipy_version < (1, 16, 0):
+      self.skipTest("scipy.linalg.solve_triangular batch broadcasting requires scipy >= 1.16")
+    rng = jtu.rand_default(self.rng())
+    k = rng(lhs_shape, dtype)
+    l = np.linalg.cholesky(
+        np.matmul(k, T(k)) + lhs_shape[-1] * np.eye(lhs_shape[-1]))
+    l = l.astype(k.dtype)
+    a = l if lower else T(l)
+    b = rng(rhs_shape, dtype)
+    osp_fun = partial(osp.linalg.solve_triangular, lower=lower)
+    jsp_fun = partial(jsp.linalg.solve_triangular, lower=lower)
+    args_maker = lambda: [a, b]
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker,
+                            rtol={np.float32: 1e-4, np.float64: 1e-11})
+    self._CompileAndCheck(jsp_fun, args_maker)
 
   @jtu.sample_product(
     [dict(left_side=left_side, a_shape=a_shape, b_shape=b_shape)
@@ -2094,6 +2154,38 @@ class ScipyLinalgTest(jtu.JaxTestCase):
                             args_maker, tol=1e-3)
 
   @jtu.sample_product(
+    [dict(lhs_shape=lhs_shape, rhs_shape=rhs_shape)
+      for lhs_shape, rhs_shape in [
+          # batched c, unbatched b (vector)
+          [(3, 4, 4), (4,)],
+          # batched c, unbatched b (matrix)
+          [(3, 4, 4), (4, 2)],
+          # batched c, batched b
+          [(3, 4, 4), (3, 4, 2)],
+          # unbatched c, batched b (broadcast c -> batch)
+          [(4, 4), (3, 4, 2)],
+      ]
+    ],
+    dtype=float_types,
+    lower=[True, False],
+  )
+  @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
+  def testChoSolveBroadcast(self, lhs_shape, rhs_shape, dtype, lower):
+    if scipy_version < (1, 16, 0):
+      self.skipTest("scipy.linalg.cho_solve batch broadcasting requires scipy >= 1.16")
+    rng = jtu.rand_default(self.rng())
+    def args_maker():
+      b = rng(rhs_shape, dtype)
+      if lower:
+        L = np.tril(rng(lhs_shape, dtype))
+        return [(L, lower), b]
+      else:
+        U = np.triu(rng(lhs_shape, dtype))
+        return [(U, lower), b]
+    self._CheckAgainstNumpy(osp.linalg.cho_solve, jsp.linalg.cho_solve,
+                            args_maker, tol=1e-3)
+
+  @jtu.sample_product(
     n=[1, 4, 5, 20, 50, 100],
     dtype=float_types + complex_types,
   )
@@ -2185,6 +2277,53 @@ class ScipyLinalgTest(jtu.JaxTestCase):
         osp.linalg.rsf2csf, jsp.linalg.rsf2csf, args_maker, tol=tol
     )
     self._CompileAndCheck(jsp.linalg.rsf2csf, args_maker)
+
+  @jtu.sample_product(
+    [dict(t_shape=t_shape, z_shape=z_shape)
+     for t_shape, z_shape in [
+       # batched T and Z
+       ((3, 4, 4), (3, 4, 4)),
+       # batched T, unbatched Z — broadcast Z
+       ((3, 4, 4), (4, 4)),
+       # unbatched T, batched Z — broadcast T
+       ((4, 4), (3, 4, 4)),
+     ]
+    ],
+    dtype=float_types + complex_types,
+  )
+  @jtu.run_on_devices("cpu")
+  @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
+  def testRsf2csfBroadcast(self, t_shape, z_shape, dtype):
+    if scipy_version < (1, 16, 0):
+      self.skipTest("scipy.linalg.rsf2csf batch broadcasting requires scipy >= 1.16")
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(t_shape, dtype), rng(z_shape, dtype)]
+    self._CheckAgainstNumpy(osp.linalg.rsf2csf, jsp.linalg.rsf2csf,
+                            args_maker, tol=3e-5)
+    self._CompileAndCheck(jsp.linalg.rsf2csf, args_maker)
+
+  @jtu.sample_product(
+    [dict(shape=shape, side=side)
+     for shape, side in [
+       ((4, 4), 'right'),  # square, side='right' (m >= n)
+       ((5, 3), 'right'),  # tall, side='right' (m > n)
+       ((3, 5), 'left'),   # wide, side='left' (m < n, qdwh constraint)
+     ]
+    ],
+    batch=[3],
+    dtype=float_types,
+  )
+  @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
+  def testPolarBatch(self, batch, shape, side, dtype):
+    if scipy_version < (1, 16, 0):
+      self.skipTest("scipy.linalg.polar batch support requires scipy >= 1.16")
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng((batch,) + shape, dtype)]
+    self._CheckAgainstNumpy(
+        partial(osp.linalg.polar, side=side),
+        partial(jsp.linalg.polar, side=side),
+        args_maker, tol=1e-4)
+    self._CompileAndCheck(partial(jsp.linalg.polar, side=side), args_maker)
 
   @jtu.sample_product(
     shape=[(1, 1), (5, 5), (20, 20), (50, 50)],
@@ -2425,6 +2564,48 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     C = rng(shape=(n, n), dtype=dtype)
     sylv_solution = jsp.linalg.solve_sylvester(A, B, C, method=method, tol=1e-5)
     self.assertArraysEqual(sylv_solution, np.full((n, n), np.nan, dtype))
+
+  @jtu.sample_product(
+    [dict(a_shape=a_shape, b_shape=b_shape, c_shape=c_shape)
+     for a_shape, b_shape, c_shape in [
+       # unbatched A,B; batched C — broadcast A,B to batch
+       ((3, 3), (4, 4), (2, 3, 4)),
+       # batched A; unbatched B, C
+       ((2, 3, 3), (4, 4), (3, 4)),
+       # all batched
+       ((2, 3, 3), (2, 4, 4), (2, 3, 4)),
+     ]
+    ],
+    dtype=float_types,
+    method=["schur", "eigen"],
+  )
+  @jtu.run_on_devices("cpu", "gpu")
+  @jax.default_matmul_precision("float32")
+  @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
+  def test_solve_sylvester_broadcast(self, a_shape, b_shape, c_shape, dtype, method):
+    if scipy_version < (1, 16, 0):
+      self.skipTest("scipy.linalg.solve_sylvester batch broadcasting requires scipy >= 1.16")
+    if jtu.test_device_matches(["gpu"]) and method == "schur":
+      self.skipTest("Schur not supported on GPU.")
+    tol = {np.float32: 5e-2, np.float64: 1e-9}
+    rng = jtu.rand_default(self.rng())
+
+    def args_maker():
+      A = rng(a_shape, dtype)
+      B = rng(b_shape, dtype)
+      # Compute the broadcast batch shape to construct a valid C
+      batch = np.broadcast_shapes(a_shape[:-2], b_shape[:-2], c_shape[:-2])
+      A_bc = np.broadcast_to(A, batch + a_shape[-2:])
+      B_bc = np.broadcast_to(B, batch + b_shape[-2:])
+      X_true = rng(batch + c_shape[-2:], dtype)
+      C = np.einsum("...ij,...jk->...ik", A_bc, X_true) + \
+          np.einsum("...ij,...jk->...ik", X_true, B_bc)
+      # Return un-broadcast A, B so JAX must do the broadcasting itself
+      return [A, B, C]
+
+    jnp_fun = partial(jsp.linalg.solve_sylvester, method=method)
+    self._CheckAgainstNumpy(osp.linalg.solve_sylvester, jnp_fun, args_maker, tol=tol)
+    self._CompileAndCheck(jnp_fun, args_maker)
 
 
 class LaxLinalgTest(jtu.JaxTestCase):


### PR DESCRIPTION
Fixes #36083.

Scipy 1.16 came with auto-batching support through the `_apply_over_batch`, however not all `jax.scipy` functions fully support this behaviour (although users could already use `vmap` as a fallback). This PR provides a very simple approach, consistent with scipy, of broadcasting to the maximal batched dimensions. I have limited its scope just to `linalg` functions to avoid cognitive overload and because that is the part of the codebase I'm more comfortable with.

The diff is a bit larger than one would expect as I had to use a similar pattern to `_lu_python` (iteratively applying `vmap` for each batch dimension) when the underlying `lax` function/primitive did not already support batch dims out the box. As such I needed to create helper function `_*_2d`.

Tests are potentially overkill so happy to rollback/simplify. Two things to highlight.

1. Batched tests are skipped for scipy < 1.16 as auto-batching was not supported then, these will lead to skips in the "Oldest supported numpy" workflow (which I think uses scipy 1.13.1)
2. I moved one existing batched triangular solve test to the new batching tests and use scipy fully now instead of the old numpy version. One could consider this a reversion, but afaiu those tests were pre-emptive of a future scipy supporting this, now it does and we test it so I felt safe to remove the duplication.

Lmk what you think.