### PR TITLE
Upgrade upstream ROCm CI from 7.2.0 to 7.2.2

### DIFF
--- a/.github/actions/download-jax-rocm-wheels/action.yml
+++ b/.github/actions/download-jax-rocm-wheels/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: true
   rocm-version:
     description: "Which ROCm version should the artifact be downloaded for?"
-    default: "7.2.0"
+    default: "7.2.2"
   jaxlib-version:
     description: "Which jaxlib version to download? (head/pypi_latest)"
     default: "head"

--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -38,9 +38,9 @@ on:
         type: string
         default: "7"
       rocm-tag:
-        description: "ROCm tag for container image (e.g., rocm720)"
+        description: "ROCm tag for container image (e.g., rocm722)"
         type: string
-        default: "rocm720"
+        default: "rocm722"
       enable-x64:
         description: "Should x64 mode be enabled?"
         type: string

--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -108,7 +108,7 @@ jobs:
     outputs:
       s3_upload_uri: ${{ steps.store-s3-upload-uri.outputs.s3_upload_uri }}
     container:
-      image: "ghcr.io/rocm/jax-manylinux_2_28-rocm-7.2.0:latest"
+      image: "ghcr.io/rocm/jax-manylinux_2_28-rocm-7.2.2:latest"
       volumes:
         - /data:/data
       options: >-

--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -34,13 +34,13 @@ on:
       rocm-version:
         description: "Which ROCm version to test?"
         type: choice
-        default: "7.2.0"
+        default: "7.2.2"
         options:
-          - "7.2.0"
+          - "7.2.2"
       rocm-tag:
-        description: "ROCm tag for container image (e.g., rocm720)"
+        description: "ROCm tag for container image (e.g., rocm722)"
         type: string
-        default: "rocm720"
+        default: "rocm722"
       jaxlib-version:
         description: "Which jaxlib version to use? (head/pypi_latest)"
         type: choice
@@ -80,11 +80,11 @@ on:
       rocm-version:
         description: "Which ROCm version to test?"
         type: string
-        default: "7.2.0"
+        default: "7.2.2"
       rocm-tag:
-        description: "ROCm tag for container image (e.g., rocm720)"
+        description: "ROCm tag for container image (e.g., rocm722)"
         type: string
-        default: "rocm720"
+        default: "rocm722"
       jaxlib-version:
         description: "Which jaxlib version to use? (head/pypi_latest)"
         type: string

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -340,7 +340,7 @@ jobs:
           runner: ["linux-x86-64-1gpu-amd", "linux-x86-64-4gpu-amd", "linux-x86-64-8gpu-amd"]
           python: ["3.11"]
           rocm: [
-            {version: "7.2.0", tag: "rocm720"},
+            {version: "7.2.2", tag: "rocm722"},
           ]
     name: "Pytest ROCm (JAX artifacts version = ${{ format('{0}', 'head') }})"
     with:

--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -185,7 +185,7 @@ jobs:
           runner: ["linux-x86-64-1gpu-amd", "linux-x86-64-4gpu-amd", "linux-x86-64-8gpu-amd"]
           python: ["3.11", "3.12", "3.13", "3.14"]
           rocm: [
-            {version: "7.2.0", tag: "rocm720"},
+            {version: "7.2.2", tag: "rocm722"},
           ]
     name: "Pytest ROCm (JAX artifacts version = ${{ startsWith(github.ref_name, 'release/') && 'latest release' || 'nightly' }})"
     with:


### PR DESCRIPTION
Point the three upstream ROCm workflows at the new 7.2.2 base images published by ROCm/rocm-jax:

- build_rocm_artifacts.yml: switch the manylinux_2_28 builder image from jax-manylinux_2_28-rocm-7.2.0:latest to ...-rocm-7.2.2:latest.
- bazel_rocm.yml / pytest_rocm.yml: bump the default rocm-tag from rocm720 to rocm722 (and the default rocm-version from 7.2.0 to 7.2.2 for pytest_rocm.yml), so the jobs pull the jax-dev-ubu24.rocm722 / jax-base-ubu24.rocm722 containers.
- wheel_tests_continuous.yml / wheel_tests_nightly_release.yml: update the rocm matrix entry to {version: "7.2.2", tag: "rocm722"}.
- download-jax-rocm-wheels composite action: bump the default rocm-version to 7.2.2 to match.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->