### PR TITLE
Add cudnn sdpa flex attention in JAX SDPA API

### DIFF
--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -667,26 +667,11 @@ def _dot_product_attention_bwd_abstract(
       ),  # grad value
     )
 
-def convert_jaxpr_to_computation(ctx, name, jaxpr, score_mod_args, is_bwd=False):
-  output_aval = jaxpr.out_avals[0]
-  attn_score = mlir.ir_constant(np.zeros(output_aval.shape, dtype=output_aval.dtype))
-  aval_out = ctx.avals_out
-  aval_in = ctx.avals_in
-  ctx.avals_out = jaxpr.out_avals
-  ctx.avals_in = jaxpr.in_avals
-  if is_bwd:
-    impl = mlir.core_call_lowering(
-      ctx, attn_score, attn_score, *score_mod_args, name=name + "_bwd", call_jaxpr=jaxpr
-    )
-  else:
-    impl = mlir.core_call_lowering(
-      ctx, attn_score, *score_mod_args, name=name, call_jaxpr=jaxpr
-    )
-  ctx.avals_out = aval_out
-  ctx.avals_in = aval_in
-  call_op = impl[0].owner
-  called_fn = call_op.attributes["callee"]
-  return called_fn.value
+def convert_jaxpr_to_computation(ctx, name, jaxpr, is_bwd=False):
+  func_op = mlir.lower_jaxpr_to_fun(
+      ctx.module_context, name + ("_bwd" if is_bwd else ""), jaxpr,
+      effects=[], num_const_args=0, in_avals=jaxpr.in_avals)
+  return func_op.sym_name.value
 
 def _dot_product_attention_fwd_cuda_lowering(
     ctx, query, key, value, bias, q_seqlen, kv_seqlen, q_offsets,
@@ -741,7 +726,7 @@ def _dot_product_attention_fwd_cuda_lowering(
   if score_mod is not None:
     operands += score_mod_args
     name, call_jaxpr = score_mod
-    called_fn = convert_jaxpr_to_computation(ctx, name, call_jaxpr, score_mod_args)
+    called_fn = convert_jaxpr_to_computation(ctx, name, call_jaxpr)
     called_computations = [called_fn]
   else:
     called_computations = []
@@ -833,7 +818,7 @@ def _dot_product_attention_bwd_cuda_lowering(
   if score_mod is not None:
     operands += score_mod_args
     name, bwd_jaxpr = score_mod
-    bwd_called_fn = convert_jaxpr_to_computation(ctx, name, bwd_jaxpr, score_mod_args, True)
+    bwd_called_fn = convert_jaxpr_to_computation(ctx, name, bwd_jaxpr, True)
     called_computations = [bwd_called_fn]
   else:
     called_computations = []

--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -16,7 +16,8 @@ import enum
 import functools
 import json
 import math
-from typing import TypedDict
+import inspect
+from typing import TypedDict, Callable, Tuple
 
 from jax._src import core
 from jax._src import custom_derivatives
@@ -34,6 +35,7 @@ from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import hlo
 from jax._src.sharding_impls import NamedSharding, PartitionSpec
 from jax._src.typing import Array
+from jax._src.api import make_jaxpr, vjp
 
 import numpy as np
 
@@ -69,7 +71,6 @@ class MaskType(enum.Enum):
   CAUSAL = 2
   PADDING_CAUSAL = 3
   ALIBI = 4
-
 
 def convert_mask_type_to_string(mask_type: MaskType) -> str:
   if mask_type == MaskType.NO_MASK:
@@ -425,18 +426,19 @@ def is_cuda_compute_capability_equal(capability):
 
 def _dot_product_attention_fwd(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v,
-    scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, cudnn_version, return_residual):
+    page_table_k, page_table_v, score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length, score_mod,
+    cudnn_version, return_residual):
   # check if flash attention is supported for this attention pattern
   check_is_flash_attention(
       query, key, value, layout, cudnn_version, bias is not None, False,
       get_max_seg_per_batch(q_offsets) > 1, check_is_paged_attention(page_table_k))
   outputs = _dot_product_attention_fwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length, is_training=False or return_residual)
+      page_table_k, page_table_v, *score_mod_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      score_mod=score_mod, is_training=False or return_residual)
   if return_residual:
     return tuple(outputs)
   else:
@@ -444,20 +446,21 @@ def _dot_product_attention_fwd(
 
 def _dot_product_attention_fwd_rule(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, cudnn_version,
-    return_residual):
+    page_table_k, page_table_v, score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length,
+    score_mod, cudnn_version, return_residual):
   # check if flash attention is supported for this attention pattern
   check_is_flash_attention(
       query, key, value, layout, cudnn_version, bias is not None, True,
       get_max_seg_per_batch(q_offsets) > 1)
   outputs = _dot_product_attention_fwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length, is_training=True)
+      page_table_k, page_table_v, *score_mod_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      score_mod=score_mod, is_training=True)
   res = (query, key, value, bias, q_seqlen, kv_seqlen, q_offsets,
-         kv_offsets, page_table_k, page_table_v, outputs[1], outputs[0])
+         kv_offsets, page_table_k, page_table_v, score_mod_args, outputs[1], outputs[0])
   if return_residual:
     return tuple(outputs), res
   else:
@@ -465,19 +468,21 @@ def _dot_product_attention_fwd_rule(
 
 def _dot_product_attention_bwd_rule(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, is_training, return_residual, res, grad_output):
+    sliding_window_length, score_mod, cudnn_version, return_residual, res,
+    grad_output):
   (query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-   page_table_k, page_table_v, activation, fwd_output) = res
+   page_table_k, page_table_v, score_mod_args, activation, fwd_output) = res
   if return_residual:
     grad_output = grad_output[0]
   grads = _dot_product_attention_bwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       page_table_k, page_table_v, activation, fwd_output, grad_output,
-      scale=scale, seed=seed, dropout_rate=dropout_rate, variadic_args=variadic_args,
-      mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length
+      *score_mod_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
+      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
+      sliding_window_length=sliding_window_length,
+      score_mod=score_mod
   )
-  grads = (*grads,) + (None,) * (10 - len(grads))
+  grads = (*grads,) + (None,) * (11 - len(grads))
   return grads
 
 def _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key):
@@ -536,37 +541,71 @@ def _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key):
 
 def _dot_product_attention_fwd_impl(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, is_training):
+    page_table_k, page_table_v, score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length,
+    score_mod, is_training):
   # args: {Q, K, V, mask*, bias*}
+  jaxpr = None
+  if score_mod is not None:
+    if layout == AttentionLayout.BNTH.value:
+      B, N, T, _ = query.shape
+      _, _, S, _ = key.shape
+    else:
+      B, T, N, _ = query.shape
+      _, S, _, _ = key.shape
+    attn_score = core.ShapedArray((B, N, T, S), np.float32)
+    fwd_jaxpr = make_jaxpr(score_mod)(attn_score, *score_mod_args)
+    jaxpr = (score_mod.__name__, fwd_jaxpr)
   q_seqlen, kv_seqlen, q_offsets, kv_offsets = \
       _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key)
   outputs = _dot_product_attention_fwd_p.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length, is_training=is_training)
+      page_table_k, page_table_v, *score_mod_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      score_mod=jaxpr, is_training=is_training)
   return outputs
 
 def _dot_product_attention_bwd_impl(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, activation, fwd_output, grad_output, scale,
-    seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length):
+    page_table_k, page_table_v, activation, fwd_output, grad_output, score_mod_args,
+    scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
+    score_mod):
+  jaxpr = None
+  if score_mod is not None:
+    if layout == AttentionLayout.BNTH.value:
+      B, N, T, _ = query.shape
+      _, _, S, _ = key.shape
+    else:
+      B, T, N, _ = query.shape
+      _, S, _, _ = key.shape
+
+    attn_score = core.ShapedArray((B, N, T, S), np.float32)
+    grad = core.ShapedArray((B, N, T, S), np.float32)
+
+    def wrapped_func(grad, *args):
+      _, grad_score_mod = vjp(score_mod, *args)
+      return grad_score_mod(grad)[0]
+
+    bwd_jaxpr = make_jaxpr(wrapped_func)(grad, attn_score, *score_mod_args)
+    jaxpr = (score_mod.__name__, bwd_jaxpr)
   q_seqlen, kv_seqlen, q_offsets, kv_offsets = \
       _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key)
   grads = _dot_product_attention_bwd_p.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       page_table_k, page_table_v, activation, fwd_output, grad_output,
-      scale=scale, seed=seed,
-      dropout_rate=dropout_rate, variadic_args=variadic_args,
-      mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length)
+      *score_mod_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
+      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
+      sliding_window_length=sliding_window_length,
+      score_mod=jaxpr)
   return grads
 
 def _dot_product_attention_fwd_abstract(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, *, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, is_training):
+    page_table_k, page_table_v, *score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length,
+    score_mod, is_training):
+  query_dtype = dtypes.canonicalize_dtype(query.dtype)
   if layout == AttentionLayout.BNTH.value:
     B, N, T, _ = query.shape
     _, _, S, H = value.shape
@@ -591,8 +630,13 @@ def _dot_product_attention_fwd_abstract(
 
 def _dot_product_attention_bwd_abstract(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, activation, fwd_output, grad_output, *,
-    scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length):
+    page_table_k, page_table_v, activation, fwd_output, grad_output,
+    *score_mod_args, scale, seed, dropout_rate, variadic_args, mask_type,
+    layout, sliding_window_length, score_mod):
+  query_dtype = dtypes.canonicalize_dtype(query.dtype)
+  key_dtype = dtypes.canonicalize_dtype(key.dtype)
+  value_dtype = dtypes.canonicalize_dtype(value.dtype)
+
   _, has_dbias = variadic_args
   if has_dbias:
     # cuDNN supports bias for this case
