### PR TITLE
[Pallas][Mosaic GPU] Updated candidate layout search in broadcast_in_dim

### DIFF
--- a/jax/_src/pallas/mosaic_gpu/lowering.py
+++ b/jax/_src/pallas/mosaic_gpu/lowering.py
@@ -2435,6 +2435,9 @@ def _broadcast_in_dim_lowering_rule(
     for candidate in candidates:
       if len(candidate.base_tile_shape) != len(shape):
         continue
+      # check if base_tile_shape is compatible with shape
+      if any(s % t != 0 for s, t in zip(shape, candidate.base_tile_shape)):
+        continue
       if candidate.reduce(new_dims) == layout:
         if new_layout is None:
           new_layout = candidate

--- a/jax/experimental/mosaic/gpu/fragmented_array.py
+++ b/jax/experimental/mosaic/gpu/fragmented_array.py
@@ -3461,7 +3461,10 @@ class FragmentedArray:
     if not isinstance(self.layout, TiledLayout) or not isinstance(layout, TiledLayout):
       raise NotImplementedError(self.layout, layout)
     if len(layout.base_tile_shape) != len(shape):
-      raise NotImplementedError("Tiling rank different than broadcast result rank")
+      raise NotImplementedError(
+          "Tiling rank different than broadcast result rank, "
+          f"{layout.base_tile_shape} vs {shape}"
+      )
     new_dimensions = sorted(set(range(len(shape))) - set(source_dimensions))
     expected_layout = layout.reduce(new_dimensions)
     if expected_layout != self.layout:


### PR DESCRIPTION
This helps to get a cleaner error when we can not apply the layout to the output instead of errors like
```python
raise ValueError(f"Tiling {self.tiles} does not apply to shape {orig_shape}")
ValueError: Tiling ((64, 8), (16, 8), (8, 8), (2,)) does not apply to shape (16, 128)
```
