### PR TITLE
[ROCm] Skip failing ROCm CI tests

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2727,10 +2727,9 @@ class LaxLinalgTest(jtu.JaxTestCase):
   @jtu.sample_product(shape=[(2,), (3,), (3, 2), (3, 4), (3, 4, 5)],
                       dtype=float_types + complex_types)
   def test_tridiagonal_solve(self, shape, dtype):
-    # Skip test on ROCm due to numerical error. Issue #575788
-    # TODO(AratiGanesh): Unskip once fixed.
-    if jtu.is_device_rocm() and dtype == np.float32 and shape in [(3, 4), (3, 4, 5)]:
-      self.skipTest("test_tridiagonal_solve not supported on ROCm for these shapes/dtype due to rocSparse issue")
+    # TODO: Add these tests back once rocSparse issues are fixed.
+    if jtu.is_device_rocm() and shape in [(3, 4), (3, 4, 5)]:
+      self.skipTest("Skipped on ROCm due to rocSparse numerical error.")
     rng = self.rng()
     d = 1.0 + jtu.rand_positive(rng)(shape, dtype)
     dl = jtu.rand_default(rng)(shape, dtype)
@@ -2768,10 +2767,9 @@ class LaxLinalgTest(jtu.JaxTestCase):
 
   @jtu.sample_product(shape=[(3,), (3, 4)], dtype=float_types + complex_types)
   def test_tridiagonal_solve_grad(self, shape, dtype):
-    if jtu.is_device_rocm() and shape == (3, 4) and dtype == np.float32:
-      # numerical errors seen as of ROCm 7.2 due to rocSparse issue for grad0 variant
-      # TODO: re-enable the test once the rocSparse issue is fixed
-      self.skipTest("test_tridiagonal_solve_grad0 not supported on ROCm due to rocSparse issue")
+    # TODO: Add these tests back once rocSparse issues are fixed.
+    if jtu.is_device_rocm() and shape == (3, 4):
+      self.skipTest("Skipped on ROCm due to rocSparse numerical error.")
     rng = self.rng()
     d = 1.0 + jtu.rand_positive(rng)(shape, dtype)
     dl = jtu.rand_default(rng)(shape, dtype)

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -113,6 +113,9 @@ class NNFunctionsTest(jtu.JaxTestCase):
       raise unittest.SkipTest("Test requires GPU.")
     if jtu.is_device_cuda() and not jtu.is_cuda_compute_capability_at_least("10.0"):
       raise unittest.SkipTest("Needs compute capability 10.0 or higher.")
+    # TODO: Re-enable once scaled dot is implemented for ROCm in XLA.
+    if jtu.is_device_rocm():
+      self.skipTest("Skipped on ROCm: scaled dot not yet supported in XLA.")
     # Check if float8_e8m0fnu is available
     configs = create_mxfp8_configs_if_available()
     batch, rhs_non_contract = 4, 256
@@ -138,6 +141,9 @@ class NNFunctionsTest(jtu.JaxTestCase):
       raise unittest.SkipTest("Test requires GPU.")
     if jtu.is_device_cuda() and not jtu.is_cuda_compute_capability_at_least("10.0"):
       raise unittest.SkipTest("Needs compute capability 10.0 or higher.")
+    # TODO: Re-enable once scaled dot is implemented for ROCm in XLA.
+    if jtu.is_device_rocm():
+      self.skipTest("Skipped on ROCm: scaled dot not yet supported in XLA.")
 
     configs = create_mxfp8_configs_if_available()
     cast_to_representable = partial(

--- a/tests/pallas/pallas_shape_poly_test.py
+++ b/tests/pallas/pallas_shape_poly_test.py
@@ -500,6 +500,9 @@ class ExportTestWithTriton(jtu.JaxTestCase):
     )
 
   def test_cross_platform(self):
+    # TODO: Add this test back once gfx arch string parsing is fixed.
+    if jtu.is_device_rocm():
+      self.skipTest("Skipped on ROCm due to gfx arch string parsing error.")
     def add_vectors_kernel(x_ref, y_ref, o_ref):
       x, y = x_ref[...], y_ref[...]
       o_ref[...] = x + y

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -620,6 +620,9 @@ class cuSparseTest(sptu.SparseTestCase):
   )
   @jtu.run_on_devices("gpu")
   def test_csr_spmm(self, shape, dtype, transpose):
+    # TODO: Add these tests back once hipSparse issue is fixed.
+    if jtu.is_device_rocm():
+      self.skipTest("Skipped on ROCm due to hipSparse internal error.")
     rng_sparse = sptu.rand_sparse(self.rng())
     rng_dense = jtu.rand_default(self.rng())
 


### PR DESCRIPTION
- Skip testScaledMatmul and testScaledDotGeneral on ROCm: scaled dot support is not yet available in XLA
- Skip test_csr_spmm on ROCm due to hipSparse internal error
- Broaden test_tridiagonal_solve and test_tridiagonal_solve_grad skips to cover complex dtypes on ROCm (rocSparse numerical error)
- Skip ExportTestWithTriton::test_cross_platform on ROCm due to gfx arch string parsing error
- Will follow up with fixes for these tests.