### PR TITLE
build: make add_subparsers required flag robust to argparse backports

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -376,8 +376,11 @@ async def main():
       formatter_class=argparse.RawDescriptionHelpFormatter
   )
 
-  # Create subparsers for build and requirements_update
-  subparsers = parser.add_subparsers(dest="command", required=True)
+  # Create subparsers for build and requirements_update. Set `required` as an
+  # attribute instead of passing required= to add_subparsers(): some argparse
+  # backports reject that keyword (TypeError).
+  subparsers = parser.add_subparsers(dest="command")
+  subparsers.required = True
 
   # requirements_update subcommand
   requirements_update_parser = subparsers.add_parser(


### PR DESCRIPTION
On a stock interpreter build/build.py runs fine, but where a third-party
argparse backport shadows the stdlib module (the reporter's traceback comes
from site-packages/argparse.py, not the stdlib path), add_subparsers(required=True)
raises TypeError: _SubParsersAction.__init__() got an unexpected keyword
argument 'required'. The backport's _SubParsersAction predates the required
keyword that stdlib argparse has had since Python 3.7.

This sets subparsers.required = True as an attribute instead of passing
required= to add_subparsers(). Every argparse reads the attribute at parse
time, so it works on both the stdlib and the older backport while still
requiring a subcommand.

Fixes #38969.
