### PR TITLE
[test] update x64_context_test for v0.10.0

### DIFF
--- a/tests/x64_context_test.py
+++ b/tests/x64_context_test.py
@@ -31,43 +31,35 @@ import jax._src.test_util as jtu
 
 jax.config.parse_flags_with_absl()
 
-# TODO(jakevdp): remove this check for JAX v0.9.0 and test jax.enable_x64 directly.
-with jtu.ignore_warning(message=".* is deprecated", category=DeprecationWarning):
-  if hasattr(jax.experimental, "enable_x64"):
-    from jax.experimental import enable_x64, disable_x64
-  else:
-    enable_x64 = jax.enable_x64
-    disable_x64 = lambda: jax.enable_x64(False)
-
 
 class X64ContextTests(jtu.JaxTestCase):
   @jtu.sample_product(jit=jtu.JIT_IMPLEMENTATION)
   def test_make_array(self, jit):
     func = jit(lambda: jnp.array(np.float64(0)))
     dtype_start = func().dtype
-    with enable_x64():
+    with jax.enable_x64():
       self.assertEqual(func().dtype, "float64")
-    with disable_x64():
+    with jax.enable_x64(False):
       self.assertEqual(func().dtype, "float32")
     self.assertEqual(func().dtype, dtype_start)
 
   @jtu.sample_product(
     jit=jtu.JIT_IMPLEMENTATION,
-    enable_or_disable=[enable_x64, disable_x64],
+    enable_or_disable=[True, False],
   )
   def test_correctly_capture_default(self, jit, enable_or_disable):
     # The fact we defined a jitted function with a block with a different value
     # of `jax.config.enable_x64` has no impact on the output.
-    with enable_or_disable():
+    with jax.enable_x64(enable_or_disable):
       func = jit(lambda: jnp.array(np.float64(0)))
       func()
 
     expected_dtype = "float64" if jax.config._read("jax_enable_x64") else "float32"
     self.assertEqual(func().dtype, expected_dtype)
 
-    with enable_x64():
+    with jax.enable_x64(True):
       self.assertEqual(func().dtype, "float64")
-    with disable_x64():
+    with jax.enable_x64(False):
       self.assertEqual(func().dtype, "float32")
 
   @jtu.sample_product(jit=jtu.JIT_IMPLEMENTATION)
@@ -82,11 +74,11 @@ class X64ContextTests(jtu.JaxTestCase):
       X = X.at[-1].mul(eps)
       return jnp.linalg.inv(X)
 
-    with enable_x64():
+    with jax.enable_x64():
       result_64 = near_singular_inverse()
       self.assertTrue(jnp.all(jnp.isfinite(result_64)))
 
-    with disable_x64():
+    with jax.enable_x64(False):
       result_32 = near_singular_inverse()
       self.assertTrue(jnp.all(~jnp.isfinite(result_32)))
 
@@ -96,20 +88,20 @@ class X64ContextTests(jtu.JaxTestCase):
     def count_to(N):
       return lax.while_loop(lambda x: x < N, lambda x: x + 1.0, 0.0)
 
-    with enable_x64():
+    with jax.enable_x64():
       self.assertArraysEqual(count_to(10), jnp.float64(10), check_dtypes=True)
 
-    with disable_x64():
+    with jax.enable_x64(False):
       self.assertArraysEqual(count_to(10), jnp.float32(10), check_dtypes=True)
 
   def test_thread_safety(self):
     def func_x32():
-      with disable_x64():
+      with jax.enable_x64(False):
         time.sleep(0.1)
         return jnp.array(np.int64(0)).dtype
 
     def func_x64():
-      with enable_x64():
+      with jax.enable_x64():
         time.sleep(0.1)
         return jnp.array(np.int64(0)).dtype
 
@@ -131,16 +123,16 @@ class X64ContextTests(jtu.JaxTestCase):
       self.skipTest("Test uses float64 which is not available")
 
     f = partial(random.uniform, random.PRNGKey(0), (1,), 'float64', -1, 1)
-    with disable_x64():
+    with jax.enable_x64(False):
       for _ in range(2):
         f()
