### PR TITLE
feat: support profiling without source code changes via JAX_PROFILE

### DIFF
--- a/jax/_src/profiler.py
+++ b/jax/_src/profiler.py
@@ -500,11 +500,16 @@ class PGLEProfiler:
               RuntimeWarning)
           
 
-import os
 import atexit
 
 _jax_profile_dir = os.environ.get("JAX_PROFILE")
 if _jax_profile_dir:
+  def _stop_trace_at_exit():
+    if _profile_state.profile_session:
+      stop_trace()
+
+  try:
     start_trace(_jax_profile_dir)
-    # Registra o stop_trace para rodar automaticamente quando o script do usuário terminar
-    atexit.register(stop_trace)
+    atexit.register(_stop_trace_at_exit)
+  except Exception as e:
+    logger.warning("Failed to auto-start JAX profiling: %s", e)

--- a/jax/_src/profiler.py
+++ b/jax/_src/profiler.py
@@ -498,3 +498,13 @@ class PGLEProfiler:
               "and then profiling a second run that has the "
               "JAX_COMPILATION_CACHE_EXPECT_PGLE option enabled.",
               RuntimeWarning)
+          
+
+import os
+import atexit
+
+_jax_profile_dir = os.environ.get("JAX_PROFILE")
+if _jax_profile_dir:
+    start_trace(_jax_profile_dir)
+    # Registra o stop_trace para rodar automaticamente quando o script do usuário terminar
+    atexit.register(stop_trace)


### PR DESCRIPTION
<!--

This PR implements support for generating profiling logs directly from the command line using the JAX_PROFILE environment variable, as requested in #20293.

Added a brief check in jax/_src/profiler.py that reads the environment variable on import and, if present, automatically starts the trace and registers stop_trace at exit using atexit.

-->