### PR TITLE
Fixes #35493

### DIFF
--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2582,8 +2582,10 @@ def _double_sided_maxwell(key, loc, scale, shape, dtype) -> Array:
 def weibull_min(key: ArrayLike,
                 scale: RealArray,
                 concentration: RealArray,
-                shape: Shape = (),
-                dtype: DTypeLikeFloat | None = None) -> Array:
+                shape: Shape | None = None,
+                dtype: DTypeLikeFloat | None = None,
+                *,
+                out_sharding: NamedSharding | P | None = None) -> Array:
   r"""Sample from a Weibull distribution.
 
   The values are distributed according to the probability density function:
@@ -2595,11 +2597,22 @@ def weibull_min(key: ArrayLike,
   parameter, and :math:`\sigma > 0` is the scale parameter.
 
   Args:
-    key: a PRNG key.
+    key: A PRNG key.
     scale: The scale parameter of the distribution.
     concentration: The concentration parameter of the distribution.
-    shape: The shape added to the parameters loc and scale broadcastable shape.
+    shape: Optional. A tuple of nonnegative integers representing the result
+      shape. Must be broadcast-compatible with ``scale`` and ``concentration``.
+      The default (None) produces a result shape equal to the result of
+      broadcasting ``scale`` and ``concentration``.
     dtype: The type used for samples.
+    out_sharding: Optional. Specifies how the output array should be sharded
+      across devices in multi-device computation. Can be a
+      :class:`~jax.sharding.NamedSharding`, a :class:`~jax.sharding.PartitionSpec`
+      (``P``), or ``None`` (default). When specified, the output will be sharded
+      according to the given sharding specification. Primarily used in explicit
+      sharding mode.
+      See the `explicit sharding tutorial <https://docs.jax.dev/en/latest/parallel.html>`_
+      for more details.
 
   Returns:
     A jnp.array of samples.
@@ -2611,14 +2624,18 @@ def weibull_min(key: ArrayLike,
   if not dtypes.issubdtype(dtype, np.floating):
     raise ValueError(f"dtype argument to `weibull_min` must be a float "
                      f"dtype, got {dtype}")
-  shape = core.canonicalize_shape(shape)
-  return _weibull_min(key, scale, concentration, shape, dtype)
+  shape = _check_broadcast_shapes("weibull_min", shape, scale, concentration)
+  out_sharding = canonicalize_sharding_for_samplers(out_sharding, "weibull_min", shape)
+  _check_all_safe_to_cast("weibull_min", dtype, scale, concentration)
+  return maybe_auto_axes(_weibull_min, out_sharding, shape=shape, dtype=dtype)(key, scale, concentration)
 
 
 @jit(static_argnums=(3, 4))
 def _weibull_min(key, scale, concentration, shape, dtype) -> Array:
   random_uniform = uniform(
       key=key, shape=shape, minval=0, maxval=1, dtype=dtype)
+  scale = lax.convert_element_type(scale, dtype)
+  concentration = lax.convert_element_type(concentration, dtype)
 
   # Inverse weibull CDF.
   return jnp.power(-jnp.log1p(-random_uniform), 1.0/concentration) * scale

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -244,6 +244,7 @@ _OUT_SHARDING_CASES = [
     ('uniform', lambda key, n, s: random.uniform(key, shape=(n,), out_sharding=s)),
     ('gamma', lambda key, n, s: random.gamma(key, a=2.0, shape=(n,), out_sharding=s)),
     ('wald', lambda key, n, s: random.wald(key, mean=1.0, shape=(n,), out_sharding=s)),
+    ('weibull_min', lambda key, n, s: random.weibull_min(key, scale=1., concentration=2., shape=(n,), out_sharding=s)),
 ]
 
 
@@ -1194,6 +1195,36 @@ class DistributionsTest(RandomTestBase):
       self.assertAllClose(np.std(samples), std, atol=0., rtol=0.1)
       self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.weibull_min(
           c=concentration, scale=scale).cdf)
+
+  def test_weibull_min_shape_none_broadcasting(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/35493
+    # When shape=None, scale and concentration should be broadcast together
+    # so different samples are drawn for each element.
+    key = random.key(0)
+    scale = np.ones(4)
+    concentration = np.ones(4)
+
+    # With shape=None, internal broadcasting should yield independent samples.
+    result_implicit = random.weibull_min(key, scale, concentration)
+    # With shape=(4,), the result should match.
+    result_explicit = random.weibull_min(key, scale, concentration, shape=(4,))
+
+    self.assertEqual(result_implicit.shape, (4,))
+    np.testing.assert_array_equal(result_implicit, result_explicit)
+    # All values should not be identical (would indicate a broadcasting bug).
+    self.assertFalse(np.all(result_implicit == result_implicit[0]),
+                    "weibull_min returned identical values for all elements, "
+                    "indicating a shape broadcasting bug.")
+
+  @jax.numpy_dtype_promotion('standard')
+  def testWeibullComplexValueRaisesError(self):
+    key = self.make_key(0)
+    complex_scale = jnp.array(1.0 + 0j)
+    with self.assertRaisesRegex(dtypes.TypePromotionError, "cannot safely cast argument of type complex"):
+      random.weibull_min(key, scale=complex_scale, concentration=2.0, shape=(10,))
+    complex_concentration = jnp.array(2.0 + 0j)
+    with self.assertRaisesRegex(dtypes.TypePromotionError, "cannot safely cast argument of type complex"):
+      random.weibull_min(key, scale=1.0, concentration=complex_concentration, shape=(10,))
 
   @parameterized.named_parameters(
       ('test1', 4.0, 1.0),


### PR DESCRIPTION
Fixes two issues noted in #35493 :
- When `shape=None` but `concentration=np.ones(n)`, this should be equivalent to when `shape=n`. 
- The output shape should always match the `dtype` argument. 