### PR TITLE
Make warnings about security on the compilation cache warnings.

### DIFF
--- a/docs/persistent_compilation_cache.md
+++ b/docs/persistent_compilation_cache.md
@@ -1,3 +1,4 @@
+(persistent-compilation-cache)=
 # Persistent compilation cache
 
 <!--* freshness: { reviewed: '2024-11-07' } *-->
@@ -13,9 +14,11 @@ Note: if the compilation cache is not on a local filesystem,
 pip install etils
 ```
 
-**CAUTION**: the compilation cache is considered trusted. Do not share a compilation cache with users you do not trust. For example, if you put the
+```{warning}
+The compilation cache is considered trusted. Do not share a compilation cache with users you do not trust. For example, if you put the
 compilation cache in a directory to which others may write, those users can trigger your JAX process to run arbitrary code. Sharing
 a compilation cache is equivalent to allowing anyone who can write to the cache directory to run code on your machine.
+```
 
 ## Usage
 

--- a/jax/_src/compilation_cache.py
+++ b/jax/_src/compilation_cache.py
@@ -189,22 +189,40 @@ class VerificationCache(CacheInterface):
 
 
 def set_cache_dir(path) -> None:
-  """
-  Sets the persistent compilation cache directory.
+  """Sets the persistent compilation cache directory.
 
   After calling this, jit-compiled functions are saved to `path`, so they
   do not need be recompiled if the process is restarted or otherwise run again.
   This also tells Jax where to look for compiled functions before compiling.
+
+  For more information, see the :ref:`persistent compilation cache guide <persistent-compilation-cache>`.
+
+  .. warning::
+     The compilation cache is considered trusted. Do not share a compilation
+     cache with users you do not trust. For example, if you put the compilation
+     cache in a directory to which others may write, those users can trigger
+     your JAX process to run arbitrary code. Sharing a compilation cache is
+     equivalent to allowing anyone who can write to the cache directory to run
+     code on your machine.
   """
   config.config.update("jax_compilation_cache_dir", path)
 
 
 def initialize_cache(path) -> None:
-  """
-  This API is deprecated; use set_cache_dir instead.
+  """This API is deprecated; use set_cache_dir instead.
 
   Set the path. To take effect, should be called prior to any calls to
   get_executable_and_time() and put_executable_and_time().
+
+  For more information, see the :ref:`persistent compilation cache guide <persistent-compilation-cache>`.
+
+  .. warning::
+     The compilation cache is considered trusted. Do not share a compilation
+     cache with users you do not trust. For example, if you put the compilation
+     cache in a directory to which others may write, those users can trigger
+     your JAX process to run arbitrary code. Sharing a compilation cache is
+     equivalent to allowing anyone who can write to the cache directory to run
+     code on your machine.
   """
   config.config.update("jax_compilation_cache_dir", path)
 
@@ -410,7 +428,10 @@ def is_initialized() -> bool:
 
 
 def reset_cache() -> None:
-  """Get back to pristine, uninitialized state."""
+  """Get back to pristine, uninitialized state.
+
+  For more information, see the :ref:`persistent compilation cache guide <persistent-compilation-cache>`.
+  """
   global _cache
   global _cache_initialized
   global _cache_checked

--- a/jax/experimental/serialize_executable.py
+++ b/jax/experimental/serialize_executable.py
@@ -50,12 +50,13 @@ def deserialize_and_load(serialized,
                          out_tree,
                          backend: str | xc.Client | None = None,
                          execution_devices: Sequence[xc.Device] | None = None):
-  """Constructs a jax.stages.Compiled from a serialized executable.
+  """Constructs a :class:`jax.stages.Compiled` from a serialized executable.
 
-  It is not safe to call this API with untrusted inputs. Do not do this.
-  Calling this API means you are loading an executable. If you feed untrusted
-  data to this API, you are loading and running a untrusted executable.
-  It is not safe to pass untrusted data here and likely never will be.
+  .. warning::
+     It is not safe to call this API with untrusted inputs. Do not do this.
+     Calling this API loads a serialized executable. Even loading such an
+     executable may run arbitrary code on your machine. It is not safe to pass
+     untrusted data here and likely never will be.
   """
 
   if backend is None or isinstance(backend, str):

--- a/jaxlib/py_client.cc
+++ b/jaxlib/py_client.cc
@@ -989,7 +989,14 @@ PyType_Slot PyClient::slots_[] = {
           },
           nb::arg("serialized"), nb::arg("executable_devices"),
           nb::arg("compile_options").none() = nb::none(),
-          nb::arg("host_callbacks") = std::vector<nb::capsule>())
+          nb::arg("host_callbacks") = std::vector<nb::capsule>(),
+          "Deserializes an executable.\n\n"
+          ".. warning::\n"
+          "   It is not safe to call this API with untrusted inputs. Do not\n"
+          "   do this. Calling this API loads a serialized executable. Even\n"
+          "   loading such an executable may run arbitrary code on your machine.\n"
+          "   It is not safe to pass untrusted data here and likely never\n"
+          "   will be.")
       .def(
           "deserialize_executable",
           [](nb_class_ptr<PyClient> client, nb::bytes serialized,
@@ -1005,7 +1012,14 @@ PyType_Slot PyClient::slots_[] = {
           },
           nb::arg("serialized"), nb::arg("executable_devices"),
           nb::arg("compile_options").none() = nb::none(),
-          nb::arg("host_callbacks") = std::vector<nb::callable>())
+          nb::arg("host_callbacks") = std::vector<nb::callable>(),
+          "Deserializes an executable.\n\n"
+          ".. warning::\n"
+          "   It is not safe to call this API with untrusted inputs. Do not\n"
+          "   do this. Calling this API loads a serialized executable. Even\n"
+          "   loading such an executable may run arbitrary code on your machine.\n"
+          "   It is not safe to pass untrusted data here and likely never\n"
+          "   will be.")
       // The following overload is for users of deprecated APIs who call
       // `deserialize_executable` but do not have visibility to `DeviceList`.
       .def(
@@ -1022,7 +1036,14 @@ PyType_Slot PyClient::slots_[] = {
                 std::vector<nb::capsule>()));
           },
           nb::arg("serialized"), nb::arg("executable_devices"),
-          nb::arg("compile_options").none() = nb::none())
+          nb::arg("compile_options").none() = nb::none(),
+          "Deserializes an executable.\n\n"
+          ".. warning::\n"
+          "   It is not safe to call this API with untrusted inputs. Do not\n"
+          "   do this. Calling this API loads a serialized executable. Even\n"
+          "   loading such an executable may run arbitrary code on your machine.\n"
+          "   It is not safe to pass untrusted data here and likely never\n"
+          "   will be.")
       .def("heap_profile", xla::ValueOrThrowWrapper(&PyClient::HeapProfile))
       // TODO(zhangqiaorjc): Experimental.
       .def("defragment",


### PR DESCRIPTION
Also include them in the API doc strings.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->