### PR TITLE
Add erfcx with stable asymptotic expansion

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -168,6 +168,7 @@ jax.scipy.special
    entr
    erf
    erfc
+   erfcx
    erfinv
    exp1
    expi

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -519,6 +519,7 @@ def erf(x: ArrayLike) -> Array:
 
   See also:
     - :func:`jax.scipy.special.erfc`
+    - :func:`jax.scipy.special.erfcx`
     - :func:`jax.scipy.special.erfinv`
   """
   x, = promote_args_inexact("erf", x)
@@ -548,6 +549,7 @@ def erfc(x: ArrayLike) -> Array:
 
   See also:
     - :func:`jax.scipy.special.erf`
+    - :func:`jax.scipy.special.erfcx`
     - :func:`jax.scipy.special.erfinv`
   """
   x, = promote_args_inexact("erfc", x)
@@ -576,6 +578,71 @@ def erfinv(x: ArrayLike) -> Array:
   """
   x, = promote_args_inexact("erfinv", x)
   return lax.erf_inv(x)
+
+
+def erfcx(x: ArrayLike) -> Array:
+  r"""Scaled complementary error function.
+
+  JAX implementation of :obj:`scipy.special.erfcx`.
+
+  .. math::
+
+     \mathrm{erfcx}(x) = e^{x^2} \mathrm{erfc}(x)
+
+  This is numerically stable for large positive ``x``, unlike the naive
+  formula which overflows.
+
+  Args:
+    x: arraylike, real-valued.
+
+  Returns:
+    array containing values of the scaled complementary error function.
+
+  See also:
+    - :func:`jax.scipy.special.erfc`
+    - :func:`jax.scipy.special.erf`
+  """
+  x, = promote_args_inexact("erfcx", x)
+  if dtypes.issubdtype(x.dtype, np.complexfloating):
+    raise ValueError("erfcx does not support complex-valued inputs.")
+  return _erfcx(x)
+
+
+@custom_derivatives.custom_jvp
+def _erfcx(x: Array) -> Array:
+  if x.dtype == np.float64:
+    # At threshold ~26.6, first omitted term |c_9|/x^18 ~ 1e-21 << eps64 ~ 2e-16.
+    return _erfcx_impl(x, nterms=9)
+  elif x.dtype == np.float32:
+    # At threshold ~9.4, first omitted term |c_5|/x^10 ~ 5e-9 << eps32 ~ 1e-7.
+    return _erfcx_impl(x, nterms=5)
+  else:  # float16, bfloat16 — upcast to float32
+    return _erfcx_impl(x.astype(np.float32), nterms=5).astype(x.dtype)
+
+_erfcx.defjvps(
+    lambda g, ans, x: g * (2 * x * ans - _lax_const(x, 2. / np.sqrt(np.pi))))
+
+
+def _erfcx_asymptotic(x: Array, nterms: int) -> Array:
+  # Asymptotic expansion: erfcx(x) ~ (1/(sqrt(pi)*x)) * P(1/x^2)
+  # P(t) = sum_{k=0}^{N} c_k * t^k,  c_k = (-1)^k * (2k-1)!! / 2^k
+  # Coefficients in descending order of degree (k=8..0) for jnp.polyval.
+  _coeffs = [7918.06640625, -1055.7421875, 162.421875, -29.53125, 6.5625,
+             -1.875, .75, -.5, 1.]
+  t = _lax_const(x, 1.) / lax.square(x)
+  p = jnp.polyval(np.array(_coeffs[-nterms:], dtype=x.dtype), t)
+  return p / (x * _lax_const(x, np.sqrt(np.pi)))
+
+
+def _erfcx_impl(x: Array, nterms: int) -> Array:
+  # Switch to asymptotic expansion when exp(x^2) would overflow.
+  # Overflow occurs when x^2 > log(fmax), i.e. x > sqrt(log(fmax)).
+  threshold = np.sqrt(np.log(dtypes.finfo(x.dtype).max))
+  large = x > _lax_const(x, threshold)
+  safe_x = lax.select(large, lax.full_like(x, 1.), x)
+  direct = lax.exp(lax.square(safe_x)) * lax.erfc(safe_x)
+  asymp = _erfcx_asymptotic(x, nterms)
+  return lax.select(large, asymp, direct)
 
 
 @custom_derivatives.custom_jvp

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -25,6 +25,7 @@ from jax._src.scipy.special import (
   entr as entr,
   erf as erf,
   erfc as erfc,
+  erfcx as erfcx,
   erfinv as erfinv,
   exp1 as exp1,
   expi as expi,

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -96,6 +96,9 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
         "erfc", 1, float_dtypes, jtu.rand_small_positive, True
     ),
     op_record(
+        "erfcx", 1, float_dtypes, jtu.rand_default, True
+    ),
+    op_record(
         "erfinv", 1, float_dtypes, jtu.rand_small_positive, True
     ),
     op_record(
@@ -230,6 +233,19 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
       jtu.check_grads(partial_lax_op, diff_args, order=1,
                       atol=.1 if jtu.test_device_matches(["tpu"]) else 1e-3,
                       rtol=.1, eps=1e-3)
+
+  def testErfcxLargeX(self):
+    # Verify no overflow and agreement with scipy in the asymptotic regime
+    # (float32: x > ~9.4, float64: x > ~26.6 — where exp(x^2) would overflow naively)
+    x = np.array([10., 20., 50., 100.], dtype=np.float32)
+    jax_val = lsp_special.erfcx(x)
+    scipy_val = osp_special.erfcx(x)
+    self.assertAllClose(jax_val, scipy_val, rtol=1e-5)
+    if jax.config.x64_enabled:
+      x = np.array([27., 50., 100., 500.], dtype=np.float64)
+      jax_val = lsp_special.erfcx(x)
+      scipy_val = osp_special.erfcx(x)
+      self.assertAllClose(jax_val, scipy_val, rtol=1e-12)
 
   @jtu.sample_product(
       n=[0, 1, 2, 3, 10, 50]


### PR DESCRIPTION
Adds jax.scipy.special.erfcx, the scaled complementary error function erfcx(x) = exp(x²) ·
erfc(x), addressing #1987.

### Implementation

The naive formula exp(x²) * erfc(x) overflows in float32 for x ≳ 9.4 and float64 for x ≳ 26.6,
even though erfcx(x) itself remains finite (it approaches 1/(√π·x) as x → ∞). To handle this,
the implementation is piecewise:

- Moderate x: exp(x²) * erfc(x) directly — no accuracy issues here since neither factor is
extreme
- Large positive x: asymptotic expansion (1/√π·x) · P(1/x²) via Horner, where P truncates the
series Σ (-1)^k (2k-1)!! / (2x²)^k — 5 terms for float32, 9 terms for float64

The switchover threshold is computed from dtypes.finfo(dtype).max as sqrt(log(fmax)), consistent
 with how igamma and similar functions handle overflow thresholds in JAX.

To prevent NaN propagation through the dead branch under JIT (the standard JAX pitfall with
jnp.where/lax.select), safe_x is clamped to 1.0 before the direct branch computation so exp(x²)
never actually overflows.

float16 and bfloat16 inputs are upcast to float32 before computation, following the bessel_i0e
pattern.

The JVP d/dx erfcx(x) = 2x·erfcx(x) − 2/√π is registered via custom_jvp/defjvps, consistent with
 how logit and xlogy are handled.

### AI Disclosure

Claude Code was used to aide in the code generation for this PR. 