### PR TITLE
Raise an informative error for stale tracers in custom_jvp nondiff_argnums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     all. The amax outputs are whole-batch statistics and do not carry the
     vmap axis; vmap over the scale/descale operands raises a clear
     `NotImplementedError`.
+  * {class}`jax.custom_jvp` functions called with a traced array in a
+    `nondiff_argnums` position now raise an informative
+    {class}`jax.errors.UnexpectedTracerError` pointing at the `nondiff_argnums`
+    usage when the custom JVP rule is applied after the value has gone out of
+    scope (e.g. when differentiating through a {func}`jax.lax.scan` or
+    {func}`jax.jit` boundary). Previously this surfaced as a generic
+    leaked-tracer error, as an internal `TypeError` during lowering, or, if
+    the rule never actually used the stale value, silently succeeded
+    ({jax-issue}`#20889`).
 
 ## JAX 0.11.0 (July 16, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,15 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     instances ({jax-issue}`#39297`).
   * Fixed `_get_prime_factors` in `jax.experimental.mesh_utils`
     ({jax-issue}`#38286`).
+  * {class}`jax.custom_jvp` functions called with a traced array in a
+    `nondiff_argnums` position now raise an informative
+    {class}`jax.errors.UnexpectedTracerError` pointing at the `nondiff_argnums`
+    usage when the custom JVP rule is applied after the value has gone out of
+    scope (e.g. when differentiating through a {func}`jax.lax.scan` or
+    {func}`jax.jit` boundary). Previously this surfaced as a generic
+    leaked-tracer error, as an internal `TypeError` during lowering, or, if
+    the rule never actually used the stale value, silently succeeded
+    ({jax-issue}`#20889`).
 
 ## JAX 0.11.0 (July 16, 2026)
 

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -284,8 +284,13 @@ class custom_jvp(Generic[ReturnValue]):
                              (*static_args, diff_args, diff_args),
                              {},
                              static_argnums=tuple(range(len(static_args))))
-      jvp = prepend_static_args(lu.wrap_init(self.jvp,
-                                             debug_info=debug_jvp), static_args)
+      # If this call is staged out (e.g. under jit or scan), the jvp rule is
+      # traced only later, when the staged call is differentiated. Any Tracer
+      # captured here in static_args is stale by then and would surface as a
+      # confusing leaked-tracer error, so check for that when the rule runs.
+      jvp_ = _check_static_args_fresh(self.jvp, static_args)
+      jvp = prepend_static_args(lu.wrap_init(jvp_, debug_info=debug_jvp),
+                                static_args)
     else:
       f_, dyn_args = lu.wrap_init(self.fun, debug_info=debug), args
       debug_jvp = debug_info("custom_jvp jvp", self.jvp,
@@ -300,6 +305,31 @@ class custom_jvp(Generic[ReturnValue]):
                                       symbolic_zeros=self.symbolic_zeros)
     _, (out_tree, _, _) = lu.merge_linear_aux(out_type1, out_type2)
     return tree_unflatten(out_tree, out_flat)
+
+def _check_static_args_fresh(jvp: Callable, static_args) -> Callable:
+  # See the comment at the call site in custom_jvp.__call__: this runs when the
+  # jvp rule itself runs, which for a staged-out custom_jvp call happens after
+  # the trace that created any Tracers in static_args has concluded.
+  def jvp_with_freshness_check(*args):
+    for arg in static_args:
+      for leaf in tree_leaves(arg):
+        if isinstance(leaf, core.Tracer) and (
+            getattr(leaf._trace, '_concluded', False)
+            or not leaf._trace.is_valid()):
+          raise UnexpectedTracerError(
+              "Found a JAX Tracer object passed as an argument to a "
+              "custom_jvp function in a position indicated by nondiff_argnums "
+              "as non-differentiable, and the custom JVP rule was applied "
+              "after the transformation that created the Tracer had finished "
+              "(as happens, for example, when differentiating through a "
+              "jax.lax.scan or jax.jit boundary). nondiff_argnums should only "
+              "be used for arguments that can't be or contain JAX tracers, "
+              "e.g. function-valued or static configuration arguments. In "
+              "particular, array-valued arguments should typically not be "
+              "indicated as nondiff_argnums; instead, pass them as ordinary "
+              "arguments and ignore the corresponding tangents.")
+    return jvp(*args)
+  return jvp_with_freshness_check
 
 @partial(lu.transformation_with_aux2, use_eq_store=True)
 def _flatten_jvp(f, store, primal_name, jvp_name, in_tree, maybe_out_type, *args):

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -284,8 +284,13 @@ class custom_jvp[ReturnValue]:
                              (*static_args, diff_args, diff_args),
                              {},
                              static_argnums=tuple(range(len(static_args))))
