### PR TITLE
[ROCm] Skip Pallas multimem tests on non-CUDA platforms

### DIFF
--- a/tests/pallas/gpu_pallas_distributed_test.py
+++ b/tests/pallas/gpu_pallas_distributed_test.py
@@ -840,6 +840,8 @@ class PallasCallRemoteDMATest(TestCase):
 
 class PallasCallMultimemTest(TestCase):
   def setUp(self):
+    if cuda_versions is None:
+      self.skipTest("Multimem requires CUDA")
     if jax.device_count() < 2:
       self.skipTest("Needs at least two devices")
     if any(
@@ -1118,6 +1120,8 @@ class PallasCallMultimemThreadUnsafeTest(TestCase):
   """
 
   def setUp(self):
+    if cuda_versions is None:
+      self.skipTest("Multimem requires CUDA")
     if jax.local_device_count() > 1:
       self.skipTest("Multimem not supported in multi-thread mode yet.")
     if jax.device_count() < 2:


### PR DESCRIPTION
The PallasCallMultimemTest and PallasCallMultimemThreadUnsafeTest classes access cuda_versions.cuda_supports_multicast() in setUp without first checking that cuda_versions is not None. On ROCm (and other non-CUDA platforms) this raises an AttributeError.

Add an early skip when cuda_versions is None since multicast memory is a CUDA-specific hardware feature.