### PR TITLE
istft handle noverlap=0 and use resolved nfft_int

### DIFF
--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -1137,8 +1137,11 @@ def istft(Zxx: Array, fs: ArrayLike = 1.0, window: str = 'hann',
     raise ValueError(
         f'FFT length ({nfft_int}) must be longer than nperseg ({nperseg_int}).')
 
-  noverlap_int = core.concrete_or_error(
-      int, noverlap or nperseg_int // 2, "noverlap of STFT")
+  if noverlap is None:
+    noverlap_int = nperseg_int // 2
+  else:
+    noverlap_int = core.concrete_or_error(
+        int, noverlap, "noverlap of STFT")
   if noverlap_int >= nperseg_int:
     raise ValueError('noverlap must be less than nperseg.')
   nstep = nperseg_int - noverlap_int
@@ -1152,7 +1155,7 @@ def istft(Zxx: Array, fs: ArrayLike = 1.0, window: str = 'hann',
   # Perform IFFT
   ifunc = jnp_fft.irfft if input_onesided else jnp_fft.ifft
   # xsubs: [..., T, N], N is the number of frames, T is the frame length.
-  xsubs = ifunc(Zxx, axis=-2, n=nfft)[..., :nperseg_int, :]
+  xsubs = ifunc(Zxx, axis=-2, n=nfft_int)[..., :nperseg_int, :]
 
   # Get window as array
   if isinstance(window, str) and window == 'hann':

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -427,5 +427,37 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
                             check_dtypes=False)
     self._CompileAndCheck(jsp_fun, args_maker, rtol=tol, atol=tol)
 
+  def testIstftZeroNoverlap(self):
+    # noverlap=0 must be honored, not replaced by the nperseg // 2 default.
+    shape = (33, 10)
+    dtype = np.float64
+    kwds = dict(window='boxcar', noverlap=0, input_onesided=True,
+                boundary=False)
+    osp_fun = partial(osp_signal.istft, **kwds)
+    jsp_fun = partial(jsp_signal.istft, **kwds)
+    tol = {np.float32: 1e-4, np.float64: 1e-6,
+           np.complex64: 1e-4, np.complex128: 1e-6}
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape, dtypes.to_complex_dtype(dtype))]
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, rtol=tol, atol=tol,
+                            check_dtypes=False)
+    self._CompileAndCheck(jsp_fun, args_maker, rtol=tol, atol=tol)
+
+  def testIstftOddNperseg(self):
+    # one-sided nfft=None with odd nperseg must use nfft_int, not raw nfft.
+    shape = (4, 10)  # nperseg=7 == n_default + 1 (odd)
+    dtype = np.float64
+    kwds = dict(window='boxcar', nperseg=7, nfft=None, input_onesided=True,
+                boundary=False)
+    osp_fun = partial(osp_signal.istft, **kwds)
+    jsp_fun = partial(jsp_signal.istft, **kwds)
+    tol = {np.float32: 1e-4, np.float64: 1e-6,
+           np.complex64: 1e-4, np.complex128: 1e-6}
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape, dtypes.to_complex_dtype(dtype))]
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, rtol=tol, atol=tol,
+                            check_dtypes=False)
+    self._CompileAndCheck(jsp_fun, args_maker, rtol=tol, atol=tol)
+
 if __name__ == "__main__":
     absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Fixes #38315

istft resolves the overlap with noverlap or nperseg_int // 2, so an explicit noverlap=0 (a valid value) is treated as unset and is replaced by the nperseg // 2 default, producing a wrong reconstruction that diverges from SciPy

Its inverse FFT is called with the raw nfft instead of the resolved nfft_int, so a one-sided transform with nfft=None and an odd nperseg drops the length correction and crashes with a broadcasting error

Also added some tests for it

(Caught a test tolerance issue where float64/complex128 cases used a flat rtol/atol=1e-4. With JAX x64 disabled, those inputs downcast to float32, making the tolerance mislabeled and too loose for true float64. Switched to dtype-specific tolerances: 1e-6 for float64/complex128 and 1e-4 for float32/complex64, matching the existing istft test behavior before submitting this pr)
