### PR TITLE
Fix missing bzlmod deps and load proto rules from protobuf for Bazel 8 compatibility

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,9 +10,11 @@ bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "flatbuffers", version = "25.2.10", repo_name = "com_github_google_flatbuffers")
 bazel_dep(name = "grpc", version = "1.78.0", repo_name = "com_github_grpc_grpc")
 bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "protobuf", version = "32.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "pybind11_bazel", version = "2.13.6")
 bazel_dep(name = "rules_cc", version = "0.2.9")
 bazel_dep(name = "rules_python", version = "1.8.4")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 
 # TODO: use a released version when available
 bazel_dep(name = "rules_ml_toolchain")
@@ -134,7 +136,7 @@ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
     python_version = python_version,
     requirements_lock = "//build:requirements_lock_{}.txt".format(python_version.replace(".", "_")),
     whl_modifications = {
-        "@//build:numpy.json": "numpy",  # @pypi_mods is defined in XLA's MODULE.bazel
+        "//build:numpy.json": "numpy",  # @pypi_mods is defined in XLA's MODULE.bazel
     },
 ) for python_version in [
     "3.11",

--- a/jaxlib/jax.bzl
+++ b/jaxlib/jax.bzl
@@ -24,7 +24,8 @@ load("@nvidia_wheel_versions//:versions.bzl", "NVIDIA_WHEEL_VERSIONS")
 load("@python_version_repo//:py_version.bzl", "HERMETIC_PYTHON_VERSION", "HERMETIC_PYTHON_VERSION_KIND")
 load("@rocm_external_test_deps//:external_deps.bzl", "EXTERNAL_DEPS")
 load("@rocm_prebuilt_test_deps//:external_deps.bzl", PREBUILT_EXTERNAL_DEPS = "EXTERNAL_DEPS")
-load("@rules_cc//cc:defs.bzl", _cc_proto_library = "cc_proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", _cc_proto_library = "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", _proto_library = "proto_library")
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("@test_shard_count//:test_shard_count.bzl", "USE_MINIMAL_SHARD_COUNT")
 load("@xla//third_party/py:python_wheel.bzl", "collect_data_files", "transitive_py_deps")
@@ -36,7 +37,7 @@ load("@xla//xla/tsl/platform:build_config_root.bzl", _tf_cuda_tests_tags = "tf_c
 cc_proto_library = _cc_proto_library
 cuda_library = _cuda_library
 rocm_library = _rocm_library
-proto_library = native.proto_library
+proto_library = _proto_library
 nanobind_extension = _pybind_extension
 if_cuda_is_configured = _if_cuda_is_configured
 if_rocm_is_configured = _if_rocm_is_configured


### PR DESCRIPTION
We're building JAX from source as a bzlmod dependency (archive_override) and hit a few issues. These fixes are all backward-compatible with JAX's current Bazel 7 WORKSPACE build.

##### Add missing protobuf and zlib bazel_deps

JAX uses cc_proto_library and proto_library but doesn't declare protobuf as a direct dependency in MODULE.bazel. It resolves today only because XLA pulls it in transitively — but bzlmod requires direct deps to be declared for them to be visible from a module's .bzl files. Same for zlib.

##### Fix @//build:numpy.json → //build:numpy.json

@// is shorthand for the root module's repository. When JAX is the root module this works fine, but when JAX is consumed as a dependency via bzlmod, @// points to the consumer's repo, not JAX's — so the label resolves to the wrong place. // (without @) always refers to the current module's repo,
  which is correct in both cases.

##### Load proto rules from @com_google_protobuf instead of @rules_cc / native

Bazel 8 removed cc_proto_library from @rules_cc//cc:defs.bzl and deprecated native.proto_library. The canonical location is now @com_google_protobuf//bazel:*.bzl. This works with Bazel 7 too since @com_google_protobuf is already defined in XLA's workspace2.bzl.