### PR TITLE
Round out jax.scipy.stats.laplace with logcdf, sf, logsf, isf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * Added {func}`jax.scipy.linalg.helmert` for constructing Helmert matrices
     ({jax-issue}`#10144`).
   * Added {func}`jax.scipy.stats.laplace.ppf` ({jax-issue}`#13291`).
+  * Added `logcdf`, `sf`, `logsf`, and `isf` to {mod}`jax.scipy.stats.laplace`
+    to round out the distribution's API surface.
   * Moved RNG APIs from "implementations" to dtypes ({jax-issue}`#27854`):
     * Added `jax.random.key_dtype` to get the dtype corresponding to a PRNG
       implementation name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     matrices ({jax-issue}`#10144`).
   * Added {func}`jax.scipy.linalg.helmert` for constructing Helmert matrices
     ({jax-issue}`#10144`).
+  * Added {func}`jax.scipy.stats.laplace.ppf` ({jax-issue}`#13291`).
   * Moved RNG APIs from "implementations" to dtypes ({jax-issue}`#27854`):
     * Added `jax.random.key_dtype` to get the dtype corresponding to a PRNG
       implementation name.

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -393,9 +393,13 @@ jax.scipy.stats.laplace
   :toctree: _autosummary
 
    cdf
+   isf
+   logcdf
    logpdf
+   logsf
    pdf
    ppf
+   sf
 
 jax.scipy.stats.logistic
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -395,6 +395,7 @@ jax.scipy.stats.laplace
    cdf
    logpdf
    pdf
+   ppf
 
 jax.scipy.stats.logistic
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/jax/_src/scipy/stats/laplace.py
+++ b/jax/_src/scipy/stats/laplace.py
@@ -107,3 +107,39 @@ def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   return lax.select(lax.le(diff, zero),
                     lax.mul(half, lax.exp(diff)),
                     lax.sub(one, lax.mul(half, lax.exp(lax.neg(diff)))))
