### PR TITLE
docs(export): note deserialize trust boundary

### DIFF
--- a/docs/export/export.md
+++ b/docs/export/export.md
@@ -66,6 +66,18 @@ Serialization is broken down into two stages:
      an alternative serialization to TensorFlow graph that can be used
      for interoperation with TensorFlow.
 
+:::{warning}
+The serialized byte array produced by ``exported.serialize()`` is **trusted
+input**. ``export.deserialize(blob)`` rehydrates an ``Exported`` (including
+the embedded MLIR module and the ``disabled_safety_checks`` set) without
+re-running the validation performed at export time. Only deserialize blobs
+that come from a trusted source; treat them with the same level of trust as
+the source code that produced them. The ``DisabledSafetyCheck`` mechanism
+signals serialization-time decisions (e.g. that the export contains custom
+calls not vetted as stable) and is not intended as an authorization or
+sandboxing layer for untrusted inputs.
+:::
+
 ## Support for reverse-mode AD
 
 Serialization can optionally support higher-order reverse-mode AD. This is done

--- a/jax/_src/export/serialization.py
+++ b/jax/_src/export/serialization.py
@@ -141,7 +141,16 @@ def serialize(exp: _export.Exported, vjp_order: int = 0) -> bytearray:
 
 
 def deserialize(ser: bytearray) -> _export.Exported:
-  """Deserializes an Exported."""
+  """Deserializes an Exported.
+
+  The serialized byte array is trusted input. ``deserialize`` reconstructs
+  an :class:`Exported` from its fields (including ``mlir_module_serialized``
+  and the embedded ``disabled_safety_checks`` set) without re-running the
+  validation performed at export time. Callers must ensure the blob comes
+  from a trusted source; do not ``deserialize`` byte arrays of unknown
+  provenance, as the resulting :class:`Exported` may compile and call
+  arbitrary jaxlib custom-call targets when invoked.
+  """
   exp = ser_flatbuf.Exported.GetRootAsExported(ser)
   return _deserialize_exported(exp)
 


### PR DESCRIPTION
Per discussion in security advisory [GHSA-g378-2xc6-4gf6](https://github.com/jax-ml/jax/security/advisories/GHSA-g378-2xc6-4gf6) (`hawkinsp`, `gnecula`), this adds a short note clarifying that `jax.export.deserialize` expects a trusted blob.

Two minimal additions, no behavioral change:

- `docs/export/export.md` — admonition right after the basic serialize/deserialize introduction, stating that the byte array is trusted input and that `DisabledSafetyCheck` is not an authorization layer.
- `jax/_src/export/serialization.py` — extends the one-line docstring of `deserialize` with the same trust-boundary note.

Both wordings stay within the scope `gnecula` outlined in the advisory:

> "a short note in the deserialize method and/or the export.md documentation may be useful, but I don't think it is useful to do more"

No additional checks are introduced. Happy to adjust the wording or relocate the note if you'd prefer it elsewhere (e.g. the public `jax.export` API page, or a dedicated security section).