### PR TITLE
[test] add top-level check that tests do not modify environment variables

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1220,6 +1220,47 @@ def assert_global_configs_unchanged():
         f"{starting_cache}, now it is {ending_cache}"
     )
 
+@contextmanager
+def assert_env_variables_unchanged():
+  starting_env = dict(os.environ)
+  yield
+  ending_env = dict(os.environ)
+
+  if starting_env != ending_env:
+    differing = {k: (starting_env.get(k, NotPresent()), ending_env.get(k, NotPresent()))
+                  for k in (starting_env.keys() | ending_env.keys())
+                  if (k not in starting_env or k not in ending_env
+                      or starting_env[k] != ending_env[k])}
+    raise AssertionError(f"Test changed environment variables values. Differing values are: {differing}")
+
+
+@contextmanager
+def restore_env(*names: str):
+  """Context manager to restore particular environment variables.
+
+  This is useful to decorate tests which set environment variables.
+
+  Example:
+
+    >>> import os
+    >>> @restore_env("SOME_VARIABLE")
+    ... def test_which_changes_variable():
+    ...   os.environ["SOME_VARIABLE"] = "temporary value"
+    ...
+    >>> starting_value = os.environ.get("SOME_VARIABLE")
+    >>> test_which_changes_variable()
+    >>> assert os.environ.get("SOME_VARIABLE") == starting_value
+  """
+  starting_env = {name: os.environ.get(name, None) for name in names}
+  try:
+    yield
+  finally:
+    for name, val in starting_env.items():
+      if val is None:
+        os.environ.pop(name, None)
+      else:
+        os.environ[name] = val
+
 
 class JaxTestCase(parameterized.TestCase):
   """Base class for JAX tests including numerical checks and boilerplate."""
@@ -1236,6 +1277,7 @@ class JaxTestCase(parameterized.TestCase):
     super().setUp()
     self._configure_subprocess_env()
     self.enterContext(assert_global_configs_unchanged())
+    self.enterContext(assert_env_variables_unchanged())
 
     # We use the adler32 hash for two reasons.
     # a) it is deterministic run to run, unlike hash() which is randomized.

--- a/tests/pallas/pallas_shape_poly_test.py
+++ b/tests/pallas/pallas_shape_poly_test.py
@@ -103,6 +103,8 @@ class ShapePolyTest(jtu.JaxTestCase, parameterized.TestCase):
     # TODO(bchetioui): Remove this for H100+ once tests are all compatible with
     # Pallas/Mosaic GPU.
     self.enter_context(config.jax_pallas_use_mosaic_gpu(False))
+    # TODO(apaszke): avoid setting CUDA_ROOT on import in jax.experimental.mosaic
+    self.enter_context(jtu.restore_env('CUDA_ROOT'))
 
   def test_copy(self):
     # The blocks are static, but the input and the grid are of polymorphic

--- a/tests/xla_bridge_test.py
+++ b/tests/xla_bridge_test.py
@@ -120,6 +120,7 @@ class XlaBridgeTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(RuntimeError, "Unknown backend foo"):
       xb.local_devices(backend="foo")
 
+  @jtu.restore_env("PJRT_NAMES_AND_LIBRARY_PATHS")
   def test_register_plugin(self):
     with self.assertLogs(level="WARNING") as log_output:
       with mock.patch.object(xc, "load_pjrt_plugin_dynamically", autospec=True):
@@ -161,6 +162,7 @@ class XlaBridgeTest(jtu.JaxTestCase):
       options["ml_framework_version"] = version.__version__
     mock_make.assert_called_once_with("name1", options, None)
 
+  @jtu.restore_env("PJRT_NAMES_AND_LIBRARY_PATHS")
   def test_register_plugin_with_config(self):
     test_json_file_path = os.path.join(
         os.path.dirname(__file__), "testdata/example_pjrt_plugin_config.json"


### PR DESCRIPTION
In `pytest` test environments, persistently setting environment variables may lead to order-dependent test behavior.

Followup to #37053.