### PR TITLE
[JAX:GPU][oneAPI]: Add OneAPI CI test scripts and infrastructure

### DIFF
--- a/build/parallel_accelerator_execute.sh
+++ b/build/parallel_accelerator_execute.sh
@@ -59,7 +59,8 @@ TEST_BINARY="$(rlocation $TEST_WORKSPACE/${1#./})"
 shift
 # *******************************************************************
 
-mkdir -p /var/lock
+JAX_LOCK_DIR="${JAX_LOCK_DIR:-/tmp/jax_accelerator_locks_${USER:-shared}}"
+mkdir -p "$JAX_LOCK_DIR"
 # Try to acquire any of the JAX_ACCELERATOR_COUNT * JAX_TESTS_PER_ACCELERATOR
 # slots to run a test at.
 #
@@ -67,7 +68,7 @@ mkdir -p /var/lock
 # So, we iterate over JAX_TESTS_PER_ACCELERATOR first.
 for j in `seq 0 $((JAX_TESTS_PER_ACCELERATOR-1))`; do
   for i in `seq 0 $((JAX_ACCELERATOR_COUNT-1))`; do
-    exec {lock_fd}>/var/lock/jax_accelerator_lock_${i}_${j} || exit 1
+    exec {lock_fd}>"$JAX_LOCK_DIR/jax_accelerator_lock_${i}_${j}" || exit 1
     if flock -n "$lock_fd";
     then
       (
@@ -76,6 +77,7 @@ for j in `seq 0 $((JAX_TESTS_PER_ACCELERATOR-1))`; do
         export TPU_VISIBLE_CHIPS=$i
         export CUDA_VISIBLE_DEVICES=$i
         export ROCR_VISIBLE_DEVICES=$i
+        export ONEAPI_VISIBLE_DEVICES=$i
         echo "Running test $TEST_BINARY $* on accelerator $i"
         "$TEST_BINARY" $@
       )

