### PR TITLE
Implement JVP for eig eigenvectors (LAPACK gauge)

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -139,6 +139,7 @@ def eig(
     *,
     compute_left_eigenvectors: bool = True,
     compute_right_eigenvectors: bool = True,
+    enable_eigvec_derivs: bool = False,
     implementation: EigImplementation | None = None,
     use_magma: bool | None = None,
 ) -> list[Array]:
@@ -169,15 +170,20 @@ def eig(
   be used if the library can be found, and the input matrix is sufficiently
   large (>= 2048x2048).
 
-  Currently autodiff is not supporteed for non-symmetric eigenvectors, and
-  is only supported to first-order for non-symmetric eigenvalues. See
-  https://github.com/jax-ml/jax/issues/2748.
-
   Args:
     x: A batch of square matrices with shape ``[..., n, n]``.
     compute_left_eigenvectors: If true, the left eigenvectors will be computed.
     compute_right_eigenvectors: If true, the right eigenvectors will be
       computed.
+    enable_eigvec_derivs: If true, enable autodiff of the returned
+      eigenvectors. The eigenvector derivative is taken under the LAPACK
+      ``geev`` normalisation (each eigenvector has unit 2-norm and its
+      largest-magnitude component is real). It is only valid when (i) all
+      eigenvalues are distinct, (ii) the eigenvectors returned by the backend
+      satisfy that normalisation, and (iii) no eigenvector has two components
+      tied for largest magnitude. Defaults to ``False`` because these
+      conditions cannot be checked statically; see
+      https://github.com/jax-ml/jax/issues/2748 for discussion.
     use_magma: Deprecated, please use ``implementation`` instead. Locally
       override the ``jax_use_magma`` flag. If ``True``, the eigendecomposition
       is computed using MAGMA. If ``False``, the computation is done using
@@ -217,6 +223,7 @@ def eig(
     )
   return eig_p.bind(x, compute_left_eigenvectors=compute_left_eigenvectors,
                     compute_right_eigenvectors=compute_right_eigenvectors,
+                    enable_eigvec_derivs=enable_eigvec_derivs,
                     implementation=implementation)
 
 
@@ -1009,7 +1016,9 @@ def _eig_compute_attr(compute):
   )
 
 def _eig_cpu_lowering(ctx, operand, *, compute_left_eigenvectors,
-                      compute_right_eigenvectors, implementation):
+                      compute_right_eigenvectors, enable_eigvec_derivs,
+                      implementation):
+  del enable_eigvec_derivs
   if implementation and implementation != EigImplementation.LAPACK:
     raise ValueError("Only the lapack implementation is supported on CPU.")
   operand_aval, = ctx.avals_in
@@ -1076,7 +1085,8 @@ def _unpack_conjugate_pairs(w: Array, vr: Array) -> Array:
 
 def _eig_gpu_lowering(ctx, operand, *,
                       compute_left_eigenvectors, compute_right_eigenvectors,
-                      implementation, target_name_prefix):
+                      enable_eigvec_derivs, implementation, target_name_prefix):
+  del enable_eigvec_derivs
   operand_aval, = ctx.avals_in
   batch_dims = operand_aval.shape[:-2]
   n, m = operand_aval.shape[-2:]
@@ -1213,11 +1223,23 @@ def _eig_vec_jvp(dot, w, v, da):
   return dw, U + v * lax.expand_dims(c, (v.ndim - 2,))
 
 def eig_jvp_rule(primals, tangents, *, compute_left_eigenvectors,
-                 compute_right_eigenvectors, implementation):
+                 compute_right_eigenvectors, enable_eigvec_derivs,
+                 implementation):
   a, = primals
   da, = tangents
