### PR TITLE
[ROCm] Override HIP_VISIBLE_DEVICES per ROCm xdist worker

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -82,3 +82,8 @@ def pytest_collection() -> None:
     os.environ["ROCR_VISIBLE_DEVICES"] = str(
         xdist_worker_number % num_rocm_devices
     )
+    # ROCR_VISIBLE_DEVICES filters HSA to a single physical device, which
+    # becomes HIP index 0. The container env-file may preset
+    # HIP_VISIBLE_DEVICES to all GPUs; override to "0" so HIP doesn't try to
+    # enable agents that ROCr just hid.
+    os.environ["HIP_VISIBLE_DEVICES"] = "0"


### PR DESCRIPTION
When the conftest restricts ROCR_VISIBLE_DEVICES to a single physical device per xdist worker, HIP_VISIBLE_DEVICES is left at whatever the runner injected (typically all GPUs, e.g., '0,1,2,3,4,5,6,7' from the GitHub gha-gpu-isolation-settings env-file mounted at container start).

HIP_VISIBLE_DEVICES indexes into the already-ROCr-filtered device list, so the leftover indices >= 1 then reference agents that ROCr no longer exposes. The HIP runtime emits one warning per such agent on every import jax in every test process:

```bash
  agent.cpp:461] Attempt to enable hip visiblity for agent-N which is
  not visible to HSA (ROCR)
```
Beyond the stderr noise, this can cause subprocess-based logging tests that assert on captured stderr to fail intermittently when the warnings displace the expected log lines (e.g., on multi-GPU CI runners with xdist '--dist=loadfile').

Set HIP_VISIBLE_DEVICES='0' alongside ROCR_VISIBLE_DEVICES to give HIP a consistent single-device view (the only valid index in the filtered ROCr list).
