### PR TITLE
pjit: guard PjitFunctionCache::Lookup against reentrant cycle-GC

### DIFF
--- a/jaxlib/pjit.cc
+++ b/jaxlib/pjit.cc
@@ -166,16 +166,15 @@ class PjitFunctionCache {
     size_t cached_hash;
 
     bool operator==(const Key& other) const {
-      bool global_cache_eq;
+      if (function.ptr() != other.function.ptr()) return false;
       try {
-        global_cache_eq = global_cache_key.equal(other.global_cache_key);
+        return global_cache_key.equal(other.global_cache_key);
       } catch (const nanobind::python_error& e) {
         throw std::invalid_argument(
-            absl::StrCat("Equality of  global cache key lead to an exception. "
+            absl::StrCat("Equality of global cache key led to an exception. "
                          "The error was:\n",
                          e.what(), "\n"));
       }
-      return function.ptr() == other.function.ptr() && global_cache_eq;
     }
 
     struct Hash {
@@ -245,6 +244,13 @@ std::shared_ptr<PjitFunctionCache::Cache> PjitFunctionCache::DefaultCache() {
   absl::Cleanup unlock = [&self]() ABSL_UNLOCK_FUNCTION(self->mu_) {
     self->mu_.unlock();
   };
+  // Key::operator== calls Python __eq__, which allocates. Auto-GC firing there
+  // can collect a pjit function whose weakref callback below erases from
+  // functions_ while we are traversing it. Suppress auto-GC for the body.
+  int gc_was_enabled = PyGC_Disable();
+  absl::Cleanup gc_restore = [gc_was_enabled]() {
+    if (gc_was_enabled) PyGC_Enable();
+  };
   Key key;
   key.function = function;
   key.global_cache_key = global_cache_key;
@@ -257,6 +263,12 @@ std::shared_ptr<PjitFunctionCache::Cache> PjitFunctionCache::DefaultCache() {
   auto callback =
       nb::cpp_function([self, key{std::move(key)}](nb::handle weakref) {
         nb::ft_object_guard lock(self);
+        // find(key) below also calls Python __eq__; guard against nested
+        // auto-GC erasing from functions_ during this traversal too.
+        int gc_was_enabled = PyGC_Disable();
+        absl::Cleanup gc_restore = [gc_was_enabled]() {
+          if (gc_was_enabled) PyGC_Enable();
+        };
         auto it = self->functions_.find(key);
         if (it == self->functions_.end()) {
           return;

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -14,6 +14,7 @@
 
 from collections import OrderedDict, namedtuple
 import dataclasses
+import gc
 import itertools
 import re
 from functools import partial, wraps
@@ -69,6 +70,8 @@ from jax._src.mesh import AxisType
 from jax._src.interpreters import pxla
 from jax._src.lib import xla_client as xc
 from jax._src.util import curry, unzip2
+from jax._src import tree_util
+from jax._src.interpreters import pxla
 
 config.parse_flags_with_absl()
 
@@ -11880,6 +11883,114 @@ class UtilTest(jtu.JaxTestCase):
 
       # Compiling with a device assignment should succeed.
       lowered.compile(device_assignment=tuple(mesh.devices.flat))
+
+  def test_pjit_function_cache_gc_during_lookup(self):
+    # Regression test for a UAF in PjitFunctionCache::Lookup. Before the fix,
+    # Key::operator== ran global_cache_key.__eq__ unconditionally during
+    # unordered_map bucket probing. If __eq__ triggered a cycle collection
+    # that collected a PjitFunction in the same cache, the weakref callback
+    # erased from functions_ mid-traversal, corrupting the bucket. The fix
+    # short-circuits on function.ptr() mismatch before calling __eq__, so the
+    # different-function case below never reaches Python; this test exercises
+    # that short-circuit by forcing a gc.collect() inside __eq__ with a prior
+    # pjit function reachable only via a cycle. (gc.collect() bypasses the
+    # separate PyGC_Disable guard, which targets *automatic* GC from
+    # allocation in __eq__ when function.ptr() does match.)
+
+    class KeyWithGcInEq:
+      def __hash__(self):
+        # Constant Python hash. The map hash also mixes function.ptr(), so
+        # bucket collision across fresh f's is still probabilistic; post-fix
+        # the ptr short-circuit makes __eq__ unreachable here regardless of
+        # bucket layout.
+        return 0
+
+      def __eq__(self, other):
+        gc.collect()
+        return self is other
+
+    cache = xc._xla.PjitFunctionCache(capacity=64)
+
+    def make_one():
+      def f(x):
+        return x
+      pj = xc._xla.pjit(
+          'f', f, lambda *a, **kw: (f(*a, **kw), None, False),
+          [], [], KeyWithGcInEq(), tree_util.dispatch_registry,
+          pxla.cc_shard_arg, cache)
+      # Leave pj reachable only via a cycle so it needs the cycle collector.
+      cyc = [pj]
+      cyc.append(cyc)
+      return None
+
+    for _ in range(32):
+      make_one()
+    gc.collect()
+    # Reaching here without a SIGSEGV / heap corruption is the pass condition.
+
+  def test_pjit_function_cache_auto_gc_during_lookup(self):
+    # Companion to the previous test, exercising automatic cycle-GC fired
+    # by allocation inside global_cache_key.__eq__ (rather than an explicit
+    # gc.collect()); this is the case the PyGC_Disable guard in Lookup
+    # targets. Key::operator== only reaches __eq__ when
+    # function.ptr() matches, so this test re-jits one shared `shared_f` with
+    # many distinct keys to force __eq__ calls, while also seeding the cache
+    # with throwaway functions left in reference cycles so that auto-GC fired
+    # from inside __eq__ can collect one and run its weakref-erase callback
+    # mid-emplace. Bucket co-residency of a throwaway entry with the shared-f
+    # probe chain is probabilistic (absl hash of function.ptr()), so the loop
+    # runs enough iterations to make it overwhelmingly likely.
+
+    class AllocatingKey:
+      def __init__(self, n):
+        self._n = n
+
+      def __hash__(self):
+        # Constant Python hash. shared_f entries share one bucket (same
+        # function.ptr() + same Python hash); throwaways join only via
+        # absl-hash collision on function.ptr().
+        return 0
+
+      def __eq__(self, other):
+        # Allocate gc-tracked containers; with threshold=(1,1,1) this trips
+        # automatic collection on the spot.
+        [[i] for i in range(64)]
+        return isinstance(other, AllocatingKey) and self._n == other._n
+
+    cache = xc._xla.PjitFunctionCache(capacity=4096)
+
+    def shared_f(x):
+      return x
+
+    def seed_throwaway():
+      def g(x):
+        return x
+      pj = xc._xla.pjit(
+          'g', g, lambda *a, **kw: (g(*a, **kw), None, False),
+          [], [], AllocatingKey(-1), tree_util.dispatch_registry,
+          pxla.cc_shard_arg, cache)
+      cyc = [pj]
+      cyc.append(cyc)  # only reachable via cycle; auto-GC can collect g
+
+    held = []
+    old_thresh = gc.get_threshold()
+    gc.set_threshold(1, 1, 1)
+    try:
+      for i in range(256):
+        seed_throwaway()
+        # Same shared_f, distinct key: Lookup probes prior shared_f entries,
+        # hunk-1 ptr-check passes, __eq__ runs and allocates. With auto-GC
+        # suppressed by the PyGC_Disable guard this cannot collect a
+        # throwaway's g mid-emplace; without the guard it can.
+        held.append(xc._xla.pjit(
+            'shared_f', shared_f,
+            lambda *a, **kw: (shared_f(*a, **kw), None, False),
+            [], [], AllocatingKey(i), tree_util.dispatch_registry,
+            pxla.cc_shard_arg, cache))
+    finally:
+      gc.set_threshold(*old_thresh)
+    del held
+    gc.collect()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes a use-after-free in `PjitFunctionCache::Lookup` that can segfault
under GC pressure when many `jax.jit`-wrapped functions are created and
dropped.

## The bug

`PjitFunctionCache` is an `unordered_map` keyed on `(function,
global_cache_key)`. Entries are cleaned up when `function` is collected,
via a weakref callback registered in `Lookup` that calls
`functions_.erase(it)`.

`Key::operator==` calls `global_cache_key.equal(other.global_cache_key)`
— Python `__eq__` on a user-visible object — *unconditionally*, and
only afterwards ANDs in the cheap `function.ptr()` comparison. During
`functions_.emplace(key, …)`, the unordered_map walks a bucket and calls
`operator==` on each resident key. The Python `__eq__` allocates (for
the default `JitGlobalCppCacheKeys` dataclass, the generated `__eq__`
builds tuples), and allocation can trip automatic cycle-GC.

Since 879431f0a added `global_cache_key` to `PjitFunction`'s
`tp_traverse`, a `PjitFunction` that is only reachable via a reference
cycle is now collectible by the cycle collector. If one is collected
while `emplace` is mid-bucket-walk, its weakref callback runs and
erases from `functions_`. The iterator `emplace` is holding into that
bucket now dangles, and the process segfaults inside `_M_find_node`.

The `mu_` lock around `Lookup` does not help here: the callback runs on
the same thread that holds it.

## The fix

Two layered changes in `jaxlib/pjit.cc`:

- **Short-circuit `operator==` on `function.ptr()` first.** The pointer
  compare is free and almost always distinguishes keys; returning early
  on mismatch means Python `__eq__` only runs when the pointers match,
  so most bucket probes no longer allocate at all.

- **Suppress automatic cycle-GC for the body of `Lookup`** (and for the
  weakref callback's own `find`) with `PyGC_Disable()` + an
  `absl::Cleanup` that restores the prior state. This covers the
  remaining case where pointers do match and `__eq__` runs: allocation
  inside `__eq__` (or `__hash__`, via `absl::HashOf`) can no longer fire
  the cycle collector while the map is being traversed. Ref-counting is
  unaffected; only the cycle collector is deferred, and the
  `absl::Cleanup` restores it on every exit path including exceptions.
  `PyGC_Disable`/`PyGC_Enable` nest correctly via the saved return
  value, so a caller that already disabled GC is left as it was.

Restructuring `Lookup` to avoid holding an iterator across Python calls
was considered, but the corruption is inside the map's own
`_M_find_node`, so any traversal hits the same hazard.

## Tests

Two regression tests in `tests/pjit_test.py::UtilTest`:

- `test_pjit_function_cache_gc_during_lookup` creates a fresh function
  per iteration with a key whose `__eq__` calls `gc.collect()`
  explicitly, leaving each prior pjit function reachable only via a
  cycle. Before the fix, `operator==` ran `__eq__` unconditionally, so
  the explicit collect could fire the erase callback mid-`emplace`.
  After the fix, the pointer short-circuit returns before `__eq__` is
  reached, regardless of bucket layout.

- `test_pjit_function_cache_auto_gc_during_lookup` exercises the
  automatic-GC path the `PyGC_Disable` guard targets: one shared
  function is re-jitted with many distinct allocating keys (so the
  pointer compare passes and `__eq__` runs), interleaved with throwaway
  functions left in cycles, with `gc.set_threshold(1, 1, 1)` so
  allocation inside `__eq__` trips the collector.

Both tests pass deterministically after the fix. *Before* the fix, the
crash in each depends on an `absl::Hash` bucket collision (the map hash
mixes `function.ptr()`, which the tests cannot control), so they loop
enough iterations to make a collision overwhelmingly likely rather than
guaranteed. The tests drive `xc._xla.pjit` / `xc._xla.PjitFunctionCache`
directly to keep the setup minimal.