### PR TITLE
Make persistent compilation cache support host callbacks

### DIFF
--- a/docs/persistent_compilation_cache.md
+++ b/docs/persistent_compilation_cache.md
@@ -267,11 +267,6 @@ jax.config.update("jax_explain_cache_misses", True)
 
 ## Pitfalls
 
-There are a couple of pitfalls that have currently been discovered:
-
-* Currently the persistent cache doesn't work with function that have host callbacks. In this situation, caching is completely avoided.
-  - This is because the HLO contains a pointer to the callback and changes from run to run even if the computation and compute infrastructure is exactly the same.
-
 * Currently the persistent cache doesn't work with a function that uses primitives that implement their own custom_partitioning.
   - The HLO of the function contains a pointer to the custom_partitioning callback, and leads to different cache keys for the same computation across runs.
   - In this situation, caching still proceeds, but a different key is produced every time, making the cache ineffective.

--- a/jax/_src/cache_key.py
+++ b/jax/_src/cache_key.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import copy
-import enum
 import hashlib
 import io
 import logging
@@ -63,22 +62,13 @@ def custom_hook() -> str:
   return ""
 
 
-class IgnoreCallbacks(enum.IntEnum):
-  # Do not remove any callback pointers from precompiled IR.
-  NO = enum.auto()
-  # Remove all callback pointers from precompiled IR.
-  ALL = enum.auto()
-  # Remove only custom_partitioning callback pointer from precompiled IR.
-  CUSTOM_PARTITIONING = enum.auto()
-
-
 def get(
     module: ir.Module,
     devices: np.ndarray,
     compile_options: xla_client.CompileOptions,
     backend: xla_client.Client,
     compression_algorithm: str = "zstandard",
-    ignore_callbacks: IgnoreCallbacks = IgnoreCallbacks.NO,
+    ignore_custom_partitioning: bool = False,
 ) -> str:
   """Creates a hashed string to use as a key to the compilation cache.
 
@@ -92,8 +82,8 @@ def get(
     backend: description of the platform (e.g., TPU version)
     compression_algorithm: a string representing the compression algorithm used
       for the executable before persisting in the cache
-    ignore_callbacks: whether to remove the all callback pointer from the
-      computation.
+    ignore_custom_partitioning: whether to remove custom_partitioning callback
+      pointers from the computation.
 
   Typical return value example:
    'jit__psum-14ac577cdb2ef6d986078b4054cc9893a9a14a16dbb0d8f37b89167c1f1aacdf'
@@ -102,7 +92,7 @@ def get(
       (
           "computation",
           lambda hash_obj: _hash_computation(
-              hash_obj, module, ignore_callbacks
+              hash_obj, module, ignore_custom_partitioning
           ),
       ),
       (
@@ -167,8 +157,8 @@ def _log_cache_key_hash(hash_obj, last_serialized: str, hashfn):
     )
 
 
-def _remove_callbacks(m: ir.Module, ignore_callbacks: IgnoreCallbacks):
-  """Removes callback pointers from precompiled IR.
+def _remove_custom_partitioning_callbacks(m: ir.Module):
+  """Removes custom_partitioning callback pointers from precompiled IR.
 
   Python function pointers are not deterministic across executions.
   """
@@ -177,35 +167,29 @@ def _remove_callbacks(m: ir.Module, ignore_callbacks: IgnoreCallbacks):
       return ir.WalkResult.ADVANCE
     call_target_name = op.attributes["call_target_name"]
     assert isinstance(call_target_name, ir.StringAttr)