@@ -623,10 +667,32 @@ def _dot_product_attention_bwd_abstract(
       ),  # grad value
     )
 
+def convert_jaxpr_to_computation(ctx, name, jaxpr, score_mod_args, is_bwd=False):
+  output_aval = jaxpr.out_avals[0]
+  attn_score = mlir.ir_constant(np.zeros(output_aval.shape, dtype=output_aval.dtype))
+  aval_out = ctx.avals_out
+  aval_in = ctx.avals_in
+  ctx.avals_out = jaxpr.out_avals
+  ctx.avals_in = jaxpr.in_avals
+  if is_bwd:
+    impl = mlir.core_call_lowering(
+      ctx, attn_score, attn_score, *score_mod_args, name=name + "_bwd", call_jaxpr=jaxpr
+    )
+  else:
+    impl = mlir.core_call_lowering(
+      ctx, attn_score, *score_mod_args, name=name, call_jaxpr=jaxpr
+    )
+  ctx.avals_out = aval_out
+  ctx.avals_in = aval_in
+  call_op = impl[0].owner
+  called_fn = call_op.attributes["callee"]
+  return called_fn.value
+
 def _dot_product_attention_fwd_cuda_lowering(
     ctx, query, key, value, bias, q_seqlen, kv_seqlen, q_offsets,
-    kv_offsets, page_table_k, page_table_v, scale, seed, dropout_rate,
-    variadic_args, mask_type, layout, sliding_window_length, is_training):
+    kv_offsets, page_table_k, page_table_v, *score_mod_args, scale, seed,
+    dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
+    score_mod, is_training):
   query_type = ir.RankedTensorType(query.type)
   query_shape = query_type.shape
   value_type = ir.RankedTensorType(value.type)
@@ -656,7 +722,7 @@ def _dot_product_attention_fwd_cuda_lowering(
       B, N, T, S, query_type.element_type, scale, seed, dropout_rate,
       mask_type, layout, sliding_window_length, max_seg_per_batch,
       is_paged_attention, is_bwd=False)
-  # {Q, K, V, bias*, q_seqlen*, kv_seqlen*,  q_offsets*, kv_offsets*}}
+  # {Q, K, V, bias*, q_seqlen*, kv_seqlen*, q_offsets*, kv_offsets*, score_mod_args*}
   # {output, activation*, workspace}
   has_dropout = dropout_rate > 0
   operands = [query, key, value]
