### PR TITLE
Fix floor_divide and divmod behavior when divisor is zero

### DIFF
--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -2590,7 +2590,7 @@ def _float_divmod(x1: ArrayLike, x2: ArrayLike) -> tuple[Array, Array]:
   ind = lax.bitwise_and(mod != 0, lax.sign(x2) != lax.sign(mod))
   mod = lax.select(ind, mod + x2, mod)
   div = lax.select(ind, div - _constant_like(div, 1), div)
-
+  div = _where(x2 == 0, lax.div(x1, x2), div)
   return lax.round(div), mod
 
 

--- a/tests/lax_numpy_operators_test.py
+++ b/tests/lax_numpy_operators_test.py
@@ -706,6 +706,17 @@ class JaxNumpyOperatorTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np.spacing, jnp.spacing, args_maker, check_dtypes=True, tol=0)
     self._CompileAndCheck(jnp.spacing, args_maker, tol=0)
 
+  @jtu.sample_product(dtype=float_dtypes)
+  def testFloatDivmodZeroDivisor(self, dtype):
+    # https://github.com/jax-ml/jax/issues/37752
+    vals = [1, -1, 100, -100]
+    args_maker = lambda: (np.array(vals, dtype=dtype), np.zeros_like(vals, dtype=dtype))
+    with np.errstate(divide='ignore'):
+      self._CheckAgainstNumpy(np.floor_divide, jnp.floor_divide, args_maker)
+      self._CompileAndCheck(jnp.floor_divide, args_maker)
+      self._CheckAgainstNumpy(np.divmod, jnp.divmod, args_maker)
+      self._CompileAndCheck(jnp.divmod, args_maker)
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
### Description
Updates the behavior of `floor_divide` and `divmod` when the divisor is 0 to match NumPy / IEEE 754.
This difference was due to nans from `lax.rem`, which poisoned the quotient. The behavior now matches `lax.div` when the divisor is 0.

Resolves #37752 