### PR TITLE
[remat3] allow custom_vjp fns that save ref residuals, via forwarding

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -50,7 +50,7 @@ from jax._src.tree_util import (
     PyTreeDef, tree_flatten, tree_unflatten, tree_structure, broadcast_prefix,
     tree_map, tree_leaves, tree_leaves_checked, Partial, tracing_registry)
 from jax._src.util import (unzip2, wraps, split_list, partition_list, safe_map,
-                           safe_zip, merge_lists, weakref_lru_cache)
+                           safe_zip, merge_lists, subs_list, weakref_lru_cache)
 from jax._src.core import typeof
 
 source_info_util.register_exclusion(__file__)
@@ -1045,16 +1045,31 @@ def _remat3(f, *, policy, static_argnums, static_argnames):
   return decorator
 
 def dce(traced, policy):
+  in_fwd = pe._jaxpr_forwarding(traced.jaxpr)
+  jaxpr = pe.prune_jaxpr_outputs(traced.jaxpr, [f is None for f in in_fwd])
+  for v in jaxpr.outvars:
+    if isinstance(v.aval, AbstractRef):
+      raise ValueError(
+          "the rematted computation's closure contains a mutable array "
+          f"reference of type {v.aval.str_short()} that is not one of the "
+          "rematted function's inputs, but such refs cannot be saved")
   # dce_jaxpr preserves attached consts (constvars are never pruned).
-  jaxpr, used = pe.dce_jaxpr(traced.jaxpr, True)
-  used_res, used_primals = split_list(used, [traced._num_consts])
-  res = [r for r, u in zip(traced._consts, used_res) if u]
-  return used_primals, Partial(partial(_dced, jaxpr, traced.out_tree, policy), res)
+  jaxpr, used = pe.dce_jaxpr(jaxpr, True)
+  keep = [u or i in {*in_fwd} for i, u in enumerate(used)]
+  kept_idx = {i: p for p, i in enumerate(i for i, k in enumerate(keep) if k)}
+  in_fwd = tuple(kept_idx[f] if f is not None else None for f in in_fwd)
+  take = tuple(kept_idx[i] for i, u in enumerate(used) if u)
+  keep_res, keep_primals = split_list(keep, [traced._num_consts])
+  res = [r for r, u in zip(traced._consts, keep_res) if u]
+  return keep_primals, Partial(
+      partial(_dced, jaxpr, in_fwd, take, traced.out_tree, policy), res)
 
 @source_info_util.extend_name_stack('rematted_computation')
-def _dced(jaxpr, out_tree, policy, res, *args):
-  out_flat = RematTraced(jaxpr, policy)(*res, *args)
-  return tree_unflatten(out_tree, out_flat)
+def _dced(jaxpr, in_fwd, take, out_tree, policy, res, *args):
+  ins = [*res, *args]
+  outs = RematTraced(jaxpr, policy)(*[ins[i] for i in take])
+  return tree_unflatten(out_tree, subs_list(in_fwd, ins, outs))
+
 
 class RematTraced(VJPHiPrimitive):
   jaxpr: core.Jaxpr
@@ -1075,8 +1090,9 @@ class RematTraced(VJPHiPrimitive):
     traced = core.jaxpr_as_fun(self.jaxpr)
     primals_out, fwd2 = remat_transform(self.policy, traced, *primals,
                                         custom_vjp_rules=True)
