### PR TITLE
[docs] Updated AOT tutorial with abstract device

### DIFF
--- a/docs/aot.md
+++ b/docs/aot.md
@@ -249,3 +249,39 @@ platform, and runtime. This makes for two important caveats:
    remain the same on the following day.
 
 When in doubt, see the package API documentation for {mod}`jax.stages`.
+
+## Tracing, lowering and compiling with an abstract device
+
+In some situations we can perform _ahead-of-time_ compilation without having a physical target device. In this case we can define {class}`jax.sharding.AbstractDevice`, an abstract array to trace and lower a jitted function under {class}`jax.sharding.use_abstract_mesh`:
+
+```python
+import jax
+import jax.numpy as jnp
+from jax.sharding import AxisType, NamedSharding
+
+
+abstract_device = jax.sharding.AbstractDevice('A100', 1, 'cuda')
+abstract_mesh = jax.sharding.AbstractMesh(
+    (1,),
+    ('x',),
+    (AxisType.Explicit,),
+    abstract_device=abstract_device,
+)
+
+@jax.jit
+def f(x):
+    return x * 10
+
+
+with jax.sharding.use_abstract_mesh(abstract_mesh):
+    abstract_arr = jax.ShapeDtypeStruct((4, 8), jnp.float32)
+    traced = f.trace(abstract_arr)
+    lowered = traced.lower()
+```
+
+Finally, we can compile on the real device:
+```python
+compiled = lowered.compile(device_assignment=tuple(jax.devices()))
+output = compiled(jnp.ones((4, 8)))
+print(output.shape)
+```

--- a/docs/jax.sharding.rst
+++ b/docs/jax.sharding.rst
@@ -20,3 +20,9 @@ Classes
    :members:
 .. autoclass:: Mesh
    :members:
+.. autoclass:: AbstractMesh
+   :members:
+.. autoclass:: AbstractDevice
+   :members:
+.. autoclass:: use_abstract_mesh
+

--- a/jax/_src/mesh.py
+++ b/jax/_src/mesh.py
@@ -453,7 +453,7 @@ class AbstractDevice:
 class AbstractMesh(BaseMesh):
   """AbstractMesh contains only axis names and axis sizes.
 
-  It does not contain concrete devices compared to `jax.sharding.Mesh`. You
+  It does not contain concrete devices compared to :class:`jax.sharding.Mesh`. You
   should use this as an input to the sharding passed to with_sharding_constraint
   and mesh passed to shard_map to avoid tracing and lowering cache misses when
   your mesh shape and axis names stay the same but the devices change.


### PR DESCRIPTION
- Exposed AbstractDevice, AbstractMesh in the API
- Updated AOT tutorial, add "Tracing, lowering and compiling with an abstract device"

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->