### PR TITLE
[jaxlib] Validate node arity in SetNumLeavesAndNumNodes

### DIFF
--- a/jaxlib/pytree.cc
+++ b/jaxlib/pytree.cc
@@ -1430,6 +1430,14 @@ void PyTreeDef::SetNumLeavesAndNumNodes() {
     if (traversal_[i].arity == 0) {
       starts.push_back(start);
     } else {
+      // arity must fit on the stack of partially-completed subtrees;
+      // otherwise the resize underflows and the back() reads below are UB.
+      if (traversal_[i].arity < 0 ||
+          static_cast<size_t>(traversal_[i].arity) > starts.size()) {
+        throw std::invalid_argument(absl::StrCat(
+            "Malformed PyTreeDef: node ", i, " has invalid arity ",
+            traversal_[i].arity, " (stack size ", starts.size(), ")"));
+      }
       starts.resize(starts.size() - (traversal_[i].arity - 1));
     }
     traversal_[i].num_leaves = num_leaves - starts.back().first;

--- a/jaxlib/pytree_test.py
+++ b/jaxlib/pytree_test.py
@@ -80,6 +80,32 @@ class PyTreeTest(absltest.TestCase):
     with self.assertRaises(ValueError):
       self.roundtrip_proto({"a": ExampleType2(field0=o, field1=o)})
 
+  def testDeserializeMalformedProtoIsRejected(self):
+    # Malformed PyTreeDefProto inputs must be rejected with a Python
+    # exception, not crash the interpreter. Each payload is a hand-built
+    # PyTreeDefProto that the legitimate flatten path could never produce
+    # (e.g. a single non-leaf node with no children to absorb).
+    cases = {
+        # Single node with arity=1, type=PY_TREE_KIND_LIST.
+        # Pre-fix this triggered an empty-vector dereference in
+        # SetNumLeavesAndNumNodes.
+        "single_list_arity_1": bytes.fromhex("0a0408011002"),
+        # Single node with arity=2, also inconsistent with the empty
+        # subtree stack at that point.
+        "single_list_arity_2": bytes.fromhex("0a0408021002"),
+        # Two leaves followed by a list claiming arity=3 (only 2 leaves
+        # are available to absorb).
+        "two_leaves_then_list_arity_3": bytes.fromhex(
+            "0a021001"     # leaf
+            "0a021001"     # leaf
+            "0a0408031002" # list, arity=3
+        ),
+    }
+    for name, blob in cases.items():
+      with self.subTest(name=name):
+        with self.assertRaises(ValueError):
+          pytree.PyTreeDef.deserialize_using_proto(registry, blob)
+
   def roundtrip_node_data(self, example):
     original = registry.flatten(example)[1]
     restored = pytree.PyTreeDef.from_node_data_and_children(


### PR DESCRIPTION
Fixes https://github.com/jax-ml/jax/issues/37410.

A `PyTreeDefProto` whose first node has any non-zero arity bypasses the only push site in `SetNumLeavesAndNumNodes`, the loop then reaches `starts.back()` on an empty `std::vector` and dereferences a null pointer. Six bytes are enough to crash the process via the public `PyTreeDef.deserialize_using_proto` API.

**Before:**

```console
$ python3 -c 'from jax._src.lib import _jax; \
    _jax.pytree.PyTreeDef.deserialize_using_proto( \
        _jax.pytree.default_registry(), \
        bytes.fromhex("0a0408011002"))'
$ echo $?
139      # SIGSEGV
```

The change now validates arity against the running stack of partially-completed subtrees before the resize. Legitimate trees produced by `flatten` always satisfy the invariant, so the new exception only fires on inputs that the proto round-trip could not have generated.

**After:**

```console
ValueError: Malformed PyTreeDef: node 0 has invalid arity 1 (stack size 0)
$ echo $?
1
```

I added regression tests covering the single-node arity=1 trigger and a multi-node variant where the arity exceeds the available subtrees.

I have also been testing it E2E after rebuilding the wheel on my machine.