### PR TITLE
[random] implement philox in terms of lax.mulhi

### DIFF
--- a/jax/_src/random/philox2x32.py
+++ b/jax/_src/random/philox2x32.py
@@ -53,57 +53,6 @@ _PHILOX_W32_0 = np.uint32(0x9E3779B9)
 _DEFAULT_ROUNDS = 10
 
 
-# -- Helper functions --
-
-
-def _mulhilo32(a, b):
-  """Compute full 64-bit product of two uint32 values, return (lo, hi).
-
-  Uses only 32-bit operations (half-width multiply), following the
-  _mulhilo_c99_tpl pattern from Random123. This avoids requiring
-  jax_enable_x64=True.
-
-  Args:
-    a: uint32 array
-    b: uint32 array
-
-  Returns:
-    Tuple of (low, high) 64-bit result split into two uint32 arrays.
-  """
-  whalf = np.uint32(16)
-  lomask = np.uint32(0xFFFF)
-
-  # Split inputs into 16-bit halves.
-  ahi = lax.shift_right_logical(a, whalf)
-  alo = a & lomask
-  bhi = lax.shift_right_logical(b, whalf)
-  blo = b & lomask
-
-  # Low 32 bits of the product (modular uint32 multiply gives this directly).
-  lo = a * b
-
-  # Cross products (each fits in uint32 since both operands are ≤ 0xFFFF).
-  ahbl = ahi * blo
-  albh = alo * bhi
-
-  # Sum of the lower halves of the cross products.
-  ahbl_albh = (ahbl & lomask) + (albh & lomask)
-
-  # High 32 bits: ahi*bhi plus upper halves of cross products plus carries.
-  hi = (
-      ahi * bhi
-      + lax.shift_right_logical(ahbl, whalf)
-      + lax.shift_right_logical(albh, whalf)
-      + lax.shift_right_logical(ahbl_albh, whalf)
-  )
-  # Carry from the addition of lo's upper half with ahbl_albh's lower half.
-  lo_upper = lax.shift_right_logical(lo, whalf)
-  carry = lax.convert_element_type(lo_upper < (ahbl_albh & lomask), np.uint32)
-  hi = hi + carry
-
-  return lo, hi
-
-
 # -- Core Philox 2x32 hash --
 
 
@@ -126,7 +75,7 @@ def _philox2x32_lowering(k0, x0, x1):
     # Philox 2x32 round function:
     #   lo, hi = mulhilo(M2x32_0, x0)
     #   out = [hi ^ x1 ^ k0, lo]
-    lo, hi = _mulhilo32(_PHILOX_M2x32_0, x0)
+    lo, hi = lax.mul(_PHILOX_M2x32_0, x0), lax.mulhi(_PHILOX_M2x32_0, x0)
 
     x0 = hi ^ x1 ^ k0
     x1 = lo

--- a/jax/_src/random/philox4x32.py
+++ b/jax/_src/random/philox4x32.py
@@ -54,61 +54,6 @@ _PHILOX_W32_1 = np.uint32(0xBB67AE85)
 
 _DEFAULT_ROUNDS = 10
 
-
-# -- Helper functions --
-
-
-# TODO(jakevdp) some platforms have single-instruction 32x32->64bit integer
-# multiply. We should use that here – either via a new primitive, or perhaps
-# an out_dtype argument on mul.
-def _mulhilo32(a, b):
-  """Compute full 64-bit product of two uint32 values, return (lo, hi).
-
-  Uses only 32-bit operations (half-width multiply), following the
-  _mulhilo_c99_tpl pattern from Random123. This avoids requiring
-  jax_enable_x64=True.
-
-  Args:
-    a: uint32 array
-    b: uint32 array
-
-  Returns:
-    Tuple of (low, high) 64-bit result split into two uint32 arrays.
-  """
-  whalf = np.uint32(16)
-  lomask = np.uint32(0xFFFF)
-
-  # Split inputs into 16-bit halves.
-  ahi = lax.shift_right_logical(a, whalf)
-  alo = a & lomask
-  bhi = lax.shift_right_logical(b, whalf)
-  blo = b & lomask
-
-  # Low 32 bits of the product (modular uint32 multiply gives this directly).
-  lo = a * b
-
-  # Cross products (each fits in uint32 since both operands are ≤ 0xFFFF).
-  ahbl = ahi * blo
-  albh = alo * bhi
-
-  # Sum of the lower halves of the cross products.
-  ahbl_albh = (ahbl & lomask) + (albh & lomask)
-
-  # High 32 bits: ahi*bhi plus upper halves of cross products plus carries.
-  hi = (
-      ahi * bhi
-      + lax.shift_right_logical(ahbl, whalf)
-      + lax.shift_right_logical(albh, whalf)
-      + lax.shift_right_logical(ahbl_albh, whalf)
-  )
-  # Carry from the addition of lo's upper half with ahbl_albh's lower half.
-  lo_upper = lax.shift_right_logical(lo, whalf)
-  carry = lax.convert_element_type(lo_upper < (ahbl_albh & lomask), np.uint32)
-  hi = hi + carry
-
-  return lo, hi
-
-
 # -- Core Philox 4x32 hash --
 
 
