### PR TITLE
[docs] add 501 (systems topics); add CuTe DSL to 401 and errors to 101

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -252,6 +252,7 @@ nb_execution_excludepatterns = [
     'distributed_data_loading.*',
     'notebooks/host-offloading.*',
     'notebooks/cute_dsl_jax.*',
+    'new_docs/401/cute-dsl.*',
 ]
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/docs/new_docs/101/errors.rst
+++ b/docs/new_docs/101/errors.rst
@@ -1,0 +1,35 @@
+:nosearch:
+
+.. _jax-101-errors:
+
+Errors
+======
+
+This page lists a few of the errors you might encounter when using JAX,
+along with representative examples of how one might fix them.
+
+.. currentmodule:: jax.errors
+.. autoclass:: InconclusiveDimensionOperation
+   :no-index:
+.. autoclass:: JaxprTypeError
+   :no-index:
+.. autoclass:: JaxRuntimeError
+   :no-index:
+.. autoclass:: JAXTypeError
+   :no-index:
+.. autoclass:: JAXIndexError
+   :no-index:
+.. autoclass:: ConcretizationTypeError
+   :no-index:
+.. autoclass:: KeyReuseError
+   :no-index:
+.. autoclass:: NonConcreteBooleanIndexError
+   :no-index:
+.. autoclass:: TracerArrayConversionError
+   :no-index:
+.. autoclass:: TracerBoolConversionError
+   :no-index:
+.. autoclass:: TracerIntegerConversionError
+   :no-index:
+.. autoclass:: UnexpectedTracerError
+   :no-index:

--- a/docs/new_docs/101/index.rst
+++ b/docs/new_docs/101/index.rst
@@ -24,6 +24,9 @@ in JAX. They're meant to be read in order:
    functions of key values, with no hidden generator state.
 5. :doc:`state` — stateful computations: threading state through pure
    functions, and in-place mutation with refs, JAX's mutable array type.
+6. :doc:`errors` — common JAX errors, explained: most arise from expressing
+   something in a way that's incompatible with tracing, so the tracing model
+   from :doc:`transformations` is the key to fixing them.
 
 The second half of the story is making these computations fast: compilation
 with :func:`jax.jit`, sharded arrays and parallelism, and profiling. Those are
@@ -38,3 +41,4 @@ the subject of the performance and scaling docs: :doc:`/new_docs/201/index`.
    pytrees
    random
    state
+   errors

--- a/docs/new_docs/201/aot.md
+++ b/docs/new_docs/201/aot.md
@@ -84,7 +84,7 @@ Array(10, dtype=int32, weak_type=True)
 ```
 
 Note that the lowered objects can be used only in the same process
-in which they were lowered. For exporting use cases, see the {ref}`export` APIs.
+in which they were lowered. For exporting use cases, see the {ref}`jax-501-export` APIs.
 
 See the {mod}`jax.stages` documentation for more details on what functionality
 the lowering and compiled functions provide.
@@ -208,7 +208,7 @@ Array(25, dtype=int32)
 ```
 
 The results of `trace` and of `lower` are not safe to serialize directly for use
-in a different process. See {ref}`export` for additional APIs for this purpose.
+in a different process. See {ref}`jax-501-export` for additional APIs for this purpose.
 
 ## AOT-compiled functions cannot be transformed
 

