### PR TITLE
jnp.linalg.cond: return inf rather than NaN for singular matrices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     assumed symmetric), so results are unchanged while the transform is
     ~1.4x faster at typical sizes.
 
+* Bug fixes
+  * Fixed a bug where {func}`jax.numpy.linalg.cond` returned NaN instead of
+    infinity for singular matrices when `p` is `None` or `2`, matching NumPy
+    and the other norms.
+
 ## JAX 0.11.1 (August 17, 2026)
 
 * New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     overwriting it, so HLO passes disabled via
     `XLA_FLAGS=--xla_disable_hlo_passes=...` stay disabled
     ({jax-issue}`#37391`).
+  * Fixed a bug where {func}`jax.numpy.linalg.cond` returned NaN instead of
+    infinity for singular matrices when `p` is `None` or `2`, matching NumPy
+    and the other norms.
 
 ## JAX 0.11.0 (July 16, 2026)
 

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -2248,7 +2248,7 @@ def cond(x: ArrayLike, p=None):
     raise ValueError(f"jnp.linalg.cond: input array must not be empty; got {arr.shape=}")
   if p is None or p == 2:
     s = svdvals(x)
-    return s[..., 0] / s[..., -1]
+    r = s[..., 0] / s[..., -1]
   elif p == -2:
     s = svdvals(x)
     r = s[..., -1] / s[..., 0]

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -2293,7 +2293,7 @@ def cond(x: ArrayLike, p=None):
     raise ValueError(f"jnp.linalg.cond: input array must not be empty; got {arr.shape=}")
   if p is None or p == 2:
     s = svdvals(x)
-    return s[..., 0] / s[..., -1]
+    r = s[..., 0] / s[..., -1]
   elif p == -2:
     s = svdvals(x)
     r = s[..., -1] / s[..., 0]

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -993,6 +993,21 @@ class NumpyLinalgTest(jtu.JaxTestCase):
                             check_dtypes=False, rtol=1e-03, atol=1e-03)
 
   @jtu.sample_product(
+    pnorm=[jnp.inf, -jnp.inf, 1, -1, 2, -2, 'fro', None],
+    dtype=float_types + complex_types,
+    batched=[True, False],
+  )
+  def testCondSingular(self, pnorm, dtype, batched):
+    # Singular matrices have an infinite condition number for every norm.
+    singular = np.zeros((2, 2), dtype=dtype)
+    x = np.stack([singular, np.eye(2, dtype=dtype)]) if batched else singular
+    args_maker = lambda: [x, pnorm]
+    self._CheckAgainstNumpy(np.linalg.cond, jnp.linalg.cond, args_maker,
+                            check_dtypes=False)
+    partial_cond = partial(jnp.linalg.cond, p=pnorm)
+    self._CompileAndCheck(partial_cond, lambda: [x], check_dtypes=False)
+
+  @jtu.sample_product(
     shape=[(1, 1), (4, 4), (6, 2, 3), (3, 4, 2, 6)],
     dtype=float_types + complex_types,
   )

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -988,6 +988,21 @@ class NumpyLinalgTest(jtu.JaxTestCase):
                             check_dtypes=False, rtol=1e-03, atol=1e-03)
 
   @jtu.sample_product(
+    pnorm=[jnp.inf, -jnp.inf, 1, -1, 2, -2, 'fro', None],
+    dtype=float_types + complex_types,
+  )
+  def testCondSingular(self, pnorm, dtype):
+    # Singular matrices have an infinite condition number for every norm.
+    singular = np.zeros((2, 2), dtype=dtype)
+    batched = np.stack([singular, np.eye(2, dtype=dtype)])
+    for x in [singular, batched]:
+      args_maker = lambda x=x: [x, pnorm]
+      self._CheckAgainstNumpy(np.linalg.cond, jnp.linalg.cond, args_maker,
+                              check_dtypes=False)
+      partial_cond = partial(jnp.linalg.cond, p=pnorm)
+      self._CompileAndCheck(partial_cond, lambda x=x: [x], check_dtypes=False)
+
+  @jtu.sample_product(
     shape=[(1, 1), (4, 4), (6, 2, 3), (3, 4, 2, 6)],
     dtype=float_types + complex_types,
   )


### PR DESCRIPTION
## What

`jax.numpy.linalg.cond` now returns infinity instead of NaN for exactly singular matrices when `p` is `None` or `2`, matching NumPy and the behavior of every other norm.

## Why

For `p in {None, 2}`, `cond` returned `s[..., 0] / s[..., -1]` directly, skipping the NaN→inf conversion applied to every other norm further down the function. For a singular input the smallest singular value is zero, and when the largest is also zero (a zero matrix, or zero members of a batch) the ratio is `0/0 = NaN`, where `np.linalg.cond` — and `jnp.linalg.cond` with any other `p` — gives `inf`. The fix routes the `p in {None, 2}` result through the same shared conversion as the rest.

## Testing

Added `testCondSingular` to `tests/linalg_test.py`, checking singular and batched singular/non-singular inputs against NumPy across all supported norms and float/complex dtypes. The `None`/`2` cases fail on `main` with NaN and pass with this change; the existing cond tests still pass. CHANGELOG entry included.
