### PR TITLE
[ROCm] Preserve pinned_host memory kind across DLPack round-trip

### DIFF
--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -450,7 +450,10 @@ class ArrayImpl(basearray.Array):
         else:
           dl_device_type = DLDeviceType.kDLCUDA
       elif "rocm" in platform_version:
-        dl_device_type = DLDeviceType.kDLROCM
+        if self.sharding.memory_kind == "pinned_host":
+          dl_device_type = DLDeviceType.kDLROCMHost
+        else:
+          dl_device_type = DLDeviceType.kDLROCM
       else:
         raise BufferError("Unknown GPU platform for __dlpack__: "
                          f"{platform_version}")

--- a/jax/_src/dlpack.py
+++ b/jax/_src/dlpack.py
@@ -86,6 +86,7 @@ _DL_DEVICE_TO_PLATFORM = {
     DLDeviceType.kDLCUDA: "cuda",
     DLDeviceType.kDLCUDAHost: "cuda",
     DLDeviceType.kDLROCM: "rocm",
+    DLDeviceType.kDLROCMHost: "rocm",
     DLDeviceType.kDLTPUHost: "tpu",
 }
 
@@ -258,6 +259,7 @@ def from_dlpack(external_array,
     stream = None
   elif dl_device_type in (
       DLDeviceType.kDLCUDAHost,
+      DLDeviceType.kDLROCMHost,
       DLDeviceType.kDLTPUHost,
   ):
     # Some producers (e.g. torch.Tensor with is_pinned()) route pinned tensors

--- a/jax/_src/typing.py
+++ b/jax/_src/typing.py
@@ -108,6 +108,7 @@ class DLDeviceType(enum.IntEnum):
   kDLCUDA = 2
   kDLCUDAHost = 3
   kDLROCM = 10
+  kDLROCMHost = 11
   kDLTPUHost = 20
 
 AnyInt = int | np.integer

--- a/jaxlib/dlpack.cc
+++ b/jaxlib/dlpack.cc
@@ -154,6 +154,10 @@ absl::StatusOr<DLDevice> DLDeviceForBuffer(const xla::PjRtBuffer& buffer) {
              memory_space->kind() == xla::PinnedHostMemorySpace::kKind &&
              buffer.device()->client()->platform_id() == xla::TpuId()) {
     context.device_type = kDLTPUHost;
+  } else if (memory_space != nullptr &&
+             memory_space->kind() == xla::PinnedHostMemorySpace::kKind &&
+             buffer.device()->client()->platform_id() == xla::RocmId()) {
+    context.device_type = kDLROCMHost;
   } else {
     TF_ASSIGN_OR_RETURN(context.device_type,
                         DLDeviceTypeForDevice(*buffer.device()));
@@ -218,6 +222,7 @@ MakePjrtBuffer(xla::PjRtDevice& device, ::DLManagedTensor* dlmt,
       dl_device_type.value_or(dlmt->dl_tensor.device.device_type);
   xla::PjRtMemorySpace* memory_space;
   if (effective_device_type == kDLCUDAHost ||
+      effective_device_type == kDLROCMHost ||
       effective_device_type == kDLTPUHost) {
     TF_ASSIGN_OR_RETURN(memory_space, device.memory_space_by_kind(
                                           xla::PinnedHostMemorySpace::kKind));
@@ -230,7 +235,9 @@ MakePjrtBuffer(xla::PjRtDevice& device, ::DLManagedTensor* dlmt,
   // semantics is handled in dlpack._place_array function.
   bool fallback_to_copy =
       !copy.has_value() &&
-      (effective_device_type == kDLCPU || effective_device_type == kDLCUDAHost);
+      (effective_device_type == kDLCPU ||
+       effective_device_type == kDLCUDAHost ||
+       effective_device_type == kDLROCMHost);
 
   // Create a view.
   if (!copy.value_or(false)) {


### PR DESCRIPTION
- ROCm pinned-host buffers were exported as plain kDLROCM, so a DLPack round-trip dropped the memory kind (pinned_host -> device).
- Tag ROCm pinned host as kDLROCMHost on export and import, matching the existing CUDA/TPU paths.
