### PR TITLE
[random] Add out_sharding to jax.random.gamma

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -1604,7 +1604,9 @@ batching.primitive_batchers[random_gamma_p] = _gamma_batching_rule
 def gamma(key: ArrayLike,
           a: RealArray,
           shape: Shape | None = None,
-          dtype: DTypeLikeFloat | None = None) -> Array:
+          dtype: DTypeLikeFloat | None = None,
+          *,
+          out_sharding: NamedSharding | P | None = None) -> Array:
   r"""Sample Gamma random values with given shape and float dtype.
 
   The values are distributed according to the probability density function:
@@ -1628,6 +1630,14 @@ def gamma(key: ArrayLike,
       produces a result shape equal to ``a.shape``.
     dtype: optional, a float dtype for the returned values (default float64 if
       jax_enable_x64 is true, otherwise float32).
+    out_sharding: Optional. Specifies how the output array should be sharded
+      across devices in multi-device computation. Can be a
+      :class:`~jax.sharding.NamedSharding`, a :class:`~jax.sharding.PartitionSpec`
+      (``P``), or ``None`` (default). When specified, the output will be sharded
+      according to the given sharding specification. Primarily used in explicit
+      sharding mode.
+      See the `explicit sharding tutorial <https://docs.jax.dev/en/latest/parallel.html>`_
+      for more details.
 
   Returns:
     A random array with the specified dtype and with shape given by ``shape`` if
@@ -1645,7 +1655,8 @@ def gamma(key: ArrayLike,
                      f"dtype, got {dtype}")
   if shape is not None:
     shape = core.canonicalize_shape(shape)
-  return _gamma(key, a, shape=shape, dtype=dtype)
+  out_sharding = canonicalize_sharding_for_samplers(out_sharding, "gamma", shape)
+  return maybe_auto_axes(_gamma, out_sharding, shape=shape, dtype=dtype)(key, a)
 
 
 def loggamma(key: ArrayLike,

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -235,6 +235,7 @@ _OUT_SHARDING_CASES = [
     ('t', lambda key, n, s: random.t(key, df=10.0, shape=(n,), out_sharding=s)),
     ('truncated_normal', lambda key, n, s: random.truncated_normal(key, lower=-2., upper=2., shape=(n,), out_sharding=s)),
     ('uniform', lambda key, n, s: random.uniform(key, shape=(n,), out_sharding=s)),
+    ('gamma', lambda key, n, s: random.gamma(key, a=2.0, shape=(n,), out_sharding=s)),
 ]
 
 


### PR DESCRIPTION
Adds out_sharding argument to  `jax.random.gamma` like in other samplers. 