### PR TITLE
Expose some jax.core errors in jax.errors

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -7,6 +7,8 @@ This page lists a few of the errors you might encounter when using JAX,
 along with representative examples of how one might fix them.
 
 .. currentmodule:: jax.errors
+.. autoclass:: InconclusiveDimensionOperation
+.. autoclass:: JaxprTypeError
 .. autoclass:: JaxRuntimeError
 .. autoclass:: JAXTypeError
 .. autoclass:: JAXIndexError

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -2989,6 +2989,7 @@ class AbstractTodo(AbstractValue):
 
 ### Operations on shapes and dimension sizes.
 
+@set_module("jax.errors")
 class InconclusiveDimensionOperation(Exception):
   """Raised when we cannot conclusively compute with symbolic dimensions."""
 
@@ -3468,6 +3469,7 @@ def aval_mismatch_extra(a1: AbstractValue, a2: AbstractValue) -> str:
       return ', so ' + ', '.join(mismatches[:-1]) + ', and ' + mismatches[-1]
   return ''
 
+@set_module("jax.errors")
 class JaxprTypeError(TypeError): pass
 
 custom_typechecks: dict[Primitive, Callable] = {}

--- a/jax/core.py
+++ b/jax/core.py
@@ -107,11 +107,11 @@ _deprecations = {
     _src_core.Effects,
   ),
   "InconclusiveDimensionOperation": (
-    "jax.core.InconclusiveDimensionOperation is deprecated. Use jax.extend.core.InconclusiveDimensionOperation.",
+    "jax.core.InconclusiveDimensionOperation is deprecated. Use jax.errors.InconclusiveDimensionOperation.",
     _src_core.InconclusiveDimensionOperation,
   ),
   "JaxprTypeError": (
-    "jax.core.JaxprTypeError is deprecated. Use jax.extend.core.JaxprTypeError.",
+    "jax.core.JaxprTypeError is deprecated. Use jax.errors.JaxprTypeError.",
     _src_core.JaxprTypeError,
   ),
   "check_jaxpr": (

--- a/jax/errors.py
+++ b/jax/errors.py
@@ -15,6 +15,11 @@
 # Note: import <name> as <name> is required for names to be exported.
 # See PEP 484 & https://github.com/jax-ml/jax/issues/7570
 
+from jax._src.core import (
+    InconclusiveDimensionOperation as InconclusiveDimensionOperation,
+    JaxprTypeError as JaxprTypeError,
+)
+
 from jax._src.errors import (
   JAXTypeError as JAXTypeError,
   JAXIndexError as JAXIndexError,

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -472,6 +472,7 @@ class CustomErrorsTest(jtu.JaxTestCase):
               'JaxIndexError',
               'JAXTypeError',
               'JaxRuntimeError',
+              'JaxprTypeError',
           ]
       ],
   )


### PR DESCRIPTION
Including:
- `jax.errors.InconclusiveDimensionOperation`
- `jax.errors.JaxprTypeError`

These were deprecated in `jax.core` in JAX v0.10.0, and exposed via `jax.extend`, but in retrospect I think this was a mistake. Errors raised by internal APIs are user-visible, and we should provide supported public import paths for them. `jax.core` is not the right place (because these APIs are not meant for public consumption), nor is `jax.extend` (since these are semi-private APIs) so moving them to `jax.errors` seems reasonable.