### PR TITLE
Document that pytree dictionary keys must be sortable

### DIFF
--- a/docs/pytrees.md
+++ b/docs/pytrees.md
@@ -286,6 +286,18 @@ To treat `None` as a leaf, you can use the `is_leaf` argument:
 jax.tree.leaves([None, None, None], is_leaf=lambda x: x is None)
 ```
 
+### Dictionary keys must be sortable
+
+`jax.tree_util` flattens a dictionary by its sorted keys, so the resulting pytree structure depends only on the *set* of keys and not on the insertion order. This keeps structure equality — and therefore JIT caching — predictable, but it means a dictionary's keys must be sortable relative to one another. Mixing key types that have no ordering between them, such as `int` and `str`, raises an error:
+
+```{code-cell}
+:tags: [raises-exception]
+
+jax.tree.map(lambda x: x + 1, {1: 7, "y": 42})
+```
+
+If you need a mapping whose keys can't be ordered, you can use `collections.OrderedDict`, which JAX flattens in insertion order without sorting the keys, or register a custom pytree node that defines its own flattening and unflattening (see {doc}`custom_pytrees`).
+
 (pytrees-common-pytree-patterns)=
 ## Common pytree patterns
 


### PR DESCRIPTION
## Summary

Fixes #15358. `jax.tree_util` flattens dictionaries by their sorted keys, so a dictionary's keys must be mutually sortable; mixing key types with no ordering between them (e.g. `int` and `str`) raises an error. As @mattjj noted on the issue, this requirement should be documented.

This adds a "Dictionary keys must be sortable" gotcha to `docs/pytrees.md`, covering:
- the requirement (dict keys must be sortable relative to one another),
- the rationale (structure/metadata equality depends on the key *set*, not insertion order, which keeps JIT caching predictable), and
- the workaround (register a custom pytree node).

## Notes

- Docs-only change.
- The example cell uses the `raises-exception` tag, consistent with other JAX docs.
- Verified the example raises as shown (`jax.tree.map(lambda x: x + 1, {1: 7, "y": 42})` -> `ValueError`) and that sortable-key dicts are unaffected.

> Authored with the assistance of an AI coding assistant; reviewed and verified by me.
