### PR TITLE
[consts] Remove mlir.ir_constants

### DIFF
--- a/docs/internals/constants.md
+++ b/docs/internals/constants.md
@@ -68,9 +68,10 @@ for each unique constant appearing in the `Jaxpr` to which it corresponds.
 These arguments, referred to as `const_args`,
 come after the dimension variable arguments, after the
 token arguments, and just before the actual array arguments.
-During lowering we maintain a mapping `const_lowering: dict[int, mlir.IrValues]`
-from the `id` of the constants to the HLO values for the corresponding
-const args.
+During lowering we maintain a mapping
+`const_lowering: dict[tuple[int, core.AbstractValue], mlir.ir.Value]`
+from the `id` of the constants and their abstract values to the HLO values
+for the corresponding const args.
 This mapping is stored in the `mlir.LoweringRuleContext` and is used
 by `mlir.ir_constant`: when a constant is encountered, we just reuse
 the existing lowering from `const_lowering` instead of emitting a

--- a/jax/_src/compute_on.py
+++ b/jax/_src/compute_on.py
@@ -110,7 +110,7 @@ def _compute_on_lowering(ctx, *args, jaxpr, compute_type, out_memory_spaces):
   const_args_and_avals = core.jaxpr_const_args(jaxpr.jaxpr)
   const_args, const_avals = unzip2(const_args_and_avals)
   const_arg_values = [
-      mlir.ir_constants(c, const_lowering=ctx.const_lowering, aval=aval)
+      mlir.ir_constant(c, const_lowering=ctx.const_lowering, aval=aval)
       for c, aval in const_args_and_avals]
   in_avals = (*const_avals, *ctx.avals_in)
   func_op, output_types, effects = mlir.lower_called_computation(

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -249,7 +249,7 @@ def get_constant_handler(type_: type) -> ConstantHandler:
 
 def ir_constant(
     val: Any, *,
-    const_lowering: dict[tuple[int, core.AbstractValue], IrValues] | None = None,
+    const_lowering: dict[tuple[int, core.AbstractValue], ir.Value] | None = None,
     aval: core.AbstractValue | None = None
 ) -> ir.Value:
   """Translate a Python ``val`` to an IR constant.
@@ -268,7 +268,6 @@ def ir_constant(
     A representation of the constant as an IR value.
 
   Raises:
-    ValueError: if the constant is represented by more than one IR value.
     TypeError: if no constant handler is registered for the type of `val`.
   """
   value = _ir_constant(val, const_lowering=const_lowering, aval=aval)
@@ -279,35 +278,8 @@ def ir_constant(
   return value
 
 
-def ir_constants(
-    val: Any, *,
-    const_lowering: dict[tuple[int, core.AbstractValue], IrValues] | None = None,
-    aval: core.AbstractValue | None = None
-) -> tuple[ir.Value, ...]:
-  """Translate a Python ``val`` to a sequence of IR constants.
-
-  See https://docs.jax.dev/en/latest/internals/constants.html.
-
-  Args:
-    val: a Python value to be translated.
-    const_lowering: an optional dictionary with known lowering for some
-      constants, indexed by ``id``. This is used, e.g., when we pass constants
-      as MLIR function arguments.
-    aval: the abstract value of ``val``, if known. Required where ambiguous,
-      e.g. for Python scalars.
-
-  Returns:
-    A representation of the constant as a sequence of IR values.
-
-  Raises:
-    TypeError: if no constant handler is registered for the type of ``val``.
-  """
-  values = _ir_constant(val, const_lowering=const_lowering, aval=aval)
-  return values if isinstance(values, tuple) else (values,)
-
-
 def _ir_constant(val: Any, *,
-  const_lowering: dict[tuple[int, core.AbstractValue], IrValues] | None = None,
+  const_lowering: dict[tuple[int, core.AbstractValue], ir.Value] | None = None,
   aval: core.AbstractValue | None = None
 ) -> IrValues:
   if const_lowering is not None:
@@ -887,7 +859,7 @@ class LoweringRuleContext:
   # This is used to implement passing along the constants that have been
   # hoisted as main function arguments down to where they are used.
   # See https://docs.jax.dev/en/latest/internals/constants.html
-  const_lowering: dict[tuple[int, core.AbstractValue], IrValues]
+  const_lowering: dict[tuple[int, core.AbstractValue], ir.Value]
   axis_size_env: dict[core.Var, ir.Value] | None = None  # Dynamic axis sizes
   # The values for the dimension variables in same order as
   # module_context.shape_poly_state.dim_vars
@@ -1907,7 +1879,7 @@ def lower_jaxpr_to_fun(
       # If we did not hoist the constants out of this function, lower them now
       const_arg_values = [ir_constant(c, aval=aval)
                           for c, aval in const_args_and_avals]
-    const_lowering: dict[tuple[int, core.AbstractValue], IrValues] = {
+    const_lowering: dict[tuple[int, core.AbstractValue], ir.Value] = {
         (id(c), aval): c_arg
         for (c, aval), c_arg in zip(const_args_and_avals, const_arg_values)
     }
@@ -2053,7 +2025,7 @@ def jaxpr_subcomp(
     consts_for_constvars: Sequence[IrValues],
     *args: IrValues,
     dim_var_values: Sequence[ir.Value],
-    const_lowering: dict[tuple[int, core.AbstractValue], IrValues],
+    const_lowering: dict[tuple[int, core.AbstractValue], ir.Value],
     outer_traceback: xc.Traceback | None,
 ) -> tuple[Sequence[IrValues], TokenSet]:
   """Lowers a jaxpr into MLIR, inlined into an existing function.
@@ -2173,7 +2145,7 @@ def _cached_lowering(
     eqn: core.JaxprEqn,
     tokens_in: TokenSet,
     dim_var_values: tuple[ir.Value, ...],
-    const_lowering: dict[tuple[int, core.AbstractValue], IrValues],
+    const_lowering: dict[tuple[int, core.AbstractValue], ir.Value],
     *args,
     **params,
 ) -> tuple[Sequence[IrValues], TokenSet]:
@@ -2210,7 +2182,7 @@ def _cached_lowering(
 
   tokens_in_args = tuple(tokens_in.get(eff) for eff in ordered_effects)
   const_arg_values = tuple(
-      ir_constants(c, const_lowering=const_lowering, aval=aval)
+      ir_constant(c, const_lowering=const_lowering, aval=aval)
       for c, aval in zip(cache_entry.const_args, cache_entry.const_arg_avals)
   )
   args = flatten_ir_values(
@@ -2270,7 +2242,7 @@ def _emit_lowering_rule_as_fun(
     dim_var_values, token_args, const_arg_values, unflattened_args = \
       util.split_list(unflattened_args,
                       [num_dim_vars, len(ordered_effects), len(const_args)])
-    const_lowering = {
+    const_lowering: dict[tuple[int, core.AbstractValue], ir.Value] = {  # pyrefly: ignore[bad-assignment]
         (id(c), aval): c_arg
         for c, aval, c_arg in zip(const_args, const_arg_avals, const_arg_values)
     }
@@ -2637,13 +2609,13 @@ def call_lowering(fn_name, call_jaxpr: core.ClosedJaxpr, backend,
                   ctx: ModuleContext, in_avals,
                   out_avals, tokens_in, *args,
                   dim_var_values: Sequence[ir.Value],
-                  const_lowering: dict[tuple[int, core.AbstractValue], IrValues],
+                  const_lowering: dict[tuple[int, core.AbstractValue], ir.Value],
                   arg_names=None, result_names=None,
                   attributes: None | dict[str, Any] = None):
   assert isinstance(call_jaxpr, core.ClosedJaxpr), type(call_jaxpr)
   const_args_and_avals = core.jaxpr_const_args(call_jaxpr.jaxpr)
   const_args, const_avals = util.unzip2(const_args_and_avals)
-  const_arg_values = [ir_constants(c, const_lowering=const_lowering, aval=aval)
+  const_arg_values = [ir_constant(c, const_lowering=const_lowering, aval=aval)
                       for c, aval in const_args_and_avals]
   args = tuple(const_arg_values) + args
   if arg_names is not None:

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1899,7 +1899,7 @@ def _composite_lowering(
   const_args_and_avals = core.jaxpr_const_args(jaxpr.jaxpr)
   const_args, const_avals = util.unzip2(const_args_and_avals)
   const_arg_values = tuple(
-      mlir.ir_constants(c, const_lowering=ctx.const_lowering, aval=aval)
+      mlir.ir_constant(c, const_lowering=ctx.const_lowering, aval=aval)
       for c, aval in const_args_and_avals
   )
   in_avals = (*const_avals, *ctx.avals_in)

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1392,8 +1392,8 @@ def _pjit_lowering(ctx: mlir.LoweringRuleContext, *args, name: str,
       out_shardings, in_layouts, out_layouts, api_name='jit')
 
   tokens_in = [ctx.tokens_in.get(eff) for eff in effects]
-  hoisted_const_values = mlir.flatten_ir_values(
-      mlir.ir_constants(c, const_lowering=ctx.const_lowering, aval=aval)
+  hoisted_const_values = tuple(
+      mlir.ir_constant(c, const_lowering=ctx.const_lowering, aval=aval)
       for c, aval in const_args_and_avals
   )
   args = (*ctx.dim_var_values, *tokens_in, *hoisted_const_values, *args)

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -970,8 +970,8 @@ def _shard_map_lowering_shardy(
   const_args_and_avals = core.jaxpr_const_args(jaxpr)
   const_args, const_avals = util.unzip2(const_args_and_avals)
   num_const_args = len(const_args)
-  const_arg_values = mlir.flatten_ir_values(
-      mlir.ir_constants(c, const_lowering=ctx.const_lowering, aval=aval)
+  const_arg_values = tuple(
+      mlir.ir_constant(c, const_lowering=ctx.const_lowering, aval=aval)
       for c, aval in const_args_and_avals
   )
   # TODO(necula,yashkatariya): how to construct consts shardy shardings from

--- a/jax/experimental/fused.py
+++ b/jax/experimental/fused.py
@@ -61,8 +61,8 @@ dispatch.simple_impl(fused_p)
 def _fused_lowering(ctx, *args, out_spaces, jaxpr):
   const_args_and_avals = core.jaxpr_const_args(jaxpr.jaxpr)
   const_args, const_arg_avals = unzip2(const_args_and_avals)
-  const_arg_values = mlir.flatten_ir_values(
-      mlir.ir_constants(c, const_lowering=ctx.const_lowering, aval=aval)
+  const_arg_values = tuple(
+      mlir.ir_constant(c, const_lowering=ctx.const_lowering, aval=aval)
       for c, aval in const_args_and_avals
   )
   in_avals = [*const_arg_avals, *ctx.avals_in]

--- a/jax/experimental/scheduling_groups.py
+++ b/jax/experimental/scheduling_groups.py
@@ -79,8 +79,8 @@ def _xla_metadata_call_lowering(ctx, *args, jaxpr, **meta):
   symbol_name = func_op.name.value
   flat_output_types = mlir.flatten_ir_types(output_types)
   tokens = [ctx.tokens_in.get(eff) for eff in effects]
-  hoisted_const_values = mlir.flatten_ir_values(
-      mlir.ir_constants(c, const_lowering=ctx.const_lowering, aval=aval)
+  hoisted_const_values = tuple(
+      mlir.ir_constant(c, const_lowering=ctx.const_lowering, aval=aval)
       for c, aval in const_args_and_avals)
   args = (*ctx.dim_var_values, *tokens, *hoisted_const_values, *args)
   call = func_dialect.CallOp(

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -44,7 +44,6 @@ from jax._src.interpreters.mlir import (
   ir as ir,
   ir_attribute as ir_attribute,
   ir_constant as ir_constant,
-  ir_constants as ir_constants,
   ir_type_handlers as ir_type_handlers,
   jaxpr_subcomp as jaxpr_subcomp,
   lower_fun as lower_fun,


### PR DESCRIPTION
This function was being used only in the context of hoisted closed-over constants (when JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS=1). That code works only for the cases when each closed-over constant lowers to exactly one mlir.IrValue. This is achieved by `mlir.ir_constant`.

It would be nice to move away from `IrValues` being a union type that includes `IrValue`, because this is confusing and makes the type checker less effective. An example of recent confusion was fixed in #36762.
