### PR TITLE
[ROCm] Accept manylinux_2_28 wheels in auditwheel validation

### DIFF
--- a/ci/utilities/run_auditwheel.sh
+++ b/ci/utilities/run_auditwheel.sh
@@ -40,7 +40,9 @@ for wheel in $WHEELS; do
     # If a wheel is manylinux_2_27 or manylinux2014 compliant, `auditwheel show`
     # will return platform tag as manylinux_2_27 or manylinux_2_17 respectively.
     # manylinux2014 is an alias for manylinux_2_17.
-    if echo "$OUTPUT" | grep -q "manylinux_2_27"; then
+    if echo "$OUTPUT" | grep -q "manylinux_2_28"; then
+        printf "\n$wheel_name is manylinux_2_28 compliant.\n"
+    elif echo "$OUTPUT" | grep -q "manylinux_2_27"; then
         printf "\n$wheel_name is manylinux_2_27 compliant.\n"
     # jax_cudaX_plugin...aarch64.whl is consistent with tag: manylinux_2_26_aarch64"
     elif echo "$OUTPUT" | grep -q "manylinux_2_26"; then
@@ -49,7 +51,7 @@ for wheel in $WHEELS; do
         printf "\n$wheel_name is manylinux2014 compliant.\n"
     else
         echo "$OUTPUT_FULL"
-        printf "\n$wheel_name is NOT manylinux_2_27 or manylinux2014 compliant.\n"
+        printf "\n$wheel_name is NOT  manylinux_2_28, manylinux_2_27, manylinux_2_26, or manylinux2014 compliant.\n"
         exit 1
     fi
 done


### PR DESCRIPTION
This PR allows `manylinux_2_28` wheels to pass auditwheel compliance validation. Current ROCm plugin wheels as constrained to `manylinux_2_28` due to glibc 2.28 usage. The existing CI check only accepts `manylinux_2_27` / `manylinux2014`, causing otherwise valid wheels to fail.

This PR extends the auditwheel validation logic to accept `manylinux_2_28`. No changes are made to the build environment or wheel contents.