@@ -672,6 +738,13 @@ def _dot_product_attention_fwd_cuda_lowering(
     operands.append(page_table_k)
     operands.append(page_table_v)
 
+  if score_mod is not None:
+    operands += score_mod_args
+    name, call_jaxpr = score_mod
+    called_fn = convert_jaxpr_to_computation(ctx, name, call_jaxpr, score_mod_args)
+    called_computations = [called_fn]
+  else:
+    called_computations = []
   custom_call_name = get_custom_call_name(has_bias, has_dropout, False)
 
   if is_training:
@@ -696,6 +769,7 @@ def _dot_product_attention_fwd_cuda_lowering(
     operand_layouts=default_layouts(
       *[ir.RankedTensorType(operand.type).shape for operand in operands]),
     result_layouts=result_layouts,
+    called_computations=called_computations,
   )
   # drop workspace memory
   # output should be (B, T, N, H) instead of (B, N, T, H)
@@ -706,8 +780,9 @@ def _dot_product_attention_fwd_cuda_lowering(
 
 def _dot_product_attention_bwd_cuda_lowering(
     ctx, query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, activation, fwd_output, grad_output,
-    scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length):
+    page_table_k, page_table_v, activation, fwd_output, grad_output, *score_mod_args,
+    scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
+    score_mod):
   query_type = ir.RankedTensorType(query.type)
   query_shape = query_type.shape
   key_type = ir.RankedTensorType(key.type)
@@ -739,7 +814,7 @@ def _dot_product_attention_bwd_cuda_lowering(
       mask_type, layout, sliding_window_length, max_seg_per_batch,
       False, is_bwd=True)
   # {Q, K, V, activation, dO, bias*, O, q_seqlen*, kv_seqlen*,
-  #  q_offsets*, kv_offsets*}
+  #  q_offsets*, kv_offsets*, score_mod_args*}
   # {dQ, dK, dV, dbias*, workspace}
   has_dropout = dropout_rate > 0
   # create operands
@@ -754,6 +829,14 @@ def _dot_product_attention_bwd_cuda_lowering(
   if max_seg_per_batch > 1:
     operands.append(q_offsets)
     operands.append(kv_offsets)
+
+  if score_mod is not None:
+    operands += score_mod_args
+    name, bwd_jaxpr = score_mod
+    bwd_called_fn = convert_jaxpr_to_computation(ctx, name, bwd_jaxpr, score_mod_args, True)
+    called_computations = [bwd_called_fn]
+  else:
+    called_computations = []
   # get custom call name
   custom_call_name = get_custom_call_name(has_bias, has_dropout, True)
 
@@ -783,6 +866,7 @@ def _dot_product_attention_bwd_cuda_lowering(
     operand_layouts=default_layouts(
       *[ir.RankedTensorType(operand.type).shape for operand in operands]),
     result_layouts=result_layouts,
+    called_computations=called_computations,
   )
   dqkv = (hlo.transpose(out.results[0], grad_transpose_perm),
           hlo.transpose(out.results[1], grad_transpose_perm),
@@ -802,10 +886,10 @@ def _check_valid_batch_dims(bdims):
 
 def _dot_product_attention_fwd_batcher(
     batched_args, batch_dims, *, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, is_training):
+    mask_type, layout, sliding_window_length, score_mod, is_training):
   _check_valid_batch_dims(batch_dims)
   query, key, value, bias, q_seqlen, kv_seqlen, \
-    q_offsets, kv_offsets, page_table_k, page_table_v = batched_args
+    q_offsets, kv_offsets, page_table_k, page_table_v, score_mod_args = batched_args
   query_bdim = batch_dims[0]
   if is_training:
     out_bdims = query_bdim, query_bdim
@@ -833,9 +917,10 @@ def _dot_product_attention_fwd_batcher(
 
   outputs = _dot_product_attention_fwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length, is_training=is_training)
+      page_table_k, page_table_v, *score_mod_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      score_mod=score_mod, is_training=is_training)
 
   # reshape to original shape
   output = outputs[0]
@@ -849,10 +934,10 @@ def _dot_product_attention_fwd_batcher(
 
 def _dot_product_attention_bwd_batcher(
      batched_args, batch_dims, *, scale, seed, dropout_rate, variadic_args,
-     mask_type, layout, sliding_window_length):
+     mask_type, layout, sliding_window_length, score_mod):
   _check_valid_batch_dims(batch_dims)
   query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets, \
-    page_table_k, page_table_v, activation, fwd_output, grad_output = batched_args
+    page_table_k, page_table_v, score_mod_args, activation, fwd_output, grad_output = batched_args
   query_bdim = batch_dims[0]
   out_bdims = query_bdim, query_bdim, query_bdim
 
@@ -885,9 +970,10 @@ def _dot_product_attention_bwd_batcher(
   grads = _dot_product_attention_bwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       page_table_k, page_table_v, activation, fwd_output, grad_output,
-      scale=scale, seed=seed, dropout_rate=dropout_rate, variadic_args=variadic_args,
-      mask_type=mask_type, layout=layout,
+      *score_mod_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
+      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
       sliding_window_length=sliding_window_length,
+      score_mod=score_mod,
   )
 
   # reshape to original shape
@@ -989,11 +1075,21 @@ def _fwd_shardy_rule(value_types, result_types, layout, is_training, is_fp8):
   return SdyShardingRule(tuple(input_sharding), output_sharding, **factor_sizes)
 
 _dot_product_attention_fwd_lower = custom_partitioning(
-    _dot_product_attention_fwd_impl, static_argnums=(10, 11, 12, 13, 14, 15, 16, 17))
+    _dot_product_attention_fwd_impl, static_argnums=(11, 12, 13, 14, 15, 16, 17, 18, 19))
+
+def _dot_product_attention_fwd_lower_wrapper(
+    query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
+    page_table_k, page_table_v, *score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length, score_mod,
+    is_training):
+  return _dot_product_attention_fwd_lower(query, key, value, bias, q_seqlen,
+    kv_seqlen, q_offsets, kv_offsets, page_table_k, page_table_v,
+    score_mod_args, scale, seed, dropout_rate, variadic_args, mask_type, layout,
+    sliding_window_length, score_mod, is_training)
 
 def _dot_product_attention_fwd_infer_sharding_from_operands(
     scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
-    is_training, mesh, arg_shapes, result_shape):
+    score_mod, is_training, mesh, arg_shapes, result_shape):
   return _infer_fwd_output_sharding(mesh, arg_shapes, variadic_args, is_training, layout)
 
 def _dot_product_attention_fwd_shardy_rule(
@@ -1003,7 +1099,7 @@ def _dot_product_attention_fwd_shardy_rule(
 
 def _dot_product_attention_fwd_partition(
     scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
-    is_training, mesh, arg_shapes, result_shape):
+    score_mod, is_training, mesh, arg_shapes, result_shape):
   # args sharding
   arg_shardings = tuple(arg_i.sharding for arg_i in arg_shapes)
   out_shardings = _infer_fwd_output_sharding(
@@ -1017,6 +1113,7 @@ def _dot_product_attention_fwd_partition(
       mask_type=mask_type,
       layout=layout,
       sliding_window_length=sliding_window_length,
+      score_mod=score_mod,
       is_training=is_training,
   )
   return mesh, impl, out_shardings, arg_shardings
@@ -1056,12 +1153,22 @@ def _bwd_shardy_rule(num_args, has_dbias, is_fp8):
   return SdyShardingRule(input_sharding, output_sharding)
 
 _dot_product_attention_bwd_lower = custom_partitioning(
-    _dot_product_attention_bwd_impl, static_argnums=(13, 14, 15, 16, 17, 18, 19)
+    _dot_product_attention_bwd_impl, static_argnums=(14, 15, 16, 17, 18, 19, 20, 21)
 )
+
+def _dot_product_attention_bwd_lower_wrapper(
+    query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
+    page_table_k, page_table_v, activation, fwd_output, grad_output,
+    *score_mod_args, scale, seed, dropout_rate, variadic_args, mask_type,
+    layout, sliding_window_length, score_mod):
+  return _dot_product_attention_bwd_lower(query, key, value, bias, q_seqlen,
+    kv_seqlen, q_offsets, kv_offsets, page_table_k, page_table_v, activation,
+    fwd_output, grad_output, score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length, score_mod)
 
 def _dot_product_attention_bwd_infer_sharding_from_operands(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, mesh, arg_shapes, result_shape):
+    sliding_window_length, score_mod, mesh, arg_shapes, result_shape):
   return _infer_bwd_output_sharding(mesh, arg_shapes, layout, variadic_args)
 
 def _dot_product_attention_bwd_shardy_rule(
@@ -1072,7 +1179,7 @@ def _dot_product_attention_bwd_shardy_rule(
 
 def _dot_product_attention_bwd_partition(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, mesh, arg_shapes, result_shape):
+    sliding_window_length, score_mod, mesh, arg_shapes, result_shape):
   out_shardings = _infer_bwd_output_sharding(mesh, arg_shapes, layout, variadic_args)
   # args sharding
   arg_shardings = [arg_i.sharding for arg_i in arg_shapes]
@@ -1098,6 +1205,7 @@ def _dot_product_attention_bwd_partition(
       mask_type=mask_type,
       layout=layout,
       sliding_window_length=sliding_window_length,
+      score_mod=score_mod,
     )
     grads = impl(*args)
     _, has_dbias = variadic_args
@@ -1184,7 +1292,7 @@ _dot_product_attention_fwd_lower.def_partition(
   sharding_rule=_dot_product_attention_fwd_shardy_rule)
 
 mlir.register_lowering(_dot_product_attention_fwd_p_wrapper,
-                        mlir.lower_fun(_dot_product_attention_fwd_lower, multiple_results=True))
+                        mlir.lower_fun(_dot_product_attention_fwd_lower_wrapper, multiple_results=True))
 
 _dot_product_attention_bwd_lower.def_partition(
   infer_sharding_from_operands=_dot_product_attention_bwd_infer_sharding_from_operands,
@@ -1192,7 +1300,7 @@ _dot_product_attention_bwd_lower.def_partition(
   sharding_rule=_dot_product_attention_bwd_shardy_rule)
 
 mlir.register_lowering(_dot_product_attention_bwd_p_wrapper,
-                        mlir.lower_fun(_dot_product_attention_bwd_lower, multiple_results=True))
+                        mlir.lower_fun(_dot_product_attention_bwd_lower_wrapper, multiple_results=True))
 
 dispatch.prim_requires_devices_during_lowering.add(
   _dot_product_attention_fwd_p
@@ -1207,7 +1315,7 @@ dispatch.prim_requires_devices_during_lowering.add(
   _dot_product_attention_bwd_p_wrapper
 )
 
-@functools.partial(custom_derivatives.custom_vjp, nondiff_argnums=(10, 11, 12, 13, 14, 15, 16, 17, 18))
+@functools.partial(custom_derivatives.custom_vjp, nondiff_argnums=(11, 12, 13, 14, 15, 16, 17, 18, 19, 20))
 def _dot_product_attention(query: Array,
                            key: Array,
                            value: Array,
@@ -1218,6 +1326,7 @@ def _dot_product_attention(query: Array,
                            kv_offsets: Array,
                            page_table_k: Array,
                            page_table_v: Array,
+                           score_mod_args: Tuple[Array] | None,
                            scale: float,
                            seed: int,
                            dropout_rate: float,
@@ -1225,14 +1334,16 @@ def _dot_product_attention(query: Array,
                            mask_type: bool,
                            layout: int,
                            sliding_window_length: int | None,
+                           score_mod,
                            cudnn_version: int,
                            return_residual: bool):
   output = _dot_product_attention_fwd(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length,
-      cudnn_version=cudnn_version, return_residual=return_residual)
+      page_table_k, page_table_v, score_mod_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      score_mod=score_mod, cudnn_version=cudnn_version,
+      return_residual=return_residual)
   return output
 
 _dot_product_attention.defvjp(
@@ -1942,6 +2053,7 @@ def dot_product_attention(
     q_offsets: Array | None = None,
     kv_offsets: Array | None = None,
     fp8_params: FP8Params | None = None,
+    score_mod_args: Tuple[Array] = (),
     *,
     scale: float = 1.0,
     mask_type: MaskType = MaskType.NO_MASK,
@@ -1949,6 +2061,7 @@ def dot_product_attention(
     dropout_rate: float = 0.,
     qkv_layout: str = "BTNH",
     sliding_window_length: int | None = None,
+    score_mod: Callable[[Array], Array] | None = None,
     use_fp8: bool = False,
     return_residual: bool = False
 ):
@@ -2048,6 +2161,14 @@ def dot_product_attention(
       raise ValueError("Require q_seqlen and kv_seqlen to use packed layout")
 
     bias = combine_bias_and_mask(bias, mask, query.dtype)
+
+    # check if the number of arg matches
+    if score_mod is not None:
+      num_args_required = len(inspect.signature(score_mod).parameters) -1
+      if num_args_required != len(score_mod_args):
+        raise ValueError(
+          f"score_mod requires {num_args_required} arguments, got {len(score_mod_args)}.")
+
     # check if input shape and data type is compatiable
     check_layout(query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       None, None, layout)
@@ -2070,7 +2191,7 @@ def dot_product_attention(
 
     output = _dot_product_attention(
         query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-        _not_used, _not_used, scale, seed, dropout_rate, variadic_args,
-        mask_type, layout.value, sliding_window_length, cudnn_version,
-        return_residual)
+        _not_used, _not_used, score_mod_args, scale, seed, dropout_rate, variadic_args,
+        mask_type, layout.value, sliding_window_length, score_mod,
+        cudnn_version, return_residual)
     return output

--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -2095,6 +2095,7 @@ def dot_product_attention(
       E.g, if 2 batches has 3 and 2 segments respectively, each segment has
       size 1, kv_offsets = [[0,1,2,-1], [0,1,-1,-1]]. kv_seqlen should be set
       to indicate the size of each segment.
+    score_mod_args: A list of args passed to score_mod.
     scale: Scale for the query.
     dropout_rate: Dropout rate.
     qkv_layout: Layout string, with supported formats being BTNH, BNTH, BSNH,
@@ -2104,6 +2105,8 @@ def dot_product_attention(
       is the index of each token. E.g., if sliding_window_length == 3 and the
       sequence is [0, 1, 2, 3, c, 4, 5], token `c` can attend to [4, 5, c].
     use_fp8: Whether to use FP8 attention mechanism.
+    score_mod: A callback function to modify attention score. The first argument
+      should always be the attention score.
     return_residual: Whether to return the logsumexp tensor of shape BTN
       or BNT to users. See section 3.1.1 in the FlashAttention-2 paper:
       https://arxiv.org/pdf/2307.08691 to find the definition of logsumexp.

--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -16,7 +16,7 @@ import enum
 import functools
 import json
 import math
-from typing import TypedDict
+from typing import Callable, Tuple, TypedDict
 
 from jax._src import core
 from jax._src import custom_derivatives
@@ -24,8 +24,9 @@ from jax._src import dispatch
 from jax._src import dtypes
 from jax._src import numpy as jnp
 from jax._src import xla_bridge
+from jax._src.api import make_jaxpr, vjp
 from jax._src.custom_partitioning import custom_partitioning
-from jax._src.custom_partitioning_sharding_rule import BATCHING, ArrayMapping, CompoundFactor, SdyShardingRule
+from jax._src.custom_partitioning_sharding_rule import ArrayMapping, BATCHING, CompoundFactor, SdyShardingRule
 from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
 from jax._src.lax import parallel as lax_parallel
@@ -69,7 +70,6 @@ class MaskType(enum.Enum):
   CAUSAL = 2
   PADDING_CAUSAL = 3
   ALIBI = 4
-
 
 def convert_mask_type_to_string(mask_type: MaskType) -> str:
   if mask_type == MaskType.NO_MASK:
@@ -425,18 +425,19 @@ def is_cuda_compute_capability_equal(capability):
 
 def _dot_product_attention_fwd(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v,
-    scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, cudnn_version, return_residual):
+    page_table_k, page_table_v, score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length, score_mod,
+    cudnn_version, return_residual):
   # check if flash attention is supported for this attention pattern
   check_is_flash_attention(
       query, key, value, layout, cudnn_version, bias is not None, False,
       get_max_seg_per_batch(q_offsets) > 1, check_is_paged_attention(page_table_k))
   outputs = _dot_product_attention_fwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length, is_training=False or return_residual)
+      page_table_k, page_table_v, *score_mod_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      score_mod=score_mod, is_training=False or return_residual)
   if return_residual:
     return tuple(outputs)
   else:
@@ -444,20 +445,21 @@ def _dot_product_attention_fwd(
 
 def _dot_product_attention_fwd_rule(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, cudnn_version,
-    return_residual):
+    page_table_k, page_table_v, score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length,
+    score_mod, cudnn_version, return_residual):
   # check if flash attention is supported for this attention pattern
   check_is_flash_attention(
       query, key, value, layout, cudnn_version, bias is not None, True,
       get_max_seg_per_batch(q_offsets) > 1)
   outputs = _dot_product_attention_fwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length, is_training=True)
+      page_table_k, page_table_v, *score_mod_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      score_mod=score_mod, is_training=True)
   res = (query, key, value, bias, q_seqlen, kv_seqlen, q_offsets,
-         kv_offsets, page_table_k, page_table_v, outputs[1], outputs[0])
+         kv_offsets, page_table_k, page_table_v, score_mod_args, outputs[1], outputs[0])
   if return_residual:
     return tuple(outputs), res
   else:
@@ -465,19 +467,21 @@ def _dot_product_attention_fwd_rule(
 
 def _dot_product_attention_bwd_rule(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, is_training, return_residual, res, grad_output):
+    sliding_window_length, score_mod, cudnn_version, return_residual, res,
+    grad_output):
   (query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-   page_table_k, page_table_v, activation, fwd_output) = res
+   page_table_k, page_table_v, score_mod_args, activation, fwd_output) = res
   if return_residual:
     grad_output = grad_output[0]
   grads = _dot_product_attention_bwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       page_table_k, page_table_v, activation, fwd_output, grad_output,
-      scale=scale, seed=seed, dropout_rate=dropout_rate, variadic_args=variadic_args,
-      mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length
+      *score_mod_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
+      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
+      sliding_window_length=sliding_window_length,
+      score_mod=score_mod
   )
