### PR TITLE
setup.py: Include only jax.* in the built wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     long_description_content_type='text/markdown',
     author='JAX team',
     author_email='jax-dev@google.com',
-    packages=find_packages(exclude=["examples"]),
+    packages=find_packages(include=["jax", "jax.*"]),
     package_data={'jax': ['py.typed', "*.pyi", "**/*.pyi"]},
     python_requires='>=3.11',
     install_requires=[


### PR DESCRIPTION
Previously, a wheel built from Git would also install `docs` to the shared root namespace.

- Fixes #37180.