### PR TITLE
Add jax.scipy.linalg.dft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     matrices ({jax-issue}`#10144`).
   * Added {func}`jax.scipy.linalg.circulant` for constructing circulant
     matrices ({jax-issue}`#10144`).
+  * Added {func}`jax.scipy.linalg.dft` for constructing discrete Fourier
+    transform matrices ({jax-issue}`#10144`).
   * Moved RNG APIs from "implementations" to dtypes ({jax-issue}`#27854`):
     * Added `jax.random.key_dtype` to get the dtype corresponding to a PRNG
       implementation name.

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -59,6 +59,7 @@ jax.scipy.linalg
    cholesky
    circulant
    det
+   dft
    eigh
    eigh_tridiagonal
    expm

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -2741,6 +2741,54 @@ def hadamard(n: int, dtype: DTypeLike = int) -> Array:
   return H
 
 
+@partial(jit, static_argnames=("n", "scale", "dtype"))
+def dft(n: int, scale: str | None = None, *,
+        dtype: DTypeLike | None = None) -> Array:
+  r"""Construct an n-by-n discrete Fourier transform matrix.
+
+  JAX implementation of :func:`scipy.linalg.dft`.
+
+  The DFT matrix :math:`W_n` has entries :math:`W_{ij} = \omega^{ij}`, where
+  :math:`\omega = e^{-2\pi i / n}` is the primitive n-th root of unity, for
+  :math:`0 \le i, j < n`.
+
+  Args:
+    n: size of the matrix.
+    scale: (optional) ``None`` (default, unscaled), ``'sqrtn'`` (scale by
+      :math:`1/\sqrt{n}`, making the matrix unitary), or ``'n'`` (scale by
+      :math:`1/n`).
+    dtype: (optional) complex floating-point dtype for the output. Defaults to
+      JAX's default complex dtype.
+
+  Returns:
+    A DFT matrix of shape ``(n, n)``.
+
+  Examples:
+    >>> jax.scipy.linalg.dft(4).round(3)
+    Array([[ 1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j],
+           [ 1.+0.j, -0.-1.j, -1.+0.j,  0.+1.j],
+           [ 1.+0.j, -1.+0.j,  1.-0.j, -1.+0.j],
+           [ 1.+0.j,  0.+1.j, -1.+0.j, -0.-1.j]], dtype=complex64)
+  """
+  if scale is not None and scale not in ('sqrtn', 'n'):
+    raise ValueError(
+        f"scale must be None, 'sqrtn', or 'n'; got {scale!r}.")
+  if dtype is None:
+    dtype = dtypes.default_complex_dtype()
+  else:
+    dtype = dtypes.check_and_canonicalize_user_dtype(dtype, "dft")
+    if not dtypes.issubdtype(dtype, np.complexfloating):
+      raise ValueError(
+          f"dtype must be a complex floating-point type; got {dtype}.")
+  a = jnp.arange(n, dtype=dtype)
+  omegas = jnp.exp(-2j * np.pi * a[:, None] * a[None, :] / n)
+  if scale == 'sqrtn':
+    omegas = omegas / jnp.sqrt(n)
+  elif scale == 'n':
+    omegas = omegas / n
+  return omegas
+
+
 def _solve_sylvester_triangular_scan(R: Array, S: Array, F: Array) -> Array:
   """
   Solves the Sylvester equation using Bartels-Stewart algorithm

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -22,6 +22,7 @@ from jax._src.scipy.linalg import (
   cho_solve as cho_solve,
   circulant as circulant,
   det as det,
+  dft as dft,
   eigh as eigh,
   eigh_tridiagonal as eigh_tridiagonal,
   expm as expm,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2628,6 +2628,31 @@ class LaxLinalgTest(jtu.JaxTestCase):
       jsp.linalg.hadamard(n)
 
   @jtu.sample_product(
+    n=[0, 1, 2, 3, 5, 8, 16],
+    scale=[None, 'sqrtn', 'n'],
+  )
+  def testDft(self, n, scale):
+    args_maker = lambda: []
+    osp_fun = partial(osp.linalg.dft, n=n, scale=scale)
+    jsp_fun = partial(jsp.linalg.dft, n=n, scale=scale)
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker,
+                            atol=1e-5, rtol=1e-5, check_dtypes=False)
+    self._CompileAndCheck(jsp_fun, args_maker)
+
+  def testDftInvalidScale(self):
+    with self.assertRaisesRegex(ValueError, "scale must be"):
+      jsp.linalg.dft(4, scale='bad')
+
+  @jtu.sample_product(dtype=complex_types)
+  def testDftDtype(self, dtype):
+    result = jsp.linalg.dft(4, dtype=dtype)
+    self.assertEqual(result.dtype, dtype)
+
+  def testDftInvalidDtype(self):
+    with self.assertRaisesRegex(ValueError, "dtype must be"):
+      jsp.linalg.dft(4, dtype=jnp.float32)
+
+  @jtu.sample_product(
       shape=[(5, 1), (10, 4), (128, 12)],
       dtype=float_types,
       symmetrize_output=[True, False],


### PR DESCRIPTION
Adds `jax.scipy.linalg.dft`, continuing to close the gap on `scipy.linalg`'s special matrices from #10144.

The implementation builds the matrix directly: `W[i, j] = exp(-2j * pi * i * j / n)`. SciPy's `scale` argument is supported (`None`, `'sqrtn'`, `'n'`), with a `ValueError` for anything else, matching SciPy's validation.

In addition to SciPy's signature, there's an optional kw-only `dtype` argument so callers can pick an explicit complex floating-point dtype. Defaults to JAX's default complex dtype (so x32 vs x64 behaves how you'd expect).

### Files touched
- `jax/_src/scipy/linalg.py`: `dft` implementation, jitted with static `n`, `scale`, and `dtype`.
- `jax/scipy/linalg.py`: re-export.
- `tests/linalg_test.py`: `testDft` (sample_product over n and scale, including n=0 and primes), `testDftInvalidScale`, `testDftDtype`, `testDftInvalidDtype`.
- `docs/jax.scipy.rst` + `CHANGELOG.md` updated.

One implementation note: the `arange` is cast to the chosen complex dtype before the outer product, to avoid int32 overflow in the intermediate `i * j` for large `n` (SciPy avoids this by using int64 `outer` + float64 math).

### Notes on prior work
Part of this was also covered by #35075 (a bundle of five special matrices) that hasn't been iterated on since the day it opened. I've been splitting the same set of functions into smaller PRs instead. `companion` is in #37333, `fiedler` in #37334, `hadamard` is already merged (#37043), and `leslie` is still open for someone to pick up.

Refs #10144.