### PR TITLE
fix crash in tree prefix error message construction

### DIFF
--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -1330,13 +1330,13 @@ def _prefix_error(
         f"At that key path, the prefix pytree {name} has a subtree of type\n"
         f"    {type(prefix_tree)}\n"
         f"with {len(prefix_tree_children)} child keys\n"
-        f"    {' '.join(str(k.key) for k in prefix_tree_keys)}\n"
+        f"    {' '.join(str(k) for k in prefix_tree_keys)}\n"
         f"but at the same key path the full pytree has a subtree of the same "
         f"type but with {len(full_tree_children)} child keys\n"
-        f"    {' '.join(str(k.key) for k in full_tree_keys)}\n"
+        f"    {' '.join(str(k) for k in full_tree_keys)}\n"
         + ("" if diff is None else
            f"so the symmetric difference on key sets is\n"
-           f"    {' '.join(str(k.key) for k in diff)}"))
+           f"    {' '.join(str(k) for k in diff)}"))
       return  # don't look for more errors in this subtree
 
   # Or they may disagree if their roots have different pytree metadata:

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -1418,7 +1418,31 @@ class TreePrefixErrorsTest(jtu.JaxTestCase):
   def test_different_num_children_print_key_diff(self):
     e, = prefix_errors({'a': 1}, {'a': 2, 'b': 3})
     expected = ("so the symmetric difference on key sets is\n"
-                "    b")
+                r"    \['b'\]")
+    with self.assertRaisesRegex(ValueError, expected):
+      raise e('in_axes')
+
+  def test_different_num_children_custom_node_with_keys(self):
+    # https://github.com/jax-ml/jax/issues/25659
+    @tree_util.register_pytree_with_keys_class
+    class Foo:
+      def __init__(self, fields):
+        self.fields = dict(fields)
+
+      def tree_flatten_with_keys(self):
+        return ([(tree_util.GetAttrKey(k), v) for k, v in self.fields.items()],
+                tuple(self.fields))
+
+      @classmethod
+      def tree_unflatten(cls, keys, children):
+        return cls(zip(keys, children))
+
+    e, = prefix_errors(Foo({'a': 1}), Foo({'a': 2, 'b': 3}))
+    expected = ("(?s)pytree structure error: different numbers of pytree "
+                "children at key path\n"
+                "    in_axes\n"
+                ".*so the symmetric difference on key sets is\n"
+                r"    \.b")
     with self.assertRaisesRegex(ValueError, expected):
       raise e('in_axes')
 


### PR DESCRIPTION
The 'different numbers of pytree children' error message in _prefix_error assumed every key path entry has a .key attribute, but only DictKey and FlattenedIndexKey do; GetAttrKey and SequenceKey do not. So for custom pytree nodes registered with e.g. GetAttrKey child keys, building the error message itself raised an AttributeError, masking the actual structure mismatch. Use each key's canonical str() form instead.

fixes #25659