### PR TITLE
[mlir] Introduced helpers for creating dense i32/i64 array attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,19 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
       `parallel_callable`, `shard_args`, `xla_pmap_p`, `Chunked`,
       `NoSharding`, `Replicated`, `ShardedAxis`, `ShardingSpec`,
       `Unstacked`, `spec_to_indices`.
+
 * Changes:
   * `vma` parameter of `jax.ShapeDtypeStruct` has been replaced with
     `manual_type: jax.sharding.ManualAxisType`. The `.vma` property has been
     replaced with `.manual_type.varying`.
   * Removed experimental {func}`jax.experimental.custom_dce.custom_dce`
+
+* Deprecations:
+  * {func}`jax.interpreters.mlir.dense_int_elements` and
+    {func}`jax.interpreters.mlir.dense_int_array` are deprecated. Use
+    {func}`jax.interpreters.mlir.i32_array_attr` and
+    {func}`jax.interpreters.mlir.i64_array_attr` instead.
+
 
 ## JAX 0.9.2 (March 18, 2026)
 

--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -637,12 +637,12 @@ def _dot_product_attention_fwd_cuda_lowering(
     B, N, T, qk_H = query_shape
     _, _, S, v_H = value_shape
     output_layout = (3, 2, 1, 0)
-    output_transpose_perm = mlir.dense_int_array((0, 1, 2, 3))
+    output_transpose_perm = mlir.i64_array_attr((0, 1, 2, 3))
   else:
     B, T, N, qk_H = query_shape
     _, S, _, v_H = value_shape
     output_layout = (3, 1, 2, 0)
-    output_transpose_perm = mlir.dense_int_array((0, 2, 1, 3))
+    output_transpose_perm = mlir.i64_array_attr((0, 2, 1, 3))
 
   max_seg_per_batch = get_max_seg_per_batch(ir.RankedTensorType(q_offsets.type))
   is_paged_attention = check_is_paged_attention(ir.RankedTensorType(page_table_k.type))
@@ -719,12 +719,12 @@ def _dot_product_attention_bwd_cuda_lowering(
     B, q_N, T, qk_H = query_shape
     _, v_N, S, v_H = value_shape
     grad_layout = (3, 2, 1, 0)
-    grad_transpose_perm = mlir.dense_int_array((0, 1, 2, 3))
+    grad_transpose_perm = mlir.i64_array_attr((0, 1, 2, 3))
   else:
     B, T, q_N, qk_H = query_shape
     _, S, v_N, v_H = value_shape
     grad_layout = (3, 1, 2, 0)
-    grad_transpose_perm = mlir.dense_int_array((0, 2, 1, 3))
+    grad_transpose_perm = mlir.i64_array_attr((0, 2, 1, 3))
 
   workspace_shape = (0,)
   workspace_type = ir.IntegerType.get_unsigned(8)
@@ -1400,12 +1400,12 @@ def _dot_product_attention_fp8_fwd_cuda_lowering(
     B, N, T, H = query_shape
     _, _, S, _ = key_shape
     output_layout = (3, 2, 1, 0)
-    output_transpose_perm = mlir.dense_int_array((0, 1, 2, 3))
+    output_transpose_perm = mlir.i64_array_attr((0, 1, 2, 3))
   else:
     B, T, N, H = query_shape
     _, S, _, _ = key_shape
     output_layout = (3, 1, 2, 0)
-    output_transpose_perm = mlir.dense_int_array((0, 2, 1, 3))
+    output_transpose_perm = mlir.i64_array_attr((0, 2, 1, 3))
 
   output_shape = (B, N, T, H)
   softmax_stat_shape = (B, N, T)
@@ -1473,12 +1473,12 @@ def _dot_product_attention_fp8_bwd_cuda_lowering(
     B, q_N, T, H = query_shape
     _, k_N, S, _ = key_shape
     grad_layout = (3, 2, 1, 0)
-    grad_transpose_perm = mlir.dense_int_array((0, 1, 2, 3))
+    grad_transpose_perm = mlir.i64_array_attr((0, 1, 2, 3))
   else:
     B, T, q_N, H = query_shape
     _, S, k_N, _ = key_shape
     grad_layout = (3, 1, 2, 0)
-    grad_transpose_perm = mlir.dense_int_array((0, 2, 1, 3))
+    grad_transpose_perm = mlir.i64_array_attr((0, 2, 1, 3))
 
   workspace_shape = (0,)
   workspace_type = ir.IntegerType.get_unsigned(8)

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -77,11 +77,15 @@ Value = ir.Value
 
 IrValues = Union[ir.Value, tuple[ir.Value, ...]]
 
+def i32_array_attr(xs, **kwargs) -> ir.DenseIntElementsAttr:
+  return ir.DenseIntElementsAttr.get(  # pyrefly: ignore[no-matching-overload]
+      np.ascontiguousarray(xs, np.int32), **kwargs
+  )
 
-def dense_int_elements(xs) -> ir.DenseElementsAttr:
-  return ir.DenseIntElementsAttr.get(np.asarray(xs, np.int64))
-
-dense_int_array = ir.DenseI64ArrayAttr.get
+def i64_array_attr(xs, **kwargs) -> ir.DenseIntElementsAttr:
+  return ir.DenseIntElementsAttr.get(  # pyrefly: ignore[no-matching-overload]
+      np.ascontiguousarray(xs, np.int64), **kwargs
+  )
 
 def i32_attr(i): return ir.IntegerAttr.get(ir.IntegerType.get_signless(32), i)
 def i64_attr(i): return ir.IntegerAttr.get(ir.IntegerType.get_signless(64), i)
@@ -309,7 +313,7 @@ def _ndarray_constant_handler(val: np.ndarray | np.generic,
         ir.RankedTensorType.get(
             val.shape, dtype_to_ir_type(collapsed_val.dtype)),
         _numpy_array_constant(collapsed_val),
-        dense_int_array(other_axes))  # type: ignore
+        i64_array_attr(other_axes))  # type: ignore
     return out
   else:
     return _numpy_array_constant(val)
@@ -361,14 +365,14 @@ def _numpy_array_attribute(x: np.ndarray | np.generic) -> ir.Attribute:
   shape = x.shape
   x = np.ascontiguousarray(x)
   try:
-    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)
+    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)  # pyrefly: ignore[no-matching-overload]
   except ValueError:
     # Backwards compatibility fallback for old MLIR versions.
     # Delete once minimum supported jaxlib version is 0.9.1.
     if x.dtype != np.bool_:
       raise
     x = np.ascontiguousarray(np.packbits(x, bitorder='little'))
-    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)
+    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)  # pyrefly: ignore[no-matching-overload]
 
 def _numpy_array_attribute_handler(val: np.ndarray | np.generic) -> ir.Attribute:
   if 0 in val.strides and val.size > 0:
