### PR TITLE
Add custom Pallas Xoshiro128++ and Threefry GPU PRNG kernels

### DIFF
--- a/jax/experimental/pallas/ops/gpu/random/threefry.py
+++ b/jax/experimental/pallas/ops/gpu/random/threefry.py
@@ -1,0 +1,128 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Implementation of the Threefry PRNG as a Pallas GPU kernel."""
+
+import math
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import triton as pltriton
+from jax._src import prng
+
+
+def make_threefry_kernel(block_size: int = 256):
+    def kernel(key_ref, out_ref):
+        pid = pl.program_id(0)
+        idx = jax.lax.iota(jnp.uint32, block_size)
+        global_idx = (pid.astype(jnp.uint32) * jnp.uint32(block_size)) + idx
+
+        k0 = key_ref[0]
+        k1 = key_ref[1]
+        ks0 = k0
+        ks1 = k1
+        ks2 = k0 ^ k1 ^ jnp.uint32(0x1BD11BDA)
+
+        c0 = jnp.zeros_like(global_idx)
+        c1 = global_idx
+
+        x0 = c0 + ks0
+        x1 = c1 + ks1
+
+        rotations = [13, 15, 26, 6, 17, 29, 16, 24]
+        for r in range(20):
+            x0 = x0 + x1
+            rot = rotations[r % 8]
+            x1 = (x1 << jnp.uint32(rot)) | (x1 >> jnp.uint32(32 - rot))
+            x1 = x1 ^ x0
+
+            if r == 3:
+                x0 = x0 + ks1
+                x1 = x1 + ks2 + jnp.uint32(1)
+            elif r == 7:
+                x0 = x0 + ks2
+                x1 = x1 + ks0 + jnp.uint32(2)
+            elif r == 11:
+                x0 = x0 + ks0
+                x1 = x1 + ks1 + jnp.uint32(3)
+            elif r == 15:
+                x0 = x0 + ks1
+                x1 = x1 + ks2 + jnp.uint32(4)
+            elif r == 19:
+                x0 = x0 + ks2
+                x1 = x1 + ks0 + jnp.uint32(5)
+
+        out_ref[:, 0] = x0
+        out_ref[:, 1] = x1
+
+    return kernel
+
+
+def plthreefry_random_bits(key, bit_width: int, shape, block_size: int = 256):
+    """
+    Generates random bits using natively unrolled Threefry2x32 via Triton.
+
+    This matches JAX's `threefry_partitionable` implementation natively.
+    """
+    if bit_width not in (32, 64):
+        raise ValueError(f"bit_width must be 32 or 64, got {bit_width}")
+
+    flat_size = int(math.prod(shape))
+
+    if flat_size > jnp.iinfo(jnp.uint32).max:
+        raise ValueError(
+            f"Shape too large ({flat_size} elements). "
+            f"Shapes larger than {jnp.iinfo(jnp.uint32).max} are not yet supported "
+            "due to 32-bit counter limits."
+        )
+
+    if flat_size == 0:
+        dtype = jnp.uint64 if bit_width == 64 else jnp.uint32
+        return jnp.empty(shape, dtype=dtype)
+
+    padded_size = (flat_size + block_size - 1) // block_size * block_size
+    num_blocks = padded_size // block_size
+
+    out_flat = pl.pallas_call(
+        make_threefry_kernel(block_size),
+        in_specs=[pl.BlockSpec((2,), lambda i: (0,))],
+        out_specs=pl.BlockSpec((block_size, 2), lambda i: (i, 0)),
+        grid=(num_blocks,),
+        out_shape=jax.ShapeDtypeStruct((num_blocks * block_size, 2), jnp.uint32),
+        compiler_params=pltriton.CompilerParams(),
+    )(key)
+
+    out_flat = out_flat[:flat_size]
+
+    if bit_width == 32:
+        # JAX's threefry_partitionable uses counter=(counts_hi, counts_lo) and folds
+        # output as x0 ^ x1 for 32-bit widths. This kernel uses (c0=0, c1=global_idx)
+        # which matches JAX's scheme for flat_size < 2^32.
+        # See jax._src.prng._threefry_random_bits_partitionable, approx line 630
+        out = out_flat[:, 0] ^ out_flat[:, 1]
+    elif bit_width == 64:
+        out = (out_flat[:, 0].astype(jnp.uint64) << jnp.uint64(32)) | out_flat[:, 1].astype(jnp.uint64)
+
+    return jnp.reshape(out, shape)
+
+
+plthreefry_prng_impl = prng.PRNGImpl(
+    key_shape=(2,),
+    seed=prng.threefry_seed,
+    split=prng.threefry_split,
+    random_bits=plthreefry_random_bits,
+    fold_in=prng.threefry_fold_in,
+    name="pallas_threefry2x32_gpu",
+    tag="plfry")
+
+prng.register_prng(plthreefry_prng_impl)

--- a/jax/experimental/pallas/ops/gpu/random/xoshiro.py
+++ b/jax/experimental/pallas/ops/gpu/random/xoshiro.py
@@ -1,0 +1,156 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Implementation of the Xoshiro128++ PRNG as a Pallas kernel.
+
+Unlike the canonical Xoshiro128++ algorithm, which expects 128 bits of
+pre-mixed entropy for initialization, this implementation is adapted for
+massively parallel execution. Because thousands of GPU threads cannot share
+the same initial 128-bit seed, this kernel derives the 128-bit state
+dynamically for each thread. It mixes a global thread index with the provided
+JAX PRNG key using a MurmurHash3 avalanche function and Weyl sequence steps,
+guaranteeing a unique starting state for every thread.
+"""
+import math
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax._src import prng
+from jax.experimental.pallas import triton as pltriton
+from jax._src.prng import threefry_2x32
+
+def rotl32(x, k):
+    return (x << jnp.uint32(k)) | (x >> jnp.uint32(32 - k))
+
+def _mix32(z):
+    """MurmurHash3 / SplitMix32 finalizer"""
+    z += jnp.uint32(1)
+    z = (z ^ (z >> jnp.uint32(16))) * jnp.uint32(0x85ebca6b)
+    z = (z ^ (z >> jnp.uint32(13))) * jnp.uint32(0xc2b2ae35)
+    return z ^ (z >> jnp.uint32(16))
+
+def make_xoshiro_kernel(block_size: int, elements_per_thread: int):
+    def kernel(key_ref, out_ref):
+        pid = pl.program_id(0)
+        idx = jax.lax.iota(jnp.uint32, block_size)
+        global_idx = (pid.astype(jnp.uint32) * jnp.uint32(block_size)) + idx
+
+        k0 = key_ref[0]
+        k1 = key_ref[1]
+
+        # Mix k0 and k1. 0x6C62272E (the upper 32 bits of the FNV-128 offset basis)
+        # is used as a multiplier to break symmetry between k0 and k1.
+        k0_mixed = _mix32(k0)
+        k1_mixed = _mix32(k1) * jnp.uint32(0x6C62272E)
+        thread_state = global_idx ^ k0_mixed ^ k1_mixed
+
+        # 0x9E3779B9 is a Weyl sequence constant (golden ratio * 2^32).
+        # We use 4 Weyl steps to initialize the 4 separate 32-bit state words.
+        weyl = jnp.uint32(0x9E3779B9)
+        s0 = _mix32(thread_state + weyl)
+        s1 = _mix32(thread_state + weyl * jnp.uint32(2))
+        s2 = _mix32(thread_state + weyl * jnp.uint32(3))
+        s3 = _mix32(thread_state + weyl * jnp.uint32(4))
+
+        s0 = jnp.where(s0 == 0, jnp.uint32(1), s0)
+
+        for i in range(elements_per_thread):
+            result = rotl32(s0 + s3, 7) + s0
+
+            t = s1 << jnp.uint32(9)
+            s2 ^= s0
+            s3 ^= s1
+            s1 ^= s2
+            s0 ^= s3
+            s2 ^= t
+            s3 = rotl32(s3, 11)
+
+            # Note on memory layout (thread-first ordering):
+            # Threads write to columns instead of rows. After flattening (.T) in the
+            # wrapper, the output groups elements by thread. This is intentional to
+            # maximize performance for sequential workloads (like MCTS) by keeping
+            # the stateful generator within registers.
+            out_ref[i, :] = result
+
+    return kernel
+
+def xoshiro_random_bits(key, bit_width: int, shape, block_size: int = 256, elements_per_thread: int = 8):
+    if bit_width not in (32, 64):
+        raise ValueError(f"bit_width must be 32 or 64, got {bit_width}")
+
+    multiplier = 2 if bit_width == 64 else 1
+    flat_size = int(math.prod(shape)) * multiplier
+
+    if flat_size > jnp.iinfo(jnp.uint32).max:
+        raise ValueError(
+            f"Shape too large ({flat_size} elements). "
+            f"Shapes larger than {jnp.iinfo(jnp.uint32).max} are not yet supported "
+            "due to 32-bit counter limits."
+        )
+
+    if flat_size == 0:
+        dtype = jnp.uint64 if bit_width == 64 else jnp.uint32
+        return jnp.empty(shape, dtype=dtype)
+
+    tile = block_size * elements_per_thread
+    padded = (flat_size + tile - 1) // tile * tile
+    num_blocks = padded // tile
+
+    out_flat = pl.pallas_call(
+        make_xoshiro_kernel(block_size, elements_per_thread),
+        in_specs=[pl.BlockSpec((2,), lambda i: (0,))],
+        out_specs=pl.BlockSpec(
+            (elements_per_thread, block_size), lambda i: (0, i)
+        ),
+        grid=(num_blocks,),
+        out_shape=jax.ShapeDtypeStruct(
+            (elements_per_thread, num_blocks * block_size), jnp.uint32
+        ),
+        compiler_params=pltriton.CompilerParams(),
+    )(key)
+
+    out = jnp.reshape(out_flat.T, (-1,))[:flat_size]
+
+    if bit_width == 64:
+        out = jnp.reshape(out, (-1, 2))
+        out = (
+            (out[:, 0].astype(jnp.uint64) << jnp.uint64(32))
+            | out[:, 1].astype(jnp.uint64)
+        )
+
+    return jnp.reshape(out, shape)
+
+def xoshiro_split(key, shape):
+    flat_size = int(math.prod(shape))
+    indices = jnp.arange(flat_size, dtype=jnp.uint32)
+    counters = jnp.stack([indices, jnp.zeros_like(indices)], axis=1)
+    new_keys = jax.vmap(lambda c: threefry_2x32(key, c))(counters)
+    return jnp.reshape(new_keys, tuple(shape) + (2,))
+
+def xoshiro_fold_in(key, data):
+    data32 = jnp.uint32(data)
+    counter = jnp.array([data32, jnp.uint32(0)], dtype=jnp.uint32)
+    return threefry_2x32(key, counter)
+
+plxoshiro_prng_impl = prng.PRNGImpl(
+    key_shape=(2,),
+    seed=prng.threefry_seed,
+    split=xoshiro_split,
+    random_bits=xoshiro_random_bits,
+    fold_in=xoshiro_fold_in,
+    name="pallas_xoshiro128pp",
+    tag="plxos",
+)
+
+prng.register_prng(plxoshiro_prng_impl)

