### PR TITLE
Copy writeable numpy buffers when may_alias=False in device_put

### DIFF
--- a/jax/_src/interpreters/pxla.py
+++ b/jax/_src/interpreters/pxla.py
@@ -169,7 +169,7 @@ shard_arg_handlers[np.ma.MaskedArray] = _masked_array_error
 
 def _shard_np_array(xs, shardings, layouts, copy_semantics):
   results = []
-  for x, sharding, layout in safe_zip(xs, shardings, layouts):
+  for x, sharding, layout, cs in safe_zip(xs, shardings, layouts, copy_semantics):
     devices = sharding._addressable_device_assignment
     if x.dtype == dtypes.float0:
       x = np.zeros(x.shape, dtype=np.dtype(bool))
@@ -177,12 +177,17 @@ def _shard_np_array(xs, shardings, layouts, copy_semantics):
     if layout is not None:
       results.append(api.device_put(x, Format(layout, sharding)))
     else:
+      # Honor an explicit copy request (e.g. device_put(..., may_alias=False)).
+      # Without this the writeable numpy buffer is aliased zero-copy and later
+      # mutations to it leak into the supposedly-immutable array (#37830).
+      force_copy = cs == xc.ArrayCopySemantics.ALWAYS_COPY
       if sharding.is_fully_replicated:
         shards = [x] * len(devices)
       else:
         indices = tuple(sharding.addressable_devices_indices_map(x.shape).values())
         shards = [x[i] for i in indices]
-      results.append(batched_device_put(aval, sharding, shards, devices))
+      results.append(batched_device_put(aval, sharding, shards, devices,
+                                        force_copy=force_copy))
   return results
 for _t in array_types:
   shard_arg_handlers[_t] = _shard_np_array
@@ -214,7 +219,8 @@ shard_arg_handlers[core.Ref] = _shard_mutable_array
 def batched_device_put(aval: core.ShapedArray,
                        sharding: JSharding, xs: Sequence[Any],
                        devices: Sequence[xc.Device], committed: bool = True,
-                       enable_x64: bool | None = None):
+                       enable_x64: bool | None = None, *,
+                       force_copy: bool = False):
   util.test_event("batched_device_put_start")
   try:
     bufs = [x for x, d in safe_zip(xs, devices)
@@ -224,7 +230,7 @@ def batched_device_put(aval: core.ShapedArray,
       return array.ArrayImpl(
           aval, sharding, bufs, committed=committed, _skip_checks=True)
     return xc.batched_device_put(aval, sharding, xs, list(devices), committed,
-                                 enable_x64=enable_x64)
+                                 force_copy, enable_x64=enable_x64)
   finally:
     util.test_event("batched_device_put_end")
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -518,6 +518,16 @@ class JitTest(jtu.BufferDonationTestCase):
                          may_alias=False, donate=False)
     self.assertNotEqual(id(arr), id(out))
 
+  def test_device_put_numpy_array_may_alias_false_copies(self):
+    # may_alias=False must copy a writeable numpy buffer, otherwise later
+    # mutations to the source leak into the (supposedly immutable) array.
+    # See https://github.com/jax-ml/jax/issues/37830.
+    x = np.arange(1024, dtype=np.float32)
+    out = jax.device_put(x, jax.devices()[0], may_alias=False)
+    self.assertNotEqual(x.ctypes.data, out.unsafe_buffer_pointer())
+    x[0] = 999
+    self.assertEqual(float(out[0]), 0.0)
+
   def test_device_put_aliasing_with_diff_compatible_sharding(self):
     if jax.device_count() < 2:
       raise unittest.SkipTest("Test requires >= 2 devices")


### PR DESCRIPTION
## What

`jax.device_put(np_array, may_alias=False)` is documented to force a copy. For
numpy inputs it silently aliased the host buffer instead, so mutating the source
array afterward changed the supposedly immutable JAX array.

## Why it happens

`api.py` turns `may_alias=False` into `ArrayCopySemantics.ALWAYS_COPY`. The
jax-array path in `dispatch.py` honors that by passing a force-copy flag to
`xc.batched_device_put`. The numpy path runs through `pxla._shard_np_array`,
which received `copy_semantics` but never used it. The local `batched_device_put`
wrapper also had no way to forward a force-copy flag, so the copy request was
dropped and the result aliased the input.

## The fix

Two files, +20/-4:

- `_shard_np_array` now reads `copy_semantics` and sets
  `force_copy = cs == xc.ArrayCopySemantics.ALWAYS_COPY`.
- The `batched_device_put` wrapper takes a keyword-only `force_copy` and forwards
  it as the 6th positional to `xc.batched_device_put`. That is the slot the
  jax-array path already uses, so no jaxlib change is needed. Keyword-only keeps
  existing positional callers safe.

## Behavior

- Before: `may_alias=False` on a numpy input returned the same buffer and
  mutations leaked.
- After: `may_alias=False` returns a fresh buffer with no leak.
- The default aliasing path is unchanged, so there is no perf regression.

`test_device_put_aliasing` only covered jax-array inputs, which is how this
slipped through. I added `test_device_put_numpy_array_may_alias_false_copies`
for the numpy path. It asserts the buffer pointer differs and mutates the source
to prove there is no leak.

## Scope

This fixes the clear defect where `may_alias=False` did not copy. It does not
change the default, since copy-by-default is a perf versus safety decision for
the maintainers, so the commit says "Part of #37830" rather than closing it.

One spot left out on purpose: the layout branch in `_shard_np_array`
(`if layout is not None`) also does not thread copy semantics. I kept this narrow
to the reported path. Happy to extend it here if you want that in the same PR.
