### PR TITLE
Fix digamma(0) to return -inf matching scipy

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -486,7 +486,15 @@ def digamma(x: ArrayLike) -> Array:
     - :func:`jax.scipy.special.polygamma`
   """
   x, = promote_args_inexact("digamma", x)
-  return lax.digamma(x)
+  # digamma has a simple pole at x = 0; lax.digamma returns NaN there, but
+  # scipy.special.digamma returns -inf for +0 and +inf for -0 (signed limit
+  # from each side of the pole). Mask x to a safe value (1.0) on the pole
+  # branch so the unselected path never produces NaN that contaminates
+  # gradients via jnp.where's VJP (0 * NaN = NaN).
+  is_zero = x == 0
+  x_safe = jnp.where(is_zero, 1.0, x)
+  pole_val = jnp.where(jnp.signbit(x), jnp.inf, -jnp.inf).astype(x.dtype)
+  return jnp.where(is_zero, pole_val, lax.digamma(x_safe))
 
 
 def gammainc(a: ArrayLike, x: ArrayLike) -> Array:

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -350,6 +350,18 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
       result_jit = lsp_special.expi(x)
     self.assertAllClose(result_jit, result_nojit)
 
+  def testDigammaBoundaryValues(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/37763
+    # digamma has a simple pole at x = 0, so digamma(+0) should be -inf and
+    # digamma(-0) should be +inf to match scipy.special.digamma, not NaN.
+    dtype = dtypes.default_float_dtype()
+    x_samples = np.array([0.0, -0.0, 1.0, 0.5, -1.0], dtype=dtype)
+    args_maker = lambda: (x_samples,)
+    rtol = 1E-3 if jtu.test_device_matches(["tpu"]) else 1e-5
+    self._CheckAgainstNumpy(lsp_special.digamma, osp_special.digamma,
+                            args_maker, rtol=rtol)
+    self._CompileAndCheck(lsp_special.digamma, args_maker, rtol=rtol)
+
   def testGammaIncBoundaryValues(self):
     dtype = dtypes.default_float_dtype()
     nan = float('nan')


### PR DESCRIPTION
## Summary

`jax.scipy.special.digamma(0.0)` currently returns `NaN` because the underlying `lax.digamma` kernel returns `NaN` at the simple pole at the origin. `scipy.special.digamma(0.0)` returns `-inf` (and `+inf` for `-0.0`, the signed limit from each side of the pole). This PR wraps the `lax.digamma` call with a `jnp.where` guard so the JAX path matches scipy parity.

The mask-to-safe-value pattern (used elsewhere in this file, e.g. `_loggamma_lanczos`) keeps gradients through the unselected path free of NaN. All other values are unchanged.

### Before
```
digamma(0.0):  scipy=-inf   jax=nan    wrong
digamma(-0.0): scipy=+inf   jax=nan    wrong
digamma(0.5):  scipy=-1.96  jax=-1.96  ok
```

### After
```
digamma(0.0):  scipy=-inf   jax=-inf   ok
digamma(-0.0): scipy=+inf   jax=+inf   ok
digamma(0.5):  scipy=-1.96  jax=-1.96  ok
```

Note: the secondary subnormal-input issue called out in the bug report (subnormals being flushed to zero by XLA's DAZ mode) is a consequence of `digamma(0)` returning `NaN`, so this fix resolves that path too on backends where the DAZ flush routes subnormals through the new branch.

Fixes #37763

## Test plan

- [x] New regression test `testDigammaBoundaryValues` added to `tests/lax_scipy_special_functions_test.py` that exercises `0.0`, `-0.0`, `1.0`, `0.5` via `_CheckAgainstNumpy` and `_CompileAndCheck`.
- [x] Existing digamma tests (`testScipySpecialFun_digamma_*`, including the autodiff tests) still pass.
- [x] Full `lax_scipy_special_functions_test.py` suite (370 tests) passes locally.
- [x] `ruff check` clean on the touched files.