### PR TITLE
ci: preserve env vars in default.env and docker.env if already set

### DIFF
--- a/ci/envs/default.env
+++ b/ci/envs/default.env
@@ -17,7 +17,7 @@
 # the behavior of these variables and their usage in the CI scripts.
 
 # The path to the JAX git repository.
-export JAXCI_JAX_GIT_DIR=$(pwd)
+export JAXCI_JAX_GIT_DIR="${JAXCI_JAX_GIT_DIR:-$(pwd)}"
 
 # Controls the version of Hermetic Python to use. Use system default if not
 # set.
@@ -42,7 +42,7 @@ export JAXCI_CLONE_MAIN_XLA=${JAXCI_CLONE_MAIN_XLA:-0}
 export JAXCI_XLA_COMMIT=${JAXCI_XLA_COMMIT:-}
 
 # Controls the location where the artifacts are written to.
-export JAXCI_OUTPUT_DIR="$(pwd)/dist"
+export JAXCI_OUTPUT_DIR="${JAXCI_OUTPUT_DIR:-$(pwd)/dist}"
 
 # Whether to use RBE to build the artifacts.
 export JAXCI_BUILD_ARTIFACT_WITH_RBE=${JAXCI_BUILD_ARTIFACT_WITH_RBE:-0}

--- a/ci/envs/docker.env
+++ b/ci/envs/docker.env
@@ -19,10 +19,10 @@ os=$(uname -s | awk '{print tolower($0)}')
 arch=$(uname -m)
 
 # The path to the JAX git repository.
-export JAXCI_JAX_GIT_DIR=$(pwd)
+export JAXCI_JAX_GIT_DIR="${JAXCI_JAX_GIT_DIR:-$(pwd)}"
 
-export JAXCI_DOCKER_WORK_DIR="/jax"
-export JAXCI_DOCKER_ARGS=""
+export JAXCI_DOCKER_WORK_DIR="${JAXCI_DOCKER_WORK_DIR:-/jax}"
+export JAXCI_DOCKER_ARGS="${JAXCI_DOCKER_ARGS:-}"
 
 # TODO(b/384533574): Replace latest tagged images with sha or release specific
 # tags when we make the new release jobs as default.

--- a/ci/utilities/run_docker_container.sh
+++ b/ci/utilities/run_docker_container.sh
@@ -53,9 +53,12 @@ if ! docker container inspect jax >/dev/null 2>&1 ; then
   fi
 
   # Create a temporary file to pass any user defined JAXCI_ / JAX_ / JAXLIB_
-  # variables to the container.
+  # variables to the container. Exclude host-specific path variables so they
+  # are recalculated inside the container using its own filesystem layout.
   JAXCI_TEMP_ENVFILE_DIR=$(mktemp)
-  env | grep -e "JAXCI_" -e "JAX_" -e "JAXLIB_" > "$JAXCI_TEMP_ENVFILE_DIR"
+  env | grep -e "JAXCI_" -e "JAX_" -e "JAXLIB_" \
+      | grep -v "^JAXCI_JAX_GIT_DIR=\|^JAXCI_OUTPUT_DIR=" \
+      > "$JAXCI_TEMP_ENVFILE_DIR"
 
   # On Windows, convert MSYS Linux-like paths to Windows paths.
   if [[ "$(uname -s)" =~ "MSYS_NT" ]]; then


### PR DESCRIPTION
## Summary

`ci/envs/default.env` and `ci/envs/docker.env` used unconditional `export VAR="value"` assignments for several key variables, silently overwriting any values set by the caller before sourcing these files.

### For example:
```
export JAXCI_DOCKER_ARGS="--gpus all --device /dev/dri"
source ci/envs/docker.env   # JAXCI_DOCKER_ARGS is now "" — custom value lost
```

This PR fixes the issue by switching to `${VAR:-"default"}` syntax so variables already set in the environment are preserved.

### Affected variables:
```
- JAXCI_DOCKER_ARGS — extra args to pass to docker run
- JAXCI_DOCKER_WORK_DIR — working directory inside the container
- JAXCI_JAX_GIT_DIR — path to the JAX git repository
- JAXCI_OUTPUT_DIR — where build artifacts are written
```

Fixes #37662 

### Test plan
- Verify that setting `JAXCI_DOCKER_ARGS` before sourcing `docker.env` preserves the value
- Verify that not setting the variable still uses the correct default