### PR TITLE
[OneAPI GPU] Add dlpack support for OneAPI

### DIFF
--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -454,6 +454,8 @@ class ArrayImpl(basearray.Array):
           dl_device_type = DLDeviceType.kDLROCMHost
         else:
           dl_device_type = DLDeviceType.kDLROCM
+      elif "oneapi" in platform_version:
+        dl_device_type = DLDeviceType.kDLOneAPI
       else:
         raise BufferError("Unknown GPU platform for __dlpack__: "
                          f"{platform_version}")

--- a/jax/_src/dlpack.py
+++ b/jax/_src/dlpack.py
@@ -88,6 +88,7 @@ _DL_DEVICE_TO_PLATFORM = {
     DLDeviceType.kDLROCM: "rocm",
     DLDeviceType.kDLROCMHost: "rocm",
     DLDeviceType.kDLTPUHost: "tpu",
+    DLDeviceType.kDLOneAPI: "oneapi",
 }
 
 

--- a/jax/_src/typing.py
+++ b/jax/_src/typing.py
@@ -110,6 +110,7 @@ class DLDeviceType(enum.IntEnum):
   kDLROCM = 10
   kDLROCMHost = 11
   kDLTPUHost = 20
+  kDLOneAPI = 14
 
 AnyInt = int | np.integer
 StaticIndex = AnyInt | slice | EllipsisType

--- a/jaxlib/dlpack.cc
+++ b/jaxlib/dlpack.cc
@@ -138,6 +138,8 @@ absl::StatusOr<DLDeviceType> DLDeviceTypeForDevice(
     return kDLCUDA;
   } else if (device.client()->platform_id() == xla::RocmId()) {
     return kDLROCM;
+  } else if (device.client()->platform_id() == xla::OneapiId()) {
+    return kDLOneAPI;
   }
   return xla::InvalidArgument("Device %s cannot be used as a DLPack device.",
                               device.DebugString());

--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -370,6 +370,7 @@ class CudaArrayInterfaceTest(jtu.JaxTestCase):
     dtype=cuda_array_interface_dtypes,
   )
   @jtu.run_on_devices("gpu")
+  @jtu.skip_on_devices("oneapi") # OneAPI does not support `__cuda_array_interface__`
   def testCudaArrayInterfaceWorks(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
     x = rng(shape, dtype)
@@ -380,6 +381,7 @@ class CudaArrayInterfaceTest(jtu.JaxTestCase):
     self.assertEqual(z.__array_interface__["typestr"], a["typestr"])
 
   @jtu.run_on_devices("gpu")
+  @jtu.skip_on_devices("oneapi") # OneAPI does not support `__cuda_array_interface__`
   def testCudaArrayInterfaceBfloat16Fails(self):
     rng = jtu.rand_default(self.rng())
     x = rng((2, 2), jnp.bfloat16)
@@ -425,6 +427,7 @@ class CudaArrayInterfaceTest(jtu.JaxTestCase):
     dtype=jtu.dtypes.supported(cuda_array_interface_dtypes),
   )
   @jtu.run_on_devices("gpu")
+  @jtu.skip_on_devices("oneapi") # OneAPI does not support `__cuda_array_interface__`
   def testCaiToJax(self, shape, dtype):
     dtype = np.dtype(dtype)
 


### PR DESCRIPTION
This PR adds following changes.

1. It adds `dlpack` array interoperability support for OneAPI GPU plugin. Adds OneAPI dlpack device type identifier in following files.
`jax/_src/array.py`
`jax/_src/dlpack.py`
`jax/_src/typing.py`
`jaxlib/dlpack.cc`
2. Adds `@jtu.skip_on_devices("oneapi")` on few tests in `tests/array_interoperability_test.py` As OneAPI does not support `__cuda_array_interface__`.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->