### PR TITLE
[array-api] __array_namespace_info__.devices(): return tuple rather than list

### DIFF
--- a/jax/_src/numpy/array_api_metadata.py
+++ b/jax/_src/numpy/array_api_metadata.py
@@ -74,11 +74,11 @@ class ArrayNamespaceInfo:
     # JAX is free to choose the most efficient device placement.
     return None
 
-  def devices(self) -> list[xc.Device | None]:
+  def devices(self) -> tuple[xc.Device | None, ...]:
     out: list[xc.Device | None] = [None]  # None indicates "uncommitted"
     for backend in xb.backends():
         out.extend(xb.devices(backend))
-    return out
+    return tuple(out)
 
   def capabilities(self):
     return self._capabilities

--- a/tests/array_api_skips.txt
+++ b/tests/array_api_skips.txt
@@ -48,7 +48,6 @@ array_api_tests/test_statistical_functions.py::test_cumulative_prod
 # TODO(jakevdp): fix the following failures:
 
 # Returns list rather than tuple
-array_api_tests/test_inspection_functions.py::TestInspection::test_devices
 array_api_tests/test_creation_functions.py::test_meshgrid
 array_api_tests/test_data_type_functions.py::test_broadcast_arrays
 


### PR DESCRIPTION
As [required](https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.info.devices.html#array_api.info.devices) by the 2025.12 version of the specification.

This is a minor breaking change, but not one that I suspect will have much impact.