### PR TITLE
Add Thor SM arch to CUDA build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -192,13 +192,13 @@ common:cuda_v12 --repo_env=HERMETIC_NVSHMEM_VERSION="3.3.9"
 common:cuda_v12 --repo_env=HERMETIC_NCCL_VERSION="2.29.7"
 # "sm" means we emit only cubin, which is forward compatible within a GPU generation.
 # "compute" means we emit both cubin and PTX, which is larger but also forward compatible to future GPU generations.
-common:cuda_v12 --repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_50,sm_60,sm_70,sm_80,sm_90,sm_100,compute_120"
+common:cuda_v12 --repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_50,sm_60,sm_70,sm_80,sm_90,sm_100,sm_101,compute_120"
 
 common:cuda_v13 --repo_env=HERMETIC_CUDA_VERSION="13.0.0"
 common:cuda_v13 --repo_env=HERMETIC_CUDNN_VERSION="9.12.0"
 common:cuda_v13 --repo_env=HERMETIC_NVSHMEM_VERSION="3.3.20"
 common:cuda_v13 --repo_env=HERMETIC_NCCL_VERSION="2.29.7"
-common:cuda_v13 --repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_75,sm_80,sm_90,sm_100,compute_120"
+common:cuda_v13 --repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_75,sm_80,sm_90,sm_100,sm_110,compute_120"
 
 common:cuda_common --repo_env TF_NEED_CUDA=1
 common:cuda_common --repo_env TF_NCCL_USE_STUB=1


### PR DESCRIPTION
Add missing Thor SM architecture target to CUDA build

N.b `sm_110` was named `sm_101` prior to CUDA 13.0 [[1]](https://docs.nvidia.com/cuda/archive/13.0.0/cuda-toolkit-release-notes/index.html#id2)