### PR TITLE
Added jax.scipy.special.loggamma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -842,6 +842,7 @@ This is a patch release of jax 0.4.36. Only "jax" was released at this version.
     ({func}`jax.numpy.linalg.eig` and {func}`jax.numpy.linalg.eigvals`) are now
     supported on GPU. See {jax-issue}`#24663` for more details.
   * Added two new configuration flags, `jax_exec_time_optimization_effort` and `jax_memory_fitting_effort`, to control the amount of effort the compiler spends minimizing execution time and memory usage, respectively.  Valid values are between -1.0 and 1.0, default is 0.0.
+  * Added {func}`jax.scipy.special.loggamma`
 
 * Bug fixes
   * Fixed a bug where the GPU implementations of LU and QR decomposition would

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -184,6 +184,7 @@ jax.scipy.special
    log_ndtr
    log_softmax
    logit
+   loggamma
    logsumexp
    lpmn
    lpmn_values

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -60,6 +60,7 @@ def gammaln(x: ArrayLike) -> Array:
   See Also:
     - :func:`jax.scipy.special.gammaln`: the natural log of the gamma function
     - :func:`jax.scipy.special.gammasgn`: the sign of the gamma function
+    - :func:`jax.scipy.special.loggamma`: the principal branch of the log-gamma function
 
   Notes:
     ``gammaln`` does not support complex-valued inputs.
@@ -186,6 +187,66 @@ def _complex_gamma(z: Array) -> Array:
   safe = is_pole | is_nan
   z_safe = jnp.where(safe, jnp.ones_like(z), z)
   return jnp.where(safe, nan_val, jnp.exp(_complex_loggamma(z_safe)))
+
+
+@jit
+def _complex_loggamma_scipy(z: Array) -> Array:
+  """Principal branch of the logarithm of the gamma function for complex arguments.
+
+  Matches SciPy's branch cuts (single cut on the negative real axis).
+  """
+  is_nan = jnp.isnan(z)
+  is_pole = (jnp.imag(z) == 0) & (jnp.real(z) == jnp.floor(jnp.real(z))) & (jnp.real(z) <= 0)
+  nan_val = jnp.array(complex(jnp.nan, jnp.nan), dtype=z.dtype)
+
+  safe = is_pole | is_nan
+  z_safe = jnp.where(safe, jnp.ones_like(z), z)
+
+  n = jnp.maximum(0, jnp.ceil(0.5 - jnp.real(z_safe)).astype(int))
+
+  def cond_fun(state):
+    k, _ = state
+    return jnp.any(k < n)
+
+  def body_fun(state):
+    k, sum_log = state
+    mask = k < n
+    zk = jnp.where(mask, z_safe + k, jnp.ones_like(z_safe))
+    return k + 1, sum_log + jnp.where(mask, jnp.log(zk), jnp.zeros_like(sum_log))
+
+  # Shift z into the right half-plane using loggamma(z) = loggamma(z+n) - sum_{k=0}^{n-1} log(z+k)
+  # to match SciPy's branch cuts along the negative real axis.
+  _, sum_log = lax.while_loop(cond_fun, body_fun, (0, jnp.zeros_like(z_safe)))
+
+  res = _complex_loggamma(z_safe + n) - sum_log
+  return jnp.where(safe, nan_val, res)
+
+
+def loggamma(x: ArrayLike) -> Array:
+  r"""Principal branch of the logarithm of the gamma function.
+
+  JAX implementation of :obj:`scipy.special.loggamma`.
+
+  Defined to be :math:`\log(\Gamma(x))` for :math:`x > 0` and
+  extended to the complex plane by analytic continuation. The
+  function has a single branch cut on the negative real axis.
+
+  Args:
+    x: arraylike, real or complex valued.
+
+  Returns:
+    array containing the values of the loggamma function. For complex inputs,
+    the output is complex-valued.
+
+  See Also:
+    - :func:`jax.scipy.special.gamma`: the gamma function.
+    - :func:`jax.scipy.special.gammaln`: the natural log of the absolute value of the gamma function.
+  """
+  x, = promote_args_inexact("loggamma", x)
+  if dtypes.issubdtype(x.dtype, np.complexfloating):
+    return _complex_loggamma_scipy(x)
+  res = lax.lgamma(x)
+  return jnp.where(x > 0, res, jnp.nan)
 
 
 def gamma(x: ArrayLike) -> Array:

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -45,6 +45,7 @@ from jax._src.scipy.special import (
   kl_div as kl_div,
   log_ndtr as log_ndtr,
   log_softmax as log_softmax,
+  loggamma as loggamma,
   logit as logit,
   logsumexp as logsumexp,
   lpmn as _deprecated_lpmn,

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -71,6 +71,13 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
         test_name="gamma_complex"
     ),
     op_record(
+        "loggamma", 1, float_dtypes, jtu.rand_positive, True
+    ),
+    op_record(
+        "loggamma", 1, jtu.dtypes.complex, jtu.rand_default, False,
+        test_name="loggamma_complex"
+    ),
+    op_record(
         "digamma", 1, float_dtypes, jtu.rand_positive, True
     ),
     op_record(


### PR DESCRIPTION
This mostly relies on the existing complex code for `jax.scipy.special.gamma`, but the SciPy version of the function has specific complex branch requirements that I couldn't figure out how to solve in closed form, so I used a recurrance relation.