### PR TITLE
test: regression test for numpy const crash in .trace().lower() (#37445)

### DIFF
--- a/tests/aot_test.py
+++ b/tests/aot_test.py
@@ -188,6 +188,22 @@ class JaxAotTest(jtu.JaxTestCase):
     self.assertLen(compiled._params.const_args, 1)
     self.assertIs(compiled._params.const_args[0], const2)
 
+  @jtu.skip_on_flag("jax_use_simplified_jaxpr_constants", False)
+  def test_numpy_const_trace_then_lower(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/37445
+    # Closing over a numpy array and calling .trace().lower() used to crash with
+    # AttributeError because const_args were passed to _resolve_in_shardings
+    # without first being converted to MetaTy via convert_to_metaty.
+    np_constant = np.array([2])
+
+    def f():
+      return jnp.sum(np_constant)
+
+    traced = jax.jit(f).trace()
+    lowered = traced.lower()
+    result = lowered.compile()()
+    self.assertArraysEqual(result, np.array(2))
+
   def test_with_constants_and_dce(self):
     const = jnp.arange(16.) + 42.  # A distinctive shape and value
 


### PR DESCRIPTION
## Summary

Closes #37445

The bug itself was fixed in 2d04b243 ("[consts] Use MetaTy for the pjit constant args"), which added `convert_to_metaty` wrapping in `const_args_shardings` and `const_args_layouts` so that raw numpy arrays are no longer passed directly to `_resolve_in_shardings`.

This PR adds a regression test to prevent future regressions.

**Root cause (for reference):** When `JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS=True`, closing over a numpy array constant and calling `jax.jit(f).trace().lower()` crashed with:
```
AttributeError: 'TypedNdArray' object has no attribute 'sharding'
```
because `const_args_shardings` passed raw numpy arrays to `_resolve_in_shardings` which expected objects with a `.sharding` attribute (i.e. `MetaTy` or `jax.Array`).

## Test plan
- [x] `python -m pytest tests/aot_test.py::JaxAotTest::test_numpy_const_trace_then_lower -x` with `JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS=True`