### PR TITLE
[maint] add named deprecation for array dtype conversion

### DIFF
--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -304,6 +304,7 @@ pytype_strict_library(
     srcs = ["basearray.py"],
     pytype_srcs = ["basearray.pyi"],
     deps = [
+        ":deprecations",
         ":named_sharding",
         ":partition_spec",
         ":sharding",

--- a/jax/_src/basearray.py
+++ b/jax/_src/basearray.py
@@ -19,8 +19,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 import sys
 from typing import Any, Union
-import warnings
 
+from jax._src import deprecations
 from jax._src.lib import xla_client as xc
 from jax._src.util import use_cpp_class
 import numpy as np
@@ -64,10 +64,14 @@ class Array:
   @property
   def __numpy_dtype__(self) -> np.dtype:
     # __numpy_dtype__ protocol added in NumPy v2.4.0.
-    warnings.warn(
-      "Implicit conversion of an array to a dtype is deprecated;"
-      " rather than dtype=arr use dtype=arr.dtype. In the future"
-      " this will result in an error.", DeprecationWarning, stacklevel=2)
+    deprecations.warn(
+      'jax-array-numpy-dtype',
+      (
+        "Implicit conversion of an array to a dtype is deprecated;"
+        " rather than dtype=arr use dtype=arr.dtype. In the future"
+        " this will result in an error."
+      ),
+      stacklevel=2)
     return self.dtype
 
   @property

--- a/jax/_src/deprecations.py
+++ b/jax/_src/deprecations.py
@@ -123,5 +123,6 @@ def warn(deprecation_id: str, message: str, stacklevel: int) -> None:
 
 # Register a number of deprecations: we do this here to ensure they're
 # always registered by the time `accelerate` and `is_acelerated` are called.
+register('jax-array-numpy-dtype')
 register('jax-nn-one-hot-float-input')
 register('jax-numpy-astype-complex-to-real')

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -889,6 +889,13 @@ class JaxArrayTest(jtu.JaxTestCase):
     self.assertIn('nreduced', str(x.sharding))
     self.assertIn('Array(shape=(), dtype=float32, sharding=', str(x))
 
+  @unittest.skipIf(jtu.numpy_version() < (2, 4, 0), "__numpy_dtype__ protocol requires NumPy v2.4 or later")
+  def test_deprecated_dtype_conversion(self):
+    x = jnp.arange(4)
+    msg = "Implicit conversion of an array to a dtype is deprecated"
+    with self.assertDeprecationWarnsOrRaises("jax-array-numpy-dtype", msg):
+      np.dtype(x)
+
 
 class ShardingTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
This will let us begin migrating downstream targets internally, in preparation for finalizing this deprecation once we require NumPy 2.4.