### PR TITLE
[JAX] Improve missing GSPMD rule error

### DIFF
--- a/jax/_src/custom_partitioning.py
+++ b/jax/_src/custom_partitioning.py
@@ -598,6 +598,16 @@ def _custom_partitioning_lowering_rule(ctx: mlir.LoweringRuleContext, *values,
     return mlir.lower_fun(
         core.jaxpr_as_fun(call), multiple_results=True)(ctx, *values)
 
+  if (not config.use_shardy_partitioner.value and
+      infer_sharding_from_operands is None):
+    function = call.jaxpr.debug_info.func_src_info
+    raise NotImplementedError(
+        f"Custom-partitioned function {function!r} does not support GSPMD "
+        "sharding propagation rules. GSPMD is deprecated; please upgrade "
+        "to and enable the Shardy partitioner "
+        "(jax_use_shardy_partitioner=True, which is the default)."
+    )
+
   def to_mesh_pspec_sharding(hlo_sharding: xc.HloSharding | None, ndim):
     if hlo_sharding is None:
       return hlo_sharding


### PR DESCRIPTION
Motivation: Make transition to Shardy easier with actionable error message

Attached a reproducer with a primitive that only defines Shardy rules

When you try to use it with GSPMD you get an opaque error:
```
File ".../python3.12/site-packages/jax/_src/custom_partitioning.py", line 214, in _custom_partitioning_infer_sharding_from_operands
TypeError: 'NoneType' object is not callable)
```

With this PR's fix, you get a clearer error message:
```
NotImplementedError: Custom-partitioned function '_inner_bind at ./jax_gspmd_test.py:52' does not support GSPMD sharding propagation rules. GSPMD is
  deprecated; please upgrade to and enable the Shardy partitioner
  (jax_use_shardy_partitioner=True, which is the default).
```

[jax_gspmd_test.py](https://github.com/user-attachments/files/29977438/jax_gspmd_test.py)
