### PR TITLE
[pallas] Fix _pallas_call_jvp_rule jvp_bms length when any tangent is Zero

### DIFF
--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -306,10 +306,17 @@ def _pallas_call_jvp_rule(
     print(f"\nThe jaxpr for the jvp of pallas_call {debug_info.func_src_info}:")
     print(jvp_jaxpr)
   in_bms, out_bms = split_list(grid_mapping.block_mappings, [len(primals)])
-  jvp_bms = (*in_bms, *in_bms, *out_bms, *out_bms)
+  # jvp_jaxpr.invars only contain tangent vars for primals whose tangents
+  # survived the nonzero_tangents filter above; match that here so jvp_bms
+  # stays consistent with jvp_jaxpr.invars (otherwise downstream lowerings
+  # safe_zip on the length mismatch).
+  in_bms_for_tangents = tuple(
+      bm for bm, nz in zip(in_bms, nonzero_tangents) if nz
+  )
+  jvp_bms = (*in_bms, *in_bms_for_tangents, *out_bms, *out_bms)
   jvp_grid_mapping = grid_mapping.replace(
       block_mappings=jvp_bms,
-      num_inputs=grid_mapping.num_inputs * 2,
+      num_inputs=grid_mapping.num_inputs + len(tangents),
       num_outputs=grid_mapping.num_outputs * 2,
   )
   if cost_estimate is not None:

--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -289,10 +289,13 @@ def _pallas_call_jvp_rule(
     print(f"\nThe jaxpr for the jvp of pallas_call {debug_info.func_src_info}:")
     print(jvp_jaxpr)
   in_bms, out_bms = split_list(grid_mapping.block_mappings, [len(primals)])
-  jvp_bms = (*in_bms, *in_bms, *out_bms, *out_bms)
+  in_bms_for_tangents = tuple(
+      bm for bm, nz in zip(in_bms, nonzero_tangents) if nz
+  )
+  jvp_bms = (*in_bms, *in_bms_for_tangents, *out_bms, *out_bms)
   jvp_grid_mapping = grid_mapping.replace(
       block_mappings=jvp_bms,
-      num_inputs=grid_mapping.num_inputs * 2,
+      num_inputs=grid_mapping.num_inputs + len(tangents),
       num_outputs=grid_mapping.num_outputs * 2,
   )
   if cost_estimate is not None:

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -2448,6 +2448,29 @@ class PallasCallAutodifferentiationTest(ptu.PallasTest):
 
     np.testing.assert_allclose(softmax_kernel(x), jax.nn.softmax(x), atol=1e-7)
 
+  def test_jvp_with_zero_tangent(self):
+    # Regression: lax.stop_gradient supplies a symbolic ad_util.Zero
+    # tangent for one input. Pre-fix _pallas_call_jvp_rule built jvp_bms
+    # by duplicating in_bms 1:1 with primals, mismatching jvp_jaxpr.invars
+    # whenever the nonzero_tangents filter dropped any input.
+    @functools.partial(
+        self.pallas_call,
+        out_shape=jax.ShapeDtypeStruct((64,), floatx),
+    )
+    def add_kernel(x_ref, y_ref, o_ref):
+      o_ref[...] = x_ref[...] + y_ref[...]
+
+    def f(x, y):
+      return add_kernel(x, lax.stop_gradient(y))
+
+    x = jnp.arange(64, dtype=floatx)
+    y = jnp.arange(64, dtype=floatx) * 2.0
+    vx = jnp.ones_like(x)
+    vy = jnp.ones_like(y)
+    out_primal, out_tangent = jax.jvp(f, (x, y), (vx, vy))
+    np.testing.assert_allclose(out_primal, x + y, atol=self.tol, rtol=self.tol)
+    np.testing.assert_allclose(out_tangent, vx, atol=self.tol, rtol=self.tol)
+
   # TODO(sharadmv): enable this when we update Triton
   # def test_jvp_matmul(self):
   #   k1, k2 = random.split(random.key(0))

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -2467,6 +2467,44 @@ class PallasCallAutodifferentiationTest(ptu.PallasTest):
 
     np.testing.assert_allclose(softmax_kernel(x), jax.nn.softmax(x), atol=1e-7)
 
+  @parameterized.named_parameters(
+      ("all_tangents", None),
+      ("first_tangent", 0),
+      ("middle_tangent", 1),
+      ("last_tangent", 2),
+  )
+  def test_jvp_with_symbolic_zero_tangents(self, active_index):
+    inputs = tuple(random.normal(random.key(i), (8,)) for i in range(3))
+    tangents = tuple(
+        random.normal(random.key(i + 3), (8,)) for i in range(3)
+    )
+
+    @functools.partial(
+        self.pallas_call,
+        out_shape=jax.ShapeDtypeStruct.like(inputs[0]),
+    )
+    def add(x_ref, y_ref, z_ref, o_ref):
+      o_ref[...] = x_ref[...] + y_ref[...] + z_ref[...]
+
+    def f(*args):
+      args = tuple(
+          arg if active_index is None or i == active_index
+          else lax.stop_gradient(arg)
+          for i, arg in enumerate(args)
+      )
+      return add(*args)
+
+    out_primal, out_tangent = jax.jvp(f, inputs, tangents)
+    np.testing.assert_allclose(
+        out_primal, sum(inputs), atol=self.tol, rtol=self.tol
+    )
+    expected_tangent = (
+        sum(tangents) if active_index is None else tangents[active_index]
+    )
+    np.testing.assert_allclose(
+        out_tangent, expected_tangent, atol=self.tol, rtol=self.tol
+    )
+
   # TODO(sharadmv): enable this when we update Triton
   # def test_jvp_matmul(self):
   #   k1, k2 = random.split(random.key(0))


### PR DESCRIPTION
## Bug

`_pallas_call_jvp_rule` in `jax/_src/pallas/pallas_call.py` constructs the
JVP'd grid mapping by duplicating `in_bms` 1:1 with primals:

```python
jvp_bms = (*in_bms, *in_bms, *out_bms, *out_bms)
jvp_grid_mapping = grid_mapping.replace(
    block_mappings=jvp_bms,
    num_inputs=grid_mapping.num_inputs * 2,
    num_outputs=grid_mapping.num_outputs * 2,
)
```

But the rule filters `ad_util.Zero` tangents earlier:

```python
nonzero_tangents = [not isinstance(t, ad_util.Zero) for t in tangents]
tangents = [t for t in tangents if type(t) is not ad_util.Zero]
nonzero_tangents_with_outputs = nonzero_tangents + [True] * grid_mapping.num_outputs
jvp_jaxpr_, _ = ad.jvp_jaxpr(closed_jaxpr, nonzero_tangents_with_outputs, [])
```

So the rebuilt `jvp_jaxpr.invars` has length
`len(primals) + len(tangents) + 2*len(outputs)`, while `jvp_bms` has length
`2*len(primals) + 2*len(outputs)`. Whenever any tangent was filtered as
`ad_util.Zero`, the two disagree by exactly the count of zero tangents.

Triton lowering surfaces the mismatch as a cryptic `safe_zip` error:

```
ValueError: safe_zip() argument 1 has length 14 but argument 0 has length 13
  File ".../pallas/triton/lowering.py", line 398, in lower_jaxpr_to_triton_ir
```

## When does it fire?

Anywhere a `pallas_call` is differentiated by JVP with **at least one input
arriving as `ad_util.Zero`**. Concrete paths I've hit:

- `lax.stop_gradient` on a `pallas_call` input (its JVP rule emits Zero).
- HVP-style flows (`jax.jvp(jax.grad(f))`) where `f` is a `custom_vjp`
  whose bwd is itself a `pallas_call`. Saved residuals that don't carry
  upstream tangents arrive as Zero during JVP linearization of the bwd.
  This is the case I originally hit, with a vendored MHSEA attention
  kernel — the bwd's residuals (`lse`, `o`) get Zero tangents under HVP.
- Mask / segment_id-style "data only" inputs that don't differentiate.

## Reproducer (minimal)

```python
import jax
import jax.numpy as jnp
from jax import lax
from jax.experimental import pallas as pl

def add_kernel(x_ref, y_ref, o_ref):
    o_ref[...] = x_ref[...] + y_ref[...]

add = pl.pallas_call(
    add_kernel,
    out_shape=jax.ShapeDtypeStruct((64,), jnp.float32),
)

def f(x, y):
    # stop_gradient injects a symbolic Zero tangent into the pallas_call,
    # triggering the rule's length mismatch.
    return add(x, lax.stop_gradient(y))

x  = jnp.arange(64, dtype=jnp.float32)
y  = jnp.arange(64, dtype=jnp.float32) * 2.0
vx = jnp.ones_like(x)
vy = jnp.ones_like(y)

# Pre-fix:  ValueError: safe_zip() argument lengths mismatch (Triton).
# Post-fix: clean.
jax.jvp(f, (x, y), (vx, vy))
```

## Fix

```diff
   in_bms, out_bms = split_list(grid_mapping.block_mappings, [len(primals)])
-  jvp_bms = (*in_bms, *in_bms, *out_bms, *out_bms)
+  in_bms_for_tangents = tuple(
+      bm for bm, nz in zip(in_bms, nonzero_tangents) if nz
+  )
+  jvp_bms = (*in_bms, *in_bms_for_tangents, *out_bms, *out_bms)
   jvp_grid_mapping = grid_mapping.replace(
       block_mappings=jvp_bms,
-      num_inputs=grid_mapping.num_inputs * 2,
+      num_inputs=grid_mapping.num_inputs + len(tangents),
       num_outputs=grid_mapping.num_outputs * 2,
   )
```

After the fix:
- `jvp_bms` length = `len(primals) + len(tangents) + 2*len(outputs)` —
  matches `jvp_jaxpr.invars`.
- `num_inputs = len(primals) + len(tangents)` — matches the
  `pallas_call_p.bind(*primals, *tangents, ...)` arg count below.

When all tangents are nonzero, behavior is identical to the previous code
(`len(tangents) == len(primals)` ⇒ `in_bms_for_tangents == in_bms`,
`num_inputs == 2 * grid_mapping.num_inputs`).

## Test

Adds `PallasCallAutodifferentiationTest::test_jvp_with_zero_tangent` in
`tests/pallas/pallas_test.py` — the `lax.stop_gradient` reproducer above
encoded as a regression test. Inherits the surrounding class's TPU skip
and Mosaic-GPU disable, so it runs under interpret mode via
`PallasCallAutodifferentiationInterpretTest` and on GPU under Triton in
CI.

## Affects

- All `pallas_call`s under JVP with any input arriving as `ad_util.Zero`.
- HVP through pallas-backed `custom_vjp`s — any realistic case hits this
  once a saved residual lacks an upstream tangent.
- Mosaic-GPU / TPU lowerings with similar `safe_zip` invariants are
  likely affected too; not independently verified here.
