### PR TITLE
[Pallas] Simplify `pl.debug_print` calls in Pallas TPU tests

### DIFF
--- a/jax/experimental/pallas/g3doc/debugging.md
+++ b/jax/experimental/pallas/g3doc/debugging.md
@@ -53,17 +53,15 @@ TPU buffers with zeros instead of NaNs.
 
 The `pl.debug_print` function can be used to print runtime values inside of a kernel.
 
-For TPUs only, the kernel must be compiled with the 'xla_tpu_enable_log_recorder' option.
+For TPUs only, the kernel must be compiled with the `xla_tpu_enable_log_recorder` option.
 <!--internal:1-->
 
 ```python
-kernel = pl.pallas_call(...)
-compiled_kernel = (
-       jax.jit(kernel)
-       .lower(x)
-       .compile({'xla_tpu_enable_log_recorder': 'true'})
- )
-result = compiled_kernel(x)
+kernel = jax.jit(
+    pl.pallas_call(...),
+    compiler_options={'xla_tpu_enable_log_recorder': 'true'},
+)
+result = kernel(x)
 ```
 
 ### Runtime Asserts

--- a/tests/pallas/tpu_pallas_call_print_test.py
+++ b/tests/pallas/tpu_pallas_call_print_test.py
@@ -38,6 +38,7 @@ partial = functools.partial
 class PallasCallPrintTest(ptu.PallasTPUTest):
 
   def test_debug_print(self):
