### PR TITLE
Normalize private symbols in persistent cache keys

### DIFF
--- a/jax/_src/cache_key.py
+++ b/jax/_src/cache_key.py
@@ -188,6 +188,66 @@ def _serialize_ir(m: ir.Module, ignore_custom_partitioning: bool) -> bytes:
   return output.getvalue()
 
 
+def _canonicalize_private_symbol_names(m: ir.Module) -> None:
+  """Renames private top-level symbols deterministically."""
+  private_symbols: list[ir.OpView] = []
+  all_symbol_names: set[str] = set()
+  public_symbol_names: set[str] = set()
+  for op in m.body.operations:
+    if "sym_name" not in op.attributes:
+      continue
+    symbol_name = ir.StringAttr(op.attributes["sym_name"]).value
+    all_symbol_names.add(symbol_name)
+    visibility = op.attributes.get("sym_visibility")
+    if (
+        visibility is not None
+        and ir.StringAttr(visibility).value == "private"
+    ):
+      private_symbols.append(op)
+    else:
+      public_symbol_names.add(symbol_name)
+
+  if not private_symbols:
+    return
+
+  name_map: dict[str, str] = {}
+  prefix = "__jax_cache_private_symbol_"
+  for i, op in enumerate(private_symbols):
+    old_name = ir.StringAttr(op.attributes["sym_name"]).value
+    new_name = f"{prefix}{i}"
+    collision_id = len(private_symbols)
+    while new_name in public_symbol_names:
+      new_name = f"{prefix}{collision_id}_{i}"
+      collision_id += 1
+    name_map[old_name] = new_name
+
+  tmp_name_map: dict[str, str] = {}
+  used_names = all_symbol_names | set(name_map.values())
+  tmp_prefix = "__jax_cache_private_symbol_tmp_"
+  # Rename through temporaries so old private names cannot collide with the
+  # canonical names assigned to earlier private symbols.
+  for i, old_name in enumerate(name_map):
+    tmp_name = f"{tmp_prefix}{i}"
+    collision_id = len(name_map)
+    while tmp_name in used_names:
+      tmp_name = f"{tmp_prefix}{collision_id}_{i}"
+      collision_id += 1
+    tmp_name_map[old_name] = tmp_name
+    used_names.add(tmp_name)
+
+  for op in private_symbols:
+    old_name = ir.StringAttr(op.attributes["sym_name"]).value
+    tmp_name = tmp_name_map[old_name]
+    ir.SymbolTable.replace_all_symbol_uses(old_name, tmp_name, m.operation)
+    ir.SymbolTable.set_symbol_name(op, tmp_name)
+  reverse_tmp_name_map = {tmp: old for old, tmp in tmp_name_map.items()}
+  for op in private_symbols:
+    tmp_name = ir.StringAttr(op.attributes["sym_name"]).value
+    new_name = name_map[reverse_tmp_name_map[tmp_name]]
+    ir.SymbolTable.replace_all_symbol_uses(tmp_name, new_name, m.operation)
+    ir.SymbolTable.set_symbol_name(op, new_name)
+
+
 def _canonicalize_ir(
     m_original: ir.Module, ignore_custom_partitioning: bool
 ) -> bytes:
@@ -197,6 +257,7 @@ def _canonicalize_ir(
         "builtin.module(strip-debuginfo)"
     )
     passes.run(m.operation)
+    _canonicalize_private_symbol_names(m)
     return _serialize_ir(m, ignore_custom_partitioning)
 
 

--- a/tests/cache_key_test.py
+++ b/tests/cache_key_test.py
@@ -30,6 +30,7 @@ from jax._src import compiler
 from jax._src import config
 from jax._src import test_util as jtu
 from jax._src import xla_bridge
+from jax._src.interpreters import mlir
 from jax._src.lib import xla_client
 from jax._src.lib.mlir import ir
 from jax._src.mesh import Mesh
@@ -162,6 +163,37 @@ class CacheKeyTest(jtu.JaxTestCase):
         cache_key.get(computation1, devices, compile_options, backend),
         cache_key.get(computation2, devices, compile_options, backend),
     )
+
+  def test_identical_computations_different_private_symbol_names(self):
+    module = """
+module @jit_train_step {
+  func.func public @main(%arg0: tensor<2xf32>) -> tensor<2xf32> {
+    %0 = call @clip_0(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+    return %0 : tensor<2xf32>
+  }
+  func.func private @clip_0(%arg0: tensor<2xf32>) -> tensor<2xf32> {
+    %0 = stablehlo.negate %arg0 : tensor<2xf32>
+    return %0 : tensor<2xf32>
+  }
+}
+"""
+    ctx = mlir.make_ir_context()
+    with ctx:
+      computation1 = ir.Module.parse(module)
+      computation2 = ir.Module.parse(module.replace("@clip_0", "@clip_1"))
+      computation3 = ir.Module.parse(
+          module.replace("stablehlo.negate", "stablehlo.abs")
+      )
+    devices = np.array([[jax.local_devices()[0]]])
+    compile_options = compiler.get_compile_options(
+        num_replicas=1, num_partitions=1
+    )
+    backend = xla_bridge.get_backend()
+    key1 = cache_key.get(computation1, devices, compile_options, backend)
+    key2 = cache_key.get(computation2, devices, compile_options, backend)
+    key3 = cache_key.get(computation3, devices, compile_options, backend)
+    self.assertEqual(key1, key2)
+    self.assertNotEqual(key1, key3)
 
   # TODO(phawkins): this test flakes if test concurrency is enabled.
   @jtu.thread_unsafe_test()


### PR DESCRIPTION
Fixes #38828.

Persistent compilation cache keys hash serialized canonicalized StableHLO. The existing canonicalization strips debug info but preserves private helper symbol names, so semantically identical modules can get different keys when private helpers are cosmetically renumbered.

This change canonicalizes top-level private symbol names before hashing by renaming them deterministically in definition order and updating symbol uses through MLIR's SymbolTable. Public symbols are left unchanged. The rename goes through temporary names to avoid collisions when an existing private symbol already has a generated canonical name.

Test plan:
- python3 -m pytest tests/cache_key_test.py::CacheKeyTest::test_identical_computations_different_private_symbol_names -q
- python3 -m pytest tests/cache_key_test.py -q
- python3 -m pytest tests/cache_key_test.py tests/compilation_cache_test.py -q