### PR TITLE
[ROCm] Skip tests that hit cublas custom call for complex GEMM path on ROCm

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -389,6 +389,24 @@ def supported_dtypes() -> set[DTypeLike]:
 def is_device_rocm() -> bool:
   return 'rocm' in xla_bridge.get_backend().platform_version
 
+def rocm_version() -> tuple[int, int, int] | None:
+  """Returns the ROCm runtime version as a (major, minor, patch) tuple.
+
+  Returns ``None`` when the current backend is not ROCm. The version is
+  parsed from the PJRT C API ``platform_version`` string, e.g.
+  ``'PJRT C API\\nrocm 70200'`` -> ``(7, 2, 0)``.
+  """
+  if not is_device_rocm():
+    return None
+  m = re.search(r'rocm\s+(\d+)',
+                xla_bridge.get_backend().platform_version)
+  if m is None:
+    return None
+  v = int(m.group(1))
+  # PJRT encodes the ROCm runtime version as MMmmpp (M=major, m=minor,
+  # p=patch), each field two decimal digits.
+  return (v // 10000, (v // 100) % 100, v % 100)
+
 def is_device_cuda() -> bool:
   return 'cuda' in xla_bridge.get_backend().platform_version
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2295,6 +2295,8 @@ class APITest(jtu.JaxTestCase):
 
   @jax.default_matmul_precision("float32")
   def test_hessian_holomorphic(self):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     R = self.rng().randn
     A = R(4, 4)
     x = R(4).astype('complex64') * (1 + 2j)

--- a/tests/eigh_test.py
+++ b/tests/eigh_test.py
@@ -268,6 +268,8 @@ class EighTest(jtu.JaxTestCase):
       lower=[True, False],
   )
   def testEighGrad(self, shape, dtype, lower):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c" and shape[0] > 1:
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     if platform.system() == "Windows":
       self.skipTest("Skip on Windows due to tolerance issues.")
     rng = jtu.rand_default(self.rng())

--- a/tests/export_harnesses_multi_platform_test.py
+++ b/tests/export_harnesses_multi_platform_test.py
@@ -70,6 +70,11 @@ class PrimitiveTest(jtu.JaxTestCase):
                "operator to work around missing XLA support for pair-reductions")
   )
   def test_prim(self, harness: test_harnesses.Harness):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2)
+        and "dot_general_different_dtypes" in harness.fullname
+        and "rhs_complex" in harness.fullname
+        and "enable_xla_False" in harness.fullname):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     if "eigh_" in harness.fullname:
       self.skipTest("Eigenvalues are sorted and it is not correct to compare "
                     "decompositions for equality.")

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -189,6 +189,8 @@ class ImageTest(jtu.JaxTestCase):
     method=["nearest", "linear", "lanczos3", "lanczos5", "cubic"],
   )
   def testResizeUp(self, dtype, image_shape, target_shape, method):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c" and method != "nearest":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     data = [64, 32, 32, 64, 50, 100]
     expected_data = {}
     expected_data["nearest"] = [
@@ -271,6 +273,8 @@ class ImageTest(jtu.JaxTestCase):
   )
   def testScaleAndTranslateUp(self, dtype, image_shape, target_shape, scale,
                               translation, method):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     data = [64, 32, 32, 64, 50, 100]
     # Note zeros occur in the output because the sampling location is outside
     # the boundaries of the input image.
@@ -312,6 +316,8 @@ class ImageTest(jtu.JaxTestCase):
     antialias=[True, False],
   )
   def testScaleAndTranslateDown(self, dtype, method, antialias):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     image_shape = [1, 6, 7, 1]
     target_shape = [1, 3, 3, 1]
 

--- a/tests/lax_numpy_einsum_test.py
+++ b/tests/lax_numpy_einsum_test.py
@@ -254,6 +254,20 @@ class EinsumTest(jtu.JaxTestCase):
       ]
       for dtype in [jnp.float32, jnp.int32, jnp.complex64, jnp.bool_])
   def test_from_dask(self, einstr, dtype):
