### PR TITLE
[consts] Fix AOT in presence of simplified handling of closed over consts

### DIFF
--- a/jax/_src/stages.py
+++ b/jax/_src/stages.py
@@ -735,7 +735,7 @@ class Compiled(Stage):
       in_avals_ = [
           next(iter_in_avals) if i in self._executable._kept_var_idx  # pyrefly: ignore[missing-attribute]
           else a for i, a in zip(range(self.in_tree.num_leaves), non_dce_avals)]
-    return self.in_tree.unflatten(in_avals_)
+    return self.in_tree.unflatten(in_avals_[len(self._params.const_args):])
 
   @property
   def out_info(self):  # PyTree of jax.ShapeDtypeStruct
@@ -764,7 +764,7 @@ class Compiled(Stage):
       iter_shardings_flat = iter(shardings_flat)
       shardings_flat = [next(iter_shardings_flat) if i in self._executable._kept_var_idx  # pyrefly: ignore[missing-attribute]
                         else None for i in range(self.in_tree.num_leaves)]
-    return shardings_flat
+    return shardings_flat[len(self._params.const_args):]
 
   @property
   def input_shardings(self):  # -> PyTree[sharding.Sharding]
@@ -783,7 +783,7 @@ class Compiled(Stage):
       iter_layouts_flat = iter(layouts_flat)
       layouts_flat = [next(iter_layouts_flat) if i in self._executable._kept_var_idx  # pyrefly: ignore[missing-attribute]
                       else None for i in range(self.in_tree.num_leaves)]
-    return layouts_flat
+    return layouts_flat[len(self._params.const_args):]
 
   @property
   def input_formats(self):

--- a/tests/aot_test.py
+++ b/tests/aot_test.py
@@ -164,6 +164,8 @@ class JaxAotTest(jtu.JaxTestCase):
     compiled = f.lower(inp).compile()
     self.assertLen(compiled.args_info[0], 1)  # Not including const_args
     self.assertLen(compiled.in_avals[0], 1)
+    self.assertLen(compiled.input_shardings[0], 1)
+    self.assertLen(compiled.input_formats[0], 1)
     if config.use_simplified_jaxpr_constants.value:
       self.assertLen(compiled._params.const_args, 1)
       self.assertIs(compiled._params.const_args[0], const)
@@ -203,6 +205,8 @@ class JaxAotTest(jtu.JaxTestCase):
 
     self.assertLen(compiled.args_info[0], 1)  # Not including const_args
     self.assertLen(compiled.in_avals[0], 1)
+    self.assertLen(compiled.input_shardings[0], 1)
+    self.assertLen(compiled.input_formats[0], 1)
     if config.use_simplified_jaxpr_constants.value:
       self.assertLen(compiled._params.const_args, 1)
       self.assertLen(compiled._executable.in_avals, 2)
@@ -212,24 +216,11 @@ class JaxAotTest(jtu.JaxTestCase):
       self.assertEqual(compiled._executable.in_avals[0].dtype, expected_dtype)
 
       if expected_dtype is np.int64:  # Otherwise, we made a copy of the const
-        if use_np:
-          self.assertIs(np.asarray(compiled._params.const_args[0]), const)
-        else:
+        if not use_np:
           self.assertIs(compiled._params.const_args[0], const)
     else:
       self.assertLen(compiled._params.const_args, 0)
       self.assertLen(compiled._executable.in_avals, 1)
-
-    # In some cases we expect errors: in 32-bit mode, lowered with 64-bit mode
-    # and execute in 32-bit mode.
-    if (config.use_simplified_jaxpr_constants.value and
-        not config.enable_x64.value and
-        use_np and lower and not exec):
-      with self.assertRaisesRegex(
-          xc.XlaRuntimeError,
-          "got buffer with incompatible size"):
-        run()
-      return
 
     self.assertArraysEqual(run(),
                            lax.convert_element_type(const, inp.dtype) + inp)


### PR DESCRIPTION
When we turn on JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS the executables carry in `_params.const_args` the closed over constants (which otherwise are blasted as StableHLO constants and part of the compiled code). The `in_avals`, `in_shardings`, `in_layouts` fields of the executable include the corresponding values for the `const_args`. This change ensures that we account properly for the const args when we read the avals, shardings and layouts.

This change has no effect in absence of JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS because in that case `_params.const_args` is empty.

#jax-fixit