### PR TITLE
splash_attention: add JIT-compatible NumpyMask pathway with SMEM check and int8 mask storage

### DIFF
--- a/benchmarks/tracing_benchmark.py
+++ b/benchmarks/tracing_benchmark.py
@@ -58,6 +58,74 @@ def make_mqa_splash_attention_fn_and_args():
       )
   ), (q, k, v)
 
+def make_jitted_mask_splash_attention_fn_and_args():
+  seed = 0
+  key = random.key(seed)
+  k1, k2, k3 = random.split(key, 3)
+
+  q_seq_len = 1024
+  kv_seq_len = 1024
+  num_q_heads = 2
+  head_dim_qk = 128
+  head_dim_v = 128
+  dtype = np.dtype("float32")
+
+  q = random.uniform(k1, (num_q_heads, q_seq_len, head_dim_qk), dtype=dtype)
+  k = random.uniform(k2, (kv_seq_len, head_dim_qk), dtype=dtype)
+  v = random.uniform(k3, (kv_seq_len, head_dim_v), dtype=dtype)
+
+  block_sizes = splash.BlockSizes.get_default()
+
+  @jax.jit
+  def fn(q, k, v):
+    mask = mask_lib.NumpyMask(
+        mask_lib.make_random_mask((q_seq_len, kv_seq_len), sparsity=0.5, seed=0)
+    )
+    mask = mask_lib.MultiHeadMask(tuple(mask for _ in range(num_q_heads)))
+    attn_fn = splash.make_splash_mqa_single_device(mask, block_sizes=block_sizes)
+    return attn_fn(q, k, v)
+
+  return fn, (q, k, v)
+
+@google_benchmark.register
+@google_benchmark.option.unit(google_benchmark.kMillisecond)
+def test_pallas_mask_mqa_splash_attention_trace(state):
+  attn, (q, k, v) = make_jitted_mask_splash_attention_fn_and_args()
+
+  while state:
+    _ = attn.trace(q, k, v)
+    clear_caches(state)
+
+
+@google_benchmark.register
+@google_benchmark.option.unit(google_benchmark.kMillisecond)
+def test_pallas_mask_mqa_splash_attention_trace_no_cache_clear(state):
+  attn, (q, k, v) = make_jitted_mask_splash_attention_fn_and_args()
+
+  while state:
+    _ = attn.trace(q, k, v)
+
+
+@google_benchmark.register
+@google_benchmark.option.unit(google_benchmark.kMillisecond)
+def test_pallas_mask_mqa_splash_attention_lower(state):
+  attn, (q, k, v) = make_jitted_mask_splash_attention_fn_and_args()
+  traced = attn.trace(q, k, v)
+
+  while state:
+    _ = traced.lower(lowering_platforms=("tpu",))
+    clear_caches(state)
+
+
+@google_benchmark.register
+@google_benchmark.option.unit(google_benchmark.kMillisecond)
+def test_pallas_mask_mqa_splash_attention_lower_no_cache_clear(state):
+  attn, (q, k, v) = make_jitted_mask_splash_attention_fn_and_args()
+  traced = attn.trace(q, k, v)
+
+  while state:
+    _ = traced.lower(lowering_platforms=("tpu",))
+
 
 @google_benchmark.register
 @google_benchmark.option.unit(google_benchmark.kMillisecond)

--- a/benchmarks/tracing_benchmark.py
+++ b/benchmarks/tracing_benchmark.py
@@ -77,40 +77,42 @@ def make_jitted_mask_splash_attention_fn_and_args():
   block_sizes = splash.BlockSizes.get_default()
 
   @jax.jit
-  def fn(q, k, v):
+  def fn(q, k, v,mask_array):
     mask = mask_lib.NumpyMask(
-        mask_lib.make_random_mask((q_seq_len, kv_seq_len), sparsity=0.5, seed=0)
+        mask_array
     )
     mask = mask_lib.MultiHeadMask(tuple(mask for _ in range(num_q_heads)))
     attn_fn = splash.make_splash_mqa_single_device(mask, block_sizes=block_sizes)
     return attn_fn(q, k, v)
 
-  return fn, (q, k, v)
+  mask_array = mask_lib.make_random_mask((q_seq_len, kv_seq_len), sparsity=0.5, seed=0)
+
+  return fn, (q, k, v, mask_array)
 
 @google_benchmark.register
 @google_benchmark.option.unit(google_benchmark.kMillisecond)
 def test_pallas_mask_mqa_splash_attention_trace(state):
-  attn, (q, k, v) = make_jitted_mask_splash_attention_fn_and_args()
+  attn, (q, k, v, mask_array) = make_jitted_mask_splash_attention_fn_and_args()
 
   while state:
-    _ = attn.trace(q, k, v)
+    _ = attn.trace(q, k, v, mask_array)
     clear_caches(state)
 
 
 @google_benchmark.register
 @google_benchmark.option.unit(google_benchmark.kMillisecond)
 def test_pallas_mask_mqa_splash_attention_trace_no_cache_clear(state):
-  attn, (q, k, v) = make_jitted_mask_splash_attention_fn_and_args()
+  attn, (q, k, v, mask_array) = make_jitted_mask_splash_attention_fn_and_args()
 
   while state:
-    _ = attn.trace(q, k, v)
+    _ = attn.trace(q, k, v, mask_array)
 
 
 @google_benchmark.register
 @google_benchmark.option.unit(google_benchmark.kMillisecond)
 def test_pallas_mask_mqa_splash_attention_lower(state):
-  attn, (q, k, v) = make_jitted_mask_splash_attention_fn_and_args()
-  traced = attn.trace(q, k, v)
+  attn, (q, k, v, mask_array) = make_jitted_mask_splash_attention_fn_and_args()
+  traced = attn.trace(q, k, v, mask_array)
 
   while state:
     _ = traced.lower(lowering_platforms=("tpu",))
@@ -120,8 +122,8 @@ def test_pallas_mask_mqa_splash_attention_lower(state):
 @google_benchmark.register
 @google_benchmark.option.unit(google_benchmark.kMillisecond)
 def test_pallas_mask_mqa_splash_attention_lower_no_cache_clear(state):
