### PR TITLE
fix: reduce count sum over last axis in multinomial.logpmf

### DIFF
--- a/jax/_src/scipy/stats/multinomial.py
+++ b/jax/_src/scipy/stats/multinomial.py
@@ -53,7 +53,7 @@ def logpmf(x: ArrayLike, n: ArrayLike, p: ArrayLike) -> Array:
   x = x.astype(p.dtype)
   n = n.astype(p.dtype)
   logprobs = gammaln(n + 1) + jnp.sum(xlogy(x, p) - gammaln(x + 1), axis=-1)
-  return jnp.where(jnp.equal(jnp.sum(x), n), logprobs, -np.inf)
+  return jnp.where(jnp.equal(jnp.sum(x, axis=-1), n), logprobs, -np.inf)
 
 
 def pmf(x: ArrayLike, n: ArrayLike, p: ArrayLike) -> Array:


### PR DESCRIPTION
## Summary

Fix `jax.scipy.stats.multinomial.logpmf` (and `.pmf`) returning `-inf` for all rows of a batched input.

## Root Cause

The count validation on [line 56](https://github.com/jax-ml/jax/blob/main/jax/_src/scipy/stats/multinomial.py#L56) uses `jnp.sum(x)` which reduces over **all** axes:

```python
# Before (buggy):
return jnp.where(jnp.equal(jnp.sum(x), n), logprobs, -np.inf)
```

For batched input `x = [[2,3,5],[1,4,5]]` with `n=10`:
- `jnp.sum(x)` = 20 (sum of ALL elements across ALL rows)
- `20 != 10` → every row gets `-inf`

The `logprobs` computation on the preceding line already correctly reduces over `axis=-1`, so only the validity mask was wrong.

## Fix

```python
# After (fixed):
return jnp.where(jnp.equal(jnp.sum(x, axis=-1), n), logprobs, -np.inf)
```

Now `jnp.sum(x, axis=-1)` = `[10, 10]`, each equals `n=10`, rows are correctly validated.

## Reproducer

```python
import jax; jax.config.update('jax_enable_x64', True)
import numpy as np
import jax.scipy.stats.multinomial as jmn
import scipy.stats as ss

p = np.array([0.2, 0.3, 0.5])
x = np.array([[2, 3, 5], [1, 4, 5]])

print(jmn.logpmf(x, 10, p))          # [-inf, -inf]  (wrong)
print(ss.multinomial.logpmf(x, 10, p)) # [-2.465, -2.752]  (correct)
```

After this fix, JAX matches SciPy for batched inputs.

Fixes #38605.
