### PR TITLE
[export] Version 12 with jax_version and a flag to bypass the export deserialization check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 
 ## Unreleased
 
+* New features
+  * Added an error check for trying to deserialize JAX exports that are older
+    than the backwards compatibility window. Without this check the
+    deserialization of expired artifacts may succeed and then result in
+    obscure downstream errors.
+    Added a configuration flag `--jax_export_deserialize_expired_versions` to
+    temporarily bypass the error check.
+    See https://docs.jax.dev/en/latest/export/export.html#compatibility-guarantees.
+
 ## JAX 0.11.0 (July 16, 2026)
 
 * New features

--- a/docs/export/export.md
+++ b/docs/export/export.md
@@ -152,6 +152,18 @@ Unlike direct lowering, the {class}`jax.export` module uses the
 [portable-artifact feature of StableHLO](https://github.com/openxla/stablehlo/blob/main/docs/compatibility.md)
 to deal with the possible evolution of the StableHLO opset.
 
+If you try to deserialize a model that is older than the backwards-compatibility
+window you may get an error from the JAX deserializer, or may simply get
+obscure errors or crashes from JAX or XLA. If you get a deserialization
+error you can try to use the `--jax_export_deserialize_expired_versions=1`
+flag (or the `JAX_EXPORT_DESERIALIZE_EXPIRED_VERSIONS=1` environment variable).
+This may give you a small time window to continue your work while you work
+to refresh the old serialized artifact.
+
+**WARNING**: If you enable `--jax_export_deserialize_expired_versions=1` you
+accept that the deserialization behavior may change at any time. You take
+responsibility for refreshing the old serialized artifact ASAP.
+
 ### Compatibility guarantees for custom calls
 
 Furthermore, the raw StableHLO may contain custom calls referencing C++

--- a/docs/new_docs/501/export.md
+++ b/docs/new_docs/501/export.md
@@ -157,6 +157,18 @@ Unlike direct lowering, the {class}`jax.export` module uses the
 [portable-artifact feature of StableHLO](https://github.com/openxla/stablehlo/blob/main/docs/compatibility.md)
 to deal with the possible evolution of the StableHLO opset.
 
+If you try to deserialize a model that is older than the backwards-compatibility
+window you may get an error from the JAX deserializer, or may simply get
+obscure errors or crashes from JAX or XLA. If you get a deserialization
+error you can try to use the `--jax_export_deserialize_expired_versions=1`
+flag (or the `JAX_EXPORT_DESERIALIZE_EXPIRED_VERSIONS=1` environment variable).
+This may give you a small time window to continue your work while you work
+to refresh the old serialized artifact.
+
+**WARNING**: If you enable `--jax_export_deserialize_expired_versions=1` you
+accept that the deserialization behavior may change at any time. You take
+responsibility for refreshing the old serialized artifact ASAP.
+
 ### Compatibility guarantees for custom calls
 
 Furthermore, the raw StableHLO may contain custom calls referencing C++

--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -853,6 +853,7 @@ pytype_strict_library(
         ":typing",
         ":util",
         ":xla_bridge",
+        "//jax:version",
         "//jax/_src/lib",
     ] + py_deps("flatbuffers") + py_deps("numpy") + py_deps("opt_einsum"),
 )

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1142,6 +1142,19 @@ export_ignore_forward_compatibility = bool_state(
     )
 )
 
+export_deserialize_expired_versions = bool_state(
+    name='jax_export_deserialize_expired_versions',
+    default=bool_env('JAX_EXPORT_DESERIALIZE_EXPIRED_VERSIONS', False),
+    help=(
+        'Whether to allow deserialization of expired versions of JAX exports.'
+        'If you turn this on, you may see obscure downstream errors in JAX or '
+        'the compiler and runtime. Furthermore, you accept the fact that the '
+        'behavior of the deserialized model may change at any time. '
+        'Read carefully '
+        'https://docs.jax.dev/en/latest/export/export.html#compatibility-guarantees.'
+    )
+)
+
 jax_platforms = optional_string_state(
     name='jax_platforms',
     default=None,

--- a/jax/_src/export/serialization.fbs
+++ b/jax/_src/export/serialization.fbs
@@ -209,6 +209,8 @@ table Exported {
   // 1-based indices into unique_named_shardings, or 0 if unspecified (added 4/4/2026, v10)
   in_shardings_idxs: [uint32];
   out_shardings_idxs: [uint32];
+
+  jax_version: string;  // Added 7/29/2026
 }
 
 root_type Exported;

--- a/jax/_src/export/serialization.py
+++ b/jax/_src/export/serialization.py
@@ -23,6 +23,7 @@ import itertools
 from functools import partial
 import types
 from typing import cast, Any, TypeVar
+import warnings
 
 try:
   import flatbuffers
@@ -31,6 +32,7 @@ except ImportError as e:
       "Please install 'flatbuffers' in order to use Exported serialization"
       ) from e
 
