### PR TITLE
Fix jax.scipy.special.betaln returning nan for negative-integer inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * Support for Python 3.11, NumPy 2.0, and SciPy 1.14 has been dropped, per the
     [deprecation policy](https://docs.jax.dev/en/latest/deprecation.html).
 
+* Bug fixes
+  * {func}`jax.scipy.special.betaln` now returns the correct finite value
+    instead of `nan` when ``a`` is a non-positive integer and ``a + b`` is also
+    a non-positive integer (e.g. ``betaln(-2, 1)``), matching
+    {func}`scipy.special.betaln` ({jax-issue}`#38243`).
+
 ## JAX 0.10.2 (June 17, 2026)
 
 * New features

--- a/jax/_src/third_party/scipy/betaln.py
+++ b/jax/_src/third_party/scipy/betaln.py
@@ -60,4 +60,25 @@ def betaln(a: ArrayLike, b: ArrayLike) -> Array:
     a, b = jnp.minimum(a, b), jnp.maximum(a, b)
     small_b = lax.lgamma(a) + (lax.lgamma(b) - lax.lgamma(a + b))
     large_b = lax.lgamma(a) + algdiv(a, b)
-    return jnp.where(b < 8, small_b, large_b)
+    result = jnp.where(b < 8, small_b, large_b)
+    # When both ``a`` and ``a + b`` are non-positive integers, ``gamma`` has a
+    # pole at each, so ``lgamma(a)`` and ``lgamma(a + b)`` are both ``+inf`` and
+    # the expression above evaluates to ``nan``. The beta function is finite
+    # there, however, because the poles cancel: taking the limit ``a -> -n`` via
+    # the residues of ``gamma`` gives
+    #   B(a, b) = (-1)**b * gamma(b) * gamma(1 - a - b) / gamma(1 - a),
+    # so ``betaln`` is ``lgamma(b) + lgamma(1 - a - b) - lgamma(1 - a)``. This
+    # also yields the correct ``+inf`` when ``b`` is a non-positive integer.
+    both_poles = _is_nonpos_int(a) & _is_nonpos_int(a + b)
+    # Evaluate the reflection formula on safe arguments where it is unused, so
+    # that the final ``where`` does not introduce nan gradients for ordinary
+    # inputs (``lgamma`` has infinite derivatives at its own poles).
+    safe_a = jnp.where(both_poles, a, -1.0)
+    safe_b = jnp.where(both_poles, b, 1.0)
+    reflected = (lax.lgamma(safe_b) + lax.lgamma(1 - safe_a - safe_b)
+                 - lax.lgamma(1 - safe_a))
+    return jnp.where(both_poles, reflected, result)
+
+
+def _is_nonpos_int(x: Array) -> Array:
+    return (x <= 0) & (x == jnp.floor(x)) & jnp.isfinite(x)

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -345,6 +345,26 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
         self.assertAllClose(osp_special.gammasgn(inp),
                             lsp_special.gammasgn(inp))
 
+  def testBetalnNegativeIntegers(self):
+    # ref: https://github.com/jax-ml/jax/issues/38243
+    # When `a` is a non-positive integer and `a + b` is also a non-positive
+    # integer, gamma has a pole at both, so the naive
+    # lgamma(a) + lgamma(b) - lgamma(a + b) gives nan even though the poles
+    # cancel and the true value is finite.
+    dtype = jnp.zeros(0).dtype  # default float dtype.
+    # Build all (a, b) pairs with a a negative integer and b an integer.
+    a_vals, b_vals = [], []
+    for a in range(-6, 0):
+      for b in range(-6, 7):
+        a_vals.append(a)
+        b_vals.append(b)
+    args_maker = lambda: [np.array(a_vals, dtype=dtype),
+                          np.array(b_vals, dtype=dtype)]
+    rtol = 1E-3 if jtu.test_device_matches(["tpu"]) else 1e-5
+    self._CheckAgainstNumpy(osp_special.betaln, lsp_special.betaln, args_maker,
+                            rtol=rtol)
+    self._CompileAndCheck(lsp_special.betaln, args_maker, rtol=rtol)
+
   def testNdtriExtremeValues(self):
     # Testing at the extreme values (bounds (0. and 1.) and outside the bounds).
     dtype = jnp.zeros(0).dtype  # default float dtype.


### PR DESCRIPTION
## Summary

Fixes #38243.

`jax.scipy.special.betaln(a, b)` returns `nan` when `a` is a negative integer and `b <= |a|`, where the mathematically correct result is finite (and SciPy/mpmath return a finite value).

### Root cause

The implementation computes `lgamma(a) + lgamma(b) - lgamma(a + b)`. When `a` is a non-positive integer **and** `a + b` is also a non-positive integer, `gamma` has a pole at both points, so `lgamma(a)` and `lgamma(a + b)` are each `+inf` and the result is `inf - inf = nan`. The beta function is finite there because the two poles cancel.

### Fix

Taking the limit `a -> -n` via the residues of `gamma`:

```
B(a, b) = (-1)**b * gamma(b) * gamma(1 - a - b) / gamma(1 - a)
```

so in this regime `betaln(a, b) = lgamma(b) + lgamma(1 - a - b) - lgamma(1 - a)`. The fix applies this reflection formula exactly when both `a` and `a + b` are non-positive integers. As a bonus, this also fixes the case where `b` is itself a non-positive integer (both arguments negative integers), which previously returned `nan` instead of SciPy's `+inf`.

The reflection branch is evaluated on safe arguments where it is unused, so the added `jnp.where` does not introduce `nan` gradients for ordinary inputs (`lgamma` has infinite derivatives at its own poles).

### Behavior

| call | before | after | scipy |
|------|--------|-------|-------|
| `betaln(-1, 1)` | `nan` | `0.0000` | `0.0000` |
| `betaln(-2, 1)` | `nan` | `-0.6931` | `-0.6931` |
| `betaln(-3, 2)` | `nan` | `-1.7918` | `-1.7918` |
| `betaln(-4, 4)` | `nan` | `-1.3863` | `-1.3863` |
| `betaln(-3, -1)` | `nan` | `inf` | `inf` |

## Testing

- New regression test `testBetalnNegativeIntegers` compares against `scipy.special.betaln` for a grid of negative-integer `a` and integer `b`, under both eager execution and jit.
- Verified against SciPy over a broader mixed grid (negative integers, zero, non-integers, large values) with no regressions to the previously-correct `inf`/`-inf`/finite cases.
- Verified gradients for ordinary (positive) inputs are unchanged and match `digamma(a) - digamma(a + b)`.