### PR TITLE
Document that segment ops drop negative indices instead of wrapping

### DIFF
--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -233,9 +233,11 @@ def segment_sum(data: ArrayLike,
 
   Args:
     data: an array with the values to be summed.
-    segment_ids: an array with integer dtype that indicates the segments of
-      `data` (along its leading axis) to be summed. Values can be repeated and
-      need not be sorted.
+    segment_ids: an array of non-negative integers that indicates the segments
+      of `data` (along its leading axis) to be summed. Values can be repeated
+      and need not be sorted. Negative ids are treated as out-of-bounds and
+      dropped rather than wrapped to count from the end, unlike
+      :attr:`jax.numpy.ndarray.at`.
     num_segments: optional, an int with nonnegative value indicating the number
       of segments. The default is set to be the minimum number of segments that
       would support all indices in ``segment_ids``, calculated as
@@ -291,9 +293,11 @@ def segment_prod(data: ArrayLike,
 
   Args:
     data: an array with the values to be reduced.
-    segment_ids: an array with integer dtype that indicates the segments of
-      `data` (along its leading axis) to be reduced. Values can be repeated and
-      need not be sorted.
+    segment_ids: an array of non-negative integers that indicates the segments
+      of `data` (along its leading axis) to be reduced. Values can be repeated
+      and need not be sorted. Negative ids are treated as out-of-bounds and
+      dropped rather than wrapped to count from the end, unlike
+      :attr:`jax.numpy.ndarray.at`.
     num_segments: optional, an int with nonnegative value indicating the number
       of segments. The default is set to be the minimum number of segments that
       would support all indices in ``segment_ids``, calculated as
@@ -351,9 +355,11 @@ def segment_max(data: ArrayLike,
 
   Args:
     data: an array with the values to be reduced.
-    segment_ids: an array with integer dtype that indicates the segments of
-      `data` (along its leading axis) to be reduced. Values can be repeated and
-      need not be sorted.
+    segment_ids: an array of non-negative integers that indicates the segments
+      of `data` (along its leading axis) to be reduced. Values can be repeated
+      and need not be sorted. Negative ids are treated as out-of-bounds and
+      dropped rather than wrapped to count from the end, unlike
+      :attr:`jax.numpy.ndarray.at`.
     num_segments: optional, an int with nonnegative value indicating the number
       of segments. The default is set to be the minimum number of segments that
       would support all indices in ``segment_ids``, calculated as
@@ -410,9 +416,11 @@ def segment_min(data: ArrayLike,
 
   Args:
     data: an array with the values to be reduced.
-    segment_ids: an array with integer dtype that indicates the segments of
-      `data` (along its leading axis) to be reduced. Values can be repeated and
-      need not be sorted.
+    segment_ids: an array of non-negative integers that indicates the segments
+      of `data` (along its leading axis) to be reduced. Values can be repeated
+      and need not be sorted. Negative ids are treated as out-of-bounds and
+      dropped rather than wrapped to count from the end, unlike
+      :attr:`jax.numpy.ndarray.at`.
     num_segments: optional, an int with nonnegative value indicating the number
       of segments. The default is set to be the minimum number of segments that
       would support all indices in ``segment_ids``, calculated as

--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -234,7 +234,7 @@ def segment_sum(data: ArrayLike,
   Args:
     data: an array with the values to be summed.
     segment_ids: an array of non-negative integers that indicates the segments
-      of `data` (along its leading axis) to be summed. Values can be repeated
+      of ``data`` (along its leading axis) to be summed. Values can be repeated
       and need not be sorted. Negative ids are treated as out-of-bounds and
       dropped rather than wrapped to count from the end, unlike
       :attr:`jax.numpy.ndarray.at`.
@@ -294,7 +294,7 @@ def segment_prod(data: ArrayLike,
   Args:
     data: an array with the values to be reduced.
     segment_ids: an array of non-negative integers that indicates the segments
-      of `data` (along its leading axis) to be reduced. Values can be repeated
+      of ``data`` (along its leading axis) to be reduced. Values can be repeated
       and need not be sorted. Negative ids are treated as out-of-bounds and
       dropped rather than wrapped to count from the end, unlike
       :attr:`jax.numpy.ndarray.at`.
@@ -356,7 +356,7 @@ def segment_max(data: ArrayLike,
   Args:
     data: an array with the values to be reduced.
     segment_ids: an array of non-negative integers that indicates the segments
-      of `data` (along its leading axis) to be reduced. Values can be repeated
+      of ``data`` (along its leading axis) to be reduced. Values can be repeated
       and need not be sorted. Negative ids are treated as out-of-bounds and
       dropped rather than wrapped to count from the end, unlike
       :attr:`jax.numpy.ndarray.at`.
@@ -417,7 +417,7 @@ def segment_min(data: ArrayLike,
   Args:
     data: an array with the values to be reduced.
     segment_ids: an array of non-negative integers that indicates the segments
-      of `data` (along its leading axis) to be reduced. Values can be repeated
+      of ``data`` (along its leading axis) to be reduced. Values can be repeated
       and need not be sorted. Negative ids are treated as out-of-bounds and
       dropped rather than wrapped to count from the end, unlike
       :attr:`jax.numpy.ndarray.at`.


### PR DESCRIPTION
Fixes #17387

The mode argument on the jax.ops.segment_* functions points users to jax.lax.GatherScatterMode, which is the same enum jax.numpy.ndarray.at uses. Because both paths reference the same mode, users reasonably expect them to handle negative indices the same way, but they do not.

The .at path normalizes negative indices and wraps them around, so a.at[-1] targets the last element. The segment functions call the scatter primitive with normalize_indices disabled, so a segment id of -1 is treated as out of bounds and, under the default FILL_OR_DROP mode, is dropped rather than mapped to the last segment.

As noted by the maintainer on the issue, this is the intended behavior for both, but it is not documented. This PR clarifies it in the docstrings of segment_sum, segment_prod, segment_max, and segment_min.

This matches the empirical behavior:

    i = jnp.array([0, 1, 2, 3, 4, -1, -1, -1, -1, -1])

    jnp.zeros(10).at[i].add(1, mode="drop")
    # Array([1., 1., 1., 1., 1., 0., 0., 0., 0., 5.])  (-1 wraps to index 9)

    jax.ops.segment_sum(jnp.ones(10), i, num_segments=10, mode="drop")
    # Array([1., 1., 1., 1., 1., 0., 0., 0., 0., 0.])  (-1 dropped)

Docs-only change. The existing doctests in the file pass.