### PR TITLE
[ROCm] Add blocking PR gate with a reduced set of tests

### DIFF
--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -87,6 +87,14 @@ on:
         description: "S3 URI for ROCm plugin/PJRT wheels (use 'latest' to resolve via LATEST pointer)"
         default: 'latest'
         type: string
+      gate-targets-file:
+        description: "Path to a file listing Bazel targets to run (one per line). If empty, runs the full default test suite."
+        type: string
+        default: ""
+      gpu-config:
+        description: "Bazel GPU config to use (e.g. single_gpu, rocm_gate)"
+        type: string
+        default: "single_gpu"
       clone_main_xla:
         description: "Should latest XLA be used?"
         type: string
@@ -191,9 +199,11 @@ jobs:
           PYTHON: ${{ inputs.python }}
           ENABLE_X64: ${{ inputs.enable-x64 }}
           RBE_IMAGE: ${{ steps.rbe-image.outputs.rbe_image }}
+          JAXCI_GATE_TARGETS_FILE: ${{ inputs.gate-targets-file }}
+          GPU_CONFIG: ${{ inputs.gpu-config }}
         run: |
           ./ci/run_bazel_test_rocm_rbe.sh  \
-            --config=single_gpu \
+            --config="${GPU_CONFIG}" \
             --local_test_jobs=4 \
             --//jax:build_jaxlib="${BUILD_JAXLIB}" \
             --//jax:build_jax="${BUILD_JAX}" \

--- a/.github/workflows/bazel_rocm_presubmit.yml
+++ b/.github/workflows/bazel_rocm_presubmit.yml
@@ -14,6 +14,8 @@ on:
   pull_request:
     branches:
       - main
+      - 'rocm-jaxlib-v*'
+      - 'amd-main'
   push:
     branches:
       - main
@@ -26,7 +28,7 @@ concurrency:
 permissions: {}
 jobs:
   run-tests:
-    if: github.event.repository.fork == false && (github.repository_owner == 'jax-ml' || github.repository_owner == 'ROCm')
+    if: github.event_name == 'workflow_dispatch' || (github.event.repository.fork == false && (github.repository_owner == 'jax-ml' || github.repository_owner == 'ROCm'))
     uses: ./.github/workflows/bazel_rocm.yml
 # Begin Presubmit Naming Check - name modification requires internal check to be updated
     strategy:
@@ -50,5 +52,32 @@ jobs:
       enable-x64:  ${{ matrix.enable-x64 }}
       build_jaxlib: ${{ (matrix.jaxlib-version == 'head' && 'wheel') || 'false' }}
       build_jax: ${{ 'true' }}
+      gate-targets-file: "build/rocm/ci_test_targets.txt"
+      run_multiaccelerator_tests: ${{ 'false' }}
+      clone_main_xla: 0
+
+  blocking-gate:
+    if: github.event_name == 'workflow_dispatch' || (github.event.repository.fork == false && (github.repository_owner == 'jax-ml' || github.repository_owner == 'ROCm'))
+    uses: ./.github/workflows/bazel_rocm.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.12"]
+        runner: ["amd-do-linux.jax.gpu.gfx950.1"]
+# Begin Presubmit Naming Check - name modification requires internal check to be updated
+    name: "ROCm blocking gate"
+# End Presubmit Naming Check github-rocm-blocking-presubmits
+    with:
+      runner: ${{ matrix.runner }}
+      python: ${{ matrix.python }}
+      rocm-version: "7"
+      rocm-tag: "rocm720"
+      download-jax-from-gcs: 0
+      jaxlib-version: "head"
+      build_jaxlib: ${{ 'true' }}
+      build_jax: ${{ 'true' }}
+      halt-for-connection: ${{ inputs.halt-for-connection }}
+      gate-targets-file: "build/rocm/ci_blocking_test_targets.txt"
+      gpu-config: "single_gpu"
       run_multiaccelerator_tests: ${{ 'false' }}
       clone_main_xla: 0

--- a/build/rocm/ci_blocking_test_targets.txt
+++ b/build/rocm/ci_blocking_test_targets.txt
@@ -1,0 +1,8 @@
+# Blocking PR gate targets.
+# Edit this file to tune which tests gate PRs; no workflow YAML changes needed.
+# Use - prefix to exclude specific tests within a suite.
+# Keep only tests that are fast and reliably passing — flaky tests block all PRs.
+
+# Starting with simple test that can cover large breakage in pjrt
+# compatibility and also does well tested math ops.
+//tests:lax_vmap_op_test_gpu

