### PR TITLE
Fix jnp.max VJP precision error on float16/bfloat16 reductions

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -8467,10 +8467,23 @@ def _reduce_chooser_jvp_rule(g, ans, operand, *, axes):
   # locations in a single pass (rather than comparing equality) and use a
   # gather, and/or even push along the chosen elements of g (b/112040122)
   shape = [1 if i in axes else d for i, d in enumerate(operand.shape)]
-  location_indicators = convert_element_type(
-      _eq_meet(operand, reshape(ans, shape)), g.dtype)
-  counts = reduce_sum(location_indicators, axes)
-  return div(reduce_sum(mul(g, location_indicators), axes), counts)
+  bool_indicators = _eq_meet(operand, reshape(ans, shape))
+
+  int_indicators = convert_element_type(
+      bool_indicators, dtypes.canonicalize_dtype(np.int32))
+  counts = reduce_sum(int_indicators, axes)
+
+  compute_dtype = g.dtype
+  if compute_dtype in (np.float16, dtypes.bfloat16):
+    compute_dtype = dtypes.canonicalize_dtype(np.float32)
+
+  g_compute = convert_element_type(g, compute_dtype)
+  location_indicators = convert_element_type(bool_indicators, compute_dtype)
+  weighted_sum = reduce_sum(mul(g_compute, location_indicators), axes)
+
+  return convert_element_type(
+      div(weighted_sum, convert_element_type(counts, compute_dtype)),
+      g.dtype)
 
 
 reduce_max_p = standard_primitive(

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -5513,6 +5513,23 @@ class APITest(jtu.JaxTestCase):
     with jax.allow_f16_reductions(False):
       jax.lax.reduce_sum(x, [0])  # allowed on singleton axes
 
+  def test_low_precision_max_min_vjp(self):
+
+    x_tie = jnp.array([1.0, 1.0, 0.0], dtype=jnp.bfloat16)
+    x_unique = jnp.array([3.0, 1.0, 2.0], dtype=jnp.bfloat16)
+
+    with jax.allow_f16_reductions(False):
+
+      grad_max_tie = jax.jit(jax.grad(jnp.max))(x_tie)
+      self.assertEqual(grad_max_tie.dtype, jnp.bfloat16)
+      self.assertAllClose(grad_max_tie, jnp.array([0.5, 0.5, 0.0], dtype=jnp.bfloat16))
+
+      grad_max_unique = jax.jit(jax.grad(jnp.max))(x_unique)
+      self.assertAllClose(grad_max_unique, jnp.array([1.0, 0.0, 0.0], dtype=jnp.bfloat16))
+
+      grad_min = jax.jit(jax.grad(jnp.min))(x_tie)
+      self.assertAllClose(grad_min, jnp.array([0.0, 0.0, 1.0], dtype=jnp.bfloat16))
+
   def test_vjp3_dont_want(self):
     @jax.jit
     def f(x, y):


### PR DESCRIPTION
Fixes #38885

**The Problem:**
When computing the VJP of `jnp.max` or `jnp.min` on low-precision inputs (`bfloat16` or `float16`), the VJP implementation was previously performing sum reductions natively in that low precision format to both count ties and compute the weighted gradient sum. 

This resulted in two problems
1. It crashed with a `ValueError` when `jax.config.update("jax_allow_f16_reductions", False)` was set. 
2. It caused severe numerical instability for large arrays (e.g., `bfloat16` loses integer counting precision at 256).

**The Solution:**
Updated `_reduce_chooser_jvp_rule` in `lax.py` to safely handle low-precision gradients:
- **Ties Counting:** The boolean indicator array is now cast to `int32` before reduction, ensuring exact counting without precision loss.
- **Weighted Gradient Sum:** If the incoming gradient is `float16` or `bfloat16`, the reduction is promoted to `float32` during accumulation and then cast back to the target dtype at the end. 

This fully bypasses the `allow_f16_reductions` restriction and yields highly accurate gradients.

**Testing:**
- Added a robust regression test to `tests/api_test.py` covering both `jnp.max` and `jnp.min` under `jax.allow_f16_reductions(False)` for unique and tied elements.
- Passes all `pre-commit` and local pytest checks.
