### PR TITLE
Removed leftover references to mypy

### DIFF
--- a/jax/_src/errors.py
+++ b/jax/_src/errors.py
@@ -29,7 +29,6 @@ class _JAXErrorMixin:
     module_name = self._module_name
     class_name = self.__class__.__name__
     error_msg = f'{message}\nSee {error_page}#{module_name}.{class_name}'
-    # https://github.com/python/mypy/issues/5887
     super().__init__(error_msg)  # type: ignore
 
 

--- a/jax/_src/export/shape_poly.py
+++ b/jax/_src/export/shape_poly.py
@@ -74,7 +74,6 @@ for more details.
 
   def __init__(self, message: str):
     error_msg = f"{message}{InconclusiveDimensionOperation._help_msg}"
-    # https://github.com/python/mypy/issues/5887
     super().__init__(error_msg)
 
 class UnexpectedDimVar(Exception):

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -71,10 +71,7 @@ zip, unsafe_zip = util.safe_zip, zip
 
 T = typing.TypeVar("T")
 
-Value = Any  # = ir.Value
-
-# mypy implicitly sets this variable to true when type checking.
-MYPY = False
+Value = ir.Value
 
 # IR Helpers
 
@@ -89,7 +86,7 @@ dense_int_array = ir.DenseI64ArrayAttr.get
 def i32_attr(i): return ir.IntegerAttr.get(ir.IntegerType.get_signless(32), i)
 def i64_attr(i): return ir.IntegerAttr.get(ir.IntegerType.get_signless(64), i)
 
-def shape_tensor(sizes: Sequence[int | ir.RankedTensorType]) -> IrValues:
+def shape_tensor(sizes: Sequence[int | ir.Value]) -> IrValues:
   int1d = aval_to_ir_type(core.ShapedArray((1,), np.int32))
   i32_type = aval_to_ir_type(core.ShapedArray((), np.int32))
   def lower_dim(d):
@@ -861,14 +858,8 @@ class LoweringRuleContext:
     ) and not lowering_parameters.export_ignore_forward_compatibility
 
 
-if not MYPY:
-  class LoweringRule(Protocol):
-    def __call__(self, ctx: LoweringRuleContext,
-                 *args: ir.Value | Sequence[ir.Value],
-                 **kw) -> Sequence[ir.Value | Sequence[ir.Value]]:
-      """Converts a JAX primitive invocation into MLIR."""
-else:
-  LoweringRule = Any
+LoweringRule = Callable[..., Sequence[ir.Value | Sequence[ir.Value]]]
+
 
 @dataclasses.dataclass(frozen=True)
 class LoweringRuleEntry:
