### PR TITLE
[remat3] produce output-to-residual-forwarding info in remat_jaxpr

### DIFF
--- a/jax/_src/interpreters/remat.py
+++ b/jax/_src/interpreters/remat.py
@@ -174,11 +174,17 @@ rules: dict[core.Primitive, Callable] = {}
 reduce_precision_handlers: dict[type, Callable] = {}
 
 
-def remat_jaxpr(jaxpr, policy, custom_vjp_rules):
-  return _remat_jaxpr(jaxpr, policy, custom_vjp_rules)
+def remat_jaxpr(
+    jaxpr, policy, custom_vjp_rules, allow_fwds
+) -> tuple[core.ClosedJaxpr, core.ClosedJaxpr, list[int | None]]:
+  n = len(jaxpr.jaxpr.outvars)
+  if type(allow_fwds) is bool:
+    allow_fwds = (allow_fwds,) * n
+  assert len(allow_fwds) == n
+  return _remat_jaxpr(jaxpr, policy, custom_vjp_rules, tuple(allow_fwds))
 
 @weakref_lru_cache
-def _remat_jaxpr(jaxpr, policy, custom_vjp_rules):
+def _remat_jaxpr(jaxpr, policy, custom_vjp_rules, allow_fwds):
   dbg = jaxpr.jaxpr.debug_info
   fwd_trace = pe.DynamicJaxprTrace(dbg)
   rem_trace = pe.DynamicJaxprTrace(dbg, auto_dce=True)
@@ -200,6 +206,13 @@ def _remat_jaxpr(jaxpr, policy, custom_vjp_rules):
   rem_jaxpr = pe.close_jaxpr(pe.convert_constvars_jaxpr(rem_jaxpr_))
   rem_trace.invalidate()
 
