### PR TITLE
[OneAPI GPU] Add OneAPI plugin extension infrastructure and glue code

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -68,6 +68,7 @@ WHEEL_BUILD_TARGET_DICT = {
     "jax-rocm-plugin": "//jaxlib/tools:jax_rocm_plugin_wheel",
     "jax-rocm-pjrt": "//jaxlib/tools:jax_rocm_pjrt_wheel",
     "mosaic-gpu-cuda": "//jaxlib/tools:mosaic_gpu_wheel_cuda{cuda_major_version}",
+    "jax-oneapi-plugin": "//jaxlib/tools:jax_oneapi_plugin_wheel",
     "jax-oneapi-pjrt": "//jaxlib/tools:jax_oneapi_pjrt_wheel",
 }
 
@@ -151,7 +152,7 @@ def add_artifact_subcommand_arguments(parser: argparse.ArgumentParser):
         --wheels="jaxlib,jax-cuda-plugin", etc.
         Valid options are: jaxlib, jax-cuda-plugin or cuda-plugin, jax-cuda-pjrt or cuda-pjrt,
         jax-rocm-plugin or rocm-plugin, jax-rocm-pjrt or rocm-pjrt,
-        jax-oneapi-pjrt or oneapi-pjrt.
+        jax-oneapi-pjrt or oneapi-pjrt, jax-oneapi-plugin or oneapi-plugin.
         """,
   )
 
@@ -514,7 +515,7 @@ async def main():
           " jax-cuda-plugin or cuda-plugin, jax-cuda-pjrt or cuda-pjrt,"
           " jax-rocm-plugin or rocm-plugin, jax-rocm-pjrt or rocm-pjrt,"
           " or mosaic-gpu",
-          " jax-oneapi-pjrt or oneapi-pjrt",
+          " jax-oneapi-plugin or oneapi-plugin, jax-oneapi-pjrt or oneapi-pjrt",
           wheel,
       )
       sys.exit(1)

--- a/jax_plugins/oneapi/__init__.py
+++ b/jax_plugins/oneapi/__init__.py
@@ -12,12 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+import importlib
 import logging
 import os
 import pathlib
 
 from jax._src.lib import xla_client
 import jax._src.xla_bridge as xb
+
+# oneapi_plugin_extension locates inside jaxlib. `jaxlib` is for testing without
+# preinstalled jax oneapi plugin packages.
+for pkg_name in ['jax_oneapi2025_1_plugin', 'jaxlib.oneapi']:
+  try:
+    oneapi_plugin_extension = importlib.import_module(
+        f'{pkg_name}.oneapi_plugin_extension'
+    )
+  except ImportError:
+    oneapi_plugin_extension = None
+  else:
+    break
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +81,29 @@ def initialize():
     return
   options = xla_client.generate_pjrt_gpu_plugin_options()
   options["platform_name"] = "SYCL"
-  xb.register_plugin(
+  c_api = xb.register_plugin(
       'oneapi', priority=500, library_path=str(path), options=options
   )
+  if oneapi_plugin_extension:
+    xla_client.register_custom_type_handler(
+        "ONEAPI",
+        functools.partial(
+            oneapi_plugin_extension.register_custom_type, c_api
+        ),
+    )
+    xla_client.register_custom_call_handler(
+        "ONEAPI",
+        functools.partial(
+            oneapi_plugin_extension.register_custom_call_target, c_api
+        ),
+    )
+    for _name, _value in oneapi_plugin_extension.ffi_types().items():
+      xla_client.register_custom_type(
+          _name, _value, platform='ONEAPI'
+      )
+    for _name, _value in oneapi_plugin_extension.ffi_handlers().items():
+      xla_client.register_custom_call_target(
+          _name, _value, platform='ONEAPI', api_version=1
+      )
+  else:
+    logger.warning('oneapi_plugin_extension is not found.')

--- a/jax_plugins/oneapi/plugin_pyproject.toml
+++ b/jax_plugins/oneapi/plugin_pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/jax_plugins/oneapi/plugin_setup.py
+++ b/jax_plugins/oneapi/plugin_setup.py
@@ -1,0 +1,72 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Setup script for JAX OneAPI plugin package."""
+
+import importlib
+import os
+from setuptools import setup
+from setuptools.dist import Distribution
+
+__version__ = None
+oneapi_version = 0  # placeholder
+project_name = f"jax-oneapi{oneapi_version}-plugin"
+package_name = f"jax_oneapi{oneapi_version}_plugin"
+
+def load_version_module(pkg_path):
+  spec = importlib.util.spec_from_file_location(
+    'version', os.path.join(pkg_path, 'version.py'))
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+_version_module = load_version_module(package_name)
+__version__ = _version_module._get_version_for_build()
+_cmdclass = _version_module._get_cmdclass(package_name)
+
+class BinaryDistribution(Distribution):
+  """This class makes 'bdist_wheel' include an ABI tag on the wheel."""
+
+  def has_ext_modules(self):
+    return True
+
+setup(
+    name=project_name,
+    version=__version__,
+    cmdclass=_cmdclass,
+    description=f"JAX Plugin for Intel GPUs (OneAPI:{oneapi_version})",
+    long_description="",
+    long_description_content_type="text/markdown",
+    author="MiniGoel",
+    author_email="mini.goel@intel.com",
+    packages=[package_name],
+    python_requires=">=3.9",
+    install_requires=[f"jax-oneapi{oneapi_version}-pjrt=={__version__}"],
+    url="https://github.com/jax-ml/jax",
+    license="Apache-2.0",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+    ],
+    package_data={
+        package_name: [
+            "*",
+        ],
+    },
+    zip_safe=False,
+    distclass=BinaryDistribution,
+)

