### PR TITLE
[ROCm] Added fixes to Bazel ROCm CI to use proper wheels.

### DIFF
--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -87,7 +87,6 @@ on:
         description: 'Should this workflow run wait for a remote connection?'
         type: string
         default: 'no'
-permissions: {}
 jobs:
   run-tests:
     defaults:
@@ -109,6 +108,7 @@ jobs:
 
     env:
       JAXCI_CLONE_MAIN_XLA: ${{ inputs.clone_main_xla }}
+      JAXCI_HERMETIC_PYTHON_VERSION: ${{ inputs.python }}
 
 # Begin Presubmit Naming Check - name modification requires internal check to be updated
     name: "linux x86, jaxlib=${{ inputs.jaxlib-version }}, ROCM=${{ inputs.rocm-version }}, Python=${{ inputs.python }}, x64=${{ inputs.enable-x64 }}, build_jax=${{ inputs.build_jax }}, build_jaxlib=${{ inputs.build_jaxlib }}"
@@ -120,12 +120,24 @@ jobs:
       - name: ROCm Info
         run: |
           rocminfo
-      - name: Download jaxlib wheel from PyPI
+      - name: Configure AWS Credentials
+        if: inputs.build_jaxlib == 'false' && inputs.jaxlib-version == 'head'
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # ratchet:aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::661452401056:role/jax-ci-amd-s3-oidc
+          aws-region: us-east-1
+      # Get the JAX/Jaxlib/Plugin/PJRT wheels from their respective
+      # sources when not building.
+      - name: Download JAX/Jaxlib/Plugin/PJRT wheels
         if: inputs.build_jaxlib == 'false'
-        run: |
-          mkdir -p $(pwd)/dist
-          python${{ inputs.python }} -m pip download jaxlib --dest $(pwd)/dist/
-          echo "Downloaded wheels:" && ls -lh $(pwd)/dist/
+        uses: ./.github/actions/download-jax-rocm-wheels
+        with:
+          python: ${{ inputs.python }}
+          rocm-version: ${{ inputs.rocm-version }}
+          download-jax-from-gcs: ${{ inputs.download-jax-from-gcs }}
+          skip-download-jaxlib-and-plugins-from-gcs: ${{ inputs.skip-download-jaxlib-and-plugins-from-gcs }}
+          jaxlib-version: ${{ inputs.jaxlib-version }}
+          gcs_download_uri: ${{ inputs.gcs_download_uri }}
       # Halt for testing
       - name: Wait For Connection
         uses: google-ml-infra/actions/ci_connection@7f5ca0c263a81ed09ea276524c1b9192f1304e3c

--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -198,6 +198,9 @@ jobs:
       gcs_download_uri: ${{inputs.gcs_download_uri}}
 
   run-bazel-test-rocm:
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/bazel_rocm.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -205,7 +208,7 @@ jobs:
           # Runner OS and Python values need to match the matrix stategy of our internal CI jobs
           # that build the wheels.
           runner: ["linux-x86-64-1gpu-amd"]
-          python: ["3.11", "3.12", "3.13", "3.13-nogil", "3.14", "3.14-nogil"]
+          python: ["3.11", "3.12", "3.13", "3.14"]
           rocm-version: [7]
           enable-x64: [0]
     name: "Bazel ROCm Non-RBE with ${{ format('{0}', 'build_jaxlib=false') }}"

--- a/third_party/rocm_wheels/workspace.bzl
+++ b/third_party/rocm_wheels/workspace.bzl
@@ -207,35 +207,69 @@ def _rocm_wheels_repository_impl(repository_ctx):
     jaxlib_version = repository_ctx.attr.jaxlib_version
     rocm_version = repository_ctx.attr.rocm_version
 
-    headers = _get_github_headers(repository_ctx)
-    release = _fetch_release_metadata(repository_ctx, headers)
+    py_tag = "cp" + python_version.replace(".", "")
+    rocm_tag = "rocm" + rocm_version if rocm_version else ""
 
