### PR TITLE
Added out_sharding to jax.random.rademacher sampler

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -2413,7 +2413,9 @@ def _f(key, dfnum, dfden, shape, dtype) -> Array:
 
 def rademacher(key: ArrayLike,
                shape: Shape = (),
-               dtype: DTypeLikeInt | None = None) -> Array:
+               dtype: DTypeLikeInt | None = None,
+               *,
+               out_sharding: NamedSharding | P | None = None) -> Array:
   r"""Sample from a Rademacher distribution.
 
   The values are distributed according to the probability mass function:
@@ -2427,6 +2429,14 @@ def rademacher(key: ArrayLike,
     key: a PRNG key.
     shape: The shape of the returned samples. Default ().
     dtype: The type used for samples.
+    out_sharding: optional, specifies how the output array should be sharded
+      across devices in multi-device computation. Can be a
+      :class:`~jax.sharding.NamedSharding`, a :class:`~jax.sharding.PartitionSpec`
+      (``P``), or ``None`` (default). When specified, the output will be sharded
+      according to the given sharding specification. Primarily used in explicit
+      sharding mode.
+      See the `explicit sharding tutorial <https://docs.jax.dev/en/latest/parallel.html>`_
+      for more details.
 
   Returns:
     A jnp.array of samples, of shape `shape`. Each element in the output has
@@ -2437,12 +2447,14 @@ def rademacher(key: ArrayLike,
   dtype = dtypes.check_and_canonicalize_user_dtype(
       int if dtype is None else dtype)
   shape = core.canonicalize_shape(shape)
-  return _rademacher(key, shape, dtype)
+  out_sharding = canonicalize_sharding_for_samplers(out_sharding, "rademacher", shape)
+  return _rademacher(key, shape, dtype, out_sharding)
 
 
-@jit(static_argnums=(1, 2))
-def _rademacher(key, shape, dtype) -> Array:
-  bernoulli_samples = bernoulli(key=key, p=0.5, shape=shape).astype(dtype)
+@jit(static_argnums=(1, 2, 3))
+def _rademacher(key, shape, dtype, out_sharding) -> Array:
+  bernoulli_samples = bernoulli(key=key, p=0.5, shape=shape,
+                                out_sharding=out_sharding).astype(dtype)
   return (2 * bernoulli_samples - 1).astype(dtype)
 
 

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -232,6 +232,7 @@ _OUT_SHARDING_CASES = [
     ('permutation', lambda key, n, s: random.permutation(key, n, out_sharding=s)),
     ('pareto', lambda key, n, s: random.pareto(key, b=3.0, shape=(n,), out_sharding=s)),
     ('poisson', lambda key, n, s: random.poisson(key, lam=3.0, shape=(n,), out_sharding=s)),
+    ('rademacher', lambda key, n, s: random.rademacher(key, shape=(n,), out_sharding=s)),
     ('randint', lambda key, n, s: random.randint(key, shape=(n,), minval=0, maxval=10, out_sharding=s)),
     ('rayleigh', lambda key, n, s: random.rayleigh(key, shape=(n,), scale=0.5, out_sharding=s)),
     ('t', lambda key, n, s: random.t(key, df=10.0, shape=(n,), out_sharding=s)),


### PR DESCRIPTION
Description:
- Added out_sharding to jax.random.rademacher sampler
- Added a test

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->