### PR TITLE
[GPU] Add VMM allocator support via XLA_PYTHON_CLIENT_ALLOCATOR=vmm

### DIFF
--- a/docs/gpu_memory_allocation.rst
+++ b/docs/gpu_memory_allocation.rst
@@ -77,6 +77,13 @@ Experimental features
 
 Features here are experimental and must be tried with caution.
 
+``XLA_PYTHON_CLIENT_ALLOCATOR=vmm``
+  This uses CUDA's virtual memory management (VMM) allocator
+  (``cudaDeviceAddressVmmAllocator``). This is a CUDA-only experimental
+  allocator that provides fine-grained virtual memory control. It does not
+  preallocate memory; use ``XLA_CLIENT_MEM_FRACTION`` to control the
+  fraction of GPU memory used.
+
 ``TF_GPU_ALLOCATOR=cuda_malloc_async``
   This replace XLA's own BFC memory allocator with `cudaMallocAsync
   <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html>`_.

--- a/jaxlib/xla_client.py
+++ b/jaxlib/xla_client.py
@@ -194,10 +194,10 @@ def generate_pjrt_gpu_plugin_options() -> _NameValueMapping:
   collective_memory_size = os.getenv(
       'XLA_PYTHON_CLIENT_COLLECTIVE_MEM_SIZE_MB', ''
   )
-  if allocator not in ('default', 'platform', 'bfc', 'cuda_async'):
+  if allocator not in ('default', 'platform', 'bfc', 'cuda_async', 'vmm'):
     raise ValueError(
         'XLA_PYTHON_CLIENT_ALLOCATOR env var must be "default", "platform", '
-        '"bfc", or "cuda_async", got "%s"' % allocator
+        '"bfc", "cuda_async", or "vmm", got "%s"' % allocator
     )
   options['allocator'] = allocator
   if memory_fraction:


### PR DESCRIPTION
 Add vmm allocator option via XLA_PYTHON_CLIENT_ALLOCATOR

  XLA recently added cudaDeviceAddressVmmAllocator (GpuAllocatorConfig::Kind::kVmm) as a new CUDA-only GPU memory allocator based on virtual memory management. This PR exposes it in JAX through the existing XLA_PYTHON_CLIENT_ALLOCATOR environment variable.

  Changes:
  - Accept "vmm" as a valid value for XLA_PYTHON_CLIENT_ALLOCATOR in jaxlib/xla_client.py
  - Document the new option in docs/gpu_memory_allocation.rst under Experimental features

  Usage:
  XLA_PYTHON_CLIENT_ALLOCATOR=vmm python your_jax_script.py
  Use XLA_CLIENT_MEM_FRACTION to control the fraction of GPU memory used.

  Notes:
  - CUDA only — on ROCm, XLA will return UnimplementedError
  - No JAX-side guard needed for platform; mirrors the pattern used for cuda_async
  - The string value is passed through as-is to the XLA PJRT plugin, which maps "vmm" → kVmm

  XLA reference: xla/pjrt/gpu/se_gpu_pjrt_client.cc — GetStreamExecutorGpuDeviceAllocator, GpuAllocatorConfig::Kind::kVmm
