### PR TITLE
Add 0-mean von Mises sampler to random core

### DIFF
--- a/jax/_src/numpy/__init__.py
+++ b/jax/_src/numpy/__init__.py
@@ -189,6 +189,7 @@ from jax._src.numpy.tensor_contractions import (
 
 from jax._src.numpy.ufuncs import (
     abs as abs,
+    arccos as arccos,
     arctan2 as arctan2,
     bitwise_and as bitwise_and,
     cbrt as cbrt,

--- a/jax/_src/random/__init__.py
+++ b/jax/_src/random/__init__.py
@@ -63,6 +63,7 @@ from jax._src.random.core import (
     triangular as triangular,
     truncated_normal as truncated_normal,
     uniform as uniform,
+    vonmises as vonmises,
     wald as wald,
     weibull_min as weibull_min,
     wrap_key_data as wrap_key_data,

--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2990,7 +2990,7 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
     )
 
     uniform_sign = 2.0 * binomial(key, jnp.ones_like(kappa), 0.5, dtype=dtype) - 1.0
-    return uniform_sign * jnp.arccos(w_final)
+    return uniform_sign * jnp.arccos(jnp.clip(w_final, -1.0, 1.0))
 
   samples = lax.select(
     kappa < kappa_small,

--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2917,26 +2917,12 @@ def vonmises(key: ArrayLike,
 
 @jit(static_argnums=(2, 3))
 def _vonmises(key, kappa, shape, dtype) -> Array:
-  """Vonmises sampling implementation, with shape and dtype already checked and broadcasted."""
-  kappa = lax.convert_element_type(kappa, dtype)
-  kappa = jnp.broadcast_to(kappa, shape)
-  # split key to match the shape of kappa
-  split_count = math.prod(shape[key.ndim:])
-  keys = key.flatten()
-  keys = vmap(_split, in_axes=(0, None))(keys, split_count)
-  keys = keys.flatten()
-  kappas = kappa.flatten()
-
-  samples = vmap(partial(_vonmises_one, dtype=dtype))(keys, kappas)
-
-  return jnp.reshape(samples, shape)
-
-
-def _vonmises_one(key: Array, kappa: Array, dtype: DTypeLikeFloat):
   """Sample from von Mises distribution with mean angle 0 and concentration kappa
 
   Jax transcription of Numpy's implementation of von Mises sampling, which uses Best and Fisher's algorithm
   """
+  kappa = lax.convert_element_type(kappa, dtype)
+  kappa = jnp.broadcast_to(kappa, shape).flatten()
 
   with np.errstate(over="ignore"):
     kappa_large = jnp.array(1e5).astype(dtype)
@@ -2968,51 +2954,55 @@ def _vonmises_one(key: Array, kappa: Array, dtype: DTypeLikeFloat):
       rho_val = (r_val - jnp.sqrt(2 * r_val)) / (2 * safe_kappa)
       return (1 + rho_val * rho_val) / (2 * rho_val)
     # Use second order Taylor expansion for small kappa
-    s_val = lax_control_flow.cond(
-      safe_kappa < kappa_mid_small, lambda kappa: 1.0 / kappa + kappa, s_val_from_kappa, safe_kappa
+    s_val = lax.select(
+      safe_kappa < kappa_mid_small, 1.0 / kappa + kappa, s_val_from_kappa(safe_kappa)
     )
 
-    def get_yw_vals(state):
-      key, kappa, s_val, *_ = state
+    def body_fn(state):
+      key, accepted, w_out = state
       new_key, zkey, vkey = _split(key, 3)
       z_val = jnp.cos(
         np.pi * uniform(zkey, shape=np.shape(kappa), dtype=dtype)
       )
       w_val = (1 + s_val * z_val) / (s_val + z_val)
-      y_val = kappa * (s_val - w_val)
+      y_val = safe_kappa * (s_val - w_val)
       v_val = uniform(vkey, shape=np.shape(kappa), dtype=dtype)
-      return (new_key, kappa, s_val, y_val, v_val, w_val)
 
-    def yw_cond(state):
-      *_, y_val, v_val, _ = state
       cond1 = y_val * (2.0 - y_val) - v_val >= 0
       cond2 = jnp.log(y_val / v_val) + 1 - y_val >= 0
-      return ~(cond1 | cond2)
+      accept = cond1 | cond2
+      w_out = lax.select(accept, w_val, w_out)
+      accepted |= accept
+      return (new_key, accepted, w_out)
+
+    def cond_fn(state):
+      accepted = state[-2]
+      return (~accepted).any()
 
     *_, w_final = lax_control_flow.while_loop(
-      yw_cond,
-      get_yw_vals,
-      # Set so yw_cond returns True for the first iteration if kappa in range
+      cond_fn,
+      body_fn,
+      # Set so cond_fn returns True for the first iteration if kappa in range
       # jit traces all branches regardless of kappa
       (key,
-       safe_kappa,
-       s_val,
-       jnp.array(0.0), -2.0 * ((safe_kappa < kappa_small) | (safe_kappa > kappa_large) | (s_val == jnp.inf)).astype(dtype) + 1.0,
-       jnp.array(0.0)),
+       (safe_kappa < kappa_small) | (safe_kappa > kappa_large),
+       jnp.zeros_like(kappa)),
     )
 
     uniform_sign = 2.0 * binomial(key, jnp.ones_like(kappa), 0.5, dtype=dtype) - 1.0
     return uniform_sign * jnp.arccos(w_final)
 
-  return lax_control_flow.cond(
+  samples = lax.select(
     kappa < kappa_small,
-    small_kappa_uniform,
-    lambda key, kappa: lax_control_flow.cond(
-      kappa > kappa_large, large_kappa_normal, mid_kappa_sample, key, kappa
-    ),
-    key,
-    kappa,
+    small_kappa_uniform(key, kappa),
+    lax.select(
+      kappa > kappa_large,
+      large_kappa_normal(key, kappa),
+      mid_kappa_sample(key, kappa)
+    )
   )
+
+  return jnp.reshape(samples, shape)
 
 def wald(key: ArrayLike,
          mean: RealArray,

--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2870,11 +2870,11 @@ def _rayleigh(key, scale, shape, dtype) -> Array:
   return ray
 
 def vonmises(key: ArrayLike,
-              kappa: RealArray = np.float32(1),
-              shape: Shape | None = None,
-              dtype: DTypeLikeFloat | None = None,
-              *,
-              out_sharding: NamedSharding | P | None = None) -> Array:
+             kappa: RealArray = 1.0,
+             shape: Shape | None = None,
+             dtype: DTypeLikeFloat | None = None,
+             *,
+             out_sharding: NamedSharding | P | None = None) -> Array:
   r""" Sample 0-mean von Mises random values with given shape and float dtype.
 
   The values are distributed according to the probability density function:
@@ -2909,7 +2909,7 @@ def vonmises(key: ArrayLike,
   dtype = dtypes.check_and_canonicalize_user_dtype(float if dtype is None else dtype)
   if not dtypes.issubdtype(dtype, np.inexact):
     raise ValueError(f"dtype argument to `vonmises` must be a float or complex dtype, "
-                    f"got {dtype}")
+                     f"got {dtype}")
   shape = _check_broadcast_shapes("vonmises", shape, kappa)
   out_sharding = canonicalize_sharding(out_sharding, "vonmises")
   _check_all_safe_to_cast("vonmises", dtype, kappa)
@@ -2932,83 +2932,87 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
   return jnp.reshape(samples, shape)
 
 
-def _vonmises_one(key: Array, kappa: ArrayLike, dtype: DTypeLikeFloat):
-    """Sample from von Mises distribution with mean angle 0 and concentration kappa
+def _vonmises_one(key: Array, kappa: Array, dtype: DTypeLikeFloat):
+  """Sample from von Mises distribution with mean angle 0 and concentration kappa
 
-    Jax transcription of Numpy's implementation of von Mises sampling, which uses Best and Fisher's algorithm
-    """
+  Jax transcription of Numpy's implementation of von Mises sampling, which uses Best and Fisher's algorithm
+  """
 
-    with np.errstate(over="ignore"):
-      kappa_large = jnp.array(1e5).astype(dtype)
-      kappa_small = jnp.array(1e-5).astype(dtype)
-      kappa_mid_small = jnp.array(1e-3).astype(dtype)
+  with np.errstate(over="ignore"):
+    kappa_large = jnp.array(1e5).astype(dtype)
+    kappa_small = jnp.array(1e-5).astype(dtype)
+    kappa_mid_small = jnp.array(1e-3).astype(dtype)
 
-    def small_kappa_uniform(key: Array, kappa: ArrayLike):
-        """For small kappa, the distribution is approximately uniform on [-pi, pi]"""
-        return uniform(
-            key, shape=np.shape(kappa), dtype=dtype, minval=-np.pi, maxval=np.pi
-        )
-
-    def large_kappa_normal(key: Array, kappa: ArrayLike):
-        """For large kappa, the distribution is approximately normal with mean 0 and variance 1/kappa"""
-        safe_kappa = jnp.where(kappa < kappa_large, 1.0, kappa)
-        return jnp.clip(
-            normal(key, shape=np.shape(kappa), dtype=dtype) / jnp.sqrt(safe_kappa),
-            -np.pi,
-            np.pi,
-        )
-
-    def mid_kappa_sample(key: Array, kappa: ArrayLike):
-
-        safe_kappa = jnp.where(kappa < kappa_small, 1.0, kappa)
-
-        def s_val_from_kappa(kappa: ArrayLike):
-            safe_kappa = jnp.where(kappa < kappa_mid_small, 1.0, kappa)
-            r_val = 1 + jnp.sqrt(1 + 4 * safe_kappa * safe_kappa)
-            rho_val = (r_val - jnp.sqrt(2 * r_val)) / (2 * safe_kappa)
-            return (1 + rho_val * rho_val) / (2 * rho_val)
-        # Use second order Taylor expansion for small kappa
-        s_val = lax_control_flow.cond(
-            safe_kappa < kappa_mid_small, lambda kappa: 1.0 / kappa + kappa, s_val_from_kappa, safe_kappa
-        )
-
-        def get_yw_vals(state):
-            key, kappa, s_val, _, _, _ = state
-            new_key, zkey, vkey = _split(key, 3)
-            z_val = jnp.cos(
-                np.pi * uniform(zkey, shape=np.shape(kappa), dtype=dtype)
-            )
-            w_val = (1 + s_val * z_val) / (s_val + z_val)
-            y_val = kappa * (s_val - w_val)
-            v_val = uniform(vkey, shape=np.shape(kappa), dtype=dtype)
-            return (new_key, kappa, s_val, y_val, v_val, w_val)
-
-        def yw_cond(state):
-            _, _, _, y_val, v_val, _ = state
-            cond1 = y_val * (2.0 - y_val) - v_val >= 0
-            cond2 = jnp.log(y_val / v_val) + 1 - y_val >= 0
-            return ~(cond1 | cond2)
-
-        _, _, _, _, _, w_final = lax_control_flow.while_loop(
-            yw_cond,
-            get_yw_vals,
-            # Set so yw_cond returns True for the first iteration if kappa in range
-            # jit traces all branches regardless of kappa
-            (key, safe_kappa, s_val, jnp.array(0.0), -2.0 * ((safe_kappa < kappa_small) | (safe_kappa > kappa_large) | (s_val == jnp.inf)).astype(dtype) + 1.0, jnp.array(0.0)),
-        )
-
-        uniform_sign = 2.0 * binomial(key, jnp.ones_like(kappa), 0.5, dtype=dtype) - 1.0
-        return uniform_sign * jnp.arccos(w_final)
-
-    return lax_control_flow.cond(
-        kappa < kappa_small,
-        small_kappa_uniform,
-        lambda key, kappa: lax_control_flow.cond(
-            kappa > kappa_large, large_kappa_normal, mid_kappa_sample, key, kappa
-        ),
-        key,
-        kappa,
+  def small_kappa_uniform(key: Array, kappa: Array):
+    """For small kappa, the distribution is approximately uniform on [-pi, pi]"""
+    return uniform(
+      key, shape=np.shape(kappa), dtype=dtype, minval=-np.pi, maxval=np.pi
     )
+
+  def large_kappa_normal(key: Array, kappa: Array):
+    """For large kappa, the distribution is approximately normal with mean 0 and variance 1/kappa"""
+    safe_kappa = jnp.where(kappa < kappa_large, 1.0, kappa)
+    return jnp.clip(
+      normal(key, shape=np.shape(kappa), dtype=dtype) / jnp.sqrt(safe_kappa),
+      -np.pi,
+      np.pi,
+    )
+
+  def mid_kappa_sample(key: Array, kappa: Array):
+
+    safe_kappa = jnp.where(kappa < kappa_small, 1.0, kappa)
+
+    def s_val_from_kappa(kappa: Array):
+      safe_kappa = jnp.where(kappa < kappa_mid_small, 1.0, kappa)
+      r_val = 1 + jnp.sqrt(1 + 4 * safe_kappa * safe_kappa)
+      rho_val = (r_val - jnp.sqrt(2 * r_val)) / (2 * safe_kappa)
+      return (1 + rho_val * rho_val) / (2 * rho_val)
+    # Use second order Taylor expansion for small kappa
+    s_val = lax_control_flow.cond(
+      safe_kappa < kappa_mid_small, lambda kappa: 1.0 / kappa + kappa, s_val_from_kappa, safe_kappa
+    )
+
+    def get_yw_vals(state):
+      key, kappa, s_val, *_ = state
+      new_key, zkey, vkey = _split(key, 3)
+      z_val = jnp.cos(
+        np.pi * uniform(zkey, shape=np.shape(kappa), dtype=dtype)
+      )
+      w_val = (1 + s_val * z_val) / (s_val + z_val)
+      y_val = kappa * (s_val - w_val)
+      v_val = uniform(vkey, shape=np.shape(kappa), dtype=dtype)
+      return (new_key, kappa, s_val, y_val, v_val, w_val)
+
+    def yw_cond(state):
+      *_, y_val, v_val, _ = state
+      cond1 = y_val * (2.0 - y_val) - v_val >= 0
+      cond2 = jnp.log(y_val / v_val) + 1 - y_val >= 0
+      return ~(cond1 | cond2)
+
+    *_, w_final = lax_control_flow.while_loop(
+      yw_cond,
+      get_yw_vals,
+      # Set so yw_cond returns True for the first iteration if kappa in range
+      # jit traces all branches regardless of kappa
+      (key,
+       safe_kappa,
+       s_val,
+       jnp.array(0.0), -2.0 * ((safe_kappa < kappa_small) | (safe_kappa > kappa_large) | (s_val == jnp.inf)).astype(dtype) + 1.0,
+       jnp.array(0.0)),
+    )
+
+    uniform_sign = 2.0 * binomial(key, jnp.ones_like(kappa), 0.5, dtype=dtype) - 1.0
+    return uniform_sign * jnp.arccos(w_final)
+
+  return lax_control_flow.cond(
+    kappa < kappa_small,
+    small_kappa_uniform,
+    lambda key, kappa: lax_control_flow.cond(
+      kappa > kappa_large, large_kappa_normal, mid_kappa_sample, key, kappa
+    ),
+    key,
+    kappa,
+  )
 
 def wald(key: ArrayLike,
          mean: RealArray,

--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2869,6 +2869,147 @@ def _rayleigh(key, scale, shape, dtype) -> Array:
   ray = lax.mul(scale, sqrt_u)
   return ray
 
+def vonmises(key: ArrayLike,
+              kappa: RealArray = np.float32(1),
+              shape: Shape | None = None,
+              dtype: DTypeLikeFloat | None = None,
+              *,
+              out_sharding: NamedSharding | P | None = None) -> Array:
+  r""" Sample 0-mean von Mises random values with given shape and float dtype.
+
+  The values are distributed according to the probability density function:
+
+  .. math::
+      f(x) = \frac{1}{2*\pi I_0(\kappa)}\exp\left(\kappa\cos(x)\right)
+
+  on the domain :math:`\pi > x > -\pi`, where :math:`\I_0(x)` is the
+  zero-th order modified Bessel function of the first kind.
+
+  Args:
+    key: a PRNG key used as the random key.
+    kappa: a float or array of floats broadcast-compatible with ``shape`` representing
+      the concentration parameter of the distribution. Default 1.
+    shape: optional, a tuple of nonnegative integers specifying the result
+      shape. The default (None) produces a result shape equal to ``()``.
+    dtype: optional, a float dtype for the returned values (default float64 if
+      jax_enable_x64 is true, otherwise float32).
+    out_sharding: optional, specifies how the output array should be sharded
+      across devices in multi-device computation. Can be a
+      :class:`~jax.sharding.NamedSharding`, a :class:`~jax.sharding.PartitionSpec`
+      (``P``), or ``None`` (default). When specified, the output will be sharded
+      according to the given sharding specification. Primarily used in explicit
+      sharding mode.
+      See the `explicit sharding tutorial <https://docs.jax.dev/en/latest/parallel.html>`_
+      for more details.
+
+  Returns:
+    A random array with the specified dtype and with shape given by ``shape``.
+  """
+  key, _ = _check_prng_key("vonmises", key)
+  dtype = dtypes.check_and_canonicalize_user_dtype(float if dtype is None else dtype)
+  if not dtypes.issubdtype(dtype, np.inexact):
+    raise ValueError(f"dtype argument to `vonmises` must be a float or complex dtype, "
+                    f"got {dtype}")
+  shape = _check_broadcast_shapes("vonmises", shape, kappa)
+  out_sharding = canonicalize_sharding(out_sharding, "vonmises")
+  _check_all_safe_to_cast("vonmises", dtype, kappa)
+  return maybe_auto_axes(_vonmises, out_sharding, shape=shape, dtype=dtype)(key, kappa)
+
+@jit(static_argnums=(2, 3))
+def _vonmises(key, kappa, shape, dtype) -> Array:
+  """Vonmises sampling implementation, with shape and dtype already checked and broadcasted."""
+  kappa = lax.convert_element_type(kappa, dtype)
+  kappa = jnp.broadcast_to(kappa, shape)
+  # split key to match the shape of kappa
+  split_count = math.prod(shape[key.ndim:])
+  keys = key.flatten()
+  keys = vmap(_split, in_axes=(0, None))(keys, split_count)
+  keys = keys.flatten()
+  kappas = kappa.flatten()
+
+  samples = vmap(partial(_vonmises_one, dtype=dtype))(keys, kappas)
+
+  return jnp.reshape(samples, shape)
+
+
+def _vonmises_one(key: Array, kappa: ArrayLike, dtype: DTypeLikeFloat):
+    """Sample from von Mises distribution with mean angle 0 and concentration kappa
+
+    Jax transcription of Numpy's implementation of von Mises sampling, which uses Best and Fisher's algorithm
+    """
+
+    with np.errstate(over="ignore"):
+      kappa_large = jnp.array(1e5).astype(dtype)
+      kappa_small = jnp.array(1e-5).astype(dtype)
+      kappa_mid_small = jnp.array(1e-3).astype(dtype)
+
+    def small_kappa_uniform(key: Array, kappa: ArrayLike):
+        """For small kappa, the distribution is approximately uniform on [-pi, pi]"""
+        return uniform(
+            key, shape=np.shape(kappa), dtype=dtype, minval=-np.pi, maxval=np.pi
+        )
+
+    def large_kappa_normal(key: Array, kappa: ArrayLike):
+        """For large kappa, the distribution is approximately normal with mean 0 and variance 1/kappa"""
+        safe_kappa = jnp.where(kappa < kappa_large, 1.0, kappa)
+        return jnp.clip(
+            normal(key, shape=np.shape(kappa), dtype=dtype) / jnp.sqrt(safe_kappa),
+            -np.pi,
+            np.pi,
+        )
+
+    def mid_kappa_sample(key: Array, kappa: ArrayLike):
+
+        safe_kappa = jnp.where(kappa < kappa_small, 1.0, kappa)
+
+        def s_val_from_kappa(kappa: ArrayLike):
+            safe_kappa = jnp.where(kappa < kappa_mid_small, 1.0, kappa)
+            r_val = 1 + jnp.sqrt(1 + 4 * safe_kappa * safe_kappa)
+            rho_val = (r_val - jnp.sqrt(2 * r_val)) / (2 * safe_kappa)
+            return (1 + rho_val * rho_val) / (2 * rho_val)
+        # Use second order Taylor expansion for small kappa
+        s_val = lax_control_flow.cond(
+            safe_kappa < kappa_mid_small, lambda kappa: 1.0 / kappa + kappa, s_val_from_kappa, safe_kappa
+        )
+
+        def get_yw_vals(state):
+            key, kappa, s_val, _, _, _ = state
+            new_key, zkey, vkey = _split(key, 3)
+            z_val = jnp.cos(
+                np.pi * uniform(zkey, shape=np.shape(kappa), dtype=dtype)
+            )
+            w_val = (1 + s_val * z_val) / (s_val + z_val)
+            y_val = kappa * (s_val - w_val)
+            v_val = uniform(vkey, shape=np.shape(kappa), dtype=dtype)
+            return (new_key, kappa, s_val, y_val, v_val, w_val)
+
+        def yw_cond(state):
+            _, _, _, y_val, v_val, _ = state
+            cond1 = y_val * (2.0 - y_val) - v_val >= 0
+            cond2 = jnp.log(y_val / v_val) + 1 - y_val >= 0
+            return ~(cond1 | cond2)
+
+        _, _, _, _, _, w_final = lax_control_flow.while_loop(
+            yw_cond,
+            get_yw_vals,
+            # Set so yw_cond returns True for the first iteration if kappa in range
+            # jit traces all branches regardless of kappa
+            (key, safe_kappa, s_val, jnp.array(0.0), -2.0 * ((safe_kappa < kappa_small) | (safe_kappa > kappa_large) | (s_val == jnp.inf)).astype(dtype) + 1.0, jnp.array(0.0)),
+        )
+
+        uniform_sign = 2.0 * binomial(key, jnp.ones_like(kappa), 0.5, dtype=dtype) - 1.0
+        return uniform_sign * jnp.arccos(w_final)
+
+    return lax_control_flow.cond(
+        kappa < kappa_small,
+        small_kappa_uniform,
+        lambda key, kappa: lax_control_flow.cond(
+            kappa > kappa_large, large_kappa_normal, mid_kappa_sample, key, kappa
+        ),
+        key,
+        kappa,
+    )
+
 def wald(key: ArrayLike,
          mean: RealArray,
          shape: Shape | None = None,

--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2955,7 +2955,7 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
       return (1 + rho_val * rho_val) / (2 * rho_val)
     # Use second order Taylor expansion for small kappa
     s_val = lax.select(
-      safe_kappa < kappa_mid_small, 1.0 / kappa + kappa, s_val_from_kappa(safe_kappa)
+      safe_kappa < kappa_mid_small, 1.0 / safe_kappa + safe_kappa, s_val_from_kappa(safe_kappa)
     )
 
     def body_fn(state):
@@ -2979,7 +2979,7 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
       accepted = state[-2]
       return (~accepted).any()
 
-    *_, w_final = lax_control_flow.while_loop(
+    _, key_final, _, w_final = lax_control_flow.while_loop(
       cond_fn,
       body_fn,
       # Set so cond_fn returns True for the first iteration if kappa in range
@@ -2989,7 +2989,7 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
        jnp.zeros_like(kappa)),
     )
 
-    uniform_sign = 2.0 * binomial(key, jnp.ones_like(kappa), 0.5, dtype=dtype) - 1.0
+    uniform_sign = rademacher(key_final, shape=np.shape(kappa), dtype=dtype)
     return uniform_sign * jnp.arccos(jnp.clip(w_final, -1.0, 1.0))
 
   samples = lax.select(

--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2959,8 +2959,8 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
     )
 
     def body_fn(state):
-      key, accepted, w_out = state
-      new_key, zkey, vkey = _split(key, 3)
+      iter_idx, key, accepted, w_out = state
+      new_key, zkey, vkey = _split(fold_in(key, iter_idx), 3)
       z_val = jnp.cos(
         np.pi * uniform(zkey, shape=np.shape(kappa), dtype=dtype)
       )
@@ -2973,7 +2973,7 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
       accept = cond1 | cond2
       w_out = lax.select(accept, w_val, w_out)
       accepted |= accept
-      return (new_key, accepted, w_out)
+      return (iter_idx+1, new_key, accepted, w_out)
 
     def cond_fn(state):
       accepted = state[-2]
@@ -2984,7 +2984,7 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
       body_fn,
       # Set so cond_fn returns True for the first iteration if kappa in range
       # jit traces all branches regardless of kappa
-      (key,
+      (0, key,
        (safe_kappa < kappa_small) | (safe_kappa > kappa_large),
        jnp.zeros_like(kappa)),
     )

--- a/jax/random.py
+++ b/jax/random.py
@@ -259,6 +259,7 @@ from jax._src.random.core import (
   triangular as triangular,
   truncated_normal as truncated_normal,
   uniform as uniform,
+  vonmises as vonmises,
   wald as wald,
   weibull_min as weibull_min,
   wrap_key_data as wrap_key_data,

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -247,6 +247,7 @@ _OUT_SHARDING_CASES = [
     ('triangular', lambda key, n, s: random.triangular(key, left=0., mode=0.5, right=1., shape=(n,), out_sharding=s)),
     ('uniform', lambda key, n, s: random.uniform(key, shape=(n,), out_sharding=s)),
     ('gamma', lambda key, n, s: random.gamma(key, a=2.0, shape=(n,), out_sharding=s)),
+    ('vonmises', lambda key, n, s: random.vonmises(key, kappa=1.0, shape=(n,), out_sharding=s)),
     ('wald', lambda key, n, s: random.wald(key, mean=1.0, shape=(n,), out_sharding=s)),
 ]
 
@@ -290,6 +291,7 @@ _DTYPE_CASES = [
     ('triangular', float, lambda key, dtype: random.triangular(key, np.float16(0.), np.float16(0.5), np.float16(1.), shape=(10,), dtype=dtype)),
     ('truncated_normal', float, lambda key, dtype: random.truncated_normal(key, lower=np.float16(-2.), upper=np.float16(2.), shape=(10,), dtype=dtype)),
     ('uniform', float, lambda key, dtype: random.uniform(key, shape=(10,), minval=np.float16(0.), maxval=np.float16(1.), dtype=dtype)),
+    ('vonmises', float, lambda key, dtype: random.vonmises(key, np.float16(1.0), shape=(10,), dtype=dtype)),
     ('wald', float, lambda key, dtype: random.wald(key, np.float16(1.0), shape=(10,), dtype=dtype)),
     ('weibull_min', float, lambda key, dtype: random.weibull_min(key, np.float16(1.0), np.float16(1.0), shape=(10,), dtype=dtype)),
 ]
@@ -340,6 +342,7 @@ _SHAPE_CASES = [
     ('triangular', lambda key, shape: random.triangular(key, jnp.zeros(shape), jnp.full(shape, 0.5), jnp.ones(shape), shape=shape)),
     ('truncated_normal', lambda key, shape: random.truncated_normal(key, lower=jnp.full(shape, -2.), upper=jnp.full(shape, 2.), shape=shape)),
     ('uniform', lambda key, shape: random.uniform(key, shape=shape, minval=jnp.zeros(shape), maxval=jnp.ones(shape))),
+    ('vonmises', lambda key, shape: random.vonmises(key, jnp.ones(shape), shape=shape)),
     ('wald', lambda key, shape: random.wald(key, jnp.ones(shape), shape=shape)),
     ('weibull_min', lambda key, shape: random.weibull_min(key, jnp.ones(shape), jnp.ones(shape), shape=shape)),
 ]
@@ -1388,6 +1391,20 @@ class DistributionsTest(RandomTestBase):
 
     for samples in [uncompiled_samples, compiled_samples]:
       self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.rayleigh(scale=scale).cdf)
+
+  @jtu.sample_product(
+      kappa = [1e-6, 1e-4, 1e-2, 1e0, 1e2, 1e4, 1e6],
+      dtype = jtu.dtypes.floating)
+  def testVonMises(self, kappa, dtype):
+    key = lambda: self.make_key(0)
+    rand = lambda key: random.vonmises(key, kappa, shape=(10000,), dtype=dtype)
+    crand = jax.jit(rand)
+
+    uncompiled_samples = rand(key())
+    compiled_samples = crand(key())
+
+    for samples in [uncompiled_samples, compiled_samples]:
+      self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.vonmises(kappa).cdf)
 
   @jtu.sample_product(
       mean= [0.2, 1., 2., 10. ,100.],


### PR DESCRIPTION
Partially addresses question #26987 and issue #11737 by adding a 0-mean von Mises sampler. Transcribes [numpy's implementation](https://github.com/numpy/numpy/blob/b6e8ad83299fc6f87107492df0039dadfb5b9b98/numpy/random/src/distributions/distributions.c#L871), which uses Best and Fisher's algorithm. Different large/small thresholds are used for default 32-bit precision (CDF test still passes at 64-bit precision).


Example code:
```
import jax
import scipy
import matplotlib.pyplot as plt
import numpy as np

angles = np.linspace(-np.pi, np.pi, 100)
kappa = 1.0
loc = 0.
pdf = scipy.stats.vonmises.pdf(angles, loc=loc, kappa=kappa)
samples = jax.random.vonmises(jax.random.key(0), kappa, shape=(10000,))

plt.hist(samples, bins=100, density=True, alpha=0.5, label="PDF")
plt.plot(angles, pdf, label="Samples")
plt.title("Von Mises kappa=1")
plt.legend()
plt.xlabel("Angle")
plt.show()
```

<img width="563" height="449" alt="image" src="https://github.com/user-attachments/assets/f5749b88-5a9c-4c71-8a1e-b938c941c0e0" />


(Note: a von Mises Fisher sampler will likely follow soon.)