### PR TITLE
Use hermetic clang to compile jax

### DIFF
--- a/build/rocm/rocm.bazelrc
+++ b/build/rocm/rocm.bazelrc
@@ -1,19 +1,12 @@
 # Used for ROCm build and test
 
-common:clang_local --noincompatible_enable_cc_toolchain_resolution
-common:clang_local --@rules_ml_toolchain//common:enable_hermetic_cc=False
-common:clang_local --repo_env USE_HERMETIC_CC_TOOLCHAIN=0
-
-common:rocm_base --config=clang_local
-common:rocm_base --crosstool_top=@local_config_rocm//crosstool:toolchain
+common:rocm_base --noincompatible_enable_cc_toolchain_resolution
+common:rocm_base --extra_toolchains=@local_config_rocm//crosstool:toolchain-linux-x86_64-hermetic
 common:rocm_base --define=using_rocm=true --define=using_rocm_hipcc=true
 common:rocm_base --repo_env=TF_NEED_ROCM=1
 
 # Build with hipcc for ROCm and clang for the host.
 common:rocm --config=rocm_base
-common:rocm --action_env=TF_HIPCC_CLANG="1"
-common:rocm --action_env=TF_ROCM_CLANG="1"
-common:rocm --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"
 common:rocm --action_env=HIPCC_COMPILE_FLAGS_APPEND=--offload-compress
 common:rocm --copt=-Wno-gnu-offsetof-extensions
 common:rocm --copt=-Qunused-arguments


### PR DESCRIPTION
Use hermetic clang provided by xla toolchains to build jax