### PR TITLE
Deprecate a few dozen jax.core APIs for v0.10.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,20 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * {func}`jax.scipy.stats.rankdata` now returns floating point values in
     all cases, following a similar change in the SciPy 1.18 release.
 
+* Deprecations:
+  * A number of internal APIs in `jax.core` have been newly deprecated and
+    some have been moved to `jax.extend.core`. These include `CallPrimitive`,
+    `DebugInfo`, `DropVar`, `Effect`, `Effects`, `InconclusiveDimensionOperation`,
+    `JaxprTypeError`, `check_jaxpr`, `concrete_or_error`, `find_top_trace`,
+    `gensym`, `get_opaque_trace_state`, `jaxprs_in_params`, `new_jaxpr_eqn`,
+    `no_effects`, `nonempty_axis_env_DO_NOT_USE`, `primal_dtype_to_tangent_dtype`,
+    `unsafe_am_i_under_a_jit_DO_NOT_USE`, `unsafe_am_i_under_a_vmap_DO_NOT_USE`,
+    `unsafe_get_axis_names_DO_NOT_USE`, `valid_jaxtype`, `JaxprPpContext`,
+    `JaxprPpSettings`, `OutputType`, `abstract_token`, `aval_mapping_handlers`,
+    `call`, `concretization_function_error`, `custom_typechecks`, `is_concrete`,
+    `is_constant_dim`, `is_constant_shape`, `literalable_types`, `no_axis_name`,
+    `pytype_aval_mappings`, and `trace_ctx`.
+
 * Changes:
   * The minimum supported SciPy version is now 1.14.
   * `vma` parameter of `jax.ShapeDtypeStruct` has been replaced with

--- a/docs/jax.extend.core.rst
+++ b/docs/jax.extend.core.rst
@@ -7,9 +7,16 @@
   :toctree: _autosummary
 
   AbstractToken
+  CallPrimitive
   ClosedJaxpr
+  DebugInfo
+  DropVar
+  Effect
+  Effects
+  InconclusiveDimensionOperation
   Jaxpr
   JaxprEqn
+  JaxprTypeError
   Literal
   Primitive
   Token
@@ -17,10 +24,24 @@
   Var
   array_types
   call_impl
+  check_jaxpr
+  concrete_or_error
+  find_top_trace
+  gensym
+  get_opaque_trace_state
   jaxpr_as_fun
-  primitives
+  jaxprs_in_params
   mapped_aval
+  new_jaxpr_eqn
+  no_effects
+  nonempty_axis_env_DO_NOT_USE
+  primal_dtype_to_tangent_dtype
+  primitives
   set_current_trace
   subjaxprs
   take_current_trace
   unmapped_aval
+  unsafe_am_i_under_a_jit_DO_NOT_USE
+  unsafe_am_i_under_a_vmap_DO_NOT_USE
+  unsafe_get_axis_names_DO_NOT_USE
+  valid_jaxtype

--- a/jax/core.py
+++ b/jax/core.py
@@ -15,55 +15,21 @@
 # Note: import <name> as <name> is required for names to be exported.
 # See PEP 484 & https://github.com/jax-ml/jax/issues/7570
 
