### PR TITLE
[ROCm] Skip flaky approx_top_k and Welch tests on ROCm

### DIFF
--- a/tests/ann_test.py
+++ b/tests/ann_test.py
@@ -67,6 +67,9 @@ class AnnTest(jtu.JaxTestCase):
     recall=[0.95],
   )
   def test_approx_max_k(self, qy_shape, db_shape, dtype, k, recall):
+    # TODO(magaonka-amd): re-enable once issue is fixed.
+    if jtu.is_device_rocm():
+      self.skipTest("Skipping due to flakiness in infra nodes in ROCm 7.2.0.")
     rng = jtu.rand_default(self.rng())
     qy = rng(qy_shape, dtype)
     db = rng(db_shape, dtype)
@@ -85,6 +88,9 @@ class AnnTest(jtu.JaxTestCase):
     recall=[0.95],
   )
   def test_approx_min_k(self, qy_shape, db_shape, dtype, k, recall):
+    # TODO(magaonka-amd): re-enable once issue is fixed.
+    if jtu.is_device_rocm():
+      self.skipTest("Skipping due to flakiness in infra nodes in ROCm 7.2.0.")
     rng = jtu.rand_default(self.rng())
     qy = rng(qy_shape, dtype)
     db = rng(db_shape, dtype)

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -311,6 +311,9 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
   def testWelchAgainstNumpy(self, *, shape, dtype, fs, window, nperseg,
                             noverlap, nfft, detrend, return_onesided,
                             scaling, timeaxis, average):
+    # TODO(magaonka-amd): re-enable once issue is fixed.
+    if jtu.is_device_rocm():
+      self.skipTest("Skipping due to flakiness in infra nodes in ROCm 7.2.0.")
     if np.dtype(dtype).kind == 'c':
       return_onesided = False
       if detrend is not None:


### PR DESCRIPTION
## Summary
`test_approx_max_k` / `test_approx_min_k` (`tests/ann_test.py`) and
`testWelchAgainstNumpy` (`tests/scipy_signal_test.py`) intermittently fail on
ROCm with `INTERNAL: hipError_t(401)` (`hipErrorIllegalState`) due to flakiness
in the ROCm 7.2.0 CI infra nodes.

TODO(magaonka-amd): re-enable once the infra issue is fixed.

## Tests skipped (ROCm only)
- `tests/ann_test.py::AnnTest::test_approx_max_k`
- `tests/ann_test.py::AnnTest::test_approx_min_k`
- `tests/scipy_signal_test.py::LaxBackedScipySignalTests::testWelchAgainstNumpy`