### PR TITLE
Fix jax.scipy.stats.truncnorm cdf/sf/logcdf/logsf swallowing NaN input

### DIFF
--- a/jax/_src/scipy/stats/truncnorm.py
+++ b/jax/_src/scipy/stats/truncnorm.py
@@ -259,11 +259,11 @@ def logcdf(x, a, b, loc=0, scale=1):
     [0, -np.inf, jnp.log1p(-jnp.exp(logsf)), logcdf]
   )
   logcdf = jnp.where(a >= b, np.nan, logcdf)
-  # A NaN x satisfies none of the jnp.select conditions and would otherwise
-  # take the default value of 0; propagate it instead so that cdf/sf/logcdf/
-  # logsf match scipy and jax.scipy.stats.norm rather than silently returning
-  # a support-boundary value.
-  logcdf = jnp.where(jnp.isnan(x), np.nan, logcdf)
+  # A NaN x, a, or b satisfies none of the jnp.select conditions and would
+  # otherwise take the default value of 0; propagate it instead so that
+  # cdf/sf/logcdf/logsf match scipy and jax.scipy.stats.norm rather than
+  # silently returning a support-boundary value.
+  logcdf = jnp.where(jnp.isnan(x) | jnp.isnan(a) | jnp.isnan(b), np.nan, logcdf)
   return logcdf
 
 @api.jit

--- a/jax/_src/scipy/stats/truncnorm.py
+++ b/jax/_src/scipy/stats/truncnorm.py
@@ -259,6 +259,11 @@ def logcdf(x, a, b, loc=0, scale=1):
     [0, -np.inf, jnp.log1p(-jnp.exp(logsf)), logcdf]
   )
   logcdf = jnp.where(a >= b, np.nan, logcdf)
+  # A NaN x satisfies none of the jnp.select conditions and would otherwise
+  # take the default value of 0; propagate it instead so that cdf/sf/logcdf/
+  # logsf match scipy and jax.scipy.stats.norm rather than silently returning
+  # a support-boundary value.
+  logcdf = jnp.where(jnp.isnan(x), np.nan, logcdf)
   return logcdf
 
 @api.jit

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -1094,6 +1094,24 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
                               tol=1e-3)
 
+  @jtu.sample_product(
+    dtype=jtu.dtypes.floating,
+    fun=['cdf', 'sf', 'logcdf', 'logsf'],
+  )
+  def testTruncnormNanPropagation(self, dtype, fun):
+    # truncnorm.{cdf,sf,logcdf,logsf} previously swallowed a NaN x and returned
+    # a support-boundary value (1.0/0.0) because a NaN satisfies none of the
+    # jnp.select branches in logcdf and fell through to the default of 0. Check
+    # that NaN now propagates, matching scipy and jax.scipy.stats.norm.
+    lax_fun = getattr(lsp_stats.truncnorm, fun)
+    scipy_fun = getattr(osp_stats.truncnorm, fun)
+    x = jnp.array([np.nan, 0.5, np.nan], dtype=dtype)
+    a, b = dtype(-1.0), dtype(2.0)
+    jax_result = lax_fun(x, a, b)
+    scipy_result = scipy_fun(np.asarray(x), a, b)
+    self.assertArraysEqual(jnp.isnan(jax_result), np.isnan(scipy_result))
+    self.assertAllClose(jax_result, scipy_result, check_dtypes=False, rtol=1e-5)
+
   @genNamedParametersNArgs(4)
   def testParetoLogPdf(self, shapes, dtypes):
     rng = jtu.rand_positive(self.rng())

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -1099,16 +1099,18 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     fun=['cdf', 'sf', 'logcdf', 'logsf'],
   )
   def testTruncnormNanPropagation(self, dtype, fun):
