### PR TITLE
 fix: cap _get_large_negative at float32 range to avoid -inf under debug_infs with float64 inputs

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -858,6 +858,11 @@ hard_swish = hard_silu
 
 def _get_large_negative(dtype):
   dtype_max = dtypes.finfo(dtype).max
+  # Softmax is always computed in float32 (see _dot_product_attention_core).
+  # Cap at float32 range so that the large negative value stays finite when
+  # cast to float32; otherwise float64 values would overflow to -inf and
+  # trigger FloatingPointError under jax.debug_infs(True).
+  dtype_max = min(dtype_max, dtypes.finfo(np.float32).max)
   return jnp.asarray(-0.7 * dtype_max, dtype=dtype)
 
 def _get_causal_mask(T, S):

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -335,6 +335,21 @@ class NNFunctionsTest(jtu.JaxTestCase):
     self.assertAllClose(dV_ref, dV_ans, rtol=.01, atol=.01)
     self.assertAllClose(dbias_ref, dbias_ans, rtol=.02, atol=.02)
 
+  def testDotProductAttentionFloat64MaskDebugInfs(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/37422
+    with jax.enable_x64():
+      T, S, K, N, H = 5, 7, 3, 6, 11
+      mask = jnp.arange(S) <= S // 2
+      with self.assertNoWarnings():
+        with jax.debug_infs(True):
+          out = nn.dot_product_attention(
+              jnp.zeros((T, N, H), dtype=jnp.float64),
+              jnp.zeros((S, K, H), dtype=jnp.float64),
+              jnp.zeros((S, K, H), dtype=jnp.float64),
+              mask=mask,
+          )
+          out.block_until_ready()
+
   @parameterized.product(
       batch_size=[1, 16],
       use_vmap=[False, True],


### PR DESCRIPTION
 Fixes #37422

  ## Root cause

  When inputs are `float64`, logits are promoted to `float64` and
  `_get_large_negative(float64)` returns ~`-1.26e308`. This is a valid
  float64 value but overflows to `-inf` when cast to `float32` for softmax
  (`padded_logits.astype(np.float32)` in `_dot_product_attention_core`).
  `jax.debug_infs(True)` fires on that intermediate `-inf` in the
  `convert_element_type` op, before softmax can normalize it away.

  ## Fix

  Cap `_get_large_negative` at `float32` max (~`3.4e38`). The resulting
  value `~-2.38e38` is still large enough that `exp(x) ≈ 0` after softmax,
  so masked positions correctly receive zero probability. It has no effect
  on float32/float16/bfloat16 inputs since their `dtype_max` is already
  within float32 range.

  ## Test

  Added `testDotProductAttentionFloat64MaskDebugInfs` which reproduces the
  exact shape/dtype from the issue and asserts no `FloatingPointError` is
  raised.