+import jax._src.core as _src_core
+
 from jax._src.core import (
   AbstractValue as AbstractValue,
   Atom as Atom,
-  CallPrimitive as CallPrimitive,
-  DebugInfo as DebugInfo,
-  DropVar as DropVar,
-  Effect as Effect,
-  Effects as Effects,
-  InconclusiveDimensionOperation as InconclusiveDimensionOperation,
-  JaxprPpContext as JaxprPpContext,
-  JaxprPpSettings as JaxprPpSettings,
-  JaxprTypeError as JaxprTypeError,
-  OutputType as OutputType,
   ParamDict as ParamDict,
   ShapedArray as ShapedArray,
   Trace as Trace,
   Tracer as Tracer,
   Value as Value,
-  abstract_token as abstract_token,
-  aval_mapping_handlers as aval_mapping_handlers,
-  call as call,
-  check_jaxpr as check_jaxpr,
-  concrete_or_error as concrete_or_error,
-  concretization_function_error as concretization_function_error,
-  custom_typechecks as custom_typechecks,
   ensure_compile_time_eval as ensure_compile_time_eval,
   eval_context as eval_context,
   eval_jaxpr as eval_jaxpr,
-  find_top_trace as find_top_trace,
-  gensym as gensym,
-  get_opaque_trace_state as get_opaque_trace_state,
-  is_concrete as is_concrete,
-  is_constant_dim as is_constant_dim,
-  is_constant_shape as is_constant_shape,
-  jaxprs_in_params as jaxprs_in_params,
-  literalable_types as literalable_types,
   max_dim as max_dim,
   min_dim as min_dim,
-  new_jaxpr_eqn as new_jaxpr_eqn,
-  no_axis_name as no_axis_name,
-  no_effects as no_effects,
-  nonempty_axis_env as nonempty_axis_env_DO_NOT_USE,  # noqa: F401
-  primal_dtype_to_tangent_dtype as primal_dtype_to_tangent_dtype,
-  pytype_aval_mappings as pytype_aval_mappings,
-  trace_ctx as trace_ctx,
-  unsafe_am_i_under_a_jit as unsafe_am_i_under_a_jit_DO_NOT_USE,  # noqa: F401
-  unsafe_am_i_under_a_vmap as unsafe_am_i_under_a_vmap_DO_NOT_USE,  # noqa: F401
-  unsafe_get_axis_names as unsafe_get_axis_names_DO_NOT_USE,  # noqa: F401
-  valid_jaxtype as valid_jaxtype,
 )
 
 _deprecations = {
@@ -119,13 +85,194 @@ _deprecations = {
     " v0.10.0. Use jax.extend.core.AbstractToken.",
     None,
   ),
+  # Deprecated in JAX v0.10.0; TODO(jakevdp) finalize in v0.11.0
+  "CallPrimitive": (
+    "jax.core.CallPrimitive is deprecated. Use jax.extend.core.CallPrimitive.",
+    _src_core.CallPrimitive,
+  ),
+  "DebugInfo": (
+    "jax.core.DebugInfo is deprecated. Use jax.extend.core.DebugInfo.",
+    _src_core.DebugInfo,
+  ),
+  "DropVar": (
+    "jax.core.DropVar is deprecated. Use jax.extend.core.DropVar.",
+    _src_core.DropVar,
+  ),
+  "Effect": (
+    "jax.core.Effect is deprecated. Use jax.extend.core.Effect.",
+    _src_core.Effect,
+  ),
+  "Effects": (
+    "jax.core.Effects is deprecated. Use jax.extend.core.Effects.",
+    _src_core.Effects,
+  ),
+  "InconclusiveDimensionOperation": (
+    "jax.core.InconclusiveDimensionOperation is deprecated. Use jax.extend.core.InconclusiveDimensionOperation.",
+    _src_core.InconclusiveDimensionOperation,
+  ),
+  "JaxprTypeError": (
+    "jax.core.JaxprTypeError is deprecated. Use jax.extend.core.JaxprTypeError.",
+    _src_core.JaxprTypeError,
+  ),
+  "check_jaxpr": (
+    "jax.core.check_jaxpr is deprecated. Use jax.extend.core.check_jaxpr.",
+    _src_core.check_jaxpr,
+  ),
+  "concrete_or_error": (
+    "jax.core.concrete_or_error is deprecated. Use jax.extend.core.concrete_or_error.",
+    _src_core.concrete_or_error,
+  ),
+  "find_top_trace": (
+    "jax.core.find_top_trace is deprecated. Use jax.extend.core.find_top_trace.",
+    _src_core.find_top_trace,
+  ),
+  "gensym": (
+    "jax.core.gensym is deprecated. Use jax.extend.core.gensym.",
+    _src_core.gensym,
+  ),
+  "get_opaque_trace_state": (
+    "jax.core.get_opaque_trace_state is deprecated. Use jax.extend.core.get_opaque_trace_state.",
+    _src_core.get_opaque_trace_state,
+  ),
+  "jaxprs_in_params": (
+    "jax.core.jaxprs_in_params is deprecated. Use jax.extend.core.jaxprs_in_params.",
+    _src_core.jaxprs_in_params,
+  ),
+  "new_jaxpr_eqn": (
+    "jax.core.new_jaxpr_eqn is deprecated. Use jax.extend.core.new_jaxpr_eqn.",
+    _src_core.new_jaxpr_eqn,
+  ),
+  "no_effects": (
+    "jax.core.no_effects is deprecated. Use jax.extend.core.no_effects.",
+    _src_core.no_effects,
+  ),
+  "nonempty_axis_env_DO_NOT_USE": (
+    "jax.core.nonempty_axis_env_DO_NOT_USE is deprecated.",
+    _src_core.nonempty_axis_env,
+  ),
+  "primal_dtype_to_tangent_dtype": (
+    "jax.core.primal_dtype_to_tangent_dtype is deprecated. Use jax.extend.core.primal_dtype_to_tangent_dtype.",
+    _src_core.primal_dtype_to_tangent_dtype,
+  ),
+  "unsafe_am_i_under_a_jit_DO_NOT_USE": (
+    "jax.core.unsafe_am_i_under_a_jit_DO_NOT_USE is deprecated.",
+    _src_core.unsafe_am_i_under_a_jit,
+  ),
+  "unsafe_am_i_under_a_vmap_DO_NOT_USE": (
+    "jax.core.unsafe_am_i_under_a_vmap_DO_NOT_USE is deprecated.",
+    _src_core.unsafe_am_i_under_a_vmap,
+  ),
+  "unsafe_get_axis_names_DO_NOT_USE": (
+    "jax.core.unsafe_get_axis_names_DO_NOT_USE is deprecated.",
+    _src_core.unsafe_get_axis_names,
+  ),
+  "valid_jaxtype": (
+    "jax.core.valid_jaxtype is deprecated. Use jax.extend.core.valid_jaxtype.",
+    _src_core.valid_jaxtype,
+  ),
+  "JaxprPpContext": (
+    "jax.core.JaxprPpContext is deprecated.",
+    _src_core.JaxprPpContext,
+  ),
+  "JaxprPpSettings": (
+    "jax.core.JaxprPpSettings is deprecated.",
+    _src_core.JaxprPpSettings,
+  ),
+  "OutputType": (
+    "jax.core.OutputType is deprecated.",
+    _src_core.OutputType,
+  ),
+  "abstract_token": (
+    "jax.core.abstract_token is deprecated.",
+    _src_core.abstract_token,
+  ),
+  "aval_mapping_handlers": (
+    "jax.core.aval_mapping_handlers is deprecated.",
+    _src_core.aval_mapping_handlers,
+  ),
+  "call": (
+    "jax.core.call is deprecated.",
+    _src_core.call,
+  ),
+  "concretization_function_error": (
+    "jax.core.concretization_function_error is deprecated.",
+    _src_core.concretization_function_error,
+  ),
+  "custom_typechecks": (
+    "jax.core.custom_typechecks is deprecated.",
+    _src_core.custom_typechecks,
+  ),
+  "is_concrete": (
+    "jax.core.is_concrete is deprecated.",
+    _src_core.is_concrete,
+  ),
+  "is_constant_dim": (
+    "jax.core.is_constant_dim is deprecated.",
+    _src_core.is_constant_dim,
+  ),
+  "is_constant_shape": (
+    "jax.core.is_constant_shape is deprecated.",
+    _src_core.is_constant_shape,
+  ),
+  "literalable_types": (
+    "jax.core.literalable_types is deprecated.",
+    _src_core.literalable_types,
+  ),
+  "no_axis_name": (
+    "jax.core.no_axis_name is deprecated.",
+    _src_core.no_axis_name,
+  ),
+  "pytype_aval_mappings": (
+    "jax.core.pytype_aval_mappings is deprecated.",
+    _src_core.pytype_aval_mappings,
+  ),
+  "trace_ctx": (
+    "jax.core.trace_ctx is deprecated.",
+    _src_core.trace_ctx,
+  ),
 }
 
 import typing as _typing
 if _typing.TYPE_CHECKING:
