### PR TITLE
Pyrefly now assumes Python 3.13

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1998,7 +1998,7 @@ def cur_qdd(x):
   prev_trace = trace_ctx.trace
   trace_ctx.set_trace(eval_trace)
   try:
-    return prev_trace.cur_qdd(x)  # pyrefly: ignore[missing-attribute]
+    return prev_trace.cur_qdd(x)
   finally:
     trace_ctx.set_trace(prev_trace)
 

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -79,7 +79,7 @@ IrValues = ir.Value | tuple[ir.Value, ...]
 
 
 def dense_int_elements(xs) -> ir.DenseElementsAttr:
-  return ir.DenseIntElementsAttr.get(np.asarray(xs, np.int64))  # pyrefly: ignore[no-matching-overload]
+  return ir.DenseIntElementsAttr.get(np.asarray(xs, np.int64))
 
 dense_int_array = ir.DenseI64ArrayAttr.get
 
@@ -424,14 +424,14 @@ def _numpy_array_attribute(x: np.ndarray | np.generic) -> ir.Attribute:
   shape = x.shape
   x = np.ascontiguousarray(x)
   try:
-    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)  # pyrefly: ignore[no-matching-overload]
+    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)
   except ValueError:
     # Backwards compatibility fallback for old MLIR versions.
     # Delete once minimum supported jaxlib version is 0.9.1.
     if x.dtype != np.bool_:
       raise
     x = np.ascontiguousarray(np.packbits(x, bitorder='little'))
-    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)  # pyrefly: ignore[no-matching-overload]
+    return ir.DenseElementsAttr.get(x, type=element_type, shape=shape)
 
 def _numpy_array_attribute_handler(val: np.ndarray | np.generic) -> ir.Attribute:
   if 0 in val.strides and val.size > 0:
