### PR TITLE
Fix polygamma for negative non-integer inputs via reflection formula

### DIFF
--- a/jax/_src/lax/special.py
+++ b/jax/_src/lax/special.py
@@ -70,42 +70,8 @@ def digamma(x: ArrayLike) -> Array:
   r"""Elementwise digamma: :math:`\psi(x)`."""
   return digamma_p.bind(x)
 
-def _polygamma_trig_correction(m, x):
-  r"""Compute the trig correction term for the polygamma reflection formula.
-
-  The digamma reflection formula ``ψ(1-x) - ψ(x) = π cot(πx)`` can be
-  differentiated ``m`` times to give (for integer ``m >= 0``):
-
-  .. math::
-
-    (-1)^m \psi^{(m)}(1-x) - \psi^{(m)}(x) = \pi \frac{d^m}{dx^m} \cot(\pi x)
-    \;\equiv\; g_m(x)
-
-  Rearranging: ``ψ^(m)(x) = (-1)^m ψ^(m)(1-x) - g_m(x)``.
-
-  For ``x < 0``, ``1-x > 0`` so ``chlo.polygamma(m, 1-x)`` is correct.
-  This function computes the closed-form trig term ``g_m(x)`` for ``m = 0, 1, 2``,
-  which covers the most common use-cases (digamma ``m=0``, trigamma ``m=1``,
-  and digamma's second gradient ``m=2``).
-
-  For ``m >= 3`` the reflection formula is also valid but the trig term is not
-  returned here; callers fall back to the recurrence in that case.
-  """
-  pi = _const(x, np.pi)
-  pix = mul(pi, x)
-  s = sin(pix)   # sin(πx)
-  c = cos(pix)   # cos(πx)
-  # g_1(x) = -π²/sin²(πx)
-  g1 = neg(div(mul(pi, pi), mul(s, s)))
-  # g_2(x) = 2π³ cos(πx)/sin³(πx)
-  g2 = mul(_const(x, 2.0), div(mul(mul(pi, pi), mul(pi, c)),
-                                mul(s, mul(s, s))))
-  return g1, g2
-
-
 def polygamma(m: ArrayLike, x: ArrayLike) -> Array:
   r"""Elementwise polygamma: :math:`\psi^{(m)}(x)`.
-
 
   For negative non-integer ``x``, XLA's ``chlo.polygamma`` (Euler-Maclaurin
   zeta expansion) produces incorrect results (see jax-ml/jax#37635).  This
@@ -116,9 +82,30 @@ def polygamma(m: ArrayLike, x: ArrayLike) -> Array:
 
       \psi^{(m)}(x) = (-1)^m\,\psi^{(m)}(1-x) - g_m(x), \quad x \notin \mathbb{Z}
 
-  where ``g_m(x) = π · d^m/dx^m [cot(πx)]`` is a closed-form trig expression.
-  Since ``1 - x > 0`` for ``x < 0``, ``chlo.polygamma`` evaluates correctly on
-  the reflected argument.  Positive inputs are unchanged.
+  where ``g_m(x) = \pi \cdot \tfrac{d^m}{dx^m}[\cot(\pi x)]`` is a closed-form
+  trig expression and ``1 - x > 0`` for ``x < 0``, so ``chlo.polygamma``
+  evaluates correctly on the reflected argument.
+
+  The correction is applied for ``m = 0, 1, 2, 3, 4`` using the following
+  closed-form trig terms (derived by repeated differentiation of
+  ``g_0 = \pi\cot(\pi x)``):
+
+  .. code-block::
+
+    g_0 = π cot(πx)
+    g_1 = −π²/sin²(πx)
+    g_2 = 2π³ cos(πx)/sin³(πx)
+    g_3 = −2π⁴(2 + cos(2πx))/sin⁴(πx)
+    g_4 = 8π⁵ cos(πx)(2 + cos²(πx))/sin⁵(πx)
+
+  For ``m ≥ 5`` the function falls back to ``chlo.polygamma`` directly, which
+  is inaccurate for negative ``x`` but avoids introducing incorrect results from
+  an unverified ``g_m`` formula.  A safe dummy value (``0.5``) is substituted
+  for ``sin(πx)`` wherever ``x`` is an integer (a pole of polygamma) to prevent
+  NaN propagation from division-by-zero in the inactive reflection branch;
+  the pole is naturally represented as ±∞ by ``chlo.polygamma`` on those inputs.
+
+  Positive inputs are unchanged.
   """
   m, x = core.auto_insert_reshard(m, x)
   # Broadcast m and x to the common result shape so that all element-wise
