### PR TITLE
improve jnp.diag performance by broadcasting across columns

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -7346,8 +7346,8 @@ def _diag(v: Array, k: int):
   if len(v_shape) == 1:
     zero = lambda x: lax.full_like(x, shape=(), fill_value=0)
     n = v_shape[0] + abs(k)
-    v = lax.pad(v, zero(v), ((max(0, k), max(0, -k), 0),))
-    return where(eye(n, k=k, dtype=bool), v, array_creation.zeros_like(v))
+    v = lax.pad(v, zero(v), ((max(0, -k), max(0, k), 0),))
+    return where(eye(n, k=k, dtype=bool), v[:, None], zero(v))
   elif len(v_shape) == 2:
     return diagonal(v, offset=k)
   else:


### PR DESCRIPTION
I noticed very poor performance of the current `jnp.diag` implementation in two specific cases:

1. Multiplying by a broadcasted vector when using transcendental functions: `diag_impl(jnp.sin(v)) * jnp.cos(v)[:, None]` (referred to in figure as "argtrigls_mwe" due to similar operation coming up in the computation of that CUTEst functions Hessian).
2. Reverse-mode AD (i.e. VJP's)

There are three obvious implementations of `jnp.diag`

Current:
```python
def where_eye_impl(v):
    """`where(eye, v, 0)` — mask-and-select pattern (inline jnp._diag body)."""
    n = v.shape[0]
    return jnp.where(jnp.eye(n, dtype=jnp.bool_), v, jnp.zeros((), v.dtype))
```

Scatter:
```python
def scatter_impl(v):
    """`zeros.at[i, i].set(v)` — scatter pattern."""
    n = v.shape[0]
    idx = jnp.arange(n)
    return jnp.zeros((n, n), v.dtype).at[idx, idx].set(v)
```

Eye;
```python
def v_times_eye_impl(v):
    """`v[:, None] * jnp.eye(n)` — pure dense multiply."""
    n = v.shape[0]
    return v[:, None] * jnp.eye(n, dtype=v.dtype)
```

For standard benchmarks (just build, or build+matvec) the implementations are a bit of a wash (with v*eye often winning by 15–25% on GPU). But for the problems above, both eye and scatter are up to 5x faster on both CPU and GPU. Scatter is usually slightly better at low sizes and eye is slightly better at large sizes.

The HLO between the different implementation is IDENTICAL except for the broadcast axis — v*eye / scatter emit dimensions={0} (v along rows), while jnp.diag / where emit dimensions={1} (v along cols). Which got me thinking whether there was a way to keep the current where-based implementation but switch the broadcast axis and indeed there is, simply as:
```python
def where_eye_col_impl(v):
    n = v.shape[0]
    return jnp.where(jnp.eye(n, dtype=jnp.bool_), v[:, None], jnp.zeros((), v.dtype))
```

It turns out that this is actually pretty performant on the argtrigls problem and is only beated by scatter at N=100 (data below all on MacOS CPU but similar patterns confirmed on A100 GPU).

<img width="2083" height="729" alt="image" src="https://github.com/user-attachments/assets/a5b6a8ce-3376-45ee-a532-150e68f2f4da" />

Furthermore, there is a very biggest difference is in the VJP, where scatter is consistently 2–5x faster on CPU and 5-10x faster on GPU. With eager constant folding on scatter is the ONLY one able to benefit from this and obtain O(1) scaling (constant 8µs dispatch floor on CPU). This is because the scatter transpose rule is a gather which is easy for jax/XLA to optimise. Fortunately, switching the broadcast axis largely fixes this too and we get much closer to scatter.

<img width="2084" height="736" alt="image" src="https://github.com/user-attachments/assets/e8069da5-0cec-4a20-8e9c-64c81d04903a" />

Performance for standard operations is maintained and actually beats all others for jvp:

<img width="2084" height="736" alt="image" src="https://github.com/user-attachments/assets/1295ff24-fa29-4daa-9c66-2c9b3996f062" />

<img width="2084" height="736" alt="image" src="https://github.com/user-attachments/assets/13688425-240a-4cc3-95cb-7bc16cb46f30" />

If we wanted to improve vjp still further instead of one of the other implementations I'd consider making diag a primitive and writing a fast transpose rule.