### PR TITLE
docs: add example and improve transpose_kernel documentation in conv_transpose

### DIFF
--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -319,9 +319,9 @@ def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
       from jax import lax
 
       # Input (batch=1, channels=1, height=2, width=2)
-      lhs = jnp.ones((1, 1, 2, 2))
+      lhs = jnp.array([[[[1.0, 2.0], [3.0, 4.0]]]])
       # Kernel (output_channels=1, input_channels=1, kh=2, kw=2)
-      rhs = jnp.ones((1, 1, 2, 2))
+      rhs = jnp.array([[[[1.0, 0.0], [0.0, 0.0]]]])
 
       # JAX default: no kernel reversal
       out_default = lax.conv_transpose(lhs, rhs, strides=(1, 1),

--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -311,7 +311,34 @@ def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
     kernel's spatial dimensions. This differs from TensorFlow's "Conv2DTranspose"
     and similar frameworks, which flip spatial axes and swap input/output channels.
 
-    To match TensorFlow/Keras behavior, set "transpose_kernel=True" .
+    To match TensorFlow/Keras behavior, set ``transpose_kernel=True``.
+
+    Example showing the convention difference::
+
+      import jax.numpy as jnp
+      from jax import lax
+
+      # Input (batch=1, channels=1, height=2, width=2)
+      lhs = jnp.ones((1, 1, 2, 2))
+      # Kernel (output_channels=1, input_channels=1, kh=2, kw=2)
+      rhs = jnp.ones((1, 1, 2, 2))
+
+      # JAX default: no kernel reversal
+      out_default = lax.conv_transpose(lhs, rhs, strides=(1, 1),
+                                        padding='VALID', dimension_numbers=('NCHW', 'OIHW', 'NCHW'))
+      # With kernel reversal (matches TensorFlow/Keras Conv2DTranspose)
+      out_tf = lax.conv_transpose(lhs, rhs, strides=(1, 1),
+                                   padding='VALID', dimension_numbers=('NCHW', 'OIHW', 'NCHW'),
+                                   transpose_kernel=True)
+
+    The ``out_default`` and ``out_tf`` will differ because the kernel is flipped
+    when ``transpose_kernel=True``. The default JAX convention computes the
+    mathematical transpose of the convolution operation, while ``transpose_kernel=True``
+    mimics the behavior of ``tf.keras.layers.Conv2DTranspose``, which flips the spatial
+    axes of the kernel before computing the transposed convolution.
+
+    Use ``transpose_kernel=True`` when porting models from TensorFlow/Keras that use
+    Conv2DTranspose layers, or when working with pretrained TensorFlow checkpoints.
 
   Args:
     lhs: a rank `n+2` dimensional input array.
@@ -333,8 +360,8 @@ def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
     transpose_kernel: if True flips spatial axes and swaps the input/output
       channel axes of the kernel. This makes the output of this function identical
       to the gradient-derived functions like keras.layers.Conv2DTranspose
-      applied to the same kernel. For typical use in neural nets this is completely
-      pointless and just makes input/output channel specification confusing.
+      applied to the same kernel. See the example above for a comparison of the
+      two conventions.
     precision: Optional. Either ``None``, which means the default precision for
       the backend, a :class:`~jax.lax.Precision` enum value (``Precision.DEFAULT``,
       ``Precision.HIGH`` or ``Precision.HIGHEST``) or a tuple of two

--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -333,9 +333,9 @@ def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
 
     The ``out_default`` and ``out_tf`` will differ because the kernel is flipped
     when ``transpose_kernel=True``. The default JAX convention computes the
-    mathematical transpose of the convolution operation, while ``transpose_kernel=True``
-    mimics the behavior of ``tf.keras.layers.Conv2DTranspose``, which flips the spatial
-    axes of the kernel before computing the transposed convolution.
+    mathematical transpose of the convolution operation, while transpose_kernel=True
+    mimics the behavior of tf.keras.layers.Conv2DTranspose, which flips the spatial axes
+    and swaps the input/output channel axes of the kernel before computing the transposed convolution.
 
     Use ``transpose_kernel=True`` when porting models from TensorFlow/Keras that use
     Conv2DTranspose layers, or when working with pretrained TensorFlow checkpoints.


### PR DESCRIPTION
Good day,

This PR addresses issue #14337, which requests documenting the convention difference between JAX's `lax.conv_transpose` and TensorFlow/Keras `Conv2DTranspose`, as well as making it easy to switch to the TF convention.

## Changes

The `transpose_kernel=True` argument already existed to switch to the TF convention, but the documentation lacked a concrete example showing the difference between the two conventions.

### What was changed in `jax/_src/lax/convolution.py`:

1. **Added a runnable code example** in the docstring demonstrating both conventions side-by-side with the same input and kernel.

2. **Improved explanation**: Added a clear description that the default JAX convention computes the mathematical transpose of convolution, while `transpose_kernel=True` mimics TensorFlow/Keras `Conv2DTranspose` behavior by flipping the kernel's spatial axes.

3. **Clarified use cases**: Added guidance that `transpose_kernel=True` should be used when porting models from TensorFlow/Keras or working with pretrained TensorFlow checkpoints.

4. **Removed misleading language**: The previous `transpose_kernel` description called it "completely pointless and just makes input/output channel specification confusing" — this was replaced with a reference to the new example.

5. **Minor fix**: Removed an extra space before the period in the original `transpose_kernel=True` reference.

## Testing

No functional code changes were made — only documentation improvements. The existing test suite for `conv_transpose` (`testConvTranspose2DT` which tests `transpose_kernel=True` against the gradient of conv) remains valid.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof