### PR TITLE
Fix jax.scipy.stats.expon.ppf returning wrong values when scale != 1

### DIFF
--- a/jax/_src/scipy/stats/expon.py
+++ b/jax/_src/scipy/stats/expon.py
@@ -265,5 +265,5 @@ def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   return jnp.where(
     jnp.isnan(q) | (q < 0) | (q > 1),
     np.nan,
-    lax.add(loc, lax.mul(scale, lax.neg(lax.log1p(lax.neg(q))))),
+    lax.sub(loc, lax.mul(scale, lax.log1p(lax.neg(q)))),
   )

--- a/jax/_src/scipy/stats/expon.py
+++ b/jax/_src/scipy/stats/expon.py
@@ -262,9 +262,8 @@ def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
     :func:`jax.scipy.stats.expon.logsf`
   """
   q, loc, scale = promote_args_inexact("expon.ppf", q, loc, scale)
-  neg_scaled_q = lax.div(lax.sub(loc, q), scale)
   return jnp.where(
     jnp.isnan(q) | (q < 0) | (q > 1),
     np.nan,
-    lax.neg(lax.log1p(neg_scaled_q)),
+    lax.add(loc, lax.mul(scale, lax.neg(lax.log1p(lax.neg(q))))),
   )

--- a/jax/_src/scipy/stats/expon.py
+++ b/jax/_src/scipy/stats/expon.py
@@ -262,9 +262,8 @@ def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
     :func:`jax.scipy.stats.expon.logsf`
   """
   q, loc, scale = promote_args_inexact("expon.ppf", q, loc, scale)
-  neg_scaled_q = lax.div(lax.sub(loc, q), scale)
   return jnp.where(
     jnp.isnan(q) | (q < 0) | (q > 1),
     np.nan,
-    lax.neg(lax.log1p(neg_scaled_q)),
+    lax.sub(loc, lax.mul(scale, lax.log1p(lax.neg(q)))),
   )

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -597,6 +597,18 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       )
       self._CompileAndCheck(lax_fun, args_maker)
 
+  def testExponPpfNonUnitScale(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/36757
+    # Previously expon.ppf ignored ``scale`` and returned the unit-rate value.
+    q = 0.5
+    for scale in (0.5, 2.0, 10.0):
+      for loc in (0.0, 1.5):
+        self.assertAllClose(
+          osp_stats.expon.ppf(q, loc=loc, scale=scale),
+          lsp_stats.expon.ppf(q, loc=loc, scale=scale),
+          atol=1e-6,
+        )
+
   @genNamedParametersNArgs(4)
   def testGammaLogPdf(self, shapes, dtypes):
     rng = jtu.rand_positive(self.rng())


### PR DESCRIPTION
Fixes #36757.

## Bug

`jax.scipy.stats.expon.ppf` returns incorrect values when `scale != 1`:

```python
>>> from scipy.stats import expon as expon_np
>>> from jax.scipy.stats import expon as expon_jax

>>> expon_np.ppf(0.4, scale=0.5)   # 0.2554
>>> expon_jax.ppf(0.4, scale=0.5)  # 1.6094  (wrong!)

>>> expon_np.ppf(0.4, scale=1e-3)  # 0.000511
>>> expon_jax.ppf(0.4, scale=1e-3) # nan     (wrong!)
```

## Root cause

The previous formula was:

```python
neg_scaled_q = (loc - q) / scale
return -log1p(neg_scaled_q)
# = -log(1 + (loc - q)/scale)
```

This is only correct when \`loc=0\` and \`scale=1\`, where it simplifies to \`-log(1-q)\`. For any other scale it produces wrong results, and for small scales (e.g. \`1e-3\`) the argument to \`log1p\` can go negative, producing NaN.

## Fix

The correct exponential PPF (inverse CDF) is:

```
ppf(q, loc, scale) = loc + scale * (-log(1 - q))
```

Updated to:

```python
return loc + scale * (-log1p(-q))
```

This uses \`log1p(-q)\` for numerical stability near \`q=0\`, matches scipy's implementation, and correctly applies both \`loc\` and \`scale\`.

## Verification

Tested the fix against scipy for multiple parameter combinations:

| q | loc | scale | scipy | old JAX | fixed JAX |
|---|-----|-------|-------|---------|-----------|
| 0.4 | 0 | 1 | 0.5108 | 0.5108 | 0.5108 |
| 0.4 | 0 | 0.5 | 0.2554 | 1.6094 | 0.2554 |
| 0.4 | 0 | 1e-3 | 0.000511 | NaN | 0.000511 |
| 0.9 | 0 | 2 | 4.6052 | - | 4.6052 |
| 0.5 | 1 | 3 | 3.0794 | - | 3.0794 |