### PR TITLE
use empty not zeros in sum type representation

### DIFF
--- a/jax/_src/ad_util.py
+++ b/jax/_src/ad_util.py
@@ -62,6 +62,13 @@ aval_zeros_likers: dict[type, Callable[[Any], Array]] = {}
 def zeros_like_jaxval(val):
   return zeros_like_aval(core.typeof(val))
 
+def empty_like_aval(aval):
+  from jax._src.hijax import HiType  # pyrefly: ignore[missing-import]
+  if isinstance(aval, HiType):
+    return aval.raise_val(*map(empty_like_aval, aval.lo_ty()))
+  return aval_empty_likers[type(aval)](aval)
+aval_empty_likers: dict[type, Callable[[Any], Array]] = {}
+
 def instantiate(z: Zero | Array) -> Array:
   if isinstance(z, Zero):
     return zeros_like_aval(z.aval)

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -765,7 +765,7 @@ def _join_cond_outputs(jaxprs: Sequence[core.ClosedJaxpr],
     def f_aug(*args):
       outs_and_residuals = core.jaxpr_as_fun(jaxpr)(*args)
       outs, residuals = split_list(outs_and_residuals, [num_non_res_outputs])
-      aug_residuals = map(ad_util.zeros_like_aval, all_res_avals)
+      aug_residuals = map(ad_util.empty_like_aval, all_res_avals)
       aug_residuals = util.subvals(aug_residuals, zip(res_indices, residuals))
       return outs + list(aug_residuals)
 

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -56,7 +56,7 @@ from jax._src.interpreters import partial_eval as pe
 from jax._src.interpreters import remat
 from jax._src.lax import slicing
 from jax._src.lax import utils as lax_utils
-from jax._src.mesh import get_abstract_mesh, get_concrete_mesh
+from jax._src.mesh import get_abstract_mesh, get_concrete_mesh, use_abstract_mesh
 from jax._src.lax.utils import (
   input_dtype, dtype_to_string, standard_multi_result_abstract_eval,
   standard_primitive, standard_abstract_eval)
@@ -3635,6 +3635,13 @@ def zeros_like_shaped_array(aval: ShapedArray) -> Array:
   out = broadcast(scalar_zero, aval.shape, out_sharding=aval.sharding)
   return core.pvary(out, tuple(aval.mat.varying))
 ad_util.aval_zeros_likers[ShapedArray] = zeros_like_shaped_array
+
+def empty_like_shaped_array(aval):
+  out = core.pvary(empty2(aval.dtype, memory_space=aval.memory_space),
+                   tuple(aval.mat.varying))
+  with use_abstract_mesh(aval.sharding.mesh):
+    return broadcast(out, aval.shape, out_sharding=aval.sharding)
+ad_util.aval_empty_likers[ShapedArray] = empty_like_shaped_array
 
 def iota(dtype: DTypeLike, size: int) -> Array:
   """Wraps XLA's `Iota

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -746,6 +746,60 @@ class ExtendedDTypeTest(jtu.JaxTestCase):
     dt_ = dtypes.primal_tangent_dtype(jnp.int8, jnp.bfloat16)
     self.assertEqual(dt, dt_)
 
+  def test_primal_tangent_dtype_cond(self):
+    differentiable_int8 = dtypes.primal_tangent_dtype(jnp.int8, jnp.float32)
+    w_float = jnp.arange(10, dtype=jnp.float32)
+
+    @jax.custom_vjp
+    def cast_to_differentiable_int8(w_fl):
+      w_int8 = w_fl.astype(jnp.int8)
+      return w_int8.astype(differentiable_int8)
+
+    def cast_to_differentiable_int8_fwd(w_fl):
+      return cast_to_differentiable_int8(w_fl), None
+
+    def cast_to_differentiable_int8_bwd(res, g):
+      return (g,)
+
+    cast_to_differentiable_int8.defvjp(cast_to_differentiable_int8_fwd, cast_to_differentiable_int8_bwd)
+
+    @jax.custom_vjp
+    def quantized_mul(w_df, x):
+      w_int8 = w_df.astype(jnp.int8)
+      w_f = w_int8.astype(jnp.float32)
+      return w_f * x
+
+    def quantized_mul_fwd(w_df, x):
+      return quantized_mul(w_df, x), (w_df, x)
+
+    def quantized_mul_bwd(res, g):
+      w_df, x = res
+      w_f = w_df.astype(jnp.int8).astype(jnp.float32)
+      return g * x, g * w_f
+
+    quantized_mul.defvjp(quantized_mul_fwd, quantized_mul_bwd)
+
+    @jax.jit
+    def train_step(w_fl, x, pred):
+
+      def loss_fn(w_float_arg):
+        w_diff = cast_to_differentiable_int8(w_float_arg)
+
+        def true_fn():
+          # Captures w_diff (PrimalTangentDType) as a residual
+          out = quantized_mul(w_diff, x)
+          return jnp.sum(out)
+
+        def false_fn():
+          return jnp.float32(0.0)
+
+        out = jax.lax.cond(pred, true_fn, false_fn)
+        return out
+
+      return jax.grad(loss_fn)(w_fl)
+    x = jnp.ones((10,), dtype=jnp.float32)
+    _ = train_step(w_float, x, True)  # don't crash
+
   @parameterized.parameters(itertools.product([(), (2,), (3, 4)], repeat=2))
   def test_edtype_conversion(self, shape_prefix, shape_suffix):
     class scalar(dtypes.extended): ...


### PR DESCRIPTION
That way, we can form products-representing-sums of types that don't have zeros defined.

I mostly copied the `zeros_like_aval` setup, which does the table-of-functions approach rather than the methods-on-types approach.