### PR TITLE
jax.scipy.stats.rankdata: always return floating point dtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
       `parallel_callable`, `shard_args`, `xla_pmap_p`, `Chunked`,
       `NoSharding`, `Replicated`, `ShardedAxis`, `ShardingSpec`,
       `Unstacked`, `spec_to_indices`.
+  * {func}`jax.scipy.stats.rankdata` now returns floating point values in
+    all cases, following a similar change in the SciPy 1.18 release.
 
 * Changes:
   * The minimum supported SciPy version is now 1.14.

--- a/jax/_src/scipy/stats/_core.py
+++ b/jax/_src/scipy/stats/_core.py
@@ -188,7 +188,7 @@ def rankdata(
     )
   if nan_policy == "raise":
     raise NotImplementedError(
-      "In order to best JIT compile `mode`, we cannot know whether `x` "
+      "In order to best JIT compile `rankdata`, we cannot know whether `x` "
       "contains nans. Please check if nans exist in `x` outside of the "
       "`rankdata` function."
     )
@@ -196,29 +196,34 @@ def rankdata(
   if method not in ("average", "min", "max", "dense", "ordinal"):
     raise ValueError(f"unknown method '{method}'")
 
-  a = jnp.asarray(a)
-
   if axis is not None:
     return jnp.apply_along_axis(rankdata, axis, a, method)
 
-  arr = jnp.ravel(a)
-  arr, sorter = lax.sort_key_val(arr, jnp.arange(arr.size))
-  inv = invert_permutation(sorter)
+  a = jnp.ravel(a)
+  out_dtype = dtypes.to_inexact_dtype(a.dtype)
 
-  if method == "ordinal":
-    return inv + 1
-  obs = jnp.concatenate([jnp.array([True]), arr[1:] != arr[:-1]])
-  dense = obs.cumsum()[inv]
-  if method == "dense":
-    return dense
-  count = jnp.nonzero(obs, size=arr.size + 1, fill_value=obs.size)[0]
-  if method == "max":
-    return count[dense]
-  if method == "min":
-    return count[dense - 1] + 1
-  if method == "average":
-    return .5 * (count[dense] + count[dense - 1] + 1).astype(dtypes.default_float_dtype())
-  raise ValueError(f"unknown method '{method}'")
+  def _rankdata(a: Array) -> Array:
+    arr, sorter = lax.sort_key_val(a, jnp.arange(a.size))
+    inv = invert_permutation(sorter)
+
+    if method == "ordinal":
+      return (inv + 1).astype(out_dtype)
+    obs = jnp.concatenate([jnp.array([True]), arr[1:] != arr[:-1]])
+    dense = obs.cumsum()[inv]
+    if method == "dense":
+      return dense.astype(out_dtype)
+    count = jnp.nonzero(obs, size=arr.size + 1, fill_value=obs.size)[0].astype(out_dtype)
+    if method == "max":
+      return count[dense]
+    if method == "min":
+      return count[dense - 1] + 1
+    if method == "average":
+      return .5 * (count[dense] + count[dense - 1] + 1)
+    raise ValueError(f"unknown method '{method}'")
+
+  return lax.cond(jnp.any(jnp.isnan(a)),
+                  lambda a: jnp.full_like(a, jnp.nan, out_dtype),
+                  _rankdata, a)
 
 
 @api.jit(static_argnames=['axis', 'nan_policy', 'keepdims'])

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -2012,11 +2012,12 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       for axis in [None, *range(len(shape))
     ]],
     dtype=jtu.dtypes.integer + jtu.dtypes.floating,
-    method=['average', 'min', 'max', 'dense', 'ordinal']
+    method=['average', 'min', 'max', 'dense', 'ordinal'],
+    sampler=[jtu.rand_default, jtu.rand_some_nan],
   )
-  def testRankData(self, shape, dtype, axis, method):
+  def testRankData(self, shape, dtype, axis, method, sampler):
 
-    rng = jtu.rand_default(self.rng())
+    rng = sampler(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
 
     scipy_fun = partial(osp_stats.rankdata, method=method, axis=axis)


### PR DESCRIPTION
This also allows us to propagate NaN values the same way as scipy in all cases.

Fixes #34490.