### PR TITLE
Pallas emit_pipeline raises ValueError on non positive grid values

### DIFF
--- a/jax/_src/pallas/mosaic/pipeline.py
+++ b/jax/_src/pallas/mosaic/pipeline.py
@@ -1846,6 +1846,11 @@ def emit_pipeline(
     no_pipelining: bool = False,
     _explicit_indices: bool = False,
 ):
+  if any(g <= 0 for g in grid if isinstance(g, int)):
+    raise ValueError(
+        f"All elements in the grid must be strictly positive, but got {grid=}"
+    )
+
   if not config.use_emit_pipeline_primitive.value:
     return _emit_pipeline(
         body,

--- a/jax/_src/pallas/mosaic_gpu/pipeline.py
+++ b/jax/_src/pallas/mosaic_gpu/pipeline.py
@@ -251,6 +251,11 @@ def emit_pipeline(
     otherwise it returns None.
   """
 
+  if any(g <= 0 for g in grid if isinstance(g, int)):
+    raise ValueError(
+        f"All elements in the grid must be strictly positive, but got {grid=}"
+    )
+
   in_specs = tuple(map(_downcast_spec, in_specs))
   out_specs = tuple(map(_downcast_spec, out_specs))
   for spec in in_specs:

--- a/tests/pallas/mosaic_gpu_test.py
+++ b/tests/pallas/mosaic_gpu_test.py
@@ -6712,6 +6712,26 @@ class PipelineTest(PallasTest):
     # are never written to.
     np.testing.assert_array_equal(kernel_fn(x)[:, :16], y[:, :16])
 
+  @parameterized.parameters(((0, 2),), ((2, -1),))
+  def test_emit_with_empty_grid(self, grid):
+    def kernel_body(o_smem):
+      o_smem[...] = jnp.zeros((128, 128))
+
+    def kernel(o_gmem):
+      plgpu.emit_pipeline(
+          kernel_body,
+          out_specs=[pl.BlockSpec((128, 128), lambda i, j: (i, j))],
+          grid=grid,
+      )(o_gmem)
+
+    with self.assertRaisesRegex(
+        ValueError, 'All elements in the grid must be strictly positive'
+    ):
+      self.kernel(
+        kernel,
+        out_type=jax.ShapeDtypeStruct((256, 256), jnp.float32),
+      )()
+
   def test_emit_with_no_output(self):
     m, n = 16, 128
 

--- a/tests/pallas/tpu_pallas_pipeline_test.py
+++ b/tests/pallas/tpu_pallas_pipeline_test.py
@@ -115,6 +115,25 @@ class PallasCallPipelineTest(jtu.JaxTestCase):
 
     super().setUp()
 
+  @parameterized.parameters(((0, 2),), ((2, -1),))
+  def test_pipeline_empty_grid(self, grid):
+    def kernel(o_hbm_ref):
+      def body(o_ref):
+        o_ref[...] = jnp.zeros((128, 128))
+
+      pltpu.emit_pipeline(
+          body, grid=grid, out_specs=pl.BlockSpec((128, 128), lambda i, j: (i, j))
+      )(o_hbm_ref)
+
+    with self.assertRaisesRegex(
+        ValueError, 'All elements in the grid must be strictly positive'
+    ):
+      pl.pallas_call(
+        kernel,
+        out_shape=jax.ShapeDtypeStruct((256, 256), jnp.float32),
+        out_specs=pl.BlockSpec(memory_space=pl.ANY),
+      )()
+
   def test_pipeline_without_inputs(self):
     def kernel(o_hbm_ref):
       def body(o_ref):


### PR DESCRIPTION
Description:
With the following code:
```python
  pltpu.emit_pipeline(
      add_body,
      grid=(x_hbm.shape[0] // 128, x_hbm.shape[1] // 128),
```
it may happen that x_hbm input shape can be smaller than 128, the code is executed and gives silently an incorrect result Now with this PR, the execution will raise ValueError
