### PR TITLE
fix: correct expon.ppf for scale != 1 (applies scale as multiplier, not divisor of q)

### DIFF
--- a/jax/_src/scipy/stats/expon.py
+++ b/jax/_src/scipy/stats/expon.py
@@ -262,9 +262,13 @@ def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
     :func:`jax.scipy.stats.expon.logsf`
   """
   q, loc, scale = promote_args_inexact("expon.ppf", q, loc, scale)
-  neg_scaled_q = lax.div(lax.sub(loc, q), scale)
+  # The correct ppf for Exp(loc, scale) is derived by inverting the CDF:
+  #   cdf(x) = 1 - exp(-(x - loc) / scale)  =>  x = loc - scale * log(1 - q)
+  # The previous implementation applied (loc - q) / scale inside log1p, which
+  # treated q as a spatial argument rather than a probability, producing wrong
+  # results whenever scale != 1.  See gh-36757.
   return jnp.where(
     jnp.isnan(q) | (q < 0) | (q > 1),
     np.nan,
-    lax.neg(lax.log1p(neg_scaled_q)),
+    lax.sub(loc, lax.mul(scale, lax.log1p(lax.neg(q)))),
   )

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -597,6 +597,20 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       )
       self._CompileAndCheck(lax_fun, args_maker)
 
+  def testExponPpfNonunitScale(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/36757.
+    # ppf(q, scale=s) must equal -s * log(1 - q).
+    # The previous implementation divided q by scale inside log1p, giving
+    # wrong results for any scale != 1.
+    q = np.array([0.4, 0.4, 0.5, 0.9])
+    loc = np.array([0.0, 0.0, 1.0, 0.0])
+    scale = np.array([0.5, 1e-3, 2.0, 3.0])
+    expected = osp_stats.expon.ppf(q, loc=loc, scale=scale)
+    actual = lsp_stats.expon.ppf(
+        jnp.array(q), jnp.array(loc), jnp.array(scale))
+    self.assertAllClose(actual, expected, rtol=1e-4, atol=1e-4,
+                        check_dtypes=False)
+
   @genNamedParametersNArgs(4)
   def testGammaLogPdf(self, shapes, dtypes):
     rng = jtu.rand_positive(self.rng())


### PR DESCRIPTION
## Summary

Fixes #36757 — `jax.scipy.stats.expon.ppf` returns wrong values for any `scale != 1`.

### Root Cause

The previous implementation computed:

```python
neg_scaled_q = (loc - q) / scale          # treats q like a spatial value
return -log1p(neg_scaled_q)               # wrong formula
```

This gives `ppf(q=0.4, scale=0.5)` → `-log1p((0 - 0.4) / 0.5)` = `-log1p(-0.8)` = `-log(0.2)` ≈ `1.609` instead of the correct `0.255`.

### Correct Formula

The inverse of the CDF `cdf(x) = 1 - exp(-(x - loc) / scale)` is:

```
ppf(q, loc, scale) = loc - scale * log(1 - q)
                   = loc - scale * log1p(-q)
```

### Fix

```python
# Before
neg_scaled_q = lax.div(lax.sub(loc, q), scale)
return jnp.where(..., lax.neg(lax.log1p(neg_scaled_q)))

# After  
return jnp.where(..., lax.sub(loc, lax.mul(scale, lax.log1p(lax.neg(q)))))
```

### Verification (from the issue)

```python
# Before fix
jax.scipy.stats.expon.ppf(0.4, scale=0.5)   # → 1.609  ❌
jax.scipy.stats.expon.ppf(0.4, scale=1e-3)  # → nan    ❌

# After fix  
jax.scipy.stats.expon.ppf(0.4, scale=0.5)   # → 0.255  ✓
jax.scipy.stats.expon.ppf(0.4, scale=1e-3)  # → 5.1e-4 ✓
```

### Tests

Added `testExponPpfNonunitScale` in `tests/scipy_stats_test.py` — tests 4 `(q, loc, scale)` combinations including the exact values from the issue report.

cc @jakevdp @froystig @yashk2810 — please let me know if you'd like any changes!