### PR TITLE
[Pallas][Mosaic GPU]Updated _infer_arch to use gpu_info from triton

### DIFF
--- a/jax/_src/pallas/BUILD
+++ b/jax/_src/pallas/BUILD
@@ -33,6 +33,7 @@ pytype_library(
         "core.py",
         "cost_estimate.py",
         "einshape.py",
+        "gpu_info.py",
         "helpers.py",
         "hlo_interpreter.py",
         "mpmd.py",

--- a/jax/_src/pallas/gpu_info.py
+++ b/jax/_src/pallas/gpu_info.py
@@ -70,6 +70,11 @@ class GpuInfo:
   compute_capability: int
   gpu_version: GpuVersion | None
 
+  def get_arch_major_minor(self) -> tuple[int, int]:
+    return (
+        self.compute_capability // 10, self.compute_capability % 10
+    )
+
 
 def is_gpu_device() -> bool:
   return _get_device().platform == "gpu"

--- a/jax/_src/pallas/triton/BUILD
+++ b/jax/_src/pallas/triton/BUILD
@@ -92,7 +92,6 @@ pytype_strict_library(
     type_checking = "pyrefly",
     deps = [
         ":core",
-        ":gpu_info",
         ":lowering",
         "//jax",
         "//jax/_src:api",
@@ -102,17 +101,5 @@ pytype_strict_library(
         "//jax/_src:mlir",
         "//jax/_src/lib",
         "//jax/_src/pallas",
-    ],
-)
-
-pytype_strict_library(
-    name = "gpu_info",
-    srcs = ["gpu_info.py"],
-    type_checking = "pyrefly",
-    deps = [
-        "//jax/_src:api",
-        "//jax/_src:mesh",
-        "//jax/_src:util",
-        "//jax/_src/lib",
     ],
 )

--- a/jax/_src/pallas/triton/pallas_call_registration.py
+++ b/jax/_src/pallas/triton/pallas_call_registration.py
@@ -30,7 +30,7 @@ from jax._src.lib.mlir import ir
 from jax._src.pallas import core as pallas_core
 from jax._src.pallas.triton import core as triton_core
 from jax._src.pallas.triton import lowering
-from jax._src.pallas.triton import gpu_info as gpu_info_lib
+from jax._src.pallas import gpu_info as gpu_info_lib
 
 
 # TODO(b/526389887): Figure out how to flip this to True.

--- a/jax/experimental/BUILD
+++ b/jax/experimental/BUILD
@@ -284,6 +284,7 @@ py_library_providing_imports_info(
         "//jax/_src:stages",
         "//jax/_src:util",
         "//jax/_src/lib",
+        "//jax/_src/pallas",
         "//jax/extend:backend",
         "//jaxlib/mlir:arithmetic_dialect",
         "//jaxlib/mlir:builtin_dialect",
@@ -515,7 +516,6 @@ pytype_strict_library(
     deps = [
         "//jax/_src/pallas",
         "//jax/_src/pallas/triton:core",
-        "//jax/_src/pallas/triton:gpu_info",
         "//jax/_src/pallas/triton:pallas_call_registration",  # build_cleaner: keep
         "//jax/_src/pallas/triton:primitives",
     ],

--- a/jax/experimental/mosaic/gpu/core.py
+++ b/jax/experimental/mosaic/gpu/core.py
@@ -38,7 +38,7 @@ from jax._src import sharding_impls
 from jax._src import util as jax_util
 from jax._src.interpreters import mlir
 from jax._src.lib import mosaic_gpu_dialect as dialect
-from jax.extend import backend as jex_backend
+from jax._src.pallas import gpu_info as gpu_info_lib
 from jaxlib.mlir import ir
 from jaxlib.mlir import passmanager
 from jaxlib.mlir.dialects import _gpu_ops_gen
@@ -785,25 +785,15 @@ def _launch(
 
 
 def _infer_arch() -> tuple[int, int]:
-  device: Any = jax.sharding.get_abstract_mesh().abstract_device
-  default_device = jex_backend.get_default_device()
-  if device is None:
-    device = default_device
-  elif (
-      hasattr(default_device, "compute_capability")
-      and device.device_kind == default_device.device_kind
-  ):
-    device = default_device
-  if not hasattr(device, "compute_capability"):
-    return (9, 0)  # TODO(apaszke): Remove this once we figure out the export story.
-  arch_name = device.compute_capability
-  # Handle ROCm devices that return architecture strings like "gfxXXX".
-  if arch_name.startswith("gfx"):
+  # This method raises ValueError for cpu and
+  # unsupported Nvidia or AMD GPUs
+  gpu_info = gpu_info_lib.get_gpu_info()
+  if gpu_info.compute_capability == 0:
     raise ValueError(
         f"Mosaic GPU does not yet support AMD ROCm devices. "
-        f"Got compute_capability: {arch_name}"
+        f"Got compute_capability: {gpu_info.arch_name}"
     )
-  return tuple(map(int, arch_name.split(".")))  # pyrefly: ignore[bad-return]
+  return gpu_info.get_arch_major_minor()
 
 
 def _lower_as_gpu_kernel(

--- a/jax/experimental/pallas/__init__.py
+++ b/jax/experimental/pallas/__init__.py
@@ -44,6 +44,11 @@ from jax._src.pallas.core import semaphore as semaphore
 from jax._src.pallas.core import Squeezed as Squeezed
 from jax._src.pallas.core import squeezed as squeezed
 from jax._src.pallas.cost_estimate import estimate_cost as estimate_cost
+from jax._src.pallas.gpu_info import GpuVersion as GpuVersion
+from jax._src.pallas.gpu_info import get_gpu_info as get_gpu_info
+from jax._src.pallas.gpu_info import get_gpu_info_from_version as get_gpu_info_from_version
+from jax._src.pallas.gpu_info import is_gpu_device as is_gpu_device
+from jax._src.pallas.gpu_info import GpuInfo as GpuInfo
 from jax._src.pallas.helpers import empty as empty
 from jax._src.pallas.helpers import empty_like as empty_like
 from jax._src.pallas.helpers import empty_ref_like as empty_ref_like

--- a/jax/experimental/pallas/triton.py
+++ b/jax/experimental/pallas/triton.py
@@ -31,8 +31,3 @@ from jax._src.pallas.triton.primitives import elementwise_inline_asm as elementw
 from jax._src.pallas.triton.primitives import load as load
 from jax._src.pallas.triton.primitives import max_contiguous as max_contiguous
 from jax._src.pallas.triton.primitives import store as store
-from jax._src.pallas.triton.gpu_info import GpuVersion as GpuVersion
-from jax._src.pallas.triton.gpu_info import get_gpu_info as get_gpu_info
-from jax._src.pallas.triton.gpu_info import get_gpu_info_from_version as get_gpu_info_from_version
-from jax._src.pallas.triton.gpu_info import is_gpu_device as is_gpu_device
-from jax._src.pallas.triton.gpu_info import GpuInfo as GpuInfo

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -29,6 +29,7 @@ from absl.testing import parameterized
 import jax
 from jax._src import config
 from jax._src import dtypes
+from jax._src import mesh as mesh_lib
 from jax._src import test_util as jtu
 from jax._src import hypothesis_test_util as htu
 from jax._src.interpreters import mlir
@@ -248,6 +249,28 @@ class TestUtilTest(TestCase):
       copy(src, dst)
     x = jnp.arange(2 * 3 * 5).reshape(2, 5, 3)
     y = mgpu.as_gpu_kernel(kernel, (1, 1, 1), (128, 1, 1), x, x, ())(x)
+    np.testing.assert_array_equal(y, x)
+
+  def test_copy_basic_deviceless_aot(self):
+    abstract_device = mesh_lib.AbstractDevice('11.0', 1, 'gpu')
+    abstract_mesh = mesh_lib.AbstractMesh(
+        (1,),
+        ('x',),
+        (mesh_lib.AxisType.Explicit,),
+        abstract_device=abstract_device,
+    )
+
+    def kernel(ctx, src, dst, _):
+      copy(src, dst)
+
+    with jax.sharding.use_abstract_mesh(abstract_mesh):
+      x = jax.ShapeDtypeStruct((2, 5, 3), jnp.int32)
+      jitted = mgpu.as_gpu_kernel(kernel, (1, 1, 1), (128, 1, 1), x, x, ())
+      lowered = jitted.lower(x)
+
+    compiled = lowered.compile(device_assignment=tuple(jax.devices()))
+    x = jnp.arange(2 * 3 * 5).reshape(2, 5, 3)
+    y = compiled(x)
     np.testing.assert_array_equal(y, x)
 
   def test_copy_swizzle(self):

--- a/tests/pallas/BUILD
+++ b/tests/pallas/BUILD
@@ -935,15 +935,14 @@ jax_multiplatform_test(
 )
 
 jax_multiplatform_test(
-    name = "triton_gpu_info_test",
+    name = "gpu_info_test",
     srcs = [
-        "triton_gpu_info_test.py",
+        "gpu_info_test.py",
     ],
     enable_backends = ["gpu"],
     shard_count = 1,
     deps = [
         "//jax/experimental:pallas",
-        "//jax/experimental:pallas_triton",
     ] + py_deps([
         "absl/testing",
     ]),

--- a/tests/pallas/gpu_info_test.py
+++ b/tests/pallas/gpu_info_test.py
@@ -12,41 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
 from absl.testing import absltest
 from absl.testing import parameterized
 import jax
 from jax._src import mesh as mesh_lib
 from jax._src import test_util as jtu
-from jax._src.pallas.triton import gpu_info
+from jax._src.pallas import gpu_info
+from jax.experimental import pallas as pl
 
-if sys.platform != "win32":
-  # pylint: disable=g-import-not-at-top
-  from jax.experimental.pallas import triton as plgpu
-  GpuVersion = plgpu.GpuVersion
-else:
-  plgpu = None
-  GpuVersion = gpu_info.GpuVersion
+
+GpuVersion = pl.GpuVersion
 
 
 class GpuInfoTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
-    if not plgpu:
-      self.skipTest("Triton support is not available.")
     if jtu.is_device_cuda() or jtu.is_device_rocm():
-      self.assertTrue(plgpu.is_gpu_device())
+      self.assertTrue(pl.is_gpu_device())
     else:
-      self.assertFalse(plgpu.is_gpu_device())
+      self.assertFalse(pl.is_gpu_device())
       self.skipTest("Skipping test because device is not a GPU.")
 
   def test_get_gpu_info_real_device(self):
     # on real device
     device = jax.devices()[0]
-    info = plgpu.get_gpu_info()
-    self.assertIsInstance(info, plgpu.GpuInfo)
+    info = pl.get_gpu_info()
+    self.assertIsInstance(info, pl.GpuInfo)
 
     expected_arch_name = str(device.compute_capability)
     if "cuda" in device.client.platform_version:
@@ -69,18 +61,18 @@ class GpuInfoTest(jtu.JaxTestCase):
         abstract_device=abstract_device,
     )
     with mesh_lib.use_abstract_mesh(abstract_mesh):
-      info = plgpu.get_gpu_info()
+      info = pl.get_gpu_info()
       self.assertEqual(info.arch_name, expected_info.arch_name)
       self.assertEqual(info.compute_capability, expected_info.compute_capability)
 
   def test_get_gpu_info_given_gpu_version(self):
-    info = plgpu.get_gpu_info()
+    info = pl.get_gpu_info()
     if info.gpu_version is None:
       self.skipTest(
           f"Skipping test as GPU device: {gpu_info.get_device_kind()} "
           "is not in GpuVersion."
       )
-    info_version = plgpu.get_gpu_info_from_version(info.gpu_version)
+    info_version = pl.get_gpu_info_from_version(info.gpu_version)
     self.assertEqual(info, info_version)
 
   @parameterized.parameters([


### PR DESCRIPTION
Follow-up to https://github.com/jax-ml/jax/pull/38762 
Description:
- Use gpu_info in `_infer_arch` MGPU 
- Moved gpu_info.py to pallas from pallas triton

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->