### PR TITLE
Add xla_metadata_call2, polish xla_metadata_call, rewrite XLA-metadata docs

### DIFF
--- a/docs/new_docs/201/controlling-xla.md
+++ b/docs/new_docs/201/controlling-xla.md
@@ -5,7 +5,7 @@ nosearch: true
 (jax-201-controlling-xla)=
 # Controlling XLA from JAX
 
-<!--* freshness: { reviewed: '2026-07-10' } *-->
+<!--* freshness: { reviewed: '2026-07-15' } *-->
 
 JAX programs are compiled by [XLA](https://openxla.org/xla), and mostly you
 can leave the compiler alone. When you can't, JAX offers two levels of
@@ -84,159 +84,168 @@ with a complete list in [xla.proto](https://github.com/openxla/xla/blob/main/xla
 and XLA publishes a [guide to the key flags](https://openxla.org/xla/flags_guidance).
 
 (jax-201-xla-metadata)=
-## Attaching metadata to operations: `set_xla_metadata`
+## Attaching metadata to operations: `xla_metadata_call`
 
-**Summary:** `set_xla_metadata` allows you to attach metadata to operations in
-your JAX code. This metadata is passed down to the XLA compiler as
-`frontend_attributes` and can be used to enable compiler-level tooling, such
-as the XLA-TPU debugger.
+Each operation in a compiled XLA program can carry *metadata*: string-valued
+`frontend_attributes` that don't change what the operation computes, but that
+compiler-level tooling — the XLA-TPU debugger, fusion control, scheduling
+hints — can read. JAX's interface for attaching metadata is
+`jax.experimental.xla_metadata`, and the recommended entry point is
+`xla_metadata_call`.
 
-You can use it in three ways:
+These APIs are experimental, and subject to change.
 
-1. Tag an individual operation by wrapping its output value
-2. Tag a block of operations using a context manager
-3. Tag all operations in a function using a decorator
+### Tagging a function: `xla_metadata_call`
 
-**Warning:** `set_xla_metadata` is an experimental feature and its API is
-subject to change.
-
-### What is XLA Metadata?
-When JAX transforms and compiles your code, it ultimately generates an XLA (Accelerated Linear Algebra) computation graph. Each operation in this graph can have associated metadata, specifically `frontend_attributes`. This metadata doesn't change the numerical result of the operation, but it can be used to signal special behavior to the compiler or runtime.
-
-`set_xla_metadata` provides a way to attach this metadata directly from your JAX code. This is a powerful feature for low-level debugging and profiling.
-
-### Usage
-#### Tagging Individual Operations
-Tagging an individual operation gives you precise control over which parts of your computation you want to inspect. To do this, you wrap the output (value) of an operation with `set_xla_metadata`. When wrapping a function with multiple operations within, only the final operation of said function will be tagged.
+`xla_metadata_call` wraps a function so that the operations it performs carry
+the given metadata, passed as keyword arguments:
 
 ```python
 import jax
 import jax.numpy as jnp
+from jax.experimental.xla_metadata import xla_metadata_call
+
+@xla_metadata_call(tag="my_block")
+def block(x):
+  y = jnp.sin(x)
+  return y * jnp.cos(x)
+
+@jax.jit
+def f(x):
+  return block(x) + 1.
+
+print(f.lower(1.0).as_text("hlo"))
+```
+
+The wrapped function is staged out as its own subcomputation, and the call
+into it carries the metadata:
+
+```
+xla_metadata_call.1 {
+  Arg_0.1 = f32[] parameter(0)
+  sin.1 = f32[] sine(Arg_0.1)
+  cos.1 = f32[] cosine(Arg_0.1)
+  ROOT mul.1 = f32[] multiply(sin.1, cos.1)
+}
+
+ENTRY main.2 {
+  x.1 = f32[] parameter(0)
+  xla_metadata_call.1 = f32[] call(x.1), to_apply=xla_metadata_call.1, frontend_attributes={tag="my_block"}
+  constant.1 = f32[] constant(1)
+  ROOT add.1 = f32[] add(xla_metadata_call.1, constant.1)
+}
+```
+
+When XLA inlines the call during optimization, it propagates the attributes
+onto the inlined operations, so the metadata lands on each operation from the
+wrapped function.
+
+Metadata values may be strings, bools, ints, or floats; all are attached as
+strings, with bools rendered as `"true"`/`"false"`.
+
+### Metadata survives transformations
+
+Because the metadata is attached to a function rather than to ambient tracing
+state, JAX transformations preserve it. Under `jax.vmap` the batched
+operations carry it, and under `jax.grad` every computation derived from the
+function — forward pass and backward pass — carries it too:
+
+```python
+@xla_metadata_call(tag="my_block")
+def block(x):
+  return jnp.sin(x)
+
+print(jax.jit(jax.grad(block)).lower(1.0).as_text("hlo"))
+```
+
+```
+xla_metadata_call.1 {
+  Arg_0.1 = f32[] parameter(0)
+  ROOT cos.1 = f32[] cosine(Arg_0.1)
+}
+
+xla_metadata_call_0.2 {
+  Arg_1.1 = f32[] parameter(1)
+  Arg_0.3 = f32[] parameter(0)
+  ROOT mul.1 = f32[] multiply(Arg_1.1, Arg_0.3)
+}
+
+ENTRY main.3 {
+  x.1 = f32[] parameter(0)
+  xla_metadata_call.2 = f32[] call(x.1), to_apply=xla_metadata_call.1, frontend_attributes={tag="my_block"}
+  constant.1 = f32[] constant(1)
+  ROOT xla_metadata_call.3 = f32[] call(xla_metadata_call.2, constant.1), to_apply=xla_metadata_call_0.2, frontend_attributes={tag="my_block"}
+}
+```
+
+The forward-pass computation (here just the `cosine` residual saved for the
+backward pass) and the backward-pass computation are each staged out and
+tagged.
+
+To leave the backward pass untagged, or to tag it differently — say, with its
+own scheduling group — use `xla_metadata_call2`, which takes the metadata as a
+dict plus an `ad_metadata` option:
+
+```python
+from jax.experimental.xla_metadata import xla_metadata_call2
+
+f = xla_metadata_call2(jnp.sin, {"tag": "x"})                             # tag fwd + bwd (default)
+f = xla_metadata_call2(jnp.sin, {"tag": "x"}, ad_metadata='drop')         # tag fwd only
+f = xla_metadata_call2(jnp.sin, {"tag": "x"}, ad_metadata={"tag": "y"})   # retag bwd
+```
+
+`ad_metadata` governs the computations autodiff derives beyond the forward
+pass: the linearized (tangent) and transposed (backward-pass) computations.
+One caveat: under forward-mode `jax.jvp`, the primal and tangent operations
+are staged out as one fused computation, so they keep the forward metadata
+regardless of `ad_metadata`.
+
+One application built on this: `must_fuse_call` in
+`jax.experimental.xla_metadata` wraps a function so that XLA must place all of
+its operations in a single fusion.
+
+### Tagging one operation in place: `set_xla_metadata`
+
+There is also `set_xla_metadata`, with two modes. Wrapping a *value* tags just
+the operation that produced it:
+
+```python
 from jax.experimental.xla_metadata import set_xla_metadata
 
-### Tagging an individual operation
-def value_tagging(x):
+def g(x):
   y = jnp.sin(x)
   z = jnp.cos(x)
   return set_xla_metadata(y * z, breakpoint=True)
 
-print(jax.jit(value_tagging).lower(1.0).as_text("hlo"))
+print(jax.jit(g).lower(1.0).as_text("hlo"))
 ```
-Results in:
+
 ```
-ENTRY main.5 {
+ENTRY main.1 {
   x.1 = f32[] parameter(0)
-  sin.2 = f32[] sine(x.1)
-  cos.3 = f32[] cosine(x.1)
-  ROOT mul.4 = f32[] multiply(sin.2, cos.3), frontend_attributes={breakpoint="true"}
-}
-```
-#### Tagging a Block of Code with a Context Manager or Decorator
-If you want to apply the same metadata to a larger section of code, you can use `set_xla_metadata` as a context manager. All JAX operations within the `with` block will have the specified metadata attached.
-
-```python
-import jax
-import jax.numpy as jnp
-from jax.experimental.xla_metadata import set_xla_metadata
-
-### Tagging a block of code
-def context_tagging(x):
-  with set_xla_metadata(_xla_log=True):
-    y = jnp.sin(x)
-    z = jnp.cos(y)
-    return y * z
-
-print(jax.jit(context_tagging).lower(1.0).as_text("hlo"))
-```
-Results in:
-```
-ENTRY main.5 {
-  x.1 = f32[] parameter(0)
-  sin.2 = f32[] sine(x.1), frontend_attributes={_xla_log="true"}
-  cos.3 = f32[] cosine(sin.2), frontend_attributes={_xla_log="true"}
-  ROOT mul.4 = f32[] multiply(sin.2, cos.3), frontend_attributes={_xla_log="true"}
+  sin.1 = f32[] sine(x.1)
+  cos.1 = f32[] cosine(x.1)
+  ROOT mul.1 = f32[] multiply(sin.1, cos.1), frontend_attributes={breakpoint="true"}
 }
 ```
 
-If you want to tag all operations in a function, you can also use `set_xla_metadata` as a decorator:
+Called with no value, `set_xla_metadata(k="v")` instead acts as a context
+manager (or decorator) that tags every operation traced under it.
 
-```python
-import jax
-import jax.numpy as jnp
-from jax.experimental.xla_metadata import set_xla_metadata
+Both modes come with caveats that `xla_metadata_call` avoids:
 
-### Tagging with a decorator
-@set_xla_metadata(_xla_log=True)
-@jax.jit
-def decorator_tagging(x):
-  y = jnp.sin(x)
-  z = jnp.cos(y)
-  return y * z
+- The context manager works by setting ambient tracing state, which is part
+  of `jit`'s cache key. Any jit-compiled function called under it — including
+  library code that jits internally — is re-traced and re-compiled for each
+  distinct metadata context, rather than reusing its existing cache entries.
+- Value-tagging doesn't propagate through autodiff: differentiate `g` above
+  and the backward-pass operations come out untagged.
 
-print(decorator_tagging.lower(1.0).as_text("hlo"))
-```
-This will result in the same HLO as above.
+Prefer `xla_metadata_call` unless you need to tag exactly one operation in
+place.
 
-### Interaction with JAX Transformations
-`set_xla_metadata` utilizes either a `XlaMetadataContextManager` or JAX `primitive` depending on use-case and is compatible with JAX's transformations like `jit`, `vmap`, and `grad`.
-*   **`vmap`**: When you `vmap` a function containing `set_xla_metadata`, the metadata will be applied to all of the relevant batched operations.
-*   **`grad`**:
-    1. When tagging a block of operations with the **context manager** `with set_xla_metadata(...):`, the metadata is applied to both the forward pass and backward pass of the operations within it.
-    2. Tagging **individual ops** with `set_xla_metadata()` currently only applies to the forward pass of a function. To tag individual operations generated by the backward pass (i.e., the gradient computation), a simple `custom_vjp` can be used:
-        ```python
-        import jax
-        import jax.numpy as jnp
-        from jax.experimental.xla_metadata import set_xla_metadata
-
-        def fn(x):
-            y = jnp.sin(x)
-            z = jnp.cos(x)
-            return y * z
-
-        metadata = {"example": "grad_tagging"}
-
-        # --- Define Custom VJP to tag gradients ---
-        @jax.custom_vjp
-        def wrapped_fn(x):
-            return fn(x)
-
-        def fwd(*args):
-            primal_out, vjp_fn = jax.vjp(fn, *args)
-            return primal_out, vjp_fn
-
-        def bwd(vjp_fn, cts_in):
-            cts_out = vjp_fn(cts_in)
-            cts_out = set_xla_metadata(cts_out, **metadata)
-            return cts_out
-
-        wrapped_fn.defvjp(fwd, bwd)
-        # ------
-
-        print(jax.jit(jax.grad(wrapped_fn)).lower(jnp.array(3.0)).as_text("hlo"))
-        ```
-        Results in:
-        ```
-        ENTRY main.10 {
-          x.1 = f32[] parameter(0)
-          sin.2 = f32[] sine(x.1)
-          neg.6 = f32[] negate(sin.2)
-          sin.5 = f32[] sine(x.1)
-          mul.7 = f32[] multiply(neg.6, sin.5)
-          cos.4 = f32[] cosine(x.1)
-          cos.3 = f32[] cosine(x.1)
-          mul.8 = f32[] multiply(cos.4, cos.3)
-          ROOT add_any.9 = f32[] add(mul.7, mul.8), frontend_attributes={example="grad_tagging"}
-        }
-        ```
-##### Strengths and Limitations of `set_xla_metadata`
-
-###### Strengths
-*   **Variable Control:** Allows you to target individual operations or blocks of operations.
-*   **Non-Intrusive:** Does not change the numerical output or fusion behavior of your program.
-*   **Enables Powerful Tooling:** Unlocks the potential for sophisticated debugging and analysis at the compiler level.
-
-###### Limitations
-*   **Attributes may be lost:** While it's intended for XLA metadata to be maintained throughout transformations and HLO optimizations, certain edge-cases may result in the metadata being lost.
-*   **Forward-pass only:** Metadata is not currently automatically propagated to gradients <u>when tagging individual operations</u> in the backward pass. A `custom_vjp` must be used in order to tag gradients in this case. See above for an example.
-*   **Liable to change**: `set_xla_metadata` is an experimental feature and its API is subject to change.
+Finally, a caveat that applies to all of these APIs: XLA intends to preserve
+`frontend_attributes` through its optimization passes, but edge cases can
+drop them, so inspect the optimized HLO if a tool depends on the metadata
+surviving.
 

--- a/jax/_src/xla_metadata.py
+++ b/jax/_src/xla_metadata.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Mapping
 from functools import partial, wraps
 from typing import Any
 
@@ -162,13 +163,115 @@ def _attach_xla_metadata_to_op(
     )
 
 
-def xla_metadata_call(f=None, **meta):
+def xla_metadata_call(f=None, /, **meta):
+  """Wraps a function so it lowers to a call op tagged with XLA metadata.
+
+  Sugar for :func:`xla_metadata_call2` with the metadata passed as keyword
+  arguments and default options. The wrapped function is staged out as a
+  separate computation, invoked via a call op annotated with the given
+  metadata as ``frontend_attributes``. XLA propagates the attributes to the
+  ops inside the call when it inlines it.
+
+  Unlike the ``set_xla_metadata`` context manager, this does not perturb the
+  tracing context, so it doesn't cause retracing or recompilation of jitted
+  functions. The metadata also follows the computation through
+  transformations: under ``jax.grad``, both the forward- and backward-pass
+  computations derived from the function carry the metadata. To leave the
+  backward pass untagged, or tag it differently, use
+  :func:`xla_metadata_call2` and its ``ad_metadata`` option.
+
+  Args:
+    f: the function to wrap. If not given, returns a decorator.
+    **meta: metadata to attach, as keyword arguments. Values may be strings,
+      bools, ints, or floats; they are attached as strings (with bools
+      rendered as ``"true"``/``"false"``).
+
+  Returns:
+    A wrapped version of ``f`` with the metadata applied, or a decorator.
+
+  Example:
+
+    >>> import jax, jax.numpy as jnp
+    >>> from jax.experimental.xla_metadata import xla_metadata_call
+    >>> @xla_metadata_call(tag="my_block")
+    ... def f(x):
+    ...   return jnp.sin(x) * jnp.cos(x)
+  """
   if f is None:
-    return lambda g: _xla_metadata_call(g, **meta)
-  return _xla_metadata_call(f, **meta)
+    return lambda g: _xla_metadata_call(g, meta, 'same')
+  return _xla_metadata_call(f, meta, 'same')
+
+
+def xla_metadata_call2(f=None, /, metadata=None, *, ad_metadata='same'):
+  """Like :func:`xla_metadata_call`, with the metadata as a dict plus options.
+
+  Args:
+    f: the function to wrap. If not given, returns a decorator.
+    metadata: a dict of metadata to attach to the call op as
+      ``frontend_attributes``. Values may be strings, bools, ints, or floats;
+      they are attached as strings (with bools rendered as
+      ``"true"``/``"false"``).
+    ad_metadata: metadata for the computations that autodiff derives from the
+      function, beyond the forward pass: the linearized (tangent) and
+      transposed (backward-pass) computations. The default ``'same'`` attaches
+      ``metadata`` to them too; ``'drop'`` leaves them untagged; a dict
+      attaches that metadata instead. Under forward-mode ``jax.jvp``, the
+      primal and tangent computations are staged out fused, so they keep
+      ``metadata`` regardless.
+
+  Returns:
+    A wrapped version of ``f`` with the metadata applied, or a decorator.
+
+  Example:
+
+    >>> import jax, jax.numpy as jnp
+    >>> from jax.experimental.xla_metadata import xla_metadata_call2
+    >>> @xla_metadata_call2({"scheduling_group": "l3"},
+    ...                     ad_metadata={"scheduling_group": "l3_bwd"})
+    ... def layer3(x):
+    ...   return jnp.sin(x) * jnp.cos(x)
+  """
+  if isinstance(f, Mapping) and metadata is None:
+    f, metadata = None, f
+  if f is not None and not callable(f):
+    raise TypeError(f"expected a callable to wrap, got {f!r}")
+  if f is None:
+    return lambda g: _xla_metadata_call(g, metadata, ad_metadata)
+  return _xla_metadata_call(f, metadata, ad_metadata)
+
+
+def _canonicalize_metadata(meta):
+  canonical = {}
+  for k, v in meta.items():
+    if isinstance(v, bool):
+      canonical[k] = str(v).lower()
+    elif isinstance(v, (str, int, float)):
+      canonical[k] = str(v)
+    else:
+      raise TypeError(
+          "xla_metadata_call metadata values must be str, bool, int, or "
+          f"float, got {type(v)} for key {k!r}")
+  return tuple(sorted(canonical.items()))
+
+def _canonicalize_ad_metadata(ad_metadata):
+  if ad_metadata == 'same':
+    return 'same'
+  elif ad_metadata == 'drop':
+    return ()
+  elif isinstance(ad_metadata, Mapping):
+    return _canonicalize_metadata(ad_metadata)
+  else:
+    raise TypeError(
+        "ad_metadata must be 'same', 'drop', or a dict of metadata, got "
+        f"{ad_metadata!r}")
 
 # TODO(yashkatariya): Figure out a way to reuse code with compute_on2_p, fused_p
-def _xla_metadata_call(fun, **meta):
+def _xla_metadata_call(fun, metadata, ad_metadata):
+  if metadata is not None and not isinstance(metadata, Mapping):
+    raise TypeError(f"metadata must be a dict, got {metadata!r}")
+  metadata_kvs = _canonicalize_metadata(metadata or {})
+  ad_metadata_kvs = _canonicalize_ad_metadata(ad_metadata)
+  @wraps(fun)
   def wrapped(*args, **kwargs):
     dbg = debug_info('xla_metadata_call', fun, args, kwargs)
     args_ft = ft.flatten((args, kwargs))
@@ -179,7 +282,8 @@ def _xla_metadata_call(fun, **meta):
     else:
       consts = []
     outs_flat = xla_metadata_call_p.bind(*consts, *args_ft.vals, jaxpr=jaxpr,
-                                         **meta)
+                                         xla_metadata=metadata_kvs,
+                                         ad_metadata=ad_metadata_kvs)
     return tree_unflatten(out_avals.tree, outs_flat)
   return wrapped
 
@@ -188,18 +292,17 @@ xla_metadata_call_p.multiple_results = True
 dispatch.simple_impl(xla_metadata_call_p)
 
 
-def _xla_metadata_call_abstract_eval(*in_avals, jaxpr, **meta):
+def _xla_metadata_call_abstract_eval(*in_avals, jaxpr, xla_metadata,
+                                     ad_metadata):
   return jaxpr.out_avals
 xla_metadata_call_p.def_abstract_eval(_xla_metadata_call_abstract_eval)
 
 
-def attr_get(x):
-  if isinstance(x, str):
-    return ir.StringAttr.get(x)
-  else:
-    raise NotImplementedError(f'mlir attr handler for {type(x)=}')
+def _resolve_ad_metadata(xla_metadata, ad_metadata):
+  return xla_metadata if ad_metadata == 'same' else ad_metadata
 
-def _xla_metadata_call_lowering(ctx, *args, jaxpr, **meta):
+
+def _xla_metadata_call_lowering(ctx, *args, jaxpr, xla_metadata, ad_metadata):
   const_args_and_avals = core.jaxpr_const_args(jaxpr)
   const_args, const_avals = unzip2(const_args_and_avals)
   in_avals = (*const_avals, *jaxpr.in_avals)
@@ -219,8 +322,9 @@ def _xla_metadata_call_lowering(ctx, *args, jaxpr, **meta):
   call = func_dialect.CallOp(
       flat_output_types, ir.FlatSymbolRefAttr.get(symbol_name),
       flat_args)
-  call.operation.attributes['mhlo.frontend_attributes'] = ir.DictAttr.get(
-      {k: attr_get(v) for k, v in meta.items()})
+  if xla_metadata:
+    call.operation.attributes['mhlo.frontend_attributes'] = ir.DictAttr.get(
+        {k: ir.StringAttr.get(v) for k, v in xla_metadata})
   out_nodes = treedef.unflatten(call.results)
   tokens, out_nodes = split_list(out_nodes, [len(effects)])
   tokens_out = ctx.tokens_in.update_tokens(mlir.TokenSet(dict(zip(effects, tokens))))
@@ -229,18 +333,26 @@ def _xla_metadata_call_lowering(ctx, *args, jaxpr, **meta):
 mlir.register_lowering(xla_metadata_call_p, _xla_metadata_call_lowering)
 
 
-def _xla_metadata_call_batcher(axis_data, vals_in, dims_in, *, jaxpr, **meta):
+def _xla_metadata_call_batcher(axis_data, vals_in, dims_in, *, jaxpr,
+                               xla_metadata, ad_metadata):
   batched_jaxpr, dims_out = batching.batch_jaxpr2(jaxpr, axis_data, dims_in)
-  outs = xla_metadata_call_p.bind(*vals_in, jaxpr=batched_jaxpr, **meta)
+  outs = xla_metadata_call_p.bind(*vals_in, jaxpr=batched_jaxpr,
+                                  xla_metadata=xla_metadata,
+                                  ad_metadata=ad_metadata)
   return outs, dims_out
 batching.fancy_primitive_batchers[xla_metadata_call_p] = _xla_metadata_call_batcher
 
 
-def _xla_metadata_call_jvp(primals, tangents, *, jaxpr, **meta):
+def _xla_metadata_call_jvp(primals, tangents, *, jaxpr, xla_metadata,
+                           ad_metadata):
+  # The jvp jaxpr fuses primal and tangent ops, so it keeps the primal
+  # metadata; ad_metadata still governs any later linearization/transposition.
   nzs = [not isinstance(t, ad.Zero) for t in tangents]
   jaxpr_jvp, out_nzs = ad.jvp_jaxpr(jaxpr, nzs, False)
   nz_tangents = [t for t in tangents if not isinstance(t, ad.Zero)]
-  outs = xla_metadata_call_p.bind(*primals, *nz_tangents, jaxpr=jaxpr_jvp, **meta)
+  outs = xla_metadata_call_p.bind(*primals, *nz_tangents, jaxpr=jaxpr_jvp,
+                                  xla_metadata=xla_metadata,
+                                  ad_metadata=ad_metadata)
   primals_out, nz_tangents_out = outs[:len(out_nzs)], outs[len(out_nzs):]
   nz_outs = iter(nz_tangents_out)
   tangents_out = [next(nz_outs) if nz else ad.Zero(aval.to_tangent_aval())
@@ -250,11 +362,13 @@ def _xla_metadata_call_jvp(primals, tangents, *, jaxpr, **meta):
 ad.primitive_jvps[xla_metadata_call_p] = _xla_metadata_call_jvp
 
 
-def _xla_metadata_call_lin(is_vjp, nzs, *primals, jaxpr, **meta):
+def _xla_metadata_call_lin(is_vjp, nzs, *primals, jaxpr, xla_metadata,
+                           ad_metadata):
   (primal_jaxpr, num_residuals_out, nzs_out, in_fwd_res,
    tangent_jaxpr) = ad.linearize_jaxpr(jaxpr, nzs, is_vjp=is_vjp)
 
   tangent_avals_out = [a.to_tangent_aval() for a in jaxpr.out_avals]
+  tangent_metadata = _resolve_ad_metadata(xla_metadata, ad_metadata)
 
   def _filter_zeros(is_nz_l, l):
     return tuple(x for nz, x in zip(is_nz_l, l) if nz)
@@ -264,14 +378,18 @@ def _xla_metadata_call_lin(is_vjp, nzs, *primals, jaxpr, **meta):
     assert len(residuals) + len(tangents_nz) == len(tangent_jaxpr.invars), (
         len(residuals), len(tangents_nz), len(tangent_jaxpr.invars))
     nz_outs = xla_metadata_call_p.bind(*residuals, *tangents_nz,
-                                       jaxpr=tangent_jaxpr, **meta)
+                                       jaxpr=tangent_jaxpr,
+                                       xla_metadata=tangent_metadata,
+                                       ad_metadata='same')
     nz_outs_ = iter(nz_outs)
     outs = [next(nz_outs_) if nz else ad.Zero(a)
             for nz, a in zip(nzs_out, tangent_avals_out)]
     assert next(nz_outs_, None) is None
     return outs
 
-  ans = xla_metadata_call_p.bind(*primals, jaxpr=primal_jaxpr, **meta)
+  ans = xla_metadata_call_p.bind(*primals, jaxpr=primal_jaxpr,
+                                 xla_metadata=xla_metadata,
+                                 ad_metadata=ad_metadata)
   primal_ans, residuals_ans = split_list(ans, [len(ans) - num_residuals_out])
   residuals_ans = subs_list(in_fwd_res, [*jaxpr.consts, *primals], residuals_ans)
   return primal_ans, nzs_out, residuals_ans, tangent_fun
@@ -295,13 +413,17 @@ def _transpose_jaxpr(jaxpr, in_tree, in_avals, specs):
   return trans_jaxpr.with_consts(consts), out_tree
 
 
-def _xla_metadata_call_transpose(cts_in, *args, jaxpr, **meta):
+def _xla_metadata_call_transpose(cts_in, *args, jaxpr, xla_metadata,
+                                 ad_metadata):
   primals_ctrefs, specs = ad.project_accums(args)
   in_flat, in_tree = tree_flatten((primals_ctrefs, cts_in))
   in_avals = [core.typeof(x) for x in in_flat]
   trans_jaxpr, out_tree = _transpose_jaxpr(jaxpr, in_tree, (*in_avals,), specs)
 
-  cts_out = xla_metadata_call_p.bind(*in_flat, jaxpr=trans_jaxpr, **meta)
+  cts_out = xla_metadata_call_p.bind(
+      *in_flat, jaxpr=trans_jaxpr,
+      xla_metadata=_resolve_ad_metadata(xla_metadata, ad_metadata),
+      ad_metadata='same')
 
   for x, ct in zip(args, tree_unflatten(out_tree, cts_out)):
     if isinstance(x, ad.ValAccum):

--- a/jax/experimental/xla_metadata.py
+++ b/jax/experimental/xla_metadata.py
@@ -27,6 +27,7 @@ import contextlib
 from jax._src.xla_metadata import (
     set_xla_metadata as set_xla_metadata,
     xla_metadata_call as xla_metadata_call,
+    xla_metadata_call2 as xla_metadata_call2,
 )
 
 

--- a/tests/xla_metadata_test.py
+++ b/tests/xla_metadata_test.py
@@ -24,6 +24,7 @@ from jax._src import test_util as jtu
 from jax._src.lax import lax
 from jax.experimental.xla_metadata import set_xla_metadata
 from jax.experimental.xla_metadata import xla_metadata_call
+from jax.experimental.xla_metadata import xla_metadata_call2
 import jax.numpy as jnp
 import numpy as np
 
@@ -476,6 +477,76 @@ class XlaMetadataTest(jtu.JaxTestCase):
     inputs = (jnp.array(0.0), jnp.arange(1, 4, dtype=jnp.float32))
     text = jax.jit(scan_fn).lower(*inputs).as_text("hlo")
     self._assert_metadata_appears_once_per_op(text, ["multiply"], metadata)
+
+  def test_xla_metadata_call_nonstring_values(self):
+    f = xla_metadata_call(lambda x: x + 1, flag=True, level=3, ratio=0.5)
+    text = jax.jit(f).lower(1.0).as_text()
+    self.assertIn('flag = "true"', text)
+    self.assertIn('level = "3"', text)
+    self.assertIn('ratio = "0.5"', text)
+
+  def test_xla_metadata_call_invalid_value(self):
+    with self.assertRaisesRegex(TypeError, "metadata values must be"):
+      xla_metadata_call(lambda x: x + 1, bad=object())
+
+  def test_xla_metadata_call_key_named_jaxpr(self):
+    f = xla_metadata_call(lambda x: x + 1, jaxpr="v", f="w")
+    self.assertIn('jaxpr = "v"', jax.jit(f).lower(1.0).as_text())
+
+  def test_xla_metadata_call_grad_metadata_on_backward_pass(self):
+    @xla_metadata_call(a="b")
+    def f(x):
+      return jnp.sin(x)
+
+    text = jax.jit(jax.grad(f)).lower(1.0).as_text()
+    self.assertEqual(text.count('mhlo.frontend_attributes = {a = "b"}'), 2)
+
+  def test_xla_metadata_call2_default_matches_sugar(self):
+    text1 = jax.jit(jax.grad(xla_metadata_call(jnp.sin, tag="x"))
+                    ).lower(1.0).as_text()
+    text2 = jax.jit(jax.grad(xla_metadata_call2(jnp.sin, {"tag": "x"}))
+                    ).lower(1.0).as_text()
+    self.assertEqual(text1, text2)
+
+  def test_xla_metadata_call2_ad_metadata_drop(self):
+    f = xla_metadata_call2(jnp.sin, {"tag": "x"}, ad_metadata='drop')
+    text = jax.jit(jax.value_and_grad(f)).lower(1.0).as_text()
+    self.assertEqual(text.count('tag = "x"'), 1)
+
+  def test_xla_metadata_call2_ad_metadata_retag(self):
+    f = xla_metadata_call2(jnp.sin, {"tag": "x"},
+                           ad_metadata={"tag": "x_bwd"})
+    text = jax.jit(jax.value_and_grad(f)).lower(1.0).as_text()
+    self.assertEqual(text.count('tag = "x"'), 1)
+    self.assertEqual(text.count('tag = "x_bwd"'), 1)
+
+  def test_xla_metadata_call2_jvp_keeps_primal_metadata(self):
+    f = xla_metadata_call2(jnp.sin, {"tag": "x"}, ad_metadata='drop')
+    text = jax.jit(lambda x, t: jax.jvp(f, (x,), (t,))
+                   ).lower(1.0, 1.0).as_text()
+    self.assertEqual(text.count('tag = "x"'), 1)
+
+  def test_xla_metadata_call2_decorator_forms(self):
+    @xla_metadata_call2({"tag": "deco"})
+    def f(x):
+      return x * 2
+
+    @xla_metadata_call2(metadata={"tag": "kw"}, ad_metadata='drop')
+    def g(x):
+      return x * 2
+
+    self.assertIn('tag = "deco"', jax.jit(f).lower(1.0).as_text())
+    self.assertIn('tag = "kw"', jax.jit(g).lower(1.0).as_text())
+
+  def test_xla_metadata_call2_invalid_args(self):
+    with self.assertRaisesRegex(TypeError, "ad_metadata must be"):
+      xla_metadata_call2(jnp.sin, {"a": "b"}, ad_metadata="typo")
+    with self.assertRaisesRegex(TypeError, "ad_metadata must be"):
+      xla_metadata_call2(jnp.sin, {"a": "b"}, ad_metadata=None)
+    with self.assertRaisesRegex(TypeError, "expected a callable"):
+      xla_metadata_call2(3, {"a": "b"})
+    with self.assertRaisesRegex(TypeError, "metadata must be a dict"):
+      xla_metadata_call2(jnp.sin, "notadict")
 
   def test_grad_xla_metadata_call_basic(self):
     @xla_metadata_call(inlineable="false")


### PR DESCRIPTION
Docs (new_docs/201/controlling-xla.md): rewrite the XLA-metadata section around xla_metadata_call instead of the set_xla_metadata context manager. The context manager perturbs the tracing context (it is part of the jit cache key), so any jitted function called under it is retraced and recompiled per distinct metadata context. Also show that metadata follows AD-derived computations, replacing the old custom_vjp workaround for tagging the backward pass.

xla_metadata_call fixes:
* canonicalize metadata values at the API boundary: str/bool/int/float attach as strings (bools as "true"/"false"); non-str values previously crashed at lowering with NotImplementedError
* consolidate the scattered **meta primitive params into a single xla_metadata tuple-of-sorted-kvs param and make f positional-only, so any metadata key works (a key named "jaxpr" used to crash the bind)
* add functools.wraps and a docstring

Add xla_metadata_call2(f=None, /, metadata=None, *, ad_metadata="same"): like xla_metadata_call, but takes metadata as a dict plus options, leaving the kwargs form as sugar over it. ad_metadata ("same" | "drop" | dict) controls metadata on the computations autodiff derives beyond the forward pass (linearize-tangent and transpose): "same" keeps the original metadata (the previous behavior), "drop" leaves them untagged, and a dict retags them (e.g. a separate scheduling group for the backward pass). Forward-mode jvp stages primal and tangent fused, so it keeps the original metadata regardless, with the knob passing through to later linearization or transposition.

Tests for all of the above in xla_metadata_test.py.