### PR TITLE
Cap symbolic shape exponent at 64 to prevent OOM

### DIFF
--- a/jax/_src/export/shape_poly.py
+++ b/jax/_src/export/shape_poly.py
@@ -766,11 +766,12 @@ class _DimExpr:
       return power.__rpow__(self)
     if power != int(power):
       raise ValueError(f"Symbolic dimension cannot be raised to non-integer powers: '{self}' ** '{power}'")
-    if power >= 0:
-      return functools.reduce(op.mul, [self] * power, 1)
-    # We don't support negative powers, because JAX does not allow negative
-    # powers for integers
-    raise ValueError(f"Symbolic dimension cannot be raised to negative powers: '{self}' ** '{power}'")
+    power = int(power)
+    if power < 0:
+      raise ValueError(f"Symbolic dimension cannot be raised to negative powers: '{self}' ** '{power}'")
+    if power > 64:
+      raise ValueError(f"Symbolic dimension exponent too large: {power}")
+    return functools.reduce(op.mul, [self] * power, 1)
 
   def __rpow__(self, other, modulo=None):
     if modulo is not None:
@@ -1654,6 +1655,8 @@ class _Parser:
         tok = self.next_tok()
         self.expect_token(tok, [tokenize.NUMBER])
         power, tok = self.integer(tok)
+        if power < 0 or power > 64:
+          raise self.parse_err(tok, f"exponent must be in [0, 64], got {power}")
         f = f ** power
 
       acc = acc * f if acc is not None else f


### PR DESCRIPTION
## Summary

Fixes #38020: `symbolic_shape` parser accepts arbitrary integer exponents (e.g., `a^100000000`), causing unbounded CPU/memory consumption via `[self] * power` in `_DimExpr.__pow__`.

**Root cause**: `_DimExpr.__pow__` does `functools.reduce(op.mul, [self] * power, 1)` which allocates a list of `power` elements and performs `power - 1` symbolic multiplications. The parser's `term()` method also passes unbounded exponents directly to `__pow__`.

**Fix**: Cap exponent at 64 in both locations:
1. `_DimExpr.__pow__`: raise `ValueError` if `power > 64`
2. `_Parser.term`: raise `parse_err` if `power > 64` or `power < 0`

## Changes

- `jax/_src/export/shape_poly.py`: 7 insertions, 5 deletions

## Test Plan

```bash
# Verify large exponents are rejected
python -c "from jax._src.export import shape_poly; shape_poly.symbolic_shape('a^65')"  # should raise
python -c "from jax._src.export import shape_poly; shape_poly.symbolic_shape('a^64')"  # should work
```

## AI Assistance

This PR was developed with AI assistance (Claude). All changed lines have been reviewed by the human submitter.