### PR TITLE
Fix istft noverlap and inferred nfft handling

### DIFF
--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -1138,7 +1138,8 @@ def istft(Zxx: Array, fs: ArrayLike = 1.0, window: str = 'hann',
         f'FFT length ({nfft_int}) must be longer than nperseg ({nperseg_int}).')
 
   noverlap_int = core.concrete_or_error(
-      int, noverlap or nperseg_int // 2, "noverlap of STFT")
+      int, nperseg_int // 2 if noverlap is None else noverlap,
+      "noverlap of STFT")
   if noverlap_int >= nperseg_int:
     raise ValueError('noverlap must be less than nperseg.')
   nstep = nperseg_int - noverlap_int
@@ -1152,7 +1153,7 @@ def istft(Zxx: Array, fs: ArrayLike = 1.0, window: str = 'hann',
   # Perform IFFT
   ifunc = jnp_fft.irfft if input_onesided else jnp_fft.ifft
   # xsubs: [..., T, N], N is the number of frames, T is the frame length.
-  xsubs = ifunc(Zxx, axis=-2, n=nfft)[..., :nperseg_int, :]
+  xsubs = ifunc(Zxx, axis=-2, n=nfft_int)[..., :nperseg_int, :]
 
   # Get window as array
   if isinstance(window, str) and window == 'hann':

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -427,5 +427,31 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
                             check_dtypes=False)
     self._CompileAndCheck(jsp_fun, args_maker, rtol=tol, atol=tol)
 
+  def testIstftZeroNoverlapAgainstNumpy(self):
+    rng = jtu.rand_default(self.rng())
+    Zxx = rng((33, 10), np.complex64)
+    kwds = dict(window='boxcar', noverlap=0, input_onesided=True,
+                boundary=False)
+
+    _, osp_x = osp_signal.istft(Zxx, **kwds)
+    _, jsp_x = jsp_signal.istft(Zxx, **kwds)
+
+    self.assertEqual(jsp_x.shape, osp_x.shape)
+    self.assertAllClose(jsp_x, osp_x, rtol=1e-6, atol=1e-6,
+                        check_dtypes=False)
+
+  def testIstftInferredNfftWithOddNpersegAgainstNumpy(self):
+    rng = jtu.rand_default(self.rng())
+    Zxx = rng((4, 10), np.complex64)
+    kwds = dict(window='boxcar', nperseg=7, nfft=None,
+                input_onesided=True, boundary=False)
+
+    _, osp_x = osp_signal.istft(Zxx, **kwds)
+    _, jsp_x = jsp_signal.istft(Zxx, **kwds)
+
+    self.assertEqual(jsp_x.shape, osp_x.shape)
+    self.assertAllClose(jsp_x, osp_x, rtol=1e-6, atol=1e-6,
+                        check_dtypes=False)
+
 if __name__ == "__main__":
-    absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
## Summary

Fixes #38315.

`jax.scipy.signal.istft` now preserves an explicit `noverlap=0` instead of replacing it with the default half-window overlap, and it passes the resolved `nfft_int` into the inverse FFT so the odd `nperseg` / one-sided inferred-`nfft` path uses the corrected FFT length.

## Root cause

- `noverlap or nperseg_int // 2` treats `0` as missing.
- The IFFT call used the original optional `nfft` argument, so `nfft=None` bypassed the earlier odd-`nperseg` correction stored in `nfft_int`.

## Tests

- `.\.venv\Scripts\python.exe -m pytest tests/scipy_signal_test.py -k "testIstftZeroNoverlapAgainstNumpy or testIstftInferredNfftWithOddNpersegAgainstNumpy" -q`
- `.\.venv\Scripts\python.exe -m pytest tests/scipy_signal_test.py -k "testIstftAgainstNumpy" -q`
- `.\.venv\Scripts\python.exe -m pytest tests/scipy_signal_test.py -q`
- `.\.venv\Scripts\python.exe -m ruff check jax/_src/scipy/signal.py tests/scipy_signal_test.py`
- `git diff --check`