--- a/jaxlib/gpu/vendor.h
+++ b/jaxlib/gpu/vendor.h
@@ -857,8 +857,28 @@ namespace jax::hip {
 inline constexpr uint32_t kNumThreadsPerWarp = 64;
 }  // namespace jax::hip
 
+#elif defined(JAX_GPU_ONEAPI)
+
+// TODO(Intel-tf):
+// placeholder for OneAPI/SYCL glue code compilation.
+// Full GPU kernel support requires additional type mappings.
+
+#define JAX_GPU_NAMESPACE oneapi
+#define JAX_GPU_PREFIX "oneapi"
+#define JAX_GPU_PLUGIN_NAME "oneapi"
+
+#define JAX_GPU_HAVE_64_BIT 0
+#define JAX_GPU_HAVE_FP8 0
+#define JAX_GPU_HAVE_SOLVER_GEEV 0
+
+namespace jax::oneapi {
+// Probably the SYCL equivalent is "sub-group size".
+// Placeholder to satisfy the vendor.h interface.
+inline constexpr uint32_t kNumThreadsPerWarp = 32;
+}  // namespace jax::oneapi
+
 #else  // defined(GPU vendor)
-#error "Either JAX_GPU_CUDA or JAX_GPU_HIP must be defined"
+#error "Either JAX_GPU_CUDA, JAX_GPU_HIP, or JAX_GPU_ONEAPI must be defined"
 #endif  // defined(GPU vendor)
 
 #endif  // JAXLIB_GPU_VENDOR_H_

--- a/jaxlib/oneapi/BUILD
+++ b/jaxlib/oneapi/BUILD
@@ -1,0 +1,50 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# INTEL ONEAPI plugin extension (glue only, no GPU kernels)
+
+load(
+    "//jaxlib:jax.bzl",
+    "nanobind_extension",
+)
+
+licenses(["notice"])
+
+package(
+    default_applicable_licenses = [],
+    default_visibility = ["//:__subpackages__"],
+)
+
+cc_library(
+    name = "oneapi_vendor",
+    hdrs = [
+        "//jaxlib/gpu:vendor.h",
+    ],
+    defines = ["JAX_GPU_ONEAPI=1"],
+    deps = [
+        "@local_config_sycl//sycl:sycl_headers",
+    ],
+)
+
+nanobind_extension(
+    name = "oneapi_plugin_extension",
+    srcs = ["oneapi_plugin_extension.cc"],
+    module_name = "oneapi_plugin_extension",
+    deps = [
+        "//jaxlib:kernel_nanobind_helpers",
+        "//jaxlib/gpu:gpu_plugin_extension",
+        "@com_google_absl//absl/status",
+        "@nanobind",
+    ],
+)

