### PR TITLE
Add test skip for tcgen05+int8

### DIFF
--- a/tests/pallas/mosaic_gpu_test.py
+++ b/tests/pallas/mosaic_gpu_test.py
@@ -4811,6 +4811,8 @@ class PallasCallTCGen05Test(PallasTCGen05Test):
       ab_type=(jnp.float16, jnp.bfloat16, jnp.int8, jnp.float8_e4m3fn)
   )
   def test_sparse_matmul_collective(self, m, n, ab_type):
+    if ab_type == jnp.int8:
+      self.skip_unless_tcgen05_int8()
     acc_type = jnp.float32 if jnp.issubdtype(ab_type, jnp.floating) else jnp.int32
     k = 128
     transforms = self.default_transforms(swizzle=64, dtype=ab_type)


### PR DESCRIPTION
This was added in https://github.com/jax-ml/jax/pull/35997.