### PR TITLE
[ROCm] Add org-based guards to all CI caller workflows

### DIFF
--- a/.github/workflows/bazel_cpu_presubmit.yml
+++ b/.github/workflows/bazel_cpu_presubmit.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   build-jax-artifact:
+    if: github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/build_artifacts.yml
     name: "Build jax artifact"
     with:
@@ -36,6 +37,7 @@ jobs:
         upload_artifacts_to_gcs: false
 
   build-jaxlib-artifact:
+    if: github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/build_artifacts.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -56,7 +58,7 @@ jobs:
         upload_artifacts_to_gcs: false
 
   run_tests:
-    if: github.event.repository.fork == false
+    if: github.event.repository.fork == false && github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/bazel_cpu.yml
 # Begin Presubmit Naming Check - name modification requires internal check to be updated
     strategy:

--- a/.github/workflows/bazel_cuda_b200_mosaic_presubmit.yml
+++ b/.github/workflows/bazel_cuda_b200_mosaic_presubmit.yml
@@ -63,7 +63,7 @@ jobs:
   # at all if no matching files were touched.
   # This would lead to Copybara waiting for the status indefinitely.
   changed_files:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.repository_owner == 'jax-ml' && github.event_name == 'pull_request' }}
     runs-on: linux-x86-n4-16
     container: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest
     steps:
