### PR TITLE
[docs] add 301 content, including autodiff+sharding doc, fix nosearch stripping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     rules from a `jvp` or `lin` rule: `linearize_from_jvp` with
     `apply_derived_linearization`, `vjp_fwd_from_jvp` with `transpose_jvp`,
     `vjp_fwd_from_lin` with `transpose_linearized`, and `jvp_from_lin`.
+  * Added {func}`jax.custom_remat` to the top-level `jax` namespace, for
+    per-function control of rematerialization under the new `jax_remat3`
+    implementation.
+  * `jax.checkpoint_policies` is now a submodule rather than a namespace
+    object (so `from jax.checkpoint_policies import ...` now works; attribute
+    access is unchanged), and it additionally exposes the name-based policy
+    classes `SaveOnlyTheseNames`, `SaveAnyNamesButThese`, and
+    `SaveAndOffloadOnlyTheseNames`.
 
 * Breaking changes
   * The deprecated module jax.cloud_tpu_init was removed. This did nothing and

--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -104,6 +104,7 @@ Automatic differentiation
     custom_gradient
     closure_convert
     checkpoint
+    custom_remat
 
 Vectorization
 -------------
@@ -272,17 +273,24 @@ Miscellaneous
 Checkpoint policies
 -------------------
 
+.. currentmodule:: jax.checkpoint_policies
+
 .. autosummary::
   :toctree: _autosummary
 
-    checkpoint_policies.everything_saveable
-    checkpoint_policies.nothing_saveable
-    checkpoint_policies.dots_saveable
-    checkpoint_policies.checkpoint_dots
-    checkpoint_policies.dots_with_no_batch_dims_saveable
-    checkpoint_policies.checkpoint_dots_with_no_batch_dims
-    checkpoint_policies.save_any_names_but_these
-    checkpoint_policies.save_only_these_names
-    checkpoint_policies.offload_dot_with_no_batch_dims
-    checkpoint_policies.save_and_offload_only_these_names
-    checkpoint_policies.save_from_both_policies
+    everything_saveable
+    nothing_saveable
+    dots_saveable
+    checkpoint_dots
+    dots_with_no_batch_dims_saveable
+    checkpoint_dots_with_no_batch_dims
+    save_any_names_but_these
+    save_only_these_names
+    offload_dot_with_no_batch_dims
+    save_and_offload_only_these_names
+    save_from_both_policies
+    SaveOnlyTheseNames
+    SaveAnyNamesButThese
+    SaveAndOffloadOnlyTheseNames
+
+.. currentmodule:: jax

--- a/docs/new_docs/101/arrays.md
+++ b/docs/new_docs/101/arrays.md
@@ -1,6 +1,7 @@
 ---
 jupytext:
   formats: md:myst
+  notebook_metadata_filter: nosearch
   text_representation:
     extension: .md
     format_name: myst
@@ -10,6 +11,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+nosearch: true
 ---
 
 ```{code-cell}

--- a/docs/new_docs/101/pytrees.md
+++ b/docs/new_docs/101/pytrees.md
@@ -1,6 +1,7 @@
 ---
 jupytext:
   formats: md:myst
+  notebook_metadata_filter: nosearch
   text_representation:
     extension: .md
     format_name: myst
@@ -10,6 +11,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+nosearch: true
 ---
 
 ```{code-cell}

--- a/docs/new_docs/101/random.md
+++ b/docs/new_docs/101/random.md
@@ -1,6 +1,7 @@
 ---
 jupytext:
   formats: md:myst
+  notebook_metadata_filter: nosearch
   text_representation:
     extension: .md
     format_name: myst
@@ -10,6 +11,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+nosearch: true
 ---
 
 (jax-101-random)=

--- a/docs/new_docs/101/state.md
+++ b/docs/new_docs/101/state.md
@@ -1,6 +1,7 @@
 ---
 jupytext:
   formats: md:myst
+  notebook_metadata_filter: nosearch
   text_representation:
     extension: .md
     format_name: myst
@@ -10,6 +11,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+nosearch: true
 ---
 
 ```{code-cell}

--- a/docs/new_docs/101/transformations.md
+++ b/docs/new_docs/101/transformations.md
@@ -1,6 +1,7 @@
 ---
 jupytext:
   formats: md:myst
+  notebook_metadata_filter: nosearch
   text_representation:
     extension: .md
     format_name: myst
@@ -10,6 +11,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+nosearch: true
 ---
 
 ```{code-cell}

--- a/docs/new_docs/201/callbacks.md
+++ b/docs/new_docs/201/callbacks.md
@@ -1,6 +1,7 @@
 ---
 jupytext:
   formats: md:myst
+  notebook_metadata_filter: nosearch
   text_representation:
     extension: .md
     format_name: myst
@@ -10,6 +11,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+nosearch: true
 ---
 
 ```{code-cell}

--- a/docs/new_docs/201/control-flow.md
+++ b/docs/new_docs/201/control-flow.md
@@ -1,6 +1,7 @@
 ---
 jupytext:
   formats: md:myst
+  notebook_metadata_filter: nosearch
   text_representation:
     extension: .md
     format_name: myst
@@ -10,6 +11,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+nosearch: true
 ---
 
 ```{code-cell}

--- a/docs/new_docs/201/debugging.md
+++ b/docs/new_docs/201/debugging.md
@@ -1,6 +1,7 @@
 ---
 jupytext:
   formats: md:myst
+  notebook_metadata_filter: nosearch
   text_representation:
     extension: .md
     format_name: myst
@@ -10,6 +11,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+nosearch: true
 ---
 
 (jax-201-debugging)=

--- a/docs/new_docs/201/jit.md
+++ b/docs/new_docs/201/jit.md
@@ -1,6 +1,7 @@
 ---
 jupytext:
   formats: md:myst
+  notebook_metadata_filter: nosearch
   text_representation:
     extension: .md
     format_name: myst
@@ -10,6 +11,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+nosearch: true
 ---
 
 ```{code-cell}

--- a/docs/new_docs/201/placement.md
+++ b/docs/new_docs/201/placement.md
@@ -1,6 +1,7 @@
 ---
 jupytext:
   formats: md:myst
+  notebook_metadata_filter: nosearch
   text_representation:
     extension: .md
     format_name: myst
@@ -10,6 +11,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+nosearch: true
 ---
 
 ```{code-cell}

--- a/docs/new_docs/201/profiling.md
+++ b/docs/new_docs/201/profiling.md
@@ -1,6 +1,7 @@
 ---
 jupytext:
   formats: md:myst
+  notebook_metadata_filter: nosearch
   text_representation:
     extension: .md
     format_name: myst
@@ -10,6 +11,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+nosearch: true
 ---
 
 (jax-201-profiling)=

--- a/docs/new_docs/201/shard-map.md
+++ b/docs/new_docs/201/shard-map.md
@@ -2,6 +2,7 @@
 jupytext:
   cell_metadata_filter: -all
   formats: md:myst
+  notebook_metadata_filter: nosearch
   text_representation:
     extension: .md
     format_name: myst
@@ -11,6 +12,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+nosearch: true
 ---
 
 (jax-201-shard-map)=

--- a/docs/new_docs/201/sharding.md
+++ b/docs/new_docs/201/sharding.md
@@ -2,6 +2,7 @@
 jupytext:
   formats: md:myst
   main_language: python
+  notebook_metadata_filter: nosearch
   text_representation:
     extension: .md
     format_name: myst
@@ -11,6 +12,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+nosearch: true
 ---
 
 (jax-201-sharding)=

