### PR TITLE
[export] Save only unique AbstractValue, AbstractMesh and NamedShardings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     {func}`jax.scipy.linalg.solve_triangular` now show a deprecation warning for
     batched 1D solves with `b.ndim > 1`. In the future these will be treated as
     batched 2D solves.
+  * Added a new version 10 for the jax.export serialization format. This is
+    an optimization for when there are multiple occurrences of the same
+    abstract value, abstract mesh, or sharding.
 
 * Bug fixes:
   * Fixed a bug that led to differing output between CPU and GPU for

--- a/jax/_src/export/serialization.fbs
+++ b/jax/_src/export/serialization.fbs
@@ -126,6 +126,7 @@ table NamedSharding {
   mesh: AbstractMesh;
   spec: PartitionSpec;
   memory_kind: string;
+  abstract_mesh_idx: uint32;  // Index in unique_abstract_meshes (added 4/4/2026, v10)
 }
 
 table AbstractValue {
@@ -194,6 +195,19 @@ table Exported {
 
   vjp: Exported;
   nr_devices: uint32 = 0;  // Added 11/25/2025
+
+  // Added 4/4/2026, v10
+  unique_avals: [AbstractValue];
+  unique_abstract_meshes: [AbstractMesh];
+  unique_named_shardings: [NamedSharding];
+
+  // Indices into unique_avals (added 4/4/2026, v10)
+  in_avals_idxs: [uint32];
+  out_avals_idxs: [uint32];
+
+  // 1-based indices into unique_named_shardings, or 0 if unspecified (added 4/4/2026, v10)
+  in_shardings_idxs: [uint32];
+  out_shardings_idxs: [uint32];
 }
 
 root_type Exported;

--- a/jax/_src/export/serialization.py
+++ b/jax/_src/export/serialization.py
@@ -16,10 +16,12 @@
 
 from __future__ import annotations
 
-import types
+
 from collections.abc import Callable, Iterable
+import dataclasses
 import itertools
 from functools import partial
+import types
 from typing import cast, Any, TypeVar
 
 try:
@@ -67,7 +69,60 @@ SerT = TypeVar("SerT")
 # Version 9, March 17th, 2026, removes HloSharding serialization.
 #   This is another attempt at what Version 7 was supposed to be.
 #   This version is backwards compatible with Version 2 to 8.
-_SERIALIZATION_VERSION = 9
+# Version 10, April 4th, 2026, optimizes serialization of duplicate shardings,
+#   abstract meshes and avals.
+_SERIALIZATION_VERSION = 10
+
+
+@dataclasses.dataclass
+class _SerializedUniques:
+  # Map unique objects to their index in the serialized data.
+  unique_avals: list[core.AbstractValue]
+  avals_map: dict[core.AbstractValue, int]
+  unique_abstract_meshes: list[mesh.AbstractMesh]
+  abstract_meshes_map: dict[mesh.AbstractMesh, int]
+  unique_named_shardings: list[named_sharding.NamedSharding]
+  named_shardings_map: dict[named_sharding.NamedSharding, int]
+
+  @staticmethod
+  def create_from_exported(exp: _export.Exported):
+    uniques = _SerializedUniques([], {}, [], {}, [], {})
+    for aval in itertools.chain(exp.in_avals, exp.out_avals):
+      uniques.add_aval(aval)
+    for sharding in itertools.chain(exp._in_named_shardings,
+                                    exp._out_named_shardings):
+      uniques.add_named_sharding(sharding)
+    return uniques
+
+  @staticmethod
+  def create_from_uniques(unique_avals: list[core.AbstractValue],
+                          unique_abstract_meshes: list[mesh.AbstractMesh],
+                          unique_named_shardings: list[named_sharding.NamedSharding]):
+    uniques = _SerializedUniques([], {}, [], {}, [], {})
+    uniques.unique_avals = unique_avals
+    uniques.avals_map = {a: i for i, a in enumerate(unique_avals)}
+    uniques.unique_abstract_meshes = unique_abstract_meshes
+    uniques.abstract_meshes_map = {m: i for i, m in enumerate(unique_abstract_meshes)}
+    uniques.unique_named_shardings = unique_named_shardings
+    uniques.named_shardings_map = {s: i for i, s in enumerate(unique_named_shardings)}
+    return uniques
+
+  def add_aval(self, aval: core.AbstractValue):
+    if aval not in self.avals_map:
+      self.avals_map[aval] = len(self.unique_avals)
+      self.unique_avals.append(aval)
+
+  def add_named_sharding(self, sharding: named_sharding.NamedSharding | None):
+    if sharding is None:
+      return
+    amesh = sharding.mesh.abstract_mesh
+    if amesh is not None and amesh not in self.abstract_meshes_map:
+      self.abstract_meshes_map[amesh] = len(self.unique_abstract_meshes)
+      self.unique_abstract_meshes.append(amesh)
+    if sharding not in self.named_shardings_map:
+      self.named_shardings_map[sharding] = len(self.unique_named_shardings)
+      self.unique_named_shardings.append(sharding)
+
 
 def serialize(exp: _export.Exported, vjp_order: int = 0) -> bytearray:
   """Serializes an Exported.
@@ -94,19 +149,27 @@ def deserialize(ser: bytearray) -> _export.Exported:
 def _serialize_exported(
     builder: flatbuffers.Builder, exp: _export.Exported, vjp_order: int
 ) -> int:
+  uniques = _SerializedUniques.create_from_exported(exp)
   if not exp._has_named_shardings:
     raise ValueError(
       "Exported being serialized must have named shardings after 3/17/2026.")
   # Serialize bottom-up
   fun_name = builder.CreateString(exp.fun_name)
   in_tree = _serialize_pytreedef(builder, exp.in_tree)
+  # TODO(necula): stop serializing in_avals 1 month after 4/4/26.
   in_avals = _serialize_array(builder, _serialize_aval, exp.in_avals)
+
   out_tree = _serialize_pytreedef(builder, exp.out_tree)
+  # TODO(necula): stop serializing out_avals 1 month after 4/4/26
   out_avals = _serialize_array(builder, _serialize_aval, exp.out_avals)
+  # TODO(necula): stop serializing in_shardings 1 month after 4/4/26
   in_shardings = _serialize_array(
-      builder, _serialize_sharding, exp._in_named_shardings)
+      builder, partial(_serialize_sharding, uniques=uniques),
+      exp._in_named_shardings)
+  # TODO(necula): stop serializing out_shardings 1 month after 4/4/26
   out_shardings = _serialize_array(
-      builder, _serialize_sharding, exp._out_named_shardings)
+      builder, partial(_serialize_sharding, uniques=uniques),
+      exp._out_named_shardings)
   ordered_effects = _serialize_array(
       builder, _serialize_effect, exp.ordered_effects
   )
@@ -133,6 +196,26 @@ def _serialize_exported(
           "order"
       )
     vjp = _serialize_exported(builder, exp.vjp(), vjp_order - 1)
+
+  unique_avals_offset = _serialize_array(
+      builder, _serialize_aval, uniques.unique_avals)
+  unique_abstract_meshes_offset = _serialize_array(
+      builder, _serialize_abstract_mesh, uniques.unique_abstract_meshes)
+  unique_named_shardings_offset = _serialize_array(
+      builder, partial(_serialize_named_sharding, uniques=uniques),
+      uniques.unique_named_shardings)
+
+  in_aval_idxs = builder.CreateNumpyVector(
+    np.array([uniques.avals_map[a] for a in exp.in_avals], dtype=np.uint32))
+  out_aval_idxs = builder.CreateNumpyVector(
+    np.array([uniques.avals_map[a] for a in exp.out_avals], dtype=np.uint32))
+
+  in_shardings_idxs = builder.CreateNumpyVector(
+    np.array([0 if s is None else 1 + uniques.named_shardings_map[s]
+              for s in exp._in_named_shardings], dtype=np.uint32))
+  out_shardings_idxs = builder.CreateNumpyVector(
+    np.array([0 if s is None else 1 + uniques.named_shardings_map[s]
+              for s in exp._out_named_shardings], dtype=np.uint32))
 
   ser_flatbuf.ExportedStart(builder)
   # TODO(necula): we cannot really store the actual serialization_version
@@ -163,6 +246,17 @@ def _serialize_exported(
   )
   if vjp is not None:
     ser_flatbuf.ExportedAddVjp(builder, vjp)
+
+  ser_flatbuf.ExportedAddUniqueAvals(builder, unique_avals_offset)
+  ser_flatbuf.ExportedAddUniqueAbstractMeshes(builder,
+                                              unique_abstract_meshes_offset)
+  ser_flatbuf.ExportedAddUniqueNamedShardings(builder,
+                                              unique_named_shardings_offset)
+  ser_flatbuf.ExportedAddInAvalsIdxs(builder, in_aval_idxs)
+  ser_flatbuf.ExportedAddOutAvalsIdxs(builder, out_aval_idxs)
+  ser_flatbuf.ExportedAddInShardingsIdxs(builder, in_shardings_idxs)
+  ser_flatbuf.ExportedAddOutShardingsIdxs(builder, out_shardings_idxs)
+
   return ser_flatbuf.ExportedEnd(builder)
 
 
@@ -180,11 +274,31 @@ def _serialize_array(
 
 
 def _deserialize_exported(exp: ser_flatbuf.Exported) -> _export.Exported:
+  scope = shape_poly.SymbolicScope(())  # TODO(necula): serialize the constraints
+
+  unique_avals = [  # type: ignore
+      _deserialize_aval(exp.UniqueAvals(i), scope=scope, sharding=None)
+      for i in range(exp.UniqueAvalsLength())]
+  unique_abstract_meshes = [
+      _deserialize_abstract_mesh(exp.UniqueAbstractMeshes(i))
+      for i in range(exp.UniqueAbstractMeshesLength())
+  ]
+  uniques = _SerializedUniques.create_from_uniques(unique_avals,  # type: ignore
+                                                   unique_abstract_meshes,
+                                                   [])
+  unique_named_shardings = [
+      _deserialize_named_sharding(exp.UniqueNamedShardings(i), uniques=uniques)
+      for i in range(exp.UniqueNamedShardingsLength())
+  ]
+  uniques = _SerializedUniques.create_from_uniques(unique_avals,  # type: ignore
+                                                   unique_abstract_meshes,
+                                                   unique_named_shardings)
+
   fun_name = exp.FunctionName().decode("utf-8")
   in_tree = tree_util.tree_structure(
       _deserialize_pytreedef_to_pytree(exp.InTree())
   )
-  scope = shape_poly.SymbolicScope(())  # TODO(necula): serialize the constraints
+
   out_tree = tree_util.tree_structure(
       _deserialize_pytreedef_to_pytree(exp.OutTree())
   )
@@ -193,53 +307,109 @@ def _deserialize_exported(exp: ser_flatbuf.Exported) -> _export.Exported:
   # the field "deprecated" once we abandon the old
   # serialization format (6 months after 11/24/2025).
   nr_devices = exp.NrDevices() or exp.NrDevicesShort()
-  in_shardings = _deserialize_tuple(
-      exp.InShardingsLength, exp.InShardings, _deserialize_sharding
-  )
-  out_shardings = _deserialize_tuple(
-      exp.OutShardingsLength, exp.OutShardings, _deserialize_sharding
-  )
+  def sharding_by_idx(idx):
+    if idx == 0:
+      return None
+    return uniques.unique_named_shardings[idx - 1]
+
+  if exp.InShardingsIdxsLength() > 0:
+    in_shardings = tuple(
+        sharding_by_idx(exp.InShardingsIdxs(i))
+        for i in range(exp.InShardingsIdxsLength())
+    )
+  elif exp.InShardingsLength() > 0:
+    # TODO(necula): remove 6 months after 4/4/26
+    in_shardings = tuple(
+        _deserialize_sharding(exp.InShardings(i), uniques=uniques)
+        for i in range(exp.InShardingsLength())
+    )
+  else:
+    in_shardings = ()
+
+  if exp.OutShardingsIdxsLength() > 0:
+    out_shardings = tuple(
+      sharding_by_idx(exp.OutShardingsIdxs(i))
+      for i in range(exp.OutShardingsIdxsLength())
+    )
+  elif exp.OutShardingsLength() > 0:
+    # TODO(necula): remove 6 months after 4/4/26
+    out_shardings = tuple(
+      _deserialize_sharding(exp.OutShardings(i), uniques=uniques)
+      for i in range(exp.OutShardingsLength())
+    )
+  else:
+    out_shardings = ()
+
   # has_named_sharding will be True for all exports created after 1/15/2026
   # TODO(b/489569164): remove has_named_sharding 6 months after 1/15/2026
   has_named_shardings = not any(isinstance(s, _export.HloSharding)
                                 for s in itertools.chain(in_shardings, out_shardings))
   if has_named_shardings:
-    in_avals = tuple(
-      _deserialize_aval(exp.InAvals(i), scope=scope, sharding=in_shardings[i])  # type: ignore
-      for i in range(exp.InAvalsLength())
-    )
-    out_avals = tuple(
-      _deserialize_aval(exp.OutAvals(i), scope=scope, sharding=out_shardings[i])  # type: ignore
-      for i in range(exp.OutAvalsLength())
-    )
+    def get_aval_by_idx(idx, sharding: _export.NamedSharding | None):
+      base_aval = uniques.unique_avals[idx]
+      if sharding is None:
+        return base_aval
+      return core.update_aval_with_sharding(base_aval, sharding)
+
+    if exp.InAvalsIdxsLength() > 0:
+      in_avals = tuple(
+          get_aval_by_idx(exp.InAvalsIdxs(i), in_shardings[i])  # type: ignore
+          for i in range(exp.InAvalsIdxsLength()))
+    elif exp.InAvalsLength() > 0:
+      # TODO(necula): remove 6 months after 4/4/26
+      in_avals = tuple(
+          _deserialize_aval(exp.InAvals(i), scope=scope, sharding=in_shardings[i])  # type: ignore
+          for i in range(exp.InAvalsLength()))
+    else:
+      in_avals = ()
+
+    if exp.OutAvalsIdxsLength() > 0:
+      out_avals = tuple(
+          get_aval_by_idx(exp.OutAvalsIdxs(i), out_shardings[i])  # type: ignore
+                          for i in range(exp.OutAvalsIdxsLength()))
+    elif exp.OutAvalsLength() > 0:
+      # TODO(necula): remove 6 months after 4/4/26
+      out_avals = tuple(
+        _deserialize_aval(exp.OutAvals(i), scope=scope, sharding=out_shardings[i])  # type: ignore
+        for i in range(exp.OutAvalsLength())
+      )
+    else:
+      out_avals = ()
+
     in_shardings_hlo = tuple(_export.named_to_hlo_sharding(s, aval)  # type: ignore
                              for s, aval in zip(in_shardings, in_avals))
     out_shardings_hlo = tuple(_export.named_to_hlo_sharding(s, aval)  # type: ignore
                              for s, aval in zip(out_shardings, out_avals))
   else:
-    in_avals = _deserialize_tuple(exp.InAvalsLength, exp.InAvals,
-                                  partial(_deserialize_aval, scope=scope, sharding=None))
-    out_avals = _deserialize_tuple(exp.OutAvalsLength, exp.OutAvals,
-                                   partial(_deserialize_aval, scope=scope, sharding=None))
+    # Export from before 1/15/26
+    in_avals = tuple(
+        _deserialize_aval(exp.InAvals(i), scope=scope, sharding=None)
+        for i in range(exp.InAvalsLength())
+    )
+    out_avals = tuple(
+        _deserialize_aval(exp.OutAvals(i), scope=scope, sharding=None)
+        for i in range(exp.OutAvalsLength())
+    )
     in_shardings_hlo = cast(tuple[_export.HloSharding | None, ...], in_shardings)
     in_shardings = (None,) * len(in_shardings)
     out_shardings_hlo = cast(tuple[_export.HloSharding | None, ...], out_shardings)
     out_shardings = (None,) * len(out_shardings)
-  platforms = _deserialize_tuple(
-      exp.PlatformsLength,
-      exp.Platforms,
-      lambda v: v.decode("utf-8"),
+
+  platforms = tuple(
+      exp.Platforms(i).decode("utf-8")
+      for i in range(exp.PlatformsLength())
   )
-  ordered_effects = _deserialize_tuple(
-      exp.OrderedEffectsLength, exp.OrderedEffects, _deserialize_effect
+  ordered_effects = tuple(
+      _deserialize_effect(exp.OrderedEffects(i))
+      for i in range(exp.OrderedEffectsLength())
   )
-  unordered_effects = _deserialize_tuple(
-      exp.UnorderedEffectsLength, exp.UnorderedEffects, _deserialize_effect
+  unordered_effects = tuple(
+      _deserialize_effect(exp.UnorderedEffects(i))
+      for i in range(exp.UnorderedEffectsLength())
   )
-  disabled_safety_checks = _deserialize_tuple(
-      exp.DisabledChecksLength,
-      exp.DisabledChecks,
-      _deserialize_disabled_safety_check,
+  disabled_safety_checks = tuple(
+      _deserialize_disabled_safety_check(exp.DisabledChecks(i))
+      for i in range(exp.DisabledChecksLength())
   )
 
   mlir_module_serialized = exp.MlirModuleSerializedAsNumpy().tobytes()
@@ -274,13 +444,6 @@ def _deserialize_exported(exp: ser_flatbuf.Exported) -> _export.Exported:
       _get_vjp=_get_vjp,
   )
 
-
-def _deserialize_tuple(
-    get_len: Callable[[], int],
-    get_elem: Callable[[int], SerT],
-    deserialize_one: Callable[[SerT], T],
-) -> tuple[T, ...]:
-  return tuple(deserialize_one(get_elem(i)) for i in range(get_len()))
 
 
 def _serialize_pytreedef(
@@ -563,8 +726,12 @@ def _deserialize_partition_spec(spec: ser_flatbuf.PartitionSpec
 
 
 def _serialize_named_sharding(
-    builder: flatbuffers.Builder, sharding: named_sharding.NamedSharding
+    builder: flatbuffers.Builder, sharding: named_sharding.NamedSharding, *,
+    uniques: _SerializedUniques
 ) -> int:
+  abstract_mesh_idx = uniques.abstract_meshes_map[sharding.mesh.abstract_mesh]
+  # TODO(necula): 1 month after 4/4/26 we can stop serializing the full
+  # abstract_mesh and only serialize the index.
   mesh_offset = _serialize_abstract_mesh(builder, sharding.mesh.abstract_mesh)
   spec_offset = _serialize_partition_spec(builder, sharding.spec)
   memory_kind = builder.CreateString(sharding.memory_kind) if sharding.memory_kind is not None else 0
@@ -574,13 +741,19 @@ def _serialize_named_sharding(
   ser_flatbuf.NamedShardingAddSpec(builder, spec_offset)
   if memory_kind != 0:
     ser_flatbuf.NamedShardingAddMemoryKind(builder, memory_kind)
+  ser_flatbuf.NamedShardingAddAbstractMeshIdx(builder, abstract_mesh_idx)
   return ser_flatbuf.NamedShardingEnd(builder)
 
 
 def _deserialize_named_sharding(
-    s: ser_flatbuf.NamedSharding
+    s: ser_flatbuf.NamedSharding, *, uniques: _SerializedUniques
 ) -> named_sharding.NamedSharding:
-  amesh = _deserialize_abstract_mesh(s.Mesh())
+  if uniques.unique_abstract_meshes:
+    amesh = uniques.unique_abstract_meshes[s.AbstractMeshIdx()]
+  else:
+    # TODO(necula): 6 months after 4/4/26 we can stop deserializing the full
+    # abstract_mesh.
+    amesh = _deserialize_abstract_mesh(s.Mesh())
   spec = _deserialize_partition_spec(s.Spec())
   memory_kind = s.MemoryKind().decode("utf-8") if s.MemoryKind() is not None else None  # type: ignore
   return named_sharding.NamedSharding(amesh, spec, memory_kind=memory_kind)
@@ -626,11 +799,12 @@ def _deserialize_aval(aval: ser_flatbuf.AbstractValue, *,
 
 
 def _serialize_sharding(
-    builder: flatbuffers.Builder, s: _export.NamedSharding | None) -> int:
+    builder: flatbuffers.Builder, s: _export.NamedSharding | None, *,
+    uniques: _SerializedUniques) -> int:
   named_sharding = None
 
   if s is not None:
-    named_sharding = _serialize_named_sharding(builder, s)
+    named_sharding = _serialize_named_sharding(builder, s, uniques=uniques)
 
   ser_flatbuf.ShardingStart(builder)
   if named_sharding is not None:
@@ -638,10 +812,12 @@ def _serialize_sharding(
   return ser_flatbuf.ShardingEnd(builder)
 
 
-def _deserialize_sharding(s: ser_flatbuf.Sharding) -> _export.HloSharding | named_sharding.NamedSharding | None:
+def _deserialize_sharding(s: ser_flatbuf.Sharding, *,
+                          uniques: _SerializedUniques) -> _export.HloSharding | named_sharding.NamedSharding | None:
   if (named_sharding_off := s.NamedSharding()) is not None:
     # After 1/15/26 all exports will have named shardings (or None)
-    return _deserialize_named_sharding(named_sharding_off)
+    # TODO(necula): We must keep reading the NamedSharding for 6 months after 4/4/26
+    return _deserialize_named_sharding(named_sharding_off, uniques=uniques)
 
   # TODO(b/489569164): We must keep reading the HloSharding for 6 months after 1/15/2026.
   if not s.HloShardingProtoIsNone():

--- a/jax/_src/export/serialization_generated.py
+++ b/jax/_src/export/serialization_generated.py
@@ -612,8 +612,15 @@ class NamedSharding(object):
             return self._tab.String(o + self._tab.Pos)
         return None
 
+    # NamedSharding
+    def AbstractMeshIdx(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Uint32Flags, o + self._tab.Pos)
+        return 0
+
 def NamedShardingStart(builder):
-    builder.StartObject(3)
+    builder.StartObject(4)
 
 def NamedShardingAddMesh(builder, mesh):
     builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(mesh), 0)
@@ -623,6 +630,9 @@ def NamedShardingAddSpec(builder, spec):
 
 def NamedShardingAddMemoryKind(builder, memoryKind):
     builder.PrependUOffsetTRelativeSlot(2, flatbuffers.number_types.UOffsetTFlags.py_type(memoryKind), 0)
+
+def NamedShardingAddAbstractMeshIdx(builder, abstractMeshIdx):
+    builder.PrependUint32Slot(3, abstractMeshIdx, 0)
 
 def NamedShardingEnd(builder):
     return builder.EndObject()
@@ -1213,8 +1223,188 @@ class Exported(object):
             return self._tab.Get(flatbuffers.number_types.Uint32Flags, o + self._tab.Pos)
         return 0
 
+    # Exported
+    def UniqueAvals(self, j):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(42))
+        if o != 0:
+            x = self._tab.Vector(o)
+            x += flatbuffers.number_types.UOffsetTFlags.py_type(j) * 4
+            x = self._tab.Indirect(x)
+            obj = AbstractValue()
+            obj.Init(self._tab.Bytes, x)
+            return obj
+        return None
+
+    # Exported
+    def UniqueAvalsLength(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(42))
+        if o != 0:
+            return self._tab.VectorLen(o)
+        return 0
+
+    # Exported
+    def UniqueAvalsIsNone(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(42))
+        return o == 0
+
+    # Exported
+    def UniqueAbstractMeshes(self, j):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(44))
+        if o != 0:
+            x = self._tab.Vector(o)
+            x += flatbuffers.number_types.UOffsetTFlags.py_type(j) * 4
+            x = self._tab.Indirect(x)
+            obj = AbstractMesh()
+            obj.Init(self._tab.Bytes, x)
+            return obj
+        return None
+
+    # Exported
+    def UniqueAbstractMeshesLength(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(44))
+        if o != 0:
+            return self._tab.VectorLen(o)
+        return 0
+
+    # Exported
+    def UniqueAbstractMeshesIsNone(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(44))
+        return o == 0
+
+    # Exported
+    def UniqueNamedShardings(self, j):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(46))
+        if o != 0:
+            x = self._tab.Vector(o)
+            x += flatbuffers.number_types.UOffsetTFlags.py_type(j) * 4
+            x = self._tab.Indirect(x)
+            obj = NamedSharding()
+            obj.Init(self._tab.Bytes, x)
+            return obj
+        return None
+
+    # Exported
+    def UniqueNamedShardingsLength(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(46))
+        if o != 0:
+            return self._tab.VectorLen(o)
+        return 0
+
+    # Exported
+    def UniqueNamedShardingsIsNone(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(46))
+        return o == 0
+
+    # Exported
+    def InAvalsIdxs(self, j):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(48))
+        if o != 0:
+            a = self._tab.Vector(o)
+            return self._tab.Get(flatbuffers.number_types.Uint32Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 4))
+        return 0
+
+    # Exported
+    def InAvalsIdxsAsNumpy(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(48))
+        if o != 0:
+            return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Uint32Flags, o)
+        return 0
+
+    # Exported
+    def InAvalsIdxsLength(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(48))
+        if o != 0:
+            return self._tab.VectorLen(o)
+        return 0
+
+    # Exported
+    def InAvalsIdxsIsNone(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(48))
+        return o == 0
+
+    # Exported
+    def OutAvalsIdxs(self, j):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(50))
+        if o != 0:
+            a = self._tab.Vector(o)
+            return self._tab.Get(flatbuffers.number_types.Uint32Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 4))
+        return 0
+
+    # Exported
+    def OutAvalsIdxsAsNumpy(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(50))
+        if o != 0:
+            return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Uint32Flags, o)
+        return 0
+
+    # Exported
+    def OutAvalsIdxsLength(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(50))
+        if o != 0:
+            return self._tab.VectorLen(o)
+        return 0
+
+    # Exported
+    def OutAvalsIdxsIsNone(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(50))
+        return o == 0
+
+    # Exported
+    def InShardingsIdxs(self, j):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(52))
+        if o != 0:
+            a = self._tab.Vector(o)
+            return self._tab.Get(flatbuffers.number_types.Uint32Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 4))
+        return 0
+
+    # Exported
+    def InShardingsIdxsAsNumpy(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(52))
+        if o != 0:
+            return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Uint32Flags, o)
+        return 0
+
+    # Exported
+    def InShardingsIdxsLength(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(52))
+        if o != 0:
+            return self._tab.VectorLen(o)
+        return 0
+
+    # Exported
+    def InShardingsIdxsIsNone(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(52))
+        return o == 0
+
+    # Exported
+    def OutShardingsIdxs(self, j):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(54))
+        if o != 0:
+            a = self._tab.Vector(o)
+            return self._tab.Get(flatbuffers.number_types.Uint32Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 4))
+        return 0
+
+    # Exported
+    def OutShardingsIdxsAsNumpy(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(54))
+        if o != 0:
+            return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Uint32Flags, o)
+        return 0
+
+    # Exported
+    def OutShardingsIdxsLength(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(54))
+        if o != 0:
+            return self._tab.VectorLen(o)
+        return 0
+
+    # Exported
+    def OutShardingsIdxsIsNone(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(54))
+        return o == 0
+
 def ExportedStart(builder):
-    builder.StartObject(19)
+    builder.StartObject(26)
 
 def ExportedAddSerializationVersion(builder, serializationVersion):
     builder.PrependUint16Slot(0, serializationVersion, 0)
@@ -1302,6 +1492,48 @@ def ExportedAddVjp(builder, vjp):
 
 def ExportedAddNrDevices(builder, nrDevices):
     builder.PrependUint32Slot(18, nrDevices, 0)
+
+def ExportedAddUniqueAvals(builder, uniqueAvals):
+    builder.PrependUOffsetTRelativeSlot(19, flatbuffers.number_types.UOffsetTFlags.py_type(uniqueAvals), 0)
+
+def ExportedStartUniqueAvalsVector(builder, numElems):
+    return builder.StartVector(4, numElems, 4)
+
+def ExportedAddUniqueAbstractMeshes(builder, uniqueAbstractMeshes):
+    builder.PrependUOffsetTRelativeSlot(20, flatbuffers.number_types.UOffsetTFlags.py_type(uniqueAbstractMeshes), 0)
+
+def ExportedStartUniqueAbstractMeshesVector(builder, numElems):
+    return builder.StartVector(4, numElems, 4)
+
+def ExportedAddUniqueNamedShardings(builder, uniqueNamedShardings):
+    builder.PrependUOffsetTRelativeSlot(21, flatbuffers.number_types.UOffsetTFlags.py_type(uniqueNamedShardings), 0)
+
+def ExportedStartUniqueNamedShardingsVector(builder, numElems):
+    return builder.StartVector(4, numElems, 4)
+
+def ExportedAddInAvalsIdxs(builder, inAvalsIdxs):
+    builder.PrependUOffsetTRelativeSlot(22, flatbuffers.number_types.UOffsetTFlags.py_type(inAvalsIdxs), 0)
+
+def ExportedStartInAvalsIdxsVector(builder, numElems):
+    return builder.StartVector(4, numElems, 4)
+
+def ExportedAddOutAvalsIdxs(builder, outAvalsIdxs):
+    builder.PrependUOffsetTRelativeSlot(23, flatbuffers.number_types.UOffsetTFlags.py_type(outAvalsIdxs), 0)
+
+def ExportedStartOutAvalsIdxsVector(builder, numElems):
+    return builder.StartVector(4, numElems, 4)
+
+def ExportedAddInShardingsIdxs(builder, inShardingsIdxs):
+    builder.PrependUOffsetTRelativeSlot(24, flatbuffers.number_types.UOffsetTFlags.py_type(inShardingsIdxs), 0)
+
+def ExportedStartInShardingsIdxsVector(builder, numElems):
+    return builder.StartVector(4, numElems, 4)
+
+def ExportedAddOutShardingsIdxs(builder, outShardingsIdxs):
+    builder.PrependUOffsetTRelativeSlot(25, flatbuffers.number_types.UOffsetTFlags.py_type(outShardingsIdxs), 0)
+
+def ExportedStartOutShardingsIdxsVector(builder, numElems):
+    return builder.StartVector(4, numElems, 4)
 
 def ExportedEnd(builder):
     return builder.EndObject()

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -2351,6 +2351,39 @@ class JaxExportTest(jtu.JaxTestCase):
         else:
           jax.jit(exp.call, out_shardings=NamedSharding(mesh, P("a")))(a, b)
 
+  def test_with_multiple_meshes(self):
+    nr_devices = 2
+    if len(jax.devices()) < nr_devices:
+      self.skipTest("Need at least 2 devices")
+    devices = jax.devices()[0:nr_devices]
+
+    mesh_inputs = Mesh(np.array(devices).reshape(1, 2), axis_names=("x1", "x2"))
+    mesh_weights = Mesh(np.array(devices).reshape(2, 1), axis_names=("y2", "y1"))
+
+    inp = np.arange(32., dtype=np.float32).reshape((4, 8))
+    TUPLE_SIZE = 4
+    inputs = (inp,) * TUPLE_SIZE
+    w = np.arange(16., dtype=np.float32).reshape((8, 2))
+    weights = (w,) * TUPLE_SIZE
+    in_shardings = (
+      (jax.sharding.NamedSharding(mesh_inputs, P(None, "x2")),) * TUPLE_SIZE,
+      (jax.sharding.NamedSharding(mesh_weights, P("y2", None),),) * TUPLE_SIZE)
+    out_shardings = (
+      (jax.sharding.NamedSharding(mesh_inputs, P(None, "x1")),) * TUPLE_SIZE)
+    @functools.partial(
+        jax.jit,
+        in_shardings=in_shardings,
+        out_shardings=out_shardings)
+    def f(inputs, weights):
+      return tuple(i @ w for i, w in zip(inputs, weights))
+
+    exp = get_exported(f)(inputs, weights)
+
+    (placed_inputs, placed_weights) = jax.device_put((inputs, weights),
+                                                      in_shardings)
+    out = exp.call(placed_inputs, placed_weights)
+    self.assertAllClose(out, tuple(i @ w for i, w in zip(inputs, weights)))
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This introduces export serialization version 10. If the serialized function
has many inputs and outputs, it is quite likely that we have
multiple instances of the same AbstractValue, AbstractMesh and NamedSharding.
We now serialize only unique values, and reference them by the index
into the list of unique values.

For a particular large benchmark there are 560 inputs and outputs, all sharing
the same AbstractMesh, and about 200 of them sharing the same NamedSharding and
AbstractValue. The time to deserialize was 370ms of which 220ms for deserializing
NamedSharding, 120ms for AbstractMesh, and 100ms for AbstractValue.

With this change, the time to deserialize is 50ms, with 14 unique NamedSharding and
20 unique AbstractValue, and 1 unique AbstractMesh.

Like for all changes to the serialization format, we have to continue to serialize the
old representations for AbstractValue, NamedSharding, and AbstractMesh for 1
month, to allow existing deserializers to consume new serialized exports. This
forward compatibility was tested by submitting first (#36362) the change to  the
export_serialization_back_compat_test including a version 10 of the serialized export.

In order to support backwards compatibility, the deserializer must be able to read
up to 6-months old serialized exported. This is tested in export_serialization_back_compat_test. 
