### PR TITLE
[random] Add out_sharding and correct dtype handling to lognormal

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -65,6 +65,25 @@ UINT_DTYPES = prng.UINT_DTYPES
 
 ### utilities
 
+def _check_broadcast_shapes(name: str, shape: tuple | Shape | None, *args: ArrayLike):
+  arg_shapes = [np.shape(a) for a in args]
+  if shape is None:
+    if arg_shapes:
+      shape = lax.broadcast_shapes(*arg_shapes)
+    else:
+      shape = ()
+  else:
+    shape = core.canonicalize_shape(shape)
+    _check_shape(name, shape, *arg_shapes)
+  return shape
+
+
+def _check_all_safe_to_cast(name: str, dtype: DTypeLike, *args):
+  for arg in args:
+    if not dtypes.safe_to_cast(arg, dtype):
+      raise dtypes.TypePromotionError(f"In arguments to {name}, cannot safely cast argument of type {jnp.asarray(arg).dtype} to {dtype}")
+
+
 def _isnan(x: ArrayLike) -> Array:
   return lax.ne(x, x)
 
@@ -2980,7 +2999,9 @@ def _triangular(key, left, mode, right, shape, dtype) -> Array:
 def lognormal(key: ArrayLike,
               sigma: RealArray = np.float32(1),
               shape: Shape | None = None,
-              dtype: DTypeLikeFloat | None = None) -> Array:
+              dtype: DTypeLikeFloat | None = None,
+              *,
+              out_sharding: NamedSharding | P | None = None) -> Array:
   r""" Sample lognormal random values with given shape and float dtype.
 
   The values are distributed according to the probability density function:
@@ -2998,27 +3019,31 @@ def lognormal(key: ArrayLike,
       shape. The default (None) produces a result shape equal to ``()``.
     dtype: optional, a float dtype for the returned values (default float64 if
       jax_enable_x64 is true, otherwise float32).
+    out_sharding: optional, specifies how the output array should be sharded
+      across devices in multi-device computation. Can be a
+      :class:`~jax.sharding.NamedSharding`, a :class:`~jax.sharding.PartitionSpec`
+      (``P``), or ``None`` (default). When specified, the output will be sharded
+      according to the given sharding specification. Primarily used in explicit
+      sharding mode.
+      See the `explicit sharding tutorial <https://docs.jax.dev/en/latest/parallel.html>`_
+      for more details.
 
   Returns:
     A random array with the specified dtype and with shape given by ``shape``.
   """
   key, _ = _check_prng_key("lognormal", key)
-  dtype = dtypes.check_and_canonicalize_user_dtype(
-      float if dtype is None else dtype)
+  dtype = dtypes.check_and_canonicalize_user_dtype(float if dtype is None else dtype)
   if not dtypes.issubdtype(dtype, np.inexact):
     raise ValueError(f"dtype argument to `lognormal` must be a float or complex dtype, "
-                     f"got {dtype}")
-  if shape is not None:
-    shape = core.canonicalize_shape(shape)
-  return _lognormal(key, sigma, shape, dtype)
+                    f"got {dtype}")
+  shape = _check_broadcast_shapes("lognormal", shape, sigma)
+  out_sharding = canonicalize_sharding(out_sharding, "lognormal")
+  _check_all_safe_to_cast("lognormal", dtype, sigma)
+  return maybe_auto_axes(_lognormal, out_sharding, shape=shape, dtype=dtype)(key, sigma)
 
 @jit(static_argnums=(2, 3), inline=True)
 def _lognormal(key, sigma, shape, dtype) -> Array:
-  if shape is None:
-    shape =  np.shape(sigma)
-  else:
-    _check_shape("triangular", shape, np.shape(sigma))
-  sigma = jnp.broadcast_to(sigma, shape)
+  sigma = lax.convert_element_type(sigma, dtype)
   scaled_norm = normal(key, shape, dtype) * sigma
   return lax.exp(scaled_norm)
 

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -31,7 +31,7 @@ from jax import random
 from jax._src import config
 from jax._src import core
 from jax._src import dtypes
-from jax._src.random import _safe_int_to_float
+from jax._src.random import _safe_int_to_float, _check_broadcast_shapes
 from jax._src import test_util as jtu
 from jax import vmap
 
@@ -227,6 +227,7 @@ _OUT_SHARDING_CASES = [
     ('laplace', lambda key, n, s: random.laplace(key, shape=(n,), out_sharding=s)),
     ('loggamma', lambda key, n, s: random.loggamma(key, a=2.0, shape=(n,), out_sharding=s)),
     ('logistic', lambda key, n, s: random.logistic(key, shape=(n,), out_sharding=s)),
+    ('lognormal', lambda key, n, s: random.lognormal(key, sigma=1.0, shape=(n,), out_sharding=s)),
     ('normal', lambda key, n, s: random.normal(key, shape=(n,), out_sharding=s)),
     ('orthogonal', lambda key, n, s: random.orthogonal(key, n=3, shape=(n,), out_sharding=s)),
     ('permutation', lambda key, n, s: random.permutation(key, n, out_sharding=s)),
@@ -1754,6 +1755,11 @@ class UnsafeRBGPRNGTest(RBGPRNGTest):
     self.assertArraysEqual(random.key_data(vmapped_keys),
                            random.key_data(ref_keys))
 
+
+class RandomUtilTest(RandomTestBase):
+  def test_check_broadcast_shapes_empty(self):
+    self.assertEqual(_check_broadcast_shapes("empty_test", (2,3)), (2,3))
+    self.assertEqual(_check_broadcast_shapes("empty_test", None), ())
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Currently, `dtype` arguments aren't always respected due to the `sigma` argument being multiplied by the result. This PR uses the `check_broadcast_shapes` utility that is proposed simultaneously in other PRs like #37254