### PR TITLE
[vjp3] add a separate channel of structured residuals

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1526,16 +1526,18 @@ def linearize(fun: Callable, *primals, has_aux: bool = False
   """
   check_callable(fun)
   primals_ft = ft.flatten(primals)
-  out_primals_ft, out_known, jaxpr, consts, *maybe_aux = ad.linearize(
-      fun, primals_ft, has_aux=has_aux)
+  out_primals_ft, out_known, jaxpr, consts, structured_residuals, *maybe_aux = \
+      ad.linearize(fun, primals_ft, has_aux=has_aux)
   in_avals = primals_ft.map(core.typeof)
   out_avals = out_primals_ft.map(core.typeof)
   lifted_jvp = Partial(
-      partial(_lift_linearized, jaxpr, in_avals, out_avals, out_known), consts)
+      partial(_lift_linearized, jaxpr, in_avals, out_avals, out_known),
+      consts, structured_residuals)
   return out_primals_ft.unflatten(), lifted_jvp, *maybe_aux
 
 
-def _lift_linearized(jaxpr, in_avals, out_avals, out_known, consts, *tangents):
+def _lift_linearized(jaxpr, in_avals, out_avals, out_known, consts,
+                     structured_residuals, *tangents):
   tangents_ft = ft.flatten(tangents)
   if tangents_ft.tree != in_avals.tree:
     raise TypeError(f"expected {in_avals.tree}, got {tangents_ft.tree}")
@@ -1566,7 +1568,8 @@ def _lift_linearized(jaxpr, in_avals, out_avals, out_known, consts, *tangents):
           "the original primal values:\n"
           f"Got tangent aval {tangent_aval} for primal aval {primal_aval} "
           f"but expected {expected_tangent_aval}.{extra_msg}")
-  tangents_out = eval_jaxpr(jaxpr, consts, *tangents_ft)
+  sres_flat = tree_leaves(structured_residuals)
+  tangents_out = eval_jaxpr(jaxpr, consts, *tangents_ft, *sres_flat)
   tangents_out_ = iter(tangents_out)
   full_out = [a2tz(aval).instantiate() if known else next(tangents_out_)
               for aval, known in zip(out_avals, out_known)]
@@ -1658,8 +1661,8 @@ def vjp(
   primals_ft = ft.flatten(primals).map(canon)
   primals_ft.map(dispatch.check_arg)
   saveable = _saveable_args_flags(saveable_args, primals_ft.tree)
-  out_primals_ft, out_known, jaxpr, residuals, *maybe_aux = ad.linearize(
-      fun, primals_ft, is_vjp=True, has_aux=has_aux)
+  out_primals_ft, out_known, jaxpr, residuals, structured_residuals, *maybe_aux = \
+      ad.linearize(fun, primals_ft, is_vjp=True, has_aux=has_aux)
 
   id_map = {id(x): i for i, x in enumerate(primals_ft)}
   used, opaque_residuals = set(), []
@@ -1670,11 +1673,12 @@ def vjp(
   args_res = tuptree_map(keep, primals_ft.tree, primals_ft, saveable)
   out_primal_avals = list(out_primals_ft.map(typeof))
   f_vjp = VJP(partial(_vjp3_callable, spec, out_known, jaxpr, out_primal_avals),
-              primals_ft.tree, out_primals_ft.tree, list(args_res), opaque_residuals)
+              primals_ft.tree, out_primals_ft.tree, list(args_res),
+              opaque_residuals, structured_residuals)
   return out_primals_ft.unflatten(), f_vjp, *maybe_aux
 
 def _vjp3_callable(spec, out_known, jaxpr, out_primal_avals, in_tree, out_tree,
-                   args_res, opaque_res, *maybe_ct_refs):
+                   args_res, opaque_res, structured_res, *maybe_ct_refs):
   explicit_refs = bool(maybe_ct_refs)
   if explicit_refs:
     maybe_ct_refs_flat, in_tree_ = tree_flatten(maybe_ct_refs)
@@ -1689,9 +1693,9 @@ def _vjp3_callable(spec, out_known, jaxpr, out_primal_avals, in_tree, out_tree,
     _vjp_not_saveable_error(jaxpr, in_tree, not_restored)
   residuals = [args_res_[i.idx] if i.primal else opaque_res[i.idx] for i in spec]
   maybe_accums = [_vjp_accum(jaxpr, in_tree, explicit_refs, idx, v, x)
-                  for idx, (v, x) in enumerate(zip(jaxpr.invars, maybe_ct_refs_flat))]
+                  for idx, (v, x) in enumerate(unsafe_zip(jaxpr.invars, maybe_ct_refs_flat))]
   return Partial(partial(_vjp3_bwd, in_tree, out_tree, out_known, jaxpr,
-                         out_primal_avals), residuals, maybe_accums)
+                         out_primal_avals), residuals, structured_res, maybe_accums)
 
 def _vjp_accum(jaxpr, in_tree, explicit_refs, idx, v, x):
   if isinstance(x, ad.GradAccum):
@@ -1780,13 +1784,14 @@ def check_accum(aval, acc):
   return acc
 
 def _vjp3_bwd(in_tree, out_tree, out_known, jaxpr, out_primal_avals, residuals,
-              maybe_accums, out_ct):
+              structured_res, maybe_accums, out_ct):
   cts_flat, out_tree_ = tree_flatten(out_ct, is_leaf=lambda x: isinstance(x, ad.Zero))
   if out_tree != out_tree_:
     _vjp_ct_tree_error(jaxpr, out_tree, out_tree_)
   _vjp_check_ct_avals(cts_flat, out_primal_avals)
   cts_flat = [ct for ct, k in zip(cts_flat, out_known) if not k]
-  ad.backward_pass3(jaxpr, True, residuals, maybe_accums, cts_flat)
+  primals_in = [*maybe_accums, *tree_leaves(structured_res)]
+  ad.backward_pass3(jaxpr, True, residuals, primals_in, cts_flat)
   arg_cts = [x.freeze() if isinstance(x, ad.ValAccum) else
              DidntWant() if isinstance(x, ad.NullAccum) else GradRef()
              for x in maybe_accums]
@@ -1938,6 +1943,7 @@ class VJP:
   out_tree: PyTreeDef
   args_res: list[Any]
   opaque_residuals: list[Any]
+  structured_residuals: list[Any]
   jaxpr = property(lambda self: self.fun.args[2])
 
   def __call__(self, out_ct, *extra_args):
@@ -1945,11 +1951,12 @@ class VJP:
       name, *_ = self.jaxpr.debug_info.func_src_info.split(' ')
       raise TypeError(_vjp_too_many_args(name, len(extra_args) + 1))
     return self.fun(self.in_tree, self.out_tree, self.args_res,
-                    self.opaque_residuals)(out_ct)
+                    self.opaque_residuals, self.structured_residuals)(out_ct)
 
   def with_refs(self, *maybe_ct_refs):
     return self.fun(self.in_tree, self.out_tree, self.args_res,
-                    self.opaque_residuals, *maybe_ct_refs)
+                    self.opaque_residuals, self.structured_residuals,
+                    *maybe_ct_refs)
 
   replace = dataclasses.replace
 
@@ -1959,7 +1966,7 @@ class VJP:
 
 register_pytree_node(
     VJP,
-    lambda vjp: ((vjp.args_res, vjp.opaque_residuals),
+    lambda vjp: ((vjp.args_res, vjp.opaque_residuals, vjp.structured_residuals),
                  (vjp.fun, vjp.in_tree, vjp.out_tree)),
     lambda meta, args_res: VJP(*meta, *args_res))
 

--- a/jax/_src/compute_on.py
+++ b/jax/_src/compute_on.py
@@ -26,7 +26,7 @@ from jax._src import effects as effects_lib
 from jax._src import linear_util as lu
 from jax._src import source_info_util
 from jax._src.interpreters import ad, batching, mlir, partial_eval as pe
-from jax._src.tree_util import tree_flatten, tree_unflatten
+from jax._src.tree_util import tree_flatten, tree_leaves, tree_unflatten
 from jax._src.util import (safe_map, safe_zip, weakref_lru_cache, unzip2,
                            split_list, subs_list, merge_lists)
 from jax._src.api_util import debug_info, flatten_fun_nokwargs, flatten_axes
@@ -218,19 +218,24 @@ ad.primitive_jvps[compute_on_p] = _compute_on_jvp
 
 def _compute_on_lin(is_vjp, nzs, *primals, jaxpr, compute_type,
                     out_memory_spaces, compiler_options_json):
-  (primal_jaxpr, num_res_out, nzs_out, in_fwd_res,
-   tangent_jaxpr) = ad.linearize_jaxpr(jaxpr, nzs, is_vjp=is_vjp)
+  primal_jaxpr, out_tree, nzs_out, in_fwd_res, tangent_jaxpr = \
+      ad.linearize_jaxpr(jaxpr, nzs, is_vjp=is_vjp)
+  _, ures_avals, sres_avals = out_tree.unpack()
+  num_res_out = len(ures_avals) + len(sres_avals)
 
   tangent_avals_out = [a.to_tangent_aval() for a in jaxpr.out_avals]
   def _filter_zeros(is_nz_l, l):
     return tuple(x for nz, x in zip(is_nz_l, l) if nz)
 
-  def tangent_fun(residuals, *tangents):
+  def tangent_fun(residuals, structured_residuals, *tangents):
     tangents_nz = _filter_zeros(nzs, tangents)
-    assert len(residuals) + len(tangents_nz) == len(tangent_jaxpr.invars), (
-        len(residuals), len(tangents_nz), len(tangent_jaxpr.invars))
+    sres_flat = tree_leaves(structured_residuals)
+    assert (len(residuals) + len(tangents_nz) + len(sres_flat)
+            == len(tangent_jaxpr.invars)), (
+        len(residuals), len(tangents_nz), len(sres_flat),
+        len(tangent_jaxpr.invars))
     tangent_out_mem_spaces = _filter_zeros(nzs_out, out_memory_spaces)
-    nz_outs = compute_on_p.bind(*residuals, *tangents_nz,
+    nz_outs = compute_on_p.bind(*residuals, *tangents_nz, *sres_flat,
                                 jaxpr=tangent_jaxpr, compute_type=compute_type,
                                 out_memory_spaces=tangent_out_mem_spaces,
                                 compiler_options_json=compiler_options_json)
@@ -245,8 +250,10 @@ def _compute_on_lin(is_vjp, nzs, *primals, jaxpr, compute_type,
                           out_memory_spaces=primal_out_mem_spaces,
                           compiler_options_json=compiler_options_json)
   primal_ans, residuals_ans = split_list(ans, [len(ans) - num_res_out])
-  residuals_ans = subs_list(in_fwd_res, [*jaxpr.consts, *primals], residuals_ans)
-  return primal_ans, nzs_out, residuals_ans, tangent_fun
+  ures, sres_flat = split_list(residuals_ans, [len(ures_avals)])
+  ures = subs_list(in_fwd_res, [*jaxpr.consts, *primals], ures)
+  sres = sres_avals.update(sres_flat).unflatten()
+  return primal_ans, nzs_out, ures, sres, tangent_fun
 ad.primitive_linearizations[compute_on_p] = _compute_on_lin
 
 def _compute_on_partial_eval(trace: pe.JaxprTrace, *in_tracers, jaxpr,

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -629,38 +629,51 @@ def _call_hi_primitive_batcher(axis_data, args_flat, dims_flat, _prim):
   return ans_flat, dims_flat
 batching.fancy_primitive_batchers[call_hi_primitive_p] = _call_hi_primitive_batcher
 
+# A `lin` or `vjp_fwd` rule may return (ans, res), (ans, res, nzs_out), or
+# (ans, res, nzs_out, sres). When it returns structured residuals, the paired
+# backward rule receives them explicitly: `linearized(res, sres, *tangents)`,
+# and `vjp_bwd(res, sres, outgrad, *arg_accums)` (which must be overridden).
 def _call_hi_primitive_linearize(is_vjp, nz_in_flat, *args_flat, _prim):
   args = tree_unflatten(_prim.in_tree, args_flat)
   nzs_in = tree_unflatten(_prim.in_tree, nz_in_flat)
   if is_vjp:
-    ans, residuals, *maybe_nzs_out = _prim.vjp_fwd(nzs_in, *args)
+    ans, residuals, *rest = _prim.vjp_fwd(nzs_in, *args)
     linearized = partial(fake_linear_op, _prim, nz_in_flat)
   else:
-    ans, residuals, *maybe_nzs_out = _prim.lin(nzs_in, *args)
+    ans, residuals, *rest = _prim.lin(nzs_in, *args)
     linearized = partial(flatten_user_linearized, _prim)
   ans_flat = tree_leaves_checked(_prim.out_tree, ans)
-  nzs_out = maybe_nzs_out[0] if maybe_nzs_out else True
+  nzs_out = rest[0] if rest else True
+  sres = rest[1] if len(rest) > 1 else None
+  if (sres is not None and is_vjp and
+      type(_prim).vjp_bwd is VJPHiPrimitive.vjp_bwd):
+    raise TypeError(
+        f"{type(_prim).__name__} returned structured residuals from `vjp_fwd`, "
+        "which requires overriding `vjp_bwd(res, sres, outgrad, *arg_accums)`")
   nzs_out_flat = broadcast_prefix(nzs_out, ans)
   linearized = partial(linearized, nzs_out_flat) if is_vjp else linearized
-  return ans_flat, nzs_out_flat, residuals, linearized
+  return ans_flat, nzs_out_flat, residuals, sres, linearized
 ad.primitive_linearizations[call_hi_primitive_p] = _call_hi_primitive_linearize
 
-def fake_linear_op(prim, nz_in_flat, nz_out_flat, rs, *tangents):
+def fake_linear_op(prim, nz_in_flat, nz_out_flat, rs, sres, *tangents):
+  rs = rs if sres is None else (rs, sres)  # unpacked in the transpose rule
   residuals_flat, residuals_tree = tree_flatten(rs)
   assert nz_in_flat == [not isinstance(t, ad_util.Zero) for t in tangents]
   nz_tangents = tree_leaves(tangents)
   out_nz = call_hi_primitive_linearized_p.bind(
       *residuals_flat, *nz_tangents, residuals_tree=residuals_tree, _prim=prim,
-      nz_in_flat=tuple(nz_in_flat), nz_out_flat=tuple(nz_out_flat))
+      nz_in_flat=tuple(nz_in_flat), nz_out_flat=tuple(nz_out_flat),
+      has_sres=sres is not None)
   out_nz_iter = iter(out_nz)
   out = [next(out_nz_iter) if nz else ad_util.Zero(a.to_tangent_aval())
          for a, nz in zip(prim.out_avals_flat, nz_out_flat)]
   assert next(out_nz_iter, sentinel := object()) is sentinel
   return out
 
-def flatten_user_linearized(prim, residuals, *tangents_flat):
+def flatten_user_linearized(prim, residuals, sres, *tangents_flat):
   tangents = tree_unflatten(prim.in_tree, tangents_flat)
-  tangents_out = prim.linearized(residuals, *tangents)
+  tangents_out = (prim.linearized(residuals, *tangents) if sres is None else
+                  prim.linearized(residuals, sres, *tangents))
   flat_vals, treedef_actual = tracing_registry.flatten(
       tangents_out, lambda x: isinstance(x, ad_util.Zero))
   if treedef_actual != prim.out_tree:
@@ -675,11 +688,11 @@ call_hi_primitive_linearized_p.multiple_results = True
 call_hi_primitive_linearized_p.is_high = lambda *args, _prim, **_: True
 @call_hi_primitive_linearized_p.def_abstract_eval
 def _call_hi_primitive_linearized_abstract_eval(
-    *_args, _prim, residuals_tree, nz_in_flat, nz_out_flat):
+    *_args, _prim, residuals_tree, nz_in_flat, nz_out_flat, has_sres):
   return [t.to_tangent_aval() for t, nz in zip(_prim.out_avals_flat, nz_out_flat) if nz]
 
 def _call_hi_primitive_linearized_transpose(
-    cts_flat_, *args, _prim, residuals_tree, nz_in_flat, nz_out_flat):
+    cts_flat_, *args, _prim, residuals_tree, nz_in_flat, nz_out_flat, has_sres):
   residuals_flat, accums_flat = split_list(args, [residuals_tree.num_leaves])
   residuals = tree_unflatten(residuals_tree, residuals_flat)
   accums_flat_ = iter(accums_flat)
@@ -692,13 +705,19 @@ def _call_hi_primitive_linearized_transpose(
               for a, nz in zip(_prim.out_avals_flat, nz_out_flat)]
   assert next(cts_flat_iter, sentinel := object()) is sentinel
   cts = tree_unflatten(_prim.out_tree, cts_flat)
-  none = _prim.vjp_bwd(residuals, cts, *accums)
+  if has_sres:
+    residuals, sres = residuals
+    none = _prim.vjp_bwd(residuals, sres, cts, *accums)
+  else:
+    none = _prim.vjp_bwd(residuals, cts, *accums)
   assert none is None
 ad.fancy_transposes[call_hi_primitive_linearized_p] = _call_hi_primitive_linearized_transpose
 
 def _call_hi_primitive_linearized_prettyprint(eqn, context, settings):
   params = dict(eqn.params, _prim=eqn.params['_prim'].__class__.__name__,
                 residuals_tree='...')
+  if not params['has_sres']:
+    del params['has_sres']
   return core._pp_eqn(eqn.replace(params=params), context, settings)
 core.pp_eqn_rules[call_hi_primitive_linearized_p] = _call_hi_primitive_linearized_prettyprint
 
@@ -788,7 +807,7 @@ def linearize_from_jvp(self, nzs_in, *primals):
     return out_primals_flat, out_tangents_flat
 
   dbg = debug_info('linearize_from_jvp', self.jvp, (primals, primals), {})
-  out_primals_flat, nzs_out_flat, consts, linearized = ad.linearize_from_jvp(
+  out_primals_flat, nzs_out_flat, consts, _, linearized = ad.linearize_from_jvp(
       lu.wrap_init(jvp_flat, debug_info=dbg), True, nzs_in_flat,
       False, False, primals_flat, {})
   out_primals = tree_unflatten(self.out_tree, out_primals_flat)
@@ -798,7 +817,7 @@ def linearize_from_jvp(self, nzs_in, *primals):
 def apply_derived_linearization(self, residuals, *tangents):
   """The `linearized` rule paired with `lin = linearize_from_jvp`."""
   tangents_flat = self.in_tree.flatten_up_to(tangents)
-  out_tangents_flat = residuals.apply(residuals.consts, *tangents_flat)
+  out_tangents_flat = residuals.apply(residuals.consts, None, *tangents_flat)
   return tree_unflatten(self.out_tree, out_tangents_flat)
 
 def jvp_from_lin(self, primals, tangents):
@@ -820,8 +839,9 @@ def jvp_from_lin(self, primals, tangents):
   tangents_flat = self.in_tree.flatten_up_to(tangents)
   nzs_in = tree_unflatten(
       self.in_tree, [not isinstance(t, ad_util.Zero) for t in tangents_flat])
-  out_primals, residuals, *_ = self.lin(nzs_in, *primals)
-  out_tangents = self.linearized(residuals, *tangents)
+  out_primals, residuals, *rest = self.lin(nzs_in, *primals)
+  out_tangents = (self.linearized(residuals, *tangents) if len(rest) < 2 else
+                  self.linearized(residuals, rest[1], *tangents))
   return out_primals, out_tangents
 
 def vjp_fwd_from_jvp(self, nzs_in, *primals):
@@ -957,7 +977,7 @@ class CustomVJPTraced(VJPHiPrimitive):
     nzs_out_flat = [True] * len(self.out_avals_flat)
     tangents_flat = tree_leaves_checked(self.in_tree, tangents)
     tangents_out_flat = fake_linear_op(self, nzs_in_flat, nzs_out_flat, residuals,
-                                       *tangents_flat)
+                                       None, *tangents_flat)
     tangents_out = tree_unflatten(self.out_tree, tangents_out_flat)
     return primals_out, tangents_out
 

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -26,7 +26,8 @@ from jax._src import linear_util as lu
 from jax._src.interpreters import partial_eval as pe
 from jax._src import flattree as ft
 from jax._src.tree_util import (
-    tree_flatten, tree_unflatten, register_pytree_node, PyTreeDef)
+    tree_map, tree_flatten, tree_unflatten, tree_leaves, register_pytree_node,
+    PyTreeDef)
 from jax._src import mesh as mesh_lib
 from jax._src import core
 from jax._src import source_info_util
@@ -39,8 +40,8 @@ from jax._src.core import (Trace, Tracer, typeof, call_p, Primitive, Literal)
 from jax._src.dtypes import dtype, float0
 from jax._src.state.types import AbstractRef
 from jax._src.util import (unzip2, safe_map, safe_zip, split_list,
-                           weakref_lru_cache, partition_list, subs_list2,
-                           foreach)
+                           split_list_checked, weakref_lru_cache,
+                           partition_list, subs_list2, foreach)
 
 Array = Any
 Ref = Any
@@ -102,11 +103,11 @@ def linearize_subtrace_2(f: Callable, is_vjp: bool,
     tracers = [LinearizeTracer(linearize_trace, p,
                                tangent_trace.new_arg(typeof(p).to_tangent_aval(),
                                                      source_info))
-               if nz else p
-               for p, nz in zip(primals, nzs_in)]
+               if nz else p for p, nz in zip(primals, nzs_in)]
     with core.set_current_trace(linearize_trace, check_leaks=True):
       ans = f(*tracers)
       out_primals, out_tangents = ans.map(linearize_trace.to_primal_tangent_pair).unzip2()
+      sres = linearize_trace.structured_residuals
       del linearize_trace, ans, tracers
   nzs_out = tuple(type(t) is not Zero for t in out_tangents)
   out_tangents = tuple(t for t, nz in zip(out_tangents, nzs_out) if nz)
@@ -115,18 +116,18 @@ def linearize_subtrace_2(f: Callable, is_vjp: bool,
   which_env = [(isinstance(c, pe.DynamicJaxprTracer) and
                 getattr(c._trace, 'tag', None) is tag) for c in consts]
   jaxpr = pe.move_envvars(jaxpr, tuple(which_env))
-  res, env = partition_list(which_env, consts)
-  residual_avals = map(typeof, res)
+  ures, env = partition_list(which_env, consts)
   # Which residuals are just forwarded inputs? Check object id.
   id_map = {id(p): i for i, p in enumerate(primals)}
-  in_fwd: list[int | None] = [id_map.get(id(r)) for r in res]
+  in_fwd: list[int | None] = [id_map.get(id(r)) for r in ures]
   # Which residuals are already primal outputs? Check object id.
   id_map = {id(p): i for i, p in enumerate(out_primals)}
-  out_fwd: list[int | None] = [id_map.get(id(r)) for r in res]
+  out_fwd: list[int | None] = [id_map.get(id(r)) for r in ures]
   # Prune residuals not to include forwarded primal inputs or outputs.
-  res = [p for p, f1, f2 in zip(res, in_fwd, out_fwd) if f1 is None and f2 is None]
-  aux = (residual_avals, nzs_out, jaxpr, env, in_fwd, out_fwd)
-  return res, out_primals, aux
+  ures = [p for p, f1, f2 in zip(ures, in_fwd, out_fwd) if f1 is None and f2 is None]
+  fwd_out_ty = ft.pack((out_primals, ft.flatten((ures, sres)))).map(typeof)
+  lin_data = (fwd_out_ty, nzs_out, jaxpr, env, in_fwd, out_fwd)
+  return out_primals, ft.flatten((ures, sres)), lin_data
 
 
 @lu.transformation_with_aux2
@@ -141,11 +142,11 @@ def linearize_subtrace(_f: Callable, _store: lu.Store, _is_vjp: bool,
     tracers = [LinearizeTracer(linearize_trace, p,
                                tangent_trace.new_arg(typeof(p).to_tangent_aval(),
                                                      source_info))
-               if nz else p
-               for p, nz in zip(primals, nzs_in)]
+               if nz else p for p, nz in zip(primals, nzs_in)]
     with core.set_current_trace(linearize_trace, check_leaks=True):
       ans = _f(*tracers)
       out_primals, out_tangents = unzip2(map(linearize_trace.to_primal_tangent_pair, ans))
+      structured_residuals = linearize_trace.structured_residuals
       del linearize_trace, ans, tracers
   nzs_out = tuple(type(t) is not Zero for t in out_tangents)
   out_tangents = tuple(t for t, nz in zip(out_tangents, nzs_out) if nz)
@@ -157,7 +158,6 @@ def linearize_subtrace(_f: Callable, _store: lu.Store, _is_vjp: bool,
                 getattr(c._trace, 'tag', None) is _tag) for c in consts]
   jaxpr = pe.move_envvars(jaxpr, tuple(which_env))
   res, env = partition_list(which_env, consts)
-  residual_avals = map(typeof, res)
   # Which residuals are just forwarded inputs? Check object id.
   id_map = {id(p): i for i, p in enumerate(primals)}
   in_fwd: list[int | None] = [id_map.get(id(r)) for r in res]
@@ -166,8 +166,9 @@ def linearize_subtrace(_f: Callable, _store: lu.Store, _is_vjp: bool,
   out_fwd: list[int | None] = [id_map.get(id(r)) for r in res]
   # Prune residuals not to include forwarded primal inputs or outputs.
   res = [p for p, f1, f2 in zip(res, in_fwd, out_fwd) if f1 is None and f2 is None]
-  _store.store((residual_avals, nzs_out, jaxpr, env, in_fwd, out_fwd))
-  return *res, *out_primals
+  fwd_out_ty = ft.flatten((out_primals, res, structured_residuals)).map(typeof)
+  _store.store((fwd_out_ty, nzs_out, jaxpr, env, in_fwd, out_fwd))
+  return *out_primals, *res, *tree_leaves(structured_residuals)
 
 # The result of `f` should be a `FlatTree`
 def jvp_subtrace_2(f: Callable, tag: core.TraceTag, primals, tangents):
@@ -197,7 +198,7 @@ def linearize_jaxpr(
     allow_fwds: bool | Sequence[bool] = True,
     *,
     is_vjp: bool,
-) -> tuple[core.Jaxpr, int, Sequence[bool], Sequence[int | None], core.Jaxpr]:
+) -> tuple[core.Jaxpr, ft.FlatTree, Sequence[bool], Sequence[int | None], core.Jaxpr]:
   if type(allow_fwds) is bool:
     allow_fwds = (allow_fwds,) * (len(jaxpr.consts) + len(jaxpr.invars))
   assert len(allow_fwds) == (len(jaxpr.consts) + len(jaxpr.invars))
@@ -215,18 +216,18 @@ def _linearize_jaxpr(
     instantiate: tuple[bool, ...],
     allow_fwds: tuple[bool, ...],
     is_vjp: bool,
-) -> tuple[core.Jaxpr, int, Sequence[bool], Sequence[int | None], core.Jaxpr]:
+) -> tuple[core.Jaxpr, ft.FlatTree, Sequence[bool], Sequence[int | None], core.Jaxpr]:
   dbg = jaxpr.debug_info
   config.enable_checks.value and dbg.assert_arg_names(len(nonzeros))
-  primal_trace = pe.DynamicJaxprTrace(dbg)
+  fwd_trace = pe.DynamicJaxprTrace(dbg)
   tangent_trace = pe.DynamicJaxprTrace(dbg, auto_dce=True)
   tag = core.TraceTag()
   tangent_trace.tag = tag
-  lin_trace = LinearizeTrace(primal_trace, tangent_trace, is_vjp=is_vjp)
+  lin_trace = LinearizeTrace(fwd_trace, tangent_trace, is_vjp=is_vjp)
 
-  def new_arg(trace, primal_aval, nz, source_info):
-    primal = primal_trace.new_arg(primal_aval, source_info)
-    tangent_aval = primal_aval.to_tangent_aval()
+  def new_arg(trace, fwd_aval, nz, source_info):
+    primal = fwd_trace.new_arg(fwd_aval, source_info)
+    tangent_aval = fwd_aval.to_tangent_aval()
     tangent = tangent_trace.new_arg(tangent_aval, source_info) if nz else Zero(tangent_aval)
     return LinearizeTracer(trace, primal, tangent)
 
@@ -240,6 +241,7 @@ def _linearize_jaxpr(
     out_primals, out_tangents = unzip2(map(lin_trace.to_primal_tangent_pair, ans))
     out_tangents = [instantiate_zeros(t) if inst else t
                     for t, inst in zip(out_tangents, instantiate)]
+    structured_residuals = lin_trace.structured_residuals
     del lin_trace, ans, new_arg, tracers
 
   # pe._check_no_returned_refs(debug_info, out_tangents)
@@ -249,6 +251,7 @@ def _linearize_jaxpr(
   tangent_jaxpr, tangent_consts = tangent_trace.to_jaxpr(
       out_tangents, dbg.with_unknown_names(), source_info)
   tangent_trace.invalidate()
+  # TODO non-residual consts..., check tracers!
   tangent_jaxpr, tangent_consts = _dce_consts(tangent_jaxpr, tangent_consts)
   tangent_jaxpr = pe.convert_constvars_jaxpr(tangent_jaxpr)
 
@@ -259,18 +262,17 @@ def _linearize_jaxpr(
   del in_primals
 
   # pe._check_no_returned_refs(debug_info, out_primals)
-  primals_and_residuals = *out_primals, *tangent_consts
-  primals_and_residuals = map(partial(primal_trace.to_jaxpr_tracer, source_info=source_info),
-                              primals_and_residuals)
-  primal_jaxpr, primal_consts = primal_trace.to_jaxpr(
-      primals_and_residuals, dbg.with_unknown_names(),
-      source_info)
-  primal_trace.invalidate()
-  primal_jaxpr, primal_consts = _dce_consts(primal_jaxpr, primal_consts)
-  primal_jaxpr = primal_jaxpr.with_consts(primal_consts)
+  all_fwd_outs = *out_primals, *tangent_consts, *tree_leaves(structured_residuals)
+  all_fwd_outs = map(partial(fwd_trace.to_jaxpr_tracer, source_info=source_info),
+                             all_fwd_outs)
+  fwd_jaxpr, fwd_consts = fwd_trace.to_jaxpr(
+      all_fwd_outs, dbg.with_unknown_names(), source_info)
+  fwd_trace.invalidate()
+  fwd_jaxpr, fwd_consts = _dce_consts(fwd_jaxpr, fwd_consts)
+  fwd_jaxpr = fwd_jaxpr.with_consts(fwd_consts)
 
-  num_residuals_out = len(tangent_consts)
-  return primal_jaxpr, num_residuals_out, nzs_out, fwds, tangent_jaxpr
+  fwd_out_ty = ft.flatten((out_primals, tangent_consts, structured_residuals)).map(typeof)
+  return fwd_jaxpr, fwd_out_ty, nzs_out, fwds, tangent_jaxpr
 
 def _dce_consts(jaxpr, consts):
   jaxpr, used_consts, _ = pe.dce_jaxpr_consts(
@@ -314,6 +316,7 @@ def linearize(traceable, primals_ft, has_aux=False, is_vjp=False):
         auxs = ()
       out_primals, out_tangents = ft.flatten(ans).map(
           lin_trace.to_primal_tangent_pair).unzip2()
+      structured_residuals = lin_trace.structured_residuals
       del lin_trace, ans, tracers
   out_nzs = [type(t) is not Zero for t in out_tangents]
   out_nz_tangents = [t for t, nz in zip(out_tangents, out_nzs) if nz]
@@ -329,7 +332,7 @@ def linearize(traceable, primals_ft, has_aux=False, is_vjp=False):
   consts = [c for c, used in zip(consts, used_consts) if used]
   out_zeros = map(op.not_, out_nzs)
   auxs = tuple(aux.unflatten() for aux in auxs)
-  return out_primals, out_zeros, jaxpr, consts, *auxs
+  return out_primals, out_zeros, jaxpr, consts, structured_residuals, *auxs
 
 class UndefinedPrimal:
   __slots__ = ['aval']
@@ -664,7 +667,7 @@ class JVPTrace(Trace):
         dict(subfuns=(fun, fwd, bwd), out_trees=out_trees,
              symbolic_zeros=symbolic_zeros))
     fwd_in = [(p, type(t) is not Zero) for p, t in zip(primals_in, tangents_in)]
-    fwd_in = [x for pair in fwd_in for x in pair]   # flatten
+    fwd_in = [x for pair in fwd_in for x in pair]
     with core.set_current_trace(self.parent_trace):
       res_and_primals_out = fwd.call_wrapped(*fwd_in)
 
@@ -752,10 +755,11 @@ call_transpose_param_updaters: dict[core.Primitive, Callable] = {}
 
 class LinearizeTrace(Trace):
   parent_trace: core.Trace
-  tangent_trace: core.Trace
+  tangent_trace: pe.DynamicJaxprTrace
   is_vjp: bool
   requires_low: bool
   _name_stack_prefix_len: int
+  structured_residuals: list
 
   def __init__(self, parent_trace, tangent_trace, is_vjp):
     super().__init__()
@@ -767,6 +771,7 @@ class LinearizeTrace(Trace):
     self.is_vjp = is_vjp
     self.requires_low = False
     self._name_stack_prefix_len = len(source_info_util.current_name_stack())
+    self.structured_residuals = []
 
   @property
   def tag(self) -> core.TraceTag:
@@ -802,11 +807,15 @@ class LinearizeTrace(Trace):
     fallback = partial(fallback_linearize_rule, primitive)
     lin = primitive_linearizations.get(primitive, fallback)
     with core.set_current_trace(self.parent_trace):
-      primal_out, tangent_nzs_out, residuals, linearized = lin(
+      primal_out, tangent_nzs_out, residuals, structured_res, linearized = lin(
           self.is_vjp, tangent_nzs, *primals_in, **params)
+    if structured_res is not None:
+      self.structured_residuals.append(structured_res)
+    new_arg = lambda x: self.tangent_trace.new_arg(typeof(x), source_info_util.current())
+    structured_res_binders = tree_map(new_arg, structured_res)
     with (core.set_current_trace(self.tangent_trace),
           source_info_util.set_name_stack(self._name_stack_suffix())):
-      tangent_out = linearized(residuals, *tangents_in)
+      tangent_out = linearized(residuals, structured_res_binders, *tangents_in)
     if primitive.multiple_results:
       return [maybe_linearize_tracer(self, x, nz, t)
               for x, nz, t in zip(primal_out, tangent_nzs_out, tangent_out)]
@@ -837,12 +846,12 @@ class LinearizeTrace(Trace):
     with core.set_current_trace(self.parent_trace):
       instantiate_zeros = not symbolic_zeros
       nonzeros_in = [type(t) is not Zero for t in tangents_in]
-      primals_out, tangent_nzs_out, residuals, linearized = linearize_from_jvp(
-          _f_jvp, True, nonzeros_in, symbolic_zeros, instantiate_zeros,
-          primals_in, {})
+      primals_out, tangent_nzs_out, residuals, structured_residuals, linearized = \
+          linearize_from_jvp(_f_jvp, True, nonzeros_in, symbolic_zeros,
+                             instantiate_zeros, primals_in, {})
 
     with core.set_current_trace(self.tangent_trace):
-      tangents_out = linearized(residuals, *tangents_in)
+      tangents_out = linearized(residuals, structured_residuals, *tangents_in)
     tangents_out = map(replace_rule_output_symbolic_zeros, tangents_out)
     return [maybe_linearize_tracer(self, x, nz, t)
             for x, nz, t in zip(primals_out, tangent_nzs_out, tangents_out)]
@@ -890,36 +899,35 @@ class LinearizeTrace(Trace):
     avals = [typeof(x) for x in primals]
     all_fwd_results = call_primitive.bind_with_trace(
         self.parent_trace, primals, avals, dict(params, subfuns=(f_fwd,)))
-    residual_avals, nzs_out, lin_jaxpr, env, in_fwd, out_fwd = linearize_outs_thunk()
+    fwd_out_ty, nzs_out, lin_jaxpr, env, in_fwd, out_fwd = linearize_outs_thunk()
+    primal_out_avals, _, sres_out_avals = fwd_out_ty.unpack()
     num_res_out = sum(f1 is None and f2 is None for f1, f2 in zip(in_fwd, out_fwd))
-    non_fwd_res = all_fwd_results[:num_res_out]
-    primals_out = all_fwd_results[num_res_out:]
+    primals_out, non_fwd_res, structured_res = split_list_checked(
+        all_fwd_results, [len(primal_out_avals), num_res_out, len(sres_out_avals)])
     residuals = subs_list2(in_fwd, out_fwd, primals, primals_out, non_fwd_res)
     update_params = call_linearize_param_updaters.get(call_primitive)
-    num_new_args = len(residuals) + len(env)
+    num_new_args = len(residuals) + len(structured_res) + len(env)
     new_params = (update_params(params, num_new_args, nzs_in)
                   if update_params else params)
-    num_residuals = len(residual_avals)
 
-    f_tangent = _get_f_tangent(lin_jaxpr, num_residuals)
+    f_tangent = _get_f_tangent(lin_jaxpr, len(residuals), len(sres_out_avals))
     nz_tangents_in = [t for (t, nz) in zip(tangents, nzs_in) if nz]
     new_params = dict(new_params, subfuns=(lu.wrap_init(f_tangent, debug_info=lin_jaxpr.debug_info),))
-    args = (*residuals, *env, *nz_tangents_in)
+    args = (*residuals, *structured_res, *env, *nz_tangents_in)
     avals = [typeof(x) for x in args]
-    nz_tangents_out = call_primitive.bind_with_trace(
-        self.tangent_trace, args, avals, new_params)
+    nz_tangents_out = call_primitive.bind_with_trace(self.tangent_trace, args, avals, new_params)
     nz_tangents_out_iter = iter(nz_tangents_out)
     tangents_out = [next(nz_tangents_out_iter) if nz else p2tz(primal)
                     for nz, primal in zip(nzs_out, primals_out)]
+    assert next(nz_tangents_out_iter, sentinel := object()) is sentinel
     return map(partial(maybe_linearize_tracer, self), primals_out, nzs_out, tangents_out)
 
 
 @weakref_lru_cache
-def _get_f_tangent(lin_jaxpr, num_residuals):
+def _get_f_tangent(lin_jaxpr, num_ures, num_sres):
   def _f(*args):
-    consts = args[:num_residuals]
-    nz_tangents = args[num_residuals:]
-    return core.eval_jaxpr(lin_jaxpr, consts, *nz_tangents)
+    consts, sres_flat, nz_tangents = split_list(args, [num_ures, num_sres])
+    return core.eval_jaxpr(lin_jaxpr, consts, *nz_tangents, *sres_flat)
   return _f
 
 
@@ -1000,7 +1008,7 @@ def linearize_from_jvp(jvp: lu.WrappedFun,
         [False] * len(jaxpr.constvars) + [True] * len(jaxpr.invars))
     out_consts = [c for used, c in zip(used_consts, out_consts) if used]
 
-    def linearized(residuals, *tangents):
+    def linearized(residuals, _, *tangents):
       nz_tangents_in = [t for (t, nz) in zip(tangents, nonzeros) if nz]
       nz_tangents_out = core.eval_jaxpr(jaxpr, residuals, *nz_tangents_in)
       nz_tangents_out_iter = iter(nz_tangents_out)
@@ -1013,11 +1021,11 @@ def linearize_from_jvp(jvp: lu.WrappedFun,
         return out_tangent
 
   if multiple_results:
-    return out_primals, out_nzs, out_consts, linearized
+    return out_primals, out_nzs, out_consts, None, linearized
   else:
     out_primal, = out_primals
     out_nz, = out_nzs
-    return out_primal, out_nz, out_consts, linearized
+    return out_primal, out_nz, out_consts, None, linearized
 
 class LinearizeTracer(Tracer[LinearizeTrace]):
   __slots__ = ['primal', 'tangent']

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import collections
 from collections.abc import Callable, Sequence
+import dataclasses
 import functools
 from functools import partial
 import itertools
@@ -24,8 +25,8 @@ from typing import Any, TypeVar
 
 from jax._src import flattree as ft
 from jax._src.tree_util import (
-    tree_flatten, tree_unflatten, tree_flatten_with_path, keystr,
-    equality_errors_pytreedef)
+    tree_flatten, tree_unflatten, tree_leaves, tree_flatten_with_path, keystr,
+    equality_errors_pytreedef, register_dataclass)
 from jax._src import ad_util
 from jax._src import api_util
 from jax._src import config
@@ -532,37 +533,49 @@ def _cond_linearize(is_vjp, nzs, *primals_in, branches, **params):
   nzs_out = [ad.linearize_jaxpr(jaxpr, nzs, allow_fwds=False, is_vjp=is_vjp)[2]
              for jaxpr in branches]
   nzs_out = map(any, zip(*nzs_out))
-  primal_jaxprs, tangent_jaxprs, branch_res_avals = [], [], []
+  fwd_jaxprs, tangent_jaxprs, branch_ures_avals, branch_sres_avals = [], [], [], []
   for jaxpr in branches:
-    primal_jaxpr, num_res_out, _, _, tangent_jaxpr = \
+    fwd_jaxpr, fwd_out_tree, _, _, tangent_jaxpr = \
         ad.linearize_jaxpr(jaxpr, nzs, instantiate=nzs_out, allow_fwds=False, is_vjp=is_vjp)
-    res_avals = primal_jaxpr.out_avals[len(primal_jaxpr.out_avals)-num_res_out:]
-    primal_jaxprs.append(primal_jaxpr)
+    _, ures_avals, sres_avals = fwd_out_tree.unpack()
+    fwd_jaxprs.append(fwd_jaxpr)
     tangent_jaxprs.append(tangent_jaxpr)
-    branch_res_avals.append(res_avals)
+    branch_ures_avals.append(ures_avals.unflatten())
+    branch_sres_avals.append(sres_avals)
+  branch_sres_avals = ft.pack(tuple(branch_sres_avals))
 
-  all_res_avals, res_avals_per_branch = _merge_branch_residuals(branch_res_avals)
-  primal_jaxprs = _join_cond_outputs(
-      primal_jaxprs, all_res_avals, res_avals_per_branch, len(nzs_out))
+  merged_ures_avals, ures_aval_indices = _merge_branch_residuals(branch_ures_avals)
+  fwd_jaxprs = _join_cond_outputs(
+      fwd_jaxprs, merged_ures_avals, ures_aval_indices, branch_sres_avals, len(nzs_out))
   tangent_jaxprs = _join_cond_pe_staged_jaxpr_inputs(
-      tangent_jaxprs, all_res_avals, res_avals_per_branch)
+      tangent_jaxprs, merged_ures_avals, ures_aval_indices, branch_sres_avals, sum(nzs))
   tangent_avals_out = [a.to_tangent_aval() for a in jaxpr.out_avals]
 
-  primals_res_out = cond_p.bind(*primals_in, branches=primal_jaxprs, **params)
+  primals_res_out = cond_p.bind(*primals_in, branches=(*fwd_jaxprs,), **params)
   primals, res = split_list(primals_res_out, [len(nzs_out)])
+  ures, sres_flat = split_list_checked(res, [len(merged_ures_avals), len(branch_sres_avals)])
 
-  def tangent_fun(res, *tangents_in):
+  def tangent_fun(res, sres, *tangents_in):
+    if sres is None:
+      idx, *res = res
+      sres_flat = []
+    else:
+      idx = sres.index
+      sres_flat = tree_leaves(sres.branches)
     nz_tangents_in = [t for t in tangents_in if not isinstance(t, ad.Zero)]
-    nz_tangents_out = cond_p.bind(*res, *nz_tangents_in,
-                                  branches=tangent_jaxprs, **params)
+    nz_tangents_out = cond_p.bind(idx, *res, *nz_tangents_in, *sres_flat,
+                                  branches=(*tangent_jaxprs,), **params)
     nz_tangents_out_ = iter(nz_tangents_out)
     tangents_out = [next(nz_tangents_out_) if nz else ad.Zero(aval)
                    for (aval, nz) in zip(tangent_avals_out, nzs_out)]
-    assert next(nz_tangents_out_, None) is None
+    assert next(nz_tangents_out_, sentinel := object()) is sentinel
     return tangents_out
 
   idx, *_ = primals_in
-  return primals, nzs_out, [idx, *res], tangent_fun
+  if not len(branch_sres_avals):
+    return primals, nzs_out, [idx, *ures], None, tangent_fun
+  sres = CondSum(idx, list(branch_sres_avals.update(sres_flat).unflatten()))
+  return primals, nzs_out, ures, sres, tangent_fun
 
 
 def _cond_jvp(primals, tangents, *, branches, **params):
@@ -624,29 +637,30 @@ def _cond_partial_eval(trace, *tracers, branches, **params):
   num_res = len(all_res_avals)
 
   num_known_outs = len(out_uks) - sum(out_uks)
+  dummy = ft.flatten([[]] * len(branches_known))
   branches_known = _join_cond_outputs(
-      branches_known, all_res_avals, res_avals_per_branch, num_known_outs)
+      branches_known, all_res_avals, res_avals_per_branch, dummy, num_known_outs)
   branches_unknown = _join_cond_pe_staged_jaxpr_inputs(
-      branches_unknown, all_res_avals, res_avals_per_branch)
+      branches_unknown, all_res_avals, res_avals_per_branch, dummy, sum(ops_uk))
   assert all(all(map(core.typematch, j.out_avals, branches_known[0].out_avals))
              for j in branches_known[1:])
 
   in_consts = [t.pval.get_known() for t in tracers if t.pval.is_known()]
-  out_consts_res = cond_p.bind(*in_consts, branches=branches_known,
+  out_consts_res = cond_p.bind(*in_consts, branches=(*branches_known,),
                                **params)
   out_consts, res = split_list(out_consts_res, [len(out_consts_res) - num_res])
 
-  index_tracer = trace.instantiate_const(tracers[0])
+  idx_tracer = trace.instantiate_const(tracers[0])
   ops_tracers = [trace.instantiate_const(t)
                  for uk, t in zip(in_unknowns[1:], tracers[1:]) if uk]
   res_tracers = map(trace.new_instantiated_const, res)
   out_tracers = [pe.JaxprTracer(trace, pe.PartialVal.unknown(aval), None)
                  for aval in branches_unknown[0].out_avals]
-  params = dict(branches=branches_unknown, **params)
+  params = dict(branches=(*branches_unknown,), **params)
   name_stack = source_info_util.current_name_stack()[len(trace.name_stack):]
   source = source_info_util.current().replace(name_stack=name_stack)
   eqn = pe.new_eqn_recipe(
-      trace, [index_tracer] + res_tracers + ops_tracers, out_tracers, cond_p, params,
+      trace, [idx_tracer, *res_tracers, *ops_tracers], out_tracers, cond_p, params,
       _join_cond_effects(branches_unknown), source)
   for t in out_tracers: t.recipe = eqn
   return util.merge_lists(out_uks, out_consts, out_tracers)
@@ -698,10 +712,11 @@ def _cond_partial_eval_custom(saveable, unks_in, inst_in, eqn):
   all_res_avals, res_avals_per_branch = _merge_branch_residuals(branch_res_avals)
   num_res = len(all_res_avals)
   num_known_outs = len(unks_out) - sum(unks_out)
+  dummy = ft.flatten([[]] * len(branches_known_))
   branches_known = _join_cond_outputs(
-      branches_known_, all_res_avals, res_avals_per_branch, num_known_outs)
+      branches_known_, all_res_avals, res_avals_per_branch, dummy, num_known_outs)
   branches_staged = _join_cond_pe_staged_jaxpr_inputs(
-      branches_staged_, all_res_avals, res_avals_per_branch)
+      branches_staged_, all_res_avals, res_avals_per_branch, dummy, len(ops_uk))
   assert all(all(map(core.typematch, j.out_avals, branches_known[0].out_avals))
              for j in branches_known[1:])
 
@@ -711,7 +726,7 @@ def _cond_partial_eval_custom(saveable, unks_in, inst_in, eqn):
   # Build the known eqn.
   ins_known, _ = partition_list(unks_in, eqn.invars)  # includes index invar
   out_binders_known, _ = partition_list(unks_out, eqn.outvars)
-  params_known = dict(branches=branches_known, **eqn_rest_params)
+  params_known = dict(branches=(*branches_known,), **eqn_rest_params)
   effects_known = _join_cond_effects(branches_known)
   eqn_known = pe.new_jaxpr_eqn(
       ins_known, [*out_binders_known, *res_binders], cond_p, params_known,
@@ -719,7 +734,7 @@ def _cond_partial_eval_custom(saveable, unks_in, inst_in, eqn):
 
   # Build the staged eqn.
   _, out_binders_staged = partition_list(inst_out, eqn.outvars)
-  params_staged = dict(branches=branches_staged, **eqn_rest_params)
+  params_staged = dict(branches=(*branches_staged,), **eqn_rest_params)
   effects_staged = _join_cond_effects(branches_staged)
   eqn_staged = pe.new_jaxpr_eqn(
       [eqn.invars[0], *res_binders, *eqn.invars[1:]], out_binders_staged,
@@ -753,11 +768,11 @@ def _cond_partial_eval_custom(saveable, unks_in, inst_in, eqn):
 # [x], [y], [x, x]             -> [x, y, x],    [[0], [1], [0, 2]]
 # [x], [x], [x, x]             -> [x, x],       [[0], [0], [0, 1]]
 # [y, x, x], [x, z, y], [z, x] -> [y, x, x, z], [[0, 1, 2], [1, 3, 0], [3, 1]]
-def _merge_branch_residuals(branch_res_avals):
+def _merge_branch_residuals(branch_ures_avals):
   def enumerate_equal(xs):
     counts = {v: itertools.count() for v in set(xs)}
     return [(x, next(counts[x])) for x in xs]
-  branch_res_tagged_avals = map(enumerate_equal, branch_res_avals)
+  branch_res_tagged_avals = map(enumerate_equal, branch_ures_avals)
   all_tagged_avals = _ordered_unique(util.concatenate(branch_res_tagged_avals))
   indices = {v: i for i, v in enumerate(all_tagged_avals)}
   branch_indices = [
@@ -768,40 +783,41 @@ def _merge_branch_residuals(branch_res_avals):
 # This function augments branch outputs to agree with the merged residual
 # format: each branch is made to return zero-filled values in the places of
 # residual outputs that it does not populate.
-def _join_cond_outputs(jaxprs: Sequence[core.Jaxpr],
-                       all_res_avals, res_aval_indices_per_jaxpr,
-                       num_non_res_outputs) -> tuple[core.Jaxpr, ...]:
-  def augment_jaxpr(jaxpr: core.Jaxpr,
-                    res_indices):
+def _join_cond_outputs(
+    jaxprs, merged_ures_avals, ures_aval_indices_per_jaxpr, sres_avals, num_primals_out
+  ) -> list[core.Jaxpr]:
+  def augment_jaxpr(jaxpr: core.Jaxpr, ures_indices, idx):
     def f_aug(*args):
       outs_and_residuals = core.jaxpr_as_fun(jaxpr)(*args)
-      outs, residuals = split_list(outs_and_residuals, [num_non_res_outputs])
-      aug_residuals = map(ad_util.empty_like_aval, all_res_avals)
-      aug_residuals = util.subvals(aug_residuals, zip(res_indices, residuals))
-      return outs + list(aug_residuals)
+      outs, ures, sres = split_list(outs_and_residuals, [num_primals_out, len(ures_indices)])
+      aug_ures = map(ad_util.empty_like_aval, merged_ures_avals)
+      aug_ures = util.subvals(aug_ures, zip(ures_indices, ures))
+      aug_sres = sres_avals.map(ad_util.empty_like_aval).unpack()
+      aug_sres = util.subvals(aug_sres, [(idx, aug_sres[idx].update(sres))])
+      return [*outs, *aug_ures, *itertools.chain.from_iterable(aug_sres)]
 
     return _make_closed_jaxpr(f_aug, jaxpr.in_avals, jaxpr.debug_info)
 
-  return tuple(map(augment_jaxpr, jaxprs, res_aval_indices_per_jaxpr))
+  return map(augment_jaxpr, jaxprs, ures_aval_indices_per_jaxpr, range(len(jaxprs)))
 
 # This function augments branch inputs to agree with the merged residual format:
 # each branch is made to accept all residuals, even though it will ignore those
 # that it does not read.
 def _join_cond_pe_staged_jaxpr_inputs(
-    jaxprs: Sequence[core.Jaxpr], all_res_avals,
-    res_aval_indices_per_jaxpr) -> tuple[core.Jaxpr, ...]:
-  all_res_vars = map(core.Var, all_res_avals)
+    jaxprs, merged_ures_avals, res_aval_indices_per_jaxpr, sres_avals, num_tangents
+  ) -> list[core.Jaxpr]:
+  all_ures_vars = map(core.Var, merged_ures_avals)
+  all_sres_vars = sres_avals.map(core.Var).unpack()
 
-  def augment_jaxpr(jaxpr: core.Jaxpr, res_indices) -> core.Jaxpr:
-    num_res = len(res_indices)
-    res_vars = jaxpr.invars[:num_res]
-    non_res_vars = jaxpr.invars[num_res:]
+  def augment_jaxpr(jaxpr: core.Jaxpr, ures_indices, idx):
+    ures_vars, tangent_vars, sres_vars = \
+        split_list(jaxpr.invars, [len(ures_indices), num_tangents])
+    aug_ures_vars = util.subvals(all_ures_vars, zip(ures_indices, ures_vars))
+    aug_sres_vars = util.subvals(all_sres_vars, [(idx, all_sres_vars[idx].update(sres_vars))])
+    invars = [*aug_ures_vars, *tangent_vars, *itertools.chain.from_iterable(aug_sres_vars)]
+    return jaxpr.replace(invars=invars)
 
-    aug_res_vars = list(util.subvals(all_res_vars, zip(res_indices, res_vars)))
-    aug_invars = aug_res_vars + non_res_vars
-    return jaxpr.replace(invars=aug_invars)
-
-  return tuple(map(augment_jaxpr, jaxprs, res_aval_indices_per_jaxpr))
+  return map(augment_jaxpr, jaxprs, res_aval_indices_per_jaxpr, range(len(jaxprs)))
 
 def _ordered_unique(xs):
   d = collections.OrderedDict((x, None) for x in xs)
@@ -838,6 +854,19 @@ def _cond_dce_rule(used_outputs: list[bool], eqn: core.JaxprEqn,
   assert all(len(new_eqn.outvars) == len(jaxpr.out_avals)
              for jaxpr in new_params['branches'])
   return [True, *used_inputs], new_eqn
+
+
+@register_dataclass
+@dataclasses.dataclass(frozen=True, slots=True)
+class CondSum:
+  """A cond-shaped sum, represented as a tagged product.
+
+  `index` is the branch that ran, and `branches` has one slot per branch: the
+  branch's value if it ran, zeros if the branch participates but wasn't taken,
+  or None if it doesn't participate. Nested conds nest their CondSums.
+  """
+  index: Any
+  branches: list
 
 
 def _cond_transpose_fancy(cts_in, index, *args, branches, **params):
@@ -948,14 +977,15 @@ def _cond_remat(trace, *args, branches, **params):
     _, res_avals = split_list_checked(jaxpr_fwd.out_avals, [len(jaxpr.out_avals), num_res])
     branch_res_avals.append(res_avals)
   merged_avals, branch_res_avals = _merge_branch_residuals(branch_res_avals)
+  dummy = ft.flatten([[]] * len(branches))
   branches_fwd = _join_cond_outputs(
-      branches_fwd, merged_avals, branch_res_avals, len(jaxpr.out_avals))
+      branches_fwd, merged_avals, branch_res_avals, dummy, len(jaxpr.out_avals))
   branches_rem = _join_cond_pe_staged_jaxpr_inputs(
-      branches_rem, merged_avals, branch_res_avals)
-  all_out = cond_p.bind(*args, branches=branches_fwd, **params)
+      branches_rem, merged_avals, branch_res_avals, dummy, len(jaxpr.in_avals))
+  all_out = cond_p.bind(*args, branches=(*branches_fwd,), **params)
   primals_out, res = split_list(all_out, [len(jaxpr.out_avals)])
   def rem(idx, *args):
-    return cond_p.bind(idx, *res, *args, branches=branches_rem, **params)
+    return cond_p.bind(idx, *res, *args, branches=(*branches_rem,), **params)
   return primals_out, rem
 
 

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -68,7 +68,8 @@ from jax._src.state import AbstractRef, discharge as state_discharge
 from jax._src.traceback_util import api_boundary
 from jax._src.tree_util import equality_errors
 from jax._src.tree_util import (
-    keystr, tree_flatten, tree_map, tree_unflatten, treedef_is_leaf)
+    keystr, tree_flatten, tree_map, tree_unflatten, tree_leaves,
+    treedef_is_leaf)
 from jax._src.typing import Array
 from jax._src.util import (
     merge_lists, partition_list, safe_map, safe_zip, split_list,
@@ -807,7 +808,7 @@ def _scan_linearize(is_vjp, nzs, *primals_in, reverse: bool, length: int,
       ft.pack((c_ok, k_ok.map(lambda _: False), xs_ok)))
   for _ in range(1 + num_carry):
     nzs = const_nz + carry_nz + xs_nz
-    primal_jaxpr, num_res_out, nzs_out, in_fwd_res, tangent_jaxpr = \
+    primal_jaxpr, out_tree, nzs_out, in_fwd_res, tangent_jaxpr = \
         ad.linearize_jaxpr(jaxpr, nzs, allow_fwds=allow_fwds,
                            instantiate=carry_nz + [False] * num_ys, is_vjp=is_vjp)
     carry_nz_out = nzs_out[:num_carry]
@@ -817,11 +818,27 @@ def _scan_linearize(is_vjp, nzs, *primals_in, reverse: bool, length: int,
       carry_nz = _map(operator.or_, carry_nz, carry_nz_out)
   else:
     assert False, "Fixpoint not reached"
-  num_res_in = len(in_fwd_res)
-  num_primals_out = len(primal_jaxpr.out_avals) - num_res_out
+  primal_out_avals, ures_out_avals, sres_out_avals = out_tree.unpack()
+  num_res_in = len(in_fwd_res) + len(sres_out_avals)
+  num_primals_out = len(primal_out_avals)
 
-  # At this point all non-forwarded residuals produced by primal_jaxpr are at
-  # the end. We want to hoist out loop-invariant ones:
+  # Input-to-output forwarding for structured residuals: an sres output that
+  # is just a forwarded xs element has stacked value equal to the whole xs
+  # argument, so don't return it from the scan; restore it from primals_in
+  # after the bind below. (Const-forwards would be unstacked, so they need
+  # loop-invariant hoisting treatment instead, and carries change every
+  # iteration.)
+  fwds = pe._jaxpr_forwarding(primal_jaxpr)
+  in_fwd_sres = [f if f is not None and f >= num_consts + num_carry and
+                 not isinstance(primals_in[f], np.ndarray) else None
+                 for f in fwds[num_primals_out + len(ures_out_avals):]]
+  primal_jaxpr = pe.prune_closed_jaxpr_outputs(
+      primal_jaxpr, [True] * (num_primals_out + len(ures_out_avals))
+      + [f is None for f in in_fwd_sres])
+  num_kept_sres = sum(f is None for f in in_fwd_sres)
+
+  # At this point all non-forwarded unstructured residuals produced by
+  # primal_jaxpr are at the end. We want to hoist out loop-invariant ones:
   # Before:
   #  [*const_primals_in , *carry_ext_primals_in] -> [*primals_out, *non_fwd_res]
   # After:
@@ -830,8 +847,9 @@ def _scan_linearize(is_vjp, nzs, *primals_in, reverse: bool, length: int,
   #  non_fwd_res = merge_lists(which_hoisted, ext_res, hoisted_res)
   const_primals_in, carry_ext_primals_in = split_list(primals_in, [num_consts])
   primal_jaxpr, const_primals_in_, which_hoisted, hoisted_res = \
-      _scan_known_hoisting(primal_jaxpr, const_primals_in, num_res_out)
-  del num_res_out
+      _scan_known_hoisting(primal_jaxpr, const_primals_in, len(ures_out_avals), num_kept_sres)
+  num_ures_out = len(ures_out_avals) - sum(which_hoisted)
+  del ures_out_avals
 
   # To make tangent_jaxpr match the scan calling convention, move to the back
   # binders that don't correspond to hoisted or const-forwarded residuals.
@@ -844,7 +862,25 @@ def _scan_linearize(is_vjp, nzs, *primals_in, reverse: bool, length: int,
                  for f in in_fwd_res]
   assert next(which_hoisted_, None) is None
   tangent_jaxpr = pe.move_binders_to_back(
-      tangent_jaxpr, res_to_move + [False] * num_tangents_in)
+      tangent_jaxpr, res_to_move + [False] * num_tangents_in + [True] * len(sres_out_avals))
+
+  # De-duplicate repeated residual outputs by var: a residual can duplicate a
+  # stacked primal ys output or an earlier residual (but not a carry output,
+  # which is the final rather than the stacked value), so return one copy of
+  # each from the scan and re-duplicate after the bind below.
+  prim_out_vars, res_out_vars = split_list(primal_jaxpr.outvars, [num_primals_out])
+  idx_map = {id(v): i for i, v in enumerate(prim_out_vars[num_carry:], num_carry)}
+  res_fwd: list[int | None] = [None] * num_primals_out
+  num_kept = num_primals_out
+  for v in res_out_vars:
+    fwd = idx_map.get(id(v))
+    res_fwd.append(fwd)
+    if fwd is None:
+      idx_map[id(v)] = num_kept  # index into the pruned outputs
+      num_kept += 1
+  primal_jaxpr = pe.prune_closed_jaxpr_outputs(
+      primal_jaxpr, [f is None for f in res_fwd])
+  num_kept_res = num_kept - num_primals_out
 
   # Run the primal scan (if it has any outputs or effects).
   if not primal_jaxpr.out_avals and not primal_jaxpr.effects:
@@ -855,48 +891,53 @@ def _scan_linearize(is_vjp, nzs, *primals_in, reverse: bool, length: int,
         *const_primals_in_, *carry_ext_primals_in, jaxpr=primal_jaxpr,
         reverse=reverse, length=length, unroll=unroll,
         ft_in=ft.pack((ft.nones(len(const_primals_in_)), carry_g, xs_g)),
-        ft_out=ft.pack((carry_g, (ft_out.unpack()[1],
-                                  ft.nones(which_hoisted.count(False))))))
+        ft_out=ft.pack((carry_g, (ft_out.unpack()[1], ft.nones(num_kept_res)))))
+  out = subs_list(res_fwd, out, out)
   primals_out, ext_res = split_list(out, [num_primals_out])
+  ext_ures, kept_sres = split_list_checked(ext_res, [num_ures_out, num_kept_sres])
 
   # Complete res using hoisted_res and input forwards.
-  res = subs_list(in_fwd_res, [*jaxpr.consts, *primals_in],
-                  merge_lists(which_hoisted, ext_res, hoisted_res))
+  ures = subs_list(in_fwd_res, [*jaxpr.consts, *primals_in],
+                   merge_lists(which_hoisted, ext_ures, hoisted_res))
+  sres_flat = subs_list(in_fwd_sres, primals_in, kept_sres)
 
-  def tangent_fun(res, *tangents):
-    int_res, ext_res = partition_list(res_to_move, res)
+  def tangent_fun(ures, sres, *tangents):
+    sres_flat = tree_leaves(sres)
+    int_res, ext_res = partition_list(res_to_move, ures)
     nz_tangents = [ad.instantiate_zeros(x) for nz, x in zip(nzs, tangents) if nz]
     nz_consts_g, nz_carry_g, nz_xs_g = ft_in.filter_with_mask(nzs).unpack()
     nz_tangents_out = scan_p.bind(
-        *int_res, *nz_tangents, *ext_res, jaxpr=tangent_jaxpr, reverse=reverse,
-        length=length, unroll=unroll,
+        *int_res, *nz_tangents, *ext_res, *sres_flat, jaxpr=tangent_jaxpr,
+        reverse=reverse, length=length, unroll=unroll,
         ft_in=ft.pack(((ft.nones(len(int_res)), nz_consts_g), nz_carry_g,
-                       (nz_xs_g, ft.nones(len(ext_res))))),
+                       (nz_xs_g, ft.nones(len(ext_res) + len(sres_flat))))),
         ft_out=ft_out.filter_with_mask(nzs_out))
     tangent_avals_out = [v.aval.to_tangent_aval() for v in jaxpr.outvars]
     return list(ft_out.filter_with_mask(nzs_out).update(nz_tangents_out)
                 .unfilter().map3(tangent_avals_out, nzs_out,
                                  lambda t, a, nz: t if nz else ad.Zero(a)))
 
-  return primals_out, nzs_out, res, tangent_fun
+  sres = sres_out_avals.update(sres_flat).unflatten()
+  return primals_out, nzs_out, ures, sres, tangent_fun
 
-def _scan_known_hoisting(jaxpr_known, known_consts, num_res):
+def _scan_known_hoisting(jaxpr_known, known_consts, num_ures, num_sres):
   # To disable:
   # return jaxpr_known, known_consts, [False] * num_res, []
 
   consts = [pe.PartialVal.unknown(a) if isinstance(a := typeof(c), AbstractRef)
             else pe.PartialVal.known(c) for c in known_consts]
   others = _map(pe.PartialVal.unknown, jaxpr_known.in_avals[len(consts):])
-  num_known_outs = len(jaxpr_known.out_avals) - num_res
+  num_known_outs = len(jaxpr_known.out_avals) - num_ures - num_sres
+  inst = [True] * num_known_outs + [False] * num_ures + [True] * num_sres
   with source_info_util.reset_name_stack():
     jaxpr_known_, pvals_out, new_known_consts = pe.trace_to_jaxpr_nounits(
         lu.wrap_init(core.jaxpr_as_fun(jaxpr_known),
                      debug_info=jaxpr_known.debug_info),
-        consts + others, instantiate=[True] * num_known_outs + [False] * num_res)
+        consts + others, instantiate=inst)
   jaxpr_known = pe.convert_constvars_jaxpr(jaxpr_known_)
-  res_pvals = pvals_out[num_known_outs:]
-  which_hoisted = [pval.is_known() for pval in res_pvals]
-  hoisted_res = [pval.get_known() for pval in res_pvals if pval.is_known()]
+  _, ures_pvals, _ = split_list(pvals_out, [num_known_outs, num_ures])
+  which_hoisted = [pval.is_known() for pval in ures_pvals]
+  hoisted_res = [pval.get_known() for pval in ures_pvals if pval.is_known()]
   mut_consts = [c for c in known_consts if isinstance(typeof(c), AbstractRef)]
   return jaxpr_known, [*new_known_consts, *mut_consts], which_hoisted, hoisted_res
 
@@ -948,7 +989,7 @@ def _scan_partial_eval(trace, *tracers, reverse: bool,
   #   non_fwd_res = merge_lists(which_hoisted, ext_res, hoisted_res)
   known_consts, known_ins = split_list(known_ins, [num_consts_known])
   jaxpr_known, known_consts_, which_hoisted, hoisted_res = \
-      _scan_known_hoisting(jaxpr_known, known_consts, num_res_out)
+      _scan_known_hoisting(jaxpr_known, known_consts, num_res_out, 0)
   del num_res_out  # changed
 
   # To make jaxpr_unknown match the scan calling convention, move to the back

--- a/jax/_src/lax/eval_jaxpr.py
+++ b/jax/_src/lax/eval_jaxpr.py
@@ -19,6 +19,7 @@ from jax._src.core import Jaxpr
 from jax._src.interpreters import ad
 from jax._src.interpreters import batching
 from jax._src.interpreters import partial_eval as pe
+from jax._src.tree_util import tree_leaves
 from jax._src.util import safe_map, safe_zip, split_list, subs_list
 
 _map = safe_map
@@ -67,16 +68,22 @@ def _eval_jaxpr_batching_rule(axis_data, args, dims, *, jaxpr):
 batching.fancy_primitive_batchers[eval_jaxpr_p] = _eval_jaxpr_batching_rule
 
 def _eval_jaxpr_linearize(is_vjp, nzs, *primals_in, jaxpr):
-  lin_out = ad.linearize_jaxpr(jaxpr, nzs, is_vjp=is_vjp)
-  primal_jaxpr, num_res_out, nzs_out, in_fwd_res, tangent_jaxpr = lin_out
+  primal_jaxpr, out_tree, nzs_out, in_fwd_res, tangent_jaxpr = \
+      ad.linearize_jaxpr(jaxpr, nzs, is_vjp=is_vjp)
+  _, ures_avals, sres_avals = out_tree.unpack()
+  num_res_out = len(ures_avals) + len(sres_avals)
   primals_and_res = eval_jaxpr_p.bind(*primals_in, jaxpr=primal_jaxpr)
   primals_out, non_fwd_res = split_list(
       primals_and_res, [len(primals_and_res) - num_res_out])
-  res = subs_list(in_fwd_res, [*jaxpr.consts, *primals_in], non_fwd_res)
+  ures, sres_flat = split_list(non_fwd_res, [len(ures_avals)])
+  res = subs_list(in_fwd_res, [*jaxpr.consts, *primals_in], ures)
+  sres = sres_avals.update(sres_flat).unflatten()
 
-  def tangent_fun(res, *tangents):
+  def tangent_fun(res, sres, *tangents):
+    sres_flat = tree_leaves(sres)
     nz_tangents = [ad.instantiate_zeros(x) for nz, x in zip(nzs, tangents) if nz]
-    nz_tangents_out = eval_jaxpr_p.bind(*res, *nz_tangents, jaxpr=tangent_jaxpr)
+    nz_tangents_out = eval_jaxpr_p.bind(*res, *nz_tangents, *sres_flat,
+                                        jaxpr=tangent_jaxpr)
     tangent_avals_out = [v.aval.to_tangent_aval() for v in jaxpr.outvars]
     nz_tangents_out_ = iter(nz_tangents_out)
     tangents_out = [next(nz_tangents_out_) if nz else ad_util.Zero(aval)
@@ -84,7 +91,7 @@ def _eval_jaxpr_linearize(is_vjp, nzs, *primals_in, jaxpr):
     assert next(nz_tangents_out_, None) is None
     return tangents_out
 
-  return primals_out, nzs_out, res, tangent_fun
+  return primals_out, nzs_out, res, sres, tangent_fun
 ad.primitive_linearizations[eval_jaxpr_p] = _eval_jaxpr_linearize
 
 def _eval_jaxpr_transpose(ct, *args, jaxpr):

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4627,8 +4627,8 @@ def _sin_lowering(ctx, x, accuracy):
 
 def _sin_lin(_is_vjp, nzs, x, accuracy):
   nz, = nzs
-  return (sin_p.bind(x, accuracy=accuracy), nz, cos(x),
-          lambda cos_x, t: mul(t, cos_x))
+  return (sin_p.bind(x, accuracy=accuracy), nz, cos(x), None,
+          lambda cos_x, _, t: mul(t, cos_x))
 
 sin_p = standard_unop(_float | _complex, 'sin')
 ad.defjvp(sin_p, lambda g, x, accuracy: mul(g, cos(x, accuracy=accuracy)))
@@ -8673,7 +8673,7 @@ def _reduce_or_lin(_is_vjp, nzs, x, *, axes):
   nz, = nzs
   y = reduce_or_p.bind(x, axes=axes)
   aval = typeof(y).to_tangent_aval()
-  return y, False, (), lambda _, t: ad_util.Zero(aval)
+  return y, False, (), None, lambda _, __, t: ad_util.Zero(aval)
 
 reduce_or_p = standard_primitive(
     _reduce_logical_shape_rule, input_dtype, 'reduce_or',

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -75,12 +75,13 @@ from jax._src.state.types import RefEffect
 from jax._src.traceback_util import api_boundary
 from jax._src import flattree as ft
 from jax._src.tree_util import (
-    tree_flatten, tree_unflatten, tree_structure, treedef_children,
+    tree_flatten, tree_unflatten, tree_leaves, tree_structure, treedef_children,
     PyTreeDef, none_leaf_registry as none_lr, tree_map)
 from jax._src.typing import Array, ArrayLike
 from jax._src.util import (
     HashableFunction, safe_map, safe_zip, wraps, distributed_debug_log,
-    split_list, weakref_lru_cache, merge_lists, subs_list, fun_name)
+    split_list, split_list_checked, weakref_lru_cache, merge_lists, subs_list,
+    fun_name)
 from jax._src.lib import jax_jit
 
 map, unsafe_map = safe_map, map
@@ -1066,7 +1067,7 @@ def _resolve_in_shardings(args, pjit_in_shardings: Sequence[PjitSharding]
     return pjit_in_shardings
 
   resolved_in_shardings: list[PjitSharding] = []
-  for arg, pjit_in_s in zip(args, pjit_in_shardings):
+  for i, (arg, pjit_in_s) in enumerate(zip(args, pjit_in_shardings)):
     # arg sharding can be None in case of ShapeDtypeStruct. jax.Array does
     # not allow None as the sharding.
     arg_s, committed = ((arg.sharding, arg.committed) if arg.sharding is not None
@@ -1611,78 +1612,88 @@ ad.primitive_jvps[jit_p] = _pjit_jvp
 def _pjit_linearize(is_vjp, nzs, *primals_in, jaxpr, in_shardings, out_shardings,
                     in_layouts, out_layouts, donated_invars, ctx_mesh, name,
                     keep_unused, inline, compiler_options_kvs):
-  (primal_jaxpr, num_residuals_out, nzs_out, in_fwd_res,
-   tangent_jaxpr) = ad.linearize_jaxpr(jaxpr, nzs, is_vjp=is_vjp)
-  num_residuals_in = len(in_fwd_res)
-  num_primals_out = len(primal_jaxpr.out_avals) - num_residuals_out
-
-  res_shardings_in = (UNSPECIFIED,) * num_residuals_in
-  res_layouts_in = (None,) * num_residuals_in
-  res_donated = (False,) * num_residuals_in
+  fwd_jaxpr, fwd_out_tree, nzs_out, in_fwd_res, tangent_jaxpr = \
+      ad.linearize_jaxpr(jaxpr, nzs, is_vjp=is_vjp)
+  primal_out_avals, ures_out_avals, sres_out_avals = fwd_out_tree.unpack()
+  num_residuals_out = len(ures_out_avals) + len(sres_out_avals)
   primal_out_shardings = tuple(out_shardings) + (UNSPECIFIED,) * num_residuals_out
   primal_out_layouts = tuple(out_layouts) + (None,) * num_residuals_out
 
-  config.enable_checks.value and core.check_jaxpr(primal_jaxpr)
+  config.enable_checks.value and core.check_jaxpr(fwd_jaxpr)
   config.enable_checks.value and core.check_jaxpr(tangent_jaxpr)
 
   def keep_where(l, should_keep):
     return tuple(x for x, keep in zip(l, should_keep) if keep)
 
-  # Input-to-output forwarding.
-  in_fwd = pe._jaxpr_forwarding(primal_jaxpr)
-  in_fwd_primal, in_fwd_res_ = split_list(in_fwd, [num_primals_out])
-  assert all(f is None for f in in_fwd_res_)
+  # Input-to-output forwarding. Forwarded ures were already pruned by
+  # linearize_jaxpr (hence the assert); sres keep their tree structure either
+  # way, so we can forward them here and re-duplicate after the bind below.
+  in_fwd = pe._jaxpr_forwarding(fwd_jaxpr)
+  in_fwd_primal, in_fwd_ures, in_fwd_sres = \
+      split_list(in_fwd, [len(primal_out_avals), len(ures_out_avals)])
+  assert all(f is None for f in in_fwd_ures)
   in_fwd = [
       fwd if isinstance(os, UnspecifiedValue) and ol is None else None
       for os, ol, fwd in zip(out_shardings, out_layouts, in_fwd_primal)
-  ] + in_fwd_res_
-  del in_fwd_res_, in_fwd_primal
+  ] + in_fwd_ures + in_fwd_sres
+  del in_fwd_primal, in_fwd_ures, in_fwd_sres
   keep = [f is None for f in in_fwd]
-  primal_jaxpr = pe.prune_closed_jaxpr_outputs(primal_jaxpr, keep)
+  fwd_jaxpr = pe.prune_closed_jaxpr_outputs(fwd_jaxpr, keep)
   primal_out_shardings = keep_where(primal_out_shardings, keep)
   primal_out_layouts = keep_where(primal_out_layouts, keep)
-  _, kept_res = split_list(keep, [num_primals_out])
+  _, kept_res = split_list(keep, [len(primal_out_avals)])
   num_kept_residuals = sum(kept_res)
-  del keep, kept_res, num_primals_out
+  del keep, kept_res, primal_out_avals
 
-  # Output-to-output forwarding.
-  num_primals_out = len(primal_jaxpr.out_avals) - num_kept_residuals
-  out_vars, res_vars = split_list(primal_jaxpr.outvars, [num_primals_out])
+  # Output-to-output forwarding. A residual can duplicate a primal output or
+  # an earlier residual (e.g. structured residuals can carry the same value in
+  # multiple tree positions), so return one copy of each and re-duplicate
+  # after the bind below.
+  num_primals_out = len(fwd_jaxpr.out_avals) - num_kept_residuals
+  out_vars, res_vars = split_list(fwd_jaxpr.outvars, [num_primals_out])
   idx_map = {id(v): i for i, v in enumerate(out_vars)}
-  out_fwd = [None] * num_primals_out + [idx_map.get(id(v)) for v in res_vars]
+  num_kept = num_primals_out
+  out_fwd: list[int | None] = [None] * num_primals_out
+  for v in res_vars:
+    if (fwd := idx_map.get(id(v))) is None:
+      idx_map[id(v)] = num_kept
+      num_kept += 1
+    out_fwd.append(fwd)
   keep = [f is None for f in out_fwd]
-  primal_jaxpr = pe.prune_closed_jaxpr_outputs(primal_jaxpr, keep)
+  fwd_jaxpr = pe.prune_closed_jaxpr_outputs(fwd_jaxpr, keep)
   primal_out_shardings = keep_where(primal_out_shardings, keep)
   primal_out_layouts = keep_where(primal_out_layouts, keep)
   del keep
 
   tangent_avals_out = [a.to_tangent_aval() for a in jaxpr.out_avals]
 
-  def tangent_fun(residuals, *tangents):
+  def _pad(nzs, primal_stuff, filler):
+    return ((filler,) * len(in_fwd_res) + _filter_zeros(nzs, primal_stuff) +
+            (filler,) * len(sres_out_avals))
+
+  def tangent_fun(residuals, structured_residuals, *tangents):
     tangents_nz = _filter_zeros(nzs, tangents)
+    sres_flat = tree_leaves(structured_residuals)
     nz_tangents_out = jit_p.bind(
-        *residuals, *tangents_nz, jaxpr=tangent_jaxpr,
-        in_shardings=res_shardings_in + _filter_zeros(nzs, in_shardings),
+        *residuals, *tangents_nz, *sres_flat, jaxpr=tangent_jaxpr,
+        in_shardings=_pad(nzs, in_shardings, UNSPECIFIED),
+        in_layouts=_pad(nzs, in_layouts, None),
+        donated_invars=_pad(nzs, donated_invars, False),
         out_shardings=_filter_zeros(nzs_out, out_shardings),
-        in_layouts=res_layouts_in + _filter_zeros(nzs, in_layouts),
         out_layouts=_filter_zeros(nzs_out, out_layouts),
-        donated_invars=res_donated + _filter_zeros(nzs, donated_invars),
-        ctx_mesh=ctx_mesh,
-        name=name,
-        keep_unused=keep_unused,
-        inline=inline,
+        ctx_mesh=ctx_mesh, name=name, keep_unused=keep_unused, inline=inline,
         compiler_options_kvs=compiler_options_kvs)
     nz_tangents_out_ = iter(nz_tangents_out)
     tangents_out = [next(nz_tangents_out_) if nz else ad.Zero(aval)
                    for (aval, nz) in zip(tangent_avals_out, nzs_out)]
-    assert next(nz_tangents_out_, None) is None
+    assert next(nz_tangents_out_, sentinel := object()) is sentinel
     return tangents_out
 
   def _filter_zeros(is_nz_l, l):
     return tuple(x for nz, x in zip(is_nz_l, l) if nz)
 
-  assert len(in_shardings) == len(primal_jaxpr.in_avals)
-  ans = jit_p.bind(*primals_in, jaxpr=primal_jaxpr,
+  assert len(in_shardings) == len(fwd_jaxpr.in_avals)
+  ans = jit_p.bind(*primals_in, jaxpr=fwd_jaxpr,
                    in_shardings=in_shardings,
                    out_shardings=primal_out_shardings,
                    in_layouts=in_layouts,
@@ -1696,8 +1707,10 @@ def _pjit_linearize(is_vjp, nzs, *primals_in, jaxpr, in_shardings, out_shardings
   ans = subs_list(out_fwd, ans, ans)
   ans = subs_list(in_fwd, primals_in, ans)
   primal_ans, residuals_ans = split_list(ans, [len(ans) - num_residuals_out])
-  residuals_ans = subs_list(in_fwd_res, [*jaxpr.consts, *primals_in], residuals_ans)
-  return primal_ans, nzs_out, residuals_ans, tangent_fun
+  ures, sres_flat = split_list_checked(residuals_ans, [len(ures_out_avals), len(sres_out_avals)])
+  ures = subs_list(in_fwd_res, [*jaxpr.consts, *primals_in], ures)
+  sres = sres_out_avals.update(sres_flat).unflatten()
+  return primal_ans, nzs_out, ures, sres, tangent_fun
 ad.primitive_linearizations[jit_p] = _pjit_linearize
 
 
@@ -2385,12 +2398,12 @@ def _reshard_linearize(is_vjp, nzs, x, *, dst_sharding, concrete_mesh):
   primal_out = reshard_p.bind(x, dst_sharding=dst_sharding,
                               concrete_mesh=concrete_mesh)
 
-  def linearized(residuals, tangent):
+  def linearized(residuals, _, tangent):
     assert not residuals
     return (reshard_p.bind(tangent, dst_sharding=dst_sharding,
                            concrete_mesh=concrete_mesh)
             if nz else ad.p2tz(tangent))
-  return primal_out, nz, (), linearized
+  return primal_out, nz, (), None, linearized
 ad.primitive_linearizations[reshard_p] = _reshard_linearize
 
 def _reshard_transpose_fancy(ct, x, *, dst_sharding, concrete_mesh):

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -18,6 +18,7 @@ import enum
 from functools import partial
 import inspect
 from math import prod
+import itertools as it
 import operator as op
 from typing import Any, TypeVar, Union, cast, overload
 
@@ -1751,19 +1752,33 @@ def _shard_map_linearize(trace, shard_map_p, f: Callable,
   all_names = _all_newly_manual_mesh_names(mesh, newly_manual_axes)
 
   def f_lin(*primals):
-    res, ans_aux, lin_data = ad.linearize_subtrace_2(
+    ans_aux, res, lin_data = ad.linearize_subtrace_2(
       f, trace.is_vjp, trace.tag, nzs_in, debug_info, primals)
     primals_out, out_specs = ans_aux.unpack_aux()
-
-    res_avals, _, _, _, in_fwd, out_fwd = lin_data
-    res_avals = [r for r, f1, f2 in zip(res_avals, in_fwd, out_fwd)
-                 if f1 is None and f2 is None]
-    res_specs = [a.nospec(mesh, check_vma, all_names) for a in res_avals]
-    new_out_specs = (*res_specs, *out_specs)
-    res = [lax.broadcast(x, (1,)) if not getattr(x, 'shape', ()) else x
-           for x in res]
-    res_and_primal = ft.pack((ft.flatten(res), primals_out))
-    return res_and_primal.with_aux((lin_data, out_specs)).with_aux(new_out_specs)
+    ures, sres = res.unpack()
+    # De-duplicate structured residuals by object id: an sres leaf that is
+    # already a primal output, a ures output, or an earlier sres leaf isn't
+    # returned again. Each leaf records an index into the flat outputs
+    # [*primals_out, *ures, *kept_sres]; re-duplication happens outside the
+    # bind below.
+    idx_map = {id(x): i for i, x in enumerate((*primals_out, *ures))}
+    n_out = len(primals_out) + len(ures)
+    kept, keep, sres_fwd = [], [], []
+    for x in sres:
+      idx = idx_map.get(id(x))
+      keep.append(idx is None)
+      if idx is None:
+        idx = idx_map[id(x)] = n_out + len(kept)
+        kept.append(x)
+      sres_fwd.append(idx)
+    _, res_avals = lin_data[0].unpack()
+    ures_avals, sres_avals = res_avals.unpack()
+    nospec = lambda a: a.nospec(mesh, check_vma, all_names)
+    new_out_specs = (*out_specs, *ures_avals.map(nospec),
+                     *(nospec(a) for a, k in zip(sres_avals, keep) if k))
+    promote = lambda x: lax.broadcast(x, (1,)) if getattr(x, 'shape', None) == () else x
+    outs = ft.pack((primals_out, ures.map(promote), ft.flatten(kept).map(promote)))
+    return outs.with_aux((lin_data, out_specs, tuple(sres_fwd))).with_aux(new_out_specs)
 
   fwd_params = dict(
       mesh=mesh, in_specs=in_specs,
@@ -1771,26 +1786,35 @@ def _shard_map_linearize(trace, shard_map_p, f: Callable,
   avals = [typeof(x) for x in primals]
   all_results_aux = shard_map_p.bind_with_trace(
       trace.parent_trace, tuple(primals), avals, dict(fwd_params, subfuns=(f_lin,)))
-  all_results, (lin_data, out_specs) = all_results_aux.unpack_aux()
-  res_avals, nzs_out, lin_jaxpr, env, in_fwd, out_fwd = lin_data
-  non_fwd_res, primals_out = all_results.unpack()
-  residuals = subs_list2(in_fwd, out_fwd, primals, (*primals_out,), non_fwd_res)
-  args_to_promote = [getattr(aval, 'shape', ()) == () and f1 is None and f2 is None
-                     for aval, f1, f2 in zip(res_avals, in_fwd, out_fwd)]
+  all_results, (lin_data, out_specs, sres_fwd) = all_results_aux.unpack_aux()
+  fwd_out_ty, nzs_out, lin_jaxpr, env, in_fwd, out_fwd = lin_data
+  primals_out, non_fwd_ures, kept_sres = all_results.unpack()
+  ures = subs_list2(in_fwd, out_fwd, primals, (*primals_out,), non_fwd_ures)
+  primal_out_avals, res_avals = fwd_out_ty.unpack()
+  ures_avals_nonfwd, sres_avals = res_avals.unpack()
+  ures_avals = subs_list2(in_fwd, out_fwd, avals, (*primal_out_avals,), ures_avals_nonfwd)
+  ures_to_promote = [getattr(a, 'shape', None) == ()
+                     and f1 is None and f2 is None
+                     for a, f1, f2 in zip(ures_avals, in_fwd, out_fwd)]
+  sres_to_promote = [getattr(a, 'shape', None) == () and w >= len(primals_out)
+                     for a, w in zip(sres_avals, sres_fwd)]
+  args_to_promote = ures_to_promote + [False] * (len(env) + sum(nzs_in)) + sres_to_promote
   with (_extend_axis_env(mesh, newly_manual_axes),
         use_abstract_mesh(_as_manual_mesh(mesh, newly_manual_axes)),
         config._check_vma(check_vma)):
     lin_jaxpr = _promote_scalar_residuals_jaxpr(lin_jaxpr, args_to_promote)
-  res_avals2 = [r for r, f1, f2 in zip(res_avals, in_fwd, out_fwd)
-                if f1 is None and f2 is None]
-  res_avals_iter = iter(res_avals2)
-  res_specs = [in_specs[f1] if f1 is not None else out_specs[f2] if f2 is not None
-               else next(res_avals_iter).nospec(mesh, check_vma, all_names)
+  ures_avals_iter = iter(ures_avals_nonfwd)
+  ures_specs = [in_specs[f1] if f1 is not None else out_specs[f2] if f2 is not None
+               else next(ures_avals_iter).nospec(mesh, check_vma, all_names)
                for f1, f2 in zip(in_fwd, out_fwd)]
-  assert next(res_avals_iter, None) is None
+  assert next(ures_avals_iter, sentinel := object()) is sentinel
   env_specs = [_repspec(typeof(e)) for e in env]
-  new_in_specs = (*res_specs, *env_specs,
-                  *(s.to_tangent_spec() for s, nz in zip(in_specs, nzs_in) if nz))
+  sres_specs = [out_specs[w] if w < len(primals_out)
+                else a.nospec(mesh, check_vma, all_names)
+                for a, w in zip(sres_avals, sres_fwd)]
+  new_in_specs = (*ures_specs, *env_specs,
+                  *(s.to_tangent_spec() for s, nz in zip(in_specs, nzs_in) if nz),
+                  *sres_specs)
   tangent_out_specs = tuple(s.to_tangent_spec() for s, nz in zip(out_specs, nzs_out) if nz)
   tangent_params = dict(
       mesh=mesh, in_specs=new_in_specs,
@@ -1802,11 +1826,21 @@ def _shard_map_linearize(trace, shard_map_p, f: Callable,
     ans = core.eval_jaxpr(lin_jaxpr, (), *args)
     return ft.flatten(ans).with_aux(tangent_out_specs)
 
+  # Re-duplicate the forwarded structured residuals, restore their tree
+  # structure, and hand them to the outer trace's structured-residuals
+  # channel, binding the tangent shard_map on fresh tangent-trace args for
+  # them (one per tree position, like LinearizeTrace.process_primitive).
+  outs_flat = [*primals_out, *non_fwd_ures, *kept_sres]
+  sres_tree = sres_avals.update(outs_flat[w] for w in sres_fwd).unflatten()
+  trace.structured_residuals.append(sres_tree)
+  new_arg = lambda x: trace.tangent_trace.new_arg(typeof(x),
+                                                  source_info_util.current())
+  sres_binders = tree_leaves(tree_map(new_arg, sres_tree))
+
   nz_tangents_in = [t for (t, nz) in zip(tangents, nzs_in) if nz]
-  args = (*residuals, *env, *nz_tangents_in)
-  avals = [typeof(x) for x in args]
+  args = (*ures, *env, *nz_tangents_in, *sres_binders)
   nz_tangents_out = shard_map_p.bind_with_trace(
-      trace.tangent_trace, args, avals,
+      trace.tangent_trace, args, map(typeof, args),
       dict(tangent_params, subfuns=(f_tangent,)))
   nz_tangents_out_iter = iter(nz_tangents_out)
   tangents_out = [next(nz_tangents_out_iter) if nz else ad.p2tz(primal)
@@ -1882,13 +1916,14 @@ remat.RematTrace.process_shard_map = _shard_map_remat
 
 
 def _promote_scalar_residuals_jaxpr(jaxpr: core.Jaxpr, which: Sequence[bool]):
-  def fun(*res_and_args):
-    res, args = split_list(res_and_args, [len(jaxpr.constvars)])
-    res = [_rem_singleton(x) if w else x for x, w in zip(res, which)]
-    return core.eval_jaxpr(jaxpr, res, *args)
+  which = list(which) + [False] * (len(jaxpr.constvars) + len(jaxpr.invars) - len(which))
+  def fun(*args):
+    args = [_rem_singleton(x) if w else x for x, w in zip(args, which)]
+    consts, args = split_list(args, [len(jaxpr.constvars)])
+    return core.eval_jaxpr(jaxpr, consts, *args)
   res_avals = [core.unmapped_aval(1, 0, v.aval) if w else v.aval
-               for v, w in zip(jaxpr.constvars, which)]
-  in_avals = ft.flatten(((*res_avals, *[v.aval for v in jaxpr.invars]), {}))
+               for v, w in zip(it.chain(jaxpr.constvars, jaxpr.invars), which)]
+  in_avals = ft.flatten(((*res_avals,), {}))
   closed_jaxpr, _ = pe.trace_to_jaxpr(fun, in_avals, debug_info=jaxpr.debug_info)
   closed_jaxpr, _ = pe.separate_consts(closed_jaxpr)
   return closed_jaxpr

--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -1114,13 +1114,13 @@ def _ref_jvp(primals, tangents, *, memory_space, kind):
 def _ref_lin(_is_vjp, nzs, x, *, memory_space, kind):
   nz, = nzs
   x_ref = core.ref_p.bind(x, memory_space=memory_space, kind=kind)
-  def mut_lin(_, x_dot):
+  def mut_lin(_, __, x_dot):
     if kind == 'no_grad_no_remat':
       aval = x_dot.aval if type(x_dot) is ad.Zero else core.typeof(x_dot)
       return ad.Zero(AbstractRef(aval))
     zero = ad_util.instantiate(x_dot)
     return core.ref_p.bind(zero, memory_space=memory_space, kind=kind)
-  return x_ref, kind != 'no_grad_no_remat', None, mut_lin
+  return x_ref, kind != 'no_grad_no_remat', None, None, mut_lin
 
 ad.primitive_jvps[core.ref_p] = _ref_jvp
 ad.primitive_linearizations[core.ref_p] = _ref_lin
@@ -1138,10 +1138,10 @@ ad.primitive_jvps[core.empty_ref_p] = _empty_ref_jvp
 
 def _empty_ref_lin(_is_vjp, nzs_in, *, ty, memory_space):
   primal_ref = core.empty_ref_p.bind(ty=ty, memory_space=memory_space)
-  def lin(_):
+  def lin(_, __):
     return core.empty_ref_p.bind(ty=ty.to_tangent_aval(),
                                  memory_space=memory_space)
-  return primal_ref, True, None, lin
+  return primal_ref, True, None, None, lin
 ad.primitive_linearizations[core.empty_ref_p] = _empty_ref_lin
 
 def _free_ref_jvp(primals, tangents):

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -196,8 +196,7 @@ def merge_lists(bs: Sequence[bool], l0: Sequence[T1], l1: Sequence[T2]
   assert sum(bs) == len(l1) and len(bs) - sum(bs) == len(l0)
   i0, i1 = iter(l0), iter(l1)
   out: list[T1 | T2] = [next(i1) if b else next(i0) for b in bs]
-  sentinel = object()
-  assert next(i0, sentinel) is next(i1, sentinel) is sentinel
+  assert next(i0, sentinel := object()) is next(i1, sentinel) is sentinel
   return out
 
 def subs_list(
@@ -205,8 +204,7 @@ def subs_list(
 ) -> list[T]:
   base_ = iter(base)
   out = [src[i] if i is not None else next(base_) for i in subs]
-  sentinel = object()
-  assert next(base_, sentinel) is sentinel
+  assert next(base_, sentinel := object()) is sentinel
   return out
 
 def subs_list2(
@@ -217,8 +215,7 @@ def subs_list2(
   base_ = iter(base)
   out = [src1[f1] if f1 is not None else src2[f2] if f2 is not None else
          next(base_) for f1, f2, in zip(subs1, subs2)]
-  sentinel = object()
-  assert next(base_, sentinel) is sentinel
+  assert next(base_, sentinel := object()) is sentinel
   return out
 
 def concatenate(xs: Iterable[Sequence[T]]) -> list[T]:

--- a/jax/_src/xla_metadata.py
+++ b/jax/_src/xla_metadata.py
@@ -28,7 +28,7 @@ from jax._src.interpreters import ad, batching, mlir, partial_eval as pe
 from jax._src.lib import _jax
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import func as func_dialect
-from jax._src.tree_util import tree_flatten, tree_unflatten
+from jax._src.tree_util import tree_flatten, tree_leaves, tree_unflatten
 from jax._src.util import (safe_map, safe_zip, weakref_lru_cache, unzip2,
                            split_list, subs_list)
 
@@ -364,8 +364,10 @@ ad.primitive_jvps[xla_metadata_call_p] = _xla_metadata_call_jvp
 
 def _xla_metadata_call_lin(is_vjp, nzs, *primals, jaxpr, xla_metadata,
                            ad_metadata):
-  (primal_jaxpr, num_residuals_out, nzs_out, in_fwd_res,
-   tangent_jaxpr) = ad.linearize_jaxpr(jaxpr, nzs, is_vjp=is_vjp)
+  primal_jaxpr, out_tree, nzs_out, in_fwd_res, tangent_jaxpr = \
+      ad.linearize_jaxpr(jaxpr, nzs, is_vjp=is_vjp)
+  _, ures_avals, sres_avals = out_tree.unpack()
+  num_residuals_out = len(ures_avals) + len(sres_avals)
 
   tangent_avals_out = [a.to_tangent_aval() for a in jaxpr.out_avals]
   tangent_metadata = _resolve_ad_metadata(xla_metadata, ad_metadata)
@@ -373,11 +375,14 @@ def _xla_metadata_call_lin(is_vjp, nzs, *primals, jaxpr, xla_metadata,
   def _filter_zeros(is_nz_l, l):
     return tuple(x for nz, x in zip(is_nz_l, l) if nz)
 
-  def tangent_fun(residuals, *tangents):
+  def tangent_fun(residuals, structured_residuals, *tangents):
     tangents_nz = _filter_zeros(nzs, tangents)
-    assert len(residuals) + len(tangents_nz) == len(tangent_jaxpr.invars), (
-        len(residuals), len(tangents_nz), len(tangent_jaxpr.invars))
-    nz_outs = xla_metadata_call_p.bind(*residuals, *tangents_nz,
+    sres_flat = tree_leaves(structured_residuals)
+    assert (len(residuals) + len(tangents_nz) + len(sres_flat)
+            == len(tangent_jaxpr.invars)), (
+        len(residuals), len(tangents_nz), len(sres_flat),
+        len(tangent_jaxpr.invars))
+    nz_outs = xla_metadata_call_p.bind(*residuals, *tangents_nz, *sres_flat,
                                        jaxpr=tangent_jaxpr,
                                        xla_metadata=tangent_metadata,
                                        ad_metadata='same')
@@ -391,8 +396,10 @@ def _xla_metadata_call_lin(is_vjp, nzs, *primals, jaxpr, xla_metadata,
                                  xla_metadata=xla_metadata,
                                  ad_metadata=ad_metadata)
   primal_ans, residuals_ans = split_list(ans, [len(ans) - num_residuals_out])
-  residuals_ans = subs_list(in_fwd_res, [*jaxpr.consts, *primals], residuals_ans)
-  return primal_ans, nzs_out, residuals_ans, tangent_fun
+  ures, sres_flat = split_list(residuals_ans, [len(ures_avals)])
+  ures = subs_list(in_fwd_res, [*jaxpr.consts, *primals], ures)
+  sres = sres_avals.update(sres_flat).unflatten()
+  return primal_ans, nzs_out, ures, sres, tangent_fun
 ad.primitive_linearizations[xla_metadata_call_p] = _xla_metadata_call_lin
 
 

--- a/jax/experimental/fused.py
+++ b/jax/experimental/fused.py
@@ -113,7 +113,7 @@ def _fused_lin(_is_vjp, nzs, *primals, jaxpr, out_spaces):
   primals_out = fused_p.bind(*primals, jaxpr=jaxpr, out_spaces=out_spaces)
   tangent_avals_out = [a.to_tangent_aval() for a in jaxpr.out_avals]
 
-  def fused_lin(primals, *tangents):
+  def fused_lin(primals, _, *tangents):
     nz_tangents = [t for t in tangents if not isinstance(t, ad.Zero)]
     inputs = [x for x, u in zip([*primals, *nz_tangents], used_inputs) if u]
     nz_outs = fused_p.bind(*inputs, jaxpr=jaxpr_lin, out_spaces=spaces_lin)
@@ -123,7 +123,7 @@ def _fused_lin(_is_vjp, nzs, *primals, jaxpr, out_spaces):
     assert next(nz_outs_, None) is None
     return outs
 
-  return primals_out, out_nzs, primals, fused_lin
+  return primals_out, out_nzs, primals, None, fused_lin
 ad.primitive_linearizations[fused_p] = _fused_lin
 
 def _fused_transpose(cts_in, *primals_in, jaxpr, out_spaces):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -5288,7 +5288,8 @@ class APITest(jtu.JaxTestCase):
   def test_deferred_primal_with_direct_linearize(self):
     def my_sin_lin(_is_vjp, nzs, x):
       nz, = nzs
-      return (my_sin_p.bind(x, accuracy=None), nz, x, lambda x, t: lax.mul(t, lax.cos(x)))
+      return (my_sin_p.bind(x, accuracy=None), nz, x, None,
+              lambda x, _, t: lax.mul(t, lax.cos(x)))
 
     my_sin_p = core.Primitive("my_sin_p")
     my_sin_p.def_impl(lax.sin)
@@ -5297,6 +5298,174 @@ class APITest(jtu.JaxTestCase):
 
     with config.use_direct_linearize(True):
       jax.grad(my_sin_p.bind)(1.0)  # doesn't crash
+
+  def test_structured_residuals_deduped_by_jit(self):
+    # Structured residuals can refer to the same value in multiple tree
+    # positions. The jit fwd call should return one copy of each value, then
+    # re-duplicate to restore the tree structure.
+    def my_sin_lin(_is_vjp, nzs, x):
+      nz, = nzs
+      c = lax.cos(x)
+      return (my_sin_p.bind(x), nz, (), {'a': c, 'b': c},
+              lambda _, sres, t: lax.mul(t, sres['b']))
+
+    my_sin_p = core.Primitive("my_sin_p")
+    my_sin_p.def_impl(lax.sin)
+    my_sin_p.def_abstract_eval(lambda x: x)
+    mlir.register_lowering(my_sin_p,
+                           mlir.lower_fun(lax.sin, multiple_results=False))
+    ad_internal.primitive_linearizations[my_sin_p] = my_sin_lin
+
+    f = jax.jit(my_sin_p.bind)
+    with config.use_direct_linearize(True):
+      y, f_vjp = jax.vjp(f, 1.0)
+      x_ct, = f_vjp(1.0)
+      self.assertAllClose(y, jnp.sin(1.0))
+      self.assertAllClose(x_ct, jnp.cos(1.0))
+      leaves = jax.tree.leaves(f_vjp.structured_residuals)
+      self.assertLen(leaves, 2)
+      self.assertIs(leaves[0], leaves[1])
+
+      jaxpr = jax.make_jaxpr(lambda x: jax.vjp(f, x)[1](1.0))(1.0)
+      fwd_eqn = next(e for e in jaxpr.eqns if e.primitive.name == 'jit')
+      self.assertLen(fwd_eqn.outvars, 2)  # primal out and one copy of cos
+
+  def test_structured_residuals_deduped_by_scan(self):
+    # Like test_structured_residuals_deduped_by_jit, but for scan: one stacked
+    # copy of each residual comes out of the scan, then the tree structure is
+    # restored by re-duplication.
+    def my_sin_lin(_is_vjp, nzs, x):
+      nz, = nzs
+      c = lax.cos(x)
+      return (my_sin_p.bind(x), nz, (), {'a': c, 'b': c},
+              lambda _, sres, t: lax.mul(t, sres['b']))
+
+    my_sin_p = core.Primitive("my_sin_p")
+    my_sin_p.def_impl(lax.sin)
+    my_sin_p.def_abstract_eval(lambda x: x)
+    mlir.register_lowering(my_sin_p,
+                           mlir.lower_fun(lax.sin, multiple_results=False))
+    ad_internal.primitive_linearizations[my_sin_p] = my_sin_lin
+
+    def f(xs):
+      def body(c, x):
+        y = my_sin_p.bind(x)
+        return c + y, y * 2.
+      c_out, ys = jax.lax.scan(body, 0., xs)
+      return c_out + ys.sum()
+
+    xs = jnp.arange(1., 4.)
+    with config.use_direct_linearize(True):
+      _, f_vjp = jax.vjp(f, xs)
+      x_ct, = f_vjp(1.0)
+      self.assertAllClose(x_ct, 3 * jnp.cos(xs))
+      leaves = jax.tree.leaves(f_vjp.structured_residuals)
+      self.assertLen(leaves, 2)
+      self.assertIs(leaves[0], leaves[1])
+      self.assertEqual(leaves[0].shape, xs.shape)  # stacked
+
+      jaxpr = jax.make_jaxpr(lambda xs: jax.vjp(f, xs)[1](1.0))(xs)
+      fwd_eqn = next(e for e in jaxpr.eqns if e.primitive.name == 'scan')
+      self.assertLen(fwd_eqn.outvars, 3)  # carry, ys, one stacked copy of cos
+
+  def test_structured_residuals_deduped_by_shard_map(self):
+    # Like test_structured_residuals_deduped_by_jit, but for shard_map: an
+    # sres leaf can forward to a primal output (with the primal's out_spec), a
+    # ures output, or an earlier sres leaf.
+    def my_sin_lin(_is_vjp, nzs, x):
+      nz, = nzs
+      c = lax.cos(x)
+      return (my_sin_p.bind(x), nz, (), {'a': c, 'b': c},
+              lambda _, sres, t: lax.mul(t, sres['b']))
+
+    my_sin_p = core.Primitive("my_sin_p")
+    my_sin_p.def_impl(lax.sin)
+    my_sin_p.def_abstract_eval(lambda x: x)
+    mlir.register_lowering(my_sin_p,
+                           mlir.lower_fun(lax.sin, multiple_results=False))
+    ad_internal.primitive_linearizations[my_sin_p] = my_sin_lin
+
+    mesh = jax.sharding.Mesh(np.array(jax.devices()[:1]), ('i',))
+    g = jax.shard_map(my_sin_p.bind, mesh=mesh, in_specs=P('i'),
+                      out_specs=P('i'))
+    f = lambda xs: g(xs).sum()
+
+    xs = jnp.arange(1., 5.)
+    with config.use_direct_linearize(True):
+      _, f_vjp = jax.vjp(f, xs)
+      x_ct, = f_vjp(1.0)
+      self.assertAllClose(x_ct, jnp.cos(xs))
+
+      # the sres tree structure propagates out of the shard_map, with the
+      # duplicated pair re-duplicated to the same object
+      leaves = jax.tree.leaves(f_vjp.structured_residuals)
+      self.assertLen(leaves, 2)
+      self.assertIs(leaves[0], leaves[1])
+
+      # the fwd shard_map returns the primal and one copy of cos
+      jaxpr = jax.make_jaxpr(lambda x: jax.vjp(f, x)[1](1.0))(xs)
+      fwd_eqn = next(e for e in jaxpr.eqns if e.primitive.name == 'shard_map')
+      self.assertLen(fwd_eqn.outvars, 2)
+
+  def test_structured_residuals_input_forwarded_by_jit(self):
+    # An sres leaf that is a forwarded input shouldn't be returned from the
+    # jit fwd call; it's restored from the caller's argument.
+    def my_sin_lin(_is_vjp, nzs, x):
+      nz, = nzs
+      return (my_sin_p.bind(x), nz, (), {'x': x},
+              lambda _, sres, t: lax.mul(t, lax.cos(sres['x'])))
+
+    my_sin_p = core.Primitive("my_sin_p")
+    my_sin_p.def_impl(lax.sin)
+    my_sin_p.def_abstract_eval(lambda x: x)
+    mlir.register_lowering(my_sin_p,
+                           mlir.lower_fun(lax.sin, multiple_results=False))
+    ad_internal.primitive_linearizations[my_sin_p] = my_sin_lin
+
+    f = jax.jit(my_sin_p.bind)
+    with config.use_direct_linearize(True):
+      _, f_vjp = jax.vjp(f, 1.0)
+      x_ct, = f_vjp(1.0)
+      self.assertAllClose(x_ct, jnp.cos(1.0))
+
+      jaxpr = jax.make_jaxpr(lambda x: jax.vjp(f, x)[1](1.0))(1.0)
+      fwd_eqn = next(e for e in jaxpr.eqns if e.primitive.name == 'jit')
+      self.assertLen(fwd_eqn.outvars, 1)  # just the primal; x is forwarded
+
+  def test_structured_residuals_input_forwarded_by_scan(self):
+    # An sres leaf that is a forwarded xs element has stacked value equal to
+    # the whole xs argument, so the scan needn't return it; it's restored from
+    # the caller's argument. (Consts and carries can't be forwarded this way.)
+    def my_sin_lin(_is_vjp, nzs, x):
+      nz, = nzs
+      return (my_sin_p.bind(x), nz, (), {'x': x},
+              lambda _, sres, t: lax.mul(t, lax.cos(sres['x'])))
+
+    my_sin_p = core.Primitive("my_sin_p")
+    my_sin_p.def_impl(lax.sin)
+    my_sin_p.def_abstract_eval(lambda x: x)
+    mlir.register_lowering(my_sin_p,
+                           mlir.lower_fun(lax.sin, multiple_results=False))
+    ad_internal.primitive_linearizations[my_sin_p] = my_sin_lin
+
+    def f(xs):
+      def body(c, x):
+        return c + my_sin_p.bind(x), c
+      c_out, ys = jax.lax.scan(body, 0., xs)
+      return c_out
+
+    xs = jnp.arange(1., 4.)
+    with config.use_direct_linearize(True):
+      _, f_vjp = jax.vjp(f, xs)
+      x_ct, = f_vjp(1.0)
+      self.assertAllClose(x_ct, jnp.cos(xs))
+      leaf, = jax.tree.leaves(f_vjp.structured_residuals)
+      self.assertIs(leaf, xs)  # the xs argument itself, not a stacked copy
+
+      jaxpr = jax.make_jaxpr(lambda x: jax.vjp(f, x)[1](1.0))(xs)
+      fwd_eqn = next(e for e in jaxpr.eqns if e.primitive.name == 'scan')
+      # carry out and ys only; the stacked x residual is forwarded
+      self.assertLen(fwd_eqn.outvars, 2)
 
   def test_ensure_compile_time_eval_no_leaks(self):
     # https://github.com/jax-ml/jax/issues/25847

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -1605,6 +1605,75 @@ class HijaxTest(jtu.JaxTestCase):
     self.assertAllClose(jax.jit(jax.grad(sin))(2.0), jnp.cos(2.0))
     self.assertAllClose(jax.grad(jax.grad(sin))(2.0), -jnp.sin(2.0))
 
+  def test_structured_residuals(self):
+    # `lin` and `vjp_fwd` may return a fourth element, structured residuals,
+    # in which case `linearized` and `vjp_bwd` receive them as an extra
+    # argument after the (unstructured) residuals.
+    class Square(VJPHiPrimitive):
+      def __init__(self, in_aval):
+        self.in_avals = (in_aval,)
+        self.out_aval = in_aval
+        self.params = {}
+        super().__init__()
+
+      def expand(self, x):
+        return x ** 2
+
+      def lin(self, nzs_in, x):
+        return self(x), (), True, {'x1': x, 'x2': x}
+
+      def linearized(self, res, sres, t):
+        return t * 2.0 * sres['x2']
+
+      def vjp_fwd(self, nzs_in, x):
+        return self(x), (), True, {'x1': x, 'x2': x}
+
+      def vjp_bwd(self, res, sres, t, x_accum):
+        if isinstance(x_accum, ad.GradAccum):
+          x_accum.accum(t * 2.0 * sres['x1'])
+
+    def square(x):
+      return Square(jax.typeof(x))(x)
+
+    self.assertAllClose(jax.grad(square)(3.0), 6.0)
+    y, f_lin = jax.linearize(square, 3.0)
+    self.assertAllClose(y, 9.0)
+    self.assertAllClose(f_lin(1.0), 6.0)
+
+    # the sres tree is user-visible, with duplicate positions re-duplicated
+    _, f_vjp = jax.vjp(square, 3.0)
+    leaves = jax.tree.leaves(f_vjp.structured_residuals)
+    self.assertLen(leaves, 2)
+    self.assertIs(leaves[0], leaves[1])
+
+    # under jit, both sres leaves are the input, so input forwarding plus
+    # de-duplication leave the fwd call returning only the primal
+    fj = jax.jit(square)
+    self.assertAllClose(jax.grad(fj)(3.0), 6.0)
+    jaxpr = jax.make_jaxpr(lambda x: jax.vjp(fj, x)[1](1.0))(3.0)
+    fwd_eqn = next(e for e in jaxpr.eqns if e.primitive.name == 'jit')
+    self.assertLen(fwd_eqn.outvars, 1)
+
+  def test_structured_residuals_require_vjp_bwd_override(self):
+    class Bad(VJPHiPrimitive):
+      def __init__(self, in_aval):
+        self.in_avals = (in_aval,)
+        self.out_aval = in_aval
+        self.params = {}
+        super().__init__()
+
+      def expand(self, x):
+        return x ** 2
+
+      def vjp_fwd(self, nzs_in, x):
+        return self(x), (), True, {'x': x}
+
+      def vjp_bwd_retval(self, res, t):
+        return (t,)
+
+    with self.assertRaisesRegex(TypeError, "structured residuals"):
+      jax.grad(lambda x: Bad(jax.typeof(x))(x))(3.0)
+
   def test_jvp_derived_from_lin(self):
     class RaiseToStaticPower(VJPHiPrimitive):
       def __init__(self, in_aval, *, power):


### PR DESCRIPTION
This PR adds a second channel for linearization residuals: alongside the flat list of unstructured residuals, a primitive's linearization rule can produce *structured residuals*: an arbitrary pytree that is threaded through linearize/vjp with its tree structure, including aliasing between leaves, preserved.

Linearization rules now return a 5-tuple `(primal_out, nzs_out, residuals, structured_residuals, tangent_fun)`, where `structured_residuals` is a pytree (or `None`), and `tangent_fun(residuals, structured_residuals, *tangents)` receives it as a new second argument.

Why a separate channel? The pre-existing unstructured residuals are materialized as the tangent jaxpr's closed-over constants, which tracing dedupes by object identity. The flat channel can't contain duplicates, and residuals that are merely forwarded inputs are pruned centrally in `linearize_jaxpr`. That's efficient but shapeless: rules get back a flat list.

Structured residuals instead keep a pytree whose shape is part of the contract, so the same object (by id) can legitimately appear at multiple leaves, whether within one rule's tree or across rules.

A tradeoff is that structured residuals are a bit harder to optimize, especially in the sense of the de-duping described above. As a partial optimization, aliases produced by AD are preserved by identity rather than materialized as numerically-equal copies: trivially at top level (where linearization runs eagerly, so aliased leaves are the same concrete array), and across `jit`, `scan`, and `shard_map`, whose rules emit a single fwd output per distinct object (including objects that alias a primal output, an earlier residual, or (under `jit` and `scan`) a forwarded input) and re-duplicate after the call, restoring the same array object at each aliased position. The `cond` rule doesn't yet do this, and it looked like it might be a bit complicated, so aliasing within a branch materializes as copies across a `cond` boundary; a static re-duplication map there can only honor aliasing common to all branches, since the joined fwd-output layout is shared across branches.

Main pieces:

* AD internals: `ad.linearize` / `ad.linearize_jaxpr` return structured residuals alongside the unstructured ones. In `jax.linearize`, structured residuals are passed to the linearized jaxpr as arguments at tangent-application time rather than closed over as consts.

* `jax.vjp`: the returned `VJP` object carries a user-visible `structured_residuals` field alongside `opaque_residuals`.

* Higher-order primitive rules (jit/pjit, scan, cond, shard_map, compute_on, xla_metadata_call, fused) thread structured residuals through their bodies, with the dedup/forwarding optimization above for jit, scan, and shard_map.  The cond rule also uses the channel itself, stashing the branch index alongside the per-branch residual trees in its structured residuals.

* Hijax: user-defined `VJPHiPrimitive`s can target the structured channel.  `lin` / `vjp_fwd` may return a fourth element (the structured residuals pytree), in which case `linearized(res, sres, *tangents)` and `vjp_bwd(res, sres, ct, *accums)` receive it after the unstructured residuals. Returning structured residuals from `vjp_fwd` without overriding `vjp_bwd` is an error.

* Mechanical 5-tuple updates to the remaining linearization rules (`reduce_or`, state primitives), plus small cleanups in `util.py`.

Tests cover the vjp/linearize surface, dedup and input-forwarding under jit, scan, and shard_map, and the hijax user-facing API.