### PR TITLE
Skip ROCm plugin discovery when JAX_PLATFORMS excludes ROCm

### DIFF
--- a/jax/_src/numpy/array_constructors.py
+++ b/jax/_src/numpy/array_constructors.py
@@ -49,22 +49,29 @@ for pkg_name in ['jax_cuda13_plugin', 'jax_cuda12_plugin', 'jaxlib.cuda']:
     break
 
 # Dynamically find and load ROCm plugin extension
+# Skip discovery if JAX_PLATFORMS is set and doesn't include ROCm,
+# to avoid iterating all distributions (slow in large venvs).
+import os as _os
+_jax_platforms = _os.environ.get('JAX_PLATFORMS', '')
 rocm_plugin_extension = None
-try:
-  from importlib.metadata import distributions
-  for dist in distributions():
-    name = dist.metadata.get('Name', '')
-    if name.startswith('jax-rocm') and name.endswith('-plugin'):
-      module_name = name.replace('-', '_')
-      try:
-        rocm_plugin_extension = importlib.import_module(
-            f'{module_name}.rocm_plugin_extension'
-        )
-        break
-      except ImportError:
-        continue
-except Exception as e:
-  logger.debug("ROCm plugin discovery failed: %s", e)
+if _jax_platforms and not any(k in _jax_platforms.lower() for k in ('rocm', 'gpu')):
+  pass  # skip ROCm discovery
+else:
+  try:
+    from importlib.metadata import distributions
+    for dist in distributions():
+      name = dist.metadata.get('Name', '')
+      if name.startswith('jax-rocm') and name.endswith('-plugin'):
+        module_name = name.replace('-', '_')
+        try:
+          rocm_plugin_extension = importlib.import_module(
+              f'{module_name}.rocm_plugin_extension'
+          )
+          break
+        except ImportError:
+          continue
+  except Exception as e:
+    logger.debug("ROCm plugin discovery failed: %s", e)
 
 
 def _supports_buffer_protocol(obj):


### PR DESCRIPTION
## Summary

Fixes #37879: ROCm plugin discovery iterates `importlib.metadata.distributions()` at import time, which is slow in large venvs (~250ms).

**Fix**: Skip the discovery loop when `JAX_PLATFORMS` environment variable is set and doesn't include "rocm". This allows users who know they're not on ROCm to avoid the import-time overhead entirely.

When `JAX_PLATFORMS` is unset (default), discovery proceeds as before.

## Changes

- `jax/_src/numpy/array_constructors.py`: guard ROCm discovery with `JAX_PLATFORMS` check

## Test Plan

```bash
# Verify ROCm discovery is skipped when JAX_PLATFORMS=cpu
JAX_PLATFORMS=cpu python -c "import jax; print('OK')"

# Verify ROCm discovery still runs when JAX_PLATFORMS unset
python -c "import jax; print('OK')"
```

## AI Assistance

This PR was developed with AI assistance (Claude). All changed lines have been reviewed by the human submitter.