### PR TITLE
Improve error for unsupported lapack dtypes

### DIFF
--- a/jaxlib/lapack.py
+++ b/jaxlib/lapack.py
@@ -53,10 +53,11 @@ def prepare_lapack_call(fn_base, dtype):
 
 def build_lapack_fn_target(fn_base: str, dtype) -> str:
   """Builds the target name for a LAPACK function custom call."""
-  try:
-    prefix = (
-        LAPACK_DTYPE_PREFIX.get(dtype, None) or LAPACK_DTYPE_PREFIX[dtype.type]
-    )
-    return f"lapack_{prefix}{fn_base}"
-  except KeyError as err:
-    raise NotImplementedError(err, f"Unsupported dtype {dtype}.") from err
+  key = np.dtype(dtype).type
+  prefix = LAPACK_DTYPE_PREFIX.get(key, None)
+  if prefix is None:
+    raise NotImplementedError(
+      f"Unsupported dtype {dtype} for LAPACK operations. Supported dtypes are "
+      f"{', '.join(typ.__name__ for typ in LAPACK_DTYPE_PREFIX)}. "
+      f"Please cast the input to a supported type.")
+  return f"lapack_{prefix}{fn_base}"

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -19,6 +19,7 @@ import numpy as np
 import scipy
 import scipy.linalg
 import scipy as osp
+import unittest
 
 from absl.testing import absltest, parameterized
 
@@ -37,6 +38,7 @@ from jax._src.numpy.util import promote_dtypes_inexact
 config.parse_flags_with_absl()
 
 scipy_version = jtu.parse_version(scipy.version.version)
+jaxlib_version = jtu.parse_version(jax.lib.__version__)
 
 T = lambda x: np.swapaxes(x, -1, -2)
 
@@ -1049,6 +1051,15 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np.linalg.inv, jnp.linalg.inv, args_maker,
                             tol=1e-3)
     self._CompileAndCheck(jnp.linalg.inv, args_maker)
+
+  @unittest.skipIf(jaxlib_version < (0, 11, 1), "Test requires jaxlib v0.11.1 or newer.")
+  @jtu.run_on_devices('cpu')
+  def testInvDtypeError(self):
+    # regression test for https://github.com/jax-ml/jax/issues/38825
+    x = jnp.ones((3, 3), dtype='float16')
+    with self.assertRaisesRegex(NotImplementedError,
+                                "Unsupported dtype .*float16.* for LAPACK operations."):
+      jsp.linalg.inv(x)
 
   @jtu.sample_product(
     [dict(shape=shape, hermitian=hermitian)


### PR DESCRIPTION
Fixes #38825

I chose to continue raising a `NotImplementedError` rather than switching to a `ValueError`, because we have existing tests that check for this. The confusion at the linked bug seems to come from the fact that the `NotImpelementedError` is raised from a `KeyError`; by cleaning up this error path and adding extra information, we avoid the appearance of an internal error.

Note that seeing the updated error requires rebuilding jaxlib.