### PR TITLE
Add jax.scipy.linalg.circulant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     TensorFlow's AREA resizing ({jax-issue}`#20098`).
   * Added {func}`jax.scipy.linalg.hadamard` for constructing Hadamard
     matrices ({jax-issue}`#10144`).
+  * Added {func}`jax.scipy.linalg.circulant` for constructing circulant
+    matrices ({jax-issue}`#10144`).
   * Moved RNG APIs from "implementations" to dtypes ({jax-issue}`#27854`):
     * Added `jax.random.key_dtype` to get the dtype corresponding to a PRNG
       implementation name.

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -57,6 +57,7 @@ jax.scipy.linalg
    cho_factor
    cho_solve
    cholesky
+   circulant
    det
    eigh
    eigh_tridiagonal

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -2569,6 +2569,49 @@ def _hankel(c: Array, r: Array) -> Array:
       precision=lax.Precision.HIGHEST)[0]
 
 
+def circulant(c: ArrayLike) -> Array:
+  r"""Construct a circulant matrix.
+
+  JAX implementation of :func:`scipy.linalg.circulant`.
+
+  A circulant matrix has cyclically shifted columns: :math:`A_{ij} = c_{(i - j) \bmod n}`
+  for :math:`0 \le i, j < n`, where ``c`` specifies the first column.
+
+  Args:
+    c: array of shape ``(..., N)`` specifying the first column.
+
+  Returns:
+    A circulant matrix of shape ``(..., N, N)``.
+
+  Examples:
+    >>> c = jnp.array([1, 2, 3])
+    >>> jax.scipy.linalg.circulant(c)
+    Array([[1, 3, 2],
+           [2, 1, 3],
+           [3, 2, 1]], dtype=int32)
+
+    For N-dimensional ``c``, the result is a batch of circulant matrices:
+
+    >>> c = jnp.array([[1, 2, 3], [4, 5, 6]])
+    >>> jax.scipy.linalg.circulant(c)
+    Array([[[1, 3, 2],
+            [2, 1, 3],
+            [3, 2, 1]],
+    <BLANKLINE>
+           [[4, 6, 5],
+            [5, 4, 6],
+            [6, 5, 4]]], dtype=int32)
+  """
+  check_arraylike("circulant", c)
+  return _circulant(jnp.atleast_1d(jnp.asarray(c)))
+
+@partial(jnp_vectorize.vectorize, signature="(n)->(n,n)")
+def _circulant(c: Array) -> Array:
+  n, = c.shape
+  idx = (jnp.arange(n)[:, None] - jnp.arange(n)[None, :]) % n
+  return c[idx]
+
+
 @jit(static_argnames=("n",))
 def hilbert(n: int) -> Array:
   r"""Create a Hilbert matrix of order n.

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -20,6 +20,7 @@ from jax._src.scipy.linalg import (
   cholesky as cholesky,
   cho_factor as cho_factor,
   cho_solve as cho_solve,
+  circulant as circulant,
   det as det,
   eigh as eigh,
   eigh_tridiagonal as eigh_tridiagonal,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -96,6 +96,14 @@ def osp_linalg_toeplitz(c: np.ndarray, r: np.ndarray | None = None) -> np.ndarra
     return np.vectorize(
       scipy.linalg.toeplitz, signature="(m),(n)->(m,n)", otypes=(np.result_type(c, r),))(c, r)
 
+def osp_linalg_circulant(c: np.ndarray) -> np.ndarray:
+  """Batched scipy circulant for testing."""
+  if scipy_version >= (1, 15):
+    return scipy.linalg.circulant(c)
+  c = np.atleast_1d(c)
+  return np.vectorize(
+      scipy.linalg.circulant, signature="(n)->(n,n)", otypes=(c.dtype,))(c)
+
 def osp_linalg_hankel(c: np.ndarray, r: np.ndarray | None = None) -> np.ndarray:
   """Batched scipy hankel for testing."""
   if scipy_version >= (1, 19):
@@ -2287,6 +2295,15 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       )
       self._CompileAndCheck(jsp.linalg.hankel, args_maker)
 
+  @jtu.sample_product(
+     shape=[(), (3,), (0,), (1,), (5,), (2, 3), (1, 2, 4)],
+     dtype=float_types + complex_types + int_types,
+  )
+  def testCirculantConstruction(self, shape, dtype):
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape, dtype)]
+    self._CheckAgainstNumpy(osp_linalg_circulant, jsp.linalg.circulant, args_maker)
+    self._CompileAndCheck(jsp.linalg.circulant, args_maker)
 
   @jtu.sample_product(
     shape=[(2, 3), (4, 6), (50, 7), (100, 110)],


### PR DESCRIPTION
Adds `jax.scipy.linalg.circulant` to continue closing the remaining gap vs `scipy.linalg`'s special matrices listed in #10144 (following `hilbert`, `pascal`, `hankel`, `toeplitz`).

The implementation uses a single gather on a precomputed index matrix, so it has no jit restrictions and preserves the input dtype for int/float/complex. It also accepts batched inputs of shape `(..., N)`, returning `(..., N, N)`, matching the convention already established for `toeplitz` and `hankel`.

- `jax/_src/scipy/linalg.py`: `circulant` + vectorized inner
- `jax/scipy/linalg.py`: re-export
- `tests/linalg_test.py`: `testCirculantConstruction` (sample_product across shapes/dtypes incl. batched), a SciPy doc known-case test, and an `osp_linalg_circulant` helper mirroring the `osp_linalg_hankel` pattern
- `docs/jax.scipy.rst` + `CHANGELOG.md` updated

Refs #10144.