### PR TITLE
[dlpack] [cuda] Support pinned host tensors in from_dlpack

### DIFF
--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -445,7 +445,10 @@ class ArrayImpl(basearray.Array):
     elif self.platform() == "gpu":
       platform_version = _get_device(self).client.platform_version
       if "cuda" in platform_version:
-        dl_device_type = DLDeviceType.kDLCUDA
+        if self.sharding.memory_kind == "pinned_host":
+          dl_device_type = DLDeviceType.kDLCUDAHost
+        else:
+          dl_device_type = DLDeviceType.kDLCUDA
       elif "rocm" in platform_version:
         dl_device_type = DLDeviceType.kDLROCM
       else:

--- a/jax/_src/dlpack.py
+++ b/jax/_src/dlpack.py
@@ -23,6 +23,7 @@ from jax._src.api import device_put
 from jax._src.lax.lax import _array_copy
 from jax._src.lib import _jax
 from jax._src.lib import xla_client
+from jax._src.lib import jaxlib_extension_version
 from jax._src.numpy import lax_numpy as jnp
 from jax._src.numpy import scalar_types as jnp_types
 from jax._src.sharding import Sharding
@@ -85,6 +86,7 @@ def _to_dlpack(x: Array, stream: int | Any | None,
 _DL_DEVICE_TO_PLATFORM = {
     DLDeviceType.kDLCPU: "cpu",
     DLDeviceType.kDLCUDA: "cuda",
+    DLDeviceType.kDLCUDAHost: "cuda",
     DLDeviceType.kDLROCM: "rocm",
 }
 
@@ -255,6 +257,10 @@ def from_dlpack(external_array,
   if _is_tensorflow_tensor(external_array):
     # TensorFlow does not support stream=.
     stream = None
+  elif dl_device_type == DLDeviceType.kDLCUDAHost:
+    # Some producers (e.g. torch.Tensor with is_pinned()) route pinned tensors
+    # through their CPU __dlpack__, which rejects a non-None stream argument.
+    stream = None
   else:
     try:
       stream = dlpack_device.get_stream_for_external_ready_events()
@@ -266,8 +272,12 @@ def from_dlpack(external_array,
   dlpack = external_array.__dlpack__(stream=stream)
 
   try:
-    arr = _jax.dlpack_managed_tensor_to_buffer(
-      dlpack, dlpack_device, stream, copy)
+    if jaxlib_extension_version >= 467:
+      arr = _jax.dlpack_managed_tensor_to_buffer(
+        dlpack, dlpack_device, stream, copy, int(dl_device_type))
+    else:
+      arr = _jax.dlpack_managed_tensor_to_buffer(
+        dlpack, dlpack_device, stream, copy)
   except xla_client.XlaRuntimeError as e:
     se = str(e)
     if "is not aligned to" in se:

--- a/jax/_src/typing.py
+++ b/jax/_src/typing.py
@@ -106,6 +106,7 @@ class DeprecatedArg:
 class DLDeviceType(enum.IntEnum):
   kDLCPU = 1
   kDLCUDA = 2
+  kDLCUDAHost = 3
   kDLROCM = 10
 
 AnyInt = int | np.integer

--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -708,6 +708,7 @@ cc_library(
         "@xla//xla:util",
         "@xla//xla:xla_data_proto_cc",
         "@xla//xla/pjrt:exceptions",
+        "@xla//xla/pjrt:host_memory_spaces",
         "@xla//xla/pjrt:pjrt_client",
         "@xla//xla/pjrt:pjrt_common",
         "@xla//xla/pjrt:pjrt_compiler",

--- a/jaxlib/_jax/__init__.pyi
+++ b/jaxlib/_jax/__init__.pyi
@@ -957,6 +957,7 @@ def dlpack_managed_tensor_to_buffer(
     device: Device,
     stream: int | None,
     copy: bool | None = ...,
+    dl_device_type: int | None = ...,
 ) -> ArrayImpl: ...
 def cuda_array_interface_to_buffer(
     cai: dict, gpu_backend: Client | None = ..., device_id: int | None = ...

--- a/jaxlib/dlpack.cc
+++ b/jaxlib/dlpack.cc
@@ -44,6 +44,7 @@ limitations under the License.
 #include "jaxlib/util.h"
 #include "xla/layout.h"
 #include "xla/pjrt/exceptions.h"
+#include "xla/pjrt/host_memory_spaces.h"
 #include "xla/pjrt/pjrt_client.h"
 #include "xla/pjrt/pjrt_common.h"
 #include "xla/pjrt/pjrt_compiler.h"
@@ -142,10 +143,18 @@ absl::StatusOr<DLDeviceType> DLDeviceTypeForDevice(
                               device.DebugString());
 }
 
-absl::StatusOr<DLDevice> DLDeviceForDevice(const xla::PjRtDevice& device) {
+absl::StatusOr<DLDevice> DLDeviceForBuffer(const xla::PjRtBuffer& buffer) {
   DLDevice context;
-  TF_ASSIGN_OR_RETURN(context.device_type, DLDeviceTypeForDevice(device));
-  context.device_id = device.local_hardware_id().value();
+  const xla::PjRtMemorySpace* memory_space = buffer.memory_space();
+  if (memory_space != nullptr &&
+      memory_space->kind() == xla::PinnedHostMemorySpace::kKind &&
+      buffer.device()->client()->platform_id() == xla::CudaId()) {
+    context.device_type = kDLCUDAHost;
+  } else {
+    TF_ASSIGN_OR_RETURN(context.device_type,
+                        DLDeviceTypeForDevice(*buffer.device()));
+  }
+  context.device_id = buffer.device()->local_hardware_id().value();
   return context;
 }
 
@@ -185,7 +194,8 @@ MakePjrtBuffer(xla::PjRtDevice& device, ::DLManagedTensor* dlmt,
                const xla::Shape& shape, xla::PrimitiveType element_type,
                absl::Span<int64_t const> dimensions,
                std::optional<bool> copy = std::nullopt,
-               std::optional<std::intptr_t> stream = std::nullopt) {
+               std::optional<std::intptr_t> stream = std::nullopt,
+               std::optional<DLDeviceType> dl_device_type = std::nullopt) {
   std::function<void()> on_delete_callback;
   if (dlmt->deleter) {
     on_delete_callback = [dlmt]() { dlmt->deleter(dlmt); };
@@ -194,17 +204,33 @@ MakePjrtBuffer(xla::PjRtDevice& device, ::DLManagedTensor* dlmt,
   void* data =
       static_cast<char*>(dlmt->dl_tensor.data) + dlmt->dl_tensor.byte_offset;
 
+  // DLPack producers advertise the tensor device type via __dlpack_device__()
+  // but the corresponding __dlpack__() call might return a capsule with a
+  // different device type. E.g. pinned PyTorch tensors on CUDA advertise
+  // kDLCUDAHost but store kDLCPU in the capsule. dl_device_type allows us to
+  // explicitly override the capsule's device type and pick the correct
+  // destination memory space, i.e. pinned_host in the above example.
+  DLDeviceType effective_device_type =
+      dl_device_type.value_or(dlmt->dl_tensor.device.device_type);
+  xla::PjRtMemorySpace* memory_space;
+  if (effective_device_type == kDLCUDAHost) {
+    TF_ASSIGN_OR_RETURN(memory_space,
+        device.memory_space_by_kind(xla::PinnedHostMemorySpace::kKind));
+  } else {
+    TF_ASSIGN_OR_RETURN(memory_space, device.default_memory_space());
+  }
+
   // On CPU, creating a view may fail because of unaligned data buffer
   // in which case we'll fallback to copy. On non-CPU, array-api copy
   // semantics is handled in dlpack._place_array function.
   bool fallback_to_copy =
-      !copy.has_value() && dlmt->dl_tensor.device.device_type == kDLCPU;
+      !copy.has_value() &&
+      (effective_device_type == kDLCPU || effective_device_type == kDLCUDAHost);
 
   // Create a view.
   if (!copy.value_or(false)) {
     auto result = device.client()->CreateViewOfDeviceBuffer(
-        data, shape, *device.default_memory_space(), on_delete_callback,
-        stream);
+        data, shape, memory_space, on_delete_callback, stream);
     if (!(result.status().code() == absl::StatusCode::kInvalidArgument &&
           fallback_to_copy)) {
       TF_RETURN_IF_ERROR(result.status());
@@ -217,8 +243,6 @@ MakePjrtBuffer(xla::PjRtDevice& device, ::DLManagedTensor* dlmt,
   if (dlmt->dl_tensor.strides) {
     TF_ASSIGN_OR_RETURN(byte_strides, GetByteStrides(dlmt->dl_tensor));
   }
-
-  TF_ASSIGN_OR_RETURN(auto* memory_space, device.default_memory_space());
 
   // Create a copy.
   TF_ASSIGN_OR_RETURN(
@@ -276,8 +300,7 @@ absl::StatusOr<nb::capsule> BufferToDLPackManagedTensor(
   dt.data = pack->external_reference->OpaqueDeviceMemoryDataPointer();
   pack->tensor.manager_ctx = pack.get();
   pack->tensor.deleter = DLPackTensorDeleter;
-  TF_ASSIGN_OR_RETURN(dt.device, DLDeviceForDevice(*pjrt_buffer->device()));
-  dt.device.device_id = pjrt_buffer->device()->local_hardware_id().value();
+  TF_ASSIGN_OR_RETURN(dt.device, DLDeviceForBuffer(*pjrt_buffer));
   dt.ndim = pjrt_buffer->dimensions().size();
   TF_ASSIGN_OR_RETURN(dt.dtype,
                       PrimitiveTypeToDLDataType(pjrt_buffer->element_type()));
@@ -328,7 +351,7 @@ absl::StatusOr<nb::capsule> BufferToDLPackManagedTensor(
 absl::StatusOr<nb::object> DLPackManagedTensorToBuffer(
     const nb::capsule& tensor, ifrt::Device* ifrt_device,
     nb_class_ptr<PyClient> client, std::optional<std::intptr_t> stream,
-    std::optional<bool> copy) {
+    std::optional<bool> copy, std::optional<DLDeviceType> dl_device_type) {
   ifrt::PjRtDevice* device =
       llvm::dyn_cast_or_null<ifrt::PjRtDevice>(ifrt_device);
   if (device == nullptr) {
@@ -374,7 +397,8 @@ absl::StatusOr<nb::object> DLPackManagedTensorToBuffer(
 
   TF_ASSIGN_OR_RETURN(auto pjrt_buffer_and_copied,
                       MakePjrtBuffer(*device->pjrt_device(), dlmt, shape,
-                                     element_type, dimensions, copy, stream));
+                                     element_type, dimensions, copy, stream,
+                                     dl_device_type));
   if (pjrt_buffer_and_copied.second) {
     // A PjRtBuffer uses a default layout if it has been created using copy.
     has_custom_layout = false;

--- a/jaxlib/dlpack.h
+++ b/jaxlib/dlpack.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <optional>
 
 #include "absl/status/statusor.h"
+#include "include/dlpack/dlpack.h"
 #include "nanobind/nanobind.h"
 #include "nanobind/ndarray.h"
 #include "jaxlib/nb_class_ptr.h"
@@ -42,7 +43,8 @@ absl::StatusOr<nanobind::capsule> BufferToDLPackManagedTensor(
 absl::StatusOr<nanobind::object> DLPackManagedTensorToBuffer(
     const nanobind::capsule& tensor, xla::ifrt::Device* device,
     nb_class_ptr<PyClient> client, std::optional<std::intptr_t> stream,
-    std::optional<bool> copy);
+    std::optional<bool> copy,
+    std::optional<DLDeviceType> dl_device_type = std::nullopt);
 
 // Converts a PrimitiveType to the nanobind specific implementation of
 // DLDataType.

--- a/jaxlib/jax.cc
+++ b/jaxlib/jax.cc
@@ -649,19 +649,26 @@ NB_MODULE(_jax, m) {
   m.def(
       "dlpack_managed_tensor_to_buffer",
       [](const nb::capsule& tensor, nb_class_ptr<PyDevice> device,
-         std::optional<std::intptr_t> stream, std::optional<bool> copy) {
+         std::optional<std::intptr_t> stream, std::optional<bool> copy,
+         std::optional<int> dl_device_type) {
+        std::optional<DLDeviceType> dl_dt;
+        if (dl_device_type.has_value()) {
+          dl_dt = static_cast<DLDeviceType>(*dl_device_type);
+        }
         return xla::ValueOrThrow(DLPackManagedTensorToBuffer(
-            tensor, device->device(), device->client(), stream, copy));
+            tensor, device->device(), device->client(), stream, copy, dl_dt));
       },
       nb::arg("dlpack"), nb::arg("device"), nb::arg("stream").none(),
       nb::arg("copy").none() = nb::none(),
+      nb::arg("dl_device_type").none() = nb::none(),
       nb::sig(
           // clang-format off
       "def dlpack_managed_tensor_to_buffer("
       "dlpack: types.CapsuleType, "
       "device: Device, "
       "stream: int | None, "
-      "copy: bool | None = ..."
+      "copy: bool | None = ..., "
+      "dl_device_type: int | None = ..."
       ") -> ArrayImpl"
           // clang-format on
           ));

--- a/jaxlib/xla_client.py
+++ b/jaxlib/xla_client.py
@@ -45,7 +45,7 @@ ifrt_programs = _xla.ifrt_programs
 # Please suffix the version number with a brief description of your change
 # in a comment. The goal here is to force a merge conflict if two changes
 # attempt to grab the same version number.
-_version = 466  # Fix UAF in PjitFunctionCache with ReentrantHashMap
+_version = 467  # Add dl_device_type param to dlpack_managed_tensor_to_buffer
 
 # An internal increasing version number for protecting jaxlib code against
 # ifrt changes.

--- a/tests/pytorch_interoperability_test.py
+++ b/tests/pytorch_interoperability_test.py
@@ -18,6 +18,7 @@ from absl.testing import absltest
 
 import jax
 from jax._src import config
+from jax._src import dlpack as dlpack_src
 from jax._src import test_util as jtu
 from jax._src import xla_bridge
 from jax._src.lib import _jax
@@ -164,6 +165,23 @@ class DLPackTest(jtu.JaxTestCase):
     # Verify the resulting value can be passed to a jit computation.
     z = jax.jit(lambda x: x + 1)(y)
     self.assertAllClose(x_np + dtype(1), z)
+
+  @jtu.run_on_devices("cuda")
+  def testPinnedTorchToJaxZeroCopy(self):
+    # A pinned CPU tensor advertises itself as kDLCUDAHost via
+    # __dlpack_device__(). Confirm that JAX imports it as a zero-copy view into
+    # the CUDA device's pinned_host memory space.
+    cuda_device = jax.devices("cuda")[0]
+    x = torch.arange(8, dtype=torch.float32).pin_memory()
+    self.assertEqual(
+        x.__dlpack_device__(),
+        (dlpack_src.DLDeviceType.kDLCUDAHost, 0))
+
+    arr = jax.dlpack.from_dlpack(x)
+    self.assertEqual(arr.sharding.memory_kind, "pinned_host")
+    self.assertEqual(arr.devices(), {cuda_device})
+    self.assertEqual(arr.unsafe_buffer_pointer(), x.data_ptr())
+    self.assertAllClose(arr, x.numpy())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On the CUDA platform JAX currently does not support importing dlpack tensors in pinned host memory. This is both because the appropriate dlpack device type (`kDLCUDAHost`) is unhandled in JAX's `from_dlpack` and because the conversion to a PjRt buffer doesn't account for pinned host memory.

This PR enables the above to work on pinned pytorch arrays, e.g.
```python
>>> import jax
>>> import jax.dlpack
>>> import torch
>>> a = torch.zeros(4, device=torch.device("cpu")).pin_memory()
>>> print(a.__dlpack_device__())
(<DLDeviceType.kDLCUDAHost: 3>, 0)
>>> a_jax = jax.dlpack.from_dlpack(a)
>>> print(a_jax.sharding, a_jax)
SingleDeviceSharding(device=CudaDevice(id=0), memory_kind=pinned_host) [0. 0. 0. 0.]
```

Eventually an analogous snippet using e.g. CuPy's `cupyx.empty_pinned(size)` should work as well (it currently doesn't because cupy advertises pinned host tensors as `kDLCPU` rather than `kDLCUDAHost`).

cc @hawkinsp 