### PR TITLE
[ROCm] Skipped tests on ROCm that are flaky and sometimes cause CI failures

### DIFF
--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -1001,6 +1001,14 @@ class BatchingTest(jtu.JaxTestCase):
       for collective_subset in it.combinations(vmap_names, subset_size)
       for collective_names in it.permutations(collective_subset))
   def testCommAssocCollective(self, collective, bulk_op, vmap_names, collective_names):
+
+    # These tests are currently skipped on ROCm due to flaky behavior.
+    if (jtu.is_device_rocm() and
+        (collective is lax.psum) and
+        vmap_names == ('i', 'j', 'k') and
+        collective_names == ('k', 'j', 'i')):
+      self.skipTest("Skipped on ROCm due to flaky behavior.")
+
     shape = (2, 2, 2)
     x = jnp.arange(np.prod(shape), dtype=jnp.float32).reshape(shape)
 

--- a/tests/blocked_sampler_test.py
+++ b/tests/blocked_sampler_test.py
@@ -137,6 +137,8 @@ class BlockedFoldInTest(jtu.JaxTestCase):
          total_size=(2, 64 * 1024, 64 * 1024), block_size_a=(1, 4096, 512),
          block_size_b=(1, 1024, 2048), tile_size=(1, 1024, 512)),
   )
+  # This test is currently skipped on ROCm due to flaky behavior.
+  @jtu.skip_on_devices("rocm")
   def test_blocked_fold_in_shape_invariance(self, total_size, block_size_a,
                                             block_size_b, tile_size):
     global_key = jax.random.key(0)

--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -197,6 +197,8 @@ class CheckifyTransformTests(jtu.JaxTestCase):
     raises_oob(partial(lax.dynamic_slice, slice_sizes=(1, 1, 1)), x, (0, 1, 8), 'index 8')
     raises_oob(partial(lax.dynamic_slice, slice_sizes=(1, 1, 1)), x, (0, 1, -10), 'index -3')
 
+  # This test is currently skipped on ROCm due to flaky behavior.
+  @jtu.skip_on_devices("rocm")
   def test_dynamic_update_slice_oobs(self):
     def raises_oob(fn, x, y, idx, *expected_strs):
       err, _ = checkify.checkify(jax.jit(fn), errors=checkify.index_checks)(x, y, idx)

--- a/tests/clear_backends_test.py
+++ b/tests/clear_backends_test.py
@@ -23,6 +23,8 @@ jax.config.parse_flags_with_absl()
 
 class ClearBackendsTest(jtu.JaxTestCase):
 
+  # This test is currently skipped on ROCm due to flaky behavior.
+  @jtu.skip_on_devices("rocm")
   def test_clear_backends(self):
     g = jax.jit(lambda x, y: x * y)
     self.assertEqual(g(1, 2), 2)

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -307,6 +307,14 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     padding=["VALID", "SAME"],
   )
   def testConvGrad(self, lhs_shape, rhs_shape, dtype, strides, padding):
+
+    # These tests are currently skipped on ROCm due to flaky behavior.
+    if (jtu.is_device_rocm() and
+        lhs_shape == (3, 3, 3, 4) and
+        rhs_shape == (2, 3, 1, 2) and
+        dtype is np.float32):
+      self.skipTest("Skipped on ROCm due to flaky behavior.")
+
     rng = jtu.rand_small(self.rng())
     lhs = rng(lhs_shape, dtype)
     rhs = rng(rhs_shape, dtype)
@@ -335,6 +343,14 @@ class LaxAutodiffTest(jtu.JaxTestCase):
   )
   def testConvWithGeneralPaddingGrad(self, lhs_shape, rhs_shape, dtype, strides,
                                      padding, lhs_dil, rhs_dil):
+
+    # These tests are currently skipped on ROCm due to flaky behavior.
+    if (jtu.is_device_rocm() and
+        lhs_shape == (2, 3, 3, 4) and
+        rhs_shape == (2, 3, 1, 2) and
+        dtype is dtypes.bfloat16):
+      self.skipTest("Skipped on ROCm due to flaky behavior.")
+
     rng = jtu.rand_small(self.rng())
     lhs = rng(lhs_shape, dtype)
     rhs = rng(rhs_shape, dtype)
