### PR TITLE
Fix type hint for bp parameter in jax.scipy.signal.detrend

### DIFF
--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -490,7 +490,8 @@ def correlate2d(in1: Array, in2: Array, mode: ModeString = 'full', boundary: str
   return result
 
 
-def detrend(data: ArrayLike, axis: int = -1, type: str = 'linear', bp: int = 0,
+def detrend(data: ArrayLike, axis: int = -1, type: str = 'linear',
+            bp: int | Sequence[int] | np.ndarray = 0,
             overwrite_data: None = None) -> Array:
   """
   Remove linear or piecewise linear trends from data.


### PR DESCRIPTION
### Motivation
- I was taking a look at this issue: https://github.com/jax-ml/jax/issues/12224 and noticed the type hint wasn't complete for an existing function

### Testing
- Ran pre-commit and unit tests

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->