### PR TITLE
Fix Bazel XML error status parsing

### DIFF
--- a/ci/postprocess/BUILD
+++ b/ci/postprocess/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-load("//third_party/bazel_rules/rules_shell/shell:sh_binary.bzl", "sh_binary")
+load("//jaxlib:jax.bzl", "py_library", "py_test")
 
 package(
     default_applicable_licenses = [],
@@ -24,4 +24,15 @@ sh_binary(
     name = "process_test_results",
     srcs = ["process_test_results.sh"],
     data = [":xml2json.py"],
+)
+
+py_library(
+    name = "xml2json",
+    srcs = ["xml2json.py"],
+)
+
+py_test(
+    name = "xml2json_test",
+    srcs = ["xml2json_test.py"],
+    deps = [":xml2json"],
 )

--- a/ci/postprocess/xml2json.py
+++ b/ci/postprocess/xml2json.py
@@ -162,14 +162,14 @@ def process_xml(file_path, job_id, fallback_timestamp=None):
         status = tc.get("status")
         if failure is not None:
           record["status"] = "FAILED"
-        elif status == "notrun":
+        elif error is not None:
+          record["status"] = "ERROR"
+        elif skipped is not None or status == "notrun":
           record["status"] = "SKIPPED"
-        elif (
-            result == "completed" or result is None
-        ):  # Default to passed if completed or not specified.
+        elif result in (None, "completed"):
           record["status"] = "PASSED"
         else:
-          record["status"] = "PASSED"  # Final safety fallback.
+          record["status"] = "ERROR"
 
       else:  # Pytest format.
         cname = tc.get("classname")

--- a/ci/postprocess/xml2json_test.py
+++ b/ci/postprocess/xml2json_test.py
@@ -1,0 +1,70 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+
+from ci.postprocess import xml2json
+
+
+class Xml2JsonTest(unittest.TestCase):
+
+  def _process_bazel_xml(self, xml):
+    with tempfile.NamedTemporaryFile(
+        "w", prefix="tests__example_test__", suffix=".xml", delete=False
+    ) as f:
+      f.write(xml)
+      path = f.name
+
+    try:
+      output = io.StringIO()
+      with contextlib.redirect_stdout(output):
+        xml2json.process_xml(path, 123, "2026-06-20T00:00:00+00:00")
+      records = [json.loads(line) for line in output.getvalue().splitlines()]
+      return records[0] if len(records) == 1 else records
+    finally:
+      os.unlink(path)
+
+  def testBazelErrorElementIsReportedAsError(self):
+    record = self._process_bazel_xml("""\
+<testsuite>
+  <testcase name="x">
+    <error message="boom">stack trace</error>
+  </testcase>
+</testsuite>
+""")
+
+    self.assertEqual(record["status"], "ERROR")
+    self.assertEqual(record["message"], "boom")
+    self.assertEqual(record["detail"], "stack trace")
+
+  def testBazelSkippedElementIsReportedAsSkipped(self):
+    record = self._process_bazel_xml("""\
+<testsuite>
+  <testcase name="x">
+    <skipped message="ignored"/>
+  </testcase>
+</testsuite>
+""")
+
+    self.assertEqual(record["status"], "SKIPPED")
+    self.assertEqual(record["message"], "ignored")
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary

- report Bazel JUnit `<error>` testcases as `ERROR` instead of falling through to `PASSED`
- keep `<skipped>` elements from being reported as passed in the Bazel path
- add a focused regression test and wire it into `ci/postprocess` so this converter path is covered

## Testing

- `PYTHONPATH=. python3 ci/postprocess/xml2json_test.py`
- `HERMETIC_PYTHON_VERSION=3.12 npx --yes @bazel/bazelisk test //ci/postprocess:xml2json_test`