### PR TITLE
[ROCm] Fix inter-block write race in pallas test_non_range_while_loop

### DIFF
--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -2115,10 +2115,6 @@ class PallasControlFlowTest(ptu.PallasTest):
     """Tests lowering of a while_loop which cannot reduce to a fori_loop."""
 
     def kernel(x_ref, r_ref):
-      @pl.when(pl.program_id(0) == 0)
-      def _():
-        r_ref[0, 0] = 0
-
       def cond(state):
         i, s = state
         return jnp.logical_and(i < 1024, s < 1024)
@@ -2127,24 +2123,24 @@ class PallasControlFlowTest(ptu.PallasTest):
         i, s = state
         sl = jax.lax.div(i, jnp.astype(128, i.dtype))
         l = jax.lax.rem(i, jnp.astype(128, i.dtype))
-        v = x_ref[0, sl, l]
+        v = x_ref[sl, l]
         return i + 1, s + v
 
-      i = jnp.int32(0)
-      _, r_ref[0, 0] = jax.lax.while_loop(cond, body, (i, r_ref[0, 0]))
+      _, r_ref[0, 0] = jax.lax.while_loop(
+          cond, body, (jnp.int32(0), jnp.zeros((), intx)))
 
-    x = jnp.arange(4096)
-    x = jnp.reshape(x, [4, 8, 128])
+    x = jnp.arange(1024)
+    x = jnp.reshape(x, [8, 128])
 
     r = pl.pallas_call(
         kernel,
-        grid=(4,),
+        grid=(1,),
         out_specs=pl.BlockSpec((1, 1), memory_space=smem_on_tpu()),
         out_shape=jax.ShapeDtypeStruct([1, 1], intx),
         in_specs=[
             pl.BlockSpec(
-                (1, 8, 128),
-                lambda i: (i, 0, 0),
+                (8, 128),
+                lambda i: (0, 0),
                 memory_space=smem_on_tpu(),
             )
         ],


### PR DESCRIPTION
Update:
As per feedback changed the test to use grid=(1,) instead. so that below racey condition never triggers.



explanation related original changes :
The kernel uses grid=(4,) with all blocks writing to a single shared output cell `r_ref[0,0]`. The init store is correctly guarded by `@pl.when(pl.program_id(0) == 0)`, but the final store after `jax.lax.while_loop` is not, so 4 grid blocks race to write to the same global cell with no atomic, no fence, no across-block guard.

Per the test setup, the per-block local accumulators are:
- block 0: 1035 (loops 46 iters until accumulator >= 1024)
- block 1: 1024, block 2: 2048, block 3: 3072 (each exits after 1 iter)

Bug is more clear at assembly level , below is annotated ISA for the racey kernel

```bash
0000000000001600 <kernel>:
; ----- prologue: load kernarg pointers, compute thread linear id -----
1600: s_load_dwordx4 s[4:7], s[0:1], 0x0     ; s[4:5] = x_ref ptr, s[6:7] = r_ref ptr
1608: v_readfirstlane_b32 s0, v0
160C: s_lshr_b32 s0, s0, 6
1610: s_nop 0
1614: v_and_or_b32 v0, v0, 63, s0            ; v0 = thread_linear_id

; ----- INIT GUARD: @pl.when(pl.program_id(0) == 0) ; r_ref[0,0] = 0 -----
161C: v_or_b32_e32 v1, s2, v0                ; v1 = block_id | lane
1620: v_cmp_eq_u32_e32 vcc, 0, v1            ; vcc = (block_id == 0 AND lane == 0)
1624: s_and_saveexec_b64 s[0:1], vcc         ; only block 0 lane 0 enters
1628: s_cbranch_execz 4
162C: v_mov_b32_e32 v1, 0
1630: s_waitcnt lgkmcnt(0)
1634: global_store_dword v1, v1, s[6:7]      ; *r_ref = 0   (block 0 lane 0 only)
163C: s_or_b64 exec, exec, s[0:1]            ; ALL 4 blocks resume

; ----- LOAD initial carry: r_ref[0,0]   (ALL 4 blocks load) -----
1640: v_mov_b32_e32 v1, 0
1644: s_waitcnt lgkmcnt(0)
1648: global_load_dword v1, v1, s[6:7]
1650: s_movk_i32 s0, 0x3ff
1654: s_waitcnt vmcnt(0)
1658: v_cmp_lt_i32_e32 vcc, s0, v1
165C: s_cbranch_vccnz 21                     ; defensive early-exit if v1 already >= 1024

; ----- LOOP setup: per-block x_ref offset (BlockSpec lambda i: (i,0,0)) -----
1660: s_lshl_b32 s0, s2, 10                  ; s0 = block_id * 1024
1664: s_ashr_i32 s1, s0, 31
1668: s_lshl_b64 s[0:1], s[0:1], 2
166C: s_add_u32 s0, s4, s0
1670: s_addc_u32 s1, s5, s1
1674: s_mov_b32 s3, 0                        ; i = 0
1678: s_movk_i32 s2, 0x400                   ; s2 = 1024 (overwrites block_id!)

; ----- WHILE-LOOP body (block 0 runs 46 iters; blocks 1/2/3 run 1) -----
167C: s_load_dword s8, s[0:1], 0x0           ; load x[block_id, .., ..]
1684: s_add_i32 s4, s3, 1
1688: s_cmpk_lt_u32 s3, 0x3ff
168C: s_mov_b32 s3, s4
1690: s_cselect_b64 s[4:5], -1, 0
1694: s_waitcnt lgkmcnt(0)
1698: v_add_u32_e32 v1, s8, v1               ; s = s + v
169C: v_cmp_gt_i32_e32 vcc, s2, v1
16A0: s_and_b64 s[4:5], s[4:5], vcc
16A4: s_add_u32 s0, s0, 4
16A8: s_addc_u32 s1, s1, 0
16AC: s_and_b64 vcc, exec, s[4:5]
16B0: s_cbranch_vccnz 65522                  ; loop back

; ----- FINAL STORE -----
16B4: v_cmp_eq_u32_e32 vcc, 0, v0            ; vcc = (lane == 0)   ...no guard here for block so whoever writes last to global store win!!
16B8: s_and_saveexec_b64 s[0:1], vcc
16BC: s_cbranch_execz 3
16C0: v_mov_b32_e32 v0, 0
16C4: global_store_dword v0, v1, s[6:7]      ; *r_ref = v1
16CC: s_endpgm
```

After fix ISA looks like below :
```bash
0000000000001600 <kernel>:
1600: s_cmp_lg_u32 s2, 0                     ; EARLY EXIT: SCC = (block_id != 0)
1604: v_readfirstlane_b32 s2, v0
1608: s_cbranch_scc0 1                       ; if block_id == 0, jump to 0x1610
160C: s_endpgm                               ; blocks 1, 2, 3 exit here
1610: s_load_dwordx4 s[4:7], s[0:1], 0x0     ; only block 0 from here on
1618: s_and_b32 s0, s2, 0xc0
1620: v_and_or_b32 v0, v0, 63, s0
1628: v_cmp_eq_u32_e32 vcc, 0, v0
162C: v_cmp_ne_u32_e64 s[0:1], 0, v0
1634: s_and_saveexec_b64 s[8:9], s[0:1]
1638: s_xor_b64 s[0:1], exec, s[8:9]
163C: s_cbranch_execz 3
1640: s_waitcnt lgkmcnt(0)
1644: s_load_dword s2, s[6:7], 0x0
164C: s_or_saveexec_b64 s[0:1], s[0:1]
1650: s_waitcnt lgkmcnt(0)
1654: v_mov_b32_e32 v0, s2
1658: s_xor_b64 exec, exec, s[0:1]
165C: s_cbranch_execz 4
1660: v_mov_b32_e32 v0, 0
1664: global_store_dword v0, v0, s[6:7]      ; init store: r_ref[0,0] = 0
166C: v_mov_b32_e32 v0, 0
1670: s_or_b64 exec, exec, s[0:1]
1674: s_movk_i32 s0, 0x400
1678: v_cmp_gt_i32_e64 s[0:1], s0, v0
1680: s_and_saveexec_b64 s[2:3], s[0:1]
1684: s_cbranch_execz 21
1688: s_mov_b32 s0, 0
168C: s_mov_b64 s[8:9], 0
1690: s_movk_i32 s10, 0x3ff
1694: s_load_dword s1, s[4:5], 0x0           ; LOOP TOP
169C: s_add_i32 s11, s0, 1
16A0: s_cmpk_gt_u32 s0, 0x3fe
16A4: s_cselect_b64 s[12:13], -1, 0
16A8: s_waitcnt lgkmcnt(0)
16AC: v_add_u32_e32 v0, s1, v0
16B0: v_cmp_lt_i32_e64 s[0:1], s10, v0
16B8: s_or_b64 s[0:1], s[12:13], s[0:1]
16BC: s_add_u32 s4, s4, 4
16C0: s_addc_u32 s5, s5, 0
16C4: s_and_b64 s[0:1], exec, s[0:1]
16C8: s_or_b64 s[8:9], s[0:1], s[8:9]
16CC: s_mov_b32 s0, s11
16D0: s_andn2_b64 exec, exec, s[8:9]
16D4: s_cbranch_execnz 65519                 ; LOOP back-edge
16D8: s_or_b64 exec, exec, s[8:9]
16DC: s_or_b64 exec, exec, s[2:3]
16E0: s_and_saveexec_b64 s[0:1], vcc
16E4: s_cbranch_execz 65481
16E8: v_mov_b32_e32 v1, 0
16EC: global_store_dword v1, v0, s[6:7]      ; only block 0 reaches here
16F4: s_endpgm
```