### PR TITLE
Handle NaN error ratios in ode.optimal_step_size

### DIFF
--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -145,11 +145,11 @@ def optimal_step_size(last_step, mean_error_ratio, safety=0.9, ifactor=10.0,
   """Compute optimal Runge-Kutta stepsize."""
   dfactor = jnp.where(mean_error_ratio < 1, 1.0, dfactor)
 
-  # Use nan-safe variants so that a NaN error ratio (e.g. from an
-  # oversized trial step) falls back to dfactor instead of poisoning
-  # all subsequent steps.  See #14612.
-  factor = jnp.nanmin(jnp.array([ifactor,
-                      jnp.nanmax(jnp.array([mean_error_ratio**(-1.0 / order) * safety, dfactor]))]))
+  # Use NaN-propagation-safe ops so that a NaN error ratio (e.g. from
+  # an oversized trial step) falls back to dfactor instead of poisoning
+  # all subsequent steps.  jnp.fmin/fmax ignore NaN operands.  #14612.
+  factor = jnp.fmin(ifactor,
+                    jnp.fmax(mean_error_ratio**(-1.0 / order) * safety, dfactor))
   return jnp.where(mean_error_ratio == 0, last_step * ifactor, last_step * factor)
 
 def odeint(func, y0, t, *args, rtol=1.4e-8, atol=1.4e-8, mxstep=jnp.inf, hmax=jnp.inf):

--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -145,8 +145,11 @@ def optimal_step_size(last_step, mean_error_ratio, safety=0.9, ifactor=10.0,
   """Compute optimal Runge-Kutta stepsize."""
   dfactor = jnp.where(mean_error_ratio < 1, 1.0, dfactor)
 
-  factor = jnp.minimum(ifactor,
-                      jnp.maximum(mean_error_ratio**(-1.0 / order) * safety, dfactor))
+  # Use nan-safe variants so that a NaN error ratio (e.g. from an
+  # oversized trial step) falls back to dfactor instead of poisoning
+  # all subsequent steps.  See #14612.
+  factor = jnp.nanmin(jnp.array([ifactor,
+                      jnp.nanmax(jnp.array([mean_error_ratio**(-1.0 / order) * safety, dfactor]))]))
   return jnp.where(mean_error_ratio == 0, last_step * ifactor, last_step * factor)
 
 def odeint(func, y0, t, *args, rtol=1.4e-8, atol=1.4e-8, mxstep=jnp.inf, hmax=jnp.inf):


### PR DESCRIPTION
Fixes #14612.

## Problem

When the error estimate from an adaptive Runge-Kutta step is NaN (e.g. from an oversized trial step that causes overflow), `jnp.minimum` / `jnp.maximum` in `optimal_step_size` propagate the NaN through the computed step factor. Once a single NaN appears, every subsequent adaptive step also computes NaN, making `odeint` unable to recover.

## Fix

Switch from `jnp.minimum` / `jnp.maximum` to `jnp.nanmin` / `jnp.nanmax` so that a NaN error ratio falls back to `dfactor` (the step-shrink bound) instead of poisoning the integrator. This is exactly the fix suggested in the issue.

```python
# Before: NaN propagates through minimum/maximum
factor = jnp.minimum(ifactor,
    jnp.maximum(mean_error_ratio**(-1.0 / order) * safety, dfactor))

# After: NaN is ignored, falls back to dfactor (step shrink)
factor = jnp.nanmin(jnp.array([ifactor,
    jnp.nanmax(jnp.array([mean_error_ratio**(-1.0 / order) * safety, dfactor]))]))
```

When `mean_error_ratio` is NaN:
- `mean_error_ratio**(-1.0/order) * safety` → NaN
- `jnp.nanmax([NaN, dfactor])` → `dfactor` (step shrinks)
- `jnp.nanmin([ifactor, dfactor])` → `dfactor`
- The integrator retries with a smaller step instead of dying

When `mean_error_ratio` is finite, `nanmin`/`nanmax` behave identically to `minimum`/`maximum`.