### PR TITLE
dtypes: fix missing canonical dtype name in ExplicitX64Mode.ERROR message

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -969,9 +969,9 @@ def _maybe_canonicalize_explicit_dtype(dtype: DType, fun_name: str) -> DType:
     return dtype
   fun_name = f" requested in {fun_name}" if fun_name else ""
   if allow == config.ExplicitX64Mode.ERROR:
-    msg = ("Explicitly requested dtype {}{} is not available. To enable more "
-           "dtypes, set the jax_enable_x64 or allow_explicit_x64_dtypes "
-           "configuration options."
+    msg = ("Explicitly requested dtype {}{} is not available, and would be "
+           "truncated to dtype {}. To enable more dtypes, set the "
+           "jax_enable_x64 or allow_explicit_x64_dtypes configuration options. "
           "See https://github.com/jax-ml/jax#current-gotchas for more.")
     msg = msg.format(dtype, fun_name, canonical_dtype.name)
     raise ValueError(msg)

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -521,7 +521,7 @@ class DtypesTest(jtu.JaxTestCase):
       if config.enable_x64.value:
         self.skipTest("x64 is enabled; ERROR path is not triggered")
       with self.assertRaisesRegex(ValueError,
-                                  r"would be truncated to dtype float32"):
+                                  rf"would be truncated to dtype {canonical.name}"):
         dtypes.dtype(x64_dtype)
 
   def testDefaultDtypes(self):

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -510,6 +510,20 @@ class DtypesTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, "Invalid argument to dtype"):
       dtypes.dtype(None)
 
+  def testExplicitX64ErrorMessageIncludesCanonicalDtype(self):
+    # Regression test: in ERROR mode the ValueError message must name the
+    # canonical (fallback) dtype so the user knows what they would get.
+    # Previously the format string had only two placeholders but was called
+    # with three arguments, silently dropping canonical_dtype.name.
+    x64_dtype = np.dtype('float64')
+    canonical = np.dtype('float32')
+    with config.explicit_x64_dtypes(config.ExplicitX64Mode.ERROR):
+      if config.enable_x64.value:
+        self.skipTest("x64 is enabled; ERROR path is not triggered")
+      with self.assertRaisesRegex(ValueError,
+                                  r"would be truncated to dtype float32"):
+        dtypes.dtype(x64_dtype)
+
   def testDefaultDtypes(self):
     self.assertEqual(dtypes.bool_, np.bool_)
     self.assertEqual(dtypes.int_, np.int64)


### PR DESCRIPTION
The `_maybe_canonicalize_explicit_dtype` function has two enforcement
branches when a 64-bit dtype is requested while `enable_x64=False`:

- `WARN` path: message template has three `{}` placeholders and correctly
  interpolates `dtype`, `fun_name`, and `canonical_dtype.name` — telling
  the user both what they asked for and what they would get.
- `ERROR` path: message template has only two `{}` placeholders (`{}{}`),
  but `.format()` is called with three arguments. Python silently drops the
  third, so `canonical_dtype.name` never appears in the raised `ValueError`.

This means a user requesting `float64` under `ERROR` mode sees:

> Explicitly requested dtype float64 is not available. To enable more dtypes…

with no indication that `float32` is the fallback. The `WARN` path already
communicates this correctly. This PR aligns the `ERROR` message to match.

**Changes:**
- Add a third `{}` placeholder to the `ERROR` branch format string and
  reword slightly for consistency with the `WARN` branch.
- Add `testExplicitX64ErrorMessageIncludesCanonicalDtype` to
  `tests/dtypes_test.py` to assert that the canonical dtype name appears
  in the error message. This test fails on the original code and passes
  after the fix.