### PR TITLE
[ROCm] CI improvements for ROCm

### DIFF
--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -99,7 +99,7 @@ fi
 echo "Final number of processes to run: $num_processes"
 
 export JAX_ENABLE_ROCM_XDIST="$gpu_count"
-export XLA_PYTHON_CLIENT_ALLOCATOR=platform
+export XLA_PYTHON_CLIENT_ALLOCATOR=default
 export XLA_PYTHON_CLIENT_PREALLOCATE=false
 export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1 --xla_gpu_enable_nccl_comm_splitting=false --xla_gpu_enable_command_buffer="
 
@@ -124,7 +124,6 @@ set +e
 "$JAXCI_PYTHON" -m pytest -n $num_processes --tb=short \
 --json-report --json-report-file=${LOGS_DIR}/pytest_results_single.json \
 --junitxml=test-artifacts/junit-single.xml \
---dist=loadfile \
 -m "not multiaccelerator" \
 --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
 --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \


### PR DESCRIPTION
Currently ROCm stream allocator has a couple of issues:
1. Even if we select the platform allocator from JAX, XLA actually provides the default BFC allocator, but it has a wiring issue with registering to the right stream. This causes occasional flaky tests due to a kernel in flight reading/writing memory that is reused by another kernel.
2. if we force stream allocator for ROCm currently it hangs whenever all workers get conv-related work (MIOpen). The issue is in XLA itself and a fix is in progress.

Because of these issues we want to give the default allocator a go. Downstream testing has been promising.

Also dropped the explicit --dist=loadfile so pytest-xdist falls back to its default (load), since loadfile was a little slower.