--- a/docs/new_docs/301/cookbook.md
+++ b/docs/new_docs/301/cookbook.md
@@ -1,0 +1,839 @@
+---
+jupytext:
+  formats: md:myst
+  notebook_metadata_filter: nosearch
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nosearch: true
+---
+
+(jax-301-cookbook)=
+# The Autodiff Cookbook
+
+<!--* freshness: { reviewed: '2026-07-10' } *-->
+
+JAX has a pretty general automatic differentiation system. In this document
+we'll go through a whole bunch of neat autodiff ideas that you can cherry-pick
+for your own work. The basics of `jax.grad` — `argnums`, differentiating with
+respect to containers, `value_and_grad`, checking derivatives against finite
+differences — are covered in the 101 docs ({ref}`jax-101-transformations`), so
+here we start one level up: Hessian-vector products, full Jacobians, the
+`jvp`/`vjp` machinery underneath it all, and differentiation with complex
+numbers.
+
+```{code-cell}
+import jax.numpy as jnp
+from jax import grad, jit, vmap
+from jax import random
+
+key = random.key(0)
+```
+
+## Setup: a running example
+
+As a running example, we'll use the same linear logistic regression model as
+the 101 docs:
+
+```{code-cell}
+def sigmoid(x):
+    return 0.5 * (jnp.tanh(x / 2) + 1)
+
+# Outputs probability of a label being true.
+def predict(W, b, inputs):
+    return sigmoid(jnp.dot(inputs, W) + b)
+
+# Build a toy dataset.
+inputs = jnp.array([[0.52, 1.12,  0.77],
+                   [0.88, -1.08, 0.15],
+                   [0.52, 0.06, -1.30],
+                   [0.74, -2.49, 1.39]])
+targets = jnp.array([True, True, False, True])
+
+# Training loss is the negative log-likelihood of the training examples.
+def loss(W, b):
+    preds = predict(W, b, inputs)
+    label_probs = preds * targets + (1 - preds) * (1 - targets)
+    return -jnp.sum(jnp.log(label_probs))
+
+# Initialize random model coefficients
+key, W_key, b_key = random.split(key, 3)
+W = random.normal(W_key, (3,))
+b = random.normal(b_key, ())
+```
+
+## Gradients
+
+### Hessian-vector products with `grad`-of-`grad`
+
+One thing we can do with higher-order `grad` is build a Hessian-vector product function. (Later on we'll write an even more efficient implementation that mixes both forward- and reverse-mode, but this one will use pure reverse-mode.)
+
+A Hessian-vector product function can be useful in a [truncated Newton Conjugate-Gradient algorithm](https://en.wikipedia.org/wiki/Truncated_Newton_method) for minimizing smooth convex functions, or for studying the curvature of neural network training objectives (e.g. [1](https://arxiv.org/abs/1406.2572), [2](https://arxiv.org/abs/1811.07062), [3](https://arxiv.org/abs/1706.04454), [4](https://arxiv.org/abs/1802.03451)).
+
+For a scalar-valued function $f : \mathbb{R}^n \to \mathbb{R}$ with continuous second derivatives (so that the Hessian matrix is symmetric), the Hessian at a point $x \in \mathbb{R}^n$ is written as $\partial^2 f(x)$. A Hessian-vector product function is then able to evaluate
+
+$\qquad v \mapsto \partial^2 f(x) \cdot v$
+
+for any $v \in \mathbb{R}^n$.
+
+The trick is not to instantiate the full Hessian matrix: if $n$ is large, perhaps in the millions or billions in the context of neural networks, then that might be impossible to store.
+
+Luckily, `grad` already gives us a way to write an efficient Hessian-vector product function. We just have to use the identity
+
+$\qquad \partial^2 f (x) v = \partial [x \mapsto \partial f(x) \cdot v] = \partial g(x)$,
+
+where $g(x) = \partial f(x) \cdot v$ is a new scalar-valued function that dots the gradient of $f$ at $x$ with the vector $v$. Notice that we're only ever differentiating scalar-valued functions of vector-valued arguments, which is exactly where we know `grad` is efficient.
+
+In JAX code, we can just write this:
+
+```{code-cell}
+def hvp(f, x, v):
+    return grad(lambda x: jnp.vdot(grad(f)(x), v))(x)
+```
+
+This example shows that you can freely use lexical closure, and JAX will never get perturbed or confused.
+
+We'll check this implementation a few cells down, once we see how to compute dense Hessian matrices. We'll also write an even better version that uses both forward-mode and reverse-mode.
+
++++
+
+### Jacobians and Hessians using `jacfwd` and `jacrev`
+
++++
+
+You can compute full Jacobian matrices using the `jacfwd` and `jacrev` functions:
+
+```{code-cell}
+from jax import jacfwd, jacrev
+
+# Isolate the function from the weight matrix to the predictions
+f = lambda W: predict(W, b, inputs)
+
+J = jacfwd(f)(W)
+print("jacfwd result, with shape", J.shape)
+print(J)
+
+J = jacrev(f)(W)
+print("jacrev result, with shape", J.shape)
+print(J)
+```
+
+These two functions compute the same values (up to machine numerics), but differ in their implementation: `jacfwd` uses forward-mode automatic differentiation, which is more efficient for "tall" Jacobian matrices (more outputs than inputs), while `jacrev` uses reverse-mode, which is more efficient for "wide" Jacobian matrices (more inputs than outputs). For matrices that are near-square, `jacfwd` probably has an edge over `jacrev`.
+
++++
+
+You can also use `jacfwd` and `jacrev` with container types:
+
+```{code-cell}
+def predict_dict(params, inputs):
+    return predict(params['W'], params['b'], inputs)
+
+J_dict = jacrev(predict_dict)({'W': W, 'b': b}, inputs)
+for k, v in J_dict.items():
+    print("Jacobian from {} to logits is".format(k))
+    print(v)
+```
+
+For more details on forward- and reverse-mode, as well as how to implement `jacfwd` and `jacrev` as efficiently as possible, read on!
+
++++
+
+Using a composition of two of these functions gives us a way to compute dense Hessian matrices:
+
+```{code-cell}
+def hessian(f):
+    return jacfwd(jacrev(f))
+
+H = hessian(f)(W)
+print("hessian, with shape", H.shape)
+print(H)
+```
+
+This shape makes sense: if we start with a function $f : \mathbb{R}^n \to \mathbb{R}^m$, then at a point $x \in \mathbb{R}^n$ we expect to get the shapes
+
+* $f(x) \in \mathbb{R}^m$, the value of $f$ at $x$,
+* $\partial f(x) \in \mathbb{R}^{m \times n}$, the Jacobian matrix at $x$,
+* $\partial^2 f(x) \in \mathbb{R}^{m \times n \times n}$, the Hessian at $x$,
+
+and so on.
+
+To implement `hessian`, we could have used `jacfwd(jacrev(f))` or `jacrev(jacfwd(f))` or any other composition of the two. But forward-over-reverse is typically the most efficient. That's because in the inner Jacobian computation we're often differentiating a function wide Jacobian (maybe like a loss function $f : \mathbb{R}^n \to \mathbb{R}$), while in the outer Jacobian computation we're differentiating a function with a square Jacobian (since $\nabla f : \mathbb{R}^n \to \mathbb{R}^n$), which is where forward-mode wins out.
+
++++
+
+## How it's made: two foundational autodiff functions
+
++++
+
+(jax-301-jvp)=
+
+### Jacobian-Vector products (JVPs, aka forward-mode autodiff)
+
+JAX includes efficient and general implementations of both forward- and reverse-mode automatic differentiation. The familiar `grad` function is built on reverse-mode, but to explain the difference in the two modes, and when each can be useful, we need a bit of math background.
+
+#### JVPs in math
+
+Mathematically, given a function $f : \mathbb{R}^n \to \mathbb{R}^m$, the Jacobian of $f$ evaluated at an input point $x \in \mathbb{R}^n$, denoted $\partial f(x)$, is often thought of as a matrix in $\mathbb{R}^m \times \mathbb{R}^n$:
+
+$\qquad \partial f(x) \in \mathbb{R}^{m \times n}$.
+
+But we can also think of $\partial f(x)$ as a linear map, which maps the tangent space of the domain of $f$ at the point $x$ (which is just another copy of $\mathbb{R}^n$) to the tangent space of the codomain of $f$ at the point $f(x)$ (a copy of $\mathbb{R}^m$):
+
+$\qquad \partial f(x) : \mathbb{R}^n \to \mathbb{R}^m$.
+
+This map is called the [pushforward map](https://en.wikipedia.org/wiki/Pushforward_(differential)) of $f$ at $x$. The Jacobian matrix is just the matrix for this linear map in a standard basis.
+
+If we don't commit to one specific input point $x$, then we can think of the function $\partial f$ as first taking an input point and returning the Jacobian linear map at that input point:
+
+$\qquad \partial f : \mathbb{R}^n \to \mathbb{R}^n \to \mathbb{R}^m$.
+
+In particular, we can uncurry things so that given input point $x \in \mathbb{R}^n$ and a tangent vector $v \in \mathbb{R}^n$, we get back an output tangent vector in $\mathbb{R}^m$. We call that mapping, from $(x, v)$ pairs to output tangent vectors, the *Jacobian-vector product*, and write it as
+
+$\qquad (x, v) \mapsto \partial f(x) v$
+
+#### JVPs in JAX code
+
+Back in Python code, JAX's `jvp` function models this transformation. Given a Python function that evaluates $f$, JAX's `jvp` is a way to get a Python function for evaluating $(x, v) \mapsto (f(x), \partial f(x) v)$.
+
+```{code-cell}
+from jax import jvp
+
+# Isolate the function from the weight matrix to the predictions
+f = lambda W: predict(W, b, inputs)
+
+key, subkey = random.split(key)
+v = random.normal(subkey, W.shape)
+
+# Push forward the vector `v` along `f` evaluated at `W`
+y, u = jvp(f, (W,), (v,))
+```
+
+In terms of [Haskell-like type signatures](https://wiki.haskell.org/Type_signature),
+we could write
+
+```haskell
+jvp :: (a -> b) -> a -> T a -> (b, T b)
+```
+
+where we use `T a` to denote the type of the tangent space for `a`. In words, `jvp` takes as arguments a function of type `a -> b`, a value of type `a`, and a tangent vector value of type `T a`. It gives back a pair consisting of a value of type `b` and an output tangent vector of type `T b`.
+
++++
+
+The `jvp`-transformed function is evaluated much like the original function, but paired up with each primal value of type `a` it pushes along tangent values of type `T a`. For each primitive numerical operation that the original function would have applied, the `jvp`-transformed function executes a "JVP rule" for that primitive that both evaluates the primitive on the primals and applies the primitive's JVP at those primal values.
+
+That evaluation strategy has some immediate implications about computational complexity: since we evaluate JVPs as we go, we don't need to store anything for later, and so the memory cost is independent of the depth of the computation. In addition, the FLOP cost of the `jvp`-transformed function is about 3x the cost of just evaluating the function (one unit of work for evaluating the original function, for example `sin(x)`; one unit for linearizing, like `cos(x)`; and one unit for applying the linearized function to a vector, like `cos_x * v`). Put another way, for a fixed primal point $x$, we can evaluate $v \mapsto \partial f(x) \cdot v$ for about the same marginal cost as evaluating $f$.
+
+That memory complexity sounds pretty compelling! So why don't we see forward-mode very often in machine learning?
+
+To answer that, first think about how you could use a JVP to build a full Jacobian matrix. If we apply a JVP to a one-hot tangent vector, it reveals one column of the Jacobian matrix, corresponding to the nonzero entry we fed in. So we can build a full Jacobian one column at a time, and to get each column costs about the same as one function evaluation. That will be efficient for functions with "tall" Jacobians, but inefficient for "wide" Jacobians.
+
+If you're doing gradient-based optimization in machine learning, you probably want to minimize a loss function from parameters in $\mathbb{R}^n$ to a scalar loss value in $\mathbb{R}$. That means the Jacobian of this function is a very wide matrix: $\partial f(x) \in \mathbb{R}^{1 \times n}$, which we often identify with the Gradient vector $\nabla f(x) \in \mathbb{R}^n$. Building that matrix one column at a time, with each call taking a similar number of FLOPs to evaluate the original function, sure seems inefficient! In particular, for training neural networks, where $f$ is a training loss function and $n$ can be in the millions or billions, this approach just won't scale.
+
+To do better for functions like this, we just need to use reverse-mode.
+
++++
+
+(jax-301-vjp)=
+
+### Vector-Jacobian products (VJPs, aka reverse-mode autodiff)
+
+Where forward-mode gives us back a function for evaluating Jacobian-vector products, which we can then use to build Jacobian matrices one column at a time, reverse-mode is a way to get back a function for evaluating vector-Jacobian products (equivalently Jacobian-transpose-vector products), which we can use to build Jacobian matrices one row at a time.
+
+#### VJPs in math
+
+Let's again consider a function $f : \mathbb{R}^n \to \mathbb{R}^m$.
+Starting from our notation for JVPs, the notation for VJPs is pretty simple:
+
+$\qquad (x, v) \mapsto v \partial f(x)$,
+
+where $v$ is an element of the cotangent space of $f$ at $x$ (isomorphic to another copy of $\mathbb{R}^m$). When being rigorous, we should think of $v$ as a linear map $v : \mathbb{R}^m \to \mathbb{R}$, and when we write $v \partial f(x)$ we mean function composition $v \circ \partial f(x)$, where the types work out because $\partial f(x) : \mathbb{R}^n \to \mathbb{R}^m$. But in the common case we can identify $v$ with a vector in $\mathbb{R}^m$ and use the two almost interchangeably, just like we might sometimes flip between "column vectors" and "row vectors" without much comment.
+
+With that identification, we can alternatively think of the linear part of a VJP as the transpose (or adjoint conjugate) of the linear part of a JVP:
+
+$\qquad (x, v) \mapsto \partial f(x)^\mathsf{T} v$.
+
+For a given point $x$, we can write the signature as
+
+$\qquad \partial f(x)^\mathsf{T} : \mathbb{R}^m \to \mathbb{R}^n$.
+
+The corresponding map on cotangent spaces is often called the [pullback](https://en.wikipedia.org/wiki/Pullback_(differential_geometry))
+of $f$ at $x$. The key for our purposes is that it goes from something that looks like the output of $f$ to something that looks like the input of $f$, just like we might expect from a transposed linear function.
+
+#### VJPs in JAX code
+
+Switching from math back to Python, the JAX function `vjp` can take a Python function for evaluating $f$ and give us back a Python function for evaluating the VJP $(x, v) \mapsto (f(x), v^\mathsf{T} \partial f(x))$.
+
+```{code-cell}
+from jax import vjp
+
+# Isolate the function from the weight matrix to the predictions
+f = lambda W: predict(W, b, inputs)
+
+y, vjp_fun = vjp(f, W)
+
+key, subkey = random.split(key)
+u = random.normal(subkey, y.shape)
+
+# Pull back the covector `u` along `f` evaluated at `W`
+v = vjp_fun(u)
+```
+
+In terms of [Haskell-like type signatures](https://wiki.haskell.org/Type_signature),
+we could write
+
+```haskell
+vjp :: (a -> b) -> a -> (b, CT b -> CT a)
+```
+
+where we use `CT a` to denote the type for the cotangent space for `a`. In words, `vjp` takes as arguments a function of type `a -> b` and a point of type `a`, and gives back a pair consisting of a value of type `b` and a linear map of type `CT b -> CT a`.
+
+This is great because it lets us build Jacobian matrices one row at a time, and the FLOP cost for evaluating $(x, v) \mapsto (f(x), v^\mathsf{T} \partial f(x))$ is only about three times the cost of evaluating $f$. In particular, if we want the gradient of a function $f : \mathbb{R}^n \to \mathbb{R}$, we can do it in just one call. That's how `grad` is efficient for gradient-based optimization, even for objectives like neural network training loss functions on millions or billions of parameters.
+
+There's a cost, though: though the FLOPs are friendly, memory scales with the depth of the computation. Also, the implementation is traditionally more complex than that of forward-mode, though JAX has some tricks up its sleeve (that's a story for a future notebook!).
+
+For more on how reverse-mode works, see [this tutorial video from the Deep Learning Summer School in 2017](http://videolectures.net/deeplearning2017_johnson_automatic_differentiation/).
+
++++
+
+### Vector-valued gradients with VJPs
+
+If you're interested in taking vector-valued gradients (like `tf.gradients`):
+
+```{code-cell}
+from jax import vjp
+
+def vgrad(f, x):
+  y, vjp_fn = vjp(f, x)
+  return vjp_fn(jnp.ones(y.shape))[0]
+
+print(vgrad(lambda x: 3*x**2, jnp.ones((2, 2))))
+```
+
+### Hessian-vector products using both forward- and reverse-mode
+
++++
+
+In a previous section, we implemented a Hessian-vector product function just using reverse-mode (assuming continuous second derivatives):
+
+```{code-cell}
+def hvp(f, x, v):
+    return grad(lambda x: jnp.vdot(grad(f)(x), v))(x)
+```
+
+That's efficient, but we can do even better and save some memory by using forward-mode together with reverse-mode.
+
+Mathematically, given a function $f : \mathbb{R}^n \to \mathbb{R}$ to differentiate, a point $x \in \mathbb{R}^n$ at which to linearize the function, and a vector $v \in \mathbb{R}^n$, the Hessian-vector product function we want is
+
+$(x, v) \mapsto \partial^2 f(x) v$
+
+Consider the helper function $g : \mathbb{R}^n \to \mathbb{R}^n$ defined to be the derivative (or gradient) of $f$, namely $g(x) = \partial f(x)$. All we need is its JVP, since that will give us
+
+$(x, v) \mapsto \partial g(x) v = \partial^2 f(x) v$.
+
+We can translate that almost directly into code:
+
+```{code-cell}
+from jax import jvp, grad
+
+# forward-over-reverse
+def hvp(f, primals, tangents):
+  return jvp(grad(f), primals, tangents)[1]
+```
+
+Even better, since we didn't have to call `jnp.dot` directly, this `hvp` function works with arrays of any shape and with arbitrary container types (like vectors stored as nested lists/dicts/tuples), and doesn't even have a dependence on `jax.numpy`.
+
+Here's an example of how to use it:
+
+```{code-cell}
+def f(X):
+  return jnp.sum(jnp.tanh(X)**2)
+
+key, subkey1, subkey2 = random.split(key, 3)
+X = random.normal(subkey1, (30, 40))
+V = random.normal(subkey2, (30, 40))
+
+ans1 = hvp(f, (X,), (V,))
+ans2 = jnp.tensordot(hessian(f)(X), V, 2)
+
+print(jnp.allclose(ans1, ans2, 1e-4, 1e-4))
+```
+
+Another way you might consider writing this is using reverse-over-forward:
+
+```{code-cell}
+# reverse-over-forward
+def hvp_revfwd(f, primals, tangents):
+  g = lambda primals: jvp(f, primals, tangents)[1]
+  return grad(g)(primals)
+```
+
+That's not quite as good, though, because forward-mode has less overhead than reverse-mode, and since the outer differentiation operator here has to differentiate a larger computation than the inner one, keeping forward-mode on the outside works best:
+
+```{code-cell}
+# reverse-over-reverse, only works for single arguments
+def hvp_revrev(f, primals, tangents):
+  x, = primals
+  v, = tangents
+  return grad(lambda x: jnp.vdot(grad(f)(x), v))(x)
+
+
+print("Forward over reverse")
+%timeit -n10 -r3 hvp(f, (X,), (V,))
+print("Reverse over forward")
+%timeit -n10 -r3 hvp_revfwd(f, (X,), (V,))
+print("Reverse over reverse")
+%timeit -n10 -r3 hvp_revrev(f, (X,), (V,))
+
+print("Naive full Hessian materialization")
+%timeit -n10 -r3 jnp.tensordot(hessian(f)(X), V, 2)
+```
+
+## Composing VJPs, JVPs, and `vmap`
+
++++
+
+### Jacobian-Matrix and Matrix-Jacobian products
+
+Now that we have `jvp` and `vjp` transformations that give us functions to push-forward or pull-back single vectors at a time, we can use JAX's `vmap` [transformation](https://github.com/jax-ml/jax#auto-vectorization-with-vmap) to push and pull entire bases at once. In particular, we can use that to write fast matrix-Jacobian and Jacobian-matrix products.
+
+```{code-cell}
+# Isolate the function from the weight matrix to the predictions
+f = lambda W: predict(W, b, inputs)
+
+# Pull back the covectors `m_i` along `f`, evaluated at `W`, for all `i`.
+# First, use a list comprehension to loop over rows in the matrix M.
+def loop_mjp(f, x, M):
+    y, vjp_fun = vjp(f, x)
+    return jnp.vstack([jnp.asarray(vjp_fun(mi)) for mi in M])
+
+# Now, use vmap to build a computation that does a single fast matrix-matrix
+# multiply, rather than an outer loop over vector-matrix multiplies.
+def vmap_mjp(f, x, M):
+    y, vjp_fun = vjp(f, x)
+    outs, = vmap(vjp_fun)(M)
+    return outs
+
+key = random.key(0)
+num_covecs = 128
+U = random.normal(key, (num_covecs,) + y.shape)
+
+loop_vs = loop_mjp(f, W, M=U)
+print('Non-vmapped Matrix-Jacobian product')
+%timeit -n10 -r3 loop_mjp(f, W, M=U)
+
+print('\nVmapped Matrix-Jacobian product')
+vmap_vs = vmap_mjp(f, W, M=U)
+%timeit -n10 -r3 vmap_mjp(f, W, M=U)
+
+assert jnp.allclose(loop_vs, vmap_vs), 'Vmap and non-vmapped Matrix-Jacobian Products should be identical'
+```
+
+```{code-cell}
+def loop_jmp(f, W, M):
+    # jvp immediately returns the primal and tangent values as a tuple,
+    # so we'll compute and select the tangents in a list comprehension
+    return jnp.vstack([jvp(f, (W,), (mi,))[1] for mi in M])
+
+def vmap_jmp(f, W, M):
+    _jvp = lambda s: jvp(f, (W,), (s,))[1]
+    return vmap(_jvp)(M)
+
+num_vecs = 128
+S = random.normal(key, (num_vecs,) + W.shape)
+
+loop_vs = loop_jmp(f, W, M=S)
+print('Non-vmapped Jacobian-Matrix product')
+%timeit -n10 -r3 loop_jmp(f, W, M=S)
+vmap_vs = vmap_jmp(f, W, M=S)
+print('\nVmapped Jacobian-Matrix product')
+%timeit -n10 -r3 vmap_jmp(f, W, M=S)
+
+assert jnp.allclose(loop_vs, vmap_vs), 'Vmap and non-vmapped Jacobian-Matrix products should be identical'
+```
+
+### The implementation of `jacfwd` and `jacrev`
+
++++
+
+Now that we've seen fast Jacobian-matrix and matrix-Jacobian products, it's not hard to guess how to write `jacfwd` and `jacrev`. We just use the same technique to push-forward or pull-back an entire standard basis (isomorphic to an identity matrix) at once.
+
+```{code-cell}
+from jax import jacrev as builtin_jacrev
+
+def our_jacrev(f):
+    def jacfun(x):
+        y, vjp_fun = vjp(f, x)
+        # Use vmap to do a matrix-Jacobian product.
+        # Here, the matrix is the Euclidean basis, so we get all
+        # entries in the Jacobian at once.
+        J, = vmap(vjp_fun, in_axes=0)(jnp.eye(len(y)))
+        return J
+    return jacfun
+
+assert jnp.allclose(builtin_jacrev(f)(W), our_jacrev(f)(W)), 'Incorrect reverse-mode Jacobian results!'
+```
+
+```{code-cell}
+from jax import jacfwd as builtin_jacfwd
+
+def our_jacfwd(f):
+    def jacfun(x):
+        _jvp = lambda s: jvp(f, (x,), (s,))[1]
+        Jt = vmap(_jvp, in_axes=1)(jnp.eye(len(x)))
+        return jnp.transpose(Jt)
+    return jacfun
+
+assert jnp.allclose(builtin_jacfwd(f)(W), our_jacfwd(f)(W)), 'Incorrect forward-mode Jacobian results!'
+```
+
+Interestingly, [Autograd](https://github.com/hips/autograd) couldn't do this. Our [implementation](https://github.com/HIPS/autograd/blob/96a03f44da43cd7044c61ac945c483955deba957/autograd/differential_operators.py#L60) of reverse-mode `jacobian` in Autograd had to pull back one vector at a time with an outer-loop `map`. Pushing one vector at a time through the computation is much less efficient than batching it all together with `vmap`.
+
++++
+
+Another thing that Autograd couldn't do is `jit`. Interestingly, no matter how much Python dynamism you use in your function to be differentiated, we could always use `jit` on the linear part of the computation. For example:
+
+```{code-cell}
+def f(x):
+    try:
+        if x < 3:
+            return 2 * x ** 3
+        else:
+            raise ValueError
+    except ValueError:
+        return jnp.pi * x
+
+y, f_vjp = vjp(f, 4.)
+print(jit(f_vjp)(1.))
+```
+
+## Complex numbers and differentiation
+
+Complex differentiation has a reputation for confusion: must the function be
+holomorphic? Where do the conjugates go? What does `grad` even mean at a
+complex input? In JAX, one organizing principle dissolves nearly all of it:
+
+**JVPs and VJPs are unambiguous, for any function, holomorphic or not. The
+only subtlety lives in the convenience wrapper `grad`, which must pick a
+packaging convention — and JAX's choice involves a conjugate you should know
+about.**
+
+### The unambiguous part: JVPs and VJPs
+
+The key move is to remember what $\mathbb{C}$ is: $\mathbb{R}^2$ with some
+extra (multiplicative) structure. Any function $f : \mathbb{C} \to
+\mathbb{C}$ determines an ordinary real function $F : \mathbb{R}^2 \to
+\mathbb{R}^2$ by
+
+$\qquad f(x + y i) = u(x, y) + v(x, y) i
+\quad\leftrightarrow\quad F(x, y) = (u(x, y), v(x, y)),$
+
+and $F$ has an ordinary real Jacobian at each point — a $2 \times 2$ matrix
+with four independent real entries, no holomorphy required:
+
+$\qquad J = \begin{bmatrix} \partial_0 u & \partial_1 u \\ \partial_0 v & \partial_1 v \end{bmatrix}.$
+
+The **JVP** of $f$ is nothing more than this real linear map applied to the
+tangent pair, with complex numbers serving as containers for pairs of reals:
+for a tangent $t = t_1 + t_2 i$, the output tangent is $J (t_1, t_2)$,
+repackaged as a complex number. Here's a check, on a decidedly
+non-holomorphic function:
+
+```{code-cell}
+def u(x, y): return x**2 + jnp.sin(y)
+def v(x, y): return x * y
+
+def fun(z):  # not holomorphic!
+  x, y = jnp.real(z), jnp.imag(z)
+  return u(x, y) + v(x, y) * 1j
+
+z = 1.5 + 0.5j
+x, y = jnp.real(z), jnp.imag(z)
+J = jnp.array([[grad(u, 0)(x, y), grad(u, 1)(x, y)],
+               [grad(v, 0)(x, y), grad(v, 1)(x, y)]])
+
+t = 0.7 - 0.3j
+_, t_out = jvp(fun, (z,), (t,))
+t_pair = J @ jnp.array([jnp.real(t), jnp.imag(t)])
+print(jnp.allclose(t_out, t_pair[0] + t_pair[1] * 1j))
+```
+
+No ambiguity, and no conjugates: the JVP is the pushforward by the real
+derivative, in complex packaging. (If $f$ happens to be holomorphic, the
+Cauchy–Riemann equations make $J$ the rotate-and-scale matrix of complex
+multiplication by $f'(z)$, and the JVP becomes $t \mapsto f'(z)\, t$.)
+
+The **VJP** is just as unambiguous, but seeing why takes one more idea —
+and that idea is also where `grad`'s conjugation convention will come from,
+so it's worth spelling out.
+
+What a VJP fundamentally is, is the *dual map* (or pullback) of the
+derivative: cotangents are linear functionals on tangents, and the
+derivative's dual map carries output functionals to input functionals by
+composition, $\varphi \mapsto \varphi \circ \partial F(x)$. That definition
+involves no choices at all. The familiar matrix transpose is what the dual
+map looks like *after* you identify each space with its dual — and the
+identification is where a choice enters. A nondegenerate pairing
+$\langle\cdot,\cdot\rangle$ is exactly such an identification (it matches
+the vector $w$ with the functional $\langle w, \cdot\rangle$), and relative
+to pairings on the two spaces, the transpose of a linear map $A$ is
+characterized by
+
+$\qquad \langle w, A t \rangle = \langle A^\mathsf{T} w, t \rangle
+\quad \text{for all } t, w.$
+
+For $\mathbb{R}^n$ with the standard dot product this recovers
+swap-the-matrix-indices transposition, but change the pairing and "the
+transpose" changes with it.
+
+Now, JAX's `vjp` hands you cotangents as complex numbers — the same type as
+the primal values — so somewhere an identification of covectors with
+vectors has been made. And note what the scalar field is in this whole
+story: it's $\mathbb{R}$, not $\mathbb{C}$. Since $f$ needn't be
+holomorphic, its derivative is only guaranteed to be $\mathbb{R}$-linear,
+so we must treat $\mathbb{C}$ and its (co)tangent spaces as vector spaces
+*over the reals*. Linear functionals are accordingly $\mathbb{R}$-valued —
+which is why the pairings below produce real numbers, not complex ones.
+(A real-linear map on $\mathbb{C}$ is complex-linear exactly when its
+matrix is a rotate-and-scale — that is, exactly when $f$ is holomorphic.
+Holomorphy is precisely the special case in which the scalar field could
+be upgraded to $\mathbb{C}$.)
+
+On complex numbers viewed as packed pairs of reals, there are two natural
+real-valued pairings to make the identification with:
+
+* the **bilinear** pairing $\langle w, t \rangle = \operatorname{Re}(w t)$,
+  which in real coordinates is $w_1 t_1 - w_2 t_2$; and
+* the **sesquilinear** pairing
+  $\langle w, t \rangle = \operatorname{Re}(\bar{w} t) = w_1 t_1 + w_2 t_2$
+  — the real part of the standard complex inner product, i.e. the ordinary
+  dot product on $\mathbb{R}^2$.
+
+They differ by conjugating one slot, so the two transposes they define
+differ by an elementwise conjugation. A convention is required, and **JAX
+uses the bilinear one**: its `vjp` is the unique map satisfying
+
+$\qquad \operatorname{Re}(w \cdot \texttt{jvp}(t)) \; = \;
+\operatorname{Re}(\texttt{vjp}(w) \cdot t)
+\qquad \text{for all } t, w,$
+
+with plain products and no conjugations in sight:
+
+```{code-cell}
+w = -0.2 + 1.1j
+
+_, fun_vjp = vjp(fun, z)
+w_out, = fun_vjp(w)
+
+print(jnp.allclose(jnp.real(w * t_out), jnp.real(w_out * t)))       # True
+print(jnp.allclose(jnp.real(jnp.conj(w) * t_out),
+                   jnp.real(jnp.conj(w_out) * t)))                  # False!
+```
+
+The second `print` shows the fork in the road: the sesquilinear version of
+the same identity is *false* for JAX's `vjp` — it's the identity the other
+convention would satisfy instead. In coordinates, JAX's VJP works out to
+$w \mapsto \overline{J^\mathsf{T} \bar{w}}$ — but the conjugations are
+packaging artifacts, not extra derivative content. Writing $\eta =
+\operatorname{diag}(1, -1)$, conjugation of a packed pair *is* $\eta$, and
+$\operatorname{Re}(w t) = w^\mathsf{T} \eta\, t$, so
+$\overline{J^\mathsf{T} \bar{w}} = \eta J^\mathsf{T} \eta\, w$: precisely
+the transpose of $J$ relative to the bilinear pairing. Equivalently, the
+underlying operation is plain $J^\mathsf{T}$ on pairs of reals, with
+covectors *encoded* as complex numbers via the conjugated identification.
+
+One payoff of this convention: for a *holomorphic* $f$, both maps become the
+same plain complex multiplication, with no conjugate in sight:
+
+$\qquad \texttt{jvp}(t) = f'(z)\,t, \qquad \texttt{vjp}(w) = f'(z)\,w.$
+
+```{code-cell}
+_, t_out = jvp(jnp.sin, (z,), (t,))
+_, sin_vjp = vjp(jnp.sin, z)
+w_out, = sin_vjp(w)
+print(jnp.allclose(t_out, jnp.cos(z) * t))
+print(jnp.allclose(w_out, jnp.cos(z) * w))
+```
+
+Under the sesquilinear convention, the VJP of a holomorphic function would
+instead be multiplication by $\overline{f'(z)}$. That's why we chose the
+bilinear one.
+
+A general (non-holomorphic) $\mathbb{C} \to \mathbb{C}$ function has four
+real degrees of freedom in its derivative, so no single complex number can
+summarize it. A single JVP or VJP call reveals a two-real-number slice; two
+calls — say with tangents (or cotangents) $1$ and $i$ — reveal everything,
+exactly as for an $\mathbb{R}^2 \to \mathbb{R}^2$ function. And for
+functions with a real side, one call is a full summary: a single `jvp`
+reveals everything about an $\mathbb{R} \to \mathbb{C}$ scalar function, and
+a single `vjp` (or `grad` — read on) reveals everything about a
+$\mathbb{C} \to \mathbb{R}$ function. When in doubt about what a complex
+derivative "means", drop down to `jvp` and `vjp`: they never lie and never
+raise.
+
+### `grad` at complex inputs: mind the conjugate
+
+`grad(f)(x)` is defined as `vjp(f, x)[1](1.0)`. For a function $f :
+\mathbb{C} \to \mathbb{R}$, writing $f(x + yi) = u(x, y)$, this works with
+no flags, and by the transpose formula above it evaluates to
+
+$\qquad \texttt{grad}(f)(z) = \partial_0 u(x, y) - \partial_1 u(x, y)\, i.$
+
+Note the minus sign: this is the *conjugate* of the vector
+$(\partial_0 u, \partial_1 u)$, which is the direction of steepest ascent in
+the plane. Under JAX's convention, directional derivatives use the plain
+product with no conjugation,
+
+$\qquad \lim_{\epsilon \to 0} \tfrac{1}{\epsilon}(f(z + \epsilon t) - f(z))
+= \operatorname{Re}(\texttt{grad}(f)(z) \cdot t),$
+
+and the flip side of that tidiness is that **for optimization you must
+conjugate the gradient**: the steepest-descent step is $z \leftarrow z -
+\eta\, \overline{\texttt{grad}(f)(z)}$. Using the unconjugated gradient
+flips the sign of the update's imaginary part — it isn't descent at all:
+
+```{code-cell}
+def f(z):
+  x, y = jnp.real(z), jnp.imag(z)
+  return x**2 + y**2      # |z|^2, minimized at z = 0
+
+print(grad(f)(3. + 4j))   # 6 - 8j: conjugate of the steepest-ascent 6 + 8j
+```
+
+```{code-cell}
+z = 3. + 4j
+for _ in range(100):
+  z = z - 0.05 * jnp.conj(grad(f)(z))   # with the conjugate: descends
+print(f(z))
+
+z = 3. + 4j
+for _ in range(100):
+  z = z - 0.05 * grad(f)(z)             # without: the imaginary part grows!
+print(f(z))
+```
+
+This is a convention, not a law of nature: defining `grad` via the
+sesquilinear pairing instead would build the conjugate in, at the cost of
+breaking the plain-product identities above (and, for holomorphic functions,
+making `grad` return $\overline{f'(z)}$ rather than $f'(z)$). The practical
+takeaways under JAX's convention:
+
+1. To optimize a real-valued loss of complex parameters, step along the
+   *conjugate* of `grad` — and audit any optimizer library you use on
+   complex parameters for exactly this, since an optimizer written with real
+   parameters in mind won't conjugate.
+2. Directional derivatives and first-order Taylor expansions use the plain
+   product: $f(z + t) \approx f(z) + \operatorname{Re}(\texttt{grad}(f)(z) \cdot t)$.
+
+### Relation to Wirtinger derivatives
+
+If you've seen complex autodiff described elsewhere — for example in
+PyTorch's documentation — you may have met *Wirtinger derivatives*:
+
+$\qquad \frac{\partial}{\partial z} = \tfrac{1}{2}\left(\frac{\partial}{\partial x} - i \frac{\partial}{\partial y}\right), \qquad
+\frac{\partial}{\partial \bar z} = \tfrac{1}{2}\left(\frac{\partial}{\partial x} + i \frac{\partial}{\partial y}\right).$
+
+These are nothing exotic: they're a change of coordinates on the same real
+$2 \times 2$ Jacobian we've been using all along. Instead of four real
+numbers, the derivative of a $\mathbb{C} \to \mathbb{C}$ function is
+encoded as two complex ones, $\partial f/\partial z$ and $\partial
+f/\partial \bar z$, and the JVP takes the tidy form
+
+$\qquad \texttt{jvp}(t) = \frac{\partial f}{\partial z}\, t + \frac{\partial f}{\partial \bar z}\, \bar{t}.$
+
+```{code-cell}
+z = 1.5 + 0.5j                # the point where we computed J above
+
+fx = J[0, 0] + J[1, 0] * 1j   # df/dx = du/dx + i dv/dx
+fy = J[0, 1] + J[1, 1] * 1j   # df/dy = du/dy + i dv/dy
+dfdz    = 0.5 * (fx - 1j * fy)
+dfdzbar = 0.5 * (fx + 1j * fy)
+
+_, t_out = jvp(fun, (z,), (t,))
+print(jnp.allclose(t_out, dfdz * t + dfdzbar * jnp.conj(t)))
+```
+
+In this vocabulary: a function is holomorphic exactly when $\partial
+f/\partial \bar z = 0$ (that *is* the Cauchy–Riemann equations), in which
+case $\partial f/\partial z = f'(z)$. And for a real-valued $f$, JAX's
+convention gives $\texttt{grad}(f)(z) = 2\, \partial f/\partial z$, while
+the steepest-ascent vector is its conjugate, $2\, \partial f/\partial \bar
+z$. PyTorch and TensorFlow adopt that other convention: PyTorch's autograd
+notes define the gradient of a real-valued loss as $\partial L/\partial
+z^*$, the steepest-descent-ready choice, so their optimizers step without
+an explicit conjugate — whereas JAX computes $\partial L/\partial z$, and
+you conjugate when stepping, as above. It's the same real derivative
+underneath; the conventions differ only in which complex packaging of it
+the convenience wrapper hands you.
+
+### Holomorphic functions and `grad(f, holomorphic=True)`
+
+For a $\mathbb{C} \to \mathbb{C}$ function, `grad` raises an error on the
+complex output — in general four real numbers of derivative information
+can't be summarized in one complex number, and the error message suggests
+the fix: use `jax.vjp` (or `jax.jvp`) directly.
+
+But a holomorphic function is precisely a $\mathbb{C} \to \mathbb{C}$
+function whose derivative *is* a single complex number, $f'(z)$: the
+Cauchy–Riemann equations force the $2\times2$ Jacobian to be a
+rotate-and-scale, the action of one complex number under multiplication. By
+passing `holomorphic=True` you promise JAX that's the case, and `grad`
+returns exactly $f'(z)$ (it's `vjp`'s $w \mapsto f'(z) w$ applied to $w =
+1.0$):
+
+```{code-cell}
+print(grad(jnp.sin, holomorphic=True)(3. + 4j))
+print(jnp.cos(3. + 4j))
+```
+
+The `holomorphic=True` promise does nothing but disable the
+complex-output error. If the function isn't actually holomorphic, you'll
+silently get the wrong-looking answer: the gradient of the function with the
+imaginary part of its output discarded:
+
+```{code-cell}
+def f(z):
+  return jnp.conjugate(z)   # not holomorphic!
+
+grad(f, holomorphic=True)(3. + 4j)
+```
+
+You should expect complex numbers to work everywhere in JAX. Here's
+differentiating through a Cholesky decomposition of a complex matrix:
+
+```{code-cell}
+A = jnp.array([[5.,    2.+3j,    5j],
+              [2.-3j,   7.,  1.+7j],
+              [-5j,  1.-7j,    12.]])
+
+def f(X):
+    L = jnp.linalg.cholesky(X)
+    return jnp.sum((L - jnp.sin(L))**2)
+
+grad(f, holomorphic=True)(A)
+```
+
+## More advanced autodiff
+
+We worked through some easy, and then progressively more complicated,
+applications of automatic differentiation in JAX. We hope you now feel that
+taking derivatives in JAX is easy and powerful. The rest of this
+documentation section goes deeper:
+
+- {doc}`sharding-ad` — how autodiff interacts with explicit sharding: the
+  same cotangent-type reasoning as this page, extended to distributed
+  arrays.
+- {doc}`custom-derivatives` — defining your own derivative rules with hijax
+  primitives (including efficient derivatives at fixed points), and
+  {doc}`custom-jvp-vjp` for the classic decorator APIs.
+- {doc}`refs` — how autodiff interacts with mutable arrays: plumbing values
+  out of backward passes and accumulating gradients in place.
+- {doc}`remat` — controlling what autodiff saves versus recomputes, to trade
+  memory for FLOPs.
+- {ref}`jax-301-hijax-types` — differentiating with respect to entirely new
+  types.

--- a/docs/new_docs/301/custom-derivatives.md
+++ b/docs/new_docs/301/custom-derivatives.md
@@ -1,0 +1,1066 @@
+---
+jupytext:
+  formats: md:myst
+  notebook_metadata_filter: nosearch
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nosearch: true
+---
+
+(jax-301-custom-derivatives)=
+# Custom derivative rules with hijax primitives
+
+<!--* freshness: { reviewed: '2026-07-10' } *-->
+
+There have long been two ways to define differentiation rules in JAX:
+
+1. using `jax.custom_jvp` and `jax.custom_vjp` to define custom
+   differentiation rules for Python functions that are already
+   JAX-transformable, as described in [the custom derivatives
+   notebook](https://docs.jax.dev/en/latest/notebooks/Custom_derivative_rules_for_Python_code.html);
+   and
+2. defining new `core.Primitive` instances along with all their
+   transformation rules, for example to call into functions from other
+   systems like solvers, simulators, or general numerical computing systems.
+
+Hijax primitives unify these two. A hijax primitive is a real JAX primitive:
+it appears as a single unit in jaxprs, and you can attach a rule for each
+transformation. But like a `jax.custom_vjp`-decorated function, it also
+carries a Python implementation, written in terms of ordinary JAX operations,
+which is used for evaluation and lowering. So you don't need to write a
+lowering rule, and rules for the other transformations are only needed if you
+actually use those transformations.
+
+This document shows how to use hijax primitives to define custom derivative
+rules for JAX-transformable Python code. It's a hijax-flavored analogue of
+the {doc}`custom_jvp/custom_vjp guide <custom-jvp-vjp>`,
+and assumes familiarity with `jax.jvp` and `jax.grad`, and the mathematical
+meaning of JVPs and VJPs (see {doc}`cookbook`).
+
+Hijax primitives are the recommended way to define custom derivative rules
+going forward: a single primitive can carry rules for both differentiation
+modes (and for other transformations), and the same mechanism extends to
+custom rematerialization, custom types, and more. They are still
+experimental — expect imports from `jax.experimental.hijax`, and expect the
+APIs to evolve. The classic `jax.custom_jvp` and `jax.custom_vjp` decorators
+remain fully supported and can be more convenient for simple cases; they're
+covered in {doc}`custom-jvp-vjp`.
+
+### TL;DR
+
+Subclass `VJPHiPrimitive`, declare the input and output types, and define an
+`expand` method giving the implementation. Then attach the derivative rules
+you need: `vjp_fwd`/`vjp_bwd_retval` for reverse mode, `jvp` for forward
+mode:
+
+```{code-cell}
+import jax
+import jax.numpy as jnp
+from jax.experimental.hijax import VJPHiPrimitive
+
+class SinTimesY(VJPHiPrimitive):
+  def __init__(self, x_aval, y_aval):
+    self.in_avals = (x_aval, y_aval)  # input types
+    self.out_aval = x_aval            # output type
+    self.params = {}                  # static parameters (none here)
+    super().__init__()
+
+  # Implementation, used for evaluation and lowering (e.g. under jit).
+  def expand(self, x, y):
+    return jnp.sin(x) * y
+
+  # Reverse-mode: forward pass returns (primal_out, residuals).
+  def vjp_fwd(self, nzs_in, x, y):
+    return self(x, y), (jnp.cos(x), jnp.sin(x), y)
+
+  # Reverse-mode: backward pass maps (residuals, output cotangent) to a tuple
+  # of input cotangents.
+  def vjp_bwd_retval(self, res, g):
+    cos_x, sin_x, y = res
+    return (cos_x * g * y, sin_x * g)
+
+  # Forward-mode rule (optional, only needed under e.g. jax.jvp).
+  def jvp(self, primals, tangents):
+    (x, y), (x_dot, y_dot) = primals, tangents
+    return self(x, y), jnp.cos(x) * x_dot * y + jnp.sin(x) * y_dot
+
+def f(x, y):
+  return SinTimesY(jax.typeof(x), jax.typeof(y))(x, y)
+```
+
+```{code-cell}
+from jax import jvp, grad
+
+print(f(2., 3.))
+y, y_dot = jvp(f, (2., 3.), (1., 0.))
+print(y)
+print(y_dot)
+print(grad(f)(2., 3.))
+```
+
+Note that, unlike with `jax.custom_jvp` and `jax.custom_vjp` where you must
+choose one or the other, a single hijax primitive can carry both forward- and
+reverse-mode rules.
+
+## Example problems
+
+To get an idea of what problems hijax custom derivatives are meant to solve,
+let's go over a few examples. A more thorough introduction to the
+`VJPHiPrimitive` API is in the next section.
+
+### Example: Numerical stability
+
+One application of custom derivative rules is to improve the numerical
+stability of differentiation.
+
+Say we want to write a function called `log1pexp`, which computes
+$x \mapsto \log ( 1 + e^x )$. We can write that using `jax.numpy`:
+
+```{code-cell}
+def log1pexp(x):
+  return jnp.log(1. + jnp.exp(x))
+
+log1pexp(3.)
+```
+
+Since it's written in terms of `jax.numpy`, it's JAX-transformable:
+
+```{code-cell}
+from jax import jit, grad, vmap
+
+print(jit(log1pexp)(3.))
+print(jit(grad(log1pexp))(3.))
+print(vmap(jit(grad(log1pexp)))(jnp.arange(3.)))
+```
+
+But there's a numerical stability problem lurking here:
+
+```{code-cell}
+print(grad(log1pexp)(100.))
+```
+
+That doesn't seem right! After all, the derivative of $x \mapsto \log (1 +
+e^x)$ is $x \mapsto \frac{e^x}{1 + e^x}$, and so for large values of $x$ we'd
+expect the value to be about 1.
+
+We can get a bit more insight into what's going on by looking at the jaxpr
+for the gradient computation:
+
+```{code-cell}
+jit(grad(log1pexp)).trace(100.).jaxpr
+```
+
+Stepping through how the jaxpr would be evaluated, we can see that the last
+line would involve multiplying values that floating point math will round to
+0 and $\infty$, respectively, which is never a good idea. That is, we're
+effectively evaluating `lambda x: (1 / (1 + jnp.exp(x))) * jnp.exp(x)` for
+large `x`, which effectively turns into `0. * jnp.inf`.
+
+Instead of generating such large and small values, hoping for a cancellation
+that floats can't always provide, we'd rather just express the derivative
+function as a more numerically stable program. In particular, we can write a
+program that more closely evaluates the equal mathematical expression $1 -
+\frac{1}{1 + e^x}$, with no cancellation in sight.
+
+This problem is interesting because even though our definition of `log1pexp`
+could already be JAX-differentiated (and transformed with `jit`, `vmap`,
+...), we're not happy with the result of applying standard autodiff rules to
+the primitives comprising `log1pexp` and composing the result. Instead, we'd
+like to specify how the whole function `log1pexp` should be differentiated,
+as a unit, and thus arrange those exponentials better.
+
+Here's a solution using a hijax primitive:
+
+```{code-cell}
+class Log1pExp(VJPHiPrimitive):
+  def __init__(self, x_aval):
+    self.in_avals = (x_aval,)
+    self.out_aval = x_aval
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x):
+    return jnp.log(1. + jnp.exp(x))
+
+  def vjp_fwd(self, nzs_in, x):
+    return self(x), x
+
+  def vjp_bwd_retval(self, x, g):
+    return ((1 - 1/(1 + jnp.exp(x))) * g,)
+
+  def jvp(self, primals, tangents):
+    (x,), (x_dot,) = primals, tangents
+    return self(x), (1 - 1/(1 + jnp.exp(x))) * x_dot
+
+  def batch_dim_rule(self, axis_data, in_dims):
+    return in_dims[0]
+
+def log1pexp(x):
+  return Log1pExp(jax.typeof(x))(x)
+```
+
+```{code-cell}
+print(grad(log1pexp)(100.))
+```
+
+```{code-cell}
+print(jit(log1pexp)(3.))
+print(jit(grad(log1pexp))(3.))
+print(vmap(jit(grad(log1pexp)))(jnp.arange(3.)))
+```
+
+The `expand` method plays the role of the original Python function: it's
+what runs when we evaluate `log1pexp` eagerly, and it's what gets traced when
+we apply `jit`. The `vjp_fwd`/`vjp_bwd_retval` pair defines reverse-mode
+differentiation, and `jvp` defines forward-mode. (The `batch_dim_rule` method
+is a one-liner that tells `vmap` where the batch dimension of the output is;
+more on that below.)
+
+We can inspect the jaxpr of the gradient computation to confirm the stable
+formula is what runs:
+
+```{code-cell}
+jit(grad(log1pexp)).trace(100.).jaxpr
+```
+
+### Example: Enforcing a differentiation convention
+
+A related application is to enforce a differentiation convention, perhaps at
+a boundary.
+
+Consider the function $f : \mathbb{R}_+ \to \mathbb{R}_+$ with $f(x) =
+\frac{x}{1 + \sqrt{x}}$, where we take $\mathbb{R}_+ = [0, \infty)$. We might
+implement $f$ as a program like this:
+
+```{code-cell}
+def f(x):
+  return x / (1 + jnp.sqrt(x))
+```
+
+As a mathematical function on $\mathbb{R}$ (the full real line), $f$ is not
+differentiable at zero (because the limit defining the derivative doesn't
+exist from the left). Correspondingly, autodiff produces a `nan` value:
+
+```{code-cell}
+print(grad(f)(0.))
+```
+
+But mathematically if we think of $f$ as a function on $\mathbb{R}_+$ then it
+is differentiable at 0 [Rudin's Principles of Mathematical Analysis
+Definition 5.1, or Tao's Analysis I 3rd ed. Definition 10.1.1 and Example
+10.1.6]. Alternatively, we might say as a convention we want to consider the
+directional derivative from the right. So there is a sensible value for the
+Python function `grad(f)` to return at `0.0`, namely `1.0`. By default, JAX's
+machinery for differentiation assumes all functions are defined over
+$\mathbb{R}$ and thus doesn't produce `1.0` here.
+
+We can use a custom derivative rule! In particular, we can define the rule in
+terms of the derivative function $x \mapsto \frac{\sqrt{x} + 2}{2(\sqrt{x} +
+1)^2}$ on $\mathbb{R}_+$:
+
+```{code-cell}
+class FOnRPlus(VJPHiPrimitive):
+  def __init__(self, x_aval):
+    self.in_avals = (x_aval,)
+    self.out_aval = x_aval
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x):
+    return x / (1 + jnp.sqrt(x))
+
+  def vjp_fwd(self, nzs_in, x):
+    return self(x), x
+
+  def vjp_bwd_retval(self, x, g):
+    return (((jnp.sqrt(x) + 2) / (2 * (jnp.sqrt(x) + 1)**2)) * g,)
+
+def f(x):
+  return FOnRPlus(jax.typeof(x))(x)
+```
+
+```{code-cell}
+print(grad(f)(0.))
+```
+
+### Example: Gradient clipping
+
+While in some cases we want to express a mathematical differentiation
+computation, in other cases we may even want to take a step away from
+mathematics to adjust the computation autodiff performs. One canonical
+example is reverse-mode gradient clipping.
+
+For gradient clipping, we can use `jnp.clip` together with a
+reverse-mode-only rule. The bounds `lo` and `hi` are ordinary traced inputs:
+they aren't involved in differentiation, but they are runtime data (they
+could even be `jit` tracers), so the forward rule saves them as residuals
+and the backward rule returns `None` for their cotangents:
+
+```{code-cell}
+class ClipGradient(VJPHiPrimitive):
+  def __init__(self, lo_aval, hi_aval, x_aval):
+    self.in_avals = (lo_aval, hi_aval, x_aval)
+    self.out_aval = x_aval
+    self.params = {}
+    super().__init__()
+
+  def expand(self, lo, hi, x):
+    return x  # identity function
+
+  def vjp_fwd(self, nzs_in, lo, hi, x):
+    return self(lo, hi, x), (lo, hi)  # save bounds as residuals
+
+  def vjp_bwd_retval(self, res, g):
+    lo, hi = res
+    return (None, None, jnp.clip(g, lo, hi))  # None: zero cotangents for lo, hi
+
+  def batch_dim_rule(self, axis_data, in_dims):
+    return in_dims[2]
+
+def clip_gradient(lo, hi, x):
+  return ClipGradient(jax.typeof(lo), jax.typeof(hi), jax.typeof(x))(lo, hi, x)
+```
+
+(Static parameters in `self.params` wouldn't work for the bounds: params
+are baked into the primitive instance when it's constructed, so they can't
+be traced values. Anything that might be dynamic data — like bounds passed
+as arguments to a `jit`-compiled function — should be an ordinary input.
+Save `self.params` for genuinely static data, like the Python function in
+the `fixed_point` example below.)
+
+```{code-cell}
+import matplotlib.pyplot as plt
+
+t = jnp.linspace(0, 10, 1000)
+
+plt.plot(jnp.sin(t))
+plt.plot(vmap(grad(jnp.sin))(t))
+```
+
+```{code-cell}
+def clip_sin(x):
+  x = clip_gradient(-0.75, 0.75, x)
+  return jnp.sin(x)
+
+plt.plot(clip_sin(t))
+plt.plot(vmap(grad(clip_sin))(t))
+```
+
+### Example: Python debugging
+
+Another application that is motivated by development workflow rather than
+numerics is to set a `pdb` debugger trace in the backward pass of
+reverse-mode autodiff.
+
+When trying to track down the source of a `nan` runtime error, or just
+examine carefully the cotangent (gradient) values being propagated, it can be
+useful to insert a debugger at a point in the backward pass that corresponds
+to a specific point in the primal computation:
+
+```{code-cell}
+import pdb
+
+class Debug(VJPHiPrimitive):
+  def __init__(self, x_aval):
+    self.in_avals = (x_aval,)
+    self.out_aval = x_aval
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x):
+    return x  # acts like identity
+
+  def vjp_fwd(self, nzs_in, x):
+    return self(x), x
+
+  def vjp_bwd_retval(self, x, g):
+    pdb.set_trace()
+    return (g,)
+
+def debug(x):
+  return Debug(jax.typeof(x))(x)
+
+def foo(x):
+  y = x ** 2
+  y = debug(y)  # insert pdb in corresponding backward pass step
+  return jnp.sin(y)
+```
+
+```python
+jax.grad(foo)(3.)
+
+> <ipython-input-113-b19a2dc1abf7>(12)vjp_bwd_retval()
+-> return (g,)
+(Pdb) p x
+Array(9., dtype=float32)
+(Pdb) p g
+Array(-0.91113025, dtype=float32)
+(Pdb) q
+```
+
+### Example: Implicit function differentiation of iterative implementations
+
+This example gets pretty deep in the mathematical weeds!
+
+Another application for custom VJP rules is reverse-mode differentiation of
+functions that are JAX-transformable (by `jit`, `vmap`, ...) but not
+efficiently JAX-differentiable for some reason, perhaps because they involve
+`lax.while_loop`. (It's not possible to produce an XLA HLO program that
+efficiently computes the reverse-mode derivative of an XLA HLO While loop
+because that would require a program with unbounded memory use, which isn't
+possible to express in XLA HLO, at least without side-effecting interactions
+through infeed/outfeed.)
+
+For example, consider this `fixed_point` routine which computes a fixed
+point by iteratively applying a function in a `while_loop`:
+
+```{code-cell}
+from jax.lax import while_loop
+
+def fixed_point(f, a, x_guess):
+  def cond_fun(carry):
+    x_prev, x = carry
+    return jnp.abs(x_prev - x) > 1e-6
+
+  def body_fun(carry):
+    _, x = carry
+    return x, f(a, x)
+
+  _, x_star = while_loop(cond_fun, body_fun, (x_guess, f(a, x_guess)))
+  return x_star
+```
+
+This is an iterative procedure for numerically solving the equation $x =
+f(a, x)$ for $x$, by iterating $x_{t+1} = f(a, x_t)$ until $x_{t+1}$ is
+sufficiently close to $x_t$. The result $x^*$ depends on the parameters $a$,
+and so we can think of there being a function $a \mapsto x^*(a)$ that is
+implicitly defined by equation $x = f(a, x)$.
+
+We can use `fixed_point` to run iterative procedures to convergence, for
+example running Newton's method to calculate square roots while only
+executing adds, multiplies, and divides:
+
+```{code-cell}
+def newton_sqrt(a):
+  update = lambda a, x: 0.5 * (x + a / x)
+  return fixed_point(update, a, a)
+```
+
+```{code-cell}
+print(newton_sqrt(2.))
+```
+
+We can `vmap` or `jit` the function as well:
+
+```{code-cell}
+print(jit(vmap(newton_sqrt))(jnp.array([1., 2., 3., 4.])))
+```
+
+We can't apply reverse-mode automatic differentiation because of the
+`while_loop`, but it turns out we wouldn't want to anyway: instead of
+differentiating through the implementation of `fixed_point` and all its
+iterations, we can exploit the mathematical structure to do something that is
+much more memory-efficient (and FLOP-efficient in this case, too!). We can
+instead use the implicit function theorem [Prop A.25 of Bertsekas's Nonlinear
+Programming, 2nd ed.], which guarantees (under some conditions) the existence
+of the mathematical objects we're about to use. In essence, we linearize at
+the solution and solve those linear equations iteratively to compute the
+derivatives we want.
+
+Consider again the equation $x = f(a, x)$ and the function $x^*$. We want to
+evaluate vector-Jacobian products like $v^\mathsf{T} \mapsto v^\mathsf{T}
+\partial x^*(a_0)$.
+
+At least in an open neighborhood around the point $a_0$ at which we want to
+differentiate, let's assume that the equation $x^*(a) = f(a, x^*(a))$ holds
+for all $a$. Since the two sides are equal as functions of $a$, their
+derivatives must be equal as well, so let's differentiate both sides:
+
+$\qquad \partial x^*(a) = \partial_0 f(a, x^*(a)) + \partial_1 f(a, x^*(a))
+\partial x^*(a)$.
+
+Setting $A = \partial_1 f(a_0, x^*(a_0))$ and $B = \partial_0 f(a_0,
+x^*(a_0))$, we can write the quantity we're after more simply as
+
+$\qquad \partial x^*(a_0) = B + A \partial x^*(a_0)$,
+
+or, by rearranging,
+
+$\qquad \partial x^*(a_0) = (I - A)^{-1} B$.
+
+That means we can evaluate vector-Jacobian products like
+
+$\qquad v^\mathsf{T} \partial x^*(a_0) = v^\mathsf{T} (I - A)^{-1} B =
+w^\mathsf{T} B$,
+
+where $w^\mathsf{T} = v^\mathsf{T} (I - A)^{-1}$, or equivalently
+$w^\mathsf{T} = v^\mathsf{T} + w^\mathsf{T} A$, or equivalently
+$w^\mathsf{T}$ is the fixed point of the map $u^\mathsf{T} \mapsto
+v^\mathsf{T} + u^\mathsf{T} A$. That last characterization gives us a way to
+write the VJP for `fixed_point` in terms of a call to `fixed_point`!
+Moreover, after expanding $A$ and $B$ back out, we can see we need only to
+evaluate VJPs of $f$ at $(a_0, x^*(a_0))$.
+
+Here's the upshot. The function argument `f` isn't differentiated, so it goes
+in `params` (functions are hashable), while `a` and `x_guess` are ordinary
+traced inputs:
+
+```{code-cell}
+from functools import partial
+from jax import vjp
+
+class FixedPoint(VJPHiPrimitive):
+  def __init__(self, a_aval, x_aval, *, f):
+    self.in_avals = (a_aval, x_aval)
+    self.out_aval = x_aval
+    self.params = dict(f=f)
+    super().__init__()
+
+  def expand(self, a, x_guess):
+    def cond_fun(carry):
+      x_prev, x = carry
+      return jnp.abs(x_prev - x) > 1e-6
+
+    def body_fun(carry):
+      _, x = carry
+      return x, self.f(a, x)
+
+    _, x_star = while_loop(cond_fun, body_fun, (x_guess, self.f(a, x_guess)))
+    return x_star
+
+  def vjp_fwd(self, nzs_in, a, x_guess):
+    x_star = self(a, x_guess)
+    return x_star, (a, x_star)
+
+  def vjp_bwd_retval(self, res, x_star_bar):
+    a, x_star = res
+    _, vjp_a = vjp(lambda a: self.f(a, x_star), a)
+    a_bar, = vjp_a(fixed_point(partial(rev_iter, self.f),
+                               (a, x_star, x_star_bar),
+                               x_star_bar))
+    return a_bar, jnp.zeros_like(x_star)
+
+def rev_iter(f, packed, u):
+  a, x_star, x_star_bar = packed
+  _, vjp_x = vjp(lambda x: f(a, x), x_star)
+  return x_star_bar + vjp_x(u)[0]
+
+def fixed_point(f, a, x_guess):
+  a_aval = jax.tree.map(jax.typeof, a)
+  x_aval = jax.tree.map(jax.typeof, x_guess)
+  return FixedPoint(a_aval, x_aval, f=f)(a, x_guess)
+```
+
+```{code-cell}
+print(newton_sqrt(2.))
+```
+
+```{code-cell}
+print(grad(newton_sqrt)(2.))
+print(grad(grad(newton_sqrt))(2.))
+```
+
+We can check our answers by differentiating `jnp.sqrt`, which uses a totally
+different implementation:
+
+```{code-cell}
+print(grad(jnp.sqrt)(2.))
+print(grad(grad(jnp.sqrt))(2.))
+```
+
+Notice that the backward rule calls `fixed_point` again, on the linear
+problem, and that the parameter `a` passed there is a pytree of arrays: the
+`in_avals` entries can themselves be pytrees of types, as discussed below.
+
+A limitation to this approach is that the argument `f` can't close over any
+values involved in differentiation, since it's a static parameter of the
+primitive. That is, you might notice that we kept the parameter `a` explicit
+in the argument list of `fixed_point`. For this use case, consider using the
+low-level primitive `lax.custom_root`, which allows for derivatives in
+closed-over variables with custom root-finding functions.
+
+## Basic usage of `VJPHiPrimitive`
+
+### Anatomy of a hijax primitive
+
+A hijax primitive is a subclass of `VJPHiPrimitive`. Its `__init__` must set
+three attributes before calling `super().__init__()`:
+
+* `in_avals`, a tuple with one entry per positional argument, giving each
+  argument's type (each entry can also be a pytree of types);
+* `out_aval`, the output type (also possibly a pytree of types);
+* `params`, a dict of hashable static parameters, which are made available as
+  attributes on the instance (e.g. `self.f` for `params = dict(f=f)`).
+  Params are static: they're baked into the primitive instance, so they
+  can't be traced values, and dynamic data must instead be an input.
+
+Since the types are fixed at construction time, the usual idiom is a wrapper
+function that builds the primitive instance from the types of the arguments,
+using `jax.typeof`, and immediately applies it:
+
+```{code-cell}
+class Square(VJPHiPrimitive):
+  def __init__(self, x_aval):
+    self.in_avals = (x_aval,)
+    self.out_aval = x_aval
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x):
+    return x * x
+
+def square(x):
+  return Square(jax.typeof(x))(x)
+
+print(square(3.))
+```
+
+The instance is callable, and calling it is what binds the primitive: in an
+eager context it evaluates, and under a `jit` trace it records itself into
+the jaxpr as a single equation. The types of the actual arguments are checked
+against `in_avals`.
+
+The only required method is `expand`, which gives the implementation as a
+JAX-traceable Python function of the (non-static) arguments. Everything else
+is optional, and is only needed if you use the corresponding transformation:
+
+| method(s) | transformation |
+|---|---|
+| `expand` | evaluation and lowering (`jit`) |
+| `vjp_fwd` and `vjp_bwd_retval` (or `vjp_bwd`) | reverse-mode autodiff (`grad`, `vjp`) |
+| `jvp` | forward-mode autodiff (`jvp`) |
+| `lin` and `linearized` | `jax.linearize` |
+| `batch_dim_rule` (or `batch`) | `vmap` |
+| `transpose` | transposition, for primitives linear in some inputs |
+
+If you apply a transformation without having defined the corresponding
+method, you get a `NotImplementedError` telling you what to implement. For a
+primitive with a `jvp` rule, the reverse-mode and linearize methods can also
+be derived automatically — see the helpers below.
+
+### Custom VJPs with `vjp_fwd` and `vjp_bwd_retval`
+
+The pair `vjp_fwd`/`vjp_bwd_retval` works just like the `f_fwd`/`f_bwd` pair
+of `jax.custom_vjp`, in Haskell-like type signatures:
+
+```haskell
+vjp_fwd :: (NonZeros, a) -> (b, c)
+vjp_bwd_retval :: (c, CT b) -> CT a
+```
+
+The function `vjp_fwd` describes the forward pass: it takes the primal
+inputs and returns a pair of the primal output and any "residual" data to be
+stored for use by the backward pass. (Its extra first argument `nzs_in` is a
+tuple of booleans indicating which inputs are being differentiated; you can
+ignore it, or use it to avoid saving residuals that won't be needed.) The
+primal output should usually be computed by calling `self(...)`, i.e. by
+binding the primitive itself; that way the custom rules also apply under
+higher-order differentiation.
+
+The function `vjp_bwd_retval` describes the backward pass: it takes the
+residuals and the cotangent of the output, and returns a tuple of cotangents
+with one entry per primal input.
+
+```{code-cell}
+class Mul(VJPHiPrimitive):
+  def __init__(self, x_aval, y_aval):
+    self.in_avals = (x_aval, y_aval)
+    self.out_aval = x_aval
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x, y):
+    return x * y
+
+  def vjp_fwd(self, nzs_in, x, y):
+    return self(x, y), (x, y)
+
+  def vjp_bwd_retval(self, res, g):
+    x, y = res
+    return (g * y, x * g)
+
+def mul(x, y):
+  return Mul(jax.typeof(x), jax.typeof(y))(x, y)
+
+print(grad(mul)(2., 3.))
+print(grad(mul, 1)(2., 3.))
+```
+
+### Custom JVPs with `jvp`
+
+The `jvp` method defines forward-mode differentiation. It takes a tuple of
+primal inputs and a tuple of tangent inputs, and returns a pair of the primal
+output and the tangent output. (The input tangents can be symbolic zeros in
+some cases; see the symbolic zeros section below.)
+
+```{code-cell}
+class Sin(VJPHiPrimitive):
+  def __init__(self, x_aval):
+    self.in_avals = (x_aval,)
+    self.out_aval = x_aval
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x):
+    return jnp.sin(x)
+
+  def jvp(self, primals, tangents):
+    (x,), (x_dot,) = primals, tangents
+    return self(x), jnp.cos(x) * x_dot
+
+def sin(x):
+  return Sin(jax.typeof(x))(x)
+
+y, y_dot = jvp(sin, (3.,), (1.,))
+print(y)
+print(y_dot)
+```
+
+One difference from `jax.custom_jvp`: by default, JAX does not automatically
+derive reverse-mode differentiation from a hijax primitive's `jvp` rule, so
+applying `grad` to `sin` as defined above raises a `NotImplementedError`
+asking for `vjp_fwd`. You can define both sets of rules on the same primitive
+(as in the TL;DR example above); unlike with `jax.custom_jvp` and
+`jax.custom_vjp`, you never have to choose between them.
+
+But you can also opt into `jax.custom_jvp`-style behavior, where everything
+is derived from the JVP rule, by assigning helper functions as class
+attributes. The helpers come in pairs: `lin = linearize_from_jvp` together
+with `linearized = apply_derived_linearization` derives linearization
+support by partially evaluating `jvp`, and `vjp_fwd = vjp_fwd_from_jvp`
+together with `vjp_bwd_retval = transpose_jvp` derives reverse mode by
+storing the primal inputs and then linearizing and transposing `jvp` on the
+backward pass:
+
+```{code-cell}
+from jax.experimental.hijax import (
+    linearize_from_jvp, apply_derived_linearization,
+    vjp_fwd_from_jvp, transpose_jvp)
+
+class SinAD(Sin):
+  lin = linearize_from_jvp
+  linearized = apply_derived_linearization
+  vjp_fwd = vjp_fwd_from_jvp
+  vjp_bwd_retval = transpose_jvp
+
+def sin(x):
+  return SinAD(jax.typeof(x))(x)
+
+print(grad(sin)(3.))
+y, sin_lin = jax.linearize(sin, 3.)
+print(sin_lin(1.))
+print(grad(grad(sin))(3.))
+```
+
+As with `jax.custom_jvp`, for the derived transposition to work, the JVP
+rule's output tangents must be linear as a function of the input tangents.
+
+A second pair, `vjp_fwd = vjp_fwd_from_lin` with `vjp_bwd_retval =
+transpose_linearized`, instead derives reverse mode from the
+`lin`/`linearized` rules (whether handwritten or themselves derived from
+`jvp`): it stores the linearization's residuals rather than the primal
+inputs, and transposes `linearized` on the backward pass. And `jvp =
+jvp_from_lin` goes the other way, deriving forward mode from handwritten
+`lin`/`linearized` rules. (Deriving in a circle, with `jvp = jvp_from_lin`
+and `lin = linearize_from_jvp` on the same primitive, is an error.)
+
+Both kinds of rules are also what make higher-order differentiation work:
+`grad`-of-`grad` composes the VJP rules, while e.g. `jax.hessian`, which is
+forward-over-reverse, needs the `jvp` rule as well. As with `jax.custom_jvp`
+and `jax.custom_vjp`, a rule applies at higher orders of differentiation only
+if it computes its primal output by binding the primitive itself, i.e. by
+calling `self(...)` rather than inlining the implementation. (This represents
+a kind of fundamental tradeoff, where we can't make use of intermediate
+values from the evaluation of `expand` in our rule *and also* have the rule
+apply in all orders of higher-order differentiation.)
+
+### Hijax primitives in jaxprs
+
+Because a hijax primitive is a real primitive, it appears as a single
+equation in jaxprs:
+
+```{code-cell}
+jit(mul).trace(2., 3.).jaxpr
+```
+
+That's true under `jit` too. It's only at lowering time that `expand` is
+traced and inlined. In an eager context, each call to the primitive calls
+`expand` again (so, like any JAX function, it's best to keep `expand` free of
+side effects, though harmless ones like `print` can be instructive):
+
+```{code-cell}
+class Noisy(VJPHiPrimitive):
+  def __init__(self, x_aval):
+    self.in_avals = (x_aval,)
+    self.out_aval = x_aval
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x):
+    print('called expand!')
+    return jnp.sin(x)
+
+def noisy(x):
+  return Noisy(jax.typeof(x))(x)
+
+print(noisy(3.))
+```
+
+```{code-cell}
+print(jit(noisy)(3.))
+print(jit(noisy)(3.))  # tracing is cached: no more 'called expand!'
+```
+
+You can also use Python control flow in `expand` and in the derivative
+rules, as long as the primitive is used eagerly (outside of `jit`), since the
+rules then see concrete values:
+
+```{code-cell}
+class G(VJPHiPrimitive):
+  def __init__(self, x_aval):
+    self.in_avals = (x_aval,)
+    self.out_aval = x_aval
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x):
+    if x > 0:
+      return jnp.sin(x)
+    else:
+      return jnp.cos(x)
+
+  def vjp_fwd(self, nzs_in, x):
+    return self(x), x
+
+  def vjp_bwd_retval(self, x, g):
+    if x > 0:
+      return (2 * g,)
+    else:
+      return (3 * g,)
+
+def g(x):
+  return G(jax.typeof(x))(x)
+
+print(grad(g)(1.))
+print(grad(g)(-1.))
+```
+
+### `vmap` with `batch_dim_rule`
+
+For `vmap` support, the easiest option is to define `batch_dim_rule`, which
+takes axis metadata and the batch dimension of each argument (`None` for
+unbatched arguments) and just returns the batch dimension of the output.
+Given that data movement answer, JAX derives the batched computation
+automatically by `vmap`-ing the primitive's other rules:
+
+```{code-cell}
+class MulV(Mul):
+  def batch_dim_rule(self, axis_data, in_dims):
+    x_dim, y_dim = in_dims
+    return y_dim if x_dim is None else x_dim
+
+def mul(x, y):
+  return MulV(jax.typeof(x), jax.typeof(y))(x, y)
+
+x = jnp.arange(3.)
+y = jnp.arange(3.) + 1.
+print(vmap(mul)(x, y))
+print(vmap(mul, in_axes=(0, None))(x, 2.))
+print(vmap(grad(mul))(x, y))
+```
+
+(For full control over the batched computation itself, you can instead
+override the `batch` method.)
+
+## More features and details
+
+### Working with `list` / `tuple` / `dict` containers (and other pytrees)
+
+The entries of `in_avals`, and `out_aval` itself, can be
+pytrees ({ref}`jax-101-pytrees`) of types, so arguments
+and outputs can be pytrees of arrays. Here's a contrived example:
+
+```{code-cell}
+from collections import namedtuple
+Point = namedtuple("Point", ["x", "y"])
+
+from jax.experimental.hijax import Zero, instantiate_zeros
+
+class FPt(VJPHiPrimitive):
+  def __init__(self, pt_aval):
+    self.in_avals = (pt_aval,)
+    self.out_aval = {'a': pt_aval.x, 'b': (pt_aval.x, pt_aval.y)}
+    self.params = {}
+    super().__init__()
+
+  def expand(self, pt):
+    return {'a': pt.x ** 2, 'b': (jnp.sin(pt.x), jnp.cos(pt.y))}
+
+  def vjp_fwd(self, nzs_in, pt):
+    return self(pt), pt
+
+  def vjp_bwd_retval(self, pt, g):
+    g = jax.tree.map(instantiate_zeros, g,
+                     is_leaf=lambda x: isinstance(x, Zero))
+    a_bar, (b0_bar, b1_bar) = g['a'], g['b']
+    x_bar = 2 * pt.x * a_bar + jnp.cos(pt.x) * b0_bar
+    y_bar = -jnp.sin(pt.y) * b1_bar
+    return (Point(x_bar, y_bar),)
+
+def f(pt):
+  return FPt(jax.tree.map(jax.typeof, pt))(pt)
+
+def fun(pt):
+  dct = f(pt)
+  return dct['a'] + dct['b'][0]
+
+pt = Point(1., 2.)
+print(f(pt))
+print(grad(fun)(pt))
+```
+
+### Symbolic zeros
+
+The example above snuck in a new detail: the cotangents passed to the
+backward rule can contain *symbolic zeros*. When part of the primitive's
+output doesn't affect the value being differentiated (here `fun` doesn't use
+`dct['b'][1]`), the corresponding cotangent is not an array of zeros but an
+instance of the special `Zero` class, which records only the type. That's in
+contrast to `jax.custom_vjp`, where symbolic zeros are opt-in via
+`symbolic_zeros=True`.
+
+Symbolic zeros let a rule avoid doing work (or avoid errors, for
+non-differentiable outputs like integer values). If you don't want to handle
+them, instantiate them into actual zero arrays with `instantiate_zeros`, as
+above.
+
+On the input side, the `nzs_in` argument to `vjp_fwd` reports symbolically
+which inputs are being differentiated: it's a tuple of booleans, one per
+input, where `False` means that input's tangent is symbolically zero, so no
+cotangent for it will be used. A rule can use that to avoid saving unneeded
+residuals:
+
+```{code-cell}
+class Mul2(VJPHiPrimitive):
+  def __init__(self, x_aval, y_aval):
+    self.in_avals = (x_aval, y_aval)
+    self.out_aval = x_aval
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x, y):
+    return x * y
+
+  def vjp_fwd(self, nzs_in, x, y):
+    x_nz, y_nz = nzs_in
+    return self(x, y), (x if y_nz else None, y if x_nz else None)
+
+  def vjp_bwd_retval(self, res, g):
+    x, y = res
+    return (g * y if y is not None else None,
+            x * g if x is not None else None)
+
+def mul2(x, y):
+  return Mul2(jax.typeof(x), jax.typeof(y))(x, y)
+
+print(grad(mul2, 0)(2., 3.))  # nzs_in == (True, False), saves only y
+print(grad(mul2, 1)(2., 3.))  # nzs_in == (False, True), saves only x
+```
+
+Notice that the backward rule can return `None` for an input whose cotangent
+isn't needed.
+
+Symbolic zeros appear on the forward-mode side too: the tangents passed to a
+`jvp` rule can be `Zero`s, for example when a primitive is applied to a mix
+of differentiated inputs and constants. That's true whether the rule is
+invoked directly by `jax.jvp` or partially evaluated by
+`linearize_from_jvp`. As with cotangents, a rule can handle them explicitly
+to exploit the sparsity, or clean them up with `instantiate_zeros`.
+
+### In-place cotangent accumulation with `vjp_bwd`
+
+Instead of `vjp_bwd_retval`, which returns the input cotangents as values, a
+backward rule can be written as `vjp_bwd`, which receives one *accumulator*
+per primal input and adds each cotangent contribution in-place by calling
+`.accum(...)`:
+
+```{code-cell}
+class Mul3(VJPHiPrimitive):
+  def __init__(self, x_aval, y_aval):
+    self.in_avals = (x_aval, y_aval)
+    self.out_aval = x_aval
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x, y):
+    return x * y
+
+  def vjp_fwd(self, nzs_in, x, y):
+    return self(x, y), (x, y)
+
+  def vjp_bwd(self, res, g, x_acc, y_acc):
+    x, y = res
+    x_acc.accum(g * y)
+    y_acc.accum(x * g)
+
+def mul3(x, y):
+  return Mul3(jax.typeof(x), jax.typeof(y))(x, y)
+
+print(grad(mul3)(2., 3.))
+```
+
+For inputs that aren't being differentiated, the accumulator is a `NullAccum`
+whose `accum` is a no-op, so it's safe to accumulate unconditionally. The
+accumulator form can save memory when gradients are accumulated across many
+contributions. Define either `vjp_bwd` or `vjp_bwd_retval`, not both.
+
+### Custom linearization with `lin` and `linearized`
+
+`jax.linearize` doesn't use the `jvp` or VJP rules; it has its own pair of
+methods. The `lin` method is like `vjp_fwd`: it takes `nzs_in` and the primal
+inputs, and returns the primal output paired with residuals. The `linearized`
+method is the linear map itself: it takes the residuals and the input
+tangents, and returns the output tangents:
+
+```{code-cell}
+class Sin2(Sin):
+  def lin(self, nzs_in, x):
+    return self(x), jnp.cos(x)
+
+  def linearized(self, cos_x, x_dot):
+    return cos_x * x_dot
+
+def sin2(x):
+  return Sin2(jax.typeof(x))(x)
+
+y, f_lin = jax.linearize(sin2, 3.)
+print(y)
+print(f_lin(1.))
+```
+
+(If you don't need to control the linearization itself, recall from above
+that a primitive with a `jvp` rule can just set `lin = linearize_from_jvp`
+and `linearized = apply_derived_linearization`.)
+
+### What we haven't covered
+
+Custom derivatives are only part of the hijax story. Hijax primitives can
+also:
+
+* introduce new types beyond arrays, by subclassing `HiType` (immutable) or
+  `MutableHiType` and registering them with `register_hitype`, with the
+  primitive's `in_avals`/`out_aval` mentioning the new types — see
+  {ref}`jax-301-hijax-types`;
+* define a `transpose` rule, for primitives that are linear in some inputs;
+* customize rematerialization via a `remat` method, and dead code
+  elimination via a `dce` method.
+
+Those deserve documents of their own. In the meantime, `tests/hijax_test.py`
+is a good source of worked examples.

--- a/docs/new_docs/301/custom-jvp-vjp.md
+++ b/docs/new_docs/301/custom-jvp-vjp.md
@@ -1,0 +1,782 @@
+---
+jupytext:
+  formats: md:myst
+  notebook_metadata_filter: nosearch
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nosearch: true
+---
+
+(jax-301-custom-jvp-vjp)=
+# Custom JVPs or VJPs with `custom_jvp` and `custom_vjp`
+
+<!--* freshness: { reviewed: '2025-12-10' } *-->
+
+There are two ways to define differentiation rules in JAX:
+
+1. using [`jax.custom_jvp`](https://docs.jax.dev/en/latest/_autosummary/jax.custom_jvp.html) and [`jax.custom_vjp`](https://docs.jax.dev/en/latest/_autosummary/jax.custom_vjp.html) to define custom differentiation rules for Python functions that are already JAX-transformable; and
+2. defining new `core.Primitive` instances along with all their transformation rules, for example to call into functions from other systems like solvers, simulators, or general numerical computing systems.
+
+This notebook is about #1. To read instead about #2, see the [notebook on adding primitives](https://docs.jax.dev/en/latest/notebooks/How_JAX_primitives_work.html).
+
+Hijax primitives (see {doc}`custom-derivatives`) unify these two approaches, and are the recommended path going forward: a hijax primitive carries a JAX-traceable Python implementation along with custom rules for differentiation and other transformations. The APIs here remain fully supported, and are often the most convenient for simple cases.
+
+For an introduction to JAX's automatic differentiation API, see {doc}`cookbook`. This notebook assumes some familiarity with [jax.jvp](https://docs.jax.dev/en/latest/_autosummary/jax.jvp.html) and [jax.grad](https://docs.jax.dev/en/latest/_autosummary/jax.grad.html), and the mathematical meaning of JVPs and VJPs.
+
++++
+
+### TL;DR: Custom JVPs with `jax.custom_jvp`
+
+```{code-cell}
+import jax.numpy as jnp
+from jax import custom_jvp
+
+@custom_jvp
+def f(x, y):
+  return jnp.sin(x) * y
+
+@f.defjvp
+def f_jvp(primals, tangents):
+  x, y = primals
+  x_dot, y_dot = tangents
+  primal_out = f(x, y)
+  tangent_out = jnp.cos(x) * x_dot * y + jnp.sin(x) * y_dot
+  return primal_out, tangent_out
+```
+
+```{code-cell}
+from jax import jvp, grad
+
+print(f(2., 3.))
+y, y_dot = jvp(f, (2., 3.), (1., 0.))
+print(y)
+print(y_dot)
+print(grad(f)(2., 3.))
+```
+
+```{code-cell}
+# Equivalent alternative using the defjvps convenience wrapper
+
+@custom_jvp
+def f(x, y):
+  return jnp.sin(x) * y
+
+f.defjvps(lambda x_dot, primal_out, x, y: jnp.cos(x) * x_dot * y,
+          lambda y_dot, primal_out, x, y: jnp.sin(x) * y_dot)
+```
+
+```{code-cell}
+print(f(2., 3.))
+y, y_dot = jvp(f, (2., 3.), (1., 0.))
+print(y)
+print(y_dot)
+print(grad(f)(2., 3.))
+```
+
+### TL;DR: Custom VJPs with `jax.custom_vjp`
+
+```{code-cell}
+from jax import custom_vjp
+
+@custom_vjp
+def f(x, y):
+  return jnp.sin(x) * y
+
+def f_fwd(x, y):
+  # Returns primal output and residuals to be used in backward pass by f_bwd.
+  return f(x, y), (jnp.cos(x), jnp.sin(x), y)
+
+def f_bwd(res, g):
+  cos_x, sin_x, y = res # Gets residuals computed in f_fwd
+  return (cos_x * g * y, sin_x * g)
+
+f.defvjp(f_fwd, f_bwd)
+```
+
+```{code-cell}
+print(grad(f)(2., 3.))
+```
+
+## Example problems
+
+To get an idea of what problems `jax.custom_jvp` and `jax.custom_vjp` are meant to solve, let's go over one example for each — a `custom_jvp` for numerical stability, and a `custom_vjp` for gradient clipping. (More example problems, including enforcing a differentiation convention at a boundary and efficient implicit differentiation of fixed points, are worked in {doc}`custom-derivatives`; each translates directly to these APIs.) A more thorough introduction to the `jax.custom_jvp` and `jax.custom_vjp` APIs is in the next section.
+
++++
+
+### Example: Numerical stability
+
+One application of `jax.custom_jvp` is to improve the numerical stability of differentiation.
+
++++
+
+Say we want to write a function called `log1pexp`, which computes $x \mapsto \log ( 1 + e^x )$. We can write that using `jax.numpy`:
+
+```{code-cell}
+def log1pexp(x):
+  return jnp.log(1. + jnp.exp(x))
+
+log1pexp(3.)
+```
+
+Since it's written in terms of `jax.numpy`, it's JAX-transformable:
+
+```{code-cell}
+from jax import jit, grad, vmap
+
+print(jit(log1pexp)(3.))
+print(jit(grad(log1pexp))(3.))
+print(vmap(jit(grad(log1pexp)))(jnp.arange(3.)))
+```
+
+But there's a numerical stability problem lurking here:
+
+```{code-cell}
+print(grad(log1pexp)(100.))
+```
+
+That doesn't seem right! After all, the derivative of $x \mapsto \log (1 + e^x)$ is $x \mapsto \frac{e^x}{1 + e^x}$, and so for large values of $x$ we'd expect the value to be about 1.
+
+We can get a bit more insight into what's going on by looking at the jaxpr for the gradient computation:
+
+```{code-cell}
+jit(grad(log1pexp)).trace(100.).jaxpr
+```
+
+Stepping through how the jaxpr would be evaluated, we can see that the last line would involve multiplying values that floating point math will round to 0 and $\infty$, respectively, which is never a good idea. That is, we're effectively evaluating `lambda x: (1 / (1 + jnp.exp(x))) * jnp.exp(x)` for large `x`, which effectively turns into `0. * jnp.inf`.
+
+Instead of generating such large and small values, hoping for a cancellation that floats can't always provide, we'd rather just express the derivative function as a more numerically stable program. In particular, we can write a program that more closely evaluates the equal mathematical expression $1 - \frac{1}{1 + e^x}$, with no cancellation in sight.
+
+This problem is interesting because even though our definition of `log1pexp` could already be JAX-differentiated (and transformed with [`jit`](https://docs.jax.dev/en/latest/_autosummary/jax.jit.html), [`vmap`](https://docs.jax.dev/en/latest/_autosummary/jax.vmap.html), ...), we're not happy with the result of applying standard autodiff rules to the primitives comprising `log1pexp` and composing the result. Instead, we'd like to specify how the whole function `log1pexp` should be differentiated, as a unit, and thus arrange those exponentials better.
+
+This is one application of custom derivative rules for Python functions that are already JAX transformable: specifying how a composite function should be differentiated, while still using its original Python definition for other transformations (like `jit`, `vmap`, ...).
+
+Here's a solution using `jax.custom_jvp`:
+
+```{code-cell}
+from jax import custom_jvp
+
+@custom_jvp
+def log1pexp(x):
+  return jnp.log(1. + jnp.exp(x))
+
+@log1pexp.defjvp
+def log1pexp_jvp(primals, tangents):
+  x, = primals
+  x_dot, = tangents
+  ans = log1pexp(x)
+  ans_dot = (1 - 1/(1 + jnp.exp(x))) * x_dot
+  return ans, ans_dot
+```
+
+```{code-cell}
+print(grad(log1pexp)(100.))
+```
+
+```{code-cell}
+print(jit(log1pexp)(3.))
+print(jit(grad(log1pexp))(3.))
+print(vmap(jit(grad(log1pexp)))(jnp.arange(3.)))
+```
+
+Here's a [`defjvps`](https://docs.jax.dev/en/latest/_autosummary/jax.custom_jvp.defjvps.html) convenience wrapper to express the same thing:
+
+```{code-cell}
+@custom_jvp
+def log1pexp(x):
+  return jnp.log(1. + jnp.exp(x))
+
+log1pexp.defjvps(lambda t, ans, x: (1 - 1/(1 + jnp.exp(x))) * t)
+```
+
+```{code-cell}
+print(grad(log1pexp)(100.))
+print(jit(log1pexp)(3.))
+print(jit(grad(log1pexp))(3.))
+print(vmap(jit(grad(log1pexp)))(jnp.arange(3.)))
+```
+
+### Example: Gradient clipping
+
+While in some cases we want to express a mathematical differentiation computation, in other cases we may even want to take a step away from mathematics to adjust the computation autodiff performs. One canonical example is reverse-mode gradient clipping.
+
+For gradient clipping, we can use [`jnp.clip`](https://docs.jax.dev/en/latest/_autosummary/jax.numpy.clip.html) together with a [`jax.custom_vjp`](https://docs.jax.dev/en/latest/_autosummary/jax.custom_vjp.html) reverse-mode-only rule:
+
+```{code-cell}
+from functools import partial
+from jax import custom_vjp
+
+@custom_vjp
+def clip_gradient(lo, hi, x):
+  return x  # identity function
+
+def clip_gradient_fwd(lo, hi, x):
+  return x, (lo, hi)  # save bounds as residuals
+
+def clip_gradient_bwd(res, g):
+  lo, hi = res
+  return (None, None, jnp.clip(g, lo, hi))  # use None to indicate zero cotangents for lo and hi
+
+clip_gradient.defvjp(clip_gradient_fwd, clip_gradient_bwd)
+```
+
+```{code-cell}
+import matplotlib.pyplot as plt
+from jax import vmap
+
+t = jnp.linspace(0, 10, 1000)
+
+plt.plot(jnp.sin(t))
+plt.plot(vmap(grad(jnp.sin))(t))
+```
+
+```{code-cell}
+def clip_sin(x):
+  x = clip_gradient(-0.75, 0.75, x)
+  return jnp.sin(x)
+
+plt.plot(clip_sin(t))
+plt.plot(vmap(grad(clip_sin))(t))
+```
+
+## Basic usage of `jax.custom_jvp` and `jax.custom_vjp` APIs
+
++++
+
+### Use `jax.custom_jvp` to define forward-mode (and, indirectly, reverse-mode) rules
+
+Here's a canonical basic example of using [`jax.custom_jvp`](https://docs.jax.dev/en/latest/_autosummary/jax.custom_jvp.html), where the comments use
+[Haskell-like type signatures](https://wiki.haskell.org/Type_signature):
+
+```{code-cell}
+from jax import custom_jvp
+import jax.numpy as jnp
+
+# f :: a -> b
+@custom_jvp
+def f(x):
+  return jnp.sin(x)
+
+# f_jvp :: (a, T a) -> (b, T b)
+def f_jvp(primals, tangents):
+  x, = primals
+  t, = tangents
+  return f(x), jnp.cos(x) * t
+
+f.defjvp(f_jvp)
+```
+
+```{code-cell}
+from jax import jvp
+
+print(f(3.))
+
+y, y_dot = jvp(f, (3.,), (1.,))
+print(y)
+print(y_dot)
+```
+
+In words, we start with a primal function `f` that takes inputs of type `a` and produces outputs of type `b`. We associate with it a JVP rule function `f_jvp` that takes a pair of inputs representing the primal inputs of type `a` and the corresponding tangent inputs of type `T a`, and produces a pair of outputs representing the primal outputs of type `b` and tangent outputs of type `T b`. The tangent outputs should be a linear function of the tangent inputs.
+
++++
+
+You can also use `f.defjvp` as a decorator, as in
+
+```python
+@custom_jvp
+def f(x):
+  ...
+
+@f.defjvp
+def f_jvp(primals, tangents):
+  ...
+```
+
++++
+
+Even though we defined only a JVP rule and no VJP rule, we can use both forward- and reverse-mode differentiation on `f`. JAX will automatically transpose the linear computation on tangent values from our custom JVP rule, computing the VJP as efficiently as if we had written the rule by hand:
+
+```{code-cell}
+from jax import grad
+
+print(grad(f)(3.))
+print(grad(grad(f))(3.))
+```
+
+For automatic transposition to work, the JVP rule's output tangents must be linear as a function of the input tangents. Otherwise a transposition error is raised.
+
++++
+
+Multiple arguments work like this:
+
+```{code-cell}
+@custom_jvp
+def f(x, y):
+  return x ** 2 * y
+
+@f.defjvp
+def f_jvp(primals, tangents):
+  x, y = primals
+  x_dot, y_dot = tangents
+  primal_out = f(x, y)
+  tangent_out = 2 * x * y * x_dot + x ** 2 * y_dot
+  return primal_out, tangent_out
+```
+
+```{code-cell}
+print(grad(f)(2., 3.))
+```
+
+The [`defjvps`](https://docs.jax.dev/en/latest/_autosummary/jax.custom_jvp.defjvps.html) convenience wrapper lets us define a JVP for each argument separately, and the results are computed separately then summed:
+
+```{code-cell}
+@custom_jvp
+def f(x):
+  return jnp.sin(x)
+
+f.defjvps(lambda t, ans, x: jnp.cos(x) * t)
+```
+
+```{code-cell}
+print(grad(f)(3.))
+```
+
+Here's a `defjvps` example with multiple arguments:
+
+```{code-cell}
+@custom_jvp
+def f(x, y):
+  return x ** 2 * y
+
+f.defjvps(lambda x_dot, primal_out, x, y: 2 * x * y * x_dot,
+          lambda y_dot, primal_out, x, y: x ** 2 * y_dot)
+```
+
+```{code-cell}
+print(grad(f)(2., 3.))
+print(grad(f, 0)(2., 3.))  # same as above
+print(grad(f, 1)(2., 3.))
+```
+
+As a shorthand, with `defjvps` you can pass a `None` value to indicate that the JVP for a particular argument is zero:
+
+```{code-cell}
+@custom_jvp
+def f(x, y):
+  return x ** 2 * y
+
+f.defjvps(lambda x_dot, primal_out, x, y: 2 * x * y * x_dot,
+          None)
+```
+
+```{code-cell}
+print(grad(f)(2., 3.))
+print(grad(f, 0)(2., 3.))  # same as above
+print(grad(f, 1)(2., 3.))
+```
+
+Calling a `jax.custom_jvp` function with keyword arguments, or writing a `jax.custom_jvp` function definition with default arguments, are both allowed so long as they can be unambiguously mapped to positional arguments based on the function signature retrieved by the standard library `inspect.signature` mechanism.
+
++++
+
+When you're not performing differentiation, the function `f` is called just as if it weren't decorated by `jax.custom_jvp`:
+
+```{code-cell}
+@custom_jvp
+def f(x):
+  print('called f!')  # a harmless side-effect
+  return jnp.sin(x)
+
+@f.defjvp
+def f_jvp(primals, tangents):
+  print('called f_jvp!')  # a harmless side-effect
+  x, = primals
+  t, = tangents
+  return f(x), jnp.cos(x) * t
+```
+
+```{code-cell}
+from jax import vmap, jit
+
+print(f(3.))
+```
+
+```{code-cell}
+print(vmap(f)(jnp.arange(3.)))
+print(jit(f)(3.))
+```
+
+The custom JVP rule is invoked during differentiation, whether forward or reverse:
+
+```{code-cell}
+y, y_dot = jvp(f, (3.,), (1.,))
+print(y_dot)
+```
+
+```{code-cell}
+print(grad(f)(3.))
+```
+
+Notice that `f_jvp` calls `f` to compute the primal outputs. In the context of higher-order differentiation, each application of a differentiation transform will use the custom JVP rule if and only if the rule calls the original `f` to compute the primal outputs. (This represents a kind of fundamental tradeoff, where we can't make use of intermediate values from the evaluation of `f` in our rule _and also_ have the rule apply in all orders of higher-order differentiation.)
+
+```{code-cell}
+grad(grad(f))(3.)
+```
+
+You can use Python control flow with `jax.custom_jvp`:
+
+```{code-cell}
+@custom_jvp
+def f(x):
+  if x > 0:
+    return jnp.sin(x)
+  else:
+    return jnp.cos(x)
+
+@f.defjvp
+def f_jvp(primals, tangents):
+  x, = primals
+  x_dot, = tangents
+  ans = f(x)
+  if x > 0:
+    return ans, 2 * x_dot
+  else:
+    return ans, 3 * x_dot
+```
+
+```{code-cell}
+print(grad(f)(1.))
+print(grad(f)(-1.))
+```
+
+### Use `jax.custom_vjp` to define custom reverse-mode-only rules
+
+While `jax.custom_jvp` suffices for controlling both forward- and, via JAX's automatic transposition, reverse-mode differentiation behavior, in some cases we may want to directly control a VJP rule, for example in the latter two example problems presented above. We can do that with [`jax.custom_vjp`](https://docs.jax.dev/en/latest/_autosummary/jax.custom_vjp.html):
+
+```{code-cell}
+from jax import custom_vjp
+import jax.numpy as jnp
+
+# f :: a -> b
+@custom_vjp
+def f(x):
+  return jnp.sin(x)
+
+# f_fwd :: a -> (b, c)
+def f_fwd(x):
+  return f(x), jnp.cos(x)
+
+# f_bwd :: (c, CT b) -> CT a
+def f_bwd(cos_x, y_bar):
+  return (cos_x * y_bar,)
+
+f.defvjp(f_fwd, f_bwd)
+```
+
+```{code-cell}
+from jax import grad
+
+print(f(3.))
+print(grad(f)(3.))
+```
+
+In words, we again start with a primal function `f` that takes inputs of type `a` and produces outputs of type `b`. We associate with it two functions, `f_fwd` and `f_bwd`, which describe how to perform the forward- and backward-passes of reverse-mode autodiff, respectively.
+
+The function `f_fwd` describes the forward pass, not only the primal computation but also what values to save for use on the backward pass. Its input signature is just like that of the primal function `f`, in that it takes a primal input of type `a`. But as output it produces a pair, where the first element is the primal output `b` and the second element is any "residual" data of type `c` to be stored for use by the backward pass. (This second output is analogous to [PyTorch's save_for_backward mechanism](https://pytorch.org/tutorials/beginner/examples_autograd/two_layer_net_custom_function.html).)
+
+The function `f_bwd` describes the backward pass. It takes two inputs, where the first is the residual data of type `c` produced by `f_fwd` and the second is the output cotangents of type `CT b` corresponding to the output of the primal function. It produces an output of type `CT a` representing the cotangents corresponding to the input of the primal function. In particular, the output of `f_bwd` must be a sequence (e.g. a tuple) of length equal to the number of arguments to the primal function.
+
++++
+
+So multiple arguments work like this:
+
+```{code-cell}
+from jax import custom_vjp
+
+@custom_vjp
+def f(x, y):
+  return jnp.sin(x) * y
+
+def f_fwd(x, y):
+  return f(x, y), (jnp.cos(x), jnp.sin(x), y)
+
+def f_bwd(res, g):
+  cos_x, sin_x, y = res
+  return (cos_x * g * y, sin_x * g)
+
+f.defvjp(f_fwd, f_bwd)
+```
+
+```{code-cell}
+print(grad(f)(2., 3.))
+```
+
+Calling a `jax.custom_vjp` function with keyword arguments, or writing a `jax.custom_vjp` function definition with default arguments, are both allowed so long as they can be unambiguously mapped to positional arguments based on the function signature retrieved by the standard library `inspect.signature` mechanism.
+
++++
+
+As with `jax.custom_jvp`, the custom VJP rule comprised by `f_fwd` and `f_bwd` is not invoked if differentiation is not applied. If function is evaluated, or transformed with `jit`, `vmap`, or other non-differentiation transformations, then only `f` is called.
+
+```{code-cell}
+@custom_vjp
+def f(x):
+  print("called f!")
+  return jnp.sin(x)
+
+def f_fwd(x):
+  print("called f_fwd!")
+  return f(x), jnp.cos(x)
+
+def f_bwd(cos_x, y_bar):
+  print("called f_bwd!")
+  return (cos_x * y_bar,)
+
+f.defvjp(f_fwd, f_bwd)
+```
+
+```{code-cell}
+print(f(3.))
+```
+
+```{code-cell}
+print(grad(f)(3.))
+```
+
+```{code-cell}
+from jax import vjp
+
+y, f_vjp = vjp(f, 3.)
+print(y)
+```
+
+```{code-cell}
+print(f_vjp(1.))
+```
+
+**Forward-mode autodiff cannot be used on the** `jax.custom_vjp` **function** and will raise an error:
+
+```{code-cell}
+from jax import jvp
+
+try:
+  jvp(f, (3.,), (1.,))
+except TypeError as e:
+  print('ERROR! {}'.format(e))
+```
+
+If you want to use both forward- and reverse-mode, use `jax.custom_jvp` instead.
+
++++
+
+We can use `jax.custom_vjp` together with `pdb` to insert a debugger trace in the backward pass:
+
+```{code-cell}
+import pdb
+
+@custom_vjp
+def debug(x):
+  return x  # acts like identity
+
+def debug_fwd(x):
+  return x, x
+
+def debug_bwd(x, g):
+  pdb.set_trace()
+  return g
+
+debug.defvjp(debug_fwd, debug_bwd)
+```
+
+```{code-cell}
+def foo(x):
+  y = x ** 2
+  y = debug(y)  # insert pdb in corresponding backward pass step
+  return jnp.sin(y)
+```
+
+```python
+jax.grad(foo)(3.)
+
+> <ipython-input-113-b19a2dc1abf7>(12)debug_bwd()
+-> return g
+(Pdb) p x
+Array(9., dtype=float32)
+(Pdb) p g
+Array(-0.91113025, dtype=float32)
+(Pdb) q
+```
+
++++
+
+## More features and details
+
++++
+
+### Working with `list` / `tuple` / `dict` containers (and other pytrees)
+
+You should expect standard Python containers like lists, tuples, namedtuples, and dicts to just work, along with nested versions of those. In general, any [pytrees](https://docs.jax.dev/en/latest/pytrees.html) are permissible, so long as their structures are consistent according to the type constraints. 
+
+Here's a contrived example with `jax.custom_jvp`:
+
+```{code-cell}
+from collections import namedtuple
+Point = namedtuple("Point", ["x", "y"])
+
+@custom_jvp
+def f(pt):
+  x, y = pt.x, pt.y
+  return {'a': x ** 2,
+          'b': (jnp.sin(x), jnp.cos(y))}
+
+@f.defjvp
+def f_jvp(primals, tangents):
+  pt, = primals
+  pt_dot, =  tangents
+  ans = f(pt)
+  ans_dot = {'a': 2 * pt.x * pt_dot.x,
+             'b': (jnp.cos(pt.x) * pt_dot.x, -jnp.sin(pt.y) * pt_dot.y)}
+  return ans, ans_dot
+
+def fun(pt):
+  dct = f(pt)
+  return dct['a'] + dct['b'][0]
+```
+
+```{code-cell}
+pt = Point(1., 2.)
+
+print(f(pt))
+```
+
+```{code-cell}
+print(grad(fun)(pt))
+```
+
+And an analogous contrived example with `jax.custom_vjp`:
+
+```{code-cell}
+@custom_vjp
+def f(pt):
+  x, y = pt.x, pt.y
+  return {'a': x ** 2,
+          'b': (jnp.sin(x), jnp.cos(y))}
+
+def f_fwd(pt):
+  return f(pt), pt
+
+def f_bwd(pt, g):
+  a_bar, (b0_bar, b1_bar) = g['a'], g['b']
+  x_bar = 2 * pt.x * a_bar + jnp.cos(pt.x) * b0_bar
+  y_bar = -jnp.sin(pt.y) * b1_bar
+  return (Point(x_bar, y_bar),)
+
+f.defvjp(f_fwd, f_bwd)
+
+def fun(pt):
+  dct = f(pt)
+  return dct['a'] + dct['b'][0]
+```
+
+```{code-cell}
+pt = Point(1., 2.)
+
+print(f(pt))
+```
+
+```{code-cell}
+print(grad(fun)(pt))
+```
+
+### Handling non-differentiable arguments
+
++++
+
+Some use cases, like the final example problem, call for non-differentiable arguments like function-valued arguments to be passed to functions with custom differentiation rules, and for those arguments to also be passed to the rules themselves. In the case of `fixed_point`, the function argument `f` was such a non-differentiable argument. A similar situation arises with `jax.experimental.odeint`.
+
++++
+
+#### `jax.custom_jvp` with `nondiff_argnums`
+
+Use the optional `nondiff_argnums` parameter to `jax.custom_jvp` to indicate arguments like these. Here's an example with `jax.custom_jvp`:
+
+```{code-cell}
+from functools import partial
+
+@partial(custom_jvp, nondiff_argnums=(0,))
+def app(f, x):
+  return f(x)
+
+@app.defjvp
+def app_jvp(f, primals, tangents):
+  x, = primals
+  x_dot, = tangents
+  return f(x), 2. * x_dot
+```
+
+```{code-cell}
+print(app(lambda x: x ** 3, 3.))
+```
+
+```{code-cell}
+print(grad(app, 1)(lambda x: x ** 3, 3.))
+```
+
+Notice the gotcha here: no matter where in the argument list these parameters appear, they're placed at the *start* of the signature of the corresponding JVP rule. Here's another example:
+
+```{code-cell}
+@partial(custom_jvp, nondiff_argnums=(0, 2))
+def app2(f, x, g):
+  return f(g((x)))
+
+@app2.defjvp
+def app2_jvp(f, g, primals, tangents):
+  x, = primals
+  x_dot, = tangents
+  return f(g(x)), 3. * x_dot
+```
+
+```{code-cell}
+print(app2(lambda x: x ** 3, 3., lambda y: 5 * y))
+```
+
+```{code-cell}
+print(grad(app2, 1)(lambda x: x ** 3, 3., lambda y: 5 * y))
+```
+
+#### `jax.custom_vjp` with `nondiff_argnums`
+
++++
+
+A similar option exists for `jax.custom_vjp`, and, similarly, the convention is that the non-differentiable arguments are passed as the first arguments to the `_bwd` rule, no matter where they appear in the signature of the original function. The signature of the `_fwd` rule remains unchanged - it is the same as the signature of the primal function. Here's an example:
+
+```{code-cell}
+@partial(custom_vjp, nondiff_argnums=(0,))
+def app(f, x):
+  return f(x)
+
+def app_fwd(f, x):
+  return f(x), x
+
+def app_bwd(f, x, g):
+  return (5 * g,)
+
+app.defvjp(app_fwd, app_bwd)
+```
+
+```{code-cell}
+print(app(lambda x: x ** 2, 4.))
+```
+
+```{code-cell}
+print(grad(app, 1)(lambda x: x ** 2, 4.))
+```
+
+See `fixed_point` above for another usage example.
+
+**You don't need to use** `nondiff_argnums` **with array-valued arguments**, for example ones with integer dtype. Instead, `nondiff_argnums` should only be used for argument values that don't correspond to JAX types (essentially don't correspond to array types), like Python callables or strings. If JAX detects that an argument indicated by `nondiff_argnums` contains a JAX Tracer, then an error is raised. The `clip_gradient` function above is a good example of not using `nondiff_argnums` for integer-dtype array arguments.

--- a/docs/new_docs/301/hijax-types.md
+++ b/docs/new_docs/301/hijax-types.md
@@ -1,0 +1,1173 @@
+---
+jupytext:
+  formats: md:myst
+  notebook_metadata_filter: nosearch
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nosearch: true
+---
+
+(jax-301-hijax-types)=
+# Defining new JAX types with hijax
+
+<!--* freshness: { reviewed: '2026-07-10' } *-->
+
+JAX's built-in currency is the array: functions you transform take arrays in
+and produce arrays out, and every intermediate the tracing machinery sees has
+an array type like `f32[3,4]`. When you want to work with aggregate data, the
+usual tool is a
+pytree ({ref}`jax-101-pytrees`): you
+bundle arrays into containers, and JAX transparently flattens the bundle
+into its array leaves at every boundary.
+
+But sometimes transparency is exactly what you don't want. Some data is best
+modeled as a new *type*, with its own identity:
+
+* it should appear in jaxprs as a single value of a single type, not as a
+  spray of array leaves;
+* it has internal invariants, so users should only produce and consume it
+  through a fixed set of operations, rather than by freely constructing or
+  pattern-matching its components;
+* its *tangent type* may differ from its primal structure, so that
+  derivatives with respect to it aren't just "the same pytree, but for
+  tangents";
+* it may have its own notion of batching under `vmap`;
+* it can carry sharding information in the type, participating in JAX's
+  explicit sharding mode.
+
+Hijax types (or "hi types") provide this. You subclass `HiType` to define
+the type, register a Python class as carrying values of that type, and write
+hijax primitives whose input and output types mention the new type. This
+document walks through the whole story with one running example: a
+quantized array type.
+
+We'll assume some familiarity with hijax primitives; see
+{ref}`hijax-custom-derivatives` for an introduction to them. Like everything
+hijax, this is experimental: expect imports from `jax.experimental.hijax`,
+and expect the APIs to evolve.
+
+### TL;DR
+
+* Subclass `HiType` and implement `lo_ty`, `lower_val`, and `raise_val` to
+  say how the type and its values lower to ordinary ("lojax") arrays, then
+  call `register_hitype` to associate your value class with your type.
+* Write `VJPHiPrimitive` subclasses whose `in_avals`/`out_aval` mention the
+  new type; these are the only way values of the type get produced and
+  consumed.
+* For autodiff, implement `to_tangent_aval` on the type, and VJP/JVP rules
+  on the primitives.
+* For `vmap`, implement `dec_rank` and `inc_rank` on the type along with a
+  `MappingSpec` subclass of your own design, and `batch` rules on the
+  primitives. Mapped-over hi type arguments require an explicit `axis_size`
+  and spec-valued `in_axes`/`out_axes` entries.
+* For sharding in types (explicit mode), record sharding data on your type
+  (e.g. a `NamedSharding` field), consume it in `lo_ty`, and propagate it
+  in your primitives' typing rules.
+
+## Example: quantized arrays
+
+Say we want to work with arrays quantized to `int8`. A quantized array is
+really a pair of arrays: the `int8` values, and a floating point scale
+shared by each row (that is, we quantize along the last axis, one scale per
+row, as in common per-row/per-channel quantization schemes):
+
+```{code-cell}
+import os
+os.environ["XLA_FLAGS"] = '--xla_force_host_platform_device_count=8'
+# (8 CPU devices, for the sharding sections at the end)
+
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+
+@dataclass(frozen=True)
+class QArray:
+  qvalue: jax.Array   # int8[*leading, n]
+  scale: jax.Array    # f32[*leading]
+```
+
+We could register `QArray` as a pytree and be done. But consider what we'd
+give up:
+
+* **Invariants.** The two components are coupled: `scale` must have the
+  shape of `qvalue` minus its last axis, and `qvalue` is only meaningful
+  together with its `scale`. As a pytree, nothing stops code from crossing
+  the streams; under transformations, JAX itself sees only independent
+  leaves.
+* **Types in jaxprs.** As a pytree, a quantized array appears in traced
+  code as two unrelated array values. We'd rather see one value, of one
+  type, so jaxprs say what they mean.
+* **Tangents.** A quantized array's values live on a discrete grid, so it
+  makes no sense to perturb them along the grid. But a pytree's tangent
+  type is forced to be the pytree of its leaves' tangent types — and the
+  tangent type of an integer array like `qvalue` is a `float0` array,
+  which can only carry a trivial payload. So as a pytree, a quantized
+  array would admit no useful perturbations at all. What we want is to
+  choose a tangent type for the quantized array as a whole, such as the
+  *continuous* `f32` arrays that the quantized values approximate.
+
+So instead we'll make `QArray` a hijax type.
+
+## The type
+
+A hijax type is a subclass of `HiType`. The required core is small:
+
+* `lo_ty` says which lojax (array) types make up the type;
+* `lower_val` and `raise_val` convert values to and from that list of
+  arrays;
+* the type must be hashable and comparable for equality (a frozen dataclass
+  gives us both).
+
+This is like the pytree flatten/unflatten interface, but it lives at the
+level of *types*: given only the type, JAX can compute the lowered types,
+without needing a value in hand.
+
+We also give the type a `sharding` field, recording how values are
+partitioned across devices; it can be ignored until the sharding sections
+near the end of this document. We reuse JAX's `NamedSharding` to describe
+the partitioning of the `qvalue` component, and derive `scale`'s
+partitioning from it by dropping the last axis. Nothing about the field is
+special to JAX, which never interprets it: only our own methods consume
+it, chiefly `lo_ty`, which stamps the component types with their
+shardings. You're free to track sharding information on your type with an
+object of your own design instead, so long as you consume it the same
+way.
+
+```{code-cell}
+from jax.experimental.hijax import HiType, ShapedArray, register_hitype
+from jax.sharding import NamedSharding
+
+@dataclass(frozen=True)
+class QArrayTy(HiType):
+  shape: tuple[int, ...]
+  sharding: NamedSharding  # qvalue's sharding; scale's is derived from it
+
+  # lowering: which array types make up this type, and how values convert
+  def lo_ty(self):
+    scale_sharding = self.sharding.update(spec=jax.P(*self.sharding.spec[:-1]))
+    return [ShapedArray(self.shape, jnp.dtype('int8'),
+                        sharding=self.sharding),
+            ShapedArray(self.shape[:-1], jnp.dtype('float32'),
+                        sharding=scale_sharding)]
+  def lower_val(self, q):
+    return [q.qvalue, q.scale]
+  def raise_val(self, qvalue, scale):
+    return QArray(qvalue, scale)
+
+  # autodiff: tangents of quantized arrays are plain float arrays (see below)
+  def to_tangent_aval(self):
+    return ShapedArray(self.shape, jnp.dtype('float32'),
+                       sharding=self.sharding)
+
+  # printing, e.g. in jaxprs
+  def str_short(self, short_dtypes=False, mesh_axis_types=False):
+    dims = [str(d) if p is None else f'{d}@{p}'
+            for d, p in zip(self.shape, self.sharding.spec)]
+    return f'q8[{",".join(dims)}]'
+  __repr__ = str_short
+
+register_hitype(QArray, lambda q: QArrayTy(q.qvalue.shape,
+                                           jax.typeof(q.qvalue).sharding))
+```
+
+The `register_hitype` call associates the value class with the type: its
+second argument computes the type of any given value, analogous to how
+`jax.typeof` maps an array to its `ShapedArray` type. (Ours reads both the
+shape and the sharding off the `qvalue` component — every array carries a
+sharding, trivial when no mesh is in play.) Indeed after registration,
+`jax.typeof` works on `QArray`s, and JAX transformations accept them
+anywhere a value is expected.
+
+## The primitives
+
+With a pytree, users construct and take apart values freely. With a hijax
+type, values are produced and consumed only by hijax primitives whose
+declared types mention the new type. That's where invariants get enforced:
+if every primitive preserves them, they always hold.
+
+Our two primitives are `quantize` and `dequantize`, written with the
+`VJPHiPrimitive` API from {ref}`hijax-custom-derivatives`. Each declares
+its input and output types, gives its implementation in `expand`, and
+(looking ahead to autodiff) carries a straight-through-estimator VJP rule:
+
+```{code-cell}
+from jax.experimental.hijax import VJPHiPrimitive
+
+class Quantize(VJPHiPrimitive):
+  def __init__(self, x_aval):
+    if x_aval.dtype != jnp.dtype('float32'): raise TypeError(x_aval.dtype)
+    self.in_avals = (x_aval,)
+    self.out_aval = QArrayTy(x_aval.shape, x_aval.sharding)
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x):
+    scale = jnp.max(jnp.abs(x), axis=-1) / 127.
+    qvalue = jnp.round(x / scale[..., None]).astype(jnp.int8)
+    return QArray(qvalue, scale)
+
+  # straight-through estimator: differentiate as if it's the identity
+  def vjp_fwd(self, nzs_in, x):
+    return self(x), None
+
+  def vjp_bwd_retval(self, _res, g):
+    return (g,)
+
+class Dequantize(VJPHiPrimitive):
+  def __init__(self, q_aval):
+    self.in_avals = (q_aval,)
+    self.out_aval = ShapedArray(q_aval.shape, jnp.dtype('float32'),
+                                sharding=q_aval.sharding)
+    self.params = {}
+    super().__init__()
+
+  def expand(self, qx):
+    return qx.qvalue.astype('float32') * qx.scale[..., None]
+
+  def vjp_fwd(self, nzs_in, qx):
+    return self(qx), None
+
+  def vjp_bwd_retval(self, _res, g):
+    return (g,)
+
+def quantize(x):
+  return Quantize(jax.typeof(x))(x)
+
+def dequantize(qx):
+  return Dequantize(jax.typeof(qx))(qx)
+```
+
+Notice that `Quantize`'s `out_aval` and `Dequantize`'s `in_avals` are
+`QArrayTy`s: the new type appears in primitive type signatures just like
+array types do. Also notice `expand` freely constructs and inspects the
+`QArray` value class; primitive implementations are inside the abstraction
+boundary.
+
+Everything works eagerly:
+
+```{code-cell}
+x = jnp.array([[1., 2., 3.],
+               [4., -5., 6.]])
+
+qx = quantize(x)
+print(qx)
+print(jax.typeof(qx))
+print(dequantize(qx))
+```
+
+### Primitives outside, container inside
+
+The `expand` methods above construct `QArray` values and read their
+attributes directly. It's important that this kind of direct container
+manipulation happen *only* in `expand` (and in the type's own methods,
+like `lower_val` and `raise_val`). Everywhere else — in particular, in
+any function you might `jit`, differentiate, or `vmap` — hi values should
+be produced and consumed only by applying primitives.
+
+The reason is what traced code actually sees. Under a trace, a quantized
+array is not a `QArray` instance: it's a `Tracer` of type `q8[...]`. So
+reading an attribute in traced code fails —
+
+```{code-cell}
+try:
+  jax.jit(lambda qx: qx.qvalue)(qx)
+except AttributeError as e:
+  print('AttributeError:', e)
+```
+
+and, worse, calling the constructor on traced arrays doesn't fail right
+away. It smuggles `Tracer`s inside a container that JAX treats as one
+opaque concrete value, and the mistake surfaces later, as a confusing
+error far from its cause (here a missing constant handler; under `grad`
+it's a leaked-tracer error):
+
+```{code-cell}
+def bad_quantize(x):
+  scale = jnp.max(jnp.abs(x), axis=-1) / 127.
+  return QArray(jnp.round(x / scale[..., None]).astype('int8'), scale)
+
+try:
+  jax.jit(bad_quantize)(x)
+except TypeError as e:
+  print('TypeError:', e)
+```
+
+In `expand` it's a different story: by the time `expand` runs, JAX has
+committed to implementing the primitive in terms of the type's lojax
+components, and its `QArray` arguments are genuine `QArray` instances
+(holding lojax values — possibly traced ones). There, manipulating the
+value as a plain container is exactly right.
+
+(The top-level peeks at attributes like `qx.qvalue` elsewhere in this
+document are fine for the same reason eager `expand` is fine: they run
+eagerly, on concrete values. But inside any function that might get
+traced, stick to primitives.)
+
+### A more realistic op: dense × quantized matmul
+
+Conversion ops alone make for a thin API: in practice, a quantized array
+type earns its keep in ops that consume the type directly. The classic
+example is an inference-style matmul, where the activations `x` are an
+ordinary dense `f32` array and the weights are quantized:
+
+```{code-cell}
+class MatmulQ(VJPHiPrimitive):
+  def __init__(self, x_aval, q_aval):
+    if not (isinstance(q_aval, QArrayTy) and len(x_aval.shape) == 2 and
+            len(q_aval.shape) == 2 and x_aval.shape[1] == q_aval.shape[0]):
+      raise TypeError(f'bad matmul_q operand types: {x_aval} @ {q_aval}')
+    self.in_avals = (x_aval, q_aval)
+    x_spec, q_spec = x_aval.sharding.spec, q_aval.sharding.spec
+    if x_spec[1] is not None or q_spec[0] is not None:
+      raise TypeError('matmul_q requires unsharded contraction axes, got '
+                      f'{x_aval} @ {q_aval}')
+    out_sharding = x_aval.sharding.update(spec=jax.P(x_spec[0], q_spec[1]))
+    self.out_aval = ShapedArray((x_aval.shape[0], q_aval.shape[1]),
+                                jnp.dtype('float32'), sharding=out_sharding)
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x, qw):
+    # fold the per-row scales into the dense operand, then apply one matmul
+    # directly against the int8 payload
+    return (x * qw.scale) @ qw.qvalue.astype(jnp.float32)
+
+  def vjp_fwd(self, nzs_in, x, qw):
+    return self(x, qw), (x, qw)
+
+  def vjp_bwd_retval(self, res, g):
+    x, qw = res
+    w = dequantize(qw)   # rules are traced code: use primitives here
+    # cotangents live where the primals live, so use the primal operands'
+    # shardings to disambiguate the (possibly sharded) contractions
+    return (jnp.matmul(g, w.T, out_sharding=jax.typeof(x).sharding),
+            jnp.matmul(x.T, g, out_sharding=jax.typeof(w).sharding))
+
+def matmul_q(x, qw):
+  return MatmulQ(jax.typeof(x), jax.typeof(qw))(x, qw)
+```
+
+A few things to notice. The type signature mixes array types and hi types
+freely: `in_avals` is a `(ShapedArray, QArrayTy)` pair, checked at
+construction time so that a shape mismatch fails immediately, with both
+operand types pretty-printed. And `expand` exploits the representation:
+because the scales apply per-row along the contraction axis, they can be
+folded into the dense operand, so the heavy matmul runs directly against
+the `int8` payload rather than a dequantized copy. Owning the op as a
+single primitive lets us state that rewriting once, in one place.
+
+Also notice the discipline from the previous section in action: `expand`
+reads `qw.scale` and `qw.qvalue` as container attributes, while the VJP
+rules — which are ordinary traced code — go through the `dequantize`
+primitive instead.
+
+(The typing rule also computes an output *sharding* — output rows
+partitioned like `x`'s, output columns like `qw`'s, with the contracted
+axes required to be unsharded — and the backward rule passes
+`out_sharding` hints to its matmuls. Both are explained in the
+explicit-sharding section below; outside of explicit mode all these
+shardings are trivial and the extra code is inert.)
+
+```{code-cell}
+w = jnp.arange(12., dtype='float32').reshape(3, 4) / 12.
+qw = quantize(w)
+
+print(matmul_q(x, qw))
+print(x @ dequantize(qw))  # reference
+```
+
+## Hi types in jaxprs
+
+When we trace, the quantized array appears as a single value of type
+`q8[2,3]`, produced by one equation and consumed by another:
+
+```{code-cell}
+jax.jit(lambda x: dequantize(quantize(x))).trace(x).jaxpr
+```
+
+Compare to the pytree approach, where the same computation would show four
+array-typed intermediates with no indication that they pair up. The hi type
+only disappears at lowering time, when `expand` is traced and each
+`q8[...]`-typed value is expanded into the array components given by
+`lo_ty`.
+
+Ops with mixed operand kinds read just as directly — one equation with a
+`f32[2,3] @ q8[3,4] -> f32[2,4]` signature:
+
+```{code-cell}
+jax.jit(matmul_q).trace(x, qw).jaxpr
+#
+# `jit` works, with quantized arrays as arguments, results, and
+# intermediates:
+```
+
+```{code-cell}
+print(jax.jit(lambda x: dequantize(quantize(x)))(x))   # QArray internal
+
+qx2 = jax.jit(quantize)(x)                             # QArray result
+print(jax.typeof(qx2))
+
+print(jax.jit(dequantize)(qx2))                        # QArray argument
+```
+
+## Autodiff and tangent types
+
+Here's where hi types earn their keep. On the type, we implemented
+
+```python
+  def to_tangent_aval(self):
+    return ShapedArray(self.shape, jnp.dtype('float32'))
+```
+
+which says: the tangent type of a quantized array is a plain `f32` array.
+No pytree can express this: a pytree's tangent type is always the pytree
+of its leaves' tangent types, and for the `int8` leaf `qvalue` that means
+a trivial `float0` tangent.
+
+Together with the straight-through VJP rules on the primitives, gradients
+flow through quantization as if it were the identity:
+
+```{code-cell}
+def f(x):
+  return jnp.sum(dequantize(quantize(x)))
+```
+
+```{code-cell}
+print(jax.grad(f)(x))
+```
+
+And differentiating with respect to a quantized array input produces a
+plain float array, as the tangent type dictates:
+
+```{code-cell}
+def g(qx):
+  return jnp.sum(dequantize(qx) ** 2)
+
+print(jax.grad(g)(qx))
+print(jax.typeof(jax.grad(g)(qx)))
+```
+
+The same goes for ops with mixed operand kinds, like the quantized
+matmul: differentiating a loss with respect to both operands gives an
+`f32` gradient for the dense activations *and* an `f32` gradient for the
+quantized weights:
+
+```{code-cell}
+def loss(x, qw):
+  return jnp.sum(matmul_q(x, qw) ** 2)
+
+grad_x, grad_qw = jax.grad(loss, argnums=(0, 1))(x, qw)
+print(jax.typeof(grad_x), jax.typeof(grad_qw))
+```
+
+Notice that making the tangent type an `f32` array was a *choice*, and
+there's a real design space here. We could instead have made the tangent
+type of `QArrayTy` be `QArrayTy` itself, so that tangents and cotangents
+are quantized too — a different tradeoff, sensible for different
+applications. (For that choice, since the tangent type is then a hi type,
+we'd also implement `vspace_zero` and `vspace_add` on it so autodiff can
+instantiate and accumulate cotangents.) This flexibility is why hi types
+are a user extension point: for each piece of JAX — tracing, lowering,
+autodiff, and batching — you set up how your type participates, however
+your situation needs.
+
+## `vmap` and mapping specs
+
+What does it mean to map over a quantized array? For arrays, `vmap`'s
+`in_axes` and `out_axes` are axis indices, and JAX can infer the mapped
+axis size from the argument's shape. For a general hi type, JAX doesn't
+guess: *you* define a "mapping spec" type that says how values of your type
+are mapped, users pass instances of it as `in_axes`/`out_axes` entries, and
+they pass `axis_size` explicitly when it can't be inferred from an array
+argument.
+
+For our quantized arrays, thanks to the per-row scales, a batch of
+`QArray`s is just a bigger `QArray`: stacking `n` quantized arrays of type
+`q8[2,3]` along a new leading axis gives a `q8[n,2,3]`, with `qvalue` of
+shape `(n, 2, 3)` and `scale` of shape `(n, 2)`. So the only mapping notion
+we need is "the leading axis," and our spec type doesn't need to carry any
+data at all:
+
+```{code-cell}
+from jax.experimental.hijax import MappingSpec
+
+@dataclass(frozen=True)
+class QArraySpec(MappingSpec):
+  pass  # QArrays are only mapped along their leading axis
+```
+
+(Specs can be as rich as your type demands. A tuple-like hi type might use
+a spec carrying one axis per component; see the tuple example at the end
+of this document.)
+
+On the type, we implement `dec_rank` and `inc_rank`, the hi type analogues
+of "remove the mapped axis" and "add the mapped axis." They take the axis
+size and a spec, and return the element type and the batched type,
+respectively:
+
+```{code-cell}
+def qarray_dec_rank(self, size, spec):
+  assert isinstance(spec, QArraySpec) and self.shape[0] == size
+  return QArrayTy(self.shape[1:],
+                  self.sharding.update(spec=jax.P(*self.sharding.spec[1:])))
+
+def qarray_inc_rank(self, size, spec):
+  assert isinstance(spec, QArraySpec)
+  return QArrayTy((size, *self.shape),
+                  self.sharding.update(spec=jax.P(None, *self.sharding.spec)))
+
+QArrayTy.dec_rank = qarray_dec_rank
+QArrayTy.inc_rank = qarray_inc_rank
+```
+
+(We're attaching methods to the class as we go, notebook-style; in real
+code these would just be more methods in the `class QArrayTy` definition.)
+
+On the primitives, we implement `batch` rules. A `batch` rule receives the
+batched arguments along with their mapping specs (`None` for unbatched
+arguments, an integer axis for batched array arguments, and a spec instance
+for batched hi type arguments), and returns the batched result along with
+its mapping spec. Note that a rule should be prepared for any combination
+of batched and unbatched arguments:
+
+```{code-cell}
+def quantize_batch(self, axis_data, args, in_dims):
+  x, = args
+  d, = in_dims
+  if d is None:
+    return quantize(x), None
+  x = jnp.moveaxis(x, d, 0)
+  return quantize(x), QArraySpec()
+Quantize.batch = quantize_batch
+
+def dequantize_batch(self, axis_data, args, in_dims):
+  qx, = args
+  d, = in_dims
+  if d is None:
+    return dequantize(qx), None
+  assert isinstance(d, QArraySpec)
+  return dequantize(qx), 0
+Dequantize.batch = dequantize_batch
+```
+
+Because per-row quantization applies at any rank, both rules can just apply
+the unbatched operation to the stacked value — the hallmark of a type whose
+batches are values of the same type family.
+
+Now we can `vmap`. Mapping *to* a quantized array output, the axis size is
+inferred from the array argument as usual, and we pass a spec for
+`out_axes`:
+
+```{code-cell}
+xs = jnp.arange(24., dtype='float32').reshape(4, 2, 3)
+
+qxs = jax.vmap(quantize, out_axes=QArraySpec())(xs)
+print(jax.typeof(qxs))
+print(qxs.qvalue.shape, qxs.scale.shape)
+```
+
+Mapping *over* a quantized array input, we pass a spec for `in_axes` — and
+since there's no array argument to infer the axis size from, we must pass
+`axis_size` explicitly:
+
+```{code-cell}
+xs_roundtrip = jax.vmap(dequantize, in_axes=QArraySpec(), axis_size=4)(qxs)
+print(jax.typeof(xs_roundtrip))
+```
+
+All the usual compositions work — `vmap` of `jit`,
+
+```{code-cell}
+print(jax.typeof(jax.vmap(jax.jit(dequantize), in_axes=QArraySpec(),
+                          axis_size=4)(qxs)))
+```
+
+`vmap` of `grad`, and so on:
+
+```{code-cell}
+def norm_quantized(x):
+  return jnp.sum(dequantize(quantize(x)) ** 2)
+
+print(jax.vmap(jax.grad(norm_quantized))(xs).shape)
+```
+
+## `scan` and the leading axis
+
+`jax.lax.scan` can loop over a stacked hi value, consuming one slice per
+step — and it can carry and produce hi values too. Where `vmap` asks the
+*user* for a mapping spec, `scan` always walks the leading axis, so it
+instead asks the *type*: the one extra method to implement is
+`leading_axis_spec`, which returns the mapping spec describing your type's
+leading axis. The `dec_rank` and `inc_rank` methods from the `vmap`
+section do the rest of the work.
+
+```{code-cell}
+def qarray_leading_axis_spec(self):
+  return QArraySpec()
+
+QArrayTy.leading_axis_spec = qarray_leading_axis_spec
+```
+
+Scanning over the stack of quantized arrays from the previous section, the
+body sees one `q8[2,3]` per step. As with `vmap`'s `axis_size`, when all
+the scanned-over values are hi types there's no leading-axis size to
+infer, so we pass `length` explicitly (if any scanned-over value is an
+array, `scan` infers the length from it and `length` can be omitted):
+
+```{code-cell}
+def sum_dequantized(total, qx):
+  return total + jnp.sum(dequantize(qx)), ()
+
+total, () = jax.lax.scan(sum_dequantized, 0., qxs, length=4)
+print(total)
+```
+
+Hi values also work as stacked outputs and as the loop carry. Here the
+carry is a quantized array, re-quantized after each accumulation step, and
+the second output stacks one fresh `QArray` per step into a `q8[4,2,3]`:
+
+```{code-cell}
+def accum_quantized(qtotal, x):
+  return quantize(dequantize(qtotal) + x), quantize(2 * x)
+
+qzero = quantize(jnp.zeros((2, 3), 'float32'))
+qtotal, qys = jax.lax.scan(accum_quantized, qzero, xs)
+print(jax.typeof(qtotal))
+print(jax.typeof(qys))
+```
+
+## Sharding in types: explicit mode
+
+Finally, sharding. In JAX's explicit sharding mode (see [the parallelism
+guide](https://docs.jax.dev/en/latest/parallel.html)), shardings are part
+of array *types*: `jax.typeof` reports how a value is partitioned across
+the mesh, sharding propagation happens while tracing, and mismatches
+surface as type errors. The `sharding` field on `QArrayTy`, and the typing
+rules on our primitives that propagate it, are exactly what let hi types
+participate. What does it mean to partition a quantized array across
+devices? The components move together: if we shard the rows, each device
+holds its rows' quantized values *and* their scales. As usual there's a
+design choice to make, and we made it back in `lo_ty`: `qvalue` carries
+the type's sharding, and `scale` shards like it with the last axis
+dropped, so every row travels with its scale.
+
+Let's see it work. We make a mesh (this is where we use the 8 CPU devices
+requested in this document's first cell), shard some rows across it, and
+quantize — the shardings propagate through our typing rules into the
+result type, which `jax.typeof` displays with `@` markers:
+
+```{code-cell}
+mesh = jax.make_mesh((4,), ('i',))
+jax.set_mesh(mesh)
+
+rows = jax.device_put(jnp.arange(24., dtype='float32').reshape(8, 3),
+                      jax.P('i'))
+
+qrows = quantize(rows)
+print(jax.typeof(qrows))
+print(qrows.qvalue.sharding.spec, qrows.scale.sharding.spec)
+print(jax.typeof(dequantize(qrows)))
+```
+
+The same holds while tracing — hi types in jaxprs now display their
+shardings, computed by our `out_aval` rules:
+
+```{code-cell}
+jax.jit(lambda x: dequantize(quantize(x))).trace(rows).jaxpr
+```
+
+The quantized matmul propagates shardings too: its typing rule partitions
+output rows like `x`'s rows and output columns like `qw`'s columns
+(requiring the contracted axes to be unsharded, since neither operand can
+say how a sharded contraction should land):
+
+```{code-cell}
+w2 = jnp.arange(12., dtype='float32').reshape(3, 4) / 12.
+
+print(jax.typeof(matmul_q(rows, quantize(w2))))                # rows sharded
+
+qw2 = quantize(jax.device_put(w2, jax.P(None, 'i')))
+print(jax.typeof(qw2))                                         # cols sharded
+print(jax.typeof(matmul_q(jnp.ones((2, 3), 'float32'), qw2)))
+```
+
+And the contraction check fires as a type error, at trace time:
+
+```{code-cell}
+xk = jax.device_put(jnp.ones((2, 8), 'float32'), jax.P(None, 'i'))
+qk = quantize(jax.device_put(jnp.ones((8, 3), 'float32'), jax.P('i')))
+
+try:
+  matmul_q(xk, qk)
+except TypeError as e:
+  print('TypeError:', e)
+```
+
+Autodiff composes with all of this. Recall that `MatmulQ`'s backward rule
+passed `out_sharding` hints to its matmuls: that's because the cotangent
+for `qw` contracts over the row axis, which may be sharded (as it is
+here), and explicit mode refuses to guess how an all-sharded contraction
+should land. The right answer is the primal operand's sharding —
+cotangents live where their primals live:
+
+```{code-cell}
+def qloss(x, qw):
+  return jnp.sum(matmul_q(x, qw) ** 2)
+
+grad_rows, grad_qw2 = jax.grad(qloss, argnums=(0, 1))(rows, quantize(w2))
+print(jax.typeof(grad_rows), jax.typeof(grad_qw2))
+```
+
+One caution: JAX does not cross-check a hi primitive's declared output
+sharding against what its `expand` actually produces. The declared
+`out_aval` is what downstream code sees while tracing; `expand` determines
+what happens at runtime. Keeping them consistent is part of the typing
+rule's job.
+
+## `shard_map` and partition specs
+
+Explicit mode partitions values while keeping one global view of the
+program. Its complement is `shard_map`, which gives a per-device view. To
+cross that boundary, a quantized array needs one more piece: a partition
+spec type of our own, saying how `shard_map`'s `in_specs`/`out_specs`
+apply to it. We keep the same design as above: a quantized array is
+sharded along its leading axes only.
+
+For `shard_map`, we express this with an `HiPspec` subclass — the
+partition spec analogue of the `MappingSpec` above. Users pass instances
+of it as `in_specs`/`out_specs` entries, and its `to_lo` method says how
+it translates to one `jax.P` partition spec per lowered component (in
+`lo_ty` order):
+
+```{code-cell}
+from jax.experimental.hijax import HiPspec
+
+@dataclass(frozen=True)
+class QArrayP(HiPspec):
+  spec: jax.P  # partitioning of the leading axes; the last axis stays whole
+
+  def to_lo(self):
+    return (self.spec, self.spec)  # qvalue and scale shard together
+```
+
+(Since `scale` has one axis fewer than `qvalue`, handing both components
+the same partition spec says exactly that the leading axes shard together
+while the trailing axis of `qvalue` is untouched.)
+
+On the type, `shard` and `unshard` compute the per-device shard type from
+the global type and vice versa, delegating to the component types:
+
+```{code-cell}
+def qarray_shard(self, mesh, manual_axes, check_vma, spec):
+  qvalue_ty, _ = self.lo_ty()
+  qspec, _ = spec.to_lo()
+  shard_ty = qvalue_ty.shard(mesh, manual_axes, check_vma, qspec)
+  return QArrayTy(shard_ty.shape, shard_ty.sharding)
+
+def qarray_unshard(self, mesh, check_vma, spec):
+  qvalue_ty, _ = self.lo_ty()
+  qspec, _ = spec.to_lo()
+  full_ty = qvalue_ty.unshard(mesh, check_vma, qspec)
+  return QArrayTy(full_ty.shape, full_ty.sharding)
+
+QArrayTy.shard = qarray_shard
+QArrayTy.unshard = qarray_unshard
+```
+
+Now quantized arrays can cross `shard_map` boundaries in either
+direction, continuing with the mesh and `rows` from the previous section.
+Producing a sharded quantized array:
+
+```{code-cell}
+@jax.jit
+@jax.shard_map(in_specs=jax.P('i'), out_specs=QArrayP(jax.P('i')))
+def quantize_shards(x):
+  assert jax.typeof(x).shape == (2, 3)   # each device sees two rows
+  return quantize(x)
+
+qrows = quantize_shards(rows)
+print(jax.typeof(qrows))
+print(qrows.qvalue.sharding.spec, qrows.scale.sharding.spec)
+```
+
+And consuming one, where each device sees a per-shard `QArray` of its own
+rows:
+
+```{code-cell}
+@jax.jit
+@jax.shard_map(in_specs=QArrayP(jax.P('i')), out_specs=jax.P('i'))
+def dequantize_shards(qx):
+  assert jax.typeof(qx).shape == (2, 3)  # a per-device QArray shard
+  return dequantize(qx)
+
+print(jnp.max(jnp.abs(dequantize_shards(qrows) - rows)))
+```
+
+Because scales are per-row, quantizing shard-by-shard agrees exactly with
+quantizing globally — the same property that made batching pleasant:
+
+```{code-cell}
+qrows_global = quantize(rows)
+assert (qrows.qvalue == qrows_global.qvalue).all()
+assert (qrows.scale == qrows_global.scale).all()
+```
+
+(For autodiff *through* a `shard_map`, there's a bit more to implement:
+`to_tangent_spec` and `to_ct_spec` on the spec type, and `nospec` on the
+hi type, which is used to shard autodiff residuals.)
+
+## Additional examples
+
+The recipe is always the same — a value class, a `HiType` with the
+`lo_ty`/`lower_val`/`raise_val` lowering triple, and primitives whose type
+signatures mention the new type — so further examples can be read quickly.
+
+### Rank-1 arrays
+
+A rank-1 array represents an `m × n` matrix as an outer product of two
+vectors, `col : f32[m]` and `row : f32[n]`. The point of the
+representation is to never materialize the `m × n` product: ops consume
+the factors directly. (A general low-rank type, with `f32[m, r]` and
+`f32[r, n]` factors, is more of the same.)
+
+```{code-cell}
+@dataclass(frozen=True)
+class Rank1:
+  col: jax.Array   # f32[m]
+  row: jax.Array   # f32[n]
+
+@dataclass(frozen=True)
+class Rank1Ty(HiType):
+  shape: tuple[int, int]   # (m, n), the dense shape represented
+  sharding: NamedSharding  # sharding of the dense shape; the factors' derive
+
+  def lo_ty(self):
+    (m, n), spec = self.shape, self.sharding.spec
+    return [ShapedArray((m,), jnp.dtype('float32'),
+                        sharding=self.sharding.update(spec=jax.P(spec[0]))),
+            ShapedArray((n,), jnp.dtype('float32'),
+                        sharding=self.sharding.update(spec=jax.P(spec[1])))]
+  def lower_val(self, r1):
+    return [r1.col, r1.row]
+  def raise_val(self, col, row):
+    return Rank1(col, row)
+
+  # rank-1 matrices aren't closed under addition, so tangents are dense
+  def to_tangent_aval(self):
+    return ShapedArray(self.shape, jnp.dtype('float32'),
+                       sharding=self.sharding)
+
+  def str_short(self, short_dtypes=False, mesh_axis_types=False):
+    dims = [str(d) if p is None else f'{d}@{p}'
+            for d, p in zip(self.shape, self.sharding.spec)]
+    return f'r1[{",".join(dims)}]'
+  __repr__ = str_short
+
+def typeof_rank1(r1):
+  col_s, row_s = jax.typeof(r1.col).sharding, jax.typeof(r1.row).sharding
+  sharding = col_s.update(spec=jax.P(col_s.spec[0], row_s.spec[0]))
+  return Rank1Ty((r1.col.shape[0], r1.row.shape[0]), sharding)
+
+register_hitype(Rank1, typeof_rank1)
+```
+
+The type records the dense shape it represents and prints as e.g.
+`r1[6,5]`. Note the tangent-type choice, which differs from `QArrayTy`'s
+for a different reason: the sum of two rank-1 matrices is in general
+rank 2, so rank-1 matrices aren't closed under addition and can't serve
+as their own tangent space. Perturbations leave the manifold, and
+tangents and cotangents are dense. The sharding story is the same as
+before, with the field consumed in `lo_ty`: the dense row axis is carried
+by `col` and the dense column axis by `row`.
+
+Unlike `QArray`, whose values were only ever created inside `quantize`,
+here construction from factors is itself a primitive — and there's an
+accessor primitive too, so that *rules* (which are ordinary traced code)
+can get at the factors without touching container attributes:
+
+```{code-cell}
+class Outer(VJPHiPrimitive):
+  def __init__(self, col_aval, row_aval):
+    if not (len(col_aval.shape) == 1 and len(row_aval.shape) == 1):
+      raise TypeError(f'bad outer factor types: {col_aval}, {row_aval}')
+    sharding = col_aval.sharding.update(
+        spec=jax.P(col_aval.sharding.spec[0], row_aval.sharding.spec[0]))
+    self.in_avals = (col_aval, row_aval)
+    self.out_aval = Rank1Ty((col_aval.shape[0], row_aval.shape[0]), sharding)
+    self.params = {}
+    super().__init__()
+
+  def expand(self, col, row):
+    return Rank1(col, row)
+
+  def vjp_fwd(self, nzs_in, col, row):
+    return self(col, row), (col, row)
+
+  def vjp_bwd_retval(self, res, g):   # g is dense, f32[m, n]
+    col, row = res
+    return g @ row, col @ g
+
+class Factors(VJPHiPrimitive):
+  def __init__(self, r1_aval):
+    self.in_avals = (r1_aval,)
+    self.out_aval = tuple(r1_aval.lo_ty())  # the factor types are the lo types
+    self.params = {}
+    super().__init__()
+
+  def expand(self, r1):
+    return (r1.col, r1.row)
+
+class MatmulR1(VJPHiPrimitive):
+  def __init__(self, x_aval, r1_aval):
+    if not (isinstance(r1_aval, Rank1Ty) and len(x_aval.shape) == 2 and
+            x_aval.shape[1] == r1_aval.shape[0]):
+      raise TypeError(f'bad matmul_r1 operand types: {x_aval} @ {r1_aval}')
+    self.in_avals = (x_aval, r1_aval)
+    out_sharding = x_aval.sharding.update(
+        spec=jax.P(x_aval.sharding.spec[0], r1_aval.sharding.spec[1]))
+    self.out_aval = ShapedArray((x_aval.shape[0], r1_aval.shape[1]),
+                                jnp.dtype('float32'), sharding=out_sharding)
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x, r1):
+    return jnp.outer(x @ r1.col, r1.row)   # never materialize col ⊗ row
+
+  def vjp_fwd(self, nzs_in, x, r1):
+    col, row = factors(r1)  # rules are traced code: primitives, not attributes
+    return self(x, r1), (x, col, row)
+
+  def vjp_bwd_retval(self, res, g):
+    x, col, row = res
+    return jnp.outer(g @ row, col), x.T @ g
+
+def outer(col, row):
+  return Outer(jax.typeof(col), jax.typeof(row))(col, row)
+
+def factors(r1):
+  return Factors(jax.typeof(r1))(r1)
+
+def matmul_r1(x, r1):
+  return MatmulR1(jax.typeof(x), jax.typeof(r1))(x, r1)
+```
+
+(Note `Factors` declares its output type as a *tuple* of types —
+`in_avals` entries and `out_aval` can be pytrees of types — and that it
+carries no autodiff rules at all, since we only apply it in forward
+passes; rules are only needed for the transformations you actually use.
+Note also `MatmulR1`'s backward rule computes the dense operand's
+cotangent as an outer product, exploiting the representation the same way
+`expand` does.)
+
+```{code-cell}
+col = jnp.arange(6., dtype='float32') / 6.
+row = jnp.arange(5., dtype='float32') / 5.
+r1 = outer(col, row)
+print(jax.typeof(r1))
+
+acts = jnp.ones((3, 6), 'float32')
+print(jnp.max(jnp.abs(matmul_r1(acts, r1) - acts @ jnp.outer(col, row))))
+```
+
+Jaxprs, `jit`, and autodiff all work as before. The gradient with respect
+to a rank-1 operand is dense, as the tangent type dictates, while
+gradients chained through the constructor land back on the factors:
+
+```{code-cell}
+jax.jit(matmul_r1).trace(acts, r1).jaxpr
+```
+
+```{code-cell}
+def r1_loss(x, r1):
+  return jnp.sum(matmul_r1(x, r1) ** 2)
+
+print(jax.typeof(jax.grad(r1_loss, argnums=1)(acts, r1)))
+
+def factor_loss(col, row):
+  return jnp.sum(matmul_r1(acts, outer(col, row)) ** 2)
+
+g_col, g_row = jax.grad(factor_loss, argnums=(0, 1))(col, row)
+print(jax.typeof(g_col), jax.typeof(g_row))
+```
+
+And the typing rules propagate shardings, just like `QArrayTy`'s:
+
+```{code-cell}
+print(jax.typeof(outer(jax.device_put(jnp.zeros(8, 'float32'), jax.P('i')),
+                       row)))
+```
+
+We stopped here, but `vmap`, `scan`, and `shard_map` support would follow
+the same recipes as in the sections above: `dec_rank`/`inc_rank` and a
+mapping spec, `leading_axis_spec`, and `shard`/`unshard` with an `HiPspec`
+partition spec type.
+
+### Tuples
+
+Our last example is a generic container: a tuple whose elements are any
+JAX values. Where `QArrayTy` and `Rank1Ty` had a fixed component
+structure, `TupTy` is parameterized by its component *types* — and every
+method delegates to them:
+
+```{code-cell}
+import itertools
+
+@dataclass(frozen=True)
+class HiTup:
+  elts: tuple
+
+@dataclass(frozen=True)
+class TupTy(HiType):
+  tys: tuple  # component types: array types, or other hi types
+
+  # lowering delegates to the component types
+  def lo_ty(self):
+    return [lo for ty in self.tys for lo in ty.lo_ty()]
+  def lower_val(self, tup):
+    return [lo for ty, elt in zip(self.tys, tup.elts)
+            for lo in ty.lower_val(elt)]
+  def raise_val(self, *los):
+    los = iter(los)
+    return HiTup(tuple(ty.raise_val(*itertools.islice(los, len(ty.lo_ty())))
+                       for ty in self.tys))
+
+  # so does the tangent type
+  def to_tangent_aval(self):
+    return TupTy(tuple(ty.to_tangent_aval() for ty in self.tys))
+
+  def str_short(self, short_dtypes=False, mesh_axis_types=False):
+    return ('Tup{' +
+            ','.join(t.str_short(short_dtypes, mesh_axis_types)
+                     for t in self.tys) + '}')
+  __repr__ = str_short
+
+register_hitype(HiTup, lambda t: TupTy(tuple(map(jax.typeof, t.elts))))
+```
+
+Two things fall out of the delegation for free. First, elements can
+themselves be hi types — tuples of tuples, or a tuple holding a `QArray` —
+since `lo_ty` and friends just recurse. Second, there's no `sharding`
+field this time: the stored component types carry their own shardings, a
+third way of handling sharding-in-types alongside `QArrayTy`'s single
+field and `Rank1Ty`'s dense-shape spec.
+
+The constructor and accessor primitives are familiar from the rank-1
+example. One new ingredient: the element index is a *static parameter*,
+passed via `params` and available as `self.idx`. And since each element
+can be batched along its own axis (or not at all), the mapping spec
+carries one entry per component:
+
+```{code-cell}
+@dataclass(frozen=True)
+class TupSpec(MappingSpec):
+  val: tuple  # one axis entry per component
+
+def tup_dec_rank(self, size, spec):
+  return TupTy(tuple(ty.dec_rank(size, s)
+                     for ty, s in zip(self.tys, spec.val)))
+
+def tup_inc_rank(self, size, spec):
+  return TupTy(tuple(ty.inc_rank(size, s)
+                     for ty, s in zip(self.tys, spec.val)))
+
+TupTy.dec_rank = tup_dec_rank
+TupTy.inc_rank = tup_inc_rank
+
+class MakeTup(VJPHiPrimitive):
+  def __init__(self, elt_avals):
+    self.in_avals = tuple(elt_avals)
+    self.out_aval = TupTy(tuple(elt_avals))
+    self.params = {}
+    super().__init__()
+
+  def expand(self, *elts):
+    return HiTup(elts)
+
+  def batch(self, axis_data, args, in_dims):
+    return make_tup(*args), TupSpec(tuple(in_dims))
+
+class GetTupElt(VJPHiPrimitive):
+  def __init__(self, tup_aval, idx):
+    self.in_avals = (tup_aval,)
+    self.out_aval = tup_aval.tys[idx]
+    self.params = dict(idx=idx)
+    super().__init__()
+
+  def expand(self, tup):
+    return tup.elts[self.idx]
+
+  def batch(self, axis_data, args, in_dims):
+    tup, = args
+    spec, = in_dims
+    if spec is None:
+      return get_tuple_element(tup, self.idx), None
+    return get_tuple_element(tup, self.idx), spec.val[self.idx]
+
+def make_tup(*elts):
+  return MakeTup(map(jax.typeof, elts))(*elts)
+
+def get_tuple_element(tup, idx):
+  return GetTupElt(jax.typeof(tup), idx)(tup)
+```
+
+(Note `GetTupElt`'s batch rule handles unbatched inputs — hi primitive
+batch rules are invoked even when no argument is batched, so `in_dims`
+entries can be `None`.)
+
+Tuples work, they nest, and they hold other hi types:
+
+```{code-cell}
+tup = make_tup(jnp.arange(3.), 5.)
+print(jax.typeof(tup))
+print(get_tuple_element(tup, 1))
+
+nested = make_tup(make_tup(1., 2.), jnp.arange(2.))
+print(jax.typeof(nested))
+print(jax.jit(lambda t: get_tuple_element(get_tuple_element(t, 0), 1))(nested))
+
+print(jax.typeof(make_tup(qx, 3.)))  # a quantized array element
+```
+
+The per-component mapping spec is the payoff under `vmap`: each element
+gets its own `in_axes`/`out_axes` entry, visible in the types. Here the
+first element is mapped on the way in, and only the second on the way
+out:
+
+```{code-cell}
+def swap(t):
+  a, b = get_tuple_element(t, 0), get_tuple_element(t, 1)
+  return make_tup(b, a)
+
+out = jax.vmap(swap, in_axes=TupSpec((0, None)), out_axes=TupSpec((None, 0)),
+               axis_size=3)(tup)
+print(jax.typeof(tup), '->', jax.typeof(out))
+```
+
+And since the component types carry their own shardings, sharding-in-types
+needs nothing extra at all:
+
+```{code-cell}
+print(jax.typeof(make_tup(rows, jnp.float32(1.))))
+```
+
+For autodiff rules on these primitives, and `scan` and `shard_map`
+support (via a per-component `HiPspec`), see the `TupTy` example in
+`tests/hijax_test.py`.
+
+## What we haven't covered
+
+On the primitive side, there are also hooks for customizing
+rematerialization and dead code elimination.
+
+As ever with hijax, `tests/hijax_test.py` is a good source of worked
+examples, and {ref}`hijax-custom-derivatives` covers the primitive-side
+API — including JVP rules, symbolic zeros, and custom linearization — in
+more depth.

--- a/docs/new_docs/301/index.rst
+++ b/docs/new_docs/301/index.rst
@@ -1,0 +1,43 @@
+:orphan:
+:nosearch:
+
+JAX 301: advanced autodiff and extending JAX
+============================================
+
+The 101 docs introduced :func:`jax.grad`; the pages here go as deep as you
+like: the machinery underneath (JVPs, VJPs, Jacobians, Hessians), defining
+your own derivative rules and even your own types, autodiff with mutable
+state, and controlling the memory/compute tradeoff of differentiation.
+
+1. :doc:`cookbook` — the autodiff cookbook: Hessian-vector products,
+   Jacobians with ``jacfwd``/``jacrev``, the ``jvp``/``vjp`` machinery and
+   how it's composed, and differentiation with complex numbers.
+2. :doc:`sharding-ad` — how autodiff interacts with explicit sharding:
+   cotangent shardings as a function of primal shardings, and controlling
+   backward-pass communication with ``unreduced`` and ``reduced``.
+3. :doc:`custom-derivatives` — defining custom derivative rules with hijax
+   primitives, the recommended approach: one primitive can carry rules for
+   both modes, plus linearization, batching, and more.
+4. :doc:`custom-jvp-vjp` — the classic decorators, customizing one
+   differentiation mode at a time: still fully supported, and often the most
+   convenient tool for simple cases.
+5. :doc:`refs` — autodiff with mutable arrays: plumbing values out of
+   backward passes, in-place gradient accumulation with ``with_refs``, and
+   differentiating with respect to refs.
+6. :doc:`remat` — gradient checkpointing with ``jax.checkpoint``: what
+   autodiff saves versus recomputes, name-based policies, offloading, and
+   per-function control with ``custom_remat``.
+7. :doc:`hijax-types` — defining entirely new JAX types with hijax, with
+   their own derivatives, batching, and sharding behavior.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   cookbook
+   sharding-ad
+   custom-derivatives
+   custom-jvp-vjp
+   refs
+   remat
+   hijax-types

--- a/docs/new_docs/301/refs.md
+++ b/docs/new_docs/301/refs.md
@@ -1,0 +1,396 @@
+---
+jupytext:
+  formats: md:myst
+  notebook_metadata_filter: nosearch
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nosearch: true
+---
+
+(jax-301-refs)=
+# Autodiff with refs
+
+<!--* freshness: { reviewed: '2026-07-10' } *-->
+
+Refs — JAX's mutable arrays, introduced in {ref}`jax-101-refs` — interact
+with automatic differentiation in ways that go beyond what immutable values
+can express: plumbing data out of backward passes, accumulating gradients
+in place across many contributions, and differentiating with respect to
+mutable state itself. This page covers the interaction in detail, ending
+with a recipe that uses refs to relax `jax.lax.scan`'s fixed access pattern.
+
+```{code-cell}
+import jax
+import jax.numpy as jnp
+```
+
+## `Ref`s and automatic differentiation
+
+Autodiff can be applied to pure functions as before, even if they use array refs
+internally. For example:
+
+```{code-cell}
+@jax.jit
+def pure2(x):
+  ref = jax.new_ref(x)
+  ref[...] = ref[...] + ref[...]
+  return ref[...]
+
+print(jax.grad(pure2)(3.0))  # 2.0
+```
+
+Autodiff can also be applied to functions that take array refs as arguments.
+The simplest case is when those ref arguments are only used for plumbing, and
+aren't involved in differentiation. For example, `jax.grad` differentiates
+with respect to its function's first argument by default, so ref arguments in
+other positions are just along for the ride. Only non-differentiated values
+can be written into such plumbing refs:
+
+```{code-cell}
+# error
+def err6(x, some_plumbing_ref):
+  y = x + x
+  some_plumbing_ref[...] += y
+  return y
+
+# fine
+def foo(x, some_plumbing_ref):
+  y = x + x
+  some_plumbing_ref[...] += jax.lax.stop_gradient(y)
+  return y
+```
+
+Differentiating _with respect to_ a ref-typed argument is another matter:
+pointing `jax.grad` at one (e.g. via `argnums`) is an error, since the
+gradient for a ref must itself live in a ref. Instead, use `jax.vjp` and
+`with_refs`, described below.
+
+You can combine plumbing refs with {func}`~jax.custom_vjp` to plumb data out of the
+backward pass of a differentiated function:
+
+```{code-cell}
+# First, define the helper `stash_grads`:
+
+@jax.custom_vjp
+def stash_grads(grads_ref, x):
+  return x
+
+def stash_grads_fwd(grads_ref, x):
+  return x, grads_ref
+
+def stash_grads_bwd(grads_ref, g):
+  grads_ref[...] = g
+  return None, g
+
+stash_grads.defvjp(stash_grads_fwd, stash_grads_bwd)
+```
+
+```{code-cell}
+# Now, use `stash_grads` to stash intermediate gradients:
+
+def f(x, grads_ref):
+  x = stash_grads(grads_ref, x)
+  x = jnp.sin(x)
+  return x
+
+grads_ref = jax.new_ref(0.)
+jax.grad(f)(1., grads_ref)
+print(grads_ref)  # Ref(0.54), the gradient at the stash point: cos(1.)
+```
+
+Notice `stash_grads_fwd` is returning a `Ref` here. That's a special
+allowance for `custom_vjp` fwd rules: it's really syntax for indicating which
+ref arguments should be shared by both the fwd and bwd rules. So any refs
+returned by a fwd rule must be arguments to that fwd rule.
+
+## Differentiating with respect to `Ref` arguments
+
+The plumbing refs above are just passengers: they carry data out of the
+computation, but no gradients flow through them. We can also differentiate
+_with respect to_ a ref argument. Since the gradient for a `Ref`-typed input
+is itself `Ref`-typed, `jax.grad` doesn't apply here. Instead we use
+`jax.vjp`, and bind a gradient ref to the VJP function using its `with_refs`
+method:
+
+```{code-cell}
+def f(x_ref):
+  return x_ref[...] ** 2
+
+x_ref = jax.new_ref(2.)
+y, f_vjp = jax.vjp(f, x_ref)
+
+x_grad_ref = jax.new_ref(0.)
+f_vjp.with_refs(x_grad_ref)(1.0)  # bind the gradient ref, then apply the VJP
+print(x_grad_ref)  # Ref(4.)
+```
+
+Here `with_refs` takes one entry per argument of the differentiated function
+and returns a new VJP function with those gradient refs bound. When
+differentiating with respect to a ref argument, using `with_refs` is
+mandatory; the gradient needs a ref to be accumulated into, so calling the
+VJP function without binding one is an error:
+
+```{code-cell}
+_, f_vjp = jax.vjp(f, jax.new_ref(2.))
+try:
+  f_vjp(1.0)  # error! no ref bound for the ref-typed argument's gradient
+except Exception as e:
+  print(e)  # ... gradient must be accumulated into a ref ... `with_refs` ...
+```
+
+The gradient is accumulated into the bound ref via `+=`, added to whatever
+the ref already contains rather than overwriting it:
+
+```{code-cell}
+x_grad_ref = jax.new_ref(100.)
+_, f_vjp = jax.vjp(f, jax.new_ref(2.))
+f_vjp.with_refs(x_grad_ref)(1.0)
+print(x_grad_ref)  # Ref(104.), i.e. 100. + 4.: accumulated, not set
+```
+
+Accumulating rather than setting might seem like an odd choice, but it means
+one gradient ref can collect contributions from several backward passes with
+no extra memory traffic, as in the examples below.
+
+In-place updates to the ref argument inside the differentiated function are
+differentiated too. The result is the gradient with respect to the ref's
+initial value:
+
+```{code-cell}
+def g(x_ref):
+  x_ref[...] = jnp.sin(x_ref[...])
+  return x_ref[...] ** 2
+
+x_ref = jax.new_ref(2.)
+_, g_vjp = jax.vjp(g, x_ref)  # runs g, so x_ref is updated in-place here
+g_grad_ref = jax.new_ref(0.)
+g_vjp.with_refs(g_grad_ref)(1.0)
+print(g_grad_ref)  # Ref(-0.757), i.e. 2*sin(2)*cos(2)
+```
+
+## Gradient refs for value arguments
+
+When differentiating with respect to an ordinary `Array` argument,
+`with_refs` is optional: we can call the VJP function directly and get the
+gradient back as a value in the usual way, or we can bind a ref and have the
+gradient accumulated into it in-place:
+
+```{code-cell}
+_, sin_vjp = jax.vjp(jnp.sin, 1.0)
+x_bar, = sin_vjp(1.0)  # the usual way: gradient returned as a value
+print(x_bar)  # 0.54
+
+grad_ref = jax.new_ref(0.)
+_, sin_vjp = jax.vjp(jnp.sin, 1.0)
+sin_vjp.with_refs(grad_ref)(1.0)  # gradient accumulated into grad_ref
+print(grad_ref)  # Ref(0.54)
+```
+
+We can mix and match. Each entry of `with_refs` can be:
+
+* a `Ref`, meaning accumulate this argument's gradient into the ref in-place
+  (the VJP call then returns a `jax.ad.GradRef()` placeholder in that
+  position);
+* `jax.ad.GradValue()`, meaning return this argument's gradient as a value in
+  the usual way (the default); or
+* `jax.ad.DontWant()`, meaning don't compute this argument's gradient at all
+  (the VJP call returns a `jax.ad.DidntWant()` placeholder in that position —
+  more on this below).
+
+One reason to use a gradient ref here is to exploit sparsity. Consider
+differentiating a function that slices its input:
+
+```{code-cell}
+@jax.jit
+def take(x, i):
+  return x[i]
+
+x = jnp.arange(10.)
+
+_, take_vjp = jax.vjp(take, x, 3)
+x_bar, _ = take_vjp(1.0)
+print(x_bar)  # [0., 0., 0., 1., 0., 0., 0., 0., 0., 0.]
+```
+
+The gradient with respect to `x` is one-hot: the backward pass materializes a
+dense array of zeros and sets a single element of it. If we compute many such
+gradients and sum them, say over a loop of sparse accesses, we pay for a
+dense array's worth of memory traffic on each one, even though each
+contribution only touches one element.
+
+If we instead bind a gradient ref with `with_refs`, each backward pass
+performs a sparse in-place add-update, writing only where it needs to:
+
+```{code-cell}
+grad_ref = jax.new_ref(jnp.zeros(10))
+
+for i in [3, 5, 3]:
+  _, take_vjp = jax.vjp(take, x, i)
+  take_vjp.with_refs(grad_ref, jax.ad.GradValue())(1.0)  # no gradient ref for i
+
+print(grad_ref)  # Ref([0., 0., 0., 2., 0., 1., 0., 0., 0., 0.])
+```
+
+We can check that the update is sparse by inspecting the jaxpr of a single
+VJP application:
+
+```{code-cell}
+@jax.make_jaxpr
+def take_vjp_jaxpr():
+  _, take_vjp = jax.vjp(take, x, 3)
+  take_vjp.with_refs(grad_ref, jax.ad.GradValue())(1.0)
+
+print(take_vjp_jaxpr())
+```
+
+The backward pass boils down to `b[c:c+1] += j`, an in-place add-update of
+one element of the gradient ref, with no dense one-hot array in sight.
+
+## `DontWant`: skipping unneeded gradients
+
+The VJP function returned by `jax.vjp` computes gradients for all the
+arguments of the differentiated function. But sometimes we don't need all of
+them, like when differentiating with respect to parameters but not data.
+Passing `jax.ad.DontWant()` for an argument tells the backward pass not to
+compute its gradient at all, playing the same role for `jax.vjp` that
+`argnums` plays for `jax.grad`:
+
+```{code-cell}
+def predict(W, x):
+  return W @ x
+
+W = jnp.ones((4, 4))
+x = jnp.ones(4)
+
+_, f_vjp = jax.vjp(predict, W, x)
+W_bar, x_bar = f_vjp.with_refs(jax.ad.GradValue(), jax.ad.DontWant())(jnp.ones(4))
+print(W_bar[0])  # [1., 1., 1., 1.]
+print(x_bar)  # DidntWant()
+```
+
+This is more than a convenience: it can save real work in the backward pass,
+like an eager form of dead code elimination. Transpose rules can check for
+`DontWant` and skip computing the corresponding cotangents. For example, the
+transpose of matrix multiplication usually computes two dot products, one for
+each operand's gradient, but with `DontWant` it computes only one. We can see
+that by counting the `dot_general` operations in the jaxpr of each VJP
+application:
+
+```{code-cell}
+_, f_vjp = jax.vjp(predict, W, x)
+both = jax.make_jaxpr(lambda: f_vjp(jnp.ones(4)))()
+only_W = jax.make_jaxpr(
+    lambda: f_vjp.with_refs(jax.ad.GradValue(), jax.ad.DontWant())(jnp.ones(4)))()
+
+print(str(both).count('dot_general'))    # 2, one dot for each gradient
+print(str(only_W).count('dot_general'))  # 1, the dot for x_bar is skipped
+```
+
+## Example: gradient accumulation over microbatches
+
+Here's a more realistic recipe that puts these pieces together. In pipelined
+training, we often split a batch into microbatches, run a forward and
+backward pass one microbatch at a time, and accumulate weight gradients as we
+go. Using `with_refs`, each microbatch's backward pass accumulates directly
+into a single fixed gradient buffer:
+
+```{code-cell}
+NUM_LAYERS = 3
+NUM_MUBATCHES = 5
+MUBATCH_SIZE = 7
+
+def mubatch_loss(Ws, xs):
+  # inner loop over layers
+  act, _ = jax.lax.scan(lambda x, W: (jnp.dot(x, W), None), xs, Ws)
+  return jnp.mean(act)
+
+def process_batch(Ws, xs_batch):
+  grad_acc = jax.new_ref(jnp.zeros_like(Ws))
+
+  def process_mubatch(_, xs):
+    loss, f_vjp = jax.vjp(lambda Ws: mubatch_loss(Ws, xs), Ws)
+    f_vjp.with_refs(grad_acc)(jnp.ones_like(loss))  # accumulate in-place
+    return (), loss
+
+  xs_mubatches = xs_batch.reshape(NUM_MUBATCHES, MUBATCH_SIZE, -1)
+  # outer loop over microbatches
+  (), losses = jax.lax.scan(process_mubatch, (), xs_mubatches)
+  return jax.freeze(grad_acc), losses
+
+Ws = jnp.ones((NUM_LAYERS, 4, 4))
+xs_batch = jnp.ones((NUM_MUBATCHES * MUBATCH_SIZE, 4))
+grads, losses = process_batch(Ws, xs_batch)
+```
+
+Each iteration of the outer scan runs a forward and backward pass for one
+microbatch, and `with_refs(grad_acc)` makes the backward pass add that
+microbatch's gradient contribution directly into `grad_acc`. Note that the
+scan body closes over `grad_acc`, which is fine for `scan` (though it
+wouldn't be for `vmap` or `shard_map`, as discussed above). Once all the
+microbatches are processed, we `freeze` the accumulator to get the total
+batch gradient as an immutable `Array`.
+
+The result matches what we'd get by differentiating the summed loss directly:
+
+```{code-cell}
+xs_mubatches = xs_batch.reshape(NUM_MUBATCHES, MUBATCH_SIZE, -1)
+grads_expected = jax.grad(
+    lambda Ws: sum(mubatch_loss(Ws, xs) for xs in xs_mubatches))(Ws)
+print(jnp.allclose(grads, grads_expected, atol=1e-3, rtol=1e-3))  # True
+```
+
+But unlike that version, the ref-based version never materializes
+per-microbatch gradients as separate arrays: there's one gradient buffer,
+allocated once, no matter how many microbatches we process.
+
+## `foreach`, a new way to write `scan`
+
+As you may know, `jax.lax.scan` is a loop construct with a built-in fixed access
+pattern for scanned-over inputs and outputs. The access pattern is built in for
+autodiff reasons: if we were instead to slice into immutable inputs directly,
+reverse-mode autodiff would end up creating one-hot gradients and summing them
+up, which can be asymptotically inefficient. See [Sec 5.3.3 of the Dex
+paper](https://arxiv.org/pdf/2104.05372).
+
+But reading slices of `Ref`s doesn't have this efficiency problem: when we
+apply reverse-mode autodiff, we always generate in-place accumulation
+operations. As a result, we no longer need to be constrained by `scan`'s fixed
+access pattern. We can write more flexible loops, e.g. with non-sequential
+access.
+
+Moreover, having mutation available allows for some syntax tricks, like in this
+recipe for a `foreach` decorator:
+
+```{code-cell}
+import jax
+import jax.numpy as jnp
+from jax.lax import scan
+
+def foreach(*args):
+  def decorator(body):
+    return scan(lambda _, elts: (None, body(*elts)), None, args)[1]
+  return decorator
+```
+
+```{code-cell}
+r = jax.new_ref(0)
+xs = jnp.arange(10)
+
+@foreach(xs)
+def ys(x):
+  r[...] += x
+  return x * 2
+
+print(r)   # Ref(45, dtype=int32)
+print(ys)  # [ 0  2  4  6  8 10 12 14 16 18]
+```
+
+Here, the loop runs immediately, updating `r` in-place and binding `ys` to be
+the mapped result.

--- a/docs/new_docs/301/remat.md
+++ b/docs/new_docs/301/remat.md
@@ -1,0 +1,666 @@
+---
+jupytext:
+  formats: md:myst
+  notebook_metadata_filter: nosearch
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nosearch: true
+---
+
+(jax-301-remat)=
+# Gradient checkpointing with `jax.checkpoint` (`jax.remat`)
+
+<!--* freshness: { reviewed: '2026-07-10' } *-->
+
+When you differentiate a function in reverse mode, JAX's autodiff saves
+intermediate values from the forward pass — called *residuals* — to use in
+the backward pass. For big models, residual memory is often *the* memory
+problem. The {func}`jax.checkpoint` decorator (aliased as {func}`jax.remat`)
+gives you control over which intermediates are saved and which are
+*rematerialized* — recomputed on the backward pass — trading memory for
+FLOPs.
+
+This page describes JAX's new rematerialization implementation, enabled with
+the `jax_remat3` flag (on its way to becoming the default):
+
+```{code-cell}
+import jax
+
+jax.config.update('jax_remat3', True)
+
+import jax.numpy as jnp
+```
+
+## Seeing what's saved
+
+Consider a little three-layer network:
+
+```{code-cell}
+def g(W, x):
+  y = jnp.dot(W, x)
+  return jnp.sin(y)
+
+def f(W1, W2, W3, x):
+  x = g(W1, x)
+  x = g(W2, x)
+  x = g(W3, x)
+  return x
+
+W1 = jnp.ones((5, 4))
+W2 = jnp.ones((6, 5))
+W3 = jnp.ones((7, 6))
+x = jnp.ones(4)
+
+# Inspect the 'residual' values to be saved on the forward pass
+# if you were to evaluate `jax.grad(f)(W1, W2, W3, x)`
+from jax.ad_checkpoint import print_saved_residuals
+print_saved_residuals(f, W1, W2, W3, x)
+```
+
+By applying {func}`jax.checkpoint` to sub-functions, as a decorator or at
+specific application sites, you force JAX not to save any of that
+sub-function's residuals. Instead, only the inputs of a
+{func}`jax.checkpoint`-decorated function might be saved, and any residuals
+consumed on the backward pass are recomputed from those inputs as needed:
+
+```{code-cell}
+def f2(W1, W2, W3, x):
+  x = jax.checkpoint(g)(W1, x)
+  x = jax.checkpoint(g)(W2, x)
+  x = jax.checkpoint(g)(W3, x)
+  return x
+
+print_saved_residuals(f2, W1, W2, W3, x)
+```
+
+Here, the values of two `sin` applications are saved because they are
+arguments in subsequent applications of the
+{func}`jax.checkpoint`-decorated `g` function, and inputs to a
+{func}`jax.checkpoint`-decorated function may be saved. But no values of
+`cos` applications are saved.
+
+To control what's saved without editing the function to be differentiated,
+name the values you care about with
+{func}`jax.ad_checkpoint.checkpoint_name`, and select among the names with a
+rematerialization *policy*:
+
+```{code-cell}
+from jax.ad_checkpoint import checkpoint_name
+
+def f4(W1, W2, W3, x):
+  x = checkpoint_name(g(W1, x), name='a')
+  x = checkpoint_name(g(W2, x), name='b')
+  x = checkpoint_name(g(W3, x), name='c')
+  return x
+
+f4 = jax.checkpoint(f4, policy=jax.checkpoint_policies.save_only_these_names('a'))
+print_saved_residuals(f4, W1, W2, W3, x)
+```
+
+When playing around with these toy examples, you can get a closer look at
+what's going on using a custom `print_fwd_bwd` utility defined here:
+
+```{code-cell}
+from jax.tree_util import tree_flatten, tree_unflatten
+
+from rich.console import Console
+from rich.table import Table
+import rich.text
+
+def print_fwd_bwd(f, *args, **kwargs) -> None:
+  args, in_tree = tree_flatten((args, kwargs))
+
+  def f_(*args):
+    args, kwargs = tree_unflatten(in_tree, args)
+    return f(*args, **kwargs)
+
+  fwd = jax.jit(lambda *args: jax.vjp(f_, *args)).trace(*args).jaxpr.jaxpr
+
+  y, f_vjp = jax.vjp(f_, *args)
+  res, in_tree = tree_flatten(f_vjp)
+
+  def g_(*args):
+    *res, y = args
+    f_vjp = tree_unflatten(in_tree, res)
+    return f_vjp(y)
+
+  bwd = jax.jit(g_).trace(*res, y).jaxpr.jaxpr
+
+  table = Table(show_header=False, show_lines=True, padding=(1, 2, 0, 2), box=None)
+  table.add_row("[bold green]forward computation:",
+                "[bold green]backward computation:")
+  table.add_row(rich.text.Text.from_ansi(str(fwd)),
+                rich.text.Text.from_ansi(str(bwd)))
+  console = Console(width=240, force_jupyter=True)
+  console.print(table)
+
+def _renderable_repr(self):
+  return self.html
+rich.jupyter.JupyterRenderable._repr_html_ = _renderable_repr
+```
+
+```{code-cell}
+# Without using `jax.checkpoint`:
+print_fwd_bwd(f, W1, W2, W3, x)
+```
+
+```{code-cell}
+# Using `jax.checkpoint` with a save-only-these-names policy:
+print_fwd_bwd(f4, W1, W2, W3, x)
+```
+
+## Let's think step by step
+
+### `jax.checkpoint` fundamentals
+
+In both {func}`jax.linearize` and {func}`jax.vjp`, there is flexibility in
+how and when some values are computed. Different choices can trade off memory
+use against FLOPs. JAX provides control over these choices with
+{func}`jax.checkpoint`.
+
+One such choice is whether to perform Jacobian coefficient computations on
+the forward pass, as soon as the inputs are available, or on the backward
+pass, just before the coefficients are needed. Consider the example of
+`sin_vjp`:
+
+```{code-cell}
+def sin_vjp(x):
+  y = jnp.sin(x)
+  cos_x = jnp.cos(x)
+  return y, lambda y_bar: cos_x * y_bar
+```
+
+Another valid implementation would compute the value of `jnp.cos(x)` on the
+backward pass rather than on the forward pass:
+
+```{code-cell}
+def sin_vjp2(x):
+  y = jnp.sin(x)
+  return y, lambda y_bar: jnp.cos(x) * y_bar
+```
+
+For this particular function, the amount of memory used by the two versions
+is the same, though we've reduced the FLOPs for the primal computation (the
+forward pass) and increased the FLOPs for the cotangent computation (the
+backward pass).
+
+There's another choice when it comes to function composition. Recall the VJP
+rule for a composition of two functions:
+
+```{code-cell}
+def f(x):
+  y = g(x)
+  z = h(y)
+  return z
+
+def f_vjp(x):
+  y, g_vjp = jax.vjp(g, x)
+  z, h_vjp = jax.vjp(h, y)
+  def f_bwd(z_bar):
+    y_bar, = h_vjp(z_bar)
+    x_bar, = g_vjp(y_bar)
+    return x_bar
+  return z, f_bwd
+```
+
+An alternative is:
+
+```{code-cell}
+def f_vjp_checkpoint(x):
+  y = g(x)
+  z, h_vjp = jax.vjp(h, y)
+  def f_bwd2(z_bar):
+    y_bar, = h_vjp(z_bar)
+    _, g_vjp = jax.vjp(g, x)
+    x_bar, = g_vjp(y_bar)
+    return x_bar
+  return z, f_bwd2
+```
+
+Using words, this alternative implementation doesn't compute `g_vjp`, or the
+residual values in its closure, on the forward pass. Instead, it only
+computes them in the backward pass `f_bwd2`. That means `f_vjp_checkpoint`
+requires less memory: if `g` and `h` each required similar amounts of memory
+for their residuals, each much larger than `x`, then the function produced by
+`f_vjp_checkpoint(x)` requires half the memory as that of `f_vjp(x)`!
+
+The cost you pay is redundant work: in `f_bwd2` you must re-evaluate `g(x)`
+as part of `jax.vjp(g, x)` just to discard its value (in the underscore
+variable on the line `_, g_vjp = jax.vjp(g, x)`).
+
+You can get this VJP behavior in autodiff — without having to write VJP
+functions directly — by instead using {func}`jax.checkpoint` in an
+alternative definition of the original function `f`:
+
+```{code-cell}
+def f_checkpoint(x):
+  y = jax.checkpoint(g)(x)
+  z = h(y)
+  return z
+```
+
+In other words, you apply {func}`jax.checkpoint` to `g` — the first stage of
+`f` — rather than to `f` itself. This way, when you evaluate
+`jax.grad(f_checkpoint)(x)`, you'd get a computation like:
+
+1. Run the forward pass of `g`, discarding residual values.
+2. Run the forward pass of `h`, saving residuals.
+3. Run the backward pass of `h`, consuming residuals from step 2.
+4. Re-run the forward pass of `g`, saving residuals.
+5. Run the backward pass of `g`, consuming residuals from step 4.
+
+That is, by evaluating `jax.grad(f_checkpoint)(x)` we'd get the same
+computation as:
+
+```{code-cell}
+def f_checkpoint_grad(x):
+  y = g(x)                  # step 1
+  _, h_vjp = jax.vjp(h)(y)  # step 2
+  y_bar, = h_vjp(1.0)       # step 3
+  _, g_vjp = jax.vjp(g, x)  # step 4
+  x_bar, = g_vjp(y_bar)     # step 5
+  return x_bar
+```
+
+In general, `jax.checkpoint(foo)` is a new function which has the same
+input-output behavior as `foo`, but behaves differently under autodiff,
+particularly under {func}`jax.linearize` and {func}`jax.vjp` (and their
+wrappers, like {func}`jax.grad`) but not {func}`jax.jvp`. When
+differentiated, only the input to a {func}`jax.checkpoint`-differentiated
+function is stored on the forward pass. On the backward pass, the residuals
+(intermediates from `foo` and its Jacobian coefficient values needed for the
+backward pass) are recomputed.
+
+Notice that if `f = lambda x: h(g(x))` is the function you want to
+differentiate (in other words, if you want to apply `jax.grad(f)`) you don't
+get any memory savings by applying {func}`jax.checkpoint` to `f` itself.
+That's because evaluating `jax.grad(jax.checkpoint(f))(x)` would lead to a
+computation such as:
+
+1. Run the forward pass, discarding all residuals.
+2. Immediately re-run the forward pass, saving residuals.
+3. Run the backward pass, consuming residuals from step 2.
+
+That is, in code, something like:
+
+```{code-cell}
+def f_grad_bad(x):
+  _ = f(x)                  # step 1
+  _, f_vjp = jax.vjp(f, x)  # step 2
+  x_bar, = f_vjp(1.0)       # step 3
+  return x_bar
+```
+
+You also wouldn't get any memory savings by applying {func}`jax.checkpoint`
+to `h`, the second stage of `f`. That's because evaluating
+`jax.grad(lambda x: jax.checkpoint(h)(g(x)))` would lead to a computation
+such as:
+
+1. Run the forward pass of `g`, saving residuals.
+2. Run the forward pass of `h`, discarding residuals.
+3. Immediately re-run the forward pass of `h`, saving residuals.
+4. Run the backward pass of `h`, consuming residuals from step 3.
+5. Run the backward pass of `g`, consuming residuals from step 1.
+
+In code, something like:
+
+```{code-cell}
+def f_grad_bad2(x):
+  y, g_vjp = jax.vjp(g, x)  # step 1
+  z = h(y)                  # step 2
+  _, h_vjp = jax.vjp(h, y)  # step 3
+  y_bar, = h_vjp(1.0)       # step 4
+  x_bar, = g_vjp(y_bar)     # step 5
+  return x_bar
+```
+
+Slightly more generally, if you had a chain composition of functions, such as
+`f = lambda x: f3(f2(f1(x)))`, and were interested in evaluating
+`jax.grad(f)`, you could say that you:
+
+* Shouldn't apply {func}`jax.checkpoint` to the whole function `f`, since
+  that wouldn't save any memory (and will perform wasteful recomputation).
+* Shouldn't apply {func}`jax.checkpoint` to the last sub-function `f3`, since
+  that wouldn't save any memory (and will perform wasteful recomputation).
+* Could apply {func}`jax.checkpoint` to `f1`, `f2`, or their composition
+  `lambda x: f2(f1(x))`, since any of those might save memory and would
+  express different memory/recompute tradeoffs.
+
+### Policies: naming what's saveable
+
+As shown so far, using {func}`jax.checkpoint` switches from one extreme to
+another:
+
+* Without {func}`jax.checkpoint`, JAX's autodiff tends to compute everything
+  possible on the forward pass and store it for the backward pass.
+* With a {func}`jax.checkpoint` decorator, you instead compute as little as
+  possible on the forward pass and recompute values as needed on the
+  backward pass.
+
+To operate between these two extremes, saving some things and not others,
+you use the `policy` argument to {func}`jax.checkpoint`. A policy is *data*,
+not code: it names which values are allowed to be saved as residuals, and
+everything else is recomputed. The workflow has two halves:
+
+1. **Name values** in the function being differentiated with
+   {func}`jax.ad_checkpoint.checkpoint_name`. By itself, `checkpoint_name`
+   is just an identity function — it only attaches a label.
+2. **Select names** in the policy, with one of the constructors on
+   {obj}`jax.checkpoint_policies`:
+
+   * `save_only_these_names(*names)` — values with these names are saveable;
+     everything else is recomputed;
+   * `save_any_names_but_these(*names)` — every *named* value is saveable
+     except these;
+   * `save_and_offload_only_these_names(...)` — like `save_only_these_names`,
+     but some names are offloaded to another memory space instead of kept
+     (more below);
+   * `everything_saveable` and `nothing_saveable` — the two extremes, as
+     escape hatches (the former is the default behavior as if no policy were
+     given; the latter is like no policy but full rematerialization).
+
+For example, consider this function to be differentiated, with named layer
+outputs:
+
+```{code-cell}
+def loss(params, x, y):
+  return jnp.sum((predict(params, x) - y)**2)
+
+def predict(params, x):
+  *Ws, Wlast = params
+  for i, W in enumerate(Ws):
+    x = layer(W, x)
+    x = checkpoint_name(x, name=f'layer{i}_output')
+  x = jnp.dot(Wlast, x)
+  return x
+
+def layer(W, x):
+  return jnp.sin(jnp.dot(W, x))
+
+W1 = W2 = W3 = jnp.ones((4, 4))
+params = [W1, W2, W3]
+x = jnp.ones(4)
+y = jnp.ones(4)
+```
+
+```{code-cell}
+print_saved_residuals(loss, params, x, y)
+```
+
+```{code-cell}
+loss_checkpoint = jax.checkpoint(
+    loss, policy=jax.checkpoint_policies.save_any_names_but_these('layer1_output'))
+print_saved_residuals(loss_checkpoint, params, x, y)
+```
+
+Notice that by providing a policy, you didn't need to change how `loss`,
+`predict`, or `layer` are *called*: you can experiment with policies in
+calling code (such as a training script) while the names live with the model
+code. And policies only indicate what is *saveable*: a value is saved only if
+it's actually needed by the backward pass.
+
+```{note}
+In older versions of JAX, a policy could also be an arbitrary *callable*
+that inspected each primitive application and returned whether its outputs
+were saveable (e.g. `jax.checkpoint_policies.dots_with_no_batch_dims_saveable`).
+Under the new implementation, policies are defunctionalized — they're the
+name-based data described above — which keeps them simple, serializable, and
+predictable. For cases where a function's remat behavior should depend on
+more than a name, the function author can use `custom_remat`, described
+below.
+```
+
+### Offloading instead of recomputing
+
+Recomputation isn't the only alternative to keeping a residual in
+accelerator memory: a residual can also be *offloaded* to another memory
+space (typically host memory) on the forward pass and brought back when the
+backward pass needs it, trading transfer bandwidth instead of FLOPs.
+
+The policy `jax.checkpoint_policies.save_and_offload_only_these_names` takes
+four arguments: `names_which_can_be_saved` (kept on device),
+`names_which_can_be_offloaded` (moved to the destination memory space), and
+the offloading source and destination. Values with other names, and unnamed
+values, are recomputed.
+
+```{code-cell}
+from functools import partial
+
+policy = jax.checkpoint_policies.save_and_offload_only_these_names(
+    names_which_can_be_saved=['y'], names_which_can_be_offloaded=['z'],
+    offload_src='device', offload_dst='pinned_host')
+
+@partial(jax.checkpoint, policy=policy)
+def f_offload(x):
+  y = checkpoint_name(jnp.sin(x), 'y')   # saved on device
+  z = checkpoint_name(jnp.sin(y), 'z')   # offloaded to pinned host memory
+  w = checkpoint_name(jnp.sin(z), 'w')   # recomputed on the backward pass
+  return jnp.sum(w)
+
+print(jax.grad(f_offload)(jnp.arange(4.)))
+print_saved_residuals(f_offload, jnp.arange(4.))
+```
+
+The `f32<host>[4]` residual is the offloaded value: it's kept, but in host
+memory rather than device memory.
+
+## Custom remat behavior with `custom_remat`
+
+Name-based policies choose among values a function has named. Sometimes a
+function *author* knows something better: a specific quantity that's worth
+saving because it makes the backward pass cheap, or a way to restructure the
+recomputation entirely. `custom_remat` lets a function carry its own
+rematerialization behavior, including behavior that depends on the ambient
+policy.
+
+{func}`jax.custom_remat` — called as `custom_remat(f, f_fwd, f_rem, f_bwd)` — takes four functions:
+
+* `f` is the primal function, used everywhere outside of rematerialized
+  differentiation;
+* `f_fwd(policy, *args) -> (out, res)` runs on the forward pass *inside a
+  rematerialized region*: it receives the ambient checkpoint policy, and
+  decides what residuals (if any) to keep;
+* `f_rem(res, *args) -> (out, res2)` runs on the backward pass to
+  rematerialize: given whatever `f_fwd` kept, plus the original arguments,
+  it (re)computes the output and the residuals the backward rule needs;
+* `f_bwd(res2, g) -> arg_cotangents` is the backward rule.
+
+For example: the derivative of `sin` is `cos`, so a memory/FLOPs sweet spot
+for `sin` under rematerialization can be to save the cosine — a value the
+standard rules would recompute. Here's a `sin` that always saves its cosine
+when rematerialized:
+
+```{code-cell}
+sin = jax.custom_remat(jnp.sin,
+                   lambda _, x: (jnp.sin(x), jnp.cos(x)),   # keep cos(x)
+                   lambda cos_x, x: (jnp.sin(x), cos_x),    # rematerialize
+                   lambda cos_x, g: (cos_x * g,))           # backward rule
+
+f = jax.remat(lambda x: sin(sin(x)))
+print(jax.grad(f)(1.0))
+print(jax.grad(jnp.sin)(jnp.sin(1.0)) * jnp.cos(1.0))  # chain rule, for reference
+```
+
+Because `f_fwd` receives the policy, the behavior can also *respond* to it.
+Here's a `sin` that saves its cosine only when the ambient policy declares
+the name `'cos'` saveable, and otherwise defers to full recomputation:
+
+```{code-cell}
+SaveOnlyTheseNames = jax.checkpoint_policies.SaveOnlyTheseNames
+
+def sin_fwd(policy, x):
+  if isinstance(policy, SaveOnlyTheseNames) and 'cos' in policy.saveable_names:
+    return jnp.sin(x), jnp.cos(x)
+  else:
+    return jnp.sin(x), None
+
+def sin_rem(cos_x, x):
+  if cos_x is None:
+    cos_x = jnp.cos(x)
+  return jnp.sin(x), cos_x
+
+def sin_bwd(cos_x, g):
+  return cos_x * g,
+
+sin = jax.custom_remat(jnp.sin, sin_fwd, sin_rem, sin_bwd)
+
+save_cos = jax.checkpoint_policies.save_only_these_names('cos')
+f = jax.checkpoint(lambda x: sin(sin(x)), policy=save_cos)
+print(jax.grad(f)(3.0))
+
+f = jax.checkpoint(lambda x: sin(sin(x)),
+                   policy=jax.checkpoint_policies.nothing_saveable)
+print(jax.grad(f)(3.0))
+```
+
+`custom_remat` currently supports reverse-mode differentiation of the
+rematerialized function (which is where rematerialization matters).
+
+## Advanced: recursive `jax.checkpoint`
+
+By applying {func}`jax.checkpoint` in the right way, there are many tradeoffs
+between memory usage and (re)computation that can be expressed. One
+surprising example is _recursive_ checkpointing, where you apply
+{func}`jax.checkpoint` to a function which itself calls
+{func}`jax.checkpoint`-decorated functions in a way so that memory usage from
+the chain composition of $D$ functions scales like $\mathcal{O}(\log_2 D)$
+rather than $\mathcal{O}(D)$.
+
+As a toy example, consider the chain composition of multiple
+{func}`jax.numpy.sin` functions:
+
+```{code-cell}
+def chain_compose(funs):
+  def f(x):
+    for fun in funs:
+      x = fun(x)
+    return x
+  return f
+
+f = chain_compose([jnp.sin] * 8)
+print_saved_residuals(f, 3.)
+```
+
+In general, the number of stored residuals scales linearly with the length of
+the chain:
+
+```{code-cell}
+f = chain_compose([jnp.sin] * 16)
+print_saved_residuals(f, 3.)
+```
+
+But you can apply {func}`jax.checkpoint` recursively to improve the scaling:
+
+```{code-cell}
+def recursive_checkpoint(funs):
+  if len(funs) == 1:
+    return funs[0]
+  elif len(funs) == 2:
+    f1, f2 = funs
+    return lambda x: f1(f2(x))
+  else:
+    f1 = recursive_checkpoint(funs[:len(funs)//2])
+    f2 = recursive_checkpoint(funs[len(funs)//2:])
+    return lambda x: f1(jax.checkpoint(f2)(x))
+```
+
+```{code-cell}
+f = recursive_checkpoint([jnp.sin] * 8)
+print_saved_residuals(f, 3.)
+```
+
+```{code-cell}
+f = recursive_checkpoint([jnp.sin] * 16)
+print_saved_residuals(f, 3.)
+```
+
+The cost here, as usual, is recomputation: in particular, you end up
+performing $\mathcal{O}(\log_2 D)$ times as many FLOPs:
+
+```{code-cell}
+f = chain_compose([jnp.sin] * 8)
+print_fwd_bwd(f, 3.)
+```
+
+```{code-cell}
+f = recursive_checkpoint([jnp.sin] * 8)
+print_fwd_bwd(f, 3.)
+```
+
+## Practical notes
+
+When differentiated functions are staged out to XLA for compilation — for
+example by applying {func}`jax.jit` to a function which contains a
+{func}`jax.grad` call — XLA will automatically optimize the computation,
+including decisions about when to compute or rematerialize values. As a
+result, **{func}`jax.checkpoint` often isn't needed for differentiated
+functions under a {func}`jax.jit`**. XLA will optimize things for you.
+
+One exception is when using staged-out control flow, like
+{func}`jax.lax.scan`. Automatic compiler optimizations across multiple
+control flow primitives (for example, across a forward-pass `scan` and the
+corresponding backward-pass `scan`), typically aren't as thorough. As a
+result, it's often a good idea to use {func}`jax.checkpoint` on the body
+function passed to {func}`jax.lax.scan`.
+
+For example, one common pattern in large
+[Transformer models](https://en.wikipedia.org/wiki/Transformer_(machine_learning_model))
+is to express the architecture as a {func}`jax.lax.scan` over layers so as to
+reduce compilation times. That is, using a simple fully-connected network as
+an analogy, instead of writing something like this:
+
+```{code-cell}
+LayerParam = tuple[jnp.ndarray, jnp.ndarray]  # Weights-bias pair for a layer.
+ParamsList = list[LayerParam]
+
+def net(params: ParamsList, x: jnp.ndarray):
+  for W, b in params:
+    x = jnp.maximum(jnp.dot(x, W) + b, 0.)
+  return x
+```
+
+Instead, iterate over the layer application with {func}`jax.lax.scan`:
+
+```{code-cell}
+params = [(jnp.array([[0.5, 0.5], [1., 1.]]), jnp.array([0.5, 0.5])),
+          (jnp.array([[0.5, 0.5], [1., 1.]]), jnp.array([0.5, 0.5]))]
+
+all_weights = jnp.stack([W for W, _ in params])
+all_biases = jnp.stack([b for _, b in params])
+
+def layer(x, W_b_pair):
+  W, b = W_b_pair
+  out = jnp.maximum(jnp.dot(x, W) + b, 0.)
+  return out, None
+
+def net(all_weights, all_biases, x):
+  x, _ = jax.lax.scan(layer, x, (all_weights, all_biases))
+  return x
+```
+
+This scan-over-layers version reduces compile times, but by foiling some
+compiler optimizations it can lead to inefficient computation of gradients.
+To mitigate the issue, you can use {func}`jax.checkpoint` on the scanned
+function — either plain, or with a names-based policy to keep the residuals
+you know are worth their memory:
+
+```{code-cell}
+@partial(jax.checkpoint,
+         policy=jax.checkpoint_policies.save_only_these_names('preactivation'))
+def layer(x, W_b_pair):
+  W, b = W_b_pair
+  pre = checkpoint_name(jnp.dot(x, W) + b, 'preactivation')
+  out = jnp.maximum(pre, 0.)
+  return out, None
+```
+
+By using {func}`jax.checkpoint` this way, you're manually controlling which
+values JAX's autodiff saves between the forward and backward passes, and
+therefore not relying on XLA optimizations to choose for you.

--- a/docs/new_docs/301/sharding-ad.md
+++ b/docs/new_docs/301/sharding-ad.md
@@ -1,0 +1,446 @@
+---
+jupytext:
+  formats: md:myst
+  notebook_metadata_filter: nosearch
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nosearch: true
+---
+
+(jax-301-sharding-ad)=
+# Autodiff and explicit sharding
+
+<!--* freshness: { reviewed: '2026-07-10' } *-->
+
+In explicit sharding mode ({ref}`jax-201-sharding`), shardings are part of
+JAX types: `jax.typeof(x)` might print `float32[8@X,4]`, meaning the leading
+axis is sharded along mesh axis `X`. This page is about what happens when you
+differentiate such a program. The main idea:
+
+**You control how your backward pass is sharded, through simple, local
+reasoning about your forward pass.**
+
+The rule that delivers this is that *cotangent types are a function of primal
+types*: the type of each gradient value in the backward pass — shape, dtype,
+and sharding — is determined by the type of the corresponding value in the
+forward pass. Once you know your forward-pass types, you know your
+backward-pass types, and hence where backward-pass communication happens.
+
+There's a second theme running through this page. If every axis of every
+array were plain *sharded*, autodiff would need nothing new: sharded
+cotangents for sharded primals, no communication anywhere. It's
+*replication* — wanting a full copy of an array on several devices — that
+makes things interesting. Replication's dual under transposition is
+*reduction*, i.e. a cross-device sum, and someone has to decide where that
+sum happens. Demanding efficient autodiff plus local reasoning in the
+presence of replication is what leads to the two new sharding states
+introduced below, `unreduced` and `reduced`.
+
+We'll use two CPU devices and a one-axis mesh throughout:
+
+```{code-cell}
+import jax
+import jax.numpy as jnp
+jax.config.update('jax_num_cpu_devices', 2)
+
+jax.set_mesh(jax.make_mesh((2,), ('X',)))  # explicit mode by default
+```
+
+## Cotangent shardings are a function of primal shardings
+
+Here's a data-parallel loss: the batch `x` is sharded along `X`, and the
+weights `w` are replicated (a full copy on every device):
+
+```{code-cell}
+x = jax.device_put(jnp.arange(8 * 4.).reshape(8, 4), jax.P('X', None))
+w = jax.device_put(jnp.arange(4 * 2.).reshape(4, 2) / 10., jax.P(None, None))
+
+def loss(w, x):
+  return jnp.sum((x @ w) ** 2)
+
+dw, dx = jax.grad(loss, argnums=(0, 1))(w, x)
+print(jax.typeof(w), '->', jax.typeof(dw))
+print(jax.typeof(x), '->', jax.typeof(dx))
+```
+
+The gradient with respect to a sharded input is sharded the same way, and the
+gradient with respect to a replicated input is replicated. This isn't just
+true of the top-level inputs and outputs of `jax.grad`; it holds for every
+intermediate in the backward pass. We can see it in the jaxpr, where each
+cotangent value's sharding matches its primal's:
+
+```{code-cell}
+print(jax.jit(jax.grad(loss)).trace(w, x).jaxpr)
+```
+
+The final two equations compute `dw`: a `dot_general` of two values sharded
+along `@X` producing a replicated (unsharded) result, then a transpose. Hold
+that thought — we'll come back to what that dot costs.
+
+There are two reasons JAX insists that cotangent shardings are determined by
+primal shardings:
+
+1. **User control.** The goal of explicit mode is that user-written code
+   determines all the shardings in the computation, in an easy-to-predict,
+   local way. The backward pass is part of the computation — but you don't
+   write it, autodiff does. Making cotangent shardings a function of primal
+   shardings means your forward-pass sharding decisions *are* your
+   backward-pass sharding decisions. (Compiler-based automatic sharding mode
+   has no analogous guarantee: there, backward-pass shardings can be chosen
+   by the compiler, unrelated to the corresponding primal shardings.)
+
+2. **Ruling out ambiguities.** If a variable is used more than once in the
+   forward pass (fan-out), autodiff generates an addition of cotangents in
+   the backward pass. If cotangent shardings could be unrelated to primal
+   shardings, the two summands might have *different* shardings, and the
+   addition would require communication that nothing in your code specifies.
+   (Similarly, the zero cotangents autodiff generates would have no
+   determined sharding.) When cotangent shardings are a function of primal
+   shardings, both summands automatically agree: they're cotangents for the
+   same primal variable, so they have the same type.
+
+This is a special case of a general principle in JAX's autodiff: cotangent
+types are always a function of the corresponding primal types — shapes,
+dtypes, and now shardings. That gives us three things: each op's backward
+rule has a clear type and knows exactly what kind of cotangent it will
+receive; a well-typed forward program always yields a well-typed backward
+program; and you can predict backward-pass types by looking only at your
+forward-pass code, without knowing what the rest of the program looks like.
+
+## Where backward-pass communication comes from
+
+In the example above, look at the types in the backward pass of `x @ w`. The
+cotangent `dw` must be replicated, because `w` is. But the data it's built
+from is spread across devices: `dw` is (the transpose of) a contraction of
+two arrays sharded along `@X`, the batch axis. Producing a replicated result
+from a contraction over a sharded axis requires a cross-device sum — an
+AllReduce. The partitioner inserts it inside that final `dot_general`.
+
+This is the familiar gradient synchronization of data-parallel training, and
+notice that you can predict it purely locally: `w` is replicated, each device
+touches only part of the batch, so somewhere in the backward pass the
+per-device gradient contributions must be summed. The types tell you the
+communication exists — but in the jaxpr above it's *implicit*, hidden inside
+an op whose operands have a sharded contracting dimension. The rest of this
+page is about making that communication explicit: something you can see in
+the types, move around, and batch up.
+
+## Unreduced: a reduction waiting to happen
+
+Consider a matmul whose *contracting* dimension is sharded:
+
+```{code-cell}
+a = jax.device_put(jnp.arange(4.).reshape(2, 2), jax.P(None, 'X'))
+b = jax.device_put(jnp.arange(4., 8.).reshape(2, 2), jax.P('X', None))
+print(jax.typeof(a))
+print(jax.typeof(b))
+```
+
+```{code-cell}
+:tags: [raises-exception]
+
+a @ b
+```
+
+JAX makes us say what we want here, because there's a genuine choice. Look at
+the data each device holds:
+
+```text
+     a: P(None, 'X')       b: P('X', None)
+  (device k has column k)  (device k has row k)
+
+        [ 0 | 1 ]             [ 4  5 ]
+                      @       ---------
+        [ 2 | 3 ]             [ 6  7 ]
+```
+
+Device 0 can multiply its column of `a` by its row of `b` without any
+communication, and likewise device 1. Each local matmul produces a
+full-shape *partial sum*, and the true answer is the elementwise sum of the
+two. One option is to finish the job with an AllReduce, by asking for an
+ordinary output sharding:
+
+```{code-cell}
+c = jnp.einsum('ij,jk->ik', a, b, out_sharding=jax.P(None, None))
+print(jax.typeof(c))
+print(c)
+```
+
+The other option is to *stop before the reduction*:
+
+```{code-cell}
+c = jnp.einsum('ij,jk->ik', a, b,
+               out_sharding=jax.P(None, None, unreduced={'X'}))
+print(jax.typeof(c))
+```
+
+The type `float32[2,2]{U:X}` reads: a 2×2 array, *unreduced* along mesh axis
+`X`. Each device along `X` holds a full-shape partial sum, and the array's
+true value is the sum of those pieces:
+
+```{code-cell}
+for shard in c.addressable_shards:
+  print(f'device {shard.device.id}:\n{shard.data}')
+```
+
+An unreduced array is a reduction waiting to happen. To cash it in, reshard
+to an ordinary sharding — this is where the deferred AllReduce runs:
+
+```{code-cell}
+print(jax.reshard(c, jax.P(None, None)))
+```
+
+Why defer? Because you might want to do more work first, and pay for fewer,
+bigger collectives. The catch is that only *linear* operations make sense on
+unreduced arrays. Adding two arrays unreduced along the same axes is fine —
+sums of partial sums are partial sums of sums:
+
+```{code-cell}
+c2 = jnp.einsum('ij,jk->ik', 2. * a, b,
+                out_sharding=jax.P(None, None, unreduced={'X'}))
+print(jax.typeof(c + c2))
+```
+
+That lets you compute a sum of sharded matmuls with a single AllReduce at the
+end — think of a LoRA-style `x @ W + x @ A @ B` — rather than one per
+matmul. Nonlinear operations, on the other hand, *can't* have a rule for
+unreduced inputs: the cosine of a sum is not the sum of the cosines, so
+applying `cos` to each device's partial sum would just compute the wrong
+answer. Such ops raise an error instead:
+
+```{code-cell}
+:tags: [raises-exception]
+
+jnp.cos(c)
+```
+
+One honest caveat: for straight-line code like `c + c2` above, XLA can often
+merge adjacent AllReduces on its own, so the compiled program may be equally
+good either way. The type-level guarantee matters when the compiler can't
+find the merge — above all, across the iterations of a loop. We'll see
+exactly that in the capstone example below.
+
+## Reduced: choosing unreduced gradients
+
+Now back to autodiff. We said cotangent shardings are a function of primal
+shardings, and we've seen two entries of that function: sharded primals get
+sharded cotangents, replicated primals get replicated cotangents.
+
+The replicated entry is exactly where backward-pass communication comes
+from: replication's transpose is a cross-device sum. With
+`CT(Replicated) = Replicated`, autodiff performs that sum *eagerly* — each
+backward-pass op that produces a cotangent for a replicated primal does its
+AllReduce on the spot, implicitly, like the `dw` dot we saw earlier. The
+natural, before-any-communication state of such a cotangent is a bunch of
+per-device partial sums — an *unreduced* array! So what if we want autodiff
+to leave it that way, and let us decide when to reduce?
+
+We need a way to ask for that in the forward pass, and it has to be a new
+*type* — remember, cotangent types are a function of primal types. That's
+what `reduced` is for:
+
+```{code-cell}
+w_ = jax.reshard(w, jax.P(None, None, reduced={'X'}))
+print(jax.typeof(w_))
+```
+
+An array that's *reduced* along `X`, written `{R:X}`, is physically identical
+to a replicated array: a full copy on every device along `X`. (The name is
+the past tense of "unreduced": it's the state an array is in after its
+reduction has happened.) In the forward pass it behaves exactly like a
+replicated array, and the reshard above is communication-free — no data
+moves. The *only* difference is how autodiff treats it. The complete
+cotangent map is:
+
+| primal type       | cotangent type    |
+|-------------------|-------------------|
+| sharded `@X`      | sharded `@X`      |
+| replicated        | replicated        |
+| reduced `{R:X}`   | unreduced `{U:X}` |
+| unreduced `{U:X}` | reduced `{R:X}`   |
+
+Use `Replicated` and you get replicated gradients; use `Reduced` and you get
+unreduced gradients. That's the only difference between them.
+
+Here's the payoff. The reshard-to-reduced above is a communication-free cast
+in the forward pass, and under transposition it becomes a
+reshard-from-unreduced in the backward pass — which is precisely the
+AllReduce. **A free cast in your forward code pins down where the collective
+runs in your backward code.** Backward-pass communication becomes something
+you can see, place, and reason about locally, while writing the forward
+pass. Compare the backward pass of our data-parallel loss with and without
+the cast:
+
+```{code-cell}
+def loss2(w, x):
+  w = jax.reshard(w, jax.P(None, None, reduced={'X'}))
+  return jnp.sum((x @ w) ** 2)
+
+print(jax.jit(jax.grad(loss2)).trace(w, x).jaxpr)
+```
+
+Where the original jaxpr had a `dot_general` with an implicit AllReduce
+buried inside, this one shows the dot producing an explicit
+`f32[2,4]{U:X}` value, and a final `reshard` — the transposed cast — turning
+it into the replicated `dw`. Same math, same total communication, but now the
+reduction is a visible, movable object in the program.
+
+And once it's visible, you can move it. Suppose the weights are used twice —
+two heads, two microbatches, a LoRA branch:
+
+```{code-cell}
+def loss_fanout(w, x1, x2):
+  w = jax.reshard(w, jax.P(None, None, reduced={'X'}))
+  return jnp.sum(x1 @ w) + jnp.sum(x2 @ w)
+
+x1 = jax.device_put(jnp.ones((8, 4)), jax.P('X', None))
+x2 = jax.device_put(jnp.ones((8, 4)), jax.P('X', None))
+print(jax.jit(jax.grad(loss_fanout)).trace(w, x1, x2).jaxpr)
+```
+
+Both backward dots produce `{U:X}` contributions, the fan-out addition
+happens *unreduced* (addition is linear!), and a single `reshard` performs
+one AllReduce for the whole gradient. Without the cast, each contribution
+would be reduced separately inside its own dot. Here the fusion is guaranteed
+by the types, not left to compiler pattern-matching — which is about to
+matter.
+
+## Capstone: microbatch gradient accumulation
+
+The classic place this bites is gradient accumulation. A realistic training
+step has *two* loops that the compiler can't see through: a scan over layers
+inside the model, and a scan over microbatches accumulating gradients, with
+one update at the end. The gradient AllReduce should happen once per step —
+but if the weights are replicated, every microbatch's backward pass
+synchronizes its own gradient contribution, inside both loops, and XLA
+cannot hoist collectives out of a loop for you. With `reduced` weights, the
+gradients come out unreduced, the accumulator stays unreduced across the
+whole scan, and you reduce once:
+
+```{code-cell}
+def predict(stacked_ws, xs):  # stacked_ws: [layer, features, features]
+  def apply_layer(xs, w):
+    return jnp.tanh(xs @ w), None
+  final_xs, _ = jax.lax.scan(apply_layer, xs, stacked_ws)
+  return final_xs
+
+def loss3(stacked_ws, batch):
+  return jnp.sum(predict(stacked_ws, batch) ** 2)
+
+@jax.jit
+def step(stacked_ws, xs):  # xs: [microbatch, batch@X, features]
+  def microbatch_step(grad_acc, xs_mb):
+    grads = jax.grad(loss3)(stacked_ws, xs_mb)
+    # ws are reduced, so grads are unreduced -- and we can check it!
+    assert jax.typeof(grads).sharding.spec.unreduced == {'X'}
+    return grad_acc + grads, None
+
+  grad_acc = jax.reshard(jnp.zeros_like(stacked_ws), jax.P(unreduced={'X'}))
+  grad_acc, _ = jax.lax.scan(microbatch_step, grad_acc, xs)
+  grads = jax.reshard(grad_acc, jax.P())        # the one AllReduce
+  ws = jax.reshard(stacked_ws, jax.P())         # free: full copies already
+  return ws - 0.01 * grads
+
+stacked_ws = jax.device_put(jnp.stack([jnp.eye(4) / 2] * 3),
+                            jax.P(reduced={'X'}))
+xs = jax.device_put(jnp.ones((5, 2, 4)), jax.P(None, 'X', None))
+
+new_ws = step(stacked_ws, xs)
+print(jax.typeof(new_ws))
+```
+
+Everything type-checks locally: the weights are `{R:X}`, so each microbatch's
+gradients come out `{U:X}` — even though they're computed by a scan over
+layers; unreduced arrays support addition, so the microbatch scan carry
+accumulates them; and one reshard to replicated is the step's single
+AllReduce. Notice the `assert` in the scan body: because shardings are part
+of JAX types, "the gradients are unreduced" isn't a hope or a comment — it's
+a property of a value you can check with `jax.typeof`, inside traced code,
+at trace time. The updated weights come back replicated; casting them back to
+`{R:X}` for the next step is free. And the compiled program keeps the
+promise — exactly one AllReduce, outside both loops:
+
+```{code-cell}
+import re
+
+def print_all_reduces(jitted, *args):
+  hlo = jitted.lower(*args).compile().as_text()
+  for line in hlo.splitlines():
+    if 'all-reduce(' in line or 'all-reduce-start(' in line:
+      print(re.search(r'op_name="([^"]*)"', line).group(1))
+
+print_all_reduces(step, stacked_ws, xs)
+```
+
+Compare the same step written with plain replicated weights:
+
+```{code-cell}
+@jax.jit
+def step_replicated(stacked_ws, xs):
+  def microbatch_step(grad_acc, xs_mb):
+    grads = jax.grad(loss3)(stacked_ws, xs_mb)  # replicated: AllReduce inside!
+    return grad_acc + grads, None
+  grad_acc = jnp.zeros_like(stacked_ws)
+  grad_acc, _ = jax.lax.scan(microbatch_step, grad_acc, xs)
+  return stacked_ws - 0.01 * grad_acc
+
+ws_replicated = jax.reshard(stacked_ws, jax.P())
+print_all_reduces(step_replicated, ws_replicated, xs)
+```
+
+The op name says it all: `while/body/.../while/body` — this AllReduce sits
+inside the transposed layer scan, inside the microbatch scan: it runs once
+per layer per microbatch. Hoisting the gradient reduction out of loops this
+way — from once per layer per microbatch down to once per step — has produced
+large wins in production LLM training — in one case cutting per-step time
+spent in gradient reduction by several times — and it's a transformation
+the compiler cannot make on its own, because it can't pattern-match
+collectives through a loop.
+
+## Why this design?
+
+A few frequently-asked design questions, for the curious.
+
+**Why not make the cotangent of Replicated be Unreduced?** It would be
+coherent — but it takes options away. Lots of code returns replicated values
+(most obviously, loss values!), and making their cotangents unreduced would
+introduce surprising communication requirements into existing programs. By
+keeping `Replicated ↔ Replicated` and adding `Reduced ↔ Unreduced` as a
+separate pair, you get to choose per-array whether gradients arrive
+replicated (reduction done for you, eagerly) or unreduced (reduction is
+yours to place), and the choice is made by a communication-free cast in the
+forward pass.
+
+**Is there a theoretical justification for Unreduced, or is it just a
+practical trick?** Here's an argument that something like it is forced.
+Suppose we want the following, none of which is individually exotic:
+
+1. autodiff should preserve communication cost, op by op: a forward op that
+   requires no communication should transpose to a backward op that requires
+   no communication (or at least, we need *some* way to write such a
+   backward pass);
+2. replication should be expressible — we don't want *only* sharded axes;
+3. multiplying a replicated scalar by a sharded vector, a communication-free
+   forward op, should be expressible;
+4. cotangents should have the same shape as their primals.
+
+Transposing (3) with respect to the scalar means mapping a sharded cotangent
+vector to a cotangent for the replicated scalar. Doing that with no
+communication (1) forces a state that is scalar-shaped (4) but holds only a
+per-device *piece* of the answer, pending a sum: that's Unreduced. (Without
+premise 4 you could simulate it by tacking on an extra device-indexed axis;
+Unreduced is in effect that axis, tracked in the sharding instead of the
+shape.)
+
+This page covered explicit sharding mode. In manual mode
+({ref}`jax-201-shard-map`), where you write per-device code with explicit
+collectives like `psum`, the same questions get answered differently — how
+forward-pass collectives transpose has its own story, planned for a future
+page.

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -90,7 +90,8 @@ from jax._src.core import typeof as typeof
 from jax._src.api import effects_barrier as effects_barrier
 from jax._src.api import block_until_ready as block_until_ready
 from jax._src.ad_checkpoint import checkpoint as checkpoint
-from jax._src.ad_checkpoint import checkpoint_policies as checkpoint_policies
+from jax import checkpoint_policies as checkpoint_policies
+from jax._src.ad_checkpoint import custom_remat as custom_remat
 from jax._src.ad_checkpoint import remat as remat
 from jax._src.api import clear_caches as clear_caches
 from jax._src.api import copy_to_host_async as copy_to_host_async

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -201,6 +201,9 @@ def save_from_both_policies(policy_1, policy_2):
 # Please update the file docs/gradient-checkpointing.md with any new
 # policies to keep the doc in sync.
 checkpoint_policies = types.SimpleNamespace(
+    SaveOnlyTheseNames=SaveOnlyTheseNames,
+    SaveAnyNamesButThese=SaveAnyNamesButThese,
+    SaveAndOffloadOnlyTheseNames=SaveAndOffloadOnlyTheseNames,
     everything_saveable=everything_saveable,
     nothing_saveable=nothing_saveable,
     dots_saveable=dots_saveable,
@@ -1198,10 +1201,42 @@ def primal_left_tangent_right(x, _x):
   return PrimalLeftTangentRight(typeof(x), typeof(_x))(x, _x)
 
 
-# TODO reverse-mode only... use hijax instead of custom_vjp
-def custom_remat(f, f1, f2, fbwd, *, static_argnums=(), static_argnames=()):
+def custom_remat(f, f_fwd, f_rem, f_bwd, *, static_argnums=(),
+                 static_argnames=()):
+  """Wrap ``f`` with custom rematerialization behavior for reverse-mode AD.
+
+  Where :func:`jax.checkpoint` policies select saveable values by name, a
+  ``custom_remat``-wrapped function carries its own rematerialization rules,
+  which can depend on the ambient checkpoint policy. Requires the
+  ``jax_remat3`` implementation.
+
+  Args:
+    f: the function to wrap, called (or traced) for ordinary evaluation.
+    f_fwd: forward-pass rule under rematerialized differentiation, of
+      signature ``f_fwd(policy, *args) -> (out, res)``. It receives the
+      ambient checkpoint policy along with the arguments of ``f``, and
+      returns the primal output paired with residuals to save (which may be
+      ``None``, to save nothing).
+    f_rem: rematerialization rule, of signature
+      ``f_rem(res, *args) -> (out, res2)``. On the backward pass it receives
+      the residuals saved by ``f_fwd`` and the arguments of ``f``, and
+      recomputes the primal output paired with the residuals that ``f_bwd``
+      needs.
+    f_bwd: backward-pass rule, of signature
+      ``f_bwd(res2, out_ct) -> args_ct``, returning a tuple of cotangents
+      with one entry per argument of ``f``.
+    static_argnums: as in :func:`jax.jit`.
+    static_argnames: as in :func:`jax.jit`.
+
+  Returns:
+    A wrapped version of ``f`` with the same call behavior, but with the
+    given rules applied when it is differentiated in reverse mode under
+    rematerialization (e.g. under :func:`jax.checkpoint`). Forward-mode
+    differentiation falls back to differentiating ``f``.
+  """
+  # TODO reverse-mode only... use hijax instead of custom_vjp
   helper = custom_derivatives.custom_vjp(lambda _, *args: f(*args))
-  helper.defvjp(f2, lambda res, g: (None, *fbwd(res, g)))
+  helper.defvjp(f_rem, lambda res, g: (None, *f_bwd(res, g)))
   def call(*args, **kwargs):
     args_ft = ft.flatten_static_argnums_argnames(
         args, kwargs, static_argnums, static_argnames)
@@ -1211,7 +1246,7 @@ def custom_remat(f, f1, f2, fbwd, *, static_argnums=(), static_argnames=()):
         static_argnames=static_argnames)
     jaxpr_, out_avals_ft = pe.trace_to_jaxpr(f, avals_ft, dbg)
     jaxpr, consts = pe.separate_consts(jaxpr_)
-    out_flat = CustomRemat(jaxpr, f1, helper, args_ft.tree, out_avals_ft.tree)(*consts, *args_ft)
+    out_flat = CustomRemat(jaxpr, f_fwd, helper, args_ft.tree, out_avals_ft.tree)(*consts, *args_ft)
     return out_avals_ft.update(out_flat).unflatten()
   return call
 

--- a/jax/checkpoint_policies.py
+++ b/jax/checkpoint_policies.py
@@ -1,0 +1,32 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from jax._src.ad_checkpoint import (
+  SaveOnlyTheseNames as SaveOnlyTheseNames,
+  SaveAnyNamesButThese as SaveAnyNamesButThese,
+  SaveAndOffloadOnlyTheseNames as SaveAndOffloadOnlyTheseNames,
+  everything_saveable as everything_saveable,
+  nothing_saveable as nothing_saveable,
+  dots_saveable as dots_saveable,
+  dots_with_no_batch_dims_saveable as dots_with_no_batch_dims_saveable,
+  offload_dot_with_no_batch_dims as offload_dot_with_no_batch_dims,
+  save_anything_except_these_names as save_anything_except_these_names,
+  save_any_names_but_these as save_any_names_but_these,
+  save_only_these_names as save_only_these_names,
+  save_from_both_policies as save_from_both_policies,
+  save_and_offload_only_these_names as save_and_offload_only_these_names,
+)
+
+checkpoint_dots = dots_saveable
+checkpoint_dots_with_no_batch_dims = dots_with_no_batch_dims_saveable

--- a/tests/documentation_coverage_test.py
+++ b/tests/documentation_coverage_test.py
@@ -54,6 +54,7 @@ UNDOCUMENTED_APIS = {
   'jax': ['auto_pcast', 'empty_ref', 'memory', 'NamedSharding', 'P', 'Ref', 'Shard', 'reshard', 'ad_checkpoint', 'api_util', 'checkpoint_policies', 'core', 'custom_derivatives', 'custom_transpose', 'debug_key_reuse', 'device_put_replicated', 'device_put_sharded', 'effects_barrier', 'example_libraries', 'explain_cache_misses', 'experimental', 'extend', 'float0', 'free_ref', 'freeze', 'fwd_and_bwd', 'host_count', 'host_id', 'host_ids', 'interpreters', 'jax', 'jax2tf_associative_scan_reductions', 'legacy_prng_key', 'lib', 'make_user_context', 'new_ref', 'no_execution', 'numpy_dtype_promotion', 'remat', 'remove_size_one_mesh_axis_from_type', 'softmax_custom_jvp', 'threefry_partitionable', 'thread_guard', 'tools', 'transfer_guard_device_to_device', 'transfer_guard_device_to_host', 'transfer_guard_host_to_device', 'version', 'allow_f16_reductions'],
   'jax.ref': ['empty_ref', 'free_ref'],
   'jax.ad_checkpoint': ['checkpoint', 'checkpoint_policies', 'print_saved_residuals', 'remat', 'Offloadable', 'Recompute', 'Saveable'],
+  'jax.checkpoint_policies': ['save_anything_except_these_names'],
   'jax.custom_batching': ['custom_vmap', 'sequential_vmap'],
   'jax.custom_derivatives': ['CustomVJPPrimal', 'SymbolicZero', 'closure_convert', 'custom_gradient', 'custom_jvp', 'custom_jvp_call_p', 'custom_vjp', 'custom_vjp_call_p', 'custom_vjp_primal_tree_values', 'linear_call', 'remat_opt_p', 'zero_from_primal'],
   'jax.debug': ['DebugEffect', 'OrderedDebugEffect', 'log'],


### PR DESCRIPTION
Add advanced autodiff 301 section to new docs.

Add new_docs/301/sharding-ad.md: cotangent shardings as a function of primal shardings, unreduced/reduced, and controlling backward-pass collectives (explicit mode only).

Also add notebook_metadata_filter to executable new_docs pages so the jupytext pre-commit hook stops silently stripping `nosearch: true` (it had already stripped it from the committed 101/201 pages).