### PR TITLE
jax/mosaic: enable CUPTI V2 multi-subscriber coexistence on CUDA 13.2+

### DIFF
--- a/jax/_src/profiler.py
+++ b/jax/_src/profiler.py
@@ -491,10 +491,11 @@ class PGLEProfiler:
         runner.called_times += 1
         if runner.fdo_profiles[-1] == b'':
           warnings.warn(
-              "PGLE collected an empty trace, may be due to contention with "
-              "another tool that subscribes to CUPTI, such as Nsight Systems - check "
-              "for CUPTI_ERROR_MULTIPLE_SUBSCRIBERS_NOT_SUPPORTED from XLA. "
-              "Consider populating a persistent compilation cache with PGLE enabled, "
-              "and then profiling a second run that has the "
+              "PGLE collected an empty trace. This may be due to contention "
+              "with another CUPTI subscriber, especially on older "
+              "CUDA/CUPTI versions that do not support multiple subscribers; "
+              "check for CUPTI_ERROR_MULTIPLE_SUBSCRIBERS_NOT_SUPPORTED from "
+              "XLA. Consider populating a persistent compilation cache with "
+              "PGLE enabled, and then profiling a second run that has the "
               "JAX_COMPILATION_CACHE_EXPECT_PGLE option enabled.",
               RuntimeWarning)

