### PR TITLE
Fix scipy.special.gammainc/gammaincc evaluation at a=inf.

### DIFF
--- a/jax/_src/lax/special.py
+++ b/jax/_src/lax/special.py
@@ -361,15 +361,16 @@ def _igamma_series(ax, x, a, enabled, dtype, mode):
 def igamma_impl(a, x, *, dtype):
   is_nan = bitwise_or(_isnan(a), _isnan(x))
   x_is_infinity = eq(x, _const(x, float('inf')))
+  a_is_infinity = eq(a, _const(a, float('inf')))
   a_is_zero = eq(a, _const(a, 0))
   x_is_zero = eq(x, _const(x, 0))
-  domain_error = _reduce(bitwise_or, [lt(x, _const(x, 0)), lt(a, _const(a, 0)), bitwise_and(a_is_zero, x_is_zero), is_nan])
+  domain_error = _reduce(bitwise_or, [lt(x, _const(x, 0)), lt(a, _const(a, 0)), bitwise_and(a_is_zero, x_is_zero), bitwise_and(a_is_infinity, x_is_infinity), is_nan])
 
   use_igammac = bitwise_and(ge(x, _const(x, 1)), gt(x, a))
   ax = a * log(x) - x - lgamma(a)
   underflow = lt(ax, -log(dtypes.finfo(dtype).max))
   ax = exp(ax)
-  enabled = bitwise_not(_reduce(bitwise_or, [x_is_zero, domain_error, underflow, x_is_infinity]))
+  enabled = bitwise_not(_reduce(bitwise_or, [x_is_zero, domain_error, underflow, x_is_infinity, a_is_infinity]))
 
   output = select(
     use_igammac,
@@ -381,6 +382,7 @@ def igamma_impl(a, x, *, dtype):
   )
   output = select(x_is_zero, full_like(a, 0), output)
   output = select(x_is_infinity, full_like(a, 1), output)
+  output = select(a_is_infinity, full_like(a, 0), output)
   output = select(domain_error, full_like(a, float('nan')), output)
   return output
 
@@ -494,11 +496,12 @@ def igammac_impl(a, x, *, dtype):
   a_is_zero = eq(a, _const(a, 0))
   x_is_zero = eq(x, _const(x, 0))
   x_is_infinity = eq(x, _const(x, float('inf')))
-  domain_error = _reduce(bitwise_or, [lt(x, _const(x, 0)), lt(a, _const(a, 0)), bitwise_and(a_is_zero, x_is_zero), is_nan])
+  a_is_infinity = eq(a, _const(a, float('inf')))
+  domain_error = _reduce(bitwise_or, [lt(x, _const(x, 0)), lt(a, _const(a, 0)), bitwise_and(a_is_zero, x_is_zero), bitwise_and(a_is_infinity, x_is_infinity), is_nan])
   use_igamma = bitwise_or(lt(x, _const(x, 1)), lt(x, a))
   ax = a * log(x) - x - lgamma(a)
   underflow = lt(ax, -log(dtypes.finfo(dtype).max))
-  enabled = bitwise_not(_reduce(bitwise_or, [domain_error, underflow, x_is_infinity, a_is_zero]))
+  enabled = bitwise_not(_reduce(bitwise_or, [domain_error, underflow, x_is_infinity, a_is_zero, a_is_infinity]))
   ax = exp(ax)
 
   igamma_call = _igamma_series(ax, x, a, bitwise_and(enabled, use_igamma),
@@ -508,6 +511,7 @@ def igammac_impl(a, x, *, dtype):
 
   output = select(use_igamma, _const(a, 1) - igamma_call, igammac_cf_call)
   output = select(bitwise_or(x_is_infinity, a_is_zero), full_like(output, 0), output)
+  output = select(a_is_infinity, full_like(output, 1), output)
   output = select(domain_error, full_like(a, float('nan')), output)
   return output
 

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -398,8 +398,8 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
     nan = float('nan')
     inf = float('inf')
     if jtu.parse_version(scipy.__version__) >= (1, 16):
-      a_samples = [0, 0, 0, 1, nan,   1, nan,   0,   1, 1, nan]
-      x_samples = [0, 1, 2, 0,   1, nan, nan, inf, inf, -1, inf]
+      a_samples = [0, 0, 0, 1, nan,   1, nan,   0,   1, 1, nan, inf, inf, inf, inf]
+      x_samples = [0, 1, 2, 0,   1, nan, nan, inf, inf, -1, inf,   0,   1,   2, inf]
     else:
       # disable samples that contradict with scipy/scipy#22441
       a_samples = [0, 0, 0, 1, nan,   1, nan,   0,   1, 1]
@@ -416,8 +416,8 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
     nan = float('nan')
     inf = float('inf')
     if jtu.parse_version(scipy.__version__) >= (1, 16):
-      a_samples = [0, 0, 0, 1, nan,   1, nan,   0,   1, 1, nan]
-      x_samples = [0, 1, 2, 0,   1, nan, nan, inf, inf, -1, inf]
+      a_samples = [0, 0, 0, 1, nan,   1, nan,   0,   1, 1, nan, inf, inf, inf, inf]
+      x_samples = [0, 1, 2, 0,   1, nan, nan, inf, inf, -1, inf,   0,   1,   2, inf]
     else:
       # disable samples that contradict with scipy/scipy#22441
       a_samples = [0, 0, 0, 1, nan,   1, nan,   0,   1, 1]


### PR DESCRIPTION
Fixes #38272.

`jax.scipy.special.gammaincc(inf, 1.0)` returns nan where scipy returns 1.
`gammainc` is affected the same way (nan instead of 0 for finite `x > 0`), and
both functions return finite values at `(inf, inf)` where scipy >= 1.16
returns nan.

The root cause is that `igamma_impl` and `igammac_impl` in
`jax/_src/lax/special.py` compute `ax = a * log(x) - x - lgamma(a)`, which is
`inf - inf = nan` for infinite `a`; the boundary selects added for #20507
handle `a == 0`, `x == 0`, and `x == inf` but not `a == inf`, so the nan
propagates to the output on every backend.

This change adds the missing `a == inf` case to both impls:
`gammainc(inf, x) = 0` and `gammaincc(inf, x) = 1` for finite `x`, with
`(inf, inf)` treated as a domain error returning nan, matching scipy >= 1.16
(the path-dependent-limit convention discussed in #20507).

The existing boundary-value tests gain `(inf, 0)`, `(inf, 1)`, `(inf, 2)`, and
`(inf, inf)` samples under the existing scipy >= 1.16 gate, checking both eager
and jit against scipy. Verified against scipy 1.17.1 on CPU in float32 and
float64.

---
This change was developed with the assistance of Claude Code.
