### PR TITLE
Fix `_get_prime_factors` dropping smaller factors when the largest prime factor exceeds `isqrt(x) + 1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 
 ## Unreleased
 
+* Bug fixes:
+  * Fixed the prime factorization helper used by
+    `jax.experimental.mesh_utils.create_device_mesh` with
+    `allow_split_physical_axes=True`, which dropped all but the largest prime
+    factor for sizes such as 10 or 14 and made mesh construction fail with a
+    reshape error ({jax-issue}`#38286`).
+
 ## JAX 0.11.0 (July 16, 2026)
 
 * New features

--- a/jax/_src/mesh_utils.py
+++ b/jax/_src/mesh_utils.py
@@ -460,8 +460,8 @@ def _get_prime_factors(x: int) -> list[int]:
       x //= p
     if x == 1:
       return factors
-  else:
-    return [x]  # x is a prime number.
+  factors.append(x)  # remaining x is a prime larger than isqrt of the input.
+  return factors
 
 
 def _enumerate_feasible_logical_axis_assignments(

--- a/tests/mesh_utils_test.py
+++ b/tests/mesh_utils_test.py
@@ -16,6 +16,7 @@
 import collections
 from collections.abc import Sequence
 import dataclasses
+import math
 
 from absl import logging
 from absl.testing import absltest
@@ -728,6 +729,37 @@ class SplitAxesDeviceMeshCreationTest(test_util.JaxTestCase):
     self.assertEqual(mesh_utils._get_prime_factors(12), [2, 2, 3])
     self.assertEqual(mesh_utils._get_prime_factors(121), [11, 11])  # square
     self.assertEqual(mesh_utils._get_prime_factors(43), [43])  # prime
+    # https://github.com/jax-ml/jax/issues/38286: composites whose largest
+    # prime factor exceeds isqrt(x) + 1 used to drop the smaller factors.
+    self.assertEqual(mesh_utils._get_prime_factors(10), [2, 5])
+    self.assertEqual(mesh_utils._get_prime_factors(14), [2, 7])
+    self.assertEqual(mesh_utils._get_prime_factors(44), [2, 2, 11])
+    # The factorization must reconstruct the input, in sorted order.
+    for n in range(1, 1000):
+      factors = mesh_utils._get_prime_factors(n)
+      self.assertEqual(math.prod(factors), n)
+      self.assertEqual(factors, sorted(factors))
+
+  def test_create_device_mesh_splitting_axes_with_large_prime_factor(self):
+    # https://github.com/jax-ml/jax/issues/38286: constructing a logical mesh
+    # whose axis size has a prime factor larger than isqrt(size) + 1 used to
+    # fail with a reshape ValueError.
+    physical_mesh = get_int_mesh([2, 5])
+    logical_mesh, assignment = (
+        mesh_utils._create_device_mesh_for_nd_torus_splitting_axes(
+            physical_mesh, [10]
+        )
+    )
+    self.assertEqual(logical_mesh.shape, (10,))
+    self.assertArraysEqual(
+        np.sort(logical_mesh.ravel()), np.arange(10, dtype=np.int64)
+    )
+    self.assertArraysEqual(
+        np.prod(assignment, axis=0), np.array([10], dtype=np.int64)
+    )
+    self.assertArraysEqual(
+        np.prod(assignment, axis=1), np.array([2, 5], dtype=np.int64)
+    )
 
   @parameterized.named_parameters(
       (


### PR DESCRIPTION
Fixes #38286.

`_get_prime_factors` in `jax/_src/mesh_utils.py` used `for … else` with no
`break` in the loop, so the `else` branch ran on every normal loop completion
and returned only the residual `[x]`, discarding the factors already
collected. Any composite whose largest prime factor exceeds `isqrt(x) + 1`
was mis-factored: `10 → [5]`, `14 → [7]`, `22 → [11]`, …

The bug was invisible for numbers whose prime factors all lie within the
trial-division bound (they collapse to 1 inside the loop and take the early
return) and for primes (the discarded list is empty), which is why the
existing unit test never caught it.

Downstream, `_enumerate_feasible_logical_axis_assignments` receives a wrong
factor multiset, so logical-mesh construction with
`allow_split_physical_axes=True` enumerates assignments whose product doesn't
match the axis size and fails, e.g. building a `(10,)` logical mesh from a
2×5 physical mesh raises `ValueError: cannot reshape array of size 10 into
shape (1,5)`.

The fix replaces the `for…else` with an unconditional post-loop append of the
residual, which at that point is always a prime larger than every appended
trial divisor (so the output stays sorted). Behavior on previously-correct
inputs is unchanged.

- `jax/_src/mesh_utils.py`: 2-line fix in `_get_prime_factors`.
- `tests/mesh_utils_test.py`: extend `test_get_prime_factors` with the
  previously-broken cases (10, 14, 44) and add
  `test_create_device_mesh_splitting_axes_with_large_prime_factor`, which
  builds a `(10,)` mesh from a 2×5 physical mesh and checks the assignment
  invariants. Both fail before the fix.
- `CHANGELOG.md`: bug-fix entry.