### PR TITLE
[ROCm] Fix PgleTest.testAutoPgle expected fdo profile counts

### DIFF
--- a/tests/pgle_test.py
+++ b/tests/pgle_test.py
@@ -167,9 +167,9 @@ class PgleTest(jtu.JaxTestCase):
           self.assertArraysEqual(f(x), expected)
         self.assertEqual(cache_miss_count(), 2)
         fdo_profiles_before_pgle = self.get_fdo_profiles(dump_dir)
-        # One for before optimizatiom, one after SPMD partitioning, and one
-        # after optimization.
-        self.assertLen(fdo_profiles_before_pgle, 3)
+        # One before optimization, one after SPMD partitioning, one before
+        # config assignment, and one after optimization.
+        self.assertLen(fdo_profiles_before_pgle, 4)
         # The FDO profile file should be empty.
         self.assertEqual(
             os.path.getsize(os.path.join(dump_dir, fdo_profiles_before_pgle[0])), 0)
@@ -179,9 +179,9 @@ class PgleTest(jtu.JaxTestCase):
           self.assertArraysEqual(f(x), expected)
         self.assertEqual(cache_miss_count(), 2)
         fdo_profiles_after_pgle = self.get_fdo_profiles(dump_dir)
-        # One more before optimizatiom, one more after SPMD partitioning, and
-        # one more after optimization.
-        self.assertLen(fdo_profiles_after_pgle, 6)
+        # Four more: one before optimization, one after SPMD partitioning, one
+        # before config assignment, and one after optimization.
+        self.assertLen(fdo_profiles_after_pgle, 8)
 
         for fdo_profile in fdo_profiles_after_pgle:
           if fdo_profile not in fdo_profiles_before_pgle:


### PR DESCRIPTION
## What
`tests/pgle_test.py::PgleTest.testAutoPgle` fails: it expects 3 `.fdo_profile`
dumps before PGLE recompilation and 6 after, but now sees 4 and 8.

## Why
openxla/xla added a `before_config_assignment` HLO dump (7067eddcfa, re-landed
as 990f1be81d), which writes one extra `.fdo_profile` per compiled module. The
multi-host test (`tests/multiprocess/pgle_test.py`) was already updated for this
(same commit that re-landed the dump); the single-host test was missed.

## Fix
Bump the expected counts 3 -> 4 and 6 -> 8 to match the new dump.