--- a/tests/pallas/gpu_pallas_random_test.py
+++ b/tests/pallas/gpu_pallas_random_test.py
@@ -1,0 +1,362 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+from jax import random as jax_random
+from jax._src import test_util as jtu
+import jax.numpy as jnp
+import numpy as np
+from jax._src import shard_map
+
+import jax.experimental.pallas.ops.gpu.random.xoshiro
+import jax.experimental.pallas.ops.gpu.random.threefry
+
+P = jax.sharding.PartitionSpec
+
+jax.config.parse_flags_with_absl()
+
+class XoshiroTest(jtu.JaxTestCase):
+
+  def setUp(self):
+    if not jtu.test_device_matches(["gpu"]):
+      self.skipTest("Need GPU devices")
+    super().setUp()
+
+  def test_deterministic(self):
+    key = jax_random.key(42, impl="pallas_xoshiro128pp")
+    out1 = jax_random.bits(key, shape=(512,), dtype=jnp.uint32)
+    out2 = jax_random.bits(key, shape=(512,), dtype=jnp.uint32)
+    np.testing.assert_array_equal(out1, out2)
+
+  def test_large_shape_raises(self):
+    key = jax_random.key(0, impl="pallas_xoshiro128pp")
+    with self.assertRaisesRegex(ValueError, "too large"):
+      jax_random.bits(key, shape=(2**32,), dtype=jnp.uint32)
+
+  def test_different_keys_produce_different_output(self):
+    key1 = jax_random.key(0, impl="pallas_xoshiro128pp")
+    key2 = jax_random.key(1, impl="pallas_xoshiro128pp")
+    out1 = jax_random.bits(key1, shape=(512,), dtype=jnp.uint32)
+    out2 = jax_random.bits(key2, shape=(512,), dtype=jnp.uint32)
+    with self.assertRaises(AssertionError):
+        np.testing.assert_array_equal(out1, out2)
+
+  def test_kernel_matches_python_reference(self):
+    # Pure Python reference implementation of the kernel logic
+    def _mix32_py(z):
+        z = (int(z) + 1) & 0xFFFFFFFF
+        z = ((z ^ (z >> 16)) * 0x85ebca6b) & 0xFFFFFFFF
+        z = ((z ^ (z >> 13)) * 0xc2b2ae35) & 0xFFFFFFFF
+        return z ^ (z >> 16)
+
+    def _rotl32_py(x, k):
+        x = int(x)
+        return ((x << k) & 0xFFFFFFFF) | (x >> (32 - k))
+
+    def get_expected_for_thread(global_idx, key_data, elements_per_thread=4):
+        k0_mixed = _mix32_py(key_data[0])
+        k1_mixed = (_mix32_py(key_data[1]) * 0x6C62272E) & 0xFFFFFFFF
+        thread_state = global_idx ^ k0_mixed ^ k1_mixed
+
+        weyl = 0x9E3779B9
+        s0 = _mix32_py((thread_state + weyl) & 0xFFFFFFFF)
+        s0 = 1 if s0 == 0 else s0
+        s1 = _mix32_py((thread_state + weyl * 2) & 0xFFFFFFFF)
+        s2 = _mix32_py((thread_state + weyl * 3) & 0xFFFFFFFF)
+        s3 = _mix32_py((thread_state + weyl * 4) & 0xFFFFFFFF)
+
+        expected = []
+        for _ in range(elements_per_thread):
+            result = (_rotl32_py((s0 + s3) & 0xFFFFFFFF, 7) + s0) & 0xFFFFFFFF
+            expected.append(result)
+
+            t = (s1 << 9) & 0xFFFFFFFF
+            s2 ^= s0
+            s3 ^= s1
+            s1 ^= s2
+            s0 ^= s3
+            s2 ^= t
+            s3 = _rotl32_py(s3, 11)
+        return np.array(expected, dtype=np.uint32)
+
+    key = jax_random.key(42, impl="pallas_xoshiro128pp")
+    key_data = jax_random.key_data(key)
+
+    # Generate 3000 elements to guarantee we spill over into Block 1
+    # (Block 0 holds 256 threads * 8 elements = 2048 elements).
+    out = jax_random.bits(key, shape=(3000,), dtype=jnp.uint32)
+
+    expected_t0 = get_expected_for_thread(0, key_data, elements_per_thread=4)
+    np.testing.assert_array_equal(out[0:4], expected_t0)
+
+    expected_t256 = get_expected_for_thread(256, key_data, elements_per_thread=4)
+    np.testing.assert_array_equal(out[2048:2052], expected_t256)
+
+  @parameterized.parameters(
+      ((256,),),
+      ((4, 128),),
+  )
+  def test_generate_bits_64(self, shape):
+    if not jax.config.jax_enable_x64:
+      self.skipTest("Requires JAX_ENABLE_X64=1")
+
+    key = jax_random.key(0, impl="pallas_xoshiro128pp")
+    out = jax_random.bits(key, shape=shape, dtype=jnp.uint64)
+    self.assertEqual(out.dtype, jnp.uint64)
+    self.assertEqual(out.shape, shape)
+
+  @parameterized.parameters(
+      ((512, 512),),
+      ((137, 275),),
+      ((4, 512, 512),),
+      ((34,),),
+      ((),),
+      ((0,),),
+  )
+  def test_generate_bits(self, shape):
+    key_pl = jax_random.key(0, impl="pallas_xoshiro128pp")
+    pl_gen = jax_random.bits(key_pl, shape=shape, dtype=jnp.uint32)
+    self.assertEqual(pl_gen.shape, shape)
+    self.assertEqual(pl_gen.dtype, jnp.uint32)
+
+    if pl_gen.size > 1:
+      unique_frac = float(len(jnp.unique(pl_gen))) / pl_gen.size
+      self.assertGreater(unique_frac, 0.99)
+
+  def test_split(self):
+    key = jax_random.key(42, impl="pallas_xoshiro128pp")
+    key1, key2 = jax_random.split(key)
+    with self.assertRaises(AssertionError):
+      np.testing.assert_array_equal(jax_random.key_data(key), jax_random.key_data(key1))
+    with self.assertRaises(AssertionError):
+      np.testing.assert_array_equal(jax_random.key_data(key), jax_random.key_data(key2))
+    with self.assertRaises(AssertionError):
+      np.testing.assert_array_equal(jax_random.key_data(key1), jax_random.key_data(key2))
+
+  def test_foldin(self):
+    key = jax_random.key(42, impl="pallas_xoshiro128pp")
+    key_f0 = jax_random.fold_in(key, 0)
+    key_f1 = jax_random.fold_in(key, 1)
+    key_f2 = jax_random.fold_in(key, 2)
+
+    keys = [key, key_f0, key_f1, key_f2]
+    for i in range(len(keys)):
+      for j in range(i + 1, len(keys)):
+        with self.assertRaises(AssertionError):
+          np.testing.assert_array_equal(jax_random.key_data(keys[i]), jax_random.key_data(keys[j]))
+
+  def test_vmap(self):
+    key = jax_random.key(42, impl="pallas_xoshiro128pp")
+    keys = jax_random.split(key, 10)
+
+    @jax.vmap
+    def generate(k):
+        return jax_random.bits(k, shape=(128,), dtype=jnp.uint32)
+
+    vmapped_out = generate(keys)
+    self.assertEqual(vmapped_out.shape, (10, 128))
+    unique_frac = float(len(jnp.unique(vmapped_out))) / vmapped_out.size
+    self.assertGreater(unique_frac, 0.99)
+
+  @parameterized.parameters(
+      ((512, 512),),
+      ((137, 275),),
+  )
+  def test_generate_uniform(self, shape):
+    key = jax_random.key(0, impl="pallas_xoshiro128pp")
+    values = jax_random.uniform(key, shape=shape)
+    if values.size > 0:
+        self.assertGreaterEqual(jnp.min(values), 0.0)
+        self.assertLessEqual(jnp.max(values), 1.0)
+
+  @parameterized.parameters(
+      ((256, 256),),
+      ((35, 113),),
+  )
+  def test_xoshiro_sharded(self, shape):
+    if jax.device_count() < 2:
+      self.skipTest("Need at least 2 devices")
+
+    num_devices = jax.device_count()
+    partition = P("x")
+    mesh = jax.make_mesh(
+        (num_devices,),
+        ("x",),
+        axis_types=(jax.sharding.AxisType.Auto,),
+    )
+    sharding = jax.sharding.NamedSharding(mesh, partition)
+
+    key_pallas = jax_random.split(
+        jax_random.key(0, impl="pallas_xoshiro128pp"), num_devices)
+    key_pallas = jax.device_put(key_pallas, sharding)
+
+    generate = shard_map.shard_map(
+        lambda x: jax_random.bits(x[0], shape=shape),
+        mesh=mesh,
+        in_specs=partition,
+        out_specs=partition,
+        check_rep=False,
+    )
+    pl_gen = generate(key_pallas)
+
+    self.assertEqual(pl_gen.shape, shape)
+
+    shard_outputs = jnp.reshape(pl_gen, (num_devices, -1))
+    for i in range(num_devices):
+        for j in range(i + 1, num_devices):
+            with self.assertRaises(AssertionError):
+                np.testing.assert_array_equal(shard_outputs[i], shard_outputs[j])
+
+
+class ThreefryTest(jtu.JaxTestCase):
+
+  def setUp(self):
+    if not jtu.test_device_matches(["gpu"]):
+      self.skipTest("Need GPU devices")
+    super().setUp()
+
+  def test_deterministic(self):
+    key = jax_random.key(42, impl="pallas_threefry2x32_gpu")
+    out1 = jax_random.bits(key, shape=(512,), dtype=jnp.uint32)
+    out2 = jax_random.bits(key, shape=(512,), dtype=jnp.uint32)
+    np.testing.assert_array_equal(out1, out2)
+
+  def test_large_shape_raises(self):
+    key = jax_random.key(0, impl="pallas_threefry2x32_gpu")
+    with self.assertRaisesRegex(ValueError, "too large"):
+      jax_random.bits(key, shape=(2**32,), dtype=jnp.uint32)
+
+  @parameterized.parameters(
+      ((256,),),
+      ((4, 128),),
+  )
+  def test_generate_bits_64(self, shape):
+    if not jax.config.jax_enable_x64:
+      self.skipTest("Requires JAX_ENABLE_X64=1")
+
+    with jax.threefry_partitionable(True):
+      key_jax = jax_random.key(0, impl="threefry2x32")
+      jax_gen = jax_random.bits(key_jax, shape=shape, dtype=jnp.uint64)
+
+      key_pl = jax_random.key(0, impl="pallas_threefry2x32_gpu")
+      pl_gen = jax_random.bits(key_pl, shape=shape, dtype=jnp.uint64)
+
+    self.assertEqual(pl_gen.dtype, jnp.uint64)
+    self.assertEqual(pl_gen.shape, shape)
+    np.testing.assert_array_equal(jax_gen, pl_gen)
+
+  @parameterized.parameters(
+      ((512, 512),),
+      ((137, 275),),
+      ((4, 512, 512),),
+      ((34,),),
+      ((),),
+  )
+  def test_pallas_matches_jax_threefry(self, shape):
+    with jax.threefry_partitionable(True):
+      key_jax = jax_random.key(42, impl="threefry2x32")
+      jax_gen = jax_random.bits(key_jax, shape=shape)
+
+      key_pl = jax_random.key(42, impl="pallas_threefry2x32_gpu")
+      pl_gen = jax_random.bits(key_pl, shape=shape)
+
+    np.testing.assert_array_equal(jax_gen, pl_gen)
+
+  def test_split(self):
+    key = jax_random.key(42, impl="pallas_threefry2x32_gpu")
+    key1, key2 = jax_random.split(key)
+    with self.assertRaises(AssertionError):
+      np.testing.assert_array_equal(jax_random.key_data(key), jax_random.key_data(key1))
+    with self.assertRaises(AssertionError):
+      np.testing.assert_array_equal(jax_random.key_data(key), jax_random.key_data(key2))
+    with self.assertRaises(AssertionError):
+      np.testing.assert_array_equal(jax_random.key_data(key1), jax_random.key_data(key2))
+
+  def test_foldin(self):
+    key = jax_random.key(42, impl="pallas_threefry2x32_gpu")
+    key_f0 = jax_random.fold_in(key, 0)
+    key_f1 = jax_random.fold_in(key, 1)
+    key_f2 = jax_random.fold_in(key, 2)
+
+    keys = [key, key_f0, key_f1, key_f2]
+    for i in range(len(keys)):
+      for j in range(i + 1, len(keys)):
+        with self.assertRaises(AssertionError):
+          np.testing.assert_array_equal(jax_random.key_data(keys[i]), jax_random.key_data(keys[j]))
+
+  def test_vmap(self):
+    key = jax_random.key(42, impl="pallas_threefry2x32_gpu")
+    keys = jax_random.split(key, 10)
+
+    @jax.vmap
+    def generate(k):
+        return jax_random.bits(k, shape=(128,), dtype=jnp.uint32)
+
+    vmapped_out = generate(keys)
+    self.assertEqual(vmapped_out.shape, (10, 128))
+    unique_frac = float(len(jnp.unique(vmapped_out))) / vmapped_out.size
+    self.assertGreater(unique_frac, 0.99)
+
+  @parameterized.parameters(
+      ((512, 512),),
+      ((137, 275),),
+  )
+  def test_generate_uniform(self, shape):
+    key = jax_random.key(0, impl="pallas_threefry2x32_gpu")
+    values = jax_random.uniform(key, shape=shape)
+    self.assertGreaterEqual(jnp.min(values), 0.0)
+    self.assertLessEqual(jnp.max(values), 1.0)
+
+  @parameterized.parameters(
+      ((256, 256),),
+      ((35, 113),),
+      ((331,),),
+  )
+  def test_threefry_kernel_matches_jax_threefry_sharded(self, shape):
+    if jax.device_count() < 2:
+      self.skipTest("Need at least 2 devices")
+    num_devices = jax.device_count()
+    partition = P("x")
+    mesh = jax.make_mesh(
+        (num_devices,),
+        ("x",),
+        axis_types=(jax.sharding.AxisType.Auto,),
+    )
+    sharding = jax.sharding.NamedSharding(mesh, partition)
+
+    with jax.threefry_partitionable(True):
+      key_jax = jax_random.split(
+          jax_random.key(0, impl="threefry2x32"), num_devices)
+      key_pallas = jax_random.split(
+          jax_random.key(0, impl="pallas_threefry2x32_gpu"), num_devices)
+
+      key_jax = jax.device_put(key_jax, sharding)
+      key_pallas = jax.device_put(key_pallas, sharding)
+
+      generate = shard_map.shard_map(
+          lambda x: jax_random.bits(x[0], shape=shape),
+          mesh=mesh,
+          in_specs=partition,
+          out_specs=partition,
+          check_rep=False,
+      )
+      jax_gen = generate(key_jax)
+      pl_gen = generate(key_pallas)
+
+    np.testing.assert_array_equal(jax_gen, pl_gen)
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Hi! This PR integrates two PRNG algorithms into Pallas for the GPU. We modeled the implementation closely after the existing TPU PRNGs to keep the API consistent and straightforward.

**Threefry**: The standard JAX solution, implemented as a custom Pallas kernel for the GPU.

**Xoshiro128++**: As discussed in [#34557](https://github.com/jax-ml/jax/discussions/34557), this contribution stems from our work on MCTS in JAX. For thesesequential workloads, keeping a stateful PRNG locked in the GPU registers vastly outperforms recalculating a stateless hash. It seemed nice to us to give other developers the option of using a different approach in case they needed to.
The JAX implementation for this has been done by @brenerf as per [this PR](https://github.com/gregghy/jax_paris8_fork/pull/2) on our fork 

We added a comprehensive test suite that follows the model of the TPU random testing.

This is our first contribution to JAX, and we did our best to follow all the guidelines in the Contributing page. If there are any problems please let me know, we'll be happy to help!