@@ -979,7 +970,7 @@ def sharded_aval(aval: core.AbstractValue,
 
 
 def eval_dynamic_shape(ctx: LoweringRuleContext,
-                       shape: core.Shape) -> tuple[int | Value, ...]:
+                       shape: core.Shape) -> tuple[int | ir.Value, ...]:
   ctx = ctx.replace(
       primitive="eval_dynamic_shape",
       avals_in=[core.dim_value_aval()] * len(ctx.module_context.shape_poly_state.dim_vars),
@@ -993,9 +984,9 @@ def eval_dynamic_shape(ctx: LoweringRuleContext,
 
 # TODO: replace usage of eval_dynamic_shape_as_vals with eval_dynamic_shape_as_ivals
 def eval_dynamic_shape_as_vals(ctx: LoweringRuleContext,
-                               shape: core.Shape) -> tuple[Value, ...]:
+                               shape: core.Shape) -> tuple[ir.Value, ...]:
   """Evaluates the dynamic shapes as int32 values."""
-  def convert_dim(d: int | Value):
+  def convert_dim(d: int | ir.Value):
     if type(d) is int:
       return ir_constant(np.array(d, dtype=np.int32))
     else:
@@ -1009,9 +1000,9 @@ def eval_dynamic_shape_as_vals(ctx: LoweringRuleContext,
 
 def eval_dynamic_shape_as_ivals(
     ctx: LoweringRuleContext, shape: core.Shape
-    ) -> tuple[int | Value, ...]:
+    ) -> tuple[int | ir.Value, ...]:
   """Evaluates the dynamic shapes as int or ir.int32 values."""
-  def convert_dim(d: int | Value) -> int | ir.Value:
+  def convert_dim(d: int | ir.Value) -> int | ir.Value:
     if type(d) is int:
       return d
     else:
@@ -1023,9 +1014,9 @@ def eval_dynamic_shape_as_ivals(
   return tuple(convert_dim(v) for v in eval_dynamic_shape(ctx, shape))
 
 def eval_dynamic_shape_as_tensor(ctx: LoweringRuleContext,
-                                 shape: core.Shape) -> Value:
+                                 shape: core.Shape) -> ir.Value:
   """Evaluates the dynamic shapes as one 1d int32 tensor."""
-  return shape_tensor(eval_dynamic_shape(ctx, shape))
+  return shape_tensor(eval_dynamic_shape(ctx, shape))  # pyrefly: ignore[bad-return]
 
 class LoweringResult(NamedTuple):
   module: ir.Module

--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -606,9 +606,6 @@ def softmax(x: ArrayLike,
     :func:`log_softmax`
   """
   if config.softmax_custom_jvp.value:
-    # mypy is confused by the `functools.partial` application in the definition
-    # of `_softmax` and incorrectly concludes that `_softmax` returns
-    # `ReturnValue` -- the unsubstituted type parameter of `custom_jvp`.
     return _softmax(x, axis, where)
   else:
     return _softmax_deprecated(x, axis, where)

--- a/jax/_src/numpy/indexing.py
+++ b/jax/_src/numpy/indexing.py
@@ -112,7 +112,7 @@ class IndexType(enum.Enum):
 
 class ParsedIndex(NamedTuple):
   """Structure for tracking an indexer parsed within the context of an array shape."""
-  index: Index  # type: ignore[assignment]  # seems to be a strange misfire by mypy.
+  index: Index  # pyrefly: ignore[bad-override]
   typ: IndexType
   consumed_axes: tuple[int, ...]
 

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -6444,7 +6444,6 @@ def _auto_repeat(fun, a, repeats, axis, total_repeat_length, out_sharding):
 def _repeat(repeats, arr, *, axis: int,
             total_repeat_length: int | None = None) -> Array:
   axis = core.concrete_or_error(operator.index, axis, "'axis' argument of jnp.repeat()")
-  assert isinstance(axis, int)  # to appease mypy
 
   if core.is_symbolic_dim(repeats):
     if total_repeat_length is not None:

--- a/jax/_src/pallas/mosaic/sc_lowering.py
+++ b/jax/_src/pallas/mosaic/sc_lowering.py
@@ -991,7 +991,6 @@ def _dma_wait_lowering_rule(
 def _extract_indirect_offsets_from_indexer(
     indexer: indexing.NDIndexer, expected_shape: tuple[int, ...] | None = None
 ) -> ir.Value | None:
-  offsets_ref: Any  # Make mypy happy.
   match indexer.indices:
     case [ir.Value() as offsets, *_] if (
         # fmt: off

--- a/jax/_src/pallas/mosaic_gpu/pipeline.py
+++ b/jax/_src/pallas/mosaic_gpu/pipeline.py
@@ -1047,7 +1047,7 @@ def emit_pipeline_warp_specialized(
         compute_block,
         memory_block
     )
-  # Mypy doesn't notice the .get_allocations assignment above.
+  # Type checkers do not understand the get_allocations assignment above.
   return pipeline  # type: ignore
 
 def _compute_registers(memory_registers: int, num_compute_wgs: int) -> int:

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from functools import partial
 import operator
-from typing import cast, Any
+from typing import Any
 
 import numpy as np
 
@@ -2538,8 +2538,7 @@ def exp1(x: ArrayLike) -> Array:
   x, = promote_args_inexact("exp1", x)
   if dtypes.issubdtype(x.dtype, np.complexfloating):
     raise ValueError("exp1 does not support complex-valued inputs.")
-  # Casting because custom_jvp generic does not work correctly with mypy.
-  return cast(Array, expn(1, x))
+  return expn(1, x)
 
 
 def _spence_poly(w: Array) -> Array:

--- a/jax/_src/third_party/scipy/betaln.py
+++ b/jax/_src/third_party/scipy/betaln.py
@@ -3,10 +3,8 @@ from jax._src import numpy as jnp
 from jax._src.typing import Array, ArrayLike
 from jax._src.numpy.util import promote_args_inexact
 
-# Note: for mysterious reasons, annotating this leads to very slow mypy runs.
-# def algdiv(a: ArrayLike, b: ArrayLike) -> Array:
 
-def algdiv(a, b):
+def algdiv(a: ArrayLike, b: ArrayLike) -> Array:
     """
     Compute ``log(gamma(a))/log(gamma(a + b))`` when ``b >= 8``.
 

--- a/jax/experimental/colocated_python/func.py
+++ b/jax/experimental/colocated_python/func.py
@@ -348,9 +348,6 @@ def _uncached_get_specialized_func(
                 _get_spec, (args, kwargs)
             )
             out_specs = specialization.out_specs_fn(*args_specs, **kwargs_specs)
-            # Type checking is ignored to silence mypy error: Incompatible types
-            # in assignment (expression has type "list[Any]", variable has type
-            # "tuple[ShapeDtypeStruct, ...]")  [assignment]
             out_specs_leaves, out_specs_treedef = tree_util.tree_flatten(  # type: ignore[assignment]
                 out_specs
             )

--- a/jax/experimental/mosaic/gpu/constraints.py
+++ b/jax/experimental/mosaic/gpu/constraints.py
@@ -14,10 +14,6 @@
 
 """Defines expressions and constraints over layouts."""
 
-# mypy has been causing more problems than it solves here. Disable it for these
-# files. We have pytype checks anyway.
-# mypy: ignore-errors
-
 from __future__ import annotations
 
 import abc

--- a/jax/experimental/mosaic/gpu/dialect_lowering.py
+++ b/jax/experimental/mosaic/gpu/dialect_lowering.py
@@ -14,10 +14,6 @@
 
 """Lowering rules and pass for the MLIR Mosaic GPU dialect."""
 
-# mypy has been causing more problems than it solves here. Disable it for these
-# files. We have pytype checks anyway.
-# mypy: ignore-errors
-
 from collections.abc import Callable, Iterable, Sequence
 import dataclasses
 import functools

--- a/jax/experimental/mosaic/gpu/examples/flash_attention.py
+++ b/jax/experimental/mosaic/gpu/examples/flash_attention.py
@@ -33,7 +33,6 @@ from jaxlib.mlir.dialects import nvvm
 from jaxlib.mlir.dialects import scf
 import numpy as np
 
-# mypy: ignore-errors
 # ruff: noqa: F405
 
 @dataclasses.dataclass(frozen=True)

--- a/jax/experimental/mosaic/gpu/examples/matmul.py
+++ b/jax/experimental/mosaic/gpu/examples/matmul.py
@@ -32,7 +32,6 @@ from jaxlib.mlir.dialects import nvvm
 from jaxlib.mlir.dialects import scf
 import numpy as np
 
-# mypy: ignore-errors
 # ruff: noqa: F405
 # pylint: disable=line-too-long, wildcard-import, missing-function-docstring, bad-continuation, g-bad-todo, protected-access
 

--- a/jax/experimental/mosaic/gpu/fragmented_array.py
+++ b/jax/experimental/mosaic/gpu/fragmented_array.py
@@ -1842,9 +1842,6 @@ class FragmentedArray:
       return FragmentedArray(
           _registers=self.registers, _layout=self.layout, _is_signed=is_signed
       )
-    # Otherwise, mypy is unhappy with using ``idx`` for both range and
-    # np.ndenumerate.
-    idx: Any
     any_reg = self.registers.flat[0]
     reg_type = any_reg.type
     is_vector_reg = isinstance(reg_type, ir.VectorType)

--- a/jax/experimental/mosaic/gpu/layout_inference.py
+++ b/jax/experimental/mosaic/gpu/layout_inference.py
@@ -14,10 +14,6 @@
 
 """Layout and transform inference pass for the MLIR Mosaic GPU dialect."""
 
-# mypy has been causing more problems than it solves here. Disable it for these
-# files. We have pytype checks anyway.
-# mypy: ignore-errors
-
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Sequence

--- a/jax/experimental/pallas/ops/gpu/hopper_matmul_mgpu.py
+++ b/jax/experimental/pallas/ops/gpu/hopper_matmul_mgpu.py
@@ -27,7 +27,6 @@ from jax.extend import backend
 import jax.numpy as jnp
 import numpy as np
 
-# mypy: ignore-errors
 
 class MatmulDimension(enum.IntEnum):
   M = 0

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py
@@ -42,7 +42,6 @@ NUM_SUBLANES = 8
 NN_DIM_NUMBERS = (((1,), (0,)), ((), ()))  # standard matmul
 NT_DIM_NUMBERS = (((1,), (1,)), ((), ()))  # RHS transposed
 
-# mypy: ignore-errors
 
 class SegmentIds(NamedTuple):
   """SegmentIds for Q and KV sequences.

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask.py
@@ -21,7 +21,6 @@ import dataclasses
 from typing import Any
 import numpy as np
 
-# mypy: ignore-errors
 
 class Mask:
   """A base class for splash attention masks."""

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
@@ -27,7 +27,6 @@ from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_ma
 import jax.numpy as jnp
 import numpy as np
 
-# mypy: ignore-errors
 
 # Logic for processing NumPy masks for kernels
 class MaskInfo(NamedTuple):

--- a/jax/experimental/sparse/_base.py
+++ b/jax/experimental/sparse/_base.py
@@ -30,8 +30,7 @@ class JAXSparse(util.StrictABC):
   data: jax.Array
   shape: tuple[int, ...]
 
-  # Ignore type because of https://github.com/python/mypy/issues/4266.
-  __hash__ = None  # type: ignore
+  __hash__ = None
 
   @property
   @abc.abstractmethod

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -15,7 +15,7 @@
 Typing tests
 ------------
 This test is meant to be both a runtime test and a static type annotation test,
-so it should be checked with pytype/mypy as well as being run with pytest.
+so it should be checked with pytype/Pyrefly as well as being run with pytest.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Note that I also change `Value` in `jax.interpreter.mlir` to point to `ir.Value` instead of `Any`, since there is no reason to keep it dynamic.