### PR TITLE
Use _check_all_safe_to_cast and _check_broadcast_shapes for gamma samples

### DIFF
--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -21,6 +21,7 @@ from operator import index
 import typing
 from typing import Union
 import warnings
+from contextlib import nullcontext
 
 import numpy as np
 
@@ -78,12 +79,10 @@ def _check_broadcast_shapes(name: str, shape: tuple | Shape | None, *args: Array
     _check_shape(name, shape, *arg_shapes)
   return shape
 
-
 def _check_all_safe_to_cast(name: str, dtype: DTypeLike, *args):
   for arg in args:
     if not dtypes.safe_to_cast(arg, dtype):
       raise dtypes.TypePromotionError(f"In arguments to {name}, cannot safely cast argument of type {jnp.asarray(arg).dtype} to {dtype}")
-
 
 def _isnan(x: ArrayLike) -> Array:
   return lax.ne(x, x)
@@ -1673,8 +1672,8 @@ def gamma(key: ArrayLike,
   if not dtypes.issubdtype(dtype, np.floating):
     raise ValueError(f"dtype argument to `gamma` must be a float "
                      f"dtype, got {dtype}")
-  if shape is not None:
-    shape = core.canonicalize_shape(shape)
+  shape = _check_broadcast_shapes("gamma", shape, a)
+  _check_all_safe_to_cast("gamma", dtype, a)
   out_sharding = canonicalize_sharding_for_samplers(out_sharding, "gamma", shape)
   return maybe_auto_axes(_gamma, out_sharding, shape=shape, dtype=dtype)(key, a)
 
@@ -1703,7 +1702,10 @@ def loggamma(key: ArrayLike,
       shape. Must be broadcast-compatible with ``a``. The default (None)
       produces a result shape equal to ``a.shape``.
     dtype: optional, a float dtype for the returned values (default float64 if
-      jax_enable_x64 is true, otherwise float32).
+      jax_enable_x64 is true, otherwise float32). If this argument is specified,
+      type promotion for ``a`` will be seen as explicit. If
+      left unspecified, type promotions will be seen as implicit, and may fail if
+      `jax_numpy_dtype_promotion='strict'`.
     out_sharding: Optional. Specifies how the output array should be sharded
       across devices in multi-device computation. Can be a
       :class:`~jax.sharding.NamedSharding`, a :class:`~jax.sharding.PartitionSpec`
@@ -1721,24 +1723,24 @@ def loggamma(key: ArrayLike,
     gamma : standard gamma sampler.
   """
   key, _ = _check_prng_key("loggamma", key)
+  if dtype is not None:
+    cxt = config.numpy_dtype_promotion('standard')
+  else:
+    cxt = nullcontext()
   dtype = dtypes.check_and_canonicalize_user_dtype(
       float if dtype is None else dtype)
   if not dtypes.issubdtype(dtype, np.floating):
     raise ValueError(f"dtype argument to `gamma` must be a float "
                      f"dtype, got {dtype}")
-  if shape is not None:
-    shape = core.canonicalize_shape(shape)
+  shape = _check_broadcast_shapes("loggamma", shape, a)
   out_sharding = canonicalize_sharding(out_sharding, "loggamma")
+  with cxt:
+    _check_all_safe_to_cast("loggamma", dtype, a)
   return maybe_auto_axes(_gamma, out_sharding, shape=shape, dtype=dtype, log_space=True)(key, a)
 
 
 @jit(static_argnames=('shape', 'dtype', 'log_space'))
 def _gamma(key, a, shape, dtype, log_space=False) -> Array:
-  if shape is None:
-    shape = np.shape(a)
-  else:
-    _check_shape("gamma", shape, np.shape(a))
-
   a = lax.convert_element_type(a, dtype)
   if np.shape(a) != shape:
     a = jnp.broadcast_to(a, shape)


### PR DESCRIPTION
This is part of the random API refactor, ensuring that promotion and broadcast semantics are consistent across the samplers. 