### PR TITLE
[ROCm] aiter mha kernels (ASM+CK) integration (#747)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,6 +13,10 @@ load("@xla//:workspace3.bzl", "xla_workspace3")
 
 xla_workspace3()
 
+load("//third_party/aiter:workspace.bzl", "aiter_mha_whl")
+
+aiter_mha_whl()
+
 # Initialize Hermetic toolchains
 # Details: https://github.com/google-ml-infra/rules_ml_toolchain
 tf_http_archive(

--- a/build/build.py
+++ b/build/build.py
@@ -365,6 +365,17 @@ def add_artifact_subcommand_arguments(parser: argparse.ArgumentParser):
         """,
   )
 
+  compile_group.add_argument(
+      "--local_aiter_path",
+      type=str,
+      default=os.environ.get("LOCAL_AITER_PATH", ""),
+      help="""
+        Path to a directory containing locally-built AITER shared libraries
+        and headers (libs/libmha_fwd.so, libs/libmha_bwd.so, include/*.h).
+        If not set, Bazel downloads the pre-built AITER wheel from GitHub.
+        """,
+  )
+
 async def main():
   parser = argparse.ArgumentParser(
       description=r"""
@@ -534,6 +545,10 @@ async def main():
   if args.local_xla_path:
     logging.debug("Local XLA path: %s", args.local_xla_path)
     wheel_build_command_base.append(f"--override_repository=xla=\"{args.local_xla_path}\"")
+
+  if args.local_aiter_path:
+    logging.debug("Local AITER libs path: %s", args.local_aiter_path)
+    wheel_build_command_base.append(f"--repo_env=LOCAL_AITER_PATH=\"{args.local_aiter_path}\"")
 
   if args.target_cpu:
     logging.debug("Target CPU: %s", args.target_cpu)

--- a/build/rocm/dev_build_rocm.py
+++ b/build/rocm/dev_build_rocm.py
@@ -69,9 +69,12 @@ def clean_dist_directory():
         sys.exit(1)
 
 
-def build_jax_xla(xla_path, rocm_version, rocm_target, use_clang, clang_path):
+def build_jax_xla(xla_path, rocm_version, rocm_target, use_clang, clang_path, local_aiter_path=""):
     bazel_options = (
         f"--bazel_options=--override_repository=xla={xla_path}" if xla_path else ""
+    )
+    aiter_option = (
+        f"--bazel_options=--repo_env=LOCAL_AITER_PATH={local_aiter_path}" if local_aiter_path else ""
     )
     clang_option = f"--clang_path={clang_path}" if clang_path else ""
     build_command = [
@@ -84,6 +87,7 @@ def build_jax_xla(xla_path, rocm_version, rocm_target, use_clang, clang_path):
         "--rocm_version=60",
         f"--rocm_amdgpu_targets={rocm_target}",
         bazel_options,
+        aiter_option,
         "--verbose"
     ]
 
@@ -128,12 +132,20 @@ def main():
     parser.add_argument(
         "--xla-path", type=str, default="", help="Specify the XLA repository path"
     )
+    parser.add_argument(
+        "--local-aiter-path", type=str, default="",
+        help="Path to locally-built AITER shared libraries and headers",
+    )
 
     args = parser.parse_args()
 
     if args.xla_path:
         args.xla_path = os.path.abspath(args.xla_path)
         print(f"Converted XLA path to absolute: {args.xla_path}")
+
+    if args.local_aiter_path:
+        args.local_aiter_path = os.path.abspath(args.local_aiter_path)
+        print(f"Converted local AITER path to absolute: {args.local_aiter_path}")
 
     rocm_version = get_rocm_version()
     if not rocm_version:
@@ -156,7 +168,8 @@ def main():
         f"Building JAX and XLA with ROCm version: {rocm_version}, Target: {rocm_target}"
     )
     build_jax_xla(
-        args.xla_path, rocm_version, rocm_target, args.use_clang, args.clang_path
+        args.xla_path, rocm_version, rocm_target, args.use_clang, args.clang_path,
+        args.local_aiter_path,
     )
 
     install_wheel()

--- a/build/rocm/tools/build_wheels.py
+++ b/build/rocm/tools/build_wheels.py
@@ -87,7 +87,8 @@ def find_clang_path():
 
 
 def build_jaxlib_wheel(
-    jax_path, rocm_path, python_version, xla_path=None, compiler="gcc"
+    jax_path, rocm_path, python_version, xla_path=None, compiler="gcc",
+    local_aiter_path=None,
 ):
     use_clang = "true" if compiler == "clang" else "false"
 
@@ -123,6 +124,9 @@ def build_jaxlib_wheel(
 
     if xla_path:
         cmd.append("--bazel_options=--override_repository=xla=%s" % xla_path)
+
+    if local_aiter_path:
+        cmd.append("--bazel_options=--repo_env=LOCAL_AITER_PATH=%s" % local_aiter_path)
 
     cpy = to_cpy_ver(python_version)
     py_bin = "/opt/python/%s-%s/bin" % (cpy, cpy)
@@ -261,6 +265,12 @@ def parse_args():
         help="Optional directory where XLA source is located to use instead of JAX builtin XLA",
     )
     p.add_argument(
+        "--local-aiter-path",
+        type=str,
+        default=None,
+        help="Optional directory containing locally-built AITER shared libraries and headers",
+    )
+    p.add_argument(
         "--compiler",
         type=str,
         default="gcc",
@@ -291,13 +301,14 @@ def main():
     print("PYTHON_VERSIONS=%r" % python_versions)
     print("JAX_PATH=%s" % args.jax_path)
     print("XLA_PATH=%s" % args.xla_path)
+    print("LOCAL_AITER_PATH=%s" % args.local_aiter_path)
 
     rocm_path = build_rocm_path(args.rocm_version)
 
     update_rocm_targets(rocm_path, GPU_DEVICE_TARGETS)
 
     for py in python_versions:
-        build_jaxlib_wheel(args.jax_path, rocm_path, py, args.xla_path, args.compiler)
+        build_jaxlib_wheel(args.jax_path, rocm_path, py, args.xla_path, args.compiler, args.local_aiter_path)
         wheel_paths = find_wheels(os.path.join(args.jax_path, "dist"))
         for wheel_path in wheel_paths:
             # skip jax wheel since it is non-platform

--- a/jax/BUILD
+++ b/jax/BUILD
@@ -137,6 +137,7 @@ py_library_providing_imports_info(
     srcs = glob(
         [
             "*.py",
+            "aiter/**/*.py",
             "image/**/*.py",
             "interpreters/**/*.py",
             "lax/**/*.py",
@@ -168,6 +169,7 @@ py_library_providing_imports_info(
         "//jax/_src:abstract_arrays",
         "//jax/_src:ad",
         "//jax/_src:ad_util",
+        "//jax/_src:aiter",
         "//jax/_src:api",
         "//jax/_src:api_util",
         "//jax/_src:basearray",

--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -1646,6 +1646,18 @@ pytype_strict_library(
 )
 
 pytype_strict_library(
+    name = "aiter",
+    srcs = glob(["aiter/**/*.py"]),
+    deps = [
+        ":core",
+        ":custom_derivatives",
+        ":dtypes",
+        ":ffi",
+        "//jax/_src/lib",
+    ] + py_deps("numpy"),
+)
+
+pytype_strict_library(
     name = "extend_src",
     srcs = glob(include = ["extend/**/*.py"]),
     type_checking = "pyrefly",

--- a/jax/_src/aiter/__init__.py
+++ b/jax/_src/aiter/__init__.py
@@ -1,0 +1,38 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Public exports for the `jax_aiter.mha` sub-package.
+
+Uses unified AITER entry point (aiter::mha_fwd / aiter::mha_bwd) for both
+batch and variable-length attention. CK vs ASM v3 dispatch handled internally
+by AITER.
+
+Public API:
+    flash_attn_func: Batch flash attention with custom_vjp
+    flash_attn_varlen: Variable-length flash attention with custom_vjp
+"""
+
+try:
+  from .aiter_mha import (
+    flash_attn_func,
+    flash_attn_varlen,
+  )
+except (ImportError, RuntimeError, OSError):
+  flash_attn_func = None  # type: ignore[assignment]
+  flash_attn_varlen = None  # type: ignore[assignment]
+
+__all__ = [
+  "flash_attn_func",
+  "flash_attn_varlen",
+]

--- a/jax/_src/aiter/aiter_mha.py
+++ b/jax/_src/aiter/aiter_mha.py
@@ -1,0 +1,967 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Simplified MHA using unified AITER entry point.
+
+Calls aiter::mha_fwd / aiter::mha_bwd through a single FFI handler per
+direction. CK vs ASM v3 dispatch is handled internally by AITER based on
+the use_asm_v3 flag. No Python-side dispatch logic.
+
+GSPMD sharding: custom_partitioning tells XLA how to partition the FFI
+calls for multi-GPU FSDP.  For batch-mode attention every dimension
+except the batch axis is replicated, so each device runs independently
+on its local batch shard (output sharding = Q input sharding, no
+collectives).  custom_partitioning wraps the raw FFI calls;
+custom_vjp sits on the outer public API -- they compose because they
+are on different levels of the call stack.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import shutil
+import subprocess
+from collections import namedtuple
+from typing import Optional
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.experimental.custom_partitioning import (
+    ArrayMapping,
+    SdyShardingRule,
+    custom_partitioning,
+)
+from jax.sharding import NamedSharding, PartitionSpec as P
+
+
+# -------------- Register AITER ------------
+
+from jax._src.lib import gpu_aiter
+
+logger = logging.getLogger(__name__)
+
+
+if gpu_aiter is not None:
+    for platform, targets in gpu_aiter.registrations().items():
+        for name, value in targets:
+            logger.debug(
+                "Registering AITER FFI target: %s for platform: %s",
+                name, platform,
+            )
+            jax.ffi.register_ffi_target(
+                name, value, platform=platform, api_version=1
+            )
+else:
+    logger.debug("AITER FFI targets not found (gpu_aiter unavailable)")
+# ------------------------------------------------------------
+
+@functools.lru_cache(maxsize=1)
+def get_gfx() -> str:
+    """Return the GFX architecture string (e.g. 'gfx950', 'gfx942')."""
+    gfx = os.getenv("GPU_ARCHS", "native")
+    if gfx == "native":
+        rocminfo = shutil.which("rocminfo")
+        if rocminfo is None:
+            raise RuntimeError(
+                "rocminfo not found on PATH; set GPU_ARCHS to specify the "
+                "target architecture (e.g. GPU_ARCHS=gfx942)"
+            )
+        try:
+            result = subprocess.run(
+                [os.path.realpath(rocminfo)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=10,
+            )
+            for line in result.stdout.split("\n"):
+                if "gfx" in line.lower():
+                    return line.split(":")[-1].strip()
+        except Exception as e:
+            raise RuntimeError(f"Get GPU arch from rocminfo failed: {e}")
+        raise RuntimeError("rocminfo did not report a gfx architecture")
+    if ";" in gfx:
+        gfx = gfx.split(";")[-1]
+    return gfx
+
+
+# Hashable config bundles for custom_partitioning static args.
+MhaFwdConfig = namedtuple("MhaFwdConfig", [
+    "dropout_p", "softmax_scale", "is_causal", "wl", "wr",
+    "return_lse", "return_randval", "use_asm_v3", "how_v3_bf16_cvt",
+    "max_seqlen_q", "max_seqlen_k", "min_seqlen_q",
+    "logits_soft_cap", "zero_tensors",
+    "cp_axis", "cp_size", "cp_load_balanced",
+])
+
+MhaBwdConfig = namedtuple("MhaBwdConfig", [
+    "dropout_p", "softmax_scale", "is_causal", "wl", "wr",
+    "deterministic", "use_asm_v3", "is_v3_atomic_fp32", "how_v3_bf16_cvt",
+    "max_seqlen_q", "max_seqlen_k", "zero_tensors",
+    "cp_axis", "cp_size", "cp_load_balanced",
+])
+
+
+def _empty(dtype):
+    return jnp.zeros((0,), dtype=dtype)
+
+
+def _sf(x) -> np.float32:
+    return np.float32(x)
+
+
+def _si(x) -> np.int32:
+    return np.int32(x)
+
+
+# ---------------------------------------------------------------------------
+# Unified forward FFI wrapper
+# ---------------------------------------------------------------------------
+
+def _make_fwd_call(out_shape, lse_shape, p_shape, rng_shape, dtype):
+    call = jax.ffi.ffi_call(
+        "hip_mha_fwd_ffi",
+        (
+            jax.ShapeDtypeStruct(out_shape, dtype),
+            jax.ShapeDtypeStruct(lse_shape, jnp.float32),
+            jax.ShapeDtypeStruct(p_shape, jnp.uint8),
+            jax.ShapeDtypeStruct(rng_shape, jnp.int64),
+        ),
+        vmap_method="broadcast_all",
+        input_layouts=[None] * 9,
+        output_layouts=[None] * 4,
+        has_side_effect=False,
+    )
+
+    def _invoke(q, k, v, cu_sq, cu_skv, out_prov, bias, alibi, gen, *,
+                dropout_p, softmax_scale, is_causal, wl, wr,
+                return_lse, return_randval, use_asm_v3, how_v3_bf16_cvt,
+                max_seqlen_q_attr, max_seqlen_k_attr, min_seqlen_q,
+                logits_soft_cap, zero_tensors):
+        return call(q, k, v, cu_sq, cu_skv, out_prov, bias, alibi, gen,
+                    dropout_p=dropout_p, softmax_scale=softmax_scale,
+                    is_causal=is_causal, window_size_left=wl, window_size_right=wr,
+                    return_softmax_lse=return_lse,
+                    return_dropout_randval=return_randval,
+                    use_asm_v3=use_asm_v3, how_v3_bf16_cvt=how_v3_bf16_cvt,
+                    max_seqlen_q_attr=max_seqlen_q_attr,
+                    max_seqlen_k_attr=max_seqlen_k_attr,
+                    min_seqlen_q=min_seqlen_q,
+                    logits_soft_cap=logits_soft_cap,
+                    zero_tensors=zero_tensors)
+
+    return jax.jit(_invoke, static_argnames=(
+        "dropout_p", "softmax_scale", "is_causal", "wl", "wr",
+        "return_lse", "return_randval", "use_asm_v3", "how_v3_bf16_cvt",
+        "max_seqlen_q_attr", "max_seqlen_k_attr", "min_seqlen_q",
+        "logits_soft_cap", "zero_tensors"))
+
+
+# ---------------------------------------------------------------------------
+# Unified backward FFI wrapper
+# ---------------------------------------------------------------------------
+
+def _make_bwd_call(dq_shape, dk_shape, dv_shape, sd_shape, dbias_shape, dtype):
+    call = jax.ffi.ffi_call(
+        "hip_mha_bwd_ffi",
+        (
+            jax.ShapeDtypeStruct(dq_shape, dtype),
+            jax.ShapeDtypeStruct(dk_shape, dtype),
+            jax.ShapeDtypeStruct(dv_shape, dtype),
+            jax.ShapeDtypeStruct(sd_shape, jnp.float32),
+            jax.ShapeDtypeStruct(dbias_shape, dtype),
+        ),
+        vmap_method="broadcast_all",
+        input_layouts=[None] * 15,
+        output_layouts=[None] * 5,
+        has_side_effect=False,
+    )
+
+    def _invoke(dout, q, k, v, out, lse, cu_sq, cu_sk,
+                dq, dk, dv, bias, alibi, rng, gen, *,
+                dropout_p, softmax_scale, is_causal, wl, wr,
+                deterministic, use_asm_v3, is_v3_atomic_fp32, how_v3_bf16_cvt,
+                max_seqlen_q_attr, max_seqlen_k_attr, zero_tensors):
+        return call(dout, q, k, v, out, lse, cu_sq, cu_sk,
+                    dq, dk, dv, bias, alibi, rng, gen,
+                    dropout_p=dropout_p, softmax_scale=softmax_scale,
+                    is_causal=is_causal, window_size_left=wl, window_size_right=wr,
+                    deterministic=deterministic, use_asm_v3=use_asm_v3,
+                    is_v3_atomic_fp32=is_v3_atomic_fp32,
+                    how_v3_bf16_cvt=how_v3_bf16_cvt,
+                    max_seqlen_q_attr=max_seqlen_q_attr,
+                    max_seqlen_k_attr=max_seqlen_k_attr,
+                    zero_tensors=zero_tensors)
+
+    return jax.jit(_invoke, static_argnames=(
+        "dropout_p", "softmax_scale", "is_causal", "wl", "wr",
+        "deterministic", "use_asm_v3", "is_v3_atomic_fp32", "how_v3_bf16_cvt",
+        "max_seqlen_q_attr", "max_seqlen_k_attr", "zero_tensors"))
+
+
+# ---------------------------------------------------------------------------
+# Sharding helpers
+# ---------------------------------------------------------------------------
+
+def _get_padded_spec(arg_info):
+    """Pad a PartitionSpec to match ndim, filling with None."""
+    if arg_info.sharding is None:
+        return (None,) * arg_info.ndim
+    spec = arg_info.sharding.spec
+    return spec + (None,) * (arg_info.ndim - len(spec))
+
+
+def _get_rank(t):
+    """Get tensor rank from either JAX ShapeDtypeStruct or MLIR RankedTensorType."""
+    if hasattr(t, 'ndim'):
+        return t.ndim
+    if hasattr(t, 'rank'):
+        return t.rank
+    return len(t.shape)
+
+
+# ---------------------------------------------------------------------------
+# Raw forward/backward FFI helpers (no partitioning, shape-driven)
+# ---------------------------------------------------------------------------
+
+def _mha_fwd_raw(q, k, v, cu_sq, cu_skv, out_prov, bias, alibi, gen,
+                 config):
+
+    is_varlen = (q.ndim == 3)
+    if is_varlen:
+        total_q, hq, dq = q.shape
+        _, hk, dv = v.shape
+        out_shape = (total_q, hq, dv)
+        lse_shape = (hq, config.max_seqlen_q) if config.return_lse else (0,)
+        p_shape = (0,)
+    else:
+        b, sq, hq, dq = q.shape
+        _, sk, hk, dv = v.shape
+        out_shape = (b, sq, hq, dv)
+        lse_shape = (b, hq, sq) if config.return_lse else (0,)
+        p_shape = (b, hq, sq, sk) if config.return_randval else (0,)
+    rng_shape = (2,)
+    fn = _make_fwd_call(out_shape, lse_shape, p_shape,
+                                  rng_shape, q.dtype)
+    return fn(q, k, v, cu_sq, cu_skv, out_prov, bias, alibi, gen,
+              dropout_p=_sf(config.dropout_p),
+              softmax_scale=_sf(config.softmax_scale),
+              is_causal=config.is_causal,
+              wl=_si(config.wl), wr=_si(config.wr),
+              return_lse=config.return_lse,
+              return_randval=config.return_randval,
+              use_asm_v3=config.use_asm_v3,
+              how_v3_bf16_cvt=_si(config.how_v3_bf16_cvt),
+              max_seqlen_q_attr=_si(config.max_seqlen_q),
+              max_seqlen_k_attr=_si(config.max_seqlen_k),
+              min_seqlen_q=_si(config.min_seqlen_q),
+              logits_soft_cap=_sf(config.logits_soft_cap),
+              zero_tensors=config.zero_tensors)
+
+
+def _mha_bwd_raw(dout, q, k, v, out, lse, cu_sq, cu_sk,
+                 dq_ws, dk_ws, dv_ws, bias, alibi, rng, gen,
+                 config):
+
+    is_varlen = (q.ndim == 3)
+    if is_varlen:
+        total_q, hq, dq_dim = q.shape
+        _, hk, _ = k.shape
+        dv_dim = v.shape[-1]
+        total_k = k.shape[0]
+        dq_shape = (total_q, hq, dq_dim)
+        dk_shape = (total_k, hk, dq_dim)
+        dv_shape = (total_k, hk, dv_dim)
+        sd_shape = (hq, config.max_seqlen_q)
+        dbias_shape = (0,)
+    else:
+        b, sq, hq, dq_dim = q.shape
+        _, sk, hk, _ = k.shape
+        dv_dim = v.shape[-1]
+        dq_shape = (b, sq, hq, dq_dim)
+        dk_shape = (b, sk, hk, dq_dim)
+        dv_shape = (b, sk, hk, dv_dim)
+        sd_shape = (b, hq, sq)
+        dbias_shape = (b, sq, hq, sk) if (bias.size > 0) else (0,)
+    fn = _make_bwd_call(dq_shape, dk_shape, dv_shape,
+                                  sd_shape, dbias_shape, q.dtype)
+    return fn(dout, q, k, v, out, lse, cu_sq, cu_sk,
+              dq_ws, dk_ws, dv_ws, bias, alibi, rng, gen,
+              dropout_p=_sf(config.dropout_p),
+              softmax_scale=_sf(config.softmax_scale),
+              is_causal=config.is_causal,
+              wl=_si(config.wl), wr=_si(config.wr),
+              deterministic=config.deterministic,
+              use_asm_v3=config.use_asm_v3,
+              is_v3_atomic_fp32=config.is_v3_atomic_fp32,
+              how_v3_bf16_cvt=_si(config.how_v3_bf16_cvt),
+              max_seqlen_q_attr=_si(config.max_seqlen_q),
+              max_seqlen_k_attr=_si(config.max_seqlen_k),
+              zero_tensors=config.zero_tensors)
+
+
+# ---------------------------------------------------------------------------
+# custom_partitioning: forward
+# ---------------------------------------------------------------------------
+
+@partial(custom_partitioning, static_argnums=(9,))
+def _mha_fwd_partitioned(q, k, v, cu_sq, cu_skv, out_prov,
+                         bias, alibi, gen, config):
+    return _mha_fwd_raw(q, k, v, cu_sq, cu_skv, out_prov,
+                        bias, alibi, gen, config)
+
+
+def _mha_fwd_infer_sharding(config, mesh, arg_shapes, result_shapes):
+    q_spec = _get_padded_spec(arg_shapes[0])
+    is_varlen = (arg_shapes[0].ndim == 3)
+
+    out_sharding = NamedSharding(mesh, P(*q_spec))
+
+    if is_varlen:
+        lse_sh = NamedSharding(mesh, P(*((None,) * result_shapes[1].ndim)))
+    else:
+        if result_shapes[1].ndim == 3:
+            lse_sh = NamedSharding(mesh, P(q_spec[0], q_spec[2], q_spec[1]))
+        else:
+            lse_sh = NamedSharding(mesh, P(None))
+
+    p_sh = NamedSharding(mesh, P(*((None,) * result_shapes[2].ndim)))
+    rng_sh = NamedSharding(mesh, P(*((None,) * result_shapes[3].ndim)))
+    return (out_sharding, lse_sh, p_sh, rng_sh)
+
+
+def _mha_fwd_partition(config, mesh, arg_shapes, result_shapes):
+    out_shardings = _mha_fwd_infer_sharding(config, mesh,
+                                            arg_shapes, result_shapes)
+    q_spec = _get_padded_spec(arg_shapes[0])
+    cp_axis = config.cp_axis
+    cp_active = cp_axis and config.cp_size > 1
+
+    shardings = []
+    for i, a in enumerate(arg_shapes):
+        if a.shape[0] == 0:
+            shardings.append(NamedSharding(mesh, P(*((None,) * a.ndim))))
+        elif i == 6 and a.ndim == 2:
+            shardings.append(NamedSharding(mesh, P(q_spec[1], None)))
+        elif cp_active and i in (1, 2) and a.ndim == 4:
+            s = _get_padded_spec(a)
+            shardings.append(NamedSharding(mesh, P(s[0], None, s[2], s[3])))
+        else:
+            shardings.append(a.sharding)
+    arg_shardings = tuple(shardings)
+
+    def _lowered(q, k, v, cu_sq, cu_skv, out_prov, bias, alibi, gen):
+        return _mha_fwd_raw(q, k, v, cu_sq, cu_skv, out_prov,
+                            bias, alibi, gen, config)
+
+    return mesh, _lowered, out_shardings, arg_shardings
+
+
+def _mha_fwd_shardy_rule(config, mesh, in_types, out_types):
+    """Shardy sharding rule: batch dims passthrough, rest placeholders."""
+    is_4d = (_get_rank(in_types[0]) == 4)
+    if is_4d:
+        q_spec = ("…0", "sq", "hq", "dq")
+        k_spec = ("…0", "sk", "hk", "dq")
+        v_spec = ("…0", "sk", "hk", "dv")
+    else:
+        q_spec = ("…0", "hq", "dq")
+        k_spec = ("…1", "hk", "dq")
+        v_spec = ("…1", "hk", "dv")
+    in_spec: list[ArrayMapping] = [
+        ArrayMapping(*q_spec),
+        ArrayMapping(*k_spec),
+        ArrayMapping(*v_spec),
+    ]
+    fid = 10
+    for i in range(3, len(in_types)):
+        if i == 6 and _get_rank(in_types[i]) == 2:
+            in_spec.append(ArrayMapping("sq", "sk"))
+        else:
+            in_spec.append(ArrayMapping(f"…{fid}"))
+            fid += 1
+
+    out_spec: list[ArrayMapping] = []
+    if is_4d:
+        out_spec.append(ArrayMapping("…0", "sq", "hq", "dv"))
+        if _get_rank(out_types[1]) == 3:
+            out_spec.append(ArrayMapping("…0", "hq", "sq"))
+        else:
+            out_spec.append(ArrayMapping(f"…{fid}"))
+    else:
+        out_spec.append(ArrayMapping("…0", "hq", "dv"))
+        out_spec.append(ArrayMapping(f"…{fid}"))
+    fid += 1
+    for j in range(2, len(out_types)):
+        out_spec.append(ArrayMapping(f"…{fid}"))
+        fid += 1
+    return SdyShardingRule(tuple(in_spec), tuple(out_spec))
+
+
+_mha_fwd_partitioned.def_partition(
+    _mha_fwd_partition,
+    infer_sharding_from_operands=_mha_fwd_infer_sharding,
+    sharding_rule=_mha_fwd_shardy_rule,
+)
+
+
+# ---------------------------------------------------------------------------
+# custom_partitioning: backward
+# ---------------------------------------------------------------------------
+
+@partial(custom_partitioning, static_argnums=(15,))
+def _mha_bwd_partitioned(dout, q, k, v, out, lse, cu_sq, cu_sk,
+                         dq_ws, dk_ws, dv_ws, bias, alibi, rng, gen,
+                         config):
+    return _mha_bwd_raw(dout, q, k, v, out, lse, cu_sq, cu_sk,
+                        dq_ws, dk_ws, dv_ws, bias, alibi, rng, gen,
+                        config)
+
+
+def _mha_bwd_infer_sharding(config, mesh, arg_shapes, result_shapes):
+    q_spec = _get_padded_spec(arg_shapes[1])
+    k_spec = _get_padded_spec(arg_shapes[2])
+    v_spec = _get_padded_spec(arg_shapes[3])
+
+    dq_sh = NamedSharding(mesh, P(*q_spec))
+    dk_sh = NamedSharding(mesh, P(*k_spec))
+    dv_sh = NamedSharding(mesh, P(*v_spec))
+    sd_sh = NamedSharding(mesh, P(*((None,) * result_shapes[3].ndim)))
+    dbias_sh = NamedSharding(mesh, P(*((None,) * result_shapes[4].ndim)))
+
+    if result_shapes[3].ndim == 3:
+        sd_sh = NamedSharding(mesh, P(q_spec[0], q_spec[2], q_spec[1]))
+    if result_shapes[4].ndim == 4:
+        dbias_sh = NamedSharding(mesh, P(q_spec[0], q_spec[1], q_spec[2], None))
+
+    return (dq_sh, dk_sh, dv_sh, sd_sh, dbias_sh)
+
+
+def _mha_bwd_partition(config, mesh, arg_shapes, result_shapes):
+    out_shardings = _mha_bwd_infer_sharding(config, mesh,
+                                            arg_shapes, result_shapes)
+    q_spec = _get_padded_spec(arg_shapes[1])
+    cp_axis = config.cp_axis
+    cp_active = cp_axis and config.cp_size > 1
+
+    shardings = []
+    for i, a in enumerate(arg_shapes):
+        if a.shape[0] == 0:
+            shardings.append(NamedSharding(mesh, P(*((None,) * a.ndim))))
+        elif i == 11 and a.ndim == 2:
+            shardings.append(NamedSharding(mesh, P(q_spec[1], None)))
+        elif cp_active and i in (2, 3) and a.ndim == 4:
+            s = _get_padded_spec(a)
+            shardings.append(NamedSharding(mesh, P(s[0], None, s[2], s[3])))
+        else:
+            shardings.append(a.sharding)
+    arg_shardings = tuple(shardings)
+
+    def _lowered(dout, q, k, v, out, lse, cu_sq, cu_sk,
+                 dq_ws, dk_ws, dv_ws, bias, alibi, rng, gen):
+        return _mha_bwd_raw(dout, q, k, v, out, lse, cu_sq, cu_sk,
+                            dq_ws, dk_ws, dv_ws, bias, alibi, rng, gen,
+                            config)
+
+    return mesh, _lowered, out_shardings, arg_shardings
+
+
+def _mha_bwd_shardy_rule(config, mesh, in_types, out_types):
+    """Shardy sharding rule for backward: all independent placeholders."""
+    fid = 0
+    in_spec: list[ArrayMapping] = []
+    for i in range(len(in_types)):
+        in_spec.append(ArrayMapping(f"…{fid}"))
+        fid += 1
+    out_spec: list[ArrayMapping] = []
+    for i in range(len(out_types)):
+        out_spec.append(ArrayMapping(f"…{fid}"))
+        fid += 1
+    return SdyShardingRule(tuple(in_spec), tuple(out_spec))
+
+
+_mha_bwd_partitioned.def_partition(
+    _mha_bwd_partition,
+    infer_sharding_from_operands=_mha_bwd_infer_sharding,
+    sharding_rule=_mha_bwd_shardy_rule,
+)
+
+
+# ---------------------------------------------------------------------------
+# Forward: single call to aiter::mha_fwd (AITER handles CK vs ASM)
+# ---------------------------------------------------------------------------
+
+def mha_fwd_unified(q, k, v, dropout_p, softmax_scale, causal,
+                    wl, wr, return_lse, return_softmax,
+                    bias=None, alibi_slopes=None,
+                    cu_seqlens_q=None, cu_seqlens_kv=None, gen=None,
+                    max_seqlen_q=-1, max_seqlen_k=-1, min_seqlen_q=0,
+                    logits_soft_cap=0.0, zero_tensors=False,
+                    cp_axis=None, cp_size=1, cp_load_balanced=True):
+    """Unified forward for both batch (4D q) and varlen (3D q)."""
+    if cu_seqlens_q is None:
+        cu_seqlens_q = _empty(jnp.int32)
+    if cu_seqlens_kv is None:
+        cu_seqlens_kv = _empty(jnp.int32)
+    if bias is None:
+        bias = _empty(q.dtype)
+    if alibi_slopes is None:
+        alibi_slopes = _empty(jnp.float32)
+    if gen is None:
+        gen = _empty(jnp.int64)
+
+    bf16_cvt = 0 if get_gfx() == "gfx950" else 1
+    dq = q.shape[-1]
+    use_v3_fwd = not (get_gfx() == "gfx950" and dq >= 96)
+
+    config = MhaFwdConfig(
+        dropout_p=float(dropout_p),
+        softmax_scale=float(softmax_scale),
+        is_causal=causal,
+        wl=int(wl), wr=int(wr),
+        return_lse=return_lse,
+        return_randval=bool(return_softmax and dropout_p > 0),
+        use_asm_v3=use_v3_fwd,
+        how_v3_bf16_cvt=int(bf16_cvt),
+        max_seqlen_q=int(max_seqlen_q),
+        max_seqlen_k=int(max_seqlen_k),
+        min_seqlen_q=int(min_seqlen_q),
+        logits_soft_cap=float(logits_soft_cap),
+        zero_tensors=zero_tensors,
+        cp_axis=cp_axis,
+        cp_size=int(cp_size) if cp_size else 1,
+        cp_load_balanced=cp_load_balanced,
+    )
+    return _mha_fwd_partitioned(q, k, v, cu_seqlens_q, cu_seqlens_kv,
+                                _empty(q.dtype), bias, alibi_slopes, gen,
+                                config)
+
+
+def mha_bwd_unified(dout, q, k, v, out, lse, dropout_p, softmax_scale,
+                    causal, wl, wr, deterministic,
+                    use_asm_v3, is_v3_atomic_fp32, how_v3_bf16_cvt,
+                    bias=None, alibi_slopes=None, rng_state=None,
+                    cu_seqlens_q=None, cu_seqlens_k=None,
+                    max_seqlen_q=-1, max_seqlen_k=-1, zero_tensors=False,
+                    cp_axis=None, cp_size=1, cp_load_balanced=True):
+    """Unified backward for both batch (4D q) and varlen (3D q)."""
+    if cu_seqlens_q is None:
+        cu_seqlens_q = _empty(jnp.int32)
+    if cu_seqlens_k is None:
+        cu_seqlens_k = _empty(jnp.int32)
+    if bias is None:
+        bias = _empty(q.dtype)
+    if alibi_slopes is None:
+        alibi_slopes = _empty(jnp.float32)
+    if rng_state is None:
+        rng_state = _empty(jnp.int64)
+
+    config = MhaBwdConfig(
+        dropout_p=float(dropout_p),
+        softmax_scale=float(softmax_scale),
+        is_causal=causal,
+        wl=int(wl), wr=int(wr),
+        deterministic=deterministic,
+        use_asm_v3=use_asm_v3,
+        is_v3_atomic_fp32=is_v3_atomic_fp32,
+        how_v3_bf16_cvt=int(how_v3_bf16_cvt),
+        max_seqlen_q=int(max_seqlen_q),
+        max_seqlen_k=int(max_seqlen_k),
+        zero_tensors=zero_tensors,
+        cp_axis=cp_axis,
+        cp_size=int(cp_size) if cp_size else 1,
+        cp_load_balanced=cp_load_balanced,
+    )
+    results = _mha_bwd_partitioned(
+        dout, q, k, v, out, lse, cu_seqlens_q, cu_seqlens_k,
+        _empty(q.dtype), _empty(q.dtype), _empty(q.dtype),
+        bias, alibi_slopes, rng_state, _empty(jnp.int64),
+        config)
+
+    dq_out, dk_out, dv_out, sd_out, dbias_expanded = results
+    is_varlen = (q.ndim == 3)
+    if not is_varlen and bias.size > 0:
+        dbias_out = jnp.sum(dbias_expanded, axis=(0, 2))
+    else:
+        dbias_out = dbias_expanded
+    return [dq_out, dk_out, dv_out, sd_out, dbias_out]
+
+
+# ---------------------------------------------------------------------------
+# Simplified forward/backward dispatch (no can_impl_* logic)
+# ---------------------------------------------------------------------------
+
+def _flash_attn_forward(q, k, v, dropout_p, softmax_scale, causal,
+                        wl, wr, bias, alibi_slopes,
+                        return_lse, return_softmax,
+                        cu_seqlens_q=None, cu_seqlens_kv=None):
+    _, sk, _, _ = v.shape
+    if wl >= sk: wl = -1
+    if wr >= sk: wr = -1
+
+    result = mha_fwd_unified(
+        q, k, v, dropout_p, softmax_scale, causal, wl, wr,
+        return_lse, return_softmax,
+        bias=bias, alibi_slopes=alibi_slopes,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_kv=cu_seqlens_kv)
+    return result
+
+
+def _flash_attn_backward(dout, q, k, v, out, lse,
+                         dropout_p, softmax_scale, causal, wl, wr,
+                         bias, alibi_slopes, deterministic,
+                         rng_state=None):
+    _, sq, hq, dq = q.shape
+    _, sk, hk, _ = k.shape
+
+    bf16_cvt = 0 if get_gfx() == "gfx950" else 1
+
+    # v3 eligibility: exclude known-broken configs.
+    swa = (wl > 0) or (wr >= 0 and wr != -1)
+    use_v3 = True
+    if dropout_p > 0:
+        use_v3 = False
+    if hq != hk:
+        use_v3 = False
+    if bias is not None and bias.size > 0:
+        use_v3 = False
+    if swa:
+        use_v3 = False
+    if causal and get_gfx() == "gfx950" and sq > sk:
+        use_v3 = False
+    if get_gfx() == "gfx950" and dq >= 96:
+        use_v3 = False
+
+    # gfx950 1-block override: sk<=256 with hd in (64,128]
+    is_950_1block = (
+        get_gfx() == "gfx950" and sk <= 256
+        and dq > 64 and dq <= 128 and dq % 8 == 0
+    )
+    bwd_det = False if is_950_1block else deterministic
+    use_v3_bwd = False if is_950_1block else use_v3
+    bwd_atomic = False if is_950_1block else use_v3_bwd
+
+    results = mha_bwd_unified(
+        dout, q, k, v, out, lse,
+        dropout_p, softmax_scale, causal, wl, wr,
+        bwd_det, use_v3_bwd, bwd_atomic, bf16_cvt,
+        bias=bias, alibi_slopes=alibi_slopes, rng_state=rng_state)
+
+    return results[0], results[1], results[2], results[3], results[4]
+
+
+# ---------------------------------------------------------------------------
+# Public API: flash_attn_func with custom_vjp
+# ---------------------------------------------------------------------------
+
+@partial(jax.custom_vjp, nondiff_argnums=(3, 4, 5, 6, 9, 10, 11, 12, 13))
+def flash_attn_func(
+    q: jnp.ndarray,
+    k: jnp.ndarray,
+    v: jnp.ndarray,
+    dropout_p: float = 0.0,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    window_size: tuple[int, int] = (-1, -1),
+    bias: Optional[jnp.ndarray] = None,
+    alibi_slopes: Optional[jnp.ndarray] = None,
+    deterministic: bool = True,
+    return_lse: bool = False,
+    return_attn_probs: bool = False,
+    cu_seqlens_q: Optional[jnp.ndarray] = None,
+    cu_seqlens_kv: Optional[jnp.ndarray] = None,
+) -> tuple[jnp.ndarray, ...]:
+    """Flash attention with automatic CK/ASM v3 dispatch via AITER.
+
+    Args:
+        q: (batch, seqlen_q, nheads, headdim_q)
+        k: (batch, seqlen_k, nheads_k, headdim_q)
+        v: (batch, seqlen_k, nheads_k, headdim_v)
+        dropout_p: Dropout probability (0.0 during eval).
+        softmax_scale: Scaling factor (default: 1/sqrt(headdim_q)).
+        causal: Apply causal mask (bottom-right aligned).
+        window_size: (left, right) for sliding window attention.
+        bias: (seqlen_q, seqlen_k) attention bias.
+        alibi_slopes: (nheads,) or (batch, nheads) ALiBi slopes.
+        deterministic: Use deterministic backward (slower, more memory).
+        return_lse: Return log-sum-exp values.
+        return_attn_probs: Return attention probabilities (testing only).
+    Returns:
+        out: (batch, seqlen_q, nheads, headdim_v), or tuple if return_lse/return_attn_probs.
+    """
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** (-0.5)
+
+    hd_q_og = q.shape[3]
+    hd_v_og = v.shape[3]
+
+    q_p, k_p, v_p = q, k, v
+    if hd_q_og % 8 != 0:
+        pad = 8 - hd_q_og % 8
+        q_p = jnp.pad(q, ((0, 0), (0, 0), (0, 0), (0, pad)))
+        k_p = jnp.pad(k, ((0, 0), (0, 0), (0, 0), (0, pad)))
+    if hd_v_og % 8 != 0:
+        pad = 8 - hd_v_og % 8
+        v_p = jnp.pad(v, ((0, 0), (0, 0), (0, 0), (0, pad)))
+
+    sk = k_p.shape[1]
+    wl = -1 if window_size[0] >= sk else window_size[0]
+    wr = -1 if window_size[1] >= sk else window_size[1]
+
+    out_p, lse, s_dmask, _ = _flash_attn_forward(
+        q_p, k_p, v_p, dropout_p, softmax_scale,
+        causal=causal, wl=wl, wr=wr,
+        bias=bias, alibi_slopes=alibi_slopes,
+        return_lse=return_lse,
+        return_softmax=return_attn_probs and dropout_p > 0,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_kv=cu_seqlens_kv)
+
+    out = out_p[..., :hd_v_og]
+    result = [out]
+    if return_lse:
+        result.append(lse)
+    if return_attn_probs:
+        result.append(s_dmask)
+    return tuple(result)
+
+
+def _flash_attn_func_fwd(q, k, v,
+                         dropout_p=0.0, softmax_scale=None, causal=False,
+                         window_size=(-1, -1), bias=None, alibi_slopes=None,
+                         deterministic=True, return_lse=False,
+                         return_attn_probs=False,
+                         cu_seqlens_q=None, cu_seqlens_kv=None):
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** (-0.5)
+
+    hd_q_og = q.shape[3]
+    hd_v_og = v.shape[3]
+
+    q_p, k_p, v_p = q, k, v
+    if hd_q_og % 8 != 0:
+        pad = 8 - hd_q_og % 8
+        q_p = jnp.pad(q, ((0, 0), (0, 0), (0, 0), (0, pad)))
+        k_p = jnp.pad(k, ((0, 0), (0, 0), (0, 0), (0, pad)))
+    if hd_v_og % 8 != 0:
+        pad = 8 - hd_v_og % 8
+        v_p = jnp.pad(v, ((0, 0), (0, 0), (0, 0), (0, pad)))
+
+    sk = k_p.shape[1]
+    wl = -1 if window_size[0] >= sk else window_size[0]
+    wr = -1 if window_size[1] >= sk else window_size[1]
+
+    out_p, lse, s_dmask, rng_state = _flash_attn_forward(
+        q_p, k_p, v_p, dropout_p, softmax_scale,
+        causal=causal, wl=wl, wr=wr,
+        bias=bias, alibi_slopes=alibi_slopes,
+        return_lse=True, return_softmax=return_attn_probs and dropout_p > 0,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_kv=cu_seqlens_kv)
+
+    out = out_p[..., :hd_v_og]
+    result = [out]
+    if return_lse:
+        result.append(lse)
+    if return_attn_probs:
+        result.append(s_dmask)
+    result = tuple(result)
+
+    residuals = (q_p, k_p, v_p, out_p, lse, rng_state,
+                 dropout_p, softmax_scale, causal, (wl, wr),
+                 bias, alibi_slopes, deterministic, hd_q_og, hd_v_og)
+    return result, residuals
+
+
+def _flash_attn_func_bwd(dropout_p, softmax_scale, causal, window_size,
+                         deterministic, return_lse, return_attn_probs,
+                         cu_seqlens_q, cu_seqlens_kv,
+                         residuals, grad_outputs):
+    (q_p, k_p, v_p, out_p, lse, rng_state,
+     res_dp, res_scale, res_causal, res_ws,
+     res_bias, res_alibi, res_det, hd_q_og, hd_v_og) = residuals
+
+    dout = grad_outputs[0] if isinstance(grad_outputs, tuple) else grad_outputs
+    if dout.shape[-1] != out_p.shape[-1]:
+        pad = out_p.shape[-1] - dout.shape[-1]
+        dout = jnp.pad(dout, ((0, 0), (0, 0), (0, 0), (0, pad)))
+
+    dq_p, dk_p, dv_p, _, dbias = _flash_attn_backward(
+        dout, q_p, k_p, v_p, out_p, lse,
+        res_dp, res_scale, res_causal, res_ws[0], res_ws[1],
+        res_bias, res_alibi, res_det, rng_state)
+
+    dq = dq_p[..., :hd_q_og]
+    dk = dk_p[..., :hd_q_og]
+    dv = dv_p[..., :hd_v_og]
+
+    return (dq, dk, dv, dbias, None)
+
+
+flash_attn_func.defvjp(_flash_attn_func_fwd, _flash_attn_func_bwd)
+
+
+# ---------------------------------------------------------------------------
+# Varlen public API: flash_attn_varlen with custom_vjp
+# ---------------------------------------------------------------------------
+
+@partial(jax.custom_vjp, nondiff_argnums=(5, 6, 7, 8, 9, 10, 11, 12))
+def flash_attn_varlen(
+    q: jnp.ndarray,              # [total_q, nheads, headdim]
+    k: jnp.ndarray,              # [total_k, nheads_k, headdim]
+    v: jnp.ndarray,              # [total_k, nheads_k, headdim_v]
+    cu_seqlens_q: jnp.ndarray,   # [batch_size + 1]
+    cu_seqlens_k: jnp.ndarray,   # [batch_size + 1]
+    max_seqlen_q: int = 0,
+    max_seqlen_k: int = 0,
+    dropout_p: float = 0.0,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    window_size: tuple[int, int] = (-1, -1),
+    deterministic: bool = False,
+    return_lse: bool = False,
+) -> tuple[jnp.ndarray, ...]:
+    """Variable-length flash attention using packed sequences.
+
+    Args:
+        q: [total_q, nheads, headdim] packed query tokens.
+        k: [total_k, nheads_k, headdim] packed key tokens.
+        v: [total_k, nheads_k, headdim_v] packed value tokens.
+        cu_seqlens_q: [batch_size+1] cumulative sequence lengths for Q.
+        cu_seqlens_k: [batch_size+1] cumulative sequence lengths for K.
+        max_seqlen_q: Maximum query sequence length.
+        max_seqlen_k: Maximum key sequence length.
+    Returns:
+        out: [total_q, nheads, headdim_v].
+    """
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** (-0.5)
+
+    hd_q_og = q.shape[-1]
+    hd_v_og = v.shape[-1]
+
+    q_p, k_p, v_p = q, k, v
+    if hd_q_og % 8 != 0:
+        pad = 8 - hd_q_og % 8
+        q_p = jnp.pad(q, ((0, 0), (0, 0), (0, pad)))
+        k_p = jnp.pad(k, ((0, 0), (0, 0), (0, pad)))
+    if hd_v_og % 8 != 0:
+        pad = 8 - hd_v_og % 8
+        v_p = jnp.pad(v, ((0, 0), (0, 0), (0, pad)))
+
+    wl = window_size[0]
+    wr = window_size[1]
+
+    out_p, lse, _, _ = mha_fwd_unified(
+        q_p, k_p, v_p, dropout_p, softmax_scale, causal, wl, wr,
+        return_lse=return_lse, return_softmax=False,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_kv=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q, max_seqlen_k=max_seqlen_k)
+
+    out = out_p[..., :hd_v_og]
+    if return_lse:
+        return (out, lse)
+    return (out,)
+
+
+def _flash_attn_varlen_fwd(q, k, v, cu_seqlens_q, cu_seqlens_k,
+                           max_seqlen_q, max_seqlen_k, dropout_p,
+                           softmax_scale, causal, window_size,
+                           deterministic, return_lse):
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** (-0.5)
+
+    hd_q_og = q.shape[-1]
+    hd_v_og = v.shape[-1]
+
+    q_p, k_p, v_p = q, k, v
+    if hd_q_og % 8 != 0:
+        pad = 8 - hd_q_og % 8
+        q_p = jnp.pad(q, ((0, 0), (0, 0), (0, pad)))
+        k_p = jnp.pad(k, ((0, 0), (0, 0), (0, pad)))
+    if hd_v_og % 8 != 0:
+        pad = 8 - hd_v_og % 8
+        v_p = jnp.pad(v, ((0, 0), (0, 0), (0, pad)))
+
+    wl, wr = window_size
+
+    out_p, lse, _, rng_state = mha_fwd_unified(
+        q_p, k_p, v_p, dropout_p, softmax_scale, causal, wl, wr,
+        return_lse=True, return_softmax=False,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_kv=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q, max_seqlen_k=max_seqlen_k)
+
+    out = out_p[..., :hd_v_og]
+    result = (out, lse) if return_lse else (out,)
+
+    residuals = (q_p, k_p, v_p, out_p, lse, rng_state,
+                 cu_seqlens_q, cu_seqlens_k,
+                 dropout_p, softmax_scale, causal, (wl, wr),
+                 deterministic, hd_q_og, hd_v_og,
+                 max_seqlen_q, max_seqlen_k)
+    return result, residuals
+
+
+def _flash_attn_varlen_bwd(max_seqlen_q, max_seqlen_k, dropout_p,
+                           softmax_scale, causal, window_size,
+                           deterministic, return_lse,
+                           residuals, grad_outputs):
+    (q_p, k_p, v_p, out_p, lse, rng_state,
+     cu_sq, cu_sk, res_dp, res_scale, res_causal, res_ws,
+     res_det, hd_q_og, hd_v_og,
+     res_max_sq, res_max_sk) = residuals
+
+    dout = grad_outputs[0] if isinstance(grad_outputs, tuple) else grad_outputs
+    if dout.shape[-1] != out_p.shape[-1]:
+        pad = out_p.shape[-1] - dout.shape[-1]
+        dout = jnp.pad(dout, ((0, 0), (0, 0), (0, pad)))
+
+    _, _, hq, dq = q_p.shape if q_p.ndim == 4 else (None, None, q_p.shape[1], q_p.shape[2])
+    hk = k_p.shape[1] if k_p.ndim == 3 else k_p.shape[2]
+
+    bf16_cvt = 0 if get_gfx() == "gfx950" else 1
+
+    swa = (window_size[0] > 0) or (window_size[1] >= 0 and window_size[1] != -1)
+    use_v3 = True
+    if res_dp > 0:
+        use_v3 = False
+    if hq != hk:
+        use_v3 = False
+    if swa:
+        use_v3 = False
+    if causal and get_gfx() == "gfx950" and max_seqlen_k > 256:
+        use_v3 = False
+    if get_gfx() == "gfx950" and dq >= 96:
+        use_v3 = False
+
+    bwd_atomic = use_v3
+
+    results = mha_bwd_unified(
+        dout, q_p, k_p, v_p, out_p, lse,
+        res_dp, res_scale, res_causal, res_ws[0], res_ws[1],
+        res_det, use_v3, bwd_atomic, bf16_cvt,
+        rng_state=rng_state,
+        cu_seqlens_q=cu_sq, cu_seqlens_k=cu_sk,
+        max_seqlen_q=res_max_sq, max_seqlen_k=res_max_sk)
+
+    dq = results[0][..., :hd_q_og]
+    dk = results[1][..., :hd_q_og]
+    dv = results[2][..., :hd_v_og]
+
+    return (dq, dk, dv, None, None)
+
+
+flash_attn_varlen.defvjp(_flash_attn_varlen_fwd, _flash_attn_varlen_bwd)

--- a/jax/_src/lib/__init__.py
+++ b/jax/_src/lib/__init__.py
@@ -141,6 +141,10 @@ import jaxlib.gpu_linalg as gpu_linalg  # noqa: F401
 
 import jaxlib.gpu_rnn as gpu_rnn  # noqa: F401
 import jaxlib.gpu_triton as gpu_triton  # noqa: F401
+try:
+  import jaxlib.gpu_aiter as gpu_aiter  # noqa: F401
+except Exception:
+  gpu_aiter = None  # type: ignore
 
 import jaxlib.mosaic.python.mosaic_gpu as mosaic_gpu_dialect  # noqa: F401
 

--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -103,6 +103,7 @@ pytype_library(
     name = "jaxlib_files",
     srcs = [
         "cpu_sparse.py",
+        "gpu_aiter.py",
         "gpu_common_utils.py",
         "gpu_linalg.py",
         "gpu_prng.py",

--- a/jaxlib/gpu/BUILD
+++ b/jaxlib/gpu/BUILD
@@ -32,6 +32,12 @@ package(
 )
 
 exports_files(srcs = [
+    "aiter_mha_fwd.cc",
+    "aiter_mha_bwd.cc",
+    "aiter_mha_common_utils.cc",
+    "aiter_mha_common_utils.h",
+    "aiter.cc",
+    "aiter.h",
     "blas_handle_pool.cc",
     "blas_handle_pool.h",
     "ffi_wrapper.h",

--- a/jaxlib/gpu/aiter.cc
+++ b/jaxlib/gpu/aiter.cc
@@ -1,0 +1,40 @@
+// Copyright 2026 The JAX Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include "nanobind/nanobind.h"
+#include "jaxlib/gpu/aiter.h"
+#include "jaxlib/kernel_nanobind_helpers.h"
+
+namespace jax {
+namespace JAX_GPU_NAMESPACE {
+namespace {
+
+namespace nb = nanobind;
+
+
+nb::dict Registrations() {
+  nb::dict dict;
+  dict["hip_mha_fwd_ffi"] = EncapsulateFfiHandler(aiter_mha_fwd);
+  dict["hip_mha_bwd_ffi"] = EncapsulateFfiHandler(aiter_mha_bwd);
+  return dict;
+}
+
+NB_MODULE(_aiter, m) {
+  m.def("registrations", &Registrations);
+}
+
+}  // namespace
+}  // namespace JAX_GPU_NAMESPACE
+}  // namespace jax

--- a/jaxlib/gpu/aiter.h
+++ b/jaxlib/gpu/aiter.h
@@ -1,0 +1,23 @@
+// Copyright 2026 The JAX Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef JAXLIB_GPU_AITER_MHA_H_
+#define JAXLIB_GPU_AITER_MHA_H_
+
+#include "xla/ffi/api/ffi.h"
+
+XLA_FFI_DECLARE_HANDLER_SYMBOL(aiter_mha_fwd);
+XLA_FFI_DECLARE_HANDLER_SYMBOL(aiter_mha_bwd);
+
+#endif  // JAXLIB_GPU_AITER_MHA_H_

--- a/jaxlib/gpu/aiter_mha_bwd.cc
+++ b/jaxlib/gpu/aiter_mha_bwd.cc
@@ -1,0 +1,653 @@
+// Copyright 2026 The JAX Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Unified MHA backward FFI handler for both batch and varlen modes.
+// Detects mode from tensor rank: 4D = batch [b,s,h,d], 3D = varlen [total,h,d].
+// Calls aiter::mha_bwd(args, stream) which handles CK vs ASM v3 internally.
+//
+// Multi-GPU note: AITER's fmha_v3_bwd impl_ptr_map is now protected by a
+// mutex (Xinya's fix cherry-picked onto third_party/aiter), so ASM v3
+// kernels can be used on all devices concurrently.
+
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <exception>
+#include <functional>
+#include <mutex>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "xla/ffi/api/c_api.h"
+#include "xla/ffi/api/ffi.h"
+
+#include "aiter/mha_bwd.h"
+#include "aiter_mha_common_utils.h"
+
+namespace ffi = xla::ffi;
+
+namespace {
+
+  // Persistent device-workspace cache keyed by (device, stream, slot).
+
+  enum class WsSlot : int {
+    kDqAcc = 0,
+    kDkExp = 1,
+    kDvExp = 2,
+    kDbias = 3,
+    kDummyRng = 4,
+  };
+
+  struct WsKey {
+    int dev;
+    hipStream_t stream;
+    WsSlot slot;
+    bool operator==(const WsKey &o) const noexcept {
+      return dev == o.dev && stream == o.stream && slot == o.slot;
+    }
+  };
+
+  struct WsKeyHash {
+    size_t operator()(const WsKey &k) const noexcept {
+      // boost-style hash combine; quality matters less than determinism here.
+      size_t h = std::hash<int>{}(k.dev);
+      size_t h2 = std::hash<void *>{}(reinterpret_cast<void *>(k.stream));
+      size_t h3 = std::hash<int>{}(static_cast<int>(k.slot));
+      h ^= h2 + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+      h ^= h3 + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+      return h;
+    }
+  };
+
+  struct WsEntry {
+    void *ptr = nullptr;
+    size_t cap = 0;
+  };
+
+  std::mutex &workspace_mu() {
+    static std::mutex mu;
+    return mu;
+  }
+
+  std::unordered_map<WsKey, WsEntry, WsKeyHash> &workspace_table() {
+    static std::unordered_map<WsKey, WsEntry, WsKeyHash> tbl;
+    return tbl;
+  }
+
+  ffi::Error get_workspace(WsSlot slot, int dev, hipStream_t stream,
+                           size_t bytes, bool zero, void **out_ptr) {
+    if (out_ptr == nullptr) {
+      return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                        "get_workspace: out_ptr must not be null");
+    }
+    if (bytes == 0) {
+      *out_ptr = nullptr;
+      return ffi::Error::Success();
+    }
+
+    void *ptr = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(workspace_mu());
+      auto &entry = workspace_table()[WsKey{dev, stream, slot}];
+      if (bytes > entry.cap) {
+        int prev_dev = -1;
+        hipError_t gerr = hipGetDevice(&prev_dev);
+        if (gerr != hipSuccess) {
+          return ffi::Error(ffi::ErrorCode::kInternal,
+                            std::string("hipGetDevice failed: ") +
+                                hipGetErrorString(gerr));
+        }
+        hipError_t serr = hipSetDevice(dev);
+        if (serr != hipSuccess) {
+          return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                            std::string("hipSetDevice(") +
+                                std::to_string(dev) +
+                                ") failed: " + hipGetErrorString(serr));
+        }
+        if (entry.ptr != nullptr) {
+          (void)hipFree(entry.ptr);
+          entry.ptr = nullptr;
+          entry.cap = 0;
+        }
+        hipError_t merr = hipMalloc(&entry.ptr, bytes);
+        // Restore the caller's device first so a hipMalloc failure cannot
+        // leak our temporary device switch into the rest of the handler.
+        (void)hipSetDevice(prev_dev);
+        if (merr != hipSuccess) {
+          entry.ptr = nullptr;
+          entry.cap = 0;
+          return ffi::Error(ffi::ErrorCode::kResourceExhausted,
+                            std::string("hipMalloc(") +
+                                std::to_string(bytes) +
+                                ") for workspace slot " +
+                                std::to_string(static_cast<int>(slot)) +
+                                " on dev " + std::to_string(dev) +
+                                " failed: " + hipGetErrorString(merr));
+        }
+        entry.cap = bytes;
+      }
+      ptr = entry.ptr;
+    }
+
+    if (zero) {
+      hipError_t err = hipMemsetAsync(ptr, 0, bytes, stream);
+      if (err != hipSuccess) {
+        return ffi::Error(ffi::ErrorCode::kInternal,
+                          std::string("hipMemsetAsync(") +
+                              std::to_string(bytes) +
+                              ") failed: " + hipGetErrorString(err));
+      }
+    }
+
+    *out_ptr = ptr;
+    return ffi::Error::Success();
+  }
+
+  size_t compute_dq_acc_size_unified(
+      bool is_varlen, int64_t batch_size, int64_t seqlen_q_or_total,
+      int64_t seqlen_k_or_max, int64_t num_heads, int64_t head_size,
+      bool deterministic, bool use_asm_v3, bool is_v3_atomic_fp32,
+      ffi::DataType q_dtype, std::vector<int64_t> &out_shape) {
+
+    size_t elem_sz = 4;
+
+    if (is_varlen) {
+      // Varlen: 4D layout [split, total_q, nheads, head_size]
+      if (!deterministic) {
+        out_shape = {1, seqlen_q_or_total, num_heads, head_size};
+      } else {
+        int64_t kN0 = head_size <= 128 ? 128 : 64;
+        int64_t nsplits = (seqlen_k_or_max + kN0 - 1) / kN0;
+        out_shape = {nsplits, seqlen_q_or_total, num_heads, head_size};
+      }
+    } else {
+      // Batch: 5D layout depends on path
+      if (!deterministic) {
+        if (use_asm_v3 && is_v3_atomic_fp32) {
+          out_shape = {1, batch_size, num_heads, seqlen_q_or_total, head_size};
+        } else if (use_asm_v3 && !is_v3_atomic_fp32) {
+          int64_t sq_pad = ((seqlen_q_or_total + 15) / 16) * 16;
+          int64_t pd = (head_size == 192) ? 192 : 128;
+          out_shape = {1, batch_size, num_heads, sq_pad, pd};
+          elem_sz = (q_dtype == ffi::DataType::F16 || q_dtype == ffi::DataType::BF16) ? 2 : 4;
+        } else {
+          out_shape = {1, batch_size, seqlen_q_or_total, num_heads, head_size};
+        }
+      } else {
+        int64_t kN0 = head_size <= 128 ? 128 : 64;
+        int64_t nsplits = (seqlen_k_or_max + kN0 - 1) / kN0;
+        if (use_asm_v3) {
+          out_shape = {nsplits, batch_size, num_heads, seqlen_q_or_total, head_size};
+        } else {
+          out_shape = {nsplits, batch_size, seqlen_q_or_total, num_heads, head_size};
+        }
+      }
+    }
+
+    size_t total = 1;
+    for (auto d : out_shape) total *= d;
+    return total * elem_sz;
+  } // compute_dq_acc_size_unified
+} // namespace
+
+namespace jax_aiter {
+
+ffi::Error aiter_mha_bwd_impl(
+    hipStream_t stream,
+    ffi::AnyBuffer dout, ffi::AnyBuffer q, ffi::AnyBuffer k, ffi::AnyBuffer v,
+    ffi::AnyBuffer out, ffi::AnyBuffer softmax_lse,
+    std::optional<ffi::AnyBuffer> cu_seqlens_q,
+    std::optional<ffi::AnyBuffer> cu_seqlens_k,
+    std::optional<ffi::AnyBuffer> dq, std::optional<ffi::AnyBuffer> dk,
+    std::optional<ffi::AnyBuffer> dv,
+    std::optional<ffi::AnyBuffer> bias, std::optional<ffi::AnyBuffer> alibi_slopes,
+    std::optional<ffi::AnyBuffer> rng_state, std::optional<ffi::AnyBuffer> gen,
+    ffi::Result<ffi::AnyBuffer> dq_ret, ffi::Result<ffi::AnyBuffer> dk_ret,
+    ffi::Result<ffi::AnyBuffer> dv_ret, ffi::Result<ffi::AnyBuffer> softmax_d_ret,
+    ffi::Result<ffi::AnyBuffer> dbias_ret,
+    float dropout_p, float softmax_scale, bool is_causal,
+    int window_size_left, int window_size_right, bool deterministic,
+    bool use_asm_v3, bool is_v3_atomic_fp32, int how_v3_bf16_cvt,
+    int max_seqlen_q_attr, int max_seqlen_k_attr, bool zero_tensors) {
+  try {
+
+  if (!q.untyped_data() || !k.untyped_data() || !v.untyped_data() ||
+      !out.untyped_data() || !softmax_lse.untyped_data() || !dout.untyped_data()) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument, "Required input buffer is null");
+  }
+
+  const int dev_idx = ::jax_aiter::device_from_ptr(q.untyped_data());
+  if (dev_idx < 0)
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument, "bad device from q");
+
+  HIP_CHECK(hipSetDevice(dev_idx));
+
+  auto q_dims = q.dimensions();
+  auto k_dims = k.dimensions();
+  auto v_dims = v.dimensions();
+  auto dout_dims = dout.dimensions();
+  auto out_dims = out.dimensions();
+  auto lse_dims = softmax_lse.dimensions();
+
+  const bool is_varlen = (q_dims.size() == 3);
+
+  int64_t batch_size, seqlen_q, num_heads, head_size_q;
+  int64_t seqlen_k, num_heads_k, head_size_v;
+  int64_t max_sq, max_sk;
+
+  if (is_varlen) {
+    seqlen_q = q_dims[0]; // total_q
+    num_heads = q_dims[1];
+    head_size_q = q_dims[2];
+    seqlen_k = k_dims[0]; // total_k
+    num_heads_k = k_dims[1];
+    head_size_v = v_dims[2];
+    if (!cu_seqlens_q.has_value() || !mha_utils::is_valid_buffer(*cu_seqlens_q))
+      return ffi::Error(ffi::ErrorCode::kInvalidArgument, "varlen requires cu_seqlens_q");
+    batch_size = cu_seqlens_q->dimensions()[0] - 1;
+    max_sq = max_seqlen_q_attr;
+    max_sk = max_seqlen_k_attr;
+  } else {
+    batch_size = q_dims[0];
+    seqlen_q = q_dims[1];
+    num_heads = q_dims[2];
+    head_size_q = q_dims[3];
+    seqlen_k = k_dims[1];
+    num_heads_k = k_dims[2];
+    head_size_v = v_dims[3];
+    max_sq = seqlen_q;
+    max_sk = seqlen_k;
+  }
+
+  auto q_dtype = q.element_type();
+  if (q_dtype != ffi::DataType::F16 && q_dtype != ffi::DataType::BF16) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                      "FlashAttention backward only supports fp16 and bf16");
+  }
+  if (k.element_type() != q_dtype || v.element_type() != q_dtype ||
+      out.element_type() != q_dtype || dout.element_type() != q_dtype) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                      "Q, K, V, OUT, DOUT must have the same dtype");
+  }
+
+  if (max_sq == 0) {
+    if (dq_ret->size_bytes() > 0)
+      HIP_CHECK(hipMemsetAsync(dq_ret->untyped_data(), 0, dq_ret->size_bytes(), stream));
+    if (dk_ret->size_bytes() > 0)
+      HIP_CHECK(hipMemsetAsync(dk_ret->untyped_data(), 0, dk_ret->size_bytes(), stream));
+    if (dv_ret->size_bytes() > 0)
+      HIP_CHECK(hipMemsetAsync(dv_ret->untyped_data(), 0, dv_ret->size_bytes(), stream));
+    if (softmax_d_ret->size_bytes() > 0)
+      HIP_CHECK(hipMemsetAsync(softmax_d_ret->untyped_data(), 0, softmax_d_ret->size_bytes(), stream));
+    if (dbias_ret->size_bytes() > 0)
+      HIP_CHECK(hipMemsetAsync(dbias_ret->untyped_data(), 0, dbias_ret->size_bytes(), stream));
+    return ffi::Error::Success();
+  }
+
+  if (!(dropout_p >= 0.0f && dropout_p < 1.0f)) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                      "dropout_p must be in [0, 1)");
+  }
+  if (num_heads % num_heads_k != 0)
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument, "num_heads_q must be divisible by num_heads_k");
+
+  bool is_mqa_gqa = (num_heads != num_heads_k);
+  std::string dtype_str(mha_utils::dtype_to_string(q_dtype));
+
+  int ref_sk = is_varlen ? max_sk : seqlen_k;
+  if (window_size_left >= ref_sk) window_size_left = -1;
+  if (window_size_right >= ref_sk) window_size_right = -1;
+  int ref_sq = is_varlen ? max_sq : seqlen_q;
+
+  auto mask = mha_utils::create_mask_info(is_causal, window_size_left, window_size_right, ref_sq, ref_sk);
+
+  // Bias handling
+  const void *bias_ptr = nullptr;
+  ck_tile::index_t stride_bias = 0;
+  bool has_bias = bias.has_value() && mha_utils::is_valid_buffer(*bias);
+  bool has_alibi = alibi_slopes.has_value() && mha_utils::is_valid_buffer(*alibi_slopes);
+
+  if (has_bias) {
+    bias_ptr = bias->untyped_data();
+    auto bd = bias->dimensions();
+    stride_bias = bd.size() >= 2 ? mha_utils::calculate_stride(bd, 0) : 0;
+  } else if (has_alibi) {
+    bias_ptr = alibi_slopes->untyped_data();
+    auto ad = alibi_slopes->dimensions();
+    stride_bias = ad.size() >= 2 ? mha_utils::calculate_stride(ad, 0) : 0;
+  }
+  bias_enum bias_type = mha_utils::get_bias_type(has_bias, has_alibi);
+
+  bool has_dbias = has_bias && (dbias_ret->size_bytes() > 0) && !is_varlen;
+  void *dbias_expanded_ptr = nullptr;
+  ck_tile::index_t stride_dbias = 0, nhead_stride_dbias = 0, batch_stride_dbias = 0;
+
+  if (has_dbias) {
+    size_t dbias_sz = batch_size * seqlen_q * num_heads * seqlen_k * mha_utils::dtype_size(q.element_type());
+    if (auto err = get_workspace(WsSlot::kDbias, dev_idx, stream, dbias_sz,
+                                 /*zero=*/true, &dbias_expanded_ptr);
+        !err.success())
+      return err;
+    stride_dbias = num_heads * seqlen_k;
+    nhead_stride_dbias = seqlen_k;
+    batch_stride_dbias = seqlen_q * num_heads * seqlen_k;
+  }
+
+  // RNG — use void* to avoid forming uint64_t* from untyped storage.
+  void *seed_ptr = nullptr, *offset_ptr = nullptr;
+  if (dropout_p > 0.0f) {
+    if (!rng_state.has_value() || !mha_utils::is_valid_buffer(*rng_state))
+      return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                        "rng_state must be a valid buffer when dropout_p > 0");
+    auto [s, o] = mha_utils::get_rng_seed_offset_ptrs(rng_state, dropout_p);
+    seed_ptr = s; offset_ptr = o;
+  } else {
+    void *dummy_rng = nullptr;
+    if (auto err = get_workspace(WsSlot::kDummyRng, dev_idx, stream,
+                                 2 * sizeof(uint64_t), /*zero=*/false,
+                                 &dummy_rng);
+        !err.success())
+      return err;
+    seed_ptr = dummy_rng;
+    offset_ptr = static_cast<char *>(dummy_rng) + sizeof(uint64_t);
+  }
+
+  // dq_acc
+  std::vector<int64_t> dq_acc_shape;
+  size_t dq_acc_bytes = compute_dq_acc_size_unified(
+      is_varlen, batch_size, seqlen_q, is_varlen ? max_sk : seqlen_k,
+      num_heads, head_size_q, deterministic, use_asm_v3, is_v3_atomic_fp32,
+      q.element_type(), dq_acc_shape);
+
+  void *dq_acc_ptr = nullptr;
+  if (auto err = get_workspace(WsSlot::kDqAcc, dev_idx, stream, dq_acc_bytes,
+                               /*zero=*/true, &dq_acc_ptr);
+      !err.success())
+    return err;
+
+  // dq_acc strides
+  ck_tile::index_t split_stride_dq_acc = 1, batch_stride_dq_acc = 0;
+  ck_tile::index_t nhead_stride_dq_acc = 1, stride_dq_acc = 1;
+
+  int rank = dq_acc_shape.size();
+  if (rank >= 4) {
+    std::vector<ck_tile::index_t> strides(rank);
+    strides[rank - 1] = 1;
+    for (int i = rank - 2; i >= 0; i--)
+      strides[i] = strides[i + 1] * dq_acc_shape[i + 1];
+
+    split_stride_dq_acc = strides[0];
+    if (is_varlen) {
+      // [split, total_q, nheads, head] → strides[1]=total_q stride, strides[2]=nhead stride
+      stride_dq_acc = strides[1];
+      nhead_stride_dq_acc = strides[2];
+    } else {
+      batch_stride_dq_acc = strides[1];
+      if (use_asm_v3) {
+        // ASM v3: [split, batch, nheads, seqlen_q, head]
+        nhead_stride_dq_acc = strides[2];
+        stride_dq_acc = strides[3];
+      } else {
+        // CK: [split, batch, seqlen_q, nheads, head]
+        stride_dq_acc = strides[2];
+        nhead_stride_dq_acc = strides[3];
+      }
+    }
+  }
+
+  // MQA/GQA expansion
+  auto dq_dims = dq_ret->dimensions();
+  auto dk_dims = dk_ret->dimensions();
+  auto dv_dims = dv_ret->dimensions();
+
+  void *dk_expanded_ptr = nullptr, *dv_expanded_ptr = nullptr;
+  void *dk_final = dk_ret->untyped_data(), *dv_final = dv_ret->untyped_data();
+
+  if (is_mqa_gqa) {
+    size_t dk_sz = (is_varlen ? seqlen_k : batch_size * seqlen_k) * num_heads * head_size_q * mha_utils::dtype_size(q.element_type());
+    size_t dv_sz = (is_varlen ? seqlen_k : batch_size * seqlen_k) * num_heads * head_size_v * mha_utils::dtype_size(v.element_type());
+    if (auto err = get_workspace(WsSlot::kDkExp, dev_idx, stream, dk_sz,
+                                 /*zero=*/true, &dk_expanded_ptr);
+        !err.success())
+      return err;
+    if (auto err = get_workspace(WsSlot::kDvExp, dev_idx, stream, dv_sz,
+                                 /*zero=*/true, &dv_expanded_ptr);
+        !err.success())
+      return err;
+    dk_final = dk_expanded_ptr; dv_final = dv_expanded_ptr;
+  }
+
+  // Zero tensors (varlen)
+  if (zero_tensors) {
+    HIP_CHECK(hipMemsetAsync(dq_ret->untyped_data(), 0, dq_ret->size_bytes(), stream));
+    HIP_CHECK(hipMemsetAsync(dk_final, 0, is_mqa_gqa ? ((is_varlen ? seqlen_k : batch_size * seqlen_k) * num_heads * head_size_q * mha_utils::dtype_size(q.element_type())) : dk_ret->size_bytes(), stream));
+    HIP_CHECK(hipMemsetAsync(dv_final, 0, is_mqa_gqa ? ((is_varlen ? seqlen_k : batch_size * seqlen_k) * num_heads * head_size_v * mha_utils::dtype_size(v.element_type())) : dv_ret->size_bytes(), stream));
+    HIP_CHECK(hipMemsetAsync(softmax_d_ret->untyped_data(), 0, softmax_d_ret->size_bytes(), stream));
+  }
+
+  float p_undrop = mha_utils::calculate_p_undrop(dropout_p);
+
+  // Strides based on rank
+  ck_tile::index_t stride_q, stride_k, stride_v, stride_o, stride_do, stride_dq, stride_dk, stride_dv;
+  ck_tile::index_t nhs_q, nhs_k, nhs_v, nhs_o, nhs_do, nhs_lse, nhs_dq, nhs_dk, nhs_dv;
+  ck_tile::index_t bs_q = 0, bs_k = 0, bs_v = 0, bs_o = 0, bs_do = 0, bs_lse = 0, bs_dq = 0, bs_dk = 0, bs_dv = 0;
+
+  if (is_varlen) {
+    stride_q = mha_utils::calculate_stride(q_dims, 0);
+    stride_k = mha_utils::calculate_stride(k_dims, 0);
+    stride_v = mha_utils::calculate_stride(v_dims, 0);
+    stride_o = mha_utils::calculate_stride(out_dims, 0);
+    stride_do = mha_utils::calculate_stride(dout_dims, 0);
+    stride_dq = mha_utils::calculate_stride(dq_dims, 0);
+    stride_dk = is_mqa_gqa ? (num_heads * head_size_q) : mha_utils::calculate_stride(dk_dims, 0);
+    stride_dv = is_mqa_gqa ? (num_heads * head_size_v) : mha_utils::calculate_stride(dv_dims, 0);
+    nhs_q = mha_utils::calculate_stride(q_dims, 1);
+    nhs_k = mha_utils::calculate_stride(k_dims, 1);
+    nhs_v = mha_utils::calculate_stride(v_dims, 1);
+    nhs_o = mha_utils::calculate_stride(out_dims, 1);
+    nhs_do = mha_utils::calculate_stride(dout_dims, 1);
+    nhs_lse = mha_utils::calculate_stride(lse_dims, 0);
+    nhs_dq = mha_utils::calculate_stride(dq_dims, 1);
+    nhs_dk = is_mqa_gqa ? head_size_q : mha_utils::calculate_stride(dk_dims, 1);
+    nhs_dv = is_mqa_gqa ? head_size_v : mha_utils::calculate_stride(dv_dims, 1);
+  } else {
+    stride_q = mha_utils::calculate_stride(q_dims, 1);
+    stride_k = mha_utils::calculate_stride(k_dims, 1);
+    stride_v = mha_utils::calculate_stride(v_dims, 1);
+    stride_o = mha_utils::calculate_stride(out_dims, 1);
+    stride_do = mha_utils::calculate_stride(dout_dims, 1);
+    stride_dq = mha_utils::calculate_stride(dq_dims, 1);
+    stride_dk = is_mqa_gqa ? (num_heads * head_size_q) : mha_utils::calculate_stride(dk_dims, 1);
+    stride_dv = is_mqa_gqa ? (num_heads * head_size_v) : mha_utils::calculate_stride(dv_dims, 1);
+    nhs_q = mha_utils::calculate_stride(q_dims, 2);
+    nhs_k = mha_utils::calculate_stride(k_dims, 2);
+    nhs_v = mha_utils::calculate_stride(v_dims, 2);
+    nhs_o = mha_utils::calculate_stride(out_dims, 2);
+    nhs_do = mha_utils::calculate_stride(dout_dims, 2);
+    nhs_lse = mha_utils::calculate_stride(lse_dims, 1);
+    nhs_dq = mha_utils::calculate_stride(dq_dims, 2);
+    nhs_dk = is_mqa_gqa ? head_size_q : mha_utils::calculate_stride(dk_dims, 2);
+    nhs_dv = is_mqa_gqa ? head_size_v : mha_utils::calculate_stride(dv_dims, 2);
+    bs_q = mha_utils::calculate_stride(q_dims, 0);
+    bs_k = mha_utils::calculate_stride(k_dims, 0);
+    bs_v = mha_utils::calculate_stride(v_dims, 0);
+    bs_o = mha_utils::calculate_stride(out_dims, 0);
+    bs_do = mha_utils::calculate_stride(dout_dims, 0);
+    bs_lse = mha_utils::calculate_stride(lse_dims, 0);
+    bs_dq = mha_utils::calculate_stride(dq_dims, 0);
+    bs_dk = is_mqa_gqa ? (seqlen_k * num_heads * head_size_q) : mha_utils::calculate_stride(dk_dims, 0);
+    bs_dv = is_mqa_gqa ? (seqlen_k * num_heads * head_size_v) : mha_utils::calculate_stride(dv_dims, 0);
+  }
+
+  // Seqstart pointers
+  const void *seqstart_q_ptr = nullptr, *seqstart_k_ptr = nullptr;
+  if (is_varlen) {
+    seqstart_q_ptr = cu_seqlens_q->untyped_data();
+    if (cu_seqlens_k.has_value() && mha_utils::is_valid_buffer(*cu_seqlens_k))
+      seqstart_k_ptr = cu_seqlens_k->untyped_data();
+  }
+
+  auto args = aiter::mha_bwd_args{
+      .use_asm_v3 = use_asm_v3,
+      .v3_atomic_fp32 = is_v3_atomic_fp32,
+      .v3_bf16_cvt = how_v3_bf16_cvt,
+      .v3_api_check = false,
+      .hdim_q = static_cast<int>(head_size_q),
+      .hdim_v = static_cast<int>(head_size_v),
+      .data_type = std::move(dtype_str),
+      .is_group_mode = is_varlen,
+      .mask_type = static_cast<int>(mask.type),
+      .bias_type = static_cast<int>(bias_type),
+      .has_dbias = has_dbias,
+      .has_dropout = (dropout_p > 0.0f),
+      .is_store_randval = false,
+      .is_deterministic = deterministic,
+      .q_ptr = q.untyped_data(), .k_ptr = k.untyped_data(),
+      .v_ptr = v.untyped_data(), .bias_ptr = bias_ptr,
+      .o_ptr = out.untyped_data(), .lse_ptr = softmax_lse.untyped_data(),
+      .do_ptr = dout.untyped_data(), .d_ptr = softmax_d_ret->untyped_data(),
+      .rand_val_ptr = nullptr,
+      .dq_ptr = dq_ret->untyped_data(), .dk_ptr = dk_final, .dv_ptr = dv_final,
+      .dbias_ptr = dbias_expanded_ptr, .dq_acc_ptr = dq_acc_ptr,
+      .seqstart_q_ptr = seqstart_q_ptr, .seqstart_k_ptr = seqstart_k_ptr,
+      .seqlen_q = static_cast<int>(seqlen_q), .seqlen_k = static_cast<int>(seqlen_k),
+      .batch = static_cast<int>(batch_size),
+      .max_seqlen_q = static_cast<int>(max_sq), .max_seqlen_k = static_cast<int>(max_sk),
+      .nhead_q = static_cast<int>(num_heads), .nhead_k = static_cast<int>(num_heads_k),
+      .scale = softmax_scale,
+      .stride_q = static_cast<int>(stride_q), .stride_k = static_cast<int>(stride_k),
+      .stride_v = static_cast<int>(stride_v), .stride_bias = static_cast<int>(stride_bias),
+      .stride_o = static_cast<int>(stride_o), .stride_randval = 0,
+      .stride_do = static_cast<int>(stride_do),
+      .stride_dq_acc = static_cast<int>(stride_dq_acc),
+      .stride_dq = static_cast<int>(stride_dq), .stride_dk = static_cast<int>(stride_dk),
+      .stride_dv = static_cast<int>(stride_dv), .stride_dbias = static_cast<int>(stride_dbias),
+      .nhead_stride_q = static_cast<int>(nhs_q), .nhead_stride_k = static_cast<int>(nhs_k),
+      .nhead_stride_v = static_cast<int>(nhs_v), .nhead_stride_bias = 0,
+      .nhead_stride_o = static_cast<int>(nhs_o), .nhead_stride_randval = 0,
+      .nhead_stride_do = static_cast<int>(nhs_do),
+      .nhead_stride_lsed = static_cast<int>(nhs_lse),
+      .nhead_stride_dq_acc = static_cast<int64_t>(nhead_stride_dq_acc),
+      .nhead_stride_dq = static_cast<int>(nhs_dq),
+      .nhead_stride_dk = static_cast<int>(nhs_dk), .nhead_stride_dv = static_cast<int>(nhs_dv),
+      .nhead_stride_dbias = static_cast<int>(nhead_stride_dbias),
+      .batch_stride_q = static_cast<int>(bs_q), .batch_stride_k = static_cast<int>(bs_k),
+      .batch_stride_v = static_cast<int>(bs_v), .batch_stride_bias = 0,
+      .batch_stride_o = static_cast<int>(bs_o), .batch_stride_randval = 0,
+      .batch_stride_do = static_cast<int>(bs_do),
+      .batch_stride_lsed = static_cast<int>(bs_lse),
+      .batch_stride_dq_acc = static_cast<int64_t>(batch_stride_dq_acc),
+      .batch_stride_dq = static_cast<int>(bs_dq),
+      .batch_stride_dk = static_cast<int>(bs_dk), .batch_stride_dv = static_cast<int>(bs_dv),
+      .batch_stride_dbias = static_cast<int>(batch_stride_dbias),
+      .split_stride_dq_acc = static_cast<int>(split_stride_dq_acc),
+      .window_size_left = static_cast<int>(mask.left),
+      .window_size_right = static_cast<int>(mask.right),
+      .p_drop = dropout_p, .p_undrop = p_undrop,
+      .drop_seed_offset = std::pair<const void *, const void *>(
+          seed_ptr, offset_ptr)
+  };
+
+  // Note: hipSetDevice(dev_idx) was already called at the top of the
+  // handler so any AITER kernel loads / launches target the data device.
+
+  auto stream_config = mha_utils::create_stream_config(stream);
+  float runtime = aiter::mha_bwd(args, stream_config);
+
+  if (runtime < 0) {
+    return ffi::Error(ffi::ErrorCode::kInternal, "aiter::mha_bwd failed");
+  }
+
+  // MQA/GQA reduction
+  if (is_mqa_gqa) {
+    int64_t groups = num_heads / num_heads_k;
+    int64_t total_tokens = is_varlen ? seqlen_k : batch_size * seqlen_k;
+
+    auto dk_err = mha_utils::launch_mqa_gqa_reduction(
+        dk_expanded_ptr, dk_ret->untyped_data(),
+        is_varlen ? 1 : batch_size,
+        is_varlen ? seqlen_k : seqlen_k,
+        num_heads, num_heads_k, head_size_q, groups, q.element_type(), stream);
+    if (!dk_err.success()) return dk_err;
+    auto dv_err = mha_utils::launch_mqa_gqa_reduction(
+        dv_expanded_ptr, dv_ret->untyped_data(),
+        is_varlen ? 1 : batch_size,
+        is_varlen ? seqlen_k : seqlen_k,
+        num_heads, num_heads_k, head_size_v, groups, v.element_type(), stream);
+    if (!dv_err.success()) return dv_err;
+
+  }
+
+  if (has_dbias && dbias_expanded_ptr) {
+    size_t dbias_size = batch_size * seqlen_q * num_heads * seqlen_k * mha_utils::dtype_size(q.element_type());
+    HIP_CHECK(hipMemcpyAsync(dbias_ret->untyped_data(), dbias_expanded_ptr,
+                             dbias_size, hipMemcpyDeviceToDevice, stream));
+  }
+
+  return ffi::Error::Success();
+
+  } catch (const std::exception &e) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                      std::string("aiter_mha_bwd: ") + e.what());
+  } catch (...) {
+    return ffi::Error(ffi::ErrorCode::kInternal,
+                      "aiter_mha_bwd: unknown C++ exception");
+  }
+} // aiter_mha_bwd_impl
+
+} // namespace jax_aiter
+
+#pragma GCC visibility push(default)
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    aiter_mha_bwd, jax_aiter::aiter_mha_bwd_impl,
+    ffi::Ffi::Bind()
+        .Ctx<ffi::PlatformStream<hipStream_t>>()
+        .Arg<ffi::AnyBuffer>() // dout
+        .Arg<ffi::AnyBuffer>() // q
+        .Arg<ffi::AnyBuffer>() // k
+        .Arg<ffi::AnyBuffer>() // v
+        .Arg<ffi::AnyBuffer>() // out
+        .Arg<ffi::AnyBuffer>() // softmax_lse
+        .Arg<ffi::AnyBuffer>() // cu_seqlens_q (optional)
+        .Arg<ffi::AnyBuffer>() // cu_seqlens_k (optional)
+        .Arg<ffi::AnyBuffer>() // dq (optional)
+        .Arg<ffi::AnyBuffer>() // dk (optional)
+        .Arg<ffi::AnyBuffer>() // dv (optional)
+        .Arg<ffi::AnyBuffer>() // bias (optional)
+        .Arg<ffi::AnyBuffer>() // alibi_slopes (optional)
+        .Arg<ffi::AnyBuffer>() // rng_state (optional)
+        .Arg<ffi::AnyBuffer>() // gen (optional)
+        .Ret<ffi::AnyBuffer>() // dq_ret
+        .Ret<ffi::AnyBuffer>() // dk_ret
+        .Ret<ffi::AnyBuffer>() // dv_ret
+        .Ret<ffi::AnyBuffer>() // softmax_d_ret
+        .Ret<ffi::AnyBuffer>() // dbias_ret
+        .Attr<float>("dropout_p")
+        .Attr<float>("softmax_scale")
+        .Attr<bool>("is_causal")
+        .Attr<int>("window_size_left")
+        .Attr<int>("window_size_right")
+        .Attr<bool>("deterministic")
+        .Attr<bool>("use_asm_v3")
+        .Attr<bool>("is_v3_atomic_fp32")
+        .Attr<int>("how_v3_bf16_cvt")
+        .Attr<int>("max_seqlen_q_attr")
+        .Attr<int>("max_seqlen_k_attr")
+        .Attr<bool>("zero_tensors"),
+    {xla::ffi::Traits::kCmdBufferCompatible});
+
+#pragma GCC visibility pop

--- a/jaxlib/gpu/aiter_mha_common_utils.cc
+++ b/jaxlib/gpu/aiter_mha_common_utils.cc
@@ -1,0 +1,192 @@
+// Copyright 2025 The JAX Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "absl/log/log.h"
+#include "absl/log/vlog_is_on.h"
+#include "aiter_mha_common_utils.h"
+#include <chrono>
+#include <cstring>
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+#ifdef __HIP_PLATFORM_AMD__
+using hip_bf16_type = hip_bfloat16;
+#else
+using hip_bf16_type = __hip_bfloat16;
+#endif
+
+namespace jax_aiter {
+namespace mha_utils {
+
+template <typename T>
+__global__ void mqa_gqa_reduce_kernel(const T *__restrict__ d_expanded,
+                                      T *__restrict__ d_reduced,
+                                      int64_t batch_size, int64_t seqlen,
+                                      int64_t num_heads_q, int64_t num_heads_k,
+                                      int64_t head_dim, int64_t num_groups) {
+
+  int64_t tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t total_elements = batch_size * seqlen * num_heads_k * head_dim;
+
+  if (tid >= total_elements)
+    return;
+
+  int64_t b = tid / (seqlen * num_heads_k * head_dim);
+  int64_t remainder = tid % (seqlen * num_heads_k * head_dim);
+  int64_t s = remainder / (num_heads_k * head_dim);
+  remainder = remainder % (num_heads_k * head_dim);
+  int64_t hk = remainder / head_dim;
+  int64_t d = remainder % head_dim;
+
+  float sum = 0.0f;
+  for (int g = 0; g < num_groups; g++) {
+    int h = hk * num_groups + g;
+    int expanded_idx = b * seqlen * num_heads_q * head_dim +
+                       s * num_heads_q * head_dim + h * head_dim + d;
+    sum += static_cast<float>(d_expanded[expanded_idx]);
+  }
+
+  d_reduced[tid] = static_cast<T>(sum);
+}
+
+template __global__ void
+mqa_gqa_reduce_kernel<__half>(const __half *__restrict__, __half *__restrict__,
+                              int64_t, int64_t, int64_t, int64_t, int64_t,
+                              int64_t);
+template __global__ void mqa_gqa_reduce_kernel<hip_bf16_type>(
+    const hip_bf16_type *__restrict__, hip_bf16_type *__restrict__, int64_t,
+    int64_t, int64_t, int64_t, int64_t, int64_t);
+
+JAX_AITER_EXPORT
+xla::ffi::Error launch_mqa_gqa_reduction(const void *src, void *dst,
+                                         int64_t batch_size, int64_t seqlen_k,
+                                         int64_t num_heads_q,
+                                         int64_t num_heads_k,
+                                         int64_t head_size, int64_t groups,
+                                         xla::ffi::DataType dtype,
+                                         hipStream_t stream) {
+
+  int64_t total_elements = batch_size * seqlen_k * num_heads_k * head_size;
+  int threads = 256;
+  int blocks = (total_elements + threads - 1) / threads;
+
+  if (dtype == xla::ffi::DataType::F16) {
+    mqa_gqa_reduce_kernel<__half><<<blocks, threads, 0, stream>>>(
+        static_cast<const __half *>(src), static_cast<__half *>(dst),
+        batch_size, seqlen_k, num_heads_q, num_heads_k, head_size, groups);
+  } else if (dtype == xla::ffi::DataType::BF16) {
+    mqa_gqa_reduce_kernel<hip_bf16_type><<<blocks, threads, 0, stream>>>(
+        static_cast<const hip_bf16_type *>(src),
+        static_cast<hip_bf16_type *>(dst), batch_size, seqlen_k, num_heads_q,
+        num_heads_k, head_size, groups);
+  } else {
+    return xla::ffi::Error(
+        xla::ffi::ErrorCode::kInvalidArgument,
+        "launch_mqa_gqa_reduction: unsupported dtype " +
+            std::to_string(static_cast<int>(dtype)) + " (expected F16 or BF16)");
+  }
+
+  return xla::ffi::Error::Success();
+}
+
+JAX_AITER_EXPORT
+xla::ffi::Error
+prepare_rng_state_for_fwd(hipStream_t stream, float dropout_p, int dev_idx,
+                          int64_t batch_size, int64_t num_heads,
+                          const std::optional<xla::ffi::AnyBuffer> &gen,
+                          xla::ffi::Result<xla::ffi::AnyBuffer> &rng_state,
+                          RngStatePointers &out_ptrs) {
+
+  if (rng_state->size_bytes() < 2 * sizeof(uint64_t)) {
+    return xla::ffi::Error(
+        xla::ffi::ErrorCode::kInvalidArgument,
+        "rng_state result buffer must have at least 2 uint64s (16 bytes)");
+  }
+
+  void *rng_base = rng_state->untyped_data();
+
+  if (dropout_p > 0.0f) {
+    if (gen.has_value() && gen->size_bytes() >= 2 * sizeof(uint64_t)) {
+      // gen is a device buffer.  Issue an async D->D copy on the compute
+      // stream; do NOT do a synchronous hipMemcpy on the hot path.
+      if (VLOG_IS_ON(1)) {
+        uint64_t host_gen[2] = {0, 0};
+        hipError_t copy_err =
+            hipMemcpy(host_gen, gen->untyped_data(), 2 * sizeof(uint64_t),
+                      hipMemcpyDeviceToHost);
+        if (copy_err == hipSuccess) {
+          VLOG(1) << "[JAX_AITER_CPP] Using provided generator with seed: "
+                  << host_gen[0] << ", offset: " << host_gen[1];
+        } else {
+          VLOG(1) << "[JAX_AITER_CPP] Using provided generator (failed to "
+                     "stage seed/offset for logging: "
+                  << hipGetErrorString(copy_err) << ")";
+        }
+      }
+
+      hipError_t err = hipMemcpyAsync(
+          rng_base, gen->untyped_data(), 2 * sizeof(uint64_t),
+          hipMemcpyDeviceToDevice, stream);
+      if (err != hipSuccess) {
+        return xla::ffi::Error(
+            xla::ffi::ErrorCode::kInternal,
+            std::string("Failed to copy RNG state to device: ") +
+                hipGetErrorString(err));
+      }
+    } else {
+      auto now = std::chrono::high_resolution_clock::now();
+      auto timestamp = std::chrono::duration_cast<std::chrono::microseconds>(
+                           now.time_since_epoch())
+                           .count();
+
+      uint64_t seed_value =
+          static_cast<uint64_t>(timestamp) ^ static_cast<uint64_t>(dev_idx);
+      uint64_t offset_value = static_cast<uint64_t>(
+          batch_size * num_heads * ck_tile::get_warp_size());
+
+      VLOG(1) << "Generated RNG with seed: " << seed_value
+              << ", offset: " << offset_value << " (no gen provided)";
+
+      uint64_t host_rng[2] = {seed_value, offset_value};
+      hipError_t err =
+          hipMemcpy(rng_base, host_rng, 2 * sizeof(uint64_t),
+                         hipMemcpyHostToDevice);
+
+      if (err != hipSuccess) {
+        return xla::ffi::Error(
+            xla::ffi::ErrorCode::kInternal,
+            std::string("Failed to copy generated RNG state to device: ") +
+                hipGetErrorString(err));
+      }
+    }
+
+    out_ptrs.seed = rng_base;
+    out_ptrs.offset = static_cast<char *>(rng_base) + sizeof(uint64_t);
+  } else {
+    hipError_t err = hipMemsetAsync(rng_base, 0, 2 * sizeof(uint64_t), stream);
+    if (err != hipSuccess) {
+      VLOG(1) << "[JAX_AITER_CPP] Warning: Failed to zero RNG state: "
+              << hipGetErrorString(err);
+    }
+
+    out_ptrs.seed = rng_base;
+    out_ptrs.offset = static_cast<char *>(rng_base) + sizeof(uint64_t);
+  }
+
+  return xla::ffi::Error::Success();
+}
+
+} // namespace mha_utils
+} // namespace jax_aiter

--- a/jaxlib/gpu/aiter_mha_common_utils.h
+++ b/jaxlib/gpu/aiter_mha_common_utils.h
@@ -1,0 +1,293 @@
+// Copyright 2025 The JAX Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "absl/log/log.h"
+#include <hip/hip_runtime.h>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <sstream>
+#include <stdexcept>
+
+#include "xla/ffi/api/c_api.h"
+#include "xla/ffi/api/ffi.h"
+
+#include "ck_tile/ops/bias.hpp"
+#include "ck_tile/host.hpp"
+#include "ck_tile/ops/mask.hpp"
+
+#if defined(__GNUC__) || defined(__clang__)
+#define JAX_AITER_EXPORT __attribute__((visibility("default")))
+#else
+#define JAX_AITER_EXPORT
+#endif
+
+namespace jax_aiter {
+namespace mha_utils {
+
+inline std::string_view dtype_to_string(xla::ffi::DataType dtype) {
+  switch (dtype) {
+  case xla::ffi::DataType::F16:
+    return "fp16";
+  case xla::ffi::DataType::BF16:
+    return "bf16";
+  case xla::ffi::DataType::F32:
+    return "fp32";
+  default:
+    throw std::runtime_error("Unsupported dtype for MHA");
+  }
+}
+
+inline size_t dtype_size(xla::ffi::DataType dtype) {
+  switch (dtype) {
+  case xla::ffi::DataType::F16:
+  case xla::ffi::DataType::BF16:
+    return 2;
+  case xla::ffi::DataType::F32:
+    return 4;
+  case xla::ffi::DataType::U8:
+    return 1;
+  case xla::ffi::DataType::S32:
+    return 4;
+  case xla::ffi::DataType::S64:
+    return 8;
+  default:
+    throw std::runtime_error("Unknown xla::ffi::DataType enum: " + std::to_string(static_cast<int>(dtype)));
+  }
+}
+
+inline ck_tile::index_t
+calculate_stride(const xla::ffi::Span<const int64_t> &dims, int dim_idx) {
+  if (dim_idx >= dims.size())
+    return 0;
+  ck_tile::index_t stride = 1;
+  for (int i = dims.size() - 1; i > dim_idx; --i) {
+    stride *= dims[i];
+  }
+  return stride;
+}
+
+inline mask_info create_mask_info(bool is_causal, int window_size_left,
+                                  int window_size_right,
+                                  ck_tile::index_t seqlen_q,
+                                  ck_tile::index_t seqlen_k) {
+  mask_info mask;
+  if (is_causal) {
+    window_size_right = 0;
+    auto mask_identify = "b:" + std::to_string(window_size_left) + ",0";
+    mask = mask_info::decode(std::move(mask_identify), seqlen_q, seqlen_k);
+  } else if (window_size_left == -1 && window_size_right == -1) {
+    mask = mask_info::decode("0", seqlen_q, seqlen_k);
+  } else {
+    auto mask_identify = "b:" + std::to_string(window_size_left) + "," +
+                         std::to_string(window_size_right);
+    mask = mask_info::decode(std::move(mask_identify), seqlen_q, seqlen_k);
+  }
+  return mask;
+}
+
+inline bias_enum get_bias_type(bool has_bias, bool has_alibi) {
+  if (has_alibi)
+    return bias_enum::alibi;
+  if (has_bias)
+    return bias_enum::elementwise_bias;
+  return bias_enum::no_bias;
+}
+
+inline float calculate_p_undrop(float dropout_p) {
+  return (dropout_p > 0.0f) ? (1.0f - dropout_p) : 1.0f;
+}
+
+inline ck_tile::stream_config create_stream_config(hipStream_t stream,
+                                                   bool log_enable = false) {
+  return ck_tile::stream_config{stream, false, log_enable};
+}
+
+inline bool is_valid_buffer(const xla::ffi::AnyBuffer &buffer) {
+  return buffer.untyped_data() != nullptr && buffer.size_bytes() > 0;
+}
+
+inline void
+validate_mha_dimensions(const xla::ffi::Span<const int64_t> &q_dims,
+                        const xla::ffi::Span<const int64_t> &k_dims,
+                        const xla::ffi::Span<const int64_t> &v_dims) {
+
+  if (q_dims.size() != 4 || k_dims.size() != 4 || v_dims.size() != 4) {
+    throw std::runtime_error(
+        "Q, K, V must be 4D tensors [batch, seqlen, nheads, hdim]");
+  }
+  if (q_dims[0] != k_dims[0] || q_dims[0] != v_dims[0]) {
+    throw std::runtime_error("Batch sizes must match for Q, K, V");
+  }
+  if (q_dims[3] != k_dims[3]) {
+    throw std::runtime_error("Head dimensions must match for Q and K");
+  }
+  if (k_dims[1] != v_dims[1] || k_dims[2] != v_dims[2]) {
+    throw std::runtime_error(
+        "Sequence length and num_heads must match for K and V");
+  }
+}
+
+inline std::pair<void *, void *> get_rng_seed_offset_ptrs(
+    std::optional<xla::ffi::AnyBuffer> &rng_state_opt, float dropout_p) {
+
+  if (!(dropout_p >= 0.0f && dropout_p < 1.0f)) {
+    throw std::runtime_error(
+        "dropout_p must be a finite value in [0, 1); got " +
+        std::to_string(dropout_p));
+  }
+
+  if (dropout_p == 0.0f) {
+    return {nullptr, nullptr};
+  }
+
+  if (!rng_state_opt.has_value() || !is_valid_buffer(*rng_state_opt)) {
+    throw std::runtime_error("rng_state must be provided when dropout_p > 0");
+  }
+
+  auto &rng_state = *rng_state_opt;
+  if (rng_state.size_bytes() < 2 * sizeof(uint64_t)) {
+    throw std::runtime_error(
+        "rng_state buffer too small, need at least 16 bytes");
+  }
+
+  auto *base = static_cast<char *>(rng_state.untyped_data());
+  return {base, base + sizeof(uint64_t)};
+}
+
+inline bool is_mqa_gqa(int64_t num_heads_q, int64_t num_heads_k,
+                       int64_t *groups_out = nullptr) {
+  bool is_mqa = (num_heads_q != num_heads_k);
+  if (is_mqa && groups_out != nullptr) {
+    if (num_heads_q % num_heads_k != 0) {
+      throw std::runtime_error(
+          "num_heads_q must be divisible by num_heads_k for MQA/GQA");
+    }
+    *groups_out = num_heads_q / num_heads_k;
+  }
+  return is_mqa;
+}
+
+inline void validate_mha_bwd_inputs(const xla::ffi::AnyBuffer &dout,
+                                    const xla::ffi::AnyBuffer &q,
+                                    const xla::ffi::AnyBuffer &k,
+                                    const xla::ffi::AnyBuffer &v,
+                                    const xla::ffi::AnyBuffer &out,
+                                    const xla::ffi::AnyBuffer &softmax_lse,
+                                    int64_t head_size_q, int64_t head_size_v,
+                                    int64_t num_heads_q, int64_t num_heads_k) {
+
+  auto q_dtype = q.element_type();
+  if (q_dtype != xla::ffi::DataType::F16 &&
+      q_dtype != xla::ffi::DataType::BF16) {
+    throw std::runtime_error(
+        "FlashAttention only supports fp16/bf16 data type");
+  }
+
+  if (k.element_type() != q_dtype || v.element_type() != q_dtype ||
+      out.element_type() != q_dtype || dout.element_type() != q_dtype) {
+    throw std::runtime_error("Q, K, V, OUT, DOUT must have the same dtype");
+  }
+
+  if (softmax_lse.element_type() != xla::ffi::DataType::F32) {
+    throw std::runtime_error("softmax_lse must be float32");
+  }
+
+  if (head_size_q % 8 != 0 || head_size_v % 8 != 0) {
+    throw std::runtime_error(
+        "head_size_q and head_size_v must be multiples of 8");
+  }
+
+  if (head_size_q > 256 || head_size_v > 256) {
+    throw std::runtime_error(
+        "CK FlashAttention backward only supports head dimension at most 256");
+  }
+
+  if (num_heads_q % num_heads_k != 0) {
+    throw std::runtime_error(
+        "Number of heads in query must divide number of heads in key/value");
+  }
+}
+
+JAX_AITER_EXPORT
+xla::ffi::Error launch_mqa_gqa_reduction(const void *src, void *dst,
+                                         int64_t batch_size, int64_t seqlen_k,
+                                         int64_t num_heads_q,
+                                         int64_t num_heads_k,
+                                         int64_t head_size, int64_t groups,
+                                         xla::ffi::DataType dtype,
+                                         hipStream_t stream);
+
+// Holds opaque device pointers to seed and offset for RNG state.
+// Stored as void* to avoid forming uint64_t* from untyped storage (UB when
+// alignment isn't provable at the language level).  The downstream CK tile
+// API accepts const void* and casts internally on the GPU side.
+struct RngStatePointers {
+  void *seed;
+  void *offset;
+};
+
+// Prepares RNG state for forward pass: uses gen if provided, else generates internally.
+JAX_AITER_EXPORT
+xla::ffi::Error
+prepare_rng_state_for_fwd(hipStream_t stream, float dropout_p, int dev_idx,
+                          int64_t batch_size, int64_t num_heads,
+                          const std::optional<xla::ffi::AnyBuffer> &gen,
+                          xla::ffi::Result<xla::ffi::AnyBuffer> &rng_state,
+                          RngStatePointers &out_ptrs);
+
+} // namespace mha_utils
+} // namespace jax_aiter
+
+namespace jax_aiter {
+
+  inline void hipCheck(hipError_t err, const char *file, int line) {
+    if (err != hipSuccess) {
+      std::ostringstream oss;
+      oss << "HIP error at " << file << ":" << line << ": " << hipGetErrorString(err);
+      throw std::runtime_error(oss.str());
+    }
+  }
+  
+  #define HIP_CHECK(expr) ::jax_aiter::hipCheck((expr), __FILE__, __LINE__)
+  
+  // Return current device index (defensive wrapper).
+  inline int current_device() {
+    int dev = 0;
+    HIP_CHECK(hipGetDevice(&dev));
+    return dev;
+  }
+  
+  // Prefer this when you have a device (or managed) pointer.
+  // Tries to infer the device owning the pointer; falls back to current device.
+  inline int device_from_ptr(const void *ptr) {
+    if (ptr == nullptr)
+      return current_device();
+  
+    hipPointerAttribute_t attr{};
+    hipError_t st = hipPointerGetAttributes(&attr, ptr);
+    if (st == hipSuccess) {
+      // Most ROCm versions expose 'attr.device'. If it's valid, use it.
+      if (attr.device >= 0) {
+        return attr.device;
+      }
+    } else {
+      // Not a device/managed pointer (or unknown); keep going with fallback.
+      LOG(WARNING) << "hipPointerGetAttributes failed in device_from_ptr: " << hipGetErrorString(st);
+    }
+    return current_device();
+  }
+} // namespace jax_aiter

--- a/jaxlib/gpu/aiter_mha_fwd.cc
+++ b/jaxlib/gpu/aiter_mha_fwd.cc
@@ -1,0 +1,467 @@
+// Copyright 2026 The JAX Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Unified MHA forward FFI handler for both batch and varlen modes.
+// Detects mode from tensor rank: 4D = batch [b,s,h,d], 3D = varlen [total,h,d].
+// Calls aiter::mha_fwd(args, stream) which handles CK vs ASM v3 internally.
+
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <string>
+
+#include "xla/ffi/api/c_api.h"
+#include "xla/ffi/api/ffi.h"
+
+#include "aiter/mha_fwd.h"
+#include "aiter_mha_common_utils.h"
+
+namespace ffi = xla::ffi;
+
+namespace {
+
+
+ffi::Error fill_float_constant(void *dst, size_t n, float val,
+                                      hipStream_t stream) {
+  if (n == 0) return ffi::Error::Success();
+  uint32_t pattern;
+  std::memcpy(&pattern, &val, sizeof(pattern));
+  hipError_t err = hipMemsetD32Async(
+      reinterpret_cast<hipDeviceptr_t>(dst),
+      static_cast<int>(pattern), n, stream);
+  if (err != hipSuccess) {
+    return ffi::Error(ffi::ErrorCode::kInternal,
+                      std::string("hipMemsetD32Async failed: ") +
+                          hipGetErrorString(err));
+  }
+  return ffi::Error::Success();
+} //fill_float_constant
+} // namespace {
+
+namespace jax_aiter {
+ffi::Error
+aiter_mha_fwd_impl(
+    hipStream_t stream,
+    ffi::AnyBuffer q,
+    ffi::AnyBuffer k,
+    ffi::AnyBuffer v,
+    std::optional<ffi::AnyBuffer> cu_seqlens_q,
+    std::optional<ffi::AnyBuffer> cu_seqlens_kv,
+    std::optional<ffi::AnyBuffer> out,
+    std::optional<ffi::AnyBuffer> bias,
+    std::optional<ffi::AnyBuffer> alibi_slopes,
+    std::optional<ffi::AnyBuffer> gen,
+    ffi::Result<ffi::AnyBuffer> o,
+    ffi::Result<ffi::AnyBuffer> lse,
+    ffi::Result<ffi::AnyBuffer> p,
+    ffi::Result<ffi::AnyBuffer> rng_state,
+    float dropout_p,
+    float softmax_scale,
+    bool is_causal,
+    int window_size_left,
+    int window_size_right,
+    bool return_softmax_lse,
+    bool return_dropout_randval,
+    bool use_asm_v3,
+    int how_v3_bf16_cvt,
+    int max_seqlen_q_attr,
+    int max_seqlen_k_attr,
+    int min_seqlen_q,
+    float logits_soft_cap,
+    bool zero_tensors) {
+
+  try {
+
+  if (!q.untyped_data() || !k.untyped_data() || !v.untyped_data()) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                      "Required input buffer (q/k/v) is null");
+  }
+
+  const int dev_idx = ::jax_aiter::device_from_ptr(q.untyped_data());
+  if (dev_idx < 0) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument, "bad device from q");
+  }
+  // Pin the HIP device context to dev_idx for the duration of this
+  // handler so any device allocations or kernel launches issued by AITER
+  // target the correct device on multi-GPU setups.
+  HIP_CHECK(hipSetDevice(dev_idx));
+
+  auto q_dims = q.dimensions();
+  auto k_dims = k.dimensions();
+  auto v_dims = v.dimensions();
+
+  // Detect batch (4D) vs varlen (3D) from tensor rank.
+  const bool is_varlen = (q_dims.size() == 3);
+
+  int64_t batch_size, seqlen_q, num_heads, head_size_q;
+  int64_t seqlen_k, num_heads_k, head_size_v;
+  int64_t max_seqlen_q, max_seqlen_k;
+
+  if (is_varlen) {
+    // [total_q, nheads, hdim]
+    int64_t total_q = q_dims[0];
+    num_heads = q_dims[1];
+    head_size_q = q_dims[2];
+    int64_t total_k = k_dims[0];
+    num_heads_k = k_dims[1];
+    head_size_v = v_dims[2];
+
+    if (!cu_seqlens_q.has_value() || !mha_utils::is_valid_buffer(*cu_seqlens_q)) {
+      return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                        "varlen mode requires cu_seqlens_q");
+    }
+    batch_size = cu_seqlens_q->dimensions()[0] - 1;
+    seqlen_q = total_q;
+    seqlen_k = total_k;
+    max_seqlen_q = max_seqlen_q_attr;
+    max_seqlen_k = max_seqlen_k_attr;
+  } else {
+    // [batch, seqlen, nheads, hdim]
+    mha_utils::validate_mha_dimensions(q_dims, k_dims, v_dims);
+    batch_size = q_dims[0];
+    seqlen_q = q_dims[1];
+    num_heads = q_dims[2];
+    head_size_q = q_dims[3];
+    seqlen_k = k_dims[1];
+    num_heads_k = k_dims[2];
+    head_size_v = v_dims[3];
+    max_seqlen_q = seqlen_q;
+    max_seqlen_k = seqlen_k;
+  }
+
+  auto q_dtype = q.element_type();
+  if (q_dtype != ffi::DataType::F16 && q_dtype != ffi::DataType::BF16) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                      "FlashAttention only supports fp16 and bf16");
+  }
+  if (k.element_type() != q_dtype || v.element_type() != q_dtype) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                      "q, k, v must have the same dtype");
+  }
+  if (!(dropout_p >= 0.0f && dropout_p < 1.0f)) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                      "dropout_p must be in [0, 1)");
+  }
+  if (batch_size <= 0) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument, "batch size must be positive");
+  }
+  if (head_size_q > 256 || head_size_v > 256) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument, "head dim must be <= 256");
+  }
+  if (head_size_q % 8 != 0 || head_size_v % 8 != 0) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument, "head dim must be multiple of 8");
+  }
+  if (num_heads % num_heads_k != 0) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                      "num_heads_q must be divisible by num_heads_k");
+  }
+  if (return_dropout_randval && dropout_p <= 0.0f) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                      "return_dropout_randval requires dropout_p > 0");
+  }
+
+  std::string dtype_str(mha_utils::dtype_to_string(q_dtype));
+
+  // Bias / ALiBi handling.
+  const void *bias_ptr = nullptr;
+  ck_tile::index_t stride_bias = 0;
+  bool has_bias = bias.has_value() && mha_utils::is_valid_buffer(*bias);
+  bool has_alibi = alibi_slopes.has_value() && mha_utils::is_valid_buffer(*alibi_slopes);
+
+  if (has_bias && has_alibi) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                      "cannot apply both bias and alibi");
+  }
+  if (has_bias) {
+    bias_ptr = bias->untyped_data();
+    auto bd = bias->dimensions();
+    stride_bias = bd.size() >= 2 ? mha_utils::calculate_stride(bd, 0) : 0;
+  } else if (has_alibi) {
+    bias_ptr = alibi_slopes->untyped_data();
+    auto ad = alibi_slopes->dimensions();
+    stride_bias = ad.size() >= 2 ? mha_utils::calculate_stride(ad, 0) : 0;
+  }
+  bias_enum bias_type = mha_utils::get_bias_type(has_bias, has_alibi);
+
+  // Causal / window normalization.
+  int w_left = window_size_left;
+  int w_right = window_size_right;
+  int ref_sk = is_varlen ? max_seqlen_k : seqlen_k;
+  int ref_sq = is_varlen ? max_seqlen_q : seqlen_q;
+  if (w_left >= ref_sk) w_left = -1;
+  if (w_right >= ref_sk) w_right = -1;
+
+  bool eff_causal = is_causal;
+  if (ref_sq == 1 && !has_alibi) eff_causal = false;
+
+  mask_info mask = mha_utils::create_mask_info(eff_causal, w_left, w_right, ref_sq, ref_sk);
+
+  // Zero tensors (varlen).
+  if (zero_tensors) {
+    HIP_CHECK(hipMemsetAsync(o->untyped_data(), 0, o->size_bytes(), stream));
+    if (return_softmax_lse && lse->size_bytes() > 0) {
+      auto fill_err = fill_float_constant(
+          lse->untyped_data(), lse->element_count(),
+          -std::numeric_limits<float>::infinity(), stream);
+      if (!fill_err.success()) return fill_err;
+    }
+    if (return_dropout_randval && p->size_bytes() > 0) {
+      HIP_CHECK(hipMemsetAsync(p->untyped_data(), 0, p->size_bytes(), stream));
+    }
+  }
+
+  // Empty key fast path.
+  if (ref_sk == 0) {
+    HIP_CHECK(hipMemsetAsync(o->untyped_data(), 0, o->size_bytes(), stream));
+    if (return_softmax_lse && lse->size_bytes() > 0) {
+      auto fill_err = fill_float_constant(
+          lse->untyped_data(), lse->element_count(),
+          std::numeric_limits<float>::infinity(), stream);
+      if (!fill_err.success()) return fill_err;
+    }
+    return ffi::Error::Success();
+  }
+
+  // RNG state for dropout.
+  mha_utils::RngStatePointers rng_ptrs;
+  auto rng_err = mha_utils::prepare_rng_state_for_fwd(
+      stream, dropout_p, dev_idx, batch_size, num_heads, gen, rng_state, rng_ptrs);
+  if (!rng_err.success()) return rng_err;
+
+  // Sequence length pointers.
+  const ck_tile::index_t *seqstart_q_ptr = nullptr;
+  const ck_tile::index_t *seqstart_k_ptr = nullptr;
+  const ck_tile::index_t *cu_seqlen_q_ptr = nullptr;
+  const ck_tile::index_t *cu_seqlen_k_ptr = nullptr;
+
+  if (is_varlen) {
+    seqstart_q_ptr = reinterpret_cast<const ck_tile::index_t *>(cu_seqlens_q->untyped_data());
+    if (cu_seqlens_kv.has_value() && mha_utils::is_valid_buffer(*cu_seqlens_kv)) {
+      seqstart_k_ptr = reinterpret_cast<const ck_tile::index_t *>(cu_seqlens_kv->untyped_data());
+    }
+  } else {
+    if (cu_seqlens_q.has_value() && mha_utils::is_valid_buffer(*cu_seqlens_q)) {
+      cu_seqlen_q_ptr = reinterpret_cast<const ck_tile::index_t *>(cu_seqlens_q->untyped_data());
+    }
+    if (cu_seqlens_kv.has_value() && mha_utils::is_valid_buffer(*cu_seqlens_kv)) {
+      cu_seqlen_k_ptr = reinterpret_cast<const ck_tile::index_t *>(cu_seqlens_kv->untyped_data());
+    }
+  }
+
+  // Compute strides based on tensor rank.
+  auto o_dims = o->dimensions();
+  auto lse_dims = lse->dimensions();
+  auto p_dims = p->dimensions();
+
+  ck_tile::index_t stride_q, stride_k, stride_v, stride_o;
+  ck_tile::index_t nhead_stride_q, nhead_stride_k, nhead_stride_v, nhead_stride_o;
+  ck_tile::index_t batch_stride_q = 0, batch_stride_k = 0, batch_stride_v = 0, batch_stride_o = 0;
+
+  if (is_varlen) {
+    // 3D: [total, nheads, d] → stride at dim 0, nhead_stride at dim 1
+    stride_q = mha_utils::calculate_stride(q_dims, 0);
+    stride_k = mha_utils::calculate_stride(k_dims, 0);
+    stride_v = mha_utils::calculate_stride(v_dims, 0);
+    stride_o = mha_utils::calculate_stride(o_dims, 0);
+    nhead_stride_q = mha_utils::calculate_stride(q_dims, 1);
+    nhead_stride_k = mha_utils::calculate_stride(k_dims, 1);
+    nhead_stride_v = mha_utils::calculate_stride(v_dims, 1);
+    nhead_stride_o = mha_utils::calculate_stride(o_dims, 1);
+  } else {
+    // 4D: [batch, seqlen, nheads, d]
+    stride_q = mha_utils::calculate_stride(q_dims, 1);
+    stride_k = mha_utils::calculate_stride(k_dims, 1);
+    stride_v = mha_utils::calculate_stride(v_dims, 1);
+    stride_o = mha_utils::calculate_stride(o_dims, 1);
+    nhead_stride_q = mha_utils::calculate_stride(q_dims, 2);
+    nhead_stride_k = mha_utils::calculate_stride(k_dims, 2);
+    nhead_stride_v = mha_utils::calculate_stride(v_dims, 2);
+    nhead_stride_o = mha_utils::calculate_stride(o_dims, 2);
+    batch_stride_q = mha_utils::calculate_stride(q_dims, 0);
+    batch_stride_k = mha_utils::calculate_stride(k_dims, 0);
+    batch_stride_v = mha_utils::calculate_stride(v_dims, 0);
+    batch_stride_o = mha_utils::calculate_stride(o_dims, 0);
+  }
+
+  ck_tile::index_t nhead_stride_lse = 0, batch_stride_lse = 0;
+  if (return_softmax_lse && lse_dims.size() >= 2) {
+    if (is_varlen) {
+      nhead_stride_lse = mha_utils::calculate_stride(lse_dims, 0);
+    } else {
+      nhead_stride_lse = mha_utils::calculate_stride(lse_dims, 1);
+      batch_stride_lse = mha_utils::calculate_stride(lse_dims, 0);
+    }
+  }
+
+  ck_tile::index_t stride_randval = 0, nhead_stride_randval = 0, batch_stride_randval = 0;
+  if (return_dropout_randval && p_dims.size() >= 2) {
+    if (is_varlen) {
+      stride_randval = mha_utils::calculate_stride(p_dims, 1);
+      nhead_stride_randval = mha_utils::calculate_stride(p_dims, 0);
+    } else {
+      stride_randval = mha_utils::calculate_stride(p_dims, 2);
+      nhead_stride_randval = mha_utils::calculate_stride(p_dims, 1);
+      batch_stride_randval = mha_utils::calculate_stride(p_dims, 0);
+    }
+  }
+
+  if (return_dropout_randval && !is_varlen && p->size_bytes() > 0) {
+    HIP_CHECK(hipMemsetAsync(p->untyped_data(), 0, p->size_bytes(), stream));
+  }
+
+  auto args = aiter::mha_fwd_args{
+      .use_asm_v3 = use_asm_v3,
+      .v3_api_check = false,
+      .how_v3_bf16_cvt = how_v3_bf16_cvt,
+      .data_type = dtype_str,
+      .is_group_mode = is_varlen,
+      .bias_type = static_cast<int>(bias_type),
+      .has_lse = return_softmax_lse,
+      .qscale_type = 0,
+      .has_sink = false,
+
+      .q_ptr = q.untyped_data(),
+      .k_ptr = k.untyped_data(),
+      .v_ptr = v.untyped_data(),
+      .bias_ptr = bias_ptr,
+      .q_descale_ptr = nullptr,
+      .k_descale_ptr = nullptr,
+      .v_descale_ptr = nullptr,
+      .rand_val_ptr = return_dropout_randval ? p->untyped_data() : nullptr,
+      .lse_ptr = return_softmax_lse ? lse->untyped_data() : nullptr,
+      .o_ptr = o->untyped_data(),
+
+      .seqstart_q_ptr = seqstart_q_ptr,
+      .seqstart_k_ptr = seqstart_k_ptr,
+      .seqlen_q_ptr = nullptr,
+      .seqlen_k_ptr = nullptr,
+      .cu_seqlen_q_ptr = cu_seqlen_q_ptr,
+      .cu_seqlen_k_ptr = cu_seqlen_k_ptr,
+      .block_scale_seqstart_q_ptr = nullptr,
+      .block_scale_seqstart_k_ptr = nullptr,
+      .sink_ptr = nullptr,
+
+      .seqlen_q = static_cast<ck_tile::index_t>(seqlen_q),
+      .seqlen_k = static_cast<ck_tile::index_t>(seqlen_k),
+      .batch = static_cast<ck_tile::index_t>(batch_size),
+      .max_seqlen_q = static_cast<ck_tile::index_t>(max_seqlen_q),
+      .hdim_q = static_cast<ck_tile::index_t>(head_size_q),
+      .hdim_v = static_cast<ck_tile::index_t>(head_size_v),
+      .nhead_q = static_cast<ck_tile::index_t>(num_heads),
+      .nhead_k = static_cast<ck_tile::index_t>(num_heads_k),
+
+      .scale_s = softmax_scale,
+      .logits_soft_cap = logits_soft_cap,
+
+      .stride_q = stride_q,
+      .stride_k = stride_k,
+      .stride_v = stride_v,
+      .stride_bias = stride_bias,
+      .stride_randval = stride_randval,
+      .stride_o = stride_o,
+      .nhead_stride_q = nhead_stride_q,
+      .nhead_stride_k = nhead_stride_k,
+      .nhead_stride_v = nhead_stride_v,
+      .nhead_stride_bias = 0,
+      .nhead_stride_randval = nhead_stride_randval,
+      .nhead_stride_lse = nhead_stride_lse,
+      .nhead_stride_o = nhead_stride_o,
+      .nhead_stride_q_descale = 0,
+      .nhead_stride_k_descale = 0,
+      .nhead_stride_v_descale = 0,
+      .batch_stride_q = batch_stride_q,
+      .batch_stride_k = batch_stride_k,
+      .batch_stride_v = batch_stride_v,
+      .batch_stride_bias = 0,
+      .batch_stride_randval = batch_stride_randval,
+      .batch_stride_lse = batch_stride_lse,
+      .batch_stride_o = batch_stride_o,
+      .batch_stride_q_descale = 0,
+      .batch_stride_k_descale = 0,
+      .batch_stride_v_descale = 0,
+
+      .window_size_left = mask.left,
+      .window_size_right = mask.right,
+      .sink_size = 0,
+      .mask_type = static_cast<ck_tile::index_t>(mask.type),
+      .min_seqlen_q = min_seqlen_q,
+
+      .p_drop = dropout_p,
+      .s_randval = return_dropout_randval,
+      .drop_seed_offset = std::pair<const void *, const void *>(
+          rng_ptrs.seed, rng_ptrs.offset),
+
+      .block_scale_size_q = 0,
+      .block_scale_size_kv = 0
+  };
+
+  auto stream_config = mha_utils::create_stream_config(stream);
+  float elapsed = aiter::mha_fwd(args, stream_config);
+
+  if (elapsed < 0) {
+    return ffi::Error(ffi::ErrorCode::kInternal,
+                      "aiter::mha_fwd failed - unsupported configuration");
+  }
+
+  return ffi::Error::Success();
+
+  } catch (const std::exception &e) {
+    return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                      std::string("aiter_mha_fwd: ") + e.what());
+  } catch (...) {
+    return ffi::Error(ffi::ErrorCode::kInternal,
+                      "aiter_mha_fwd: unknown C++ exception");
+  }
+}
+
+} // namespace jax_aiter
+
+#pragma GCC visibility push(default)
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    aiter_mha_fwd, jax_aiter::aiter_mha_fwd_impl,
+    ffi::Ffi::Bind()
+        .Ctx<ffi::PlatformStream<hipStream_t>>()
+        .Arg<ffi::AnyBuffer>() // q: 4D [b,s,h,d] or 3D [total,h,d]
+        .Arg<ffi::AnyBuffer>() // k
+        .Arg<ffi::AnyBuffer>() // v
+        .Arg<ffi::AnyBuffer>() // cu_seqlens_q (optional)
+        .Arg<ffi::AnyBuffer>() // cu_seqlens_kv (optional)
+        .Arg<ffi::AnyBuffer>() // out_provided (optional)
+        .Arg<ffi::AnyBuffer>() // bias (optional)
+        .Arg<ffi::AnyBuffer>() // alibi_slopes (optional)
+        .Arg<ffi::AnyBuffer>() // gen (optional)
+        .Ret<ffi::AnyBuffer>() // o
+        .Ret<ffi::AnyBuffer>() // lse
+        .Ret<ffi::AnyBuffer>() // p (dropout mask)
+        .Ret<ffi::AnyBuffer>() // rng_state
+        .Attr<float>("dropout_p")
+        .Attr<float>("softmax_scale")
+        .Attr<bool>("is_causal")
+        .Attr<int>("window_size_left")
+        .Attr<int>("window_size_right")
+        .Attr<bool>("return_softmax_lse")
+        .Attr<bool>("return_dropout_randval")
+        .Attr<bool>("use_asm_v3")
+        .Attr<int>("how_v3_bf16_cvt")
+        .Attr<int>("max_seqlen_q_attr")
+        .Attr<int>("max_seqlen_k_attr")
+        .Attr<int>("min_seqlen_q")
+        .Attr<float>("logits_soft_cap")
+        .Attr<bool>("zero_tensors"),
+    {xla::ffi::Traits::kCmdBufferCompatible});
+
+#pragma GCC visibility pop

--- a/jaxlib/gpu_aiter.py
+++ b/jaxlib/gpu_aiter.py
@@ -1,0 +1,43 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import logging
+from typing import Any
+from .plugin_support import _PLUGIN_MODULE_NAMES, import_from_plugin
+
+logger = logging.getLogger(__name__)
+_hip_aiter = import_from_plugin("rocm", "_aiter")
+
+def _is_rocm_platform() -> bool:
+  """Return True when any ROCm plugin wheel is installed."""
+  return any(
+      importlib.util.find_spec(name) is not None
+      for name in _PLUGIN_MODULE_NAMES.get("rocm", [])
+  )
+
+def registrations() -> dict[str, list[tuple[str, Any]]]:
+  result: dict[str, list[tuple[str, Any]]] = {
+      "ROCM": [],
+  }
+  if _hip_aiter:
+    result["ROCM"].extend(
+        (name, value) for name, value in _hip_aiter.registrations().items()
+    )
+  elif _is_rocm_platform():
+    logger.warning(
+        "AITer: _aiter module not loaded. FFI handlers will not be registered. "
+        "Ensure the jax-rocm plugin wheel is installed with _aiter.so."
+    )
+  return result

--- a/jaxlib/rocm/BUILD
+++ b/jaxlib/rocm/BUILD
@@ -501,9 +501,54 @@ rocm_nanobind_extension(
     ],
 )
 
+rocm_library(
+    name = "aiter_mha",
+    srcs = if_rocm_is_configured([
+        "//jaxlib/gpu:aiter_mha_fwd.cc",
+        "//jaxlib/gpu:aiter_mha_bwd.cc",
+        "//jaxlib/gpu:aiter_mha_common_utils.cc",
+    ]),
+    hdrs = if_rocm_is_configured([
+        "//jaxlib/gpu:aiter.h",
+        "//jaxlib/gpu:aiter_mha_common_utils.h",
+    ]),
+    deps = [
+        ":hip_gpu_kernel_helpers",
+        ":hip_vendor",
+        "//third_party/aiter:aiter_mha",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:hip_runtime",
+        "@xla//xla/ffi/api:ffi",
+        "@com_google_absl//absl/log",
+    ],
+)
+
+
+rocm_nanobind_extension(
+    name = "_aiter",
+    srcs = ["//jaxlib/gpu:aiter.cc"],
+    copts = [
+        "-fexceptions",
+        "-fno-strict-aliasing",
+    ],
+    features = ["-use_header_modules"],
+    linkopts = ["-Wl,-rpath,$$ORIGIN"],
+    module_name = "_aiter",
+    deps = [
+        ":aiter_mha",
+        ":hip_gpu_kernel_helpers",
+        ":hip_vendor",
+        "//jaxlib:kernel_nanobind_helpers",
+        "@local_config_rocm//rocm:hip_runtime",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@nanobind",
+    ],
+)
+
 py_library(
     name = "rocm_gpu_support",
     deps = [
+        ":_aiter",
         ":_hybrid",
         ":_linalg",
         ":_prng",

--- a/jaxlib/tools/BUILD.bazel
+++ b/jaxlib/tools/BUILD.bazel
@@ -239,6 +239,7 @@ wheel_sources(
     ]) + if_rocm([
         "//jax_plugins/rocm:plugin_pyproject.toml",
         "//jax_plugins/rocm:plugin_setup.py",
+        "//third_party/aiter:aiter_runtime_sos",
     ]),
 )
 

--- a/jaxlib/tools/build_gpu_kernels_wheel.py
+++ b/jaxlib/tools/build_gpu_kernels_wheel.py
@@ -21,6 +21,7 @@ import argparse
 import functools
 import os
 import pathlib
+import shutil
 import tempfile
 
 from python.runfiles import runfiles
@@ -189,6 +190,7 @@ def prepare_wheel_rocm(
   copy_files(
       dst_dir=plugin_dir,
       src_files=[
+          f"{source_file_prefix}jaxlib/rocm/_aiter.{pyext}",
           f"{source_file_prefix}jaxlib/rocm/_linalg.{pyext}",
           f"{source_file_prefix}jaxlib/rocm/_prng.{pyext}",
           f"{source_file_prefix}jaxlib/rocm/_solver.{pyext}",
@@ -201,6 +203,27 @@ def prepare_wheel_rocm(
       ],
   )
 
+  required_aiter_libs = {"libmha_fwd.so", "libmha_bwd.so"}
+  if wheel_sources:
+    found = set()
+    for src in wheel_sources:
+        basename = os.path.basename(src)
+        if basename in required_aiter_libs:
+            shutil.copy(src, plugin_dir / basename)
+            found.add(basename)
+
+    missing = required_aiter_libs - found
+    if missing:
+        raise RuntimeError(
+            f"AITER shared libraries missing from wheel sources: "
+            f"{', '.join(sorted(missing))}. "
+            f"The ROCm plugin wheel will not work without them."
+        )
+  else:
+    raise RuntimeError(
+        "wheel_sources is empty; cannot build ROCm plugin wheel "
+        "without AITER shared libraries (libmha_fwd.so, libmha_bwd.so)"
+    )
 
 # Build wheel for cuda kernels
 if args.enable_rocm:

--- a/jaxlib/tools/build_wheel.py
+++ b/jaxlib/tools/build_wheel.py
@@ -206,6 +206,7 @@ def prepare_wheel(wheel_sources_path: pathlib.Path, *, cpu, wheel_sources):
           f"{source_file_prefix}jaxlib/gpu_rnn.py",
           f"{source_file_prefix}jaxlib/gpu_triton.py",
           f"{source_file_prefix}jaxlib/gpu_common_utils.py",
+          f"{source_file_prefix}jaxlib/gpu_aiter.py",
           f"{source_file_prefix}jaxlib/gpu_solver.py",
           f"{source_file_prefix}jaxlib/gpu_sparse.py",
           f"{source_file_prefix}jaxlib/plugin_support.py",

--- a/tests/aiter_mha_test.py
+++ b/tests/aiter_mha_test.py
@@ -1,0 +1,616 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+"""Comprehensive tests for unified MHA handlers (mha_v2).
+
+Test strategy:
+- Dtype-based tolerances (eps^(2/3))
+- Dropout: shape/crash check only (no numeric comparison)
+- Covers all head dims, seqlen combos, MHA/MQA/GQA, features, edge cases
+- Regression guards for every historical bug found during AITER bump
+"""
+
+import math
+import pytest
+import jax
+import jax.numpy as jnp
+
+from jax._src.aiter.aiter_mha import (
+    flash_attn_func,
+    flash_attn_varlen,
+    get_gfx,
+)
+
+# AITER MHA accuracy checks compare bf16/fp16 kernel outputs against an fp32
+# reference (and use eps^(2/3) tolerances).  Enable x64 so the reference path
+# can use float64 where it helps numerical fidelity, and so scalar Python
+# floats used as scales aren't silently demoted.
+jax.config.update("jax_enable_x64", True)
+
+# AITER MHA kernels are only built/tuned for gfx942 (MI300) and gfx950
+# (MI355).  Other ROCm GPUs and all non-ROCm platforms are unsupported.
+_SUPPORTED_GFX = {"gfx942", "gfx950"}
+
+
+def _on_rocm() -> bool:
+    """True only when JAX is running on an AMD ROCm GPU."""
+    try:
+        return str(jax.devices()[0]).startswith("rocm")
+    except Exception:
+        return False
+
+
+def _detected_gfx() -> str:
+    """Return the GFX arch (e.g. 'gfx942') or '' if it can't be detected."""
+    try:
+        return get_gfx()
+    except Exception:
+        return ""
+
+
+_GFX = _detected_gfx()
+
+pytestmark = pytest.mark.skipif(
+    not _on_rocm() or _GFX not in _SUPPORTED_GFX,
+    reason=(
+        "AITER MHA kernels are only supported on ROCm gfx942 / gfx950 "
+        f"(detected: platform={'rocm' if _on_rocm() else 'non-rocm'}, "
+        f"gfx={_GFX or 'unknown'})"
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Tolerances (matching TE: eps^(2/3))
+# ---------------------------------------------------------------------------
+
+def get_tolerances(dtype):
+    if dtype == jnp.float16:
+        eps = jnp.finfo(jnp.float16).eps
+        tol = float(eps ** (2.0 / 3.0))
+        return tol, tol
+    elif dtype == jnp.bfloat16:
+        eps = jnp.finfo(jnp.bfloat16).eps
+        tol = float(eps ** (2.0 / 3.0))
+        return tol, tol
+    return 1e-5, 1e-5
+
+
+def assert_close(actual, expected, dtype, name="", bwd_factor=1):
+    atol, rtol = get_tolerances(dtype)
+    atol *= bwd_factor
+    a32 = actual.astype(jnp.float32)
+    e32 = expected.astype(jnp.float32)
+    max_diff = float(jnp.max(jnp.abs(a32 - e32)))
+    max_ref = float(jnp.max(jnp.abs(e32)))
+    rel_diff = max_diff / max(max_ref, 1e-6)
+    assert max_diff < atol or rel_diff < rtol, \
+        f"{name}: max_diff={max_diff:.6f} (atol={atol:.6f}), rel={rel_diff:.6f} (rtol={rtol:.6f})"
+
+
+# ---------------------------------------------------------------------------
+# Reference implementation
+# ---------------------------------------------------------------------------
+
+def attention_ref(q, k, v, causal=False, scale=None, window_size=(-1, -1)):
+    q, k, v = q.astype(jnp.float32), k.astype(jnp.float32), v.astype(jnp.float32)
+    scale = scale or 1.0 / math.sqrt(q.shape[-1])
+    sq, sk = q.shape[1], k.shape[1]
+    attn = jnp.einsum("bshd,bthd->bhst", q, k) * scale
+    if causal:
+        mask = jnp.tril(jnp.ones((sq, sk), dtype=bool), k=sk - sq)
+        attn = jnp.where(mask[None, None, :, :], attn, float("-inf"))
+    if window_size != (-1, -1):
+        wl, wr = window_size
+        row_idx = jnp.arange(sq)[:, None] + (sk - sq)
+        col_idx = jnp.arange(sk)[None, :]
+        swa_mask = jnp.ones((sq, sk), dtype=bool)
+        if wl >= 0:
+            swa_mask = swa_mask & (row_idx - col_idx <= wl)
+        if wr >= 0:
+            swa_mask = swa_mask & (col_idx - row_idx <= wr)
+        attn = jnp.where(swa_mask[None, None, :, :], attn, float("-inf"))
+    attn = jax.nn.softmax(attn, axis=-1)
+    return jnp.einsum("bhst,bthd->bshd", attn, v)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_qkv(b, sq, sk, hq, hk, d, dtype, seed=0):
+    key = jax.random.PRNGKey(seed)
+    k1, k2, k3 = jax.random.split(key, 3)
+    q = jax.random.normal(k1, (b, sq, hq, d), dtype=dtype)
+    k_t = jax.random.normal(k2, (b, sk, hk, d), dtype=dtype)
+    v = jax.random.normal(k3, (b, sk, hk, d), dtype=dtype)
+    return q, k_t, v
+
+
+def make_varlen(batch, max_sq, max_sk, hq, hk, d, dtype, seed=0):
+    key = jax.random.PRNGKey(seed)
+    k1, k2, k3, k4, k5 = jax.random.split(key, 5)
+    sq = jax.random.randint(k4, (batch,), 1, max_sq + 1)
+    sk = jax.random.randint(k5, (batch,), 1, max_sk + 1)
+    tq, tk = int(jnp.sum(sq)), int(jnp.sum(sk))
+    cu_sq = jnp.concatenate([jnp.zeros(1, jnp.int32), jnp.cumsum(sq).astype(jnp.int32)])
+    cu_sk = jnp.concatenate([jnp.zeros(1, jnp.int32), jnp.cumsum(sk).astype(jnp.int32)])
+    q = jax.random.normal(k1, (tq, hq, d), dtype=dtype)
+    k_t = jax.random.normal(k2, (tk, hk, d), dtype=dtype)
+    v = jax.random.normal(k3, (tk, hk, d), dtype=dtype)
+    return q, k_t, v, cu_sq, cu_sk, max_sq, max_sk
+
+
+def run_fwd(q, k, v, **kw):
+    result = flash_attn_func(q, k, v, **kw)
+    return result[0] if isinstance(result, tuple) else result
+
+
+def run_bwd(q, k, v, **kw):
+    def loss(q, k, v):
+        return jnp.sum(run_fwd(q, k, v, **kw))
+    return jax.grad(loss, argnums=(0, 1, 2))(q, k, v)
+
+
+def run_varlen_fwd(q, k, v, cu_sq, cu_sk, msq, msk, **kw):
+    result = flash_attn_varlen(q, k, v, cu_sq, cu_sk,
+                               max_seqlen_q=msq, max_seqlen_k=msk, **kw)
+    return result[0] if isinstance(result, tuple) else result
+
+
+def run_varlen_bwd(q, k, v, cu_sq, cu_sk, msq, msk, **kw):
+    def loss(q, k, v):
+        return jnp.sum(run_varlen_fwd(q, k, v, cu_sq, cu_sk, msq, msk, **kw))
+    return jax.grad(loss, argnums=(0, 1, 2))(q, k, v)
+
+
+# ===========================================================================
+# BATCH CONFIGS
+# ===========================================================================
+
+# Core configs: cover all head dims, seqlens, MHA types
+BATCH_CORE = [
+    # Self-attention configs
+    pytest.param(2, 128, 128, 4, 4, 32, jnp.bfloat16, id="d32_bf16"),
+    pytest.param(2, 128, 128, 4, 4, 40, jnp.float16, id="d40_fp16"),
+    pytest.param(2, 128, 128, 4, 4, 59, jnp.bfloat16, id="d59_bf16"),
+    pytest.param(2, 128, 128, 4, 4, 64, jnp.bfloat16, id="d64_bf16"),
+    pytest.param(2, 128, 128, 4, 4, 64, jnp.float16, id="d64_fp16"),
+    pytest.param(2, 64, 64, 4, 4, 96, jnp.bfloat16, id="d96_bf16"),
+    pytest.param(2, 64, 64, 4, 4, 96, jnp.float16, id="d96_fp16"),
+    pytest.param(2, 64, 64, 4, 4, 111, jnp.float16, id="d111_fp16"),
+    pytest.param(2, 128, 128, 4, 4, 128, jnp.bfloat16, id="d128_bf16"),
+    pytest.param(2, 128, 128, 4, 4, 128, jnp.float16, id="d128_fp16"),
+    pytest.param(2, 64, 64, 4, 4, 160, jnp.bfloat16, id="d160_bf16"),
+    pytest.param(2, 64, 64, 4, 4, 256, jnp.bfloat16, id="d256_bf16"),
+    # Cross-attention (sq != sk)
+    pytest.param(2, 512, 256, 4, 4, 64, jnp.bfloat16, id="cross_sq_gt_sk"),
+    pytest.param(2, 256, 512, 4, 4, 64, jnp.bfloat16, id="cross_sq_lt_sk"),
+    pytest.param(2, 1024, 1023, 4, 4, 128, jnp.bfloat16, id="off_by_one"),
+    pytest.param(2, 1023, 1024, 4, 4, 128, jnp.bfloat16, id="off_by_one_rev"),
+    # GQA / MQA
+    pytest.param(2, 128, 128, 6, 3, 64, jnp.bfloat16, id="gqa_bf16"),
+    pytest.param(2, 128, 128, 6, 3, 64, jnp.float16, id="gqa_fp16"),
+    pytest.param(2, 128, 128, 6, 1, 64, jnp.float16, id="mqa_fp16"),
+    pytest.param(2, 128, 128, 8, 2, 128, jnp.bfloat16, id="gqa4_d128"),
+    # Large seqlens
+    pytest.param(2, 1024, 1024, 4, 4, 128, jnp.bfloat16, id="large_1024"),
+    pytest.param(1, 2048, 2048, 4, 4, 64, jnp.bfloat16, id="large_2048"),
+    # Decode (sq=1)
+    pytest.param(2, 1, 128, 4, 4, 64, jnp.bfloat16, id="decode_sq1"),
+    pytest.param(2, 1, 512, 4, 4, 128, jnp.bfloat16, id="decode_sq1_long"),
+    # Larger batch
+    pytest.param(8, 64, 64, 4, 4, 64, jnp.bfloat16, id="batch8"),
+]
+
+# Configs suitable for accuracy check (MHA, sq==sk, reasonable size)
+BATCH_ACCURACY = [c for c in BATCH_CORE
+                  if c.values[1] == c.values[2] and c.values[3] == c.values[4]
+                  and c.values[1] <= 256 and c.values[5] <= 128]
+
+# Varlen configs
+VARLEN_CONFIGS = [
+    pytest.param(4, 128, 128, 4, 4, 64, jnp.bfloat16, id="vl_self_bf16"),
+    pytest.param(4, 128, 128, 4, 4, 64, jnp.float16, id="vl_self_fp16"),
+    pytest.param(4, 256, 128, 4, 4, 128, jnp.bfloat16, id="vl_cross_bf16"),
+    pytest.param(4, 128, 128, 6, 3, 64, jnp.bfloat16, id="vl_gqa_bf16"),
+    pytest.param(4, 128, 128, 6, 1, 64, jnp.float16, id="vl_mqa_fp16"),
+    pytest.param(4, 64, 64, 4, 4, 96, jnp.bfloat16, id="vl_d96_bf16"),
+    pytest.param(4, 64, 64, 4, 4, 128, jnp.float16, id="vl_d128_fp16"),
+    pytest.param(4, 64, 64, 4, 4, 32, jnp.bfloat16, id="vl_d32_bf16"),
+    pytest.param(2, 512, 512, 4, 4, 64, jnp.bfloat16, id="vl_large_bf16"),
+]
+
+
+# ===========================================================================
+# BATCH FORWARD TESTS
+# ===========================================================================
+
+@pytest.mark.parametrize("b,sq,sk,hq,hk,d,dtype", BATCH_CORE)
+@pytest.mark.parametrize("causal", [False, True], ids=["nomask", "causal"])
+def test_batch_fwd_shape(b, sq, sk, hq, hk, d, dtype, causal):
+    """Forward: correct shape, dtype, finite values for all configs."""
+    q, k_t, v = make_qkv(b, sq, sk, hq, hk, d, dtype)
+    out = run_fwd(q, k_t, v, causal=causal)
+    assert out.shape == (b, sq, hq, d)
+    assert out.dtype == dtype
+    assert jnp.all(jnp.isfinite(out)), f"NaN/Inf in output for d={d}"
+
+
+@pytest.mark.parametrize("b,sq,sk,hq,hk,d,dtype", BATCH_ACCURACY)
+@pytest.mark.parametrize("causal", [False, True], ids=["nomask", "causal"])
+def test_batch_fwd_accuracy(b, sq, sk, hq, hk, d, dtype, causal):
+    """Forward accuracy vs JAX reference."""
+    q, k_t, v = make_qkv(b, sq, sk, hq, hk, d, dtype, seed=42)
+    scale = d ** (-0.5)
+    out = run_fwd(q, k_t, v, causal=causal, softmax_scale=scale)
+    ref = attention_ref(q, k_t, v, causal=causal, scale=scale).astype(dtype)
+    assert_close(out, ref, dtype, "fwd_out")
+
+
+# ===========================================================================
+# BATCH BACKWARD TESTS
+# ===========================================================================
+
+@pytest.mark.parametrize("b,sq,sk,hq,hk,d,dtype", BATCH_CORE)
+@pytest.mark.parametrize("causal", [False, True], ids=["nomask", "causal"])
+def test_batch_bwd_shape(b, sq, sk, hq, hk, d, dtype, causal):
+    """Backward: gradient shapes, dtypes, finiteness."""
+    q, k_t, v = make_qkv(b, sq, sk, hq, hk, d, dtype, seed=1)
+    dq, dk, dv = run_bwd(q, k_t, v, causal=causal)
+    assert dq.shape == q.shape, f"dq {dq.shape} != {q.shape}"
+    assert dk.shape == k_t.shape, f"dk {dk.shape} != {k_t.shape}"
+    assert dv.shape == v.shape, f"dv {dv.shape} != {v.shape}"
+    assert dq.dtype == dtype
+    assert jnp.all(jnp.isfinite(dq)), "dq NaN/Inf"
+    assert jnp.all(jnp.isfinite(dk)), "dk NaN/Inf"
+    assert jnp.all(jnp.isfinite(dv)), "dv NaN/Inf"
+
+
+_BWD_XFAIL_DIMS = {96, 111, 128}
+
+@pytest.mark.parametrize("b,sq,sk,hq,hk,d,dtype", BATCH_ACCURACY)
+def test_batch_bwd_accuracy(b, sq, sk, hq, hk, d, dtype):
+    """Backward accuracy: gradients vs JAX reference (10x relaxed tolerance).
+
+    Head dims >= 96 are xfailed due to known CK/ASM backward accuracy
+    limitations on gfx950 (large dq errors at these dims).
+    """
+    if d in _BWD_XFAIL_DIMS:
+        pytest.xfail(f"Known backward accuracy issue for d={d} on gfx950")
+    q, k_t, v = make_qkv(b, sq, sk, hq, hk, d, dtype, seed=2)
+    scale = d ** (-0.5)
+
+    def aiter_loss(q, k, v):
+        return jnp.sum(run_fwd(q, k, v, softmax_scale=scale))
+    def ref_loss(q, k, v):
+        return jnp.sum(attention_ref(q, k, v, scale=scale).astype(dtype))
+
+    dq, dk, dv = jax.grad(aiter_loss, argnums=(0, 1, 2))(q, k_t, v)
+    dq_r, dk_r, dv_r = jax.grad(ref_loss, argnums=(0, 1, 2))(q, k_t, v)
+
+    for n, g, r in [("dq", dq, dq_r), ("dk", dk, dk_r), ("dv", dv, dv_r)]:
+        assert_close(g, r, dtype, n, bwd_factor=10)
+
+
+# ===========================================================================
+# DROPOUT TESTS (shape/crash only, no numeric comparison)
+# ===========================================================================
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("causal", [False, True], ids=["nomask", "causal"])
+def test_dropout_fwd(dtype, causal):
+    """Dropout forward: no crash, finite output."""
+    q, k_t, v = make_qkv(2, 128, 128, 4, 4, 64, dtype, seed=10)
+    out = run_fwd(q, k_t, v, dropout_p=0.1, causal=causal)
+    assert jnp.all(jnp.isfinite(out))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16], ids=["fp16", "bf16"])
+def test_dropout_bwd(dtype):
+    """Dropout backward: no crash, finite gradients."""
+    q, k_t, v = make_qkv(2, 64, 64, 4, 4, 64, dtype, seed=10)
+    dq, dk, dv = run_bwd(q, k_t, v, dropout_p=0.1)
+    assert jnp.all(jnp.isfinite(dq))
+    assert jnp.all(jnp.isfinite(dk))
+    assert jnp.all(jnp.isfinite(dv))
+
+
+# ===========================================================================
+# SWA (SLIDING WINDOW ATTENTION)
+# ===========================================================================
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16], ids=["fp16", "bf16"])
+def test_swa_fwd(dtype):
+    """SWA forward."""
+    q, k_t, v = make_qkv(2, 256, 256, 4, 4, 64, dtype, seed=11)
+    out = run_fwd(q, k_t, v, causal=True, window_size=(64, 0))
+    assert out.shape == (2, 256, 4, 64)
+    assert jnp.all(jnp.isfinite(out))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16], ids=["fp16", "bf16"])
+def test_swa_bwd(dtype):
+    """SWA backward."""
+    q, k_t, v = make_qkv(2, 128, 128, 4, 4, 64, dtype, seed=11)
+    dq, dk, dv = run_bwd(q, k_t, v, causal=True, window_size=(32, 0))
+    assert jnp.all(jnp.isfinite(dq))
+    assert jnp.all(jnp.isfinite(dk))
+
+
+# ===========================================================================
+# BIAS AND ALIBI
+# ===========================================================================
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16], ids=["fp16", "bf16"])
+def test_bias_fwd(dtype):
+    """Attention bias forward."""
+    b, sq, sk, h, d = 2, 128, 128, 4, 64
+    q, k_t, v = make_qkv(b, sq, sk, h, h, d, dtype, seed=15)
+    bias = jax.random.normal(jax.random.PRNGKey(99), (sq, sk), dtype=dtype) * 0.1
+    out = run_fwd(q, k_t, v, bias=bias)
+    assert jnp.all(jnp.isfinite(out))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16], ids=["fp16", "bf16"])
+def test_bias_bwd(dtype):
+    """Attention bias backward: dbias gradient flows."""
+    b, sq, sk, h, d = 2, 64, 64, 4, 64
+    q, k_t, v = make_qkv(b, sq, sk, h, h, d, dtype, seed=15)
+    bias = jax.random.normal(jax.random.PRNGKey(99), (sq, sk), dtype=dtype) * 0.1
+
+    def loss(q, k, v, bias):
+        return jnp.sum(run_fwd(q, k, v, bias=bias))
+    dq, dk, dv, dbias = jax.grad(loss, argnums=(0, 1, 2, 3))(q, k_t, v, bias)
+    assert jnp.all(jnp.isfinite(dq))
+    assert jnp.all(jnp.isfinite(dk))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("alibi_shape", ["1d", "2d"], ids=["alibi1d", "alibi2d"])
+def test_alibi_fwd(dtype, alibi_shape):
+    """ALiBi forward with 1D and 2D slopes."""
+    b, sq, sk, h, d = 2, 128, 128, 4, 64
+    q, k_t, v = make_qkv(b, sq, sk, h, h, d, dtype, seed=16)
+    if alibi_shape == "1d":
+        alibi = jnp.linspace(0.1, 0.5, h, dtype=jnp.float32)
+    else:
+        alibi = jnp.broadcast_to(jnp.linspace(0.1, 0.5, h), (b, h)).astype(jnp.float32)
+    out = run_fwd(q, k_t, v, alibi_slopes=alibi)
+    assert jnp.all(jnp.isfinite(out))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16], ids=["fp16", "bf16"])
+def test_alibi_causal(dtype):
+    """ALiBi with causal mask."""
+    b, sq, sk, h, d = 2, 128, 128, 4, 64
+    q, k_t, v = make_qkv(b, sq, sk, h, h, d, dtype, seed=16)
+    alibi = jnp.linspace(0.1, 0.5, h, dtype=jnp.float32)
+    out = run_fwd(q, k_t, v, alibi_slopes=alibi, causal=True)
+    assert jnp.all(jnp.isfinite(out))
+
+
+# ===========================================================================
+# RETURN VALUES
+# ===========================================================================
+
+def test_return_lse():
+    """Return log-sum-exp."""
+    b, sq, sk, h, d = 2, 128, 128, 4, 64
+    q, k_t, v = make_qkv(b, sq, sk, h, h, d, jnp.bfloat16, seed=12)
+    result = flash_attn_func(q, k_t, v, return_lse=True)
+    assert isinstance(result, tuple) and len(result) >= 2
+    assert result[0].shape == (b, sq, h, d)
+    assert result[1].shape == (b, h, sq)
+    assert jnp.all(jnp.isfinite(result[1]))
+
+
+def test_return_attn_probs_with_dropout():
+    """Return attention probs (S_dmask) with dropout."""
+    b, sq, sk, h, d = 2, 64, 64, 4, 64
+    q, k_t, v = make_qkv(b, sq, sk, h, h, d, jnp.bfloat16, seed=12)
+    result = flash_attn_func(q, k_t, v, dropout_p=0.1, return_attn_probs=True)
+    assert isinstance(result, tuple) and len(result) >= 2
+
+
+# ===========================================================================
+# PADDED HEAD DIMENSIONS
+# ===========================================================================
+
+@pytest.mark.parametrize("d", [32, 40, 59, 64, 96, 111, 128, 160, 256],
+                         ids=[f"d{d}" for d in [32, 40, 59, 64, 96, 111, 128, 160, 256]])
+def test_padded_head_dim_fwd(d):
+    """All head dims produce correct output shape."""
+    q, k_t, v = make_qkv(2, 64, 64, 4, 4, d, jnp.bfloat16, seed=13)
+    out = run_fwd(q, k_t, v)
+    assert out.shape == (2, 64, 4, d)
+    assert jnp.all(jnp.isfinite(out))
+
+
+@pytest.mark.parametrize("d", [59, 111], ids=["d59", "d111"])
+def test_padded_head_dim_bwd(d):
+    """Non-multiple-of-8 head dims: backward produces finite gradients."""
+    q, k_t, v = make_qkv(2, 64, 64, 4, 4, d, jnp.bfloat16, seed=13)
+    dq, dk, dv = run_bwd(q, k_t, v)
+    assert dq.shape == (2, 64, 4, d)
+    assert jnp.all(jnp.isfinite(dq))
+
+
+# ===========================================================================
+# DETERMINISTIC
+# ===========================================================================
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16], ids=["fp16", "bf16"])
+def test_deterministic_consistency(dtype):
+    """Deterministic: identical results across calls."""
+    q, k_t, v = make_qkv(2, 128, 128, 4, 4, 64, dtype, seed=14)
+    o1 = run_fwd(q, k_t, v, deterministic=True)
+    o2 = run_fwd(q, k_t, v, deterministic=True)
+    assert jnp.allclose(o1, o2, atol=0)
+
+
+def test_deterministic_bwd():
+    """Deterministic backward: identical gradients across calls."""
+    q, k_t, v = make_qkv(2, 64, 64, 4, 4, 64, jnp.bfloat16, seed=14)
+    dq1, _, _ = run_bwd(q, k_t, v, deterministic=True)
+    dq2, _, _ = run_bwd(q, k_t, v, deterministic=True)
+    assert jnp.allclose(dq1, dq2, atol=0)
+
+
+# ===========================================================================
+# VARLEN TESTS
+# ===========================================================================
+
+@pytest.mark.parametrize("batch,max_sq,max_sk,hq,hk,d,dtype", VARLEN_CONFIGS)
+@pytest.mark.parametrize("causal", [False, True], ids=["nomask", "causal"])
+def test_varlen_fwd(batch, max_sq, max_sk, hq, hk, d, dtype, causal):
+    """Varlen forward: shape, dtype, finite."""
+    q, k_t, v, cu_sq, cu_sk, msq, msk = make_varlen(batch, max_sq, max_sk, hq, hk, d, dtype, seed=20)
+    out = run_varlen_fwd(q, k_t, v, cu_sq, cu_sk, msq, msk, causal=causal)
+    assert out.shape == (q.shape[0], hq, d)
+    assert out.dtype == dtype
+    assert jnp.all(jnp.isfinite(out))
+
+
+@pytest.mark.parametrize("batch,max_sq,max_sk,hq,hk,d,dtype", VARLEN_CONFIGS)
+def test_varlen_bwd(batch, max_sq, max_sk, hq, hk, d, dtype):
+    """Varlen backward: gradient shapes and finiteness."""
+    q, k_t, v, cu_sq, cu_sk, msq, msk = make_varlen(batch, max_sq, max_sk, hq, hk, d, dtype, seed=21)
+    dq, dk, dv = run_varlen_bwd(q, k_t, v, cu_sq, cu_sk, msq, msk)
+    assert dq.shape == q.shape
+    assert dk.shape == k_t.shape
+    assert dv.shape == v.shape
+    assert jnp.all(jnp.isfinite(dq))
+    assert jnp.all(jnp.isfinite(dk))
+    assert jnp.all(jnp.isfinite(dv))
+
+
+# ===========================================================================
+# EDGE CASES
+# ===========================================================================
+
+def test_decode_sq1_fwd_bwd():
+    """Decode: sq=1, forward + backward."""
+    q, k_t, v = make_qkv(2, 1, 256, 4, 4, 64, jnp.bfloat16, seed=30)
+    out = run_fwd(q, k_t, v)
+    assert out.shape == (2, 1, 4, 64)
+    dq, dk, dv = run_bwd(q, k_t, v)
+    assert jnp.all(jnp.isfinite(dq))
+
+
+def test_sq_gt_sk_nomask():
+    """sq > sk without causal mask."""
+    q, k_t, v = make_qkv(2, 256, 128, 4, 4, 64, jnp.bfloat16, seed=31)
+    out = run_fwd(q, k_t, v)
+    assert out.shape == (2, 256, 4, 64)
+    dq, dk, dv = run_bwd(q, k_t, v)
+    assert jnp.all(jnp.isfinite(dq))
+
+
+def test_sq_gt_sk_causal():
+    """sq > sk with causal mask."""
+    q, k_t, v = make_qkv(2, 256, 128, 4, 4, 64, jnp.bfloat16, seed=31)
+    out = run_fwd(q, k_t, v, causal=True)
+    assert jnp.all(jnp.isfinite(out))
+    dq, dk, dv = run_bwd(q, k_t, v, causal=True)
+    assert jnp.all(jnp.isfinite(dq))
+
+
+def test_large_batch():
+    """Batch=16."""
+    q, k_t, v = make_qkv(16, 64, 64, 4, 4, 64, jnp.bfloat16, seed=32)
+    out = run_fwd(q, k_t, v, causal=True)
+    assert jnp.all(jnp.isfinite(out))
+
+
+def test_single_head():
+    """Single head (nheads=1)."""
+    q, k_t, v = make_qkv(2, 64, 64, 1, 1, 64, jnp.bfloat16, seed=33)
+    out = run_fwd(q, k_t, v)
+    assert out.shape == (2, 64, 1, 64)
+    dq, dk, dv = run_bwd(q, k_t, v)
+    assert jnp.all(jnp.isfinite(dq))
+
+
+def test_many_heads():
+    """Many heads (nheads=16)."""
+    q, k_t, v = make_qkv(2, 64, 64, 16, 16, 64, jnp.bfloat16, seed=34)
+    out = run_fwd(q, k_t, v)
+    assert out.shape == (2, 64, 16, 64)
+
+
+# ===========================================================================
+# REGRESSION GUARDS — every historical bug from AITER bump
+# ===========================================================================
+
+class TestRegressions:
+    """Configs that caught historical bugs. Must never regress."""
+
+    def test_v3_bwd_sq_gt_sk_causal(self):
+        """c5bc2e2: ASM v3 bwd wrong gradients for causal sq > sk on gfx950."""
+        for d in [96, 128]:
+            q, k_t, v = make_qkv(2, 128, 64, 4, 4, d, jnp.bfloat16, seed=40)
+            dq, dk, dv = run_bwd(q, k_t, v, causal=True)
+            assert jnp.all(jnp.isfinite(dq)), f"d={d}: dq NaN"
+
+    @pytest.mark.parametrize("d", [96, 111, 128], ids=["d96", "d111", "d128"])
+    @pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16], ids=["fp16", "bf16"])
+    def test_1024_1023_causal(self, d, dtype):
+        """c5bc2e2: seqlen=(1024,1023) causal d>=96 on gfx950."""
+        q, k_t, v = make_qkv(2, 1024, 1023, 4, 4, d, dtype, seed=41)
+        dq, dk, dv = run_bwd(q, k_t, v, causal=True)
+        assert jnp.all(jnp.isfinite(dq)), f"d={d}: dq NaN"
+
+    def test_mqa_gqa_bwd_routing(self):
+        """e53633c: MQA/GQA backward routing (nhead_q != nhead_k guard)."""
+        for hq, hk in [(6, 3), (6, 1), (8, 2)]:
+            q, k_t, v = make_qkv(2, 128, 128, hq, hk, 64, jnp.bfloat16, seed=42)
+            dq, dk, dv = run_bwd(q, k_t, v, causal=True)
+            assert dq.shape == (2, 128, hq, 64)
+            assert dk.shape == (2, 128, hk, 64)
+            assert jnp.all(jnp.isfinite(dq)), f"hq={hq},hk={hk}: dq NaN"
+            assert jnp.all(jnp.isfinite(dk))
+            assert jnp.all(jnp.isfinite(dv))
+
+    @pytest.mark.parametrize("d", [
+        pytest.param(96, marks=pytest.mark.xfail(reason="gfx950 CK varlen bwd causal max_sk>256 kernel issue")),
+        pytest.param(128, marks=pytest.mark.xfail(reason="gfx950 CK varlen bwd causal max_sk>256 kernel issue")),
+    ], ids=["d96", "d128"])
+    def test_varlen_large_sk_causal(self, d):
+        """c5bc2e2: varlen max_sk>256 causal d>=96 on gfx950."""
+        q, k_t, v, cu_sq, cu_sk, msq, msk = make_varlen(4, 512, 512, 4, 4, d, jnp.bfloat16, seed=43)
+        dq, dk, dv = run_varlen_bwd(q, k_t, v, cu_sq, cu_sk, msq, msk, causal=True)
+        assert jnp.all(jnp.isfinite(dq)), f"d={d}: varlen dq NaN"
+
+    def test_gfx950_1block_override(self):
+        """is_950_1block: sk<=256 with hd in (64,128] forces deterministic=False."""
+        q, k_t, v = make_qkv(2, 128, 128, 4, 4, 96, jnp.bfloat16, seed=44)
+        dq, dk, dv = run_bwd(q, k_t, v, deterministic=True)
+        assert jnp.all(jnp.isfinite(dq))
+
+    def test_swa_not_v3_bwd(self):
+        """SWA excluded from ASM v3 backward (wrong gradients on gfx950)."""
+        q, k_t, v = make_qkv(2, 128, 128, 4, 4, 128, jnp.bfloat16, seed=45)
+        dq, dk, dv = run_bwd(q, k_t, v, causal=True, window_size=(32, 0))
+        assert jnp.all(jnp.isfinite(dq))
+
+    @pytest.mark.parametrize("d", [32, 64, 96, 128], ids=["d32", "d64", "d96", "d128"])
+    def test_all_head_dims_bwd(self, d):
+        """All common head dims produce finite backward gradients."""
+        q, k_t, v = make_qkv(2, 64, 64, 4, 4, d, jnp.bfloat16, seed=46)
+        dq, dk, dv = run_bwd(q, k_t, v)
+        assert jnp.all(jnp.isfinite(dq)), f"d={d}: dq NaN"
+        assert jnp.all(jnp.isfinite(dk))
+        assert jnp.all(jnp.isfinite(dv))

