### PR TITLE
jnp.fill_diagonal: implement wrap=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     Added a configuration flag `--jax_export_deserialize_expired_versions` to
     temporarily bypass the error check.
     See https://docs.jax.dev/en/latest/export/export.html#compatibility-guarantees.
+  * {func}`jax.numpy.fill_diagonal` now supports `wrap=True`, matching the
+    NumPy behavior of wrapping the diagonal for tall matrices.
 
 * Breaking changes
   * JAX does not support anymore deserialization of Exported modules from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     arguments (or the `JAX_MTLS_CERT_FILE`, `JAX_MTLS_KEY_FILE`,
     `JAX_MTLS_CA_FILE`, `JAX_MTLS_PEER_URI_PREFIX` and
     `JAX_DISTRIBUTED_VERIFY_SECURE_CREDENTIALS` environment variables).
+  * {func}`jax.numpy.fill_diagonal` now supports `wrap=True`, matching the
+    NumPy behavior of wrapping the diagonal for tall matrices.
 
 * Changes
   * JAX now uses Bazel 8.7.0 to build from source.

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -7092,7 +7092,9 @@ def fill_diagonal(a: ArrayLike, val: ArrayLike, wrap: bool = False, *,
       dimensions must be the same size.
     val: scalar or array with which to fill the diagonal. If an array, it will
       be flattened and repeated to fill the diagonal entries.
-    wrap: Not implemented by JAX. Only the default value of ``False`` is supported.
+    wrap: if True, the diagonal of a tall 2-dimensional array wraps around,
+      restarting every ``ncols + 1`` rows. Only affects arrays with
+      ``a.ndim == 2`` and more rows than columns. Default is False.
     inplace: must be set to False to indicate that the input is not modified
       in-place, but rather a modified copy is returned.
 
@@ -7132,6 +7134,16 @@ def fill_diagonal(a: ArrayLike, val: ArrayLike, wrap: bool = False, *,
            [0, 1, 0, 0, 0],
            [0, 0, 1, 0, 0]], dtype=int32)
 
+    With ``wrap=True``, the diagonal of a tall array wraps around:
+
+    >>> x = jnp.zeros((5, 3), dtype=int)
+    >>> jnp.fill_diagonal(x, 1, wrap=True, inplace=False)
+    Array([[1, 0, 0],
+           [0, 1, 0],
+           [0, 0, 1],
+           [0, 0, 0],
+           [1, 0, 0]], dtype=int32)
+
     And for square N-dimensional arrays, the N-dimensional diagonal is filled:
 
     >>> y = jnp.zeros((2, 2, 2))
