### PR TITLE
docs: improve grammar and wording in Ref guide

### DIFF
--- a/docs/array_refs.py
+++ b/docs/array_refs.py
@@ -73,7 +73,7 @@ print(jax.grad(g)(1.0))  # 0.54
 
 # `Ref` is a distinct type from `Array`, and it comes with some important
 # constraints and limitations. In particular, indexed reading and writing is just
-# about the *only* thing you can do with an `Ref`. References can't be passed
+# about the *only* thing you can do with a `Ref`. References can't be passed
 # where `Array`s are expected:
 
 x_ref = jax.new_ref(1.0)
@@ -103,7 +103,7 @@ def array_ref(init_val: Array) -> Ref:
 
 # -
 
-# `jax.freeze` is its antithesis, invalidating the given ref (so that accessing it
+# `jax.freeze` is its opposite, invalidating the given ref (so that accessing it
 # afterwards is an error) and producing its final value:
 
 def freeze(ref: Ref) -> Array:


### PR DESCRIPTION
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->## Summary

This PR improves the Ref documentation by fixing a grammar issue and simplifying wording for readability.

## Changes

- Changed `an Ref` to `a Ref`
- Changed `its antithesis` to `its opposite`

These changes do not affect functionality and only improve documentation clarity.