### PR TITLE
[ROCm] Override ROCR_VISIBLE_DEVICES instead of using setdefault in conftest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -79,6 +79,6 @@ def pytest_collection() -> None:
     if not xdist_worker_name.startswith("gw"):
       return
     xdist_worker_number = int(xdist_worker_name[len("gw") :])
-    os.environ.setdefault(
-        "ROCR_VISIBLE_DEVICES", str(xdist_worker_number % num_rocm_devices)
+    os.environ["ROCR_VISIBLE_DEVICES"] = str(
+        xdist_worker_number % num_rocm_devices
     )


### PR DESCRIPTION
- Use direct assignment instead of os.environ.setdefault for ROCR_VISIBLE_DEVICES in pytest xdist worker GPU assignment
- setdefault silently skips if the variable is already set, which can cause workers to share GPUs unintentionally

