### PR TITLE
[ROCm] Enable HLO module transform registration for GPU backends

### DIFF
--- a/jax/_src/xla_transform.py
+++ b/jax/_src/xla_transform.py
@@ -69,8 +69,12 @@ def register_hlo_module_transformation(
   stage_int = stage.value
 
   # Canonicalize platforms to a list of strings early.
+  # When platforms=None we want all backends. Backend factory keys (e.g.
+  # "rocm") may differ from the platform string a client reports at runtime
+  # (e.g. "gpu"), so we include both forms and "gpu" as a catch-all for GPU
+  # plugin clients.
   if platforms is None:
-    platforms_list = ["cpu"] + list(xla_bridge._backend_factories.keys())
+    platforms_list = ["cpu", "gpu"] + list(xla_bridge._backend_factories.keys())
     platforms_list = list(dict.fromkeys(platforms_list))
   elif isinstance(platforms, str):
     platforms_list = [platforms]

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -278,7 +278,7 @@ jax_multiplatform_test(
 jax_multiplatform_test(
     name = "xla_transform_test",
     srcs = ["xla_transform_test.py"],
-    enable_backends = ["cpu"],
+    enable_backends = ["cpu", "gpu"],
     deps = [
         "//jax/extend:xla",
         "//jaxlib:_xla",


### PR DESCRIPTION
## Summary

- **`jax/_src/xla_transform.py`**: `register_hlo_module_transformation(platforms=None)` was silently skipping GPU plugin clients. The default platforms list only contained factory keys (e.g. `"rocm"`) while PJRT plugin clients report `client.platform` as `"gpu"`. Add `"gpu"` as an explicit entry so the backend initialization hook fires for all GPU plugin clients.
- **`tests/BUILD`**: Enable `xla_transform_test` for the GPU backend.

## Dependencies

Depends on the corresponding XLA change: openxla/xla#43630