### PR TITLE
Handle Gumbel ppf endpoint domains

### DIFF
--- a/jax/_src/scipy/stats/gumbel_l.py
+++ b/jax/_src/scipy/stats/gumbel_l.py
@@ -193,10 +193,10 @@ def ppf(p: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   quantile = lax.add(loc, t)
   quantile = jnp.where(
     p == 0,
-    lax.add(loc, lax.mul(scale, _lax_const(p, -np.inf))),
+    loc - np.inf,
     jnp.where(
       p == 1,
-      lax.add(loc, lax.mul(scale, _lax_const(p, np.inf))),
+      loc + np.inf,
       quantile,
     ),
   )

--- a/jax/_src/scipy/stats/gumbel_l.py
+++ b/jax/_src/scipy/stats/gumbel_l.py
@@ -185,13 +185,21 @@ def ppf(p: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
     - :func:`jax.scipy.stats.gumbel_l.sf`
   """
   p, loc, scale = promote_args_inexact("gumbel_l.ppf", p, loc, scale)
-  ok = lax.bitwise_and(lax.gt(p, _lax_const(p, 0)),
-                       lax.lt(p, _lax_const(p, 1)))
+  ok = (scale > 0) & (p >= 0) & (p <= 1)
   # quantile = loc + (scale)*log(-log(1 - p))
   t1 = xlog1py(-1, lax.neg(p))
   # xlogp failed here too, that's why log is used
   t = lax.mul(scale, lax.log(t1))
   quantile = lax.add(loc, t)
+  quantile = jnp.where(
+    p == 0,
+    lax.add(loc, lax.mul(scale, _lax_const(p, -np.inf))),
+    jnp.where(
+      p == 1,
+      lax.add(loc, lax.mul(scale, _lax_const(p, np.inf))),
+      quantile,
+    ),
+  )
   return jnp.where(ok, quantile, np.nan)
 
 

--- a/jax/_src/scipy/stats/gumbel_r.py
+++ b/jax/_src/scipy/stats/gumbel_r.py
@@ -191,10 +191,10 @@ def ppf(p: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   quantile = lax.sub(loc, t)
   quantile = jnp.where(
     p == 0,
-    lax.add(loc, lax.mul(scale, _lax_const(p, -np.inf))),
+    loc - np.inf,
     jnp.where(
       p == 1,
-      lax.add(loc, lax.mul(scale, _lax_const(p, np.inf))),
+      loc + np.inf,
       quantile,
     ),
   )

--- a/jax/_src/scipy/stats/gumbel_r.py
+++ b/jax/_src/scipy/stats/gumbel_r.py
@@ -183,14 +183,21 @@ def ppf(p: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
     - :func:`jax.scipy.stats.gumbel_r.logsf`
   """
   p, loc, scale = promote_args_inexact("gumbel_r.ppf", p, loc, scale)
-  # 0 < p < 1
-  ok = lax.bitwise_and(lax.gt(p, _lax_const(p, 0)),
-                       lax.lt(p, _lax_const(p, 1)))
+  ok = (scale > 0) & (p >= 0) & (p <= 1)
 
   # quantile = loc - (scale)*log(-log(p))
   t1 = xlogy(-1, p)
   t = lax.mul(scale, lax.log(t1))
   quantile = lax.sub(loc, t)
+  quantile = jnp.where(
+    p == 0,
+    lax.add(loc, lax.mul(scale, _lax_const(p, -np.inf))),
+    jnp.where(
+      p == 1,
+      lax.add(loc, lax.mul(scale, _lax_const(p, np.inf))),
+      quantile,
+    ),
+  )
   return jnp.where(ok, quantile, np.nan)
 
 

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -1731,6 +1731,41 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
                               tol=5e-3)
       self._CompileAndCheck(lax_fun, args_maker)
 
+  @jtu.sample_product(
+    dist_name=["gumbel_l", "gumbel_r"],
+    dtype=jtu.dtypes.floating,
+  )
+  def testGumbelPpfDomain(self, dist_name, dtype):
+    p = np.array([np.nan, -1., 0., 0.25, 0.5, 0.75, 1., 2.], dtype)
+    loc = np.array(2., dtype)
+    scale = np.array(3., dtype)
+    scipy_fun = getattr(osp_stats, dist_name).ppf
+    lax_fun = getattr(lsp_stats, dist_name).ppf
+
+    self.assertAllClose(
+      scipy_fun(p, loc, scale), lax_fun(p, loc, scale), check_dtypes=False)
+    self.assertAllClose(
+      scipy_fun(p, loc, scale), jax.jit(lax_fun)(p, loc, scale),
+      check_dtypes=False)
+
+  @jtu.sample_product(
+    dist_name=["gumbel_l", "gumbel_r"],
+    dtype=jtu.dtypes.floating,
+  )
+  def testGumbelPpfInvalidScale(self, dist_name, dtype):
+    p = np.array([0., 0.25, 0.5, 1.], dtype)
+    loc = np.array(2., dtype)
+    scale = np.array([0., -1., np.nan, 0.], dtype)
+    scipy_fun = getattr(osp_stats, dist_name).ppf
+    lax_fun = getattr(lsp_stats, dist_name).ppf
+    with np.errstate(invalid="ignore"):
+      expected = scipy_fun(p, loc, scale)
+
+    self.assertAllClose(
+      expected, lax_fun(p, loc, scale), check_dtypes=False)
+    self.assertAllClose(
+      expected, jax.jit(lax_fun)(p, loc, scale), check_dtypes=False)
+
   @genNamedParametersNArgs(3)
   def testGumbelLSf(self, shapes, dtypes):
     rng = jtu.rand_default(self.rng())


### PR DESCRIPTION
## Summary

Handle closed probability-domain endpoints for `jax.scipy.stats.gumbel_l.ppf` and `gumbel_r.ppf`, and return `nan` for invalid scales.

Addresses the Gumbel `ppf` portion mentioned in #38318.

## Root cause

Both implementations used a strict `0 < p < 1` mask before returning the inverse-CDF formula. That made `p == 0` and `p == 1` return `nan`, while SciPy returns the support endpoints. The same mask also did not enforce the positive-scale domain for `ppf`, unlike the neighboring Gumbel functions.

## Solution

- Accept `0 <= p <= 1` when `scale > 0`
- Return `loc + scale * -inf` for `p == 0`
- Return `loc + scale * inf` for `p == 1`
- Preserve `nan` for out-of-domain probabilities and invalid scales

## Tests

- `python -m pytest tests/scipy_stats_test.py -k "testGumbelPpfDomain or testGumbelPpfInvalidScale" -q`
- `python -m pytest tests/scipy_stats_test.py -k "testGumbelRPpf or testGumbelLPpf" -q`
- `python -m pytest tests/scipy_stats_test.py -k Gumbel -q`
- `python -m ruff check jax/_src/scipy/stats/gumbel_l.py jax/_src/scipy/stats/gumbel_r.py tests/scipy_stats_test.py`
- `git diff --check`