### PR TITLE
[Mosaic GPU] Support mixed E4M3/E5M2 FP8 operands in wgmma

### DIFF
--- a/docs/pallas/CHANGELOG.md
+++ b/docs/pallas/CHANGELOG.md
@@ -31,6 +31,13 @@ Remember to align the itemized text with the first line of an item within a list
     {func}`jax.experimental.export.export`, since the corresponding custom call
     is not considered export-stable and needs to be enabled explicitly.
 
+### Mosaic GPU
+
+* New features
+
+  * {func}`jax.experimental.pallas.mosaic_gpu.wgmma` now supports mixing the
+    e4m3 and e5m2 FP8 types across its two operands.
+
 
 ### Mosaic GPU
 

--- a/docs/pallas/gpu/reference.md
+++ b/docs/pallas/gpu/reference.md
@@ -417,7 +417,9 @@ The supported MMA shapes are such that:
 * `N` is divisible by 8 and not greater than 256
 * `K` is a multiple of `swizzle` divided by the operand's element type bytewidth
 
-The currently supported data types are: `jnp.float32`, `jnp.bfloat16` and `jnp.float16`.
+The currently supported data types are: `jnp.float32`, `jnp.bfloat16`, `jnp.float16`,
+and the FP8 types `jnp.float8_e4m3fn` and `jnp.float8_e5m2` (which may be mixed across
+the two operands).
 The accumulator `D` must be a `jnp.float32`, with the exception of `jnp.float16` inputs,
 in which case it is allowed to be `jnp.float16` as well.
 

--- a/jax/_src/pallas/mosaic_gpu/primitives.py
+++ b/jax/_src/pallas/mosaic_gpu/primitives.py
@@ -1520,8 +1520,15 @@ def wgmma(acc: gpu_core.WGMMAAbstractAccumulatorRef, a, b) -> None:
         f" rhs={b.shape=}, acc={acc.shape}"
     )
 
-  if a.dtype != b.dtype:
-    raise ValueError(f"Mixed input dtypes for matrix multiplication unsupported: lhs={a.dtype}, rhs={b.dtype}")
+  # A and B must share a dtype, except that the e4m3/e5m2 FP8 pair may be mixed:
+  # `wgmma` takes independent `.atype`/`.btype` operands for FP8.
+  fp8_dtypes = (jnp.float8_e4m3fn, jnp.float8_e5m2)
+  both_fp8 = a.dtype in fp8_dtypes and b.dtype in fp8_dtypes
+  if a.dtype != b.dtype and not both_fp8:
+    raise ValueError(
+        "Mixed input dtypes for matrix multiplication unsupported: "
+        f"lhs={a.dtype}, rhs={b.dtype}"
+    )
 
   acc_transforms_leaves: list
   if isinstance(acc, pallas_core.TransformedRef):

--- a/jax/experimental/mosaic/gpu/wgmma.py
+++ b/jax/experimental/mosaic/gpu/wgmma.py
@@ -28,6 +28,7 @@ import numpy as np
 from . import fragmented_array as fa
 from . import mma_utils
 from . import utils
+from .mma import SUPPORTED_F8_TYPES
 
 
 c = utils.c
@@ -126,11 +127,14 @@ def wgmma_m64(
     b_k_stride: int,
     n: int,
     swizzle: int,
-    element_type: ir.Type,
+    a_element_type: ir.Type,
+    b_element_type: ir.Type,
 ):
   out_ty = ir.VectorType(acc.flat[0].type).element_type
-  if not _supported_wgmma_types(out_ty, element_type):
-    raise ValueError(f"Unsupported wgmma types {(out_ty, element_type)=}")
+  if not _supported_wgmma_types(out_ty, a_element_type):
+    raise ValueError(f"Unsupported wgmma types {(out_ty, a_element_type)=}")
+  if not _supported_wgmma_types(out_ty, b_element_type):
+    raise ValueError(f"Unsupported wgmma types {(out_ty, b_element_type)=}")
   if n % 8:
     raise ValueError
 
