### PR TITLE
Use _check_broadcast_shapes and _check_all_safe_to_cast for uniform sampler

### DIFF
--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -21,6 +21,7 @@ from operator import index
 import typing
 from typing import Union
 import warnings
+from contextlib import nullcontext
 
 import numpy as np
 
@@ -468,7 +469,7 @@ def canonicalize_sharding_for_samplers(out_sharding, name, shape):
 
 
 def uniform(key: ArrayLike,
-            shape: Shape = (),
+            shape: Shape | None = None,
             dtype: DTypeLikeFloat | None = None,
             minval: RealArray = 0.,
             maxval: RealArray = 1.,
@@ -479,9 +480,12 @@ def uniform(key: ArrayLike,
   Args:
     key: a PRNG key used as the random key.
     shape: optional, a tuple of nonnegative integers representing the result
-      shape. Default ().
+      shape. If ``None``, the result will broadcast the shapes of ``minval`` and ``maxval``.
     dtype: optional, a float dtype for the returned values (default float64 if
-      jax_enable_x64 is true, otherwise float32).
+      jax_enable_x64 is true, otherwise float32). If this argument is specified,
+      any type promotions of ``minval`` or ``maxval`` will be seen as explicit. If
+      left unspecified, type promotions will be seen as implicit, and may fail if
+      `jax_numpy_dtype_promotion='strict'`.
     minval: optional, a minimum (inclusive) value broadcast-compatible with shape for the range (default 0).
     maxval: optional, a maximum (exclusive) value broadcast-compatible with shape for the range (default 1).
     out_sharding: Optional. Specifies how the output array should be sharded
@@ -497,23 +501,25 @@ def uniform(key: ArrayLike,
     A random array with the specified shape and dtype.
   """
   key, _ = _check_prng_key("uniform", key)
+  if dtype is not None:
+    cxt = config.numpy_dtype_promotion('standard')
+  else:
+    cxt = nullcontext()
   dtype = dtypes.check_and_canonicalize_user_dtype(
       float if dtype is None else dtype)
-  shape = core.canonicalize_shape(shape)
+  shape = _check_broadcast_shapes("uniform", shape, minval, maxval)
   out_sharding = canonicalize_sharding_for_samplers(out_sharding, "uniform", shape)
 
   if not dtypes.issubdtype(dtype, np.floating):
     raise ValueError(f"dtype argument to `uniform` must be a float dtype, "
                      f"got {dtype}")
+  with cxt:
+    _check_all_safe_to_cast("uniform", dtype, minval, maxval)
   return maybe_auto_axes(_uniform, out_sharding,
                          shape=shape, dtype=dtype)(key, minval, maxval)
 
 @jit(static_argnums=(3, 4))
 def _uniform(key, minval, maxval, shape, dtype) -> Array:
-  _check_shape("uniform", shape)
-  if not dtypes.issubdtype(dtype, np.floating):
-    raise TypeError("uniform only accepts floating point dtypes.")
-
   minval = lax.convert_element_type(minval, dtype)
   maxval = lax.convert_element_type(maxval, dtype)
   minval = lax.broadcast_to_rank(minval, len(shape))
@@ -2138,7 +2144,8 @@ def laplace(key: ArrayLike,
 def _laplace(key, shape, dtype) -> Array:
   _check_shape("laplace", shape)
   u = uniform(
-      key, shape, dtype, minval=-1. + dtypes.finfo(dtype).epsneg, maxval=1.)
+    key, shape, dtype,
+    minval=dtypes.finfo(dtype).epsneg - jnp.array(1, dtype=dtype), maxval=1.)
   return lax.mul(lax.sign(u), lax.log1p(lax.neg(lax.abs(u))))
 
 

--- a/jax/experimental/rnn.py
+++ b/jax/experimental/rnn.py
@@ -171,7 +171,7 @@ def init_lstm_weight(rng: PRNGKeyArray, input_size: int, hidden_size: int,
   """Random initialize LSTM weights from U(-k, k), k=sqrt(1/hidden_size)."""
   param_count = get_num_params_in_lstm(input_size, hidden_size, num_layers,
                                        bidirectional)
-  k = np.sqrt(1.0 / hidden_size)
+  k = np.sqrt(1.0 / hidden_size).astype(jnp.float32)
   return jax.random.uniform(
       rng, shape=(param_count,), dtype=jnp.float32, minval=-k, maxval=k)
 


### PR DESCRIPTION
This PR ensures that the output shape for `uniform` broadcasts `minval` and `maxval`. 