### PR TITLE
Remove fancy batching rule for lax.empty_p

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -71,7 +71,7 @@ from jax._src.sharding_impls import (
 from jax._src.typing import Array, ArrayLike, DimSize, DuckTypedArray, DType, DTypeLike, Shape
 from jax._src.util import (cache, canonicalize_axis,
                            safe_map, safe_zip, split_list, weakref_lru_cache,
-                           foreach, tuple_insert)
+                           foreach)
 
 _max = builtins.max
 _min = builtins.min
@@ -9650,16 +9650,6 @@ def _empty_lower(ctx, *, shape, dtype, out_sharding):
   out = mlir.broadcast_in_dim(ctx, out, phys_aval, broadcast_dimensions=[])
   return [mlir.lower_with_sharding_in_types(ctx, out, phys_aval)]
 mlir.register_lowering(empty_p, _empty_lower)
-
-def _empty_batcher(axis_data, vals_in, dims_in, *, shape, dtype, out_sharding):
-  batched_shape = tuple_insert(shape, 0, axis_data.size)
-  batched_out_sharding = (
-      None if out_sharding is None else
-      batching.get_sharding_for_vmap(axis_data, out_sharding, 0))
-  y = empty_p.bind(shape=batched_shape, dtype=dtype,
-                   out_sharding=batched_out_sharding)
-  return y, 0
-batching.fancy_primitive_batchers[empty_p] = _empty_batcher
 
 # TODO(yashkatariya): Delete `empty2` and replace scan's usage with `empty` once
 # AllocateBuffer issues are fixed

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4534,7 +4534,6 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(out.shape, (2, 2))
     self.assertEqual(out.dtype, jnp.float32)
 
-  @jtu.run_on_devices('gpu', 'tpu')
   def test_lax_empty_vmap(self):
     inp = np.arange(8, dtype=jnp.int32).reshape(4, 2)
 
@@ -4542,9 +4541,18 @@ class APITest(jtu.JaxTestCase):
       return jax.lax.empty(x.shape, x.dtype)
 
     f = jax.jit(jax.vmap(f))
-    f(inp)  # doesn't crash
-    lowered_text = f.lower(inp).as_text()
-    self.assertIn('@AllocateBuffer() : () -> tensor<4x2xi32>', lowered_text)
+    result = f(inp)
+    self.assertEqual(result.shape, inp.shape)
+
+  def test_lax_empty_batching_bug(self):
+    def f(x):
+      out = jax.lax.empty((2,), x.dtype)
+      out = out.at[0].set(1)
+      return out.at[1].set(out[0] * x[0])
+
+    x = jnp.arange(3.0)
+    res = jax.hessian(f)(x)
+    self.assertArraysEqual(res, np.zeros((2, 3, 3)))
 
   def test_leaked_tracer_issue_7613(self):
     # from https://github.com/jax-ml/jax/issues/7613


### PR DESCRIPTION
This turned out to fail when in_axes=None. It is cleaner here to rely on the default batching behavior.

The following is a short script that failed under the previous implementation:
```python
import jax

def f(x):
  out = jax.lax.empty((2,), x.dtype)
  return out.at[1].set(out[0] * x[0])

x = jax.numpy.arange(3.0)
jax.hessian(f)(x)
# ValueError: at vmap out_axes[0], got axis spec None but output was batched on axis 0
```