### PR TITLE
[ROCm] Bake TheRock-aware RUNPATH into wheels and fix /opt/rocm-less CI

### DIFF
--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -117,6 +117,11 @@ jobs:
     env:
       JAXCI_CLONE_MAIN_XLA: ${{ inputs.clone_main_xla }}
       JAXCI_HERMETIC_PYTHON_VERSION: ${{ inputs.python }}
+      # Required on gfx950 with ROCm 7.13 to avoid HIP "invalid device function"
+      # failures during multi-accelerator collectives. RCCL emits an explicit
+      # warning when this is unset; the env var must be in place before HIP
+      # initialization, which happens at JAX import time.
+      HSA_NO_SCRATCH_RECLAIM: "1"
 
 # Begin Presubmit Naming Check - name modification requires internal check to be updated
     name: "linux x86, jaxlib=${{ inputs.jaxlib-version }}, ROCM=${{ inputs.rocm-version }}, Python=${{ inputs.python }}, x64=${{ inputs.enable-x64 }}, build_jax=${{ inputs.build_jax }}, build_jaxlib=${{ inputs.build_jaxlib }}"
@@ -127,6 +132,15 @@ jobs:
           persist-credentials: false
       - name: ROCm Info
         run: |
+          # TheRock (pip) ROCm images are /opt/rocm-less; rocminfo lives in the
+          # SDK bin dir, so put it on PATH via rocm-sdk. apt-ROCm images lack
+          # rocm-sdk and already have rocminfo on PATH.
+          if command -v rocm-sdk >/dev/null 2>&1; then
+            sdk_bin="$(rocm-sdk path --bin)"
+            if [[ -n "$sdk_bin" ]]; then
+              export PATH="$sdk_bin:$PATH"
+            fi
+          fi
           rocminfo
       - name: Configure AWS Credentials
         if: inputs.build_jaxlib == 'false' && inputs.jaxlib-version == 'head'

--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -150,7 +150,17 @@ jobs:
           curl -fSsL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
           chmod +x /usr/local/bin/bazel
       - name: ROCm Info
-        run: rocminfo
+        run: |
+          # TheRock (pip) ROCm images are /opt/rocm-less; rocminfo lives in the
+          # SDK bin dir, so put it on PATH via rocm-sdk. apt-ROCm images lack
+          # rocm-sdk and already have rocminfo on PATH.
+          if command -v rocm-sdk >/dev/null 2>&1; then
+            sdk_bin="$(rocm-sdk path --bin)"
+            if [[ -n "$sdk_bin" ]]; then
+              export PATH="$sdk_bin:$PATH"
+            fi
+          fi
+          rocminfo
       # Halt for testing
       - name: Wait For Connection
         uses: google-ml-infra/actions/ci_connection@7f5ca0c263a81ed09ea276524c1b9192f1304e3c

--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -139,6 +139,11 @@ jobs:
       JAXCI_HERMETIC_PYTHON_VERSION: "${{ inputs.python }}"
       JAXCI_PYTHON: "python${{ inputs.python }}"
       JAXCI_ENABLE_X64: "0"
+      # Required on gfx950 with ROCm 7.13 to avoid HIP "invalid device function"
+      # failures during multi-accelerator collectives. RCCL emits an explicit
+      # warning when this is unset; the env var must be in place before HIP
+      # initialization, which happens at JAX import time.
+      HSA_NO_SCRATCH_RECLAIM: "1"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/ci/build_rocm_artifacts.sh
+++ b/ci/build_rocm_artifacts.sh
@@ -73,6 +73,18 @@ if [[ -n "${JAXCI_BAZEL_OUTPUT_BASE}" ]]; then
   bazel_startup_options="--bazel_startup_options=--output_base=${JAXCI_BAZEL_OUTPUT_BASE}"
 fi
 
+# Point the build ROCm at the TheRock SDK already installed in this image, so
+# the wheel's ROCm SONAMEs (e.g. librocsolver) match the runtime image. Without
+# this, rules_ml_toolchain silently downloads its default distro (a different,
+# older ROCm) and the wheel links e.g. librocsolver.so.1 while the runtime only
+# has librocsolver.so.0. rules_ml_toolchain honors ROCM_PATH ahead of its
+# download path; rocm-sdk path --root is the pip-installed SDK root (no
+# /opt/rocm needed). Gated on rocm-sdk so apt-ROCm images keep the default.
+rocm_path_flags=()
+if command -v rocm-sdk >/dev/null 2>&1; then
+  rocm_path_flags=("--bazel_options=--repo_env=ROCM_PATH=$(rocm-sdk path --root)")
+fi
+
 echo "Building $artifact..."
 
 python build/build.py build --wheels="$artifact" \
