### PR TITLE
Infer total devices from mesh shape

### DIFF
--- a/tests/scaled_matmul_stablehlo_test.py
+++ b/tests/scaled_matmul_stablehlo_test.py
@@ -108,10 +108,7 @@ def _parse_replica_group_semantics(line):
       group_size = math.prod(mesh_shape[axis] for axis in selected_axes)
     else:
       group_size = 1
-    if mesh_match.group(2):
-      total_devices = len(_parse_int_list(mesh_match.group(2)))
-    else:
-      total_devices = math.prod(mesh_shape.values())
+    total_devices = math.prod(mesh_shape.values())
     num_groups = total_devices // group_size if group_size else None
     return group_size, num_groups, total_devices
 


### PR DESCRIPTION
A helper function in `scaled_matmul_stablehlo_test.py` parses total device count from HLO as a comma-separated list of device IDs, but this can fail when HLO sharding v3 is disabled (e.g. due to [0e07f95](https://github.com/openxla/xla/commit/0e07f95)) because XLA may add a device assignment like `device_ids=([2,2]T(1,0))`. However, it is possible to always infer total device count from mesh shape alone in both v3 and non-v3 HLO sharding.