### PR TITLE
[docs] add new_docs 301 page on first-class VJPs, including saveable_args

### DIFF
--- a/docs/new_docs/301/cookbook.md
+++ b/docs/new_docs/301/cookbook.md
@@ -15,9 +15,9 @@ nosearch: true
 ---
 
 (jax-301-cookbook)=
-# The Autodiff Cookbook
+# The Autodiff Cookbook with JVP and VJP
 
-<!--* freshness: { reviewed: '2026-07-10' } *-->
+<!--* freshness: { reviewed: '2026-07-16' } *-->
 
 JAX has a pretty general automatic differentiation system. In this document
 we'll go through a whole bunch of neat autodiff ideas that you can cherry-pick
@@ -570,73 +570,11 @@ y, f_vjp = vjp(f, 4.)
 print(jit(f_vjp)(1.))
 ```
 
-## Splitting the forward and backward passes
-
-`jax.grad` and `jax.vjp` package the forward and backward passes together:
-under a `jax.jit`, they compile into a single program. Usually that's what
-you want. But sometimes it's useful to run the forward and backward passes
-as *separate* compiled functions — say, to interleave the forward and
-backward passes of different microbatches or pipeline stages on a schedule
-of your own, with each function compiled once and reused many times.
-
-You can build this out of `jax.vjp` directly:
-
-```{code-cell}
-import jax
-
-def fwd_and_bwd(f):
-  def fwd(*args):
-    return jax.vjp(f, *args)
-  def bwd(f_vjp, y_bar):
-    return f_vjp(y_bar)
-  return jit(fwd), jit(bwd)
-```
-
-The trick is that the callable returned by `jax.vjp` is itself a pytree: its
-leaves are the residual values saved by the forward pass, and its tree
-structure records the backward-pass computation. So it can be returned out
-of one jit-compiled function and passed into another, like any other data.
-Notice that there's nothing specific to `f` in `bwd` — it's just "apply".
-
-Each of `fwd` and `bwd` compiles once, and we can call them however many
-times and in whatever order we like:
-
-```{code-cell}
-def layer(W, x):
-  return jnp.tanh(x @ W)
-
-fwd, bwd = fwd_and_bwd(layer)
-
-W1, W2 = jnp.ones((3, 3)), 2. * jnp.ones((3, 3))
-x0 = jnp.ones((2, 3))
-
-# forward through two layers, then backward, on our own schedule:
-x1, res1 = fwd(W1, x0)
-x2, res2 = fwd(W2, x1)
-dW2, dx1 = bwd(res2, jnp.ones_like(x2))
-dW1, dx0 = bwd(res1, dx1)
-```
-
-That computes the same gradients that an end-to-end `jax.grad` would:
-
-```{code-cell}
-def two_layers(W1, W2, x):
-  return jnp.sum(layer(W2, layer(W1, x)))
-
-dW1_ref, dW2_ref = grad(two_layers, argnums=(0, 1))(W1, W2, x0)
-print(jnp.allclose(dW1, dW1_ref), jnp.allclose(dW2, dW2_ref))
-```
-
-JAX also provides this pattern prepackaged as `jax.fwd_and_bwd`, with an
-`argnums` argument selecting which inputs to produce cotangents for:
-
-```{code-cell}
-fwd, bwd = jax.fwd_and_bwd(layer, argnums=(0, 1))
-
-y, residuals = fwd(W1, x0)
-dW1, dx0 = bwd(residuals, jnp.ones_like(y))
-print(dW1.shape, dx0.shape)
-```
+In fact, the callable returned by `jax.vjp` is a first-class value in its
+own right — a pytree whose leaves are the saved residuals — which you can
+use to split the forward and backward passes into separately compiled
+functions, schedule them yourself, and control what gets saved. That's the
+subject of {doc}`vjp-objects`.
 
 ## Complex numbers and differentiation
 

--- a/docs/new_docs/301/index.rst
+++ b/docs/new_docs/301/index.rst
@@ -10,26 +10,30 @@ autodiff interacts with sharding, defining your own derivative rules and
 even your own types, autodiff with mutable state, and controlling the
 memory/compute tradeoff of differentiation.
 
-1. :doc:`cookbook` — the autodiff cookbook: Hessian-vector products,
-   Jacobians with ``jacfwd``/``jacrev``, the ``jvp``/``vjp`` machinery and
-   how it's composed, and differentiation with complex numbers.
-2. :doc:`sharding-ad` — how autodiff interacts with sharding: cotangent
+1. :doc:`cookbook` — cooking with autodiff's fundamental ingredients, the
+   ``jvp`` and ``vjp`` machinery: recipes for Hessian-vector products and
+   full Jacobians, spiced up by mixing in ``vmap`` and complex numbers.
+2. :doc:`vjp-objects` — the VJP object as a pytree, splitting the forward
+   and backward passes into separately compiled functions run on your own
+   schedule, and excluding argument values (like weights) from the saved
+   state with ``saveable_args``.
+3. :doc:`sharding-ad` — how autodiff interacts with sharding: cotangent
    shardings as a function of primal shardings, and controlling
    backward-pass communication with ``unreduced`` and ``reduced``, in both
    explicit and manual (``shard_map``) modes.
-3. :doc:`custom-derivatives` — defining custom derivative rules with hijax
+4. :doc:`custom-derivatives` — defining custom derivative rules with hijax
    primitives, the recommended approach: one primitive can carry rules for
    both modes, plus linearization, batching, and more.
-4. :doc:`custom-jvp-vjp` — the classic decorators, customizing one
+5. :doc:`custom-jvp-vjp` — the classic decorators, customizing one
    differentiation mode at a time: still fully supported, and often the most
    convenient tool for simple cases.
-5. :doc:`refs` — autodiff with mutable arrays: plumbing values out of
+6. :doc:`refs` — autodiff with mutable arrays: plumbing values out of
    backward passes, in-place gradient accumulation with ``with_refs``, and
    differentiating with respect to refs.
-6. :doc:`remat` — gradient checkpointing with ``jax.checkpoint``: what
+7. :doc:`remat` — gradient checkpointing with ``jax.checkpoint``: what
    autodiff saves versus recomputes, name-based policies, offloading, and
    per-function control with ``custom_remat``.
-7. :doc:`hijax-types` — defining entirely new JAX types with hijax, with
+8. :doc:`hijax-types` — defining entirely new JAX types with hijax, with
    their own derivatives, batching, and sharding behavior.
 
 .. toctree::
@@ -37,6 +41,7 @@ memory/compute tradeoff of differentiation.
    :maxdepth: 1
 
    cookbook
+   vjp-objects
    sharding-ad
    custom-derivatives
    custom-jvp-vjp

--- a/docs/new_docs/301/vjp-objects.md
+++ b/docs/new_docs/301/vjp-objects.md
@@ -1,0 +1,214 @@
+---
+jupytext:
+  formats: md:myst
+  notebook_metadata_filter: nosearch
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nosearch: true
+---
+
+(jax-301-vjp-objects)=
+# First-class VJPs
+
+<!--* freshness: { reviewed: '2026-07-16' } *-->
+
+The callable returned by `jax.vjp` is more than a closure to call once and
+throw away: it's a *VJP object*, a first-class value. It's a pytree whose
+leaves are the residual values saved by the forward pass, so it can be
+passed into and out of compiled functions, serialized, or offloaded like any
+other data — and its saved state can be inspected and edited. This page
+covers what that enables: splitting the forward and backward passes into
+separately compiled functions run on your own schedule, and excluding
+argument values (like weights) from the saved state with `saveable_args`.
+
+```{code-cell}
+import jax
+import jax.numpy as jnp
+from jax import grad, jit
+```
+
+(jax-301-fwd-bwd-split)=
+## Splitting the forward and backward passes
+
+`jax.grad` and `jax.vjp` package the forward and backward passes together:
+under a `jax.jit`, they compile into a single program. Usually that's what
+you want. But sometimes it's useful to run the forward and backward passes
+as *separate* compiled functions — say, to interleave the forward and
+backward passes of different microbatches or pipeline stages on a schedule
+of your own, with each function compiled once and reused many times.
+
+You can build this out of `jax.vjp` directly:
+
+```{code-cell}
+def fwd_and_bwd(f):
+  def fwd(*args):
+    return jax.vjp(f, *args)
+  def bwd(f_vjp, y_bar):
+    return f_vjp(y_bar)
+  return jit(fwd), jit(bwd)
+```
+
+The trick is that the callable returned by `jax.vjp` is itself a pytree: its
+leaves are the residual values saved by the forward pass, and its tree
+structure records the backward-pass computation. So it can be returned out
+of one jit-compiled function and passed into another, like any other data.
+Notice that there's nothing specific to `f` in `bwd` — it's just "apply".
+
+Each of `fwd` and `bwd` compiles once, and we can call them however many
+times and in whatever order we like:
+
+```{code-cell}
+def layer(W, x):
+  return jnp.tanh(x @ W)
+
+fwd, bwd = fwd_and_bwd(layer)
+
+W1, W2 = jnp.ones((3, 3)), 2. * jnp.ones((3, 3))
+x0 = jnp.ones((2, 3))
+
+# forward through two layers, then backward, on our own schedule:
+x1, res1 = fwd(W1, x0)
+x2, res2 = fwd(W2, x1)
+dW2, dx1 = bwd(res2, jnp.ones_like(x2))
+dW1, dx0 = bwd(res1, dx1)
+```
+
+That computes the same gradients that an end-to-end `jax.grad` would:
+
+```{code-cell}
+def two_layers(W1, W2, x):
+  return jnp.sum(layer(W2, layer(W1, x)))
+
+dW1_ref, dW2_ref = grad(two_layers, argnums=(0, 1))(W1, W2, x0)
+print(jnp.allclose(dW1, dW1_ref), jnp.allclose(dW2, dW2_ref))
+```
+
+JAX also provides this pattern prepackaged as `jax.fwd_and_bwd`, with an
+`argnums` argument selecting which inputs to produce cotangents for:
+
+```{code-cell}
+fwd, bwd = jax.fwd_and_bwd(layer, argnums=(0, 1))
+
+y, residuals = fwd(W1, x0)
+dW1, dx0 = bwd(residuals, jnp.ones_like(y))
+print(dW1.shape, dx0.shape)
+```
+
+## What the VJP object saves
+
+The VJP object exposes its saved state in two attributes: `args_res` holds
+argument values that the backward pass needs *verbatim*, arranged to mirror
+the arguments, and `opaque_residuals` holds values computed during the
+forward pass. For `layer`, the backward pass of `x @ W` needs both `x` and
+`W` as they were:
+
+```{code-cell}
+y, f_vjp = jax.vjp(layer, W1, x0)
+print(f_vjp.args_res)
+```
+
+(An argument the backward pass doesn't need would appear as a `NotNeeded()`
+sentinel instead.)
+
+So every VJP object in the pipeline example above carries a full copy of its
+layer's weights. If we're running many microbatches through the same layer
+before applying their backward passes — or serializing or offloading each
+VJP object — every one of them duplicates the weights, which are typically
+the biggest thing in the saved state and which we already have. Only the
+activations vary per microbatch.
+
+## Marking arguments not saveable: `saveable_args`
+
+The `saveable_args` argument to `jax.vjp` is a tuple-tree of bools (nested
+tuples with bool leaves), one entry per argument, defaulting to the single
+bool `True` — everything saveable, the usual behavior. Where a `False`
+applies, argument values that would have been saved verbatim are instead
+replaced with `NotSaveable()` sentinels:
+
+```{code-cell}
+y, f_vjp = jax.vjp(layer, W1, x0, saveable_args=(False, True))
+print(f_vjp.args_res)
+```
+
+`NotSaveable` is an empty pytree node, so flattening the VJP object — to
+serialize or offload it — includes no leaves for those arguments:
+
+```{code-cell}
+print(len(jax.tree.leaves(f_vjp)))  # 3, not 4: W1 isn't part of the saved state
+```
+
+## Restoring before the backward pass
+
+Before the VJP function can be applied, the missing values must be restored.
+Forgetting is an error that names the arguments still needing restoration:
+
+```{code-cell}
+try:
+  f_vjp(jnp.ones_like(y))
+except ValueError as e:
+  print(e)
+```
+
+Restore by assigning into `args_res`, or more functionally with `replace`:
+
+```{code-cell}
+f_vjp.args_res[0] = W1
+# or: f_vjp = f_vjp.replace(args_res=[W1, f_vjp.args_res[1]])
+dW1, dx0 = f_vjp(jnp.ones_like(y))
+print(dW1.shape, dx0.shape)
+```
+
+Here's the pipeline example again, with the weights left out of the saved
+state and instead passed to the backward function directly:
+
+```{code-cell}
+def fwd_light(W, x):
+  return jax.vjp(layer, W, x, saveable_args=(False, True))
+
+def bwd_light(f_vjp, W, y_bar):
+  f_vjp.args_res[0] = W
+  return f_vjp(y_bar)
+
+fwd_light, bwd_light = jit(fwd_light), jit(bwd_light)
+
+x1, res1 = fwd_light(W1, x0)
+x2, res2 = fwd_light(W2, x1)
+dW2, dx1 = bwd_light(res2, W2, jnp.ones_like(x2))
+dW1, dx0 = bwd_light(res1, W1, dx1)
+print(jnp.allclose(dW1, dW1_ref), jnp.allclose(dW2, dW2_ref))
+```
+
+## The fine print
+
+`saveable_args` must form a tree prefix of the arguments, in a loose sense:
+containers are matched only by their number of children, so a tuple entry
+can line up with a dict argument, and a single bool broadcasts over a whole
+argument subtree (that's how the default `True` covers everything). When
+restoring, you can assign values with the original pytree structure:
+
+```{code-cell}
+def g(d):
+  return d['bye'] @ d['hi']
+
+d = {'hi': jnp.ones((4, 5)), 'bye': jnp.ones((3, 4))}
+_, g_vjp = jax.vjp(g, d, saveable_args=((True, False),))
+g_vjp.args_res = [d]  # restore with the original dict
+d_grad, = g_vjp(jnp.ones((3, 5)))
+print(jax.tree.map(jnp.shape, d_grad))
+```
+
+Two more details worth knowing:
+
+- Only argument values saved *verbatim* are affected. Residuals *computed*
+  from arguments are saved in `opaque_residuals` as usual — `saveable_args`
+  never causes recomputation. For the save-versus-recompute tradeoff, see
+  {doc}`remat`.
+- Arguments the backward pass doesn't need stay `NotNeeded()` even when
+  marked `False`, so `args_res` shows exactly which values must be restored.


### PR DESCRIPTION
Add docs/new_docs/301/vjp-objects.md ("First-class VJPs"), covering the VJP object returned by jax.vjp as a first-class value:

* splitting the forward and backward passes into separately compiled functions run on a schedule of your own, including jax.fwd_and_bwd (this section moved here from the cookbook, since it's part of the same story);
* the VJP object's saved state: args_res (argument values the backward pass needs verbatim, mirroring the arguments, with NotNeeded sentinels for unused arguments) versus opaque_residuals (values computed on the forward pass);
* the new saveable_args option to jax.vjp: marking arguments not-saveable, the NotSaveable sentinels as empty pytree nodes excluded from flattening, restoring values via args_res assignment or .replace before applying, and the error naming the arguments still missing if you forget;
* the fine print: saveable_args is a tuple-tree of bools forming a loose tree prefix of the arguments (containers matched only by their number of children, bools broadcasting over subtrees), only verbatim-saved argument values are affected (computed residuals are saved as usual; saveable_args never causes recomputation -- that tradeoff is remat's), and unneeded arguments stay NotNeeded even when marked False.

Every code cell of the new page and the cookbook executes cleanly in order.

Also:

* retitle the cookbook to "The Autodiff Cookbook with JVP and VJP" to emphasize what that page is about, and end its jvp/vjp material with a pointer to the new page;
* update the 301 index: add the new page as entry 2, and rewrite the cookbook entry description to match the new title and contents.