### PR TITLE
[hijax] custom_vjp3 fixes: VmapOf sym-zero jvp, errors, pretty-printing

### DIFF
--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -532,10 +532,15 @@ class VmapOf(VJPHiPrimitive):
                     **self._vmap_params)(*args)
 
   def jvp(self, primals, tangents):
-    # TODO probably gonna get non-pytree-prefix errors because of sym zeros...
-    return api.vmap(self.prim.jvp, in_axes=(self.in_dims, self.in_dims),  # pyrefly: ignore[missing-attribute]
-                    out_axes=(self.out_dim, self.out_dim),
-                    **self._vmap_params)(primals, tangents)
+    tangents = tree_map(partial(map_zero, self.axis_data), self.in_dims,
+                        tangents, is_leaf=lambda x: x is None)
+    primals_out, tangents_out = api.vmap(
+        self.prim.jvp, in_axes=(self.in_dims, self.in_dims),  # pyrefly: ignore[missing-attribute]
+        out_axes=(self.out_dim, self.out_dim),
+        **self._vmap_params)(primals, tangents)
+    tangents_out = tree_map(partial(unmap_zero, self.axis_data), self.out_dim,
+                            tangents_out, is_leaf=lambda x: x is None)
+    return primals_out, tangents_out
 
   def vjp_fwd(self, in_nzs, *args):
     store = lambda: None
@@ -604,6 +609,16 @@ def _call_hi_primitive_to_lojax(*args_flat, _prim):
   ans = _prim.expand(*args)
   return tree_leaves_checked(_prim.out_tree, ans)
 call_hi_primitive_p.to_lojax = _call_hi_primitive_to_lojax
+
+def _call_hi_primitive_prettyprint(eqn, context, settings):
+  # print CustomVJPTraced tersely since its params repr is noise (Traced
+  # objects, functions), but let prims like RematTraced print in full since
+  # their repr shows the inner jaxpr
+  if isinstance(eqn.params['_prim'], CustomVJPTraced):
+    params = dict(eqn.params, _prim=eqn.params['_prim'].__class__.__name__)
+    eqn = eqn.replace(params=params)
+  return core._pp_eqn(eqn, context, settings)
+core.pp_eqn_rules[call_hi_primitive_p] = _call_hi_primitive_prettyprint
 
 def _call_hi_primitive_batcher(axis_data, args_flat, dims_flat, _prim):
   args = tree_unflatten(_prim.in_tree, args_flat)