-    if op.name == "stablehlo.custom_call" and (
-        (
-            ignore_callbacks == IgnoreCallbacks.ALL
-            and call_target_name.value.endswith("callback")
-        )
-        or call_target_name.value == "CustomSPMDPartitioning"
+    if (
+        op.name == "stablehlo.custom_call"
+        and call_target_name.value == "CustomSPMDPartitioning"
     ):
       op.attributes["backend_config"] = ir.StringAttr.get("REMOVED")
     return ir.WalkResult.ADVANCE
-
-  if ignore_callbacks == IgnoreCallbacks.NO:
-    return m
 
   m.operation.walk(_update_bc_attribute)
   return m
 
 
-def _serialize_ir(m: ir.Module, ignore_callbacks: IgnoreCallbacks) -> bytes:
+def _serialize_ir(m: ir.Module, ignore_custom_partitioning: bool) -> bytes:
   output = io.BytesIO()
-  if ignore_callbacks != IgnoreCallbacks.NO:
-    m = _remove_callbacks(
-        type_cast(ir.Module, m.operation.clone()), ignore_callbacks
+  if ignore_custom_partitioning:
+    m = _remove_custom_partitioning_callbacks(
+        type_cast(ir.Module, m.operation.clone())
     )
   m.operation.write_bytecode(file=output)
   return output.getvalue()
 
 
 def _canonicalize_ir(
-    m_original: ir.Module, ignore_callbacks: IgnoreCallbacks
+    m_original: ir.Module, ignore_custom_partitioning: bool
 ) -> bytes:
   with m_original.context:
     m = type_cast(ir.Module, m_original.operation.clone())
@@ -213,14 +197,14 @@ def _canonicalize_ir(
         "builtin.module(strip-debuginfo)"
     )
     passes.run(m.operation)
-    return _serialize_ir(m, ignore_callbacks)
+    return _serialize_ir(m, ignore_custom_partitioning)
 
 
-def _hash_computation(hash_obj, module, ignore_callbacks: IgnoreCallbacks):
+def _hash_computation(hash_obj, module, ignore_custom_partitioning: bool):
   if config.compilation_cache_include_metadata_in_key.value:
-    canonical_ir = _serialize_ir(module, ignore_callbacks)
+    canonical_ir = _serialize_ir(module, ignore_custom_partitioning)
   else:
-    canonical_ir = _canonicalize_ir(module, ignore_callbacks)
+    canonical_ir = _canonicalize_ir(module, ignore_custom_partitioning)
   hash_obj.update(canonical_ir)
 
 

--- a/jax/_src/compilation_cache.py
+++ b/jax/_src/compilation_cache.py
@@ -14,8 +14,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 import logging
 import threading
+from typing import Any
 import warnings
 import zlib
 
@@ -322,7 +324,8 @@ def is_executable_in_cache(backend, cache_key: str) -> bool:
 
 
 def get_executable_and_time(
-    cache_key: str, compile_options, backend, executable_devices
+    cache_key: str, compile_options, backend, executable_devices,
+    host_callbacks: Sequence[Any] = (),
 ) -> tuple[xla_client.LoadedExecutable | None, int | None]:
   """Returns the cached executable and its compilation time if present, or None
   otherwise.
@@ -339,7 +342,8 @@ def get_executable_and_time(
   serialized_executable, compile_time = extract_executable_and_time(
       executable_and_time)
   xla_executable_deserialized = backend.deserialize_executable(
-      serialized_executable, executable_devices, compile_options)
+      serialized_executable, executable_devices, compile_options,
+      host_callbacks)
   return xla_executable_deserialized, compile_time
 
 
@@ -404,7 +408,7 @@ def get_cache_key(
     devices: np.ndarray,
     compile_options,
     backend,
-    ignore_callbacks: cache_key.IgnoreCallbacks = cache_key.IgnoreCallbacks.NO,
+    ignore_custom_partitioning: bool = False,
 ) -> str:
   return cache_key.get(
       module,
@@ -412,7 +416,7 @@ def get_cache_key(
       compile_options,
       backend,
       "zstandard" if zstandard is not None else "zlib",
-      ignore_callbacks,
+      ignore_custom_partitioning,
   )
 
 

--- a/jax/_src/compiler.py
+++ b/jax/_src/compiler.py
@@ -25,7 +25,6 @@ from typing import Any
 from collections.abc import Callable
 import warnings
 
-from jax._src import cache_key as cache_key_type
 from jax._src import compilation_cache
 from jax._src import config as config
 from jax._src import distributed
@@ -427,7 +426,8 @@ def compile_or_get_cached(
 
   cache_retrieval_start = time.monotonic()
   retrieved_executable, retrieved_compile_time = _cache_read(
-      module_name, cache_key, compile_options, backend, executable_devices)
+      module_name, cache_key, compile_options, backend, executable_devices,
+      host_callbacks)
   cache_retrieval_time = time.monotonic() - cache_retrieval_start
 
   if retrieved_executable is not None:
@@ -448,9 +448,6 @@ def compile_or_get_cached(
       config.share_binary_between_hosts.value
       and is_multi_process
       and distributed.global_state.client is not None
-      # Host callbacks are currently baked into the HLO module so we can't share
-      # them.
-      and len(host_callbacks) == 0
   ):
     log_persistent_cache_miss(module_name, cache_key)
     return _compile_and_share_module(
@@ -586,10 +583,6 @@ def _get_cache_key(
     override_fdo_profile: bytes | None = None) -> str | None:
   if not compilation_cache.is_cache_used(backend):
     return None
-  if config.remove_custom_partitioning_ptr_from_cache_key.value:
-    ignore_callbacks = cache_key_type.IgnoreCallbacks.CUSTOM_PARTITIONING
-  else:
-    ignore_callbacks = cache_key_type.IgnoreCallbacks.NO
   if override_fdo_profile is not None:
     options = copy.deepcopy(options)
     options.executable_build_options.fdo_profile = override_fdo_profile
@@ -599,7 +592,7 @@ def _get_cache_key(
         devices,
         options,
         backend,
-        ignore_callbacks,
+        config.remove_custom_partitioning_ptr_from_cache_key.value,
     )
   except _jax.JaxRuntimeError as ex:
     logger.error("compile_or_get_cached: unable to generate cache key, "
@@ -630,7 +623,7 @@ def _share_fdo_profiles(
             devices,
             compile_options,
             backend,
-            cache_key_type.IgnoreCallbacks.ALL,
+            ignore_custom_partitioning=True,
         )
         + "_fdo_sync"
     )
@@ -715,7 +708,8 @@ def _compile_and_share_module(
         serialized_executable
     )
     executable = backend.deserialize_executable(
-        serialized_executable, executable_devices, compile_options)
+        serialized_executable, executable_devices, compile_options,
+        host_callbacks)
 
   _compile_and_share_module.modules_cache[cache_key] = executable  # pyrefly: ignore[missing-attribute]
   return executable
@@ -738,9 +732,7 @@ def _compile_and_write_cache(
       backend, computation, executable_devices, compile_options, host_callbacks
   )
   compile_time = time.monotonic() - start_time
-  _cache_write(
-      cache_key, compile_time, module_name, backend, executable, host_callbacks
-  )
+  _cache_write(cache_key, compile_time, module_name, backend, executable)
   return executable
 
 
@@ -769,13 +761,15 @@ def _is_executable_in_cache(backend, cache_key) -> bool:
 def _cache_read(
     module_name: str, cache_key: str, compile_options: xc.CompileOptions,
     backend: xc.Client, executable_devices: xc.DeviceList,
+    host_callbacks: Sequence[Any],
 ) -> tuple[xc.LoadedExecutable | None, int | None]:
   """Looks up the `computation` and it's compilation time in the persistent
   compilation cache repository.
   """
   try:
     return compilation_cache.get_executable_and_time(
-        cache_key, compile_options, backend, executable_devices)
+        cache_key, compile_options, backend, executable_devices,
+        host_callbacks)
   except Exception as ex:
     if _should_raise_persistent_cache_error(ex):
       raise
@@ -788,8 +782,8 @@ def _cache_read(
 def _cache_write(cache_key: str,
                  compile_time_secs: float,
                  module_name: str,
-                 backend: xc.Client, executable: xc.LoadedExecutable,
-                 host_callbacks: Sequence[Any]) -> None:
+                 backend: xc.Client,
+                 executable: xc.LoadedExecutable) -> None:
   """Writes the `serialized_computation` and its compilation time to the
   persistent compilation cache repository.
   """
@@ -802,13 +796,6 @@ def _cache_write(cache_key: str,
   if distributed.global_state.process_id != 0:
     logger.log(log_priority,
                "Not writing persistent cache entry since process_id != 0")
-    return
-
-  if host_callbacks:
-    logger.log(
-        log_priority,
-        "Not writing persistent cache entry for '%s' because it uses host "
-        "callbacks (e.g. from jax.debug.print or breakpoint)", module_name)
     return
 
   min_compile_time = config.persistent_cache_min_compile_time_secs.value

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1750,6 +1750,7 @@ jax_multiplatform_test(
     deps = [
         "//jax/_src:compilation_cache_internal",
         "//jax/_src:compiler",
+        "//jax/experimental",
     ] + py_deps([
         "absl/testing",
         "numpy",

--- a/tests/cache_key_test.py
+++ b/tests/cache_key_test.py
@@ -203,9 +203,8 @@ class CacheKeyTest(jtu.JaxTestCase):
           r'\}'
       )
       with computation.context:
-        updated_module = cache_key._remove_callbacks(
+        updated_module = cache_key._remove_custom_partitioning_callbacks(
             type_cast(ir.Module, computation.operation.clone()),
-            ignore_callbacks=cache_key.IgnoreCallbacks.ALL,
         )
         bcs = [
             match[2]
@@ -223,38 +222,12 @@ class CacheKeyTest(jtu.JaxTestCase):
           devices,
           compile_options,
           backend,
-          ignore_callbacks=cache_key.IgnoreCallbacks.CUSTOM_PARTITIONING,
+          ignore_custom_partitioning=True,
       )
       expected_hash = cache_key.get(
           updated_module, devices, compile_options, backend
       )
       self.assertEqual(expected_hash, hash_without_callback_ptrs)
-
-  @jtu.skip_on_devices("cpu")
-  def test_host_callbacks_ptrs_removed(self):
-    def _host_callback(x, y):
-      jax.debug.print("x={x[0]} y={y[0]}", x=x, y=y)
-
-    computation = (
-        jax.jit(_host_callback)
-        .lower(
-            jax.ShapeDtypeStruct([1024], dtype=jax.numpy.float32),
-            jax.ShapeDtypeStruct([1024], dtype=jax.numpy.float32),
-        )
-        .compiler_ir()
-    )
-    pattern = r'(.*?backend_config\s*=\s*"([^"]*)".*?)'
-    with computation.context:
-      updated_module = cache_key._remove_callbacks(
-          type_cast(ir.Module, computation.operation.clone()),
-          ignore_callbacks=cache_key.IgnoreCallbacks.ALL,
-      )
-      bcs = [
-          match[1]
-          for match in re.findall(pattern, str(updated_module), re.DOTALL)
-      ]
-      for bc in bcs:
-        self.assertEqual(bc, "REMOVED")
 
   def test_different_device_assignment(self):
     computation = jax.jit(lambda x, y: x + y).lower(1, 1).compiler_ir()

--- a/tests/compilation_cache_test.py
+++ b/tests/compilation_cache_test.py
@@ -284,6 +284,53 @@ class CompilationCacheTest(CompilationCacheTestCase):
     self.assertAllClose(f1(3), 3 * 142)
     self.assertEqual(count_cache_items(), 1 + expected_compilations)
 
+  def test_jit_with_host_callback(self):
+    calls = []
+
+    def record(x):
+      calls.append(int(x))
+      return x
+
+    f = jit(lambda x: jax.experimental.io_callback(record, x, x))
+    self.assertCacheMisses(
+    # block_until_ready to make sure callback fires before we check `calls` below
+      lambda: jax.block_until_ready(f(7)),
+      lowering=1, compilation_after_persistent_cache_miss=1)
+    self.assertEqual(count_cache_items(), 1)
+    self.assertEqual(calls, [7])
+
+    # Cache hit with same callback
+    f1 = jit(lambda x: jax.experimental.io_callback(record, x, x))
+    self.assertCacheMisses(
+      lambda: jax.block_until_ready(f1(3)),
+      lowering=1, compilation_after_persistent_cache_miss=0)
+    self.assertEqual(count_cache_items(), 1)
+    self.assertEqual(calls, [7, 3])
+
+    # Cache hit with different callback, same signature
+    def record2(x):
+      calls.append(int(x) + 1)
+      return x
+
+    f2 = jit(lambda x: jax.experimental.io_callback(record2, x, x))
+    self.assertCacheMisses(
+      lambda: jax.block_until_ready(f2(4)),
+      lowering=1, compilation_after_persistent_cache_miss=0)
+    self.assertEqual(count_cache_items(), 1)
+    self.assertEqual(calls, [7, 3, 5])
+
+    # Cache miss with new signature
+    def record3(x):
+      calls.append(int(x))
+      return x, x
+
+    f3 = jit(lambda x: jax.experimental.io_callback(record3, (x, x), x))
+    self.assertCacheMisses(
+      lambda: jax.block_until_ready(f3(8)),
+      lowering=1, compilation_after_persistent_cache_miss=1)
+    self.assertEqual(count_cache_items(), 2)
+    self.assertEqual(calls, [7, 3, 5, 8])
+
   def test_set_cache_dir_after_backends_init(self):
     # This a regression test for #25768
     with config.compilation_cache_dir(None):
@@ -534,37 +581,17 @@ class CompilationCacheTest(CompilationCacheTestCase):
           config.compilation_cache_dir(tmp_dir),
       ):
         # omitting writing to cache because compilation is too fast
-        pure_fn = lambda a: jnp.array(1, dtype=jnp.int32)
         with config.persistent_cache_min_compile_time_secs(1e5):
           with self.assertLogs(level="DEBUG") as log:
-            jit(
-                lambda x: x
-                + jax.pure_callback(
-                    pure_fn, jax.ShapeDtypeStruct((), jnp.int32), x
-                )
-            )(1)
+            jit(lambda x: x + 1)(1)
           msg1 = "Not writing persistent cache entry"
-          msg2 = "because it uses host callbacks"
+          msg2 = "because it took <"
           self.assertTrue(
               msg_exists_in_logs(msg1, log.records, logging.WARNING)
           )
           self.assertTrue(
               msg_exists_in_logs(msg2, log.records, logging.WARNING)
           )
-
-        # omitting writing to cache because host callback is present
-        pure_fn = lambda a: jnp.array(1, dtype=jnp.int32)
-        with self.assertLogs(level="DEBUG") as log:
-          jit(
-              lambda x: x
-              + jax.pure_callback(
-                  pure_fn, jax.ShapeDtypeStruct((), jnp.int32), x
-              )
-          )(1)
-        msg1 = "Not writing persistent cache entry"
-        msg2 = "because it uses host callbacks"
-        self.assertTrue(msg_exists_in_logs(msg1, log.records, logging.WARNING))
-        self.assertTrue(msg_exists_in_logs(msg2, log.records, logging.WARNING))
 
         # omitting writing to cache because binary is too small
         with config.persistent_cache_min_entry_size_bytes(int(1e9)):
@@ -595,18 +622,6 @@ class CompilationCacheTest(CompilationCacheTestCase):
         msg1, msg2 = "Not writing persistent cache entry", "because it took <"
         self.assertFalse(msg_exists_in_logs(msg1, log.records, logging.WARNING))
         self.assertFalse(msg_exists_in_logs(msg2, log.records, logging.WARNING))
-
-      # omitting writing to cache because host callback is present
-      pure_fn = lambda a: jnp.array(1, dtype=jnp.int32)
-      with self.assertLogs(level="DEBUG") as log:
-        jit(
-            lambda x: x
-            + jax.pure_callback(pure_fn, jax.ShapeDtypeStruct((), jnp.int32), x)
-        )(1)
-      msg1 = "Not writing persistent cache entry"
-      msg2 = "because it uses host callbacks"
-      self.assertFalse(msg_exists_in_logs(msg1, log.records, logging.WARNING))
-      self.assertFalse(msg_exists_in_logs(msg2, log.records, logging.WARNING))
 
       # omitting writing to cache because binary is too small
       with config.persistent_cache_min_entry_size_bytes(int(1e9)):


### PR DESCRIPTION
This already mostly worked, since callback function pointers aren't embedded in the HLO or cached executable. This change just fixes the cache to allow callbacks and properly plumb them into cached executables. It also removes the unnecessary logic for scrubbing host callback metadata from the cache key (it still scrubs custom partition pass metadata).

I manually verified that this actually works across processes on CPU and TPU.