### PR TITLE
Allow passing real client for cross-compilation

### DIFF
--- a/jax/_src/compiler.py
+++ b/jax/_src/compiler.py
@@ -35,6 +35,7 @@ from jax._src import path as pathlib
 from jax._src import profiler
 from jax._src import traceback_util
 from jax._src import util
+from jax._src import xla_bridge as xb
 from jax._src.interpreters import mlir
 from jax._src.lib import xla_client as xc
 from jax._src.lib import _jax
@@ -67,6 +68,24 @@ traceback_util.register_exclusion(__file__)
 CompileOptions = xc.CompileOptions
 
 logger = logging.getLogger(__name__)
+
+
+def _get_cross_compile_backend(compile_only_backend):
+  """Returns a real backend for cross-compilation via a real client.
+
+  When cross-compiling via a compile-only client, checks if a real backend
+  is available for the same platform. If so, returns it so compilation can
+  leverage real hardware (e.g., for GPU kernel autotuning).
+  """
+  platform = compile_only_backend.platform
+  try:
+    real_backend = xb.get_backend(platform)
+  except Exception:
+    return None
+  # Don't use the real backend if it's also a compile-only client.
+  if isinstance(real_backend, _jax.CompileOnlyPyClient):
+    return None
+  return real_backend
 
 
 # Will be monkeypatched with the function that gets the XLA-AutoFDO profile
@@ -306,6 +325,17 @@ def backend_compile_and_load(
     # separately in Python profiling results
     # TODO(dsuo): Simplify this logic once we delete _jax.CompileOnlyPyClient.
     if isinstance(backend, _jax.CompileOnlyPyClient):
+      # When a real backend is available for the same platform, use it for
+      # cross-compilation. The real client provides hardware access (e.g.,
+      # for GPU kernel autotuning) while the topology specifies the target.
+      cross_compile_backend = _get_cross_compile_backend(backend)
+      if cross_compile_backend is not None and not host_callbacks:
+        cross_compile_topology = xc.get_topology_for_devices(backend.devices())
+        return cross_compile_backend.compile(  # type: ignore
+            module,
+            topology=cross_compile_topology,
+            compile_options=options,
+        )
       if host_callbacks:
         return backend.compile(  # type: ignore
             module,

--- a/jaxlib/_jax/__init__.pyi
+++ b/jaxlib/_jax/__init__.pyi
@@ -874,10 +874,18 @@ class Client:
   def process_index(self) -> int: ...
   def host_id(self) -> int: ...
   def task_id(self) -> int: ...
+  @overload
   def compile(
       self,
       computation: object,
       executable_devices: DeviceList,
+      compile_options: CompileOptions = ...,
+  ) -> Executable: ...
+  @overload
+  def compile(
+      self,
+      computation: object,
+      topology: DeviceTopology,
       compile_options: CompileOptions = ...,
   ) -> Executable: ...
   @overload

--- a/jaxlib/py_client.cc
+++ b/jaxlib/py_client.cc
@@ -442,35 +442,52 @@ PyClient::CompileAndLoadIfrtProgram(
                                            std::move(fingerprint));
 }
 
-/* static */ absl::StatusOr<nb_class_ptr<PyExecutable>> PyClient::Compile(
-    nb_class_ptr<PyClient> client, mlir::ModuleOp module,
-    ifrt::DeviceListRef executable_devices, xla::CompileOptions options) {
+static absl::StatusOr<nb_class_ptr<PyExecutable>>
+CompileWithTopology(nb_class_ptr<PyClient> client, mlir::ModuleOp module,
+                    const xla::ifrt::Topology &topology,
+                    xla::CompileOptions options, ifrt::DeviceListRef devices) {
   mlir::OwningOpRef<mlir::ModuleOp> clone(module.clone());
-  module = *clone;
+  options.allow_in_place_mlir_modification = true;
   ifrt::ExecutableRef ifrt_executable;
   {
-    TF_ASSIGN_OR_RETURN(
-        auto topology,
-        client->ifrt_client()->GetTopologyForDevices(executable_devices));
-    auto xla_options = std::make_unique<ifrt::XlaCompileOptions>(
-        options, std::move(executable_devices));
+    auto xla_options =
+        std::make_unique<ifrt::XlaCompileOptions>(options, std::move(devices));
 #if JAX_IFRT_VERSION_NUMBER >= 47
-    TF_ASSIGN_OR_RETURN(ifrt_executable,
-                        client->ifrt_client()
-                            ->GetDefaultCompiler()
-                            ->Compile(std::make_unique<xla::ifrt::HloProgram>(
-                                          std::move(module)),
-                                      *topology, std::move(xla_options))
-                            .Await());
+    TF_ASSIGN_OR_RETURN(
+        ifrt_executable,
+        client->ifrt_client()
+            ->GetDefaultCompiler()
+            ->Compile(std::make_unique<xla::ifrt::HloProgram>(std::move(clone)),
+                      topology, std::move(xla_options))
+            .Await());
 #else
     TF_ASSIGN_OR_RETURN(
         ifrt_executable,
         client->ifrt_client()->GetDefaultCompiler()->Compile(
-            std::make_unique<xla::ifrt::HloProgram>(std::move(module)),
-            *topology, std::move(xla_options)));
+            std::make_unique<xla::ifrt::HloProgram>(std::move(clone)), topology,
+            std::move(xla_options)));
 #endif
   }
   return make_nb_class<PyExecutable>(ifrt_executable);
+}
+
+absl::StatusOr<nb_class_ptr<PyExecutable>>
+PyClient::Compile(nb_class_ptr<PyClient> client, mlir::ModuleOp module,
+                  ifrt::DeviceListRef executable_devices,
+                  xla::CompileOptions options) {
+  TF_ASSIGN_OR_RETURN(
+      auto topology,
+      client->ifrt_client()->GetTopologyForDevices(executable_devices));
+  return CompileWithTopology(std::move(client), module, *topology,
+                             std::move(options), std::move(executable_devices));
+}
+
+absl::StatusOr<nb_class_ptr<PyExecutable>>
+PyClient::Compile(nb_class_ptr<PyClient> client, mlir::ModuleOp module,
+                  std::shared_ptr<xla::ifrt::Topology> topology,
+                  xla::CompileOptions options) {
+  return CompileWithTopology(std::move(client), module, *topology,
+                             std::move(options), ifrt::DeviceListRef());
 }
 
 /* static */ absl::StatusOr<nb_class_ptr<PyLoadedExecutable>>