@@ -3269,7 +3269,7 @@ def custom_call(
     # We add the result_shapes at the end of the operands, and must pass
     # the indices_of_output_operands attribute. This attribute is not yet
     # accepted by the CustomCall constructor, so we use build_generic
-    attributes["indices_of_shape_operands"] = ir.DenseIntElementsAttr.get(  # pyrefly: ignore[no-matching-overload]
+    attributes["indices_of_shape_operands"] = ir.DenseIntElementsAttr.get(
         np.asarray(list(range(len(operands), len(operands) + len(result_shapes))),
                    dtype=np.int64))
     if operand_layouts is not None:
@@ -3279,7 +3279,7 @@ def custom_call(
 
   if operand_layouts is not None:
     attributes["operand_layouts"] = ir.ArrayAttr.get([
-        ir.DenseIntElementsAttr.get(  # pyrefly: ignore[no-matching-overload]
+        ir.DenseIntElementsAttr.get(
             np.atleast_1d(np.asarray(l, dtype=np.int64)),
             type=ir.IndexType.get()) for l in operand_layouts
     ])
@@ -3288,7 +3288,7 @@ def custom_call(
     assert len(result_layouts) == len(result_types), (
         result_layouts, result_types)
     attributes["result_layouts"] = ir.ArrayAttr.get([
-        ir.DenseIntElementsAttr.get(  # pyrefly: ignore[no-matching-overload]
+        ir.DenseIntElementsAttr.get(
             np.atleast_1d(np.asarray(l, dtype=np.int64)),
             type=ir.IndexType.get()) for l in result_layouts
     ])
@@ -3355,7 +3355,7 @@ def reduce_window(
         window_strides=dense_int_array(window_strides),
         base_dilations=dense_int_array(base_dilation),
         window_dilations=dense_int_array(window_dilation),
-        padding=ir.DenseIntElementsAttr.get(np.asarray(padding, np.int64),  # pyrefly: ignore[no-matching-overload]
+        padding=ir.DenseIntElementsAttr.get(np.asarray(padding, np.int64),
                                             shape=[len(padding), 2]))
     reducer = rw.regions[0].blocks.append(*(scalar_types + scalar_types))
     with ir.InsertionPoint(reducer):

--- a/jax/_src/lax/ann.py
+++ b/jax/_src/lax/ann.py
@@ -297,7 +297,7 @@ def _approx_top_k_lowering(ctx, operand, *, k,
   iota = mlir.iota(ctx, core.ShapedArray(ctx.avals_in[0].shape, np.int32),
                    dimension=reduction_dimension)
 
-  init_arg = hlo.constant(ir.DenseElementsAttr.get(np.int32(-1)))  # pyrefly: ignore[no-matching-overload]
+  init_arg = hlo.constant(ir.DenseElementsAttr.get(np.int32(-1)))
   init_val_array = _get_init_val_literal(ctx.avals_in[0].dtype, is_max_k)
   init_vals = [mlir.ir_constant(init_val_array.reshape(()))]
 

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -934,7 +934,7 @@ def _replica_groups_hlo(replica_groups: Sequence[Sequence[int]]
   # Uneven replica groups are padded with -1.
   groups = np.array(list(itertools.zip_longest(*replica_groups, fillvalue=-1)),
                     dtype=np.int64).T
-  return ir.DenseIntElementsAttr.get(np.ascontiguousarray(groups))  # pyrefly: ignore[no-matching-overload]
+  return ir.DenseIntElementsAttr.get(np.ascontiguousarray(groups))
 
 def _allreduce_impl(prim, pos_reducer, arg, *, axes, axis_index_groups):
   assert axis_index_groups is None
@@ -2295,7 +2295,7 @@ def _build_axis_index_lowering_hlo(ctx, axis_name, axis_env):
       axis_context.manual_axes and
       axis_context.manual_axes != frozenset(axis_context.mesh.axis_names)):
     if axis_env.sizes[axis_pos] == 1:
-      return hlo.constant(ir.DenseElementsAttr.get(np.asarray(0, dtype=np.int32)))  # pyrefly: ignore[no-matching-overload]
+      return hlo.constant(ir.DenseElementsAttr.get(np.asarray(0, dtype=np.int32)))
     def f():
       return axis_index_p.bind(axis_name=axis_name)
     return mlir.lower_fun(

--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -741,7 +741,7 @@ def _select_and_scatter_lower(
       init_value,
       window_dimensions=mlir.dense_int_array(window_dimensions),
       window_strides=mlir.dense_int_array(window_strides),
-      padding=ir.DenseIntElementsAttr.get(np.asarray(padding, np.int64),  # pyrefly: ignore[no-matching-overload]
+      padding=ir.DenseIntElementsAttr.get(np.asarray(padding, np.int64),
                                           shape=(len(padding), 2)))
   select = op.select.blocks.append(scalar_type, scalar_type)
   with ir.InsertionPoint(select):

--- a/jax/_src/numpy/array_constructors.py
+++ b/jax/_src/numpy/array_constructors.py
@@ -52,7 +52,7 @@ rocm_plugin_extension = None
 try:
   from importlib.metadata import distributions
   for dist in distributions():
-    name = dist.metadata.get('Name', '')  # pyrefly: ignore[missing-attribute]
+    name = dist.metadata.get('Name', '')
     if name.startswith('jax-rocm') and name.endswith('-plugin'):
       module_name = name.replace('-', '_')
       try:

--- a/jax/_src/pallas/mosaic_gpu/lowering.py
+++ b/jax/_src/pallas/mosaic_gpu/lowering.py
@@ -568,7 +568,7 @@ class ModuleContext:
       assert smem_base is not None
       view = memref_dialect.view(scratch_ty, smem_base, _as_index(off), [])
     else:
-      view = mgpu.dialect.slice_smem(scratch_ty, off)  # pyrefly: ignore[bad-argument-type]
+      view = mgpu.dialect.slice_smem(scratch_ty, off)
 
     off += gpu_core.align_to(
         math.prod(struct.shape)
@@ -1487,7 +1487,7 @@ def _extract_aliased_ref(
                   "The base ref for aliases must come from a slice_smem op."
               )
 
-            base_offset = ref.owner.offset.value  # pyrefly: ignore[missing-attribute]
+            base_offset = ref.owner.offset.value
             total_offset = base_offset + offset
 
             ref_ty = ir.MemRefType.get(

--- a/jax/_src/pallas/mosaic_gpu/primitives.py
+++ b/jax/_src/pallas/mosaic_gpu/primitives.py
@@ -731,7 +731,7 @@ def _copy_gmem_to_smem_lowering(
           [ir.IntegerAttr.get(i32, axis) for axis in collective or []]
       ),
       leader_tracked=leader_tracked_attr,
-      oob_fill_mode=ir.IntegerAttr.get(i32, oob_mode.value)  # pyrefly: ignore[unexpected-keyword]
+      oob_fill_mode=ir.IntegerAttr.get(i32, oob_mode.value)
   )
   return ()
 

--- a/jax/_src/pallas/mpmd.py
+++ b/jax/_src/pallas/mpmd.py
@@ -312,7 +312,7 @@ def _mpmd_map(
 
     for mesh, fn in meshes_and_fns:
       grid_spec = pallas_core.GridSpec(
-          grid=tuple(mesh.shape.items()),  # pyrefly: ignore[bad-argument-type]
+          grid=tuple(mesh.shape.items()),
           in_specs=in_tree.unflatten(
               pallas_core.BlockSpec(
                   memory_space=aval.memory_space

--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -1352,7 +1352,7 @@ def _multiple_of_rule(ctx: LoweringRuleContext, x, values: Sequence[int]):
   _set_attr(
       x,
       "tt.divisibility",
-      ir.DenseIntElementsAttr.get(np.asarray(values, dtype=np.int32)),  # pyrefly: ignore[no-matching-overload]
+      ir.DenseIntElementsAttr.get(np.asarray(values, dtype=np.int32)),
   )
   return x
 

--- a/jax/_src/pallas/triton/primitives.py
+++ b/jax/_src/pallas/triton/primitives.py
@@ -700,6 +700,6 @@ def _max_contiguous_rule(
   lowering._set_attr(
       x,
       "tt.contiguity",
-      ir.DenseIntElementsAttr.get(np.asarray(values, dtype=np.int32)),  # pyrefly: ignore[no-matching-overload]
+      ir.DenseIntElementsAttr.get(np.asarray(values, dtype=np.int32)),
   )
   return x

--- a/jax/experimental/mosaic/gpu/core.py
+++ b/jax/experimental/mosaic/gpu/core.py
@@ -420,7 +420,7 @@ def _slice_smem(
     lowering_semantics: LoweringSemantics,
 ) -> ir.Value:
   if lowering_semantics == LoweringSemantics.Warpgroup:
-    return dialect.slice_smem(result, offset)  # pyrefly: ignore[bad-argument-type]
+    return dialect.slice_smem(result, offset)
   else:
     ir_offset = arith.constant(ir.IndexType.get(), offset)
     return memref.view(result, smem_base, ir_offset, [])

--- a/jax/experimental/mosaic/gpu/dialect_lowering.py
+++ b/jax/experimental/mosaic/gpu/dialect_lowering.py
@@ -1079,7 +1079,7 @@ def _mgpu_async_load_op_lowering_rule(
     utils.warpgroup_barrier()  # Make sure the writes have completed.
 
   # TODO(dasenov): Add support for the remaining op properties.
-  oob_mode = lc.OOBFillMode(ir.IntegerAttr(load_op.oob_fill_mode).value)  # pyrefly: ignore[missing-attribute]
+  oob_mode = lc.OOBFillMode(ir.IntegerAttr(load_op.oob_fill_mode).value)
   ctx.launch_context.async_copy(
       src_ref=load_op.source,
       dst_ref=unwrapped_dst,
@@ -1641,7 +1641,7 @@ def _mgpu_slice_smem_op_lowering_rule(
     ctx: LoweringContext, op: mgpu.SliceSMEMOp
 ) -> Sequence[ir.Value]:
   ref_ty = ir.MemRefType(op.result.type)
-  offset = op.offset.value  # pyrefly: ignore[missing-attribute]
+  offset = op.offset.value
   if isinstance(ref_ty.element_type, mgpu.BarrierType):
     # Barrier memrefs are not transformed and must not be wrapped.
     assert not inference_utils.has_out_transforms_set(op)

--- a/jax/experimental/mosaic/gpu/launch_context.py
+++ b/jax/experimental/mosaic/gpu/launch_context.py
@@ -2013,7 +2013,7 @@ class LaunchContext:
       parameter_uses_multimem = np.zeros(self.num_params, dtype=np.int64)
 
     parameter_uses_multimem[parameter_id] = 1
-    module_attributes[MULTIMEM_ARGS_ATTR] = ir.DenseIntElementsAttr.get(  # pyrefly: ignore[no-matching-overload]
+    module_attributes[MULTIMEM_ARGS_ATTR] = ir.DenseIntElementsAttr.get(
         parameter_uses_multimem
     )
 

--- a/jax/experimental/mosaic/gpu/layout_inference.py
+++ b/jax/experimental/mosaic/gpu/layout_inference.py
@@ -1726,7 +1726,7 @@ def _slice_tmem_constraint_system(
   # TODO(bchetioui): enforce that the parent is a TmemAllocOp.
   if "alias_id" in op.attributes:
     alias_id = ir.IntegerAttr(op.attributes["alias_id"]).value
-    alias_key = _AliasKey(None, op.offset.value, alias_id)  # pyrefly: ignore[missing-attribute]
+    alias_key = _AliasKey(None, op.offset.value, alias_id)
     if (cached_variable := ctx.slice_tmem_aliases.get(alias_key)) is not None:
       result_variable = cached_variable
     else:
@@ -1769,7 +1769,7 @@ def _slice_smem_constraint_system(
   result = ValueSite(op, VariableType.RESULT, 0)
   if "alias_id" in op.attributes:
     alias_id = ir.IntegerAttr(op.attributes["alias_id"]).value
-    alias_key = _AliasKey(None, op.offset.value, alias_id)  # pyrefly: ignore[missing-attribute]
+    alias_key = _AliasKey(None, op.offset.value, alias_id)
     if (cached_variable := ctx.slice_smem_aliases.get(alias_key)) is not None:
       result_variable = cached_variable
     else:

--- a/jax/experimental/mosaic/gpu/utils.py
+++ b/jax/experimental/mosaic/gpu/utils.py
@@ -53,7 +53,7 @@ def nvvm_shfl_sync(ty, *args):
   if first_param != "thread_mask":
     return nvvm.shfl_sync(ty, *args)
   else:
-    return nvvm.shfl_sync(*args, results=[ty])  # pyrefly: ignore=[unexpected-keyword]
+    return nvvm.shfl_sync(*args, results=[ty])
 
 
 def gpu_address_space_to_nvptx(address_space: gpu.AddressSpace) -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ doctest_optionflags = [
 addopts = "--doctest-glob='*.rst' --ignore='examples/ffi' --import-mode=importlib"
 
 [tool.pyrefly]
-python-version = "3.11"
+python-version = "3.13"
 project-includes = [
     "jax/**/*.py*",
 ]


### PR DESCRIPTION
We were previously using 3.11, our minimum supported version, but it is more convenient to match the version we have internally at Google to make sure the type checking is consistent internally and externally.

I also nuked unnecessary Pyrefly suppressions.
