### PR TITLE
[Pallas][Trition] Fix gpu_info on real devices

### DIFF
--- a/jax/_src/pallas/triton/gpu_info.py
+++ b/jax/_src/pallas/triton/gpu_info.py
@@ -16,37 +16,28 @@
 
 import dataclasses
 import enum
-import re
 from collections.abc import Callable
 
 from jax._src import mesh as mesh_lib
 from jax._src import util as jax_util
 from jax._src.interpreters import pxla
+from jax._src.lib import xla_client as xc
 
 
 class GpuVersion(enum.Enum):
   """GPU version"""
 
   # NVIDIA GPUs
-  A10 = "NVIDIA A10"
-  A30 = "NVIDIA A30"
-  A100 = "NVIDIA A100"
-  H100 = "NVIDIA H100"
-  H200 = "NVIDIA H200"
-  GH200 = "NVIDIA GH200"
-  B200 = "NVIDIA B200"
-  GB200 = "NVIDIA GB200"
-  B300 = "NVIDIA B300"
-  GB300 = "NVIDIA GB300"
-  GB10 = "NVIDIA GB10"
-  L4 = "NVIDIA L4"
-  L40 = "NVIDIA L40"
-  T4 = "Tesla T4"
-  RTX_4090 = "NVIDIA GeForce RTX 4090"
-  RTX_PRO_4500 = "NVIDIA RTX PRO 4500"
-  RTX_PRO_5000 = "NVIDIA RTX PRO 5000"
-  RTX_PRO_6000 = "NVIDIA RTX PRO 6000"
-  THOR = "NVIDIA Thor"
+  NV_7_5 = "7.5"
+  NV_8_0 = "8.0"
+  NV_8_6 = "8.6"
+  NV_8_9 = "8.9"
+  NV_9_0 = "9.0"
+  NV_10_0 = "10.0"
+  NV_10_3 = "10.3"
+  NV_11_0 = "11.0"
+  NV_12_0 = "12.0"
+  NV_12_1 = "12.1"
 
   # AMD GPUs
   GFX908 = "gfx908"
@@ -66,25 +57,22 @@ class GpuVersion(enum.Enum):
     return self.value
 
 
-_GPU_VERSION_RE = re.compile(r"\b(" + "|".join(e.value for e in GpuVersion) + r")\b")
-
-
 def gpu_version_from_device_kind(device_kind: str) -> GpuVersion | None:
-  if m := _GPU_VERSION_RE.match(device_kind):
-    return GpuVersion(m.group())
+  if device_kind in GpuVersion:
+    return GpuVersion(device_kind)
   return None
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GpuInfo:
   """GPU hardware information"""
-  gpu_version: GpuVersion
   arch_name: str
   compute_capability: int
+  gpu_version: GpuVersion | None
 
 
 def is_gpu_device() -> bool:
-  return gpu_version_from_device_kind(get_device_kind()) is not None
+  return _get_device().platform == "gpu"
 
 
 registry: dict[str, Callable[[], GpuInfo]] = {}
