### PR TITLE
[random] Add out_sharding, shape and dtype checks to jax.random.wald

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -65,6 +65,25 @@ UINT_DTYPES = prng.UINT_DTYPES
 
 ### utilities
 
+def _check_broadcast_shapes(name: str, shape: tuple | Shape | None, *args: ArrayLike):
+  arg_shapes = [np.shape(a) for a in args]
+  if shape is None:
+    if arg_shapes:
+      shape = lax.broadcast_shapes(*arg_shapes)
+    else:
+      shape = ()
+  else:
+    shape = core.canonicalize_shape(shape)
+    _check_shape(name, shape, *arg_shapes)
+  return shape
+
+
+def _check_all_safe_to_cast(name: str, dtype: DTypeLike, *args):
+  for arg in args:
+    if not dtypes.safe_to_cast(arg, dtype):
+      raise dtypes.TypePromotionError(f"In arguments to {name}, cannot safely cast argument of type {jnp.asarray(arg).dtype} to {dtype}")
+
+
 def _isnan(x: ArrayLike) -> Array:
   return lax.ne(x, x)
 
@@ -2828,7 +2847,9 @@ def _rayleigh(key, scale, shape, dtype) -> Array:
 def wald(key: ArrayLike,
          mean: RealArray,
          shape: Shape | None = None,
-         dtype: DTypeLikeFloat | None = None) -> Array:
+         dtype: DTypeLikeFloat | None = None,
+         *,
+         out_sharding: NamedSharding | P | None = None) -> Array:
   r"""Sample Wald random values with given shape and float dtype.
 
   The values are returned according to the probability density function:
@@ -2849,6 +2870,14 @@ def wald(key: ArrayLike,
       (None) produces a result shape equal to ``np.shape(mean)``.
     dtype: optional, a float dtype for the returned values (default float64 if
       jax_enable_x64 is true, otherwise float32).
+    out_sharding: optional, specifies how the output array should be sharded
+      across devices in multi-device computation. Can be a
+      :class:`~jax.sharding.NamedSharding`, a :class:`~jax.sharding.PartitionSpec`
+      (``P``), or ``None`` (default). When specified, the output will be sharded
+      according to the given sharding specification. Primarily used in explicit
+      sharding mode.
+      See the `explicit sharding tutorial <https://docs.jax.dev/en/latest/parallel.html>`_
+      for more details.
 
   Returns:
     A random array with the specified dtype and with shape given by ``shape`` if
@@ -2860,16 +2889,13 @@ def wald(key: ArrayLike,
   if not dtypes.issubdtype(dtype, np.floating):
     raise ValueError("dtype argument to `wald` must be a float "
                      f"dtype, got {dtype}")
-  if shape is not None:
-    shape = core.canonicalize_shape(shape)
-  return _wald(key, mean, shape, dtype)
+  shape = _check_broadcast_shapes("wald", shape, mean)
+  out_sharding = canonicalize_sharding(out_sharding, "wald")
+  _check_all_safe_to_cast("wald", dtype, mean)
+  return maybe_auto_axes(_wald, out_sharding, shape=shape, dtype=dtype)(key, mean)
 
 @jit(static_argnums=(2, 3))
 def _wald(key, mean, shape, dtype) -> Array:
-  if shape is None:
-    shape =  np.shape(mean)
-  else:
-    _check_shape("wald", shape, np.shape(mean))
   k1, k2 = _split(key, 2)
   mean = mean.astype(dtype)
   mean = jnp.broadcast_to(mean, shape)

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -240,6 +240,7 @@ _OUT_SHARDING_CASES = [
     ('truncated_normal', lambda key, n, s: random.truncated_normal(key, lower=-2., upper=2., shape=(n,), out_sharding=s)),
     ('uniform', lambda key, n, s: random.uniform(key, shape=(n,), out_sharding=s)),
     ('gamma', lambda key, n, s: random.gamma(key, a=2.0, shape=(n,), out_sharding=s)),
+    ('wald', lambda key, n, s: random.wald(key, mean=1.0, shape=(n,), out_sharding=s)),
 ]
 
 


### PR DESCRIPTION
Adds an `out_sharding` argument to the `wald` sampler. Also uses the standardized `_check_all_safe_to_cast` and `_check_broadcast_shapes` utilities being added to all samplers. 