### PR TITLE
Fix jax.lax.clz return docstring wording

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1128,7 +1128,7 @@ def clz(x: ArrayLike) -> Array:
 
   Returns:
     An array of the same shape and dtype as ``x``, containing the number of
-    set bits in the input.
+    leading zero bits in the input.
 
   See also:
     - :func:`jax.lax.population_count`: Count the number of set bits in each element.


### PR DESCRIPTION
Fix `jax.lax.clz` docstring return description in `jax/_src/lax/lax.py`.
Replace incorrect "set bits" wording with "leading zero bits" (it seems it
was copy&paste mistake previously)
