### PR TITLE
Add jax.scipy.special.boxcox and boxcox1p

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     matrices ({jax-issue}`#10144`).
   * Added {func}`jax.scipy.linalg.helmert` for constructing Helmert matrices
     ({jax-issue}`#10144`).
+  * Added {func}`jax.scipy.special.boxcox` and
+    {func}`jax.scipy.special.boxcox1p` for the Box-Cox power transformation.
   * Moved RNG APIs from "implementations" to dtypes ({jax-issue}`#27854`):
     * Added `jax.random.key_dtype` to get the dtype corresponding to a PRNG
       implementation name.

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -169,6 +169,8 @@ jax.scipy.special
    beta
    betainc
    betaln
+   boxcox
+   boxcox1p
    comb
    dawsn
    digamma

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -1042,6 +1042,70 @@ def entr(x: ArrayLike) -> Array:
                     lax.neg(_xlogx(x)))
 
 
+def boxcox(x: ArrayLike, lmbda: ArrayLike) -> Array:
+  r"""Box-Cox power transformation.
+
+  JAX implementation of :obj:`scipy.special.boxcox`.
+
+  .. math::
+
+     \mathrm{boxcox}(x, \lambda) = \begin{cases}
+       (x^\lambda - 1) / \lambda & \lambda \ne 0 \\
+       \log(x) & \lambda = 0
+     \end{cases}
+
+  Defined for :math:`x > 0`; returns ``nan`` for non-positive ``x``.
+
+  Args:
+    x: arraylike, positive real-valued.
+    lmbda: arraylike, real-valued.
+
+  Returns:
+    array containing Box-Cox transformed values.
+
+  See also:
+    :func:`jax.scipy.special.boxcox1p`
+  """
+  x, lmbda = promote_args_inexact("boxcox", x, lmbda)
+  lmbda_is_zero = lmbda == 0
+  safe_lmbda = jnp.where(lmbda_is_zero, jnp.ones_like(lmbda), lmbda)
+  log_x = jnp.log(x)
+  power_branch = jnp.expm1(safe_lmbda * log_x) / safe_lmbda
+  return jnp.where(lmbda_is_zero, log_x, power_branch)
+
+
+def boxcox1p(x: ArrayLike, lmbda: ArrayLike) -> Array:
+  r"""Box-Cox transformation of ``1 + x``.
+
+  JAX implementation of :obj:`scipy.special.boxcox1p`.
+
+  .. math::
+
+     \mathrm{boxcox1p}(x, \lambda) = \begin{cases}
+       ((1 + x)^\lambda - 1) / \lambda & \lambda \ne 0 \\
+       \log(1 + x) & \lambda = 0
+     \end{cases}
+
+  Defined for :math:`x > -1`; returns ``nan`` for ``x <= -1``.
+
+  Args:
+    x: arraylike, real-valued, greater than ``-1``.
+    lmbda: arraylike, real-valued.
+
+  Returns:
+    array containing values of the shifted Box-Cox transform.
+
+  See also:
+    :func:`jax.scipy.special.boxcox`
+  """
+  x, lmbda = promote_args_inexact("boxcox1p", x, lmbda)
+  lmbda_is_zero = lmbda == 0
+  safe_lmbda = jnp.where(lmbda_is_zero, jnp.ones_like(lmbda), lmbda)
+  log1p_x = jnp.log1p(x)
+  power_branch = jnp.expm1(safe_lmbda * log1p_x) / safe_lmbda
+  return jnp.where(lmbda_is_zero, log1p_x, power_branch)
+
+
 def multigammaln(a: ArrayLike, d: ArrayLike) -> Array:
   r"""The natural log of the multivariate gamma function.
 

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -21,6 +21,8 @@ from jax._src.scipy.special import (
   beta as beta,
   betainc as betainc,
   betaln as betaln,
+  boxcox as boxcox,
+  boxcox1p as boxcox1p,
   comb as comb,
   dawsn as dawsn,
   digamma as digamma,

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -64,6 +64,13 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
         "betainc", 3, float_dtypes, jtu.rand_positive, False
     ),
     op_record(
+        "boxcox", 2, float_dtypes, jtu.rand_positive, True
+    ),
+    op_record(
+        "boxcox1p", 2, float_dtypes,
+        functools.partial(jtu.rand_uniform, low=-0.5, high=5.0), True
+    ),
+    op_record(
         "gamma", 1, float_dtypes, jtu.rand_default, True
     ),
     op_record(


### PR DESCRIPTION
Adds `jax.scipy.special.boxcox` and `jax.scipy.special.boxcox1p`. Both are common in stats / regression and neither has a JAX equivalent today.

The only subtlety is the `lmbda = 0` limit. Using the naive `(x**lmbda - 1) / lmbda` form catastrophically cancels as `lmbda * log(x) -> 0`, which is exactly the regime a Box-Cox sweep crosses. I went with the `expm1` rewrite instead:

```python
power_branch = jnp.expm1(safe_lmbda * jnp.log(x)) / safe_lmbda
```

ULP-level accurate through the limit; SciPy parity drops from `~1e-3` to `~1e-9` near `lmbda = 0`. The `lmbda == 0` arm still routes to plain `log` / `log1p` for the exact limit. `boxcox1p` gets the same treatment with `log1p` on the inner expression, which also kills the `1 + x` precision loss for tiny `x`.

### Tests

Both names registered in `JAX_SPECIAL_FUNCTION_RECORDS` with `test_autodiff=True`, so they pick up the existing parity-vs-SciPy sweep, jit check, and `check_grads`. `boxcox` uses `jtu.rand_positive`; `boxcox1p` uses `jtu.rand_uniform(low=-0.5, high=5.0)` to cover negative `x` without crossing `-1`. 20 cases pass locally. Zero-sized dim + jit verified.

Issue: scipy.special API parity (no specific issue, follows the ongoing scipy port).