+    # Only a subset of einstrings dispatch through hipBLASLt's complex GEMM
+    # path on ROCm; simple contractions go through different kernels.
+    _ROCM_HIPBLASLT_FAILING_EINSTRS = (
+        "aab,bc->ac",
+        "aab,bcc->ac",
+        "ab...,bc...->ac...",
+        "abcdef,bcdfg->abcdeg",
+        "defab,fedbc->defac",
+        "ea,fb,abcd,gc,hd->efgh",
+        "fff,fae,bef,def->abd",
+    )
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c"
+        and einstr in _ROCM_HIPBLASLT_FAILING_EINSTRS):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     r = jtu.rand_default(self.rng())
     if '->' in einstr:
       input_str, result_names = einstr.split('->')

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -529,6 +529,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   )
   @jax.default_matmul_precision("float32")
   def testDot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and any(np.dtype(d).kind == "c" for d in (lhs_dtype, rhs_dtype))
+        and len(lhs_shape) >= 2 and len(rhs_shape) >= 2):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     tol = {np.float16: 1e-2, np.float32: 2e-5, np.float64: 1e-14,
@@ -580,6 +583,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   )
   @jax.default_matmul_precision("float32")
   def testMatmul(self, name, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and any(np.dtype(d).kind == "c" for d in (lhs_dtype, rhs_dtype)):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     def np_fun(x, y):
       dtype = jnp.promote_types(lhs_dtype, rhs_dtype)
@@ -644,6 +649,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @jax.default_matmul_precision("float32")
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testMatvec(self, lhs_batch, rhs_batch, mat_size, vec_size, dtype):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     lhs_shape = (*lhs_batch, mat_size, vec_size)
     rhs_shape = (*rhs_batch, vec_size)
@@ -669,6 +676,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @jax.default_matmul_precision("float32")
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testVecmat(self, lhs_batch, rhs_batch, mat_size, vec_size, dtype):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c" and mat_size == 1:
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     lhs_shape = (*lhs_batch, vec_size)
     rhs_shape = (*rhs_batch, vec_size, mat_size)
@@ -746,6 +755,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   )
   @jax.default_matmul_precision("float32")
   def testInner(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and any(np.dtype(d).kind == "c" for d in (lhs_dtype, rhs_dtype))
+        and len(lhs_shape) >= 2 and len(rhs_shape) >= 2):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     def np_fun(lhs, rhs):

--- a/tests/lax_scipy_sparse_test.py
+++ b/tests/lax_scipy_sparse_test.py
@@ -134,6 +134,8 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     dtype=float_types + complex_types,
   )
   def test_cg_as_solve(self, shape, dtype):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
 
     rng = jtu.rand_default(self.rng())
     a = rng(shape, dtype)
@@ -370,6 +372,9 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
   @jtu.skip_on_devices("cuda")
   def test_gmres_on_identity_system(self, shape, dtype, preconditioner,
                                     solve_method):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c"
+        and tuple(shape) == (7, 7)):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     A = jnp.eye(shape[1], dtype=dtype)
 
     solution = jnp.ones(shape[1], dtype=dtype)
@@ -394,6 +399,9 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
   @jtu.skip_on_devices("cuda")
   def test_gmres_on_random_system(self, shape, dtype, preconditioner,
                                   solve_method):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c"
+        and tuple(shape) == (2, 2)):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     A = rng(shape, dtype)
 

--- a/tests/lax_scipy_spectral_dac_test.py
+++ b/tests/lax_scipy_spectral_dac_test.py
@@ -36,6 +36,8 @@ class LaxScipySpectralDacTest(jtu.JaxTestCase):
     termination_size=[1, 19],
   )
   def test_spectral_dac_eigh(self, linear_size, dtype, termination_size):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and jnp.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     if not jtu.test_device_matches(["tpu"]) and termination_size != 1:
       raise unittest.SkipTest(
           "Termination sizes greater than 1 only work on TPU")

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -441,6 +441,8 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     self, n_zero_sv, degeneracy, geometric_spectrum, max_sv, shape, method,
       side, nonzero_condition_number, dtype, seed):
     """ Tests jax.scipy.linalg.polar."""
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     if not jtu.test_device_matches(["cpu"]):
       if jnp.dtype(dtype).name in ("bfloat16", "float16"):
         raise unittest.SkipTest("Skip half precision off CPU.")

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -819,6 +819,8 @@ class LaxTest(jtu.JaxTestCase):
   def testConvGeneralDilatedLocal(self, dtype, precision, n, padding, lhs_spec,
                                   rhs_spec, out_spec):
     """Make sure LCN with tiled CNN kernel matches CNN."""
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     lhs_spec_default = 'NCHWDX'[:n + 2]
     rhs_spec_default = 'OIHWDX'[:n + 2]
 
@@ -1423,6 +1425,8 @@ class LaxTest(jtu.JaxTestCase):
   )
   def testDotGeneralContractAndBatch(self, lhs_shape, rhs_shape, dtype,
                                      dimension_numbers):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_small(self.rng())
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
 
