### PR TITLE
Fix detection of CUDA nvcc package on newer cuda 13 wheels

### DIFF
--- a/jax/_src/lib/__init__.py
+++ b/jax/_src/lib/__init__.py
@@ -164,32 +164,39 @@ def _cuda_path() -> str | None:
     return os.environ.get('CUDA_ROOT', None)
 
   def _try_cuda_nvcc_import() -> str | None:
-    """Try to import `cuda_nvcc` and get its path directly.
+    """Try to import a CUDA nvcc package and get its path directly.
 
-    If the pip package `nvidia-cuda-nvcc-cu11` is installed, it should have
-    both of the things XLA looks for in the cuda path, namely `bin/ptxas` and
-    `nvvm/libdevice/libdevice.10.bc`.
+    If a pip package such as `nvidia-cuda-nvcc-cu13`/`nvidia-cuda-nvcc-cu12` is
+    installed, it should have both of the things XLA looks for in the cuda path,
+    namely `bin/ptxas` and `nvvm/libdevice/libdevice.10.bc`.
+
+    `nvidia.cu13` is a namespace package shared by several CUDA-13 wheels, so it
+    can be importable without containing `ptxas` (e.g. when only
+    `nvidia-cuda-nvdisasm-cu13` is installed). Accept a module only if its
+    directory actually contains `bin/ptxas`; otherwise fall back to the next
+    candidate so a valid `nvidia.cuda_nvcc` is still found.
     """
-    try:
-      nvcc_module = importlib.import_module('nvidia.cu13')
-    except ImportError:
-      try:
-        nvcc_module = importlib.import_module('nvidia.cuda_nvcc')
-      except ImportError:
-        return None
-
-    cuda_nvcc_path = None
-    if hasattr(nvcc_module, '__file__') and nvcc_module.__file__ is not None:
-      cuda_nvcc_path = pathlib.Path(nvcc_module.__file__).parent
-    elif hasattr(nvcc_module, '__path__') and nvcc_module.__path__ is not None:
-      for path in nvcc_module.__path__:
-        if (pathlib.Path(path) / 'bin' / 'ptxas').exists():
-          cuda_nvcc_path = pathlib.Path(path)
-          break
-    else:
+    def _resolve_with_ptxas(module) -> pathlib.Path | None:
+      candidates = []
+      if getattr(module, '__file__', None) is not None:
+        candidates.append(pathlib.Path(module.__file__).parent)
+      candidates.extend(
+          pathlib.Path(p) for p in getattr(module, '__path__', None) or ())
+      for candidate in dict.fromkeys(candidates):
+        if (candidate / 'bin' / 'ptxas').exists():
+          return candidate
       return None
 
-    return str(cuda_nvcc_path)
+    for module_name in ('nvidia.cu13', 'nvidia.cuda_nvcc'):
+      try:
+        nvcc_module = importlib.import_module(module_name)
+      except ImportError:
+        continue
+      cuda_nvcc_path = _resolve_with_ptxas(nvcc_module)
+      if cuda_nvcc_path is not None:
+        return str(cuda_nvcc_path)
+
+    return None
 
   def _try_bazel_runfiles() -> str | None:
     """Try to get the path to the cuda installation in bazel runfiles."""


### PR DESCRIPTION
Update the detection of CUDA nvcc package to work with newer CU13 namespaces. We fallback to the older namespace when not found.