@@ -143,15 +147,16 @@ def wgmma_m64(
   f8e4m3fn = ir.Float8E4M3FNType.get()
   if b_k_stride % 16:
     raise ValueError
+  assert bytewidth(a_element_type) == bytewidth(b_element_type)
   # Only 16-bit types support transposes
-  supports_transpose = bytewidth(element_type) == 2
+  supports_transpose = bytewidth(b_element_type) == 2
   if not supports_transpose and (a_transpose or b_transpose):
     raise ValueError("Only f16 WGMMA supports transposes")
   if a_in_regs := isinstance(a, fa.FragmentedArray):
     if a.mlir_dtype not in {bf16, f16, i8, f8e5m2, f8e4m3fn}:
       raise ValueError(f"Unsupported A register array dtype: {a.mlir_dtype}")
     # Column count must be equal to swizzle // bytewidth.
-    elt_bytewidth = utils.bytewidth(element_type)
+    elt_bytewidth = utils.bytewidth(a_element_type)
     swizzle_elems = swizzle // elt_bytewidth
     if a.shape != (64, swizzle_elems):
       raise ValueError("Unsupported A register array shape")
@@ -222,24 +227,32 @@ def wgmma_m64(
   # Immediate regs (scale, ...).
   imm_regs = "".join(f", {r}" for r in take_regs(num_imm_regs))
   assert next(reg_count) == len(reg_constraints_list)
-  k_instr = 32 // bytewidth(element_type)
-  el_ty = str(element_type)
-  if isinstance(element_type, ir.Float8E5M2Type):
-    el_ty = "e5m2"
-  elif isinstance(element_type, ir.Float8E4M3FNType):
-    el_ty = "e4m3"
-  elif isinstance(element_type, ir.IntegerType):
-    # TODO(bchetioui): add u8 support in the future. Currently we always assume
-    # that 8-bit integers are s8, and we would need to change the signature of
-    # `wgmma` to indicate whether the input should be treated as signed or not.
-    el_ty = "s8"
+  k_instr = 32 // bytewidth(b_element_type)
+
+  def ptx_operand_type(ty):
+    if isinstance(ty, ir.Float8E5M2Type):
+      return "e5m2"
+    if isinstance(ty, ir.Float8E4M3FNType):
+      return "e4m3"
+    if isinstance(ty, ir.IntegerType):
+      # TODO(bchetioui): add u8 support in the future. Currently we always
+      # assume that 8-bit integers are s8, and we would need to change the
+      # signature of `wgmma` to indicate whether the input should be treated as
+      # signed or not.
+      return "s8"
+    return str(ty)
+
+  # `a` and `b` share an element type except for the FP8 e4m3/e5m2 pair, which
+  # may be mixed: PTX `wgmma` takes independent `.atype`/`.btype`.
+  a_el_ty = ptx_operand_type(a_element_type)
+  b_el_ty = ptx_operand_type(b_element_type)
 
   out_ty_str = str(out_ty)
   if out_ty == i32:
     out_ty_str = "s32"
 
   wgmma_instr = (
-      f"wgmma.mma_async.sync.aligned.m64n{n}k{k_instr}.{out_ty_str}.{el_ty}.{el_ty} "
+      f"wgmma.mma_async.sync.aligned.m64n{n}k{k_instr}.{out_ty_str}.{a_el_ty}.{b_el_ty} "
       f"{acc_reg_vector}, {a_regs}, {b_desc_reg}, p{imm_regs};"
   )
   ptx = f"{{ .reg .pred p; setp.ne.b32 p, {use_out_reg}, 0; {wgmma_instr} }}\n"
@@ -264,7 +277,7 @@ def wgmma_m64(
   expected_regs_per_tile = 4 if utils.bitwidth(out_ty) == 32 else 2
   if acc.ndim != expected_dim or acc.shape[0] != 1 or math.prod(acc.shape[2:]) != expected_regs_per_tile:
     raise ValueError(acc.shape)
-  for i in range((swizzle // bytewidth(element_type)) // k_instr):
+  for i in range((swizzle // bytewidth(b_element_type)) // k_instr):
     # Slice out the relevant part of A or advance the A descriptor.
     if a_in_regs:
       a_slice = a[:, (i * k_instr) : ((i + 1) * k_instr)]
@@ -353,10 +366,17 @@ def wgmma(
         "WGMMA requires A and B to have the same contraction dimension (K),"
         f" got: {k2} and {k}"
     )
-  if element_type != element_type2:
+  both_fp8 = (
+      isinstance(element_type, SUPPORTED_F8_TYPES)
+      and isinstance(element_type2, SUPPORTED_F8_TYPES)
+  )
+  # A and B must share an element type, except that the e4m3/e5m2 FP8 pair may
+  # be mixed (PTX `wgmma` takes independent `.atype`/`.btype`). See
+  # https://docs.nvidia.com/cuda/parallel-thread-execution/#asynchronous-warpgroup-level-matrix-instructions-wgmma-mma
+  if element_type != element_type2 and not both_fp8:
     raise ValueError(
-        "WGMMA requires A and B to have the same element type, got:"
-        f" {element_type2} and {element_type}"
+        "WGMMA requires A and B to have the same element type (or be a mix of"
+        f" the e4m3/e5m2 FP8 types), got: {element_type2} and {element_type}"
     )
   if acc._value.shape != (m, n):
     raise ValueError(
@@ -402,8 +422,14 @@ def wgmma(
   m_groups = m // m_group_elems
   k_groups = k // k_group_elems
   # TODO(apaszke): Require users to bitcast input refs to tf32 before WGMMA.
-  wgmma_element_type = (
+  b_wgmma_element_type = (
       ir.FloatTF32Type.get() if element_type == ir.F32Type.get() else element_type
+  )
+  # `a`'s PTX operand type, which differs from `b`'s only for the mixed FP8 case.
+  a_wgmma_element_type = (
+      ir.FloatTF32Type.get()
+      if element_type2 == ir.F32Type.get()
+      else element_type2
   )
 
   # Step 3. Compute the operand descriptors.
@@ -472,7 +498,8 @@ def wgmma(
           b_k,
           swizzle=swizzle,
           n=n_group_elems,
-          element_type=wgmma_element_type,
+          a_element_type=a_wgmma_element_type,
+          b_element_type=b_wgmma_element_type,
           b_transpose=b_fastest != mma_utils.Dim.K,
           b_k_stride=b_k_instr_stride,
           **a_instr_params,

--- a/jaxlib/mosaic/dialect/gpu/mosaic_gpu.cc
+++ b/jaxlib/mosaic/dialect/gpu/mosaic_gpu.cc
@@ -433,8 +433,20 @@ llvm::LogicalResult WGMMAOp::verify() {
   auto b_type = getB().getType();
   auto acc_type = getAccumulator().getType();
 
-  if (a_type.getElementType() != b_type.getElementType()) {
-    return error("The `a` and `b` inputs must have the same element type.");
+  auto a_element_type = a_type.getElementType();
+  auto b_element_type = b_type.getElementType();
+  // FP8 is the exception to the "same element type" rule: the PTX
+  // `wgmma.mma_async` instruction takes independent `.atype`/`.btype` operand
+  // types, each of which may be `.e4m3` or `.e5m2`, so any mix of the two FP8
+  // types is a valid `a`/`b` pairing.
+  auto is_fp8 = [](mlir::Type t) {
+    return llvm::isa<mlir::Float8E4M3FNType, mlir::Float8E5M2Type>(t);
+  };
+  if (a_element_type != b_element_type &&
+      !(is_fp8(a_element_type) && is_fp8(b_element_type))) {
+    return error(
+        "The `a` and `b` inputs must have the same element type, except that "
+        "FP8 types (f8E4M3FN and f8E5M2) may be mixed.");
   }
 
   auto a_shape = a_type.getShape();

--- a/tests/mosaic/gpu_dialect_test.py
+++ b/tests/mosaic/gpu_dialect_test.py
@@ -651,6 +651,23 @@ class DialectTest(MosaicGpuTest):
     ):
       self.module.operation.verify()
 
+  def test_wgmma_mixed_fp8_operands_are_allowed(self):
+    if jtu.jaxlib_version() < (0, 11, 0):
+      self.skipTest("Mixed FP8 wgmma operands require a newer jaxlib verifier")
+
+    e4m3 = ir.Float8E4M3FNType.get()
+    e5m2 = ir.Float8E5M2Type.get()
+    with ir.InsertionPoint(self.module.body):
+      for a_type, b_type in ((e4m3, e5m2), (e5m2, e4m3)):
+        acc, a, b = undefs(
+            ir.VectorType.get([128, 160], ir.F32Type.get()),
+            ir.MemRefType.get([128, 128], a_type),
+            ir.MemRefType.get([128, 160], b_type),
+        )
+        mgpu.dialect.wgmma(acc, a, b)
+
+    self.module.operation.verify()
+
   def test_wgmma_acc_m_dim_not_multiple_of_64(self):
     with ir.InsertionPoint(self.module.body):
       acc, a, b = undefs(

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -1027,6 +1027,14 @@ class I8Type:
     return ir.IntegerType.get_signless(8)
 
 
+# Maps an FP8 MLIR element-type class to the (jax dtype, exponent_bits,
+# mantissa_bits) used to quantize reference inputs to that type.
+_FP8_DTYPE_INFO = {
+    ir.Float8E5M2Type: (jnp.float8_e5m2, 5, 2),
+    ir.Float8E4M3FNType: (jnp.float8_e4m3fn, 4, 3),
+}
+
+
 class WGMMATest(TestCase):
 
   def setUp(self):
@@ -1070,6 +1078,35 @@ class WGMMATest(TestCase):
         jax_out_dtype=jax_out_dtype,
         lhs_tiling_kind="small+no_transpose" if lhs_transpose else "small",
         rhs_tiling_kind="small+no_transpose" if rhs_transpose else "small",
+    )
+
+  @parameterized.product(
+      lhs_rhs_dtype_cls=(
+          (ir.Float8E4M3FNType, ir.Float8E5M2Type),
+          (ir.Float8E5M2Type, ir.Float8E4M3FNType),
+      ),
+      m=(64, 128),
+      n=(128,),
+      swizzle=(64, 128),
+      jax_out_dtype=(jnp.float16, jnp.float32),
+  )
+  def test_wgmma_mixed_fp8(self, lhs_rhs_dtype_cls, m, n, swizzle, jax_out_dtype):
+    # The e4m3/e5m2 FP8 pair may be mixed across the two operands. FP8 wgmma does
+    # not support operand transposes, so the only valid layout is `a` row-major
+    # and `b` column-major (rhs_transpose=True).
+    lhs_dtype_cls, rhs_dtype_cls = lhs_rhs_dtype_cls
+    self._test_wgmma_basic(
+        m=m,
+        n=n,
+        k_steps=2,
+        in_mlir_dtype_cls=lhs_dtype_cls,
+        rhs_in_mlir_dtype_cls=rhs_dtype_cls,
+        lhs_transpose=False,
+        rhs_transpose=True,
+        swizzle=swizzle,
+        jax_out_dtype=jax_out_dtype,
+        lhs_tiling_kind="small",
+        rhs_tiling_kind="small+no_transpose",
     )
 
   @parameterized.product(
@@ -1141,7 +1178,12 @@ class WGMMATest(TestCase):
       jax_out_dtype,
       rhs_tiling_kind,
       lhs_tiling_kind,
+      rhs_in_mlir_dtype_cls=None,
   ):
+    # `b` reuses `a`'s element type unless a distinct one is given (only the
+    # e4m3/e5m2 FP8 pair may be mixed).
+    if rhs_in_mlir_dtype_cls is None:
+      rhs_in_mlir_dtype_cls = in_mlir_dtype_cls
     if jax_out_dtype == jnp.int32 and in_mlir_dtype_cls != I8Type:
       self.skipTest("s32 accumulator only supported with s8 inputs")
     if jax_out_dtype != jnp.int32 and in_mlir_dtype_cls == I8Type:
@@ -1173,17 +1215,31 @@ class WGMMATest(TestCase):
         exponent_bits, mantissa_bits = 8, 7
       else:
         raise NotImplementedError(in_mlir_dtype)
-    elif in_mlir_dtype_cls == ir.Float8E5M2Type:
-      in_jax_dtype = jnp.float8_e5m2
-      exponent_bits, mantissa_bits = 5, 2
-    elif in_mlir_dtype_cls == ir.Float8E4M3FNType:
-      in_jax_dtype = jnp.float8_e4m3fn
-      exponent_bits, mantissa_bits = 4, 3
+    elif in_mlir_dtype_cls in _FP8_DTYPE_INFO:
+      in_jax_dtype, exponent_bits, mantissa_bits = (
+          _FP8_DTYPE_INFO[in_mlir_dtype_cls]
+      )
     elif in_mlir_dtype_cls == I8Type:
       in_jax_dtype = jnp.int8
       exponent_bits = mantissa_bits = None
     else:
       raise NotImplementedError(in_mlir_dtype)
+
+    # `b`'s dtype matches `a`'s except for the mixed e4m3/e5m2 FP8 case. Both FP8
+    # types are 1 byte, so the tiling/swizzle math (driven by `in_mlir_dtype`) is
+    # identical; only the operand values and `b`'s SMEM dtype differ.
+    if rhs_in_mlir_dtype_cls is in_mlir_dtype_cls:
+      rhs_in_jax_dtype = in_jax_dtype
+      rhs_exponent_bits, rhs_mantissa_bits = exponent_bits, mantissa_bits
+    elif rhs_in_mlir_dtype_cls in _FP8_DTYPE_INFO:
+      rhs_in_jax_dtype, rhs_exponent_bits, rhs_mantissa_bits = (
+          _FP8_DTYPE_INFO[rhs_in_mlir_dtype_cls]
+      )
+    else:
+      raise NotImplementedError(
+          "Mixed-dtype WGMMA is only supported for the e4m3/e5m2 FP8 pair, got"
+          f" a={in_mlir_dtype_cls} b={rhs_in_mlir_dtype_cls}"
+      )
     nk_tile = swizzle // bytewidth(in_mlir_dtype)
     k = nk_tile * k_steps
     if n % nk_tile:
@@ -1234,18 +1290,18 @@ class WGMMATest(TestCase):
       nvvm.wgmma_wait_group_sync_aligned(0)
       acc.value.store_untiled(out, optimized=False)
 
-    def quantize(x):
-      # Quantize the input to avoid rounding when feeding the WGMMA
-      return jax.lax.reduce_precision(x, exponent_bits, mantissa_bits)
-
     x_shape = (k, m) if lhs_transpose else (m, k)
     y_shape = (n, k) if rhs_transpose else (k, n)
     if in_mlir_dtype_cls == I8Type:
       x = self.prng.integers(-128, 127, x_shape).astype(in_jax_dtype)
-      y = self.prng.integers(-128, 127, y_shape).astype(in_jax_dtype)
+      y = self.prng.integers(-128, 127, y_shape).astype(rhs_in_jax_dtype)
     else:
-      x = quantize(self.prng.uniform(-1, 1, x_shape)).astype(in_jax_dtype)
-      y = quantize(self.prng.uniform(-1, 1, y_shape)).astype(in_jax_dtype)
+      x = jax.lax.reduce_precision(
+        self.prng.uniform(-1, 1, x_shape), exponent_bits, mantissa_bits
+      ).astype(in_jax_dtype)
+      y = jax.lax.reduce_precision(
+        self.prng.uniform(-1, 1, y_shape), rhs_exponent_bits, rhs_mantissa_bits
+      ).astype(rhs_in_jax_dtype)
     out_shape = jax.ShapeDtypeStruct((m, n), jax_out_dtype)
     if transpose_rhs_tiles:
       rhs_tiling_t = rhs_tiling[::-1] if rhs_transpose else rhs_tiling
@@ -1259,7 +1315,7 @@ class WGMMATest(TestCase):
       lhs_smem_shape = tile_shape(x_shape, lhs_tiling)
     scratch_shape = [
         jax.ShapeDtypeStruct(lhs_smem_shape, in_jax_dtype),
-        jax.ShapeDtypeStruct(rhs_smem_shape, in_jax_dtype),
+        jax.ShapeDtypeStruct(rhs_smem_shape, rhs_in_jax_dtype),
         mgpu.TMABarrier(2),
     ]
     z = mgpu.as_gpu_kernel(

--- a/tests/pallas/mosaic_gpu_test.py
+++ b/tests/pallas/mosaic_gpu_test.py
@@ -4540,6 +4540,50 @@ class PallasCallSm90ATest(PallasSm90ATest):
         res, a.astype(acc_type) @ b.T.astype(acc_type)
     )
 
+  @parameterized.parameters(
+      (jnp.float8_e4m3fn, jnp.float8_e5m2),
+      (jnp.float8_e5m2, jnp.float8_e4m3fn),
+  )
+  def test_wgmma_mixed_fp8(self, lhs_dtype, rhs_dtype):
+    m, k, n = 64, 128, 64
+
+    def kernel(a_ref, b_ref, o_ref):
+
+      def scope(acc_ref):
+        plgpu.wgmma(acc_ref, a_ref, plgpu.transpose_ref(b_ref, (1, 0)))
+        return acc_ref[...]
+
+      o_ref[...] = pl.run_scoped(scope, plgpu.ACC((m, n), jnp.float32))
+
+    # Small integers are exact in both e4m3 and e5m2, so the reference matmul is
+    # exact and the comparison is insensitive to FP8 rounding.
+    a = jax.random.randint(jax.random.key(0), (m, k), -8, 8).astype(lhs_dtype)
+    b = jax.random.randint(jax.random.key(1), (n, k), -8, 8).astype(rhs_dtype)
+
+    # Both FP8 types are 1 byte, so the LHS and RHS share the same transforms.
+    transforms = self.default_transforms(dtype=lhs_dtype)
+    res = self.pallas_call(
+        kernel,
+        in_specs=[
+            plgpu.BlockSpec(
+                (m, k),
+                lambda i, j: (i, j),
+                transforms=transforms,
+            ),
+            plgpu.BlockSpec(
+                (n, k),
+                lambda *i: i,
+                transforms=transforms,
+            ),
+        ],
+        out_specs=plgpu.BlockSpec((m, n), lambda *i: i),
+        out_shape=jax.ShapeDtypeStruct((m, n), jnp.float32),
+        grid=(1, 1),
+    )(a, b)
+    np.testing.assert_array_equal(
+        res, a.astype(jnp.float32) @ b.T.astype(jnp.float32)
+    )
+
   def test_wgmma_sliced_acc_flip(self):
     dtype = jnp.float16
 


### PR DESCRIPTION
Mixed `e4m3`/`e5m2` matmuls arise in FP8 training; e.g. when gradients are kept in `e5m2` (for dynamic range) while weights/activations are in `e4m3` (for precision), the backward GEMMs pair the two formats (the recipe described in the [FP8-formats paper](https://arxiv.org/abs/2209.05433) and NVIDIA's [Transformer Engine](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/examples/fp8_primer.html)). `wgmma` supports this natively via independent `.atype`/`.btype`, but Pallas/Mosaic previously rejected any operand dtype mismatch.

This PR relaxes the checks that currently require both inputs to have the same element type to allow mixed FP8 types, faithfully reflecting the (FP8) signature of the [wgmma.mma_async](https://docs.nvidia.com/cuda/parallel-thread-execution/#asynchronous-warpgroup-level-matrix-instructions-wgmma-mma) PTX instruction:

<details>

```
FP8 floating point type

wgmma.mma_async.sync.aligned.shape.dtype.atype.btype  d, a-desc, b-desc, scale-d, imm-scale-a, imm-scale-b;

wgmma.mma_async.sync.aligned.shape.dtype.atype.btype  d, a, b-desc, scale-d, imm-scale-a, imm-scale-b;

.shape   = {.m64n8k32, .m64n16k32, .m64n24k32, .m64n32k32,
            .m64n40k32, .m64n48k32, .m64n56k32, .m64n64k32,
            .m64n72k32, .m64n80k32, .m64n88k32, .m64n96k32,
            .m64n104k32, .m64n112k32, .m64n120k32, .m64n128k32,
            .m64n136k32, .m64n144k32, .m64n152k32, .m64n160k32,
            .m64n168k32, .m64n176k32, .m64n184k32, .m64n192k32,
            .m64n200k32, .m64n208k32, .m64n216k32, .m64n224k32,
            .m64n232k32, .m64n240k32, .m64n248k32, .m64n256k32};
.atype  = {.e4m3, .e5m2};
.btype  = {.e4m3, .e5m2};
.dtype  = {.f16, .f32};
```
</details>

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->