### PR TITLE
fix(scipy.linalg): toeplitz/hankel incorrectly propagate NaN via conv…

### DIFF
--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -2496,13 +2496,10 @@ def _toeplitz(c: Array, r: Array) -> Array:
   nrows, = r.shape
   if ncols == 0 or nrows == 0:
     return jnp.empty((ncols, nrows), dtype=jnp.promote_types(c.dtype, r.dtype))
-  nelems = ncols + nrows - 1
   elems = jnp.concatenate((c[::-1], r[1:]))
-  patches = lax.conv_general_dilated_patches(
-      elems.reshape((1, nelems, 1)),
-      (nrows,), (1,), 'VALID', dimension_numbers=('NTC', 'IOT', 'NTC'),
-      precision=lax.Precision.HIGHEST)[0]
-  return jnp.flip(patches, axis=0)
+  i = jnp.arange(ncols)[:, None]
+  j = jnp.arange(nrows)[None, :]
+  return elems[ncols - 1 - i + j]
 
 def hankel(c: ArrayLike, r: ArrayLike | None = None) -> Array:
   r"""Construct a Hankel matrix.
@@ -2564,11 +2561,9 @@ def _hankel(c: Array, r: Array) -> Array:
   if ncols == 0 or nrows == 0:
     return jnp.empty((ncols, nrows), dtype=jnp.result_type(c, r))
   v = jnp.concatenate((c, r[1:]))
-  return lax.conv_general_dilated_patches(
-      v.reshape((1, ncols + nrows - 1, 1)),
-      (nrows,), (1,), 'VALID',
-      dimension_numbers=('NTC', 'IOT', 'NTC'),
-      precision=lax.Precision.HIGHEST)[0]
+  i = jnp.arange(ncols)[:, None]
+  j = jnp.arange(nrows)[None, :]
+  return v[i + j]
 
 
 def circulant(c: ArrayLike) -> Array:

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -2497,9 +2497,9 @@ def _toeplitz(c: Array, r: Array) -> Array:
   if ncols == 0 or nrows == 0:
     return jnp.empty((ncols, nrows), dtype=jnp.promote_types(c.dtype, r.dtype))
   elems = jnp.concatenate((c[::-1], r[1:]))
-  i = jnp.arange(ncols)[:, None]
+  i = jnp.arange(ncols - 1, -1, -1)[:, None]
   j = jnp.arange(nrows)[None, :]
-  return elems[ncols - 1 - i + j]
+  return elems[i + j]
 
 def hankel(c: ArrayLike, r: ArrayLike | None = None) -> Array:
   r"""Construct a Hankel matrix.

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2261,6 +2261,58 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       [1, 4, 5, 6],
       [2, 1, 4, 5],
       [3, 2, 1, 4]], dtype=np.float32))
+  def testToeplitzNaNPropagation(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/38636
+    # NaN in column/row should only appear at the diagonal position it maps to,
+    # not bleed into the whole matrix. The old conv-based implementation used
+    # arithmetic (NaN + x = NaN) instead of pure indexing, poisoning all outputs.
+    column = np.array([np.nan, np.inf, -0.0], dtype=np.float32)
+    row = np.array([np.nan, 2.0, 3.0], dtype=np.float32)
+    expected = np.array([
+        [np.nan, 2.0,    3.0 ],
+        [np.inf, np.nan, 2.0 ],
+        [-0.0,   np.inf, np.nan],
+    ], dtype=np.float32)
+    out = np.asarray(jsp.linalg.toeplitz(
+        jnp.asarray(column), jnp.asarray(row)))
+    self.assertTrue(
+        np.array_equal(out, expected, equal_nan=True),
+        msg=f"toeplitz NaN propagation: got\n{out}\nexpected\n{expected}")
+    # Exactly 3 NaNs on the main diagonal, none elsewhere
+    self.assertEqual(np.sum(np.isnan(out)), 3,
+                     msg="Expected exactly 3 NaNs (main diagonal only)")
+
+    # Also verify: a single NaN in c[0] only populates the main diagonal.
+    c2 = np.array([np.nan, 1.0, 2.0], dtype=np.float32)
+    r2 = np.array([np.nan, 3.0, 4.0], dtype=np.float32)
+    out2 = np.asarray(jsp.linalg.toeplitz(jnp.asarray(c2), jnp.asarray(r2)))
+    # Non-diagonal entries must be finite (no NaN bleed)
+    diag_mask = np.eye(3, dtype=bool)
+    self.assertTrue(np.all(np.isfinite(out2[~diag_mask])),
+                    msg=f"Off-diagonal entries should be finite, got\n{out2}")
+    self.assertTrue(np.all(np.isnan(out2[diag_mask])),
+                    msg=f"Diagonal entries should be NaN, got\n{out2}")
+
+  def testHankelNaNPropagation(self):
+    # Companion regression for https://github.com/jax-ml/jax/issues/38636:
+    # hankel also used conv_general_dilated_patches (same root cause).
+    c = np.array([np.nan, 1.0, 2.0], dtype=np.float32)
+    r = np.array([np.nan, 4.0, 5.0], dtype=np.float32)
+    # hankel[i,j] = v[i+j], where v = [c[0], c[1], c[2], r[1], r[2]]
+    # = [NaN, 1, 2, 4, 5]
+    # Only hankel[0,0] (v[0]) should be NaN.
+    expected = np.array([
+        [np.nan, 1.0, 2.0],
+        [1.0,    2.0, 4.0],
+        [2.0,    4.0, 5.0],
+    ], dtype=np.float32)
+    out = np.asarray(jsp.linalg.hankel(jnp.asarray(c), jnp.asarray(r)))
+    self.assertTrue(
+        np.array_equal(out, expected, equal_nan=True),
+        msg=f"hankel NaN propagation: got\n{out}\nexpected\n{expected}")
+    self.assertEqual(np.sum(np.isnan(out)), 1,
+                     msg="Expected exactly 1 NaN at [0,0] only")
+
   def testHankelConstructionWithKnownCases(self):
     # r=None should default to zeros_like(c)
     c = np.array([1, 2, 3], dtype=np.float32)


### PR DESCRIPTION
Fixes #38636.

jax.scipy.linalg.toeplitz returned an all-NaN matrix whenever any element of c or r was NaN, even when those values should only appear at specific diagonal positions.

python
# Before
jax.scipy.linalg.toeplitz([nan, inf, -0.], [nan, 2., 3.])
# → [[nan, nan, nan], [nan, nan, nan], [nan, nan, nan]]  
# After
# → [[nan, 2.0, 3.0], [inf, nan, 2.0], [-0., inf, nan]]  
Root Cause

_toeplitz (and _hankel) used lax.conv_general_dilated_patches — a convolution — to extract sliding windows from the concatenated input vector. Convolution involves arithmetic sums: NaN + x = NaN per IEEE 754, so any NaN in the kernel window poisoned every output position that window overlapped, turning the entire matrix NaN.

Fix

Toeplitz output cell A[i, j] maps to elems[ncols-1-i+j] for elems = c[::-1] ++ r[1:] in both triangles — a pure integer-indexed gather, not arithmetic. NaN isolation is guaranteed by construction.

python
# _toeplitz — 3 lines replacing 6
elems = jnp.concatenate((c[::-1], r[1:]))
i, j = jnp.arange(ncols)[:, None], jnp.arange(nrows)[None, :]
return elems[ncols - 1 - i + j]
# _hankel
v = jnp.concatenate((c, r[1:]))
return v[i + j]
The fix is also shorter and simpler (no reshape, no flip, no convolution), and produces identical results for all finite inputs.

Changes

File	Change
jax/_src/scipy/linalg.py	Replace conv_general_dilated_patches with index gather in _toeplitz and _hankel
tests/linalg_test.py	Add testToeplitzNaNPropagation + testHankelNaNPropagation regression tests
Tests — testToeplitzNaNPropagation reproduces the exact MRE, asserts exactly 3 NaNs on the main diagonal and zero elsewhere. testHankelNaNPropagation covers the same root cause in _hankel, asserting exactly 1 NaN at H[0,0].

References — Closes #38636