### PR TITLE
[remat3] fixes: hijax, effects/diffability, roofline

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -636,8 +636,7 @@ def remat_partial_eval(trace: pe.JaxprTrace, *tracers: core.Tracer,
   disallowed_effects = effects.remat_allowed_effects.filter_not_in(jaxpr.effects)
   if disallowed_effects:
     raise NotImplementedError(
-        'Effects not supported in partial-eval of `checkpoint`/`remat`: '
-        f'{disallowed_effects}')
+        f'Effects not supported in AD of `checkpoint`/`remat`: {disallowed_effects}')
   policy = params['policy'] or nothing_saveable
   in_unknowns = [not t.is_known() for t in tracers]
   jaxpr_known, jaxpr_staged, out_unknowns, out_inst, num_res = \
@@ -1079,7 +1078,15 @@ class RematTraced(VJPHiPrimitive):
     self.in_avals = tuple(jaxpr.in_avals)
     self.out_aval = jaxpr.out_avals
     self.params = dict(jaxpr=jaxpr, policy=policy)
+    self.effects = frozenset(core.positional_effects(jaxpr))
     super().__init__()
+
+  def _check_differentiable(self):
+    disallowed = effects.remat_allowed_effects.filter_not_in(self.jaxpr.effects)
+    if disallowed:
+      raise NotImplementedError(
+          'Effects not supported in partial-eval of `checkpoint`/`remat`: '
+          f'{disallowed}')
 
   def expand(self, *args):
     # TODO eval_jaxpr_p
@@ -1087,6 +1094,7 @@ class RematTraced(VJPHiPrimitive):
 
   def vjp_fwd(self, _nzs_in, *primals):
     # TODO eval_jaxpr_p trace time
+    self._check_differentiable()
     traced = core.jaxpr_as_fun(self.jaxpr)
     primals_out, fwd2 = remat_transform(self.policy, traced, *primals,
                                         custom_vjp_rules=True)
@@ -1110,6 +1118,7 @@ class RematTraced(VJPHiPrimitive):
     return api.jvp(traced, primals, tangents)
 
   def lin(self, nzs_in, *primals):
+    self._check_differentiable()
     traced = core.jaxpr_as_fun(self.jaxpr)
     primals_out, fwd2 = remat_transform(self.policy, traced, *primals,
                                         custom_vjp_rules=True)

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2042,14 +2042,14 @@ def linear_transpose(fun: Callable, *primals, reduce_axes=()) -> Callable:
                    debug_info=debug_info("linear_transpose", fun, primals, {})),
       in_tree)
   in_avals = [shaped_abstractify(x) for x in primals_flat]
-  in_dtypes = map(lambda a: a.dtype, in_avals)
+  in_dtypes = [a.dtype for a in in_avals if not a.is_high]
 
   in_pvals = map(pe.PartialVal.unknown, in_avals)
   jaxpr, out_pvals, const = pe.trace_to_jaxpr_nounits(flat_fun, in_pvals,
                                                       instantiate=True)
   jaxpr, _ = pe.dce_jaxpr(jaxpr, [True] * len(jaxpr.outvars), True)
   out_avals, _ = unzip2(out_pvals)
-  out_dtypes = map(lambda a: a.dtype, out_avals)
+  out_dtypes = [a.dtype for a in out_avals if not a.is_high]
   if not (all(dtypes.issubdtype(d, np.inexact) for d in in_dtypes + out_dtypes)
           or all(dtypes.issubdtype(d, np.integer)
                  for d in in_dtypes + out_dtypes)):

--- a/jax/experimental/roofline/roofline.py
+++ b/jax/experimental/roofline/roofline.py
@@ -144,7 +144,10 @@ def _roofline_interpreter(
   pin_rhs_in_vmem: bool = False,
 ) -> RooflineResult:
   if jaxpr.is_high:
-    jaxpr = lower_jaxpr2(jaxpr)
+    # we interpret the body of a shard_map, so all mesh axes are in scope
+    axes = list(mesh.shape.items()) if mesh is not None else []
+    with core.extend_axis_env_nd(axes):
+      jaxpr = lower_jaxpr2(jaxpr)
 
   name_stack = source_info_util.new_name_stack(util.wrap_name("roofline", f_name))
 

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -261,6 +261,8 @@ class MakeTup(VJPHiPrimitive):
     tangents = map(ad.instantiate_zeros, tangents)
     return make_tup(*primals), make_tup(*tangents)
 
+  vjp_fwd, vjp_bwd_retval = vjp_from_jvp
+
   def transpose(self, ct, *maybe_accums):
     cts = [get_tuple_element(ct, i) for i in range(len(self.out_aval.tys))]
     for ct_, accum in zip(cts, maybe_accums):
@@ -290,7 +292,7 @@ class GetTupElt(VJPHiPrimitive):
     elts[self.idx] = g
     tup_accum.accum(make_tup(*elts))
 
-  def vjp_fwd(self, tup):
+  def vjp_fwd(self, nzs_in, tup):
     return get_tuple_element(tup, self.idx), None
 
   def vjp_bwd_retval(self, _res, g):
@@ -1417,8 +1419,14 @@ class HijaxTest(jtu.JaxTestCase):
     x = jnp.float32(2.0)
     expected_grad = jnp.float32(4.0)
     with self.subTest("jit-of-grad"):
-      with Square.assert_jvp_rule_called_once():
+      if config.remat3.value:
+        # remat3 differentiates via the vjp rules; the jvp rule is unused
+        count = Square._jvp_execution_count
         actual_grad = jax.jit(jax.grad(jax.remat(square)))(x)
+        self.assertEqual(Square._jvp_execution_count, count)
+      else:
+        with Square.assert_jvp_rule_called_once():
+          actual_grad = jax.jit(jax.grad(jax.remat(square)))(x)
       self.assertArraysAllClose(actual_grad, expected_grad)
 
   @parameterized.parameters([False, True])

--- a/tests/python_callback_test.py
+++ b/tests/python_callback_test.py
@@ -1250,8 +1250,7 @@ class IOCallbackTest(jtu.JaxTestCase):
       io_callback(lambda x: x, y, y)
       return x
 
-    with self.assertRaisesRegex(NotImplementedError,
-        "Effects not supported in partial-eval of `checkpoint`"):
+    with self.assertRaisesRegex(NotImplementedError, "Effects not supported in"):
       f(2., 3.)
 
   @parameterized.named_parameters(


### PR DESCRIPTION
A few small remat3 fixes to make in-tree tests green. Still broken is key-reuse checking.