--- a/jaxlib/oneapi/oneapi_plugin_extension.cc
+++ b/jaxlib/oneapi/oneapi_plugin_extension.cc
@@ -1,0 +1,49 @@
+/* Copyright 2026 The JAX Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "nanobind/nanobind.h"
+#include "jaxlib/gpu/gpu_plugin_extension.h"
+#include "jaxlib/kernel_nanobind_helpers.h"
+#include "xla/pjrt/status_casters.h"
+
+namespace nb = nanobind;
+
+namespace jax {
+namespace {
+
+nb::dict FfiTypes() { return nb::dict(); }
+nb::dict FfiHandlers() { return nb::dict(); }
+
+}  // namespace
+
+NB_MODULE(oneapi_plugin_extension, m) {
+  BuildGpuPluginExtension(m);
+  m.def("ffi_types", &FfiTypes);
+  m.def("ffi_handlers", &FfiHandlers);
+
+  m.def(
+      "get_device_ordinal",
+      [](std::intptr_t data_value) {
+        // TODO(Intel-tf): Implement using SYCL USM pointer query API to retrieve
+        // the device ordinal for the given device pointer.
+        xla::ThrowIfError(
+            absl::UnimplementedError("get_device_ordinal not yet implemented for OneAPI"));
+      },
+      nb::arg("data_value"));
+}
+}  // namespace jax

--- a/jaxlib/tools/BUILD.bazel
+++ b/jaxlib/tools/BUILD.bazel
@@ -224,6 +224,8 @@ wheel_sources(
     ]) + if_rocm([
         "//jaxlib/rocm:rocm_gpu_support",
         "//jaxlib/rocm:rocm_plugin_extension",
+    ]) + if_sycl([
+        "//jaxlib/oneapi:oneapi_plugin_extension",
     ]),
     py_srcs = [":version"] + if_cuda([
         "//jaxlib/cuda:cuda_gpu_support",
@@ -239,6 +241,9 @@ wheel_sources(
     ]) + if_rocm([
         "//jax_plugins/rocm:plugin_pyproject.toml",
         "//jax_plugins/rocm:plugin_setup.py",
+    ]) + if_sycl([
+        "//jax_plugins/oneapi:plugin_pyproject.toml",
+        "//jax_plugins/oneapi:plugin_setup.py",
     ]),
 )
 
@@ -305,6 +310,26 @@ jax_wheel(
     source_files = [":jax_plugin_sources"],
     wheel_binary = ":build_gpu_kernels_wheel_tool",
     wheel_name = "jax_rocm{}_plugin".format(ROCM_MAJOR_VERSION),
+)
+
+jax_wheel(
+    name = "jax_oneapi_plugin_wheel",
+    enable_oneapi = True,
+    no_abi = False,
+    platform_version = "2025.1",
+    source_files = [":jax_plugin_sources"],
+    wheel_binary = ":build_gpu_kernels_wheel_tool",
+    wheel_name = "jax_oneapi2025_1_plugin",
+)
+
+jax_wheel(
+    name = "jax_oneapi_plugin_wheel_editable",
+    editable = True,
+    enable_oneapi = True,
+    platform_version = "2025.1",
+    source_files = [":jax_plugin_sources"],
+    wheel_binary = ":build_gpu_kernels_wheel_tool",
+    wheel_name = "jax_oneapi2025_1_plugin",
 )
 
 # JAX PJRT wheel targets.

--- a/jaxlib/tools/build_gpu_kernels_wheel.py
+++ b/jaxlib/tools/build_gpu_kernels_wheel.py
@@ -46,12 +46,12 @@ parser.add_argument(
     "--platform_version",
     default=None,
     required=True,
-    help="Target CUDA/ROCM version. Required.",
+    help="Target CUDA/ROCM/ONEAPI version. Required.",
 )
 parser.add_argument(
     "--editable",
     action="store_true",
-    help="Create an 'editable' jax cuda/rocm plugin build instead of a wheel.",
+    help="Create an 'editable' jax cuda/rocm/oneapi plugin build instead of a wheel.",
 )
 parser.add_argument(
     "--enable-cuda",
@@ -61,6 +61,10 @@ parser.add_argument(
     "--enable-rocm",
     default=False,
     help="Should we build with ROCM enabled?")
+parser.add_argument(
+    "--enable-oneapi",
+    default=False,
+    help="Should we build with ONEAPI enabled?")
 parser.add_argument(
     "--srcs", help="source files for the wheel", action="append"
 )
@@ -202,9 +206,57 @@ def prepare_wheel_rocm(
   )
 
 
+def prepare_wheel_oneapi(
+    wheel_sources_path: pathlib.Path, *, cpu, oneapi_version, wheel_sources
+):
+  """Assembles a source tree for the oneapi plugin wheel in `wheel_sources_path`."""
+  source_file_prefix = build_utils.get_source_file_prefix(wheel_sources)
+  # Sanitize oneapi_version for package names (replace dots with underscores)
+  sanitized_version = oneapi_version.replace(".", "_")
+  wheel_sources_map = build_utils.create_wheel_sources_map(
+      wheel_sources,
+      root_packages=[
+          "jax_plugins",
+          f"jax_oneapi{sanitized_version}_plugin",
+          "jaxlib",
+      ],
+  )
+  copy_files = functools.partial(
+      build_utils.copy_file,
+      runfiles=r,
+      wheel_sources_map=wheel_sources_map,
+  )
+
+  copy_files(
+      f"{source_file_prefix}jax_plugins/oneapi/plugin_pyproject.toml",
+      dst_dir=wheel_sources_path,
+      dst_filename="pyproject.toml",
+  )
+  copy_files(
+      f"{source_file_prefix}jax_plugins/oneapi/plugin_setup.py",
+      dst_dir=wheel_sources_path,
+      dst_filename="setup.py",
+  )
+  build_utils.update_setup_with_oneapi_version(wheel_sources_path, oneapi_version)
+  write_setup_cfg(wheel_sources_path, cpu)
+
+  plugin_dir = wheel_sources_path / f"jax_oneapi{sanitized_version}_plugin"
+  plugin_dir.mkdir(parents=True, exist_ok=True)
+  (plugin_dir / "__init__.py").touch()
+  copy_files(
+      dst_dir=plugin_dir,
+      src_files=[
+          f"{source_file_prefix}jaxlib/oneapi/oneapi_plugin_extension.{pyext}",
+          f"{source_file_prefix}jaxlib/version.py",
+      ],
+  )
+
+
 # Build wheel for cuda kernels
 if args.enable_rocm:
   tmpdir = tempfile.TemporaryDirectory(prefix="jax_rocm_plugin")
+elif args.enable_oneapi:
+  tmpdir = tempfile.TemporaryDirectory(prefix="jax_oneapi_plugin")
 else:
   tmpdir = tempfile.TemporaryDirectory(prefix="jax_cuda_plugin")
 sources_path = tmpdir.name
@@ -227,6 +279,14 @@ try:
         wheel_sources=args.srcs,
     )
     package_name = f"jax rocm{args.platform_version} plugin"
+  elif args.enable_oneapi:
+    prepare_wheel_oneapi(
+        pathlib.Path(sources_path),
+        cpu=args.cpu,
+        oneapi_version=args.platform_version,
+        wheel_sources=args.srcs,
+    )
+    package_name = f"jax oneapi{args.platform_version} plugin"
   if args.editable:
     build_utils.build_editable(sources_path, args.output_path, package_name)
   else:


### PR DESCRIPTION
This PR adds the foundational infrastructure for an Intel OneAPI (SYCL) GPU plugin in JAX. No GPU kernel implementations are included — this is only the plugin skeleton and build wiring.

**Contributors**
@mini-goel
@kranipa