-      jvp = prepend_static_args(lu.wrap_init(self.jvp,
-                                             debug_info=debug_jvp), static_args)
+      # If this call is staged out (e.g. under jit or scan), the jvp rule is
+      # traced only later, when the staged call is differentiated. Any Tracer
+      # captured here in static_args is stale by then and would surface as a
+      # confusing leaked-tracer error, so check for that when the rule runs.
+      jvp_ = _check_static_args_fresh(self.jvp, static_args)
+      jvp = prepend_static_args(lu.wrap_init(jvp_, debug_info=debug_jvp),
+                                static_args)
     else:
       f_, dyn_args = lu.wrap_init(self.fun, debug_info=debug), args
       debug_jvp = debug_info("custom_jvp jvp", self.jvp,
@@ -300,6 +305,31 @@ class custom_jvp[ReturnValue]:
                                       symbolic_zeros=self.symbolic_zeros)
     _, (out_tree, _, _) = lu.merge_linear_aux(out_type1, out_type2)
     return tree_unflatten(out_tree, out_flat)
+
+def _check_static_args_fresh(jvp: Callable, static_args) -> Callable:
+  # See the comment at the call site in custom_jvp.__call__: this runs when the
+  # jvp rule itself runs, which for a staged-out custom_jvp call happens after
+  # the trace that created any Tracers in static_args has concluded.
+  def jvp_with_freshness_check(*args):
+    for arg in static_args:
+      for leaf in tree_leaves(arg):
+        if isinstance(leaf, core.Tracer) and (
+            getattr(leaf._trace, '_concluded', False)
+            or not leaf._trace.is_valid()):
+          raise UnexpectedTracerError(
+              "Found a JAX Tracer object passed as an argument to a "
+              "custom_jvp function in a position indicated by nondiff_argnums "
+              "as non-differentiable, and the custom JVP rule was applied "
+              "after the transformation that created the Tracer had finished "
+              "(as happens, for example, when differentiating through a "
+              "jax.lax.scan or jax.jit boundary). nondiff_argnums should only "
+              "be used for arguments that can't be or contain JAX tracers, "
+              "e.g. function-valued or static configuration arguments. In "
+              "particular, array-valued arguments should typically not be "
+              "indicated as nondiff_argnums; instead, pass them as ordinary "
+              "arguments and ignore the corresponding tangents.")
+    return jvp(*args)
+  return jvp_with_freshness_check
 
 @partial(lu.transformation_with_aux2, use_eq_store=True)
 def _flatten_jvp(f, store, primal_name, jvp_name, in_tree, maybe_out_type, *args):

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1760,7 +1760,7 @@ class TracingEqn:
     return self.in_tracers
 
 class DynamicJaxprTrace(core.Trace):
-  __slots__ = ("frame", "tag", "parent_trace")
+  __slots__ = ("frame", "tag", "parent_trace", "_concluded")
 
   # Note that tag is only used when DynamicJaxprTrace is associated with a LinearizeTrace;
   # otherwise it will be undefined.
@@ -1768,6 +1768,7 @@ class DynamicJaxprTrace(core.Trace):
   frame: JaxprStackFrame
   parent_trace: core.Trace | None
   requires_low: bool
