### PR TITLE
[oneAPI] Enable Hermetic Runtime Loading for JAX oneAPI Wheels

### DIFF
--- a/jax_plugins/oneapi/__init__.py
+++ b/jax_plugins/oneapi/__init__.py
@@ -12,28 +12,134 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ctypes
 import functools
 import importlib
+import importlib.util
 import logging
 import os
 import pathlib
+import sys
 
 from jax._src.lib import xla_client
 import jax._src.xla_bridge as xb
 
+logger = logging.getLogger(__name__)
+
 # oneapi_plugin_extension locates inside jaxlib. `jaxlib` is for testing without
 # preinstalled jax oneapi plugin packages.
-for pkg_name in ['jax_oneapi_plugin', 'jax_oneapi_pjrt', 'jaxlib.oneapi']:
-  try:
-    oneapi_plugin_extension = importlib.import_module(
-        f'{pkg_name}.oneapi_plugin_extension'
-    )
-  except ImportError:
-    oneapi_plugin_extension = None
-  else:
-    break
+def _load_oneapi_plugin_extension():
+  for pkg_name in ['jax_oneapi_plugin', 'jax_oneapi_pjrt', 'jaxlib.oneapi']:
+    try:
+      return importlib.import_module(f'{pkg_name}.oneapi_plugin_extension')
+    except ImportError:
+      continue
+  return None
 
-logger = logging.getLogger(__name__)
+
+def _try_load_library(path_or_name):
+  try:
+    if sys.platform == 'win32':
+      ctypes.CDLL(str(path_or_name))
+    else:
+      mode = getattr(os, 'RTLD_GLOBAL', 0) | getattr(os, 'RTLD_LAZY', 0)
+      ctypes.CDLL(str(path_or_name), mode=mode)
+    logger.debug('Loaded library: %s', path_or_name)
+    return True
+  except OSError as e:
+    logger.debug('Failed to load library %s: %s', path_or_name, e)
+    return False
+
+
+def _load_matching_libraries(lib_dir, patterns, loaded):
+  import re
+  def _version_key(path):
+    return [int(s) if s.isdigit() else s for s in re.split(r'(\d+)', path.name)]
+
+  for pattern in patterns:
+    matches = sorted(lib_dir.glob(pattern), key=_version_key, reverse=True)
+    for path in matches:
+      if str(path) in loaded:
+        continue
+      if _try_load_library(path):
+        loaded.add(str(path))
+        break
+
+
+def _try_load_from_package(package_name, lib_patterns, loaded):
+  pkg_paths = []
+  try:
+    spec = importlib.util.find_spec(package_name)
+  except Exception:
+    spec = None
+
+  if spec is not None:
+    if spec.submodule_search_locations:
+      pkg_paths.extend(pathlib.Path(p) for p in spec.submodule_search_locations)
+    elif spec.origin:
+      pkg_paths.append(pathlib.Path(spec.origin).resolve().parent)
+
+  for pkg_path in pkg_paths:
+    for lib_dir in (pkg_path / 'lib', pkg_path):
+      if lib_dir.exists():
+        _load_matching_libraries(lib_dir, lib_patterns, loaded)
+
+
+def _load_oneapi_libraries():
+  patterns = [
+      'libimf.so*',
+      'libintlc.so*',
+      'libirc.so*',
+      'libsvml.so*',
+      'libirng.so*',
+      'libumf.so*',
+      'libhwloc.so*',
+      'libur_loader.so*',
+      'libur_adapter_level_zero.so*',
+      'libur_adapter_opencl.so*',
+      'libOpenCL.so*',
+      'libsycl.so*',
+      'libmpi.so*',
+      'libmkl_core.so*',
+      'libmkl_sequential.so*',
+      'libmkl_intel_ilp64.so*',
+      'libmkl_intel_lp64.so*',
+      'libmkl_intel_thread.so*',
+      'libmkl_rt.so*',
+      'libmkl_sycl_blas.so*',
+      'libmkl_sycl_dft.so*',
+      'libmkl_sycl_lapack.so*',
+      'libmkl_sycl_rng.so*',
+      'libmkl_sycl_sparse.so*',
+      'libmkl_sycl_stats.so*',
+  ]
+
+  loaded = set()
+
+  for package_name in [
+      'jax_oneapi_plugin',
+      'intel_sycl_rt',
+      'intel_cmplr_lib_rt',
+      'intel_cmplr_lic_rt',
+      'intel_cmplr_lib_ur',
+      'umf',
+      'impi_rt',
+      'mkl',
+  ]:
+    _try_load_from_package(package_name, patterns, loaded)
+
+  lib_dirs = [
+      pathlib.Path(sys.prefix) / 'lib',
+      pathlib.Path(sys.prefix) / 'lib64',
+      pathlib.Path('/usr/local/lib'),
+  ]
+
+  for lib_dir in lib_dirs:
+    if lib_dir.exists():
+      _load_matching_libraries(lib_dir, patterns, loaded)
+
+  logger.debug('Loaded oneAPI libs via paths: %s', sorted(loaded))
+
 
 def _get_library_path():
   base_path = pathlib.Path(__file__).resolve().parent
