### PR TITLE
Fix cudnn attention batching rules for operands without the vmap axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     temporarily bypass the error check.
     See https://docs.jax.dev/en/latest/export/export.html#compatibility-guarantees.
 
+* Bug fixes
+  * The batching rules of the cuDNN fused attention primitives (used by
+    {func}`jax.nn.dot_product_attention` with `implementation='cudnn'`) now
+    support operands that do not carry the vmap axis, including a shared
+    bias or `mask`. Previously `jax.jacobian`, `jax.vmap` with partial
+    `in_axes`, and `jax.vmap` of a VJP or of `jax.grad` failed with a
+    reshape `TypeError` ({jax-issue}`#38495`).
+
 ## JAX 0.11.0 (July 16, 2026)
 
 * New features

--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -805,10 +805,44 @@ def _check_valid_batch_dims(bdims):
       raise NotImplementedError(
         f"Currently only support batch_dim in [0, None], but got {dim=}")
 
+def _broadcast_unbatched_args(batched_args, batch_dims, arg_idx):
+  # Broadcast the vmap axis onto the operands in arg_idx that do not carry it,
+  # so the flattening logic below sees uniformly batched operands.
+  sizes = {args.shape[dim] for args, dim in zip(batched_args, batch_dims)
+           if dim is not None}
+  assert len(sizes) == 1, f"expected one vmap axis size, got {sizes}"
+  axis_size, = sizes
+  args, dims = list(batched_args), list(batch_dims)
+  for i in arg_idx:
+    if dims[i] is None:
+      args[i] = jnp.broadcast_to(args[i][None], (axis_size,) + args[i].shape)
+      dims[i] = 0
+  return tuple(args), tuple(dims)
+
+def _batcher_arg_idx(mask_type, num_args):
+  # Operands that participate in batching; bias (index 3) is decided by the
+  # caller since an unbatched batch-1 bias may rely on cuDNN's broadcasting.
+  arg_idx = [0, 1, 2] + list(range(10, num_args))
+  if has_padding(mask_type):
+    arg_idx += [4, 5]
+  return arg_idx
+
 def _dot_product_attention_fwd_batcher(
     batched_args, batch_dims, *, scale, seed, dropout_rate, variadic_args,
     mask_type, layout, sliding_window_length, is_training):
   _check_valid_batch_dims(batch_dims)
+  has_bias, _ = variadic_args
+  arg_idx = _batcher_arg_idx(mask_type, len(batched_args))
+  if has_bias and batch_dims[3] is None:
+    query_batch = math.prod(
+        batched_args[0].shape[:-3]
+        if batch_dims[0] is None else batched_args[0].shape[1:-3])
+    if batched_args[3].shape[0] == query_batch:
+      arg_idx.append(3)
+  elif has_bias:
+    arg_idx.append(3)
+  batched_args, batch_dims = _broadcast_unbatched_args(
+      batched_args, batch_dims, arg_idx)
   query, key, value, bias, q_seqlen, kv_seqlen, \
     q_offsets, kv_offsets, page_table_k, page_table_v = batched_args
   query_bdim = batch_dims[0]
