### PR TITLE
[remat3] support offloading via offload_dot_with_no_batch_dims

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -95,19 +95,24 @@ class DotsSaveable:
 checkpoint_dots = dots_saveable = DotsSaveable(False)
 dots_with_no_batch_dims_saveable = DotsSaveable(True)
 
-# TODO TODO memories_test.py
+@dataclass(frozen=True)
+class OffloadDotWithNoBatchDims:
+  offload_src: str
+  offload_dst: str
+
+  def __call__(self, prim, *_, **params):
+    if prim is lax_internal.dot_general_p:
+      (_, _), (lhs_b, rhs_b) = params['dimension_numbers']
+      if not lhs_b and not rhs_b:
+        return pe.Offloadable(src=self.offload_src, dst=self.offload_dst)
+    return pe.Recompute
+
 def offload_dot_with_no_batch_dims(offload_src, offload_dst):
   """Same as ``dots_with_no_batch_dims_saveable``, but offload to CPU memory
   instead of recomputing.
 
   This is a useful heuristic for transformers."""
-  def policy(prim, *_, **params):
-    if prim is lax_internal.dot_general_p:
-      (_, _), (lhs_b, rhs_b) = params['dimension_numbers']
-      if not lhs_b and not rhs_b:
-        return pe.Offloadable(src=offload_src, dst=offload_dst)
-    return pe.Recompute
-  return policy
+  return OffloadDotWithNoBatchDims(offload_src, offload_dst)
 
 
 name_p = core.Primitive('name')

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -6002,12 +6002,24 @@ dot_general_p = standard_primitive(
 
 
 def _dot_general_remat(trace, lhs, rhs, **params):
-  from jax._src.ad_checkpoint import DotsSaveable, primal_left_tangent_right
+  from jax._src.ad_checkpoint import (
+      DotsSaveable, OffloadDotWithNoBatchDims, primal_left_tangent_right)
   dot = partial(dot_general_p.bind, **params)
   out = dot(lhs, rhs)
   if (isinstance(trace.policy, DotsSaveable) and
       trace.policy(dot_general_p, typeof(lhs), typeof(rhs), **params)):
     return out, lambda lhs, rhs: primal_left_tangent_right(out, dot(lhs, rhs))
+  if isinstance(trace.policy, OffloadDotWithNoBatchDims):
+    verdict = trace.policy(dot_general_p, typeof(lhs), typeof(rhs), **params)
+    if isinstance(verdict, pe.Offloadable):
+      from jax._src.api import device_put
+      out_host = device_put(out, core.mem_kind_to_space(verdict.dst),
+                            may_alias=False)
+      src_space = core.mem_kind_to_space(verdict.src)
+      def rem(lhs, rhs):
+        out_dev = device_put(out_host, src_space, may_alias=False)
+        return primal_left_tangent_right(out_dev, dot(lhs, rhs))
+      return out, rem
   return out, dot  # full remat
 remat.rules[dot_general_p] = _dot_general_remat
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6858,6 +6858,26 @@ class RematTest(jtu.JaxTestCase):
     self.assertEqual(jaxpr_text.count('MemorySpace.Device'), 2)
     self.assertIn('<host>[3,16]', jaxpr_text)  # stacked host residuals
 
+  def test_remat_offload_dot_with_no_batch_dims_jaxpr(self):
+    # Jaxpr-level check of offload_dot_with_no_batch_dims: outputs of dots
+    # without batch dimensions are device_put to the offload destination on
+    # the fwd pass and saved there, then device_put back on the bwd pass;
+    # dots with batch dimensions are rematerialized as usual.
+    policy = jax.checkpoint_policies.offload_dot_with_no_batch_dims(
+        'device', 'pinned_host')
+
+    @partial(jax.remat, policy=policy)
+    def f(x, b):
+      x = jnp.einsum('ij,jk->ik', x, x)      # offloaded
+      b = jnp.einsum('bij,bjk->bik', b, b)   # batch dims: not offloaded
+      x = jnp.sin(x)
+      return jnp.sum(x) + jnp.sum(jnp.sin(b))
+
+    jaxpr_text = str(api.make_jaxpr(api.grad(f))(jnp.ones((4, 4)),
+                                                 jnp.ones((2, 4, 4))))
+    self.assertEqual(jaxpr_text.count('MemorySpace.Host'), 1)
+    self.assertEqual(jaxpr_text.count('MemorySpace.Device'), 1)
+
   @parameterized.named_parameters(
       {"testcase_name": f"{suffix}", "remat": remat}
       for suffix, remat in [


### PR DESCRIPTION
Defunctionalize offload_dot_with_no_batch_dims into a dataclass policy, and handle it in dot_general's remat rule the same way CheckpointName's rule handles SaveAndOffloadOnlyTheseNames: the fwd side device_puts the dot's output to the offload destination, and the rem side device_puts it back and pairs it with the recomputation via primal_left_tangent_right, so the saved residual is the offloaded copy. Dots with batch dimensions are rematerialized as before. The dataclass keeps the remat2 functional interface (returning pe.Offloadable / pe.Recompute), so remat2 behavior is unchanged, and the two configs produce the same device_put structure.

```python
# with jax_remat3=True:
policy = jax.checkpoint_policies.offload_dot_with_no_batch_dims(
    'device', 'pinned_host')

@partial(jax.remat, policy=policy)
def f(x):
  x = jnp.einsum('ij,jk->ik', x, x)
  x = jnp.sin(x)
  return jnp.sum(x)

print(jax.make_jaxpr(jax.grad(f))(jnp.ones((4, 4))))
```

The dot's output is offloaded on the fwd pass, the host copy is the saved residual, and the rebound remat reloads it on the bwd pass:

```
{ lambda ; a:f32[4,4]. let
    b:f32[4,4] = dot_general[...] a a
    c:f32<host>[4,4] = device_put[devices=(MemorySpace.Host,) ...] b
    ...
    e:f32<host>[4,4] = reduce_precision[...] c
    ...
    h:... = call_hi_primitive[
      _prim=RematTraced[{'jaxpr': { lambda ; a:f32<host>[4,4] ... let
    ...
    d:f32[4,4] = device_put[devices=(MemorySpace.Device,) ...] a
    ...
```

The test is jaxpr-level and runs under both remat configs on any backend (execution needs a device with memory kinds; see tests/memories_test.py), and includes a batched dot checking the no-batch-dims restriction.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->