### PR TITLE
[random] Add RandomShapeTest for samplers with shape + array args

### DIFF
--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -320,6 +320,42 @@ class RandomDtypeTest(RandomTestBase):
       # self.assertRaises(dtypes.TypePromotionError, jitted, key, dtype)
 
 
+_SHAPE_CASES = [
+    ('beta', lambda key, shape: random.beta(key, jnp.ones(shape), jnp.ones(shape), shape=shape)),
+    ('binomial', lambda key, shape: random.binomial(key, jnp.full(shape, 10.), jnp.full(shape, 0.5), shape=shape)),
+    ('chisquare', lambda key, shape: random.chisquare(key, jnp.ones(shape), shape=shape)),
+    # ('double_sided_maxwell', lambda key, shape: random.double_sided_maxwell(key, loc=jnp.zeros(shape), scale=jnp.ones(shape), shape=shape)),
+    ('f', lambda key, shape: random.f(key, jnp.ones(shape), jnp.ones(shape), shape=shape)),
+    ('gamma', lambda key, shape: random.gamma(key, jnp.ones(shape), shape=shape)),
+    ('geometric', lambda key, shape: random.geometric(key, jnp.full(shape, 0.5), shape=shape)),
+    ('loggamma', lambda key, shape: random.loggamma(key, jnp.ones(shape), shape=shape)),
+    ('lognormal', lambda key, shape: random.lognormal(key, jnp.ones(shape), shape=shape)),
+    ('pareto', lambda key, shape: random.pareto(key, jnp.ones(shape), shape=shape)),
+    ('poisson', lambda key, shape: random.poisson(key, jnp.ones(shape), shape=shape)),
+    ('randint', lambda key, shape: random.randint(key, shape=shape, minval=jnp.zeros(shape, jnp.int32), maxval=jnp.full(shape, 10, jnp.int32))),
+    ('rayleigh', lambda key, shape: random.rayleigh(key, jnp.ones(shape), shape=shape)),
+    ('t', lambda key, shape: random.t(key, jnp.ones(shape), shape=shape)),
+    ('triangular', lambda key, shape: random.triangular(key, jnp.zeros(shape), jnp.full(shape, 0.5), jnp.ones(shape), shape=shape)),
+    ('truncated_normal', lambda key, shape: random.truncated_normal(key, lower=jnp.full(shape, -2.), upper=jnp.full(shape, 2.), shape=shape)),
+    ('uniform', lambda key, shape: random.uniform(key, shape=shape, minval=jnp.zeros(shape), maxval=jnp.ones(shape))),
+    ('wald', lambda key, shape: random.wald(key, jnp.ones(shape), shape=shape)),
+    ('weibull_min', lambda key, shape: random.weibull_min(key, jnp.ones(shape), jnp.ones(shape), shape=shape)),
+]
+
+
+class RandomShapeTest(RandomTestBase):
+  """Tests that shape arguments are obeyed for jax.random functions."""
+
+  @parameterized.named_parameters(_SHAPE_CASES)
+  def test_shape(self, fn):
+    key = random.key(0)
+    shape = (3, 4)
+    result = fn(key, shape)
+    self.assertEqual(result.shape, shape)
+    jit_result = jax.jit(fn, static_argnums=(1,))(key, shape)
+    self.assertEqual(jit_result.shape, shape)
+
+
 class DistributionsTest(RandomTestBase):
   """
   Tests of distribution statistics that need only be run with the default PRNG.


### PR DESCRIPTION
Adds _SHAPE_CASES list and RandomShapeTest class. Each case receives a shape at test time and constructs float32/int32 array arguments with that same shape so batch dimensions are aligned with the requested output shape. test_shape verifies result.shape matches both in eager and jit modes.

double_sided_maxwell fails, so is commented out.