### PR TITLE
[jaxpr consts] Do not make consts literals under AD

### DIFF
--- a/docs/internals/constants.md
+++ b/docs/internals/constants.md
@@ -24,7 +24,7 @@ def f(x):
 ```
 
 We describe below the **future** internal implementation details for
-constants. As of July 2025, this is not yet the default implementation;
+constants. As of March 2026, this is not yet the default implementation;
 it is enabled by the environment variable `JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS=True`.
 See further [below](#previous-implementation) for the details of the previous
 implementation, including its drawbacks.

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -569,11 +569,19 @@ class Literal:
 # end up as `constvars`.
 literalable_types: set[type] = set()
 
-def is_literalable(x: Any) -> bool:
+def is_literalable(x: Any, for_ad: bool = False) -> bool:
   # See https://docs.jax.dev/en/latest/internals/constants.html
+  # for_ad: we want to preserve under AD
+  if config.use_simplified_jaxpr_constants.value:
+    from jax._src.array import ArrayImpl  # type: ignore
+    do_lit_array = not for_ad
+    if isinstance(x, ArrayImpl):
+      return do_lit_array
+  else:
+    do_lit_array = False
   for t in type(x).__mro__:
     if t in literalable_types:
-      return (not np.shape(x) or config.use_simplified_jaxpr_constants.value)
+      return (not np.shape(x) or do_lit_array)
   return False
 
 @partial(weakref_lru_cache, trace_context_in_key=False)

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -162,7 +162,7 @@ class JaxprTrace(Trace):
     if const is None:
       return tracer
     else:
-      if core.is_literalable(const):
+      if core.is_literalable(const, True):
         return self.new_instantiated_literal(const)
       else:
         return self.new_instantiated_const(const)
@@ -1915,7 +1915,7 @@ class DynamicJaxprTrace(core.Trace):
     id_c = id(c)
     assert type(c) not in (int, float, complex, np.generic, np.ndarray), (
         f"non-canonical constant of type {type(c).__name__}: {c!r}")
-    if core.is_literalable(c):
+    if core.is_literalable(c, self.frame.auto_dce):
       val = Literal(c, aval)
       return DynamicJaxprTracer(self, aval, val, source_info)
     else:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6421,24 +6421,21 @@ class RematTest(jtu.JaxTestCase):
       return z * ((x1 * x2) * y) * np.array([3.])
 
     res = saved_residuals(f, (2., 3.), y=4.)
+    self.assertLen(res, 6)
+    self.assertEqual(res[0][0].shape, (1,))
     if config.use_simplified_jaxpr_constants.value:
-      self.assertLen(res, 5)
-      start_idx = 0
+      self.assertEqual(res[0][1], "from a literal")
     else:
-      self.assertLen(res, 6)
-      self.assertEqual(res[0][0].shape, (1,))
       self.assertEqual(res[0][1], "from a constant")
-      start_idx = 1
-
-    self.assertEqual(res[start_idx][0].shape, ())
-    self.assertEqual(res[start_idx][1], "from the argument x[0]")
-    self.assertEqual(res[start_idx + 1][0].shape, ())
-    self.assertEqual(res[start_idx + 1][1], "from the argument x[1]")
-    self.assertEqual(res[start_idx + 2][0].shape, ())
-    self.assertEqual(res[start_idx + 2][1], "from the argument y")
-    self.assertEqual(res[start_idx + 3][0].shape, ())
-    self.assertStartsWith(res[start_idx + 3][1], "named 'z'")
-    self.assertEqual(res[start_idx + 4][0].shape, ())
+    self.assertEqual(res[1][0].shape, ())
+    self.assertEqual(res[1][1], "from the argument x[0]")
+    self.assertEqual(res[2][0].shape, ())
+    self.assertEqual(res[2][1], "from the argument x[1]")
+    self.assertEqual(res[3][0].shape, ())
+    self.assertEqual(res[3][1], "from the argument y")
+    self.assertEqual(res[4][0].shape, ())
+    self.assertStartsWith(res[4][1], "named 'z'")
+    self.assertEqual(res[5][0].shape, ())
 
   def test_saved_residuals_utility_jit(self):
     @jax.jit
@@ -6448,22 +6445,33 @@ class RematTest(jtu.JaxTestCase):
       return z * ((x1 * x2) * y) * np.array([3.])
 
     res = saved_residuals(f, (2., 3.), y=4.)
+    self.assertLen(res, 6)
     if config.use_simplified_jaxpr_constants.value:
-      pass
+      self.assertEqual(res[0][1], "from the argument x[0]")
+      self.assertEqual(res[0][0].shape, ())
+      self.assertEqual(res[1][1], "from the argument x[1]")
+      self.assertEqual(res[1][0].shape, ())
+      self.assertEqual(res[2][1], "from the argument y")
+      self.assertEqual(res[2][0].shape, ())
+      self.assertStartsWith(res[3][1], "output of jitted function 'f'")
+      self.assertEqual(res[3][0].shape, ())
+      self.assertStartsWith(res[4][1], "output of jitted function 'f'")
+      self.assertEqual(res[4][0].shape, ())
+      self.assertStartsWith(res[5][1], "output of jitted function 'f'")
+      self.assertEqual(res[5][0].shape, (1,))
     else:
       self.assertEqual(res[0][1], "from a constant")
       self.assertEqual(res[0][0].shape, (1,))
-      res.pop(0)
-    self.assertLen(res, 5)
-    self.assertEqual(res[0][0].shape, ())
-    self.assertEqual(res[0][1], "from the argument x[0]")
-    self.assertEqual(res[1][0].shape, ())
-    self.assertEqual(res[1][1], "from the argument x[1]")
-    self.assertEqual(res[2][0].shape, ())
-    self.assertEqual(res[2][1], "from the argument y")
-    self.assertEqual(res[3][0].shape, ())
-    self.assertStartsWith(res[3][1], "output of jitted function 'f'")
-    self.assertEqual(res[4][0].shape, ())
+      self.assertEqual(res[1][1], "from the argument x[0]")
+      self.assertEqual(res[1][0].shape, ())
+      self.assertEqual(res[2][1], "from the argument x[1]")
+      self.assertEqual(res[2][0].shape, ())
+      self.assertEqual(res[3][1], "from the argument y")
+      self.assertEqual(res[4][0].shape, ())
+      self.assertStartsWith(res[4][1], "output of jitted function 'f'")
+      self.assertEqual(res[4][0].shape, ())
+      self.assertStartsWith(res[5][1], "output of jitted function 'f'")
+      self.assertEqual(res[5][0].shape, ())
 
   @parameterized.named_parameters(
       {"testcase_name": f"{suffix}", "remat": remat}
@@ -7899,6 +7907,12 @@ class InputSavedVJPTest(jtu.JaxTestCase):
 
   def test_basic_opaque_vjp3(self):
     f = jnp.sin
+    primals = 3.,
+    _, f_vjp = api.vjp(f, *primals)
+    self.assertTrue(f_vjp.opaque_residuals)  # can detect if opaque res are used
+
+  def test_basic_opaque_cond_vjp3(self):
+    f = lambda x: jax.lax.cond(x > 0, jnp.sin, jnp.cos, x)
     primals = 3.,
     _, f_vjp = api.vjp(f, *primals)
     self.assertTrue(f_vjp.opaque_residuals)  # can detect if opaque res are used


### PR DESCRIPTION
When we turn on JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS we want to preserve the behavior under AD w.r.t. residuals. We obtain this by using the `auto_dce` parameter from a `DynamicJaxprTrace` and if True then we ignore the flag  JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS.

