### PR TITLE
Fix a Pallas lowering failure when using dynamic indices.

### DIFF
--- a/jax/_src/state/indexing.py
+++ b/jax/_src/state/indexing.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import dataclasses
 import math
 import operator
-from typing import cast, Any, ClassVar, Union
+from typing import cast, Any, ClassVar
 
 from jax._src import core
 from jax._src import pretty_printer as pp
@@ -58,8 +58,8 @@ def _pp_slice(context: core.JaxprPpContext, dim, slc: Slice) -> pp.Doc:
       end_str = "" if end == dim else str(end)
       return pp.text(f"{start_str}:{end_str}")
 
-IntIndexer = Union[int, Array, Any]
-DimIndexer = Union[IntIndexer, Slice]
+IntIndexer = int | Array | Any
+DimIndexer = IntIndexer | Slice
 
 def unpack_ndindexer(indexer: NDIndexer) -> tuple[tuple[bool, ...],
                                                   tuple[Slice, ...],


### PR DESCRIPTION
`indexing.IntIndexer` was defined using `typing.Union`, which in Python 3.11 (JAX's minimum supported version) fails to respect custom `__instancecheck__` hooks (such as the one JAX uses to make tracers appear as `jax.Array` instances). This caused `isinstance(idx, IntIndexer)` to incorrectly return `False` for dynamic index tracers during lowering.

This change redefines `IntIndexer` and `DimIndexer` using the modern `|` union operator, which correctly propagates custom `isinstance` checks at runtime.