@@ -130,6 +130,7 @@ jobs:
     if: >-
       ${{
           !cancelled()
+          && github.repository_owner == 'jax-ml'
           && (
                github.event_name == 'workflow_dispatch'
                || needs.changed_files.outputs.any_changed == 'true'

--- a/.github/workflows/bazel_cuda_h100_b200.yml
+++ b/.github/workflows/bazel_cuda_h100_b200.yml
@@ -66,7 +66,8 @@ jobs:
   run_tests:
     if: >-
       ${{
-          github.event.repository.fork == false
+          github.repository_owner == 'jax-ml'
+          && github.event.repository.fork == false
           && (github.event_name == 'schedule'
               || github.event_name == 'workflow_dispatch'
               || contains(github.event.pull_request.labels.*.name,
@@ -111,8 +112,9 @@ jobs:
   run_multiaccelerator_tests:
     if: >-
       ${{
-          github.event.repository.fork == false &&
-          (
+          github.repository_owner == 'jax-ml'
+          && github.event.repository.fork == false
+          && (
               github.event_name == 'schedule'
               || github.event_name == 'workflow_dispatch'
               || contains(github.event.pull_request.labels.*.name,

--- a/.github/workflows/bazel_cuda_presubmit.yml
+++ b/.github/workflows/bazel_cuda_presubmit.yml
@@ -26,6 +26,7 @@ concurrency:
 permissions: {}
 jobs:
   build-cuda-artifacts:
+    if: github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/build_artifacts.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -45,7 +46,7 @@ jobs:
       upload_artifacts_to_gcs: false
 
   run-tests:
-    if: github.event.repository.fork == false
+    if: github.event.repository.fork == false && github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/bazel_cuda.yml
 # Begin Presubmit Naming Check - name modification requires internal check to be updated
     strategy:

--- a/.github/workflows/bazel_nobuild.yml
+++ b/.github/workflows/bazel_nobuild.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   bazel-dependency-violations:
+    if: github.repository_owner == 'jax-ml'
     # Begin Presubmit Naming Check - name modification requires internal check to be updated
     name: Bazel dependency violations
     # End Presubmit Naming Check github-bazel-nobuild

--- a/.github/workflows/bazel_rocm_presubmit.yml
+++ b/.github/workflows/bazel_rocm_presubmit.yml
@@ -26,7 +26,7 @@ concurrency:
 permissions: {}
 jobs:
   run-tests:
-    if: github.event.repository.fork == false
+    if: github.event.repository.fork == false && (github.repository_owner == 'jax-ml' || github.repository_owner == 'ROCm')
     uses: ./.github/workflows/bazel_rocm.yml
 # Begin Presubmit Naming Check - name modification requires internal check to be updated
     strategy:

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -171,6 +171,7 @@ jobs:
 
 
   documentation_render:
+    if: github.repository_owner == 'jax-ml'
     name: Documentation - render documentation
     runs-on: linux-x86-n4-16
     container:
@@ -215,6 +216,7 @@ jobs:
         PORTSERVER_ADDRESS=@unittest-portserver $PYTHON_BIN -m sphinx -j auto --color -W --keep-going -b html docs docs/build/html
 
   ffi:
+    if: github.repository_owner == 'jax-ml'
     name: FFI example
     runs-on: linux-x86-g2-16-l4-1gpu
     container:

--- a/.github/workflows/cloud-tpu-ci-nightly.yml
+++ b/.github/workflows/cloud-tpu-ci-nightly.yml
@@ -28,6 +28,7 @@ env:
 
 jobs:
   cloud-tpu-test:
+    if: github.repository_owner == 'jax-ml'
     strategy:
       fail-fast: false # don't cancel all jobs on failure
       matrix:

--- a/.github/workflows/cloud-tpu-ci-presubmit.yml
+++ b/.github/workflows/cloud-tpu-ci-presubmit.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   run-bazel-test-tpu:
-    if: github.event.repository.fork == false
+    if: github.event.repository.fork == false && github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/bazel_test_tpu.yml
     # Begin Presubmit Naming Check - name modification requires internal check to be updated
     name: "TPU test (jaxlib=head)"

--- a/.github/workflows/jax-array-api.yml
+++ b/.github/workflows/jax-array-api.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   build:
+    if: github.repository_owner == 'jax-ml'
     runs-on: linux-x86-n4-16
     container: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest
     strategy:

--- a/.github/workflows/numpy_nightly.yml
+++ b/.github/workflows/numpy_nightly.yml
@@ -29,6 +29,7 @@ env:
 
 jobs:
   test-nightly-numpy:
+    if: github.repository_owner == 'jax-ml'
     defaults:
       run:
         shell: bash

--- a/.github/workflows/oldest_supported_numpy.yml
+++ b/.github/workflows/oldest_supported_numpy.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   test-oldest-supported-numpy:
-    if: ${{ github.event.repository.fork == false && !startsWith(github.head_ref, 'release/') }}
+    if: ${{ github.repository_owner == 'jax-ml' && github.event.repository.fork == false && !startsWith(github.head_ref, 'release/') }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   build-jax-in-docker:
+    if: github.repository_owner == 'jax-ml' || github.repository_owner == 'ROCm'
     runs-on: linux-x86_64-cirrascale-64-8gpu-amd-mi250
     env:
       BASE_IMAGE: "ubuntu:22.04"

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   tsan:
+    if: github.repository_owner == 'jax-ml'
     runs-on: linux-x86-n4-64
     container:
       image: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build@sha256:ea67e8453d8b09c2ba48853da5e79efef4b65804b4a48dfae4b4da89ffd38405 # ml-build container (based on Ubuntu 22.04)

--- a/.github/workflows/upload_metadata.yml
+++ b/.github/workflows/upload_metadata.yml
@@ -34,6 +34,7 @@ permissions:
 
 jobs:
   upload:
+    if: github.repository_owner == 'jax-ml'
     name: "Upload Workflow Metadata"
     runs-on: linux-x86-n4-16
     container: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest

--- a/.github/workflows/upstream-nightly.yml
+++ b/.github/workflows/upstream-nightly.yml
@@ -27,6 +27,7 @@ env:
 
 jobs:
   upstream-dev:
+    if: github.repository_owner == 'jax-ml'
     runs-on: linux-x86-n4-64
     container: index.docker.io/library/ubuntu@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b # ratchet:ubuntu:24.04
     permissions:

--- a/.github/workflows/verify-squash.yml
+++ b/.github/workflows/verify-squash.yml
@@ -9,6 +9,7 @@ permissions: {}
 
 jobs:
   verify-squash:
+    if: github.repository_owner == 'jax-ml'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -44,6 +44,7 @@ concurrency:
 
 jobs:
   build-jax-artifact:
+    if: github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/build_artifacts.yml
     name: "Build jax artifact"
     with:
@@ -55,6 +56,7 @@ jobs:
         gcs_upload_uri: 'gs://general-ml-ci-transient/jax-github-actions/jax/${{ github.workflow }}/${{ github.run_number }}/${{ github.run_attempt }}'
 
   build-jaxlib-artifact:
+    if: github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/build_artifacts.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -76,6 +78,7 @@ jobs:
         gcs_upload_uri: 'gs://general-ml-ci-transient/jax-github-actions/jax/${{ github.workflow }}/${{ github.run_number }}/${{ github.run_attempt }}'
 
   build-cuda-artifacts:
+    if: github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/build_artifacts.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -96,10 +99,7 @@ jobs:
       gcs_upload_uri: 'gs://general-ml-ci-transient/jax-github-actions/jax/${{ github.workflow }}/${{ github.run_number }}/${{ github.run_attempt }}'
 
   run-pytest-cpu:
-    # Run test jobs even if the build job fails. Avoids losing test coverage if a single unrelated
-    # build job fails. E.g Windows build job fails but everything else succeeds. In this case, we
-    # still want to run the tests for other platforms.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && github.repository_owner == 'jax-ml' }}
     needs: [build-jax-artifact, build-jaxlib-artifact]
     uses: ./.github/workflows/pytest_cpu.yml
     strategy:
@@ -118,10 +118,7 @@ jobs:
       gcs_download_uri: ${{ needs.build-jaxlib-artifact.outputs.gcs_upload_uri }}
 
   run-pytest-cuda:
-    # Run test jobs even if the build job fails. Avoids losing test coverage if a single unrelated
-    # build job fails. E.g Windows build job fails but everything else succeeds. In this case, we
-    # still want to run the tests for other platforms.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && github.repository_owner == 'jax-ml' }}
     needs: [build-jax-artifact, build-jaxlib-artifact, build-cuda-artifacts]
     uses: ./.github/workflows/pytest_cuda.yml
     strategy:
@@ -162,6 +159,7 @@ jobs:
       gcs_download_uri: ${{ needs.build-jaxlib-artifact.outputs.gcs_upload_uri }}
 
   run-bazel-test-cpu-py-import:
+    if: github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/bazel_cpu.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -179,10 +177,7 @@ jobs:
       clone_main_xla: 1
 
   run-bazel-test-cuda:
-    # Run test jobs even if the build job fails. Avoids losing test coverage if a single unrelated
-    # build job fails. E.g Windows build job fails but everything else succeeds. In this case, we
-    # still want to run the tests for other platforms.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && github.repository_owner == 'jax-ml' }}
     needs: [build-jax-artifact, build-jaxlib-artifact, build-cuda-artifacts]
     uses: ./.github/workflows/bazel_cuda.yml
     strategy:
@@ -211,10 +206,7 @@ jobs:
       clone_main_xla: 1
 
   run-bazel-test-cuda-py-import:
-    # Run test jobs even if the build job fails. Avoids losing test coverage if a single unrelated
-    # build job fails. E.g Windows build job fails but everything else succeeds. In this case, we
-    # still want to run the tests for other platforms.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && github.repository_owner == 'jax-ml' }}
     uses: ./.github/workflows/bazel_cuda.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -239,10 +231,7 @@ jobs:
       clone_main_xla: 1
 
   run-pytest-tpu:
-    # Run test jobs even if the build job fails. Avoids losing test coverage if a single unrelated
-    # build job fails. E.g Windows build job fails but everything else succeeds. In this case, we
-    # still want to run the tests for other platforms.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && github.repository_owner == 'jax-ml' }}
     needs: [build-jax-artifact, build-jaxlib-artifact]
     uses: ./.github/workflows/pytest_tpu.yml
     strategy:
@@ -267,10 +256,7 @@ jobs:
       gcs_download_uri: ${{ needs.build-jaxlib-artifact.outputs.gcs_upload_uri }}
 
   run-bazel-test-tpu:
-    # Run test jobs even if the build job fails. Avoids losing test coverage if a single unrelated
-    # build job fails. E.g Windows build job fails but everything else succeeds. In this case, we
-    # still want to run the tests for other platforms.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && github.repository_owner == 'jax-ml' }}
     uses: ./.github/workflows/bazel_test_tpu.yml
     needs: [build-jaxlib-artifact]
     strategy:
@@ -297,6 +283,7 @@ jobs:
       clone_main_xla: 1
 
   build-rocm-artifacts:
+    if: github.repository_owner == 'jax-ml' || github.repository_owner == 'ROCm'
     uses: ./.github/workflows/build_rocm_artifacts.yml
     permissions:
       id-token: write
@@ -327,7 +314,7 @@ jobs:
       s3_upload_uri: 's3://jax-ci-amd/rocm-wheels/wheel-tests-continuous/${{ github.run_number }}/${{ github.run_attempt }}'
 
   run-pytest-rocm:
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && (github.repository_owner == 'jax-ml' || github.repository_owner == 'ROCm') }}
     needs: [build-jax-artifact, build-jaxlib-artifact, build-rocm-artifacts]
     uses: ./.github/workflows/pytest_rocm.yml
     permissions:
@@ -353,7 +340,7 @@ jobs:
       s3_download_uri: 's3://jax-ci-amd/rocm-wheels/wheel-tests-continuous/${{ github.run_number }}/${{ github.run_attempt }}'
 
   run-bazel-test-rocm:
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && (github.repository_owner == 'jax-ml' || github.repository_owner == 'ROCm') }}
     needs: [build-jax-artifact, build-jaxlib-artifact, build-rocm-artifacts]
     uses: ./.github/workflows/bazel_rocm.yml
     permissions:

--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -48,6 +48,7 @@ env:
 
 jobs:
   run-pytest-cpu:
+    if: github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/pytest_cpu.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -75,6 +76,7 @@ jobs:
       max-processes: ${{ contains(matrix.runner, 'windows-x86') && '16' || '' }}
 
   run-bazel-test-cpu:
+    if: github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/bazel_cpu.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -96,6 +98,7 @@ jobs:
       clone_main_xla: 0
 
   run-pytest-cuda:
+    if: github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/pytest_cuda.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -147,6 +150,7 @@ jobs:
       halt-for-connection: ${{inputs.halt-for-connection}}
 
   run-bazel-test-cuda:
+    if: github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/bazel_cuda.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -227,6 +231,7 @@ jobs:
       clone_main_xla: 0
 
   run-pytest-tpu:
+    if: github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/pytest_tpu.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -291,6 +296,7 @@ jobs:
       halt-for-connection: ${{inputs.halt-for-connection}}
 
   run-bazel-test-tpu:
+    if: github.repository_owner == 'jax-ml'
     uses: ./.github/workflows/bazel_test_tpu.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure
@@ -365,7 +371,7 @@ jobs:
       clone_main_xla: 0
 
   verify-release-wheels-install:
-    if: ${{ startsWith(github.ref_name, 'release/')}}
+    if: ${{ startsWith(github.ref_name, 'release/') && github.repository_owner == 'jax-ml' }}
     defaults:
       run:
         # Set the shell to bash as GitHub actions runs with /bin/sh by default


### PR DESCRIPTION
## Summary

Add `github.repository_owner` guards to every caller workflow job so that CI only runs for organizations that have the required infrastructure. This prevents forks from queueing jobs on runners or accessing secrets they don't have.

**Two guard patterns are applied consistently:**

- **Non-ROCm jobs**: `if: github.repository_owner == 'jax-ml'` — gates access to Google Cloud runners, GCS, GCR containers, and TPU infrastructure.
- **ROCm jobs**: `if: github.repository_owner == 'jax-ml' || github.repository_owner == 'ROCm'` — allows the ROCm org to run AMD GPU CI on its fork while still gating Google-specific infrastructure.

Jobs that already have `if:` conditions (e.g., `!cancelled()`, `github.event.repository.fork == false`) get the owner check prepended with `&&` to preserve existing behavior.

## Affected workflows (19 files)

<details>
<summary><strong>16 files from existing experimental work</strong></summary>

| Workflow | Jobs gated | Pattern |
|---|---|---|
| `wheel_tests_continuous.yml` | 13 jobs | 10 jax-ml, 3 ROCm dual-org |
| `wheel_tests_nightly_release.yml` | 10 jobs | 7 jax-ml, 3 ROCm dual-org |
| `bazel_cpu_presubmit.yml` | 3 jobs | jax-ml |
| `bazel_cuda_presubmit.yml` | 2 jobs | jax-ml |
| `bazel_cuda_b200_mosaic_presubmit.yml` | 2 jobs | jax-ml |
| `bazel_cuda_h100_b200.yml` | 2 jobs | jax-ml |
| `bazel_nobuild.yml` | 1 job | jax-ml |
| `bazel_rocm_presubmit.yml` | 1 job | ROCm dual-org |
| `cloud-tpu-ci-nightly.yml` | 1 job | jax-ml |
| `cloud-tpu-ci-presubmit.yml` | 1 job | jax-ml |
| `jax-array-api.yml` | 1 job | jax-ml |
| `numpy_nightly.yml` | 1 job | jax-ml |
| `oldest_supported_numpy.yml` | 1 job | jax-ml |
| `rocm-ci.yml` | 1 job | ROCm dual-org |
| `upstream-nightly.yml` | 1 job | jax-ml |
| `verify-squash.yml` | 1 job | jax-ml |

</details>

**3 newly identified files (not in the experimental branch):**

| Workflow | Jobs gated | Reason |
|---|---|---|
| `ci-build.yaml` | `documentation_render`, `ffi` | Self-hosted Google runners (`linux-x86-n4-16`, `linux-x86-g2-16-l4-1gpu`) |
| `tsan.yaml` | `tsan` | Self-hosted runner + `us-docker.pkg.dev/` container |
| `upload_metadata.yml` | `upload` | Self-hosted runner + GCS upload + `us-docker.pkg.dev/` container |

<details>
<summary><strong>Already guarded (no changes needed)</strong></summary>

- `asan.yaml` — already uses `github.repository == 'jax-ml/jax'`
- `community_release_actions.yml` — already uses `github.repository_owner == 'jax-ml'`
- `ci-build.yaml` / `build` job — already uses `github.repository == 'jax-ml/jax'`

</details>

<details>
<summary><strong>No guard needed</strong></summary>

- `k8s.yaml`, `release-notification.yml` — runs on `ubuntu-latest`, no secrets or special infra
- `ci-build.yaml` / `lint_and_typecheck`, `zizmor`, `documentation` — runs on `ubuntu-latest`
- All reusable workflows (`bazel_cpu.yml`, `pytest_cuda.yml`, etc.) — gating is the caller's responsibility

</details>

## Design decisions open for discussion

1. **`repository_owner` vs `repository`**: Using `repository_owner` allows org-level matching rather than exact repo names, which is more flexible for org-managed forks.

2. **Preserving `fork == false`**: Some jobs already guard with `github.event.repository.fork == false`. The owner check is strictly stronger, but we preserve the existing fork check for backward compatibility.

3. **`!cancelled()` pattern**: Test jobs in `wheel_tests_continuous.yml` use `!cancelled()` so they run even if an unrelated build job fails. The org guard is combined as `!cancelled() && github.repository_owner == 'jax-ml'` to preserve that semantics within the org.

4. **`verify-squash.yml`**: This uses `ubuntu-latest` and technically doesn't need gating, but is included for consistency. Open to removing it if preferred.

## Test plan

- [ ] Verify CI passes on `jax-ml/jax` (all jobs should run as before)
- [ ] Verify on a fork outside `jax-ml`/`ROCm` orgs that all jobs are skipped
- [ ] Verify on `ROCm/jax` fork that only ROCm-gated jobs run