--- a/build/rocm/ci_test_targets.txt
+++ b/build/rocm/ci_test_targets.txt
@@ -1,0 +1,55 @@
+# Full CI test suite targets.
+# Edit this file to tune which tests run in the regular CI; no workflow YAML changes needed.
+# Use - prefix to exclude specific tests within a suite.
+
+//tests:gpu_tests
+//tests:backend_independent_tests
+//tests/pallas:gpu_tests
+//tests/pallas:backend_independent_tests
+//jaxlib/tools:check_gpu_wheel_sources_test
+-//tests/pallas:pallas_test_gpu
+-//tests/pallas:ops_test_gpu
+-//tests/pallas:ops_test_mgpu_gpu
+-//tests/pallas:pallas_shape_poly_test_gpu
+-//tests/pallas:pallas_vmap_test_gpu
+-//tests/pallas:triton_pallas_test_gpu
+-//tests:export_harnesses_multi_platform_test_gpu
+-//tests:jet_test_gpu
+-//tests:lax_autodiff_test_gpu
+-//tests:lax_numpy_setops_test_gpu
+-//tests:lax_numpy_test_gpu
+-//tests:lax_test_gpu
+-//tests:linalg_test_gpu
+-//tests:logging_test_gpu
+-//tests:random_lax_test_gpu
+-//tests:scipy_signal_test_gpu
+-//tests:stax_test_gpu
+-//tests:ode_test_gpu
+-//tests:lobpcg_test_gpu
+-//tests:scipy_stats_test_gpu
+-//tests:nn_test_gpu
+-//tests:lax_scipy_sparse_test_gpu
+-//tests:lax_scipy_spectral_dac_test_gpu
+-//tests:lax_scipy_special_functions_test_gpu
+-//tests:cholesky_update_test_gpu
+-//tests:api_test_gpu
+-//tests:ann_test_gpu
+-//tests:experimental_rnn_test_gpu
+-//tests:lax_vmap_test_gpu
+-//tests:qdwh_test_gpu
+-//tests:scaled_dot_test_gpu
+-//tests:scipy_spatial_test_gpu
+-//tests:shape_poly_test_gpu
+-//tests:sparsify_test_gpu
+-//tests:lax_numpy_reducers_test_gpu
+-//tests:scipy_optimize_test_gpu
+-//tests:lax_numpy_einsum_test_gpu
+-//tests:lax_scipy_test_gpu
+-//tests:sparse_test_gpu
+-//tests:sparse_bcoo_bcsr_test_gpu
+-//tests:svd_test_gpu
+-//tests:eigh_test_gpu
+-//tests:image_test_gpu
+# buffer_callback_test_gpu uses py_import deps that are incompatible with
+# pre-built plugin wheels (build_jaxlib=false); exclude it unconditionally.
+-//tests:buffer_callback_test_gpu

--- a/ci/run_bazel_test_rocm_rbe.sh
+++ b/ci/run_bazel_test_rocm_rbe.sh
@@ -45,52 +45,10 @@ echo "Running RBE GPU tests..."
 
 TAG_FILTERS="jax_test_gpu,-config-cuda-only,-manual"
 
