### PR TITLE
[doc] fix some inconsistencies around partial and jit

### DIFF
--- a/docs/jit-compilation.md
+++ b/docs/jit-compilation.md
@@ -210,11 +210,9 @@ g_jit_correct = jax.jit(g, static_argnames=['n'])
 print(g_jit_correct(10, 20))
 ```
 
-To specify such arguments when using `jit` as a decorator, a common pattern is to use python's {func}`functools.partial`:
+To specify such arguments when using `jit` as a decorator, use the decorator factory pattern:
 
 ```{code-cell}
-from functools import partial
-
 @jax.jit(static_argnames=['n'])
 def g_jit_decorated(x, n):
   i = 0

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -333,7 +333,7 @@ def jit(
 
     >>> from functools import partial
     >>>
-    >>> @jax.jit(static_argnames=['n'])
+    >>> @partial(jax.jit, static_argnames=['n'])
     ... def g(x, n):
     ...   for i in range(n):
     ...     x = x ** 2


### PR DESCRIPTION
We used a global find/replace to replace `@partial(jit, ...)` with `@jit(...)`, and this left the documentation inconsistent in a couple places.