-  grads = (*grads,) + (None,) * (10 - len(grads))
+  grads = (*grads,) + (None,) * (11 - len(grads))
   return grads
 
 def _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key):
@@ -536,37 +540,73 @@ def _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key):
 
 def _dot_product_attention_fwd_impl(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, is_training):
+    page_table_k, page_table_v, score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length,
+    score_mod, is_training):
   # args: {Q, K, V, mask*, bias*}
+  score_mod_name = None
+  score_mod_jaxpr = None
+  if score_mod is not None:
+    if layout == AttentionLayout.BNTH.value:
+      B, N, T, _ = query.shape
+      _, _, S, _ = key.shape
+    else:
+      B, T, N, _ = query.shape
+      _, S, _, _ = key.shape
+    attn_score = core.ShapedArray((B, N, T, S), np.float32)
+    score_mod_jaxpr = make_jaxpr(score_mod)(attn_score, *score_mod_args)
+    score_mod_name = score_mod.__name__
   q_seqlen, kv_seqlen, q_offsets, kv_offsets = \
       _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key)
   outputs = _dot_product_attention_fwd_p.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length, is_training=is_training)
+      page_table_k, page_table_v, *score_mod_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      score_mod_name=score_mod_name, score_mod_jaxpr=score_mod_jaxpr,
+      is_training=is_training)
   return outputs
 
 def _dot_product_attention_bwd_impl(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, activation, fwd_output, grad_output, scale,
-    seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length):
+    page_table_k, page_table_v, activation, fwd_output, grad_output, score_mod_args,
+    scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
+    score_mod):
+  score_mod_name = None
+  score_mod_jaxpr = None
+  if score_mod is not None:
+    if layout == AttentionLayout.BNTH.value:
+      B, N, T, _ = query.shape
+      _, _, S, _ = key.shape
+    else:
+      B, T, N, _ = query.shape
+      _, S, _, _ = key.shape
+
+    attn_score = core.ShapedArray((B, N, T, S), np.float32)
+    grad = core.ShapedArray((B, N, T, S), np.float32)
+
+    def wrapped_func(grad, *args):
+      _, grad_score_mod = vjp(score_mod, *args)
+      return grad_score_mod(grad)[0]
+
+    score_mod_jaxpr = make_jaxpr(wrapped_func)(grad, attn_score, *score_mod_args)
+    score_mod_name = score_mod.__name__ + "_bwd"
   q_seqlen, kv_seqlen, q_offsets, kv_offsets = \
       _fix_seqlen_offsets(q_seqlen, kv_seqlen, q_offsets, kv_offsets, query, key)
   grads = _dot_product_attention_bwd_p.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       page_table_k, page_table_v, activation, fwd_output, grad_output,
-      scale=scale, seed=seed,
-      dropout_rate=dropout_rate, variadic_args=variadic_args,
-      mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length)
+      *score_mod_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
+      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
+      sliding_window_length=sliding_window_length,
+      score_mod_name=score_mod_name, score_mod_jaxpr=score_mod_jaxpr)
   return grads
 
 def _dot_product_attention_fwd_abstract(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, *, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, is_training):
+    page_table_k, page_table_v, *score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length, is_training,
+    **_):
   if layout == AttentionLayout.BNTH.value:
     B, N, T, _ = query.shape
     _, _, S, H = value.shape
@@ -591,8 +631,9 @@ def _dot_product_attention_fwd_abstract(
 
 def _dot_product_attention_bwd_abstract(
     query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, activation, fwd_output, grad_output, *,
-    scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length):
+    page_table_k, page_table_v, activation, fwd_output, grad_output,
+    *score_mod_args, scale, seed, dropout_rate, variadic_args, mask_type,
+    layout, sliding_window_length, **_):
   _, has_dbias = variadic_args
   if has_dbias:
     # cuDNN supports bias for this case
@@ -625,8 +666,9 @@ def _dot_product_attention_bwd_abstract(
 
 def _dot_product_attention_fwd_cuda_lowering(
     ctx, query, key, value, bias, q_seqlen, kv_seqlen, q_offsets,
-    kv_offsets, page_table_k, page_table_v, scale, seed, dropout_rate,
-    variadic_args, mask_type, layout, sliding_window_length, is_training):
+    kv_offsets, page_table_k, page_table_v, *score_mod_args, scale, seed,
+    dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
+    score_mod_name, score_mod_jaxpr, is_training):
   query_type = ir.RankedTensorType(query.type)
   query_shape = query_type.shape
   value_type = ir.RankedTensorType(value.type)
@@ -656,7 +698,7 @@ def _dot_product_attention_fwd_cuda_lowering(
       B, N, T, S, query_type.element_type, scale, seed, dropout_rate,
       mask_type, layout, sliding_window_length, max_seg_per_batch,
       is_paged_attention, is_bwd=False)
-  # {Q, K, V, bias*, q_seqlen*, kv_seqlen*,  q_offsets*, kv_offsets*}}
+  # {Q, K, V, bias*, q_seqlen*, kv_seqlen*, q_offsets*, kv_offsets*, score_mod_args*}
   # {output, activation*, workspace}
   has_dropout = dropout_rate > 0
   operands = [query, key, value]