--- a/docs/new_docs/201/debugging.md
+++ b/docs/new_docs/201/debugging.md
@@ -360,7 +360,7 @@ postmortem.
 
 ```{warning}
 These flags are best suited to single-process development, and don't work
-well in multi-controller (multi-process) JAX ({doc}`/multi_process`).
+well in multi-controller (multi-process) JAX ({ref}`jax-501-multiprocess`).
 Raising a Python error on one process but not the others — say, when only
 one process's shard produces a NaN under `jax_debug_nans` — breaks the
 assumption that every process runs the same program in lockstep, and the

--- a/docs/new_docs/201/jit.md
+++ b/docs/new_docs/201/jit.md
@@ -323,7 +323,7 @@ For a lighter-weight signal, `jax_log_compiles` logs one line per
 compilation, without the diagnosis. When tracing or compilation time itself
 becomes the problem, {doc}`slow-compilation` is a field guide to diagnosing
 it; and the persistent compilation cache
-({doc}`/persistent_compilation_cache`) keeps compiled executables across
+({ref}`jax-501-compilation-cache`) keeps compiled executables across
 process restarts.
 
 ## Using `jit` with methods

--- a/docs/new_docs/201/placement.md
+++ b/docs/new_docs/201/placement.md
@@ -229,7 +229,7 @@ Everything on this page generalizes to multiple processes: meshes can span
 hosts, can cover just a subset of the devices in a cluster, and
 `jax.device_put` can transfer between meshes across processes over
 high-speed interconnects. That story belongs to the multi-process systems
-docs — see {doc}`/multi_process` in the meantime.
+docs; see {ref}`jax-501-multiprocess`.
 
 ## Notes
 

--- a/docs/new_docs/201/profiling.md
+++ b/docs/new_docs/201/profiling.md
@@ -532,7 +532,7 @@ that sharded computations execute. For multi-process programs, start a
 profiler server in each process; XProf's capture dialog accepts a
 comma-separated list of profiler-service addresses, so you can capture
 several hosts into one profile. (The multi-process programming story itself
-is covered in the systems docs; see {doc}`/multi_process`.)
+is covered in the systems docs; see {ref}`jax-501-multiprocess`.)
 
 ### Viewing program traces with Perfetto
 

--- a/docs/new_docs/201/slow-compilation.md
+++ b/docs/new_docs/201/slow-compilation.md
@@ -149,7 +149,7 @@ that unintentionally invalidate JAX's caches.
 
 JAX can also use a persistent compilation cache for use across multiple
 JAX processes.
-See {doc}`/persistent_compilation_cache`.
+See {ref}`jax-501-compilation-cache`.
 
 ### Gotcha: Dynamically Recreating Function Objects
 

--- a/docs/new_docs/401/cute-dsl.md
+++ b/docs/new_docs/401/cute-dsl.md
@@ -1,0 +1,1219 @@
+---
+jupytext:
+  formats: md:myst
+  notebook_metadata_filter: nosearch
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nosearch: true
+---
+
+<!--* freshness: { reviewed: "2026-04-28" } *-->
+
+(jax-401-cute-dsl)=
+# Writing High-Performance GPU Kernels with CuTe DSL and JAX
+
+## Overview
+
+JAX provides excellent built-in GPU support through XLA, but sometimes you need to go beyond what the compiler can generate automatically. Custom GPU kernels let you exploit hardware-specific features, fuse operations that XLA misses, or implement algorithms that don't map cleanly to standard library calls. CuTe DSL bridges this gap by letting you write CUDA kernels in Python and plug them directly into JAX programs.
+
+**What you'll do:**
+
+- Install CUTLASS 4.x and its CuTe DSL Python front-end
+- Write a **Vector Add** kernel using `@cute.kernel` and launch it with `@cute.jit`
+- Integrate CuTe DSL kernels into JAX programs via `cutlass.jax.cutlass_call`
+- Implement **SAXPY** (`y = alpha * x + y`) with scalar kernel arguments
+- Write **ReLU** and **Fused Bias+ReLU** activation kernels for deep learning
+- Build a **tiled GEMM** using tensor core MMA instructions
+- Shard CUTLASS kernels across multiple GPUs with `jax.shard_map`
+- **Export and serialize** JAX functions containing CUTLASS kernels with **`jax.export`**
+
++++
+
+## Introduction
+
+[CuTe DSL](https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/cute_dsl.html) is the Python-native interface to [CUTLASS](https://docs.nvidia.com/cutlass/latest/) 4.4+, NVIDIA's open-source library of high-performance CUDA kernels. It exposes the same CuTe abstractions (layouts, tensors, thread-to-data mappings) that power CUTLASS's C++ template library, but authored entirely in Python.
+
+Traditionally, writing custom GPU kernels meant working in C++ or CUDA — a steep learning curve for Python-focused ML engineers. CuTe DSL changes this: you define per-thread logic with `@cute.kernel`, configure launch parameters with `@cute.jit`, and the CUTLASS JIT compiler generates optimized CUDA code behind the scenes. The `cutlass.jax` integration module then lets you call these kernels from JAX as if they were native operations, with full support for `@jax.jit`, automatic differentiation plumbing, and multi-device sharding.
+
+This notebook walks through progressively more complex kernels showing the patterns you'll reuse in your own custom operations.
+
++++
+
+## The CuTe mental model
+
+At its core, CuTe is an **index transformation DSL** — it provides abstractions for mapping logical coordinates to physical memory offsets. Everything in CuTe builds on the following concepts:
+
+**Shape** describes the dimensions of your data. A shape can be simple like `(M, N)` for a matrix, or hierarchical like `((2, 4), N)` where the first mode is itself subdivided. Hierarchical shapes are especially useful on GPUs, where work is organized in layers:
+
+- A **thread** is the smallest unit of execution — one thread runs one sequence of instructions.
+- A **warp** is a group of 32 threads that execute in lockstep on the same hardware unit.
+- A **block** is a group of threads (organized internally into warps) that share fast on-chip (shared) memory and can synchronize with each other.
+- The **grid** is the collection of all blocks launched by a kernel.
+
+CuTe shapes can nest to mirror this hierarchy. Such a hierarchical shape can be used to model a GPU execution hierarchy — for example, 32 threads per warp × 8 warps per block, across N blocks — when bound to CUDA’s thread and block indices.
+
+**Coordinate** is a position within a shape. For a shape `(4, 8)`, the coordinate `(2, 5)` identifies one element — row 2, column 5.
+
+**Stride** tells CuTe how far you move in memory when you step along each dimension. In a row-major `(4, 8)` matrix, memory is laid out row by row: the first 8 elements belong to row 0, the next 8 to row 1, and so on. Moving one column to the right simply advances to the next element in memory (stride 1). Moving one row down skips over an entire row of 8 elements (stride 8). So the stride is `(8, 1)`.
+
+**Layout = (Shape, Stride)** is CuTe's central abstraction. Shape and stride must have the same rank — each logical dimension must have a corresponding stride.
+
+Although we think of tensors as multi-dimensional, GPU memory itself is just a long one-dimensional array of elements. Given a coordinate, a layout tells you where that element lives in memory. It does this by combining the coordinate with the stride:
+
+```
+offset = coord[0] * stride[0] + coord[1] * stride[1] + ...
+```
+
+In CuTe DSL, you can define layout using:
+
+```python
+cute.make_layout((...), stride=(...))
+```
+
+One important thing to note here: in  *row-major* layout, elements of each row are stored contiguously in memory (so columns vary fastest), whereas in *column-major* layout, elements of each column are stored contiguously (so rows vary fastest), meaning the logical shape stays the same but the stride — and therefore the memory access pattern — changes.
+
+For example, with layout in row-major order `((4, 8), (8, 1))`, coordinate `(2, 5)` maps to offset `2*8 + 5*1 = 21`.
+
+A column-major layout for the same shape would use stride `(1, 4)`, so the same coordinate maps to `2*1 + 5*4 = 22`.
+
+The shape stays the same — only the stride changes.
+
+```python
+row_major = cute.make_layout((M, N), stride=(N, cutlass.Int32(1)))
+col_major = cute.make_layout((M, N), stride=(cutlass.Int32(1), M))
+```
+
+This separation of logical structure from physical storage is what makes CuTe powerful. Algorithms operate on coordinates, while layouts decide how those coordinates map to memory. Change the stride, and you change the storage pattern — without rewriting the algorithm.
+
+In the following examples, you won’t see `make_layout` because the kernels operate on `cute.Tensor` objects and use CuTe’s tensor / fragment helpers (`cute.size`, `cute.make_rmem_tensor`, `cute.autovec_copy`, `Tensor[...]`) which already encode the shape, stride and indexing semantics the kernel needs. The code stays higher-level and avoids manual offset arithmetic or explicit layout construction — that’s deliberate: CuTe’s helpers are there so kernels read like algorithms, not pointer math.
+
++++
+
+## Hardware and software requirements
+
+| Requirement | Minimum | Recommended |
+|------------|---------|-------------|
+| GPU | SM 8.0+ (Ampere) | SM 9.0+ (Hopper) |
+| CUDA | 12.9 | 13.1 |
+| JAX | 0.8.1+ | Latest |
+| CUTLASS | 4.4+ (CuTe DSL) | Latest |
+| Python | 3.10+ | 3.12 |
+
++++
+
+First, let's check which GPUs are available in this environment. The `nvidia-smi` command shows the GPU model, driver version, CUDA toolkit version, and current memory usage.
+
+```{code-cell}
+!nvidia-smi
+```
+
+We programmatically query the GPU's **compute capability** using `nvidia-smi`. This two-digit number (e.g., 9.0 for Hopper) tells us which hardware features are available. CuTe DSL requires SM 8.0 (Ampere) or newer.
+
+```{code-cell}
+import subprocess
+
+
+def get_compute_capability():
+  """Query the compute capability of the first visible GPU."""
+  out = subprocess.check_output(
+      ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader"],
+      text=True,
+  )
+  major, minor = out.strip().split("\n")[0].split(".")
+  return int(major), int(minor)
+
+
+SM_MAJOR, SM_MINOR = get_compute_capability()
+print(f"Detected compute capability: SM {SM_MAJOR}.{SM_MINOR}")
+
+if SM_MAJOR < 8:
+  print("WARNING: CuTe DSL requires SM 8.0+ (Ampere or newer).")
+  print("Some examples may not run on this GPU.")
+else:
+  print("GPU is compatible with CuTe DSL.")
+```
+
+## Install CuTe DSL and import dependencies
+
+The `nvidia-cutlass-dsl` package bundles CuTe DSL together with its JAX integration module (`cutlass.jax`). The `[cu13]` extra pulls in CUDA 13.x compatible runtime libraries. Version 4.4+ is required for the JAX integration.
+
+Refer to the [official documentation](https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/quick_start.html) for a more comprehensive installation guide.
+
+```{code-cell}
+%pip install "nvidia-cutlass-dsl[cu13]" --quiet
+```
+
+With CUTLASS installed, we import the libraries we'll use throughout the notebook: `cutlass` for kernel definitions, `jax` and `jnp` for array computation and JIT compilation, and `numpy` for result validation.
+
+```{code-cell}
+import os
+
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"  # suppress TF/XLA info & warnings
+os.environ["XLA_FLAGS"] = "--xla_gpu_cuda_data_dir=/usr/local/cuda"
+
+import cutlass
+from importlib.metadata import version as _pkg_version
+
+print(f"CUTLASS version: {_pkg_version('nvidia-cutlass-dsl')}")
+
+import cutlass.cute as cute
+import cutlass.jax as cjax
+import cuda.bindings.driver as cuda
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+print(f"JAX version:     {jax.__version__}")
+print(f"JAX devices:     {jax.devices()}")
+```
+
+## Defining kernels
+
+In CuTe DSL, kernels are defined in two layers:
+
+1. **`@cute.kernel`** defines the per-thread program — the sequence of instructions executed by each thread instance.
+2. **`@cute.jit`** compiles the kernel and specifies how it runs on the GPU: the grid (how many blocks), the block (how many threads per block), and the CUDA stream (which execution queue to launch into).
+
+CuTe DSL lowers Python kernels to CUDA/CUTLASS code and compiles them just-in-time using the CUTLASS JIT toolchain.
+
+**Note:** CuTe DSL relies on Python source inspection `inspect.getsourcelines()` to parse kernel definitions. In many environments (including this notebook), defining `@cute.kernel` / `@cute.jit` functions directly in notebook cells works correctly. However, this is not consistently reliable across all interactive environments (e.g. plain Python REPL), where source inspection may fail with errors like `OSError: could not get source code`.
+
+We show the executable kernel definitions inline in the notebook. At the same time, for robustness and reproducibility, we keep equivalent definitions in a separate .py module ([cute_dsl_jax_kernels.py](../../notebooks/cute_dsl_jax/cute_dsl_jax_kernels.py)).
+
+Here, we import the pre-written kernel launch functions from [cute_dsl_jax_kernels.py](../../notebooks/cute_dsl_jax/cute_dsl_jax_kernels.py).
+
+```{code-cell}
+# Optional, if you execute the equivalent kernel definitions further in the notebook
+
+# from cute_dsl_jax.cute_dsl_jax_kernels import (
+#     launch_vector_add, launch_saxpy, launch_gemm,
+#     launch_relu, launch_fused_bias_relu,
+#     launch_elementwise_add,
+# )
+# print("Imported: launch_vector_add, launch_saxpy, launch_gemm, launch_relu, launch_fused_bias_relu, launch_elementwise_add")
+```
+
+```{code-cell}
+def split_keys(seed=0):
+  key = jax.random.key(seed)
+  while True:
+    key, subkey = jax.random.split(key)
+    yield subkey
+
+keys = iter(split_keys())
+```
+
+## Basic kernel: vector add
+
+We’ll start with the simplest GPU kernel — vector add: `c[i] = a[i] + b[i]`.
+
+Each thread in the kernel below identifies itself using `thread_idx()` and `block_idx()`. Thread and block indices are accessed through `cute.arch` (e.g., `thread_idx`, `block_idx`), each returning `(x, y, z)` tuples, because CUDA’s execution and indexing are 3-dimensional by design. Since this kernel is launched in 1D, we only use the `x` component (`tidx` and `bidx`) and ignore the unused `y` and `z` values with `_`.
+
+```python
+tidx, _, _ = cute.arch.thread_idx()
+bidx, _, _ = cute.arch.block_idx()
+```
+
+Inside the kernel, tensors are typically created in register memory using `cute.make_rmem_tensor`.
+
+Below, `frgA` and `frgB` hold the input values in registers, while `frgC` is a register fragment that will store the computed result before it is written back to global memory. `mode=[0]` selects the first dimension of the tensor — the "elements per thread" axis — so the register fragment is sized to hold exactly the data owned by one thread.
+
+Data movement between global and register memory is explicit: fragments are read using `load()` and written back using `store()`, while `cute.autovec_copy` performs efficient, vectorized transfers between memory spaces. Here, one element of `a` and `b` is loaded into register fragments, the sum in registers is computed and the result is stored back to `c`. The `None` selects the entire first dimension (which has size 1 in this example), preserving the (`elems_per_thread`, `threads_per_block`, `num_blocks`) structure while allowing each thread to access its own slice of the tensor.
+
+>  **Concept: Tensor = Pointer + Layout**
+>
+> A CuTe **Tensor** pairs a pointer to GPU memory with a **Layout** that describes how to navigate it. When the kernel receives `a: cute.Tensor`, it gets both the raw data and the index mapping. In this example, our tensors have shape `(1, BLOCK, num_blocks)` — one element per thread, `BLOCK=256` (defined in the example below) threads per block, spread across blocks. The layout maps a `(elems_per_thread, threads_per_block, num_blocks)` coordinate to the flat memory offset where that element lives. The kernel never computes offsets manually — it just indexes the tensor with `a[None, tidx, bidx]` and CuTe's layout handles the rest.
+
+```{code-cell}
+@cute.kernel
+def vector_add_kernel(a: cute.Tensor, b: cute.Tensor, c: cute.Tensor):
+  """Per-thread kernel: each thread adds one element."""
+  tidx, _, _ = cute.arch.thread_idx()
+  bidx, _, _ = cute.arch.block_idx()
+
+  frgA = cute.make_rmem_tensor(cute.size(a, mode=[0]), a.element_type)
+  frgB = cute.make_rmem_tensor(cute.size(b, mode=[0]), b.element_type)
+  frgC = cute.make_rmem_tensor(cute.size(c, mode=[0]), c.element_type)
+
+  cute.autovec_copy(a[None, tidx, bidx], frgA)
+  cute.autovec_copy(b[None, tidx, bidx], frgB)
+  frgC.store(frgA.load() + frgB.load())
+  cute.autovec_copy(frgC, c[None, tidx, bidx])
+```
+
+The `@cute.kernel` defines one thread’s work. The `@cute.jit` launcher decides how many threads run, and how they’re grouped. It must follow the signature convention: `(stream, *inputs, *outputs, *, **kwargs)` — where `stream` is a CUDA stream managed by XLA, followed by input tensors, then output tensors.
+
+We launch `a.shape[-2]` threads per block and `a.shape[-1]` blocks, directly matching the tensor’s `(1, threads_per_block, num_blocks)` layout so that `threadIdx.x` indexes the thread dimension and `blockIdx.x` indexes the block dimension. We use -2 and -1 because they refer to the last two tensor dimensions (threads per block and number of blocks), making the launch configuration robust even if additional leading dimensions are added.
+
+> **Concept: Layout composition**
+>
+> The vector add kernel expects 3-D tensors with shape `(elems_per_thread, threads_per_block, num_blocks)`, but our data is a flat 1-D array. The JAX wrapper reshapes from 1-D to 3-D before calling the kernel, and back afterward. In CuTe terms, this reshape is a **layout composition** — combining the original 1-D layout with a new layout that splits the single dimension into three. CuTe performs this algebraically: the composed layout maps 3-D coordinates directly to the original flat offsets, with no data movement. Reshaping is free — it's just a change of layout, not a copy.
+
+```{code-cell}
+@cute.jit
+def launch_vector_add(
+    stream: cuda.CUstream,
+    a: cute.Tensor,
+    b: cute.Tensor,
+    c: cute.Tensor,
+):
+  vector_add_kernel(a, b, c).launch(
+      grid=[a.shape[-1], 1, 1],
+      block=[a.shape[-2], 1, 1],
+      stream=stream,
+  )
+```
+
+### JAX integration via `cutlass_call`
+
+The `cutlass.jax.cutlass_call` function wraps a CuTe `@cute.jit` launch function as a JAX custom call, so your CuTe/CUTLASS kernel can be invoked inside `@jax.jit`-compiled code and become part of the XLA computation graph.
+
+High-level flow:
+
+1. Prepare the data (pad + reshape)
+
+* We pad `N` up to a multiple of BLOCK so blocks are full (no partial last block), then reshape the 1-D vector into the 3-D logical tensor shape the kernel expects: `(elems_per_thread, threads_per_block, num_blocks)`.
+* This reshape is free — it only changes the layout/interpretation of memory. No copy happens.
+
+```python
+N = a.shape[0]
+padded = ((N + BLOCK - 1) // BLOCK) * BLOCK
+a_pad = jnp.pad(a, (0, padded - N))
+a_3d = a_pad.reshape(1, BLOCK, padded // BLOCK)
+```
+
+2. Wrap the launcher
+
+* This returns a callable that accepts JAX arrays (DeviceArrays) and will, when executed inside `@jax.jit`, lower to a JAX custom call that launches your compiled CUTLASS kernel.
+* `output_shape_dtype` tells JAX/XLA what the kernel will produce so shapes and dtypes are known for compilation and graph building.
+* `use_static_tensors=True` asks the wrapper to treat the kernel tensors as static (compile-time) shapes where possible — this allows CuTe/CUTLASS to generate specialized, high-performance code for fixed shapes.
+
+```python
+call = cjax.cutlass_call(
+    launch_fn,                    # The @cute.jit function
+    output_shape_dtype=...,       # Shape/dtype of output(s)
+)
+result = call(*input_arrays)      # Pass JAX arrays here
+```
+
+3. Call the wrapped launcher
+
+* Inside a `@jax.jit` function this becomes a custom call node in the XLA graph; at runtime XLA provides a CUDA `CUstream` and device pointers, and the CUTLASS kernel is invoked on that stream.
+* The callable accepts JAX arrays and returns a JAX array containing the kernel output.
+
+```python
+c_3d = call(a_3d, b_3d)
+```
+
+4. Unpack back to 1-D and trim padding
+
+* Convert the logical 3-D result back to a flat 1-D array and drop the padded tail.
+
+```python
+return c_3d.reshape(-1)[:N]
+```
+
+```{code-cell}
+BLOCK = 256  # threads per block for vector add: 256 is a practical default:
+# large enough to expose parallelism, small enough to scale
+# well across different GPUs, and aligned with the hardware’s
+# 32-thread warp execution model.
+
+
+@jax.jit
+def jax_vector_add(a, b):
+  """JAX-compatible vector add using CUTLASS kernel."""
+  N = a.shape[0]
+  padded = ((N + BLOCK - 1) // BLOCK) * BLOCK
+  a_pad = jnp.pad(a, (0, padded - N))
+  b_pad = jnp.pad(b, (0, padded - N))
+  # Reshape to (1, BLOCK, num_blocks) for the CuTe kernel
+  a_3d = a_pad.reshape(1, BLOCK, padded // BLOCK)
+  b_3d = b_pad.reshape(1, BLOCK, padded // BLOCK)
+  call = cjax.cutlass_call(
+      launch_vector_add,
+      output_shape_dtype=jax.ShapeDtypeStruct.like(a_3d),
+      use_static_tensors=True,
+  )
+  c_3d = call(a_3d, b_3d)
+  return c_3d.reshape(-1)[:N]
+```
+
+Let's test our CUTLASS vector add by comparing its output against JAX's built-in `+` operator. We generate two random arrays, run both implementations, and verify the results match element-by-element.
+
+```{code-cell}
+# Test vector add
+N = 1024
+a = jax.random.normal(next(keys), (N,), dtype=jnp.float32)
+b = jax.random.normal(next(keys), (N,), dtype=jnp.float32)
+
+c = jax_vector_add(a, b)
+c_ref = a + b
+
+np.testing.assert_allclose(np.array(c), np.array(c_ref), rtol=1e-5)
+print(f"Vector Add PASSED (N={N})")
+print(f"  Max error: {float(jnp.max(jnp.abs(c - c_ref))):.2e}")
+```
+
+## SAXPY: scalar parameters in kernels
+
+**SAXPY** computes `out[i] = alpha * x[i] + y[i]`. This builds on the vector add pattern and introduces passing a **scalar argument** (`alpha`) alongside tensor arguments.
+
+The SAXPY kernel follows the same structure as vector add — identify the thread, load data into registers, compute, write back — with one addition: a scalar `alpha` parameter.
+
+```python
+def saxpy_kernel(x: cute.Tensor, y: cute.Tensor, out: cute.Tensor, alpha: float):
+```
+
+The signature adds `alpha: float` alongside the tensor arguments. CuTe DSL compiles scalar parameters just like CUDA kernel arguments — they are passed by value and available to every thread.
+
+The body is identical to vector add except for the arithmetic:
+
+```python
+frgO.store(alpha * frgX.load() + frgY.load())
+```
+
+Each thread loads its element of `x` and `y` into register fragments, multiplies `x` by `alpha`, adds `y`, and writes the result to `out`.
+
+```{code-cell}
+@cute.kernel
+def saxpy_kernel(
+    x: cute.Tensor, y: cute.Tensor, out: cute.Tensor, alpha: float
+):
+  """SAXPY: out[i] = alpha * x[i] + y[i]."""
+  tidx, _, _ = cute.arch.thread_idx()
+  bidx, _, _ = cute.arch.block_idx()
+
+  frgX = cute.make_rmem_tensor(cute.size(x, mode=[0]), x.element_type)
+  frgY = cute.make_rmem_tensor(cute.size(y, mode=[0]), y.element_type)
+  frgO = cute.make_rmem_tensor(cute.size(out, mode=[0]), out.element_type)
+
+  cute.autovec_copy(x[None, tidx, bidx], frgX)
+  cute.autovec_copy(y[None, tidx, bidx], frgY)
+  frgO.store(alpha * frgX.load() + frgY.load())
+  cute.autovec_copy(frgO, out[None, tidx, bidx])
+```
+
+The launcher passes `alpha` as a **keyword-only** argument (note the `*` in the signature):
+
+```{code-cell}
+@cute.jit
+def launch_saxpy(
+    stream: cuda.CUstream,
+    x: cute.Tensor,
+    y: cute.Tensor,
+    out: cute.Tensor,
+    *,
+    alpha: float,
+):
+  saxpy_kernel(x, y, out, alpha).launch(
+      grid=[x.shape[-1], 1, 1],
+      block=[x.shape[-2], 1, 1],
+      stream=stream,
+  )
+```
+
+The keyword-only convention matters for `cutlass_call`: positional arguments correspond to JAX tensors (managed by XLA), while keyword arguments are scalar values passed directly to the kernel. In the JAX wrapper below, `alpha=alpha` routes through `cutlass_call` as a kernel kwarg:
+
+```python
+call = cjax.cutlass_call(
+    launch_saxpy,
+    ...,
+    alpha=alpha,    # scalar kwarg → passed to the kernel
+)
+out_3d = call(x_3d, y_3d)  # tensor args → managed by XLA
+```
+
+> **Concept: Static vs dynamic integers**
+>
+> CUTLASS distinguishes between values known at **compile time** (static) and values known only at **runtime** (dynamic). Static integers — like tensor shapes passed with `use_static_tensors=True` or constants like `BLOCK_SIZE` — are baked into the generated CUDA code, letting the compiler unroll loops, optimize memory access patterns, and eliminate branches. Dynamic values like `alpha` are passed as regular kernel arguments and read at runtime. As a rule of thumb: make shapes and tile sizes static, keep data-dependent values dynamic.
+
+Note that `jax_saxpy` uses `@jax.jit(static_argnums=(2,))` to mark `alpha` as a static argument to JAX. This means JAX will recompile the function whenever `alpha` changes — which is fine for a value that rarely varies, and lets the CUTLASS JIT bake the exact `alpha` value into the generated CUDA code.
+
+```{code-cell}
+BLOCK = 256
+
+
+@jax.jit(static_argnums=(2,))
+def jax_saxpy(x, y, alpha=2.0):
+  """JAX-compatible SAXPY using CUTLASS kernel."""
+  N = x.shape[0]
+  padded = ((N + BLOCK - 1) // BLOCK) * BLOCK
+  x_pad = jnp.pad(x, (0, padded - N))
+  y_pad = jnp.pad(y, (0, padded - N))
+  x_3d = x_pad.reshape(1, BLOCK, padded // BLOCK)
+  y_3d = y_pad.reshape(1, BLOCK, padded // BLOCK)
+  call = cjax.cutlass_call(
+      launch_saxpy,
+      output_shape_dtype=jax.ShapeDtypeStruct.like(x_3d),
+      use_static_tensors=True,
+      alpha=alpha,
+  )
+  out_3d = call(x_3d, y_3d)
+  return out_3d.reshape(-1)[:N]
+```
+
+We test the SAXPY kernel with `alpha=2.5`, comparing against the reference computation `alpha * x + y`. The `assert_allclose` check verifies that results match within floating-point tolerance.
+
+```{code-cell}
+# Test SAXPY
+N = 2048
+ALPHA = 2.5
+x = jax.random.normal(next(keys), (N,), dtype=jnp.float32)
+y = jax.random.normal(next(keys), (N,), dtype=jnp.float32)
+
+result = jax_saxpy(x, y, alpha=ALPHA)
+ref = ALPHA * x + y
+
+np.testing.assert_allclose(np.array(result), np.array(ref),
+                           rtol=1e-5, atol=1e-5)
+print(f"SAXPY PASSED (N={N}, alpha={ALPHA})")
+print(f"  Max error: {float(jnp.max(jnp.abs(result - ref))):.2e}")
+```
+
+## Deep learning activations: ReLU and fused bias+ReLU
+
+### ReLU
+
+**ReLU** (`max(0, x)`) is the most widely used activation function in deep learning. It's elementwise and trivially parallel — a perfect custom kernel for ML workloads.
+
+The ReLU kernel uses a different pattern from vector add and SAXPY. Instead of the 3-D tensor approach with register fragments, it uses **flat 1-D indexing** — simpler and equally efficient for elementwise operations.
+
+```python
+tidx, _, _ = cute.arch.thread_idx()
+bidx, _, _ = cute.arch.block_idx()
+bdx, _, _ = cute.arch.block_dim()
+```
+
+A new call appears here: `cute.arch.block_dim()` returns the number of threads per block (set at launch time). Together with `thread_idx` and `block_idx`, it lets each thread compute its unique **global index**:
+
+```python
+idx = bidx * bdx + tidx
+```
+
+For example, if we launch 256 threads per block: thread 3 in block 2 gets `idx = 2 * 256 + 3 = 515`. This is the standard CUDA pattern for mapping threads to 1-D data.
+
+Here we index the tensors directly with `x[idx]` — no register fragments or `autovec_copy`. For simple elementwise operations this flat approach is cleaner. `cutlass.max` is CuTe DSL's built-in max function, and `cutlass.Float32(0.0)` creates a typed zero constant that matches the tensor's element type.
+
+```{code-cell}
+@cute.kernel
+def relu_kernel(x: cute.Tensor, out: cute.Tensor, N: int):
+  """Per-thread kernel: each thread computes ReLU of one element."""
+  tidx, _, _ = cute.arch.thread_idx()
+  bidx, _, _ = cute.arch.block_idx()
+  bdx, _, _ = cute.arch.block_dim()
+
+  idx = bidx * bdx + tidx
+  if idx < N:
+    val = x[idx]
+    out[idx] = cutlass.max(val, cutlass.Float32(0.0))
+```
+
+The launcher computes how many blocks are needed to cover `N` elements:
+
+```{code-cell}
+@cute.jit
+def launch_relu(
+    stream: cuda.CUstream,
+    x: cute.Tensor,
+    out: cute.Tensor,
+    *,
+    N: int,
+):
+  BLOCK_SIZE = 256
+  grid_size = (N + BLOCK_SIZE - 1) // BLOCK_SIZE
+  relu_kernel(x, out, N).launch(
+      grid=[grid_size, 1, 1],
+      block=[BLOCK_SIZE, 1, 1],
+      stream=stream,
+  )
+```
+
+The formula `(N + BLOCK_SIZE - 1) // BLOCK_SIZE` is ceiling division — it ensures we launch enough blocks even when `N` isn't a multiple of 256. The bounds check inside the kernel handles the leftover threads in the last block.
+
+### JAX wrapper: ReLU
+
+The JAX wrapper is simpler than vector add because we skip the 3-D reshape. The kernel works on flat 1-D data directly:
+
+```python
+x_flat = x.reshape(-1)         # flatten to 1-D
+call = cjax.cutlass_call(
+    launch_relu,
+    output_shape_dtype=jax.ShapeDtypeStruct.like(x_flat),
+    N=N,                        # scalar kwarg → bounds check inside kernel
+)
+out_flat = call(x_flat)
+return out_flat.reshape(x.shape)  # restore original shape
+```
+
+`N` is passed as a keyword argument so the kernel knows how many elements are valid. The output is reshaped back to match the input's original shape (works for any dimensionality).
+
+```{code-cell}
+@jax.jit
+def jax_relu(x):
+  """JAX-compatible ReLU using CUTLASS kernel."""
+  N = x.size
+  x_flat = x.reshape(-1)
+  call = cjax.cutlass_call(
+      launch_relu,
+      output_shape_dtype=jax.ShapeDtypeStruct.like(x_flat),
+      N=N,
+  )
+  out_flat = call(x_flat)
+  return out_flat.reshape(x.shape)
+```
+
+We verify the ReLU kernel by comparing against `jax.nn.relu`. Positive values should pass through unchanged, and negative values should become zero.
+
+```{code-cell}
+# Test ReLU
+N = 2048
+x = jax.random.normal(next(keys), (N,), dtype=jnp.float32)
+
+result = jax_relu(x)
+ref = jax.nn.relu(x)
+
+np.testing.assert_allclose(np.array(result), np.array(ref), rtol=1e-5)
+print(f"ReLU PASSED (N={N})")
+print(f"  Max error: {float(jnp.max(jnp.abs(result - ref))):.2e}")
+print(f"  Sample: x[:6]   = {x[:6]}")
+print(f"          out[:6] = {result[:6]}")
+```
+
+### Fused bias+ReLU
+
+**Fused bias+ReLU** computes `max(0, x + bias)` in a single kernel. This demonstrates **kernel fusion** — combining multiple operations into one GPU pass.
+
+Why fusion matters:
+- **Without fusion:** `x + bias` writes an intermediate array to global memory, then `max(0, ...)` reads it back. That's two kernel launches and two round-trips to memory.
+- **With fusion:** one kernel reads `x` and `bias`, computes the sum and the max, and writes the final result. Half the memory traffic, one launch instead of two.
+
+The kernel extends the ReLU pattern with a bias lookup.
+
+The input `x` is a flattened `(batch, width)` matrix. `idx` is the global flat index, and `col = idx % width` recovers which column (feature) this element belongs to, so we can look up the correct bias. This modular indexing pattern is common in fused kernels that combine elementwise and broadcast operations.
+
+```{code-cell}
+@cute.kernel
+def fused_bias_relu_kernel(
+    x: cute.Tensor,
+    bias: cute.Tensor,
+    out: cute.Tensor,
+    N: int,
+    width: int,
+):
+  """Per-thread: out[i] = max(0, x[i] + bias[i % width])."""
+  tidx, _, _ = cute.arch.thread_idx()
+  bidx, _, _ = cute.arch.block_idx()
+  bdx, _, _ = cute.arch.block_dim()
+
+  idx = bidx * bdx + tidx
+  if idx < N:
+    col = idx % width
+    val = x[idx] + bias[col]
+    out[idx] = cutlass.max(val, cutlass.Float32(0.0))
+```
+
+The launcher and JAX wrapper follow the same flat-indexing pattern as ReLU, with `N` (total elements) and `width` (columns) passed as keyword arguments:
+
+```{code-cell}
+@cute.jit
+def launch_fused_bias_relu(
+    stream: cuda.CUstream,
+    x: cute.Tensor,
+    bias: cute.Tensor,
+    out: cute.Tensor,
+    *,
+    N: int,
+    width: int,
+):
+  BLOCK_SIZE = 256
+  grid_size = (N + BLOCK_SIZE - 1) // BLOCK_SIZE
+  fused_bias_relu_kernel(x, bias, out, N, width).launch(
+      grid=[grid_size, 1, 1],
+      block=[BLOCK_SIZE, 1, 1],
+      stream=stream,
+  )
+```
+
+Note that `width` is marked as a static argument in the JAX wrapper via `static_argnums=(2,)`. This means JAX recompiles when the feature dimension changes, allowing CUTLASS to generate specialized code for each width.
+
+```python
+call = cjax.cutlass_call(
+    launch_fused_bias_relu,
+    output_shape_dtype=jax.ShapeDtypeStruct.like(x_flat),
+    N=N, width=width,
+)
+out_flat = call(x_flat, bias)   # two input tensors: x and bias
+```
+
+```{code-cell}
+@jax.jit(static_argnums=(2,))
+def jax_fused_bias_relu(x, bias, width):
+  """JAX-compatible fused Bias+ReLU using CUTLASS kernel.
+
+  Args:
+      x: Input matrix of shape (batch, width), flattened to 1-D for the kernel.
+      bias: Bias vector of shape (width,).
+      width: Number of columns (static, passed as constexpr to the kernel).
+  """
+  N = x.size
+  x_flat = x.reshape(-1)
+  call = cjax.cutlass_call(
+      launch_fused_bias_relu,
+      output_shape_dtype=jax.ShapeDtypeStruct.like(x_flat),
+      N=N,
+      width=width,
+  )
+  out_flat = call(x_flat, bias)
+  return out_flat.reshape(x.shape)
+```
+
+Test the fused kernel against the equivalent two-step JAX computation: add bias, then apply ReLU. The results should match exactly since both paths perform the same arithmetic.
+
+```{code-cell}
+# Test Fused Bias+ReLU
+BATCH, WIDTH = 64, 512
+x = jax.random.normal(next(keys), (BATCH, WIDTH), dtype=jnp.float32)
+bias = jax.random.normal(next(keys), (WIDTH,), dtype=jnp.float32)
+
+result = jax_fused_bias_relu(x, bias, WIDTH)
+ref = jnp.maximum(0, x + bias[None, :])
+
+np.testing.assert_allclose(np.array(result), np.array(ref), rtol=1e-5)
+print(f"Fused Bias+ReLU PASSED (batch={BATCH}, width={WIDTH})")
+print(f"  Max error: {float(jnp.max(jnp.abs(result - ref))):.2e}")
+```
+
+> **Going further:** For a production-grade generalization of elementwise kernels — with optimized TV (thread-value) layouts, vectorized memory access, and support for arbitrary binary operators including custom ops like `leaky_relu` — see NVIDIA's [elementwise_apply_example.py](https://github.com/NVIDIA/cutlass/blob/main/examples/python/CuTeDSL/jax/elementwise_apply_example.py).
+
++++
+
+## Advanced: Tiled GEMM
+
+This demonstrates a general matrix multiply (GEMM) kernel: `D = A @ B` where `A` is `(M, K)`, `B` is `(K, N)`, and `D` is `(M, N)`. Unlike the previous elementwise kernels, GEMM requires cooperation across data dimensions — each output element is a dot product over `K` values.
+
+> **Concept: Tiling**
+>
+> Tiling is CuTe's mechanism for partitioning data into sub-problems that map onto the GPU's execution hierarchy. In a GEMM, we divide the output matrix into `BLOCK_M x BLOCK_N` tiles, each assigned to one thread block. Within a tile, individual threads split the work further. CuTe's tiling operations decompose a layout into an "inner" part (the tile itself) and an "outer" part (which tile we're on). The block index `(bm, bn)` selects the outer coordinate, and thread indices work within the inner tile. This two-level decomposition — partition then index locally — is the fundamental pattern for mapping parallel GPU work to data.
+
+This is our first kernel using a **2-D grid**. Each block is responsible for a `BLOCK_M x BLOCK_N` tile of the output matrix:
+
+```python
+    tidx, _, _ = cute.arch.thread_idx()
+    bm, bn, _ = cute.arch.block_idx()
+    bdx, _, _ = cute.arch.block_dim()
+```
+
+Note `bm, bn, _` — the block index now has two meaningful components: `bm` selects the tile row, `bn` selects the tile column.
+
+Each tile contains `BLOCK_M * BLOCK_N` output elements, but we only have `bdx` (256) threads per block. A **stride loop** distributes the work evenly:
+
+```python
+    for i in cutlass.range(tidx, BLOCK_M * BLOCK_N, bdx):
+```
+
+This loop starts at `tidx` and steps by `bdx` (the block size). For a `64 x 64 = 4096` element tile with 256 threads, each thread computes `4096 / 256 = 16` output elements. `cutlass.range` works like Python's `range()` but generates CUDA loop code.
+
+Within the loop, the flat tile index `i` is converted to 2-D tile-local coordinates, then to global matrix coordinates:
+
+```python
+        row = i // BLOCK_N          # tile-local row
+        col = i % BLOCK_N           # tile-local column
+        m_idx = bm * BLOCK_M + row  # global row in D
+        n_idx = bn * BLOCK_N + col  # global column in D
+```
+
+A bounds check handles edge tiles where the matrix dimensions aren't multiples of the block size:
+
+```python
+        if m_idx < M and n_idx < N:
+```
+
+The inner loop accumulates the dot product over the K dimension:
+
+```python
+            acc = cutlass.Float32(0.0)
+            for k in cutlass.range(K):
+                acc += A[m_idx * K + k] * B[k * N + n_idx]
+            D[m_idx * N + n_idx] = acc
+```
+
+Here we use **manual row-major indexing**: `A[m_idx * K + k]` computes the offset into the flattened 1-D tensor for element `(m_idx, k)` of a row-major matrix with K columns. Similarly, `B[k * N + n_idx]` indexes element `(k, n_idx)`. Production CUTLASS kernels use multi-dimensional CuTe tensor indexing instead, but explicit indexing makes the memory layout visible for learning.
+
+```{code-cell}
+@cute.kernel
+def gemm_kernel(
+    A: cute.Tensor,
+    B: cute.Tensor,
+    D: cute.Tensor,
+    M: int,
+    N: int,
+    K: int,
+    BLOCK_M: int,
+    BLOCK_N: int,
+):
+  """Tiled GEMM: each thread accumulates output elements."""
+  tidx, _, _ = cute.arch.thread_idx()
+  bm, bn, _ = cute.arch.block_idx()
+  bdx, _, _ = cute.arch.block_dim()
+
+  for i in cutlass.range(tidx, BLOCK_M * BLOCK_N, bdx):
+    row = i // BLOCK_N
+    col = i % BLOCK_N
+    m_idx = bm * BLOCK_M + row
+    n_idx = bn * BLOCK_N + col
+    if m_idx < M and n_idx < N:
+      acc = cutlass.Float32(0.0)
+      for k in cutlass.range(K):
+        acc += A[m_idx * K + k] * B[k * N + n_idx]
+      D[m_idx * N + n_idx] = acc
+```
+
+The launcher sets up a 2-D grid matching the tile decomposition:
+
+- `grid=[grid_m, grid_n, 1]` — one block per output tile, arranged in a 2-D grid
+- `block=[256, 1, 1]` — 256 threads per block, each handling multiple elements via the stride loop
+- `M, N, K, BLOCK_M, BLOCK_N` are all passed as compile-time constants to the kernel
+
+```{code-cell}
+@cute.jit
+def launch_gemm(
+    stream: cuda.CUstream,
+    A: cute.Tensor,
+    B: cute.Tensor,
+    D: cute.Tensor,
+    *,
+    M: int,
+    N: int,
+    K: int,
+):
+  BLOCK_M, BLOCK_N = 64, 64
+  grid_m = (M + BLOCK_M - 1) // BLOCK_M
+  grid_n = (N + BLOCK_N - 1) // BLOCK_N
+  gemm_kernel(A, B, D, M, N, K, BLOCK_M, BLOCK_N).launch(
+      grid=[grid_m, grid_n, 1],
+      block=[256, 1, 1],
+      stream=stream,
+  )
+```
+
+The JAX wrapper flattens both input matrices to 1-D (matching the kernel's flat indexing), passes the matrix dimensions as keyword arguments, and reshapes the result:
+
+```{code-cell}
+@jax.jit
+def jax_cutlass_gemm(a, b):
+  """JAX wrapper for the CUTLASS GEMM kernel."""
+  M, K = a.shape
+  _, N = b.shape
+  a_flat = a.reshape(-1)
+  b_flat = b.reshape(-1)
+  call = cjax.cutlass_call(
+      launch_gemm,
+      output_shape_dtype=jax.ShapeDtypeStruct((M * N,), a.dtype),
+      M=M,
+      N=N,
+      K=K,
+  )
+  d_flat = call(a_flat, b_flat)
+  return d_flat.reshape(M, N)
+```
+
+Test the CUTLASS GEMM against JAX's `jnp.matmul`. We use relaxed tolerances (`rtol=1e-2`) because our simple kernel accumulates the K-dimension in a different order than cuBLAS, leading to small floating-point differences that are expected and harmless.
+
+```{code-cell}
+# Test GEMM
+M, N, K = 256, 256, 128
+A = jax.random.normal(next(keys), (M, K), dtype=jnp.float32)
+B = jax.random.normal(next(keys), (K, N), dtype=jnp.float32)
+
+D = jax_cutlass_gemm(A, B)
+D_ref = jnp.matmul(A, B)
+
+np.testing.assert_allclose(np.array(D), np.array(D_ref), rtol=1e-2, atol=2e-2)
+print(f"GEMM PASSED (M={M}, N={N}, K={K})")
+print(f"  Max error: {float(jnp.max(jnp.abs(D - D_ref))):.2e}")
+```
+
+## Performance comparison
+
+Let's compare our CUTLASS GEMM kernel against JAX's built-in `jnp.matmul` (which calls cuBLAS under the hood).
+
+Our simple tiled kernel is **not expected to beat cuBLAS** — cuBLAS is one of the most heavily optimized libraries in existence, with hand-tuned assembly for each GPU architecture. The goal here is to show the integration pattern and demonstrate that custom kernels produce correct results.
+
+CuTe DSL's real value shows up when you need kernels that cuBLAS doesn't provide: custom fusions, non-standard data layouts, mixed-precision schemes, or operations specific to your model architecture.
+
+The benchmark below runs each implementation 20 times (after a warmup pass to trigger JIT compilation) and reports the average wall-clock time. `block_until_ready()` ensures we time the actual GPU execution, not just the asynchronous launch.
+
+```{code-cell}
+import time
+
+M, N, K = 512, 512, 512
+A = jax.random.normal(next(keys), (M, K), dtype=jnp.float32)
+B = jax.random.normal(next(keys), (K, N), dtype=jnp.float32)
+
+# Warmup
+_ = jax_cutlass_gemm(A, B).block_until_ready()
+_ = jnp.matmul(A, B).block_until_ready()
+
+NUM_RUNS = 20
+
+# Time CUTLASS GEMM
+start = time.perf_counter()
+for _ in range(NUM_RUNS):
+  _ = jax_cutlass_gemm(A, B).block_until_ready()
+cutlass_time = (time.perf_counter() - start) / NUM_RUNS
+
+# Time JAX matmul
+start = time.perf_counter()
+for _ in range(NUM_RUNS):
+  _ = jnp.matmul(A, B).block_until_ready()
+jax_time = (time.perf_counter() - start) / NUM_RUNS
+
+print(f"Matrix size: {M}x{N}x{K}")
+print(f"CUTLASS GEMM:  {cutlass_time*1000:.3f} ms")
+print(f"JAX jnp.matmul: {jax_time*1000:.3f} ms")
+print(f"Ratio (CUTLASS / JAX): {cutlass_time / jax_time:.2f}x")
+print()
+print("Note: Our simple tiled kernel is not expected to beat cuBLAS.")
+print("CuTe DSL's value is in specialized kernels cuBLAS doesn't provide.")
+```
+
+## Multi-GPU: sharding CUTLASS kernels via `jax.shard_map`
+
+One of JAX's key strengths is transparent multi-device execution. CUTLASS kernels integrated via `cutlass_call` participate fully in JAX's sharding APIs, so you can distribute work across all available GPUs without modifying the kernel code.
+
+### How sharding works
+
+The key idea: split the data across devices, run the same kernel independently on each device's local shard, and let JAX handle the coordination.
+
+**1. Create a device mesh.** A mesh maps physical devices to named logical axes:
+
+```python
+mesh = jax.make_mesh((num_devices,), ("x",))
+jax.set_mesh(mesh)
+```
+
+This creates a 1-D mesh with `num_devices` devices along an axis called `"x"`. For 8 GPUs, the mesh maps device 0 through device 7 to positions 0–7 along the `"x"` axis.
+
+**2. Define the sharding spec.**
+
+`PartitionSpec` tells JAX how to slice each tensor dimension across the mesh:
+
+```python
+sharding = P(None, None, "x")
+```
+
+For our 3-D tensors with shape `(elems_per_thread, threads_per_block, num_blocks)`:
+- `None` — don't shard the first dimension (elems per thread, stays local)
+- `None` — don't shard the second dimension (threads per block, stays local)
+- `"x"` — shard the third dimension (blocks) across devices on the `"x"` axis
+
+So with 8 devices and 128 total blocks, each device gets a tensor of shape `(1, 256, 16)` — its 16 local blocks.
+
+**3. Create sharded inputs.**
+
+With explicit mesh axes, inputs must already have a layout compatible with the mesh.
+
+We create them directly with the desired sharding:
+
+```python
+a = jax.random.normal(
+    jax.random.key(10),
+    shape,
+    dtype=jnp.float32,
+    out_sharding=sharding,
+)
+b = jax.random.normal(
+    jax.random.key(11),
+    shape,
+    dtype=jnp.float32,
+    out_sharding=sharding,
+)
+```
+
+This produces arrays with sharding P(None, None, "x"), matching the computation.
+
+An equivalent alternative is to create unsharded arrays and place them explicitly:
+
+```python
+from jax.sharding import NamedSharding
+
+named_sharding = NamedSharding(mesh, sharding)
+
+a = jax.random.normal(jax.random.key(10), shape, dtype=jnp.float32)
+b = jax.random.normal(jax.random.key(11), shape, dtype=jnp.float32)
+
+a = jax.device_put(a, named_sharding)
+b = jax.device_put(b, named_sharding)
+```
+
+**4. Use `jax.shard_map` to run per-device code**
+
+With an explicit mesh set via `jax.set_mesh`, `jax.shard_map` can be written concisely:
+
+```python
+@jax.shard_map(out_specs=sharding)
+def sharded_vector_add(a_shard, b_shard):
+    call = cjax.cutlass_call(
+        launch_vector_add,
+        output_shape_dtype=jax.typeof(a_shard),
+        use_static_tensors=True,
+    )
+    return call(a_shard, b_shard)
+```
+
+Inside `sharded_vector_add`, the code is identical to single-GPU — it sees a regular tensor and calls the same CUTLASS kernel. The kernel has no idea it's running on multiple GPUs. JAX handles splitting inputs before the kernel and reassembling outputs afterward.
+
+```{code-cell}
+from jax.sharding import PartitionSpec as P
+
+num_devices = len(jax.devices())
+print(f"Number of devices: {num_devices}")
+
+BLOCK = 256
+
+mesh = jax.make_mesh((num_devices,), ("x",))
+
+# Use `jax.set_mesh` as a context manager so the mesh is scoped to this
+# sharding demo and does not leak into later cells.
+with jax.set_mesh(mesh):
+  # Kernel expects 3-D tensors: (elems_per_thread, threads, blocks)
+  # Shard along the blocks axis (last dim)
+  sharding = P(None, None, "x")
+
+  @jax.shard_map(out_specs=sharding)
+  def sharded_vector_add(a_shard, b_shard):
+    call = cjax.cutlass_call(
+        launch_vector_add,
+        output_shape_dtype=jax.typeof(a_shard),
+        use_static_tensors=True,
+    )
+    return call(a_shard, b_shard)
+
+  # Create 3-D tensors: (1, 256, total_blocks) with total_blocks divisible by device count
+  blocks_per_device = 16
+  total_blocks = blocks_per_device * num_devices
+  shape = (1, BLOCK, total_blocks)
+
+  a_m = jax.random.normal(
+      jax.random.key(10),
+      shape,
+      dtype=jnp.float32,
+      out_sharding=sharding,
+  )
+  b_m = jax.random.normal(
+      jax.random.key(11),
+      shape,
+      dtype=jnp.float32,
+      out_sharding=sharding,
+  )
+
+  print("a_m sharding:", a_m.sharding)
+  print("b_m sharding:", b_m.sharding)
+
+  c_m = sharded_vector_add(a_m, b_m)
+
+  np.testing.assert_allclose(jnp.array(c_m), jnp.array(a_m + b_m), rtol=1e-5)
+  n_total = int(np.prod(shape))
+  print(f"Sharded Vector Add PASSED across {num_devices} devices (N={n_total})")
+```
+
+## Exporting CUTLASS kernels with `jax.export`
+
+So far, every kernel we've written lives inside a `@jax.jit` function — it compiles and runs within the current Python process. But what if you want to **save** a compiled JAX function containing a CUTLASS kernel, ship it to another machine, or load it in a non-Python runtime?
+
+That's what `jax.export` does. It takes a JIT-compiled function and produces a **standalone, serialized artifact** that you can save to disk, send over the network, and reload later — even after the original Python program has exited. Without `jax.export`, JAX functions are only compiled and callable inside the same Python process through `jit`.
+
+With `jax.export` you get:
+
+- **Serialization** — turn your staged JAX computation into a blob that can be stored and reused
+- **Interoperability** — future tools could invoke this from non-Python runtimes (TensorFlow, C++, other frameworks)
+- **Stable HLO output** — useful for ahead-of-time (AOT) compilation, deployment, and cross-platform interoperability
+
+For CUTLASS kernels specifically:
+
+- The exported function includes **custom calls** to CUTLASS kernels — these aren't part of JAX's built-in compilation pipeline. `get_export_disabled_safety_checks()` tells JAX that these custom calls are safe to include in the exported output.
+- With **symbolic shapes**, the exported artifact works for multiple input sizes without recompilation. The kernel doesn't have to be recompiled for new input shapes after export.
+
+### What `jax.export` gives you
+
+- **A StableHLO representation** of the compiled function (the lowered intermediate representation)
+- **Metadata** about the function's inputs and outputs
+- **A serialized blob** you can save to disk or transmit over the network
+- **A callable object** (`rehydrated.call(...)`) that works independently of the code that built it
+
+### How it works
+
+The flow is straightforward:
+
+```python
+from jax import export
+from cutlass.jax import get_export_disabled_safety_checks
+
+# 1. Export the JIT-compiled function
+exported = jax.export.export(f, disabled_checks=get_export_disabled_safety_checks())
+
+# 2. Specialize to a signature (concrete or symbolic shapes) and serialize
+traced = exported(shape_dtype_spec, shape_dtype_spec)
+blob = traced.serialize()
+
+# 3. Later: deserialize and call with real data
+rehydrated = export.deserialize(blob)
+result = rehydrated.call(a, b)
+```
+
+The following example is adapted from [NVIDIA's official export example](https://github.com/NVIDIA/cutlass/blob/main/examples/python/CuTeDSL/jax/cutlass_call_export.py). It exports a function that adds two matrices with a CUTLASS kernel and applies `sigmoid`, then serializes, deserializes, and verifies the result.
+
+```{code-cell}
+from cutlass.jax import get_export_disabled_safety_checks
+from jax import export
+
+
+# Element-wise Add (2-D, flat indexing)
+@cute.kernel
+def elementwise_add_kernel(gA: cute.Tensor, gB: cute.Tensor, gC: cute.Tensor):
+  """Per-thread kernel: 2-D element-wise add using flat indexing."""
+  tidx, _, _ = cute.arch.thread_idx()
+  bidx, _, _ = cute.arch.block_idx()
+  bdim, _, _ = cute.arch.block_dim()
+
+  thread_idx = bidx * bdim + tidx
+
+  m, n = gA.shape
+
+  if thread_idx < m * n:
+
+    ni = thread_idx % n
+    mi = thread_idx // n
+
+    a_val = gA[mi, ni]
+    b_val = gB[mi, ni]
+    gC[mi, ni] = a_val + b_val
+
+
+@cute.jit
+def launch_elementwise_add(
+    stream: cuda.CUstream,
+    mA: cute.Tensor,
+    mB: cute.Tensor,
+    mC: cute.Tensor,
+):
+  num_threads_per_block = 256
+  m, n = mA.shape
+  elementwise_add_kernel(mA, mB, mC).launch(
+      grid=((m * n + num_threads_per_block - 1) // num_threads_per_block, 1, 1),
+      block=(num_threads_per_block, 1, 1),
+      stream=stream,
+  )
+
+
+# Define a function that uses a CUTLASS kernel + JAX ops.
+# We use launch_elementwise_add which accepts 2-D tensors directly
+# with flat indexing — compatible with jax.export's tracing.
+@jax.jit
+def f(a, b):
+  call = cjax.cutlass_call(launch_elementwise_add, output_shape_dtype=a)
+  return jax.nn.sigmoid(call(a, b))
+
+
+# Reference implementation (pure JAX)
+@jax.jit
+def ref_f(a, b):
+  return jax.nn.sigmoid(a + b)
+
+
+# --- Export with concrete shapes ---
+M, N = 512, 256
+export_shape_dtype = jax.ShapeDtypeStruct((M, N), jnp.float32)
+
+print(
+    f"Exporting with input signature: ({export_shape_dtype},"
+    f" {export_shape_dtype})"
+)
+
+# Export the function — get_export_disabled_safety_checks() tells JAX
+# that CUTLASS custom call targets are safe to include
+exported = jax.export.export(
+    f, disabled_checks=get_export_disabled_safety_checks()
+)
+traced = exported(export_shape_dtype, export_shape_dtype)
+
+# Serialize to a byte blob
+blob = traced.serialize()
+print(f"Serialized computation: {len(blob):,} bytes")
+
+# Deserialize and run — this works independently of the original function
+rehydrated = export.deserialize(blob)
+
+a = jax.random.normal(next(keys), (M, N), dtype=jnp.float32)
+b = jax.random.normal(next(keys), (M, N), dtype=jnp.float32)
+
+c = rehydrated.call(a, b)
+c_ref = ref_f(a, b)
+
+np.testing.assert_allclose(np.array(c), np.array(c_ref), rtol=1e-5)
+print(f"Export + Deserialize PASSED (M={M}, N={N})")
+print(f"  Max error: {float(jnp.max(jnp.abs(c - c_ref))):.2e}")
+```
+
+### Exporting with symbolic shapes
+
+With concrete shapes, the exported artifact only works for the exact dimensions it was traced with. **Symbolic shapes** lift this restriction — they let you export once and call with any compatible dimensions, without recompilation.
+
+`export.symbolic_shape("a, b")` creates symbolic dimension variables. The exported function is parameterized over these variables, so the same serialized blob works for `(512, 256)`, `(1024, 1024)`, or any other shape.
+
+```{code-cell}
+# --- Export with symbolic shapes ---
+a_sym, b_sym = export.symbolic_shape("a, b")
+symbolic_shape_dtype = jax.ShapeDtypeStruct((a_sym, b_sym), jnp.float32)
+
+print(
+    f"Exporting with symbolic signature: ({symbolic_shape_dtype},"
+    f" {symbolic_shape_dtype})"
+)
+
+exported_sym = jax.export.export(
+    f, disabled_checks=get_export_disabled_safety_checks()
+)
+traced_sym = exported_sym(symbolic_shape_dtype, symbolic_shape_dtype)
+blob_sym = traced_sym.serialize()
+print(f"Serialized computation: {len(blob_sym):,} bytes")
+
+rehydrated_sym = export.deserialize(blob_sym)
+
+# Call with different shapes — no recompilation needed.
+# The same serialized blob works for any (M, N) where M*N is a
+# multiple of the kernel's block size (256).
+for shape in [(512, 256), (1024, 512), (2048, 1024)]:
+  a = jax.random.normal(next(keys), shape, dtype=jnp.float32)
+  b = jax.random.normal(next(keys), shape, dtype=jnp.float32)
+  c = rehydrated_sym.call(a, b)
+  c_ref = ref_f(a, b)
+  np.testing.assert_allclose(np.array(c), np.array(c_ref), rtol=1e-5)
+  print(f"  Symbolic export PASSED for shape {shape}")
+
+print("All symbolic shape tests passed.")
+```
+
+## Summary
+
+In this notebook you learned to:
+
+- Define GPU kernels in Python with **`@cute.kernel`** and **`@cute.jit`**
+- Bridge CuTe DSL kernels into JAX via **`cutlass.jax.cutlass_call`**
+- Pass both tensor and scalar arguments to custom kernels
+- Write **ReLU** and **Fused Bias+ReLU** activation kernels for deep learning
+- Demonstrate **kernel fusion** — combining multiple ops into a single GPU kernel
+- Build a **tiled GEMM** kernel using CuTe DSL abstractions
+- Distribute CUTLASS kernels across GPUs with **`jax.shard_map`**
+- **Export and serialize** JAX functions containing CUTLASS kernels with **`jax.export`**
+
+CuTe DSL is the right tool when you need direct control over tensor core matrix multiply-accumulate (MMA) instructions, shared memory layouts, and warp-level operations.

--- a/docs/new_docs/401/index.rst
+++ b/docs/new_docs/401/index.rst
@@ -11,7 +11,9 @@ both escape hatches.
 1. :doc:`pallas` — Pallas, JAX's kernel language for writing custom GPU and
    TPU kernels; mostly a map to the extensive Pallas documentation at
    `pallas.jax.dev <https://pallas.jax.dev>`_.
-2. :doc:`ffi` — the foreign function interface: wrapping external C++/CUDA
+2. :doc:`cute-dsl` — writing high-performance GPU kernels with NVIDIA's
+   CuTe DSL and calling them from JAX.
+3. :doc:`ffi` — the foreign function interface: wrapping external C++/CUDA
    code as a JAX operation, and teaching it to work with ``jit``, ``vmap``,
    ``grad``, and sharding.
 
@@ -20,4 +22,5 @@ both escape hatches.
    :maxdepth: 1
 
    pallas
+   cute-dsl
    ffi

--- a/docs/new_docs/501/compilation-cache.md
+++ b/docs/new_docs/501/compilation-cache.md
@@ -1,0 +1,312 @@
+---
+nosearch: true
+---
+
+(jax-501-compilation-cache)=
+# Persistent compilation cache
+
+<!--* freshness: { reviewed: '2024-11-07' } *-->
+
+JAX has an optional disk cache for compiled programs. If enabled, JAX will
+store copies of compiled programs on disk, which can save recompilation time
+when running the same or similar tasks repeatedly.
+
+Note: if the compilation cache is not on a local filesystem,
+[etils](https://pypi.org/project/etils/) needs to be installed.
+
+```python
+pip install etils
+```
+
+```{warning}
+The compilation cache is considered trusted. Do not share a compilation cache with users you do not trust. For example, if you put the
+compilation cache in a directory to which others may write, those users can trigger your JAX process to run arbitrary code. Sharing
+a compilation cache is equivalent to allowing anyone who can write to the cache directory to run code on your machine.
+```
+
+## Usage
+
+### Quick start
+
+```python
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_compilation_cache_dir", "/tmp/jax_cache")
+jax.config.update("jax_persistent_cache_min_entry_size_bytes", -1)
+jax.config.update("jax_persistent_cache_min_compile_time_secs", 0)
+jax.config.update("jax_persistent_cache_enable_xla_caches", "xla_gpu_per_fusion_autotune_cache_dir")
+
+@jax.jit
+def f(x):
+  return x + 1
+
+x = jnp.zeros((2, 2))
+f(x)
+```
+
+### Setting cache directory
+
+The compilation cache is enabled when the
+[cache location](https://github.com/jax-ml/jax/blob/jax-v0.4.26/jax/_src/config.py#L1206)
+is set. This should be done prior to the first compilation. Set the location as
+follows:
+
+(1) Using environment variable
+
+In shell, before running the script:
+
+```sh
+export JAX_COMPILATION_CACHE_DIR="/tmp/jax_cache"
+```
+
+Or on the top of the Python script:
+
+```python
+import os
+os.environ["JAX_COMPILATION_CACHE_DIR"] = "/tmp/jax_cache"
+```
+
+(2) Using `jax.config.update()`
+
+```python
+jax.config.update("jax_compilation_cache_dir", "/tmp/jax_cache")
+```
+
+(3) Using [`set_cache_dir()`](https://github.com/jax-ml/jax/blob/jax-v0.4.26/jax/experimental/compilation_cache/compilation_cache.py#L18)
+
+```python
+from jax.experimental.compilation_cache import compilation_cache as cc
+cc.set_cache_dir("/tmp/jax_cache")
+```
+
+### Caching thresholds
+
+* `jax_persistent_cache_min_compile_time_secs`: A computation will only be
+   written to the persistent cache if the compilation time is longer than
+   the specified value. It is defaulted to 1.0 second.
+
+* `jax_persistent_cache_min_entry_size_bytes`: The minimum size (in bytes)
+   of an entry that will be cached in the persistent compilation cache:
+
+   *  `-1`: disable the size restriction and prevent overrides.
+
+   *  Leave at default (`0`) to allow for overrides. The override will
+      typically ensure that the minimum size is optimal for the file system
+      being used for the cache.
+
+   *  `> 0`: the actual minimum size desired; no overrides.
+
+Note that both criteria need to be satisfied for a function to be cached.
+
+### Additional caching
+
+XLA supports additional caching mechanism which can be enabled alongside JAX's
+persistent compilation cache to further improve recompilation time.
+
+* `jax_persistent_cache_enable_xla_caches`: Possible values:
+
+   * `all`: enable all XLA caching features
+
+   * `none`: don't enable any extra XLA caching features
+
+   * `xla_gpu_kernel_cache_file`: only enable the kernel cache
+
+   * `xla_gpu_per_fusion_autotune_cache_dir`: (default value) only enable the
+      autotuning cache
+
+
+### Google Cloud
+
+When running on Google Cloud, the compilation cache can be placed on a Google
+Cloud Storage (GCS) bucket. We recommend the following configuration:
+
+*  Create the bucket in the same region as where the workload will run.
+
+*  Create the bucket in the same project as the workload’s VM(s). Ensure that
+   permissions are set so that the VM(s) can write to the bucket.
+
+*  There is no need for replication for smaller workloads. Larger workloads
+   could benefit from replication.
+
+*  Use “Standard” for the default storage class for the bucket.
+
+*  Set the soft delete policy to its shortest: 7 days.
+
+*  Set the object lifecycle to the expected duration of the workload run.
+   For example, if the workload is expected to run for 10 days, set the object
+   lifecycle to 10 days. That should cover restarts that occur during the entire
+   run. Use `age` for the lifecycle condition and `Delete` for the action. See
+   [Object Lifecycle Management](https://cloud.google.com/storage/docs/lifecycle)
+   for details. If the object lifecycle is not set, the cache will continue to
+   grow since there is no eviction mechanism implemented.
+
+*  All encryption policies are supported.
+
+It is **recommended** to use
+[Google Cloud Storage Fuse](https://cloud.google.com/storage/docs/cloud-storage-fuse)
+to mount the GCS bucket as a local directory. This is because when running JAX
+in a multi-node setup, multiple nodes might try to write to the cache
+simultaneously, leading to GCS rate-limit errors. GCSFuse handles this by
+ensuring that only one process can write to a file at a time, preventing these
+errors.
+
+To set up GCSFuse, follow instructions for
+[GCE](https://cloud.google.com/storage/docs/cloud-storage-fuse/mount-bucket) or
+[GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-setup).
+For better performance, enable file caching
+([GCE](https://cloud.google.com/storage/docs/cloud-storage-fuse/file-caching) and
+[GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-perf#enable-and-use-file-caching)).
+
+Once GCSFuse is configured, set the JAX cache directory to the GCSFuse mount
+point:
+
+```python
+# Example assuming the GCS bucket is mounted at /gcs/my-bucket
+jax.config.update("jax_compilation_cache_dir", "/gcs/my-bucket/jax-cache")
+```
+
+**Direct GCS access :**
+
+If you choose not to use GCSFuse, you can point the cache directly to a GCS
+bucket.
+
+Assuming that `gs://jax-cache` is the GCS bucket, set cache location as
+follows:
+
+```python
+jax.config.update("jax_compilation_cache_dir", "gs://jax-cache")
+```
+
+## How it works
+
+The cache key is the signature for a compiled function containing the
+following parameters:
+
+*  The computation performed by the function captured by the non-optimized HLO of the JAX function being hashed
+
+*  The jaxlib version
+
+*  Relevant XLA compilation flags
+
+*  Device configuration captured in general, by the number of devices and the topology of the devices.
+   Currently for GPUs, the topology only contains a string representation of the GPU name
+
+*  Compression algorithm used to compress the compiled executable
+
+*  A string produced by `jax._src.cache_key.custom_hook()`. This function can
+   be reassigned to a user-defined function, so that the resulting string can
+   be altered. By default, this function always returns an empty string.
+
+## Caching on multiple nodes
+
+The first time a program is run (the persistent cache is cold / empty) all processes will compile,
+but only the process with rank 0 in the global communication group will write to the persistent cache.
+In subsequent runs, all processes will attempt to read from the persistent cache,
+so it is important for the persistent cache to be in a shared file system (eg: NFS) or remote storage (eg: GFS).
+If the persistent cache is local to rank 0, then all processes except rank 0 will once again compile
+in subsequent runs as a result of a compilation cache miss.
+
+### Pre-compiling multi-node programs on single node
+
+JAX can populate the compilation cache with compiled programs for multiple nodes
+on a single node. Preparing the cache on a single node helps to decrease the costly
+compilation time on a cluster. To compile and run multi-node programs on a single
+node, users can create fake remote devices using
+the `jax_mock_gpu_topology` configuration option.
+
+For instance, the snippet below instructs JAX to mock a cluster with four
+nodes, each node running eight processes with each process attached to one GPU.
+
+```python
+jax.config.update("jax_mock_gpu_topology", "4x8x1")
+```
+
+After populating the cache with this config, users can run the program
+without recompilation on four nodes, eight processes per node,
+one GPU per process.
+
+Important notes:
+
+* The process running the mocked program must have the same amount of GPUs
+  and the same GPU model as the nodes that would use the cache. For instance,
+  a mocked topology `8x4x2` must run in a process with two GPUs.
+
+* When running programs with mocked topology, the results of communications
+  with other nodes are undefined, so the outputs of JAX programs running
+  in mocked environments will likely be incorrect.
+
+
+## Logging cache activity
+
+It can be helpful to examine what exactly is happening with the persistent compilation cache for debugging.
+Here are a few suggestions on how to begin.
+
+Users can enable the logging of related source files by placing
+
+```python
+import os
+os.environ["JAX_DEBUG_LOG_MODULES"] = "jax._src.compiler,jax._src.lru_cache"
+```
+
+on the top of the script. Alternatively, you can change the global jax logging level with
+
+```python
+import os
+os.environ["JAX_LOGGING_LEVEL"] = "DEBUG"
+# or locally with
+jax.config.update("jax_logging_level", "DEBUG")
+```
+
+### Examining cache misses
+
+To examine and understand why there are cache misses, JAX includes a configuration flag that
+enables the logging of all cache misses (including persistent compilation cache misses) with their explanations.
+Although currently, this is only implemented for tracing cache misses, the eventual goal is to
+explain all cache misses. This can be enabled by setting the following configuration.
+
+```python
+jax.config.update("jax_explain_cache_misses", True)
+```
+
+## Pitfalls
+
+* Currently the persistent cache doesn't work with a function that uses primitives that implement their own custom_partitioning.
+  - The HLO of the function contains a pointer to the custom_partitioning callback, and leads to different cache keys for the same computation across runs.
+  - In this situation, caching still proceeds, but a different key is produced every time, making the cache ineffective.
+
+### Working around `custom_partitioning`
+
+As mentioned, the compilation cache doesn't work with a function that is composed of primitives that implement `custom_partitioning`. However, it is possible to use shard_map to circumvent `custom_partitioning` for those primitives that do implement it and make the compilation cache work as expected:
+
+Let's pretend we have a function `F` that implements a layernorm followed by a matrix multiplication using a primitive `LayerNorm` that implements `custom_partitioning`:
+
+```python
+import jax
+
+def F(x1, x2, gamma, beta):
+   ln_out = LayerNorm(x1, gamma, beta)
+   return ln_out @ x2
+```
+If we were to merely compile this function without shard_map, the cache key for `layernorm_matmul_without_shard_map` would be different every time we ran the same code:
+
+```python
+layernorm_matmul_without_shard_map = jax.jit(F, in_shardings=(...), out_sharding=(...))(x1, x2, gamma, beta)
+```
+
+However, if we were to wrap the layernorm primitive in shard_map and define a function G that performs the same computation, the cache key for `layernorm_matmul_with_shard_map` will be the same every time despite `LayerNorm` being implementing `custom_partitioning`:
+
+```python
+import jax
+
+def G(x1, x2, gamma, beta, mesh, ispecs, ospecs):
+   ln_out = jax.shard_map(LayerNorm, mesh=mesh, in_specs=ispecs, out_specs=ospecs, check_vma=False)(x1, x2, gamma, beta)
+   return ln_out @ x2
+
+ispecs = jax.sharding.PartitionSpec(...)
+ospecs = jax.sharding.PartitionSpec(...)
+mesh = jax.sharding.Mesh(...)
+layernorm_matmul_with_shard_map = jax.jit(G, static_argnames=['mesh', 'ispecs', 'ospecs'])(x1, x2, gamma, beta, mesh, ispecs, ospecs)
+```
+
+Note that the primitive that implements `custom_partitioning` must be wrapped in shard_map for this work around. It is insufficient to wrap the outer function `F` in shard_map.

--- a/docs/new_docs/501/data-loading.md
+++ b/docs/new_docs/501/data-loading.md
@@ -1,0 +1,395 @@
+---
+nosearch: true
+---
+
+(jax-501-data-loading)=
+# Distributed data loading
+
+<!--* freshness: { reviewed: '2024-05-16' } *-->
+
+This high-level guide demonstrates how you can perform distributed data loading — when you run JAX in a {doc}`multi-host or multi-process environment <./multiprocess>`, and the data required for the JAX computations is split across the multiple processes. This document covers the overall approach for how to think about distributed data loading, and then how to apply it to *data-parallel* (simpler) and *model-parallel* (more complicated) workloads.
+
+Distributed data loading is usually more efficient (the data is split across processes) but also *more complex* compared with its alternatives, such as: 1) loading the *full global data in a single process*, splitting it up and sending the needed parts to the other processes via RPC; and 2) loading the *full global data in all processes* and only using the needed parts in each process. Loading the full global data is often simpler but more expensive. For example, in machine learning the training loop can get blocked while waiting for data, and additional network bandwidth gets used per each process.
+
+```{note}
+When using distributed data loading, it's important that each device (for example, each GPU or TPU) has access to the input data shard(s) that it needs to run the computation. This is what usually makes distributed data loading more complicated and challenging to implement correctly (compared with the alternatives described above). If the incorrect data shards end up on the wrong devices, the computation can still run without errors, since the computation has no way to know what the input data "should" be. However, the final result will often be incorrect, since the input data was different than intended.
+```
+
+## General approach for loading a `jax.Array`
+
+Consider a case of creating a single {class}`jax.Array` from raw data not produced by JAX. These concepts apply beyond loading batched data records, such as any multi-process {class}`jax.Array` that wasn't directly produced by a JAX computation. Examples include: 1) loading model weights from a checkpoint; or 2) loading a large spatially-sharded image.
+
+Every {class}`jax.Array` has an associated {mod}`~jax.sharding.Sharding`, which describes which shard of the global data is required by each global device. When you create a {class}`jax.Array` from scratch, you also need to create its `Sharding`. This is how JAX can understand how the data is laid out across devices. You can create whatever `Sharding` you want. In practice, you usually pick a `Sharding` based on what kind of parallelism strategy you are implementing (you will learn more about data and model parallelism in more detail later in this guide). You can also pick a `Sharding` based on how the raw data will be produced within each process.
+
+Once you have defined a {mod}`~jax.sharding.Sharding`, you can use {func}`~jax.sharding.Sharding.addressable_devices()` to provide a list of devices needed to load data for within the current process. (Note: The term "addressable devices" is a more general version of "local devices". The goal is to make sure that each process's data loader provides the right data to all of that process' local devices.
+
+### Examples
+
+For example, consider a `(64, 128)` {class}`jax.Array` that you need to shard across 4 processes with 2 devices each (8 devices total). This will result in 8 unique data shards, one for each device. There are many ways to shard this {class}`jax.Array`. You can perform a 1D sharding across the second dimension of the {class}`jax.Array`, giving each device a `(64, 16)` shard, as demonstrated below:
+
+<center>
+
+![8 unique data shards](../../_static/distributed_data_loading/1.svg)
+
+</center>
+
+In the above figure, each data shard has its own color to indicate which process needs to load that shard. For example, you assume process `0`'s 2 devices contain shards `A` and `B`, corresponding to the first `(64, 32)` piece of the global data.
+
+You can pick a different distribution of shards to devices. For example:
+
+<center>
+
+![8 unique data shards - different distribution](../../_static/distributed_data_loading/2.svg)
+
+</center>
+
+Here is another example — a 2D sharding:
+
+<center>
+
+![2D sharding](../../_static/distributed_data_loading/3.svg)
+
+</center>
+
+However the {class}`jax.Array` happens to be sharded, you have to make sure that each process's data loader is provided with/loads the required shard(s) of the global data. There are several high-level methods for achieving this: 1) load the global data in each process; 2) use a per-device data pipeline; 3) use a consolidated per-process data pipeline; 4) load data in some convenient way and then reshard inside computation.
+
+### Option 1: Load the global data in each process
+
+<center>
+
+![Loading the global data in each process](../../_static/distributed_data_loading/4.svg)
+
+</center>
+
+Using this option, each process:
+
+1) Loads the full value needed; and
+2) Transfers only the needed shards to that process's local devices.
+
+This is not an efficient approach to distributed data loading, since each process will throw away the data not needed by its local devices, and the total data ingested can be higher than necessary. But this option works and is relatively simple to implement, while the performance overhead may be acceptable for certain workloads (for example, if the global data is small).
+
+### Option 2: Use a per-device data pipeline
+
+<center>
+
+![Using a per-device data pipeline](../../_static/distributed_data_loading/5.svg)
+
+</center>
+
+In this option, each process sets up a data loader for each of its local devices (that is, each device gets its own data loader for just the data shard it requires).
+
+This is efficient in terms of the data loaded. It can also sometimes be simpler to consider each device independently rather than all of a process's local devices at once (refer to _Option 3: Use a consolidated per-process data pipeline_ below). However, having multiple concurrent data loaders can sometimes cause performance issues.
+
+### Option 3: Use a consolidated per-process data pipeline
+
+<center>
+
+![Using a consolidated per-process data pipeline](../../_static/distributed_data_loading/6.svg)
+
+</center>
+
+If you choose this option, each process:
+
+1) Sets up a single data loader that loads the data required for all of its local devices; and then
+2) Shards the local data before transferring to each local device.
+
+This is the *most efficient way to do distributed loading*. However, it's also the *most complex*, since logic is needed both to figure out which data is needed by each device, and to create a single data loading that loads only all of that data (and, ideally, no other extra data).
+
+### Option 4: Load data in some convenient way, reshard inside computation
+
+<center>
+
+![Loading  data in some convenient way, reshard inside computation](../../_static/distributed_data_loading/7.svg)
+
+</center>
+
+This option is more challenging to explain, but often easier to implement than the above options (from 1 to 3).
+
+Imagine a scenario where it's difficult or rather impossible to set up data loaders that load exactly the data you need, either for per-device or per-process loaders. However, it may still be possible to set up a data loader per process that loads `1 / num_processes` of the data, just not in the right sharding.
+
+Then, continuing with your 2D example sharding from before, assume it is easier for each process to load a single column of the data:
+
+Then, you can create a {class}`jax.Array` with a {mod}`~jax.sharding.Sharding` representing the per-column data, pass that directly into the computation, and use {func}`jax.lax.with_sharding_constraint` to immediately reshard the column-sharded input to the desired sharding. And since the data is resharded inside the computation, it will be resharded over the accelerator communication links (for example, TPU ICI or NVLink).
+
+This Option 4 has similar benefits to Option 3 (_Use a consolidated per-process data pipeline_):
+
+- Each process still has a single data loader; and
+- The global data is loaded exactly once across all processes; and
+- The global data has the additional benefit of offering more flexibility in how the data is loaded.
+
+However, this approach uses accelerator interconnect bandwidth to perform the resharding, which may slow down certain workloads. Option 4 also requires that the input data be expressed as a separate `Sharding`, in addition to the target `Sharding`.
+
+## Replication
+
+Replication describes a process where multiple devices have the same data shard. The general options mentioned above (Options 1 through 4) still work with replication. The only difference is that some processes may end up loading the same data shards. This section describes full replication and partial replication.
+
+###  Full replication
+
+**Full replication** is a process where all devices have a full copy of the data (that is, the data "shard" is the entire array value).
+
+In the below example, since there are 8 devices in total (2 per process), you will end up with 8 copies of the full data. Each copy of the data is unsharded, that is the copy lives on a single device:
+
+<center>
+
+![Full replication](../../_static/distributed_data_loading/8.svg)
+
+</center>
+
+###  Partial replication
+
+**Partial replication** describes a process where there are multiple copies of the data, and each copy is sharded across multiple devices. For a given array value, there are generally many possible ways to perform partial replication (Note: There is always a single fully-replicated {mod}`~jax.sharding.Sharding` for a given array shape).
+
+Below are two possible examples.
+
+In the first example below, each copy is sharded across the two local devices of a process, for a total of 4 copies. This means that each process will need to load the full global data, since its local devices will have a full copy of the data.
+
+<center>
+
+![Partial replication - example 1](../../_static/distributed_data_loading/9.svg)
+
+</center>
+
+In the second example below, each copy is still sharded across two devices, but each device pair is spread across two different processes. Process `0` (pink) and process `1` (yellow) both need to load just the first row of the data, and process `2` (green) and process `3` (blue) both need to load just the second row of the data:
+
+<center>
+
+![Partial replication - example 2](../../_static/distributed_data_loading/10.svg)
+
+</center>
+
+Now that you've gone over the high-level options for creating a {class}`jax.Array`, let's apply them to data loading for ML applications.
+
+## Data parallelism
+
+In *pure data parallelism* (without model parallelism):
+
+- You replicate the model on each device; and
+- Each model replica (that is, each device) receives a different per-replica batch of data.
+
+<center>
+
+![Data parallelism - example 1](../../_static/distributed_data_loading/11.svg)
+
+</center>
+
+When representing the input data as a single {class}`jax.Array`, the Array contains the data across all replicas for this step (this is called *global batch*), with each shard of the {class}`jax.Array` containing a single per-replica batch. You can represent this as a 1D sharding across all devices (check the example below) — in other words, the global batch is composed of all the per-replica batches concatenated together across the batch axis.
+
+<center>
+
+![Data parallelism - example 2](../../_static/distributed_data_loading/12.svg)
+
+</center>
+
+Applying this framework, you may conclude that process `0` should get the first quarter (2 out of 8) of the global batch, while process `1` should get the second, and so on.
+
+But how can you know what the first quarter is? And how do you make sure process `0` gets the first quarter? Luckily, there's a very important trick about data parallelism that means you don't have to answer these questions and makes the whole setup simpler.
+
+## Important trick about data parallelism
+
+The trick is you don't need to care which per-replica batch lands on which replica. Therefore, it doesn't matter which process loads a batch. The reason is that since each device corresponds to a model replica performing the same thing, it doesn't matter which device gets which per-replica batch within the global batch.
+
+What this means is that you are free to rearrange the per-replica batches within the global batch. In other words, you are free to randomize which data shard each device gets.
+
+For example:
+
+<center>
+
+![Data parallelism - example 3](../../_static/distributed_data_loading/13.svg)
+
+</center>
+
+Usually, rearranging the data shards of a {class}`jax.Array`, as demonstrated above, is not a good idea – you're effectively permuting the value of the {class}`jax.Array`! However, for data parallelism, the global batch order isn't meaningful, and you are free to rearrange the per-replica batches in the global batch, as already mentioned before.
+
+This simplifies data loading because it means each device just needs an independent stream of per-replica batches, which can be easily implemented in most data loaders by creating an independent pipeline per process and chunking the resulting per-process batch into per-replica batches.
+
+<center>
+
+![Data parallelism - example 4](../../_static/distributed_data_loading/14.svg)
+
+</center>
+
+This is an instance of the _Option 2: Consolidated per-process data pipeline_. You can also use other options (such as 0, 1 and 3, which are covered earlier in this document), but this one is relatively simple and efficient.
+
+Here's an example of how to implement this setup using tf.data:
+
+```python
+import jax
+import tensorflow as tf
+import numpy as np
+
+################################################################################
+# Step 1: setup the Dataset for pure data parallelism (do once)
+################################################################################
+# Fake example data (replace with your Dataset)
+ds = tf.data.Dataset.from_tensor_slices(
+    [np.ones((16, 3)) * i for i in range(100)])
+
+ds = ds.shard(num_shards=jax.process_count(), index=jax.process_index())
+
+################################################################################
+# Step 2: create a jax.Array of per-replica batches from the per-process batch
+# produced from the Dataset (repeat every step). This can be used with batches
+# produced by different data loaders as well!
+################################################################################
+# Grab just the first batch from the Dataset for this example
+per_process_batch = ds.as_numpy_iterator().next()
+
+mesh = jax.make_mesh((jax.device_count(),), ('batch',))
+sharding = jax.NamedSharding(mesh, jax.sharding.PartitionSpec('batch'))
+global_batch_array = jax.make_array_from_process_local_data(
+    sharding, per_process_batch)
+```
+
+## Data + model parallelism
+
+In **model parallelism** you shard each model replica across multiple devices. If you use **pure model parallelism** (without data parallelism):
+
+- There's just one model replica sharded across all devices; and
+- The data is (usually) fully replicated across all devices.
+
+This guide considers a case where you use **both data and model parallelism**:
+
+- You shard each of the multiple model replicas over multiple devices; and
+- You partially replicate the data over each model replica — each device in the same model replica gets the same per-replica batch, and devices across model replicas get different per-replica batches.
+
+### Model parallelism within a process
+
+For the purposes of data loading, the simplest approach can be to shard each model replica within the local devices of a single process.
+
+For this example, let's switch to 2 processes with 4 devices each (instead of 4 processes with 2 devices each). Consider a scenario where each model replica is sharded over the 2 local devices of a single process. This results in 2 model replicas per process and 4 model replicas total, as demonstrated below:
+
+<center>
+
+![Data and model parallelism - example 1](../../_static/distributed_data_loading/15.svg)
+
+</center>
+
+Here, once again, the input data is represented as a single {class}`jax.Array` with a 1D sharding where each shard is a per-replica batch with an exception:
+
+- Unlike in the pure data parallelism case, you introduce partial replication and make 2 copies of the 1D-sharded global batch.
+- This is because each model replica is composed of 2 devices that each need a copy of the per-replica batch.
+
+<center>
+
+![Data and model parallelism - example 2](../../_static/distributed_data_loading/16.svg)
+
+</center>
+
+Keeping each model replica within a single process can make things simpler because you can reuse the pure data parallelism setup described above, except you also need to replicate the per-replica batches:
+
+<center>
+
+![Data and model parallelism - example 3](../../_static/distributed_data_loading/17.svg)
+
+</center>
+
+```{note}
+_It's also very important to replicate the per-replica batches to the correct devices!_ While the very important trick about data parallelism means you don't care which batch ends up on which replica, *you do care that a single replica only gets a single batch*.
+```
+
+For example, this is OK:
+
+<center>
+
+![Data and model parallelism - example 4](../../_static/distributed_data_loading/18.svg)
+
+</center>
+
+However, if you’re not careful about which local device you load each batch onto, you may accidentally create unreplicated data, even though the {mod}`~jax.sharding.Sharding` (and the parallelism strategy) says the data is replicated:
+
+<center>
+
+![Data and model parallelism - example 4](../../_static/distributed_data_loading/19.svg)
+
+</center>
+
+JAX will raise an error if you accidentally create a {class}`jax.Array` with unreplicated data that should be replicated within a single process (this isn't always true for model parallelism across processes though; see the next section).
+
+Here's an example of how to implement per-process model parallelism and data parallelism using `tf.data`:
+
+```python
+import jax
+import tensorflow as tf
+import numpy as np
+
+################################################################################
+# Step 1: Set up the Dataset with a different data shard per-process (do once)
+#         (same as for pure data parallelism)
+################################################################################
+# Fake example data (replace with your Dataset)
+per_process_batches = [np.ones((16, 3)) * i for i in range(100)]
+ds = tf.data.Dataset.from_tensor_slices(per_process_batches)
+
+ds = ds.shard(num_shards=jax.process_count(), index=jax.process_index())
+
+################################################################################
+# Step 2: Create a jax.Array of per-replica batches from the per-process batch
+# produced from the Dataset (repeat every step)
+################################################################################
+# Grab just the first batch from the Dataset for this example
+per_process_batch = ds.as_numpy_iterator().next()
+
+num_model_replicas_per_process = 2 # set according to your parallelism strategy
+num_model_replicas_total = num_model_replicas_per_process * jax.process_count()
+
+# Create an example `Mesh` for per-process data parallelism. Make sure all devices
+# are grouped by process, and then resize so each row is a model replica.
+mesh_devices = np.array([jax.local_devices(process_idx)
+                         for process_idx in range(jax.process_count())])
+mesh_devices = mesh_devices.reshape(num_model_replicas_total, -1)
+# Double check that each replica's devices are on a single process.
+for replica_devices in mesh_devices:
+  num_processes = len(set(d.process_index for d in replica_devices))
+  assert num_processes == 1
+mesh = jax.sharding.Mesh(mesh_devices, ["model_replicas", "data_parallelism"])
+
+# Shard the data across model replicas. You don't shard across the
+# data_parallelism mesh axis, meaning each per-replica shard will be replicated
+# across that axis.
+sharding = jax.sharding.NamedSharding(
+    mesh, jax.sharding.PartitionSpec("model_replicas"))
+
+global_batch_array = jax.make_array_from_process_local_data(
+    sharding, per_process_batch)
+```
+
+### Model parallelism across processes
+
+It can get more interesting when model replicas are spread across processes, either:
+
+- Because a single replica can't fit within a process; or
+- Because the device assignment just isn't set up that way.
+
+For example, going back to the previous setup of 4 processes with 2 devices each, if you assign devices to replicas like so:
+
+<center>
+
+![Model parallelism across processes - example 1](../../_static/distributed_data_loading/20.svg)
+
+</center>
+
+This is the same parallelism strategy as the previous per-process model parallelism example – 4 model replicas each sharded across 2 devices. The only difference is the device assignment – each replica's two devices are split across different processes, and each process is only responsible for one copy of each per-replica batch (but for two replicas).
+
+Splitting the model replicas across processes like this may seem like an arbitrary and unnecessary thing to do (and in this example it arguably is), but actual deployments may end up with this kind of device assignment to best take advantage of the communication links between devices.
+
+Data loading now becomes more complicated because some extra coordination is required across processes. In the pure data parallelism and per-process model parallelism cases, it was only important that each process loaded a unique data stream. Now certain processes must load the same data, and some must load different data. In the above example, processes `0` and `2` (in colors pink and green, respectively) must load the same 2 per-replica batches, and processes `1` and `3` (colors yellow and blue, respectively) must also  load the same 2 per-replica batches (but different from process `0` and `2`'s batches).
+
+Furthermore, it's important that each process doesn't mix up its 2 per-replica batches. While you don't care which batch lands on which replica (the very important trick about data parallelism), you need to care that all the devices in a replica get the same batch. For example, this would be bad:
+
+<center>
+
+![Model parallelism across processes - example 2](../../_static/distributed_data_loading/21.svg)
+
+</center>
+
+```{note}
+As of August 2023, JAX cannot detect if {class}`jax.Array` shards across processes are supposed to be replicated but aren't, and will produce wrong results when the computation is run. So be careful not to do this!
+```
+
+To get the correct per-replica batch on each device, you need to represent the global input data as the following {class}`jax.Array`:
+
+<center>
+
+![Model parallelism across processes - example 3](../../_static/distributed_data_loading/22.svg)
+
+</center>

--- a/docs/new_docs/501/export.md
+++ b/docs/new_docs/501/export.md
@@ -1,0 +1,847 @@
+---
+nosearch: true
+---
+
+(jax-501-export)=
+# Exporting and serializing staged-out computations
+
+<!--* freshness: { owner: "necula" reviewed: "2024-06-26" } *-->
+
+The {ref}`jax-201-aot` APIs produce
+objects that can be used for debugging or for compilation and
+execution in the same process.
+Sometimes you want to serialize a lowered JAX function for
+compilation and execution in a separate process, perhaps
+at a later time. This would allow you to:
+
+  * compile and execute the function in another process or machine
+    without requiring access to the JAX program,
+    and without having to repeat the staging-out and lowering, e.g.,
+    in an inference system.
+  * trace and lower a function on a machine that does not have access
+    to the accelerator for which you want to later compile and execute
+    the function.
+  * archive a snapshot of a JAX function, e.g., to be able to
+    reproduce later your results. **Note:** check out the [compatibility
+    guarantees](#compatibility-guarantees) for this use case.
+
+For more details see the {mod}`jax.export` API reference.
+
+Here is an example:
+
+```python
+>>> import re
+>>> import numpy as np
+>>> import jax
+>>> from jax import export
+
+>>> def f(x): return 2 * x * x
+
+
+>>> exported: export.Exported = export.export(jax.jit(f))(
+...    jax.ShapeDtypeStruct((), np.float32))
+
+>>> # You can inspect the Exported object
+>>> print(re.search(r".*@main.*", exported.mlir_module()).group(0))
+  func.func public @main(%arg0: tensor<f32> loc("x")) -> (tensor<f32> {jax.result_info = "result"}) {
+
+>>> # And you can serialize the Exported to a bytearray.
+>>> serialized: bytearray = exported.serialize()
+
+>>> # The serialized function can later be rehydrated and called from
+>>> # another JAX computation, possibly in another process.
+>>> rehydrated_exp: export.Exported = export.deserialize(serialized)
+
+>>> def callee(y):
+...  return 3. * rehydrated_exp.call(y * 4.)
+
+>>> callee(1.)
+Array(96., dtype=float32)
+
+```
+
+Serialization is broken down into two stages:
+   1. exporting to produce an {class}`jax.export.Exported` object that contains
+     the StableHLO for the lowered function along with the metadata necessary to
+     call it from another JAX function. We have plans to add code to generate
+     `Exported` objects from TensorFlow, and to use `Exported` objects from
+     TensorFlow and PyTorch.
+   2. the actual serialization to a byte array using the flatbuffers format.
+     See {ref}`jax2tf` for
+     an alternative serialization to TensorFlow graph that can be used
+     for interoperation with TensorFlow.
+
+**WARNING**: The serialized bytearray must be trusted input. If you execute it
+after deserialization, it may execute any custom call registered in the jaxlib.
+
+## Support for reverse-mode AD
+
+Serialization can optionally support higher-order reverse-mode AD. This is done
+by serializing the {func}`jax.vjp` of the primal function along with the primal
+function,
+up to a user-specified order (default is 0, meaning that the rehydrated
+function cannot be differentiated):
+
+```python
+>>> import jax
+>>> from jax import export
+>>> from typing import Callable
+
+>>> def f(x): return 7 * x * x * x
+
+>>> # Serialize 3 levels of VJP along with the primal function
+>>> blob: bytearray = export.export(jax.jit(f))(1.).serialize(vjp_order=3)
+>>> rehydrated_f: Callable = export.deserialize(blob).call
+
+>>> rehydrated_f(0.1)  # 7 * 0.1^3
+Array(0.007, dtype=float32)
+
+>>> jax.grad(rehydrated_f)(0.1)  # 7*3 * 0.1^2
+Array(0.21000001, dtype=float32)
+
+>>> jax.grad(jax.grad(rehydrated_f))(0.1)  # 7*3*2 * 0.1
+Array(4.2, dtype=float32)
+
+>>> jax.grad(jax.grad(jax.grad(rehydrated_f)))(0.1)  # 7*3*2
+Array(42., dtype=float32)
+
+>>> jax.grad(jax.grad(jax.grad(jax.grad(rehydrated_f))))(0.1)  # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+ValueError: No VJP is available
+
+```
+
+Note that the VJP function is computed lazily while serializing,
+when the JAX program is still available.
+This means that it respects all features of JAX VJP,
+e.g., {func}`jax.custom_vjp` and {func}`jax.remat`.
+
+Note that the rehydrated function does not support any other
+transformations, e.g., forward-mode AD (jvp), or {func}`jax.vmap`.
+
+## Compatibility guarantees
+
+When you use the {class}`jax.export` module, you get the following export
+compatibility guarantees:
+A JAX exported and serialized artifact supports `.deserialize` and `.call`
+(i.e. compilation and execution) by a compiler and JAX runtime system that are:
+
+  * **up to 6 months newer** than the version of JAX used for exporting
+  (we say that JAX export offers **6 months backward compatibility**).
+  This is useful if you want to archive the exported artifact to be compiled and
+  executed later.
+  * **up to 3 weeks older** than the version of JAX used for exporting
+  (we say that JAX export offers **3 weeks forward compatibility**).
+  This is useful if you want to compile and run an exported artifact with a
+  consumer that was built and deployed before the export, e.g.,
+  an inference system that is already deployed when the exporting is done.
+
+(The particular compatibility window lengths are the same that JAX
+[promises for jax2tf](https://github.com/jax-ml/jax/blob/main/jax/experimental/jax2tf/README.md#usage-saved-model),
+and are based on [TensorFlow Compatibility](https://www.tensorflow.org/guide/versions#graph_and_checkpoint_compatibility_when_extending_tensorflow).
+The terminology “backward compatibility” is from the perspective of the
+consumer, e.g., the inference system.)
+
+What **matters is when the exporting and consuming components were built**,
+not the time when the exporting and the compilation happen.
+To reduce chances of incompatibility, internal JAX users should **rebuild and
+redeploy consumer systems as frequently as possible**.
+
+External users should export for archival **with the latest released version of
+jaxlib**.
+
+The compatibility guarantees do not apply if you bypass the `jax.export` APIs
+to obtain the StableHLO code (e.g., by `jax.jit(f).lower(1.).compiler_ir()`)
+and then try to use it with a different build of JAX or jaxlib.
+Unlike direct lowering, the {class}`jax.export` module uses the
+[portable-artifact feature of StableHLO](https://github.com/openxla/stablehlo/blob/main/docs/compatibility.md)
+to deal with the possible evolution of the StableHLO opset.
+
+### Compatibility guarantees for custom calls
+
+Furthermore, the raw StableHLO may contain custom calls referencing C++
+functions.
+JAX uses custom calls for lowering of a small number of primitives,
+e.g., linear algebra primitives, sharding annotations, or Pallas kernels.
+These do not fall under the compatibility guarantees for StableHLO.
+The C++ implementations of these functions change rarely, but they can change.
+
+In order to ensure forward compatibility, when we change the JAX lowering rules
+to use a new custom call target, JAX will refrain for 3 weeks to use the new
+target. To use the latest lowering rules, you can pass the
+`--jax_export_ignore_forward_compatibility=1` configuration flag
+or the `JAX_EXPORT_IGNORE_FORWARD_COMPATIBILITY=1` environment variable.
+
+Only a subset of custom calls are guaranteed stable and have
+compatibility guarantees ([see list](https://github.com/search?q=repo%3Ajax-ml%2Fjax++%22_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE+%3D%22+path%3A_export.py&amp%3Btype=code&type=code)).
+We continuously
+add more custom call targets to the allowed list along with backwards
+compatibility tests. If you try to serialize
+code that invokes other custom call targets you will get an error
+during exporting.
+
+If you want to disable this safety check for a specific custom call,
+e.g., with target `my_target`, you can add
+`export.DisabledSafetyCheck.custom_call("my_target")` to the
+`disabled_checks` parameter of the `export` method.
+
+Alternatively, `export.DisabledSafetyCheck.custom_call("ALL")` can be used to
+disable the check for all custom calls, this should only be used when export
+compatibility is not needed.
+
+The following example shows how to disable the check for a specific custom call:
+
+```python
+>>> import jax
+>>> from jax import export
+>>> from jax import lax
+>>> from jax._src import core
+>>> from jax._src.interpreters import mlir
+>>> # Define a new primitive backed by a custom call
+>>> new_prim = core.Primitive("new_prim")
+>>> _ = new_prim.def_abstract_eval(lambda x: x)
+>>> _ = mlir.register_lowering(new_prim, lambda ctx, o: mlir.custom_call("my_new_prim", operands=[o], result_types=[o.type]).results)
+>>> print(jax.jit(new_prim.bind).lower(1.).compiler_ir())
+module @jit_bind attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<f32>) -> (tensor<f32> {jax.result_info = "result"}) {
+    %0 = stablehlo.custom_call @my_new_prim(%arg0) {api_version = 2 : i32, backend_config = ""} : (tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
+  }
+}
+
+>>> # If we try to export, we get an error
+>>> export.export(jax.jit(new_prim.bind))(1.)  # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+ValueError: Cannot serialize code with custom calls whose targets have no compatibility guarantees: my_new_bind
+
+>>> # We can avoid the error if we pass a `DisabledSafetyCheck.custom_call`
+>>> exp = export.export(
+...    jax.jit(new_prim.bind),
+...    disabled_checks=[export.DisabledSafetyCheck.custom_call("my_new_prim")])(1.)
+
+```
+
+See {ref}`export_ensuring_compat` for developer information regarding
+ensuring compatibility.
+
+## Cross-platform and multi-platform export
+
+JAX lowering is platform specific for a small number of JAX primitives.
+By default, the code is lowered and exported for the accelerator
+present on the exporting machine:
+
+```python
+>>> from jax import export
+>>> export.default_export_platform()
+'cpu'
+
+```
+
+There is a safety check that will raise an error when trying to compile
+an `Exported` object on a machine that does not have the accelerator
+for which the code was exported.
+
+You can specify explicitly for what platforms the code should be exported.
+This allows you to specify a different accelerator than you have
+available at export time,
+and it even allows you to specify multi-platform export to
+obtain an `Exported` object that can be compiled and executed
+on multiple platforms.
+
+```python
+>>> import jax
+>>> from jax import export
+>>> from jax import lax
+
+>>> # You can specify the export platform, e.g., `tpu`, `cpu`, `cuda`, `rocm`
+>>> # even if the current machine does not have that accelerator.
+>>> exp = export.export(jax.jit(lax.cos), platforms=['tpu'])(1.)
+
+>>> # But you will get an error if you try to compile `exp`
+>>> # on a machine that does not have TPUs.
+>>> exp.call(1.)  # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+ValueError: Function 'cos' was lowered for platforms '('tpu',)' but it is used on '('cpu',)'.
+
+>>> # We can avoid the error if we pass a `DisabledSafetyCheck.platform`
+>>> # parameter to `export`, e.g., because you have reasons to believe
+>>> # that the code lowered will run adequately on the current
+>>> # compilation platform (which is the case for `cos` in this
+>>> # example):
+>>> exp_unsafe = export.export(jax.jit(lax.cos),
+...    platforms=['tpu'],
+...    disabled_checks=[export.DisabledSafetyCheck.platform()])(1.)
+
+>>> exp_unsafe.call(1.)
+Array(0.5403023, dtype=float32, weak_type=True)
+
+# and similarly with multi-platform lowering
+>>> exp_multi = export.export(jax.jit(lax.cos),
+...    platforms=['tpu', 'cpu', 'cuda'])(1.)
+>>> exp_multi.call(1.)
+Array(0.5403023, dtype=float32, weak_type=True)
+
+```
+
+For multi-platform export, the StableHLO will contain multiple
+lowerings but only for those primitives that require it, so the
+resulting module size should be only marginally larger than the
+size of a module with default export.
+As an extreme case, when serializing a module without any
+primitives with platform-specific lowering, you will get
+the same StableHLO as for the single-platform export.
+
+```python
+>>> import jax
+>>> from jax import export
+>>> from jax import lax
+>>> # A largish function
+>>> def f(x):
+...   for i in range(1000):
+...     x = jnp.cos(x)
+...   return x
+
+>>> exp_single = export.export(jax.jit(f))(1.)
+>>> len(exp_single.mlir_module_serialized)  # doctest: +SKIP
+9220
+
+>>> exp_multi = export.export(jax.jit(f),
+...                           platforms=["cpu", "tpu", "cuda"])(1.)
+>>> len(exp_multi.mlir_module_serialized)  # doctest: +SKIP
+9282
+
+```
+
+## Shape polymorphic export
+
+When used in JIT mode, JAX will trace and lower a function separately
+for each combination of input shapes. When exporting, it is possible
+in some cases to use dimension variables for some input dimensions
+in order to obtain an exported artifact that can be used with multiple
+combinations of input shapes.
+
+See the {ref}`jax-501-shape-poly` documentation.
+
+## Device-polymorphic export
+
+An exported artifact may contain sharding annotations for inputs,
+outputs and for some intermediates, but these annotations do not refer
+directly to the actual physical devices that existed at exporting time.
+Instead, the sharding annotations refer to logical devices. This
+means that you can compile and run the exported artifacts on different
+physical devices that were used for exporting.
+
+The cleanest way to achieve a device-polymorphic export is to
+use shardings constructed with a `jax.sharding.AbstractMesh`,
+which contains only the mesh shape and axis names. But,
+you can achieve the same results if you use shardings
+constructed for a mesh with concrete devices, since the actual
+devices in the mesh are ignored for tracing and lowering:
+
+```python
+>>> import jax
+>>> from jax import export
+>>> from jax.sharding import AbstractMesh, Mesh, NamedSharding
+>>> from jax.sharding import PartitionSpec as P
+>>>
+>>> # Use an AbstractMesh for exporting
+>>> export_mesh = AbstractMesh((4,), ("a",))
+
+>>> def f(x):
+...   return x.T
+
+>>> exp = export.export(jax.jit(f))(
+...    jax.ShapeDtypeStruct((32,), dtype=np.int32,
+...                         sharding=NamedSharding(export_mesh, P("a"))))
+
+>>> # `exp` knows for how many devices it was exported.
+>>> exp.nr_devices
+4
+
+>>> # and it knows the shardings for the inputs. These will be applied
+>>> # when the exported is called.
+>>> exp.in_shardings_jax(export_mesh)
+(NamedSharding(mesh=AbstractMesh('a': 4, axis_types=(Auto,)), spec=P('a',)),)
+
+>>> # You can also use a concrete set of devices for exporting
+>>> concrete_devices = jax.local_devices()[:4]
+>>> concrete_mesh = Mesh(concrete_devices, ("a",))
+>>> exp2 = export.export(jax.jit(f))(
+...    jax.ShapeDtypeStruct((32,), dtype=np.int32,
+...                         sharding=NamedSharding(concrete_mesh, P("a"))))
+
+>>> # When you call an Exported, you must use a concrete set of devices
+>>> arg = jax.device_put(jnp.arange(8 * 4),
+...                      NamedSharding(concrete_mesh, P("a")))
+
+>>> res1 = exp.call(arg)
+>>> # Check out the first 2 shards of the result
+>>> [f"device={s.device} index={s.index}" for s in res1.addressable_shards[:2]]
+['device=cpu:0 index=(slice(0, 8, None),)', 'device=cpu:1 index=(slice(8, 16, None),)']
+
+>>> # We can call `exp` with some other 4 devices and another
+>>> # mesh with a different shape, as long as the number of devices is
+>>> # the same.
+>>> other_mesh = Mesh(np.array(jax.local_devices()[2:6]).reshape((2, 2)), ("b", "c"))
+>>> res2 = exp.call(jax.device_put(arg,
+...                                NamedSharding(other_mesh, P("b"))))
+
+>>> # Check out the first 2 shards of the result. Notice that the output is
+>>> # sharded similarly; this means that the input was resharded according to the
+>>> # exp.in_shardings.
+>>> [f"device={s.device} index={s.index}" for s in res2.addressable_shards[:2]]
+['device=cpu:2 index=(slice(0, 8, None),)', 'device=cpu:3 index=(slice(8, 16, None),)']
+
+```
+
+It is an error to try to invoke an exported artifact with a different number
+of devices than it was exported for:
+
+```python
+>>> import jax
+>>> from jax import export
+>>> from jax.sharding import Mesh, NamedSharding
+>>> from jax.sharding import PartitionSpec as P
+
+>>> export_devices = jax.local_devices()
+>>> export_mesh = Mesh(np.array(export_devices), ("a",))
+>>> def f(x):
+...   return x.T
+
+>>> exp = export.export(jax.jit(f))(
+...    jax.ShapeDtypeStruct((4 * len(export_devices),), dtype=np.int32,
+...                         sharding=NamedSharding(export_mesh, P("a"))))
+
+>>> arg = jnp.arange(4 * len(export_devices))
+>>> exp.call(arg)  # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+ValueError: Exported module f was lowered for 8 devices and is called in a context with 1 devices. This is disallowed because: the module was lowered for more than 1 device.
+
+```
+
+There are helper functions to shard the inputs for calling an exported
+artifacts using a new mesh constructed at the call site:
+
+```python
+>>> import jax
+>>> from jax import export
+>>> from jax.sharding import Mesh, NamedSharding
+>>> from jax.sharding import PartitionSpec as P
+
+>>> export_devices = jax.local_devices()
+>>> export_mesh = Mesh(np.array(export_devices), ("a",))
+>>> def f(x):
+...   return x.T
+
+
+>>> exp = export.export(jax.jit(f))(
+...    jax.ShapeDtypeStruct((4 * len(export_devices),), dtype=np.int32,
+...                         sharding=NamedSharding(export_mesh, P("a"))))
+
+>>> # Prepare the mesh for calling `exp`.
+>>> calling_mesh = Mesh(np.array(export_devices[::-1]), ("a",))
+
+>>> # Shard the arg according to what `exp` expects.
+>>> arg = jnp.arange(4 * len(export_devices))
+>>> sharded_arg = jax.device_put(arg, exp.in_shardings_jax(calling_mesh)[0])
+>>> res = exp.call(sharded_arg)
+
+```
+
+As a special facility, if a function was exported for 1 device and if it
+contains no sharding annotations, then it can be invoked on an argument of
+the same shape but sharded on multiple devices, and the compiler will shard
+the function appropriately:
+
+```python
+>>> import jax
+>>> from jax import export
+>>> from jax.sharding import Mesh, NamedSharding
+>>> from jax.sharding import PartitionSpec as P
+
+>>> def f(x):
+...   return jnp.cos(x)
+
+>>> arg = jnp.arange(4)
+>>> exp = export.export(jax.jit(f))(arg)
+>>> exp.in_avals
+(ShapedArray(int32[4]),)
+
+>>> exp.nr_devices
+1
+
+>>> # Prepare the mesh for calling `exp`.
+>>> calling_mesh = Mesh(jax.local_devices()[:4], ("b",))
+
+>>> # Shard the arg according to what `exp` expects.
+>>> sharded_arg = jax.device_put(arg,
+...                              NamedSharding(calling_mesh, P("b")))
+>>> res = exp.call(sharded_arg)
+
+```
+
+## Calling convention versions
+
+The JAX export support has evolved over time, e.g., to support
+effects. In order to support compatibility (see [compatibility guarantees](#compatibility-guarantees))
+we maintain a calling convention version for each `Exported`.
+As of June 2024, all function exported with version 9
+(the latest, see [all calling convention versions](#calling-convention-versions)):
+
+```python
+>>> from jax import export
+>>> exp: export.Exported = export.export(jnp.cos)(1.)
+>>> exp.calling_convention_version
+10
+
+```
+
+At any given time, the export APIs may support a range
+of calling convention versions. You can control which calling convention
+version to use using the `--jax_export_calling_convention_version` flag
+or the `JAX_EXPORT_CALLING_CONVENTION_VERSION` environment variable:
+
+```python
+>>> from jax import export
+>>> (export.minimum_supported_calling_convention_version, export.maximum_supported_calling_convention_version)
+(9, 10)
+
+>>> from jax._src import config
+>>> with config.jax_export_calling_convention_version(10):
+...  exp = export.export(jnp.cos)(1.)
+...  exp.calling_convention_version
+10
+
+```
+
+We reserve the right to remove support for
+generating or consuming calling convention versions older than 6 months.
+
+### Module calling convention
+
+The `Exported.mlir_module` has a `main` function that takes an optional first
+platform index argument if the module supports multiple platforms
+(`len(platforms) > 1`), followed by the token arguments corresponding
+to the ordered effects, followed by the kept array
+arguments (corresponding to `module_kept_var_idx` and `in_avals`).
+The platform index is a i32 or i64 scalar encoding the index of the current
+compilation platform into the `platforms` sequence.
+
+Inner functions use a different calling convention: an optional
+platform index argument, optional dimension variable arguments
+(scalar tensors of type i32 or i64),
+followed by optional token arguments (in presence of ordered effects),
+followed by the regular array arguments.
+The dimension arguments correspond to the dimension variables appearing in
+the `args_avals`, in sorted order of their names.
+
+Consider the lowering of a function with one array argument of type
+`f32[w, 2 * h]`, where `w` and `h` are two dimension variables.
+Assume that we use multi-platform lowering, and we have
+one ordered effect. The `main` function will be as follows:
+
+```
+      func public main(
+            platform_index: i32 {jax.global_constant="_platform_index"},
+            token_in: token,
+            arg: f32[?, ?]) {
+         arg_w = hlo.get_dimension_size(arg, 0)
+         dim1 = hlo.get_dimension_size(arg, 1)
+         arg_h = hlo.floordiv(dim1, 2)
+         call _check_shape_assertions(arg)  # See below
+         token = new_token()
+         token_out, res = call _wrapped_jax_export_main(platform_index,
+                                                        arg_h,
+                                                        arg_w,
+                                                        token_in,
+                                                        arg)
+         return token_out, res
+      }
+```
+
+The actual computation is in `_wrapped_jax_export_main`, taking also
+the values of `h` and `w` dimension variables.
+
+The signature of the `_wrapped_jax_export_main` is:
+
+```
+      func private _wrapped_jax_export_main(
+          platform_index: i32 {jax.global_constant="_platform_index"},
+          arg_h: i32 {jax.global_constant="h"},
+          arg_w: i32 {jax.global_constant="w"},
+          arg_token: stablehlo.token {jax.token=True},
+          arg: f32[?, ?]) -> (stablehlo.token, ...)
+```
+
+Prior to calling convention version 9 the calling convention for effects was
+different: the `main` function does not take or return a token. Instead
+the function creates dummy tokens of type `i1[0]` and passes them to the
+`_wrapped_jax_export_main`. The `_wrapped_jax_export_main`
+takes dummy tokens of type `i1[0]` and will create internally real
+tokens to pass to the inner functions. The inner functions use real
+tokens (both before and after calling convention version 9)
+
+Also starting with calling convention version 9, function arguments that contain
+the platform index or the dimension variable values have a
+`jax.global_constant` string attribute whose value is the name of the
+global constant, either `_platform_index` or a dimension variable name.
+The global constant name may be empty if it is not known.
+Some global constant computations use inner functions, e.g., for
+`floor_divide`. The arguments of such functions have a `jax.global_constant`
+attribute for all attributes, meaning that the result of the function is
+also a global constant.
+
+Note that `main` contains a call to `_check_shape_assertions`.
+JAX tracing assumes that `arg.shape[1]` is even, and that both `w` and `h`
+have values >= 1. We must check these constraints when we invoke the
+module. We use a special custom call `@shape_assertion` that takes
+a boolean first operand, a string `error_message` attribute that may contain
+format specifiers `{0}`, `{1}`, ..., and a variadic number of integer
+scalar operands corresponding to the format specifiers.
+
+```
+       func private _check_shape_assertions(arg: f32[?, ?]) {
+         # Check that w is >= 1
+         arg_w = hlo.get_dimension_size(arg, 0)
+         custom_call @shape_assertion(arg_w >= 1, arg_w,
+            error_message="Dimension variable 'w' must have integer value >= 1. Found {0}")
+         # Check that dim1 is even
+         dim1 = hlo.get_dimension_size(arg, 1)
+         custom_call @shape_assertion(dim1 % 2 == 0, dim1 % 2,
+            error_message="Division had remainder {0} when computing the value of 'h')
+         # Check that h >= 1
+         arg_h = hlo.floordiv(dim1, 2)
+         custom_call @shape_assertion(arg_h >= 1, arg_h,
+            error_message=""Dimension variable 'h' must have integer value >= 1. Found {0}")
+```
+
+(jax-501-export-calling-convention-version)=
+
+### Calling convention versions
+
+We list here a history of the calling convention version numbers:
+
+  * Version 1 used MHLO & CHLO to serialize the code, not supported anymore.
+  * Version 2 supports StableHLO & CHLO. Used from October 2022. Not supported
+    anymore.
+  * Version 3 supports platform checking and multiple platforms.
+    Used from February 2023. Not supported anymore.
+  * Version 4 supports StableHLO with compatibility guarantees.
+    This is the earliest version at the time of the JAX native serialization
+    launch.
+    Used in JAX from March 15, 2023 (cl/516885716). Starting with
+    March 28th, 2023 we stopped using `dim_args_spec` (cl/520033493).
+    The support for this version was dropped on
+    October 17th, 2023 (cl/573858283).
+  * Version 5 adds support for `call_tf_graph`. This is currently used
+    for some specialized use cases. Used in JAX from May 3rd, 2023
+    (cl/529106145).
+  * Version 6 adds support for the `disabled_checks` attribute. This version
+    mandates a non-empty `platforms` attribute. Supported by XlaCallModule
+    since June 7th, 2023 and available in JAX since
+    June 13th, 2023 (JAX 0.4.13).
+  * Version 7 adds support for `stablehlo.shape_assertion` operations and
+    for `shape_assertions` specified in `disabled_checks`.
+    See [Errors in presence of shape polymorphism](https://github.com/jax-ml/jax/blob/main/jax/experimental/jax2tf/README.md#errors-in-presence-of-shape-polymorphism).
+    Supported by XlaCallModule
+    since July 12th, 2023 (cl/547482522),
+    available in JAX serialization since July 20th, 2023 (JAX 0.4.14),
+    and the default since August 12th, 2023 (JAX 0.4.15).
+  * Version 8 adds support for the `jax.uses_shape_polymorphism` module
+    attribute and enables the shape refinement pass only when the
+    attribute is present. Supported by XlaCallModule since July 21st, 2023
+    (cl/549973693), available in JAX since July 26th, 2023 (JAX 0.4.14),
+    and the default since October 21st, 2023 (JAX 0.4.20).
+  * Version 9 adds support for effects.
+    See the docstring for `export.Exported` for the precise calling convention.
+    In this calling convention version we also tag the platform index and the
+    dimension variables arguments with `jax.global_constant` attributes.
+    Supported by XlaCallModule since October 27th, 2023,
+    available in JAX since October 20th, 2023 (JAX 0.4.20),
+    and the default since February 1st, 2024 (JAX 0.4.24).
+    This is the only supported version as of 27th of March, 2024.
+  * Version 10 propagate the `jax.config.use_shardy_partitioner` value to
+    XlaCallModule. Supported by XlaCallModule since May 20th, 2025, and
+    the default in JAX since July 14th, 2025 (JAX 0.7.0).
+
+## Developer documentation
+
+(jax-501-export-debugging)=
+### Debugging
+
+You can log the exported modules, with somewhat different flags in OSS versus
+in Google. In OSS you can do the following:
+
+```shell
+# Log from python
+python tests/export_test.py JaxExportTest.test_basic -v=3
+# Or, log from pytest to /tmp/mylog.txt
+pytest tests/export_test.py -k test_basic --log-level=3 --log-file=/tmp/mylog.txt
+```
+
+You will see a log line of the form:
+```shell
+I0619 10:54:18.978733 8299482112 _export.py:606] Exported JAX function: fun_name=sin version=9 lowering_platforms=('cpu',) disabled_checks=()
+I0619 10:54:18.978767 8299482112 _export.py:607] Define JAX_DUMP_IR_TO to dump the module.
+```
+
+If you set the environment variable `JAX_DUMP_IR_TO` to a directory,
+the exported (and the JIT compiled) HLO
+modules will be saved there.
+
+```shell
+JAX_DUMP_IR_TO=/tmp/export.dumps pytest tests/export_test.py -k test_basic --log-level=3 --log-file=/tmp/mylog.txt
+INFO     absl:_export.py:606 Exported JAX function: fun_name=sin version=9 lowering_platforms=('cpu',) disabled_checks=()
+INFO     absl:_export.py:607 The module was dumped to jax_ir0_jit_sin_export.mlir.
+```
+
+You will see both the exported modules (named `..._export.mlir`
+and the JIT compiled modules (named `..._compile.mlir`):
+```shell
+$ ls -l /tmp/export.dumps/
+total 32
+-rw-rw-r--@ 1 necula  wheel  2316 Jun 19 11:04 jax_ir0_jit_sin_export.mlir
+-rw-rw-r--@ 1 necula  wheel  2279 Jun 19 11:04 jax_ir1_jit_sin_compile.mlir
+-rw-rw-r--@ 1 necula  wheel  3377 Jun 19 11:04 jax_ir2_jit_call_exported_compile.mlir
+-rw-rw-r--@ 1 necula  wheel  2333 Jun 19 11:04 jax_ir3_jit_my_fun_export.mlir
+```
+
+Set [`JAX_DEBUG_LOG_MODULES=jax._src.export`](https://docs.jax.dev/en/latest/config_options.html#jax_debug_log_modules) to enable extra debugging logging.
+
+(jax-501-export-ensuring-compat)=
+### Ensuring forward and backward compatibility
+
+This section discusses the process JAX developers
+should use to ensure the [compatibility guarantees](#compatibility-guarantees).
+
+One complication is that external users install JAX and jaxlib
+in separate packages,
+and users often end up using an older jaxlib than JAX.
+We observe that the custom calls live in the jaxlib, and only the jaxlib is
+relevant for a consumer of an exported artifact.
+To simplify the process, we are setting the expectation for external users
+that the compatibility window is defined in terms of jaxlib releases,
+and it is their responsibility to ensure that they export with a new jaxlib
+even if JAX would function with an older version.
+
+Thus, we care only about jaxlib releases.
+We can start a backward-compatibility deprecation clock when we make a
+jaxlib release, even if we don’t force it to be the minimum allowed version.
+
+Let’s say that we need to add, delete, or change the semantics of a
+custom call target `T` used by the JAX lowering rules.
+Here is a possible chronology (for changing custom call targets
+that live in jaxlib):
+
+  1. Day “D - 1”, before the change. Say that the active internal JAX
+     version is `0.4.31` (the version of the next JAX and jaxlib releases).
+     The JAX lowering rules use a custom call `T`.
+  2. Day “D”, we add the new custom call target `T_NEW`.
+    We should create a new custom call target, and clean up the old
+    target roughly after 6 months, rather than updating `T` in place:
+       * See the example [PR #20997](https://github.com/jax-ml/jax/pull/20997)
+         implementing the steps below.
+       * We add the custom call target `T_NEW`.
+       * We change the JAX lowering rules that were previous using `T`,
+         to use `T_NEW`, conditionally as follows:
+
+        ```python
+        from jax._src import config
+        from jax._src.lib import version as jaxlib_version
+
+        def my_lowering_rule(ctx: LoweringRuleContext, ...):
+          if ctx.is_forward_compat() or jaxlib_version < (0, 4, 31):
+            # this is the old lowering, using target T, while we
+            # are in forward compatibility mode for T, or we
+            # are in OSS and are using an old jaxlib.
+            return hlo.custom_call("T", ...)
+          else:
+            # This is the new lowering, using target T_NEW, for
+            # when we use a jaxlib with version `>= (0, 4, 31)`
+            # (or when this is internal usage), and also we are
+            # in JIT mode.
+            return hlo.custom_call("T_NEW", ...)
+        ```
+       * Note that the forward compatibility mode is always false in JIT mode
+         or if the user passes `--jax_export_ignore_forward_compatibility=true`
+       * Note that at this point the exports will still not use `T_NEW`.
+  3. This can be done at any time after the previous step, and before
+     the next step: Add a backward compatibility test for `T_NEW`,
+     and add `T_NEW` to the list of
+     [`_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE`](https://github.com/search?q=repo%3Ajax-ml%2Fjax++%22_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE+%3D%22+path%3A_export.py&amp%3Btype=code&type=code) in `_export.py`.
+       * Instructions for adding backwards compatibility tests are at
+         the top of
+         [export_back_compat_test_util.py](https://github.com/search?q=repo%3Ajax-ml%2Fjax+++path%3Aexport_back_compat_test_util.py&amp%3Btype=code&type=code).
+       * An example is in [PR #29488](https://github.com/jax-ml/jax/pull/29488).
+       * Note that if you do this before the next step, the exporting will
+         still not use the `T_NEW` lowering, and you have to add
+         `with config.export_ignore_forward_compatibility(True):` around the
+         call to `self.run_one_test`. This can be removed when you actually get
+         to step 4.
+       * You may also need to enable the test only for new versions of jaxlib.
+  4. Day “D + 21” (end of forward compatibility window; can be even later than
+    21 days):
+    We remove the `forward_compat_mode` in the lowering code, so now exporting
+    will start using the new custom call target `T_NEW` as long as we are using
+    a new `jaxlib`.
+  5. Day "RELEASE > D" (the first JAX release date after `D`, when we release
+    version `0.4.31`):
+    we start the clock for the 6 months backwards compatibility.
+    Note that this is relevant only if `T` is among the custom call targets for
+    which we already guarantee stability, i.e., are listed in
+    [`_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE`](https://github.com/search?q=repo%3Ajax-ml%2Fjax++%22_CUSTOM_CALL_TARGETS_GUARANTEED_STABLE+%3D%22+path%3A_export.py&amp%3Btype=code&type=code).
+      * If `RELEASE` is in the forward compatibility window `[D, D + 21]` and if
+        we make `RELEASE` the minimum allowed jaxlib version then we can
+        remove the `jaxlib_version < (0, 4, 31)` conditional in the
+        JIT branch.
+  6. Day “RELEASE + 180” (end of backward compatibility window,
+    can be even later than 180 days): By now, we must have bumped
+    the minimum jaxlib so that the lowering conditional
+    `jaxlib_version < (0, 4, 31)`
+    was already removed and JAX lowering cannot generate custom calls to `T`.
+      * We remove the C++ implementation of the old custom call target `T`.
+      * We remove also the backwards compatibility test for `T`
+
+## Serializing compiled executables
+
+`jax.export` serializes computations at the StableHLO level: portable across
+machines and (within the guarantees above) across versions, but still
+requiring compilation at load time. If you instead want to skip compilation
+entirely, the experimental {mod}`jax.experimental.serialize_executable`
+module provides `serialize` and `deserialize_and_load` for pickling the
+*compiled* executables produced by ahead-of-time compilation
+({ref}`jax-201-aot`). Compiled executables are far more fragile than
+exported modules: they are specific to the exact accelerator type, runtime
+versions, and device topology they were compiled for, and they come with no
+compatibility guarantees. For the common goal of just avoiding
+recompilation across restarts on the same machines, the persistent
+compilation cache ({ref}`jax-501-compilation-cache`) is usually the better
+tool.
+
+## Migration guide from jax.experimental.export
+
+On June 18, 2024 (JAX version 0.4.30)
+we deprecated the `jax.experimental.export` APIs
+in favor of `jax.export` APIs. There have been some minor changes:
+
+  * `jax.experimental.export.export`:
+    * The old function used to allow any Python callable, or the result of
+      `jax.jit`. Now only the latter is accepted. You have to manually apply
+      `jax.jit` to the function to export before calling `export`.
+    * The old `lowering_parameters` kwarg is now named `platforms`
+  * `jax.experimental.export.default_lowering_platform()` is now
+    at {func}`jax.export.default_export_platform`.
+  * `jax.experimental.export.call` is now a method of the
+    {class}`jax.export.Exported` object.
+    Instead of `export.call(exp)` you should use `exp.call`.
+  * `jax.experimental.export.serialize` is now a method of the
+    {class}`jax.export.Exported`
+    object. Instead of `export.serialize(exp)` you should use `exp.serialize()`.
+  * The configuration flag `--jax-serialization-version` is deprecated.
+    Use `--jax-export-calling-convention-version`.
+  * The value `jax.experimental.export.minimum_supported_serialization_version`
+    is now at `jax.export.minimum_supported_calling_convention_version`.
+  * The following fields of {class}`jax.export.Exported` have been renamed
+     * `uses_shape_polymorphism` is now `uses_global_constants`
+     * `mlir_module_serialization_version` is now `calling_convention_version`
+     * `lowering_platforms` is now `platforms`.

--- a/docs/new_docs/501/fault-tolerance.rst
+++ b/docs/new_docs/501/fault-tolerance.rst
@@ -1,0 +1,1533 @@
+:nosearch:
+
+.. _jax-501-fault-tolerance:
+
+.. raw:: html
+
+    <link href="../../_static/fault_tolerance/fault_tolerance.css" rel="stylesheet" />
+    <script src="../../_static/fault_tolerance/fault_tolerance.js"></script>
+
+
+Fault Tolerant Distributed JAX
+==============================
+
+Recall that :doc:`multi-controller JAX <multiprocess>` allows you to run a JAX program distributed
+across multiple machines. By default, if *any* of these machines fail, then
+*every* machine will fail. That is, multi-controller JAX is not
+**fault-tolerant** by default.
+
+This article has three parts. In the first part, we'll explain the basics of
+how to write fault tolerant multi-controller JAX programs. In the second part,
+we'll show some example fault-tolerant multi-controller JAX programs. In the
+third part, we'll take a look under the covers at how multi-controller JAX
+implements fault tolerance.
+
+.. warning::
+
+    JAX's support for fault tolerance is still experimental. It currently only
+    works fully on GPUs. It has rough edges, is probably buggy, and is subject
+    to change. Use at your own risk.
+
+.. note::
+
+    If you're looking for an alternative to fault-tolerant multi-controller JAX
+    on TPU, consider `Pathways`_.
+
+
+.. _jax-501-ft-part1:
+
+Part 1: Fault Tolerance Basics
+------------------------------
+
+Fault Intolerant By Default
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, multi-controller JAX programs are not fault tolerant. If *any*
+process crashes, then *all* other processes will also intentionally crash. To
+make this concrete, consider the following trivial script, ``example.py``, that
+initializes multi-controller JAX by calling ``jax.distributed.initialize`` and
+then enters an infinite loop.
+
+.. literalinclude:: ../../_static/fault_tolerance/while_loop.py
+    :language: python
+    :emphasize-lines: 12-18
+    :lines: 15-
+    :linenos:
+    :caption: ``example.py``
+
+Run ``example.py`` across four processes on a VM with four GPUs by running
+the following four commands, each in a different terminal. The
+``local_device_ids`` argument to ``jax.distributed.initialize`` ensures each
+process is assigned only one of the four GPUs. We'll explain the
+``heartbeat_timeout_seconds`` argument in just a second.
+
+.. code-block:: shell
+
+    python example.py --i=0 --n=4  # in terminal 1
+    python example.py --i=1 --n=4  # in terminal 2
+    python example.py --i=2 --n=4  # in terminal 3
+    python example.py --i=3 --n=4  # in terminal 4
+
+When you run these commands, you'll see the processes dutifully printing out
+the current time every second. Next, fail the fourth process: ``pkill -9 -f
+'python example.py --i=3 --n=4'``. After about ten seconds, the other
+processes will also terminate and spit out error messages that look something
+like this:
+
+.. code-block::
+
+   E0926 17:26:32.075402  157988 coordination_service_agent.cc:332] Polled an error from coordination service (this can be an error from this or another task).
+   F0926 17:26:32.075587  157988 client.h:77] Terminating process because the JAX distributed service detected fatal errors. This most likely indicates that another task died; see the other task logs for more details. Disable Python buffering, i.e. `python -u`, to be sure to see all the previous output. absl::Status: UNAVAILABLE: The following tasks are unhealthy (stopped sending heartbeats):
+   /job:jax_worker/replica:0/task:3
+   The tasks have crashed. Check the task logs for an earlier error, or scheduler events (e.g. preemption, eviction) to debug further.
+
+   RPC: /tensorflow.CoordinationService/PollForError [type.googleapis.com/tensorflow.CoordinationServiceError='']
+
+When a process in a multi-controller JAX program notices that a peer process
+has crashed, it decides to crash as well. The processes `share fate`_. The
+``heartbeat_timeout_seconds`` argument to ``jax.distributed.initialize``
+determines how long a process waits before concluding a peer process has died.
+The first three processes crash about ten seconds after you kill the fourth
+because we passed ``heartbeat_timeout_seconds=10`` as an argument to
+``jax.distributed.initialize``.
+
+Surviving Faults
+^^^^^^^^^^^^^^^^
+
+We can disable fate-sharing by adding the
+``--xla_gpu_nccl_terminate_on_error=false`` flag and the
+``jax_enable_recoverability`` configuration option to ``example.py``, as shown
+below:
+
+.. literalinclude:: ../../_static/fault_tolerance/dont_fail.py
+    :language: python
+    :emphasize-lines: 1-2,15
+    :linenos:
+    :lines: 15-
+
+Again run the script across four processes and then kill the fourth. Notice
+that now, the other three processes happily continue executing.
+
+Next try failing process 0. Notice that all four processes terminate with
+error messages that look something like the following:
+
+.. code-block::
+
+   E0929 17:42:48.594192 1044529 coordination_service_agent.cc:332] Polled an error from coordination service (this can be an error from this or another task).
+   F0929 17:42:48.594200 1044529 client.h:77] Terminating process because the JAX distributed service detected fatal errors. This most likely indicates that another task died; see the other task logs for more details. Disable Python buffering, i.e. `python -u`, to be sure to see all the previous output. absl::Status: UNAVAILABLE: Failed to send RPC to coordination service. Either the leader task was preempted/died/restarted unexpectedly or this task is experiencing network issues. Check earlier logs from 1) this task, 2) the leader (usually slice 0 task 0), and 3) cluster scheduler to debug further.
+   Additional GRPC error information from remote target coordination_service while calling /tensorflow.CoordinationService/PollForError:
+   :UNKNOWN:Error received from peer  {grpc_message:"Socket closed", grpc_status:14}
+
+Process 0 is special. If process 0 fails, every process will fail, even with
+fate-sharing disabled. Why? Process 0 runs an RPC service called the
+coordination service that all processes use to coordination with each other. If
+the coordination service fails, all other processes have no choice but to fail.
+See :ref:`jax-501-ft-part3` for more details.
+
+Getting Stuck in Collectives
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``example.py`` is now able to survive faults, but the processes do not
+communicate with each other at all. Any realistic multi-controller JAX program
+would involve communication between the processes (otherwise, what's the point
+of using multi-controller JAX?). Let's edit ``example.py`` so that the
+processes perform a collective ``jnp.sum`` in every iteration of the loop.
+
+.. literalinclude:: ../../_static/fault_tolerance/collectives.py
+    :language: python
+    :emphasize-lines: 27-32
+    :linenos:
+    :lines: 15-
+
+In the highlighted code above, the processes create an array ``x`` sharded
+across the four processes and then perform a distributed ``jnp.sum``. Again run
+the program and fail the fourth process. You'll notice that the first three
+process do not crash, but they do get *stuck*. By default, if a process fails
+while participating in a distributed computation (like ``jnp.sum``), then the
+rest of the processes participating in the computation will get stuck
+*forever*.
+
+.. _`jax-501-ft-canceling-collectives`:
+
+Cancelling Collectives
+^^^^^^^^^^^^^^^^^^^^^^
+
+We can avoid getting stuck by cancelling collectives with a failed participant.
+We can enable collective cancelling by providing a few more flags and
+environment variables, highlighted below.
+
+.. literalinclude:: ../../_static/fault_tolerance/cancel_collectives.py
+    :language: python
+    :emphasize-lines: 1-8,22,33-35
+    :linenos:
+    :lines: 15-
+
+We also need to insert a call to
+``jax.experimental.multihost_utils._live_devices`` to make the script work. You
+should normally not do this. You should instead use the ``live_devices`` API
+that we'll introduce momentarily. For now, ``_live_devices`` is a hack to get
+the script working before we explain the proper API.
+
+Again run the script and fail the fourth process. The first three processes
+will be stuck in their call to ``jnp.sum``, but after about ten seconds, the
+call will be cancelled and ``jnp.sum`` will raise an exception that looks
+something like this:
+
+.. code-block::
+
+    jaxlib._jax.XlaRuntimeError: FAILED_PRECONDITION: Task with incarnation id 3446767950926952685 is not connected
+
+
+Knowing Who's Alive
+^^^^^^^^^^^^^^^^^^^
+
+After a process dies, the remaining *alive* procesess need to learn who is dead
+and who is alive. For this, we can use the core JAX fault tolerance API:
+``live_devices``. ``live_devices`` is a context manager that takes a list of
+devices as an argument and returns the subset of these devices that are alive.
+Below, we edit ``example.py`` to call ``live_devices``.
+
+.. literalinclude:: ../../_static/fault_tolerance/live_devices.py
+    :language: python
+    :emphasize-lines: 34-46
+    :linenos:
+    :lines: 15-
+
+In the highlighted code above, we call ``live_devices`` with all devices
+(``jax.devices()``) to get the set ``devices`` of live devices. We then shard
+array ``x`` over these devices and perform a ``jnp.sum``. If a process fails
+while executing the ``jnp.sum``, then ``jnp.sum`` will be cancelled and raise
+an exception on the remaining live devices. Technically, the collective is not
+guaranteed to fail. We'll revisit this in :ref:`jax-501-ft-atomicity`. For now, assume it
+will fail.
+
+.. note::
+
+    ``jax.devices()`` always returns the set of *all* devices, even if some of
+    these devices are on failed processes. Use
+    ``jax.experimental.multihost_utils.live_devices`` to learn which of these
+    devices are live.
+
+Again run the script and fail the fourth process. Notice that the remaining
+three alive processes catch the exception raised by ``jnp.sum`` and continue to
+the next iteration of the while loop. In this next iteration, ``devices`` does
+not include the device on the failed fourth process. The three alive processes
+continue to execute correctly even though the fourth process is dead.
+
+Next, restart the fourth process. Notice that after the fourth process
+restarts, its device is again included in the set of alive devices returned by
+``live_devices``. All four processes then continue executing normally.
+
+At first blush, ``live_devices`` seems trivial. You give it a list of devices,
+and it returns the ones that are alive. How complicated can that be?
+Unfortunately, as with `many things in distributed systems`_, there are a lot
+subtleties to iron out. Next, we explain the **barrier** semantics and
+**atomicity** properties of ``live_devices``.
+
+Barrier Semantics
+^^^^^^^^^^^^^^^^^
+
+Recall that every process in a :doc:`multi-controller JAX <multiprocess>` program should run in
+lockstep. The processes should execute the same instructions in the same order.
+Failing to do so will *almost certainly* lead to deadlocks, crashes, or
+anomalous behavior.
+
+In the context of ``live_devices``, we need to ensure that every process agrees
+on which processes are currently alive. This is difficult to ensure because
+every process is executing independently at potentially different speeds and
+processes can fail at any time. Consider again the ``example.py`` script from
+above running on four processes. Imagine process 1 and 2 call ``live_devices``,
+then process 4 fails, and then process 3 calls ``live_devices``. Process 1 and
+2 might think process 4 is alive while process 3 thinks it is dead.
+
+To avoid situations like these, ``live_devices`` guarantees that it returns the
+same set of live devices to every process. It accomplishes this using a
+barrier. A call to ``live_devicess(devices)`` blocks until every live process
+hosting a device in ``devices`` has also called ``live_devices``. Once every
+live process is in the ``live_devices`` barrier, ``live_devices`` returns the
+same set of live devices to every process.
+
+.. important::
+
+    ``live_devices`` uses a barrier to ensure that it will *always* return the
+    same set of live devices to every live process.
+
+Because ``live_devices`` implements a barrier it is susceptible to deadlock if
+used improperly. We recommend only having a single ``with live_devices`` block
+in a program. Multiple calls to ``live_devices`` is hard to reason about and
+can lead to deadlock.
+
+See :ref:`jax-501-ft-part3` for details on how the ``live_devices`` barrier is implemented
+as well as a formal semantics based on `linearizability`_.
+
+.. _jax-501-ft-atomicity:
+
+Atomicity
+^^^^^^^^^
+
+A distributed computation is **atomic** if every participant in the computation
+agrees on whether the operation succeeds or fails. In the ``example.py`` script
+above, we saw that when a process failed during the execution of a ``jnp.sum``,
+then ``jnp.sum`` would abort and raise an exception on the remaining live
+processes. So ``jnp.sum`` is atomic?
+
+Unfortunately, it's not.
+
+When a process fails during the execution of a collective operation (like
+``jnp.sum``), the remaining processes may cancel the operation and raise an
+exception or they may complete the operation successfully. Collective
+operations in JAX do not have any inherent atomicity properties.
+
+If collective operations are not atomic, however, then multi-controller JAX
+processes might diverge. For example, if a process fails during a training step
+of a machine learning model, some processes might detect the failure and roll
+the model back to a checkpoint while other processes might think the step
+succeeded and keep training.
+
+To avoid the complexities of non-atomic execution, ``live_devices`` provides
+its own atomicity guarantees despite the fact that collectives are not atomic.
+Specifically, the body of a ``with live_devices`` block is guaranteed to either
+complete successfully on all processes or raise an exception on all processes.
+More concretely, if we consider the code snippet below, either every process
+executes branch A or every process executes branch B. It is impossible for some
+processes to execute A while others execute B.
+
+.. code-block:: python
+
+    try:
+      with live_devices(jax.devices()) as devices:
+        ...
+    except Exception as e:
+      ... # Branch A
+    else:
+      ... # Branch B
+
+.. warning::
+
+    A ``with live_devices`` block does not guarantee atomicity if the code
+    block non-deterministically raises exceptions for reasons other than
+    collectives that fail because of a crashed process. For example, if one
+    process raises an exception because it runs out of memory, this exception
+    will not be propagated to the other processes.
+
+Recall that JAX uses `asynchronous dispatch`_. Operations like ``jnp.sum`` do
+not block until the operation is complete. Instead, they return ``jax.Arrays``
+that act as futures. This asynchrony can interact with ``live_devices`` in
+unexpected ways. For example, consider the following code that performs a
+``jnp.sum``, assigns the result to ``y``, and then prints ``y``:
+
+.. code-block:: python
+
+    x = ...
+    y = ...
+    try:
+      with live_devices(jax.devices()) as devices:
+        y = jnp.sum(x)
+    except Exception as e:
+      ... # Branch A
+    else:
+      ... # Branch B
+    print(y)
+
+Imagine that the ``with live_devices`` block executes successfully on all
+processes. That is, all processes execute branch B. This only guarantees that
+every process successfully created a future and assigned it to ``y``. The
+actual computation of the ``jnp.sum`` may be delayed until outside the block.
+Thus, some processes might successfully complete the ``jnp.sum`` and print the
+value of ``y`` while other processes fail to complete the ``jnp.sum`` and raise
+an exception when trying to print ``y``.
+
+To avoid this, use ``jax.block_until_ready`` to ensure that computations are
+performed within the ``with live_devices`` block. The code snippet below, which
+now calls ``jax.block_until_ready`` when assigning to ``y``, guarantees that
+every process will successfully execute the ``jnp.sum`` or every process will
+raise an exception.
+
+.. code-block:: python
+
+    x = ...
+    y = ...
+    try:
+      with live_devices(jax.devices()) as devices:
+        y = jax.block_until_ready(jnp.sum(x))
+    except Exception as e:
+      ... # Branch A
+    else:
+      ... # Branch B
+    print(y)
+
+See :ref:`jax-501-ft-part3` for details on how atomicity is implemented.
+
+Part 2: Examples
+----------------
+
+``live_devices`` is not a panacea; it is a tool. It does not magically make
+multi-controller JAX programs fault tolerant. Rather, it allows you to
+implement fault tolerance yourself in the way that is best for your
+application.
+
+The exact details of how you implement fault-tolerance will vary greatly based
+on the nature of your application. In this section, we present some examples of
+how to use ``live_devices``. The examples are meant to be illustrative but not
+prescriptive. There are many other ways to implement fault tolerance.
+
+Example 1: Fault Tolerant Data Parallel Training
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In this example, we train a trivial single-parameter linear model (:math:`y =
+\alpha x`) with data parallelism across four processes. The example is
+contrived---you would never train a model with a single parameter across four
+machines---but we intentionally keep the model simple to focus on fault
+tolerance.
+
+Data parallelism makes implementing fault tolerance relatively straightforward.
+Because every process has a full copy of the model weights, if a process fails,
+we can simply ignore it and continue training. This example tolerates an
+arbitrary number of process failures (excluding process 0), but once a process
+fails, we assume it does not recover. The next example shows how to handle
+process recovery.
+
+First, we set some flags to disable fate-sharing and enable collective
+cancelling. We also make the necessary imports and define some flags.
+
+.. literalinclude:: ../../_static/fault_tolerance/data_parallelism.py
+    :language: python
+    :lines: 15-33
+    :lineno-start: 1
+
+Next, we define a ``replicated`` function that returns an array replicated
+across a set of devices. Note that ``replicated`` doesn't actually move any
+data. It assumes the argument ``x`` already has equal value across all
+processes. It simply returns a new view of that data, in a process-spanning
+`jax.Array` with a replicated sharding.
+
+.. literalinclude:: ../../_static/fault_tolerance/data_parallelism.py
+    :language: python
+    :lines: 35-49
+    :lineno-start: 21
+
+We define a similar ``sharded`` function that returns an array sharded across a
+set of devices. Again, ``sharded`` is not actually moving any data between
+processes.
+
+.. literalinclude:: ../../_static/fault_tolerance/data_parallelism.py
+    :language: python
+    :lines: 52-64
+    :lineno-start: 38
+
+Now, we're ready to start writing our training loop. We begin by initializing
+multi-controller JAX by calling ``jax.distributed.initialize``.
+
+.. literalinclude:: ../../_static/fault_tolerance/data_parallelism.py
+    :language: python
+    :lines: 67-76
+    :lineno-start: 53
+
+Then, we define our simple linear model, generate some random training data,
+and initialize some basic hyperparameters.
+
+.. literalinclude:: ../../_static/fault_tolerance/data_parallelism.py
+    :language: python
+    :lines: 78-97
+    :lineno-start: 64
+
+Finally, we enter the main training loop.
+
+.. literalinclude:: ../../_static/fault_tolerance/data_parallelism.py
+    :language: python
+    :lines: 99-125
+    :lineno-start: 85
+
+- Every iteration of the loop, we call ``live_devices`` to learn which devices
+  are currently alive.
+- We then ensure that the model weights are replicated across these devices and
+  ensure that the training data is sharded across these devices. Note that this
+  doesn't actually move any data between the devices; it simply creates JAX
+  arrays with the appropriate replication and sharding metadata.
+- We call ``loss_and_grad`` to compute the gradient of the weights with respect
+  to the current batch of data and then compute the new weights. Notice that we
+  assign the new weights to ``new_weights`` rather than assigning to
+  ``weights`` in case the training step fails. We also call
+  ``jax.block_until_ready`` to ensure that every process has computed the new
+  weights when we exit the ``live_devices`` block.
+- If no processes failed during the execution of the training step, then the
+  ``else`` branch is taken. The step is incremented, and ``weights`` is
+  updated. Otherwise, an exception will be raised and the ``except`` branch is
+  taken. In this case, we do not update ``step`` or ``weights`` and retry the
+  step on the next iteration with the new set of live devices.
+
+Here is the full example:
+
+.. literalinclude:: ../../_static/fault_tolerance/data_parallelism.py
+    :language: python
+    :linenos:
+    :lines: 15-
+
+Example 2: Fault Tolerant Data Parallel Training With Recovery
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Now, we modify the example above to allow failed processes to recover. When a
+process recovers, it needs to receive the current step and model weights.
+Because we assume process 0 never fails---recall that if process 0 fails, every
+process will fail---we have process 0 send the current step and weights to
+recovering processes.
+
+First, we define ``send`` and ``recv`` functions that use a ``shard_map`` to
+send data from one device to another. The sender calls ``send``, and the
+receiver calls ``recv``.
+
+.. literalinclude:: ../../_static/fault_tolerance/data_parallelism_with_recovery.py
+    :language: python
+    :lines: 69-90
+    :lineno-start: 55
+
+``allgather`` performs an AllGather of a single float across a set of devices.
+
+.. literalinclude:: ../../_static/fault_tolerance/data_parallelism_with_recovery.py
+    :language: python
+    :lines: 93-100
+    :lineno-start: 79
+
+Finally, we modify the training loop to handle recovering processes, as shown
+in the highlighted code below.
+
+.. literalinclude:: ../../_static/fault_tolerance/data_parallelism_with_recovery.py
+    :language: python
+    :lines: 135-178
+    :lineno-start: 121
+    :emphasize-lines: 7-22
+
+Recovery is a two-step process. First, we need to detect which processes are
+recovering. Second, we need process 0 to send the step and weights to the
+recovering processes.
+
+1. To detect which processes are recovering, we perform an AllGather on all
+   live processes' steps. When a failed process recovers, its ``step`` will be
+   ``0``, while the ``step`` on process ``0`` will be some positive number, so
+   if a process' step is not equal to process 0's step, then it is recovering.
+2. Then, we call the ``send`` and ``recv`` functions we defined above to
+   transfer the current step and model weights from process 0 to the recovering
+   processes.
+
+Here is the full example:
+
+.. literalinclude:: ../../_static/fault_tolerance/data_parallelism_with_recovery.py
+    :language: python
+    :linenos:
+    :lines: 15-
+
+.. _jax-501-ft-part3:
+
+
+Part 3: Implementation Details
+------------------------------
+
+We now take a deep dive into the architecture of multi-controller JAX and the
+semantics and implementation of ``live_devices``. If you're only interested in
+writing fault-tolerant multi-controller JAX programs, the first two parts of
+this article suffice.
+
+The Coordination Service
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When you launch a multi-controller JAX program, the first process (i.e. process
+0) runs a standalone RPC server called the **coordination service**. Moreover,
+all processes (including process 0) create an RPC client to the coordination
+service. Concretely, the ``coordinator_address`` argument of
+:func:`jax.distributed.initialize` is the address of the coordination service.
+This argument lets process 0 know on what address to run the server, and it
+lets all processes know which address to connect to.
+
+The coordination service implements the multi-controller JAX **control plane**.
+For example, it can perform a distributed barrier across all processes, and it
+implements a key-value store that processes can use to exchange small amounts
+of metadata. Note, however, that the **data plane** (e.g., all collective
+operations on program data) is implemented directly between the processes and
+does not involve the coordination service.
+
+One of the most important functionalities of the coordination service is health
+checking. Every process periodically sends a heartbeat to the coordination
+service. If a process fails, it stops sending heartbeats. If the coordination
+service hasn't received a heartbeat from a process for a while, it assumes the
+process has failed.
+
+This is shown in the interactive visualization below. The coordination service
+is shown at the top and three multi-controller JAX processes are shown at the
+bottom. Note how the processes periodically send heartbeats to the controller,
+and the controller keeps track of the health of each process based on when it
+last received a heartbeat. Try failing process 2 by clicking the "Fail" button.
+Observe how the process stops sending heartbeats and the coordination service
+eventually considers the process dead.
+
+.. raw:: html
+
+    <div class="cluster" id="cluster_1"></div>
+    <script>
+      init_cluster("cluster_1", {
+        share_fate: false,
+        live_devices: false,
+        barrier: false,
+      });
+    </script>
+
+By default, when the coordination service detects that a process has failed, it
+sends a message to all other processes requesting that they self-terminate. In
+other words, all processes in a multi-controller JAX program `share fate`_.
+Again fail process 2 in the visualization below by clicking the "Fail" button
+and observe how the coordination service notifies the other processes to fail.
+
+.. raw:: html
+
+    <div class="cluster" id="cluster_2"></div>
+    <script>
+      init_cluster("cluster_2", {
+        share_fate: true,
+        live_devices: false,
+        barrier: false,
+      });
+    </script>
+
+This fate sharing means that multi-controller JAX programs are not at all
+fault-tolerant. They are fault-*intolerant*. To enable fault-tolerance, we
+need to do two things:
+
+- First, we need to remove fate sharing and allow processes to continue
+  executing even when a peer process has died. This can be enabled using the
+  ``jax_enable_recoverability`` option, as described in :ref:`jax-501-ft-part1`. We'll
+  assume that this option is set.
+- Second, we need to provide an API that processes can use to learn which
+  processes are alive and which have failed. This is the ``live_devices`` API
+  introduced in :ref:`jax-501-ft-part1`.
+
+There is a surprising amount of technical depth and subtlety in implementing
+the ``live_devices`` API. We'll walk through the design and implementation of
+the API step-by-step. We'll begin by introducing a simpler ``live_processes``
+API and slowly improve it until we arrive at the ``live_devices`` API.
+
+Live Processes
+^^^^^^^^^^^^^^
+
+Let's try to design a new hypothetical JAX API: ``jax.live_processes``. As the
+name suggests, we want ``jax.live_processes()`` to return the set of all
+currently alive processes.  Here is a naive but (as we'll see momentarily)
+incorrect implementation. When a process calls ``jax.live_processes()``, it
+sends an RPC request to the coordination service. Remember that the
+coordination service already uses heartbeats to keep track of which processes
+are dead and which are alive, so when it receives a ``jax.live_processes``
+request, it responds with the set of processes it thinks are alive.
+
+This is illustrated below. Below each process is a "Call live_processes"
+button. You can click this button to make the process call
+``jax.live_processes``. Note how the coordination service replies to a
+``live_processess`` request with the set of alive processes. Fail process 2 by
+clicking the "Fail" button and see how it affects later calls to
+``jax.live_processes``.
+
+.. raw:: html
+
+    <div class="cluster" id="cluster_3"></div>
+    <script>
+      init_cluster("cluster_3", {
+        share_fate: false,
+        live_devices: true,
+        barrier: false,
+      });
+    </script>
+
+This naive implementation is simple but incorrect. It is crucial that all
+processes in a multi-controller JAX job execute the same instructions in the
+same order. If the processes start to diverge, by executing different code
+paths in the JAX program, the job will behave erratically. Most likely, it will
+crash or hang or produce garbage values, and most certainly it will be very
+hard to reason about.
+
+Our naive implementation of ``jax.live_processes`` can very easily lead to
+divergence. For example, consider a multi-controller JAX job with three
+processes. If process 0 and 1 both call ``jax.live_processes`` around the same
+time that process 2 fails, the coordination service might report to process 0
+that all processes are alive but report to process 1 that only processes 0 and
+1 are alive. Try to produce this scenario in the visualization below:
+
+.. raw:: html
+
+    <div class="cluster" id="cluster_4"></div>
+    <script>
+      init_cluster("cluster_4", {
+        share_fate: false,
+        live_devices: true,
+        barrier: false,
+      });
+    </script>
+
+If processes disagree on which processes are alive, they will almost certainly
+diverge. Thankfully, we can avoid this divergence by augmenting
+``jax.live_processes`` with barrier semantics.
+
+Barrier Semantics
+^^^^^^^^^^^^^^^^^
+
+Let's change the implementation of ``jax.live_processes`` so that when the
+coordination service receives a ``jax.live_processes()`` request, it does not
+reply right away. Instead, the coordination service only replies once *every*
+live process has called ``jax.live_processes()``. Once every alive process has
+entered the ``jax.live_processess()`` barrier, the coordination service returns
+the set of live processes. Crucially, the coordination service returns the
+*same* set of live processes to all processes, which prevents the processes
+from diverging.
+
+This is illustrated below. Note that coordination server now keeps track of
+which devices are in the ``live_processes`` barrier.  Try calling
+``live_processes`` from every process.  Notice how the coordination service
+doesn't respond until every process has entered the barrier. Then fail process
+2 and call ``live_processes`` from process 0 and process 1.
+
+.. raw:: html
+
+    <div class="cluster" id="cluster_5"></div>
+    <script>
+      init_cluster("cluster_5", {
+        share_fate: false,
+        live_devices: true,
+        barrier: true,
+      });
+    </script>
+
+Formal Semantics
+^^^^^^^^^^^^^^^^
+
+Distributed systems are notoriously complex. Machines can fail at arbitrary
+times, and network messages can be dropped, delayed, and reordered. In this
+section, we introduce a formal semantics of the ``jax.live_processes`` API to
+help tame this complexity. Thinking rigorously about the semantics of
+``jax.live_processes`` will help us understand the behavior of the API even in
+pathological executions.
+
+We'll base the formal semantics of ``jax.live_processes`` on
+`linearizability`_: a popular formalism used to define the semantics of many
+distributed APIs. Concretely, we model our distributed system as a number of
+processes. Each process serially performs a number of events. There are four
+types of events:
+
+1. A process can **start** (👶). We'll assume that when a process starts, it
+   connects to the coordination service, so the coordination service is aware
+   that is has started.
+2. A process can **fail** (💀). Unlike starting, the coordination service may
+   not immediately be aware that a process has failed.
+3. A process can **send** a ``jax.live_processes`` request to the coordination
+   service.
+4. A process can **receive** a reply to a ``jax.live_processes`` request from
+   the coordination service.
+
+Below is a diagram of an execution of three processes: 0, 1, and 2. Time
+progresses from left to right. First, all three processes start. This is shown
+with the baby emojis. Then all three processes send ``jax.live_processes``
+requests to the coordination service. This is shown as the start of the thick
+colored regions. Later, all three processes receive a reply from the
+coordination service with ``0,1,2`` as the set of live devices.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 160">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+        <text x="0" y="100" class="proc">2</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+        <line x1="10" y1="100" x2="300" y2="100" class="proc-axis"></line>
+
+        <!-- Process 1 -->
+        <text x="25" y="0" class="event">👶</text>
+        <line x1="50" y1="0" x2="250" y2="0" class="rpc p0-color"></line>
+        <text x="250" y="-15" class="reply">0,1,2</text>
+
+        <!-- Process 2 -->
+        <text x="25" y="50" class="event">👶</text>
+        <line x1="50" y1="50" x2="250" y2="50" class="rpc p1-color"></line>
+        <text x="250" y="35" class="reply">0,1,2</text>
+
+        <!-- Process 2 -->
+        <text x="25" y="100" class="event">👶</text>
+        <line x1="50" y1="100" x2="250" y2="100" class="rpc p2-color"></line>
+        <text x="250" y="85" class="reply">0,1,2</text>
+      </svg>
+    </div>
+
+In this simple execution, it is clear that ``jax.live_processes`` is behaving
+correctly. We can formalize this intuition with the following formal semantics.
+
+.. attention::
+
+   An execution is valid if whenever ``jax.live_processes`` returns a set ``P``
+   of live processes, there exists an instantaneous moment in time at which
+   every process in ``P`` was in the ``live_processes`` barrier and every other
+   process was dead. An implementation of ``live_processes`` is correct if
+   it only allows for valid executions.
+
+Later, we will amend these formal semantics to cover some subtle corner cases,
+but assume this simplified semantics for now.
+
+In the example above, ``live_processes`` returns ``0,1,2``. In the
+visualization below, we show that there does exist an instantaneous moment of
+time in which processes 0, 1, and 2 are all in the barrier and all other
+processes (there are none) are dead. The moment in time is drawn as a vertical
+red bar.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 160">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+        <text x="0" y="100" class="proc">2</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+        <line x1="10" y1="100" x2="300" y2="100" class="proc-axis"></line>
+
+        <!-- Process 1 -->
+        <text x="25" y="0" class="event">👶</text>
+        <line x1="50" y1="0" x2="250" y2="0" class="rpc p0-color"></line>
+        <text x="250" y="-15" class="reply">0,1,2</text>
+
+        <!-- Process 2 -->
+        <text x="25" y="50" class="event">👶</text>
+        <line x1="50" y1="50" x2="250" y2="50" class="rpc p1-color"></line>
+        <text x="250" y="35" class="reply">0,1,2</text>
+
+        <!-- Process 2 -->
+        <text x="25" y="100" class="event">👶</text>
+        <line x1="50" y1="100" x2="250" y2="100" class="rpc p2-color"></line>
+        <text x="250" y="85" class="reply">0,1,2</text>
+
+        <!-- Snapshot -->
+        <line x1="150" y1="-20" x2="150" y2="120" class="snapshot"></line>
+      </svg>
+    </div>
+
+There is nothing special about the specific moment in time we chose in the
+visualization above. All that's important is that *there exists some* moment in
+time where all processes in `P` are in the barrier and all other processes are
+dead. There are many moments in time that satisfy this property, as shown
+below.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 160">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+        <text x="0" y="100" class="proc">2</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+        <line x1="10" y1="100" x2="300" y2="100" class="proc-axis"></line>
+
+        <!-- Process 1 -->
+        <text x="25" y="0" class="event">👶</text>
+        <line x1="50" y1="0" x2="250" y2="0" class="rpc p0-color"></line>
+        <text x="250" y="-15" class="reply">0,1,2</text>
+
+        <!-- Process 2 -->
+        <text x="25" y="50" class="event">👶</text>
+        <line x1="50" y1="50" x2="250" y2="50" class="rpc p1-color"></line>
+        <text x="250" y="35" class="reply">0,1,2</text>
+
+        <!-- Process 2 -->
+        <text x="25" y="100" class="event">👶</text>
+        <line x1="50" y1="100" x2="250" y2="100" class="rpc p2-color"></line>
+        <text x="250" y="85" class="reply">0,1,2</text>
+
+        <!-- Snapshot -->
+        <line x1="150" y1="-20" x2="150" y2="120" class="snapshot">
+          <animate attributeName="x1" values="50;250;50" dur="4s" repeatCount="indefinite"/>
+          <animate attributeName="x2" values="50;250;50" dur="4s" repeatCount="indefinite"/>
+        </line>
+      </svg>
+    </div>
+
+In the next example, processes 0 and 1 start, call ``live_devices``, and
+receive ``0,1`` as a reply. Process 2 is dead throughout the execution.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 160">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+        <text x="0" y="100" class="proc">2</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+        <line x1="10" y1="100" x2="300" y2="100" class="proc-axis"></line>
+
+        <!-- Process 1 -->
+        <text x="25" y="0" class="event">👶</text>
+        <line x1="50" y1="0" x2="250" y2="0" class="rpc p0-color"></line>
+        <text x="250" y="-15" class="reply">0,1</text>
+
+        <!-- Process 2 -->
+        <text x="25" y="50" class="event">👶</text>
+        <line x1="50" y1="50" x2="250" y2="50" class="rpc p1-color"></line>
+        <text x="250" y="35" class="reply">0,1</text>
+
+        <!-- Process 2 -->
+        <text x="25" y="100" class="event">💀</text>
+      </svg>
+    </div>
+
+This is a valid execution under our formal semantics because there exists a
+moment a time in which processes 0 and 1 are in the barrier and process 2 is
+dead.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 160">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+        <text x="0" y="100" class="proc">2</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+        <line x1="10" y1="100" x2="300" y2="100" class="proc-axis"></line>
+
+        <!-- Process 1 -->
+        <text x="25" y="0" class="event">👶</text>
+        <line x1="50" y1="0" x2="250" y2="0" class="rpc p0-color"></line>
+        <text x="250" y="-15" class="reply">0,1</text>
+
+        <!-- Process 2 -->
+        <text x="25" y="50" class="event">👶</text>
+        <line x1="50" y1="50" x2="250" y2="50" class="rpc p1-color"></line>
+        <text x="250" y="35" class="reply">0,1</text>
+
+        <!-- Process 2 -->
+        <text x="25" y="100" class="event">💀</text>
+
+        <!-- Snapshot -->
+        <line x1="150" y1="-20" x2="150" y2="120" class="snapshot"></line>
+      </svg>
+    </div>
+
+In the following execution, process 0 calls ``jax.live_processes`` and receives
+a reply of ``0``. Process 1 calls ``jax.live_processes``, but dies before
+receiving a reply.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 110">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+
+        <!-- Process 0 -->
+        <text x="25" y="0" class="event">👶</text>
+        <line x1="50" y1="0" x2="250" y2="0" class="rpc p0-color"></line>
+        <text x="250" y="-15" class="reply">0</text>
+
+        <!-- Process 1 -->
+        <text x="25" y="50" class="event">👶</text>
+        <line x1="50" y1="50" x2="150" y2="50" class="rpc p1-color"></line>
+        <text x="150" y="50" class="event">💀</text>
+      </svg>
+    </div>
+
+Is this a valid execution? Yes. There exists a moment in time at which process
+0 is in the barrier and process 1 is dead, as shown below. Even though process
+1 called ``jax.live_processes``, it is not guaranteed that process 1 will be
+included in the coordination service's response.
+
+For example, process 1's ``jax.live_processes`` request may have been dropped
+by the network and never received by the coordination service. So from the
+coordination service's perspective, process 1 is thoroughly dead and never even
+entered the ``live_processes`` barrier.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 110">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+
+        <!-- Process 0 -->
+        <text x="25" y="0" class="event">👶</text>
+        <line x1="50" y1="0" x2="250" y2="0" class="rpc p0-color"></line>
+        <text x="250" y="-15" class="reply">0</text>
+
+        <!-- Process 1 -->
+        <text x="25" y="50" class="event">👶</text>
+        <line x1="50" y1="50" x2="150" y2="50" class="rpc p1-color"></line>
+        <text x="150" y="50" class="event">💀</text>
+
+        <!-- Snapshot -->
+        <line x1="200" y1="-20" x2="200" y2="70" class="snapshot"></line>
+      </svg>
+    </div>
+
+What about the same exact execution, except that process 0 now receives the
+reply ``0,1`` from the coordination service?
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 110">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+
+        <!-- Process 0 -->
+        <text x="25" y="0" class="event">👶</text>
+        <line x1="50" y1="0" x2="250" y2="0" class="rpc p0-color"></line>
+        <text x="250" y="-15" class="reply">0,1</text>
+
+        <!-- Process 1 -->
+        <text x="25" y="50" class="event">👶</text>
+        <line x1="50" y1="50" x2="150" y2="50" class="rpc p1-color"></line>
+        <text x="150" y="50" class="event">💀</text>
+      </svg>
+    </div>
+
+Again, this is a valid execution, as witnessed below. Intuitively, the
+coordination service could have received ``jax.live_processes`` requests from
+both processes 0 and 1 and sent the reply ``0,1`` to both. While this reply was
+in the network, process 1 failed. Thus, even though process 1 is dead when
+process 0 receives a reply, the execution is still valid.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 110">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+
+        <!-- Process 0 -->
+        <text x="25" y="0" class="event">👶</text>
+        <line x1="50" y1="0" x2="250" y2="0" class="rpc p0-color"></line>
+        <text x="250" y="-15" class="reply">0,1</text>
+
+        <!-- Process 1 -->
+        <text x="25" y="50" class="event">👶</text>
+        <line x1="50" y1="50" x2="150" y2="50" class="rpc p1-color"></line>
+        <text x="150" y="50" class="event">💀</text>
+
+        <!-- Snapshot -->
+        <line x1="100" y1="-20" x2="100" y2="70" class="snapshot"></line>
+      </svg>
+    </div>
+
+This point bears repeating. If ``jax.live_processes`` returns a set ``P`` of
+processes, it does not mean that all processes in ``P`` are *currently* alive
+and all other processes are *currently* dead. It only means that *there existed
+a point in time* when this was true.
+
+In the following execution, process 1 calls ``jax.live_processes`` and fails.
+Later, process 0 starts, calls ``jax.live_processes``, and receives ``0,1`` as
+a reply.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 110">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+
+        <!-- Process 0 -->
+        <text x="175" y="0" class="event">👶</text>
+        <line x1="200" y1="0" x2="250" y2="0" class="rpc p0-color"></line>
+        <text x="250" y="-15" class="reply">0,1</text>
+
+        <!-- Process 1 -->
+        <text x="25" y="50" class="event">👶</text>
+        <line x1="50" y1="50" x2="100" y2="50" class="rpc p1-color"></line>
+        <text x="100" y="50" class="event">💀</text>
+      </svg>
+    </div>
+
+Using the formal semantics described thus far, this is *not* a valid execution.
+There is never a point in time where process 0 and 1 are both alive. However,
+this *should* be a valid execution.
+
+The reason has to do with the unavoidable fact that in a distributed system, it
+is impossible to detect failures with 100% accuracy. If the coordination
+service hasn't received heartbeats from a process in a while, it considers the
+process dead. But, the coordination service cannot determine with 100%
+certainty when the process died or if the process is actually dead at all.
+Maybe the process died a long time ago, or maybe it died very recently, or
+maybe it is alive but on the other side of a network partition.
+
+Let's return to the execution above for a concrete example. Imagine the
+coordination service successfully received process 1's ``live_processes``
+request. Then, process 1 failed but the coordination service didn't detect the
+failure immediately. In the meantime, the coordination service received process
+0's ``live_processes`` request. At this point, the coordination service thought
+both processes were alive and saw that both processes were in the barrier, so
+it naturally returned ``0,1`` to both processes (though only process 0 received
+the reply because process 1 was dead).
+
+The coordination service thought process 1 was alive when it was dead. And
+sometimes the coordination service might think a process is dead when it is
+alive. Though not ideal, we need to accommodate executions like this because
+they are unavoidable.
+
+We amend our formal semantics and allow ourselves to move a failure either
+earlier or later in time, though we cannot move a failure past a different
+event from the same process. Intuitively, we can move a failure from when it
+actually happened to the point in time when the coordination service thought it
+happened. Continuing the example above, we can delay the failure of process 1
+to create a moment in time in which both processes 0 and 1 are in the barrier,
+witnessing the fact that the execution is valid.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 110">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+
+        <!-- Process 0 -->
+        <text x="175" y="0" class="event">👶</text>
+        <line x1="200" y1="0" x2="250" y2="0" class="rpc p0-color"></line>
+        <text x="250" y="-15" class="reply">0,1</text>
+
+        <!-- Process 1 -->
+        <text x="25" y="50" class="event">👶</text>
+        <line x1="50" y1="50" x2="100" y2="50" class="rpc p1-color">
+          <animate attributeName="x2" values="100;275;100" dur="4s" repeatCount="indefinite"/>
+        </line>
+        <text x="100" y="50" class="event">
+          <animate attributeName="x" values="100;275;100" dur="4s" repeatCount="indefinite"/>
+          💀
+        </text>
+
+        <!-- Snapshot -->
+        <line x1="225" y1="-20" x2="225" y2="70" class="snapshot">
+          <animate attributeName="opacity" values="0;0;0;1;0;0;0" dur="4s" repeatCount="indefinite"/>
+        </line>
+      </svg>
+    </div>
+
+Consider a similar execution below.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 110">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+
+        <!-- Process 0 -->
+        <text x="25" y="0" class="event">👶</text>
+        <line x1="100" y1="0" x2="200" y2="0" class="rpc p0-color"></line>
+        <text x="200" y="-15" class="reply">0</text>
+
+        <!-- Process 1 -->
+        <text x="25" y="50" class="event">👶</text>
+        <line x1="50" y1="50" x2="250" y2="50" class="rpc p1-color"></line>
+        <text x="250" y="50" class="event">💀</text>
+      </svg>
+    </div>
+
+As is, there is no moment in time in which process 0 is alive and process 1 is
+dead. However, if we move the failure of process 1 leftwards, there is. How
+might such an execution arise? Imagine process 1 is partitioned from the
+coordination service. The coordination service doesn't receive any messages
+from process 1, including its heartbeats. This leads the coordination service
+to conclude that process 1 is dead, even though it isn't. Then, the
+coordination service receives process 0's ``live_processes`` request and
+responds with ``0``.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 110">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+
+        <!-- Process 0 -->
+        <text x="25" y="0" class="event">👶</text>
+        <line x1="100" y1="0" x2="200" y2="0" class="rpc p0-color"></line>
+        <text x="200" y="-15" class="reply">0</text>
+
+        <!-- Process 1 -->
+        <text x="25" y="50" class="event">👶</text>
+        <line x1="50" y1="50" x2="250" y2="50" class="rpc p1-color">
+          <animate attributeName="x2" values="250;100;250" dur="4s" repeatCount="indefinite"/>
+        </line>
+        <text x="250" y="50" class="event">
+          <animate attributeName="x" values="250;100;250" dur="4s" repeatCount="indefinite"/>
+          💀
+        </text>
+
+        <!-- Snapshot -->
+        <line x1="150" y1="-20" x2="150" y2="70" class="snapshot">
+          <animate attributeName="opacity" values="0;0;0;1;0;0;0" dur="4s" repeatCount="indefinite"/>
+        </line>
+      </svg>
+    </div>
+
+We cannot move a process failure past the process' other events, however. For
+example, the following execution is *invalid* because no matter where we move
+the failure of process 1, there is never a moment in time where both processes
+are in the barrier.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 110">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+
+        <!-- Process 0 -->
+        <text x="175" y="0" class="event">👶</text>
+        <line x1="200" y1="0" x2="250" y2="0" class="rpc p0-color"></line>
+        <text x="250" y="-15" class="reply">0,1</text>
+
+        <!-- Process 1 -->
+        <text x="25" y="50" class="event">👶</text>
+        <text x="175" y="50" class="event">👶</text>
+        <line x1="50" y1="50" x2="100" y2="50" class="rpc p1-color">
+          <animate attributeName="x2" values="100;150;100" dur="2s" repeatCount="indefinite"/>
+        </line>
+        <text x="100" y="50" class="event">
+          <animate attributeName="x" values="100;150;100" dur="2s" repeatCount="indefinite"/>
+          💀
+        </text>
+      </svg>
+    </div>
+
+With these formal semantics, we can make sense of even complex executions. For
+example, consider the following execution.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 160">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+        <text x="0" y="100" class="proc">2</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+        <line x1="10" y1="100" x2="300" y2="100" class="proc-axis"></line>
+
+        <!-- Process 0 -->
+        <text x="25" y="0" class="event">👶</text>
+        <line x1="40" y1="0" x2="150" y2="0" class="rpc p0-color"></line>
+        <text x="150" y="-15" class="reply">0</text>
+        <line x1="175" y1="0" x2="275" y2="0" class="rpc p0-color"></line>
+        <text x="275" y="-15" class="reply">0,2</text>
+
+        <!-- Process 1 -->
+        <text x="50" y="50" class="event">👶</text>
+        <line x1="65" y1="50" x2="125" y2="50" class="rpc p1-color"></line>
+        <text x="125" y="50" class="event">💀</text>
+        <text x="150" y="50" class="event">👶</text>
+        <line x1="165" y1="50" x2="290" y2="50" class="rpc p1-color"></line>
+        <text x="290" y="50" class="event">💀</text>
+
+        <!-- Process 2 -->
+        <text x="100" y="100" class="event">👶</text>
+        <line x1="115" y1="100" x2="150" y2="100" class="rpc p2-color"></line>
+        <text x="150" y="100" class="event">💀</text>
+      </svg>
+    </div>
+
+
+After moving some process failures, we see the execution is valid.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 160">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+        <text x="0" y="100" class="proc">2</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+        <line x1="10" y1="100" x2="300" y2="100" class="proc-axis"></line>
+
+        <!-- Process 0 -->
+        <text x="25" y="0" class="event">👶</text>
+        <line x1="40" y1="0" x2="150" y2="0" class="rpc p0-color"></line>
+        <text x="150" y="-15" class="reply">0</text>
+        <line x1="175" y1="0" x2="275" y2="0" class="rpc p0-color"></line>
+        <text x="275" y="-15" class="reply">0,2</text>
+
+        <!-- Process 1 -->
+        <text x="50" y="50" class="event">👶</text>
+        <line x1="65" y1="50" x2="75" y2="50" class="rpc p1-color"></line>
+        <text x="75" y="50" class="event">💀</text>
+        <text x="150" y="50" class="event">👶</text>
+        <line x1="165" y1="50" x2="200" y2="50" class="rpc p1-color"></line>
+        <text x="200" y="50" class="event">💀</text>
+
+        <!-- Process 2 -->
+        <text x="100" y="100" class="event">👶</text>
+        <line x1="115" y1="100" x2="275" y2="100" class="rpc p2-color"></line>
+        <text x="275" y="100" class="event">💀</text>
+
+        <!-- Snapshot -->
+        <line x1="87" y1="-20" x2="87" y2="120" class="snapshot"></line>
+        <line x1="225" y1="-20" x2="225" y2="120" class="snapshot"></line>
+      </svg>
+    </div>
+
+The following execution, on the other hand, is invalid.
+
+.. raw:: html
+
+    <div class="svgbox">
+      <svg viewBox="-10 -30 325 160">
+        <!-- Process names -->
+        <text x="0" y="0" class="proc">0</text>
+        <text x="0" y="50" class="proc">1</text>
+        <text x="0" y="100" class="proc">2</text>
+
+        <!-- Process axes -->
+        <line x1="10" y1="0" x2="300" y2="0" class="proc-axis"></line>
+        <line x1="10" y1="50" x2="300" y2="50" class="proc-axis"></line>
+        <line x1="10" y1="100" x2="300" y2="100" class="proc-axis"></line>
+
+        <!-- Process 0 -->
+        <text x="165" y="0" class="event">👶</text>
+        <line x1="180" y1="0" x2="275" y2="0" class="rpc p0-color"></line>
+        <text x="275" y="-15" class="reply">0,2</text>
+
+        <!-- Process 1 -->
+        <text x="25" y="50" class="event">👶</text>
+        <line x1="40" y1="50" x2="125" y2="50" class="rpc p1-color"></line>
+        <text x="125" y="35" class="reply">1</text>
+        <text x="140" y="50" class="event">💀</text>
+
+        <!-- Process 2 -->
+        <text x="25" y="100" class="event">👶</text>
+        <line x1="40" y1="100" x2="275" y2="100" class="rpc p2-color"></line>
+        <text x="275" y="100" class="event">💀</text>
+      </svg>
+    </div>
+
+
+Atomicity
+^^^^^^^^^
+
+Equipped with ``jax.live_processes``, let's try to write some fault-tolerant
+multi-controller JAX code.
+
+.. code-block:: python
+
+   step = 0
+   while True:
+       # Get the devices on all live processes.
+       procs = jax.live_processes()
+       devices = [d for d in jax.devices() if d.process_index in procs]
+
+       # Shard array x over these devices.
+       mesh = jax.make_mesh((len(devices),), ("i",), devices=devices)
+       spec = jax.sharding.PartitionSpec("i")
+       sharding = jax.sharding.NamedSharding(mesh, spec)
+       x = jax.make_array_from_process_local_data(sharding, np.ones(1))
+
+       # Try to perform a jnp.sum.
+       try:
+           print(jnp.sum(x))
+       except:
+           # jnp.sum failed.
+           pass
+       else:
+           # jnp.sum succeeded.
+           step += 1
+
+The code repeatedly
+
+- calls ``jax.live_processes`` to learn which processes are alive,
+- computes the set of devices on the healthy processes,
+- shards an array across these healthy devices,
+- performs a ``jnp.sum`` (i.e. AllReduce) on the array, and
+- increments ``step`` if the ``jnp.sum`` succeeds.
+
+This code *looks* correct, but it has a very subtle bug. Assume the ``jnp.sum``
+is being performed across a set of processes ``P``. If one (or more) of the
+processes in ``P`` fails during the execution of the ``jnp.sum``, then
+``jnp.sum`` can behave differently on different processes. Some processes in
+``P`` might see ``jnp.sum`` return the correct result. Other processes might
+see ``jnp.sum`` raise an exception. Others might see ``jnp.sum`` return an
+incorrect result.
+
+.. warning::
+
+   If a process fails during a collective operation, the operation may behave
+   differently on different processes.
+
+This means that the processes executing the code example above might diverge.
+Some might increment ``step``, and some might not. In the trivial code example
+above, this divergence is benign, but in a real program, the divergence would
+likely lead to a crash, a deadlock, or garbage outputs. For example, if a
+multi-controller JAX program is training a model with data parallelism and
+starts to diverge, some processes might roll back their model weights to a
+previous checkpoint while others continue training, leading to a
+"franken-model" where nobody agrees on what the model weights are supposed to
+be.
+
+To write fault-tolerant code that does not diverge, we want **atomicity**. When
+executing a block of code (like the ``jnp.sum`` above), we either want *every*
+process to run the code successfully, or *every* process to learn that the code
+failed to execute successfully. We don't want some processes succeeding and
+others failing.
+
+Thankfully, we can achieve atomicity with a very simple trick: call
+``live_processes`` twice, once before a code block and once after. If all the
+processes that were alive before the block are also alive after the block, then
+the code block executed successfully on all live processes. On the other hand,
+if any process died, then all remaining processes can agree the code block
+failed to execute properly. Here's a sketch of what that might look like:
+
+.. code-block:: python
+
+        # Get the set of live processes before the code block.
+        procs_before = jax.live_processes()
+
+        # Execute the code block.
+        ...
+
+        # Get the set of live processes after the code block
+        procs_after = jax.live_processes()
+        if procs_before == procs_after:
+            # The code block executed successfully on all processes in
+            # procs_before.
+            pass
+        else:
+            # The code block did not execute successfully. All processes will
+            # agree it failed.
+            pass
+
+The code above should give you a rough idea of how to use two calls to
+``live_processes`` to achieve atomicity, but there are still a handful of small
+issues we need to address before it is fully correct. For example,
+
+- What if the code block throws an exception? We need to catch the exception
+  and still call ``live_processess`` the second time and then re-raise the
+  exception.
+- What if a process fails after the first call to ``live_processes`` and
+  recovers before the second call? Wouldn't the code block fail but the
+  processes before and after be the same? Every time a process starts, it
+  generates a random **incarnation id**. In addition to checking that the set
+  of processes hasn't changed, we also check that their incarnation ids haven't
+  changed.
+- What if a process recovers and its first call to ``live_processes`` matches
+  up with a different process' second call to ``live_processes``? Couldn't this
+  lead to a deadlock? Yes. We can avoid the problem by only calling
+  ``live_processes`` at a single program point. We can be clever and use a
+  single call to ``live_processes`` for two purposes. It can be used to check
+  that the set of processes hasn't changed since the previous call to
+  ``live_processes``, and it can be used to generate the set of live processes
+  that should be used the next time the atomic code block is executed.
+
+All these details are handled and abstracted away by the ``live_devices`` API
+introduced in :ref:`jax-501-ft-part1`. ``live_devices`` is a context manager that
+guarantees the atomic execution of a block of code. In the code snippet below,
+``devices`` is a list of the devices on all live processes. The code block
+``A`` will execute atomically across these processes. That is, either every
+process will see the code raise an exception (branch ``B``) or every process
+will see the code succeed (branch ``C``).
+
+.. code-block:: python
+
+    try:
+      with live_devices() as devices:
+        pass # A
+    except Exception as e:
+      pass # B
+    else:
+      pass # C
+
+Cancelling Collectives
+^^^^^^^^^^^^^^^^^^^^^^
+
+As mentioned in :ref:`jax-501-ft-canceling-collectives`, if a process participating in a
+collective fails, then the other participating processes get stuck forever. We
+need to explicitly cancel these collectives to allow the alive participants to
+make progress. While the ``live_devices`` API is supported on all JAX backends
+(i.e. CPU, GPU, TPU), cancelling collectives is only supported by the GPU
+backend. Here, we briefly explain some of the implementation details behind
+collective cancelling.
+
+The GPU backend implements collectives using `NCCL`_, NVIDIA's collective
+communication library. When a set of processes wants to perform a collective,
+they form a **NCCL communicator**. Processes can then repeatedly perform
+collectives using this communicator. Creating a communicator is expensive---it
+requires network communication---so the JAX backend caches communicators keyed
+by the set of participating processes and their incarnation ids.
+
+Internally, a JAX client polls the coordination service for the current status
+of every process. If a client ever detects that a process is dead or has
+restarted with a new incarnation id, then the client aborts all communicators
+with the failed incarnation id in its cache key.
+
+.. _NCCL: https://developer.nvidia.com/nccl
+.. _Pathways: https://docs.cloud.google.com/ai-hypercomputer/docs/workloads/pathways-on-cloud/pathways-intro
+.. _asynchronous dispatch: https://docs.jax.dev/en/latest/async_dispatch.html
+.. _linearizability: https://cs.brown.edu/~mph/HerlihyW90/p463-herlihy.pdf
+.. _many things in distributed systems: https://en.wikipedia.org/wiki/Fallacies_of_distributed_computing
+.. _reference: https://docs.jax.dev/en/latest/config_options.html#jax_enable_recoverability
+.. _share fate: https://en.wikipedia.org/wiki/Fate-sharing

--- a/docs/new_docs/501/index.rst
+++ b/docs/new_docs/501/index.rst
@@ -1,0 +1,76 @@
+:orphan:
+:nosearch:
+
+JAX 501: systems topics
+=======================
+
+Everything so far assumed one Python process driving some devices. These
+pages are about running JAX as part of a larger system: many processes and
+hosts, long-lived and restartable jobs, artifacts that outlive the process
+that created them, and the machinery that keeps it all fast and safe.
+
+1. :doc:`multiprocess` — multi-controller JAX: running one process per host,
+   process-spanning meshes and arrays, runtime-level pipeline parallelism
+   with ``jax.device_put``, and building global arrays from per-process
+   data.
+2. :doc:`data-loading` — distributed data loading: getting each batch's
+   shards onto the right hosts, for data-parallel and model-parallel
+   workloads.
+3. :doc:`fault-tolerance` — fault-tolerant distributed JAX: surviving
+   machine failures with ``jax.live_devices``, barrier semantics, and
+   recovery, with worked training examples.
+4. :doc:`export` — exporting and serializing staged-out computations for
+   later or cross-platform execution, and :doc:`shape-polymorphism` —
+   exporting with symbolic shapes so one artifact serves many input sizes.
+5. :doc:`compilation-cache` — the persistent compilation cache: skipping
+   recompilation across process restarts and sharing compiled artifacts
+   across nodes.
+6. :doc:`transfer-guard` — logging or disallowing unintended host-device
+   transfers.
+
+Smaller notes
+-------------
+
+A few systems topics are small enough to cover right here.
+
+**Concurrency and threads.** JAX has limited support for Python concurrency:
+it's fine to call JAX APIs like :func:`jax.jit` or :func:`jax.grad` from
+multiple Python threads, but you must not use threads to manipulate JAX
+trace values *inside* a traced function — the likely outcome is a mysterious
+error. In multi-controller JAX (:doc:`multiprocess`) threading has a further
+hazard: every process must enqueue the same operations in the same order on
+a given device, and threads can schedule work in different orders in
+different processes, causing non-deterministic crashes. The
+:func:`jax.thread_guard` context manager helps detect this: once set, an
+error is raised if a JAX operation is issued from a thread other than the
+one where the guard was set.
+
+**Multi-process coordination helpers.** The
+:mod:`jax.experimental.multihost_utils` module collects small utilities for
+multi-controller programs: ``sync_global_devices`` (a named cross-process
+barrier), ``broadcast_one_to_all`` (make process 0's value everyone's
+value), ``process_allgather`` (gather a value from every process),
+``assert_equal`` (check that a value agrees across processes), and
+``host_local_array_to_global_array`` / ``global_array_to_host_local_array``
+(convert between per-host and global views of arrays).
+
+**Compatibility policies for long-lived artifacts.** Serialized artifacts
+outlive the process that made them, so it's worth knowing what's promised:
+exported modules have explicit compatibility windows (see the compatibility
+guarantees in :doc:`export`); persistent compilation cache entries make no
+cross-version promises, but their keys include the jaxlib version, so
+version changes cause cache misses rather than misbehavior; and JAX's
+general API stability rules are described in the
+:doc:`API compatibility policy </api_compatibility>`.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   multiprocess
+   data-loading
+   fault-tolerance
+   export
+   shape-polymorphism
+   compilation-cache
+   transfer-guard

--- a/docs/new_docs/501/multiprocess.md
+++ b/docs/new_docs/501/multiprocess.md
@@ -1,0 +1,946 @@
+---
+nosearch: true
+---
+
+(jax-501-multiprocess)=
+# Introduction to multi-controller JAX (aka multi-process/multi-host JAX)
+
+<!--* freshness: { reviewed: '2025-04-09' } *-->
+
+By reading this tutorial, you'll learn how to scale JAX computations to more
+devices than can fit in a single host machine, e.g. when running on a GPU
+cluster, Cloud TPU pod, or multiple CPU-only machines.
+
+The main idea
+
+- **Run multiple Python processes**, which we sometimes call "controllers." We
+  can run one (or more) process per host machine.
+- **Initialize the cluster with {func}`jax.distributed.initialize`**.
+- **A {class}`jax.Array` can span all processes**, and if each process applies
+  the same JAX function to it, it's like programming against one big device.
+- **Use the same [unified sharding mechanism][distributed_arrays]** as in
+  single-controller JAX to control how data is distributed and computation is
+  parallelized. XLA automatically exploits high-speed networking links like TPU
+  ICI or NVLink between hosts when available, and otherwise uses available host
+  networking (e.g. Ethernet, InfiniBand).
+- **All processes (usually) run the same Python script**. You write this Python
+  code almost exactly the same as you would for a single process — just run
+  multiple instances of it and JAX takes care of the rest. In other words,
+  except for array creation, you can write your JAX code as if there were one
+  giant machine with all devices attached to it.
+
+This tutorial assumes you've read [Distributed arrays and automatic
+parallelization][distributed_arrays], which is about single-controller JAX.
+
+```{figure} ../../_static/multi_process/mcjax_overview.png
+:alt: Illustration of a multi-host TPU pod. Each host in the pod is attached via PCI to a board of four TPU chips. The TPUs chips themselves are connected via high-speed inter-chip interconnects.
+
+Illustration of a multi-host TPU pod. Each host in the pod (green) is attached
+via PCI to a board of four TPU chips (blue). The TPUs chips themselves are
+connected via high-speed inter-chip interconnects (ICI). JAX Python code runs on
+each host, e.g. via ssh. The JAX processes on each host are aware of each other,
+allowing you to orchestrate computation across the entire pods' worth of chips.
+The principle is the same for GPU, CPU, and other platforms with JAX support!
+```
+
+## Toy example
+
+Before we define terms and walk through the details, here's a toy example:
+making a process-spanning {class}`jax.Array` of values and applying
+{mod}`jax.numpy` functions to it.
+
+```python
+# call this file toy.py, to be run in each process simultaneously
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import NamedSharding, PartitionSpec as P
+import numpy as np
+
+# in this example, get multi-process parameters from sys.argv
+import sys
+proc_id = int(sys.argv[1])
+num_procs = int(sys.argv[2])
+
+# initialize the distributed system
+jax.distributed.initialize('localhost:10000', num_procs, proc_id)
+
+# this example assumes 8 devices total
+assert jax.device_count() == 8
+
+# make a 2D mesh that refers to devices from all processes
+mesh = jax.make_mesh((4, 2), ('i', 'j'))
+
+# create some toy data
+global_data = np.arange(32).reshape((4, 8))
+
+# make a process- and device-spanning array from our toy data
+sharding = NamedSharding(mesh, P('i', 'j'))
+global_array = jax.device_put(global_data, sharding)
+assert global_array.shape == global_data.shape
+
+# each process has different shards of the global array
+for shard in global_array.addressable_shards:
+  print(f"device {shard.device} has local data {shard.data}")
+
+# apply a simple computation, automatically partitioned
+global_result = jnp.sum(jnp.sin(global_array))
+print(f'process={proc_id} got result: {global_result}')
+```
+
+Here, `mesh` contains devices from all processes. We use it to create
+`global_array`, logically a single shared array, stored distributed across
+devices from all processes.
+
+Every process must apply the same operations, in the same order, to
+`global_array`. XLA automatically partitions those computations, for example
+inserting communication collectives to compute the `jnp.sum` over the full
+array.  We can print the final result because its value is replicated across
+processes.
+
+We can run this code locally on CPU, e.g. using 4 processes and 2 CPU devices
+per process:
+
+```bash
+export JAX_NUM_CPU_DEVICES=2
+num_processes=4
+
+range=$(seq 0 $(($num_processes - 1)))
+
+for i in $range; do
+  python toy.py $i $num_processes > /tmp/toy_$i.out &
+done
+
+wait
+
+for i in $range; do
+  echo "=================== process $i output ==================="
+  cat /tmp/toy_$i.out
+  echo
+done
+```
+
+Outputs:
+
+```text
+=================== process 0 output ===================
+device TFRT_CPU_0 has local data [[0 1 2 3]]
+device TFRT_CPU_1 has local data [[4 5 6 7]]
+process=0 got result: -0.12398731708526611
+
+=================== process 1 output ===================
+device TFRT_CPU_131072 has local data [[ 8  9 10 11]]
+device TFRT_CPU_131073 has local data [[12 13 14 15]]
+process=1 got result: -0.12398731708526611
+
+=================== process 2 output ===================
+device TFRT_CPU_262144 has local data [[16 17 18 19]]
+device TFRT_CPU_262145 has local data [[20 21 22 23]]
+process=2 got result: -0.12398731708526611
+
+=================== process 3 output ===================
+device TFRT_CPU_393216 has local data [[24 25 26 27]]
+device TFRT_CPU_393217 has local data [[28 29 30 31]]
+process=3 got result: -0.12398731708526611
+```
+
+This might not look so different from single-controller JAX code, and in fact,
+this is exactly how you'd write the single-controller version of the same
+program! (We don't technically need to call {func}`jax.distributed.initialize`
+for single-controller, but it doesn't hurt.) Let's run the same code from a
+single process:
+
+```text
+JAX_NUM_CPU_DEVICES=8 python toy.py 0 1
+```
+
+Outputs:
+
+```text
+device TFRT_CPU_0 has local data [[0 1 2 3]]
+device TFRT_CPU_1 has local data [[4 5 6 7]]
+device TFRT_CPU_2 has local data [[ 8  9 10 11]]
+device TFRT_CPU_3 has local data [[12 13 14 15]]
+device TFRT_CPU_4 has local data [[16 17 18 19]]
+device TFRT_CPU_5 has local data [[20 21 22 23]]
+device TFRT_CPU_6 has local data [[24 25 26 27]]
+device TFRT_CPU_7 has local data [[28 29 30 31]]
+process=0 got result: -0.12398731708526611
+```
+
+The data is sharded across eight devices on one process rather than eight
+devices across four processes, but otherwise we're running the same operations
+over the same data.
+
+## Terminology
+
+It's worth pinning down some terminology.
+
+We sometimes call each Python process running JAX computations a **controller**,
+but the two terms are essentially synonymous.
+
+Each process has a set of **local devices**, meaning it can transfer data to and
+from those devices' memories and run computation on those devices without
+involving any other processes. The local devices are usually physically attached
+to the process's corresponding host, e.g. via PCI. A device can only be local to
+one process; that is, the local device sets are disjoint. A process's local
+devices can be queried by evaluating {func}`jax.local_devices()`. We sometimes
+use the term **addressable** to mean the same thing as local.
+
+```{figure} ../../_static/multi_process/controller_and_local_devices.png
+:alt: Illustration of how a process/controller and local devices fit into a larger multi-host cluster. The "global devices" are all devices in the cluster.
+
+Illustration of how a process/controller and local devices fit into a larger
+multi-host cluster. The "global devices" are all devices in the cluster.
+```
+
+The devices across all processes are called the **global devices**. The list of
+global devices is queried by {func}`jax.devices()`. That list of all devices is
+populated by running {func}`jax.distributed.initialize` on all processes, which
+sets up a simple distributed system connecting the processes.
+
+We often use the terms **global** and **local** to describe process-spanning and
+process-local concepts in general. For example, a "local array" could be a numpy
+array that's only visible to a single process, vs. a JAX "global array" is
+conceptually visible to all processes.
+
+## Setting up multiple JAX processes
+
+In practice, setting up multiple JAX processes looks a bit different from the
+toy example, which is run from a single host machine. We usually launch each
+process on a separate host, or have multiple hosts with multiple processes each.
+We can do that directly using `ssh`, or with a cluster manager like Slurm or
+Kubernetes. In any case, **you must manually run your JAX program on each
+host!** JAX doesn’t automatically start multiple processes from a single program
+invocation.
+
+However they're launched, the Python processes need to run
+{func}`jax.distributed.initialize`. When using Slurm, Kubernetes, or any Cloud
+TPU deployment, we can run {func}`jax.distributed.initialize` with no arguments
+as they're automatically populated. Initializing the system means we can run
+{func}`jax.devices()` to report all devices across all processes.
+
+```{warning}
+{func}`jax.distributed.initialize` must be called before running
+{func}`jax.devices()`, {func}`jax.local_devices()`, or running any computations
+on devices (e.g. with {mod}`jax.numpy`). Otherwise the JAX process won't be
+aware of any non-local devices.  (Using {func}`jax.config` or other
+non-device-accessing functionality is ok.) {func}`jax.distributed.initialize`
+will raise an error if you accidentally call it after accessing any devices.
+```
+
+### GPU Example
+
+We can run multi-controller JAX on a cluster of [GPU machines][gpu_machines].
+For example, after creating four VMs on Google Cloud with two GPUs per VM, we
+can run the following JAX program on every VM. In this example, we provide
+arguments to {func}`jax.distributed.initialize` explicitly.  The coordinator
+address, process id, and number of processes are read from the command line.
+
+```python
+# In file gpu_example.py...
+
+import jax
+import sys
+
+# Get the coordinator_address, process_id, and num_processes from the command line.
+coord_addr = sys.argv[1]
+proc_id = int(sys.argv[2])
+num_procs = int(sys.argv[3])
+
+# Initialize the GPU machines.
+jax.distributed.initialize(coordinator_address=coord_addr,
+                           num_processes=num_procs,
+                           process_id=proc_id)
+print("process id =", jax.process_index())
+print("global devices =", jax.devices())
+print("local devices =", jax.local_devices())
+```
+
+For example, if the first VM has address `192.168.0.1`, then you would run
+`python3 gpu_example.py 192.168.0.1:8000 0 4` on the first VM, `python3
+gpu_example.py 192.168.0.1:8000 1 4` on the second VM, and so on. After running
+the JAX program on all four VMs, the first process prints the following.
+
+```text
+process id = 0
+global devices = [CudaDevice(id=0), CudaDevice(id=1), CudaDevice(id=2), CudaDevice(id=3), CudaDevice(id=4), CudaDevice(id=5), CudaDevice(id=6), CudaDevice(id=7)]
+local devices = [CudaDevice(id=0), CudaDevice(id=1)]
+```
+
+The process successfully sees all eight GPUs as global devices, as well as its
+two local devices. Similarly, the second process prints the following.
+
+```text
+process id = 1
+global devices = [CudaDevice(id=0), CudaDevice(id=1), CudaDevice(id=2), CudaDevice(id=3), CudaDevice(id=4), CudaDevice(id=5), CudaDevice(id=6), CudaDevice(id=7)]
+local devices = [CudaDevice(id=2), CudaDevice(id=3)]
+```
+
+This VM sees the same global devices, but has a different set of local devices.
+
+### TPU Example
+
+As another example, we can run on [Cloud TPU][cloud_tpu]. After creating a
+`v5litepod-16` (which has 4 host machines), we might want to test that we can
+connect the processes and list all devices:
+
+```text
+$ TPU_NAME=jax-demo
+$ EXTERNAL_IPS=$(gcloud compute tpus tpu-vm describe $TPU_NAME --zone 'us-central1-a' \
+                 | grep externalIp | cut -d: -f2)
+$ cat << EOF > demo.py
+import jax
+jax.distributed.initialize()
+if jax.process_index() == 0:
+  print(jax.devices())
+EOF
+$ echo $EXTERNAL_IPS | xargs -n 1 -P 0 bash -c '
+scp demo.py $0:
+ssh $0 "pip -q install -U jax[tpu]"
+ssh $0 "python demo.py" '
+```
+
+Here we're using `xargs` to run multiple `ssh` commands in parallel, each one
+running the same Python program on one of the TPU host machines. In the Python
+code, we use {func}`jax.process_index()` to print only on one process. Here's
+what it prints:
+
+```text
+[TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0), TpuDevice(id=1, process_index=0, coords=(1,0,0), core_on_chip=0), TpuDevice(id=4, process_index=0, coords=(0,1,0), core_on_chip=0), TpuDevice(id=5, process_index=0, coords=(1,1,0), core_on_chip=0), TpuDevice(id=2, process_index=1, coords=(2,0,0), core_on_chip=0), TpuDevice(id=3, process_index=1, coords=(3,0,0), core_on_chip=0), TpuDevice(id=6, process_index=1, coords=(2,1,0), core_on_chip=0), TpuDevice(id=7, process_index=1, coords=(3,1,0), core_on_chip=0), TpuDevice(id=8, process_index=2, coords=(0,2,0), core_on_chip=0), TpuDevice(id=9, process_index=2, coords=(1,2,0), core_on_chip=0), TpuDevice(id=12, process_index=2, coords=(0,3,0), core_on_chip=0), TpuDevice(id=13, process_index=2, coords=(1,3,0), core_on_chip=0), TpuDevice(id=10, process_index=3, coords=(2,2,0), core_on_chip=0), TpuDevice(id=11, process_index=3, coords=(3,2,0), core_on_chip=0), TpuDevice(id=14, process_index=3, coords=(2,3,0), core_on_chip=0), TpuDevice(id=15, process_index=3, coords=(3,3,0), core_on_chip=0)]
+```
+
+Woohoo, look at all those TPU cores!
+
+### Kubernetes Example
+
+Running multi-controller JAX on a Kubernetes cluster is almost identical in spirit to the GPU and TPU examples above: every pod runs the same Python program, JAX discovers its peers, and the cluster behaves like one giant machine.
+
+1. **Container image** - start from a JAX-enabled image, e.g. one of the public JAX AI images on Google Artifact Registry ([TPU][google-artifact-tpu] / [GPU][google-artifact-gpu]) or NVIDIA ([NGC][nvidia-ngc] / [JAX-Toolbox][nvidia-jax-toolbox]).
+
+2. **Workload type** - use either a [JobSet][k8s-jobset] or an [indexed Job][k8s-indexed-job]. Each replica corresponds to one JAX process.
+
+3. **Service Account** - JAX needs permission to list the pods that belong to the job so that processes discover their peers. A minimal RBAC setup is provided in [examples/k8s/svc-acct.yaml][rbac-svc-acct].
+
+Below is a [minimal JobSet][minimal-jobset] that launches two replicas. Replace the placeholders - 
+image, GPU count, and any private registry secrets - with values that match your environment.
+
+```yaml
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: jaxjob
+spec:
+  replicatedJobs:
+  - name: workers
+    template:
+      spec:
+        parallelism: 2
+        completions: 2
+        backoffLimit: 0
+        template:
+          spec:
+            serviceAccountName: jax-job-sa  # kubectl apply -f svc-acct.yaml
+            restartPolicy: Never
+            imagePullSecrets:
+              # https://k8s.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+            - name: null
+            containers:
+            - name: main
+              image: null  # e.g. ghcr.io/nvidia/jax:jax
+              imagePullPolicy: Always
+              resources:
+                limits:
+                  cpu: 1
+                  # https://k8s.io/docs/tasks/manage-gpus/scheduling-gpus/
+                  nvidia.com/gpu: null
+              command: 
+                - python
+              args:
+                - -c
+                - |
+                  import jax
+                  jax.distributed.initialize()
+                  print(jax.devices())
+                  print(jax.local_devices())
+                  assert jax.process_count() > 1
+                  assert len(jax.devices()) > len(jax.local_devices())
+```
+
+Apply the manifest and watch the pods complete:
+
+```bash
+$ kubectl apply -f example.yaml
+$ kubectl get pods -l jobset.sigs.k8s.io/jobset-name=jaxjob
+NAME                       READY   STATUS      RESTARTS   AGE
+jaxjob-workers-0-0-xpx8l   0/1     Completed   0          8m32s
+jaxjob-workers-0-1-ddkq8   0/1     Completed   0          8m32s
+```
+
+When the job finishes, inspect the logs to confirm that every process saw all accelerators:
+
+```bash
+$ kubectl logs -l jobset.sigs.k8s.io/jobset-name=jaxjob
+[CudaDevice(id=0), CudaDevice(id=1)]
+[CudaDevice(id=0)]
+[CudaDevice(id=0), CudaDevice(id=1)]
+[CudaDevice(id=1)]
+```
+
+Every pod should have the same set of global devices and a different set of local devices. At this point, you can replace the inline script with your real JAX program.
+
+Once the processes are set up, we can start building global {class}`jax.Array`s
+and running computations. The remaining Python code examples in this tutorial
+are meant to be run on all processes simultaneously, after running
+{func}`jax.distributed.initialize`.
+
+## Meshes can span processes and hosts
+
+Programming multiple processes from JAX usually looks just like programming a
+single process, just with more devices! The main exceptions to this are around
+data coming in or out of JAX, e.g. when loading from external data sources.
+We'll first go over the basics of multi-process computations here, which largely
+look the same as their single-process counterparts. We'll go over some data
+loading fundamentals, i.e. how to create JAX Arrays from non-JAX sources, later
+in this doc.
+
+Recall a {class}`jax.sharding.Mesh` pairs an array of {class}`jax.Device`s with
+a sequence of names, with one name per array axis.
+Here's an example that directly constructs a `Mesh` using {func}`jax.devices()`
+to get devices from all processes:
+
+```python
+from jax.sharding import Mesh
+mesh = Mesh(jax.devices(), ('a',))
+
+# in this case, the same as
+mesh = jax.make_mesh((jax.device_count(),), ('a',))  # use this in practice
+```
+
+You should probably use the {func}`jax.make_mesh` helper in practice, not only
+because it's simpler but also because it can choose more performant device
+orderings automatically, but we're spelling it out here. By default it includes
+all devices across processes, just like {func}`jax.devices()`.
+
+### Meshes can have non-uniform communication bandwidth
+
+When we scale out to larger GPU and TPU systems, the available communication bandwidth
+between devices in the mesh will no longer be uniform, and it is important to construct
+the mesh appropriately to ensure that the fastest, highest-bandwidth interconnects are
+used for the most communication-intensive operations.
+
+JAX APIs use a TPU-derived nomenclature, with the fast interconnect between nearby chips
+denoted ICI (inter chip interconnect), a collection of chips that are connected by ICI
+called a slice, and the slower interconnect used to communicate between slices called
+DCN (data-center network).
+All of these concepts apply equally to running on GPU, but the usual terminology on GPU is a little different:
+
+| JAX/TPU | NVIDIA GPU                                 |
+| ------- | ------------------------------------------ |
+| ICI     | NVLink                                     |
+| DCN     | InfiniBand (IB), Ethernet, EFA, TCPXO, ... |
+| Slice   | NVLink domain (e.g. 18 hosts with 4 GPUs each in a GB200-NVL72 rack-scale system, 1 host with 8 GPUs in an HGX B200 NVL8 system, ...) |
+
+JAX will automatically detect which devices belong to which slices  during
+{func}`jax.distributed.initialize` and assign `slice_index` values to the
+devices accordingly.
+
+If you are using devices within a single slice (NVLink domain), it is sufficient to use
+{func}`jax.make_mesh`.
+
+If you are using a larger mesh of devices that spans multiple slices, use
+{func}`jax.experimental.mesh_utils.create_hybrid_device_mesh`. For example:
+```
+Mesh(create_hybrid_device_mesh((1, devices_per_slice), (num_slices, 1)), axis_names=("dcn", "ici"))
+```
+will produce a mesh that maps the `dcn` axis to DCN interconnect and the `ici` axis to
+ICI interconnect.
+```{warning}
+On popular GPU systems such as NVIDIA DGX H100 (A3 instances on GCP, P5 on AWS, ...),
+each node is a single NVLink domain, so even a two-node job is a multi-slice device mesh.
+```
+
+Simply reshaping `jax.devices()` to the desired shape will not reliably give good performance,
+use the helper functions described above.
+
+## Arrays and computations can be distributed across hosts
+
+Once we have a multi-process mesh, we can shard arrays over it by using it in a
+{class}`jax.sharding.Sharding`. There are a few ways to
+efficiently build process-spanning arrays, detailed in the last section, but for
+now we'll stick to `jax.device_put` for simplicity:
+
+```python
+arr = jax.device_put(jnp.ones((32, 32)), NamedSharding(mesh, P('a')))
+if jax.process_index() == 0:
+  jax.debug.visualize_array_sharding(arr)
+```
+
+On process 0, this is printed:
+
+```
+┌───────────────────────┐
+│         TPU 0         │
+├───────────────────────┤
+│         TPU 1         │
+├───────────────────────┤
+│         TPU 4         │
+├───────────────────────┤
+│         TPU 5         │
+├───────────────────────┤
+│         TPU 2         │
+├───────────────────────┤
+│         TPU 3         │
+├───────────────────────┤
+│         TPU 6         │
+├───────────────────────┤
+│         TPU 7         │
+├───────────────────────┤
+│         TPU 8         │
+├───────────────────────┤
+│         TPU 9         │
+├───────────────────────┤
+│        TPU 12         │
+├───────────────────────┤
+│        TPU 13         │
+├───────────────────────┤
+│        TPU 10         │
+├───────────────────────┤
+│        TPU 11         │
+├───────────────────────┤
+│        TPU 14         │
+├───────────────────────┤
+│        TPU 15         │
+└───────────────────────┘
+```
+
+Let's try a slightly more interesting computation!
+
+```python
+mesh = jax.make_mesh((jax.device_count() // 2, 2), ('a', 'b'))
+
+def device_put(x, spec):
+  return jax.device_put(x, NamedSharding(mesh, spec))
+
+# construct global arrays by sharding over the global mesh
+x = device_put(jnp.ones((4096, 2048)), P('a', 'b'))
+y = device_put(jnp.ones((2048, 4096)), P('b', None))
+
+# run a distributed matmul
+z = jax.nn.relu(x @ y)
+
+# inspect the sharding of the result
+if jax.process_index() == 0:
+  jax.debug.visualize_array_sharding(z)
+  print()
+  print(z.sharding)
+```
+
+On process 0, this is printed:
+
+```
+┌───────────────────────┐
+│        TPU 0,1        │
+├───────────────────────┤
+│        TPU 4,5        │
+├───────────────────────┤
+│        TPU 8,9        │
+├───────────────────────┤
+│       TPU 12,13       │
+├───────────────────────┤
+│        TPU 2,3        │
+├───────────────────────┤
+│        TPU 6,7        │
+├───────────────────────┤
+│       TPU 10,11       │
+├───────────────────────┤
+│       TPU 14,15       │
+└───────────────────────┘
+
+NamedSharding(mesh=Mesh('a': 8, 'b': 2), spec=PartitionSpec('a',), memory_kind=device)
+```
+
+Here, just from evaluating `x @ y` on all processes, XLA is automatically
+generating and running a distributed matrix multiplication. The result is
+sharded against the mesh like `P('a', None)`, since in this case the matmul
+included a `psum` over the `'b'` axis.
+
+```{warning}
+When applying JAX computations to process-spanning arrays, to avoid deadlocks
+and hangs, **it's crucial that all processes with participating devices run the
+same computation in the same order**. That's because the computation may
+involve collective communication barriers. If a device over which an array is
+sharded does not join in the collective because its controller didn't issue the
+same computation, the other devices are left waiting. For example, if only the
+first three processes evaluated `x @ y`, while the last process evaluated `y @
+x`, the computation would likely hang indefinitely. This assumption,
+computations on process-spanning arrays are run on all participating processes
+in the same order, is mostly unchecked.
+
+So the easiest way to avoid deadlocks in multi-process JAX is to run the same
+Python code on every process, and beware of any control flow that depends on
+{func}`jax.process_index()` and includes communication.
+```
+
+If a process-spanning array is sharded over devices on different processes, it
+is an error to perform operations on the array that require the data to be
+available locally to a process, like printing. For example, if we run `print(z)`
+in the preceding example, we see
+
+```
+RuntimeError: Fetching value for `jax.Array` that spans non-addressable (non process local) devices is not possible. You can use `jax.experimental.multihost_utils.process_allgather` to print the global array or use `.addressable_shards` method of jax.Array to inspect the addressable (process local) shards.
+```
+
+To print the full array value, we must first ensure it's replicated over
+processes (but not necessarily over each process's local devices), e.g. using
+`jax.device_put`. In the above example, we can write at the end:
+
+```
+w = device_put(z, P(None, None))
+if jax.process_index() == 0:
+  print(w)
+```
+
+Be careful not to write the {func}`jax.device_put` under the `if process_index()
+== 0`, because that would lead to a deadlock as only process 0 initiates the
+collective communication and waits indefinitely for the other processes.
+The {mod}`jax.experimental.multihost_utils` module has some functions that
+make it easier to process global {class}`jax.Array`s (e.g.,
+{func}`jax.experimental.multihost_utils.process_allgather`).
+
+Alternatively, to print or otherwise perform Python operations on only
+process-local data, we can access `z.addressable_shards`. Accessing that
+attribute does not require any communication, so any subset of processes can do
+it without needing the others. That attribute is not available under a
+{func}`jax.jit`.
+
+### Running on a subset of devices
+
+In the above examples, we used global meshes over all devices. Multi-controller
+JAX also supports meshes over just a subset of devices, which is useful for
+running different computations concurrently on different devices.
+
+Let's define a mesh that includes just half of the global devices and
+place some data on it. We'll use the `devices` arg of `jax.make_mesh` to
+indicate which devices to use.
+
+```python
+num_devices = jax.device_count() // 2
+mesh = jax.make_mesh((num_devices,), ('a',),
+                     devices=jax.devices()[num_devices:],
+                     axis_types=(jax.sharding.AxisType.Explicit,))
+sharding = NamedSharding(mesh, P('a'))
+
+data = np.arange(64).reshape((8, 8))
+x = jax.device_put(data, sharding)
+
+# inspect the sharding of the result
+if jax.process_index() == 0:
+  jax.debug.visualize_array_sharding(x)
+  print()
+  print(x.sharding)
+
+# inspect the data local to each host
+print(f"Devices attached to process {jax.process_index()}: {jax.local_devices()}")
+print(f"Addressable data for process {jax.process_index()}:")
+for shard in x.addressable_shards:
+  print(f"device {shard.device} has local data {shard.data}")
+```
+
+The sharding, again on a four-host `v5litepod-16`, looks like this:
+
+```
+┌───────────────────────┐
+│         TPU 8         │
+├───────────────────────┤
+│         TPU 9         │
+├───────────────────────┤
+│        TPU 10         │
+├───────────────────────┤
+│        TPU 11         │
+├───────────────────────┤
+│        TPU 15         │
+├───────────────────────┤
+│        TPU 14         │
+├───────────────────────┤
+│        TPU 13         │
+├───────────────────────┤
+│        TPU 12         │
+└───────────────────────┘
+
+NamedSharding(mesh=Mesh('a': 8, axis_types=(Explicit,)), spec=PartitionSpec('a',), memory_kind=device)
+```
+
+Only processes 2 and 3 have local devices in the sharding; processes 0 and 1
+don't participate. Since process 0 has no addressable data in the array, it
+prints the following:
+
+```
+Devices attached to process 0: [TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0), TpuDevice(id=1, process_index=0, coords=(1,0,0), core_on_chip=0), TpuDevice(id=4, process_index=0, coords=(0,1,0), core_on_chip=0), TpuDevice(id=5, process_index=0, coords=(1,1,0), core_on_chip=0)]
+
+Addressable data for process 0:
+```
+
+Process 1 prints something similar. Process 3, on the other hand, has half of
+the array's data on its local devices, so it prints the following:
+
+```
+Devices attached to process 3: [TpuDevice(id=10, process_index=3, coords=(2,2,0), core_on_chip=0), TpuDevice(id=11, process_index=3, coords=(3,2,0), core_on_chip=0), TpuDevice(id=14, process_index=3, coords=(2,3,0), core_on_chip=0), TpuDevice(id=15, process_index=3, coords=(3,3,0), core_on_chip=0)]
+Addressable data for process 3
+device TPU_10(process=3,(2,2,0,0)) has local data [[16 17 18 19 20 21 22 23]]
+device TPU_11(process=3,(3,2,0,0)) has local data [[24 25 26 27 28 29 30 31]]
+device TPU_15(process=3,(3,3,0,0)) has local data [[32 33 34 35 36 37 38 39]]
+device TPU_14(process=3,(2,3,0,0)) has local data [[40 41 42 43 44 45 46 47]]
+```
+
+Now let's run the same computation as in `toy.py` above with this array as
+input. This time, only the devices attached to processes 2 and 3
+participate, and the collective `jnp.sum` replicates the result across only
+those devices.
+
+```python
+result = jnp.sum(jnp.sin(x))
+print(f"process={jax.process_index()} got result: {result}")
+```
+
+Process 2 (and 3) can print the result:
+```
+process=2 got result: Array(0.09658563, dtype=float32)
+```
+
+Processes 0 and 1 have no participating devices, so they don't have local
+copies of the result. Process 0 prints
+```
+process=0 got result: Array(shape=(), dtype=float32)
+```
+
+Keep in mind that each process must apply the same operations in the same order
+*in processes that participate in the sharding*. In previous examples, all
+processes participated. In this example, we could have run the computation only
+in processes 2 and 3, but applying it in non-participating processes is fine
+too and will produce an array with no local data, as in process 0 above.
+
+### Transferring data across processes with `jax.device_put`
+
+{func}`jax.device_put` can transfer data between devices across processes. As
+with cross-process collectives, the data is transferred via high-speed
+networking links like TPU ICI or NVLink when available. Cross-process
+{func}`jax.device_put` must be called on all hosts that participate in either
+the source or destination sharding.
+
+An example use case is a pipeline-parallel program where each stage runs on a
+different set of devices. After the first stage completes, use
+{func}`jax.device_put` to transfer the result to another set of devices for the
+next stage of the pipeline. Here's a simple illustration:
+
+```python
+# Create a sharding that contains half of the global devices for the first
+# stage of the pipeline.
+num_devices = jax.device_count() // 2
+mesh_first_half = jax.make_mesh((num_devices,), ('a',),
+                                devices=jax.devices()[:num_devices],
+                                axis_types=(jax.sharding.AxisType.Explicit,))
+sharding_first_half = NamedSharding(mesh_first_half, P('a'))
+
+# Create a sharding that contains the other half of the devices.
+mesh_second_half = jax.make_mesh((num_devices,), ('a',),
+                                 devices=jax.devices()[num_devices:],
+                                 axis_types=(jax.sharding.AxisType.Explicit,))
+sharding_second_half = NamedSharding(mesh_second_half, P('a'))
+
+# Place the input data on the first mesh.
+data = np.arange(64).reshape((8, 8))
+x = jax.device_put(data, sharding_first_half)
+
+# `f` is the first stage of the pipeline.
+@jax.jit
+def f(x):
+  # Arbitrary JAX computation.
+  return x
+
+# `g` is the second stage of the pipeline
+@jax.jit
+def g(x):
+  # More JAX operations.
+  return x
+
+# Run the first stage on the first set of devices.
+y = f(x)
+
+# Transfer the data to the second set of devices.
+# `device_put` must be called in all processes that participate in either
+# `y.sharding` or `sharding_second_half`, so it's important to call `y = f(x)`
+# in all processes -- not just those that participate in the first stage -- so
+# that we always have a reference to `y`.
+z = jax.device_put(y, sharding_second_half)
+
+# Run the second stage on the second set of devices.
+result = g(z)
+```
+
+Thanks to JAX's {ref}`jax-201-async-dispatch`, {func}`jax.jit` functions and/or
+{func}`jax.device_put`s running on different devices will run in parallel if
+their inputs are ready. We can take advantage of this to implement a very
+simple example of microbatched pipeline parallelism:
+
+```python
+# Pipeline stage functions. Each stage will run on a different device.
+pipeline_stages = [f, g, f, g]
+devices = jax.devices()[:4]
+
+microbatches = [np.arange(512**2).reshape((512, 512)) for _ in range(12)]
+
+# Each microbatch is enqueued on each device sequentially, but each device
+# conceptually has an independent queue of computations and transfers which can
+# run in parallel across queues. For example, because there are no data
+# dependencies between the microbatches, device 0 will immediately start a new
+# microbatch once the previous is finished, overlapping with the `device_put` to
+# device 1.
+results = []
+for mb in microbatches:
+  for d, s in zip(devices, pipeline_stages):
+    mb = jax.device_put(mb, d)
+    mb = s(mb)
+  results.append(mb)
+```
+
+Cross-process {func}`jax.device_put` is currently supported only when the
+source and destination shardings contain the same number of devices and have
+the same shard shapes. If you're finding this overly restrictive, please file a
+[Github Issue](https://github.com/jax-ml/jax/issues).
+
+## Making process-spanning arrays from external data
+
+There are three main ways to create process-spanning {class}`jax.Array`s from
+external data sources (e.g. numpy arrays from a data loader):
+
+1. Create or load the full array on all processes, then shard onto devices using
+   {func}`jax.device_put`;
+
+2. Create or load on each process an array representing just the data that will
+   be locally sharded and stored on that process's devices, then shard onto
+   devices using {func}`jax.make_array_from_process_local_data`;
+
+3. Create or load on each process's devices separate arrays, each representing
+   the data to be stored on that device, then assemble them without any data
+   movement using {func}`jax.make_array_from_single_device_arrays`.
+
+The latter two are most often used in practice, since it's often too expensive
+to materialize the full global data in every process.
+
+The toy example above uses {func}`jax.device_put`.
+
+{func}`jax.make_array_from_process_local_data` is often used for distributed data
+loading. It's not as general as {func}`jax.make_array_from_single_device_arrays`,
+because it doesn't directly specify which slice of the process-local data goes
+on each local device. This is convenient when loading data-parallel batches,
+because it doesn't matter exactly which microbatch goes on each device. For
+example:
+
+```python
+# target (micro)batch size across the whole cluster
+batch_size = 1024
+# how many examples each process should load per batch
+per_process_batch_size = batch_size // jax.process_count()
+# how many examples each device will process per batch
+per_device_batch_size = batch_size // jax.device_count()
+
+# make a data-parallel mesh and sharding
+mesh = jax.make_mesh((jax.device_count(),), ('batch'))
+sharding = NamedSharding(mesh, P('batch'))
+
+# our "data loader". each process loads a different set of "examples".
+process_batch = np.random.rand(per_process_batch_size, 2048, 42)
+
+# assemble a global array containing the per-process batches from all processes
+global_batch = jax.make_array_from_process_local_data(sharding, process_batch)
+
+# sanity check that everything got sharded correctly
+assert global_batch.shape[0] == batch_size
+assert process_batch.shape[0] == per_process_batch_size
+assert global_batch.addressable_shards[0].data.shape[0] == per_device_batch_size
+```
+
+{func}`jax.make_array_from_single_device_arrays` is the most general way to
+build a process-spanning array. It's often used after performing
+{func}`jax.device_put`s to send each device its required data. This is the
+lowest-level option, since all data movement is performed manually (via e.g.
+{func}`jax.device_put`). Here's an example:
+
+```python
+shape = (jax.process_count(), jax.local_device_count())
+mesh = jax.make_mesh(shape, ('i', 'j'))
+sharding = NamedSharding(mesh, P('i', 'j'))
+
+# manually create per-device data equivalent to np.arange(jax.device_count())
+# i.e. each device will get a single scalar value from 0..N
+local_arrays = [
+    jax.device_put(
+        jnp.array([[jax.process_index() * jax.local_device_count() + i]]),
+        device)
+    for i, device in enumerate(jax.local_devices())
+]
+
+# assemble a global array from the local_arrays across all processes
+global_array = jax.make_array_from_single_device_arrays(
+    shape=shape,
+    sharding=sharding,
+    arrays=local_arrays)
+
+# sanity check
+assert (np.all(
+    jax.experimental.multihost_utils.process_allgather(global_array) ==
+    np.arange(jax.device_count()).reshape(global_array.shape)))
+```
+
+All of these methods can also be used to create arrays that span only a subset
+of processes. For example, we can use {func}`jax.make_array_from_single_device_arrays`
+to create an array spanning the devices on processes 0 and 1:
+
+```python
+num_participating_processes = 2
+shape = (num_participating_processes, jax.local_device_count())
+devices = (jax.local_devices(process_index=0) +
+           jax.local_devices(process_index=1))
+mesh = jax.make_mesh(shape, ('i', 'j'),
+                     axis_types=(jax.sharding.AxisType.Explicit,) * 2,
+                     devices=devices)
+sharding = NamedSharding(mesh, P('i', 'j'))
+
+# manually create per-device data in processes 0 and 1.
+if jax.process_index() in (0, 1):
+  local_arrays = [
+      jax.device_put(
+          jnp.array([[jax.process_index() * jax.local_device_count() + i]]),
+          device)
+      for i, device in enumerate(jax.local_devices())
+  ]
+else:
+  local_arrays = []
+
+# assemble an array from the local_arrays across processes 0 and 1
+array = jax.make_array_from_single_device_arrays(
+    shape=shape,
+    sharding=sharding,
+    arrays=local_arrays,
+    dtype=jnp.int32)
+
+# sanity check
+if jax.process_index() in (0, 1):
+  for shard in array.addressable_shards:
+    assert shard.data.size == 1
+else:
+  assert not array.addressable_shards
+```
+
+[cloud_tpu]: https://cloud.google.com/tpu?hl=en
+[distributed_arrays]: ../201/sharding.md
+[gpu_machines]: https://cloud.google.com/compute/docs/gpus
+[google-artifact-tpu]: https://console.cloud.google.com/artifacts/docker/cloud-tpu-images/us/jax-ai-image/tpu
+[google-artifact-gpu]: https://console.cloud.google.com/artifacts/docker/deeplearning-images/us-central1/jax-ai-image/gpu
+[nvidia-ngc]: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/jax
+[nvidia-jax-toolbox]: https://github.com/NVIDIA/JAX-Toolbox
+[k8s-jobset]: https://github.com/kubernetes-sigs/jobset
+[k8s-indexed-job]: https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs
+[rbac-svc-acct]: https://github.com/jax-ml/jax/blob/main/examples/k8s/svc-acct.yaml
+[minimal-jobset]: https://github.com/jax-ml/jax/blob/main/examples/k8s/example.yaml

--- a/docs/new_docs/501/shape-polymorphism.md
+++ b/docs/new_docs/501/shape-polymorphism.md
@@ -1,0 +1,642 @@
+---
+nosearch: true
+---
+
+(jax-501-shape-poly)=
+# Shape polymorphism
+
+When JAX is used in JIT mode, a function will be traced, lowered to StableHLO, and compiled for each
+combination of input types and shapes. After exporting a function and
+deserializing it on another system we don't have the Python sources available anymore,
+so we cannot re-trace and re-lower it. **Shape polymorphism** is a feature of JAX export
+to allow some exported functions to be used for a whole family of input shapes.
+These functions are traced and lowered once, during exporting, and `Exported`
+object contains the information needed to be able to compile and execute the function
+on many concrete input shapes. We do this by specifying shapes that contain
+dimension variables (symbolic shapes) when exporting, as in the
+following example:
+
+```python
+>>> import jax
+>>> from jax import export
+>>> from jax import numpy as jnp
+>>> def f(x):  # f: f32[a, b]
+...   return jnp.concatenate([x, x], axis=1)
+
+>>> # We construct symbolic dimension variables.
+>>> a, b = export.symbolic_shape("a, b")
+
+>>> # We can use the symbolic dimensions to construct shapes.
+>>> x_shape = (a, b)
+>>> x_shape
+(a, b)
+
+>>> # Then we export with symbolic shapes:
+>>> exp: export.Exported = export.export(jax.jit(f))(
+...     jax.ShapeDtypeStruct(x_shape, jnp.int32))
+>>> exp.in_avals
+(ShapedArray(int32[a,b]),)
+>>> exp.out_avals
+(ShapedArray(int32[a,2*b]),)
+
+>>> # We can later call with concrete shapes (with a=3 and b=4), without re-tracing `f`.
+>>> res = exp.call(np.ones((3, 4), dtype=np.int32))
+>>> res.shape
+(3, 8)
+
+```
+
+Note that such functions are still re-compiled on demand for
+each concrete input shape they are invoked on. Only the
+tracing and the lowering are saved.
+
+The {func}`jax.export.symbolic_shape` is used in the above
+example to parse a string representation of a symbolic shape
+into dimension expressions objects (of type `_DimExpr`) that are usable in place of integer
+constants to construct shapes. The dimension expression objects
+overload most integer operators, so you can use them as
+you'd use integer constants in most cases.
+See {ref}`jax-501-computing-with-dimension-variables` for more details.
+
+Additionally, we provide the {func}`jax.export.symbolic_args_specs` that
+can be used to construct pytrees of `jax.ShapeDtypeStruct` objects based
+on a polymorphic shape specification:
+
+```python
+>>> def f1(x, y): # x: f32[a, 1], y : f32[a, 4]
+...  return x + y
+
+>>> # Assuming you have some actual args with concrete shapes
+>>> x = np.ones((3, 1), dtype=np.int32)
+>>> y = np.ones((3, 4), dtype=np.int32)
+>>> args_specs = export.symbolic_args_specs((x, y), "a, ...")
+>>> exp = export.export(jax.jit(f1))(* args_specs)
+>>> exp.in_avals
+(ShapedArray(int32[a,1]), ShapedArray(int32[a,4]))
+
+```
+
+Note how the polymorphic shape specification `"a, ..."` contains
+the placeholder `...` to be filled from the concrete shapes of
+the concrete shapes of the arguments `(x, y)`.
+The placeholder `...` stands for 0 or more dimensions, while the
+placeholder `_` stands for one dimension.
+The {func}`jax.export.symbolic_args_specs` supports pytrees of arguments,
+which are used to fill-in the dtypes and any placeholders.
+The function will construct a pytree of
+argument specifications ({class}`jax.ShapeDtypeStruct`)
+matching the structure of the arguments passed to it.
+The polymorphic shapes specification can be a
+pytree prefix in cases where one specification should apply
+to multiple arguments, as in the above example.
+See [how optional parameters are matched to arguments](https://docs.jax.dev/en/latest/pytrees.html#applying-optional-parameters-to-pytrees).
+
+
+A few examples of shape specifications:
+
+  * `("(b, _, _)", None)` can be used for a function with two arguments, the first
+    being a 3D array with a batch leading dimension that should be symbolic.
+    The other dimensions for the
+    first argument and the shape of the second argument are specialized based on the actual
+    arguments. Note that the same specification would work if the first
+    argument is a pytree of 3D arrays, all with the same leading dimension
+    but possibly with different trailing dimensions.
+    The value `None` for the second argument means that the argument
+    is not symbolic. Equivalently, one can use `...`.
+
+  * `("(batch, ...)", "(batch,)")` specifies that the two arguments
+    have matching leading dimensions, the first argument has rank at
+    least 1, and the second has rank 1.
+
+## Correctness of shape polymorphism
+
+We want to trust that the exported program produces the same results as the
+original JAX program when compiled and executed for any applicable concrete shapes.
+More precisely:
+
+For any JAX function `f` and any argument specification `arg_spec` containing a
+symbolic shape, and any concrete argument `arg` whose shape matches `arg_spec`:
+
+ * If the JAX native execution succeeds on the concrete argument: `res = f(arg)`,
+ * and if the exporting succeeds with symbolic shapes: `exp = export.export(f)(arg_spec)`,
+ * then compiling and running the export will succeed with the same result: `res == exp.call(arg)`
+
+It is crucial to understand that `f(arg)` has the freedom to re-invoke
+the JAX tracing machinery,
+and in fact it does so for each distinct concrete `arg` shape,
+while the execution of `exp.call(arg)` cannot use JAX tracing anymore
+(this execution may happen in an environment where the source code
+of `f` is not available).
+
+Ensuring this form of correctness is hard, and in the hardest cases
+exporting fails. The rest of this chapter describes how to handle these failures.
+
+(jax-501-computing-with-dimension-variables)=
+
+## Computing with dimension variables
+
+JAX keeps track of the shapes of all intermediate results. When those shapes depend
+on dimension variables JAX computes them as symbolic dimension expressions
+involving dimension variables.
+Dimension variables stand for integer values greater or equal to 1.
+The symbolic expressions can represent the result
+of applying arithmetic operators (add, sub, mul, floordiv, mod,
+including the NumPy variants `np.sum`, `np.prod`, etc.) **on dimension
+expressions and integers** (`int`, `np.int`, or anything convertible by `operator.index`).
+These symbolic dimensions can then be used in shape-parameters of JAX primitives
+and APIs, e.g., in `jnp.reshape`, `jnp.arange`, slicing indices, etc.
+
+For example, in the following code to flatten a 2D array, the computation
+`x.shape[0] * x.shape[1]` computes the symbolic dimension `4 * b` as the
+new shape:
+
+```python
+>>> f = lambda x: jnp.reshape(x, (x.shape[0] * x.shape[1],))
+>>> arg_spec = jax.ShapeDtypeStruct(export.symbolic_shape("b, 4"), jnp.int32)
+>>> exp = export.export(jax.jit(f))(arg_spec)
+>>> exp.out_avals
+(ShapedArray(int32[4*b]),)
+
+```
+
+It is possible to convert dimension expressions explicitly
+to JAX arrays, with `jnp.array(x.shape[0])` or even `jnp.array(x.shape)`.
+The result of these operations can be used as regular JAX arrays,
+but cannot be used anymore as dimensions in shapes, e.g., in `reshape`:
+
+```python
+>>> exp = export.export(jax.jit(lambda x: jnp.array(x.shape[0]) + x))(
+...     jax.ShapeDtypeStruct(export.symbolic_shape("b"), np.int32))
+>>> exp.call(jnp.arange(3, dtype=np.int32))
+Array([3, 4, 5], dtype=int32)
+
+>>> exp = export.export(jax.jit(lambda x: x.reshape(jnp.array(x.shape[0]) + 2)))(
+...     jax.ShapeDtypeStruct(export.symbolic_shape("b"), np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+TypeError: Shapes must be 1D sequences of concrete values of integer type, got [Traced<ShapedArray(int32[], weak_type=True)>with<DynamicJaxprTrace(level=1/0)>].
+
+```
+
+When a symbolic dimension is used in arithmetic operations with **non-integers**,
+e.g., `float`, `np.float`, `np.ndarray`, or JAX arrays, it is automatically
+converted to a JAX array using `jnp.array`.
+For example, in the function below all occurrences of `x.shape[0]`
+are converted implicitly to `jnp.array(x.shape[0])` because
+they are involved in operations with non-integer scalars or with
+JAX arrays:
+
+```python
+>>> exp = export.export(jax.jit(
+...     lambda x: (5. + x.shape[0],
+...                x.shape[0] - np.arange(5, dtype=jnp.int32),
+...                x + x.shape[0] + jnp.sin(x.shape[0]))))(
+...     jax.ShapeDtypeStruct(export.symbolic_shape("b"), jnp.int32))
+>>> exp.out_avals
+(ShapedArray(float32[], weak_type=True),
+ ShapedArray(int32[5]),
+ ShapedArray(float32[b], weak_type=True))
+
+>>> exp.call(jnp.ones((3,), jnp.int32))
+ (Array(8., dtype=float32, weak_type=True),
+  Array([ 3, 2, 1, 0, -1], dtype=int32),
+  Array([4.14112, 4.14112, 4.14112], dtype=float32, weak_type=True))
+
+```
+
+Another typical example is when computing averages
+(observe how `x.shape[0]` is automatically turned into a JAX array):
+
+```python
+>>> exp = export.export(jax.jit(
+...     lambda x: jnp.sum(x, axis=0) / x.shape[0]))(
+...     jax.ShapeDtypeStruct(export.symbolic_shape("b, c"), jnp.int32))
+>>> exp.call(jnp.arange(12, dtype=jnp.int32).reshape((3, 4)))
+Array([4., 5., 6., 7.], dtype=float32)
+
+```
+
+### Errors in presence of shape polymorphism
+
+Most JAX code assumes that the shapes of JAX arrays are tuples of integers,
+but with shape polymorphism some dimensions may be symbolic expressions.
+This can lead to a number of errors. For example, we can have the usual
+JAX shape check errors:
+
+```python
+>>> v, = export.symbolic_shape("v,")
+>>> export.export(jax.jit(lambda x, y: x + y))(      # doctest: +IGNORE_EXCEPTION_DETAIL
+...     jax.ShapeDtypeStruct((v,), dtype=np.int32),  # doctest: +IGNORE_EXCEPTION_DETAIL
+...     jax.ShapeDtypeStruct((4,), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+TypeError: add got incompatible shapes for broadcasting: (v,), (4,).
+
+>>> export.export(jax.jit(lambda x: jnp.matmul(x, x)))(  # doctest: +IGNORE_EXCEPTION_DETAIL
+...     jax.ShapeDtypeStruct((v, 4), dtype=np.int32))    # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+TypeError: dot_general requires contracting dimensions to have the same shape, got (4,) and (v,).
+
+```
+
+We can fix the above matmul example by specifying that the
+argument has shape `(v, v)`.
+
+### Comparison of symbolic dimensions is partially supported
+
+Inside JAX there are a number of equality and inequality comparisons
+involving shapes, e.g., for doing shape checking or even for choosing
+the implementation for some primitives. Comparisons are supported
+as follows:
+
+  * equality is supported with a caveat: if the two symbolic dimensions denote the same
+    value under all valuations for dimension variables, then equality evaluates to `True`,
+    e.g., for `b + b == 2*b`; otherwise the equality evaluates to `False`.
+    See [below](#caveat-for-equality-comparisons)
+    for a discussion of important consequences of this behavior.
+  * disequality is always the negation of equality.
+  * inequality is partially supported, in a similar way as partial equality.
+    However, in this
+    case we take into consideration that dimension variables range over strictly positive
+    integers. E.g., `b >= 1`, `b >= 0`, `2 * a + b >= 3` are `True`, while `b >= 2`,
+    `a >= b`, `a - b >= 0` are inconclusive and result in an exception.
+
+In cases where a comparison operation cannot be resolved to a boolean,
+we raise {class}`InconclusiveDimensionOperation`. E.g.,
+
+```python
+import jax
+>>> export.export(jax.jit(lambda x: 0 if x.shape[0] + 1 >= x.shape[1] else 1))(
+...     jax.ShapeDtypeStruct(export.symbolic_shape("a, b"), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+jax._src.export.shape_poly.InconclusiveDimensionOperation: Symbolic dimension comparison 'a + 1' >= 'b' is inconclusive.
+This error arises for comparison operations with shapes that
+are non-constant, and the result of the operation cannot be represented as
+a boolean value for all values of the symbolic dimensions involved.
+
+```
+
+If you do get a `InconclusiveDimensionOperation`, you can try
+several strategies:
+
+ * If your code uses the built-in `max` or `min`, or the
+   `np.max` or `np.min` then you can replace those with
+   `core.max_dim` and `core.min_dim`, which have the effect
+   of delaying the inequality comparison to the compilation
+   time, when shapes become known.
+ * Try to rewrite conditionals using `core.max_dim` and
+   `core.min_dim`, e.g., instead of `d if d > 0 else 0`
+   you can write `core.max_dim(d, 0)`.
+ * Try to rewrite the code to be less dependent on the fact
+   that dimensions should be integers, and rely on the fact
+   that symbolic dimensions duck-type as integers for most
+   arithmetic operations. E.g., instead of `int(d) + 5` write
+   `d + 5`.
+ * Specify symbolic constraints, as explained below.
+
+#### User-specified symbolic constraints
+
+By default, JAX assumes that all dimension variables range
+over values greater-or-equal to 1, and it tries to derive
+other simple inequalities from that, e.g.:
+
+  * `a + 2 >= 3`,
+  * `a * 2 >= 1`,
+  * `a + b + c >= 3`,
+  * `a // 4 >= 0`, `a**2 >= 1`, and so on.
+
+You can avoid some inequality comparison failures if you
+change the symbolic shape specifications to add **implicit** constraints
+for dimension sizes. E.g.,
+
+  * You can use `2*b` for a dimension to constrain it to be even and greater or equal
+    to 2.
+  * You can use `b + 15` for a dimension to constrain it to
+    be at least 16. E.g., the following code would fail without
+    the `+ 15` part, because JAX will want to verify that slice sizes
+    are at most as large as the axis size.
+
+```python
+>>> _ = export.export(jax.jit(lambda x: x[0:16]))(
+...    jax.ShapeDtypeStruct(export.symbolic_shape("b + 15"), dtype=np.int32))
+
+```
+
+Such implicit symbolic constraints are used for deciding comparisons and are
+checked at compile time, as explained [below](#shape-assertion-errors).
+
+You can also specify **explicit** symbolic constraints:
+
+```python
+>>> # Introduce dimension variable with constraints.
+>>> a, b = export.symbolic_shape("a, b",
+...                              constraints=("a >= b", "b >= 16"))
+>>> _ = export.export(jax.jit(lambda x: x[:x.shape[1], :16]))(
+...    jax.ShapeDtypeStruct((a, b), dtype=np.int32))
+
+```
+
+The constraints form a conjunction together with the implicit
+constraints. You can specify `>=`, `<=`, and `==` constraints.
+At the moment, JAX has limited support for reasoning with
+symbolic constraints:
+
+  * You get the most from constraints of the form
+    of a variable being greater-or-equal or
+    less-or-equal to a constant.
+    For example, from the constraints that
+    `a >= 16` and `b >= 8` we can infer
+    that `a + 2*b >= 32`.
+  * You get limited power when the constraint involves
+    more complex expressions, e.g., from `a >= b + 8` we
+    can infer that `a - b >= 8` but not that `a >= 9`.
+    We may improve somewhat this area in the future.
+  * Equality constraints are treated as rewrite rules:
+    whenever the symbolic expression on the left of `==`
+    is encountered, it is rewritten to the expression on
+    the right.
+    E.g., `floordiv(a, b) == c` works by replacing all
+    occurrences of `floordiv(a, b)` with `c`.
+    Equality constraints must not contain addition or
+    subtraction at the top-level on the left-hand-side. Examples of
+    valid left-hand-sides are `a * b`, or `4 * a`, or
+    `floordiv(a + c, b)`.
+
+```python
+>>> # Introduce dimension variable with equality constraints.
+>>> a, b, c, d = export.symbolic_shape("a, b, c, d",
+...                                    constraints=("a * b == c + d",))
+>>> 2 * b * a
+2*d + 2*c
+
+>>> a * b * b
+b*d + b*c
+
+```
+
+The symbolic constraints can also help to work around the
+limitations in the JAX reasoning mechanisms.
+For example, in the code below JAX will attempt to prove that
+the slice size `x.shape[0] % 3`, which is the symbolic expression
+`mod(b, 3)`, is less or equal to the axis size, which is `b`.
+This happens to be true for all strictly positive values of
+`b`, but it is not something JAX's symbolic comparison rules
+can prove. Hence, the following code raises an error:
+
+```python
+from jax import lax
+>>> b, = export.symbolic_shape("b")
+>>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % 3)
+>>> export.export(jax.jit(f))(
+...     jax.ShapeDtypeStruct((b,), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+jax._src.export.shape_poly.InconclusiveDimensionOperation: Symbolic dimension comparison 'b' >= 'mod(b, 3)' is inconclusive.
+This error arises for comparison operations with shapes that
+are non-constant, and the result of the operation cannot be represented as
+a boolean value for all values of the symbolic dimensions involved.
+
+```
+
+One option here would be to restrict the code to work only on
+axis sizes that are multiple of `3` (by replacing
+`b` with `3*b` in the shape). Then, JAX would be able
+to simplify the modulo operation `mod(3*b, 3)` to `0`.
+Another option is to add a symbolic constraint
+with the exact inconclusive inequality that JAX
+is attempting to prove:
+
+```python
+>>> b, = export.symbolic_shape("b",
+...                            constraints=["b >= mod(b, 3)"])
+>>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % 3)
+>>> _ = export.export(jax.jit(f))(
+...     jax.ShapeDtypeStruct((b,), dtype=np.int32))
+
+```
+
+Just like the implicit constraints, the explicit
+symbolic constraints are checked at compile time,
+using the same mechanism as explained [below](#shape-assertion-errors).
+
+#### Symbolic dimension scopes
+
+The symbolic constraints are stored in αn
+{class}`jax.export.SymbolicScope` object, which is created implicitly
+for each call to {func}`jax.export.symbolic_shapes`. You must be careful
+to not mix symbolic expressions that use different scopes.
+For example,
+the following code will fail because `a1` and `a2`
+use different scopes (created by different invocations of
+{func}`jax.export.symbolic_shape`):
+
+```python
+>>> a1, = export.symbolic_shape("a,")
+>>> a2, = export.symbolic_shape("a,", constraints=("a >= 8",))
+
+>>> a1 + a2  # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+ValueError: Invalid mixing of symbolic scopes for linear combination.
+Expected  scope 4776451856 created at <doctest shape_poly.md[31]>:1:6 (<module>)
+and found for 'a' (unknown) scope 4776979920 created at <doctest shape_poly.md[32]>:1:6 (<module>) with constraints:
+  a >= 8
+```
+
+The symbolic expressions that originate from a single call
+to {func}`jax.export.symbolic_shape` share a scope and
+can be mixed up in arithmetic operations. The result would
+also share the same scope.
+
+You can reuse scopes:
+
+```python
+>>> a, = export.symbolic_shape("a,", constraints=("a >= 8",))
+>>> b, = export.symbolic_shape("b,", scope=a.scope)  # Reuse the scope of `a`
+
+>>> a + b  # Allowed
+b + a
+
+```
+
+You can also create scopes explicitly:
+
+```python
+>>> my_scope = export.SymbolicScope()
+>>> c, = export.symbolic_shape("c", scope=my_scope)
+>>> d, = export.symbolic_shape("d", scope=my_scope)
+>>> c + d  # Allowed
+d + c
+
+```
+
+JAX tracing uses caches keyed partially by shapes, and
+symbolic shapes that are printed identically will be considered
+distinct if they use different scopes.
+
+### Caveat for equality comparisons
+
+The equality comparison returns `False` for `b + 1 == b` or `b == 0`
+(in which case it is certain that the dimensions are different for all values
+of the dimension variables),
+but also for `b == 1` and for `a == b`. This is unsound, and we
+ought to raise `core.InconclusiveDimensionOperation` because under
+some valuations the result should be `True` and under other
+valuations it should be `False`. We choose to make equality total
+thus allowing unsoundness because otherwise we may get spurious errors
+in presence of hash collisions
+when hashing dimension expressions or objects that include
+them (shapes, `core.AbstractValue`, `core.Jaxpr`).
+Besides the hashing errors, a partial semantics of equality
+leads to errors for the following expressions `b == a or b == b` or `b in [a, b]`
+even though the error is avoided if we change the order of the comparisons.
+
+Code of the form `if x.shape[0] != 1: raise NiceErrorMessage` is sound even
+with this treatment of equality, but code of the form `if x.shape[0] != 1: return 1`
+is unsound.
+
+### Dimension variables must be solvable from the input shapes
+
+Currently, the only way to pass the values of dimension variables
+when an exported object is invoked is indirectly through the shapes
+of the array arguments. E.g., the value of `b` can be inferred at the
+call site from the shape of the first argument of type `f32[b]`.
+This works well for most use cases, and
+it mirrors the calling convention of JIT functions.
+
+Sometimes you may want to export a function parameterized
+by an integer value that determines some shapes in the program.
+For example, we may
+want to export the function `my_top_k` defined below,
+parameterized by the
+value of `k`, which determines the shape of the result.
+The following attempt will lead to an error since the dimension
+variable `k` cannot be derived from the shape of the input `x: i32[4, 10]`:
+
+```python
+>>> def my_top_k(k, x):  # x: i32[4, 10], k <= 10
+...   return lax.top_k(x, k)[0]  # : i32[4, 3]
+>>> x = np.arange(40, dtype=np.int32).reshape((4, 10))
+
+>>> # Export with static `k=3`. Since `k` appears in shapes it must be in `static_argnums`.
+>>> exp_static_k = export.export(jax.jit(my_top_k, static_argnums=0))(3, x)
+>>> exp_static_k.in_avals[0]
+ShapedArray(int32[4,10])
+
+>>> exp_static_k.out_avals[0]
+ShapedArray(int32[4,3])
+
+>>> # When calling the exported function we pass only the non-static arguments
+>>> exp_static_k.call(x)
+Array([[ 9,  8,  7],
+       [19, 18, 17],
+       [29, 28, 27],
+       [39, 38, 37]], dtype=int32)
+
+>>> # Now attempt to export with symbolic `k` so that we choose `k` after export.
+>>> k, = export.symbolic_shape("k", constraints=["k <= 10"])
+>>> export.export(jax.jit(my_top_k, static_argnums=0))(k, x)  # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+UnexpectedDimVar: "Encountered dimension variable 'k' that is not appearing in the shapes of the function arguments
+
+```
+
+In the future, we may add an additional mechanism to pass the values of
+dimension variables, besides implicitly through the input shapes.
+Meanwhile, the workaround for the above use case is to replace the
+function parameter `k` with an array of shape `(0, k)`, so that
+`k` can be derived from the input shape of an array.
+The first dimension is 0 to ensure that the whole array is empty
+and there is no performance penalty when we call the exported function.
+
+```python
+>>> def my_top_k_with_dimensions(dimensions, x):  # dimensions: i32[0, k], x: i32[4, 10]
+...   return my_top_k(dimensions.shape[1], x)
+>>> exp = export.export(jax.jit(my_top_k_with_dimensions))(
+...     jax.ShapeDtypeStruct((0, k), dtype=np.int32),
+...     x)
+>>> exp.in_avals
+(ShapedArray(int32[0,k]), ShapedArray(int32[4,10]))
+
+>>> exp.out_avals[0]
+ShapedArray(int32[4,k])
+
+>>> # When we invoke `exp` we must construct and pass an array of shape (0, k)
+>>> exp.call(np.zeros((0, 3), dtype=np.int32), x)
+Array([[ 9,  8,  7],
+       [19, 18, 17],
+       [29, 28, 27],
+       [39, 38, 37]], dtype=int32)
+
+```
+
+Another situation when you may get an error is when some dimension
+variables do appear in the input shapes, but in a non-linear
+expression that JAX cannot currently solve:
+
+```python
+>>> a, = export.symbolic_shape("a")
+>>> export.export(jax.jit(lambda x: x.shape[0]))(
+...    jax.ShapeDtypeStruct((a * a,), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+ValueError: Cannot solve for values of dimension variables {'a'}.
+We can only solve linear uni-variate constraints.
+Using the following polymorphic shapes specifications: args[0].shape = (a^2,).
+Unprocessed specifications: 'a^2' for dimension size args[0].shape[0].
+
+```
+
+### Shape assertion errors
+
+JAX assumes that dimension variables range over strictly positive integers,
+and this assumption is checked when the code is compiled for concrete
+input shapes.
+
+For example, given the symbolic input shape `(b, b, 2*d)`,
+JAX will generate code to check the following assertions when
+invoked with actual argument `arg`:
+
+  * `arg.shape[0] >= 1`
+  * `arg.shape[1] == arg.shape[0]`
+  * `arg.shape[2] % 2 == 0`
+  * `arg.shape[2] // 2 >= 1`
+
+For example, here is the error we get when we call the exported
+on an argument of shape `(3, 3, 5)`:
+
+```python
+>>> def f(x):  # x: f32[b, b, 2*d]
+...   return x
+>>> exp = export.export(jax.jit(f))(
+...     jax.ShapeDtypeStruct(export.symbolic_shape("b, b, 2*d"), dtype=np.int32))   
+>>> exp.call(np.ones((3, 3, 5), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+ValueError: Input shapes do not match the polymorphic shapes specification.
+Division had remainder 1 when computing the value of 'd'.
+Using the following polymorphic shapes specifications:
+  args[0].shape = (b, b, 2*d).
+Obtained dimension variables: 'b' = 3 from specification 'b' for dimension args[0].shape[0] (= 3), .
+Please see https://docs.jax.dev/en/latest/export/shape_poly.html#shape-assertion-errors for more details.
+
+```
+
+These errors arise in a pre-processing step before the
+compilation.
+
+(jax-501-shape-poly-debugging)=
+## Debugging
+
+First, see the {ref}`jax-501-export-debugging` documentation.
+Additionally, you can debug the shape refinement, which is
+invoked at compilation time for modules that have dimension variables or multi-platform
+support.
+
+If there is an error during shape refinement, you can set the `JAX_DUMP_IR_TO`
+environment variable to see a dump of the HLO module before
+shape refinement (named `..._before_refine_polymorphic_shapes.mlir`).
+This module should already have static input shapes.
+
+To enable the logging of all stages of shape refinement you can set the
+environment variable `TF_CPP_VMODULE=refine_polymorphic_shapes=3` in OSS
+(inside Google, you pass `--vmodule=refine_polymorphic_shapes=3`):
+
+```shell
+# Log from python
+JAX_DUMP_IR_TO=/tmp/export.dumps/ TF_CPP_VMODULE=refine_polymorphic_shapes=3 python tests/shape_poly_test.py ShapePolyTest.test_simple_unary -v=3
+```

--- a/docs/new_docs/501/transfer-guard.rst
+++ b/docs/new_docs/501/transfer-guard.rst
@@ -1,0 +1,76 @@
+:nosearch:
+
+.. _jax-501-transfer-guard:
+
+Transfer guard
+==============
+
+JAX may transfer data between the host and devices and between devices during
+type conversion and input sharding. To log or disallow any unintended
+transfers, the user may configure a JAX transfer guard.
+
+JAX transfer guards distinguish between two types of transfers:
+
+* Explicit transfers: ``jax.device_put*()`` and ``jax.device_get()`` calls.
+* Implicit transfers: Other transfers (e.g., printing a ``DeviceArray``).
+
+A transfer guard can take an action based on its guard level:
+
+* ``"allow"``: Silently allow all transfers (default).
+* ``"log"``: Log and allow implicit transfers. Silently allow explicit
+  transfers.
+* ``"disallow"``: Disallow implicit transfers. Silently allow explicit
+  transfers.
+* ``"log_explicit"``: Log and allow all transfers.
+* ``"disallow_explicit"``: Disallow all transfers.
+
+JAX will raise a ``RuntimeError`` when disallowing a transfer.
+
+The transfer guards use the standard JAX configuration system:
+
+* A ``--jax_transfer_guard=GUARD_LEVEL`` command-line flag and
+  ``jax.config.update("jax_transfer_guard", GUARD_LEVEL)`` will set the global
+  option.
+* A ``with jax.transfer_guard(GUARD_LEVEL): ...`` context manager will set the
+  thread-local option within the scope of the context manager.
+
+Note that similar to other JAX configuration options, a newly spawned thread
+will use the global option instead of any active thread-local option of the
+scope where the thread was spawned.
+
+The transfer guards can also be applied more selectively, based on the
+direction of transfer. The flag and context manager name is suffixed with a
+corresponding transfer direction (e.g., ``--jax_transfer_guard_host_to_device``
+and ``jax.config.transfer_guard_host_to_device``):
+
+* ``"host_to_device"``: Converting a Python value or NumPy array into a JAX
+  on-device buffer.
+* ``"device_to_device"``: Copying a JAX on-device buffer to a different device.
+* ``"device_to_host"``: Fetching a JAX on-device buffer.
+
+Fetching a buffer on a CPU device is always allowed regardless of the transfer
+guard level.
+
+The following shows an example of using the transfer guard.
+
+.. code-block:: python
+
+   >>> jax.config.update("jax_transfer_guard", "allow")  # This is default.
+   >>>
+   >>> x = jnp.array(1)
+   >>> y = jnp.array(2)
+   >>> z = jnp.array(3)
+   >>>
+   >>> print("x", x)  # All transfers are allowed.
+   x 1
+   >>> with jax.transfer_guard("disallow"):
+   ...   print("x", x)  # x has already been fetched into the host.
+   ...   print("y", jax.device_get(y))  # Explicit transfers are allowed.
+   ...   try:
+   ...     print("z", z)  # Implicit transfers are disallowed.
+   ...     assert False, "This line is expected to be unreachable."
+   ...   except:
+   ...     print("z could not be fetched")  # doctest: +SKIP
+   x 1
+   y 2
+   z could not be fetched

--- a/docs/new_docs/index.rst
+++ b/docs/new_docs/index.rst
@@ -31,9 +31,9 @@ or jump to the level that matches what you're trying to do:
   TPU kernels with Pallas, and calling external code through the foreign
   function interface.
 
-One more level — JAX 501, on systems topics like multi-controller JAX,
-exporting and serialization, and fault tolerance — is planned but not yet
-written.
+* :doc:`JAX 501 <501/index>` — **systems topics**: multi-controller JAX
+  across many hosts, distributed data loading, fault tolerance, exporting
+  and serialization, the persistent compilation cache, and transfer guards.
 
 .. toctree::
    :hidden:
@@ -43,3 +43,4 @@ written.
    201/index
    301/index
    401/index
+   501/index


### PR DESCRIPTION
**This is a follow-up to #39088, and includes that commit also until #39088 gets merged, but the relevant commit here is the latter one.**

Add new_docs/501, ports of the systems docs into the new flow: multi-controller JAX (which also covers runtime-level pipeline parallelism via device_put), distributed data loading, fault-tolerant JAX with jax.live_devices, exporting and serialization (plus shape polymorphism, and a new section on jax.experimental.serialize_executable), the persistent compilation cache, and transfer guards. The 501 index also inlines a few smaller notes: thread-safety and jax.thread_guard, jax.experimental.multihost_utils, and compatibility policies for long-lived artifacts.

Also: add the CuTe DSL tutorial to 401 (after Pallas, with an execution exclude for the copy), add the errors reference to 101 (framed via the tracing mental model, with :no-index: to avoid duplicate objects), repoint stale 201 cross-links at the new 501 pages, and add 501 to the new_docs landing page.