### PR TITLE
[ROCm] Add TheRock 7.14.0/latest coverage to CI workflows

### DIFF
--- a/.github/workflows/bazel_rocm_presubmit.yml
+++ b/.github/workflows/bazel_rocm_presubmit.yml
@@ -49,6 +49,8 @@ jobs:
       jaxlib-version: ${{ matrix.jaxlib-version }}
       halt-for-connection: ${{ inputs.halt-for-connection }}
       rocm-version: ${{ matrix.rocm-version }}
+      rocm-tag: "therock-7.14"
+      rocm-release-version: "7.14.0"
       enable-x64:  ${{ matrix.enable-x64 }}
       build_jaxlib: ${{ (matrix.jaxlib-version == 'head' && 'wheel') || 'false' }}
       build_jax: ${{ 'true' }}
@@ -71,7 +73,8 @@ jobs:
       runner: ${{ matrix.runner }}
       python: ${{ matrix.python }}
       rocm-version: "7"
-      rocm-tag: "rocm720"
+      rocm-tag: "therock-7.14"
+      rocm-release-version: "7.14.0"
       download-jax-from-gcs: 0
       jaxlib-version: "head"
       build_jaxlib: ${{ 'true' }}

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -504,7 +504,7 @@ jobs:
           artifact: ["jax-rocm-plugin", "jax-rocm-pjrt"]
           python: ["3.12", "3.13", "3.14"]
           rocm: [
-            {label: "ROCm 7.2.0", wheel-version: "7", release-version: "7.2.0", manylinux-image: ""},
+            {label: "TheRock 7.14.0", wheel-version: "7", release-version: "7.14.0", manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-7.14:latest" },
           ]
           exclude:
             - artifact: "jax-rocm-pjrt"
@@ -545,7 +545,7 @@ jobs:
           runner: ["amd-do-linux.jax.gpu.gfx950.1", "amd-do-linux.jax.gpu.gfx950.4", "amd-do-linux.jax.gpu.gfx950.8"]
           python: ["3.12"]
           rocm: [
-            {label: "ROCm 7.2.0", wheel-version: "7", release-version: "7.2.0", tag: "rocm720"},
+            {label: "TheRock 7.14.0", wheel-version: "7", release-version: "7.14.0", tag: "therock-7.14"},
           ]
     name: "Pytest ROCm (${{ matrix.rocm.label }})"
     with:
@@ -580,7 +580,7 @@ jobs:
           runner: ["amd-do-linux.jax.gpu.gfx950.4", "amd-do-linux.jax.gpu.gfx950.8"]
           python: ["3.12"]
           rocm: [
-            {label: "ROCm 7.2.0", wheel-version: "7", release-version: "7.2.0", tag: "rocm720"},
+            {label: "TheRock 7.14.0", wheel-version: "7", release-version: "7.14.0", tag: "therock-7.14"},
           ]
           enable-x64: [0]
     name: "Bazel ROCm (${{ matrix.rocm.label }})"

--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -181,7 +181,8 @@ jobs:
           artifact: ["jax-rocm-plugin", "jax-rocm-pjrt"]
           python: ["3.12", "3.13", "3.14"]
           rocm: [
-            {label: "ROCm 7.2.0", wheel-version: "7", release-version: "7.2.0", manylinux-image: ""},
+            {label: "TheRock 7.14.0", wheel-version: "7", release-version: "7.14.0", manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-7.14:latest" },
+            {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-latest:latest"},
           ]
           exclude:
             - artifact: "jax-rocm-pjrt"
@@ -214,7 +215,8 @@ jobs:
           runner: ["amd-do-linux.jax.gpu.gfx950.1", "amd-do-linux.jax.gpu.gfx950.4", "amd-do-linux.jax.gpu.gfx950.8"]
           python: ["3.12", "3.13", "3.14"]
           rocm: [
-            {label: "ROCm 7.2.0", wheel-version: "7", release-version: "7.2.0", tag: "rocm720"},
+            {label: "TheRock 7.14.0", wheel-version: "7", release-version: "7.14.0", tag: "therock-7.14"},
+            {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", tag: "therock-latest"},
           ]
     name: "Pytest ROCm (${{ matrix.rocm.label }})"
     with:
@@ -241,7 +243,8 @@ jobs:
           runner: ["amd-do-linux.jax.gpu.gfx950.1"]
           python: ["3.12", "3.13", "3.14"]
           rocm: [
-            {label: "ROCm 7.2.0", wheel-version: "7", release-version: "7.2.0", tag: "rocm720"},
+            {label: "TheRock 7.14.0", wheel-version: "7", release-version: "7.14.0", tag: "therock-7.14"},
+            {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", tag: "therock-latest"},
           ]
           enable-x64: [0]
     name: "Bazel ROCm (${{ matrix.rocm.label }})"

--- a/ci/run_bazel_test_rocm_rbe.sh
+++ b/ci/run_bazel_test_rocm_rbe.sh
@@ -61,6 +61,16 @@ done
 
 TEST_ARTIFACTS_DIR="test-artifacts"
 mkdir -p "$TEST_ARTIFACTS_DIR"
+
+# Point ROCM_PATH and LD_LIBRARY_PATH at the local TheRock installation.
+ROCM_SDK_FLAGS=()
+if command -v rocm-sdk >/dev/null 2>&1; then
+    ROCM_SDK_ROOT="$(rocm-sdk path --root)"
+    ROCM_SDK_FLAGS=(
+        "--repo_env=ROCM_PATH=${ROCM_SDK_ROOT}"
+        "--test_env=LD_LIBRARY_PATH=${ROCM_SDK_ROOT}/lib"
+    )
+fi
 echo "::endgroup::" >&2
 
 echo "::group::Bazel ROCm RBE tests" >&2
@@ -79,6 +89,7 @@ bazel --bazelrc=build/rocm/rocm.bazelrc test \
     --test_env=JAX_SKIP_SLOW_TESTS=true \
     --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a,gfx942,gfx950" \
     --color=yes \
+    "${ROCM_SDK_FLAGS[@]}" \
     $@ \
     --spawn_strategy=local \
     --target_pattern_file="${TARGETS_FILE}" || bazel_retval=$?

--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -26,6 +26,15 @@ set -exu -o history -o allexport
 # Source default JAXCI environment variables.
 source ci/envs/default.env
 
+# Point PATH and LD_LIBRARY_PATH at the local TheRock installation.
+if command -v rocm-sdk >/dev/null 2>&1; then
+  sdk_root="$(rocm-sdk path --root)"
+  if [[ -n "$sdk_root" ]]; then
+    export PATH="$sdk_root/bin:$PATH"
+    export LD_LIBRARY_PATH="$sdk_root/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+  fi
+fi
+
 # Install jaxlib and ROCm plugin wheels inside the $JAXCI_OUTPUT_DIR directory
 echo "Installing wheels locally..."
 source ./ci/utilities/install_wheels_locally.sh
@@ -35,17 +44,6 @@ echo "Installed packages:"
 "$JAXCI_PYTHON" -m uv pip freeze
 
 "$JAXCI_PYTHON" -c "import jax; print(jax.default_backend()); print(jax.devices()); print(len(jax.devices()))"
-
-# TheRock (pip) ROCm images are intentionally /opt/rocm-less, so ROCm CLI tools
-# (rocminfo, rocm-smi, ...) live in the SDK bin dir rather than on PATH. Put
-# them on PATH via rocm-sdk. apt-ROCm images lack rocm-sdk and already have
-# these tools on PATH, so the gate leaves them untouched.
-if command -v rocm-sdk >/dev/null 2>&1; then
-  sdk_bin="$(rocm-sdk path --bin)"
-  if [[ -n "$sdk_bin" ]]; then
-    export PATH="$sdk_bin:$PATH"
-  fi
-fi
 
 rocm-smi
 


### PR DESCRIPTION
## Summary

- Extends the ROCm wheel test matrices (build, pytest, and bazel jobs) to cover `TheRock 7.14.0` (N), replacing the `ROCm 7.2.0` (`rocm720`) entry. `wheel_tests_nightly_release.yml` also adds`TheRock latest` (N+1); `wheel_tests_continuous.yml` only runs `TheRock 7.14.0` to keep the continuous matrix smaller.
- Points `bazel_rocm_presubmit.yml`'s `run-tests` and `blocking-gate` checks at TheRock 7.14.0 (container tag `therock-7.14`, release-version `7.14.0`), replacing `rocm720`.
- TheRock images install 7.14.0 via pip. `run_bazel_test_rocm_rbe.sh` now passes `--repo_env=ROCM_PATH` (when `rocm-sdk` is present) so `local_config_rocm` builds against the installed 7.14.0 SDK, plus `--test_env=LD_LIBRARY_PATH` so RBE-executed tests find the matching runtime libraries (TheRock's pip install is intentionally `/opt/rocm-less`, so nothing is on the default loader path). `run_pytest_rocm.sh` gets the equivalent `LD_LIBRARY_PATH` export. `build_rocm_artifacts.sh` already had the `ROCM_PATH` handling from a prior commit. No-op on apt-ROCm images, which lack `rocm-sdk`.