### PR TITLE
docs(nn): describe scaled_matmul platform behavior accurately

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -1299,12 +1299,15 @@ def scaled_matmul(
       - We currently do not support user-defined `precision` for customizing the
         compute data type. It is fixed to `jnp.float32`.
       - Block size is inferred as `K // K_a` for `a` and `K // K_b` for `b`.
-      - **Platform support:** ``scaled_matmul`` is currently implemented only on
-        GPU (NVIDIA CUDA, natively fused on Blackwell via cuDNN; AMD ROCm). It has
-        no TPU or CPU lowering and raises ``NotImplementedError`` on those
-        platforms. Portable callers should branch on
-        ``jax.devices()[0].platform`` and provide a fallback (e.g. dequantize +
-        ``jax.lax.dot_general`` on the quantized operands).
+      - **Platform support:** ``scaled_matmul`` has a natively fused fast path on
+        GPU (NVIDIA CUDA, fused on Blackwell via cuDNN; AMD ROCm). On other
+        platforms it lowers through the ``xla.scaled_dot`` composite, whose
+        default expansion dequantizes the operands and calls
+        ``jax.lax.dot_general`` (correct, but not a native low-precision matmul
+        unless the backend provides a block-scaling rewrite for the composite).
+        Backends without any registered lowering raise ``NotImplementedError``;
+        portable callers can branch on ``jax.devices()[0].platform`` if they need
+        to guarantee a specific path.
       - To use cuDNN with Nvidia Blackwell GPUs, inputs must match::
 
           # mxfp8

--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -1299,6 +1299,12 @@ def scaled_matmul(
       - We currently do not support user-defined `precision` for customizing the
         compute data type. It is fixed to `jnp.float32`.
       - Block size is inferred as `K // K_a` for `a` and `K // K_b` for `b`.
+      - **Platform support:** ``scaled_matmul`` is currently implemented only on
+        GPU (NVIDIA CUDA, natively fused on Blackwell via cuDNN; AMD ROCm). It has
+        no TPU or CPU lowering and raises ``NotImplementedError`` on those
+        platforms. Portable callers should branch on
+        ``jax.devices()[0].platform`` and provide a fallback (e.g. dequantize +
+        ``jax.lax.dot_general`` on the quantized operands).
       - To use cuDNN with Nvidia Blackwell GPUs, inputs must match::
 
           # mxfp8


### PR DESCRIPTION
## Summary

Updates the `scaled_matmul` docstring's platform-support note to describe what
actually happens on each backend, instead of stating it is GPU-only.

- **GPU (CUDA/ROCm):** natively fused fast path (cuDNN on Blackwell).
- **Other backends:** lowers through the `xla.scaled_dot` composite, whose default
  expansion dequantizes and calls `lax.dot_general` — correct, but native only if
  the backend provides a block-scaling rewrite for the composite.
- Backends with no registered lowering raise `NotImplementedError`.

## Context

This supersedes the earlier "GPU-only / always raises `NotImplementedError` on
TPU" wording, which is no longer accurate given the TPU lowering added in #39056.
The two PRs are complementary: #39056 registers the TPU lowering; this PR keeps the
public docstring consistent with the composite-based behavior.

---
*Authored with [Navi](https://navibot.dev) on behalf of @lokic233.*