### PR TITLE
[remat3] fix interactions with scan, custom_vjp, and higher-order AD

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -991,6 +991,21 @@ def checkpoint_name3(name, x):
   return CheckpointName(name, typeof(x))(x)
 
 def remat3(f=None, /, policy=None, static_argnums=(), static_argnames=()):
+  """Rematerialization decorator (new implementation, ``jax_remat3``).
+
+  Note on interaction with :func:`jax.custom_vjp`: when differentiating
+  rematted code, a custom_vjp application that appears *inside another
+  custom_vjp's fwd rule* is rematerialized as an opaque unit. For the
+  conventional idiom of a fwd rule calling its own custom_vjp-decorated
+  function to compute the primal output, that is exactly the intended
+  semantics. Values and gradients are unaffected at every order of
+  differentiation. The one observable consequence arises only under
+  higher-order AD: differentiating a second time runs the inner application's
+  own fwd rule (at first order it never runs, since the outer bwd rule
+  discharges the derivative), and values inside it (e.g.
+  ``checkpoint_name``-tagged intermediates) cannot be marked saveable by the
+  checkpoint ``policy`` there; they are always recomputed.
+  """
   if f is None:
     return partial(partial, _remat3, policy, static_argnums, static_argnames)
   else:
@@ -1037,7 +1052,8 @@ class RematTraced(VJPHiPrimitive):
   def vjp_fwd(self, _nzs_in, *primals):
     # TODO eval_jaxpr_p trace time
     traced = core.jaxpr_as_fun(self.jaxpr)
-    primals_out, fwd2 = remat_transform(self.policy, traced, *primals)
+    primals_out, fwd2 = remat_transform(self.policy, traced, *primals,
+                                        custom_vjp_rules=True)
     used, rem = dce(api.jit(lambda *xs: api.vjp(fwd2, *xs)[1]).trace(*primals),
                     self.policy)
     primals_ = [x for x, u in zip(tree_leaves(primals), used) if u]
@@ -1058,7 +1074,8 @@ class RematTraced(VJPHiPrimitive):
 
   def lin(self, nzs_in, *primals):
     traced = core.jaxpr_as_fun(self.jaxpr)
-    primals_out, fwd2 = remat_transform(self.policy, traced, *primals)
+    primals_out, fwd2 = remat_transform(self.policy, traced, *primals,
+                                        custom_vjp_rules=True)
     used, rem = dce(api.jit(lambda *xs: api.linearize(fwd2, *xs)[1]).trace(*primals),
                     self.policy)
     primals_ = [x for x, u in zip(tree_leaves(primals), used) if u]
@@ -1089,7 +1106,8 @@ class CheckpointName(VJPHiPrimitive):
   def expand(self, x):  # pyrefly: ignore[bad-override]
     return x
 
