### PR TITLE
don't insert dropvars into jaxprs

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -30,7 +30,7 @@ import re
 import threading
 import types
 from typing import (Any, ClassVar, Generic, NamedTuple, TypeVar, final,
-                    overload, Union, TYPE_CHECKING)
+                    overload, Union, TYPE_CHECKING, Literal as Literal_)
 import warnings
 import weakref
 
@@ -3511,7 +3511,7 @@ def check_jaxpr(jaxpr: Jaxpr):
   """
   @functools.cache
   def ctx_factory():
-    ctx = JaxprPpContext()
+    ctx = JaxprPpContext(_dropvars(jaxpr))
     pp_settings = JaxprPpSettings()
     try: pp_jaxpr(jaxpr, ctx, pp_settings)  # side-effect on ctx, build variable names
     except: pass
@@ -3543,8 +3543,16 @@ class MutableTypecheckVal:
   aval : AbstractValue
   mutable_qdd : MutableQuasiDynamicData
 
-
-
+@partial(weakref_lru_cache, trace_context_in_key=False)
+def _dropvars(jaxpr: Jaxpr) -> dict[Var, Literal_['_']]:
+  varnames: dict[Var, Literal_['_']] = {}
+  used: set[Var] = {atom for atom in jaxpr.outvars if isinstance(atom, Var)}
+  for eqn in jaxpr.eqns[::-1]:
+    for v in eqn.outvars:
+      if not v in used:
+        varnames[v] = '_'
+    used.update(atom for atom in eqn.invars if isinstance(atom, Var))
+  return varnames
 
 
 def _check_jaxpr(
@@ -3917,7 +3925,7 @@ def pp_toplevel_jaxpr(jaxpr_to_print: Jaxpr, *,
                       custom_pp_eqn_rules : bool = True,
                       name_stack: bool = False,
                       print_effects: bool = False) -> pp.Doc:
-    context = JaxprPpContext()
+    context = JaxprPpContext(_dropvars(jaxpr_to_print))
     settings = JaxprPpSettings(
         source_info=source_info,
         print_shapes=print_shapes,
@@ -3980,24 +3988,20 @@ def _encode_digits_alphabetic(n: int) -> str:
     s = chr(97 + i % 26) + s
   return s
 
-# A JaxprPpContext allows us to globally uniquify variable names within nested
-# Jaxprs.
+# A JaxprPpContext allows globally unique variable names within nested Jaxprs.
 class JaxprPpContext:
   var_names: defaultdict[Var, str]
-  # Shared jaxprs are those that are used multiple times and are printed
-  # first.
+  # Shared jaxprs are those that are used multiple times and are printed first.
   shared_jaxprs: MutableMapping[Jaxpr, str]  # maps shared jaxpr to its name
   shared_jaxpr_names: MutableSet[str]
 
-  def __init__(self) -> None:
+  def __init__(self, var_names: dict | None = None) -> None:
     self.shared_jaxprs = {}
     self.shared_jaxpr_names = set()
     fresh_names: Iterator[str] = (
-        name
-        for i in it.count()
-        if (name := _encode_digits_alphabetic(i)) not in self.shared_jaxpr_names
-    )
-    self.var_names = defaultdict(fresh_names.__next__)
+        name for i in it.count()
+        if (name := _encode_digits_alphabetic(i)) not in self.shared_jaxpr_names)
+    self.var_names = defaultdict(fresh_names.__next__, var_names or {})
 
   def suggest_same_var_names(self,
                              for_vars: Sequence[Atom],

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1710,7 +1710,6 @@ class JaxprStackFrame:
     constvars, constvals = unzip2(self.constvar_to_val.copy().items())
     eqns = self.get_eqns()
     outvars = [t.val for t in out_tracers]
-    constvars, constvals = _drop_unused_vars(constvars, constvals, eqns, outvars)
     effs = make_jaxpr_effects(constvars, self.invars, outvars, eqns)
 
     # TODO(dougalm): handle qdd for consts
@@ -1759,22 +1758,6 @@ ForwardingRule = Callable[
     tuple[list[Union[int, None]], Union[JaxprEqn, None]]
 ]
 forwarding_rules: dict[Primitive, ForwardingRule] = {}
-
-
-def _drop_unused_vars(constvars, constvals, eqns, outvars
-                      ) -> tuple[tuple[Var, ...], tuple[Any, ...]]:
-  # modifies eqns in-place!
-  def vars(atom: Atom) -> list[Var]:
-    if isinstance(atom, Literal):
-      return []
-    return [atom]
-  used: set[Var] = {v for atom in outvars for v in vars(atom)}
-  for eqn in eqns[::-1]:
-    eqn.outvars = [v if v in used else DropVar(v.aval) for v in eqn.outvars]
-    used.update(v for atom in eqn.invars for v in vars(atom))
-  constvars, constvals = unzip2(
-      (v, val) for v, val in zip(constvars, constvals) if v in used)
-  return constvars, constvals
 
 
 @multi_weakref_lru_cache

--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -533,9 +533,8 @@ def _swap_pp_rule(eqn, context, settings) -> pp.Doc:
   transforms = tree_util.tree_unflatten(eqn.params["tree"], flat_idx)
   annotation = (source_info_util.summarize(eqn.source_info)
                 if settings.source_info else None)
-  if type(y) is core.DropVar:
-    # In the case of a set (ignored return value),
-    # pretty print `_ = swap x v i` as `x[i] <- v`
+  if context.var_names.get(y) == '_':
+    # In the case of a set (ignored return value), print as `x[i] <- v`
     del y
     return pp.concat([
         pp_ref_transforms(context, x, transforms),

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -561,41 +561,6 @@ class JaxprTypeChecks(jtu.JaxTestCase):
         r"for let-binder of type f32\[2,3\]\n\nin equation:\n\nb:f32\[2,3\] = sin\ a",
         lambda: core.check_jaxpr(jaxpr))
 
-  def test_jaxpr_dropvar_from_jit_call(self):
-    def inner(x):
-      return x + 1, x + 2
-
-    def f(x):
-      _, y = jit(inner)(x)
-      return y + 3
-
-    jaxpr = make_jaxpr(f)(1).jaxpr
-    assert isinstance(jaxpr.eqns[0].outvars[0], core.DropVar)
-    core.check_jaxpr(jaxpr)
-
-  def test_jaxpr_dropvar_from_loop(self):
-    def f(x):
-      _, y = lax.while_loop(lambda s: s[0] < 0.,
-                            lambda s: (jnp.sin(s[0]), jnp.cos(s[1])),
-                            (x, x))
-      return y + 1.
-
-    jaxpr = make_jaxpr(f)(1.).jaxpr
-    assert isinstance(jaxpr.eqns[0].outvars[0], core.DropVar)
-    core.check_jaxpr(jaxpr)
-
-  def test_jaxpr_dropvar_from_cond(self):
-    def f(x):
-      _, y = lax.cond(x < 0.,
-                      lambda x: (jnp.sin(x), x + 1.),
-                      lambda x: (jnp.cos(x), x + 2.),
-                      x)
-      return y
-
-    jaxpr = make_jaxpr(f)(1.).jaxpr
-    assert isinstance(jaxpr.eqns[-1].outvars[0], core.DropVar)
-    core.check_jaxpr(jaxpr)
-
 
 class JaxprPrettyPrintTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
The main motivation is saving a tiny bit of trace time. It also simplifies jaxprs. In a follow-up we should be able to delete `DropVar`, since we never actually create them now, except some out-of-tree code depends on the object existing (ugh).