--- a/jax/experimental/mosaic/gpu/profiler.py
+++ b/jax/experimental/mosaic/gpu/profiler.py
@@ -162,10 +162,11 @@ def measure(
   Notes:
     `CUPTI (CUDA Profiling Tools Interface)
     <https://docs.nvidia.com/cupti/index.html>`_ is a high-accuracy profiling
-    API used by Nsight Systems and Nsight Compute. The CUPTI API only allows a
-    single subscriber, so ``measure`` cannot be used with other CUPTI-based
-    tools like CUDA-GDB, Compute Sanitizer, Nsight Systems, or Nsight
-    Compute.
+    API used by Nsight Systems and Nsight Compute. Before CUDA/CUPTI 13.2,
+    CUPTI allows only a single subscriber, so ``measure`` cannot be used with
+    other CUPTI-based tools like CUDA-GDB, Compute Sanitizer, Nsight Systems,
+    or Nsight Compute. On CUDA/CUPTI 13.2 and newer, ``measure`` uses the
+    CUPTI V2 subscriber APIs and can coexist with another CUPTI subscriber.
   """  # fmt: skip
   if iterations < 1:
     raise ValueError(f"{iterations=} must be positive")

--- a/jaxlib/mosaic/gpu/mosaic_gpu_ext.cc
+++ b/jaxlib/mosaic/gpu/mosaic_gpu_ext.cc
@@ -152,6 +152,8 @@ NB_MODULE(_mosaic_gpu_ext, m) {
     params.structSize = CUpti_SubscriberParams_STRUCT_SIZE;
     params.subscriberName = "MosaicGpuProfiler";
     params.allowMultipleSubscribers = 1;
+    // Ok to pass nullptr for the callback here because we don't register any
+    // callbacks through cuptiEnableCallback.
     THROW_IF_CUPTI_ERROR(cuptiSubscribe_v2(&profiler_state.subscriber,
                                            /*callback=*/nullptr,
                                            /*userdata=*/nullptr, &params),
@@ -203,6 +205,9 @@ NB_MODULE(_mosaic_gpu_ext, m) {
             "failed to flush CUPTI activity buffers");
         // The legacy dropped-record query is process-global, so in the V2
         // path it could attribute another subscriber's drops to Mosaic.
+        // TODO: In the V2 path, plumb enough context/stream information to
+        // query dropped activity records safely with
+        // cuptiActivityGetNumDroppedRecords().
         // cuptiUnsubscribe() is sufficient here; cuptiFinalize() tears down
         // global CUPTI state and breaks later V2 re-initialization.
 #else

--- a/jaxlib/mosaic/gpu/mosaic_gpu_ext.cc
+++ b/jaxlib/mosaic/gpu/mosaic_gpu_ext.cc
@@ -28,6 +28,13 @@ limitations under the License.
 #include "jaxlib/absl_status_casters.h"
 #include "jaxlib/gpu/vendor.h"
 #include "jaxlib/mosaic/gpu/target.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
+
+// JAX_CUPTI_HAS_MULTI_SUBSCRIBER is defined when the CUPTI V2 multi-subscriber
+// APIs are available (CUPTI_API_VERSION >= 130200, i.e. CUDA 13.2+).
+#if CUPTI_API_VERSION >= 130200
+#define JAX_CUPTI_HAS_MULTI_SUBSCRIBER
+#endif
 
 namespace jax::cuda {
 namespace {
@@ -55,14 +62,19 @@ namespace nb = nanobind;
     }                                            \
   } while (0)
 
-// CUPTI can only have one subscriber per process, so it's ok to make the
-// profiler state global.
+// Mosaic keeps a single global profiler state, so only one session may be
+// active at a time.
 struct {
   CUpti_SubscriberHandle subscriber;
   std::vector<std::tuple<const char* /*kernel_name*/, double /*ms*/>> timings;
 } profiler_state;
 
-void callback_request(uint8_t** buffer, size_t* size, size_t* maxNumRecords) {
+#ifdef JAX_CUPTI_HAS_MULTI_SUBSCRIBER
+void callback_request(uint8_t **buffer, size_t *size, size_t *maxNumRecords,
+                      CUpti_BufferCallbackRequestInfo * /*info*/) {
+#else
+void callback_request(uint8_t **buffer, size_t *size, size_t *maxNumRecords) {
+#endif
   // 10 MiB buffer size is generous but somewhat arbitrary, it's at the upper
   // bound of what's recommended in CUPTI documentation:
   // https://docs.nvidia.com/cupti/main/main.html#cupti-callback-api:~:text=For%20typical%20workloads%2C%20it%E2%80%99s%20suggested%20to%20choose%20a%20size%20between%201%20and%2010%20MB.
@@ -75,8 +87,13 @@ void callback_request(uint8_t** buffer, size_t* size, size_t* maxNumRecords) {
   *maxNumRecords = 0;
 }
 
-void callback_complete(CUcontext context, uint32_t streamId, uint8_t* buffer,
+#ifdef JAX_CUPTI_HAS_MULTI_SUBSCRIBER
+void callback_complete(uint8_t *buffer, size_t size, size_t validSize,
+                       CUpti_BufferCallbackCompleteInfo * /*info*/) {
+#else
+void callback_complete(CUcontext context, uint32_t streamId, uint8_t *buffer,
                        size_t size, size_t validSize) {
+#endif
   // take ownership of the buffer once CUPTI is done using it
   absl::Cleanup cleanup = [buffer]() {
     operator delete[](buffer, std::align_val_t(8));
@@ -103,11 +120,13 @@ void callback_complete(CUcontext context, uint32_t streamId, uint8_t* buffer,
     }
   }
 
+#ifndef JAX_CUPTI_HAS_MULTI_SUBSCRIBER
   size_t num_dropped;
   THROW_IF_CUPTI_ERROR(
       cuptiActivityGetNumDroppedRecords(context, streamId, &num_dropped),
       "failed to get number of dropped activity records");
   THROW_IF(num_dropped > 0, "activity records were dropped");
+#endif
 }
 
 NB_MODULE(_mosaic_gpu_ext, m) {
@@ -127,6 +146,28 @@ NB_MODULE(_mosaic_gpu_ext, m) {
   });
   m.def("_cupti_init", []() {
     profiler_state.timings.clear();
+#ifdef JAX_CUPTI_HAS_MULTI_SUBSCRIBER
+    // V2 API: allows coexistence with other subscribers, such as jax.profiler.
+    CUpti_SubscriberParams params = {};
+    params.structSize = CUpti_SubscriberParams_STRUCT_SIZE;
+    params.subscriberName = "MosaicGpuProfiler";
+    params.allowMultipleSubscribers = 1;
+    THROW_IF_CUPTI_ERROR(cuptiSubscribe_v2(&profiler_state.subscriber,
+                                           /*callback=*/nullptr,
+                                           /*userdata=*/nullptr, &params),
+                         "failed to subscribe to CUPTI");
+    THROW_IF_CUPTI_ERROR(
+        cuptiActivityRegisterCallbacks_v2(profiler_state.subscriber,
+                                          callback_request, callback_complete),
+        "failed to register CUPTI activity callbacks");
+    CUpti_ActivityConfig act_cfg = {};
+    act_cfg.structSize = CUpti_ActivityConfig_STRUCT_SIZE;
+    THROW_IF_CUPTI_ERROR(
+        cuptiActivityEnable_v2(profiler_state.subscriber,
+                               CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL, &act_cfg),
+        "failed to enable tracking of kernel activity by CUPTI");
+#else
+    // V1 API: only one CUPTI subscriber allowed at a time.
     // Ok to pass nullptr for the callback here because we don't register any
     // callbacks through cuptiEnableCallback.
     auto subscribe_result = cuptiSubscribe(
@@ -145,19 +186,38 @@ NB_MODULE(_mosaic_gpu_ext, m) {
     THROW_IF_CUPTI_ERROR(
         cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL),
         "failed to enable tracking of kernel activity by CUPTI");
+#endif
   });
   m.def(
       "_cupti_get_timings",
       [](bool finalize) {
+#ifdef JAX_CUPTI_HAS_MULTI_SUBSCRIBER
+        (void)finalize;  // unused in the V2 path
+        THROW_IF_CUPTI_ERROR(
+            cuptiActivityDisable_v2(profiler_state.subscriber,
+                                    CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL,
+                                    nullptr),
+            "failed to disable tracking of kernel activity by CUPTI");
+        THROW_IF_CUPTI_ERROR(
+            cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED),
+            "failed to flush CUPTI activity buffers");
+        // The legacy dropped-record query is process-global, so in the V2
+        // path it could attribute another subscriber's drops to Mosaic.
+        // cuptiUnsubscribe() is sufficient here; cuptiFinalize() tears down
+        // global CUPTI state and breaks later V2 re-initialization.
+#else
         THROW_IF_CUPTI_ERROR(
             cuptiActivityDisable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL),
             "failed to disable tracking of kernel activity by CUPTI");
         THROW_IF_CUPTI_ERROR(
             cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED),
             "failed to flush CUPTI activity buffers");
+        // In the V1 path, cuptiFinalize() is required to avoid leaking CUPTI
+        // state across repeated measurements.
         if (finalize) {
           THROW_IF_CUPTI_ERROR(cuptiFinalize(), "failed to detach CUPTI");
         }
+#endif
         THROW_IF_CUPTI_ERROR(cuptiUnsubscribe(profiler_state.subscriber),
                              "failed to unsubscribe from CUPTI");
         return profiler_state.timings;

--- a/tests/mosaic/profiler_cupti_test.py
+++ b/tests/mosaic/profiler_cupti_test.py
@@ -13,9 +13,16 @@
 # limitations under the License.
 # ==============================================================================
 
+import os
+import tempfile
+
 from absl.testing import absltest, parameterized
+import jax
+import jax.profiler
 from jax._src import config
+from jax._src import profiler as jax_profiler_src
 from jax._src import test_util as jtu
+from jax._src.lib import cuda_versions
 import jax.numpy as jnp
 try:
   import jax._src.lib.mosaic_gpu  # noqa: F401
@@ -23,6 +30,7 @@ try:
 except ImportError:
   HAS_MOSAIC_GPU = False
 else:
+  from jax.experimental.compilation_cache import compilation_cache as cc
   from jax.experimental.mosaic.gpu import profiler
 
 # ruff: noqa: F405
@@ -87,17 +95,204 @@ class ProfilerCuptiTest(parameterized.TestCase):
     self.assertEqual(len(timings), 5)
     self.assertTrue(all(isinstance(t, float) for t in timings))
 
-  def test_measure_double_subscription(self):
-    # This needs to run in a separate process, otherwise it affects the
-    # outcomes of other tests since CUPTI state is global.
-    self.skipTest("Must run in a separate process from other profiler tests")
-    # Initialize profiler manually, which subscribes to CUPTI. There can only
-    # be one CUPTI subscriber at a time.
-    jax._src.lib.mosaic_gpu._mosaic_gpu_ext._cupti_init()
-    with self.assertRaisesRegex(RuntimeError,
-      "Attempted to subscribe to CUPTI while another subscriber, "
-      "such as Nsight Systems or Nsight Compute, is active."):
-      profiler.measure(self.f, aggregate=False)(self.x)
+
+class _CuptiV2TestBase(jtu.JaxTestCase):
+  """Base for V2 multi-subscriber tests."""
+
+  def setUp(self):
+    if not HAS_MOSAIC_GPU:
+      self.skipTest("jaxlib built without Mosaic GPU")
+    if not jtu.test_device_matches(["cuda"]):
+      self.skipTest("Only runs on NVIDIA GPUs")
+    super().setUp()
+    self.x = jnp.ones((512, 512), dtype=jnp.float32)
+
+  def _skip_unless_cupti_v2(self):
+    if cuda_versions is None:
+      self.skipTest("cuda_versions is unavailable")
+    cupti_version = cuda_versions.cupti_get_version()
+    if cupti_version < 130200:
+      self.skipTest(
+          f"Requires CUPTI >= 13.2 for multi-subscriber V2 APIs; "
+          f"found {cupti_version}")
+
+  def _run_mosaic_profile(self):
+    result, runtime_ms = profiler.measure(lambda x: x @ x)(self.x)
+    jax.block_until_ready(result)
+    self.assertIsInstance(runtime_ms, float)
+    self.assertGreater(runtime_ms, 0.0)
+    return runtime_ms
+
+  def _run_jax_trace(self):
+    with tempfile.TemporaryDirectory() as trace_dir:
+      with jax.profiler.trace(trace_dir):
+        jax.block_until_ready(jax.jit(lambda x: x @ x)(self.x))
+      trace_files = list(os.scandir(trace_dir))
+      self.assertTrue(trace_files, "No trace files written")
+
+  def _run_pgle_trace(self):
+    runner = jax_profiler_src.PGLEProfiler(retries=1, percentile=90)
+    with jax_profiler_src.PGLEProfiler.trace(runner):
+      jax.block_until_ready(jax.jit(lambda x: x @ x)(self.x))
+    self.assertEqual(runner.called_times, 1)
+
+
+class ProfilerCuptiMultiSubscriberTest(_CuptiV2TestBase):
+  """jax.profiler + mosaic_gpu.profiler coexistence via CUPTI V2."""
+
+  def setUp(self):
+    super().setUp()
+    self._skip_unless_cupti_v2()
+
+  def test_mosaic_profiler_inside_jax_trace(self):
+    """mosaic profiler inside a jax.profiler trace (both V2 subscribers)."""
+    with tempfile.TemporaryDirectory() as trace_dir:
+      jax.profiler.start_trace(trace_dir)
+      try:
+        runtime_ms = self._run_mosaic_profile()
+      finally:
+        jax.profiler.stop_trace()
+    self.assertIsInstance(runtime_ms, float)
+    self.assertGreater(runtime_ms, 0.0)
+
+  def test_jax_trace_then_mosaic_profiler(self):
+    """jax.profiler trace then mosaic profiler."""
+    self._run_jax_trace()
+    self._run_mosaic_profile()
+
+  def test_mosaic_profiler_then_jax_trace(self):
+    """mosaic profiler then jax trace."""
+    self._run_mosaic_profile()
+    self._run_jax_trace()
+
+  def test_finalize_flag_ignored_on_cupti_v2(self):
+    """finalize has no effect on the CUPTI V2 multi-subscriber path."""
+    f = lambda x: x @ x
+
+    result_true, runtime_ms1 = profiler.Cupti(finalize=True).measure(f)(self.x)
+    jax.block_until_ready(result_true)
+
+    result_false, runtime_ms2 = profiler.Cupti(finalize=False).measure(f)(self.x)
+    jax.block_until_ready(result_false)
+
+    self.assertIsInstance(runtime_ms1, float)
+    self.assertGreater(runtime_ms1, 0.0)
+    self.assertIsInstance(runtime_ms2, float)
+    self.assertGreater(runtime_ms2, 0.0)
+
+  def test_mosaic_trace_mosaic_reuse(self):
+    """Mosaic profiling works before and after a jax.profiler trace session."""
+    f = jax.jit(lambda x: x @ x)
+
+    result1, runtime_ms1 = profiler.measure(f)(self.x)
+    jax.block_until_ready(result1)
+
+    with tempfile.TemporaryDirectory() as trace_dir:
+      with jax.profiler.trace(trace_dir):
+        jax.block_until_ready(f(self.x))
+      trace_files = list(os.scandir(trace_dir))
+      self.assertTrue(trace_files, "No trace files written")
+
+    result2, runtime_ms2 = profiler.measure(f)(self.x)
+    jax.block_until_ready(result2)
+
+    self.assertIsInstance(runtime_ms1, float)
+    self.assertGreater(runtime_ms1, 0.0)
+    self.assertIsInstance(runtime_ms2, float)
+    self.assertGreater(runtime_ms2, 0.0)
+
+
+class ProfilerCuptiPgleTest(_CuptiV2TestBase):
+  """PGLE + mosaic_gpu.profiler coexistence via CUPTI V2."""
+
+  def setUp(self):
+    super().setUp()
+    self._skip_unless_cupti_v2()
+
+  def test_mosaic_profiler_inside_pgle_trace(self):
+    """mosaic profiler inside an active PGLE trace (both as V2 subscribers)."""
+    runner = jax_profiler_src.PGLEProfiler(retries=1, percentile=90)
+    with jax_profiler_src.PGLEProfiler.trace(runner):
+      result, runtime_ms = profiler.measure(lambda x: x @ x)(self.x)
+      jax.block_until_ready(result)
+    self.assertIsInstance(runtime_ms, float)
+    self.assertGreater(runtime_ms, 0.0)
+    # PGLE session completed; collected profile data may be empty if no HLO ops
+    # were captured.
+    self.assertEqual(runner.called_times, 1)
+
+  def test_pgle_trace_then_mosaic_profiler(self):
+    """PGLE trace then mosaic profiler."""
+    self._run_pgle_trace()
+    self._run_mosaic_profile()
+
+  def test_mosaic_profiler_then_pgle_trace(self):
+    """mosaic profiler then PGLE trace."""
+    self._run_mosaic_profile()
+    self._run_pgle_trace()
+
+  def test_pgle_workflow_with_mosaic_profiler(self):
+    """jax_enable_pgle=True: mosaic profiler concurrent with PGLE (V2 mode)."""
+    with (tempfile.TemporaryDirectory(prefix="pgle_test_") as cache_dir,
+          config.enable_pgle(True),
+          config.pgle_profiling_runs(2),
+          config.enable_compilation_cache(True),
+          config.raise_persistent_cache_errors(True),
+          config.persistent_cache_min_entry_size_bytes(0),
+          config.persistent_cache_min_compile_time_secs(0)):
+      jax.clear_caches()
+      cc.reset_cache()
+      cc.set_cache_dir(cache_dir)
+      self.addCleanup(cc.set_cache_dir, None)
+      self.addCleanup(cc.reset_cache)
+      self.addCleanup(jax.clear_caches)
+
+      @jax.jit
+      def step(x):
+        return x @ x
+
+      x = jnp.ones((256, 256), dtype=jnp.float32)
+
+      for i in range(4):
+        x = step(x)
+        x.block_until_ready()
+        _, ms = profiler.measure(lambda v: v @ v)(jnp.ones((128, 128)))
+        self.assertIsInstance(ms, float, f"iter {i}: bad mosaic timing {ms}")
+        self.assertGreater(ms, 0.0, f"iter {i}: bad mosaic timing {ms}")
+
+
+class ProfilerCuptiXplaneTest(_CuptiV2TestBase):
+  """XPlane (jax.profiler.trace) + mosaic profiler coexistence via CUPTI V2."""
+
+  def setUp(self):
+    super().setUp()
+    self._skip_unless_cupti_v2()
+
+  def test_xplane_trace_written_while_mosaic_active(self):
+    """jax.profiler.trace writes trace files with mosaic profiler active."""
+    with tempfile.TemporaryDirectory() as trace_dir:
+      with jax.profiler.trace(trace_dir):
+        jax.block_until_ready(jax.jit(lambda x: x @ x)(self.x))
+        runtime_ms = self._run_mosaic_profile()
+      # Check trace files were written
+      trace_files = list(os.scandir(trace_dir))
+      self.assertTrue(trace_files, "No trace files written by jax.profiler.trace()")
+    self.assertIsInstance(runtime_ms, float)
+    self.assertGreater(runtime_ms, 0.0)
+
+  def test_xplane_trace_with_mosaic_profiler(self):
+    """XPlane trace and mosaic profiler concurrently (two V2 subscribers)."""
+    with tempfile.TemporaryDirectory() as trace_dir:
+      with jax.profiler.trace(trace_dir):
+        # mosaic profiler as second V2 subscriber
+        result1, ms1 = profiler.measure(lambda x: x @ x)(self.x)
+        jax.block_until_ready(result1)
+        # regular jit computation captured by XPlane
+        jax.block_until_ready(jax.jit(lambda x: x @ x)(self.x))
+      trace_files = list(os.scandir(trace_dir))
+      self.assertTrue(trace_files, "No trace files written")
+    self.assertIsInstance(ms1, float)
+    self.assertGreater(ms1, 0.0)
 
 
 if __name__ == "__main__":

--- a/tests/mosaic/profiler_cupti_test.py
+++ b/tests/mosaic/profiler_cupti_test.py
@@ -25,10 +25,11 @@ from jax._src import test_util as jtu
 from jax._src.lib import cuda_versions
 import jax.numpy as jnp
 try:
-  import jax._src.lib.mosaic_gpu  # noqa: F401
+  from jax._src.lib import mosaic_gpu as mosaic_gpu_lib
   HAS_MOSAIC_GPU = True
 except ImportError:
   HAS_MOSAIC_GPU = False
+  mosaic_gpu_lib = None
 else:
   from jax.experimental.compilation_cache import compilation_cache as cc
   from jax.experimental.mosaic.gpu import profiler
@@ -95,6 +96,25 @@ class ProfilerCuptiTest(parameterized.TestCase):
     self.assertEqual(len(timings), 5)
     self.assertTrue(all(isinstance(t, float) for t in timings))
 
+  def test_measure_double_subscription(self):
+    ext = mosaic_gpu_lib._mosaic_gpu_ext
+    ext._cupti_init()
+    self.addCleanup(ext._cupti_get_timings, False)
+
+    cupti_version = (
+        None if cuda_versions is None else cuda_versions.cupti_get_version()
+    )
+    if cupti_version is not None and cupti_version >= 130200:
+      _, timings = profiler.measure(self.f, aggregate=False)(self.x)
+      self.assertLen(timings, 1)
+      return
+
+    with self.assertRaisesRegex(
+        RuntimeError,
+        "Attempted to subscribe to CUPTI while another subscriber, such as "
+        "Nsight Systems or Nsight Compute, is active."):
+      profiler.measure(self.f, aggregate=False)(self.x)
+
 
 class _CuptiV2TestBase(jtu.JaxTestCase):
   """Base for V2 multi-subscriber tests."""
@@ -104,10 +124,6 @@ class _CuptiV2TestBase(jtu.JaxTestCase):
       self.skipTest("jaxlib built without Mosaic GPU")
     if not jtu.test_device_matches(["cuda"]):
       self.skipTest("Only runs on NVIDIA GPUs")
-    super().setUp()
-    self.x = jnp.ones((512, 512), dtype=jnp.float32)
-
-  def _skip_unless_cupti_v2(self):
     if cuda_versions is None:
       self.skipTest("cuda_versions is unavailable")
     cupti_version = cuda_versions.cupti_get_version()
@@ -115,6 +131,8 @@ class _CuptiV2TestBase(jtu.JaxTestCase):
       self.skipTest(
           f"Requires CUPTI >= 13.2 for multi-subscriber V2 APIs; "
           f"found {cupti_version}")
+    super().setUp()
+    self.x = jnp.ones((512, 512), dtype=jnp.float32)
 
   def _run_mosaic_profile(self):
     result, runtime_ms = profiler.measure(lambda x: x @ x)(self.x)
@@ -123,26 +141,16 @@ class _CuptiV2TestBase(jtu.JaxTestCase):
     self.assertGreater(runtime_ms, 0.0)
     return runtime_ms
 
+
+class ProfilerCuptiMultiSubscriberTest(_CuptiV2TestBase):
+  """jax.profiler + mosaic_gpu.profiler coexistence via CUPTI V2."""
+
   def _run_jax_trace(self):
     with tempfile.TemporaryDirectory() as trace_dir:
       with jax.profiler.trace(trace_dir):
         jax.block_until_ready(jax.jit(lambda x: x @ x)(self.x))
       trace_files = list(os.scandir(trace_dir))
       self.assertTrue(trace_files, "No trace files written")
-
-  def _run_pgle_trace(self):
-    runner = jax_profiler_src.PGLEProfiler(retries=1, percentile=90)
-    with jax_profiler_src.PGLEProfiler.trace(runner):
-      jax.block_until_ready(jax.jit(lambda x: x @ x)(self.x))
-    self.assertEqual(runner.called_times, 1)
-
-
-class ProfilerCuptiMultiSubscriberTest(_CuptiV2TestBase):
-  """jax.profiler + mosaic_gpu.profiler coexistence via CUPTI V2."""
-
-  def setUp(self):
-    super().setUp()
-    self._skip_unless_cupti_v2()
 
   def test_mosaic_profiler_inside_jax_trace(self):
     """mosaic profiler inside a jax.profiler trace (both V2 subscribers)."""
@@ -171,9 +179,11 @@ class ProfilerCuptiMultiSubscriberTest(_CuptiV2TestBase):
 
     result_true, runtime_ms1 = profiler.Cupti(finalize=True).measure(f)(self.x)
     jax.block_until_ready(result_true)
+    self._run_jax_trace()
 
-    result_false, runtime_ms2 = profiler.Cupti(finalize=False).measure(f)(self.x)
-    jax.block_until_ready(result_false)
+    result_true_again, runtime_ms2 = profiler.Cupti(
+        finalize=True).measure(f)(self.x)
+    jax.block_until_ready(result_true_again)
 
     self.assertIsInstance(runtime_ms1, float)
     self.assertGreater(runtime_ms1, 0.0)
@@ -205,9 +215,11 @@ class ProfilerCuptiMultiSubscriberTest(_CuptiV2TestBase):
 class ProfilerCuptiPgleTest(_CuptiV2TestBase):
   """PGLE + mosaic_gpu.profiler coexistence via CUPTI V2."""
 
-  def setUp(self):
-    super().setUp()
-    self._skip_unless_cupti_v2()
+  def _run_pgle_trace(self):
+    runner = jax_profiler_src.PGLEProfiler(retries=1, percentile=90)
+    with jax_profiler_src.PGLEProfiler.trace(runner):
+      jax.block_until_ready(jax.jit(lambda x: x @ x)(self.x))
+    self.assertEqual(runner.called_times, 1)
 
   def test_mosaic_profiler_inside_pgle_trace(self):
     """mosaic profiler inside an active PGLE trace (both as V2 subscribers)."""
@@ -263,10 +275,6 @@ class ProfilerCuptiPgleTest(_CuptiV2TestBase):
 
 class ProfilerCuptiXplaneTest(_CuptiV2TestBase):
   """XPlane (jax.profiler.trace) + mosaic profiler coexistence via CUPTI V2."""
-
-  def setUp(self):
-    super().setUp()
-    self._skip_unless_cupti_v2()
 
   def test_xplane_trace_written_while_mosaic_active(self):
     """jax.profiler.trace writes trace files with mosaic profiler active."""

--- a/tests/mosaic/profiler_cupti_test.py
+++ b/tests/mosaic/profiler_cupti_test.py
@@ -37,6 +37,7 @@ else:
 # ruff: noqa: F405
 config.parse_flags_with_absl()
 
+@jtu.thread_unsafe_test_class()
 class ProfilerCuptiTest(parameterized.TestCase):
 
   def setUp(self):
@@ -97,17 +98,15 @@ class ProfilerCuptiTest(parameterized.TestCase):
     self.assertTrue(all(isinstance(t, float) for t in timings))
 
   def test_measure_double_subscription(self):
+    assert cuda_versions is not None
+    cupti_version = cuda_versions.cupti_get_version()
+    if cupti_version >= 130200:
+      self.skipTest(
+          "Legacy single-subscriber behavior only applies before CUPTI 13.2.")
+
     ext = mosaic_gpu_lib._mosaic_gpu_ext
     ext._cupti_init()
-    self.addCleanup(ext._cupti_get_timings, False)
-
-    cupti_version = (
-        None if cuda_versions is None else cuda_versions.cupti_get_version()
-    )
-    if cupti_version is not None and cupti_version >= 130200:
-      _, timings = profiler.measure(self.f, aggregate=False)(self.x)
-      self.assertLen(timings, 1)
-      return
+    self.addCleanup(ext._cupti_get_timings, True)
 
     with self.assertRaisesRegex(
         RuntimeError,
@@ -116,6 +115,7 @@ class ProfilerCuptiTest(parameterized.TestCase):
       profiler.measure(self.f, aggregate=False)(self.x)
 
 
+@jtu.thread_unsafe_test_class()
 class _CuptiV2TestBase(jtu.JaxTestCase):
   """Base for V2 multi-subscriber tests."""
 
@@ -173,8 +173,8 @@ class ProfilerCuptiMultiSubscriberTest(_CuptiV2TestBase):
     self._run_mosaic_profile()
     self._run_jax_trace()
 
-  def test_finalize_flag_ignored_on_cupti_v2(self):
-    """finalize has no effect on the CUPTI V2 multi-subscriber path."""
+  def test_finalize_true_allows_cupti_v2_reuse(self):
+    """finalize=True does not break later CUPTI V2 subscribers."""
     f = lambda x: x @ x
 
     result_true, runtime_ms1 = profiler.Cupti(finalize=True).measure(f)(self.x)


### PR DESCRIPTION
Updates the Mosaic GPU profiler to use the CUPTI V2 APIs where available, refreshes the related docs/warnings, and adds coexistence coverage for PGLE and jax.profiler.trace.