### PR TITLE
[jaxlib] Validate PyTreeDef leaf count before flatten_up_to

### DIFF
--- a/jaxlib/pytree.cc
+++ b/jaxlib/pytree.cc
@@ -950,7 +950,16 @@ nb::object PyTreeDef::Unflatten(absl::Span<const nb::object> leaves) const {
 }
 
 nb::list PyTreeDef::FlattenUpTo(nb::handle xs) const {
-  nb::list leaves = nb::steal<nb::list>(PyList_New(num_leaves()));
+  // Malformed cached leaf counts can come from deserialization.
+  if (num_leaves() < 0) {
+    throw std::invalid_argument(absl::StrCat(
+        "Malformed PyTreeDef: num_leaves() = ", num_leaves(), " is negative"));
+  }
+  PyObject* py_leaves = PyList_New(num_leaves());
+  if (py_leaves == nullptr) {
+    throw nb::python_error();
+  }
+  nb::list leaves = nb::steal<nb::list>(py_leaves);
   std::vector<nb::object> agenda;
   agenda.push_back(nb::borrow<nb::object>(xs));
   auto it = traversal_.rbegin();

--- a/jaxlib/pytree_test.py
+++ b/jaxlib/pytree_test.py
@@ -80,6 +80,23 @@ class PyTreeTest(parameterized.TestCase):
     with self.assertRaises(ValueError):
       self.roundtrip_proto({"a": ExampleType2(field0=o, field1=o)})
 
+  def testFlattenUpToWithCorruptedNumLeavesRejects(self):
+    # Regression test for a malformed cached leaf count from __setstate__.
+    int_min = -(2**31)
+    poisoned_state = (
+        registry,
+        [
+            (0, 0, None, None, 1, 1),  # leaf
+            (0, 0, None, None, 1, 1),  # leaf
+            (0, 0, None, None, 1, 1),  # leaf
+            (4, 3, None, None, int_min, 4),  # list with num_leaves = INT_MIN
+        ],
+    )
+    td = pytree.PyTreeDef.__new__(pytree.PyTreeDef)
+    td.__setstate__(poisoned_state)
+    with self.assertRaisesRegex(ValueError, "is negative"):
+      td.flatten_up_to([1, 2, 3])
+
   def roundtrip_node_data(self, example):
     original = registry.flatten(example)[1]
     restored = pytree.PyTreeDef.from_node_data_and_children(


### PR DESCRIPTION
Fixes https://github.com/jax-ml/jax/issues/37412.

`PyTreeDef.__setstate__` restores cached node fields from pickle, including `num_leaves`. If that cached value is malformed, `flatten_up_to()` currently trusts it.

The bad case is `num_leaves() == INT_MIN`: `PyList_New(num_leaves())` returns null, and `num_leaves() - 1` can wrap to a large positive leaf index before the first `PyList_SET_ITEM`.

This patch makes `FlattenUpTo` reject negative cached leaf counts before allocating the output list, and checks the raw `PyList_New` result before handing it to nanobind. The malformed state now raises:

```text
ValueError: Malformed PyTreeDef: num_leaves() = -2147483648 is negative
```

I also added a regression test that builds the malformed `PyTreeDef` via `__setstate__` and verifies `flatten_up_to()` raises instead of crashing.

Validation:

- Reproduced the crash against the released `jaxlib==0.10.0` wheel: child process exits with `SIGSEGV`.
- Ran the same malformed pickle against the rebuilt extension from this branch: it raises the `ValueError` above.
- Checked a normal `flatten_up_to()` path still returns the expected leaves.