--- a/ci/run_bazel_test_oneapi.sh
+++ b/ci/run_bazel_test_oneapi.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Run Bazel GPU tests without RBE. This runs two commands: single accelerator
+# tests with one GPU a piece, multiaccelerator tests with all GPUS.
+# If $JAXCI_BUILD_JAXLIB=false, the job requires that jaxlib, jax-oneapi-plugin,
+# and jax-oneapi-pjrt wheels are stored inside the ../dist folder
+#
+# -e: abort script if one command fails
+# -u: error if undefined variable used
+# -x: log all commands
+# -o history: record shell history
+# -o allexport: export all functions and variables to be available to subscripts
+set -exu -o history -o allexport
+
+# Source default JAXCI environment variables.
+source ci/envs/default.env
+
+# Set up the build environment.
+source "ci/utilities/setup_build_environment.sh"
+
+# Run Bazel GPU tests (single accelerator and multiaccelerator tests) directly
+# on the VM without RBE.
+echo "Running single accelerator tests (without RBE)..."
+
+# ==============================================================================
+# Detect OneAPI GPU count
+# ==============================================================================
+detect_oneapi_gpus() {
+  if command -v xpu-smi &> /dev/null; then
+    local count=$(xpu-smi discovery 2>/dev/null | grep -c "Device Name")
+    echo $count
+  else
+    echo 0
+  fi
+}
+
+# ==============================================================================
+# Set up test environment variables
+# ==============================================================================
+export gpu_count=$(detect_oneapi_gpus)
+if [[ $gpu_count -eq 0 ]]; then
+  echo "ERROR: No OneAPI GPUs detected, exiting"
+  exit 1
+fi
+
+export max_tests_per_gpu=8
+if command -v xpu-smi &> /dev/null; then
+  gpu_memory_gb=$(xpu-smi discovery --dump 16 | grep -v "Memory\|^$" | awk '{print int($1/1024+0.5)}' | head -1)
+  gpu_memory_gb="${gpu_memory_gb:-16}"
+  export max_tests_per_gpu=$((gpu_memory_gb / 2))
+  [[ $max_tests_per_gpu -lt 4 ]] && export max_tests_per_gpu=4
+  [[ $max_tests_per_gpu -gt 16 ]] && export max_tests_per_gpu=16
+fi
+
+export num_test_jobs=$((gpu_count * max_tests_per_gpu))
+export num_cpu_cores=$(nproc)
+export total_ram_gib=$(awk '/MemTotal/ {printf "%.0f", $2/1048576}' /proc/meminfo)
+export host_memory_limit=$((total_ram_gib / 6))
+
+if [[ $num_cpu_cores -lt $num_test_jobs ]]; then
+  num_test_jobs=$num_cpu_cores
+fi
+
+if [[ $host_memory_limit -lt $num_test_jobs ]]; then
+  num_test_jobs=$host_memory_limit
+fi
+
+# Log detected configuration
+echo "=== OneAPI Configuration ==="
+echo "GPU Count: $gpu_count"
+echo "Max Tests Per GPU: $max_tests_per_gpu"
+echo "Num Test Jobs: $num_test_jobs"
+echo "Num CPU Cores: $num_cpu_cores"
+echo "Total RAM: $total_ram_gib GiB"
+echo "=========================="
+# End of test environment variables setup.
+
+if [[ "$JAXCI_HERMETIC_PYTHON_VERSION" == *"-nogil" ]]; then
+  JAXCI_HERMETIC_PYTHON_VERSION=${JAXCI_HERMETIC_PYTHON_VERSION%-nogil}-ft
+  FREETHREADED_FLAG_VALUE="yes"
+else
+  FREETHREADED_FLAG_VALUE="no"
+fi
+
+OVERRIDE_XLA_REPO=""
+if [[ -n "${JAXCI_XLA_GIT_DIR}" ]]; then
+  OVERRIDE_XLA_REPO="--override_repository=xla=${JAXCI_XLA_GIT_DIR}"
+fi
+
+# Get oneapi version
+oneapi_version="2025.1"
+TEST_CONFIG="oneapi"
+
+# Don't abort the script if one command fails to ensure we run both test
+# commands below.
+set +e
+
+
+# Runs single accelerator tests with one GPU apiece.
+# It appears --run_under needs an absolute path.
+# The product of the `JAX_ACCELERATOR_COUNT`` and `JAX_TESTS_PER_ACCELERATOR`
+# should match the VM's CPU core count (set in `--local_test_jobs`).
+bazel test --config=$TEST_CONFIG \
+       --repo_env=HERMETIC_PYTHON_VERSION="$JAXCI_HERMETIC_PYTHON_VERSION" \
+       --@rules_python//python/config_settings:py_freethreaded="$FREETHREADED_FLAG_VALUE" \
+       $OVERRIDE_XLA_REPO \
+       --//jax:build_jaxlib=$JAXCI_BUILD_JAXLIB \
+       --//jax:build_jax=$JAXCI_BUILD_JAX \
+       --test_env=XLA_PYTHON_CLIENT_ALLOCATOR=platform \
+       --run_under "$(pwd)/build/parallel_accelerator_execute.sh" \
+       --test_output=errors \
+       --test_env=JAX_ACCELERATOR_COUNT=$gpu_count \
+       --test_env=JAX_TESTS_PER_ACCELERATOR=$max_tests_per_gpu \
+       --test_env=JAX_LOCK_DIR=/tmp/jax_accelerator_locks \
+       --test_env=XLA_FLAGS \
+       --local_test_jobs=$num_test_jobs \
+       --test_env=JAX_EXCLUDE_TEST_TARGETS=PmapTest.testSizeOverflow \
+       --test_tag_filters=-multiaccelerator,-multiaccelerator-only \
+       --test_env=TF_CPP_MIN_LOG_LEVEL=0 \
+       --test_env=JAX_SKIP_SLOW_TESTS=true \
+       --action_env=JAX_ENABLE_X64="$JAXCI_ENABLE_X64" \
+       --color=yes \
+       //tests:gpu_tests //tests:backend_independent_tests
+       # TODO(Intel-tf): uncomment this when pallas GPU tests are working
+       # //tests/pallas:gpu_tests //tests/pallas:backend_independent_tests
+
+# Store the return value of the first bazel command.
+first_bazel_cmd_retval=$?
+
+echo "Running multi-accelerator tests (without RBE)..."
+# Runs multiaccelerator tests with all GPUs directly on the VM without RBE..
+bazel test --config=$TEST_CONFIG \
+      --repo_env=HERMETIC_PYTHON_VERSION="$JAXCI_HERMETIC_PYTHON_VERSION" \
+      --@rules_python//python/config_settings:py_freethreaded="$FREETHREADED_FLAG_VALUE" \
+      $OVERRIDE_XLA_REPO \
+      --//jax:build_jaxlib=$JAXCI_BUILD_JAXLIB \
+      --//jax:build_jax=$JAXCI_BUILD_JAX \
+      --test_env=XLA_PYTHON_CLIENT_ALLOCATOR=platform \
+      --test_env=XLA_FLAGS \
+      --test_output=errors \
+      --local_test_jobs=8 \
+      --test_tag_filters=multiaccelerator,multiaccelerator-only \
+      --test_env=TF_CPP_MIN_LOG_LEVEL=0 \
+      --test_env=JAX_SKIP_SLOW_TESTS=true \
+      --action_env=JAX_ENABLE_X64="$JAXCI_ENABLE_X64" \
+      --color=yes \
+      //tests:gpu_tests //tests/multiprocess:gpu_tests
+      # TODO(Intel-tf): uncomment this when pallas GPU tests are working
+      # //tests/pallas:gpu_tests
+
+# Store the return value of the second bazel command.
+second_bazel_cmd_retval=$?
+
+ci/utilities/collect_bazel_test_xmls.sh test-artifacts
+
+# Exit with failure if either command fails.
+if [[ $first_bazel_cmd_retval -ne 0 ]]; then
+  exit $first_bazel_cmd_retval
+elif [[ $second_bazel_cmd_retval -ne 0 ]]; then
+  exit $second_bazel_cmd_retval
+else
+  exit 0
+fi