@@ -1448,6 +1452,8 @@ class LaxTest(jtu.JaxTestCase):
   )
   def testDotGeneralAgainstNumpy(self, lhs_shape, rhs_shape, dtype,
                                  dimension_numbers):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_small(self.rng())
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
     op = lambda x, y: lax.dot_general(x, y, dimension_numbers)

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -457,6 +457,8 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   )
   @jtu.run_on_devices("cpu", "gpu")
   def testEigGradComplexInputs(self, shape, dtype, left_right):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     # Small matrices only; the eigenvector derivative blows up like
     # 1/min|w_i - w_j| so close eigenvalues make the FD check noisy.
     left, right = left_right
@@ -474,6 +476,10 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   )
   @jtu.run_on_devices("cpu", "gpu")
   def testEigGradRealInputs(self, shape, dtype, left_right):
+    # Although inputs are real, the eig gradient produces complex
+    # intermediates that hit hipBLASLt's complex GEMM path.
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "f":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     # dgeev does not pin the sign of complex-pair eigenvectors so the primal
     # output is itself discontinuous; compose with elementwise v -> v*v which
     # is sign-invariant but still phase-sensitive (so still exercises the
@@ -685,6 +691,9 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   )
   @jax.default_matmul_precision("float32")
   def testMatmul(self, lhs_shape, rhs_shape, dtype):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c"
+        and len(lhs_shape) >= 2 and len(rhs_shape) >= 2):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
     np_fn = jtu.promote_like_jnp(np.linalg.matmul)
@@ -711,6 +720,8 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   )
   @jax.default_matmul_precision("float32")
   def testTensordot(self, lhs_shape, rhs_shape, axes, dtype):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c" and axes == 1:
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
     np_fn = jtu.promote_like_jnp(partial(np.linalg.tensordot, axes=axes))
@@ -884,6 +895,8 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   )
   @jax.default_matmul_precision("float32")
   def testSVDGrad(self, shape, dtype, full_matrices, compute_uv):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     a = rng(shape, dtype)
     if not compute_uv:
@@ -919,6 +932,8 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   )
   @jax.default_matmul_precision("float32")
   def testQr(self, shape, dtype, full_matrices):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c" and 0 not in shape:
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     if (jtu.test_device_matches(["cuda"]) and
         _is_required_cuda_version_satisfied(12000)):
       self.skipTest("Triggers a bug in cuda-12 b/287345077")
@@ -1107,6 +1122,9 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   )
   @jtu.ignore_warning(message="invalid value", category=RuntimeWarning)
   def testPinv(self, shape, hermitian, dtype):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c"
+        and not hermitian and shape[-2] >= 2 and shape[-1] >= 2):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     def args_maker():
       a = rng(shape, dtype)
@@ -1152,6 +1170,9 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   )
   @jax.default_matmul_precision("float32")
   def testMatrixPower(self, shape, dtype, n):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c"
+        and n != 1 and shape[-1] > 1):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
     self._CheckAgainstNumpy(partial(np.linalg.matrix_power, n=n),
@@ -1263,6 +1284,9 @@ class NumpyLinalgTest(jtu.JaxTestCase):
 
   # Regression test for incorrect type for eigenvalues of a complex matrix.
   def testIssue669(self):
+    # Test uses complex input; hits hipBLASLt complex GEMM on ROCm.
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     def test(x):
       val, vec = jnp.linalg.eigh(x)
       return jnp.real(jnp.sum(val))
@@ -1410,6 +1434,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     dtype=float_types + complex_types,
   )
   def testLuGrad(self, shape, dtype):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c" and shape[-1] > 1:
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     a = rng(shape, dtype)
     lu = vmap(jsp.linalg.lu) if len(shape) > 2 else jsp.linalg.lu
@@ -1641,6 +1667,9 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   def testTriangularSolveGrad(
       self, lower, transpose_a, conjugate_a, unit_diagonal, left_side, a_shape,
       b_shape, dtype):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c"
+        and tuple(a_shape) == (3, 3) and tuple(b_shape) == (4, 3)):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     # Test lax.linalg.triangular_solve instead of scipy.linalg.solve_triangular
     # because it exposes more options.
@@ -1728,6 +1757,9 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   )
   @jax.default_matmul_precision("float32")
   def testScipyQrModes(self, shape, dtype, mode, pivoting):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c"
