### PR TITLE
Fix poisson.cdf to return 1.0 when k is infinity

### DIFF
--- a/jax/_src/scipy/stats/poisson.py
+++ b/jax/_src/scipy/stats/poisson.py
@@ -119,11 +119,13 @@ def cdf(k: ArrayLike, mu: ArrayLike, loc: ArrayLike = 0) -> Array:
   inf = _lax_const(k, np.inf)
   x = lax.sub(k, loc)
   p = gammaincc(jnp.floor(1 + x), mu)
-  return jnp.select(
+  p = jnp.select(
     [lax.lt(x, zero), lax.eq(x, inf)],
     [zero, one],
     p,
   )
+  nan = _lax_const(mu, np.nan)
+  return jnp.where(jnp.isnan(mu) | lax.lt(mu, zero), nan, p)
 
 @api.jit
 def entropy(mu: ArrayLike, loc: ArrayLike = 0) -> Array:

--- a/jax/_src/scipy/stats/poisson.py
+++ b/jax/_src/scipy/stats/poisson.py
@@ -115,9 +115,15 @@ def cdf(k: ArrayLike, mu: ArrayLike, loc: ArrayLike = 0) -> Array:
   """
   k, mu, loc = promote_args_inexact("poisson.logpmf", k, mu, loc)
   zero = _lax_const(k, 0)
+  one = _lax_const(k, 1)
+  inf = _lax_const(k, np.inf)
   x = lax.sub(k, loc)
   p = gammaincc(jnp.floor(1 + x), mu)
-  return jnp.where(lax.lt(x, zero), zero, p)
+  return jnp.select(
+    [lax.lt(x, zero), lax.eq(x, inf)],
+    [zero, one],
+    p,
+  )
 
 @api.jit
 def entropy(mu: ArrayLike, loc: ArrayLike = 0) -> Array:

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -172,6 +172,16 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
                               tol=1e-3)
       self._CompileAndCheck(lax_fun, args_maker)
 
+  @jtu.sample_product(
+    dtype=jtu.dtypes.floating,
+  )
+  def testPoissonCdfBoundary(self, dtype):
+    mu = jnp.array([0.0, 0.1, 1.0, 5.0], dtype=dtype)
+    loc = jnp.array(0.0, dtype=dtype)
+    k = jnp.array(np.inf, dtype=dtype)
+    jax_result = lsp_stats.poisson.cdf(k, mu, loc=loc)
+    scipy_result = osp_stats.poisson.cdf(np.inf, np.asarray(mu), loc=0.0)
+    self.assertAllClose(jax_result, scipy_result, check_dtypes=False)
 
   @genNamedParametersNArgs(3)
   def testBernoulliLogPmf(self, shapes, dtypes):

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -176,12 +176,13 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     dtype=jtu.dtypes.floating,
   )
   def testPoissonCdfBoundary(self, dtype):
-    mu = jnp.array([0.0, 0.1, 1.0, 5.0], dtype=dtype)
+    mu = jnp.array([-1.0, 0.0, 0.1, 1.0, 5.0, np.nan], dtype=dtype)
     loc = jnp.array(0.0, dtype=dtype)
-    k = jnp.array(np.inf, dtype=dtype)
-    jax_result = lsp_stats.poisson.cdf(k, mu, loc=loc)
-    scipy_result = osp_stats.poisson.cdf(np.inf, np.asarray(mu), loc=0.0)
-    self.assertAllClose(jax_result, scipy_result, check_dtypes=False)
+    for k_val in [np.inf, -np.inf]:
+      k = jnp.array(k_val, dtype=dtype)
+      jax_result = lsp_stats.poisson.cdf(k, mu, loc=loc)
+      scipy_result = osp_stats.poisson.cdf(k_val, np.asarray(mu), loc=0.0)
+      self.assertAllClose(jax_result, scipy_result, check_dtypes=False)
 
   @genNamedParametersNArgs(3)
   def testBernoulliLogPmf(self, shapes, dtypes):


### PR DESCRIPTION
### Description

This PR addresses issue #38622 where `jax.scipy.stats.poisson.cdf` unexpectedly returns `nan` when `k` is positive infinity with a positive `mu`.

### Cause

`poisson.cdf` is implemented in terms of:

```python
gammaincc(jnp.floor(1 + (k - loc)), mu)
```

When `k=+inf`, the first argument to `gammaincc` becomes `a=+inf`. The underlying `igammac_impl` does not explicitly handle this boundary case, and intermediate computations involving `a` can produce undefined floating-point values that eventually propagate to the final result as `nan`.

### Fix

To handle this boundary case safely without touching the shared special functions, a simple boundary handling step using `jnp.select` was added directly inside `poisson.cdf`. Now, it explicitly returns `1.0` when `k` is positive infinity, matching the expected analytical behavior and SciPy's output.

A regression test `testPoissonCdfBoundary` has also been added to ensure compliance across different floating-point dtypes and various `mu` values.