### PR TITLE
Rotation.as_euler: avoid empty array when zeros are expected

### DIFF
--- a/jax/_src/scipy/spatial/transform.py
+++ b/jax/_src/scipy/spatial/transform.py
@@ -346,7 +346,7 @@ def _compute_euler_from_quat(quat: Array, axes: Array, extrinsic: bool, degrees:
   b = jnp.where(symmetric, quat[i], quat[i] + quat[k] * sign)
   c = jnp.where(symmetric, quat[j], quat[j] + quat[3])
   d = jnp.where(symmetric, quat[k] * sign, quat[k] * sign - quat[i])
-  angles = jnp.empty(3, dtype=quat.dtype)
+  angles = jnp.zeros(3, dtype=quat.dtype)
   angles = angles.at[1].set(2 * jnp.arctan2(jnp.hypot(c, d), jnp.hypot(a, b)))
   case = jnp.where(jnp.abs(angles[1] - np.pi) <= eps, 2, 0)
   case = jnp.where(jnp.abs(angles[1]) <= eps, 1, case)


### PR DESCRIPTION
This helps unblock lowering `jnp.empty` to `lax.empty` in v0.11.0.