### PR TITLE
Always raise in case of CacheVerificationError

### DIFF
--- a/jax/_src/compilation_cache.py
+++ b/jax/_src/compilation_cache.py
@@ -108,6 +108,24 @@ def get_file_cache(path: str) -> tuple[CacheInterface, str] | None:
   return cache, path
 
 
+class CacheVerificationError(RuntimeError):
+  """Error raised when a freshly compiled executable does not exactly
+  match an executable in the compilation cache at the same key.
+  """
+
+  def __init__(
+      self,
+      message: str,
+      cache_key: str,
+      executable_on_disk: bytes,
+      executable_new: bytes,
+  ):
+    super().__init__(message)
+    self.cache_key = cache_key
+    self.executable_on_disk = executable_on_disk
+    self.executable_new = executable_new
+
+
 class VerificationCache(CacheInterface):
   """A cache that wraps another cache and verifies its contents.
 
@@ -154,10 +172,13 @@ class VerificationCache(CacheInterface):
         executable_on_disk, _ = extract_executable_and_time(decompressed_on_disk)
         executable_new, _ = extract_executable_and_time(decompressed_new)
         if executable_on_disk != executable_new:
-          raise RuntimeError(
+          raise CacheVerificationError(
               f"Persistent compilation cache inconsistency for key {key}. "
               "Executable found in the disk cache does not match the "
-              "freshly compiled executable."
+              "freshly compiled executable.",
+              key,
+              executable_on_disk,
+              executable_new,
           )
       self._verified_keys.add(key)
 

--- a/jax/_src/compiler.py
+++ b/jax/_src/compiler.py
@@ -760,13 +760,21 @@ def _compile_and_write_cache(
   return executable
 
 
+def _should_raise_persistent_cache_error(ex: Exception) -> bool:
+  """Returns True if the exception should be raised, False if it should be warned."""
+  return (
+      config.raise_persistent_cache_errors.value or
+      isinstance(ex, compilation_cache.CacheVerificationError)
+  )
+
+
 def _is_executable_in_cache(backend, cache_key) -> bool:
   """Checks if executable is presented in cache on a given key
   """
   try:
     return compilation_cache.is_executable_in_cache(backend, cache_key)
   except Exception as ex:
-    if config.raise_persistent_cache_errors.value:
+    if _should_raise_persistent_cache_error(ex):
       raise
     warnings.warn(
         f"Error reading persistent compilation cache entry for "
@@ -785,7 +793,7 @@ def _cache_read(
     return compilation_cache.get_executable_and_time(
         cache_key, compile_options, backend, executable_devices)
   except Exception as ex:
-    if config.raise_persistent_cache_errors.value:
+    if _should_raise_persistent_cache_error(ex):
       raise
     warnings.warn(
         f"Error reading persistent compilation cache entry for "
@@ -836,7 +844,7 @@ def _cache_write(cache_key: str,
     compilation_cache.put_executable_and_time(
         cache_key, module_name, executable, backend, int(compile_time_secs))
   except Exception as ex:
-    if config.raise_persistent_cache_errors.value:
+    if _should_raise_persistent_cache_error(ex):
       raise
     warnings.warn(
         f"Error writing persistent compilation cache entry for "


### PR DESCRIPTION
If the user enables jax_compilation_cache_check_contents and there's a CacheVerificationError then we should raise regardless of the value of jax_raise_persistent_cache_error.