### PR TITLE
Export jax.dtypes.TypePromotionError

### DIFF
--- a/docs/jax.dtypes.rst
+++ b/docs/jax.dtypes.rst
@@ -14,3 +14,4 @@
     prng_key
     result_type
     scalar_type_of
+    TypePromotionError

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -765,8 +765,12 @@ _standard_x64_lattice_ubs = _make_lattice_upper_bounds(strict=False, x64=True)
 _standard_x32_lattice_ubs = _make_lattice_upper_bounds(strict=False, x64=False)
 _strict_lattice_ubs = _make_lattice_upper_bounds(strict=True, x64=True)
 
+
+@export
 class TypePromotionError(ValueError):
+  """Raised when JAX type promotion fails."""
   pass
+
 
 # We don't use util.memoize because there is no implicit X64 dependence.
 @functools.lru_cache(512)

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -27,4 +27,5 @@ from jax._src.dtypes import (
     prng_key as prng_key,
     result_type as result_type,
     scalar_type_of as scalar_type_of,
+    TypePromotionError as TypePromotionError,
 )

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -230,7 +230,7 @@ class DtypesTest(jtu.JaxTestCase):
            "path when jax_numpy_dtype_promotion=strict")
 
     assertTypePromotionError = functools.partial(
-      self.assertRaisesRegex, dtypes.TypePromotionError, msg,
+      self.assertRaisesRegex, jax.dtypes.TypePromotionError, msg,
       dtypes.promote_types)
 
     # Check that strong types have diagonal promotion table:
@@ -275,7 +275,7 @@ class DtypesTest(jtu.JaxTestCase):
   def testPromoteDtypesStandard(self):
     assertTypePromotionError = functools.partial(
         self.assertRaisesRegex,
-        dtypes.TypePromotionError,
+        jax.dtypes.TypePromotionError,
         'Input dtypes .* have no available implicit dtype promotion path.',
         dtypes.promote_types,
     )
@@ -1132,7 +1132,7 @@ class TestPromotionTables(jtu.JaxTestCase):
         continue
       x = jnp.array(1, dtype=dtype)
       y = jnp.array(1, dtype='float32')
-      with self.assertRaisesRegex(dtypes.TypePromotionError,
+      with self.assertRaisesRegex(jax.dtypes.TypePromotionError,
                                   ".*8-bit floats do not support implicit promotion"):
         x + y
 
@@ -1144,7 +1144,7 @@ class TestPromotionTables(jtu.JaxTestCase):
         continue
       x = jnp.array(1, dtype=dtype)
       y = jnp.array(1, dtype='float32')
-      with self.assertRaisesRegex(dtypes.TypePromotionError,
+      with self.assertRaisesRegex(jax.dtypes.TypePromotionError,
                                   ".*4-bit floats do not support implicit promotion"):
         x + y
 
@@ -1159,7 +1159,7 @@ class TestPromotionTables(jtu.JaxTestCase):
       x = jnp.array(1, dtype=dtype)
       y = jnp.array(1, dtype='int32')
       with self.assertRaisesRegex(
-          dtypes.TypePromotionError,
+          jax.dtypes.TypePromotionError,
           '.*[124]-bit integers do not support implicit promotion',
       ):
         x + y
@@ -1237,11 +1237,11 @@ class TestPromotionTables(jtu.JaxTestCase):
 
       try:
         result_dtype = dtypes.result_type(input_dtype, dtypes.canonicalize_dtype(output_dtype))
-      except dtypes.TypePromotionError:
+      except jax.dtypes.TypePromotionError:
         result_dtype = None
 
       if result_dtype is None and input_dtype != output_dtype:
-        with self.assertRaises(dtypes.TypePromotionError):
+        with self.assertRaises(jax.dtypes.TypePromotionError):
           dtypes.safe_to_cast(input_dtype, output_dtype)
       else:
         self.assertEqual(dtypes.result_type(output_dtype) == result_dtype,


### PR DESCRIPTION
This is a symbol that downstream users often import from `jax._src`; as a publicly-visible exception it should be publicly importable.