### PR TITLE
[checkify] fix corner case where debug_info must be updated within custom_jvp_call

### DIFF
--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -1038,10 +1038,13 @@ def custom_jvp_call_rule(in_err: Error,
   # JVP rule, one must instead use checkify-of-jvp. Thus this implementation
   # just forwards the input error and code (and trivial tangents) to the output.
   err_vals, err_tree = jtu.tree_flatten(in_err)
+  dbg = call_jaxpr.debug_info
+  if dbg.arg_names is not None:
+    dbg = dbg._replace(arg_names=("",) * err_tree.num_leaves + dbg.arg_names)
   partial_checkify = lu.wrap_init(
       functools.partial(checkify_jaxpr_flat, call_jaxpr,
                         call_jaxpr.consts, enabled_errors, err_tree),
-      debug_info=call_jaxpr.debug_info)
+      debug_info=dbg)
   partial_checkify, f_metadata = _flatten_and_get_error_metadata_thunk(
       partial_checkify)
   jvp = lift_jvp(err_tree.num_leaves, num_consts, jvp_jaxpr_fun)

--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -956,6 +956,26 @@ class CheckifyTransformTests(jtu.JaxTestCase):
     self.assertIsNotNone(err.get())
     self.assertStartsWith(err.get(), "x must be positive")
 
+  def test_checkify_custom_jvp(self):
+    @jax.custom_jvp
+    def f(x):
+      return x * 2.0
+
+    @f.defjvp
+    def f_jvp(primals, tangents):
+      x, = primals
+      dx, = tangents
+      return f(x), dx * 2.0
+
+    def body(x):
+      checkify.check(x > 0, "x must be positive")
+      return f(x)
+
+    checked_f = jax.jit(checkify.checkify(body))
+    err, res = checked_f(2.0)
+    self.assertIsNone(err.get())
+    self.assertAllClose(res, 4.0)
+
 
 @jtu.with_config(jax_check_tracer_leaks=True)
 class AssertPrimitiveTests(jtu.JaxTestCase):


### PR DESCRIPTION
This came up while testing the hijax execution path for searchsorted.