### PR TITLE
Track total number of eqns contained in a jaxpr

### DIFF
--- a/jax/_src/jaxpr_util.py
+++ b/jax/_src/jaxpr_util.py
@@ -64,6 +64,12 @@ def collect_eqns(jaxpr: core.Jaxpr, key: Callable):
     d[key(eqn)].append(eqn)
   return dict(d)
 
+@util.weakref_lru_cache
+def count_eqns(
+    jaxpr: core.Jaxpr, revisit_inner_jaxprs: bool = True
+) -> int:
+  return sum(1 for _ in all_eqns(jaxpr, revisit_inner_jaxprs=revisit_inner_jaxprs))
+
 def histogram(jaxpr: core.Jaxpr, key: Callable,
               key_fmt: Callable = lambda x: x):
   d = collect_eqns(jaxpr, key)

--- a/tests/jaxpr_util_test.py
+++ b/tests/jaxpr_util_test.py
@@ -20,6 +20,7 @@ from absl.testing import absltest
 
 import jax
 from jax import jit, make_jaxpr, numpy as jnp
+from jax import lax
 from jax._src import config
 from jax._src import jaxpr_util
 from jax._src import test_util as jtu
@@ -108,6 +109,23 @@ class JaxprStatsTest(jtu.JaxTestCase):
     self.assertSetEqual(
         {"sampleType", "sample", "stringTable", "location", "function"},
         set(profile.keys()))
+
+  def test_count_eqns(self):
+    # Test a simple flat jaxpr
+    def f(x):
+      return x + 2
+    jaxpr = make_jaxpr(f)(42)
+    # Check that accessing the property works on the ClosedJaxpr
+    self.assertEqual(jaxpr_util.count_eqns(jaxpr), 1)
+
+    # Test a higher-order jaxpr (contains nested subjaxprs)
+    def g(x):
+      return lax.cond(x > 0, lambda x: x + 2, lambda x: x - 2, x)
+    jaxpr_nested = make_jaxpr(g)(42)
+
+    # Verify the property resolves successfully and aggregates the nested equations
+    # (should be > 1 due to the condition and branch eqns)
+    self.assertEqual(jaxpr_util.count_eqns(jaxpr_nested), 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Can be used for metrics-gathering purposes to identify trace latency compared to number of equations. Iteratively constructs the value as the jaxpr is constructed to avoid needing to recursively count the value downstream.

pre-commit also picked up a lint issue within `tests/api_test.py`.