### PR TITLE
[random] Add out_sharding to jax.random.f and jax.random.chisquare

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -2339,7 +2339,7 @@ def chisquare(key: ArrayLike,
       produces a result shape equal to ``df.shape``.
     dtype: optional, a float dtype for the returned values (default float64 if
       jax_enable_x64 is true, otherwise float32).
-    out_sharding: Optional. Specifies how the output array should be sharded
+    out_sharding: optional, Specifies how the output array should be sharded
       across devices in multi-device computation. Can be a
       :class:`~jax.sharding.NamedSharding`, a :class:`~jax.sharding.PartitionSpec`
       (``P``), or ``None`` (default). When specified, the output will be sharded
@@ -2358,21 +2358,16 @@ def chisquare(key: ArrayLike,
   if not dtypes.issubdtype(dtype, np.floating):
     raise ValueError("dtype argument to `chisquare` must be a float "
                      f"dtype, got {dtype}")
-  if shape is not None:
-    shape = core.canonicalize_shape(shape)
+  shape = _check_broadcast_shapes("chisquare", shape, df)
   out_sharding = canonicalize_sharding_for_samplers(out_sharding, "chisquare", shape)
-  return maybe_auto_axes(_chisquare, out_sharding, shape=shape, dtype=dtype)(key, df)
+  return _chisquare(key, df, shape, dtype, out_sharding)
 
-@jit(static_argnums=(2, 3))
-def _chisquare(key, df, shape, dtype) -> Array:
-  if shape is None:
-    shape = np.shape(df)
-  else:
-    _check_shape("chisquare", shape, np.shape(df))
+@jit(static_argnums=(2, 3, 4))
+def _chisquare(key, df, shape, dtype, out_sharding) -> Array:
   df = lax.convert_element_type(df, dtype)
   two = lax._const(df, 2)
   half_df = lax.div(df, two)
-  log_g = loggamma(key, a=half_df, shape=shape, dtype=dtype)
+  log_g = loggamma(key, a=half_df, shape=shape, dtype=dtype, out_sharding=out_sharding)
   chi2 = lax.mul(jnp.exp(log_g), two)
   return chi2
 
@@ -2381,7 +2376,9 @@ def f(key: ArrayLike,
       dfnum: RealArray,
       dfden: RealArray,
       shape: Shape | None = None,
-      dtype: DTypeLikeFloat | None = None) -> Array:
+      dtype: DTypeLikeFloat | None = None,
+      *,
+      out_sharding: NamedSharding | P | None = None) -> Array:
   r"""Sample F-distribution random values with given shape and float dtype.
 
   The values are distributed according to the probability density function:
@@ -2406,6 +2403,14 @@ def f(key: ArrayLike,
       and ``dfden.shape``.
     dtype: optional, a float dtype for the returned values (default float64 if
       jax_enable_x64 is true, otherwise float32).
+    out_sharding: optional, specifies how the output array should be sharded
+      across devices in multi-device computation. Can be a
+      :class:`~jax.sharding.NamedSharding`, a :class:`~jax.sharding.PartitionSpec`
+      (``P``), or ``None`` (default). When specified, the output will be sharded
+      according to the given sharding specification. Primarily used in explicit
+      sharding mode.
+      See the `explicit sharding tutorial <https://docs.jax.dev/en/latest/parallel.html>`_
+      for more details.
 
   Returns:
     A random array with the specified dtype and with shape given by ``shape`` if
@@ -2417,24 +2422,17 @@ def f(key: ArrayLike,
   if not dtypes.issubdtype(dtype, np.floating):
     raise ValueError("dtype argument to `f` must be a float "
                      f"dtype, got {dtype}")
-  if shape is not None:
-    shape = core.canonicalize_shape(shape)
-  return _f(key, dfnum, dfden, shape, dtype)
+  shape = _check_broadcast_shapes("f", shape, dfnum, dfden)
+  out_sharding = canonicalize_sharding_for_samplers(out_sharding, "f", shape)
+  return _f(key, dfnum, dfden, shape, dtype, out_sharding)
 
-@jit(static_argnums=(3, 4))
-def _f(key, dfnum, dfden, shape, dtype) -> Array:
-  if shape is None:
-    shape =  lax.broadcast_shapes(np.shape(dfden), np.shape(dfnum))
-  else:
-    _check_shape("f", shape, np.shape(dfden), np.shape(dfnum))
+@jit(static_argnums=(3, 4, 5))
+def _f(key, dfnum, dfden, shape, dtype, out_sharding) -> Array:
   dfden = lax.convert_element_type(dfden, dtype)
   dfnum = lax.convert_element_type(dfnum, dtype)
   key_dfd, key_dfn = _split(key)
-  chi2_dfn = chisquare(key_dfn, dfnum, shape, dtype)
-  chi2_dfd = chisquare(key_dfd, dfden, shape, dtype)
-  # broadcast dfden and dfnum to do div operation
-  dfden = jnp.broadcast_to(dfden, shape)
-  dfnum = jnp.broadcast_to(dfnum, shape)
+  chi2_dfn = chisquare(key_dfn, dfnum, shape, dtype, out_sharding=out_sharding)
+  chi2_dfd = chisquare(key_dfd, dfden, shape, dtype, out_sharding=out_sharding)
   num = lax.div(chi2_dfn, dfnum)
   den = lax.div(chi2_dfd ,dfden)
   f = lax.div(num, den)

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -223,6 +223,7 @@ _OUT_SHARDING_CASES = [
     ('chisquare', lambda key, n, s: random.chisquare(key, df=1.0, shape=(n,), out_sharding=s)),
     ('dirichlet', lambda key, n, s: random.dirichlet(key, jnp.ones(3), shape=(n,), out_sharding=s)),
     ('exponential', lambda key, n, s: random.exponential(key, shape=(n,), out_sharding=s)),
+    ('f', lambda key, n, s: random.f(key, dfnum=2.0, dfden=3.0, shape=(n,), out_sharding=s)),
     ('gumbel', lambda key, n, s: random.gumbel(key, shape=(n,), out_sharding=s)),
     ('multivariate_normal', lambda key, n, s: random.multivariate_normal(key, mean=jnp.zeros((n,)), cov=jnp.eye(n), shape=(n,), out_sharding=s)),
     ('laplace', lambda key, n, s: random.laplace(key, shape=(n,), out_sharding=s)),


### PR DESCRIPTION
The chisquare part was necessary to complete the f part, so I bundled them in the same commit. Unlike other PRs for out_sharding, this PR does not use `auto_axes`, but just propagates the `out_sharding` argument from the F distribution to the chisquare distributions, which propagates it to the underlying loggamma. 