### PR TITLE
[vjp3] add a fancy transpose rule for gather_p, for sparse gradient-ref updates

### DIFF
--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -1549,8 +1549,10 @@ def _dynamic_slice_transpose_fancy(out_ct, operand, *start_indices, slice_sizes)
     assert operand.ref is not None
     operand.ref.addupdate(out_ct, tuple(map(ds, start_indices, slice_sizes)))
   else:
+    # use out_ct's dtype, not operand_aval's: cotangents can flow in a
+    # different (e.g. higher-precision) dtype than the primal
     operand_aval, = lax_utils.ensure_shaped(operand.aval)
-    zeros = lax.full(operand_aval.shape, 0, operand_aval.dtype,
+    zeros = lax.full(operand_aval.shape, 0, typeof(out_ct).dtype,
                      sharding=operand_aval.sharding)
     zeros = core.pvary(zeros, tuple(operand_aval.mat.varying))
     operand.accum(dynamic_update_slice_p.bind(zeros, out_ct, *start_indices))
@@ -2162,28 +2164,67 @@ def _gather_jvp_rule(g, operand, indices, *, dimension_numbers,
                 indices_are_sorted=indices_are_sorted, mode=mode,
                 fill_value=0)
 
-def _gather_transpose_rule(t, operand, indices, *, dimension_numbers,
-                           slice_sizes, unique_indices, indices_are_sorted,
-                           mode, fill_value):
-  assert ad.is_undefined_primal(operand)
-  if type(t) is ad_util.Zero:
-    out = ad_util.Zero(operand.aval)
+def _gather_to_ref_indexer(indices, dimension_numbers, slice_sizes, mode,
+                           operand_shape):
+  # Try to express the gather as NumPy-style advanced indexing over leading
+  # operand axes, like the gathers `rewriting_take` builds for `x[idx]`.
+  # Returns a ref indexer of index arrays, or None if the gather doesn't fit.
+  dnums = dimension_numbers
+  if dnums.operand_batching_dims or dnums.start_indices_batching_dims:
+    return None
+  if mode not in (GatherScatterMode.PROMISE_IN_BOUNDS,
+                  GatherScatterMode.FILL_OR_DROP):
+    return None  # e.g. CLIP transposes to clamped updates, but addupdate drops
+  k = len(dnums.start_index_map)
+  num_batch_dims = indices.ndim - 1
+  operand_ndim = len(operand_shape)
+  if not (k > 0 and
+          dnums.start_index_map == tuple(range(k)) and
+          dnums.collapsed_slice_dims == tuple(range(k)) and
+          tuple(slice_sizes) == (1,) * k + tuple(operand_shape[k:]) and
+          dnums.offset_dims == tuple(range(num_batch_dims,
+                                           num_batch_dims + operand_ndim - k))):
+    return None
+  return tuple(indices[..., i] for i in range(k))
+
+def _gather_transpose_fancy(out_ct, operand, indices, *, dimension_numbers,
+                            slice_sizes, unique_indices, indices_are_sorted,
+                            mode, fill_value):
+  assert isinstance(operand, ad.GradAccum)
+  assert not isinstance(indices, ad.GradAccum)
+  if type(out_ct) is ad_util.Zero or isinstance(operand, ad.NullAccum):
+    return
+  operand_aval, = lax_utils.ensure_shaped(operand.aval)
+  if isinstance(operand, ad.RefAccum):
+    indexer = _gather_to_ref_indexer(indices, dimension_numbers, slice_sizes,
+                                     mode, operand_aval.shape)
+    if indexer is not None:
+      # in-place add-update at the gathered indices, no dense intermediates
+      operand.inst().ref.addupdate(out_ct, indexer)
+      return
+  scatter_dnums = ScatterDimensionNumbers(
+      update_window_dims=dimension_numbers.offset_dims,
+      inserted_window_dims=dimension_numbers.collapsed_slice_dims,
+      scatter_dims_to_operand_dims=dimension_numbers.start_index_map,
+      operand_batching_dims=dimension_numbers.operand_batching_dims,
+      scatter_indices_batching_dims=dimension_numbers.start_indices_batching_dims,
+  )
+  if isinstance(operand, ad.RefAccum):
+    # scatter-add onto the ref's current value, still avoiding dense zeros
+    ref = operand.inst().ref
+    ref[...] = scatter_add(ref[...], indices, out_ct, scatter_dnums,
+                           unique_indices=unique_indices,
+                           indices_are_sorted=indices_are_sorted, mode=mode)
   else:
-    zeros = lax.full(operand.aval.shape, 0, typeof(t).dtype,
-                     sharding=operand.aval.sharding)
-    zeros = core.pvary(zeros, tuple(operand.aval.mat.varying))
-    scatter_dnums = ScatterDimensionNumbers(
-        update_window_dims=dimension_numbers.offset_dims,
-        inserted_window_dims=dimension_numbers.collapsed_slice_dims,
-        scatter_dims_to_operand_dims=dimension_numbers.start_index_map,
-        operand_batching_dims=dimension_numbers.operand_batching_dims,
-        scatter_indices_batching_dims=dimension_numbers.start_indices_batching_dims,
-    )
-    out = scatter_add(zeros, indices, t, scatter_dnums,
-                      unique_indices=unique_indices,
-                      indices_are_sorted=indices_are_sorted,
-                      mode=mode)
-  return [out, None]
+    # use out_ct's dtype, not operand_aval's: cotangents can flow in a
+    # different (e.g. higher-precision) dtype than the primal
+    zeros = lax.full(operand_aval.shape, 0, typeof(out_ct).dtype,
+                     sharding=operand_aval.sharding)
+    zeros = core.pvary(zeros, tuple(operand_aval.mat.varying))
+    operand.accum(scatter_add(zeros, indices, out_ct, scatter_dnums,
+                              unique_indices=unique_indices,
+                              indices_are_sorted=indices_are_sorted,
+                              mode=mode))
 
 def _gather_batching_rule(batched_args: Sequence[Array], batch_dims: Sequence[int | None], *,
                           dimension_numbers, slice_sizes, unique_indices, indices_are_sorted,
@@ -2276,7 +2317,7 @@ gather_p = standard_primitive(
     weak_type_rule=_argnum_weak_type(0), sharding_rule=_gather_sharding_rule,
     vma_rule=partial(core.standard_vma_rule, 'gather'))
 ad.defjvp(gather_p, _gather_jvp_rule, None)
-ad.primitive_transposes[gather_p] = _gather_transpose_rule
+ad.fancy_transposes[gather_p] = _gather_transpose_fancy
 batching.primitive_batchers[gather_p] = _gather_batching_rule
 
 

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -1017,6 +1017,35 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     x = rng(shape, dtype)
     check_grads(gather, (x,), 2, ["fwd", "rev"], 1e-2, 1e-2, 1.)
 
+  def testGatherTransposeCotangentDtype(self):
+    # cotangents can flow in a different (e.g. higher-precision) dtype than
+    # the primal; the gather and dynamic_slice transposes must follow the
+    # cotangent's dtype rather than the primal's
+    @jax.custom_vjp
+    def h(x):
+      return x.astype(np.float32).sum()
+    def h_fwd(x):
+      return h(x), x.shape
+    def h_bwd(shape, g):
+      return (lax.full(shape, g, np.float32),)  # f32 cotangent, bf16 primal
+    h.defvjp(h_fwd, h_bwd)
+
+    x = np.ones((7, 4), dtypes.bfloat16)
+    idx = np.array([1, 2, 1])
+
+    g = jax.grad(lambda t: h(t[idx]))(x)  # gather
+    self.assertEqual(g.dtype, np.float32)
+    expected = np.zeros((7, 4), np.float32)
+    expected[1], expected[2] = 2., 1.
+    self.assertAllClose(g, expected)
+
+    g = jax.grad(jax.jit(  # dynamic_slice, via the traced start index
+        lambda t, i: h(lax.dynamic_slice(t, (i, 0), (2, 4)))))(x, 1)
+    self.assertEqual(g.dtype, np.float32)
+    expected = np.zeros((7, 4), np.float32)
+    expected[1:3] = 1.
+    self.assertAllClose(g, expected)
+
   @jtu.sample_product(
     [dict(arg_shape=arg_shape, idxs_shape=idxs.shape, idxs_dtype=idxs.dtype,
           dnums=dnums, update_shape=update_shape, max_idx=max_idx)

--- a/tests/mutable_array_test.py
+++ b/tests/mutable_array_test.py
@@ -1194,6 +1194,66 @@ class MutableArrayTest(jtu.JaxTestCase):
     f_vjp(1.0)
     self.assertAllClose(x_grad_ref[...], 4., check_dtypes=False)
 
+  @parameterized.parameters([False, True])
+  def test_gather_with_vjp3(self, jit):
+    # reverse-mode of advanced indexing accumulates in-place into a bound
+    # gradient ref, without materializing dense one-hot cotangents
+    def f(x, i):
+      return x[i]
+    if jit:
+      f = jax.jit(f)
+
+    x = jnp.arange(10.)
+    idx = jnp.array([3, 5, 3])  # note the duplicate index
+    ct = jnp.arange(1., 4.)
+
+    grad_accum = jax.new_ref(jnp.zeros(10))
+    _, f_vjp = jax.vjp(f, x, idx)
+    f_vjp.with_refs(grad_accum, jax.ad.GradValue())(ct)
+    self.assertAllClose(grad_accum[...], jnp.zeros(10).at[idx].add(ct),
+                        check_dtypes=False)
+
+    @jax.make_jaxpr
+    def run():
+      _, f_vjp = jax.vjp(f, x, idx)
+      f_vjp.with_refs(grad_accum, jax.ad.GradValue())(ct)
+
+    jaxpr_str = str(run())
+    self.assertIn('+=', jaxpr_str)
+    self.assertNotIn('scatter-add', jaxpr_str)
+
+  def test_gather_with_vjp3_multidim(self):
+    def f(x, i):
+      return x[i, i]
+
+    x = jnp.arange(84.).reshape(7, 4, 3)
+    idx = jnp.array([3, 1, 3])
+
+    _, f_vjp = jax.vjp(f, x, idx)
+    expected, _ = f_vjp(jnp.ones((3, 3)))
+
+    grad_accum = jax.new_ref(jnp.zeros_like(x))
+    _, f_vjp = jax.vjp(f, x, idx)
+    f_vjp.with_refs(grad_accum, jax.ad.GradValue())(jnp.ones((3, 3)))
+    self.assertAllClose(grad_accum[...], expected, check_dtypes=False)
+
+  def test_gather_with_vjp3_general_fallback(self):
+    # gathers that don't look like NumPy-style indexing (e.g. clip mode)
+    # accumulate via scatter-add on the ref's value, matching the dense result
+    def f(x, i):
+      return x.at[i].get(mode='clip')
+
+    x = jnp.arange(10.)
+    idx = jnp.array([3, 100])  # out-of-bounds index clamps under clip mode
+
+    _, f_vjp = jax.vjp(f, x, idx)
+    expected, _ = f_vjp(jnp.ones(2))
+
+    grad_accum = jax.new_ref(jnp.zeros(10))
+    _, f_vjp = jax.vjp(f, x, idx)
+    f_vjp.with_refs(grad_accum, jax.ad.GradValue())(jnp.ones(2))
+    self.assertAllClose(grad_accum[...], expected, check_dtypes=False)
+
 
 @jtu.with_config(jax_mutable_array_checks=True)
 class MutableArrayErrorsTest(jtu.JaxTestCase):


### PR DESCRIPTION
When reverse-mode differentiating a gather with the operand's cotangent accumulated into a ref (via jax.vjp + with_refs), the backward pass previously materialized a dense zeros array, scatter-added into it, and dense-added the result into the ref. Now:
* gathers that look like NumPy-style advanced indexing over leading axes (e.g. from `x[idx]`, like embedding lookups) become a single in-place indexed add-update on the gradient ref: `ref[idx] += ct`;
* all other gathers (clip mode, batched dims from vmap, etc.) become a scatter-add onto the ref's current value, which still avoids materializing dense zeros.

We only accept gather modes whose out-of-bounds transpose semantics match ref addupdate's (drop, not clamp), so clip-mode gathers take the general path.