@@ -824,7 +858,6 @@ def _dot_product_attention_fwd_batcher(
     *Bs, T, N, _ = query.shape
     *_, S, _, _ = key.shape
   B = math.prod(Bs)
-  has_bias, _ = variadic_args
   original_shape = query.shape
   # reshape to 4D shape
   query = jnp.reshape(query, (B,) + query.shape[-3:])
@@ -856,6 +889,23 @@ def _dot_product_attention_bwd_batcher(
      batched_args, batch_dims, *, scale, seed, dropout_rate, variadic_args,
      mask_type, layout, sliding_window_length):
   _check_valid_batch_dims(batch_dims)
+  has_bias, has_dbias = variadic_args
+  arg_idx = _batcher_arg_idx(mask_type, len(batched_args))
+  tile_shared_bias = False
+  if has_bias and batch_dims[3] is None:
+    query_batch = math.prod(
+        batched_args[0].shape[:-3]
+        if batch_dims[0] is None else batched_args[0].shape[1:-3])
+    if batched_args[3].shape[0] == query_batch:
+      arg_idx.append(3)
+    elif any(batch_dims[i] is None for i in arg_idx):
+      # The kernel sums dbias over the whole flattened batch, so a shared
+      # batch-1 bias must be tiled here and its gradient re-summed below.
+      tile_shared_bias = True
+  elif has_bias:
+    arg_idx.append(3)
+  batched_args, batch_dims = _broadcast_unbatched_args(
+      batched_args, batch_dims, arg_idx)
   query, key, value, bias, q_seqlen, kv_seqlen, q_offsets, kv_offsets, \
     page_table_k, page_table_v, activation, fwd_output, grad_output = batched_args
   query_bdim = batch_dims[0]
@@ -868,7 +918,6 @@ def _dot_product_attention_bwd_batcher(
     *Bs, T, N, _ = query.shape
     *_, S, _, _ = key.shape
   B = math.prod(Bs)
-  has_bias, has_dbias = variadic_args
   original_query_shape = query.shape
   original_key_shape = key.shape
   original_value_shape = value.shape
@@ -879,6 +928,8 @@ def _dot_product_attention_bwd_batcher(
   value = jnp.reshape(value, (B,) + key.shape[-3:])
   if has_bias and batch_dims[3] is not None:
     bias = jnp.reshape(bias, (B, N, T, S))
+  elif tile_shared_bias:
+    bias = jnp.broadcast_to(bias, (B,) + bias.shape[1:])
   if has_padding(mask_type):
     q_seqlen = jnp.reshape(q_seqlen, (B, ))
     kv_seqlen = jnp.reshape(kv_seqlen, (B, ))
@@ -900,12 +951,19 @@ def _dot_product_attention_bwd_batcher(
   grads[1] = jnp.reshape(grads[1], original_key_shape)
   grads[2] = jnp.reshape(grads[2], original_value_shape)
   if has_dbias:
-    assert has_bias
-    if variadic_args[1]:
+    assert has_bias and original_bias_shape is not None
+    if tile_shared_bias:
+      # Sum per-example bias gradients over the shared (non-vmap) batch dims.
+      dbias = jnp.reshape(grads[3], tuple(Bs) + grads[3].shape[1:])
+      dbias = jnp.sum(dbias, axis=tuple(range(1, len(Bs))))
+      grads[3] = jnp.reshape(dbias, (Bs[0],) + original_bias_shape)
+      out_bdims += (0,)
+    elif variadic_args[1]:
       grads[3] = jnp.reshape(grads[3], original_bias_shape)
+      out_bdims += (batch_dims[3],)
     else:
       grads.append(jnp.zeros(original_bias_shape, bias.dtype))
-    out_bdims += (batch_dims[3],)
+      out_bdims += (batch_dims[3],)
   return grads, out_bdims
 
 # custom partitioning

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -354,6 +354,165 @@ class DotProductAttentionTest(jtu.JaxTestCase):
       kv_seqlen=kv_seqlen, page_table_k=page_table_k, page_table_v=page_table_v)
     out_ref = sdpa_infer_ref(q, k, v)
     self.assertArraysAllClose(out_ref, out_ref, rtol=1e-2, atol=1e-2)
+
+
+@jtu.with_config(jax_numpy_dtype_promotion="standard")
+class DotProductAttentionBatchingTest(jtu.JaxTestCase):
+  # Regression tests for https://github.com/jax-ml/jax/issues/38495.
+  # Trace-level (jax.eval_shape), so they do not need Ampere, except for
+  # the execution-mode test_sdpa_mixed_batching_values at the end.
+
+  def setUp(self):
+    super().setUp()
+    try:
+      check_cudnn_version()
+    except RuntimeError as e:
+      self.skipTest(str(e))
+
+  def _shapes(self, tree):
+    return jax.tree.map(lambda x: (x.shape, x.dtype), tree)
+
+  def _make_qkv(self):
+    keys = jax.random.split(jax.random.key(0), 3)
+    return [jax.random.normal(key, (2, 4, 16, 32), dtype=jnp.float16)
+            for key in keys]
+
+  def _check_matches_xla(self, transform, *args):
+    cudnn_fn = transform(
+        partial(jax.nn.dot_product_attention, implementation="cudnn"))
+    xla_fn = transform(
+        partial(jax.nn.dot_product_attention, implementation="xla"))
+    out = jax.eval_shape(cudnn_fn, *args)
+    out_ref = jax.eval_shape(xla_fn, *args)
+    self.assertEqual(self._shapes(out), self._shapes(out_ref))
+
+  @jtu.run_on_devices("cuda")
+  def test_jacobian(self):
+    # The reported case: unbatched residuals with a batched cotangent.
+    q, k, v = self._make_qkv()
+    self._check_matches_xla(jax.jacobian, q, k, v)
+
+  @jtu.run_on_devices("cuda")
+  def test_vmap_partial_in_axes(self):
+    # Only query carries the vmap axis; its size (3) differs from the
+    # per-example batch (2) so a mixed-up axis would change the shape.
+    q, k, v = self._make_qkv()
+    qb = jnp.stack([q, q, q])
+    self._check_matches_xla(
+        lambda f: jax.vmap(f, in_axes=(0, None, None)), qb, k, v)
+
+  @jtu.run_on_devices("cuda")
+  def test_vmap_of_vjp(self):
+    # Shared primals, batched cotangents, decoupled from jacobian's basis.
+    q, k, v = self._make_qkv()
+    cts = jnp.zeros((5,) + q.shape, q.dtype)
+
+    def transform(f):
+      def pull(ct):
+        _, pullback = jax.vjp(f, q, k, v)
+        return pullback(ct)
+      return jax.vmap(pull)
+
+    self._check_matches_xla(transform, cts)
+
+  @jtu.run_on_devices("cuda")
+  def test_vmap_of_grad(self):
+    # A reduction cotangent reaches the backward batcher unbatched even
+    # when all primals are batched.
+    q, k, v = self._make_qkv()
+    qb, kb, vb = (jnp.stack([x, x, x]) for x in (q, k, v))
+
+    def transform(f):
+      return jax.vmap(jax.grad(
+          lambda *xs: f(*xs).astype(jnp.float32).sum(), argnums=(0, 1, 2)))
+
+    self._check_matches_xla(transform, qb, kb, vb)
+
+  @jtu.run_on_devices("cuda")
+  def test_jacobian_with_bias(self):
+    # Bias with an explicit batch dim; also covers dbias labeling.
+    q, k, v = self._make_qkv()
+    bias = jax.random.normal(jax.random.key(1), (2, 16, 4, 4),
+                             dtype=jnp.float16)
+    self._check_matches_xla(
+        lambda f: jax.jacobian(partial(f, q, k, v)), bias)
+
+  @jtu.run_on_devices("cuda")
+  def test_vmap_of_grad_shared_bias(self):
+    # A batch-1 (shared) bias exercises the tile-and-resum dbias path.
+    q, k, v = self._make_qkv()
+    qb, kb, vb = (jnp.stack([x, x, x]) for x in (q, k, v))
+    bias = jax.random.normal(jax.random.key(1), (1, 16, 4, 4),
+                             dtype=jnp.float16)
+
+    def transform(f):
+      return jax.vmap(jax.grad(
+          lambda q_, k_, v_, b_: f(q_, k_, v_, b_).astype(jnp.float32).sum(),
+          argnums=(0, 1, 2, 3)), in_axes=(0, 0, 0, None))
+
+    self._check_matches_xla(transform, qb, kb, vb, bias)
+
+  @jtu.run_on_devices("cuda")
+  def test_jacobian_with_mask(self):
+    # mask= becomes a batch-1 bias internally (shared-bias tiling path).
+    q, k, v = self._make_qkv()
+    mask = jnp.tril(jnp.ones((4, 4), dtype=jnp.bool_))
+    self._check_matches_xla(
+        lambda f: jax.jacobian(lambda q_: f(q_, k, v, mask=mask)), q)
+
+  @jtu.run_on_devices("cuda")
+  def test_jacobian_gqa_unequal_seqlen(self):
+    # GQA with unequal seq lengths so mixed-up dims cannot cancel out.
+    keys = jax.random.split(jax.random.key(0), 3)
+    q = jax.random.normal(keys[0], (2, 4, 16, 32), dtype=jnp.float16)
+    k = jax.random.normal(keys[1], (2, 6, 8, 32), dtype=jnp.float16)
+    v = jax.random.normal(keys[2], (2, 6, 8, 32), dtype=jnp.float16)
+    self._check_matches_xla(jax.jacobian, q, k, v)
+
+  @jtu.run_on_devices("cuda")
+  def test_all_batched_vmap(self):
+    # The previously working fully-batched case must stay intact.
+    q, k, v = self._make_qkv()
+    qb, kb, vb = (jnp.stack([x, x, x]) for x in (q, k, v))
+    self._check_matches_xla(jax.vmap, qb, kb, vb)
+
+  @jtu.run_on_devices("cuda")
+  def test_sdpa_mixed_batching_values(self):
+    # Execution-mode companion of the trace-level tests above: checks
+    # values, not just shapes. Lives in this class rather than
+    # DotProductAttentionTest for its dtype promotion config: the xla
+    # reference implementation of jax.nn.dot_product_attention promotes
+    # bfloat16 logits to float32, which strict mode rejects.
+    if not jtu.is_cuda_compute_capability_at_least("8.0"):
+      self.skipTest("Requires at least Ampere arch")
+    if jtu.is_cuda_version_at_least(13, 0):
+      self.skipTest("cuDNN creates no execution plans on CUDA 13.0.")
+    keys = jax.random.split(jax.random.key(0), 3)
+    B, T, N, H = 2, 64, 4, 64
+    q, k, v = (jax.random.normal(key, (B, T, N, H), dtype=jnp.bfloat16)
+               for key in keys)
+    qb = jnp.stack([q, q + 1, q - 1])
+
+    def attn(impl):
+      return partial(jax.nn.dot_product_attention, implementation=impl)
+
+    # Forward batcher: only query carries the vmap axis.
+    out_ans = jax.vmap(attn("cudnn"), in_axes=(0, None, None))(qb, k, v)
+    out_ref = jax.vmap(attn("xla"), in_axes=(0, None, None))(qb, k, v)
+    self.assertArraysAllClose(out_ref, out_ans, rtol=1e-2, atol=1e-2)
+
+    # Backward batcher: the reduction cotangent reaches it unbatched.
+    def grads(impl):
+      return jax.vmap(jax.grad(
+          lambda *xs: attn(impl)(*xs).astype(jnp.float32).sum(),
+          argnums=(0, 1, 2)), in_axes=(0, None, None))
+
+    grads_ans = grads("cudnn")(qb, k, v)
+    grads_ref = grads("xla")(qb, k, v)
+    for g_ref, g_ans in zip(grads_ref, grads_ans):
+      self.assertArraysAllClose(g_ref, g_ans, rtol=2e-1, atol=2e-1)
+
+
 @jtu.with_config(jax_numpy_dtype_promotion="standard")
 class DotProductAttentionF8Test(jtu.JaxTestCase):
 


### PR DESCRIPTION
The batching rules of the cudnn fused attention primitives assumed every operand carries the vmap axis together, deriving the batch size and the output batch dims from query alone. Under jax.jacobian (vmap of the VJP), jax.vmap with partial in_axes, or vmap of jax.grad (whose reduction cotangent arrives as an unbatched constant), some operands carry no batch dim and the rules crashed with a reshape TypeError.

Broadcast the vmap axis onto unbatched operands before the existing flattening logic. A shared batch-1 bias (also what mask= becomes internally) is tiled across the batch in the backward rule and its per-example gradients are summed back per vmap element. Zero-size placeholder operands are left untouched, and fully-batched calls are unchanged.

Fixes #38495
