### PR TITLE
TritonKernelCall CUDA graph support

### DIFF
--- a/jaxlib/gpu/gpu_kernels.cc
+++ b/jaxlib/gpu/gpu_kernels.cc
@@ -88,9 +88,14 @@ XLA_FFI_REGISTER_HANDLER(XLA_FFI_GetApi(), "cusparse_gtsv2_ffi", "CUDA",
                          kGtsv2);
 XLA_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM("triton_kernel_call", TritonKernelCall,
                                          "CUDA");
-XLA_FFI_REGISTER_HANDLER(XLA_FFI_GetApi(), "triton_kernel_call_ffi", "CUDA",
-                         kTritonKernelCallFfi);
 
+XLA_FFI_REGISTER_HANDLER(XLA_FFI_GetApi(), "triton_kernel_call_ffi", "CUDA",
+                         {
+                            /*instantiate=*/nullptr,
+                            /*prepare=*/nullptr,
+                            /*initialize=*/kTritonKernelCallFfiInitialize,
+                            /*execute=*/kTritonKernelCallFfi,
+                        });
 }  // namespace
 }  // namespace JAX_GPU_NAMESPACE
 }  // namespace jax

--- a/jaxlib/gpu/triton.cc
+++ b/jaxlib/gpu/triton.cc
@@ -46,7 +46,11 @@ namespace jax::JAX_GPU_NAMESPACE {
 
 nb::dict Registrations() {
   nb::dict dict;
-  dict["triton_kernel_call_ffi"] = EncapsulateFfiHandler(kTritonKernelCallFfi);
+  nb::dict gpu_dict;
+  gpu_dict["initialize"] = EncapsulateFfiHandler(
+    kTritonKernelCallFfiInitialize);
+  gpu_dict["execute"] = EncapsulateFfiHandler(kTritonKernelCallFfi);
+  dict["triton_kernel_call_ffi"] = gpu_dict;
   return dict;
 }
 

--- a/jaxlib/gpu/triton_kernels.cc
+++ b/jaxlib/gpu/triton_kernels.cc
@@ -820,12 +820,37 @@ void TritonKernelCall(gpuStream_t stream, void** buffers, const char* opaque,
   return ::xla::ffi::Error::Success();
 }
 
+// For command buffer support, make sure that the kernel cache is populated
+// during initialization.
+::xla::ffi::Error TritonKernelCallFfiInitialize(gpuStream_t stream,
+                                      std::string_view opaque,
+                                      ::xla::ffi::RemainingArgs args,
+                                      ::xla::ffi::RemainingRets rets) {
+  std::vector<void*> buffers = CombineBuffers(args, rets);
+  auto kernel_call_or = GetKernelCall(opaque, stream, buffers.data());
+  if (!kernel_call_or.ok()) {
+    return ::xla::ffi::Error::InvalidArgument(
+        std::string(kernel_call_or.status().message()));
+  }
+  return ::xla::ffi::Error::Success();
+}
+
 XLA_FFI_DEFINE_HANDLER_SYMBOL(
     kTritonKernelCallFfi, TritonKernelCallFfi,
     ::xla::ffi::Ffi::Bind()
         .Ctx<::xla::ffi::PlatformStream<gpuStream_t>>()
         .Attr<std::string_view>("opaque")
         .RemainingArgs()
-        .RemainingRets());
+        .RemainingRets(),
+    {::xla::ffi::Traits::kCmdBufferCompatible});
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    kTritonKernelCallFfiInitialize, TritonKernelCallFfiInitialize,
+    ::xla::ffi::Ffi::BindInitialize()
+        .Ctx<::xla::ffi::PlatformStream<gpuStream_t>>()
+        .Attr<std::string_view>("opaque")
+        .RemainingArgs()
+        .RemainingRets(),
+    {::xla::ffi::Traits::kCmdBufferCompatible});
 
 }  // namespace jax::JAX_GPU_NAMESPACE

--- a/jaxlib/gpu/triton_kernels.h
+++ b/jaxlib/gpu/triton_kernels.h
@@ -36,6 +36,7 @@ void TritonKernelCall(gpuStream_t stream, void** buffers, const char* opaque,
                       size_t opaque_len, XlaCustomCallStatus* status);
 
 XLA_FFI_DECLARE_HANDLER_SYMBOL(kTritonKernelCallFfi);
+XLA_FFI_DECLARE_HANDLER_SYMBOL(kTritonKernelCallFfiInitialize);
 
 class ModuleImage;
 


### PR DESCRIPTION
Add an explicit initialize step that triggers autotuning and kernel loading, as these are not valid under graph capture, and then mark the custom call CUDA graph compatible.

~Sits on top of https://github.com/jax-ml/jax/pull/36835~