### PR TITLE
Improve pytree prefix mismatch errors involving None specs and dummy …

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -358,7 +358,9 @@ def flatten_axes(name, treedef, axis_tree, *, kws=False, tupled_args=False):
                    f"means that {name} might need to be wrapped in "
                    f"a singleton tuple.")
     dummy_tree = tree_unflatten(treedef, [PytreeLeaf()] * treedef.num_leaves)
-    errors = prefix_errors(axis_tree, dummy_tree)
+    # None is a valid leaf of axis_tree (we flattened it with
+    # none_leaf_registry above), so the error scan must treat it as one too.
+    errors = prefix_errors(axis_tree, dummy_tree, is_leaf=lambda x: x is None)
     if errors:
       details = "\n  ".join(e(name).args[0] for e in errors)
       prefix_err_msg = (
@@ -422,7 +424,9 @@ def flatten_axis_resources(what, tree, shardings, tupled_args):
   # Because we only have the `tree` treedef and not the full pytree here,
   # we construct a dummy tree to compare against. Revise this in callers?
   dummy_tree = tree_unflatten(tree, [PytreeLeaf()] * tree.num_leaves)
-  errors = prefix_errors(axis_tree, dummy_tree)
+  # None is a valid leaf of axis_tree (flatten_axes broadcasts it with
+  # none_leaf_registry), so the error scan must treat it as one too.
+  errors = prefix_errors(axis_tree, dummy_tree, is_leaf=lambda x: x is None)
   if errors:
     details = "\n".join(e(what).args[0] for e in errors)
     raise ValueError(

--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -405,7 +405,9 @@ def flatten_axes(name, treedef, axis_tree, *, kws=False, tupled_args=False):
                    f"means that {name} might need to be wrapped in "
                    f"a singleton tuple.")
     dummy_tree = tree_unflatten(treedef, [PytreeLeaf()] * treedef.num_leaves)
-    errors = prefix_errors(axis_tree, dummy_tree)
+    # None is a valid leaf of axis_tree (we flattened it with
+    # none_leaf_registry above), so the error scan must treat it as one too.
+    errors = prefix_errors(axis_tree, dummy_tree, is_leaf=lambda x: x is None)
     if errors:
       details = "\n  ".join(e(name).args[0] for e in errors)
       prefix_err_msg = (
@@ -469,7 +471,9 @@ def flatten_axis_resources(what, tree, shardings, tupled_args):
   # Because we only have the `tree` treedef and not the full pytree here,
   # we construct a dummy tree to compare against. Revise this in callers?
   dummy_tree = tree_unflatten(tree, [PytreeLeaf()] * tree.num_leaves)
-  errors = prefix_errors(axis_tree, dummy_tree)
+  # None is a valid leaf of axis_tree (flatten_axes broadcasts it with
+  # none_leaf_registry), so the error scan must treat it as one too.
+  errors = prefix_errors(axis_tree, dummy_tree, is_leaf=lambda x: x is None)
   if errors:
     details = "\n".join(e(what).args[0] for e in errors)
     raise ValueError(

--- a/jax/_src/pmap.py
+++ b/jax/_src/pmap.py
@@ -623,7 +623,7 @@ def _get_in_axes_flat(
       # None is a valid in_axes leaf (the broadcast above treats it as one),
       # so the error scan must treat it as one too.
       e, *_ = prefix_errors((dyn_in_axes, 0), (dyn_args, kwargs),
-                            is_leaf=lambda x: x is None)
+                            is_leaf=lambda x: x is None or x is _UNMAPPED_PMAxis)
       ex = e("pmap in_axes")
       (msg,) = ex.args
       msg += (

--- a/jax/_src/pmap.py
+++ b/jax/_src/pmap.py
@@ -620,7 +620,10 @@ def _get_in_axes_flat(
           )
       )
     except ValueError:
-      e, *_ = prefix_errors((dyn_in_axes, 0), (dyn_args, kwargs))
+      # None is a valid in_axes leaf (the broadcast above treats it as one),
+      # so the error scan must treat it as one too.
+      e, *_ = prefix_errors((dyn_in_axes, 0), (dyn_args, kwargs),
+                            is_leaf=lambda x: x is None)
       ex = e("pmap in_axes")
       (msg,) = ex.args
       msg += (

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -263,7 +263,9 @@ def _shard_map(f: F, *, mesh: Mesh | AbstractMesh | None,
       in_specs_flat = broadcast_prefix(
           in_specs, args, is_leaf=lambda x: x is None)
     except ValueError:
-      e, *_ = prefix_errors(in_specs, args)
+      # None is a valid in_specs leaf (the broadcast above treats it as one),
+      # so the error scan must treat it as one too.
+      e, *_ = prefix_errors(in_specs, args, is_leaf=lambda x: x is None)
       raise e('shard_map in_specs') from None
 
     if (in_specs is Infer and

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -268,7 +268,9 @@ def _shard_map[F: Callable](
       in_specs_flat = broadcast_prefix(
           in_specs, args, is_leaf=lambda x: x is None)
     except ValueError:
-      e, *_ = prefix_errors(in_specs, args)
+      # None is a valid in_specs leaf (the broadcast above treats it as one),
+      # so the error scan must treat it as one too.
+      e, *_ = prefix_errors(in_specs, args, is_leaf=lambda x: x is None)
       raise e('shard_map in_specs') from None
 
     if (in_specs is Infer and

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -618,7 +618,7 @@ def broadcast_prefix(prefix_tree: Any, full_tree: Any,
   try:
     tree_map(add_leaves, prefix_tree, full_tree, is_leaf=is_leaf)
   except ValueError:
-      e, *_ = prefix_errors(prefix_tree, full_tree)
+      e, *_ = prefix_errors(prefix_tree, full_tree, is_leaf=is_leaf)
       raise e('broadcast_prefix prefix_tree') from None
   return result
 
@@ -1286,13 +1286,25 @@ def _prefix_error(
 
   # The subtrees may disagree because their roots are of different types:
   if type(prefix_tree) != type(full_tree):
+    if prefix_tree is None:
+      prefix_desc = ("None, which is treated as a pytree container "
+                     "with no leaves,\n")
+    else:
+      prefix_desc = f"a subtree of type\n    {type(prefix_tree)}\n"
+    if full_tree is None:
+      full_desc = ("None, which is treated as a pytree container "
+                   "with no leaves.")
+    elif treedef_is_strict_leaf(tree_structure(full_tree, is_leaf=is_leaf)):
+      # Don't print the leaf's type: callers like api_util.flatten_axes only
+      # have a treedef for the full tree, so its leaves are dummy objects.
+      full_desc = "a leaf."
+    else:
+      full_desc = f"a subtree of different type\n    {type(full_tree)}."
     yield lambda name: ValueError(
       "pytree structure error: different types at key path\n"
       f"    {name}{keystr(key_path)}\n"
-      f"At that key path, the prefix pytree {name} has a subtree of type\n"
-      f"    {type(prefix_tree)}\n"
-      f"but at the same key path the full pytree has a subtree of different type\n"
-      f"    {type(full_tree)}.")
+      f"At that key path, the prefix pytree {name} has {prefix_desc}"
+      f"but at the same key path the full pytree has {full_desc}")
     return  # don't look for more errors in this subtree
 
   # Or they may disagree if their roots have different numbers or keys of
@@ -1368,7 +1380,7 @@ def _prefix_error(
     ("equal pytree nodes gave differing prefix_tree_keys: "
      f"{prefix_tree_keys} and {full_tree_keys}")
   for k, t1, t2 in zip(prefix_tree_keys, prefix_tree_children, full_tree_children):
-    yield from _prefix_error((*key_path, k), t1, t2)
+    yield from _prefix_error((*key_path, k), t1, t2, is_leaf)
 
 def _ensure_inbounds(allow_invalid: bool, num_args: int, argnums: Sequence[int]
                      ) -> tuple[int, ...]:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3393,6 +3393,18 @@ class APITest(jtu.JaxTestCase):
         lambda: api.vmap(lambda x: x, in_axes=([0],))(value_tree)
     )
 
+  def test_vmap_in_axes_tree_prefix_error_with_none(self):
+    # A valid None entry in in_axes must not be reported as a mismatch, and
+    # the message must not leak internal dummy leaf types.
+    # https://github.com/jax-ml/jax/issues/13074
+    x = jnp.ones(3)
+    with self.assertRaises(ValueError) as cm:
+      api.vmap(lambda a, b: (a, b), in_axes=(None, (0, 0, 0)))(x, (x, x))
+    msg = str(cm.exception)
+    self.assertIn("Mismatch details (1 found)", msg)
+    self.assertNotIn("PytreeLeaf", msg)
+    self.assertNotIn("NoneType", msg)
+
   def test_vmap_in_axes_leaf_types(self):
     with self.assertRaisesRegex(
         TypeError, r"vmap in_axes must be an int, None, or .*"):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3478,6 +3478,18 @@ class APITest(jtu.JaxTestCase):
         lambda: api.vmap(lambda x: x, in_axes=([0],))(value_tree)
     )
 
+  def test_vmap_in_axes_tree_prefix_error_with_none(self):
+    # A valid None entry in in_axes must not be reported as a mismatch, and
+    # the message must not leak internal dummy leaf types.
+    # https://github.com/jax-ml/jax/issues/13074
+    x = jnp.ones(3)
+    with self.assertRaises(ValueError) as cm:
+      api.vmap(lambda a, b: (a, b), in_axes=(None, (0, 0, 0)))(x, (x, x))
+    msg = str(cm.exception)
+    self.assertIn("Mismatch details (1 found)", msg)
+    self.assertNotIn("PytreeLeaf", msg)
+    self.assertNotIn("NoneType", msg)
+
   def test_vmap_in_axes_leaf_types(self):
     with self.assertRaisesRegex(
         TypeError, r"vmap in_axes must be an int, None, or .*"):

--- a/tests/api_util_test.py
+++ b/tests/api_util_test.py
@@ -124,6 +124,39 @@ class ApiUtilTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, r"Mismatch details \(2 found\)"):
       api_util.flatten_axis_resources("test_spec", tree, shardings, False)
 
+  def test_flatten_axes_error_mentions_leaf_not_dummy_type(self):
+    # https://github.com/jax-ml/jax/issues/13074
+    treedef = jax.tree.structure({"a": 1})
+    spec = {"a": (0, 1)}
+    with self.assertRaises(ValueError) as cm:
+      api_util.flatten_axes("test_spec", treedef, spec)
+    self.assertNotIn("PytreeLeaf", str(cm.exception))
+    self.assertIn("the full pytree has a leaf", str(cm.exception))
+
+  def test_flatten_axes_valid_none_spec_not_reported(self):
+    # None is a valid spec leaf, so it must not be reported as a mismatch.
+    # https://github.com/jax-ml/jax/issues/13074
+    treedef = jax.tree.structure({"a": 1, "b": 2})
+    spec = {"a": None, "b": (0, 1)}
+    with self.assertRaisesRegex(ValueError, r"Mismatch details \(1 found\)"):
+      api_util.flatten_axes("test_spec", treedef, spec)
+
+  def test_flatten_axis_resources_error_mentions_leaf_not_dummy_type(self):
+    # https://github.com/jax-ml/jax/issues/13074
+    tree = jax.tree.structure({"a": 1})
+    shardings = {"a": (None, None)}
+    with self.assertRaises(ValueError) as cm:
+      api_util.flatten_axis_resources("test_spec", tree, shardings, False)
+    self.assertNotIn("PytreeLeaf", str(cm.exception))
+    self.assertIn("the full pytree has a leaf", str(cm.exception))
+
+  def test_flatten_axis_resources_valid_none_spec_not_reported(self):
+    # https://github.com/jax-ml/jax/issues/13074
+    tree = jax.tree.structure({"a": 1, "b": 2})
+    shardings = {"a": None, "b": (None, None)}
+    with self.assertRaisesRegex(ValueError, r"Mismatch details \(1 found\)"):
+      api_util.flatten_axis_resources("test_spec", tree, shardings, False)
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/api_util_test.py
+++ b/tests/api_util_test.py
@@ -146,6 +146,39 @@ class ApiUtilTest(jtu.JaxTestCase):
     self.assertNotEqual(partial(g).func, g.func)
     self.assertRegex(fsi(partial(g)), expected)
 
+  def test_flatten_axes_error_mentions_leaf_not_dummy_type(self):
+    # https://github.com/jax-ml/jax/issues/13074
+    treedef = jax.tree.structure({"a": 1})
+    spec = {"a": (0, 1)}
+    with self.assertRaises(ValueError) as cm:
+      api_util.flatten_axes("test_spec", treedef, spec)
+    self.assertNotIn("PytreeLeaf", str(cm.exception))
+    self.assertIn("the full pytree has a leaf", str(cm.exception))
+
+  def test_flatten_axes_valid_none_spec_not_reported(self):
+    # None is a valid spec leaf, so it must not be reported as a mismatch.
+    # https://github.com/jax-ml/jax/issues/13074
+    treedef = jax.tree.structure({"a": 1, "b": 2})
+    spec = {"a": None, "b": (0, 1)}
+    with self.assertRaisesRegex(ValueError, r"Mismatch details \(1 found\)"):
+      api_util.flatten_axes("test_spec", treedef, spec)
+
+  def test_flatten_axis_resources_error_mentions_leaf_not_dummy_type(self):
+    # https://github.com/jax-ml/jax/issues/13074
+    tree = jax.tree.structure({"a": 1})
+    shardings = {"a": (None, None)}
+    with self.assertRaises(ValueError) as cm:
+      api_util.flatten_axis_resources("test_spec", tree, shardings, False)
+    self.assertNotIn("PytreeLeaf", str(cm.exception))
+    self.assertIn("the full pytree has a leaf", str(cm.exception))
+
+  def test_flatten_axis_resources_valid_none_spec_not_reported(self):
+    # https://github.com/jax-ml/jax/issues/13074
+    tree = jax.tree.structure({"a": 1, "b": 2})
+    shardings = {"a": None, "b": (None, None)}
+    with self.assertRaisesRegex(ValueError, r"Mismatch details \(1 found\)"):
+      api_util.flatten_axis_resources("test_spec", tree, shardings, False)
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -612,6 +612,14 @@ class PythonPmapTest(jtu.JaxTestCase):
         ValueError, re.escape("each argument passed by keyword is mapped")):
       f(x=(x, x), y=x)
 
+  def testInAxesPyTreePrefixMismatchErrorWithNone(self):
+    # A valid None entry in in_axes must not be reported as the mismatch.
+    # https://github.com/jax-ml/jax/issues/13074
+    x = jnp.array([3.14])
+    f = pmap(lambda x, y: x, in_axes=(None, (0, 0, 0)))
+    with self.assertRaisesRegex(ValueError, re.escape("pmap in_axes[0][1]")):
+      f(x, (x, x))
+
   def testOutAxesPyTreePrefixMismatchError(self):
     x = jnp.array([3.14])
     f = jax.pmap(lambda x, y: ((x, x), x), out_axes=((0, 0, 0), 0))

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -981,6 +981,20 @@ class ShardMapTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, r'shard_map in_specs\[0\]'):
       f([x, x])
 
+  def test_tree_prefix_error_with_none(self):
+    # A valid None entry in in_specs must not be reported as the mismatch.
+    # https://github.com/jax-ml/jax/issues/13074
+    mesh = jtu.create_mesh((2, 2), ('x', 'y'))
+
+    @partial(shard_map, mesh=mesh,
+             in_specs=(None, (P('x'), P('x'), P('x'))), out_specs=P('x'))
+    def f(x, ys):
+      return x
+
+    x = jnp.arange(8.).reshape(4, 2)
+    with self.assertRaisesRegex(ValueError, r'shard_map in_specs\[1\]'):
+      f(x, (x, x))
+
   def test_rank_errors(self):
     mesh = jtu.create_mesh((2, 2), ('x', 'y'))
 

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -980,6 +980,20 @@ class ShardMapTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, r'shard_map in_specs\[0\]'):
       f([x, x])
 
+  def test_tree_prefix_error_with_none(self):
+    # A valid None entry in in_specs must not be reported as the mismatch.
+    # https://github.com/jax-ml/jax/issues/13074
+    mesh = jtu.create_mesh((2, 2), ('x', 'y'))
+
+    @partial(shard_map, mesh=mesh,
+             in_specs=(None, (P('x'), P('x'), P('x'))), out_specs=P('x'))
+    def f(x, ys):
+      return x
+
+    x = jnp.arange(8.).reshape(4, 2)
+    with self.assertRaisesRegex(ValueError, r'shard_map in_specs\[1\]'):
+      f(x, (x, x))
+
   def test_rank_errors(self):
     mesh = jtu.create_mesh((2, 2), ('x', 'y'))
 

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -1524,6 +1524,42 @@ class TreePrefixErrorsTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, expected):
       raise e('in_axes')
 
+  def test_different_types_full_tree_leaf(self):
+    # The full tree may be a dummy tree whose leaves are internal sentinel
+    # objects, so the message must not mention the leaf's type.
+    # https://github.com/jax-ml/jax/issues/13074
+    e, = prefix_errors({'a': 1}, 7)
+    expected = (r"(?s)pytree structure error: different types at key path.*"
+                r"but at the same key path the full pytree has a leaf\.")
+    with self.assertRaisesRegex(ValueError, expected):
+      raise e('in_axes')
+
+  def test_different_types_full_tree_none(self):
+    # https://github.com/jax-ml/jax/issues/13074
+    e, = prefix_errors((1, 2), None)
+    expected = (r"(?s)pytree structure error: different types at key path.*"
+                r"but at the same key path the full pytree has None, which is "
+                r"treated as a pytree container with no leaves\.")
+    with self.assertRaisesRegex(ValueError, expected):
+      raise e('in_axes')
+
+  def test_different_types_prefix_none(self):
+    # https://github.com/jax-ml/jax/issues/13074
+    e, = prefix_errors(None, 7)
+    expected = (r"(?s)pytree structure error: different types at key path.*"
+                r"prefix pytree in_axes has None, which is treated as a "
+                r"pytree container with no leaves,")
+    with self.assertRaisesRegex(ValueError, expected):
+      raise e('in_axes')
+
+  def test_none_is_leaf_nested_valid_prefix(self):
+    # is_leaf must apply below the root too: it used to be dropped on
+    # recursion, so the nested None was falsely reported as a mismatch.
+    # https://github.com/jax-ml/jax/issues/13074
+    errors = prefix_errors((None, (1, 2)), ((3, 4), (5, 6)),
+                           is_leaf=lambda x: x is None)
+    self.assertEqual(errors, [])
+
 
 class TreeAliasTest(jtu.JaxTestCase):
   """Simple smoke-tests for tree_util aliases under jax.tree"""

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -1564,6 +1564,42 @@ class TreePrefixErrorsTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, expected):
       raise e('in_axes')
 
+  def test_different_types_full_tree_leaf(self):
+    # The full tree may be a dummy tree whose leaves are internal sentinel
+    # objects, so the message must not mention the leaf's type.
+    # https://github.com/jax-ml/jax/issues/13074
+    e, = prefix_errors({'a': 1}, 7)
+    expected = (r"(?s)pytree structure error: different types at key path.*"
+                r"but at the same key path the full pytree has a leaf\.")
+    with self.assertRaisesRegex(ValueError, expected):
+      raise e('in_axes')
+
+  def test_different_types_full_tree_none(self):
+    # https://github.com/jax-ml/jax/issues/13074
+    e, = prefix_errors((1, 2), None)
+    expected = (r"(?s)pytree structure error: different types at key path.*"
+                r"but at the same key path the full pytree has None, which is "
+                r"treated as a pytree container with no leaves\.")
+    with self.assertRaisesRegex(ValueError, expected):
+      raise e('in_axes')
+
+  def test_different_types_prefix_none(self):
+    # https://github.com/jax-ml/jax/issues/13074
+    e, = prefix_errors(None, 7)
+    expected = (r"(?s)pytree structure error: different types at key path.*"
+                r"prefix pytree in_axes has None, which is treated as a "
+                r"pytree container with no leaves,")
+    with self.assertRaisesRegex(ValueError, expected):
+      raise e('in_axes')
+
+  def test_none_is_leaf_nested_valid_prefix(self):
+    # is_leaf must apply below the root too: it used to be dropped on
+    # recursion, so the nested None was falsely reported as a mismatch.
+    # https://github.com/jax-ml/jax/issues/13074
+    errors = prefix_errors((None, (1, 2)), ((3, 4), (5, 6)),
+                           is_leaf=lambda x: x is None)
+    self.assertEqual(errors, [])
+
 
 class TreeAliasTest(jtu.JaxTestCase):
   """Simple smoke-tests for tree_util aliases under jax.tree"""


### PR DESCRIPTION
…leaves

When an in_shardings/in_axes/in_specs spec is not a pytree prefix of the arguments, the error scan ran with different leaf semantics than the broadcast it explains: None (a valid "unspecified" spec leaf) was reported as a mismatching container, and _prefix_error dropped is_leaf on recursion. In pmap and shard_map the false report could hide the genuine mismatch. The messages also leaked the internal dummy-leaf type "<class 'jax._src.api_util.PytreeLeaf'>".

Pass is_leaf=lambda x: x is None to prefix_errors wherever the broadcast treats None as a leaf, propagate is_leaf through _prefix_error's recursion, and reword the "different types" message: a full-tree leaf is described as "a leaf" (never its possibly-dummy type) and None as "a pytree container with no leaves".

Fixes #13074