@@ -2697,14 +2701,14 @@ def broadcast_in_dim(ctx: LoweringRuleContext, op, aval_out: core.AbstractValue,
       out = hlo.dynamic_broadcast_in_dim(
           aval_to_ir_type(aval_out), op,
           shape,
-          dense_int_array(broadcast_dimensions),
+          i64_array_attr(broadcast_dimensions),
       )
     else:
       assert all(d != ir.ShapedType.get_dynamic_size()
                  for d in aval_out.shape), aval_out  # type: ignore
       out = hlo.broadcast_in_dim(
           aval_to_ir_type(aval_out), op,
-          dense_int_array(broadcast_dimensions))
+          i64_array_attr(broadcast_dimensions))
     wrap_compute_type_in_place(ctx, _get_owner(out))
     return out
 
@@ -2770,9 +2774,9 @@ def slice_op(ctx: LoweringRuleContext, x, aval_out, *,
         x, start_indices, limit_indices, strides)
     else:
       return hlo.slice(x,
-                       dense_int_array(start_indices),
-                       dense_int_array(limit_indices),
-                       dense_int_array(strides))
+                       i64_array_attr(start_indices),
+                       i64_array_attr(limit_indices),
+                       i64_array_attr(strides))
 
 def dynamic_slice(ctx: LoweringRuleContext, aval_out, x, *,
                   start_indices) -> ir.Value:
@@ -2805,7 +2809,7 @@ def dynamic_slice(ctx: LoweringRuleContext, aval_out, x, *,
         shape_tensor([1] * len(start_indices))
     )
   else:
