### PR TITLE
ci: harden workflow triggers to prevent fork PR execution on self-hosted runners

### DIFF
--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   asan:
     # Don't execute in fork due to runner type
-    if: github.repository == 'jax-ml/jax'
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: linux-x86-n4-64
     container:
       image: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest

--- a/.github/workflows/bazel_cpu_presubmit.yml
+++ b/.github/workflows/bazel_cpu_presubmit.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   build-jax-artifact:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/build_artifacts.yml
     name: "Build jax artifact"
     with:
@@ -36,6 +37,7 @@ jobs:
         upload_artifacts_to_gcs: false
 
   build-jaxlib-artifact:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/build_artifacts.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -56,7 +58,7 @@ jobs:
         upload_artifacts_to_gcs: false
 
   run_tests:
-    if: github.event.repository.fork == false
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/bazel_cpu.yml
 # Begin Presubmit Naming Check - name modification requires internal check to be updated
     strategy:

--- a/.github/workflows/bazel_cuda_b200_mosaic_presubmit.yml
+++ b/.github/workflows/bazel_cuda_b200_mosaic_presubmit.yml
@@ -63,7 +63,7 @@ jobs:
   # at all if no matching files were touched.
   # This would lead to Copybara waiting for the status indefinitely.
   changed_files:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: linux-x86-n4-16
     container: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest
     steps:
@@ -130,6 +130,7 @@ jobs:
     if: >-
       ${{
           !cancelled()
+          && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
           && (
                github.event_name == 'workflow_dispatch'
                || needs.changed_files.outputs.any_changed == 'true'

--- a/.github/workflows/bazel_cuda_presubmit.yml
+++ b/.github/workflows/bazel_cuda_presubmit.yml
@@ -26,6 +26,7 @@ concurrency:
 permissions: {}
 jobs:
   build-cuda-artifacts:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/build_artifacts.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -45,7 +46,7 @@ jobs:
       upload_artifacts_to_gcs: false
 
   run-tests:
-    if: github.event.repository.fork == false
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/bazel_cuda.yml
 # Begin Presubmit Naming Check - name modification requires internal check to be updated
     strategy:

--- a/.github/workflows/bazel_rocm_presubmit.yml
+++ b/.github/workflows/bazel_rocm_presubmit.yml
@@ -26,7 +26,7 @@ concurrency:
 permissions: {}
 jobs:
   run-tests:
-    if: github.event.repository.fork == false
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/bazel_rocm.yml
 # Begin Presubmit Naming Check - name modification requires internal check to be updated
     strategy:

--- a/.github/workflows/cloud-tpu-ci-presubmit.yml
+++ b/.github/workflows/cloud-tpu-ci-presubmit.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   run-bazel-test-tpu:
-    if: github.event.repository.fork == false
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/bazel_test_tpu.yml
     # Begin Presubmit Naming Check - name modification requires internal check to be updated
     name: "TPU test (jaxlib=head)"

--- a/.github/workflows/jax-array-api.yml
+++ b/.github/workflows/jax-array-api.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: linux-x86-n4-16
     container: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest
     strategy:

--- a/.github/workflows/oldest_supported_numpy.yml
+++ b/.github/workflows/oldest_supported_numpy.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   test-oldest-supported-numpy:
-    if: ${{ github.event.repository.fork == false && !startsWith(github.head_ref, 'release/') }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && !startsWith(github.head_ref, 'release/') }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   tsan:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: linux-x86-n4-64
     container:
       image: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build@sha256:ea67e8453d8b09c2ba48853da5e79efef4b65804b4a48dfae4b4da89ffd38405 # ml-build container (based on Ubuntu 22.04)


### PR DESCRIPTION
## Summary

Several presubmit workflows use `pull_request` triggers with self-hosted runners but have ineffective or missing fork PR guards:

- **Broken guard pattern:** `github.event.repository.fork == false` — this always evaluates to `true` for `pull_request` events because `github.event.repository` refers to the base repo, not the head/fork repo.
- **Missing guards:** Some build jobs have no fork check at all.

This PR fixes all 9 affected presubmit workflows by replacing the broken condition with:
```yaml
github.event.pull_request.head.repo.full_name == github.repository
```

This correctly checks whether the PR originates from the same repository or an external fork.

## Affected workflows

| Workflow | Fix |
|----------|-----|
| `bazel_cpu_presubmit.yml` | Fixed broken guard on `run_tests`, added guard to `build-*` jobs |
| `bazel_cuda_presubmit.yml` | Fixed broken guard on `run-tests`, added guard to `build-cuda-artifacts` |
| `cloud-tpu-ci-presubmit.yml` | Fixed broken guard on `run-bazel-test-tpu` |
| `bazel_cuda_b200_mosaic_presubmit.yml` | Added guard to `changed_files` and `run_tests` |
| `bazel_rocm_presubmit.yml` | Fixed broken guard on `run-tests` |
| `asan.yaml` | Replaced ineffective `github.repository` check |
| `tsan.yaml` | Added missing guard |
| `oldest_supported_numpy.yml` | Fixed broken guard |
| `jax-array-api.yml` | Added missing guard |

## Test plan

- [x] All modified workflows retain their existing trigger logic for push, schedule, and workflow_dispatch events
- [ ] PRs from the same repo (non-fork) continue to trigger self-hosted runner jobs
- [ ] Fork PRs are correctly skipped for self-hosted runner jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)