### PR TITLE
[consts] Fix AOT in presence of simplified handling of closed over consts

### DIFF
--- a/docs/internals/constants.md
+++ b/docs/internals/constants.md
@@ -148,7 +148,10 @@ The C++ fast path has support for const args starting with jaxlib 0.7.1.
 In prior versions, the fast path is disabled when there are const args.
 
 To implement this scheme, we keep the `const_args` in
-`stages.Lowering`, `stages.Lowered`, and `stages.CompiledCallParams`.
+`stages.Lowering`, `stages.Lowered`, `stages.CompiledCallParams`,
+and `pxla.MeshExecutable`.
+In `stages.Compiled` the fields, e.g., `in_avals`, do not include
+`const_args`.
 
 Interestingly, when we serialize an executable, e.g., for the compilation
 cache, we do not need to serialize the closed over constants. The executable

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -1915,18 +1915,19 @@ class MeshExecutable(stages.Executable):
     self.build_unsafe_call = build_unsafe_call
     # in_avals is a list of global and local avals. Aval is global if input
     # is a GDA or jax.Array else local.
-    self.in_avals = in_avals  # includes the const_args
+    self.in_avals = in_avals  # has const_args, but not dead args
     self.out_avals = out_avals
     self._unsafe_call = None
-    self._in_shardings = in_shardings
+    self._in_shardings = in_shardings  # has const_args, but not dead args
     self._out_shardings = out_shardings
     self._auto_spmd_lowering = auto_spmd_lowering
+    # indices include const_args and dead args
     self._kept_var_idx = kept_var_idx
-    self._xla_in_layouts = xla_in_layouts
+    self._xla_in_layouts = xla_in_layouts  # has const_args, but not dead args
     self._dispatch_in_layouts = dispatch_in_layouts
     self._xla_out_layouts = xla_out_layouts
     self._mut = mut
-    self._all_args_info = all_args_info
+    self._all_args_info = all_args_info  # has const_args and also dead args
     self._unloaded_executable = unloaded_executable
 
   @property

