### PR TITLE
Add jax.scipy.special.erfcx

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -574,7 +574,7 @@ def erfcx(x: ArrayLike) -> Array:
     - :func:`jax.scipy.special.erf`
   """
   x, = promote_args_inexact("erfcx", x)
-  return lax.exp(lax.square(x)) * lax.erfc(x)
+  return lax.erfcx(x)
 
 
 def erfinv(x: ArrayLike) -> Array:

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -554,6 +554,29 @@ def erfc(x: ArrayLike) -> Array:
   return lax.erfc(x)
 
 
+def erfcx(x: ArrayLike) -> Array:
+  r"""The scaled complementary error function
+
+  JAX implementation of :obj:`scipy.special.erfcx`.
+
+  .. math::
+
+     \mathrm{erfcx}(x) = e^{x^2} \mathrm{erfc}(x)
+
+  Args:
+    x: arraylike, real-valued.
+
+  Returns:
+    array containing values of the scaled complementary error function.
+
+  See also:
+    - :func:`jax.scipy.special.erfc`
+    - :func:`jax.scipy.special.erf`
+  """
+  x, = promote_args_inexact("erfcx", x)
+  return lax.exp(lax.square(x)) * lax.erfc(x)
+
+
 def erfinv(x: ArrayLike) -> Array:
   """The inverse of the error function
 

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -25,6 +25,7 @@ from jax._src.scipy.special import (
   entr as entr,
   erf as erf,
   erfc as erfc,
+  erfcx as erfcx,
   erfinv as erfinv,
   exp1 as exp1,
   expi as expi,

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -96,6 +96,9 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
         "erfc", 1, float_dtypes, jtu.rand_small_positive, True
     ),
     op_record(
+        "erfcx", 1, float_dtypes, jtu.rand_small_positive, True
+    ),
+    op_record(
         "erfinv", 1, float_dtypes, jtu.rand_small_positive, True
     ),
     op_record(


### PR DESCRIPTION
Good day

This PR adds `jax.scipy.special.erfcx`, the scaled complementary error function defined as `exp(x²) · erfc(x)`, to address GitHub issue #1987.

## Changes

- `jax/_src/scipy/special.py`: Added `erfcx` function following the same pattern as `erfc` and other special functions. Implementation uses `lax.exp(lax.square(x)) * lax.erfc(x)`.
- `jax/scipy/special.py`: Exported `erfcx` in the public API.
- `tests/lax_scipy_special_functions_test.py`: Added `erfcx` to the `JAX_SPECIAL_FUNCTION_RECORDS` test suite.

## Motivation

The scaled complementary error function `erfcx(x) = exp(x²) · erfc(x)` is a standard SciPy special function ([scipy.special.erfcx](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.erfcx.html)) that appears frequently in statistics and probability applications, particularly in Normal-adjacent distributions. JAX already has `jax.scipy.special.erfc`, so adding `erfcx` completes the set.

This issue was labeled `good first issue` by the JAX maintainers.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof