### PR TITLE
Fix jax.scipy.stats.vonmises pdf/logpdf returning nan at kappa=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * Support for Python 3.11, NumPy 2.0, and SciPy 1.14 has been dropped, per the
     [deprecation policy](https://docs.jax.dev/en/latest/deprecation.html).
 
+* Bug fixes
+  * Fixed {func}`jax.scipy.stats.vonmises.pdf` and
+    {func}`jax.scipy.stats.vonmises.logpdf` returning `nan` at `kappa == 0`,
+    where the distribution reduces to the uniform distribution on the circle
+    (density `1 / (2 * pi)`), instead of the finite value returned by SciPy
+    ({jax-issue}`#38621`).
+
 ## JAX 0.10.2 (June 17, 2026)
 
 * New features

--- a/jax/_src/scipy/stats/vonmises.py
+++ b/jax/_src/scipy/stats/vonmises.py
@@ -48,7 +48,11 @@ def logpdf(x: ArrayLike, kappa: ArrayLike) -> Array:
   """
   x, kappa = promote_args_inexact('vonmises.logpdf', x, kappa)
   zero = _lax_const(kappa, 0)
-  return jnp.where(lax.gt(kappa, zero), kappa * (jnp.cos(x) - 1) - jnp.log(2 * np.pi * lax.bessel_i0e(kappa)), np.nan)
+  # kappa == 0 is a valid boundary case: the distribution reduces to the uniform
+  # distribution on the circle, with density 1 / (2 * pi). The closed-form
+  # expression already evaluates correctly there (bessel_i0e(0) == 1), so it is
+  # included via a non-strict comparison; only kappa < 0 is out of support.
+  return jnp.where(lax.ge(kappa, zero), kappa * (jnp.cos(x) - 1) - jnp.log(2 * np.pi * lax.bessel_i0e(kappa)), np.nan)
 
 
 def pdf(x: ArrayLike, kappa: ArrayLike) -> Array:

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -77,6 +77,26 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
                             tol=1e-3)
       self._CompileAndCheck(lax_fun, args_maker)
 
+  def testVonMisesPdfKappaZero(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/38621.
+    # kappa == 0 is a valid boundary case: the distribution reduces to the
+    # uniform distribution on the circle, with density 1 / (2 * pi). It must
+    # not be treated as out-of-support and return nan. The default RNG used by
+    # testVonMises{Pdf,LogPdf} essentially never samples kappa exactly 0, so
+    # the boundary is exercised explicitly here.
+    x = np.array([0.0, 1.0, -1.0, np.pi, -np.pi])
+    kappa = np.zeros_like(x)
+    self.assertAllClose(lsp_stats.vonmises.pdf(x, kappa),
+                        osp_stats.vonmises.pdf(x, kappa),
+                        check_dtypes=False, rtol=1e-5)
+    self.assertAllClose(lsp_stats.vonmises.logpdf(x, kappa),
+                        osp_stats.vonmises.logpdf(x, kappa),
+                        check_dtypes=False, rtol=1e-5)
+    self._CompileAndCheck(lsp_stats.vonmises.pdf, lambda: [x, kappa])
+    # kappa < 0 is out of support and still returns nan, matching scipy.
+    neg_kappa = np.full_like(x, -1.0)
+    self.assertTrue(np.all(np.isnan(lsp_stats.vonmises.pdf(x, neg_kappa))))
+
   @genNamedParametersNArgs(2)
   def testWrappedCauchyPdf(self, shapes, dtypes):
     rng = jtu.rand_default(self.rng())


### PR DESCRIPTION
Fixes #38621.

### Problem

`jax.scipy.stats.vonmises.pdf(x, kappa=0.0)` returns `nan` for finite `x`,
while SciPy returns `1 / (2 * pi) ≈ 0.15915494`. At `kappa == 0` the von Mises
distribution reduces to the uniform distribution on the circle, so the density
is a finite constant.

The cause is in `logpdf`, which guards the closed-form expression with a strict
comparison:

```python
jnp.where(lax.gt(kappa, zero), <closed-form density>, np.nan)
```

`kappa == 0` is a mathematically valid boundary value (excluded only by the
strict `>`), so it incorrectly falls into the `nan` branch. The closed-form
expression itself already evaluates correctly at `kappa == 0`, since
`bessel_i0e(0) == 1`, giving `logpdf = -log(2 * pi)`.

### Fix

Use a non-strict comparison `lax.ge(kappa, zero)` so `kappa == 0` uses the
closed-form expression. `kappa < 0` remains out of support and returns `nan`,
matching SciPy. This fixes both `pdf` (which is `exp(logpdf(...))`) and
`logpdf`.

### Verification

Reproducer from the issue, after the fix (x64 enabled):

```
       x  kappa |          scipy            jax            jit
   0.000   0.00 |     0.15915494     0.15915494     0.15915494
   1.000   0.00 |     0.15915494     0.15915494     0.15915494
  -1.000   0.00 |     0.15915494     0.15915494     0.15915494
   3.142   0.00 |     0.15915494     0.15915494     0.15915494
  -3.142   0.00 |     0.15915494     0.15915494     0.15915494
   0.000   1.00 |     0.34171049     0.34171049     0.34171049   (control: kappa>0)
     nan   0.00 |            nan            nan            nan    (control: non-finite x)
     inf   0.00 |            nan            nan            nan    (control: non-finite x)
   0.000  -1.00 |            nan            nan            nan    (control: kappa<0)
```

`logpdf(x, 0) == -log(2 * pi)` matches SciPy, and gradients w.r.t. both `x` and
`kappa` are finite at `kappa == 0` (no `nan` leaks through the `where`).

### Tests

Added `testVonMisesPdfKappaZero`, which checks `pdf`/`logpdf` at `kappa == 0`
against SciPy (the existing `testVonMises{Pdf,LogPdf}` take `abs(kappa)` and the
default RNG essentially never samples exactly `0`, so the boundary was
untested), the jitted path, and that `kappa < 0` still returns `nan`. All
existing von Mises tests continue to pass.