### PR TITLE
[shard_map] Raise TypeError for eager new_ref tracing

### DIFF
--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -1317,6 +1317,12 @@ class ShardMapTrace(core.Trace):
       return val_, core.ManualAxisType()
 
   def process_primitive(self, prim, tracers, params, /):
+    if prim.name == 'new_ref':
+        raise TypeError(
+            "Detected `jax.lax.new_ref` inside an eager `shard_map`. "
+            "This is not supported because eager execution cannot discharge "
+            "stateful effects. Please wrap your function in `@jax.jit`."
+        )
     in_vals, in_mat = unzip2(map(self.to_val_mat_pair, tracers))
     if self.check:
       out_avals, _ = prim.abstract_eval(*(typeof(t) for t in tracers), **params)

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -1317,12 +1317,12 @@ class ShardMapTrace(core.Trace):
       return val_, core.ManualAxisType()
 
   def process_primitive(self, prim, tracers, params, /):
-    if prim.name == 'new_ref':
-        raise TypeError(
-            "Detected `jax.lax.new_ref` inside an eager `shard_map`. "
-            "This is not supported because eager execution cannot discharge "
-            "stateful effects. Please wrap your function in `@jax.jit`."
-        )
+    if prim is core.ref_p or prim is core.empty_ref_p:
+    raise TypeError(
+        f"Detected primitive {prim.name} inside an eager `shard_map`. "
+        "This is not supported because eager execution cannot discharge "
+        "stateful effects. Please wrap your function in `@jax.jit`."
+    )
     in_vals, in_mat = unzip2(map(self.to_val_mat_pair, tracers))
     if self.check:
       out_avals, _ = prim.abstract_eval(*(typeof(t) for t in tracers), **params)


### PR DESCRIPTION
<!--This PR adds a safety check to ShardMapTrace to prevent stateful operations (like new_ref) from being executed in eager mode. Previously, this would result in a confusing low-level NotImplementedError during MLIR translation. This change provides a human-readable TypeError directing users to use @jax.jit instead.