-  def remat(self, policy, x):  # pyrefly: ignore[bad-override]
+  def remat(self, trace, x):  # pyrefly: ignore[bad-override]
+    policy = trace.policy
     x = CheckpointName(self.name, self.in_avals[0])(x)
     if isinstance(policy, (SaveOnlyTheseNames, SaveAnyNamesButThese)):
       saveable = (self.name not in policy.names if isinstance(policy, SaveAnyNamesButThese)
@@ -1181,9 +1199,9 @@ class CustomRemat(VJPHiPrimitive):
   def expand(self, *args):
     return core.jaxpr_as_fun(self.jaxpr)(*args)
 
-  def remat(self, policy, *args_flat):  # type: ignore
+  def remat(self, trace, *args_flat):  # type: ignore
     args, kwargs = tree_unflatten(self._in_tree, args_flat)  # type: ignore
-    out_primal, res = self.f1(policy, *args, **kwargs)
+    out_primal, res = self.f1(trace.policy, *args, **kwargs)
     out_primal_flat = tree_leaves_checked(self._out_tree, out_primal)  # type: ignore
     def rem_flat(*args_flat):
       args, kwargs = tree_unflatten(self._in_tree, args_flat)  # type: ignore

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -462,7 +462,7 @@ class VJPHiPrimitive:
       return True, True, self
 
   # optional remat control
-  def remat(self, _policy, *args):
+  def remat(self, _trace, *args):
     return self(*args), self  # full remat by default
 
   def __call__(self, *args):
@@ -697,9 +697,9 @@ pe.dce_rules[call_hi_primitive_p] = _call_hi_primitive_dce
 call_hi_primitive_linearized_p.to_lojax = ad.raise_custom_vjp_error_on_jvp
 batching.fancy_primitive_batchers[call_hi_primitive_linearized_p] = ad.raise_custom_vjp_error_on_jvp
 
-def _call_hi_primitive_remat(policy, *args_flat, _prim):
+def _call_hi_primitive_remat(trace, *args_flat, _prim):
   args = tree_unflatten(_prim.in_tree, args_flat)
-  out, rem_ = _prim.remat(policy, *args)
+  out, rem_ = _prim.remat(trace, *args)
   def rem(*args_flat):
     args = tree_unflatten(_prim.in_tree, args_flat)
     out = rem_(*args)
@@ -802,7 +802,11 @@ class CustomVJPTraced(VJPHiPrimitive):
     if disallowed:
       raise NotImplementedError(f'Effects not supported in `custom_jvp`: {disallowed}')
 
-  def remat(self, policy, *args):  # type: ignore
+  def remat(self, trace, *args):  # type: ignore
+    if self.opt_remat:
+      return self(*args), self
+    if not trace.custom_vjp_rules:
+      return self(*args), self  # see https://github.com/jax-ml/jax/pull/38914
     if not self.static_argnums:
       fwd, dyn_args = self.fwd, args
     else:
@@ -810,7 +814,10 @@ class CustomVJPTraced(VJPHiPrimitive):
       dyn_args, static_args = partition_list(which_static, args)
       static_args = [x.val for x in static_args]
       fwd = lambda *dyn_args: self.fwd(*merge_lists(which_static, dyn_args, static_args))
-    (out, _), rem_ = remat.remat_transform(policy, fwd, *dyn_args)
+    # custom_vjp_rules=False so that custom_vjp applications inside fwd hit
+    # the early return above rather than recursively tracing their fwds.
+    (out, _), rem_ = remat.remat_transform(trace.policy, fwd, *dyn_args,
+                                           custom_vjp_rules=False)
     rem = lambda *args: rem_(*[x for i, x in enumerate(args) if i not in self.static_argnums])
     helper = CustomVJPTraced(self.traced, rem, self.bwd, self.in_avals,
                              False, self.static_argnums, False)

--- a/jax/_src/interpreters/remat.py
+++ b/jax/_src/interpreters/remat.py
@@ -36,12 +36,12 @@ zip = safe_zip
 #  [ ] allow NotAvailable sentinels
 #  [ ] primal-output-to-residual forwarding
 
-def remat_transform(policy, f, *args):
+def remat_transform(policy, f, *args, custom_vjp_rules):
   dbg = api_util.debug_info("remat", f, args, {})
   with core.take_current_trace() as parent_trace:
     jaxpr_trace = pe.DynamicJaxprTrace(None)
     jaxpr_trace.tag = core.TraceTag()
-    trace = RematTrace(parent_trace, jaxpr_trace, policy)
+    trace = RematTrace(parent_trace, jaxpr_trace, policy, custom_vjp_rules)
     args_ft, _ = ft.flatten_args(*args).unpack()
     in_tracers = args_ft.map(
         lambda x: RematTracer(trace, x, jaxpr_trace.new_arg(typeof(x), None)))  # type: ignore # noqa F821
@@ -72,12 +72,14 @@ class RematTracer(core.Tracer['RematTrace']):
     self.tracer = jaxpr_tracer
 
 class RematTrace(core.Trace):
-  def __init__(self, parent_trace, jaxpr_trace, policy):
+  def __init__(self, parent_trace, jaxpr_trace, policy, custom_vjp_rules):
     super().__init__()
     self.parent_trace = parent_trace
     self.jaxpr_trace = jaxpr_trace
     self.policy = policy
     self.requires_low = False
+    # flag to handle checkpoint_name calls in custom_vjp fwd w/o inf recursion
+    self.custom_vjp_rules = custom_vjp_rules
 
   tag = property(lambda self: self.jaxpr_trace.tag)
 
@@ -96,7 +98,7 @@ class RematTrace(core.Trace):
     in_vals, in_vals2 = unzip2(map(self.to_val_tracer_pair, tracers))
     if prim in rules:
       with core.set_current_trace(self.parent_trace):
-        out_primal, rem = rules[prim](self.policy, *in_vals, **params)
+        out_primal, rem = rules[prim](self, *in_vals, **params)
       with core.set_current_trace(self.jaxpr_trace):
         out_primal2 = rem(*in_vals2)
     else:  # default: full remat
@@ -116,7 +118,8 @@ class RematTrace(core.Trace):
   def process_custom_jvp_call(self, prim, fun, jvp, tracers, /, *, symbolic_zeros):
     in_vals, in_vals2 = unzip2(map(self.to_val_tracer_pair, tracers))
     with core.set_current_trace(self.parent_trace):
-      out_primal = fun.call_wrapped(*in_vals)
+      out_primal = prim.bind(*in_vals, subfuns=(fun, jvp),
+                             symbolic_zeros=symbolic_zeros)
     with core.set_current_trace(self.jaxpr_trace):
       out_primal2 = prim.bind(*in_vals2, subfuns=(fun, jvp),
                               symbolic_zeros=symbolic_zeros)
@@ -125,19 +128,20 @@ class RematTrace(core.Trace):
   def process_custom_vjp_call(self, prim, f, fwd, bwd, tracers, /, *, out_trees, symbolic_zeros):
     in_vals, in_vals2 = unzip2(map(self.to_val_tracer_pair, tracers))
     with core.set_current_trace(self.parent_trace):
-      out_primal = f.call_wrapped(*in_vals)
+      out_primal = prim.bind(*in_vals, subfuns=(f, fwd, bwd),
+                             out_trees=out_trees, symbolic_zeros=symbolic_zeros)
     with core.set_current_trace(self.jaxpr_trace):
       out_primal2 = prim.bind(*in_vals2, subfuns=(f, fwd, bwd),
                               out_trees=out_trees, symbolic_zeros=symbolic_zeros)
     return map(partial(RematTracer, self), out_primal, out_primal2)
 
 def remat_subtrace(f: Callable, tag: core.TraceTag, policy,
-                   debug_info: core.DebugInfo, args):
+                   debug_info: core.DebugInfo, args, custom_vjp_rules):
   source_info = source_info_util.current()
   with core.take_current_trace() as parent_trace:
     rem_trace = pe.DynamicJaxprTrace(debug_info, auto_dce=True)
     rem_trace.tag = tag
