### PR TITLE
[pallas] Allow pl.empty_ref_like to accept a Ref directly

### DIFF
--- a/docs/pallas/CHANGELOG.md
+++ b/docs/pallas/CHANGELOG.md
@@ -18,6 +18,9 @@ Remember to align the itemized text with the first line of an item within a list
   * {func}`jax.experimental.pallas.kernel` now only aliases closed over or
     passed in refs if the kernel writes to them. If you need aliasing without
     an explicit write, use {func}`jax.experimental.pallas.tpu.touch`.
+  * {func}`jax.experimental.pallas.empty_ref_like` now also accepts a `Ref`
+    (e.g. a kernel argument), returning an empty Ref with the same shape,
+    dtype, and memory space.
 
 ### Triton
 

--- a/docs/pallas/CHANGELOG.md
+++ b/docs/pallas/CHANGELOG.md
@@ -52,6 +52,9 @@ Remember to align the itemized text with the first line of an item within a list
   * {func}`jax.experimental.pallas.kernel` now only aliases closed over or
     passed in refs if the kernel writes to them. If you need aliasing without
     an explicit write, use {func}`jax.experimental.pallas.tpu.touch`.
+  * {func}`jax.experimental.pallas.empty_ref_like` now also accepts a `Ref`
+    (e.g. a kernel argument), returning an empty Ref with the same shape,
+    dtype, and memory space.
 
 ### Triton
 

--- a/jax/_src/pallas/helpers.py
+++ b/jax/_src/pallas/helpers.py
@@ -54,12 +54,20 @@ def empty_like(x: object):
 
 
 def empty_ref_like(x: object) -> jax_typing.Array:
-  """Returns an empty array Ref with same shape/dtype/memory space as x."""
+  """Returns an empty array Ref with same shape/dtype/memory space as x.
+
+  ``x`` may be a ``pl.MemoryRef``, a ``jax.ShapeDtypeStruct``, or a ``Ref``
+  (e.g. a kernel argument).
+  """
   match x:
     case pl_core.MemoryRef():
       memory_space = x.memory_space
     case jax_core.ShapeDtypeStruct():
       memory_space = pl_core.MemorySpace.ANY
+    case jax_core.Tracer() | jax_core.Ref() if isinstance(
+        aval := jax_core.typeof(x), state_types.AbstractRef):
+      return jax_core.new_ref(
+          empty(aval.shape, aval.dtype), memory_space=aval.memory_space)
     case _:
       raise ValueError(f'empty_ref_like does not support {type(x)}')
   return jax_core.new_ref(empty_like(x), memory_space=memory_space)

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -941,6 +941,35 @@ class PallasCallTest(ptu.PallasTest):
 
     self.assertAllClose(kernel(x), expected)
 
+  def test_empty_ref_like_accepts_kernel_ref(self):
+    # https://github.com/jax-ml/jax/issues/39190
+    if jtu.test_device_matches(["gpu"]) and not self.INTERPRET:
+      self.skipTest("In-kernel ref allocation is not supported on GPU")
+
+    x = jnp.arange(8 * 128, dtype=jnp.int32).reshape(8, 128)
+    ref_avals = []
+
+    @functools.partial(
+        self.pallas_call,
+        out_shape=jax.ShapeDtypeStruct.like(x),
+    )
+    def double(x_ref, o_ref):
+      tmp_ref = pl.empty_ref_like(x_ref)
+      ref_avals.append((jax.typeof(x_ref), jax.typeof(tmp_ref)))
+      tmp_ref[...] = x_ref[...] * 2
+      o_ref[...] = tmp_ref[...]
+
+    np.testing.assert_array_equal(double(x), x * 2)
+    x_ref_aval, tmp_ref_aval = ref_avals[0]
+    self.assertEqual(tmp_ref_aval.shape, x_ref_aval.shape)
+    self.assertEqual(tmp_ref_aval.dtype, x_ref_aval.dtype)
+    self.assertEqual(tmp_ref_aval.memory_space, x_ref_aval.memory_space)
+
+  def test_empty_ref_like_rejects_unsupported_inputs(self):
+    with self.assertRaisesRegex(
+        ValueError, "empty_ref_like does not support"):
+      pl.empty_ref_like(jnp.ones((8, 128), jnp.int32))
+
 
 class PallasCallInterpretTest(PallasCallTest):
   INTERPRET = True

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -973,6 +973,35 @@ class PallasCallTest(ptu.PallasTest):
 
     self.assertAllClose(kernel(x), expected)
 
