### PR TITLE
`IrTypes` and `IrValues` are no longer `Any`

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -865,7 +865,7 @@ def _remat_lowering(
     barrier_op = hlo.OptimizationBarrierOp(
         mlir.flatten_ir_values(barrier_args))
     barrier_results = mlir.unflatten_ir_values_like_types(
-        barrier_op.results, map(mlir.aval_to_ir_type, barrier_avals))
+        barrier_op.results, map(mlir._aval_to_ir_types, barrier_avals))
     args = merge_lists(prevent_cse, other_args, barrier_results)
   outs, tokens_out = mlir.jaxpr_subcomp(
       ctx.module_context, jaxpr, ctx.name_stack.extend('checkpoint'),

--- a/jax/_src/callback.py
+++ b/jax/_src/callback.py
@@ -637,7 +637,8 @@ def receive_from_host(
     sharding: SdyArrayList | xc.OpSharding | None = None,
 ) -> tuple[ir.Value, ir.Value]:
   channel_handle = hlo.ChannelHandle.get(channel, mlir.RECV_FROM_HOST_TYPE)
-  recv_op = hlo.RecvOp([mlir.aval_to_ir_type(out_aval),
+  out_type = mlir.aval_to_ir_type(out_aval)
+  recv_op = hlo.RecvOp([out_type,
                         hlo.TokenType.get()], token, channel_handle,
                         is_host_transfer=ir.BoolAttr.get(True))
   recv_op.attributes["mhlo.frontend_attributes"] = ir.DictAttr.get(

--- a/jax/_src/compute_on.py
+++ b/jax/_src/compute_on.py
@@ -110,7 +110,7 @@ def _compute_on_lowering(ctx, *args, jaxpr, compute_type, out_memory_spaces):
   const_args_and_avals = core.jaxpr_const_args(jaxpr.jaxpr)
   const_args, const_avals = unzip2(const_args_and_avals)
   const_arg_values = [
-      mlir.ir_constant(c, const_lowering=ctx.const_lowering, aval=aval)
+      mlir.ir_constants(c, const_lowering=ctx.const_lowering, aval=aval)
       for c, aval in const_args_and_avals]
   in_avals = (*const_avals, *ctx.avals_in)
   func_op, output_types, effects = mlir.lower_called_computation(

--- a/jax/_src/custom_partitioning.py
+++ b/jax/_src/custom_partitioning.py
@@ -618,7 +618,7 @@ def _custom_partitioning_lowering_rule(ctx: mlir.LoweringRuleContext, *values,
   # partitioner runs so we keep it alive by attaching it to the executable.
   ctx.module_context.add_keepalive(sharding_callback_info)
 
-  result_types = [mlir.aval_to_ir_type(s) for s in call.out_avals]
+  result_types = mlir.flatten_ir_types(map(mlir.aval_to_ir_types, call.out_avals))
   out = hlo.CustomCallOp(
       result_types,
       list(values),
@@ -630,7 +630,7 @@ def _custom_partitioning_lowering_rule(ctx: mlir.LoweringRuleContext, *values,
       operand_layouts=None,
       result_layouts=None)
   if sharding_rule is not None:
-    value_types = [mlir.aval_to_ir_type(s) for s in call.in_avals]
+    value_types = mlir.flatten_ir_types(map(mlir.aval_to_ir_types, call.in_avals))
     if callable(sharding_rule):
       sharding_rule = sharding_rule(*static_args, mesh, value_types, result_types)
       if isinstance(sharding_rule, (list, tuple)) and len(sharding_rule) == 2:

--- a/jax/_src/custom_partitioning_sharding_rule.py
+++ b/jax/_src/custom_partitioning_sharding_rule.py
@@ -15,7 +15,6 @@
 """Implements SdyShardingRule."""
 
 from collections import OrderedDict
-from typing import Union
 
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import sdy
@@ -28,8 +27,6 @@ BATCHING: str = "…"
 # leading ... into factors.
 _BATCHING_DIM_FACTOR_PREFIX = "?"
 
-# A Jax value in general corresponds to an ir.Type or a tuple of ir.Types.
-IrTypes = Union[ir.Type, tuple[ir.Type, ...]]
 
 def _check_factor(factor:str):
   """Validates a factor.
@@ -365,8 +362,8 @@ def str_to_sdy_sharding_rule(rule: str, *,
 
 def sdy_sharding_rule_to_mlir(
   rule: SdyShardingRule,
-  operand_types: list[IrTypes],
-  result_types: list[IrTypes],) -> ir.Attribute:
+  operand_types: list[ir.Type],
+  result_types: list[ir.Type],) -> ir.Attribute:
   """Builds the MLIR representation for the sharding rule.
 
   This is done by verifying that the rule is consistent with the types of

--- a/jax/_src/export/_export.py
+++ b/jax/_src/export/_export.py
@@ -1660,7 +1660,7 @@ def _call_exported_lowering(ctx: mlir.LoweringRuleContext, *args,
                     new_aval: core.AbstractValue) -> ir.Value:
     new_ir_type = mlir.aval_to_ir_type(new_aval)
     if x.type != new_ir_type:
-      return hlo.convert(mlir.aval_to_ir_type(new_aval), x)
+      return hlo.convert(new_ir_type, x)
     else:
       return x
 

--- a/jax/_src/ffi.py
+++ b/jax/_src/ffi.py
@@ -246,7 +246,7 @@ def build_ffi_lowering_function(
             f"of at least 4; got api_version={kwargs['api_version']}.")
       kwargs["backend_config"] = backend_config
     if "result_types" not in kwargs:
-      kwargs["result_types"] = [mlir.aval_to_ir_type(aval) for aval in ctx.avals_out]
+      kwargs["result_types"] = mlir.flatten_ir_types(map(mlir.aval_to_ir_types, ctx.avals_out))
     if not skip_ffi_layout_processing:
       if operand_layouts is None:
         kwargs["operand_layouts"] = map(

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -76,8 +76,7 @@ Value = ir.Value
 # IR Helpers
 
 # TODO(slebedev): Fix all callers and uncomment this.
-# IrValues = Union[ir.Value, tuple[ir.Value, ...]]
-IrValues = Any
+IrValues = ir.Value | tuple[ir.Value, ...]
 
 
 def dense_int_elements(xs) -> ir.DenseElementsAttr:
@@ -88,7 +87,7 @@ dense_int_array = ir.DenseI64ArrayAttr.get
 def i32_attr(i): return ir.IntegerAttr.get(ir.IntegerType.get_signless(32), i)
 def i64_attr(i): return ir.IntegerAttr.get(ir.IntegerType.get_signless(64), i)
 
-def shape_tensor(sizes: Sequence[int | ir.Value]) -> IrValues:
+def shape_tensor(sizes: Sequence[int | ir.Value]) -> ir.Value:
   int1d = aval_to_ir_type(core.ShapedArray((1,), np.int32))
   i32_type = aval_to_ir_type(core.ShapedArray((), np.int32))
   def lower_dim(d):
@@ -118,8 +117,7 @@ def delegate_lowering(ctx, lowering_fun, *args, **ctx_override_kwargs):
 # IR Types
 
 # TODO(slebedev): Fix all callers and uncomment this.
-# IrTypes = Union[ir.Type, tuple[ir.Type, ...]]
-IrTypes = Any
+IrTypes = ir.Type | tuple[ir.Type, ...]
 
 def _is_ir_values(x: IrValues) -> bool:
   """Returns true if `x` is an ir.Value or tuple of ir.Values"""
@@ -199,15 +197,16 @@ def _dynamic_array_ir_types(aval: core.ShapedArray) -> ir.Type:
 
 ir_type_handlers: dict[type[core.AbstractValue], Callable[[Any], IrTypes]] = {}
 
-def aval_to_ir_type(aval: core.AbstractValue) -> IrTypes:
-  """Converts a JAX aval to zero or more MLIR IR types.
+def aval_to_ir_type(aval: core.AbstractValue) -> ir.Type:
+  """Converts a JAX aval to a single MLIR IR type.
 
-  In general, a JAX value may be represented by multiple IR values, so this
-  function may return a tuple of types."""
-  try:
-    return ir_type_handlers[type(aval)](aval)
-  except KeyError as err:
-    raise TypeError(f"No ir_type_handler for aval type: {type(aval)}") from err
+  Use only when ``aval`` is known to map to a single IR type. For opaque
+  avals, use ``aval_to_ir_types`` instead.
+  """
+  ir_type = _aval_to_ir_types(aval)
+  if isinstance(ir_type, ir.Type):
+    return ir_type
+  raise TypeError(f"Expected a single IR type, got {ir_type}")
 
 ir_type_handlers[core.ShapedArray] = _array_ir_types
 ir_type_handlers[core.AbstractToken] = lambda _: hlo.TokenType.get()
@@ -215,10 +214,23 @@ if jaxlib_extension_version >= 427:
   # pyrefly: ignore[missing-attribute]
   ir_type_handlers[core.AbstractTodo] = lambda x: hlo.FutureType.get([_array_ir_types(x.inner_aval)])
 
-# This is a backwards compatibility shim for external users of jax.mlir apis.
 def aval_to_ir_types(aval: core.AbstractValue) -> tuple[ir.Type, ...]:
-  typ = aval_to_ir_type(aval)
-  return (typ,) if isinstance(typ, ir.Type) else typ
+  """Converts a JAX aval to one or more MLIR IR types.
+
+  In general, a JAX value may be represented by multiple IR values, so this
+  function returns a tuple of types. This is the safe version to use when the
+  concrete type of ``aval`` is not known.
+  """
+  ir_types = _aval_to_ir_types(aval)
+  return (ir_types,) if isinstance(ir_types, ir.Type) else ir_types
+
+
+def _aval_to_ir_types(aval: core.AbstractValue) -> IrTypes:
+  try:
+    return ir_type_handlers[type(aval)](aval)
+  except KeyError as err:
+    raise TypeError(f"No ir_type_handler for aval type: {type(aval)}") from err
+
 
 # Constants
 
@@ -236,25 +248,70 @@ def register_constant_handler(type_: type, handler_fun: ConstantHandler):
 def get_constant_handler(type_: type) -> ConstantHandler:
   return _constant_handlers[type_]
 
+
 def ir_constant(
-  val: Any, *,
-  const_lowering: dict[tuple[int, core.AbstractValue], IrValues] | None = None,
-  aval: core.AbstractValue | None = None
-) -> IrValues:
-  """Translate a Python `val` to an IR constant.
+    val: Any, *,
+    const_lowering: dict[tuple[int, core.AbstractValue], IrValues] | None = None,
+    aval: core.AbstractValue | None = None
+) -> ir.Value:
+  """Translate a Python ``val`` to an IR constant.
 
   See https://docs.jax.dev/en/latest/internals/constants.html.
+
   Args:
     val: a Python value to be translated to a constant.
     const_lowering: an optional dictionary with known lowering for some
-      constants, indexed by `id`. This is used, e.g., when we pass constants
+      constants, indexed by ``id``. This is used, e.g., when we pass constants
       as MLIR function arguments.
-    aval: the abstract value of `val`, if known. Required where ambiguous, e.g.
-      for Python scalars.
+    aval: the abstract value of ``val``, if known. Required where ambiguous,
+      e.g. for Python scalars.
 
   Returns:
-    A representation of the constant as an IR value or sequence of IR values.
+    A representation of the constant as an IR value.
+
+  Raises:
+    ValueError: if the constant is represented by more than one IR value.
+    TypeError: if no constant handler is registered for the type of `val`.
   """
+  value = _ir_constant(val, const_lowering=const_lowering, aval=aval)
+  if isinstance(value, tuple):
+    raise ValueError(
+        f"Expected a constant to produce a single ir.Value, got {value}"
+    )
+  return value
+
+
+def ir_constants(
+    val: Any, *,
+    const_lowering: dict[tuple[int, core.AbstractValue], IrValues] | None = None,
+    aval: core.AbstractValue | None = None
+) -> tuple[ir.Value, ...]:
+  """Translate a Python ``val`` to a sequence of IR constants.
+
+  See https://docs.jax.dev/en/latest/internals/constants.html.
+
+  Args:
+    val: a Python value to be translated.
+    const_lowering: an optional dictionary with known lowering for some
+      constants, indexed by ``id``. This is used, e.g., when we pass constants
+      as MLIR function arguments.
+    aval: the abstract value of ``val``, if known. Required where ambiguous,
+      e.g. for Python scalars.
+
+  Returns:
+    A representation of the constant as a sequence of IR values.
+
+  Raises:
+    TypeError: if no constant handler is registered for the type of ``val``.
+  """
+  values = _ir_constant(val, const_lowering=const_lowering, aval=aval)
+  return values if isinstance(values, tuple) else (values,)
+
+
+def _ir_constant(val: Any, *,
+  const_lowering: dict[tuple[int, core.AbstractValue], IrValues] | None = None,
+  aval: core.AbstractValue | None = None
+) -> IrValues:
   if const_lowering is not None:
     # pyrefly: ignore[bad-argument-type]
     if np.shape(val) and (c_val := const_lowering.get((id(val), aval))) is not None:
@@ -269,7 +326,8 @@ def ir_constant(
     return ir_constant(val.__jax_array__())
   raise TypeError(f"No constant handler for type: {type(val)}")
 
-def _numpy_array_constant(x: np.ndarray | np.generic) -> IrValues:
+
+def _numpy_array_constant(x: np.ndarray | np.generic) -> ir.Value:
   return hlo.constant(_numpy_array_attribute(x))
 
 
@@ -1589,8 +1647,8 @@ def lower_jaxpr_to_fun(
   assert arg_names is None or nr_args == len(arg_names), (nr_args, arg_names)
 
   # Function inputs: *dim_var_values, *tokens, *const_args, *actual_inputs
-  input_types = map(aval_to_ir_type, in_avals)
-  output_types = map(aval_to_ir_type, jaxpr.out_avals)
+  input_types = map(_aval_to_ir_types, in_avals)
+  output_types = map(_aval_to_ir_types, jaxpr.out_avals)
   num_tokens = len(effects)
 
   token_types = [token_type() for _ in effects]
@@ -1849,9 +1907,9 @@ def lower_jaxpr_to_fun(
     const_args_and_avals = core.jaxpr_const_args(jaxpr.jaxpr)
     if num_const_args == 0:
       # If we did not hoist the constants out of this function, lower them now
-      const_arg_values = [ir_constant(c, aval=aval)
+      const_arg_values = [ir_constants(c, aval=aval)
                           for c, aval in const_args_and_avals]
-    const_lowering = {
+    const_lowering: dict[tuple[int, core.AbstractValue], IrValues] = {
         (id(c), aval): c_arg
         for (c, aval), c_arg in zip(const_args_and_avals, const_arg_values)
     }
@@ -1884,7 +1942,7 @@ def lower_jaxpr_to_fun(
     tokens_in = TokenSet(zip(effects, token_args))
     args: list[IrValues] = unflattened_args
     unique_consts = {
-        id(c): ir_constant(c, aval=var.aval)
+        id(c): _ir_constant(c, aval=var.aval)
         for c, var in zip(jaxpr.consts, jaxpr.jaxpr.constvars)
     }
     consts_for_constvars = [unique_consts[id(c)] for c in jaxpr.consts]
@@ -1953,9 +2011,7 @@ def wrap_with_memory_kind(
   if aval_out is None:
     result_type = x.type
   else:
-    typ = aval_to_ir_type(aval_out)
-    assert isinstance(typ, ir.Type), typ
-    result_type = typ
+    (result_type,) = aval_to_ir_types(aval_out)
   op = custom_call("annotate_device_placement", result_types=[result_type],
                    operands=[x], has_side_effect=True, api_version=1)
   op.attributes["mhlo.frontend_attributes"] = ir.DictAttr.get({
@@ -2016,7 +2072,7 @@ def jaxpr_subcomp(
 
   def read(v: core.Atom) -> IrValues:
     if type(v) is core.Literal:
-      return ir_constant(v.val, const_lowering=const_lowering, aval=v.aval)
+      return _ir_constant(v.val, const_lowering=const_lowering, aval=v.aval)
     else:
       assert isinstance(v, core.Var)
       return env[v]
@@ -2156,7 +2212,7 @@ def _cached_lowering(
 
   tokens_in_args = tuple(tokens_in.get(eff) for eff in ordered_effects)
   const_arg_values = tuple(
-      ir_constant(c, const_lowering=const_lowering, aval=aval)
+      ir_constants(c, const_lowering=const_lowering, aval=aval)
       for c, aval in zip(cache_entry.const_args, cache_entry.const_arg_avals)
   )
   args = flatten_ir_values(
@@ -2195,8 +2251,8 @@ def _emit_lowering_rule_as_fun(
 
   const_args, const_arg_avals = util.unzip2(core.eqn_params_const_args(params))
 
-  input_types = map(aval_to_ir_type, const_arg_avals + avals_in)  # type: ignore
-  output_types = map(aval_to_ir_type, avals_out)
+  input_types = map(_aval_to_ir_types, const_arg_avals + avals_in)  # type: ignore
+  output_types = map(_aval_to_ir_types, avals_out)
   token_types = [token_type() for _ in ordered_effects]
   input_types = [*dim_var_types, *token_types, *input_types]
   output_types = [*token_types, *output_types]
@@ -2437,7 +2493,7 @@ def lower_per_platform(ctx: LoweringRuleContext,
       hlo.return_([ir_constant(np.int32(platform_to_kept_rules_idx[p]))])
   ordered_effects = effects_lib.ordered_effects.filter_in(effects)
   rule_out_avals = [core.abstract_token] * len(ordered_effects) + ctx.avals_out
-  output_types = map(aval_to_ir_type, rule_out_avals)
+  output_types = map(_aval_to_ir_types, rule_out_avals)
   case_op = hlo.CaseOp(flatten_ir_types(output_types),
                       index=rule_idx_op.result,
                       num_branches=len(kept_rules))
@@ -2482,7 +2538,7 @@ def lower_per_platform(ctx: LoweringRuleContext,
 
 def ir_consts(consts, avals: Sequence[core.AbstractValue]) -> list[IrValues]:
   uniq_consts = {
-      id(c): ir_constant(c, aval=aval) for c, aval in zip(consts, avals)
+      id(c): _ir_constant(c, aval=aval) for c, aval in zip(consts, avals)
   }
   return [uniq_consts[id(c)] for c in consts]
 
@@ -2570,7 +2626,7 @@ def lower_called_computation(
   assert isinstance(call_jaxpr, core.ClosedJaxpr), type(call_jaxpr)
   check_backend_matches(backend, ctx.platforms)
   effects = list(tokens_in.effects())
-  output_types = map(aval_to_ir_type, out_avals)
+  output_types = map(_aval_to_ir_types, out_avals)
   output_types = [token_type()] * len(effects) + output_types
   func_op = _lower_jaxpr_to_fun_cached(
       ctx, fn_name, call_jaxpr, num_const_args, effects, in_avals=in_avals,
@@ -2588,7 +2644,7 @@ def call_lowering(fn_name, call_jaxpr: core.ClosedJaxpr, backend,
   assert isinstance(call_jaxpr, core.ClosedJaxpr), type(call_jaxpr)
   const_args_and_avals = core.jaxpr_const_args(call_jaxpr.jaxpr)
   const_args, const_avals = util.unzip2(const_args_and_avals)
-  const_arg_values = [ir_constant(c, const_lowering=const_lowering, aval=aval)
+  const_arg_values = [ir_constants(c, const_lowering=const_lowering, aval=aval)
                       for c, aval in const_args_and_avals]
   args = tuple(const_arg_values) + args
   if arg_names is not None:
@@ -2697,16 +2753,18 @@ def broadcast_in_dim(ctx: LoweringRuleContext, op, aval_out: core.AbstractValue,
   else:
     if not core.is_constant_shape(aval_out.shape):  # type: ignore
       shape = eval_dynamic_shape_as_tensor(ctx, aval_out.shape)  # type: ignore
+      (result_type,) = aval_to_ir_types(aval_out)
       out = hlo.dynamic_broadcast_in_dim(
-          aval_to_ir_type(aval_out), op,
+          result_type, op,
           shape,
           dense_int_array(broadcast_dimensions),
       )
     else:
       assert all(d != ir.ShapedType.get_dynamic_size()
                  for d in aval_out.shape), aval_out  # type: ignore
+      (result_type,) = aval_to_ir_types(aval_out)
       out = hlo.broadcast_in_dim(
-          aval_to_ir_type(aval_out), op,
+          result_type, op,
           dense_int_array(broadcast_dimensions))
     wrap_compute_type_in_place(ctx, _get_owner(out))
     return out
@@ -2745,11 +2803,13 @@ def reshape(ctx: LoweringRuleContext, op, aval_out: core.AbstractValue) -> ir.Va
   aval_out = core.physical_aval(aval_out)
   if not core.is_constant_shape(aval_out.shape):  # type: ignore
     shape = eval_dynamic_shape_as_tensor(ctx, aval_out.shape)  # type: ignore
+    (result_type,) = aval_to_ir_types(aval_out)
     return hlo.dynamic_reshape(
-        aval_to_ir_type(aval_out), op, shape,
+        result_type, op, shape,
     )
   else:
-    return hlo.reshape(aval_to_ir_type(aval_out), op)
+    (result_type,) = aval_to_ir_types(aval_out)
+    return hlo.reshape(result_type, op)
 
 def slice_op(ctx: LoweringRuleContext, x, aval_out, *,
              start_indices, limit_indices, strides) -> ir.Value:
@@ -2768,8 +2828,9 @@ def slice_op(ctx: LoweringRuleContext, x, aval_out, *,
       start_indices = eval_dynamic_shape_as_tensor(ctx, start_indices)
       limit_indices = eval_dynamic_shape_as_tensor(ctx, limit_indices)
       strides = eval_dynamic_shape_as_tensor(ctx, strides)
+      (result_type,) = aval_to_ir_types(aval_out)
       return hlo.real_dynamic_slice(
-        aval_to_ir_type(aval_out),
+        result_type,
         x, start_indices, limit_indices, strides)
     else:
       return hlo.slice(x,
@@ -2801,8 +2862,9 @@ def dynamic_slice(ctx: LoweringRuleContext, aval_out, x, *,
       hlo.subtract(
         eval_dynamic_shape_as_tensor(ctx, x_aval.shape),  # type: ignore
         slice_sizes))
+    (result_type,) = aval_to_ir_types(aval_out)
     return hlo.real_dynamic_slice(
-        aval_to_ir_type(aval_out), x,
+        result_type, x,
         clamped_start,
         hlo.add(clamped_start, slice_sizes),
         shape_tensor([1] * len(start_indices))
@@ -2838,20 +2900,23 @@ def pad(ctx: LoweringRuleContext, aval_out,
     padding_low = eval_dynamic_shape_as_tensor(ctx, padding_low)
     padding_high = eval_dynamic_shape_as_tensor(ctx, padding_high)
     padding_interior = eval_dynamic_shape_as_tensor(ctx, padding_interior)
+    (result_type,) = aval_to_ir_types(aval_out)
     return hlo.dynamic_pad(
-        aval_to_ir_type(aval_out),
+        result_type,
         x, padding_value, padding_low, padding_high, padding_interior)
 
 def iota(ctx: LoweringRuleContext, aval_out, *, dimension: int):
   if not core.is_constant_shape(aval_out.shape):
     shape = eval_dynamic_shape_as_tensor(ctx, aval_out.shape)
+    (result_type,) = aval_to_ir_types(aval_out)
     return hlo.dynamic_iota(
-        aval_to_ir_type(aval_out),
+        result_type,
         shape,
         i64_attr(dimension),
     )
   else:
-    return hlo.iota(aval_to_ir_type(aval_out), i64_attr(dimension))
+    (result_type,) = aval_to_ir_types(aval_out)
+    return hlo.iota(result_type, i64_attr(dimension))
 
 def full_like_aval(ctx: LoweringRuleContext, value, aval: core.ShapedArray) -> ir.Value:
   """Returns an IR constant shaped full of `value` shaped like `aval`."""
@@ -2919,7 +2984,8 @@ def convert_hlo(ctx: LoweringRuleContext, x, aval_in, aval_out):
       compare_type = "UNSIGNED"
     x = compare_hlo(x, full_like_aval(ctx, 0, aval_in), "NE", compare_type)
     # continue, to adjust the shape if needed
-  return hlo.convert(aval_to_ir_type(aval_out), x)
+  (result_type,) = aval_to_ir_types(aval_out)
+  return hlo.convert(result_type, x)
 
 def _wrap_with_spmd_op(name: str,
                        ctx: LoweringRuleContext,
@@ -2939,8 +3005,7 @@ def _wrap_with_spmd_op(name: str,
         [str(i) for i in sorted(unspecified_dims)]) + "]"
   else:
     backend_config = ""
-  result_type = aval_to_ir_type(aval_out)
-  assert isinstance(result_type, ir.Type), result_type
+  (result_type,) = aval_to_ir_types(aval_out)
   out_shape = core.physical_aval(aval_out).shape  # type: ignore
   if core.is_constant_shape(out_shape):
     result_shapes = None
@@ -3015,8 +3080,7 @@ def wrap_with_layout_op(ctx: LoweringRuleContext,
                         aval_out: core.AbstractValue,
                         layout: Layout,
                         aval_in: core.AbstractValue):
-  result_type = aval_to_ir_type(aval_out)
-  assert isinstance(result_type, ir.Type), result_type
+  (result_type,) = aval_to_ir_types(aval_out)
   out_shape = core.physical_aval(aval_out).shape  # type: ignore
   if core.is_constant_shape(out_shape):
     result_shapes = None
@@ -3259,7 +3323,7 @@ def reduce_window(
     window_dimensions, window_strides, padding, base_dilation, window_dilation):
   """Builds a ReduceWindowOp, with support for dynamic shapes."""
 
-  scalar_types = flatten_ir_types([aval_to_ir_type(aval) for aval in init_values_avals])
+  scalar_types = flatten_ir_types(map(aval_to_ir_types, init_values_avals))
   if any(not core.is_constant_shape(s)
          for s in [window_dimensions, window_dilation, window_strides, base_dilation, *padding]):
     # d_padding will be an array i32[N, 2] with pad_lo and pad_hi for each
@@ -3281,7 +3345,7 @@ def reduce_window(
 
     rw = custom_call(
       "stablehlo.dynamic_reduce_window",
-      result_types=flatten_ir_types(map(aval_to_ir_type, out_avals)),
+      result_types=flatten_ir_types(map(aval_to_ir_types, out_avals)),
       operands=[
         *operands, *init_values,
         eval_dynamic_shape_as_tensor(ctx, window_dimensions),
@@ -3293,7 +3357,7 @@ def reduce_window(
     )
   else:  # Static shapes
     rw = hlo.ReduceWindowOp(
-        list(map(aval_to_ir_type, out_avals)),
+        flatten_ir_types(map(aval_to_ir_types, out_avals)),
         operands, init_values,
         dense_int_array(window_dimensions),
         window_strides=dense_int_array(window_strides),

--- a/jax/_src/lax/ann.py
+++ b/jax/_src/lax/ann.py
@@ -299,9 +299,7 @@ def _approx_top_k_lowering(ctx, operand, *, k,
 
   init_arg = hlo.constant(ir.DenseElementsAttr.get(np.int32(-1)))  # pyrefly: ignore[no-matching-overload]
   init_val_array = _get_init_val_literal(ctx.avals_in[0].dtype, is_max_k)
-  init_vals = mlir.flatten_ir_values(
-      [mlir.ir_constant(init_val_array.reshape(()))
-  ])
+  init_vals = [mlir.ir_constant(init_val_array.reshape(()))]
 
   backend_config = {
     "reduction_dim" : mlir.i64_attr(reduction_dimension),
@@ -324,9 +322,7 @@ def _approx_top_k_lowering(ctx, operand, *, k,
     backend_config["top_k"] = mlir.i64_attr(k)
     out = mlir.custom_call(
         "ApproxTopK",
-        result_types=mlir.flatten_ir_types(
-            mlir.aval_to_ir_type(aval) for aval in ctx.avals_out
-        ),
+        result_types=mlir.flatten_ir_types(map(mlir.aval_to_ir_types, ctx.avals_out)),
         operands=[operand, iota, *init_vals, init_arg],
         called_computations=[comparator.name.value],
         backend_config=backend_config,
@@ -335,9 +331,7 @@ def _approx_top_k_lowering(ctx, operand, *, k,
     k_value, = mlir.eval_dynamic_shape_as_vals(ctx, (k,))
     out = mlir.custom_call(
         "stablehlo.dynamic_approx_top_k",
-        result_types=mlir.flatten_ir_types(
-            mlir.aval_to_ir_type(aval) for aval in ctx.avals_out
-        ),
+        result_types=mlir.flatten_ir_types(map(mlir.aval_to_ir_types, ctx.avals_out)),
         operands=[operand, iota, *init_vals, init_arg, k_value],
         called_computations=[comparator.name.value],
         backend_config=backend_config,

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -1022,7 +1022,7 @@ def _cond_lowering(ctx, index, *args, branches, **params):
   tokens_in = ctx.tokens_in.subset(ordered_effects)
   output_token_types = [mlir.token_type() for _ in ordered_effects]
   output_types = [
-      *output_token_types, *map(mlir.aval_to_ir_type, ctx.avals_out)]
+      *output_token_types, *map(mlir._aval_to_ir_types, ctx.avals_out)]
   flat_output_types = mlir.flatten_ir_types(output_types)
 
   # CaseOp takes a single argument 'index' and the corresponding blocks
@@ -1034,10 +1034,8 @@ def _cond_lowering(ctx, index, *args, branches, **params):
   for i, jaxpr in enumerate(branches):
     branch = case_op.regions[i].blocks.append()
     with ir.InsertionPoint(branch):
-      consts = [
-          mlir.ir_constant(x, aval=var.aval)
-          for x, var in zip(jaxpr.consts, jaxpr.jaxpr.constvars)
-      ]
+      consts = mlir.ir_consts(
+          jaxpr.consts, [v.aval for v in jaxpr.jaxpr.constvars])
       out_vals, tokens_out = mlir.jaxpr_subcomp(
           ctx.module_context, jaxpr.jaxpr, name_stack.extend(f'branch_{i}_fun'),
           tokens_in, consts, *args,
@@ -1198,8 +1196,7 @@ def _platform_index_lowering(ctx: mlir.LoweringRuleContext,
                              platforms: BranchesPlatforms):
   def lower_constant(ctx: mlir.LoweringRuleContext, *,
                      i: int) -> Sequence[ir.Value]:
-    v = mlir.ir_constant(np.int32(i))
-    return mlir.flatten_ir_values([v])
+    return [mlir.ir_constant(np.int32(i))]
 
   platform_rules: dict[str, mlir.LoweringRule] = {}
   default_rule = None

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -2047,7 +2047,7 @@ def _while_lowering(ctx, *args, cond_jaxpr, body_jaxpr, cond_nconsts,
       return out
     return mlir.lower_fun(fun)(ctx, *args)
 
-  loop_carry_types = _map(mlir.aval_to_ir_type, ctx.avals_in)
+  loop_carry_types = _map(mlir._aval_to_ir_types, ctx.avals_in)
   body_effects = effects.ordered_effects.filter_in(body_jaxpr.effects)
   num_tokens = len(body_effects)
   tokens = [ctx.tokens_in.get(eff) for eff in body_effects]
@@ -2069,10 +2069,8 @@ def _while_lowering(ctx, *args, cond_jaxpr, body_jaxpr, cond_nconsts,
     cond_args = mlir.unflatten_ir_values_like_types(flat_cond_args, loop_carry_types)
     cond_args = cond_args[num_tokens:]  # Remove tokens from cond args
     x, _, z = util.split_list(cond_args, [cond_nconsts, body_nconsts])
-    cond_consts = [
-        mlir.ir_constant(x, aval=var.aval)
-        for x, var in zip(cond_jaxpr.consts, cond_jaxpr.jaxpr.constvars)
-    ]
+    cond_consts = mlir.ir_consts(
+        cond_jaxpr.consts, [v.aval for v in cond_jaxpr.jaxpr.constvars])
     cond_name_stack = name_stack.extend('cond')
     (pred,), _ = mlir.jaxpr_subcomp(
         ctx.module_context,
@@ -2104,7 +2102,7 @@ def _while_lowering(ctx, *args, cond_jaxpr, body_jaxpr, cond_nconsts,
           pred_ctx,
           pred,
           axes=tuple(range(len(pred_aval.shape))))
-    hlo.return_([pred])
+    hlo.return_(mlir.flatten_ir_values([pred]))
 
   # Loop body
   body_block = while_op.regions[1].blocks.append(*flat_loop_carry_types)
@@ -2118,10 +2116,8 @@ def _while_lowering(ctx, *args, cond_jaxpr, body_jaxpr, cond_nconsts,
     tokens_in = mlir.TokenSet(zip(body_effects, token_args))
     x, y, z = util.split_list(body_args, [cond_nconsts, body_nconsts])
     body_name_stack = name_stack.extend('body')
-    body_consts = [
-        mlir.ir_constant(x, aval=var.aval)
-        for x, var in zip(body_jaxpr.consts, body_jaxpr.jaxpr.constvars)
-    ]
+    body_consts = mlir.ir_consts(
+        body_jaxpr.consts, [v.aval for v in body_jaxpr.jaxpr.constvars])
     new_z, tokens_out = mlir.jaxpr_subcomp(
         ctx.module_context, body_jaxpr.jaxpr, body_name_stack,
         tokens_in, body_consts, *(y + z),
@@ -2130,10 +2126,8 @@ def _while_lowering(ctx, *args, cond_jaxpr, body_jaxpr, cond_nconsts,
     out_tokens = [tokens_out.get(eff) for eff in body_effects]
     if batched:
       body_pred_name_stack = name_stack.extend('body_pred')
-      cond_consts = [
-          mlir.ir_constant(x, aval=var.aval)
-          for x, var in zip(cond_jaxpr.consts, cond_jaxpr.jaxpr.constvars)
-      ]
+      cond_consts = mlir.ir_consts(
+          cond_jaxpr.consts, [v.aval for v in cond_jaxpr.jaxpr.constvars])
       (body_pred,), _ = mlir.jaxpr_subcomp(
           ctx.module_context, cond_jaxpr.jaxpr, body_pred_name_stack,
           mlir.TokenSet(), cond_consts, *(x + z),
@@ -2389,7 +2383,7 @@ def _pred_bcast_select_hlo(ctx,
     pred_aval: core.ShapedArray, pred: ir.Value, x: mlir.IrValues,
     y: mlir.IrValues, x_y_aval: core.AbstractValue) -> Sequence[ir.Value]:
   if x_y_aval is core.abstract_token:
-    return [hlo.AfterAllOp([x, y]).result]
+    return [hlo.after_all(mlir.flatten_ir_values([x, y]))]
   else:
     assert isinstance(x, ir.Value), x
     assert isinstance(y, ir.Value), y

--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -813,8 +813,9 @@ def _conv_general_dilated_lower(
     # TODO(https://github.com/openxla/stablehlo/issues/1268)
     raise NotImplementedError("Convolutions with non-static strides, dilation, feature_group_count, or batch_group_count")
   if all(core.is_constant_shape(p) for p in padding):
+    result_type = mlir.aval_to_ir_type(aval_out)
     out = hlo.convolution(
-        mlir.aval_to_ir_type(aval_out), lhs, rhs,
+        result_type, lhs, rhs,
         dimension_numbers=dnums,
         feature_group_count=mlir.i64_attr(feature_group_count),
         batch_group_count=mlir.i64_attr(batch_group_count),
@@ -835,9 +836,10 @@ def _conv_general_dilated_lower(
     d_padding = hlo.concatenate(
         list(map(prep_one_pad, padding)), mlir.i64_attr(0)
     )
+    result_type = mlir.aval_to_ir_type(aval_out)
     return [
         hlo.dynamic_conv(
-          mlir.aval_to_ir_type(aval_out),
+          result_type,
           lhs,
           rhs,
           d_padding,

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1895,7 +1895,7 @@ def _composite_lowering(
   const_args_and_avals = core.jaxpr_const_args(jaxpr.jaxpr)
   const_args, const_avals = util.unzip2(const_args_and_avals)
   const_arg_values = tuple(
-      mlir.ir_constant(c, const_lowering=ctx.const_lowering, aval=aval)
+      mlir.ir_constants(c, const_lowering=ctx.const_lowering, aval=aval)
       for c, aval in const_args_and_avals
   )
   in_avals = (*const_avals, *ctx.avals_in)
@@ -5219,7 +5219,8 @@ batching.defvectorized(bitcast_convert_type_p)
 
 def _bitcast_convert_type_lower(ctx, operand, *, new_dtype):
   aval_out, = ctx.avals_out
-  out = hlo.bitcast_convert(mlir.aval_to_ir_type(aval_out), operand)
+  out_type = mlir.aval_to_ir_type(aval_out)
+  out = hlo.bitcast_convert(out_type, operand)
   return [mlir.lower_with_sharding_in_types(ctx, out, aval_out)]
 
 mlir.register_lowering(bitcast_convert_type_p, _bitcast_convert_type_lower)
@@ -5822,8 +5823,9 @@ def _dot_general_lower(ctx, lhs, rhs, *, dimension_numbers,
       rhs_batching_dimensions=list(rhs_batch),
       lhs_contracting_dimensions=list(lhs_contracting),
       rhs_contracting_dimensions=list(rhs_contracting))
+  acc_type = mlir.aval_to_ir_type(accumulation_aval)
   result = hlo.dot_general(
-      mlir.aval_to_ir_type(accumulation_aval),
+      acc_type,
       lhs,
       rhs,
       dot_dnums,
@@ -6397,8 +6399,9 @@ def _ragged_dot_general_lower(
       ),
       rhs_group_dimensions=list(rhs_group_dims),
   )
+  acc_type = mlir.aval_to_ir_type(accumulation_aval)
   result = chlo.ragged_dot(
-      mlir.aval_to_ir_type(accumulation_aval),
+      acc_type,
       lhs,
       rhs,
       group_sizes,
@@ -7740,9 +7743,9 @@ def _reduce_lower(ctx: mlir.LoweringRuleContext, *values,
   assert all(isinstance(x, core.ShapedArray) for x in ctx.avals_in), ctx.avals_in
   operands, init_values = util.split_list(values, [len(values) // 2])
   init_value_avals = ctx.avals_in[len(values) // 2:]
-  op = hlo.ReduceOp([mlir.aval_to_ir_type(aval) for aval in ctx.avals_out],
+  op = hlo.ReduceOp(mlir.flatten_ir_types(map(mlir.aval_to_ir_types, ctx.avals_out)),
                     operands, init_values, mlir.dense_int_array(dimensions))
-  ir_types = [mlir.aval_to_ir_type(aval) for aval in init_value_avals]
+  ir_types = mlir.flatten_ir_types(map(mlir.aval_to_ir_types, init_value_avals))
   reducer = op.regions[0].blocks.append(*(ir_types + ir_types))
   with ir.InsertionPoint(reducer):
     name_stack = source_info_util.new_name_stack()
@@ -8005,7 +8008,8 @@ batching.defreducer(reduce_xor_p)
 def _unary_reduce_lower(reducer, unit_factory, ctx, x, *, axes, **kwargs):
   aval_out, = ctx.avals_out
   dtype = aval_out.dtype
-  op = hlo.ReduceOp([mlir.aval_to_ir_type(aval_out)], [x],
+  out_type = mlir.aval_to_ir_type(aval_out)
+  op = hlo.ReduceOp([out_type], [x],
                     [mlir.ir_constant(unit_factory(aval_out.dtype))],
                     mlir.dense_int_array(axes))
   scalar_type = mlir.aval_to_ir_type(core.ShapedArray((), dtype))
@@ -8206,7 +8210,7 @@ batching.primitive_batchers[sort_p] = _sort_batch_rule
 
 def _sort_lower(ctx, *operands, dimension, is_stable, num_keys):
   assert all(isinstance(x, core.ShapedArray) for x in ctx.avals_in), ctx.avals_in
-  sort = hlo.SortOp([mlir.aval_to_ir_type(aval) for aval in ctx.avals_out],
+  sort = hlo.SortOp(mlir.flatten_ir_types(map(mlir.aval_to_ir_types, ctx.avals_out)),
                     mlir.flatten_ir_values(operands),
                     dimension=mlir.i64_attr(dimension),
                     is_stable=ir.BoolAttr.get(is_stable))
@@ -8317,8 +8321,8 @@ def _top_k_lower(ctx, operand, k, axis):
     results = mlir.custom_call(
         "stablehlo.dynamic_top_k",
         result_types=mlir.flatten_ir_types([
-            mlir.aval_to_ir_type(out_values_aval),
-            mlir.aval_to_ir_type(out_indices_aval)
+            mlir.aval_to_ir_types(out_values_aval),
+            mlir.aval_to_ir_types(out_indices_aval)
         ]),
         operands=[operand, k_value],
     ).results
@@ -8512,10 +8516,10 @@ def _rng_bit_generator_lowering(
       mlir.eval_dynamic_shape(ctx, out_vals_aval.shape))
     out_key, out_vals = mlir.custom_call(
         "stablehlo.dynamic_rng_bit_generator",
-        result_types=mlir.flatten_ir_types([
+        result_types=[
             key.type,
             mlir.aval_to_ir_type(core.ShapedArray(shape, rbg_dtype))
-        ]),
+        ],
         operands=mlir.flatten_ir_values([key, output_shape]),
         extra_attributes=dict(rng_algorithm=algorithm_attr),
     ).results
@@ -9109,7 +9113,7 @@ def _optimization_barrier_abstract_eval(*args):
   return args
 
 def _optimization_barrier_lowering_rule(ctx, *args):
-  barrier_types = map(mlir.aval_to_ir_type, ctx.avals_in)
+  barrier_types = map(mlir._aval_to_ir_types, ctx.avals_in)
   flat_args = mlir.flatten_ir_values(args)
   barrier_op = hlo.OptimizationBarrierOp(flat_args)
   return mlir.unflatten_ir_values_like_types(barrier_op.results, barrier_types)

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1377,7 +1377,7 @@ def _householder_product_lowering(ctx, a, taus):
     result_shapes = None
   op = mlir.custom_call(
       "ProductOfElementaryHouseholderReflectors",
-      result_types=mlir.flatten_ir_types([mlir.aval_to_ir_type(aval_out)]),
+      result_types=mlir.flatten_ir_types(mlir.aval_to_ir_types(aval_out)),
       operands=[a, taus],
       api_version=1,
       result_shapes=result_shapes)
@@ -1704,9 +1704,9 @@ def _lu_cpu_gpu_lowering(ctx, operand, *, target_name_prefix: str):
 
 def _lu_tpu_lowering_rule(ctx, operand):
   result_types = mlir.flatten_ir_types([
-      mlir.aval_to_ir_type(ctx.avals_out[0]),
-      mlir.aval_to_ir_type(ctx.avals_out[1]),
-      mlir.aval_to_ir_type(ctx.avals_out[2]),
+      mlir.aval_to_ir_types(ctx.avals_out[0]),
+      mlir.aval_to_ir_types(ctx.avals_out[1]),
+      mlir.aval_to_ir_types(ctx.avals_out[2]),
   ])
   if any(not is_constant_shape(a.shape) for a in ctx.avals_out):
     result_shapes = [
@@ -1909,7 +1909,7 @@ def _geqrf_dtype_rule(dtype):
 def _geqrf_lowering_rule(ctx, operand):
   ts_type = mlir.aval_to_ir_type(ctx.avals_out[0])
   r_type = mlir.aval_to_ir_type(ctx.avals_out[1])
-  result_types = mlir.flatten_ir_types([ts_type, r_type])
+  result_types = [ts_type, r_type]
   if any(not is_constant_shape(aval_out.shape)
          for aval_out in ctx.avals_out):
     result_shapes = [
@@ -3074,8 +3074,8 @@ def _build_sdy_sharding_rule(num_batch_dims, avals_in, avals_out):
   sdy_sharding_rule = str_to_sdy_sharding_rule(f"{lhs} -> {rhs}")
   return sdy_sharding_rule_to_mlir(
       sdy_sharding_rule,
-      [mlir.aval_to_ir_type(a) for a in avals_in],
-      [mlir.aval_to_ir_type(a) for a in avals_out])
+      mlir.flatten_ir_types(map(mlir.aval_to_ir_types, avals_in)),
+      mlir.flatten_ir_types(map(mlir.aval_to_ir_types, avals_out)))
 
 def _linalg_ffi_lowering(target_name, avals_in=None, avals_out=None,
                          operand_output_aliases=None, column_major=True,

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -1217,8 +1217,9 @@ def _precv_lowering_gpu(ctx, token, *, out_shape, axis_name, perm):
   full_perm, other_args = _pcollectives_lowering_common(
       ctx, axis_name=axis_name, perm=perm, op_name="precv"
   )
+  out_type = mlir.aval_to_ir_type(out_shape)
   recv_op = hlo.RecvOp(
-      [mlir.aval_to_ir_type(out_shape), token.type],
+      [out_type, token.type],
       token,
       source_target_pairs=mlir.dense_int_elements(full_perm),
       **other_args,
@@ -1789,19 +1790,20 @@ def _all_gather_lowering(ctx, x, *, all_gather_dimension, axis_name,
   else:
     other_args = {}
 
+  out_type = mlir.aval_to_ir_type(out_aval)
   if not is_async:
     return hlo.AllGatherOp(
-        [mlir.aval_to_ir_type(out_aval)],
+        [out_type],
         [x], all_gather_dim=mlir.i64_attr(all_gather_dimension),
         replica_groups=_replica_groups_hlo(replica_groups),
         **other_args).results
 
-  future_type = hlo.FutureType.get([mlir.aval_to_ir_type(out_aval)])  # type: ignore
+  future_type = hlo.FutureType.get([out_type])  # type: ignore
   async_start = hlo.AsyncStartOp(future_type, [x])
   block = async_start.regions[0].blocks.append(x.type)
   with ir.InsertionPoint(block):
     results = hlo.AllGatherOp(
-        [mlir.aval_to_ir_type(out_aval)],
+        [out_type],
         [block.arguments[0]],
         all_gather_dim=mlir.i64_attr(all_gather_dimension),
         replica_groups=_replica_groups_hlo(replica_groups),
@@ -2054,7 +2056,8 @@ def _reduce_scatter_lowering(
   if tiled:
     return op.results
   else:
-    return [hlo.reshape(mlir.aval_to_ir_type(aval_out), op.result)]
+    out_type = mlir.aval_to_ir_type(aval_out)
+    return [hlo.reshape(out_type, op.result)]
 
 
 def _reduce_scatter_effectful_abstract_eval(

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -2345,7 +2345,7 @@ def _gather_lower(ctx, operand, indices, *,
     # return hlo.DynamicGatherOp(
     #     operand, indices, mlir.shape_tensor(slice_sizes),
     #     dnums, indices_are_sorted=ir.BoolAttr.get(indices_are_sorted)).results
-    results = mlir.flatten_ir_types([mlir.aval_to_ir_type(aval_out)])
+    results = mlir.flatten_ir_types(mlir.aval_to_ir_types(aval_out))
     operands = [operand, indices, slice_sizes]
     attributes: dict[str, ir.Attribute] = {
         "dimension_numbers": dnums,

--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -733,8 +733,9 @@ def _select_and_scatter_lower(
   scalar_aval = operand_aval.update(
       shape=(), sharding=operand_aval.sharding.update(spec=()))
   scalar_type = mlir.aval_to_ir_type(scalar_aval)
+  result_type = mlir.aval_to_ir_type(aval_out)
   op = hlo.SelectAndScatterOp(
-      mlir.aval_to_ir_type(aval_out),
+      result_type,
       operand,
       source,
       init_value,

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1373,7 +1373,7 @@ def _pjit_lowering(ctx: mlir.LoweringRuleContext, *args, name: str,
                    out_shardings, in_layouts, out_layouts, donated_invars,
                    ctx_mesh, keep_unused, inline, compiler_options_kvs):
   effects = list(ctx.tokens_in.effects())
-  output_types = map(mlir.aval_to_ir_type, ctx.avals_out)
+  output_types = map(mlir._aval_to_ir_types, ctx.avals_out)
   output_types = [mlir.token_type()] * len(effects) + output_types
   flat_output_types = mlir.flatten_ir_types(output_types)
 
@@ -1392,10 +1392,10 @@ def _pjit_lowering(ctx: mlir.LoweringRuleContext, *args, name: str,
       api_name='jit')
 
   tokens_in = [ctx.tokens_in.get(eff) for eff in effects]
-  hoisted_const_values = [
-      mlir.ir_constant(c, const_lowering=ctx.const_lowering, aval=aval)
+  hoisted_const_values = mlir.flatten_ir_values(
+      mlir.ir_constants(c, const_lowering=ctx.const_lowering, aval=aval)
       for c, aval in const_args_and_avals
-  ]
+  )
   args = (*ctx.dim_var_values, *tokens_in, *hoisted_const_values, *args)
   with mlir.source_info_to_location(
       ctx.module_context, None,

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -1091,8 +1091,9 @@ def iota_2x32_shape_lowering(ctx, *, shape):
   shift = mlir.broadcast_in_dim(ctx, shift, aval_u64,
                                 broadcast_dimensions=[])
   counts_shifted = mlir.hlo.shift_right_logical(counts, shift)
-  counts_lo = mlir.hlo.convert(mlir.aval_to_ir_type(aval_out), counts)
-  counts_hi = mlir.hlo.convert(mlir.aval_to_ir_type(aval_out), counts_shifted)
+  result_type = mlir.aval_to_ir_type(aval_out)
+  counts_lo = mlir.hlo.convert(result_type, counts)
+  counts_hi = mlir.hlo.convert(result_type, counts_shifted)
   return counts_hi, counts_lo
 mlir.register_lowering(iota_2x32_shape_p, iota_2x32_shape_lowering)
 

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -970,9 +970,10 @@ def _shard_map_lowering_shardy(
   const_args_and_avals = core.jaxpr_const_args(jaxpr)
   const_args, const_avals = util.unzip2(const_args_and_avals)
   num_const_args = len(const_args)
-  const_arg_values = tuple(
-      mlir.ir_constant(c, const_lowering=ctx.const_lowering, aval=aval)
-      for c, aval in const_args_and_avals)
+  const_arg_values = mlir.flatten_ir_values(
+      mlir.ir_constants(c, const_lowering=ctx.const_lowering, aval=aval)
+      for c, aval in const_args_and_avals
+  )
   # TODO(necula,yashkatariya): how to construct consts shardy shardings from
   #  consts that can be ndarray or jax.Array?
   const_args_shardings = [
@@ -993,19 +994,19 @@ def _shard_map_lowering_shardy(
   out_shardings = sharding_impls.SdyArrayList(out_shardings).build()
 
   output_types = ([hlo.TokenType.get()] * num_tokens +
-                  list(map(mlir.aval_to_ir_type, ctx.avals_out)))
+                  mlir.flatten_ir_types(map(mlir.aval_to_ir_types, ctx.avals_out)))
 
   args = (*ctx.dim_var_values, *tokens, *const_arg_values, *in_nodes)
   manual_computation_op = sdy.ManualComputationOp(
       output_types, mlir.flatten_ir_values(args), in_shardings, out_shardings,
       sdy.ManualAxesAttr.get([ir.StringAttr.get(i) for i in manual_axes]))
 
-  dim_var_types = mlir.flatten_ir_types(
-    [mlir.aval_to_ir_type(core.ShapedArray((), dtypes.default_int_dtype()))]
-  ) * num_dim_vars
+  dim_var_types = [
+    mlir.aval_to_ir_type(core.ShapedArray((), dtypes.default_int_dtype()))
+  ] * num_dim_vars
   token_types = [hlo.TokenType.get()] * num_tokens
-  const_arg_types = mlir.flatten_ir_types(map(mlir.aval_to_ir_type, const_avals))
-  in_types = mlir.flatten_ir_types(map(mlir.aval_to_ir_type, in_avals_))
+  const_arg_types = mlir.flatten_ir_types(map(mlir.aval_to_ir_types, const_avals))
+  in_types = mlir.flatten_ir_types(map(mlir.aval_to_ir_types, in_avals_))
   block = ir.Block.create_at_start(
       manual_computation_op.body,
       (*dim_var_types, *token_types, *const_arg_types, *in_types))

--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -1130,7 +1130,7 @@ def _lower_create_linear(ctx):
   return mlir.custom_call(
       "CreateBuffer",
       operands=[],
-      result_types=mlir.flatten_ir_types([mlir.aval_to_ir_type(out_aval)]),
+      result_types=mlir.flatten_ir_types(mlir.aval_to_ir_types(out_aval)),
   ).results
 mlir.register_lowering(create_linear_p, _lower_create_linear)
 
@@ -1149,7 +1149,7 @@ def _lower_pin(ctx, x_op):
   return mlir.custom_call(
       "Pin",
       operands=mlir.flatten_ir_values([x_op]),
-      result_types=mlir.flatten_ir_types([mlir.aval_to_ir_type(out_aval)]),
+      result_types=mlir.flatten_ir_types(mlir.aval_to_ir_types(out_aval)),
   ).results
 mlir.register_lowering(pin_p, _lower_pin)
 
@@ -1168,7 +1168,7 @@ def _lower_unpin(ctx, x_op):
   return mlir.custom_call(
       "Unpin",
       operands=mlir.flatten_ir_values([x_op]),
-      result_types=mlir.flatten_ir_types([mlir.aval_to_ir_type(out_aval)]),
+      result_types=mlir.flatten_ir_types(mlir.aval_to_ir_types(out_aval)),
   ).results
 mlir.register_lowering(unpin_p, _lower_unpin)
 

--- a/jax/_src/tpu/linalg/eigh.py
+++ b/jax/_src/tpu/linalg/eigh.py
@@ -666,7 +666,7 @@ def _eigh_tpu_lowering(
     v_aval, w_aval = ctx.avals_out
     eigvecs_type = mlir.aval_to_ir_type(v_aval)
     eigvals_type = mlir.aval_to_ir_type(w_aval)
-    result_types = mlir.flatten_ir_types([eigvecs_type, eigvals_type])
+    result_types = [eigvecs_type, eigvals_type]
 
     backend_config = f"{int(lower)},{int(sort_eigenvalues)},100,1e-6"
 

--- a/jax/_src/tpu_custom_call.py
+++ b/jax/_src/tpu_custom_call.py
@@ -385,7 +385,7 @@ def _tpu_custom_call_lowering(
     input_output_aliases: tuple[tuple[int, int], ...],
     metadata: Any | None,
 ) -> ir.OpResultList:
-  result_types = mlir.flatten_ir_types(map(mlir.aval_to_ir_type, out_avals))
+  result_types = mlir.flatten_ir_types(map(mlir.aval_to_ir_types, out_avals))
   axis_context = ctx.module_context.axis_context
   if isinstance(axis_context, sharding_impls.SPMDAxisContext):
     manual_axes = axis_context.manual_axes | set(axis_context.mesh.manual_axes)

--- a/jax/experimental/fused.py
+++ b/jax/experimental/fused.py
@@ -61,9 +61,10 @@ dispatch.simple_impl(fused_p)
 def _fused_lowering(ctx, *args, out_spaces, jaxpr):
   const_args_and_avals = core.jaxpr_const_args(jaxpr.jaxpr)
   const_args, const_arg_avals = unzip2(const_args_and_avals)
-  const_arg_values = [
-      mlir.ir_constant(c, const_lowering=ctx.const_lowering, aval=aval)
-      for c, aval in const_args_and_avals]
+  const_arg_values = mlir.flatten_ir_values(
+      mlir.ir_constants(c, const_lowering=ctx.const_lowering, aval=aval)
+      for c, aval in const_args_and_avals
+  )
   in_avals = [*const_arg_avals, *ctx.avals_in]
   func_op, _, _ = mlir.lower_called_computation(
       "fused", jaxpr, ctx.module_context, len(const_args), in_avals,

--- a/jax/experimental/scheduling_groups.py
+++ b/jax/experimental/scheduling_groups.py
@@ -66,9 +66,10 @@ def attr_get(x):
 def _xla_metadata_call_lowering(ctx, *args, jaxpr, **meta):
   const_args_and_avals = core.jaxpr_const_args(jaxpr.jaxpr)
   const_args, const_avals = unzip2(const_args_and_avals)
-  const_arg_values = [
-      mlir.ir_constant(c, const_lowering=ctx.const_lowering, aval=aval)
-      for c, aval in const_args_and_avals]
+  const_arg_values = mlir.flatten_ir_values(
+      mlir.ir_constants(c, const_lowering=ctx.const_lowering, aval=aval)
+      for c, aval in const_args_and_avals
+  )
   in_avals = (*const_avals, *ctx.avals_in)
   func_op, output_types, effects = mlir.lower_called_computation(
       "xla_metadata_call", jaxpr, ctx.module_context, len(const_args), in_avals,

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -44,6 +44,7 @@ from jax._src.interpreters.mlir import (
   ir as ir,
   ir_attribute as ir_attribute,
   ir_constant as ir_constant,
+  ir_constants as ir_constants,
   ir_type_handlers as ir_type_handlers,
   jaxpr_subcomp as jaxpr_subcomp,
   lower_fun as lower_fun,


### PR DESCRIPTION
The change conceptually consists of two commits, which were squashed because
of Copybara limitations:

* The first commit splits `mlir.ir_constant` into a pair of functions:
  `mlir.ir_constant`, returning a single `ir.Value`, and  `mlir.ir_constants`,
  which always returns a tuple.
* The second commit does a similar refactoring for `aval_to_ir_type`.

Previously, both of these APIs returned a union type, `IrValues` or `IrTypes`
respectively. This was problematic for type checking because

* most call sites had either one or the other;
* but the return type was always a union, which caused type errors!

Now the call site can explicitly declare its expectations by calling a singular
or a plural form of each API.