### PR TITLE
fix: propagate NaN in jax.scipy.special.rel_entr

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -1219,7 +1219,11 @@ def rel_entr(
   result = jnp.where(
       both_gt_zero_mask, log_val, jnp.where(one_zero_mask, zero, np.inf)
   )
-  return result
+  # Propagate NaN: if either input is NaN, the result should be NaN,
+  # not inf. Comparisons with NaN return False, so both masks above
+  # are False for NaN inputs, causing the fallback to inf.
+  nan_mask = lax.bitwise_or(jnp.isnan(p), jnp.isnan(q))
+  return jnp.where(nan_mask, jnp.nan, result)
 
 # coefs of (2k)! / B_{2k} where B are bernoulli numbers
 # those numbers are obtained using https://www.wolframalpha.com


### PR DESCRIPTION
## Summary

Fix NaN propagation in `jax.scipy.special.rel_entr`.

Currently, `rel_entr(x, nan)` and `rel_entr(nan, y)` return `inf` for **all** NaN-containing inputs. SciPy returns `nan` in all these cases.

## Root Cause

Comparisons with NaN return `False`, so both `both_gt_zero_mask` and `one_zero_mask` evaluate to `False` when either input is NaN. This causes the function to fall through to the `inf` default branch.

## Fix

Add an explicit NaN check after computing the result: if either input is NaN, return `nan` instead of `inf`.

```python
# Before (buggy):
return result  # inf when inputs are NaN

# After (fixed):
nan_mask = lax.bitwise_or(jnp.isnan(p), jnp.isnan(q))
return jnp.where(nan_mask, np.nan, result)
```

## Reproducer

```python
import jax.scipy.special as jss
import jax.numpy as jnp
import numpy as np

# All of these should return nan (matching scipy), but return inf before fix:
print(jss.rel_entr(jnp.float32(0.0), jnp.float32(np.nan)))   # inf -> nan
print(jss.rel_entr(jnp.float32(1.0), jnp.float32(np.nan)))   # inf -> nan
print(jss.rel_entr(jnp.float32(np.nan), jnp.float32(1.0)))   # inf -> nan
print(jss.rel_entr(jnp.float32(np.nan), jnp.float32(np.nan))) # inf -> nan
```

## References

- Fixes #38262
- Part of edge-case meta-issue #38651
- SciPy reference: [`scipy.special.rel_entr`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.rel_entr.html)
