### PR TITLE
[remat3] fix small issues that cause downstream failures

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -1154,6 +1154,16 @@ class RematTraced(VJPHiPrimitive):
       return tree_unflatten(out_tree, out_flat)
     return out, rem
 
+  def dce(self, used_outs):
+    used_outs_flat = tree_leaves_checked(self.out_tree, used_outs)
+    if not any(used_outs_flat):
+      return False, False, None
+    new_jaxpr, used_ins = pe.dce_jaxpr(self.jaxpr, used_outs_flat)
+    if all(used_ins) and all(used_outs_flat):
+      return True, True, self
+    return (tuple(used_ins), tuple(used_outs_flat),
+            RematTraced(new_jaxpr, self.policy))
+
 class CheckpointName(VJPHiPrimitive):
   name: str
 

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -438,49 +438,8 @@ def _remat_static_argnums(fun, static_argnums, args):
   new_fun = _dyn_args_fun(fun, static_argnums_, tuple(static_args), nargs)
   return new_fun, dyn_args
 
-class WrapHashably:
-  val: Any
-  hash: int
-  hashable: bool
-
-  def __init__(self, val):
-    self.val = val
-    try:
-      self.hash = hash(val)
-      self.hashable = True
-    except:
-      self.hash = id(val)
-      self.hashable = False
-  def __hash__(self):
-    return self.hash
-  def __eq__(self, other):
-    if isinstance(other, WrapHashably):
-      if self.hashable and other.hashable:
-        return self.val == other.val
-      else:
-        return self.val is other.val
-    return False
-
-# This caching is useful to avoid retracing even when static_argnums is used.
-# See api_benchmark.py:bench_remat_eager_retracing_overheads_static_argnums.
-# On that benchmark, including this caching makes a ~10x difference (which can
-# be made arbitrary large by involving larger functions to be traced).
-def _dyn_args_fun(fun: Callable, static_argnums: frozenset[int],
-                  static_args: tuple[WrapHashably, ...], nargs: int):
-  if any(isinstance(x.val, core.Tracer) for x in static_args):
-    return _dyn_args_fun_uncached(fun, static_argnums, static_args, nargs)
-  return _dyn_args_fun_cached(fun, static_argnums, static_args, nargs)
-
-def _dyn_args_fun_uncached(fun: Callable, static_argnums: frozenset[int],
-                           static_args: tuple[WrapHashably, ...], nargs: int):
-  def new_fun(*dyn_args, **kwargs):
-    static_args_, dyn_args_ = iter(static_args), iter(dyn_args)
-    full_args = [next(static_args_).val if i in static_argnums
-                 else next(dyn_args_) for i in range(nargs)]
-    return fun(*full_args, **kwargs)
-  return new_fun
-
-_dyn_args_fun_cached = weakref_lru_cache(_dyn_args_fun_uncached)
+WrapHashably = api_util.WrapHashably
+_dyn_args_fun = api_util.dyn_args_fun
 
 # This helper is similar to those in control_flow/common.py, but with
 # remat-specific errors.
@@ -1031,6 +990,21 @@ def remat3(f=None, /, policy=None, static_argnums=(), static_argnames=()):
 def _remat3(f, *, policy, static_argnums, static_argnames):
   @wraps(f)
   def decorator(*args, **kwargs):
+    if static_argnums or static_argnames:
+      # Like classic remat (and custom_vjp3), support unhashable static
+      # values by closing over them instead of threading them through the
+      # tracing machinery, which hashes them.
+      args_ = api_util.resolve_kwargs(f, args, kwargs)
+      argnums_ = (static_argnums,) if type(static_argnums) is int else static_argnums
+      argnums = frozenset(i % len(args_) for i in _static_argnums(
+          f, argnums_, static_argnames))
+      if not all(api_util.is_hashable(args_[i]) for i in argnums):
+        which_static = [i in argnums for i in range(len(args_))]
+        dyn_args, static_args = partition_list(which_static, args_)
+        f2 = _dyn_args_fun(f, argnums, tuple(map(WrapHashably, static_args)),
+                           len(args_))
+        return _remat3(f2, policy=policy, static_argnums=(),
+                       static_argnames=())(*dyn_args)
     args_ft = ft.flatten_static_argnums_argnames(
         args, kwargs, static_argnums, static_argnames)
     avals_ft = args_ft.map(typeof)
