### PR TITLE
docs[pallas]: replace "Coming soon!" with links to backend-specific guides

### DIFF
--- a/docs/pallas/gpu/index.rst
+++ b/docs/pallas/gpu/index.rst
@@ -1,3 +1,5 @@
+.. _pallas_mosaic_gpu:
+
 Pallas:Mosaic GPU
 =================
 Backend specific documentation for the Mosaic GPU backend.

--- a/docs/pallas/quickstart.ipynb
+++ b/docs/pallas/quickstart.ipynb
@@ -220,7 +220,7 @@
     "We then use TPU vector compute to execute the addition, then copy the resulting\n",
     "value back into SRAM. After the kernel is executed, the SRAM value is copied back into HBM.\n",
     "\n",
-    "We are in the process of writing backend-specific Pallas guides. Coming soon!"
+    "For more details on each backend, see {ref}`the Mosaic GPU backend guide <pallas_mosaic_gpu>` and {ref}`the TPU backend guide <pallas_tpu>`."
    ]
   },
   {

--- a/docs/pallas/quickstart.ipynb
+++ b/docs/pallas/quickstart.ipynb
@@ -220,7 +220,8 @@
     "We then use TPU vector compute to execute the addition, then copy the resulting\n",
     "value back into SRAM. After the kernel is executed, the SRAM value is copied back into HBM.\n",
     "\n",
-    "For more details on each backend, see {ref}`the Mosaic GPU backend guide <pallas_mosaic_gpu>` and {ref}`the TPU backend guide <pallas_tpu>`."
+    "For more details on each backend, see {ref}`the Mosaic GPU backend guide <pallas_mosaic_gpu>`\n",
+    "and {ref}`the TPU backend guide <pallas_tpu>`."
    ]
   },
   {

--- a/docs/pallas/quickstart.md
+++ b/docs/pallas/quickstart.md
@@ -159,7 +159,7 @@ SRAM and when we do `x_ref[...]` we are copying the value from SRAM into a regis
 We then use TPU vector compute to execute the addition, then copy the resulting
 value back into SRAM. After the kernel is executed, the SRAM value is copied back into HBM.
 
-We are in the process of writing backend-specific Pallas guides. Coming soon!
+For more details on each backend, see {ref}`the Mosaic GPU backend guide <pallas_mosaic_gpu>` and {ref}`the TPU backend guide <pallas_tpu>`.
 
 +++
 

--- a/docs/pallas/tpu/index.rst
+++ b/docs/pallas/tpu/index.rst
@@ -1,3 +1,5 @@
+.. _pallas_tpu:
+
 Pallas TPU
 ==========
 TPU specific documentation.


### PR DESCRIPTION
## Summary

- Removes the placeholder "Coming soon!" line from the Pallas quickstart (`docs/pallas/quickstart.md` and `.ipynb`)
- Replaces it with `{ref}` cross-references to the existing GPU (Mosaic GPU) and TPU backend guide index pages, matching the style used in `pallas/pipelining.md`
- Adds `.. _pallas_mosaic_gpu:` label to `docs/pallas/gpu/index.rst` and `.. _pallas_tpu:` label to `docs/pallas/tpu/index.rst` to support these references

## Test plan

- [ ] Verify docs build without warnings: `sphinx-build docs docs/_build`
- [ ] Confirm cross-reference links resolve correctly in the rendered quickstart page
- [ ] Check that `{ref}pallas_mosaic_gpu` and `{ref}pallas_tpu` render as clickable links pointing to the correct index pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)