@@ -432,6 +448,14 @@ class LaxAutodiffTest(jtu.JaxTestCase):
   )
   def testDotGeneralContractAndBatchGrads(self, lhs_shape, rhs_shape, dtype,
                                           dimension_numbers):
+
+    # These tests are currently skipped on ROCm due to flaky behavior.
+    if (jtu.is_device_rocm() and
+        lhs_shape == (3, 3, 2) and
+        rhs_shape == (3, 2, 4) and
+        dtype is np.float32):
+      self.skipTest("Skipped on ROCm due to flaky behavior.")
+
     rng = jtu.rand_small(self.rng())
     lhs = rng(lhs_shape, dtype)
     rhs = rng(rhs_shape, dtype)
@@ -582,6 +606,14 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     dtype=float_dtypes,
   )
   def testSelectGrad(self, pred_shape, arg_shape, dtype):
+
+    # These tests are currently skipped on ROCm due to flaky behavior.
+    if (jtu.is_device_rocm() and
+        pred_shape == (2, 3) and
+        arg_shape == (2, 3) and
+        dtype is np.float16):
+      self.skipTest("Skipped on ROCm due to flaky behavior.")
+
     rng = jtu.rand_default(self.rng())
     pred = rng(pred_shape, np.bool_)
     on_true = rng(arg_shape, dtype)

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -1585,6 +1585,13 @@ class IndexedUpdateTest(jtu.JaxTestCase):
   )
   def testAdvancedIndexing(self, name, shape, dtype, update_shape, update_dtype,
                            indexer, op):
+
+    # These tests are currently skipped on ROCm due to flaky behavior.
+    if (jtu.is_device_rocm() and
+        name == "Two1DIntArrayIndicesNoBroadcasting" and
+        op == UpdateOps.SUB):
+      self.skipTest("Skipped on ROCm due to flaky behavior.")
+
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype), rng(update_shape, update_dtype)]
     np_fn = lambda x, y: UpdateOps.np_fn(op, indexer, x, y)

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -198,6 +198,13 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
   @jax.numpy_dtype_promotion('standard')  # This test explicitly exercises dtype promotion
   def testScipySpecialFun(self, op, rng_factory, shapes, dtypes,
                           test_autodiff, nondiff_argnums):
+
+    # These tests are currently skipped on ROCm due to flaky behavior.
+    if (jtu.is_device_rocm() and
+        ((op == "gammainc" and shapes == ((3, 1), (1, 4))) or
+         (op == "hyp1f1" and shapes == ((), (1, 4), (2, 1, 4))))):
+      self.skipTest("Skipped on ROCm due to flaky behavior.")
+
     scipy_op = getattr(osp_special, op)
     lax_op = getattr(lsp_special, op)
     rng = rng_factory(self.rng())

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -2102,6 +2102,8 @@ class PallasControlFlowTest(ptu.PallasTest):
     )(*(jnp.array([[x]]) for x in (2, 6)))
     np.testing.assert_array_equal(r, 4)
 
+  # This test is currently skipped on ROCm due to flaky behavior.
+  @jtu.skip_on_devices("rocm")
   def test_non_range_while_loop(self):
     """Tests lowering of a while_loop which cannot reduce to a fori_loop."""
 

--- a/tests/pallas/pallas_vmap_test.py
+++ b/tests/pallas/pallas_vmap_test.py
@@ -235,7 +235,8 @@ class PallasCallVmapTest(PallasBaseTest):
 
     np.testing.assert_allclose(out, out_ref)
 
-  @jtu.skip_on_devices("cpu")  # Test is very slow on CPU
+  # This test is currently skipped on ROCm due to flaky behavior.
+  @jtu.skip_on_devices("cpu", "rocm")  # Test is very slow on CPU
   def test_small_small_large_vmap(self):
 
     @functools.partial(

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -1509,6 +1509,13 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     dtype=jtu.dtypes.floating,
   )
   def testMultivariateNormalLogpdfBatch(self, ndim, nbatch, dtype):
