### PR TITLE
Add jax.scipy.linalg.leslie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     matrices ({jax-issue}`#10144`).
   * Added {func}`jax.scipy.linalg.dft` for constructing discrete Fourier
     transform matrices ({jax-issue}`#10144`).
+  * Added {func}`jax.scipy.linalg.leslie` for constructing Leslie matrices
+    ({jax-issue}`#10144`).
   * Moved RNG APIs from "implementations" to dtypes ({jax-issue}`#27854`):
     * Added `jax.random.key_dtype` to get the dtype corresponding to a PRNG
       implementation name.

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -70,6 +70,7 @@ jax.scipy.linalg
    hankel
    hilbert
    inv
+   leslie
    lu
    lu_factor
    lu_solve

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -2612,6 +2612,51 @@ def _circulant(c: Array) -> Array:
   return c[idx]
 
 
+def leslie(f: ArrayLike, s: ArrayLike) -> Array:
+  r"""Construct a Leslie matrix.
+
+  JAX implementation of :func:`scipy.linalg.leslie`.
+
+  Given fecundity coefficients ``f`` of shape ``(..., N)`` and survival
+  coefficients ``s`` of shape ``(..., N - 1)``, the Leslie matrix has ``f`` as
+  its first row, ``s`` along its first sub-diagonal, and zeros elsewhere.
+
+  Args:
+    f: array of shape ``(..., N)`` with ``N >= 2`` containing the fecundity
+      coefficients.
+    s: array of shape ``(..., N - 1)`` containing the survival coefficients.
+
+  Returns:
+    A Leslie matrix of shape ``(..., N, N)``.
+
+  Examples:
+    >>> jax.scipy.linalg.leslie(jnp.array([0.1, 2.0, 1.0, 0.1]),
+    ...                         jnp.array([0.2, 0.8, 0.7]))
+    Array([[0.1, 2. , 1. , 0.1],
+           [0.2, 0. , 0. , 0. ],
+           [0. , 0.8, 0. , 0. ],
+           [0. , 0. , 0.7, 0. ]], dtype=float32)
+  """
+  check_arraylike("leslie", f, s)
+  f_arr = jnp.atleast_1d(f)
+  s_arr = jnp.atleast_1d(s)
+  if f_arr.shape[-1] < 2:
+    raise ValueError(
+        "The length of f along the last axis must be at least 2; "
+        f"got shape {f_arr.shape}.")
+  if s_arr.shape[-1] != f_arr.shape[-1] - 1:
+    raise ValueError(
+        "Incorrect lengths for f and s. The length of s along the last axis "
+        f"must be one less than the length of f; got f shape {f_arr.shape} "
+        f"and s shape {s_arr.shape}.")
+  return _leslie(f_arr, s_arr)
+
+@partial(jnp_vectorize.vectorize, signature="(n),(m)->(n,n)")
+def _leslie(f: Array, s: Array) -> Array:
+  f, s = promote_dtypes(f, s)
+  return jnp.diag(s, k=-1).at[0].set(f)
+
+
 @jit(static_argnames=("n",))
 def hilbert(n: int) -> Array:
   r"""Create a Hilbert matrix of order n.

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -32,6 +32,7 @@ from jax._src.scipy.linalg import (
   hankel as hankel,
   hilbert as hilbert,
   inv as inv,
+  leslie as leslie,
   lu as lu,
   lu_factor as lu_factor,
   lu_solve as lu_solve,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -104,6 +104,17 @@ def osp_linalg_circulant(c: np.ndarray) -> np.ndarray:
   return np.vectorize(
       scipy.linalg.circulant, signature="(n)->(n,n)", otypes=(c.dtype,))(c)
 
+def osp_linalg_leslie(f: np.ndarray, s: np.ndarray) -> np.ndarray:
+  """Batched scipy leslie for testing."""
+  f = np.atleast_1d(f)
+  s = np.atleast_1d(s)
+  if scipy_version >= (1, 15):
+    return scipy.linalg.leslie(f, s)
+  out_dtype = np.result_type(f.dtype, s.dtype)
+  return np.vectorize(
+      scipy.linalg.leslie, signature="(n),(m)->(n,n)",
+      otypes=(out_dtype,))(f, s)
+
 def osp_linalg_hankel(c: np.ndarray, r: np.ndarray | None = None) -> np.ndarray:
   """Batched scipy hankel for testing."""
   if scipy_version >= (1, 19):
@@ -2304,6 +2315,28 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype)]
     self._CheckAgainstNumpy(osp_linalg_circulant, jsp.linalg.circulant, args_maker)
     self._CompileAndCheck(jsp.linalg.circulant, args_maker)
+
+  @jtu.sample_product(
+     n=[2, 3, 5, 8],
+     batch=[(), (2,), (1, 3)],
+     dtype=float_types + int_types,
+  )
+  def testLeslie(self, n, batch, dtype):
+    rng = jtu.rand_default(self.rng())
+    f_shape = batch + (n,)
+    s_shape = batch + (n - 1,)
+    args_maker = lambda: [rng(f_shape, dtype), rng(s_shape, dtype)]
+    self._CheckAgainstNumpy(osp_linalg_leslie, jsp.linalg.leslie, args_maker,
+                            check_dtypes=False)
+    self._CompileAndCheck(jsp.linalg.leslie, args_maker)
+
+  def testLeslieInvalidLength(self):
+    with self.assertRaisesRegex(ValueError, "length of f along the last axis"):
+      jsp.linalg.leslie(jnp.array([1.0]), jnp.array([]))
+    with self.assertRaisesRegex(ValueError, "Incorrect lengths for f and s"):
+      jsp.linalg.leslie(jnp.array([1., 2., 3.]), jnp.array([0.5]))
+    with self.assertRaisesRegex(ValueError, "Incorrect lengths for f and s"):
+      jsp.linalg.leslie(jnp.array([1., 2.]), jnp.array([]))
 
   @jtu.sample_product(
     shape=[(2, 3), (4, 6), (50, 7), (100, 110)],


### PR DESCRIPTION
Adds `jax.scipy.linalg.leslie`, continuing the special-matrix series from #10144 (after `hadamard`, `circulant`, `dft`, `companion` in #37333, and `fiedler` in #37334).

Given fecundity coefficients `f` of shape `(..., N)` and survival `s` of shape `(..., N - 1)`, the Leslie matrix puts `f` in the first row, `s` on the first sub-diagonal, and zeros everywhere else. The implementation is essentially `jnp.diag(s, k=-1).at[0].set(f)` after promoting both inputs to a common dtype, wrapped in `jnp.vectorize` so batched leading axes fall out for free.

The outer wrapper enforces the `len(s) == len(f) - 1` relationship (and that `f` has at least 2 elements) with `ValueError` messages matching SciPy's.

### Tests
`testLeslie` runs parity against SciPy across a sweep of `n`, batch shapes including `()` / `(2,)` / `(1, 3)`, and float + int dtypes — 11 cases under both x32 and x64. `testLeslieInvalidLength` covers `f` too short, `s` longer than expected, and empty `s` with `f` of length 2. Doctest passes. I also sanity-checked locally: jit, vmap, mixed-dtype `f`/`s` (int + float promotes correctly), and broadcasting between un-batched `s` and batched `f` (vectorize handles it).

### Notes on prior work
This was the last unclaimed item from the stale bundle PR #35075 (no activity since 2026-02-13). With `companion` in #37333, `dft` in #37149, `fiedler` in #37334, and the already-merged `hadamard` (#37043), splitting that bundle into smaller PRs has been working out — this one lands the rest of its content.

Issue: #10144