### PR TITLE
Fix spurious zeros from jax.scipy.special.erfcx for large arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 * Deprecations
   * Passing 2-dimensional arrays (or mixed 2D and 3D arrays) to {func}`jax.numpy.cross` is deprecated and will be removed in JAX 0.12.0, aligning with NumPy 2.5 behavior.
 
+* Bug fixes:
+  * Fixed {func}`jax.scipy.special.erfcx` returning a spurious `0` for a band of
+    large arguments (~[26.5, 26.64] for float64, ~[9.2, 9.42] for float32)
+    ({jax-issue}`#38607`).
+
 ## JAX 0.10.2 (June 17, 2026)
 
 * New features

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -701,10 +701,8 @@ def erfcx(x: ArrayLike) -> Array:
 @custom_derivatives.custom_jvp
 def _erfcx(x: Array) -> Array:
   if x.dtype == np.float64:
-    # At threshold ~26.6, first omitted term |c_9|/x^18 ~ 1e-21 << eps64 ~ 2e-16.
     return _erfcx_impl(x, nterms=9)
   elif x.dtype == np.float32:
-    # At threshold ~9.4, first omitted term |c_5|/x^10 ~ 5e-9 << eps32 ~ 1e-7.
     return _erfcx_impl(x, nterms=5)
   else:  # float16, bfloat16 — upcast to float32
     return _erfcx_impl(x.astype(np.float32), nterms=5).astype(x.dtype)
@@ -725,9 +723,21 @@ def _erfcx_asymptotic(x: Array, nterms: int) -> Array:
 
 
 def _erfcx_impl(x: Array, nterms: int) -> Array:
-  # Switch to asymptotic expansion when exp(x^2) would overflow.
-  # Overflow occurs when x^2 > log(fmax), i.e. x > sqrt(log(fmax)).
-  threshold = np.sqrt(np.log(dtypes.finfo(x.dtype).max))
+  # erfcx(x) = exp(x^2) * erfc(x). Evaluating this product directly loses all
+  # precision once erfc(x) underflows into the subnormal range, which happens at
+  # an argument *smaller* than the one at which exp(x^2) overflows (the two
+  # cancel, so the result stays finite well past where the product can be
+  # represented). Switching to the asymptotic expansion based on the overflow
+  # point of exp(x^2) therefore leaves a band of large x where the direct
+  # product underflows to a spurious 0 (https://github.com/jax-ml/jax/issues/38607).
+  #
+  # Instead, switch as soon as the asymptotic expansion is accurate to machine
+  # epsilon, which happens well before the direct path degrades. The first
+  # omitted term of the expansion truncated at `nterms` terms is
+  # |c_nterms| / x^(2*nterms) with c_n = (2n-1)!! / 2^n, so the expansion reaches
+  # eps for x >= (|c_nterms| / eps) ** (1 / (2*nterms)).
+  c_next = float(np.prod(np.arange(1, 2 * nterms, 2))) / 2.0 ** nterms
+  threshold = (c_next / float(dtypes.finfo(x.dtype).eps)) ** (1. / (2 * nterms))
   large = x > _lax_const(x, threshold)
   safe_x = lax.select(large, lax.full_like(x, 1.), x)
   direct = lax.exp(lax.square(safe_x)) * lax.erfc(safe_x)

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -262,6 +262,25 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
       scipy_val = osp_special.erfcx(x)
       self.assertAllClose(jax_val, scipy_val, rtol=1e-12)
 
+  def testErfcxNoSpuriousZeros(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/38607. erfcx(x)
+    # is strictly positive for all finite x, but it returned a spurious 0 in a
+    # band of large x where exp(x^2) is still finite yet erfc(x) has underflowed,
+    # so the direct product exp(x^2) * erfc(x) underflowed to 0. The bands were
+    # ~[9.2, 9.42] for float32 and ~[26.5, 26.64] for float64 -- just below the
+    # argument at which exp(x^2) overflows.
+    x = np.linspace(8., 11., 2000, dtype=np.float32)
+    jax_val = lsp_special.erfcx(x)
+    self.assertTrue(np.all(np.asarray(jax_val) > 0.))
+    self.assertAllClose(jax_val, osp_special.erfcx(x.astype(np.float64)),
+                        rtol=1e-5, check_dtypes=False)
+    if jax.config.x64_enabled:
+      x = np.linspace(25., 28., 2000, dtype=np.float64)
+      jax_val = lsp_special.erfcx(x)
+      self.assertTrue(np.all(np.asarray(jax_val) > 0.))
+      self.assertAllClose(jax_val, osp_special.erfcx(x), rtol=1e-12,
+                          check_dtypes=False)
+
   def testWofzAccuracy(self):
     # Verify wofz agrees with scipy over the full complex plane (float32).
     rng = jtu.rand_default(np.random.RandomState(0))


### PR DESCRIPTION
`jax.scipy.special.erfcx` returns 0 for a range of large x where the true value is nonzero (#38607):

```python
>>> import jax; jax.config.update('jax_enable_x64', True)
>>> import jax.scipy.special as jsp, scipy.special as ssp
>>> jsp.erfcx(26.6), ssp.erfcx(26.6)
(0.0, 0.02119517815916648)
```

`erfcx(x) = exp(x^2) * erfc(x)`. The code computes this product directly and only falls back to the asymptotic series once `exp(x^2)` would overflow (around x=26.64 for float64). But `erfc(x)` underflows to a subnormal a bit before that point, so in the band roughly [26.5, 26.64] for float64 (and [9.2, 9.42] for float32) the product is `finite * 0 = 0`.

The fix switches to the asymptotic series as soon as it is accurate to eps, rather than waiting for the overflow point. The first dropped term is `|c_n|/x^(2n)` with `c_n = (2n-1)!!/2^n`, so it falls below eps for `x >= (|c_n|/eps)^(1/(2n))`, about 13.7 for float64 and 6.9 for float32. That is well before the direct product breaks down, so no accuracy is lost.

Added a regression test covering both bands. `tests/lax_scipy_special_functions_test.py` passes with x64 enabled (518 tests), and erfcx matches scipy to a few ulp across [0, 40].

Fixes #38607
