### PR TITLE
Remove deprecated jax_default_dtype_bits config for JAX v0.10.0.

### DIFF
--- a/docs/sphinxext/jax_list_config_options.py
+++ b/docs/sphinxext/jax_list_config_options.py
@@ -22,7 +22,6 @@ from sphinx.util.docutils import SphinxDirective
 logger = logging.getLogger(__name__)
 
 _deprecations = (
-  'jax_default_dtype_bits', # an experiment that we never documented, but we can't remove it because Keras depends on its existing broken behavior
   'jax_serialization_version'
 )
 

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -23,7 +23,6 @@ import logging
 import os
 import sys
 from typing import Any, Generic, Generator, NoReturn, Optional, Protocol, Type, TypeVar, cast
-import warnings
 
 from jax._src import logging_config
 from jax._src.lib import _jax
@@ -1533,25 +1532,6 @@ remove_custom_partitioning_ptr_from_cache_key = bool_state(
           'unsafe flag to set and only users who are sure of '
           'what they are trying to achieve should set it.'),
 )
-
-def _default_dtype_bits_deprecation(val):
-  if val != '_default':
-    warnings.warn(
-        (
-          'The jax_default_dtype_bits configuration is deprecated in JAX v0.7.1'
-          ' and has no effect as of JAX v0.9.0. It will be removed in JAX v0.10.0.'
-        ),
-        category=DeprecationWarning,
-        stacklevel=4)
-
-
-default_dtype_bits = enum_state(
-    name='jax_default_dtype_bits',
-    enum_values=['_default', '32', '64'],
-    default='_default',
-    help=('[deprecated]. This has no effect starting with JAX v0.9.0, and'
-          ' will be removed in JAX v0.10.0.'),
-    extra_validator=_default_dtype_bits_deprecation)
 
 
 class ExplicitX64Mode(enum.IntEnum):


### PR DESCRIPTION
This was deprecated in JAX v0.7.1, and has had no effect (aside from raising a warning) since JAX v0.9.0.