### PR TITLE
[internal] rename `is_python_scalar` to `is_weakly_typed_scalar`

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -926,7 +926,7 @@ def is_weakly_typed(x: Any) -> bool:
   except AttributeError:
     return False
 
-def is_python_scalar(x: Any) -> bool:
+def is_weakly_typed_scalar(x: Any) -> bool:
   try:
     return x.aval.weak_type and np.ndim(x) == 0
   except AttributeError:

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -440,7 +440,7 @@ def _numpy_array_attribute_handler(val: np.ndarray | np.generic) -> ir.Attribute
         "NumPy arrays with zero strides are not supported as MLIR attributes")
   if val.dtype == dtypes.float0:
     val = np.zeros(val.shape, dtype=np.bool_)
-  if dtypes.is_python_scalar(val) or np.isscalar(val):
+  if dtypes.is_weakly_typed_scalar(val) or np.isscalar(val):
     return _numpy_scalar_attribute(val)
   else:
     return _numpy_array_attribute(val)

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -9021,7 +9021,7 @@ def _check_shapelike(fun_name, arg_name, obj, non_zero_shape=False):
 
 def _const(example, val):
   dtype = _dtype(example)
-  if dtypes.is_python_scalar(example):
+  if dtypes.is_weakly_typed_scalar(example):
     val = dtypes.scalar_type_of(example)(val)
     return val if dtype == _dtype(val) else np.array(val, dtype)
   return literals.TypedNdArray(np.array(val, dtype))

--- a/jax/_src/numpy/array_constructors.py
+++ b/jax/_src/numpy/array_constructors.py
@@ -227,7 +227,7 @@ def array(object: Any, dtype: DTypeLike | None = None, copy: bool = True,
     )
 
   # For Python scalar literals, call coerce_to_array to catch any overflow
-  # errors. We don't use dtypes.is_python_scalar because we don't want this
+  # errors. We don't use dtypes.is_weakly_typed_scalar because we don't want this
   # triggering for traced values. We do this here because it matters whether or
   # not dtype is None. We don't assign the result because we want the raw object
   # to be used for type inference below.

--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -50,7 +50,7 @@ def _isscalar(element: Any) -> bool:
   m = getattr(element, '__jax_array__', None)
   if m is not None:
     element = m()
-  return dtypes.is_python_scalar(element) or np.isscalar(element)
+  return dtypes.is_weakly_typed_scalar(element) or np.isscalar(element)
 
 def _moveaxis(a: ArrayLike, source: int, destination: int) -> Array:
   # simplified version of jnp.moveaxis() for local use.


### PR DESCRIPTION
The old name is misleading