### PR TITLE
Add jax.scipy.linalg.companion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     transform matrices ({jax-issue}`#10144`).
   * Added {func}`jax.scipy.linalg.leslie` for constructing Leslie matrices
     ({jax-issue}`#10144`).
+  * Added {func}`jax.scipy.linalg.companion` for constructing companion
+    matrices from polynomial coefficients ({jax-issue}`#10144`).
   * Moved RNG APIs from "implementations" to dtypes ({jax-issue}`#27854`):
     * Added `jax.random.key_dtype` to get the dtype corresponding to a PRNG
       implementation name.

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -58,6 +58,7 @@ jax.scipy.linalg
    cho_solve
    cholesky
    circulant
+   companion
    det
    dft
    eigh

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -2657,6 +2657,50 @@ def _leslie(f: Array, s: Array) -> Array:
   return jnp.diag(s, k=-1).at[0].set(f)
 
 
+def companion(a: ArrayLike) -> Array:
+  r"""Construct a companion matrix.
+
+  JAX implementation of :func:`scipy.linalg.companion`.
+
+  Given polynomial coefficients :math:`a = [a_0, a_1, \ldots, a_{n-1}]` with
+  :math:`a_0 \neq 0`, the companion matrix is the :math:`(n-1) \times (n-1)`
+  matrix whose first row is :math:`-[a_1, a_2, \ldots, a_{n-1}] / a_0` and
+  whose first sub-diagonal is filled with ones.
+
+  Args:
+    a: array of shape ``(..., N)`` with ``N >= 2`` specifying the polynomial
+      coefficients.
+
+  Returns:
+    A companion matrix of shape ``(..., N - 1, N - 1)``.
+
+  Note:
+    Unlike :func:`scipy.linalg.companion`, this function does not check at
+    runtime that ``a[..., 0]`` is non-zero; if the leading coefficient is
+    zero, the result will contain ``inf`` or ``nan`` entries.
+
+  Examples:
+    >>> jax.scipy.linalg.companion(jnp.array([1., -10., 31., -30.]))
+    Array([[ 10., -31.,  30.],
+           [  1.,   0.,   0.],
+           [  0.,   1.,   0.]], dtype=float32)
+  """
+  a, = promote_args_inexact("companion", a)
+  a = jnp.atleast_1d(a)
+  if a.shape[-1] < 2:
+    raise ValueError(
+        "The length of `a` along the last axis must be at least 2; "
+        f"got shape {a.shape}.")
+  return _companion(a)
+
+@partial(jnp_vectorize.vectorize, signature="(n)->(m,m)")
+def _companion(a: Array) -> Array:
+  first_row = -a[1:] / a[0]
+  m = a.shape[0] - 1
+  out = jnp.eye(m, m, k=-1, dtype=first_row.dtype)
+  return out.at[0].set(first_row)
+
+
 @jit(static_argnames=("n",))
 def hilbert(n: int) -> Array:
   r"""Create a Hilbert matrix of order n.

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -21,6 +21,7 @@ from jax._src.scipy.linalg import (
   cho_factor as cho_factor,
   cho_solve as cho_solve,
   circulant as circulant,
+  companion as companion,
   det as det,
   dft as dft,
   eigh as eigh,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -104,6 +104,15 @@ def osp_linalg_circulant(c: np.ndarray) -> np.ndarray:
   return np.vectorize(
       scipy.linalg.circulant, signature="(n)->(n,n)", otypes=(c.dtype,))(c)
 
+def osp_linalg_companion(a: np.ndarray) -> np.ndarray:
+  """Batched scipy companion for testing."""
+  if scipy_version >= (1, 15):
+    return scipy.linalg.companion(a)
+  a = np.atleast_1d(a)
+  out_dtype = np.result_type(a.dtype, np.float32)
+  return np.vectorize(
+      scipy.linalg.companion, signature="(n)->(m,m)", otypes=(out_dtype,))(a)
+
 def osp_linalg_leslie(f: np.ndarray, s: np.ndarray) -> np.ndarray:
   """Batched scipy leslie for testing."""
   f = np.atleast_1d(f)
@@ -2345,6 +2354,25 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       jsp.linalg.leslie(jnp.array([1., 2., 3.]), jnp.array([0.5]))
     with self.assertRaisesRegex(ValueError, "Incorrect lengths for f and s"):
       jsp.linalg.leslie(jnp.array([1., 2.]), jnp.array([]))
+
+  @jtu.sample_product(
+     shape=[(2,), (3,), (5,), (8,), (2, 3), (1, 2, 4)],
+     dtype=float_types + complex_types + int_types,
+  )
+  def testCompanion(self, shape, dtype):
+    rng = jtu.rand_nonzero(self.rng())
+    args_maker = lambda: [rng(shape, dtype)]
+    tol = {np.complex64: 1e-5, np.float32: 1e-5}
+    self._CheckAgainstNumpy(osp_linalg_companion, jsp.linalg.companion,
+                            args_maker, atol=tol, rtol=tol, check_dtypes=False)
+    self._CompileAndCheck(jsp.linalg.companion, args_maker)
+
+  @jtu.sample_product(shape=[(0,), (1,), (3, 0), (3, 1)])
+  def testCompanionInvalidLength(self, shape):
+    a = jnp.zeros(shape)
+    with self.assertRaisesRegex(ValueError, "length of `a` along the last axis"):
+      jsp.linalg.companion(a)
+
 
   @jtu.sample_product(
     shape=[(2, 3), (4, 6), (50, 7), (100, 110)],


### PR DESCRIPTION
Adds `jax.scipy.linalg.companion` to keep chipping away at the special-matrix gap from #10144 (following `hadamard`, `circulant`, and `dft`).

The first row is `-a[1:] / a[0]` and the first sub-diagonal is ones, matching SciPy. Batching falls out of `jnp.vectorize` so `(..., N)` inputs give `(..., N-1, N-1)` outputs.

A small thing worth calling out: SciPy raises a `ValueError` when `a[..., 0] == 0`. We can't do that under jit without forcing concretization, so the function lets the `inf` / `nan` from the division propagate through. There's a `Note` in the docstring spelling this out.

### Tests
- `testCompanion`: parity vs SciPy across float / complex / int dtypes and 1-D + batched shapes (14 cases, x32 and x64).
- `testCompanionInvalidLength`: length 0 / 1 on the last axis raises.
- Doctest passes.
- Sanity-checked manually: eigenvalues of the companion of `x^3 - 6x^2 + 11x - 6` come out as `{1, 2, 3}`, and scaling all coefficients leaves the matrix unchanged.

### Notes on prior work
There were two earlier attempts that have gone quiet, and I tried to be respectful of the review history rather than start from scratch:

- #34460 covered companion specifically; @jakevdp left detailed feedback there in February that the original author didn't get back to. I read through it before writing this and tried to address each point: no separate test file, `assertRaisesRegex` for error checks, batched cases parameterized into the main test, no value-dependent error inside jit, `n < 2` matches SciPy's `ValueError`, no redundant `jnp.asarray`, and no `* 1.0` for promotion since `truediv` handles it.
- #35075 bundled five special matrices in one PR but hasn't been touched since the day it opened. This PR handles `companion` on its own; `dft` is in #37149, `fiedler` in #37334, `hadamard` is already merged (#37043), and `leslie` is in #37335.

Issue: #10144
