### PR TITLE
Improve error message for unsupported LAPACK dtypes in jax.scipy.linalg

### DIFF
--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -47,10 +47,10 @@ because compiled JAX code cannot perform checks of array values at runtime.
 _no_overwrite_and_chkfinite_doc = _no_chkfinite_doc + "\nDoes not support the Scipy argument ``overwrite_*=True``."
 
 def _check_linalg_supported_dtype(dtype, fn_name: str):
-  dtype = np.dtype(dtype)
-  if dtype == np.dtype(np.float16) or dtype == np.dtype(dtypes.bfloat16):
+  promoted_dtype = dtypes.to_inexact_dtype(dtype)
+  if promoted_dtype not in (np.dtype(np.float32), np.dtype(np.float64), np.dtype(np.complex64), np.dtype(np.complex128)):
     raise TypeError(
-      f"{fn_name} does not support dtype {dtype}. "
+      f"{fn_name} does not support dtype {np.dtype(dtype)}. "
       "Supported dtypes are float32, float64, complex64, complex128."
     )
   
@@ -118,7 +118,7 @@ def cholesky(a: ArrayLike, lower: bool = False, overwrite_a: bool = False,
     Array(True, dtype=bool)
   """
   del overwrite_a, check_finite  # Unused
-  _check_linalg_supported_dtype(a.dtype, "jax.scipy.linalg.cholesky")
+  _check_linalg_supported_dtype(dtypes.dtype(a), "jax.scipy.linalg.cholesky")
   return _cholesky(a, lower)
 
 
@@ -639,7 +639,7 @@ def inv(a: ArrayLike, overwrite_a: bool = False, check_finite: bool = True) -> A
      Array([ 0.  ,  1.25, -0.5 ], dtype=float32)
   """
   del overwrite_a, check_finite  # unused
-  _check_linalg_supported_dtype(a.dtype, "jax.scipy.linalg.inv")
+  _check_linalg_supported_dtype(dtypes.dtype(a), "jax.scipy.linalg.inv")
   return jnp_linalg.inv(a)
 
 

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -46,6 +46,14 @@ because compiled JAX code cannot perform checks of array values at runtime.
 """)
 _no_overwrite_and_chkfinite_doc = _no_chkfinite_doc + "\nDoes not support the Scipy argument ``overwrite_*=True``."
 
+def _check_linalg_supported_dtype(dtype, fn_name: str):
+  dtype = np.dtype(dtype)
+  if dtype == np.dtype(np.float16) or dtype == np.dtype(dtypes.bfloat16):
+    raise TypeError(
+      f"{fn_name} does not support dtype {dtype}. "
+      "Supported dtypes are float32, float64, complex64, complex128."
+    )
+  
 @jit(static_argnames=('lower',))
 def _cholesky(a: ArrayLike, lower: bool) -> Array:
   a, = promote_dtypes_inexact(jnp.asarray(a))
@@ -110,6 +118,7 @@ def cholesky(a: ArrayLike, lower: bool = False, overwrite_a: bool = False,
     Array(True, dtype=bool)
   """
   del overwrite_a, check_finite  # Unused
+  _check_linalg_supported_dtype(a.dtype, "jax.scipy.linalg.cholesky")
   return _cholesky(a, lower)
 
 
@@ -630,6 +639,7 @@ def inv(a: ArrayLike, overwrite_a: bool = False, check_finite: bool = True) -> A
      Array([ 0.  ,  1.25, -0.5 ], dtype=float32)
   """
   del overwrite_a, check_finite  # unused
+  _check_linalg_supported_dtype(a.dtype, "jax.scipy.linalg.inv")
   return jnp_linalg.inv(a)
 
 

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1330,7 +1330,21 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(osp.linalg.block_diag, jsp.linalg.block_diag,
                             args_maker, check_dtypes=False)
     self._CompileAndCheck(jsp.linalg.block_diag, args_maker)
+  def testInvUnsupportedDtype(self):
+    x = jnp.eye(4, dtype=jnp.float16)
 
+    with self.assertRaisesRegex(
+          TypeError,
+          r"jax\.scipy\.linalg\.inv does not support dtype float16"):
+        jsp.linalg.inv(x)
+
+  def testCholeskyUnsupportedBfloat16(self):
+      x = jnp.eye(4, dtype=jnp.bfloat16)
+
+      with self.assertRaisesRegex(
+          TypeError,
+          r"jax\.scipy\.linalg\.cholesky does not support dtype bfloat16"):
+        jsp.linalg.cholesky(x)
   @jtu.sample_product(
     shape=[(1, 1), (4, 5), (10, 5), (50, 50)],
     dtype=float_types + complex_types,


### PR DESCRIPTION
Fixes #38825

This PR improves the user-facing error when unsupported dtypes (float16 and bfloat16) are passed to LAPACK-backed functions in jax.scipy.linalg, such as `inv` and `cholesky`.

Currently, unsupported dtypes fail with a low-level KeyError originating from the LAPACK dispatch layer, which is confusing and not actionable for users.

This change ensures that unsupported dtypes are rejected early at the `jax.scipy.linalg` API boundary with a clear TypeError message.

Changes:
- Add explicit dtype validation for LAPACK-backed functions in `jax.scipy.linalg`
- Raise TypeError for unsupported dtypes (float16, bfloat16)
- Improve clarity of error messages by avoiding internal jaxlib exceptions

Tests:
- Added regression test for `inv` with float16 input
- Added regression test for `cholesky` with bfloat16 input