+
+    # These tests are currently skipped on ROCm due to flaky behavior.
+    if (jtu.is_device_rocm() and
+        ndim == 3 and
+        nbatch == 5):
+      self.skipTest("Skipped on ROCm due to flaky behavior.")
+
     # Regression test for #5570
     rng = jtu.rand_default(self.rng())
     x = rng((nbatch, ndim), dtype)

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -3691,6 +3691,16 @@ class ShapePolyHarnessesTest(jtu.JaxTestCase):
       raise unittest.SkipTest(
           "native serialization with shape polymorphism not implemented for window_reductions on CPU and GPU")
 
+    # These tests are currently skipped on ROCm due to flaky behavior.
+    if (jtu.test_device_matches(["rocm"]) and
+        harness.fullname in [
+            "vmap_lu_shape_complex64_3_5_",
+            "vmap_qr_multi_array_shape_complex64_1_1_fullmatrices_False",
+            "vmap_cholesky_shape_bfloat16_1_1_",
+            "lu_shape_float32_2_4_0_poly_b_",
+            ]):
+      raise unittest.SkipTest("Skipped on ROCm due to flaky behavior.")
+
     if harness.group_name == "vmap_conv_general_dilated":
       # https://github.com/openxla/stablehlo/issues/1268
       raise unittest.SkipTest("Need more dynamism for DynamicConvOp")


### PR DESCRIPTION
## Summary
Several tests have been skipped on ROCm because they exhibit flaky behavior. This causes the CI to fail unexpectedly and in a non-deterministic manner. Once the root cause has been properly diagnosed and addressed, these tests will be unskipped. The full list of skipped tests is as follows:

Pallas Tests
- tests/pallas/pallas_vmap_test.py::PallasCallVmapInterpretTest::test_small_small_large_vmap
- tests/pallas/pallas_test.py::PallasControlFlowTest::test_non_range_while_loop

Shape Poly Harness Tests
- tests/shape_poly_test.py::ShapePolyHarnessesTest::test_harness_vmap_lu_shape_complex64_3_5_
- tests/shape_poly_test.py::ShapePolyHarnessesTest::test_harness_vmap_qr_multi_array_shape_complex64_1_1_fullmatrices_False
- tests/shape_poly_test.py::ShapePolyHarnessesTest::test_harness_vmap_cholesky_shape_bfloat16_1_1_
- tests/shape_poly_test.py::ShapePolyHarnessesTest::test_harness_lu_shape_float32_2_4_0_poly_b_

Scipy Special Function Tests
- tests/lax_scipy_special_functions_test.py::LaxScipySpecialFunctionsTest::testScipySpecialFun_gammainc_3x1_1x4_float32_float32
- tests/lax_scipy_special_functions_test.py::LaxScipySpecialFunctionsTest::testScipySpecialFun_hyp1f1_s_1x4_2x1x4_float32_float32_float32

Lax Autodiff Tests
- tests/lax_autodiff_test.py::LaxAutodiffTest::testSelectGrad0
- tests/lax_autodiff_test.py::LaxAutodiffTest::testDotGeneralContractAndBatchGrads7
- tests/lax_autodiff_test.py::LaxAutodiffTest::testConvGrad8
- tests/lax_autodiff_test.py::LaxAutodiffTest::testConvWithGeneralPaddingGrad1

Misc. Tests
- tests/blocked_sampler_test.py::BlockedFoldInTest::test_blocked_fold_in_shape_invariance_4096x512_vs_1024x2048
- tests/clear_backends_test.py::ClearBackendsTest::test_clear_backends
- tests/checkify_test.py::CheckifyTransformTests::test_dynamic_update_slice_oobs
- tests/batching_test.py::BatchingTest::testCommAssocCollective_psum_vmap_names=ijk_collective_names=kji
- tests/lax_numpy_indexing_test.py::IndexedUpdateTest::testAdvancedIndexing8
- tests/scipy_stats_test.py::LaxBackedScipyStatsTests::testMultivariateNormalLogpdfBatch2
