### PR TITLE
Experiment: add config to require strict indexing

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -64,6 +64,7 @@ from jax._src.config import (
   default_prng_impl as default_prng_impl,
   numpy_dtype_promotion as numpy_dtype_promotion,
   numpy_rank_promotion as numpy_rank_promotion,
+  numpy_strict_indexing as numpy_strict_indexing,
   allow_f16_reductions as allow_f16_reductions,
   jax2tf_associative_scan_reductions as jax2tf_associative_scan_reductions,
   legacy_prng_key as legacy_prng_key,

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1728,6 +1728,15 @@ numpy_rank_promotion = enum_state(
     include_in_jit_key=True,
     include_in_trace_context=True)
 
+numpy_strict_indexing = bool_state(
+    name='jax_numpy_strict_indexing',
+    default=False,
+    help=('If set to True, require NumPy indexing expressions to explicitly '
+          'specify indices for all axes of arrays.'),
+    include_in_jit_key=True,
+    include_in_trace_context=True,
+)
+
 auto_pcast = bool_state(
     name='jax_auto_pcast',
     default=True,  # TODO(yashkatariya): False

--- a/jax/_src/numpy/indexing.py
+++ b/jax/_src/numpy/indexing.py
@@ -323,6 +323,8 @@ class NDIndexer:
           expanded.append(ParsedIndex(index=slice(None), typ=IndexType.SLICE, consumed_axes=(axis,)))
       else:
         expanded.append(idx)
+    if config.numpy_strict_indexing.value and consumed != len(self.shape):
+      raise ValueError(f"Found only {consumed} indices for array of size {len(self.shape)}")
     for axis in range(consumed, len(self.shape)):
       expanded.append(ParsedIndex(index=slice(None), typ=IndexType.SLICE, consumed_axes=(axis,)))
     return NDIndexer(shape=self.shape, indices=expanded)

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1228,6 +1228,7 @@ class JaxTestCase(parameterized.TestCase):
     'jax_enable_checks': True,
     'jax_numpy_dtype_promotion': 'strict',
     'jax_numpy_rank_promotion': 'raise',
+    'jax_numpy_strict_indexing': True,
     'jax_traceback_filtering': 'off',
     'jax_legacy_prng_key': 'error',
   }

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -5531,6 +5531,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                             r"shapes \(2,\) \(1, 2\).*", lambda: jnp.ones(2) + jnp.ones((1, 2)))
       jnp.ones(2) + 3  # don't want to warn for scalars
 
+  def testStrictIndexing(self):
+    x = jnp.zeros((2, 3, 4))
+    with jax.numpy_strict_indexing(True):
+      with self.assertRaisesRegex(ValueError, "Found only 1"):
+        x[0]
+      x[0, ...]  # doesn't fail
+    with jax.numpy_strict_indexing(False):
+      x[0]  # doesn't fail
+      x[0, ...]  # doesn't fail
+
   def testStackArrayArgument(self):
     # tests https://github.com/jax-ml/jax/issues/1271
     @jax.jit


### PR DESCRIPTION
An experiment in addressing #37735: this is a configuration flag that when enabled requires indexing operations to explicitly specify indices for each array dimension. For example,
```python
x = jnp.zeros((2, 3))
with jax.numpy_strict_indexing():
  x[0]  # fails when x has more than one dimension
  x[0, :]  # succeeds when x has exactly two dimensions
  x[0, ...]  # succeeds when x has one or more dimensions
```
See the discussion in #37735 for motivations behind this idea.

If we land this, we should improve the error message and probably use a custom `IndexError` for this. Also, we could put some thought into the flag behavior (the name, whether to allow "warn" vs "error", etc.)

Landing this will require fixing usage across JAX (by adding an explicit traiilng `...` wherever this fails) and being OK with working in strict mode for JAX library code going forward (the flag is more-or-less useless to end-users if JAX's own APIs trigger the error).