--- a/ci/run_pytest_oneapi.sh
+++ b/ci/run_pytest_oneapi.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Runs Pytest ONEAPI tests. Requires the jaxlib, jax-oneapi-plugin, and jax-oneapi-pjrt
+# wheels to be present inside $JAXCI_OUTPUT_DIR (../dist)
+#
+# -e: abort script if one command fails
+# -u: error if undefined variable used
+# -x: log all commands
+# -o history: record shell history
+# -o allexport: export all functions and variables to be available to subscripts
+set -exu -o history -o allexport
+
+# Source default JAXCI environment variables.
+source ci/envs/default.env
+
+
+# Install jaxlib, jax-oneapi-plugin, and jax-oneapi-pjrt wheels inside the
+# $JAXCI_OUTPUT_DIR directory on the system.
+echo "Installing wheels locally..."
+source ./ci/utilities/install_wheels_locally.sh
+
+# Install oneapi runtime dependencies from the locally installed plugin wheel.
+# This avoids version pinning conflicts that occur when using jax[oneapi] extras.
+oneapi_plugin_whl=$(ls "$JAXCI_OUTPUT_DIR"/*oneapi*plugin*.whl 2>/dev/null | head -1)
+if [[ -n "$oneapi_plugin_whl" ]]; then
+  "$JAXCI_PYTHON" -m uv pip install "${oneapi_plugin_whl}[with-oneapi]" --prerelease=allow
+fi
+
+# Test-time deps not provided by install_wheels_locally.sh. pytest-xdist is
+# required for the `-n $num_processes` flag used below.
+"$JAXCI_PYTHON" -m uv pip install pytest-xdist
+
+# Set up the build environment.
+source "ci/utilities/setup_build_environment.sh"
+
+# Validate OneAPI runtime is available
+if ! command -v xpu-smi &> /dev/null; then
+  echo "ERROR: OneAPI runtime not detected (xpu-smi not found)"
+  echo "Please ensure xpu-smi is installed"
+  exit 1
+fi
+
+# Verify wheels exist
+if ! ls "$JAXCI_OUTPUT_DIR"/*oneapi*.whl 1> /dev/null 2>&1; then
+  echo "ERROR: No OneAPI wheels found in $JAXCI_OUTPUT_DIR"
+  echo "Available files:"
+  ls -la "$JAXCI_OUTPUT_DIR" || echo "(directory not accessible)"
+  exit 1
+fi
+
+# Print all the installed packages
+echo "Installed packages:"
+"$JAXCI_PYTHON" -m uv pip freeze
+
+"$JAXCI_PYTHON" -c "import jax; print(jax.default_backend()); print(jax.devices()); print(len(jax.devices()))"
+
+# ==============================================================================
+# Set up the generic test environment variables
+# ==============================================================================
+export PY_COLORS=1
+export JAX_SKIP_SLOW_TESTS=true
+export TF_CPP_MIN_LOG_LEVEL=0
+export JAX_ENABLE_X64="$JAXCI_ENABLE_X64"
+
+
+# TODO(Intel-tf): Revisit this.
+# Some process-instance fails to find the tests/ direcotory in multi-process run.
+# add a path to $pwd to PYTHONPATH to ensure that the tests/ directory is found.
+export PYTHONPATH="$PWD${PYTHONPATH:+:$PYTHONPATH}"
+
+# ==============================================================================
+# Calculate the optimal number of parallel processes for pytest
+# This will be the minimum of: GPU capacity, CPU core count, and a system RAM limit.
+# ==============================================================================
+
+# Detect OneAPI GPU count
+detect_oneapi_gpus() {
+  if command -v xpu-smi &> /dev/null; then
+    local count=$(xpu-smi discovery 2>/dev/null | grep -c "Device Name")
+    echo $count
+  else
+    echo 0
+  fi
+}
+
+export gpu_count=$(detect_oneapi_gpus)
+if [[ $gpu_count -eq 0 ]]; then
+  echo "ERROR: No OneAPI GPUs detected, exiting"
+  exit 1
+fi
+echo "Number of GPUs detected: $gpu_count"
+
+# Calculate max tests per GPU based on available memory
+export max_tests_per_gpu=8
+if command -v xpu-smi &> /dev/null; then
+  gpu_memory_gb=$(xpu-smi discovery --dump 16 | grep -v "Memory\|^$" | awk '{print int($1/1024+0.5)}' | head -1)
+  gpu_memory_gb="${gpu_memory_gb:-16}"
+  export max_tests_per_gpu=$((gpu_memory_gb / 2))
+  [[ $max_tests_per_gpu -lt 4 ]] && export max_tests_per_gpu=4
+  [[ $max_tests_per_gpu -gt 16 ]] && export max_tests_per_gpu=16
+fi
+echo "Max tests per GPU (assuming 2GiB/test): $max_tests_per_gpu"
+
+export num_processes=$((gpu_count * max_tests_per_gpu))
+echo "Initial number of processes based on GPU capacity: $num_processes"
+
+export num_cpu_cores=$(nproc)
+echo "Number of CPU cores available: $num_cpu_cores"
+
+# Reads total memory from /proc/meminfo (in KiB) and converts to GiB.
+export total_ram_gib=$(awk '/MemTotal/ {printf "%.0f", $2/1048576}' /proc/meminfo)
+echo "Total system RAM: $total_ram_gib GiB"
+
+# Set a safety limit for system RAM usage, e.g., 1/6th of total.
+export host_memory_limit=$((total_ram_gib / 6))
+echo "Host memory process limit (1/6th of total RAM): $host_memory_limit"
+
+if [[ $num_cpu_cores -lt $num_processes ]]; then
+  num_processes=$num_cpu_cores
+  echo "Adjusting num_processes to match CPU core count: $num_processes"
+fi
+
+if [[ $host_memory_limit -lt $num_processes ]]; then
+  num_processes=$host_memory_limit
+  echo "Adjusting num_processes to match host memory limit: $num_processes"
+fi
+
+echo "Final number of processes to run: $num_processes"
+
+export JAX_ENABLE_ONEAPI_XDIST="$gpu_count"
+export XLA_PYTHON_CLIENT_ALLOCATOR=platform
+
+# ==============================================================================
+# Run tests
+# ==============================================================================
+echo "Running oneAPI tests..."
+mkdir -p test-artifacts
+"$JAXCI_PYTHON" -m pytest -n $num_processes --tb=short --maxfail=20 \
+--junitxml=test-artifacts/junit.xml \
+--ignore=jax_plugins \
+--ignore=tests/pallas \
+--ignore=tests/mosaic \
+tests examples \
+--deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
+--deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
+--deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric

--- a/ci/utilities/install_wheels_locally.sh
+++ b/ci/utilities/install_wheels_locally.sh
@@ -18,7 +18,7 @@
 # binary set in JAXCI_PYTHON. Use the absolute path to the `find` utility to
 # avoid using the Windows version of `find` on Msys.
 
-WHEELS=( $(/usr/bin/find "$JAXCI_OUTPUT_DIR/" -type f \(  -name "*jax*py3*"  -o -name "*jaxlib*" -o -name "*jax*cuda*pjrt*" -o -name "*jax*cuda*plugin*" -o -name "*jax*rocm*pjrt*" -o -name "*jax*rocm*plugin*" \)) )
+WHEELS=( $(/usr/bin/find "$JAXCI_OUTPUT_DIR/" -type f \(  -name "*jax*py3*"  -o -name "*jaxlib*" -o -name "*jax*cuda*pjrt*" -o -name "*jax*cuda*plugin*" -o -name "*jax*rocm*pjrt*" -o -name "*jax*rocm*plugin*" -o -name "*jax*oneapi*pjrt*" -o -name "*jax*oneapi*plugin*" \)) )
 
 for i in "${!WHEELS[@]}"; do
   if [[ "${WHEELS[$i]}" == *jax*py3*none*any.whl ]]; then

--- a/conftest.py
+++ b/conftest.py
@@ -95,3 +95,15 @@ def pytest_collection() -> None:
     # HIP_VISIBLE_DEVICES to all GPUs; override to "0" so HIP doesn't try to
     # enable agents that ROCr just hid.
     os.environ["HIP_VISIBLE_DEVICES"] = "0"
+
+  elif num_oneapi_devices := os.environ.get("JAX_ENABLE_ONEAPI_XDIST", None):
+    num_oneapi_devices = int(num_oneapi_devices)
+    if num_oneapi_devices <= 0:
+      return
+    xdist_worker_name = os.environ.get("PYTEST_XDIST_WORKER", "")
+    if not xdist_worker_name.startswith("gw"):
+      return
+    xdist_worker_number = int(xdist_worker_name[len("gw") :])
+    os.environ.setdefault(
+        "ZE_AFFINITY_MASK", str(xdist_worker_number % num_oneapi_devices)
+    )


### PR DESCRIPTION
- `build/parallel_accelerator_execute.sh`: make lock dir configurable via JAX_LOCK_DIR env var; add ONEAPI_VISIBLE_DEVICES support
- `ci/utilities/install_wheels_locally.sh`: add oneapi pjrt and plugin wheel patterns for local installation
- `ci/run_bazel_test_oneapi.sh`: add Bazel GPU test script for Intel GPUs with automatic GPU detection and parallelization
- `ci/run_pytest_oneapi.sh`: add pytest script for Intel GPUs with automatic GPU detection, parallelization, and oneapi extras support
- `conftest.py`: add JAX_ENABLE_ONEAPI_XDIST support for parallel testing across Intel GPU devices using ZE_AFFINITY_MASK

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->