### PR TITLE
[ROCm] fix: wire up clone_main_xla for ROCm builds and tests

### DIFF
--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -96,7 +96,7 @@ jobs:
         shell: bash
     runs-on: ${{ inputs.runner }}
     container:
-      image: "rocm/tensorflow-build@sha256:30e7fcfad87b74a4b916565a6156f4d8d01a2f5a4e06d0d0e6c37926a1507d72"
+      image: ghcr.io/rocm/jax-dev-ubu24.${{ inputs.rocm-tag }}:latest
       volumes:
         - /data:/data
       options: >-
@@ -106,6 +106,10 @@ jobs:
         --group-add video
         --shm-size 64G
         --env-file /etc/podinfo/gha-gpu-isolation-settings
+
+    env:
+      JAXCI_CLONE_MAIN_XLA: ${{ inputs.clone_main_xla }}
+
 # Begin Presubmit Naming Check - name modification requires internal check to be updated
     name: "linux x86, jaxlib=${{ inputs.jaxlib-version }}, ROCM=${{ inputs.rocm-version }}, Python=${{ inputs.python }}, x64=${{ inputs.enable-x64 }}, build_jax=${{ inputs.build_jax }}, build_jaxlib=${{ inputs.build_jaxlib }}"
 # End Presubmit Naming Check github-rocm-presubmits
@@ -127,6 +131,20 @@ jobs:
         uses: google-ml-infra/actions/ci_connection@7f5ca0c263a81ed09ea276524c1b9192f1304e3c
         with:
           halt-dispatch-input: ${{ inputs.halt-for-connection }}
