### PR TITLE
Support negative axis arguments in lax.psum_scatter and lax.all_to_all

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -569,6 +569,8 @@ def _all_to_all_is_async(x, axis_name, split_axis, concat_axis, *,
                          axis_index_groups=None, tiled=False, is_async=False):
   axis_index_groups = _canonicalize_axis_index_groups(axis_index_groups)
   def bind(x, split_axis=split_axis, concat_axis=concat_axis):
+    split_axis = canonicalize_axis(split_axis, np.ndim(x))
+    concat_axis = canonicalize_axis(concat_axis, np.ndim(x))
     group_size = _axis_size(axis_name, axis_index_groups)
     if tiled:
       if x.shape[split_axis] % group_size != 0:
@@ -2334,7 +2336,8 @@ def _psum_scatter(x, axis_name, *, scatter_dimension, axis_index_groups, tiled,
     leaf = insert_collective_pvary(axis_name, leaf)
     prim = reduce_scatter_start_p if is_async else reduce_scatter_p
     return prim.bind(
-        leaf, axis_name=axis_name, scatter_dimension=scatter_dimension,
+        leaf, axis_name=axis_name,
+        scatter_dimension=canonicalize_axis(scatter_dimension, np.ndim(leaf)),
         axis_index_groups=axis_index_groups, axis_size=axis_size, tiled=tiled)
   return tree_util.tree_map(bind, x)
 

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -470,6 +470,20 @@ class PythonPmapTest(jtu.JaxTestCase):
       self.assertAllClose(actual,
                           expected[i * scatter_len:(i + 1) * scatter_len])
 
+  def testReduceScatterNegativeScatterDimension(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/20125: a
+    # negative scatter_dimension should give the same result as the equivalent
+    # non-negative axis.
+    device_count = jax.device_count()
+    shape = (device_count, device_count, 4 * device_count)
+    x = np.arange(math.prod(shape), dtype=np.float32).reshape(shape)
+    # The per-device operand is rank 2, so scatter_dimension=-1 is axis 1.
+    pos = pmap(lambda x: lax.psum_scatter(x, 'i', scatter_dimension=1,
+                                          tiled=True), axis_name='i')(x)
+    neg = pmap(lambda x: lax.psum_scatter(x, 'i', scatter_dimension=-1,
+                                          tiled=True), axis_name='i')(x)
+    self.assertAllClose(neg, pos)
+
   def testReduceScatterReplicaGroupsTiled(self):
     replicas = jax.device_count()
     if replicas % 2 != 0:
@@ -566,6 +580,18 @@ class PythonPmapTest(jtu.JaxTestCase):
     ref = jnp.moveaxis(x, (pmap_in_axis, split_axis),
                           (concat_axis + 1, 0))
     self.assertAllClose(y, ref)
+
+  def testAllToAllNegativeAxes(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/20125: negative
+    # split_axis/concat_axis arguments should give the same result as the
+    # equivalent non-negative axes.
+    shape = (jax.device_count(),) * 3
+    rng = jtu.rand_default(self.rng())
+    x = rng(shape, np.float32)
+    # The per-device operand is rank 2, so (-2, -1) map to (0, 1).
+    pos = pmap(lambda x: lax.all_to_all(x, 'i', 0, 1), axis_name='i')(x)
+    neg = pmap(lambda x: lax.all_to_all(x, 'i', -2, -1), axis_name='i')(x)
+    self.assertAllClose(neg, pos)
 
   def testMismatchedAxisSizes(self):
     n = jax.device_count()


### PR DESCRIPTION
## What

`jax.lax.psum_scatter` (`scatter_dimension`) and `jax.lax.all_to_all` (`split_axis`, `concat_axis`) now accept negative axis arguments, consistent with `jax.lax.all_gather`.

## Why

Fixes #20125 and #19720. Previously a negative `scatter_dimension` was forwarded straight to the reduce-scatter primitive and reached XLA as a negative `scatter_dimension` attribute, failing StableHLO verification (`value is non-negative`). Negative `split_axis`/`concat_axis` in `all_to_all` fed raw axis arithmetic in the collective helper and crashed lowering. `all_gather` avoids this by normalizing its axis, and the surrounding code already assumes non-negative axes.

Following @hawkinsp's suggestion on #20125, the axes are now normalized with `jax._src.util.canonicalize_axis` (already imported in `parallel.py`) at the public API boundary — against the per-device operand rank — before any downstream arithmetic. This also yields a clear `ValueError` on an out-of-range axis instead of an opaque XLA verification failure or a crash. No primitive, batching, transpose, or lowering rules change; both the tiled and non-tiled paths and the sync/async variants are covered.

## Testing

Added `testReduceScatterNegativeScatterDimension` and `testAllToAllNegativeAxes` to `tests/pmap_test.py`, asserting that a negative axis produces the same result as the equivalent non-negative axis. Both fail on `main` (MLIR verification error / segfault) and pass with this change; existing pmap/shard_map/async/batching collective tests still pass.
