### PR TITLE
[consts] Fix tests

### DIFF
--- a/tests/compilation_cache_test.py
+++ b/tests/compilation_cache_test.py
@@ -199,6 +199,7 @@ class CompilationCacheTest(CompilationCacheTestCase):
     # TODO: create a test for calling pmap with the same input more than once
 
   def test_pmap_with_consts(self):
+    self.enter_context(config.embedded_constants_max_bytes(4))
     const = jnp.array([42, 43], dtype=np.int32)
     clear_cache()
     f = pmap(lambda x: x - lax.psum(x, "i") + const[0], axis_name="i")
@@ -242,6 +243,7 @@ class CompilationCacheTest(CompilationCacheTestCase):
       self.assertEqual(count_cache_items(), 2)
 
   def test_jit_with_constants(self):
+    self.enter_context(config.embedded_constants_max_bytes(4))
     const = jnp.array([42, 43])  #  A distinctive shape
     clear_cache()
     f = jit(lambda x: x * const[0])

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -260,7 +260,8 @@ class JaxJitTest(jtu.JaxTestCase):
 
   @jtu.skip_on_flag("jax_use_simplified_jaxpr_constants", False)
   def test_check_for_large_number_of_constants_new(self):
-    y = np.ones((128, 128), dtype=np.float32)
+    self.enter_context(config.embedded_constants_max_bytes(4))
+    y = np.ones((128, 128))
     x = jnp.zeros((128,))
 
     def jit_maker(): # need to ensure we lower at each test
@@ -269,7 +270,7 @@ class JaxJitTest(jtu.JaxTestCase):
       return jax.jit(my_func)
 
     with self.assertWarnsRegex(UserWarning,
-        r'Closed-over constant .* float32\[128,128\] in my_func .*'):
+        r'Closed-over constant .* float..\[128,128\] in my_func .*'):
       with config.captured_constants_warn_bytes(y.nbytes):
         jit_maker()(x)
 

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -5004,6 +5004,7 @@ class CompositeTest(jtu.JaxTestCase):
       grad(my_square)(1.0)
 
   def test_composite_with_array_consts(self):
+    self.enter_context(config.embedded_constants_max_bytes(4))
     @partial(lax.composite, name="my.consts")
     def my_consts(x, /, *, scale):
       return jnp.round(x / scale)


### PR DESCRIPTION
Some tests started to fail with JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS=1 due to recent changes in #36974.