--- a/third_party/aiter/BUILD
+++ b/third_party/aiter/BUILD
@@ -1,0 +1,43 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+cc_import(
+    name = "mha_fwd_so",
+    shared_library = "@aiter_mha_wheel//:libs/libmha_fwd.so",
+    deps = ["@aiter_mha_wheel//:aiter_headers"],
+)
+
+cc_import(
+    name = "mha_bwd_so",
+    shared_library = "@aiter_mha_wheel//:libs/libmha_bwd.so",
+    deps = ["@aiter_mha_wheel//:aiter_headers"],
+)
+
+cc_library(
+    name = "aiter_mha",
+    deps = [
+        ":mha_fwd_so",
+        ":mha_bwd_so",
+    ],
+)
+
+filegroup(
+    name = "aiter_runtime_sos",
+    srcs = [
+        "@aiter_mha_wheel//:libs/libmha_fwd.so",
+        "@aiter_mha_wheel//:libs/libmha_bwd.so",
+    ],
+)

--- a/third_party/aiter/workspace.bzl
+++ b/third_party/aiter/workspace.bzl
@@ -1,0 +1,81 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_BUILD_CONTENT = """\
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "libs/libmha_fwd.so",
+    "libs/libmha_bwd.so",
+])
+
+cc_library(
+    name = "aiter_headers",
+    hdrs = [
+        "include/aiter_hip_common.h",
+        "include/aiter_logger.h",
+        "include/mha_bwd.h",
+        "include/mha_fwd.h",
+    ],
+    strip_include_prefix = "include",
+    include_prefix = "aiter",
+)
+"""
+
+_AITER_MHA_URL = "https://github.com/ROCm/jax/releases/download/AITER-MHA/aiter_mha-0.1.0-py3-none-linux_x86_64.whl"
+_AITER_MHA_SHA256 = "943e8736ded39244acab96c0c4e3901aa0cb166fdbcd1e0bee178799e21868c2"
+_AITER_MHA_STRIP_PREFIX = "aiter_mha-0.1.0.data"
+
+_REQUIRED_FILES = [
+    "libs/libmha_fwd.so",
+    "libs/libmha_bwd.so",
+    "include/aiter_hip_common.h",
+    "include/aiter_logger.h",
+    "include/mha_bwd.h",
+    "include/mha_fwd.h",
+]
+
+def _aiter_mha_repo_impl(repository_ctx):
+    local_path = repository_ctx.os.environ.get("LOCAL_AITER_PATH", "")
+    if local_path:
+        for f in _REQUIRED_FILES:
+            src = local_path + "/" + f
+            result = repository_ctx.execute(["test", "-f", src])
+            if result.return_code != 0:
+                fail("LOCAL_AITER_PATH=%s is missing %s" % (local_path, f))
+            repository_ctx.symlink(src, f)
+    else:
+        repository_ctx.download_and_extract(
+            url = [_AITER_MHA_URL],
+            sha256 = _AITER_MHA_SHA256,
+            type = "zip",
+            stripPrefix = _AITER_MHA_STRIP_PREFIX,
+        )
+    repository_ctx.file("BUILD.bazel", _BUILD_CONTENT)
+
+_aiter_mha_repo = repository_rule(
+    implementation = _aiter_mha_repo_impl,
+    environ = ["LOCAL_AITER_PATH"],
+)
+
+def aiter_mha_whl():
+    """Provides @aiter_mha_wheel with libmha_fwd.so, libmha_bwd.so, and headers.
+
+    By default, downloads a pre-built wheel from GitHub. To use local libs:
+      a) python build/build.py build --local_aiter_path=/path/to/aiter_mha-0.1.0.data
+      b) --bazel_options='--repo_env=LOCAL_AITER_PATH=/path/to/aiter_mha-0.1.0.data'
+
+    The directory must contain libs/{libmha_fwd,libmha_bwd}.so and include/*.h.
+    """
+    _aiter_mha_repo(name = "aiter_mha_wheel")


