### PR TITLE
[consts] Allow small constants to be included in the HLO and executable.

### DIFF
--- a/docs/internals/constants.md
+++ b/docs/internals/constants.md
@@ -76,6 +76,11 @@ by `mlir.ir_constant`: when a constant is encountered, we just reuse
 the existing lowering from `const_lowering` instead of emitting a
 `stablehlo.constant`.
 
+An exception is made for small constants, with size at most
+`config.embedded_constants_max_bytes`.
+These are not hoisted as additional arguments and are instead embedded in the
+generated HLO and the executable.
+
 When we lower an HLO inner function (i.e., not the `main` function),
 we call again `core.jaxpr_const_args`
 to get the actual constants in the corresponding `Jaxpr`. These are
@@ -90,9 +95,11 @@ but instead creates a block within the current function. It uses
 the enclosing function's `const_lowering`.
 
 Note also that there will still be `stablehlo.constant` in the lowered
-code, in three cases:
+code:
   * when the constant is a scalar; we want these constants to be
   available to XLA for constant folding.
+  * when the constant is small, with size at most
+  `config.embedded_constants_max_bytes`, as described above.
   * when the constant did not appear in the traced program, and is
   hence not in the `Jaxpr`. This can happen for constants that
   arise during lowering, e.g., the lowering of some PRNG functions

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1317,8 +1317,18 @@ use_simplified_jaxpr_constants = bool_state(
     help=('Enable a simplification of the handling of closed-over constants '
           'in Jaxpr. The value `True` enables the new behavior. '
           'This flag will exist only briefly, while we transition '
-          'users. See https://github.com/jax-ml/jax/pull/29679.'
+          'users. See https://docs.jax.dev/en/latest/internals/constants.html.'
           'DO NOT RELY ON THIS FLAG.'),
+    include_in_jit_key=True,
+    include_in_trace_context=True)
+
+embedded_constants_max_bytes = int_state(
+    name='jax_embedded_constants_max_bytes',
+    default=32,
+    help=('Maximum size in bytes of a constant that is allowed to be '
+          'embedded in the lowered HLO. Constants larger than this '
+          'are hoisted as additional arguments to the executable. '
+          'See https://docs.jax.dev/en/latest/internals/constants.html.'),
     include_in_jit_key=True,
     include_in_trace_context=True)
 

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -589,8 +589,12 @@ def is_literalable(x: Any, for_ad: bool = False) -> bool:
     do_lit_array = False
   for t in x_type.__mro__:
     if t in literalable_types:
-      return (not np.ndim(x) or do_lit_array)
+      return (do_lit_array or not np.ndim(x))
   return False
+
+def is_hoistable(v: Literal) -> bool:
+  return (np.shape(v.val) and
+          getattr(v.val, "nbytes", 4) > config.embedded_constants_max_bytes.value)
 
 @partial(weakref_lru_cache, trace_context_in_key=False)
 def jaxpr_const_args(jaxpr: Jaxpr) -> list[tuple[ArrayLike, AbstractValue]]:
@@ -602,12 +606,12 @@ def jaxpr_const_args(jaxpr: Jaxpr) -> list[tuple[ArrayLike, AbstractValue]]:
     return []
   consts_by_id: dict[int, tuple[ArrayLike, AbstractValue]] = {}
   for v in jaxpr.outvars:
-    if type(v) is Literal and np.shape(v.val):
+    if type(v) is Literal and is_hoistable(v):
       consts_by_id[id(v)] = (v.val, v.aval)
 
   for eqn in jaxpr.eqns:
     for v in eqn.invars:
-      if type(v) is Literal and np.shape(v.val):
+      if type(v) is Literal and is_hoistable(v):
         consts_by_id[id(v)] = (v.val, v.aval)
     consts_by_id.update({id(v_aval[0]): v_aval
                          for v_aval in eqn_params_const_args(eqn.params)})

--- a/tests/aot_test.py
+++ b/tests/aot_test.py
@@ -176,6 +176,18 @@ class JaxAotTest(jtu.JaxTestCase):
     self.assertArraysEqual(compiled(inp), const[0:8] + inp)
     self.assertCacheMisses(lambda: compiled(inp), cpp=0, aot_call=0)
 
+  @jtu.skip_on_flag("jax_use_simplified_jaxpr_constants", False)
+  def test_with_small_constants(self):
+    const1 = np.ones((4,), dtype=np.int32)  # Will be embedded
+    const2 = jnp.ones((16,), dtype=np.int32)
+    @jax.jit
+    def f():
+      return const1 + const2[:const1.shape[0]]
+    with config.embedded_constants_max_bytes(const1.nbytes):
+      compiled = f.lower().compile()
+    self.assertLen(compiled._params.const_args, 1)
+    self.assertIs(compiled._params.const_args[0], const2)
+
   def test_with_constants_and_dce(self):
     const = jnp.arange(16.) + 42.  # A distinctive shape and value
 
@@ -217,13 +229,13 @@ class JaxAotTest(jtu.JaxTestCase):
     # execution can be run in 64-bit or 32-bit mode.
     with config.enable_x64(True):
       arange = np.arange if use_np else jnp.arange
-      const = arange(8, dtype=np.int64) + 42
+      const = arange(16, dtype=np.int64) + 42
 
       @jax.jit
       def f(x):
         return lax.convert_element_type(const, np.float32) + x
 
-    inp = np.arange(8., dtype=np.float32)
+    inp = np.arange(16., dtype=np.float32)
     with config.enable_x64(True) if lower else contextlib.nullcontext():
       lowered = f.lower(inp)
     with config.enable_x64(True) if compile else contextlib.nullcontext():

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -3213,9 +3213,9 @@ class ArrayPjitTest(jtu.JaxTestCase):
     if jax.device_count() < 2:
       self.skipTest('Requires >=2 devices')
 
-    arr = jax.device_put(np.arange(8), make_single_device_sharding(
+    arr = jax.device_put(np.arange(16), make_single_device_sharding(
         jax.devices()[0]))
-    const = jax.device_put(np.arange(8), make_single_device_sharding(
+    const = jax.device_put(np.arange(16), make_single_device_sharding(
         jax.devices()[1]))
 
     @jax.jit
@@ -3226,7 +3226,7 @@ class ArrayPjitTest(jtu.JaxTestCase):
         ValueError, "Received incompatible devices for jitted computation"):
       f(arr)
 
-    out = f(np.arange(8))
+    out = f(np.arange(16))
     self.assertEqual(out.sharding, const.sharding)
 
   def test_device_put_grad(self):


### PR DESCRIPTION
Once we turn on JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS, all non-scalar closed-over constants are hoisted as additional arguments to an executable. This has benefits when the constants are large, but for small constants it is an overhead to pass additional small objects as arguments to an executable compared to the alternative of just storing those in the executable itself. 

Furthermore, it is easy to inadvertendly close-over small constants. A particularly large JAX project turns out to have 20 small constants that are closed over.

This CL adds a configuration option, JAX_EMBEDDED_CONSTANTS_MAX_BYTES (default 32), to configure the threshold over which constants are hoisted. This is a natural extension of the previous implementation that kept scalars inside the executable (but arrays of sized 1 were hoisted as arguments).

This change has effect only if JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS=1.