### PR TITLE
Fix jax.random.poisson(lam=inf) returning 0 instead of dtype max

### DIFF
--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -1830,7 +1830,12 @@ def _poisson(key, lam, shape, dtype) -> Array:
     _poisson_knuth(key, lam_knuth, shape, dtype, max_iters),
     _poisson_rejection(key, lam_rejection, shape, dtype, max_iters),
   )
-  return lax.select(lam == 0, jnp.zeros_like(result), result)
+  result = lax.select(lam == 0, jnp.zeros_like(result), result)
+  # lam=inf produces undefined behavior in XLA when cast to int.
+  # Saturate to dtype max, analogous to finite huge lam -> INT64_MAX.
+  isinf_lam = lax.isinf(lam) & (lam > 0)
+  return lax.select(isinf_lam, jnp.full_like(result, dtypes.iinfo(dtype).max),
+                    result)
 
 
 def poisson(key: ArrayLike,

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -835,6 +835,14 @@ class DistributionsTest(RandomTestBase):
     samples = random.poisson(key, lam, shape=(2, 20))
     self.assertArraysEqual(samples[:, :10], jnp.zeros_like(samples[:, :10]))
 
+  def testPoissonLamInf(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/38335
+    # lam=inf should saturate to dtype max, not return 0
+    key = self.make_key(0)
+    samples = random.poisson(key, jnp.inf, shape=(10,), dtype=np.int64)
+    expected = jnp.full(10, jnp.iinfo(np.int64).max, dtype=np.int64)
+    self.assertArraysEqual(samples, expected)
+
   def testPoissonCornerCases(self):
     key = self.make_key(0)
     lam = jnp.array([-1, 0, jnp.nan])


### PR DESCRIPTION
## Summary

Fixes #38335: `jax.random.poisson(lam=inf)` returns `0` instead of `INT64_MAX`.

## Root Cause

`lam=inf` → `_poisson_rejection` path → `k = floor(... + inf + 0.43) = inf` → `float(inf)` cast to `int64` is undefined behavior in XLA, which lands on `0` on CPU.

## Fix

Saturate to `dtype max` (e.g., `INT64_MAX`), consistent with the behavior of huge finite lam values which also saturate to `INT64_MAX`.

## Changes

- `jax/_src/random/core.py`: 5 lines — add `lax.isinf(lam)` check after `lam==0` special case
- `tests/random_lax_test.py`: 8 lines — regression test

Fixes #38335

<!-- BEGIN RELEASE NOTES -->
* random
  * Fixed `poisson(lam=inf)` returning 0 instead of dtype max ([#38335](https://github.com/jax-ml/jax/issues/38335))
<!-- END RELEASE NOTES -->