### PR TITLE
[vjp3] add a way to log data out of the backward pass

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1678,7 +1678,8 @@ def vjp(
   return out_primals_ft.unflatten(), f_vjp, *maybe_aux
 
 def _vjp3_callable(spec, out_known, jaxpr, out_primal_avals, in_tree, out_tree,
-                   args_res, opaque_res, structured_res, *maybe_ct_refs):
+                   args_res, opaque_res, structured_res, want_logs,
+                   *maybe_ct_refs):
   explicit_refs = bool(maybe_ct_refs)
   if explicit_refs:
     maybe_ct_refs_flat, in_tree_ = tree_flatten(maybe_ct_refs)
@@ -1695,7 +1696,8 @@ def _vjp3_callable(spec, out_known, jaxpr, out_primal_avals, in_tree, out_tree,
   maybe_accums = [_vjp_accum(jaxpr, in_tree, explicit_refs, idx, v, x)
                   for idx, (v, x) in enumerate(unsafe_zip(jaxpr.invars, maybe_ct_refs_flat))]
   return Partial(partial(_vjp3_bwd, in_tree, out_tree, out_known, jaxpr,
-                         out_primal_avals), residuals, structured_res, maybe_accums)
+                         out_primal_avals, want_logs), residuals, structured_res,
+                 maybe_accums)
 
 def _vjp_accum(jaxpr, in_tree, explicit_refs, idx, v, x):
   if isinstance(x, ad.GradAccum):
@@ -1783,20 +1785,21 @@ def check_accum(aval, acc):
     raise ValueError(f"Accumulator aval mismatch: expected {aval}, got {acc.aval}")
   return acc
 
-def _vjp3_bwd(in_tree, out_tree, out_known, jaxpr, out_primal_avals, residuals,
-              structured_res, maybe_accums, out_ct):
+def _vjp3_bwd(in_tree, out_tree, out_known, jaxpr, out_primal_avals, want_logs,
+              residuals, structured_res, maybe_accums, out_ct):
   cts_flat, out_tree_ = tree_flatten(out_ct, is_leaf=lambda x: isinstance(x, ad.Zero))
   if out_tree != out_tree_:
     _vjp_ct_tree_error(jaxpr, out_tree, out_tree_)
   _vjp_check_ct_avals(cts_flat, out_primal_avals)
   cts_flat = [ct for ct, k in zip(cts_flat, out_known) if not k]
   primals_in = [*maybe_accums, *tree_leaves(structured_res)]
-  ad.backward_pass3(jaxpr, True, residuals, primals_in, cts_flat)
+  logs = ad.backward_pass3(jaxpr, True, residuals, primals_in, cts_flat)
   arg_cts = [x.freeze() if isinstance(x, ad.ValAccum) else
              DidntWant() if isinstance(x, ad.NullAccum) else GradRef()
              for x in maybe_accums]
   arg_cts = map(ad.instantiate_zeros, arg_cts)
-  return tree_unflatten(in_tree, arg_cts)
+  arg_cts = tree_unflatten(in_tree, arg_cts)
+  return (arg_cts, logs) if want_logs else arg_cts
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -1944,6 +1947,7 @@ class VJP:
   args_res: list[Any]
   opaque_residuals: list[Any]
   structured_residuals: list[Any]
+  want_logs: bool = False
   jaxpr = property(lambda self: self.fun.args[2])
 
   def __call__(self, out_ct, *extra_args):
@@ -1951,12 +1955,18 @@ class VJP:
       name, *_ = self.jaxpr.debug_info.func_src_info.split(' ')
       raise TypeError(_vjp_too_many_args(name, len(extra_args) + 1))
     return self.fun(self.in_tree, self.out_tree, self.args_res,
-                    self.opaque_residuals, self.structured_residuals)(out_ct)
+                    self.opaque_residuals, self.structured_residuals,
+                    self.want_logs)(out_ct)
+
+  # Like __call__, but returns a pair (arg_cts, logs), where logs is a dict
+  # merging (with clobber semantics, in backward execution order) the dicts
+  # logged by transpose/vjp_bwd rules. Plain __call__ drops the logs.
+  with_logs = property(lambda self: self.replace(want_logs=True))
 
   def with_refs(self, *maybe_ct_refs):
     return self.fun(self.in_tree, self.out_tree, self.args_res,
                     self.opaque_residuals, self.structured_residuals,
-                    *maybe_ct_refs)
+                    self.want_logs, *maybe_ct_refs)
 
   replace = dataclasses.replace
 
@@ -1967,8 +1977,8 @@ class VJP:
 register_pytree_node(
     VJP,
     lambda vjp: ((vjp.args_res, vjp.opaque_residuals, vjp.structured_residuals),
-                 (vjp.fun, vjp.in_tree, vjp.out_tree)),
-    lambda meta, args_res: VJP(*meta, *args_res))
+                 (vjp.fun, vjp.in_tree, vjp.out_tree, vjp.want_logs)),
+    lambda meta, args_res: VJP(*meta[:3], *args_res, meta[3]))  # type: ignore
 
 
 @partial(api_boundary, repro_api_name="jax.linear_transpose")

--- a/jax/_src/compute_on.py
+++ b/jax/_src/compute_on.py
@@ -344,34 +344,43 @@ pe.partial_eval_jaxpr_custom_rules[compute_on_p] = \
             _compute_on_partial_eval_custom_params_updater)
 
 @weakref_lru_cache
-def _transpose_jaxpr(jaxpr, in_avals, in_tree):
+@weakref_lru_cache
+def _transpose_jaxpr(jaxpr, in_tree, in_avals, specs):
   cell = lambda: None
   def transposed(*in_flat):
-    primals_in, cts_in = tree_unflatten(in_tree, in_flat)
-    out = ad.backward_pass(jaxpr, False, jaxpr.consts, primals_in, cts_in)
-    out = [ct if not isinstance(ct, ad.Zero) else None for ct in out]
-    cts_out, cell.out_tree = tree_flatten(out)  # pyrefly: ignore[missing-attribute]
-    return cts_out
+    primals_ctrefs, cts_in = tree_unflatten(in_tree, in_flat)
+    args = ad.unproject_accums(specs, primals_ctrefs)
+    logs = ad.backward_pass3(jaxpr, False, jaxpr.consts, args, cts_in)
+    cts_out = [x.freeze() if isinstance(x, ad.ValAccum) else None for x in args]
+    outs, cell.out_tree = tree_flatten((cts_out, logs))  # pyrefly: ignore[missing-attribute]
+    return outs
   dbg = jaxpr.debug_info.with_unknown_names()
   trans_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
       lu.wrap_init(transposed, debug_info=dbg), in_avals)
   return trans_jaxpr.with_consts(consts), cell.out_tree  # pyrefly: ignore[missing-attribute]
 
