### PR TITLE
[ROCm] Allow XLA_PYTHON_CLIENT_ALLOCATOR=address

### DIFF
--- a/docs/gpu_memory_allocation.rst
+++ b/docs/gpu_memory_allocation.rst
@@ -84,6 +84,14 @@ Features here are experimental and must be tried with caution.
   preallocate memory; use ``XLA_CLIENT_MEM_FRACTION`` to control the
   fraction of GPU memory used.
 
+``XLA_PYTHON_CLIENT_ALLOCATOR=address``
+  This makes the PJRT client use a dedicated synchronous passthrough allocator
+  (``StreamExecutorAddressAllocator``) that calls the underlying StreamExecutor
+  allocate/deallocate APIs directly, bypassing the BFC allocator entirely.
+  Unlike ``platform``, it constructs its own allocator at the PJRT level instead
+  of sharing the backend allocator, which avoids the BFC allocator being built
+  alongside it. This allocator is platform-agnostic (CUDA and ROCm).
+
 ``TF_GPU_ALLOCATOR=cuda_malloc_async``
   This replace XLA's own BFC memory allocator with `cudaMallocAsync
   <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html>`_.

--- a/jaxlib/xla_client.py
+++ b/jaxlib/xla_client.py
@@ -192,10 +192,18 @@ def generate_pjrt_gpu_plugin_options() -> _NameValueMapping:
   collective_memory_size = os.getenv(
       'XLA_PYTHON_CLIENT_COLLECTIVE_MEM_SIZE_MB', ''
   )
-  if allocator not in ('default', 'platform', 'bfc', 'cuda_async', 'vmm'):
+  allowed_allocators = (
+      'default',
+      'platform',
+      'bfc',
+      'cuda_async',
+      'vmm',
+      'address',
+  )
+  if allocator not in allowed_allocators:
     raise ValueError(
-        'XLA_PYTHON_CLIENT_ALLOCATOR env var must be "default", "platform", '
-        '"bfc", "cuda_async", or "vmm", got "%s"' % allocator
+        'XLA_PYTHON_CLIENT_ALLOCATOR env var must be one of %s, got "%s"'
+        % (', '.join(f'"{a}"' for a in allowed_allocators), allocator)
     )
   options['allocator'] = allocator
   if memory_fraction:


### PR DESCRIPTION
## Summary
Allow `XLA_PYTHON_CLIENT_ALLOCATOR=address`, forwarding it to the PJRT GPU plugin
so JAX can select the dedicated synchronous passthrough allocator
(`StreamExecutorAddressAllocator`) that bypasses BFC.

This is the JAX-side pairing for openxla/xla#44335, which adds the
`GpuAllocatorConfig::Kind::kAddress` allocator. Without this change the value is
rejected by `generate_pjrt_gpu_plugin_options` before it reaches the plugin.

## Why
On JAX pytests / debugging we rely on a non-BFC passthrough allocator (BFC can
OOM quickly, and the address allocator is simple to reason about). That
capability used to be reachable via `platform` but regressed with openxla/xla#41761.



## For readers who wants to know more on why address allocator is needed 

Since https://github.com/openxla/xla/pull/41761 , we don't have option to select stream address allocator because xla backend now defaults to BFC
I originally made https://github.com/openxla/xla/pull/42627 this PR under the assumption that platfrom allocator always means address allocator. after comments/suggestions from G I now have followup change.

"I think we need a different solution. platform means that it shares the allocator with tf which is why the jax2tf tests are failing. We cannot change the meaning of platform and either need to allow configuring the underlying allocator to be the address allocator or a separate option for pjrt which changes the allocator."

based on this: I decided to go with second option i,e separate option for pjrt which changes the allocator.