@@ -672,6 +714,14 @@ def _dot_product_attention_fwd_cuda_lowering(
     operands.append(page_table_k)
     operands.append(page_table_v)
 
+  if score_mod_jaxpr is not None:
+    operands += score_mod_args
+    func_op = mlir.lower_jaxpr_to_fun(
+        ctx.module_context, score_mod_name, score_mod_jaxpr,
+        effects=[], num_const_args=0, in_avals=score_mod_jaxpr.in_avals)
+    called_computations = [func_op.sym_name.value]
+  else:
+    called_computations = []
   custom_call_name = get_custom_call_name(has_bias, has_dropout, False)
 
   if is_training:
@@ -696,6 +746,7 @@ def _dot_product_attention_fwd_cuda_lowering(
     operand_layouts=default_layouts(
       *[ir.RankedTensorType(operand.type).shape for operand in operands]),
     result_layouts=result_layouts,
+    called_computations=called_computations,
   )
   # drop workspace memory
   # output should be (B, T, N, H) instead of (B, N, T, H)
@@ -706,8 +757,9 @@ def _dot_product_attention_fwd_cuda_lowering(
 
 def _dot_product_attention_bwd_cuda_lowering(
     ctx, query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-    page_table_k, page_table_v, activation, fwd_output, grad_output,
-    scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length):
+    page_table_k, page_table_v, activation, fwd_output, grad_output, *score_mod_args,
+    scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
+    score_mod_name, score_mod_jaxpr):
   query_type = ir.RankedTensorType(query.type)
   query_shape = query_type.shape
   key_type = ir.RankedTensorType(key.type)
@@ -739,7 +791,7 @@ def _dot_product_attention_bwd_cuda_lowering(
       mask_type, layout, sliding_window_length, max_seg_per_batch,
       False, is_bwd=True)
   # {Q, K, V, activation, dO, bias*, O, q_seqlen*, kv_seqlen*,
-  #  q_offsets*, kv_offsets*}
+  #  q_offsets*, kv_offsets*, score_mod_args*}
   # {dQ, dK, dV, dbias*, workspace}
   has_dropout = dropout_rate > 0
   # create operands
@@ -754,6 +806,15 @@ def _dot_product_attention_bwd_cuda_lowering(
   if max_seg_per_batch > 1:
     operands.append(q_offsets)
     operands.append(kv_offsets)
+
+  if score_mod_jaxpr is not None:
+    operands += score_mod_args
+    func_op = mlir.lower_jaxpr_to_fun(
+        ctx.module_context, score_mod_name, score_mod_jaxpr,
+        effects=[], num_const_args=0, in_avals=score_mod_jaxpr.in_avals)
+    called_computations = [func_op.sym_name.value]
+  else:
+    called_computations = []
   # get custom call name
   custom_call_name = get_custom_call_name(has_bias, has_dropout, True)
 
@@ -783,6 +844,7 @@ def _dot_product_attention_bwd_cuda_lowering(
     operand_layouts=default_layouts(
       *[ir.RankedTensorType(operand.type).shape for operand in operands]),
     result_layouts=result_layouts,
+    called_computations=called_computations,
   )
   dqkv = (hlo.transpose(out.results[0], grad_transpose_perm),
           hlo.transpose(out.results[1], grad_transpose_perm),
@@ -802,10 +864,14 @@ def _check_valid_batch_dims(bdims):
 
 def _dot_product_attention_fwd_batcher(
     batched_args, batch_dims, *, scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, is_training):
+    mask_type, layout, sliding_window_length, score_mod, is_training):
   _check_valid_batch_dims(batch_dims)
+  # The primitive takes the score_mod_args operands variadically, so the
+  # batched args after page_table_v are the score_mod_args entries (possibly
+  # none).
   query, key, value, bias, q_seqlen, kv_seqlen, \
-    q_offsets, kv_offsets, page_table_k, page_table_v = batched_args
+    q_offsets, kv_offsets, page_table_k, page_table_v = batched_args[:10]
+  score_mod_args = batched_args[10:]
   query_bdim = batch_dims[0]
   if is_training:
     out_bdims = query_bdim, query_bdim
@@ -833,9 +899,10 @@ def _dot_product_attention_fwd_batcher(
 
   outputs = _dot_product_attention_fwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length, is_training=is_training)
+      page_table_k, page_table_v, *score_mod_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      score_mod=score_mod, is_training=is_training)
 
   # reshape to original shape
   output = outputs[0]
@@ -849,10 +916,14 @@ def _dot_product_attention_fwd_batcher(
 
 def _dot_product_attention_bwd_batcher(
      batched_args, batch_dims, *, scale, seed, dropout_rate, variadic_args,
-     mask_type, layout, sliding_window_length):
+     mask_type, layout, sliding_window_length, score_mod):
   _check_valid_batch_dims(batch_dims)
+  # The primitive bind order is the 10 fixed operands, then activation,
+  # fwd_output, grad_output, then the variadic *score_mod_args entries.
   query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets, \
-    page_table_k, page_table_v, activation, fwd_output, grad_output = batched_args
+    page_table_k, page_table_v = batched_args[:10]
+  activation, fwd_output, grad_output = batched_args[10:13]
+  score_mod_args = batched_args[13:]
   query_bdim = batch_dims[0]
   out_bdims = query_bdim, query_bdim, query_bdim
 
@@ -885,9 +956,10 @@ def _dot_product_attention_bwd_batcher(
   grads = _dot_product_attention_bwd_p_wrapper.bind(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       page_table_k, page_table_v, activation, fwd_output, grad_output,
-      scale=scale, seed=seed, dropout_rate=dropout_rate, variadic_args=variadic_args,
-      mask_type=mask_type, layout=layout,
+      *score_mod_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
+      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
       sliding_window_length=sliding_window_length,
+      score_mod=score_mod,
   )
 
   # reshape to original shape
@@ -989,23 +1061,42 @@ def _fwd_shardy_rule(value_types, result_types, layout, is_training, is_fp8):
   return SdyShardingRule(tuple(input_sharding), output_sharding, **factor_sizes)
 
 _dot_product_attention_fwd_lower = custom_partitioning(
-    _dot_product_attention_fwd_impl, static_argnums=(10, 11, 12, 13, 14, 15, 16, 17))
+    _dot_product_attention_fwd_impl, static_argnums=(11, 12, 13, 14, 15, 16, 17, 18, 19))
+
+def _dot_product_attention_fwd_lower_wrapper(
+    query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
+    page_table_k, page_table_v, *score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length, score_mod,
+    is_training):
+  return _dot_product_attention_fwd_lower(query, key, value, bias, q_seqlen,
+    kv_seqlen, q_offsets, kv_offsets, page_table_k, page_table_v,
+    score_mod_args, scale, seed, dropout_rate, variadic_args, mask_type, layout,
+    sliding_window_length, score_mod, is_training)
 
 def _dot_product_attention_fwd_infer_sharding_from_operands(
     scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
-    is_training, mesh, arg_shapes, result_shape):
+    score_mod, is_training, mesh, arg_shapes, result_shape):
   return _infer_fwd_output_sharding(mesh, arg_shapes, variadic_args, is_training, layout)
 
 def _dot_product_attention_fwd_shardy_rule(
     scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
-    is_training, mesh, value_types, result_types):
+    score_mod, is_training, mesh, value_types, result_types):
   return _fwd_shardy_rule(value_types, result_types, layout, is_training, is_fp8=False)
+
+def _get_arg_sharding(arg):
+  # arg_shapes from custom_partitioning is the unflattened input pytree, so
+  # entries that came in as nested tuples (e.g. score_mod_args) appear as
+  # tuples here. Recurse to preserve the structure expected when the framework
+  # re-flattens the returned arg_shardings.
+  if isinstance(arg, tuple):
+    return tuple(_get_arg_sharding(a) for a in arg)
+  return arg.sharding
 
 def _dot_product_attention_fwd_partition(
     scale, seed, dropout_rate, variadic_args, mask_type, layout, sliding_window_length,
-    is_training, mesh, arg_shapes, result_shape):
+    score_mod, is_training, mesh, arg_shapes, result_shape):
   # args sharding
-  arg_shardings = tuple(arg_i.sharding for arg_i in arg_shapes)
+  arg_shardings = tuple(_get_arg_sharding(arg_i) for arg_i in arg_shapes)
   out_shardings = _infer_fwd_output_sharding(
     mesh, arg_shapes, variadic_args, is_training, layout)
   impl = functools.partial(
@@ -1017,6 +1108,7 @@ def _dot_product_attention_fwd_partition(
       mask_type=mask_type,
       layout=layout,
       sliding_window_length=sliding_window_length,
+      score_mod=score_mod,
       is_training=is_training,
   )
   return mesh, impl, out_shardings, arg_shardings
@@ -1056,26 +1148,36 @@ def _bwd_shardy_rule(num_args, has_dbias, is_fp8):
   return SdyShardingRule(input_sharding, output_sharding)
 
 _dot_product_attention_bwd_lower = custom_partitioning(
-    _dot_product_attention_bwd_impl, static_argnums=(13, 14, 15, 16, 17, 18, 19)
+    _dot_product_attention_bwd_impl, static_argnums=(14, 15, 16, 17, 18, 19, 20, 21)
 )
+
+def _dot_product_attention_bwd_lower_wrapper(
+    query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
+    page_table_k, page_table_v, activation, fwd_output, grad_output,
+    *score_mod_args, scale, seed, dropout_rate, variadic_args, mask_type,
+    layout, sliding_window_length, score_mod):
+  return _dot_product_attention_bwd_lower(query, key, value, bias, q_seqlen,
+    kv_seqlen, q_offsets, kv_offsets, page_table_k, page_table_v, activation,
+    fwd_output, grad_output, score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length, score_mod)
 
 def _dot_product_attention_bwd_infer_sharding_from_operands(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, mesh, arg_shapes, result_shape):
+    sliding_window_length, score_mod, mesh, arg_shapes, result_shape):
   return _infer_bwd_output_sharding(mesh, arg_shapes, layout, variadic_args)
 
 def _dot_product_attention_bwd_shardy_rule(
     scale, seed, dropout_rate, variadic_args,
-    mask_type, layout, sliding_window_length, mesh, value_types, result_types):
+    mask_type, layout, sliding_window_length, score_mod, mesh, value_types, result_types):
   _, has_dbias = variadic_args
   return _bwd_shardy_rule(len(value_types), has_dbias, is_fp8=False)
 
 def _dot_product_attention_bwd_partition(
     scale, seed, dropout_rate, variadic_args, mask_type, layout,
-    sliding_window_length, mesh, arg_shapes, result_shape):
+    sliding_window_length, score_mod, mesh, arg_shapes, result_shape):
   out_shardings = _infer_bwd_output_sharding(mesh, arg_shapes, layout, variadic_args)
   # args sharding
-  arg_shardings = [arg_i.sharding for arg_i in arg_shapes]
+  arg_shardings = [_get_arg_sharding(arg_i) for arg_i in arg_shapes]
   # grad_output (index 12) may be inferred as replicated (e.g. when it
   # originates from a broadcast in jnp.sum's backward pass). The cuDNN
   # backward custom-call is lowered with batch size B taken from the
@@ -1098,6 +1200,7 @@ def _dot_product_attention_bwd_partition(
       mask_type=mask_type,
       layout=layout,
       sliding_window_length=sliding_window_length,
+      score_mod=score_mod,
     )
     grads = impl(*args)
     _, has_dbias = variadic_args
@@ -1141,7 +1244,23 @@ _dot_product_attention_fwd_p_wrapper = core.Primitive(
     "dot_product_attention_fwd_wrapper"
 )
 _dot_product_attention_fwd_p_wrapper.multiple_results = True
-_dot_product_attention_fwd_p_wrapper.def_impl(_dot_product_attention_fwd_impl)
+def _dot_product_attention_fwd_impl_wrapper(
+    query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
+    page_table_k, page_table_v, *score_mod_args, scale, seed, dropout_rate,
+    variadic_args, mask_type, layout, sliding_window_length, score_mod,
+    is_training):
+  # The wrapper primitive is bound with score_mod_args spread positionally, so
+  # re-pack them into a tuple to match _dot_product_attention_fwd_impl's
+  # signature (analogous to _dot_product_attention_fwd_lower_wrapper).
+  return _dot_product_attention_fwd_impl(
+      query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
+      page_table_k, page_table_v, score_mod_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args,
+      mask_type=mask_type, layout=layout,
+      sliding_window_length=sliding_window_length, score_mod=score_mod,
+      is_training=is_training)
+_dot_product_attention_fwd_p_wrapper.def_impl(
+    _dot_product_attention_fwd_impl_wrapper)
 _dot_product_attention_fwd_p_wrapper.def_abstract_eval(
     _dot_product_attention_fwd_abstract
 )
