### PR TITLE
[ROCm] CI: use address allocator for pytest

### DIFF
--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -110,7 +110,7 @@ fi
 echo "Final number of processes to run: $num_processes"
 
 export JAX_ENABLE_ROCM_XDIST="$gpu_count"
-export XLA_PYTHON_CLIENT_ALLOCATOR=default
+export XLA_PYTHON_CLIENT_ALLOCATOR=address
 export XLA_PYTHON_CLIENT_PREALLOCATE=false
 export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1 --xla_gpu_enable_nccl_comm_splitting=false --xla_gpu_enable_command_buffer="
 


### PR DESCRIPTION
## Summary
One change to `ci/run_pytest_rocm.sh`:

- Set `XLA_PYTHON_CLIENT_ALLOCATOR=address` (was `default`) so the ROCm pytest
  run uses the synchronous passthrough `StreamExecutorAddressAllocator` instead
  of BFC. 
- Also I need to point out this : CUDA probably needs same changes to allocator, because for the past month CUDA CI is run with platform allocator but in XLA it is most likely got connected to BFC. I dont have CUDA hw to verify so I did not make change there. If reviewers prefer it I'm happy to switch allocator for team green too.
## Depends on
- openxla/xla#44335 (adds the `kAddress` allocator)
- jax-ml/jax#38490 (allows `XLA_PYTHON_CLIENT_ALLOCATOR=address` in JAX)