### PR TITLE
Fix spurious KeyReuseError under vmap over a zero-sized key array

### DIFF
--- a/jax/experimental/key_reuse/_core.py
+++ b/jax/experimental/key_reuse/_core.py
@@ -76,10 +76,12 @@ class _SourceSinkBase:
     assert isinstance(idx, int)
     if isinstance(mask, np.ndarray):
       assert mask.dtype == np.dtype('bool')
-      if np.all(mask):
-        mask = True
-      elif not np.any(mask):
+      if not np.any(mask):
+        # An empty mask (e.g. from vmap over a zero-sized axis) is a no-op:
+        # np.all() is vacuously True for empty arrays, so this must come first.
         mask = False
+      elif np.all(mask):
+        mask = True
       elif mask.flags.writeable:
           mask = np.array(mask, copy=True)
           mask.flags.writeable = False

--- a/tests/key_reuse_test.py
+++ b/tests/key_reuse_test.py
@@ -673,6 +673,16 @@ class KeyReuseEagerTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(KeyReuseError, self.traced_bits_msg):
       f()
 
+  def test_vmap_zero_sized_axis(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/37859: vmap over
+    # a zero-sized key axis must not raise a spurious KeyReuseError.
+    def f(key):
+      a, b = jax.random.split(key)
+      return jax.random.bits(a) + jax.random.bits(b)
+    keys = jax.random.split(jax.random.key(0), 0)
+    self.assertEqual(keys.shape, (0,))
+    jax.vmap(f)(keys)  # does not raise
+
 
 class KeyReuseImplementationTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Fixes #37859.

When `jax_debug_key_reuse` is enabled, `vmap`-ing a function over a zero-sized PRNG key array raised a spurious `KeyReuseError`, even when the function did no key reuse (e.g. it split its key and consumed each derived sub-key exactly once).

In `_SourceSinkBase.__init__`, an all-True mask is collapsed to scalar `True`. But `np.all()` is vacuously `True` for an empty array, so a mask coming from a zero-sized `vmap` axis (which affects no keys) was wrongly collapsed to `True`, i.e. full consumption, which then tripped the reuse check.

Checking `not np.any(mask)` before `np.all(mask)` makes an empty mask collapse to `False` (a no-op) while leaving every non-empty mask unchanged (for any non-empty mask exactly one of the two branches was already taken). Adds a regression test.