### PR TITLE
Small fix in the hooks for repro generation.

### DIFF
--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -1355,6 +1355,7 @@ def _pallas_call_state_discharge_rule(
   return updated_vals_in, rest
 
 
+@partial(api_boundary, repro_api_name="jax.experimental.pallas.pallas_call")
 def pallas_call(
     kernel: Callable[..., None],
     out_shape: Any,
@@ -1464,7 +1465,6 @@ def pallas_call(
   )
 
 
-@partial(api_boundary, repro_api_name="jax.experimental.pallas.pallas_call")
 def _pallas_call(
     kernel: Callable[..., None],
     out_shape: Any,

--- a/jax/_src/traceback_util.py
+++ b/jax/_src/traceback_util.py
@@ -226,8 +226,8 @@ def api_boundary(
         raise
       finally:
         del mode, tb
-  if (repro_api_name or repro_user_func) and repro:
-    reraise_with_filtered_traceback = repro.boundary(
+  if repro and (repro_api_name or repro_user_func):
+    reraise_with_filtered_traceback = repro.boundary(  # pyrefly: ignore [missing-attribute]
         reraise_with_filtered_traceback, api_name=repro_api_name,
         is_user=repro_user_func)
   return cast(C, reraise_with_filtered_traceback)
@@ -236,7 +236,6 @@ try:
   # TODO: import from the final location
   from jax._src import repro  # pyrefly: ignore[missing-module-attribute]
   repro_is_enabled = repro.is_enabled
-
-except ImportError:
+except (ImportError, AttributeError):
   repro = None
-  def repro_is_enabled(): return False
+  repro_is_enabled = lambda: False


### PR DESCRIPTION
Repro generation is not yet committed, but some hooks for it are. This handles the situation when the `jax/_src/repro` directory exists but is empty, which can happen when git switches branches.
