### PR TITLE
[hijax] normalize jupytext cell spacing in hitypes doc

### DIFF
--- a/docs/hijax_types.ipynb
+++ b/docs/hijax_types.ipynb
@@ -676,9 +676,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e254a848",
-   "metadata": {
-    "lines_to_end_of_cell_marker": 2
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def qarray_shard(self, mesh, manual_axes, check_vma, spec):\n",
@@ -709,10 +707,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ecd5c343",
-   "metadata": {
-    "lines_to_end_of_cell_marker": 0,
-    "lines_to_next_cell": 1
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mesh = jax.make_mesh((4,), ('i',))\n",

--- a/docs/hijax_types.py
+++ b/docs/hijax_types.py
@@ -487,8 +487,6 @@ def qarray_unshard(self, mesh, check_vma, spec):
 
 QArrayTy.shard = qarray_shard
 QArrayTy.unshard = qarray_unshard
-
-
 # -
 
 # Now quantized arrays can cross `shard_map` boundaries in either direction.
@@ -511,6 +509,8 @@ def quantize_shards(x):
 qrows = quantize_shards(rows)
 print(jax.typeof(qrows))
 print(qrows.qvalue.sharding.spec, qrows.scale.sharding.spec)
+
+
 # -
 
 # And consuming one, where each device sees a per-shard `QArray` of its own


### PR DESCRIPTION
Fixes the lint_and_typecheck failure on main: the pre-commit jupytext hook rewrites docs/hijax_types.{py,ipynb} because the py file's nonstandard blank-line spacing is stored as cell metadata in the ipynb but is not representable in the md pairing. No content changes.