### PR TITLE
Add Device.clear_memory_stats()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     * Added `jax.random.key_dtype` to get the dtype corresponding to a PRNG
       implementation name.
     * `jax.random.key` and `wrap_key_data` now accept a `dtype` argument.
+  * Added `Device.clear_memory_stats()`, which resets `peak_bytes_in_use` (and
+    other peak counters) reported by `Device.memory_stats()` for backends that
+    support memory stats.
 
 * Breaking changes
   * `with mesh:` context manager has been deprecated. Please use

--- a/jaxlib/_jax/__init__.pyi
+++ b/jaxlib/_jax/__init__.pyi
@@ -453,6 +453,8 @@ class Device:
     different stats, or -1 for unavailable stats. 'bytes_in_use' is usually
     available. Intended for diagnostic use.
     """
+  def clear_memory_stats(self) -> None:
+    """Clears the peak memory tracking statistics for this device."""
 
   def get_stream_for_external_ready_events(self) -> int: ...
   def poison_execution(self, launch_id: int, error: str | object) -> bool: ...

--- a/jaxlib/py_device.cc
+++ b/jaxlib/py_device.cc
@@ -299,7 +299,13 @@ PyType_Slot PyDevice::slots_[] = {
       .def(
           "clear_memory_stats",
           [](const PyDevice& self) {
-            xla::ThrowIfError(self.ClearMemoryStats());
+            absl::Status status = self.ClearMemoryStats();
+            if (absl::IsUnimplemented(status)) {
+              PyErr_SetString(PyExc_NotImplementedError,
+                              std::string(status.message()).c_str());
+              throw nb::python_error();
+            }
+            xla::ThrowIfError(status);
           },
           "Clears the peak memory tracking statistics for this device.")
       .def(

--- a/jaxlib/py_device.cc
+++ b/jaxlib/py_device.cc
@@ -188,6 +188,16 @@ PyDevice::MemoryStats() const {
   return result;
 }
 
+absl::Status PyDevice::ClearMemoryStats() const {
+  GlobalPyRefManager()->CollectGarbage();
+  ifrt::PjRtDevice* device = llvm::dyn_cast<ifrt::PjRtDevice>(device_);
+  if (device == nullptr || !device->IsAddressable()) {
+    return xla::InvalidArgument(
+        "ClearMemoryStats is only supported for addressable PjRt devices.");
+  }
+  return device->pjrt_device()->ClearMemoryStats();
+}
+
 absl::StatusOr<std::intptr_t> PyDevice::GetStreamForExternalReadyEvents()
     const {
   ifrt::PjRtDevice* device = llvm::dyn_cast<ifrt::PjRtDevice>(device_);
@@ -286,6 +296,12 @@ PyType_Slot PyDevice::slots_[] = {
           "be implemented on all platforms, and different platforms may return "
           "different stats, or -1 for unavailable stats. 'bytes_in_use' is "
           "usually available. Intended for diagnostic use.")
+      .def(
+          "clear_memory_stats",
+          [](const PyDevice& self) {
+            xla::ThrowIfError(self.ClearMemoryStats());
+          },
+          "Clears the peak memory tracking statistics for this device.")
       .def(
           "get_stream_for_external_ready_events",
           xla::ValueOrThrowWrapper(&PyDevice::GetStreamForExternalReadyEvents))

--- a/jaxlib/py_device.h
+++ b/jaxlib/py_device.h
@@ -65,6 +65,7 @@ class PyDevice {
   absl::StatusOr<
       std::optional<nanobind::typed<nanobind::dict, nanobind::str, int>>>
   MemoryStats() const;
+  absl::Status ClearMemoryStats() const;
 
   absl::StatusOr<std::intptr_t> GetStreamForExternalReadyEvents() const;
 

--- a/tests/multi_device_test.py
+++ b/tests/multi_device_test.py
@@ -347,7 +347,10 @@ class MultiDeviceTest(jtu.JaxTestCase):
 
     del x
     jax.effects_barrier()
-    device.clear_memory_stats()
+    try:
+      device.clear_memory_stats()
+    except NotImplementedError:
+      self.skipTest("clear_memory_stats not supported on this device")
     peak_after_clear = device.memory_stats()["peak_bytes_in_use"]
     self.assertLess(peak_after_clear, peak_before)
 

--- a/tests/multi_device_test.py
+++ b/tests/multi_device_test.py
@@ -335,5 +335,21 @@ class MultiDeviceTest(jtu.JaxTestCase):
     tm.stop()
     self.assertEqual(y.sharding, x.sharding)
 
+  def test_clear_memory_stats(self):
+    device = jax.devices()[0]
+    if device.memory_stats() is None:
+      self.skipTest("memory_stats not supported on this device")
+
+    x = jnp.ones((1024, 1024), dtype=jnp.float32, device=device)
+    x.block_until_ready()
+    peak_before = device.memory_stats()["peak_bytes_in_use"]
+    self.assertGreater(peak_before, 0)
+
+    del x
+    jax.effects_barrier()
+    device.clear_memory_stats()
+    peak_after_clear = device.memory_stats()["peak_bytes_in_use"]
+    self.assertLess(peak_after_clear, peak_before)
+
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Adds `Device.clear_memory_stats()`, the write-side companion to the existing `Device.memory_stats()`. It resets the peak memory counters (e.g. `peak_bytes_in_use`) for backends that support memory stats. Mirrors `MemoryStats()`: dyn_cast the ifrt Device to `ifrt::PjRtDevice` and forward to `pjrt_device()->ClearMemoryStats()` (the method added to XLA's PjRt C API client). Raises on non-PjRt / non-addressable devices.

Note: this is the follow up to xla pull request [[PJRT & GPU] implement PJRT_Device_ClearMemoryStats](https://github.com/openxla/xla/pull/41175).