### PR TITLE
Fix enable_remat_opt_pass overwriting existing XLA_FLAGS disabled passes

### DIFF
--- a/jax/_src/compiler.py
+++ b/jax/_src/compiler.py
@@ -228,7 +228,12 @@ def get_compile_options(
     debug_options.xla_test_all_input_layouts = False
 
   if not config.enable_remat_opt_pass.value:
-    debug_options.xla_disable_hlo_passes = "rematerialization"
+    existing = debug_options.xla_disable_hlo_passes
+    if existing:
+      if "rematerialization" not in {p.strip() for p in existing.split(",")}:
+        debug_options.xla_disable_hlo_passes = existing + ",rematerialization"
+    else:
+      debug_options.xla_disable_hlo_passes = "rematerialization"
 
   # XLA-AutoFDO profile version: precedence order is:
   # 1. Whatever --jax_xla_profile_version is set to.


### PR DESCRIPTION
## Summary

Fixes #37391: `jax.config.update("jax_compiler_enable_remat_pass", False)` overwrites any existing `--xla_disable_hlo_passes` configured via `XLA_FLAGS`.

**Root cause**: `compiler.py:231` directly sets `xla_disable_hlo_passes = "rematerialization"`, replacing whatever was already configured (e.g., `scalar-constant-sinker`).

**Fix**: Append `"rematerialization"` to the existing value instead of replacing it.

## Changes

- `jax/_src/compiler.py`: 4-line change — read existing value and append instead of overwrite

## AI Assistance

This PR was developed with AI assistance (Claude). All changed lines have been reviewed by the human submitter.