### PR DESCRIPTION
## Summary

This PR adds AMD AITER's flash-attention kernels (both Composable-Kernel and ASM v3 backends) as a first-class JAX primitive on ROCm. The kernels are exposed through the FFI as `hip_mha_fwd_ffi` / `hip_mha_bwd_ffi` and wrapped on the Python side by `flash_attn_func` (batch) and `flash_attn_varlen` (variable-length), both with `custom_vjp` for autograd and `custom_partitioning`.
The pre-built AITER shared libraries and headers are fetched as a Bazel external repo (`@aiter_mha_wheel`) from the `ROCm/jax` GitHub release `AITER-MHA`, or sourced from a local checkout via `LOCAL_AITER_PATH` for development.

## Motivation
JAX on ROCm currently has no production-grade fused attention kernel. AITER provides tuned CK and ASM v3 kernels for gfx942 / gfx950. Integrating them directly into `jaxlib` (rather than as an out-of-tree plugin) means:
- one wheel ships everything users need (`libmha_fwd.so`, `libmha_bwd.so` are bundled into the `jax-rocm-*-plugin` wheel),
- FSDP / batch-sharded attention works through `custom_partitioning` without any user-side glue,
- Python users get a stable `jax._src.aiter` API that does not depend on PyTorch / `aiter` Python package.

