### PR TITLE
prevent static numpy array indices from being converted to tracers

### DIFF
--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -3445,9 +3445,14 @@ def _dynamic_slice_indices(
         result.append(i)
       continue
     if allow_negative_index:
-      d_arr = lax.convert_element_type(d, _dtype(i))
-      # pyrefly: ignore[unsupported-operation]
-      result.append(lax.select(i < 0, i + d_arr, i))
+      # Prefer a numpy wrap when possible: staging lax.select promotes the
+      # index to a tracer, breaking later numpy ops on it under transforms.
+      if isinstance(i, np.ndarray) and core.is_constant_dim(d):
+        result.append(np.where(i < 0, i + d, i).astype(_dtype(i)))
+      else:
+        d_arr = lax.convert_element_type(d, _dtype(i))
+        # pyrefly: ignore[unsupported-operation]
+        result.append(lax.select(i < 0, i + d_arr, i))
     else:
       result.append(i)
   return result

--- a/jax/_src/numpy/indexing.py
+++ b/jax/_src/numpy/indexing.py
@@ -343,6 +343,12 @@ class NDIndexer:
         axis, = idx.consumed_axes
         if dtypes.issubdtype(idx.index.dtype, np.unsignedinteger):
           normed_index = idx.index
+        # Prefer a numpy wrap when possible: staging lax.select promotes the
+        # index to a tracer, breaking later numpy ops on it under transforms.
+        elif isinstance(idx.index, np.ndarray) and core.is_constant_dim(self.shape[axis]):
+          size = self.shape[axis]
+          normed_index = np.where(idx.index < 0,
+                                  idx.index + size, idx.index).astype(idx.index.dtype)
         else:
           size = self.shape[axis]
           if core.is_constant_dim(size):
@@ -751,8 +757,9 @@ def _normalize_index(index, axis_size):
                                              dtypes.dtype(index))
   if isinstance(index, (int, np.integer)):
     return lax.add(index, axis_size_val) if index < 0 else index
-  else:
-    return lax.select(index < 0, lax.add(index, axis_size_val), index)
+  if isinstance(index, np.ndarray) and core.is_constant_dim(axis_size):
+    return np.where(index < 0, index + axis_size, index).astype(index.dtype)
+  return lax.select(index < 0, lax.add(index, axis_size_val), index)
 
 
 @export

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -1108,6 +1108,32 @@ class IndexingTest(jtu.JaxTestCase):
     self.assertLen(jaxpr.jaxpr.eqns, 1)
     self.assertEqual(jaxpr.jaxpr.eqns[0].primitive, lax.rev_p)
 
+  def testStaticNumpyIndicesNotStaged(self):
+    # Negative-index wrapping for static numpy indices should fold in numpy
+    # rather than staging lax.add/lax.select into the jaxpr (which would
+    # promote the index to a tracer and break later numpy ops on it).
+
+    # Wrapped indices remain numpy arrays under tracing, so a numpy op on the
+    # wrapped result does not raise TracerArrayConversionError.
+    from jax._src.numpy.indexing import _normalize_index
+    @jax.jit
+    def f(x):
+      wrapped = _normalize_index(np.array([-1, 0, 1]), 5)
+      np.asarray(wrapped)  # would raise if `wrapped` were a tracer
+      return x[wrapped]
+    self.assertArraysEqual(f(jnp.arange(5.)), jnp.array([4., 0., 1.]))
+
+    # And no spurious add/select_n in the lowered jaxpr.
+    jaxpr = jax.make_jaxpr(lambda x: x[np.array([-1, 0, 1])])(jnp.arange(5.))
+    eqns_str = str(jaxpr)
+    self.assertNotIn('add', eqns_str)
+    self.assertNotIn('select_n', eqns_str)
+
+    jaxpr = jax.make_jaxpr(
+        lambda x: lax.dynamic_slice(x, [np.array(-1)], [1]))(jnp.arange(5.))
+    self.assertLen(jaxpr.jaxpr.eqns, 1)
+    self.assertEqual(jaxpr.jaxpr.eqns[0].primitive, lax.dynamic_slice_p)
+
   def testOOBEmptySlice(self):
     x = jnp.arange(4, dtype='float32')
     self.assertArraysEqual(x[1:0], jnp.empty(0, dtype='float32'))


### PR DESCRIPTION
I've been working on some function transformations to explore sparsity-leveraging accelerations in Jacobian computation and I've found without `EAGER_CONSTANT_FOLDING=1` static **numpy** array indices are being converted to tracers unnecessarily which prevents compile time inspection of sparsity (especially duplication). The conversion happens when indices are "normalised", e.g. their negative indices receive a positive shift equal to the length of array. Implementing this in pure numpy is trivial.

Let me know if I've missed any edge cases, but I think this should be a net win!