@@ -86,7 +98,8 @@ python build/build.py build --wheels="$artifact" \
   --output_path="$JAXCI_OUTPUT_DIR" \
   $artifact_tag_flags \
   $override_xla_repo \
-  $wheel_version_suffix_flag
+  $wheel_version_suffix_flag \
+  "${rocm_path_flags[@]}"
 
 # Verify manylinux compliance.
 ./ci/utilities/run_auditwheel.sh

--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -36,6 +36,17 @@ echo "Installed packages:"
 
 "$JAXCI_PYTHON" -c "import jax; print(jax.default_backend()); print(jax.devices()); print(len(jax.devices()))"
 
+# TheRock (pip) ROCm images are intentionally /opt/rocm-less, so ROCm CLI tools
+# (rocminfo, rocm-smi, ...) live in the SDK bin dir rather than on PATH. Put
+# them on PATH via rocm-sdk. apt-ROCm images lack rocm-sdk and already have
+# these tools on PATH, so the gate leaves them untouched.
+if command -v rocm-sdk >/dev/null 2>&1; then
+  sdk_bin="$(rocm-sdk path --bin)"
+  if [[ -n "$sdk_bin" ]]; then
+    export PATH="$sdk_bin:$PATH"
+  fi
+fi
+
 rocm-smi
 
 # ==============================================================================

--- a/jaxlib/rocm/rocm_rpath.bzl
+++ b/jaxlib/rocm/rocm_rpath.bzl
@@ -33,11 +33,86 @@ load("//jaxlib:jax.bzl", "if_oss", "nanobind_extension")
 
 _ROCM_LINK_ONLY = "@local_config_rocm//rocm:link_only"
 
