### PR TITLE
fix: jnp.angle returns 0.0 (not NaN) under jit for logical_xor zeros

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1554,6 +1554,21 @@ def angle(z: ArrayLike, deg: bool = False) -> Array:
     re = lax.convert_element_type(re, dtype)
     im = lax.convert_element_type(im, dtype)
   result = lax.atan2(im, re)
+
+  float_zero = lax.full_like(result, 0)
+  re_zero = lax.eq(re, float_zero)
+  imag_zero = lax.eq(im, float_zero)
+  both_zero = lax.bitwise_and(re_zero, imag_zero)
+
+  re_neg = lax.lt(lax.div(lax._const(re, 1.0), re), lax._const(re, 0.0))
+  im_neg = lax.lt(lax.div(lax._const(im, 1.0), im), lax._const(im, 0.0))
+
+  pi = lax.full_like(result, np.pi)
+  zero_result = lax.select(re_neg, pi, float_zero)
+  zero_result = lax.select(im_neg, lax.neg(zero_result), zero_result)
+
+  result = lax.select(both_zero, zero_result, result)
+
   return ufuncs.degrees(result) if deg else result
 
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6751,6 +6751,8 @@ class NumpyUfuncTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(np_op, jnp_op, args_maker, check_dtypes=False, tol=1E-2)
 
 
+
+
 class NumpyDocTests(jtu.JaxTestCase):
 
   def test_lax_numpy_docstrings(self):
@@ -6785,6 +6787,27 @@ class NumpyDocTests(jtu.JaxTestCase):
         if name not in ["frompyfunc", "isdtype", "promote_types"]:
           self.assertIn("Examples:", doc, msg=f"'Examples:' not found in docstring of jnp.{name}")
 
+class NumpyAngleTests(jtu.JaxTestCase):
+
+  def testAngleLogicalXorZeroBug(self):
+    t = jnp.array([1, 2, 3, 4], dtype=jnp.int32)
+    expected = jnp.zeros(4)
+
+    self.assertAllClose(jnp.angle(jnp.logical_xor(t, t)), expected)
+
+    f = lambda t: jnp.angle(jnp.logical_xor(t, t))
+    self.assertAllClose(jax.jit(f)(t), expected)
+
+    t2 = jnp.zeros((4,), dtype=jnp.bool_)
+    self.assertAllClose(jax.jit(jnp.angle)(t2), expected)
+
+    self.assertAllClose(
+        jax.jit(lambda t: jnp.angle(jnp.logical_xor(t, t), deg=True))(t),
+        jnp.zeros(4)
+    )
+
+    self.assertAllClose(jnp.angle(-0.0), jnp.pi)
+    self.assertAllClose(jax.jit(jnp.angle)(-0.0), jnp.pi)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
`jnp.angle(jnp.logical_xor(t, t))` returned `nan` under `jax.jit` while eager mode and direct `jnp.zeros(bool)` returned `0.0`.

**Root cause**: After promoting bool zero to float, `lax.atan2(0, 0)` can return NaN in runtime JIT paths (constant folding hides it for direct zeros).

**Fix**: Added explicit guard using `full_like` + `bitwise_and` + `select` to force `0.0` when both real and imaginary parts are zero. Matches NumPy behavior.

**Test**: Added regression test covering eager + JIT paths.

Fixes #38681