+  if compute_left_eigenvectors or compute_right_eigenvectors:
+    if not enable_eigvec_derivs:
+      raise NotImplementedError(
+          'Derivatives of non-symmetric eigenvectors are only valid under '
+          'assumptions on the input that JAX cannot check (distinct '
+          'eigenvalues, and eigenvectors satisfying the LAPACK geev '
+          'normalisation). Pass enable_eigvec_derivs=True to '
+          'jax.lax.linalg.eig to opt in. See '
+          'https://github.com/jax-ml/jax/issues/2748 for discussion.')
   outs = eig(a, compute_left_eigenvectors=compute_left_eigenvectors,
-             compute_right_eigenvectors=True, implementation=implementation)
+             compute_right_eigenvectors=True,
+             enable_eigvec_derivs=enable_eigvec_derivs,
+             implementation=implementation)
   w, vr = outs[0], outs[-1]
   dot = partial(lax.dot if a.ndim == 2 else lax.batch_matmul,
                 precision=lax.Precision.HIGHEST)

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -179,8 +179,7 @@ def eig(
       eigenvectors. The eigenvector derivative is taken under the LAPACK
       ``geev`` normalisation (each eigenvector has unit 2-norm and its
       largest-magnitude component is real). It is only valid when (i) all
-      eigenvalues are distinct, (ii) the eigenvectors returned by the backend
-      satisfy that normalisation, and (iii) no eigenvector has two components
+      eigenvalues are distinct and (ii) no eigenvector has two components
       tied for largest magnitude. Defaults to ``False`` because these
       conditions cannot be checked statically; see
       https://github.com/jax-ml/jax/issues/2748 for discussion.
@@ -1231,10 +1230,9 @@ def eig_jvp_rule(primals, tangents, *, compute_left_eigenvectors,
     if not enable_eigvec_derivs:
       raise NotImplementedError(
           'Derivatives of non-symmetric eigenvectors are only valid under '
-          'assumptions on the input that JAX cannot check (distinct '
-          'eigenvalues, and eigenvectors satisfying the LAPACK geev '
-          'normalisation). Pass enable_eigvec_derivs=True to '
-          'jax.lax.linalg.eig to opt in. See '
+          'assumptions on the input that JAX cannot check (see the '
+          'enable_eigvec_derivs argument to jax.lax.linalg.eig). Pass '
+          'enable_eigvec_derivs=True to jax.lax.linalg.eig to opt in. See '
           'https://github.com/jax-ml/jax/issues/2748 for discussion.')
   outs = eig(a, compute_left_eigenvectors=compute_left_eigenvectors,
              compute_right_eigenvectors=True,

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1188,19 +1188,53 @@ def _eig_gpu_lowering(ctx, operand, *,
     output.append(vr)
   return output
 
+def _eig_vec_jvp(dot, w, v, da):
+  # Nondegenerate perturbation theory, see e.g. Sec 3.1 of
+  # https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf
+  # The eigenvalue equation A v_j = w_j v_j fixes v_j only up to a (complex)
+  # scalar. LAPACK's geev fixes that scalar by normalising each v_j to have unit
+  # 2-norm and real largest-magnitude component, and we differentiate through
+  # that choice. See https://github.com/jax-ml/jax/issues/2748 for discussion.
+  n = w.shape[-1]
+  eye_n = lax._eye(w.dtype, (n, n))
+  with config.numpy_rank_promotion('allow'):
+    Fmat = lax.reciprocal(eye_n + w[..., None, :] - w[..., None]) - eye_n
+  P = dot(_solve(v, da), v)
+  dw = _extract_diagonal(P)
+  U = dot(v, Fmat * P)
+  # The eigenvalue equation gives dv_j = u_j + c_j v_j with c_j free; the two
+  # real LAPACK normalisation constraints fix c_j to
+  #   c_j = -Re(v_j* . u_j) - i Im(u_{k_j j}) / v_{k_j j},  k_j = argmax_i |v_ij|.
+  k = lax.argmax(lax.abs(v), axis=v.ndim - 2, index_dtype=np.int32)
+  mask = (lax.broadcasted_iota(np.int32, v.shape, v.ndim - 2)
+          == lax.expand_dims(k, (v.ndim - 2,))).astype(v.dtype)
+  c = lax.complex(-(v.conj() * U).sum(-2).real,
+                  -(mask * U).sum(-2).imag / (mask * v).sum(-2).real)
+  return dw, U + v * lax.expand_dims(c, (v.ndim - 2,))
+
 def eig_jvp_rule(primals, tangents, *, compute_left_eigenvectors,
                  compute_right_eigenvectors, implementation):
-  if compute_left_eigenvectors or compute_right_eigenvectors:
-    raise NotImplementedError(
-        'The derivatives of non-symmetric eigenvectors are not supported. '
-        'Only first-order derivatives of eigenvalues are supported. See '
-        'https://github.com/jax-ml/jax/issues/2748 for discussion.')
-  # Formula for derivative of eigenvalues w.r.t. a is eqn 4.60 in
-  # https://arxiv.org/abs/1701.00392
   a, = primals
   da, = tangents
-  l, v = eig(a, compute_left_eigenvectors=False, implementation=implementation)
-  return [l], [(_solve(v, da.astype(v.dtype)) * _T(v)).sum(-1)]
+  outs = eig(a, compute_left_eigenvectors=compute_left_eigenvectors,
+             compute_right_eigenvectors=True, implementation=implementation)
+  w, vr = outs[0], outs[-1]
+  dot = partial(lax.dot if a.ndim == 2 else lax.batch_matmul,
+                precision=lax.Precision.HIGHEST)
+  da = da.astype(vr.dtype)
+  if not (compute_left_eigenvectors or compute_right_eigenvectors):
+    return [w], [(_solve(vr, da) * _T(vr)).sum(-1)]
+  dw, dvr = _eig_vec_jvp(dot, w, vr, da)
+  primal_out, tangent_out = [w], [dw]
+  if compute_left_eigenvectors:
+    vl = outs[1]
+    _, dvl = _eig_vec_jvp(dot, w.conj(), vl, _H(da))
+    primal_out.append(vl)
+    tangent_out.append(dvl)
+  if compute_right_eigenvectors:
+    primal_out.append(vr)
+    tangent_out.append(dvr)
+  return primal_out, tangent_out
 
 eig_p = linalg_primitive(
     _eig_dtype_rule, (_float | _complex,), (2,), _eig_shape_rule, "eig",

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -417,7 +417,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     tol = 1e-4 if dtype in (np.float64, np.complex128) else 5e-1
     f = partial(lax.linalg.eig, compute_left_eigenvectors=left,
                 compute_right_eigenvectors=right)
-    jtu.check_grads(f, (a,), order=1, modes=['fwd', 'rev'], rtol=tol, atol=tol)
+    jtu.check_grads(f, (a,), order=1, rtol=tol, atol=tol)
 
   @jtu.sample_product(
     shape=[(4, 4), (5, 5), (50, 50)],

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -403,6 +403,23 @@ class NumpyLinalgTest(jtu.JaxTestCase):
                     modes=['fwd', 'rev'], rtol=tol, atol=tol)
 
   @jtu.sample_product(
+    shape=[(4, 4), (5, 5), (3, 4, 4)],
+    dtype=float_types + complex_types,
+    left_right=[(False, True), (True, False), (True, True)],
+  )
+  @jtu.run_on_devices("cpu", "gpu")
+  def testEigGrad(self, shape, dtype, left_right):
+    # Small matrices only; the eigenvector derivative blows up like
+    # 1/min|w_i - w_j| so close eigenvalues make the FD check noisy.
+    left, right = left_right
+    rng = jtu.rand_default(self.rng())
+    a = rng(shape, dtype)
+    tol = 1e-4 if dtype in (np.float64, np.complex128) else 5e-1
+    f = partial(lax.linalg.eig, compute_left_eigenvectors=left,
+                compute_right_eigenvectors=right)
+    jtu.check_grads(f, (a,), order=1, modes=['fwd', 'rev'], rtol=tol, atol=tol)
+
+  @jtu.sample_product(
     shape=[(4, 4), (5, 5), (50, 50)],
     dtype=float_types + complex_types,
   )

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -404,20 +404,22 @@ class NumpyLinalgTest(jtu.JaxTestCase):
 
   @jtu.sample_product(
     shape=[(4, 4), (5, 5), (3, 4, 4)],
-    dtype=float_types + complex_types,
+    dtype=complex_types,
     left_right=[(False, True), (True, False), (True, True)],
   )
   @jtu.run_on_devices("cpu", "gpu")
   def testEigGrad(self, shape, dtype, left_right):
     # Small matrices only; the eigenvector derivative blows up like
-    # 1/min|w_i - w_j| so close eigenvalues make the FD check noisy.
+    # 1/min|w_i - w_j| so close eigenvalues make the FD check noisy. Complex
+    # input only: for real input dgeev does not pin the sign of complex-pair
+    # eigenvectors, so the primal output is itself discontinuous.
     left, right = left_right
     rng = jtu.rand_default(self.rng())
     a = rng(shape, dtype)
-    tol = 1e-4 if dtype in (np.float64, np.complex128) else 5e-1
+    tol = 1e-3 if dtype == np.complex128 else 5e-1
     f = partial(lax.linalg.eig, compute_left_eigenvectors=left,
                 compute_right_eigenvectors=right)
-    jtu.check_grads(f, (a,), order=1, rtol=tol, atol=tol)
+    jtu.check_grads(f, (a,), order=2, rtol=tol, atol=tol)
 
   @jtu.sample_product(
     shape=[(4, 4), (5, 5), (50, 50)],

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -403,22 +403,41 @@ class NumpyLinalgTest(jtu.JaxTestCase):
                     modes=['fwd', 'rev'], rtol=tol, atol=tol)
 
   @jtu.sample_product(
-    shape=[(4, 4), (5, 5), (3, 4, 4)],
+    shape=[(4, 4), (5, 5)],
     dtype=complex_types,
     left_right=[(False, True), (True, False), (True, True)],
   )
   @jtu.run_on_devices("cpu", "gpu")
-  def testEigGrad(self, shape, dtype, left_right):
+  def testEigGradComplexInputs(self, shape, dtype, left_right):
     # Small matrices only; the eigenvector derivative blows up like
-    # 1/min|w_i - w_j| so close eigenvalues make the FD check noisy. Complex
-    # input only: for real input dgeev does not pin the sign of complex-pair
-    # eigenvectors, so the primal output is itself discontinuous.
+    # 1/min|w_i - w_j| so close eigenvalues make the FD check noisy.
     left, right = left_right
     rng = jtu.rand_default(self.rng())
     a = rng(shape, dtype)
     tol = 1e-3 if dtype == np.complex128 else 5e-1
     f = partial(lax.linalg.eig, compute_left_eigenvectors=left,
                 compute_right_eigenvectors=right)
+    jtu.check_grads(f, (a,), order=2, rtol=tol, atol=tol)
+
+  @jtu.sample_product(
+    shape=[(4, 4), (5, 5)],
+    dtype=float_types,
+    left_right=[(False, True), (True, False), (True, True)],
+  )
+  @jtu.run_on_devices("cpu", "gpu")
+  def testEigGradRealInputs(self, shape, dtype, left_right):
+    # dgeev does not pin the sign of complex-pair eigenvectors so the primal
+    # output is itself discontinuous; compose with elementwise v -> v*v which
+    # is sign-invariant but still phase-sensitive (so still exercises the
+    # gauge-fixing part of the JVP).
+    left, right = left_right
+    rng = jtu.rand_default(self.rng())
+    a = rng(shape, dtype)
+    tol = 1e-3 if dtype == np.float64 else 5e-1
+    def f(a):
+      out = lax.linalg.eig(a, compute_left_eigenvectors=left,
+                           compute_right_eigenvectors=right)
+      return (out[0],) + tuple(v * v for v in out[1:])
     jtu.check_grads(f, (a,), order=2, rtol=tol, atol=tol)
 
   @jtu.sample_product(

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -416,7 +416,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     a = rng(shape, dtype)
     tol = 1e-3 if dtype == np.complex128 else 5e-1
     f = partial(lax.linalg.eig, compute_left_eigenvectors=left,
-                compute_right_eigenvectors=right)
+                compute_right_eigenvectors=right, enable_eigvec_derivs=True)
     jtu.check_grads(f, (a,), order=2, rtol=tol, atol=tol)
 
   @jtu.sample_product(
@@ -436,9 +436,21 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     tol = 1e-3 if dtype == np.float64 else 5e-1
     def f(a):
       out = lax.linalg.eig(a, compute_left_eigenvectors=left,
-                           compute_right_eigenvectors=right)
+                           compute_right_eigenvectors=right,
+                           enable_eigvec_derivs=True)
       return (out[0],) + tuple(v * v for v in out[1:])
     jtu.check_grads(f, (a,), order=2, rtol=tol, atol=tol)
+
+  @jtu.run_on_devices("cpu", "gpu")
+  def testEigGradEigvecsDisabledByDefault(self):
+    a = jnp.eye(3)
+    with self.assertRaisesRegex(NotImplementedError,
+                                "enable_eigvec_derivs=True"):
+      jax.jvp(jnp.linalg.eig, (a,), (a,))
+    with self.assertRaisesRegex(NotImplementedError,
+                                "enable_eigvec_derivs=True"):
+      jax.jvp(partial(lax.linalg.eig, compute_left_eigenvectors=True,
+                      compute_right_eigenvectors=False), (a,), (a,))
 
   @jtu.sample_product(
     shape=[(4, 4), (5, 5), (50, 50)],

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -441,17 +441,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       return (out[0],) + tuple(v * v for v in out[1:])
     jtu.check_grads(f, (a,), order=2, rtol=tol, atol=tol)
 
-  @jtu.run_on_devices("cpu", "gpu")
-  def testEigGradEigvecsDisabledByDefault(self):
-    a = jnp.eye(3)
-    with self.assertRaisesRegex(NotImplementedError,
-                                "enable_eigvec_derivs=True"):
-      jax.jvp(jnp.linalg.eig, (a,), (a,))
-    with self.assertRaisesRegex(NotImplementedError,
-                                "enable_eigvec_derivs=True"):
-      jax.jvp(partial(lax.linalg.eig, compute_left_eigenvectors=True,
-                      compute_right_eigenvectors=False), (a,), (a,))
-
   @jtu.sample_product(
     shape=[(4, 4), (5, 5), (50, 50)],
     dtype=float_types + complex_types,


### PR DESCRIPTION
LAPACK's `*geev` fixes the free per-eigenvector scalar by normalising each column to unit 2-norm with its largest-magnitude component real. This PR differentiates through that choice so that `jvp`/`grad` of `eig` (with eigenvectors) matches finite differences of `eig` itself, not just of gauge-invariant downstream functions.

The derivative is gated behind a new `enable_eigvec_derivs: bool = False` kwarg on `lax.linalg.eig`: it is only valid when (i) the eigenvalues are distinct and (ii) no eigenvector has two components tied for largest magnitude. Those can't be checked statically, so the user must opt in. Differentiating without the flag raises a `NotImplementedError` pointing at the kwarg and #2748. The eigenvalues-only JVP path is unchanged.

(All current backends — LAPACK, MAGMA, and per its docs cuSOLVER — apply the geev normalisation that the JVP differentiates; the new `testEigGrad*` tests run on GPU in CI as a guard.)

### Derivation

Differentiating $A V = V \Lambda$ and writing $P = V^{-1} \dot A V$ and $F_{ij} = 1/(\lambda_j - \lambda_i)$ (zero on the diagonal) gives

$$\dot V = V(F \circ P) + V \mathrm{diag}(c)$$

with $c \in \mathbb{C}^n$ free. Setting $u_j = V(F \circ P) e_j$, the two real gauge constraints $\mathrm{Re}(v_j^{\mathsf H} \dot v_j) = 0$ and $\mathrm{Im}(\dot v_{k_j,j}) = 0$ at $k_j = \arg\max_i \lvert v_{ij}\rvert$ give

$$c_j = -\mathrm{Re}(v_j^{\mathsf H} u_j) - i \frac{\mathrm{Im}(u_{k_j,j})}{v_{k_j,j}}.$$

Left eigenvectors are right eigenvectors of $A^{\mathsf H}$ with eigenvalues $\bar\lambda$, so the same helper applies with $(V_L, \bar\lambda, \dot A^{\mathsf H})$. The eigenvalues-only fast path is unchanged.

### Stability / where it breaks

Two failure modes are inherited from perturbation theory and shared with `eigh`: $F$ blows up as $1/\min_{i\ne j}\lvert\lambda_i-\lambda_j\rvert$ (degenerate eigenvalues), and the $V^{-1}\dot A$ solve amplifies by $\kappa(V)$ (large near defective matrices).

The gauge correction itself is numerically tame: the only division is by $v_{k_j,j}$, the max-magnitude entry of a unit vector, so $\lvert v_{k_j,j}\rvert \ge 1/\sqrt{n}$. However, the gauge-fixed eigenvectors are *discontinuous* (hence non-differentiable) wherever two entries of $v_j$ tie in magnitude, since $k_j$ jumps. There is no $1/\varepsilon$ divergence at such points, just a step; the JVP returned is the one-sided derivative for whichever index LAPACK picks. Gauge-invariant downstream functions are unaffected.

**Real input.** `zgeev` makes $v_{k_j,j}$ real and *positive*, so the gauge is fully determined and the JVP is exact. `dgeev` (real input) does *not* pin the sign of complex-conjugate-pair eigenvectors, so the primal output of `eig` is itself discontinuous in $A$ and finite-difference checks fail across sign flips. The JVP we compute is the locally-consistent linearisation. `testEigGradRealInputs` therefore composes with elementwise $v \mapsto v^2$, which is sign-invariant but still phase-sensitive (so still exercises the gauge correction). Making real-input `eig` continuous would need a `sign(v[k,j])` post-normalisation in the primal, which is left for a follow-up since it changes the output relative to NumPy.

Closes #2748.