@@ -136,8 +81,8 @@ def _philox4x32_lowering(k0, k1, x0, x1, x2, x3):
     #   lo0, hi0 = mulhilo(M0, x0)
     #   lo1, hi1 = mulhilo(M1, x2)
     #   out = [hi1 ^ x1 ^ k0, lo1, hi0 ^ x3 ^ k1, lo0]
-    lo0, hi0 = _mulhilo32(_PHILOX_M4x32_0, x0)
-    lo1, hi1 = _mulhilo32(_PHILOX_M4x32_1, x2)
+    lo0, hi0 = lax.mul(_PHILOX_M4x32_0, x0), lax.mulhi(_PHILOX_M4x32_0, x0)
+    lo1, hi1 = lax.mul(_PHILOX_M4x32_1, x2), lax.mulhi(_PHILOX_M4x32_1, x2)
 
     x0_new = hi1 ^ x1 ^ k0
     x1_new = lo1


### PR DESCRIPTION
This uses the recently-added `mulhi` op, which is supported by jaxlib at head.

Bechmark results for compilation & runtime, generating 1024x128 arrays with `jax.random.bits`. I included threefry benchmarks as a baseline which should not be affected by this change.

## TPU v6e
TPU v6e has hardware support for `mulhi`. 

Results before this change
```
(Backend=tpu-v6e, Shape=(1024, 128), Seed=3141592653)
================================================================================
PRNG Implementation  | Compilation Time (s) | Runtime per loop (ms)
--------------------------------------------------------------------------------
threefry2x32         | 0.3924 ± 0.0046 s    | 0.1910 ± 0.0040 ms
threefry4x32         | 0.6379 ± 0.0082 s    | 0.2078 ± 0.0221 ms
philox2x32           | 0.6331 ± 0.0256 s    | 0.1895 ± 0.0032 ms
philox4x32           | 0.6912 ± 0.0147 s    | 0.1967 ± 0.0029 ms
```

Results after this change:
```
(Backend=tpu-v6e, Shape=(1024, 128), Seed=3141592653)
================================================================================
PRNG Implementation  | Compilation Time (s) | Runtime per loop (ms)
--------------------------------------------------------------------------------
threefry2x32         | 0.3908 ± 0.0083 s    | 0.2046 ± 0.0063 ms
threefry4x32         | 0.6514 ± 0.0086 s    | 0.2012 ± 0.0023 ms
philox2x32           | 0.3115 ± 0.0042 s    | 0.1912 ± 0.0016 ms
philox4x32           | 0.4147 ± 0.0093 s    | 0.2027 ± 0.0061 ms
```
The main improvement here is a ~50% reduction in compilation time for philox2x32 and ~40% reduction for philox4x32; the runtime is more-or-less unchanged, I suspect because the compiler is lowering the old sequence of ops to the same instructions.

## CPU x32
(note that on CPU, threefry2x32 is relatively slow because of the issue that will be fixed in #37872).

Results before this change:
```
(Backend=cpu-x32, Shape=(1024, 128), Seed=3141592653)
================================================================================
PRNG Implementation  | Compilation Time (s) | Runtime per loop (ms)
--------------------------------------------------------------------------------
threefry2x32         | 0.6562 ± 0.0103 s    | 1.3603 ± 0.1357 ms
threefry4x32         | 0.4022 ± 0.0191 s    | 0.8167 ± 0.0235 ms
philox2x32           | 0.4181 ± 0.0421 s    | 0.8004 ± 0.0219 ms
philox4x32           | 0.5676 ± 0.0537 s    | 0.9632 ± 0.0025 ms
```
Results after this change:
```
(Backend=cpu-x32, Shape=(1024, 128), Seed=3141592653)
================================================================================
PRNG Implementation  | Compilation Time (s) | Runtime per loop (ms)
--------------------------------------------------------------------------------
threefry2x32         | 0.6126 ± 0.0422 s    | 1.3459 ± 0.4730 ms
threefry4x32         | 0.3560 ± 0.0355 s    | 0.9239 ± 0.1661 ms
philox2x32           | 0.2096 ± 0.0608 s    | 0.5803 ± 0.0091 ms
philox4x32           | 0.2426 ± 0.0384 s    | 0.6574 ± 0.0309 ms
```
As on TPU, we see ~50% improvement in compilation time for philox2x32 & 4x32, but in this case there is also a ~30% improvement in runtime.