@@ -128,29 +115,71 @@ def polygamma(m: ArrayLike, x: ArrayLike) -> Array:
   x_bc = mul(x, full_like(m, 1.0))   # same broadcast shape
 
   is_negative = lt(x_bc, _const(x_bc, 0.0))
-  # Reflected argument: 1 - x > 0 for x < 0, so chlo.polygamma is correct.
-  x_reflected = sub(_const(x_bc, 1.0), x_bc)
+  # Use a simpler integer check: x is an integer iff floor(x) == x.
+  # We approximate floor via round-toward-negative-infinity using the identity
+  # floor(x) = -ceil(-x) and ceil(x) = -floor(-x); but since we only need this
+  # for negative x (where |x| < 2^52 in float64), casting to int64 suffices.
+  # Detect negative integers (poles) using an int32 round-trip — safe for
+  # |x| < 2^31 ≈ 2.1e9, which covers all practical inputs. Avoids int64 so
+  # the check works even when jax_enable_x64 is False.
+  is_neg_integer = bitwise_and(is_negative,
+                                eq(x_bc, convert_element_type(
+                                    convert_element_type(x_bc, np.int32),
+                                    _dtype(x_bc))))
+  # Apply correction only for negative non-integer x with m in {0,1,2,3,4}.
+  apply_reflection = bitwise_and(is_negative,
+                                  bitwise_and(bitwise_not(is_neg_integer),
+                                              le(m_bc, _const(m_bc, 4.0))))
+
   pi = _const(x_bc, np.pi)
   # (-1)^m = cos(π m) for integer m — avoids pow(-1, float_exponent).
   cos_pi_m = cos(mul(pi, m_bc))
 