@@ -1042,6 +1016,14 @@ def _remat3(f, *, policy, static_argnums, static_argnames):
     out_flat = RematTraced(jaxpr, policy)(*consts, *args_ft)
     return out_avals_ft.update(out_flat).unflatten()
   return decorator
+
+def _static_argnums(f, argnums, argnames) -> frozenset[int]:
+  argnums = set(argnums)
+  if argnames:
+    sig = api_util.fun_signature(f)
+    assert sig is not None
+    argnums |= set(api_util.infer_argnums_and_argnames(sig, None, argnames)[0])
+  return frozenset(argnums)
 
 def dce(traced, policy):
   in_fwd = pe._jaxpr_forwarding(traced.jaxpr)

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1825,37 +1825,46 @@ class RSpec:
 def tuptree_map(f, treedef, *args):
   return treedef.walk(lambda xs, _: tuple(xs), lambda xs: f(*xs), zip(*args))
 
-def _saveable_args_flags(saveable_args, treedef) -> list[bool]:
+def tuptree_flags(prefix, treedef, name: str, full_name: str) -> list[bool]:
+  """Expand a tuple-tree of bools into per-leaf flags for `treedef`.
+
+  A tuple-tree is made of bools and tuples only, and must form a tree prefix
+  of `treedef` up to pytree node types: tuples are matched against containers
+  only by their number of children."""
   ret: list[bool] = []
-  _saveable_args_flags_rec(saveable_args, treedef, (), ret)
+  _tuptree_flags_rec(prefix, treedef, name, full_name, (), ret)
   return ret
 
-def _saveable_args_flags_rec(prefix, td, path, ret):
+def _saveable_args_flags(saveable_args, treedef) -> list[bool]:
+  return tuptree_flags(saveable_args, treedef, 'saveable_args',
+                       'the saveable_args argument to jax.vjp')
+
+def _tuptree_flags_rec(prefix, td, name, full_name, path, ret):
   if isinstance(prefix, bool):
     ret.extend([prefix] * td.num_leaves)
     return
-  where = 'saveable_args' + ''.join(f'[{i}]' for i in path)
+  where = name + ''.join(f'[{i}]' for i in path)
   if not isinstance(prefix, tuple):
     raise ValueError(
-        "the saveable_args argument to jax.vjp must be a tuple-tree of bools "
+        f"{full_name} must be a tuple-tree of bools "
         f"(made of bools and tuples only), but {where} is {prefix!r} of type "
         f"{type(prefix).__name__}")
   if treedef_is_strict_leaf(td):
     raise ValueError(
-        "the saveable_args argument to jax.vjp must form a tree prefix of "
-        f"the primal arguments (up to pytree node types), but {where} is a "
-        "tuple while the corresponding part of the arguments is a leaf; use "
+        f"{full_name} must form a tree prefix of "
+        f"the corresponding values (up to pytree node types), but {where} is "
+        "a tuple while the corresponding part of the values is a leaf; use "
         "a single bool there instead")
   td_children = td.children()
   if len(prefix) != len(td_children):
     raise ValueError(
-        "the saveable_args argument to jax.vjp must form a tree prefix of "
-        "the primal arguments (up to pytree node types, so containers need "
-        f"only match in their number of children), but {where} has "
-        f"{len(prefix)} children while the corresponding container in the "
-        f"arguments has {len(td_children)}")
+        f"{full_name} must form a tree prefix of "
+        "the corresponding values (up to pytree node types, so containers "
+        f"need only match in their number of children), but {where} has "
+        f"{len(prefix)} children while the corresponding container has "
+        f"{len(td_children)}")
   for i, (p, td_) in enumerate(zip(prefix, td_children)):
-    _saveable_args_flags_rec(p, td_, (*path, i), ret)
+    _tuptree_flags_rec(p, td_, name, full_name, (*path, i), ret)
 
 def _is_ref(x):
   from jax._src.state.types import AbstractRef

--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -31,7 +31,8 @@ from jax._src.tree_util import (
     broadcast_flattened_prefix_with_treedef, treedef_is_leaf, tree_structure,
     tracing_registry)
 from jax._src import linear_util as lu
