### PR TITLE
add fast path _scatter_addsub_jvp when updates are Zero

### DIFF
--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -2754,6 +2754,8 @@ def _scatter_addsub_jvp(
       mode=mode)
   if type(g_operand) is ad_util.Zero and type(g_updates) is ad_util.Zero:
     tangent_out = ad_util.p2tz(val_out)
+  elif type(g_updates) is ad_util.Zero:
+    tangent_out = g_operand
   else:
     g_operand = ad.instantiate_zeros(g_operand)
     g_updates = ad.instantiate_zeros(g_updates)

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -1086,6 +1086,19 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     y = rng(update_shape, dtype)
     check_grads(scatter, (x, y), 2, ["fwd", "rev"], 1e-2, 1e-2, 1.)
 
+  def testScatterAddLinearizeEliminatesScatterAddWhenUpdatesConstant(self):
+    dnums = lax.ScatterDimensionNumbers(
+        update_window_dims=(), inserted_window_dims=(0,),
+        scatter_dims_to_operand_dims=(0,))
+    idxs = np.array([[1], [3]])
+    updates = np.array([10., 20.], dtype=np.float32)
+    f = lambda x: lax.scatter_add(x, idxs, updates, dnums)
+    x = np.arange(5, dtype=np.float32)
+    _, f_lin = jax.linearize(f, x)
+    jaxpr = jax.make_jaxpr(f_lin)(x)
+    prims = [eqn.primitive for eqn in jaxpr.jaxpr.eqns]
+    self.assertNotIn(lax.scatter_add_p, prims)
+
   def testScatterGradSymbolicZeroUpdate(self):
     # https://github.com/jax-ml/jax/issues/1901
     def f(x):


### PR DESCRIPTION
I was surprised that `scatter_add` is not eliminated from the jaxpr upon linearization when updates are constant whereas `add` does, maybe there's a good reason why this isn't implemented but if not here's a simple two-line fix (and guarding test) to address this.

Before this PR:
```python
  >>> jax.make_jaxpr(jax.linearize(lambda x: x + 5, jnp.ones(10))[1])(jnp.ones(10))
  { lambda ; a:f32[10]. let  in (a,) } # add disappears

  >>> jax.make_jaxpr(jax.linearize(lambda x: x.at[1].add(5), jnp.ones(10))[1])(jnp.ones(10))
  { lambda a:i32[1] b:f32[]; c:f32[10]. let
      d:f32[10] = scatter-add[
        dimension_numbers=ScatterDimensionNumbers(update_window_dims=(), inserted_window_dims=(0,), scatter_dims_to_operand_dims=(0,),
   operand_batching_dims=(), scatter_indices_batching_dims=())
        indices_are_sorted=True
        mode=GatherScatterMode.FILL_OR_DROP
        unique_indices=True
        update_consts=()
        update_jaxpr={ lambda ; e:f32[] f:f32[]. let g:f32[] = add e f in (g,) }
      ] c a b
    in (d,) }
```

After this PR:
```python
  >>> jax.make_jaxpr(jax.linearize(lambda x: x.at[1].add(5), jnp.ones(10))[1])(jnp.ones(10))
  { lambda ; a:f32[10]. let  in (a,) } # scatter_add disappears
```