### PR TITLE
[ROCm] Reduce RBE build parallelism for rocm bazel jobs

### DIFF
--- a/build/rocm/rocm.bazelrc
+++ b/build/rocm/rocm.bazelrc
@@ -68,7 +68,7 @@ build:rocm_rbe --repo_env=REMOTE_GPU_TESTING=1
 build:rocm_rbe --remote_download_outputs=minimal
 
 test:rocm_rbe --remote_timeout=3600
-test:rocm_rbe --jobs=50
+test:rocm_rbe --jobs=32
 test:rocm_rbe --strategy=TestRunner=remote,local
 test:rocm_rbe --worker_sandboxing=false
 test:rocm_rbe --repo_env=REMOTE_GPU_TESTING=1


### PR DESCRIPTION
Lower the --jobs count for the rbe config to reduce load on the remote build executor and local scheduling overhead. We have taken out some of the problematic pools out of rotation. so until we put them back reduce the parallelism

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->