### PR TITLE
[ROCm] Add Bazel option `remote_download_toplevel` for building.

### DIFF
--- a/ci/build_rocm_artifacts.sh
+++ b/ci/build_rocm_artifacts.sh
@@ -80,6 +80,7 @@ python build/build.py build --wheels="$artifact" \
   $bazel_startup_options \
   --bazel_options=--config=rocm_release_wheel \
   --bazel_options=--config=rocm_rbe \
+  --bazel_options=--remote_download_toplevel \
   --python_version=$JAXCI_HERMETIC_PYTHON_VERSION \
   --verbose --detailed_timestamped_log \
   --output_path="$JAXCI_OUTPUT_DIR" \


### PR DESCRIPTION
## Motivation
Currently, the Bazel option `remote_download_outputs` is set to `minimal`. Cache hits to the remote cache when building wheels result in Bazel checking for successful operation but not downloading the actual wheels. These missing wheels led to intermittent CI failures when building ROCm artifacts. The option `toplevel` is now added at the build invocation to override the `minimal` option and ensure wheels are downloaded in preparation for the audit wheel check. `toplevel` should now ensure that the wheels are downloaded in the ROCm build step regardless of whether there was a hit or miss to the remote cache.

## Changes
The only change is to add the Bazel option `--remote_download_toplevel` in file: `ci/build_rocm_artifacts.sh`.