### PR TITLE
[bug] temporary fix for random.geometric

### DIFF
--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2986,6 +2986,10 @@ def _geometric(key, p, shape, dtype, out_sharding) -> Array:
   check_arraylike("geometric", p)
   p, = promote_dtypes_inexact(p)
   u = uniform(key, shape, p.dtype, out_sharding=out_sharding)
+  # TODO(jakevdp): switch to log_u = lax.log1p(u - 1)
+  # For now we map u=0 to u=1 to avoid inf in log_u without otherwise
+  # changing samples produced for a given key.
+  u = jnp.where(u == 0, 1, u)
   log_u = lax.log(u)
   log_one_minus_p = lax.log1p(-p)
   log_one_minus_p = jnp.broadcast_to(log_one_minus_p, shape, out_sharding=out_sharding)

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -1611,6 +1611,16 @@ class DistributionsTest(RandomTestBase):
     counts = jnp.bincount(data, length=n_bins).astype(float)
     self._CheckKolmogorovSmirnovCDF(counts, scipy.stats.poisson(n_samples / n_bins).cdf)
 
+  def test_geometric_avoids_infs(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/38007
+    key = random.key(0)
+    # Sample at bfloat16 so that there are only 2^7 distinct values,
+    # and sample 2^8 points so we are likely to cover the whole space.
+    p = jnp.bfloat16(0.1)
+    vals = random.geometric(key, p, shape=(256,))
+    self.assertFalse(np.any(vals == jnp.iinfo(vals.dtype).max),
+                     "geometric sampler produced an infinity.")
+
 
 def get_energy_distance(samples_1, samples_2):
   """


### PR DESCRIPTION
This is a temporary fix that eliminates the `inf` outputs in `random.geometric` (see #38007).

Eventually we should replace `log(u)` with `log1p(u - 1)`, but that will result in broader changes to the sampling, so we should wait for a meso release.