+  # Residuals that are just primal outputs needn't be returned again by the
+  # fwd jaxpr; the caller passes its own copies of the primal outputs for
+  # them, using fwds as the wiring.
+  id_map = {id(x): i for i, (x, a) in enumerate(zip(out_primals, allow_fwds)) if a}
+  fwds = [id_map.get(id(c)) for c in rem_consts]
+  rem_consts = [c for c, f in zip(rem_consts, fwds) if f is None]
+
   rem_consts = map(partial(fwd_trace.to_jaxpr_tracer, source_info=src), rem_consts)
   out_primals = [fwd_trace.to_jaxpr_tracer(x, source_info=src) for x in out_primals]
   fwd_jaxpr_, fwd_consts = fwd_trace.to_jaxpr(
@@ -207,4 +220,4 @@ def _remat_jaxpr(jaxpr, policy, custom_vjp_rules):
   fwd_trace.invalidate()
 
   fwd_jaxpr = core.ClosedJaxpr(fwd_jaxpr_, fwd_consts)
-  return fwd_jaxpr, rem_jaxpr, len(rem_consts)
+  return fwd_jaxpr, rem_jaxpr, fwds

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -938,8 +938,11 @@ def _cond_typecheck(bind_time, *in_atoms, branches, **params):
 def _cond_remat(trace, *args, branches, **params):
   branches_fwd, branches_rem, branch_res_avals = [], [], []
   for jaxpr in branches:
-    jaxpr_fwd, jaxpr_rem, num_res = remat.remat_jaxpr(
-      jaxpr, trace.policy, trace.custom_vjp_rules)
+    # TODO(mattjj): allow forwarding (requires per-branch wiring to survive
+    # the cross-branch residual merging below).
+    jaxpr_fwd, jaxpr_rem, fwds = remat.remat_jaxpr(
+      jaxpr, trace.policy, trace.custom_vjp_rules, allow_fwds=False)
+    num_res = len(fwds)
     branches_fwd.append(jaxpr_fwd)
     branches_rem.append(jaxpr_rem)
     _, res_avals = split_list_checked(jaxpr_fwd.out_avals, [len(jaxpr.out_avals), num_res])

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1456,8 +1456,11 @@ def _scan_state_partial_discharge_rule(
   return refvals_out, [*carry, *ys]
 
 def _scan_remat(trace, *args, jaxpr, **params):
-  jaxpr_fwd, jaxpr_rem_, num_res = remat.remat_jaxpr(
-      jaxpr, trace.policy, trace.custom_vjp_rules)
+  # TODO(mattjj): allow forwarding for ys outputs; carry outputs can't be
+  # forwarded since residuals ride in the stacked ys position.
+  jaxpr_fwd, jaxpr_rem_, fwds = remat.remat_jaxpr(
+      jaxpr, trace.policy, trace.custom_vjp_rules, allow_fwds=False)
+  num_res = len(fwds)
   all_out = scan_p.bind(*args, jaxpr=jaxpr_fwd, **params)
   primals_out, res = split_list(all_out, [len(jaxpr.outvars)])
   jaxpr_rem = pe.move_binders_to_back(jaxpr_rem_, [True] * num_res)

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1670,28 +1670,32 @@ ad.primitive_linearizations[jit_p] = _pjit_linearize
 
 
 def _pjit_remat(trace, *args, jaxpr, **params):
-  jaxpr_fwd, jaxpr_rem, num_res = remat.remat_jaxpr(jaxpr, trace.policy,
-                                                    trace.custom_vjp_rules)
-  params_fwd, params_rem = _add_res_to_params(num_res, **params)
+  jaxpr_fwd, jaxpr_rem, fwds = remat.remat_jaxpr(
+      jaxpr, trace.policy, trace.custom_vjp_rules, allow_fwds=True)
+  num_res_out = sum(f is None for f in fwds)
+  params_fwd, params_rem = _add_res_to_params(num_res_out, len(fwds), **params)
   primals_res_out = jit_p.bind(*args, jaxpr=jaxpr_fwd, **params_fwd)
   primals_out, res = split_list(primals_res_out, [len(jaxpr.outvars)])
-  return primals_out, partial(jit_p.bind, *res, jaxpr=jaxpr_rem, **params_rem)
+  res_ = iter(res)
+  res_full = [primals_out[f] if f is not None else next(res_) for f in fwds]
+  assert next(res_, None) is None
+  return primals_out, partial(jit_p.bind, *res_full, jaxpr=jaxpr_rem, **params_rem)
 remat.rules[jit_p] = _pjit_remat
 
-def _add_res_to_params(num_res, in_shardings, out_shardings, in_layouts,
-                       out_layouts, donated_invars, **params):
+def _add_res_to_params(num_res_out, num_res_in, in_shardings, out_shardings,
+                       in_layouts, out_layouts, donated_invars, **params):
   params_fwd = dict(params,
                     in_shardings=in_shardings,
-                    out_shardings=out_shardings + (UNSPECIFIED,) * num_res,
+                    out_shardings=out_shardings + (UNSPECIFIED,) * num_res_out,
                     in_layouts=in_layouts,
-                    out_layouts=out_layouts + (None,) * num_res,
+                    out_layouts=out_layouts + (None,) * num_res_out,
                     donated_invars=donated_invars)
   params_rem = dict(params,
-                    in_shardings=(UNSPECIFIED,) * num_res + in_shardings,
+                    in_shardings=(UNSPECIFIED,) * num_res_in + in_shardings,
                     out_shardings=out_shardings,
-                    in_layouts=(None,) * num_res + in_layouts,
+                    in_layouts=(None,) * num_res_in + in_layouts,
                     out_layouts=out_layouts,
-                    donated_invars=(False,) * num_res + donated_invars)
+                    donated_invars=(False,) * num_res_in + donated_invars)
   return params_fwd, params_rem
 
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6794,6 +6794,21 @@ class RematTest(jtu.JaxTestCase):
     expected = api.grad(lambda c, as_: lax.scan(f, c, as_)[0].sum())(c, as_)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  def test_remat_of_jit_residual_forwarding(self):
+    policy = jax.checkpoint_policies.save_only_these_names('y')
+    @partial(jax.remat, policy=policy)
+    def f(x):
+      y = checkpoint_name(jnp.sin(jnp.ones(2, 'float32')), 'y')
+      x = jax.jit(lambda: x * y)()
+      x = jax.jit(lambda: x * y)()
+      return x
+
+    res = saved_residuals(f, jnp.float32(3.))
+    self.assertLen(res, 1)
+
+    ans = api.grad(lambda x: f(x).sum())(jnp.float32(3.))
+    self.assertAllClose(ans, 2 * np.sin(1.) ** 2, check_dtypes=False)
+
   @parameterized.named_parameters(
       {"testcase_name": f"{suffix}", "remat": remat}
       for suffix, remat in [
@@ -7638,6 +7653,24 @@ class Remat3Test(RematTest):
     jaxpr_text = str(jaxpr)
     self.assertEqual(jaxpr_text.count(' sin '), 0)
     self.assertEqual(jaxpr_text.count(' cos '), 0)
+
+  def test_remat_output_to_residual_forwarding(self):
+    # When a saved residual is also a primal output, the fwd jaxpr shouldn't
+    # return it twice; the wiring in fwds records the forwarding instead.
+    from jax._src.interpreters import remat as remat_internal
+
+    def body(x):
+      return checkpoint_name(jnp.sin(x), 'y')
+
+    jaxpr = jax.jit(body).trace(1.).jaxpr
+    policy = jax.checkpoint_policies.save_only_these_names('y')
+    fwd_jaxpr, _, fwds = remat_internal.remat_jaxpr(
+        jaxpr, policy, custom_vjp_rules=True, allow_fwds=True)
+    self.assertEqual(fwds, [0])
+    self.assertLen(fwd_jaxpr.jaxpr.outvars, len(jaxpr.jaxpr.outvars))
+
+    f = jax.remat(lambda x: jax.jit(body)(x), policy=policy)
+    self.assertAllClose(api.grad(f)(1.), jnp.cos(1.), check_dtypes=False)
 
   # We don't support everything_saveable with remat3
   def test_remat_custom_policy_save_anything_new_remat(self): pass


### PR DESCRIPTION
Residuals that are just primal outputs needn't be returned again by the fwd jaxpr; the caller passes its own copies of the primal outputs for them. remat_jaxpr takes a per-output allow_fwds mask and returns fwds, mapping each residual to a primal output index or None for local residuals. _pjit_remat uses it with allow_fwds=True; _scan_remat and _cond_remat pass allow_fwds=False for now, since a scan body's carry outputs can't be deduplicated with residuals (which ride in the stacked ys position), and cond's per-branch wiring would need to survive cross-branch residual merging.

```python
# with jax_remat3=True:
import jax, jax.numpy as jnp
from jax._src.interpreters import remat
from jax.ad_checkpoint import checkpoint_name

jaxpr = jax.jit(lambda x: checkpoint_name(jnp.sin(x), 'y')).trace(1.).jaxpr
policy = jax.checkpoint_policies.save_only_these_names('y')
fwd_jaxpr, rem_jaxpr, fwds = remat.remat_jaxpr(
    jaxpr, policy, custom_vjp_rules=True, allow_fwds=True)
print(fwd_jaxpr)
```

With allow_fwds=False (identical to the behavior before this change), the saved residual is also the primal output, so the fwd jaxpr returns it twice:

```
{ lambda ; a:f32[]. let
    b:f32[] = sin a
    c:f32[] = call_hi_primitive[_prim=CheckpointName[{'name': 'y'}]] b
  in (c, c) }
```

With allow_fwds=True, the fwd jaxpr returns it once and fwds == [0] records the wiring — the caller passes its own copy of primal output 0 as that residual:

```
{ lambda ; a:f32[]. let
    b:f32[] = sin a
    c:f32[] = call_hi_primitive[_prim=CheckpointName[{'name': 'y'}]] b
  in (c,) }
```

The duplicate isn't always dead code downstream: when the value is needed both as a bwd residual and by consumers of the primal output, both copies stay live in traced grad computations, so the fwd computation materializes and returns an extra copy of the saved value.

Also adds a Remat3Test regression test checking the fwds wiring and that gradients are unchanged.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->