### PR TITLE
[ROCm] Restore default SVD algorithms on ROCm.

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -2279,19 +2279,12 @@ def _resolve_gpu_svd_implementation(
     raise NotImplementedError(
         f"Unsupported SVD algorithm on GPU: {algorithm!r}")
 
-  if target_name_prefix == "cu":
+  if target_name_prefix in ["cu", "hip"]:
     try:
       if m <= 1024 and n <= 1024:
         return _GpuSvdImpl.JACOBI
     except core.InconclusiveDimensionOperation:
       pass
-    return _GpuSvdImpl.GESVD
-
-  if target_name_prefix == "hip":
-    if (not ctx.is_forward_compat()
-        and jaxlib_extension_version >= 426
-        and _gpu_solver_has_ffi("ROCM", "hipsolver_gesdd_ffi")):
-      return _GpuSvdImpl.GESDD
     return _GpuSvdImpl.GESVD
 
   raise AssertionError(

--- a/tests/export_back_compat_test.py
+++ b/tests/export_back_compat_test.py
@@ -700,7 +700,7 @@ class CompatTest(bctu.CompatTestBase):
     algorithm = dict(
         qr=lax.linalg.SvdAlgorithm.QR,
         jacobi=lax.linalg.SvdAlgorithm.JACOBI,
-        gesdd=lax.linalg.SvdAlgorithm.DEFAULT,  # ROCm uses gesdd by default
+        gesdd=lax.linalg.SvdAlgorithm.DIVIDE_AND_CONQUER,
     )[algorithm_name]
 
     def func(operand):
@@ -735,17 +735,9 @@ class CompatTest(bctu.CompatTestBase):
       self.skipTest("Unsupported platform: " + jtu.device_under_test())
 
     data = self.load_testdata(platform_data)
-    # For the "gesdd" algorithm on ROCm: the stored test data was serialized
-    # with hipsolver_gesdd_ffi, but current serialization uses the
-    # is_forward_compat() guard and falls back to hipsolver_gesvd_ffi.
-    # Pass expect_current_custom_calls so the assertion matches the fallback.
-    expect_current_custom_calls = None
-    if algorithm_name == "gesdd" and jtu.test_device_matches(["rocm"]):
-      expect_current_custom_calls = ["hipsolver_gesvd_ffi"]
     self.run_one_test(func, data, rtol=rtol, atol=atol,
                       check_results=partial(self.check_svd_results,
-                                            *data.inputs),
-                      expect_current_custom_calls=expect_current_custom_calls)
+                                            *data.inputs))
 
   @jtu.parameterized_filterable(
     kwargs=[


### PR DESCRIPTION
## Motivation
ROCm recently switched to GESDD as the default SVD algorithm in PR https://github.com/jax-ml/jax/pull/35534. However, this caused a number of failures in unit tests. The original default SVD algorithms have been restored while the GESDD issues are being fixed. GESDD will be restored on ROCm once these issues are fixed since benchmarking shows it to perform better than alternatives on ROCm devices.

## Summary
- The default path for SVD in `jax/_src/lax/linalg.py` has been restored (and doesn't use GESDD)
- The unit test `test_gpu_svd_solver_gesvd` in file `tests/export_back_compat_test.py` has been modified to pass without GESDD as the default path on ROCm

## Testing
The following tests were broken with the switch to GESDD:

- SVD related shape tests in `tests/shape_poly_test.py::ShapePolyHarnessesTest`
- SVD related shape tests in `tests/export_harnesses_multi_platform_test.py::PrimitiveTest`
- MatrixRank tests in tests/linalg_test.py::NumpyLinalgTest

These tests all pass when the SVD path is reverted.