### PR TITLE
Disabled permissive-ignores for Pyrefly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ ignore-missing-imports = [
     "xprof.*",
     "zstandard.*",
 ]
-permissive-ignores = true
 untyped-def-behavior = "check-and-infer-return-any"
 
 [tool.ruff]


### PR DESCRIPTION
We are now using Pyrefly internally and externally, so we no longer need the flexibility of permissive-ignores.

Note that `# type: ignore` is enabled by default and will continue to work. See https://pyrefly.org/en/docs/configuration/#enabled-ignores.