### PR TITLE
Fix spurious NaN in scipy.stats.chi2.logpdf at x=0 and x=inf when df=2.

### DIFF
--- a/jax/_src/scipy/stats/chi2.py
+++ b/jax/_src/scipy/stats/chi2.py
@@ -18,7 +18,7 @@ from jax._src import lax
 from jax._src import numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.util import promote_args_inexact
-from jax._src.scipy.special import gammainc, gammaincc
+from jax._src.scipy.special import gammainc, gammaincc, xlogy
 from jax._src.typing import Array, ArrayLike
 
 
@@ -62,7 +62,7 @@ def logpdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1
   y = lax.div(lax.sub(x, loc), scale)
   df_on_two = lax.div(df, two)
 
-  kernel = lax.sub(lax.mul(lax.sub(df_on_two, one), lax.log(y)), lax.div(y,two))
+  kernel = lax.sub(xlogy(lax.sub(df_on_two, one), y), lax.div(y,two))
 
   nrml_cnst = lax.neg(lax.add(lax.lgamma(df_on_two),lax.div(lax.mul(lax.log(two), df),two)))
 

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -1286,6 +1286,18 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
                               tol=5e-4)
       self._CompileAndCheck(lax_fun, args_maker)
 
+  @jtu.ignore_warning(category=RuntimeWarning,
+                      message="divide by zero encountered.*")
+  @jtu.ignore_warning(category=RuntimeWarning,
+                      message="invalid value encountered.*")
+  def testChi2LogPdfBoundaryValues(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/38316
+    x = np.array([0., 1., np.inf])[:, None]
+    df = np.array([1., 2., 4.])
+    self.assertAllClose(osp_stats.chi2.logpdf(x, df),
+                        lsp_stats.chi2.logpdf(x, df), atol=1e-6)
+    self.assertAllClose(osp_stats.chi2.pdf(0., 2.), lsp_stats.chi2.pdf(0., 2.),
+                        atol=1e-6)
 
   @genNamedParametersNArgs(4)
   def testChi2LogCdf(self, shapes, dtypes):


### PR DESCRIPTION
Fixes #38316.

`jax.scipy.stats.chi2.logpdf` returns NaN at `x=0` and `x=inf` when `df=2` (and
`chi2.pdf(0, 2)` returns NaN instead of 0.5). This applies the fix suggested in the
issue: compute the kernel with `xlogy(df/2 - 1, y)` instead of a plain multiply,
mirroring `gamma.logpdf`. No new import cycle: `chi2.py` already imports from
`jax._src.scipy.special`.

One boundary case the issue also flags, `logpdf(inf, df > 2)`, turns out to be NaN
in scipy as well, so this change deliberately preserves it; after the fix jax matches
scipy at every tested boundary point. Behavior for `df != 2` is otherwise unchanged,
gradients at interior points are unaffected (`xlogy`'s JVP reduces to the product
rule away from `x=0`), and `pdf` inherits the fix via `exp(logpdf)`.

Added a regression test comparing against scipy over `x in {0, 1, inf}` x
`df in {1, 2, 4}` plus `pdf(0, 2)`, following the existing `testGammaLogPdfZero`
pattern; the chi2 subset of `scipy_stats_test.py` passes on CPU in both default and
`JAX_ENABLE_X64=1` modes.