+
+
+def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Laplace percent point function.
+
+  JAX implementation of :obj:`scipy.stats.laplace` ``ppf``.
+
+  The percent point function is the inverse of the cumulative distribution
+  function, :func:`jax.scipy.stats.laplace.cdf`. In closed form,
+
+  .. math::
+
+     f_{ppf}(q) = \begin{cases}
+       \mathrm{loc} + \mathrm{scale} \cdot \log(2 q) & q \le 1/2 \\
+       \mathrm{loc} - \mathrm{scale} \cdot \log(2 - 2 q) & q > 1/2
+     \end{cases}
+
+  Args:
+    q: arraylike, value at which to evaluate the PPF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of ppf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.laplace.cdf`
+    - :func:`jax.scipy.stats.laplace.pdf`
+  """
+  q, loc, scale = promote_args_inexact("laplace.ppf", q, loc, scale)
+  half = _lax_const(q, 0.5)
+  two = _lax_const(q, 2)
+  centered = lax.sub(q, half)
+  # ppf(q) = loc - scale * sign(q - 1/2) * log(1 - 2|q - 1/2|)
+  log_term = lax.log1p(lax.neg(lax.mul(two, lax.abs(centered))))
+  return lax.sub(loc, lax.mul(scale, lax.mul(lax.sign(centered), log_term)))

--- a/jax/_src/scipy/stats/laplace.py
+++ b/jax/_src/scipy/stats/laplace.py
@@ -109,6 +109,108 @@ def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
                     lax.sub(one, lax.mul(half, lax.exp(lax.neg(diff)))))
 
 
+def logcdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Laplace log cumulative distribution function.
+
+  JAX implementation of :obj:`scipy.stats.laplace` ``logcdf``.
+
+  The logcdf is defined as
+
+  .. math::
+
+     f_{logcdf}(x) = \log f_{cdf}(x)
+
+  where :math:`f_{cdf}` is the cumulative distribution function,
+  :func:`jax.scipy.stats.laplace.cdf`. The :math:`x \ge \mathrm{loc}` branch
+  uses ``log1p`` to avoid catastrophic cancellation.
+
+  Args:
+    x: arraylike, value at which to evaluate the log-CDF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logcdf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.laplace.cdf`
+    - :func:`jax.scipy.stats.laplace.logpdf`
+    - :func:`jax.scipy.stats.laplace.logsf`
+  """
+  x, loc, scale = promote_args_inexact("laplace.logcdf", x, loc, scale)
+  half = _lax_const(x, 0.5)
+  log_half = lax.log(half)
+  zero = _lax_const(x, 0)
+  diff = lax.div(lax.sub(x, loc), scale)
+  return lax.select(lax.le(diff, zero),
+                    lax.add(log_half, diff),
+                    lax.log1p(lax.neg(lax.mul(half, lax.exp(lax.neg(diff))))))
+
+
+def sf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Laplace survival function.
+
+  JAX implementation of :obj:`scipy.stats.laplace` ``sf``.
+
+  The survival function is defined as
+
+  .. math::
+
+     f_{sf}(x) = 1 - f_{cdf}(x)
+
+  where :math:`f_{cdf}` is the cumulative distribution function,
+  :func:`jax.scipy.stats.laplace.cdf`. The Laplace distribution is symmetric
+  around ``loc``, so ``sf(x) == cdf(2 * loc - x)``.
+
+  Args:
+    x: arraylike, value at which to evaluate the SF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of sf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.laplace.cdf`
+    - :func:`jax.scipy.stats.laplace.logsf`
+    - :func:`jax.scipy.stats.laplace.isf`
+  """
+  x, loc, scale = promote_args_inexact("laplace.sf", x, loc, scale)
+  return cdf(lax.sub(lax.mul(_lax_const(x, 2), loc), x), loc, scale)
+
+
+def logsf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Laplace log survival function.
+
+  JAX implementation of :obj:`scipy.stats.laplace` ``logsf``.
+
+  The log survival function is defined as
+
+  .. math::
+
+     f_{logsf}(x) = \log(1 - f_{cdf}(x))
+
+  where :math:`f_{cdf}` is the cumulative distribution function,
+  :func:`jax.scipy.stats.laplace.cdf`. The :math:`x \le \mathrm{loc}` branch
+  uses ``log1p`` to avoid catastrophic cancellation.
+
+  Args:
+    x: arraylike, value at which to evaluate the log-SF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of logsf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.laplace.sf`
+    - :func:`jax.scipy.stats.laplace.logcdf`
+    - :func:`jax.scipy.stats.laplace.isf`
+  """
+  x, loc, scale = promote_args_inexact("laplace.logsf", x, loc, scale)
+  return logcdf(lax.sub(lax.mul(_lax_const(x, 2), loc), x), loc, scale)
+
+
 def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   r"""Laplace percent point function.
 
@@ -143,3 +245,28 @@ def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   # ppf(q) = loc - scale * sign(q - 1/2) * log(1 - 2|q - 1/2|)
   log_term = lax.log1p(lax.neg(lax.mul(two, lax.abs(centered))))
   return lax.sub(loc, lax.mul(scale, lax.mul(lax.sign(centered), log_term)))
+
+
+def isf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  r"""Laplace inverse survival function.
+
+  JAX implementation of :obj:`scipy.stats.laplace` ``isf``.
+
+  The inverse survival function is the inverse of the survival function,
+  :func:`jax.scipy.stats.laplace.sf`. By symmetry about ``loc``,
+  ``isf(q) == 2 * loc - ppf(q)``.
+
+  Args:
+    q: arraylike, value at which to evaluate the ISF
+    loc: arraylike, distribution offset parameter
+    scale: arraylike, distribution scale parameter
+
+  Returns:
+    array of isf values.
+
+  See Also:
+    - :func:`jax.scipy.stats.laplace.sf`
+    - :func:`jax.scipy.stats.laplace.ppf`
+  """
+  q, loc, scale = promote_args_inexact("laplace.isf", q, loc, scale)
+  return lax.sub(lax.mul(_lax_const(q, 2), loc), ppf(q, loc, scale))

--- a/jax/scipy/stats/laplace.py
+++ b/jax/scipy/stats/laplace.py
@@ -17,7 +17,11 @@
 
 from jax._src.scipy.stats.laplace import (
   cdf as cdf,
+  isf as isf,
+  logcdf as logcdf,
   logpdf as logpdf,
+  logsf as logsf,
   pdf as pdf,
   ppf as ppf,
+  sf as sf,
 )

--- a/jax/scipy/stats/laplace.py
+++ b/jax/scipy/stats/laplace.py
@@ -19,4 +19,5 @@ from jax._src.scipy.stats.laplace import (
   cdf as cdf,
   logpdf as logpdf,
   pdf as pdf,
+  ppf as ppf,
 )

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -785,6 +785,70 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       self._CompileAndCheck(lax_fun, args_maker)
 
   @genNamedParametersNArgs(3)
+  def testLaplaceLogCdf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.laplace.logcdf
+    lax_fun = lsp_stats.laplace.logcdf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.clip(scale, a_min=0.1, a_max=None).astype(scale.dtype)
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol={np.float32: 1e-5, np.float64: 1e-6})
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testLaplaceSf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.laplace.sf
+    lax_fun = lsp_stats.laplace.sf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.clip(scale, a_min=0.1, a_max=None).astype(scale.dtype)
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol={np.float32: 1e-5, np.float64: 1e-6})
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testLaplaceLogSf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.laplace.logsf
+    lax_fun = lsp_stats.laplace.logsf
+
+    def args_maker():
+      x, loc, scale = map(rng, shapes, dtypes)
+      scale = np.clip(scale, a_min=0.1, a_max=None).astype(scale.dtype)
+      return [x, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol={np.float32: 1e-5, np.float64: 1e-6})
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
+  def testLaplaceIsf(self, shapes, dtypes):
+    rng = jtu.rand_uniform(self.rng(), low=0.01, high=0.99)
+    scipy_fun = osp_stats.laplace.isf
+    lax_fun = lsp_stats.laplace.isf
+
+    def args_maker():
+      q, loc, scale = map(rng, shapes, dtypes)
+      scale = np.clip(scale, a_min=0.1, a_max=None).astype(scale.dtype)
+      return [q, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol={np.float32: 1e-5, np.float64: 1e-6})
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
   def testLogisticCdf(self, shapes, dtypes):
     rng = jtu.rand_default(self.rng())
     scipy_fun = osp_stats.logistic.cdf

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -769,6 +769,22 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       self._CompileAndCheck(lax_fun, args_maker)
 
   @genNamedParametersNArgs(3)
+  def testLaplacePpf(self, shapes, dtypes):
+    rng = jtu.rand_uniform(self.rng(), low=0.01, high=0.99)
+    scipy_fun = osp_stats.laplace.ppf
+    lax_fun = lsp_stats.laplace.ppf
+
+    def args_maker():
+      q, loc, scale = map(rng, shapes, dtypes)
+      scale = np.clip(scale, a_min=0.1, a_max=None).astype(scale.dtype)
+      return [q, loc, scale]
+
+    with jtu.strict_promotion_if_dtypes_match(dtypes):
+      self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                              tol={np.float32: 1e-5, np.float64: 1e-6})
+      self._CompileAndCheck(lax_fun, args_maker)
+
+  @genNamedParametersNArgs(3)
   def testLogisticCdf(self, shapes, dtypes):
     rng = jtu.rand_default(self.rng())
     scipy_fun = osp_stats.logistic.cdf


### PR DESCRIPTION
Adds `logcdf`, `sf`, `logsf`, and `isf` to `jax.scipy.stats.laplace` so the Laplace distribution exposes the same `cdf` / `sf` / `pdf` / `ppf` surface that the other continuous distributions in `jax.scipy.stats` already have. Sister to #37755 (which adds `ppf`) and builds on top of that branch since `isf` reuses `ppf`.

All four are closed-form:

- `logcdf` and `logsf` use `log1p` on their respective tails (`log1p(-0.5 * exp(-|z|))`) to dodge the catastrophic cancellation you get from naively logging `cdf` / `sf`.
- `sf` and `logsf` lean on Laplace symmetry: `sf(x) == cdf(2 * loc - x)` and `logsf(x) == logcdf(2 * loc - x)`.
- `isf(q) == 2 * loc - ppf(q)`, again by symmetry about `loc`.

A small win worth flagging: SciPy's default `logcdf` for `rv_continuous` is `log(cdf(x))`, which underflows to `-inf` at deep tails (e.g. `z = -10000`). This implementation routes through `log_half + z` on that branch instead, so it stays finite where SciPy gives up. The parity test stays inside SciPy's safe range so there is no test breakage from this.

### Tests

Added `testLaplaceLogCdf`, `testLaplaceSf`, `testLaplaceLogSf`, and `testLaplaceIsf` mirroring the existing `testLaplaceCdf` / `testLaplacePpf` pattern. SciPy parity passes at `tol={float32: 1e-5, float64: 1e-6}` across the shared `genNamedParametersNArgs(3)` sweep. Local: all 70 Laplace cases pass under both x32 and x64.

Depends on #37755 (review and merge that one first).
