### PR TITLE
take_current_trace should leave no trace

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -684,7 +684,7 @@ class Primitive:
     # is called frequently and it's slightly faster to avoid using a context
     # manager object.
     prev_trace = trace_ctx.trace
-    trace_ctx.set_trace(eval_trace)
+    trace_ctx.set_trace(None)
     try:
       return self.bind_with_trace(prev_trace, args, avals, params)
     finally:
@@ -1267,31 +1267,33 @@ class EvalTrace(Trace):
     return self.process_primitive(stage_p, [val], {})
 
   def process_primitive(self, primitive, args, params, /):
-    if config.debug_key_reuse.value:
-      # Import here to avoid circular imports
-      from jax.experimental.key_reuse._core import call_impl_with_key_reuse_checks  # pyrefly: ignore[missing-import]
-      return call_impl_with_key_reuse_checks(primitive, primitive.impl, *args, **params)
-    else:
-      # TODO(dougalm): delete. this shouldn't be necessary
-      args = map(full_lower, args)
-      check_eval_args(args)
-      return primitive.impl(*args, **params)
+    with set_current_trace(self):
+      if config.debug_key_reuse.value:
+        from jax.experimental.key_reuse._core import call_impl_with_key_reuse_checks  # pyrefly: ignore[missing-import]
+        return call_impl_with_key_reuse_checks(primitive, primitive.impl, *args, **params)
+      else:
+        # TODO(dougalm): delete. this shouldn't be necessary
+        args = map(full_lower, args)
+        check_eval_args(args)
+        return primitive.impl(*args, **params)
 
   def process_call(self, primitive, f, tracers, params, /):
-    if config.debug_key_reuse.value:
-      # Import here to avoid circular imports
-      from jax.experimental.key_reuse._core import call_impl_with_key_reuse_checks  # pyrefly: ignore[missing-import]
-      return call_impl_with_key_reuse_checks(primitive, primitive.impl, f, *tracers, **params)
-    else:
-      return primitive.impl(f, *tracers, **params)
+    with set_current_trace(self):
+      if config.debug_key_reuse.value:
+        from jax.experimental.key_reuse._core import call_impl_with_key_reuse_checks  # pyrefly: ignore[missing-import]
+        return call_impl_with_key_reuse_checks(primitive, primitive.impl, f, *tracers, **params)
+      else:
+        return primitive.impl(f, *tracers, **params)
 
   def process_custom_jvp_call(self, primitive, fun, jvp, tracers, /, **_):
     del primitive, jvp, _  # Unused.
-    return fun.call_wrapped(*tracers)
+    with set_current_trace(self):
+      return fun.call_wrapped(*tracers)
 
   def process_custom_vjp_call(self, primitive, fun, fwd, bwd, tracers, /, **_):
     del primitive, fwd, bwd, _  # Unused.
-    return fun.call_wrapped(*tracers)
+    with set_current_trace(self):
+      return fun.call_wrapped(*tracers)
 
   def cur_qdd(self, x):
     return x.cur_qdd()
@@ -1416,8 +1418,10 @@ class TracingContext:
     return axis_env_state.value
 
   def is_top_level(self) -> bool:
-    return (self.trace is eval_trace and
-            self.axis_env is top_axis_env)
+    return self.trace is eval_trace and self.axis_env is top_axis_env
+
+  def is_empty(self) -> bool:
+    return self.trace is None
 
   def set_trace(self, trace):
     trace_state_strong_ref.set_local(trace)
@@ -1435,7 +1439,7 @@ class TakeCurrentTraceContextManager:
 
   def __enter__(self):
     self.prev = trace_ctx.trace
-    trace_ctx.set_trace(eval_trace)
+    trace_ctx.set_trace(None)
     return self.prev
 
   def __exit__(self, exc_type, exc_value, traceback):
@@ -1543,7 +1547,7 @@ def get_axis_env():
 
 
 def trace_state_clean() -> bool:
