### PR TITLE
State the default dimension order in the lax conv docstrings

### DIFF
--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -75,8 +75,13 @@ def conv_general_dilated(
   operator.
 
   Args:
-    lhs: a rank `n+2` dimensional input array.
-    rhs: a rank `n+2` dimensional array of kernel weights.
+    lhs: a rank `n+2` dimensional input array. Under the default
+      ``dimension_numbers``, the dimensions are interpreted as
+      ``(batch, in_features, spatial...)``, i.e. ``NCHW`` for a 2D convolution.
+    rhs: a rank `n+2` dimensional array of kernel weights. Under the default
+      ``dimension_numbers``, the dimensions are interpreted as
+      ``(out_features, in_features, spatial...)``, i.e. ``OIHW`` for a 2D
+      convolution.
     window_strides: a sequence of `n` integers, representing the inter-window
       strides.
     padding: either the strings `'SAME'`, `'SAME_LOWER'`, or `'VALID'`, or a
@@ -197,8 +202,11 @@ def conv(lhs: Array, rhs: Array, window_strides: Sequence[int],
   """Convenience wrapper around `conv_general_dilated`.
 
   Args:
-    lhs: a rank `n+2` dimensional input array.
-    rhs: a rank `n+2` dimensional array of kernel weights.
+    lhs: a rank `n+2` dimensional input array, with dimensions ordered as
+      ``(batch, in_features, spatial...)``, i.e. ``NCHW`` for a 2D convolution.
+    rhs: a rank `n+2` dimensional array of kernel weights, with dimensions
+      ordered as ``(out_features, in_features, spatial...)``, i.e. ``OIHW`` for
+      a 2D convolution.
     window_strides: a sequence of `n` integers, representing the inter-window
       strides.
     padding: either the string `'SAME'`, the string `'VALID'`.
@@ -227,8 +235,11 @@ def conv_with_general_padding(lhs: Array, rhs: Array,
   """Convenience wrapper around `conv_general_dilated`.
 
   Args:
-    lhs: a rank `n+2` dimensional input array.
-    rhs: a rank `n+2` dimensional array of kernel weights.
+    lhs: a rank `n+2` dimensional input array, with dimensions ordered as
+      ``(batch, in_features, spatial...)``, i.e. ``NCHW`` for a 2D convolution.
+    rhs: a rank `n+2` dimensional array of kernel weights, with dimensions
+      ordered as ``(out_features, in_features, spatial...)``, i.e. ``OIHW`` for
+      a 2D convolution.
     window_strides: a sequence of `n` integers, representing the inter-window
       strides.
     padding: either the string `'SAME'`, the string `'VALID'`, or a sequence of


### PR DESCRIPTION
The lhs/rhs argument descriptions of lax.conv,
lax.conv_with_general_padding and lax.conv_general_dilated did not say what dimension order the arrays must have. Document the default order (batch, in_features, spatial...) / (out_features, in_features, spatial...), i.e. NCHW/OIHW for 2D, directly at the argument descriptions. conv_transpose is left to #14337, which documents its different (TensorFlow-style) convention.

Fixes #11632