### PR TITLE
Print the gradient in the value_and_grad tutorial example

### DIFF
--- a/docs/101/transformations.md
+++ b/docs/101/transformations.md
@@ -136,6 +136,7 @@ training progress. {func}`jax.value_and_grad` computes both in one pass:
 ```{code-cell}
 loss_value, Wb_grad = jax.value_and_grad(loss, (0, 1))(W, b)
 print(loss_value)
+print(Wb_grad)
 ```
 
 And sometimes a function naturally computes intermediate results worth

--- a/docs/automatic-differentiation.md
+++ b/docs/automatic-differentiation.md
@@ -193,6 +193,7 @@ Continuing the previous examples:
 loss_value, Wb_grad = jax.value_and_grad(loss, (0, 1))(W, b)
 print('loss value', loss_value)
 print('loss value', loss(W, b))
+print('Wb_grad', Wb_grad)
 ```
 
 (automatic-differentiation-checking-against-numerical-differences)=

--- a/docs/automatic-differentiation.md
+++ b/docs/automatic-differentiation.md
@@ -195,6 +195,7 @@ Continuing the previous examples:
 loss_value, Wb_grad = jax.value_and_grad(loss, (0, 1))(W, b)
 print('loss value', loss_value)
 print('loss value', loss(W, b))
+print('Wb_grad', Wb_grad)
 ```
 
 (automatic-differentiation-checking-against-numerical-differences)=

--- a/docs/new_docs/101/transformations.md
+++ b/docs/new_docs/101/transformations.md
@@ -140,6 +140,7 @@ training progress. {func}`jax.value_and_grad` computes both in one pass:
 ```{code-cell}
 loss_value, Wb_grad = jax.value_and_grad(loss, (0, 1))(W, b)
 print(loss_value)
+print(Wb_grad)
 ```
 
 And sometimes a function naturally computes intermediate results worth

--- a/docs/notebooks/autodiff_cookbook.ipynb
+++ b/docs/notebooks/autodiff_cookbook.ipynb
@@ -289,7 +289,8 @@
      "output_type": "stream",
      "text": [
       "loss value 3.051939\n",
-      "loss value 3.051939\n"
+      "loss value 3.051939\n",
+      "Wb_grad (Array([-0.16965576, -0.8774645 , -1.4901344 ], dtype=float32), Array(-0.29227236, dtype=float32))\n"
      ]
     }
    ],
@@ -297,7 +298,8 @@
     "from jax import value_and_grad\n",
     "loss_value, Wb_grad = value_and_grad(loss, (0, 1))(W, b)\n",
     "print('loss value', loss_value)\n",
-    "print('loss value', loss(W, b))"
+    "print('loss value', loss(W, b))\n",
+    "print('Wb_grad', Wb_grad)"
    ]
   },
   {

--- a/docs/notebooks/autodiff_cookbook.md
+++ b/docs/notebooks/autodiff_cookbook.md
@@ -169,6 +169,7 @@ from jax import value_and_grad
 loss_value, Wb_grad = value_and_grad(loss, (0, 1))(W, b)
 print('loss value', loss_value)
 print('loss value', loss(W, b))
+print('Wb_grad', Wb_grad)
 ```
 
 +++ {"id": "rYTrH5tKllC_"}

--- a/docs/notebooks/autodiff_cookbook.md
+++ b/docs/notebooks/autodiff_cookbook.md
@@ -171,6 +171,7 @@ from jax import value_and_grad
 loss_value, Wb_grad = value_and_grad(loss, (0, 1))(W, b)
 print('loss value', loss_value)
 print('loss value', loss(W, b))
+print('Wb_grad', Wb_grad)
 ```
 
 +++ {"id": "rYTrH5tKllC_"}


### PR DESCRIPTION
The value_and_grad example in the autodiff tutorials assigns the gradients to Wb_grad but only prints the loss value, so the reader never sees the gradient result. Add a print of Wb_grad in automatic-differentiation.md, the autodiff cookbook notebook pair (synced with jupytext), and the 101 transformations page.

Fixes #39140
