### PR TITLE
make Tracer<ShapedArray>.__iter__ call lax.unstack

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4118,12 +4118,7 @@ def _iter(tracer):
   if tracer.ndim == 0:
     raise TypeError("iteration over a 0-d array")  # same as numpy error
   else:
-    n = int(tracer.shape[0])
-    if any(isinstance(d, core.Tracer) for d in tracer.shape):
-      return (slicing.dynamic_index_in_dim(tracer, i, keepdims=False)
-              for i in range(n))
-    else:
-      return (slicing.index_in_dim(tracer, i, keepdims=False) for i in range(n))
+    return unstack(tracer)
 ShapedArray._iter = staticmethod(_iter)  # pyrefly: ignore[bad-assignment]
 
 def _add_arrays(x, y):

--- a/jax/experimental/key_reuse/_core.py
+++ b/jax/experimental/key_reuse/_core.py
@@ -448,6 +448,13 @@ def _slice_signature(eqn):
 key_reuse_signatures[lax.slice_p] = _slice_signature
 
 @dynamic_key_reuse_signature
+def _unstack_signature(eqn):
+  return KeyReuseSignature(Sink(0),
+                           *(Source(i) for i in range(len(eqn.outvars))))
+
+key_reuse_signatures[lax.unstack_p] = _unstack_signature
+
+@dynamic_key_reuse_signature
 def _concatenate_signature(eqn):
   num_vals = len(eqn.invars)
   # TODO(jakevdp): should this signature be more granular?

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -3880,6 +3880,13 @@ class LaxTest(jtu.JaxTestCase):
     y = lax_internal.stage(x)
     self.assertTrue(dtypes.is_weakly_typed(y))
 
+  def testIterUsesUnstack(self):
+    def f(x):
+      return list(x)
+    jaxpr = jax.make_jaxpr(f)(np.arange(3.))
+    primitives = [eqn.primitive for eqn in jaxpr.jaxpr.eqns]
+    self.assertIn(lax_internal.unstack_p, primitives)
+
 
 class LazyConstantTest(jtu.JaxTestCase):
   def _Check(self, make_const, expected):


### PR DESCRIPTION
`unstack` has better autodiff behavior than `lambda x: lax.index_in_dim(x, i, keepdims=False) for i in range(x.shape[0])` because the transpose of the latter will generate a bunch of sparse (one-slice-hot) arrays and sum them, while the transpose of the former just stacks.