### PR TITLE
Update for jax.random.maxwell out_sharding when calling normal

### DIFF
--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2535,6 +2535,9 @@ def maxwell(key: ArrayLike,
 @jit(static_argnums=(1, 2, 3))
 def _maxwell(key, shape, dtype, out_sharding) -> Array:
   shape = shape + (3,)
+  # update the out_sharding spec to explicitly put None for the new axis with 3:
+  new_partitions = (*out_sharding.spec, None)
+  out_sharding = out_sharding.update(spec=out_sharding.spec.update(partitions=new_partitions))
   norm_rvs = normal(key=key, shape=shape, dtype=dtype, out_sharding=out_sharding)
   return jnp_linalg.norm(norm_rvs, axis=-1)
 


### PR DESCRIPTION
Follow-up to this comment: https://github.com/jax-ml/jax/pull/37361#discussion_r3269402800

cc @yashk2810 

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->