### PR TITLE
[documentation] Add CuTe DSL tutorial to advanced guides

### DIFF
--- a/docs/advanced_guides.rst
+++ b/docs/advanced_guides.rst
@@ -81,6 +81,11 @@ operations.
    :maxdepth: 1
 
    ffi
+
+.. toctree::
+   :caption: GPU kernel authoring tools
+   :maxdepth: 1
+
    notebooks/cute_dsl_jax
 
 .. toctree::


### PR DESCRIPTION
## Description

Follow-up to #36496. The CuTe DSL tutorial was merged, but its `advanced_guides.rst` toctree entry was accidentally dropped during cleanup, leaving the page out of the Advanced Guides menu.

This adds the tutorial back under a new "GPU kernel authoring tools" section.

## Testing

Not run; docs navigation-only change.