### PR TITLE
Fix typo about ad checkpointing (under -> over budget)

### DIFF
--- a/docs/notebooks/host-offloading.ipynb
+++ b/docs/notebooks/host-offloading.ipynb
@@ -491,7 +491,7 @@
     "* Using checkpoint names to mark specific activations\n",
     "* Applying policies to control where and how activations are stored\n",
     "* Supporting common JAX patterns like scan operations\n",
-    "* Moving selected activations to host memory when device memory is under budget\n",
+    "* Moving selected activations to host memory when device memory is over budget\n",
     "\n",
     "This approach is particularly useful when working with large models that would otherwise exceed device memory capacity.\n",
     "\n",


### PR DESCRIPTION
> Moving selected activations to host memory when device memory is under budget

If device memory were under budget we wouldn't move the selected activations to host memory right?