### PR TITLE
add jvp rule for qr_multiply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 * New features:
   * Added `ResizeMethod.CUBIC_PYTORCH` to {func}`jax.image.resize` to match
     PyTorch's bicubic resize ({jax-issue}`#15768`).
+  * Added {func}`jax.scipy.linalg.qr_multiply` and lower-level 
+    {func}`jax.lax.linalg.qr_multiply` for more efficient QR solves.
   * We now support differentiation of {func}`jax.lax.linalg.qr` for wide
     matrices and when `full_matrices` is `True`.
 

--- a/docs/jax.lax.rst
+++ b/docs/jax.lax.rst
@@ -259,6 +259,7 @@ Linear algebra operators (jax.lax.linalg)
     ormqr
     qdwh
     qr
+    qr_multiply
     schur
     svd
     SvdAlgorithm

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -443,6 +443,60 @@ def qr(x: ArrayLike, *, pivoting: bool = False, full_matrices: bool = True,
   return q, r
 
 
+@overload
+def qr_multiply(a: ArrayLike, c: ArrayLike, *,
+                left: bool = False,
+                pivoting: Literal[False] = False, conjugate: bool = False,
+                use_magma: bool | None = None) -> tuple[Array, Array]:
+  ...
+
+@overload
+def qr_multiply(a: ArrayLike, c: ArrayLike, *,
+                left: bool = False,
+                pivoting: Literal[True], conjugate: bool = False,
+                use_magma: bool | None = None) -> tuple[Array, Array, Array]:
+  ...
+
+@overload
+def qr_multiply(a: ArrayLike, c: ArrayLike, *,
+                left: bool = False,
+                pivoting: bool = False, conjugate: bool = False,
+                use_magma: bool | None = None
+                ) -> tuple[Array, Array] | tuple[Array, Array, Array]:
+  ...
+
+def qr_multiply(a: ArrayLike, c: ArrayLike, *,
+                left: bool = False,
+                pivoting: bool = False, conjugate: bool = False,
+                use_magma: bool | None = None
+                ) -> tuple[Array, Array] | tuple[Array, Array, Array]:
+  r"""QR decomposition and multiply Q with a matrix.
+
+  Computes ``Q @ c`` (or ``c @ Q``) and ``R`` without materializing Q, where
+  ``A = Q R`` is the QR decomposition of ``a``.
+
+  Args:
+    a: A batch of matrices with shape ``[..., m, n]``.
+    c: Matrix to multiply by Q. For ``left=True``, shape ``[..., k, p]``
+      where ``k = min(m, n)``. For ``left=False``, shape ``[..., p, m]``.
+    left: If ``True``, compute ``Q @ c``. If ``False``, compute ``c @ Q``.
+    pivoting: If ``True``, compute column-pivoted QR and return pivot indices.
+    conjugate: If ``True``, use ``conj(Q)`` (element-wise conjugate) instead
+      of ``Q``. For real arrays this has no effect.
+    use_magma: Locally override the ``jax_use_magma`` flag. If ``True``, the
+      pivoted ``qr`` factorization is computed using MAGMA. If ``False``, the
+      computation is done using LAPACK on the host CPU. If ``None`` (default),
+      the behavior is controlled by the ``jax_use_magma`` flag. This argument is
+      only used on GPU.
+
+  Returns:
+    ``(result, R)`` if ``pivoting=False``, else ``(result, R, P)``.
+  """
+  a, c = core.standard_insert_pvary(a, c)
+  return qr_multiply_p.bind(a, c, left=left, conjugate=conjugate,
+                             pivoting=pivoting, use_magma=use_magma)
+
+
 def schur(
     x: ArrayLike,
     *,
@@ -2167,6 +2221,165 @@ qr_p = linalg_primitive(
     multiple_results=True)
 ad.primitive_jvps[qr_p] = qr_jvp_rule
 mlir.register_lowering(qr_p, mlir.lower_fun(_qr_lowering))
+
+
+# QR Multiply
+
+def _qr_multiply_shape_rule(a_shape, c_shape, *, left, conjugate, pivoting,
+                             use_magma):
+  m, n = a_shape
+  k = core.min_dim(m, n)
+  if left:
+    result_shape = (m, c_shape[1])
+  else:
+    result_shape = (c_shape[0], k)
+  r_shape = (k, n)
+  if pivoting:
+    return (result_shape, r_shape, (n,))
+  return (result_shape, r_shape)
+
+def _qr_multiply_dtype_rule(a_dtype, c_dtype, *, pivoting, **_):
+  if pivoting:
+    return (a_dtype, a_dtype, np.dtype(np.int32))
+  return (a_dtype, a_dtype)
+
+def _qr_multiply_lowering(a, c, *, left, conjugate, pivoting, use_magma):
+  """Factorize a and apply Q to c without materializing Q."""
+  *batch_dims, m, n = a.shape
+  k = min(m, n)
+
+  pvt = None
+  if pivoting:
+    jpvt = lax.full((*batch_dims, n), 0, dtype=np.dtype(np.int32))
+    r_state, pvt, taus_state = geqp3(a, jpvt, use_magma=use_magma)
+    pvt = pvt - 1
+  else:
+    r_state, taus_state = geqrf(a)
+
+  if m > n and left:
+    zeros = lax.full((*c.shape[:-2], m - k, c.shape[-1]), 0, dtype=c.dtype)
+    c = lax.concatenate([c, zeros], dimension=len(c.shape) - 2)
+
+  if conjugate:
+    # Avoid explicit conj call by instead transposing (for free under jit)
+    # and telling LAPACK to compute Hermitian.
+    c = _T(c)
+
+  # conjugate swaps left/right because c and Q change sides when transposing.
+  ormqr_left = left != conjugate
+  cQ = ormqr(r_state, taus_state, c, left=ormqr_left, transpose=conjugate)
+
+  if conjugate:
+    cQ = _T(cQ)
+
+  if not left:
+    cQ = cQ[..., :k]
+
+  r = _triu(r_state[..., :k, :])
+  if pivoting:
+    assert pvt is not None
+    return cQ, r, pvt
+  return cQ, r
+
+def _qr_multiply_jvp_rule(primals, tangents, *, left, conjugate, pivoting,
+                           use_magma):
+  a, c = primals
+  da, dc = tangents
+  *batch_dims, m, n = a.shape
+
+  if m < n:
+    raise NotImplementedError(
+      "qr_multiply JVP only supports m >= n (tall or square matrices)")
+
+  primal_result = qr_multiply_p.bind(a, c, left=left, conjugate=conjugate,
+                                      pivoting=pivoting, use_magma=use_magma)
+  # Capture a before pivoting permutes it; XLA CSE deduplicates the
+  # factorization against the primal's.
+  a_orig = a
+  def apply_Q(x, qr_left, qr_conjugate):
+    return qr_multiply_p.bind(a_orig, x, left=qr_left, conjugate=qr_conjugate,
+                              pivoting=pivoting, use_magma=use_magma)[0]
+
+  P = None
+  if pivoting:
+    cQ, R, P = primal_result
+    # vmap-safe column permutation (see _lu_jvp_rule).
+    permute_cols = lambda x, p: x[..., p]
+    for _ in batch_dims:
+      permute_cols = api.vmap(permute_cols)
+    a = permute_cols(a, P)
+    if type(da) is not ad_util.Zero:
+      da = permute_cols(da, P)
+  else:
+    cQ, R = primal_result
+
+  if type(da) is ad_util.Zero:
+    tangent_cQ = apply_Q(dc, left, conjugate)
+    tangent_R = ad_util.p2tz(R)
+    if pivoting:
+      assert P is not None
+      return primal_result, (tangent_cQ, tangent_R, ad_util.p2tz(P))
+    return primal_result, (tangent_cQ, tangent_R)
+
+  _maybe_conj = (lambda x: x.conj()) if conjugate else (lambda x: x)
+  qt_da = _T(apply_Q(_T(da), False, True))
+  qt_da_rinv = triangular_solve(R, qt_da)
+
+  # dr_rinv = dR @ R^{-1}, computed directly as the upper-triangular
+  # Hermitian projection of qt_da_rinv.
+  # Eye trick: more flops than scatter but can perform slightly better on
+  # modern accelerators. Matches the pattern used in qr_jvp_rule.
+  n = qt_da_rinv.shape[-1]
+  dr_rinv = _triu(qt_da_rinv, 1) + _triu(_H(qt_da_rinv), 1)
+  I = lax.expand_dims(lax._eye(qt_da_rinv.dtype, (n, n)),
+                      range(qt_da_rinv.ndim - 2))
+  dr_rinv = dr_rinv + I * qt_da_rinv.real.astype(qt_da_rinv.dtype)
+  dR = dr_rinv @ R
+
+  if left:
+    rinv_c = triangular_solve(R, c, left_side=True, conjugate_a=conjugate)
+    tangent_core = -_maybe_conj(dr_rinv) @ c
+    if type(dc) is not ad_util.Zero:
+      tangent_core = tangent_core + dc
+    d_cQ = apply_Q(tangent_core, True, conjugate) + _maybe_conj(da) @ rinv_c
+  else:
+    c_da_rinv = triangular_solve(R, c @ _maybe_conj(da), conjugate_a=conjugate)
+    d_cQ = c_da_rinv - cQ @ _maybe_conj(dr_rinv)
+    if type(dc) is not ad_util.Zero:
+      d_cQ = d_cQ + apply_Q(dc, False, conjugate)
+
+  if pivoting:
+    assert P is not None
+    return primal_result, (d_cQ, dR, ad_util.p2tz(P))
+  return primal_result, (d_cQ, dR)
+
+
+def _qr_multiply_transpose_rule(cotangents, a, c, *, left, conjugate,
+                                 pivoting, use_magma):
+  # qr_multiply is linear in c and nonlinear in a.
+  assert not ad.is_undefined_primal(a) and ad.is_undefined_primal(c)
+
+  cotangent_cQ = cotangents[0]
+
+  # Only cotangent_cQ contributes to c's cotangent (R and P depend only on a).
+  if type(cotangent_cQ) is ad_util.Zero:
+    return [None, ad_util.Zero(c.aval)]
+
+  cotangent_c = _T(qr_multiply_p.bind(a, _T(cotangent_cQ),
+                                       left=not left, conjugate=conjugate,
+                                       pivoting=pivoting, use_magma=use_magma)[0])
+
+  return [None, cotangent_c]
+
+
+qr_multiply_p = linalg_primitive(
+    _qr_multiply_dtype_rule,
+    (_float | _complex,) * 2, (2, 2),
+    _qr_multiply_shape_rule, "qr_multiply",
+    multiple_results=True, require_same=True)
+ad.primitive_jvps[qr_multiply_p] = _qr_multiply_jvp_rule
+ad.primitive_transposes[qr_multiply_p] = _qr_multiply_transpose_rule
+mlir.register_lowering(qr_multiply_p, mlir.lower_fun(_qr_multiply_lowering))
 
 
 # Schur Decomposition

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -1137,41 +1137,17 @@ def qr_multiply(a: ArrayLike, c: ArrayLike, mode: str = 'right',
   a = jnp.broadcast_to(a, batch + a.shape[-2:])
   c = jnp.broadcast_to(c, batch + c.shape[-2:])
 
-  p: Array | None = None
-  if pivoting:
-    jpvt = jnp.zeros(a.shape[:-2] + (n,), dtype=jnp.int32)
-    r, p, taus = lax_linalg.geqp3(a, jpvt)
-    p -= 1  # Convert geqp3's 1-based indices to 0-based indices by subtracting 1.
-  else:
-    r, taus = lax_linalg.geqrf(a)
-
-  if m > n and mode == 'left':
-    zeros = jnp.zeros(c.shape[:-2] + (m - k,) + c.shape[-1:], dtype=c.dtype)
-    c = jnp.concatenate([c, zeros], axis=-2)
-
-  if conjugate:
-    # Avoid explicit jnp.conj call by instead transposing (for free under jit)
-    # and telling LAPACK to compute Hermitian
-    c = c.swapaxes(-1, -2)
-
-  # conjugate swaps left/right because c and Q change sides when transposing.
-  left = (mode == 'left') != conjugate
-  cQ = lax_linalg.ormqr(r, taus, c, left=left, transpose=conjugate)
-
-  if conjugate:
-    cQ = cQ.swapaxes(-1, -2)
-
-  if mode == 'right':
-    cQ = cQ[..., :k]
+  result = lax_linalg.qr_multiply(a, c, left=mode == 'left', pivoting=pivoting,
+                                  conjugate=conjugate)
+  cQ = result[0]
+  r = result[1]
 
   if onedim:
     cQ = cQ.ravel()
 
-  r = jnp.triu(r[..., :k, :])
-
   if pivoting:
-    assert p is not None
-    return cQ, r, p
+    assert len(result) == 3
+    return cQ, r, result[2]
   return cQ, r
 
 

--- a/jax/lax/linalg.py
+++ b/jax/lax/linalg.py
@@ -35,6 +35,8 @@ from jax._src.lax.linalg import (
   ormqr_p as ormqr_p,
   qr as qr,
   qr_p as qr_p,
+  qr_multiply as qr_multiply,
+  qr_multiply_p as qr_multiply_p,
   schur as schur,
   schur_p as schur_p,
   svd as svd,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1986,6 +1986,165 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     self._CompileAndCheck(fn, args_maker)
 
   @jtu.sample_product(
+      shape=[(4, 3), (4, 4), (6, 4)],
+      dtype=float_types + complex_types,
+      conjugate=[False, True],
+  )
+  @jax.default_matmul_precision("highest")
+  def testQrMultiplyJvp(self, shape, dtype, conjugate):
+    """Finite-difference JVP check using the identity cQ @ conj?(R) = c @ conj?(a)."""
+    m, n = shape
+    rng = jtu.rand_default(self.rng())
+    c_shape = (2, m)
+    maybe_conj = jnp.conj if conjugate else lambda x: x
+
+    def qr_mul_identity(a, c):
+      cQ, R = lax.linalg.qr_multiply(a, c, left=False, conjugate=conjugate)
+      return cQ @ maybe_conj(R)
+
+    a = rng(shape, dtype)
+    c = rng(c_shape, dtype)
+    jtu.check_jvp(qr_mul_identity, partial(jvp, qr_mul_identity),
+                  (a, c), atol=5e-2)
+
+  @jtu.sample_product(
+      shape=[(4, 3), (4, 4), (6, 4)],
+      dtype=float_types + complex_types,
+      mode=['right', 'left'],
+      conjugate=[False, True],
+  )
+  @jax.default_matmul_precision("highest")
+  def testQrMultiplyJvpAgainstDense(self, shape, dtype, mode, conjugate):
+    """Verify qr_multiply JVP matches dense QR JVP."""
+    m, n = shape
+
+    rng = jtu.rand_default(self.rng())
+    k = min(m, n)
+    c_shape = (k, 2) if mode == 'left' else (2, m)
+
+    a = rng(shape, dtype)
+    c = rng(c_shape, dtype)
+    da = rng(shape, dtype)
+    dc = rng(c_shape, dtype)
+
+    fn_qm = partial(lax.linalg.qr_multiply, left=mode == 'left', conjugate=conjugate)
+    primals_qm, tangents_qm = jax.jvp(fn_qm, (a, c), (da, dc))
+
+    def fn_dense(a, c):
+      Q, R = jnp.linalg.qr(a, mode='reduced')
+      if mode == 'left' and not conjugate:
+        return Q @ c, R
+      elif mode == 'left' and conjugate:
+        return jnp.conj(Q) @ c, R
+      elif mode == 'right' and not conjugate:
+        return c @ Q, R
+      else:
+        return (c @ jnp.conj(Q))[:, :min(m, n)], R
+
+    primals_d, tangents_d = jax.jvp(fn_dense, (a, c), (da, dc))
+
+    tol = {np.float32: 1e-4, np.complex64: 1e-4, np.float64: 1e-10,
+           np.complex128: 1e-10}
+    self.assertAllClose(primals_qm[0], primals_d[0], rtol=tol, atol=tol)
+    self.assertAllClose(tangents_qm[0], tangents_d[0], rtol=tol, atol=tol)
+    self.assertAllClose(tangents_qm[1], tangents_d[1], rtol=tol, atol=tol)
+
+  @jtu.sample_product(
+      shape=[(4, 3), (4, 4), (6, 4)],
+      dtype=float_types + complex_types,
+      mode=['right', 'left'],
+      conjugate=[False, True],
+  )
+  @jax.default_matmul_precision("highest")
+  def testQrMultiplyJvpPivoting(self, shape, dtype, mode, conjugate):
+    """Verify pivoted qr_multiply JVP matches dense pivoted QR JVP."""
+    m, n = shape
+    if not jtu.test_device_matches(["cpu", "gpu"]):
+      self.skipTest("Pivoting is only supported on CPU and GPU.")
+
+    rng = jtu.rand_default(self.rng())
+    k = min(m, n)
+    c_shape = (k, 2) if mode == 'left' else (2, m)
+
+    a = rng(shape, dtype)
+    c = rng(c_shape, dtype)
+    da = rng(shape, dtype)
+    dc = rng(c_shape, dtype)
+
+    fn_qm = partial(lax.linalg.qr_multiply, left=mode == 'left',
+                    conjugate=conjugate, pivoting=True)
+    primals_qm, tangents_qm = jax.jvp(fn_qm, (a, c), (da, dc))
+
+    def fn_dense(a, c):
+      Q, R, P = jax.scipy.linalg.qr(a, pivoting=True, mode='economic')
+      if mode == 'left' and not conjugate:
+        return Q @ c, R, P
+      elif mode == 'left' and conjugate:
+        return jnp.conj(Q) @ c, R, P
+      elif mode == 'right' and not conjugate:
+        return c @ Q, R, P
+      else:
+        return c @ jnp.conj(Q), R, P
+
+    primals_d, tangents_d = jax.jvp(fn_dense, (a, c), (da, dc))
+
+    tol = {np.float32: 1e-4, np.complex64: 1e-4, np.float64: 1e-10,
+           np.complex128: 1e-10}
+    self.assertAllClose(primals_qm[0], primals_d[0], rtol=tol, atol=tol)
+    self.assertAllClose(tangents_qm[0], tangents_d[0], rtol=tol, atol=tol)
+    self.assertAllClose(tangents_qm[1], tangents_d[1], rtol=tol, atol=tol)
+
+  @jtu.sample_product(
+      shape=[(4, 3), (4, 4), (6, 4)],
+      dtype=float_types + complex_types,
+      mode=['right', 'left'],
+      conjugate=[False, True],
+      pivoting=[False, True],
+  )
+  @jax.default_matmul_precision("highest")
+  def testQrMultiplyVjp(self, shape, dtype, mode, conjugate, pivoting):
+    """Verify qr_multiply VJP (reverse mode) matches dense QR VJP."""
+    m, n = shape
+    if pivoting and not jtu.test_device_matches(["cpu", "gpu"]):
+      self.skipTest("Pivoting is only supported on CPU and GPU.")
+
+    rng = jtu.rand_default(self.rng())
+    k = min(m, n)
+    c_shape = (k, 2) if mode == 'left' else (2, m)
+
+    a = rng(shape, dtype)
+    c = rng(c_shape, dtype)
+
+    def f_qm(a, c):
+      result = lax.linalg.qr_multiply(a, c, left=mode == 'left',
+                                       conjugate=conjugate, pivoting=pivoting)
+      cQ, R = result[0], result[1]
+      return jnp.sum(cQ.real) + jnp.sum(R.real)
+
+    def f_dense(a, c):
+      if pivoting:
+        Q, R, P = jax.scipy.linalg.qr(a, pivoting=True, mode='economic')
+      else:
+        Q, R = jnp.linalg.qr(a, mode='reduced')
+      if mode == 'left' and not conjugate:
+        cQ = Q @ c
+      elif mode == 'left' and conjugate:
+        cQ = jnp.conj(Q) @ c
+      elif mode == 'right' and not conjugate:
+        cQ = c @ Q
+      else:
+        cQ = c @ jnp.conj(Q)
+      return jnp.sum(cQ.real) + jnp.sum(R.real)
+
+    grad_a_qm, grad_c_qm = jax.grad(f_qm, argnums=(0, 1))(a, c)
+    grad_a_d, grad_c_d = jax.grad(f_dense, argnums=(0, 1))(a, c)
+
+    tol = {np.float32: 1e-4, np.complex64: 1e-4, np.float64: 1e-10,
+           np.complex128: 1e-10}
+    self.assertAllClose(grad_a_qm, grad_a_d, rtol=tol, atol=tol)
+    self.assertAllClose(grad_c_qm, grad_c_d, rtol=tol, atol=tol)
+
+  @jtu.sample_product(
       [dict(shape=shape, k=k)
        for shape in [(1, 1), (3, 4, 4), (10, 5)]
        # TODO(phawkins): there are some test failures on GPU for k=0


### PR DESCRIPTION
**Design**

Key equations (see https://j-towns.github.io/papers/qr-derivative.pdf):

$$Q^T dA R^{-1} = dΩ (\mathsf{skew\ symmetric}) + dR R^{-1}( \mathrm{upper\ triangular\ with\ real\ diagonal})$$

$$d(c Q) = dc Q + c dA R^{-1} - c Q dR R^{-1} $$

$$d(Qc) = Q dc + dA R^{-1} c - Q dR R^{-1} c $$

(apologies, GitHub markdown math doesn't allow custom spacing to make this easier to read)

* Based on the current QR JVP rule but designed to never explicitly materialise Q and instead just call the new `_qr_multiply_p.bind`.
* Operations involving c are prioritised as it is like to be thinner than A.
* Factorisation is done before binding the primitive and subject to `stop_gradient`
* New lax function `lax.linalg.qr_multiply` inspired by `lax.linalg.qr` exposing `use_magma` and avoiding any `_qr_multiply_p.bind` calls in `scipy.linalg`
* Instead of extracting a diagonal with a `lax._eye` stencil I've used `.at[...].set(...)` with diagonal indexing, this seems a clear win and I've also implemented this change in the existing qr jvp rule.
* Instead of extracting the skew matrix $dΩ$ from $Q^T dA R^{-1}$ we extract $dR R^{-1}$ by adding triangles together. There wasn't any discernible difference in performance but it seemed a little cleaner. I haven't modified the QR jvp rule  to adopt this, happy to do this if there is interest.

**Performance**

Very good performance when `dc` is the only tangent (matches the primal evaluation).

Performance similar to thin dense QR when `dA` plays a role on MacOS Accelerate. We could just write the jvp rule in terms of dense QR's for simplicity but I think having it in terms of `qr_multiply_p` is quite nice as if we managed to speed up `qr_multiply` the jvp rule will directly benefit (e.g. see my proposal to user `geqrt/gemqrt in scipy's [dev forum](https://discuss.scientific-python.org/t/using-geqrt-and-gemqr-in-qr-multiply/2284) for one option).

**Testing**

Verified with `check_jvp` and directly against dense QR.
