### PR TITLE
Fix cuDNN attention backward batcher for vmap(grad(...))

### DIFF
--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -882,13 +882,12 @@ def _dot_product_attention_bwd_batcher(
   # activation (idx 10), fwd_output (idx 11), and grad_output (idx 12) may
   # not carry the vmap batch axis (batch_dims[i] is None) when the cotangent
   # is uniform across vmap lanes (e.g. grad_output from a scalar loss
-  # reduction).  Handle by inserting a size-1 axis and broadcasting to match
-  # the vmap axis size before flattening into the single B dimension.
+  # reduction).  Handle by prepending the vmap dimension and broadcasting to
+  # match the batched inputs before flattening into the single B dimension.
   def _reshape_residual(tensor, bdim, target_shape):
-    if bdim is not None:
-      return jnp.reshape(tensor, target_shape)
-    tensor = jnp.expand_dims(tensor, axis=0)
-    tensor = jnp.broadcast_to(tensor, (Bs[0],) + tensor.shape[1:])
+    if bdim is None:
+      # Prepend the vmap dimension and broadcast to match the batched inputs.
+      tensor = jnp.broadcast_to(tensor[None, ...], (Bs[0],) + tensor.shape)
     return jnp.reshape(tensor, target_shape)
 
   activation = _reshape_residual(activation, batch_dims[10], (B, N, T))
@@ -1632,9 +1631,19 @@ def _dot_product_attention_fp8_bwd_batcher(
   key = jnp.reshape(key, (B,) + key.shape[-3:])
   value = jnp.reshape(value, (B,) + key.shape[-3:])
 
-  activation = jnp.reshape(activation, (B, N, T))
-  fwd_output = jnp.reshape(fwd_output, (B,) + query.shape[-3:])
-  grad_output = jnp.reshape(grad_output, (B,) + query.shape[-3:])
+  # fwd_output (idx 3), grad_output (idx 4), activation (idx 5) may not carry
+  # the vmap batch axis when the cotangent is uniform across vmap lanes.
+  def _reshape_residual(tensor, bdim, target_shape):
+    if bdim is None:
+      # Prepend the vmap dimension and broadcast to match the batched inputs.
+      tensor = jnp.broadcast_to(tensor[None, ...], (Bs[0],) + tensor.shape)
+    return jnp.reshape(tensor, target_shape)
+
+  activation = _reshape_residual(activation, batch_dims[5], (B, N, T))
+  fwd_output = _reshape_residual(
+      fwd_output, batch_dims[3], (B,) + query.shape[-3:])
+  grad_output = _reshape_residual(
+      grad_output, batch_dims[4], (B,) + query.shape[-3:])
 
   grads = _dot_product_attention_fp8_bwd_p_wrapper.bind(
       query, key, value, fwd_output, grad_output, activation,

--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -879,9 +879,23 @@ def _dot_product_attention_bwd_batcher(
     q_seqlen = jnp.reshape(q_seqlen, (B, ))
     kv_seqlen = jnp.reshape(kv_seqlen, (B, ))
 
-  activation = jnp.reshape(activation, (B, N, T))
-  fwd_output = jnp.reshape(fwd_output, (B,) + query.shape[-3:])
-  grad_output = jnp.reshape(grad_output, (B,) + query.shape[-3:])
+  # activation (idx 10), fwd_output (idx 11), and grad_output (idx 12) may
+  # not carry the vmap batch axis (batch_dims[i] is None) when the cotangent
+  # is uniform across vmap lanes (e.g. grad_output from a scalar loss
+  # reduction).  Handle by inserting a size-1 axis and broadcasting to match
+  # the vmap axis size before flattening into the single B dimension.
+  def _reshape_residual(tensor, bdim, target_shape):
+    if bdim is not None:
+      return jnp.reshape(tensor, target_shape)
+    tensor = jnp.expand_dims(tensor, axis=0)
+    tensor = jnp.broadcast_to(tensor, (Bs[0],) + tensor.shape[1:])
+    return jnp.reshape(tensor, target_shape)
+
+  activation = _reshape_residual(activation, batch_dims[10], (B, N, T))
+  fwd_output = _reshape_residual(
+      fwd_output, batch_dims[11], (B,) + query.shape[-3:])
+  grad_output = _reshape_residual(
+      grad_output, batch_dims[12], (B,) + query.shape[-3:])
 
   grads = _dot_product_attention_bwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,


### PR DESCRIPTION
## Summary
- Fix `_dot_product_attention_bwd_batcher` to handle unbatched `activation`, `fwd_output`, and `grad_output` when called via `vmap(grad(f))`

## Problem
`jax.vmap(jax.grad(loss_fn))(q, k, v)` where `loss_fn` uses `jax.nn.dot_product_attention(..., implementation='cudnn')` fails with:
```
TypeError: cannot reshape array of shape (1, 4, 2, 8) (size 64) into shape (2, 4, 2, 8) (size 128)
```

The backward batcher computes `B = math.prod(Bs)` from `query.shape` (which includes the vmap axis, so B=2), then reshapes `grad_output` to `(B,) + query.shape[-3:]`. But `grad_output` may arrive without the vmap axis (`batch_dims[12] is None`), so it has fewer elements than expected.

## Fix
Check each residual tensor's `batch_dims` entry. If `None` (unbatched), insert a size-1 axis at position 0 and `broadcast_to` the vmap axis size before flattening into `(B, ...)`. The broadcast is a zero-copy view, adding no overhead.

## Use Case
This enables `vmap(grad(dot_product_attention(..., implementation='cudnn')))` which is needed for meta-learning / learned optimizer training where multiple tasks are vectorized via `vmap` with per-task gradient computation.

## Test plan
- [x] `vmap(grad(f))` with `implementation='cudnn'` — previously failed, now passes
- [x] `vmap(value_and_grad(f))` — previously failed, now passes
- [x] Various batch sizes (B=2, B=3) — all pass
- [x] Larger tensors (seq=16, head_dim=64) — passes
- [x] Non-vmapped path unchanged (no regression)
- Tested on NVIDIA L40S with JAX 0.9.2

🤖 Generated with [Claude Code](https://claude.ai/claude-code)