### PR TITLE
[ROCm] Move ROCm Bazel presubmit workflow to 32-bit mode.

### DIFF
--- a/.github/workflows/bazel_rocm_presubmit.yml
+++ b/.github/workflows/bazel_rocm_presubmit.yml
@@ -35,7 +35,7 @@ jobs:
           python: ["3.14"]
           runner: ["amd-do-linux.jax.gpu.gfx950.1"]
           jaxlib-version: ["head", "pypi_latest"]
-          enable-x64: [1]
+          enable-x64: [0]
           rocm-version: ["7"]
     name: "${{ matrix.runner && 'Test' }}"
 # End Presubmit Naming Check github-rocm-presubmits


### PR DESCRIPTION
## Summary
The ROCm Bazel presubmit workflow was originally using 64-bit mode. For now, it is being set to 32-bit mode for broader testing. Eventually, both will be enabled for full testing.

## Changes
The only change is to the ROCm Bazel presubmit workflow file (`.github/workflows/bazel_rocm_presubmit.yml`). `enable-x64` is now set to `0` instead of `1`.