### PR TITLE
Fix jax.random.geometric returning dtype max when uniform sample is zero

### DIFF
--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2980,10 +2980,10 @@ def _geometric(key, p, shape, dtype) -> Array:
   check_arraylike("geometric", p)
   p, = promote_dtypes_inexact(p)
   u = uniform(key, shape, p.dtype)
-  log_u = lax.log(u)
+  log_one_minus_u = lax.log1p(-u)
   log_one_minus_p = lax.log1p(-p)
   log_one_minus_p = jnp.broadcast_to(log_one_minus_p, shape)
-  g = lax.floor(lax.div(log_u, log_one_minus_p)) + 1
+  g = lax.floor(lax.div(log_one_minus_u, log_one_minus_p)) + 1
   return g.astype(dtype)
 
 

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -1382,6 +1382,22 @@ class DistributionsTest(RandomTestBase):
       self.assertAllClose(samples.var(), (1 - p) / (p * p) , rtol=0.05,
                           check_dtypes=False)
 
+  def testGeometricNoDtypeMax(self):
+    # Regression test: geometric should never return dtype max.
+    # Previously, log(0) = -inf could produce floor(-inf / log(1-p)) + 1 = dtype_max.
+    # Using log1p(-u) avoids log(0) entirely.
+    from unittest import mock
+    key = self.make_key(0)
+    for dtype in [np.int16, np.int32, np.int64]:
+      with mock.patch('jax._src.random.core.uniform',
+                      lambda key, shape, dtype: jnp.zeros(shape, dtype)):
+        samples = random.geometric(key, 0.5, shape=(10,), dtype=dtype)
+      max_val = np.iinfo(dtype).max
+      self.assertFalse(np.any(samples == max_val),
+                       f"geometric returned dtype max ({max_val}) for dtype={dtype}")
+      self.assertTrue(np.all(samples == 1),
+                      f"geometric with u=0 should return 1, got {samples}")
+
   @jtu.sample_product(
       left = [0.2, 0.5, 1., 2.],
       mode = [3., 5., 8., 9.],


### PR DESCRIPTION
## Summary

Fixes #38007: `jax.random.geometric` can return `dtype.max` when the uniform sample is exactly zero.

**Root cause**: `uniform(key, shape, dtype)` samples from `[0, 1)`, so `u` can be exactly `0`. The implementation computes `log(u)`, which yields `-inf` for `u=0`. Then `floor(-inf / log(1-p)) + 1` overflows to `dtype.max`.

**Fix**: Replace `log(u)` with `log1p(-u)`, which maps `u ∈ [0, 1)` to `log([1, 0))` — avoiding `log(0)` entirely. When `u=0`: `log1p(0) = 0`, so `floor(0 / log(1-p)) + 1 = 1` (correct minimum value for geometric distribution).

## Changes

- `jax/_src/random/core.py`: 2-line change in `_geometric` — `log(u)` → `log1p(-u)`
- `tests/random_lax_test.py`: regression test `testGeometricNoDtypeMax` verifying no dtype max in output

## Test Plan

```bash
python -m pytest tests/random_lax_test.py::RandomLaxTest::testGeometricNoDtypeMax -v
```

## AI Assistance

This PR was developed with AI assistance (Claude). All changed lines have been reviewed by the human submitter.