### PR TITLE
[Mosaic GPU] Add missing `cse` pass in `_kernel_to_module` similarly to `lower_jaxpr_to_module`

### DIFF
--- a/jax/experimental/mosaic/gpu/core.py
+++ b/jax/experimental/mosaic/gpu/core.py
@@ -1015,7 +1015,7 @@ def _kernel_to_module(
   if thread_semantics == LoweringSemantics.Warpgroup and dialect is not None:
     # We need to run a pass that removes dead-code for which layout inference
     # does not work.
-    pm = mlir.passmanager.PassManager.parse("builtin.module(canonicalize)", module.context)
+    pm = mlir.passmanager.PassManager.parse("builtin.module(canonicalize,cse)", module.context)
     pm.run(module.operation)
 
     # Run Python lowering passes. The remaining passes will be run in C++ in


### PR DESCRIPTION
Follow-up to https://github.com/jax-ml/jax/pull/36897

The newer code block from `lower_jaxpr_to_module`
https://github.com/jax-ml/jax/blob/9c715422140357a0285fdd866ce0f101710e9e05/jax/_src/pallas/mosaic_gpu/lowering.py#L1150-L1161

is almost the same as in `_kernel_to_module`:
https://github.com/jax-ml/jax/blob/9c715422140357a0285fdd866ce0f101710e9e05/jax/experimental/mosaic/gpu/core.py#L1009-L1018

This PR adds missing cse pass to `_kernel_to_module` function which was similarly added in https://github.com/jax-ml/jax/pull/36897 to `lower_jaxpr_to_module`.

@bchetioui PTAL, thanks!