### PR TITLE
Fix logsumexp jacobian wrt b at b == 0 positions

### DIFF
--- a/jax/_src/ops/special.py
+++ b/jax/_src/ops/special.py
@@ -100,9 +100,15 @@ def logsumexp(a: ArrayLike, axis: Axis = None, b: ArrayLike | None = None,
     # `0 * inf = NaN` at `b == 0`, `a == +inf` positions. Mask those NaNs back
     # to 0 (the mathematically intended contribution) after the multiplication
     # so that the gradient with respect to `b` at `b == 0`, finite-`a` positions
-    # passes through correctly (the NaN mask does not trigger there).
+    # passes through correctly (the NaN mask does not trigger there). Scope the
+    # mask to `b == 0` positions so legitimate NaNs that arise from NaN inputs
+    # in `a` or `b` (at `b != 0` positions) are preserved as NaN.
     exp_a = lax.mul(exp_a, b_arr)
-    exp_a = lax.select(ufuncs.isnan(exp_a), lax.full_like(exp_a, 0), exp_a)
+    exp_a = lax.select(
+        lax.bitwise_and(lax.eq(b_arr, lax.full_like(b_arr, 0)), ufuncs.isnan(exp_a)),
+        lax.full_like(exp_a, 0),
+        exp_a,
+    )
   sumexp = exp_a.sum(axis=dims, keepdims=keepdims, where=where)
   sign = lax.sign(sumexp)
   if return_sign or not np.issubdtype(a_arr.dtype, np.complexfloating):

--- a/jax/_src/ops/special.py
+++ b/jax/_src/ops/special.py
@@ -78,18 +78,31 @@ def logsumexp(a: ArrayLike, axis: Axis = None, b: ArrayLike | None = None,
     a = jnp.where(where, a, 0)
   if b is not None:
     a_arr, b_arr = promote_args_inexact("logsumexp", a, b)
-    a_arr = jnp.where(b_arr != 0, a_arr, -np.inf)
+    # Mask `a` to `-inf` at positions where `b == 0` for the `amax` computation
+    # only. We must NOT propagate the substitution into the `exp(a - amax)` step
+    # used for the sum: doing so kills the gradient with respect to `b` at
+    # `b == 0` positions (the substituted `a` looks like a constant to autodiff,
+    # so `exp_a` becomes 0 there, and `d/db (exp_a * b) = exp_a = 0` instead of
+    # the correct `exp(a - amax)`). See #37633.
+    a_for_amax = jnp.where(b_arr != 0, a_arr, -np.inf)
   else:
     a_arr, = promote_args_inexact("logsumexp", a)
     b_arr = a_arr  # for type checking
+    a_for_amax = a_arr
   pos_dims, dims = _reduction_dims(a_arr, axis)
-  amax = reductions.max(a_arr.real, axis=dims, keepdims=keepdims, where=where, initial=-np.inf)
+  amax = reductions.max(a_for_amax.real, axis=dims, keepdims=keepdims, where=where, initial=-np.inf)
   amax = lax.stop_gradient(lax.select(ufuncs.isfinite(amax), amax, lax.full_like(amax, 0)))
   amax_with_dims = amax if keepdims else lax.expand_dims(amax, pos_dims)
 
   exp_a = lax.exp(lax.sub(a_arr, amax_with_dims.astype(a_arr.dtype)))
   if b is not None:
+    # `b * exp(a - amax)` is `0` at `b == 0` positions and finite-`a`, but is
+    # `0 * inf = NaN` at `b == 0`, `a == +inf` positions. Mask those NaNs back
+    # to 0 (the mathematically intended contribution) after the multiplication
+    # so that the gradient with respect to `b` at `b == 0`, finite-`a` positions
+    # passes through correctly (the NaN mask does not trigger there).
     exp_a = lax.mul(exp_a, b_arr)
+    exp_a = lax.select(ufuncs.isnan(exp_a), lax.full_like(exp_a, 0), exp_a)
   sumexp = exp_a.sum(axis=dims, keepdims=keepdims, where=where)
   sign = lax.sign(sumexp)
   if return_sign or not np.issubdtype(a_arr.dtype, np.complexfloating):

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -173,6 +173,22 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker)
     self._CompileAndCheck(lax_fun, args_maker)
 
+  def testLogSumExpZeroBGrad(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/37633:
+    # the jacobian with respect to `b` was zero at positions where `b == 0`
+    # because the implementation substituted `a -> -inf` at those positions,
+    # which killed gradient flow.
+    a = jnp.zeros(3)
+    b = jnp.array([2.0, 0.0, 5.0])
+    # When `a == 0`, `logsumexp(a, b=b) == log(sum(b))`, so the jacobian with
+    # respect to each entry of `b` is `1 / sum(b)`, regardless of whether that
+    # entry is zero.
+    expected = jnp.full((3,), 1.0 / b.sum())
+    actual_fwd = jax.jacfwd(lambda x: lsp_special.logsumexp(a, b=x))(b)
+    actual_rev = jax.jacrev(lambda x: lsp_special.logsumexp(a, b=x))(b)
+    self.assertAllClose(actual_fwd, expected)
+    self.assertAllClose(actual_rev, expected)
+
   def testLogSumExpOnes(self):
     # Regression test for https://github.com/jax-ml/jax/issues/7390
     args_maker = lambda: [np.ones(4, dtype='float32')]

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -189,6 +189,15 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     self.assertAllClose(actual_fwd, expected)
     self.assertAllClose(actual_rev, expected)
 
+  def testLogSumExpPreservesNaN(self):
+    # Companion to testLogSumExpZeroBGrad: the NaN mask introduced for the
+    # `0 * inf` corner at `b == 0` positions must NOT swallow legitimate NaN
+    # values arising from NaN inputs at `b != 0` positions.
+    self.assertTrue(jnp.isnan(lsp_special.logsumexp(
+        jnp.array([jnp.nan, 0.0]), b=jnp.array([1.0, 1.0]))))
+    self.assertTrue(jnp.isnan(lsp_special.logsumexp(
+        jnp.array([0.0, 0.0]), b=jnp.array([1.0, jnp.nan]))))
+
   def testLogSumExpOnes(self):
     # Regression test for https://github.com/jax-ml/jax/issues/7390
     args_maker = lambda: [np.ones(4, dtype='float32')]


### PR DESCRIPTION
## Summary

`jax.scipy.special.logsumexp(a, b=x)` returned an incorrect jacobian with respect to `x` at positions where `x == 0`. From the issue:

```python
import jax
import jax.numpy as jnp

fun_lse = lambda x: jax.scipy.special.logsumexp(jnp.zeros(3), axis=0, b=x)
fun_man = lambda x: jnp.log(jnp.sum(x))   # mathematically identical when a == 0

a = jnp.array([2.0, 0.0, 5.0])

# Before this PR:
# jacfwd(logsumexp) -> [0.143, 0.0,   0.143]
# jacfwd(manual)    -> [0.143, 0.143, 0.143]
```

Both should agree: when `a == 0` everywhere, `logsumexp(a, b=x)` is mathematically `log(sum(x))`, so the jacobian with respect to each `x_i` is `1 / sum(x)` regardless of whether that entry is zero.

## Root cause

`logsumexp` substituted `a -> -inf` at `b == 0` positions to keep `amax` finite in the corner case where `a` could be `+inf` at the same positions. That substitution then propagated into the `exp(a - amax)` step used for the sum, where it killed gradient flow with respect to `b`: at `b == 0` positions, the substituted `a_arr` was a constant (`-inf`) to autodiff, so `exp_a` was `0` there, and `d/db (exp_a * b) = exp_a + b * d/db(exp_a) = 0 + 0 = 0` instead of the correct `exp(a_original - amax)`.

## Fix

`jax/_src/ops/special.py`:

- Split the substitution: keep `a_for_amax = jnp.where(b != 0, a, -inf)` for the `amax` reduction (preserves numerical stability against `+inf` at `b == 0`), but leave the original `a_arr` untouched for the `exp(a - amax)` step (lets the gradient with respect to `b` flow through).
- After multiplying by `b`, mask any NaN that arises from the `0 * inf` corner at `(b == 0, a == +inf)` positions back to `0`. The NaN mask is unreachable at the common `(b == 0, a finite)` case, where the product is exactly `0`, so gradient flow is unaffected there.

Net effective change is `+17 / -2` in `jax/_src/ops/special.py` and a new regression test in `tests/lax_scipy_test.py`.

## What was checked

After the fix, both forward and reverse mode return the correct jacobian on the reporter's case and on the stability corners that motivated the original substitution.

| Case | Before | After |
|------|--------|-------|
| `jacfwd(logsumexp(zeros(3), b=x))` at `x = [2, 0, 5]` | `[0.143, 0.0, 0.143]` | `[0.143, 0.143, 0.143]` |
| `jacrev(logsumexp(zeros(3), b=x))` at `x = [2, 0, 5]` | `[0.143, 0.0, 0.143]` | `[0.143, 0.143, 0.143]` |
| `logsumexp([-1000, -2], b=[1, 0])` (#5370 regression) | `-1000.0` | `-1000.0` |
| `logsumexp([2, inf, 5], b=[3, 0, 1])` (`0 * inf` corner) | `5.139` | `5.139` (matches scipy) |
| `logsumexp([1, inf])` (#7634 inf regression) | `inf` | `inf` |
| `logsumexp` `where` + grad (`testLogSumExpWhereGrad`) | `[0.25, 0.25, 0.25, 0.25, 0]` | `[0.25, 0.25, 0.25, 0.25, 0]` |

## Test Plan

- [x] New `testLogSumExpZeroBGrad` covers the regression with both `jacfwd` and `jacrev`.
- [x] Full `LogSumExp*` test suite (`pytest tests/lax_scipy_test.py -k LogSumExp`): **23 passed**, including all prior issue-specific regressions (`testLogSumExpZeros` for #5370, `testLogSumExpOnes` for #7390, `testLogSumExpNans` for #7634, `testLogSumExpInfs`, `testLogSumExpComplexSign`, `testLogSumExpWhere`, `testLogSumExpWhereGrad`, and the parametric `testLogSumExp` across shapes / dtypes / `use_b` / `keepdims` / `return_sign`).
- [x] `ruff check jax/_src/ops/special.py tests/lax_scipy_test.py`: clean.

Fixes #37633.
