### PR TITLE
threefry2x32: use unrolled loops in CPU lowering

### DIFF
--- a/jax/_src/random/threefry2x32.py
+++ b/jax/_src/random/threefry2x32.py
@@ -184,10 +184,6 @@ _threefry2x32_lowering_rule = mlir.lower_fun(
     partial(_threefry2x32_lowering, use_rolled_loops=False),
     multiple_results=True)
 
-_threefry2x32_cpu_lowering_rule = mlir.lower_fun(
-    partial(_threefry2x32_lowering, use_rolled_loops=True),
-    multiple_results=True)
-
 
 def _threefry2x32_gpu_lowering_rule(ctx, k1, k2, x1, x2, *, target_name_prefix):
   if not config.threefry_gpu_kernel_lowering.value:  # back to default lowering
@@ -218,8 +214,6 @@ threefry2x32_p.def_abstract_eval(_threefry2x32_abstract_eval)
 batching.defbroadcasting(threefry2x32_p)
 mlir.register_lowering(
     threefry2x32_p, _threefry2x32_lowering_rule, inline=False)
-mlir.register_lowering(
-    threefry2x32_p, _threefry2x32_cpu_lowering_rule, platform='cpu')
 mlir.register_lowering(
     threefry2x32_p,
     partial(_threefry2x32_gpu_lowering_rule, target_name_prefix='cu'),


### PR DESCRIPTION
With the recent thunk runtime changes, it seems like using rolled loops in the `threefry2x32` hash is no longer advantageous either in compilation cost or runtime cost. For generating `(2048, 128)` uniform samples on my macbook CPU, changing to unrolled loops reduces compile time from ~70ms to ~40ms, and reduces runtime from ~1.0ms to ~0.3ms.

<details>
<summary>benchmark scripts</summary>

Run at head:
```python
In [1]: import jax

In [2]: key = jax.random.key(0)

In [3]: %timeit jax.jit(lambda k: jax.random.uniform(k, (2048, 128))).lower(key).compile()
71.5 ms ± 3.43 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [4]: f = jax.jit(lambda k: jax.random.uniform(k, (2048, 128)))

In [5]: _ = f(key).block_until_ready()

In [6]: %timeit f(key).block_until_ready()
1.03 ms ± 14.7 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

Run with changes in this PR:
```python
In [1]: import jax

In [2]: key = jax.random.key(0)

In [3]: %timeit jax.jit(lambda k: jax.random.uniform(k, (2048, 128))).lower(key).compile()
40.9 ms ± 196 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [4]: f = jax.jit(lambda k: jax.random.uniform(k, (2048, 128)))

In [5]: _ = f(key).block_until_ready()

In [6]: %timeit f(key).block_until_ready()
317 μs ± 1.04 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

</details>