### PR TITLE
Add jax.scipy.linalg.convolution_matrix

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -59,6 +59,7 @@ jax.scipy.linalg
    cholesky
    circulant
    companion
+   convolution_matrix
    det
    dft
    eigh

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from functools import partial
 import math
+import operator
 import textwrap
 from typing import overload, Any, Literal
 import warnings
@@ -2727,6 +2728,75 @@ def fiedler(a: ArrayLike) -> Array:
   check_arraylike("fiedler", a)
   arr = jnp.atleast_1d(a)
   return jnp.abs(arr[..., None] - arr[..., None, :])
+
+
+@jit(static_argnames=("n", "mode"))
+def convolution_matrix(a: ArrayLike, n: int, mode: str = 'full') -> Array:
+  r"""Construct a convolution matrix.
+
+  JAX implementation of :func:`scipy.linalg.convolution_matrix`.
+
+  Builds a Toeplitz matrix :math:`A` such that ``A @ v`` equals
+  ``jnp.convolve(a, v, mode)``. The returned array has ``n`` columns;
+  the row count :math:`k` depends on ``mode``:
+
+  - ``'full'``: :math:`k = m + n - 1`
+  - ``'same'``: :math:`k = \max(m, n)`
+  - ``'valid'``: :math:`k = \max(m, n) - \min(m, n) + 1`
+
+  where :math:`m` is the size of ``a`` along the last axis.
+
+  Args:
+    a: array of shape ``(..., m)`` to convolve. Must have ``m >= 1``.
+    n: number of columns in the output. Must be a positive integer.
+    mode: one of ``'full'``, ``'same'``, ``'valid'``. Defaults to ``'full'``.
+
+  Returns:
+    A convolution matrix of shape ``(..., k, n)``, where ``k`` depends on
+    ``mode`` as described above.
+
+  See also:
+    :func:`jax.scipy.linalg.toeplitz`
+
+  Examples:
+    >>> jax.scipy.linalg.convolution_matrix(jnp.array([-1, 4, -2]), 5, mode='same')
+    Array([[ 4, -1,  0,  0,  0],
+           [-2,  4, -1,  0,  0],
+           [ 0, -2,  4, -1,  0],
+           [ 0,  0, -2,  4, -1],
+           [ 0,  0,  0, -2,  4]], dtype=int32)
+  """
+  n = operator.index(n)
+  if n <= 0:
+    raise ValueError(f"n must be a positive integer; got {n}.")
+  check_arraylike("convolution_matrix", a)
+  a_arr = jnp.asarray(a)
+  if a_arr.ndim == 0:
+    raise ValueError(
+        "convolution_matrix: a must be at least 1-dimensional, got a scalar.")
+  m = a_arr.shape[-1]
+  if m < 1:
+    raise ValueError(f"len(a) must be at least 1; got shape {a_arr.shape}.")
+  if mode not in ('full', 'valid', 'same'):
+    raise ValueError(
+        f"mode must be one of 'full', 'valid', 'same'; got {mode!r}.")
+  pad_widths = [(0, 0)] * (a_arr.ndim - 1) + [(0, n - 1)]
+  az = jnp.pad(a_arr, pad_widths)
+  raz = jnp.pad(jnp.flip(a_arr, axis=-1), pad_widths)
+  L = m + n - 1
+  if mode == 'same':
+    trim = min(n, m) - 1
+    tb = trim // 2
+    te = trim - tb
+  elif mode == 'valid':
+    tb = min(n, m) - 1
+    te = tb
+  else:  # 'full'
+    tb = 0
+    te = 0
+  col0 = lax.slice_in_dim(az, tb, L - te, axis=-1)
+  row0 = lax.slice_in_dim(raz, L - n - tb, L - tb, axis=-1)
+  return toeplitz(col0, row0)
 
 
 @jit(static_argnames=("n",))

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -22,6 +22,7 @@ from jax._src.scipy.linalg import (
   cho_solve as cho_solve,
   circulant as circulant,
   companion as companion,
+  convolution_matrix as convolution_matrix,
   det as det,
   dft as dft,
   eigh as eigh,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -132,6 +132,19 @@ def osp_linalg_fiedler(a: np.ndarray) -> np.ndarray:
   return np.vectorize(
       scipy.linalg.fiedler, signature="(n)->(n,n)", otypes=(a.dtype,))(a)
 
+def osp_linalg_convolution_matrix(a: np.ndarray, n: int,
+                                  mode: str = 'full') -> np.ndarray:
+  """Batched scipy convolution_matrix for testing."""
+  if scipy_version >= (1, 15):
+    return scipy.linalg.convolution_matrix(a, n, mode=mode)
+  a = np.atleast_1d(a)
+  if a.ndim == 1:
+    return scipy.linalg.convolution_matrix(a, n, mode=mode)
+  flat = a.reshape(-1, a.shape[-1])
+  out = np.stack([scipy.linalg.convolution_matrix(row, n, mode=mode)
+                  for row in flat])
+  return out.reshape(*a.shape[:-1], *out.shape[-2:])
+
 def osp_linalg_hankel(c: np.ndarray, r: np.ndarray | None = None) -> np.ndarray:
   """Batched scipy hankel for testing."""
   if scipy_version >= (1, 19):
@@ -2391,6 +2404,40 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(osp_linalg_fiedler, jsp.linalg.fiedler, args_maker,
                             check_dtypes=False)
     self._CompileAndCheck(jsp.linalg.fiedler, args_maker)
+
+  @jtu.sample_product(
+     m=[1, 2, 3, 5],
+     n=[1, 2, 3, 5, 7],
+     mode=['full', 'valid', 'same'],
+     batch=[(), (2,), (1, 3)],
+     # Integer dtypes are skipped because the underlying Toeplitz lowers via
+     # an integer convolution that CuDNN only supports for s8 inputs with f32
+     # bias on GPU.
+     dtype=float_types + complex_types,
+  )
+  def testConvolutionMatrix(self, m, n, mode, batch, dtype):
+    rng = jtu.rand_default(self.rng())
+    shape = (*batch, m)
+    args_maker = lambda: [rng(shape, dtype)]
+    osp_fun = partial(osp_linalg_convolution_matrix, n=n, mode=mode)
+    jsp_fun = partial(jsp.linalg.convolution_matrix, n=n, mode=mode)
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, check_dtypes=False)
+    self._CompileAndCheck(jsp_fun, args_maker)
+
+  def testConvolutionMatrixInvalidArgs(self):
+    a = jnp.array([1., 2., 3.])
+    with self.assertRaisesRegex(ValueError, "n must be a positive integer"):
+      jsp.linalg.convolution_matrix(a, 0)
+    with self.assertRaisesRegex(ValueError, "n must be a positive integer"):
+      jsp.linalg.convolution_matrix(a, -1)
+    with self.assertRaisesRegex(ValueError, "mode must be one of"):
+      jsp.linalg.convolution_matrix(a, 3, mode='bad')
+    with self.assertRaisesRegex(ValueError, r"len\(a\) must be at least 1"):
+      jsp.linalg.convolution_matrix(jnp.zeros((0,)), 3)
+    with self.assertRaisesRegex(ValueError, r"len\(a\) must be at least 1"):
+      jsp.linalg.convolution_matrix(jnp.zeros((2, 0)), 3)
+    with self.assertRaisesRegex(ValueError, "must be at least 1-dimensional"):
+      jsp.linalg.convolution_matrix(jnp.array(5.0), 3)
 
   @jtu.sample_product(
     shape=[(2, 3), (4, 6), (50, 7), (100, 110)],


### PR DESCRIPTION
Implements `scipy.linalg.convolution_matrix` in `jax.scipy.linalg`.

Builds the Toeplitz matrix `A` such that `A @ v == jnp.convolve(a, v, mode)` for `mode` in `{'full', 'valid', 'same'}`. Returns shape `(..., k, n)`, where `k` is `m + n - 1` (`'full'`), `max(m, n)` (`'same'`), or `max(m, n) - min(m, n) + 1` (`'valid'`). Supports leading batch axes on the input by reusing the existing batched `toeplitz`.

Tracks issue #10144.

## Test plan
- [x] `pytest tests/linalg_test.py -k ConvolutionMatrix`
- [x] Smoke check vs `scipy.linalg.convolution_matrix` for all three modes (1D + batched)
- [x] `A @ v` matches `np.convolve(a, v, mode)`