### PR TITLE
Fix NaN issue in Rotation from/to rotation vectors for identity rotat…

### DIFF
--- a/jax/_src/scipy/spatial/transform.py
+++ b/jax/_src/scipy/spatial/transform.py
@@ -389,7 +389,7 @@ def _from_rotvec(rotvec: Array, degrees: bool) -> Array:
   angle = _vector_norm(rotvec)
   angle2 = angle * angle
   small_scale = 0.5 - angle2 / 48 + angle2 * angle2 / 3840
-  denom = jnp.where(angle < 1e-20, 1.0, angle)
+  denom = jnp.where(angle == 0, 1.0, angle)
   large_scale = jnp.sin(angle / 2) / denom
   scale = jnp.where(angle <= 1e-3, small_scale, large_scale)
   return jnp.hstack([scale * rotvec, jnp.cos(angle / 2)])

--- a/jax/_src/scipy/spatial/transform.py
+++ b/jax/_src/scipy/spatial/transform.py
@@ -317,7 +317,7 @@ def _as_rotvec(quat: Array, degrees: bool) -> Array:
   angle2 = angle * angle
   small_scale = 2 + angle2 / 12 + 7 * angle2 * angle2 / 2880
   sin_half = jnp.sin(angle / 2)
-  denom = jnp.where(jnp.abs(sin_half) < 1e-20, 1.0, sin_half)
+  denom = jnp.where(sin_half == 0, 1.0, sin_half)
   large_scale = angle / denom
   scale = jnp.where(angle <= 1e-3, small_scale, large_scale)
   scale = jnp.where(degrees, jnp.rad2deg(scale), scale)

--- a/jax/_src/scipy/spatial/transform.py
+++ b/jax/_src/scipy/spatial/transform.py
@@ -316,7 +316,9 @@ def _as_rotvec(quat: Array, degrees: bool) -> Array:
   angle = 2. * jnp.arctan2(_vector_norm(quat[:3]), quat[3])
   angle2 = angle * angle
   small_scale = 2 + angle2 / 12 + 7 * angle2 * angle2 / 2880
-  large_scale = angle / jnp.sin(angle / 2)
+  sin_half = jnp.sin(angle / 2)
+  denom = jnp.where(jnp.abs(sin_half) < 1e-20, 1.0, sin_half)
+  large_scale = angle / denom
   scale = jnp.where(angle <= 1e-3, small_scale, large_scale)
   scale = jnp.where(degrees, jnp.rad2deg(scale), scale)
   return scale * jnp.array(quat[:3])
@@ -386,8 +388,9 @@ def _from_rotvec(rotvec: Array, degrees: bool) -> Array:
   rotvec = jnp.where(degrees, jnp.deg2rad(rotvec), rotvec)
   angle = _vector_norm(rotvec)
   angle2 = angle * angle
-  small_scale = scale = 0.5 - angle2 / 48 + angle2 * angle2 / 3840
-  large_scale = jnp.sin(angle / 2) / angle
+  small_scale = 0.5 - angle2 / 48 + angle2 * angle2 / 3840
+  denom = jnp.where(angle < 1e-20, 1.0, angle)
+  large_scale = jnp.sin(angle / 2) / denom
   scale = jnp.where(angle <= 1e-3, small_scale, large_scale)
   return jnp.hstack([scale * rotvec, jnp.cos(angle / 2)])
 

--- a/jax/_src/scipy/spatial/transform.py
+++ b/jax/_src/scipy/spatial/transform.py
@@ -317,7 +317,7 @@ def _as_rotvec(quat: Array, degrees: bool) -> Array:
   angle2 = angle * angle
   small_scale = 2 + angle2 / 12 + 7 * angle2 * angle2 / 2880
   sin_half = jnp.sin(angle / 2)
-  denom = jnp.where(jnp.abs(sin_half) < 1e-20, 1.0, sin_half)
+  denom = jnp.where(sin_half == 0, 1.0, sin_half)
   large_scale = angle / denom
   scale = jnp.where(angle <= 1e-3, small_scale, large_scale)
   scale = jnp.where(degrees, jnp.rad2deg(scale), scale)
