### PR TITLE
Mention keyword arguments in the vmap in_axes arity error

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1189,9 +1189,19 @@ def vmap(fun: F,
   def vmap_f(*args, **kwargs):
     nonlocal spmd_axis_name
     if isinstance(in_axes, tuple) and len(in_axes) != len(args):
-      raise ValueError("vmap in_axes must be an int, None, or a tuple of entries corresponding "
-                       "to the positional arguments passed to the function, "
-                       f"but got {len(in_axes)=}, {len(args)=}")
+      msg = ("vmap in_axes must be an int, None, or a tuple of entries "
+             "corresponding to the positional arguments passed to the "
+             f"function, but got {len(in_axes)=}, {len(args)=}.")
+      if kwargs:
+        msg += (" Note that the function was called with keyword arguments "
+                f"{list(kwargs)}, which the entries of a tuple in_axes never "
+                "correspond to: keyword arguments are always mapped along "
+                "their leading axis (axis 0). If that is the intended "
+                "mapping, make in_axes correspond to the positional "
+                "arguments only; otherwise pass the arguments positionally, "
+                "or bind unmapped keyword arguments with functools.partial "
+                "before applying vmap.")
+      raise ValueError(msg)
 
     args_flat, in_tree  = tree_flatten((args, kwargs), is_leaf=batching.is_vmappable)
     dbg = debug_info("vmap", fun, args, kwargs)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3387,6 +3387,32 @@ class APITest(jtu.JaxTestCase):
                   "positional arguments passed to the function, but got len(in_axes)=2, len(args)=1")):
       jax.vmap(lambda x: x['a'], in_axes=(0, {'a': 0}))({'a': jnp.zeros((3, 3))})
 
+  def test_vmap_in_axes_tuple_with_kwargs_error(self):
+    # https://github.com/jax-ml/jax/issues/7465
+    def f(a, b, c):
+      return a + b + c
+
+    with self.assertRaisesRegex(
+        ValueError,
+        re.escape("but got len(in_axes)=3, len(args)=0. Note that the function "
+                  "was called with keyword arguments ['a', 'b', 'c'], which "
+                  "the entries of a tuple in_axes never correspond to: "
+                  "keyword arguments are always mapped along their leading "
+                  "axis (axis 0)")):
+      jax.vmap(f, in_axes=(0, 0, None))(
+          a=jnp.array([1, 2]), b=jnp.array([2, 4]), c=0.5)
+
+  def test_vmap_in_axes_tuple_with_kwonly_error(self):
+    # https://github.com/jax-ml/jax/issues/7465
+    def g(a, *, b):
+      return a @ b
+
+    with self.assertRaisesRegex(
+        ValueError,
+        re.escape("but got len(in_axes)=2, len(args)=1. Note that the function "
+                  "was called with keyword arguments ['b']")):
+      jax.vmap(g, in_axes=(None, 0))(jnp.ones((2, 4)), b=jnp.ones((10, 4, 2)))
+
   def test_vmap_in_axes_tree_prefix_error(self):
     # https://github.com/jax-ml/jax/issues/795
     value_tree = jnp.ones(3)


### PR DESCRIPTION
A tuple in_axes only corresponds to positional arguments, and keyword arguments are always mapped along axis 0 (documented behavior). Calls that pass arguments by keyword hit the in_axes/args length check with a message that only reported len(in_axes) and len(args), never saying that the keyword arguments are the cause. Append a note naming the keyword arguments, explaining the axis-0 rule, and suggesting fixes: shorten in_axes if axis-0 mapping is intended, pass the arguments positionally, or bind unmapped keyword arguments with functools.partial.

Message-only change; the error without keyword arguments is unchanged.

Helps with #7465