@@ -1166,7 +1285,22 @@ _dot_product_attention_bwd_p_wrapper = core.Primitive(
     "dot_product_attention_bwd_wrapper"
 )
 _dot_product_attention_bwd_p_wrapper.multiple_results = True
-_dot_product_attention_bwd_p_wrapper.def_impl(_dot_product_attention_bwd_impl)
+def _dot_product_attention_bwd_impl_wrapper(
+    query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
+    page_table_k, page_table_v, activation, fwd_output, grad_output,
+    *score_mod_args, scale, seed, dropout_rate, variadic_args, mask_type,
+    layout, sliding_window_length, score_mod):
+  # The wrapper primitive is bound with score_mod_args spread positionally, so
+  # re-pack them into a tuple to match _dot_product_attention_bwd_impl's
+  # signature (analogous to _dot_product_attention_bwd_lower_wrapper).
+  return _dot_product_attention_bwd_impl(
+      query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
+      page_table_k, page_table_v, activation, fwd_output, grad_output,
+      score_mod_args, scale=scale, seed=seed, dropout_rate=dropout_rate,
+      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
+      sliding_window_length=sliding_window_length, score_mod=score_mod)
+_dot_product_attention_bwd_p_wrapper.def_impl(
+    _dot_product_attention_bwd_impl_wrapper)
 _dot_product_attention_bwd_p_wrapper.def_abstract_eval(
     _dot_product_attention_bwd_abstract
 )
