### PR TITLE
Handle TypedNdArray closed-over constants in _resolve_in_shardings

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1064,8 +1064,14 @@ def _resolve_in_shardings(args, pjit_in_shardings: Sequence[PjitSharding]
   for arg, pjit_in_s in zip(args, pjit_in_shardings):
     # arg sharding can be None in case of ShapeDtypeStruct. jax.Array does
     # not allow None as the sharding.
-    arg_s, committed = ((arg.sharding, arg.committed) if arg.sharding is not None
-                        else (UNSPECIFIED, False))
+    if not hasattr(arg, 'sharding'):
+      arg_s, committed = UNSPECIFIED, False
+    else:
+      arg_s, committed = (
+          (arg.sharding, arg.committed)
+          if arg.sharding is not None
+          else (UNSPECIFIED, False))
+      
     if isinstance(arg_s, NamedSharding) and arg_s.mesh.empty:
       arg_s, committed = UNSPECIFIED, False
     if isinstance(pjit_in_s, UnspecifiedValue):

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -3788,12 +3788,13 @@ class ArrayPjitTest(jtu.JaxTestCase):
       self.assertEmpty(jaxpr.consts)
       self.assertIs(const, inner_pjit_jaxpr.consts[0])
 
-    def test_typed_ndarray_closed_over_constant_lowering(self):
-      if not config.use_simplified_jaxpr_constants.value:
-        self.skipTest('Requires use_simplified_jaxpr_constants=True')
+  def test_typed_ndarray_closed_over_constant_lowering(self):
+    if not config.use_simplified_jaxpr_constants.value:
+      self.skipTest('Requires use_simplified_jaxpr_constants=True')
 
-        const = literals.TypedNdArray(
+    const = literals.TypedNdArray(
         np.array([2]), weak_type=False)
+
     @jax.jit
     def f():
       return jnp.sum(const)

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -3788,6 +3788,19 @@ class ArrayPjitTest(jtu.JaxTestCase):
       self.assertEmpty(jaxpr.consts)
       self.assertIs(const, inner_pjit_jaxpr.consts[0])
 
+    def test_typed_ndarray_closed_over_constant_lowering(self):
+      if not config.use_simplified_jaxpr_constants.value:
+        self.skipTest('Requires use_simplified_jaxpr_constants=True')
+
+        const = literals.TypedNdArray(
+        np.array([2]), weak_type=False)
+    @jax.jit
+    def f():
+      return jnp.sum(const)
+
+    traced = f.trace()
+    traced.lower()
+    
   def test_lowering_cache_hit_with_closed_over_constants_jit(self):
     np_inp = np.arange(8)
     arr = jnp.arange(8)


### PR DESCRIPTION
Fixes an AttributeError when lowering a jitted function with
JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS=True and a NumPy closed-over constant.

TypedNdArray instances do not expose a .sharding attribute, but
_resolve_in_shardings() accessed it unconditionally.

This change adds a defensive hasattr(..., "sharding") check, matching
existing patterns already used elsewhere in pjit.py.

Test

Adds a regression test covering lowering of a jitted function with a
closed-over TypedNdArray constant under simplified jaxpr constants.