### PR TITLE
Fix jax.scipy.stats.expon.ppf for scale != 1

### DIFF
--- a/jax/_src/scipy/stats/expon.py
+++ b/jax/_src/scipy/stats/expon.py
@@ -237,7 +237,7 @@ def sf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
 
 
 def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
-  r"""Exponential survival function.
+  r"""Exponential percent point function.
 
   JAX implementation of :obj:`scipy.stats.expon` ``ppf``.
 
@@ -245,26 +245,22 @@ def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   cumulative distribution function, :func:`jax.scipy.stats.expon.cdf`.
 
   Args:
-    x: arraylike, value at which to evaluate the PDF
+    q: arraylike, value at which to evaluate the PPF
     loc: arraylike, distribution offset parameter
     scale: arraylike, distribution scale parameter
 
   Returns:
-    array of pdf values.
+    array of ppf values.
 
   See Also:
     :func:`jax.scipy.stats.expon.cdf`
     :func:`jax.scipy.stats.expon.pdf`
-    :func:`jax.scipy.stats.expon.ppf`
-    :func:`jax.scipy.stats.expon.sf`
     :func:`jax.scipy.stats.expon.logcdf`
     :func:`jax.scipy.stats.expon.logpdf`
-    :func:`jax.scipy.stats.expon.logsf`
   """
   q, loc, scale = promote_args_inexact("expon.ppf", q, loc, scale)
-  neg_scaled_q = lax.div(lax.sub(loc, q), scale)
   return jnp.where(
     jnp.isnan(q) | (q < 0) | (q > 1),
     np.nan,
-    lax.neg(lax.log1p(neg_scaled_q)),
+    lax.sub(loc, lax.mul(scale, lax.log1p(lax.neg(q)))),
   )


### PR DESCRIPTION
Good day

This PR fixes a bug in `jax.scipy.stats.expon.ppf` where incorrect output was produced when `scale != 1`.

## Bug Description

The percent point function (PPF) of the exponential distribution was returning wrong values when the `scale` parameter was not set to the default of 1:



## Root Cause

The original formula was:


This is mathematically incorrect. For the exponential distribution PPF, the correct formula is:
```
ppf(q) = loc - scale * log(1 - q)
```

Which in JAX:
```python
return lax.sub(loc, lax.mul(scale, lax.log1p(lax.neg(q))))
```

## Fix Applied

1. Changed the formula from `(loc - q) / scale` and `-log1p` to `loc - scale * log1p(-q)`
2. Fixed docstring: `survival function` → `percent point function`
3. Fixed Args: `x` → `q`, `pdf values` → `ppf values`
4. Removed duplicate See Also entries

## Verification

The fix was verified using scipy as reference:
- scale=0.5: result=0.2554128119, expected=0.2554128119 ✓
- scale=1.0: result=0.5108256238, expected=0.5108256238 ✓
- scale=1e-3: result=0.0005108256, expected=0.0005108256 ✓

Fixes: https://github.com/jax-ml/jax/issues/36757

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof