### PR TITLE
Propagate NaNs in uniform stats functions

### DIFF
--- a/jax/_src/scipy/stats/uniform.py
+++ b/jax/_src/scipy/stats/uniform.py
@@ -49,9 +49,12 @@ def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   """
   x, loc, scale = promote_args_inexact("uniform.logpdf", x, loc, scale)
   log_probs = lax.neg(lax.log(scale))
-  return jnp.where(jnp.logical_or(lax.gt(x, lax.add(loc, scale)),
-                                  lax.lt(x, loc)),
-                   -np.inf, log_probs)
+  return jnp.where(
+      jnp.isnan(x) | jnp.isnan(loc) | jnp.isnan(scale),
+      np.nan,
+      jnp.where(jnp.logical_or(lax.gt(x, lax.add(loc, scale)),
+                              lax.lt(x, loc)),
+                -np.inf, log_probs))
 
 
 def pdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
@@ -116,7 +119,10 @@ def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   conds = [lax.lt(x, loc), lax.gt(x, lax.add(loc, scale)), lax.ge(x, loc) & lax.le(x, lax.add(loc, scale))]
   vals = [zero, one, lax.div(lax.sub(x, loc), scale)]
 
-  return jnp.select(conds, vals)
+  return jnp.where(
+      jnp.isnan(x) | jnp.isnan(loc) | jnp.isnan(scale),
+      np.nan,
+      jnp.select(conds, vals))
 
 
 def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -1256,6 +1256,22 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
                               tol=1e-5)
       self._CompileAndCheck(lax_fun, args_maker)
 
+  @jtu.sample_product(
+      func=["cdf", "pdf", "logpdf"],
+      dtype=jtu.dtypes.floating)
+  def testUniformNanPropagation(self, func, dtype):
+    scipy_fun = getattr(osp_stats.uniform, func)
+    lax_fun = getattr(lsp_stats.uniform, func)
+    x = np.array([np.nan, 0.5, 0.5], dtype)
+    loc = np.array([0.0, np.nan, 0.0], dtype)
+    scale = np.array([1.0, 1.0, np.nan], dtype)
+    expected = scipy_fun(x, loc, scale)
+
+    self.assertAllClose(lax_fun(x, loc, scale), expected,
+                        check_dtypes=False)
+    self.assertAllClose(jax.jit(lax_fun)(x, loc, scale), expected,
+                        check_dtypes=False)
+
   @genNamedParametersNArgs(3)
   def testUniformPpf(self, shapes, dtypes):
     rng = jtu.rand_default(self.rng())


### PR DESCRIPTION
## Summary

Fixes #38317.

`jax.scipy.stats.uniform.cdf`, `pdf`, and `logpdf` now propagate NaNs in `x`, `loc`, or `scale` instead of treating NaN comparisons as ordinary in-support values.

## Root cause

- `cdf` uses comparison masks with `jnp.select`; comparisons with NaN are all false, so the default branch returned `0`.
- `logpdf` only checked range comparisons, so NaN inputs fell through to `-log(scale)`, and `pdf` inherited that finite result via `exp(logpdf)`.

## Tests

- Reproduced the pre-fix behavior: `cdf(nan)=0.0`, `pdf(nan)=1.0`, `logpdf(nan)=-0.0` while SciPy returns `nan`.
- `.\.venv\Scripts\python.exe -m pytest tests/scipy_stats_test.py -k testUniformNanPropagation -q`
- `.\.venv\Scripts\python.exe -m pytest tests/scipy_stats_test.py -k "testUniformLogPdf or testUniformCdf or testUniformPpf" -q`
- `.\.venv\Scripts\python.exe -m pytest tests/scipy_stats_test.py -k Uniform -q`
- `.\.venv\Scripts\python.exe -m ruff check jax/_src/scipy/stats/uniform.py tests/scipy_stats_test.py`
- `git diff --check`