### PR TITLE
[remat3] support offloading via save_and_offload_only_these_names

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -143,28 +143,38 @@ def save_only_these_names(*names_which_can_be_saved):
   """Save only named values, and only among the names given."""
   return SaveOnlyTheseNames(frozenset(names_which_can_be_saved))
 
+@dataclass(frozen=True)
+class SaveAndOffloadOnlyTheseNames:
+  names_which_can_be_saved: frozenset[str]
+  names_which_can_be_offloaded: frozenset[str]
+  offload_src: str
+  offload_dst: str
+
+  def __call__(self, prim, *_, **params):
+    if prim is name_p and params['name'] in self.names_which_can_be_saved:
+      return pe.Saveable
+    if prim is name_p and params['name'] in self.names_which_can_be_offloaded:
+      return pe.Offloadable(src=self.offload_src, dst=self.offload_dst)
+    return pe.Recompute  # not saveable unless it's in the allow-list
+
 def save_and_offload_only_these_names(
     *, names_which_can_be_saved, names_which_can_be_offloaded,
     offload_src, offload_dst):
   """Same as ``save_only_these_names``, but offload to CPU memory instead of
   recomputing."""
-  names_which_can_be_saved = set(names_which_can_be_saved)
-  names_which_can_be_offloaded = set(names_which_can_be_offloaded)
-  intersection = names_which_can_be_saved.intersection(names_which_can_be_offloaded)
+  names_which_can_be_saved = frozenset(names_which_can_be_saved)
+  names_which_can_be_offloaded = frozenset(names_which_can_be_offloaded)
+  intersection = names_which_can_be_saved & names_which_can_be_offloaded
   if intersection:
     raise ValueError(
         "The names should be exclusive and should not intersect in"
         " `names_which_can_be_saved` and `names_which_can_be_offloaded`. Got"
-        f" names_which_can_be_saved={names_which_can_be_saved},"
-        f" names_which_can_be_offloaded={names_which_can_be_offloaded} and the"
-        f" intersection={intersection}")
-  def policy(prim, *_, **params):
-    if prim is name_p and params['name'] in names_which_can_be_saved:
-      return pe.Saveable
-    if prim is name_p and params['name'] in names_which_can_be_offloaded:
-      return pe.Offloadable(src=offload_src, dst=offload_dst)
-    return pe.Recompute  # not saveable unless it's in the allow-list
-  return policy
+        f" names_which_can_be_saved={set(names_which_can_be_saved)},"
+        f" names_which_can_be_offloaded={set(names_which_can_be_offloaded)} and"
+        f" the intersection={set(intersection)}")
+  return SaveAndOffloadOnlyTheseNames(
+      names_which_can_be_saved, names_which_can_be_offloaded,
+      offload_src, offload_dst)
 
 
 def save_from_both_policies(policy_1, policy_2):
@@ -1114,6 +1124,19 @@ class CheckpointName(VJPHiPrimitive):
                   else self.name in policy.saveable_names)
       rem = partial(primal_left_tangent_right, x) if saveable else lambda x: x
       return x, rem
+    elif isinstance(policy, SaveAndOffloadOnlyTheseNames):
+      if self.name in policy.names_which_can_be_saved:
+        return x, partial(primal_left_tangent_right, x)
+      elif self.name in policy.names_which_can_be_offloaded:
+        x_host = api.device_put(x, core.mem_kind_to_space(policy.offload_dst),
+                                may_alias=False)
+        src_space = core.mem_kind_to_space(policy.offload_src)
+        def rem(x_rem):
+          x_dev = api.device_put(x_host, src_space, may_alias=False)
+          return primal_left_tangent_right(x_dev, x_rem)
+        return x, rem
+      else:
+        return x, lambda x: x  # full remat
     elif policy is everything_saveable:
       return x, partial(primal_left_tangent_right, x)
     else:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6809,6 +6809,55 @@ class RematTest(jtu.JaxTestCase):
     ans = api.grad(lambda x: f(x).sum())(jnp.float32(3.))
     self.assertAllClose(ans, 2 * np.sin(1.) ** 2, check_dtypes=False)
 