@@ -96,102 +84,50 @@ def _get_gpu_info_impl(gpu_version: GpuVersion) -> GpuInfo:
   Args:
     gpu_version: The GPU version.
   """
-  # https://developer.nvidia.com/cuda/gpus
-  match gpu_version:
-    case GpuVersion.T4:
-      return GpuInfo(
-          gpu_version=gpu_version,
-          arch_name="7.5",
-          compute_capability=75,
-      )
-    case GpuVersion.A100 | GpuVersion.A30:
-      return GpuInfo(
-          gpu_version=gpu_version,
-          arch_name="8.0",
-          compute_capability=80,
-      )
-    case GpuVersion.A10:
-      return GpuInfo(
-          gpu_version=gpu_version,
-          arch_name="8.6",
-          compute_capability=86,
-      )
-    case GpuVersion.L4 | GpuVersion.L40 | GpuVersion.RTX_4090:
-      return GpuInfo(
-          gpu_version=gpu_version,
-          arch_name="8.9",
-          compute_capability=89,
-      )
-    case GpuVersion.H100 | GpuVersion.H200 | GpuVersion.GH200:
-      return GpuInfo(
-          gpu_version=gpu_version,
-          arch_name="9.0",
-          compute_capability=90,
-      )
-    case GpuVersion.B200 | GpuVersion.GB200:
-      return GpuInfo(
-          gpu_version=gpu_version,
-          arch_name="10.0",
-          compute_capability=100,
-      )
-    case GpuVersion.B300 | GpuVersion.GB300:
-      return GpuInfo(
-          gpu_version=gpu_version,
-          arch_name="10.3",
-          compute_capability=103,
-      )
-    case GpuVersion.RTX_PRO_4500 | GpuVersion.RTX_PRO_5000 | GpuVersion.RTX_PRO_6000:
-      return GpuInfo(
-          gpu_version=gpu_version,
-          arch_name="12.0",
-          compute_capability=120,
-      )
-    case GpuVersion.GB10:
-      return GpuInfo(
-          gpu_version=gpu_version,
-          arch_name="12.1",
-          compute_capability=121,
-      )
-    case GpuVersion.THOR:
-      return GpuInfo(
-          gpu_version=gpu_version,
-          arch_name="11.0",
-          compute_capability=110,
-      )
-    # AMD GPUs. The enum value is already the gfx arch name.
-    case (
-        GpuVersion.GFX908
-        | GpuVersion.GFX90A
-        | GpuVersion.GFX942
-        | GpuVersion.GFX950
-        | GpuVersion.GFX1030
-        | GpuVersion.GFX1100
-        | GpuVersion.GFX1101
-        | GpuVersion.GFX1103
-        | GpuVersion.GFX1150
-        | GpuVersion.GFX1151
-        | GpuVersion.GFX1200
-        | GpuVersion.GFX1201
-    ):
-      return GpuInfo(
-          gpu_version=gpu_version,
-          arch_name=gpu_version.value,
-          compute_capability=0,
-      )
-    case _:
-      raise ValueError(f"Unsupported GPU version: {gpu_version}")
+  def get_cc(arch_name):
+    try:
+      return int(arch_name.replace(".", ""))
+    except ValueError:
+      return 0
+
+  return GpuInfo(
+      arch_name=gpu_version.value,
+      compute_capability=get_cc(gpu_version.value),
+      gpu_version=gpu_version,
+  )
 
 
 @jax_util.cache(trace_context_in_key=True)
 def get_gpu_info() -> GpuInfo:
   """Returns the GPU hardware info for the current device."""
-  device_kind = get_device_kind()
-  gpu_version = gpu_version_from_device_kind(device_kind)
-  if gpu_version is None:
+  device = _get_device()
+  if device.platform != "gpu":
+    raise RuntimeError(f"Can not get GPU info on the platform: {device.platform}")
+
+  if isinstance(device, mesh_lib.AbstractDevice):
+    device_kind = device.device_kind
+    gpu_version = gpu_version_from_device_kind(device.device_kind)
+    if gpu_version is not None:
+      return _get_gpu_info_impl(gpu_version)
+
     if device_kind in registry:
       return registry[device_kind]()
-    raise ValueError(f"Unsupported GPU device kind: {device_kind}")
-  return _get_gpu_info_impl(gpu_version)
+
+    raise RuntimeError(f"Unsupported GPU device kind: {device_kind}")
+  else:
+    # Real device case.
+    arch_name = str(device.compute_capability)
+    if "cuda" in device.client.platform_version:
+      compute_capability = int(arch_name.replace(".", ""))
+    else:
+      # Other cases, e.g. rocm.
+      compute_capability = 0
+
+    return GpuInfo(
+      arch_name=arch_name,
+      compute_capability=compute_capability,
+      gpu_version=None,
+    )
 
 
 @jax_util.cache(trace_context_in_key=True)
@@ -206,7 +142,15 @@ def get_gpu_info_from_version(
   return _get_gpu_info_impl(gpu_version)
 
 
-def get_device_kind() -> str:
+def _get_device() -> mesh_lib.AbstractDevice | xc.Device:
+  default_device = pxla.get_default_device()
   if abstract_device := mesh_lib.get_abstract_mesh().abstract_device:
-    return abstract_device.device_kind
-  return pxla.get_default_device().device_kind
+    # Check if abstract device was created from a real device.
+    if default_device.device_kind == abstract_device.device_kind:
+      return default_device
+    return abstract_device
+  return default_device
+
+
+def get_device_kind() -> str:
+  return _get_device().device_kind

--- a/tests/pallas/triton_gpu_info_test.py
+++ b/tests/pallas/triton_gpu_info_test.py
@@ -17,6 +17,7 @@ import sys
 from absl.testing import absltest
 from absl.testing import parameterized
 import jax
+from jax._src import mesh as mesh_lib
 from jax._src import test_util as jtu
 from jax._src.pallas.triton import gpu_info
 
@@ -34,67 +35,65 @@ class GpuInfoTest(jtu.JaxTestCase):
   def setUp(self):
     super().setUp()
     if not plgpu:
-      self.skipTest("Skipping test because device is not a GPU.")
+      self.skipTest("Triton support is not available.")
     if jtu.is_device_cuda() or jtu.is_device_rocm():
       self.assertTrue(plgpu.is_gpu_device())
     else:
       self.assertFalse(plgpu.is_gpu_device())
       self.skipTest("Skipping test because device is not a GPU.")
 
-  def test_get_gpu_info(self):
+  def test_get_gpu_info_real_device(self):
+    # on real device
     device = jax.devices()[0]
     info = plgpu.get_gpu_info()
     self.assertIsInstance(info, plgpu.GpuInfo)
-    self.assertEqual(info.arch_name, device.compute_capability)
-    expected_version = gpu_info.gpu_version_from_device_kind(device.device_kind)
-    self.assertEqual(info.gpu_version, expected_version)
 
-    cc = info.compute_capability
-    match info.gpu_version:
-      case GpuVersion.T4:
-        self.assertEqual(cc, 75)
-      case GpuVersion.A100 | GpuVersion.A30:
-        self.assertEqual(cc, 80)
-      case GpuVersion.A10:
-        self.assertEqual(cc, 86)
-      case GpuVersion.L4 | GpuVersion.L40 | GpuVersion.RTX_4090:
-        self.assertEqual(cc, 89)
-      case GpuVersion.H100 | GpuVersion.H200 | GpuVersion.GH200:
-        self.assertEqual(cc, 90)
-      case GpuVersion.B200 | GpuVersion.GB200:
-        self.assertEqual(cc, 100)
-      case GpuVersion.B300 | GpuVersion.GB300:
-        self.assertEqual(cc, 103)
-      case GpuVersion.RTX_PRO_4500 | GpuVersion.RTX_PRO_5000 | GpuVersion.RTX_PRO_6000:
-        self.assertEqual(cc, 120)
-      case GpuVersion.GB10:
-        self.assertEqual(cc, 121)
-      case _:
-        self.assertEqual(cc, 0)
+    expected_arch_name = str(device.compute_capability)
+    if "cuda" in device.client.platform_version:
+      expected_compute_capability = int(expected_arch_name.replace(".", ""))
+    else:
+      expected_compute_capability = 0
+    self.assertEqual(info.arch_name, expected_arch_name)
+    self.assertEqual(info.compute_capability, expected_compute_capability)
+
+  @parameterized.parameters([
+    "10.0",
+    "gfx1200",
+  ])
+  def test_get_gpu_info_abs_device(self, device_kind):
+    expected_info = gpu_info.get_gpu_info_from_version(
+        gpu_info.gpu_version_from_device_kind(device_kind)
+    )
+    abstract_device = mesh_lib.AbstractDevice(device_kind, 1, platform='gpu')
+    abstract_mesh = mesh_lib.AbstractMesh(
+        (1,),
+        ('x',),
+        (mesh_lib.AxisType.Explicit,),
+        abstract_device=abstract_device,
+    )
+    with mesh_lib.use_abstract_mesh(abstract_mesh):
+      info = plgpu.get_gpu_info()
+      self.assertEqual(info.arch_name, expected_info.arch_name)
+      self.assertEqual(info.compute_capability, expected_info.compute_capability)
 
   def test_get_gpu_info_given_gpu_version(self):
     info = plgpu.get_gpu_info()
+    if info.gpu_version is None:
+      self.skipTest(
+          f"Skipping test as GPU device: {gpu_info.get_device_kind()} "
+          "is not in GpuVersion."
+      )
     info_version = plgpu.get_gpu_info_from_version(info.gpu_version)
     self.assertEqual(info, info_version)
 
   @parameterized.parameters([
-    ("NVIDIA A100-SXM4-40GB", GpuVersion.A100),
-    ("NVIDIA A100-SXM4-80GB", GpuVersion.A100),
-    ("NVIDIA A100-PCIE-40GB", GpuVersion.A100),
-    ("NVIDIA A100 80GB PCIe", GpuVersion.A100),
-    ("NVIDIA A10 WHATEVER", GpuVersion.A10),
-    ("NVIDIA H100 80GB HBM3", GpuVersion.H100),
-    ("NVIDIA H100 PCIe", GpuVersion.H100),
-    ("NVIDIA H100 NVL", GpuVersion.H100),
-    ("NVIDIA RTX 123", None),
+    ("10.0", GpuVersion.NV_10_0),
+    ("12.1", GpuVersion.NV_12_1),
     ("UNKNOWN", None),
     ("gfx908", GpuVersion.GFX908),
     ("gfx90a", GpuVersion.GFX90A),
-    ("gfx90a:sramecc+:xnack-", GpuVersion.GFX90A),
     ("gfx942", GpuVersion.GFX942),
-    ("gfx942:sramecc+:xnack-", GpuVersion.GFX942),
     ("gfx950", GpuVersion.GFX950),
-    ("gfx950:sramecc+:xnack-", GpuVersion.GFX950),
     ("gfx1030", GpuVersion.GFX1030),
     ("gfx1100", GpuVersion.GFX1100),
     ("gfx1101", GpuVersion.GFX1101),

--- a/tests/pallas/triton_pallas_test.py
+++ b/tests/pallas/triton_pallas_test.py
@@ -507,10 +507,8 @@ class TritonPallasTest(PallasBaseTest):
     )
 
   def test_deviceless_aot(self):
-    if jtu.is_device_rocm():
-      abstract_device = mesh_lib.AbstractDevice('gfx950', 1, 'rocm')
-    else:
-      abstract_device = mesh_lib.AbstractDevice('NVIDIA A100', 1, 'cuda')
+    device_kind = 'gfx950' if jtu.is_device_rocm() else '10.0'
+    abstract_device = mesh_lib.AbstractDevice(device_kind, 1, 'gpu')
     abstract_mesh = mesh_lib.AbstractMesh(
         (1,),
         ('x',),
@@ -551,6 +549,31 @@ class TritonPallasTest(PallasBaseTest):
     np.testing.assert_allclose(
         output, jax.nn.softmax(x, axis=-1), atol=1e-5, rtol=1e-5
     )
+
+  def test_gpu_info_under_shard_map(self):
+    mesh = mesh_lib.Mesh(jax.devices(), 'x')
+    abstract_mesh = mesh.abstract_mesh
+
+    batch_size = 2
+    size = 32
+    block_size = 64
+    @functools.partial(
+        self.pallas_call,
+        out_shape=jax.ShapeDtypeStruct((batch_size, size), jnp.float32),
+        grid=batch_size,
+    )
+    def kernel(x_ref, o_ref):
+      row_idx = pl.program_id(0)
+      x_idx = jnp.arange(block_size)
+      row_idxs = (row_idx, x_idx)
+      mask = x_idx < x_ref.shape[1]
+      row = plgpu.load(x_ref.at[row_idxs], mask=mask, other=-float("inf"))
+      plgpu.store(o_ref.at[row_idxs], row, mask=mask)
+
+    x = jnp.ones((batch_size, size))
+    kernel = jax.shard_map(kernel, mesh=abstract_mesh,
+                           in_specs=jax.P(), out_specs=jax.P(), check_vma=False)
+    jax.jit(kernel).trace(x).lower(lowering_platforms=('gpu',))
 
   def test_unsigned_integer_dot_raises(self):
     @functools.partial(


### PR DESCRIPTION
- Now it is returning compute_capability and arch_name from the real device and from GpuVersion list for AbstractDevice
- If abstract device is available and it matches the real device (same device_kind), then we use real device for GpuInfo