-    return hlo.dynamic_slice(x, start_indices, dense_int_array(slice_sizes))
+    return hlo.dynamic_slice(x, start_indices, i64_array_attr(slice_sizes))
 
 def dynamic_update_slice(ctx: LoweringRuleContext, aval_out, x, update, *,
                          start_indices) -> ir.Value:
@@ -2828,9 +2832,9 @@ def pad(ctx: LoweringRuleContext, aval_out,
   if all(core.is_constant_shape(s) for s in (padding_low,
                                              padding_high, padding_interior)):
     return hlo.pad(x, padding_value,
-                   dense_int_array(padding_low),
-                   dense_int_array(padding_high),
-                   dense_int_array(padding_interior))
+                   i64_array_attr(padding_low),
+                   i64_array_attr(padding_high),
+                   i64_array_attr(padding_interior))
   else:
     padding_low = eval_dynamic_shape_as_tensor(ctx, padding_low)
     padding_high = eval_dynamic_shape_as_tensor(ctx, padding_high)
@@ -3210,9 +3214,9 @@ def custom_call(
     # We add the result_shapes at the end of the operands, and must pass
     # the indices_of_output_operands attribute. This attribute is not yet
     # accepted by the CustomCall constructor, so we use build_generic
-    attributes["indices_of_shape_operands"] = ir.DenseIntElementsAttr.get(
-        np.asarray(list(range(len(operands), len(operands) + len(result_shapes))),
-                   dtype=np.int64))
+    attributes["indices_of_shape_operands"] = i64_array_attr(
+        list(range(len(operands), len(operands) + len(result_shapes)))
+    )
     if operand_layouts is not None:
       assert len(operand_layouts) == len(operands), (operand_layouts, operands)
       operand_layouts = list(operand_layouts) + [(0,)] * len(result_shapes)
@@ -3220,18 +3224,16 @@ def custom_call(
 
   if operand_layouts is not None:
     attributes["operand_layouts"] = ir.ArrayAttr.get([
-        ir.DenseIntElementsAttr.get(
-            np.atleast_1d(np.asarray(l, dtype=np.int64)),
-            type=ir.IndexType.get()) for l in operand_layouts
+        i64_array_attr(np.atleast_1d(l), type=ir.IndexType.get())
+        for l in operand_layouts
     ])
   if result_layouts is not None:
     assert result_layouts is not None
     assert len(result_layouts) == len(result_types), (
         result_layouts, result_types)
     attributes["result_layouts"] = ir.ArrayAttr.get([
-        ir.DenseIntElementsAttr.get(
-            np.atleast_1d(np.asarray(l, dtype=np.int64)),
-            type=ir.IndexType.get()) for l in result_layouts
+        i64_array_attr(np.atleast_1d(l), type=ir.IndexType.get())
+        for l in result_layouts
     ])
 
   op = hlo.CustomCallOp.build_generic(results=result_types, operands=operands,
@@ -3292,12 +3294,11 @@ def reduce_window(
     rw = hlo.ReduceWindowOp(
         list(map(aval_to_ir_type, out_avals)),
         operands, init_values,
-        dense_int_array(window_dimensions),
-        window_strides=dense_int_array(window_strides),
-        base_dilations=dense_int_array(base_dilation),
-        window_dilations=dense_int_array(window_dilation),
-        padding=ir.DenseIntElementsAttr.get(np.asarray(padding, np.int64),
-                                            shape=[len(padding), 2]))
+        i64_array_attr(window_dimensions),
+        window_strides=i64_array_attr(window_strides),
+        base_dilations=i64_array_attr(base_dilation),
+        window_dilations=i64_array_attr(window_dilation),
+        padding=i64_array_attr(padding, shape=[len(padding), 2]))
     reducer = rw.regions[0].blocks.append(*(scalar_types + scalar_types))
     with ir.InsertionPoint(reducer):
       hlo.return_(reducer_body(reducer))

--- a/jax/_src/lax/ann.py
+++ b/jax/_src/lax/ann.py
@@ -297,7 +297,7 @@ def _approx_top_k_lowering(ctx, operand, *, k,
   iota = mlir.iota(ctx, core.ShapedArray(ctx.avals_in[0].shape, np.int32),
                    dimension=reduction_dimension)
 
-  init_arg = hlo.constant(ir.DenseElementsAttr.get(np.int32(-1)))
+  init_arg = hlo.constant(mlir.i32_array_attr(np.int32(-1)))
   init_val_array = _get_init_val_literal(ctx.avals_in[0].dtype, is_max_k)
   init_vals = mlir.flatten_ir_values(
       [mlir.ir_constant(init_val_array.reshape(()))

--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -818,10 +818,10 @@ def _conv_general_dilated_lower(
         dimension_numbers=dnums,
         feature_group_count=mlir.i64_attr(feature_group_count),
         batch_group_count=mlir.i64_attr(batch_group_count),
-        window_strides=mlir.dense_int_array(window_strides),
-        padding=mlir.dense_int_elements(padding),
-        lhs_dilation=mlir.dense_int_array(lhs_dilation),
-        rhs_dilation=mlir.dense_int_array(rhs_dilation),
+        window_strides=mlir.i64_array_attr(window_strides),
+        padding=mlir.i64_array_attr(padding),
+        lhs_dilation=mlir.i64_array_attr(lhs_dilation),
+        rhs_dilation=mlir.i64_array_attr(rhs_dilation),
         window_reversal=window_reversal,
         precision_config=lax.precision_attr(precision))
     return [mlir.lower_with_sharding_in_types(ctx, out, aval_out)]
@@ -843,9 +843,9 @@ def _conv_general_dilated_lower(
           dimension_numbers=dnums,
           feature_group_count=mlir.i64_attr(feature_group_count),
           batch_group_count=mlir.i64_attr(batch_group_count),
-          window_strides=mlir.dense_int_array(window_strides),
-          lhs_dilation=mlir.dense_int_array(lhs_dilation),
-          rhs_dilation=mlir.dense_int_array(rhs_dilation),
+          window_strides=mlir.i64_array_attr(window_strides),
+          lhs_dilation=mlir.i64_array_attr(lhs_dilation),
+          rhs_dilation=mlir.i64_array_attr(rhs_dilation),
           window_reversal=window_reversal,
           precision_config=lax.precision_attr(precision))
     ]

--- a/jax/_src/lax/fft.py
+++ b/jax/_src/lax/fft.py
@@ -133,7 +133,7 @@ def _fft_lowering(ctx, x, *, fft_type, fft_lengths):
     raise NotImplementedError("Shape polymorphism for FFT with non-constant fft_length is not implemented for TPU and GPU")
   return [
       hlo.FftOp(x, hlo.FftTypeAttr.get(fft_type.name),
-                mlir.dense_int_array(fft_lengths)).result
+                mlir.i64_array_attr(fft_lengths)).result
   ]
 
 

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -6359,7 +6359,7 @@ def _ragged_dot_general_lower(
       _, rhs_aval, _ = ctx.avals_in
       perm = list(range(rhs_aval.ndim))
       perm[-2], perm[-1] = perm[-1], perm[-2]
-      rhs = hlo.transpose(rhs, mlir.dense_int_array(perm))
+      rhs = hlo.transpose(rhs, mlir.i64_array_attr(perm))
       rhs_contracting = (1,)
   ragged_dot_dnums = chlo.RaggedDotDimensionNumbers.get(
       lhs_batching_dimensions=list(lhs_batch),
@@ -7298,7 +7298,7 @@ def _reshape_batch_rule(axis_data, batched_args, batch_dims, *, new_sizes,
 def _reshape_lower(ctx, x, new_sizes, dimensions, sharding):
   aval_out, = ctx.avals_out
   if dimensions is not None:
-    x = hlo.transpose(x, mlir.dense_int_array(dimensions))
+    x = hlo.transpose(x, mlir.i64_array_attr(dimensions))
   out = mlir.reshape(ctx, x, aval_out)
   return [mlir.lower_with_sharding_in_types(ctx, out, aval_out)]
 
@@ -7350,7 +7350,7 @@ batching.primitive_batchers[rev_p] = _rev_batch_rule
 
 def _rev_lower(ctx, x, *, dimensions):
   aval_out, = ctx.avals_out
-  out = hlo.reverse(x, mlir.dense_int_array(dimensions))
+  out = hlo.reverse(x, mlir.i64_array_attr(dimensions))
   return [mlir.lower_with_sharding_in_types(ctx, out, aval_out)]
 mlir.register_lowering(rev_p, _rev_lower)
 
@@ -7386,7 +7386,7 @@ def _transpose_lower(ctx, x, *, permutation):
     elt_shape = core.physical_element_aval(aval_out.dtype).shape
     trailing_dims = [aval_out.ndim + i for i in range(len(elt_shape))]
     permutation = [*permutation, *trailing_dims]
-  out = hlo.transpose(x, mlir.dense_int_array(permutation))
+  out = hlo.transpose(x, mlir.i64_array_attr(permutation))
   return [mlir.lower_with_sharding_in_types(ctx, out, aval_out)]
 
 transpose_p = standard_primitive(
@@ -7701,7 +7701,7 @@ def _reduce_lower(ctx: mlir.LoweringRuleContext, *values,
   operands, init_values = util.split_list(values, [len(values) // 2])
   init_value_avals = ctx.avals_in[len(values) // 2:]
   op = hlo.ReduceOp([mlir.aval_to_ir_type(aval) for aval in ctx.avals_out],
-                    operands, init_values, mlir.dense_int_array(dimensions))
+                    operands, init_values, mlir.i64_array_attr(dimensions))
   ir_types = [mlir.aval_to_ir_type(aval) for aval in init_value_avals]
   reducer = op.regions[0].blocks.append(*(ir_types + ir_types))
   with ir.InsertionPoint(reducer):
@@ -7967,7 +7967,7 @@ def _unary_reduce_lower(reducer, unit_factory, ctx, x, *, axes, **kwargs):
   dtype = aval_out.dtype
   op = hlo.ReduceOp([mlir.aval_to_ir_type(aval_out)], [x],
                     [mlir.ir_constant(unit_factory(aval_out.dtype))],
-                    mlir.dense_int_array(axes))
+                    mlir.i64_array_attr(axes))
   scalar_type = mlir.aval_to_ir_type(core.ShapedArray((), dtype))
   reducer_region = op.regions[0].blocks.append(scalar_type, scalar_type)
   with ir.InsertionPoint(reducer_region):
@@ -8259,7 +8259,7 @@ def _top_k_lower(ctx, operand, k, axis):
   if axis != ndim - 1:
     perm = list(range(ndim))
     perm[axis], perm[-1] = perm[-1], perm[axis]
-    operand = hlo.transpose(operand, mlir.dense_int_array(perm))
+    operand = hlo.transpose(operand, mlir.i64_array_attr(perm))
   else:
     perm = None
 
@@ -8280,7 +8280,7 @@ def _top_k_lower(ctx, operand, k, axis):
 
   # Move last dimension back into place
   if perm is not None:
-    results = [hlo.transpose(result, mlir.dense_int_array(perm))
+    results = [hlo.transpose(result, mlir.i64_array_attr(perm))
                for result in results]
   return results
 

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -2385,7 +2385,7 @@ def _svd_gpu_sub_lowering(ctx, operand, *, full_matrices, compute_uv,
   if (use_jacobi or use_polar) and compute_uv:
     vt = hlo.transpose(
         vt,
-        mlir.dense_int_array(tuple(range(nb)) + (nb + 1, nb)))
+        mlir.i64_array_attr(tuple(range(nb)) + (nb + 1, nb)))
     if np.issubdtype(operand_aval.dtype, np.complexfloating):
       vt = hlo.complex(hlo.real(vt), hlo.negate(hlo.imag(vt)))
     if not full_matrices and not econ:

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -933,7 +933,7 @@ def _replica_groups_hlo(replica_groups: Sequence[Sequence[int]]
   # Uneven replica groups are padded with -1.
   groups = np.array(list(itertools.zip_longest(*replica_groups, fillvalue=-1)),
                     dtype=np.int64).T
-  return ir.DenseIntElementsAttr.get(np.ascontiguousarray(groups))
+  return mlir.i64_array_attr(groups)
 
 def _allreduce_impl(prim, pos_reducer, arg, *, axes, axis_index_groups):
   assert axis_index_groups is None
@@ -1110,7 +1110,7 @@ def _ppermute_lowering(ctx, x, *, axis_name, perm):
       ctx, axis_name=axis_name, perm=perm, op_name="ppermute"
   )
   return hlo.CollectivePermuteOp(
-      x, mlir.dense_int_elements(full_perm), **other_args).results
+      x, mlir.i64_array_attr(full_perm), **other_args).results
 
 
 def _ppermute_transpose_rule(t, x, perm, axis_name):
@@ -1176,7 +1176,7 @@ def _psend_lowering_gpu(ctx, x, *, axis_name, perm):
   send_op = hlo.SendOp(
       [x],
       token,
-      source_target_pairs=mlir.dense_int_elements(full_perm),
+      source_target_pairs=mlir.i64_array_attr(full_perm),
       **other_args,
   )
   axis_ctx = ctx.module_context.axis_context
@@ -1219,7 +1219,7 @@ def _precv_lowering_gpu(ctx, token, *, out_shape, axis_name, perm):
   recv_op = hlo.RecvOp(
       [mlir.aval_to_ir_type(out_shape), token.type],
       token,
-      source_target_pairs=mlir.dense_int_elements(full_perm),
+      source_target_pairs=mlir.i64_array_attr(full_perm),
       **other_args,
   )
   axis_ctx = ctx.module_context.axis_context
@@ -1766,7 +1766,7 @@ def _all_gather_lowering(ctx, x, *, all_gather_dimension, axis_name,
     broadcast_dimensions = [i for i in range(len(new_shape)) if i != all_gather_dimension]
     x = hlo.broadcast_in_dim(
         mlir.aval_to_ir_type(x_aval.update(shape=new_shape)), x,
-        mlir.dense_int_array(broadcast_dimensions))
+        mlir.i64_array_attr(broadcast_dimensions))
   replica_groups = _replica_groups(ctx.module_context.axis_env, axis_name,
                                     axis_index_groups)
   if is_spmd:
@@ -2263,7 +2263,7 @@ def _build_axis_index_lowering_hlo(ctx, axis_name, axis_env):
       axis_context.manual_axes and
       axis_context.manual_axes != frozenset(axis_context.mesh.axis_names)):
     if axis_env.sizes[axis_pos] == 1:
-      return hlo.constant(ir.DenseElementsAttr.get(np.asarray(0, dtype=np.int32)))
+      return hlo.constant(mlir.i32_array_attr(np.int32(0)))
     def f():
       return axis_index_p.bind(axis_name=axis_name)
     return mlir.lower_fun(

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -2357,7 +2357,7 @@ def _gather_lower(ctx, operand, indices, *,
     out = mlir.full_like_aval(ctx, 0, aval_out)
     return [mlir.lower_with_sharding_in_types(ctx, out, aval_out)]
   else:
-    out = hlo.gather(operand, indices, dnums, mlir.dense_int_array(slice_sizes),
+    out = hlo.gather(operand, indices, dnums, mlir.i64_array_attr(slice_sizes),
                      indices_are_sorted=ir.BoolAttr.get(indices_are_sorted))
     return [mlir.lower_with_sharding_in_types(ctx, out, aval_out)]
 

--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -738,10 +738,9 @@ def _select_and_scatter_lower(
       operand,
       source,
       init_value,
-      window_dimensions=mlir.dense_int_array(window_dimensions),
-      window_strides=mlir.dense_int_array(window_strides),
-      padding=ir.DenseIntElementsAttr.get(np.asarray(padding, np.int64),
-                                          shape=(len(padding), 2)))
+      window_dimensions=mlir.i64_array_attr(window_dimensions),
+      window_strides=mlir.i64_array_attr(window_strides),
+      padding=mlir.i64_array_attr(padding, shape=(len(padding), 2)))
   select = op.select.blocks.append(scalar_type, scalar_type)
   with ir.InsertionPoint(select):
     if select_jaxpr.effects:

--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -925,7 +925,7 @@ def lower_jaxpr_into_module(
       # remaining physical dtype.
       block_shape += list(_get_aval_physical_dtype_shape(bm.block_aval.inner_aval))  # pytype: disable=wrong-arg-types
       block_shape = dynamic_shape_replacement_fn(block_shape)
-      window_shape = ir.DenseI64ArrayAttr.get(block_shape)
+      window_shape = mlir.i64_array_attr(block_shape)
       block_params: dict[str, ir.Attribute] = dict(
           window_bounds=window_shape,
           transform_indices=ir.FlatSymbolRefAttr.get(func_name),
@@ -997,7 +997,7 @@ def lower_jaxpr_into_module(
         MLIR_DYNAMIC if b is pallas_core.dynamic_grid_dim else b for b in grid
     ]
     static_grid = dynamic_shape_replacement_fn(static_grid)
-    func_op.attributes["iteration_bounds"] = ir.DenseI64ArrayAttr.get(static_grid)
+    func_op.attributes["iteration_bounds"] = mlir.i64_array_attr(static_grid)
   func_op.attributes["scalar_prefetch"] = ir.IntegerAttr.get(
       ir.IntegerType.get_signless(64), len(mosaic_grid_mapping.scalar_prefetch_types))
   func_op.attributes["scratch_operands"] = ir.IntegerAttr.get(

--- a/jax/_src/pallas/mosaic/sc_lowering.py
+++ b/jax/_src/pallas/mosaic/sc_lowering.py
@@ -390,7 +390,7 @@ def lower_jaxpr_into_module(
   sym_tab.insert(func_op)
   assert mosaic_grid_mapping.grid is not None
   assert all(isinstance(d, int) for d in mosaic_grid_mapping.grid)
-  func_op.attributes["iteration_bounds"] = ir.DenseI64ArrayAttr.get(
+  func_op.attributes["iteration_bounds"] = mlir.i64_array_attr(
       cast(tuple[int, ...], mosaic_grid_mapping.grid)
   )
   func_op.attributes["dimension_semantics"] = (
@@ -419,7 +419,7 @@ def lower_jaxpr_into_module(
 
     block_shape = list(pallas_core._get_block_shape(bm.block_shape))
     block_params = dict(
-        window_bounds=ir.DenseI64ArrayAttr.get(block_shape),
+        window_bounds=mlir.i64_array_attr(block_shape),
         transform_indices=ir.FlatSymbolRefAttr.get(func_name),
     )
     window_params.append(ir.DictAttr.get(block_params))

--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -1318,7 +1318,7 @@ def debug_print_lowering_rule(
       f" {fmt} ",
       hex=False,
       args=args,
-      is_signed=ir.DenseI32ArrayAttr.get([
+      is_signed=mlir.i32_array_attr([
           jnp.issubdtype(aval.dtype, jnp.signedinteger) for aval in ctx.avals_in
       ]),
   )
@@ -1344,11 +1344,7 @@ def _set_attr(v: ir.Value, name: str, attr: ir.Attribute) -> None:
 def _multiple_of_rule(ctx: LoweringRuleContext, x, values: Sequence[int]):
   [x_aval] = ctx.avals_in
   assert max(1, len(x_aval.shape)) == len(values)
-  _set_attr(
-      x,
-      "tt.divisibility",
-      ir.DenseIntElementsAttr.get(np.asarray(values, dtype=np.int32)),
-  )
+  _set_attr(x, "tt.divisibility", mlir.i32_array_attr(values))
   return x
 
 

--- a/jax/_src/pallas/triton/primitives.py
+++ b/jax/_src/pallas/triton/primitives.py
@@ -26,6 +26,7 @@ from jax._src import effects
 from jax._src import lax
 from jax._src import state
 from jax._src import tree_util
+from jax._src.interpreters import mlir
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import arith as arith_dialect
 from jax._src.lib.mlir.dialects import gpu as gpu_dialect
@@ -36,9 +37,7 @@ from jax._src.pallas.triton import lowering
 from jax._src.state import discharge as state_discharge
 from jax._src.state import indexing
 from jax._src.state import primitives as state_primitives
-from jax.interpreters import mlir
 import jax.numpy as jnp
-import numpy as np
 
 
 Ref: TypeAlias = state.AbstractRef | state.TransformedRef
@@ -697,9 +696,5 @@ def _max_contiguous_rule(
 ):
   [x_aval] = ctx.avals_in
   assert len(x_aval.shape) == len(values)
-  lowering._set_attr(
-      x,
-      "tt.contiguity",
-      ir.DenseIntElementsAttr.get(np.asarray(values, dtype=np.int32)),
-  )
+  lowering._set_attr(x, "tt.contiguity", mlir.i32_array_attr(values))
   return x

--- a/jax/experimental/sparse/bcsr.py
+++ b/jax/experimental/sparse/bcsr.py
@@ -682,7 +682,7 @@ def _bcsr_dot_general_gpu_lowering(
   elif rhs_aval.ndim == 2:
     dot_general_fn = _lowerings._csr_spmm_gpu_lowering
     if rhs_contract[0] == 1:
-      rhs = hlo.transpose(rhs, permutation=mlir.dense_int_array([1, 0]))
+      rhs = hlo.transpose(rhs, permutation=mlir.i64_array_attr([1, 0]))
       *avals_in, rhs_aval = sub_ctx.avals_in
       rhs_aval = core.ShapedArray(
           shape=(rhs_aval.shape[1], rhs_aval.shape[0]), dtype=rhs_aval.dtype)

--- a/jax/experimental/sparse/coo.py
+++ b/jax/experimental/sparse/coo.py
@@ -246,7 +246,7 @@ def _coo_todense_gpu_lowering(ctx, data, row, col, *, spinfo, target_name_prefix
   result = _lowerings.coo_todense_gpu_lowering(
       sub_ctx, data, row, col, shape=shape, target_name_prefix=target_name_prefix)
   return (
-      [hlo.transpose(result, mlir.dense_int_array([1, 0]))]
+      [hlo.transpose(result, mlir.i64_array_attr([1, 0]))]
       if transpose else [result])
 
 

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -33,14 +33,14 @@ from jax._src.interpreters.mlir import (
   aval_to_ir_type as aval_to_ir_type,
   aval_to_ir_types as aval_to_ir_types,
   core_call_lowering as core_call_lowering,
-  dense_int_array as dense_int_array,
-  dense_int_elements as dense_int_elements,
   dtype_to_ir_type as dtype_to_ir_type,
   flatten_ir_types as flatten_ir_types,
   flatten_ir_values as flatten_ir_values,
   unflatten_ir_values_like_types as unflatten_ir_values_like_types,
   i32_attr as i32_attr,
+  i32_array_attr as i32_array_attr,
   i64_attr as i64_attr,
+  i64_array_attr as i64_array_attr,
   ir as ir,
   ir_attribute as ir_attribute,
   ir_constant as ir_constant,
@@ -76,6 +76,15 @@ from jax._src.callback import (
 )
 
 _deprecations = {
+    # Added Mar 25 2026
+    "dense_int_array": (
+        "mlir.dense_int_array is deprecated; use mlir.i64_array_attr instead.",
+        i64_array_attr,
+    ),
+    "dense_int_elements": (
+        "mlir.dense_int_elements is deprecated; use mlir.i64_array_attr instead.",
+        i64_array_attr,
+    ),
     # Added Apr 7 2025
     "custom_call": (
         (
@@ -89,7 +98,7 @@ _deprecations = {
 import typing as _typing
 
 if _typing.TYPE_CHECKING:
-  pass
+  dense_int_array = dense_int_elements = i64_array_attr
 else:
   from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
 

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -290,7 +290,7 @@ class TestUtilTest(TestCase):
           reg = vector.extract(
               source=vec_reg,
               dynamic_position=[],
-              static_position=ir.DenseI64ArrayAttr.get([j]),
+              static_position=mlir.i64_array_attr([j]),
           )
           memref.store(
               reg, dst, [gpu.thread_id(gpu.Dimension.x), c(2 * i + j, index)]


### PR DESCRIPTION
Previously we had two very similar APIs for the i64 case: `dense_int_elements` and `dense_int_array`, where the latter also allowed customizing type=, shape= etc.

The new APIs make the element type obvious and also ensure that the argument is a contiguous array of the right type.