### PR TITLE
Expose input_output_aliases on pl.kernel and mpmd_map

### DIFF
--- a/docs/pallas/CHANGELOG.md
+++ b/docs/pallas/CHANGELOG.md
@@ -19,6 +19,9 @@ Remember to align the itemized text with the first line of an item within a list
     `jax_pallas_poison_buffers`) to poison (initialize with NaNs or lowest
     possible integers) any scratch buffers allocated by Pallas in Mosaic TPU
     lowering for debugging.
+  * {func}`jax.experimental.pallas.kernel` and ``mpmd_map`` now accept
+    ``input_output_aliases``, with the same semantics as the existing
+    parameter on {func}`jax.experimental.pallas.pallas_call`.
 
 * Deprecations
 

--- a/jax/_src/pallas/helpers.py
+++ b/jax/_src/pallas/helpers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Pallas helper functions."""
 
-from collections.abc import Callable, Hashable, Sequence
+from collections.abc import Callable, Hashable, Mapping, Sequence
 import functools
 from typing import Any, TypeVar, cast, overload
 
@@ -158,6 +158,7 @@ def kernel(
     out_type: object | None = (),
     *,
     mesh: pl_core.Mesh | Sequence[pl_core.Mesh],
+    input_output_aliases: Mapping[int, int] = {},
     scratch_types: pl_core.ScratchShapeTree = (),
     compiler_params: pl_core.CompilerParams | None = None,
     interpret: Any = False,
@@ -220,6 +221,9 @@ def kernel(
       ``jax.ShapeDtypeStruct`` or JAX types.
     mesh: The mesh to run the kernel on. Must be a sequence of meshes if
       ``body`` is a sequence of callables.
+    input_output_aliases: a dictionary mapping the index of some inputs to
+      the index of the output that aliases them. These indices are in the
+      flattened inputs and outputs.
     scratch_types: The shapes of the scratch arrays.
     compiler_params: The compiler parameters to pass to the backend.
     interpret: Whether to run the function in interpret mode.
@@ -241,6 +245,7 @@ def kernel(
   make_kernel = functools.partial(
       mpmd.mpmd_map,
       out_types=out_type,
+      input_output_aliases=input_output_aliases,
       scratch_types=scratch_types,
       compiler_params=compiler_params,
       interpret=(

--- a/jax/_src/pallas/mpmd.py
+++ b/jax/_src/pallas/mpmd.py
@@ -605,6 +605,7 @@ def mpmd_map(
     /,
     out_types: tree_util.PyTree = (),
     *,
+    input_output_aliases: Mapping[int, int] = {},
     scratch_types: pallas_core.ScratchShapeTree = (),
     compiler_params: Any | None = None,
     interpret: bool | Any = False,
@@ -619,7 +620,7 @@ def mpmd_map(
   return _mpmd_map(
       meshes_and_fns,
       out_types,
-      input_output_aliases={},
+      input_output_aliases=input_output_aliases,
       scratch_types=scratch_types,
       compiler_params=compiler_params,
       interpret=interpret,

--- a/tests/pallas/tpu_pallas_mpmd_test.py
+++ b/tests/pallas/tpu_pallas_mpmd_test.py
@@ -425,6 +425,23 @@ class MpmdTest(PallasSCTest):
     np.testing.assert_array_equal(out, x)
     np.testing.assert_array_equal(mutated_x, x.at[0, :num_lanes].add(1))
 
+  @parameterized.parameters([TC, SCV])
+  def test_input_output_aliases(self, core_type):
+    mesh = from_core_type(core_type)
+    x = jnp.arange(8 * 128, dtype=jnp.int32).reshape(8, 128)
+
+    def fn(x_ref, o_ref):
+      del o_ref
+      x_ref[...] = x_ref[...] + 1
+
+    out = pl.kernel(
+        body=fn,
+        mesh=mesh,
+        out_type=jax.typeof(x),
+        input_output_aliases={0: 0},
+    )(x)
+    np.testing.assert_array_equal(out, x + 1)
+
   @parameterized.parameters([TC, SCS, SCV])
   def test_passing_in_refs_read_only(self, core_type):
     mesh = from_core_type(core_type)


### PR DESCRIPTION
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->