### PR TITLE
Switched to Python 3.11 in Pyrefly settings

### DIFF
--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -78,7 +78,7 @@ IrValues = Union[ir.Value, tuple[ir.Value, ...]]
 
 
 def dense_int_elements(xs) -> ir.DenseElementsAttr:
-  return ir.DenseIntElementsAttr.get(np.asarray(xs, np.int64))
+  return ir.DenseIntElementsAttr.get(np.asarray(xs, np.int64))  # pyrefly: ignore[no-matching-overload]
 
 dense_int_array = ir.DenseI64ArrayAttr.get
 
@@ -360,14 +360,14 @@ def _numpy_array_attribute(x: np.ndarray | np.generic) -> ir.Attribute:
   shape = x.shape
   x = np.ascontiguousarray(x)
   try:
-    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)
+    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)  # pyrefly: ignore[no-matching-overload]
   except ValueError:
     # Backwards compatibility fallback for old MLIR versions.
     # Delete once minimum supported jaxlib version is 0.9.1.
     if x.dtype != np.bool_:
       raise
     x = np.ascontiguousarray(np.packbits(x, bitorder='little'))
-    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)
+    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)  # pyrefly: ignore[no-matching-overload]
 
 def _numpy_array_attribute_handler(val: np.ndarray | np.generic) -> ir.Attribute:
   if 0 in val.strides and val.size > 0:
@@ -3203,7 +3203,7 @@ def custom_call(
     # We add the result_shapes at the end of the operands, and must pass
     # the indices_of_output_operands attribute. This attribute is not yet
     # accepted by the CustomCall constructor, so we use build_generic
-    attributes["indices_of_shape_operands"] = ir.DenseIntElementsAttr.get(
+    attributes["indices_of_shape_operands"] = ir.DenseIntElementsAttr.get(  # pyrefly: ignore[no-matching-overload]
         np.asarray(list(range(len(operands), len(operands) + len(result_shapes))),
                    dtype=np.int64))
     if operand_layouts is not None:
@@ -3213,7 +3213,7 @@ def custom_call(
 
   if operand_layouts is not None:
     attributes["operand_layouts"] = ir.ArrayAttr.get([
-        ir.DenseIntElementsAttr.get(
+        ir.DenseIntElementsAttr.get(  # pyrefly: ignore[no-matching-overload]
             np.atleast_1d(np.asarray(l, dtype=np.int64)),
             type=ir.IndexType.get()) for l in operand_layouts
     ])
@@ -3222,7 +3222,7 @@ def custom_call(
     assert len(result_layouts) == len(result_types), (
         result_layouts, result_types)
     attributes["result_layouts"] = ir.ArrayAttr.get([
-        ir.DenseIntElementsAttr.get(
+        ir.DenseIntElementsAttr.get(  # pyrefly: ignore[no-matching-overload]
             np.atleast_1d(np.asarray(l, dtype=np.int64)),
             type=ir.IndexType.get()) for l in result_layouts
     ])
@@ -3289,7 +3289,7 @@ def reduce_window(
         window_strides=dense_int_array(window_strides),
         base_dilations=dense_int_array(base_dilation),
         window_dilations=dense_int_array(window_dilation),
-        padding=ir.DenseIntElementsAttr.get(np.asarray(padding, np.int64),
+        padding=ir.DenseIntElementsAttr.get(np.asarray(padding, np.int64),  # pyrefly: ignore[no-matching-overload]
                                             shape=[len(padding), 2]))
     reducer = rw.regions[0].blocks.append(*(scalar_types + scalar_types))
     with ir.InsertionPoint(reducer):

--- a/jax/_src/lax/ann.py
+++ b/jax/_src/lax/ann.py
@@ -297,7 +297,7 @@ def _approx_top_k_lowering(ctx, operand, *, k,
   iota = mlir.iota(ctx, core.ShapedArray(ctx.avals_in[0].shape, np.int32),
                    dimension=reduction_dimension)
 
-  init_arg = hlo.constant(ir.DenseElementsAttr.get(np.int32(-1)))
+  init_arg = hlo.constant(ir.DenseElementsAttr.get(np.int32(-1)))  # pyrefly: ignore[no-matching-overload]
   init_val_array = _get_init_val_literal(ctx.avals_in[0].dtype, is_max_k)
   init_vals = mlir.flatten_ir_values(
       [mlir.ir_constant(init_val_array.reshape(()))

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -933,7 +933,7 @@ def _replica_groups_hlo(replica_groups: Sequence[Sequence[int]]
   # Uneven replica groups are padded with -1.
   groups = np.array(list(itertools.zip_longest(*replica_groups, fillvalue=-1)),
                     dtype=np.int64).T
-  return ir.DenseIntElementsAttr.get(np.ascontiguousarray(groups))
+  return ir.DenseIntElementsAttr.get(np.ascontiguousarray(groups))  # pyrefly: ignore[no-matching-overload]
 
 def _allreduce_impl(prim, pos_reducer, arg, *, axes, axis_index_groups):
   assert axis_index_groups is None
@@ -2263,7 +2263,7 @@ def _build_axis_index_lowering_hlo(ctx, axis_name, axis_env):
       axis_context.manual_axes and
       axis_context.manual_axes != frozenset(axis_context.mesh.axis_names)):
     if axis_env.sizes[axis_pos] == 1:
-      return hlo.constant(ir.DenseElementsAttr.get(np.asarray(0, dtype=np.int32)))
+      return hlo.constant(ir.DenseElementsAttr.get(np.asarray(0, dtype=np.int32)))  # pyrefly: ignore[no-matching-overload]
     def f():
       return axis_index_p.bind(axis_name=axis_name)
     return mlir.lower_fun(

--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -740,7 +740,7 @@ def _select_and_scatter_lower(
       init_value,
       window_dimensions=mlir.dense_int_array(window_dimensions),
       window_strides=mlir.dense_int_array(window_strides),
-      padding=ir.DenseIntElementsAttr.get(np.asarray(padding, np.int64),
+      padding=ir.DenseIntElementsAttr.get(np.asarray(padding, np.int64),  # pyrefly: ignore[no-matching-overload]
                                           shape=(len(padding), 2)))
   select = op.select.blocks.append(scalar_type, scalar_type)
   with ir.InsertionPoint(select):

--- a/jax/_src/numpy/array_constructors.py
+++ b/jax/_src/numpy/array_constructors.py
@@ -51,7 +51,7 @@ rocm_plugin_extension = None
 try:
   from importlib.metadata import distributions
   for dist in distributions():
-    name = dist.metadata.get('Name', '')
+    name = dist.metadata.get('Name', '')  # pyrefly: ignore[missing-attribute]
     if name.startswith('jax-rocm') and name.endswith('-plugin'):
       module_name = name.replace('-', '_')
       try:

--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -1347,7 +1347,7 @@ def _multiple_of_rule(ctx: LoweringRuleContext, x, values: Sequence[int]):
   _set_attr(
       x,
       "tt.divisibility",
-      ir.DenseIntElementsAttr.get(np.asarray(values, dtype=np.int32)),
+      ir.DenseIntElementsAttr.get(np.asarray(values, dtype=np.int32)),  # pyrefly: ignore[no-matching-overload]
   )
   return x
 

--- a/jax/_src/pallas/triton/primitives.py
+++ b/jax/_src/pallas/triton/primitives.py
@@ -700,6 +700,6 @@ def _max_contiguous_rule(
   lowering._set_attr(
       x,
       "tt.contiguity",
-      ir.DenseIntElementsAttr.get(np.asarray(values, dtype=np.int32)),
+      ir.DenseIntElementsAttr.get(np.asarray(values, dtype=np.int32)),  # pyrefly: ignore[no-matching-overload]
   )
   return x

--- a/jax/_src/test_loader.py
+++ b/jax/_src/test_loader.py
@@ -31,6 +31,7 @@ from contextlib import contextmanager
 import logging
 import os
 import re
+import sys
 import threading
 import time
 import unittest
@@ -174,8 +175,9 @@ class ThreadSafeTestResult:
   def addExpectedFailure(self, test: unittest.TestCase, err):
     self.actions.append(lambda: self.test_result.addExpectedFailure(test, err))
 
-  def addDuration(self, test: unittest.TestCase, elapsed):
-    self.actions.append(lambda: self.test_result.addDuration(test, elapsed))
+  if sys.version_info[:2] >= (3, 12):
+    def addDuration(self, test: unittest.TestCase, elapsed):
+      self.actions.append(lambda: self.test_result.addDuration(test, elapsed))
 
 
 class JaxTestSuite(unittest.TestSuite):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,11 +41,9 @@ doctest_optionflags = [
 addopts = "--doctest-glob='*.rst' --ignore='examples/ffi' --import-mode=importlib"
 
 [tool.pyrefly]
-# TODO(slebedev): Use 3.11 here.
-python-version = "3.12"
+python-version = "3.11"
 project-includes = [
     "jax/**/*.py*",
-    # "tests/**/*.py",
 ]
 project-excludes = [
     "jax/_src/internal_test_util/export_back_compat_test_data/*.py",
@@ -85,7 +83,6 @@ ignore-missing-imports = [
     "zstandard.*",
 ]
 permissive-ignores = true
-# TODO(slebedev): Change this to "check-and-infer-return-type".
 untyped-def-behavior = "check-and-infer-return-any"
 
 [tool.ruff]


### PR DESCRIPTION
Most suppressions added in this change are due to MLIR using the `Buffer` type in `ir.DenseElementsAttr.get`, which is not available in 3.11.