### PR TITLE
Fix BCOO gradients for vmapped sparse matvecs

### DIFF
--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -47,7 +47,8 @@ from jax._src.interpreters import ad
 from jax._src.interpreters import batching
 from jax._src.interpreters import partial_eval as pe
 from jax._src.lax.lax import (
-  _const, ranges_like, remaining, _dot_general_batch_dim_nums, DotDimensionNumbers)
+  _const, _unbroadcast, ranges_like, remaining, _dot_general_batch_dim_nums,
+  DotDimensionNumbers)
 from jax._src.lax.slicing import GatherDimensionNumbers, GatherScatterMode
 from jax._src.numpy.setops import _unique
 from jax._src.typing import Array, ArrayLike, DTypeLike
@@ -895,6 +896,7 @@ def _bcoo_dot_general_transpose(ct, lhs_data, lhs_indices, rhs, *, dimension_num
       out_dense_T = lax.dot_general(ct, rhs, dimension_numbers=dims)
       out_dense = lax.transpose(out_dense_T, out_axes)
       result = _bcoo_extract(lhs_indices, out_dense)
+    result = _unbroadcast(lhs_data.aval, result)
     return result, lhs_indices, rhs
   else:
     dims = ((lhs_kept, ans_lhs), (lhs_batch, ans_batch))

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -691,6 +691,41 @@ class SparseGradTest(sptu.SparseTestCase):
       self.assertAllClose(jax.grad(f, argnums=1, has_aux=has_aux)(X, y),
                           sparse.grad(f, argnums=1, has_aux=has_aux)(Xsp, y))
 
+  def test_bcoo_dot_general_vmap_matvec_grad(self):
+    A_dense = jnp.array(
+        [[4.0, -1.0, 0.0, 0.0],
+         [-1.0, 4.0, -1.0, 0.0],
+         [0.0, -1.0, 4.0, -1.0],
+         [0.0, 0.0, -1.0, 4.0]],
+        dtype=jnp.float32)
+    A_bcoo = sparse.BCOO.fromdense(A_dense)
+    B = jnp.array(
+        [[1.0, 0.0, 2.0],
+         [0.0, 1.0, 1.0],
+         [1.0, 1.0, 0.0],
+         [0.0, 2.0, 1.0]],
+        dtype=jnp.float32)
+
+    def sparse_objective(data):
+      A = sparse.BCOO(
+          (data, A_bcoo.indices),
+          shape=A_bcoo.shape,
+          indices_sorted=A_bcoo.indices_sorted,
+          unique_indices=A_bcoo.unique_indices)
+      X = jax.vmap(lambda b: A @ b, in_axes=1, out_axes=1)(B)
+      return jnp.sum(X ** 2)
+
+    def dense_objective(A):
+      X = jax.vmap(lambda b: A @ b, in_axes=1, out_axes=1)(B)
+      return jnp.sum(X ** 2)
+
+    grad_bcoo_data = jax.grad(sparse_objective)(A_bcoo.data)
+    grad_dense = jax.grad(dense_objective)(A_dense)
+
+    self.assertEqual(grad_bcoo_data.shape, A_bcoo.data.shape)
+    self.assertAllClose(
+        grad_bcoo_data, sparse_bcoo._bcoo_extract(A_bcoo.indices, grad_dense))
+
   @jtu.sample_product(
     has_aux=[True, False],
     transform=['jacrev', 'jacfwd', 'jacobian']


### PR DESCRIPTION
Fixes #37647

This PR fixes reverse-mode differentiation through vmapped `BCOO` matrix-vector products.

The transpose rule for `bcoo_dot_general` can produce a cotangent for `lhs_data` with broadcast batch dimensions. The primal sparse data may have size-1 batch dimensions, so returning the broadcasted cotangent directly leads to a shape mismatch during transpose checking.

This change reuses JAX's existing `_unbroadcast` helper before returning the sparse-data cotangent, reducing it back to the primal `lhs_data` shape.