### PR TITLE
[pallas] Fix jax.jvp through kernels that call program_id / num_programs

### DIFF
--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -276,7 +276,8 @@ def _pallas_call_jvp_rule(
   tangents = [t for t in tangents if type(t) is not ad_util.Zero]
   nonzero_tangents_with_outputs = nonzero_tangents + [True] * grid_mapping.num_outputs
   closed_jaxpr = jax_core.ClosedJaxpr(jaxpr, ())
-  jvp_jaxpr_, _ = ad.jvp_jaxpr(closed_jaxpr, nonzero_tangents_with_outputs, [])
+  with grid_mapping.trace_env():
+    jvp_jaxpr_, _ = ad.jvp_jaxpr(closed_jaxpr, nonzero_tangents_with_outputs, [])
   jvp_jaxpr, () = jvp_jaxpr_.jaxpr, jvp_jaxpr_.consts  # TODO consts
   # `pallas_call` takes in inputs and returns outputs but its jaxpr *does not*.
   # `pallas_call` takes in a stateful jaxpr, meaning the jaxpr accepts input


### PR DESCRIPTION
`jax.jvp` through any `pallas_call` whose kernel uses `program_id` or `num_programs` currently fails with `AssertionError` deep inside `pallas_core.axis_frame()`.

Repro (works on current branch but fails on main):
```python
import jax
import jax.experimental.pallas as pl
import jax.experimental.pallas.triton as pltriton
import jax.numpy as jnp


def kernel(x_ref, y_ref):
    y_ref[...] = x_ref[...] + pl.program_id(0)


def jax_fn(x):
    spec = pl.BlockSpec((None,) * x.ndim, lambda *a: a)
    return pl.pallas_call(
        kernel,
        out_shape=x,
        grid=x.shape,
        in_specs=[spec],
        out_specs=spec,
        compiler_params=pltriton.CompilerParams(),
    )(x)


x = jnp.arange(5.0)
y, dy = jax.jvp(jax_fn, (x,), (jnp.ones_like(x),))
print(dy)
```

Root cause: `_pallas_call_jvp_rule` retraces the kernel jaxpr via `ad.jvp_jaxpr` to produce the tangent-augmented kernel. During that retrace, `program_id` / `num_programs` query `pallas_core.axis_frame()` to validate the axis index, but the grid context isn't set up — so `axis_frame()` asserts.

Fix: wrap the `ad.jvp_jaxpr` call in `grid_mapping.trace_env()`. This is the same pattern already used at every other site in `pallas_call.py` that retraces the kernel jaxpr (`_trace_kernel_to_jaxpr`, the checkify rules, the state-discharge rule, etc.); the JVP rule was the one missing it.