### PR TITLE
Remove the false-positive `no_tracing` check from the jit dispatch slow path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,13 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     instances ({jax-issue}`#39297`).
   * Fixed `_get_prime_factors` in `jax.experimental.mesh_utils`
     ({jax-issue}`#38286`).
+  * `jax.no_tracing` no longer raises a spurious "re-tracing" error on warm
+    calls that miss the C++ dispatch fastpath without actually re-tracing,
+    such as every call of a jitted function containing a host callback
+    ({jax-issue}`#39289`). Relatedly, transformations of an already-traced
+    jitted function (e.g. a first `jax.grad` call) may now derive and compile
+    new executables under `no_tracing` without raising, since no Python code
+    is re-traced; previously any such call raised.
 
 ## JAX 0.11.0 (July 16, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     all. The amax outputs are whole-batch statistics and do not carry the
     vmap axis; vmap over the scale/descale operands raises a clear
     `NotImplementedError`.
+  * `jax.no_tracing` no longer raises a spurious "re-tracing" error on warm
+    calls that miss the C++ dispatch fastpath without actually re-tracing,
+    such as every call of a jitted function containing a host callback
+    ({jax-issue}`#39289`). Relatedly, transformations of an already-traced
+    jitted function (e.g. a first `jax.grad` call) may now derive and compile
+    new executables under `no_tracing` without raising, since no Python code
+    is re-traced; previously any such call raised.
 
 ## JAX 0.11.0 (July 16, 2026)
 

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -258,9 +258,6 @@ def _cpp_pjit(fun: Callable, jit_info: PjitInfo):
   def cache_miss(*args, **kwargs):
     # args do not include the const args
     # See https://docs.jax.dev/en/latest/internals/constants.html.
-    if config.no_tracing.value:
-      raise RuntimeError(f"re-tracing function {jit_info.fun_sourceinfo} for "
-                         "`jit`, but 'no_tracing' is set")
     p, args_flat = _infer_params(fun, jit_info, args, kwargs)
     (outs, out_flat, out_tree, args_flat, jaxpr,
      executable, pgle_profiler, const_args) = _run_python_pjit(

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1572,6 +1572,25 @@ class JitTest(jtu.BufferDonationTestCase):
       with jax.no_tracing():
         _ = f(y)  # crash!
 
+  def test_no_tracing_warm_call_with_callback(self):
+    # https://github.com/jax-ml/jax/issues/39289
+    @jax.jit
+    def f(x):
+      jax.debug.callback(lambda _: None, x)
+      return x + 1
+
+    # inputs created outside no_tracing to avoid cold internal jits
+    x = jnp.arange(3.)
+    y = jnp.arange(4.)
+    _ = f(x)  # compile once
+
+    with jax.no_tracing():
+      _ = f(x)  # warm call, callbacks never take the C++ fastpath; no crash
+
+    with self.assertRaisesRegex(RuntimeError, 'no_tracing'):
+      with jax.no_tracing():
+        _ = f(y)  # new shape, genuine re-trace: crash!
+
   def test_no_execution(self):
     @jax.jit
     def f():

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1552,6 +1552,25 @@ class JitTest(jtu.BufferDonationTestCase):
       with jax.no_tracing():
         _ = f(y)  # crash!
 
+  def test_no_tracing_warm_call_with_callback(self):
+    # https://github.com/jax-ml/jax/issues/39289
+    @jax.jit
+    def f(x):
+      jax.debug.callback(lambda _: None, x)
+      return x + 1
+
+    # inputs created outside no_tracing to avoid cold internal jits
+    x = jnp.arange(3.)
+    y = jnp.arange(4.)
+    _ = f(x)  # compile once
+
+    with jax.no_tracing():
+      _ = f(x)  # warm call, callbacks never take the C++ fastpath; no crash
+
+    with self.assertRaisesRegex(RuntimeError, 'no_tracing'):
+      with jax.no_tracing():
+        _ = f(y)  # new shape, genuine re-trace: crash!
+
   def test_no_execution(self):
     @jax.jit
     def f():


### PR DESCRIPTION
Fixes #39289.

`jax.no_tracing()` was checked in two places:

1. at the top of `trace_to_jaxpr_nocache` (`jax/_src/interpreters/partial_eval.py`),
   which fires exactly when a jaxpr is about to be built, and
2. at the top of `cache_miss` in `jax/_src/pjit.py`, which fires on **any** C++
   fastpath miss, before any Python-level cache is consulted.

The second check conflates "missed the C++ dispatch cache" with "re-tracing".
Jitted functions containing host callbacks (`jax.debug.print`,
`jax.debug.callback`, `io_callback`) are permanently excluded from the C++
fastpath (`_get_fastpath_data` returns `None` for effectful executables), so
every warm call of such a function entered `cache_miss` and raised
`RuntimeError: re-tracing function ... but 'no_tracing' is set` even though the
Python trace cache hit and no tracing occurred.

This PR removes the coarse check. Genuine re-traces (cold compiles, shape/dtype
changes, AOT `.trace()`/`.lower()`) all build jaxprs through
`trace_to_jaxpr_nocache`, so they still raise, which the updated test asserts.

Note: this drops an undocumented side-behavior — the old check also detected
Python-dispatch slow paths for *pure* functions with C++-cache anomalies
(e.g. #39089), and it incidentally made cold transformations of an
already-traced jitted function (e.g. a first `jax.grad` call) raise even
though such calls derive new jaxprs from existing jaxprs without re-tracing
any Python code; those now proceed (and may compile) silently. If
slow-dispatch detection is wanted, it should live behind a separately named
guard rather than `no_tracing`, whose help string ("Disallow tracing for JIT
compilation.") and introducing commits (#23222, #24165) both describe tracing
semantics.

- `jax/_src/pjit.py`: delete the 3-line check in `cache_miss`.
- `tests/api_test.py`: add `test_no_tracing_warm_call_with_callback` — a warm
  call of a callback-carrying jitted function under `no_tracing` must not
  raise; a shape-changing call under `no_tracing` must still raise. Fails
  before this change, passes after.
- `CHANGELOG.md`: bug-fix entry.