### PR TITLE
Improve pjit pytree error messages: replace PytreeLeaf with None

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -367,8 +367,8 @@ def flatten_axes(name, treedef, axis_tree, *, kws=False, tupled_args=False):
           hint += (f" In particular, you're passing in a single argument which "
                    f"means that {name} might need to be wrapped in "
                    f"a singleton tuple.")
-    dummy_tree = tree_unflatten(treedef, [PytreeLeaf()] * treedef.num_leaves)
-    errors = prefix_errors(axis_tree, dummy_tree)
+    dummy_tree = tree_unflatten(treedef, [None] * treedef.num_leaves)
+    errors = prefix_errors(axis_tree, dummy_tree, is_leaf=lambda x: x is None)
     if errors:
       details = "\n  ".join(e(name).args[0] for e in errors)
       prefix_err_msg = (
@@ -431,8 +431,9 @@ def flatten_axis_resources(what, tree, shardings, tupled_args):
 
   # Because we only have the `tree` treedef and not the full pytree here,
   # we construct a dummy tree to compare against. Revise this in callers?
-  dummy_tree = tree_unflatten(tree, [PytreeLeaf()] * tree.num_leaves)
-  errors = prefix_errors(axis_tree, dummy_tree)
+  dummy_tree = tree_unflatten(tree, [None] * tree.num_leaves)
+  errors = prefix_errors(axis_tree, dummy_tree,
+                         is_leaf=lambda x: x is None)
   if errors:
     details = "\n".join(e(what).args[0] for e in errors)
     raise ValueError(


### PR DESCRIPTION
Good day,

## Problem

When pjit in_axis_resources (or in_layouts) is not a pytree prefix of the corresponding arguments pytrees, the error messages mention PytreeLeaf instances - an internal implementation detail that should not appear in user-facing error messages. Additionally, None is treated confusingly since it is a valid leaf value but gets described as if it were a container.

## Solution

Replace the use of PytreeLeaf() with None when constructing the dummy tree for prefix error checking, and pass is_leaf=lambda x: x is None to prefix_errors. This ensures:

1. Error messages no longer expose internal PytreeLeaf details
2. None is properly recognized as a leaf (not a container) in error messages
3. Errors are clearer and less confusing for users

## Changes

Modified two places in jax/_src/api_util.py:
- flatten_axes(): replaced PytreeLeaf() with None and added is_leaf argument
- flatten_axis_resources(): same replacement and added is_leaf argument

## Testing

- Changes are minimal and targeted to error reporting paths
- No functional behavior change for valid inputs

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof