### PR TITLE
Added out_sharding arg to jax.random.categorical sampler

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -1962,6 +1962,8 @@ def categorical(
   shape: Shape | None = None,
   replace: bool = True,
   mode: str | None = None,
+  *,
+  out_sharding: NamedSharding | P | None = None
 ) -> Array:
   """Sample random values from categorical distributions.
 
@@ -1984,6 +1986,14 @@ def categorical(
       for events with probability less than about 1E-7; with mode="high" this limit
       is pushed down to about 1E-14. mode="high" approximately doubles the cost of
       sampling.
+    out_sharding: Optional. Specifies how the output array should be sharded
+      across devices in multi-device computation. Can be a
+      :class:`~jax.sharding.NamedSharding`, a :class:`~jax.sharding.PartitionSpec`
+      (``P``), or ``None`` (default). When specified, the output will be sharded
+      according to the given sharding specification. Primarily used in explicit
+      sharding mode.
+      See the `explicit sharding tutorial <https://docs.jax.dev/en/latest/parallel.html>`_
+      for more details.
 
   Returns:
     A random array with int dtype and shape given by ``shape`` if ``shape``
@@ -2004,8 +2014,13 @@ def categorical(
   else:
     shape = core.canonicalize_shape(shape)
     _check_shape("categorical", shape, batch_shape)
-  shape_prefix = shape[:len(shape)-len(batch_shape)]
+  out_sharding = canonicalize_sharding(out_sharding, "categorical")
+  return maybe_auto_axes(_categorical, out_sharding, shape=shape,
+                         batch_shape=batch_shape, axis=axis,
+                         replace=replace, mode=mode)(key, logits_arr)
 
+def _categorical(key, logits_arr, shape, batch_shape, axis, replace, mode) -> Array:
+  shape_prefix = shape[:len(shape)-len(batch_shape)]
   if replace:
     if axis >= 0:
       axis -= len(logits_arr.shape)

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -214,6 +214,10 @@ _OUT_SHARDING_CASES = [
     ('bernoulli', lambda key, n, s: random.bernoulli(key, p=0.5, shape=(n,), out_sharding=s)),
     ('beta', lambda key, n, s: random.beta(key, 0.2, 5.0, shape=(n,), out_sharding=s)),
     ('bits', lambda key, n, s: random.bits(key, shape=(n,), out_sharding=s)),
+    ('categorical_1', lambda key, n, s: random.categorical(key, jnp.asarray([0.0, 1.0, 2.0]), shape=(n,), out_sharding=s, replace=True)),
+    ('categorical_2', lambda key, n, s: random.categorical(key, jnp.ones((n,)), shape=(n,), out_sharding=s, replace=False)),
+    ('categorical_3', lambda key, n, s: random.categorical(key, jnp.ones((n, 3), out_sharding=s), shape=(n,), out_sharding=s, replace=True)),
+    ('categorical_4', lambda key, n, s: random.categorical(key, jnp.ones((n, 3), out_sharding=s), shape=(n,), out_sharding=s, replace=False)),
     ('cauchy', lambda key, n, s: random.cauchy(key, shape=(n,), out_sharding=s)),
     ('exponential', lambda key, n, s: random.exponential(key, shape=(n,), out_sharding=s)),
     ('gumbel', lambda key, n, s: random.gumbel(key, shape=(n,), out_sharding=s)),
@@ -248,7 +252,7 @@ class RandomOutShardingTest(RandomTestBase):
     n = sharding.mesh.shape['x']
     with jax.set_mesh(sharding.mesh):
       result = fn(key, n, sharding)
-      jit_result = jax.jit(fn, static_argnums=(1,2))(key, n, sharding)
+      jit_result = jax.jit(fn, static_argnums=(1, 2))(key, n, sharding)
     self.assertTrue(result.sharding.is_equivalent_to(sharding, result.ndim))
     self.assertTrue(result.sharding.is_equivalent_to(sharding, jit_result.ndim))
 


### PR DESCRIPTION
Description:
- Added out_sharding arg to jax.random.categorical sampler
- Added tests

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->