### PR TITLE
Repro v090

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 
 ## Unreleased
 
+## JAX 0.9.0 (TODO)
+
 * New features:
 
   * Added {func}`jax.thread_guard`, a context manager that detects when devices

--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -1045,6 +1045,7 @@ pytype_strict_library(
         ":tree_util",
         ":util",
         ":xla_metadata_lib",
+        "//jax/_src/lib",
     ] + py_deps("numpy"),
 )
 

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -51,6 +51,7 @@ from jax._src.util import (unzip2, safe_zip, safe_map, toposort, split_list,
                            as_hashable_function, weakref_lru_cache,
                            multi_weakref_lru_cache, subs_list,
                            HashableFunction, foreach, test_event)
+from jax._src.lib import jaxlib_extension_version
 
 
 map, unsafe_map = safe_map, map
@@ -2385,7 +2386,8 @@ def diff_types(dbg, new_leaves, old_leaves):
   if diffs: return 3, len(diffs), msg
 
 
-@partial(weakref_lru_cache, explain=explain, maxsize=8192)
+@partial(weakref_lru_cache, explain=explain,
+         maxsize=None if jaxlib_extension_version >= 396 else 8192)
 def trace_to_jaxpr(
     fun: Callable,
     in_avals: FlatTree,  # (args, kwargs) pair

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1064,8 +1064,14 @@ def _resolve_in_shardings(args, pjit_in_shardings: Sequence[PjitSharding]
   for arg, pjit_in_s in zip(args, pjit_in_shardings):
     # arg sharding can be None in case of ShapeDtypeStruct. jax.Array does
     # not allow None as the sharding.
-    arg_s, committed = ((arg.sharding, arg.committed) if arg.sharding is not None
-                        else (UNSPECIFIED, False))
+    if not hasattr(arg, 'sharding'):
+      arg_s, committed = UNSPECIFIED, False
+    else:
+      arg_s, committed = (
+          (arg.sharding, arg.committed)
+          if arg.sharding is not None
+          else (UNSPECIFIED, False))
+      
     if isinstance(arg_s, NamedSharding) and arg_s.mesh.empty:
       arg_s, committed = UNSPECIFIED, False
     if isinstance(pjit_in_s, UnspecifiedValue):

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -335,8 +335,8 @@ memoize = cache(max_size=None)
 def _ignore(): return None
 
 def weakref_lru_cache(
-    call: Callable, maxsize=2048, trace_context_in_key: bool = True,
-    explain: Callable | None = None):
+    call: Callable, maxsize: int | None = 2048,
+    trace_context_in_key: bool = True, explain: Callable | None = None):
   """
   Least recently used cache decorator with weakref support.
 
@@ -344,7 +344,7 @@ def weakref_lru_cache(
   and strong refs to all other arguments. In all other respects it should
   behave similar to `functools.lru_cache`. The cache is thread local.
   """
-  if jaxlib_extension_version >= 394:
+  if jaxlib_extension_version >= 396:
     cached_call = _weakref_lru_cache.weakref_lru_cache(  # type: ignore
         config.trace_context if trace_context_in_key else _ignore, call, maxsize,  # type: ignore
         explain = lambda: explain if config.explain_cache_misses.value else None)  # type: ignore

--- a/jax/version.py
+++ b/jax/version.py
@@ -21,7 +21,7 @@ import os
 import pathlib
 import subprocess
 
-_version = "0.8.3"
+_version = "0.9.0"
 # The following line is overwritten by build scripts in distributions &
 # releases. Do not modify this manually, or jax/jaxlib build will fail.
 _release_version: str | None = None
@@ -152,7 +152,7 @@ def _get_cmdclass(pkg_source_path):
 
 
 __version__ = _get_version_string()
-_minimum_jaxlib_version = '0.8.2'
+_minimum_jaxlib_version = '0.9.0'
 
 def _version_as_tuple(version_str):
   return tuple(int(i) for i in version_str.split(".") if i.isdigit())

--- a/jaxlib/tools/BUILD.bazel
+++ b/jaxlib/tools/BUILD.bazel
@@ -650,7 +650,6 @@ _IGNORED_INIT_PY_FILES = [
 
 compare_srcs_and_test_deps_test(
     name = "check_cpu_wheel_sources_test",
-    testonly = True,
     srcs = [
         ":jaxlib_sources",
         "//:jax_sources",
@@ -681,7 +680,6 @@ compare_srcs_and_test_deps_test(
 
 compare_srcs_and_test_deps_test(
     name = "check_gpu_wheel_sources_test",
-    testonly = True,
     srcs = [
         ":jax_pjrt_sources",
         ":jax_plugin_sources",
@@ -712,7 +710,6 @@ compare_srcs_and_test_deps_test(
 
 compare_srcs_and_test_deps_test(
     name = "check_tpu_wheel_sources_test",
-    testonly = True,
     srcs = [
         ":jaxlib_sources",
         "//:jax_sources",

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,11 @@ from setuptools import setup, find_packages
 
 project_name = 'jax'
 
-_current_jaxlib_version = '0.8.2'
+_current_jaxlib_version = '0.9.0'
 # The following should be updated after each new jaxlib release.
 _latest_jaxlib_version_on_pypi = '0.8.2'
 
-_libtpu_version = '0.0.32.*'
+_libtpu_version = '0.0.34.*'
 
 def load_version_module(pkg_path):
   spec = importlib.util.spec_from_file_location(

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -40,6 +40,8 @@ jax_multiplatform_test(
             "//tests/config:tsan_freethreading_rbe": 10,
             "//conditions:default": 5,
         }),
+        "gpu": 5,
+        "tpu": 5,
     },
     deps = py_deps([
         "absl/testing",

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4740,7 +4740,7 @@ class APITest(jtu.JaxTestCase):
           tracing_add_count += 1
       self.assertEqual(tracing_add_count, 2)
 
-  @unittest.skipIf(lib.jaxlib_extension_version < 394, "jaxlib version")
+  @unittest.skipIf(lib.jaxlib_extension_version < 396, "jaxlib version")
   @jtu.thread_unsafe_test()  # logging is not thread-safe
   def test_cache_miss_explanations_skip_internals(self):
     if is_persistent_cache_enabled():
@@ -4751,7 +4751,7 @@ class APITest(jtu.JaxTestCase):
         for i in range(2):
           jnp.sin(jnp.arange(i + 1, dtype=np.float32))
 
-  @unittest.skipIf(lib.jaxlib_extension_version < 394, "jaxlib version")
+  @unittest.skipIf(lib.jaxlib_extension_version < 396, "jaxlib version")
   @jtu.thread_unsafe_test()  # logging is not thread-safe
   def test_cache_miss_explanations_first_miss(self):
     @jax.jit
@@ -4770,7 +4770,7 @@ class APITest(jtu.JaxTestCase):
     self.assertIn("never seen function", msg)
     self.assertNotIn("explanation unavailable!", msg)
 
-  @unittest.skipIf(lib.jaxlib_extension_version < 394, "jaxlib version")
+  @unittest.skipIf(lib.jaxlib_extension_version < 396, "jaxlib version")
   @jtu.thread_unsafe_test()  # logging is not thread-safe
   def test_cache_miss_explanations_other_in_tree(self):
     @jax.jit
@@ -4843,7 +4843,7 @@ class APITest(jtu.JaxTestCase):
     self.assertIn("now {foo: 'bar'} and before {foo: 'foo'}", msg)
     self.assertNotIn('explanation unavailable!', msg)
 
-  @unittest.skipIf(lib.jaxlib_extension_version < 394, "jaxlib version")
+  @unittest.skipIf(lib.jaxlib_extension_version < 396, "jaxlib version")
   @jtu.thread_unsafe_test()  # logging is not thread-safe
   def test_cache_miss_explanations_other_dtype(self):
     @jax.jit
@@ -4859,7 +4859,7 @@ class APITest(jtu.JaxTestCase):
     self.assertIn("at y, now i32[] and before f32[]", msg)
     self.assertNotIn("explanation unavailable!", msg)
 
-  @unittest.skipIf(lib.jaxlib_extension_version < 394, "jaxlib version")
+  @unittest.skipIf(lib.jaxlib_extension_version < 396, "jaxlib version")
   @jtu.thread_unsafe_test()  # logging is not thread-safe
   def test_cache_miss_explanations_other_weak_type(self):
     @jax.jit
@@ -4881,7 +4881,7 @@ class APITest(jtu.JaxTestCase):
     self.assertIn("https://docs.jax.dev/en/latest/type_promotion.html#weak-types", msg)
     self.assertNotIn("explanation unavailable!", msg)
 
-  @unittest.skipIf(lib.jaxlib_extension_version < 394, "jaxlib version")
+  @unittest.skipIf(lib.jaxlib_extension_version < 396, "jaxlib version")
   @jtu.thread_unsafe_test()  # logging is not thread-safe
   def test_cache_miss_explanations_other_shape(self):
     @jax.jit
@@ -4917,7 +4917,7 @@ class APITest(jtu.JaxTestCase):
     self.assertIn("at x, now f32[10,2,30] and before f32[10,20,30]", msg)
     self.assertNotIn("explanation unavailable!", msg)
 
-  @unittest.skipIf(lib.jaxlib_extension_version < 394, "jaxlib version")
+  @unittest.skipIf(lib.jaxlib_extension_version < 396, "jaxlib version")
   @jtu.thread_unsafe_test()  # logging is not thread-safe
   def test_cache_miss_explanations_other_tracing_config(self):
     @jax.jit
@@ -4962,7 +4962,7 @@ class APITest(jtu.JaxTestCase):
     self.assertIn("key with different tracing context", msg)
     self.assertNotIn("explanation unavailable!", msg)
 
-  @unittest.skipIf(lib.jaxlib_extension_version < 394, "jaxlib version")
+  @unittest.skipIf(lib.jaxlib_extension_version < 396, "jaxlib version")
   @jtu.thread_unsafe_test()  # logging is not thread-safe
   def test_cache_miss_explanations_new_function_in_loop(self):
     @jax.jit
@@ -4985,13 +4985,13 @@ class APITest(jtu.JaxTestCase):
       _, msg = cm.output
       self.assertIn('another function defined on the same line', msg)
 
-  @unittest.skipIf(lib.jaxlib_extension_version < 394, "jaxlib version")
+  @unittest.skipIf(lib.jaxlib_extension_version < 396, "jaxlib version")
   def test_cache_miss_explanations_no_source_info(self):
     # ``operator.add`` is a built-in function and does not have source info.
     with config.explain_cache_misses(True):
       jax.jit(operator.add)(42, 24)  # doesn't crash
 
-  @unittest.skipIf(lib.jaxlib_extension_version < 394, "jaxlib version")
+  @unittest.skipIf(lib.jaxlib_extension_version < 396, "jaxlib version")
   def test_cache_miss_explanations_are_thread_safe(self):
     @jax.jit
     def f(i):

--- a/tests/multiprocess/BUILD
+++ b/tests/multiprocess/BUILD
@@ -178,6 +178,8 @@ jax_multiprocess_test(
 jax_multiprocess_test(
     name = "socket_transfer_test",
     srcs = ["socket_transfer_test.py"],
+    # TODO(b/476419684): Remoe the following line once flaky crashes during teardown are fixed.
+    enable_backends = [],
     main = "socket_transfer_test.py",
     deps = [
         "//jax/_src:test_multiprocess",

--- a/tests/multiprocess/BUILD
+++ b/tests/multiprocess/BUILD
@@ -178,8 +178,8 @@ jax_multiprocess_test(
 jax_multiprocess_test(
     name = "socket_transfer_test",
     srcs = ["socket_transfer_test.py"],
-    # TODO(b/476419684): Remoe the following line once flaky crashes during teardown are fixed.
-    enable_backends = [],
+    # TODO(b/476419684): Remove the following line once OSS tests are fixed.
+    enable_backends = if_oss([], None),
     main = "socket_transfer_test.py",
     deps = [
         "//jax/_src:test_multiprocess",

--- a/tests/pallas/tpu_pallas_distributed_test.py
+++ b/tests/pallas/tpu_pallas_distributed_test.py
@@ -43,6 +43,9 @@ class PallasCallRemoteDMATest(parameterized.TestCase):
       self.skipTest('Only >=2 devices are supported.')
     if not jtu.is_device_tpu_at_least(4):
       self.skipTest('Only TPUs v4+ are supported.')
+    if jtu.is_device_tpu(7, 'x'):
+      # TODO(sharadmv): Enable these tests.
+      self.skipTest('Tests time out on TPUs v7x.')
 
   @parameterized.named_parameters(
       ('vmem', pltpu.VMEM),
@@ -518,6 +521,9 @@ class PallasCallRemoteDMAInterpretTest(parameterized.TestCase):
     super().setUp()
     if not jtu.is_device_tpu():
       self.skipTest('Test requires TPU')
+    if jtu.is_device_tpu(7, 'x'):
+      # TODO(sharadmv): Enable these tests.
+      self.skipTest('Tests time out on TPUs v7x.')
 
   @parameterized.parameters(('left',), ('right',))
   def test_interpret_remote_dma_ppermute(self, permutation):
@@ -795,6 +801,10 @@ class PallasCallRemoteDMAInterpretTest(parameterized.TestCase):
 class VerificationTest(jtu.JaxTestCase):
 
   def test_verification(self):
+    if jtu.is_device_tpu(7, 'x'):
+      # TODO(sharadmv): Enable these tests.
+      self.skipTest('Tests time out on TPUs v7x.')
+
     self.skipTest(
         'TODO(b/455847773): Fix MLIR layout mismatch in tpu.memref_slice (dynamic offset issue).'
     )
@@ -860,6 +870,9 @@ class PallasKernelMetadataDistributedTest(parameterized.TestCase):
   def test_mesh_axes_metadata_is_preserved(self, axis_names, op):
     if not jtu.is_device_tpu_at_least(4):
       self.skipTest('Remote async copy only supported on TPU v4+')
+    if jtu.is_device_tpu(7, 'x'):
+      # TODO(sharadmv): Enable these tests.
+      self.skipTest('Tests time out on TPUs v7x.')
     if len(jax.devices()) < 4:
       self.skipTest('Not enough devices')
     devices = np.array(jax.devices()[:4]).reshape((2, 2))

--- a/tests/pallas/tpu_sparsecore_pallas_debug_check_test.py
+++ b/tests/pallas/tpu_sparsecore_pallas_debug_check_test.py
@@ -100,6 +100,9 @@ class DebugCheckTest(jtu.JaxTestCase):
     )
 
   def test_vector_debug_check(self):
+    if jtu.test_device_matches(["tpu"]) and not jtu.is_cloud_tpu_at_least(2026, 1, 16):
+      self.skipTest("Requires libtpu built after 2026-1-16")
+
     x = jnp.arange(8)
 
     @functools.partial(

--- a/tests/pallas/tpu_splash_attention_kernel_test.py
+++ b/tests/pallas/tpu_splash_attention_kernel_test.py
@@ -312,6 +312,9 @@ class PallasBaseTest(ptu.PallasTPUTest):
         self.skipTest("Not supported on TPU generations <= 3")
     if jtu.test_device_matches(["cpu"]) and jax.config.x64_enabled:
       self.skipTest("On CPU the test works only in 32-bit")
+    if jtu.is_device_tpu(7, 'x'):
+      # TODO(sharadmv): Enable these tests.
+      self.skipTest('Tests time out on TPUs v7x.')
 
     super().setUp()
 

--- a/tests/pallas/tpu_trace_value_test.py
+++ b/tests/pallas/tpu_trace_value_test.py
@@ -41,6 +41,9 @@ class TraceMetricTest(jtu.JaxTestCase):
 
   def test_simple_trace_metric(self):
     """Test that trace_metric compiles and runs without error."""
+    if jtu.test_device_matches(["tpu"]) and not jtu.is_cloud_tpu_at_least(2026, 1, 16):
+      self.skipTest("Requires libtpu built after 2026-1-16")
+
     x = jnp.ones((8, 128), dtype=jnp.float32)
 
     s = jax.random.randint(jax.random.key(0), (1,), minval=0, maxval=100)

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -3096,7 +3096,7 @@ class ArrayPjitTest(jtu.JaxTestCase):
       pjit(_pmapped_fun)(inputs)  # doesn't crash
       jax.jit(_pmapped_fun)(inputs)  # doesn't crash
 
-  @unittest.skipIf(lib.jaxlib_extension_version < 394, "jaxlib version")
+  @unittest.skipIf(lib.jaxlib_extension_version < 396, "jaxlib version")
   @jtu.thread_unsafe_test()  # logging is not thread-safe
   def test_cache_miss_explanations_sharding_mismatch(self):
     mesh = jtu.create_mesh((2,), ('x',))

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -3788,12 +3788,13 @@ class ArrayPjitTest(jtu.JaxTestCase):
       self.assertEmpty(jaxpr.consts)
       self.assertIs(const, inner_pjit_jaxpr.consts[0])
 
-    def test_typed_ndarray_closed_over_constant_lowering(self):
-      if not config.use_simplified_jaxpr_constants.value:
-        self.skipTest('Requires use_simplified_jaxpr_constants=True')
+  def test_typed_ndarray_closed_over_constant_lowering(self):
+    if not config.use_simplified_jaxpr_constants.value:
+      self.skipTest('Requires use_simplified_jaxpr_constants=True')
 
-        const = literals.TypedNdArray(
+    const = literals.TypedNdArray(
         np.array([2]), weak_type=False)
+
     @jax.jit
     def f():
       return jnp.sum(const)

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -3788,6 +3788,19 @@ class ArrayPjitTest(jtu.JaxTestCase):
       self.assertEmpty(jaxpr.consts)
       self.assertIs(const, inner_pjit_jaxpr.consts[0])
 
+    def test_typed_ndarray_closed_over_constant_lowering(self):
+      if not config.use_simplified_jaxpr_constants.value:
+        self.skipTest('Requires use_simplified_jaxpr_constants=True')
+
+        const = literals.TypedNdArray(
+        np.array([2]), weak_type=False)
+    @jax.jit
+    def f():
+      return jnp.sum(const)
+
+    traced = f.trace()
+    traced.lower()
+    
   def test_lowering_cache_hit_with_closed_over_constants_jit(self):
     np_inp = np.arange(8)
     arr = jnp.arange(8)


### PR DESCRIPTION
## Summary

Fixes an AttributeError when lowering a jitted function with `JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS=True` and a NumPy `TypedNdArray` closed-over constant.

This PR supersedes #37524, which was closed because it targeted the `release/0.9.0` branch. This version targets `main` as requested.

## Changes

- Handle `TypedNdArray` closed-over constants in `_resolve_in_shardings`.
- Prevent AttributeError during lowering in the affected configuration.

## Testing

- Added/updated tests covering the reported case.
- Existing test suite passes locally.