### PR TITLE
perf: make safemin/bignum constexpr in MaybePerturbPivot

### DIFF
--- a/jaxlib/cpu/lapack_kernels.cc
+++ b/jaxlib/cpu/lapack_kernels.cc
@@ -125,6 +125,7 @@ static ffi::Error ParallelBatchMap(
 
 //== Triangular System Solver ==//
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error TriMatrixEquationSolver<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x, ffi::Buffer<dtype> y,
@@ -172,6 +173,7 @@ ffi::Error TriMatrixEquationSolver<dtype, IntType>::Kernel(
         }
       });
 }
+// EVOLVE-BLOCK-END
 
 template <ffi::DataType dtype>
 ffi::Error TriMatrixEquationSolverKernel(
@@ -198,6 +200,7 @@ template struct TriMatrixEquationSolver<ffi::DataType::C128, int64_t>;
 
 //== LU Decomposition ==//
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error LuDecomposition<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x,
@@ -269,6 +272,7 @@ ffi::Error LuDecomposition<dtype, IntType>::Kernel(
         }
       });
 }
+// EVOLVE-BLOCK-END
 
 template <ffi::DataType dtype>
 ffi::Error LuDecompositionKernel(ffi::ThreadPool thread_pool,
@@ -295,6 +299,7 @@ template struct LuDecomposition<ffi::DataType::C128, int64_t>;
 
 //== QR Factorization ==//
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error QrFactorization<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x,
@@ -348,6 +353,7 @@ ffi::Error QrFactorization<dtype, IntType>::Kernel(
         }
       });
 }
+// EVOLVE-BLOCK-END
 
 template <ffi::DataType dtype>
 ffi::Error QrFactorizationKernel(ffi::ThreadPool thread_pool,
@@ -384,6 +390,7 @@ template struct QrFactorization<ffi::DataType::C128, int64_t>;
 //== Column Pivoting QR Factorization ==//
 
 // lapack geqp3
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error PivotingQrFactorization<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x,
@@ -491,6 +498,7 @@ ffi::Error PivotingQrFactorization<dtype, IntType>::Kernel(
         }
       });
 }
+// EVOLVE-BLOCK-END
 
 template <ffi::DataType dtype>
 ffi::Error PivotingQrFactorizationKernel(
@@ -534,6 +542,7 @@ template struct PivotingQrFactorization<ffi::DataType::C128, int64_t>;
 //== Orthogonal QR                                      ==//
 //== Computes orthogonal matrix Q from QR Decomposition ==//
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error OrthogonalQr<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x, ffi::Buffer<dtype> tau,
@@ -587,6 +596,7 @@ ffi::Error OrthogonalQr<dtype, IntType>::Kernel(
         }
       });
 }
+// EVOLVE-BLOCK-END
 
 template <ffi::DataType dtype>
 ffi::Error OrthogonalQrKernel(ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x,
@@ -622,6 +632,7 @@ template struct OrthogonalQr<ffi::DataType::C128, int64_t>;
 
 //== Orthogonal QR Multiply ==//
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error OrthogonalQrMultiply<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> a, ffi::Buffer<dtype> tau,
@@ -696,6 +707,7 @@ ffi::Error OrthogonalQrMultiply<dtype, IntType>::Kernel(
         }
       });
 }
+// EVOLVE-BLOCK-END
 
 template <ffi::DataType dtype, typename IntType>
 int64_t OrthogonalQrMultiply<dtype, IntType>::GetWorkspaceSize(
@@ -734,6 +746,7 @@ ffi::Error OrthogonalQrMultiplyKernel(ffi::ThreadPool thread_pool,
 
 //== Cholesky Factorization ==//
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error CholeskyFactorization<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x, MatrixParams::UpLo uplo,
@@ -778,6 +791,7 @@ ffi::Error CholeskyFactorization<dtype, IntType>::Kernel(
         }
       });
 }
+// EVOLVE-BLOCK-END
 
 template <ffi::DataType dtype>
 ffi::Error CholeskyFactorizationKernel(ffi::ThreadPool thread_pool,
@@ -818,9 +832,13 @@ bool ShouldParallelizeSVD(int64_t batch_size, int64_t rows, int64_t cols,
 
   const int64_t kMinMatrixSizeForParallelization = 8 * 8;
 
-  return matrix_size >= kMinMatrixSizeForParallelization && batch_size > 1;
+  if (batch_size <= 1) {
+    return false;
+  }
+  return matrix_size >= kMinMatrixSizeForParallelization;
 }
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 static ffi::Error SvdKernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x,
@@ -951,6 +969,7 @@ static ffi::Error SvdKernel(
         }
       });
 }
+// EVOLVE-BLOCK-END
 
 template <ffi::DataType dtype, typename IntType>
 static int64_t SvdGetWorkspaceSize(IntType x_rows, IntType x_cols,
@@ -979,6 +998,7 @@ static int64_t SvdGetWorkspaceSize(IntType x_rows, IntType x_cols,
   return info == 0 ? static_cast<int64_t>(std::real(optimal_size)) : -1;
 }
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 static ffi::Error SvdQRKernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x,
@@ -1101,6 +1121,7 @@ static ffi::Error SvdQRKernel(
         }
       });
 }
+// EVOLVE-BLOCK-END
 
 template <ffi::DataType dtype, typename IntType>
 static absl::StatusOr<IntType> SvdQRGetWorkspaceSize(
@@ -1278,6 +1299,7 @@ int64_t eig::GetIntWorkspaceSize(int64_t x_cols, ComputationMode mode) {
   }
 }
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error EigenvalueDecompositionSymmetric<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x, MatrixParams::UpLo uplo,
@@ -1340,6 +1362,7 @@ ffi::Error EigenvalueDecompositionSymmetric<dtype, IntType>::Kernel(
       });
   return ffi::Error::Success();
 }
