### PR TITLE
fixed issue with get prime factor number logic

### DIFF
--- a/jax/_src/mesh_utils.py
+++ b/jax/_src/mesh_utils.py
@@ -459,8 +459,10 @@ def _get_prime_factors(x: int) -> list[int]:
       x //= p
     if x == 1:
       return factors
-  else:
-    return [x]  # x is a prime number.
+  # The loop exited without `x` reaching 1, so the remaining `x` is a single
+  # prime factor larger than sqrt of the original input; append it too.
+  factors.append(x)
+  return factors
 
 
 def _enumerate_feasible_logical_axis_assignments(

--- a/tests/mesh_utils_test.py
+++ b/tests/mesh_utils_test.py
@@ -16,6 +16,7 @@
 import collections
 from collections.abc import Sequence
 import dataclasses
+import math
 
 from absl import logging
 from absl.testing import absltest
@@ -728,6 +729,16 @@ class SplitAxesDeviceMeshCreationTest(test_util.JaxTestCase):
     self.assertEqual(mesh_utils._get_prime_factors(12), [2, 2, 3])
     self.assertEqual(mesh_utils._get_prime_factors(121), [11, 11])  # square
     self.assertEqual(mesh_utils._get_prime_factors(43), [43])  # prime
+    # Numbers whose largest prime factor exceeds sqrt(x) (the trial-division
+    # bound) must still retain the smaller factors found before it.
+    self.assertEqual(mesh_utils._get_prime_factors(10), [2, 5])
+    self.assertEqual(mesh_utils._get_prime_factors(14), [2, 7])
+    self.assertEqual(mesh_utils._get_prime_factors(15), [3, 5])
+    self.assertEqual(mesh_utils._get_prime_factors(28), [2, 2, 7])
+    self.assertEqual(mesh_utils._get_prime_factors(2 * 9973), [2, 9973])
+    # The product of the returned factors must always reconstruct the input.
+    for n in range(1, 1000):
+      self.assertEqual(math.prod(mesh_utils._get_prime_factors(n)), n)
 
   @parameterized.named_parameters(
       (


### PR DESCRIPTION
Fixes https://github.com/jax-ml/jax/issues/38286

The for else in _get_prime_factors (jax/_src/mesh_utils.py) has no break, so the else runs on loop completion and returns only the leftover prime, discarding the factors already seen.

The loop trial divides up to isqrt(x) + 1 (range(2, isqrt(x) + 2)), so any composite whose largest prime factor exceeds that bound returns an incorrect result.


