### PR TITLE
Add clear_cache to jit-wrapped type

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -669,6 +669,9 @@ class JitWrapped(stages.Wrapped):
   def trace(self, *args, **kwargs) -> stages.Traced:
     raise NotImplementedError
 
+  def clear_cache(self) -> None:
+    raise NotImplementedError
+
 
 # in_shardings and out_shardings can't be None as the default value
 # because `None` means that the input is fully replicated.

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -155,6 +155,7 @@ if TYPE_CHECKING:
   assert_type(mat, jax.Array)
   assert_type(vals, jax.Array)
   assert_type(mask, jax.Array)
+  assert_type(jax.jit(lambda x: x).clear_cache(), None)
 
   # Functions with non-trivial typing overloads:
   # jnp.linspace


### PR DESCRIPTION
`clear_cache()` is available at runtime on jit-wrapped functions but is missing from `JitWrapped`, the return type of `jax.jit`, causing type checkers to reject valid calls. This adds the method declaration to `JitWrapped` so the static type matches the runtime interface.

Fixes #38244