### PR TITLE
Fix pallas tuple axes

### DIFF
--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -2496,10 +2496,25 @@ class OpsTest(PallasBaseTest):
           ("add", jnp.sum),
           ("max", jnp.max),
           ("min", jnp.min),
+      ]
+      for axis in [0, 1, (1,), (0, 1)]
+      for dtype in [
+          "float16",
+          "bfloat16",
+          "float32",
+          "float64",
+          "int32",
+          "int64",
+          "uint32",
+          "uint64",
+      ]
+  ] + [
+      (f"{op_name}_{dtype}_{axis}", op, dtype, axis)
+      for op_name, op in [
           ("argmax", jnp.argmax),
           ("argmin", jnp.argmin),
       ]
-      for axis in [0, 1, (1,), (0, 1)]
+      for axis in [0, 1]
       for dtype in [
           "float16",
           "bfloat16",


### PR DESCRIPTION
During the JAX/Pallas bring-up for Meroplane's Loom AI accelerator, I found that the parameter grid in ops_test.py passes tuple axes to argmin and argmax. Since those operations don't support tuple axes, it crashes JAX before the graph even reaches our compiler.