### PR TITLE
Fix missing iterator increment in flatten_one_level_with_keys for namedtuples

### DIFF
--- a/jaxlib/pytree.cc
+++ b/jaxlib/pytree.cc
@@ -398,6 +398,7 @@ nb::object PyTreeRegistry::FlattenOneLevelImpl(nb::handle x,
         for (nb::handle entry : in) {
           out.append(nb::make_tuple(
               make_nb_class<GetAttrKey>(nb::str(*field_iter)), entry));
+          ++field_iter;
         }
         return nb::make_tuple(std::move(out), x.type());
       }


### PR DESCRIPTION
Fixes #39297.

This adds the missing increment of `field_iter` in `FlattenOneLevelImpl`.