-    with enable_x64():
+    with jax.enable_x64():
       for _ in range(2):
         f()
 
   def test_convert_element_type(self):
     # Regression test for part of https://github.com/jax-ml/jax/issues/5982
-    with enable_x64():
+    with jax.enable_x64():
       x = jnp.int64(1)
     self.assertEqual(x.dtype, jnp.int64)
 
@@ -153,13 +145,13 @@ class X64ContextTests(jtu.JaxTestCase):
   def test_python_scalar(self):
     @jax.jit
     def f(a):
-      with enable_x64():
+      with jax.enable_x64():
         return 2 + a
     self.assertEqual(f(1).dtype, jnp.int64)
 
   def test_grad(self):
     def fun(x):
-      with enable_x64(True):
+      with jax.enable_x64(True):
         return jnp.sin(x)
     self.assertEqual(
         jax.grad(fun)(0.5).dtype,
@@ -168,7 +160,7 @@ class X64ContextTests(jtu.JaxTestCase):
 
   def test_sin(self):
     def fun(x):
-      with enable_x64(True):
+      with jax.enable_x64(True):
         x = jnp.asarray(x, dtype=jnp.float64)
       return lax.sin(x)
 
@@ -176,7 +168,7 @@ class X64ContextTests(jtu.JaxTestCase):
 
   def test_mul(self):
     def fun(x, y):
-      with enable_x64(True):
+      with jax.enable_x64(True):
         x = jnp.asarray(x, dtype=jnp.float64)
         y = jnp.asarray(y, dtype=jnp.float64)
       return lax.mul(x, y)
@@ -188,7 +180,7 @@ class X64ContextTests(jtu.JaxTestCase):
     with jax.disable_jit(disable_jit):
       def f(a):
         def body(carry, _):
-          with enable_x64():
+          with jax.enable_x64():
             y = (carry + a).astype(jnp.int64)
             assert y.dtype == jnp.int64
             z = y.astype(jnp.int32)
@@ -213,7 +205,7 @@ class X64ContextTests(jtu.JaxTestCase):
       return f(x), t * jnp.sin(x)
 
     def g(x):
-      with enable_x64():
+      with jax.enable_x64():
         x = jnp.array(x, jnp.float64)
         return f(x)
 
@@ -222,13 +214,13 @@ class X64ContextTests(jtu.JaxTestCase):
     self.assertEqual(out_primal.dtype, jnp.float64)
     self.assertEqual(out_tangent.dtype, jnp.float64)
 
-    with enable_x64(False):
+    with jax.enable_x64(False):
       self.assertEqual(g(5.).dtype, jnp.float64)
       self.assertEqual(grad(g)(5.).dtype, jnp.float32)
       self.assertEqual(grad(grad(g))(5.).dtype, jnp.float32)
       self.assertEqual(grad(grad(grad(g)))(5.).dtype, jnp.float32)
 
-    with enable_x64(True):
+    with jax.enable_x64(True):
       self.assertEqual(g(5.).dtype, jnp.float64)
       self.assertEqual(grad(g)(5.).dtype, jnp.float64)
       self.assertEqual(grad(grad(g))(5.).dtype, jnp.float64)
@@ -248,17 +240,17 @@ class X64ContextTests(jtu.JaxTestCase):
     f.defvjp(f_fwd, f_bwd)
 
     def g(x):
-      with enable_x64():
+      with jax.enable_x64():
         x = jnp.array(x, jnp.float64)
         return f(x)
 
-    with enable_x64(False):
+    with jax.enable_x64(False):
       self.assertEqual(g(5.).dtype, jnp.float64)
       self.assertEqual(grad(g)(5.).dtype, jnp.float32)
       self.assertEqual(grad(grad(g))(5.).dtype, jnp.float32)
       self.assertEqual(grad(grad(grad(g)))(5.).dtype, jnp.float32)
 
-    with enable_x64(True):
+    with jax.enable_x64(True):
       self.assertEqual(g(5.).dtype, jnp.float64)
       self.assertEqual(grad(g)(5.).dtype, jnp.float64)
       self.assertEqual(grad(grad(g))(5.).dtype, jnp.float64)


### PR DESCRIPTION
`jax.experimental.enable_x64` and `jax.experimental.disable_x64` have now been removed and replaced by `jax.enable_x64`.