### PR TITLE
[ROCm] Remove redundant --config=rocm_base from wheel build command

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -667,7 +667,6 @@ async def main():
       )
 
   if "rocm" in args.wheels:
-    wheel_build_command_base.append("--config=rocm_base")
     wheel_build_command_base.append("--config=rocm")
     if clang_local:
       wheel_build_command_base.append(f"--action_env=CLANG_COMPILER_PATH=\"{clang_path}\"")


### PR DESCRIPTION
## Summary

- Removes the redundant `--config=rocm_base` flag from the ROCm wheel build command in `build/build.py`.
- `--config=rocm` already implies `rocm_base`; passing both causes the build to fail.
- This was missed by #37740.

## Test plan

https://github.com/ROCm/jax/actions/runs/26130468380 shows a successful build run.

- [x] ROCm wheel build (`jax-rocm-plugin`, `jax-rocm-pjrt`).