### PR TITLE
[Pallas][Triton] Add AMD Instinct GPU support to gpu_info

### DIFF
--- a/jax/_src/pallas/triton/gpu_info.py
+++ b/jax/_src/pallas/triton/gpu_info.py
@@ -25,8 +25,9 @@ from jax._src.interpreters import pxla
 
 
 class GpuVersion(enum.Enum):
-  """NVidia GPU version"""
+  """GPU version"""
 
+  # NVIDIA GPUs
   A10 = "NVIDIA A10"
   A30 = "NVIDIA A30"
   A100 = "NVIDIA A100"
@@ -46,6 +47,20 @@ class GpuVersion(enum.Enum):
   RTX_PRO_5000 = "NVIDIA RTX PRO 5000"
   RTX_PRO_6000 = "NVIDIA RTX PRO 6000"
   THOR = "NVIDIA Thor"
+
+  # AMD GPUs
+  GFX908 = "gfx908"
+  GFX90A = "gfx90a"
+  GFX942 = "gfx942"
+  GFX950 = "gfx950"
+  GFX1030 = "gfx1030"
+  GFX1100 = "gfx1100"
+  GFX1101 = "gfx1101"
+  GFX1103 = "gfx1103"
+  GFX1150 = "gfx1150"
+  GFX1151 = "gfx1151"
+  GFX1200 = "gfx1200"
+  GFX1201 = "gfx1201"
 
   def __str__(self) -> str:
     return self.value
@@ -142,6 +157,26 @@ def _get_gpu_info_impl(gpu_version: GpuVersion) -> GpuInfo:
           gpu_version=gpu_version,
           arch_name="11.0",
           compute_capability=110,
+      )
+    # AMD GPUs. The enum value is already the gfx arch name.
+    case (
+        GpuVersion.GFX908
+        | GpuVersion.GFX90A
+        | GpuVersion.GFX942
+        | GpuVersion.GFX950
+        | GpuVersion.GFX1030
+        | GpuVersion.GFX1100
+        | GpuVersion.GFX1101
+        | GpuVersion.GFX1103
+        | GpuVersion.GFX1150
+        | GpuVersion.GFX1151
+        | GpuVersion.GFX1200
+        | GpuVersion.GFX1201
+    ):
+      return GpuInfo(
+          gpu_version=gpu_version,
+          arch_name=gpu_version.value,
+          compute_capability=0,
       )
     case _:
       raise ValueError(f"Unsupported GPU version: {gpu_version}")

--- a/jax/_src/pallas/triton/pallas_call_registration.py
+++ b/jax/_src/pallas/triton/pallas_call_registration.py
@@ -112,8 +112,6 @@ def pallas_call_lowering(
   else:
     arch_name = gpu_info.arch_name
     compute_capability = gpu_info.compute_capability
-    if lowering_platform == "rocm":
-      compute_capability = 0
 
   # Sanitize the name to conform to NVPTX requirements. We do this here
   # to avoid the need to fetch the new name from PTX post compilation.

--- a/tests/pallas/triton_gpu_info_test.py
+++ b/tests/pallas/triton_gpu_info_test.py
@@ -35,11 +35,11 @@ class GpuInfoTest(jtu.JaxTestCase):
     super().setUp()
     if not plgpu:
       self.skipTest("Skipping test because device is not a GPU.")
-    if not jtu.is_device_cuda():
+    if jtu.is_device_cuda() or jtu.is_device_rocm():
+      self.assertTrue(plgpu.is_gpu_device())
+    else:
       self.assertFalse(plgpu.is_gpu_device())
       self.skipTest("Skipping test because device is not a GPU.")
-    else:
-      self.assertTrue(plgpu.is_gpu_device())
 
   def test_get_gpu_info(self):
     device = jax.devices()[0]
@@ -88,6 +88,21 @@ class GpuInfoTest(jtu.JaxTestCase):
     ("NVIDIA H100 NVL", GpuVersion.H100),
     ("NVIDIA RTX 123", None),
     ("UNKNOWN", None),
+    ("gfx908", GpuVersion.GFX908),
+    ("gfx90a", GpuVersion.GFX90A),
+    ("gfx90a:sramecc+:xnack-", GpuVersion.GFX90A),
+    ("gfx942", GpuVersion.GFX942),
+    ("gfx942:sramecc+:xnack-", GpuVersion.GFX942),
+    ("gfx950", GpuVersion.GFX950),
+    ("gfx950:sramecc+:xnack-", GpuVersion.GFX950),
+    ("gfx1030", GpuVersion.GFX1030),
+    ("gfx1100", GpuVersion.GFX1100),
+    ("gfx1101", GpuVersion.GFX1101),
+    ("gfx1103", GpuVersion.GFX1103),
+    ("gfx1150", GpuVersion.GFX1150),
+    ("gfx1151", GpuVersion.GFX1151),
+    ("gfx1200", GpuVersion.GFX1200),
+    ("gfx1201", GpuVersion.GFX1201),
   ])
   def test_gpu_version_from_device_kind(self, device_kind, expected):
     info = gpu_info.gpu_version_from_device_kind(device_kind)

--- a/tests/pallas/triton_pallas_test.py
+++ b/tests/pallas/triton_pallas_test.py
@@ -507,7 +507,10 @@ class TritonPallasTest(PallasBaseTest):
     )
 
   def test_deviceless_aot(self):
-    abstract_device = mesh_lib.AbstractDevice('NVIDIA A100', 1, 'cuda')
+    if jtu.is_device_rocm():
+      abstract_device = mesh_lib.AbstractDevice('gfx950', 1, 'rocm')
+    else:
+      abstract_device = mesh_lib.AbstractDevice('NVIDIA A100', 1, 'cuda')
     abstract_mesh = mesh_lib.AbstractMesh(
         (1,),
         ('x',),


### PR DESCRIPTION
Restore ROCm Pallas support broken by PR #38762, which introduced a NVIDIA-only GpuVersion enum. Add AMD Instinct entries mapping each to its gfx target.