### PR TITLE
Fix cudnn fp8 attention batching rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     bias or `mask`. Previously `jax.jacobian`, `jax.vmap` with partial
     `in_axes`, and `jax.vmap` of a VJP or of `jax.grad` failed with a
     reshape `TypeError` ({jax-issue}`#38495`).
+  * `jax.vmap` of fp8 cuDNN fused attention now works: its batching rules
+    additionally mislabeled or dropped the amax outputs and restored output
+    shapes incorrectly, so previously no vmap of the fp8 path succeeded at
+    all. The amax outputs are whole-batch statistics and do not carry the
+    vmap axis; vmap over the scale/descale operands raises a clear
+    `NotImplementedError`.
 
 ## JAX 0.11.0 (July 16, 2026)
 

--- a/jax/_src/cudnn/fused_attention_stablehlo.py
+++ b/jax/_src/cudnn/fused_attention_stablehlo.py
@@ -1620,16 +1620,32 @@ def _dot_product_attention_fp8_bwd_cuda_lowering(
   # Only keep dQ, dK, dV, amax_dQ, amax_dK, amax_dV, amax_dP here
   return dqkv_amaxs
 
+def _check_unbatched_scaling_factors(batched_args, batch_dims, first_idx):
+  # The fp8 scale/descale operands are whole-tensor scaling factors; the
+  # kernel consumes a single value per tensor, so a vmapped (per-example)
+  # scaling factor cannot be expressed.
+  for i in range(first_idx, len(batched_args)):
+    if batch_dims[i] is not None:
+      raise NotImplementedError(
+          "vmap over the scale/descale operands of fp8 attention is not "
+          "supported.")
+
 def _dot_product_attention_fp8_fwd_batcher(
     batched_args, batch_dims, *, scale, use_causal_mask, layout, is_training):
   _check_valid_batch_dims(batch_dims)
+  _check_unbatched_scaling_factors(batched_args, batch_dims, 3)
+  batched_args, batch_dims = _broadcast_unbatched_args(
+      batched_args, batch_dims, [0, 1, 2])
   query, key, value,\
     descale_q, descale_k, descale_v, descale_s, scale_s, scale_o, = batched_args
   query_bdim = batch_dims[0]
+  # The amax outputs are whole-batch statistics: the kernel computes one
+  # value across the flattened batch, exactly as a non-vmapped call on the
+  # same data would, so they do not carry the vmap axis.
   if is_training:
-    out_bdims = query_bdim, query_bdim
+    out_bdims = query_bdim, None, None, query_bdim
   else:
-    out_bdims = (query_bdim,)
+    out_bdims = (query_bdim, None, None)
 
   if layout == AttentionLayout.BNTH.value:
     *Bs, N, T, _ = query.shape
@@ -1638,6 +1654,7 @@ def _dot_product_attention_fp8_fwd_batcher(
     *Bs, T, N, _ = query.shape
     *_, S, _, _ = key.shape
   B = math.prod(Bs)
+  original_shape = query.shape
 
   # reshape to 4D shape
   query = jnp.reshape(query, (B,) + query.shape[-3:])
@@ -1650,7 +1667,7 @@ def _dot_product_attention_fp8_fwd_batcher(
 
   # reshape to original shape
   output, amax_s, amax_o = outputs[0], outputs[1], outputs[2]
-  output = jnp.reshape(output, query.shape)
+  output = jnp.reshape(output, original_shape)
   if is_training:
     activation = outputs[3]
     activation = jnp.reshape(activation, (*Bs, N, T))
@@ -1661,11 +1678,15 @@ def _dot_product_attention_fp8_fwd_batcher(
 def _dot_product_attention_fp8_bwd_batcher(
     batched_args, batch_dims, *, scale, use_causal_mask, layout):
   _check_valid_batch_dims(batch_dims)
+  _check_unbatched_scaling_factors(batched_args, batch_dims, 6)
+  batched_args, batch_dims = _broadcast_unbatched_args(
+      batched_args, batch_dims, [0, 1, 2, 3, 4, 5])
   query, key, value, fwd_output, grad_output, activation,\
     descale_q, descale_k, descale_v, descale_o, descale_dO, descale_s, descale_dP,\
     scale_s, scale_dQ, scale_dK, scale_dV, scale_dP = batched_args
   query_bdim = batch_dims[0]
-  out_bdims = query_bdim, query_bdim, query_bdim
+  # The four amax outputs are whole-batch statistics (see the fwd batcher).
+  out_bdims = (query_bdim, query_bdim, query_bdim, None, None, None, None)
 
   if layout == AttentionLayout.BNTH.value:
     *Bs, N, T, _ = query.shape
@@ -1674,6 +1695,9 @@ def _dot_product_attention_fp8_bwd_batcher(
     *Bs, T, N, _ = query.shape
     *_, S, _, _ = key.shape
   B = math.prod(Bs)
+  original_query_shape = query.shape
+  original_key_shape = key.shape
+  original_value_shape = value.shape
 
   # reshape to 4D shape
   query = jnp.reshape(query, (B,) + query.shape[-3:])
@@ -1690,11 +1714,10 @@ def _dot_product_attention_fp8_bwd_batcher(
       scale=scale, use_causal_mask=use_causal_mask, layout=layout,
   )
 
-  grad_query, grad_key, grad_value = grads[:3]
   # reshape to original shape
-  grad_query = jnp.reshape(grad_query, query.shape)
-  grad_key = jnp.reshape(grad_key, key.shape)
-  grad_value = jnp.reshape(grad_value, value.shape)
+  grads[0] = jnp.reshape(grads[0], original_query_shape)
+  grads[1] = jnp.reshape(grads[1], original_key_shape)
+  grads[2] = jnp.reshape(grads[2], original_value_shape)
 
   return grads, out_bdims
 
@@ -1955,7 +1978,11 @@ def paged_attention(
       token's left local window (pos - sliding_window_length, pos] where `pos`
       is the index of each token. E.g., if sliding_window_length == 3 and the
       sequence is [0, 1, 2, 3, c, 4, 5], token `c` can attend to [4, 5, c].
-    use_fp8: Whether to use FP8 attention mechanism.
+    use_fp8: Whether to use FP8 attention mechanism. The fp8 amax outputs
+      are statistics of the whole (flattened) batch; under `jax.vmap` every
+      vmapped instance observes the same global amax rather than a
+      per-instance one, and vmap over the scale/descale entries of
+      `fp8_params` is not supported.
     return_residual: Whether to return the logsumexp tensor of shape BTN
       or BNT to users. See section 3.1.1 in the FlashAttention-2 paper:
       https://arxiv.org/pdf/2307.08691 to find the definition of logsumexp.
@@ -2068,7 +2095,11 @@ def dot_product_attention(
       token's left local window (pos - sliding_window_length, pos] where `pos`
       is the index of each token. E.g., if sliding_window_length == 3 and the
       sequence is [0, 1, 2, 3, c, 4, 5], token `c` can attend to [4, 5, c].
-    use_fp8: Whether to use FP8 attention mechanism.
+    use_fp8: Whether to use FP8 attention mechanism. The fp8 amax outputs
+      are statistics of the whole (flattened) batch; under `jax.vmap` every
+      vmapped instance observes the same global amax rather than a
+      per-instance one, and vmap over the scale/descale entries of
+      `fp8_params` is not supported.
     return_residual: Whether to return the logsumexp tensor of shape BTN
       or BNT to users. See section 3.1.1 in the FlashAttention-2 paper:
       https://arxiv.org/pdf/2307.08691 to find the definition of logsumexp.

--- a/tests/fused_attention_stablehlo_test.py
+++ b/tests/fused_attention_stablehlo_test.py
@@ -514,6 +514,106 @@ class DotProductAttentionBatchingTest(jtu.JaxTestCase):
 
 
 @jtu.with_config(jax_numpy_dtype_promotion="standard")
+class DotProductAttentionF8BatchingTest(jtu.JaxTestCase):
+  # The fp8 twins of the batching-rule fixes above: besides the same
+  # unbatched-operand crash, the fp8 batchers returned out_bdims tuples
+  # shorter than their outputs (the amax outputs were unaccounted for) and
+  # restored output shapes from already-flattened operands, so no vmap of
+  # fp8 attention worked at all. Trace-level, like the class above. The
+  # amax outputs are whole-batch statistics and do not carry the vmap axis.
+
+  def setUp(self):
+    super().setUp()
+    try:
+      check_cudnn_version()
+    except RuntimeError as e:
+      self.skipTest(str(e))
+
+  def _make_inputs(self):
+    B, T, N, H = 2, 128, 4, 128
+    f8 = jnp.float8_e4m3fn
+    keys = jax.random.split(jax.random.key(0), 3)
+    q, k, v = (jax.random.normal(key, (B, T, N, H), jnp.float32).astype(f8)
+               for key in keys)
+    fp8_metas = {name: jnp.ones((1, 1, 1, 1), jnp.float32)
+                 for name in fp8_meta_names}
+    return q, k, v, fp8_metas
+
+  def _attn(self, fp8_metas):
+    return partial(dot_product_attention, scale=0.5,
+                   mask_type=MaskType.NO_MASK, use_fp8=True,
+                   fp8_params=fp8_metas)
+
+  @jtu.sample_product(layout=["BTNH", "BNTH"])
+  @jtu.run_on_devices("cuda")
+  def test_all_batched_vmap(self, layout):
+    q, k, v, fp8_metas = self._make_inputs()
+    if layout == "BNTH":
+      q, k, v = (jnp.einsum("btnh->bnth", x) for x in (q, k, v))
+    qb, kb, vb = (jnp.stack([x, x, x]) for x in (q, k, v))
+    attn = partial(dot_product_attention, scale=0.5,
+                   mask_type=MaskType.NO_MASK, use_fp8=True,
+                   fp8_params=fp8_metas, qkv_layout=layout)
+    out, amax_s, amax_o = jax.eval_shape(jax.vmap(attn), qb, kb, vb)
+    self.assertEqual(out.shape, (3,) + q.shape)
+    self.assertEqual(amax_s.shape, (3, 1, 1, 1, 1))
+    self.assertEqual(amax_o.shape, (3, 1, 1, 1, 1))
+
+  @jtu.run_on_devices("cuda")
+  def test_vmap_partial_in_axes(self):
+    q, k, v, fp8_metas = self._make_inputs()
+    qb = jnp.stack([q, q, q])
+    out, _, _ = jax.eval_shape(
+        jax.vmap(self._attn(fp8_metas), in_axes=(0, None, None)), qb, k, v)
+    self.assertEqual(out.shape, (3,) + q.shape)
+
+  @jtu.run_on_devices("cuda")
+  def test_vmap_of_grad(self):
+    # Covers both the unbatched reduction cotangent (all-batched primals)
+    # and fully mixed batching (only query batched).
+    q, k, v, fp8_metas = self._make_inputs()
+    qb, kb, vb = (jnp.stack([x, x, x]) for x in (q, k, v))
+
+    def loss(q_, k_, v_):
+      out, _, _ = self._attn(fp8_metas)(q_, k_, v_)
+      return out.astype(jnp.float32).sum()
+
+    grads = jax.eval_shape(
+        jax.vmap(jax.grad(loss, argnums=(0, 1, 2))), qb, kb, vb)
+    self.assertEqual(tuple(g.shape for g in grads),
+                     ((3,) + q.shape,) * 3)
+    grads = jax.eval_shape(
+        jax.vmap(jax.grad(loss, argnums=(0, 1, 2)),
+                 in_axes=(0, None, None)), qb, k, v)
+    self.assertEqual(tuple(g.shape for g in grads),
+                     ((3,) + q.shape,) * 3)
+
+  @jtu.run_on_devices("cuda")
+  def test_vmap_over_scaling_factor_raises(self):
+    q, k, v, fp8_metas = self._make_inputs()
+    qb = jnp.stack([q, q, q])
+    descale_qs = jnp.ones((3, 1, 1, 1, 1), jnp.float32)
+
+    def fn(q_, descale_q):
+      metas = dict(fp8_metas, descale_q=descale_q)
+      return self._attn(metas)(q_, k, v)[0]
+
+    with self.assertRaisesRegex(NotImplementedError,
+                                "scale/descale operands"):
+      jax.eval_shape(jax.vmap(fn), qb, descale_qs)
+
+    # Same guard on the backward batcher, via a batched bwd-only scale.
+    def loss(q_, scale_dQ):
+      metas = dict(fp8_metas, scale_dQ=scale_dQ)
+      out, _, _ = self._attn(metas)(q_, k, v)
+      return out.astype(jnp.float32).sum()
+
+    with self.assertRaisesRegex(NotImplementedError,
+                                "scale/descale operands"):
+      jax.eval_shape(jax.vmap(jax.grad(loss)), qb, descale_qs)
+
+
+@jtu.with_config(jax_numpy_dtype_promotion="standard")
 class DotProductAttentionF8Test(jtu.JaxTestCase):
 
   def setUp(self):


### PR DESCRIPTION
Follow-up to #39451 (same root cause as #38495, fp8 path).

This applies the same normalization as the non-fp8 fix (broadcast the vmap axis onto unbatched tensor operands, reusing the helper from that PR)

This branch is stacked on #39451; only the top commit is new.