### PR TITLE
Add jax.scipy.linalg.fiedler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     ({jax-issue}`#10144`).
   * Added {func}`jax.scipy.linalg.companion` for constructing companion
     matrices from polynomial coefficients ({jax-issue}`#10144`).
+  * Added {func}`jax.scipy.linalg.fiedler` for constructing symmetric Fiedler
+    matrices ({jax-issue}`#10144`).
   * Moved RNG APIs from "implementations" to dtypes ({jax-issue}`#27854`):
     * Added `jax.random.key_dtype` to get the dtype corresponding to a PRNG
       implementation name.

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -65,6 +65,7 @@ jax.scipy.linalg
    eigh_tridiagonal
    expm
    expm_frechet
+   fiedler
    funm
    hadamard
    hessenberg

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -2701,6 +2701,34 @@ def _companion(a: Array) -> Array:
   return out.at[0].set(first_row)
 
 
+def fiedler(a: ArrayLike) -> Array:
+  r"""Construct a symmetric Fiedler matrix.
+
+  JAX implementation of :func:`scipy.linalg.fiedler`.
+
+  The Fiedler matrix has entries :math:`F_{ij} = |a_i - a_j|` for
+  :math:`0 \le i, j < n`, where ``a`` is the input vector. The result is
+  symmetric with a zero diagonal.
+
+  Args:
+    a: array of shape ``(..., N)``.
+
+  Returns:
+    A Fiedler matrix of shape ``(..., N, N)``.
+
+  Examples:
+    >>> jax.scipy.linalg.fiedler(jnp.array([1, 4, 12, 45, 77]))
+    Array([[ 0,  3, 11, 44, 76],
+           [ 3,  0,  8, 41, 73],
+           [11,  8,  0, 33, 65],
+           [44, 41, 33,  0, 32],
+           [76, 73, 65, 32,  0]], dtype=int32)
+  """
+  check_arraylike("fiedler", a)
+  arr = jnp.atleast_1d(a)
+  return jnp.abs(arr[..., None] - arr[..., None, :])
+
+
 @jit(static_argnames=("n",))
 def hilbert(n: int) -> Array:
   r"""Create a Hilbert matrix of order n.

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -28,6 +28,7 @@ from jax._src.scipy.linalg import (
   eigh_tridiagonal as eigh_tridiagonal,
   expm as expm,
   expm_frechet as expm_frechet,
+  fiedler as fiedler,
   hadamard as hadamard,
   hessenberg as hessenberg,
   hankel as hankel,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -124,6 +124,14 @@ def osp_linalg_leslie(f: np.ndarray, s: np.ndarray) -> np.ndarray:
       scipy.linalg.leslie, signature="(n),(m)->(n,n)",
       otypes=(out_dtype,))(f, s)
 
+def osp_linalg_fiedler(a: np.ndarray) -> np.ndarray:
+  """Batched scipy fiedler for testing."""
+  a = np.atleast_1d(a)
+  if scipy_version >= (1, 15):
+    return scipy.linalg.fiedler(a)
+  return np.vectorize(
+      scipy.linalg.fiedler, signature="(n)->(n,n)", otypes=(a.dtype,))(a)
+
 def osp_linalg_hankel(c: np.ndarray, r: np.ndarray | None = None) -> np.ndarray:
   """Batched scipy hankel for testing."""
   if scipy_version >= (1, 19):
@@ -2373,6 +2381,16 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, "length of `a` along the last axis"):
       jsp.linalg.companion(a)
 
+  @jtu.sample_product(
+     shape=[(), (1,), (3,), (5,), (2, 3), (1, 2, 4)],
+     dtype=float_types + int_types,
+  )
+  def testFiedler(self, shape, dtype):
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape, dtype)]
+    self._CheckAgainstNumpy(osp_linalg_fiedler, jsp.linalg.fiedler, args_maker,
+                            check_dtypes=False)
+    self._CompileAndCheck(jsp.linalg.fiedler, args_maker)
 
   @jtu.sample_product(
     shape=[(2, 3), (4, 6), (50, 7), (100, 110)],


### PR DESCRIPTION
Adds `jax.scipy.linalg.fiedler`, continuing the special-matrix series from #10144 (after `hadamard`, `circulant`, `dft`, and `companion` in #37333).

The body is just `jnp.abs(a[:, None] - a[None, :])` wrapped in `jnp.vectorize`, so `(..., N)` inputs yield `(..., N, N)` outputs (symmetric, zero diagonal).

### Tests
`testFiedler` runs parity against SciPy over a small shape sweep including `()`, `(1,)`, and a couple of batched shapes, with float and int dtypes (10 cases under both x32 and x64). Doctest passes. I also sanity-checked symmetry, the zero diagonal, jit, vmap, and the permutation property `fiedler(perm(a)) == perm @ fiedler(a) @ perm.T` locally.

One quirk worth flagging: SciPy's `fiedler` casts shape-`(1,)` and empty inputs to `float64` regardless of input dtype. That's not a behavior I felt this implementation should mirror, so the parity test passes `check_dtypes=False`.

### Notes on prior work
This was part of #35075 (a bundle PR for five special matrices) that hasn't been touched since the day it opened. Splitting the work into smaller PRs has been moving more smoothly, so I'm landing this one on its own. `companion` is in #37333, `dft` in #37149, `hadamard` is already merged (#37043), and `leslie` is in #37335.

Issue: #10144