-from jax._src.util import safe_map, HashableFunction, Unhashable, safe_zip
+from jax._src.util import (safe_map, HashableFunction, Unhashable, safe_zip,
+                           weakref_lru_cache)
 from jax._src import traceback_util
 
 traceback_util.register_exclusion(__file__)
@@ -324,6 +325,52 @@ def is_hashable(arg):
     return True
   except TypeError:
     return False
+
+
+class WrapHashably:
+  val: Any
+  hash: int
+  hashable: bool
+
+  def __init__(self, val):
+    self.val = val
+    try:
+      self.hash = hash(val)
+      self.hashable = True
+    except:
+      self.hash = id(val)
+      self.hashable = False
+  def __hash__(self):
+    return self.hash
+  def __eq__(self, other):
+    if isinstance(other, WrapHashably):
+      if self.hashable and other.hashable:
+        return self.val == other.val
+      else:
+        return self.val is other.val
+    return False
+
+# This caching is useful to avoid retracing even when static_argnums is used.
+# See api_benchmark.py:bench_remat_eager_retracing_overheads_static_argnums.
+# On that benchmark, including this caching makes a ~10x difference (which can
+# be made arbitrary large by involving larger functions to be traced).
+def dyn_args_fun(fun: Callable, static_argnums: frozenset[int],
+                 static_args: tuple[WrapHashably, ...], nargs: int):
+  if any(isinstance(x.val, core.Tracer) for x in static_args):
+    return _dyn_args_fun_uncached(fun, static_argnums, static_args, nargs)
+  return _dyn_args_fun_cached(fun, static_argnums, static_args, nargs)
+
+def _dyn_args_fun_uncached(fun: Callable, static_argnums: frozenset[int],
+                           static_args: tuple[WrapHashably, ...], nargs: int):
+  def new_fun(*dyn_args, **kwargs):
+    static_args_, dyn_args_ = iter(static_args), iter(dyn_args)
+    full_args = [next(static_args_).val if i in static_argnums
+                 else next(dyn_args_) for i in range(nargs)]
+    return fun(*full_args, **kwargs)
+  new_fun.__name__ = getattr(fun, '__name__', '<unnamed function>')
+  return new_fun
+
+_dyn_args_fun_cached = weakref_lru_cache(_dyn_args_fun_uncached)
 
 
 SENTINEL = object()

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -28,7 +28,8 @@ from jax._src import core
 from jax._src import dtypes
 from jax._src import effects
 from jax._src.api_util import (
-    resolve_kwargs, infer_argnums_and_argnames, debug_info, is_hashable)
+    resolve_kwargs, infer_argnums_and_argnames, debug_info, is_hashable,
+    dyn_args_fun, WrapHashably)
 from jax._src import linear_util as lu
 from jax._src import traceback_util
 from jax._src.core import typeof
@@ -1126,8 +1127,8 @@ class custom_vjp3:
       # accepted unhashable nondiff_argnums values, so close over them instead
       which_static = [i in self.static_argnums for i in range(len(args))]
       dyn_args, static_args = partition_list(which_static, args)
-      f = lambda *dyn: self.f(*merge_lists(which_static, dyn, static_args))
-      f.__name__ = getattr(self.f, '__name__', '<unnamed function>')
+      f = dyn_args_fun(self.f, self.static_argnums,
+                       tuple(map(WrapHashably, static_args)), len(args))
       traced = api.jit(f).trace(*dyn_args)
     if any(isinstance(x, core.Tracer) for x in traced._consts):
       t = next(x for x in traced._consts if isinstance(x, core.Tracer))
@@ -1386,8 +1387,8 @@ class custom_jvp3:
       # accepted unhashable nondiff_argnums values, so close over them instead
       which_static = [i in self.static_argnums for i in range(len(args))]
       dyn_args, static_args = partition_list(which_static, args)
-      f = lambda *dyn: self.f(*merge_lists(which_static, dyn, static_args))
-      f.__name__ = getattr(self.f, '__name__', '<unnamed function>')
+      f = dyn_args_fun(self.f, self.static_argnums,
+                       tuple(map(WrapHashably, static_args)), len(args))
       traced = api.jit(f).trace(*dyn_args)
     if any(isinstance(x, core.Tracer) for x in traced._consts):
       t = next(x for x in traced._consts if isinstance(x, core.Tracer))

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -778,8 +778,13 @@ def _call_hi_primitive_dce(used_outs_flat, eqn):
   used_ins, produced_outs, new_prim = _prim.dce(used_out)
   if new_prim is None:
     return [False] * len(eqn.invars), None
