### PR TITLE
add wofz (Faddeeva function) and extend erfcx to complex inputs

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -207,6 +207,7 @@ jax.scipy.special
    softmax
    spence
    sph_harm_y
+   wofz
    xlog1py
    xlogy
    zeta

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -248,6 +248,17 @@ def promote_args_inexact(fun_name: str, *args: ArrayLike) -> list[Array]:
   return promote_shapes(fun_name, *promote_dtypes_inexact(*args))
 
 
+def promote_args_complex(fun_name: str, *args: ArrayLike) -> list[Array]:
+  """Convenience function to apply Numpy argument shape and dtype promotion.
+
+  Promotes non-complex types to a complex type."""
+  check_arraylike(fun_name, *args)
+  args = tuple(_check_jax_array_protocol(arg) for arg in args)
+  _check_no_float0s(fun_name, *args)
+  check_for_prngkeys(fun_name, *args)
+  return promote_shapes(fun_name, *promote_dtypes_complex(*args))
+
+
 @api.jit(inline=True)
 def _broadcast_arrays(*args: ArrayLike) -> list[Array]:
   """Like Numpy's broadcast_arrays but doesn't return views."""

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -33,7 +33,7 @@ from jax._src.api import jit, jvp, vmap
 from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy import einsum as jnp_einsum
 from jax._src.numpy import vectorize as jnp_vectorize
-from jax._src.numpy.util import promote_args_inexact, promote_dtypes_inexact
+from jax._src.numpy.util import promote_args_complex, promote_args_inexact, promote_dtypes_inexact
 from jax._src.ops import special as ops_special
 from jax._src.third_party.scipy.betaln import betaln as _betaln_impl
 from jax._src.typing import Array, ArrayLike
@@ -580,6 +580,52 @@ def erfinv(x: ArrayLike) -> Array:
   return lax.erf_inv(x)
 
 
+# Weideman (1994) N=32 rational approximation constants for the Faddeeva function.
+# Descending-degree polynomial coefficients for jnp.polyval: polyval(c, Z) = sum_n c[n]*Z^(N-n).
+# Algorithm: w(z) = 2*polyval(c, Z)/(L-iz)^2 + 1/(sqrt(pi)*(L-iz))
+# where Z = (L+iz)/(L-iz), valid for Im(z) >= 0.
+_WOFZ_L = 4.7568284600108841
+_WOFZ_C = np.array([
+    -1.3034426067909105e-12, 3.7411838373738471e-12, 8.030427700497756e-12, -2.1543593557490879e-11,
+    -5.5442449963237932e-11, 1.165824698850374e-10, 4.1537441121999766e-10, -5.2310202114920615e-10,
+    -3.2080151339721323e-09, 8.1248864216535907e-10, 2.3797556530014025e-08, 2.2930438438915445e-08,
+    -1.4813078929137642e-07, -4.1840763750512053e-07, 4.2558331397138446e-07, 4.4015317312832251e-06,
+    6.8210319443575151e-06, -2.1409619201999998e-05, -0.00013075449254579421, -0.00024532980270038237,
+    0.00039259136070109705, 0.0045195411053493093, 0.019006155784845501, 0.057304403529837282,
+    0.14060716226893755, 0.29544451071508743, 0.54601397206393376, 0.9019254893648001,
+    1.3455441692345449, 1.8256696296324815, 2.2635372999002676, 2.5722534081245696,
+])
+
+
+def _wofz_upper(z: Array) -> Array:
+  re = lax.real(z)
+  L = lax.complex(_lax_const(re, _WOFZ_L), _lax_const(re, 0.))
+  iz = lax.complex(lax.neg(lax.imag(z)), re)
+  denom = L - iz
+  Z = (L + iz) / denom
+  p = jnp.polyval(jnp.asarray(_WOFZ_C, dtype=Z.dtype), Z)
+  one_over_sqrtpi = lax.complex(_lax_const(re, 1. / np.sqrt(np.pi)), _lax_const(re, 0.))
+  return 2 * p / (denom * denom) + one_over_sqrtpi / denom
+
+
+@custom_derivatives.custom_jvp
+def _wofz(z: Array) -> Array:
+  sign = lax.ge(lax.imag(z), _lax_const(lax.real(z), 0.))
+  z_upper = lax.select(sign, z, lax.neg(z))
+  w_upper = _wofz_upper(z_upper)
+  correction = 2 * lax.exp(lax.neg(z * z)) - w_upper
+  return lax.select(sign, w_upper, correction)
+
+_wofz.defjvps(
+    lambda g, ans, z: g * (
+        lax.neg(2 * z * ans) + lax.complex(
+            _lax_const(lax.real(z), 0.),
+            _lax_const(lax.real(z), 2. / np.sqrt(np.pi)),
+        )
+    )
+)
+
+
 def erfcx(x: ArrayLike) -> Array:
   r"""Scaled complementary error function.
 
@@ -593,7 +639,7 @@ def erfcx(x: ArrayLike) -> Array:
   formula which overflows.
 
   Args:
-    x: arraylike, real-valued.
+    x: arraylike, real or complex.
 
   Returns:
     array containing values of the scaled complementary error function.
@@ -601,10 +647,12 @@ def erfcx(x: ArrayLike) -> Array:
   See also:
     - :func:`jax.scipy.special.erfc`
     - :func:`jax.scipy.special.erf`
+    - :func:`jax.scipy.special.wofz`
   """
   x, = promote_args_inexact("erfcx", x)
   if dtypes.issubdtype(x.dtype, np.complexfloating):