@@ -1184,7 +1318,7 @@ _dot_product_attention_fwd_lower.def_partition(
   sharding_rule=_dot_product_attention_fwd_shardy_rule)
 
 mlir.register_lowering(_dot_product_attention_fwd_p_wrapper,
-                        mlir.lower_fun(_dot_product_attention_fwd_lower, multiple_results=True))
+                        mlir.lower_fun(_dot_product_attention_fwd_lower_wrapper, multiple_results=True))
 
 _dot_product_attention_bwd_lower.def_partition(
   infer_sharding_from_operands=_dot_product_attention_bwd_infer_sharding_from_operands,
@@ -1192,7 +1326,7 @@ _dot_product_attention_bwd_lower.def_partition(
   sharding_rule=_dot_product_attention_bwd_shardy_rule)
 
 mlir.register_lowering(_dot_product_attention_bwd_p_wrapper,
-                        mlir.lower_fun(_dot_product_attention_bwd_lower, multiple_results=True))
+                        mlir.lower_fun(_dot_product_attention_bwd_lower_wrapper, multiple_results=True))
 
 dispatch.prim_requires_devices_during_lowering.add(
   _dot_product_attention_fwd_p
@@ -1207,7 +1341,7 @@ dispatch.prim_requires_devices_during_lowering.add(
   _dot_product_attention_bwd_p_wrapper
 )
 
-@functools.partial(custom_derivatives.custom_vjp, nondiff_argnums=(10, 11, 12, 13, 14, 15, 16, 17, 18))
+@functools.partial(custom_derivatives.custom_vjp, nondiff_argnums=(11, 12, 13, 14, 15, 16, 17, 18, 19, 20))
 def _dot_product_attention(query: Array,
                            key: Array,
                            value: Array,
@@ -1218,6 +1352,7 @@ def _dot_product_attention(query: Array,
                            kv_offsets: Array,
                            page_table_k: Array,
                            page_table_v: Array,
+                           score_mod_args: Tuple[Array, ...],
                            scale: float,
                            seed: int,
                            dropout_rate: float,
@@ -1225,14 +1360,16 @@ def _dot_product_attention(query: Array,
                            mask_type: bool,
                            layout: int,
                            sliding_window_length: int | None,
+                           score_mod: Callable[[Array], Array] | None,
                            cudnn_version: int,
                            return_residual: bool):
   output = _dot_product_attention_fwd(
       query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-      page_table_k, page_table_v, scale=scale, seed=seed, dropout_rate=dropout_rate,
-      variadic_args=variadic_args, mask_type=mask_type, layout=layout,
-      sliding_window_length=sliding_window_length,
-      cudnn_version=cudnn_version, return_residual=return_residual)
+      page_table_k, page_table_v, score_mod_args, scale=scale, seed=seed,
+      dropout_rate=dropout_rate, variadic_args=variadic_args, mask_type=mask_type,
+      layout=layout, sliding_window_length=sliding_window_length,
+      score_mod=score_mod, cudnn_version=cudnn_version,
+      return_residual=return_residual)
   return output
 
 _dot_product_attention.defvjp(
@@ -1925,8 +2062,8 @@ def paged_attention(
 
   output = _dot_product_attention(
       query, key, value, bias, q_seqlen, kv_seqlen, _not_used, _not_used,
-      page_table_k, page_table_v, scale, seed, dropout_rate, variadic_args,
-      mask_type, layout.value, sliding_window_length, cudnn_version,
+      page_table_k, page_table_v, (), scale, seed, dropout_rate, variadic_args,
+      mask_type, layout.value, sliding_window_length, None, cudnn_version,
       return_residual)
   return output
 
@@ -1942,6 +2079,7 @@ def dot_product_attention(
     q_offsets: Array | None = None,
     kv_offsets: Array | None = None,
     fp8_params: FP8Params | None = None,
+    score_mod_args: Tuple[Array, ...] = (),
     *,
     scale: float = 1.0,
     mask_type: MaskType = MaskType.NO_MASK,
@@ -1949,6 +2087,7 @@ def dot_product_attention(
     dropout_rate: float = 0.,
     qkv_layout: str = "BTNH",
     sliding_window_length: int | None = None,
+    score_mod: Callable[[Array], Array] | None = None,
     use_fp8: bool = False,
     return_residual: bool = False
 ):
@@ -1997,6 +2136,7 @@ def dot_product_attention(
       E.g, if 2 batches has 3 and 2 segments respectively, each segment has
       size 1, kv_offsets = [[0,1,2,-1], [0,1,-1,-1]]. kv_seqlen should be set
       to indicate the size of each segment.
+    score_mod_args: A list of args passed to score_mod.
     scale: Scale for the query.
     dropout_rate: Dropout rate.
     qkv_layout: Layout string, with supported formats being BTNH, BNTH, BSNH,
@@ -2006,6 +2146,9 @@ def dot_product_attention(
       is the index of each token. E.g., if sliding_window_length == 3 and the
       sequence is [0, 1, 2, 3, c, 4, 5], token `c` can attend to [4, 5, c].
     use_fp8: Whether to use FP8 attention mechanism.
+    score_mod: A callback function to modify the attention score after adding
+      the bias to the logits and before the softmax. It will be called with
+      arguments (attention_score, *score_mod_args).
     return_residual: Whether to return the logsumexp tensor of shape BTN
       or BNT to users. See section 3.1.1 in the FlashAttention-2 paper:
       https://arxiv.org/pdf/2307.08691 to find the definition of logsumexp.
@@ -2046,8 +2189,12 @@ def dot_product_attention(
         f"Require sliding_window_length > 0, got {sliding_window_length}")
     if q_offsets is not None and (q_seqlen is None or kv_seqlen is None):
       raise ValueError("Require q_seqlen and kv_seqlen to use packed layout")
+    if score_mod is None and score_mod_args:
+      raise ValueError(
+        "score_mod_args must not be provided when score_mod is None.")
 
     bias = combine_bias_and_mask(bias, mask, query.dtype)
+
     # check if input shape and data type is compatiable
     check_layout(query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
       None, None, layout)
@@ -2070,7 +2217,7 @@ def dot_product_attention(
 
     output = _dot_product_attention(
         query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
-        _not_used, _not_used, scale, seed, dropout_rate, variadic_args,
-        mask_type, layout.value, sliding_window_length, cudnn_version,
-        return_residual)
+        _not_used, _not_used, score_mod_args, scale, seed, dropout_rate, variadic_args,
+        mask_type, layout.value, sliding_window_length, score_mod,
+        cudnn_version, return_residual)
     return output

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -14,6 +14,10 @@
 
 from functools import partial
 from absl.testing import absltest
+import os
+
+os.environ["XLA_FLAGS"] = \
+  "--xla_dump_to=./hlo --xla_dump_hlo_as_text"
 
 import numpy as np
 import jax
@@ -28,6 +32,7 @@ from jax._src.cudnn.fused_attention_stablehlo import (
     check_cudnn_version,
     MaskType,
 )
+from typing import Callable, Tuple
 
 config.parse_flags_with_absl()
 Array = jnp.ndarray
@@ -97,11 +102,13 @@ def sdpa_train(query: Array,
                kv_seqlen: Array | None = None,
                q_offsets: Array | None = None,
                kv_offsets: Array | None = None,
+               score_mod_args: Tuple[Array] = (),
                scale: float = 0.5,
                mask_type: MaskType = MaskType.NO_MASK,
                is_bnth: bool = False,
                dropout_rate: float = 0.1,
-               sliding_window_length: int | None = None) -> Array:
+               sliding_window_length: int | None = None,
+               score_mod = None) -> Array:
   if mask_type == MaskType.PADDING:
     if is_bnth:
       B, _, S, _ = query.shape
@@ -112,8 +119,10 @@ def sdpa_train(query: Array,
       partial(dot_product_attention, scale=scale, mask_type=mask_type,
               dropout_rate=dropout_rate,
               qkv_layout="BNTH" if is_bnth else "BTNH",
-              sliding_window_length=sliding_window_length),
-      query, key, value, bias, mask, q_seqlen, kv_seqlen, q_offsets, kv_offsets)
+              sliding_window_length=sliding_window_length,
+              score_mod=score_mod),
+      query, key, value, bias, mask, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
+      None, score_mod_args)
   query_grad, key_grad, value_grad, bias_grad = sdpa_vjp(grad)[:4]
   if bias is not None:
     # has dbias
@@ -125,11 +134,13 @@ def sdpa_ref(query: Array,
       value: Array,
       bias: Array | None = None,
       mask: Array | None = None,
+      score_mod_args: Tuple[Array] = (),
       scale: float = 0.5,
       mask_type: MaskType = MaskType.NO_MASK,
       is_bnth: bool = False,
       dropout_rate: float = 0.1,
-      sliding_window_length: int | None = None) -> Array:
+      sliding_window_length: int | None = None,
+      score_mod = None) -> Array:
 
   def get_causal_mask(logits):
     large_negative_number = get_large_negative_number(logits.dtype)
@@ -198,6 +209,8 @@ def sdpa_ref(query: Array,
     if bias.shape != logits.shape:
       bias = jnp.broadcast_to(bias, logits.shape)
     logits = logits + bias.astype(logits.dtype)
+  if score_mod is not None:
+    logits = score_mod(logits, *score_mod_args).astype(jnp.float32)
   probs = jax.nn.softmax(logits, axis=-1).astype(query.dtype)
   if dropout_rate > 0.:
     keep_prob = 1.0 - dropout_rate
@@ -225,14 +238,17 @@ def sdpa_train_ref(query: Array,
             mask_type: MaskType = MaskType.NO_MASK,
             is_bnth: bool = False,
             dropout_rate: float = 0.1,
-            sliding_window_length: int | None = None) -> Array:
+            sliding_window_length: int | None = None,
+            score_mod = None,
+            score_mod_args = ()) -> Array:
   out_ref, sdpa_vjp_ref = jax.vjp(
     partial(
       sdpa_ref, scale=scale, mask_type=mask_type, dropout_rate=dropout_rate,
-      sliding_window_length=sliding_window_length, is_bnth=is_bnth),
-    query, key, value, bias, mask)
-  query_grad_ref, key_grad_ref, value_grad_ref, bias_grad_ref, _ = sdpa_vjp_ref(grad)
-  if bias is not None:
+      sliding_window_length=sliding_window_length, is_bnth=is_bnth,
+      score_mod=score_mod),
+    query, key, value, bias, mask, score_mod_args)
+  query_grad_ref, key_grad_ref, value_grad_ref, bias_grad_ref = sdpa_vjp_ref(grad)[:4]
+  if bias is not None and len(bias.shape) == 3:
     return out_ref, (query_grad_ref, key_grad_ref, value_grad_ref, bias_grad_ref)
   return out_ref, (query_grad_ref, key_grad_ref, value_grad_ref)
 
@@ -751,6 +767,75 @@ class DotProductAttentionTest(jtu.JaxTestCase):
       self.assertArraysAllClose(query_grad_ref, query_grad, rtol=1e-2, atol=1e-2)
       self.assertArraysAllClose(key_grad_ref, key_grad, rtol=1e-2, atol=1e-2)
       self.assertArraysAllClose(value_grad_ref, value_grad, rtol=1e-2, atol=1e-2)
+
+  def test_sdpa_flex_attention(self):
+    k1, k2, k3, k4 = jax.random.split(jax.random.key(0), 4)
+    query = jax.random.normal(
+        k1, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    key = jax.random.normal(
+        k2, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    value = jax.random.normal(
+        k3, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+
+    soft_cap_scalar = jax.random.normal(
+        k4, (4, 4, 1024, 1024), dtype=jnp.float32)
+
+    def soft_cap(attn_score, soft_cap_scalar):
+      return soft_cap_scalar * jax.lax.tanh(attn_score / soft_cap_scalar)
+
+    jitted_sdpa = jax.jit(
+      partial(
+        dot_product_attention, scale=1.0, mask_type=MaskType.NO_MASK,
+        dropout_rate=0, score_mod=soft_cap),
+    )
+
+    jitted_sdpa_ref = jax.jit(
+      partial(
+        sdpa_ref, scale=1.0, mask_type=MaskType.NO_MASK,
+        dropout_rate=0, score_mod=soft_cap),
+    )
+
+    out = jitted_sdpa(query, key, value, score_mod_args=(soft_cap_scalar,))
+    out_ref = jitted_sdpa_ref(query, key, value, score_mod_args=(soft_cap_scalar,))
+    self.assertArraysAllClose(out, out_ref, rtol=1e-2, atol=1e-2)
+
+  def test_sdpa_flex_attention_train(self):
+    k1, k2, k3, k4, k5 = jax.random.split(jax.random.key(0), 5)
+    query = jax.random.normal(
+        k1, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    key = jax.random.normal(
+        k2, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    value = jax.random.normal(
+        k3, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    grad = jax.random.normal(
+        k4, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+
+    soft_cap_scalar = jax.random.normal(
+        k5, (4, 4, 1024, 1024), dtype=jnp.float32)
+
+    def soft_cap(attn_score, soft_cap_scalar):
+      return soft_cap_scalar * jax.lax.tanh(attn_score / soft_cap_scalar)
+
+    jitted_sdpa = jax.jit(
+      partial(
+        sdpa_train, scale=1.0, mask_type=MaskType.NO_MASK,
+        dropout_rate=0, score_mod=soft_cap),
+    )
+
+    jitted_sdpa_ref = jax.jit(
+      partial(
+        sdpa_train_ref, scale=1.0, mask_type=MaskType.NO_MASK,
+        dropout_rate=0, score_mod=soft_cap),
+    )
+
+    out, (query_grad, key_grad, value_grad) = \
+      jitted_sdpa(query, key, value, grad, score_mod_args=(soft_cap_scalar,))
+    out_ref, (query_grad_ref, key_grad_ref, value_grad_ref) = \
+      jitted_sdpa_ref(query, key, value, grad, score_mod_args=(soft_cap_scalar,))
+    self.assertArraysAllClose(out_ref, out, rtol=1e-2, atol=1e-2)
+    self.assertArraysAllClose(query_grad_ref, query_grad, rtol=1e-2, atol=1e-2)
+    self.assertArraysAllClose(key_grad_ref, key_grad, rtol=1e-2, atol=1e-2)
+    self.assertArraysAllClose(value_grad_ref, value_grad, rtol=1e-2, atol=1e-2)
 
   @jtu.run_on_devices("cuda")
   def test_sdpa_residual(self):

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -14,10 +14,6 @@
 
 from functools import partial
 from absl.testing import absltest
-import os
-
-os.environ["XLA_FLAGS"] = \
-  "--xla_dump_to=./hlo --xla_dump_hlo_as_text"
 
 import numpy as np
 import jax

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -28,6 +28,7 @@ from jax._src.cudnn.fused_attention_stablehlo import (
     check_cudnn_version,
     MaskType,
 )
+from typing import Callable, Tuple
 
 config.parse_flags_with_absl()
 Array = jnp.ndarray
@@ -97,11 +98,13 @@ def sdpa_train(query: Array,
                kv_seqlen: Array | None = None,
                q_offsets: Array | None = None,
                kv_offsets: Array | None = None,
+               score_mod_args: Tuple[Array, ...] = (),
                scale: float = 0.5,
                mask_type: MaskType = MaskType.NO_MASK,
                is_bnth: bool = False,
                dropout_rate: float = 0.1,
-               sliding_window_length: int | None = None) -> Array:
+               sliding_window_length: int | None = None,
+               score_mod: Callable[[Array], Array] | None = None) -> Array:
   if mask_type == MaskType.PADDING:
     if is_bnth:
       B, _, S, _ = query.shape
@@ -112,8 +115,10 @@ def sdpa_train(query: Array,
       partial(dot_product_attention, scale=scale, mask_type=mask_type,
               dropout_rate=dropout_rate,
               qkv_layout="BNTH" if is_bnth else "BTNH",
-              sliding_window_length=sliding_window_length),
-      query, key, value, bias, mask, q_seqlen, kv_seqlen, q_offsets, kv_offsets)
+              sliding_window_length=sliding_window_length,
+              score_mod=score_mod),
+      query, key, value, bias, mask, q_seqlen, kv_seqlen, q_offsets, kv_offsets,
+      None, score_mod_args)
   query_grad, key_grad, value_grad, bias_grad = sdpa_vjp(grad)[:4]
   if bias is not None:
     # has dbias
@@ -125,11 +130,13 @@ def sdpa_ref(query: Array,
       value: Array,
       bias: Array | None = None,
       mask: Array | None = None,
+      score_mod_args: Tuple[Array, ...] = (),
       scale: float = 0.5,
       mask_type: MaskType = MaskType.NO_MASK,
       is_bnth: bool = False,
       dropout_rate: float = 0.1,
-      sliding_window_length: int | None = None) -> Array:
+      sliding_window_length: int | None = None,
+      score_mod: Callable[[Array], Array] | None = None) -> Array:
 
   def get_causal_mask(logits):
     large_negative_number = get_large_negative_number(logits.dtype)
@@ -198,6 +205,8 @@ def sdpa_ref(query: Array,
     if bias.shape != logits.shape:
       bias = jnp.broadcast_to(bias, logits.shape)
     logits = logits + bias.astype(logits.dtype)
+  if score_mod is not None:
+    logits = score_mod(logits, *score_mod_args).astype(jnp.float32)
   probs = jax.nn.softmax(logits, axis=-1).astype(query.dtype)
   if dropout_rate > 0.:
     keep_prob = 1.0 - dropout_rate
@@ -225,13 +234,16 @@ def sdpa_train_ref(query: Array,
             mask_type: MaskType = MaskType.NO_MASK,
             is_bnth: bool = False,
             dropout_rate: float = 0.1,
-            sliding_window_length: int | None = None) -> Array:
+            sliding_window_length: int | None = None,
+            score_mod: Callable[[Array], Array] | None = None,
+            score_mod_args: Tuple[Array, ...] = ()) -> Array:
   out_ref, sdpa_vjp_ref = jax.vjp(
     partial(
       sdpa_ref, scale=scale, mask_type=mask_type, dropout_rate=dropout_rate,
-      sliding_window_length=sliding_window_length, is_bnth=is_bnth),
-    query, key, value, bias, mask)
-  query_grad_ref, key_grad_ref, value_grad_ref, bias_grad_ref, _ = sdpa_vjp_ref(grad)
+      sliding_window_length=sliding_window_length, is_bnth=is_bnth,
+      score_mod=score_mod),
+    query, key, value, bias, mask, score_mod_args)
+  query_grad_ref, key_grad_ref, value_grad_ref, bias_grad_ref = sdpa_vjp_ref(grad)[:4]
   if bias is not None:
     return out_ref, (query_grad_ref, key_grad_ref, value_grad_ref, bias_grad_ref)
   return out_ref, (query_grad_ref, key_grad_ref, value_grad_ref)
@@ -269,8 +281,6 @@ class DotProductAttentionTest(jtu.JaxTestCase):
     super().setUp()
     if not jtu.is_cuda_compute_capability_at_least("8.0"):
       self.skipTest("Requires at least Ampere arch")
-    if jtu.is_cuda_version_at_least(13, 0):
-      self.skipTest("cuDNN creates no execution plans on CUDA 13.0.")
     self.enter_context(jtu.ignore_warning(
         category=DeprecationWarning, message='`with mesh:` context manager'))
 
@@ -754,6 +764,97 @@ class DotProductAttentionTest(jtu.JaxTestCase):
       self.assertArraysAllClose(key_grad_ref, key_grad, rtol=1e-2, atol=1e-2)
       self.assertArraysAllClose(value_grad_ref, value_grad, rtol=1e-2, atol=1e-2)
 
+  def test_sdpa_flex_attention(self):
+    k1, k2, k3, k4 = jax.random.split(jax.random.key(0), 4)
+    query = jax.random.normal(
+        k1, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    key = jax.random.normal(
+        k2, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+    value = jax.random.normal(
+        k3, (4, 1024, 4, 64), dtype=jnp.bfloat16)
+
+    soft_cap_scalar = jax.random.normal(
+        k4, (4, 4, 1024, 1024), dtype=jnp.float32)
+
+    def soft_cap(attn_score, soft_cap_scalar):
+      return soft_cap_scalar * jax.lax.tanh(attn_score / soft_cap_scalar)
+
+    jitted_sdpa = jax.jit(
+      partial(
+        dot_product_attention, scale=1.0, mask_type=MaskType.NO_MASK,
+        dropout_rate=0, score_mod=soft_cap),
+    )
+
+    jitted_sdpa_ref = jax.jit(
+      partial(
+        sdpa_ref, scale=1.0, mask_type=MaskType.NO_MASK,
+        dropout_rate=0, score_mod=soft_cap),
+    )
+
+    out = jitted_sdpa(query, key, value, score_mod_args=(soft_cap_scalar,))
+    out_ref = jitted_sdpa_ref(query, key, value, score_mod_args=(soft_cap_scalar,))
+    self.assertArraysAllClose(out, out_ref, rtol=1e-2, atol=1e-2)
+
+  @jtu.run_on_devices("cuda")
+  def test_sdpa_flex_attention_train(self):
+    if len(jax.local_devices()) < 4:
+      self.skipTest("Require at least 4 devices to run sharding tests.")
+    k1, k2, k3, k4, k5 = jax.random.split(jax.random.key(0), 5)
+    batch_size, seq_len, num_heads, head_dim = 4, 1024, 4, 64
+    qkv_shape = (batch_size, seq_len, num_heads, head_dim)
+    query = jax.random.normal(k1, qkv_shape, dtype=jnp.bfloat16)
+    key = jax.random.normal(k2, qkv_shape, dtype=jnp.bfloat16)
+    value = jax.random.normal(k3, qkv_shape, dtype=jnp.bfloat16)
+    grad = jax.random.normal(k4, qkv_shape, dtype=jnp.bfloat16)
+    soft_cap_scalar = jax.random.normal(
+        k5, (batch_size, num_heads, seq_len, seq_len), dtype=jnp.float32)
+
+    def soft_cap(attn_score, soft_cap_scalar):
+      return soft_cap_scalar * jax.lax.tanh(attn_score / soft_cap_scalar)
+
+    devices = np.array(jax.local_devices()[:4])
+    devices = devices.reshape((2, 2))
+    with Mesh(devices, ("dp", "tp")) as mesh:
+      qkv_spec = PartitionSpec("dp", None, "tp", None)
+      score_mod_spec = PartitionSpec("dp", "tp", None, None)
+      qkv_sharding = NamedSharding(mesh, qkv_spec)
+      score_mod_sharding = NamedSharding(mesh, score_mod_spec)
+      query = jax.device_put(query, qkv_sharding)
+      key = jax.device_put(key, qkv_sharding)
+      value = jax.device_put(value, qkv_sharding)
+      grad = jax.device_put(grad, qkv_sharding)
+      soft_cap_scalar = jax.device_put(soft_cap_scalar, score_mod_sharding)
+
+      in_shardings = (qkv_sharding, qkv_sharding, qkv_sharding, qkv_sharding,
+                      (score_mod_sharding,))
+      out_shardings = (qkv_sharding,
+                       (qkv_sharding, qkv_sharding, qkv_sharding))
+
+      jitted_sdpa = jax.jit(
+        lambda q, k, v, g, sm_args: sdpa_train(
+          q, k, v, g, score_mod_args=sm_args, scale=1.0,
+          mask_type=MaskType.NO_MASK, dropout_rate=0, score_mod=soft_cap),
+        in_shardings=in_shardings,
+        out_shardings=out_shardings,
+      )
+
+      jitted_sdpa_ref = jax.jit(
+        lambda q, k, v, g, sm_args: sdpa_train_ref(
+          q, k, v, g, score_mod_args=sm_args, scale=1.0,
+          mask_type=MaskType.NO_MASK, dropout_rate=0, score_mod=soft_cap),
+        in_shardings=in_shardings,
+        out_shardings=out_shardings,
+      )
+
+      out, (query_grad, key_grad, value_grad) = \
+        jitted_sdpa(query, key, value, grad, (soft_cap_scalar,))
+      out_ref, (query_grad_ref, key_grad_ref, value_grad_ref) = \
+        jitted_sdpa_ref(query, key, value, grad, (soft_cap_scalar,))
+      self.assertArraysAllClose(out_ref, out, rtol=1e-2, atol=1e-2)
+      self.assertArraysAllClose(query_grad_ref, query_grad, rtol=1e-2, atol=1e-2)
+      self.assertArraysAllClose(key_grad_ref, key_grad, rtol=1e-2, atol=1e-2)
+      self.assertArraysAllClose(value_grad_ref, value_grad, rtol=1e-2, atol=1e-2)
+
   @jtu.run_on_devices("cuda")
   @jtu.ignore_warning(category=DeprecationWarning,
                       message='`with mesh:` context manager')
@@ -982,8 +1083,6 @@ class DotProductAttentionF8Test(jtu.JaxTestCase):
       self.skipTest("Requires at least Hopper arch")
     if jtu.is_cuda_compute_capability_equal("12.0"):
       self.skipTest("cuDNN does not support FP8 with compute capability 12.0")
-    if jtu.is_cuda_version_at_least(13, 0):
-      self.skipTest("cuDNN creates no execution plans on CUDA 13.0.")
 
   @jtu.sample_product(
       batch_size=[2, 4],


### PR DESCRIPTION
Support adding arbitrary pointwise operations between bmm1 and softmax to support new variants of cuDNN attention. For example: softcap.

```
def test_sdpa_flex_attention(self):
    k1, k2, k3, k4 = jax.random.split(jax.random.key(0), 4)
    query = jax.random.normal(
        k1, (4, 1024, 4, 64), dtype=jnp.bfloat16)
    key = jax.random.normal(
        k2, (4, 1024, 4, 64), dtype=jnp.bfloat16)
    value = jax.random.normal(
        k3, (4, 1024, 4, 64), dtype=jnp.bfloat16)


    soft_cap_scalar = jax.random.normal(
        k4, (4, 4, 1024, 1024), dtype=jnp.bfloat16)


    def soft_cap(attn_score, soft_cap_scalar):
      return soft_cap_scalar * jax.lax.tanh(attn_score / soft_cap_scalar)


    jitted_sdpa = jax.jit(
      partial(
        dot_product_attention, scale=1.0, mask_type=MaskType.NO_MASK,
        dropout_rate=0, score_mod=soft_cap),
    )
    out = jitted_sdpa(query, key, value, score_mod_args=(soft_cap_scalar,))
```
In this example, users create a **soft_cap** function and pass to **dot_product_attention** through argument **score_mod**, soft_cap accepts two arguments and therefore **soft_cap_scalar** argument needs to be passed to **dot_product_attention** through **score_mod_args**.