### PR TITLE
docs: fix type querying inside JIT in parallel docs

### DIFF
--- a/docs/parallel.ipynb
+++ b/docs/parallel.ipynb
@@ -584,9 +584,9 @@
     "@jax.jit\n",
     "def add_arrays(x, y):\n",
     "  ans = x + y\n",
-    "  print(f\"{jax.typeof(arg0)=!s}\")\n",
-    "  print(f\"{jax.typeof(arg1)=!s}\")\n",
-    "  print(f\"{jax.typeof(result)=!s}\")\n",
+    "  print(f\"jax.typeof(arg0)={jax.typeof(x)!s}\")\n",
+    "  print(f\"jax.typeof(arg1)={jax.typeof(y)!s}\")\n",
+    "  print(f\"jax.typeof(result)={jax.typeof(ans)!s}\")\n",
     "  return ans\n",
     "\n",
     "add_arrays(arg0, arg1)"

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -341,9 +341,9 @@ We can do the same type querying under a `jit`:
 @jax.jit
 def add_arrays(x, y):
   ans = x + y
-  print(f"{jax.typeof(arg0)=!s}")
-  print(f"{jax.typeof(arg1)=!s}")
-  print(f"{jax.typeof(result)=!s}")
+  print(f"jax.typeof(arg0)={jax.typeof(x)!s}")
+  print(f"jax.typeof(arg1)={jax.typeof(y)!s}")
+  print(f"jax.typeof(result)={jax.typeof(ans)!s}")
   return ans
 
 add_arrays(arg0, arg1)

--- a/docs/parallel.py
+++ b/docs/parallel.py
@@ -301,9 +301,9 @@ print(f"{jax.typeof(result)=!s}")
 @jax.jit
 def add_arrays(x, y):
   ans = x + y
-  print(f"{jax.typeof(arg0)=!s}")
-  print(f"{jax.typeof(arg1)=!s}")
-  print(f"{jax.typeof(result)=!s}")
+  print(f"jax.typeof(arg0)={jax.typeof(x)!s}")
+  print(f"jax.typeof(arg1)={jax.typeof(y)!s}")
+  print(f"jax.typeof(result)={jax.typeof(ans)!s}")
   return ans
 
 add_arrays(arg0, arg1)


### PR DESCRIPTION
In add_arrays under jax.jit, the code was incorrectly querying the types of global variables arg0, arg1, and result instead of the local parameters x, y and the local result ans. This resulted in querying the concrete types of the global variables rather than the tracers inside JIT. This change fixes it to use the local variables.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->