### PR TITLE
[hijax] error on specified jit in/out_shardings for hi types

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -845,6 +845,13 @@ def pjit_check_aval_sharding(
     if isinstance(s, UnspecifiedValue):
       continue
     name_str = f' with pytree key path {name}' if name else ''
+    if aval.is_high:
+      raise NotImplementedError(
+          f'One of {what_aval}{name_str} has non-array (hijax) type {aval} '
+          f'with a specified sharding {s}, which is not supported; only '
+          'unspecified shardings are allowed for non-array types. If this '
+          'would be useful to you, please open an issue at '
+          'https://github.com/jax-ml/jax/issues.')
     shape = aval.shape
     try:
       s.check_compatible_aval(shape)
@@ -928,8 +935,6 @@ def _lojax_expand_params(
   mut_out_lol, out_lol_ = out_avals.unpack()
   out_lol = out_lol_.unpack()
 
-  # some pjit params match the length of hi_jaxpr.invars/outvars, so when
-  # lowering we must expand them to match their number of lojax types
   def expand(lol, stuff):
     return tuple(x for l, x in zip(lol, stuff) for _ in l)
   donated_invars = expand(in_lol , donated_invars)

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -940,6 +940,20 @@ class HijaxTest(jtu.JaxTestCase):
     self.assertAllClose(a, jnp.arange(3.) + 1)
     self.assertAllClose(b, jnp.arange(3. * 4).reshape(3, 4) * 2)
 
+  def test_tuple_jit_shardings_error(self):
+    # jit in_shardings/out_shardings must be unspecified for hi-type
+    # args/outputs; anything else raises rather than crashing or silently
+    # broadcasting one sharding across the lojax components
+    mesh = jtu.create_mesh((2,), ('i',))
+    tup = make_tup(jnp.arange(8., dtype='float32').reshape(4, 2),
+                   jnp.arange(4., dtype='float32'))
+    s = jax.NamedSharding(mesh, jax.P('i'))
+    with jax.set_mesh(mesh):
+      with self.assertRaisesRegex(NotImplementedError, "open an issue"):
+        jax.jit(lambda t: t, in_shardings=s)(tup)
+      with self.assertRaisesRegex(NotImplementedError, "open an issue"):
+        jax.jit(lambda t: t, out_shardings=s)(tup)
+
   @jtu.with_explicit_mesh((2, 2), ('i', 'j'))
   def test_tuple_shit(self, mesh):
     x = jax.device_put(jnp.arange(4.), jax.P('i'))


### PR DESCRIPTION
Previously a specified in_sharding or out_sharding for a hijax-typed jit argument or output crashed with an AttributeError (`aval.shape` on the hi aval in pjit_check_aval_sharding), and if it had gotten past that, _lojax_expand_params would have silently broadcast the one sharding across all of the value's lojax components. Now anything but UNSPECIFIED on a hi type raises NotImplementedError, with a pointer to the issue tracker in case someone wants this supported.