### PR TITLE
[vjp3] xla_call_metadata_call / compute_on lojax rules, sres, logging

### DIFF
--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -1346,11 +1346,13 @@ pytype_strict_library(
         ":config",
         ":core",
         ":effects",
+        ":flattree",
         ":mlir",
         ":partial_eval",
         ":source_info_util",
         ":tree_util",
         ":util",
+        ":xla_metadata",
         "//jax/_src/lib",
     ],
 )

--- a/jax/_src/compute_on.py
+++ b/jax/_src/compute_on.py
@@ -26,7 +26,9 @@ from jax._src import effects as effects_lib
 from jax._src import linear_util as lu
 from jax._src import source_info_util
 from jax._src.interpreters import ad, batching, mlir, partial_eval as pe
+from jax._src import flattree as ft
 from jax._src.tree_util import tree_flatten, tree_leaves, tree_unflatten
+from jax._src.xla_metadata import _check_no_qdd
 from jax._src.util import (safe_map, safe_zip, weakref_lru_cache, unzip2,
                            split_list, subs_list, merge_lists)
 from jax._src.api_util import debug_info, flatten_fun_nokwargs, flatten_axes
@@ -222,6 +224,16 @@ def _compute_on_lin(is_vjp, nzs, *primals, jaxpr, compute_type,
       ad.linearize_jaxpr(jaxpr, nzs, is_vjp=is_vjp)
   _, ures_avals, sres_avals = out_tree.unpack()
   num_res_out = len(ures_avals) + len(sres_avals)
+  num_primals_out = len(primal_jaxpr.out_avals) - num_res_out
+
+  _, in_fwd_ures, in_fwd_sres = split_list(
+      pe._jaxpr_forwarding(primal_jaxpr), [num_primals_out, len(ures_avals)])
+  assert all(f is None for f in in_fwd_ures)
+  in_fwd = [None] * (num_primals_out + len(ures_avals)) + in_fwd_sres
+  primal_jaxpr = pe.prune_closed_jaxpr_outputs(
+      primal_jaxpr, [f is None for f in in_fwd])
+  primal_jaxpr, out_fwd = pe.dedup_jaxpr_outputs(primal_jaxpr, num_primals_out)
+  num_kept_res = sum(f is None for f in out_fwd) - num_primals_out
 
   tangent_avals_out = [a.to_tangent_aval() for a in jaxpr.out_avals]
   def _filter_zeros(is_nz_l, l):
@@ -245,10 +257,12 @@ def _compute_on_lin(is_vjp, nzs, *primals, jaxpr, compute_type,
     assert next(nz_outs_, None) is None
     return outs
 
-  primal_out_mem_spaces = out_memory_spaces + (core.MemorySpace.Device,) * num_res_out
+  primal_out_mem_spaces = out_memory_spaces + (core.MemorySpace.Device,) * num_kept_res
   ans = compute_on_p.bind(*primals, jaxpr=primal_jaxpr, compute_type=compute_type,
                           out_memory_spaces=primal_out_mem_spaces,
                           compiler_options_json=compiler_options_json)
+  ans = subs_list(out_fwd, ans, ans)
+  ans = subs_list(in_fwd, primals, ans)
   primal_ans, residuals_ans = split_list(ans, [len(ans) - num_res_out])
   ures, sres_flat = split_list(residuals_ans, [len(ures_avals)])
   ures = subs_list(in_fwd_res, [*jaxpr.consts, *primals], ures)
@@ -381,6 +395,26 @@ def _compute_on_transpose(cts_in, *args, jaxpr, compute_type,
       x.accum(ct)
   return logs
 ad.fancy_transposes[compute_on_p] = _compute_on_transpose
+
+
+def _compute_on_to_lojax(*hi_args, jaxpr, compute_type, out_memory_spaces,
+                         compiler_options_json):
+  _check_no_qdd(jaxpr, 'compute_on')
+  lo_args_lol = [a.lower_val(x) for a, x in zip(jaxpr.in_avals, hi_args)]
+  lo_args = [x for xs in lo_args_lol for x in xs]
+  in_avals = ft.flatten(([[core.typeof(x) for x in xs] for xs in lo_args_lol],
+                         {}))
+  lo_jaxpr, out_avals = pe.lower_jaxpr(jaxpr, in_avals)
+  _, out_lol = out_avals.unpack()
+  lo_spaces = tuple(s for l, s in zip(out_lol.unpack(), out_memory_spaces)
+                    for _ in l)
+  all_outs = compute_on_p.bind(*lo_args, jaxpr=lo_jaxpr,
+                               compute_type=compute_type,
+                               out_memory_spaces=lo_spaces,
+                               compiler_options_json=compiler_options_json)
+  _, lo_outs = out_avals.update(all_outs).unpack()
+  return [a.raise_val2(y) for a, y in zip(jaxpr.out_avals, lo_outs.unpack())]
+compute_on_p.to_lojax = _compute_on_to_lojax
 
 def dce_jaxpr_compute_on_rule(used_outputs: list[bool], eqn: pe.JaxprEqn
                               ) -> tuple[list[bool], pe.JaxprEqn | None]:

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1281,6 +1281,25 @@ _prune_jaxpr_outputs_cached = weakref_lru_cache(_prune_jaxpr_outputs)
 # (attached consts are preserved by Jaxpr.replace).
 prune_closed_jaxpr_outputs = prune_jaxpr_outputs
 
+def dedup_jaxpr_outputs(jaxpr: Jaxpr, num_kept_prefix: int,
+                        fwdable_prefix: Sequence[bool] | None = None,
+                        ) -> tuple[Jaxpr, list[int | None]]:
+  """Prune duplicated outputs, for callers to restore after evaluation."""
+  prefix_vars, rest_vars = split_list(jaxpr.outvars, [num_kept_prefix])
+  fwdable = ([True] * num_kept_prefix if fwdable_prefix is None
+             else fwdable_prefix)
+  idx_map = {id(v): i for i, (v, f) in enumerate(zip(prefix_vars, fwdable))
+             if f}
+  num_kept = num_kept_prefix
+  out_fwd: list[int | None] = [None] * num_kept_prefix
+  for v in rest_vars:
+    if (fwd := idx_map.get(id(v))) is None:
+      idx_map[id(v)] = num_kept
+      num_kept += 1
+    out_fwd.append(fwd)
+  jaxpr = prune_jaxpr_outputs(jaxpr, [f is None for f in out_fwd])
+  return jaxpr, out_fwd
+
 
 def dce_jaxpr(jaxpr: Jaxpr, used_outputs: bool | Sequence[bool],
               instantiate: bool | Sequence[bool] = False,

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -868,19 +868,10 @@ def _scan_linearize(is_vjp, nzs, *primals_in, reverse: bool, length: int,
   # stacked primal ys output or an earlier residual (but not a carry output,
   # which is the final rather than the stacked value), so return one copy of
   # each from the scan and re-duplicate after the bind below.
-  prim_out_vars, res_out_vars = split_list(primal_jaxpr.outvars, [num_primals_out])
-  idx_map = {id(v): i for i, v in enumerate(prim_out_vars[num_carry:], num_carry)}
-  res_fwd: list[int | None] = [None] * num_primals_out
-  num_kept = num_primals_out
-  for v in res_out_vars:
-    fwd = idx_map.get(id(v))
-    res_fwd.append(fwd)
-    if fwd is None:
-      idx_map[id(v)] = num_kept  # index into the pruned outputs
-      num_kept += 1
-  primal_jaxpr = pe.prune_closed_jaxpr_outputs(
-      primal_jaxpr, [f is None for f in res_fwd])
-  num_kept_res = num_kept - num_primals_out
+  primal_jaxpr, res_fwd = pe.dedup_jaxpr_outputs(
+      primal_jaxpr, num_primals_out,
+      [False] * num_carry + [True] * (num_primals_out - num_carry))
+  num_kept_res = sum(f is None for f in res_fwd) - num_primals_out
 
   # Run the primal scan (if it has any outputs or effects).
   if not primal_jaxpr.out_avals and not primal_jaxpr.effects:

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1650,17 +1650,8 @@ def _pjit_linearize(is_vjp, nzs, *primals_in, jaxpr, in_shardings, out_shardings
   # multiple tree positions), so return one copy of each and re-duplicate
   # after the bind below.
   num_primals_out = len(fwd_jaxpr.out_avals) - num_kept_residuals
-  out_vars, res_vars = split_list(fwd_jaxpr.outvars, [num_primals_out])
-  idx_map = {id(v): i for i, v in enumerate(out_vars)}
-  num_kept = num_primals_out
-  out_fwd: list[int | None] = [None] * num_primals_out
-  for v in res_vars:
-    if (fwd := idx_map.get(id(v))) is None:
-      idx_map[id(v)] = num_kept
-      num_kept += 1
-    out_fwd.append(fwd)
+  fwd_jaxpr, out_fwd = pe.dedup_jaxpr_outputs(fwd_jaxpr, num_primals_out)
   keep = [f is None for f in out_fwd]
-  fwd_jaxpr = pe.prune_closed_jaxpr_outputs(fwd_jaxpr, keep)
   primal_out_shardings = keep_where(primal_out_shardings, keep)
   primal_out_layouts = keep_where(primal_out_layouts, keep)
   del keep

--- a/jax/_src/xla_metadata.py
+++ b/jax/_src/xla_metadata.py
@@ -368,6 +368,15 @@ def _xla_metadata_call_lin(is_vjp, nzs, *primals, jaxpr, xla_metadata,
       ad.linearize_jaxpr(jaxpr, nzs, is_vjp=is_vjp)
   _, ures_avals, sres_avals = out_tree.unpack()
   num_residuals_out = len(ures_avals) + len(sres_avals)
+  num_primals_out = len(primal_jaxpr.out_avals) - num_residuals_out
+
+  _, in_fwd_ures, in_fwd_sres = split_list(
+      pe._jaxpr_forwarding(primal_jaxpr), [num_primals_out, len(ures_avals)])
+  assert all(f is None for f in in_fwd_ures)
+  in_fwd = [None] * (num_primals_out + len(ures_avals)) + in_fwd_sres
+  primal_jaxpr = pe.prune_closed_jaxpr_outputs(
+      primal_jaxpr, [f is None for f in in_fwd])
+  primal_jaxpr, out_fwd = pe.dedup_jaxpr_outputs(primal_jaxpr, num_primals_out)
 
   tangent_avals_out = [a.to_tangent_aval() for a in jaxpr.out_avals]
   tangent_metadata = _resolve_ad_metadata(xla_metadata, ad_metadata)
@@ -395,6 +404,8 @@ def _xla_metadata_call_lin(is_vjp, nzs, *primals, jaxpr, xla_metadata,
   ans = xla_metadata_call_p.bind(*primals, jaxpr=primal_jaxpr,
                                  xla_metadata=xla_metadata,
                                  ad_metadata=ad_metadata)
+  ans = subs_list(out_fwd, ans, ans)
+  ans = subs_list(in_fwd, primals, ans)
   primal_ans, residuals_ans = split_list(ans, [len(ans) - num_residuals_out])
   ures, sres_flat = split_list(residuals_ans, [len(ures_avals)])
   ures = subs_list(in_fwd_res, [*jaxpr.consts, *primals], ures)
@@ -440,6 +451,28 @@ def _xla_metadata_call_transpose(cts_in, *args, jaxpr, xla_metadata,
 
 
 ad.fancy_transposes[xla_metadata_call_p] = _xla_metadata_call_transpose
+
+
+def _xla_metadata_call_to_lojax(*hi_args, jaxpr, xla_metadata, ad_metadata):
+  _check_no_qdd(jaxpr, 'xla_metadata_call')
+  lo_args_lol = [a.lower_val(x) for a, x in zip(jaxpr.in_avals, hi_args)]
+  lo_args = [x for xs in lo_args_lol for x in xs]
+  in_avals = ft.flatten(([[core.typeof(x) for x in xs] for xs in lo_args_lol],
+                         {}))
+  lo_jaxpr, out_avals = pe.lower_jaxpr(jaxpr, in_avals)
+  all_outs = xla_metadata_call_p.bind(*lo_args, jaxpr=lo_jaxpr,
+                                      xla_metadata=xla_metadata,
+                                      ad_metadata=ad_metadata)
+  _, lo_outs = out_avals.update(all_outs).unpack()
+  return [a.raise_val2(y) for a, y in zip(jaxpr.out_avals, lo_outs.unpack())]
+xla_metadata_call_p.to_lojax = _xla_metadata_call_to_lojax
+
+def _check_no_qdd(jaxpr, name):
+  if (any(a.has_qdd for a in jaxpr.in_avals) or
+      any(core.typeof(c).has_qdd for c in jaxpr.consts)):
+    raise NotImplementedError(
+        f"hijax values with quasi-dynamic data (e.g. Boxes) are not "
+        f"supported in {name} bodies")
 
 
 def _xla_metadata_call_partial_eval_custom_params_updater(

--- a/jax/experimental/BUILD
+++ b/jax/experimental/BUILD
@@ -643,6 +643,7 @@ pytype_strict_library(
         "//jax/_src:api_util",
         "//jax/_src:batching",
         "//jax/_src:core",
+        "//jax/_src:flattree",
         "//jax/_src:mlir",
         "//jax/_src:partial_eval",
         "//jax/_src:tree_util",

--- a/jax/experimental/fused.py
+++ b/jax/experimental/fused.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from jax._src import core
+from jax._src import flattree as ft
 from jax._src import linear_util as lu
 from jax._src import dispatch
 from jax._src.core import typeof
@@ -157,3 +158,18 @@ def _transpose_jaxpr(jaxpr, in_tree, in_avals):
       lu.wrap_init(transposed, debug_info=dbg), in_avals)
   return trans_jaxpr.with_consts(consts), cell.out_tree  # pyrefly: ignore[missing-attribute]
 ad.primitive_transposes[fused_p] = _fused_transpose
+
+
+def _fused_to_lojax(*hi_args, jaxpr, out_spaces):
+  from jax._src.xla_metadata import _check_no_qdd  # pyrefly: ignore[missing-import]
+  _check_no_qdd(jaxpr, 'fused')
+  lo_args_lol = [a.lower_val(x) for a, x in zip(jaxpr.in_avals, hi_args)]
+  lo_args = [x for xs in lo_args_lol for x in xs]
+  in_avals = ft.flatten(([[typeof(x) for x in xs] for xs in lo_args_lol], {}))
+  lo_jaxpr, out_avals = pe.lower_jaxpr(jaxpr, in_avals)
+  _, out_lol = out_avals.unpack()
+  lo_spaces = tuple(s for l, s in zip(out_lol.unpack(), out_spaces) for _ in l)
+  all_outs = fused_p.bind(*lo_args, jaxpr=lo_jaxpr, out_spaces=lo_spaces)
+  _, lo_outs = out_avals.update(all_outs).unpack()
+  return [a.raise_val2(y) for a, y in zip(jaxpr.out_avals, lo_outs.unpack())]
+fused_p.to_lojax = _fused_to_lojax

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -1955,6 +1955,75 @@ class HijaxTest(jtu.JaxTestCase):
     self.assertAllClose(ct, jnp.cos(1.0))
     self.assertEqual(logs, {})
 
+  @jtu.run_on_devices("cpu")  # TODO(mattjj): debug xla failures
+  def test_hijax_inside_call_primitives(self):
+    from jax._src.compute_on import compute_on2
+    from jax.experimental.fused import fused
+    from jax.experimental.scheduling_groups import scheduling_group
+
+    class Square(VJPHiPrimitive):
+      def __init__(self, in_aval):
+        self.in_avals = (in_aval,)
+        self.out_aval = in_aval
+        self.params = {}
+        super().__init__()
+
+      def expand(self, x):
+        return x ** 2
+
+      def lin(self, nzs_in, x):
+        c = x * 2.0
+        return self(x), (), True, {'x1': x, 'x2': x, 'c1': c, 'c2': c}
+
+      def linearized(self, res, sres, t):
+        return t * sres['c2']
+
+      def vjp_fwd(self, nzs_in, x):
+        c = x * 2.0
+        return self(x), (), True, {'x1': x, 'x2': x, 'c1': c, 'c2': c}
+
+      def vjp_bwd(self, res, sres, t, x_accum):
+        if isinstance(x_accum, ad.GradAccum):
+          x_accum.accum(t * sres['c1'])
+        return {'sq': sres['x1']}
+
+    def square(x):
+      return Square(jax.typeof(x))(x)
+
+    co = lambda f: compute_on2(f, compute_type='device_host',
+                               out_memory_spaces=jax.memory.Space.Device)
+    for wrap, prim_name in [(scheduling_group('g'), 'xla_metadata_call'),
+                            (co, 'compute_on')]:
+      f = wrap(square)
+      self.assertAllClose(f(3.0), 9.0)
+      self.assertAllClose(jax.grad(f)(3.0), 6.0)
+      self.assertAllClose(jax.grad(jax.jit(f))(3.0), 6.0)
+      _, f_vjp = jax.vjp(f, 3.0)
+      cts, logs = f_vjp.with_logs(1.0)
+      self.assertAllClose(cts[0], 6.0)
+      self.assertAllClose(logs['sq'], 3.0)
+      leaves = jax.tree.leaves(f_vjp.structured_residuals)
+      self.assertLen(leaves, 4)
+      self.assertIs(leaves[0], leaves[1])  # c pair, deduped
+      self.assertIs(leaves[2], leaves[3])  # x pair, input-forwarded
+      jaxpr = jax.make_jaxpr(lambda x: jax.vjp(f, x)[1](1.0))(3.0)
+      fwd_eqn = next(e for e in jaxpr.eqns if e.primitive.name == prim_name)
+      self.assertLen(fwd_eqn.outvars, 2)
+
+    ff = fused(out_spaces=(jax.memory.Space.Device,))(square)
+    lo = jax.jit(ff).trace(3.0).lojax.jaxpr
+    eqn = next(e for e in lo.jaxpr.eqns if e.primitive.name == 'fused_call')
+    self.assertFalse(eqn.params['jaxpr'].is_high)
+    self.assertEqual(eqn.params['out_spaces'], (jax.memory.Space.Device,))
+
+    box = new_box()
+    box_set(box, 0.0)
+    def g(x):
+      box_set(box, x * 2.0)
+      return x * 3.0
+    with self.assertRaisesRegex(NotImplementedError, "quasi-dynamic"):
+      scheduling_group('g')(g)(1.0)
+
   def test_backward_pass_logging_call_primitives(self):
     from jax._src import api_util
     from jax._src import flattree as ft


### PR DESCRIPTION
This is just updating the xla_metadata_call and compute_on HOPs to catch up with some recent AD features: lojax rules, structured residuals, and backward pass logging. They basically look like the pjit (ie call) path.