### PR TITLE
Fix kl_div returning nan instead of inf at (inf, 0)

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -1176,7 +1176,13 @@ def kl_div(
   p, q = promote_args_inexact("kl_div", p, q)
   if dtypes.issubdtype(p.dtype, np.complexfloating):
     raise ValueError("kl_div does not support complex-valued inputs.")
-  return rel_entr(p, q) - p + q
+  # kl_div(p,q) = p*log(p/q) - p + q when p>0,q>0; q when p=0,q>=0; inf otherwise.
+  # Use piecewise to avoid inf - inf = nan for cases like (inf, 0).
+  case1 = (p > 0) & (q > 0)
+  case2 = (p == 0) & (q >= 0)
+  with jnp.errstate(invalid='ignore', divide='ignore'):
+    return jnp.where(case1, rel_entr(p, q) - p + q,
+                     jnp.where(case2, q, jnp.inf))
 
 
 def rel_entr(


### PR DESCRIPTION
## Summary

Fixes #38239: `jax.scipy.special.kl_div(inf, 0.0)` returns `nan` instead of `inf`.

## Root Cause

`kl_div` delegates to `rel_entr(p, q) - p + q`. At `p=inf, q=0`, `rel_entr(inf, 0)` correctly returns `inf`, but then `inf - inf + 0 = nan`.

## Fix

Use piecewise conditions per the definition instead of raw arithmetic:
- `p > 0, q > 0` → `rel_entr(p, q) - p + q`
- `p == 0, q >= 0` → `q`
- otherwise → `inf`

This avoids computing `inf - inf` outside the valid domain.

## Changes

- `jax/_src/scipy/special.py`: 4 lines

Fixes #38239

<!-- BEGIN RELEASE NOTES -->
* scipy
  * Fixed `kl_div(inf, 0.0)` returning nan instead of inf ([#38239](https://github.com/jax-ml/jax/issues/38239))
<!-- END RELEASE NOTES -->