### PR TITLE
Preserve disabled HLO passes when disabling remat

### DIFF
--- a/jax/_src/compiler.py
+++ b/jax/_src/compiler.py
@@ -100,6 +100,15 @@ def get_latest_profile_version(backend: xc.Client) -> int:
   return -1
 
 
+def _append_disabled_hlo_passes(
+    disabled_passes: str, pass_name: str
+) -> str:
+  passes = [p.strip() for p in disabled_passes.split(",") if p.strip()]
+  if pass_name not in passes:
+    passes.append(pass_name)
+  return ",".join(passes)
+
+
 def _walk_operations(op, k):
   k -= 1
   if k < 0:
@@ -228,7 +237,8 @@ def get_compile_options(
     debug_options.xla_test_all_input_layouts = False
 
   if not config.enable_remat_opt_pass.value:
-    debug_options.xla_disable_hlo_passes = "rematerialization"
+    debug_options.xla_disable_hlo_passes = _append_disabled_hlo_passes(
+        debug_options.xla_disable_hlo_passes, "rematerialization")
 
   # XLA-AutoFDO profile version: precedence order is:
   # 1. Whatever --jax_xla_profile_version is set to.

--- a/tests/xla_bridge_test.py
+++ b/tests/xla_bridge_test.py
@@ -113,6 +113,34 @@ class XlaBridgeTest(jtu.JaxTestCase):
     # Map order does not matter.
     self.assertEqual(c1str, c2.SerializeAsString())
 
+  def test_disable_hlo_passes_preserves_existing_and_dedupes(self):
+    self.assertEqual(
+        compiler._append_disabled_hlo_passes("", "rematerialization"),
+        "rematerialization",
+    )
+    self.assertEqual(
+        compiler._append_disabled_hlo_passes(
+            "scalar-constant-sinker", "rematerialization"
+        ),
+        "scalar-constant-sinker,rematerialization",
+    )
+    self.assertEqual(
+        compiler._append_disabled_hlo_passes(
+            "scalar-constant-sinker, rematerialization", "rematerialization"
+        ),
+        "scalar-constant-sinker,rematerialization",
+    )
+
+    with config.enable_remat_opt_pass(False):
+      compile_options = compiler.get_compile_options(
+          num_replicas=1, num_partitions=1
+      )
+      passes = (
+          compile_options.executable_build_options.debug_options
+          .xla_disable_hlo_passes
+      )
+      self.assertIn("rematerialization", passes.split(","))
+
   def test_local_devices(self):
     self.assertNotEmpty(xb.local_devices())
     with self.assertRaisesRegex(ValueError, "Unknown process_index 100"):


### PR DESCRIPTION
Fixes #37391.

`get_compile_options` previously replaced `xla_disable_hlo_passes` with
`rematerialization` when `jax_compiler_enable_remat_pass=False`, which dropped
any passes already disabled through `XLA_FLAGS`.

This preserves the existing disabled pass list and appends `rematerialization`
only when it is not already present.

Tested:
- `uv run --with pytest --with absl-py --with 'jaxlib>=0.10.0' --with 'ml_dtypes>=0.5.0' --with 'numpy>=2.0' --with opt_einsum --with 'scipy>=1.14' -m pytest -q tests/xla_bridge_test.py`