### PR TITLE
[consts] Implement logging of closed-over constants

### DIFF
--- a/docs/internals/constants.md
+++ b/docs/internals/constants.md
@@ -23,8 +23,13 @@ def f(x):
   return x + a_jax_array + np.full((16,), 42.) + jnp.full((16,), 142.)
 ```
 
+It is easy to close over constants inadvertently. You can set the configuration
+environment variable `JAX_CAPTURED_CONSTANTS_WARN_BYTES` to any non-negative
+value to log the closed-over constants of at least that size during lowering
+of a function.
+
 We describe below the **future** internal implementation details for
-constants. As of March 2026, this is not yet the default implementation;
+constants. As of April 2026, this is not yet the default implementation;
 it is enabled by the environment variable `JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS=True`.
 See further [below](#previous-implementation) for the details of the previous
 implementation, including its drawbacks.

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -593,7 +593,7 @@ def is_literalable(x: Any, for_ad: bool = False) -> bool:
   return False
 
 def is_hoistable(v: Literal) -> bool:
-  return (np.shape(v.val) and
+  return (np.ndim(v.val) > 0 and
           getattr(v.val, "nbytes", 4) > config.embedded_constants_max_bytes.value)
 
 @partial(weakref_lru_cache, trace_context_in_key=False)

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -1195,8 +1195,6 @@ def _get_unconstrained_variants(s, aval) -> UnconstrainedVariants:
 
 def check_jaxpr_constants(closed_jaxpr: core.ClosedJaxpr):
   """Check if a JAXPR contains an excessive amount of constants, if so, report where they were captured"""
-  if config.use_simplified_jaxpr_constants.value:
-    return
   if (threshold := config.captured_constants_warn_bytes.value) == -1:
     return
 
@@ -1238,6 +1236,20 @@ def check_jaxpr_constants(closed_jaxpr: core.ClosedJaxpr):
     warnings.warn(message)
   except Exception as exc:
     warnings.warn(message + f" Exception raised while generating report: {exc}")
+
+def log_closed_over_constant(v: core.Literal, eqn: core.JaxprEqn,
+                             debug_info: core.DebugInfo):
+  if getattr(v.val, "nbytes", 4) < config.captured_constants_warn_bytes.value:
+    return
+  msg = (f"Closed-over constant {type(v.val)}: {v.aval.str_short()} "
+         f"in {debug_info.func_src_info}")
+  if (num_frames := config.captured_constants_report_frames.value) > 0:
+    eqn_si = source_info_util.summarize(eqn.source_info, num_frames)
+    msg += (" used at:\n" +
+           "  " * 2 + eqn_si.replace("\n", "\n" + "  " * 2) +
+           "\n\n")
+  warnings.warn(msg)
+
 
 # TODO(phawkins): it is my firm belief that:
 # a) channel IDs have only a vestigal function when applied to collectives, and
@@ -2109,7 +2121,14 @@ def jaxpr_subcomp(
   foreach(write, jaxpr.invars, args)
   last_used = core.last_used(jaxpr)
   outer_traceback = outer_traceback or xc.Traceback()
+  should_log_constants = (config.use_simplified_jaxpr_constants.value and
+                          config.captured_constants_warn_bytes.value >= 0)
   for eqn in jaxpr.eqns:
+    if should_log_constants:
+      for v in eqn.invars:
+        if type(v) is core.Literal and core.is_hoistable(v):
+          log_closed_over_constant(v, eqn, jaxpr._debug_info)
+
     in_nodes = tuple(map(read, eqn.invars))
     assert all(_is_ir_values(v) for v in in_nodes), (eqn, in_nodes)
 

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -238,7 +238,7 @@ class JaxJitTest(jtu.JaxTestCase):
     self.assertArraysEqual(v2, v2_expected)
 
   @jtu.skip_on_flag("jax_use_simplified_jaxpr_constants", True)
-  def test_check_for_large_number_of_constants(self):
+  def test_check_for_large_number_of_constants_old(self):
     y = jnp.ones((128, 128))
     x = jnp.zeros((128,))
 
@@ -248,6 +248,28 @@ class JaxJitTest(jtu.JaxTestCase):
       return jax.jit(func)
 
     with self.assertWarnsRegex(UserWarning, "A large amount of constants were captured during lowering"):
+      with config.captured_constants_warn_bytes(y.nbytes):
+        jit_maker()(x)
+
+    with self.assertNoWarnings():
+      with config.captured_constants_warn_bytes(y.nbytes + 1):
+        jit_maker()(x)
+
+      with config.captured_constants_warn_bytes(-1):
+        jit_maker()(x)
+
+  @jtu.skip_on_flag("jax_use_simplified_jaxpr_constants", False)
+  def test_check_for_large_number_of_constants_new(self):
+    y = np.ones((128, 128), dtype=np.float32)
+    x = jnp.zeros((128,))
+
+    def jit_maker(): # need to ensure we lower at each test
+      def my_func(x):
+        return x @ y
+      return jax.jit(my_func)
+
+    with self.assertWarnsRegex(UserWarning,
+        r'Closed-over constant .* float32\[128,128\] in my_func .*'):
       with config.captured_constants_warn_bytes(y.nbytes):
         jit_maker()(x)
 


### PR DESCRIPTION
In the process of landing JAX_USE_SIMPLFIED_JAXPR_CONSTANTS=1 by default, I find test failures due to inadvertent closing over constants. The logging introduced here can help find where those constants are closed-over.

We reuse the existing configuration variables JAX_CAPTURED_CONSTANTS_WARN_BYTES and JAX_CAPTURED_CONSTANTS_REPORT_FRAMES. We cannot reuse the same implementation because with JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS the constants are not in the `jaxpr.consts` anymore.

TODO: this PR will be merged with #36974, and only the hoisted closed-over constants will be logged.