## Public API
```python
from jax._src.aiter import flash_attn_func, flash_attn_varlen
```

Both functions:

support fp16 / bf16, head dims 32–256, MHA / MQA / GQA,
accept causal, sliding-window (window_size_left, window_size_right), softmax_scale, dropout_p, ALiBi slopes, attention bias, logits soft-cap,
expose use_asm_v3 to opt into the ASM v3 backend (with how_v3_bf16_cvt, is_v3_atomic_fp32 knobs),
return either the output alone or (out, lse, ...) when return_lse / return_randval are set,
are differentiable through custom_vjp, and partitionable through custom_partitioning (output sharding follows Q, no collectives — every dim except batch is replicated per device).
If the AITER .so are not present at runtime (e.g. CUDA build, or stripped wheel), the public symbols import as None so the rest of jax still loads.

## What's in the PR

FFI handlers (C++):

- jaxlib/gpu/aiter_mha_fwd.cc — unified forward handler (aiter::mha_fwd), batch + varlen detected from rank.
- jaxlib/gpu/aiter_mha_bwd.cc — unified backward handler (aiter::mha_bwd).
- jaxlib/gpu/aiter_mha_common_utils.{cc,h} — dtype / stride / mask / bias helpers shared between fwd and bwd.
- jaxlib/gpu/aiter.{cc,h} — nanobind module _aiter exporting hip_mha_fwd_ffi / hip_mha_bwd_ffi registrations.