-    # truncnorm.{cdf,sf,logcdf,logsf} previously swallowed a NaN x and returned
-    # a support-boundary value (1.0/0.0) because a NaN satisfies none of the
-    # jnp.select branches in logcdf and fell through to the default of 0. Check
-    # that NaN now propagates, matching scipy and jax.scipy.stats.norm.
+    # truncnorm.{cdf,sf,logcdf,logsf} previously swallowed a NaN in x, a, or b
+    # and returned a support-boundary value (1.0/0.0) because a NaN satisfies
+    # none of the jnp.select branches in logcdf and fell through to the default
+    # of 0. Check that a NaN in any of x, a, or b now propagates, matching scipy
+    # and jax.scipy.stats.norm.
     lax_fun = getattr(lsp_stats.truncnorm, fun)
     scipy_fun = getattr(osp_stats.truncnorm, fun)
-    x = jnp.array([np.nan, 0.5, np.nan], dtype=dtype)
-    a, b = dtype(-1.0), dtype(2.0)
+    x = jnp.array([np.nan, 0.5, 0.5, 0.5, 0.5, np.nan], dtype=dtype)
+    a = jnp.array([-1.0, -1.0, np.nan, -1.0, np.nan, np.nan], dtype=dtype)
+    b = jnp.array([2.0, 2.0, 2.0, np.nan, np.nan, np.nan], dtype=dtype)
     jax_result = lax_fun(x, a, b)
-    scipy_result = scipy_fun(np.asarray(x), a, b)
+    scipy_result = scipy_fun(np.asarray(x), np.asarray(a), np.asarray(b))
     self.assertArraysEqual(jnp.isnan(jax_result), np.isnan(scipy_result))
     self.assertAllClose(jax_result, scipy_result, check_dtypes=False, rtol=1e-5)
 


### PR DESCRIPTION
Fixes #38606.

## Bug

`jax.scipy.stats.truncnorm.{cdf,sf,logcdf,logsf}` swallow a NaN `x` and return a support-boundary value instead of propagating NaN:

```python
>>> import numpy as np
>>> from scipy.stats import truncnorm as tn_np
>>> from jax.scipy.stats import truncnorm as tn_jax
>>> tn_np.cdf(np.nan, -1.0, 2.0)     # nan
>>> tn_jax.cdf(np.nan, -1.0, 2.0)    # 1.0  (wrong)
>>> tn_np.logcdf(np.nan, -1.0, 2.0)  # nan
>>> tn_jax.logcdf(np.nan, -1.0, 2.0) # 0.0  (wrong)
```

This also disagrees with `jax.scipy.stats.norm`, which already propagates NaN.

## Root cause

`logcdf` selects its result with `jnp.select`:

```python
logcdf = jnp.select(
    [x >= b, x <= a, logcdf > -0.1, x > a],
    [0, -np.inf, jnp.log1p(-jnp.exp(logsf)), logcdf],
)
```

A NaN `x` satisfies none of these conditions, so it falls through to the `jnp.select` default of `0`. `cdf` is then `exp(0) = 1`, and `sf`/`logsf` route through `logcdf` as well, so all four functions return a boundary value for a NaN input.

## Fix

Propagate NaN at the end of `logcdf` (the single chokepoint that `cdf`, `sf`, and `logsf` all route through):

```python
logcdf = jnp.where(jnp.isnan(x), np.nan, logcdf)
```

One line, and it matches scipy and `jax.scipy.stats.norm`.

## Verification

`a = -1.0`, `b = 2.0` (scipy vs JAX, before and after the fix):

| fun    | x   | scipy  | old JAX | fixed JAX |
|--------|-----|--------|---------|-----------|
| cdf    | nan | nan    | 1.0     | nan       |
| cdf    | 0.5 | 0.5497 | 0.5497  | 0.5497    |
| sf     | nan | nan    | 1.0     | nan       |
| logcdf | nan | nan    | 0.0     | nan       |
| logsf  | nan | nan    | 0.0     | nan       |

Added a regression test (`testTruncnormNanPropagation`) covering all four functions over the floating dtypes, asserting both the NaN mask and that the non-NaN values match scipy. Ran locally on CPU: `4 passed`, and confirmed the test fails when the one-line fix is reverted. Finite, `+inf`, and `-inf` inputs are unchanged and continue to match scipy.
