### PR TITLE
[ROCm] Use compiler-rt builtins for all clang-based ROCm builds

### DIFF
--- a/build/rocm/rocm.bazelrc
+++ b/build/rocm/rocm.bazelrc
@@ -18,7 +18,16 @@ common:rocm_clang_local --noincompatible_enable_cc_toolchain_resolution
 common:rocm_clang_local --@rules_ml_toolchain//common:enable_hermetic_cc=False
 common:rocm_clang_local --repo_env USE_HERMETIC_CC_TOOLCHAIN=0
 common:rocm_clang_local --crosstool_top=@local_config_rocm//crosstool:toolchain
-common:rocm_clang_local --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang" 
+common:rocm_clang_local --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"
+# Use compiler-rt builtins instead of libgcc_s.so.1 for compiler support routines.
+# The ROCm clang is built with -DCLANG_DEFAULT_RTLIB=compiler-rt; this aligns the
+# local clang with that default so that symbols such as __extendhfsf2 are resolved
+# statically from libclang_rt.builtins.a rather than as runtime dependencies on
+# libgcc_s.so.1. (-rtlib is Clang-only, so it lives here rather than in :rocm.)
+common:rocm_clang_local --copt=-rtlib=compiler-rt
+common:rocm_clang_local --host_copt=-rtlib=compiler-rt
+common:rocm_clang_local --linkopt=-rtlib=compiler-rt
+common:rocm_clang_local --host_linkopt=-rtlib=compiler-rt
 
 # ROCm with hermetic toolchain from rules_ml_toolchain
 common:rocm_clang_hermetic --config=rocm
@@ -27,6 +36,15 @@ common:rocm_clang_hermetic --@rules_ml_toolchain//common:enable_cuda=False
 common:rocm_clang_hermetic --@rules_ml_toolchain//common:enable_sycl=False
 common:rocm_clang_hermetic --@rules_ml_toolchain//common:enable_hermetic_cc=True
 common:rocm_clang_hermetic --strategy=CppLink=local
+# Use compiler-rt builtins instead of libgcc_s.so.1 for compiler support routines.
+# The ROCm clang is built with -DCLANG_DEFAULT_RTLIB=compiler-rt; this aligns the
+# hermetic clang with that default so that symbols such as __extendhfsf2 are resolved
+# statically from libclang_rt.builtins.a rather than as runtime dependencies on
+# libgcc_s.so.1. (-rtlib is Clang-only, so it lives here rather than in :rocm.)
+common:rocm_clang_hermetic --copt=-rtlib=compiler-rt
+common:rocm_clang_hermetic --host_copt=-rtlib=compiler-rt
+common:rocm_clang_hermetic --linkopt=-rtlib=compiler-rt
+common:rocm_clang_hermetic --host_linkopt=-rtlib=compiler-rt
 
 # ROCm with hermetic clang but local (system) sysroot
 # Use this when ROCm libraries are built against system libstdc++ to avoid ABI mismatches


### PR DESCRIPTION
## Problem

Local JAX hermetic builds inside the `manylinux_2_28` container fail with:

```
ImportError: libmlir_for_stubgen_common.so: undefined symbol: __extendhfsf2
```

`__extendhfsf2` is the soft-float ABI routine that converts a binary16 (half-precision) float to binary32. Clang generates calls to it when compiling `_Float16` code on x86-64 targets that do not assume F16C hardware. The hermetic clang (`@llvm18_linux_x86_64`) and the locally built clang default to resolving this symbol from `libgcc_s.so.1` at runtime. On the `manylinux_2_28` builder (AlmaLinux 8), `libgcc_s.so.1` is from GCC 8 and does not export this symbol.

CI avoids the failure because `--remote_download_toplevel` allows Bazel to serve the stub generator action output from the remote cache (built on Ubuntu where `libgcc_s.so.1` is from GCC 12+ and has the symbol). Local builds must run the action inside the container and hit the missing symbol.

## Root Cause

The ROCm clang is built with `-DCLANG_DEFAULT_RTLIB=compiler-rt`, so it resolves compiler support routines from its own `libclang_rt.builtins.a` by default. The hermetic clang and locally built clang use the upstream default (`libgcc`), creating a mismatch: they emit `__extendhfsf2` as an undefined dynamic symbol that must be satisfied by `libgcc_s.so.1` at runtime.

## Fix

Add `-rtlib=compiler-rt` to the base `rocm` config so all clang-based ROCm builds match the ROCm clang's existing default. The symbol is resolved statically at link time from the clang's bundled `libclang_rt.builtins.a` with no new shared library dependencies, preserving manylinux wheel compliance.

## Testing

- Built `//jaxlib/tools:jaxlib_wheel` locally inside the `manylinux_2_28` container — succeeds where it previously failed.
- Confirmed `libmlir_for_stubgen_common.so` has no undefined `__extendhfsf2` after the fix.
- Confirmed NEEDED list is unchanged and all dependencies remain on the manylinux_2_28 whitelist.](url)