### PR TITLE
[hijax] fix linearize bug in presence of non-differentiable args

### DIFF
--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -661,8 +661,14 @@ def fake_linear_op(prim, nz_in_flat, nz_out_flat, rs, *tangents):
 def flatten_user_linearized(prim, residuals, *tangents_flat):
   tangents = tree_unflatten(prim.in_tree, tangents_flat)
   tangents_out = prim.linearized(residuals, *tangents)
-  tangents_out_flat = tree_leaves_checked(prim.out_tree, tangents_out)
-  return tangents_out_flat
+  flat_vals, treedef_actual = tracing_registry.flatten(
+      tangents_out, lambda x: isinstance(x, ad_util.Zero))
+  if treedef_actual != prim.out_tree:
+    raise RuntimeError(
+        f"tree mismatch during linearization of {prim=}."
+        f" Expected: {prim.out_tree} got: {treedef_actual}"
+    )
+  return flat_vals
 
 call_hi_primitive_linearized_p = core.Primitive("call_hi_primitive_linearized")
 call_hi_primitive_linearized_p.multiple_results = True

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -498,6 +498,25 @@ def square(x):
   return Square(jax.typeof(x))(x)
 
 
+class NonDiffPrim(VJPHiPrimitive):
+  def __init__(self, in_aval):
+    self.in_avals = (in_aval,)
+    self.out_aval = in_aval
+    self.params = {}
+    super().__init__()
+
+  def expand(self, x):
+    return x
+
+  def jvp(self, primals, tangents):
+    (x,), _ = primals, tangents
+    import numpy as np
+    return x, np.empty(x.shape, dtype=jax.dtypes.float0)
+
+  lin = linearize_from_jvp
+  linearized = apply_derived_linearization
+
+
 class HijaxTest(jtu.JaxTestCase):
 
   def test_closed_call(self):
@@ -1844,6 +1863,13 @@ class HijaxTest(jtu.JaxTestCase):
     debug_info = lowered._lowering.compile_args['all_args_info'].debug_info
     # QArrayTy.lo_ty() returns [int8[m,k], f32[m]], so 'x' is replicated twice
     self.assertEqual(debug_info.arg_names, ('x', 'x'))
+
+  def test_nondiff_linearize(self):
+    def f(x):
+      return NonDiffPrim(jax.typeof(x))(x)
+    _, f_lin = jax.linearize(f, jnp.ones((5,)))
+    out_tangent = f_lin(jnp.ones((5,)))
+    self.assertArraysEqual(out_tangent, jnp.zeros((5,)))
 
 
 class BoxTest(jtu.JaxTestCase):


### PR DESCRIPTION
This fixes an issue encountered when trying to enable the `hijax.searchsorted` path by default.