### PR TITLE
Fix namedtuple keys in one-level pytree flattening

### DIFF
--- a/jaxlib/pytree.cc
+++ b/jaxlib/pytree.cc
@@ -386,10 +386,9 @@ nb::object PyTreeRegistry::FlattenOneLevelImpl(nb::handle x,
               "A namedtuple's _fields attribute should have the same size as "
               "the tuple.");
         }
-        auto field_iter = fields.begin();
-        for (nb::handle entry : in) {
+        for (size_t i = 0; i < in.size(); ++i) {
           out.append(nb::make_tuple(
-              make_nb_class<GetAttrKey>(nb::str(*field_iter)), entry));
+              make_nb_class<GetAttrKey>(nb::str(fields[i])), in[i]));
         }
         return nb::make_tuple(std::move(out), x.type());
       }

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -992,6 +992,12 @@ class TreeTest(jtu.JaxTestCase):
                                        (SequenceKey(1), tree1["sub"][1])])
     self.assertIsNone(meta)
 
+    # Namedtuple
+    children, meta = tree_util.flatten_one_level_with_keys(tree1["sub"][1])
+    self.assertEqual(list(children), [(GetAttrKey("foo"), ()),
+                                       (GetAttrKey("bar"), [None])])
+    self.assertIs(meta, ATuple)
+
     # Custom object with keys
     children, meta = tree_util.flatten_one_level_with_keys(tree1["obj"])
     self.assertEqual(list(children), [("x", EmptyTuple()), ("y", 0)])


### PR DESCRIPTION
Fixes #39297.

Tests:
- `bazel test //tests:tree_util_test --test_filter=TreeTest.testFlattenOneLevelWithKeys --macos_minimum_os=11.0 --macos_sdk_version=26.2`
- `bazel test //tests:tree_util_test --macos_minimum_os=11.0 --macos_sdk_version=26.2` (474 tests passed, 23 skipped)
- Applicable pre-commit hooks for `jaxlib/pytree.cc` and `tests/tree_util_test.py` (AST, merge-conflict, EOF, debug statements, trailing whitespace, ruff, pyrefly, copyright)
