### PR TITLE
ci: restrict presubmit artifact builds to non-fork PRs

### DIFF
--- a/.github/workflows/bazel_cpu_presubmit.yml
+++ b/.github/workflows/bazel_cpu_presubmit.yml
@@ -26,6 +26,9 @@ concurrency:
 
 jobs:
   build-jax-artifact:
+    # Restrict artifact builds to non-fork PRs to prevent untrusted code from
+    # running on privileged self-hosted GCE runners.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/build_artifacts.yml
     name: "Build jax artifact"
     with:
@@ -36,6 +39,7 @@ jobs:
         upload_artifacts_to_gcs: false
 
   build-jaxlib-artifact:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/build_artifacts.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure

--- a/.github/workflows/bazel_cuda_b200_mosaic_presubmit.yml
+++ b/.github/workflows/bazel_cuda_b200_mosaic_presubmit.yml
@@ -132,7 +132,8 @@ jobs:
           !cancelled()
           && (
                github.event_name == 'workflow_dispatch'
-               || needs.changed_files.outputs.any_changed == 'true'
+               || (github.event.pull_request.head.repo.full_name == github.repository
+                   && needs.changed_files.outputs.any_changed == 'true')
           )
       }}
     runs-on: linux-x86-a4-224-b200-1gpu

--- a/.github/workflows/bazel_cuda_presubmit.yml
+++ b/.github/workflows/bazel_cuda_presubmit.yml
@@ -26,6 +26,9 @@ concurrency:
 permissions: {}
 jobs:
   build-cuda-artifacts:
+    # Restrict artifact builds to non-fork PRs to prevent untrusted code from
+    # running on privileged self-hosted GCE runners.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/build_artifacts.yml
     strategy:
         fail-fast: false # don't cancel all jobs on failure


### PR DESCRIPTION
## Summary

Artifact build jobs in three presubmit workflows execute code from the checked-out repository on privileged self-hosted GCE runners (`linux-x86-n4-16`, `linux-arm64-c4a-16`, `windows-x86-n2-16`, `linux-x86-a4-224-b200-1gpu`) without restricting to same-repository pull requests.

An attacker who opens a PR from a fork can modify `ci/build_artifacts.sh` or `ci/run_bazel_cuda_targeted_tests.sh` in their fork and have it executed on these GCE runners, giving access to the runner's GCE service account (accessible via the metadata server at `http://metadata.google.internal/`).

**Affected jobs (no fork guard):**
- `bazel_cpu_presubmit.yml` → `build-jax-artifact`, `build-jaxlib-artifact` (n4-16, arm64-c4a-16, windows-x86-n2-16)
- `bazel_cuda_presubmit.yml` → `build-cuda-artifacts` (n4-16)
- `bazel_cuda_b200_mosaic_presubmit.yml` → `run_tests` (a4-224-b200-1gpu)

Note: `run_tests` in `bazel_cpu_presubmit.yml`, `run-tests` in `bazel_cuda_presubmit.yml`, and `run-bazel-test-tpu` in `cloud-tpu-ci-presubmit.yml` already have correct guards (`if: github.event.repository.fork == false`).

## Fix

Add `if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository` to the three affected jobs:
- Allows `workflow_dispatch` and `push` events (main/release branch CI) to proceed normally
- Restricts `pull_request` triggers to same-repository PRs only
- Fork PRs skip the artifact build jobs (no code execution, no resource access)

## Test plan

- [ ] Verify CI passes on a non-fork PR after this change
- [ ] Verify that fork PRs skip the artifact build jobs (check workflow run for `build-jax-artifact`, `build-jaxlib-artifact`, `build-cuda-artifacts`, and B200 `run_tests`)