-  pass
+  CallPrimitive = _src_core.CallPrimitive
+  DebugInfo = _src_core.DebugInfo
+  DropVar = _src_core.DropVar
+  Effect = _src_core.Effect
+  Effects = _src_core.Effects
+  InconclusiveDimensionOperation = _src_core.InconclusiveDimensionOperation
+  JaxprPpContext = _src_core.JaxprPpContext
+  JaxprPpSettings = _src_core.JaxprPpSettings
+  JaxprTypeError = _src_core.JaxprTypeError
+  OutputType = _src_core.OutputType
+  abstract_token = _src_core.abstract_token
+  aval_mapping_handlers = _src_core.aval_mapping_handlers
+  call = _src_core.call
+  check_jaxpr = _src_core.check_jaxpr
+  concrete_or_error = _src_core.concrete_or_error
+  concretization_function_error = _src_core.concretization_function_error
+  custom_typechecks = _src_core.custom_typechecks
+  find_top_trace = _src_core.find_top_trace
+  gensym = _src_core.gensym
+  get_opaque_trace_state = _src_core.get_opaque_trace_state
+  is_concrete = _src_core.is_concrete
+  is_constant_dim = _src_core.is_constant_dim
+  is_constant_shape = _src_core.is_constant_shape
+  jaxprs_in_params = _src_core.jaxprs_in_params
+  literalable_types = _src_core.literalable_types
+  new_jaxpr_eqn = _src_core.new_jaxpr_eqn
+  no_axis_name = _src_core.no_axis_name
+  no_effects = _src_core.no_effects
+  nonempty_axis_env_DO_NOT_USE = _src_core.nonempty_axis_env
+  primal_dtype_to_tangent_dtype = _src_core.primal_dtype_to_tangent_dtype
+  pytype_aval_mappings = _src_core.pytype_aval_mappings
+  trace_ctx = _src_core.trace_ctx
+  unsafe_am_i_under_a_jit_DO_NOT_USE = _src_core.unsafe_am_i_under_a_jit
+  unsafe_am_i_under_a_vmap_DO_NOT_USE = _src_core.unsafe_am_i_under_a_vmap
+  unsafe_get_axis_names_DO_NOT_USE = _src_core.unsafe_get_axis_names
+  valid_jaxtype = _src_core.valid_jaxtype
 else:
   from jax._src.deprecations import deprecation_getattr as _deprecation_getattr
   __getattr__ = _deprecation_getattr(__name__, _deprecations)
   del _deprecation_getattr
 del _typing
