### PR TITLE
Add jax.scipy.linalg.hadamard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 * New features
   * Added `ResizeMethod.AREA` to {func}`jax.image.resize`, which matches
     TensorFlow's AREA resizing ({jax-issue}`#20098`).
+  * Added {func}`jax.scipy.linalg.hadamard` for constructing Hadamard
+    matrices ({jax-issue}`#10144`).
 
 * Breaking changes
   * `with mesh:` context manager has been deprecated. Please use

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -63,6 +63,7 @@ jax.scipy.linalg
    expm
    expm_frechet
    funm
+   hadamard
    hessenberg
    hankel
    hilbert

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from functools import partial
+import math
 import textwrap
 from typing import overload, Any, Literal
 import warnings
@@ -34,7 +35,7 @@ from jax._src.numpy.util import (
     check_arraylike, promote_dtypes, promote_dtypes_inexact,
     promote_dtypes_complex, promote_args_inexact)
 from jax._src.tpu.linalg import qdwh
-from jax._src.typing import Array, ArrayLike
+from jax._src.typing import Array, ArrayLike, DTypeLike
 
 
 _no_chkfinite_doc = textwrap.dedent("""
@@ -2660,6 +2661,41 @@ def _binom(n, k):
   b = lax.lgamma(n - k + 1.0)
   c = lax.lgamma(k + 1.0)
   return lax.exp(a - b - c)
+
+
+@partial(jit, static_argnames=("n", "dtype"))
+def hadamard(n: int, dtype: DTypeLike = int) -> Array:
+  r"""Construct an n-by-n Hadamard matrix.
+
+  JAX implementation of :func:`scipy.linalg.hadamard`.
+
+  For ``n`` a positive power of 2, the Hadamard matrix :math:`H_n` satisfies
+  :math:`H_n H_n^T = n I`. It is defined recursively by the Sylvester
+  construction: :math:`H_1 = [[1]]`, and
+  :math:`H_{2m} = \begin{bmatrix} H_m & H_m \\ H_m & -H_m \end{bmatrix}`.
+
+  Args:
+    n: size of the matrix. Must be a positive power of 2.
+    dtype: output dtype. Defaults to ``int``.
+
+  Returns:
+    A Hadamard matrix of shape ``(n, n)``.
+
+  Examples:
+    >>> jax.scipy.linalg.hadamard(4)
+    Array([[ 1,  1,  1,  1],
+           [ 1, -1,  1, -1],
+           [ 1,  1, -1, -1],
+           [ 1, -1, -1,  1]], dtype=int32)
+  """
+  if n < 1 or not math.log2(n).is_integer():
+    raise ValueError(
+        f"n must be a positive power of 2; got {n}.")
+  lg2 = int(math.log2(n))
+  H = jnp.ones((1, 1), dtype=dtype)
+  for _ in range(lg2):
+    H = jnp.block([[H, H], [H, -H]])
+  return H
 
 
 def _solve_sylvester_triangular_scan(R: Array, S: Array, F: Array) -> Array:

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -25,6 +25,7 @@ from jax._src.scipy.linalg import (
   eigh_tridiagonal as eigh_tridiagonal,
   expm as expm,
   expm_frechet as expm_frechet,
+  hadamard as hadamard,
   hessenberg as hessenberg,
   hankel as hankel,
   hilbert as hilbert,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2595,6 +2595,22 @@ class LaxLinalgTest(jtu.JaxTestCase):
     self._CompileAndCheck(jsp_fun, args_maker)
 
   @jtu.sample_product(
+    n=[1, 2, 4, 8, 16],
+    dtype=int_types + float_types,
+  )
+  def testHadamard(self, n, dtype):
+    args_maker = lambda: []
+    osp_fun = partial(osp.linalg.hadamard, n=n, dtype=dtype)
+    jsp_fun = partial(jsp.linalg.hadamard, n=n, dtype=dtype)
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker)
+    self._CompileAndCheck(jsp_fun, args_maker)
+
+  @jtu.sample_product(n=[0, -1, 3, 5, 7])
+  def testHadamardInvalidN(self, n):
+    with self.assertRaisesRegex(ValueError, "positive power of 2"):
+      jsp.linalg.hadamard(n)
+
+  @jtu.sample_product(
       shape=[(5, 1), (10, 4), (128, 12)],
       dtype=float_types,
       symmetrize_output=[True, False],


### PR DESCRIPTION
Adds `jax.scipy.linalg.hadamard` as a follow-up to #37015 (circulant) to continue closing the gap vs `scipy.linalg`'s special matrices listed in #10144.

Uses the Sylvester construction (iterative `jnp.block` expansion). The public function is jitted with static `n` and `dtype`, so the log2(n)-step expansion unrolls at trace time. Validation mirrors SciPy: raises `ValueError` when `n` is not a positive power of 2, and the check accepts float-valued integer `n` (e.g. `4.0`) the same way SciPy does.

- `jax/_src/scipy/linalg.py`: `hadamard` implementation
- `jax/scipy/linalg.py`: re-export
- `tests/linalg_test.py`: `testHadamard` (sample_product over `n` and signed int / float dtypes) + `testHadamardInvalidN` (parametrized over bad `n` values)
- `docs/jax.scipy.rst` + `CHANGELOG.md` updated

Refs #10144.