+  _concluded: bool
 
   def __init__(self, debug_info: core.DebugInfo | None,
                parent_trace: core.Trace | None = None,
@@ -1776,10 +1777,16 @@ class DynamicJaxprTrace(core.Trace):
     self.requires_low = lower
     self.frame = JaxprStackFrame(debug_info, auto_dce)
     self.parent_trace = parent_trace
+    self._concluded = False
 
   def invalidate(self):
     # TODO(mattjj): exposed existing tracer leaks; fix them and re-enable!
     # super().invalidate()
+
+    # Unlike _invalidated, this flag doesn't make binds involving this trace's
+    # tracers an error (see the TODO above); it only marks that tracing has
+    # concluded, so opt-in checks can diagnose stale tracers.
+    self._concluded = True
 
     # avoid cyclic refs
     self.frame.tracing_eqns = []  # thunk -> eqn -> in_tracers -> trace ->

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1621,7 +1621,7 @@ class TracingEqn:
     return self.in_tracers
 
 class DynamicJaxprTrace(core.Trace):
-  __slots__ = ("frame", "tag", "parent_trace")
+  __slots__ = ("frame", "tag", "parent_trace", "_concluded")
 
   # Note that tag is only used when DynamicJaxprTrace is associated with a LinearizeTrace;
   # otherwise it will be undefined.
@@ -1629,6 +1629,7 @@ class DynamicJaxprTrace(core.Trace):
   frame: JaxprStackFrame
   parent_trace: core.Trace | None
   requires_low: bool
+  _concluded: bool
 
   def __init__(self, debug_info: core.DebugInfo | None,
                parent_trace: core.Trace | None = None,
@@ -1637,10 +1638,16 @@ class DynamicJaxprTrace(core.Trace):
     self.requires_low = lower
     self.frame = JaxprStackFrame(debug_info, auto_dce)
     self.parent_trace = parent_trace
+    self._concluded = False
 
   def invalidate(self):
     # TODO(mattjj): exposed existing tracer leaks; fix them and re-enable!
     # super().invalidate()
+
+    # Unlike _invalidated, this flag doesn't make binds involving this trace's
+    # tracers an error (see the TODO above); it only marks that tracing has
+    # concluded, so opt-in checks can diagnose stale tracers.
+    self._concluded = True
 
     # avoid cyclic refs
     self.frame.tracing_eqns = []  # thunk -> eqn -> in_tracers -> trace ->

--- a/tests/custom_api_test.py
+++ b/tests/custom_api_test.py
@@ -425,6 +425,68 @@ class CustomJVPTest(jtu.JaxTestCase):
     with self.assertRaises(UnexpectedTracerError):
       api.jvp(f, (2.,), (1.,))
 
+  def test_nondiff_arg_stale_tracer_error_scan_grad(self):
+    # https://github.com/jax-ml/jax/issues/20889
+    @partial(jax.custom_jvp, nondiff_argnums=(1,))
+    def f(arr, mask):
+      return arr * mask
+    @f.defjvp
+    def f_jvp(mask, primals, tangents):
+      return api.jvp(lambda arr: arr * mask, primals, tangents)
+
+    def loss(x, mask):
+      def step(carry, _):
+        return (f(*carry), carry[1]), None
+      carry, _ = lax.scan(step, (x, mask), None, length=2)
+      return carry[0].sum()
+
+    x = jnp.ones(3)
+    mask = jnp.zeros(3)
+    with self.assertRaisesRegex(UnexpectedTracerError, "nondiff_argnums"):
+      grad(loss)(x, mask)
+
+  def test_nondiff_arg_stale_tracer_error_grad_of_jit(self):
+    # https://github.com/jax-ml/jax/issues/20889: this variant used to fail
+    # with an internal TypeError from lowering rather than any tracer error.
+    @partial(jax.custom_jvp, nondiff_argnums=(1,))
+    def f(arr, mask):
+      return arr * mask
+    @f.defjvp
+    def f_jvp(mask, primals, tangents):
+      return api.jvp(lambda arr: arr * mask, primals, tangents)
+
+    x = jnp.ones(3)
+    mask = jnp.zeros(3)
+    with self.assertRaisesRegex(UnexpectedTracerError, "nondiff_argnums"):
+      grad(lambda x: jit(f)(x, mask).sum())(x)
+
+  def test_nondiff_arg_tracer_inline_jvp_still_works(self):
+    # An array-valued nondiff arg is discouraged but works when the jvp rule
+    # runs inline, while the captured tracer is still live; in particular the
+    # stale-tracer check must not fire under jit(grad) or when the nondiff
+    # argument is a concrete array captured into a scan.
+    @partial(jax.custom_jvp, nondiff_argnums=(1,))
+    def f(x, scale):
+      return x * scale
+    @f.defjvp
+    def f_jvp(scale, primals, tangents):
+      (x,), (t,) = primals, tangents
+      return f(x, scale), t * scale
+
+    x = jnp.ones(3)
+    scale = jnp.full(3, 2.)
+    ans = jit(grad(lambda x, s: f(x, s).sum()))(x, scale)
+    self.assertAllClose(ans, scale)
+
+    def loss(x):
+      carry, _ = lax.scan(lambda c, _: (f(c, scale), None), x, None, length=2)
+      return carry.sum()
+    self.assertAllClose(grad(loss)(x), jnp.full(3, 4.))
+
+    scales = jnp.stack([scale, 3 * scale])
+    ans = grad(lambda x: jax.vmap(f)(x, scales).sum())(jnp.ones((2, 3)))
+    self.assertAllClose(ans, scales)
+
   def test_vmap_axes(self):
     raise unittest.SkipTest("TODO")  # TODO(mattjj): write test
 
@@ -4429,6 +4491,7 @@ class CustomJVP3Test(CustomJVPTest):
   # custom_jvp3 nondiff_argnums must be static, not Tracers
   def test_nondiff_arg_vmap_tracer(self): pass
   def test_nondiff_argnums_vmap_tracer(self): pass
+  def test_nondiff_arg_tracer_inline_jvp_still_works(self): pass
 
   def test_hard_stuff2(self):
     # Like the base test, except the last case: the batchedness of a

--- a/tests/custom_api_test.py
+++ b/tests/custom_api_test.py
@@ -425,6 +425,68 @@ class CustomJVPTest(jtu.JaxTestCase):
     with self.assertRaises(UnexpectedTracerError):
       api.jvp(f, (2.,), (1.,))
 
+  def test_nondiff_arg_stale_tracer_error_scan_grad(self):
+    # https://github.com/jax-ml/jax/issues/20889
+    @partial(jax.custom_jvp, nondiff_argnums=(1,))
+    def f(arr, mask):
+      return arr * mask
+    @f.defjvp
+    def f_jvp(mask, primals, tangents):
+      return api.jvp(lambda arr: arr * mask, primals, tangents)
+
+    def loss(x, mask):
+      def step(carry, _):
+        return (f(*carry), carry[1]), None
+      carry, _ = lax.scan(step, (x, mask), None, length=2)
+      return carry[0].sum()
+
+    x = jnp.ones(3)
+    mask = jnp.zeros(3)
+    with self.assertRaisesRegex(UnexpectedTracerError, "nondiff_argnums"):
+      grad(loss)(x, mask)
+
+  def test_nondiff_arg_stale_tracer_error_grad_of_jit(self):
+    # https://github.com/jax-ml/jax/issues/20889: this variant used to fail
+    # with an internal TypeError from lowering rather than any tracer error.
+    @partial(jax.custom_jvp, nondiff_argnums=(1,))
+    def f(arr, mask):
+      return arr * mask
+    @f.defjvp
+    def f_jvp(mask, primals, tangents):
+      return api.jvp(lambda arr: arr * mask, primals, tangents)
+
+    x = jnp.ones(3)
+    mask = jnp.zeros(3)
+    with self.assertRaisesRegex(UnexpectedTracerError, "nondiff_argnums"):
+      grad(lambda x: jit(f)(x, mask).sum())(x)
+
+  def test_nondiff_arg_tracer_inline_jvp_still_works(self):
+    # An array-valued nondiff arg is discouraged but works when the jvp rule
+    # runs inline, while the captured tracer is still live; in particular the
+    # stale-tracer check must not fire under jit(grad) or when the nondiff
+    # argument is a concrete array captured into a scan.
+    @partial(jax.custom_jvp, nondiff_argnums=(1,))
+    def f(x, scale):
+      return x * scale
+    @f.defjvp
+    def f_jvp(scale, primals, tangents):
+      (x,), (t,) = primals, tangents
+      return f(x, scale), t * scale
+
+    x = jnp.ones(3)
+    scale = jnp.full(3, 2.)
+    ans = jit(grad(lambda x, s: f(x, s).sum()))(x, scale)
+    self.assertAllClose(ans, scale)
+
+    def loss(x):
+      carry, _ = lax.scan(lambda c, _: (f(c, scale), None), x, None, length=2)
+      return carry.sum()
+    self.assertAllClose(grad(loss)(x), jnp.full(3, 4.))
+
+    scales = jnp.stack([scale, 3 * scale])
+    ans = grad(lambda x: jax.vmap(f)(x, scales).sum())(jnp.ones((2, 3)))
+    self.assertAllClose(ans, scales)
+
   def test_vmap_axes(self):
     raise unittest.SkipTest("TODO")  # TODO(mattjj): write test
 
@@ -4609,6 +4671,7 @@ class CustomJVP3Test(CustomJVPTest):
   # custom_jvp3 nondiff_argnums must be static, not Tracers
   def test_nondiff_arg_vmap_tracer(self): pass
   def test_nondiff_argnums_vmap_tracer(self): pass
+  def test_nondiff_arg_tracer_inline_jvp_still_works(self): pass
 
   def test_hard_stuff2(self):
     # Like the base test, except the last case: the batchedness of a


### PR DESCRIPTION
Fixes #20889.

When a custom_jvp call with array-valued nondiff_argnums is staged out (jit, scan) and differentiated later, the jvp rule's captured tracer is stale and surfaced as a generic leaked-tracer error or an internal lowering TypeError. Check the captured static args when the rule runs and raise an UnexpectedTracerError naming nondiff_argnums instead. Inline paths (jit(grad), grad(vmap), plain jit), where the capture is still live, are unchanged.

