### PR TITLE
Fix jnp.cumsum(x, dtype=bool) producing wrong values for non-bool input

### DIFF
--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -2067,10 +2067,6 @@ def _cumulative_reduction(
 
   a = lax.convert_element_type(a, result_type)
   result = reduction(a, axis)
-
-  # We downcast to boolean because we accumulate in integer types
-  if dtype is not None and dtypes.issubdtype(dtype, np.bool_):
-    result = lax.convert_element_type(result, np.bool_)
   return result
 
 

--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -2062,11 +2062,16 @@ def _cumulative_reduction(
     if dtypes.issubdtype(result_type, np.bool_):
       result_type = _promote_integer_dtype(result_type)
 
-  if a_type != np.bool_ and dtype == np.bool_:
-    a = lax.asarray(a).astype(np.bool_)
+  if not dtypes.issubdtype(a_type, np.bool_) and dtype is not None and dtypes.issubdtype(
+      dtypes.check_and_canonicalize_user_dtype(dtype, name), np.bool_):
+    a = lax.convert_element_type(a, np.bool_)
 
   a = lax.convert_element_type(a, result_type)
   result = reduction(a, axis)
+
+  # We downcast to boolean because we accumulate in integer types
+  if dtype is not None and dtypes.issubdtype(dtype, np.bool_):
+    result = lax.convert_element_type(result, np.bool_)
   return result
 
 


### PR DESCRIPTION
## Summary

`jnp.cumsum(x, dtype=bool)` produces incorrect values when `x` is integer. NumPy casts input to bool before accumulating; JAX skipped this cast because the guard condition used `dtype == np.bool_`, which is `False` when the user passes Python's builtin `bool`.

## Root Cause

```python
# Before (broken): Python bool != np.bool_
if a_type != np.bool_ and dtype == np.bool_:
```

## Fix

Use the canonicalized dtype (already computed via `check_and_canonicalize_user_dtype`) with `dtypes.issubdtype()` so that `bool`, `np.bool_`, and `"bool"` are all recognized:

```python
if a_type != np.bool_ and canonical_dtype is not None and dtypes.issubdtype(canonical_dtype, np.bool_):
```

## Reproducer

```python
import jax.numpy as jnp, numpy as np
x = np.array([-1, 1], dtype=np.int32)
print(np.cumsum(x, dtype=bool))              # [True  True]
print(jnp.cumsum(jnp.array(x), dtype=bool))  # [True False] → now [True True]
```

Fixes #37991