### PR TITLE
remove integer_pow from jaxpr in jvp rule where possible

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4678,7 +4678,13 @@ def _integer_pow_dtype_rule(x, *, y):
   return dtype
 
 def _integer_pow_jvp(g, x, *, y):
-  return _zeros(g) if y == 0 else mul(g, mul(_const(x, y), integer_pow(x, y - 1)))
+  if y == 0:
+    return _zeros(g)
+  if y == 1:
+    return g
+  if y == 2:
+    return mul(g, mul(_const(x, y), x))
+  return mul(g, mul(_const(x, y), integer_pow(x, y - 1)))
 
 integer_pow_p = standard_primitive(
   _attrgetter('shape'), _integer_pow_dtype_rule, 'integer_pow',

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -248,6 +248,13 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     args = tuple(rng(shape, dtype) for shape in shapes)
     check_grads(op, args, order, ["fwd", "rev"], tol, tol)
 
+  def testIntegerPowLinearizeEliminatesIntegerPow(self):
+    x = np.float32(3.0)
+    _, f_lin = jax.linearize(lambda x: 2 * x**0 + 3 * x**1 + 4 * x**2, x)
+    jaxpr = jax.make_jaxpr(f_lin)(x)
+    prims = [eqn.primitive for eqn in jaxpr.jaxpr.eqns]
+    self.assertNotIn(lax.integer_pow_p, prims)
+
   @parameterized.parameters(itertools.chain.from_iterable(
     jtu.sample_product_testcases(
       [dict(op=rec.op, tol=rec.tol)],


### PR DESCRIPTION
I've been working on some liinearity/quadratic detection for automated variable projection and I was finding that `jax.grad(x**2)` was not registering as linear because `integer_pow` does not have a `linear_transpose`. `integer_pow = x**y` already has a special case for `pow=0` (0), to fix the problem I have added additional special cases for `pow=1` (just `g=dx`) and `pow=2` (`2*x*dx`). This will allow more robust linear detection and for a more succint jaxpr. Under XLA there should be no performance difference.