### PR TITLE
make optimization_barrier propagate symbolic zeros

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -9865,13 +9865,22 @@ def _optimization_barrier_batcher(batched_args, batch_dims, **params):
 batching.primitive_batchers[optimization_barrier_p] = _optimization_barrier_batcher
 
 def _opt_barrier_jvp(primals, tangents):
-  tangents = [ad.instantiate_zeros(t) for t in tangents]
-  return optimization_barrier(primals), optimization_barrier(tangents)
+  primals_out = optimization_barrier(primals)
+  nzs = [not isinstance(t, ad.Zero) for t in tangents]
+  nz_ts = [t for t, nz in zip(tangents, nzs) if nz]
+  if not nz_ts:
+    return primals_out, tangents
+  out = iter(optimization_barrier(nz_ts))
+  tangents_out = [next(out) if nz else t for t, nz in zip(tangents, nzs)]
+  return primals_out, tangents_out
 ad.primitive_jvps[optimization_barrier_p] = _opt_barrier_jvp
 
 def _opt_barrier_transpose(cts, *primals):
-  cts = [ad.instantiate_zeros(ct) for ct in cts]
-  return optimization_barrier(cts)
+  nzs = [not isinstance(ct, ad.Zero) for ct in cts]
+  nz_cts = [ct for ct, nz in zip(cts, nzs) if nz]
+  if not nz_cts: return cts
+  out = iter(optimization_barrier(nz_cts))
+  return [next(out) if nz else ct for ct, nz in zip(cts, nzs)]
 ad.primitive_transposes[optimization_barrier_p] = _opt_barrier_transpose
 
 

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -3747,6 +3747,14 @@ class LaxTest(jtu.JaxTestCase):
     g = jax.grad(f)(5.)  # doesn't crash
     self.assertAllClose(g, 3., check_dtypes=False)
 
+  def test_optimization_barrier_backward_pass_zeros(self):
+    def f(x):
+      y = jnp.log(x)
+      y, x = jax.lax.optimization_barrier((y, x))
+      return x
+    not_nan = jax.grad(f)(0.)
+    self.assertFalse(jnp.isnan(not_nan))
+
   def test_shape_as_value_handles_static_shapes(self):
     result = lax.shape_as_value(())
     self.assertArraysEqual(result, lax.full((0,), np.array(0, np.int32)))


### PR DESCRIPTION
Previously, for no good reasons, optimization_barrier instantiated both forward and transpose symbolic zeros (in its jvp and transpose rules respectively). That led to a #1052 style issue, e.g.:

```python
def f(x):
  y = jnp.log(x)
  y, x = jax.lax.optimization_barrier((y, x))
  return x
nan = jax.grad(f)(0.)  # a nan!
```

The solution is just not to instantiate zeros in these rules.

This is a default, not a constraint on users. If users want some other behavior here, they can wrap optimization_barrier in a custom_jvp or custom_vjp or hijax primitive and thus control exactly how symbolic zeros are handled.