### PR TITLE
[Fix] jax.jit produces non-finite gradients for a function involving jnp.cross(x, x) and jnp.linalg.cholesky where eager gradients are finite

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -7939,7 +7939,6 @@ def apply_over_axes(func: Callable[[ArrayLike, int], Array], a: ArrayLike,
 
 
 @export
-@api.jit(static_argnames=('axisa', 'axisb', 'axisc', 'axis'))
 def cross(a, b, axisa: int = -1, axisb: int = -1, axisc: int = -1,
           axis: int | None = None):
   r"""Compute the (batched) cross product of two arrays.
@@ -8020,9 +8019,27 @@ def cross(a, b, axisa: int = -1, axisb: int = -1, axisc: int = -1,
     axisa = axis
     axisb = axis
     axisc = axis
+
+  if a is b:
+    ndim = np.ndim(a)
+    axisa = _canonicalize_axis(axisa, ndim)
+    axisb = _canonicalize_axis(axisb, ndim)
+    if axisa == axisb:
+      dimension = np.shape(a)[axisa]
+      if dimension not in (2, 3):
+        raise ValueError("Dimension must be either 2 or 3 for cross product")
+      if dimension == 2:
+        return array_creation.zeros_like(moveaxis(a, axisa, -1)[..., 0])
+      return array_creation.zeros_like(moveaxis(a, axisa, axisc))
+
+  return _cross(a, b, axisa, axisb, axisc)
+
+
+@api.jit(static_argnames=('axisa', 'axisb', 'axisc'))
+def _cross(a, b, axisa: int = -1, axisb: int = -1, axisc: int = -1):
+  util.check_arraylike("cross", a, b)
   a = moveaxis(a, axisa, -1)
   b = moveaxis(b, axisb, -1)
-
   if a.shape[-1] not in (2, 3) or b.shape[-1] not in (2, 3):
     raise ValueError("Dimension must be either 2 or 3 for cross product")
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -511,6 +511,29 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, tol=tol)
       self._CompileAndCheck(jnp_fun, args_maker, atol=tol, rtol=tol)
 
+  def testCrossSameArgumentJitGradCholeskyFinite(self):
+    key = jax.random.PRNGKey(921742)
+    key, k1 = jax.random.split(key)
+    t1 = jax.random.normal(k1, (16, 3))
+    key, k2 = jax.random.split(key)
+    t2 = jax.random.normal(k2, (16, 3))
+    key, k3 = jax.random.split(key)
+    t3 = jax.random.normal(k3, (16, 3))
+
+    def model(t1, t2, t3):
+      scale = t1.shape[-1] ** -0.5
+      w = jax.nn.softmax(
+          jnp.matmul(t1, jnp.swapaxes(t2, -2, -1)) * scale, axis=-1)
+      t = jnp.matmul(w, t3)
+      c = jnp.cross(t, t)
+      a = c / (jnp.linalg.norm(c) + 1.0)
+      a = jnp.matmul(a, a.T) + jnp.eye(16)
+      l = jnp.linalg.cholesky(a)
+      return jnp.vecdot(l, l).sum()
+
+    grads = jax.jit(jax.grad(model, argnums=(0, 1, 2)))(t1, t2, t3)
+    self.assertTrue(all(bool(jnp.isfinite(g).all()) for g in grads))
+
   @jtu.sample_product(
     [dict(lhs_shape=lhs_shape, rhs_shape=rhs_shape)
       for lhs_shape, rhs_shape in [


### PR DESCRIPTION
Fixes: #38611 
jnp.cross(x, x) now returns exact zeros when both operands are the same object and the vector axes match. The old implementation was: JAX split t, t into two tracer arguments before the function body could notice they were identical. I split it into a small public wrapper plus a jitted _cross fallback.
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->