### PR TITLE
Fix OpenBLAS thread oversubscription causing heap corruption in batched LAPACK eigh

### DIFF
--- a/jaxlib/cpu/lapack_kernels.cc
+++ b/jaxlib/cpu/lapack_kernels.cc
@@ -19,7 +19,9 @@ limitations under the License.
 #include <cmath>
 #include <complex>
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -106,6 +108,34 @@ int64_t GetLapackBatchChunkSize(int64_t batch_size, int64_t cost_per_matrix,
 #endif  // PLATFORM_GOOGLE
 }
 
+// RAII guard that constrains OpenBLAS to a single thread for the duration of a
+// ParallelBatchMap call. JAX parallelizes across the batch dimension via its
+// own thread pool; allowing each individual LAPACK call to also spawn threads
+// causes catastrophic thread oversubscription (N tasks × N OpenBLAS threads)
+// and heap corruption from OpenBLAS internal workspace contention.
+class OpenblasThreadGuard {
+ public:
+  OpenblasThreadGuard() {
+    const char* old_val = getenv("OPENBLAS_NUM_THREADS");
+    if (old_val) {
+      saved_ = std::string(old_val);
+    }
+    setenv("OPENBLAS_NUM_THREADS", "1", /*overwrite=*/1);
+  }
+  ~OpenblasThreadGuard() {
+    if (saved_.has_value()) {
+      setenv("OPENBLAS_NUM_THREADS", saved_->c_str(), /*overwrite=*/1);
+    } else {
+      unsetenv("OPENBLAS_NUM_THREADS");
+    }
+  }
+  OpenblasThreadGuard(const OpenblasThreadGuard&) = delete;
+  OpenblasThreadGuard& operator=(const OpenblasThreadGuard&) = delete;
+
+ private:
+  std::optional<std::string> saved_;
+};
+
 // Divide batch_count elements into chunk_size pieces, and call run_chunk on
 // each. Use the thread pool if we have more than one chunk.
 static ffi::Error ParallelBatchMap(
@@ -116,13 +146,14 @@ static ffi::Error ParallelBatchMap(
     run_chunk(0, batch_count);
     return ffi::Error::Success();
   } else {
+    auto guard = std::make_shared<OpenblasThreadGuard>();
     int64_t num_tasks = (batch_count + chunk_size - 1) / chunk_size;
     absl::BlockingCounter counter(num_tasks);
 
     for (int64_t i = 0; i < batch_count; i += chunk_size) {
       int64_t current_chunk_size = std::min(chunk_size, batch_count - i);
 
-      thread_pool.Schedule([run_chunk, &counter, i, current_chunk_size]() {
+      thread_pool.Schedule([run_chunk, &counter, guard, i, current_chunk_size]() {
         run_chunk(i, current_chunk_size);
         counter.DecrementCount();
       });


### PR DESCRIPTION
Fixes #39292.

## Problem

`jnp.linalg.eigh` (and potentially other batched LAPACK operations) causes heap corruption on machines with many CPU cores (256+). The root cause is thread oversubscription: JAX dispatches batched LAPACK calls across the XLA thread pool via `ParallelBatchMap`, and each individual call independently spawns `OMP_NUM_THREADS` threads through OpenBLAS, leading to N×N thread explosion and corrupted internal OpenBLAS workspace buffers.

## Fix

Added an `OpenblasThreadGuard` RAII class that sets `OPENBLAS_NUM_THREADS=1` before dispatching to the thread pool, and restores the original value when all tasks complete. A `shared_ptr<OpenblasThreadGuard>` is captured by each thread-pool task lambda, keeping the environment set for the lifetime of all concurrent tasks.

The fix is placed in the `#ifdef PLATFORM_GOOGLE` path (where `ParallelBatchMap` actually uses the thread pool). The open-source `#else` path already serializes LAPACK calls, so there is no behavioral change for open-source builds.

## Testing

- Verified C++ syntax with `g++ -std=c++17`
- Verified save/restore semantics of the guard in a standalone test
- All batched eigh / eigvalsh / cholesky / SVD / QR tests pass on 32-core machine
- **Note**: The bug requires 256+ cores to reproduce and the `PLATFORM_GOOGLE` build path, which is not available in local testing. CI verification on Google-internal infrastructure is needed to confirm the fix works on high-core-count machines.

## Changes

Single file: `jaxlib/cpu/lapack_kernels.cc` (+32/-1 lines)