@@ -818,6 +835,27 @@ PyType_Slot PyClient::slots_[] = {
               "self, "
               "computation: object, "
               "executable_devices: DeviceList, "
+              "compile_options: CompileOptions = ..."
+              ") -> Executable"
+              // clang-format on
+              ))
+      .def(
+          "compile",
+          [](nb_class_ptr<PyClient> client, MlirModule mlir_module,
+             std::shared_ptr<xla::ifrt::Topology> topology,
+             xla::CompileOptions options) {
+            return xla::ValueOrThrow(PyClient::Compile(
+                std::move(client), unwrap(mlir_module), std::move(topology),
+                std::move(options)));
+          },
+          nb::arg("computation"), nb::arg("topology"),
+          nb::arg("compile_options") = xla::CompileOptions(),
+          nb::sig(
+              // clang-format off
+              "def compile("
+              "self, "
+              "computation: object, "
+              "topology: DeviceTopology, "
               "compile_options: CompileOptions = ..."
               ") -> Executable"
               // clang-format on

--- a/jaxlib/py_client.h
+++ b/jaxlib/py_client.h
@@ -168,6 +168,11 @@ class PyClient {
       nb_class_ptr<PyClient> client, mlir::ModuleOp mlir_module,
       xla::ifrt::DeviceListRef executable_devices, xla::CompileOptions options);
 
+  static absl::StatusOr<nb_class_ptr<PyExecutable>>
+  Compile(nb_class_ptr<PyClient> client, mlir::ModuleOp mlir_module,
+          std::shared_ptr<xla::ifrt::Topology> topology,
+          xla::CompileOptions options);
+
   static absl::StatusOr<nb_class_ptr<PyLoadedExecutable>> CompileAndLoad(
       nb_class_ptr<PyClient> client, mlir::ModuleOp mlir_module,
       xla::ifrt::DeviceListRef executable_devices, xla::CompileOptions options,

--- a/tests/aot_test.py
+++ b/tests/aot_test.py
@@ -286,5 +286,48 @@ class JaxAotTest(jtu.JaxTestCase):
     result = compiled(input)
     self.assertEqual(result, 14.)
 
+  @jtu.run_on_devices('gpu')
+  def test_cross_compile_with_real_gpu(self):
+    """Test that cross-compilation uses the real GPU for autotuning."""
+    target_config = xc.get_topology_for_devices(jax.devices()).target_config
+    gpu_platform = jax.devices()[0].platform
+
+    # Create a compile-only topology, but DON'T switch to CPU so the real
+    # GPU backend remains available for cross-compilation with autotuning.
+    topology = topologies.get_topology_desc(
+        platform=gpu_platform,
+        target_config=target_config,
+        topology="1x1x1",
+    )
+    assert topology.devices[0].client.runtime_type == "compile_only_runtime"
+    mesh = topologies.make_mesh(
+        topo=topology, mesh_shape=(1,), axis_names=("x",)
+    )
+    x = jax.ShapeDtypeStruct(
+        shape=(2, 2),
+        dtype=jnp.float32,
+        sharding=jax.sharding.NamedSharding(
+            mesh, jax.sharding.PartitionSpec("x")
+        ),
+    )
+    compiled = jax.jit(lambda x: jnp.sum(x * x)).lower(x).compile()
+    serialized_executable, _, _ = serialize(compiled)
+
+    _, in_tree = jax.tree.flatten(((0,), {}))
+    _, out_tree = jax.tree.flatten(0)
+    compiled = deserialize_and_load(
+        serialized_executable,
+        in_tree,
+        out_tree,
+        backend=gpu_platform,
+        execution_devices=jax.devices()[:1],
+    )
+    input = jnp.array(
+        [[0., 1.], [2., 3.]], dtype=jnp.float32, device=jax.devices()[0]
+    )
+    result = compiled(input)
+    self.assertEqual(result, 14.)
+
+
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
When we are cross-compiling for a given topology and have local client with compatible backend, we can use it at compile time for auto tuning. 

This is a JAX change that corresponds to XLA change: https://github.com/openxla/xla/pull/40132