### PR TITLE
Fix normalization factor math formulas in multivariate_normal docstrings

### DIFF
--- a/jax/_src/scipy/stats/multivariate_normal.py
+++ b/jax/_src/scipy/stats/multivariate_normal.py
@@ -33,7 +33,7 @@ def logpdf(x: ArrayLike, mean: ArrayLike, cov: ArrayLike, allow_singular: None =
 
   .. math::
 
-     f(x) = \frac{1}{(2\pi)^k\det\Sigma}\exp\left(-\frac{(x-\mu)^T\Sigma^{-1}(x-\mu)}{2} \right)
+     f(x) = \frac{1}{\sqrt{(2\pi)^k\det\Sigma}}\exp\left(-\frac{(x-\mu)^T\Sigma^{-1}(x-\mu)}{2} \right)
 
   where :math:`\mu` is the ``mean``, :math:`\Sigma` is the covariance matrix (``cov``), and
   :math:`k` is the rank of :math:`\Sigma`.
@@ -83,7 +83,7 @@ def pdf(x: ArrayLike, mean: ArrayLike, cov: ArrayLike) -> Array:
 
   .. math::
 
-     f(x) = \frac{1}{(2\pi)^k\det\Sigma}\exp\left(-\frac{(x-\mu)^T\Sigma^{-1}(x-\mu)}{2} \right)
+     f(x) = \frac{1}{\sqrt{(2\pi)^k\det\Sigma}}\exp\left(-\frac{(x-\mu)^T\Sigma^{-1}(x-\mu)}{2} \right)
 
   where :math:`\mu` is the ``mean``, :math:`\Sigma` is the covariance matrix (``cov``), and
   :math:`k` is the rank of :math:`\Sigma`.


### PR DESCRIPTION
### Problem
As noted in #38615, the documentation strings for `jax.scipy.stats.multivariate_normal.pdf` and `jax.scipy.stats.multivariate_normal.logpdf` contained a math notation error. The normalization factor in the LaTeX block omitted the square root term over the denominator, diverging from the standard formulation and upstream SciPy's reference documentation.

### Solution
Updated the `.. math::` blocks in both `pdf` and `logpdf` functions within `jax/_src/scipy/stats/multivariate_normal.py` to wrap the denominator term inside a `\sqrt{}` block:
$$\frac{1}{\sqrt{(2\pi)^k\det\Sigma}}$$

This is a pure documentation fix; the underlying runtime execution paths are mathematically correct and remain unchanged.

### Verification
- Validated that the file compiles cleanly via `py_compile`.
- Ran the local `pre-commit` hook suite to ensure style compliance.
- Ran the relevant unit tests to verify no regressions:
  ```bash
  pytest tests/scipy_stats_test.py
Result: All 972 passed.

Fixes #38615