### PR TITLE
Add von Mises-Fisher 1D, 2D, and 3D samplers to random core

### DIFF
--- a/jax/_src/numpy/__init__.py
+++ b/jax/_src/numpy/__init__.py
@@ -189,6 +189,7 @@ from jax._src.numpy.tensor_contractions import (
 
 from jax._src.numpy.ufuncs import (
     abs as abs,
+    arccos as arccos,
     arctan2 as arctan2,
     bitwise_and as bitwise_and,
     cbrt as cbrt,

--- a/jax/_src/random/__init__.py
+++ b/jax/_src/random/__init__.py
@@ -63,6 +63,7 @@ from jax._src.random.core import (
     triangular as triangular,
     truncated_normal as truncated_normal,
     uniform as uniform,
+    vonmises as vonmises,
     wald as wald,
     weibull_min as weibull_min,
     wrap_key_data as wrap_key_data,

--- a/jax/_src/random/__init__.py
+++ b/jax/_src/random/__init__.py
@@ -64,6 +64,7 @@ from jax._src.random.core import (
     truncated_normal as truncated_normal,
     uniform as uniform,
     vonmises as vonmises,
+    vonmises_fisher as vonmises_fisher,
     wald as wald,
     weibull_min as weibull_min,
     wrap_key_data as wrap_key_data,

--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2990,7 +2990,7 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
     )
 
     uniform_sign = 2.0 * binomial(key, jnp.ones_like(kappa), 0.5, dtype=dtype) - 1.0
-    return uniform_sign * jnp.arccos(w_final)
+    return uniform_sign * jnp.arccos(jnp.clip(w_final, -1.0, 1.0))
 
   samples = lax.select(
     kappa < kappa_small,

--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -29,6 +29,8 @@ from jax._src import core
 from jax._src import dispatch
 from jax._src import dtypes
 from jax._src import numpy as jnp
+from jax._src.numpy.einsum import einsum
+from jax._src.numpy.lax_numpy import isclose
 from jax._src.random import prng
 from jax._src.random import threefry2x32
 from jax._src import xla_bridge
@@ -2915,7 +2917,7 @@ def vonmises(key: ArrayLike,
   _check_all_safe_to_cast("vonmises", dtype, kappa)
   return maybe_auto_axes(_vonmises, out_sharding, shape=shape, dtype=dtype)(key, kappa)
 
-@jit(static_argnums=(2, 3))
+#@jit(static_argnums=(2, 3))
 def _vonmises(key, kappa, shape, dtype) -> Array:
   """Sample from von Mises distribution with mean angle 0 and concentration kappa
 
@@ -3003,6 +3005,144 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
   )
 
   return jnp.reshape(samples, shape)
+
+def vonmises_fisher(key: ArrayLike,
+                    mean: RealArray,
+                    kappa: RealArray,
+                    shape: Shape | None = None,
+                    dtype: DTypeLikeFloat | None = None,
+                    *,
+                    out_sharding: NamedSharding | P | None = None) -> Array:
+  r"""Sample von Mises-Fisher random values with given mean direction and concentration parameter.
+
+  The normalized vectors are returned according to the probability density function:
+
+  .. math::
+     f(x;\mu, \kappa) = \frac{\kappa^{k/2-1}}{(2\pi^{k/2} I_{k/2-1}(\kappa)} e^{\kappa \mu^T x}
+
+  where :math:`k` is the dimension, :math:`\mu` is the mean direction (given by ``mean``) and
+  :math:`\kappa` is the concentration parameter (given by ``kappa``).
+
+  Args:
+    key: a PRNG key used as the random key.
+    mean: a mean direction of shape ``(..., k)``, which will be normalized to unit length.
+    kappa: a concentration parameter of shape ``(...,)``.
+    shape: optional, a tuple of nonnegative integers specifying the result
+      batch shape; that is, the prefix of the result shape excluding the last
+      axis. Must be broadcast-compatible with ``mean.shape[:-1]`` and
+      ``kappa.shape``. The default (None) produces a result batch shape by
+      broadcasting together the batch shapes of ``mean`` and ``kappa``.
+    dtype: optional, a float dtype for the returned values (default float64 if
+      jax_enable_x64 is true, otherwise float32).
+    out_sharding: Optional. Specifies how the output array should be sharded
+      across devices in multi-device computation. Can be a
+      :class:`~jax.sharding.NamedSharding`, a :class:`~jax.sharding.PartitionSpec`
+      (``P``), or ``None`` (default). When specified, the output will be sharded
+      according to the given sharding specification. Primarily used in explicit
+      sharding mode.
+      See the `explicit sharding tutorial <https://docs.jax.dev/en/latest/parallel.html>`_
+      for more details.
+
+  Returns:
+    A random array with the specified dtype and shape given by
+    ``shape + mean.shape[-1:]`` if ``shape`` is not None, or else
+    ``broadcast_shapes(mean.shape[:-1], kappa.shape) + mean.shape[-1:]``.
+  """
+  key, _ = _check_prng_key("vonmises_fisher", key)
+  mean, kappa = promote_dtypes_inexact(mean, kappa)
+  if dtype is None:
+    dtype = mean.dtype
+  else:
+    dtype = dtypes.check_and_canonicalize_user_dtype(dtype)
+  if not dtypes.issubdtype(dtype, np.floating):
+    raise ValueError(f"dtype argument to `vonmises_fisher` must be a float "
+                     f"dtype, got {dtype}")
+  if shape is not None:
+    shape = core.canonicalize_shape(shape)
+  out_sharding = canonicalize_sharding_for_samplers(out_sharding, "vonmises_fisher", shape)
+  return maybe_auto_axes(_vonmises_fisher, out_sharding,
+                         shape=shape, dtype=dtype)(key, mean, kappa)
+
+#@jit(static_argnums=(3, 4))
+def _vonmises_fisher(key, mean, kappa, shape, dtype) -> Array:
+  """Sample from von Mises-Fisher distribution with mean direction `mean` and concentration `kappa`.
+
+  1D: Weighted Rademacher distribution
+  2D: Jax transcription of Scipy's implementation, which uses the von Mises distribution
+  3D: Jax transcription of Scipy's implementation, which explicitly references:
+      https://www.mitsuba-renderer.org/~wenzel/files/vmf.pdf
+  4+D: Scipy uses rejection sampling, which is NOT reproduced here.
+  """
+
+  from jax._src.nn.functions import sigmoid  # pyrefly: ignore[missing-import]
+  if not np.ndim(mean) >= 1:
+    msg = "vonmises_fisher requires mean.ndim >= 1, got mean.ndim == {}"
+    raise ValueError(msg.format(np.ndim(mean)))
+  n_dim = mean.shape[-1]
+  if n_dim > 3:
+    msg = "vonmises_fisher is only implemented for 1D, 2D, and 3D spaces, got mean.shape[-1] == {}"
+    raise ValueError(msg.format(n_dim))
+
+  if shape is None:
+    shape = lax.broadcast_shapes(mean.shape[:-1], kappa.shape)
+  else:
+    _check_shape("vonmises_fisher", shape, mean.shape[:-1], kappa.shape)
+  kappa = jnp.broadcast_to(kappa, shape)
+  mean = jnp.broadcast_to(mean, shape + (n_dim,))
+
+  safe_norm_mean = mean / jnp.maximum(jnp.linalg.norm(mean, axis=-1, keepdims=True), 1e-8)
+  with np.errstate(over="ignore"):
+    kappa_small = jnp.array(1e-5).astype(dtype)
+
+  if n_dim == 1:
+    # For 1D, use weighted Rademacher distribution
+    bernoulli_samples = bernoulli(key=key, p=sigmoid(2*kappa[..., None])).astype(dtype)
+    return safe_norm_mean * (2 * bernoulli_samples - 1).astype(dtype)
+
+  def small_kappa_uniform(key, kappa):
+    # For small kappa values, we use a uniform distribution over the n-sphere
+    uniforms = uniform(key, shape + (n_dim,), dtype=dtype)
+    return uniforms / jnp.maximum(jnp.linalg.norm(uniforms, axis=-1, keepdims=True), 1e-8)
+
+  def large_kappa_sample(key, kappa):
+    # Implementation for larger kappa values
+    safe_kappa = jnp.where(kappa < kappa_small, 1.0, kappa).astype(dtype)
+    if n_dim == 2:
+      # For 2D, reduce to the von Mises distribution
+      mean_angle = jnp.arctan2(safe_norm_mean[..., 1], safe_norm_mean[..., 0])
+      angle_samples = vonmises(key, safe_kappa, shape=shape, dtype=dtype) + mean_angle
+      samples = jnp.stack([jnp.cos(angle_samples), jnp.sin(angle_samples)], axis=-1).astype(dtype)
+    elif n_dim == 3:
+      # For 3D, use Wenzel's method, start sampling around [1, 0, 0]
+      x_key, yz_key = _split(key, 2)
+      us = uniform(x_key, shape=shape, dtype=dtype)
+      xs = 1.0 + jnp.log(us + (1.0 - us)*jnp.exp(-2.0*safe_kappa))/safe_kappa
+
+      yz_us = normal(yz_key, shape=shape + (2,), dtype=dtype)
+      uniformcircle = yz_us / jnp.maximum(jnp.linalg.norm(yz_us, axis=-1, keepdims=True), 1e-8)
+      temp = jnp.sqrt(1.0 - jnp.square(xs))
+      samples_aboutx = jnp.stack([xs, temp*uniformcircle[..., 0], temp*uniformcircle[..., 1]], axis=-1).astype(dtype)
+
+      # QR decomposition is used to find the rotation that maps the north pole (1, 0,...,0) to the vector mu.
+      # This rotation is then applied to all samples.
+      base_point = jnp.zeros(shape + (n_dim,), dtype=dtype)
+      base_point = base_point.at[..., 0].set(1.0)
+      embedded = jnp.concatenate([safe_norm_mean[..., None, :], jnp.zeros(shape + (n_dim - 1, n_dim))], axis=-2)
+      rotmatrix, _ = jnp.linalg.qr(embedded.swapaxes(-2, -1))
+      rotsign = (2.0 * jnp.all(isclose((rotmatrix @ base_point[..., None])[..., 0], safe_norm_mean), axis=1, keepdims=True).astype(dtype) - 1.0)
+      samples = (einsum('...ij,...j->...i', rotmatrix, samples_aboutx) * rotsign).astype(dtype)
+    else:
+      # Should never reach
+      samples = jnp.zeros(shape + (n_dim,), dtype=dtype)
+      raise ValueError("vonmises_fisher is only implemented for 1D, 2D, and 3D spaces.")
+
+    return samples
+
+  return lax.select(
+    jnp.broadcast_to(kappa[..., None], mean.shape).astype(dtype) < kappa_small,
+    small_kappa_uniform(key, kappa),
+    large_kappa_sample(key, kappa)
+  )
 
 def wald(key: ArrayLike,
          mean: RealArray,

--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2917,26 +2917,12 @@ def vonmises(key: ArrayLike,
 
 @jit(static_argnums=(2, 3))
 def _vonmises(key, kappa, shape, dtype) -> Array:
-  """Vonmises sampling implementation, with shape and dtype already checked and broadcasted."""
-  kappa = lax.convert_element_type(kappa, dtype)
-  kappa = jnp.broadcast_to(kappa, shape)
-  # split key to match the shape of kappa
-  split_count = math.prod(shape[key.ndim:])
-  keys = key.flatten()
-  keys = vmap(_split, in_axes=(0, None))(keys, split_count)
-  keys = keys.flatten()
-  kappas = kappa.flatten()
-
-  samples = vmap(partial(_vonmises_one, dtype=dtype))(keys, kappas)
-
-  return jnp.reshape(samples, shape)
-
-
-def _vonmises_one(key: Array, kappa: Array, dtype: DTypeLikeFloat):
   """Sample from von Mises distribution with mean angle 0 and concentration kappa
 
   Jax transcription of Numpy's implementation of von Mises sampling, which uses Best and Fisher's algorithm
   """
+  kappa = lax.convert_element_type(kappa, dtype)
+  kappa = jnp.broadcast_to(kappa, shape).flatten()
 
   with np.errstate(over="ignore"):
     kappa_large = jnp.array(1e5).astype(dtype)
@@ -2968,51 +2954,55 @@ def _vonmises_one(key: Array, kappa: Array, dtype: DTypeLikeFloat):
       rho_val = (r_val - jnp.sqrt(2 * r_val)) / (2 * safe_kappa)
       return (1 + rho_val * rho_val) / (2 * rho_val)
     # Use second order Taylor expansion for small kappa
-    s_val = lax_control_flow.cond(
-      safe_kappa < kappa_mid_small, lambda kappa: 1.0 / kappa + kappa, s_val_from_kappa, safe_kappa
+    s_val = lax.select(
+      safe_kappa < kappa_mid_small, 1.0 / kappa + kappa, s_val_from_kappa(safe_kappa)
     )
 
-    def get_yw_vals(state):
-      key, kappa, s_val, *_ = state
+    def body_fn(state):
+      key, accepted, w_out = state
       new_key, zkey, vkey = _split(key, 3)
       z_val = jnp.cos(
         np.pi * uniform(zkey, shape=np.shape(kappa), dtype=dtype)
       )
       w_val = (1 + s_val * z_val) / (s_val + z_val)
-      y_val = kappa * (s_val - w_val)
+      y_val = safe_kappa * (s_val - w_val)
       v_val = uniform(vkey, shape=np.shape(kappa), dtype=dtype)
-      return (new_key, kappa, s_val, y_val, v_val, w_val)
 
-    def yw_cond(state):
-      *_, y_val, v_val, _ = state
       cond1 = y_val * (2.0 - y_val) - v_val >= 0
       cond2 = jnp.log(y_val / v_val) + 1 - y_val >= 0
-      return ~(cond1 | cond2)
+      accept = cond1 | cond2
+      w_out = lax.select(accept, w_val, w_out)
+      accepted |= accept
+      return (new_key, accepted, w_out)
+
+    def cond_fn(state):
+      accepted = state[-2]
+      return (~accepted).any()
 
     *_, w_final = lax_control_flow.while_loop(
-      yw_cond,
-      get_yw_vals,
-      # Set so yw_cond returns True for the first iteration if kappa in range
+      cond_fn,
+      body_fn,
+      # Set so cond_fn returns True for the first iteration if kappa in range
       # jit traces all branches regardless of kappa
       (key,
-       safe_kappa,
-       s_val,
-       jnp.array(0.0), -2.0 * ((safe_kappa < kappa_small) | (safe_kappa > kappa_large) | (s_val == jnp.inf)).astype(dtype) + 1.0,
-       jnp.array(0.0)),
+       (safe_kappa < kappa_small) | (safe_kappa > kappa_large),
+       jnp.zeros_like(kappa)),
     )
 
     uniform_sign = 2.0 * binomial(key, jnp.ones_like(kappa), 0.5, dtype=dtype) - 1.0
     return uniform_sign * jnp.arccos(w_final)
 
-  return lax_control_flow.cond(
+  samples = lax.select(
     kappa < kappa_small,
-    small_kappa_uniform,
-    lambda key, kappa: lax_control_flow.cond(
-      kappa > kappa_large, large_kappa_normal, mid_kappa_sample, key, kappa
-    ),
-    key,
-    kappa,
+    small_kappa_uniform(key, kappa),
+    lax.select(
+      kappa > kappa_large,
+      large_kappa_normal(key, kappa),
+      mid_kappa_sample(key, kappa)
+    )
   )
+
+  return jnp.reshape(samples, shape)
 
 def wald(key: ArrayLike,
          mean: RealArray,

--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2870,11 +2870,11 @@ def _rayleigh(key, scale, shape, dtype) -> Array:
   return ray
 
 def vonmises(key: ArrayLike,
-              kappa: RealArray = np.float32(1),
-              shape: Shape | None = None,
-              dtype: DTypeLikeFloat | None = None,
-              *,
-              out_sharding: NamedSharding | P | None = None) -> Array:
+             kappa: RealArray = 1.0,
+             shape: Shape | None = None,
+             dtype: DTypeLikeFloat | None = None,
+             *,
+             out_sharding: NamedSharding | P | None = None) -> Array:
   r""" Sample 0-mean von Mises random values with given shape and float dtype.
 
   The values are distributed according to the probability density function:
@@ -2909,7 +2909,7 @@ def vonmises(key: ArrayLike,
   dtype = dtypes.check_and_canonicalize_user_dtype(float if dtype is None else dtype)
   if not dtypes.issubdtype(dtype, np.inexact):
     raise ValueError(f"dtype argument to `vonmises` must be a float or complex dtype, "
-                    f"got {dtype}")
+                     f"got {dtype}")
   shape = _check_broadcast_shapes("vonmises", shape, kappa)
   out_sharding = canonicalize_sharding(out_sharding, "vonmises")
   _check_all_safe_to_cast("vonmises", dtype, kappa)
@@ -2932,83 +2932,87 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
   return jnp.reshape(samples, shape)
 
 
-def _vonmises_one(key: Array, kappa: ArrayLike, dtype: DTypeLikeFloat):
-    """Sample from von Mises distribution with mean angle 0 and concentration kappa
+def _vonmises_one(key: Array, kappa: Array, dtype: DTypeLikeFloat):
+  """Sample from von Mises distribution with mean angle 0 and concentration kappa
 
-    Jax transcription of Numpy's implementation of von Mises sampling, which uses Best and Fisher's algorithm
-    """
+  Jax transcription of Numpy's implementation of von Mises sampling, which uses Best and Fisher's algorithm
+  """
 
-    with np.errstate(over="ignore"):
-      kappa_large = jnp.array(1e5).astype(dtype)
-      kappa_small = jnp.array(1e-5).astype(dtype)
-      kappa_mid_small = jnp.array(1e-3).astype(dtype)
+  with np.errstate(over="ignore"):
+    kappa_large = jnp.array(1e5).astype(dtype)
+    kappa_small = jnp.array(1e-5).astype(dtype)
+    kappa_mid_small = jnp.array(1e-3).astype(dtype)
 
-    def small_kappa_uniform(key: Array, kappa: ArrayLike):
-        """For small kappa, the distribution is approximately uniform on [-pi, pi]"""
-        return uniform(
-            key, shape=np.shape(kappa), dtype=dtype, minval=-np.pi, maxval=np.pi
-        )
-
-    def large_kappa_normal(key: Array, kappa: ArrayLike):
-        """For large kappa, the distribution is approximately normal with mean 0 and variance 1/kappa"""
-        safe_kappa = jnp.where(kappa < kappa_large, 1.0, kappa)
-        return jnp.clip(
-            normal(key, shape=np.shape(kappa), dtype=dtype) / jnp.sqrt(safe_kappa),
-            -np.pi,
-            np.pi,
-        )
-
-    def mid_kappa_sample(key: Array, kappa: ArrayLike):
-
-        safe_kappa = jnp.where(kappa < kappa_small, 1.0, kappa)
-
-        def s_val_from_kappa(kappa: ArrayLike):
-            safe_kappa = jnp.where(kappa < kappa_mid_small, 1.0, kappa)
-            r_val = 1 + jnp.sqrt(1 + 4 * safe_kappa * safe_kappa)
-            rho_val = (r_val - jnp.sqrt(2 * r_val)) / (2 * safe_kappa)
-            return (1 + rho_val * rho_val) / (2 * rho_val)
-        # Use second order Taylor expansion for small kappa
-        s_val = lax_control_flow.cond(
-            safe_kappa < kappa_mid_small, lambda kappa: 1.0 / kappa + kappa, s_val_from_kappa, safe_kappa
-        )
-
-        def get_yw_vals(state):
-            key, kappa, s_val, _, _, _ = state
-            new_key, zkey, vkey = _split(key, 3)
-            z_val = jnp.cos(
-                np.pi * uniform(zkey, shape=np.shape(kappa), dtype=dtype)
-            )
-            w_val = (1 + s_val * z_val) / (s_val + z_val)
-            y_val = kappa * (s_val - w_val)
-            v_val = uniform(vkey, shape=np.shape(kappa), dtype=dtype)
-            return (new_key, kappa, s_val, y_val, v_val, w_val)
-
-        def yw_cond(state):
-            _, _, _, y_val, v_val, _ = state
-            cond1 = y_val * (2.0 - y_val) - v_val >= 0
-            cond2 = jnp.log(y_val / v_val) + 1 - y_val >= 0
-            return ~(cond1 | cond2)
-
-        _, _, _, _, _, w_final = lax_control_flow.while_loop(
-            yw_cond,
-            get_yw_vals,
-            # Set so yw_cond returns True for the first iteration if kappa in range
-            # jit traces all branches regardless of kappa
-            (key, safe_kappa, s_val, jnp.array(0.0), -2.0 * ((safe_kappa < kappa_small) | (safe_kappa > kappa_large) | (s_val == jnp.inf)).astype(dtype) + 1.0, jnp.array(0.0)),
-        )
-
-        uniform_sign = 2.0 * binomial(key, jnp.ones_like(kappa), 0.5, dtype=dtype) - 1.0
-        return uniform_sign * jnp.arccos(w_final)
-
-    return lax_control_flow.cond(
-        kappa < kappa_small,
-        small_kappa_uniform,
-        lambda key, kappa: lax_control_flow.cond(
-            kappa > kappa_large, large_kappa_normal, mid_kappa_sample, key, kappa
-        ),
-        key,
-        kappa,
+  def small_kappa_uniform(key: Array, kappa: Array):
+    """For small kappa, the distribution is approximately uniform on [-pi, pi]"""
+    return uniform(
+      key, shape=np.shape(kappa), dtype=dtype, minval=-np.pi, maxval=np.pi
     )
+
+  def large_kappa_normal(key: Array, kappa: Array):
+    """For large kappa, the distribution is approximately normal with mean 0 and variance 1/kappa"""
+    safe_kappa = jnp.where(kappa < kappa_large, 1.0, kappa)
+    return jnp.clip(
+      normal(key, shape=np.shape(kappa), dtype=dtype) / jnp.sqrt(safe_kappa),
+      -np.pi,
+      np.pi,
+    )
+
+  def mid_kappa_sample(key: Array, kappa: Array):
+
+    safe_kappa = jnp.where(kappa < kappa_small, 1.0, kappa)
+
+    def s_val_from_kappa(kappa: Array):
+      safe_kappa = jnp.where(kappa < kappa_mid_small, 1.0, kappa)
+      r_val = 1 + jnp.sqrt(1 + 4 * safe_kappa * safe_kappa)
+      rho_val = (r_val - jnp.sqrt(2 * r_val)) / (2 * safe_kappa)
+      return (1 + rho_val * rho_val) / (2 * rho_val)
+    # Use second order Taylor expansion for small kappa
+    s_val = lax_control_flow.cond(
+      safe_kappa < kappa_mid_small, lambda kappa: 1.0 / kappa + kappa, s_val_from_kappa, safe_kappa
+    )
+
+    def get_yw_vals(state):
+      key, kappa, s_val, *_ = state
+      new_key, zkey, vkey = _split(key, 3)
+      z_val = jnp.cos(
+        np.pi * uniform(zkey, shape=np.shape(kappa), dtype=dtype)
+      )
+      w_val = (1 + s_val * z_val) / (s_val + z_val)
+      y_val = kappa * (s_val - w_val)
+      v_val = uniform(vkey, shape=np.shape(kappa), dtype=dtype)
+      return (new_key, kappa, s_val, y_val, v_val, w_val)
+
+    def yw_cond(state):
+      *_, y_val, v_val, _ = state
+      cond1 = y_val * (2.0 - y_val) - v_val >= 0
+      cond2 = jnp.log(y_val / v_val) + 1 - y_val >= 0
+      return ~(cond1 | cond2)
+
+    *_, w_final = lax_control_flow.while_loop(
+      yw_cond,
+      get_yw_vals,
+      # Set so yw_cond returns True for the first iteration if kappa in range
+      # jit traces all branches regardless of kappa
+      (key,
+       safe_kappa,
+       s_val,
+       jnp.array(0.0), -2.0 * ((safe_kappa < kappa_small) | (safe_kappa > kappa_large) | (s_val == jnp.inf)).astype(dtype) + 1.0,
+       jnp.array(0.0)),
+    )
+
+    uniform_sign = 2.0 * binomial(key, jnp.ones_like(kappa), 0.5, dtype=dtype) - 1.0
+    return uniform_sign * jnp.arccos(w_final)
+
+  return lax_control_flow.cond(
+    kappa < kappa_small,
+    small_kappa_uniform,
+    lambda key, kappa: lax_control_flow.cond(
+      kappa > kappa_large, large_kappa_normal, mid_kappa_sample, key, kappa
+    ),
+    key,
+    kappa,
+  )
 
 def wald(key: ArrayLike,
          mean: RealArray,

--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2869,6 +2869,147 @@ def _rayleigh(key, scale, shape, dtype) -> Array:
   ray = lax.mul(scale, sqrt_u)
   return ray
 
+def vonmises(key: ArrayLike,
+              kappa: RealArray = np.float32(1),
+              shape: Shape | None = None,
+              dtype: DTypeLikeFloat | None = None,
+              *,
+              out_sharding: NamedSharding | P | None = None) -> Array:
+  r""" Sample 0-mean von Mises random values with given shape and float dtype.
+
+  The values are distributed according to the probability density function:
+
+  .. math::
+      f(x) = \frac{1}{2*\pi I_0(\kappa)}\exp\left(\kappa\cos(x)\right)
+
+  on the domain :math:`\pi > x > -\pi`, where :math:`\I_0(x)` is the
+  zero-th order modified Bessel function of the first kind.
+
+  Args:
+    key: a PRNG key used as the random key.
+    kappa: a float or array of floats broadcast-compatible with ``shape`` representing
+      the concentration parameter of the distribution. Default 1.
+    shape: optional, a tuple of nonnegative integers specifying the result
+      shape. The default (None) produces a result shape equal to ``()``.
+    dtype: optional, a float dtype for the returned values (default float64 if
+      jax_enable_x64 is true, otherwise float32).
+    out_sharding: optional, specifies how the output array should be sharded
+      across devices in multi-device computation. Can be a
+      :class:`~jax.sharding.NamedSharding`, a :class:`~jax.sharding.PartitionSpec`
+      (``P``), or ``None`` (default). When specified, the output will be sharded
+      according to the given sharding specification. Primarily used in explicit
+      sharding mode.
+      See the `explicit sharding tutorial <https://docs.jax.dev/en/latest/parallel.html>`_
+      for more details.
+
+  Returns:
+    A random array with the specified dtype and with shape given by ``shape``.
+  """
+  key, _ = _check_prng_key("vonmises", key)
+  dtype = dtypes.check_and_canonicalize_user_dtype(float if dtype is None else dtype)
+  if not dtypes.issubdtype(dtype, np.inexact):
+    raise ValueError(f"dtype argument to `vonmises` must be a float or complex dtype, "
+                    f"got {dtype}")
+  shape = _check_broadcast_shapes("vonmises", shape, kappa)
+  out_sharding = canonicalize_sharding(out_sharding, "vonmises")
+  _check_all_safe_to_cast("vonmises", dtype, kappa)
+  return maybe_auto_axes(_vonmises, out_sharding, shape=shape, dtype=dtype)(key, kappa)
+
+@jit(static_argnums=(2, 3))
+def _vonmises(key, kappa, shape, dtype) -> Array:
+  """Vonmises sampling implementation, with shape and dtype already checked and broadcasted."""
+  kappa = lax.convert_element_type(kappa, dtype)
+  kappa = jnp.broadcast_to(kappa, shape)
+  # split key to match the shape of kappa
+  split_count = math.prod(shape[key.ndim:])
+  keys = key.flatten()
+  keys = vmap(_split, in_axes=(0, None))(keys, split_count)
+  keys = keys.flatten()
+  kappas = kappa.flatten()
+
+  samples = vmap(partial(_vonmises_one, dtype=dtype))(keys, kappas)
+
+  return jnp.reshape(samples, shape)
+
+
+def _vonmises_one(key: Array, kappa: ArrayLike, dtype: DTypeLikeFloat):
+    """Sample from von Mises distribution with mean angle 0 and concentration kappa
+
+    Jax transcription of Numpy's implementation of von Mises sampling, which uses Best and Fisher's algorithm
+    """
+
+    with np.errstate(over="ignore"):
+      kappa_large = jnp.array(1e5).astype(dtype)
+      kappa_small = jnp.array(1e-5).astype(dtype)
+      kappa_mid_small = jnp.array(1e-3).astype(dtype)
+
+    def small_kappa_uniform(key: Array, kappa: ArrayLike):
+        """For small kappa, the distribution is approximately uniform on [-pi, pi]"""
+        return uniform(
+            key, shape=np.shape(kappa), dtype=dtype, minval=-np.pi, maxval=np.pi
+        )
+
+    def large_kappa_normal(key: Array, kappa: ArrayLike):
+        """For large kappa, the distribution is approximately normal with mean 0 and variance 1/kappa"""
+        safe_kappa = jnp.where(kappa < kappa_large, 1.0, kappa)
+        return jnp.clip(
+            normal(key, shape=np.shape(kappa), dtype=dtype) / jnp.sqrt(safe_kappa),
+            -np.pi,
+            np.pi,
+        )
+
+    def mid_kappa_sample(key: Array, kappa: ArrayLike):
+
+        safe_kappa = jnp.where(kappa < kappa_small, 1.0, kappa)
+
+        def s_val_from_kappa(kappa: ArrayLike):
+            safe_kappa = jnp.where(kappa < kappa_mid_small, 1.0, kappa)
+            r_val = 1 + jnp.sqrt(1 + 4 * safe_kappa * safe_kappa)
+            rho_val = (r_val - jnp.sqrt(2 * r_val)) / (2 * safe_kappa)
+            return (1 + rho_val * rho_val) / (2 * rho_val)
+        # Use second order Taylor expansion for small kappa
+        s_val = lax_control_flow.cond(
+            safe_kappa < kappa_mid_small, lambda kappa: 1.0 / kappa + kappa, s_val_from_kappa, safe_kappa
+        )
+
+        def get_yw_vals(state):
+            key, kappa, s_val, _, _, _ = state
+            new_key, zkey, vkey = _split(key, 3)
+            z_val = jnp.cos(
+                np.pi * uniform(zkey, shape=np.shape(kappa), dtype=dtype)
+            )
+            w_val = (1 + s_val * z_val) / (s_val + z_val)
+            y_val = kappa * (s_val - w_val)
+            v_val = uniform(vkey, shape=np.shape(kappa), dtype=dtype)
+            return (new_key, kappa, s_val, y_val, v_val, w_val)
+
+        def yw_cond(state):
+            _, _, _, y_val, v_val, _ = state
+            cond1 = y_val * (2.0 - y_val) - v_val >= 0
+            cond2 = jnp.log(y_val / v_val) + 1 - y_val >= 0
+            return ~(cond1 | cond2)
+
+        _, _, _, _, _, w_final = lax_control_flow.while_loop(
+            yw_cond,
+            get_yw_vals,
+            # Set so yw_cond returns True for the first iteration if kappa in range
+            # jit traces all branches regardless of kappa
+            (key, safe_kappa, s_val, jnp.array(0.0), -2.0 * ((safe_kappa < kappa_small) | (safe_kappa > kappa_large) | (s_val == jnp.inf)).astype(dtype) + 1.0, jnp.array(0.0)),
+        )
+
+        uniform_sign = 2.0 * binomial(key, jnp.ones_like(kappa), 0.5, dtype=dtype) - 1.0
+        return uniform_sign * jnp.arccos(w_final)
+
+    return lax_control_flow.cond(
+        kappa < kappa_small,
+        small_kappa_uniform,
+        lambda key, kappa: lax_control_flow.cond(
+            kappa > kappa_large, large_kappa_normal, mid_kappa_sample, key, kappa
+        ),
+        key,
+        kappa,
+    )
+
 def wald(key: ArrayLike,
          mean: RealArray,
          shape: Shape | None = None,

--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2955,7 +2955,7 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
       return (1 + rho_val * rho_val) / (2 * rho_val)
     # Use second order Taylor expansion for small kappa
     s_val = lax.select(
-      safe_kappa < kappa_mid_small, 1.0 / kappa + kappa, s_val_from_kappa(safe_kappa)
+      safe_kappa < kappa_mid_small, 1.0 / safe_kappa + safe_kappa, s_val_from_kappa(safe_kappa)
     )
 
     def body_fn(state):
@@ -2979,7 +2979,7 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
       accepted = state[-2]
       return (~accepted).any()
 
-    *_, w_final = lax_control_flow.while_loop(
+    _, key_final, _, w_final = lax_control_flow.while_loop(
       cond_fn,
       body_fn,
       # Set so cond_fn returns True for the first iteration if kappa in range
@@ -2989,7 +2989,7 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
        jnp.zeros_like(kappa)),
     )
 
-    uniform_sign = 2.0 * binomial(key, jnp.ones_like(kappa), 0.5, dtype=dtype) - 1.0
+    uniform_sign = rademacher(key_final, shape=np.shape(kappa), dtype=dtype)
     return uniform_sign * jnp.arccos(jnp.clip(w_final, -1.0, 1.0))
 
   samples = lax.select(

--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -3087,8 +3087,8 @@ def _vonmises_fisher(key, mean, kappa, shape, dtype) -> Array:
     shape = lax.broadcast_shapes(mean.shape[:-1], kappa.shape)
   else:
     _check_shape("vonmises_fisher", shape, mean.shape[:-1], kappa.shape)
-  kappa = jnp.broadcast_to(kappa, shape)
-  mean = jnp.broadcast_to(mean, shape + (n_dim,))
+  kappa = jnp.broadcast_to(kappa, shape).astype(dtype)
+  mean = jnp.broadcast_to(mean, shape + (n_dim,)).astype(dtype)
 
   safe_norm_mean = mean / jnp.maximum(jnp.linalg.norm(mean, axis=-1, keepdims=True), 1e-8)
   with np.errstate(over="ignore"):
@@ -3116,7 +3116,7 @@ def _vonmises_fisher(key, mean, kappa, shape, dtype) -> Array:
       # For 3D, use Wenzel's method, start sampling around [1, 0, 0]
       x_key, yz_key = _split(key, 2)
       us = uniform(x_key, shape=shape, dtype=dtype)
-      xs = 1.0 + jnp.log(us + (1.0 - us)*jnp.exp(-2.0*safe_kappa))/safe_kappa
+      xs = 1.0 + jnp.log((1.0 - us) + us * jnp.exp(-2.0 * safe_kappa)) / safe_kappa
 
       yz_us = normal(yz_key, shape=shape + (2,), dtype=dtype)
       uniformcircle = yz_us / jnp.maximum(jnp.linalg.norm(yz_us, axis=-1, keepdims=True), 1e-8)
@@ -3127,9 +3127,9 @@ def _vonmises_fisher(key, mean, kappa, shape, dtype) -> Array:
       # This rotation is then applied to all samples.
       base_point = jnp.zeros(shape + (n_dim,), dtype=dtype)
       base_point = base_point.at[..., 0].set(1.0)
-      embedded = jnp.concatenate([safe_norm_mean[..., None, :], jnp.zeros(shape + (n_dim - 1, n_dim))], axis=-2)
+      embedded = jnp.concatenate([safe_norm_mean[..., None, :], jnp.zeros(shape + (n_dim - 1, n_dim), dtype=dtype)], axis=-2)
       rotmatrix, _ = jnp.linalg.qr(embedded.swapaxes(-2, -1))
-      rotsign = (2.0 * jnp.all(isclose((rotmatrix @ base_point[..., None])[..., 0], safe_norm_mean), axis=1, keepdims=True).astype(dtype) - 1.0)
+      rotsign = (2.0 * jnp.all(isclose((rotmatrix @ base_point[..., None])[..., 0], safe_norm_mean), axis=-1, keepdims=True).astype(dtype) - 1.0)
       samples = (einsum('...ij,...j->...i', rotmatrix, samples_aboutx) * rotsign).astype(dtype)
     else:
       # Should never reach

--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -2959,8 +2959,8 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
     )
 
     def body_fn(state):
-      key, accepted, w_out = state
-      new_key, zkey, vkey = _split(key, 3)
+      iter_idx, key, accepted, w_out = state
+      new_key, zkey, vkey = _split(fold_in(key, iter_idx), 3)
       z_val = jnp.cos(
         np.pi * uniform(zkey, shape=np.shape(kappa), dtype=dtype)
       )
@@ -2973,7 +2973,7 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
       accept = cond1 | cond2
       w_out = lax.select(accept, w_val, w_out)
       accepted |= accept
-      return (new_key, accepted, w_out)
+      return (iter_idx+1, new_key, accepted, w_out)
 
     def cond_fn(state):
       accepted = state[-2]
@@ -2984,7 +2984,7 @@ def _vonmises(key, kappa, shape, dtype) -> Array:
       body_fn,
       # Set so cond_fn returns True for the first iteration if kappa in range
       # jit traces all branches regardless of kappa
-      (key,
+      (0, key,
        (safe_kappa < kappa_small) | (safe_kappa > kappa_large),
        jnp.zeros_like(kappa)),
     )

--- a/jax/random.py
+++ b/jax/random.py
@@ -259,6 +259,7 @@ from jax._src.random.core import (
   triangular as triangular,
   truncated_normal as truncated_normal,
   uniform as uniform,
+  vonmises as vonmises,
   wald as wald,
   weibull_min as weibull_min,
   wrap_key_data as wrap_key_data,

--- a/jax/random.py
+++ b/jax/random.py
@@ -260,6 +260,7 @@ from jax._src.random.core import (
   truncated_normal as truncated_normal,
   uniform as uniform,
   vonmises as vonmises,
+  vonmises_fisher as vonmises_fisher,
   wald as wald,
   weibull_min as weibull_min,
   wrap_key_data as wrap_key_data,

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -1417,7 +1417,7 @@ class DistributionsTest(RandomTestBase):
     r = self.rng()
     key = lambda: self.make_key(0)
     mu = 2.0 * r.randn(ndim) - 1.0
-    mu = mu / jnp.maximum(jnp.linalg.norm(mu), 1e-8)
+    mu = (mu / jnp.maximum(jnp.linalg.norm(mu), 1e-8)).astype(dtype)
     rand = lambda key: random.vonmises_fisher(key, mean=mu, kappa=kappa, shape=(10000,), dtype=dtype)
     crand = jax.jit(rand)
 
@@ -1427,7 +1427,7 @@ class DistributionsTest(RandomTestBase):
     for samples in [uncompiled_samples, compiled_samples]:
       # Check that all samples are on unit sphere
       assert jnp.isfinite(samples).all(), f"Non-finite samples found with mu: {mu}"
-      self.assertAllClose(jnp.linalg.norm(samples, axis=-1), jnp.ones(samples.shape[:-1]), rtol=1e-4)
+      self.assertAllClose(jnp.linalg.norm(samples, axis=-1), jnp.ones(samples.shape[:-1], dtype=dtype), rtol=1e-4)
       if ndim == 1:
         # For 1D, crudely check that mean is approximately tanh(kappa)
         self.assertAllClose(jnp.mean(samples), jnp.mean(mu * jnp.tanh(kappa)), rtol=1e-2, atol=1e-2)
@@ -1438,15 +1438,17 @@ class DistributionsTest(RandomTestBase):
         # Recenter around mu_angle and re-fmod
         angles_recentered = sample_angles - mu_angle
         angles_recentered = (angles_recentered - (jnp.ceil((angles_recentered + jnp.pi) / (2.0*jnp.pi) - 1.0) * 2.0*jnp.pi))
-        self.assertAllClose(jnp.mean(angles_recentered), 0.0, rtol=1e-1, atol=1e-1)
+        self.assertAllClose(jnp.mean(angles_recentered), jnp.array(0.0, dtype=dtype), rtol=1e-1, atol=1e-1)
         self._CheckKolmogorovSmirnovCDF(angles_recentered, scipy.stats.vonmises(kappa).cdf)
       elif ndim == 3:
         # For 3D, crudely check the mean is close to theoretical value
         if kappa >= 1e0:
           # For smaller kappa values, the variance of the mean is too high
           self.assertAllClose(jnp.mean(samples, axis=0) / jnp.linalg.norm(jnp.mean(samples, axis=0)), mu, rtol=1e-1, atol=1e-1)
-        theoretical_mean_length = scipy.special.iv(1.5, kappa) / scipy.special.iv(0.5, kappa)
-        self.assertAllClose(jnp.linalg.norm(jnp.mean(samples, axis=0)), theoretical_mean_length, rtol=1e-1, atol=1e-1)
+        if kappa < 1e3:
+          # iv overflows for large kappa values
+          theoretical_mean_length = scipy.special.iv(1.5, kappa) / scipy.special.iv(0.5, kappa)
+          self.assertAllClose(jnp.linalg.norm(jnp.mean(samples, axis=0)), theoretical_mean_length, rtol=1e-1, atol=1e-1)
 
   @jtu.sample_product(
       mean= [0.2, 1., 2., 10. ,100.],

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -248,6 +248,7 @@ _OUT_SHARDING_CASES = [
     ('uniform', lambda key, n, s: random.uniform(key, shape=(n,), out_sharding=s)),
     ('gamma', lambda key, n, s: random.gamma(key, a=2.0, shape=(n,), out_sharding=s)),
     ('vonmises', lambda key, n, s: random.vonmises(key, kappa=1.0, shape=(n,), out_sharding=s)),
+    ('vonmises_fisher', lambda key, n, s: random.vonmises_fisher(key, mean=jnp.array([1.0, 0.0, 0.0]), kappa=1.0, shape=(n,), out_sharding=s)),
     ('wald', lambda key, n, s: random.wald(key, mean=1.0, shape=(n,), out_sharding=s)),
 ]
 
@@ -292,6 +293,7 @@ _DTYPE_CASES = [
     ('truncated_normal', float, lambda key, dtype: random.truncated_normal(key, lower=np.float16(-2.), upper=np.float16(2.), shape=(10,), dtype=dtype)),
     ('uniform', float, lambda key, dtype: random.uniform(key, shape=(10,), minval=np.float16(0.), maxval=np.float16(1.), dtype=dtype)),
     ('vonmises', float, lambda key, dtype: random.vonmises(key, np.float16(1.0), shape=(10,), dtype=dtype)),
+    ('vonmises_fisher', float, lambda key, dtype: random.vonmises_fisher(key, mean=jnp.array([1.0, 0.0, 0.0], dtype=np.float16), kappa=np.float16(1.0), shape=(10,), dtype=dtype)),
     ('wald', float, lambda key, dtype: random.wald(key, np.float16(1.0), shape=(10,), dtype=dtype)),
     ('weibull_min', float, lambda key, dtype: random.weibull_min(key, np.float16(1.0), np.float16(1.0), shape=(10,), dtype=dtype)),
 ]
@@ -343,6 +345,7 @@ _SHAPE_CASES = [
     ('truncated_normal', lambda key, shape: random.truncated_normal(key, lower=jnp.full(shape, -2.), upper=jnp.full(shape, 2.), shape=shape)),
     ('uniform', lambda key, shape: random.uniform(key, shape=shape, minval=jnp.zeros(shape), maxval=jnp.ones(shape))),
     ('vonmises', lambda key, shape: random.vonmises(key, jnp.ones(shape), shape=shape)),
+    # vonmises_fisher output shape is equal to (shape + (n_dim,)), so it will fail this test.
     ('wald', lambda key, shape: random.wald(key, jnp.ones(shape), shape=shape)),
     ('weibull_min', lambda key, shape: random.weibull_min(key, jnp.ones(shape), jnp.ones(shape), shape=shape)),
 ]
@@ -1405,6 +1408,45 @@ class DistributionsTest(RandomTestBase):
 
     for samples in [uncompiled_samples, compiled_samples]:
       self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.vonmises(kappa).cdf)
+
+  @jtu.sample_product(
+      kappa = [1e-6, 1e-4, 1e-2, 1e0, 1e2, 1e4, 1e6],
+      ndim = [1, 2, 3],
+      dtype = jtu.dtypes.floating)
+  def testVonMisesFisher(self, kappa, ndim, dtype):
+    r = self.rng()
+    key = lambda: self.make_key(0)
+    mu = 2.0 * r.randn(ndim) - 1.0
+    mu = mu / jnp.maximum(jnp.linalg.norm(mu), 1e-8)
+    rand = lambda key: random.vonmises_fisher(key, mean=mu, kappa=kappa, shape=(10000,), dtype=dtype)
+    crand = jax.jit(rand)
+
+    uncompiled_samples = rand(key())
+    compiled_samples = crand(key())
+
+    for samples in [uncompiled_samples, compiled_samples]:
+      # Check that all samples are on unit sphere
+      assert jnp.isfinite(samples).all(), f"Non-finite samples found with mu: {mu}"
+      self.assertAllClose(jnp.linalg.norm(samples, axis=-1), jnp.ones(samples.shape[:-1]), rtol=1e-4)
+      if ndim == 1:
+        # For 1D, crudely check that mean is approximately tanh(kappa)
+        self.assertAllClose(jnp.mean(samples), jnp.mean(mu * jnp.tanh(kappa)), rtol=1e-2, atol=1e-2)
+      elif ndim == 2:
+        # For 2D, check the distribution matches the von Mises distribution
+        sample_angles = jnp.arctan2(samples[:, 1], samples[:, 0])
+        mu_angle = jnp.arctan2(mu[1], mu[0])
+        # Recenter around mu_angle and re-fmod
+        angles_recentered = sample_angles - mu_angle
+        angles_recentered = (angles_recentered - (jnp.ceil((angles_recentered + jnp.pi) / (2.0*jnp.pi) - 1.0) * 2.0*jnp.pi))
+        self.assertAllClose(jnp.mean(angles_recentered), 0.0, rtol=1e-1, atol=1e-1)
+        self._CheckKolmogorovSmirnovCDF(angles_recentered, scipy.stats.vonmises(kappa).cdf)
+      elif ndim == 3:
+        # For 3D, crudely check the mean is close to theoretical value
+        if kappa >= 1e0:
+          # For smaller kappa values, the variance of the mean is too high
+          self.assertAllClose(jnp.mean(samples, axis=0) / jnp.linalg.norm(jnp.mean(samples, axis=0)), mu, rtol=1e-1, atol=1e-1)
+        theoretical_mean_length = scipy.special.iv(1.5, kappa) / scipy.special.iv(0.5, kappa)
+        self.assertAllClose(jnp.linalg.norm(jnp.mean(samples, axis=0)), theoretical_mean_length, rtol=1e-1, atol=1e-1)
 
   @jtu.sample_product(
       mean= [0.2, 1., 2., 10. ,100.],

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -247,6 +247,7 @@ _OUT_SHARDING_CASES = [
     ('triangular', lambda key, n, s: random.triangular(key, left=0., mode=0.5, right=1., shape=(n,), out_sharding=s)),
     ('uniform', lambda key, n, s: random.uniform(key, shape=(n,), out_sharding=s)),
     ('gamma', lambda key, n, s: random.gamma(key, a=2.0, shape=(n,), out_sharding=s)),
+    ('vonmises', lambda key, n, s: random.vonmises(key, kappa=1.0, shape=(n,), out_sharding=s)),
     ('wald', lambda key, n, s: random.wald(key, mean=1.0, shape=(n,), out_sharding=s)),
 ]
 
@@ -290,6 +291,7 @@ _DTYPE_CASES = [
     ('triangular', float, lambda key, dtype: random.triangular(key, np.float16(0.), np.float16(0.5), np.float16(1.), shape=(10,), dtype=dtype)),
     ('truncated_normal', float, lambda key, dtype: random.truncated_normal(key, lower=np.float16(-2.), upper=np.float16(2.), shape=(10,), dtype=dtype)),
     ('uniform', float, lambda key, dtype: random.uniform(key, shape=(10,), minval=np.float16(0.), maxval=np.float16(1.), dtype=dtype)),
+    ('vonmises', float, lambda key, dtype: random.vonmises(key, np.float16(1.0), shape=(10,), dtype=dtype)),
     ('wald', float, lambda key, dtype: random.wald(key, np.float16(1.0), shape=(10,), dtype=dtype)),
     ('weibull_min', float, lambda key, dtype: random.weibull_min(key, np.float16(1.0), np.float16(1.0), shape=(10,), dtype=dtype)),
 ]
@@ -340,6 +342,7 @@ _SHAPE_CASES = [
     ('triangular', lambda key, shape: random.triangular(key, jnp.zeros(shape), jnp.full(shape, 0.5), jnp.ones(shape), shape=shape)),
     ('truncated_normal', lambda key, shape: random.truncated_normal(key, lower=jnp.full(shape, -2.), upper=jnp.full(shape, 2.), shape=shape)),
     ('uniform', lambda key, shape: random.uniform(key, shape=shape, minval=jnp.zeros(shape), maxval=jnp.ones(shape))),
+    ('vonmises', lambda key, shape: random.vonmises(key, jnp.ones(shape), shape=shape)),
     ('wald', lambda key, shape: random.wald(key, jnp.ones(shape), shape=shape)),
     ('weibull_min', lambda key, shape: random.weibull_min(key, jnp.ones(shape), jnp.ones(shape), shape=shape)),
 ]
@@ -1388,6 +1391,20 @@ class DistributionsTest(RandomTestBase):
 
     for samples in [uncompiled_samples, compiled_samples]:
       self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.rayleigh(scale=scale).cdf)
+
+  @jtu.sample_product(
+      kappa = [1e-6, 1e-4, 1e-2, 1e0, 1e2, 1e4, 1e6],
+      dtype = jtu.dtypes.floating)
+  def testVonMises(self, kappa, dtype):
+    key = lambda: self.make_key(0)
+    rand = lambda key: random.vonmises(key, kappa, shape=(10000,), dtype=dtype)
+    crand = jax.jit(rand)
+
+    uncompiled_samples = rand(key())
+    compiled_samples = crand(key())
+
+    for samples in [uncompiled_samples, compiled_samples]:
+      self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.vonmises(kappa).cdf)
 
   @jtu.sample_product(
       mean= [0.2, 1., 2., 10. ,100.],


### PR DESCRIPTION
Prerequisite (i.e. to be merged _after_): https://github.com/jax-ml/jax/pull/38094

Partially addresses issue https://github.com/jax-ml/jax/issues/11737 by adding a von Mises-Fisher sampler. Transcribes [scipy's implementation](https://github.com/scipy/scipy/blob/8c75ae75176236f233824e9a0483c26a69e6dfec/scipy/stats/_multivariate.py#L7511), which uses a base von Mises sampler for 2D, and Wenzel's approach for 3D. I also added a 1D version that outputs [Weighted Rademacher Samples](https://en.wikipedia.org/wiki/Von_Mises%E2%80%93Fisher_distribution#Weighted_Rademacher_distribution).