### PR TITLE
Add bcomplex32 (complex<bfloat16>) ExtendedDType support

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -570,7 +570,9 @@ def _check_input_dtype_revderiv(name, holomorphic, allow_int, x):
     if (dtypes.issubdtype(aval.dtype, dtypes.extended) or
         dtypes.issubdtype(aval.dtype, np.integer) or
         dtypes.issubdtype(aval.dtype, np.bool_)):
-      if not allow_int:
+      is_complex_ext = (dtypes.issubdtype(aval.dtype, dtypes.extended) and
+                        dtypes.issubdtype(aval.dtype, np.inexact))
+      if not allow_int and not is_complex_ext:
         raise TypeError(f"{name} requires real- or complex-valued inputs (input dtype "
                         f"that is a sub-dtype of np.inexact), but got {aval.dtype.name}. "
                         "If you want to use Boolean- or integer-valued inputs, use vjp "

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -83,6 +83,20 @@ class prng_key(extended):
   """
 
 
+@export
+class bcomplex32_scalar(extended):
+  """Scalar class for bcomplex32 (complex<bfloat16>) dtype.
+
+  This is an abstract class that should never be instantiated, but rather
+  exists for the sake of `jnp.issubdtype`.
+
+  Examples:
+    >>> from jax._src import dtypes
+    >>> jnp.issubdtype(dtypes.bcomplex32_edtype, dtypes.bcomplex32_scalar)
+    True
+  """
+
+
 class ExtendedDType(StrictABC):
   """Abstract Base Class for extended dtypes"""
   @property
@@ -90,6 +104,37 @@ class ExtendedDType(StrictABC):
   def type(self) -> type: ...
 
   _rules: Any = None
+
+
+class _BComplex32DType(ExtendedDType):
+  """ExtendedDType for bcomplex32 (complex<bfloat16>).
+
+  Logical representation: shape (N,), dtype=bcomplex32_edtype
+  Physical representation: shape (N, 2), dtype=bfloat16
+  The trailing dimension stores [real_part, imaginary_part].
+  """
+  type = bcomplex32_scalar
+  _rules = None  # Set later to avoid circular imports
+
+  @property
+  def name(self):
+    return 'bcomplex32'
+
+  @property
+  def itemsize(self):
+    return 4  # 2 * bfloat16
+
+  def __repr__(self):
+    return 'bcomplex32'
+
+  def __eq__(self, other):
+    return type(other) is _BComplex32DType
+
+  def __hash__(self):
+    return hash(self.__class__)
+
+
+bcomplex32_edtype = _BComplex32DType()
 
 # fp8 support
 float8_e3m4: type[np.generic] = ml_dtypes.float8_e3m4
@@ -132,6 +177,10 @@ def supports_inf(dtype: DTypeLike) -> bool:
 # bfloat16 support
 bfloat16: type[np.generic] = ml_dtypes.bfloat16
 _bfloat16_dtype: np.dtype = np.dtype(bfloat16)
+
+# bcomplex32 support (complex<bfloat16>, 4 bytes)
+bcomplex32: type[np.generic] = ml_dtypes.bcomplex32
+_bcomplex32_dtype: np.dtype = np.dtype(bcomplex32)
 
 _custom_float_scalar_types = [
     float4_e2m1fn,
@@ -270,7 +319,11 @@ def jax_dtype(obj: DTypeLike | None, *, align: bool = False,
     return obj  # pyrefly: ignore[bad-return]
   elif isinstance(obj, type) and (f := _DEFAULT_TYPEMAP.get(obj)) is not None:
     obj = f()
-  return np.dtype(obj, align=align, copy=copy)
+  result = np.dtype(obj, align=align, copy=copy)
+  # Map bcomplex32 np.dtype to its ExtendedDType counterpart
+  if result == _bcomplex32_dtype:
+    return bcomplex32_edtype
+  return result
 
 _DEFAULT_TYPEMAP: dict[type, Callable[[], np.dtype]] = {
   bool: lambda: np.dtype(bool),
@@ -285,6 +338,8 @@ def itemsize_bits(dtype: DTypeLike) -> int:
   # incorrect for sub-byte integer types.
   if dtype is None:
     raise ValueError("dtype cannot be None.")
+  if dtype is bcomplex32_edtype:
+    return 32  # 2 * 16 bits for bfloat16
   if dtype == np.dtype(bool):
     return 8  # physical bit layout for boolean dtype
   elif issubdtype(dtype, np.integer):
@@ -328,6 +383,11 @@ def to_numeric_dtype(dtype: DTypeLike) -> DType:
 
 def to_inexact_dtype(dtype: DTypeLike) -> DType:
   """Promotes a dtype into an inexact dtype, if it is not already one."""
+  if isinstance(dtype, ExtendedDType):
+    # ExtendedDTypes like bcomplex32 are already inexact; return as-is.
+    if issubdtype(dtype, np.complexfloating) or issubdtype(dtype, np.floating):
+      return dtype
+    raise TypeError(f"Cannot interpret {dtype!r} as a data type")
   dtype_ = np.dtype(dtype)
   return _dtype_to_inexact.get(dtype_, dtype_)
 
@@ -340,6 +400,8 @@ def to_floating_dtype(dtype: DTypeLike) -> DType:
 
 def to_complex_dtype(dtype: DTypeLike) -> DType:
   ftype = to_inexact_dtype(dtype)
+  if ftype == _bfloat16_dtype:
+    return bcomplex32_edtype
   if ftype in [np.dtype('float64'), np.dtype('complex128')]:
     return np.dtype('complex128')
   return np.dtype('complex64')
@@ -358,6 +420,9 @@ def _canonicalize_dtype(x64_enabled: bool, allow_extended_dtype: bool, dtype: An
     raise TypeError(f'dtype {dtype!r} not understood') from e
 
   if x64_enabled:
+    # Map bcomplex32 np.dtype to its ExtendedDType counterpart
+    if dtype_ == _bcomplex32_dtype:
+      return bcomplex32_edtype
     return dtype_
   else:
     return _dtype_to_32bit_dtype.get(dtype_, dtype_)
@@ -449,6 +514,15 @@ python_scalar_types_to_dtypes: dict[type, DType] = {
 def scalar_type_of(x: Any) -> type:
   """Return the scalar type associated with a JAX value."""
   typ = dtype(x)
+  if isinstance(typ, ExtendedDType):
+    if issubdtype(typ, np.complexfloating):
+      return complex
+    elif issubdtype(typ, np.floating):
+      return float
+    elif issubdtype(typ, np.integer):
+      return int
+    else:
+      raise TypeError(f"Invalid scalar value {x}")
   if typ in _custom_float_dtypes:
     return float
   elif typ in _intn_dtypes:
@@ -459,6 +533,8 @@ def scalar_type_of(x: Any) -> type:
     return int
   elif np.issubdtype(typ, np.floating):
     return float
+  elif typ == _bcomplex32_dtype or typ is bcomplex32_edtype:
+    return complex
   elif np.issubdtype(typ, np.complexfloating):
     return complex
   else:
@@ -576,6 +652,8 @@ def _issubdtype_cached(a: type | np.dtype | ExtendedDType,
   # to the normal scalar type hierarchy.
   if a_sctype in _custom_float_scalar_types:
     return b_sctype in {a_sctype, np.floating, np.inexact, np.number, np.generic}
+  if a_sctype == bcomplex32 or a_sctype is bcomplex32_scalar:
+    return b_sctype in {bcomplex32, bcomplex32_scalar, np.complexfloating, np.inexact, np.number, np.generic}
   if a_sctype in [int2, int4] or (int1 is not None and a_sctype == int1):
     return b_sctype in {a_sctype, np.signedinteger, np.integer, np.number, np.generic}
   if a_sctype in [uint2, uint4] or (uint1 is not None and a_sctype == uint1):
@@ -645,7 +723,12 @@ _jax_dtype_set = {
     *_int_types,
     *_float_types,
     *_complex_types,
+    _bcomplex32_dtype,
 }
+
+# bcomplex32_edtype is a valid JAX dtype but is an ExtendedDType, not np.dtype.
+# It's checked separately in issubdtype/check_valid_dtype.
+_jax_dtype_set_with_extended = _jax_dtype_set | {bcomplex32_edtype}
 
 if jaxlib_extension_version >= 465:
   _jax.set_valid_dtypes(_jax_dtype_set)
@@ -718,6 +801,12 @@ def _jax_type(dtype: DType, weak_type: bool) -> JAXType:
       return float
     return type(dtype.type(0).item())
   return dtype
+
+
+def _lattice_result_to_dtype(lattice_type: JAXType) -> DType:
+  """Map a lattice result type back to the appropriate dtype."""
+  return dtype(lattice_type)
+
 
 def _dtype_and_weaktype(value: Any) -> tuple[DType, bool]:
   """Return a (dtype, weak_type) tuple for the given input."""
@@ -980,7 +1069,7 @@ def is_weakly_typed_scalar(x: Any) -> bool:
     return type(x) in python_scalar_types
 
 def check_valid_dtype(dtype: DType) -> None:
-  if dtype not in _jax_dtype_set:
+  if dtype not in _jax_dtype_set_with_extended:
     raise TypeError(f"Dtype {dtype} is not a valid JAX array "
                     "type. Only arrays of numeric types are supported by JAX.")
 
@@ -1041,6 +1130,9 @@ def dtype(x: Any) -> DType:
     # Numpy scalar types, e.g., np.int32, np.float32
     if _issubclass(x, np.generic):
       dt = np.dtype(x)
+      # Map bcomplex32 np.dtype to ExtendedDType
+      if dt == _bcomplex32_dtype:
+        return bcomplex32_edtype
       return _maybe_canonicalize_explicit_dtype(dt, "dtype")
 
   # Python scalar values, e.g., int(3), float(3.14)
@@ -1057,6 +1149,9 @@ def dtype(x: Any) -> DType:
     if dt not in _jax_dtype_set and not issubdtype(dt, extended):
       raise TypeError(f"Value '{x}' with dtype {dt} is not a valid JAX array "
                       "type. Only arrays of numeric types are supported by JAX.")
+    # Map bcomplex32 np.dtype to ExtendedDType
+    if dt == _bcomplex32_dtype:
+      return bcomplex32_edtype
     return _maybe_canonicalize_explicit_dtype(dt, "dtype")
 
   # If x has a dtype attribute, and it's a valid dtype, use it. This avoids
@@ -1077,13 +1172,13 @@ def dtype(x: Any) -> DType:
   return canonicalize_dtype(dt, allow_extended_dtype=True)  # pyrefly: ignore[bad-return]
 
 def lattice_result_type(*args: Any) -> tuple[DType, bool]:
-  dtypes, weak_types = zip(*(_dtype_and_weaktype(arg) for arg in args))
-  if len(dtypes) == 1:
-    out_dtype = dtypes[0]
+  dtypes_list, weak_types = zip(*(_dtype_and_weaktype(arg) for arg in args))
+  if len(dtypes_list) == 1:
+    out_dtype = dtypes_list[0]
     out_weak_type = weak_types[0]
-  elif len(set(dtypes)) == 1 and not all(weak_types):
+  elif len(set(dtypes_list)) == 1 and not all(weak_types):
     # Trivial promotion case. This allows extended dtypes through.
-    out_dtype = dtypes[0]
+    out_dtype = dtypes_list[0]
     out_weak_type = False
   elif all(weak_types) and config.numpy_dtype_promotion.value != config.NumpyDtypePromotion.STRICT:
     # If all inputs are weakly typed, we compute the bound of the strongly-typed
@@ -1092,14 +1187,14 @@ def lattice_result_type(*args: Any) -> tuple[DType, bool]:
     # TODO(jakevdp): explore removing this special case.
     result_type = _least_upper_bound(
         config.numpy_dtype_promotion.value, config.enable_x64.value,
-        *{_jax_type(dtype, False) for dtype in dtypes})
-    out_dtype = dtype(result_type)
+        *{_jax_type(dtype, False) for dtype in dtypes_list})
+    out_dtype = _lattice_result_to_dtype(result_type)
     out_weak_type = True
   else:
     result_type = _least_upper_bound(
         config.numpy_dtype_promotion.value, config.enable_x64.value,
-        *{_jax_type(d, w) for d, w in zip(dtypes, weak_types)})
-    out_dtype = dtype(result_type)
+        *{_jax_type(d, w) for d, w in zip(dtypes_list, weak_types)})
+    out_dtype = _lattice_result_to_dtype(result_type)
     out_weak_type = any(result_type is t for t in _weak_types)
   return out_dtype, (out_dtype != bool_) and out_weak_type
 
@@ -1147,6 +1242,9 @@ def check_and_canonicalize_user_dtype(dtype, fun_name=None) -> DType:
   if isinstance(dtype, type) and (f := _DEFAULT_TYPEMAP.get(dtype)) is not None:
     return f()
   np_dtype = np.dtype(dtype)
+  # Map bcomplex32 np.dtype to its ExtendedDType counterpart
+  if np_dtype == _bcomplex32_dtype:
+    return bcomplex32_edtype
   if np_dtype not in _jax_dtype_set:
     msg = (
         f'JAX only supports number, bool, and string dtypes, got dtype {dtype}'

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4144,7 +4144,11 @@ for t in itertools.chain(
 
 _fixed_dtype = \
     lambda dtype: lambda *args, **kwargs: np.dtype(dtype)
-_complex_basetype = lambda dtype, **kwargs: np.abs(np.zeros((), dtype)).dtype
+
+def _complex_basetype(dtype, **kwargs):
+  if dtype is dtypes.bcomplex32_edtype:
+    return dtypes._bfloat16_dtype
+  return np.abs(np.zeros((), dtype)).dtype
 
 _strip_weak_type = lambda *args, **_: False
 
@@ -4404,7 +4408,7 @@ def _unary_with_accuracy_pp_rule(eqn, context, settings):
 
 _float = {np.floating}
 _complex = {np.complexfloating}
-_complex_elem_types = {np.float32, np.float64}
+_complex_elem_types = {np.dtype(dtypes.bfloat16), np.float32, np.float64}
 _int = {np.integer}
 _bool = {np.bool_}
 _signedint = {np.signedinteger}
@@ -4673,6 +4677,10 @@ def _complex_transpose_rule(t, x, y):
       return [None, _unbroadcast(y.aval, imag(neg(t)))]
 
 def _complex_dtype(dtype, *args, **kwargs):
+  if dtype is dtypes.bcomplex32_edtype:
+    return dtypes.bcomplex32_edtype
+  if np.dtype(dtype) == dtypes._bfloat16_dtype:
+    return dtypes.bcomplex32_edtype
   return (np.zeros((), dtype) + np.zeros((), np.complex64)).dtype
 complex_p = naryop(_complex_dtype, [_complex_elem_types, _complex_elem_types],
                   'complex')
@@ -5363,7 +5371,13 @@ pe.const_fold_rules[convert_element_type_p] = _convert_elt_type_folding_rule
 pe.forwarding_rules[convert_element_type_p] = _convert_elt_type_fwd_rule
 core.pp_eqn_rules[convert_element_type_p] = _convert_elt_type_pp_rule
 
-def _real_dtype(dtype): return np.finfo(dtype).dtype
+def _real_dtype(dtype):
+  if isinstance(dtype, dtypes.ExtendedDType):
+    # bcomplex32_edtype -> bf16
+    if dtype is dtypes.bcomplex32_edtype:
+      return dtypes._bfloat16_dtype
+    raise TypeError(f"No real dtype for extended dtype {dtype}")
+  return np.finfo(dtype).dtype
 
 def _convert_element_type_lower(ctx, operand, *, new_dtype, weak_type,
                                 sharding):
@@ -5808,6 +5822,11 @@ def _dot_general_dtype_rule(lhs, rhs, *, dimension_numbers, precision,
                        check_bit_width=not has_algorithm)
 
 def _bit_width(d):
+  if isinstance(d, dtypes.ExtendedDType):
+    # bcomplex32_edtype is 32 bits total (2 * bf16)
+    if d is dtypes.bcomplex32_edtype:
+      return 32
+    raise TypeError(f"Cannot determine bit width for extended dtype {d}")
   if dtypes.issubdtype(d, np.inexact): return dtypes.finfo(d).bits
   elif dtypes.issubdtype(d, np.integer): return dtypes.iinfo(d).bits
   elif d == np.dtype('bool'): return 1
@@ -9796,3 +9815,8 @@ def _array_reduce_precision_handler(t, x):
     return reduce_precision(x, exponent_bits=finfo.nexp, mantissa_bits=finfo.nmant)
   return x
 remat.reduce_precision_handlers[core.ShapedArray] = _array_reduce_precision_handler
+
+
+# Register bcomplex32 ExtendedDType lowerings.
+from jax._src.lax.lax_bcomplex32 import _register_lowerings as _bcomplex32_register_lowerings
+_bcomplex32_register_lowerings()

--- a/jax/_src/lax/lax_bcomplex32.py
+++ b/jax/_src/lax/lax_bcomplex32.py
@@ -1,0 +1,736 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ExtendedDType support for bcomplex32 (complex<bfloat16>).
+
+bcomplex32 is represented physically as a bfloat16 array with an extra
+trailing dimension of size 2: shape (..., N) -> physical shape (..., N, 2).
+The trailing dim stores [real_part, imaginary_part].
+
+At the MLIR level, bcomplex32 arrays appear as `tensor<...x2xbf16>`,
+which is fully compatible with StableHLO/XLA.
+"""
+
+from __future__ import annotations
+
+
+import numpy as np
+
+from jax._src import core
+from jax._src import dtypes
+from jax._src.interpreters import mlir
+from jax._src.lib.mlir import ir
+from jax._src.lib.mlir.dialects import hlo
+
+_bfloat16_dtype = dtypes._bfloat16_dtype
+_bcomplex32_edtype = dtypes.bcomplex32_edtype
+
+
+# ============================================================
+# BComplex32Rules -- required by ExtendedDType
+# ============================================================
+
+
+class BComplex32Rules:
+  """Rules for bcomplex32 ExtendedDType."""
+
+  # Allow convert_element_type to/from the physical bf16 representation.
+  allow_conversion: bool = True
+
+  @staticmethod
+  def physical_element_aval(dtype):
+    """Physical element: a pair of bf16 values -> ShapedArray((2,), bf16)."""
+    return core.ShapedArray((2,), _bfloat16_dtype)
+
+  @staticmethod
+  def tangent_dtype(dtype):
+    """Tangent dtype for bcomplex32 is bcomplex32 itself (complex tangents)."""
+    return _bcomplex32_edtype
+
+  @staticmethod
+  def result_handler(sticky_device, aval):
+    """Create a result handler for bcomplex32 arrays."""
+    from jax._src.interpreters import pxla
+    from jax._src.lax.lax_bcomplex32_array import BComplex32Array
+
+    phys_aval = core.physical_aval(aval)
+    phys_handler = pxla.local_result_handlers[core.ShapedArray](
+      sticky_device, phys_aval
+    )
+
+    def handler(buf):
+      buf.aval = core.ShapedArray(buf.shape, buf.dtype)
+      return BComplex32Array(aval, buf)
+
+    return phys_handler.wrap(handler)
+
+  @staticmethod
+  def global_sharded_result_handler(aval, out_sharding, committed):
+    """Create a global sharded result handler for bcomplex32 arrays."""
+    from jax._src.interpreters import pxla
+    from jax._src.lax.lax_bcomplex32_array import BComplex32Array
+    from jax._src.sharding_impls import physical_sharding
+
+    phys_aval = core.physical_aval(aval)
+    phys_handler_maker = pxla.global_result_handlers[core.ShapedArray]
+    phys_sharding = physical_sharding(aval, out_sharding)
+    phys_handler = phys_handler_maker(phys_aval, phys_sharding, committed)
+
+    def handler(phys_array):
+      return BComplex32Array(aval, phys_array)
+
+    return phys_handler.wrap(handler)
+
+  @staticmethod
+  def make_sharded_array(aval, sharding, arrays, committed):
+    """Create a sharded bcomplex32 array from physical arrays."""
+    from jax._src.interpreters import pxla
+    from jax._src.lax.lax_bcomplex32_array import BComplex32Array
+    from jax._src.sharding_impls import physical_sharding
+
+    phys_aval = core.physical_aval(aval)
+    phys_handler_maker = pxla.global_result_handlers[core.ShapedArray]
+    phys_sharding = physical_sharding(aval, sharding)
+    phys_handler = phys_handler_maker(phys_aval, phys_sharding, committed)
+    phys_result = phys_handler(arrays)
+    return BComplex32Array(aval, phys_result)
+
+  @staticmethod
+  def device_put_sharded(vals, aval, sharding, devices):
+    """Handle device_put_sharded for bcomplex32."""
+    from jax._src import api
+    from jax._src.lax import lax as lax_module
+
+    physical_buffers = [
+      lax_module.from_edtype_p.bind(v, dtype=_bfloat16_dtype) for v in vals
+    ]
+    physical_result = api.device_put_sharded(physical_buffers, list(devices))
+    return lax_module.to_edtype_p.bind(
+      physical_result, edtype=_bcomplex32_edtype
+    )
+
+  @staticmethod
+  def device_put_replicated(val, aval, sharding, devices):
+    """Handle device_put_replicated for bcomplex32."""
+    from jax._src.interpreters import pxla
+    from jax._src.lax import lax as lax_module
+    from jax._src.sharding_impls import physical_sharding
+
+    physical_buf = lax_module.from_edtype_p.bind(val, dtype=_bfloat16_dtype)
+    phys_aval = core.physical_aval(aval)
+    phys_sharding = physical_sharding(aval, sharding)
+    physical_result = pxla.batched_device_put(
+      phys_aval, phys_sharding, [physical_buf] * len(devices), devices
+    )
+    return lax_module.to_edtype_p.bind(
+      physical_result, edtype=_bcomplex32_edtype
+    )
+
+  @staticmethod
+  def full(shape, fill_value, dtype):
+    """Create a bcomplex32 array filled with `fill_value`."""
+    from jax._src.lax import lax as lax_module
+
+    # Split fill_value into real/imag parts. Must avoid np.asarray because
+    # fill_value may be a Tracer (e.g. under jit), and np.asarray would raise
+    # TracerArrayConversionError.
+    if isinstance(fill_value, complex):
+      re_val, im_val = fill_value.real, fill_value.imag
+    elif hasattr(fill_value, "dtype") and dtypes.issubdtype(
+      fill_value.dtype, np.complexfloating
+    ):
+      re_val = lax_module.real(fill_value)
+      im_val = lax_module.imag(fill_value)
+    elif hasattr(fill_value, "imag") and hasattr(fill_value, "real") and not isinstance(
+      fill_value, (int, float, np.integer, np.floating)
+    ):
+      re_val, im_val = fill_value.real, fill_value.imag
+    else:
+      re_val, im_val = fill_value, 0
+
+    # convert_element_type + broadcast are Tracer-safe (np.asarray is not).
+    re_bf16 = lax_module.convert_element_type(re_val, _bfloat16_dtype)
+    im_bf16 = lax_module.convert_element_type(im_val, _bfloat16_dtype)
+    re_arr = lax_module.broadcast(re_bf16, shape)
+    im_arr = lax_module.broadcast(im_bf16, shape)
+    physical = lax_module.concatenate(
+      [re_arr[..., np.newaxis], im_arr[..., np.newaxis]], dimension=len(shape)
+    )
+    return lax_module.to_edtype_p.bind(physical, edtype=_bcomplex32_edtype)
+
+  @staticmethod
+  def physical_const(val):
+    """Return the physical representation of a bcomplex32 constant."""
+    from jax._src.lax.lax_bcomplex32_array import BComplex32Array
+
+    if isinstance(val, BComplex32Array):
+      return val._base_array
+    return val
+
+  @staticmethod
+  def zero(dtype):
+    """Zero value for bcomplex32: a bf16 scalar zero."""
+    return np.zeros((), _bfloat16_dtype)
+
+  @staticmethod
+  def add(dtype, x, y):
+    """Add two bcomplex32 arrays (used by AD gradient accumulation)."""
+    from jax._src.lax import lax as lax_module
+
+    return lax_module.add(x, y)
+
+
+def ml_dtypes_bfloat16():
+  """Return the bfloat16 numpy dtype, importing ml_dtypes lazily."""
+  import ml_dtypes
+
+  return ml_dtypes.bfloat16
+
+
+# Set the rules on the ExtendedDType singleton
+_bcomplex32_edtype._rules = BComplex32Rules
+
+
+# ============================================================
+# Helper utilities
+# ============================================================
+
+
+def _is_bcomplex32_edtype(dtype):
+  return dtype is _bcomplex32_edtype
+
+
+def _physical_slice_real(ctx, x_physical, logical_shape):
+  """Extract real part from physical bf16 tensor with trailing dim 2.
+
+  x_physical: MLIR value of type tensor<...x2xbf16>
+  Returns: MLIR value of type tensor<...xbf16> (the real part)
+  """
+  rank = len(logical_shape) + 1  # +1 for the trailing dim
+
+  # Build start_indices and limit_indices for the slice
+  start_indices = [0] * rank
+  start_indices[-1] = 0  # Take element 0 (real)
+  limit_indices = list(logical_shape) + [1]  # Slice to get shape (*, 1)
+  strides = [1] * rank
+
+  sliced = hlo.slice(
+    x_physical,
+    start_indices=start_indices,
+    limit_indices=limit_indices,
+    strides=strides,
+  )
+  # Remove the trailing singleton dimension: reshape from (*, 1) to (*)
+  result_type = ir.RankedTensorType.get(logical_shape, ir.BF16Type.get())
+  return hlo.reshape(result_type, sliced)
+
+
+def _physical_slice_imag(ctx, x_physical, logical_shape):
+  """Extract imaginary part from physical bf16 tensor with trailing dim 2."""
+  rank = len(logical_shape) + 1
+
+  start_indices = [0] * rank
+  start_indices[-1] = 1  # Take element 1 (imag)
+  limit_indices = list(logical_shape) + [2]
+  strides = [1] * rank
+
+  sliced = hlo.slice(
+    x_physical,
+    start_indices=start_indices,
+    limit_indices=limit_indices,
+    strides=strides,
+  )
+  # Remove the trailing singleton dimension: reshape from (*, 1) to (*)
+  result_type = ir.RankedTensorType.get(logical_shape, ir.BF16Type.get())
+  return hlo.reshape(result_type, sliced)
+
+
+def _physical_stack_real_imag(ctx, re_physical, im_physical, logical_shape):
+  """Stack real and imag bf16 tensors into a physical bcomplex32 tensor.
+
+  re_physical, im_physical: MLIR values of type tensor<...xbf16>
+  Returns: MLIR value of type tensor<...x2xbf16>
+  """
+  (aval_out,) = ctx.avals_out
+  # Add trailing dimension to each
+  re_shape = list(logical_shape) + [1]
+  im_shape = list(logical_shape) + [1]
+
+  re_type = ir.RankedTensorType.get(re_shape, ir.BF16Type.get())
+  im_type = ir.RankedTensorType.get(im_shape, ir.BF16Type.get())
+
+  re_expanded = hlo.reshape(re_type, re_physical)
+  im_expanded = hlo.reshape(im_type, im_physical)
+
+  # Concatenate along the last dimension
+  return hlo.concatenate(
+    [re_expanded, im_expanded], dimension=len(logical_shape)
+  )
+
+
+# ============================================================
+# Custom lowerings for real_p, imag_p, complex_p with bcomplex32
+# ============================================================
+
+
+def _real_lower_bcomplex32(ctx, x, **kw):
+  """Custom lowering for real_p when input is bcomplex32 ExtendedDType.
+
+  The MLIR input x is the physical bf16 tensor with trailing dim 2.
+  We need to extract element 0 (real part).
+  """
+  (aval_in,) = ctx.avals_in
+  # The physical aval of the input has shape (*logical, 2) and dtype bf16.
+  # But ctx.avals_in has the LOGICAL aval (shape, bcomplex32_edtype).
+  logical_shape = aval_in.shape
+  return [_physical_slice_real(ctx, x, logical_shape)]
+
+
+def _imag_lower_bcomplex32(ctx, x, **kw):
+  """Custom lowering for imag_p when input is bcomplex32 ExtendedDType."""
+  (aval_in,) = ctx.avals_in
+  logical_shape = aval_in.shape
+  return [_physical_slice_imag(ctx, x, logical_shape)]
+
+
+def _complex_lower_bcomplex32(ctx, re, im, **kw):
+  """Custom lowering for complex_p when constructing bcomplex32.
+
+  re, im are bf16 MLIR tensors. We need to stack them into (*shape, 2).
+  """
+  (aval_out,) = ctx.avals_out
+  logical_shape = aval_out.shape
+  return [_physical_stack_real_imag(ctx, re, im, logical_shape)]
+
+
+def _neg_lower_bcomplex32(ctx, x, **kw):
+  """Custom lowering for neg_p on bcomplex32.
+
+  Negate both real and imag in the physical bf16 representation.
+  """
+  (aval_in,) = ctx.avals_in
+  logical_shape = aval_in.shape
+  re = _physical_slice_real(ctx, x, logical_shape)
+  im = _physical_slice_imag(ctx, x, logical_shape)
+  neg_re = hlo.negate(re)
+  neg_im = hlo.negate(im)
+  return [_physical_stack_real_imag(ctx, neg_re, neg_im, logical_shape)]
+
+
+def _conj_lower_bcomplex32(ctx, x, **kw):
+  """Custom lowering for conj_p on bcomplex32: conj(re + im*j) = re - im*j."""
+  (aval_in,) = ctx.avals_in
+  logical_shape = aval_in.shape
+  re = _physical_slice_real(ctx, x, logical_shape)
+  im = _physical_slice_imag(ctx, x, logical_shape)
+  neg_im = hlo.negate(im)
+  return [_physical_stack_real_imag(ctx, re, neg_im, logical_shape)]
+
+
+def _add_lower_bcomplex32(ctx, x, y, **kw):
+  """Custom lowering for add_p on bcomplex32."""
+  # Element-wise addition on physical bf16 pairs works directly.
+  # Since both x and y are physical (*, 2) bf16 tensors, we can just add.
+  # The sharding/broadcast is handled by the generic lowering path.
+  return [hlo.add(x, y)]
+
+
+def _sub_lower_bcomplex32(ctx, x, y, **kw):
+  """Custom lowering for sub_p on bcomplex32."""
+  return [hlo.subtract(x, y)]
+
+
+def _mul_lower_bcomplex32(ctx, x, y, **kw):
+  """Custom lowering for mul_p on bcomplex32.
+
+  Complex multiplication: (a+bi)(c+di) = (ac-bd) + (ad+bc)i
+  x = [..., 0: re_x, ..., 1: im_x]
+  y = [..., 0: re_y, ..., 1: im_y]
+  """
+  aval_in_x, aval_in_y = ctx.avals_in
+  (aval_out,) = ctx.avals_out
+  logical_shape = aval_out.shape
+
+  re_x = _physical_slice_real(ctx, x, logical_shape)
+  im_x = _physical_slice_imag(ctx, x, logical_shape)
+  re_y = _physical_slice_real(ctx, y, logical_shape)
+  im_y = _physical_slice_imag(ctx, y, logical_shape)
+
+  # real = re_x * re_y - im_x * im_y
+  re_part = hlo.subtract(hlo.multiply(re_x, re_y), hlo.multiply(im_x, im_y))
+  # imag = re_x * im_y + im_x * re_y
+  im_part = hlo.add(hlo.multiply(re_x, im_y), hlo.multiply(im_x, re_y))
+
+  return [_physical_stack_real_imag(ctx, re_part, im_part, logical_shape)]
+
+
+def _abs_lower_bcomplex32(ctx, x, **kw):
+  """Custom lowering for abs_p on bcomplex32.
+
+  |a + bi| = sqrt(a^2 + b^2)  computed in bf16.
+  """
+  (aval_in,) = ctx.avals_in
+  logical_shape = aval_in.shape
+  re = _physical_slice_real(ctx, x, logical_shape)
+  im = _physical_slice_imag(ctx, x, logical_shape)
+  re_sq = hlo.multiply(re, re)
+  im_sq = hlo.multiply(im, im)
+  sum_sq = hlo.add(re_sq, im_sq)
+  return [hlo.sqrt(sum_sq)]
+
+
+def _div_lower_bcomplex32(ctx, x, y, **kw):
+  """Custom lowering for div_p on bcomplex32.
+
+  Smith's method: (a+bi)/(c+di) = ((ac+bd) + (bc-ad)i) / (c^2 + d^2)
+  """
+  aval_in_x, aval_in_y = ctx.avals_in
+  (aval_out,) = ctx.avals_out
+  logical_shape = aval_out.shape
+
+  re_x = _physical_slice_real(ctx, x, logical_shape)
+  im_x = _physical_slice_imag(ctx, x, logical_shape)
+  re_y = _physical_slice_real(ctx, y, logical_shape)
+  im_y = _physical_slice_imag(ctx, y, logical_shape)
+
+  # d = c^2 + d^2
+  d = hlo.add(hlo.multiply(re_y, re_y), hlo.multiply(im_y, im_y))
+  # real = (a*c + b*d) / d
+  re_part = hlo.divide(
+    hlo.add(hlo.multiply(re_x, re_y), hlo.multiply(im_x, im_y)), d
+  )
+  # imag = (b*c - a*d) / d
+  im_part = hlo.divide(
+    hlo.subtract(hlo.multiply(im_x, re_y), hlo.multiply(re_x, im_y)), d
+  )
+
+  return [_physical_stack_real_imag(ctx, re_part, im_part, logical_shape)]
+
+
+def _dot_general_lower_bcomplex32(
+  ctx,
+  lhs,
+  rhs,
+  *,
+  dimension_numbers,
+  precision,
+  preferred_element_type,
+  out_sharding,
+  **kw,
+):
+  """Custom lowering for dot_general_p on bcomplex32.
+
+  Decompose complex matmul into 4 real bf16 matmuls:
+    C_re = X_re @ Y_re - X_im @ Y_im
+    C_im = X_re @ Y_im + X_im @ Y_re
+  Each sub-matmul operates on pure bf16 arrays, hitting GPU tensor cores.
+  """
+  from jax._src.lax.lax import precision_attr
+
+  aval_lhs, aval_rhs = ctx.avals_in
+  (aval_out,) = ctx.avals_out
+  logical_shape = aval_out.shape
+
+  # Extract real and imag parts from both lhs and rhs
+  re_lhs = _physical_slice_real(ctx, lhs, aval_lhs.shape)
+  im_lhs = _physical_slice_imag(ctx, lhs, aval_lhs.shape)
+  re_rhs = _physical_slice_real(ctx, rhs, aval_rhs.shape)
+  im_rhs = _physical_slice_imag(ctx, rhs, aval_rhs.shape)
+
+  # Build the dot dimension numbers for real (bf16) arrays.
+  # The logical shape matches, so we reuse the same dimension_numbers.
+  (lhs_contracting, rhs_contracting), (lhs_batch, rhs_batch) = dimension_numbers
+  dot_dnums = hlo.DotDimensionNumbers.get(
+    lhs_batching_dimensions=list(lhs_batch),
+    rhs_batching_dimensions=list(rhs_batch),
+    lhs_contracting_dimensions=list(lhs_contracting),
+    rhs_contracting_dimensions=list(rhs_contracting),
+  )
+
+  # Compute output shape for the real-valued dot products.
+  # The output logical shape may differ from the real-part shape by
+  # having no trailing dim-2, so we derive the real output shape.
+  re_out_shape = logical_shape  # real/imag parts have this shape
+
+  # bf16 accumulation type
+  bf16_type = ir.BF16Type.get()
+  acc_type = ir.RankedTensorType.get(re_out_shape, bf16_type)
+
+  # 4 real matmuls
+  c_re_re = hlo.dot_general(
+    acc_type,
+    re_lhs,
+    re_rhs,
+    dot_dnums,
+    precision_config=precision_attr(precision),
+  )
+  c_im_im = hlo.dot_general(
+    acc_type,
+    im_lhs,
+    im_rhs,
+    dot_dnums,
+    precision_config=precision_attr(precision),
+  )
+  c_re_im = hlo.dot_general(
+    acc_type,
+    re_lhs,
+    im_rhs,
+    dot_dnums,
+    precision_config=precision_attr(precision),
+  )
+  c_im_re = hlo.dot_general(
+    acc_type,
+    im_lhs,
+    re_rhs,
+    dot_dnums,
+    precision_config=precision_attr(precision),
+  )
+
+  # C_re = X_re @ Y_re - X_im @ Y_im
+  c_re = hlo.subtract(c_re_re, c_im_im)
+  # C_im = X_re @ Y_im + X_im @ Y_re
+  c_im = hlo.add(c_re_im, c_im_re)
+
+  return [_physical_stack_real_imag(ctx, c_re, c_im, logical_shape)]
+
+
+def _make_transcendental_lower_bcomplex32(lax_fn_name):
+  """Create a lowering for a transcendental function on bcomplex32.
+
+  Strategy: promote to complex64, compute, demote back.
+  We use mlir.lower_fun which traces through the Python function,
+  producing a jaxpr that uses the already-registered lowerings for
+  real, imag, complex, convert_element_type on bcomplex32.
+  """
+
+  def lower(ctx, x, **kw):
+    def impl(x):
+      from jax._src.lax import lax as lax_mod
+
+      # Extract real/imag as bf16, promote to float32
+      re_bf16 = lax_mod.real(x)
+      im_bf16 = lax_mod.imag(x)
+      re_f32 = lax_mod.convert_element_type(re_bf16, np.float32)
+      im_f32 = lax_mod.convert_element_type(im_bf16, np.float32)
+      # Construct complex64
+      x64 = lax_mod.complex(re_f32, im_f32)
+      # Compute the transcendental
+      result64 = getattr(lax_mod, lax_fn_name)(x64)
+      # Demote back to bf16 and reconstruct bcomplex32
+      re_out = lax_mod.convert_element_type(
+        lax_mod.real(result64), _bfloat16_dtype
+      )
+      im_out = lax_mod.convert_element_type(
+        lax_mod.imag(result64), _bfloat16_dtype
+      )
+      return lax_mod.complex(re_out, im_out)
+
+    return mlir.lower_fun(impl, multiple_results=False)(ctx, x)
+
+  return lower
+
+
+def _register_lowerings():
+  """Register all bcomplex32 custom lowerings.
+
+  This must be called after the primitives are defined in lax.py.
+  We use the mlir_lowering override mechanism.
+  """
+  from jax._src.lax import lax as lax_module
+
+  # Helper to get the original lowering rule function for a primitive.
+  def _get_original_rule(prim):
+    entry = mlir._lowerings.get(prim)
+    return entry.rule if entry is not None else None
+
+  # For real_p: override lowering when input is bcomplex32_edtype
+  original_real_lowering = _get_original_rule(lax_module.real_p)
+
+  def _real_lowering(ctx, x, **kw):
+    (aval_in,) = ctx.avals_in
+    if _is_bcomplex32_edtype(aval_in.dtype):
+      return _real_lower_bcomplex32(ctx, x, **kw)
+    return original_real_lowering(ctx, x, **kw)
+
+  mlir.register_lowering(lax_module.real_p, _real_lowering)
+
+  # For imag_p
+  original_imag_lowering = _get_original_rule(lax_module.imag_p)
+
+  def _imag_lowering(ctx, x, **kw):
+    (aval_in,) = ctx.avals_in
+    if _is_bcomplex32_edtype(aval_in.dtype):
+      return _imag_lower_bcomplex32(ctx, x, **kw)
+    return original_imag_lowering(ctx, x, **kw)
+
+  mlir.register_lowering(lax_module.imag_p, _imag_lowering)
+
+  # For complex_p
+  original_complex_lowering = _get_original_rule(lax_module.complex_p)
+
+  def _complex_lowering(ctx, re, im, **kw):
+    (aval_out,) = ctx.avals_out
+    if _is_bcomplex32_edtype(aval_out.dtype):
+      return _complex_lower_bcomplex32(ctx, re, im, **kw)
+    return original_complex_lowering(ctx, re, im, **kw)
+
+  mlir.register_lowering(lax_module.complex_p, _complex_lowering)
+
+  # For neg_p
+  original_neg_lowering = _get_original_rule(lax_module.neg_p)
+
+  def _neg_lowering(ctx, x, **kw):
+    (aval_in,) = ctx.avals_in
+    if _is_bcomplex32_edtype(aval_in.dtype):
+      return _neg_lower_bcomplex32(ctx, x, **kw)
+    return original_neg_lowering(ctx, x, **kw)
+
+  mlir.register_lowering(lax_module.neg_p, _neg_lowering)
+
+  # For conj_p
+  original_conj_lowering = _get_original_rule(lax_module.conj_p)
+
+  def _conj_lowering(ctx, x, **kw):
+    (aval_in,) = ctx.avals_in
+    if _is_bcomplex32_edtype(aval_in.dtype):
+      return _conj_lower_bcomplex32(ctx, x, **kw)
+    return original_conj_lowering(ctx, x, **kw)
+
+  mlir.register_lowering(lax_module.conj_p, _conj_lowering)
+
+  # For add_p
+  original_add_lowering = _get_original_rule(lax_module.add_p)
+
+  def _add_lowering(ctx, x, y, **kw):
+    avals_in = ctx.avals_in
+    if any(_is_bcomplex32_edtype(a.dtype) for a in avals_in):
+      return _add_lower_bcomplex32(ctx, x, y, **kw)
+    return original_add_lowering(ctx, x, y, **kw)
+
+  mlir.register_lowering(lax_module.add_p, _add_lowering)
+
+  # For sub_p
+  original_sub_lowering = _get_original_rule(lax_module.sub_p)
+
+  def _sub_lowering(ctx, x, y, **kw):
+    avals_in = ctx.avals_in
+    if any(_is_bcomplex32_edtype(a.dtype) for a in avals_in):
+      return _sub_lower_bcomplex32(ctx, x, y, **kw)
+    return original_sub_lowering(ctx, x, y, **kw)
+
+  mlir.register_lowering(lax_module.sub_p, _sub_lowering)
+
+  # For mul_p
+  original_mul_lowering = _get_original_rule(lax_module.mul_p)
+
+  def _mul_lowering(ctx, x, y, **kw):
+    avals_in = ctx.avals_in
+    if any(_is_bcomplex32_edtype(a.dtype) for a in avals_in):
+      return _mul_lower_bcomplex32(ctx, x, y, **kw)
+    return original_mul_lowering(ctx, x, y, **kw)
+
+  mlir.register_lowering(lax_module.mul_p, _mul_lowering)
+
+  # For abs_p
+  original_abs_lowering = _get_original_rule(lax_module.abs_p)
+
+  def _abs_lowering(ctx, x, **kw):
+    (aval_in,) = ctx.avals_in
+    if _is_bcomplex32_edtype(aval_in.dtype):
+      return _abs_lower_bcomplex32(ctx, x, **kw)
+    return original_abs_lowering(ctx, x, **kw)
+
+  mlir.register_lowering(lax_module.abs_p, _abs_lowering)
+
+  # For div_p
+  original_div_lowering = _get_original_rule(lax_module.div_p)
+
+  def _div_lowering(ctx, x, y, **kw):
+    avals_in = ctx.avals_in
+    if any(_is_bcomplex32_edtype(a.dtype) for a in avals_in):
+      return _div_lower_bcomplex32(ctx, x, y, **kw)
+    return original_div_lowering(ctx, x, y, **kw)
+
+  mlir.register_lowering(lax_module.div_p, _div_lowering)
+
+  # For dot_general_p
+  # We need to override both the default and platform-specific lowerings.
+  original_dot_general_lowering = _get_original_rule(lax_module.dot_general_p)
+
+  # Also capture platform-specific original lowerings
+  from jax._src.interpreters import mlir as mlir_mod
+
+  platform_specific_dot_general = {}
+  for plat in ["cpu", "tpu", "gpu", "cuda", "rocm"]:
+    plat_rules = mlir_mod._platform_specific_lowerings.get(plat, {})
+    if lax_module.dot_general_p in plat_rules:
+      platform_specific_dot_general[plat] = plat_rules[
+        lax_module.dot_general_p
+      ].rule
+
+  def _dot_general_lowering_wrapper(ctx, lhs, rhs, **params):
+    avals_in = ctx.avals_in
+    if any(_is_bcomplex32_edtype(a.dtype) for a in avals_in):
+      return _dot_general_lower_bcomplex32(ctx, lhs, rhs, **params)
+    return original_dot_general_lowering(ctx, lhs, rhs, **params)
+
+  def _dot_general_lowering_wrapper_platform(ctx, lhs, rhs, **params):
+    avals_in = ctx.avals_in
+    if any(_is_bcomplex32_edtype(a.dtype) for a in avals_in):
+      return _dot_general_lower_bcomplex32(ctx, lhs, rhs, **params)
+    platform = params.get("platform", "default")
+    orig = platform_specific_dot_general.get(
+      platform,
+      platform_specific_dot_general.get("cpu", original_dot_general_lowering),
+    )
+    return orig(ctx, lhs, rhs, **params)
+
+  mlir.register_lowering(
+    lax_module.dot_general_p, _dot_general_lowering_wrapper
+  )
+  # Also register for CPU and TPU platforms where dot_general has
+  # platform-specific lowerings
+  for plat in platform_specific_dot_general:
+    mlir.register_lowering(
+      lax_module.dot_general_p,
+      _dot_general_lowering_wrapper_platform,
+      platform=plat,
+    )
+
+  # For transcendental unary ops: exp, log, sin, cos, sqrt, tanh
+  transcendental_prims = [
+    ("exp_p", "exp"),
+    ("log_p", "log"),
+    ("sin_p", "sin"),
+    ("cos_p", "cos"),
+    ("sqrt_p", "sqrt"),
+    ("tanh_p", "tanh"),
+  ]
+  for prim_attr, fn_name in transcendental_prims:
+    prim = getattr(lax_module, prim_attr)
+    original_lowering = _get_original_rule(prim)
+    bcomplex32_lower = _make_transcendental_lower_bcomplex32(fn_name)
+
+    def _make_wrapped_lowering(orig, bc32_lower):
+      def wrapped(ctx, x, **kw):
+        (aval_in,) = ctx.avals_in
+        if _is_bcomplex32_edtype(aval_in.dtype):
+          return bc32_lower(ctx, x, **kw)
+        return orig(ctx, x, **kw)
+
+      return wrapped
+
+    mlir.register_lowering(
+      prim, _make_wrapped_lowering(original_lowering, bcomplex32_lower)
+    )

--- a/jax/_src/lax/lax_bcomplex32_array.py
+++ b/jax/_src/lax/lax_bcomplex32_array.py
@@ -1,0 +1,278 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""BComplex32Array: Python wrapper for bcomplex32 extended dtype arrays.
+
+bcomplex32 is physically stored as bfloat16 array with trailing dim of size 2.
+This wrapper provides the logical complex-number view over the physical data.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+from jax._src import basearray
+from jax._src import core
+from jax._src import dtypes
+from jax._src import tree_util
+from jax._src import sharding_impls
+from jax._src.interpreters import pxla
+from jax._src.interpreters import mlir
+
+
+class BComplex32Array(basearray.Array):
+  """Array wrapper for bcomplex32 (complex<bfloat16>) dtype.
+
+  Stores data physically as bfloat16 array with trailing dimension of size 2.
+  The trailing dim holds [real_part, imaginary_part].
+  """
+
+  __slots__ = ["_aval", "_base_array"]
+  __hash__ = None
+  __array_priority__ = 100
+
+  def __init__(self, aval, base_array):
+    assert isinstance(aval, core.ShapedArray), aval
+    assert aval.dtype is dtypes.bcomplex32_edtype, aval.dtype
+    assert not isinstance(base_array, core.Tracer), type(base_array)
+    self._aval = aval
+    self._base_array = base_array
+
+  # --- Logical view properties ---
+
+  @property
+  def aval(self):
+    return self._aval
+
+  @property
+  def dtype(self):
+    return self._aval.dtype
+
+  @property
+  def shape(self):
+    return self._aval.shape
+
+  @property
+  def ndim(self):
+    return len(self._aval.shape)
+
+  @property
+  def size(self):
+    return math.prod(self._aval.shape) if self._aval.shape else 1
+
+  @property
+  def itemsize(self):
+    return 4  # 2 * bfloat16
+
+  @property
+  def nbytes(self):
+    return self.size * self.itemsize
+
+  def __len__(self):
+    if self.ndim == 0:
+      raise TypeError("len() of unsized object")
+    return self.shape[0]
+
+  def __repr__(self):
+    return f"BComplex32Array(shape={self.shape}, dtype={self.dtype})"
+
+  def __iter__(self):
+    if self.ndim == 0:
+      raise TypeError("iteration over a 0-d array")
+    for i in range(self.shape[0]):
+      yield self[i]
+
+  def reshape(self, *args, order="C"):
+    """Reshape the bcomplex32 array via lax.reshape."""
+    from jax._src.lax import lax as lax_mod
+
+    # Normalize shape argument: reshape((2,2)) or reshape(2,2) or reshape(-1)
+    if len(args) == 1 and isinstance(args[0], (tuple, list)):
+      shape = tuple(args[0])
+    else:
+      shape = tuple(int(a) for a in args)
+    # Handle -1 in shape: compute the inferred dimension
+    if -1 in shape:
+      known = 1
+      unknown_idx = None
+      for i, s in enumerate(shape):
+        if s == -1:
+          if unknown_idx is not None:
+            raise ValueError("can only specify one unknown dimension")
+          unknown_idx = i
+        else:
+          known *= s
+      if unknown_idx is not None:
+        total = self.size
+        inferred = total // known
+        shape = shape[:unknown_idx] + (inferred,) + shape[unknown_idx + 1 :]
+    return lax_mod.reshape(self, shape)
+
+  # --- Forward to self._base_array ---
+
+  @property
+  def _device(self):
+    return self._base_array._device
+
+  @property
+  def _committed(self):
+    return self._base_array._committed
+
+  @property
+  def committed(self):
+    return self._base_array.committed
+
+  @property
+  def device(self):
+    return self._base_array.device
+
+  @property
+  def is_fully_addressable(self):
+    return self._base_array.is_fully_addressable
+
+  @property
+  def is_fully_replicated(self):
+    return self._base_array.is_fully_replicated
+
+  def devices(self):
+    return self._base_array.devices()
+
+  def delete(self):
+    self._base_array.delete()
+
+  def is_deleted(self):
+    return self._base_array.is_deleted()
+
+  def on_device_size_in_bytes(self):
+    return self._base_array.on_device_size_in_bytes()
+
+  def block_until_ready(self):
+    _ = self._base_array.block_until_ready()
+    return self
+
+  def copy_to_host_async(self):
+    self._base_array.copy_to_host_async()
+
+  def copy(self):
+    return BComplex32Array(self._aval, self._base_array.copy())
+
+  # --- Defer to extended dtype rules for sharding ---
+
+  @property
+  def sharding(self):
+    phys_sharding = self._base_array.sharding
+    return sharding_impls.logical_sharding(
+      self.shape, self.dtype, phys_sharding
+    )
+
+  def addressable_data(self, index: int):
+    return BComplex32Array(self._aval, self._base_array.addressable_data(index))
+
+  @property
+  def addressable_shards(self):
+    return [
+      type(s)(
+        device=s._device,
+        sharding=s._sharding,
+        global_shape=s._global_shape,
+        data=BComplex32Array(self._aval, s._data),
+      )
+      for s in self._base_array.addressable_shards
+    ]
+
+  @property
+  def global_shards(self):
+    return [
+      type(s)(
+        device=s._device,
+        sharding=s._sharding,
+        global_shape=s._global_shape,
+        data=BComplex32Array(self._aval, s._data),
+      )
+      for s in self._base_array.global_shards
+    ]
+
+
+# ============================================================
+# Registrations
+# ============================================================
+
+
+# Pytree: flatten/unflatten
+def _bcomplex32_flatten(x):
+  return (x._base_array,), x._aval
+
+
+def _bcomplex32_unflatten(aval, children):
+  return BComplex32Array(aval, children[0])
+
+
+tree_util.dispatch_registry.register_node(
+  BComplex32Array, _bcomplex32_flatten, _bcomplex32_unflatten
+)
+
+# Type -> abstract value mapping
+core.pytype_aval_mappings[BComplex32Array] = lambda x: x.aval
+
+# Don't convert to numpy
+dtypes.register_canonicalize_value_handler(BComplex32Array, None)
+
+
+# Shard argument handler (unwrap to physical for dispatch)
+def _bcomplex32_shard_arg_handler(xs, shardings, layouts, copy_semantics):
+  arrs = [x._base_array for x in xs]
+  phys_shardings = [
+    sharding_impls.physical_sharding(x.aval, sharding)
+    for x, sharding in zip(xs, shardings)
+  ]
+  # TODO(yashkatariya): `layouts` should be converted to physical layouts.
+  return pxla.shard_args(phys_shardings, layouts, copy_semantics, arrs)
+
+
+pxla.shard_arg_handlers[BComplex32Array] = _bcomplex32_shard_arg_handler
+
+
+# MLIR constant handler (unwrap to physical)
+def _bcomplex32_constant_handler(val, aval):
+  arr = val._base_array
+  return mlir.get_constant_handler(type(arr))(arr, aval)
+
+
+mlir.register_constant_handler(BComplex32Array, _bcomplex32_constant_handler)
+
+# Operator forwarding: set array operators so that __add__, __mul__, etc.
+# dispatch through JAX's lax_numpy functions which handle ExtendedDType.
+from jax._src.numpy.array_methods import (
+  _array_operators,
+  _set_array_base_attributes,
+)
+
+_set_array_base_attributes(
+  BComplex32Array,
+  include=[
+    *(f"__{op}__" for op in _array_operators),
+  ],
+)
+
+# AD utility: register adder for gradient accumulation
+from jax._src import ad_util
+from jax._src.lax import lax as _lax_module
+
+
+def _bcomplex32_add(x, y):
+  return _lax_module.add(x, y)
+
+
+ad_util.raw_jaxval_adders[BComplex32Array] = _bcomplex32_add

--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -3350,13 +3350,21 @@ def conjugate(x: ArrayLike, /) -> Array:
     Array([2.+1.j, 3.-5.j, 7.-0.j], dtype=complex64)
   """
   x = ensure_arraylike("conjugate", x)
-  return lax.conj(x) if np.iscomplexobj(x) else lax.asarray(x)
+  return lax.conj(x) if np.iscomplexobj(x) or _is_edtype_complex(x) else lax.asarray(x)
 
 
 @export
 def conj(x: ArrayLike, /) -> Array:
   """Alias of :func:`jax.numpy.conjugate`"""
   return conjugate(x)
+
+
+def _is_edtype_complex(val):
+  """Check if val has a complex ExtendedDType (e.g. bcomplex32_edtype)."""
+  try:
+    return isinstance(val.dtype, dtypes.ExtendedDType) and dtypes.issubdtype(val.dtype, np.complexfloating)
+  except (AttributeError, TypeError):
+    return False
 
 
 @export
@@ -3388,7 +3396,7 @@ def imag(val: ArrayLike, /) -> Array:
     Array([ 3., -1.,  0.], dtype=float32)
   """
   val = ensure_arraylike("imag", val)
-  return lax.imag(val) if np.iscomplexobj(val) else lax.full_like(val, 0)
+  return lax.imag(val) if np.iscomplexobj(val) or _is_edtype_complex(val) else lax.full_like(val, 0)
 
 
 @export
@@ -3420,7 +3428,7 @@ def real(val: ArrayLike, /) -> Array:
     Array([ 3.,  4., -0.], dtype=float32)
   """
   val = ensure_arraylike("real", val)
-  return lax.real(val) if np.iscomplexobj(val) else lax.asarray(val)
+  return lax.real(val) if np.iscomplexobj(val) or _is_edtype_complex(val) else lax.asarray(val)
 
 
 @export

--- a/tests/lax_bcomplex32_edtype_test.py
+++ b/tests/lax_bcomplex32_edtype_test.py
@@ -1,0 +1,724 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for bcomplex32 ExtendedDType support in JAX."""
+
+import unittest
+
+import numpy as np
+import ml_dtypes
+
+import jax
+import jax.numpy as jnp
+from jax import lax
+from jax._src import dtypes
+from jax._src import core
+
+jax.config.update("jax_enable_x64", False)
+
+# Reference bf16 and bcomplex32 types
+bf16 = ml_dtypes.bfloat16
+_bfloat16_dtype = dtypes._bfloat16_dtype
+_bcomplex32_edtype = dtypes.bcomplex32_edtype
+
+
+class BComplex32DTypeTest(unittest.TestCase):
+  """Test bcomplex32 ExtendedDType infrastructure."""
+
+  def test_edtype_exists(self):
+    """bcomplex32_edtype is an ExtendedDType singleton."""
+    self.assertIsInstance(_bcomplex32_edtype, dtypes.ExtendedDType)
+    self.assertIs(_bcomplex32_edtype, dtypes.bcomplex32_edtype)
+
+  def test_edtype_properties(self):
+    """Basic properties of bcomplex32_edtype."""
+    self.assertEqual(_bcomplex32_edtype.name, "bcomplex32")
+    self.assertEqual(_bcomplex32_edtype.itemsize, 4)
+    self.assertEqual(repr(_bcomplex32_edtype), "bcomplex32")
+
+  def test_edtype_equality(self):
+    """bcomplex32_edtype equality and hash."""
+    self.assertEqual(_bcomplex32_edtype, _bcomplex32_edtype)
+    self.assertNotEqual(_bcomplex32_edtype, _bfloat16_dtype)
+    # Different instances of the same type should be equal
+    self.assertEqual(hash(_bcomplex32_edtype), hash(dtypes.bcomplex32_edtype))
+
+  def test_issubdtype(self):
+    """issubdtype works correctly for bcomplex32_edtype."""
+    self.assertTrue(dtypes.issubdtype(_bcomplex32_edtype, dtypes.extended))
+    self.assertTrue(
+      dtypes.issubdtype(_bcomplex32_edtype, dtypes.bcomplex32_scalar)
+    )
+    self.assertTrue(dtypes.issubdtype(_bcomplex32_edtype, np.complexfloating))
+    self.assertTrue(dtypes.issubdtype(_bcomplex32_edtype, np.inexact))
+    self.assertTrue(dtypes.issubdtype(_bcomplex32_edtype, np.number))
+    self.assertFalse(dtypes.issubdtype(_bcomplex32_edtype, np.floating))
+    self.assertFalse(dtypes.issubdtype(_bcomplex32_edtype, dtypes.prng_key))
+
+  def test_physical_element_aval(self):
+    """Physical element aval is ShapedArray((2,), bf16)."""
+    rules = _bcomplex32_edtype._rules
+    self.assertIsNotNone(rules)
+    aval = rules.physical_element_aval(_bcomplex32_edtype)
+    self.assertIsInstance(aval, core.ShapedArray)
+    self.assertEqual(aval.shape, (2,))
+    self.assertEqual(aval.dtype, _bfloat16_dtype)
+
+  def test_physical_aval(self):
+    """physical_aval converts logical bcomplex32 to physical bf16."""
+    logical = core.ShapedArray((3, 4), _bcomplex32_edtype)
+    physical = core.physical_aval(logical)
+    self.assertEqual(physical.shape, (3, 4, 2))
+    self.assertEqual(physical.dtype, _bfloat16_dtype)
+
+  def test_tangent_dtype(self):
+    """Tangent dtype for bcomplex32 is bcomplex32 itself (complex tangents)."""
+    rules = _bcomplex32_edtype._rules
+    self.assertIs(rules.tangent_dtype(_bcomplex32_edtype), _bcomplex32_edtype)
+
+  def test_dtype_resolution(self):
+    """dtype() correctly maps bcomplex32 inputs to bcomplex32_edtype."""
+    # From np.dtype
+    dt = dtypes.dtype(np.dtype(ml_dtypes.bcomplex32))
+    self.assertIs(dt, _bcomplex32_edtype)
+
+    # From scalar type
+    dt = dtypes.dtype(ml_dtypes.bcomplex32)
+    self.assertIs(dt, _bcomplex32_edtype)
+
+  def test_check_and_canonicalize_user_dtype(self):
+    """check_and_canonicalize_user_dtype maps bcomplex32 to edtype."""
+    dt = dtypes.check_and_canonicalize_user_dtype(
+      np.dtype(ml_dtypes.bcomplex32)
+    )
+    self.assertIs(dt, _bcomplex32_edtype)
+
+    dt = dtypes.check_and_canonicalize_user_dtype(_bcomplex32_edtype)
+    self.assertIs(dt, _bcomplex32_edtype)
+
+
+class BComplex32ArrayCreationTest(unittest.TestCase):
+  """Test array creation with bcomplex32 ExtendedDType."""
+
+  def test_zeros(self):
+    """Create bcomplex32 zeros array."""
+    x = jnp.zeros(3, dtype=_bcomplex32_edtype)
+    self.assertEqual(x.dtype, _bcomplex32_edtype)
+    self.assertEqual(x.shape, (3,))
+
+  def test_ones(self):
+    """Create bcomplex32 ones array."""
+    x = jnp.ones(3, dtype=_bcomplex32_edtype)
+    self.assertEqual(x.dtype, _bcomplex32_edtype)
+    self.assertEqual(x.shape, (3,))
+
+  def test_full(self):
+    """Create bcomplex32 full array."""
+    x = jnp.full((2, 3), 1.0 + 2.0j, dtype=_bcomplex32_edtype)
+    self.assertEqual(x.dtype, _bcomplex32_edtype)
+    self.assertEqual(x.shape, (2, 3))
+
+  def test_scalar_type_of(self):
+    """scalar_type_of returns complex for bcomplex32."""
+    x = jnp.zeros(1, dtype=_bcomplex32_edtype)
+    self.assertEqual(dtypes.scalar_type_of(x), complex)
+
+  def test_cross_dtype_promotion_blocked(self):
+    """bcomplex32 must not implicitly promote with other dtypes (cf. PRNG keys).
+
+    ExtendedDTypes are kept out of the global type promotion lattice so that
+    cross-dtype operations require explicit decomposition via `lax.real` /
+    `lax.imag`. This preserves the memory advantage of bcomplex32 by
+    preventing silent promotion to complex64.
+    """
+    x = jnp.zeros(2, dtype=_bcomplex32_edtype)
+    with self.assertRaises((TypeError, ValueError)):
+      _ = x + jnp.ones(2, dtype=jnp.complex64)
+    with self.assertRaises((TypeError, ValueError)):
+      _ = x + jnp.ones(2, dtype=jnp.bfloat16)
+    with self.assertRaises((TypeError, ValueError)):
+      _ = x + 1.0  # weak float must not promote
+    with self.assertRaises((TypeError, ValueError)):
+      _ = x + 1j  # weak complex must not promote
+
+  def test_same_dtype_arithmetic_allowed(self):
+    """Same-dtype arithmetic on bcomplex32 must work without promotion."""
+    x = jnp.full((2,), 1.0 + 2.0j, dtype=_bcomplex32_edtype)
+    y = jnp.full((2,), 3.0 + 4.0j, dtype=_bcomplex32_edtype)
+    z = x + y
+    self.assertEqual(z.dtype, _bcomplex32_edtype)
+
+  def test_indexing_and_iteration(self):
+    """Indexing slices the trailing physical dim; iteration yields 0-d arrays."""
+    x = jnp.full((3,), 0.0, dtype=_bcomplex32_edtype)
+    x0 = jnp.full((1,), 1.0 + 10.0j, dtype=_bcomplex32_edtype)
+    x1 = jnp.full((1,), 2.0 + 20.0j, dtype=_bcomplex32_edtype)
+    x2 = jnp.full((1,), 3.0 + 30.0j, dtype=_bcomplex32_edtype)
+    x = lax.concatenate([x0, x1, x2], dimension=0)
+
+    # Indexing
+    self.assertEqual(x[1].dtype, _bcomplex32_edtype)
+    self.assertEqual(x[1].shape, ())
+    self.assertEqual(x[1:].shape, (2,))
+
+    # Iteration yields 0-d bcomplex32 arrays
+    items = list(x)
+    self.assertEqual(len(items), 3)
+    self.assertEqual(items[0].dtype, _bcomplex32_edtype)
+    self.assertEqual(items[0].shape, ())
+    np.testing.assert_allclose(
+      np.array(jnp.real(items[1]), dtype=np.float32),
+      np.array([2.0], dtype=np.float32),
+      rtol=0.02,
+    )
+
+  def test_iter_on_zero_d_raises(self):
+    """Iterating a 0-d bcomplex32 array must raise TypeError."""
+    x = jnp.full((), 1.0 + 2.0j, dtype=_bcomplex32_edtype)
+    with self.assertRaises(TypeError):
+      list(x)
+
+
+class BComplex32OpsTest(unittest.TestCase):
+  """Test basic operations on bcomplex32 arrays."""
+
+  def test_real(self):
+    """Extract real part of bcomplex32 array."""
+    x = jnp.full((2,), 1.0 + 2.0j, dtype=_bcomplex32_edtype)
+    # Override: create with distinct values via separate full calls
+    x0 = jnp.full((1,), 1.0 + 2.0j, dtype=_bcomplex32_edtype)
+    x1 = jnp.full((1,), 3.0 + 4.0j, dtype=_bcomplex32_edtype)
+    from jax._src.lax import lax
+
+    x = lax.concatenate([x0, x1], 0)
+    r = jnp.real(x)
+    self.assertEqual(r.dtype, _bfloat16_dtype)
+    np.testing.assert_allclose(
+      np.array(r, dtype=np.float32),
+      np.array([1.0, 3.0], dtype=np.float32),
+      rtol=0.02,
+    )
+
+  def test_imag(self):
+    """Extract imaginary part of bcomplex32 array."""
+    x0 = jnp.full((1,), 1.0 + 2.0j, dtype=_bcomplex32_edtype)
+    x1 = jnp.full((1,), 3.0 + 4.0j, dtype=_bcomplex32_edtype)
+    from jax._src.lax import lax
+
+    x = lax.concatenate([x0, x1], 0)
+    i = jnp.imag(x)
+    self.assertEqual(i.dtype, _bfloat16_dtype)
+    np.testing.assert_allclose(
+      np.array(i, dtype=np.float32),
+      np.array([2.0, 4.0], dtype=np.float32),
+      rtol=0.02,
+    )
+
+  def test_complex_construction(self):
+    """Construct bcomplex32 from bf16 real and imag."""
+    from jax._src.lax import lax
+
+    re = jnp.array([1.0, 3.0], dtype=_bfloat16_dtype)
+    im = jnp.array([2.0, 4.0], dtype=_bfloat16_dtype)
+    z = lax.complex(re, im)
+    self.assertEqual(z.dtype, _bcomplex32_edtype)
+    self.assertEqual(z.shape, (2,))
+
+  def test_neg(self):
+    """Negate bcomplex32 array."""
+    x = jnp.full((1,), 1.0 + 2.0j, dtype=_bcomplex32_edtype)
+    y = -x
+    self.assertEqual(y.dtype, _bcomplex32_edtype)
+    np.testing.assert_allclose(
+      np.array(jnp.real(y), dtype=np.float32),
+      np.array([-1.0], dtype=np.float32),
+      rtol=0.02,
+    )
+    np.testing.assert_allclose(
+      np.array(jnp.imag(y), dtype=np.float32),
+      np.array([-2.0], dtype=np.float32),
+      rtol=0.02,
+    )
+
+  def test_add(self):
+    """Add two bcomplex32 arrays."""
+    x = jnp.full((1,), 1.0 + 2.0j, dtype=_bcomplex32_edtype)
+    y = jnp.full((1,), 3.0 + 4.0j, dtype=_bcomplex32_edtype)
+    z = x + y
+    self.assertEqual(z.dtype, _bcomplex32_edtype)
+    np.testing.assert_allclose(
+      np.array(jnp.real(z), dtype=np.float32),
+      np.array([4.0], dtype=np.float32),
+      rtol=0.02,
+    )
+    np.testing.assert_allclose(
+      np.array(jnp.imag(z), dtype=np.float32),
+      np.array([6.0], dtype=np.float32),
+      rtol=0.02,
+    )
+
+  def test_sub(self):
+    """Subtract two bcomplex32 arrays."""
+    x = jnp.full((1,), 3.0 + 4.0j, dtype=_bcomplex32_edtype)
+    y = jnp.full((1,), 1.0 + 2.0j, dtype=_bcomplex32_edtype)
+    z = x - y
+    self.assertEqual(z.dtype, _bcomplex32_edtype)
+    np.testing.assert_allclose(
+      np.array(jnp.real(z), dtype=np.float32),
+      np.array([2.0], dtype=np.float32),
+      rtol=0.02,
+    )
+    np.testing.assert_allclose(
+      np.array(jnp.imag(z), dtype=np.float32),
+      np.array([2.0], dtype=np.float32),
+      rtol=0.02,
+    )
+
+  def test_mul(self):
+    """Multiply two bcomplex32 arrays."""
+    # (1+2j) * (3+4j) = 3 + 4j + 6j + 8j^2 = 3 - 8 + 10j = -5 + 10j
+    x = jnp.full((1,), 1.0 + 2.0j, dtype=_bcomplex32_edtype)
+    y = jnp.full((1,), 3.0 + 4.0j, dtype=_bcomplex32_edtype)
+    z = x * y
+    self.assertEqual(z.dtype, _bcomplex32_edtype)
+    np.testing.assert_allclose(
+      np.array(jnp.real(z), dtype=np.float32),
+      np.array([-5.0], dtype=np.float32),
+      rtol=0.1,
+    )
+    np.testing.assert_allclose(
+      np.array(jnp.imag(z), dtype=np.float32),
+      np.array([10.0], dtype=np.float32),
+      rtol=0.1,
+    )
+
+  def test_conj(self):
+    """Conjugate bcomplex32 array."""
+    x = jnp.full((1,), 1.0 + 2.0j, dtype=_bcomplex32_edtype)
+    y = jnp.conj(x)
+    self.assertEqual(y.dtype, _bcomplex32_edtype)
+    np.testing.assert_allclose(
+      np.array(jnp.real(y), dtype=np.float32),
+      np.array([1.0], dtype=np.float32),
+      rtol=0.02,
+    )
+    np.testing.assert_allclose(
+      np.array(jnp.imag(y), dtype=np.float32),
+      np.array([-2.0], dtype=np.float32),
+      rtol=0.02,
+    )
+
+  def test_abs(self):
+    """Absolute value of bcomplex32 array."""
+    x = jnp.full((1,), 3.0 + 4.0j, dtype=_bcomplex32_edtype)
+    y = jnp.abs(x)
+    self.assertEqual(y.dtype, _bfloat16_dtype)
+    np.testing.assert_allclose(
+      np.array(y, dtype=np.float32),
+      np.array([5.0], dtype=np.float32),
+      rtol=0.05,
+    )
+
+
+class BComplex32TypePromotionTest(unittest.TestCase):
+  """Test type promotion with bcomplex32."""
+
+  def test_promote_bf16_bcomplex32(self):
+    """bf16 + bcomplex32 -> bcomplex32 via explicit construction."""
+    # Mixed-type promotion between bf16 and bcomplex32_edtype requires
+    # explicitly constructing the complex value from real bf16 + zero imag.
+    from jax._src.lax import lax as lax_mod
+
+    x_re = jnp.full((1,), 1.0, dtype=_bfloat16_dtype)
+    x = lax_mod.complex(x_re, jnp.zeros_like(x_re))
+    y = jnp.full((1,), 2.0 + 3.0j, dtype=_bcomplex32_edtype)
+    z = x + y
+    self.assertEqual(z.dtype, _bcomplex32_edtype)
+
+  def test_to_complex_dtype(self):
+    """to_complex_dtype maps bf16 to bcomplex32_edtype."""
+    result = dtypes.to_complex_dtype(_bfloat16_dtype)
+    self.assertIs(result, _bcomplex32_edtype)
+
+
+class BComplex32JitTest(unittest.TestCase):
+  """Test JIT compilation with bcomplex32."""
+
+  def test_jit_real(self):
+    """JIT-compiled real extraction."""
+
+    @jax.jit
+    def f(x):
+      return jnp.real(x)
+
+    x = jnp.full((2,), 1.0 + 2.0j, dtype=_bcomplex32_edtype)
+    r = f(x)
+    self.assertEqual(r.dtype, _bfloat16_dtype)
+    np.testing.assert_allclose(
+      np.array(r, dtype=np.float32),
+      np.array([1.0, 1.0], dtype=np.float32),
+      rtol=0.02,
+    )
+
+  def test_jit_add(self):
+    """JIT-compiled addition."""
+
+    @jax.jit
+    def f(x, y):
+      return x + y
+
+    x = jnp.full((1,), 1.0 + 2.0j, dtype=_bcomplex32_edtype)
+    y = jnp.full((1,), 3.0 + 4.0j, dtype=_bcomplex32_edtype)
+    z = f(x, y)
+    self.assertEqual(z.dtype, _bcomplex32_edtype)
+    np.testing.assert_allclose(
+      np.array(jnp.real(z), dtype=np.float32),
+      np.array([4.0], dtype=np.float32),
+      rtol=0.02,
+    )
+
+
+class BComplex32DivTest(unittest.TestCase):
+  """Test division on bcomplex32 arrays."""
+
+  def test_div_basic(self):
+    """Basic complex division: (6+8j) / (3+4j) = 2.0."""
+    from jax._src.lax import lax
+
+    re_x = jnp.array([6.0], dtype=_bfloat16_dtype)
+    im_x = jnp.array([8.0], dtype=_bfloat16_dtype)
+    x = lax.complex(re_x, im_x)
+
+    re_y = jnp.array([3.0], dtype=_bfloat16_dtype)
+    im_y = jnp.array([4.0], dtype=_bfloat16_dtype)
+    y = lax.complex(re_y, im_y)
+
+    z = x / y
+    self.assertEqual(z.dtype, _bcomplex32_edtype)
+    z_re = np.array(jnp.real(z), dtype=np.float32)
+    z_im = np.array(jnp.imag(z), dtype=np.float32)
+    # (6+8j)/(3+4j) = (6*3+8*4 + (8*3-6*4)j) / (9+16) = (50+0j)/25 = 2.0
+    np.testing.assert_allclose(z_re, [2.0], rtol=0.1, atol=0.1)
+    np.testing.assert_allclose(z_im, [0.0], rtol=0.1, atol=0.1)
+
+  def test_div_general(self):
+    """General complex division: (1+2j) / (3+4j)."""
+    from jax._src.lax import lax
+
+    re_x = jnp.array([1.0], dtype=_bfloat16_dtype)
+    im_x = jnp.array([2.0], dtype=_bfloat16_dtype)
+    x = lax.complex(re_x, im_x)
+
+    re_y = jnp.array([3.0], dtype=_bfloat16_dtype)
+    im_y = jnp.array([4.0], dtype=_bfloat16_dtype)
+    y = lax.complex(re_y, im_y)
+
+    z = x / y
+    self.assertEqual(z.dtype, _bcomplex32_edtype)
+    z_re = np.array(jnp.real(z), dtype=np.float32)
+    z_im = np.array(jnp.imag(z), dtype=np.float32)
+    # (1+2j)/(3+4j) = (3+8 + (6-4)j) / (9+16) = (11+2j)/25
+    np.testing.assert_allclose(z_re, [0.44], rtol=0.1, atol=0.1)
+    np.testing.assert_allclose(z_im, [0.08], rtol=0.1, atol=0.1)
+
+  def test_div_jit(self):
+    """JIT-compiled complex division."""
+
+    @jax.jit
+    def f(x, y):
+      return x / y
+
+    from jax._src.lax import lax
+
+    x = lax.complex(
+      jnp.array([6.0], dtype=_bfloat16_dtype),
+      jnp.array([8.0], dtype=_bfloat16_dtype),
+    )
+    y = lax.complex(
+      jnp.array([3.0], dtype=_bfloat16_dtype),
+      jnp.array([4.0], dtype=_bfloat16_dtype),
+    )
+
+    z = f(x, y)
+    z_re = np.array(jnp.real(z), dtype=np.float32)
+    np.testing.assert_allclose(z_re, [2.0], rtol=0.1, atol=0.1)
+
+
+class BComplex32MatmulTest(unittest.TestCase):
+  """Test matrix multiplication with bcomplex32."""
+
+  def _make_bcomplex32_matrix(self, complex64_arr):
+    """Convert a complex64 array to bcomplex32 via lax.complex."""
+    from jax._src.lax import lax
+
+    re_bf16 = jnp.array(complex64_arr.real, dtype=_bfloat16_dtype)
+    im_bf16 = jnp.array(complex64_arr.imag, dtype=_bfloat16_dtype)
+    return lax.complex(re_bf16, im_bf16)
+
+  def _to_complex64(self, bcomplex32_arr):
+    """Convert a bcomplex32 array back to complex64 for comparison."""
+    from jax._src.lax import lax
+
+    return lax.complex(
+      jnp.array(jnp.real(bcomplex32_arr), dtype=jnp.float32),
+      jnp.array(jnp.imag(bcomplex32_arr), dtype=jnp.float32),
+    )
+
+  def test_2x2_matmul(self):
+    """2x2 complex matrix multiplication."""
+    a64 = np.array([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]], dtype=np.complex64)
+    b64 = np.array([[2 + 1j, 4 + 3j], [6 + 5j, 8 + 7j]], dtype=np.complex64)
+    expected = a64 @ b64
+
+    a32 = self._make_bcomplex32_matrix(a64)
+    b32 = self._make_bcomplex32_matrix(b64)
+    result = a32 @ b32
+    result64 = self._to_complex64(result)
+    np.testing.assert_allclose(result64, expected, rtol=0.15, atol=0.15)
+
+  def test_vector_matrix_mul(self):
+    """Vector-matrix multiplication."""
+    a64 = np.array([1 + 2j, 3 + 4j], dtype=np.complex64)
+    b64 = np.array([[2 + 1j, 4 + 3j], [6 + 5j, 8 + 7j]], dtype=np.complex64)
+    expected = a64 @ b64
+
+    a32 = self._make_bcomplex32_matrix(a64)
+    b32 = self._make_bcomplex32_matrix(b64)
+    result = a32 @ b32
+    result64 = self._to_complex64(result)
+    np.testing.assert_allclose(result64, expected, rtol=0.15, atol=0.15)
+
+  def test_matmul_jit(self):
+    """JIT-compiled matmul."""
+
+    @jax.jit
+    def f(a, b):
+      return a @ b
+
+    a64 = np.array([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]], dtype=np.complex64)
+    b64 = np.array([[2 + 1j, 4 + 3j], [6 + 5j, 8 + 7j]], dtype=np.complex64)
+    expected = a64 @ b64
+
+    a32 = self._make_bcomplex32_matrix(a64)
+    b32 = self._make_bcomplex32_matrix(b64)
+    result = f(a32, b32)
+    result64 = self._to_complex64(result)
+    np.testing.assert_allclose(result64, expected, rtol=0.15, atol=0.15)
+
+
+class BComplex32TranscendentalTest(unittest.TestCase):
+  """Test transcendental functions on bcomplex32."""
+
+  def _make_bcomplex32_value(self, re, im):
+    """Create a scalar bcomplex32 value."""
+    from jax._src.lax import lax
+
+    return lax.complex(
+      jnp.array([re], dtype=_bfloat16_dtype),
+      jnp.array([im], dtype=_bfloat16_dtype),
+    )
+
+  def _to_complex64(self, arr):
+    """Convert bcomplex32 to complex64."""
+    from jax._src.lax import lax
+
+    return lax.complex(
+      jnp.array(jnp.real(arr), dtype=jnp.float32),
+      jnp.array(jnp.imag(arr), dtype=jnp.float32),
+    )
+
+  def test_exp(self):
+    """exp of bcomplex32 value."""
+    x = self._make_bcomplex32_value(0.0, 1.0)
+    # exp(i) = cos(1) + i*sin(1) ~ 0.5403 + 0.8415i
+    result = jnp.exp(x)
+    result64 = self._to_complex64(result)
+    expected = np.exp(1j)
+    np.testing.assert_allclose(result64, [expected], rtol=0.1, atol=0.1)
+
+  def test_exp_real(self):
+    """exp of a real-valued bcomplex32."""
+    x = self._make_bcomplex32_value(1.0, 0.0)
+    result = jnp.exp(x)
+    result64 = self._to_complex64(result)
+    np.testing.assert_allclose(result64, [np.exp(1.0)], rtol=0.05, atol=0.05)
+
+  def test_log(self):
+    """log of bcomplex32 value."""
+    # log(1) = 0
+    x = self._make_bcomplex32_value(1.0, 0.0)
+    result = jnp.log(x)
+    result64 = self._to_complex64(result)
+    np.testing.assert_allclose(result64, [0.0], rtol=0.05, atol=0.05)
+
+  def test_log_complex(self):
+    """log of complex bcomplex32 value."""
+    x = self._make_bcomplex32_value(1.0, 1.0)
+    result = jnp.log(x)
+    result64 = self._to_complex64(result)
+    expected = np.log(1.0 + 1.0j)
+    np.testing.assert_allclose(result64, [expected], rtol=0.1, atol=0.1)
+
+  def test_sin(self):
+    """sin of bcomplex32 value."""
+    x = self._make_bcomplex32_value(1.0, 0.0)
+    result = jnp.sin(x)
+    result64 = self._to_complex64(result)
+    np.testing.assert_allclose(result64, [np.sin(1.0)], rtol=0.05, atol=0.05)
+
+  def test_cos(self):
+    """cos of bcomplex32 value."""
+    x = self._make_bcomplex32_value(1.0, 0.0)
+    result = jnp.cos(x)
+    result64 = self._to_complex64(result)
+    np.testing.assert_allclose(result64, [np.cos(1.0)], rtol=0.05, atol=0.05)
+
+  def test_sqrt(self):
+    """sqrt of bcomplex32 value."""
+    x = self._make_bcomplex32_value(4.0, 0.0)
+    result = jnp.sqrt(x)
+    result64 = self._to_complex64(result)
+    np.testing.assert_allclose(result64, [2.0], rtol=0.05, atol=0.05)
+
+  def test_sqrt_complex(self):
+    """sqrt of a complex bcomplex32 value."""
+    x = self._make_bcomplex32_value(-1.0, 0.0)
+    result = jnp.sqrt(x)
+    result64 = self._to_complex64(result)
+    np.testing.assert_allclose(result64, [1j], rtol=0.1, atol=0.1)
+
+  def test_tanh(self):
+    """tanh of bcomplex32 value."""
+    x = self._make_bcomplex32_value(0.0, 0.0)
+    result = jnp.tanh(x)
+    result64 = self._to_complex64(result)
+    np.testing.assert_allclose(result64, [0.0], rtol=0.05, atol=0.05)
+
+  def test_tanh_real(self):
+    """tanh of a real-valued bcomplex32."""
+    x = self._make_bcomplex32_value(1.0, 0.0)
+    result = jnp.tanh(x)
+    result64 = self._to_complex64(result)
+    np.testing.assert_allclose(result64, [np.tanh(1.0)], rtol=0.05, atol=0.05)
+
+  def test_exp_jit(self):
+    """JIT-compiled exp."""
+
+    @jax.jit
+    def f(x):
+      return jnp.exp(x)
+
+    x = self._make_bcomplex32_value(0.0, 1.0)
+    result = f(x)
+    result64 = self._to_complex64(result)
+    expected = np.exp(1j)
+    np.testing.assert_allclose(result64, [expected], rtol=0.1, atol=0.1)
+
+
+class BComplex32AutodiffTest(unittest.TestCase):
+  """Test autodiff (grad, jvp, vjp) with bcomplex32."""
+
+  def test_grad_mul(self):
+    """grad of |x|^2 at x=1+2j matches complex64 behavior."""
+    from jax._src.lax import lax
+
+    def f(x):
+      return lax.real(lax.mul(x, lax.conj(x)))
+
+    # |x|^2 = x * conj(x)
+    # With JAX's grad convention for complex, grad(|x|^2) = 2*conj(x)
+    x = lax.complex(
+      jnp.array(1.0, dtype=_bfloat16_dtype),
+      jnp.array(2.0, dtype=_bfloat16_dtype),
+    )
+    g = jax.grad(f)(x)
+    # grad should be approximately 2*conj(x) = 2-4j (matches complex64 behavior)
+    re_grad = lax.convert_element_type(lax.real(g), np.float32)
+    im_grad = lax.convert_element_type(lax.imag(g), np.float32)
+    np.testing.assert_allclose(re_grad, 2.0, rtol=0.1)
+    np.testing.assert_allclose(im_grad, -4.0, rtol=0.1)
+
+  def test_grad_real_function(self):
+    """grad of Re(x) for complex input matches complex64 behavior."""
+    from jax._src.lax import lax
+
+    def f(x):
+      return lax.real(x)
+
+    x = lax.complex(
+      jnp.array(3.0, dtype=_bfloat16_dtype),
+      jnp.array(4.0, dtype=_bfloat16_dtype),
+    )
+    g = jax.grad(f)(x)
+    # With JAX's grad convention for complex, grad(Re(x)) = 1+0j
+    re_grad = lax.convert_element_type(lax.real(g), np.float32)
+    im_grad = lax.convert_element_type(lax.imag(g), np.float32)
+    np.testing.assert_allclose(re_grad, 1.0, rtol=0.1)
+    np.testing.assert_allclose(im_grad, 0.0, atol=0.1)
+
+  def test_jvp_add(self):
+    """JVP of addition works"""
+    from jax._src.lax import lax
+
+    x = lax.complex(
+      jnp.array([1.0], dtype=_bfloat16_dtype),
+      jnp.array([2.0], dtype=_bfloat16_dtype),
+    )
+    tx = lax.complex(
+      jnp.array([0.1], dtype=_bfloat16_dtype),
+      jnp.array([0.2], dtype=_bfloat16_dtype),
+    )
+    primals, tangents = jax.jvp(lambda x: lax.add(x, x), [x], [tx])
+    self.assertEqual(primals.dtype, _bcomplex32_edtype)
+
+  def test_vjp_matmul(self):
+    """VJP of matmul works with bcomplex32"""
+    from jax._src.lax import lax
+
+    a = lax.complex(
+      jnp.eye(3, dtype=_bfloat16_dtype),
+      jnp.zeros((3, 3), dtype=_bfloat16_dtype),
+    )
+    b = lax.complex(
+      jnp.ones((3, 3), dtype=_bfloat16_dtype),
+      jnp.zeros((3, 3), dtype=_bfloat16_dtype),
+    )
+    _, vjp_fn = jax.vjp(jnp.matmul, a, b)
+    g_out = lax.complex(
+      jnp.ones((3, 3), dtype=_bfloat16_dtype),
+      jnp.zeros((3, 3), dtype=_bfloat16_dtype),
+    )
+    ga, gb = vjp_fn(g_out)
+    self.assertEqual(ga.dtype, _bcomplex32_edtype)
+    self.assertEqual(gb.dtype, _bcomplex32_edtype)
+
+  def test_grad_jit(self):
+    """Grad + JIT works"""
+    from jax._src.lax import lax
+
+    @jax.jit
+    def f(x):
+      return lax.real(lax.mul(x, x))
+
+    x = lax.complex(
+      jnp.array(2.0, dtype=_bfloat16_dtype),
+      jnp.array(0.0, dtype=_bfloat16_dtype),
+    )
+    g = jax.grad(f)(x)
+    re_grad = lax.convert_element_type(lax.real(g), np.float32)
+    np.testing.assert_allclose(re_grad, 4.0, rtol=0.1)  # d/dx(x^2) = 2x = 4
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Description