-    used, rem = dce(api.jit(lambda *xs: api.vjp(fwd2, *xs)[1]).trace(*primals),
-                    self.policy)
+    with config.mutable_array_checks(False):
+      traced_vjp = api.jit(lambda *xs: api.vjp(fwd2, *xs)[1]).trace(*primals)
+    used, rem = dce(traced_vjp, self.policy)
     primals_ = [x for x, u in zip(tree_leaves(primals), used) if u]
     # TODO(mattjj): propagate symbolic zeros more generally
     nzs_out = [getattr(a.to_tangent_aval(), 'dtype', None) is not dtypes.float0
@@ -1097,8 +1113,10 @@ class RematTraced(VJPHiPrimitive):
     traced = core.jaxpr_as_fun(self.jaxpr)
     primals_out, fwd2 = remat_transform(self.policy, traced, *primals,
                                         custom_vjp_rules=True)
-    used, rem = dce(api.jit(lambda *xs: api.linearize(fwd2, *xs)[1]).trace(*primals),
-                    self.policy)
+    with config.mutable_array_checks(False):
+      traced_lin = api.jit(
+          lambda *xs: api.linearize(fwd2, *xs)[1]).trace(*primals)
+    used, rem = dce(traced_lin, self.policy)
     primals_ = [x for x, u in zip(tree_leaves(primals), used) if u]
     return primals_out, (primals_, rem)
 

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -67,6 +67,7 @@ from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import chlo
 from jax._src.lib.mlir.dialects import hlo
 from jax._src.sharding import Sharding
+from jax._src.state.types import AbstractRef, WriteEffect
 from jax._src.partition_spec import PartitionSpec as P, UnreducedKind
 from jax._src.sharding_impls import (NamedSharding, canonicalize_sharding,
                                      flatten_spec)
@@ -9819,7 +9820,10 @@ def optimization_barrier(operand, /):
   Optimization barriers have no effect outside a compiled function.
 
   Args:
-    operand: a pytree of JAX values.
+    operand: a pytree of JAX values, possibly including mutable array
+      references. Refs are pinned as barrier inputs (their current value is
+      threaded through the barrier when state is discharged) but appear only
+      on the input side, and are returned unchanged.
 
   Returns:
     A pytree of JAX values, with the same structure and contents as ``operand``.
@@ -9833,9 +9837,11 @@ def optimization_barrier(operand, /):
     Array(0., dtype=float32, weak_type=True)
   """
   flat_args, treedef = tree_util.tree_flatten(operand)
-  flat_args = core.auto_insert_reshard(*flat_args)
-  out = optimization_barrier_p.bind(*flat_args)
-  return tree_util.tree_unflatten(treedef, out)
+  is_ref = [isinstance(core.typeof(x), AbstractRef) for x in flat_args]
+  vals, refs = util.partition_list(is_ref, flat_args)
+  vals = core.auto_insert_reshard(*vals)
+  out = optimization_barrier_p.bind(*util.merge_lists(is_ref, vals, refs))
+  return tree_util.tree_unflatten(treedef, util.merge_lists(is_ref, out, refs))
 
 
 optimization_barrier_p = core.Primitive('optimization_barrier')
@@ -9844,9 +9850,13 @@ optimization_barrier_p.def_impl(
     partial(dispatch.apply_primitive, optimization_barrier_p))
 
 def _optimization_barrier_abstract_eval(*args):
-  core.standard_vma_rule('optimization_barrier', *args)
-  return args
-optimization_barrier_p.def_abstract_eval(_optimization_barrier_abstract_eval)
+  is_ref = [isinstance(a, AbstractRef) for a in args]
+  vals = [a for a, r in zip(args, is_ref) if not r]
+  core.standard_vma_rule('optimization_barrier', *vals)
+  effects = {WriteEffect(i) for i, r in enumerate(is_ref) if r}
+  return vals, effects
+optimization_barrier_p.def_effectful_abstract_eval(
+    _optimization_barrier_abstract_eval)
 
 def _optimization_barrier_lowering_rule(ctx, *args):
   barrier_types = map(partial(mlir._aval_to_ir_types, ctx.module_context),

--- a/jax/_src/state/discharge.py
+++ b/jax/_src/state/discharge.py
@@ -583,6 +583,19 @@ def _addupdate_discharge_rule(
   ans = _addupdate_discharge(x, val, idx, tree)
   return (ans, None) + (None,) * len(idx), []
 
+@register_partial_discharge_rule(lax.optimization_barrier_p)
+def _optimization_barrier_partial_discharge(
+    should_discharge: Sequence[bool],
+    in_avals: Sequence[core.AbstractValue],
+    out_avals: Sequence[core.AbstractValue], *args):
+  # A discharged ref's value is threaded through the barrier and written back,
+  # so the underlying buffer is pinned like any other barrier operand.
+  del out_avals
+  outs = lax.optimization_barrier(list(args))
+  is_ref = [isinstance(a, AbstractRef) for a in in_avals]
+  new_invals = [o if d else None for o, d in zip(outs, should_discharge)]
+  return new_invals, [o for o, r in zip(outs, is_ref) if not r]
+
 def _addupdate_discharge(x, val, idx, tree):
   transforms = tree_util.tree_unflatten(tree, idx)
   if not transforms:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -47,6 +47,7 @@ import jax
 from jax import device_put, float0, grad, hessian, jacfwd, jacrev, jit
 from jax import lax
 from jax import tree_util
+from jax._src import ad_checkpoint
 from jax._src import api, api_util, dtypes, lib
 from jax._src import array
 from jax._src import config
@@ -8067,6 +8068,24 @@ class Remat3Test(RematTest):
     self.assertNotIn('cos', fwd_str)
     self.assertIn('cos ', bwd_str)
     jtu.check_grads(f, (3.,), order=2, modes=['rev'])
+
+  def test_remat_dce_input_to_output_forwarding(self):
+    traced = jax.jit(lambda x, y: (x, x * y)).trace(
+        jnp.float32(1.), jnp.float32(2.))
+    used, rem = ad_checkpoint.dce(traced, None)
+    self.assertEqual(used, [True, True])
+    self.assertLen(rem.func.args[0].outvars, 1)
+    self.assertAllClose(rem(jnp.float32(3.), jnp.float32(4.)), (3., 12.),
+                        check_dtypes=False)
+
+    # a forwarding source is kept even if the pruned jaxpr doesn't use it
+    traced = jax.jit(lambda x, y: (x, y * y)).trace(
+        jnp.float32(1.), jnp.float32(2.))
+    used, rem = ad_checkpoint.dce(traced, None)
+    self.assertEqual(used, [True, True])
+    self.assertLen(rem.func.args[0].invars, 1)
+    self.assertAllClose(rem(jnp.float32(3.), jnp.float32(4.)), (3., 16.),
+                        check_dtypes=False)
 
 
 @jtu.with_config(jax_pprint_use_color=False)

--- a/tests/mutable_array_test.py
+++ b/tests/mutable_array_test.py
@@ -30,6 +30,7 @@ from jax._src.interpreters import mlir
 from jax.sharding import NamedSharding, PartitionSpec as P, AxisType
 import jax.numpy as jnp
 
+from jax._src.state import discharge as state_discharge
 from jax._src.state.types import (RefEffect)
 
 config.parse_flags_with_absl()
@@ -823,11 +824,38 @@ class MutableArrayTest(jtu.JaxTestCase):
     self.assertAllClose(g, jnp.cos(2.))
     self.assertLen(lst, 4)
 
+  def test_optimization_barrier_with_refs(self):
+    x_ref = core.new_ref(jnp.float32(1.))
+    y, x_ref2 = jax.lax.optimization_barrier((jnp.float32(2.), x_ref))
+    self.assertIs(x_ref2, x_ref)
+    self.assertAllClose(y, 2., check_dtypes=False)
+
+    def f(x_ref, y):
+      y, _ = jax.lax.optimization_barrier((y, x_ref))
+      x_ref[...] += y
+      return x_ref[...]
+
+    self.assertAllClose(jax.jit(f)(x_ref, jnp.float32(2.)), 3.,
+                        check_dtypes=False)
+    self.assertAllClose(x_ref[...], 3., check_dtypes=False)
+
+    # discharge threads the ref's value in and out of the barrier
+    jaxpr = jax.jit(f).trace(core.new_ref(jnp.float32(0.)),
+                             jnp.float32(2.)).jaxpr
+    discharged = state_discharge.discharge_state(jaxpr)
+    eqn, = (e for e in discharged.eqns if e.primitive.name ==
+            'optimization_barrier')
+    self.assertLen(eqn.invars, 2)
+    self.assertLen(eqn.outvars, 2)
+
   def test_remat_grad_stats_plumbing_basic(self):
+    # The custom_vjp's output must be used, else it all gets DCE'd away
+    # without exercising the ref-residual plumbing.
     @jax.remat
     def f(x_ref, y):
-      stash_grads(x_ref, y)
-      return y
+      y = jnp.sin(y)
+      y = stash_grads(x_ref, y)
+      return jnp.sin(y)
 
     @jax.custom_vjp
     def stash_grads(grads_ref, x):
@@ -839,8 +867,11 @@ class MutableArrayTest(jtu.JaxTestCase):
       return None, g
     stash_grads.defvjp(stash_grads_fwd, stash_grads_bwd)
 
-    x_ref = core.new_ref(0)
-    jax.grad(f, 1)(x_ref, 3.14)
+    x_ref = core.new_ref(jnp.float32(0.))
+    g = jax.grad(f, 1)(x_ref, jnp.float32(1.))
+    self.assertAllClose(x_ref[...], jnp.cos(jnp.sin(1.)), check_dtypes=False)
+    self.assertAllClose(g, jnp.cos(jnp.sin(1.)) * jnp.cos(1.),
+                        check_dtypes=False)
 
   @jtu.run_on_devices("cpu")  # tolerances, lol
   def test_vjp3_ref_grads_for_val_primals(self):


### PR DESCRIPTION
Here's a behavior we support, from the docs

```python
@jax.custom_vjp
def stash_grads(grads_ref, x):
  return x

def stash_grads_fwd(grads_ref, x):
  return x, grads_ref

def stash_grads_bwd(grads_ref, g):
  grads_ref[...] = g
  return None, g

stash_grads.defvjp(stash_grads_fwd, stash_grads_bwd)
```
```python
def f(x, grads_ref):
  x = stash_grads(grads_ref, x)
  x = jnp.sin(x)
  return x

grads_ref = jax.new_ref(0.)
jax.grad(f)(1., grads_ref)
print(grads_ref)  # Ref(0.54), the gradient at the stash point: cos(1.)
```

The idea is that a custom_vjp fwd rule can return an argument ref in the
output residuals slot just to indicate that it should also be passed to
the backward pass, as a common argument.

But JAX_REMAT3=1 broke that behavior, in the sense that this
`test_remat_grad_stats_plumbing_basic` test would raise an exception
(except the test before this PR was accidentally buggy and issues might
get DCE'd instead of checked...):

```python
f = jax.remat(f)
grads_ref = jax.new_ref(0.)
jax.grad(f)(1., grads_ref)
```

The problem was that `remat` itself (with JAX_REMAT3) had no way to
indicate that one of its argument refs was needed as a residual.

In keeping with our existing pattern, we solve this by more generally
supporting "forwarded residuals" (both values and refs). That is, we
ensure that when the remat primitive's linearize rule needs a residual
that is one of its arguments, that residual argument is passed directly
from the caller (rather than being first produced as an output of
remat). That subsumes the ref case, though a less-terse (but more
structured) alternative would be to have a special slot built into vjp
rule signatures just for indicating common arguments (composed as
"wiring diagrams").

One downside to the approach taken here is that we rely on
`mutable_array_checks(False)` because the initial-style `RematTraced`
first traces things to a jaxpr before applying the forwarding
optimization.

We also teach optimization_barrier to accept refs (something @sharadmv
asked for at one point): in the user-facing traceable, refs are accepted
as operands but the same objects are returned; they are inputs to but
not outputs from bind. The abstract eval emits a WriteEffect per ref
input for ordering (and to keep the eqn from being DCE'd), and the new
state discharge rule threads a discharged ref's value through the
barrier and back.