### PR TITLE
Configure a portserver when running bazel tests.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -100,12 +100,5 @@ jobs:
       env:
         PYTHON_BIN: ${{ steps.setup_python.outputs.python-bin }}
       run: |
-        $PYTHON_BIN build/portserver.py &
-        SERVER_PID=$!
-        # Stop the background portserver even if Sphinx exits with an error.
-        cleanup_portserver() {
-          kill "$SERVER_PID" 2>/dev/null || true
-          wait "$SERVER_PID" 2>/dev/null || true
-        }
-        trap cleanup_portserver EXIT
+        source ci/utilities/setup_portserver.sh
         PORTSERVER_ADDRESS=@unittest-portserver $PYTHON_BIN -m sphinx -j auto --color -W --keep-going -b html docs docs/build/html

--- a/ci/run_bazel_cuda_targeted_tests.sh
+++ b/ci/run_bazel_cuda_targeted_tests.sh
@@ -76,6 +76,7 @@ bazel_args=(
   --repo_env=HERMETIC_PYTHON_VERSION="${hermetic_python_version}"
   --repo_env=HERMETIC_CUDNN_VERSION=9.11.0
   --repo_env=HERMETIC_CUDA_UMD_VERSION=13.1.1
+  --test_env=JAX_PORTSERVER_ADDRESS=@unittest-portserver
   --test_env=XLA_PYTHON_CLIENT_ALLOCATOR=platform
   --test_output=errors
   --strategy=TestRunner=local
@@ -127,6 +128,8 @@ if [[ ${#targets[@]} -eq 0 ]]; then
   exit 1
 fi
 echo "::endgroup::" >&2
+
+source ci/utilities/setup_portserver.sh
 
 echo "::group::Bazel CUDA targeted tests" >&2
 INVOCATION_ID=$(python3 ci/utilities/generate_invocation_id.py)

--- a/ci/run_bazel_test_cuda_non_rbe.sh
+++ b/ci/run_bazel_test_cuda_non_rbe.sh
@@ -100,6 +100,7 @@ common_bazel_test_args=(
   "--repo_env=HERMETIC_CUDA_UMD_VERSION=13.1.1"
   "--//jax:build_jaxlib=$JAXCI_BUILD_JAXLIB"
   "--//jax:build_jax=$JAXCI_BUILD_JAX"
+  "--test_env=JAX_PORTSERVER_ADDRESS=@unittest-portserver"
   "--test_env=XLA_PYTHON_CLIENT_ALLOCATOR=platform"
   "--test_env=TF_CPP_MIN_LOG_LEVEL=0"
   "--test_env=JAX_SKIP_SLOW_TESTS=true"
@@ -147,6 +148,8 @@ set +e
 TEST_ARTIFACTS_DIR="test-artifacts-single"
 mkdir -p "$TEST_ARTIFACTS_DIR"
 echo "::endgroup::" >&2
+
+source ci/utilities/setup_portserver.sh
 
 echo "::group::Bazel CUDA single-accelerator tests" >&2
 INVOCATION_ID_SINGLE=$(python3 ci/utilities/generate_invocation_id.py)

--- a/ci/run_bazel_test_tpu.sh
+++ b/ci/run_bazel_test_tpu.sh
@@ -54,7 +54,8 @@ J=$((NB_TPUS * JOBS_PER_ACC))
 
 # TODO(ybaturina): Bazel cache shouldn't be invalidated when
 # `VBAR_CONTROL_SERVICE_URL` changes.
-COMMON_TPU_TEST_ENV_VARS="--test_env=TPU_SKIP_MDS_QUERY=true \
+COMMON_TPU_TEST_ENV_VARS="--test_env=JAX_PORTSERVER_ADDRESS=@unittest-portserver \
+ --test_env=TPU_SKIP_MDS_QUERY=true \
  --test_env=TPU_TOPOLOGY \
  --test_env=TPU_WORKER_ID \
  --test_env=TPU_TOPOLOGY_WRAP \
@@ -78,6 +79,8 @@ set +e
 IGNORE_TESTS_MULTIACCELERATOR="-//tests/multiprocess:array_test_tpu"
 
 echo "::endgroup::" >&2
+
+source ci/utilities/setup_portserver.sh
 
 if [[ "$JAXCI_RUN_FULL_TPU_TEST_SUITE" == "1" ]]; then
   # We're deselecting all Pallas TPU tests in the oldest libtpu build. Mosaic

--- a/ci/utilities/setup_portserver.sh
+++ b/ci/utilities/setup_portserver.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under/the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Starts the JAX portserver in the background and configures cleanup on exit.
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "ERROR: ci/utilities/setup_portserver.sh must be sourced, not executed directly." >&2
+  exit 1
+fi
+
+if [[ ! -f "build/portserver.py" ]]; then
+  echo "ERROR: build/portserver.py not found. Make sure you are in the JAX root directory." >&2
+  exit 1
+fi
+
+echo "::group::Start Portserver" >&2
+${PYTHON_BIN:-python3} build/portserver.py &
+SERVER_PID=$!
+cleanup_portserver() {
+  kill "$SERVER_PID" 2>/dev/null || true
+  wait "$SERVER_PID" 2>/dev/null || true
+}
+trap cleanup_portserver EXIT
+echo "::endgroup::" >&2

--- a/jax/_src/test_multiprocess.py
+++ b/jax/_src/test_multiprocess.py
@@ -228,8 +228,10 @@ def _main(argv, shard_main):
   if portpicker is None:
     slicebuilder_ports = [10000 + i for i in range(num_processes)]
   else:
+    portserver_address = os.environ.get("JAX_PORTSERVER_ADDRESS")
     slicebuilder_ports = [
-        portpicker.pick_unused_port() for _ in range(num_processes)
+        portpicker.pick_unused_port(portserver_address=portserver_address)
+        for _ in range(num_processes)
     ]
   slicebuilder_addresses = ",".join(
       f"localhost:{port}" for port in slicebuilder_ports
@@ -254,7 +256,8 @@ def _main(argv, shard_main):
   else:
     # TODO(emilyaf): Use a port server if there are flaky port collisions due
     # to pick_unused_port() racing among tests.
-    jax_port = portpicker.pick_unused_port()
+    portserver_address = os.environ.get("JAX_PORTSERVER_ADDRESS")
+    jax_port = portpicker.pick_unused_port(portserver_address=portserver_address)
   subprocesses = []
   output_filenames = []
   output_files = []
@@ -312,7 +315,10 @@ def _main(argv, shard_main):
       if portpicker is None:
         megascale_port = 9877
       else:
-        megascale_port = portpicker.pick_unused_port()
+        portserver_address = os.environ.get("JAX_PORTSERVER_ADDRESS")
+        megascale_port = portpicker.pick_unused_port(
+            portserver_address=portserver_address
+        )
       if megascale_coordinator_port is None:
         megascale_coordinator_port = megascale_port
       args += [


### PR DESCRIPTION
Without this the multiprocess bazel tests can flake if the collide on their chosen ports.
