### PR TITLE
[ROCm] Remove outdated ROCm skip that depends on ROCm versions < 6.4

### DIFF
--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -16,8 +16,6 @@ import contextlib
 from functools import partial
 import itertools
 import math
-import os
-from pathlib import Path
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -40,15 +38,6 @@ import jax.numpy as jnp
 from jax._src.util import split_list
 import numpy as np
 import scipy.sparse
-
-def get_rocm_version():
-  rocm_path = os.environ.get("ROCM_PATH", "/opt/rocm")
-  version_path = Path(rocm_path) / ".info" / "version"
-  if not version_path.exists():
-    raise FileNotFoundError(f"Expected ROCm version file at {version_path}")
-  version_str = version_path.read_text().strip()
-  major, minor, *_ = version_str.split(".")
-  return int(major), int(minor)
 
 jax.config.parse_flags_with_absl()
 
@@ -245,14 +234,6 @@ class cuSparseTest(sptu.SparseTestCase):
       transpose=[True, False],
   )
   def test_csr_matmat(self, shape, dtype, transpose):
-    if (
-        jtu.is_device_rocm() and
-        get_rocm_version() < (6, 4) and
-        dtype in (jtu.dtypes.floating + jtu.dtypes.complex)
-    ):
-      # TODO: Remove this check when ROCm 6.4+ is the minimum supported version
-      self.skipTest("ROCm <6.4 bug: NaN propagation when beta==0 (fixed in ROCm 6.4.0)")
-
     op = lambda M: M.T if transpose else M
 
     B_rng = jtu.rand_default(self.rng())


### PR DESCRIPTION
# Description
ROCm 6.4 is outdated so removing the skip.
Cherry-picked from https://github.com/ROCm/jax/pull/776/changes/c2b9145c3ba1360ef53e8b6e80c1c9cfe8a77695
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->