-    trace = RematTrace(parent_trace, rem_trace, policy)
+    trace = RematTrace(parent_trace, rem_trace, policy, custom_vjp_rules)
     tracers = [RematTracer(trace, x, rem_trace.new_arg(typeof(x), source_info))
                for x in args]
     with core.set_current_trace(trace, check_leaks=True):
@@ -170,16 +174,16 @@ rules: dict[core.Primitive, Callable] = {}
 reduce_precision_handlers: dict[type, Callable] = {}
 
 
-def remat_jaxpr(jaxpr, policy):
-  return _remat_jaxpr(jaxpr, policy)
+def remat_jaxpr(jaxpr, policy, custom_vjp_rules):
+  return _remat_jaxpr(jaxpr, policy, custom_vjp_rules)
 
 @weakref_lru_cache
-def _remat_jaxpr(jaxpr, policy):
+def _remat_jaxpr(jaxpr, policy, custom_vjp_rules):
   dbg = jaxpr.jaxpr.debug_info
   fwd_trace = pe.DynamicJaxprTrace(dbg)
   rem_trace = pe.DynamicJaxprTrace(dbg, auto_dce=True)
   rem_trace.tag = core.TraceTag()
-  trace = RematTrace(fwd_trace, rem_trace, policy)
+  trace = RematTrace(fwd_trace, rem_trace, policy, custom_vjp_rules)
   src = source_info_util.current()
 
   def new_arg(a):

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -935,10 +935,11 @@ def _cond_typecheck(bind_time, *in_atoms, branches, **params):
       f'called with operands of type {_avals_short(op_avals)}')
   return jaxpr0.out_avals, joined_effects
 
-def _cond_remat(policy, *args, branches, **params):
+def _cond_remat(trace, *args, branches, **params):
   branches_fwd, branches_rem, branch_res_avals = [], [], []
   for jaxpr in branches:
