### PR TITLE
[bug] fix threefry abstract eval rule

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4133,6 +4133,10 @@ def naryop_dtype_rule(result_dtype, accepted_dtypes, name, *avals,
 
 
 def broadcasting_shape_rule(name, *avals, **kwargs):
+  if not isinstance(name, str):
+    raise RuntimeError(
+      "First argument of broadcasting_shape_rule should be a name."
+      f" Got {name}")
   shapes = [aval.shape for aval in avals if aval.shape]
   if not shapes:
     return ()
@@ -4140,6 +4144,10 @@ def broadcasting_shape_rule(name, *avals, **kwargs):
 
 
 def broadcasting_sharding_rule(name, *avals, **kwargs):
+  if not isinstance(name, str):
+    raise RuntimeError(
+      "First argument of broadcasting_sharding_rule should be a name."
+      f" Got {name}")
   mesh = None
   for a in avals:
     if a.sharding is not None and not a.sharding.mesh.empty:

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -862,8 +862,8 @@ def _threefry2x32_abstract_eval(*args):
     raise TypeError("Arguments to threefry2x32 must have uint32 type, got {}"
                     .format(args))
   if all(isinstance(arg, core.ShapedArray) for arg in args):
-    shape = lax.broadcasting_shape_rule(*args)
-    sharding = lax.broadcasting_sharding_rule(*args)
+    shape = lax.broadcasting_shape_rule("threefry2x32", *args)
+    sharding = lax.broadcasting_sharding_rule("threefry2x32", *args)
     aval = core.ShapedArray(shape, np.dtype('uint32'), sharding=sharding)
   else:
     raise TypeError(f"Arguments to threefry2x32 must all be arrays, got {args}")


### PR DESCRIPTION
This bug hasn't caused any user-visible errors in practice because threefry PRNG keys always consist of a pair of buffers with the same shape and sharding. I uncovered this bug when experimenting with a PRNG key that has a single buffer.