Adds `bcomplex32` (complex<bfloat16>) as a new ExtendedDType. Physical representation is a `bfloat16` array with a trailing dimension of size 2 holding `[real, imag]`, similar to how JAX represents `key<...>` dtypes.

**Motivation.** Complex bfloat16 enables ~2x memory reduction and bf16 tensor-core acceleration for workloads that need complex arithmetic but tolerate reduced precision (e.g. quantum circuit simulation, ML training).

One might ask why ExtendedDType is needed when `ml_dtypes` already provides `bcomplex32` as a NumPy dtype — the reason is XLA. XLA does not have `complex<bf16>` as an element type, so normal lowering produces `tensor<Nxcomplex<bf16>>` which StableHLO rejects. ExtendedDType rewrites the logical `tensor<Nxbcomplex32>` to physical `tensor<Nx2xbf16>` before it reaches XLA (same approach as PRNG keys, which are uint32 pairs under the hood).

## Status

🚧 Draft. `bcomplex32_edtype` is intentionally kept out of the global type promotion lattice (similar to PRNG keys), so cross-dtype operations require explicit decomposition via `lax.real` / `lax.imag` rather than silent promotion. This is consistent with how other ExtendedDTypes (prng, Pallas fuse dtype) behave in JAX.

CI will fail until `ml_dtypes >= 0.5.5` is released (see Dependencies).

