### PR TITLE
Add jax.scipy.special.comb

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -8,7 +8,7 @@ jax.scipy.cluster
 
 .. autosummary::
    :toctree: _autosummary
-   
+
    vq
 
 jax.scipy.fft
@@ -164,6 +164,7 @@ jax.scipy.special
    beta
    betainc
    betaln
+   comb
    digamma
    entr
    erf

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -361,6 +361,48 @@ def factorial(n: ArrayLike, exact: bool = False) -> Array:
   return jnp.where(n < 0, 0, lax.exp(lax.lgamma(n + 1)))
 
 
+def comb(N: ArrayLike, k: ArrayLike, *, repetition: bool = False) -> Array:
+  r"""The number of combinations of N things taken k at a time ("N choose k").
+
+  JAX implementation of :func:`scipy.special.comb`.
+
+  .. math::
+
+    \mathrm{comb}(N, k) = \binom{N}{k} = \frac{N!}{k!\,(N - k)!}
+
+  Args:
+    N: arraylike, number of things.
+    k: arraylike, number of elements taken.
+    repetition: bool, compute the number of combinations with repetition.
+
+  Returns:
+    array containing the total number of combinations.
+
+  Notes:
+    This computes the float-valued binomial coefficient via the
+    :func:`~jax.scipy.special.gammaln` function. The ``exact`` argument
+    from :func:`scipy.special.comb` is not supported because JAX does not
+    support arbitrary-precision integers. If ``N < 0``, ``k < 0``, or
+    ``k > N`` and ``repetition=False``, then 0 is returned.
+
+  See Also:
+    - :func:`jax.scipy.special.factorial`
+    - :func:`jax.scipy.special.gammaln`
+  """
+  N, k = promote_args_inexact("comb", N, k)
+
+  if repetition:
+    cond = (k == 0) & (N >= 0)
+    result = comb(N + k - 1, k, repetition=False)
+    return jnp.where(cond, 1.0, result)
+
+  cond = (k <= N) & (N >= 0) & (k >= 0)
+  safe_N = jnp.where(cond, N, 0.0)
+  safe_k = jnp.where(cond, k, 0.0)
+  result = lax.exp(gammaln(safe_N + 1) - gammaln(safe_k + 1) - gammaln(safe_N + 1 - safe_k))
+  return jnp.where(cond, result, 0.0)
+
+
 def beta(a: ArrayLike, b: ArrayLike) -> Array:
   r"""The beta function
 

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -21,6 +21,7 @@ from jax._src.scipy.special import (
   beta as beta,
   betainc as betainc,
   betaln as betaln,
+  comb as comb,
   digamma as digamma,
   entr as entr,
   erf as erf,

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -112,6 +112,9 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
         "gammaln", 1, float_dtypes, jtu.rand_positive, False
     ),
     op_record(
+        "comb", 2, float_dtypes, jtu.rand_positive, False
+    ),
+    op_record(
         "factorial", 1, float_dtypes, jtu.rand_default, True
     ),
     op_record(
@@ -257,6 +260,19 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
     args_maker = lambda: []
     self._CheckAgainstNumpy(scipy_op, lax_op, args_maker, atol=0, rtol=1E-5)
     self._CompileAndCheck(lax_op, args_maker, atol=0, rtol=1E-5)
+
+  @parameterized.parameters(
+      ([-1, -1, 5, 5], [0, 2, -1, 7], False),
+      ([0, 0], [0, 4], True),
+  )
+  def testCombBoundaryValues(self, N_samples, k_samples, repetition):
+    dtype = dtypes.default_float_dtype()
+    rtol = 1E-3 if jtu.test_device_matches(["tpu"]) else 1e-5
+    args_maker = lambda: (np.array(N_samples, dtype=dtype), np.array(k_samples, dtype=dtype))
+    scipy_op = functools.partial(osp_special.comb, repetition=repetition)
+    lax_op = functools.partial(lsp_special.comb, repetition=repetition)
+    self._CheckAgainstNumpy(scipy_op, lax_op, args_maker, rtol=rtol)
+    self._CompileAndCheck(lax_op, args_maker, rtol=rtol)
 
   def testGammaSign(self):
     dtype = jnp.zeros(0).dtype  # default float dtype.


### PR DESCRIPTION
### Description

Adds jax.scipy.special.comb. Builds on the work in #18389 from @Phionx and adds arg edge case handling from the [scipy implementation](https://github.com/scipy/scipy/blob/de6696861c733a427ce3c790bcb662e3589ce5bb/scipy/special/_basic.py#L2602). 


Resolves: #9709 