### PR TITLE
Uncomment dtype tests in random_lax_test

### DIFF
--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -268,41 +268,42 @@ class RandomOutShardingTest(RandomTestBase):
     self.assertTrue(result.sharding.is_equivalent_to(sharding, jit_result.ndim))
 
 _DTYPE_CASES = [
-    ('beta', float_dtypes, lambda key, dtype: random.beta(key, np.float16(0.5), np.float16(0.5), shape=(10,), dtype=dtype)),
-    ('binomial', float_dtypes, lambda key, dtype: random.binomial(key, np.float16(10.), np.float16(0.5), shape=(10,), dtype=dtype)),
-    ('chisquare', float_dtypes, lambda key, dtype: random.chisquare(key, np.float16(2.0), shape=(10,), dtype=dtype)),
-    ('dirichlet', float_dtypes, lambda key, dtype: random.dirichlet(key, np.ones(3, np.float16), shape=(10,), dtype=dtype)),
-    # ('double_sided_maxwell', float_dtypes, lambda key, dtype: random.double_sided_maxwell(key, loc=np.float16(0.), scale=np.float16(1.), shape=(10,), dtype=dtype)),
-    ('f', float_dtypes, lambda key, dtype: random.f(key, np.float16(2.0), np.float16(2.0), shape=(10,), dtype=dtype)),
-    ('gamma', float_dtypes, lambda key, dtype: random.gamma(key, np.float16(2.0), shape=(10,), dtype=dtype)),
-    ('geometric', int_dtypes + uint_dtypes, lambda key, dtype: random.geometric(key, np.float16(0.5), shape=(10,), dtype=dtype)),
-    ('loggamma', float_dtypes, lambda key, dtype: random.loggamma(key, np.float16(2.0), shape=(10,), dtype=dtype)),
-    # ('lognormal', float_dtypes, lambda key, dtype: random.lognormal(key, np.float16(1.0), shape=(10,), dtype=dtype)),
-    ('pareto', float_dtypes, lambda key, dtype: random.pareto(key, np.float16(3.0), shape=(10,), dtype=dtype)),
-    ('poisson', int_dtypes + uint_dtypes, lambda key, dtype: random.poisson(key, np.float16(3.0), shape=(10,), dtype=dtype)),
-    ('randint', int_dtypes + uint_dtypes, lambda key, dtype: random.randint(key, shape=(10,), minval=np.int32(0), maxval=np.int32(10), dtype=dtype)),
-    ('rayleigh', float_dtypes, lambda key, dtype: random.rayleigh(key, np.float16(0.5), shape=(10,), dtype=dtype)),
-    ('t', float_dtypes, lambda key, dtype: random.t(key, np.float16(10.0), shape=(10,), dtype=dtype)),
-    # ('triangular', float_dtypes, lambda key, dtype: random.triangular(key, np.float16(0.), np.float16(0.5), np.float16(1.), shape=(10,), dtype=dtype)),
-    ('truncated_normal', float_dtypes, lambda key, dtype: random.truncated_normal(key, lower=np.float16(-2.), upper=np.float16(2.), shape=(10,), dtype=dtype)),
-    ('uniform', float_dtypes, lambda key, dtype: random.uniform(key, shape=(10,), minval=np.float16(0.), maxval=np.float16(1.), dtype=dtype)),
-    ('wald', float_dtypes, lambda key, dtype: random.wald(key, np.float16(1.0), shape=(10,), dtype=dtype)),
-    # ('weibull_min', float_dtypes, lambda key, dtype: random.weibull_min(key, np.float16(1.0), np.float16(1.0), shape=(10,), dtype=dtype)),
+    ('beta', float, lambda key, dtype: random.beta(key, np.float16(0.5), np.float16(0.5), shape=(10,), dtype=dtype)),
+    ('binomial', float, lambda key, dtype: random.binomial(key, np.float16(10.), np.float16(0.5), shape=(10,), dtype=dtype)),
+    ('chisquare', float, lambda key, dtype: random.chisquare(key, np.float16(2.0), shape=(10,), dtype=dtype)),
+    ('dirichlet', float, lambda key, dtype: random.dirichlet(key, np.ones(3, np.float16), shape=(10,), dtype=dtype)),
+    ('double_sided_maxwell', float, lambda key, dtype: random.double_sided_maxwell(key, loc=np.float16(0.), scale=np.float16(1.), shape=(10,), dtype=dtype)),
+    ('f', float, lambda key, dtype: random.f(key, np.float16(2.0), np.float16(2.0), shape=(10,), dtype=dtype)),
+    ('gamma', float, lambda key, dtype: random.gamma(key, np.float16(2.0), shape=(10,), dtype=dtype)),
+    ('geometric', int, lambda key, dtype: random.geometric(key, np.float16(0.5), shape=(10,), dtype=dtype)),
+    ('loggamma', float, lambda key, dtype: random.loggamma(key, np.float16(2.0), shape=(10,), dtype=dtype)),
+    ('lognormal', float, lambda key, dtype: random.lognormal(key, np.float16(1.0), shape=(10,), dtype=dtype)),
+    ('pareto', float, lambda key, dtype: random.pareto(key, np.float16(3.0), shape=(10,), dtype=dtype)),
+    ('poisson', int, lambda key, dtype: random.poisson(key, np.float16(3.0), shape=(10,), dtype=dtype)),
+    ('randint', int, lambda key, dtype: random.randint(key, shape=(10,), minval=np.int32(0), maxval=np.int32(10), dtype=dtype)),
+    ('rayleigh', float, lambda key, dtype: random.rayleigh(key, np.float16(0.5), shape=(10,), dtype=dtype)),
+    ('t', float, lambda key, dtype: random.t(key, np.float16(10.0), shape=(10,), dtype=dtype)),
+    ('triangular', float, lambda key, dtype: random.triangular(key, np.float16(0.), np.float16(0.5), np.float16(1.), shape=(10,), dtype=dtype)),
+    ('truncated_normal', float, lambda key, dtype: random.truncated_normal(key, lower=np.float16(-2.), upper=np.float16(2.), shape=(10,), dtype=dtype)),
+    ('uniform', float, lambda key, dtype: random.uniform(key, shape=(10,), minval=np.float16(0.), maxval=np.float16(1.), dtype=dtype)),
+    ('wald', float, lambda key, dtype: random.wald(key, np.float16(1.0), shape=(10,), dtype=dtype)),
+    ('weibull_min', float, lambda key, dtype: random.weibull_min(key, np.float16(1.0), np.float16(1.0), shape=(10,), dtype=dtype)),
 ]
 
 def expand_dtype_cases(cases):
