### PR TITLE
Added out_sharding to jax.random.t sampler

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -2196,7 +2196,9 @@ def _pareto(key, b, shape, dtype) -> Array:
 def t(key: ArrayLike,
       df: RealArray,
       shape: Shape = (),
-      dtype: DTypeLikeFloat | None = None) -> Array:
+      dtype: DTypeLikeFloat | None = None,
+      *,
+      out_sharding: NamedSharding | P | None = None) -> Array:
   r"""Sample Student's t random values with given shape and float dtype.
 
   The values are distributed according to the probability density function:
@@ -2215,6 +2217,14 @@ def t(key: ArrayLike,
       produces a result shape equal to ``df.shape``.
     dtype: optional, a float dtype for the returned values (default float64 if
       jax_enable_x64 is true, otherwise float32).
+    out_sharding: Optional. Specifies how the output array should be sharded
+      across devices in multi-device computation. Can be a
+      :class:`~jax.sharding.NamedSharding`, a :class:`~jax.sharding.PartitionSpec`
+      (``P``), or ``None`` (default). When specified, the output will be sharded
+      according to the given sharding specification. Primarily used in explicit
+      sharding mode.
+      See the `explicit sharding tutorial <https://docs.jax.dev/en/latest/parallel.html>`_
+      for more details.
 
   Returns:
     A random array with the specified dtype and with shape given by ``shape`` if
@@ -2227,7 +2237,9 @@ def t(key: ArrayLike,
     raise ValueError(f"dtype argument to `t` must be a float "
                      f"dtype, got {dtype}")
   shape = core.canonicalize_shape(shape)
-  return _t(key, df, shape, dtype)
+  out_sharding = canonicalize_sharding_for_samplers(out_sharding, "t", shape)
+  return maybe_auto_axes(_t, out_sharding,
+                         shape=shape, dtype=dtype)(key, df)
 
 @jit(static_argnums=(2, 3))
 def _t(key, df, shape, dtype) -> Array:

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -227,6 +227,7 @@ _OUT_SHARDING_CASES = [
     ('poisson', lambda key, n, s: random.poisson(key, lam=3.0, shape=(n,), out_sharding=s)),
     ('randint', lambda key, n, s: random.randint(key, shape=(n,), minval=0, maxval=10, out_sharding=s)),
     ('rayleigh', lambda key, n, s: random.rayleigh(key, shape=(n,), scale=0.5, out_sharding=s)),
+    ('t', lambda key, n, s: random.t(key, df=10.0, shape=(n,), out_sharding=s)),
     ('truncated_normal', lambda key, n, s: random.truncated_normal(key, lower=-2., upper=2., shape=(n,), out_sharding=s)),
     ('uniform', lambda key, n, s: random.uniform(key, shape=(n,), out_sharding=s)),
 ]


### PR DESCRIPTION
Description:
- Added out_sharding to jax.random.t sampler
- Added test

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->