### PR TITLE
docs: print gradients in value_and_grad examples

### DIFF
--- a/docs/automatic-differentiation.md
+++ b/docs/automatic-differentiation.md
@@ -192,7 +192,7 @@ Continuing the previous examples:
 ```{code-cell}
 loss_value, Wb_grad = jax.value_and_grad(loss, (0, 1))(W, b)
 print('loss value', loss_value)
-print('loss value', loss(W, b))
+print('gradients', Wb_grad)
 ```
 
 (automatic-differentiation-checking-against-numerical-differences)=

--- a/docs/notebooks/autodiff_cookbook.ipynb
+++ b/docs/notebooks/autodiff_cookbook.ipynb
@@ -289,7 +289,7 @@
      "output_type": "stream",
      "text": [
       "loss value 3.051939\n",
-      "loss value 3.051939\n"
+      "gradients (Array([-0.16965576, -0.8774645 , -1.4901344 ], dtype=float32), Array(-0.29227236, dtype=float32))\n"
      ]
     }
    ],
@@ -297,7 +297,7 @@
     "from jax import value_and_grad\n",
     "loss_value, Wb_grad = value_and_grad(loss, (0, 1))(W, b)\n",
     "print('loss value', loss_value)\n",
-    "print('loss value', loss(W, b))"
+    "print('gradients', Wb_grad)"
    ]
   },
   {

--- a/docs/notebooks/autodiff_cookbook.md
+++ b/docs/notebooks/autodiff_cookbook.md
@@ -168,7 +168,7 @@ Another convenient function is `value_and_grad` for efficiently computing both a
 from jax import value_and_grad
 loss_value, Wb_grad = value_and_grad(loss, (0, 1))(W, b)
 print('loss value', loss_value)
-print('loss value', loss(W, b))
+print('gradients', Wb_grad)
 ```
 
 +++ {"id": "rYTrH5tKllC_"}


### PR DESCRIPTION
# Title
docs: print gradients in value_and_grad examples

# Description

## Summary
This PR fixes a bug in the documentation examples for `jax.value_and_grad` where the computed gradient was never printed and the loss value was instead printed twice.

## Motivation
In both the standalone tutorial **"Evaluating a function and its gradient using jax.value_and_grad"** and the corresponding section of the **Autodiff Cookbook**, the code cell demonstrates the use of the `jax.value_and_grad` API. 

However, the previous code block computed `loss_value, Wb_grad = jax.value_and_grad(loss, (0, 1))(W, b)` but redundantly printed the loss value twice under the same `'loss value'` label (once from `loss_value` and once from a separate call to `loss(W, b)`). The computed gradient (`Wb_grad`) was never printed.

Changing the second print statement to output `Wb_grad` corrects the duplicate output and directly demonstrates how the gradient is returned alongside the function value.

## What Changed
* Updated the second print statement from `print('loss value', loss(W, b))` to `print('gradients', Wb_grad)` in:
  * `docs/automatic-differentiation.md`
  * `docs/notebooks/autodiff_cookbook.ipynb`
* Synchronized `docs/notebooks/autodiff_cookbook.md` using Jupytext.
* Updated the static stdout cell outputs in the Jupyter notebook (`docs/notebooks/autodiff_cookbook.ipynb`) to match the new print output while retaining consistent historical random seed numbers.

## Testing Performed
* Verified the outputs match when running the setup and the `value_and_grad` cells.
* Ran `pre-commit run jupytext --all-files` to ensure all notebook formats are correctly synchronized.
* Verified that the Sphinx documentation builds successfully.