-  for (name, types, func) in cases:
-    sampled_types = jtu.sample_product_testcases(dtype=types)
+  for (name, abstract_type, func) in cases:
+    to_test = {int: int_dtypes + uint_dtypes, float: float_dtypes}
+    sampled_types = jtu.sample_product_testcases(dtype=to_test[abstract_type])
     for dtype_dict in sampled_types:
       dtype = dtype_dict['dtype']
-      yield (f"{name}_{dtype}", dtype, func)
+      yield (f"{name}_{dtype}", abstract_type, dtype, func)
 
 class RandomDtypeTest(RandomTestBase):
   """Tests that dtype arguments are obeyed for jax.random functions."""
 
   @parameterized.named_parameters(expand_dtype_cases(_DTYPE_CASES))
   @jax.numpy_dtype_promotion('standard')
-  def test_dtype(self, dtype, fn):
+  def test_dtype(self, abstract_type, dtype, fn):
     key = random.key(0)
     jitted = jax.jit(fn, static_argnums=(1,))
     if dtypes.safe_to_cast(np.float16, dtype):
@@ -310,7 +311,7 @@ class RandomDtypeTest(RandomTestBase):
       self.assertEqual(result.dtype, dtype)
       jit_result = jitted(key, dtype)
       self.assertEqual(jit_result.dtype, dtype)
-    else:
+    elif abstract_type is float:
       pass
       # No samplers currently do this, but they should!
       # self.assertRaises(dtypes.TypePromotionError, fn, key, dtype)


### PR DESCRIPTION
This PR uncomments the dtype tests that were previously commented in `random_lax_test.py`