### PR TITLE
[ROCm] Skip `tridiagonal_solve_perturbed` code path in eigh unit tests on ROCm

### DIFF
--- a/tests/eigh_test.py
+++ b/tests/eigh_test.py
@@ -372,7 +372,10 @@ class LaxLinalgEighTest(jtu.JaxTestCase):
     atol = 4 * np.sqrt(n) * finfo.eps * np.amax(np.abs(eigvals_expected))
     self.assertAllClose(eigvals_expected, eigvals, atol=atol, rtol=1e-4)
 
-    if jaxlib_version >= (0, 10) and not jtu.test_device_matches(["tpu"]):
+    # TODO: The ROCm 0.10.0 plugin is not yet released. This will be
+    # re-enabled for ROCm on the 0.10.0 ROCm plugin release.
+    if (jaxlib_version >= (0, 10) and
+        not jtu.test_device_matches(["tpu", "rocm"])):
       @jax.jit
       def solve(a, b):
         return jax.scipy.linalg.eigh_tridiagonal(a, b, eigvals_only=False)


### PR DESCRIPTION
## Summary
The ROCm 0.10.0 plugin is not yet released so invocations of the FFI call `tridiagonal_solve_perturbed` will fail when jaxlib versions of 0.10.0 or higher are used in conjunction with an old ROCm plugin. The code path for this FFI call in the unit tests is skipped until the ROCm 0.10.0 plugin is released.

## Changes
The code block in `tests/eigh_test.py` that invokes the FFI call `tridiagonal_solve_perturbed` (`jax.scipy.linalg.eigh_tridiagonal(eigvals_only=False)`) has been skipped on ROCm devices.