-    plugin_asset, pjrt_asset = _find_wheel_assets(
-        release,
-        python_version,
-        rocm_version,
-    )
+    # Check for local wheels in jax/dist/ first in case they
+    # are downloaded already from S3 or pip.
+    dist_dir = repository_ctx.workspace_root.get_child("dist")
+    dl_plugin = None
+    dl_pjrt = None
 
-    tag_name = release.get("tag_name", "unknown")
+    if dist_dir.exists:
+        for entry in dist_dir.readdir():
 
-    # buildifier: disable=print
-    print("rocm_wheels: release '{}' — plugin='{}', pjrt='{}'".format(
-        tag_name,
-        plugin_asset["name"],
-        pjrt_asset["name"],
-    ))
+            name = entry.basename
+            if not name.endswith(".whl"):
+                continue
+            if rocm_tag and rocm_tag not in name:
+                continue
 
-    repository_ctx.download(
-        url = plugin_asset["browser_download_url"],
-        output = "plugin.whl",
-        headers = headers,
-    )
+            if "plugin" in name and "pjrt" not in name and py_tag in name:
+                dl_plugin = entry
+            elif "pjrt" in name:
+                dl_pjrt = entry
 
-    repository_ctx.download(
-        url = pjrt_asset["browser_download_url"],
-        output = "pjrt.whl",
-        headers = headers,
-    )
+    if dl_plugin and dl_pjrt:
+
+        # buildifier: disable=print
+        print("rocm_wheels: dist/ -  plugin='{}', pjrt='{}'".format(
+            dl_plugin.basename,
+            dl_pjrt.basename,
+        ))
+        repository_ctx.symlink(dl_plugin, "plugin.whl")
+        repository_ctx.symlink(dl_pjrt, "pjrt.whl")
+
+    else:
+        headers = _get_github_headers(repository_ctx)
+        release = _fetch_release_metadata(repository_ctx, headers)
+
+        plugin_asset, pjrt_asset = _find_wheel_assets(
+            release,
+            python_version,
+            rocm_version,
+        )
+
+        tag_name = release.get("tag_name", "unknown")
+
+        # buildifier: disable=print
+        print("rocm_wheels: release '{}' - plugin='{}', pjrt='{}'".format(
+            tag_name,
+            plugin_asset["name"],
+            pjrt_asset["name"],
+        ))
+
+        repository_ctx.download(
+            url = plugin_asset["browser_download_url"],
+            output = "plugin.whl",
+            headers = headers,
+        )
+
+        repository_ctx.download(
+            url = pjrt_asset["browser_download_url"],
+            output = "pjrt.whl",
+            headers = headers,
+        )
 
     repository_ctx.file("BUILD.bazel", _BUILD_TEMPLATE)
 


### PR DESCRIPTION
## Summary
Bazel ROCm tests now use the `download-jax-rocm-wheels` action to provide wheels for the presubmit, continuous, and nightly ROCm workflows. Checks needing up-to-date wheels will use wheels from a S3 bucket or PyPi wheels. JAX and Jaxlib wheels come from the GCS buckets.

For ROCm Bazel tests, whenever `inputs.build_jaxlib == 'false'` is set now, the composite action to download wheels is called. The S3 wheels are used if `inputs.jaxlib-version == 'head'` is also True, otherwise a PyPi wheel is retrieved.

## Changes
- `bazel_rocm.yml` now inherits permissions from the caller instead of declaring no permissions and adds the
`JAXCI_HERMETIC_PYTHON_VERSION` env var. It also adds steps to configure AWS credentials and call a composite action to download wheels from S3 or pip.

- `wheel_tests_nightly_release.yml` has job-level permissions added to `run-bazel-test-rocm` to enable it to retrieve S3 wheels (similar to `run-pytest-rocm`). The nogil Python tests have been removed since ROCm does not currently support them.

- `third_party/rocm_wheels/workspace.bzl` now checks for and prioritizes wheels downloaded from S3 or pip.