### PR TITLE
docs: Fix ANF expansion to A-normal form

### DIFF
--- a/docs/jaxpr.md
+++ b/docs/jaxpr.md
@@ -17,7 +17,7 @@ kernelspec:
 
 <!--* freshness: { reviewed: '2024-05-03' } *-->
 
-Jaxprs are JAX’s internal intermediate representation (IR) of programs. They are explicitly typed, functional, first-order, and in algebraic normal form (ANF).
+Jaxprs are JAX’s internal intermediate representation (IR) of programs. They are explicitly typed, functional, first-order, and in A-normal form (ANF).
 
 Conceptually, one can think of JAX transformations, such as {func}`jax.jit` or {func}`jax.grad`, as first trace-specializing the Python function to be transformed into a small and well-behaved intermediate form that is then interpreted with transformation-specific interpretation rules.
 


### PR DESCRIPTION
Fix a typo where ANF in the "[JAX internals: The jaxpr language](https://docs.jax.dev/en/latest/jaxpr.html#jax-internals-jaxpr)" guide was expanded to "algebraic normal form", which is a concept of Boolean algebra, to "A-normal form", which is what it is supposed to be (to the best of my knowledge).

Independent of the above, "A-normal form" is also what brings up the correct concepts when searching for the term, so I think it is the most helpful expansion of ANF for a guide.

Due to this PR being a very tiny change, I hope it is okay that I skipped the "first issue then PR" path.