-    raise ValueError("erfcx does not support complex-valued inputs.")
+    iz = lax.complex(lax.neg(lax.imag(x)), lax.real(x))
+    return _wofz(iz)
   return _erfcx(x)
 
 
@@ -930,6 +978,28 @@ _BERNOULLI_COEFS = np.array([
     759790291646040068357842010112000000 / 1723168255201,
     -134196726836183700385281186201600000000 / 7709321041217,
 ])
+
+
+def wofz(z: ArrayLike) -> Array:
+  r"""Faddeeva function.
+
+  JAX implementation of :obj:`scipy.special.wofz`.
+
+  .. math::
+
+     \mathrm{wofz}(z) = e^{-z^2} \mathrm{erfc}(-iz)
+
+  Args:
+    z: arraylike, real or complex.
+
+  Returns:
+    array of complex values of the Faddeeva function.
+
+  See also:
+    - :func:`jax.scipy.special.erfcx`
+  """
+  z, = promote_args_complex("wofz", z)
+  return _wofz(z)
 
 
 @custom_derivatives.custom_jvp

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -62,6 +62,7 @@ from jax._src.scipy.special import (
   softmax as softmax,
   spence as spence,
   sph_harm_y as sph_harm_y,
+  wofz as wofz,
   xlog1py as xlog1py,
   xlogy as xlogy,
   zeta as zeta,

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -96,7 +96,7 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
         "erfc", 1, float_dtypes, jtu.rand_small_positive, True
     ),
     op_record(
-        "erfcx", 1, float_dtypes, jtu.rand_default, True
+        "erfcx", 1, float_dtypes + jtu.dtypes.complex, jtu.rand_default, True
     ),
     op_record(
         "erfinv", 1, float_dtypes, jtu.rand_small_positive, True
@@ -182,6 +182,7 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
     ),
     op_record("log_softmax", 1, float_dtypes, jtu.rand_default, True),
     op_record("softmax", 1, float_dtypes, jtu.rand_default, True),
+    op_record("wofz", 1, jtu.dtypes.complex, jtu.rand_default, False),
 ]
 
 
@@ -247,6 +248,32 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
       jax_val = lsp_special.erfcx(x)
       scipy_val = osp_special.erfcx(x)
       self.assertAllClose(jax_val, scipy_val, rtol=1e-12)
+
+  def testWofzAccuracy(self):
+    # Verify wofz agrees with scipy over the full complex plane (float32).
+    rng = jtu.rand_default(np.random.RandomState(0))
+    z = rng((50,), np.complex64)
+    jax_val = np.array(lsp_special.wofz(z))
+    scipy_val = osp_special.wofz(z.astype(np.complex128)).astype(np.complex64)
+    self.assertAllClose(jax_val, scipy_val, rtol=1e-5)
+
+  def testWofzLowerHalfPlane(self):
+    # The reflection formula w(-z) = 2*exp(-z^2) - w(z) must hold.
+    rng = jtu.rand_default(np.random.RandomState(1))
+    z = rng((20,), np.complex64)
+    z_lower = z.real - 1j * np.abs(z.imag) - 1j * 0.1  # ensure Im < 0
+    jax_w = np.array(lsp_special.wofz(z_lower))
+    scipy_w = osp_special.wofz(z_lower.astype(np.complex128)).astype(np.complex64)
+    self.assertAllClose(jax_w, scipy_w, rtol=1e-5)
+
+  def testWofzJvp(self):
+    # d/dz w(z) = -2z*w(z) + 2i/sqrt(pi) — test against numerical diff.
+    rng = jtu.rand_default(np.random.RandomState(2))
+    z = rng((10,), np.complex64) + 0.5j  # stay in upper half-plane
+    import jax
+    primals, tangents = jax.jvp(lsp_special.wofz, (z,), (np.ones_like(z),))
+    expected_tangents = -2 * z * primals + jnp.array(2j / np.sqrt(np.pi), dtype=z.dtype)
+    self.assertAllClose(tangents, expected_tangents, rtol=1e-4)
 
   @jtu.sample_product(
       n=[0, 1, 2, 3, 10, 50]


### PR DESCRIPTION
## Summary

Adds jax.scipy.special.wofz, the Faddeeva function $w(z) = e^{-z^2}\mathrm{erfc}(-iz)$, using the Weideman (1994) N=32 rational approximation. Also extends jax.scipy.special.erfcx to accept complex inputs by routing them through wofz.

Continuing to add to this family of functions from #37580.

## Implementation:
  - _wofz_upper(z): evaluates the rational approximation via jnp.polyval for Im(z) ≥ 0
  - _wofz(z): applies the reflection formula $w(-z) = 2e^{-z^2} - w(z)$ for the lower half-plane; decorated with @custom_jvp implementing $w'(z) = -2z,w(z) + \frac{2i}{\sqrt{\pi}}$
  - wofz(z): public wrapper promoting real inputs to complex before dispatching
  - erfcx complex branch: erfcx(z) = wofz(iz), matching SciPy behaviour
  - Coefficients stored in descending-degree order to avoid a [::-1] reversal on every polyval call

## Tests added:
  - testWofzAccuracy: float32 accuracy against SciPy reference
  - testWofzLowerHalfPlane: lower-half-plane reflection formula
  - testWofzJvp: JVP correctness against the analytic derivative
  - testErfcxComplex: erfcx(z) == wofz(iz) identity + SciPy reference