### PR TITLE
Add 'dtype' argument to `permutation` sampler

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -700,7 +700,8 @@ def permutation(key: ArrayLike,
                 axis: int = 0,
                 independent: bool = False,
                 *,
-                out_sharding: NamedSharding | P | None = None) -> Array:
+                out_sharding: NamedSharding | P | None = None,
+                dtype: DTypeLike | None = None) -> Array:
   """Returns a randomly permuted array or range.
 
   Args:
@@ -718,6 +719,8 @@ def permutation(key: ArrayLike,
       sharding mode.
       See the `explicit sharding tutorial <https://docs.jax.dev/en/latest/parallel.html>`_
       for more details.
+    dtype: optional. If specified, determines the dtype of the np.arange used
+      when x is an integer. If x is an array, the array must have this dtype.
 
   Returns:
     A shuffled version of x or array range
@@ -730,8 +733,12 @@ def permutation(key: ArrayLike,
     if not np.issubdtype(lax.dtype(x), np.integer):
       raise TypeError("x must be an integer or at least 1-dimensional")
     r = core.concrete_or_error(int, x, "argument x of jax.random.permutation()")
-    return maybe_auto_axes(lambda key: _shuffle(key, jnp.arange(r), axis),
-                           out_sharding)(key)
+    return maybe_auto_axes(
+        lambda key: _shuffle(key, jnp.arange(r, dtype=dtype), axis),
+        out_sharding)(key)
+  if dtype is not None and lax.dtype(x) != np.dtype(dtype):
+    raise TypeError(
+        f"dtype argument {np.dtype(dtype)} does not match dtype of x: {lax.dtype(x)}")
   return maybe_auto_axes(
       _permutation, out_sharding, axis=axis, independent=independent)(key, x)
 

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -400,6 +400,26 @@ class DistributionsTest(RandomTestBase):
     with self.assertRaises(core.ConcretizationTypeError):
       jax.jit(random.permutation)(key, 10)
 
+  def testPermutationDtype(self):
+    key = self.make_key(0)
+    # When x is an integer, dtype controls the arange dtype.
+    perm = random.permutation(key, 10, dtype=np.int16)
+    self.assertEqual(perm.dtype, np.dtype(np.int16))
+    self.assertArraysEqual(np.sort(perm), np.arange(10, dtype=np.int16))
+
+    # Default dtype (None) still works.
+    perm_default = random.permutation(key, 10)
+    self.assertArraysEqual(np.sort(perm_default), np.arange(10))
+
+    # When x is an array and dtype matches, no error.
+    x = np.arange(10, dtype=np.int32)
+    perm = random.permutation(key, x, dtype=np.int32)
+    self.assertEqual(perm.dtype, np.dtype(np.int32))
+
+    # When x is an array and dtype mismatches, raise TypeError.
+    with self.assertRaises(TypeError):
+      random.permutation(key, x, dtype=np.int16)
+
   @jtu.sample_product(
     p=[0.1, 0.5, 0.9],
     dtype=jtu.dtypes.floating,


### PR DESCRIPTION
This PR makes the `permutation` sampler similar to other jax samplers by giving it a `dtype` argument, which is used when the input array to permute is provided implicitly as an integer rather than an actual array. 