### PR TITLE
[export] Handle AMD device kinds in get_platform_from_device_kind

### DIFF
--- a/jax/_src/export/serialization.py
+++ b/jax/_src/export/serialization.py
@@ -651,7 +651,7 @@ def get_platform_from_device_kind(device_kind) -> str:
     return 'cpu'
   elif 'tpu' in device_kind:
     return 'tpu'
-  elif any(x in device_kind for x in ['nvidia', 'tesla']):
+  elif any(x in device_kind for x in ['nvidia', 'tesla', 'amd']):
     return 'gpu'
   else:
     raise ValueError(f'Got unexpected {device_kind=}')


### PR DESCRIPTION
On AMD ROCm hosts, `device_kind` strings like `"AMD Instinct MI300X"`, `"AMD Instinct MI350X VF"`, or `"AMD Instinct MI355X"` don't match any branch in `get_platform_from_device_kind`, so the legacy fallback in `_deserialize_abstract_device` 

raises: `ValueError: Got unexpected device_kind='amd instinct mi350x vf'

This breaks `tests/export_test.py::JaxExportTest::test_multi_platform_and_sharding` (and any other path through `_deserialize_abstract_mesh`) on AMD GPUs.
Add an `amd` / `instinct` / `radeon` branch that returns the legacy `'gpu'` alias, symmetric with the existing `nvidia` / `tesla` branch;
`xla_bridge.canonicalize_platform` resolves it to `rocm`.
