### PR TITLE
Remove internal get_aval alias

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1783,10 +1783,9 @@ def update_aval_with_sharding(aval, sharding, manual_type=None):
 # their own separate implementation. Now they're effectively the same, with the
 # following differences:
 #
-# - typeof is like abstractify, but also accepts tracers.
+# - typeof returns avals for valid array-like objects, including tracers.
 # - shaped_abstractify is like typeof, but also accepts duck-typed arrays.
 #
-# TODO(jakevdp): can these be unified further?
 
 def shaped_abstractify(x):
   typ = type(x)
@@ -1834,9 +1833,6 @@ def typeof(x: Any) -> Any:
         ' using jax.numpy.array(), or register your object as a pytree.'
     )
   raise TypeError(f"Argument '{x}' of type '{typ}' is not a valid JAX type")
-
-# TODO(phawkins): remove this alias
-get_aval = typeof
 
 def is_concrete(x):
   return to_concrete_value(x) is not None

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -1075,7 +1075,6 @@ def result_type(*args: Any, return_weak_type_flag: bool = False) -> DType | tupl
   dtype, weak_type = lattice_result_type(*(default_float_dtype() if arg is None else arg for arg in args))
   if weak_type:
     dtype = default_types['f' if dtype in _custom_float_dtypes else dtype.kind]()
-  # TODO(jakevdp): fix return type annotation and remove this ignore.
   return (dtype, weak_type) if return_weak_type_flag else dtype
 
 def check_and_canonicalize_user_dtype(dtype, fun_name=None) -> DType:

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -39,7 +39,7 @@ from jax._src import source_info_util
 from jax._src import tree_util
 from jax._src import xla_metadata_lib
 from jax._src.core import (
-    Trace, Tracer, TraceTag, Jaxpr, Literal, get_aval, AbstractValue,
+    Trace, Tracer, TraceTag, Jaxpr, Literal, AbstractValue,
     ClosedJaxpr, new_jaxpr_eqn, Var, DropVar, Atom, JaxprEqn, Primitive,
     get_referent, JaxprEqnContext, typeof)
 from jax._src.lib import _jax
@@ -105,7 +105,7 @@ class PartialVal(tuple):
     """Get AbstractValue directly (if unknown) or from the constant (known)."""
     known = self.get_known()
     if known is not None:
-      return get_aval(known)
+      return typeof(known)
     else:
       return self[0]
 
@@ -138,11 +138,11 @@ class JaxprTrace(Trace):
     return JaxprTracer(self, PartialVal.known(val), None)
 
   def new_instantiated_literal(self, val) -> JaxprTracer:
-    aval = get_aval(val)
+    aval = typeof(val)
     return JaxprTracer(self, PartialVal.unknown(aval), Literal(val, aval))
 
   def new_instantiated_const(self, val) -> JaxprTracer:
-    aval = get_aval(val)
+    aval = typeof(val)
     return JaxprTracer(self, PartialVal.unknown(aval), ConstVar(val))
 
   def new_arg(self, pval: PartialVal) -> JaxprTracer:
@@ -1902,7 +1902,7 @@ class DynamicJaxprTrace(core.Trace):
     tracer = self.frame.constid_to_tracer.get(id(c))
     if tracer is None:
       if aval is None:
-        aval = get_aval(c)
+        aval = typeof(c)
       if aval.has_qdd:
         with core.set_current_trace(self.parent_trace or core.eval_trace):
           aval = core.AvalQDD(aval, core.cur_qdd(c))  # type: ignore
@@ -2007,7 +2007,7 @@ class DynamicJaxprTrace(core.Trace):
                    params, /):
     source_info = source_info_util.current()
     to_jaxpr_tracer = partial(self.to_jaxpr_tracer, source_info=source_info)
-    in_type = (tuple(get_aval(t) for t in in_tracers) if f.in_type is None
+    in_type = (tuple(typeof(t) for t in in_tracers) if f.in_type is None
                else f.in_type)
     f.in_type = None
     assert in_type is not None


### PR DESCRIPTION
The deprecated public alias (`jax.core.get_aval`) is now removed, so we can now clean up the internal alias.