+  def test_remat_offload_names_jaxpr(self):
+    # Jaxpr-level check of save_and_offload_only_these_names: offloaded values
+    # are device_put to the offload destination on the fwd pass and saved
+    # there, then device_put back on the bwd pass. (Execution needs a device
+    # with memory kinds; see tests/memories_test.py.)
+    policy = jax.checkpoint_policies.save_and_offload_only_these_names(
+        names_which_can_be_saved=['y'], names_which_can_be_offloaded=['z', 'w'],
+        offload_src='device', offload_dst='pinned_host')
+
+    @partial(jax.remat, policy=policy)
+    def f(x):
+      y = checkpoint_name(jnp.sin(x), 'y')
+      z = checkpoint_name(jnp.sin(y), 'z')
+      w = checkpoint_name(jnp.sin(z), 'w')
+      return jnp.sum(w * z)
+
+    jaxpr_text = str(api.make_jaxpr(api.grad(f))(jnp.arange(16.)))
+    self.assertEqual(jaxpr_text.count('MemorySpace.Host'), 2)
+    self.assertEqual(jaxpr_text.count('MemorySpace.Device'), 2)
+
+    with self.assertRaisesRegex(
+        ValueError, "The names should be exclusive and should not intersect"):
+      jax.checkpoint_policies.save_and_offload_only_these_names(
+          names_which_can_be_saved=['y'], names_which_can_be_offloaded=['y'],
+          offload_src='device', offload_dst='pinned_host')
+
+  def test_remat_offload_names_of_scan_jaxpr(self):
+    # Like test_remat_offload_names_jaxpr, but with the named values inside a
+    # scan body: the per-iteration offloaded copies are saved as stacked
+    # host-space residuals.
+    policy = jax.checkpoint_policies.save_and_offload_only_these_names(
+        names_which_can_be_saved=['y'], names_which_can_be_offloaded=['z', 'w'],
+        offload_src='device', offload_dst='pinned_host')
+
+    @partial(jax.remat, policy=policy)
+    def f(x):
+      def g(y, _):
+        y = checkpoint_name(jnp.sin(y), 'y')
+        z = checkpoint_name(jnp.sin(y), 'z')
+        w = checkpoint_name(jnp.sin(z), 'w')
+        return w, jnp.sum(w * z)
+      _, out = lax.scan(g, x, None, length=3)
+      return jnp.sum(out)
+
+    jaxpr_text = str(api.make_jaxpr(api.grad(f))(jnp.arange(16.)))
+    self.assertEqual(jaxpr_text.count('MemorySpace.Host'), 2)
+    self.assertEqual(jaxpr_text.count('MemorySpace.Device'), 2)
+    self.assertIn('<host>[3,16]', jaxpr_text)  # stacked host residuals
+
   @parameterized.named_parameters(
       {"testcase_name": f"{suffix}", "remat": remat}
       for suffix, remat in [


### PR DESCRIPTION
Defunctionalize save_and_offload_only_these_names into a dataclass policy, and handle it in CheckpointName's remat rule: the fwd side device_puts the named value to the offload destination, and the rem side device_puts it back, so the saved residual is the offloaded copy. The dataclass keeps the remat2 functional interface (returning pe.Saveable / pe.Offloadable / pe.Recompute), so remat2 behavior is unchanged. This replaces remat2's approach of constructing device_put eqns during partial evaluation.

```python
# with jax_remat3=True:
policy = jax.checkpoint_policies.save_and_offload_only_these_names(
    names_which_can_be_saved=[], names_which_can_be_offloaded=['z'],
    offload_src='device', offload_dst='pinned_host')

@partial(jax.remat, policy=policy)
def f(x):
  z = checkpoint_name(jnp.sin(x), 'z')
  return jnp.sum(z * z)

print(jax.make_jaxpr(jax.grad(f))(jnp.arange(4.)))
```

```
{ lambda ; a:f32[4]. let
    b:f32[4] = sin a
    c:f32[4] = call_hi_primitive[_prim=CheckpointName[{'name': 'z'}]] b
    d:f32<host>[4] = device_put[devices=(MemorySpace.Host,) ...] c
    e:f32[4] = mul c c
    _:f32[] = reduce_sum[axes=(0,) out_sharding=None] e
    f:f32<host>[4] = reduce_precision[...] d
    g:f32[4] = optimization_barrier a
    h:f32[4] i:f32[4] = call_hi_primitive[
      _prim=RematTraced[{'jaxpr': { lambda ; a:f32<host>[4] b:f32[4]. let
    c:f32[4] = cos b
    d:f32[4] = device_put[devices=(MemorySpace.Device,) ...] a
  in (c, d) }, 'policy': SaveAndOffloadOnlyTheseNames(...)}]
    ] f g
    ...
  in (n,) }
```

Tests are jaxpr-level and run under both remat configs on any backend (execution needs a device with memory kinds; see tests/memories_test.py), including a scan case checking the stacked host-space residuals.

Note: jtu.fwd_bwd_jaxprs can't be used for these tests because make_jaxpr(..., return_shape=True) drops the memory space from its ShapeDtypeStructs, so retracing the bwd feeds device-space avals where the rebound remat expects host-space residuals (its input typecheck rejects that, correctly). The tests trace grad in one go instead. The same issue means memories_test's fwd_bwd_jaxprs-based assertions will need that fidelity fix before they can pass under remat3.