### PR TITLE
[WIP][ROCm] Prevent job-container teardown hangs in ROCm CI

### DIFF
--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -119,6 +119,7 @@ jobs:
       volumes:
         - /data:/data
       options: >-
+        --init
         --device=/dev/kfd
         --device=/dev/dri
         --security-opt seccomp=unconfined
@@ -224,3 +225,10 @@ jobs:
           artifact-name: bazel-test-artifacts-${{ inputs.runner }}-py${{ inputs.python }}-rocm${{ inputs.rocm-version }}
           inputs_json: ${{ toJSON(inputs) }}
           matrix_json: ${{ toJSON(matrix) }}
+      - name: Release container resources
+        if: always()
+        continue-on-error: true
+        timeout-minutes: 3
+        run: |
+          bazel shutdown 2>/dev/null || true
+          ps -eo pid,ppid,stat,wchan:24,comm | awk 'NR==1 || $3 ~ /^[DZ]/' || true

--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -127,6 +127,7 @@ jobs:
       volumes:
         - /data:/data
       options: >-
+        --init
         --device=/dev/kfd
         --device=/dev/dri
         --security-opt seccomp=unconfined
@@ -197,3 +198,10 @@ jobs:
         run: echo "s3_upload_uri=${INPUTS_S3_UPLOAD_URI}" >> "$GITHUB_OUTPUT"
         env:
           INPUTS_S3_UPLOAD_URI: ${{ inputs.s3_upload_uri }}
+      - name: Release container resources
+        if: always()
+        continue-on-error: true
+        timeout-minutes: 3
+        run: |
+          bazel shutdown 2>/dev/null || true
+          ps -eo pid,ppid,stat,wchan:24,comm | awk 'NR==1 || $3 ~ /^[DZ]/' || true

--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -133,7 +133,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
+      options: --init --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
     name: "${{ (contains(inputs.runner, 'gfx950.1') && 'gfx950.1') ||
         (contains(inputs.runner, 'gfx950.4') && 'gfx950.4') ||
         (contains(inputs.runner, 'gfx950.8') && 'gfx950.8') }}, ROCm ${{ inputs.rocm-version }}, py${{ inputs.python }}"
@@ -205,3 +205,9 @@ jobs:
           IS_NIGHTLY: ${{ contains(github.workflow, 'Nightly/Release') && 'nightly' || 'continuous' }}
         run: |
           ./ci/upload_rocm_logs.sh
+      - name: Release container resources
+        if: always()
+        continue-on-error: true
+        timeout-minutes: 3
+        run: |
+          ps -eo pid,ppid,stat,wchan:24,comm | awk 'NR==1 || $3 ~ /^[DZ]/' || true


### PR DESCRIPTION
## What

ROCm CI job containers now run with `--init`, and each ROCm workflow ends with a
short, bounded cleanup step. This addresses jobs that finish their real work in
minutes but then sit for tens of minutes in the runner's implicit
"Stop containers" step.

one such example:
https://github.com/jax-ml/jax/actions/runs/30273768721/job/90002526109?pr=39461#step:20:1