+from jax._src import config
 from jax._src import core
 from jax._src import dtypes
 from jax._src import effects
@@ -43,6 +45,7 @@ from jax._src import named_sharding
 from jax._src import partition_spec
 from jax._src import tree_util
 
+from jax import version
 import numpy as np
 
 T = TypeVar("T")
@@ -74,7 +77,8 @@ SerT = TypeVar("SerT")
 # Version 10, April 4th, 2026, optimizes serialization of duplicate shardings,
 #   abstract meshes and avals.
 # Version 11, May 15th, 2026, add AbstractDevice.platform.
-_SERIALIZATION_VERSION = 11
+# Version 12, July 29th, 2026, add JAX version for the serializer.
+_SERIALIZATION_VERSION = 12
 
 
 @dataclasses.dataclass(slots=True)
@@ -224,6 +228,8 @@ def _serialize_exported(
     np.array([0 if s is None else 1 + uniques.named_shardings_map[s]
               for s in exp._out_named_shardings], dtype=np.uint32))
 
+  jax_version_idx = builder.CreateString(version.__version__)
+
   ser_flatbuf.ExportedStart(builder)
   # Started saving the actual serialization version on 7/27/2026.
   ser_flatbuf.ExportedAddSerializationVersion(builder, _SERIALIZATION_VERSION)