+    @jax.jit(compiler_options={'xla_tpu_enable_log_recorder': 'true'})
     @functools.partial(
         self.pallas_call,
         out_shape=jax.ShapeDtypeStruct((8, 128), jnp.float32),
@@ -46,13 +47,8 @@ class PallasCallPrintTest(ptu.PallasTPUTest):
       pl.debug_print('It works!')
 
     x = jnp.arange(8 * 128, dtype=jnp.float32).reshape((8, 128))
-    compiled_kernel = (
-        jax.jit(kernel)
-        .lower(x)
-        .compile({'xla_tpu_enable_log_recorder': 'true'})
-    )
     with jtu.capture_stderr() as get_output:
-      jax.block_until_ready(compiled_kernel(x))
+      jax.block_until_ready(kernel(x))
     self.assertIn('It works!', get_output())
 
   @parameterized.product(arg_type=[int, float])
@@ -60,6 +56,7 @@ class PallasCallPrintTest(ptu.PallasTPUTest):
     if not jtu.is_libtpu_at_least('0.0.43'):
       self.skipTest('Requires libtpu 0.0.43 or newer')
 
+    @jax.jit(compiler_options={'xla_tpu_enable_log_recorder': 'true'})
     @functools.partial(
         self.pallas_call,
         out_shape=jax.ShapeDtypeStruct((8, 128), jnp.float32),
@@ -68,13 +65,8 @@ class PallasCallPrintTest(ptu.PallasTPUTest):
       del o_ref  # Unused.
       pl.debug_print('DONE ', arg_type(123))
 
-    compiled_kernel = (
-        jax.jit(kernel)
-        .lower()
-        .compile({'xla_tpu_enable_log_recorder': 'true'})
-    )
     with jtu.capture_stderr() as get_output:
-      jax.block_until_ready(compiled_kernel())
+      jax.block_until_ready(kernel())
 
     if arg_type is int:
       self.assertIn('DONE s32[] 123', get_output())
@@ -86,6 +78,7 @@ class PallasCallPrintTest(ptu.PallasTPUTest):
       pl.debug_print('It works!')
       return (i, 0)
 
+    @jax.jit(compiler_options={'xla_tpu_enable_log_recorder': 'true'})
     @functools.partial(
         self.pallas_call,
         grid=(1,),
@@ -96,13 +89,8 @@ class PallasCallPrintTest(ptu.PallasTPUTest):
       o_ref[...] = x_ref[...]
 
     x = jnp.arange(8 * 128, dtype=jnp.float32).reshape((8, 128))
-    compiled_kernel = (
-        jax.jit(kernel)
-        .lower(x)
-        .compile({'xla_tpu_enable_log_recorder': 'true'})
-    )
     with jtu.capture_stderr() as get_output:
-      jax.block_until_ready(compiled_kernel(x))
+      jax.block_until_ready(kernel(x))
     self.assertIn('It works!', get_output())
 
   @parameterized.parameters(
@@ -118,6 +106,7 @@ class PallasCallPrintTest(ptu.PallasTPUTest):
     ):
       self.skipTest('Requires libtpu 0.0.43 or newer')
 
+    @jax.jit(compiler_options={'xla_tpu_enable_log_recorder': 'true'})
     @functools.partial(
         self.pallas_call,
         in_specs=(pl.BlockSpec(memory_space=pltpu.SMEM),),
@@ -128,13 +117,8 @@ class PallasCallPrintTest(ptu.PallasTPUTest):
       pl.debug_print('x[0] == {}', x_ref[0])
 
     x = jnp.array([value], dtype=dtype)
-    compiled_kernel = (
-        jax.jit(kernel)
-        .lower(x)
-        .compile({'xla_tpu_enable_log_recorder': 'true'})
-    )
     with jtu.capture_stderr() as get_output:
-      jax.block_until_ready(compiled_kernel(x))
+      jax.block_until_ready(kernel(x))
     output = get_output()
     self.assertIn(f'x[0] == {value}', output)
 
@@ -143,6 +127,7 @@ class PallasCallPrintTest(ptu.PallasTPUTest):
       'x[0] == {} and x[1] == {} and trailing text',
   )
   def test_debug_print_multiple_with_formatting(self, fmt):
+    @jax.jit(compiler_options={'xla_tpu_enable_log_recorder': 'true'})
     @functools.partial(
         self.pallas_call,
         out_shape=jax.ShapeDtypeStruct((8, 128), jnp.int32),
@@ -152,13 +137,8 @@ class PallasCallPrintTest(ptu.PallasTPUTest):
       pl.debug_print(fmt, x_ref[0], x_ref[1])
 
     x = jnp.array([1, 2], dtype=jnp.int32)
-    compiled_kernel = (
-        jax.jit(kernel)
-        .lower(x)
-        .compile({'xla_tpu_enable_log_recorder': 'true'})
-    )
     with jtu.capture_stderr() as get_output:
-      jax.block_until_ready(compiled_kernel(x))
+      jax.block_until_ready(kernel(x))
     output = get_output()
     self.assertIn(fmt.format(x[0], x[1]), output)
 
@@ -175,6 +155,7 @@ class PallasCallPrintTest(ptu.PallasTPUTest):
       for dtype in (jnp.int32, jnp.uint32, jnp.float32)
   )
   def test_debug_print_vector(self, shape, dtype):
+    @jax.jit(compiler_options={"xla_tpu_enable_log_recorder": "true"})
     @functools.partial(
         self.pallas_call,
         out_shape=jax.ShapeDtypeStruct(shape, dtype),
@@ -185,13 +166,8 @@ class PallasCallPrintTest(ptu.PallasTPUTest):
 
     n = np.prod(shape)
     x = jnp.arange(n, dtype=dtype).reshape(shape)
-    compiled_kernel = (
-        jax.jit(kernel)
-        .lower(x)
-        .compile({"xla_tpu_enable_log_recorder": "true"})
-    )
     with jtu.capture_stderr() as get_output:
-      jax.block_until_ready(compiled_kernel(x))
+      jax.block_until_ready(kernel(x))
     output = get_output()
     numbers = [
         int(num)


### PR DESCRIPTION
The change simplifies the `pl.debug_print` calls in Pallas TPU tests. The tests now pass the `xla_tpu_enable_log_recorder` option directly through `jax.jit(..., compiler_options=...)`, instead of the verbose `.lower(...).compile(...)` flow.

Also simplifies the description in the documentation.