-def _compute_on_transpose(cts_in, *primals_in, jaxpr, compute_type,
+def _compute_on_transpose(cts_in, *args, jaxpr, compute_type,
                           out_memory_spaces, compiler_options_json):
-  in_flat, in_tree = tree_flatten((primals_in, cts_in))
+  primals_ctrefs, specs = ad.project_accums(args)
+  in_flat, in_tree = tree_flatten((primals_ctrefs, cts_in))
   in_avals = tuple(core.typeof(x) for x in in_flat)
-  trans_jaxpr, out_tree = _transpose_jaxpr(jaxpr, in_avals, in_tree)
-  in_spaces = [x.aval.memory_space if isinstance(x, ad.UndefinedPrimal)
-               else core.typeof(x).memory_space for x in primals_in]
-  cts_out_ = tree_unflatten(out_tree, trans_jaxpr.out_avals)
-  trans_spaces = tuple(s for x, s in zip(cts_out_, in_spaces) if x)
-  cts_out = compute_on_p.bind(*in_flat, jaxpr=trans_jaxpr,
-                              compute_type=compute_type,
-                              out_memory_spaces=trans_spaces,
-                              compiler_options_json=compiler_options_json)
-  return tree_unflatten(out_tree, cts_out)
-ad.primitive_transposes[compute_on_p] = _compute_on_transpose
+  trans_jaxpr, out_tree = _transpose_jaxpr(jaxpr, in_tree, in_avals, specs)
+  cts_out_, logs_ = tree_unflatten(out_tree, trans_jaxpr.out_avals)
+  arg_spaces = [x.aval.memory_space if isinstance(x, ad.GradAccum)  # type: ignore
+                else core.typeof(x).memory_space for x in args]
+  trans_spaces = tuple(s for x, s in zip(cts_out_, arg_spaces)
+                       if isinstance(x, core.AbstractValue))
+  trans_spaces += tuple(a.memory_space for a in tree_leaves(logs_))
+  outs = compute_on_p.bind(*in_flat, jaxpr=trans_jaxpr,
+                           compute_type=compute_type,
+                           out_memory_spaces=trans_spaces,
+                           compiler_options_json=compiler_options_json)
+  cts_out, logs = tree_unflatten(out_tree, outs)
+  for x, ct in zip(args, cts_out):
+    if isinstance(x, ad.ValAccum):
+      x.accum(ct)
+  return logs
+ad.fancy_transposes[compute_on_p] = _compute_on_transpose
 
 def dce_jaxpr_compute_on_rule(used_outputs: list[bool], eqn: pe.JaxprEqn
                               ) -> tuple[list[bool], pe.JaxprEqn | None]:

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -705,12 +705,18 @@ def _call_hi_primitive_linearized_transpose(
               for a, nz in zip(_prim.out_avals_flat, nz_out_flat)]
   assert next(cts_flat_iter, sentinel := object()) is sentinel
   cts = tree_unflatten(_prim.out_tree, cts_flat)
+  # A vjp_bwd rule may return a dict of pytrees to log out of the backward
+  # pass (see VJP.with_logs), or None (the usual case) to log nothing.
   if has_sres:
     residuals, sres = residuals
-    none = _prim.vjp_bwd(residuals, sres, cts, *accums)
+    log = _prim.vjp_bwd(residuals, sres, cts, *accums)
   else:
-    none = _prim.vjp_bwd(residuals, cts, *accums)
-  assert none is None
+    log = _prim.vjp_bwd(residuals, cts, *accums)
+  if log is not None and type(log) is not dict:
+    raise TypeError(
+        f"{type(_prim).__name__}.vjp_bwd should return None or a dict of "
+        f"backward-pass log entries, got {type(log).__name__}")
+  return log
 ad.fancy_transposes[call_hi_primitive_linearized_p] = _call_hi_primitive_linearized_transpose
 
 def _call_hi_primitive_linearized_prettyprint(eqn, context, settings):
@@ -733,8 +739,12 @@ ad.primitive_jvps[call_hi_primitive_p] = _call_hi_primitive_jvp
 def _call_hi_primitive_transpose(cts_flat, *primals_flat, _prim):
   cts = tree_unflatten(_prim.out_tree, cts_flat)
   primals = tree_unflatten(_prim.in_tree, primals_flat)
-  none = _prim.transpose(cts, *primals)
-  assert none is None
+  log = _prim.transpose(cts, *primals)  # a returned dict logs entries
+  if log is not None and type(log) is not dict:
+    raise TypeError(
+        f"{type(_prim).__name__}.transpose should return None or a dict of "
+        f"backward-pass log entries, got {type(log).__name__}")
+  return log
 ad.fancy_transposes[call_hi_primitive_p] = _call_hi_primitive_transpose
 
 def _call_hi_primitive_dce(used_outs_flat, eqn):

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -360,9 +360,14 @@ def get_primitive_transpose(p):
 def backward_pass3(
     jaxpr: core.Jaxpr, transform_stack: bool,
     consts: Sequence[Array], primals_in: Sequence[Array | Ref | GradAccum],
-    cotangents_in: Sequence[Array]) -> None:
+    cotangents_in: Sequence[Array]) -> dict:
+  # Returns a dict of backward-pass log entries. A fancy transpose rule can
+  # contribute entries by returning a dict (None, which all accumulator-style
+  # rules return today, means the same as {}). Entries are merged in backward
+  # execution order with clobber semantics, so on a key collision the entry
+  # from the earlier-in-forward-order equation wins.
   if all(type(ct) is Zero for ct in cotangents_in) and not jaxpr.effects:
-    return
+    return {}
 
   env: dict = dict(zip((*jaxpr.constvars, *jaxpr.invars),
                        (*consts, *primals_in)))
