### PR TITLE
Removed or revised a few more `type: ignore`s

### DIFF
--- a/jax/_src/callback.py
+++ b/jax/_src/callback.py
@@ -864,7 +864,7 @@ def emit_python_callback(
   call_target_name = f"xla_ffi{partition}_python_{device}_callback"
   if token:
     callback_without_token = _wrapped_callback
-    def _wrapped_callback(token, *args):  # type: ignore
+    def _wrapped_callback(token, *args):
       return (token, *callback_without_token(*args))
     operands = [token, *operands]
     if (

--- a/jax/_src/clusters/mpi4py_cluster.py
+++ b/jax/_src/clusters/mpi4py_cluster.py
@@ -39,7 +39,7 @@ class Mpi4pyCluster(clusters.ClusterEnv):
     # Then broadcast the hostname and port.
 
 
-    from mpi4py import MPI #type: ignore
+    from mpi4py import MPI  # pyrefly: ignore[missing-import]
     # Get the global communicator:
     COMM_WORLD = MPI.COMM_WORLD
 

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -575,7 +575,7 @@ def is_literalable(x: Any, for_ad: bool = False) -> bool:
   # See https://docs.jax.dev/en/latest/internals/constants.html
   # for_ad: we want to preserve under AD
   if config.use_simplified_jaxpr_constants.value:
-    from jax._src.array import ArrayImpl  # type: ignore
+    from jax._src.array import ArrayImpl  # pyrefly: ignore[missing-import]
     do_lit_array = not for_ad
     if isinstance(x, ArrayImpl):
       return do_lit_array
@@ -659,7 +659,7 @@ class Primitive:
   def bind_with_trace(self, trace, args, avals, params, /):
     if self.is_high(*avals, **params) and trace.requires_low:
       with set_current_trace(trace):
-        return self.to_lojax(*args, **params)  # type: ignore
+        return self.to_lojax(*args, **params)  # pyrefly: ignore[not-callable]
     return trace.process_primitive(self, args, params)
 
   def def_impl(self, impl):
@@ -1740,10 +1740,10 @@ class AbstractValue:
     return add_jaxvals(x, y)
 
   def raise_val2(self, lo_vals_ft):
-    return self.raise_val(*lo_vals_ft.unflatten())  # type: ignore
+    return self.raise_val(*lo_vals_ft.unflatten())  # pyrefly: ignore[missing-attribute]
 
   def lower_val2(self, hi_val):
-    return FlatTree.flatten(self.lower_val(hi_val))  # type: ignore
+    return FlatTree.flatten(self.lower_val(hi_val))  # pyrefly: ignore[missing-attribute]
 
 InputType = tuple[AbstractValue, ...]
 OutputType = tuple[AbstractValue, ...]
@@ -1924,19 +1924,19 @@ class AvalQDD:
     return self.aval.lo_ty_qdd(self.qdd)
 
   def read_loval(self, val):
-    return self.aval.read_loval(self.qdd, val)  # type: ignore
+    return self.aval.read_loval(self.qdd, val)  # pyrefly: ignore[missing-attribute]
 
   def read_loval_in(self, val):
-    return self.aval.read_loval_in(self.qdd, val)  # type: ignore
+    return self.aval.read_loval_in(self.qdd, val)  # pyrefly: ignore[missing-attribute]
 
   def read_loval_out(self, val):
-    return self.aval.read_loval_out(self.qdd, val)  # type: ignore
+    return self.aval.read_loval_out(self.qdd, val)  # pyrefly: ignore[missing-attribute]
 
   def new_from_loval(self, *lovals):
-    return self.aval.new_from_loval(self.qdd, *lovals)  # type: ignore
+    return self.aval.new_from_loval(self.qdd, *lovals)  # pyrefly: ignore[missing-attribute]
 
   def to_tangent_aval(self):
-    return AvalQDD(self.aval.to_tangent_aval(), self.qdd and self.qdd.to_tangent_qdd())  # type: ignore
+    return AvalQDD(self.aval.to_tangent_aval(), self.qdd and self.qdd.to_tangent_qdd())  # pyrefly: ignore[missing-attribute]
 
 @dataclass(frozen=True)
 class AvalMutableQDD:
@@ -3149,7 +3149,7 @@ def evaluate_shape(shape: Shape, dim_vars: Sequence[str],
       return operator.index(d)
     except:
       # Is a _DimExpr
-      return d._evaluate(env)  # type: ignore
+      return d._evaluate(env)  # pyrefly: ignore[missing-attribute]
   return tuple(eval_one_dim(d) for d in shape)
 
 def dim_value_dtype():
@@ -3215,7 +3215,7 @@ closed_call_p.def_effectful_abstract_eval(
 def mapped_aval(size: AxisSize, axis, aval: AbstractValue) -> AbstractValue:
   from jax._src.hijax import HiType  # pytype: disable=import-error
   if isinstance(aval, HiType):
-    return aval.dec_rank(size, axis)  # type: ignore
+    return aval.dec_rank(size, axis)  # pyrefly: ignore[bad-argument-type]
   handler, _ = aval_mapping_handlers.get(type(aval), (None, None))
   if handler is not None:
     return handler(size, axis, aval)
@@ -3230,7 +3230,7 @@ def unmapped_aval(size: AxisSize, axis: int | None,
                   aval: AbstractValue, explicit_mesh_axis=None) -> AbstractValue:
   from jax._src.hijax import HiType  # pytype: disable=import-error
   if isinstance(aval, HiType):
-    return aval.inc_rank(size, axis)  # type: ignore
+    return aval.inc_rank(size, axis)  # pyrefly: ignore[bad-argument-type]
   _, handler = aval_mapping_handlers.get(type(aval), (None, None))
   if handler is not None:
     return handler(size, axis, explicit_mesh_axis, aval)
@@ -3523,7 +3523,9 @@ def _check_jaxpr(
 
   # Check each eqn.
   sentinel = object()
-  in_idx = {v: i for i, v in enumerate(it.chain(jaxpr.constvars, jaxpr.invars))}
+  in_idx: dict[Var, int | None] = {
+      v: i for i, v in enumerate(it.chain(jaxpr.constvars, jaxpr.invars))
+  }
   mut_arrays = set()
   for eqn_idx, eqn in enumerate(jaxpr.eqns):
     prim = eqn.primitive
@@ -3548,7 +3550,7 @@ def _check_jaxpr(
       if prim.ref_primitive:
         if prim in _ref_allocating_primitives:
           outvar, = eqn.outvars
-          in_idx[outvar] = None  # type: ignore
+          in_idx[outvar] = None
           mut_arrays.add(outvar)
       if eqn.effects != eqn_effects:
         raise JaxprTypeError("Inferred effects do not match equation effects. "

--- a/jax/_src/export/_export.py
+++ b/jax/_src/export/_export.py
@@ -827,7 +827,7 @@ def _export_lowered(
       if isinstance(sharding, sharding_impls.NamedSharding):
         cur_mesh = sharding.mesh
         break
-    if cur_mesh and isinstance(cur_mesh, mesh_lib.Mesh):
+    if cur_mesh is not None and isinstance(cur_mesh, mesh_lib.Mesh):
       cur_mesh = cur_mesh.abstract_mesh
 
   in_named_shardings = tuple(
@@ -861,7 +861,7 @@ def _export_lowered(
         device_assignment=device_assignment,
         apply_jit=True,
         flat_primal_fun=True,
-        mesh=cur_mesh)  # type: ignore[arg-type]
+        mesh=cur_mesh)
     return export(fun_vjp_jax,
                   platforms=exp_primal.platforms,
                   disabled_checks=exp_primal.disabled_safety_checks)(*vjp_in_avals)
@@ -1381,7 +1381,7 @@ def _get_vjp_fun(
     if has_named_shardings or mesh:
       vjp_in_shardings = tuple(
           _get_named_sharding(has_named_shardings, named_sharding,
-                              hlo_sharding, aval, mesh)  # type: ignore[arg-type]
+                              hlo_sharding, aval, mesh)  # pyrefly: ignore[bad-argument-type]
           for named_sharding, hlo_sharding, aval in zip(
             itertools.chain(in_named_shardings, out_named_shardings),
             itertools.chain(in_shardings_hlo, out_shardings_hlo),
@@ -1787,5 +1787,5 @@ def wrap_with_sharding(
     x_sharding = x_sharding._to_sdy_sharding(x_aval.ndim)  # pyrefly: ignore[missing-attribute]
   else:
     x_sharding = x_sharding.to_proto()  # pyrefly: ignore[missing-attribute]
-  return mlir.wrap_with_sharding_op(ctx, x, x_aval, x_sharding,  # type: ignore[arg-type]
+  return mlir.wrap_with_sharding_op(ctx, x, x_aval, x_sharding,
                                     allow_shardy_lowering=use_shardy)

--- a/jax/_src/export/shape_poly.py
+++ b/jax/_src/export/shape_poly.py
@@ -2105,7 +2105,7 @@ def _solve_dim_equations(
       if not isinstance(var_value, _DimExpr):
         assert var_value.dtype == core.dim_value_dtype()  # type: ignore[attribute-error]
       shape_env[var] = var_value  # pyrefly: ignore[unsupported-operation]
-      solution_error_message_pieces.extend([  # type: ignore[container-type-mismatch]
+      solution_error_message_pieces.extend([
         f"'{var}' = ", var_value,
         f" from specification '{eqn.aval_dim_expr}' "
         f"for dimension {eqn.dim_name} (= ",

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -699,7 +699,7 @@ def tracers_to_jaxpr(
   outvars = map(get_atom, out_tracers)
   jaxpr_effects = make_jaxpr_effects(const_vars, invars, outvars, eqns)
   is_high |= any(x.aval.is_high for x in it.chain(const_vars, invars, outvars))
-  jaxpr = Jaxpr(const_vars, invars,  # type: ignore[arg-type]
+  jaxpr = Jaxpr(const_vars, invars,  # pyrefly: ignore[bad-argument-type]
                 outvars, eqns, jaxpr_effects, debug_info, is_high)
   config.enable_checks.value and core.check_jaxpr(jaxpr)
   # del getvar  # needed to avoid cyclic-reference closure, apparently!

--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -1129,7 +1129,7 @@ def lower_sharding_computation(
        len(const_args), tuple(global_in_avals),
        semantic_in_shardings, semantic_out_shardings,
        in_layouts, out_layouts, num_devices,
-       tuple(device_list) if prim_requires_devices else None,  # type: ignore[arg-type]
+       tuple(device_list) if prim_requires_devices else None,  # pyrefly: ignore[bad-argument-type]
        donated_invars, all_default_mem_kind, inout_aliases,
        propagated_out_mem_kinds, platforms,
        lowering_parameters=lowering_parameters,
@@ -1630,7 +1630,7 @@ def _maybe_get_and_check_out_shardings(
           dtypes.issubdtype(aval.dtype, dtypes.extended)):
         xla_s = sharding_impls.logical_sharding(aval.shape, aval.dtype, xla_s)
       try:
-        new_out_shardings.append(_gspmd_to_named_sharding(xla_s, aval, orig))  # type: ignore[arg-type]
+        new_out_shardings.append(_gspmd_to_named_sharding(xla_s, aval, orig))  # pyrefly: ignore[bad-argument-type]
       except:
         new_out_shardings.append(xla_s)
     else:

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -473,7 +473,7 @@ def scan(f: Callable[[Carry, X], tuple[Carry, Y]],
 
 def _infer_scan_length(
     xs_flat: list[Any], xs_avals: list[AbstractValue],
-    length: int | None) -> int:
+    length: Any | None) -> int:
 
   # TODO(dougalm): put this in some sort of `scannable` typeclass
   from jax._src.hijax import HiType
@@ -503,7 +503,7 @@ def _infer_scan_length(
       msg = ('The `length` argument to `scan` expects a concrete `int` value.'
              ' For scan-like iteration with a dynamic length, use `while_loop`'
              ' or `fori_loop`.')
-      raise core.ConcretizationTypeError(length, msg) from None  # type: ignore[arg-type]
+      raise core.ConcretizationTypeError(length, msg) from None
     else:
       if not all(length == l for l in lengths):
         msg = ("scan got `length` argument of {} which disagrees with "

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -23,7 +23,7 @@ from functools import partial
 import itertools
 import math
 import operator
-from typing import Any, NamedTuple, TypeVar, Union, cast as type_cast, overload
+from typing import Any, NamedTuple, Never, TypeVar, Union, cast as type_cast, overload
 import warnings
 
 import numpy as np
@@ -3374,8 +3374,8 @@ def full(shape: Shape, fill_value: ArrayLike, dtype: DTypeLike | None = None, *,
     weak_type = dtypes.is_weakly_typed(fill_value)
     fill_dtype = _dtype(fill_value)
   else:
-    if dtypes.issubdtype(dtype, dtypes.extended):
-      return dtype._rules.full(shape, fill_value, dtype)  # type: ignore[union-attr]
+    if isinstance(dtype, dtypes.ExtendedDType):
+      return dtype._rules.full(shape, fill_value, dtype)
     weak_type = False
     fill_dtype = dtypes.check_and_canonicalize_user_dtype(dtype, "full")
   fill_value = _convert_element_type(fill_value, fill_dtype, weak_type)
@@ -3579,11 +3579,11 @@ def full_like(x: ArrayLike | DuckTypedArray,
     An ndarray with the same shape as `x` with its entries set equal to
     `fill_value`, similar to the output of np.full.
   """
-  fill_shape = np.shape(x) if shape is None else canonicalize_shape(shape)  # type: ignore[arg-type]
+  fill_shape = np.shape(x) if shape is None else canonicalize_shape(shape)  # pyrefly: ignore[no-matching-overload]
   weak_type = dtype is None and dtypes.is_weakly_typed(x)
   dtype = _dtype(dtype) if dtype is not None else _dtype(x)
-  if dtypes.issubdtype(dtype, dtypes.extended):
-    return dtype._rules.full(fill_shape, fill_value, dtype)  # type: ignore[union-attr]
+  if isinstance(dtype, dtypes.ExtendedDType):
+    return dtype._rules.full(fill_shape, fill_value, dtype)
 
   if sharding is None and shape is None and isinstance(x, core.Tracer):
     sharding = x.aval.sharding  # pyrefly: ignore[missing-attribute]
@@ -3601,7 +3601,7 @@ def full_like(x: ArrayLike | DuckTypedArray,
         and (x.sharding._is_concrete or not get_concrete_mesh().empty)
         and getattr(x, '_committed', True)
         and not weak_type
-        and (fill_shape == np.shape(x) or x.sharding.is_fully_replicated)  # type: ignore[arg-type]
+        and (fill_shape == np.shape(x) or x.sharding.is_fully_replicated)  # pyrefly: ignore[no-matching-overload]
     )
     if use_x_sharding:
       sharding = x.sharding  # pyrefly: ignore[missing-attribute]
@@ -7160,7 +7160,7 @@ def _merge_on_one_axis(operand, new_sizes):
   return _split_on_one_axis(new_sizes, operand.shape)
 
 
-def raise_reshape_error(operand, new_sizes):
+def raise_reshape_error(operand, new_sizes) -> Never:
   raise core.ShardingTypeError(
       'This reshape is not supported. Please specify the sharding of the'
       ' output via the `out_sharding` argument of jax.lax.reshape. Got'
@@ -7181,16 +7181,16 @@ def _reshape_sharding_rule(operand, *, new_sizes, dimensions, sharding):
     is_split, out_split = _split_on_one_axis(operand.shape, new_sizes)
   except ReshapeExplicitError:
     raise_reshape_error(operand, new_sizes)
-  if is_split:  # type: ignore
-    return _split_an_axis_sharding_rule(operand, out_split, new_sizes,  # type: ignore
+  if is_split:
+    return _split_an_axis_sharding_rule(operand, out_split, new_sizes,
                                         dimensions)
 
   try:
     is_merge, operand_merge = _merge_on_one_axis(operand, new_sizes)
   except ReshapeExplicitError:
     raise_reshape_error(operand, new_sizes)
-  if is_merge:  # type: ignore
-    return _merge_an_axis_sharding_rule(operand, operand_merge, new_sizes,  # type: ignore
+  if is_merge:
+    return _merge_an_axis_sharding_rule(operand, operand_merge, new_sizes,
                                         dimensions)
   raise_reshape_error(operand, new_sizes)
 

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -3408,10 +3408,10 @@ def _dynamic_slice_indices(
     msg = ("Length of slice indices must match number of operand dimensions ({} "
           "vs {})")
     raise ValueError(msg.format(len(start_indices), operand.shape))
-  if not isinstance(start_indices, (tuple, list)):
-    if start_indices.ndim != 1:  # type: ignore[union-attr]
+  if not isinstance(start_indices, Sequence):
+    if start_indices.ndim != 1:
       raise ValueError("Slice indices must be a 1D sequence, got {}"
-                       .format(start_indices.shape))  # type: ignore[union-attr]
+                       .format(start_indices.shape))
     start_indices = list(start_indices)
   result: list[ArrayLike] = []
   if isinstance(allow_negative_indices, bool):

--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -20,7 +20,7 @@ from collections.abc import Sequence
 from functools import partial
 import operator
 import numpy as np
-from typing import Any, Literal, overload
+from typing import Any, Literal, overload, SupportsIndex
 import warnings
 
 from jax._src import api
@@ -705,7 +705,7 @@ def _one_hot(x: Array, num_classes: int, *,
       num_classes,
       "The error arose in jax.nn.one_hot argument `num_classes`.")
   try:
-    output_pos_axis = util.canonicalize_axis(axis, x.ndim + 1)  # type: ignore[arg-type]
+    output_pos_axis = util.canonicalize_axis(axis, x.ndim + 1)  # pyrefly: ignore[bad-argument-type]
   except TypeError:
     axis_size = lax.axis_size(axis)
     if num_classes != axis_size:
@@ -713,7 +713,8 @@ def _one_hot(x: Array, num_classes: int, *,
                        f"but {num_classes} != {axis_size}") from None
     axis_idx = lax.axis_index(axis)
     return jnp.asarray(x == axis_idx, dtype=dtype)
-  axis = operator.index(axis)  # type: ignore[arg-type]
+  assert isinstance(axis, SupportsIndex)
+  axis = operator.index(axis)
   lhs = lax.expand_dims(x, (axis,))
   rhs_shape = [1] * x.ndim
   rhs_shape.insert(output_pos_axis, num_classes)

--- a/jax/_src/numpy/array_creation.py
+++ b/jax/_src/numpy/array_creation.py
@@ -455,7 +455,7 @@ def full_like(a: ArrayLike | DuckTypedArray,
     return lax.full_like(a, fill_value, dtype, shape,
                          sharding=util.canonicalize_device_to_sharding(device))
   else:
-    shape = np.shape(a) if shape is None else shape  # type: ignore[arg-type]
+    shape = np.shape(a) if shape is None else shape  # pyrefly: ignore[no-matching-overload]
     dtype = dtypes.result_type(a) if dtype is None else dtype
     return api.device_put(
         util._broadcast_to(asarray(fill_value, dtype=dtype), shape), device)

--- a/jax/_src/numpy/array_methods.py
+++ b/jax/_src/numpy/array_methods.py
@@ -514,10 +514,12 @@ def _compute_newshape(arr: Array, newshape: DimSize | Shape) -> Shape:
   """Fixes a -1 value in newshape, if present."""
   orig_newshape = newshape  # for error messages
   try:
-    iter(newshape)  # type: ignore[arg-type]
-  except:
+    iter(newshape)  # pyrefly: ignore[no-matching-overload]
+  except TypeError:
     newshape = [newshape]
-  newshape = core.canonicalize_shape(newshape)  # type: ignore[arg-type]
+  else:
+    newshape: Sequence[DimSize]  # pyrefly: ignore[redefinition]
+  newshape = core.canonicalize_shape(newshape)
   neg1s = [i for i, d in enumerate(newshape) if type(d) is int and d == -1]
   if len(neg1s) > 1:
     raise TypeError("can only specify one unknown axis size with a `-1` value, "

--- a/jax/_src/numpy/indexing.py
+++ b/jax/_src/numpy/indexing.py
@@ -150,7 +150,7 @@ def _parse_indices(
       dimensions_consumed.append(0)
       ellipses_indices.append(i)
     elif typ == IndexType.BOOLEAN:
-      dimensions_consumed.append(np.ndim(idx))  # type: ignore[arg-type]
+      dimensions_consumed.append(np.ndim(idx))  # pyrefly: ignore[bad-argument-type]
     elif typ in [IndexType.INTEGER, IndexType.ARRAY, IndexType.SLICE, IndexType.DYNAMIC_SLICE]:
       dimensions_consumed.append(1)
     else:
@@ -287,11 +287,11 @@ class NDIndexer:
     new_indices = list(self.indices)
     current_dim = 0
     for i, idx in enumerate(self.indices):
-      if idx.typ == IndexType.BOOLEAN and np.ndim(idx.index) == 0:  # type: ignore[arg-type]
+      if idx.typ == IndexType.BOOLEAN and np.ndim(idx.index) == 0:  # pyrefly: ignore[bad-argument-type]
         new_shape.insert(i, 1)
         new_sharding_spec.insert(i, None)
         new_indices[i] = ParsedIndex(
-          np.arange(int(idx.index)), typ=IndexType.ARRAY, consumed_axes=(current_dim,))  # type: ignore[arg-type]
+          np.arange(int(idx.index)), typ=IndexType.ARRAY, consumed_axes=(current_dim,))  # pyrefly: ignore[bad-argument-type]
         current_dim += 1
       else:
         n_consumed = len(idx.consumed_axes)
@@ -491,7 +491,7 @@ class NDIndexer:
           raise TypeError("dynamic_slice: only unit steps supported in slice."
                           f" Got {pidx.index} at position {position}")
       elif pidx.typ == IndexType.ARRAY:
-        if isinstance(pidx.index, Sequence) or np.shape(pidx.index) != ():  # type: ignore[arg-type]
+        if isinstance(pidx.index, Sequence) or np.shape(pidx.index) != ():  # pyrefly: ignore[no-matching-overload]
           raise TypeError("dynamic_slice: only scalar indices allowed."
                           f" Got index of type {type(pidx.index)} at position {position}")
       elif pidx.typ == IndexType.BOOLEAN:
@@ -571,7 +571,7 @@ class NDIndexer:
   def is_advanced_int_indexer(self):
     """Returns True if idx should trigger int array indexing, False otherwise."""
     # https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html#advanced-indexing
-    return any(idx.typ in [IndexType.ARRAY, IndexType.BOOLEAN] and np.ndim(idx.index) > 0  # type: ignore[arg-type]
+    return any(idx.typ in [IndexType.ARRAY, IndexType.BOOLEAN] and np.ndim(idx.index) > 0  # pyrefly: ignore[bad-argument-type]
                for idx in self.indices)
 
   def to_gather(self, x_sharding: NamedSharding | Any,
@@ -1383,12 +1383,12 @@ def _index_to_gather(indexer: NDIndexer, *, x_sharding: NamedSharding | Any,
       gather_slice_shape.append(1)
       continue
 
-    if index.typ in [IndexType.INTEGER, IndexType.ARRAY] and np.ndim(index.index) == 0:  # type: ignore[arg-type]
+    if index.typ in [IndexType.INTEGER, IndexType.ARRAY] and np.ndim(index.index) == 0:  # pyrefly: ignore[bad-argument-type]
       # Basic scalar int indices
       if core.definitely_equal(indexer.shape[x_axis], 0):
         # XLA gives error when indexing into an axis of size 0
         raise IndexError(f"index is out of bounds for axis {x_axis} with size 0")
-      i_converted = lax.convert_element_type(index.index, index_dtype)  # type: ignore[arg-type]
+      i_converted = lax.convert_element_type(index.index, index_dtype)  # pyrefly: ignore[bad-argument-type]
       gather_indices.append((i_converted, len(gather_indices_shape)))
       collapsed_slice_dims.append(x_axis)
       gather_slice_shape.append(1)

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -963,7 +963,7 @@ def histogram2d(x: ArrayLike, y: ArrayLike, bins: ArrayLike | list[ArrayLike] = 
   """
   x, y = util.ensure_arraylike("histogram2d", x, y)
   try:
-    N = len(bins)  # type: ignore[arg-type]
+    N = len(bins)  # pyrefly: ignore[bad-argument-type]
   except TypeError:
     N = 1
 
@@ -1043,19 +1043,18 @@ def histogramdd(sample: ArrayLike, bins: ArrayLike | list[ArrayLike] = 10,
   N, D = np.shape(sample)
 
   if range is not None and (
-      len(range) != D or any(r is not None and np.shape(r)[0] != 2 for r in range)):  # type: ignore[arg-type]
+      len(range) != D or any(r is not None and np.shape(r)[0] != 2 for r in range)):  # pyrefly: ignore[no-matching-overload]
     raise ValueError(f"For sample.shape={(N, D)}, range must be a sequence "
                      f"of {D} pairs or Nones; got {range=}")
 
   try:
-    num_bins = len(bins)  # type: ignore[arg-type]
+    bins_per_dimension = list(bins)  # pyrefly: ignore[bad-argument-type]
   except TypeError:
     # when bin_size is integer, the same bin is used for each dimension
     bins_per_dimension: list[ArrayLike] = D * [bins]  # type: ignore[assignment]
   else:
-    if num_bins != D:
+    if len(bins_per_dimension) != D:
       raise ValueError("should be a bin for each dimension.")
-    bins_per_dimension = list(bins)  # type: ignore[arg-type]
 
   bin_idx_by_dim: list[Array] = []
   bin_edges_by_dim: list[Array] = []
@@ -4469,11 +4468,9 @@ def tile(A: ArrayLike, reps: DimSize | Sequence[DimSize]) -> Array:
   """
   A = util.ensure_arraylike("tile", A)
   try:
-    iter(reps)  # type: ignore[arg-type]
+    reps_tup = tuple(iter(reps))  # pyrefly: ignore[no-matching-overload]
   except TypeError:
     reps_tup: tuple[DimSize, ...] = (reps,)
-  else:
-    reps_tup = tuple(reps)  # type: ignore[arg-type]
   reps_tup = tuple(operator.index(rep) if core.is_constant_dim(rep) else rep
                    for rep in reps_tup)
   # lax.tile expects reps and A.shape to have the same rank.
@@ -7635,7 +7632,7 @@ def delete(
 
   # Case 1: obj is a static integer.
   try:
-    obj = operator.index(obj)  # type: ignore[arg-type]
+    obj = operator.index(obj)  # pyrefly: ignore[bad-argument-type]
     obj = _canonicalize_axis(obj, a.shape[axis])
   except TypeError:
     pass

--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -165,10 +165,12 @@ def _canonicalize_axis_allow_named(x, rank):
 def _reduction_dims(a: ArrayLike, axis: Axis):
   if axis is None:
     return (tuple(range(np.ndim(a))),) * 2
-  elif not isinstance(axis, (np.ndarray, tuple, list)):
-    axis = (axis,)  # type: ignore[assignment]
+  if not isinstance(axis, (np.ndarray, tuple, list)):
+    axes = (axis,)
+  else:
+    axes = axis
   canon_axis = tuple(_canonicalize_axis_allow_named(x, np.ndim(a))
-                     for x in axis)  # type: ignore[union-attr]
+                     for x in axes)
   if len(canon_axis) != len(set(canon_axis)):
     raise ValueError(f"duplicate value in 'axis': {axis}")
   canon_pos_axis = tuple(x for x in canon_axis if isinstance(x, int))

--- a/jax/_src/numpy/ufunc_api.py
+++ b/jax/_src/numpy/ufunc_api.py
@@ -468,7 +468,7 @@ class ufunc:
       idx = tuple(ind if isinstance(ind, slice) else ind[i] for ind in indices)
       a = a.at[idx].set(self(a.at[idx].get(), *(arg[i] for arg in args)))
       return (i + 1, a), x
-    carry, _ = control_flow.scan(scan_fun, (0, a), None, len(indices[0]))  # type: ignore[arg-type]
+    carry, _ = control_flow.scan(scan_fun, (0, a), None, len(indices[0]))  # pyrefly: ignore[bad-argument-type]
     return carry[1]
 
   @api.jit(static_argnames=['self', 'axis', 'dtype'])

--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -2675,7 +2675,7 @@ def power(x1: ArrayLike, x2: ArrayLike, /) -> Array:
   # Case 1: concrete integer scalar powers:
   if core.is_concrete(x2):
     try:
-      x2 = operator.index(x2)  # type: ignore[arg-type]
+      x2 = operator.index(x2)  # pyrefly: ignore[bad-argument-type]
     except TypeError:
       pass
     else:

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -259,7 +259,7 @@ def _broadcast_to(arr: ArrayLike, shape: DimSize | Shape, sharding=None
   if not isinstance(shape, tuple) and np.ndim(shape) == 0:
     shape = (shape,)
   # check that shape is concrete
-  shape = core.canonicalize_shape(shape)  # type: ignore[arg-type]
+  shape = core.canonicalize_shape(shape)  # pyrefly: ignore[bad-argument-type]
   arr_shape = np.shape(arr)
   if (core.definitely_equal_shape(arr_shape, shape) and
       (sharding is None or core.typeof(arr).sharding == sharding)):
@@ -363,7 +363,7 @@ def ndim(a: ArrayLike | SupportsNdim) -> int:
   if hasattr(a, "__jax_array__"):
     a = a.__jax_array__()
   # NumPy dispatches to a.ndim if available.
-  return np.ndim(a)  # type: ignore[arg-type]
+  return np.ndim(a)  # pyrefly: ignore[bad-argument-type]
 
 
 @export
@@ -456,6 +456,6 @@ def size(a: ArrayLike | SupportsSize | SupportsShape, axis: int | Sequence[int] 
   check_arraylike("size", a, emit_warning=True)
   if axis is None and hasattr(a, "size"):
     return a.size
-  _shape = shape(a)  # type: ignore[arg-type]
+  _shape = shape(a)  # pyrefly: ignore[bad-argument-type]
   axis = canonicalize_axis_tuple(axis, len(_shape), allow_duplicate=False)
   return math.prod(_shape[i] for i in axis)

--- a/jax/_src/pallas/core.py
+++ b/jax/_src/pallas/core.py
@@ -1160,8 +1160,8 @@ def get_grid_mapping(
   else:
     dim_check: Any = jax_core.is_constant_dim
   assert all(i is None or dim_check(i) for i in grid_spec.grid)
-  grid_mapping_grid = tuple(
-      dynamic_grid_dim if (
+  grid_mapping_grid: GridMappingGrid = tuple(
+      dynamic_grid_dim if (  # pyrefly: ignore[bad-argument-type]
           d is None or (not jax_core.is_constant_dim(d) and not dynamic_shapes_export_enabled())
       ) else d
       for d in grid_spec.grid
@@ -1252,7 +1252,7 @@ def get_grid_mapping(
       out_avals,
   )
   grid_mapping = GridMapping(
-      grid=grid_mapping_grid,  # type: ignore[arg-type]
+      grid=grid_mapping_grid,
       grid_names=grid_spec.grid_names,
       block_mappings=(*in_block_mappings, *out_block_mappings),
       index_map_avals=index_map_avals,
@@ -1708,7 +1708,7 @@ def lower_as_mlir(
     exported = export(f, platforms=platforms)(*args, **kwargs)
     stablehlo = exported.mlir_module()
 
-  return stablehlo  # type: ignore[return-value]
+  return stablehlo
 
 
 _out_shape_to_aval_mapping: dict[

--- a/jax/_src/pallas/hlo_interpreter.py
+++ b/jax/_src/pallas/hlo_interpreter.py
@@ -363,7 +363,7 @@ def pallas_call_hlo_interpret(
   )
   dynamic_grid_args_iter = iter(dynamic_grid_args)
   grid = tuple(
-      a if a is not pallas_core.dynamic_grid_dim
+      a if not isinstance(a, pallas_core.DynamicGridDim)
       else next(dynamic_grid_args_iter)
       for a in grid_mapping.grid
   )
@@ -412,7 +412,7 @@ def pallas_call_hlo_interpret(
   num_inout_blocks = len(block_args) + len(out)
   grid_start_indices = (jnp.int32(0),) * len(grid)
   if grid:
-    num_iterations = reduce(jnp.multiply, grid)  # type: ignore[arg-type]
+    num_iterations = reduce(jnp.multiply, grid)
   else:
     # Base case is always one iteration when grid is ()
     num_iterations = 1

--- a/jax/_src/pallas/mosaic/interpret/interpret_pallas_call.py
+++ b/jax/_src/pallas/mosaic/interpret/interpret_pallas_call.py
@@ -1824,7 +1824,7 @@ def interpret_pallas_call(
   )
   dynamic_grid_args_iter = iter(dynamic_grid_args)
   grid = tuple(
-      a if a is not pallas_core.dynamic_grid_dim
+      a if not isinstance(a, pallas_core.DynamicGridDim)
       else next(dynamic_grid_args_iter)
       for a in grid_mapping.grid
   )
@@ -1996,7 +1996,7 @@ def interpret_pallas_call(
       jaxpr.invars[grid_mapping.slice_block_ops], [num_inputs])
 
   if grid:
-    num_iterations = functools.reduce(jnp.multiply, grid)  # type: ignore[arg-type]
+    num_iterations = functools.reduce(jnp.multiply, grid)
   else:
     # Base case is always one iteration when grid is ()
     num_iterations = 1
@@ -2007,14 +2007,14 @@ def interpret_pallas_call(
     randomized_grid_coordinates = (jnp.array((), dtype=jnp.int32),) * len(grid)
   else:
     randomized_grid_coordinates = _get_randomized_grid_coordinates(
-        grid, mosaic_params, interpret_params.random_seed  # type: ignore[arg-type]
+        grid, mosaic_params, interpret_params.random_seed
     )
 
   parallel_dim_semantics = _get_parallel_dim_semantics(
       mosaic_params, len(grid)
   )
   parallel_subgrid_size = _get_parallel_subgrid_size(
-      parallel_dim_semantics, grid  # type: ignore[arg-type]
+      parallel_dim_semantics, grid
   )
   num_points_in_parallel_subgrid_per_core = (
       parallel_subgrid_size + interpret_params.num_cores_per_device - 1

--- a/jax/_src/pallas/mosaic/pipeline.py
+++ b/jax/_src/pallas/mosaic/pipeline.py
@@ -1522,7 +1522,7 @@ def _partition_grid(
       partition_dimension,
       grid_offset,
   )
-  return new_grid, offsets  # type: ignore[return-value]
+  return new_grid, offsets
 
 
 def sync_copy(src: REF | BufferedRef, dst: REF | BufferedRef, indices):

--- a/jax/_src/pallas/mosaic_gpu/lowering.py
+++ b/jax/_src/pallas/mosaic_gpu/lowering.py
@@ -3025,7 +3025,7 @@ def _block_id(ctx: LoweringRuleContext, dim: gpu_dialect.Dimension) -> ir.Value:
   return arith_dialect.divui(result, _as_index(cluster_size[dim.value]))
 
 
-def _resolve_cluster_axis(axis_names: _AxisNames | None, axis_name: str):
+def _resolve_cluster_axis(axis_names: _AxisNames | None, axis_name: Hashable):
   if not axis_names:
     raise LookupError(
         "No axis names are available. Make sure you are using `pl.core_map`"

--- a/jax/_src/pallas/mosaic_gpu/primitives.py
+++ b/jax/_src/pallas/mosaic_gpu/primitives.py
@@ -839,7 +839,9 @@ def _async_prefetch_lowering(
     )
 
   if ctx.module_ctx.lowering_semantics == mgpu.LoweringSemantics.Lane:
-    predicate_kwarg = dict(predicate=ctx.module_ctx.single_lane_predicate)
+    predicate_kwarg: dict[str, Any] = dict(
+        predicate=ctx.module_ctx.single_lane_predicate
+    )
     if gmem_slice := copy_params.get("gmem_slice", ()):
       first_idx = gmem_slice[0]
       # Gathers are a warpgroup-level collective and can't take a predicate.
@@ -851,7 +853,7 @@ def _async_prefetch_lowering(
         collective=collective,
         leader_tracked=leader_tracked,
         **copy_params,
-        **predicate_kwarg,  # type: ignore[arg-type]
+        **predicate_kwarg,
     )
     return ()
 
@@ -4073,7 +4075,7 @@ def query_cluster_cancel_lowering(ctx: lowering.LoweringRuleContext,
   i32 = ir.IntegerType.get_signless(32)
   # Divide out the cluster dimensions.
   for axis in ctx.module_ctx.axis_names.cluster:
-    dim = lowering._resolve_cluster_axis(ctx.module_ctx.axis_names, axis)  # type: ignore[arg-type]
+    dim = lowering._resolve_cluster_axis(ctx.module_ctx.axis_names, axis)
     cta_grid[dim] = arith_dialect.divui(
         cta_grid[dim],
         mgpu.c(ctx.launch_ctx.cluster_size[dim], i32))

--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -21,7 +21,7 @@ import enum
 from functools import partial, reduce
 import math
 import types
-from typing import Any
+from typing import Any, cast
 
 from jax._src import ad_util
 from jax._src import api
@@ -833,7 +833,7 @@ def pallas_call_checkify_oob_grid(error: checkify.Error,
   )
   grid_start_indices = (jnp.int32(0),) * len(grid)
   if grid:
-    num_iterations = reduce(jnp.multiply, grid)  # type: ignore[arg-type]
+    num_iterations = reduce(jnp.multiply, grid)  # pyrefly: ignore[bad-argument-type]
   else:
     # Base case is always one iteration when grid is ()
     num_iterations = 1
@@ -1261,7 +1261,7 @@ def _pallas_call_state_discharge_rule(
   ref_block_mappings = [
       block_spec.to_block_mapping(
           origin="",  # TODO(sharadmv): enable origins for refs
-          array_aval=ref_aval.inner_aval,  # type: ignore[arg-type]
+          array_aval=cast(jax_core.ShapedArray, ref_aval.inner_aval),
           index_map_avals=grid_mapping.index_map_avals,
           index_map_tree=grid_mapping.index_map_tree,
           grid=grid_mapping.grid,

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -409,7 +409,7 @@ def _shmap_checks(mesh, axis_names, in_specs, out_specs, _smap):
 
 
 def _manual_spec(manual_axes, spec: P, mesh) -> P:
-  out: list[str | tuple[str, ...] | None] = []
+  out: list[str | tuple[str | None, ...] | None] = []
   s: str | None | tuple[str, ...]
   for s in spec:
     if s is None:
@@ -420,7 +420,7 @@ def _manual_spec(manual_axes, spec: P, mesh) -> P:
         temp.pop()
       if None in temp:
         raise ValueError(f"Invalid spec: {spec}")
-      out.append(None if len(temp) == 0 else tuple(temp))  # type: ignore[arg-type]
+      out.append(None if len(temp) == 0 else tuple(temp))
     else:
       out.append(s if s in manual_axes else None)
   _check_unreduced(SpecErrorType.input, mesh, manual_axes, spec)

--- a/jax/experimental/source_mapper/common.py
+++ b/jax/experimental/source_mapper/common.py
@@ -33,13 +33,13 @@ class SourceMapDump:
 
 class CompileFn(Protocol):
 
-  def __call__(self, work_dir, fn, f_args, f_kwargs, **kwargs) -> Any:
+  def __call__(self, work_dir, fn, f_args, f_kwargs, /, **kwargs) -> Any:
     ...
 
 
 class GenerateDumpFn(Protocol):
 
-  def __call__(self, compile_result: Any, **kwargs) -> SourceMapDump:
+  def __call__(self, compile_result: Any, /, **kwargs) -> SourceMapDump:
     ...
 
 

--- a/jax/experimental/source_mapper/hlo.py
+++ b/jax/experimental/source_mapper/hlo.py
@@ -176,8 +176,8 @@ def stable_hlo_generate_dump(args: tuple[Any, str],
 common.register_pass(
     common.Pass(
         name=HloPass.STABLE_HLO.value,
-        compile_fn=trace_and_lower,  # type: ignore[arg-type]
-        generate_dump=stable_hlo_generate_dump,  # type: ignore[arg-type]
+        compile_fn=trace_and_lower,
+        generate_dump=stable_hlo_generate_dump,
     )
 )
 
@@ -198,8 +198,8 @@ def original_hlo_generate_dump(args: tuple[Any, str],
 common.register_pass(
     common.Pass(
         name=HloPass.ORIGINAL.value,
-        compile_fn=trace_and_lower,  # type: ignore[arg-type]
-        generate_dump=original_hlo_generate_dump,  # type: ignore[arg-type]
+        compile_fn=trace_and_lower,
+        generate_dump=original_hlo_generate_dump,
     )
 )
 
@@ -221,7 +221,7 @@ def optimized_generate_dump(args: tuple[Any, str],
 common.register_pass(
     common.Pass(
         name=HloPass.OPTIMIZED.value,
-        compile_fn=trace_and_lower,  # type: ignore[arg-type]
-        generate_dump=optimized_generate_dump,  # type: ignore[arg-type]
+        compile_fn=trace_and_lower,
+        generate_dump=optimized_generate_dump,
     )
 )

--- a/jax/experimental/source_mapper/jaxpr.py
+++ b/jax/experimental/source_mapper/jaxpr.py
@@ -73,8 +73,6 @@ def make_jaxpr_dump(jaxpr: core.Jaxpr, **_) -> common.SourceMapDump:
 
 common.register_pass(
     common.Pass(
-        name='jaxpr',
-        compile_fn=compile_jaxpr,  # type: ignore[arg-type]
-        generate_dump=make_jaxpr_dump,  # type: ignore[arg-type]
+        name='jaxpr', compile_fn=compile_jaxpr, generate_dump=make_jaxpr_dump
     )
 )

--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -639,7 +639,8 @@ def bcoo_dot_general(lhs: BCOO | Array, rhs: BCOO | Array, *,
                                preferred_element_type=preferred_element_type)
     return BCOO(bufs, shape=shape)
   elif isinstance(lhs, BCOO):
-    return _bcoo_dot_general(lhs.data, lhs.indices, rhs, dimension_numbers=dimension_numbers,  # type: ignore[arg-type]
+    assert not isinstance(rhs, BCOO)
+    return _bcoo_dot_general(lhs.data, lhs.indices, rhs, dimension_numbers=dimension_numbers,
                              preferred_element_type=preferred_element_type,
                              lhs_spinfo=lhs._info)
   elif isinstance(rhs, BCOO):


### PR DESCRIPTION
Pyrefly treats any `type: ignore` as a blanket suppression, even if the `ignore` is followed by a mypy-style code. So, e.g. `type: ignore[foo-bar]` will suppress `bad-argument-type` and `bad-assignment` and any other error code.