Python:

- jax/_src/aiter/aiter_mha.py — flash_attn_func, flash_attn_varlen, custom_vjp, custom_partitioning, FFI wrappers, GFX detection.
- jax/_src/aiter/__init__.py — public re-exports with graceful fallback when the kernels are unavailable.
- jaxlib/gpu_aiter.py — plugin-aware loader that pulls _aiter out of the installed ROCm plugin wheel.
- jax/_src/lib/__init__.py — best-effort import jaxlib.gpu_aiter (falls back to None).

Build / packaging:

- WORKSPACE, third_party/aiter/workspace.bzl, third_party/aiter/BUILD — fetch the AITER MHA wheel by URL+SHA256, expose libmha_{fwd,bwd}.so and headers, support LOCAL_AITER_PATH override (symlinks a local aiter_mha-*.data directory).
- jaxlib/rocm/BUILD — new aiter_mha rocm_library and _aiter nanobind extension; added to rocm_gpu_support.
- jaxlib/gpu/BUILD, jaxlib/BUILD, jax/BUILD, jax/_src/BUILD — wire the new sources / py targets.
- jaxlib/tools/build_gpu_kernels_wheel.py — copy libmha_{fwd,bwd}.so into the ROCm plugin wheel and fail the build if either is missing, so a broken wheel can never ship.
- jaxlib/tools/build_wheel.py, jaxlib/tools/BUILD.bazel — include gpu_aiter.py in jaxlib and the AITER .sos in wheel_sources.
- build/build.py, build/rocm/dev_build_rocm.py, build/rocm/tools/build_wheels.py — new --local_aiter_path / --local-aiter-path CLI flag that forwards to --repo_env=LOCAL_AITER_PATH=....

Tests:

- tests/aiter_mha_test.py (570+ lines) — gated on ROCm devices, covers:

- - all supported head dims (32, 40, 59, 64, 96, 111, 128, 160, 256),
- - MHA / MQA / GQA, self-attention, cross-attention, off-by-one shapes, decode (sq=1), batch=8,
- - varlen (cu_seqlens) variants of the above,
- - causal, SWA, dropout (shape/finiteness only),