### PR TITLE
[mutable-arrays] document Ref autodiff interactions, esp jax.vjp with_refs

### DIFF
--- a/docs/array_refs.ipynb
+++ b/docs/array_refs.ipynb
@@ -447,7 +447,7 @@
     "  ref[...] = ref[...] + ref[...]\n",
     "  return ref[...]\n",
     "\n",
-    "print(jax.grad(pure1)(3.0))  # 2.0"
+    "print(jax.grad(pure2)(3.0))  # 2.0"
    ]
   },
   {
@@ -455,8 +455,12 @@
    "id": "801c3b60",
    "metadata": {},
    "source": [
-    "Autodiff can also be applied to functions that take array refs as arguments, if\n",
-    "those arguments are only used for plumbing and not involved in differentiation:"
+    "Autodiff can also be applied to functions that take array refs as arguments.\n",
+    "The simplest case is when those ref arguments are only used for plumbing, and\n",
+    "aren't involved in differentiation. For example, `jax.grad` differentiates\n",
+    "with respect to its function's first argument by default, so ref arguments in\n",
+    "other positions are just along for the ride. Only non-differentiated values\n",
+    "can be written into such plumbing refs:"
    ]
   },
   {
@@ -484,6 +488,11 @@
    "id": "86622dd6",
    "metadata": {},
    "source": [
+    "Differentiating _with respect to_ a ref-typed argument is another matter:\n",
+    "pointing `jax.grad` at one (e.g. via `argnums`) is an error, since the\n",
+    "gradient for a ref must itself live in a ref. Instead, use `jax.vjp` and\n",
+    "`with_refs`, described below.\n",
+    "\n",
     "You can combine plumbing refs with `custom_vjp` to plumb data out of the\n",
     "backward pass of a differentiated function:"
    ]
@@ -521,13 +530,13 @@
     "# Now, use `stash_grads` to stash intermediate gradients:\n",
     "\n",
     "def f(x, grads_ref):\n",
-    "  x = jnp.sin(x)\n",
     "  x = stash_grads(grads_ref, x)\n",
+    "  x = jnp.sin(x)\n",
     "  return x\n",
     "\n",
     "grads_ref = jax.new_ref(0.)\n",
-    "f(1., grads_ref)\n",
-    "print(grads_ref)"
+    "jax.grad(f)(1., grads_ref)\n",
+    "print(grads_ref)  # Ref(0.54), the gradient at the stash point: cos(1.)"
    ]
   },
   {
@@ -539,6 +548,390 @@
     "allowance for `custom_vjp` fwd rules: it's really syntax for indicating which\n",
     "ref arguments should be shared by both the fwd and bwd rules. So any refs\n",
     "returned by a fwd rule must be arguments to that fwd rule.\n",
+    "\n",
+    "#### Differentiating with respect to `Ref` arguments\n",
+    "\n",
+    "The plumbing refs above are just passengers: they carry data out of the\n",
+    "computation, but no gradients flow through them. We can also differentiate\n",
+    "_with respect to_ a ref argument. Since the gradient for a `Ref`-typed input\n",
+    "is itself `Ref`-typed, `jax.grad` doesn't apply here. Instead we use\n",
+    "`jax.vjp`, and bind a gradient ref to the VJP function using its `with_refs`\n",
+    "method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d6828aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def f(x_ref):\n",
+    "  return x_ref[...] ** 2\n",
+    "\n",
+    "x_ref = jax.new_ref(2.)\n",
+    "y, f_vjp = jax.vjp(f, x_ref)\n",
+    "\n",
+    "x_grad_ref = jax.new_ref(0.)\n",
+    "f_vjp.with_refs(x_grad_ref)(1.0)  # bind the gradient ref, then apply the VJP\n",
+    "print(x_grad_ref)  # Ref(4.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f96c988",
+   "metadata": {},
+   "source": [
+    "Here `with_refs` takes one entry per argument of the differentiated function\n",
+    "and returns a new VJP function with those gradient refs bound. When\n",
+    "differentiating with respect to a ref argument, using `with_refs` is\n",
+    "mandatory; the gradient needs a ref to be accumulated into, so calling the\n",
+    "VJP function without binding one is an error:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a162018",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_, f_vjp = jax.vjp(f, jax.new_ref(2.))\n",
+    "try:\n",
+    "  f_vjp(1.0)  # error! no ref bound for the ref-typed argument's gradient\n",
+    "except Exception as e:\n",
+    "  print(e)  # ... gradient must be accumulated into a ref ... `with_refs` ..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c534d830",
+   "metadata": {},
+   "source": [
+    "The gradient is accumulated into the bound ref via `+=`, added to whatever\n",
+    "the ref already contains rather than overwriting it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29ab786e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_grad_ref = jax.new_ref(100.)\n",
+    "_, f_vjp = jax.vjp(f, jax.new_ref(2.))\n",
+    "f_vjp.with_refs(x_grad_ref)(1.0)\n",
+    "print(x_grad_ref)  # Ref(104.), i.e. 100. + 4.: accumulated, not set"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ab05826",
+   "metadata": {},
+   "source": [
+    "Accumulating rather than setting might seem like an odd choice, but it means\n",
+    "one gradient ref can collect contributions from several backward passes with\n",
+    "no extra memory traffic, as in the examples below.\n",
+    "\n",
+    "In-place updates to the ref argument inside the differentiated function are\n",
+    "differentiated too. The result is the gradient with respect to the ref's\n",
+    "initial value:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f655d2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def g(x_ref):\n",
+    "  x_ref[...] = jnp.sin(x_ref[...])\n",
+    "  return x_ref[...] ** 2\n",
+    "\n",
+    "x_ref = jax.new_ref(2.)\n",
+    "_, g_vjp = jax.vjp(g, x_ref)  # runs g, so x_ref is updated in-place here\n",
+    "g_grad_ref = jax.new_ref(0.)\n",
+    "g_vjp.with_refs(g_grad_ref)(1.0)\n",
+    "print(g_grad_ref)  # Ref(-0.757), i.e. 2*sin(2)*cos(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e62f6475",
+   "metadata": {},
+   "source": [
+    "#### Gradient refs for value arguments\n",
+    "\n",
+    "When differentiating with respect to an ordinary `Array` argument,\n",
+    "`with_refs` is optional: we can call the VJP function directly and get the\n",
+    "gradient back as a value in the usual way, or we can bind a ref and have the\n",
+    "gradient accumulated into it in-place:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9222b5fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_, sin_vjp = jax.vjp(jnp.sin, 1.0)\n",
+    "x_bar, = sin_vjp(1.0)  # the usual way: gradient returned as a value\n",
+    "print(x_bar)  # 0.54\n",
+    "\n",
+    "grad_ref = jax.new_ref(0.)\n",
+    "_, sin_vjp = jax.vjp(jnp.sin, 1.0)\n",
+    "sin_vjp.with_refs(grad_ref)(1.0)  # gradient accumulated into grad_ref\n",
+    "print(grad_ref)  # Ref(0.54)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd77fa5a",
+   "metadata": {},
+   "source": [
+    "We can mix and match. Each entry of `with_refs` can be:\n",
+    "\n",
+    "* a `Ref`, meaning accumulate this argument's gradient into the ref in-place\n",
+    "  (the VJP call then returns a `jax.ad.GradRef()` placeholder in that\n",
+    "  position);\n",
+    "* `jax.ad.GradValue()`, meaning return this argument's gradient as a value in\n",
+    "  the usual way (the default); or\n",
+    "* `jax.ad.DontWant()`, meaning don't compute this argument's gradient at all\n",
+    "  (the VJP call returns a `jax.ad.DidntWant()` placeholder in that position —\n",
+    "  more on this below).\n",
+    "\n",
+    "One reason to use a gradient ref here is to exploit sparsity. Consider\n",
+    "differentiating a function that slices its input:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f37de8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@jax.jit\n",
+    "def take(x, i):\n",
+    "  return x[i]\n",
+    "\n",
+    "x = jnp.arange(10.)\n",
+    "\n",
+    "_, take_vjp = jax.vjp(take, x, 3)\n",
+    "x_bar, _ = take_vjp(1.0)\n",
+    "print(x_bar)  # [0., 0., 0., 1., 0., 0., 0., 0., 0., 0.]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f36de718",
+   "metadata": {},
+   "source": [
+    "The gradient with respect to `x` is one-hot: the backward pass materializes a\n",
+    "dense array of zeros and sets a single element of it. If we compute many such\n",
+    "gradients and sum them, say over a loop of sparse accesses, we pay for a\n",
+    "dense array's worth of memory traffic on each one, even though each\n",
+    "contribution only touches one element.\n",
+    "\n",
+    "If we instead bind a gradient ref with `with_refs`, each backward pass\n",
+    "performs a sparse in-place add-update, writing only where it needs to:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a3cdd3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grad_ref = jax.new_ref(jnp.zeros(10))\n",
+    "\n",
+    "for i in [3, 5, 3]:\n",
+    "  _, take_vjp = jax.vjp(take, x, i)\n",
+    "  take_vjp.with_refs(grad_ref, jax.ad.GradValue())(1.0)  # no gradient ref for i\n",
+    "\n",
+    "print(grad_ref)  # Ref([0., 0., 0., 2., 0., 1., 0., 0., 0., 0.])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb594427",
+   "metadata": {},
+   "source": [
+    "We can check that the update is sparse by inspecting the jaxpr of a single\n",
+    "VJP application:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0c12467",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@jax.make_jaxpr\n",
+    "def take_vjp_jaxpr():\n",
+    "  _, take_vjp = jax.vjp(take, x, 3)\n",
+    "  take_vjp.with_refs(grad_ref, jax.ad.GradValue())(1.0)\n",
+    "\n",
+    "print(take_vjp_jaxpr())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5ba9756",
+   "metadata": {},
+   "source": [
+    "The backward pass boils down to `b[c:c+1] += j`, an in-place add-update of\n",
+    "one element of the gradient ref, with no dense one-hot array in sight.\n",
+    "\n",
+    "#### `DontWant`: skipping unneeded gradients\n",
+    "\n",
+    "The VJP function returned by `jax.vjp` computes gradients for all the\n",
+    "arguments of the differentiated function. But sometimes we don't need all of\n",
+    "them, like when differentiating with respect to parameters but not data.\n",
+    "Passing `jax.ad.DontWant()` for an argument tells the backward pass not to\n",
+    "compute its gradient at all, playing the same role for `jax.vjp` that\n",
+    "`argnums` plays for `jax.grad`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83e5c240",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def predict(W, x):\n",
+    "  return W @ x\n",
+    "\n",
+    "W = jnp.ones((4, 4))\n",
+    "x = jnp.ones(4)\n",
+    "\n",
+    "_, f_vjp = jax.vjp(predict, W, x)\n",
+    "W_bar, x_bar = f_vjp.with_refs(jax.ad.GradValue(), jax.ad.DontWant())(jnp.ones(4))\n",
+    "print(W_bar[0])  # [1., 1., 1., 1.]\n",
+    "print(x_bar)  # DidntWant()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7debced6",
+   "metadata": {},
+   "source": [
+    "This is more than a convenience: it can save real work in the backward pass,\n",
+    "like an eager form of dead code elimination. Transpose rules can check for\n",
+    "`DontWant` and skip computing the corresponding cotangents. For example, the\n",
+    "transpose of matrix multiplication usually computes two dot products, one for\n",
+    "each operand's gradient, but with `DontWant` it computes only one. We can see\n",
+    "that by counting the `dot_general` operations in the jaxpr of each VJP\n",
+    "application:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43b2d76d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_, f_vjp = jax.vjp(predict, W, x)\n",
+    "both = jax.make_jaxpr(lambda: f_vjp(jnp.ones(4)))()\n",
+    "only_W = jax.make_jaxpr(\n",
+    "    lambda: f_vjp.with_refs(jax.ad.GradValue(), jax.ad.DontWant())(jnp.ones(4)))()\n",
+    "\n",
+    "print(str(both).count('dot_general'))    # 2, one dot for each gradient\n",
+    "print(str(only_W).count('dot_general'))  # 1, the dot for x_bar is skipped"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4fbfdd1",
+   "metadata": {},
+   "source": [
+    "#### Example: gradient accumulation over microbatches\n",
+    "\n",
+    "Here's a more realistic recipe that puts these pieces together. In pipelined\n",
+    "training, we often split a batch into microbatches, run a forward and\n",
+    "backward pass one microbatch at a time, and accumulate weight gradients as we\n",
+    "go. Using `with_refs`, each microbatch's backward pass accumulates directly\n",
+    "into a single fixed gradient buffer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a6e48eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NUM_LAYERS = 3\n",
+    "NUM_MUBATCHES = 5\n",
+    "MUBATCH_SIZE = 7\n",
+    "\n",
+    "def mubatch_loss(Ws, xs):\n",
+    "  # inner loop over layers\n",
+    "  act, _ = jax.lax.scan(lambda x, W: (jnp.dot(x, W), None), xs, Ws)\n",
+    "  return jnp.mean(act)\n",
+    "\n",
+    "def process_batch(Ws, xs_batch):\n",
+    "  grad_acc = jax.new_ref(jnp.zeros_like(Ws))\n",
+    "\n",
+    "  def process_mubatch(_, xs):\n",
+    "    loss, f_vjp = jax.vjp(lambda Ws: mubatch_loss(Ws, xs), Ws)\n",
+    "    f_vjp.with_refs(grad_acc)(jnp.ones_like(loss))  # accumulate in-place\n",
+    "    return (), loss\n",
+    "\n",
+    "  xs_mubatches = xs_batch.reshape(NUM_MUBATCHES, MUBATCH_SIZE, -1)\n",
+    "  # outer loop over microbatches\n",
+    "  (), losses = jax.lax.scan(process_mubatch, (), xs_mubatches)\n",
+    "  return jax.freeze(grad_acc), losses\n",
+    "\n",
+    "Ws = jnp.ones((NUM_LAYERS, 4, 4))\n",
+    "xs_batch = jnp.ones((NUM_MUBATCHES * MUBATCH_SIZE, 4))\n",
+    "grads, losses = process_batch(Ws, xs_batch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc942b91",
+   "metadata": {},
+   "source": [
+    "Each iteration of the outer scan runs a forward and backward pass for one\n",
+    "microbatch, and `with_refs(grad_acc)` makes the backward pass add that\n",
+    "microbatch's gradient contribution directly into `grad_acc`. Note that the\n",
+    "scan body closes over `grad_acc`, which is fine for `scan` (though it\n",
+    "wouldn't be for `vmap` or `shard_map`, as discussed above). Once all the\n",
+    "microbatches are processed, we `freeze` the accumulator to get the total\n",
+    "batch gradient as an immutable `Array`.\n",
+    "\n",
+    "The result matches what we'd get by differentiating the summed loss directly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cbf90816",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs_mubatches = xs_batch.reshape(NUM_MUBATCHES, MUBATCH_SIZE, -1)\n",
+    "grads_expected = jax.grad(\n",
+    "    lambda Ws: sum(mubatch_loss(Ws, xs) for xs in xs_mubatches))(Ws)\n",
+    "print(jnp.allclose(grads, grads_expected, atol=1e-3, rtol=1e-3))  # True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26772f3e",
+   "metadata": {},
+   "source": [
+    "But unlike that version, the ref-based version never materializes\n",
+    "per-microbatch gradients as separate arrays: there's one gradient buffer,\n",
+    "allocated once, no matter how many microbatches we process.\n",
     "\n",
     "### `Ref`s and performance\n",
     "\n",

--- a/docs/array_refs.md
+++ b/docs/array_refs.md
@@ -304,11 +304,15 @@ def pure2(x):
   ref[...] = ref[...] + ref[...]
   return ref[...]
 
-print(jax.grad(pure1)(3.0))  # 2.0
+print(jax.grad(pure2)(3.0))  # 2.0
 ```
 
-Autodiff can also be applied to functions that take array refs as arguments, if
-those arguments are only used for plumbing and not involved in differentiation:
+Autodiff can also be applied to functions that take array refs as arguments.
+The simplest case is when those ref arguments are only used for plumbing, and
+aren't involved in differentiation. For example, `jax.grad` differentiates
+with respect to its function's first argument by default, so ref arguments in
+other positions are just along for the ride. Only non-differentiated values
+can be written into such plumbing refs:
 
 ```{code-cell}
 # error
@@ -323,6 +327,11 @@ def foo(x, some_plumbing_ref):
   some_plumbing_ref[...] += jax.lax.stop_gradient(y)
   return y
 ```
+
+Differentiating _with respect to_ a ref-typed argument is another matter:
+pointing `jax.grad` at one (e.g. via `argnums`) is an error, since the
+gradient for a ref must itself live in a ref. Instead, use `jax.vjp` and
+`with_refs`, described below.
 
 You can combine plumbing refs with `custom_vjp` to plumb data out of the
 backward pass of a differentiated function:
@@ -348,19 +357,259 @@ stash_grads.defvjp(stash_grads_fwd, stash_grads_bwd)
 # Now, use `stash_grads` to stash intermediate gradients:
 
 def f(x, grads_ref):
-  x = jnp.sin(x)
   x = stash_grads(grads_ref, x)
+  x = jnp.sin(x)
   return x
 
 grads_ref = jax.new_ref(0.)
-f(1., grads_ref)
-print(grads_ref)
+jax.grad(f)(1., grads_ref)
+print(grads_ref)  # Ref(0.54), the gradient at the stash point: cos(1.)
 ```
 
 Notice `stash_grads_fwd` is returning a `Ref` here. That's a special
 allowance for `custom_vjp` fwd rules: it's really syntax for indicating which
 ref arguments should be shared by both the fwd and bwd rules. So any refs
 returned by a fwd rule must be arguments to that fwd rule.
+
+#### Differentiating with respect to `Ref` arguments
+
+The plumbing refs above are just passengers: they carry data out of the
+computation, but no gradients flow through them. We can also differentiate
+_with respect to_ a ref argument. Since the gradient for a `Ref`-typed input
+is itself `Ref`-typed, `jax.grad` doesn't apply here. Instead we use
+`jax.vjp`, and bind a gradient ref to the VJP function using its `with_refs`
+method:
+
+```{code-cell}
+def f(x_ref):
+  return x_ref[...] ** 2
+
+x_ref = jax.new_ref(2.)
+y, f_vjp = jax.vjp(f, x_ref)
+
+x_grad_ref = jax.new_ref(0.)
+f_vjp.with_refs(x_grad_ref)(1.0)  # bind the gradient ref, then apply the VJP
+print(x_grad_ref)  # Ref(4.)
+```
+
+Here `with_refs` takes one entry per argument of the differentiated function
+and returns a new VJP function with those gradient refs bound. When
+differentiating with respect to a ref argument, using `with_refs` is
+mandatory; the gradient needs a ref to be accumulated into, so calling the
+VJP function without binding one is an error:
+
+```{code-cell}
+_, f_vjp = jax.vjp(f, jax.new_ref(2.))
+try:
+  f_vjp(1.0)  # error! no ref bound for the ref-typed argument's gradient
+except Exception as e:
+  print(e)  # ... gradient must be accumulated into a ref ... `with_refs` ...
+```
+
+The gradient is accumulated into the bound ref via `+=`, added to whatever
+the ref already contains rather than overwriting it:
+
+```{code-cell}
+x_grad_ref = jax.new_ref(100.)
+_, f_vjp = jax.vjp(f, jax.new_ref(2.))
+f_vjp.with_refs(x_grad_ref)(1.0)
+print(x_grad_ref)  # Ref(104.), i.e. 100. + 4.: accumulated, not set
+```
+
+Accumulating rather than setting might seem like an odd choice, but it means
+one gradient ref can collect contributions from several backward passes with
+no extra memory traffic, as in the examples below.
+
+In-place updates to the ref argument inside the differentiated function are
+differentiated too. The result is the gradient with respect to the ref's
+initial value:
+
+```{code-cell}
+def g(x_ref):
+  x_ref[...] = jnp.sin(x_ref[...])
+  return x_ref[...] ** 2
+
+x_ref = jax.new_ref(2.)
+_, g_vjp = jax.vjp(g, x_ref)  # runs g, so x_ref is updated in-place here
+g_grad_ref = jax.new_ref(0.)
+g_vjp.with_refs(g_grad_ref)(1.0)
+print(g_grad_ref)  # Ref(-0.757), i.e. 2*sin(2)*cos(2)
+```
+
+#### Gradient refs for value arguments
+
+When differentiating with respect to an ordinary `Array` argument,
+`with_refs` is optional: we can call the VJP function directly and get the
+gradient back as a value in the usual way, or we can bind a ref and have the
+gradient accumulated into it in-place:
+
+```{code-cell}
+_, sin_vjp = jax.vjp(jnp.sin, 1.0)
+x_bar, = sin_vjp(1.0)  # the usual way: gradient returned as a value
+print(x_bar)  # 0.54
+
+grad_ref = jax.new_ref(0.)
+_, sin_vjp = jax.vjp(jnp.sin, 1.0)
+sin_vjp.with_refs(grad_ref)(1.0)  # gradient accumulated into grad_ref
+print(grad_ref)  # Ref(0.54)
+```
+
+We can mix and match. Each entry of `with_refs` can be:
+
+* a `Ref`, meaning accumulate this argument's gradient into the ref in-place
+  (the VJP call then returns a `jax.ad.GradRef()` placeholder in that
+  position);
+* `jax.ad.GradValue()`, meaning return this argument's gradient as a value in
+  the usual way (the default); or
+* `jax.ad.DontWant()`, meaning don't compute this argument's gradient at all
+  (the VJP call returns a `jax.ad.DidntWant()` placeholder in that position —
+  more on this below).
+
+One reason to use a gradient ref here is to exploit sparsity. Consider
+differentiating a function that slices its input:
+
+```{code-cell}
+@jax.jit
+def take(x, i):
+  return x[i]
+
+x = jnp.arange(10.)
+
+_, take_vjp = jax.vjp(take, x, 3)
+x_bar, _ = take_vjp(1.0)
+print(x_bar)  # [0., 0., 0., 1., 0., 0., 0., 0., 0., 0.]
+```
+
+The gradient with respect to `x` is one-hot: the backward pass materializes a
+dense array of zeros and sets a single element of it. If we compute many such
+gradients and sum them, say over a loop of sparse accesses, we pay for a
+dense array's worth of memory traffic on each one, even though each
+contribution only touches one element.
+
+If we instead bind a gradient ref with `with_refs`, each backward pass
+performs a sparse in-place add-update, writing only where it needs to:
+
+```{code-cell}
+grad_ref = jax.new_ref(jnp.zeros(10))
+
+for i in [3, 5, 3]:
+  _, take_vjp = jax.vjp(take, x, i)
+  take_vjp.with_refs(grad_ref, jax.ad.GradValue())(1.0)  # no gradient ref for i
+
+print(grad_ref)  # Ref([0., 0., 0., 2., 0., 1., 0., 0., 0., 0.])
+```
+
+We can check that the update is sparse by inspecting the jaxpr of a single
+VJP application:
+
+```{code-cell}
+@jax.make_jaxpr
+def take_vjp_jaxpr():
+  _, take_vjp = jax.vjp(take, x, 3)
+  take_vjp.with_refs(grad_ref, jax.ad.GradValue())(1.0)
+
+print(take_vjp_jaxpr())
+```
+
+The backward pass boils down to `b[c:c+1] += j`, an in-place add-update of
+one element of the gradient ref, with no dense one-hot array in sight.
+
+#### `DontWant`: skipping unneeded gradients
+
+The VJP function returned by `jax.vjp` computes gradients for all the
+arguments of the differentiated function. But sometimes we don't need all of
+them, like when differentiating with respect to parameters but not data.
+Passing `jax.ad.DontWant()` for an argument tells the backward pass not to
+compute its gradient at all, playing the same role for `jax.vjp` that
+`argnums` plays for `jax.grad`:
+
+```{code-cell}
+def predict(W, x):
+  return W @ x
+
+W = jnp.ones((4, 4))
+x = jnp.ones(4)
+
+_, f_vjp = jax.vjp(predict, W, x)
+W_bar, x_bar = f_vjp.with_refs(jax.ad.GradValue(), jax.ad.DontWant())(jnp.ones(4))
+print(W_bar[0])  # [1., 1., 1., 1.]
+print(x_bar)  # DidntWant()
+```
+
+This is more than a convenience: it can save real work in the backward pass,
+like an eager form of dead code elimination. Transpose rules can check for
+`DontWant` and skip computing the corresponding cotangents. For example, the
+transpose of matrix multiplication usually computes two dot products, one for
+each operand's gradient, but with `DontWant` it computes only one. We can see
+that by counting the `dot_general` operations in the jaxpr of each VJP
+application:
+
+```{code-cell}
+_, f_vjp = jax.vjp(predict, W, x)
+both = jax.make_jaxpr(lambda: f_vjp(jnp.ones(4)))()
+only_W = jax.make_jaxpr(
+    lambda: f_vjp.with_refs(jax.ad.GradValue(), jax.ad.DontWant())(jnp.ones(4)))()
+
+print(str(both).count('dot_general'))    # 2, one dot for each gradient
+print(str(only_W).count('dot_general'))  # 1, the dot for x_bar is skipped
+```
+
+#### Example: gradient accumulation over microbatches
+
+Here's a more realistic recipe that puts these pieces together. In pipelined
+training, we often split a batch into microbatches, run a forward and
+backward pass one microbatch at a time, and accumulate weight gradients as we
+go. Using `with_refs`, each microbatch's backward pass accumulates directly
+into a single fixed gradient buffer:
+
+```{code-cell}
+NUM_LAYERS = 3
+NUM_MUBATCHES = 5
+MUBATCH_SIZE = 7
+
+def mubatch_loss(Ws, xs):
+  # inner loop over layers
+  act, _ = jax.lax.scan(lambda x, W: (jnp.dot(x, W), None), xs, Ws)
+  return jnp.mean(act)
+
+def process_batch(Ws, xs_batch):
+  grad_acc = jax.new_ref(jnp.zeros_like(Ws))
+
+  def process_mubatch(_, xs):
+    loss, f_vjp = jax.vjp(lambda Ws: mubatch_loss(Ws, xs), Ws)
+    f_vjp.with_refs(grad_acc)(jnp.ones_like(loss))  # accumulate in-place
+    return (), loss
+
+  xs_mubatches = xs_batch.reshape(NUM_MUBATCHES, MUBATCH_SIZE, -1)
+  # outer loop over microbatches
+  (), losses = jax.lax.scan(process_mubatch, (), xs_mubatches)
+  return jax.freeze(grad_acc), losses
+
+Ws = jnp.ones((NUM_LAYERS, 4, 4))
+xs_batch = jnp.ones((NUM_MUBATCHES * MUBATCH_SIZE, 4))
+grads, losses = process_batch(Ws, xs_batch)
+```
+
+Each iteration of the outer scan runs a forward and backward pass for one
+microbatch, and `with_refs(grad_acc)` makes the backward pass add that
+microbatch's gradient contribution directly into `grad_acc`. Note that the
+scan body closes over `grad_acc`, which is fine for `scan` (though it
+wouldn't be for `vmap` or `shard_map`, as discussed above). Once all the
+microbatches are processed, we `freeze` the accumulator to get the total
+batch gradient as an immutable `Array`.
+
+The result matches what we'd get by differentiating the summed loss directly:
+
+```{code-cell}
+xs_mubatches = xs_batch.reshape(NUM_MUBATCHES, MUBATCH_SIZE, -1)
+grads_expected = jax.grad(
+    lambda Ws: sum(mubatch_loss(Ws, xs) for xs in xs_mubatches))(Ws)
+print(jnp.allclose(grads, grads_expected, atol=1e-3, rtol=1e-3))  # True
+```
+
+But unlike that version, the ref-based version never materializes
+per-microbatch gradients as separate arrays: there's one gradient buffer,
+allocated once, no matter how many microbatches we process.
 
 ### `Ref`s and performance
 

--- a/docs/array_refs.py
+++ b/docs/array_refs.py
@@ -307,13 +307,17 @@ def pure2(x):
   ref[...] = ref[...] + ref[...]
   return ref[...]
 
-print(jax.grad(pure1)(3.0))  # 2.0
+print(jax.grad(pure2)(3.0))  # 2.0
 
 
 # -
 
-# Autodiff can also be applied to functions that take array refs as arguments, if
-# those arguments are only used for plumbing and not involved in differentiation:
+# Autodiff can also be applied to functions that take array refs as arguments.
+# The simplest case is when those ref arguments are only used for plumbing, and
+# aren't involved in differentiation. For example, `jax.grad` differentiates
+# with respect to its function's first argument by default, so ref arguments in
+# other positions are just along for the ride. Only non-differentiated values
+# can be written into such plumbing refs:
 
 # +
 # error
@@ -331,6 +335,11 @@ def foo(x, some_plumbing_ref):
 
 # -
 
+# Differentiating _with respect to_ a ref-typed argument is another matter:
+# pointing `jax.grad` at one (e.g. via `argnums`) is an error, since the
+# gradient for a ref must itself live in a ref. Instead, use `jax.vjp` and
+# `with_refs`, described below.
+#
 # You can combine plumbing refs with `custom_vjp` to plumb data out of the
 # backward pass of a differentiated function:
 
@@ -355,13 +364,13 @@ stash_grads.defvjp(stash_grads_fwd, stash_grads_bwd)
 # Now, use `stash_grads` to stash intermediate gradients:
 
 def f(x, grads_ref):
-  x = jnp.sin(x)
   x = stash_grads(grads_ref, x)
+  x = jnp.sin(x)
   return x
 
 grads_ref = jax.new_ref(0.)
-f(1., grads_ref)
-print(grads_ref)
+jax.grad(f)(1., grads_ref)
+print(grads_ref)  # Ref(0.54), the gradient at the stash point: cos(1.)
 
 
 # -
@@ -370,6 +379,248 @@ print(grads_ref)
 # allowance for `custom_vjp` fwd rules: it's really syntax for indicating which
 # ref arguments should be shared by both the fwd and bwd rules. So any refs
 # returned by a fwd rule must be arguments to that fwd rule.
+#
+# #### Differentiating with respect to `Ref` arguments
+#
+# The plumbing refs above are just passengers: they carry data out of the
+# computation, but no gradients flow through them. We can also differentiate
+# _with respect to_ a ref argument. Since the gradient for a `Ref`-typed input
+# is itself `Ref`-typed, `jax.grad` doesn't apply here. Instead we use
+# `jax.vjp`, and bind a gradient ref to the VJP function using its `with_refs`
+# method:
+
+# +
+def f(x_ref):
+  return x_ref[...] ** 2
+
+x_ref = jax.new_ref(2.)
+y, f_vjp = jax.vjp(f, x_ref)
+
+x_grad_ref = jax.new_ref(0.)
+f_vjp.with_refs(x_grad_ref)(1.0)  # bind the gradient ref, then apply the VJP
+print(x_grad_ref)  # Ref(4.)
+# -
+
+# Here `with_refs` takes one entry per argument of the differentiated function
+# and returns a new VJP function with those gradient refs bound. When
+# differentiating with respect to a ref argument, using `with_refs` is
+# mandatory; the gradient needs a ref to be accumulated into, so calling the
+# VJP function without binding one is an error:
+
+_, f_vjp = jax.vjp(f, jax.new_ref(2.))
+try:
+  f_vjp(1.0)  # error! no ref bound for the ref-typed argument's gradient
+except Exception as e:
+  print(e)  # ... gradient must be accumulated into a ref ... `with_refs` ...
+
+# The gradient is accumulated into the bound ref via `+=`, added to whatever
+# the ref already contains rather than overwriting it:
+
+x_grad_ref = jax.new_ref(100.)
+_, f_vjp = jax.vjp(f, jax.new_ref(2.))
+f_vjp.with_refs(x_grad_ref)(1.0)
+print(x_grad_ref)  # Ref(104.), i.e. 100. + 4.: accumulated, not set
+
+
+# Accumulating rather than setting might seem like an odd choice, but it means
+# one gradient ref can collect contributions from several backward passes with
+# no extra memory traffic, as in the examples below.
+#
+# In-place updates to the ref argument inside the differentiated function are
+# differentiated too. The result is the gradient with respect to the ref's
+# initial value:
+
+# +
+def g(x_ref):
+  x_ref[...] = jnp.sin(x_ref[...])
+  return x_ref[...] ** 2
+
+x_ref = jax.new_ref(2.)
+_, g_vjp = jax.vjp(g, x_ref)  # runs g, so x_ref is updated in-place here
+g_grad_ref = jax.new_ref(0.)
+g_vjp.with_refs(g_grad_ref)(1.0)
+print(g_grad_ref)  # Ref(-0.757), i.e. 2*sin(2)*cos(2)
+# -
+
+# #### Gradient refs for value arguments
+#
+# When differentiating with respect to an ordinary `Array` argument,
+# `with_refs` is optional: we can call the VJP function directly and get the
+# gradient back as a value in the usual way, or we can bind a ref and have the
+# gradient accumulated into it in-place:
+
+# +
+_, sin_vjp = jax.vjp(jnp.sin, 1.0)
+x_bar, = sin_vjp(1.0)  # the usual way: gradient returned as a value
+print(x_bar)  # 0.54
+
+grad_ref = jax.new_ref(0.)
+_, sin_vjp = jax.vjp(jnp.sin, 1.0)
+sin_vjp.with_refs(grad_ref)(1.0)  # gradient accumulated into grad_ref
+print(grad_ref)  # Ref(0.54)
+
+
+# -
+
+# We can mix and match. Each entry of `with_refs` can be:
+#
+# * a `Ref`, meaning accumulate this argument's gradient into the ref in-place
+#   (the VJP call then returns a `jax.ad.GradRef()` placeholder in that
+#   position);
+# * `jax.ad.GradValue()`, meaning return this argument's gradient as a value in
+#   the usual way (the default); or
+# * `jax.ad.DontWant()`, meaning don't compute this argument's gradient at all
+#   (the VJP call returns a `jax.ad.DidntWant()` placeholder in that position —
+#   more on this below).
+#
+# One reason to use a gradient ref here is to exploit sparsity. Consider
+# differentiating a function that slices its input:
+
+# +
+@jax.jit
+def take(x, i):
+  return x[i]
+
+x = jnp.arange(10.)
+
+_, take_vjp = jax.vjp(take, x, 3)
+x_bar, _ = take_vjp(1.0)
+print(x_bar)  # [0., 0., 0., 1., 0., 0., 0., 0., 0., 0.]
+# -
+
+# The gradient with respect to `x` is one-hot: the backward pass materializes a
+# dense array of zeros and sets a single element of it. If we compute many such
+# gradients and sum them, say over a loop of sparse accesses, we pay for a
+# dense array's worth of memory traffic on each one, even though each
+# contribution only touches one element.
+#
+# If we instead bind a gradient ref with `with_refs`, each backward pass
+# performs a sparse in-place add-update, writing only where it needs to:
+
+# +
+grad_ref = jax.new_ref(jnp.zeros(10))
+
+for i in [3, 5, 3]:
+  _, take_vjp = jax.vjp(take, x, i)
+  take_vjp.with_refs(grad_ref, jax.ad.GradValue())(1.0)  # no gradient ref for i
+
+print(grad_ref)  # Ref([0., 0., 0., 2., 0., 1., 0., 0., 0., 0.])
+
+
+# -
+
+# We can check that the update is sparse by inspecting the jaxpr of a single
+# VJP application:
+
+# +
+@jax.make_jaxpr
+def take_vjp_jaxpr():
+  _, take_vjp = jax.vjp(take, x, 3)
+  take_vjp.with_refs(grad_ref, jax.ad.GradValue())(1.0)
+
+print(take_vjp_jaxpr())
+
+
+# -
+
+# The backward pass boils down to `b[c:c+1] += j`, an in-place add-update of
+# one element of the gradient ref, with no dense one-hot array in sight.
+#
+# #### `DontWant`: skipping unneeded gradients
+#
+# The VJP function returned by `jax.vjp` computes gradients for all the
+# arguments of the differentiated function. But sometimes we don't need all of
+# them, like when differentiating with respect to parameters but not data.
+# Passing `jax.ad.DontWant()` for an argument tells the backward pass not to
+# compute its gradient at all, playing the same role for `jax.vjp` that
+# `argnums` plays for `jax.grad`:
+
+# +
+def predict(W, x):
+  return W @ x
+
+W = jnp.ones((4, 4))
+x = jnp.ones(4)
+
+_, f_vjp = jax.vjp(predict, W, x)
+W_bar, x_bar = f_vjp.with_refs(jax.ad.GradValue(), jax.ad.DontWant())(jnp.ones(4))
+print(W_bar[0])  # [1., 1., 1., 1.]
+print(x_bar)  # DidntWant()
+# -
+
+# This is more than a convenience: it can save real work in the backward pass,
+# like an eager form of dead code elimination. Transpose rules can check for
+# `DontWant` and skip computing the corresponding cotangents. For example, the
+# transpose of matrix multiplication usually computes two dot products, one for
+# each operand's gradient, but with `DontWant` it computes only one. We can see
+# that by counting the `dot_general` operations in the jaxpr of each VJP
+# application:
+
+# +
+_, f_vjp = jax.vjp(predict, W, x)
+both = jax.make_jaxpr(lambda: f_vjp(jnp.ones(4)))()
+only_W = jax.make_jaxpr(
+    lambda: f_vjp.with_refs(jax.ad.GradValue(), jax.ad.DontWant())(jnp.ones(4)))()
+
+print(str(both).count('dot_general'))    # 2, one dot for each gradient
+print(str(only_W).count('dot_general'))  # 1, the dot for x_bar is skipped
+# -
+
+# #### Example: gradient accumulation over microbatches
+#
+# Here's a more realistic recipe that puts these pieces together. In pipelined
+# training, we often split a batch into microbatches, run a forward and
+# backward pass one microbatch at a time, and accumulate weight gradients as we
+# go. Using `with_refs`, each microbatch's backward pass accumulates directly
+# into a single fixed gradient buffer:
+
+# +
+NUM_LAYERS = 3
+NUM_MUBATCHES = 5
+MUBATCH_SIZE = 7
+
+def mubatch_loss(Ws, xs):
+  # inner loop over layers
+  act, _ = jax.lax.scan(lambda x, W: (jnp.dot(x, W), None), xs, Ws)
+  return jnp.mean(act)
+
+def process_batch(Ws, xs_batch):
+  grad_acc = jax.new_ref(jnp.zeros_like(Ws))
+
+  def process_mubatch(_, xs):
+    loss, f_vjp = jax.vjp(lambda Ws: mubatch_loss(Ws, xs), Ws)
+    f_vjp.with_refs(grad_acc)(jnp.ones_like(loss))  # accumulate in-place
+    return (), loss
+
+  xs_mubatches = xs_batch.reshape(NUM_MUBATCHES, MUBATCH_SIZE, -1)
+  # outer loop over microbatches
+  (), losses = jax.lax.scan(process_mubatch, (), xs_mubatches)
+  return jax.freeze(grad_acc), losses
+
+Ws = jnp.ones((NUM_LAYERS, 4, 4))
+xs_batch = jnp.ones((NUM_MUBATCHES * MUBATCH_SIZE, 4))
+grads, losses = process_batch(Ws, xs_batch)
+# -
+
+# Each iteration of the outer scan runs a forward and backward pass for one
+# microbatch, and `with_refs(grad_acc)` makes the backward pass add that
+# microbatch's gradient contribution directly into `grad_acc`. Note that the
+# scan body closes over `grad_acc`, which is fine for `scan` (though it
+# wouldn't be for `vmap` or `shard_map`, as discussed above). Once all the
+# microbatches are processed, we `freeze` the accumulator to get the total
+# batch gradient as an immutable `Array`.
+#
+# The result matches what we'd get by differentiating the summed loss directly:
+
+xs_mubatches = xs_batch.reshape(NUM_MUBATCHES, MUBATCH_SIZE, -1)
+grads_expected = jax.grad(
+    lambda Ws: sum(mubatch_loss(Ws, xs) for xs in xs_mubatches))(Ws)
+print(jnp.allclose(grads, grads_expected, atol=1e-3, rtol=1e-3))  # True
+
+
+# But unlike that version, the ref-based version never materializes
+# per-microbatch gradients as separate arrays: there's one gradient buffer,
+# allocated once, no matter how many microbatches we process.
 #
 # ### `Ref`s and performance
 #

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -569,6 +569,14 @@ def _check_scalar(x):
 def _check_input_dtype_revderiv(name, holomorphic, allow_int, x):
   dispatch.check_arg(x)
   aval = core.typeof(x)
+  if _is_ref_aval(aval):
+    raise TypeError(
+        f"{name} cannot differentiate with respect to a Ref-typed argument, "
+        "because the gradient for a ref must itself be accumulated into a "
+        "ref. Instead, use `jax.vjp` and bind a gradient ref using the "
+        "returned VJP function's `with_refs` method. (Ref arguments not "
+        f"selected by {name}'s argnums are fine: they are treated as "
+        "plumbing, and are not differentiated.)")
   if holomorphic:
     if not dtypes.issubdtype(aval.dtype, np.complexfloating):
       raise TypeError(f"{name} with holomorphic=True requires inputs with complex dtype, "
@@ -1632,21 +1640,88 @@ def vjp(
 
 def _vjp3_callable(spec, out_known, jaxpr, out_primal_avals, in_tree, out_tree,
                    args_res, opaque_res, *maybe_ct_refs):
-  if not maybe_ct_refs:
-    maybe_ct_refs_flat = [GradValue()] * in_tree.num_leaves
-  else:
+  explicit_refs = bool(maybe_ct_refs)
+  if explicit_refs:
     maybe_ct_refs_flat, in_tree_ = tree_flatten(maybe_ct_refs)
     if in_tree != in_tree_:
-      raise Exception  # TODO accept isomorph tuple tree
+      _vjp_with_refs_tree_error(jaxpr, in_tree, in_tree_)
+  else:
+    maybe_ct_refs_flat = [GradValue()] * in_tree.num_leaves
   args_res_ = tree_leaves(args_res, is_leaf=lambda x: isinstance(x, NotNeeded))
   residuals = [args_res_[i.idx] if i.primal else opaque_res[i.idx] for i in spec]
-  maybe_accums = [check_accum(v.aval.to_ct_aval(), x) if isinstance(x, ad.GradAccum) else
-                  ad.RefAccum(_ref_aval(v.aval).to_ct_aval(), x) if _is_ref(x) else
-                  ad.NullAccum(v.aval.to_ct_aval()) if isinstance(x, DontWant) else
-                  ad.ValAccum(v.aval.to_ct_aval())
-                  for v, x in zip(jaxpr.invars, maybe_ct_refs_flat)]
+  maybe_accums = [_vjp_accum(jaxpr, in_tree, explicit_refs, idx, v, x)
+                  for idx, (v, x) in enumerate(zip(jaxpr.invars, maybe_ct_refs_flat))]
   return Partial(partial(_vjp3_bwd, in_tree, out_tree, out_known, jaxpr,
                          out_primal_avals), residuals, maybe_accums)
+
+def _vjp_accum(jaxpr, in_tree, explicit_refs, idx, v, x):
+  if isinstance(x, ad.GradAccum):
+    return check_accum(v.aval.to_ct_aval(), x)
+  elif _is_ref(x):
+    expected_aval = _ref_aval(v.aval).to_ct_aval()
+    given_aval = _ref_aval(typeof(x))
+    if (not core.typecompat(expected_aval, given_aval) and
+        not _temporary_dtype_exception(given_aval, expected_aval)):
+      raise ValueError(
+          "unexpected JAX type (e.g. shape/dtype) for gradient ref passed to "
+          f"the VJP function's `with_refs` method for "
+          f"{_vjp_arg_name(jaxpr, in_tree, idx)}: the given ref has type "
+          f"{typeof(x).str_short()}, but accumulating this argument's "
+          f"gradient requires a ref of type Ref{{{expected_aval.str_short()}}}")
+    return ad.RefAccum(expected_aval, x)
+  elif isinstance(x, DontWant):
+    return ad.NullAccum(v.aval.to_ct_aval())
+  elif _is_ref_aval(v.aval):
+    if explicit_refs:
+      raise ValueError(
+          f"the gradient for {_vjp_arg_name(jaxpr, in_tree, idx)}, which is "
+          "Ref-typed, can't be returned as a value. In the arguments to the "
+          "VJP function's `with_refs` method, pass a `Ref` for it, to "
+          "accumulate the gradient into the ref in-place, or pass "
+          "`jax.ad.DontWant()` to skip computing this argument's gradient.")
+    else:
+      raise ValueError(
+          f"{_vjp_arg_name(jaxpr, in_tree, idx)} is Ref-typed, so its "
+          "gradient must be accumulated into a ref, but no gradient ref was "
+          "provided. Bind one using the VJP function's `with_refs` method "
+          "before applying it, as in `f_vjp.with_refs(grad_ref)(ct)`; the "
+          "gradient will be accumulated into `grad_ref` in-place via "
+          "addition. Or, to skip computing this argument's gradient, pass "
+          "`jax.ad.DontWant()` in place of a gradient ref.")
+  else:
+    return ad.ValAccum(v.aval.to_ct_aval())
+
+def _vjp_arg_name(jaxpr, in_tree, idx):
+  try:
+    dummy_args = tree_unflatten(in_tree, list(range(in_tree.num_leaves)))
+    path, _ = list(generate_key_paths(dummy_args))[idx]
+    position = f"args{keystr(path)}"
+  except Exception:  # unflattening custom pytree nodes can reject dummy leaves
+    position = f"flat argument index {idx}"
+  return (f"the argument at position {position} of the "
+          f"differentiated function {jaxpr.debug_info.func_src_info}")
+
+def _vjp_with_refs_tree_error(jaxpr, in_tree, refs_tree):
+  msg = f"""unexpected tree structure in the arguments to a VJP function's \
+`with_refs` method.
+
+The arguments to `with_refs` must match the pytree structure of the primal
+arguments of the differentiated function {jaxpr.debug_info.func_src_info},
+with one entry for each array argument. Each entry must be a `Ref` (to
+accumulate this argument's gradient into the ref in-place), a
+`jax.ad.GradValue()` (to have this argument's gradient returned as a value,
+the default behavior), or a `jax.ad.DontWant()` (to skip computing this
+argument's gradient). Note that `None` is an empty pytree, so it can't be
+used as a placeholder entry.
+
+But the tree structures differ:
+"""
+  msg += '\n'.join(f"  * args{keystr(path)} was a {thing1} in the primal "
+                   f"arguments, but a {thing2} in the `with_refs` arguments, "
+                   f"so {explanation}."
+                   for path, thing1, thing2, explanation
+                   in equality_errors_pytreedef(in_tree, refs_tree))
+  raise ValueError(msg)
 
 def check_accum(aval, acc):
   if not core.typecompat(acc.aval, aval):
@@ -1682,6 +1757,10 @@ def _is_ref(x):
     return isinstance(typeof(x), AbstractRef)
   except:
     return False
+
+def _is_ref_aval(a):
+  from jax._src.state.types import AbstractRef
+  return isinstance(a, AbstractRef)
 
 def _ref_aval(a):
   from jax._src.state.types import AbstractRef

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -1428,6 +1428,7 @@ def _slice_transpose_fancy(out_ct, operand, *, start_indices, limit_indices, str
   if type(out_ct) is ad_util.Zero or isinstance(operand, ad.NullAccum):
     return
   if isinstance(operand, ad.RefAccum):
+    strides = (1,) * len(start_indices) if strides is None else strides
     slices = map(_slice, start_indices, limit_indices, strides)
     assert operand.ref is not None
     operand.ref.addupdate(out_ct, tuple(slices))

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -5550,6 +5550,68 @@ class APITest(jtu.JaxTestCase):
     self.assertAllClose(y_grad, x)
     self.assertLen(g.trace().jaxpr.eqns, 1)
 
+  def test_vjp3_with_refs_tree_errors(self):
+    # wrong number of entries
+    _, f_vjp = jax.vjp(lambda x, y: x * y, 1., 2.)
+    with self.assertRaisesRegex(ValueError, "tree structures differ"):
+      f_vjp.with_refs(jax.new_ref(0.))
+
+    # None is an empty pytree, so it can't be used as a placeholder
+    _, f_vjp = jax.vjp(lambda x, y: x * y, 1., 2.)
+    with self.assertRaisesRegex(ValueError, "NoneType"):
+      f_vjp.with_refs(jax.new_ref(0.), None)
+
+  def test_vjp3_with_refs_aval_mismatch_errors(self):
+    # binding a gradient ref of the wrong shape errors at bind time
+    _, f_vjp = jax.vjp(lambda x: x.sum(), jnp.zeros(3))
+    with self.assertRaisesRegex(ValueError, "requires a ref of type"):
+      f_vjp.with_refs(jax.new_ref(jnp.zeros(4)))
+
+    # wrong dtype too
+    _, f_vjp = jax.vjp(lambda x: x.sum(), jnp.zeros(3))
+    with self.assertRaisesRegex(ValueError, "requires a ref of type"):
+      f_vjp.with_refs(jax.new_ref(jnp.zeros(3, 'int32')))
+
+  def test_vjp3_ref_arg_needs_with_refs_errors(self):
+    def f(x_ref):
+      return x_ref[...] ** 2
+
+    # differentiating wrt a ref-typed argument requires binding a gradient ref
+    _, f_vjp = jax.vjp(f, jax.new_ref(2.))
+    with self.assertRaisesRegex(ValueError, "with_refs"):
+      f_vjp(1.0)
+
+    # a GradValue entry doesn't cut it either...
+    _, f_vjp = jax.vjp(f, jax.new_ref(2.))
+    with self.assertRaisesRegex(ValueError, "can't be returned as a value"):
+      f_vjp.with_refs(jax.ad.GradValue())
+
+    # ...though a DontWant entry works
+    _, f_vjp = jax.vjp(f, jax.new_ref(2.))
+    out, = f_vjp.with_refs(jax.ad.DontWant())(1.)
+    self.assertIsInstance(out, jax.ad.DidntWant)
+
+  def test_grad_wrt_ref_arg_error(self):
+    def f(x_ref):
+      return x_ref[...] ** 2
+
+    with self.assertRaisesRegex(
+        TypeError, "grad cannot differentiate with respect to a Ref"):
+      jax.grad(f)(jax.new_ref(2.))
+
+    g = lambda x, y_ref: x * y_ref[...]
+    with self.assertRaisesRegex(
+        TypeError, "grad cannot differentiate with respect to a Ref"):
+      jax.grad(g, argnums=1)(1., jax.new_ref(2.))
+
+    with self.assertRaisesRegex(
+        TypeError, "jacrev cannot differentiate with respect to a Ref"):
+      jax.jacrev(f)(jax.new_ref(2.))
+
+    # ref args not selected by argnums are plumbing, and still work
+    self.assertAllClose(jax.grad(g)(3., jax.new_ref(2.)), 2.,
+                        check_dtypes=False)
+
   def test_while_jvp_debug_info_crash(self):
     def loop_fun(x, p):
       cond = lambda val: val[0] < 3

--- a/tests/mutable_array_test.py
+++ b/tests/mutable_array_test.py
@@ -1006,6 +1006,37 @@ class MutableArrayTest(jtu.JaxTestCase):
     self.assertIn('+=', str(jaxpr))
     self.assertNotIn('0.0', str(jaxpr))
 
+  def test_static_slicing_with_vjp3(self):
+    # like test_slicing_with_vjp3, but not jitted, so that the static index
+    # hits slice_p rather than dynamic_slice_p
+    def f(x, i):
+      return x[i]
+
+    x = jnp.arange(10.)
+
+    grad_accum = jax.new_ref(jnp.zeros(10))
+    _, f_vjp = jax.vjp(f, x, 3)
+    f_vjp.with_refs(grad_accum, jax.ad.GradValue())(1.)
+    self.assertAllClose(grad_accum[...], jnp.zeros(10).at[3].set(1.),
+                        check_dtypes=False)
+
+    @jax.make_jaxpr
+    def run():
+      _, f_vjp = jax.vjp(f, x, 3)
+      f_vjp.with_refs(grad_accum, jax.ad.GradValue())(1.)
+
+    jaxpr = run()
+    self.assertIn('+=', str(jaxpr))
+    self.assertNotIn('0.0', str(jaxpr))
+
+    # strided slices take the sparse in-place path too
+    grad_accum = jax.new_ref(jnp.zeros(10))
+    _, f_vjp = jax.vjp(lambda x: x[::2], x)
+    f_vjp.with_refs(grad_accum)(jnp.arange(5.))
+    self.assertAllClose(grad_accum[...],
+                        jnp.zeros(10).at[::2].set(jnp.arange(5.)),
+                        check_dtypes=False)
+
   @absltest.skip("Not yet implemented")
   def test_none_index(self):
     ref = jax.new_ref(jnp.array([1, 2, 3]))


### PR DESCRIPTION
Update docs/array_refs.{py,ipynb,md} with new material on refs and AD:
* differentiating with respect to Ref-typed args via jax.vjp, where with_refs is required and gradients are accumulated via += rather than set;
* binding gradient refs for value args too, e.g. to exploit sparsity when differentiating slices (in-place sparse add-updates instead of materializing dense one-hot cotangents);
* the jax.ad.GradValue and jax.ad.DontWant entries, the latter for skipping cotangent computation entirely (eager DCE, e.g. computing one dot instead of two in dot_general's transpose);
* a microbatched gradient accumulation recipe (nested scans over layers and microbatches, accumulating into one gradient buffer).

Also some fixes surfaced while writing the docs:
* fix slice_p's fancy transpose rule, which crashed on strides=None when accumulating into a gradient ref (e.g. non-jitted x[i] with a static index); strided slices take the sparse in-place path too;
* replace the bare `raise Exception` on with_refs pytree structure mismatches with a real error message (including a note that None can't be used as a placeholder entry);
* raise a clear error when a Ref-typed arg's gradient has nowhere to go, pointing at with_refs / jax.ad.DontWant (previously a confusing cotangent type error on plain calls, or an AttributeError crash for GradValue entries);
* check gradient ref shapes/dtypes eagerly when with_refs binds them, rather than failing mid-backward-pass inside addupdate;
* fix the stash_grads docs example, which never actually ran the backward pass (so it stashed nothing and printed Ref(0.)).