+      - name: Resolve RBE container image digest
+        id: rbe-image
+        run: |
+          IMAGE="ghcr.io/rocm/jax-dev-ubu24.${{ inputs.rocm-tag }}"
+          REPO="rocm/jax-dev-ubu24.${{ inputs.rocm-tag }}"
+          TOKEN=$(curl -sf "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO}:pull" | \
+            python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+          echo "::add-mask::${TOKEN}"
+          DIGEST=$(curl -sfI "https://ghcr.io/v2/${REPO}/manifests/latest" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Accept: application/vnd.docker.distribution.manifest.v2+json" | \
+            grep -i docker-content-digest | awk '{print $2}' | tr -d '\r\n')
+          echo "RBE image: ${IMAGE}@${DIGEST}"
+          echo "rbe_image=${IMAGE}@${DIGEST}" >> "$GITHUB_OUTPUT"
       - name: "Bazel ROCm tests with build_jax=${{ inputs.build_jax }}, build_jaxlib=${{ inputs.build_jaxlib }}"
         timeout-minutes: 120
         run: |
@@ -137,7 +155,7 @@ jobs:
             --//jax:build_jax="${{ inputs.build_jax }}" \
             --repo_env=HERMETIC_PYTHON_VERSION="${{ inputs.python }}" \
             --action_env=JAX_ENABLE_X64="${{ inputs.enable-x64 }}" \
-            --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="rocm/tensorflow-build@sha256:30e7fcfad87b74a4b916565a6156f4d8d01a2f5a4e06d0d0e6c37926a1507d72" \
+            --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="${{ steps.rbe-image.outputs.rbe_image }}" \
             ${JAXCI_ROCM_LOCK_FLAG:-}
       - name: Upload test artifacts
         if: always()

--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -120,6 +120,7 @@ jobs:
 
     env:
       JAXCI_HERMETIC_PYTHON_VERSION: "${{ inputs.python }}"
+      JAXCI_CLONE_MAIN_XLA: "${{ inputs.clone_main_xla }}"
       JAXCI_OUTPUT_DIR: "${{ github.workspace }}/dist"
 
     name: "${{ inputs.artifact }}, py ${{ inputs.python }}, ROCm ${{ inputs.rocm-version }}"
@@ -139,19 +140,12 @@ jobs:
         uses: google-ml-infra/actions/ci_connection@7f5ca0c263a81ed09ea276524c1b9192f1304e3c
         with:
           halt-dispatch-input: ${{ inputs.halt-for-connection }}
-      - name: Create dist dir
-        run: mkdir -p $JAXCI_OUTPUT_DIR/
       - name: Build ${{ inputs.artifact }}
         timeout-minutes: 120
-        run: |
-          bazel --bazelrc=build/rocm/rocm.bazelrc run \
-                --config=rocm_release_wheel \
-                --config=rocm_rbe \
-                --repo_env=HERMETIC_PYTHON_VERSION="${{ inputs.python }}" \
-                ${{ inputs.wheel-version-suffix && format('--action_env=WHEEL_VERSION_SUFFIX={0}', inputs.wheel-version-suffix) || '' }} \
-                $DEPLOY_TARGET -- $JAXCI_OUTPUT_DIR/
+        run: ./ci/build_rocm_artifacts.sh "$INPUTS_ARTIFACT"
         env:
-          DEPLOY_TARGET: ${{ inputs.artifact == 'jax-rocm-plugin' && '//jaxlib/tools:deploy_rocm_plugin_wheel' || '//jaxlib/tools:deploy_rocm_pjrt_wheel' }}
+          INPUTS_ARTIFACT: ${{ inputs.artifact }}
+          JAXCI_WHEEL_VERSION_SUFFIX: ${{ inputs.wheel-version-suffix }}
       - name: Configure AWS Credentials
         if: ${{ inputs.upload_artifacts_to_s3 }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # ratchet:aws-actions/configure-aws-credentials@v6

--- a/ci/build_rocm_artifacts.sh
+++ b/ci/build_rocm_artifacts.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Build ROCm JAX artifacts.
+# Usage: ./ci/build_rocm_artifacts.sh "<artifact>"
+# Supported artifact values are: jax-rocm-plugin, jax-rocm-pjrt
+#
+# -e: abort script if one command fails
+# -u: error if undefined variable used
+# -x: log all commands
+# -o history: record shell history
+# -o allexport: export all functions and variables to be available to subscripts
+set -exu -o history -o allexport
+
+artifact="$1"
+
+# Source default JAXCI environment variables.
+source ci/envs/default.env
+
+# Clone XLA at HEAD if path to local XLA is not provided
+if [[ -z "$JAXCI_XLA_GIT_DIR" && -z "$JAXCI_CLONE_MAIN_XLA" ]]; then
+    export JAXCI_CLONE_MAIN_XLA=1
+fi
+
+# Set up the build environment.
+source "ci/utilities/setup_build_environment.sh"
+
+allowed_artifacts=("jax-rocm-plugin" "jax-rocm-pjrt")
+
+if [[ ! " ${allowed_artifacts[*]} " =~ " ${artifact} " ]]; then
+  echo "Error: Invalid artifact: $artifact. Allowed values are: ${allowed_artifacts[*]}"
+  exit 1
+fi
+
+# Determine the artifact tag flags based on the artifact type, mirroring
+# ci/build_artifacts.sh.
+if [[ "$JAXCI_ARTIFACT_TYPE" == "release" ]]; then
+  artifact_tag_flags="--bazel_options=--repo_env=ML_WHEEL_TYPE=release --bazel_options=--//jaxlib/tools:jaxlib_git_hash=$(git rev-parse HEAD)"
+elif [[ "$JAXCI_ARTIFACT_TYPE" == "nightly" ]]; then
+  current_date=$(date +%Y%m%d)
+  artifact_tag_flags="--bazel_options=--repo_env=ML_WHEEL_BUILD_DATE=${current_date} --bazel_options=--repo_env=ML_WHEEL_TYPE=nightly --bazel_options=--//jaxlib/tools:jaxlib_git_hash=$(git rev-parse HEAD)"
+elif [[ "$JAXCI_ARTIFACT_TYPE" == "default" ]]; then
+  artifact_tag_flags="--bazel_options=--repo_env=ML_WHEEL_TYPE=custom --bazel_options=--repo_env=ML_WHEEL_BUILD_DATE=$(git show -s --format=%as HEAD) --bazel_options=--repo_env=ML_WHEEL_GIT_HASH=$(git rev-parse HEAD) --bazel_options=--//jaxlib/tools:jaxlib_git_hash=$(git rev-parse HEAD)"
+else
+  echo "Error: Invalid artifact type: $JAXCI_ARTIFACT_TYPE. Allowed values are: release, nightly, default"
+  exit 1
+fi
+
+override_xla_repo=""
+if [[ "$JAXCI_CLONE_MAIN_XLA" == 1 ]]; then
+  override_xla_repo="--bazel_options=--override_repository=xla=${JAXCI_XLA_GIT_DIR}"
+fi
+
+wheel_version_suffix_flag=""
+if [[ -n "${JAXCI_WHEEL_VERSION_SUFFIX:-}" ]]; then
+  wheel_version_suffix_flag="--bazel_options=--repo_env=ML_WHEEL_VERSION_SUFFIX=${JAXCI_WHEEL_VERSION_SUFFIX}"
+fi
+
+bazel_startup_options=""
+if [[ -n "${JAXCI_BAZEL_OUTPUT_BASE}" ]]; then
+  bazel_startup_options="--bazel_startup_options=--output_base=${JAXCI_BAZEL_OUTPUT_BASE}"
+fi
+
+echo "Building $artifact..."
+
+python build/build.py build --wheels="$artifact" \
+  --bazel_startup_options="--bazelrc=build/rocm/rocm.bazelrc" \
+  $bazel_startup_options \
+  --bazel_options=--config=rocm_release_wheel \
+  --bazel_options=--config=rocm_rbe \
+  --python_version=$JAXCI_HERMETIC_PYTHON_VERSION \
+  --verbose --detailed_timestamped_log \
+  --output_path="$JAXCI_OUTPUT_DIR" \
+  $artifact_tag_flags \
+  $override_xla_repo \
+  $wheel_version_suffix_flag
+
+# Verify manylinux compliance.
+./ci/utilities/run_auditwheel.sh

--- a/ci/run_bazel_test_rocm_rbe.sh
+++ b/ci/run_bazel_test_rocm_rbe.sh
@@ -23,6 +23,22 @@
 # -o allexport: export all functions and variables to be available to subscripts
 set -exu -o history -o allexport
 
+# Source default JAXCI environment variables.
+source ci/envs/default.env
+
+# Clone XLA at HEAD if path to local XLA is not provided
+if [[ -z "$JAXCI_XLA_GIT_DIR" && -z "$JAXCI_CLONE_MAIN_XLA" ]]; then
+    export JAXCI_CLONE_MAIN_XLA=1
+fi
+
+# Set up the build environment.
+source "ci/utilities/setup_build_environment.sh"
+
+OVERRIDE_XLA_REPO=""
+if [[ "$JAXCI_CLONE_MAIN_XLA" == 1 ]]; then
+  OVERRIDE_XLA_REPO="--override_repository=xla=${JAXCI_XLA_GIT_DIR}"
+fi
+
 # Run Bazel GPU tests with RBE (single accelerator tests with one GPU apiece).
 echo "Running RBE GPU tests..."
 
@@ -85,6 +101,7 @@ done
 bazel --bazelrc=build/rocm/rocm.bazelrc test \
     --config=rocm \
     --config=rocm_rbe_dynamic \
+    $OVERRIDE_XLA_REPO \
     --test_env=XLA_PYTHON_CLIENT_ALLOCATOR=platform \
     --test_output=errors \
     --test_env=TF_CPP_MIN_LOG_LEVEL=0 \


### PR DESCRIPTION
## Summary

Fix missing `clone_main_xla` plumbing in the ROCm CI pipeline and switch the
Bazel ROCm CI to the `jax-dev` container family.

### Wire up `clone_main_xla` for ROCm (mirroring CUDA)

- **`bazel_rocm.yml`**: Add `env` block mapping the `clone_main_xla` workflow input to `JAXCI_CLONE_MAIN_XLA` (as `bazel_cuda.yml` does).
- **`run_bazel_test_rocm_rbe.sh`**: Source `ci/envs/default.env` and `ci/utilities/setup_build_environment.sh`, then construct and pass `--override_repository=xla=...` to Bazel (as `run_bazel_test_cuda_rbe.sh` does).
- **`ci/build_rocm_artifacts.sh`** (**new**): Create a dedicated build script mirroring `ci/build_artifacts.sh` that handles environment setup, XLA cloning, and the Bazel build command — consolidating logic that was previously inlined in workflow steps.
- **`build_rocm_artifacts.yml`**: Add `JAXCI_CLONE_MAIN_XLA` to the env block and delegate the build to `ci/build_rocm_artifacts.sh`.

The `clone_main_xla` input was already passed as `1` by `bazel_rocm_presubmit.yml` and `wheel_tests_continuous.yml` but was silently ignored — these callers now correctly build and test against ToT XLA.

### Switch Bazel ROCm CI to `jax-dev` container

- **`bazel_rocm.yml`**: Replace the pinned `rocm/tensorflow-build` container with `ghcr.io/rocm/jax-dev-ubu24.<rocm-tag>:latest` for both the runner and RBE executor.
- **Dynamic RBE digest resolution**: EngFlow RBE requires `docker://<repo>@sha256:<digest>` format. Add a step that resolves the `:latest` tag to its SHA256 digest at runtime via the GHCR registry API (anonymous OCI token exchange), so the workflow always uses the latest image without hardcoding digests.

## Test plan

- Manually triggered `CI - Wheel Tests (Continuous)` (ROCm-only subset) on a test branch to validate end-to-end.