### PR TITLE
Fix dce_sink batching rule to emit no outputs

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -9337,7 +9337,13 @@ dce_sink_p.def_impl(lambda _, **__: [])
 dce_sink_p.multiple_results = True
 dce_sink_p.def_effectful_abstract_eval(lambda _, **__: ([], {no_dce_effect}))
 ad.deflinear(dce_sink_p, lambda _, **__: [])
-batching.primitive_batchers[dce_sink_p] = lambda x, bd, **_: (x, bd)
+def _dce_sink_batcher(batched_args, batch_dims, **params):
+  # dce_sink has no outputs as indicated in the abstract eval above.
+  # Re-bind it on the batched value to keep the no-DCE effect, and return no outputs.
+  (x,) = batched_args
+  dce_sink_p.bind(x, **params)
+  return [], []
+batching.primitive_batchers[dce_sink_p] = _dce_sink_batcher
 
 @partial(mlir.register_lowering, dce_sink_p)
 def _dce_sink_lowering(ctx, x, *, prevent_mlir_dce):

--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -1292,6 +1292,28 @@ class AssertPrimitiveTests(jtu.JaxTestCase):
     # TODO(lenamartens): re-enable assertions below.
     # self.assertIsNone(err.get())
 
+  @jtu.skip_on_devices("tpu")
+  def test_vmap_of_checkify_of_while(self):
+    # vmap-of-checkify-of-while is a supported composition: checkify injects a
+    # dce_sink into the while body and the outer vmap must batch it. Regression
+    # test for "foreach() argument 2 is longer than argument 1".
+    def fun(v):
+      def while_cond(s):
+        counter, value = s
+        return value < 6.
+      def while_body(s):
+        counter, value = s
+        checkify.check(value >= 0, "value needs to be positive!")
+        return counter + 1, value + 1.
+      counter, _ = jax.lax.while_loop(while_cond, while_body,
+                                      (jnp.int32(0), v))
+      return counter
+
+    checked_f = checkify.checkify(fun, errors=checkify.all_checks)
+    err, counts = jax.jit(jax.vmap(checked_f))(jnp.asarray([1., 2., 3.]))
+    self.assertIsNone(err.get())
+    self.assertArraysEqual(counts, jnp.asarray([5, 4, 3], dtype=jnp.int32))
+
   def test_assert_cond_no_data_dependence(self):
     def true_fun():
       return checkify.check(False, "hi!")

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -3895,6 +3895,24 @@ class LaxTest(jtu.JaxTestCase):
     hlo = jax.jit(g).lower(x).compile().as_text()
     self.assertNotIn("add", hlo)
 
+  def test_dce_sink_vmap_of_while(self):
+    # dce_sink is a 0-output, effect-only primitive; its batching rule must
+    # not emit an output. Regression test for a batching-arity bug that made
+    # vmap over a while_loop containing a dce_sink fail with
+    # "foreach() argument 2 is longer than argument 1".
+    def cond(c):
+      x, i = c
+      return i < 3
+    def body(c):
+      x, i = c
+      lax.dce_sink(x > 0)
+      return x + 1., i + 1
+    def f(x):
+      x, _ = lax.while_loop(cond, body, (x, jnp.int32(0)))
+      return x
+    out = jax.jit(jax.vmap(f))(jnp.arange(3.))
+    self.assertAllClose(out, jnp.arange(3.) + 3., check_dtypes=False)
+
   def testStagePreservesWeakType(self):
     aval = core.ShapedArray((), np.float32, weak_type=True)
     x = literals.TypedNdArray(np.array(1.0, dtype=np.float32), aval=aval)


### PR DESCRIPTION
### What
`lax.dce_sink` is a 0-output, effect-only primitive, but its batching rule returned one output. This fixes the rule so it emits no outputs while preserving the no-DCE effect.
### Why
Every rule for `dce_sink_p` reports 0 outputs except the batching rule, which echoed its operand back:
```python
dce_sink_p.def_effectful_abstract_eval(lambda _, **__: ([], {no_dce_effect}))  # 0 outputs
batching.primitive_batchers[dce_sink_p] = lambda x, bd, **_: (x, bd)           # 1 output
```
That's harmless at the top level (the op is never re-bound into the jaxpr), but when a `dce_sink` sits inside a `while_loop`/`cond` body, batching that primitive replays the body sub-jaxpr through `core.eval_jaxpr`, where the equation's 0 `outvars` clash with the rule's 1 output and raise `foreach() argument 2 is longer than argument 1`.
This is reachable through the public, checkify-recommended `vmap`-of-`checkify`-of-`while` composition, since `checkify` injects a `dce_sink(cond(...))` into the while body (`checkify_while_body_jaxpr`). Minimal repro:
```python
import jax, jax.numpy as jnp
from jax.experimental import checkify
def f(x):
    def cond(c):
        i, acc = c
        return acc < 10.0
    def body(c):
        i, acc = c
        checkify.check(acc >= 0.0, "acc must stay non-negative")
        return i + 1, acc + x
    _, acc = jax.lax.while_loop(cond, body, (jnp.int32(0), jnp.float32(0.0)))
    return acc
checked = checkify.checkify(f, errors=checkify.all_checks)
errs, out = jax.jit(jax.vmap(checked))(jnp.array([1.0, 2.0, 3.0]))  # ValueError before this PR
```
### How
Re-bind `dce_sink` on the batched value (keeping the `no_dce_effect`) and return no outputs. Adds a targeted regression test in `tests/lax_test.py` and a `checkify` integration test in `tests/checkify_test.py`. The `prevent_mlir_dce=True` FFI lowering path is unaffected (the batcher forwards `**params`).

Fixes #39501