### PR TITLE
[ROCm] [pallas:triton] Use a gfx abstract device_kind directly as the arch

### DIFF
--- a/jax/_src/pallas/triton/gpu_info.py
+++ b/jax/_src/pallas/triton/gpu_info.py
@@ -182,9 +182,13 @@ def get_gpu_info_from_version(
 def get_device_kind() -> str:
   device = pxla.get_default_device()
   abstract_device = mesh_lib.get_abstract_mesh().abstract_device
-  if (abstract_device is not None
-      and abstract_device.device_kind != device.device_kind):
-    return abstract_device.device_kind
+  if abstract_device is not None:
+    if abstract_device.device_kind.startswith("gfx"):
+      return abstract_device.device_kind
+    # A kind that differs from the concrete device is a deliberate AOT target;
+    # if it matches, the abstract mesh just mirrors the local device.
+    if abstract_device.device_kind != device.device_kind:
+      return abstract_device.device_kind
   cc = getattr(device, "compute_capability", None)
   if isinstance(cc, str) and cc.startswith("gfx"):
     return cc


### PR DESCRIPTION
## What
Honor a `gfx*` abstract-mesh `device_kind` directly as the Triton arch in
`get_gpu_info()`, independent of the concrete device.

## Why
`get_device_kind()` only returned the abstract `device_kind` when it differed from
the concrete device's. 
On ROCm gfx950 runners (with empty marketing name) the concrete
`device_kind` is the raw ISA `gfx950:sramecc+:xnack-`, so an abstract device set to
that same ISA collided and was dropped in favor of `compute_capability` (`gfx950`) 
causing the intermittent `triton_gpu_info` arch test failure. 

I setup small interposer to simulate missing marketing name scenario which we see in XLA infra node verified test working.
```@bash
[       OK ] GpuInfoTest.test_gfx_device_kind_used_as_arch2 ('gfx950:sramecc+:xnack-')
Ran 21 tests in 1.802s
OK (skipped=1)
```