### PR TITLE
Fix betaln returning nan for infinite arguments

### DIFF
--- a/jax/_src/third_party/scipy/betaln.py
+++ b/jax/_src/third_party/scipy/betaln.py
@@ -60,4 +60,7 @@ def betaln(a: ArrayLike, b: ArrayLike) -> Array:
     a, b = jnp.minimum(a, b), jnp.maximum(a, b)
     small_b = lax.lgamma(a) + (lax.lgamma(b) - lax.lgamma(a + b))
     large_b = lax.lgamma(a) + algdiv(a, b)
-    return jnp.where(b < 8, small_b, large_b)
+    result = jnp.where(b < 8, small_b, large_b)
+    # B(a, inf) -> 0 for finite a > 0, so betaln(a, inf) -> -inf. The lgamma/algdiv
+    # path returns nan for an infinite argument; b is max(a, b) after the swap above.
+    return jnp.where(jnp.isinf(b) & jnp.isfinite(a) & (a > 0), -jnp.inf, result)

--- a/tests/lax_scipy_special_functions_test.py
+++ b/tests/lax_scipy_special_functions_test.py
@@ -262,6 +262,16 @@ class LaxScipySpecialFunctionsTest(jtu.JaxTestCase):
       scipy_val = osp_special.erfcx(x)
       self.assertAllClose(jax_val, scipy_val, rtol=1e-12)
 
+  def testBetalnInfiniteArgs(self):
+    # https://github.com/jax-ml/jax/issues/39106: betaln(a, inf) for finite a > 0
+    # tends to -inf (B(a, inf) -> 0). The lgamma/algdiv path returned nan instead.
+    a = np.array([2., 0.5, 10.], dtype=np.float32)
+    inf = np.full_like(a, np.inf)
+    self.assertAllClose(
+        lsp_special.betaln(a, inf), osp_special.betaln(a, inf).astype(np.float32))
+    self.assertAllClose(
+        lsp_special.betaln(inf, a), osp_special.betaln(inf, a).astype(np.float32))
+
   def testWofzAccuracy(self):
     # Verify wofz agrees with scipy over the full complex plane (float32).
     rng = jtu.rand_default(np.random.RandomState(0))


### PR DESCRIPTION
Fixes #39106.

## Problem
`jax.scipy.special.betaln(a, b)` returns `nan` for an infinite argument where a finite limit exists:

```python
>>> from jax.scipy.special import betaln
>>> betaln(jnp.inf, 2.0), betaln(2.0, jnp.inf)
(nan, nan)   # SciPy: (-inf, -inf)
```

For finite `a > 0`, `B(a, inf) -> 0`, so `betaln(a, inf) -> -inf`. The implementation (`jax/_src/third_party/scipy/betaln.py`) computes the result through `lgamma` and `algdiv`, both of which yield `nan` at an infinite argument. `betaln(inf, inf)` already matches SciPy at `nan`.

## Fix
After the `min/max` swap, `b` is the larger argument. Guard the result so that when `b` is `+inf` and `a` is finite and positive, it returns `-inf`. Finite inputs are unchanged (verified against SciPy across normal and large-argument values).

## Test
```
JAX_ENABLE_X64=1 python -m pytest tests/lax_scipy_special_functions_test.py -k testBetalnInfiniteArgs
```