### PR TITLE
Added out_sharding to jax.random.cauchy sampler

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -1239,7 +1239,9 @@ def _beta(key, a, b, shape, dtype) -> Array:
 
 def cauchy(key: ArrayLike,
            shape: Shape = (),
-           dtype: DTypeLikeFloat | None = None) -> Array:
+           dtype: DTypeLikeFloat | None = None,
+           *,
+           out_sharding: NamedSharding | P | None = None) -> Array:
   r"""Sample Cauchy random values with given shape and float dtype.
 
   The values are distributed according to the probability density function:
@@ -1255,6 +1257,14 @@ def cauchy(key: ArrayLike,
       shape. Default ().
     dtype: optional, a float dtype for the returned values (default float64 if
       jax_enable_x64 is true, otherwise float32).
+    out_sharding: Optional. Specifies how the output array should be sharded
+      across devices in multi-device computation. Can be a
+      :class:`~jax.sharding.NamedSharding`, a :class:`~jax.sharding.PartitionSpec`
+      (``P``), or ``None`` (default). When specified, the output will be sharded
+      according to the given sharding specification. Primarily used in explicit
+      sharding mode.
+      See the `explicit sharding tutorial <https://docs.jax.dev/en/latest/parallel.html>`_
+      for more details.
 
   Returns:
     A random array with the specified shape and dtype.
@@ -1266,7 +1276,9 @@ def cauchy(key: ArrayLike,
     raise ValueError(f"dtype argument to `cauchy` must be a float "
                      f"dtype, got {dtype}")
   shape = core.canonicalize_shape(shape)
-  return _cauchy(key, shape, dtype)
+  out_sharding = canonicalize_sharding_for_samplers(out_sharding, "cauchy", shape)
+  return maybe_auto_axes(_cauchy, out_sharding,
+                         shape=shape, dtype=dtype)(key)
 
 @jit(static_argnums=(1, 2))
 def _cauchy(key, shape, dtype) -> Array:

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -214,6 +214,7 @@ _OUT_SHARDING_CASES = [
     ('bernoulli',        lambda key, n, s: random.bernoulli(key, p=0.5, shape=(n,), out_sharding=s)),
     ('beta',             lambda key, n, s: random.beta(key, 0.2, 5.0, shape=(n,), out_sharding=s)),
     ('bits',             lambda key, n, s: random.bits(key, shape=(n,), out_sharding=s)),
+    ('cauchy',           lambda key, n, s: random.cauchy(key, shape=(n,), out_sharding=s)),
     ('gumbel',           lambda key, n, s: random.gumbel(key, shape=(n,), out_sharding=s)),
     ('normal',           lambda key, n, s: random.normal(key, shape=(n,), out_sharding=s)),
     ('permutation',      lambda key, n, s: random.permutation(key, n, out_sharding=s)),


### PR DESCRIPTION
Description:
- Added out_sharding to jax.random.cauchy sampler
- Added test

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->