### PR TITLE
Fix NaN/inf propagation in scipy.linalg.toeplitz and hankel

### DIFF
--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -2496,13 +2496,13 @@ def _toeplitz(c: Array, r: Array) -> Array:
   nrows, = r.shape
   if ncols == 0 or nrows == 0:
     return jnp.empty((ncols, nrows), dtype=jnp.promote_types(c.dtype, r.dtype))
-  nelems = ncols + nrows - 1
+  # Build the matrix by gathering from the flattened diagonals. Selecting
+  # entries (rather than a conv, where 0 * inf == nan) keeps non-finite values
+  # confined to the cells they actually belong to.
   elems = jnp.concatenate((c[::-1], r[1:]))
-  patches = lax.conv_general_dilated_patches(
-      elems.reshape((1, nelems, 1)),
-      (nrows,), (1,), 'VALID', dimension_numbers=('NTC', 'IOT', 'NTC'),
-      precision=lax.Precision.HIGHEST)[0]
-  return jnp.flip(patches, axis=0)
+  i = lax.broadcasted_iota(np.int32, (ncols, nrows), 0)
+  j = lax.broadcasted_iota(np.int32, (ncols, nrows), 1)
+  return elems[ncols - 1 + j - i]
 
 def hankel(c: ArrayLike, r: ArrayLike | None = None) -> Array:
   r"""Construct a Hankel matrix.
@@ -2563,12 +2563,11 @@ def _hankel(c: Array, r: Array) -> Array:
   nrows, = r.shape
   if ncols == 0 or nrows == 0:
     return jnp.empty((ncols, nrows), dtype=jnp.result_type(c, r))
+  # Gather from the anti-diagonals instead of convolving; see _toeplitz.
   v = jnp.concatenate((c, r[1:]))
-  return lax.conv_general_dilated_patches(
-      v.reshape((1, ncols + nrows - 1, 1)),
-      (nrows,), (1,), 'VALID',
-      dimension_numbers=('NTC', 'IOT', 'NTC'),
-      precision=lax.Precision.HIGHEST)[0]
+  i = lax.broadcasted_iota(np.int32, (ncols, nrows), 0)
+  j = lax.broadcasted_iota(np.int32, (ncols, nrows), 1)
+  return v[i + j]
 
 
 def circulant(c: ArrayLike) -> Array:

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2275,6 +2275,32 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     out2 = jsp.linalg.hankel(c, r2)
     self.assertAllClose(out1, out2)
 
+  def testToeplitzNonFiniteValues(self):
+    # https://github.com/jax-ml/jax/issues/38636: non-finite entries must not
+    # leak into cells that select a different, finite input value.
+    c = np.array([np.nan, np.inf, -0.0], dtype=np.float32)
+    r = np.array([np.nan, 2.0, 3.0], dtype=np.float32)
+    expected = np.array([
+      [np.nan, 2.0, 3.0],
+      [np.inf, np.nan, 2.0],
+      [-0.0, np.inf, np.nan]], dtype=np.float32)
+    actual = np.asarray(jsp.linalg.toeplitz(c, r))
+    self.assertArraysEqual(actual, expected)
+    self.assertTrue(np.signbit(actual[2, 0]))  # -0.0 sign preserved
+
+  def testHankelNonFiniteValues(self):
+    # https://github.com/jax-ml/jax/issues/38635: non-finite entries must not
+    # leak into cells that select a different, finite input value.
+    c = np.array([np.nan, np.inf, -0.0], dtype=np.float32)
+    r = np.array([np.nan, 2.0, 3.0], dtype=np.float32)
+    expected = np.array([
+      [np.nan, np.inf, -0.0],
+      [np.inf, -0.0, 2.0],
+      [-0.0, 2.0, 3.0]], dtype=np.float32)
+    actual = np.asarray(jsp.linalg.hankel(c, r))
+    self.assertArraysEqual(actual, expected)
+    self.assertTrue(np.signbit(actual[0, 2]))  # -0.0 sign preserved
+
   @jtu.sample_product(
      cshape = [(3,), (0,), (2, 3), (1, 2, 3)],
      rshape = [(4,), (0,), (1, 4), (2, 4), (1, 1, 4)],


### PR DESCRIPTION
### What

`jax.scipy.linalg.toeplitz` and `jax.scipy.linalg.hankel` return an all-`NaN` matrix whenever any input element is non-finite, even for output cells that should select a perfectly finite value.

```python
>>> import jax.numpy as jnp, jax.scipy.linalg as jsl
>>> c = jnp.array([jnp.nan, jnp.inf, -0.0], dtype=jnp.float32)
>>> r = jnp.array([jnp.nan, 2.0, 3.0], dtype=jnp.float32)
>>> jsl.toeplitz(c, r)
Array([[nan, nan, nan],
       [nan, nan, nan],
       [nan, nan, nan]], dtype=float32)   # every scipy/numpy entry here is finite except the diagonal
```

SciPy returns `[[nan, 2, 3], [inf, nan, 2], [-0, inf, nan]]`; `hankel` is affected the same way.

### Why

Both `_toeplitz` and `_hankel` materialize their entries with `lax.conv_general_dilated_patches`, i.e. an im2col implemented as a convolution against a 0/1 kernel. Convolution is a multiply-accumulate, and `0 * inf == nan`, `0 * nan == nan`. So in each output cell's dot product the masked-out terms aren't actually zero — a single non-finite input poisons the entire result, regardless of which entry that cell was supposed to select.

### Fix

A Toeplitz/Hankel matrix is a pure *selection* of the input values, so construct it by indexing rather than arithmetic. Each layout has a closed-form index into the flattened diagonals:

```
toeplitz: A[i, j] = elems[ncols - 1 + j - i],  elems = concat(c[::-1], r[1:])
hankel:   H[i, j] = v[i + j],                   v     = concat(c, r[1:])
```

Gathering with `broadcasted_iota` index grids touches the data only by selection: non-finite values stay confined to their own cells and signed zeros survive intact. As a bonus it removes the convolution + `flip`, which is both simpler and cheaper than im2col for this access pattern. The `@jnp.vectorize` batching wrappers are unchanged.

### Tests

- New `testToeplitzNonFiniteValues` / `testHankelNonFiniteValues` lock in the SciPy-matching output (including `-0.0` sign preservation).
- The existing `testToeplitzConstruction` / `testHankelConstruction` suites pass; I also checked the new indexing against `scipy.linalg` across every column/row shape combination they cover.

Fixes #38636
Fixes #38635