### PR TITLE
[ROCm] Split ROCm pytest into single- and multi-accelerator passes

### DIFF
--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -115,10 +115,48 @@ export NPROC=32
 LOGS_DIR="logs"
 mkdir -p "${LOGS_DIR}"
 mkdir -p test-artifacts
+
+# Don't abort the script if one command fails to ensure we run both test
+# commands below.
+set +e
+
+# Run single-accelerator tests in parallel
 "$JAXCI_PYTHON" -m pytest -n $num_processes --tb=short \
---json-report --json-report-file=${LOGS_DIR}/pytest_results.json \
---junitxml=test-artifacts/junit.xml \
-tests \
+--json-report --json-report-file=${LOGS_DIR}/pytest_results_single.json \
+--junitxml=test-artifacts/junit-single.xml \
+--dist=loadfile \
+-m "not multiaccelerator" \
 --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
 --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
---deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric
+--deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
+tests
+
+first_cmd_retval=$?
+
+if [[ $gpu_count -gt 1 ]]; then
+  # Run multi-accelerator tests across all GPUs without xdist.
+  unset JAX_ENABLE_ROCM_XDIST
+
+  "$JAXCI_PYTHON" -m pytest --tb=short \
+    --json-report --json-report-file=${LOGS_DIR}/pytest_results_multi.json \
+    --junitxml=test-artifacts/junit-multi.xml \
+    -m "multiaccelerator" \
+    --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
+    --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
+    --deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
+    tests
+
+  second_cmd_retval=$?
+else
+  echo "Skipping multi-accelerator tests (only $gpu_count GPU detected)"
+  second_cmd_retval=0
+fi
+
+# Exit with failure if either command fails.
+if [[ $first_cmd_retval -ne 0 ]]; then
+  exit $first_cmd_retval
+elif [[ $second_cmd_retval -ne 0 ]]; then
+  exit $second_cmd_retval
+else
+  exit 0
+fi

--- a/conftest.py
+++ b/conftest.py
@@ -79,6 +79,6 @@ def pytest_collection() -> None:
     if not xdist_worker_name.startswith("gw"):
       return
     xdist_worker_number = int(xdist_worker_name[len("gw") :])
-    os.environ.setdefault(
-        "ROCR_VISIBLE_DEVICES", str(xdist_worker_number % num_rocm_devices)
+    os.environ["ROCR_VISIBLE_DEVICES"] = str(
+        xdist_worker_number % num_rocm_devices
     )


### PR DESCRIPTION
- Use the existing `multiaccelerator` pytest marker to split ROCm CI tests into two passes, matching the TPU pytest workflow.
- Single-accelerator pass runs with xdist parallelism and `-m "not multiaccelerator"`.
- Multi-accelerator pass runs without xdist across all GPUs with `-m "multiaccelerator"`, skipped on single-GPU machines.
- Override ROCR_VISIBLE_DEVICES in conftest.py xdist hook to ensure workers are always pinned to the correct GPU.