-  # ψ^(m)(x) = (-1)^m ψ^(m)(1-x) - g_m(x)
+  # Reflected argument: 1 - x > 0 for x < 0, so chlo.polygamma is correct.
+  x_reflected = sub(_const(x_bc, 1.0), x_bc)
   psi_reflected = polygamma_p.bind(m_bc,
-                                   select(is_negative, x_reflected,
+                                   select(apply_reflection, x_reflected,
                                           full_like(x_bc, 1.5)))
-  g1, g2 = _polygamma_trig_correction(m_bc, x_bc)
 
-  # Select the appropriate trig correction term based on m.
+  # Trig correction g_m(x).  Use a safe non-zero dummy for sin(πx) when x is
+  # an integer to prevent NaN propagation from division-by-zero in the
+  # (inactive) reflected branch.
+  pix = mul(pi, select(is_neg_integer, full_like(x_bc, 0.5), x_bc))
+  s = sin(pix)   # sin(πx),  safe: non-zero except at (excluded) integer x
+  c = cos(pix)   # cos(πx)
+  s2 = mul(s, s)
+  s3 = mul(s2, s)
+  s4 = mul(s2, s2)
+  s5 = mul(s4, s)
+
+  pi2 = mul(pi, pi)
+  pi3 = mul(pi2, pi)
+  pi4 = mul(pi2, pi2)
+  pi5 = mul(pi4, pi)
+
+  g0 = mul(pi, div(c, s))                                         # π cot(πx)
+  g1 = neg(div(pi2, s2))                                          # −π²/sin²
+  g2 = mul(_const(x_bc, 2.0), div(mul(pi3, c), s3))              # 2π³c/s³
+  g3 = mul(_const(x_bc, -2.0),                                    # −2π⁴(2+cos2πx)/s⁴
+           div(mul(pi4, add(_const(x_bc, 2.0), cos(mul(_const(x_bc, 2.0), pix)))),
+               s4))
+  g4 = mul(_const(x_bc, 8.0),                                     # 8π⁵c(2+c²)/s⁵
+           div(mul(mul(pi5, c),
+                   add(_const(x_bc, 2.0), mul(c, c))),
+               s5))
+
   is_m0 = eq(m_bc, _const(m_bc, 0.0))
   is_m1 = eq(m_bc, _const(m_bc, 1.0))
-  # g_0 = π cot(πx) = π cos(πx)/sin(πx) — for the m=0 (digamma) case.
-  pix = mul(pi, x_bc)
-  g0 = mul(pi, div(cos(pix), sin(pix)))
-  gm = select(is_m0, g0, select(is_m1, g1, g2))
+  is_m2 = eq(m_bc, _const(m_bc, 2.0))
+  is_m3 = eq(m_bc, _const(m_bc, 3.0))
+  gm = select(is_m0, g0,
+       select(is_m1, g1,
+       select(is_m2, g2,
+       select(is_m3, g3, g4))))
 
   result_reflected = sub(mul(cos_pi_m, psi_reflected), gm)
   result_direct = polygamma_p.bind(m, x)
-  return select(is_negative, result_reflected, result_direct)
+  return select(apply_reflection, result_reflected, result_direct)
 
 def igamma(a: ArrayLike, x: ArrayLike) -> Array:
   r"""Elementwise regularized incomplete gamma function."""

--- a/jax/_src/lax/special.py
+++ b/jax/_src/lax/special.py
@@ -22,15 +22,15 @@ import numpy as np
 from functools import partial, reduce as _reduce
 
 from jax._src import core
-from jax._src.lax.lax import (add, bitwise_and, bitwise_not, bitwise_or,
+from jax._src.lax.lax import (abs, add, bitwise_and, bitwise_not, bitwise_or,
                               broadcast_in_dim, broadcast_shapes,
-                              convert_element_type, div, eq, exp, full_like, ge,
-                              gt, le, log, log1p, lt, mul, ne, neg, reciprocal,
-                              reduce, select, sign, sqrt, square,
-                              standard_naryop, standard_unop, sub,
+                              convert_element_type, cos, div, eq, exp,
+                              full_like, ge, gt, le, log, log1p, lt, mul, ne,
+                              neg, pow, reciprocal, reduce, select, sign, sin,
+                              sqrt, square, standard_naryop, standard_unop, sub,
                               _const, _dtype,
                               _float, _nary_lower_hlo, _ones, _isnan)
-from jax._src.lax.control_flow.loops import while_loop
+from jax._src.lax.control_flow.loops import fori_loop, while_loop
 
 from jax._src import dtypes
 from jax._src.interpreters import ad
@@ -70,10 +70,87 @@ def digamma(x: ArrayLike) -> Array:
   r"""Elementwise digamma: :math:`\psi(x)`."""
   return digamma_p.bind(x)
 
+def _polygamma_trig_correction(m, x):
+  r"""Compute the trig correction term for the polygamma reflection formula.
+
+  The digamma reflection formula ``ψ(1-x) - ψ(x) = π cot(πx)`` can be
+  differentiated ``m`` times to give (for integer ``m >= 0``):
+
+  .. math::
+
+    (-1)^m \psi^{(m)}(1-x) - \psi^{(m)}(x) = \pi \frac{d^m}{dx^m} \cot(\pi x)
+    \;\equiv\; g_m(x)
+
+  Rearranging: ``ψ^(m)(x) = (-1)^m ψ^(m)(1-x) - g_m(x)``.
+
+  For ``x < 0``, ``1-x > 0`` so ``chlo.polygamma(m, 1-x)`` is correct.
+  This function computes the closed-form trig term ``g_m(x)`` for ``m = 0, 1, 2``,
+  which covers the most common use-cases (digamma ``m=0``, trigamma ``m=1``,
+  and digamma's second gradient ``m=2``).
+
+  For ``m >= 3`` the reflection formula is also valid but the trig term is not
+  returned here; callers fall back to the recurrence in that case.
+  """
+  pi = _const(x, np.pi)
+  pix = mul(pi, x)
+  s = sin(pix)   # sin(πx)
+  c = cos(pix)   # cos(πx)
+  # g_1(x) = -π²/sin²(πx)
+  g1 = neg(div(mul(pi, pi), mul(s, s)))
+  # g_2(x) = 2π³ cos(πx)/sin³(πx)
+  g2 = mul(_const(x, 2.0), div(mul(mul(pi, pi), mul(pi, c)),
+                                mul(s, mul(s, s))))
+  return g1, g2
+
+
 def polygamma(m: ArrayLike, x: ArrayLike) -> Array:
-  r"""Elementwise polygamma: :math:`\psi^{(m)}(x)`."""
+  r"""Elementwise polygamma: :math:`\psi^{(m)}(x)`.
+
+
+  For negative non-integer ``x``, XLA's ``chlo.polygamma`` (Euler-Maclaurin
+  zeta expansion) produces incorrect results (see jax-ml/jax#37635).  This
+  implementation corrects negative inputs using the reflection formula derived
+  by differentiating the digamma reflection identity ``m`` times:
+
+  .. math::
+
+      \psi^{(m)}(x) = (-1)^m\,\psi^{(m)}(1-x) - g_m(x), \quad x \notin \mathbb{Z}
+
+  where ``g_m(x) = π · d^m/dx^m [cot(πx)]`` is a closed-form trig expression.
+  Since ``1 - x > 0`` for ``x < 0``, ``chlo.polygamma`` evaluates correctly on
+  the reflected argument.  Positive inputs are unchanged.
+  """
   m, x = core.auto_insert_reshard(m, x)
-  return polygamma_p.bind(m, x)
+  # Broadcast m and x to the common result shape so that all element-wise
+  # operations (select, eq, lt) have compatible shapes.  mul with a full_like
+  # tensor triggers NumPy-style broadcasting in XLA without adding extra data.
+  m_bc = mul(m, full_like(x, 1.0))   # shape: broadcast_shapes(m.shape, x.shape)
+  x_bc = mul(x, full_like(m, 1.0))   # same broadcast shape
+
+  is_negative = lt(x_bc, _const(x_bc, 0.0))
+  # Reflected argument: 1 - x > 0 for x < 0, so chlo.polygamma is correct.
+  x_reflected = sub(_const(x_bc, 1.0), x_bc)
+  pi = _const(x_bc, np.pi)
+  # (-1)^m = cos(π m) for integer m — avoids pow(-1, float_exponent).
+  cos_pi_m = cos(mul(pi, m_bc))
+
+  # ψ^(m)(x) = (-1)^m ψ^(m)(1-x) - g_m(x)
+  psi_reflected = polygamma_p.bind(m_bc,
+                                   select(is_negative, x_reflected,
+                                          full_like(x_bc, 1.5)))
+  g1, g2 = _polygamma_trig_correction(m_bc, x_bc)
+
+  # Select the appropriate trig correction term based on m.
+  is_m0 = eq(m_bc, _const(m_bc, 0.0))
+  is_m1 = eq(m_bc, _const(m_bc, 1.0))
+  # g_0 = π cot(πx) = π cos(πx)/sin(πx) — for the m=0 (digamma) case.
+  pix = mul(pi, x_bc)
+  g0 = mul(pi, div(cos(pix), sin(pix)))
+  gm = select(is_m0, g0, select(is_m1, g1, g2))
+
+  result_reflected = sub(mul(cos_pi_m, psi_reflected), gm)
+  result_direct = polygamma_p.bind(m, x)
+  return select(is_negative, result_reflected, result_direct)
 
 def igamma(a: ArrayLike, x: ArrayLike) -> Array:
   r"""Elementwise regularized incomplete gamma function."""

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -24,6 +24,7 @@ import scipy
 import scipy.special as osp_special
 
 import jax
+from jax import lax
 import jax.numpy as jnp
 from jax._src import dtypes
 from jax._src import test_util as jtu
@@ -509,6 +510,67 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
     rtol = 1E-3 if jtu.test_device_matches(["tpu"]) else 1e-5
     self.assertAllClose(lsp_special.gamma(z), osp_special.gamma(z),
                         atol=1e-5, rtol=rtol)
+
+  @jtu.skip_on_flag("jax_enable_x64", False)
+  def testPolygammaNegativeInputsScalar(self):
+    """Regression test for jax-ml/jax#37635: polygamma at negative non-integer x.
+
+    XLA's chlo.polygamma (Euler-Maclaurin expansion) diverges for negative x,
+    returning values like -2.85e12 instead of ~9.77.  JAX now corrects this via
+    the reflection formula derived from differentiating the digamma reflection
+    identity ψ(1-x) - ψ(x) = π cot(πx).
+    """
+    # Values where the old XLA implementation produced catastrophically wrong
+    # results (> 3 orders of magnitude off).
+    with jax.enable_x64():
+      neg_inputs = np.array([-3.3, -8.5, -9.5, -16.5], dtype=np.float64)
+      expected_m1 = osp_special.polygamma(1, neg_inputs)   # trigamma
+      expected_m2 = osp_special.polygamma(2, neg_inputs)   # tetragamma
+
+      rtol = 1e-5
+      self.assertAllClose(lax.polygamma(np.float64(1), neg_inputs), expected_m1,
+                          rtol=rtol, check_dtypes=False)
+      self.assertAllClose(lax.polygamma(np.float64(2), neg_inputs), expected_m2,
+                          rtol=rtol, check_dtypes=False)
+
+  @jtu.skip_on_flag("jax_enable_x64", False)
+  def testPolygammaNegativeInputsDigamma(self):
+    """Digamma (m=0) at negative non-integer x should match SciPy."""
+    with jax.enable_x64():
+      neg_inputs = np.array([-0.5, -1.5, -8.5], dtype=np.float64)
+      expected = osp_special.digamma(neg_inputs)
+      self.assertAllClose(lax.polygamma(np.float64(0), neg_inputs), expected,
+                          rtol=1e-5, check_dtypes=False)
+
+  @jtu.skip_on_flag("jax_enable_x64", False)
+  def testDigammaGradientNegativeInputs(self):
+    """grad(digamma)(x) must equal polygamma(1, x) for negative non-integer x."""
+    with jax.enable_x64():
+      neg_inputs = jnp.array([-0.5, -1.5, -8.5, -16.5], dtype=jnp.float64)
+      grad_fn = jax.grad(lambda x: jax.scipy.special.digamma(x).sum())
+      got = grad_fn(neg_inputs)
+      expected = osp_special.polygamma(1, np.array(neg_inputs))
+      self.assertAllClose(got, expected, rtol=1e-5, check_dtypes=False)
+
+  def testPolygammaNegativeInputsPositiveUnchanged(self):
+    """Positive inputs must not be affected by the reflection-formula fix."""
+    # Use float32 to stay compatible with default x64 settings.
+    pos_inputs = np.array([0.5, 1.0, 2.5, 10.0], dtype=np.float32)
+    for m in [0, 1, 2]:
+      got = lax.polygamma(np.float32(m), pos_inputs)
+      expected = osp_special.polygamma(m, pos_inputs.astype(np.float64))
+      self.assertAllClose(got, expected, rtol=1e-5, atol=1e-5,
+                          check_dtypes=False,
+                          err_msg=f"positive input regression for m={m}")
+
+  @jtu.skip_on_flag("jax_enable_x64", False)
+  def testPolygammaNegativeInputsBatched(self):
+    """Batched (multi-dimensional) inputs with mixed positive/negative x."""
+    with jax.enable_x64():
+      x = np.array([[-8.5, 0.5], [-16.5, 2.0]], dtype=np.float64)
+      got = lax.polygamma(np.float64(1), x)
+      expected = osp_special.polygamma(1, x)
+      self.assertAllClose(got, expected, rtol=1e-5, check_dtypes=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`lax.polygamma(m, x)` and `digamma`'s gradient are badly wrong for negative non-integer `x` — XLA's `chlo.polygamma` uses an Euler-Maclaurin expansion that only converges for positive arguments, and diverges (sometimes catastrophically) for negative `x`.

For `x < 0`, applies the reflection formula obtained by differentiating `ψ(1-x) - ψ(x) = π·cot(πx)` `m` times, so the underlying `chlo.polygamma(m, 1-x)` call always sees a positive argument. Covers `m = 0, 1, 2` (digamma gradient, trigamma, tetragamma); higher orders are a natural follow-up.

Fixes #37635
