### PR TITLE
Raise OverflowError instead of silently truncating 64-bit NumPy integer inputs when x64 is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     {func}`jax.jit`.
 
 * Breaking changes
+  * When `jax_enable_x64` is disabled (the default), a NumPy int64 or
+    uint64 array or scalar whose values do not fit in 32 bits now raises an
+    `OverflowError` instead of silently wrapping the values around
+    ({jax-issue}`#18385`). This matches the existing behavior for out-of-range
+    Python ints, and applies wherever such values enter JAX: function
+    arguments, `jax.numpy.asarray`, `jax.device_put`, NumPy constants closed
+    over by traced functions, and callback results. Requires a matching
+    jaxlib.
   * The deprecated module jax.cloud_tpu_init was removed. This did nothing and
     references to it can be safely removed.
   * Support for Python 3.11, NumPy 2.0, and SciPy 1.14 has been dropped, per the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,14 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     {func}`jax.jit`.
 
 * Breaking changes
+  * When `jax_enable_x64` is disabled (the default), a NumPy int64 or
+    uint64 array or scalar whose values do not fit in 32 bits now raises an
+    `OverflowError` instead of silently wrapping the values around
+    ({jax-issue}`#18385`). This matches the existing behavior for out-of-range
+    Python ints, and applies wherever such values enter JAX: function
+    arguments, `jax.numpy.asarray`, `jax.device_put`, NumPy constants closed
+    over by traced functions, and callback results. Requires a matching
+    jaxlib.
   * The deprecated module jax.cloud_tpu_init was removed. This did nothing and
     references to it can be safely removed.
   * Support for Python 3.11, NumPy 2.0, and SciPy 1.14 has been dropped, per the

--- a/jaxlib/py_values.cc
+++ b/jaxlib/py_values.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include <cstdint>
 #include <exception>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -447,6 +448,76 @@ absl::StatusOr<ShardFn> HandlePythonInt(nb::handle obj, ifrt::Client* client,
   };
 }
 
