### PR TITLE
[ROCm] Fix invalid parallel local jobs execution

### DIFF
--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           ./ci/run_bazel_test_rocm_rbe.sh  \
             --config="${GPU_CONFIG}" \
-            --local_test_jobs=4 \
+            --local_test_jobs=1 \
             --//jax:build_jaxlib="${BUILD_JAXLIB}" \
             --//jax:build_jax="${BUILD_JAX}" \
             --repo_env=HERMETIC_PYTHON_VERSION="${PYTHON}" \


### PR DESCRIPTION
rocm uses 1 gpu gha runner hence we have to limit the number of local test jobs to 1