### PR TITLE
Fix _get_prime_factors dropping smaller factors for numbers with a large prime factor

### DIFF
--- a/jax/_src/mesh_utils.py
+++ b/jax/_src/mesh_utils.py
@@ -461,7 +461,7 @@ def _get_prime_factors(x: int) -> list[int]:
     if x == 1:
       return factors
   else:
-    return [x]  # x is a prime number.
+    return factors + [x]  # the remaining part is prime; keep the factors found so far
 
 
 def _enumerate_feasible_logical_axis_assignments(

--- a/tests/mesh_utils_test.py
+++ b/tests/mesh_utils_test.py
@@ -728,6 +728,10 @@ class SplitAxesDeviceMeshCreationTest(test_util.JaxTestCase):
     self.assertEqual(mesh_utils._get_prime_factors(12), [2, 2, 3])
     self.assertEqual(mesh_utils._get_prime_factors(121), [11, 11])  # square
     self.assertEqual(mesh_utils._get_prime_factors(43), [43])  # prime
+    # A prime factor larger than isqrt(x) must not drop the smaller factors.
+    self.assertEqual(mesh_utils._get_prime_factors(10), [2, 5])
+    self.assertEqual(mesh_utils._get_prime_factors(15), [3, 5])
+    self.assertEqual(mesh_utils._get_prime_factors(35), [5, 7])
 
   @parameterized.named_parameters(
       (


### PR DESCRIPTION
`_get_prime_factors` returns `[x]` in its `for/else`, discarding the factors already collected when a prime factor larger than `isqrt(x)` remains. So the result isn't a factorization of the input:

```python
_get_prime_factors(10)  # -> [5]   (should be [2, 5])
_get_prime_factors(15)  # -> [5]   (should be [3, 5])
_get_prime_factors(35)  # -> [7]   (should be [5, 7])
```

`prod(result) != x`. Numbers whose largest prime factor is ≤ `isqrt(x)` (e.g. the values in the existing test: 6, 12, 16, 121) happen to work, which is why it went unnoticed.

This is reached from `create_device_mesh(..., allow_split_physical_axes=True)` via `_enumerate_feasible_logical_axis_assignments`, which calls `_get_prime_factors` on the logical and physical axis sizes. A mesh axis of size 10, 14, 15, 22, 35, … gets a corrupted factor set, breaking the documented `prod(z_1..z_n) == axis_size` invariant and producing a wrong or unsatisfiable assignment.

Fix: append the leftover prime to the factors already found (`factors + [x]`), and extend the existing unit test with numbers whose largest prime factor exceeds `isqrt(x)`.
