### PR TITLE
[ROCm] Skip unit tests in `testEighIdentity` because of hipSolver issue.

### DIFF
--- a/tests/eigh_test.py
+++ b/tests/eigh_test.py
@@ -222,6 +222,18 @@ class EighTest(jtu.JaxTestCase):
     lower=[True, False],
   )
   def testEighIdentity(self, n, dtype, lower):
+
+    # In ROCm 7.2.0, hipsolverDnCheevd and hipsolverDnZheevd produce NaNs in
+    # eigenvectors for complex types when matrices are too large (n>64) and
+    # have certain structures (such as the identity matrix).
+    #
+    # TODO: Re-enable this test when the hipSolver issue is resolved.
+    #
+    if (jtu.is_device_rocm() and n > 64
+        and np.issubdtype(dtype, np.complexfloating)):
+      self.skipTest("Complex types not currently supported on ROCm due to "
+                    "hipSolver issue.")
+
     tol = np.finfo(dtype).eps
     uplo = "L" if lower else "U"
 


### PR DESCRIPTION
## Motivation
One of the unit tests in `tests/eigh_test.py` was failing when invoking eigendecomposition. When the data types are complex and the matrix size is too large (n>64), hipSolver produces NaNs in the eigenvectors for eigendecomposition (heevd). This only applies for certain matrix structures (like the identity matrix). As such, only certain variants of this test are skipped for ROCm until the issue is resolved.

## Changes
Changes are contained to `tests/eigh_test.py::EighTest` and skip the `testEighIdentity` unit test for ROCm under conditions where a NaN is returned. These will be re-enabled once fixed.

## Unit Tests
The specific tests that were failing were:

- `tests/eigh_test.py::EighTest::testEighIdentity0`
- `tests/eigh_test.py::EighTest::testEighIdentity8`

 when run with `jax_enable_x64` set.