-  return trace_ctx.is_top_level()
+  return trace_ctx.is_empty() or trace_ctx.is_top_level()
 
 def reset_trace_state() -> bool:
   """Resets the global trace state and returns True if it was already clean."""
@@ -2024,12 +2028,11 @@ class AvalMutableQDD:
   mutable_qdd: MutableQuasiDynamicData
 
 def cur_qdd(x):
-  prev_trace = trace_ctx.trace
-  trace_ctx.set_trace(eval_trace)
-  try:
-    return prev_trace.cur_qdd(x)
-  finally:
-    trace_ctx.set_trace(prev_trace)
+  with take_current_trace() as prev_trace:
+    if prev_trace is None:
+      return x.cur_qdd()
+    else:
+      return prev_trace.cur_qdd(x)
 
 def cur_aval_qdd(x):
   aval = typeof(x)
@@ -3279,7 +3282,8 @@ class CallPrimitive(Primitive):
 
 def call_impl(f: lu.WrappedFun, *args, **params):
   del params  # params parameterize the call primitive, not the function
-  return f.call_wrapped(*args)
+  with set_current_trace(eval_trace):
+    return f.call_wrapped(*args)
 
 call_p: CallPrimitive = CallPrimitive('call')
 call = call_p.bind

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -85,8 +85,7 @@ def jvp(fun: Callable, primals, tangents, has_aux=False, instantiate=True,
   if type(instantiate) is bool:
     instantiate = [instantiate] * len(out_tangents)
   out_tangents = out_tangents.map2(
-      lambda t, inst: instantiate_zeros(t) if inst else t, instantiate
-  )
+      lambda t, inst: instantiate_zeros(t) if inst else t, instantiate)
   auxs = tuple(aux.unflatten() for aux in auxs)
   return out_primals, out_tangents, *auxs
 

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -281,7 +281,7 @@ def _cpp_pjit(fun: Callable, jit_info: PjitInfo):
 
   cpp_cache = (cache
                if ((cache := config.jax_jit_cpp_cache_obj.value) is not None
-                   and core.trace_state_clean())
+                   and core.trace_ctx.is_top_level())
                else _get_cpp_global_cache(cache_key.contains_explicit_attributes))
 
   cpp_pjit_f = _jax.pjit(
@@ -525,7 +525,7 @@ def _trace_for_jit(
       dispatch.log_elapsed_time(
           "Finished tracing {fun_name} for jit in {elapsed_time:.9f} sec",
           fun_name(fun), event=dispatch.JAXPR_TRACE_EVENT)
-      if core.trace_state_clean() else contextlib.nullcontext())
+      if core.trace_ctx.is_top_level() else contextlib.nullcontext())
   with elapsed_time_ctx:
     if ji.use_resource_env:  # pjit
       with (_internal_use_concrete_mesh(ctx_mesh),


### PR DESCRIPTION
This change prevents bugs like the recent one behind #38280, where due to accidentally indenting a bit of zeros-instantiating code the wrong amount, we accidentally allocated real zeros constants even when under a `jit`.

The problem was that when we run `core.take_current_trace` to read the current trace from context, we would replace it with an `EvalTrace`. That was done for expedience when landing stackless/omnitracing. But it meant we might accidentally be in an EvalTrace context even when it didn't make sense (e.g. even under a `jit).

The fix is just to follow the original plan with `take_current_trace`, namely to take the current trace from context without replacement. That is, once we've read the context (e.g. coming from user code), we shouldn't need to leave the context populated. Instead we explicitly re-set the context later when e.g. calling into user code, or when a trace's rules have the convention of being run inside a particular trace. For an example of the latter, we adjust `EvalTrace.process_primitive` so that the impl rules are always run in an `EvalTrace` context.

We had to tweak the `is_top_level` logic for fast paths in pjit.py and elsewhere, but otherwise the changes were minimal.