### PR TITLE
Automatic differentiation for lax.linalg.eig

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -184,7 +184,7 @@ def eig(
 
   To prevent silently incorrect gradients, differentiation through eigenvectors
   raises an error by default. Set ``allow_eigvec_deriv=True`` to opt in,
-  thereby asserting that your computation does not depend on the phase of the
+  thereby promising that your computation does not depend on the phase of the
   eigenvectors. When this flag is set, the JVP projects out the full gauge
   ambiguity (both norm and phase components) from the eigenvector tangents,
   making the result well-defined regardless.

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1266,7 +1266,8 @@ def eig_jvp_rule(primals, tangents, *, compute_left_eigenvectors,
     dVL_raw = dot(vl, Fmat_L * P_L)
     # Normalization correction: enforce real(VL^H dVL)_{jj} = 0
     VLH_dVL = dot(_H(vl), dVL_raw)
-    dVL = dVL_raw - vl * _extract_diagonal(VLH_dVL.real)[..., np.newaxis, :]
+    norm_corr_L = _extract_diagonal(VLH_dVL.real).astype(vl.dtype)
+    dVL = dVL_raw - vl * norm_corr_L[..., np.newaxis, :]
 
     out_primals.append(vl)
     out_tangents.append(dVL)
@@ -1276,7 +1277,8 @@ def eig_jvp_rule(primals, tangents, *, compute_left_eigenvectors,
     dVR_raw = dot(vr, Fmat * P)
     # Normalization correction: enforce real(VR^H dVR)_{jj} = 0
     VRH_dVR = dot(_H(vr), dVR_raw)
-    dVR = dVR_raw - vr * _extract_diagonal(VRH_dVR.real)[..., np.newaxis, :]
+    norm_corr_R = _extract_diagonal(VRH_dVR.real).astype(vr.dtype)
+    dVR = dVR_raw - vr * norm_corr_R[..., np.newaxis, :]
 
     out_primals.append(vr)
     out_tangents.append(dVR)

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -141,6 +141,7 @@ def eig(
     compute_right_eigenvectors: bool = True,
     implementation: EigImplementation | None = None,
     use_magma: bool | None = None,
+    allow_eigvec_deriv: bool = False,
 ) -> list[Array]:
   """Eigendecomposition of a general matrix.
 
@@ -175,11 +176,30 @@ def eig(
   (repeated) eigenvalues are mathematically ill-defined and will produce
   numerically large or infinite values.
 
+  **Phase ambiguity in eigenvector gradients.** Eigenvectors are defined only
+  up to an arbitrary complex phase: if ``v`` is an eigenvector, so is
+  ``e^{iθ} v`` for any real ``θ``. This means eigenvector-dependent gradients
+  are only well-defined when the downstream computation does not depend on this
+  arbitrary phase choice. This is analogous to the ``holomorphic=True`` flag on
+  :func:`jax.grad`.
+
+  To prevent silently incorrect gradients, differentiation through eigenvectors
+  raises an error by default. Set ``allow_eigvec_deriv=True`` to opt in,
+  thereby asserting that your computation does not depend on the phase of the
+  eigenvectors. When this flag is set, the JVP projects out the full gauge
+  ambiguity (both norm and phase components) from the eigenvector tangents,
+  making the result well-defined regardless.
+
   Args:
     x: A batch of square matrices with shape ``[..., n, n]``.
     compute_left_eigenvectors: If true, the left eigenvectors will be computed.
     compute_right_eigenvectors: If true, the right eigenvectors will be
       computed.
+    allow_eigvec_deriv: If ``False`` (default), differentiating through
+      eigenvectors raises an error. Set to ``True`` to enable eigenvector
+      differentiation, asserting that your downstream computation does not
+      depend on the arbitrary phase of the eigenvectors. See the note on phase
+      ambiguity above.
     use_magma: Deprecated, please use ``implementation`` instead. Locally
       override the ``jax_use_magma`` flag. If ``True``, the eigendecomposition
       is computed using MAGMA. If ``False``, the computation is done using
@@ -219,7 +239,8 @@ def eig(
     )
   return eig_p.bind(x, compute_left_eigenvectors=compute_left_eigenvectors,
                     compute_right_eigenvectors=compute_right_eigenvectors,
-                    implementation=implementation)
+                    implementation=implementation,
+                    allow_eigvec_deriv=allow_eigvec_deriv)
 
 
 class EighImplementation(enum.Enum):
@@ -1011,7 +1032,7 @@ def _eig_compute_attr(compute):
   )
 
 def _eig_cpu_lowering(ctx, operand, *, compute_left_eigenvectors,
-                      compute_right_eigenvectors, implementation):
+                      compute_right_eigenvectors, implementation, **_):
   if implementation and implementation != EigImplementation.LAPACK:
     raise ValueError("Only the lapack implementation is supported on CPU.")
   operand_aval, = ctx.avals_in
@@ -1078,7 +1099,7 @@ def _unpack_conjugate_pairs(w: Array, vr: Array) -> Array:
 
 def _eig_gpu_lowering(ctx, operand, *,
                       compute_left_eigenvectors, compute_right_eigenvectors,
-                      implementation, target_name_prefix):
+                      implementation, target_name_prefix, **_):
   operand_aval, = ctx.avals_in
   batch_dims = operand_aval.shape[:-2]
   n, m = operand_aval.shape[-2:]
@@ -1191,17 +1212,31 @@ def _eig_gpu_lowering(ctx, operand, *,
   return output
 
 def eig_jvp_rule(primals, tangents, *, compute_left_eigenvectors,
-                 compute_right_eigenvectors, implementation):
+                 compute_right_eigenvectors, implementation, allow_eigvec_deriv):
   # Formulas from https://arxiv.org/abs/1701.00392:
   #   eigenvalue JVP:       eqn 4.60
   #   right eigenvector JVP: eqn 4.63
   # Left eigenvectors of A are right eigenvectors of A^H, so their JVP is
   # derived by applying the right-eigenvector formula to (A^H, dA^H).
   #
-  # Normalization: LAPACK returns unit-norm eigenvectors. The raw perturbation
-  # formula gives dV that changes the norm to first order. We correct this by
-  # projecting out the real part of the diagonal of V^H dV, which enforces the
-  # unit-norm constraint d(||v_j||^2)/dt = 0.
+  # Gauge projection: eigenvectors are defined only up to a complex phase
+  # e^{iθ}. The raw JVP formula produces a tangent dV that may include a
+  # component in this ambiguous direction. We project it out by subtracting
+  # V * diag(V^H dV), which zeros the full complex diagonal of V^H dV
+  # (both the real/norm component and the imaginary/phase component).
+  # This makes the JVP well-defined when the downstream computation is
+  # independent of the eigenvector phase (the condition the user asserts
+  # by setting allow_eigvec_deriv=True).
+  if (compute_left_eigenvectors or compute_right_eigenvectors) and not allow_eigvec_deriv:
+    raise ValueError(
+        "Differentiation through eigenvectors of lax.linalg.eig is disabled "
+        "by default because eigenvectors are only defined up to an arbitrary "
+        "complex phase. Set allow_eigvec_deriv=True to enable eigenvector "
+        "differentiation, asserting that your downstream computation does not "
+        "depend on the phase of the eigenvectors. See the lax.linalg.eig "
+        "docstring for details."
+    )
+
   a, = primals
   da, = tangents
   n = a.shape[-1]
@@ -1215,6 +1250,7 @@ def eig_jvp_rule(primals, tangents, *, compute_left_eigenvectors,
         compute_left_eigenvectors=True,
         compute_right_eigenvectors=True,
         implementation=implementation,
+        allow_eigvec_deriv=allow_eigvec_deriv,
     )
   else:
     l, vr = eig_p.bind(
@@ -1222,6 +1258,7 @@ def eig_jvp_rule(primals, tangents, *, compute_left_eigenvectors,
         compute_left_eigenvectors=False,
         compute_right_eigenvectors=True,
         implementation=implementation,
+        allow_eigvec_deriv=allow_eigvec_deriv,
     )
 
   da = da.astype(l.dtype)
@@ -1264,10 +1301,11 @@ def eig_jvp_rule(primals, tangents, *, compute_left_eigenvectors,
       ) - eye_n
 
     dVL_raw = dot(vl, Fmat_L * P_L)
-    # Normalization correction: enforce real(VL^H dVL)_{jj} = 0
+    # Gauge projection: zero the full complex diagonal of VL^H dVL to remove
+    # both the norm component (Re diag) and the phase component (Im diag).
     VLH_dVL = dot(_H(vl), dVL_raw)
-    norm_corr_L = _extract_diagonal(VLH_dVL.real).astype(vl.dtype)
-    dVL = dVL_raw - vl * norm_corr_L[..., np.newaxis, :]
+    gauge_corr_L = _extract_diagonal(VLH_dVL).astype(vl.dtype)
+    dVL = dVL_raw - vl * gauge_corr_L[..., np.newaxis, :]
 
     out_primals.append(vl)
     out_tangents.append(dVL)
@@ -1275,10 +1313,11 @@ def eig_jvp_rule(primals, tangents, *, compute_left_eigenvectors,
   if compute_right_eigenvectors:
     # Right eigenvector JVP
     dVR_raw = dot(vr, Fmat * P)
-    # Normalization correction: enforce real(VR^H dVR)_{jj} = 0
+    # Gauge projection: zero the full complex diagonal of VR^H dVR to remove
+    # both the norm component (Re diag) and the phase component (Im diag).
     VRH_dVR = dot(_H(vr), dVR_raw)
-    norm_corr_R = _extract_diagonal(VRH_dVR.real).astype(vr.dtype)
-    dVR = dVR_raw - vr * norm_corr_R[..., np.newaxis, :]
+    gauge_corr_R = _extract_diagonal(VRH_dVR).astype(vr.dtype)
+    dVR = dVR_raw - vr * gauge_corr_R[..., np.newaxis, :]
 
     out_primals.append(vr)
     out_tangents.append(dVR)

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -180,8 +180,7 @@ def eig(
   up to an arbitrary complex phase: if ``v`` is an eigenvector, so is
   ``e^{iθ} v`` for any real ``θ``. This means eigenvector-dependent gradients
   are only well-defined when the downstream computation does not depend on this
-  arbitrary phase choice. This is analogous to the ``holomorphic=True`` flag on
-  :func:`jax.grad`.
+  arbitrary phase choice.
 
   To prevent silently incorrect gradients, differentiation through eigenvectors
   raises an error by default. Set ``allow_eigvec_deriv=True`` to opt in,

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -169,9 +169,11 @@ def eig(
   be used if the library can be found, and the input matrix is sufficiently
   large (>= 2048x2048).
 
-  Currently autodiff is not supporteed for non-symmetric eigenvectors, and
-  is only supported to first-order for non-symmetric eigenvalues. See
-  https://github.com/jax-ml/jax/issues/2748.
+  Autodiff (forward-mode JVP and, by transposition, reverse-mode VJP) is
+  supported for eigenvalues and eigenvectors. The formulas follow eqns 4.60
+  and 4.63 in https://arxiv.org/abs/1701.00392. Gradients through degenerate
+  (repeated) eigenvalues are mathematically ill-defined and will produce
+  numerically large or infinite values.
 
   Args:
     x: A batch of square matrices with shape ``[..., n, n]``.
@@ -1190,17 +1192,96 @@ def _eig_gpu_lowering(ctx, operand, *,
 
 def eig_jvp_rule(primals, tangents, *, compute_left_eigenvectors,
                  compute_right_eigenvectors, implementation):
-  if compute_left_eigenvectors or compute_right_eigenvectors:
-    raise NotImplementedError(
-        'The derivatives of non-symmetric eigenvectors are not supported. '
-        'Only first-order derivatives of eigenvalues are supported. See '
-        'https://github.com/jax-ml/jax/issues/2748 for discussion.')
-  # Formula for derivative of eigenvalues w.r.t. a is eqn 4.60 in
-  # https://arxiv.org/abs/1701.00392
+  # Formulas from https://arxiv.org/abs/1701.00392:
+  #   eigenvalue JVP:       eqn 4.60
+  #   right eigenvector JVP: eqn 4.63
+  # Left eigenvectors of A are right eigenvectors of A^H, so their JVP is
+  # derived by applying the right-eigenvector formula to (A^H, dA^H).
+  #
+  # Normalization: LAPACK returns unit-norm eigenvectors. The raw perturbation
+  # formula gives dV that changes the norm to first order. We correct this by
+  # projecting out the real part of the diagonal of V^H dV, which enforces the
+  # unit-norm constraint d(||v_j||^2)/dt = 0.
   a, = primals
   da, = tangents
-  l, v = eig(a, compute_left_eigenvectors=False, implementation=implementation)
-  return [l], [(_solve(v, da.astype(v.dtype)) * _T(v)).sum(-1)]
+  n = a.shape[-1]
+
+  # Always compute right eigenvectors — they are required for the eigenvalue JVP
+  # (dl = diag(VR^{-1} dA VR)). If left eigenvectors are also requested, fetch
+  # them in the same LAPACK call to avoid redundant work.
+  if compute_left_eigenvectors:
+    l, vl, vr = eig_p.bind(
+        a,
+        compute_left_eigenvectors=True,
+        compute_right_eigenvectors=True,
+        implementation=implementation,
+    )
+  else:
+    l, vr = eig_p.bind(
+        a,
+        compute_left_eigenvectors=False,
+        compute_right_eigenvectors=True,
+        implementation=implementation,
+    )
+
+  da = da.astype(l.dtype)
+  dot = partial(lax.dot if a.ndim == 2 else lax.batch_matmul,
+                precision=lax.Precision.HIGHEST)
+
+  # P = VR^{-1} dA VR  (n×n projected perturbation matrix)
+  temp = _solve(vr, da)  # VR^{-1} dA
+  P = dot(temp, vr)       # VR^{-1} dA VR
+
+  # Eigenvalue JVP: dl_j = P_{jj}
+  dl = _extract_diagonal(P)
+
+  if not compute_left_eigenvectors and not compute_right_eigenvectors:
+    return [l], [dl]
+
+  # Build F-matrix: F[i,j] = 1/(l[j] - l[i]) for i≠j, 0 on the diagonal.
+  # Trick: (eye + l[j] - l[i]) equals 1 on the diagonal and (l[j]-l[i])
+  # elsewhere. Taking the elementwise reciprocal and subtracting eye zeros out
+  # the diagonal while leaving the off-diagonal entries as 1/(l[j]-l[i]).
+  eye_n = lax._eye(l.dtype, (n, n))
+  with config.numpy_rank_promotion("allow"):
+    Fmat = lax.integer_pow(eye_n + l[..., np.newaxis, :] - l[..., :, np.newaxis], -1) - eye_n
+
+  out_primals = [l]
+  out_tangents = [dl]
+
+  if compute_left_eigenvectors:
+    # Left eigenvectors VL are right eigenvectors of A^H with eigenvalues
+    # conj(l). Apply the right-eigenvector JVP formula to (A^H, dA^H).
+    da_H = _H(da)
+    temp_L = _solve(vl, da_H)   # VL^{-1} dA^H
+    P_L = dot(temp_L, vl)        # VL^{-1} dA^H VL
+
+    # F-matrix for conjugate eigenvalues: F_L[i,j] = 1/(conj(l[j]) - conj(l[i]))
+    l_conj = l.conj()
+    with config.numpy_rank_promotion("allow"):
+      Fmat_L = lax.integer_pow(
+          eye_n + l_conj[..., np.newaxis, :] - l_conj[..., :, np.newaxis], -1
+      ) - eye_n
+
+    dVL_raw = dot(vl, Fmat_L * P_L)
+    # Normalization correction: enforce real(VL^H dVL)_{jj} = 0
+    VLH_dVL = dot(_H(vl), dVL_raw)
+    dVL = dVL_raw - vl * _extract_diagonal(VLH_dVL.real)[..., np.newaxis, :]
+
+    out_primals.append(vl)
+    out_tangents.append(dVL)
+
+  if compute_right_eigenvectors:
+    # Right eigenvector JVP
+    dVR_raw = dot(vr, Fmat * P)
+    # Normalization correction: enforce real(VR^H dVR)_{jj} = 0
+    VRH_dVR = dot(_H(vr), dVR_raw)
+    dVR = dVR_raw - vr * _extract_diagonal(VRH_dVR.real)[..., np.newaxis, :]
+
+    out_primals.append(vr)
+    out_tangents.append(dVR)
+
+  return out_primals, out_tangents
 
 eig_p = linalg_primitive(
     _eig_dtype_rule, (_float | _complex,), (2,), _eig_shape_rule, "eig",

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -793,7 +793,7 @@ def det(a: ArrayLike) -> Array:
 
 
 @export
-def eig(a: ArrayLike) -> EigResult:
+def eig(a: ArrayLike, *, allow_eigvec_deriv: bool = False) -> EigResult:
   """
   Compute the eigenvalues and eigenvectors of a square array.
 
@@ -801,6 +801,10 @@ def eig(a: ArrayLike) -> EigResult:
 
   Args:
     a: array of shape ``(..., M, M)`` for which to compute the eigenvalues and vectors.
+    allow_eigvec_deriv: If ``False`` (default), differentiating through eigenvectors
+      raises an error. Set to ``True`` to enable eigenvector differentiation, asserting
+      that your downstream computation does not depend on the arbitrary complex phase of
+      the eigenvectors. See :func:`jax.lax.linalg.eig` for details.
 
   Returns:
     A namedtuple ``(eigenvalues, eigenvectors)``. The namedtuple has fields:
@@ -816,8 +820,6 @@ def eig(a: ArrayLike) -> EigResult:
     - At present, non-symmetric eigendecomposition is only implemented on the CPU and
       GPU backends. For more details about the GPU implementation, see the
       documentation for :func:`jax.lax.linalg.eig`.
-    - Currently autodiff is not supported for computation of non-symmetric eigenvectors;
-      see https://github.com/jax-ml/jax/issues/2748.
 
   See also:
     - :func:`jax.lax.linalg.eig`: similar function with different eigenvector options
@@ -838,7 +840,8 @@ def eig(a: ArrayLike) -> EigResult:
   """
   a = ensure_arraylike("jnp.linalg.eig", a)
   a, = promote_dtypes_inexact(a)
-  w, v = lax_linalg.eig(a, compute_left_eigenvectors=False)
+  w, v = lax_linalg.eig(a, compute_left_eigenvectors=False,
+                        allow_eigvec_deriv=allow_eigvec_deriv)
   return EigResult(w, v)
 
 

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -153,6 +153,7 @@ def _normalizing_eig(a, compute_left_eigenvectors=False,
       a,
       compute_left_eigenvectors=compute_left_eigenvectors,
       compute_right_eigenvectors=compute_right_eigenvectors,
+      allow_eigvec_deriv=True,
   )
   w = results[0]
   out = [w]
@@ -477,6 +478,17 @@ class NumpyLinalgTest(jtu.JaxTestCase):
                 compute_right_eigenvectors=compute_right_eigenvectors)
     tol = 1e-4 if dtype in (np.float64, np.complex128) else 5e-2
     jtu.check_grads(f, (a,), order=1, modes=['fwd', 'rev'], rtol=tol, atol=tol)
+
+  @jtu.run_on_devices("cpu", "gpu")
+  def testEigGradRaisesWithoutAllowEigvecDeriv(self):
+    # Differentiating through eigenvectors should raise an error unless
+    # allow_eigvec_deriv=True is set.
+    rng = jtu.rand_default(self.rng())
+    a = rng((4, 4), np.float32)
+    f = lambda x: lax.linalg.eig(x, compute_right_eigenvectors=True,
+                                  compute_left_eigenvectors=False)[1]
+    with self.assertRaisesRegex(ValueError, "allow_eigvec_deriv"):
+      jax.jacfwd(f)(a)
 
   @jtu.sample_product(
     shape=[(4, 4), (5, 5), (50, 50)],

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -476,8 +476,9 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     f = partial(_normalizing_eig,
                 compute_left_eigenvectors=compute_left_eigenvectors,
                 compute_right_eigenvectors=compute_right_eigenvectors)
+    order = 2 if dtype in (np.float64, np.complex128) else 1
     tol = 1e-4 if dtype in (np.float64, np.complex128) else 5e-2
-    jtu.check_grads(f, (a,), order=1, modes=['fwd', 'rev'], rtol=tol, atol=tol)
+    jtu.check_grads(f, (a,), order=order, modes=['fwd', 'rev'], rtol=tol, atol=tol)
 
   @jtu.run_on_devices("cpu", "gpu")
   def testEigGradRaisesWithoutAllowEigvecDeriv(self):

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -143,6 +143,36 @@ def _normalizing_eigh(H: np.ndarray, lower: bool, symmetrize_input: bool):
   return e, v
 
 
+# (complex) Eigenvectors of a general matrix are only unique up to a complex phase, making
+# finite-difference gradient checks unreliable. We normalize each eigenvector so that its first
+# component has phase 0 (i.e. is real and positive), which yields a smooth, unique representative
+# as long as the first component is non-zero.
+def _normalizing_eig(a, compute_left_eigenvectors=False,
+                     compute_right_eigenvectors=True):
+  results = lax.linalg.eig(
+      a,
+      compute_left_eigenvectors=compute_left_eigenvectors,
+      compute_right_eigenvectors=compute_right_eigenvectors,
+  )
+  w = results[0]
+  out = [w]
+  idx = 1
+
+  def _normalize_cols(v):
+    """Rotate each column so its first element is real and positive."""
+    top = v[..., 0:1, :]       # shape (..., 1, n)
+    angle = -jnp.angle(top)
+    phase = lax.complex(jnp.cos(angle), jnp.sin(angle))
+    return v * phase
+
+  if compute_left_eigenvectors:
+    out.append(_normalize_cols(results[idx]))
+    idx += 1
+  if compute_right_eigenvectors:
+    out.append(_normalize_cols(results[idx]))
+  return tuple(out)
+
+
 # (complex) singular vectors are only unique up to an arbitrary phase. This makes the gradient
 # tests based on finite differences unstable, since perturbing the input matri may cause an
 # arbitrary sign flip of one or more of the singular vectors. To remedy this, we normalize the
@@ -419,6 +449,34 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     tol = 1e-4 if dtype in (np.float64, np.complex128) else 1e-1
     jtu.check_grads(lambda x: jnp.linalg.eigvals(x), (a,), order=1,
                     modes=['fwd', 'rev'], rtol=tol, atol=tol)
+
+  @jtu.sample_product(
+    shape=[(4, 4), (5, 5), (7, 6, 6)],
+    dtype=float_types + complex_types,
+    compute_left_eigenvectors=[False, True],
+    compute_right_eigenvectors=[False, True],
+  )
+  @jtu.run_on_devices("cpu", "gpu")
+  def testEigGrad(self, shape, dtype, compute_left_eigenvectors,
+                  compute_right_eigenvectors):
+    # Test that eig JVP and VJP (transpose of JVP) are correct for
+    # eigenvalues and eigenvectors of a general matrix.
+    #
+    # Eigenvectors are unique only up to complex phase, so we fix a gauge
+    # by normalizing each vector so its first element is real and positive
+    # (see _normalizing_eig). Finite-difference checks can still fail if a
+    # perturbation causes two eigenvalues to swap order; we restrict to small
+    # matrices where this is unlikely for random inputs.
+    if not (compute_left_eigenvectors or compute_right_eigenvectors):
+      # Eigenvalue-only gradients are already covered by testEigvalsGrad.
+      self.skipTest("eigenvalue-only case covered by testEigvalsGrad")
+    rng = jtu.rand_default(self.rng())
+    a = rng(shape, dtype)
+    f = partial(_normalizing_eig,
+                compute_left_eigenvectors=compute_left_eigenvectors,
+                compute_right_eigenvectors=compute_right_eigenvectors)
+    tol = 1e-4 if dtype in (np.float64, np.complex128) else 5e-2
+    jtu.check_grads(f, (a,), order=1, modes=['fwd', 'rev'], rtol=tol, atol=tol)
 
   @jtu.sample_product(
     shape=[(4, 4), (5, 5), (50, 50)],


### PR DESCRIPTION
The implementation was generated with Claude Code after providing the following resources:
- pytorch implementation of eig autodiff
- autograd implementation of eig autodiff
- fmmax implementation of eig autodiff
- Github issue #2748 discussion
- Giles, M. (2008). https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf
- Boeddeker, C. et al. (2017) https://arxiv.org/abs/1701.00392

I do not have the expertise to understand the underlying mathematics but I needed the implementation and thought it may be valuable for others.

I tested gradients against lax.linalg.eigh and jax.scipy.linalg.expm with identical results.

I also tested the implementation from within PyMC models with MCMC sampling and thousands of evaluations and obtained correct fast model convergence.
