### PR TITLE
Add jax.scipy.linalg.helmert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     matrices from polynomial coefficients ({jax-issue}`#10144`).
   * Added {func}`jax.scipy.linalg.fiedler` for constructing symmetric Fiedler
     matrices ({jax-issue}`#10144`).
+  * Added {func}`jax.scipy.linalg.helmert` for constructing Helmert matrices
+    ({jax-issue}`#10144`).
   * Moved RNG APIs from "implementations" to dtypes ({jax-issue}`#27854`):
     * Added `jax.random.key_dtype` to get the dtype corresponding to a PRNG
       implementation name.

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -68,6 +68,7 @@ jax.scipy.linalg
    fiedler
    funm
    hadamard
+   helmert
    hessenberg
    hankel
    hilbert

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -2823,6 +2823,46 @@ def _binom(n, k):
   return lax.exp(a - b - c)
 
 
+@jit(static_argnames=("n", "full"))
+def helmert(n: int, full: bool = False) -> Array:
+  r"""Construct a Helmert matrix.
+
+  JAX implementation of :func:`scipy.linalg.helmert`.
+
+  The Helmert matrix has rows of orthonormal contrasts. For ``k = 1, ...,
+  n - 1``, row ``k - 1`` is :math:`(\underbrace{1, \ldots, 1}_{k}, -k, 0,
+  \ldots, 0) / \sqrt{k(k + 1)}`. If ``full`` is ``True``, a row of
+  :math:`1 / \sqrt{n}` is prepended.
+
+  Args:
+    n: size of the matrix. Must be a positive integer.
+    full: if ``True``, return the full ``(n, n)`` matrix; otherwise return
+      only the ``(n - 1, n)`` contrast block. Defaults to ``False``.
+
+  Returns:
+    A Helmert matrix of shape ``(n - 1, n)`` if ``full`` is ``False``, or
+    ``(n, n)`` if ``full`` is ``True``.
+
+  Examples:
+    >>> jax.scipy.linalg.helmert(2, full=True).round(3)
+    Array([[ 0.707,  0.707],
+           [ 0.707, -0.707]], dtype=float32)
+  """
+  if n < 1:
+    raise ValueError(f"n must be a positive integer; got {n}.")
+  i = jnp.arange(n - 1)[:, None]
+  j = jnp.arange(n)[None, :]
+  k = i + 1
+  k_f = k.astype(dtypes.default_float_dtype())
+  denom = jnp.sqrt(k_f * (k_f + 1))
+  H = jnp.where(j <= i, 1.0 / denom,
+                jnp.where(j == k, -k_f / denom, jnp.zeros_like(denom)))
+  if full:
+    first_row = jnp.full((1, n), 1.0 / jnp.sqrt(n), dtype=H.dtype)
+    H = jnp.concatenate([first_row, H], axis=0)
+  return H
+
+
 @jit(static_argnames=("n", "dtype"))
 def hadamard(n: int, dtype: DTypeLike = int) -> Array:
   r"""Construct an n-by-n Hadamard matrix.

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -30,6 +30,7 @@ from jax._src.scipy.linalg import (
   expm_frechet as expm_frechet,
   fiedler as fiedler,
   hadamard as hadamard,
+  helmert as helmert,
   hessenberg as hessenberg,
   hankel as hankel,
   hilbert as hilbert,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2715,6 +2715,23 @@ class LaxLinalgTest(jtu.JaxTestCase):
       jsp.linalg.hadamard(n)
 
   @jtu.sample_product(
+    n=[1, 2, 3, 4, 5, 8],
+    full=[False, True],
+  )
+  def testHelmert(self, n, full):
+    args_maker = lambda: []
+    osp_fun = partial(osp.linalg.helmert, n=n, full=full)
+    jsp_fun = partial(jsp.linalg.helmert, n=n, full=full)
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker,
+                            atol=1e-5, rtol=1e-5, check_dtypes=False)
+    self._CompileAndCheck(jsp_fun, args_maker)
+
+  @jtu.sample_product(n=[0, -1, -5])
+  def testHelmertInvalidN(self, n):
+    with self.assertRaisesRegex(ValueError, "n must be a positive integer"):
+      jsp.linalg.helmert(n)
+
+  @jtu.sample_product(
     n=[0, 1, 2, 3, 5, 8, 16],
     scale=[None, 'sqrtn', 'n'],
   )


### PR DESCRIPTION
Adds `jax.scipy.linalg.helmert`, continuing the special-matrix series from #10144 (after `hadamard`, `circulant`, `dft`, `companion` in #37333, `fiedler` in #37334, and `leslie` in #37335).

For row index `k = 1, ..., n - 1`, the contrast row has `k` entries of `1/sqrt(k(k+1))`, then `-k/sqrt(k(k+1))`, then zeros. The implementation just builds those rows from broadcast `arange` indices and two `jnp.where` masks. With `full=True`, a row of `1/sqrt(n)` is prepended so the result is orthogonal.

Static `n` and `full` via `jit`, same pattern as `hadamard` and `hilbert`. Raises `ValueError` for `n < 1`. The `n = 1` corner case still works: returns `(0, 1)` for `full=False` and `[[1.]]` for `full=True`, matching SciPy.

One subtlety worth flagging: the integer indices need an explicit cast to the default float dtype before division, otherwise strict-promotion mode rejects mixing `int32` with `float32` in `1.0 / denom` and `-k / denom`. I caught that the first time tests ran. Casting upfront with `k_f = k.astype(dtypes.default_float_dtype())` fixes it cleanly, and the inner `where` uses `jnp.zeros_like(denom)` instead of `0.0` for the same reason.

### Tests
`testHelmert` runs parity vs SciPy across `n` ∈ {1, 2, 3, 4, 5, 8} × `full` ∈ {False, True}, giving 13 cases under both x32 and x64. `testHelmertInvalidN` covers `n ∈ {0, -1, -5}`. Doctest passes. I also sanity-checked locally that `H @ H.T = I` holds for `full=True` up to `n = 32`, and that contrast rows sum to zero (the property that makes Helmert useful for compositional analysis).

Issue: #10144