-TESTS_TO_IGNORE=(
-    -//tests/pallas:pallas_test_gpu
-    -//tests/pallas:ops_test_gpu
-    -//tests/pallas:ops_test_mgpu_gpu
-    -//tests/pallas:pallas_shape_poly_test_gpu
-    -//tests/pallas:pallas_vmap_test_gpu
-    -//tests/pallas:triton_pallas_test_gpu
-    -//tests:export_harnesses_multi_platform_test_gpu
-    -//tests:jet_test_gpu
-    -//tests:lax_autodiff_test_gpu
-    -//tests:lax_numpy_setops_test_gpu
-    -//tests:lax_numpy_test_gpu
-    -//tests:lax_test_gpu
-    -//tests:linalg_test_gpu
-    -//tests:logging_test_gpu
-    -//tests:random_lax_test_gpu
-    -//tests:scipy_signal_test_gpu
-    -//tests:stax_test_gpu
-    -//tests:ode_test_gpu
-    -//tests:lobpcg_test_gpu
-    -//tests:scipy_stats_test_gpu
-    -//tests:nn_test_gpu
-    -//tests:lax_scipy_sparse_test_gpu
-    -//tests:lax_scipy_spectral_dac_test_gpu
-    -//tests:lax_scipy_special_functions_test_gpu
-    -//tests:cholesky_update_test_gpu
-    -//tests:api_test_gpu
-    -//tests:ann_test_gpu
-    -//tests:experimental_rnn_test_gpu
-    -//tests:lax_vmap_test_gpu
-    -//tests:qdwh_test_gpu
-    -//tests:scaled_dot_test_gpu
-    -//tests:scipy_spatial_test_gpu
-    -//tests:shape_poly_test_gpu
-    -//tests:sparsify_test_gpu
-    -//tests:lax_numpy_reducers_test_gpu
-    -//tests:scipy_optimize_test_gpu
-    #TODO(mgaonka-amd) re-enable these tests once this issue is fixed.
-    -//tests:lax_numpy_einsum_test_gpu
-    -//tests:lax_scipy_test_gpu
-    -//tests:sparse_test_gpu
-    -//tests:sparse_bcoo_bcsr_test_gpu
-    -//tests:svd_test_gpu
-    -//tests:eigh_test_gpu
-    -//tests:image_test_gpu
-)
+# JAXCI_GATE_TARGETS_FILE selects which Bazel target pattern file to use.
+# Defaults to the full CI suite; set to build/rocm/ci_blocking_test_targets.txt
+# for the PR blocking gate.
+TARGETS_FILE="${JAXCI_GATE_TARGETS_FILE:-build/rocm/ci_test_targets.txt}"
 
 for arg in "$@"; do
     if [[ "$arg" == "--config=multi_gpu" ]]; then
@@ -98,12 +56,6 @@ for arg in "$@"; do
     fi
     if [[ "$arg" == "--config=single_gpu" ]]; then
         TAG_FILTERS="${TAG_FILTERS},gpu,-multiaccelerator,-multiaccelerator-only"
-    fi
-    if [[ "$arg" == "--//jax:build_jaxlib=false" ]]; then
-        # tests to ignore for pre-built plugin wheels
-        TESTS_TO_IGNORE+=(
-            -//tests:buffer_callback_test_gpu
-        )
     fi
 done
 
@@ -129,13 +81,7 @@ bazel --bazelrc=build/rocm/rocm.bazelrc test \
     --color=yes \
     $@ \
     --spawn_strategy=local \
-    -- \
-    //tests:gpu_tests \
-    //tests:backend_independent_tests \
-    //tests/pallas:gpu_tests \
-    //tests/pallas:backend_independent_tests \
-    //jaxlib/tools:check_gpu_wheel_sources_test \
-    "${TESTS_TO_IGNORE[@]}" || bazel_retval=$?
+    --target_pattern_file="${TARGETS_FILE}" || bazel_retval=$?
 echo "::endgroup::" >&2
 
 echo "::group::Cleanup" >&2


### PR DESCRIPTION
## Summary

- Adds a `blocking-gate` job to `bazel_rocm_presubmit.yml` that runs a curated subset of GPU tests on every pull request to `amd-main` and `rocm-jaxlib-v*` branches, building everything from source so there is no dependency on pre-built GCS/S3 artifacts.
- Replaces the hardcoded `TESTS_TO_IGNORE` array in `ci/run_bazel_test_rocm_rbe.sh` with `--target_pattern_file` so the test list is controlled by a plain text file (`JAXCI_GATE_TARGETS_FILE` env var), making it easy to tune without touching the shell script.
- Adds `build/rocm/ci_blocking_test_targets.txt` (reduced gate list) and `build/rocm/ci_test_targets.txt` (full CI suite, replacing the inline exclusion array).
- Adds `gate-targets-file` and `gpu-config` inputs to `bazel_rocm.yml`;
- Fixes job conditions in `bazel_rocm_presubmit.yml` to allow `workflow_dispatch` on `ROCm/jax` (which is a fork and would otherwise be skipped by the `fork == false` check).

## Test plan

- [x] Trigger `workflow_dispatch` on `rocm-blocking-gate-v2` and confirm the `blocking-gate` job runs only the tests listed in `ci_blocking_test_targets.txt`.
- [x] Confirm the full `run-tests` job still uses `ci_test_targets.txt`.