@@ -76,6 +182,9 @@ def _get_library_path():
 
 
 def initialize():
+  _load_oneapi_libraries()
+  oneapi_plugin_extension = _load_oneapi_plugin_extension()
+
   path = _get_library_path()
   if path is None:
     return

--- a/jax_plugins/oneapi/plugin_setup.py
+++ b/jax_plugins/oneapi/plugin_setup.py
@@ -34,6 +34,26 @@ _version_module = load_version_module(package_name)
 __version__ = _version_module._get_version_for_build()
 _cmdclass = _version_module._get_cmdclass(package_name)
 
+# oneAPI runtime dependency pins
+dpcpp_cpp_rt_version = "==2025.1.1"
+intel_sycl_rt_version = "==2025.1.1"
+tbb_version = "==2022.1.0"
+intel_cmplr_lib_rt_version = "==2025.1.1"
+intel_cmplr_lib_ur_version = "==2025.1.1"
+intel_cmplr_lic_rt_version = "==2025.1.1"
+intel_opencl_rt_version = "==2025.1.1"
+intel_openmp_version = "==2025.1.1"
+impi_rt_version = "==2021.15.0"
+intel_pti_version = "==0.12.0"
+mkl_version = "==2025.1.0"
+onemkl_sycl_blas_version = "==2025.1.0"
+onemkl_sycl_dft_version = "==2025.1.0"
+onemkl_sycl_lapack_version = "==2025.1.0"
+onemkl_sycl_rng_version = "==2025.1.0"
+onemkl_sycl_sparse_version = "==2025.1.0"
+umf_version = "==0.10.0"
+tcmlib_version = "==1.3.0"
+
 class BinaryDistribution(Distribution):
   """This class makes 'bdist_wheel' include an ABI tag on the wheel."""
 
@@ -54,6 +74,28 @@ setup(
     install_requires=[f"jax-oneapi-pjrt=={__version__}"],
     url="https://github.com/jax-ml/jax",
     license="Apache-2.0",
+    extras_require={
+        "with-oneapi": [
+            f"dpcpp-cpp-rt{dpcpp_cpp_rt_version}",
+            f"intel-sycl-rt{intel_sycl_rt_version}",
+            f"tbb{tbb_version}",
+            f"intel-cmplr-lib-rt{intel_cmplr_lib_rt_version}",
+            f"intel-cmplr-lib-ur{intel_cmplr_lib_ur_version}",
+            f"intel-cmplr-lic-rt{intel_cmplr_lic_rt_version}",
+            f"intel-opencl-rt{intel_opencl_rt_version}",
+            f"intel-openmp{intel_openmp_version}",
+            f"impi-rt{impi_rt_version}",
+            f"intel-pti{intel_pti_version}",
+            f"mkl{mkl_version}",
+            f"onemkl-sycl-blas{onemkl_sycl_blas_version}",
+            f"onemkl-sycl-dft{onemkl_sycl_dft_version}",
+            f"onemkl-sycl-lapack{onemkl_sycl_lapack_version}",
+            f"onemkl-sycl-rng{onemkl_sycl_rng_version}",
+            f"onemkl-sycl-sparse{onemkl_sycl_sparse_version}",
+            f"umf{umf_version}",
+            f"tcmlib{tcmlib_version}",
+        ],
+    },
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3.12",

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,11 @@ setup(
           f"jax-rocm7-plugin=={_jax_version}.*",
         ],
 
+        'oneapi': [
+          f"jaxlib>={_current_jaxlib_version},<={_jax_version}",
+          f"jax-oneapi-plugin[with-oneapi]>={_current_jaxlib_version},<={_jax_version}",
+        ],
+
         # For automatic bootstrapping distributed jobs in Kubernetes
         'k8s': [
           'kubernetes',


### PR DESCRIPTION
Add library loading functions and dependency management for hermetic oneAPI 2025.1 runtime execution:

- jax_plugins/oneapi/__init__.py: Add _load_oneapi_libraries() to dynamically load oneAPI runtime libraries from wheel packages (jax_oneapi_plugin, intel_sycl_rt, mkl, etc.) or system paths
- jax_plugins/oneapi/plugin_setup.py: Add oneAPI 2025.1 runtime dependency pins and extras_require[oneapi] for hermetic wheel installation

This enables JAX oneAPI wheels to bundle and load their own oneAPI runtime instead of requiring system-installed oneAPI.
