### PR TITLE
Fix spurious KeyReuseError for debug.breakpoint in vmap

### DIFF
--- a/jax/experimental/key_reuse/_core.py
+++ b/jax/experimental/key_reuse/_core.py
@@ -375,7 +375,7 @@ def jaxpr_type_signature(jaxpr: core.Jaxpr) -> KeyReuseSignature:
       # vmap batching rules slice consumed keys for debug callbacks.
       if (eqn.primitive == lax.slice_p
           and is_key(eqn.invars[0])
-          and np.all(consumed.get(eqn.invars[0], False))):
+          and np.all(is_consumed(eqn.invars[0]))):
         signature = KeyReuseSignature(Forward(0, 0))
       if eqn.primitive == assert_consumed_value_p:
         # This is a special case that goes beyond normal key reuse logic.

--- a/jax/experimental/key_reuse/_core.py
+++ b/jax/experimental/key_reuse/_core.py
@@ -370,6 +370,13 @@ def jaxpr_type_signature(jaxpr: core.Jaxpr) -> KeyReuseSignature:
     name_stack = source_info_util.current_name_stack() + eqn.source_info.name_stack
     with source_info_util.user_context(traceback, name_stack=name_stack):
       signature = key_reuse_signature_from_eqn(eqn)
+      # If slicing a key that is already fully consumed, just forward
+      # rather than trying to re-consume. This handles the case where
+      # vmap batching rules slice consumed keys for debug callbacks.
+      if (eqn.primitive == lax.slice_p
+          and is_key(eqn.invars[0])
+          and np.all(consumed.get(eqn.invars[0], False))):
+        signature = KeyReuseSignature(Forward(0, 0))
       if eqn.primitive == assert_consumed_value_p:
         # This is a special case that goes beyond normal key reuse logic.
         _check_consumed_value(eqn, is_consumed(eqn.invars[0]))

--- a/tests/key_reuse_test.py
+++ b/tests/key_reuse_test.py
@@ -528,6 +528,19 @@ class KeyReuseIntegrationTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(KeyReuseError, self.random_bits_error):
       self.check_key_reuse(f_bad, jnp.arange(4))
 
+  def test_vmap_debug_callback_with_consumed_key(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/37795
+    # debug.breakpoint() inside vmap should not raise spurious KeyReuseError
+    # when the function consumes PRNG keys.
+    def f(key):
+      a, b = jax.random.split(key)
+      jax.debug.callback(lambda _: None, key)
+      return jax.random.normal(a) + jax.random.normal(b)
+
+    keys = jax.random.split(jax.random.key(0), 3)
+    # Should not raise KeyReuseError
+    self.check_key_reuse(lambda k: jax.vmap(f)(k), keys)
+
   def test_while_simple(self):
     def f(seed):
       key = jax.random.key(seed)


### PR DESCRIPTION
## Summary

Fixes #37795: `jax.debug.breakpoint()` (and `jax.debug.callback()`) inside a `vmap`-ed function that consumes PRNG keys raises a spurious `KeyReuseError`.

**Root cause**: The vmap batching rule for `debug_callback` slices each captured local (including consumed keys) via `lax.index_in_dim`, which lowers to `lax.slice_p`. The slice's key-reuse signature (`Sink + Source`) tries to re-consume the key, conflicting with it already being consumed.

**Fix**: In `jaxpr_type_signature`, when processing a `slice_p` equation on a key that is already fully consumed, override the signature to `Forward(0, 0)` instead of `Sink + Source`. This allows slicing a consumed key without error — the output inherits the consumed state from the input.

This is analogous to #25957 which fixed a similar issue for `device_put_p`.

## Changes

- `jax/experimental/key_reuse/_core.py`: 4-line addition in `jaxpr_type_signature` to forward slices of fully-consumed keys
- `tests/key_reuse_test.py`: regression test `test_vmap_debug_callback_with_consumed_key`

## Test Plan

```bash
python -m pytest tests/key_reuse_test.py::KeyReuseIntegrationTest::test_vmap_debug_callback_with_consumed_key -v
python -m pytest tests/key_reuse_test.py -v  # full suite to verify no regressions
```

## AI Assistance

This PR was developed with AI assistance (Claude). All changed lines have been reviewed by the human submitter.