### PR TITLE
Add Splash attention cost estimate

### DIFF
--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py
@@ -21,6 +21,7 @@ import dataclasses
 import enum
 import functools
 import json
+import math
 from typing import Any, Literal, NamedTuple, Optional, Union, overload
 
 import jax
@@ -897,6 +898,54 @@ def _div(dividend: int, divisor: int):
   return lax.div(dividend, divisor)
 
 
+def _bytes(x: jax.Array | jax.ShapeDtypeStruct) -> int:
+  return math.prod(x.shape) * x.dtype.itemsize
+
+
+def _splash_fwd_cost_estimate(
+    q: jax.Array | jax.ShapeDtypeStruct,
+    k: jax.Array | jax.ShapeDtypeStruct,
+    v: jax.Array | jax.ShapeDtypeStruct,
+    segment_ids: SegmentIds | None,
+    sinks: jax.Array | jax.ShapeDtypeStruct | None,
+    *,
+    mask_value: float,
+    save_residuals: bool,
+    attn_logits_soft_cap: float | None,
+    is_mqa: bool,
+    kernel_inputs_specs,
+    kernel_outputs_specs,
+) -> pl.CostEstimate:
+  num_q_heads, q_seq_len, head_dim_qk = q.shape
+  kv_seq_len = k.shape[0 if is_mqa else 1]
+  head_dim_v = v.shape[-1]
+  mask = jax.ShapeDtypeStruct((q_seq_len, kv_seq_len), jnp.bool_)
+  q_head = jax.ShapeDtypeStruct((q_seq_len, head_dim_qk), q.dtype)
+  k_head = jax.ShapeDtypeStruct((kv_seq_len, head_dim_qk), k.dtype)
+  v_head = jax.ShapeDtypeStruct((kv_seq_len, head_dim_v), v.dtype)
+  sinks_spec = None if sinks is None else jax.ShapeDtypeStruct((), sinks.dtype)
+  body_cost = pl.estimate_cost(
+      attention_reference,
+      mask,
+      q_head,
+      k_head,
+      v_head,
+      segment_ids,
+      sinks_spec,
+      mask_value=mask_value,
+      save_residuals=save_residuals,
+      custom_type="flash",
+      attn_logits_soft_cap=attn_logits_soft_cap,
+  )
+  input_bytes = sum(_bytes(x) for x in jax.tree.leaves(kernel_inputs_specs))
+  output_bytes = sum(_bytes(x) for x in jax.tree.leaves(kernel_outputs_specs))
+  return pl.CostEstimate(
+      flops=num_q_heads * body_cost.flops,
+      transcendentals=num_q_heads * body_cost.transcendentals,
+      bytes_accessed=input_bytes + output_bytes,
+  )
+
+
 def _splash_attention_forward(
     fwd_mask_info: mask_info_lib.MaskInfo,
     q: jax.Array,
@@ -1139,6 +1188,19 @@ def _splash_attention_forward(
     grid_width = kv_seq_len // bkv
 
   grid = (num_q_heads, q_seq_len // bq, grid_width)
+  kernel_inputs = (
+      fwd_mask_info.data_next,
+      fwd_mask_info.block_mask,
+      fwd_mask_info.mask_next,
+      q if q_layout == QKVLayout.HEAD_DIM_MINOR else q.swapaxes(-1, -2),
+      k if k_layout == QKVLayout.HEAD_DIM_MINOR else k.swapaxes(-1, -2),
+      v if v_layout == QKVLayout.HEAD_DIM_MINOR else v.swapaxes(-1, -2),
+      q_segment_ids,
+      kv_segment_ids,
+      sinks,
+      fwd_mask_info.partial_mask_blocks,
+      q_sequence,
+  )
   with jax.named_scope(kernel_name):
     all_out = pl.pallas_call(
         partial(
@@ -1168,19 +1230,20 @@ def _splash_attention_forward(
         name=kernel_name,
         interpret=interpret,
         metadata=metadata,
-    )(
-        fwd_mask_info.data_next,
-        fwd_mask_info.block_mask,
-        fwd_mask_info.mask_next,
-        q if q_layout == QKVLayout.HEAD_DIM_MINOR else q.swapaxes(-1, -2),
-        k if k_layout == QKVLayout.HEAD_DIM_MINOR else k.swapaxes(-1, -2),
-        v if v_layout == QKVLayout.HEAD_DIM_MINOR else v.swapaxes(-1, -2),
-        q_segment_ids,
-        kv_segment_ids,
-        sinks,
-        fwd_mask_info.partial_mask_blocks,
-        q_sequence,
-    )
+        cost_estimate=_splash_fwd_cost_estimate(
+            q,
+            k,
+            v,
+            segment_ids,
+            sinks,
+            mask_value=mask_value,
+            save_residuals=save_residuals,
+            attn_logits_soft_cap=attn_logits_soft_cap,
+            is_mqa=is_mqa,
+            kernel_inputs_specs=kernel_inputs,
+            kernel_outputs_specs=out_shapes,
+        ),
+    )(*kernel_inputs)
 
   (
       _,

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py
@@ -898,7 +898,7 @@ def _div(dividend: int, divisor: int):
   return lax.div(dividend, divisor)
 
 
-def _bytes(x: jax.Array | jax.ShapeDtypeStruct) -> int:
+def _bytes(x: jax.Array | jax.ShapeDtypeStruct | np.ndarray) -> int:
   return math.prod(x.shape) * x.dtype.itemsize
 
 

--- a/tests/pallas/tpu_splash_attention_kernel_test.py
+++ b/tests/pallas/tpu_splash_attention_kernel_test.py
@@ -29,6 +29,7 @@ from jax import random
 from jax._src import test_util as jtu
 from jax._src import hypothesis_test_util as htu
 from jax._src.pallas import pallas_test_util as ptu
+from jax.experimental import pallas as pl
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_kernel as splash
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask as mask_lib
 from jax.experimental.pallas.ops.tpu.splash_attention.splash_attention_mask_info import process_mask
@@ -301,6 +302,74 @@ def block_sizes_strategy(
 
 def attn_logits_soft_cap_strategy() -> hps.SearchStrategy[float | None]:
   return hps.one_of(hps.just(None), hps.floats(min_value=1.0, max_value=50.0))
+
+
+class SplashAttentionCostEstimateTest(jtu.JaxTestCase):
+
+  def test_splash_mha_forward_cost_estimate(self):
+    num_q_heads = 2
+    num_kv_heads = 1
+    q_seq_len = 64
+    kv_seq_len = 128
+    head_dim_qk = 16
+    head_dim_v = 32
+    dtype = jnp.bfloat16
+
+    q = jax.ShapeDtypeStruct(
+        (num_q_heads, q_seq_len, head_dim_qk), dtype
+    )
+    k = jax.ShapeDtypeStruct(
+        (num_kv_heads, kv_seq_len, head_dim_qk), dtype
+    )
+    v = jax.ShapeDtypeStruct(
+        (num_kv_heads, kv_seq_len, head_dim_v), dtype
+    )
+    kernel_inputs = (q, k, v)
+    kernel_outputs = (
+        jax.ShapeDtypeStruct((q_seq_len, splash.NUM_LANES), jnp.float32),
+        jax.ShapeDtypeStruct((q_seq_len, splash.NUM_LANES), jnp.float32),
+        jax.ShapeDtypeStruct((q_seq_len, head_dim_v), jnp.float32),
+        jax.ShapeDtypeStruct((num_q_heads, q_seq_len, head_dim_v), dtype),
+        None,
+    )
+
+    cost = splash._splash_fwd_cost_estimate(
+        q,
+        k,
+        v,
+        None,
+        None,
+        mask_value=splash.DEFAULT_MASK_VALUE,
+        save_residuals=False,
+        attn_logits_soft_cap=None,
+        is_mqa=False,
+        kernel_inputs_specs=kernel_inputs,
+        kernel_outputs_specs=kernel_outputs,
+    )
+    per_head_cost = pl.estimate_cost(
+        splash.attention_reference,
+        jax.ShapeDtypeStruct((q_seq_len, kv_seq_len), jnp.bool_),
+        jax.ShapeDtypeStruct((q_seq_len, head_dim_qk), dtype),
+        jax.ShapeDtypeStruct((kv_seq_len, head_dim_qk), dtype),
+        jax.ShapeDtypeStruct((kv_seq_len, head_dim_v), dtype),
+        None,
+        None,
+        mask_value=splash.DEFAULT_MASK_VALUE,
+        save_residuals=False,
+        custom_type="flash",
+        attn_logits_soft_cap=None,
+    )
+    expected_bytes = sum(
+        int(np.prod(x.shape)) * x.dtype.itemsize
+        for x in jax.tree.leaves((kernel_inputs, kernel_outputs))
+    )
+
+    self.assertEqual(cost.flops, num_q_heads * per_head_cost.flops)
+    self.assertEqual(
+        cost.transcendentals,
+        num_q_heads * per_head_cost.transcendentals,
+    )
+    self.assertEqual(cost.bytes_accessed, expected_bytes)
 
 
 @jtu.with_config(jax_traceback_filtering="off")


### PR DESCRIPTION
Splash's forward pass never passed a `cost_estimate` into its `pallas_call`, so the cost defaulted to zero. That can make the compiler treat the kernel as free, which affects profile utilization numbers and communication-overlap decisions. FlashAttention already has a cost estimate for its forward pass, so this adds the same kind of estimate for Splash.

The new `_splash_fwd_cost_estimate` gets FLOPs and transcendentals by running `pl.estimate_cost` on the reference attention implementation that's already in this file. That reference handles one head at a time, while Splash's grid runs over all query heads, so the per-head cost is scaled by `num_q_heads`. It reads the KV length from the right axis depending on `is_mqa`, so MHA/GQA/MQA layouts are covered. For bytes, it sums the actual kernel inputs and outputs rather than just q/k/v, so mask-info arrays, transposed q/k/v, segment ids, sinks, and output buffers are included.

I also pulled the kernel args into a local tuple so the same values feed both the cost estimate and the actual call.

One thing worth flagging: the FLOPs come from the dense reference, so a causal or otherwise sparse mask does not reduce the estimate. This is an upper bound in those cases, matching the approach used by FlashAttention's estimate.

Fixes #28776
Fixes #29463

Tests:
- `PYTHONPATH=$PWD python tests/pallas/tpu_splash_attention_kernel_test.py SplashAttentionCostEstimateTest.test_splash_mha_forward_cost_estimate`
- `PYTHONPATH=$PWD python tests/pallas/tpu_splash_attention_kernel_test.py` (passes locally; 83 TPU tests skipped because no TPU/libtpu is available)
- `PYTHONPATH=$PWD python tests/pallas/pallas_cost_estimate_test.py`
- `pre-commit run ruff --files jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py tests/pallas/tpu_splash_attention_kernel_test.py`
- `pre-commit run pyrefly-check --files jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py tests/pallas/tpu_splash_attention_kernel_test.py`
- `PYTHONPATH=$PWD python -m py_compile jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py tests/pallas/tpu_splash_attention_kernel_test.py`

Not run locally:
- TPU execution of the non-interpreted Splash attention tests; this requires TPU/libtpu and should be covered by JAX CI.