+        and mode == "economic" and pivoting and shape[-2] > shape[-1]):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     if pivoting:
       if not jtu.test_device_matches(["cpu", "gpu"]):
         self.skipTest("Pivoting is only supported on CPU and GPU.")
@@ -1759,6 +1791,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       pivoting=[False, True],
   )
   def testQrMultiply(self, shape, dtype, mode, pivoting):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     if pivoting and not jtu.test_device_matches(["cpu", "gpu"]):
       self.skipTest("Pivoting is only supported on CPU and GPU.")
     rng = jtu.rand_default(self.rng())
@@ -1869,6 +1903,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       transpose=[False, True],
   )
   def testOrmqr(self, a_shape, c_shape, dtype, left, transpose):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(a_shape, dtype), rng(c_shape, dtype)]
 
@@ -1967,6 +2003,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     dtype=float_types + complex_types,
   )
   def testIssue2131(self, n, dtype):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     args_maker_zeros = lambda: [np.zeros((n, n), dtype)]
     osp_fun = lambda a: osp.linalg.expm(a)
     jsp_fun = lambda a: jsp.linalg.expm(a)
@@ -2034,6 +2072,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     dtype=float_types + complex_types,
   )
   def testExpmFrechet(self, n, dtype):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_small(self.rng())
     if dtype == np.float64 or dtype == np.complex128:
       target_norms = [1.0e-2, 2.0e-1, 9.0e-01, 2.0, 3.0]
@@ -2072,6 +2112,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     dtype=float_types + complex_types,
   )
   def testExpmGrad(self, n, dtype):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c" and n > 1:
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_small(self.rng())
     a = rng((n, n), dtype)
     if dtype == np.float64 or dtype == np.complex128:
@@ -2447,6 +2489,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   @jtu.run_on_devices("cpu", "gpu")
   @jax.default_matmul_precision("float32")
   def test_solve_sylvester(self, shape, dtype, method):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and method == "eigen":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     if jtu.test_device_matches(["gpu"]) and method == "schur":
       self.skipTest("Schur not supported on GPU.")
 
