### PR TITLE
support checkpoint_name in custom_vjp fwd if custom_vjp3=1

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -1114,13 +1114,36 @@ class CheckpointName(VJPHiPrimitive):
   def linearized(self, _, g):  # type: ignore
     return g
 
-@custom_derivatives.custom_jvp
+class PrimalLeftTangentRight(VJPHiPrimitive):
+  def __init__(self, aval_x, aval__x):
+    self.in_avals = aval_x, aval__x
+    self.out_aval = aval_x
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x, _x):  # pyrefly: ignore[bad-override]
+    return x
+
+  def lin(self, nzs_in, x, _x):  # type: ignore
+    return x, None
+
+  def linearized(self, _, xdot, _xdot):  # type: ignore
+    return _xdot
+
+  def vjp_fwd(self, nzs_in, x, _x):  # type: ignore
+    return x, None
+
+  def vjp_bwd_retval(self, _, g):
+    return None, g
+
+  def jvp(self, primals, tangents):
+    assert False
+
+  def batch(self, axis_data, args, dims):
+    assert False
+
 def primal_left_tangent_right(x, _x):
-  return x
-@primal_left_tangent_right.defjvp
-def _jvp(primals, tangents):
-  (x, _), (_, t) = primals, tangents
-  return x, t
+  return PrimalLeftTangentRight(typeof(x), typeof(_x))(x, _x)
 
 
 # TODO reverse-mode only... use hijax instead of custom_vjp

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -39,7 +39,8 @@ from jax._src.custom_derivatives import (
 from jax._src.errors import UnexpectedTracerError
 from jax._src.state.types import AbstractRef
 from jax._src import ad_util
-from jax._src.util import safe_zip, safe_map, split_list, unzip2
+from jax._src.util import (
+    safe_zip, safe_map, split_list, unzip2, partition_list, merge_lists)
 from jax._src import flattree as ft
 from jax._src.tree_util import (
     tree_map, tree_flatten, tree_unflatten, tree_leaves, tree_leaves_checked,
@@ -786,6 +787,20 @@ class CustomVJPTraced(VJPHiPrimitive):
     disallowed = effects.custom_derivatives_allowed_effects.filter_not_in(effs)
     if disallowed:
       raise NotImplementedError(f'Effects not supported in `custom_jvp`: {disallowed}')
+
+  def remat(self, policy, *args):  # type: ignore
+    if not self.static_argnums:
+      fwd, dyn_args = self.fwd, args
+    else:
+      which_static = [i in self.static_argnums for i in range(len(args))]
+      dyn_args, static_args = partition_list(which_static, args)
+      static_args = [x.val for x in static_args]
+      fwd = lambda *dyn_args: self.fwd(*merge_lists(which_static, dyn_args, static_args))
+    (out, _), rem_ = remat.remat_transform(policy, fwd, *dyn_args)
+    rem = lambda *args: rem_(*[x for i, x in enumerate(args) if i not in self.static_argnums])
+    helper = CustomVJPTraced(self.traced, rem, self.bwd, self.in_avals,
+                             False, self.static_argnums, False)
+    return out, helper
 
 def _vjp_primal_fwd_tree_mismatch_err(self, tree):
   return (f"Custom VJP fwd rule {self.fwd.__name__} for function {self.traced.fun_name} "

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -7489,7 +7489,8 @@ class Remat3Test(RematTest):
     self.assertEqual(jaxpr_text.count(' sin '), 1)
     self.assertEqual(jaxpr_text.count(' cos '), 2)
 
-  def test_remat_of_cond_funky_custom_jvp2(self): pass
+  def test_remat_of_cond_funky_custom_jvp2(self):
+    raise unittest.SkipTest()
 
   def test_remat_of_cond_policy(self):
     def sin_fwd(policy, x):
@@ -7516,7 +7517,8 @@ class Remat3Test(RematTest):
     self.assertEqual(jaxpr_text.count(' sin '), 0)
     self.assertEqual(jaxpr_text.count(' cos '), 0)
 
-  def test_remat_of_scan_funky_custom_jvp2(self): pass
+  def test_remat_of_scan_funky_custom_jvp2(self):
+    raise unittest.SkipTest()
 
   def test_remat_of_scan_policy(self):
     def sin_fwd(policy, x):
@@ -7588,7 +7590,78 @@ class Remat3Test(RematTest):
     with assertEvals(3):
       vjp(v)
 
-  # TODO(mattjj): nested remat test
+  @config.custom_vjp3(True)
+  def test_custom_vjp_with_checkpoint_name_in_fwd(self):
+    assert jax.config.jax_custom_vjp3
+    sin = jax.custom_vjp(jnp.sin)
+    def fwd(x):
+      return jnp.sin(x), checkpoint_name(jnp.cos(x), 'cos')
+    def bwd(cos_x, g):
+      return cos_x * g,
+    sin.defvjp(fwd, bwd)
+
+    def fwd_bwd_jaxpr_strs(f, *args):
+      fwd_jaxpr = jax.jit(partial(jax.vjp, f)).trace(*args).lojax.jaxpr
+      fwd_jaxpr, _ = pe.dce_jaxpr(fwd_jaxpr.jaxpr, True)
+      fwd_str = fwd_jaxpr.pretty_print(use_color=False)
+
+      y, f_vjp = jax.vjp(f, *args)
+      bwd_jaxpr = jax.jit(f_vjp).trace(y).lojax.jaxpr
+      bwd_jaxpr, _ = pe.dce_jaxpr(bwd_jaxpr.jaxpr, True)
+      bwd_str = bwd_jaxpr.pretty_print(use_color=False)
+
+      return fwd_str, bwd_str
+
+    policy = jax.checkpoint_policies.save_only_these_names('cos')
+    f = jax.remat(sin, policy=policy)
+    fwd_str, bwd_str = fwd_bwd_jaxpr_strs(f, jnp.arange(3.))
+    self.assertIn('cos ', fwd_str)
+    self.assertNotIn('cos ', bwd_str)
+    jtu.check_grads(f, (3.,), order=2, modes=['rev'])
+
+    f = jax.remat(sin)
+    fwd_str, bwd_str = fwd_bwd_jaxpr_strs(f, jnp.arange(3.))
+    self.assertNotIn('cos', fwd_str)
+    self.assertIn('cos ', bwd_str)
+    jtu.check_grads(f, (3.,), order=2, modes=['rev'])
+
+  @config.custom_vjp3(True)
+  def test_custom_vjp_with_checkpoint_name_in_fwd_static_argnums(self):
+    # Like the above test, but exercises nondiff_argnums
+    assert jax.config.jax_custom_vjp3
+    sin = jax.custom_vjp(lambda _, x: jnp.sin(x), nondiff_argnums=(0,))
+    def fwd(_, x):
+      return jnp.sin(x), checkpoint_name(jnp.cos(x), 'cos')
+    def bwd(_, cos_x, g):
+      return cos_x * g,
+    sin.defvjp(fwd, bwd)
+
+    def fwd_bwd_jaxpr_strs(f, *args):
+      fwd_jaxpr = jax.jit(partial(jax.vjp, f)).trace(*args).lojax.jaxpr
+      fwd_jaxpr, _ = pe.dce_jaxpr(fwd_jaxpr.jaxpr, True)
+      fwd_str = fwd_jaxpr.pretty_print(use_color=False)
+
+      y, f_vjp = jax.vjp(f, *args)
+      bwd_jaxpr = jax.jit(f_vjp).trace(y).lojax.jaxpr
+      bwd_jaxpr, _ = pe.dce_jaxpr(bwd_jaxpr.jaxpr, True)
+      bwd_str = bwd_jaxpr.pretty_print(use_color=False)
+
+      return fwd_str, bwd_str
+
+    policy = jax.checkpoint_policies.save_only_these_names('cos')
+    f = jax.remat(partial(sin, 'hi'), policy=policy)
+    fwd_str, bwd_str = fwd_bwd_jaxpr_strs(f, jnp.arange(3.))
+    self.assertIn('cos ', fwd_str)
+    self.assertNotIn('cos ', bwd_str)
+    jtu.check_grads(f, (3.,), order=2, modes=['rev'])
+
+    f = jax.remat(partial(sin, 'hi'))
+    fwd_str, bwd_str = fwd_bwd_jaxpr_strs(f, jnp.arange(3.))
+    self.assertNotIn('cos', fwd_str)
+    self.assertIn('cos ', bwd_str)
+    jtu.check_grads(f, (3.,), order=2, modes=['rev'])
+
+
 
 @jtu.with_config(jax_pprint_use_color=False)
 class JaxprTest(jtu.JaxTestCase):


### PR DESCRIPTION
The basic idea is to give the custom_vjp3 primitive a remat rule which applies the remat_transform to the primal function.

This change also makes primal_left_tangent_right into a hijax primitive so it lowers away in lojax (useful for knowing when code is dead).

Morally, this rule is just

```python
  def remat(self, policy, *args):  # type: ignore
    (out, _), rem = remat.remat_transform(policy, self.fwd, *args)
    helper = custom_vjp(self.traced)  # just used for result type
    helper.defvjp(rem, self.bwd)
    return out, helper
```

but it got more complicated because of nondiff_argnums/static_argnums.

TODO check and document the higher-order AD behavior