### PR TITLE
Fix mesh prime factorization with large remainders

### DIFF
--- a/jax/_src/mesh_utils.py
+++ b/jax/_src/mesh_utils.py
@@ -459,7 +459,8 @@ def _get_prime_factors(x: int) -> list[int]:
       x //= p
     if x == 1:
       return factors
-  factors.append(x)
+  if x > 1:
+    factors.append(x)
   return factors
 
 

--- a/jax/_src/mesh_utils.py
+++ b/jax/_src/mesh_utils.py
@@ -459,8 +459,8 @@ def _get_prime_factors(x: int) -> list[int]:
       x //= p
     if x == 1:
       return factors
-  else:
-    return [x]  # x is a prime number.
+  factors.append(x)
+  return factors
 
 
 def _enumerate_feasible_logical_axis_assignments(

--- a/tests/mesh_utils_test.py
+++ b/tests/mesh_utils_test.py
@@ -724,6 +724,8 @@ class SplitAxesDeviceMeshCreationTest(test_util.JaxTestCase):
     self.assertEqual(mesh_utils._get_prime_factors(4), [2, 2])
     self.assertEqual(mesh_utils._get_prime_factors(8), [2, 2, 2])
     self.assertEqual(mesh_utils._get_prime_factors(6), [2, 3])
+    self.assertEqual(mesh_utils._get_prime_factors(10), [2, 5])
+    self.assertEqual(mesh_utils._get_prime_factors(22), [2, 11])
     self.assertEqual(mesh_utils._get_prime_factors(16), [2, 2, 2, 2])
     self.assertEqual(mesh_utils._get_prime_factors(12), [2, 2, 3])
     self.assertEqual(mesh_utils._get_prime_factors(121), [11, 11])  # square


### PR DESCRIPTION
## Summary

- preserve factors already found when the remaining quotient is a larger prime
- add regression coverage for axis sizes 10 and 22

## Root cause

`_get_prime_factors` returned `[x]` from a `for ... else` block after trial division completed. When a smaller factor had already been removed, that discarded the accumulated factors and returned only the remaining prime. This produced incomplete logical mesh factorization for sizes such as 10, 14, and 22.

## Validation

- `git diff --check`
- Exhaustively validated values 1 through 10000: factors are sorted primes and their product reconstructs the input.
- Attempted `python -m pytest tests/mesh_utils_test.py -k get_prime_factors -q`; local collection is blocked by a `jaxlib 0.10.2` macOS arm64 `cpu_sparse` import segmentation fault before tests run.

Fixes #38286
