### PR TITLE
Add ProcessFailureError to live_devices with failed process IDs

### DIFF
--- a/jax/experimental/multihost_utils.py
+++ b/jax/experimental/multihost_utils.py
@@ -518,6 +518,17 @@ def _gtl_lowering(ctx, x, *, global_mesh, pspec):
 mlir.register_lowering(global_array_to_host_local_array_p, _gtl_lowering)
 
 
+class ProcessFailureError(Exception):
+  """Raised by live_devices when one or more processes have failed.
+
+  Attributes:
+    failed_devices: A set of devices whose processes failed.
+  """
+  def __init__(self, failed_devices: set[xla_client.Device]):
+    self.failed_devices = failed_devices
+    super().__init__(f'Devices failed: {failed_devices}')
+
+
 def _live_devices(client, devices: list[xla_client.Device]) -> dict[xla_client.Device, int]:
   """Returns the subset of the provided devices that are live and healthy."""
   process_ids = {d.process_index for d in devices}
@@ -639,6 +650,9 @@ class _LiveDevices:
   Raises:
     RuntimeError: If the distributed runtime was not initialized.
     ValueError: If no local devices are provided.
+    ProcessFailureError: If one or more processes fail during the with block.
+      The exception's failed_devices attribute contains the set of failed
+      devices.
   """
 
   def __init__(self):
@@ -668,9 +682,15 @@ class _LiveDevices:
       old_devices = self.devices
       new_devices = _live_devices(client, devices)
       self.devices = new_devices
+      # A device has failed if its process died (absent from new_devices) or
+      # restarted with a new incarnation id.
+      failed_devices = {
+          d for d in old_devices
+          if d not in new_devices or new_devices[d] != old_devices[d]
+      }
+      if failed_devices:
+        raise ProcessFailureError(failed_devices) from exception
       if exception:
         raise exception
-      if not old_devices.items() <= new_devices.items():
-        raise ValueError(f'{old_devices} is not a subset of {new_devices}')
 
 live_devices = _LiveDevices()


### PR DESCRIPTION
## Summary

When `live_devices` detects that processes have died during a `with` block, it now raises `ProcessFailureError` instead of a generic exception, so callers can identify exactly which devices failed:

```python
from jax.experimental.multihost_utils import ProcessFailureError

try:
    with live_devices(jax.devices()) as devices:
        ...
except ProcessFailureError as e:
    log(f"Devices {e.failed_devices} failed")
    recover(e.failed_devices)
```

## Changes

- Added `ProcessFailureError(Exception)` class to `jax/experimental/multihost_utils.py` with a `failed_devices: set[Device]` attribute
- In `_LiveDevices.__call__`'s `finally` block, compute failed process IDs from the diff of `old_devices` vs `new_devices` and raise `ProcessFailureError` (chaining any in-block exception via `from exception`)
- Updated `_LiveDevices` docstring `Raises` section

I leave fault_tolerance.rst untouched but would be happy to contribute if needed.

**Edit:** Changed the exception attribute from `failed_process_ids: set[int]` to `failed_devices: set[Device]` per code owner's suggestion.

Enhancement: #36372