### PR TITLE
[hijax] Fix nested vmap for hi types

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1284,9 +1284,10 @@ def _mapped_axis_size(fn, tree, vals, dims, name, axis_size=None):
         f"*args={args} and **kwargs={kwargs}"
     )
 
-  def _get_axis_size(name: str, x, shape: tuple[core.AxisSize, ...], axis: int
-                     ) -> core.AxisSize | None:
+  def _get_axis_size(name: str, x, axis: int) -> core.AxisSize | None:
+    shape: tuple[core.AxisSize, ...] = ()
     try:
+      shape = np.shape(x)
       return shape[axis]
     except (IndexError, TypeError) as e:
       if not core.valid_jaxtype(x) or not isinstance(axis, int):
@@ -1299,7 +1300,7 @@ def _mapped_axis_size(fn, tree, vals, dims, name, axis_size=None):
           f"but is only {len(shape)} (its shape is {shape})") from e
 
   all_mapped_sizes = [
-    None if d is None else _get_axis_size(name, x, np.shape(x), d)
+    None if d is None else _get_axis_size(name, x, d)
     for x, d in zip(vals, dims)
   ]
   all_sizes = [s for s in all_mapped_sizes if s is not None]

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -750,12 +750,23 @@ class HijaxTest(jtu.JaxTestCase):
 
   def test_tuple_vmap(self):
     tup = make_tup(jnp.arange(3.), jnp.arange(3.))
-    jax.vmap(lambda x: x, in_axes=TupSpec((0, 0)), out_axes=TupSpec((0, 0)), axis_size=3)(tup)
+    out = jax.vmap(lambda x: x, in_axes=TupSpec((0, 0)),
+                   out_axes=TupSpec((0, 0)), axis_size=3)(tup)
+    self.assertAllClose(out.elts, tup.elts)
 
   def test_tuple_vmap_infer(self):
     tup = make_tup(jnp.arange(3.), jnp.arange(3.))
     jax.vmap(lambda _: make_tup(jnp.ones(3), jnp.ones(3)),
              in_axes=TupSpec((0, 0)), out_axes=batching.infer, axis_size=3)(tup)
+
+  def test_tuple_nested_vmap(self):
+    tup = make_tup(jnp.arange(12.).reshape((3, 4)), jnp.arange(12.).reshape((3, 4)))
+    map1 = jax.vmap(lambda x: x, in_axes=TupSpec((0, 0)), out_axes=TupSpec((0, 0)),
+                    axis_size=3)
+    map2 = jax.vmap(map1, in_axes=TupSpec((1, 1)), out_axes=TupSpec((1, 1)),
+                    axis_size=4)
+    out = map2(tup)
+    self.assertAllClose(out.elts, tup.elts)
 
   # def test_tuple_vmap_match(self):
   #   tup = make_tup(jnp.arange(3.), jnp.arange(3.))


### PR DESCRIPTION
The _get_axis_size function previously needed `np.shape(x)` as an argument. This happens to work when `x` is a hi value, and returns `()`. But when `x` is a VmapTracer there is an error due to attempted conversion of a tracer to an array.

This fix is more of a workaround, the real fix would validate the axis_size w.r.t. the mapping spec, which would probably require another method on HiType.
