### PR TITLE
Raise clear error for jnp.compress/jnp.extract under jit without size

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -9033,7 +9033,12 @@ def compress(condition: ArrayLike, a: ArrayLike, axis: int | None = None,
   arr = arr[:condition_arr.shape[0]]
 
   if size is None:
-    if reductions.any(extra):
+    msg = ("The size argument of jnp.compress must be specified in order to use "
+           "jnp.compress within JAX transformations like jax.jit, jax.vmap, and "
+           "jax.grad. For more information, refer to the jnp.compress documentation.")
+    condition_arr = core.concrete_or_error(None, condition_arr, msg)
+    extra = core.concrete_or_error(None, extra, msg)
+    if extra.any():
       raise ValueError("condition contains entries that are out of bounds")
     result = arr[condition_arr]
   elif not 0 <= size <= arr.shape[0]:

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1578,6 +1578,19 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jnp_fun = lambda condition, x: jnp.asarray(x).compress(condition, axis=axis)
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
 
+  def testCompressExtractJitErrorMessage(self):
+    # Without a static `size`, the output shape of compress/extract is
+    # data-dependent, so they cannot be used within transformations like jit.
+    # In that case we should raise a clear ConcretizationTypeError pointing the
+    # user at the `size` argument, rather than a confusing internal error.
+    # https://github.com/jax-ml/jax/issues/38603
+    x = jnp.ones((4, 4), dtype=jnp.float32)
+    msg = "The size argument of jnp.compress must be specified"
+    with self.assertRaisesRegex(core.ConcretizationTypeError, msg):
+      jax.jit(jnp.compress)(x.ravel() > 0, x.ravel())
+    with self.assertRaisesRegex(core.ConcretizationTypeError, msg):
+      jax.jit(jnp.extract)(x > 0, x)
+
   @jtu.sample_product(
     [dict(base_shape=base_shape, axis=axis)
       for base_shape in [(4,), (3, 4), (2, 3, 4)]


### PR DESCRIPTION
## Summary

Fixes #38603.

`jnp.compress` and `jnp.extract` crash with a confusing `TracerBoolConversionError` when called inside `jax.jit` without a `size` argument. The error originates in JAX's own implementation, where the `size=None` branch of `jnp.compress` calls `reductions.any(extra)` on a traced array.

Because the `size=None` path produces a **data-dependent output shape**, it fundamentally cannot be made JIT-compatible (the same is true of `jnp.nonzero` and `jnp.unique` without `size`). This PR therefore makes the failure mode clear and actionable: the `size=None` branch now concretizes the condition via `core.concrete_or_error`, so calling these functions under a transformation raises a `ConcretizationTypeError` that points the user at the `size` argument — matching the behavior of `jnp.nonzero`.

## Behavior

Before:

```
jax.errors.TracerBoolConversionError: Attempted boolean conversion of traced array with shape bool[].
```

After:

```
jax.errors.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected: ...
The size argument of jnp.compress must be specified in order to use jnp.compress within JAX
transformations like jax.jit, jax.vmap, and jax.grad. ...
```

- Eager execution of `compress`/`extract` is unchanged.
- The `size=`-specified JIT path is unchanged and still works.
- The out-of-bounds `ValueError` for oversized conditions is preserved.

## Testing

Added `testCompressExtractJitErrorMessage` covering both `compress` and `extract`, asserting the clear `ConcretizationTypeError` without `size` and successful JIT execution with `size`.