### PR TITLE
Don't check vma inside of core_map/mosaic_gpu

### DIFF
--- a/jax/_src/pallas/core.py
+++ b/jax/_src/pallas/core.py
@@ -976,7 +976,7 @@ class GridMapping:
       axis_env_ctx = jax_core.extend_axis_env_nd(
           zip(self.grid_names, self.grid)  # pyrefly: ignore[bad-argument-type]
       )
-    with tracing_grid_env(self.grid, self.vmapped_dims), axis_env_ctx:
+    with tracing_grid_env(self.grid, self.vmapped_dims), axis_env_ctx, config._check_vma(False):
       yield
 
   @property
@@ -1474,6 +1474,7 @@ def core_map(
     with (
         tracing_grid_env(tuple(mesh.shape.values()), mapped_dims=()),
         jax_core.extend_axis_env_nd(mesh.shape.items()),
+        config._check_vma(False),
     ):
       jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(flat_fun, ref_avals)
 
@@ -1729,7 +1730,7 @@ def _core_map_discharge_rule(in_avals, out_avals, *args_flat, jaxpr, debug_info,
 
 
 def _core_map_typecheck_rule(_, *in_atoms, jaxpr, mesh, **kwargs):
-  with jax_core.extend_axis_env_nd(tuple(mesh.shape.items())):
+  with jax_core.extend_axis_env_nd(tuple(mesh.shape.items())), config._check_vma(False):
     jax_core.check_jaxpr(jaxpr)
   return _core_map_abstract_eval(*in_atoms, jaxpr=jaxpr, mesh=mesh, **kwargs)
 

--- a/jax/_src/pallas/mosaic_gpu/lowering.py
+++ b/jax/_src/pallas/mosaic_gpu/lowering.py
@@ -3280,7 +3280,8 @@ def _run_scoped_lowering_rule(
       # consts. We also don't want to wrap the values in refs.
       no_const_jaxpr = pe.convert_constvars_jaxpr(jaxpr)
       should_discharge = [False] * len(consts) + should_discharge
-      discharged_jaxpr, _ = discharge.discharge_state(no_const_jaxpr, (), should_discharge=should_discharge)
+      with config._check_vma(False):
+        discharged_jaxpr, _ = discharge.discharge_state(no_const_jaxpr, (), should_discharge=should_discharge)
       new_input_vals = (*consts, *input_refs)
       outs = lower_jaxpr_to_mosaic_gpu(
           ctx.module_ctx,
@@ -3366,9 +3367,10 @@ def _run_state_lowering_rule(
         "Expected at least one accumulator to in run_state."
     )
 
-  discharged_jaxpr, new_consts = discharge.discharge_state(
-      jaxpr, (), should_discharge=should_discharge
-  )
+  with config._check_vma(False):
+    discharged_jaxpr, new_consts = discharge.discharge_state(
+        jaxpr, (), should_discharge=should_discharge
+    )
   assert not new_consts
   outs = lower_jaxpr_to_mosaic_gpu(
       ctx.module_ctx, ctx.launch_ctx, discharged_jaxpr, new_input_vals, ()  # pyrefly: ignore[bad-argument-type]

--- a/jax/_src/pallas/mpmd.py
+++ b/jax/_src/pallas/mpmd.py
@@ -316,7 +316,7 @@ def _mpmd_map(
       flat_fun, out_tree_thunk = api_util.flatten_fun_nokwargs(
           lu.wrap_init(fn, debug_info=debug_info), kernel_in_tree
       )
-      with jax_core.extend_axis_env_nd(mesh.shape.items()):
+      with jax_core.extend_axis_env_nd(mesh.shape.items()), config._check_vma(False):
         jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
             flat_fun, flat_kernel_avals
         )

--- a/tests/pallas/mgpu_ragged_dot_test.py
+++ b/tests/pallas/mgpu_ragged_dot_test.py
@@ -170,6 +170,42 @@ class RaggedDotTestCase(jtu.JaxTestCase):
     )
     np.testing.assert_allclose(out, out_ref, atol=1e-3, rtol=1e-3)
 
+  def test_ragged_dot_shard_map_check_vma(self):
+    """Test that ragged_dot can lower inside shard_map with check_vma=True."""
+    dtype = jnp.float16
+    block_m, block_n, block_k = 64, 64, 64
+    max_concurrent_steps = 2
+    grid_block_n = 2
+    num_groups = 3
+    m, k, n = 1024, 512, 512
+
+    P = jax.sharding.PartitionSpec
+    abstract_mesh = jax.sharding.AbstractMesh((2,), ("x",))
+
+    @jax.shard_map(
+        mesh=abstract_mesh,
+        in_specs=(P(), P(), P()),
+        out_specs=P(),
+        check_vma=True,
+    )
+    def sharded_ragged_dot(group_sizes_shard, lhs_shard, rhs_shard):
+      return ragged_dot_mgpu.ragged_dot(
+          lhs_shard,
+          rhs_shard,
+          group_sizes=group_sizes_shard,
+          block_m=block_m,
+          block_n=block_n,
+          block_k=block_k,
+          max_concurrent_steps=max_concurrent_steps,
+          grid_block_n=grid_block_n,
+      )
+
+    jax.jit(sharded_ragged_dot).trace(
+        jnp.zeros((num_groups,), dtype=jnp.int32),
+        jnp.zeros((m, k), dtype=dtype),
+        jnp.zeros((num_groups, k, n), dtype=dtype),
+    ).lower(lowering_platforms=("gpu",))  # doesn't crash
+
 
 @jtu.with_config(jax_traceback_filtering="off")
 class RaggedDotTCGen05TestCase(jtu.JaxTestCase, jtu.CudaArchSpecificTest):


### PR DESCRIPTION
- Disables check_vma inside of core_map and mosaic gpu lowering. This allows check_vma to be used with mosaic GPU kernels.
- Add a test to make sure the ragged dot kernel lowers inside of a shard_map with check_vma=True (none of the inputs are sharded, but it passes all of the VMA type checks).