### PR TITLE
Add hermitian arg in jax.numpy.linalg.matrix_rank

### DIFF
--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -412,9 +412,10 @@ def matrix_power(a: ArrayLike, n: int) -> Array:
 
 
 @export
-@api.jit
+@api.jit(static_argnames=('hermitian',))
 def matrix_rank(
-  M: ArrayLike, rtol: ArrayLike | None = None, *, tol: ArrayLike | None = None) -> Array:
+  M: ArrayLike, rtol: ArrayLike | None = None,
+  *, hermitian: bool = False, tol: ArrayLike | None = None) -> Array:
   """Compute the rank of a matrix.
 
   JAX implementation of :func:`numpy.linalg.matrix_rank`.
@@ -428,6 +429,8 @@ def matrix_rank(
       smaller than `rtol * largest_singular_value` are considered to be zero. If
       ``rtol`` is None (the default), a reasonable default is chosen based the
       floating point precision of the input.
+    hermitian: if True, then the input is assumed to be Hermitian, and a more
+      efficient algorithm is used (default: False)
     tol: alias of the ``rtol`` argument present for backward compatibility.
       Only one of `rtol` or `tol` may be specified.
 
@@ -459,7 +462,7 @@ def matrix_rank(
   M, = promote_dtypes_inexact(M)
   if M.ndim < 2:
     return (M != 0).any().astype(np.int32)
-  S = svd(M, full_matrices=False, compute_uv=False)
+  S = svd(M, full_matrices=False, compute_uv=False, hermitian=hermitian)
   if rtol is None:
     rtol = S.max(-1) * np.max(M.shape[-2:]).astype(S.dtype) * jnp.finfo(S.dtype).eps
   rtol = jnp.expand_dims(rtol, np.ndim(rtol))

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1067,14 +1067,14 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @jtu.ignore_warning(message="invalid value", category=RuntimeWarning)
   def testPinv(self, shape, hermitian, dtype):
     rng = jtu.rand_default(self.rng())
-    args_maker = lambda: [rng(shape, dtype)]
-
-    jnp_fn = partial(jnp.linalg.pinv, hermitian=hermitian)
-    def np_fn(a):
-      # Symmetrize the input matrix to match the jnp behavior.
+    def args_maker():
+      a = rng(shape, dtype)
       if hermitian:
         a = (a + T(a.conj())) / 2
-      return np.linalg.pinv(a, hermitian=hermitian)
+      return [a]
+
+    np_fn = partial(np.linalg.pinv, hermitian=hermitian)
+    jnp_fn = partial(jnp.linalg.pinv, hermitian=hermitian)
     self._CheckAgainstNumpy(np_fn, jnp_fn, args_maker, tol=1e-4)
     self._CompileAndCheck(jnp_fn, args_maker, atol=1e-5)
 
@@ -1127,17 +1127,25 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     self.assertArraysEqual(np_result, jnp_result)
 
   @jtu.sample_product(
-    shape=[(3, ), (1, 2), (8, 5), (4, 4), (5, 5), (50, 50), (3, 4, 5),
-           (2, 3, 4, 5)],
+    [dict(shape=shape, hermitian=hermitian)
+     for shape in [(3, ), (1, 2), (8, 5), (4, 4), (5, 5), (50, 50), (3, 4, 5),
+                   (2, 3, 4, 5)]
+     for hermitian in ([False, True] if len(shape) >= 2 and shape[-1] == shape[-2] else [False])],
     dtype=float_types + complex_types,
   )
-  def testMatrixRank(self, shape, dtype):
+  def testMatrixRank(self, shape, dtype, hermitian):
     rng = jtu.rand_default(self.rng())
-    args_maker = lambda: [rng(shape, dtype)]
-    a, = args_maker()
-    self._CheckAgainstNumpy(np.linalg.matrix_rank, jnp.linalg.matrix_rank,
+    def args_maker():
+      a = rng(shape, dtype)
+      if hermitian:
+        a = (a + T(a.conj())) / 2
+      return [a]
+
+    np_fn = partial(np.linalg.matrix_rank, hermitian=hermitian)
+    jnp_fn = partial(jnp.linalg.matrix_rank, hermitian=hermitian)
+    self._CheckAgainstNumpy(np_fn, jnp_fn,
                             args_maker, check_dtypes=False, tol=1e-3)
-    self._CompileAndCheck(jnp.linalg.matrix_rank, args_maker,
+    self._CompileAndCheck(jnp_fn, args_maker,
                           check_dtypes=False, rtol=1e-3)
 
   def testMatrixRankTol(self):


### PR DESCRIPTION
### Motivation

I was taking a look through the linalg module and noticed that matrix_rank was missing numpy's hermitian arg. Jax svd supports the hermitian optimization and I couldn't find any discussion about leaving the arg off.

### Links
- [numpy doc](https://numpy.org/doc/2.4/reference/generated/numpy.linalg.matrix_rank.html)
- [pinv reference](https://github.com/jax-ml/jax/blob/2df8eced12c0e5a2456ebc0c693077109fa51fbd/jax/_src/numpy/linalg.py#L982)
