### PR TITLE
fix(mesh_utils): _get_prime_factors discards small factors for composites with large largest prime

### DIFF
--- a/jax/_src/mesh_utils.py
+++ b/jax/_src/mesh_utils.py
@@ -459,8 +459,11 @@ def _get_prime_factors(x: int) -> list[int]:
       x //= p
     if x == 1:
       return factors
-  else:
-    return [x]  # x is a prime number.
+  # If x > 1 after the loop, the remaining x is a prime factor (it was not
+  # divisible by any integer in [2, isqrt(original_x) + 1]).
+  if x > 1:
+    factors.append(x)
+  return factors
 
 
 def _enumerate_feasible_logical_axis_assignments(

--- a/tests/mesh_utils_test.py
+++ b/tests/mesh_utils_test.py
@@ -728,6 +728,16 @@ class SplitAxesDeviceMeshCreationTest(test_util.JaxTestCase):
     self.assertEqual(mesh_utils._get_prime_factors(12), [2, 2, 3])
     self.assertEqual(mesh_utils._get_prime_factors(121), [11, 11])  # square
     self.assertEqual(mesh_utils._get_prime_factors(43), [43])  # prime
+    # Regression: composites whose largest prime factor exceeds isqrt(x)+1 were
+    # previously returned as [largest_prime], discarding smaller factors (#38286).
+    self.assertEqual(mesh_utils._get_prime_factors(10), [2, 5])
+    self.assertEqual(mesh_utils._get_prime_factors(14), [2, 7])
+    self.assertEqual(mesh_utils._get_prime_factors(22), [2, 11])
+    self.assertEqual(mesh_utils._get_prime_factors(26), [2, 13])
+    for n in range(2, 200):
+      factors = mesh_utils._get_prime_factors(n)
+      import math as _math
+      self.assertEqual(_math.prod(factors), n, msg=f"factors of {n} don't multiply back: {factors}")
 
   @parameterized.named_parameters(
       (


### PR DESCRIPTION
Fixes #38286.

**Problem**

`_get_prime_factors` uses a `for…else` construct. Python's `else` on a `for` loop runs when the loop completes without a `break` — and there is no `break` in this loop. So the `else` branch always runs, overwriting `factors` with just `[x]`. Small factors collected in the `while` body are discarded.

Examples: `_get_prime_factors(10)` returns `[5]` instead of `[2, 5]`. Same for 14, 22, 26, and any composite where the largest prime factor is large.

**Fix**

Remove the `for…else`. After the loop, append `x` only if `x > 1` (meaning `x` is a prime residual that wasn't divided out).

**Test**

- Added cases: `_get_prime_factors(10)` → `[2, 5]`, same for 14, 22, 26
- Round-trip: `math.prod(_get_prime_factors(n)) == n` for all `n` in `[2, 199]`