-_WHEEL_RPATHS = [
-    "-Wl,-rpath,$$ORIGIN/../rocm/lib",
-    "-Wl,-rpath,$$ORIGIN/../../rocm/lib",
-    "-Wl,-rpath,/opt/rocm/lib",
+# TheRock per-GPU-family pip package suffixes (per-GPU-family index at
+# https://rocm.nightlies.amd.com/v2/<family>/). End users install per-arch, so
+# the resulting `_rocm_sdk_libraries_<family>` package dirs must be searchable.
+# The multi-arch index instead ships a single `_rocm_sdk_libraries` package.
+_THEROCK_TARGET_FAMILIES = [
+    "gfx950-dcgpu",
+    "gfx94X-dcgpu",
+    "gfx90a",
+    "gfx90X-dcgpu",
+    "gfx908",
+    "gfx906",
+    "gfx900",
+    "gfx120X-all",
+    "gfx1153",
+    "gfx1152",
+    "gfx1151",
+    "gfx1150",
+    "gfx110X-all",
+    "gfx103X-all",
+    "gfx101X-dgpu",
 ]
+
+def _rocm_wheel_rpaths():
+    """Builds the wheel-relative ROCm RUNPATH entries baked into the .so files.
+
+    Covers the TheRock tarball/`/opt/rocm-<ver>` layout (`rocm/lib`), the
+    TheRock pip layouts (multi-arch and per-GPU-family `_rocm_sdk_*`), and
+    cross-Python / absolute installs where TheRock lives under a different
+    interpreter than the JAX wheel (e.g. the Bazel py_import runfiles layout
+    where TheRock is in the container's system Python). The legacy `/opt/rocm`
+    fallback is appended by the caller so it stays last.
+    """
+    # `_rocm_sdk_core/lib` holds the non-arch runtime libs; `_rocm_sdk_libraries
+    # [...]/lib` holds the math libs + per-arch kernel data. site_libs covers the
+    # multi-arch + per-family packages; core_libs is the cross-Python/absolute
+    # fallback (package roots only).
+    core_libs = ["_rocm_sdk_core/lib", "_rocm_sdk_libraries/lib"]
+    site_libs = core_libs + [
+        "_rocm_sdk_libraries_%s/lib" % f.replace("-", "_")
+        for f in _THEROCK_TARGET_FAMILIES
+    ]
+
+    # $ORIGIN-to-site-packages depth differs per wheel (kernel .so is 1-deep in
+    # jax_rocm<v>_plugin/, pjrt .so is 2-deep in jax_plugins/xla_rocm<v>/).
+    # linkopts apply to every target uniformly, so emit both; the loader skips
+    # RUNPATH entries whose directories don't exist.
+    origin_to_site = ["$$ORIGIN/..", "$$ORIGIN/../.."]
+    py_minors = range(9, 16)
+
+    rpaths = [
+        # TheRock tarball / extracted /opt/rocm-<ver> layout.
+        "-Wl,-rpath,$$ORIGIN/../rocm/lib",
+        "-Wl,-rpath,$$ORIGIN/../../rocm/lib",
+    ]
+
+    # Pip layouts at each possible $ORIGIN-to-site depth: same-Python (TheRock
+    # packages under the site-packages root next to the JAX wheel) and
+    # cross-Python (TheRock under a different python3.<m>/dist-packages under
+    # the same root).
+    for ots in origin_to_site:
+        rpaths += ["-Wl,-rpath,%s/%s" % (ots, lib) for lib in site_libs]
+        rpaths += [
+            "-Wl,-rpath,%s/../../python3.%d/dist-packages/%s" % (ots, m, lib)
+            for m in py_minors
+            for lib in core_libs
+        ]
+
+    # Absolute system-Python fallback (Bazel py_import runfiles / dev-image
+    # installs, where the .so isn't under a site-packages root reachable from
+    # $ORIGIN but TheRock is pip-installed into the system interpreter).
+    rpaths += [
+        "-Wl,-rpath,/usr/local/lib/python3.%d/dist-packages/%s" % (m, lib)
+        for m in py_minors
+        for lib in core_libs
+    ]
+    return rpaths
+
+# /opt/rocm is the legacy ROCm fallback for the transition period. Keep it last
+# so the wheel's own ROCm paths are always preferred over a system install.
+_WHEEL_RPATHS = _rocm_wheel_rpaths() + ["-Wl,-rpath,/opt/rocm/lib"]
 
 def _wheel_features():
     return select({


### PR DESCRIPTION
## Summary
Makes the ROCm JAX wheels and CI work against TheRock's /opt/rocm-less layout.

- **Wheel RUNPATH at link time** (`rocm_rpath.bzl`, `ci/build_rocm_artifacts.sh`):  Consolidate the ROCm wheel RUNPATH strategy and embed it at link time via  `_WHEEL_RPATHS` instead of a post-build patchelf step. A single wheel resolves ROCm libs across TheRock pip wheels (1- and 2-deep `$ORIGIN`), TheRock tarballs  under `/opt/rocm-<ver>`, and legacy `/opt/rocm`; the loader skips `$ORIGIN` entries whose dirs don't exist.
- **CLI tools on PATH** (`bazel_rocm.yml`, `build_rocm_artifacts.yml`, `run_pytest_rocm.sh`): prepend `rocm-sdk path --bin` so `rocminfo`/`rocm-smi` resolve on /opt/rocm-less images (gated on `rocm-sdk` existing; apt-ROCm
  images unaffected).
- **HSA_NO_SCRATCH_RECLAIM=1** in test workflows: required on gfx950 with recent ROCm to avoid HIP "invalid device function" during multi-accelerator collectives.

## Test plan
- Wheel built with `--config=rocm_release_wheel`; `readelf -d` shows the expected multi-entry RUNPATH and `ldd` resolves every ROCm dep with no `/opt/rocm`.
- TheRock CI jobs pass the "ROCm Info" step and run the pytest suite.

## Test Results
Validated on a continuous run against the latest TheRock ROCm SDK container (/opt/rocm-less, 4x AMD GPUs):
- **CLI/GPU detection:** `rocminfo`/`rocm-smi` resolve via `rocm-sdk path --bin`; the "ROCm Info" step passes and pytest detects all 4 GPUs (previously exit 127).
- **Wheel RUNPATH:** the wheel loads ROCm libs purely through baked `$ORIGIN` RUNPATHs with no `/opt/rocm` present; JAX registers the rocm backend.
- **Suite:** ran across `pytest-xdist` (16 workers). Remaining failures (linalg, sparse, shape_poly, export, nn) are all the pre-existing GEMM fallback issue (`INTERNAL: GEMM is not supported by cublasLt and legacy cublas fallback is removed`), tracked/addressed separately and unrelated to these RUNPATH/PATH changes. 

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->