@@ -2482,6 +2526,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     We simulate this case below by randomly selecting the eigenvalues of A and then assign the
     eigenvalues of B as negative eigenvalues of A. We say that A and B are ill-conditioned.
     """
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and method == "eigen":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     if jtu.test_device_matches(["gpu"]) and method == "schur":
       self.skipTest("Schur not supported on GPU.")
 
@@ -2521,6 +2567,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   @jax.default_matmul_precision("float32")
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def test_solve_sylvester_broadcast(self, a_shape, b_shape, c_shape, dtype, method):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and method == "eigen":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     if scipy_version < (1, 16, 0):
       self.skipTest("scipy.linalg.solve_sylvester batch broadcasting requires scipy >= 1.16")
     if jtu.test_device_matches(["gpu"]) and method == "schur":
@@ -2555,6 +2603,9 @@ class LaxLinalgTest(jtu.JaxTestCase):
                       k_rhs=[1, 2],
                       perturb_singular=[False, True])
   def test_tridiagonal_solve(self, shape, dtype, k_rhs, perturb_singular):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c"
+        and k_rhs == 2 and len(shape) <= 2):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
 
     if perturb_singular and not jtu.test_device_matches(["cpu", "gpu"]):
       self.skipTest("perturb_singular=True only supported on CPU and GPU")

--- a/tests/qdwh_test.py
+++ b/tests/qdwh_test.py
@@ -81,6 +81,8 @@ class QdwhTest(jtu.JaxTestCase):
   )
   def testQdwhWithUpperTriangularInputAllOnes(self, shape, dtype):
     """Tests qdwh with upper triangular input of all ones."""
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     m, n = shape
     a = jnp.triu(jnp.ones((m, n))).astype(dtype)
     self._testQdwh(a)
@@ -91,6 +93,8 @@ class QdwhTest(jtu.JaxTestCase):
   )
   def testQdwhWithDynamicShape(self, shape, dtype):
     """Tests qdwh with dynamic shapes."""
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_uniform(self.rng())
     a = rng((10, 10), dtype)
     self._testQdwh(a, dynamic_shape=shape)
@@ -102,6 +106,8 @@ class QdwhTest(jtu.JaxTestCase):
   )
   def testQdwhWithRandomMatrix(self, shape, log_cond, dtype):
     """Tests qdwh with upper triangular input of all ones."""
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     # ROCm: Triton GEMM autotuner cannot compile this specific case.
     # TODO(gulsumgudukbay): Unskip once fixed. Issue #34711.
     if (jtu.is_device_rocm()
@@ -129,6 +135,8 @@ class QdwhTest(jtu.JaxTestCase):
   )
   def testQdwhJitCompatibility(self, m, n, padding, dtype):
     """Tests JIT compilation of QDWH with and without dynamic shape."""
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_uniform(self.rng())
     a = rng((m, n), dtype)
     def lsp_linalg_fn(a):
@@ -152,6 +160,8 @@ class QdwhTest(jtu.JaxTestCase):
   )
   def testQdwhOnRankDeficientInput(self, m, n, r, log_cond, dtype):
     """Tests qdwh on rank-deficient input."""
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     eps = jnp.finfo(dtype).eps
     a = np.triu(np.ones((m, n))).astype(dtype)
 
@@ -191,6 +201,8 @@ class QdwhTest(jtu.JaxTestCase):
   )
   def testQdwhWithTinyElement(self, m, n, r, c, dtype):
     """Tests qdwh on matrix with zeros and close-to-zero entries."""
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     a = jnp.zeros((m, n), dtype=dtype)
     one = dtype(1.0)
     tiny_elem = dtype(jnp.finfo(a.dtype).tiny)

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -913,6 +913,9 @@ class DistributionsTest(RandomTestBase):
   )
   @jax.default_matmul_precision("float32")
   def testOrthogonal(self, n, shape, dtype, m):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c"
+        and n >= 2 and (m is None or m >= 2)):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     if m is None:
       m = n
 

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -3748,6 +3748,10 @@ class ShapePolyHarnessesTest(jtu.JaxTestCase):
       #one_containing="",
   )
   def test_harness(self, harness: PolyHarness):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2)
+        and "vmap_dot_general_different_dtypes" in harness.fullname
+        and "rhs_complex" in harness.fullname):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     # We do not expect the associative scan error on TPUs
     if harness.expect_error == expect_error_associative_scan and jtu.test_device_matches(["tpu"]):
       harness.expect_error = None

--- a/tests/sparse_bcoo_bcsr_test.py
+++ b/tests/sparse_bcoo_bcsr_test.py
@@ -436,6 +436,8 @@ class BCOOTest(sptu.SparseTestCase):
   def test_bcoo_dot_general(
       self, dtype: np.dtype, props: sptu.BatchedDotGeneralProperties
   ):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     sprng = sptu.rand_bcoo(self.rng(), n_batch=props.n_batch, n_dense=props.n_dense)
     args_maker = lambda: [sprng(props.lhs_shape, dtype),
@@ -480,6 +482,9 @@ class BCOOTest(sptu.SparseTestCase):
   def test_bcoo_dot_general_cusparse(
       self, lhs_shape, rhs_shape, dtype, lhs_contracting, rhs_contracting
   ):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c"
+        and len(lhs_shape) >= 2 and len(rhs_shape) >= 2):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_small(self.rng())
     rng_sparse = sptu.rand_sparse(self.rng())
     def args_maker():
@@ -532,6 +537,8 @@ class BCOOTest(sptu.SparseTestCase):
       lhs_contracting,
       rhs_contracting,
   ):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_small(self.rng())
     rng_sparse = sptu.rand_sparse(self.rng())
     def args_maker():
@@ -660,6 +667,8 @@ class BCOOTest(sptu.SparseTestCase):
   def test_bcoo_rdot_general(
       self, dtype: np.dtype, props: sptu.BatchedDotGeneralProperties
   ):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     sprng = sptu.rand_bcoo(self.rng(), n_batch=props.n_batch, n_dense=props.n_dense)
     args_maker = lambda: [rng(props.rhs_shape, dtype),
@@ -712,6 +721,8 @@ class BCOOTest(sptu.SparseTestCase):
   def test_bcoo_dot_general_partial_batch(
       self, lhs_shape, rhs_shape, dtype, dimension_numbers, n_batch, n_dense
   ):
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_small(self.rng())
     rng_sparse = sptu.rand_sparse(self.rng())
 
@@ -785,6 +796,9 @@ class BCOOTest(sptu.SparseTestCase):
   @jax.default_matmul_precision("float32")
   def test_bcoo_dot_general_sampled_fast_cases(
       self, xshape, yshape, lhs_contract, rhs_contract, n_batch, dtype):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c"
+        and len(xshape) >= 2 and len(yshape) >= 2):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     sprng = sptu.rand_bcoo(self.rng(), n_batch=n_batch)
     dimension_numbers = ((lhs_contract, rhs_contract), ([], []))
@@ -1462,6 +1476,9 @@ class BCOOTest(sptu.SparseTestCase):
   @jax.default_matmul_precision("float32")
   @jtu.ignore_warning(category=sparse.CuSparseEfficiencyWarning)
   def test_bcsr_matmul(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(lhs_dtype).kind == "c"
+        and len(rhs_shape) >= 2):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     # Note: currently, batch dimensions in matmul must correspond to batch
     # dimensions in the sparse representation.
     n_batch_lhs = max(0, len(lhs_shape) - 2)
@@ -1497,6 +1514,9 @@ class BCOOTest(sptu.SparseTestCase):
   @jax.default_matmul_precision("float32")
   @jtu.ignore_warning(category=sparse.CuSparseEfficiencyWarning)
   def test_bcoo_matmul(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(lhs_dtype).kind == "c"
+        and np.dtype(rhs_dtype).kind == "c" and len(rhs_shape) >= 2):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     if (jtu.test_device_matches(["cuda"]) and
         _is_required_cuda_version_satisfied(12000)):
       raise unittest.SkipTest("Triggers a bug in cuda-12 b/287344632")
@@ -1873,6 +1893,9 @@ class BCSRTest(sptu.SparseTestCase):
   def test_bcsr_dot_general(
       self, dtype: np.dtype, props: sptu.BatchedDotGeneralProperties
   ):
+    if (jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c"
+        and len(props.dimension_numbers[0][0]) > 0):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     rng = jtu.rand_default(self.rng())
     sprng = sptu.rand_bcsr(self.rng(), n_batch=props.n_batch, n_dense=props.n_dense)
     args_maker = lambda: [sprng(props.lhs_shape, dtype),

--- a/tests/svd_test.py
+++ b/tests/svd_test.py
@@ -64,6 +64,10 @@ class SvdTest(jtu.JaxTestCase):
   )
   def testSvdWithRectangularInput(self, m, n, log_cond, full_matrices):
     """Tests SVD with rectangular input."""
+    # The test casts input to complex (`a.astype(complex) * (1 + 1j)`), so on
+    # ROCm every sampled variant hits hipBLASLt's complex GEMM path.
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     with jax.default_matmul_precision('float32'):
       a = np.random.uniform(
           low=0.3, high=0.9, size=(m, n)).astype(_SVD_TEST_DTYPE)
@@ -173,6 +177,10 @@ class SvdTest(jtu.JaxTestCase):
   )
   def testSingularValues(self, m, n, log_cond, full_matrices):
     """Tests singular values."""
+    # The test casts input to complex (`a = a + 1j * a`), so on ROCm every
+    # sampled variant hits hipBLASLt's complex GEMM path.
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2):
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     with jax.default_matmul_precision('float32'):
       a = np.random.uniform(
           low=0.3, high=0.9, size=(m, n)).astype(_SVD_TEST_DTYPE)
@@ -215,6 +223,8 @@ class SvdTest(jtu.JaxTestCase):
   )
   def testSvdAllZero(self, m, n, full_matrices, compute_uv, dtype):
     """Tests SVD on matrix of all zeros, +/-infinity or NaN."""
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     osp_fun = functools.partial(
         osp_linalg.svd, full_matrices=full_matrices, compute_uv=compute_uv
     )
@@ -236,6 +246,8 @@ class SvdTest(jtu.JaxTestCase):
       self, m, n, fill_value, full_matrices, compute_uv, dtype
   ):
     """Tests SVD on matrix of all zeros, +/-infinity or NaN."""
+    if jtu.rocm_version() and jtu.rocm_version()[:2] == (7, 2) and np.dtype(dtype).kind == "c":
+      self.skipTest("hipblasLT doesn't support complex numbers in ROCm 7.2.x")
     lax_fun = functools.partial(
         svd.svd, full_matrices=full_matrices, compute_uv=compute_uv
     )


### PR DESCRIPTION
ROCm 7.2.0 ships a hipBLASLt that does not support complex GEMM and XLA removed rocblas/cublas backend support recently. For ROCm this was the way to support complex numbers, so now any test that ends up dispatching a complex GEMM fails with:

    INTERNAL: GEMM is not supported by cublasLt and legacy cublas
    fallback is removed.

Add a small `rocm_version()` helper to `jax._src.test_util` so tests can
gate ROCm-specific skips on the runtime version exposed by the PJRT
backend ('PJRT C API\\nrocm NNNNNN').

This PR skips 222 tests.