### PR TITLE
Fix jnp.vectorize crash when None is at index 0

### DIFF
--- a/jax/_src/numpy/vectorize.py
+++ b/jax/_src/numpy/vectorize.py
@@ -283,7 +283,7 @@ def vectorize(pyfunc, *, excluded=frozenset(), signature=None):
       output_core_dims = None
 
     none_args = {i for i, arg in enumerate(args) if arg is None}
-    if any(none_args):
+    if none_args:
       if any(input_core_dims[i] != () for i in none_args):
         raise ValueError(f"Cannot pass None at locations {none_args} with {signature=}")
       excluded_func, args, _ = _apply_excluded(excluded_func, none_args, args, {})

--- a/tests/lax_numpy_vectorize_test.py
+++ b/tests/lax_numpy_vectorize_test.py
@@ -249,6 +249,12 @@ class VectorizeTest(jtu.JaxTestCase):
     y = jnp.arange(10, 20)
     self.assertAllClose(f(x, y), x + y)
 
+  def test_none_arg_at_index_zero(self):
+    # Regression test for https://github.com/jax-ml/jax/pull/38117
+    f = jnp.vectorize(lambda y, x: x if y is None else x + y)
+    x = jnp.arange(10)
+    self.assertAllClose(f(None, x), x)
+
   def test_none_arg_bad_signature(self):
     f = jnp.vectorize(lambda x, y: x if y is None else x + y,
                       signature='(k),(k)->(k)')


### PR DESCRIPTION
## Summary

`jnp.vectorize` crashes with `ValueError: None is not a valid value for jnp.array` when a positional `None` argument is at index 0, but works for any other position.

## Root cause

`jax/_src/numpy/vectorize.py` collects the positions of `None` arguments into a set and guards the None-handling branch with `if any(none_args):`. When the only `None` is at index 0, `none_args == {0}` and `any({0})` is `False` (the set has one element and that element is `0`). The branch that strips `None` args out is skipped, the next line runs `jnp.asarray(None)`, and that raises.

```python
>>> import jax.numpy as jnp
>>> f = jnp.vectorize(lambda y, x: x if y is None else x + y)
>>> f(None, jnp.arange(10))
ValueError: None is not a valid value for jnp.array
```

With the same `None` at any other index, `vectorize` works as designed (e.g. `f(jnp.arange(10), None)`).

`None` support was added in #18441; the regression test (`test_none_arg`) only exercised `None` at index 1, which is why this slipped through.

## Fix

Replace `if any(none_args):` with `if none_args:`. The set's emptiness is what we actually want to test — same intent, different reduction. One-character change.

## Test

Extended `test_none_arg` in `tests/lax_numpy_vectorize_test.py` to also exercise `None` at index 0. Verified the fix locally by patching the installed jax and re-running:

- `g(None, x)` returns `x` (previously crashed)
- `f(x, None)`, `f(x, y)` continue to work
- `test_none_arg_bad_signature` continues to raise the expected `ValueError` for invalid signatures, including with `None` at index 0

## Duplicate check

Searched open and closed PRs and issues for `vectorize none`, `any(none_args)`, and `vectorize None at index`. No prior PR or open issue covers this case; the only related PR (#18441) is the merged one that introduced the bug.

## Disclosure

AI-assisted: a code-search agent flagged the suspicious `any(set)` pattern; the fix and tests were reviewed line-by-line before submission. I will sign the CLA after opening this PR if not already covered.