+// When jax_enable_x64 is disabled, 64-bit integer inputs are converted to
+// 32-bit ones. Out-of-range values would wrap around silently, so we raise
+// OverflowError instead, mirroring the treatment of out-of-range Python ints.
+// See https://github.com/jax-ml/jax/issues/18385.
+[[noreturn]] void ThrowIntegerDowncastOverflow(nb::handle bad_value,
+                                               bool is_signed) {
+  PyErr_Format(PyExc_OverflowError,
+               "NumPy %s value %S too large in magnitude to convert to %s. "
+               "Enable the jax_enable_x64 configuration option to allow "
+               "64-bit values.",
+               is_signed ? "int64" : "uint64", bad_value.ptr(),
+               is_signed ? "int32" : "uint32");
+  throw nb::python_error();
+}
+
+// Checks that a 64-bit integer ndarray that is about to be cast to the 32-bit
+// integer type `target_type_num` contains only values representable in 32
+// bits. Casts between other types are ignored. The array is about to be cast
+// and copied anyway, so the extra pass to compute its min/max is
+// proportionally cheap.
+void CheckIntegerArrayFitsIn32Bits(nb::handle array_h, int target_type_num) {
+  PyArrayObject* array = reinterpret_cast<PyArrayObject*>(array_h.ptr());
+  bool is_signed;
+  if (PyArray_EquivTypenums(PyArray_TYPE(array), NPY_INT64) &&
+      PyArray_EquivTypenums(target_type_num, NPY_INT32)) {
+    is_signed = true;
+  } else if (PyArray_EquivTypenums(PyArray_TYPE(array), NPY_UINT64) &&
+             PyArray_EquivTypenums(target_type_num, NPY_UINT32)) {
+    is_signed = false;
+  } else {
+    return;
+  }
+  if (PyArray_SIZE(array) == 0) {
+    return;
+  }
+  auto as_index = [](const nb::object& value) -> nb::object {
+    nb::object result = nb::steal(PyNumber_Index(value.ptr()));
+    if (!result.ptr()) {
+      throw nb::python_error();
+    }
+    return result;
+  };
+  nb::object max = array_h.attr("max")();
+  if (is_signed) {
+    int64_t hi = PyLong_AsLongLong(as_index(max).ptr());
+    if (hi == -1 && PyErr_Occurred()) {
+      throw nb::python_error();
+    }
+    if (hi > std::numeric_limits<int32_t>::max()) {
+      ThrowIntegerDowncastOverflow(max, is_signed);
+    }
+    nb::object min = array_h.attr("min")();
+    int64_t lo = PyLong_AsLongLong(as_index(min).ptr());
+    if (lo == -1 && PyErr_Occurred()) {
+      throw nb::python_error();
+    }
+    if (lo < std::numeric_limits<int32_t>::min()) {
+      ThrowIntegerDowncastOverflow(min, is_signed);
+    }
+  } else {
+    uint64_t hi = PyLong_AsUnsignedLongLong(as_index(max).ptr());
+    if (hi == static_cast<uint64_t>(-1) && PyErr_Occurred()) {
+      throw nb::python_error();
+    }
+    if (hi > std::numeric_limits<uint32_t>::max()) {
+      ThrowIntegerDowncastOverflow(max, is_signed);
+    }
+  }
+}
+
 template <typename T, typename SquashedT = T>
 absl::StatusOr<ShardFn> HandleNumpyScalar(nb::handle h, ifrt::Client* client,
                                           ifrt::Device* to_device,
@@ -515,6 +586,18 @@ absl::StatusOr<ShardFn> HandleNumpyScalar(nb::handle h, ifrt::Client* client,
   } else {
     T value;
     PyArray_ScalarAsCtype(h.ptr(), &value);
+    if constexpr (std::is_integral_v<T> && !std::is_same_v<T, SquashedT>) {
+      bool fits;
+      if constexpr (std::is_signed_v<T>) {
+        fits = value >= std::numeric_limits<SquashedT>::min() &&
+               value <= std::numeric_limits<SquashedT>::max();
+      } else {
+        fits = value <= std::numeric_limits<SquashedT>::max();
+      }
+      if (!fits) {
+        ThrowIntegerDowncastOverflow(h, std::is_signed_v<T>);
+      }
+    }
     data.template emplace<1>(static_cast<SquashedT>(value));
     type = xla::primitive_util::NativeToPrimitiveType<SquashedT>();
   }
@@ -602,6 +685,9 @@ absl::StatusOr<ShardFn> HandleNumpyArray(nb::handle h, ifrt::Client* client,
     if (squashed_type != type) {
       TF_ASSIGN_OR_RETURN(xla::nb_dtype squashed_dtype,
                           PrimitiveTypeToNbDtype(squashed_type));
+      CheckIntegerArrayFitsIn32Bits(
+          array,
+          reinterpret_cast<PyArray_Descr*>(squashed_dtype.ptr())->type_num);
       array = nb::steal<xla::nb_numpy_ndarray>(PyArray_CastToType(
           reinterpret_cast<PyArrayObject*>(array.ptr()),
           reinterpret_cast<PyArray_Descr*>(squashed_dtype.release().ptr()),
@@ -985,6 +1071,8 @@ nb::object CanonicalizeNumpyArray(nb::handle x) {
   if (raw_dtype.ptr() == canonical_dtype.ptr()) {
     return typed_ndarray_type(x);
   }
+  CheckIntegerArrayFitsIn32Bits(
+      x, reinterpret_cast<PyArray_Descr*>(canonical_dtype.ptr())->type_num);
   Py_INCREF(canonical_dtype.ptr());
   PyObject* casted = PyArray_CastToType(
       reinterpret_cast<PyArrayObject*>(x.ptr()),
@@ -1008,6 +1096,18 @@ nb::object CanonicalizeNumpyScalar(nb::handle x) {
   xla::nb_dtype canonical_dtype = CanonicalizeDtype(raw_dtype);
   if (raw_dtype.ptr() == canonical_dtype.ptr()) {
     return typed_ndarray_type(x);
+  }
+  int raw_type_num = reinterpret_cast<PyArray_Descr*>(raw_dtype.ptr())->type_num;
+  if (PyArray_EquivTypenums(raw_type_num, NPY_INT64) ||
+      PyArray_EquivTypenums(raw_type_num, NPY_UINT64)) {
+    nb::object scalar_as_array =
+        nb::steal(PyArray_FromScalar(x.ptr(), nullptr));
+    if (!scalar_as_array.ptr()) {
+      throw nb::python_error();
+    }
+    CheckIntegerArrayFitsIn32Bits(
+        scalar_as_array,
+        reinterpret_cast<PyArray_Descr*>(canonical_dtype.ptr())->type_num);
   }
   Py_INCREF(canonical_dtype.ptr());
   PyObject* coerced_val = PyArray_FromScalar(

--- a/jaxlib/py_values.cc
+++ b/jaxlib/py_values.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include <cstdint>
 #include <exception>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -420,6 +421,76 @@ absl::StatusOr<ShardFn> HandlePythonInt(nb::handle obj, ifrt::Client* client,
   };
 }
 
+// When jax_enable_x64 is disabled, 64-bit integer inputs are converted to
+// 32-bit ones. Out-of-range values would wrap around silently, so we raise
+// OverflowError instead, mirroring the treatment of out-of-range Python ints.
+// See https://github.com/jax-ml/jax/issues/18385.
+[[noreturn]] void ThrowIntegerDowncastOverflow(nb::handle bad_value,
+                                               bool is_signed) {
+  PyErr_Format(PyExc_OverflowError,
+               "NumPy %s value %S too large in magnitude to convert to %s. "
+               "Enable the jax_enable_x64 configuration option to allow "
+               "64-bit values.",
+               is_signed ? "int64" : "uint64", bad_value.ptr(),
+               is_signed ? "int32" : "uint32");
+  throw nb::python_error();
+}
+
+// Checks that a 64-bit integer ndarray that is about to be cast to the 32-bit
+// integer type `target_type_num` contains only values representable in 32
+// bits. Casts between other types are ignored. The array is about to be cast
+// and copied anyway, so the extra pass to compute its min/max is
+// proportionally cheap.
+void CheckIntegerArrayFitsIn32Bits(nb::handle array_h, int target_type_num) {
+  PyArrayObject* array = reinterpret_cast<PyArrayObject*>(array_h.ptr());
+  bool is_signed;
+  if (PyArray_EquivTypenums(PyArray_TYPE(array), NPY_INT64) &&
+      PyArray_EquivTypenums(target_type_num, NPY_INT32)) {
+    is_signed = true;
+  } else if (PyArray_EquivTypenums(PyArray_TYPE(array), NPY_UINT64) &&
+             PyArray_EquivTypenums(target_type_num, NPY_UINT32)) {
+    is_signed = false;
+  } else {
+    return;
+  }
+  if (PyArray_SIZE(array) == 0) {
+    return;
+  }
+  auto as_index = [](const nb::object& value) -> nb::object {
+    nb::object result = nb::steal(PyNumber_Index(value.ptr()));
+    if (!result.ptr()) {
+      throw nb::python_error();
+    }
+    return result;
+  };
+  nb::object max = array_h.attr("max")();
+  if (is_signed) {
+    int64_t hi = PyLong_AsLongLong(as_index(max).ptr());
+    if (hi == -1 && PyErr_Occurred()) {
+      throw nb::python_error();
+    }
+    if (hi > std::numeric_limits<int32_t>::max()) {
+      ThrowIntegerDowncastOverflow(max, is_signed);
+    }
+    nb::object min = array_h.attr("min")();
+    int64_t lo = PyLong_AsLongLong(as_index(min).ptr());
+    if (lo == -1 && PyErr_Occurred()) {
+      throw nb::python_error();
+    }
+    if (lo < std::numeric_limits<int32_t>::min()) {
+      ThrowIntegerDowncastOverflow(min, is_signed);
+    }
+  } else {
+    uint64_t hi = PyLong_AsUnsignedLongLong(as_index(max).ptr());
+    if (hi == static_cast<uint64_t>(-1) && PyErr_Occurred()) {
+      throw nb::python_error();
+    }
+    if (hi > std::numeric_limits<uint32_t>::max()) {
+      ThrowIntegerDowncastOverflow(max, is_signed);
+    }
+  }
+}
+
 template <typename T, typename SquashedT = T>
 absl::StatusOr<ShardFn> HandleNumpyScalar(nb::handle h, ifrt::Client* client,
                                           ifrt::Device* to_device,
@@ -488,6 +559,18 @@ absl::StatusOr<ShardFn> HandleNumpyScalar(nb::handle h, ifrt::Client* client,
   } else {
     T value;
     PyArray_ScalarAsCtype(h.ptr(), &value);
+    if constexpr (std::is_integral_v<T> && !std::is_same_v<T, SquashedT>) {
+      bool fits;
+      if constexpr (std::is_signed_v<T>) {
+        fits = value >= std::numeric_limits<SquashedT>::min() &&
+               value <= std::numeric_limits<SquashedT>::max();
+      } else {
+        fits = value <= std::numeric_limits<SquashedT>::max();
+      }
+      if (!fits) {
+        ThrowIntegerDowncastOverflow(h, std::is_signed_v<T>);
+      }
+    }
     data.template emplace<1>(static_cast<SquashedT>(value));
     type = xla::primitive_util::NativeToPrimitiveType<SquashedT>();
   }
@@ -575,6 +658,9 @@ absl::StatusOr<ShardFn> HandleNumpyArray(nb::handle h, ifrt::Client* client,
     if (squashed_type != type) {
       TF_ASSIGN_OR_RETURN(xla::nb_dtype squashed_dtype,
                           PrimitiveTypeToNbDtype(squashed_type));
+      CheckIntegerArrayFitsIn32Bits(
+          array,
+          reinterpret_cast<PyArray_Descr*>(squashed_dtype.ptr())->type_num);
       array = nb::steal<xla::nb_numpy_ndarray>(PyArray_CastToType(
           reinterpret_cast<PyArrayObject*>(array.ptr()),
           reinterpret_cast<PyArray_Descr*>(squashed_dtype.release().ptr()),
@@ -965,6 +1051,8 @@ nb::object CanonicalizeNumpyArray(nb::handle x) {
   if (raw_dtype.ptr() == canonical_dtype.ptr()) {
     return typed_ndarray_type(x);
   }
+  CheckIntegerArrayFitsIn32Bits(
+      x, reinterpret_cast<PyArray_Descr*>(canonical_dtype.ptr())->type_num);
   Py_INCREF(canonical_dtype.ptr());
   PyObject* casted = PyArray_CastToType(
       reinterpret_cast<PyArrayObject*>(x.ptr()),
@@ -988,6 +1076,18 @@ nb::object CanonicalizeNumpyScalar(nb::handle x) {
   xla::nb_dtype canonical_dtype = CanonicalizeDtype(raw_dtype);
   if (raw_dtype.ptr() == canonical_dtype.ptr()) {
     return typed_ndarray_type(x);
+  }
+  int raw_type_num = reinterpret_cast<PyArray_Descr*>(raw_dtype.ptr())->type_num;
+  if (PyArray_EquivTypenums(raw_type_num, NPY_INT64) ||
+      PyArray_EquivTypenums(raw_type_num, NPY_UINT64)) {
+    nb::object scalar_as_array =
+        nb::steal(PyArray_FromScalar(x.ptr(), nullptr));
+    if (!scalar_as_array.ptr()) {
+      throw nb::python_error();
+    }
+    CheckIntegerArrayFitsIn32Bits(
+        scalar_as_array,
+        reinterpret_cast<PyArray_Descr*>(canonical_dtype.ptr())->type_num);
   }
   Py_INCREF(canonical_dtype.ptr());
   PyObject* coerced_val = PyArray_FromScalar(

--- a/jaxlib/xla_client.py
+++ b/jaxlib/xla_client.py
@@ -45,7 +45,7 @@ ifrt_programs = _xla.ifrt_programs
 # Please suffix the version number with a brief description of your change
 # in a comment. The goal here is to force a merge conflict if two changes
 # attempt to grab the same version number.
-_version = 478  # JAX UnreducedKind
+_version = 479  # OverflowError when 64-bit integer inputs are truncated to 32 bits
 
 # An internal increasing version number for protecting jaxlib code against
 # ifrt changes.

--- a/jaxlib/xla_client.py
+++ b/jaxlib/xla_client.py
@@ -45,7 +45,7 @@ ifrt_programs = _xla.ifrt_programs
 # Please suffix the version number with a brief description of your change
 # in a comment. The goal here is to force a merge conflict if two changes
 # attempt to grab the same version number.
-_version = 486  # PyArray.ReplaceWithAlias checks committed
+_version = 487  # OverflowError when 64-bit integer inputs are truncated to 32 bits
 
 # An internal increasing version number for protecting jaxlib code against
 # ifrt changes.

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -8356,6 +8356,80 @@ class NamedCallTest(jtu.JaxTestCase):
           OverflowError, 'An overflow.*whose argument path is x.', f,
           int_max + 1)
 
+  @parameterized.parameters(
+    [dict(func=func, np_dtype=np_dtype)
+      for func in ['jit', 'asarray', 'device_put']
+      for np_dtype in ['int64', 'uint64']
+    ],
+  )
+  def test_numpy_64bit_array_overflow(self, func, np_dtype):
+    # https://github.com/jax-ml/jax/issues/18385
+    if lib.jaxlib_extension_version < 479:
+      self.skipTest("requires jaxlib extension version >= 479")
+    funcdict = {
+      'jit': jax.jit(lambda x: x + 0),
+      'asarray': lambda x: jnp.asarray(x),
+      'device_put': lambda x: api.device_put(x),
+    }
+    f = funcdict[func]
+
+    dtype = np.dtype(np_dtype)
+    small_dtype = np.dtype('int32') if np_dtype == 'int64' else np.dtype('uint32')
+    in_range = [np.iinfo(small_dtype).min, np.iinfo(small_dtype).max]
+    out_of_range = [
+      np.array([np.iinfo(small_dtype).max + 1], dtype=dtype),
+      np.array(np.iinfo(small_dtype).max + 1, dtype=dtype),  # 0-dimensional
+      np.array([np.iinfo(dtype).max], dtype=dtype),
+    ]
+    if np_dtype == 'int64':
+      out_of_range.append(np.array([np.iinfo(small_dtype).min - 1], dtype=dtype))
+
+    if config.enable_x64.value:
+      # No truncation happens, so any value must pass through unchanged.
+      for x in out_of_range:
+        self.assertArraysEqual(f(x), x)
+      return
+
+    # Boundary values must convert exactly, before and after any jit cache
+    # entry exists for this dtype/shape (the two calls take different paths
+    # through jaxlib).
+    for _ in range(2):
+      for value in in_range:
+        out = f(np.array([value], dtype=dtype))
+        self.assertArraysEqual(out, np.array([value], dtype=small_dtype))
+
+    # Empty arrays trivially satisfy the range check.
+    self.assertArraysEqual(f(np.array([], dtype=dtype)),
+                           np.array([], dtype=small_dtype))
+
+    # Out-of-range values must raise OverflowError rather than silently
+    # wrapping around, both with a cold and with a warm jit cache.
+    for _ in range(2):
+      for x in out_of_range:
+        self.assertRaisesRegex(OverflowError, "too large in magnitude", f, x)
+
+  @parameterized.parameters('int64', 'uint64')
+  def test_numpy_64bit_scalar_overflow(self, np_dtype):
+    # https://github.com/jax-ml/jax/issues/18385
+    if lib.jaxlib_extension_version < 479:
+      self.skipTest("requires jaxlib extension version >= 479")
+    scalar_type = np.int64 if np_dtype == 'int64' else np.uint64
+    small_dtype = np.dtype('int32') if np_dtype == 'int64' else np.dtype('uint32')
+    good = scalar_type(np.iinfo(small_dtype).max)
+    bad = scalar_type(np.iinfo(small_dtype).max + 1)
+
+    f = jax.jit(lambda x: x + 0)
+    if config.enable_x64.value:
+      self.assertEqual(f(bad), bad)
+      self.assertEqual(jnp.asarray(bad), bad)
+      return
+    # Cold and warm jit caches take different paths through jaxlib.
+    for _ in range(2):
+      self.assertEqual(f(good), good)
+      self.assertRaisesRegex(OverflowError, "too large in magnitude", f, bad)
+    self.assertRaisesRegex(
+        OverflowError, "too large in magnitude", jnp.asarray, bad)
+
 
 class BackendsTest(jtu.JaxTestCase):
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -9098,6 +9098,80 @@ class NamedCallTest(jtu.JaxTestCase):
           OverflowError, 'An overflow.*whose argument path is x.', f,
           int_max + 1)
 
+  @parameterized.parameters(
+    [dict(func=func, np_dtype=np_dtype)
+      for func in ['jit', 'asarray', 'device_put']
+      for np_dtype in ['int64', 'uint64']
+    ],
+  )
+  def test_numpy_64bit_array_overflow(self, func, np_dtype):
+    # https://github.com/jax-ml/jax/issues/18385
+    if lib.jaxlib_extension_version < 487:
+      self.skipTest("requires jaxlib extension version >= 487")
+    funcdict = {
+      'jit': jax.jit(lambda x: x + 0),
+      'asarray': lambda x: jnp.asarray(x),
+      'device_put': lambda x: api.device_put(x),
+    }
+    f = funcdict[func]
+
+    dtype = np.dtype(np_dtype)
+    small_dtype = np.dtype('int32') if np_dtype == 'int64' else np.dtype('uint32')
+    in_range = [np.iinfo(small_dtype).min, np.iinfo(small_dtype).max]
+    out_of_range = [
+      np.array([np.iinfo(small_dtype).max + 1], dtype=dtype),
+      np.array(np.iinfo(small_dtype).max + 1, dtype=dtype),  # 0-dimensional
+      np.array([np.iinfo(dtype).max], dtype=dtype),
+    ]
+    if np_dtype == 'int64':
+      out_of_range.append(np.array([np.iinfo(small_dtype).min - 1], dtype=dtype))
+
+    if config.enable_x64.value:
+      # No truncation happens, so any value must pass through unchanged.
+      for x in out_of_range:
+        self.assertArraysEqual(f(x), x)
+      return
+
+    # Boundary values must convert exactly, before and after any jit cache
+    # entry exists for this dtype/shape (the two calls take different paths
+    # through jaxlib).
+    for _ in range(2):
+      for value in in_range:
+        out = f(np.array([value], dtype=dtype))
+        self.assertArraysEqual(out, np.array([value], dtype=small_dtype))
+
+    # Empty arrays trivially satisfy the range check.
+    self.assertArraysEqual(f(np.array([], dtype=dtype)),
+                           np.array([], dtype=small_dtype))
+
+    # Out-of-range values must raise OverflowError rather than silently
+    # wrapping around, both with a cold and with a warm jit cache.
+    for _ in range(2):
+      for x in out_of_range:
+        self.assertRaisesRegex(OverflowError, "too large in magnitude", f, x)
+
+  @parameterized.parameters('int64', 'uint64')
+  def test_numpy_64bit_scalar_overflow(self, np_dtype):
+    # https://github.com/jax-ml/jax/issues/18385
+    if lib.jaxlib_extension_version < 487:
+      self.skipTest("requires jaxlib extension version >= 487")
+    scalar_type = np.int64 if np_dtype == 'int64' else np.uint64
+    small_dtype = np.dtype('int32') if np_dtype == 'int64' else np.dtype('uint32')
+    good = scalar_type(np.iinfo(small_dtype).max)
+    bad = scalar_type(np.iinfo(small_dtype).max + 1)
+
+    f = jax.jit(lambda x: x + 0)
+    if config.enable_x64.value:
+      self.assertEqual(f(bad), bad)
+      self.assertEqual(jnp.asarray(bad), bad)
+      return
+    # Cold and warm jit caches take different paths through jaxlib.
+    for _ in range(2):
+      self.assertEqual(f(good), good)
+      self.assertRaisesRegex(OverflowError, "too large in magnitude", f, bad)
+    self.assertRaisesRegex(
+        OverflowError, "too large in magnitude", jnp.asarray, bad)
+
 
 class BackendsTest(jtu.JaxTestCase):
 

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -421,7 +421,15 @@ class LaxVmapTest(jtu.JaxTestCase):
   )
   def testReduce(self, op, init_val, shape, dtype, dims, bdims):
     rng = jtu.rand_small(self.rng())
-    init_val = np.asarray(init_val, dtype=dtype)
+    # Without x64, 64-bit dtypes are canonicalized to 32 bits. Clamp extremal
+    # 64-bit init_vals (e.g. iinfo(int64).min) into the canonical dtype's
+    # range, where they keep their role as the reduction's identity; otherwise
+    # converting them would raise an OverflowError.
+    canonical_dtype = dtypes.canonicalize_dtype(dtype)
+    if np.issubdtype(canonical_dtype, np.integer):
+      iinfo = dtypes.iinfo(canonical_dtype)
+      init_val = min(max(init_val, int(iinfo.min)), int(iinfo.max))
+    init_val = np.asarray(init_val, dtype=canonical_dtype)
     fun = lambda operand: lax.reduce(operand, init_val, op, dims)
     self._CheckBatching(fun, 5, bdims, (shape,), (dtype,), rng)
 


### PR DESCRIPTION
Fixes #18385.

When `jax_enable_x64` is disabled (the default), 64-bit inputs are canonicalized
to 32 bits. For NumPy int64/uint64 arrays and scalars this used an unsafe cast,
so out-of-range values wrapped around silently:

```python
>>> jax.jit(lambda x: x + 0)(np.array([2**32]))
Array([0], dtype=int32)   # silently wrong
```

Out-of-range Python ints, by contrast, already raise
`OverflowError: Python int 4294967296 too large to convert to int32`.

This change makes the NumPy paths consistent with the Python-int behavior: if a
64-bit integer array or scalar contains a value that does not fit in the 32-bit
target type, JAX raises `OverflowError` (mentioning `jax_enable_x64`) instead of
truncating. Float/complex downcasts are unchanged (they follow IEEE semantics,
e.g. float64 overflow becomes `inf`).

There are two independent conversion paths in jaxlib and both are fixed:

- the `canonicalize_value` handlers (`CanonicalizeNumpyArray`,
  `CanonicalizeNumpyScalar`), used on cache misses and by `jnp.asarray` /
  `jax.device_put`;
- the `squash_64bit_types` branches of `DevicePut` (`HandleNumpyArray`,
  `HandleNumpyScalar`), used by the C++ pjit fast path on cache hits (the jit
  cache key is dtype+shape, so a warm cache must still check values).

The check runs only in the branch that already casts and copies the array, so
there is no cost for already-canonical inputs, jax.Arrays, or x64 mode. The
error is raised as a genuine Python `OverflowError` (not `std::overflow_error`,
which the pjit vectorcall handler would remap to `ValueError`).

This is a rework of the bitrotted #15275; the conversion logic has since moved
into C++ in jaxlib, which makes the fix much more contained now.

Tests: new `test_numpy_64bit_array_overflow` / `test_numpy_64bit_scalar_overflow`
in tests/api_test.py cover int64/uint64, arrays (incl. 0-d), scalars, cold and
warm jit caches, `jnp.asarray`, `jax.device_put`, exact int32/uint32 boundary
values, and x64-enabled pass-through; they are gated on jaxlib extension
version 478. `lax_vmap_test.py::testReduce` is adjusted to clamp its extremal
64-bit reduction-identity init values into the canonical dtype's range instead
of relying on silent wraparound.
