### PR TITLE
Fix nan issue in lax.igammac when arguments approach infinity

### DIFF
--- a/jax/_src/lax/special.py
+++ b/jax/_src/lax/special.py
@@ -494,11 +494,13 @@ def igammac_impl(a, x, *, dtype):
   a_is_zero = eq(a, _const(a, 0))
   x_is_zero = eq(x, _const(x, 0))
   x_is_infinity = eq(x, _const(x, float('inf')))
-  domain_error = _reduce(bitwise_or, [lt(x, _const(x, 0)), lt(a, _const(a, 0)), bitwise_and(a_is_zero, x_is_zero), is_nan])
+  a_is_infinity = eq(a, _const(a, float('inf')))
+  both_infinity = bitwise_and(a_is_infinity, x_is_infinity)
+  domain_error = _reduce(bitwise_or, [lt(x, _const(x, 0)), lt(a, _const(a, 0)), bitwise_and(a_is_zero, x_is_zero), is_nan, both_infinity])
   use_igamma = bitwise_or(lt(x, _const(x, 1)), lt(x, a))
   ax = a * log(x) - x - lgamma(a)
   underflow = lt(ax, -log(dtypes.finfo(dtype).max))
-  enabled = bitwise_not(_reduce(bitwise_or, [domain_error, underflow, x_is_infinity, a_is_zero]))
+  enabled = bitwise_not(_reduce(bitwise_or, [domain_error, underflow, x_is_infinity, a_is_zero, a_is_infinity]))
   ax = exp(ax)
 
   igamma_call = _igamma_series(ax, x, a, bitwise_and(enabled, use_igamma),
@@ -507,7 +509,9 @@ def igammac_impl(a, x, *, dtype):
     bitwise_and(enabled, bitwise_not(use_igamma)), dtype, IgammaMode.VALUE)
 
   output = select(use_igamma, _const(a, 1) - igamma_call, igammac_cf_call)
-  output = select(bitwise_or(x_is_infinity, a_is_zero), full_like(output, 0), output)
+  output = select(x_is_infinity, full_like(output, 0), output)
+  output = select(a_is_zero, full_like(output, 0), output)
+  output = select(a_is_infinity, full_like(output, 1), output)
   output = select(domain_error, full_like(a, float('nan')), output)
   return output
 

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -418,12 +418,12 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
     nan = float('nan')
     inf = float('inf')
     if jtu.parse_version(scipy.__version__) >= (1, 16):
-      a_samples = [0, 0, 0, 1, nan,   1, nan,   0,   1, 1, nan]
-      x_samples = [0, 1, 2, 0,   1, nan, nan, inf, inf, -1, inf]
+      a_samples = [0, 0, 0, 1, nan,   1, nan,   0,   1, 1, nan, inf, inf]
+      x_samples = [0, 1, 2, 0,   1, nan, nan, inf, inf, -1, inf, 1, inf]
     else:
       # disable samples that contradict with scipy/scipy#22441
-      a_samples = [0, 0, 0, 1, nan,   1, nan,   0,   1, 1]
-      x_samples = [0, 1, 2, 0,   1, nan, nan, inf, inf, -1]
+      a_samples = [0, 0, 0, 1, nan,   1, nan,   0,   1, 1, inf, inf]
+      x_samples = [0, 1, 2, 0,   1, nan, nan, inf, inf, -1, 1, inf]
 
     args_maker = lambda: (np.array(a_samples, dtype=dtype), np.array(x_samples, dtype=dtype))
 

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -3643,6 +3643,8 @@ class LaxTest(jtu.JaxTestCase):
   def testIgammaSpecial(self):
     self.assertEqual(lax.igamma(1., np.inf), 1.)
     self.assertEqual(lax.igammac(1., np.inf), 0.)
+    self.assertEqual(lax.igammac(np.inf, 1.), 1.)
+    self.assertTrue(np.isnan(lax.igammac(np.inf, np.inf)))
 
   def testRegressionIssue5728(self):
     # The computation in this test gave garbage data on CPU due to an LLVM bug.

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -172,6 +172,18 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
                               tol=1e-3)
       self._CompileAndCheck(lax_fun, args_maker)
 
+  @jtu.sample_product(
+    dtype=jtu.dtypes.floating,
+  )
+  def testPoissonCdfInfinity(self, dtype):
+    mu = jnp.array(5.0, dtype=dtype)
+    k = jnp.array(np.inf, dtype=dtype)
+    self.assertAllClose(
+      lsp_stats.poisson.cdf(k, mu),
+      osp_stats.poisson.cdf(np.inf, np.array(5.0, dtype=dtype)),
+      check_dtypes=False,
+    )
+
 
   @genNamedParametersNArgs(3)
   def testBernoulliLogPmf(self, shapes, dtypes):


### PR DESCRIPTION
Issue #38622 highlighted a bug where poisson.cdf returns nan when k approaches infinity.
My previous PR fixed the issue on the Poisson side. 
Based on the review feedback, I updated the fix to address the root cause directly in gammaincc.

In jax/_src/lax/special.py, k and mu are passed to igammac as a and x, respectively. 
The existing implementation already handled NaN, zero, and x == inf cases. 
This update adds handling for a == inf while preserving the existing behavior for a == x == inf.

I also added tests to cover the new behavior:
-Added primitive-level unit tests in tests/lax_test.py.
-Extended the boundary-value tests in tests/lax_scipy_special_functions_test.py to include the a == inf case.
-Added a regression test in tests/scipy_stats_test.py for the Poisson CDF issue reported in #38622.

The test results are consistent with the expected behavior and match SciPy for the relevant edge cases:
**Primitive tests**
igamma(1, inf) == 1.0
igammac(1, inf) == 0.0
igammac(inf, 1) == 1.0
igammac(inf, inf) == nan

**Boundary-value tests**
gammaincc(0, inf) matches SciPy.
gammaincc(1, inf) matches SciPy.
gammaincc(inf, 1) matches SciPy.
gammaincc(inf, inf) matches SciPy (nan).

**Poisson regression test**
poisson.cdf(inf, 5) now returns 1.0 for both float32 and float64, matching SciPy.

Thank you for taking the time to review this.