@@ -397,6 +402,7 @@ def backward_pass3(
 
   ctx = (source_info_util.transform_name_stack('transpose') if transform_stack
          else contextlib.nullcontext())
+  logs: dict = {}
   for acc, ct in zip(map(read, jaxpr.outvars), cotangents_in):
     if isinstance(acc, GradAccum):
       acc.accum(ct)  # jaxpr.outvars can have Literals, env can have inst zeros
@@ -416,7 +422,8 @@ def backward_pass3(
             cts_in, = cts_in
           if eqn.primitive in fancy_transposes:
             rule = fancy_transposes[eqn.primitive]
-            rule(cts_in, *map(read, eqn.invars), **eqn.params)
+            eqn_logs = rule(cts_in, *map(read, eqn.invars), **eqn.params)
+            logs = _merge_rule_logs(logs, eqn_logs, eqn.primitive)
           else:
             rule = get_primitive_transpose(eqn.primitive)
             primals = map(read, eqn.invars)
@@ -432,6 +439,17 @@ def backward_pass3(
             for x, ct in zip(primals, cts_out):
               if isinstance(x, GradAccum):
                 x.accum(ct)
+  return logs
+
+def _merge_rule_logs(logs: dict, eqn_logs, primitive) -> dict:
+  if eqn_logs is None:
+    return logs
+  if type(eqn_logs) is not dict:
+    raise TypeError(
+        f"the fancy transpose rule for '{primitive}' should return None or a "
+        "dict of backward-pass log entries (see VJP.with_logs), but it "
+        f"returned a {type(eqn_logs).__name__}")
+  return {**logs, **eqn_logs} if eqn_logs else logs
 
 def _name_stack_ctx(src_info):
   stack = source_info_util.current_name_stack() + src_info.name_stack
@@ -1205,10 +1223,10 @@ def call_transpose_fancy(primitive, cts, *args, call_jaxpr, **params):
   def transposed(*flat_args):
     primals_ctrefs, cts = tree_unflatten(treedef, flat_args)
     args = unproject_accums(specs, primals_ctrefs)
-    backward_pass3(call_jaxpr, False, (), args, cts)
+    logs = backward_pass3(call_jaxpr, False, (), args, cts)
     cts_out = [x.freeze() if isinstance(x, ValAccum) else None for x in args]
-    cts_out, cell.out_tree = tree_flatten(cts_out)  # pyrefly: ignore[missing-attribute]
-    return cts_out
+    outs, cell.out_tree = tree_flatten((cts_out, logs))  # pyrefly: ignore[missing-attribute]
+    return outs
 
   update_params = call_transpose_param_updaters.get(primitive)
   if update_params:
@@ -1216,15 +1234,17 @@ def call_transpose_fancy(primitive, cts, *args, call_jaxpr, **params):
                            [type(x) is not Zero for x in cts])
 
   out_flat = primitive.bind(*flat_args, subfuns=(transposed,), **params)
-  for x, ct in zip(args, tree_unflatten(cell.out_tree, out_flat)):  # pyrefly: ignore[missing-attribute]
+  cts_out, logs = tree_unflatten(cell.out_tree, out_flat)  # pyrefly: ignore[missing-attribute]
+  for x, ct in zip(args, cts_out):
     if isinstance(x, ValAccum): x.accum(ct)
+  return logs
 fancy_transposes[core.call_p] = partial(call_transpose_fancy, call_p)
 
 def _closed_call_transpose(ct, *args, call_jaxpr, **params):
   jaxpr_, consts = call_jaxpr, call_jaxpr.consts
   jaxpr_ = pe.convert_constvars_jaxpr(jaxpr_)
-  call_transpose_fancy(core.closed_call_p, ct, *consts, *args,
-                       call_jaxpr=jaxpr_, **params)
+  return call_transpose_fancy(core.closed_call_p, ct, *consts, *args,
+                              call_jaxpr=jaxpr_, **params)
 fancy_transposes[core.closed_call_p] = _closed_call_transpose
 
 def jvp_jaxpr(jaxpr: core.Jaxpr, nonzeros: Sequence[bool],

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -15,8 +15,8 @@
 from __future__ import annotations
 
 import collections
-from collections.abc import Callable, Sequence
 import dataclasses
+from collections.abc import Callable, Sequence
 import functools
 from functools import partial
 import itertools
@@ -869,6 +869,7 @@ class CondSum:
   branches: list
 
 
+
 def _cond_transpose_fancy(cts_in, index, *args, branches, **params):
   assert not isinstance(index, ad.GradAccum)
   primals_ctrefs, specs = ad.project_accums(args)
@@ -876,28 +877,58 @@ def _cond_transpose_fancy(cts_in, index, *args, branches, **params):
   in_avals = tuple(core.AvalQDD(a, cur_qdd(x)) if (a := typeof(x)).has_qdd
                    else a for x in in_flat)
   trans_branches, out_trees = unzip2(
-      _transpose_jaxpr_fancy(j, in_tree, in_avals, specs, (False,) * len(args))
+      _transpose_jaxpr_fancy(j, in_tree, in_avals, specs, (False,) * len(args),
+                             None, 0)
       for j in branches)
-  out_nzs = [[not isinstance(x, ad.Zero) for x in tree_unflatten(t, j.out_avals)]
-             for t, j in zip(out_trees, trans_branches)]
+  outs = [tree_unflatten(t, j.out_avals)
+          for t, j in zip(out_trees, trans_branches)]
+  branch_cts, branch_logs = unzip2(outs)
+  out_nzs = [[not isinstance(x, ad.Zero) for x in cts] for cts in branch_cts]
   out_nz = tuple(map(partial(functools.reduce, operator.or_), zip(*out_nzs)))
+  # Each key logged by any branch gets one slot per branch (see CondSum), so
+  # the branches needn't agree about keys or types.
+  log_spec = []
+  for k in sorted({k for logs in branch_logs for k in logs}):
+    branch_specs = []
+    for logs in branch_logs:
+      if k in logs:
+        avals, treedef = tree_flatten(logs[k])
+        branch_specs.append((treedef, tuple(avals)))
+      else:
+        branch_specs.append(None)  # type: ignore
+    log_spec.append((k, tuple(branch_specs)))
+  log_spec = tuple(log_spec)
   trans_branches, out_trees = unzip2(
-      _transpose_jaxpr_fancy(j, in_tree, in_avals, specs, out_nz) for j in branches)
+      _transpose_jaxpr_fancy(j, in_tree, in_avals, specs, out_nz, log_spec, b)
+      for b, j in enumerate(branches))
   out_tree, = set(out_trees)
-  cts_out = cond_p.bind(index, *in_flat, branches=(*trans_branches,), **params)
-  for x, ct in zip(args, tree_unflatten(out_tree, cts_out)):
+  outs = cond_p.bind(index, *in_flat, branches=(*trans_branches,), **params)
+  cts_out, logs = tree_unflatten(out_tree, outs)
+  for x, ct in zip(args, cts_out):
     if isinstance(x, ad.ValAccum): x.accum(ct)
+  return {k: CondSum(index, slots) for k, slots in logs.items()}
 
 @util.weakref_lru_cache
-def _transpose_jaxpr_fancy(jaxpr, in_tree, in_avals, specs, inst_out):
+def _transpose_jaxpr_fancy(jaxpr, in_tree, in_avals, specs, inst_out, log_spec,
+                           which_branch):
   maybe_inst = lambda x, inst: ad.instantiate_zeros(x) if inst else x
   def transposed(*in_flat):
     primals_ctrefs, cts_in = tree_unflatten(in_tree, in_flat)
     args = ad.unproject_accums(specs, primals_ctrefs)
-    ad.backward_pass3(jaxpr, False, jaxpr.consts, args, cts_in)
+    raw_logs = ad.backward_pass3(jaxpr, False, jaxpr.consts, args, cts_in)
     cts_out = [maybe_inst(x.freeze(), inst) if isinstance(x, ad.ValAccum)
                else None for x, inst in zip(args, inst_out)]
-    return cts_out
+    if log_spec is None:
+      return cts_out, raw_logs
+    # If this jaxpr runs, this branch was the one taken: its slot holds its
+    # live values, other branches' slots hold zeros (or None for keys they
+    # don't log).
+    logs = {k: [raw_logs.get(k) if b == which_branch else
+                None if spec is None else
+                tree_unflatten(spec[0], map(ad_util.zeros_like_aval, spec[1]))
+                for b, spec in enumerate(branch_specs)]
+            for k, branch_specs in log_spec}
+    return cts_out, logs
   dbg = jaxpr.debug_info.with_unknown_names()
   closed_jaxpr, out_avals = pe.trace_to_jaxpr(
       transposed, ft.flatten_args(*in_avals), dbg

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -69,7 +69,7 @@ from jax._src.traceback_util import api_boundary
 from jax._src.tree_util import equality_errors
 from jax._src.tree_util import (
     keystr, tree_flatten, tree_map, tree_unflatten, tree_leaves,
-    treedef_is_leaf)
+    treedef_is_leaf, PyTreeDef)
 from jax._src.typing import Array
 from jax._src.util import (
     merge_lists, partition_list, safe_map, safe_zip, split_list,
@@ -1167,19 +1167,24 @@ def _scan_transpose_fancy(cts, *args, reverse, length, ft_in, ft_out, jaxpr,
   trans_avals, ext_avals = split_list(_map(accum_typeof, trans_in), [num_consts+num_carry])
   trans_avals = trans_avals + [core.mapped_leading_aval(length, a) for a in ext_avals]
   xs_avals = tuple(core.mapped_leading_aval(length, accum_typeof(x)) for x in immut_xs_dot)
-  jaxpr_trans = _transpose_scan_jaxpr_fancy(
+  jaxpr_trans, log_tree = _transpose_scan_jaxpr_fancy(
       jaxpr, trans_tree, tuple(trans_avals), lin_refs, xs_avals)
 
-  # run it
+  # run it; per-iteration log entries come out as extra ys outputs, stacked
+  # index-aligned with the forward scan's iterations
   outs = scan_p.bind(
       *trans_in, reverse=not reverse, length=length, jaxpr=jaxpr_trans,
       ft_in=ft.flatten(((ires, mut_consts_bar), (ct_immut_consts, ct_carry),
                         (mut_xs_bar, ct_ys, eres))).void(),
-      ft_out=ft.flatten(((ct_immut_consts, ct_carry), immut_xs_dot)).void(),
+      ft_out=ft.pack((ft.flatten((ct_immut_consts, ct_carry)).void(),
+                      ft.pack((ft.flatten(immut_xs_dot).void(),
+                               ft.nones(log_tree.num_leaves))))),
       unroll=unroll)
+  outs, log_leaves = split_list(outs, [len(outs) - log_tree.num_leaves])
 
   for a, x in zip([*immut_consts_dot, *carry_dot, *immut_xs_dot], outs):
     if isinstance(a, ad.GradAccum): a.accum(x)
+  return tree_unflatten(log_tree, log_leaves)
 
 # _transpose_scan_jaxpr_fancy converts the jaxpr signature:
 #  Before: [(ires,  T d_mut,  T d_pure), T c, ( T a_mut,  T a_pure, eres)] -> [T c, T b]
@@ -1193,7 +1198,9 @@ def _scan_transpose_fancy(cts, *args, reverse, length, ft_in, ft_out, jaxpr,
 # only the pure tangents' cotangents appear as outputs.
 @weakref_lru_cache
 def _transpose_scan_jaxpr_fancy(
-    jaxpr, trans_tree, trans_avals, lin_refs, immut_xs_avals) -> core.Jaxpr:
+    jaxpr, trans_tree, trans_avals, lin_refs, immut_xs_avals
+  ) -> tuple[core.Jaxpr, PyTreeDef]:
+  cell = lambda: None
   def transposed(*args):
     args = [ad.RefAccum(typeof(x).inner_aval, x) if l else x
             for l, x in zip(lin_refs, args)]
@@ -1204,12 +1211,15 @@ def _transpose_scan_jaxpr_fancy(
     immut_xs_dot = [ad.ValAccum(a) for a in immut_xs_avals]
     primals = (ires + mut_consts_bar + immut_consts_dot + carry_dot + mut_xs_bar
                + immut_xs_dot + eres)
-    ad.backward_pass3(jaxpr, False, jaxpr.consts, primals, ct_carry + ct_ys)
-    return [ad.instantiate_zeros(x.freeze()) for x in primals
-            if isinstance(x, ad.ValAccum)]
+    logs = ad.backward_pass3(jaxpr, False, jaxpr.consts, primals, ct_carry + ct_ys)
+    cts_out = [ad.instantiate_zeros(x.freeze()) for x in primals
+               if isinstance(x, ad.ValAccum)]
+    log_leaves, cell.log_tree = tree_flatten(logs)  # pyrefly: ignore[missing-attribute]
+    return [*cts_out, *log_leaves]
 
   dbg = jaxpr.debug_info.with_unknown_names()
-  return _make_closed_jaxpr(transposed, trans_avals, dbg)
+  jaxpr_trans = _make_closed_jaxpr(transposed, trans_avals, dbg)
+  return jaxpr_trans, cell.log_tree  # pyrefly: ignore[missing-attribute]
 
 
 def _scan_batching_rule(axis_data, args, dims, reverse, length, jaxpr,

--- a/jax/_src/lax/eval_jaxpr.py
+++ b/jax/_src/lax/eval_jaxpr.py
@@ -97,6 +97,6 @@ ad.primitive_linearizations[eval_jaxpr_p] = _eval_jaxpr_linearize
 def _eval_jaxpr_transpose(ct, *args, jaxpr):
   jaxpr_, consts = jaxpr, jaxpr.consts
   jaxpr_ = pe.convert_constvars_jaxpr(jaxpr_)
-  ad.call_transpose_fancy(core.closed_call_p, ct, *consts, *args,
-                          call_jaxpr=jaxpr_)
+  return ad.call_transpose_fancy(core.closed_call_p, ct, *consts, *args,
+                                 call_jaxpr=jaxpr_)
 ad.fancy_transposes[eval_jaxpr_p] = _eval_jaxpr_transpose

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1943,11 +1943,14 @@ def _pjit_transpose_fancy(
       [l for x, l in zip(args, in_layouts)
        if not isinstance(x, (ad.ValAccum, ad.NullAccum))] +
       [l for x, l in zip(cts_in, out_layouts) if not isinstance(x, ad.Zero)])
-  cts_out_ = tree_unflatten(out_tree, trans_jaxpr.out_avals)
+  cts_out_, logs_ = tree_unflatten(out_tree, trans_jaxpr.out_avals)
+  num_log_leaves = len(tree_leaves(logs_))
   trans_out_shardings = tuple(s for x, s in zip(cts_out_, in_shardings)
-                              if isinstance(x, core.AbstractValue))
+                              if isinstance(x, core.AbstractValue)
+                              ) + (UNSPECIFIED,) * num_log_leaves
   trans_out_layouts   = tuple(l for x, l in zip(cts_out_, in_layouts  )
-                              if isinstance(x, core.AbstractValue))
+                              if isinstance(x, core.AbstractValue)
+                              ) + (None,) * num_log_leaves
 
   try:
     cts_out = jit_p.bind(
@@ -1969,8 +1972,10 @@ def _pjit_transpose_fancy(
       api_util._raise_no_nan_in_deoptimized(e)
 
   # pyrefly: ignore[unbound-name]  # pyrefly#2219
-  for x, ct in zip(args, tree_unflatten(out_tree, cts_out)):
+  cts_out, logs = tree_unflatten(out_tree, cts_out)
+  for x, ct in zip(args, cts_out):
     if isinstance(x, ad.ValAccum): x.accum(ct)
+  return logs
 
 @weakref_lru_cache
 def _transpose_jaxpr_fancy(jaxpr, in_tree, in_avals, specs):
@@ -1978,10 +1983,10 @@ def _transpose_jaxpr_fancy(jaxpr, in_tree, in_avals, specs):
   def transposed(*in_flat):
     primals_ctrefs, cts_in = tree_unflatten(in_tree, in_flat)
     args = ad.unproject_accums(specs, primals_ctrefs)
-    ad.backward_pass3(jaxpr, False, jaxpr.consts, args, cts_in)
+    logs = ad.backward_pass3(jaxpr, False, jaxpr.consts, args, cts_in)
     cts_out = [x.freeze() if isinstance(x, ad.ValAccum) else None for x in args]
-    cts_out, cell.out_tree = tree_flatten(cts_out)  # pyrefly: ignore[missing-attribute]
-    return cts_out
+    outs, cell.out_tree = tree_flatten((cts_out, logs))  # pyrefly: ignore[missing-attribute]
+    return outs
   dbg = jaxpr.debug_info.with_unknown_names()
   trans_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
       lu.wrap_init(transposed, debug_info=dbg), in_avals)

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -1938,7 +1938,7 @@ def _unmentioned2(mesh: Mesh, spec, manual_axes: frozenset[AxisName]
 
 
 def _shard_map_transpose(out_cts, *args, jaxpr: core.Jaxpr, mesh, in_specs,
-                         out_specs, check_vma, newly_manual_axes):
+                              out_specs, check_vma, newly_manual_axes):
   mb_div = lambda x, y: x / y if y != 1 else x
   out_cts = [
       ad.Zero(shard_aval(mesh, newly_manual_axes, check_vma, sp.to_ct_spec(), x.aval))
@@ -1950,30 +1950,49 @@ def _shard_map_transpose(out_cts, *args, jaxpr: core.Jaxpr, mesh, in_specs,
           ad.UndefinedPrimal(shard_aval(mesh, newly_manual_axes, check_vma, sp.to_ct_spec(), x.aval))
           for sp, x in zip(in_specs, args)]
   all_args, in_tree = tree_flatten((out_cts, tuple(args)))
+  all_names = _all_newly_manual_mesh_names(mesh, newly_manual_axes)
 
   def fun_trans_callable(*right_flat):
     right_cts, primals_or_undefs = tree_unflatten(in_tree, right_flat)
-    left_cts = ad.backward_pass(jaxpr, False, (), primals_or_undefs, right_cts)
+    accums = [ad.ValAccum(x.aval) if type(x) is ad.UndefinedPrimal else x
+              for x in primals_or_undefs]
+    logs = ad.backward_pass3(jaxpr, False, (), accums, right_cts)
+    left_cts = [x.freeze() if isinstance(x, ad.ValAccum) else ad.p2cz(x)
+                for x in accums]
     left_cts = [x if type(x) is ad.Zero or check_vma
                 else lax_parallel.psum(x, tuple(_unmentioned2(mesh, sp.to_ct_spec(), newly_manual_axes)))
                 for sp, x in zip(in_specs, left_cts)]
     left_specs_nz = tuple(
         s.to_ct_spec() for ct, s in zip(left_cts, in_specs)
         if ct is not None and type(ct) is not ad.Zero)
-    return ft.flatten(left_cts).with_aux(left_specs_nz)
+    # Per-shard log values come out mesh-stacked along their leading axis
+    # (scalars are first promoted to shape (1,)).
+    logs = tree_map(lambda x: lax.broadcast(x, (1,))
+                    if getattr(x, 'shape', None) == () else x, logs)
+    log_specs = tuple(typeof(x).nospec(mesh, check_vma, all_names)
+                      for x in tree_leaves(logs))
+    return ft.flatten((left_cts, logs)).with_aux((*left_specs_nz, *log_specs))
 
   dbg = jaxpr.debug_info.with_unknown_names()
   new_in_specs = (
       [s.to_ct_spec() for s, x in zip(out_specs, out_cts) if type(x) is not ad.Zero] +
       [s for s, x in zip(in_specs, args) if type(x) is not ad.UndefinedPrimal])
 
-  left_ct = shard_map_p.bind(
+  outs = shard_map_p.bind(
       *all_args, subfuns=(fun_trans_callable,), mesh=mesh, in_specs=tuple(new_in_specs),
       check_vma=check_vma, newly_manual_axes=newly_manual_axes, debug_info=dbg)
-  left_cts = left_ct.unflatten()
-  return [ad.Zero(unshard_aval(mesh, check_vma, sp.to_ct_spec(), x.aval))
-          if type(x) is ad.Zero else x for sp, x in zip(in_specs, left_cts)]
-ad.primitive_transposes[shard_map_p] = _shard_map_transpose
+  left_cts, logs = outs.unflatten()
+  left_cts = [ad.Zero(unshard_aval(mesh, check_vma, sp.to_ct_spec(), x.aval))
+              if type(x) is ad.Zero else x for sp, x in zip(in_specs, left_cts)]
+  return left_cts, logs
+
+def _shard_map_transpose_fancy(out_cts, *args, **params):
+  up = lambda x: ad.UndefinedPrimal(x.aval) if isinstance(x, ad.GradAccum) else x
+  left_cts, logs = _shard_map_transpose(out_cts, *map(up, args), **params)
+  for x, ct in zip(args, left_cts):
+    if isinstance(x, ad.GradAccum): x.accum(ct)
+  return logs
+ad.fancy_transposes[shard_map_p] = _shard_map_transpose_fancy
 
 # Remat
 

--- a/jax/_src/xla_metadata.py
+++ b/jax/_src/xla_metadata.py
@@ -410,10 +410,10 @@ def _transpose_jaxpr(jaxpr, in_tree, in_avals, specs):
     nonlocal out_tree
     primals_ctrefs, cts_in = tree_unflatten(in_tree, in_flat)
     args = ad.unproject_accums(specs, primals_ctrefs)
-    ad.backward_pass3(jaxpr, False, jaxpr.consts, args, cts_in)
+    logs = ad.backward_pass3(jaxpr, False, jaxpr.consts, args, cts_in)
     cts_out = [x.freeze() if isinstance(x, ad.ValAccum) else None for x in args]
-    cts_out, out_tree = tree_flatten(cts_out)
-    return cts_out
+    outs, out_tree = tree_flatten((cts_out, logs))
+    return outs
   dbg = jaxpr.debug_info.with_unknown_names()
   trans_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
       lu.wrap_init(transposed, debug_info=dbg), in_avals)
@@ -427,14 +427,16 @@ def _xla_metadata_call_transpose(cts_in, *args, jaxpr, xla_metadata,
   in_avals = [core.typeof(x) for x in in_flat]
   trans_jaxpr, out_tree = _transpose_jaxpr(jaxpr, in_tree, (*in_avals,), specs)
 
-  cts_out = xla_metadata_call_p.bind(
+  outs = xla_metadata_call_p.bind(
       *in_flat, jaxpr=trans_jaxpr,
       xla_metadata=_resolve_ad_metadata(xla_metadata, ad_metadata),
       ad_metadata='same')
 
-  for x, ct in zip(args, tree_unflatten(out_tree, cts_out)):
+  cts_out, logs = tree_unflatten(out_tree, outs)
+  for x, ct in zip(args, cts_out):
     if isinstance(x, ad.ValAccum):
       x.accum(ct)
+  return logs
 
 
 ad.fancy_transposes[xla_metadata_call_p] = _xla_metadata_call_transpose

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -1674,6 +1674,326 @@ class HijaxTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError, "structured residuals"):
       jax.grad(lambda x: Bad(jax.typeof(x))(x))(3.0)
 
+  def test_backward_pass_logging(self):
+    # A vjp_bwd rule can return a dict of pytrees to log out of the backward
+    # pass; f_vjp.with_logs(out_ct) returns (arg_cts, logs), where logs merges
+    # the rules' dicts with clobber semantics. Plain f_vjp(out_ct) drops them.
+    class Square(VJPHiPrimitive):
+      def __init__(self, in_aval, tag):
+        self.in_avals = (in_aval,)
+        self.out_aval = in_aval
+        self.params = dict(tag=tag)
+        super().__init__()
+
+      def expand(self, x):
+        return x ** 2
+
+      def vjp_fwd(self, nzs_in, x):
+        return self(x), x
+
+      def vjp_bwd(self, res, t, x_accum):
+        if isinstance(x_accum, ad.GradAccum):
+          x_accum.accum(t * 2.0 * res)
+        return {self.tag: {'x': res, 'ct_in': t}}
+
+    def square(x, tag='sq'):
+      return Square(jax.typeof(x), tag)(x)
+
+    _, f_vjp = jax.vjp(square, 3.0)
+    cts, logs = f_vjp.with_logs(1.0)
+    self.assertAllClose(cts[0], 6.0)
+    self.assertAllClose(logs, {'sq': {'x': 3.0, 'ct_in': 1.0}},
+                        check_dtypes=False)
+    self.assertAllClose(f_vjp(1.0)[0], 6.0)  # plain call drops the logs
+    self.assertAllClose(jax.grad(square)(3.0), 6.0)
+
+    # distinct keys are both present; a repeated key is clobbered, with the
+    # earlier-in-forward-order rule winning
+    f2 = lambda x: square(square(x, 'inner'), 'outer')
+    _, f2_vjp = jax.vjp(f2, 2.0)
+    _, logs2 = f2_vjp.with_logs(1.0)
+    self.assertEqual(set(logs2), {'inner', 'outer'})
+    self.assertAllClose(logs2['inner']['x'], 2.0)
+    self.assertAllClose(logs2['outer']['x'], 4.0)
+    _, f3_vjp = jax.vjp(lambda x: square(square(x)), 2.0)
+    _, logs3 = f3_vjp.with_logs(1.0)
+    self.assertAllClose(logs3['sq']['x'], 2.0)
+
+    # logs flow out of a transposed jit, and with_logs itself can be traced
+    fj = jax.jit(lambda x: square(x))
+    _, fj_vjp = jax.vjp(fj, 3.0)
+    ctsj, logsj = fj_vjp.with_logs(1.0)
+    self.assertAllClose(ctsj[0], 6.0)
+    self.assertAllClose(logsj['sq']['x'], 3.0)
+    ctsT, logsT = jax.jit(
+        lambda x, ct: jax.vjp(fj, x)[1].with_logs(ct))(3.0, 1.0)
+    self.assertAllClose(logsT['sq']['x'], 3.0)
+
+    # logs from a scan body are stacked leaf-wise, index-aligned with the
+    # forward iterations
+    def f_scan(xs):
+      c_out, ys = jax.lax.scan(lambda c, x: (c + square(x), square(x)), 0., xs)
+      return c_out + ys.sum()
+    xs = jnp.array([1., 2., 3.])
+    _, fs_vjp = jax.vjp(f_scan, xs)
+    ctss, logss = fs_vjp.with_logs(1.0)
+    self.assertAllClose(ctss[0], 4.0 * xs)
+    self.assertArraysEqual(logss['sq']['x'], xs)
+    self.assertEqual(logss['sq']['ct_in'].shape, xs.shape)
+
+  def test_backward_pass_logging_cond(self):
+    # A transposed cond logs a sum represented as a tagged product: each key
+    # logged by any branch maps to a CondSum holding the taken-branch index
+    # and one slot per branch (live value / zeros if untaken / None if the
+    # branch doesn't log the key). Branches needn't agree on keys or types.
+    from jax._src.lax.control_flow.conditionals import CondSum
+
+    class Square(VJPHiPrimitive):
+      def __init__(self, in_aval, tag):
+        self.in_avals = (in_aval,)
+        self.out_aval = in_aval
+        self.params = dict(tag=tag)
+        super().__init__()
+
+      def expand(self, x):
+        return x ** 2
+
+      def vjp_fwd(self, nzs_in, x):
+        return self(x), x
+
+      def vjp_bwd(self, res, t, x_accum):
+        if isinstance(x_accum, ad.GradAccum):
+          x_accum.accum(t * 2.0 * res)
+        return {self.tag: res}
+
+    def square(x, tag):
+      return Square(jax.typeof(x), tag)(x)
+
+    def f(x):
+      return jax.lax.cond(x > 0,
+                          lambda x: square(x, 'pos') * 1.0,
+                          lambda x: square(x, 'neg') * 2.0, x)
+
+    _, f_vjp = jax.vjp(f, 3.0)
+    cts, logs = f_vjp.with_logs(1.0)
+    self.assertAllClose(cts[0], 6.0)
+    self.assertEqual(set(logs), {'pos', 'neg'})
+    self.assertIsInstance(logs['pos'], CondSum)
+    i = int(logs['pos'].index)
+    self.assertAllClose(logs['pos'].branches[i], 3.0)      # taken, live
+    self.assertIsNone(logs['pos'].branches[1 - i])         # doesn't log 'pos'
+    self.assertAllClose(logs['neg'].branches[1 - i], 0.0)  # untaken, zeros
+    self.assertIsNone(logs['neg'].branches[i])
+
+    _, f_vjp2 = jax.vjp(f, -3.0)
+    cts2, logs2 = f_vjp2.with_logs(1.0)
+    self.assertAllClose(cts2[0], -12.0)
+    i2 = int(logs2['neg'].index)
+    self.assertAllClose(logs2['neg'].branches[i2], -3.0)
+    self.assertAllClose(logs2['pos'].branches[1 - i2], 0.0)
+
+    def g(x):
+      return jax.lax.cond(
+          x > 0,
+          lambda x: square(x, 'both') * 1.0,
+          lambda x: square(jnp.stack([x, x]), 'both').sum() * 2.0, x)
+
+    _, g_vjp = jax.vjp(g, 3.0)
+    _, glogs = g_vjp.with_logs(1.0)
+    self.assertEqual(set(glogs), {'both'})
+    j = int(glogs['both'].index)
+    self.assertAllClose(glogs['both'].branches[j], 3.0)     # taken, live
+    self.assertAllClose(glogs['both'].branches[1 - j],
+                        jnp.zeros(2))                       # untaken, zeros
+
+    _, g_vjp2 = jax.vjp(g, -3.0)
+    _, glogs2 = g_vjp2.with_logs(1.0)
+    j2 = int(glogs2['both'].index)
+    self.assertAllClose(glogs2['both'].branches[j2], jnp.array([-3., -3.]))
+    self.assertAllClose(glogs2['both'].branches[1 - j2], 0.0)
+
+    # nested conds nest their CondSums
+    def nested(x):
+      inner = lambda x: jax.lax.cond(x > 1, lambda x: square(x, 'deep'),
+                                     lambda x: x * 5.0, x)
+      return jax.lax.cond(x > 0, inner, lambda x: x * 7.0, x)
+    _, n_vjp = jax.vjp(nested, 2.0)
+    _, nlogs = n_vjp.with_logs(1.0)
+    outer = nlogs['deep']
+    self.assertIsInstance(outer, CondSum)
+    inner_log = outer.branches[int(outer.index)]
+    self.assertIsInstance(inner_log, CondSum)
+    self.assertAllClose(inner_log.branches[int(inner_log.index)], 2.0)
+
+    # under jit, and plain grad unaffected
+    _, fj_vjp = jax.vjp(jax.jit(f), 3.0)
+    _, logsj = fj_vjp.with_logs(1.0)
+    self.assertAllClose(logsj['pos'].branches[int(logsj['pos'].index)], 3.0)
+    self.assertAllClose(jax.grad(f)(3.0), 6.0)
+
+  def test_backward_pass_logging_shard_map(self):
+    # Logs from inside a transposed shard_map come out mesh-stacked along
+    # their leading axis (per-shard scalars come out with shape (num_shards,)).
+    class Square(VJPHiPrimitive):
+      def __init__(self, in_aval):
+        self.in_avals = (in_aval,)
+        self.out_aval = in_aval
+        self.params = {}
+        super().__init__()
+
+      def expand(self, x):
+        return x ** 2
+
+      def vjp_fwd(self, nzs_in, x):
+        return self(x), x
+
+      def vjp_bwd(self, res, t, x_accum):
+        if isinstance(x_accum, ad.GradAccum):
+          x_accum.accum(t * 2.0 * res)
+        return {'x': res, 'norm2': (res ** 2).sum()}
+
+    def square(x):
+      return Square(jax.typeof(x))(x)
+
+    mesh = jax.make_mesh((1,), ('i',), axis_types=(jax.sharding.AxisType.Auto,))
+    spec = jax.sharding.PartitionSpec('i')
+    sm = jax.shard_map(lambda x: square(x) * 2.0, mesh=mesh, in_specs=spec,
+                       out_specs=spec)
+    xs = jnp.arange(1., 5.)
+    f = lambda x: sm(x).sum()
+    _, f_vjp = jax.vjp(f, xs)
+    cts, logs = f_vjp.with_logs(1.0)
+    self.assertAllClose(cts[0], 4.0 * xs)
+    self.assertArraysEqual(logs['x'], xs)
+    self.assertEqual(logs['norm2'].shape, (1,))  # one shard
+    self.assertAllClose(logs['norm2'][0], (xs ** 2).sum())
+    self.assertAllClose(jax.grad(f)(xs), 4.0 * xs)
+
+  def test_backward_pass_logging_bad_return(self):
+    class Bad(VJPHiPrimitive):
+      def __init__(self, in_aval):
+        self.in_avals = (in_aval,)
+        self.out_aval = in_aval
+        self.params = {}
+        super().__init__()
+
+      def expand(self, x):
+        return x ** 2
+
+      def vjp_fwd(self, nzs_in, x):
+        return self(x), x
+
+      def vjp_bwd(self, res, t, x_accum):
+        if isinstance(x_accum, ad.GradAccum):
+          x_accum.accum(t * 2.0 * res)
+        return [t]  # not a dict
+
+    with self.assertRaisesRegex(TypeError, "backward-pass log"):
+      jax.vjp(lambda x: Bad(jax.typeof(x))(x), 3.0)[1](1.0)
+
+    bad_id_p = core.Primitive('bad_id')
+    bad_id_p.def_impl(lambda x: x)
+    bad_id_p.def_abstract_eval(lambda a: a)
+    ad.defjvp(bad_id_p, lambda g, x: bad_id_p.bind(g))
+    def bad_transpose(ct, x):
+      if isinstance(x, ad.ValAccum):
+        x.accum(ct)
+      return [ct]  # not a dict
+    ad.fancy_transposes[bad_id_p] = bad_transpose
+
+    with self.assertRaisesRegex(TypeError, "backward-pass log"):
+      jax.vjp(lambda x: bad_id_p.bind(x) * 2., 3.0)[1](1.0)
+
+  def test_backward_pass_logging_with_refs(self):
+    class Square(VJPHiPrimitive):
+      def __init__(self, in_aval):
+        self.in_avals = (in_aval,)
+        self.out_aval = in_aval
+        self.params = {}
+        super().__init__()
+
+      def expand(self, x):
+        return x ** 2
+
+      def vjp_fwd(self, nzs_in, x):
+        return self(x), x
+
+      def vjp_bwd(self, res, t, x_accum):
+        if isinstance(x_accum, ad.GradAccum):
+          x_accum.accum(t * 2.0 * res)
+        return {'sq': {'x': res, 'ct_in': t}}
+
+    def f(x, y):
+      return Square(jax.typeof(x))(x) * y
+
+    _, f_vjp = jax.vjp(f, 3.0, 2.0)
+    arg_cts, logs = f_vjp.with_logs.with_refs(
+        jax.ad.GradValue(), jax.ad.DontWant())(1.0)
+    x_ct, y_ct = arg_cts
+    self.assertAllClose(x_ct, 12.0)  # d(x**2 * y)/dx = 2xy
+    self.assertIsInstance(y_ct, jax.ad.DidntWant)
+    self.assertAllClose(logs, {'sq': {'x': 3.0, 'ct_in': 2.0}},
+                        check_dtypes=False)
+
+    x_ct, y_ct = f_vjp.with_refs(jax.ad.GradValue(), jax.ad.DontWant())(1.0)
+    self.assertAllClose(x_ct, 12.0)
+    (x_ct, y_ct), logs = f_vjp.with_logs(1.0)
+    self.assertAllClose(x_ct, 12.0)
+    self.assertAllClose(y_ct, 9.0)  # d(x**2 * y)/dy = x**2
+    self.assertAllClose(logs, {'sq': {'x': 3.0, 'ct_in': 2.0}},
+                        check_dtypes=False)
+
+  def test_backward_pass_logging_vjp_pytree_roundtrip(self):
+    _, f_vjp = jax.vjp(jnp.sin, 1.0)
+
+    leaves, treedef = jax.tree.flatten(f_vjp)
+    (ct,) = jax.tree.unflatten(treedef, leaves)(1.0)
+    self.assertAllClose(ct, jnp.cos(1.0))
+
+    leaves, treedef = jax.tree.flatten(f_vjp.with_logs)
+    (ct,), logs = jax.tree.unflatten(treedef, leaves)(1.0)
+    self.assertAllClose(ct, jnp.cos(1.0))
+    self.assertEqual(logs, {})
+
+  def test_backward_pass_logging_call_primitives(self):
+    from jax._src import api_util
+    from jax._src import flattree as ft
+    from jax._src.compute_on import compute_on2
+    from jax._src.interpreters import mlir, partial_eval as pe
+    from jax._src.lax.eval_jaxpr import eval_jaxpr_p
+    from jax.experimental.scheduling_groups import scheduling_group
+
+    log_id_p = core.Primitive('log_id')
+    log_id_p.def_impl(lambda x: x)
+    log_id_p.def_abstract_eval(lambda a: a)
+    ad.defjvp(log_id_p, lambda g, x: log_id_p.bind(g))
+    mlir.register_lowering(log_id_p, lambda ctx, x: [x])
+    def _log_id_transpose(ct, x):
+      if isinstance(x, ad.ValAccum):
+        x.accum(ct)
+      return {'canary': ct}
+    ad.fancy_transposes[log_id_p] = _log_id_transpose
+
+    def f(x):
+      return log_id_p.bind(jnp.sin(x)) * 2.
+
+    dbg = api_util.debug_info('test', f, (1.0,), {})
+    args_ft = ft.flatten(((1.0,), {}))
+    jaxpr, _ = pe.trace_to_jaxpr(f, args_ft.map(core.shaped_abstractify), dbg)
+
+    fns = [scheduling_group('g')(f),
+           compute_on2(f, compute_type='device_host',
+                       out_memory_spaces=jax.memory.Space.Device),
+           lambda x: eval_jaxpr_p.bind(x, jaxpr=jaxpr)[0]]
+    for fn in fns:
+      _, f_vjp = jax.vjp(fn, 1.0)
+      cts, logs = f_vjp.with_logs(1.0)
+      self.assertAllClose(cts[0], 2 * jnp.cos(1.0))
+      self.assertAllClose(logs, {'canary': jnp.float32(2.0)},
+                          check_dtypes=False)
+      (ct,) = f_vjp(1.0)  # plain call drops the logs without error
+      self.assertAllClose(ct, 2 * jnp.cos(1.0))
+
   def test_jvp_derived_from_lin(self):
     class RaiseToStaticPower(VJPHiPrimitive):
       def __init__(self, in_aval, *, power):


### PR DESCRIPTION
Transpose rules can now log named pytrees of data out of the backward pass.  Instead of `f_vjp(out_ct)`, call `f_vjp.with_logs(out_ct)` to get a pair `(arg_cts, logs)`, where logs is a dict; plain `f_vjp(out_ct)` drops the logs (and under jit the logging compute gets DCE'd away). `with_logs` is a property returning a logs-flavored VJP, so it composes with gradient refs: `f_vjp.with_logs.with_refs(*refs)(out_ct)`.

Rules opt in by returning a dict (or None, meaning {}, the monoid identity) from a new output slot; existing accumulator-style rules all return None, so they need no updating. In particular, a `VJPHiPrimitive`'s `vjp_bwd` (or transpose) rule can return a dict of log entries (a `vjp_bwd` that receives structured residuals logs the same way). backward_pass3 merges the rules' dicts with clobber semantics, in backward execution order, so on a key collision the earlier-in-forward-order rule wins.

Higher-order primitives plumb logs out of their transposed computations by appending the inner backward pass's log leaves to the transposed jaxpr's outputs, next to the cotangents; the transpose rule splits them back off after the call and returns the reassembled dict. jit, call, closed_call (via call_transpose_fancy), eval_jaxpr, xla_metadata_call, and compute_on relay the body's logs unchanged this way (compute_on's transpose rule migrated from the legacy backward_pass to an accumulator-style fancy rule to participate). Three primitives additionally transform the logged values in transit:
* scan: the body's per-iteration log dict is stacked leaf-wise (extra ys of the reversed scan, index-aligned with the forward iterations);
* cond: each value of the branches' log dicts is wrapped, per key, in a tagged product (CondSum, shared with cond's structured residuals) with one slot per branch. If a cond's branches' backward passes log

    branch 0: {'a': v0, 'b': w}          branch 1: {'a': v1}

  then transposing the cond when branch 1 was taken logs

    {'a': CondSum(index=1, branches=[zeros_like(v0), v1]),
     'b': CondSum(index=1, branches=[zeros_like(w), None])}

  so branches needn't agree on keys or types, sibling conds don't collide since user keys stay top-level, and nested conds nest their CondSums;
* shard_map: per-shard log values come out mesh-stacked along their leading axis (per-shard scalars become shape (num_shards,) vectors).

Logs inside remat, custom_vjp bwd rules, fused, and while_loop are not plumbed yet and are silently dropped, consistent with the drop-by-default semantics.