@@ -389,7 +389,7 @@ def _from_rotvec(rotvec: Array, degrees: bool) -> Array:
   angle = _vector_norm(rotvec)
   angle2 = angle * angle
   small_scale = 0.5 - angle2 / 48 + angle2 * angle2 / 3840
-  denom = jnp.where(angle < 1e-20, 1.0, angle)
+  denom = jnp.where(angle == 0, 1.0, angle)
   large_scale = jnp.sin(angle / 2) / denom
   scale = jnp.where(angle <= 1e-3, small_scale, large_scale)
   return jnp.hstack([scale * rotvec, jnp.cos(angle / 2)])

--- a/tests/scipy_spatial_test.py
+++ b/tests/scipy_spatial_test.py
@@ -234,6 +234,19 @@ class LaxBackedScipySpatialTransformTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fn, jnp_fn, args_maker, check_dtypes=True, tol=1e-4)
     self._CompileAndCheck(jnp_fn, args_maker, atol=1e-4)
 
+  def testRotationIdentityDebugNans(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/23839
+    with jax.debug_nans(True):
+      rotvec = jsp_Rotation.identity().as_rotvec()
+      self.assertAllClose(rotvec, jnp.zeros(3), check_dtypes=False)
+
+  def testRotationFromZeroRotvecDebugNans(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/23839
+    with jax.debug_nans(True):
+      rot = jsp_Rotation.from_rotvec(jnp.zeros(3))
+      self.assertAllClose(
+          rot.as_quat(), jnp.array([0., 0., 0., 1.]), check_dtypes=False)
+
   @jtu.sample_product(
     dtype=float_dtypes,
     shape=[(4,), (num_samples, 4)],


### PR DESCRIPTION
This PR addresses #23839. When `jax_debug_nans` is enabled, an identity rotation triggers a division-by-zero error because the denominator evaluates to zero during internal calculations.

Since this issue was opened back in September 2024, I checked the current codebase to see if it had been updated. I found that it already includes a Taylor series approximation along with a `jnp.where` branch.

**File: jax/_src/scipy/spatial/transform.py
Function: _as_rotvec**
small_scale = 2 + angle2 / 12 + 7 * angle2 * angle2 / 2880
large_scale = angle / jnp.sin(angle / 2)
scale = jnp.where(angle <= 1e-3, small_scale, large_scale)

**Function: _from_rotvec**
small_scale = scale = 0.5 - angle2 / 48 + angle2 * angle2 / 3840
large_scale = jnp.sin(angle / 2) / angle
scale = jnp.where(angle <= 1e-3, small_scale, large_scale)

To verify this, I ran unit tests with `jax_debug_nans` enabled and confirmed that the issue still occurs:

**Test 1: `Rotation.identity().as_rotvec()**
  FloatingPointError: invalid value (nan) encountered in div
  File "jax/_src/scipy/spatial/transform.py", line 319, in _as_rotvec
    large_scale = angle / jnp.sin(angle / 2)

**Test 2: Rotation.from_rotvec(jnp.zeros(3))**
FloatingPointError: invalid value (nan) encountered in div
File "jax/_src/scipy/spatial/transform.py", line 377, in _from_rotvec
  large_scale = jnp.sin(angle / 2) / angle

Since both operands of `jnp.where` are computed before the selection, the division-by-zero occurs even when the `small_scale` branch is ultimately selected.

I tried a safe division pattern. This keeps the existing jnp.where structure while preventing invalid intermediate divisions.

After adding the unit tests to `tests/scipy_spatial_test.py` and running them with `jax_debug_nans` enabled, The NaN issue no longer occurs.

=== identity.as_rotvec() with debug_nans ===
[0. 0. 0.]
=== from_rotvec(zeros) with debug_nans ===
[0. 0. 0. 1.]