+  def test_empty_ref_like_accepts_kernel_ref(self):
+    # https://github.com/jax-ml/jax/issues/39190
+    if jtu.test_device_matches(["gpu"]) and not self.INTERPRET:
+      self.skipTest("In-kernel ref allocation is not supported on GPU")
+
+    x = jnp.arange(8 * 128, dtype=jnp.int32).reshape(8, 128)
+    ref_avals = []
+
+    @functools.partial(
+        self.pallas_call,
+        out_shape=jax.ShapeDtypeStruct.like(x),
+    )
+    def double(x_ref, o_ref):
+      tmp_ref = pl.empty_ref_like(x_ref)
+      ref_avals.append((jax.typeof(x_ref), jax.typeof(tmp_ref)))
+      tmp_ref[...] = x_ref[...] * 2
+      o_ref[...] = tmp_ref[...]
+
+    np.testing.assert_array_equal(double(x), x * 2)
+    x_ref_aval, tmp_ref_aval = ref_avals[0]
+    self.assertEqual(tmp_ref_aval.shape, x_ref_aval.shape)
+    self.assertEqual(tmp_ref_aval.dtype, x_ref_aval.dtype)
+    self.assertEqual(tmp_ref_aval.memory_space, x_ref_aval.memory_space)
+
+  def test_empty_ref_like_rejects_unsupported_inputs(self):
+    with self.assertRaisesRegex(
+        ValueError, "empty_ref_like does not support"):
+      pl.empty_ref_like(jnp.ones((8, 128), jnp.int32))
+
 
 class PallasCallInterpretTest(PallasCallTest):
   INTERPRET = True


### PR DESCRIPTION
Fixes #39190.

pl.empty_ref_like previously only accepted a pl.MemoryRef (e.g. pltpu.VMEM((8, 128), jnp.int32)) or a jax.ShapeDtypeStruct. Passing a Ref — most naturally a kernel argument, as in pl.empty_ref_like(x_ref) — failed during kernel tracing with:

ValueError: empty_ref_like does not support <class 'jax._src.interpreters.partial_eval.DynamicJaxprTracer'>
This change adds a match case for inputs whose abstract value is an AbstractRef (traced kernel refs as well as concrete jax.new_ref(...) refs). The new empty Ref takes its shape, dtype, and memory space from the input ref's aval, and is created with the same new_ref(empty(...)) call the existing cases use, so the emitted jaxpr (an empty eqn followed by a new_ref eqn) and the backend lowering path are identical to the already-supported inputs.

TransformedRef inputs (e.g. x_ref.at[0:4]) remain unsupported and keep raising the pre-existing clear ValueError; the new case is guarded so they do not hit jax.typeof's TransformedRefAvalError instead.

Tests: test_empty_ref_like_accepts_kernel_ref reproduces the issue's kernel (fails before this change, passes after) and checks that the created ref preserves the source ref's shape/dtype/memory space at trace time; test_empty_ref_like_rejects_unsupported_inputs pins the error path for unsupported inputs. Also adds a docs/pallas/CHANGELOG.md entry.

Tested on CPU (interpret mode); no GPU/TPU hardware was available, so compiled TPU/GPU runs are deferred to CI. One note for TPU review: a plain kernel ref yields memory_space=default, a value the existing in-tree empty_ref_like uses never pass at this spot; Mosaic maps DEFAULT to VMEM on the tensor core (jax/_src/pallas/mosaic/core.py), matching what the already-supported MemoryRef arm produces.