### PR TITLE
[oneAPI] Add ThreeFry2x32 PRNG GPU kernel for Intel GPUs

### DIFF
--- a/jax/_src/random/threefry2x32.py
+++ b/jax/_src/random/threefry2x32.py
@@ -230,6 +230,11 @@ mlir.register_lowering(
     partial(_threefry2x32_gpu_lowering_rule, target_name_prefix='hip'),
     platform='rocm',
     inline=False)
+mlir.register_lowering(
+    threefry2x32_p,
+    partial(_threefry2x32_gpu_lowering_rule, target_name_prefix='oneapi'),
+    platform='oneapi',
+    inline=False)
 
 
 @api.jit(inline=True)

--- a/jaxlib/gpu/BUILD
+++ b/jaxlib/gpu/BUILD
@@ -54,6 +54,7 @@ exports_files(srcs = [
     "prng_kernels.cc",
     "prng_kernels.cu.cc",
     "prng_kernels.h",
+    "prng_kernels_oneapi.cc",
     "py_client_gpu.cc",
     "py_client_gpu.h",
     "rnn.cc",

--- a/jaxlib/gpu/prng_kernels_oneapi.cc
+++ b/jaxlib/gpu/prng_kernels_oneapi.cc
@@ -1,0 +1,144 @@
+/* Copyright 2026 The JAX Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "jaxlib/gpu/prng_kernels.h"
+
+#include <algorithm>
+#include <cstdint>
+
+#include "jaxlib/gpu/vendor.h"
+
+namespace jax {
+namespace JAX_GPU_NAMESPACE {
+
+// Kernel name type — must be in a named namespace for SYCL linkage.
+class prng_threefry2x32_kernel;
+
+namespace {
+
+void ThreeFry2x32Kernel(::sycl::nd_item<1> item,
+                        const std::uint32_t* key0,
+                        const std::uint32_t* key1,
+                        const std::uint32_t* data0,
+                        const std::uint32_t* data1,
+                        std::uint32_t* out0, std::uint32_t* out1,
+                        std::int64_t n, const std::int64_t* n_ptr) {
+  if (n < 0) {
+    n = *n_ptr;
+  }
+
+  const std::int64_t grid_stride = item.get_global_range(0);
+  for (std::int64_t idx = item.get_global_id(0); idx < n;
+       idx += grid_stride) {
+    std::uint32_t rotations[8] = {13, 15, 26, 6, 17, 29, 16, 24};
+    std::uint32_t x[2];
+    std::uint32_t ks[3];
+
+    // 0x1BD11BDA is a parity constant specified by the ThreeFry2x32 algorithm.
+    ks[2] = 0x1BD11BDA;
+
+    ks[0] = key0[idx];
+    x[0] = data0[idx];
+    ks[2] = ks[2] ^ key0[idx];
+
+    ks[1] = key1[idx];
+    x[1] = data1[idx];
+    ks[2] = ks[2] ^ key1[idx];
+
+    auto rotate_left = [](std::uint32_t v, std::uint32_t distance) {
+      return (v << distance) | (v >> (32 - distance));
+    };
+
+    auto round = [&](std::uint32_t* v, std::uint32_t rotation) {
+      v[0] += v[1];
+      v[1] = rotate_left(v[1], rotation);
+      v[1] ^= v[0];
+    };
+
+    // 20 rounds of ThreeFry2x32 (5 iterations x 4 rounds).
+    x[0] = x[0] + ks[0];
+    x[1] = x[1] + ks[1];
+    for (int i = 0; i < 4; ++i) {
+      round(x, rotations[i]);
+    }
+
+    x[0] = x[0] + ks[1];
+    x[1] = x[1] + ks[2] + 1u;
+    for (int i = 4; i < 8; ++i) {
+      round(x, rotations[i]);
+    }
+
+    x[0] = x[0] + ks[2];
+    x[1] = x[1] + ks[0] + 2u;
+    for (int i = 0; i < 4; ++i) {
+      round(x, rotations[i]);
+    }
+
+    x[0] = x[0] + ks[0];
+    x[1] = x[1] + ks[1] + 3u;
+    for (int i = 4; i < 8; ++i) {
+      round(x, rotations[i]);
+    }
+
+    x[0] = x[0] + ks[1];
+    x[1] = x[1] + ks[2] + 4u;
+    for (int i = 0; i < 4; ++i) {
+      round(x, rotations[i]);
+    }
+
+    out0[idx] = x[0] + ks[2];
+    out1[idx] = x[1] + ks[0] + 5u;
+  }
+}
+
+}  // namespace
+
+void LaunchThreeFry2x32KernelFfi(gpuStream_t stream,
+                                 std::int64_t n,
+                                 std::uint32_t* keys0,
+                                 std::uint32_t* keys1,
+                                 std::uint32_t* data0,
+                                 std::uint32_t* data1,
+                                 std::uint32_t* out0,
+                                 std::uint32_t* out1) {
+  // Unlike CUDA, SYCL throws sycl::exception(errc::invalid) when constructing a
+  // zero-sized nd_range. Guard against empty inputs (n <= 0) to avoid it.
+  if (n <= 0) {
+    return;
+  }
+  const int local_range = 128;  // work-items per work-group
+  const std::int64_t num_work_groups =
+      std::min<std::int64_t>(1024, (n + local_range - 1) / local_range);
+
+  absl::Status status = TryCatchToStatus([&] {
+    stream->submit([&](::sycl::handler& cgh) {
+      cgh.parallel_for<prng_threefry2x32_kernel>(
+          ::sycl::nd_range<1>(::sycl::range<1>(num_work_groups * local_range),
+                              ::sycl::range<1>(local_range)),
+          [=](::sycl::nd_item<1> item) {
+            ThreeFry2x32Kernel(item, keys0, keys1, data0, data1, out0, out1, n,
+                               nullptr);
+          });
+    });
+  });
+
+  if (!status.ok()) {
+    LOG(ERROR) << "LaunchThreeFry2x32KernelFfi: " << status.message();
+  }
+
+}
+
+}  // namespace JAX_GPU_NAMESPACE
+}  // namespace jax

--- a/jaxlib/gpu/prng_kernels_oneapi.cc
+++ b/jaxlib/gpu/prng_kernels_oneapi.cc
@@ -1,0 +1,143 @@
+/* Copyright 2026 The JAX Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "jaxlib/gpu/prng_kernels.h"
+
+#include <algorithm>
+#include <cstdint>
+
+#include "jaxlib/gpu/vendor.h"
+
+namespace jax {
+namespace JAX_GPU_NAMESPACE {
+
+// Kernel name type — must be in a named namespace for SYCL linkage.
+class prng_threefry2x32_kernel;
+
+namespace {
+
+void ThreeFry2x32Kernel(::sycl::nd_item<1> item,
+                        const std::uint32_t* key0,
+                        const std::uint32_t* key1,
+                        const std::uint32_t* data0,
+                        const std::uint32_t* data1,
+                        std::uint32_t* out0, std::uint32_t* out1,
+                        std::int64_t n, const std::int64_t* n_ptr) {
+  if (n < 0) {
+    n = *n_ptr;
+  }
+
+  const std::int64_t grid_stride = item.get_global_range(0);
+  for (std::int64_t idx = item.get_global_id(0); idx < n;
+       idx += grid_stride) {
+    std::uint32_t rotations[8] = {13, 15, 26, 6, 17, 29, 16, 24};
+    std::uint32_t x[2];
+    std::uint32_t ks[3];
+
+    // 0x1BD11BDA is a parity constant specified by the ThreeFry2x32 algorithm.
+    ks[2] = 0x1BD11BDA;
+
+    ks[0] = key0[idx];
+    x[0] = data0[idx];
+    ks[2] = ks[2] ^ key0[idx];
+
+    ks[1] = key1[idx];
+    x[1] = data1[idx];
+    ks[2] = ks[2] ^ key1[idx];
+
+    auto rotate_left = [](std::uint32_t v, std::uint32_t distance) {
+      return (v << distance) | (v >> (32 - distance));
+    };
+
+    auto round = [&](std::uint32_t* v, std::uint32_t rotation) {
+      v[0] += v[1];
+      v[1] = rotate_left(v[1], rotation);
+      v[1] ^= v[0];
+    };
+
+    // 20 rounds of ThreeFry2x32 (5 iterations x 4 rounds).
+    x[0] = x[0] + ks[0];
+    x[1] = x[1] + ks[1];
+    for (int i = 0; i < 4; ++i) {
+      round(x, rotations[i]);
+    }
+
+    x[0] = x[0] + ks[1];
+    x[1] = x[1] + ks[2] + 1u;
+    for (int i = 4; i < 8; ++i) {
+      round(x, rotations[i]);
+    }
+
+    x[0] = x[0] + ks[2];
+    x[1] = x[1] + ks[0] + 2u;
+    for (int i = 0; i < 4; ++i) {
+      round(x, rotations[i]);
+    }
+
+    x[0] = x[0] + ks[0];
+    x[1] = x[1] + ks[1] + 3u;
+    for (int i = 4; i < 8; ++i) {
+      round(x, rotations[i]);
+    }
+
+    x[0] = x[0] + ks[1];
+    x[1] = x[1] + ks[2] + 4u;
+    for (int i = 0; i < 4; ++i) {
+      round(x, rotations[i]);
+    }
+
+    out0[idx] = x[0] + ks[2];
+    out1[idx] = x[1] + ks[0] + 5u;
+  }
+}
+
+}  // namespace
+
+void LaunchThreeFry2x32KernelFfi(gpuStream_t stream,
+                                 std::int64_t n,
+                                 std::uint32_t* keys0,
+                                 std::uint32_t* keys1,
+                                 std::uint32_t* data0,
+                                 std::uint32_t* data1,
+                                 std::uint32_t* out0,
+                                 std::uint32_t* out1) {
+  // Unlike CUDA, SYCL throws sycl::exception(errc::invalid) when constructing a
+  // zero-sized nd_range. Guard against empty inputs (n <= 0) to avoid it.
+  if (n <= 0) {
+    return;
+  }
+  const int local_range = 128;  // work-items per work-group
+  const std::int64_t num_work_groups =
+      std::min<std::int64_t>(1024, (n + local_range - 1) / local_range);
+
+  absl::Status status = TryCatchToStatus([&] {
+    stream->submit([&](::sycl::handler& cgh) {
+      cgh.parallel_for<prng_threefry2x32_kernel>(
+          ::sycl::nd_range<1>(::sycl::range<1>(num_work_groups * local_range),
+                              ::sycl::range<1>(local_range)),
+          [=](::sycl::nd_item<1> item) {
+            ThreeFry2x32Kernel(item, keys0, keys1, data0, data1, out0, out1, n,
+                               nullptr);
+          });
+    });
+  });
+
+  if (!status.ok()) {
+    LOG(ERROR) << "LaunchThreeFry2x32KernelFfi: " << status.message();
+  }
+}
+
+}  // namespace JAX_GPU_NAMESPACE
+}  // namespace jax

--- a/jaxlib/gpu_prng.py
+++ b/jaxlib/gpu_prng.py
@@ -18,14 +18,16 @@ from .plugin_support import import_from_plugin
 
 _cuda_prng = import_from_plugin("cuda", "_prng")
 _hip_prng = import_from_plugin("rocm", "_prng")
+_oneapi_prng = import_from_plugin("oneapi", "_prng")
 
 
 def registrations() -> dict[str, list[tuple[str, Any, int]]]:
   registrations: dict[str, list[tuple[str, Any, int]]] = {
       "CUDA": [],
       "ROCM": [],
+      "ONEAPI": [],
   }
-  for platform, module in [("CUDA", _cuda_prng), ("ROCM", _hip_prng)]:
+  for platform, module in [("CUDA", _cuda_prng), ("ROCM", _hip_prng), ("ONEAPI", _oneapi_prng)]:
     if module:
       registrations[platform].extend(
           (name, value, int(name.endswith("_ffi")))

--- a/jaxlib/oneapi/BUILD.bazel
+++ b/jaxlib/oneapi/BUILD.bazel
@@ -97,6 +97,36 @@ sycl_library(
     ],
 )
 
+sycl_library(
+    name = "oneapi_prng_kernels_impl",
+    srcs = ["//jaxlib/gpu:prng_kernels_oneapi.cc"],
+    hdrs = ["//jaxlib/gpu:prng_kernels.h"],
+    features = ["-use_header_modules"],
+    deps = [
+        ":oneapi_gpu_kernel_helpers",
+        ":oneapi_vendor",
+        "@xla//xla/ffi/api:ffi",
+    ],
+)
+
+sycl_library(
+    name = "oneapi_prng_kernels",
+    srcs = ["//jaxlib/gpu:prng_kernels.cc"],
+    hdrs = ["//jaxlib/gpu:prng_kernels.h"],
+    features = ["-use_header_modules"],
+    deps = [
+        ":oneapi_gpu_kernel_helpers",
+        ":oneapi_gpu_runtime",
+        ":oneapi_prng_kernels_impl",
+        ":oneapi_vendor",
+        "//jaxlib:ffi_helpers",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/status",
+        "@xla//xla/ffi/api:c_api",
+        "@xla//xla/ffi/api:ffi",
+    ],
+)
+
 nanobind_extension(
     name = "_solver",
     srcs = ["//jaxlib/gpu:solver.cc"],
@@ -120,9 +150,29 @@ nanobind_extension(
     ],
 )
 
+nanobind_extension(
+    name = "_prng",
+    srcs = ["//jaxlib/gpu:prng.cc"],
+    copts = [
+        "-fexceptions",
+        "-fno-strict-aliasing",
+    ],
+    linkopts = ["-link_stage"],
+    features = ["-use_header_modules"],
+    module_name = "_prng",
+    deps = [
+        ":oneapi_gpu_kernel_helpers",
+        ":oneapi_prng_kernels",
+        ":oneapi_vendor",
+        "//jaxlib:kernel_nanobind_helpers",
+        "@nanobind",
+    ],
+)
+
 py_library(
     name = "oneapi_gpu_support",
     deps = [
+        ":_prng",
         ":_solver",
     ],
 )

--- a/jaxlib/tools/build_gpu_kernels_wheel.py
+++ b/jaxlib/tools/build_gpu_kernels_wheel.py
@@ -243,6 +243,7 @@ def prepare_wheel_oneapi(
   copy_files(
       dst_dir=plugin_dir,
       src_files=[
+          f"{source_file_prefix}jaxlib/oneapi/_prng.{pyext}",
           f"{source_file_prefix}jaxlib/oneapi/_solver.{pyext}",
           f"{source_file_prefix}jaxlib/oneapi/oneapi_plugin_extension.{pyext}",
           f"{source_file_prefix}jaxlib/version.py",

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -415,12 +415,16 @@ class PrngTest(jtu.JaxTestCase):
       hlo_text = jax.jit(f).lower(jax.random.key(17)).as_text()
       if jtu.is_device_rocm():
         self.assertNotIn("hip_threefry2x32", hlo_text)
+      elif jtu.is_device_oneapi():
+        self.assertNotIn("oneapi_threefry2x32", hlo_text)
       else:
         self.assertNotIn("cu_threefry2x32", hlo_text)
     with jax._src.config.threefry_gpu_kernel_lowering(True):
       hlo_text = jax.jit(f).lower(jax.random.key(17)).as_text()
       if jtu.is_device_rocm():
         self.assertIn("hip_threefry2x32", hlo_text)
+      elif jtu.is_device_oneapi():
+        self.assertIn("oneapi_threefry2x32", hlo_text)
       else:
         self.assertIn("cu_threefry2x32", hlo_text)
 


### PR DESCRIPTION
This PR:

1. Adds a SYCL/oneAPI implementation of the ThreeFry2x32 PRNG GPU kernel (`jaxlib/gpu/prng_kernels_oneapi.cc`), enabling native random number generation on Intel GPUs. 
2. Wires the `oneapi` platform through registration and lowering (`jaxlib/gpu_prng.py`, `jax/_src/random/threefry2x32.py`) plus the Bazel build and wheel packaging (`jaxlib/oneapi/BUILD.bazel`, `jaxlib/gpu/BUILD`, `jaxlib/tools/*`).
3. Extends `test_threefry_gpu_kernel_lowering` to assert the `oneapi_threefry2x32` custom-call via `jtu.is_device_oneapi()`; oneAPI wheels build cleanly with `--config=oneapi`.
