### PR TITLE
[aot] Eliminate control of lowering_platform from `sharding.use_abstract_mesh`

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1250,11 +1250,6 @@ def _pjit_lower(
     lowering_platforms: tuple[str, ...] | None,
     lowering_parameters: mlir.LoweringParameters,
     pgle_profiler: profiler.PGLEProfiler | None) -> pxla.MeshComputation:
-  if (isinstance(ctx_mesh, mesh_lib.AbstractMesh) and
-      (abd := ctx_mesh.abstract_device) is not None):
-    plat = (abd.platform,)
-    lowering_platforms = (plat if lowering_platforms is None else
-                          lowering_platforms + plat)
   return pxla.lower_sharding_computation(
       jaxpr, 'jit', name, in_shardings, out_shardings,
       in_layouts, out_layouts, tuple(donated_invars),

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -4819,7 +4819,7 @@ class ArrayPjitTest(jtu.JaxTestCase):
       return x * 3
 
     with jax.sharding.use_abstract_mesh(am):
-      f.trace(np.arange(8)).lower()  # doesn't crash
+      f.trace(np.arange(8)).lower(lowering_platforms=("cpu",))  # doesn't crash
 
 
 class ShardingInTypesTest(jtu.JaxTestCase):


### PR DESCRIPTION
Previously when certain abstracted meshes (non-empty and with
at least one Explicit axis) are set with `sharding.use_abstract_mesh` the `lowering_platforms` parameter
    was affected. Here we remove that connection; the only way to set
    the lowering platform is by passing the `lowering_platforms` argument
    to the lowering functions. Now `use_abstract_mesh` does only exactly
    what its name says.

 Also, the previous implementation had other problems:
   * if `lowering_platforms` is set, it should take priority. Previously,
        the AbstractDevice.platform was added to the lowering_platforms. This
        is incorrect because if `lowering_platforms` was already set it means
        that the user has set it explicitly. In particular, we don't want to
        trigger multi-platform lowering just because we have an abstract mesh
        in the context.
    * the AbstractDevice.platform is not always appropriate for
        `lowering_platforms`. E.g., instead of "gpu" we must use "cuda" or "rocm".
        Ideally, the AbstractDevice would have the canonical platform name.
    * the mechanism was taking effect not only on AOT code paths, but also
        on the jit path.