+// EVOLVE-BLOCK-END
 
 template <ffi::DataType dtype>
 ffi::Error EigenvalueDecompositionSymmetricKernel(
@@ -1376,6 +1399,7 @@ int64_t GetRealWorkspaceSize(int64_t x_cols, ComputationMode mode) {
 
 }  // namespace eig
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error EigenvalueDecompositionHermitian<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x, MatrixParams::UpLo uplo,
@@ -1449,6 +1473,7 @@ ffi::Error EigenvalueDecompositionHermitian<dtype, IntType>::Kernel(
 
 template <ffi::DataType dtype>
 ffi::Error EigenvalueDecompositionHermitianKernel(
+// EVOLVE-BLOCK-END
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x, MatrixParams::UpLo uplo,
     ffi::ResultBuffer<dtype> x_out,
     ffi::ResultBuffer<ffi::ToReal(dtype)> eigenvalues,
@@ -1470,6 +1495,7 @@ template struct EigenvalueDecompositionHermitian<ffi::DataType::C64, int64_t>;
 template struct EigenvalueDecompositionHermitian<ffi::DataType::C128, int32_t>;
 template struct EigenvalueDecompositionHermitian<ffi::DataType::C128, int64_t>;
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error EigenvalueDecomposition<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x,
@@ -1570,6 +1596,7 @@ ffi::Error EigenvalueDecomposition<dtype, IntType>::Kernel(
       });
   return ffi::Error::Success();
 }
+// EVOLVE-BLOCK-END
 
 template <ffi::DataType dtype>
 ffi::Error EigenvalueDecompositionKernel(
@@ -1590,6 +1617,7 @@ ffi::Error EigenvalueDecompositionKernel(
       eigvecs_left, eigvecs_right, info);
 }
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error EigenvalueDecompositionComplex<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x,
@@ -1676,6 +1704,7 @@ ffi::Error EigenvalueDecompositionComplex<dtype, IntType>::Kernel(
 
 template <ffi::DataType dtype>
 ffi::Error EigenvalueDecompositionComplexKernel(
+// EVOLVE-BLOCK-END
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x,
     eig::ComputationMode compute_left, eig::ComputationMode compute_right,
     ffi::ResultBuffer<dtype> eigvals, ffi::ResultBuffer<dtype> eigvecs_left,
@@ -1735,6 +1764,7 @@ template struct EigenvalueDecompositionComplex<ffi::DataType::C128, int64_t>;
 
 //== Schur Decomposition ==//
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error SchurDecomposition<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x,
@@ -1831,6 +1861,7 @@ ffi::Error SchurDecomposition<dtype, IntType>::Kernel(
 
 template <ffi::DataType dtype>
 ffi::Error SchurDecompositionKernel(
+// EVOLVE-BLOCK-END
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x,
     schur::ComputationMode mode, schur::Sort sort,
     ffi::ResultBuffer<dtype> x_out, ffi::ResultBuffer<dtype> schur_vectors,
@@ -1850,6 +1881,7 @@ ffi::Error SchurDecompositionKernel(
       eigvals_imag, selected_eigvals, info);
 }
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error SchurDecompositionComplex<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x,
@@ -1938,6 +1970,7 @@ ffi::Error SchurDecompositionComplex<dtype, IntType>::Kernel(
 
 template <ffi::DataType dtype>
 ffi::Error SchurDecompositionComplexKernel(
+// EVOLVE-BLOCK-END
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x,
     schur::ComputationMode mode, schur::Sort sort,
     ffi::ResultBuffer<dtype> x_out, ffi::ResultBuffer<dtype> schur_vectors,
@@ -1995,6 +2028,7 @@ template struct SchurDecompositionComplex<ffi::DataType::C128, int64_t>;
 
 //== Hessenberg Decomposition ==//
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error HessenbergDecomposition<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x, int32_t low,
@@ -2051,6 +2085,7 @@ ffi::Error HessenbergDecomposition<dtype, IntType>::Kernel(
 
 template <ffi::DataType dtype>
 ffi::Error HessenbergDecompositionKernel(
+// EVOLVE-BLOCK-END
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x, int32_t low,
     int32_t high, ffi::ResultBuffer<dtype> x_out, ffi::ResultBuffer<dtype> tau,
     ffi::ResultBuffer<LapackIntDtype> info) {
@@ -2084,6 +2119,7 @@ template struct HessenbergDecomposition<ffi::DataType::C128, int64_t>;
 
 //== Tridiagonal Reduction ==//
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error TridiagonalReduction<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x, MatrixParams::UpLo uplo,
@@ -2151,6 +2187,7 @@ ffi::Error TridiagonalReduction<dtype, IntType>::Kernel(
 
 template <ffi::DataType dtype>
 ffi::Error TridiagonalReductionKernel(
+// EVOLVE-BLOCK-END
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> x, MatrixParams::UpLo uplo,
     ffi::ResultBuffer<dtype> x_out,
     ffi::ResultBuffer<ffi::ToReal(dtype)> diagonal,
@@ -2189,6 +2226,7 @@ template struct TridiagonalReduction<ffi::DataType::C128, int64_t>;
 
 // lapack gtsv
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType dtype, typename IntType>
 ffi::Error TridiagonalSolver<dtype, IntType>::Kernel(
     ffi::ThreadPool thread_pool, ffi::Buffer<dtype> dl, ffi::Buffer<dtype> d,
@@ -2248,6 +2286,7 @@ ffi::Error TridiagonalSolver<dtype, IntType>::Kernel(
 
 template <ffi::DataType dtype>
 ffi::Error TridiagonalSolverKernel(ffi::ThreadPool thread_pool,
+// EVOLVE-BLOCK-END
                                    ffi::Buffer<dtype> dl, ffi::Buffer<dtype> d,
                                    ffi::Buffer<dtype> du, ffi::Buffer<dtype> b,
                                    ffi::ResultBuffer<dtype> dl_out,

--- a/jaxlib/cpu/sparse_kernels.cc
+++ b/jaxlib/cpu/sparse_kernels.cc
@@ -40,6 +40,7 @@ using InputMap = Eigen::Map<const MatrixT, Eigen::Aligned32>;
 template <typename MatrixT>
 using OutputMap = Eigen::Map<MatrixT, Eigen::Aligned32>;
 
+// EVOLVE-BLOCK-START
 template <typename ElementType, typename StorageType>
 static ffi::Future CsrSparseDenseKernelImpl(
     const InputMap<SparseMatrixType<ElementType, StorageType>>& lhs_matrix,
@@ -63,7 +64,6 @@ static ffi::Future CsrSparseDenseKernelImpl(
     return ffi::Future(promise);
   } else {
     std::vector<int64_t> batch_sizes;
-// EVOLVE-BLOCK-START
     {
       int64_t running_batch_nnz = 0;
       int64_t running_number_rows = 0;
@@ -85,12 +85,10 @@ static ffi::Future CsrSparseDenseKernelImpl(
         }
       }
     }
-// EVOLVE-BLOCK-END
 
     ffi::CountDownPromise promise(batch_sizes.size());
     ffi::Future future(promise);
     int64_t batch_start = 0;
-// EVOLVE-BLOCK-START
     for (int64_t size : batch_sizes) {
       thread_pool.Schedule([out_matrix, lhs_matrix, rhs_matrix, batch_start,
                             size, promise]() mutable {
@@ -100,10 +98,10 @@ static ffi::Future CsrSparseDenseKernelImpl(
       });
       batch_start += size;
     }
-// EVOLVE-BLOCK-END
     return future;
   }
 }
+// EVOLVE-BLOCK-END
 
 template <typename ElementType, typename StorageType>
 static ffi::Future CsrSparseDenseKernelTypedDispatch(

--- a/jaxlib/cpu/sparse_kernels.cc
+++ b/jaxlib/cpu/sparse_kernels.cc
@@ -63,6 +63,7 @@ static ffi::Future CsrSparseDenseKernelImpl(
     return ffi::Future(promise);
   } else {
     std::vector<int64_t> batch_sizes;
+// EVOLVE-BLOCK-START
     {
       int64_t running_batch_nnz = 0;
       int64_t running_number_rows = 0;
@@ -84,10 +85,12 @@ static ffi::Future CsrSparseDenseKernelImpl(
         }
       }
     }
+// EVOLVE-BLOCK-END
 
     ffi::CountDownPromise promise(batch_sizes.size());
     ffi::Future future(promise);
     int64_t batch_start = 0;
+// EVOLVE-BLOCK-START
     for (int64_t size : batch_sizes) {
       thread_pool.Schedule([out_matrix, lhs_matrix, rhs_matrix, batch_start,
                             size, promise]() mutable {
@@ -97,6 +100,7 @@ static ffi::Future CsrSparseDenseKernelImpl(
       });
       batch_start += size;
     }
+// EVOLVE-BLOCK-END
     return future;
   }
 }

--- a/jaxlib/cpu/tridiagonal_solve_kernels.cc
+++ b/jaxlib/cpu/tridiagonal_solve_kernels.cc
@@ -56,6 +56,7 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
       auto* du_ptr = reinterpret_cast<const float*>(du_data);
       auto* b_ptr = reinterpret_cast<const float*>(b_data);
       auto* x_out_ptr = reinterpret_cast<float*>(x_out_data);
+// EVOLVE-BLOCK-START
       for (int64_t i = 0; i < batch_count; ++i) {
         SolveWithGaussianEliminationWithPivotingAndPerturbSingular<float>(
             b_rows, b_cols, dl_ptr, d_ptr, du_ptr, b_ptr, x_out_ptr,
@@ -66,6 +67,7 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
         b_ptr += b_step;
         x_out_ptr += b_step;
       }
+// EVOLVE-BLOCK-END
       break;
     }
     case ffi::DataType::F64: {
@@ -76,6 +78,7 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
       auto* du_ptr = reinterpret_cast<const double*>(du_data);
       auto* b_ptr = reinterpret_cast<const double*>(b_data);
       auto* x_out_ptr = reinterpret_cast<double*>(x_out_data);
+// EVOLVE-BLOCK-START
       for (int64_t i = 0; i < batch_count; ++i) {
         SolveWithGaussianEliminationWithPivotingAndPerturbSingular<double>(
             b_rows, b_cols, dl_ptr, d_ptr, du_ptr, b_ptr, x_out_ptr,
@@ -86,6 +89,7 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
         b_ptr += b_step;
         x_out_ptr += b_step;
       }
+// EVOLVE-BLOCK-END
       break;
     }
     case ffi::DataType::C64: {
@@ -96,6 +100,7 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
       auto* du_ptr = reinterpret_cast<const std::complex<float>*>(du_data);
       auto* b_ptr = reinterpret_cast<const std::complex<float>*>(b_data);
       auto* x_out_ptr = reinterpret_cast<std::complex<float>*>(x_out_data);
+// EVOLVE-BLOCK-START
       for (int64_t i = 0; i < batch_count; ++i) {
         SolveWithGaussianEliminationWithPivotingAndPerturbSingular<
             std::complex<float>>(b_rows, b_cols, dl_ptr, d_ptr, du_ptr, b_ptr,
@@ -107,6 +112,7 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
         b_ptr += b_step;
         x_out_ptr += b_step;
       }
+// EVOLVE-BLOCK-END
       break;
     }
     case ffi::DataType::C128: {
@@ -117,6 +123,7 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
       auto* du_ptr = reinterpret_cast<const std::complex<double>*>(du_data);
       auto* b_ptr = reinterpret_cast<const std::complex<double>*>(b_data);
       auto* x_out_ptr = reinterpret_cast<std::complex<double>*>(x_out_data);
+// EVOLVE-BLOCK-START
       for (int64_t i = 0; i < batch_count; ++i) {
         SolveWithGaussianEliminationWithPivotingAndPerturbSingular<
             std::complex<double>>(b_rows, b_cols, dl_ptr, d_ptr, du_ptr, b_ptr,
@@ -128,6 +135,7 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
         b_ptr += b_step;
         x_out_ptr += b_step;
       }
+// EVOLVE-BLOCK-END
       break;
     }
     default:

--- a/jaxlib/cpu/tridiagonal_solve_kernels.cc
+++ b/jaxlib/cpu/tridiagonal_solve_kernels.cc
@@ -27,6 +27,7 @@ namespace jax {
 
 namespace ffi = xla::ffi;
 
+// EVOLVE-BLOCK-START
 ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
                                             ffi::AnyBuffer du, ffi::AnyBuffer b,
                                             ffi::Result<ffi::AnyBuffer> x_out) {
@@ -56,7 +57,6 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
       auto* du_ptr = reinterpret_cast<const float*>(du_data);
       auto* b_ptr = reinterpret_cast<const float*>(b_data);
       auto* x_out_ptr = reinterpret_cast<float*>(x_out_data);
-// EVOLVE-BLOCK-START
       for (int64_t i = 0; i < batch_count; ++i) {
         SolveWithGaussianEliminationWithPivotingAndPerturbSingular<float>(
             b_rows, b_cols, dl_ptr, d_ptr, du_ptr, b_ptr, x_out_ptr,
@@ -67,7 +67,6 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
         b_ptr += b_step;
         x_out_ptr += b_step;
       }
-// EVOLVE-BLOCK-END
       break;
     }
     case ffi::DataType::F64: {
@@ -78,7 +77,6 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
       auto* du_ptr = reinterpret_cast<const double*>(du_data);
       auto* b_ptr = reinterpret_cast<const double*>(b_data);
       auto* x_out_ptr = reinterpret_cast<double*>(x_out_data);
-// EVOLVE-BLOCK-START
       for (int64_t i = 0; i < batch_count; ++i) {
         SolveWithGaussianEliminationWithPivotingAndPerturbSingular<double>(
             b_rows, b_cols, dl_ptr, d_ptr, du_ptr, b_ptr, x_out_ptr,
@@ -89,7 +87,6 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
         b_ptr += b_step;
         x_out_ptr += b_step;
       }
-// EVOLVE-BLOCK-END
       break;
     }
     case ffi::DataType::C64: {
@@ -100,7 +97,6 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
       auto* du_ptr = reinterpret_cast<const std::complex<float>*>(du_data);
       auto* b_ptr = reinterpret_cast<const std::complex<float>*>(b_data);
       auto* x_out_ptr = reinterpret_cast<std::complex<float>*>(x_out_data);
-// EVOLVE-BLOCK-START
       for (int64_t i = 0; i < batch_count; ++i) {
         SolveWithGaussianEliminationWithPivotingAndPerturbSingular<
             std::complex<float>>(b_rows, b_cols, dl_ptr, d_ptr, du_ptr, b_ptr,
@@ -112,7 +108,6 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
         b_ptr += b_step;
         x_out_ptr += b_step;
       }
-// EVOLVE-BLOCK-END
       break;
     }
     case ffi::DataType::C128: {
@@ -123,7 +118,6 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
       auto* du_ptr = reinterpret_cast<const std::complex<double>*>(du_data);
       auto* b_ptr = reinterpret_cast<const std::complex<double>*>(b_data);
       auto* x_out_ptr = reinterpret_cast<std::complex<double>*>(x_out_data);
-// EVOLVE-BLOCK-START
       for (int64_t i = 0; i < batch_count; ++i) {
         SolveWithGaussianEliminationWithPivotingAndPerturbSingular<
             std::complex<double>>(b_rows, b_cols, dl_ptr, d_ptr, du_ptr, b_ptr,
@@ -135,7 +129,6 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
         b_ptr += b_step;
         x_out_ptr += b_step;
       }
-// EVOLVE-BLOCK-END
       break;
     }
     default:
@@ -143,6 +136,7 @@ ffi::Error TridiagonalSolvePerturbedFfiImpl(ffi::AnyBuffer dl, ffi::AnyBuffer d,
   }
   return ffi::Error::Success();
 }
+// EVOLVE-BLOCK-END
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(tridiagonal_solve_perturbed_ffi,
                               TridiagonalSolvePerturbedFfiImpl,

--- a/jaxlib/gpu/householder_kernels.cu.cc
+++ b/jaxlib/gpu/householder_kernels.cu.cc
@@ -62,12 +62,15 @@ __global__ void ProductOfElementaryHouseholderReflectorsSmallBatchedLeftKernel(
   const T* tau = tau_data + batch_idx * k;
   T* c = c_data + batch_idx * m * n;  // c is m x n, ldc = m
 
+// EVOLVE-BLOCK-START
   if constexpr (IsOrgqr) {
     for (int r = 0; r < m; ++r) {
       c[r + col_idx * m] = (r == col_idx) ? T(1) : T(0);
     }
   }
+// EVOLVE-BLOCK-END
 
+// EVOLVE-BLOCK-START
   for (int step = 0; step < k; ++step) {
     // H_1...H_k * C applies H_k first (reverse), H_k^H...H_1^H * C applies
     // H_1^H first (forward)
@@ -82,10 +85,12 @@ __global__ void ProductOfElementaryHouseholderReflectorsSmallBatchedLeftKernel(
     // This thread's scalar w is the element W[col], i.e., w = v^H C[:, col].
     // Recall the 'v' vectors are packed into the lower triangle of `a`.
     T w = c[i + col_idx * m];  // Implicit leading `1` coefficient.
+// EVOLVE-BLOCK-START
     for (int r = i + 1; r < m; ++r) {
       // $w \leftarrow w + \overline{A_{r, i}} C_{r, \text{col}}$
       w = w + Eigen::numext::conj(a[r + i * lda]) * c[r + col_idx * m];
     }
+// EVOLVE-BLOCK-END
 
     T t_w = t * w;
     // The outer product update is $C \leftarrow C - \tau v W$, where $W = v^H
@@ -94,13 +99,16 @@ __global__ void ProductOfElementaryHouseholderReflectorsSmallBatchedLeftKernel(
     // $r = i$, $v_i = 1$:
     c[i + col_idx * m] = c[i + col_idx * m] - t_w;
     // For $r > i$, $v_r = A_{r, i}$:
+// EVOLVE-BLOCK-START
     for (int r = i + 1; r < m; ++r) {
       c[r + col_idx * m] = c[r + col_idx * m] - a[r + i * lda] * t_w;
     }
+// EVOLVE-BLOCK-END
   }
 #endif
 }
 
+// EVOLVE-BLOCK-START
 // Applies the product of elementary reflectors from the right (parallelized
 // over rows) to c, which is updated in-place. a, tau, and c_data are all
 // batch-major. The matrices must be column major within each batch element.
@@ -122,6 +130,7 @@ __global__ void ProductOfElementaryHouseholderReflectorsSmallBatchedRightKernel(
   const T* tau = tau_data + batch_idx * k;
   T* c = c_data + batch_idx * m * n;  // c is m x n, ldc = m
 
+// EVOLVE-BLOCK-START
   for (int step = 0; step < k; ++step) {
     // C * H_1...H_k applies H_1 first (forward), C * H_k^H...H_1^H applies
     // H_k^H first (reverse)
@@ -134,25 +143,30 @@ __global__ void ProductOfElementaryHouseholderReflectorsSmallBatchedRightKernel(
 
     // From $C H = C - \tau (C v) v^H$, let the column vector $U = C v$.
     T u = c[row_idx + i * m];
+// EVOLVE-BLOCK-START
     for (int col = i + 1; col < n; ++col) {
       // $u \leftarrow u + C_{\text{row}, c} A_{c, i}$
       u = u + c[row_idx + col * m] * a[col + i * lda];
     }
+// EVOLVE-BLOCK-END
 
     T u_t = u * t;
     // The row update is $c_{row} \leftarrow c_{row} - u_t v^H$. Since $v[i] =
     // 1$ and $v[col > i] = A_{col, i}$: $C_{\text{row}, i} \leftarrow
     // C_{\text{row}, i} - u_t$
     c[row_idx + i * m] = c[row_idx + i * m] - u_t;
+// EVOLVE-BLOCK-START
     for (int col = i + 1; col < n; ++col) {
       // $C_{\text{row}, col} \leftarrow C_{\text{row}, col} - u_t
       // \overline{A_{col, i}}$
       c[row_idx + col * m] =
           c[row_idx + col * m] - u_t * Eigen::numext::conj(a[col + i * lda]);
     }
+// EVOLVE-BLOCK-END
 
     // Each thread works on its own row.
   }
+// EVOLVE-BLOCK-END
 #endif
 }
 

--- a/jaxlib/gpu/householder_kernels.cu.cc
+++ b/jaxlib/gpu/householder_kernels.cu.cc
@@ -47,6 +47,7 @@ EIGEN_USING_STD_COMPLEX_OPERATORS
 // a, tau, and c_data are all batch-major. The matrices must be
 // column major within each batch element.
 template <typename T, bool IsOrgqr = false>
+// EVOLVE-BLOCK-START
 __global__ void ProductOfElementaryHouseholderReflectorsSmallBatchedLeftKernel(
     int batch, int m, int n, int k, int lda, int64_t a_stride, const T* a_data,
     const T* tau_data, T* c_data, bool transpose) {
@@ -62,15 +63,12 @@ __global__ void ProductOfElementaryHouseholderReflectorsSmallBatchedLeftKernel(
   const T* tau = tau_data + batch_idx * k;
   T* c = c_data + batch_idx * m * n;  // c is m x n, ldc = m
 
-// EVOLVE-BLOCK-START
   if constexpr (IsOrgqr) {
     for (int r = 0; r < m; ++r) {
       c[r + col_idx * m] = (r == col_idx) ? T(1) : T(0);
     }
   }
-// EVOLVE-BLOCK-END
 
-// EVOLVE-BLOCK-START
   for (int step = 0; step < k; ++step) {
     // H_1...H_k * C applies H_k first (reverse), H_k^H...H_1^H * C applies
     // H_1^H first (forward)
@@ -85,12 +83,10 @@ __global__ void ProductOfElementaryHouseholderReflectorsSmallBatchedLeftKernel(
     // This thread's scalar w is the element W[col], i.e., w = v^H C[:, col].
     // Recall the 'v' vectors are packed into the lower triangle of `a`.
     T w = c[i + col_idx * m];  // Implicit leading `1` coefficient.
-// EVOLVE-BLOCK-START
     for (int r = i + 1; r < m; ++r) {
       // $w \leftarrow w + \overline{A_{r, i}} C_{r, \text{col}}$
       w = w + Eigen::numext::conj(a[r + i * lda]) * c[r + col_idx * m];
     }
-// EVOLVE-BLOCK-END
 
     T t_w = t * w;
     // The outer product update is $C \leftarrow C - \tau v W$, where $W = v^H
@@ -99,22 +95,21 @@ __global__ void ProductOfElementaryHouseholderReflectorsSmallBatchedLeftKernel(
     // $r = i$, $v_i = 1$:
     c[i + col_idx * m] = c[i + col_idx * m] - t_w;
     // For $r > i$, $v_r = A_{r, i}$:
-// EVOLVE-BLOCK-START
     for (int r = i + 1; r < m; ++r) {
       c[r + col_idx * m] = c[r + col_idx * m] - a[r + i * lda] * t_w;
     }
-// EVOLVE-BLOCK-END
   }
 #endif
 }
+// EVOLVE-BLOCK-END
 
-// EVOLVE-BLOCK-START
 // Applies the product of elementary reflectors from the right (parallelized
 // over rows) to c, which is updated in-place. a, tau, and c_data are all
 // batch-major. The matrices must be column major within each batch element.
 // This kernel is similar to the left-sided kernel, except that each thread
 // computes a single row of the output.
 template <typename T>
+// EVOLVE-BLOCK-START
 __global__ void ProductOfElementaryHouseholderReflectorsSmallBatchedRightKernel(
     int batch, int m, int n, int k, int lda, int64_t a_stride, const T* a_data,
     const T* tau_data, T* c_data, bool transpose) {
@@ -130,7 +125,6 @@ __global__ void ProductOfElementaryHouseholderReflectorsSmallBatchedRightKernel(
   const T* tau = tau_data + batch_idx * k;
   T* c = c_data + batch_idx * m * n;  // c is m x n, ldc = m
 
-// EVOLVE-BLOCK-START
   for (int step = 0; step < k; ++step) {
     // C * H_1...H_k applies H_1 first (forward), C * H_k^H...H_1^H applies
     // H_k^H first (reverse)
@@ -143,36 +137,33 @@ __global__ void ProductOfElementaryHouseholderReflectorsSmallBatchedRightKernel(
 
     // From $C H = C - \tau (C v) v^H$, let the column vector $U = C v$.
     T u = c[row_idx + i * m];
-// EVOLVE-BLOCK-START
     for (int col = i + 1; col < n; ++col) {
       // $u \leftarrow u + C_{\text{row}, c} A_{c, i}$
       u = u + c[row_idx + col * m] * a[col + i * lda];
     }
-// EVOLVE-BLOCK-END
 
     T u_t = u * t;
     // The row update is $c_{row} \leftarrow c_{row} - u_t v^H$. Since $v[i] =
     // 1$ and $v[col > i] = A_{col, i}$: $C_{\text{row}, i} \leftarrow
     // C_{\text{row}, i} - u_t$
     c[row_idx + i * m] = c[row_idx + i * m] - u_t;
-// EVOLVE-BLOCK-START
     for (int col = i + 1; col < n; ++col) {
       // $C_{\text{row}, col} \leftarrow C_{\text{row}, col} - u_t
       // \overline{A_{col, i}}$
       c[row_idx + col * m] =
           c[row_idx + col * m] - u_t * Eigen::numext::conj(a[col + i * lda]);
     }
-// EVOLVE-BLOCK-END
 
     // Each thread works on its own row.
   }
-// EVOLVE-BLOCK-END
 #endif
 }
+// EVOLVE-BLOCK-END
 
 }  // namespace
 
 template <typename T>
+// EVOLVE-BLOCK-START
 gpuError_t LaunchOrmqrSmallBatchedKernel(gpuStream_t stream, int batch, int m,
                                          int n, int k, int lda,
                                          int64_t a_stride, const T* a,
@@ -197,8 +188,10 @@ gpuError_t LaunchOrmqrSmallBatchedKernel(gpuStream_t stream, int batch, int m,
   }
   return gpuGetLastError();
 }
+// EVOLVE-BLOCK-END
 
 template <typename T>
+// EVOLVE-BLOCK-START
 gpuError_t LaunchOrgqrSmallBatchedKernel(gpuStream_t stream, int batch, int m,
                                          int n, int k, int lda,
                                          int64_t a_stride, const T* a,
@@ -214,6 +207,7 @@ gpuError_t LaunchOrgqrSmallBatchedKernel(gpuStream_t stream, int batch, int m,
                                               tau, out, /*transpose=*/false);
   return gpuGetLastError();
 }
+// EVOLVE-BLOCK-END
 
 /// Explicit instantiations for real types
 template gpuError_t LaunchOrmqrSmallBatchedKernel<float>(
@@ -227,6 +221,7 @@ template gpuError_t LaunchOrmqrSmallBatchedKernel<double>(
     bool left, bool transpose);
 
 template <>
+// EVOLVE-BLOCK-START
 gpuError_t LaunchOrmqrSmallBatchedKernel<gpuComplex>(
     gpuStream_t stream, int batch, int m, int n, int k, int lda,
     int64_t a_stride, const gpuComplex* a, const gpuComplex* tau,
@@ -251,8 +246,10 @@ gpuError_t LaunchOrmqrSmallBatchedKernel<gpuComplex>(
   }
   return gpuGetLastError();
 }
+// EVOLVE-BLOCK-END
 
 template <>
+// EVOLVE-BLOCK-START
 gpuError_t LaunchOrmqrSmallBatchedKernel<gpuDoubleComplex>(
     gpuStream_t stream, int batch, int m, int n, int k, int lda,
     int64_t a_stride, const gpuDoubleComplex* a, const gpuDoubleComplex* tau,
@@ -277,6 +274,7 @@ gpuError_t LaunchOrmqrSmallBatchedKernel<gpuDoubleComplex>(
   }
   return gpuGetLastError();
 }
+// EVOLVE-BLOCK-END
 
 template gpuError_t LaunchOrgqrSmallBatchedKernel<float>(
     gpuStream_t stream, int batch, int m, int n, int k, int lda,
@@ -287,6 +285,7 @@ template gpuError_t LaunchOrgqrSmallBatchedKernel<double>(
     int64_t a_stride, const double* a, const double* tau, double* out);
 
 template <>
+// EVOLVE-BLOCK-START
 gpuError_t LaunchOrgqrSmallBatchedKernel<gpuComplex>(
     gpuStream_t stream, int batch, int m, int n, int k, int lda,
     int64_t a_stride, const gpuComplex* a, const gpuComplex* tau,
@@ -301,8 +300,10 @@ gpuError_t LaunchOrgqrSmallBatchedKernel<gpuComplex>(
       reinterpret_cast<std::complex<float>*>(out), /*transpose=*/false);
   return gpuGetLastError();
 }
+// EVOLVE-BLOCK-END
 
 template <>
+// EVOLVE-BLOCK-START
 gpuError_t LaunchOrgqrSmallBatchedKernel<gpuDoubleComplex>(
     gpuStream_t stream, int batch, int m, int n, int k, int lda,
     int64_t a_stride, const gpuDoubleComplex* a, const gpuDoubleComplex* tau,
@@ -317,6 +318,7 @@ gpuError_t LaunchOrgqrSmallBatchedKernel<gpuDoubleComplex>(
       reinterpret_cast<std::complex<double>*>(out), /*transpose=*/false);
   return gpuGetLastError();
 }
+// EVOLVE-BLOCK-END
 
 }  // namespace JAX_GPU_NAMESPACE
 }  // namespace jax

--- a/jaxlib/gpu/hybrid_kernels.cc
+++ b/jaxlib/gpu/hybrid_kernels.cc
@@ -246,6 +246,7 @@ class PivotingQrFactorizationHost {
   explicit PivotingQrFactorizationHost() = default;
   PivotingQrFactorizationHost(PivotingQrFactorizationHost&&) = default;
 
+// EVOLVE-BLOCK-START
   ffi::Error compute(int64_t batch, int64_t rows, int64_t cols,
                      gpuStream_t stream, ffi::ScratchAllocator& scratch,
                      ffi::AnyBuffer x, ffi::AnyBuffer jpvt,
@@ -322,6 +323,7 @@ class PivotingQrFactorizationHost {
     FFI_RETURN_IF_ERROR_STATUS(JAX_AS_STATUS(gpuStreamSynchronize(stream)));
     return ffi::Error::Success();
   }
+// EVOLVE-BLOCK-END
 
  private:
   absl::StatusOr<IntType> lwork(IntType m, IntType n) {
@@ -348,6 +350,7 @@ class PivotingQrFactorizationMagma {
   explicit PivotingQrFactorizationMagma() = default;
   PivotingQrFactorizationMagma(PivotingQrFactorizationMagma&&) = default;
 
+// EVOLVE-BLOCK-START
   ffi::Error compute(int64_t batch, int64_t rows, int64_t cols,
                      gpuStream_t stream, ffi::ScratchAllocator& scratch,
                      ffi::AnyBuffer x, ffi::AnyBuffer jpvt,
@@ -399,6 +402,7 @@ class PivotingQrFactorizationMagma {
     FFI_RETURN_IF_ERROR_STATUS(JAX_AS_STATUS(gpuStreamSynchronize(stream)));
     return ffi::Error::Success();
   }
+// EVOLVE-BLOCK-END
 
  private:
   Fn* fn_ = nullptr;
@@ -598,6 +602,7 @@ class EigRealMagma {
   Fn* fn_ = nullptr;
 };
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType DataType, typename IntType, typename Impl>
 ffi::Error EigReal(Impl impl, int64_t batch, int64_t cols, gpuStream_t stream,
                    bool left, bool right, ffi::AnyBuffer x,
@@ -674,6 +679,7 @@ ffi::Error EigReal(Impl impl, int64_t batch, int64_t cols, gpuStream_t stream,
 
   return ffi::Error::Success();
 }
+// EVOLVE-BLOCK-END
 
 ffi::Error EigRealDispatch(gpuStream_t stream, std::string_view magma,
                            bool left, bool right, ffi::AnyBuffer x,
@@ -841,6 +847,7 @@ class EigCompMagma {
   Fn* fn_ = nullptr;
 };
 
+// EVOLVE-BLOCK-START
 template <ffi::DataType DataType, typename IntType, typename Impl>
 ffi::Error EigComp(Impl impl, int64_t batch, int64_t cols, gpuStream_t stream,
                    bool left, bool right, ffi::AnyBuffer x,
@@ -904,6 +911,7 @@ ffi::Error EigComp(Impl impl, int64_t batch, int64_t cols, gpuStream_t stream,
 
   return ffi::Error::Success();
 }
+// EVOLVE-BLOCK-END
 
 ffi::Error EigCompDispatch(gpuStream_t stream, std::string_view magma,
                            bool left, bool right, ffi::AnyBuffer x,

--- a/jaxlib/gpu/linalg_kernels.cc
+++ b/jaxlib/gpu/linalg_kernels.cc
@@ -73,11 +73,13 @@ ffi::Error CholeskyUpdateFfiImpl(gpuStream_t stream, ffi::AnyBuffer matrix_in,
         gpuMemcpyAsync(vector, vector_in.untyped_data(), vector_in.size_bytes(),
                        gpuMemcpyDeviceToDevice, stream)));
   }
+// EVOLVE-BLOCK-START
   for (auto n = 0; n < batch; ++n) {
     FFI_RETURN_IF_ERROR_STATUS(JAX_AS_STATUS(LaunchCholeskyUpdateFfiKernel(
         stream, matrix, vector, size, is_single_precision)));
     FFI_RETURN_IF_ERROR_STATUS(JAX_AS_STATUS(gpuGetLastError()));
   }
+// EVOLVE-BLOCK-END
   return ffi::Error::Success();
 }
 }  // namespace

--- a/jaxlib/gpu/linalg_kernels.cc
+++ b/jaxlib/gpu/linalg_kernels.cc
@@ -32,6 +32,7 @@ namespace JAX_GPU_NAMESPACE {
 namespace ffi = xla::ffi;
 
 namespace {
+// EVOLVE-BLOCK-START
 ffi::Error CholeskyUpdateFfiImpl(gpuStream_t stream, ffi::AnyBuffer matrix_in,
                                  ffi::AnyBuffer vector_in,
                                  ffi::Result<ffi::AnyBuffer> matrix_out,
@@ -73,15 +74,14 @@ ffi::Error CholeskyUpdateFfiImpl(gpuStream_t stream, ffi::AnyBuffer matrix_in,
         gpuMemcpyAsync(vector, vector_in.untyped_data(), vector_in.size_bytes(),
                        gpuMemcpyDeviceToDevice, stream)));
   }
-// EVOLVE-BLOCK-START
   for (auto n = 0; n < batch; ++n) {
     FFI_RETURN_IF_ERROR_STATUS(JAX_AS_STATUS(LaunchCholeskyUpdateFfiKernel(
         stream, matrix, vector, size, is_single_precision)));
     FFI_RETURN_IF_ERROR_STATUS(JAX_AS_STATUS(gpuGetLastError()));
   }
-// EVOLVE-BLOCK-END
   return ffi::Error::Success();
 }
+// EVOLVE-BLOCK-END
 }  // namespace
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(CholeskyUpdateFfi, CholeskyUpdateFfiImpl,
@@ -93,6 +93,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(CholeskyUpdateFfi, CholeskyUpdateFfiImpl,
                                   .Ret<ffi::AnyBuffer>());
 
 namespace {
+// EVOLVE-BLOCK-START
 ffi::Error LuPivotsToPermutationImpl(
     gpuStream_t stream, ffi::Buffer<ffi::DataType::S32> pivots,
     ffi::Result<ffi::Buffer<ffi::DataType::S32>> permutation) {
@@ -117,6 +118,7 @@ ffi::Error LuPivotsToPermutationImpl(
   FFI_RETURN_IF_ERROR_STATUS(JAX_AS_STATUS(gpuGetLastError()));
   return ffi::Error::Success();
 }
+// EVOLVE-BLOCK-END
 }  // namespace
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(LuPivotsToPermutation, LuPivotsToPermutationImpl,
@@ -126,6 +128,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(LuPivotsToPermutation, LuPivotsToPermutationImpl,
                                   .Ret<ffi::Buffer<ffi::DataType::S32>>());
 
 namespace {
+// EVOLVE-BLOCK-START
 ffi::Error TridiagonalSolvePerturbedImpl(
     gpuStream_t stream, ffi::ScratchAllocator scratch, ffi::AnyBuffer subdiag,
     ffi::AnyBuffer diag, ffi::AnyBuffer superdiag, ffi::AnyBuffer rhs,
@@ -177,6 +180,7 @@ ffi::Error TridiagonalSolvePerturbedImpl(
   FFI_RETURN_IF_ERROR_STATUS(JAX_AS_STATUS(gpuGetLastError()));
   return ffi::Error::Success();
 }
+// EVOLVE-BLOCK-END
 }  // namespace
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(TridiagonalSolvePerturbedFfi,

--- a/jaxlib/gpu/linalg_kernels.cu.cc
+++ b/jaxlib/gpu/linalg_kernels.cu.cc
@@ -32,8 +32,8 @@ namespace JAX_GPU_NAMESPACE {
 
 namespace {
 
-template <typename T>
 // EVOLVE-BLOCK-START
+template <typename T>
 __device__ void drotg(T* da, T* db, T* c, T* s) {
   if (*db == 0) {
     *c = 1.;
@@ -49,6 +49,7 @@ __device__ void drotg(T* da, T* db, T* c, T* s) {
 }
 // EVOLVE-BLOCK-END
 
+// EVOLVE-BLOCK-START
 template <typename T>
 __global__ void CholeskyUpdateKernel(T* rMatrix, T* uVector, int nSize) {
   cg::grid_group grid = cg::this_grid();
@@ -56,7 +57,6 @@ __global__ void CholeskyUpdateKernel(T* rMatrix, T* uVector, int nSize) {
 
   T c, s;
 
-// EVOLVE-BLOCK-START
   for (int step = 0; step < 2 * nSize; ++step) {
     grid.sync();
 
@@ -71,10 +71,11 @@ __global__ void CholeskyUpdateKernel(T* rMatrix, T* uVector, int nSize) {
     uVector[i] = s * rMatrix[k * nSize + i] + c * uVector[i];
     rMatrix[k * nSize + i] = r_i;
   }
-// EVOLVE-BLOCK-END
 }
+// EVOLVE-BLOCK-END
 }  // namespace
 
+// EVOLVE-BLOCK-START
 template <typename T>
 gpuError_t LaunchCholeskyUpdateFfiKernelBody(gpuStream_t stream, void* matrix,
                                              void* vector, int grid_dim,
@@ -113,6 +114,7 @@ gpuError_t LaunchCholeskyUpdateFfiKernel(gpuStream_t stream, void* matrix,
                                                      grid_dim, block_dim, size);
   }
 }
+// EVOLVE-BLOCK-END
 
 namespace {
 
@@ -156,6 +158,7 @@ __global__ void LuPivotsToPermutationKernel(
 
 }  // namespace
 
+// EVOLVE-BLOCK-START
 void LaunchLuPivotsToPermutationKernel(gpuStream_t stream,
                                        std::int64_t batch_size,
                                        std::int32_t pivot_size,
@@ -170,11 +173,12 @@ void LaunchLuPivotsToPermutationKernel(gpuStream_t stream,
                                 /*dynamic_shared_mem_bytes=*/0, stream>>>(
       pivots, permutation, batch_size, pivot_size, permutation_size);
 }
+// EVOLVE-BLOCK-END
 
 namespace {
 
-template <typename T>
 // EVOLVE-BLOCK-START
+template <typename T>
 __global__ void TridiagonalSolvePerturbedKernel(
     std::int64_t batch_size, int n, int k_rhs, const T* subdiag, const T* diag,
     const T* superdiag, const T* rhs, T* x, void* workspace) {
@@ -191,6 +195,7 @@ __global__ void TridiagonalSolvePerturbedKernel(
 }
 // EVOLVE-BLOCK-END
 
+// EVOLVE-BLOCK-START
 template <typename T>
 void LaunchTridiagonalSolvePerturbedKernelBody(
     gpuStream_t stream, std::int64_t batch_size, int n, int k_rhs,
@@ -208,9 +213,11 @@ void LaunchTridiagonalSolvePerturbedKernelBody(
           reinterpret_cast<const T*>(superdiag),
           reinterpret_cast<const T*>(rhs), reinterpret_cast<T*>(x), workspace);
 }
+// EVOLVE-BLOCK-END
 
 }  // namespace
 
+// EVOLVE-BLOCK-START
 void LaunchTridiagonalSolvePerturbedKernel(
     gpuStream_t stream, std::int64_t batch_size, int n, int k_rhs,
     xla::ffi::DataType dtype, const void* subdiag, const void* diag,
@@ -248,6 +255,7 @@ void LaunchTridiagonalSolvePerturbedKernel(
       break;
   }
 }
+// EVOLVE-BLOCK-END
 
 }  // namespace JAX_GPU_NAMESPACE
 }  // namespace jax

--- a/jaxlib/gpu/linalg_kernels.cu.cc
+++ b/jaxlib/gpu/linalg_kernels.cu.cc
@@ -33,6 +33,7 @@ namespace JAX_GPU_NAMESPACE {
 namespace {
 
 template <typename T>
+// EVOLVE-BLOCK-START
 __device__ void drotg(T* da, T* db, T* c, T* s) {
   if (*db == 0) {
     *c = 1.;
@@ -46,6 +47,7 @@ __device__ void drotg(T* da, T* db, T* c, T* s) {
   *c = a * rh;
   *s = -(b * rh);
 }
+// EVOLVE-BLOCK-END
 
 template <typename T>
 __global__ void CholeskyUpdateKernel(T* rMatrix, T* uVector, int nSize) {
@@ -54,6 +56,7 @@ __global__ void CholeskyUpdateKernel(T* rMatrix, T* uVector, int nSize) {
 
   T c, s;
 
+// EVOLVE-BLOCK-START
   for (int step = 0; step < 2 * nSize; ++step) {
     grid.sync();
 
@@ -68,6 +71,7 @@ __global__ void CholeskyUpdateKernel(T* rMatrix, T* uVector, int nSize) {
     uVector[i] = s * rMatrix[k * nSize + i] + c * uVector[i];
     rMatrix[k * nSize + i] = r_i;
   }
+// EVOLVE-BLOCK-END
 }
 }  // namespace
 
@@ -112,6 +116,7 @@ gpuError_t LaunchCholeskyUpdateFfiKernel(gpuStream_t stream, void* matrix,
 
 namespace {
 
+// EVOLVE-BLOCK-START
 __device__ void ComputePermutation(const std::int32_t* pivots,
                                    std::int32_t* permutation_out,
                                    const std::int32_t pivot_size,
@@ -132,7 +137,9 @@ __device__ void ComputePermutation(const std::int32_t* pivots,
     permutation_out[pivots[i]] = swap_temporary;
   }
 }
+// EVOLVE-BLOCK-END
 
+// EVOLVE-BLOCK-START
 __global__ void LuPivotsToPermutationKernel(
     const std::int32_t* pivots, std::int32_t* permutation_out,
     const std::int64_t batch_size, const std::int32_t pivot_size,
@@ -145,6 +152,7 @@ __global__ void LuPivotsToPermutationKernel(
                        permutation_size);
   }
 }
+// EVOLVE-BLOCK-END
 
 }  // namespace
 
@@ -166,6 +174,7 @@ void LaunchLuPivotsToPermutationKernel(gpuStream_t stream,
 namespace {
 
 template <typename T>
+// EVOLVE-BLOCK-START
 __global__ void TridiagonalSolvePerturbedKernel(
     std::int64_t batch_size, int n, int k_rhs, const T* subdiag, const T* diag,
     const T* superdiag, const T* rhs, T* x, void* workspace) {
@@ -180,6 +189,7 @@ __global__ void TridiagonalSolvePerturbedKernel(
         rhs_row_workspace);
   }
 }
+// EVOLVE-BLOCK-END
 
 template <typename T>
 void LaunchTridiagonalSolvePerturbedKernelBody(

--- a/jaxlib/gpu/prng_kernels.cu.cc
+++ b/jaxlib/gpu/prng_kernels.cu.cc
@@ -25,6 +25,7 @@ namespace JAX_GPU_NAMESPACE {
 namespace {
 
 __global__ void ThreeFry2x32Kernel(const std::uint32_t* key0,
+// EVOLVE-BLOCK-START
                                    const std::uint32_t* key1,
                                    const std::uint32_t* data0,
                                    const std::uint32_t* data1,
@@ -69,43 +70,33 @@ __global__ void ThreeFry2x32Kernel(const std::uint32_t* key0,
     // We are conservative and use 20 rounds.
     x[0] = x[0] + ks[0];
     x[1] = x[1] + ks[1];
-// EVOLVE-BLOCK-START
     for (int i = 0; i < 4; ++i) {
       round(x, rotations[i]);
     }
-// EVOLVE-BLOCK-END
 
     x[0] = x[0] + ks[1];
     x[1] = x[1] + ks[2] + 1u;
-// EVOLVE-BLOCK-START
     for (int i = 4; i < 8; ++i) {
       round(x, rotations[i]);
     }
-// EVOLVE-BLOCK-END
 
     x[0] = x[0] + ks[2];
     x[1] = x[1] + ks[0] + 2u;
-// EVOLVE-BLOCK-START
     for (int i = 0; i < 4; ++i) {
       round(x, rotations[i]);
     }
-// EVOLVE-BLOCK-END
 
     x[0] = x[0] + ks[0];
     x[1] = x[1] + ks[1] + 3u;
-// EVOLVE-BLOCK-START
     for (int i = 4; i < 8; ++i) {
       round(x, rotations[i]);
     }
-// EVOLVE-BLOCK-END
 
     x[0] = x[0] + ks[1];
     x[1] = x[1] + ks[2] + 4u;
-// EVOLVE-BLOCK-START
     for (int i = 0; i < 4; ++i) {
       round(x, rotations[i]);
     }
-// EVOLVE-BLOCK-END
 
     out0[idx] = x[0] + ks[2];
     out1[idx] = x[1] + ks[0] + 5u;
@@ -115,6 +106,7 @@ __global__ void ThreeFry2x32Kernel(const std::uint32_t* key0,
 }  // namespace
 
 void LaunchThreeFry2x32KernelFfi(gpuStream_t stream, std::int64_t n,
+// EVOLVE-BLOCK-START
                                  std::uint32_t* keys0, std::uint32_t* keys1,
                                  std::uint32_t* data0, std::uint32_t* data1,
                                  std::uint32_t* out0, std::uint32_t* out1) {
@@ -125,6 +117,7 @@ void LaunchThreeFry2x32KernelFfi(gpuStream_t stream, std::int64_t n,
                        stream>>>(keys0, keys1, data0, data1, out0, out1, n,
                                  nullptr);
 }
+// EVOLVE-BLOCK-END
 
 }  // namespace JAX_GPU_NAMESPACE
 }  // namespace jax

--- a/jaxlib/gpu/prng_kernels.cu.cc
+++ b/jaxlib/gpu/prng_kernels.cu.cc
@@ -69,33 +69,43 @@ __global__ void ThreeFry2x32Kernel(const std::uint32_t* key0,
     // We are conservative and use 20 rounds.
     x[0] = x[0] + ks[0];
     x[1] = x[1] + ks[1];
+// EVOLVE-BLOCK-START
     for (int i = 0; i < 4; ++i) {
       round(x, rotations[i]);
     }
+// EVOLVE-BLOCK-END
 
     x[0] = x[0] + ks[1];
     x[1] = x[1] + ks[2] + 1u;
+// EVOLVE-BLOCK-START
     for (int i = 4; i < 8; ++i) {
       round(x, rotations[i]);
     }
+// EVOLVE-BLOCK-END
 
     x[0] = x[0] + ks[2];
     x[1] = x[1] + ks[0] + 2u;
+// EVOLVE-BLOCK-START
     for (int i = 0; i < 4; ++i) {
       round(x, rotations[i]);
     }
+// EVOLVE-BLOCK-END
 
     x[0] = x[0] + ks[0];
     x[1] = x[1] + ks[1] + 3u;
+// EVOLVE-BLOCK-START
     for (int i = 4; i < 8; ++i) {
       round(x, rotations[i]);
     }
+// EVOLVE-BLOCK-END
 
     x[0] = x[0] + ks[1];
     x[1] = x[1] + ks[2] + 4u;
+// EVOLVE-BLOCK-START
     for (int i = 0; i < 4; ++i) {
       round(x, rotations[i]);
     }
+// EVOLVE-BLOCK-END
 
     out0[idx] = x[0] + ks[2];
     out1[idx] = x[1] + ks[0] + 5u;

--- a/jaxlib/gpu/solver_kernels_ffi.cc
+++ b/jaxlib/gpu/solver_kernels_ffi.cc
@@ -104,6 +104,7 @@ inline absl::StatusOr<gpuDataType> SolverDataType(ffi::DataType dataType,
 
 // LU decomposition: getrf
 
+// EVOLVE-BLOCK-START
 template <typename T>
 ffi::Error GetrfImpl(int64_t batch, int64_t rows, int64_t cols,
                      gpuStream_t stream, ffi::ScratchAllocator& scratch,
@@ -205,9 +206,11 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(GetrfFfi, GetrfDispatch,
                                   .Ret<ffi::Buffer<ffi::S32>>()  // ipiv
                                   .Ret<ffi::Buffer<ffi::S32>>()  // info
 );
+// EVOLVE-BLOCK-END
 
 // QR decomposition: geqrf
 
+// EVOLVE-BLOCK-START
 template <typename T>
 ffi::Error GeqrfImpl(int64_t batch, int64_t rows, int64_t cols,
                      gpuStream_t stream, ffi::ScratchAllocator& scratch,
@@ -316,9 +319,11 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(GeqrfFfi, GeqrfDispatch,
                                   .Ret<ffi::AnyBuffer>()  // out
                                   .Ret<ffi::AnyBuffer>()  // tau
 );
+// EVOLVE-BLOCK-END
 
 // Householder transformations: orgqr
 
+// EVOLVE-BLOCK-START
 template <typename T>
 ffi::Error OrgqrImpl(int64_t batch, int64_t rows, int64_t cols, int64_t size,
                      gpuStream_t stream, ffi::ScratchAllocator& scratch,
@@ -413,6 +418,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(OrgqrFfi, OrgqrDispatch,
                                   .Arg<ffi::AnyBuffer>()  // tau
                                   .Ret<ffi::AnyBuffer>()  // out
 );
+// EVOLVE-BLOCK-END
 
 // Householder multiply: ormqr/unmqr
 
@@ -427,6 +433,7 @@ gpublasOperation_t TransposeOp() {
   }
 }
 
+// EVOLVE-BLOCK-START
 template <typename T>
 ffi::Error OrmqrImpl(int64_t batch, int64_t c_rows, int64_t c_cols, int64_t k,
                      int64_t a_rows, int64_t a_cols, bool left, bool transpose,
@@ -521,9 +528,11 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(OrmqrFfi, OrmqrDispatch,
                                   .Attr<bool>("transpose")
                                   .Ret<ffi::AnyBuffer>()  // out
 );
+// EVOLVE-BLOCK-END
 
 // Cholesky decomposition: potrf
 
+// EVOLVE-BLOCK-START
 template <typename T>
 ffi::Error PotrfImpl(int64_t batch, int64_t size, gpuStream_t stream,
                      ffi::ScratchAllocator& scratch, bool lower,
@@ -627,6 +636,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(PotrfFfi, PotrfDispatch,
                                   .Ret<ffi::AnyBuffer>()         // out
                                   .Ret<ffi::Buffer<ffi::S32>>()  // info
 );
+// EVOLVE-BLOCK-END
 
 // Symmetric (Hermitian) eigendecomposition:
 // * Jacobi algorithm: syevj/heevj (batches of matrices up to 32)
@@ -647,6 +657,7 @@ absl::StatusOr<bool> IsSyevBatchedSupported() {
   return version >= 11701;
 }
 
+// EVOLVE-BLOCK-START
 ffi::Error Syevd64Impl(int64_t batch, int64_t n, gpuStream_t stream,
                        ffi::ScratchAllocator& scratch, bool lower,
                        ffi::AnyBuffer a, ffi::Result<ffi::AnyBuffer> out,
@@ -884,9 +895,11 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(SyevdFfi, SyevdDispatch,
                                   .Ret<ffi::AnyBuffer>()         // w
                                   .Ret<ffi::Buffer<ffi::S32>>()  // info
 );
+// EVOLVE-BLOCK-END
 
 // Symmetric rank-k update: syrk
 
+// EVOLVE-BLOCK-START
 template <typename T>
 ffi::Error SyrkImpl(gpuStream_t stream, bool transpose, ffi::AnyBuffer a,
                     ffi::AnyBuffer c_in, ffi::AnyBuffer alpha,
@@ -962,9 +975,11 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(SyrkFfi, SyrkDispatch,
                                   .Arg<ffi::AnyBuffer>()    // beta
                                   .Ret<ffi::AnyBuffer>()    // c_out
 );
+// EVOLVE-BLOCK-END
 
 // Singular Value Decomposition: gesvd
 
+// EVOLVE-BLOCK-START
 #if JAX_GPU_HAVE_64_BIT
 
 ffi::Error Gesvd64Impl(int64_t batch, int64_t m, int64_t n, gpuStream_t stream,
@@ -1156,7 +1171,9 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(GesvdFfi, GesvdDispatch,
                                   .Ret<ffi::AnyBuffer>()         // vt
                                   .Ret<ffi::Buffer<ffi::S32>>()  // info
 );
+// EVOLVE-BLOCK-END
 
+// EVOLVE-BLOCK-START
 template <typename T>
 ffi::Error GesvdjImpl(int64_t batch, int64_t rows, int64_t cols,
                       gpuStream_t stream, ffi::ScratchAllocator& scratch,
@@ -1278,6 +1295,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(GesvdjFfi, GesvdjDispatch,
                                   .Ret<ffi::AnyBuffer>()         // v
                                   .Ret<ffi::Buffer<ffi::S32>>()  // info
 );
+// EVOLVE-BLOCK-END
 
 #ifdef JAX_GPU_HIP
 // Workspace size from LAPACK formula instead of querying rocsolver. A
@@ -1317,6 +1335,7 @@ size_t GesddWorkspaceSizeFromFormula(signed char job, int m, int n) {
 }  // namespace
 
 // Singular Value Decomposition (divide-and-conquer): gesdd (ROCm rocsolver).
+// EVOLVE-BLOCK-START
 template <typename T>
 ffi::Error GesddImpl(int64_t batch, int64_t rows, int64_t cols,
                      gpuStream_t stream, ffi::ScratchAllocator& scratch,
@@ -1438,10 +1457,11 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(GesddFfi, GesddDispatch,
                                   .Ret<ffi::AnyBuffer>()         // vt
                                   .Ret<ffi::Buffer<ffi::S32>>()  // info
 );
+// EVOLVE-BLOCK-END
 #endif  // JAX_GPU_HIP
 
 // Singular Value Decomposition: gesvdp (Polar decomposition)
-
+// EVOLVE-BLOCK-START
 #ifdef JAX_GPU_CUDA
 
 ffi::Error GesvdpImpl(int64_t batch, int64_t m, int64_t n, gpuStream_t stream,
@@ -1570,9 +1590,10 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(GesvdpFfi, GesvdpDispatch,
                                   .Ret<ffi::AnyBuffer>()         // v
                                   .Ret<ffi::Buffer<ffi::S32>>()  // info
 );
+// EVOLVE-BLOCK-END
 
 // csrlsvqr: Linear system solve via Sparse QR
-
+// EVOLVE-BLOCK-START
 template <typename T>
 ffi::Error CsrlsvqrImpl(int64_t n, int64_t nnz, double tol, int reorder,
                         gpuStream_t stream, ffi::AnyBuffer csrValA,
@@ -1646,11 +1667,12 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(CsrlsvqrFfi, CsrlsvqrDispatch,
                                   .Arg<ffi::AnyBuffer>()         // b
                                   .Ret<ffi::AnyBuffer>()         // x
 );
+// EVOLVE-BLOCK-END
 
 #endif  // JAX_GPU_CUDA
 
 // Symmetric tridiagonal reduction: sytrd
-
+// EVOLVE-BLOCK-START
 template <typename T>
 ffi::Error SytrdImpl(int64_t batch, int64_t size, gpuStream_t stream,
                      ffi::ScratchAllocator& scratch, bool lower,
@@ -1743,9 +1765,10 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(SytrdFfi, SytrdDispatch,
                                   .Ret<ffi::AnyBuffer>()         // tau
                                   .Ret<ffi::Buffer<ffi::S32>>()  // info
 );
+// EVOLVE-BLOCK-END
 
 // General eigenvalue decomposition: geev
-
+// EVOLVE-BLOCK-START
 #if JAX_GPU_HAVE_SOLVER_GEEV
 
 ffi::Error GeevImpl(gpuStream_t stream, ffi::ScratchAllocator scratch,
@@ -1867,6 +1890,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(GeevFfi, GeevImpl,
                                   .Ret<ffi::AnyBuffer>()         // vr
                                   .Ret<ffi::Buffer<ffi::S32>>()  // info
 );
+// EVOLVE-BLOCK-END
 
 #endif  // JAX_GPU_HAVE_SOLVER_GEEV
 

--- a/jaxlib/tridiagonal_solve_perturbed.h
+++ b/jaxlib/tridiagonal_solve_perturbed.h
@@ -68,6 +68,7 @@ namespace jax {
 // the i'th row of the solution as rhs[i,:] * (1 / pivot). This logic is
 // extracted from the LAPACK routine xLAGTS.
 template <typename Scalar, typename Derived>
+// EVOLVE-BLOCK-START
 EIGEN_DEVICE_FUNC void MaybePerturbPivot(
     typename Eigen::NumTraits<Scalar>::Real perturb, Scalar& pivot,
     Eigen::DenseBase<Derived>& rhs_row) {
@@ -85,7 +86,6 @@ EIGEN_DEVICE_FUNC void MaybePerturbPivot(
            : small * (one + std::numeric_limits<RealScalar>::epsilon()));
   constexpr RealScalar bignum = one / safemin;
 
-// EVOLVE-BLOCK-START
   RealScalar abs_pivot = Eigen::numext::abs(pivot);
   if (abs_pivot >= one) {
     return;
@@ -101,7 +101,6 @@ EIGEN_DEVICE_FUNC void MaybePerturbPivot(
   const RealScalar max_factor = rhs_row.derived().array().abs().maxCoeff();
 
   while (abs_pivot < one && !stop) {
-// EVOLVE-BLOCK-START
     if (abs_pivot < safemin) {
       if (abs_pivot == RealScalar(0.0) || max_factor * safemin > abs_pivot) {
         pivot += perturb;
@@ -118,10 +117,9 @@ EIGEN_DEVICE_FUNC void MaybePerturbPivot(
       stop = true;
     }
     abs_pivot = Eigen::numext::abs(pivot);
-// EVOLVE-BLOCK-END
   }
-// EVOLVE-BLOCK-END
 }
+// EVOLVE-BLOCK-END
 
 // This function roughly follows LAPACK's xLAGTF + xLAGTS routines.
 //
@@ -145,12 +143,12 @@ EIGEN_DEVICE_FUNC void MaybePerturbPivot(
 // and pivoting information, and the forward solve is done on-the-fly
 // during factorization, instead of requiring a separate loop.
 template <typename Scalar>
+// EVOLVE-BLOCK-START
 EIGEN_DEVICE_FUNC void
 SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
     int n, int k_rhs, const Scalar* subdiag_ptr, const Scalar* diag_ptr,
     const Scalar* superdiag_ptr, const Scalar* rhs_ptr, Scalar* x_ptr,
     Scalar* u_workspace, Scalar* rhs_row_workspace) {
-// EVOLVE-BLOCK-START
   using RealScalar = typename Eigen::NumTraits<Scalar>::Real;
   using InputMatrixMap =
       Eigen::Map<const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic,
@@ -203,14 +201,17 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
   RealScalar scale1 = Eigen::numext::abs(u(0, 0)) + Eigen::numext::abs(u(0, 1));
   x.row(0) = rhs.row(0);
 
-// EVOLVE-BLOCK-START
   for (int k = 0; k < n - 1; ++k) {
+    // The non-zeros in the (k+1)-st row are
+    //    [ ... subdiag(k+1) (diag(k+1)-shift) superdiag(k+1) ... ]
     u(k + 1, 0) = diag(k + 1);
     RealScalar scale2 =
         Eigen::numext::abs(subdiag(k + 1)) + Eigen::numext::abs(u(k + 1, 0));
     if (k < n - 2) scale2 += Eigen::numext::abs(superdiag(k + 1));
 
     if (subdiag(k + 1) == zero) {
+      // The sub-diagonal in the k+1 row is already zero. Move to the next
+      // row.
       scale1 = scale2;
       u(k + 1, 1) = superdiag(k + 1);
       u(k, 2) = zero;
@@ -221,6 +222,7 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
       const RealScalar piv2 = Eigen::numext::abs(subdiag(k + 1)) / scale2;
 
       if (piv2 <= piv1) {
+        // No row pivoting needed.
         scale1 = scale2;
         const Scalar factor = subdiag(k + 1) / u(k, 0);
         u(k + 1, 0) -= factor * u(k, 1);
@@ -228,6 +230,7 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
         u(k, 2) = zero;
         x.row(k + 1) = rhs.row(k + 1) - factor * x.row(k);
       } else {
+        // Swap rows k and k+1
         const Scalar factor = u(k, 0) / subdiag(k + 1);
         const Scalar utmp = u(k, 1);
         u(k, 0) = subdiag(k + 1);
@@ -246,14 +249,11 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
       }
     }
     if (k < n - 2) {
-// EVOLVE-BLOCK-START
       for (int i = 0; i < 3; ++i) {
         max_abs_u = std::max(max_abs_u, Eigen::numext::abs(u(k, i)));
       }
-// EVOLVE-BLOCK-END
     }
   }
-// EVOLVE-BLOCK-END
   max_abs_u = std::max(max_abs_u, Eigen::numext::abs(u(n - 1, 0)));
 
   RealScalar eps = std::numeric_limits<RealScalar>::epsilon();
@@ -277,16 +277,14 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
     x.row(n - 2) = rhs_row * (Scalar(1.0) / p);
   }
 
-// EVOLVE-BLOCK-START
   for (int k = n - 3; k >= 0; --k) {
     p = u(k, 0);
     rhs_row = x.row(k) - u(k, 1) * x.row(k + 1) - u(k, 2) * x.row(k + 2);
     MaybePerturbPivot(std::copysign(perturb, real(p)), p, rhs_row);
     x.row(k) = rhs_row * (Scalar(1.0) / p);
   }
-// EVOLVE-BLOCK-END
-// EVOLVE-BLOCK-END
 }
+// EVOLVE-BLOCK-END
 
 }  // namespace jax
 

--- a/jaxlib/tridiagonal_solve_perturbed.h
+++ b/jaxlib/tridiagonal_solve_perturbed.h
@@ -85,29 +85,21 @@ EIGEN_DEVICE_FUNC void MaybePerturbPivot(
            : small * (one + std::numeric_limits<RealScalar>::epsilon()));
   constexpr RealScalar bignum = one / safemin;
 
-// EVOLVE-BLOCK-START
   RealScalar abs_pivot = Eigen::numext::abs(pivot);
-// EVOLVE-BLOCK-START
   if (abs_pivot >= one) {
     return;
   }
-// EVOLVE-BLOCK-END
 
   // Safeguard against infinite loop if 'perturb' is zero.
   // 'perturb' should never have magnitude smaller than safemin.
-// EVOLVE-BLOCK-START
   perturb = std::max(Eigen::numext::abs(perturb), safemin);
   // Make sure perturb and pivot have the same sign.
   perturb = std::copysign(perturb, real(pivot));
-// EVOLVE-BLOCK-END
 
   bool stop = false;
-// EVOLVE-BLOCK-START
   const RealScalar max_factor = rhs_row.derived().array().abs().maxCoeff();
-// EVOLVE-BLOCK-END
 
   while (abs_pivot < one && !stop) {
-// EVOLVE-BLOCK-START
     if (abs_pivot < safemin) {
       if (abs_pivot == RealScalar(0.0) || max_factor * safemin > abs_pivot) {
         pivot += perturb;
@@ -123,10 +115,8 @@ EIGEN_DEVICE_FUNC void MaybePerturbPivot(
     } else {
       stop = true;
     }
-// EVOLVE-BLOCK-END
     abs_pivot = Eigen::numext::abs(pivot);
   }
-// EVOLVE-BLOCK-END
 }
 
 // This function roughly follows LAPACK's xLAGTF + xLAGTS routines.
@@ -156,7 +146,6 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
     int n, int k_rhs, const Scalar* subdiag_ptr, const Scalar* diag_ptr,
     const Scalar* superdiag_ptr, const Scalar* rhs_ptr, Scalar* x_ptr,
     Scalar* u_workspace, Scalar* rhs_row_workspace) {
-// EVOLVE-BLOCK-START
   using RealScalar = typename Eigen::NumTraits<Scalar>::Real;
   using InputMatrixMap =
       Eigen::Map<const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic,
@@ -182,7 +171,6 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
     return;
   }
 
-// EVOLVE-BLOCK-START
   if (n == 1) {
     Scalar p = diag(0);
     RealScalar eps = std::numeric_limits<RealScalar>::epsilon();
@@ -192,11 +180,17 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
     x.row(0) = rhs_row / p;
     return;
   }
-// EVOLVE-BLOCK-END
 
+  // The three columns in u are the diagonal, superdiagonal, and second
+  // superdiagonal, respectively, of the U matrix in the LU decomposition
+  // of the input matrix (subject to row exchanges due to pivoting). For
+  // a pivoted tridiagonal matrix, the U matrix has at most two non-zero
+  // superdiagonals.
   Eigen::Map<Eigen::Array<Scalar, Eigen::Dynamic, 3>> u(u_workspace, n, 3);
   u.setZero();
 
+  // We accumulate max( abs( U(i,j) ) ) in max_abs_u for use in perturbing
+  // near-zero pivots during the solution phase.
   u(0, 0) = diag(0);
   u(0, 1) = superdiag(0);
   RealScalar max_abs_u =
@@ -204,36 +198,36 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
   RealScalar scale1 = Eigen::numext::abs(u(0, 0)) + Eigen::numext::abs(u(0, 1));
   x.row(0) = rhs.row(0);
 
-// EVOLVE-BLOCK-START
   for (int k = 0; k < n - 1; ++k) {
+    // The non-zeros in the (k+1)-st row are
+    //    [ ... subdiag(k+1) (diag(k+1)-shift) superdiag(k+1) ... ]
     u(k + 1, 0) = diag(k + 1);
     RealScalar scale2 =
         Eigen::numext::abs(subdiag(k + 1)) + Eigen::numext::abs(u(k + 1, 0));
     if (k < n - 2) scale2 += Eigen::numext::abs(superdiag(k + 1));
 
     if (subdiag(k + 1) == zero) {
+      // The sub-diagonal in the k+1 row is already zero. Move to the next
+      // row.
       scale1 = scale2;
       u(k + 1, 1) = superdiag(k + 1);
       u(k, 2) = zero;
       x.row(k + 1) = rhs.row(k + 1);
     } else {
-// EVOLVE-BLOCK-START
       const RealScalar piv1 =
           u(k, 0) == zero ? realzero : Eigen::numext::abs(u(k, 0)) / scale1;
       const RealScalar piv2 = Eigen::numext::abs(subdiag(k + 1)) / scale2;
-// EVOLVE-BLOCK-END
 
       if (piv2 <= piv1) {
-// EVOLVE-BLOCK-START
+        // No row pivoting needed.
         scale1 = scale2;
         const Scalar factor = subdiag(k + 1) / u(k, 0);
         u(k + 1, 0) -= factor * u(k, 1);
         u(k + 1, 1) = superdiag(k + 1);
         u(k, 2) = zero;
         x.row(k + 1) = rhs.row(k + 1) - factor * x.row(k);
-// EVOLVE-BLOCK-END
       } else {
-// EVOLVE-BLOCK-START
+        // Swap rows k and k+1
         const Scalar factor = u(k, 0) / subdiag(k + 1);
         const Scalar utmp = u(k, 1);
         u(k, 0) = subdiag(k + 1);
@@ -249,52 +243,43 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
 
         scale1 =
             Eigen::numext::abs(u(k + 1, 0)) + Eigen::numext::abs(u(k + 1, 1));
-// EVOLVE-BLOCK-END
       }
     }
     if (k < n - 2) {
-// EVOLVE-BLOCK-START
       for (int i = 0; i < 3; ++i) {
         max_abs_u = std::max(max_abs_u, Eigen::numext::abs(u(k, i)));
       }
-// EVOLVE-BLOCK-END
     }
   }
-// EVOLVE-BLOCK-END
   max_abs_u = std::max(max_abs_u, Eigen::numext::abs(u(n - 1, 0)));
 
-// EVOLVE-BLOCK-START
   RealScalar eps = std::numeric_limits<RealScalar>::epsilon();
   RealScalar perturb = eps * max_abs_u;
-// EVOLVE-BLOCK-END
 
-// EVOLVE-BLOCK-START
+  // We have already solved L z = P rhs above. Now we solve U x = z,
+  // possibly perturbing small pivots to avoid overflow. The variable perturb
+  // contains eps * max( abs( u(:,:) ) ). If tiny pivots are encountered,
+  // they are perturbed by a small amount on the scale of perturb to avoid
+  // overflow or scaled up to avoid underflow.
+  // Back substitution
   Scalar p = u(n - 1, 0);
   rhs_row = x.row(n - 1);
   MaybePerturbPivot(perturb, p, rhs_row);
   x.row(n - 1) = rhs_row * (Scalar(1.0) / p);
-// EVOLVE-BLOCK-END
 
   if (n > 1) {
-// EVOLVE-BLOCK-START
     p = u(n - 2, 0);
     rhs_row = x.row(n - 2) - u(n - 2, 1) * x.row(n - 1);
     MaybePerturbPivot(std::copysign(perturb, real(p)), p, rhs_row);
     x.row(n - 2) = rhs_row * (Scalar(1.0) / p);
-// EVOLVE-BLOCK-END
   }
 
-// EVOLVE-BLOCK-START
   for (int k = n - 3; k >= 0; --k) {
     p = u(k, 0);
-// EVOLVE-BLOCK-START
     rhs_row = x.row(k) - u(k, 1) * x.row(k + 1) - u(k, 2) * x.row(k + 2);
     MaybePerturbPivot(std::copysign(perturb, real(p)), p, rhs_row);
-// EVOLVE-BLOCK-END
     x.row(k) = rhs_row * (Scalar(1.0) / p);
   }
-// EVOLVE-BLOCK-END
-// EVOLVE-BLOCK-END
 }
 
 }  // namespace jax

--- a/jaxlib/tridiagonal_solve_perturbed.h
+++ b/jaxlib/tridiagonal_solve_perturbed.h
@@ -85,6 +85,7 @@ EIGEN_DEVICE_FUNC void MaybePerturbPivot(
            : small * (one + std::numeric_limits<RealScalar>::epsilon()));
   constexpr RealScalar bignum = one / safemin;
 
+// EVOLVE-BLOCK-START
   RealScalar abs_pivot = Eigen::numext::abs(pivot);
   if (abs_pivot >= one) {
     return;
@@ -100,6 +101,7 @@ EIGEN_DEVICE_FUNC void MaybePerturbPivot(
   const RealScalar max_factor = rhs_row.derived().array().abs().maxCoeff();
 
   while (abs_pivot < one && !stop) {
+// EVOLVE-BLOCK-START
     if (abs_pivot < safemin) {
       if (abs_pivot == RealScalar(0.0) || max_factor * safemin > abs_pivot) {
         pivot += perturb;
@@ -116,7 +118,9 @@ EIGEN_DEVICE_FUNC void MaybePerturbPivot(
       stop = true;
     }
     abs_pivot = Eigen::numext::abs(pivot);
+// EVOLVE-BLOCK-END
   }
+// EVOLVE-BLOCK-END
 }
 
 // This function roughly follows LAPACK's xLAGTF + xLAGTS routines.
@@ -146,6 +150,7 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
     int n, int k_rhs, const Scalar* subdiag_ptr, const Scalar* diag_ptr,
     const Scalar* superdiag_ptr, const Scalar* rhs_ptr, Scalar* x_ptr,
     Scalar* u_workspace, Scalar* rhs_row_workspace) {
+// EVOLVE-BLOCK-START
   using RealScalar = typename Eigen::NumTraits<Scalar>::Real;
   using InputMatrixMap =
       Eigen::Map<const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic,
@@ -198,17 +203,14 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
   RealScalar scale1 = Eigen::numext::abs(u(0, 0)) + Eigen::numext::abs(u(0, 1));
   x.row(0) = rhs.row(0);
 
+// EVOLVE-BLOCK-START
   for (int k = 0; k < n - 1; ++k) {
-    // The non-zeros in the (k+1)-st row are
-    //    [ ... subdiag(k+1) (diag(k+1)-shift) superdiag(k+1) ... ]
     u(k + 1, 0) = diag(k + 1);
     RealScalar scale2 =
         Eigen::numext::abs(subdiag(k + 1)) + Eigen::numext::abs(u(k + 1, 0));
     if (k < n - 2) scale2 += Eigen::numext::abs(superdiag(k + 1));
 
     if (subdiag(k + 1) == zero) {
-      // The sub-diagonal in the k+1 row is already zero. Move to the next
-      // row.
       scale1 = scale2;
       u(k + 1, 1) = superdiag(k + 1);
       u(k, 2) = zero;
@@ -219,7 +221,6 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
       const RealScalar piv2 = Eigen::numext::abs(subdiag(k + 1)) / scale2;
 
       if (piv2 <= piv1) {
-        // No row pivoting needed.
         scale1 = scale2;
         const Scalar factor = subdiag(k + 1) / u(k, 0);
         u(k + 1, 0) -= factor * u(k, 1);
@@ -227,7 +228,6 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
         u(k, 2) = zero;
         x.row(k + 1) = rhs.row(k + 1) - factor * x.row(k);
       } else {
-        // Swap rows k and k+1
         const Scalar factor = u(k, 0) / subdiag(k + 1);
         const Scalar utmp = u(k, 1);
         u(k, 0) = subdiag(k + 1);
@@ -246,11 +246,14 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
       }
     }
     if (k < n - 2) {
+// EVOLVE-BLOCK-START
       for (int i = 0; i < 3; ++i) {
         max_abs_u = std::max(max_abs_u, Eigen::numext::abs(u(k, i)));
       }
+// EVOLVE-BLOCK-END
     }
   }
+// EVOLVE-BLOCK-END
   max_abs_u = std::max(max_abs_u, Eigen::numext::abs(u(n - 1, 0)));
 
   RealScalar eps = std::numeric_limits<RealScalar>::epsilon();
@@ -274,12 +277,15 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
     x.row(n - 2) = rhs_row * (Scalar(1.0) / p);
   }
 
+// EVOLVE-BLOCK-START
   for (int k = n - 3; k >= 0; --k) {
     p = u(k, 0);
     rhs_row = x.row(k) - u(k, 1) * x.row(k + 1) - u(k, 2) * x.row(k + 2);
     MaybePerturbPivot(std::copysign(perturb, real(p)), p, rhs_row);
     x.row(k) = rhs_row * (Scalar(1.0) / p);
   }
+// EVOLVE-BLOCK-END
+// EVOLVE-BLOCK-END
 }
 
 }  // namespace jax

--- a/jaxlib/tridiagonal_solve_perturbed.h
+++ b/jaxlib/tridiagonal_solve_perturbed.h
@@ -85,21 +85,29 @@ EIGEN_DEVICE_FUNC void MaybePerturbPivot(
            : small * (one + std::numeric_limits<RealScalar>::epsilon()));
   constexpr RealScalar bignum = one / safemin;
 
+// EVOLVE-BLOCK-START
   RealScalar abs_pivot = Eigen::numext::abs(pivot);
+// EVOLVE-BLOCK-START
   if (abs_pivot >= one) {
     return;
   }
+// EVOLVE-BLOCK-END
 
   // Safeguard against infinite loop if 'perturb' is zero.
   // 'perturb' should never have magnitude smaller than safemin.
+// EVOLVE-BLOCK-START
   perturb = std::max(Eigen::numext::abs(perturb), safemin);
   // Make sure perturb and pivot have the same sign.
   perturb = std::copysign(perturb, real(pivot));
+// EVOLVE-BLOCK-END
 
   bool stop = false;
+// EVOLVE-BLOCK-START
   const RealScalar max_factor = rhs_row.derived().array().abs().maxCoeff();
+// EVOLVE-BLOCK-END
 
   while (abs_pivot < one && !stop) {
+// EVOLVE-BLOCK-START
     if (abs_pivot < safemin) {
       if (abs_pivot == RealScalar(0.0) || max_factor * safemin > abs_pivot) {
         pivot += perturb;
@@ -115,8 +123,10 @@ EIGEN_DEVICE_FUNC void MaybePerturbPivot(
     } else {
       stop = true;
     }
+// EVOLVE-BLOCK-END
     abs_pivot = Eigen::numext::abs(pivot);
   }
+// EVOLVE-BLOCK-END
 }
 
 // This function roughly follows LAPACK's xLAGTF + xLAGTS routines.
@@ -146,6 +156,7 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
     int n, int k_rhs, const Scalar* subdiag_ptr, const Scalar* diag_ptr,
     const Scalar* superdiag_ptr, const Scalar* rhs_ptr, Scalar* x_ptr,
     Scalar* u_workspace, Scalar* rhs_row_workspace) {
+// EVOLVE-BLOCK-START
   using RealScalar = typename Eigen::NumTraits<Scalar>::Real;
   using InputMatrixMap =
       Eigen::Map<const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic,
@@ -171,6 +182,7 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
     return;
   }
 
+// EVOLVE-BLOCK-START
   if (n == 1) {
     Scalar p = diag(0);
     RealScalar eps = std::numeric_limits<RealScalar>::epsilon();
@@ -180,17 +192,11 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
     x.row(0) = rhs_row / p;
     return;
   }
+// EVOLVE-BLOCK-END
 
-  // The three columns in u are the diagonal, superdiagonal, and second
-  // superdiagonal, respectively, of the U matrix in the LU decomposition
-  // of the input matrix (subject to row exchanges due to pivoting). For
-  // a pivoted tridiagonal matrix, the U matrix has at most two non-zero
-  // superdiagonals.
   Eigen::Map<Eigen::Array<Scalar, Eigen::Dynamic, 3>> u(u_workspace, n, 3);
   u.setZero();
 
-  // We accumulate max( abs( U(i,j) ) ) in max_abs_u for use in perturbing
-  // near-zero pivots during the solution phase.
   u(0, 0) = diag(0);
   u(0, 1) = superdiag(0);
   RealScalar max_abs_u =
@@ -198,36 +204,36 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
   RealScalar scale1 = Eigen::numext::abs(u(0, 0)) + Eigen::numext::abs(u(0, 1));
   x.row(0) = rhs.row(0);
 
+// EVOLVE-BLOCK-START
   for (int k = 0; k < n - 1; ++k) {
-    // The non-zeros in the (k+1)-st row are
-    //    [ ... subdiag(k+1) (diag(k+1)-shift) superdiag(k+1) ... ]
     u(k + 1, 0) = diag(k + 1);
     RealScalar scale2 =
         Eigen::numext::abs(subdiag(k + 1)) + Eigen::numext::abs(u(k + 1, 0));
     if (k < n - 2) scale2 += Eigen::numext::abs(superdiag(k + 1));
 
     if (subdiag(k + 1) == zero) {
-      // The sub-diagonal in the k+1 row is already zero. Move to the next
-      // row.
       scale1 = scale2;
       u(k + 1, 1) = superdiag(k + 1);
       u(k, 2) = zero;
       x.row(k + 1) = rhs.row(k + 1);
     } else {
+// EVOLVE-BLOCK-START
       const RealScalar piv1 =
           u(k, 0) == zero ? realzero : Eigen::numext::abs(u(k, 0)) / scale1;
       const RealScalar piv2 = Eigen::numext::abs(subdiag(k + 1)) / scale2;
+// EVOLVE-BLOCK-END
 
       if (piv2 <= piv1) {
-        // No row pivoting needed.
+// EVOLVE-BLOCK-START
         scale1 = scale2;
         const Scalar factor = subdiag(k + 1) / u(k, 0);
         u(k + 1, 0) -= factor * u(k, 1);
         u(k + 1, 1) = superdiag(k + 1);
         u(k, 2) = zero;
         x.row(k + 1) = rhs.row(k + 1) - factor * x.row(k);
+// EVOLVE-BLOCK-END
       } else {
-        // Swap rows k and k+1
+// EVOLVE-BLOCK-START
         const Scalar factor = u(k, 0) / subdiag(k + 1);
         const Scalar utmp = u(k, 1);
         u(k, 0) = subdiag(k + 1);
@@ -243,43 +249,52 @@ SolveWithGaussianEliminationWithPivotingAndPerturbSingular(
 
         scale1 =
             Eigen::numext::abs(u(k + 1, 0)) + Eigen::numext::abs(u(k + 1, 1));
+// EVOLVE-BLOCK-END
       }
     }
     if (k < n - 2) {
+// EVOLVE-BLOCK-START
       for (int i = 0; i < 3; ++i) {
         max_abs_u = std::max(max_abs_u, Eigen::numext::abs(u(k, i)));
       }
+// EVOLVE-BLOCK-END
     }
   }
+// EVOLVE-BLOCK-END
   max_abs_u = std::max(max_abs_u, Eigen::numext::abs(u(n - 1, 0)));
 
+// EVOLVE-BLOCK-START
   RealScalar eps = std::numeric_limits<RealScalar>::epsilon();
   RealScalar perturb = eps * max_abs_u;
+// EVOLVE-BLOCK-END
 
-  // We have already solved L z = P rhs above. Now we solve U x = z,
-  // possibly perturbing small pivots to avoid overflow. The variable perturb
-  // contains eps * max( abs( u(:,:) ) ). If tiny pivots are encountered,
-  // they are perturbed by a small amount on the scale of perturb to avoid
-  // overflow or scaled up to avoid underflow.
-  // Back substitution
+// EVOLVE-BLOCK-START
   Scalar p = u(n - 1, 0);
   rhs_row = x.row(n - 1);
   MaybePerturbPivot(perturb, p, rhs_row);
   x.row(n - 1) = rhs_row * (Scalar(1.0) / p);
+// EVOLVE-BLOCK-END
 
   if (n > 1) {
+// EVOLVE-BLOCK-START
     p = u(n - 2, 0);
     rhs_row = x.row(n - 2) - u(n - 2, 1) * x.row(n - 1);
     MaybePerturbPivot(std::copysign(perturb, real(p)), p, rhs_row);
     x.row(n - 2) = rhs_row * (Scalar(1.0) / p);
+// EVOLVE-BLOCK-END
   }
 
+// EVOLVE-BLOCK-START
   for (int k = n - 3; k >= 0; --k) {
     p = u(k, 0);
+// EVOLVE-BLOCK-START
     rhs_row = x.row(k) - u(k, 1) * x.row(k + 1) - u(k, 2) * x.row(k + 2);
     MaybePerturbPivot(std::copysign(perturb, real(p)), p, rhs_row);
+// EVOLVE-BLOCK-END
     x.row(k) = rhs_row * (Scalar(1.0) / p);
   }
+// EVOLVE-BLOCK-END
+// EVOLVE-BLOCK-END
 }
 
 }  // namespace jax

--- a/jaxlib/tridiagonal_solve_perturbed.h
+++ b/jaxlib/tridiagonal_solve_perturbed.h
@@ -74,14 +74,16 @@ EIGEN_DEVICE_FUNC void MaybePerturbPivot(
   using RealScalar = typename Eigen::NumTraits<Scalar>::Real;
   using std::real;
   constexpr RealScalar one(1.0);
-  const RealScalar tiny = std::numeric_limits<RealScalar>::min();
-  const RealScalar small = one / std::numeric_limits<RealScalar>::max();
+  // std::numeric_limits<T>::min/max/epsilon are constexpr in C++11+,
+  // so these constants are evaluated at compile time.
+  constexpr RealScalar tiny = std::numeric_limits<RealScalar>::min();
+  constexpr RealScalar small = one / std::numeric_limits<RealScalar>::max();
   // The following logic is extracted from xLAMCH in LAPACK.
-  const RealScalar safemin =
+  constexpr RealScalar safemin =
       (small < tiny
            ? tiny
            : small * (one + std::numeric_limits<RealScalar>::epsilon()));
-  const RealScalar bignum = one / safemin;
+  constexpr RealScalar bignum = one / safemin;
 
   RealScalar abs_pivot = Eigen::numext::abs(pivot);
   if (abs_pivot >= one) {


### PR DESCRIPTION
## Summary

Mark the `numeric_limits`-derived safety constants in `MaybePerturbPivot` as `constexpr` so the compiler evaluates them at compile time rather than recomputing them on every function call.

### Change

**Before:**
```cpp
const RealScalar tiny = std::numeric_limits<RealScalar>::min();
const RealScalar small = one / std::numeric_limits<RealScalar>::max();
const RealScalar safemin = (small < tiny ? tiny : small * (one + std::numeric_limits<RealScalar>::epsilon()));
const RealScalar bignum = one / safemin;
```

**After:**
```cpp
constexpr RealScalar tiny = std::numeric_limits<RealScalar>::min();
constexpr RealScalar small = one / std::numeric_limits<RealScalar>::max();
constexpr RealScalar safemin = (small < tiny ? tiny : small * (one + std::numeric_limits<RealScalar>::epsilon()));
constexpr RealScalar bignum = one / safemin;
```

### Why

`MaybePerturbPivot` is called O(n) times during each tridiagonal solve. For n=8192 with k_rhs=10, that''s ~8000 calls (across forward elimination and back-substitution). Each call recomputed four `numeric_limits`-derived constants that depend only on the scalar type (float or double).

`std::numeric_limits<T>::min()`, `::max()`, and `::epsilon()` have been `constexpr` since C++11. Since `RealScalar` resolves to `float` or `double`, all four constants are fully determined at compile time per template instantiation and can be evaluated once rather than on every call.

### Correctness

No behavioral change — the computed values are identical. Only the evaluation strategy changes from runtime to compile-time.

This is a completely independent optimization from the back-substitution `.noalias()` change (PR #37725).