### PR TITLE
Add wrap boundary support to convolve2d and correlate2d

### DIFF
--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -195,6 +195,42 @@ def _convolve_nd(in1: Array, in2: Array, mode: ModeString, *, precision: Precisi
   return result[0, 0]
 
 
+def _convolve_nd_wrap(in1: Array, in2: Array, mode: ModeString, *,
+                      precision: PrecisionLike) -> Array:
+  if mode not in ["full", "same", "valid"]:
+    raise ValueError("mode must be one of ['full', 'same', 'valid']")
+  if mode == "valid":
+    return _convolve_nd(in1, in2, mode, precision=precision)
+  if in1.ndim != in2.ndim:
+    raise ValueError("in1 and in2 must have the same number of dimensions")
+  if in1.size == 0 or in2.size == 0:
+    raise ValueError(f"zero-size arrays not supported in convolutions, got shapes {in1.shape} and {in2.shape}.")
+
+  if mode == "full":
+    out_shape = tuple(s1 + s2 - 1 for s1, s2 in zip(in1.shape, in2.shape))
+    out_start = (0,) * in1.ndim
+  else:
+    out_shape = in1.shape
+    out_start = tuple((s2 - 1) // 2 for s2 in in2.shape)
+
+  # Pad only the periodic input window needed for valid convolution to produce
+  # the requested full/same output.
+  pad_width = tuple((s2 - 1 - start, start + out - s1)
+                    for s1, s2, out, start in zip(in1.shape, in2.shape,
+                                                  out_shape, out_start))
+  return _convolve_nd(jnp.pad(in1, pad_width, mode="wrap"), in2, "valid",
+                      precision=precision)
+
+
+def _check_2d_boundary(func_name: str, boundary: str, fillvalue: float) -> None:
+  if boundary not in ["fill", "wrap"]:
+    raise NotImplementedError(
+        f"{func_name}() only supports boundary='fill' or boundary='wrap'")
+  if boundary == "fill" and fillvalue != 0:
+    raise NotImplementedError(
+        f"{func_name}() only supports fillvalue=0 when boundary='fill'")
+
+
 def convolve(in1: Array, in2: Array, mode: ModeString = 'full', method: str = 'auto',
              precision: PrecisionLike = None) -> Array:
   """Convolution of two N-dimensional arrays.
@@ -277,8 +313,9 @@ def convolve2d(in1: Array, in2: Array, mode: ModeString = 'full', boundary: str 
       * ``"valid"``: return the portion of the ``"full"`` output which do not
         depend on padding at the array edges.
 
-    boundary: only ``"fill"`` is supported.
-    fillvalue: only ``0`` is supported.
+    boundary: ``"fill"`` and ``"wrap"`` are supported.
+    fillvalue: only ``0`` is supported with ``boundary="fill"``; ignored for
+      ``boundary="wrap"``.
     method: controls the computation method. Options are
 
       * ``"auto"``: (default) always uses the ``"direct"`` method.
@@ -327,10 +364,11 @@ def convolve2d(in1: Array, in2: Array, mode: ModeString = 'full', boundary: str 
     Array([[22., 17.],
            [30., 32.]], dtype=float32)
   """
-  if boundary != 'fill' or fillvalue != 0:
-    raise NotImplementedError("convolve2d() only supports boundary='fill', fillvalue=0")
+  _check_2d_boundary("convolve2d", boundary, fillvalue)
   if np.ndim(in1) != 2 or np.ndim(in2) != 2:
     raise ValueError("convolve2d() only supports 2-dimensional inputs.")
+  if boundary == "wrap":
+    return _convolve_nd_wrap(in1, in2, mode, precision=precision)
   return _convolve_nd(in1, in2, mode, precision=precision)
 
 
@@ -411,8 +449,9 @@ def correlate2d(in1: Array, in2: Array, mode: ModeString = 'full', boundary: str
       * ``"valid"``: return the portion of the ``"full"`` output which do not
         depend on padding at the array edges.
 
-    boundary: only ``"fill"`` is supported.
-    fillvalue: only ``0`` is supported.
+    boundary: ``"fill"`` and ``"wrap"`` are supported.
+    fillvalue: only ``0`` is supported with ``boundary="fill"``; ignored for
+      ``boundary="wrap"``.
     method: controls the computation method. Options are
 
       * ``"auto"``: (default) always uses the ``"direct"`` method.
@@ -462,10 +501,17 @@ def correlate2d(in1: Array, in2: Array, mode: ModeString = 'full', boundary: str
     Array([[15., 24.],
            [28., 14.]], dtype=float32)
   """
-  if boundary != 'fill' or fillvalue != 0:
-    raise NotImplementedError("correlate2d() only supports boundary='fill', fillvalue=0")
+  _check_2d_boundary("correlate2d", boundary, fillvalue)
   if np.ndim(in1) != 2 or np.ndim(in2) != 2:
     raise ValueError("correlate2d() only supports 2-dimensional inputs.")
+
+  if boundary == "wrap" and mode != "valid":
+    if mode == "same":
+      # Preserve SciPy's correlate2d same-mode offset convention.
+      return jnp.flip(_convolve_nd_wrap(jnp.flip(in1), in2.conj(), mode,
+                                        precision=precision))
+    return _convolve_nd_wrap(in1, jnp.flip(in2).conj(), mode,
+                             precision=precision)
 
   swap = all(s1 <= s2 for s1, s2 in zip(in1.shape, in2.shape))
   same_shape =  all(s1 == s2 for s1, s2 in zip(in1.shape, in2.shape))

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -59,6 +59,13 @@ istft_test_shapes = [
 
 default_dtypes = jtu.dtypes.floating + jtu.dtypes.integer + jtu.dtypes.complex
 _TPU_FFT_TOL = 0.15
+_CONVOLUTION_2D_TOL = {
+    np.float16: 1e-2,
+    np.float32: 1e-2,
+    np.float64: 1e-12,
+    np.complex64: 1e-2,
+    np.complex128: 1e-12,
+}
 
 def _real_dtype(dtype):
   return jnp.finfo(dtypes.to_inexact_dtype(dtype)).dtype
@@ -126,22 +133,70 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
 
   @jtu.sample_product(
     mode=['full', 'same', 'valid'],
+    boundary=['fill', 'wrap'],
     op=['convolve2d', 'correlate2d'],
     dtype=default_dtypes,
     xshape=twodim_shapes,
     yshape=twodim_shapes,
   )
-  def testConvolutions2D(self, xshape, yshape, dtype, mode, op):
+  def testConvolutions2D(self, xshape, yshape, dtype, mode, boundary, op):
     jsp_op = getattr(jsp_signal, op)
     osp_op = getattr(osp_signal, op)
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(xshape, dtype), rng(yshape, dtype)]
-    osp_fun = partial(osp_op, mode=mode)
-    jsp_fun = partial(jsp_op, mode=mode, precision=lax.Precision.HIGHEST)
-    tol = {np.float16: 1e-2, np.float32: 1e-2, np.float64: 1e-12, np.complex64: 1e-2, np.complex128: 1e-12}
+    osp_fun = partial(osp_op, mode=mode, boundary=boundary)
+    jsp_fun = partial(jsp_op, mode=mode, boundary=boundary,
+                      precision=lax.Precision.HIGHEST)
     self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, check_dtypes=False,
-                            tol=tol)
-    self._CompileAndCheck(jsp_fun, args_maker, rtol=tol, atol=tol)
+                            tol=_CONVOLUTION_2D_TOL)
+    self._CompileAndCheck(jsp_fun, args_maker, rtol=_CONVOLUTION_2D_TOL,
+                          atol=_CONVOLUTION_2D_TOL)
+
+  @jtu.sample_product(
+    [dict(xshape=xshape, yshape=yshape)
+     for xshape, yshape in [((3, 4), (2, 5)), ((2, 5), (3, 4)),
+                            ((1, 3), (4, 2)), ((4, 2), (1, 3))]
+    ],
+    mode=['full', 'same'],
+    op=['convolve2d', 'correlate2d'],
+    dtype=default_dtypes,
+  )
+  def testConvolutions2DWrapMixedShapes(self, xshape, yshape, dtype, mode, op):
+    jsp_op = getattr(jsp_signal, op)
+    osp_op = getattr(osp_signal, op)
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(xshape, dtype), rng(yshape, dtype)]
+    osp_fun = partial(osp_op, mode=mode, boundary='wrap')
+    jsp_fun = partial(jsp_op, mode=mode, boundary='wrap',
+                      precision=lax.Precision.HIGHEST)
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, check_dtypes=False,
+                            tol=_CONVOLUTION_2D_TOL)
+    self._CompileAndCheck(jsp_fun, args_maker, rtol=_CONVOLUTION_2D_TOL,
+                          atol=_CONVOLUTION_2D_TOL)
+
+  @jtu.sample_product(
+    mode=['full', 'same', 'valid'],
+    op=['convolve2d', 'correlate2d'],
+    dtype=default_dtypes,
+  )
+  def testConvolutions2DWrapIgnoresFillValue(self, dtype, mode, op):
+    jsp_op = getattr(jsp_signal, op)
+    osp_op = getattr(osp_signal, op)
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng((3, 4), dtype), rng((2, 3), dtype)]
+    osp_fun = partial(osp_op, mode=mode, boundary='wrap', fillvalue=7)
+    jsp_fun = partial(jsp_op, mode=mode, boundary='wrap', fillvalue=7,
+                      precision=lax.Precision.HIGHEST)
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, check_dtypes=False,
+                            tol=_CONVOLUTION_2D_TOL)
+    self._CompileAndCheck(jsp_fun, args_maker, rtol=_CONVOLUTION_2D_TOL,
+                          atol=_CONVOLUTION_2D_TOL)
+
+  @jtu.sample_product(op=['convolve2d', 'correlate2d'])
+  def testConvolutions2DRejectFillValue(self, op):
+    jsp_op = getattr(jsp_signal, op)
+    with self.assertRaisesRegex(NotImplementedError, "fillvalue=0"):
+      jsp_op(jnp.ones((2, 2)), jnp.ones((2, 2)), boundary='fill', fillvalue=1)
 
   @jtu.sample_product(
     shape=[(5,), (4, 5), (3, 4, 5)],


### PR DESCRIPTION
Fixes #7276.

This adds `boundary="wrap"` support to `jax.scipy.signal.convolve2d`, and uses the same path for `correlate2d`.

The implementation explicitly pads the first input with `mode="wrap"` and then reuses the existing direct convolution in `valid` mode. The amount of padding is computed per axis from the requested output window, so cases like `(1000, 2)` avoid the excessive padding discussed in #21241.

`mode="valid"` continues to use the existing path because it does not depend on boundary padding for accepted shapes. `fillvalue` is ignored for `boundary="wrap"`, matching SciPy.

Tests added:

- SciPy parity for `convolve2d`/`correlate2d` with `boundary="fill"` and `boundary="wrap"`.
- Mixed-shape wrap cases that cover the failure mode from #21241.
- `fillvalue` behavior for wrap and fill boundaries.

Local checks:

```
python -m pytest -q tests/scipy_signal_test.py
# 98 passed, 24 skipped

python -m pytest -q tests/scipy_signal_test.py -k 'testConvolutions2D'
# 32 passed, 90 deselected

JAX_NUM_GENERATED_CASES=50 python -m pytest -q -n auto tests/scipy_signal_test.py -k 'testConvolutions'
# 168 passed

JAX_ENABLE_X64=1 JAX_NUM_GENERATED_CASES=50 python -m pytest -q -n auto tests/scipy_signal_test.py -k 'testConvolutions'
# 188 passed

ruff check jax/_src/scipy/signal.py tests/scipy_signal_test.py
# All checks passed
```
