### PR TITLE
Make array dtype conversion deprecation raise a TypeError.

### DIFF
--- a/jax/_src/basearray.py
+++ b/jax/_src/basearray.py
@@ -71,7 +71,8 @@ class Array:
         " rather than dtype=arr use dtype=arr.dtype. In the future"
         " this will result in an error."
       ),
-      stacklevel=2)
+      stacklevel=2,
+      error_class=TypeError)
     return self.dtype
 
   @property

--- a/jax/_src/deprecations.py
+++ b/jax/_src/deprecations.py
@@ -112,10 +112,12 @@ def is_accelerated(deprecation_id: str) -> bool:
   return _registered_deprecations[deprecation_id].accelerated
 
 
-def warn(deprecation_id: str, message: str, stacklevel: int) -> None:
+def warn(deprecation_id: str, message: str, stacklevel: int, *,
+         error_class: type[Exception] = ValueError) -> None:
   """Warns about a deprecation, or errors if the deprecation is accelerated."""
   if is_accelerated(deprecation_id):
-    raise ValueError(message)
+    assert issubclass(error_class, Exception)
+    raise error_class(message)
   else:
     warnings.warn(message, category=DeprecationWarning,
                   stacklevel=stacklevel + 1)

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1290,13 +1290,14 @@ class JaxTestCase(parameterized.TestCase):
   def rng(self):
     return self._rng
 
-  def assertDeprecationWarnsOrRaises(self, deprecation_id: str, message: str):
+  def assertDeprecationWarnsOrRaises(self, deprecation_id: str, message: str, *,
+                                     error_class=ValueError):
     """Assert warning or error, depending on deprecation state.
 
     For use with functions that call :func:`jax._src.deprecations.warn`.
     """
     if deprecations.is_accelerated(deprecation_id):
-      return self.assertRaisesRegex(ValueError, message)
+      return self.assertRaisesRegex(error_class, message)
     else:
       return self.assertWarnsRegex(DeprecationWarning, message)
 

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -893,7 +893,7 @@ class JaxArrayTest(jtu.JaxTestCase):
   def test_deprecated_dtype_conversion(self):
     x = jnp.arange(4)
     msg = "Implicit conversion of an array to a dtype is deprecated"
-    with self.assertDeprecationWarnsOrRaises("jax-array-numpy-dtype", msg):
+    with self.assertDeprecationWarnsOrRaises("jax-array-numpy-dtype", msg, error_class=TypeError):
       np.dtype(x)
 
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -33,6 +33,7 @@ from jax import numpy as jnp
 from jax import random
 from jax._src import config
 from jax._src import core
+from jax._src import deprecations
 from jax._src import dispatch
 from jax._src import dtypes
 from jax._src import test_util as jtu
@@ -656,6 +657,9 @@ class KeyArrayTest(jtu.JaxTestCase):
     self.assertFalse(jnp.issubdtype(key.dtype, np.number))
     if jtu.numpy_version() < (2, 4, 0):
       with self.assertRaisesRegex(TypeError, "Cannot interpret"):
+        jnp.issubdtype(key, dtypes.prng_key)
+    elif deprecations.is_accelerated("jax-array-numpy-dtype"):
+      with self.assertRaisesRegex(TypeError, "Implicit conversion of an array to a dtype"):
         jnp.issubdtype(key, dtypes.prng_key)
     else:
       with jtu.ignore_warning(category=DeprecationWarning,


### PR DESCRIPTION
This is consistent with the error that will be raised by NumPy once the deprecation is complete.