### PR TITLE
Add jax.scipy.stats.laplace.ppf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     ({jax-issue}`#10144`).
   * Added {func}`jax.scipy.special.boxcox` and
     {func}`jax.scipy.special.boxcox1p` for the Box-Cox power transformation.
+  * Added {func}`jax.scipy.stats.laplace.ppf` ({jax-issue}`#13291`).
   * Moved RNG APIs from "implementations" to dtypes ({jax-issue}`#27854`):
     * Added `jax.random.key_dtype` to get the dtype corresponding to a PRNG
       implementation name.

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -404,6 +404,7 @@ jax.scipy.stats.laplace
    cdf
    logpdf
    pdf
+   ppf
 
 jax.scipy.stats.logistic
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/jax/_src/scipy/stats/laplace.py
+++ b/jax/_src/scipy/stats/laplace.py
@@ -107,3 +107,39 @@ def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   return lax.select(lax.le(diff, zero),
                     lax.mul(half, lax.exp(diff)),
                     lax.sub(one, lax.mul(half, lax.exp(lax.neg(diff)))))
+
+
+def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Laplace percent point function.
+
+  JAX implementation of :obj:`scipy.stats.laplace` ``ppf``.
+
+  The percent point function is the inverse of the cumulative distribution
+  function, :func:`jax.scipy.stats.laplace.cdf`. In closed form,
+
+  .. math::
+
+     f_{ppf}(q) = \begin{cases}
+       \mathrm{loc} + \mathrm{scale} \cdot \log(2 q) & q \le 1/2 \\
+       \mathrm{loc} - \mathrm{scale} \cdot \log(2 - 2 q) & q > 1/2
+     \end{cases}
+
+  Args:
+    q: arraylike, value at which to evaluate the PPF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of ppf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.laplace.cdf`
+    - :func:`jax.scipy.stats.laplace.pdf`
+  """
+  q, loc, scale = promote_args_inexact("laplace.ppf", q, loc, scale)
+  half = _lax_const(q, 0.5)
+  two = _lax_const(q, 2)
+  centered = lax.sub(q, half)
+  # ppf(q) = loc - scale * sign(q - 1/2) * log(1 - 2|q - 1/2|)
+  log_term = lax.log1p(lax.neg(lax.mul(two, lax.abs(centered))))
+  return lax.sub(loc, lax.mul(scale, lax.mul(lax.sign(centered), log_term)))

--- a/jax/scipy/stats/laplace.py
+++ b/jax/scipy/stats/laplace.py
@@ -19,4 +19,5 @@ from jax._src.scipy.stats.laplace import (
   cdf as cdf,
   logpdf as logpdf,
   pdf as pdf,
+  ppf as ppf,
 )

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -769,6 +769,24 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       self._CompileAndCheck(lax_fun, args_maker)
 
   @genNamedParametersNArgs(3)
+  def testLaplacePpf(self, shapes, dtypes):
+    rng = jtu.rand_uniform(self.rng(), low=0.01, high=0.99)
+    scipy_fun = osp_stats.laplace.ppf
+    lax_fun = lsp_stats.laplace.ppf
+
+    def args_maker():
+      q, loc, scale = map(rng, shapes, dtypes)
+      scale = np.clip(scale, a_min=0.1, a_max=None).astype(scale.dtype)
+      return [q, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol={
+                                  np.float32: 1e-3 if jtu.test_device_matches(["tpu"]) else 1e-5,
+                                  np.float64: 1e-6})
+      self._CompileAndCheck(lax_fun, args_maker, rtol={np.float32: 1e-4})
+
+  @genNamedParametersNArgs(3)
   def testLogisticCdf(self, shapes, dtypes):
     rng = jtu.rand_default(self.rng())
     scipy_fun = osp_stats.logistic.cdf


### PR DESCRIPTION
Adds `jax.scipy.stats.laplace.ppf` (percent point function, i.e. inverse CDF) for the Laplace distribution. Addresses one of the unchecked items in #13291.

Uses the branch-free identity

```
ppf(q) = loc - scale * sign(q - 1/2) * log(1 - 2|q - 1/2|)
```

rather than a `lax.select` between the two halves of the piecewise form. The branch-free version avoids the predicate-shape pitfall when `q`, `loc`, and `scale` broadcast against each other (`lax.select` requires the predicate to either be scalar or match the case shape), and it also collapses to `loc` at the `q = 1/2` cusp by construction.

Edge cases match SciPy: `ppf(0) = -inf`, `ppf(1) = +inf`, `ppf(0.5) = loc`. Round-trip `cdf(ppf(q)) == q` is clean at float32 ULP scale.

### Tests

`testLaplacePpf` follows the existing `testLaplaceCdf` pattern with `genNamedParametersNArgs(3)`, parity vs SciPy at `tol={float32: 1e-5, float64: 1e-6}`. Input sampled from `rand_uniform(low=0.01, high=0.99)` to stay off the `±inf` boundaries. 10 cases pass under both x32 and x64.

Follow-up PR will add `logcdf`, `sf`, `logsf`, `isf` to round out the surface.

Issue: #13291