+del _src_core

--- a/jax/extend/core/__init__.py
+++ b/jax/extend/core/__init__.py
@@ -21,21 +21,42 @@ from jax._src.abstract_arrays import (
 
 from jax._src.core import (
   AbstractToken as AbstractToken,
-  call_impl as call_impl,
+  CallPrimitive as CallPrimitive,
   ClosedJaxpr as ClosedJaxpr,
+  DebugInfo as DebugInfo,
+  DropVar as DropVar,
+  Effect as Effect,
+  Effects as Effects,
+  InconclusiveDimensionOperation as InconclusiveDimensionOperation,
   Jaxpr as Jaxpr,
   JaxprEqn as JaxprEqn,
-  jaxpr_as_fun as jaxpr_as_fun,
-  mapped_aval as mapped_aval,
+  JaxprTypeError as JaxprTypeError,
   Literal as Literal,
   Primitive as Primitive,
+  Token as Token,
+  TraceTag as TraceTag,
+  Var as Var,
+  call_impl as call_impl,
+  check_jaxpr as check_jaxpr,
+  concrete_or_error as concrete_or_error,
+  find_top_trace as find_top_trace,
+  gensym as gensym,
+  get_opaque_trace_state as get_opaque_trace_state,
+  jaxpr_as_fun as jaxpr_as_fun,
+  jaxprs_in_params as jaxprs_in_params,
+  mapped_aval as mapped_aval,
+  new_jaxpr_eqn as new_jaxpr_eqn,
+  no_effects as no_effects,
+  nonempty_axis_env as nonempty_axis_env_DO_NOT_USE,  # noqa: F401
+  primal_dtype_to_tangent_dtype as primal_dtype_to_tangent_dtype,
   set_current_trace as set_current_trace,
   subjaxprs as subjaxprs,
   take_current_trace as take_current_trace,
-  Token as Token,
-  TraceTag as TraceTag,
   unmapped_aval as unmapped_aval,
-  Var as Var,
+  unsafe_am_i_under_a_jit as unsafe_am_i_under_a_jit_DO_NOT_USE,  # noqa: F401
+  unsafe_am_i_under_a_vmap as unsafe_am_i_under_a_vmap_DO_NOT_USE,  # noqa: F401
+  unsafe_get_axis_names as unsafe_get_axis_names_DO_NOT_USE,  # noqa: F401
+  valid_jaxtype as valid_jaxtype,
 )
 
 from . import primitives as primitives


### PR DESCRIPTION
I've moved several of these to `jax.extend.core` in cases where I found downstream usage with no easy replacement.