### PR TITLE
[hijax] extend hitypes doc: container-vs-primitive discipline, matmul_q op, sharding in types

### DIFF
--- a/docs/hijax_custom_derivatives.ipynb
+++ b/docs/hijax_custom_derivatives.ipynb
@@ -225,9 +225,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from jax import make_jaxpr\n",
-    "\n",
-    "make_jaxpr(grad(log1pexp))(100.)"
+    "jit(grad(log1pexp)).trace(100.).jaxpr"
    ]
   },
   {
@@ -336,7 +334,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "make_jaxpr(grad(log1pexp))(100.)"
+    "jit(grad(log1pexp)).trace(100.).jaxpr"
    ]
   },
   {
@@ -1118,7 +1116,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "make_jaxpr(mul)(2., 3.)"
+    "jit(mul).trace(2., 3.).jaxpr"
    ]
   },
   {

--- a/docs/hijax_custom_derivatives.md
+++ b/docs/hijax_custom_derivatives.md
@@ -166,9 +166,7 @@ We can get a bit more insight into what's going on by looking at the jaxpr
 for the gradient computation:
 
 ```{code-cell}
-from jax import make_jaxpr
-
-make_jaxpr(grad(log1pexp))(100.)
+jit(grad(log1pexp)).trace(100.).jaxpr
 ```
 
 Stepping through how the jaxpr would be evaluated, we can see that the last
@@ -241,7 +239,7 @@ We can inspect the jaxpr of the gradient computation to confirm the stable
 formula is what runs:
 
 ```{code-cell}
-make_jaxpr(grad(log1pexp))(100.)
+jit(grad(log1pexp)).trace(100.).jaxpr
 ```
 
 ### Example: Enforcing a differentiation convention
@@ -801,7 +799,7 @@ Because a hijax primitive is a real primitive, it appears as a single
 equation in jaxprs:
 
 ```{code-cell}
-make_jaxpr(mul)(2., 3.)
+jit(mul).trace(2., 3.).jaxpr
 ```
 
 That's true under `jit` too. It's only at lowering time that `expand` is

--- a/docs/hijax_custom_derivatives.py
+++ b/docs/hijax_custom_derivatives.py
@@ -159,13 +159,8 @@ print(grad(log1pexp)(100.))
 # We can get a bit more insight into what's going on by looking at the jaxpr
 # for the gradient computation:
 
-# +
-from jax import make_jaxpr
+jit(grad(log1pexp)).trace(100.).jaxpr
 
-make_jaxpr(grad(log1pexp))(100.)
-
-
-# -
 
 # Stepping through how the jaxpr would be evaluated, we can see that the last
 # line would involve multiplying values that floating point math will round to
@@ -234,7 +229,7 @@ print(vmap(jit(grad(log1pexp)))(jnp.arange(3.)))
 # We can inspect the jaxpr of the gradient computation to confirm the stable
 # formula is what runs:
 
-make_jaxpr(grad(log1pexp))(100.)
+jit(grad(log1pexp)).trace(100.).jaxpr
 
 
 # ### Example: Enforcing a differentiation convention
@@ -794,7 +789,7 @@ print(grad(grad(sin))(3.))
 # Because a hijax primitive is a real primitive, it appears as a single
 # equation in jaxprs:
 
-make_jaxpr(mul)(2., 3.)
+jit(mul).trace(2., 3.).jaxpr
 
 
 # That's true under `jit` too. It's only at lowering time that `expand` is

--- a/docs/hijax_types.ipynb
+++ b/docs/hijax_types.ipynb
@@ -50,7 +50,9 @@
     "* its *tangent type* may differ from its primal structure, so that\n",
     "  derivatives with respect to it aren't just \"the same pytree, but for\n",
     "  tangents\";\n",
-    "* it may have its own notion of batching under `vmap`.\n",
+    "* it may have its own notion of batching under `vmap`;\n",
+    "* it can carry sharding information in the type, participating in JAX's\n",
+    "  explicit sharding mode.\n",
     "\n",
     "Hijax types (or \"hi types\") provide this. You subclass `HiType` to define\n",
     "the type, register a Python class as carrying values of that type, and write\n",
@@ -77,6 +79,9 @@
     "  `MappingSpec` subclass of your own design, and `batch` rules on the\n",
     "  primitives. Mapped-over hi type arguments require an explicit `axis_size`\n",
     "  and spec-valued `in_axes`/`out_axes` entries.\n",
+    "* For sharding in types (explicit mode), record sharding data on your type\n",
+    "  (e.g. a `NamedSharding` field), consume it in `lo_ty`, and propagate it\n",
+    "  in your primitives' typing rules.\n",
     "\n",
     "## Example: quantized arrays\n",
     "\n",
@@ -95,7 +100,7 @@
    "source": [
     "import os\n",
     "os.environ[\"XLA_FLAGS\"] = '--xla_force_host_platform_device_count=8'\n",
-    "# (8 CPU devices, for the shard_map section at the end)\n",
+    "# (8 CPU devices, for the sharding sections at the end)\n",
     "\n",
     "from dataclasses import dataclass\n",
     "\n",
@@ -147,7 +152,18 @@
     "\n",
     "This is like the pytree flatten/unflatten interface, but it lives at the\n",
     "level of *types*: given only the type, JAX can compute the lowered types,\n",
-    "without needing a value in hand."
+    "without needing a value in hand.\n",
+    "\n",
+    "We also give the type a `sharding` field, recording how values are\n",
+    "partitioned across devices; it can be ignored until the sharding sections\n",
+    "near the end of this document. We reuse JAX's `NamedSharding` to describe\n",
+    "the partitioning of the `qvalue` component, and derive `scale`'s\n",
+    "partitioning from it by dropping the last axis. Nothing about the field is\n",
+    "special to JAX, which never interprets it: only our own methods consume\n",
+    "it, chiefly `lo_ty`, which stamps the component types with their\n",
+    "shardings. You're free to track sharding information on your type with an\n",
+    "object of your own design instead, so long as you consume it the same\n",
+    "way."
    ]
   },
   {
@@ -158,15 +174,20 @@
    "outputs": [],
    "source": [
     "from jax.experimental.hijax import HiType, ShapedArray, register_hitype\n",
+    "from jax.sharding import NamedSharding\n",
     "\n",
     "@dataclass(frozen=True)\n",
     "class QArrayTy(HiType):\n",
     "  shape: tuple[int, ...]\n",
+    "  sharding: NamedSharding  # qvalue's sharding; scale's is derived from it\n",
     "\n",
     "  # lowering: which array types make up this type, and how values convert\n",
     "  def lo_ty(self):\n",
-    "    return [ShapedArray(self.shape, jnp.dtype('int8')),\n",
-    "            ShapedArray(self.shape[:-1], jnp.dtype('float32'))]\n",
+    "    scale_sharding = self.sharding.update(spec=jax.P(*self.sharding.spec[:-1]))\n",
+    "    return [ShapedArray(self.shape, jnp.dtype('int8'),\n",
+    "                        sharding=self.sharding),\n",
+    "            ShapedArray(self.shape[:-1], jnp.dtype('float32'),\n",
+    "                        sharding=scale_sharding)]\n",
     "  def lower_val(self, q):\n",
     "    return [q.qvalue, q.scale]\n",
     "  def raise_val(self, qvalue, scale):\n",
@@ -174,14 +195,18 @@
     "\n",
     "  # autodiff: tangents of quantized arrays are plain float arrays (see below)\n",
     "  def to_tangent_aval(self):\n",
-    "    return ShapedArray(self.shape, jnp.dtype('float32'))\n",
+    "    return ShapedArray(self.shape, jnp.dtype('float32'),\n",
+    "                       sharding=self.sharding)\n",
     "\n",
     "  # printing, e.g. in jaxprs\n",
     "  def str_short(self, short_dtypes=False, mesh_axis_types=False):\n",
-    "    return f'q8[{\",\".join(map(str, self.shape))}]'\n",
+    "    dims = [str(d) if p is None else f'{d}@{p}'\n",
+    "            for d, p in zip(self.shape, self.sharding.spec)]\n",
+    "    return f'q8[{\",\".join(dims)}]'\n",
     "  __repr__ = str_short\n",
     "\n",
-    "register_hitype(QArray, lambda q: QArrayTy(q.qvalue.shape))"
+    "register_hitype(QArray, lambda q: QArrayTy(q.qvalue.shape,\n",
+    "                                           jax.typeof(q.qvalue).sharding))"
    ]
   },
   {
@@ -191,9 +216,11 @@
    "source": [
     "The `register_hitype` call associates the value class with the type: its\n",
     "second argument computes the type of any given value, analogous to how\n",
-    "`jax.typeof` maps an array to its `ShapedArray` type. Indeed after\n",
-    "registration, `jax.typeof` works on `QArray`s, and JAX transformations\n",
-    "accept them anywhere a value is expected.\n",
+    "`jax.typeof` maps an array to its `ShapedArray` type. (Ours reads both the\n",
+    "shape and the sharding off the `qvalue` component — every array carries a\n",
+    "sharding, trivial when no mesh is in play.) Indeed after registration,\n",
+    "`jax.typeof` works on `QArray`s, and JAX transformations accept them\n",
+    "anywhere a value is expected.\n",
     "\n",
     "## The primitives\n",
     "\n",
@@ -221,7 +248,7 @@
     "  def __init__(self, x_aval):\n",
     "    if x_aval.dtype != jnp.dtype('float32'): raise TypeError(x_aval.dtype)\n",
     "    self.in_avals = (x_aval,)\n",
-    "    self.out_aval = QArrayTy(x_aval.shape)\n",
+    "    self.out_aval = QArrayTy(x_aval.shape, x_aval.sharding)\n",
     "    self.params = {}\n",
     "    super().__init__()\n",
     "\n",
@@ -240,7 +267,8 @@
     "class Dequantize(VJPHiPrimitive):\n",
     "  def __init__(self, q_aval):\n",
     "    self.in_avals = (q_aval,)\n",
-    "    self.out_aval = ShapedArray(q_aval.shape, jnp.dtype('float32'))\n",
+    "    self.out_aval = ShapedArray(q_aval.shape, jnp.dtype('float32'),\n",
+    "                                sharding=q_aval.sharding)\n",
     "    self.params = {}\n",
     "    super().__init__()\n",
     "\n",
@@ -295,6 +323,176 @@
    "id": "49ccc6a2",
    "metadata": {},
    "source": [
+    "### Primitives outside, container inside\n",
+    "\n",
+    "The `expand` methods above construct `QArray` values and read their\n",
+    "attributes directly. It's important that this kind of direct container\n",
+    "manipulation happen *only* in `expand` (and in the type's own methods,\n",
+    "like `lower_val` and `raise_val`). Everywhere else — in particular, in\n",
+    "any function you might `jit`, differentiate, or `vmap` — hi values should\n",
+    "be produced and consumed only by applying primitives.\n",
+    "\n",
+    "The reason is what traced code actually sees. Under a trace, a quantized\n",
+    "array is not a `QArray` instance: it's a `Tracer` of type `q8[...]`. So\n",
+    "reading an attribute in traced code fails —"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de0d922c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "  jax.jit(lambda qx: qx.qvalue)(qx)\n",
+    "except AttributeError as e:\n",
+    "  print('AttributeError:', e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47ef5033",
+   "metadata": {},
+   "source": [
+    "and, worse, calling the constructor on traced arrays doesn't fail right\n",
+    "away. It smuggles `Tracer`s inside a container that JAX treats as one\n",
+    "opaque concrete value, and the mistake surfaces later, as a confusing\n",
+    "error far from its cause (here a missing constant handler; under `grad`\n",
+    "it's a leaked-tracer error):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8c7ed79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def bad_quantize(x):\n",
+    "  scale = jnp.max(jnp.abs(x), axis=-1) / 127.\n",
+    "  return QArray(jnp.round(x / scale[..., None]).astype('int8'), scale)\n",
+    "\n",
+    "try:\n",
+    "  jax.jit(bad_quantize)(x)\n",
+    "except TypeError as e:\n",
+    "  print('TypeError:', e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "645c78bd",
+   "metadata": {},
+   "source": [
+    "In `expand` it's a different story: by the time `expand` runs, JAX has\n",
+    "committed to implementing the primitive in terms of the type's lojax\n",
+    "components, and its `QArray` arguments are genuine `QArray` instances\n",
+    "(holding lojax values — possibly traced ones). There, manipulating the\n",
+    "value as a plain container is exactly right.\n",
+    "\n",
+    "(The top-level peeks at attributes like `qx.qvalue` elsewhere in this\n",
+    "document are fine for the same reason eager `expand` is fine: they run\n",
+    "eagerly, on concrete values. But inside any function that might get\n",
+    "traced, stick to primitives.)\n",
+    "\n",
+    "### A more realistic op: dense × quantized matmul\n",
+    "\n",
+    "Conversion ops alone make for a thin API: in practice, a quantized array\n",
+    "type earns its keep in ops that consume the type directly. The classic\n",
+    "example is an inference-style matmul, where the activations `x` are an\n",
+    "ordinary dense `f32` array and the weights are quantized:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18416d37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class MatmulQ(VJPHiPrimitive):\n",
+    "  def __init__(self, x_aval, q_aval):\n",
+    "    if not (isinstance(q_aval, QArrayTy) and len(q_aval.shape) == 2 and\n",
+    "            x_aval.shape[-1] == q_aval.shape[0]):\n",
+    "      raise TypeError(f'bad matmul_q operand types: {x_aval} @ {q_aval}')\n",
+    "    self.in_avals = (x_aval, q_aval)\n",
+    "    x_spec, q_spec = x_aval.sharding.spec, q_aval.sharding.spec\n",
+    "    if x_spec[-1] is not None or q_spec[0] is not None:\n",
+    "      raise TypeError('matmul_q requires unsharded contraction axes, got '\n",
+    "                      f'{x_aval} @ {q_aval}')\n",
+    "    out_sharding = x_aval.sharding.update(\n",
+    "        spec=jax.P(*x_spec[:-1], q_spec[-1]))\n",
+    "    self.out_aval = ShapedArray((*x_aval.shape[:-1], q_aval.shape[-1]),\n",
+    "                                jnp.dtype('float32'), sharding=out_sharding)\n",
+    "    self.params = {}\n",
+    "    super().__init__()\n",
+    "\n",
+    "  def expand(self, x, qw):\n",
+    "    # fold the per-row scales into the dense operand, then apply one matmul\n",
+    "    # directly against the int8 payload\n",
+    "    return (x * qw.scale) @ qw.qvalue.astype(jnp.float32)\n",
+    "\n",
+    "  def vjp_fwd(self, nzs_in, x, qw):\n",
+    "    return self(x, qw), (x, qw)\n",
+    "\n",
+    "  def vjp_bwd_retval(self, res, g):\n",
+    "    x, qw = res\n",
+    "    w = dequantize(qw)   # rules are traced code: use primitives here\n",
+    "    # cotangents live where the primals live, so use the primal operands'\n",
+    "    # shardings to disambiguate the (possibly sharded) contractions\n",
+    "    return (jnp.matmul(g, w.T, out_sharding=jax.typeof(x).sharding),\n",
+    "            jnp.matmul(x.T, g, out_sharding=jax.typeof(w).sharding))\n",
+    "\n",
+    "def matmul_q(x, qw):\n",
+    "  return MatmulQ(jax.typeof(x), jax.typeof(qw))(x, qw)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dff6f01",
+   "metadata": {},
+   "source": [
+    "A few things to notice. The type signature mixes array types and hi types\n",
+    "freely: `in_avals` is a `(ShapedArray, QArrayTy)` pair, checked at\n",
+    "construction time so that a shape mismatch fails immediately, with both\n",
+    "operand types pretty-printed. And `expand` exploits the representation:\n",
+    "because the scales apply per-row along the contraction axis, they can be\n",
+    "folded into the dense operand, so the heavy matmul runs directly against\n",
+    "the `int8` payload rather than a dequantized copy. Owning the op as a\n",
+    "single primitive lets us state that rewriting once, in one place.\n",
+    "\n",
+    "Also notice the discipline from the previous section in action: `expand`\n",
+    "reads `qw.scale` and `qw.qvalue` as container attributes, while the VJP\n",
+    "rules — which are ordinary traced code — go through the `dequantize`\n",
+    "primitive instead.\n",
+    "\n",
+    "(The typing rule also computes an output *sharding* — output rows\n",
+    "partitioned like `x`'s, output columns like `qw`'s, with the contracted\n",
+    "axes required to be unsharded — and the backward rule passes\n",
+    "`out_sharding` hints to its matmuls. Both are explained in the\n",
+    "explicit-sharding section below; outside of explicit mode all these\n",
+    "shardings are trivial and the extra code is inert.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e238c0f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w = jnp.arange(12., dtype='float32').reshape(3, 4) / 12.\n",
+    "qw = quantize(w)\n",
+    "\n",
+    "print(matmul_q(x, qw))\n",
+    "print(x @ dequantize(qw))  # reference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee8a9685",
+   "metadata": {},
+   "source": [
     "## Hi types in jaxprs\n",
     "\n",
     "When we trace, the quantized array appears as a single value of type\n",
@@ -308,7 +506,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "jax.make_jaxpr(lambda x: dequantize(quantize(x)))(x)"
+    "jax.jit(lambda x: dequantize(quantize(x))).trace(x).jaxpr"
    ]
   },
   {
@@ -322,8 +520,21 @@
     "`q8[...]`-typed value is expanded into the array components given by\n",
     "`lo_ty`.\n",
     "\n",
-    "`jit` works, with quantized arrays as arguments, results, and\n",
-    "intermediates:"
+    "Ops with mixed operand kinds read just as directly — one equation with a\n",
+    "`f32[2,3] @ q8[3,4] -> f32[2,4]` signature:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cba8a58c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jax.jit(matmul_q).trace(x, qw).jaxpr\n",
+    "#\n",
+    "# `jit` works, with quantized arrays as arguments, results, and\n",
+    "# intermediates:"
    ]
   },
   {
@@ -410,6 +621,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a77c3e02",
+   "metadata": {},
+   "source": [
+    "The same goes for ops with mixed operand kinds, like the quantized\n",
+    "matmul: differentiating a loss with respect to both operands gives an\n",
+    "`f32` gradient for the dense activations *and* an `f32` gradient for the\n",
+    "quantized weights:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff1d870e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def loss(x, qw):\n",
+    "  return jnp.sum(matmul_q(x, qw) ** 2)\n",
+    "\n",
+    "grad_x, grad_qw = jax.grad(loss, argnums=(0, 1))(x, qw)\n",
+    "print(jax.typeof(grad_x), jax.typeof(grad_qw))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6ea2bf8c",
    "metadata": {},
    "source": [
@@ -480,11 +716,13 @@
    "source": [
     "def qarray_dec_rank(self, size, spec):\n",
     "  assert isinstance(spec, QArraySpec) and self.shape[0] == size\n",
-    "  return QArrayTy(self.shape[1:])\n",
+    "  return QArrayTy(self.shape[1:],\n",
+    "                  self.sharding.update(spec=jax.P(*self.sharding.spec[1:])))\n",
     "\n",
     "def qarray_inc_rank(self, size, spec):\n",
     "  assert isinstance(spec, QArraySpec)\n",
-    "  return QArrayTy((size, *self.shape))\n",
+    "  return QArrayTy((size, *self.shape),\n",
+    "                  self.sharding.update(spec=jax.P(None, *self.sharding.spec)))\n",
     "\n",
     "QArrayTy.dec_rank = qarray_dec_rank\n",
     "QArrayTy.inc_rank = qarray_inc_rank"
@@ -707,14 +945,162 @@
    "id": "270bc322",
    "metadata": {},
    "source": [
+    "## Sharding in types: explicit mode\n",
+    "\n",
+    "Finally, sharding. In JAX's explicit sharding mode (see [the parallelism\n",
+    "guide](https://docs.jax.dev/en/latest/parallel.html)), shardings are part\n",
+    "of array *types*: `jax.typeof` reports how a value is partitioned across\n",
+    "the mesh, sharding propagation happens while tracing, and mismatches\n",
+    "surface as type errors. The `sharding` field on `QArrayTy`, and the typing\n",
+    "rules on our primitives that propagate it, are exactly what let hi types\n",
+    "participate. What does it mean to partition a quantized array across\n",
+    "devices? The components move together: if we shard the rows, each device\n",
+    "holds its rows' quantized values *and* their scales. As usual there's a\n",
+    "design choice to make, and we made it back in `lo_ty`: `qvalue` carries\n",
+    "the type's sharding, and `scale` shards like it with the last axis\n",
+    "dropped, so every row travels with its scale.\n",
+    "\n",
+    "Let's see it work. We make a mesh (this is where we use the 8 CPU devices\n",
+    "requested in this document's first cell), shard some rows across it, and\n",
+    "quantize — the shardings propagate through our typing rules into the\n",
+    "result type, which `jax.typeof` displays with `@` markers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57b5d4a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh = jax.make_mesh((4,), ('i',))\n",
+    "jax.set_mesh(mesh)\n",
+    "\n",
+    "rows = jax.device_put(jnp.arange(24., dtype='float32').reshape(8, 3),\n",
+    "                      jax.P('i'))\n",
+    "\n",
+    "qrows = quantize(rows)\n",
+    "print(jax.typeof(qrows))\n",
+    "print(qrows.qvalue.sharding.spec, qrows.scale.sharding.spec)\n",
+    "print(jax.typeof(dequantize(qrows)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "066ed148",
+   "metadata": {},
+   "source": [
+    "The same holds while tracing — hi types in jaxprs now display their\n",
+    "shardings, computed by our `out_aval` rules:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61beaf4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jax.jit(lambda x: dequantize(quantize(x))).trace(rows).jaxpr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a25c4969",
+   "metadata": {},
+   "source": [
+    "The quantized matmul propagates shardings too: its typing rule partitions\n",
+    "output rows like `x`'s rows and output columns like `qw`'s columns\n",
+    "(requiring the contracted axes to be unsharded, since neither operand can\n",
+    "say how a sharded contraction should land):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "760f5c19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w2 = jnp.arange(12., dtype='float32').reshape(3, 4) / 12.\n",
+    "\n",
+    "print(jax.typeof(matmul_q(rows, quantize(w2))))                # rows sharded\n",
+    "\n",
+    "qw2 = quantize(jax.device_put(w2, jax.P(None, 'i')))\n",
+    "print(jax.typeof(qw2))                                         # cols sharded\n",
+    "print(jax.typeof(matmul_q(jnp.ones((2, 3), 'float32'), qw2)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63409cd8",
+   "metadata": {},
+   "source": [
+    "And the contraction check fires as a type error, at trace time:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "faa4a663",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xk = jax.device_put(jnp.ones((2, 8), 'float32'), jax.P(None, 'i'))\n",
+    "qk = quantize(jax.device_put(jnp.ones((8, 3), 'float32'), jax.P('i')))\n",
+    "\n",
+    "try:\n",
+    "  matmul_q(xk, qk)\n",
+    "except TypeError as e:\n",
+    "  print('TypeError:', e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93462e0d",
+   "metadata": {},
+   "source": [
+    "Autodiff composes with all of this. Recall that `MatmulQ`'s backward rule\n",
+    "passed `out_sharding` hints to its matmuls: that's because the cotangent\n",
+    "for `qw` contracts over the row axis, which may be sharded (as it is\n",
+    "here), and explicit mode refuses to guess how an all-sharded contraction\n",
+    "should land. The right answer is the primal operand's sharding —\n",
+    "cotangents live where their primals live:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0b707c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def qloss(x, qw):\n",
+    "  return jnp.sum(matmul_q(x, qw) ** 2)\n",
+    "\n",
+    "grad_rows, grad_qw2 = jax.grad(qloss, argnums=(0, 1))(rows, quantize(w2))\n",
+    "print(jax.typeof(grad_rows), jax.typeof(grad_qw2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5acca0e9",
+   "metadata": {},
+   "source": [
+    "One caution: JAX does not cross-check a hi primitive's declared output\n",
+    "sharding against what its `expand` actually produces. The declared\n",
+    "`out_aval` is what downstream code sees while tracing; `expand` determines\n",
+    "what happens at runtime. Keeping them consistent is part of the typing\n",
+    "rule's job.\n",
+    "\n",
     "## `shard_map` and partition specs\n",
     "\n",
-    "Finally, sharding. What does it mean to partition a quantized array across\n",
-    "devices? Once again the components move together: if we shard the rows,\n",
-    "each device should hold a `QArray` of its rows' quantized values *and*\n",
-    "their scales. And once again there's a design choice to make. We'll say a\n",
-    "quantized array can be sharded along its leading axes only, so the\n",
-    "quantized axis stays whole and every row travels with its scale.\n",
+    "Explicit mode partitions values while keeping one global view of the\n",
+    "program. Its complement is `shard_map`, which gives a per-device view. To\n",
+    "cross that boundary, a quantized array needs one more piece: a partition\n",
+    "spec type of our own, saying how `shard_map`'s `in_specs`/`out_specs`\n",
+    "apply to it. We keep the same design as above: a quantized array is\n",
+    "sharded along its leading axes only.\n",
     "\n",
     "For `shard_map`, we express this with an `HiPspec` subclass — the\n",
     "partition spec analogue of the `MappingSpec` above. Users pass instances\n",
@@ -763,12 +1149,14 @@
     "def qarray_shard(self, mesh, manual_axes, check_vma, spec):\n",
     "  qvalue_ty, _ = self.lo_ty()\n",
     "  qspec, _ = spec.to_lo()\n",
-    "  return QArrayTy(qvalue_ty.shard(mesh, manual_axes, check_vma, qspec).shape)\n",
+    "  shard_ty = qvalue_ty.shard(mesh, manual_axes, check_vma, qspec)\n",
+    "  return QArrayTy(shard_ty.shape, shard_ty.sharding)\n",
     "\n",
     "def qarray_unshard(self, mesh, check_vma, spec):\n",
     "  qvalue_ty, _ = self.lo_ty()\n",
     "  qspec, _ = spec.to_lo()\n",
-    "  return QArrayTy(qvalue_ty.unshard(mesh, check_vma, qspec).shape)\n",
+    "  full_ty = qvalue_ty.unshard(mesh, check_vma, qspec)\n",
+    "  return QArrayTy(full_ty.shape, full_ty.sharding)\n",
     "\n",
     "QArrayTy.shard = qarray_shard\n",
     "QArrayTy.unshard = qarray_unshard"
@@ -779,9 +1167,9 @@
    "id": "2ccb9aa6",
    "metadata": {},
    "source": [
-    "Now quantized arrays can cross `shard_map` boundaries in either direction.\n",
-    "(This is where we use the 8 CPU devices requested in this document's first\n",
-    "cell.) Producing a sharded quantized array:"
+    "Now quantized arrays can cross `shard_map` boundaries in either\n",
+    "direction, continuing with the mesh and `rows` from the previous section.\n",
+    "Producing a sharded quantized array:"
    ]
   },
   {
@@ -791,12 +1179,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mesh = jax.make_mesh((4,), ('i',))\n",
-    "jax.set_mesh(mesh)\n",
-    "\n",
-    "rows = jax.device_put(jnp.arange(24., dtype='float32').reshape(8, 3),\n",
-    "                      jax.P('i'))\n",
-    "\n",
     "@jax.jit\n",
     "@jax.shard_map(in_specs=jax.P('i'), out_specs=QArrayP(jax.P('i')))\n",
     "def quantize_shards(x):\n",
@@ -827,7 +1209,7 @@
     "@jax.jit\n",
     "@jax.shard_map(in_specs=QArrayP(jax.P('i')), out_specs=jax.P('i'))\n",
     "def dequantize_shards(qx):\n",
-    "  assert jax.typeof(qx) == QArrayTy((2, 3))  # a per-device QArray shard\n",
+    "  assert jax.typeof(qx).shape == (2, 3)  # a per-device QArray shard\n",
     "  return dequantize(qx)\n",
     "\n",
     "print(jnp.max(jnp.abs(dequantize_shards(qrows) - rows)))"

--- a/docs/hijax_types.md
+++ b/docs/hijax_types.md
@@ -52,7 +52,9 @@ modeled as a new *type*, with its own identity:
 * its *tangent type* may differ from its primal structure, so that
   derivatives with respect to it aren't just "the same pytree, but for
   tangents";
-* it may have its own notion of batching under `vmap`.
+* it may have its own notion of batching under `vmap`;
+* it can carry sharding information in the type, participating in JAX's
+  explicit sharding mode.
 
 Hijax types (or "hi types") provide this. You subclass `HiType` to define
 the type, register a Python class as carrying values of that type, and write
@@ -79,6 +81,9 @@ and expect the APIs to evolve.
   `MappingSpec` subclass of your own design, and `batch` rules on the
   primitives. Mapped-over hi type arguments require an explicit `axis_size`
   and spec-valued `in_axes`/`out_axes` entries.
+* For sharding in types (explicit mode), record sharding data on your type
+  (e.g. a `NamedSharding` field), consume it in `lo_ty`, and propagate it
+  in your primitives' typing rules.
 
 ## Example: quantized arrays
 
@@ -90,7 +95,7 @@ row, as in common per-row/per-channel quantization schemes):
 ```{code-cell}
 import os
 os.environ["XLA_FLAGS"] = '--xla_force_host_platform_device_count=8'
-# (8 CPU devices, for the shard_map section at the end)
+# (8 CPU devices, for the sharding sections at the end)
 
 from dataclasses import dataclass
 
@@ -139,17 +144,33 @@ This is like the pytree flatten/unflatten interface, but it lives at the
 level of *types*: given only the type, JAX can compute the lowered types,
 without needing a value in hand.
 
+We also give the type a `sharding` field, recording how values are
+partitioned across devices; it can be ignored until the sharding sections
+near the end of this document. We reuse JAX's `NamedSharding` to describe
+the partitioning of the `qvalue` component, and derive `scale`'s
+partitioning from it by dropping the last axis. Nothing about the field is
+special to JAX, which never interprets it: only our own methods consume
+it, chiefly `lo_ty`, which stamps the component types with their
+shardings. You're free to track sharding information on your type with an
+object of your own design instead, so long as you consume it the same
+way.
+
 ```{code-cell}
 from jax.experimental.hijax import HiType, ShapedArray, register_hitype
+from jax.sharding import NamedSharding
 
 @dataclass(frozen=True)
 class QArrayTy(HiType):
   shape: tuple[int, ...]
+  sharding: NamedSharding  # qvalue's sharding; scale's is derived from it
 
   # lowering: which array types make up this type, and how values convert
   def lo_ty(self):
-    return [ShapedArray(self.shape, jnp.dtype('int8')),
-            ShapedArray(self.shape[:-1], jnp.dtype('float32'))]
+    scale_sharding = self.sharding.update(spec=jax.P(*self.sharding.spec[:-1]))
+    return [ShapedArray(self.shape, jnp.dtype('int8'),
+                        sharding=self.sharding),
+            ShapedArray(self.shape[:-1], jnp.dtype('float32'),
+                        sharding=scale_sharding)]
   def lower_val(self, q):
     return [q.qvalue, q.scale]
   def raise_val(self, qvalue, scale):
@@ -157,21 +178,27 @@ class QArrayTy(HiType):
 
   # autodiff: tangents of quantized arrays are plain float arrays (see below)
   def to_tangent_aval(self):
-    return ShapedArray(self.shape, jnp.dtype('float32'))
+    return ShapedArray(self.shape, jnp.dtype('float32'),
+                       sharding=self.sharding)
 
   # printing, e.g. in jaxprs
   def str_short(self, short_dtypes=False, mesh_axis_types=False):
-    return f'q8[{",".join(map(str, self.shape))}]'
+    dims = [str(d) if p is None else f'{d}@{p}'
+            for d, p in zip(self.shape, self.sharding.spec)]
+    return f'q8[{",".join(dims)}]'
   __repr__ = str_short
 
-register_hitype(QArray, lambda q: QArrayTy(q.qvalue.shape))
+register_hitype(QArray, lambda q: QArrayTy(q.qvalue.shape,
+                                           jax.typeof(q.qvalue).sharding))
 ```
 
 The `register_hitype` call associates the value class with the type: its
 second argument computes the type of any given value, analogous to how
-`jax.typeof` maps an array to its `ShapedArray` type. Indeed after
-registration, `jax.typeof` works on `QArray`s, and JAX transformations
-accept them anywhere a value is expected.
+`jax.typeof` maps an array to its `ShapedArray` type. (Ours reads both the
+shape and the sharding off the `qvalue` component — every array carries a
+sharding, trivial when no mesh is in play.) Indeed after registration,
+`jax.typeof` works on `QArray`s, and JAX transformations accept them
+anywhere a value is expected.
 
 ## The primitives
 
@@ -192,7 +219,7 @@ class Quantize(VJPHiPrimitive):
   def __init__(self, x_aval):
     if x_aval.dtype != jnp.dtype('float32'): raise TypeError(x_aval.dtype)
     self.in_avals = (x_aval,)
-    self.out_aval = QArrayTy(x_aval.shape)
+    self.out_aval = QArrayTy(x_aval.shape, x_aval.sharding)
     self.params = {}
     super().__init__()
 
@@ -211,7 +238,8 @@ class Quantize(VJPHiPrimitive):
 class Dequantize(VJPHiPrimitive):
   def __init__(self, q_aval):
     self.in_avals = (q_aval,)
-    self.out_aval = ShapedArray(q_aval.shape, jnp.dtype('float32'))
+    self.out_aval = ShapedArray(q_aval.shape, jnp.dtype('float32'),
+                                sharding=q_aval.sharding)
     self.params = {}
     super().__init__()
 
@@ -249,13 +277,135 @@ print(jax.typeof(qx))
 print(dequantize(qx))
 ```
 
+### Primitives outside, container inside
+
+The `expand` methods above construct `QArray` values and read their
+attributes directly. It's important that this kind of direct container
+manipulation happen *only* in `expand` (and in the type's own methods,
+like `lower_val` and `raise_val`). Everywhere else — in particular, in
+any function you might `jit`, differentiate, or `vmap` — hi values should
+be produced and consumed only by applying primitives.
+
+The reason is what traced code actually sees. Under a trace, a quantized
+array is not a `QArray` instance: it's a `Tracer` of type `q8[...]`. So
+reading an attribute in traced code fails —
+
+```{code-cell}
+try:
+  jax.jit(lambda qx: qx.qvalue)(qx)
+except AttributeError as e:
+  print('AttributeError:', e)
+```
+
+and, worse, calling the constructor on traced arrays doesn't fail right
+away. It smuggles `Tracer`s inside a container that JAX treats as one
+opaque concrete value, and the mistake surfaces later, as a confusing
+error far from its cause (here a missing constant handler; under `grad`
+it's a leaked-tracer error):
+
+```{code-cell}
+def bad_quantize(x):
+  scale = jnp.max(jnp.abs(x), axis=-1) / 127.
+  return QArray(jnp.round(x / scale[..., None]).astype('int8'), scale)
+
+try:
+  jax.jit(bad_quantize)(x)
+except TypeError as e:
+  print('TypeError:', e)
+```
+
+In `expand` it's a different story: by the time `expand` runs, JAX has
+committed to implementing the primitive in terms of the type's lojax
+components, and its `QArray` arguments are genuine `QArray` instances
+(holding lojax values — possibly traced ones). There, manipulating the
+value as a plain container is exactly right.
+
+(The top-level peeks at attributes like `qx.qvalue` elsewhere in this
+document are fine for the same reason eager `expand` is fine: they run
+eagerly, on concrete values. But inside any function that might get
+traced, stick to primitives.)
+
+### A more realistic op: dense × quantized matmul
+
+Conversion ops alone make for a thin API: in practice, a quantized array
+type earns its keep in ops that consume the type directly. The classic
+example is an inference-style matmul, where the activations `x` are an
+ordinary dense `f32` array and the weights are quantized:
+
+```{code-cell}
+class MatmulQ(VJPHiPrimitive):
+  def __init__(self, x_aval, q_aval):
+    if not (isinstance(q_aval, QArrayTy) and len(q_aval.shape) == 2 and
+            x_aval.shape[-1] == q_aval.shape[0]):
+      raise TypeError(f'bad matmul_q operand types: {x_aval} @ {q_aval}')
+    self.in_avals = (x_aval, q_aval)
+    x_spec, q_spec = x_aval.sharding.spec, q_aval.sharding.spec
+    if x_spec[-1] is not None or q_spec[0] is not None:
+      raise TypeError('matmul_q requires unsharded contraction axes, got '
+                      f'{x_aval} @ {q_aval}')
+    out_sharding = x_aval.sharding.update(
+        spec=jax.P(*x_spec[:-1], q_spec[-1]))
+    self.out_aval = ShapedArray((*x_aval.shape[:-1], q_aval.shape[-1]),
+                                jnp.dtype('float32'), sharding=out_sharding)
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x, qw):
+    # fold the per-row scales into the dense operand, then apply one matmul
+    # directly against the int8 payload
+    return (x * qw.scale) @ qw.qvalue.astype(jnp.float32)
+
+  def vjp_fwd(self, nzs_in, x, qw):
+    return self(x, qw), (x, qw)
+
+  def vjp_bwd_retval(self, res, g):
+    x, qw = res
+    w = dequantize(qw)   # rules are traced code: use primitives here
+    # cotangents live where the primals live, so use the primal operands'
+    # shardings to disambiguate the (possibly sharded) contractions
+    return (jnp.matmul(g, w.T, out_sharding=jax.typeof(x).sharding),
+            jnp.matmul(x.T, g, out_sharding=jax.typeof(w).sharding))
+
+def matmul_q(x, qw):
+  return MatmulQ(jax.typeof(x), jax.typeof(qw))(x, qw)
+```
+
+A few things to notice. The type signature mixes array types and hi types
+freely: `in_avals` is a `(ShapedArray, QArrayTy)` pair, checked at
+construction time so that a shape mismatch fails immediately, with both
+operand types pretty-printed. And `expand` exploits the representation:
+because the scales apply per-row along the contraction axis, they can be
+folded into the dense operand, so the heavy matmul runs directly against
+the `int8` payload rather than a dequantized copy. Owning the op as a
+single primitive lets us state that rewriting once, in one place.
+
+Also notice the discipline from the previous section in action: `expand`
+reads `qw.scale` and `qw.qvalue` as container attributes, while the VJP
+rules — which are ordinary traced code — go through the `dequantize`
+primitive instead.
+
+(The typing rule also computes an output *sharding* — output rows
+partitioned like `x`'s, output columns like `qw`'s, with the contracted
+axes required to be unsharded — and the backward rule passes
+`out_sharding` hints to its matmuls. Both are explained in the
+explicit-sharding section below; outside of explicit mode all these
+shardings are trivial and the extra code is inert.)
+
+```{code-cell}
+w = jnp.arange(12., dtype='float32').reshape(3, 4) / 12.
+qw = quantize(w)
+
+print(matmul_q(x, qw))
+print(x @ dequantize(qw))  # reference
+```
+
 ## Hi types in jaxprs
 
 When we trace, the quantized array appears as a single value of type
 `q8[2,3]`, produced by one equation and consumed by another:
 
 ```{code-cell}
-jax.make_jaxpr(lambda x: dequantize(quantize(x)))(x)
+jax.jit(lambda x: dequantize(quantize(x))).trace(x).jaxpr
 ```
 
 Compare to the pytree approach, where the same computation would show four
@@ -264,8 +414,15 @@ only disappears at lowering time, when `expand` is traced and each
 `q8[...]`-typed value is expanded into the array components given by
 `lo_ty`.
 
-`jit` works, with quantized arrays as arguments, results, and
-intermediates:
+Ops with mixed operand kinds read just as directly — one equation with a
+`f32[2,3] @ q8[3,4] -> f32[2,4]` signature:
+
+```{code-cell}
+jax.jit(matmul_q).trace(x, qw).jaxpr
+#
+# `jit` works, with quantized arrays as arguments, results, and
+# intermediates:
+```
 
 ```{code-cell}
 print(jax.jit(lambda x: dequantize(quantize(x)))(x))   # QArray internal
@@ -311,6 +468,19 @@ def g(qx):
 
 print(jax.grad(g)(qx))
 print(jax.typeof(jax.grad(g)(qx)))
+```
+
+The same goes for ops with mixed operand kinds, like the quantized
+matmul: differentiating a loss with respect to both operands gives an
+`f32` gradient for the dense activations *and* an `f32` gradient for the
+quantized weights:
+
+```{code-cell}
+def loss(x, qw):
+  return jnp.sum(matmul_q(x, qw) ** 2)
+
+grad_x, grad_qw = jax.grad(loss, argnums=(0, 1))(x, qw)
+print(jax.typeof(grad_x), jax.typeof(grad_qw))
 ```
 
 Notice that making the tangent type an `f32` array was a *choice*, and
@@ -361,11 +531,13 @@ respectively:
 ```{code-cell}
 def qarray_dec_rank(self, size, spec):
   assert isinstance(spec, QArraySpec) and self.shape[0] == size
-  return QArrayTy(self.shape[1:])
+  return QArrayTy(self.shape[1:],
+                  self.sharding.update(spec=jax.P(*self.sharding.spec[1:])))
 
 def qarray_inc_rank(self, size, spec):
   assert isinstance(spec, QArraySpec)
-  return QArrayTy((size, *self.shape))
+  return QArrayTy((size, *self.shape),
+                  self.sharding.update(spec=jax.P(None, *self.sharding.spec)))
 
 QArrayTy.dec_rank = qarray_dec_rank
 QArrayTy.inc_rank = qarray_inc_rank
@@ -487,14 +659,102 @@ print(jax.typeof(qtotal))
 print(jax.typeof(qys))
 ```
 
+## Sharding in types: explicit mode
+
+Finally, sharding. In JAX's explicit sharding mode (see [the parallelism
+guide](https://docs.jax.dev/en/latest/parallel.html)), shardings are part
+of array *types*: `jax.typeof` reports how a value is partitioned across
+the mesh, sharding propagation happens while tracing, and mismatches
+surface as type errors. The `sharding` field on `QArrayTy`, and the typing
+rules on our primitives that propagate it, are exactly what let hi types
+participate. What does it mean to partition a quantized array across
+devices? The components move together: if we shard the rows, each device
+holds its rows' quantized values *and* their scales. As usual there's a
+design choice to make, and we made it back in `lo_ty`: `qvalue` carries
+the type's sharding, and `scale` shards like it with the last axis
+dropped, so every row travels with its scale.
+
+Let's see it work. We make a mesh (this is where we use the 8 CPU devices
+requested in this document's first cell), shard some rows across it, and
+quantize — the shardings propagate through our typing rules into the
+result type, which `jax.typeof` displays with `@` markers:
+
+```{code-cell}
+mesh = jax.make_mesh((4,), ('i',))
+jax.set_mesh(mesh)
+
+rows = jax.device_put(jnp.arange(24., dtype='float32').reshape(8, 3),
+                      jax.P('i'))
+
+qrows = quantize(rows)
+print(jax.typeof(qrows))
+print(qrows.qvalue.sharding.spec, qrows.scale.sharding.spec)
+print(jax.typeof(dequantize(qrows)))
+```
+
+The same holds while tracing — hi types in jaxprs now display their
+shardings, computed by our `out_aval` rules:
+
+```{code-cell}
+jax.jit(lambda x: dequantize(quantize(x))).trace(rows).jaxpr
+```
+
+The quantized matmul propagates shardings too: its typing rule partitions
+output rows like `x`'s rows and output columns like `qw`'s columns
+(requiring the contracted axes to be unsharded, since neither operand can
+say how a sharded contraction should land):
+
+```{code-cell}
+w2 = jnp.arange(12., dtype='float32').reshape(3, 4) / 12.
+
+print(jax.typeof(matmul_q(rows, quantize(w2))))                # rows sharded
+
+qw2 = quantize(jax.device_put(w2, jax.P(None, 'i')))
+print(jax.typeof(qw2))                                         # cols sharded
+print(jax.typeof(matmul_q(jnp.ones((2, 3), 'float32'), qw2)))
+```
+
+And the contraction check fires as a type error, at trace time:
+
+```{code-cell}
+xk = jax.device_put(jnp.ones((2, 8), 'float32'), jax.P(None, 'i'))
+qk = quantize(jax.device_put(jnp.ones((8, 3), 'float32'), jax.P('i')))
+
+try:
+  matmul_q(xk, qk)
+except TypeError as e:
+  print('TypeError:', e)
+```
+
+Autodiff composes with all of this. Recall that `MatmulQ`'s backward rule
+passed `out_sharding` hints to its matmuls: that's because the cotangent
+for `qw` contracts over the row axis, which may be sharded (as it is
+here), and explicit mode refuses to guess how an all-sharded contraction
+should land. The right answer is the primal operand's sharding —
+cotangents live where their primals live:
+
+```{code-cell}
+def qloss(x, qw):
+  return jnp.sum(matmul_q(x, qw) ** 2)
+
+grad_rows, grad_qw2 = jax.grad(qloss, argnums=(0, 1))(rows, quantize(w2))
+print(jax.typeof(grad_rows), jax.typeof(grad_qw2))
+```
+
+One caution: JAX does not cross-check a hi primitive's declared output
+sharding against what its `expand` actually produces. The declared
+`out_aval` is what downstream code sees while tracing; `expand` determines
+what happens at runtime. Keeping them consistent is part of the typing
+rule's job.
+
 ## `shard_map` and partition specs
 
-Finally, sharding. What does it mean to partition a quantized array across
-devices? Once again the components move together: if we shard the rows,
-each device should hold a `QArray` of its rows' quantized values *and*
-their scales. And once again there's a design choice to make. We'll say a
-quantized array can be sharded along its leading axes only, so the
-quantized axis stays whole and every row travels with its scale.
+Explicit mode partitions values while keeping one global view of the
+program. Its complement is `shard_map`, which gives a per-device view. To
+cross that boundary, a quantized array needs one more piece: a partition
+spec type of our own, saying how `shard_map`'s `in_specs`/`out_specs`
+apply to it. We keep the same design as above: a quantized array is
+sharded along its leading axes only.
 
 For `shard_map`, we express this with an `HiPspec` subclass — the
 partition spec analogue of the `MappingSpec` above. Users pass instances
@@ -524,28 +784,24 @@ the global type and vice versa, delegating to the component types:
 def qarray_shard(self, mesh, manual_axes, check_vma, spec):
   qvalue_ty, _ = self.lo_ty()
   qspec, _ = spec.to_lo()
-  return QArrayTy(qvalue_ty.shard(mesh, manual_axes, check_vma, qspec).shape)
+  shard_ty = qvalue_ty.shard(mesh, manual_axes, check_vma, qspec)
+  return QArrayTy(shard_ty.shape, shard_ty.sharding)
 
 def qarray_unshard(self, mesh, check_vma, spec):
   qvalue_ty, _ = self.lo_ty()
   qspec, _ = spec.to_lo()
-  return QArrayTy(qvalue_ty.unshard(mesh, check_vma, qspec).shape)
+  full_ty = qvalue_ty.unshard(mesh, check_vma, qspec)
+  return QArrayTy(full_ty.shape, full_ty.sharding)
 
 QArrayTy.shard = qarray_shard
 QArrayTy.unshard = qarray_unshard
 ```
 
-Now quantized arrays can cross `shard_map` boundaries in either direction.
-(This is where we use the 8 CPU devices requested in this document's first
-cell.) Producing a sharded quantized array:
+Now quantized arrays can cross `shard_map` boundaries in either
+direction, continuing with the mesh and `rows` from the previous section.
+Producing a sharded quantized array:
 
 ```{code-cell}
-mesh = jax.make_mesh((4,), ('i',))
-jax.set_mesh(mesh)
-
-rows = jax.device_put(jnp.arange(24., dtype='float32').reshape(8, 3),
-                      jax.P('i'))
-
 @jax.jit
 @jax.shard_map(in_specs=jax.P('i'), out_specs=QArrayP(jax.P('i')))
 def quantize_shards(x):
@@ -564,7 +820,7 @@ rows:
 @jax.jit
 @jax.shard_map(in_specs=QArrayP(jax.P('i')), out_specs=jax.P('i'))
 def dequantize_shards(qx):
-  assert jax.typeof(qx) == QArrayTy((2, 3))  # a per-device QArray shard
+  assert jax.typeof(qx).shape == (2, 3)  # a per-device QArray shard
   return dequantize(qx)
 
 print(jnp.max(jnp.abs(dequantize_shards(qrows) - rows)))

--- a/docs/hijax_types.py
+++ b/docs/hijax_types.py
@@ -46,7 +46,9 @@
 # * its *tangent type* may differ from its primal structure, so that
 #   derivatives with respect to it aren't just "the same pytree, but for
 #   tangents";
-# * it may have its own notion of batching under `vmap`.
+# * it may have its own notion of batching under `vmap`;
+# * it can carry sharding information in the type, participating in JAX's
+#   explicit sharding mode.
 #
 # Hijax types (or "hi types") provide this. You subclass `HiType` to define
 # the type, register a Python class as carrying values of that type, and write
@@ -73,6 +75,9 @@
 #   `MappingSpec` subclass of your own design, and `batch` rules on the
 #   primitives. Mapped-over hi type arguments require an explicit `axis_size`
 #   and spec-valued `in_axes`/`out_axes` entries.
+# * For sharding in types (explicit mode), record sharding data on your type
+#   (e.g. a `NamedSharding` field), consume it in `lo_ty`, and propagate it
+#   in your primitives' typing rules.
 #
 # ## Example: quantized arrays
 #
@@ -84,7 +89,7 @@
 # +
 import os
 os.environ["XLA_FLAGS"] = '--xla_force_host_platform_device_count=8'
-# (8 CPU devices, for the shard_map section at the end)
+# (8 CPU devices, for the sharding sections at the end)
 
 from dataclasses import dataclass
 
@@ -134,18 +139,34 @@ class QArray:
 # This is like the pytree flatten/unflatten interface, but it lives at the
 # level of *types*: given only the type, JAX can compute the lowered types,
 # without needing a value in hand.
+#
+# We also give the type a `sharding` field, recording how values are
+# partitioned across devices; it can be ignored until the sharding sections
+# near the end of this document. We reuse JAX's `NamedSharding` to describe
+# the partitioning of the `qvalue` component, and derive `scale`'s
+# partitioning from it by dropping the last axis. Nothing about the field is
+# special to JAX, which never interprets it: only our own methods consume
+# it, chiefly `lo_ty`, which stamps the component types with their
+# shardings. You're free to track sharding information on your type with an
+# object of your own design instead, so long as you consume it the same
+# way.
 
 # +
 from jax.experimental.hijax import HiType, ShapedArray, register_hitype
+from jax.sharding import NamedSharding
 
 @dataclass(frozen=True)
 class QArrayTy(HiType):
   shape: tuple[int, ...]
+  sharding: NamedSharding  # qvalue's sharding; scale's is derived from it
 
   # lowering: which array types make up this type, and how values convert
   def lo_ty(self):
-    return [ShapedArray(self.shape, jnp.dtype('int8')),
-            ShapedArray(self.shape[:-1], jnp.dtype('float32'))]
+    scale_sharding = self.sharding.update(spec=jax.P(*self.sharding.spec[:-1]))
+    return [ShapedArray(self.shape, jnp.dtype('int8'),
+                        sharding=self.sharding),
+            ShapedArray(self.shape[:-1], jnp.dtype('float32'),
+                        sharding=scale_sharding)]
   def lower_val(self, q):
     return [q.qvalue, q.scale]
   def raise_val(self, qvalue, scale):
@@ -153,21 +174,27 @@ class QArrayTy(HiType):
 
   # autodiff: tangents of quantized arrays are plain float arrays (see below)
   def to_tangent_aval(self):
-    return ShapedArray(self.shape, jnp.dtype('float32'))
+    return ShapedArray(self.shape, jnp.dtype('float32'),
+                       sharding=self.sharding)
 
   # printing, e.g. in jaxprs
   def str_short(self, short_dtypes=False, mesh_axis_types=False):
-    return f'q8[{",".join(map(str, self.shape))}]'
+    dims = [str(d) if p is None else f'{d}@{p}'
+            for d, p in zip(self.shape, self.sharding.spec)]
+    return f'q8[{",".join(dims)}]'
   __repr__ = str_short
 
-register_hitype(QArray, lambda q: QArrayTy(q.qvalue.shape))
+register_hitype(QArray, lambda q: QArrayTy(q.qvalue.shape,
+                                           jax.typeof(q.qvalue).sharding))
 # -
 
 # The `register_hitype` call associates the value class with the type: its
 # second argument computes the type of any given value, analogous to how
-# `jax.typeof` maps an array to its `ShapedArray` type. Indeed after
-# registration, `jax.typeof` works on `QArray`s, and JAX transformations
-# accept them anywhere a value is expected.
+# `jax.typeof` maps an array to its `ShapedArray` type. (Ours reads both the
+# shape and the sharding off the `qvalue` component — every array carries a
+# sharding, trivial when no mesh is in play.) Indeed after registration,
+# `jax.typeof` works on `QArray`s, and JAX transformations accept them
+# anywhere a value is expected.
 #
 # ## The primitives
 #
@@ -188,7 +215,7 @@ class Quantize(VJPHiPrimitive):
   def __init__(self, x_aval):
     if x_aval.dtype != jnp.dtype('float32'): raise TypeError(x_aval.dtype)
     self.in_avals = (x_aval,)
-    self.out_aval = QArrayTy(x_aval.shape)
+    self.out_aval = QArrayTy(x_aval.shape, x_aval.sharding)
     self.params = {}
     super().__init__()
 
@@ -207,7 +234,8 @@ class Quantize(VJPHiPrimitive):
 class Dequantize(VJPHiPrimitive):
   def __init__(self, q_aval):
     self.in_avals = (q_aval,)
-    self.out_aval = ShapedArray(q_aval.shape, jnp.dtype('float32'))
+    self.out_aval = ShapedArray(q_aval.shape, jnp.dtype('float32'),
+                                sharding=q_aval.sharding)
     self.params = {}
     super().__init__()
 
@@ -247,18 +275,148 @@ print(jax.typeof(qx))
 print(dequantize(qx))
 # -
 
+# ### Primitives outside, container inside
+#
+# The `expand` methods above construct `QArray` values and read their
+# attributes directly. It's important that this kind of direct container
+# manipulation happen *only* in `expand` (and in the type's own methods,
+# like `lower_val` and `raise_val`). Everywhere else — in particular, in
+# any function you might `jit`, differentiate, or `vmap` — hi values should
+# be produced and consumed only by applying primitives.
+#
+# The reason is what traced code actually sees. Under a trace, a quantized
+# array is not a `QArray` instance: it's a `Tracer` of type `q8[...]`. So
+# reading an attribute in traced code fails —
+
+try:
+  jax.jit(lambda qx: qx.qvalue)(qx)
+except AttributeError as e:
+  print('AttributeError:', e)
+
+
+# and, worse, calling the constructor on traced arrays doesn't fail right
+# away. It smuggles `Tracer`s inside a container that JAX treats as one
+# opaque concrete value, and the mistake surfaces later, as a confusing
+# error far from its cause (here a missing constant handler; under `grad`
+# it's a leaked-tracer error):
+
+# +
+def bad_quantize(x):
+  scale = jnp.max(jnp.abs(x), axis=-1) / 127.
+  return QArray(jnp.round(x / scale[..., None]).astype('int8'), scale)
+
+try:
+  jax.jit(bad_quantize)(x)
+except TypeError as e:
+  print('TypeError:', e)
+
+
+# -
+
+# In `expand` it's a different story: by the time `expand` runs, JAX has
+# committed to implementing the primitive in terms of the type's lojax
+# components, and its `QArray` arguments are genuine `QArray` instances
+# (holding lojax values — possibly traced ones). There, manipulating the
+# value as a plain container is exactly right.
+#
+# (The top-level peeks at attributes like `qx.qvalue` elsewhere in this
+# document are fine for the same reason eager `expand` is fine: they run
+# eagerly, on concrete values. But inside any function that might get
+# traced, stick to primitives.)
+#
+# ### A more realistic op: dense × quantized matmul
+#
+# Conversion ops alone make for a thin API: in practice, a quantized array
+# type earns its keep in ops that consume the type directly. The classic
+# example is an inference-style matmul, where the activations `x` are an
+# ordinary dense `f32` array and the weights are quantized:
+
+# +
+class MatmulQ(VJPHiPrimitive):
+  def __init__(self, x_aval, q_aval):
+    if not (isinstance(q_aval, QArrayTy) and len(q_aval.shape) == 2 and
+            x_aval.shape[-1] == q_aval.shape[0]):
+      raise TypeError(f'bad matmul_q operand types: {x_aval} @ {q_aval}')
+    self.in_avals = (x_aval, q_aval)
+    x_spec, q_spec = x_aval.sharding.spec, q_aval.sharding.spec
+    if x_spec[-1] is not None or q_spec[0] is not None:
+      raise TypeError('matmul_q requires unsharded contraction axes, got '
+                      f'{x_aval} @ {q_aval}')
+    out_sharding = x_aval.sharding.update(
+        spec=jax.P(*x_spec[:-1], q_spec[-1]))
+    self.out_aval = ShapedArray((*x_aval.shape[:-1], q_aval.shape[-1]),
+                                jnp.dtype('float32'), sharding=out_sharding)
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x, qw):
+    # fold the per-row scales into the dense operand, then apply one matmul
+    # directly against the int8 payload
+    return (x * qw.scale) @ qw.qvalue.astype(jnp.float32)
+
+  def vjp_fwd(self, nzs_in, x, qw):
+    return self(x, qw), (x, qw)
+
+  def vjp_bwd_retval(self, res, g):
+    x, qw = res
+    w = dequantize(qw)   # rules are traced code: use primitives here
+    # cotangents live where the primals live, so use the primal operands'
+    # shardings to disambiguate the (possibly sharded) contractions
+    return (jnp.matmul(g, w.T, out_sharding=jax.typeof(x).sharding),
+            jnp.matmul(x.T, g, out_sharding=jax.typeof(w).sharding))
+
+def matmul_q(x, qw):
+  return MatmulQ(jax.typeof(x), jax.typeof(qw))(x, qw)
+
+
+# -
+
+# A few things to notice. The type signature mixes array types and hi types
+# freely: `in_avals` is a `(ShapedArray, QArrayTy)` pair, checked at
+# construction time so that a shape mismatch fails immediately, with both
+# operand types pretty-printed. And `expand` exploits the representation:
+# because the scales apply per-row along the contraction axis, they can be
+# folded into the dense operand, so the heavy matmul runs directly against
+# the `int8` payload rather than a dequantized copy. Owning the op as a
+# single primitive lets us state that rewriting once, in one place.
+#
+# Also notice the discipline from the previous section in action: `expand`
+# reads `qw.scale` and `qw.qvalue` as container attributes, while the VJP
+# rules — which are ordinary traced code — go through the `dequantize`
+# primitive instead.
+#
+# (The typing rule also computes an output *sharding* — output rows
+# partitioned like `x`'s, output columns like `qw`'s, with the contracted
+# axes required to be unsharded — and the backward rule passes
+# `out_sharding` hints to its matmuls. Both are explained in the
+# explicit-sharding section below; outside of explicit mode all these
+# shardings are trivial and the extra code is inert.)
+
+# +
+w = jnp.arange(12., dtype='float32').reshape(3, 4) / 12.
+qw = quantize(w)
+
+print(matmul_q(x, qw))
+print(x @ dequantize(qw))  # reference
+# -
+
 # ## Hi types in jaxprs
 #
 # When we trace, the quantized array appears as a single value of type
 # `q8[2,3]`, produced by one equation and consumed by another:
 
-jax.make_jaxpr(lambda x: dequantize(quantize(x)))(x)
+jax.jit(lambda x: dequantize(quantize(x))).trace(x).jaxpr
 
 # Compare to the pytree approach, where the same computation would show four
 # array-typed intermediates with no indication that they pair up. The hi type
 # only disappears at lowering time, when `expand` is traced and each
 # `q8[...]`-typed value is expanded into the array components given by
 # `lo_ty`.
+#
+# Ops with mixed operand kinds read just as directly — one equation with a
+# `f32[2,3] @ q8[3,4] -> f32[2,4]` signature:
+
+jax.jit(matmul_q).trace(x, qw).jaxpr
 #
 # `jit` works, with quantized arrays as arguments, results, and
 # intermediates:
@@ -307,6 +465,21 @@ def g(qx):
 
 print(jax.grad(g)(qx))
 print(jax.typeof(jax.grad(g)(qx)))
+
+
+# -
+
+# The same goes for ops with mixed operand kinds, like the quantized
+# matmul: differentiating a loss with respect to both operands gives an
+# `f32` gradient for the dense activations *and* an `f32` gradient for the
+# quantized weights:
+
+# +
+def loss(x, qw):
+  return jnp.sum(matmul_q(x, qw) ** 2)
+
+grad_x, grad_qw = jax.grad(loss, argnums=(0, 1))(x, qw)
+print(jax.typeof(grad_x), jax.typeof(grad_qw))
 # -
 
 # Notice that making the tangent type an `f32` array was a *choice*, and
@@ -359,11 +532,13 @@ class QArraySpec(MappingSpec):
 # +
 def qarray_dec_rank(self, size, spec):
   assert isinstance(spec, QArraySpec) and self.shape[0] == size
-  return QArrayTy(self.shape[1:])
+  return QArrayTy(self.shape[1:],
+                  self.sharding.update(spec=jax.P(*self.sharding.spec[1:])))
 
 def qarray_inc_rank(self, size, spec):
   assert isinstance(spec, QArraySpec)
-  return QArrayTy((size, *self.shape))
+  return QArrayTy((size, *self.shape),
+                  self.sharding.update(spec=jax.P(None, *self.sharding.spec)))
 
 QArrayTy.dec_rank = qarray_dec_rank
 QArrayTy.inc_rank = qarray_inc_rank
@@ -490,14 +665,102 @@ print(jax.typeof(qtotal))
 print(jax.typeof(qys))
 # -
 
+# ## Sharding in types: explicit mode
+#
+# Finally, sharding. In JAX's explicit sharding mode (see [the parallelism
+# guide](https://docs.jax.dev/en/latest/parallel.html)), shardings are part
+# of array *types*: `jax.typeof` reports how a value is partitioned across
+# the mesh, sharding propagation happens while tracing, and mismatches
+# surface as type errors. The `sharding` field on `QArrayTy`, and the typing
+# rules on our primitives that propagate it, are exactly what let hi types
+# participate. What does it mean to partition a quantized array across
+# devices? The components move together: if we shard the rows, each device
+# holds its rows' quantized values *and* their scales. As usual there's a
+# design choice to make, and we made it back in `lo_ty`: `qvalue` carries
+# the type's sharding, and `scale` shards like it with the last axis
+# dropped, so every row travels with its scale.
+#
+# Let's see it work. We make a mesh (this is where we use the 8 CPU devices
+# requested in this document's first cell), shard some rows across it, and
+# quantize — the shardings propagate through our typing rules into the
+# result type, which `jax.typeof` displays with `@` markers:
+
+# +
+mesh = jax.make_mesh((4,), ('i',))
+jax.set_mesh(mesh)
+
+rows = jax.device_put(jnp.arange(24., dtype='float32').reshape(8, 3),
+                      jax.P('i'))
+
+qrows = quantize(rows)
+print(jax.typeof(qrows))
+print(qrows.qvalue.sharding.spec, qrows.scale.sharding.spec)
+print(jax.typeof(dequantize(qrows)))
+# -
+
+# The same holds while tracing — hi types in jaxprs now display their
+# shardings, computed by our `out_aval` rules:
+
+jax.jit(lambda x: dequantize(quantize(x))).trace(rows).jaxpr
+
+# The quantized matmul propagates shardings too: its typing rule partitions
+# output rows like `x`'s rows and output columns like `qw`'s columns
+# (requiring the contracted axes to be unsharded, since neither operand can
+# say how a sharded contraction should land):
+
+# +
+w2 = jnp.arange(12., dtype='float32').reshape(3, 4) / 12.
+
+print(jax.typeof(matmul_q(rows, quantize(w2))))                # rows sharded
+
+qw2 = quantize(jax.device_put(w2, jax.P(None, 'i')))
+print(jax.typeof(qw2))                                         # cols sharded
+print(jax.typeof(matmul_q(jnp.ones((2, 3), 'float32'), qw2)))
+# -
+
+# And the contraction check fires as a type error, at trace time:
+
+# +
+xk = jax.device_put(jnp.ones((2, 8), 'float32'), jax.P(None, 'i'))
+qk = quantize(jax.device_put(jnp.ones((8, 3), 'float32'), jax.P('i')))
+
+try:
+  matmul_q(xk, qk)
+except TypeError as e:
+  print('TypeError:', e)
+
+
+# -
+
+# Autodiff composes with all of this. Recall that `MatmulQ`'s backward rule
+# passed `out_sharding` hints to its matmuls: that's because the cotangent
+# for `qw` contracts over the row axis, which may be sharded (as it is
+# here), and explicit mode refuses to guess how an all-sharded contraction
+# should land. The right answer is the primal operand's sharding —
+# cotangents live where their primals live:
+
+# +
+def qloss(x, qw):
+  return jnp.sum(matmul_q(x, qw) ** 2)
+
+grad_rows, grad_qw2 = jax.grad(qloss, argnums=(0, 1))(rows, quantize(w2))
+print(jax.typeof(grad_rows), jax.typeof(grad_qw2))
+# -
+
+# One caution: JAX does not cross-check a hi primitive's declared output
+# sharding against what its `expand` actually produces. The declared
+# `out_aval` is what downstream code sees while tracing; `expand` determines
+# what happens at runtime. Keeping them consistent is part of the typing
+# rule's job.
+#
 # ## `shard_map` and partition specs
 #
-# Finally, sharding. What does it mean to partition a quantized array across
-# devices? Once again the components move together: if we shard the rows,
-# each device should hold a `QArray` of its rows' quantized values *and*
-# their scales. And once again there's a design choice to make. We'll say a
-# quantized array can be sharded along its leading axes only, so the
-# quantized axis stays whole and every row travels with its scale.
+# Explicit mode partitions values while keeping one global view of the
+# program. Its complement is `shard_map`, which gives a per-device view. To
+# cross that boundary, a quantized array needs one more piece: a partition
+# spec type of our own, saying how `shard_map`'s `in_specs`/`out_specs`
+# apply to it. We keep the same design as above: a quantized array is
+# sharded along its leading axes only.
 #
 # For `shard_map`, we express this with an `HiPspec` subclass — the
 # partition spec analogue of the `MappingSpec` above. Users pass instances
@@ -529,28 +792,26 @@ class QArrayP(HiPspec):
 def qarray_shard(self, mesh, manual_axes, check_vma, spec):
   qvalue_ty, _ = self.lo_ty()
   qspec, _ = spec.to_lo()
-  return QArrayTy(qvalue_ty.shard(mesh, manual_axes, check_vma, qspec).shape)
+  shard_ty = qvalue_ty.shard(mesh, manual_axes, check_vma, qspec)
+  return QArrayTy(shard_ty.shape, shard_ty.sharding)
 
 def qarray_unshard(self, mesh, check_vma, spec):
   qvalue_ty, _ = self.lo_ty()
   qspec, _ = spec.to_lo()
-  return QArrayTy(qvalue_ty.unshard(mesh, check_vma, qspec).shape)
+  full_ty = qvalue_ty.unshard(mesh, check_vma, qspec)
+  return QArrayTy(full_ty.shape, full_ty.sharding)
 
 QArrayTy.shard = qarray_shard
 QArrayTy.unshard = qarray_unshard
+
+
 # -
 
-# Now quantized arrays can cross `shard_map` boundaries in either direction.
-# (This is where we use the 8 CPU devices requested in this document's first
-# cell.) Producing a sharded quantized array:
+# Now quantized arrays can cross `shard_map` boundaries in either
+# direction, continuing with the mesh and `rows` from the previous section.
+# Producing a sharded quantized array:
 
 # +
-mesh = jax.make_mesh((4,), ('i',))
-jax.set_mesh(mesh)
-
-rows = jax.device_put(jnp.arange(24., dtype='float32').reshape(8, 3),
-                      jax.P('i'))
-
 @jax.jit
 @jax.shard_map(in_specs=jax.P('i'), out_specs=QArrayP(jax.P('i')))
 def quantize_shards(x):
@@ -571,7 +832,7 @@ print(qrows.qvalue.sharding.spec, qrows.scale.sharding.spec)
 @jax.jit
 @jax.shard_map(in_specs=QArrayP(jax.P('i')), out_specs=jax.P('i'))
 def dequantize_shards(qx):
-  assert jax.typeof(qx) == QArrayTy((2, 3))  # a per-device QArray shard
+  assert jax.typeof(qx).shape == (2, 3)  # a per-device QArray shard
   return dequantize(qx)
 
 print(jnp.max(jnp.abs(dequantize_shards(qrows) - rows)))


### PR DESCRIPTION
Add to the quantized-array worked example:
* caution section on constructing/inspecting hi values outside `expand`
* a dense @ quantized matmul primitive with mixed-type signature
* a `sharding: NamedSharding` field on QArrayTy, propagated by the primitives' typing rules, with a new explicit-mode section

Also switch jaxpr displays to `jax.jit(...).trace(...).jaxpr`.