### PR TITLE
[debug_info] Fix result_paths usage in _check_returned_jaxtypes

### DIFF
--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -2394,7 +2394,7 @@ def _check_returned_jaxtypes(dbg, out_tracers):
   for i, x in enumerate(out_tracers):
     try: typeof(x)
     except TypeError:
-      if (dbg and len(paths := dbg.resolve_result_paths()) > i and
+      if (dbg and len(paths := dbg.resolve_result_paths().result_paths) > i and
           (p := paths[i].removeprefix('result'))):
         extra = f' at output component {p}'
       else:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3010,6 +3010,16 @@ class APITest(jtu.JaxTestCase):
     out_shape = api.eval_shape(lambda x: x, x)  # doesn't crash
     self.assertEqual(out_shape.shape, (3,))
 
+  def test_eval_shape_error_bad_output(self):
+    def f(x):
+      return (2.0, f)
+
+    with self.assertRaisesRegex(
+        TypeError,
+        r'function f at .*returned a value.*'
+        r'at output component \[1\], which is not a valid JAX type'):
+      api.eval_shape(f, 1)
+
   def test_issue_871(self):
     T = jnp.array([[1., 2.], [3., 4.], [5., 6.]])
     x = jnp.array([1, 2, 3])


### PR DESCRIPTION
Previously, `paths := dbg.resolve_result_paths()`
was picking up the whole `DebugInfo`, which resulted in `paths[i]` picking various fields of the `DebugInfo`, instead of the result paths.

