### PR TITLE
Error on ffi_call with sharded inputs under explicit mesh

### DIFF
--- a/jax/_src/ffi.py
+++ b/jax/_src/ffi.py
@@ -623,7 +623,11 @@ def _aval_is_sharded(aval: core.AbstractValue) -> bool:
   sharding = aval.sharding
   if sharding is None or sharding.mesh.empty:
     return False
-  return any(p is not None for p in sharding.spec)
+  spec = sharding.spec
+  if spec.unreduced or spec.reduced:
+    return True
+  from jax._src.named_sharding import flatten_spec
+  return any(s is not None for s in flatten_spec(spec))
 
 
 def _in_shard_map_manual_context(avals: Sequence[core.AbstractValue]) -> bool:

--- a/jax/_src/ffi.py
+++ b/jax/_src/ffi.py
@@ -508,6 +508,7 @@ def ffi_call(
 
   def wrapped(*args: ArrayLike, **kwargs: Any):
     in_avals = [core.typeof(x) for x in args]
+    _check_explicit_mesh_ffi_call(in_avals)
 
     if input_layouts is None:
       static_input_layouts = tuple(map(_convert_layout_for_lowering, in_avals))
@@ -614,6 +615,34 @@ def _unwrap_kwargs_hashable(kwargs: Sequence[tuple[str, Any]]) -> dict[str, Any]
     else:
       unwrapped_kwargs[k] = v
   return unwrapped_kwargs
+
+
+def _aval_is_sharded(aval: core.AbstractValue) -> bool:
+  if not isinstance(aval, core.ShapedArray):
+    return False
+  sharding = aval.sharding
+  if sharding is None or sharding.mesh.empty:
+    return False
+  return any(p is not None for p in sharding.spec)
+
+
+def _in_shard_map_manual_context(avals: Sequence[core.AbstractValue]) -> bool:
+  return any(isinstance(a, core.ShapedArray) and not a.mat.empty for a in avals)
+
+
+def _check_explicit_mesh_ffi_call(in_avals: Sequence[core.AbstractValue]) -> None:
+  from jax._src import mesh as mesh_lib
+
+  mesh = mesh_lib.get_abstract_mesh()
+  if not mesh.are_all_axes_explicit:
+    return
+  if _in_shard_map_manual_context(in_avals):
+    return
+  if any(_aval_is_sharded(a) for a in in_avals):
+    raise ValueError(
+        "ffi_call with sharded inputs is not supported under an explicit mesh"
+        " outside of jax.shard_map, because XLA may insert implicit all-gathers."
+        " Wrap the ffi_call in jax.shard_map or insert explicit collectives.")
 
 
 @dataclasses.dataclass(frozen=True, slots=True)

--- a/tests/ffi_test.py
+++ b/tests/ffi_test.py
@@ -23,7 +23,7 @@ from absl.testing import parameterized
 import jax
 from jax import lax
 import jax.numpy as jnp
-from jax.sharding import PartitionSpec as P
+from jax.sharding import AxisType, NamedSharding, PartitionSpec as P
 
 from jax._src import core
 from jax._src import dispatch
@@ -320,6 +320,43 @@ class FfiTest(jtu.JaxTestCase):
     def f(x):
       return jax.ffi.ffi_call("edtype", (), has_side_effect=True)(x)
     jax.jit(f).lower(jax.random.key(0))   # doesn't crash
+
+  @jtu.with_explicit_mesh((2,), ('data',), axis_types=(AxisType.Explicit,))
+  @jtu.run_on_devices('cpu')
+  def test_explicit_mesh_sharded_ffi_call_errors(self, mesh):
+    def f(x):
+      b, n, _ = x.shape
+      return jax.ffi.ffi_call(
+          "lapack_sgetrf_ffi",
+          (jax.ShapeDtypeStruct((b, n, n), jnp.float32),
+           jax.ShapeDtypeStruct((b, n), jnp.int32),
+           jax.ShapeDtypeStruct((b,), jnp.int32)),
+      )(x)
+
+    xs = jax.device_put(
+        jnp.ones((2, 4, 4), jnp.float32), NamedSharding(mesh, P('data', None, None)))
+    with self.assertRaisesRegex(ValueError, 'ffi_call with sharded inputs'):
+      jax.jit(f).lower(xs)
+
+  @jtu.with_explicit_mesh((2,), ('data',), axis_types=(AxisType.Explicit,))
+  @jtu.run_on_devices('cpu')
+  def test_explicit_mesh_ffi_call_inside_shard_map(self, mesh):
+    @jax.jit
+    @partial(shard_map, mesh=mesh, in_specs=P('data'), out_specs=(P('data'), P('data'), P('data')))
+    def f(x):
+      b, n, _ = x.shape
+      mat = jax.sharding.ManualAxisType(varying={'data'})
+      sharding = NamedSharding(jax.sharding.get_abstract_mesh(), P())
+      return jax.ffi.ffi_call(
+          "lapack_sgetrf_ffi",
+          (jax.ShapeDtypeStruct((b, n, n), jnp.float32, sharding=sharding, manual_axis_type=mat),
+           jax.ShapeDtypeStruct((b, n), jnp.int32, sharding=sharding, manual_axis_type=mat),
+           jax.ShapeDtypeStruct((b,), jnp.int32, sharding=sharding, manual_axis_type=mat)),
+      )(x)
+
+    xs = jax.device_put(jnp.ones((2, 4, 4), jnp.float32), P('data'))
+    hlo = f.lower(xs).compile().as_text()
+    self.assertNotIn('all-gather', hlo)
 
 
 def ffi_call_geqrf(x, **kwargs):

--- a/tests/ffi_test.py
+++ b/tests/ffi_test.py
@@ -324,19 +324,37 @@ class FfiTest(jtu.JaxTestCase):
   @jtu.with_explicit_mesh((2,), ('data',), axis_types=(AxisType.Explicit,))
   @jtu.run_on_devices('cpu')
   def test_explicit_mesh_sharded_ffi_call_errors(self, mesh):
-    def f(x):
-      b, n, _ = x.shape
-      return jax.ffi.ffi_call(
-          "lapack_sgetrf_ffi",
-          (jax.ShapeDtypeStruct((b, n, n), jnp.float32),
-           jax.ShapeDtypeStruct((b, n), jnp.int32),
-           jax.ShapeDtypeStruct((b,), jnp.int32)),
-      )(x)
+    xs = jax.device_put(
+        jnp.ones((2, 4, 4), jnp.float32), NamedSharding(mesh, P('data', None, None)))
+    with self.assertRaisesRegex(ValueError, 'ffi_call with sharded inputs'):
+      jax.jit(ffi_call_sgetrf).lower(xs)
+
+  @jtu.with_explicit_mesh((2,), ('data',), axis_types=(AxisType.Explicit,))
+  @jtu.run_on_devices('cpu')
+  def test_explicit_mesh_unreduced_ffi_call_errors(self, mesh):
+    @partial(shard_map, mesh=mesh, in_specs=P('data'), out_specs=P(unreduced={'data'}))
+    def make_unreduced(x):
+      return x
 
     xs = jax.device_put(
         jnp.ones((2, 4, 4), jnp.float32), NamedSharding(mesh, P('data', None, None)))
     with self.assertRaisesRegex(ValueError, 'ffi_call with sharded inputs'):
-      jax.jit(f).lower(xs)
+      jax.jit(ffi_call_sgetrf).lower(make_unreduced(xs))
+
+  @jtu.with_explicit_mesh((2,), ('data',), axis_types=(AxisType.Explicit,))
+  @jtu.run_on_devices('cpu')
+  def test_explicit_mesh_reduced_ffi_call_errors(self, mesh):
+    xs = jax.device_put(
+        jnp.ones((2, 4, 4), jnp.float32), NamedSharding(mesh, P(reduced={'data'})))
+    with self.assertRaisesRegex(ValueError, 'ffi_call with sharded inputs'):
+      jax.jit(ffi_call_sgetrf).lower(xs)
+
+  @jtu.with_explicit_mesh((2,), ('data',), axis_types=(AxisType.Explicit,))
+  @jtu.run_on_devices('cpu')
+  def test_explicit_mesh_replicated_ffi_call_lowers(self, mesh):
+    xs = jax.device_put(
+        jnp.ones((2, 4, 4), jnp.float32), NamedSharding(mesh, P()))
+    jax.jit(ffi_call_sgetrf).lower(xs)  # doesn't crash
 
   @jtu.with_explicit_mesh((2,), ('data',), axis_types=(AxisType.Explicit,))
   @jtu.run_on_devices('cpu')
@@ -357,6 +375,16 @@ class FfiTest(jtu.JaxTestCase):
     xs = jax.device_put(jnp.ones((2, 4, 4), jnp.float32), P('data'))
     hlo = f.lower(xs).compile().as_text()
     self.assertNotIn('all-gather', hlo)
+
+
+def ffi_call_sgetrf(x):
+  b, n, _ = x.shape
+  return jax.ffi.ffi_call(
+      "lapack_sgetrf_ffi",
+      (jax.ShapeDtypeStruct((b, n, n), jnp.float32),
+       jax.ShapeDtypeStruct((b, n), jnp.int32),
+       jax.ShapeDtypeStruct((b,), jnp.int32)),
+  )(x)
 
 
 def ffi_call_geqrf(x, **kwargs):


### PR DESCRIPTION
## Summary

- Reject `ffi_call` outside `jax.shard_map` when an explicit mesh is active and inputs are partitioned.
- Prevents XLA from silently inserting implicit all-gathers before FFI custom calls.
- Add regression tests for the error path and the existing `shard_map` workaround.

Fixes #38551

## Test plan

- [x] `python tests/ffi_test.py FfiTest.test_explicit_mesh_sharded_ffi_call_errors`
- [x] `python tests/ffi_test.py FfiTest.test_explicit_mesh_ffi_call_inside_shard_map`


Made with [Cursor](https://cursor.com)