### PR TITLE
Fix loggamma to return inf at x=0 matching scipy

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -246,7 +246,12 @@ def loggamma(x: ArrayLike) -> Array:
   if dtypes.issubdtype(x.dtype, np.complexfloating):
     return _complex_loggamma_scipy(x)
   res = lax.lgamma(x)
-  return jnp.where(x > 0, res, jnp.nan)
+  # The gamma function has a simple pole at x = 0, so loggamma(0) = +inf,
+  # matching scipy. lax.lgamma already returns +inf there, so no explicit
+  # special case is needed, and routing x = 0 through res keeps the correct
+  # nan gradient at the pole. Negative reals (including negative integer
+  # poles) return nan, also matching scipy for real-valued inputs.
+  return jnp.where(x >= 0, res, jnp.nan)
 
 
 def gamma(x: ArrayLike) -> Array:

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -343,6 +343,18 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
         self.assertAllClose(osp_special.gammasgn(inp),
                             lsp_special.gammasgn(inp))
 
+  def testLoggammaZeroPole(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/38240
+    # gamma has a simple pole at x=0, so loggamma(0) is +inf and must match
+    # scipy. rand_positive excludes 0 from the parameterized test above, so
+    # cover the pole explicitly here for both 0.0 and -0.0.
+    dtype = jnp.zeros(0).dtype  # default float dtype.
+    x = np.array([0.0, -0.0], dtype=dtype)
+    self.assertArraysEqual(lsp_special.loggamma(x),
+                           np.array([np.inf, np.inf], dtype=dtype))
+    self.assertAllClose(osp_special.loggamma(x), lsp_special.loggamma(x),
+                        check_dtypes=False)
+
   def testNdtriExtremeValues(self):
     # Testing at the extreme values (bounds (0. and 1.) and outside the bounds).
     dtype = jnp.zeros(0).dtype  # default float dtype.


### PR DESCRIPTION
The gamma function has a simple pole at x equals 0, so log of gamma at 0 is positive infinity. SciPy returns inf there, but jax.scipy.special.loggamma returned nan because the real branch kept results only for x greater than 0 and mapped every other value, including 0, to nan.

This returns positive infinity at x equals 0 and at negative zero, while leaving negative reals at nan. That still matches scipy for real-valued inputs, since loggamma is complex-valued on the negative real axis and scipy returns nan for real inputs there. Negative integer poles continue to return nan as before, consistent with scipy.

Verified against the scipy oracle across positive, zero, and negative inputs, confirmed the gradient at a positive point still equals digamma, and the existing loggamma tests in tests/lax_scipy_special_functions_test.py pass (12 passed).

Fixes #38240