### PR TITLE
Fix type promotion in t dist sampler

### DIFF
--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2253,7 +2253,7 @@ def _pareto(key, b, shape, dtype) -> Array:
 
 def t(key: ArrayLike,
       df: RealArray,
-      shape: Shape = (),
+      shape: Shape | None = None,
       dtype: DTypeLikeFloat | None = None,
       *,
       out_sharding: NamedSharding | P | None = None) -> Array:
@@ -2294,8 +2294,9 @@ def t(key: ArrayLike,
   if not dtypes.issubdtype(dtype, np.floating):
     raise ValueError(f"dtype argument to `t` must be a float "
                      f"dtype, got {dtype}")
-  shape = core.canonicalize_shape(shape)
+  shape = _check_broadcast_shapes("t", shape, df)
   out_sharding = canonicalize_sharding_for_samplers(out_sharding, "t", shape)
+  _check_all_safe_to_cast("t", dtype, df)
   return maybe_auto_axes(_t, out_sharding,
                          shape=shape, dtype=dtype)(key, df)
 


### PR DESCRIPTION
Uses `_check_broadcast_shapes` and `_check_all_safe_to_cast` for the T distribution sampler.