### PR TITLE
Add regression test for jnp.corrcoef NumPy 2.2 behavior

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -5110,6 +5110,31 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
     self._CompileAndCheck(jnp_fun, args_maker)
 
+  @unittest.skipIf(numpy_version < (2, 2, 0), "test covers NumPy 2.2+ behavior.")
+  @jtu.sample_product(
+      shape=[(1, 3), (3, 1)],
+      rowvar=[True, False],
+  )
+  @jax.default_matmul_precision("float32")
+  def testCorrCoefTransposeBehavior(self, shape, rowvar):
+    # Regression test for https://github.com/jax-ml/jax/issues/29571. The
+    # NumPy 2.2 update to jnp.cov (see
+    # https://github.com/numpy/numpy/pull/27661) flows through to corrcoef
+    # for single-row design matrices with rowvar=False, so the output shape
+    # and NaN propagation should now match NumPy.
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape, np.float32)]
+
+    @jtu.ignore_warning(category=RuntimeWarning, message="invalid value.*")
+    @jtu.ignore_warning(category=RuntimeWarning, message="Degrees of freedom.*")
+    @jtu.ignore_warning(category=RuntimeWarning, message="divide by zero.*")
+    def np_fun(x):
+      return np.corrcoef(x, rowvar=rowvar)
+
+    jnp_fun = partial(jnp.corrcoef, rowvar=rowvar)
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
   def testCorrCoefDtype(self):
     x = jnp.arange(5)
     result_bf16 = jnp.corrcoef(x, x, dtype='bfloat16')


### PR DESCRIPTION
Closes #29571.

The single-row design matrix mismatch reported in #29571 stops reproducing on current `main`. The underlying cause was that `jnp.cov` collapsed the (1, N) design matrix to a scalar when `rowvar=False`, and #32308 aligned `jnp.cov` with the NumPy 2.2 change so the (2, 2) NaN matrix now flows through `jnp.corrcoef` as well. That fix added a `testCovTransposeBehavior` test for `cov` but did not add a matching one for `corrcoef`, so this PR pins the new corrcoef behavior with `testCorrCoefTransposeBehavior`.

The test parametrizes over the two failure-prone shapes (`(1, 3)` and `(3, 1)`) and both values of `rowvar`, gated on NumPy >= 2.2 because the reference output only matches on that version line. It uses the same warning filters the existing `testCorrCoef` uses, plus filters for the "Degrees of freedom <= 0 for slice" and "divide by zero encountered in divide" warnings that `np.corrcoef` raises when there is only one observation per variable.

Running the new cases locally:

```
$ pytest tests/lax_numpy_test.py -k TransposeBehavior
testCorrCoefTransposeBehavior0 PASSED
testCorrCoefTransposeBehavior1 PASSED
testCorrCoefTransposeBehavior2 PASSED
testCorrCoefTransposeBehavior3 PASSED
```

The full `CorrCoef` and `Cov` suites in `tests/lax_numpy_test.py` and `tests/lax_numpy_reducers_test.py` also pass.