### PR TITLE
[ROCm] Fix env var and backend factory leak in xla_bridge_test

### DIFF
--- a/tests/xla_bridge_test.py
+++ b/tests/xla_bridge_test.py
@@ -32,6 +32,14 @@ mock = absltest.mock
 
 class XlaBridgeTest(jtu.JaxTestCase):
 
+  def setUp(self):
+    super().setUp()
+    # Tests in this class mutate xb._backend_factories via
+    # register_pjrt_plugin_factories_from_env(); isolate the mutation so it
+    # doesn't leak into other tests in the same xdist worker (e.g.,
+    # clear_backends_test.py, logging_test.py).
+    self.enter_context(mock.patch.dict(xb._backend_factories))
+
   def test_set_device_assignment_no_partition(self):
     compile_options = compiler.get_compile_options(
         num_replicas=4, num_partitions=1, device_assignment=[0, 1, 2, 3])
@@ -121,20 +129,18 @@ class XlaBridgeTest(jtu.JaxTestCase):
       xb.local_devices(backend="foo")
 
   def test_register_plugin(self):
-    with self.assertLogs(level="WARNING") as log_output:
-      with mock.patch.object(xc, "load_pjrt_plugin_dynamically", autospec=True):
-        if platform.system() == "Windows":
-          os.environ["PJRT_NAMES_AND_LIBRARY_PATHS"] = (
-              "name1;path1,name2;path2,name3"
-          )
-        else:
-          os.environ["PJRT_NAMES_AND_LIBRARY_PATHS"] = (
-              "name1:path1,name2:path2,name3"
-          )
-        with mock.patch.object(
-            _profiler, "register_plugin_profiler", autospec=True
-        ):
-          xb.register_pjrt_plugin_factories_from_env()
+    env_value = (
+        "name1;path1,name2;path2,name3"
+        if platform.system() == "Windows"
+        else "name1:path1,name2:path2,name3"
+    )
+    with (
+        self.assertLogs(level="WARNING") as log_output,
+        mock.patch.object(xc, "load_pjrt_plugin_dynamically", autospec=True),
+        mock.patch.dict(os.environ, {"PJRT_NAMES_AND_LIBRARY_PATHS": env_value}),
+        mock.patch.object(_profiler, "register_plugin_profiler", autospec=True),
+    ):
+      xb.register_pjrt_plugin_factories_from_env()
     registration = xb._backend_factories["name1"]
     with mock.patch.object(xc, "make_c_api_client", autospec=True) as mock_make:
       with mock.patch.object(
@@ -165,16 +171,17 @@ class XlaBridgeTest(jtu.JaxTestCase):
     test_json_file_path = os.path.join(
         os.path.dirname(__file__), "testdata/example_pjrt_plugin_config.json"
     )
-    os.environ["PJRT_NAMES_AND_LIBRARY_PATHS"] = (
+    env_value = (
         f"name1;{test_json_file_path}"
         if platform.system() == "Windows"
         else f"name1:{test_json_file_path}"
     )
-    with mock.patch.object(xc, "load_pjrt_plugin_dynamically", autospec=True):
-      with mock.patch.object(
-          _profiler, "register_plugin_profiler", autospec=True
-      ):
-        xb.register_pjrt_plugin_factories_from_env()
+    with (
+        mock.patch.dict(os.environ, {"PJRT_NAMES_AND_LIBRARY_PATHS": env_value}),
+        mock.patch.object(xc, "load_pjrt_plugin_dynamically", autospec=True),
+        mock.patch.object(_profiler, "register_plugin_profiler", autospec=True),
+    ):
+      xb.register_pjrt_plugin_factories_from_env()
     registration = xb._backend_factories["name1"]
     with mock.patch.object(xc, "make_c_api_client", autospec=True) as mock_make:
       with mock.patch.object(

--- a/tests/xla_bridge_test.py
+++ b/tests/xla_bridge_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import os
 import platform
 
@@ -28,6 +29,26 @@ from jax._src.lib import xla_client as xc
 config.parse_flags_with_absl()
 
 mock = absltest.mock
+
+
+def restore_backends_and_env(test_method):
+  """Restores ``os.environ`` and ``xb._backend_factories`` after a test.
+
+  Some plugin-registration tests below set
+  ``os.environ["PJRT_NAMES_AND_LIBRARY_PATHS"]`` and add entries to the
+  ``xb._backend_factories`` global.
+  """
+  @functools.wraps(test_method)
+  def wrapper(*args, **kwargs):
+    orig_environ = dict(os.environ)
+    orig_factories = dict(xb._backend_factories)
+    try:
+      return test_method(*args, **kwargs)
+    finally:
+      os.environ.clear()
+      os.environ.update(orig_environ)
+      xb._backend_factories = orig_factories
+  return wrapper
 
 
 class XlaBridgeTest(jtu.JaxTestCase):
@@ -120,6 +141,7 @@ class XlaBridgeTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(RuntimeError, "Unknown backend foo"):
       xb.local_devices(backend="foo")
 
+  @restore_backends_and_env
   def test_register_plugin(self):
     with self.assertLogs(level="WARNING") as log_output:
       with mock.patch.object(xc, "load_pjrt_plugin_dynamically", autospec=True):
@@ -161,6 +183,7 @@ class XlaBridgeTest(jtu.JaxTestCase):
       options["ml_framework_version"] = version.__version__
     mock_make.assert_called_once_with("name1", options, None)
 
+  @restore_backends_and_env
   def test_register_plugin_with_config(self):
     test_json_file_path = os.path.join(
         os.path.dirname(__file__), "testdata/example_pjrt_plugin_config.json"
@@ -202,6 +225,7 @@ class XlaBridgeTest(jtu.JaxTestCase):
 
     mock_make.assert_called_once_with("name1", options, None)
 
+  @restore_backends_and_env
   def test_register_plugin_with_lazy_config(self):
     options = {"bar": "baz"}
 


### PR DESCRIPTION
## Summary

`test_register_plugin`, `test_register_plugin_with_config`, and
`test_register_plugin_with_lazy_config` write to
`os.environ["PJRT_NAMES_AND_LIBRARY_PATHS"]` and `xb._backend_factories`
without restoring either, so the state leaks across xdist workers and
breaks `logging_test` subprocess tests and `clear_backends_test`.

### Changes

- Add a `restore_backends_and_env` decorator that snapshots `os.environ`
  and `xb._backend_factories` before the test and restores both in a
  `finally` block.
- Apply the decorator to the three plugin-registration tests.

### Testing

Ran `xla_bridge_test.py` under pytest-xdist alongside `clear_backends_test.py`
and `logging_test.py`  ,no cross-test pollution observed.