--- a/jax/_src/stages.py
+++ b/jax/_src/stages.py
@@ -659,7 +659,8 @@ class Compiled(Stage):
   """
   __slots__ = ["args_info", "out_tree", "_executable", "_no_kwargs", "_params"]
 
-  args_info: Any                # PyTree of ArgInfo, not including const_args
+  # PyTree of ArgInfo, including dead args, but not const_args
+  args_info: Any
   out_tree: tree_util.PyTreeDef
   _executable: Executable
   _no_kwargs: bool
@@ -728,14 +729,16 @@ class Compiled(Stage):
 
   @property
   def in_avals(self):
-    in_avals_ = self._executable.in_avals  # pyrefly: ignore[missing-attribute]
+    # Including dead args, but not const_args
+    nr_const_args = len(self._params.const_args)
+    in_avals_ = self._executable.in_avals[nr_const_args:]  # pyrefly: ignore[missing-attribute]
     if self.in_tree.num_leaves > len(in_avals_):
       iter_in_avals = iter(in_avals_)
-      non_dce_avals = self._executable._all_args_info.in_avals  # pyrefly: ignore[missing-attribute]
+      non_dce_avals = self._executable._all_args_info.in_avals[nr_const_args:]  # pyrefly: ignore[missing-attribute]
       in_avals_ = [
-          next(iter_in_avals) if i in self._executable._kept_var_idx  # pyrefly: ignore[missing-attribute]
+          next(iter_in_avals) if i + nr_const_args in self._executable._kept_var_idx # pyrefly: ignore[missing-attribute]
           else a for i, a in zip(range(self.in_tree.num_leaves), non_dce_avals)]
-    return self.in_tree.unflatten(in_avals_[len(self._params.const_args):])
+    return self.in_tree.unflatten(in_avals_)
 
   @property
   def out_info(self):  # PyTree of jax.ShapeDtypeStruct
@@ -758,16 +761,18 @@ class Compiled(Stage):
     return self._executable.runtime_executable()
 
   def _input_shardings_flat(self):
-    shardings_flat = self._executable._in_shardings  # pyrefly: ignore[missing-attribute]
+    nr_const_args = len(self._params.const_args)
+    shardings_flat = self._executable._in_shardings[nr_const_args:]  # pyrefly: ignore[missing-attribute]
     # Some input shardings got DCE'd
     if self.in_tree.num_leaves > len(shardings_flat):
       iter_shardings_flat = iter(shardings_flat)
-      shardings_flat = [next(iter_shardings_flat) if i in self._executable._kept_var_idx  # pyrefly: ignore[missing-attribute]
+      shardings_flat = [next(iter_shardings_flat) if i + nr_const_args in self._executable._kept_var_idx  # pyrefly: ignore[missing-attribute]
                         else None for i in range(self.in_tree.num_leaves)]
-    return shardings_flat[len(self._params.const_args):]
+    return shardings_flat
 
   @property
   def input_shardings(self):  # -> PyTree[sharding.Sharding]
+    # Including dead args, but not const_args
     shardings_flat = self._input_shardings_flat()
     return tree_util.tree_unflatten(self.in_tree, shardings_flat)  # pytype: disable=attribute-error
 
@@ -777,16 +782,18 @@ class Compiled(Stage):
     return tree_util.tree_unflatten(self.out_tree, shardings_flat)  # pytype: disable=attribute-error
 
   def _input_layouts_flat(self):
-    layouts_flat = self._executable._xla_in_layouts  # pyrefly: ignore[missing-attribute]
+    nr_const_args = len(self._params.const_args)
+    layouts_flat = self._executable._xla_in_layouts[nr_const_args:]  # pyrefly: ignore[missing-attribute]
     # Some input layouts got DCE'd
     if self.in_tree.num_leaves > len(layouts_flat):
       iter_layouts_flat = iter(layouts_flat)
-      layouts_flat = [next(iter_layouts_flat) if i in self._executable._kept_var_idx  # pyrefly: ignore[missing-attribute]
+      layouts_flat = [next(iter_layouts_flat) if i + nr_const_args in self._executable._kept_var_idx  # pyrefly: ignore[missing-attribute]
                       else None for i in range(self.in_tree.num_leaves)]
-    return layouts_flat[len(self._params.const_args):]
+    return layouts_flat
 
   @property
   def input_formats(self):
+    # Including dead args, but not const_args
     layouts_flat = self._input_layouts_flat()
     shardings_flat = self._input_shardings_flat()
     formats_flat = [Format(l, s) for l, s in zip(layouts_flat, shardings_flat)]

--- a/tests/aot_test.py
+++ b/tests/aot_test.py
@@ -163,7 +163,9 @@ class JaxAotTest(jtu.JaxTestCase):
     inp = jnp.arange(8.)
     compiled = f.lower(inp).compile()
     self.assertLen(compiled.args_info[0], 1)  # Not including const_args
+    self.assertEqual(compiled.args_info[0][0]._aval.shape, inp.shape)
     self.assertLen(compiled.in_avals[0], 1)
+    self.assertEqual(compiled.in_avals[0][0].shape, inp.shape)
     self.assertLen(compiled.input_shardings[0], 1)
     self.assertLen(compiled.input_formats[0], 1)
     if config.use_simplified_jaxpr_constants.value:
@@ -173,6 +175,34 @@ class JaxAotTest(jtu.JaxTestCase):
       self.assertLen(compiled._params.const_args, 0)
     self.assertArraysEqual(compiled(inp), const[0:8] + inp)
     self.assertCacheMisses(lambda: compiled(inp), cpp=0, aot_call=0)
+
+  def test_with_constants_and_dce(self):
+    const = jnp.arange(16.) + 42.  # A distinctive shape and value
+
+    @jax.jit
+    def f(x, y_dead):  # y is DCEed
+      z = const[0:8] + x
+      return z
+
+    inp = jnp.arange(8.)
+    y_dead = jnp.arange(24.)
+    compiled = f.lower(inp, y_dead).compile()
+    # `compiled.` fields include dead args, but not the const_args
+    self.assertLen(compiled.args_info[0], 2)
+    self.assertEqual(compiled.args_info[0][0]._aval.shape, inp.shape)
+    self.assertEqual(compiled.args_info[0][1]._aval.shape, y_dead.shape)
+    self.assertLen(compiled.in_avals[0], 2)
+    self.assertEqual(compiled.in_avals[0][0].shape, inp.shape)
+    self.assertEqual(compiled.in_avals[0][1].shape, y_dead.shape)
+    self.assertLen(compiled.input_shardings[0], 2)
+    self.assertLen(compiled.input_formats[0], 2)
+    if config.use_simplified_jaxpr_constants.value:
+      self.assertLen(compiled._params.const_args, 1)
+      self.assertIs(compiled._params.const_args[0], const)
+    else:
+      self.assertLen(compiled._params.const_args, 0)
+    self.assertArraysEqual(compiled(inp, y_dead), const[0:8] + inp)
+    self.assertCacheMisses(lambda: compiled(inp, y_dead), cpp=0, aot_call=0)
 
   @jtu.parameterized_filterable(
       kwargs=[


### PR DESCRIPTION
This is a continuation of the fix in #36141, also considering the case when there are dead inputs.

This change has no effect in absence of JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS because in that case _params.const_args is empty.
