### PR TITLE
[Pallas][Triton] Reapply the missing code from PR 38762 (gpu_info.py)

### DIFF
--- a/jax/_src/pallas/triton/gpu_info.py
+++ b/jax/_src/pallas/triton/gpu_info.py
@@ -16,6 +16,7 @@
 
 import dataclasses
 import enum
+import re
 from collections.abc import Callable
 
 from jax._src import mesh as mesh_lib
@@ -49,29 +50,14 @@ class GpuVersion(enum.Enum):
     return self.value
 
 
-def gpu_version_from_device_kind(device_kind: str) -> GpuVersion | None:
-  def loose_match(version_name, device_name):
-    # we assume that device_name is a full device name string larger than
-    # version_name string
-    name = version_name.lower()
-    dname = device_name.lower()
-    if not dname.startswith(name):
-      return False
-    # Check the next char is not digit to avoid matching e.g. NVIDIA A10 to NVIDIA A100
-    idx = len(name)
-    if idx < len(dname) and dname[idx] not in "0123456879":
-      return True
-    return False
+_GPU_VERSION_RE = re.compile(r"\b(" + "|".join(e.value for e in GpuVersion) + r")\b")
 
-  for version in GpuVersion:
-    # Loose compare due to variants of GPU names
-    # e.g. A100 GPU can be NVIDIA A100-SXM4-40GB or NVIDIA A100-SXM4-80GB
-    # or NVIDIA A100-PCIE-40GB or NVIDIA A100 80GB PCIe etc
-    if version.value == device_kind or loose_match(
-        version.value, device_kind
-    ):
-      return version
+
+def gpu_version_from_device_kind(device_kind: str) -> GpuVersion | None:
+  if m := _GPU_VERSION_RE.match(device_kind):
+    return GpuVersion(m.group())
   return None
+
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GpuInfo:
@@ -129,8 +115,8 @@ def _get_gpu_info_impl(gpu_version: GpuVersion) -> GpuInfo:
     case GpuVersion.B200 | GpuVersion.GB200:
       return GpuInfo(
           gpu_version=gpu_version,
-          arch_name="9.0",
-          compute_capability=90,
+          arch_name="10.0",
+          compute_capability=100,
       )
     case GpuVersion.B300 | GpuVersion.GB300:
       return GpuInfo(

--- a/tests/pallas/triton_gpu_info_test.py
+++ b/tests/pallas/triton_gpu_info_test.py
@@ -45,11 +45,32 @@ class GpuInfoTest(jtu.JaxTestCase):
     device = jax.devices()[0]
     info = plgpu.get_gpu_info()
     self.assertIsInstance(info, plgpu.GpuInfo)
-    for version in plgpu.GpuVersion:
-      if version.value in device.device_kind:
-        self.assertEqual(info.gpu_version, version)
-        return
-    self.fail(f"Unexpected device kind: {device.device_kind}")
+    self.assertEqual(info.arch_name, device.compute_capability)
+    expected_version = gpu_info.gpu_version_from_device_kind(device.device_kind)
+    self.assertEqual(info.gpu_version, expected_version)
+
+    cc = info.compute_capability
+    match info.gpu_version:
+      case GpuVersion.T4:
+        self.assertEqual(cc, 75)
+      case GpuVersion.A100 | GpuVersion.A30:
+        self.assertEqual(cc, 80)
+      case GpuVersion.A10:
+        self.assertEqual(cc, 86)
+      case GpuVersion.L4 | GpuVersion.L40 | GpuVersion.RTX_4090:
+        self.assertEqual(cc, 89)
+      case GpuVersion.H100 | GpuVersion.H200 | GpuVersion.GH200:
+        self.assertEqual(cc, 90)
+      case GpuVersion.B200 | GpuVersion.GB200:
+        self.assertEqual(cc, 100)
+      case GpuVersion.B300 | GpuVersion.GB300:
+        self.assertEqual(cc, 103)
+      case GpuVersion.RTX_PRO_4500 | GpuVersion.RTX_PRO_5000 | GpuVersion.RTX_PRO_6000:
+        self.assertEqual(cc, 120)
+      case GpuVersion.GB10:
+        self.assertEqual(cc, 121)
+      case _:
+        self.assertEqual(cc, 0)
 
   def test_get_gpu_info_given_gpu_version(self):
     info = plgpu.get_gpu_info()
@@ -65,6 +86,8 @@ class GpuInfoTest(jtu.JaxTestCase):
     ("NVIDIA H100 80GB HBM3", GpuVersion.H100),
     ("NVIDIA H100 PCIe", GpuVersion.H100),
     ("NVIDIA H100 NVL", GpuVersion.H100),
+    ("NVIDIA RTX 123", None),
+    ("UNKNOWN", None),
   ])
   def test_gpu_version_from_device_kind(self, device_kind, expected):
     info = gpu_info.gpu_version_from_device_kind(device_kind)


### PR DESCRIPTION

Description:
- Reapply the missing code from PR 38762 "Added gpu_info and removed gpu device fallback from pallas_call_lowering"
