### PR TITLE
Release GIL while awaiting topology compile

### DIFF
--- a/jaxlib/py_client.cc
+++ b/jaxlib/py_client.cc
@@ -440,6 +440,7 @@ static absl::StatusOr<nb_class_ptr<PyExecutable>> CompileWithTopology(
   options.allow_in_place_mlir_modification = true;
   ifrt::ExecutableRef ifrt_executable;
   {
+    nb::gil_scoped_release gil_release;
     auto xla_options =
         std::make_unique<ifrt::XlaCompileOptions>(options, std::move(devices));
     TF_ASSIGN_OR_RETURN(


### PR DESCRIPTION
Fixes #38829.

`CompileWithTopology` waits on an IFRT compile future via `Compile(...).Await()`. When the future invokes Python HLO module transformation callbacks, those callbacks need to acquire the Python GIL. Holding the GIL while awaiting the future can deadlock the callback path.

This releases the GIL around the blocking topology compile await, matching the pattern used by other blocking compile paths in `py_client.cc`.

Tested manually in a TPU AOT compile path with a Python HLO transformation callback: the callback enters Python and the compile completes successfully.