@@ -676,7 +691,7 @@ def _call_hi_primitive_linearized_transpose(
 ad.fancy_transposes[call_hi_primitive_linearized_p] = _call_hi_primitive_linearized_transpose
 
 def _call_hi_primitive_linearized_prettyprint(eqn, context, settings):
-  params = dict(eqn.params, _prim=str(eqn.params['_prim'].__class__),
+  params = dict(eqn.params, _prim=eqn.params['_prim'].__class__.__name__,
                 residuals_tree='...')
   return core._pp_eqn(eqn.replace(params=params), context, settings)
 core.pp_eqn_rules[call_hi_primitive_linearized_p] = _call_hi_primitive_linearized_prettyprint
@@ -924,7 +939,7 @@ class CustomVJPTraced(VJPHiPrimitive):
     return in_cts
 
   def jvp(self, primals, tangents):
-    if self.symbolic_zeros: raise NotImplementedError
+    if self.symbolic_zeros: ad.raise_custom_vjp_error_on_jvp()
     zero = lambda x: isinstance(x, ad_util.Zero)
     tangents = tree_map(ad_util.instantiate, tangents, is_leaf=zero)
     if self.opt_remat:
@@ -1058,7 +1073,6 @@ class custom_vjp3:
           f"custom_vjp-decorated function {self.f} closed over a {type(t).__name__} "
           f"of type {t.aval.str_short()}, but custom_vjp functions can't close "
           f"over Tracers. Rewrite {self.f} to take it as an explicit input.")
-      raise Exception  # TODO(mattjj):error tracer type, value type, primal name
     args = tuple(Static(x) if i in self.static_argnums else x for i, x in enumerate(args))
     in_avals = tree_map(typeof, args)
     prim = CustomVJPTraced(traced, self.fwd, self.bwd, in_avals, self.symz,

--- a/tests/custom_api_test.py
+++ b/tests/custom_api_test.py
@@ -1926,6 +1926,27 @@ class CustomVJPTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(UnexpectedTracerError, "custom_vjp"):
       _ = api.grad(g, 1)(2., 3.)
 
+  def test_nondiff_arg_nested_tracer_error(self):
+    # Like test_nondiff_arg_tracer_error, but with the tracer hidden inside a
+    # container in the nondiff_argnums slot.
+    @partial(jax.custom_vjp, nondiff_argnums=(0,))
+    def f(xs, y):
+      return xs[0] * y
+    def f_fwd(xs, y):
+      return f(xs, y), jnp.cos(y)
+    def f_rev(xs, cos_y, g):
+      return (cos_y * g,)
+    f.defvjp(f_fwd, f_rev)
+
+    @jit
+    def g(x, y):
+      return f((x,), y)
+
+    with self.assertRaisesRegex(UnexpectedTracerError, "custom_vjp"):
+      _ = g(2., 3.)
+    with self.assertRaisesRegex(UnexpectedTracerError, "custom_vjp"):
+      _ = api.grad(g, 1)(2., 3.)
+
   def test_vmap_axes(self):
     raise unittest.SkipTest("TODO")  # TODO(mattjj): write test
 
@@ -3399,8 +3420,58 @@ class CustomVJP3Test(CustomVJPTest):
   def test_symbolic_zero_custom_vjp_bwd_shape_error(self): pass
   def test_symbolic_zeros_remat(self): pass
   def test_dce(self): pass
-  def test_pretty_print(self): pass
-  def test_custom_lin_pretty_print(self): pass
+
+  def test_pretty_print(self):
+    @jax.custom_vjp
+    def f(x):
+      return x + 1
+
+    def f_fwd(x):
+      return f(x), ()
+
+    def f_bwd(_, g):
+      return g
+    f.defvjp(f_fwd, f_bwd)
+
+    x = jnp.array([4.2], dtype=jnp.float32)
+    jaxpr = jax.make_jaxpr(f)(x)
+    actual = jaxpr.pretty_print(use_color=False)
+    expected = textwrap.dedent(
+        """
+        { lambda ; a:f32[1]. let
+            b:f32[1] = call_hi_primitive[_prim=CustomVJPTraced] a
+          in (b,) }
+        """).strip()
+    self.assertEqual(actual, expected)
+
+  def test_custom_lin_pretty_print(self):
+    @jax.custom_vjp
+    def f(x):
+      return x + 1
+
+    def f_fwd(x):
+      return f(x), ()
+
+    def f_bwd(_, g):
+      return g
+    f.defvjp(f_fwd, f_bwd)
+
+    x = jnp.array([4.2], dtype=jnp.float32)
+    jaxpr = jax.make_jaxpr(lambda x: jax.jvp(f, (x,), (x,)))(x)
+    jaxpr, _ = pe.dce_jaxpr(jaxpr.jaxpr, [False, True])
+    actual = jaxpr.pretty_print(use_color=False)
+    expected = textwrap.dedent(
+        """
+        { lambda ; a:f32[1]. let
+            b:f32[1] = call_hi_primitive_linearized[
+              _prim=CustomVJPTraced
+              nz_in_flat=(True,)
+              nz_out_flat=(True,)
+              residuals_tree=...
+            ] a
+          in (b,) }
+        """).strip()
+    self.assertEqual(actual, expected)
 
   # vmap closure: don't support anymore, but raise good errors
   def test_closed_over_vmap_tracer(self):
@@ -3463,6 +3534,23 @@ class CustomVJP3Test(CustomVJPTest):
 
     with self.assertRaisesRegex(UnexpectedTracerError, "can't close over"):
       jtu.check_grads(h, (jnp.float32(3.14),), order=1, modes=['rev'])
+
+  # improved error message (classic raises "CustomVJPPrimal ... is not a valid
+  # JAX type" here instead)
+  def test_jvp_error_symbolic_zeros(self):
+    @jax.custom_vjp
+    def f(x):
+      return jnp.sin(x)
+    def f_fwd(x):
+      return f(x), jnp.cos(x)
+    def f_rev(cos_x, g):
+      return (2 * cos_x * g.value,)
+    f.defvjp(f_fwd, f_rev, symbolic_zeros=True)
+
+    self.assertRaisesRegex(
+        TypeError,
+        r"can't apply forward-mode autodiff \(jvp\) to a custom_vjp function.",
+        lambda: api.jvp(f, (3.,), (1.,)))
 
   # improved error message
   def test_fwd_rule_primal_out_type_doesnt_match_primal_error_message(self):

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -1164,6 +1164,43 @@ class HijaxTest(jtu.JaxTestCase):
     f = jax.vmap(mul, in_axes=(0, None))
     f = jax.vmap(f, in_axes=(2, None), out_axes=2)
     self.assertAllClose(f(x, y), x * y[None, :, None])
+
+  def test_newstyle_hiprimitive_vmap_jvp_symbolic_zero_tangent(self):
+
+    class Mul(VJPHiPrimitive):
+
+      def __init__(self, aval):
+        self.in_avals = (aval, aval)
+        self.out_aval = aval
+        self.params = {}
+        super().__init__()
+
+      def expand(self, x, y):
+        return x * y
+
+      def jvp(self, primals, tangents):
+        (x, y), (x_dot, y_dot) = primals, tangents
+        x_dot, y_dot = map(instantiate_zeros, (x_dot, y_dot))
+        return mul(x, y), mul(x_dot, y) + mul(x, y_dot)
+
+      def batch_dim_rule(self, axis_data, in_dims):
+        return in_dims[1] if in_dims[0] is None else in_dims[0]
+
+    def mul(x, y):
+      return Mul(typeof(x))(x, y)
+
+    # ys is closed over, so its tangent is a symbolic zero whose aval must be
+    # mapped before reaching the jvp rule under vmap
+    xs, ys = jnp.arange(3.0), jnp.full(3, 2.0)
+    primals_out, tangents_out = jax.jvp(
+        lambda x: jax.vmap(mul)(x, ys), (xs,), (jnp.ones(3),))
+    self.assertAllClose(primals_out, xs * ys)
+    self.assertAllClose(tangents_out, ys)
+
+    primals_out, tangents_out = jax.jvp(
+        lambda x: jax.vmap(mul, in_axes=(0, None))(x, 2.0), (xs,), (jnp.ones(3),))
+    self.assertAllClose(primals_out, 2.0 * xs)
+    self.assertAllClose(tangents_out, jnp.full(3, 2.0))
     x = jnp.arange(12.0).reshape(3, 4)
     y = jnp.arange(6.0).reshape(2, 3)
     f = jax.vmap(mul, in_axes=(None, 0))


### PR DESCRIPTION
* fix VmapOf.jvp to map/unmap symbolic-zero tangent avals; it previously produced wrong-shaped outputs when a tangent was a symbolic zero (e.g. from a closed-over constant under jvp-of-vmap)
* raise the classic "can't apply forward-mode autodiff (jvp)" TypeError for jvp of a symbolic_zeros=True custom_vjp, not a bare NotImplementedError
* add a pretty-print rule for call_hi_primitive_p and print class names rather than str(cls) in call_hi_primitive_linearized; un-regress the pretty-print tests under custom_vjp3
* test that tracers nested inside containers in nondiff_argnums slots raise UnexpectedTracerError (already handled via the unhashable-statics fallback)
* remove an unreachable raise in custom_vjp3.__call__