### PR TITLE
Allocate triton's global scratch buffer instead of passing null

### DIFF
--- a/jaxlib/gpu/triton.cc
+++ b/jaxlib/gpu/triton.cc
@@ -56,7 +56,11 @@ nb::dict Registrations() {
 NB_MODULE(_triton, m) {
   nb::class_<Kernel>(m, "TritonKernel")
       .def(nb::init<std::string, uint32_t, uint32_t, uint32_t, std::string,
-                    std::string, int>());
+                    std::string, int, uint32_t, uint32_t>(),
+           nb::arg("kernel_name"), nb::arg("num_warps"), nb::arg("num_ctas"),
+           nb::arg("shared_mem_bytes"), nb::arg("ptx"), nb::arg("ttir"),
+           nb::arg("compute_capability"), nb::arg("global_scratch_size") = 0,
+           nb::arg("global_scratch_align") = 1);
 
   nb::class_<KernelCall::Parameter>(m, "TritonParameter");
 

--- a/jaxlib/gpu/triton.proto
+++ b/jaxlib/gpu/triton.proto
@@ -10,6 +10,10 @@ message TritonKernel {
   string ptx = 4;
   string ttir = 5;
   uint32 compute_capability = 6;
+  // Per-CTA global scratch memory required by the kernel (e.g. for
+  // on-device construction of TMA descriptors). Zero if unused.
+  optional uint32 global_scratch_size = 11;
+  optional uint32 global_scratch_align = 12;
 
   reserved 7, 8, 9;
 }

--- a/jaxlib/gpu/triton_kernels.cc
+++ b/jaxlib/gpu/triton_kernels.cc
@@ -674,13 +674,23 @@ absl::Status KernelCall::Launch(gpuStream_t stream, void** buffers) {
   if (global_scratch_size > 0) {
     uint64_t grid_size =
         static_cast<uint64_t>(grid_[0]) * grid_[1] * grid_[2];
-    uint64_t alloc_size =
-        grid_size * kernel_.num_ctas() * global_scratch_size;
+    uint64_t num_ctas = kernel_.num_ctas();
+    if (grid_size != 0 && num_ctas != 0 &&
+        global_scratch_size >
+            std::numeric_limits<uint64_t>::max() / grid_size / num_ctas) {
+      return absl::InvalidArgumentError(
+          "Triton global scratch buffer size overflow.");
+    }
+    uint64_t alloc_size = grid_size * num_ctas * global_scratch_size;
 #ifdef JAX_GPU_CUDA
     GPU_RETURN_IF_ERROR(cuMemAllocAsync(&global_scratch, alloc_size, stream));
 #else  // JAX_GPU_HIP
-    GPU_RETURN_IF_ERROR(hipMallocAsync(
-        reinterpret_cast<void**>(&global_scratch), alloc_size, stream));
+    // Allocate into a temporary void* rather than reinterpret_cast'ing the
+    // address of `global_scratch` itself, to avoid punning through an
+    // incompatible pointer type.
+    void* hip_scratch_ptr = nullptr;
+    GPU_RETURN_IF_ERROR(hipMallocAsync(&hip_scratch_ptr, alloc_size, stream));
+    global_scratch = reinterpret_cast<gpuDevicePtr_t>(hip_scratch_ptr);
 #endif
   }
   absl::Cleanup global_scratch_deleter = [&] {

--- a/jaxlib/gpu/triton_kernels.cc
+++ b/jaxlib/gpu/triton_kernels.cc
@@ -452,14 +452,18 @@ class ModuleImage {
 
 Kernel::Kernel(std::string kernel_name, uint32_t num_warps, uint32_t num_ctas,
                uint32_t shared_mem_bytes, std::string ptx, std::string ttir,
-               int compute_capability)
+               int compute_capability, uint32_t global_scratch_size,
+               uint32_t global_scratch_align)
     : kernel_name_(std::move(kernel_name)),
       block_dim_x_(num_warps * kNumThreadsPerWarp),
       num_ctas_(num_ctas),
       shared_mem_bytes_(shared_mem_bytes),
       ptx_(std::move(ptx)),
       ttir_(std::move(ttir)),
-      compute_capability_(compute_capability) {}
+      compute_capability_(compute_capability),
+      global_scratch_size_(global_scratch_size),
+      global_scratch_align_(global_scratch_align == 0 ? 1
+                                                       : global_scratch_align) {}
 
 absl::Status Kernel::Launch(gpuStream_t stream, uint32_t grid[3],
                             void** params) {
@@ -530,10 +534,18 @@ absl::Status Kernel::Launch(gpuStream_t stream, uint32_t grid[3],
 /*static*/ Kernel Kernel::FromProto(const jax_triton::TritonKernel& proto) {
   // Use 1 as default value if not specified in already serialized kernels.
   int num_ctas = proto.has_num_ctas() ? proto.num_ctas() : 1;
+  // Older serialized kernels don't carry scratch memory metadata; 0/1 mean
+  // "no scratch buffer needed", matching pre-existing (null pointer)
+  // behavior.
+  uint32_t global_scratch_size =
+      proto.has_global_scratch_size() ? proto.global_scratch_size() : 0;
+  uint32_t global_scratch_align =
+      proto.has_global_scratch_align() ? proto.global_scratch_align() : 1;
 
   return Kernel(proto.kernel_name(), proto.num_warps(), num_ctas,
                 proto.shared_mem_bytes(), proto.ptx(), proto.ttir(),
-                proto.compute_capability());
+                proto.compute_capability(), global_scratch_size,
+                global_scratch_align);
 }
 
 jax_triton::TritonKernel Kernel::ToProto() const {
@@ -545,6 +557,8 @@ jax_triton::TritonKernel Kernel::ToProto() const {
   proto.set_ptx(ptx_);
   proto.set_ttir(ttir_);
   proto.set_compute_capability(compute_capability_);
+  proto.set_global_scratch_size(global_scratch_size_);
+  proto.set_global_scratch_align(global_scratch_align_);
   return proto;
 }
 
@@ -650,14 +664,40 @@ absl::Status KernelCall::Launch(gpuStream_t stream, void** buffers) {
           param.value)));
     }
   }
-  // Triton's kernel ABI expects an additional scratchpad global memory.
-  // For now it is only used for on-device creation of TMA descriptors, which
-  // we do not use yet, so we are just replacing this argument with a null
-  // pointer.
-  // TODO: b/381242007 - Allocate a proper buffer if we want to use
-  // device-side TMA APIs.
-  void* tma_descriptor_buffer = nullptr;  // Alive until kernel_.Launch returns.
-  params.push_back(&tma_descriptor_buffer);
+  // Triton's kernel ABI expects an additional scratchpad global memory
+  // buffer, used e.g. for on-device construction of TMA descriptors.
+  // Sized per-CTA by the compiler; the launcher must multiply by the
+  // number of CTAs actually launched (mirrors Triton's own CPU-side
+  // launcher in triton/backends/nvidia/driver.py).
+  gpuDevicePtr_t global_scratch = 0;
+  uint32_t global_scratch_size = kernel_.global_scratch_size();
+  if (global_scratch_size > 0) {
+    uint64_t grid_size =
+        static_cast<uint64_t>(grid_[0]) * grid_[1] * grid_[2];
+    uint64_t alloc_size =
+        grid_size * kernel_.num_ctas() * global_scratch_size;
+#ifdef JAX_GPU_CUDA
+    GPU_RETURN_IF_ERROR(cuMemAllocAsync(&global_scratch, alloc_size, stream));
+#else  // JAX_GPU_HIP
+    GPU_RETURN_IF_ERROR(hipMallocAsync(
+        reinterpret_cast<void**>(&global_scratch), alloc_size, stream));
+#endif
+  }
+  absl::Cleanup global_scratch_deleter = [&] {
+    if (global_scratch == 0) return;
+#ifdef JAX_GPU_CUDA
+    absl::Status s = JAX_AS_STATUS(cuMemFreeAsync(global_scratch, stream));
+#else  // JAX_GPU_HIP
+    absl::Status s = JAX_AS_STATUS(
+        hipFreeAsync(reinterpret_cast<void*>(global_scratch), stream));
+#endif
+    if (!s.ok()) {
+      LOG(WARNING) << "Failed to free Triton global scratch buffer: " << s;
+    }
+  };
+  // Alive until kernel_.Launch returns.
+  void* global_scratch_ptr = reinterpret_cast<void*>(global_scratch);
+  params.push_back(&global_scratch_ptr);
   void* profiling_buffer = nullptr;  // Alive until kernel_.Launch returns.
   params.push_back(&profiling_buffer);
 

--- a/jaxlib/gpu/triton_kernels.h
+++ b/jaxlib/gpu/triton_kernels.h
@@ -44,7 +44,8 @@ class Kernel {
  public:
   Kernel(std::string kernel_name, uint32_t num_warps, uint32_t num_ctas,
          uint32_t shared_mem_bytes, std::string ptx, std::string ttir,
-         int compute_capability);
+         int compute_capability, uint32_t global_scratch_size = 0,
+         uint32_t global_scratch_align = 1);
 
   absl::Status Launch(gpuStream_t stream, uint32_t grid[3], void** params);
 
@@ -54,6 +55,10 @@ class Kernel {
   // Returns true if we can launch the kernel without crashing.
   bool CanLaunchOnDevice(gpuDevice_t) const;
 
+  uint32_t num_ctas() const { return num_ctas_; }
+  uint32_t global_scratch_size() const { return global_scratch_size_; }
+  uint32_t global_scratch_align() const { return global_scratch_align_; }
+
  private:
   std::string kernel_name_;
   uint32_t block_dim_x_;
@@ -62,6 +67,10 @@ class Kernel {
   std::string ptx_;
   std::string ttir_;
   int compute_capability_;
+  // Per-CTA global scratch memory required by the kernel (e.g. for
+  // on-device construction of TMA descriptors). Zero if unused.
+  uint32_t global_scratch_size_;
+  uint32_t global_scratch_align_;
 
   ModuleImage* module_image_ = nullptr;
 };


### PR DESCRIPTION
Triton kernels that build TMA tensor descriptors on-device (used by Gluon's `make_tensor_descriptor` and friends) need an extra "global scratch" buffer, which Triton's compiler expects as an implicit trailing kernel arg. Right now `KernelCall::Launch` just passes null for it, so any kernel that actually touches an on-device descriptor compiles fine but blows up at launch with an illegal memory access.

This allocates a real stream-ordered buffer sized the same way Triton's own CPU-side launcher does it (see `triton/backends/nvidia/driver.py`), and frees it async on the same stream right after the launch. When no scratch is needed (basically every kernel today) it's still just a null pointer, so no behavior change there.

Companion jax-triton PR wiring the new metadata through: https://github.com/jax-ml/jax-triton/pull/390
