### PR TITLE
[OneAPI GPU] Test utilities for oneapi

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -392,6 +392,9 @@ def is_device_rocm() -> bool:
 def is_device_cuda() -> bool:
   return 'cuda' in xla_bridge.get_backend().platform_version
 
+def is_device_oneapi() -> bool:
+  return 'oneapi' in xla_bridge.get_backend().platform_version
+
 def is_cloud_tpu() -> bool:
   return running_in_cloud_tpu_vm
 
@@ -570,6 +573,8 @@ def _get_device_tags():
     return {device_under_test(), "rocm"}
   elif is_device_cuda():
     return {device_under_test(), "cuda"}
+  elif is_device_oneapi():
+    return {device_under_test(), "oneapi"}
   else:
     return {device_under_test()}
 

--- a/jaxlib/py_array.cc
+++ b/jaxlib/py_array.cc
@@ -2367,7 +2367,8 @@ absl::Status PyArray::Register(nb::module_& m) {
             self.ifrt_array()->sharding().devices();
         absl::string_view platform_name =
             devices->devices().front()->PlatformName();
-        if (platform_name == "cuda" || platform_name == "rocm") {
+        if (platform_name == "cuda" || platform_name == "rocm" ||
+            platform_name == "oneapi") {
           return std::string_view("gpu");
         } else {
           return platform_name;

--- a/jaxlib/py_client.h
+++ b/jaxlib/py_client.h
@@ -105,7 +105,8 @@ class PyClient {
     // we haven't yet updated JAX clients that expect "gpu". Migrate users and
     // remove this code.
     if (ifrt_client_->platform_name() == "cuda" ||
-        ifrt_client_->platform_name() == "rocm") {
+        ifrt_client_->platform_name() == "rocm" ||
+        ifrt_client_->platform_name() == "oneapi") {
       return "gpu";
     } else {
       return ifrt_client_->platform_name();

--- a/tests/export_harnesses_multi_platform_test.py
+++ b/tests/export_harnesses_multi_platform_test.py
@@ -120,10 +120,12 @@ class PrimitiveTest(jtu.JaxTestCase):
         if d.platform not in unimplemented_platforms
     ]
     logging.info("Using devices %s", [str(d) for d in devices])
-    # lowering_platforms uses "cuda" or "rocm" instead of "gpu"
+    # lowering_platforms uses "cuda" or "rocm" or "oneapi" instead of "gpu"
     gpu_platform = "cuda"
     if jtu.is_device_rocm():
       gpu_platform = "rocm"
+    if jtu.is_device_oneapi():
+      gpu_platform = "oneapi"
     lowering_platforms: list[str] = [
         p if p != "gpu" else gpu_platform
         for p in ("cpu", "gpu", "tpu")

--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -66,6 +66,9 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
       if jtu.is_device_rocm():
         env["ROCR_VISIBLE_DEVICES"] = ",".join(
             str((task * num_gpus_per_task) + i) for i in range(num_gpus_per_task))
+      elif jtu.is_device_oneapi():
+        env["ZE_AFFINITY_MASK"] = ",".join(
+            str((task * num_gpus_per_task) + i) for i in range(num_gpus_per_task))
       else:
         env["CUDA_VISIBLE_DEVICES"] = ",".join(
             str((task * num_gpus_per_task) + i) for i in range(num_gpus_per_task))


### PR DESCRIPTION

This PR introduces following changes.
1. Added test utilities function for `oneapi`  in `test_util.py`.
2. `oneapi` gpu platform mapping in `tests/export_harnesses_multi_platform_test.py` and `tests/multiprocess_gpu_test.py`
3. Maps `oneapi` platform to `gpu` in `py_client.h` and `py_array.cc`.
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->