### PR TITLE
Fix cuDNN attention backward pass partitioning with sharded inputs

### DIFF
--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -1076,7 +1076,19 @@ def _dot_product_attention_bwd_partition(
     sliding_window_length, mesh, arg_shapes, result_shape):
   out_shardings = _infer_bwd_output_sharding(mesh, arg_shapes, layout, variadic_args)
   # args sharding
-  arg_shardings = tuple(arg_i.sharding for arg_i in arg_shapes)
+  arg_shardings = [arg_i.sharding for arg_i in arg_shapes]
+  # grad_output (index 12) may be inferred as replicated (e.g. when it
+  # originates from a broadcast in jnp.sum's backward pass). The cuDNN
+  # backward custom-call is lowered with batch size B taken from the
+  # partitioned query, so every operand that carries a batch dimension
+  # must be partitioned identically. Force fwd_output (11) and
+  # grad_output (12) to match query's sharding so the SPMD partitioner
+  # slices them to the correct per-shard shape.
+  # See https://github.com/jax-ml/jax/issues/25986
+  query_sharding = arg_shardings[0]
+  arg_shardings[11] = query_sharding # fwd_output
+  arg_shardings[12] = query_sharding # grad_output
+  arg_shardings = tuple(arg_shardings)
   def sharded_impl(*args):
     impl = functools.partial(
       _dot_product_attention_bwd_impl,

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -909,6 +909,58 @@ class DotProductAttentionTest(jtu.JaxTestCase):
       out_ref = jitted_sdpa_inference_ref(query, key, value)
       self.assertArraysAllClose(out_ref, out, rtol=2e-2, atol=2e-2)
 
+  @jtu.run_on_devices("cuda")
+  def test_sdpa_grad_sharded_regression_25986(self):
+    """Regression test for https://github.com/jax-ml/jax/issues/25986.
+
+    Taking the gradient of jnp.sum(dot_product_attention(...)) with
+    batch-sharded inputs causes grad_output to be inferred as replicated
+    (from the sum's backward broadcast), while the query is batch-sharded.
+    Without the fix in the bwd partition function, this triggers an SPMD
+    partitioning error because the cuDNN backward custom-call is lowered
+    with the batch dimension taken from the partitioned query.
+    """
+    if len(jax.local_devices()) < 2:
+      self.skipTest("Requires at least 2 devices.")
+
+    k1, k2, k3 = jax.random.split(jax.random.key(0), 3)
+    query = jax.random.normal(k1, (2, 128, 2, 64), dtype=jnp.bfloat16)
+    key = jax.random.normal(k2, (2, 128, 2, 64), dtype=jnp.bfloat16)
+    value = jax.random.normal(k3, (2, 128, 2, 64), dtype=jnp.bfloat16)
+
+    devices = np.array(jax.local_devices()[:2])
+    with Mesh(devices, ("dp",)) as mesh:
+      qkv_spec = PartitionSpec("dp", None, None, None)
+      qkv_sharding = NamedSharding(mesh, qkv_spec)
+      query = jax.device_put(query, qkv_sharding)
+      key = jax.device_put(key, qkv_sharding)
+      value = jax.device_put(value, qkv_sharding)
+
+      # This pattern -- jax.grad of jnp.sum(dot_product_attention(...)) --
+      # causes the SPMD partitioner to infer grad_output as replicated.
+      @jax.jit
+      def compute_grad(q, k, v):
+        def loss_fn(q, k, v):
+          out = dot_product_attention(
+              q, k, v, scale=0.5, mask_type=MaskType.NO_MASK, dropout_rate=0)
+          return jnp.sum(out)
+        return jax.grad(loss_fn, argnums=(0, 1, 2))(q, k, v)
+
+      # Should not raise an SPMD partitioning error.
+      dq, dk, dv = compute_grad(query, key, value)
+      # Sanity-check that the output is batch-sharded.
+      self.assertTrue(dq.sharding.is_equivalent_to(qkv_sharding, ndim=4))
+
+    # Compute reference gradients without sharding using the pure-JAX
+    # reference implementation.
+    grad = jnp.ones_like(query)
+    _, (dq_ref, dk_ref, dv_ref) = sdpa_train_ref(
+        query, key, value, grad, scale=0.5,
+        mask_type=MaskType.NO_MASK, dropout_rate=0)
+    self.assertArraysAllClose(dq_ref, dq, rtol=2e-1, atol=2e-1)
+    self.assertArraysAllClose(dk_ref, dk, rtol=2e-1, atol=2e-1)
+    self.assertArraysAllClose(dv_ref, dv, rtol=2e-1, atol=2e-1)
+
 
 @jtu.with_config(jax_numpy_dtype_promotion="standard")
 class DotProductAttentionF8Test(jtu.JaxTestCase):


### PR DESCRIPTION
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->

Closes #25986 and adds regression test.

Updates the `partition` function for `_dot_product_attention_bwd_lower` to force `grad_output` and `fwd_output` to match the sharding of the query. I am pretty new to jax so I am not 100% sure that I have understood all the nuances here but this seems like the right minimal fix.

Tested with `python tests/multiprocess/cudnn_attention_test.py --num_processes=2 --gpus_per_process=2`.

before:
```
Launching process 0:
  stdout: /tmp/jax_0_stdout.log
  stderr: /tmp/jax_0_stderr.log
Launching process 1:
  stdout: /tmp/jax_1_stdout.log
  stderr: /tmp/jax_1_stderr.log
============================ All launched, running =============================
Process 1 finished.
Process 0 finished.
================================= All finished =================================
=================================== Summary ====================================
Process 0, ret: 1, len(stdout): 0, len(stderr): 2436; Ran 1 test in 10.370s; FAILED (errors=1)
Process 1, ret: 1, len(stdout): 0, len(stderr): 2626; Ran 1 test in 10.375s; FAILED (errors=1)
================================ Detailed logs =================================
========================== Process 0: return code: 1 ===========================
------------------------------- Process 0 stderr -------------------------------
I0324 18:04:06.073130 139861826099008 distributed.py:126] JAX distributed initialized with visible devices: 0,1
I0324 18:04:06.073261 139861826099008 distributed.py:149] Starting JAX distributed service on [::]:42385
I0324 18:04:06.077453 139861826099008 distributed.py:172] Connecting to JAX distributed service on localhost:42385
Running tests under Python 3.14.2: /cv/home/kleinhej/jax/.venv/bin/python
[ RUN      ] CudnnAttentionMultiProcessTest.test_cudnn_attention_grad_sharded
W0324 18:04:06.731413 139861826099008 __init__.py:285] cuBLAS < 13.2 (120901 found) has a known issue where many kernels free TMEM buffers multiple times. Executing a cuBLAS kernel concurrently with another kernel (e.g. on another stream) can lead to silent data corruption.
I0324 18:04:06.792273 139861826099008 xla_bridge.py:822] Unable to initialize backend 'tpu': INTERNAL: Failed to open libtpu.so: libtpu.so: cannot open shared object file: No such file or directory
[  FAILED  ] CudnnAttentionMultiProcessTest.test_cudnn_attention_grad_sharded
======================================================================
ERROR: test_cudnn_attention_grad_sharded (__main__.CudnnAttentionMultiProcessTest)
CudnnAttentionMultiProcessTest.test_cudnn_attention_grad_sharded
Regression test for issue #25986.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/cv/home/kleinhej/jax/tests/multiprocess/cudnn_attention_test.py", line 116, in test_cudnn_attention_grad_sharded
    g_direct = direct_grad(q, k, v)
jax.errors.JaxRuntimeError: INTERNAL: The stride for the last dimension corresponding to the embedding size per head should be 1 for input_names::K
in external/xla/xla/stream_executor/cuda/cuda_dnn.cc(6843): 'graph_.build_operation_graph(cudnn_handle)' 
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.

----------------------------------------------------------------------
Ran 1 test in 10.370s

FAILED (errors=1)
W0324 18:04:21.496973 2752358 pjrt_client.cc:1604] WatchJobStateAsync failed for task 0: UNAVAILABLE: Cancelling all calls
Additional GRPC error information from remote target coordination_service while calling /tensorflow.CoordinationService/WatchJobState:
:UNKNOWN:Error received from peer  {grpc_message:"Cancelling all calls", grpc_status:14}

========================== Process 1: return code: 1 ===========================
------------------------------- Process 1 stderr -------------------------------
I0324 18:04:06.076224 139693765773120 distributed.py:126] JAX distributed initialized with visible devices: 2,3
I0324 18:04:06.077040 139693765773120 distributed.py:172] Connecting to JAX distributed service on localhost:42385
Running tests under Python 3.14.2: /cv/home/kleinhej/jax/.venv/bin/python
[ RUN      ] CudnnAttentionMultiProcessTest.test_cudnn_attention_grad_sharded
W0324 18:04:06.731064 139693765773120 __init__.py:285] cuBLAS < 13.2 (120901 found) has a known issue where many kernels free TMEM buffers multiple times. Executing a cuBLAS kernel concurrently with another kernel (e.g. on another stream) can lead to silent data corruption.
I0324 18:04:06.792757 139693765773120 xla_bridge.py:822] Unable to initialize backend 'tpu': INTERNAL: Failed to open libtpu.so: libtpu.so: cannot open shared object file: No such file or directory
E0324 18:04:08.541510 2752346 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]
E0324 18:04:08.541561 2752345 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]
E0324 18:04:08.541599 2752344 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]
E0324 18:04:08.554895 2752343 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]
E0324 18:04:08.555021 2752342 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]
E0324 18:04:08.557295 2752341 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]
[  FAILED  ] CudnnAttentionMultiProcessTest.test_cudnn_attention_grad_sharded
======================================================================
ERROR: test_cudnn_attention_grad_sharded (__main__.CudnnAttentionMultiProcessTest)
CudnnAttentionMultiProcessTest.test_cudnn_attention_grad_sharded
Regression test for issue #25986.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/cv/home/kleinhej/jax/tests/multiprocess/cudnn_attention_test.py", line 116, in test_cudnn_attention_grad_sharded
    g_direct = direct_grad(q, k, v)
jax.errors.JaxRuntimeError: INTERNAL: The stride for the last dimension corresponding to the embedding size per head should be 1 for input_names::K
in external/xla/xla/stream_executor/cuda/cuda_dnn.cc(6843): 'graph_.build_operation_graph(cudnn_handle)' 
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.

----------------------------------------------------------------------
Ran 1 test in 10.375s

FAILED (errors=1)

============================== Done detailed logs ==============================
Traceback (most recent call last):
  File "/cv/home/kleinhej/jax/tests/multiprocess/cudnn_attention_test.py", line 125, in <module>
    jt_multiprocess.main()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "/cv/home/kleinhej/jax/jax/_src/test_multiprocess.py", line 134, in main
    app.run(functools.partial(_main, shard_main=shard_main))
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cv/home/kleinhej/jax/.venv/lib/python3.14/site-packages/absl/app.py", line 367, in run
    _run_main(main, args)
    ~~~~~~~~~^^^^^^^^^^^^
  File "/cv/home/kleinhej/jax/.venv/lib/python3.14/site-packages/absl/app.py", line 312, in _run_main
    sys.exit(main(argv))
             ~~~~^^^^^^
  File "/cv/home/kleinhej/jax/jax/_src/test_multiprocess.py", line 418, in _main
    assert retval == 0, f"process {i} failed, return value: {retval}"
           ^^^^^^^^^^^
AssertionError: process 0 failed, return value: 1
```

after:
```
Launching process 0:
  stdout: /tmp/jax_0_stdout.log
  stderr: /tmp/jax_0_stderr.log
Launching process 1:
  stdout: /tmp/jax_1_stdout.log
  stderr: /tmp/jax_1_stderr.log
============================ All launched, running =============================
Process 1 finished.
Process 0 finished.
================================= All finished =================================
=================================== Summary ====================================
Process 0, ret: 0, len(stdout): 0, len(stderr): 1479; Ran 1 test in 10.602s; OK
Process 1, ret: 0, len(stdout): 0, len(stderr): 2238; Ran 1 test in 10.622s; OK
================================ Detailed logs =================================
========================== Process 0: return code: 0 ===========================
------------------------------- Process 0 stderr -------------------------------
I0324 18:05:32.896656 139765507921728 distributed.py:126] JAX distributed initialized with visible devices: 0,1
I0324 18:05:32.896792 139765507921728 distributed.py:149] Starting JAX distributed service on [::]:34447
I0324 18:05:32.898690 139765507921728 distributed.py:172] Connecting to JAX distributed service on localhost:34447
Running tests under Python 3.14.2: /cv/home/kleinhej/jax/.venv/bin/python
[ RUN      ] CudnnAttentionMultiProcessTest.test_cudnn_attention_grad_sharded
W0324 18:05:34.595775 139765507921728 __init__.py:285] cuBLAS < 13.2 (120901 found) has a known issue where many kernels free TMEM buffers multiple times. Executing a cuBLAS kernel concurrently with another kernel (e.g. on another stream) can lead to silent data corruption.
I0324 18:05:34.620502 139765507921728 xla_bridge.py:822] Unable to initialize backend 'tpu': INTERNAL: Failed to open libtpu.so: libtpu.so: cannot open shared object file: No such file or directory
[       OK ] CudnnAttentionMultiProcessTest.test_cudnn_attention_grad_sharded
----------------------------------------------------------------------
Ran 1 test in 10.602s

OK
W0324 18:05:49.578053 2753290 pjrt_client.cc:1604] WatchJobStateAsync failed for task 0: UNAVAILABLE: Cancelling all calls
Additional GRPC error information from remote target coordination_service while calling /tensorflow.CoordinationService/WatchJobState:
:UNKNOWN:Error received from peer  {grpc_message:"Cancelling all calls", grpc_status:14}

========================== Process 1: return code: 0 ===========================
------------------------------- Process 1 stderr -------------------------------
I0324 18:05:32.893125 140640888682304 distributed.py:126] JAX distributed initialized with visible devices: 2,3
I0324 18:05:32.894012 140640888682304 distributed.py:172] Connecting to JAX distributed service on localhost:34447
Running tests under Python 3.14.2: /cv/home/kleinhej/jax/.venv/bin/python
[ RUN      ] CudnnAttentionMultiProcessTest.test_cudnn_attention_grad_sharded
W0324 18:05:34.568625 140640888682304 __init__.py:285] cuBLAS < 13.2 (120901 found) has a known issue where many kernels free TMEM buffers multiple times. Executing a cuBLAS kernel concurrently with another kernel (e.g. on another stream) can lead to silent data corruption.
I0324 18:05:34.620033 140640888682304 xla_bridge.py:822] Unable to initialize backend 'tpu': INTERNAL: Failed to open libtpu.so: libtpu.so: cannot open shared object file: No such file or directory
E0324 18:05:36.195530 2753277 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]
E0324 18:05:36.195592 2753278 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]
E0324 18:05:36.195629 2753276 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]
E0324 18:05:36.195649 2753275 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]
E0324 18:05:36.195711 2753274 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]
E0324 18:05:36.195727 2753273 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]
[       OK ] CudnnAttentionMultiProcessTest.test_cudnn_attention_grad_sharded
----------------------------------------------------------------------
Ran 1 test in 10.622s

OK
W0324 18:05:44.578240 2753291 pjrt_client.cc:1604] WatchJobStateAsync failed for task 1: UNAVAILABLE: failed to connect to all addresses; last error: UNKNOWN: ipv4:127.0.0.1:34447: Failed to connect to remote host: Connection refused
Additional GRPC error information from remote target coordination_service while calling /tensorflow.CoordinationService/WatchJobState:
:UNKNOWN:Error received from peer  {grpc_status:14, grpc_message:"failed to connect to all addresses; last error: UNKNOWN: ipv4:127.0.0.1:34447: Failed to connect to remote host: Connection refused"}

============================== Done detailed logs ==============================
```