### PR TITLE
[OneAPI GPU] Add OneAPI (SYCL) GPU Runtime Functions.

### DIFF
--- a/jaxlib/gpu/vendor.h
+++ b/jaxlib/gpu/vendor.h
@@ -905,9 +905,7 @@ struct GpuErrorTraits<miopenStatus_t> {
 
 #elif defined(JAX_GPU_ONEAPI)
 
-// TODO(Intel-tf):
-// placeholder for OneAPI/SYCL glue code compilation.
-// Full GPU kernel support requires additional type mappings.
+#include "jaxlib/oneapi/oneapi_gpu_runtime.h"
 
 #define JAX_GPU_NAMESPACE oneapi
 #define JAX_GPU_PREFIX "oneapi"
@@ -917,10 +915,27 @@ struct GpuErrorTraits<miopenStatus_t> {
 #define JAX_GPU_HAVE_FP8 0
 #define JAX_GPU_HAVE_SOLVER_GEEV 0
 
+typedef ::sycl::queue *gpuStream_t;
+
+#define GPU_EVENT_DEFAULT 0
+
+// The Sycl* wrappers return absl::Status; JAX_AS_STATUS resolves to the
+// AsStatus(const absl::Status&) passthrough in gpu_kernel_helpers.h.
+#define gpuMemcpyDeviceToHost ::jax::oneapi::SyclMemcpyDeviceToHost
+#define gpuMemcpyHostToDevice ::jax::oneapi::SyclMemcpyHostToDevice
+#define gpuMemcpyDeviceToDevice ::jax::oneapi::SyclMemcpyDeviceToDevice
+#define gpuMemcpyAsync ::jax::oneapi::SyclMemcpyAsync
+#define gpuGetLastError ::jax::oneapi::SyclGetLastError
+#define gpuStreamSynchronize ::jax::oneapi::SyclStreamSynchronize
+
 namespace jax::oneapi {
-// Probably the SYCL equivalent is "sub-group size".
-// Placeholder to satisfy the vendor.h interface.
 inline constexpr uint32_t kNumThreadsPerWarp = 32;
+
+// Declared here so the AsStatus<T> template in gpu_kernel_helpers.h
+// can compile. Specializations are not needed for oneAPI.
+template <typename T>
+struct GpuErrorTraits;
+
 }  // namespace jax::oneapi
 
 #else  // defined(GPU vendor)

--- a/jaxlib/oneapi/BUILD.bazel
+++ b/jaxlib/oneapi/BUILD.bazel
@@ -27,13 +27,55 @@ package(
 )
 
 cc_library(
+    name = "oneapi_gpu_runtime_hdrs",
+    hdrs = ["oneapi_gpu_runtime.h"],
+    deps = [
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@local_config_sycl//sycl:sycl_headers",
+    ],
+)
+
+cc_library(
+    name = "oneapi_gpu_runtime",
+    srcs = ["oneapi_gpu_runtime.cc"],
+    hdrs = ["oneapi_gpu_runtime.h"],
+    copts = ["-fsycl"],
+    features = ["-use_header_modules"],
+    linkopts = ["-fsycl"],
+    deps = [
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@local_config_sycl//sycl:sycl_headers",
+    ],
+)
+
+cc_library(
     name = "oneapi_vendor",
-    hdrs = [
+    defines = ["JAX_GPU_ONEAPI=1"],
+    textual_hdrs = [
         "//jaxlib/gpu:vendor.h",
     ],
-    defines = ["JAX_GPU_ONEAPI=1"],
     deps = [
-        "@local_config_sycl//sycl:sycl_headers",
+        ":oneapi_gpu_runtime_hdrs",
+    ],
+)
+
+cc_library(
+    name = "oneapi_gpu_kernel_helpers",
+    hdrs = ["//jaxlib/gpu:gpu_kernel_helpers.h"],
+    features = ["-use_header_modules"],
+    deps = [
+        ":oneapi_vendor",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 

--- a/jaxlib/oneapi/oneapi_gpu_runtime.cc
+++ b/jaxlib/oneapi/oneapi_gpu_runtime.cc
@@ -1,0 +1,57 @@
+/* Copyright 2026 The JAX Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// OneAPI/SYCL GPU runtime wrappers for JAX.
+// Reference: xla/stream_executor/sycl/sycl_gpu_runtime.cc
+
+#include "jaxlib/oneapi/oneapi_gpu_runtime.h"
+
+namespace jax {
+namespace oneapi {
+
+absl::Status SyclMemcpyAsync(void *dst, const void *src, size_t byte_count,
+                             SyclMemcpyKind /*kind*/, ::sycl::queue *stream) {
+  if (byte_count == 0) {
+    return absl::OkStatus();
+  }
+  if (dst == nullptr) {
+    return absl::InvalidArgumentError(
+        "SyclMemcpyAsync: null destination pointer (dst); cannot copy into it");
+  }
+  if (src == nullptr) {
+    return absl::InvalidArgumentError(
+        "SyclMemcpyAsync: null source pointer (src); cannot copy from it");
+  }
+  if (stream == nullptr) {
+    return absl::InvalidArgumentError(
+        "SyclMemcpyAsync: null SYCL queue (sycl::queue* stream); cannot submit "
+        "the memcpy");
+  }
+  return TryCatchToStatus([&] { stream->memcpy(dst, src, byte_count); });
+}
+
+absl::Status SyclGetLastError() { return absl::OkStatus(); }
+
+absl::Status SyclStreamSynchronize(::sycl::queue *stream) {
+  if (stream == nullptr) {
+    return absl::InvalidArgumentError(
+        "SyclStreamSynchronize: null SYCL queue (sycl::queue* stream); cannot "
+        "wait for completion");
+  }
+  return TryCatchToStatus([&] { stream->wait(); });
+}
+
+}  // namespace oneapi
+}  // namespace jax

--- a/jaxlib/oneapi/oneapi_gpu_runtime.h
+++ b/jaxlib/oneapi/oneapi_gpu_runtime.h
@@ -1,0 +1,127 @@
+/* Copyright 2026 The JAX Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// OneAPI/SYCL GPU runtime wrappers for JAX.
+//
+// SYCL wrappers (SyclMemcpyAsync, SyclGetLastError, SyclStreamSynchronize)
+// that use SYCL queue APIs and exception handling to return absl::Status.
+// On a SYCL exception the descriptive message is embedded in an
+// absl::InternalError. vendor.h aliases these to the gpuXxx
+// (e.g. gpuMemcpyAsync) abstractions.
+//
+// Reference: xla/stream_executor/sycl/sycl_gpu_runtime.cc
+
+#ifndef JAXLIB_ONEAPI_ONEAPI_GPU_RUNTIME_H_
+#define JAXLIB_ONEAPI_ONEAPI_GPU_RUNTIME_H_
+
+#include <sycl/sycl.hpp>
+
+#include <cstdint>
+#include <exception>
+#include <type_traits>
+#include <utility>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+
+namespace jax {
+namespace oneapi {
+
+template <typename Callable>
+using InvokeResult = std::invoke_result_t<Callable>;
+
+template <typename Callable>
+using StatusOrResult =
+    std::conditional_t<std::is_void_v<InvokeResult<Callable>>, absl::Status,
+                       absl::StatusOr<InvokeResult<Callable>>>;
+
+// `TryCatchToStatus` converts any thrown exception into an absl error status.
+// a void callable returns OkStatus on success, a value callable
+// returns its result wrapped in StatusOr.
+//
+// Usage patterns:
+//
+//   1. Void SYCL op inside a function returning absl::Status.
+//        return JAX_AS_STATUS(TryCatchToStatus([&] {
+//          stream->memcpy(dst, src, n);
+//        }));
+//
+//        JAX_RETURN_IF_ERROR(JAX_AS_STATUS(TryCatchToStatus([&] {
+//            stream->memcpy(dst, src, byte_count);
+//        })));
+//
+//   2. Capturing a value (e.g. a sycl::event).
+//        JAX_ASSIGN_OR_RETURN(sycl::event ev, TryCatchToStatus([&] {
+//          return stream->submit(
+//              [&](sycl::handler& h) { h.parallel_for(...); });
+//        }));
+//
+//   3. When the status cannot be returned: consume it locally.
+//        absl::Status s = TryCatchToStatus(
+//            [&] { q->submit([&](handler& h) {...}); });
+//        if (!s.ok()) LOG(ERROR) << s.message();
+//
+template <typename Callable>
+StatusOrResult<Callable> TryCatchToStatus(Callable&& func) {
+  try {
+    if constexpr (std::is_void_v<InvokeResult<Callable>>) {
+      std::forward<Callable>(func)();
+      return absl::OkStatus();
+    } else {
+      return std::forward<Callable>(func)();
+    }
+  } catch (const ::sycl::exception& e) {
+    return absl::InternalError(
+        absl::StrCat("SYCL exception: ", e.what(),
+                     " [sycl_code=", e.code().value(), "]"));
+  } catch (const std::exception& e) {
+    return absl::InternalError(absl::StrCat("std::exception: ", e.what()));
+  } catch (...) {
+    return absl::InternalError("Unknown (non-std::exception) thrown");
+  }
+}
+
+// q->memcpy We do not need to specify in which direction the copy is meant to
+// happen but we keep the enum for API compatibility with call sites that pass
+// gpuMemcpyDeviceToDevice etc. at call sites.
+enum SyclMemcpyKind {
+  SyclMemcpyHostToHost = 0,
+  SyclMemcpyHostToDevice = 1,
+  SyclMemcpyDeviceToHost = 2,
+  SyclMemcpyDeviceToDevice = 3,
+};
+
+// Wraps sycl::queue::memcpy in a try-catch and returns absl::Status.
+// The `kind` parameter is accepted for API compatibility but is not used
+// by SYCL (memcpy direction is implicit in the source and destination
+// pointers).
+absl::Status SyclMemcpyAsync(void *dst, const void *src, size_t byte_count,
+                             SyclMemcpyKind kind, ::sycl::queue *stream);
+
+// TODO(Intel-tf): Asynchronous error handling.
+// Placeholder for gpuGetLastError. SYCL has no equivalent; currently returns
+// OkStatus so that call sites can compile without #ifdef guards.
+absl::Status SyclGetLastError();
+
+// Stream synchronization wrapper.
+// Wraps sycl::queue::wait() in a try-catch and returns absl::Status.
+absl::Status SyclStreamSynchronize(::sycl::queue *stream);
+
+}  // namespace oneapi
+}  // namespace jax
+
+#endif  // JAXLIB_ONEAPI_ONEAPI_GPU_RUNTIME_H_

--- a/jaxlib/plugin_support.py
+++ b/jaxlib/plugin_support.py
@@ -24,6 +24,7 @@ from .version import __version__ as jaxlib_version
 _PLUGIN_MODULE_NAMES = {
     "cuda": ["jax_cuda13_plugin", "jax_cuda12_plugin"],
     "rocm": ["jax_rocm7_plugin", "jax_rocm60_plugin"],
+    "oneapi": ["jax_oneapi_plugin"],
 }
 
 


### PR DESCRIPTION
This PR introduces following changes.

1. It adds the OneAPI (SYCL) GPU runtime.
2. `./jaxlib/oneapi/` contains runtime files and necessary type aliases under `vendor.h` and `gpu_kernel_helpers.h` overloads.
3. OneAPI guards area added in `gpu_kernel_helpers.cc` for those functions where OneAPI/SYCL has no equivalent.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->