### PR TITLE
Use hermetic clang for ROCm

### DIFF
--- a/build/rocm/rocm.bazelrc
+++ b/build/rocm/rocm.bazelrc
@@ -1,10 +1,5 @@
 # Used for ROCm build and test
 
-common:clang_local --noincompatible_enable_cc_toolchain_resolution
-common:clang_local --@rules_ml_toolchain//common:enable_hermetic_cc=False
-common:clang_local --repo_env USE_HERMETIC_CC_TOOLCHAIN=0
-
-common:rocm_base --config=clang_local
 common:rocm_base --crosstool_top=@local_config_rocm//crosstool:toolchain
 common:rocm_base --define=using_rocm=true --define=using_rocm_hipcc=true
 common:rocm_base --repo_env=TF_NEED_ROCM=1
@@ -13,7 +8,6 @@ common:rocm_base --repo_env=TF_NEED_ROCM=1
 common:rocm --config=rocm_base
 common:rocm --action_env=TF_HIPCC_CLANG="1"
 common:rocm --action_env=TF_ROCM_CLANG="1"
-common:rocm --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"
 common:rocm --action_env=HIPCC_COMPILE_FLAGS_APPEND=--offload-compress
 common:rocm --copt=-Wno-gnu-offsetof-extensions
 common:rocm --copt=-Qunused-arguments


### PR DESCRIPTION
https://github.com/openxla/xla/pull/39854 removed inspection of include directories, causing recent builds of bazel_rocm_presubmit to fail.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->