-    jaxpr_fwd, jaxpr_rem, num_res = remat.remat_jaxpr(jaxpr, policy)
+    jaxpr_fwd, jaxpr_rem, num_res = remat.remat_jaxpr(
+      jaxpr, trace.policy, trace.custom_vjp_rules)
     branches_fwd.append(jaxpr_fwd)
     branches_rem.append(jaxpr_rem)
     _, res_avals = split_list_checked(jaxpr_fwd.out_avals, [len(jaxpr.out_avals), num_res])

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1081,6 +1081,8 @@ def _scan_transpose_fancy(cts, *args, reverse, length, num_consts,
   # prepare cotangent values to be passed in to transpose
   ct_carry, ct_ys = split_list(cts, [num_carry])
   ct_carry = _map(ad.instantiate_zeros, ct_carry)  # TODO(mattjj): fixpoint
+  ct_ys = [ad.Zero(core.mapped_leading_aval(length, x.aval))
+           if isinstance(x, ad.Zero) else x for x in ct_ys]
 
   # initialize values to be used to accumulate pure constant gradients
   immut_const_avals = jaxpr.in_avals[num_ires+len(mut_consts_bar):num_consts]
@@ -1453,8 +1455,9 @@ def _scan_state_partial_discharge_rule(
   assert next(refvals_iter, None) is None
   return refvals_out, [*carry, *ys]
 
-def _scan_remat(policy, *args, jaxpr, **params):
-  jaxpr_fwd, jaxpr_rem_, num_res = remat.remat_jaxpr(jaxpr, policy)
+def _scan_remat(trace, *args, jaxpr, **params):
+  jaxpr_fwd, jaxpr_rem_, num_res = remat.remat_jaxpr(
+      jaxpr, trace.policy, trace.custom_vjp_rules)
   all_out = scan_p.bind(*args, jaxpr=jaxpr_fwd, **params)
   primals_out, res = split_list(all_out, [len(jaxpr.outvars)])
   jaxpr_rem = pe.move_binders_to_back(jaxpr_rem_, [True] * num_res)

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -6001,12 +6001,12 @@ dot_general_p = standard_primitive(
 )
 
 
-def _dot_general_remat(policy, lhs, rhs, **params):
+def _dot_general_remat(trace, lhs, rhs, **params):
   from jax._src.ad_checkpoint import DotsSaveable, primal_left_tangent_right
   dot = partial(dot_general_p.bind, **params)
   out = dot(lhs, rhs)
-  if (isinstance(policy, DotsSaveable) and
-      policy(dot_general_p, typeof(lhs), typeof(rhs), **params)):
+  if (isinstance(trace.policy, DotsSaveable) and
+      trace.policy(dot_general_p, typeof(lhs), typeof(rhs), **params)):
     return out, lambda lhs, rhs: primal_left_tangent_right(out, dot(lhs, rhs))
   return out, dot  # full remat
 remat.rules[dot_general_p] = _dot_general_remat

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1669,8 +1669,9 @@ def _pjit_linearize(is_vjp, nzs, *primals_in, jaxpr, in_shardings, out_shardings
 ad.primitive_linearizations[jit_p] = _pjit_linearize
 
 
-def _pjit_remat(policy, *args, jaxpr, **params):
-  jaxpr_fwd, jaxpr_rem, num_res = remat.remat_jaxpr(jaxpr, policy)
+def _pjit_remat(trace, *args, jaxpr, **params):
+  jaxpr_fwd, jaxpr_rem, num_res = remat.remat_jaxpr(jaxpr, trace.policy,
+                                                    trace.custom_vjp_rules)
   params_fwd, params_rem = _add_res_to_params(num_res, **params)
   primals_res_out = jit_p.bind(*args, jaxpr=jaxpr_fwd, **params_fwd)
   primals_out, res = split_list(primals_res_out, [len(jaxpr.outvars)])

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -1810,7 +1810,8 @@ def _shard_map_remat(trace, shard_map_p, f, tracers, mesh, in_specs, check_vma,
 
   def f_fwd(*in_vals):
     res, ans_aux, rem_data = remat.remat_subtrace(
-        f, trace.tag, trace.policy, debug_info, in_vals)
+        f, trace.tag, trace.policy, debug_info, in_vals,
+        custom_vjp_rules=trace.custom_vjp_rules)
     primals_out, out_specs = ans_aux.unpack_aux()
 
     res_avals, _, _, in_fwd, out_fwd = rem_data

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6715,6 +6715,23 @@ class RematTest(jtu.JaxTestCase):
     self.assertIn(' sin ', str(jaxpr))
     self.assertIn(' cos ', str(jaxpr))
 
+  def test_remat_of_scan_unused_extensive_output_grad(self):
+    # The scanned-over output `b` is unused by the differentiated function, so
+    # its cotangent is a symbolic zero with the stacked aval; the scan
+    # transpose must handle it.
+    def f(c, a):
+      b = jnp.sin(a).sum() + jnp.sin(c).sum()
+      return jnp.sin(c * b), b
+
+    g = jax.remat(partial(lax.scan, f),
+                  policy=jax.checkpoint_policies.nothing_saveable)
+    c = jnp.arange(4.) / 4.
+    as_ = jnp.arange(15.).reshape(5, 3) / 15.
+
+    ans = api.grad(lambda c, as_: g(c, as_)[0].sum())(c, as_)
+    expected = api.grad(lambda c, as_: lax.scan(f, c, as_)[0].sum())(c, as_)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
   @parameterized.named_parameters(
       {"testcase_name": f"{suffix}", "remat": remat}
       for suffix, remat in [

--- a/tests/custom_api_test.py
+++ b/tests/custom_api_test.py
@@ -4158,5 +4158,15 @@ class CustomApiTest(jtu.JaxTestCase):
           self.assertIsInstance(getattr(f, method), Callable)
 
 
+@jtu.with_config(jax_remat3=True)
+class CustomJVPRemat3Test(CustomJVPTest):
+  ...
+
+
+@jtu.with_config(jax_remat3=True)
+class CustomVJP3Remat3Test(CustomVJP3Test):
+  ...
+
+
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -1109,7 +1109,7 @@ class ShardMapTest(jtu.JaxTestCase):
       return z.sum()
 
     x = jax.device_put(jnp.arange(2.), jax.P('i'))
-    y1, f_ = remat_transform(policy, f, x)  # don't crash
+    y1, f_ = remat_transform(policy, f, x, custom_vjp_rules=True)  # don't crash
     y2 = f_(x)
     self.assertAllClose(y1, y2, check_dtypes=False)
 


### PR DESCRIPTION
Fixes several bugs found by running existing test suites with jax_remat3=True (and jax_custom_vjp3=True):

* scan transpose with symbolic-zero cotangents needed shape conversion (since remat currently foils some DCE we were relying on before);
* higher-order AD through remat: RematTrace.process_custom_{jvp,vjp}_call evaluated the primal side via fun.call_wrapped, losing the custom rule when the parent trace is itself a differentiation trace (e.g. grad-of-grad of rematted code containing custom_jvp/custom_vjp). Bind the custom-call primitive on the parent trace instead.
* optimize_remat: CustomVJPTraced.remat took the primal output from the remat-transformed fwd, but with optimize_remat=True the primal must come from the original function (#21303)
* custom_vjp fwd self-call recursion (see below)

The recursion issue was:
```python
  # with jax_remat3=True and jax_custom_vjp3=True:

  @jax.custom_vjp
  def f(x):
    return jnp.sin(x)

  def f_fwd(x):
    return f(x), jnp.cos(x)   # conventional: fwd calls f itself for the primal

  def f_bwd(cos_x, g):
    return (2. * cos_x * g,)

  f.defvjp(f_fwd, f_bwd)

  jax.grad(jax.remat(f))(1.0)   # RecursionError without custom_vjp_rules=False
```

Before `custom_remat`, the way to customize remat behavior of custom_vjp rules was to write `checkpoint_name` inside a `custom_vjp`'s forward rule. We're trying to provide back compatibility for that old behavior, but with the new remat-before-autodiff pattern of remat3 it's tricky: to do it, when `remat_transform` encounters a `custom_vjp` rule, then we apply `remat_transform` to its fwd rule. But that led to the ol' infinite recursion issue in examples like the above. So we only do it one level deep, using this `custom_vjp_rules` boolean.

The better way to control both autodiff rules and remat behavior is `custom_remat`, or writing a hijax primitive.