### PR TITLE
Make internal code robust to empty() values

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -8998,7 +8998,7 @@ def empty(shape, dtype, *, out_sharding=None):
     Uninitialized array of the specified shape, dtype, and sharding.
 
   Examples:
-    >>> jnp.empty(3, jnp.float32)  # doctest: +SKIP
+    >>> lax.empty(3, jnp.float32)  # doctest: +SKIP
     Array([-5.7326739e+29 -7.7323739e+29 -3.14159256e-29], dtype=float32)
 
   .. _explicit sharding: https://docs.jax.dev/en/latest/parallel.html

--- a/jax/_src/numpy/array_creation.py
+++ b/jax/_src/numpy/array_creation.py
@@ -180,9 +180,9 @@ def empty(shape: Any, dtype: DTypeLike | None = None, *,
     - :func:`jax.numpy.full`
 
   Examples:
-    >>> jnp.empty(4)
+    >>> jnp.empty(4)  # doctest: +SKIP
     Array([0., 0., 0., 0.], dtype=float32)
-    >>> jnp.empty((2, 3), dtype=bool)
+    >>> jnp.empty((2, 3), dtype=bool)  # doctest: +SKIP
     Array([[False, False, False],
            [False, False, False]], dtype=bool)
 
@@ -380,11 +380,11 @@ def empty_like(prototype: ArrayLike | DuckTypedArray,
 
   Examples:
     >>> x = jnp.arange(4)
-    >>> jnp.empty_like(x)
+    >>> jnp.empty_like(x)  # doctest: +SKIP
     Array([0, 0, 0, 0], dtype=int32)
-    >>> jnp.empty_like(x, dtype=bool)
+    >>> jnp.empty_like(x, dtype=bool)  # doctest: +SKIP
     Array([False, False, False, False], dtype=bool)
-    >>> jnp.empty_like(x, shape=(2, 3))
+    >>> jnp.empty_like(x, shape=(2, 3))  # doctest: +SKIP
     Array([[0, 0, 0],
            [0, 0, 0]], dtype=int32)
   """

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -1459,7 +1459,7 @@ def _lstsq(a: ArrayLike, b: ArrayLike, rcond: Array | float | None, *,
   if a.size == 0:
     s = array_creation.empty(0, dtype=a.dtype)
     rank = jnp.array(0, dtype=int)
-    x = array_creation.empty((n, *b.shape[1:]), dtype=a.dtype)
+    x = array_creation.zeros((n, *b.shape[1:]), dtype=a.dtype)
   else:
     if rcond is None:
       rcond = float(jnp.finfo(dtype).eps) * max(n, m)

--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -870,7 +870,7 @@ def _bcoo_dot_general_transpose(ct, lhs_data, lhs_indices, rhs, *, dimension_num
     out_axes = list(map(int, np.argsort(permutation)))
 
     # Determine whether efficient approach is possible:
-    placeholder_data = jnp.empty((lhs_indices.ndim - 2) * (1,) + (lhs_indices.shape[-2],))
+    placeholder_data = jnp.zeros((lhs_indices.ndim - 2) * (1,) + (lhs_indices.shape[-2],))
     placeholder_shape = tuple(lhs_indices.shape[:-2]) + lhs_indices.shape[-1] * (1,)
     try:
       _validate_permutation(placeholder_data, lhs_indices, permutation, placeholder_shape)
@@ -1142,7 +1142,7 @@ def _bcoo_spdot_general_unbatched(lhs_data, lhs_indices, rhs_data, rhs_indices, 
   out_data = jnp.where(overlap & lhs_valid[:, None] & rhs_valid[None, :],
                        lhs_data[:, None] * rhs_data[None, :], 0).ravel()
 
-  out_indices = jnp.empty([lhs.nse, rhs.nse, lhs_j.shape[-1] + rhs_j.shape[-1]],
+  out_indices = jnp.zeros([lhs.nse, rhs.nse, lhs_j.shape[-1] + rhs_j.shape[-1]],
                           dtype=jnp.result_type(lhs_indices, rhs_indices))
   out_indices = out_indices.at[:, :, :lhs_j.shape[-1]].set(lhs_j[:, None])
   out_indices = out_indices.at[:, :, lhs_j.shape[-1]:].set(rhs_j[None, :])
@@ -1420,7 +1420,7 @@ def _bcoo_sum_duplicates_impl(data, indices, *, spinfo, nse):
   indices_out = _adjust_indices_nse(indices_out, nse=nse, shape=spinfo.shape)
   if props.n_sparse == 0:
     data = data.sum(props.n_batch, keepdims=True, dtype=data.dtype)
-  data_out = jnp.empty((*map(max, indices.shape[:props.n_batch], data.shape[:props.n_batch]),
+  data_out = jnp.zeros((*map(max, indices.shape[:props.n_batch], data.shape[:props.n_batch]),
                         nse, *data.shape[props.n_batch + 1:]), dtype=data.dtype)
   permute = lambda d_out, m, d: d_out.at[m].add(d, mode='drop')
   permute = nfold_vmap(permute, props.n_batch)
@@ -1542,7 +1542,7 @@ def _bcoo_sum_duplicates_jvp(primals, tangents, *, spinfo, nse):
   if props.n_sparse == 0:
     data = data.sum(props.n_batch, keepdims=True, dtype=data.dtype)
     data_dot = data_dot.sum(props.n_batch, keepdims=True, dtype=data_dot.dtype)
-  data_out = jnp.empty((*map(max, indices.shape[:props.n_batch], data.shape[:props.n_batch]),
+  data_out = jnp.zeros((*map(max, indices.shape[:props.n_batch], data.shape[:props.n_batch]),
                         nse, *data.shape[props.n_batch + 1:]), dtype=data.dtype)
   data_dot_out = data_out
   # This check is because scatter-add on zero-sized arrays has poorly defined
@@ -1883,7 +1883,7 @@ def bcoo_reshape(mat: BCOO, *, new_sizes: Sequence[int],
 
   # Reshape the sparse dimensions: this is accomplished by re-indexing.
   if not new_sparse_shape:
-    indices = jnp.empty_like(indices, shape=(*new_batch_shape, mat.nse, 0))
+    indices = jnp.zeros_like(indices, shape=(*new_batch_shape, mat.nse, 0))
   elif sparse_shape:
     index_cols = tuple(indices[..., i] for i in sparse_perm)
     sparse_shape = [int(mat.shape[mat.n_batch + i]) for i in sparse_perm]

--- a/jax/experimental/sparse/random.py
+++ b/jax/experimental/sparse/random.py
@@ -88,7 +88,7 @@ def random_bcoo(key: Array,
   @vmap
   def _indices(key):
     if not sparse_shape:
-      return jnp.empty((nse, n_sparse), dtype=indices_dtype)
+      return jnp.zeros((nse, n_sparse), dtype=indices_dtype)
     flat_ind = random.choice(key, sparse_size, shape=(nse,),
                              replace=not unique_indices).astype(indices_dtype)
     return jnp.column_stack(jnp.unravel_index(flat_ind, sparse_shape))

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2951,8 +2951,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     x = jax.ShapeDtypeStruct((1, 2, 3), np.dtype("int32"))
     self.assertArraysEqual(jnp.zeros_like(x), jnp.zeros(x.shape, x.dtype))
     self.assertArraysEqual(jnp.ones_like(x), jnp.ones(x.shape, x.dtype))
-    self.assertArraysEqual(jnp.empty_like(x), jnp.empty(x.shape, x.dtype))
     self.assertArraysEqual(jnp.full_like(x, 2), jnp.full(x.shape, 2, x.dtype))
+
+    self.assertEqual(jnp.empty_like(x).shape, jnp.empty(x.shape, x.dtype).shape)
+    self.assertEqual(jnp.empty_like(x).dtype, jnp.empty(x.shape, x.dtype).dtype)
 
   @jtu.sample_product(
     [dict(func=func, args=args)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1501,7 +1501,8 @@ class JnpWithKeyArrayTest(jtu.JaxTestCase):
 
     key_func = arr_func = lambda x: func(x, *args)
     self.check_shape(key_func, keys)
-    self.check_against_reference(key_func, arr_func, keys)
+    if func != jnp.empty_like:
+      self.check_against_reference(key_func, arr_func, keys)
 
   def test_full_like_with_key_fillvalue(self):
     keys = random.split(random.key(789543))
@@ -1521,7 +1522,8 @@ class JnpWithKeyArrayTest(jtu.JaxTestCase):
 
     key_func = arr_func = lambda x: func(x.shape, dtype=x.dtype, **kwds)
     self.check_shape(key_func, keys)
-    self.check_against_reference(key_func, arr_func, keys)
+    if func != jnp.empty:
+      self.check_against_reference(key_func, arr_func, keys)
 
   def test_full_with_key_fillvalue(self):
     keys = random.split(random.key(789543))

--- a/tests/sparse_bcoo_bcsr_test.py
+++ b/tests/sparse_bcoo_bcsr_test.py
@@ -187,7 +187,6 @@ class BCOOTest(sptu.SparseTestCase):
     self.assertEqual(M.n_batch, n_batch)
     self.assertEqual(M.n_dense, n_dense)
     self.assertEqual(M.dtype, dtype)
-    self.assertArraysEqual(M.todense(), jnp.empty(shape, dtype))
 
   @jtu.sample_product(
       [

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -855,7 +855,7 @@ class SparseObjectTest(sptu.SparseTestCase):
     def to_elt(x):
       assert x.ndim == 2
       assert x.n_sparse == 2
-      return jnp.empty(x.shape, x.dtype)
+      return jnp.zeros(x.shape, x.dtype)
 
     with self.subTest('to_elt'):
       M_out = vmap(to_elt)(Msp)
@@ -892,7 +892,9 @@ class SparseObjectTest(sptu.SparseTestCase):
     M = sparse.empty(shape, sparse_format=sparse_format)
     self.assertIsInstance(M, cls)
     self.assertEqual(M.nse, 0)
-    self.assertArraysEqual(M.todense(), jnp.empty(shape))
+    MD = M.todense()
+    self.assertEqual(MD.shape, tuple(shape))
+    self.assertEqual(MD.dtype, jnp.empty(()).dtype)
 
   @parameterized.named_parameters(
     {"testcase_name": f"_{cls.__name__}{(N, M, k)}",
@@ -924,7 +926,9 @@ class SparseObjectTest(sptu.SparseTestCase):
   def test_empty_nse(self, shape, nse=2):
     M = sparse.empty(shape, nse=nse)
     self.assertEqual(M.nse, nse)
-    self.assertArraysEqual(M.todense(), jnp.empty(shape))
+    MD = M.todense()
+    self.assertEqual(MD.shape, tuple(shape))
+    self.assertEqual(MD.dtype, jnp.empty(()).dtype)
 
   @parameterized.named_parameters(
     {"testcase_name": f"_{Obj.__name__}", "Obj": Obj}


### PR DESCRIPTION
Tested by temporarily making `empty()` and `empty_like()` return NaNs where possible, and nonzero values otherwise.