@@ -7144,13 +7156,21 @@ def fill_diagonal(a: ArrayLike, val: ArrayLike, wrap: bool = False, *,
   """
   if inplace:
     raise NotImplementedError("JAX arrays are immutable, must use inplace=False")
-  if wrap:
-    raise NotImplementedError("wrap=True is not implemented, must use wrap=False")
   a, val = util.ensure_arraylike("fill_diagonal", a, val)
   if a.ndim < 2:
     raise ValueError("array must be at least 2-d")
   if a.ndim > 2 and not all(n == a.shape[0] for n in a.shape[1:]):
     raise ValueError("All dimensions of input must be of equal length")
+  if a.ndim == 2:
+    # As in np.fill_diagonal, fill entries at flat index k * (ncols + 1), where
+    # k is unbounded if wrap=True so that the diagonal wraps for tall matrices.
+    # The min() clips end for wide matrices, matching a.flat[:ncols**2:ncols+1];
+    # unlike slicing, arange does not clip out-of-range stops.
+    ncols = a.shape[1]
+    end = a.size if wrap else min(a.size, ncols * ncols)
+    idx = np.arange(0, end, ncols + 1)
+    return a.at[idx // ncols, idx % ncols].set(
+        val if val.ndim == 0 else _tile_to_size(val.ravel(), idx.size))
   n = min(a.shape)
   idx = diag_indices(n, a.ndim)
   return a.at[idx].set(val if val.ndim == 0 else _tile_to_size(val.ravel(), n))

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -7108,7 +7108,9 @@ def fill_diagonal(a: ArrayLike, val: ArrayLike, wrap: bool = False, *,
       dimensions must be the same size.
     val: scalar or array with which to fill the diagonal. If an array, it will
       be flattened and repeated to fill the diagonal entries.
-    wrap: Not implemented by JAX. Only the default value of ``False`` is supported.
+    wrap: if True, the diagonal of a tall 2-dimensional array wraps around,
+      restarting every ``ncols + 1`` rows. Only affects arrays with
+      ``a.ndim == 2`` and more rows than columns. Default is False.
     inplace: must be set to False to indicate that the input is not modified
       in-place, but rather a modified copy is returned.
 
@@ -7148,6 +7150,16 @@ def fill_diagonal(a: ArrayLike, val: ArrayLike, wrap: bool = False, *,
            [0, 1, 0, 0, 0],
            [0, 0, 1, 0, 0]], dtype=int32)
 
+    With ``wrap=True``, the diagonal of a tall array wraps around:
+
+    >>> x = jnp.zeros((5, 3), dtype=int)
+    >>> jnp.fill_diagonal(x, 1, wrap=True, inplace=False)
+    Array([[1, 0, 0],
+           [0, 1, 0],
+           [0, 0, 1],
+           [0, 0, 0],
+           [1, 0, 0]], dtype=int32)
+
     And for square N-dimensional arrays, the N-dimensional diagonal is filled:
 
     >>> y = jnp.zeros((2, 2, 2))
@@ -7160,13 +7172,21 @@ def fill_diagonal(a: ArrayLike, val: ArrayLike, wrap: bool = False, *,
   """
   if inplace:
     raise NotImplementedError("JAX arrays are immutable, must use inplace=False")
-  if wrap:
-    raise NotImplementedError("wrap=True is not implemented, must use wrap=False")
   a, val = util.ensure_arraylike("fill_diagonal", a, val)
   if a.ndim < 2:
     raise ValueError("array must be at least 2-d")
   if a.ndim > 2 and not all(n == a.shape[0] for n in a.shape[1:]):
     raise ValueError("All dimensions of input must be of equal length")
+  if a.ndim == 2:
+    # As in np.fill_diagonal, fill entries at flat index k * (ncols + 1), where
+    # k is unbounded if wrap=True so that the diagonal wraps for tall matrices.
+    # The min() clips end for wide matrices, matching a.flat[:ncols**2:ncols+1];
+    # unlike slicing, arange does not clip out-of-range stops.
+    ncols = a.shape[1]
+    end = a.size if wrap else min(a.size, ncols * ncols)
+    idx = np.arange(0, end, ncols + 1)
+    return a.at[idx // ncols, idx % ncols].set(
+        val if val.ndim == 0 else _tile_to_size(val.ravel(), idx.size))
   n = min(a.shape)
   idx = diag_indices(n, a.ndim)
   return a.at[idx].set(val if val.ndim == 0 else _tile_to_size(val.ravel(), n))

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2250,18 +2250,19 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   @jtu.sample_product(
     dtype=default_dtypes,
-    a_shape=[(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1), (2, 2), (1, 2), (0, 2), (2, 3), (2, 2, 2), (2, 2, 2, 2)],
+    a_shape=[(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1), (2, 2), (1, 2), (0, 2), (2, 3), (5, 1), (5, 2), (7, 3), (2, 2, 2), (2, 2, 2, 2)],
     val_shape=[(), (1,), (2,), (1, 2), (3, 2)],
+    wrap=[True, False],
   )
-  def testFillDiagonal(self, dtype, a_shape, val_shape):
+  def testFillDiagonal(self, dtype, a_shape, val_shape, wrap):
     rng = jtu.rand_default(self.rng())
 
     def np_fun(a, val):
       a_copy = a.copy()
-      np.fill_diagonal(a_copy, val)
+      np.fill_diagonal(a_copy, val, wrap=wrap)
       return a_copy
 
-    jnp_fun = partial(jnp.fill_diagonal, inplace=False)
+    jnp_fun = partial(jnp.fill_diagonal, wrap=wrap, inplace=False)
     args_maker = lambda : [rng(a_shape, dtype), rng(val_shape, dtype)]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2245,18 +2245,19 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   @jtu.sample_product(
     dtype=default_dtypes,
-    a_shape=[(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1), (2, 2), (1, 2), (0, 2), (2, 3), (2, 2, 2), (2, 2, 2, 2)],
+    a_shape=[(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1), (2, 2), (1, 2), (0, 2), (2, 3), (5, 1), (5, 2), (7, 3), (2, 2, 2), (2, 2, 2, 2)],
     val_shape=[(), (1,), (2,), (1, 2), (3, 2)],
+    wrap=[True, False],
   )
-  def testFillDiagonal(self, dtype, a_shape, val_shape):
+  def testFillDiagonal(self, dtype, a_shape, val_shape, wrap):
     rng = jtu.rand_default(self.rng())
 
     def np_fun(a, val):
       a_copy = a.copy()
-      np.fill_diagonal(a_copy, val)
+      np.fill_diagonal(a_copy, val, wrap=wrap)
       return a_copy
 
-    jnp_fun = partial(jnp.fill_diagonal, inplace=False)
+    jnp_fun = partial(jnp.fill_diagonal, wrap=wrap, inplace=False)
     args_maker = lambda : [rng(a_shape, dtype), rng(val_shape, dtype)]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)


### PR DESCRIPTION
## What

`jax.numpy.fill_diagonal` now supports `wrap=True`, matching `np.fill_diagonal`: for a tall 2-d array the diagonal wraps around, restarting every `ncols + 1` rows.

## Why

`wrap=True` previously raised `NotImplementedError`, but nothing about it needs dynamic shapes: NumPy implements it as a flat assignment with stride `ncols + 1`, with the end index unbounded when `wrap=True` and clipped to `ncols**2` otherwise. Since shapes are static in JAX, the flat indices are computable with `np.arange` at trace time and the whole thing lowers to a single static `.at[...].set(...)` scatter. The 2-d path now goes through this; the N-d square path via `diag_indices` is unchanged.

One subtlety: NumPy's non-wrapped 2-d case relies on slice clipping (`a.flat[:ncols**2:ncols+1]`), which `arange` doesn't do, so the end index is clipped explicitly with `min(a.size, ncols * ncols)` — this matters for wide matrices.

## Testing

Extended `testFillDiagonal` in `tests/lax_numpy_test.py` with `wrap=[True, False]` and tall shapes `(5, 1)`, `(5, 2)`, `(7, 3)`, checked against `np.fill_diagonal` across dtypes and scalar/array `val` shapes, including under jit. Added a `wrap=True` docstring example (doctested). CHANGELOG entry included.
