### PR TITLE
[jax2tf] Add pyrefly suppressions

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -43,7 +43,7 @@ from jax._src.export import _export
 from jax._src.export import shape_poly
 from jax._src.lib import xla_client
 
-import tensorflow as tf
+import tensorflow as tf  # pyrefly: ignore [untyped-import]
 
 # These don't have public equivalents.
 from tensorflow.compiler.tf2xla.python import xla as tfxla
@@ -519,7 +519,7 @@ def _make_custom_gradient_fn_tf(fun_jax,
         assert core.primal_dtype_to_tangent_dtype(out_ct_aval.dtype) == dtypes.float0, f"{out_ct_tf=}"
         # Note that out_ct_aval.shape contains dimension variable from the
         # primal function scope. We use tf.zeros_like to make a 0 of the right shape.
-        return tf.zeros_like(out_tf, dtype=_tf_np_dtype_for_float0)
+        return tf.zeros_like(out_tf, dtype=_tf_np_dtype_for_float0)  # pyrefly: ignore [no-matching-overload]
 
       out_cts_fixed_flat_tf = tuple(map(fix_out_ct, out_cts_flat_tf, outs_avals, outs_tf))
       vjp_args_flat_tf = tuple(args_tf) + out_cts_fixed_flat_tf
@@ -847,25 +847,25 @@ def _shard_value(val: TfVal,
 
   # To use xla_sharding.py, we must have a xla_data_pb2.OpSharding.
   xla_sharding_v1_proto: xla_data_pb2.OpSharding = xla_data_pb2.OpSharding(
-      type=int(sharding_proto.type),
+      type=int(sharding_proto.type),  # pyrefly: ignore [bad-argument-type]
       tile_assignment_dimensions=sharding_proto.tile_assignment_dimensions,
-      tile_assignment_devices=tad,
+      tile_assignment_devices=tad,  # pyrefly: ignore [bad-argument-type]
       replicate_on_last_tile_dim=sharding_proto.replicate_on_last_tile_dim,
-      last_tile_dims=sharding_proto.last_tile_dims,
+      last_tile_dims=sharding_proto.last_tile_dims,  # pyrefly: ignore [bad-argument-type]
   )
   # Shardy requires V2 sharding format.
   if config.use_shardy_partitioner.value:
     xla_sharding_v2_proto: xla_data_pb2.OpSharding = xla_data_pb2.OpSharding(
-        type=int(sharding_proto.type),
+        type=int(sharding_proto.type),  # pyrefly: ignore [bad-argument-type]
         tile_assignment_dimensions=sharding_proto.tile_assignment_dimensions,
         tile_assignment_devices=sharding_proto.tile_assignment_devices,
         iota_reshape_dims=sharding_proto.iota_reshape_dims,
         iota_transpose_perm=sharding_proto.iota_transpose_perm,
         replicate_on_last_tile_dim=sharding_proto.replicate_on_last_tile_dim,
-        last_tile_dims=sharding_proto.last_tile_dims,
+        last_tile_dims=sharding_proto.last_tile_dims,  # pyrefly: ignore [bad-argument-type]
     )
   else:
-    xla_sharding_v2_proto = None
+    xla_sharding_v2_proto = None  # pyrefly: ignore [bad-assignment]
   if tf_context.executing_eagerly():
     raise ValueError(
         "A jit function with sharded arguments or results must be used under a `tf.function` context. "
@@ -888,12 +888,12 @@ def _register_checkpoint_pytrees():
   m = tf.Module()
   # The types here are automagically changed by TensorFlow's checkpointing
   # infrastructure.
-  m.a = (tf.Module(), tf.Module())
-  m.b = [tf.Module(), tf.Module()]
-  m.c = {"a": tf.Module()}
-  tuple_wrapper = type(m.a)
-  list_wrapper = type(m.b)
-  dict_wrapper = type(m.c)
+  m.a = (tf.Module(), tf.Module())  # pyrefly: ignore [missing-attribute]
+  m.b = [tf.Module(), tf.Module()]  # pyrefly: ignore [missing-attribute]
+  m.c = {"a": tf.Module()}  # pyrefly: ignore [missing-attribute]
+  tuple_wrapper = type(m.a)  # pyrefly: ignore [missing-attribute]
+  list_wrapper = type(m.b)  # pyrefly: ignore [missing-attribute]
+  dict_wrapper = type(m.c)  # pyrefly: ignore [missing-attribute]
 
   # TF AutoTrackable swaps container types out for wrappers.
   assert tuple_wrapper is not tuple


### PR DESCRIPTION
These silence all the errors with pyrefly 0.61.0.

It is strange that I have to add these suppressions, it may be because I am using pyrefly 0.61.0 on
my machine, while `pre-commit` uses a development version?