### PR TITLE
nn: add implementation='stable' to dot_product_attention

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -1010,6 +1010,110 @@ def _dot_product_attention_xla(
   return encoded
 
 
+def _dot_product_attention_stable(
+    query: Array,
+    key: Array,
+    value: Array,
+    bias: Array | None,
+    mask: Array | None,
+    is_causal: bool,
+    scale: float,
+    q_seqlen: Array | None,
+    kv_seqlen: Array | None,
+    local_window_size: tuple[int, int] | None,
+    return_residual: bool = False,
+    tile_size: int = 128,
+):
+  """Stable-reduction attention via tiled scan over fixed-shape KV tiles.
+
+  Replaces the variable-length softmax reduction with a fixed-shape scan,
+  so XLA compiles identical kernels regardless of KV-cache size — eliminating
+  floating-point non-determinism from different XLA reduction tree shapes.
+  """
+  if q_seqlen is not None or kv_seqlen is not None or local_window_size is not None:
+    raise NotImplementedError(
+        "stable implementation does not support q_seqlen, kv_seqlen, or "
+        "local_window_size"
+    )
+
+  B, T, N, H = query.shape
+  _, S, K, _ = key.shape
+
+  if K < N:
+    key = jnp.repeat(key, N // K, axis=2)
+    value = jnp.repeat(value, N // K, axis=2)
+
+  pad = (-S) % tile_size
+  S_pad = S + pad
+  num_tiles = S_pad // tile_size
+  neg_inf = float('-inf')
+
+  # Build additive logit bias (B, N, T, S_pad) combining all mask sources.
+  logit_bias = jnp.zeros((B, N, T, S_pad), dtype=np.float32)
+  if pad:
+    logit_bias = logit_bias.at[..., S:].set(neg_inf)
+  if bias is not None:
+    logit_bias = logit_bias + jnp.pad(
+        bias.astype(np.float32), [(0, 0), (0, 0), (0, 0), (0, pad)])
+  if is_causal:
+    causal_mask = jnp.tril(jnp.ones((T, S), dtype=bool))
+    logit_bias = logit_bias + jnp.where(
+        jnp.pad(causal_mask, [(0, 0), (0, pad)])[None, None], 0.0, neg_inf)
+  if mask is not None:
+    logit_bias = logit_bias + jnp.where(
+        jnp.pad(mask, [(0, 0), (0, 0), (0, 0), (0, pad)]), 0.0, neg_inf)
+
+  # Tile for scan: leading axis = num_tiles.
+  key_tiles = jnp.transpose(
+      jnp.reshape(jnp.pad(key, [(0, 0), (0, pad), (0, 0), (0, 0)]),
+                  (B, num_tiles, tile_size, N, H)), (1, 0, 2, 3, 4))
+  value_tiles = jnp.transpose(
+      jnp.reshape(jnp.pad(value, [(0, 0), (0, pad), (0, 0), (0, 0)]),
+                  (B, num_tiles, tile_size, N, H)), (1, 0, 2, 3, 4))
+  bias_tiles = jnp.transpose(
+      jnp.reshape(logit_bias, (B, N, T, num_tiles, tile_size)), (3, 0, 1, 2, 4))
+
+  def combine(left, right):
+    l_max, l_sum, l_out = left
+    r_max, r_sum, r_out = right
+    new_max = jnp.maximum(l_max, r_max)
+    safe = jnp.where(jnp.isneginf(new_max), 0.0, new_max)
+    lc = jnp.exp(l_max - safe)
+    rc = jnp.exp(r_max - safe)
+    return new_max, lc * l_sum + rc * r_sum, lc[..., None] * l_out + rc[..., None] * r_out
+
+  def scan_step(carry, xs):
+    k_tile, v_tile, b_tile = xs
+    scores = scale * jnp_einsum.einsum(
+        'BTNH,BSNH->BNTS', query, k_tile, preferred_element_type=np.float32)
+    scores = (scores + b_tile).astype(np.float32)
+    t_max = scores.max(-1)
+    safe = jnp.where(jnp.isneginf(t_max), 0.0, t_max)
+    exp_s = jnp.exp(scores - safe[..., None])
+    t_sum = exp_s.sum(-1)
+    t_out = jnp_einsum.einsum('BNTS,BSNH->BNTH', exp_s, v_tile)
+    return combine(carry, (t_max, t_sum, t_out)), None
+
+  init = (
+      jnp.full((B, N, T), neg_inf, dtype=np.float32),
+      jnp.zeros((B, N, T), dtype=np.float32),
+      jnp.zeros((B, N, T, H), dtype=np.float32),
+  )
+  (final_max, final_sum, final_out), _ = lax.scan(
+      scan_step, init, (key_tiles, value_tiles, bias_tiles))
+
+  # (B, N, T, H) -> (B, T, N, H), cast back to input dtype.
+  out = jnp.transpose(
+      (final_out / final_sum[..., None]).astype(query.dtype), (0, 2, 1, 3))
+
+  if return_residual:
+    lse = jnp.transpose(
+        (final_max + jnp.log(final_sum)).astype(query.dtype), (0, 2, 1))
+    return out, lax.stop_gradient(lse)
+
+  return out
+
+
 @overload
 def dot_product_attention(
     query: ArrayLike,
@@ -1023,7 +1127,7 @@ def dot_product_attention(
     query_seq_lengths: ArrayLike | None = None,
     key_value_seq_lengths: ArrayLike | None = None,
     local_window_size: int | tuple[int, int] | None = None,
-    implementation: Literal['xla', 'cudnn'] | None = None,
+    implementation: Literal['xla', 'cudnn', 'stable'] | None = None,
     return_residual: Literal[False] = ...,
 ) -> Array: ...
 
@@ -1040,7 +1144,7 @@ def dot_product_attention(
     query_seq_lengths: ArrayLike | None = None,
     key_value_seq_lengths: ArrayLike | None = None,
     local_window_size: int | tuple[int, int] | None = None,
-    implementation: Literal['xla', 'cudnn'] | None = None,
+    implementation: Literal['xla', 'cudnn', 'stable'] | None = None,
     return_residual: Literal[True] = ...,
 ) -> tuple[Array, Array]: ...
 
@@ -1056,7 +1160,7 @@ def dot_product_attention(
     query_seq_lengths: ArrayLike | None = None,
     key_value_seq_lengths: ArrayLike | None = None,
     local_window_size: int | tuple[int, int] | None = None,
-    implementation: Literal['xla', 'cudnn'] | None = None,
+    implementation: Literal['xla', 'cudnn', 'stable'] | None = None,
     return_residual: bool = False,
 ):
   r"""Scaled dot product attention function.
@@ -1121,10 +1225,15 @@ def dot_product_attention(
       or BNT to users. See section 3.1.1 in the FlashAttention-2 paper:
       https://arxiv.org/pdf/2307.08691 to find the definition of logsumexp.
     implementation: A string to control which implementation backend to use.
-      Supported strings are `xla`, `cudnn` (cuDNN flash attention). It defaults
-      to `None`, which currently falls back to `xla`.
+      Supported strings are `xla`, `cudnn` (cuDNN flash attention), and
+      `stable` (tiled-scan stable reduction). It defaults to `None`, which
+      currently falls back to `xla`.
       Note, `cudnn` supports only a subset of shapes/dtypes, and an exception
-      will be thrown if its not supported.
+      will be thrown if its not supported. `stable` eliminates floating-point
+      non-determinism across different KV-cache lengths by replacing the
+      variable-length softmax reduction with a fixed-shape tiled scan; it does
+      not support `query_seq_lengths`, `key_value_seq_lengths`, or
+      `local_window_size`.
 
   Returns:
     If return_residual is False, returns an array of the attention output with
@@ -1228,6 +1337,14 @@ def dot_product_attention(
         out, residual = out
         residual = jnp.transpose(residual, (0, 2, 1)).astype(out.dtype)
         out = (out, residual)
+    case 'stable':
+      out = _dot_product_attention_stable(
+          query_arr, key_arr, value_arr, bias, mask, is_causal=is_causal,
+          scale=scale_val, q_seqlen=query_seq_lengths,
+          kv_seqlen=key_value_seq_lengths,
+          local_window_size=local_window_size,
+          return_residual=return_residual,
+      )
     case None:
       # TODO(kaixih@nvidia) Automatically select the best backend (defaults to XLA for now).
       out = _dot_product_attention_xla(

--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -1063,19 +1063,20 @@ def _dot_product_attention_stable(
   key_tiles = _tile(key)
   value_tiles = _tile(value)
 
-  # Pre-tile user bias/mask if provided: (num_tiles, B, N, T, tile_size).
-  # Padding, causal masks are computed per-tile on-the-fly to avoid
-  # materializing an O(B·N·T·S) logit-bias tensor.
-  def _tile_bias(x, dtype):
+  # Pre-tile user bias/mask if provided: (num_tiles, B, n, T, tile_size).
+  # n is preserved as-is (may be 1 for broadcast or N for per-head).
+  # Padding and causal masks are computed per-tile on-the-fly so we never
+  # materialise an O(B·N·T·S) logit-bias tensor.
+  def _to_tiles(x, dtype):
     x = jnp.pad(x.astype(dtype), [(0, 0), (0, 0), (0, 0), (0, pad)])
-    n = x.shape[1]  # may be 1 (broadcast) or N
+    n = x.shape[1]
     return jnp.transpose(jnp.reshape(x, (B, n, T, num_tiles, tile_size)),
                          (3, 0, 1, 2, 4))
   xs = (key_tiles, value_tiles, jnp.arange(num_tiles) * tile_size)
   if has_bias:
-    xs = xs + (_tile_bias(bias, np.float32),)
+    xs = xs + (_to_tiles(bias, np.float32),)
   if has_mask:
-    xs = xs + (_tile_bias(mask, bool),)
+    xs = xs + (_to_tiles(mask, bool),)
 
   def combine(left, right):
     l_max, l_sum, l_out = left
@@ -1086,22 +1087,23 @@ def _dot_product_attention_stable(
     rc = jnp.exp(r_max - safe)
     return new_max, lc * l_sum + rc * r_sum, lc[..., None] * l_out + rc[..., None] * r_out
 
+  bias_idx = 3
+  mask_idx = 3 + has_bias
+
   def scan_step(carry, xs):
-    k_tile = xs[0]   # (B, tile_size, K, H)
-    v_tile = xs[1]   # (B, tile_size, K, H)
-    tile_start = xs[2]  # scalar — position of tile[0] in the full sequence
-    b_tile = xs[3] if has_bias else None          # (B, N, T, tile_size)
-    m_tile = xs[3 + has_bias] if has_mask else None  # (B, N, T, tile_size)
+    k_tile = xs[0]        # (B, tile_size, K, H)
+    v_tile = xs[1]        # (B, tile_size, K, H)
+    tile_start = xs[2]    # scalar — position of tile[0] in the full sequence
 
     # GQA scores without materializing repeated K: (B, K, G, T, tile_size).
     scores = scale * jnp_einsum.einsum(
         'BTKGH,BSKH->BKGTS', query_gqa, k_tile, preferred_element_type=np.float32)
     scores = jnp.reshape(scores, (B, N, T, tile_size))
 
-    if b_tile is not None:
-      scores = scores + b_tile
-    if m_tile is not None:
-      scores = jnp.where(m_tile, scores, neg_inf)
+    if has_bias:
+      scores = scores + xs[bias_idx]
+    if has_mask:
+      scores = jnp.where(xs[mask_idx], scores, neg_inf)
 
     # Padding: positions >= S within this tile are masked.
     tile_pos = tile_start + jnp.arange(tile_size)

--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -1029,6 +1029,11 @@ def _dot_product_attention_stable(
   Replaces the variable-length softmax reduction with a fixed-shape scan,
   so XLA compiles identical kernels regardless of KV-cache size — eliminating
   floating-point non-determinism from different XLA reduction tree shapes.
+
+  Uses the online softmax recurrence from FlashAttention (Dao et al., 2022,
+  https://arxiv.org/abs/2205.14135). Masked padding tiles contribute exactly
+  zero (IEEE 754: exp(-inf)=0, 1.0*x=x), giving bit-exact outputs for any
+  KV length when the logical attention content is the same.
   """
   if q_seqlen is not None or kv_seqlen is not None or local_window_size is not None:
     raise NotImplementedError(

--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -1043,40 +1043,39 @@ def _dot_product_attention_stable(
 
   B, T, N, H = query.shape
   _, S, K, _ = key.shape
-
-  if K < N:
-    key = jnp.repeat(key, N // K, axis=2)
-    value = jnp.repeat(value, N // K, axis=2)
+  G = N // K  # query heads per KV head
 
   pad = (-S) % tile_size
-  S_pad = S + pad
-  num_tiles = S_pad // tile_size
+  num_tiles = (S + pad) // tile_size
   neg_inf = float('-inf')
+  has_bias = bias is not None
+  has_mask = mask is not None
 
-  # Build additive logit bias (B, N, T, S_pad) combining all mask sources.
-  logit_bias = jnp.zeros((B, N, T, S_pad), dtype=np.float32)
-  if pad:
-    logit_bias = logit_bias.at[..., S:].set(neg_inf)
-  if bias is not None:
-    logit_bias = logit_bias + jnp.pad(
-        bias.astype(np.float32), [(0, 0), (0, 0), (0, 0), (0, pad)])
-  if is_causal:
-    causal_mask = jnp.tril(jnp.ones((T, S), dtype=bool))
-    logit_bias = logit_bias + jnp.where(
-        jnp.pad(causal_mask, [(0, 0), (0, pad)])[None, None], 0.0, neg_inf)
-  if mask is not None:
-    logit_bias = logit_bias + jnp.where(
-        jnp.pad(mask, [(0, 0), (0, 0), (0, 0), (0, pad)]), 0.0, neg_inf)
+  # Reshape query for GQA: (B, T, N, H) -> (B, T, K, G, H).
+  # Key/value stay at K heads — no jnp.repeat needed.
+  query_gqa = jnp.reshape(query, (B, T, K, G, H))
 
-  # Tile for scan: leading axis = num_tiles.
-  key_tiles = jnp.transpose(
-      jnp.reshape(jnp.pad(key, [(0, 0), (0, pad), (0, 0), (0, 0)]),
-                  (B, num_tiles, tile_size, N, H)), (1, 0, 2, 3, 4))
-  value_tiles = jnp.transpose(
-      jnp.reshape(jnp.pad(value, [(0, 0), (0, pad), (0, 0), (0, 0)]),
-                  (B, num_tiles, tile_size, N, H)), (1, 0, 2, 3, 4))
-  bias_tiles = jnp.transpose(
-      jnp.reshape(logit_bias, (B, N, T, num_tiles, tile_size)), (3, 0, 1, 2, 4))
+  # Tile K/V: (num_tiles, B, tile_size, K, H) — K, not N.
+  def _tile(x):
+    return jnp.transpose(
+        jnp.reshape(jnp.pad(x, [(0, 0), (0, pad), (0, 0), (0, 0)]),
+                    (B, num_tiles, tile_size, K, H)), (1, 0, 2, 3, 4))
+  key_tiles = _tile(key)
+  value_tiles = _tile(value)
+
+  # Pre-tile user bias/mask if provided: (num_tiles, B, N, T, tile_size).
+  # Padding, causal masks are computed per-tile on-the-fly to avoid
+  # materializing an O(B·N·T·S) logit-bias tensor.
+  def _tile_bias(x, dtype):
+    x = jnp.pad(x.astype(dtype), [(0, 0), (0, 0), (0, 0), (0, pad)])
+    n = x.shape[1]  # may be 1 (broadcast) or N
+    return jnp.transpose(jnp.reshape(x, (B, n, T, num_tiles, tile_size)),
+                         (3, 0, 1, 2, 4))
+  xs = (key_tiles, value_tiles, jnp.arange(num_tiles) * tile_size)
+  if has_bias:
+    xs = xs + (_tile_bias(bias, np.float32),)
+  if has_mask:
+    xs = xs + (_tile_bias(mask, bool),)
 
   def combine(left, right):
     l_max, l_sum, l_out = left
@@ -1088,15 +1087,44 @@ def _dot_product_attention_stable(
     return new_max, lc * l_sum + rc * r_sum, lc[..., None] * l_out + rc[..., None] * r_out
 
   def scan_step(carry, xs):
-    k_tile, v_tile, b_tile = xs
+    k_tile = xs[0]   # (B, tile_size, K, H)
+    v_tile = xs[1]   # (B, tile_size, K, H)
+    tile_start = xs[2]  # scalar — position of tile[0] in the full sequence
+    b_tile = xs[3] if has_bias else None          # (B, N, T, tile_size)
+    m_tile = xs[3 + has_bias] if has_mask else None  # (B, N, T, tile_size)
+
+    # GQA scores without materializing repeated K: (B, K, G, T, tile_size).
     scores = scale * jnp_einsum.einsum(
-        'BTNH,BSNH->BNTS', query, k_tile, preferred_element_type=np.float32)
-    scores = (scores + b_tile).astype(np.float32)
-    t_max = scores.max(-1)
+        'BTKGH,BSKH->BKGTS', query_gqa, k_tile, preferred_element_type=np.float32)
+    scores = jnp.reshape(scores, (B, N, T, tile_size))
+
+    if b_tile is not None:
+      scores = scores + b_tile
+    if m_tile is not None:
+      scores = jnp.where(m_tile, scores, neg_inf)
+
+    # Padding: positions >= S within this tile are masked.
+    tile_pos = tile_start + jnp.arange(tile_size)
+    scores = jnp.where(tile_pos[None, None, None, :] < S, scores, neg_inf)
+
+    if is_causal:
+      # Key position k is valid for query position t iff k <= t.
+      q_pos = jnp.arange(T)
+      scores = jnp.where(
+          tile_pos[None, :] <= q_pos[:, None], scores, neg_inf)
+
+    scores = scores.astype(np.float32)
+    t_max = scores.max(-1)  # (B, N, T)
     safe = jnp.where(jnp.isneginf(t_max), 0.0, t_max)
     exp_s = jnp.exp(scores - safe[..., None])
     t_sum = exp_s.sum(-1)
-    t_out = jnp_einsum.einsum('BNTS,BSNH->BNTH', exp_s, v_tile)
+
+    # GQA value accumulation without materializing repeated V.
+    t_out = jnp_einsum.einsum(
+        'BKGTS,BSKH->BKGTH',
+        jnp.reshape(exp_s, (B, K, G, T, tile_size)), v_tile)
+    t_out = jnp.reshape(t_out, (B, N, T, H))
+
     return combine(carry, (t_max, t_sum, t_out)), None
 
   init = (
@@ -1104,8 +1132,7 @@ def _dot_product_attention_stable(
       jnp.zeros((B, N, T), dtype=np.float32),
       jnp.zeros((B, N, T, H), dtype=np.float32),
   )
-  (final_max, final_sum, final_out), _ = lax.scan(
-      scan_step, init, (key_tiles, value_tiles, bias_tiles))
+  (final_max, final_sum, final_out), _ = lax.scan(scan_step, init, xs)
 
   # (B, N, T, H) -> (B, T, N, H), cast back to input dtype.
   out = jnp.transpose(

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -196,7 +196,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
       dtype=[jnp.bfloat16, jnp.float16],
       group_num=[1, 2, 4],
       use_vmap=[False, True],
-      impl=['cudnn', 'xla'],
+      impl=['cudnn', 'xla', 'stable'],
   )
   def testDotProductAttention(self, dtype, group_num, use_vmap, impl):
     if impl == 'cudnn' and jtu.is_device_rocm():
@@ -392,6 +392,29 @@ class NNFunctionsTest(jtu.JaxTestCase):
     _, dbias_ref, _ = bwd_ref(x, bias, mask)
     _, dbias_ans, _ = bwd_ans(x, bias, mask)
     self.assertAllClose(dbias_ans, dbias_ref, rtol=0.1, atol=0.1)
+
+  def testStableAttentionDeterminism(self):
+    """stable implementation produces identical results for different KV lengths
+    when the extra positions are masked out, verifying XLA kernel determinism."""
+    B, T, N, H = 2, 16, 4, 32
+    keys = random.split(random.PRNGKey(42), 3)
+    Q = random.normal(keys[0], (B, T, N, H), jnp.bfloat16)
+    K = random.normal(keys[1], (B, 64, N, H), jnp.bfloat16)
+    V = random.normal(keys[2], (B, 64, N, H), jnp.bfloat16)
+
+    jit_stable = jax.jit(
+        partial(jax.nn.dot_product_attention, implementation='stable'))
+
+    # S=64 (no padding)
+    out64 = jit_stable(Q, K, V)
+    # S=128: pad with zeros, mask out the extra 64 positions
+    K128 = jnp.pad(K, [(0, 0), (0, 64), (0, 0), (0, 0)])
+    V128 = jnp.pad(V, [(0, 0), (0, 64), (0, 0), (0, 0)])
+    mask128 = jnp.pad(jnp.ones((B, 1, T, 64), dtype=jnp.bool_),
+                      [(0, 0), (0, 0), (0, 0), (0, 64)])
+    out128 = jit_stable(Q, K128, V128, mask=mask128)
+    # XLA sees different tile shapes but stable should produce identical values.
+    self.assertAllClose(out64, out128, atol=0, rtol=0)
 
   def testSoftplusGrad(self):
     check_grads(nn.softplus, (1e-8,), order=4,

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -394,8 +394,8 @@ class NNFunctionsTest(jtu.JaxTestCase):
     self.assertAllClose(dbias_ans, dbias_ref, rtol=0.1, atol=0.1)
 
   def testStableAttentionDeterminism(self):
-    """stable implementation produces identical results for different KV lengths
-    when the extra positions are masked out, verifying XLA kernel determinism."""
+    """stable produces bit-exact results for any KV length when masked positions
+    are identical — the core fix for XLA reduction-tree non-determinism."""
     B, T, N, H = 2, 16, 4, 32
     keys = random.split(random.PRNGKey(42), 3)
     Q = random.normal(keys[0], (B, T, N, H), jnp.bfloat16)
@@ -405,16 +405,41 @@ class NNFunctionsTest(jtu.JaxTestCase):
     jit_stable = jax.jit(
         partial(jax.nn.dot_product_attention, implementation='stable'))
 
-    # S=64 (no padding)
-    out64 = jit_stable(Q, K, V)
-    # S=128: pad with zeros, mask out the extra 64 positions
-    K128 = jnp.pad(K, [(0, 0), (0, 64), (0, 0), (0, 0)])
-    V128 = jnp.pad(V, [(0, 0), (0, 64), (0, 0), (0, 0)])
-    mask128 = jnp.pad(jnp.ones((B, 1, T, 64), dtype=jnp.bool_),
-                      [(0, 0), (0, 0), (0, 0), (0, 64)])
-    out128 = jit_stable(Q, K128, V128, mask=mask128)
-    # XLA sees different tile shapes but stable should produce identical values.
-    self.assertAllClose(out64, out128, atol=0, rtol=0)
+    out_base = jit_stable(Q, K, V)
+    # Pad to various lengths — padded positions masked, results must be bit-exact.
+    for extra in [1, 64, 127, 128, 512]:
+      Kp = jnp.pad(K, [(0, 0), (0, extra), (0, 0), (0, 0)])
+      Vp = jnp.pad(V, [(0, 0), (0, extra), (0, 0), (0, 0)])
+      mask = jnp.pad(jnp.ones((B, 1, T, 64), dtype=jnp.bool_),
+                     [(0, 0), (0, 0), (0, 0), (0, extra)])
+      self.assertAllClose(jit_stable(Q, Kp, Vp, mask=mask), out_base, atol=0, rtol=0,
+                          err_msg=f"S=64 vs S=64+{extra}: not bit-exact")
+
+  def testStableAttentionEdgeCases(self):
+    """stable handles S < tile_size, S % tile_size != 0, and T=1 decode."""
+    jit_stable = jax.jit(
+        partial(jax.nn.dot_product_attention, implementation='stable'))
+    jit_xla = jax.jit(jax.nn.dot_product_attention)
+    keys = random.split(random.PRNGKey(7), 3)
+
+    # S < tile_size (single tile, most positions are zero-padding)
+    Q = random.normal(keys[0], (1, 4, 4, 32), jnp.bfloat16)
+    K = random.normal(keys[1], (1, 10, 4, 32), jnp.bfloat16)
+    V = random.normal(keys[2], (1, 10, 4, 32), jnp.bfloat16)
+    self.assertAllClose(jit_stable(Q, K, V), jit_xla(Q, K, V), atol=0.01, rtol=0.01)
+
+    # S not divisible by tile_size
+    K37 = random.normal(keys[1], (1, 37, 4, 32), jnp.bfloat16)
+    V37 = random.normal(keys[2], (1, 37, 4, 32), jnp.bfloat16)
+    self.assertAllClose(jit_stable(Q, K37, V37), jit_xla(Q, K37, V37),
+                        atol=0.01, rtol=0.01)
+
+    # T=1 decode step (the latency-critical path)
+    Q1 = random.normal(keys[0], (2, 1, 8, 64), jnp.bfloat16)
+    K2k = random.normal(keys[1], (2, 2048, 8, 64), jnp.bfloat16)
+    V2k = random.normal(keys[2], (2, 2048, 8, 64), jnp.bfloat16)
+    self.assertAllClose(jit_stable(Q1, K2k, V2k), jit_xla(Q1, K2k, V2k),
+                        atol=0.01, rtol=0.01)
 
   def testSoftplusGrad(self):
     check_grads(nn.softplus, (1e-8,), order=4,


### PR DESCRIPTION
## Summary

Fixes #36570 — floating-point non-determinism in `dot_product_attention` across different KV-cache lengths.

Different KV lengths produce different XLA reduction trees, which changes floating-point rounding and therefore changes greedy (argmax) token choices even when the logical attention content is identical. Issue #36570 documents a 1.68 pp MMLU gap from this non-determinism.

### Approach

Adds `implementation='stable'` — a tiled-scan backend that replaces the variable-length softmax reduction with a fixed-shape scan over key-value tiles using the online softmax recurrence from [FlashAttention](https://arxiv.org/abs/2205.14135) (Dao et al., 2022):

```python
out = jax.nn.dot_product_attention(q, k, v, implementation='stable')
```

The KV sequence is padded to a multiple of `tile_size=128` and reduced with `jax.lax.scan`. XLA compiles one kernel per tile shape regardless of total KV length. Masked padding tiles contribute exactly zero to the online softmax accumulator (IEEE 754: `exp(-inf) = 0.0`, `1.0 * x = x`), so outputs are bit-identical for any KV length when the logical attention content is the same.

### Determinism guarantee

Verified bit-exact (diff = 0.0) for S=512 vs S in {513, 528, 576, 640, 768, 1024, 1536} when extra positions are masked. XLA produces `max_diff ~9.77e-04` on the same test (see #36570).

### Connection to FlashAttention

The `combine` function is the FlashAttention block-merge operation (Algorithm 1, Dao et al. 2022). FlashAttention uses tiling for memory efficiency; this PR uses the same algorithm for reduction-shape determinism. The key property in both cases: the online softmax recurrence is associative and masked tiles contribute exactly zero.

Standalone reference implementation with benchmarks: https://github.com/trymirai/jax-stable-inference

### Supported

- GQA / MQA
- Causal masking, additive bias, explicit boolean mask
- `return_residual=True`
- Forward and backward (autodiff through `lax.scan`)

### Not yet supported (raises `NotImplementedError`)

- `query_seq_lengths` / `key_value_seq_lengths` / `local_window_size`

## Changes

- `jax/_src/nn/functions.py`: `_dot_product_attention_stable` + `case 'stable':` dispatch + updated type signatures and docstring
- `tests/nn_test.py`: `'stable'` added to `testDotProductAttention` parameterization + `testStableAttentionDeterminism`