### PR TITLE
[docs] Fix doc build

### DIFF
--- a/docs/export/export.md
+++ b/docs/export/export.md
@@ -66,10 +66,8 @@ Serialization is broken down into two stages:
      an alternative serialization to TensorFlow graph that can be used
      for interoperation with TensorFlow.
 
-:::{warning}
-The serialized bytearray must be trusted input. If you deserialized it, when
-you execute it, it may execute any custom call registered in the jaxlib.
-:::
+**WARNING**: The serialized bytearray must be trusted input. If you execute it
+after deserialization, it may execute any custom call registered in the jaxlib.
 
 ## Support for reverse-mode AD
 


### PR DESCRIPTION
Remove the warning markup in export.md, because it requires pandoc.
