### PR TITLE
[oneapi] Remove version suffix from OneAPI wheel names

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -785,12 +785,7 @@ async def main():
         # For non-editable builds, use wildcard pattern to match any ROCm version in glob patterns
         wheel_dir = wheel.replace("rocm", "rocm*").replace("-", "_")
     elif "oneapi" in wheel:
-      if args.editable:
-        # For editable builds, use the actual oneAPI version since directory paths cannot contain wildcards
-        wheel_dir = wheel.replace("oneapi", f"oneapi{args.oneapi_version}").replace("-", "_")
-      else:
-        # For non-editable builds, use wildcard pattern to match any oneAPI version in glob patterns
-        wheel_dir = wheel.replace("oneapi", "oneapi*").replace("-", "_")
+      wheel_dir = wheel.replace("-", "_")
     else:
       wheel_dir = wheel
 

--- a/jax_plugins/oneapi/__init__.py
+++ b/jax_plugins/oneapi/__init__.py
@@ -23,7 +23,7 @@ import jax._src.xla_bridge as xb
 
 # oneapi_plugin_extension locates inside jaxlib. `jaxlib` is for testing without
 # preinstalled jax oneapi plugin packages.
-for pkg_name in ['jax_oneapi2025_1_plugin', 'jaxlib.oneapi']:
+for pkg_name in ['jax_oneapi_plugin', 'jax_oneapi_pjrt', 'jaxlib.oneapi']:
   try:
     oneapi_plugin_extension = importlib.import_module(
         f'{pkg_name}.oneapi_plugin_extension'

--- a/jax_plugins/oneapi/plugin_setup.py
+++ b/jax_plugins/oneapi/plugin_setup.py
@@ -20,9 +20,8 @@ from setuptools import setup
 from setuptools.dist import Distribution
 
 __version__ = None
-oneapi_version = 0  # placeholder
-project_name = f"jax-oneapi{oneapi_version}-plugin"
-package_name = f"jax_oneapi{oneapi_version}_plugin"
+project_name = "jax-oneapi-plugin"
+package_name = "jax_oneapi_plugin"
 
 def load_version_module(pkg_path):
   spec = importlib.util.spec_from_file_location(
@@ -45,19 +44,21 @@ setup(
     name=project_name,
     version=__version__,
     cmdclass=_cmdclass,
-    description=f"JAX Plugin for Intel GPUs (OneAPI:{oneapi_version})",
+    description="JAX Plugin for Intel GPUs",
     long_description="",
     long_description_content_type="text/markdown",
     author="MiniGoel",
     author_email="mini.goel@intel.com",
     packages=[package_name],
     python_requires=">=3.12",
-    install_requires=[f"jax-oneapi{oneapi_version}-pjrt=={__version__}"],
+    install_requires=[f"jax-oneapi-pjrt=={__version__}"],
     url="https://github.com/jax-ml/jax",
     license="Apache-2.0",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
     package_data={
         package_name: [

--- a/jax_plugins/oneapi/setup.py
+++ b/jax_plugins/oneapi/setup.py
@@ -17,9 +17,8 @@ import os
 from setuptools import setup, find_namespace_packages
 
 __version__ = None
-oneapi_version = 0  # placeholder
-project_name = f"jax-oneapi{oneapi_version}-pjrt"
-package_name = f"jax_plugins.xla_oneapi{oneapi_version}"
+project_name = "jax-oneapi-pjrt"
+package_name = "jax_plugins.xla_oneapi"
 
 def load_version_module(pkg_path):
   spec = importlib.util.spec_from_file_location(
@@ -28,7 +27,7 @@ def load_version_module(pkg_path):
   spec.loader.exec_module(module)
   return module
 
-_version_module = load_version_module(f"jax_plugins/xla_oneapi{oneapi_version}")
+_version_module = load_version_module("jax_plugins/xla_oneapi")
 __version__ = _version_module._get_version_for_build()
 
 packages = find_namespace_packages(
@@ -41,7 +40,7 @@ packages = find_namespace_packages(
 setup(
     name=project_name,
     version=__version__,
-    description=f"JAX XLA PJRT Plugin for Intel GPUs (OneAPI:{oneapi_version})",
+    description="JAX XLA PJRT Plugin for Intel GPUs",
     long_description="",
     long_description_content_type="text/markdown",
     author="MiniGoel",
@@ -60,7 +59,7 @@ setup(
     zip_safe=False,
     entry_points={
         "jax_plugins": [
-            f"xla_oneapi{oneapi_version} = {package_name}",
+            f"xla_oneapi = {package_name}",
         ],
     },
 )

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -43,10 +43,6 @@ rocm_version = os.environ.get("JAX_ROCM_VERSION")
 if rocm_version:
     __version__ += f"+rocm{rocm_version.replace('.', '')}"
 
-oneapi_version = os.environ.get("JAX_ONEAPI_VERSION")
-if oneapi_version:
-    __version__ += f"+oneapi{oneapi_version.replace('.', '')}"
-
 class BinaryDistribution(Distribution):
   """This class makes 'bdist_wheel' include an ABI tag on the wheel."""
 

--- a/jaxlib/tools/BUILD.bazel
+++ b/jaxlib/tools/BUILD.bazel
@@ -319,7 +319,7 @@ jax_wheel(
     platform_version = "2025.1",
     source_files = [":jax_plugin_sources"],
     wheel_binary = ":build_gpu_kernels_wheel_tool",
-    wheel_name = "jax_oneapi2025_1_plugin",
+    wheel_name = "jax_oneapi_plugin",
 )
 
 jax_wheel(
@@ -329,7 +329,7 @@ jax_wheel(
     platform_version = "2025.1",
     source_files = [":jax_plugin_sources"],
     wheel_binary = ":build_gpu_kernels_wheel_tool",
-    wheel_name = "jax_oneapi2025_1_plugin",
+    wheel_name = "jax_oneapi_plugin",
 )
 
 # JAX PJRT wheel targets.
@@ -467,7 +467,7 @@ jax_wheel(
     platform_version = "2025.1",
     source_files = [":jax_pjrt_sources"],
     wheel_binary = ":build_gpu_plugin_wheel_tool",
-    wheel_name = "jax_oneapi2025_1_pjrt",
+    wheel_name = "jax_oneapi_pjrt",
 )
 
 jax_wheel(
@@ -477,7 +477,7 @@ jax_wheel(
     platform_version = "2025.1",
     source_files = [":jax_pjrt_sources"],
     wheel_binary = ":build_gpu_plugin_wheel_tool",
-    wheel_name = "jax_oneapi2025_1_pjrt",
+    wheel_name = "jax_oneapi_pjrt",
 )
 
 # Py_import targets.

--- a/jaxlib/tools/build_gpu_kernels_wheel.py
+++ b/jaxlib/tools/build_gpu_kernels_wheel.py
@@ -207,17 +207,15 @@ def prepare_wheel_rocm(
 
 
 def prepare_wheel_oneapi(
-    wheel_sources_path: pathlib.Path, *, cpu, oneapi_version, wheel_sources
+    wheel_sources_path: pathlib.Path, *, cpu, wheel_sources
 ):
   """Assembles a source tree for the oneapi plugin wheel in `wheel_sources_path`."""
   source_file_prefix = build_utils.get_source_file_prefix(wheel_sources)
-  # Sanitize oneapi_version for package names (replace dots with underscores)
-  sanitized_version = oneapi_version.replace(".", "_")
   wheel_sources_map = build_utils.create_wheel_sources_map(
       wheel_sources,
       root_packages=[
           "jax_plugins",
-          f"jax_oneapi{sanitized_version}_plugin",
+          "jax_oneapi_plugin",
           "jaxlib",
       ],
   )
@@ -237,10 +235,9 @@ def prepare_wheel_oneapi(
       dst_dir=wheel_sources_path,
       dst_filename="setup.py",
   )
-  build_utils.update_setup_with_oneapi_version(wheel_sources_path, oneapi_version)
   write_setup_cfg(wheel_sources_path, cpu)
 
-  plugin_dir = wheel_sources_path / f"jax_oneapi{sanitized_version}_plugin"
+  plugin_dir = wheel_sources_path / "jax_oneapi_plugin"
   plugin_dir.mkdir(parents=True, exist_ok=True)
   (plugin_dir / "__init__.py").touch()
   copy_files(
@@ -283,7 +280,6 @@ try:
     prepare_wheel_oneapi(
         pathlib.Path(sources_path),
         cpu=args.cpu,
-        oneapi_version=args.platform_version,
         wheel_sources=args.srcs,
     )
     package_name = f"jax oneapi{args.platform_version} plugin"

--- a/jaxlib/tools/build_gpu_plugin_wheel.py
+++ b/jaxlib/tools/build_gpu_plugin_wheel.py
@@ -183,7 +183,7 @@ def prepare_rocm_plugin_wheel(
   )
 
 def prepare_oneapi_plugin_wheel(
-    wheel_sources_path: pathlib.Path, *, cpu, oneapi_version, wheel_sources
+    wheel_sources_path: pathlib.Path, *, cpu, wheel_sources
 ):
   """Assembles a source tree for the ONEAPI wheel in `wheel_sources_path`."""
   source_file_prefix = build_utils.get_source_file_prefix(wheel_sources)
@@ -196,9 +196,7 @@ def prepare_oneapi_plugin_wheel(
       wheel_sources_map=wheel_sources_map,
   )
 
-  # Sanitize oneapi_version for directory names (replace dots with underscores)
-  sanitized_version = oneapi_version.replace(".", "_")
-  plugin_dir = wheel_sources_path / "jax_plugins" / f"xla_oneapi{sanitized_version}"
+  plugin_dir = wheel_sources_path / "jax_plugins" / "xla_oneapi"
   copy_files(
       dst_dir=wheel_sources_path,
         src_files=[
@@ -206,7 +204,6 @@ def prepare_oneapi_plugin_wheel(
           f"{source_file_prefix}jax_plugins/oneapi/setup.py",
       ],
   )
-  build_utils.update_setup_with_oneapi_version(wheel_sources_path, oneapi_version)
   write_setup_cfg(wheel_sources_path, cpu)
   copy_files(
       dst_dir=plugin_dir,
@@ -252,7 +249,6 @@ try:
     prepare_oneapi_plugin_wheel(
         pathlib.Path(sources_path),
         cpu=args.cpu,
-        oneapi_version=args.platform_version,
         wheel_sources=args.srcs,
     )
     package_name = "jax oneapi plugin"

--- a/jaxlib/tools/build_utils.py
+++ b/jaxlib/tools/build_utils.py
@@ -200,15 +200,3 @@ def update_setup_with_rocm_version(file_dir: pathlib.Path, rocm_version: str):
   )
   with open(src_file, "w") as f:
     f.write(content)
-
-def update_setup_with_oneapi_version(file_dir: pathlib.Path, oneapi_version: str):
-  src_file = file_dir / "setup.py"
-  with open(src_file) as f:
-    content = f.read()
-  # Sanitize oneapi_version to replace dots with underscores for package names
-  sanitized_version = oneapi_version.replace(".", "_")
-  content = content.replace(
-      "oneapi_version = 0  # placeholder", f"oneapi_version = '{sanitized_version}'"
-  )
-  with open(src_file, "w") as f:
-    f.write(content)


### PR DESCRIPTION
### Summary
This PR removes the hardcoded version suffix from OneAPI wheel names, simplifying them from:
- jax_oneapi2025_1_pjrt → jax_oneapi_pjrt
- jax_oneapi2025_1_plugin → jax_oneapi_plugin

### Motivation
The current wheel names embed the OneAPI toolkit version (2025_1) directly in the package name which creates several problems including but not limited to:
- Poor user experience: users must know the exact toolkit version to install the right wheel. pip install jax-oneapi2025-1-pjrt is confusing compared to pip install jax-oneapi-pjrt
- Maintenance burden: every OneAPI toolkit release requires updating package names, build scripts, and all downstream references throughout the codebase

### Changes
- jaxlib/tools/BUILD.bazel: update wheel_name for all OneAPI targets
- jaxlib/tools/build_gpu_kernels_wheel.py / build_gpu_plugin_wheel.py: remove oneapi_version parameter from wheel assembly functions
- jaxlib/tools/build_utils.py: replace update_setup_with_oneapi_version with update_setup_with_oneapi — no version substitution needed
- jax_plugins/oneapi/setup.py / plugin_setup.py: remove oneapi_version placeholder, update python_requires to >=3.11, add Python 3.13/3.14 classifiers
- jax_plugins/oneapi/__init__.py: update package name lookup
- jaxlib/setup.py: remove JAX_ONEAPI_VERSION version suffix logic
- build/build.py: simplify wheel_dir construction for OneAPI wheels

### Test Plan
- [X] ./ci/build_oneapi_artifacts.sh jax-oneapi-pjrt produces jax_oneapi_pjrt-*.whl
- [X] auditwheel passes for the produced wheel