### PR TITLE
[tree_util] Name the offending pytree type in the metadata equality error

### DIFF
--- a/jaxlib/pytree.cc
+++ b/jaxlib/pytree.cc
@@ -298,11 +298,19 @@ bool PyTreeDef::operator==(const PyTreeDef& other) const {
         return false;
       }
     } catch (nb::python_error& e) {
-      nb::raise_from(e, PyExc_ValueError,
-                     "Exception raised while checking equality of metadata "
-                     "fields of pytree. Make sure that metadata fields are "
-                     "hashable and have simple equality semantics. (Note: "
-                     "arrays cannot be passed as metadata fields!)");
+      std::string message =
+          "Exception raised while checking equality of metadata fields of "
+          "pytree";
+      if (a.custom != nullptr) {
+        absl::StrAppend(
+            &message, " node of type ",
+            nb::cast<std::string_view>(nb::repr(a.custom->type)));
+      }
+      absl::StrAppend(&message,
+                      ". Make sure that metadata fields are hashable and have "
+                      "simple equality semantics. (Note: arrays cannot be "
+                      "passed as metadata fields!)");
+      nb::raise_from(e, PyExc_ValueError, "%s", message.c_str());
     }
     if (!IsSortedPyDictKeysEqual(a.sorted_dict_keys, b.sorted_dict_keys)) {
       return false;

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -18,6 +18,7 @@ import dataclasses
 import functools
 import pickle
 import re
+import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -30,6 +31,8 @@ from jax._src.tree_util import (
     prefix_errors, broadcast_flattened_prefix_with_treedef,
     default_registry, dispatch_registry)
 import jax.numpy as jnp
+
+jaxlib_version = jtu.jaxlib_version()
 
 # Easier to read.
 SequenceKey = tree_util.SequenceKey
@@ -81,6 +84,19 @@ class AnObject:
 
 tree_util.register_pytree_node(AnObject, lambda o: ((o.x, o.y), o.z),
                                lambda z, xy: AnObject(xy[0], xy[1], z))
+
+class ArrayMetadataBox:
+  # A pytree whose metadata (aux_data) is an array, hence unhashable and not
+  # comparable with plain `==` semantics. Used to test that pytree equality
+  # errors name the offending registered type. See issue #13027.
+
+  def __init__(self, x):
+    self.x = x
+
+tree_util.register_pytree_node(
+    ArrayMetadataBox,
+    lambda obj: ((), (obj.x,)),
+    lambda aux_data, children: ArrayMetadataBox(aux_data[0]))
 
 class AnObject2(AnObject): pass
 
@@ -1161,6 +1177,30 @@ class TreeKeyTest(absltest.TestCase):
     # Second fall fails, because arrays are marked static and compared for equality.
     with self.assertRaisesRegex(ValueError, msg):
       f(Tree(jnp.arange(4)))
+
+  @unittest.skipIf(jaxlib_version < (0, 11, 1),
+                    "Test requires jaxlib v0.11.1 or newer.")
+  def testEqualityErrorNamesOffendingType(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/13027
+    a = ArrayMetadataBox(jnp.arange(3))
+    b = ArrayMetadataBox(jnp.arange(3))
+    _, treedef_a = tree_util.tree_flatten(a)
+    _, treedef_b = tree_util.tree_flatten(b)
+
+    # hash succeeds despite unhashable metadata (metadata isn't actually
+    # hashed); the error only appears once equality is checked.
+    hash(treedef_a)
+    hash(treedef_b)
+
+    with self.assertRaisesRegex(ValueError, "ArrayMetadataBox"):
+      treedef_a == treedef_b
+
+    # The same error, reached through jax.jit's dispatch cache, should also
+    # name the offending type.
+    f = jax.jit(lambda x: x)
+    f(a)
+    with self.assertRaisesRegex(ValueError, "ArrayMetadataBox"):
+      f(b)
 
 
 class StaticTest(parameterized.TestCase):


### PR DESCRIPTION

When PyTreeDef::operator== catches an exception raised while comparing node metadata (e.g. unhashable/uncomparable aux_data such as a numpy array), the resulting ValueError already explains what's wrong but not which registered pytree type triggered it. Include the type's repr in the message using the Registration pointer already available at that point.

Fixes #13027