## Implementation

- `jax._src.dtypes._BComplex32DType(ExtendedDType)` — dtype registration, `bcomplex32_edtype` singleton, `to_complex_dtype`.
- `jax._src.lax.lax_bcomplex32.BComplex32Rules` — ExtendedDType rules and primitive lowerings for arithmetic, matmul, transcendentals.
- `jax/_src/lax/lax_bcomplex32_array.BComplex32Array` — Python wrapper modeled after `PRNGKeyArray`.
- Updates to `lax.py`, `ufuncs.py`, `mlir.py`, `api.py` for integration.

**Matmul decomposition.** Complex matmul `C = A @ B` lowers to four real bf16 `dot_general` calls so it runs on bf16 tensor cores:

\`\`\`
C_re = A_re@B_re - A_im@B_im
C_im = A_re@B_im + A_im@B_re
\`\`\`

**Transcendentals.** `exp`, `log`, `sin`, `cos`, `tan`, `sqrt`, etc.
promote to complex64, compute, then demote back. Lossy but correct.

**Autodiff.** Supports `jit`, `grad`, `jvp`, `vjp`.

## Dependencies

This PR depends on `ml_dtypes >= 0.5.5` (unreleased), which adds `bcomplex32` as a NumPy extended dtype. Tracked in [jax-ml/ml_dtypes#355](https://github.com/jax-ml/ml_dtypes/issues/355).

Until `ml_dtypes` ships a release containing bcomplex32, CI will fail to import. Marking as draft until then.

cc @seberg for visibility on the ml_dtypes side.

## Testing

50 new tests in `tests/lax_bcomplex32_edtype_test.py` covering dtype registration, type promotion behavior, casting, array creation, arithmetic, matmul, transcendentals, autodiff, and JIT. All 50 pass against `ml_dtypes @ main`:

\`\`\`
============================= 50 passed in 14.50s =============================
\`\`\`

## Checklist

- [x] Single self-contained commit
- [x] `ruff check` / `ruff format --check` pass on new files
- [x] Tests added and passing
- [x] CLA signed
- [ ] `ml_dtypes >= 0.5.5` released (blocking CI)