### PR TITLE
Add clear_cache to JitWrapped typing

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -677,6 +677,9 @@ class JitWrapped(stages.Wrapped):
   def trace(self, *args, **kwargs) -> stages.Traced:
     raise NotImplementedError
 
+  def clear_cache(self) -> None:
+    raise NotImplementedError
+
 
 # in_shardings and out_shardings can't be None as the default value
 # because `None` means that the input is fully replicated.


### PR DESCRIPTION
## Summary

Adds the missing `clear_cache()` declaration to `JitWrapped`, matching the method installed on jitted functions at runtime.

Fixes #38244.

## Validation

- `python3 -m py_compile jax/_src/pjit.py`
- AST check that `JitWrapped` declares `clear_cache`

I could not run import-based JAX tests locally because this checkout requires `jaxlib>=0.10.1`, which is not installed in this environment.