### PR TITLE
Fix expn/exp1/expi returning nan at infinite arguments

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -2604,7 +2604,10 @@ def expi(x: ArrayLike) -> Array:
   x_arr, = promote_args_inexact("expi", x)
   if dtypes.issubdtype(x_arr.dtype, np.complexfloating):
     raise ValueError("expi does not support complex-valued inputs.")
-  return jnp.piecewise(x_arr, [x_arr < 0], [_expi_neg, _expi_pos])
+  result = jnp.piecewise(x_arr, [x_arr < 0], [_expi_neg, _expi_pos])
+  # expi(+inf) = +inf; the Cephes Pade approximant _expint7 evaluates
+  # exp(inf) * (1/inf) * polynomial = inf * 0 = nan without this guard.
+  return jnp.where(jnp.isposinf(x_arr), _lax_const(x_arr, np.inf), result)
 
 @expi.defjvp
 @jit
@@ -2979,6 +2982,7 @@ def expn(n: ArrayLike, x: ArrayLike) -> Array:
   zero = _c(x, 0)
   one = _c(x, 1)
   conds = [
+    jnp.isinf(x) & (x > zero),
     (n < _c(n, 0)) | (x < zero),
     (x == zero) & (n < _c(n, 2)),
     (x == zero) & (n >= _c(n, 2)),
@@ -2988,6 +2992,7 @@ def expn(n: ArrayLike, x: ArrayLike) -> Array:
   ]
   n1 = jnp.where(n == _c(n, 1), n + n, n)
   vals = [
+    zero,        # E_n(+inf) = 0 for all n >= 0: integrand e^{-t}/t^n vanishes
     np.nan,
     np.inf,
     one / n1,  # prevent div by zero

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -379,6 +379,24 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
     with self.assertRaises(TypeError):
       lsp_special.beta(x=1, y=1)
 
+  def testExpnExpiInfLimits(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/38519
+    # The integrand e^{-t}/t^n vanishes as t->inf, so E_n(+inf) = 0.
+    # expi(+inf) diverges to +inf. expi(-inf) = -exp1(inf) = -0.
+    inf = float('inf')
+    for dtype in [jnp.float32, jnp.float64]:
+      for n in [1, 2, 3]:
+        val = lsp_special.expn(n, dtype(inf))
+        self.assertEqual(float(val), 0.0,
+                         f"expn({n}, inf) dtype={dtype}: expected 0, got {val}")
+      self.assertEqual(float(lsp_special.exp1(dtype(inf))), 0.0,
+                       f"exp1(inf) dtype={dtype}: expected 0")
+      self.assertTrue(jnp.isposinf(lsp_special.expi(dtype(inf))),
+                      f"expi(+inf) dtype={dtype}: expected +inf")
+      # expi(-inf) = -exp1(+inf) = -0; the sign bit may differ by dtype
+      self.assertEqual(abs(float(lsp_special.expi(dtype(-inf)))), 0.0,
+                       f"expi(-inf) dtype={dtype}: expected 0")
+
   def testExpnTracerLeaks(self):
     # Regression test for https://github.com/jax-ml/jax/issues/26972
     with jax.checking_leaks():


### PR DESCRIPTION
`expn`, `exp1`, and `expi` return `nan` at infinite arguments where the limit is finite and scipy returns it correctly.

`expn`/`exp1` hit an indeterminate `inf * 0` inside the continued-fraction branch even though `lax.select` should mask it — added an explicit `isinf(x) & (x > 0)` case returning `0` (the integrand vanishes as `t -> inf`). `expi(+inf)` hits the same `inf * 0` form in `_eval_expint_k` — wrapped the result in `jnp.where(isposinf(x), inf, result)`. `expi(-inf)` falls out for free once `exp1` is fixed.

Fixes #38519