-  used_ins_flat = broadcast_prefix(used_ins, _prim.in_avals)
-  produced_outs_flat = broadcast_prefix(produced_outs, _prim.out_aval)
+  name = f'{type(_prim).__name__}.dce'
+  used_ins_flat = api.tuptree_flags(
+      used_ins, _prim.in_tree, 'used_ins',
+      f'the first (used inputs) return value of {name}')
+  produced_outs_flat = api.tuptree_flags(
+      produced_outs, _prim.out_tree, 'produced_outs',
+      f'the second (produced outputs) return value of {name}')
   new_invars = [x for x, u in zip(eqn.invars, used_ins_flat) if u]
   new_outvars = [v for v, u in zip(eqn.outvars, produced_outs_flat) if u]
   new_eqn = eqn.replace(invars=new_invars, outvars=new_outvars,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -8091,14 +8091,29 @@ class Remat3Test(RematTest):
     self.assertAllClose(rem(jnp.float32(3.), jnp.float32(4.)), (3., 16.),
                         check_dtypes=False)
 
+  def test_remat_unhashable_static_argnums(self):
+    # unhashable static values are closed over rather than hashed
+    @partial(jax.remat, static_argnums=1)
+    def f(x, static_dict):
+      return x * static_dict['scale']
+
+    x = jnp.ones(4)
+    g = jax.grad(lambda x: jnp.sum(f(x, {'scale': 2.0})))(x)
+    self.assertAllClose(g, jnp.full(4, 2.), check_dtypes=False)
+
+    @partial(jax.checkpoint, static_argnames='cfg')
+    def h(x, cfg):
+      return x * cfg['scale']
+
+    g = jax.grad(lambda x: jnp.sum(h(x, cfg={'scale': 3.0})))(x)
+    self.assertAllClose(g, jnp.full(4, 3.), check_dtypes=False)
+
   def test_remat_eqn_dce(self):
-    # dce through a remat application prunes unused outputs and the inputs
-    # only they needed
     @jax.remat
     def f(x, y):
       return jnp.sin(x), jnp.cos(y)
 
-    jaxpr = jax.make_jaxpr(f)(1., 2.)
+    jaxpr = jax.make_jaxpr(f)(jnp.float32(1.), jnp.float32(2.))
     dced, used_ins = pe.dce_jaxpr(jaxpr, [True, False])
     self.assertEqual(used_ins, [True, False])
     eqn, = dced.eqns

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -8091,6 +8091,29 @@ class Remat3Test(RematTest):
     self.assertAllClose(rem(jnp.float32(3.), jnp.float32(4.)), (3., 16.),
                         check_dtypes=False)
 
+  def test_remat_eqn_dce(self):
+    # dce through a remat application prunes unused outputs and the inputs
+    # only they needed
+    @jax.remat
+    def f(x, y):
+      return jnp.sin(x), jnp.cos(y)
+
+    jaxpr = jax.make_jaxpr(f)(1., 2.)
+    dced, used_ins = pe.dce_jaxpr(jaxpr, [True, False])
+    self.assertEqual(used_ins, [True, False])
+    eqn, = dced.eqns
+    self.assertEqual(eqn.primitive.name, 'call_hi_primitive')
+    self.assertLen(eqn.invars, 1)
+    self.assertLen(eqn.outvars, 1)
+    out, = core.eval_jaxpr(dced, dced.consts, jnp.float32(3.))
+    self.assertAllClose(out, jnp.sin(3.), check_dtypes=False)
+
+    # with all outputs used, the primitive is unchanged
+    dced2, used_ins2 = pe.dce_jaxpr(jaxpr, [True, True])
+    self.assertEqual(used_ins2, [True, True])
+    eqn2, = dced2.eqns
+    self.assertIs(eqn2.params['_prim'], jaxpr.eqns[0].params['_prim'])
+
 
 @jtu.with_config(jax_pprint_use_color=False)
 class JaxprTest(jtu.JaxTestCase):


### PR DESCRIPTION
Two main fixes:
1. allow unhashable static args
2. give RematTraced internal DCE

The latter is the first step in fixing a flax remat failure, which will need an update in flax too.