-  attn, (q, k, v) = make_jitted_mask_splash_attention_fn_and_args()
-  traced = attn.trace(q, k, v)
+  attn, (q, k, v, mask_array) = make_jitted_mask_splash_attention_fn_and_args()
+  traced = attn.trace(q, k, v, mask_array)
 
   while state:
     _ = traced.lower(lowering_platforms=("tpu",))

--- a/benchmarks/tracing_benchmark.py
+++ b/benchmarks/tracing_benchmark.py
@@ -85,7 +85,7 @@ def make_jitted_mask_splash_attention_fn_and_args():
     attn_fn = splash.make_splash_mqa_single_device(mask, block_sizes=block_sizes)
     return attn_fn(q, k, v)
 
-  mask_array = mask_lib.make_random_mask((q_seq_len, kv_seq_len), sparsity=0.5, seed=0)
+  mask_array = jax.random.bernoulli(key, p=0.5, shape=(q_seq_len, kv_seq_len))
 
   return fn, (q, k, v, mask_array)
 

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py
@@ -615,9 +615,9 @@ def _apply_mask_and_soft_cap(
   masks = []
   if mask_ref is not None:
     if k_in_lanes:
-      mask = mask_ref[:, k_slice]
+      mask = mask_ref[:, k_slice].astype(jnp.bool_)
     else:
-      mask = mask_ref[k_slice, :]
+      mask = mask_ref[k_slice, :].astype(jnp.bool_)
 
     masks.append(
         jnp.bitwise_or(mask, jnp.broadcast_to(should_not_mask, mask.shape))
@@ -932,10 +932,12 @@ def _splash_attention_forward(
   partial_mask_blocks = fwd_mask_info.partial_mask_blocks
   if (
       partial_mask_blocks is not None
-      and jnp.dtype(partial_mask_blocks.dtype) != np.bool_
+      and
+      (jnp.dtype(partial_mask_blocks.dtype) != np.bool_
+      and jnp.dtype(partial_mask_blocks.dtype) != jnp.int8)
   ):
     raise ValueError(
-        "partial_mask_blocks must be of type np.bool_ but got"
+        "partial_mask_blocks must be of type np.bool_ or np.int8 but got"
         f" {partial_mask_blocks.dtype}"
     )
 

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask.py
@@ -20,7 +20,7 @@ from collections.abc import Callable, Sequence
 import dataclasses
 from typing import Any
 import numpy as np
-
+from jax.core import Tracer
 
 class Mask:
   """A base class for splash attention masks."""
@@ -512,6 +512,10 @@ class NumpyMask(Mask):
     return np.array_equal(self.array, other.array, equal_nan=True)
 
   def __hash__(self):
+    if isinstance(self.array, Tracer):
+      # Content hashing on tracers leads to materialization errors
+      # Fall back to identity hashing.
+      return hash(id(self.array))
     return hash((type(self), self.array.tobytes()))
 
 

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
@@ -23,6 +23,7 @@ from typing import NamedTuple
 
 import jax
 from jax._src import util as jax_util
+from jax.core import Tracer
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask as mask_lib
 import jax.numpy as jnp
 import numpy as np
@@ -161,6 +162,10 @@ class _HashableNDArray:
     self.array = array
 
   def __hash__(self):
+    if isinstance(self.array, Tracer):
+      # Content hashing on tracers leads to materialization errors
+      # Fall back to identity hashing.
+      return hash(id(self.array))
     return hash(self.array.tobytes())
 
   def __eq__(self, other: object) -> bool:
@@ -582,7 +587,25 @@ def _process_mask(
   if mod != 0:
     raise ValueError(f'{head_shards=} should divide {head_count=}.')
 
+  def _is_numpy_mask_with_traced_arrays(mask):
+    """Check if mask is a MultiHeadMask of NumpyMasks with traced arrays."""
+    if not isinstance(mask, mask_lib.MultiHeadMask):
+      return False
+    return any(isinstance(m, mask_lib.NumpyMask)
+           and isinstance(m.array, Tracer)
+            for m in mask.masks)
 
+  if _is_numpy_mask_with_traced_arrays(mask):
+    jax_mask = jnp.stack([m.array for m in mask.masks if isinstance(m, mask_lib.NumpyMask)])
+    return _process_dynamic_mask(
+          jax_mask,
+          block_shape,
+          is_dkv,
+          downcast_smem_data=downcast_smem_data,
+          head_shards=head_shards,
+          q_seq_shards=q_seq_shards,
+          shrink_grid=shrink_grid,
+      )
   # Uniquify the masks.
   # Create a collection of the unique head masks in the input multi-head mask.
   # This avoids processing the same mask multiple times and it enables

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
@@ -591,7 +591,7 @@ def _process_mask(
     """Check if mask is a MultiHeadMask of NumpyMasks with traced arrays."""
     if not isinstance(mask, mask_lib.MultiHeadMask):
       return False
-    return any(isinstance(m, mask_lib.NumpyMask)
+    return all(isinstance(m, mask_lib.NumpyMask)
            and isinstance(m.array, Tracer)
             for m in mask.masks)
 

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
@@ -343,11 +343,12 @@ def _check_smem_limit(
 
     In both cases, smaller block sizes produce more blocks, increasing
     metadata quadratically. If the metadata exceeds SMEM capacity, a
-    ValueError is raised with a suggested minimum block size (rounded to
-    an even multiple of the default block size to ensure clean divisibility
-    with power-of-2 sequence lengths). The suggestion is conservative:
-    increasing block size reduces block counts, which both shrinks the
-    metadata and may enable more aggressive downcasting of index values.
+    ValueError is raised with a suggested minimum block size (The suggestion 
+    uses geometric scaling (powers of 2) relative to the default block 
+    size to ensure clean divisibility with powers of 2 sequence lengths). 
+    The suggestion is conservative: increasing block size reduces block counts, 
+    which both shrinks the metadata and may enable more aggressive downcasting 
+    of index values.
 
     Args:
         heads_per_shard: Number of attention heads on this shard.
@@ -365,10 +366,10 @@ def _check_smem_limit(
             iterates over KV blocks).
 
     Raises:
-        ValueError: If the estimated SMEM usage exceeds TPU capacity,
-            with a suggested minimum block size (rounded to an even
-            multiple of the default block size to ensure clean divisibility
-            with power-of-2 sequence lengths) that would fit.
+        ValueError: If the estimated SMEM usage exceeds TPU capacity, 
+        provide a suggested minimum block size that would fit. The suggestion 
+        uses geometric scaling (powers of 2) relative to the default block 
+        size to ensure clean divisibility with powers of 2 sequence lengths.
   """
 
   tpu_info = get_tpu_info()
@@ -405,9 +406,8 @@ def _check_smem_limit(
     block_size = math.sqrt(
             (required_smem_bytes * q_block_size * kv_block_size) / smem_limit
         )
-    scaling_factor = math.ceil(block_size / default_block_size)
-    scaling_factor = scaling_factor if scaling_factor % 2 == 0 else scaling_factor + 1
-    min_block_size = scaling_factor * default_block_size
+    scaling_factor = math.ceil(math.log2(block_size / default_block_size))
+    min_block_size = default_block_size * (2 ** scaling_factor)
     raise ValueError(
             f"Splash attention mask metadata requires {required_smem_bytes / (1024*1024):.2f} MiB "
             f"but SMEM limit is {smem_limit / (1024*1024):.2f} MiB. "

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
@@ -343,11 +343,11 @@ def _check_smem_limit(
 
     In both cases, smaller block sizes produce more blocks, increasing
     metadata quadratically. If the metadata exceeds SMEM capacity, a
-    ValueError is raised with a suggested minimum block size (The suggestion 
-    uses geometric scaling (powers of 2) relative to the default block 
-    size to ensure clean divisibility with powers of 2 sequence lengths). 
-    The suggestion is conservative: increasing block size reduces block counts, 
-    which both shrinks the metadata and may enable more aggressive downcasting 
+    ValueError is raised with a suggested minimum block size (The suggestion
+    uses geometric scaling (powers of 2) relative to the default block
+    size to ensure clean divisibility with powers of 2 sequence lengths).
+    The suggestion is conservative: increasing block size reduces block counts,
+    which both shrinks the metadata and may enable more aggressive downcasting
     of index values.
 
     Args:
@@ -366,9 +366,9 @@ def _check_smem_limit(
             iterates over KV blocks).
 
     Raises:
-        ValueError: If the estimated SMEM usage exceeds TPU capacity, 
-        provide a suggested minimum block size that would fit. The suggestion 
-        uses geometric scaling (powers of 2) relative to the default block 
+        ValueError: If the estimated SMEM usage exceeds TPU capacity,
+        provide a suggested minimum block size that would fit. The suggestion
+        uses geometric scaling (powers of 2) relative to the default block
         size to ensure clean divisibility with powers of 2 sequence lengths.
   """
 

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
@@ -500,7 +500,7 @@ def _process_dynamic_mask(
           kv_block_size,
       )
       .swapaxes(-2, -3)
-      .astype(np.bool_)
+      .astype(jnp.int8)
   )
 
   # The block mask is 2 for all blocks with all entries set to True and 1 for

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
@@ -27,7 +27,7 @@ from jax.core import Tracer
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask as mask_lib
 import jax.numpy as jnp
 import numpy as np
-
+from jax._src.pallas.mosaic.tpu_info import get_tpu_info
 
 # Logic for processing NumPy masks for kernels
 class MaskInfo(NamedTuple):
@@ -595,8 +595,47 @@ def _process_mask(
            and isinstance(m.array, Tracer)
             for m in mask.masks)
 
+  def _check_smem_limit(heads_per_shard, q_blocks_per_shard, kv_blocks_count,
+                          q_block_size, kv_block_size, is_dkv):
+    """Check that the size of the mask metadata fits in SMEM."""
+
+    tpu_info = get_tpu_info()
+    smem_limit = tpu_info.smem_capacity_bytes
+
+    def _downcast_dtype_size(max_val):
+      if max_val <= np.iinfo(np.int8).max:
+        return np.dtype(np.int8).itemsize
+      elif max_val <= np.iinfo(np.int16).max:
+        return np.dtype(np.int16).itemsize
+      return np.dtype(np.int32).itemsize
+
+    elements = heads_per_shard * q_blocks_per_shard * kv_blocks_count
+    data_next_max = q_blocks_per_shard if is_dkv else kv_blocks_count
+    required_smem_bytes = (
+        elements * 1                                       # block_mask: always int8
+        + elements * _downcast_dtype_size(data_next_max)   # data_next
+        + elements * _downcast_dtype_size(elements)        # mask_next
+    )
+
+    if required_smem_bytes > smem_limit:
+      # When block size increases, element counts drop. It also enables aggressive
+      # downcasting (smaller dtypes), so actual SMEM usage drops faster than the linear estimate.
+      # Future work may explore rectangular block sizes as current symmetric block
+      # size will always be safe, just potentially larger than strictly necessary.
+      default_block_size = 128
+      block_size = math.sqrt(
+            (required_smem_bytes * q_block_size * kv_block_size) / smem_limit
+        )
+      min_block_size = math.ceil(block_size / default_block_size) * default_block_size
+      raise ValueError(
+            f"Splash attention mask metadata requires {required_smem_bytes / (1024*1024):.2f} MiB "
+            f"but SMEM limit is {smem_limit / (1024*1024):.2f} MiB. "
+            f"Rebuild mask and attention with block_sizes=({min_block_size}, {min_block_size})."
+        )
+
   if _is_numpy_mask_with_traced_arrays(mask):
     jax_mask = jnp.stack([m.array for m in mask.masks if isinstance(m, mask_lib.NumpyMask)])
+    _check_smem_limit(heads_per_shard, q_blocks_per_shard, kv_blocks_count, q_block_size, kv_block_size, is_dkv)
     return _process_dynamic_mask(
           jax_mask,
           block_shape,

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
@@ -317,6 +317,102 @@ def _get_mask_info_for_shard(
 
   return data_next, mask_next
 
+def _check_smem_limit(
+    heads_per_shard: int,
+    q_blocks_per_shard: int,
+    kv_blocks_count: int,
+    q_block_size: int,
+    kv_block_size: int,
+    has_mask_function: bool,
+    is_dkv: bool,
+  ):
+  """Check that mask scheduling metadata fits in SMEM.
+
+    The Splash Attention kernel prefetches scheduling metadata into SMEM
+    before execution. The metadata layout depends on the mask type:
+
+    For NumpyMask, three arrays are stored: block_mask (int8, marks each
+    block pair as skip/full/partial), data_next (index to the next data
+    block), and mask_next (index to the next mask block). These have shape
+    [heads, q_blocks, kv_blocks], so their combined size scales as
+    heads * blocks² * dtype_size.
+
+    For CausalMask, only data_next is needed, with shape
+    [1, q_blocks, kv_blocks]. The SMEM usage scales as blocks² * dtype_size(data_next),
+    independent of head count.
+
+    In both cases, smaller block sizes produce more blocks, increasing
+    metadata quadratically. If the metadata exceeds SMEM capacity, a
+    ValueError is raised with a suggested minimum block size (rounded to
+    an even multiple of the default block size to ensure clean divisibility
+    with power-of-2 sequence lengths). The suggestion is conservative:
+    increasing block size reduces block counts, which both shrinks the
+    metadata and may enable more aggressive downcasting of index values.
+
+    Args:
+        heads_per_shard: Number of attention heads on this shard.
+        q_blocks_per_shard: Number of query blocks on this shard.
+        kv_blocks_count: Total number of key-value blocks.
+        q_block_size: Number of tokens per query block.
+        kv_block_size: Number of tokens per key-value block.
+        has_mask_function: If True, the mask is computed inside the kernel
+            via a mask_function (e.g. CausalMask), so only data_next is
+            stored in SMEM. If False, assumes NumpyMask with all three
+            metadata arrays scaled by heads_per_shard.
+        is_dkv: If True, uses q_blocks_per_shard as the max value for
+            data_next downcasting (dKV backward pass iterates over Q
+            blocks), otherwise uses kv_blocks_count (forward pass
+            iterates over KV blocks).
+
+    Raises:
+        ValueError: If the estimated SMEM usage exceeds TPU capacity,
+            with a suggested minimum block size (rounded to an even
+            multiple of the default block size to ensure clean divisibility
+            with power-of-2 sequence lengths) that would fit.
+  """
+
+  tpu_info = get_tpu_info()
+  smem_limit = tpu_info.smem_capacity_bytes
+
+  def _downcast_dtype_size(max_val):
+    if max_val <= np.iinfo(np.int8).max:
+      return np.dtype(np.int8).itemsize
+    elif max_val <= np.iinfo(np.int16).max:
+      return np.dtype(np.int16).itemsize
+    return np.dtype(np.int32).itemsize
+
+  data_next_max = q_blocks_per_shard if is_dkv else kv_blocks_count
+
+  if has_mask_function:
+    elements = q_blocks_per_shard * kv_blocks_count
+    required_smem_bytes = (
+        elements * _downcast_dtype_size(data_next_max)   # data_next
+      )
+  else:
+    elements = heads_per_shard * q_blocks_per_shard * kv_blocks_count
+    required_smem_bytes = (
+          elements * 1                                       # block_mask: always int8
+          + elements * _downcast_dtype_size(data_next_max)   # data_next
+          + elements * _downcast_dtype_size(elements)        # mask_next
+      )
+
+  if required_smem_bytes > smem_limit:
+    # When block size increases, element counts drop. It also enables aggressive
+    # downcasting (smaller dtypes), so actual SMEM usage drops faster than the linear estimate.
+    # Future work may explore rectangular block sizes as current symmetric block
+    # size will always be safe, just potentially larger than strictly necessary.
+    default_block_size = 128
+    block_size = math.sqrt(
+            (required_smem_bytes * q_block_size * kv_block_size) / smem_limit
+        )
+    scaling_factor = math.ceil(block_size / default_block_size)
+    scaling_factor = scaling_factor if scaling_factor % 2 == 0 else scaling_factor + 1
+    min_block_size = scaling_factor * default_block_size
+    raise ValueError(
+            f"Splash attention mask metadata requires {required_smem_bytes / (1024*1024):.2f} MiB "
+            f"but SMEM limit is {smem_limit / (1024*1024):.2f} MiB. "
+            f"Rebuild mask and attention with block_sizes={min_block_size}."
+        )
 
 def _process_dynamic_mask(
     mask: jax.Array,
@@ -595,47 +691,10 @@ def _process_mask(
            and isinstance(m.array, Tracer)
             for m in mask.masks)
 
-  def _check_smem_limit(heads_per_shard, q_blocks_per_shard, kv_blocks_count,
-                          q_block_size, kv_block_size, is_dkv):
-    """Check that the size of the mask metadata fits in SMEM."""
-
-    tpu_info = get_tpu_info()
-    smem_limit = tpu_info.smem_capacity_bytes
-
-    def _downcast_dtype_size(max_val):
-      if max_val <= np.iinfo(np.int8).max:
-        return np.dtype(np.int8).itemsize
-      elif max_val <= np.iinfo(np.int16).max:
-        return np.dtype(np.int16).itemsize
-      return np.dtype(np.int32).itemsize
-
-    elements = heads_per_shard * q_blocks_per_shard * kv_blocks_count
-    data_next_max = q_blocks_per_shard if is_dkv else kv_blocks_count
-    required_smem_bytes = (
-        elements * 1                                       # block_mask: always int8
-        + elements * _downcast_dtype_size(data_next_max)   # data_next
-        + elements * _downcast_dtype_size(elements)        # mask_next
-    )
-
-    if required_smem_bytes > smem_limit:
-      # When block size increases, element counts drop. It also enables aggressive
-      # downcasting (smaller dtypes), so actual SMEM usage drops faster than the linear estimate.
-      # Future work may explore rectangular block sizes as current symmetric block
-      # size will always be safe, just potentially larger than strictly necessary.
-      default_block_size = 128
-      block_size = math.sqrt(
-            (required_smem_bytes * q_block_size * kv_block_size) / smem_limit
-        )
-      min_block_size = math.ceil(block_size / default_block_size) * default_block_size
-      raise ValueError(
-            f"Splash attention mask metadata requires {required_smem_bytes / (1024*1024):.2f} MiB "
-            f"but SMEM limit is {smem_limit / (1024*1024):.2f} MiB. "
-            f"Rebuild mask and attention with block_sizes=({min_block_size}, {min_block_size})."
-        )
-
   if _is_numpy_mask_with_traced_arrays(mask):
+    _check_smem_limit(heads_per_shard, q_blocks_per_shard, kv_blocks_count,
+                    q_block_size, kv_block_size, has_mask_function=False,is_dkv=is_dkv)
     jax_mask = jnp.stack([m.array for m in mask.masks if isinstance(m, mask_lib.NumpyMask)])
-    _check_smem_limit(heads_per_shard, q_blocks_per_shard, kv_blocks_count, q_block_size, kv_block_size, is_dkv)
     return _process_dynamic_mask(
           jax_mask,
           block_shape,
@@ -740,6 +799,8 @@ def _process_mask(
     ):
       q_sequence = unique_mask.q_sequence
       mask_function = unique_mask.mask_function
+      _check_smem_limit(heads_per_shard, q_blocks_per_shard, kv_blocks_count,
+                      q_block_size, kv_block_size, has_mask_function=True,is_dkv=is_dkv)
 
   # Identify the partial mask blocks and the value of the block mask for each
   # block.

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
@@ -318,58 +318,54 @@ def _get_mask_info_for_shard(
   return data_next, mask_next
 
 def _check_smem_limit(
-    heads_per_shard: int,
-    q_blocks_per_shard: int,
+    leading_dim: int,
+    q_blocks_count: int,
     kv_blocks_count: int,
     q_block_size: int,
     kv_block_size: int,
-    has_mask_function: bool,
+    has_mask_next: bool,
     is_dkv: bool,
+    max_mask_next: int | None = None,
+    max_data_next: int | None = None,
   ):
   """Check that mask scheduling metadata fits in SMEM.
 
     The Splash Attention kernel prefetches scheduling metadata into SMEM
-    before execution. The metadata layout depends on the mask type:
+    before execution. The metadata layout depends on the mask type.
 
-    For NumpyMask, three arrays are stored: block_mask (int8, marks each
-    block pair as skip/full/partial), data_next (index to the next data
-    block), and mask_next (index to the next mask block). These have shape
-    [heads, q_blocks, kv_blocks], so their combined size scales as
-    heads * blocks² * dtype_size.
-
-    For CausalMask, only data_next is needed, with shape
-    [1, q_blocks, kv_blocks]. The SMEM usage scales as blocks² * dtype_size(data_next),
-    independent of head count.
-
-    In both cases, smaller block sizes produce more blocks, increasing
-    metadata quadratically. If the metadata exceeds SMEM capacity, a
-    ValueError is raised with a suggested minimum block size (The suggestion
-    uses geometric scaling (powers of 2) relative to the default block
-    size to ensure clean divisibility with powers of 2 sequence lengths).
-    The suggestion is conservative: increasing block size reduces block counts,
-    which both shrinks the metadata and may enable more aggressive downcasting
-    of index values.
+    Smaller block sizes produce more blocks, increasing metadata
+    quadratically. If the metadata exceeds SMEM capacity, a ValueError is
+    raised with a suggested minimum block size. The suggestion uses
+    geometric scaling (powers of 2) relative to the default block size to
+    ensure clean divisibility with powers-of-2 sequence lengths, and is
+    conservative: increasing block size reduces block counts, which both
+    shrinks the metadata and may enable more aggressive downcasting of
+    index values.
 
     Args:
-        heads_per_shard: Number of attention heads on this shard.
-        q_blocks_per_shard: Number of query blocks on this shard.
-        kv_blocks_count: Total number of key-value blocks.
+        leading_dim: Leading dimension of the metadata arrays (per-shard
+            where applicable).
+        q_blocks_count: Number of query blocks in the metadata (per-shard
+            where applicable).
+        kv_blocks_count: Number of key-value blocks in the metadata.
         q_block_size: Number of tokens per query block.
         kv_block_size: Number of tokens per key-value block.
-        has_mask_function: If True, the mask is computed inside the kernel
-            via a mask_function (e.g. CausalMask), so only data_next is
-            stored in SMEM. If False, assumes NumpyMask with all three
-            metadata arrays scaled by heads_per_shard.
-        is_dkv: If True, uses q_blocks_per_shard as the max value for
-            data_next downcasting (dKV backward pass iterates over Q
-            blocks), otherwise uses kv_blocks_count (forward pass
-            iterates over KV blocks).
+        has_mask_next: If True, a mask_next array is materialized in SMEM
+            (NumpyMask / dynamic mask case; all three metadata arrays are
+            present and scaled by leading_dim). If False, the mask is
+            computed in-kernel via a mask_function (e.g. CausalMask), so
+            mask_next is omitted from the estimate.
+        is_dkv: If True, uses q_blocks_count as the max value for data_next
+            downcasting (dKV backward pass iterates over Q blocks);
+            otherwise uses kv_blocks_count (forward pass iterates over KV
+            blocks).
+        max_mask_next: Optional Maximum value for mask_next. Used to
+            compute a tighter mask_next estimate when has_mask_next is True.
+        max_data_next: Optional Maximum value for data_next.
 
     Raises:
-        ValueError: If the estimated SMEM usage exceeds TPU capacity,
-        provide a suggested minimum block size that would fit. The suggestion
-        uses geometric scaling (powers of 2) relative to the default block
-        size to ensure clean divisibility with powers of 2 sequence lengths.
+        ValueError: If the estimated SMEM usage exceeds TPU capacity. The
+            message includes a suggested minimum block size that would fit.
   """
 
   tpu_info = get_tpu_info()
@@ -382,20 +378,17 @@ def _check_smem_limit(
       return np.dtype(np.int16).itemsize
     return np.dtype(np.int32).itemsize
 
-  data_next_max = q_blocks_per_shard if is_dkv else kv_blocks_count
+  data_next_max = max_data_next
+  if data_next_max is None:
+    data_next_max = q_blocks_count if is_dkv else kv_blocks_count
+  elements = leading_dim * q_blocks_count * kv_blocks_count
+  required_smem_bytes = (
+          elements * _downcast_dtype_size(data_next_max) # data_next
+        + elements * 1                                   # block_mask: always int8
+  )
 
-  if has_mask_function:
-    elements = q_blocks_per_shard * kv_blocks_count
-    required_smem_bytes = (
-        elements * _downcast_dtype_size(data_next_max)   # data_next
-      )
-  else:
-    elements = heads_per_shard * q_blocks_per_shard * kv_blocks_count
-    required_smem_bytes = (
-          elements * 1                                       # block_mask: always int8
-          + elements * _downcast_dtype_size(data_next_max)   # data_next
-          + elements * _downcast_dtype_size(elements)        # mask_next
-      )
+  if has_mask_next and max_mask_next is not None:
+    required_smem_bytes += elements * _downcast_dtype_size(max_mask_next) # mask_next
 
   if required_smem_bytes > smem_limit:
     # When block size increases, element counts drop. It also enables aggressive
@@ -692,8 +685,15 @@ def _process_mask(
             for m in mask.masks)
 
   if _is_numpy_mask_with_traced_arrays(mask):
-    _check_smem_limit(heads_per_shard, q_blocks_per_shard, kv_blocks_count,
-                    q_block_size, kv_block_size, has_mask_function=False,is_dkv=is_dkv)
+    _check_smem_limit(leading_dim=head_count,
+                      q_blocks_count=q_blocks_per_shard,
+                      kv_blocks_count=kv_blocks_count,
+                      q_block_size=q_block_size,
+                      kv_block_size=kv_block_size,
+                      has_mask_next=True,
+                      is_dkv=is_dkv,
+                      max_mask_next=heads_per_shard * q_blocks_per_shard * kv_blocks_count,
+                      max_data_next=None)
     jax_mask = jnp.stack([m.array for m in mask.masks if isinstance(m, mask_lib.NumpyMask)])
     return _process_dynamic_mask(
           jax_mask,
@@ -799,9 +799,17 @@ def _process_mask(
     ):
       q_sequence = unique_mask.q_sequence
       mask_function = unique_mask.mask_function
-      _check_smem_limit(heads_per_shard, q_blocks_per_shard, kv_blocks_count,
-                      q_block_size, kv_block_size, has_mask_function=True,is_dkv=is_dkv)
-
+      _check_smem_limit(
+            leading_dim=block_mask_shape[0],
+            q_blocks_count=q_blocks_per_shard,
+            kv_blocks_count=kv_blocks_count,
+            q_block_size=q_block_size,
+            kv_block_size=kv_block_size,
+            has_mask_next=False,
+            is_dkv=is_dkv,
+            max_mask_next=None,
+            max_data_next=None,
+                )
   # Identify the partial mask blocks and the value of the block mask for each
   # block.
   # The partial mask blocks are "global", meaning it is a collection of such
@@ -956,11 +964,27 @@ def _process_mask(
     if has_mask_next:
       mask_next = np.concatenate(mask_next_per_head_list, axis=head_axis)
 
-  # Shrink the width of the mask info when possible.
-  if (
+  shrink_width_conditional = (
       shrink_grid
       and block_mask.shape[0] == head_shards
       and len(unique_masks) == 1
+      )
+  if not shrink_width_conditional:
+    smem_mask_next = has_mask_next and mask_function is None
+    _check_smem_limit(
+        leading_dim=block_mask.shape[0],
+        q_blocks_count=block_mask.shape[1],
+        kv_blocks_count=kv_blocks_count,
+        q_block_size=q_block_size,
+        kv_block_size=kv_block_size,
+        has_mask_next=smem_mask_next,
+        is_dkv=is_dkv,
+        max_mask_next= np.max(mask_next) if smem_mask_next and mask_next is not None else None,
+        max_data_next= np.max(data_next) if data_next.size > 0 else None
+    )
+  # Shrink the width of the mask info when possible.
+  if (
+      shrink_width_conditional
   ):
     rows_per_q_shard = block_mask.shape[1] // q_seq_shards
     block_mask_shards = []
@@ -1009,6 +1033,18 @@ def _process_mask(
       block_mask = block_mask_shards[0]
       data_next = data_next_shards[0]
       mask_next = mask_next_shards[0]
+      smem_mask_next = has_mask_next and mask_function is None
+      _check_smem_limit(
+          leading_dim=block_mask.shape[0],
+          q_blocks_count=q_blocks_count,
+          kv_blocks_count=kv_blocks_count,
+          q_block_size=q_block_size,
+          kv_block_size=kv_block_size,
+          has_mask_next=smem_mask_next,
+          is_dkv=is_dkv,
+          max_mask_next=np.max(mask_next) if smem_mask_next and mask_next is not None else None,
+          max_data_next=np.max(data_next) if data_next.size > 0 else None
+      )
     else:
       # Since shrinking happens independently for each shard along Q we might
       # end up with uneven mask info shards. Insert padding where necessary to
@@ -1060,7 +1096,18 @@ def _process_mask(
       block_mask = np.concatenate(padded_block_mask_shards, axis=1)
       data_next = np.concatenate(padded_data_next_shards, axis=1)
       mask_next = np.concatenate(padded_mask_next_shards, axis=1)
-
+      smem_mask_next = has_mask_next and mask_function is None
+      _check_smem_limit(
+          leading_dim=block_mask.shape[0],
+          q_blocks_count=block_mask.shape[1],
+          kv_blocks_count=block_mask.shape[2],
+          q_block_size=q_block_size,
+          kv_block_size=kv_block_size,
+          has_mask_next=smem_mask_next,
+          is_dkv=is_dkv,
+          max_mask_next=np.max(mask_next) if smem_mask_next and mask_next is not None else None,
+          max_data_next=np.max(data_next) if data_next.size > 0 else None
+      )
   if downcast_smem_data:
     data_next = _downcast_to_small_type(data_next)
     block_mask = _downcast_to_small_type(block_mask)

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask_info.py
@@ -684,7 +684,14 @@ def _process_mask(
            and isinstance(m.array, Tracer)
             for m in mask.masks)
 
-  if _is_numpy_mask_with_traced_arrays(mask):
+  if _is_numpy_mask_with_traced_arrays(mask) and q_seq_shards == 1:
+    # Sequence sharding (q_seq_shards > 1) is not supported for materialized
+    # NumpyMask in this path: full masks crash in _process_mask's per-shard
+    # np.concatenate, and causal/random numpy masks produce wrong output for
+    # shards. Unlike _ComputableMask, NumpyMask has no mask_function to
+    # evaluate per shard -- it's a materialized array -- so there's no
+    # shard-agnostic rule to re-slice correctly. See the q_seq_shards > 1 branch
+    # below, which rejects that case explicitly.
     _check_smem_limit(leading_dim=head_count,
                       q_blocks_count=q_blocks_per_shard,
                       kv_blocks_count=kv_blocks_count,
@@ -704,6 +711,12 @@ def _process_mask(
           q_seq_shards=q_seq_shards,
           shrink_grid=shrink_grid,
       )
+  elif _is_numpy_mask_with_traced_arrays(mask) and q_seq_shards > 1:
+    raise ValueError("Sequence sharding (q_seq_shards > 1) is not supported for "
+                      "materialized NumpyMask under JIT. Unlike _ComputableMask, NumpyMask has no "
+                      "mask_function to evaluate per shard, so it cannot be sharded "
+                      "correctly along the sequence dimension. Use a computable mask "
+                      "(e.g. LocalMask, CausalMask), disable JIT, or set q_seq_shards == 1.")
   # Uniquify the masks.
   # Create a collection of the unique head masks in the input multi-head mask.
   # This avoids processing the same mask multiple times and it enables

--- a/tests/pallas/tpu_splash_attention_mask_test.py
+++ b/tests/pallas/tpu_splash_attention_mask_test.py
@@ -22,6 +22,7 @@ import jax
 from jax._src import test_util as jtu
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask as mask_lib
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask_info as mask_info_lib
+from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_kernel
 import jax.numpy as jnp
 import numpy as np
 
@@ -2380,6 +2381,48 @@ class SplashAttentionMaskInfoTest(jtu.JaxTestCase):
     self.assertArraysEqual(mask_info.mask_next, _expected_mask_next)
     self.assertArraysEqual(mask_info.data_next, _expected_data_next)
 
+  @parameterized.product(
+    shape=[(128, 128), (256, 256), (256, 512),(512, 256), (512, 512)],
+    seed=[0, 1, 2],
+    mask_type=['causal', 'random', 'full'],
+            )
+  def test_numpy_mask_jit_vs_eager(self, shape, seed,mask_type):
+    q_len, kv_len = shape
+    batch_size = 2
+    num_heads = 2
+    head_dim = 128
+
+    q = jax.random.normal(jax.random.key(seed), (batch_size, num_heads, q_len, head_dim))
+    k = jax.random.normal(jax.random.key(seed + 1), (batch_size, num_heads, kv_len, head_dim))
+    v = jax.random.normal(jax.random.key(seed + 2), (batch_size, num_heads, kv_len, head_dim))
+
+    if mask_type == 'causal':
+        dense_mask = np.tril(np.ones((q_len, kv_len), dtype=np.bool_))
+    elif mask_type == 'random':
+        dense_mask = mask_lib.make_random_mask((q_len, kv_len), 0.5, seed=seed)
+    elif mask_type == 'full':
+        dense_mask = np.ones((q_len, kv_len), dtype=np.bool_)
+
+    def run_attention(query, key, value, mask_array):
+        mask = mask_lib.NumpyMask(array=mask_array)
+        multi_head_mask = mask_lib.MultiHeadMask(
+            masks=(mask,) * num_heads
+        )
+        kernel = splash_attention_kernel.make_splash_mha(
+            mask=multi_head_mask,
+            head_shards=1,
+            q_seq_shards=1,
+        )
+        return jax.vmap(kernel)(query, key, value)
+
+    eager_output = run_attention(q, k, v, dense_mask)
+    jit_output = jax.jit(run_attention)(q, k, v, dense_mask)
+
+    # Attention output should match between eager and jit. Under jit, NumpyMask
+    # arrays become tracers and are routed through the dynamic mask path, producing
+    # different intermediate representations, but the final result must be identical .
+
+    self.assertArraysEqual(eager_output, jit_output)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/pallas/tpu_splash_attention_mask_test.py
+++ b/tests/pallas/tpu_splash_attention_mask_test.py
@@ -2384,8 +2384,7 @@ class SplashAttentionMaskInfoTest(jtu.JaxTestCase):
   @parameterized.product(
     shape=[(128, 128), (256, 256), (256, 512),(512, 256), (512, 512)],
     seed=[0, 1, 2],
-    mask_type=['causal', 'random', 'full'],
-            )
+    mask_type=['causal', 'random', 'full'],)
   def test_numpy_mask_jit_vs_eager(self, shape, seed,mask_type):
     q_len, kv_len = shape
     batch_size = 2
@@ -2396,12 +2395,12 @@ class SplashAttentionMaskInfoTest(jtu.JaxTestCase):
     k = jax.random.normal(jax.random.key(seed + 1), (batch_size, num_heads, kv_len, head_dim))
     v = jax.random.normal(jax.random.key(seed + 2), (batch_size, num_heads, kv_len, head_dim))
 
-    if mask_type == 'causal':
-        dense_mask = np.tril(np.ones((q_len, kv_len), dtype=np.bool_))
-    elif mask_type == 'random':
-        dense_mask = mask_lib.make_random_mask((q_len, kv_len), 0.5, seed=seed)
-    elif mask_type == 'full':
-        dense_mask = np.ones((q_len, kv_len), dtype=np.bool_)
+    mask_factories = {
+        'causal': lambda: np.tril(np.ones((q_len, kv_len), dtype=np.bool_)),
+        'random': lambda: mask_lib.make_random_mask((q_len, kv_len), 0.5, seed=seed),
+        'full': lambda: np.ones((q_len, kv_len), dtype=np.bool_),
+    }
+    dense_mask = mask_factories[mask_type]()
 
     def run_attention(query, key, value, mask_array):
         mask = mask_lib.NumpyMask(array=mask_array)

--- a/tests/pallas/tpu_splash_attention_mask_test.py
+++ b/tests/pallas/tpu_splash_attention_mask_test.py
@@ -2396,9 +2396,9 @@ class SplashAttentionMaskInfoTest(jtu.JaxTestCase):
     v = jax.random.normal(jax.random.key(seed + 2), (batch_size, num_heads, kv_len, head_dim))
 
     mask_factories = {
-        'causal': lambda: np.tril(np.ones((q_len, kv_len), dtype=np.bool_)),
-        'random': lambda: mask_lib.make_random_mask((q_len, kv_len), 0.5, seed=seed),
-        'full': lambda: np.ones((q_len, kv_len), dtype=np.bool_),
+        'causal': lambda: jnp.tril(jnp.ones((q_len, kv_len), dtype=jnp.bool_)),
+        'random': lambda: jax.random.bernoulli(jax.random.key(seed), p=0.5, shape=(q_len, kv_len)),
+        'full': lambda: jnp.ones((q_len, kv_len), dtype=jnp.bool_),
     }
     dense_mask = mask_factories[mask_type]()
 

--- a/tests/pallas/tpu_splash_attention_mask_test.py
+++ b/tests/pallas/tpu_splash_attention_mask_test.py
@@ -23,6 +23,7 @@ from jax._src import test_util as jtu
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask as mask_lib
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask_info as mask_info_lib
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_kernel
+from jax.sharding import Mesh, PartitionSpec as P
 import jax.numpy as jnp
 import numpy as np
 
@@ -2419,9 +2420,59 @@ class SplashAttentionMaskInfoTest(jtu.JaxTestCase):
 
     # Attention output should match between eager and jit. Under jit, NumpyMask
     # arrays become tracers and are routed through the dynamic mask path, producing
-    # different intermediate representations, but the final result must be identical .
+    # different intermediate representations.
 
     self.assertArraysEqual(eager_output, jit_output)
+
+  @parameterized.product(
+    shape=[(128, 128), (256, 256), (256, 512),(512, 256), (512, 512)],
+    seed=[0, 1, 2],
+    mask_type=['causal', 'random', 'full'],)
+  def test_numpy_mask_jit_vs_eager_distributed_heads(self, shape, seed,mask_type):
+    q_len, kv_len = shape
+    batch_size = 2
+    num_heads = 8
+    head_dim = 128
+
+    q = jax.random.normal(jax.random.key(seed), (batch_size, num_heads, q_len, head_dim))
+    k = jax.random.normal(jax.random.key(seed + 1), (batch_size, num_heads, kv_len, head_dim))
+    v = jax.random.normal(jax.random.key(seed + 2), (batch_size, num_heads, kv_len, head_dim))
+
+    mask_factories = {
+        'causal': lambda: jnp.tril(jnp.ones((q_len, kv_len), dtype=jnp.bool_)),
+        'random': lambda: jax.random.bernoulli(jax.random.key(seed), p=0.5, shape=(q_len, kv_len)),
+        'full': lambda: jnp.ones((q_len, kv_len), dtype=jnp.bool_),
+    }
+    dense_mask = mask_factories[mask_type]()
+    num_devices = jax.device_count()
+    mesh = Mesh(np.array(jax.devices()), axis_names=('heads',))
+
+    # Path A: concrete mask captured as constant should follow static pathway (process_mask)
+    def run_static(query, key, value):
+        mask = mask_lib.NumpyMask(array=np.asarray(dense_mask))
+        mhm = mask_lib.MultiHeadMask(masks=(mask,) * num_heads)
+        kernel = splash_attention_kernel.make_splash_mha(
+            mask=mhm, head_shards=num_devices, q_seq_shards=1)
+        return jax.vmap(kernel)(query, key, value)
+
+    # Path B: mask passed as arg becomes a tracer should follow dynamic pathway (process_dynamic_mask)
+    def run_dynamic(query, key, value, mask_array):
+        mask = mask_lib.NumpyMask(array=mask_array)
+        mhm = mask_lib.MultiHeadMask(masks=(mask,) * num_heads)
+        kernel = splash_attention_kernel.make_splash_mha(
+            mask=mhm, head_shards=num_devices, q_seq_shards=1)
+        return jax.vmap(kernel)(query, key, value)
+
+    static_out  = jax.shard_map(run_static,  mesh=mesh,
+                    in_specs=(P(None,'heads',None,None),)*3,
+                    out_specs=P(None,'heads',None,None), check_vma=False)(q, k, v)
+
+    dynamic_out = jax.shard_map(run_dynamic, mesh=mesh,
+                    in_specs=(P(None,'heads',None,None),)*3 + (P(),),
+                    out_specs=P(None,'heads',None,None), check_vma=False)(q, k, v, dense_mask)
+
+
+    self.assertArraysEqual(static_out, dynamic_out)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/pallas/tpu_splash_attention_mask_test.py
+++ b/tests/pallas/tpu_splash_attention_mask_test.py
@@ -2334,7 +2334,7 @@ class SplashAttentionMaskInfoTest(jtu.JaxTestCase):
             [[1, 1, 1, 1], [1, 1, 1, 1]],
             [[1, 1, 1, 0], [1, 1, 1, 1]],
         ],
-        dtype=np.bool_,
+        dtype=np.int8,
     )
 
     _expected_mask_next = np.array(


### PR DESCRIPTION
This PR is aimed at adding a JIT-compatible pathway for Numpy Masks to be used in splash attention.

NumpyMask validates for arrays to be boolean np arrays . But in practice, especially in larger codebases where multiple pipelines interoperate and mask arrays may originate from upstream JAX computations, they cannot be converted to numpy arrays within a jitted context without raising ConcretizationTypeError.

The PR aims to detect traced arrays in Numpy Masks and route it to a dynamic mask processing path adding robustness to its usage.

Benchmark numbers below for reference 

<img width="1758" height="386" alt="image" src="https://github.com/user-attachments/assets/cdf3b61b-ee93-48b0-b36c-c43f0e20ded1" />


An alternative approach was making process_mask itself JIT-compatible, but this would regress performance for the existing non-JIT NumPy mask pathway. Instead, a separate process_dynamic_mask path is used to keep the existing pathway untouched.