@@ -259,7 +265,7 @@ def _serialize_exported(
   ser_flatbuf.ExportedAddOutAvalsIdxs(builder, out_aval_idxs)
   ser_flatbuf.ExportedAddInShardingsIdxs(builder, in_shardings_idxs)
   ser_flatbuf.ExportedAddOutShardingsIdxs(builder, out_shardings_idxs)
-
+  ser_flatbuf.ExportedAddJaxVersion(builder, jax_version_idx)
   return ser_flatbuf.ExportedEnd(builder)
 
 
@@ -279,7 +285,9 @@ def _serialize_array(
 def _deserialize_exported(exp: ser_flatbuf.Exported) -> _export.Exported:
   # TODO(b/539419341): check the minimum serialization version.
   # We only started to save the actual serialization version on 7/27/2026, so
-  # we can add this check after 1/27/2027.
+  # we can add this check after 1/27/2027. We also started saving the
+  # JAX version that created the export on 7/28/2026 and we can use it
+  # after 1/28/2027 in error messages.
   scope = shape_poly.SymbolicScope(())  # TODO(necula): serialize the constraints
 
   unique_avals = [
@@ -304,12 +312,20 @@ def _deserialize_exported(exp: ser_flatbuf.Exported) -> _export.Exported:
 
   nr_devices = exp.NrDevices()
   if nr_devices == 0 and exp.NrDevicesShort() > 0:
-    raise ValueError(
+    msg = (
         "Exported being deserialized seems to be from before 11/25/2025 and "
         "cannot be deserialized anymore because it is older than the 6-month "
         "backward-compatibility window. The Exported has serialization version "
         f"{exp.SerializationVersion()}."
     )
+    if exp.JaxVersion() is not None:
+      msg += f" It was created with JAX version {exp.JaxVersion().decode('utf-8')}."
+    if not config.export_deserialize_expired_versions.value:
+      raise ValueError(msg)
+    # TODO(necula): remove this once we bump the minimum supported version.
+    warnings.warn(msg, DeprecationWarning)
+    nr_devices = exp.NrDevicesShort()
+
   def sharding_by_idx(idx):
     if idx == 0:
       return None

--- a/jax/_src/export/serialization_generated.py
+++ b/jax/_src/export/serialization_generated.py
@@ -21,7 +21,7 @@ import flatbuffers
 from flatbuffers.compat import import_numpy
 np = import_numpy()
 
-class PyTreeDefKind:
+class PyTreeDefKind(object):
     leaf = 0
     none = 1
     tuple = 2
@@ -30,12 +30,12 @@ class PyTreeDefKind:
     custom = 5
 
 
-class AbstractValueKind:
+class AbstractValueKind(object):
     shapedArray = 0
     abstractToken = 1
 
 
-class DType:
+class DType(object):
     bool = 0
     i8 = 1
     i16 = 2
@@ -68,33 +68,33 @@ class DType:
     key_unsafe_rbg = 29
 
 
-class MemorySpace:
+class MemorySpace(object):
     Missing = 0
     Device = 1
     Host = 2
     Any = 3
 
 
-class AxisType:
+class AxisType(object):
     Missing = 0
     Auto = 1
     Explicit = 2
     Manual = 3
 
 
-class ShardingKind:
+class ShardingKind(object):
     unspecified = 0
     hlo_sharding = 1
     named_sharding = 2
 
 
-class DisabledSafetyCheckKind:
+class DisabledSafetyCheckKind(object):
     platform = 0
     custom_call = 1
     shape_assertions = 2
 
 
-class PyTreeDef:
+class PyTreeDef(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -229,7 +229,7 @@ def PyTreeDefEnd(builder):
 
 
 
-class AbstractDevice:
+class AbstractDevice(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -285,7 +285,7 @@ def AbstractDeviceEnd(builder):
 
 
 
-class AbstractMesh:
+class AbstractMesh(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -416,7 +416,7 @@ def AbstractMeshEnd(builder):
 
 
 
-class PartitionSpecOneAxis:
+class PartitionSpecOneAxis(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -468,7 +468,7 @@ def PartitionSpecOneAxisEnd(builder):
 
 
 
-class PartitionSpec:
+class PartitionSpec(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -576,7 +576,7 @@ def PartitionSpecEnd(builder):
 
 
 
-class NamedSharding:
+class NamedSharding(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -648,7 +648,7 @@ def NamedShardingEnd(builder):
 
 
 
-class AbstractValue:
+class AbstractValue(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -730,7 +730,7 @@ def AbstractValueEnd(builder):
 
 
 
-class Sharding:
+class Sharding(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -812,7 +812,7 @@ def ShardingEnd(builder):
 
 
 
-class Effect:
+class Effect(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -848,7 +848,7 @@ def EffectEnd(builder):
 
 
 
-class DisabledSafetyCheck:
+class DisabledSafetyCheck(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -894,7 +894,7 @@ def DisabledSafetyCheckEnd(builder):
 
 
 
-class Exported:
+class Exported(object):
     __slots__ = ['_tab']
 
     @classmethod
@@ -1412,8 +1412,15 @@ class Exported:
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(54))
         return o == 0
 
+    # Exported
+    def JaxVersion(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(56))
+        if o != 0:
+            return self._tab.String(o + self._tab.Pos)
+        return None
+
 def ExportedStart(builder):
-    builder.StartObject(26)
+    builder.StartObject(27)
 
 def ExportedAddSerializationVersion(builder, serializationVersion):
     builder.PrependUint16Slot(0, serializationVersion, 0)
@@ -1543,6 +1550,9 @@ def ExportedAddOutShardingsIdxs(builder, outShardingsIdxs):
 
 def ExportedStartOutShardingsIdxsVector(builder, numElems):
     return builder.StartVector(4, numElems, 4)
+
+def ExportedAddJaxVersion(builder, jaxVersion):
+    builder.PrependUOffsetTRelativeSlot(26, flatbuffers.number_types.UOffsetTFlags.py_type(jaxVersion), 0)
 
 def ExportedEnd(builder):
     return builder.EndObject()


### PR DESCRIPTION
Started JAX serialization version 12, adding the version of JAX that was used to serialize an Exported.

Added a configuration flag `--jax_export_deserialize_expired_versions` to temporarily bypass the error check.
See https://docs.jax.dev/en/latest/export/export.html#compatibility-guarantees
