### PR TITLE
[ROCm] Added stricter checks to detect non-numeric strings in pallas lowering.

### DIFF
--- a/jax/_src/pallas/triton/pallas_call_registration.py
+++ b/jax/_src/pallas/triton/pallas_call_registration.py
@@ -102,8 +102,15 @@ def pallas_call_lowering(
     arch_name = str(gpu_device.compute_capability)
     if lowering_platform == "rocm":
       compute_capability = 0
+    elif (arch_numeric := arch_name.replace(".", "")).isdigit():
+      compute_capability = int(arch_numeric)
     else:
-      compute_capability = int(arch_name.replace(".", ""))
+      # In the case of cross platform export, e.g. lowering for CUDA on a
+      # ROCm device, we may get an `arch_name` (e.g. gfx*) that can't be
+      # parsed properly by the above conditionals. In this case, fall back
+      # to the same defaults as used above.
+      arch_name = "8.0"
+      compute_capability = 80
 
   # Sanitize the name to conform to NVPTX requirements. We do this here
   # to avoid the need to fetch the new name from PTX post compilation.

--- a/tests/pallas/pallas_shape_poly_test.py
+++ b/tests/pallas/pallas_shape_poly_test.py
@@ -500,9 +500,6 @@ class ExportTestWithTriton(jtu.JaxTestCase):
     )
 
   def test_cross_platform(self):
-    # TODO: Add this test back once gfx arch string parsing is fixed.
-    if jtu.is_device_rocm():
-      self.skipTest("Skipped on ROCm due to gfx arch string parsing error.")
     def add_vectors_kernel(x_ref, y_ref, o_ref):
       x, y = x_ref[...], y_ref[...]
       o_ref[...] = x + y


### PR DESCRIPTION
## Motivation 
Recent changes in file `pallas/triton/pallas_registration_call.py` caused a bug to be revealed for a cross-platform export scenario. 
The commit https://github.com/jax-ml/jax/commit/1b6cd8916f moved the compute capability detection earlier, exposing the bug.

This resulted in a failure of the unit test: `tests/pallas/pallas_shape_poly_test.py::ExportTestWithTriton::test_cross_platform` when a ROCm device tried to export a Pallas kernel targeting CUDA because the lowering code assumes that the target platform matches the GPU. If the target platform is not ROCm, the `arch_name` is parsed as an integer (and ROCm produces an `arch_name` in the format `gfx*`).

As a fix, the conditional checks if the string is a number - it knows that the lowering platform must be CUDA since it has already checked if the lowering platform is ROCm prior. If both of these fail, we have the cross-platform export scenario with a ROCm `arch_name` but with CUDA as the lowering platform. It now falls back on the same defaults used earlier in the function (`arch_name` = "8.0" and `compute_capability` = 80).

Please note that the inverse cross-platform export scenario (exporting a ROCm Pallas kernel on a CUDA device) is already taken care of by the first conditional.

## Testing
The unit test `tests/pallas/pallas_shape_poly_test.py::ExportTestWithTriton::test_cross_platform` now passes on ROCm devices so it has been unskipped.