### PR TITLE
Better error message for non-static slice indices

### DIFF
--- a/jax/_src/numpy/indexing.py
+++ b/jax/_src/numpy/indexing.py
@@ -222,10 +222,19 @@ class NDIndexer:
     for position, idx in enumerate(self.indices):
       if idx.typ == IndexType.SLICE:
         assert isinstance(idx.index, slice)
+        elts = [idx.index.start, idx.index.stop, idx.index.step]
         if not all(_is_slice_element_none_or_constant_or_symbolic(val)
-                   for val in [idx.index.start, idx.index.stop, idx.index.step]):
-          raise IndexError("Slice entries must be static integers."
-                          f" Got {idx.index} at position {position}")
+                   for val in elts):
+          msg = ("Array slice indices must have static start/stop/step to be used "
+                 f"with NumPy indexing syntax. Got {idx.index} at position "
+                 f"{position}. To index an array at a dynamic position with a "
+                 "static slice size, use x[jax.ds(start, size)] or "
+                 "lax.dynamic_slice/dynamic_update_slice instead (JAX does not "
+                 "support dynamically sized arrays within traced functions).")
+          tracer = next((val for val in elts if isinstance(val, core.Tracer)), None)
+          if tracer is not None:
+            msg += tracer._origin_msg()
+          raise IndexError(msg)
 
   @staticmethod
   def is_sharded(arr) -> bool:

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -1135,6 +1135,37 @@ class IndexingTest(jtu.JaxTestCase):
                                 "index .* out of bounds for axis .* with size 0"):
       jax.jit(lambda i: x[0, i])(0)  # JAX indexing under jit
 
+  def testNonStaticSliceErrorMessage(self):
+    # https://github.com/jax-ml/jax/issues/7222
+    x = jnp.arange(5)
+
+    # The error states the constraint, suggests dynamic-slicing remedies, and
+    # reports the transform and argument that produced the traced index.
+    with self.assertRaises(IndexError) as cm:
+      jax.jit(lambda x, i: x[i:i + 2])(x, 2)
+    self.assertIn("Array slice indices must have static start/stop/step",
+                  str(cm.exception))
+    self.assertIn("jax.ds(start, size)", str(cm.exception))
+    self.assertIn("lax.dynamic_slice", str(cm.exception))
+    self.assertRegex(str(cm.exception), r"while tracing the function .* for jit")
+    self.assertIn("the argument i", str(cm.exception))
+
+    # The transform name reflects the actual tracing context.
+    with self.assertRaises(IndexError) as cm:
+      lax.fori_loop(0, 3, lambda i, acc: acc + x[i:i + 2].sum(), 0)
+    self.assertRegex(str(cm.exception),
+                     r"while tracing the function .* for fori_loop")
+
+    # vmap tracers report their creation site.
+    with self.assertRaises(IndexError) as cm:
+      jax.vmap(lambda i: x[i:i + 1])(jnp.arange(2))
+    self.assertIn("BatchTracer", str(cm.exception))
+
+    # The update path shares the same error.
+    with self.assertRaises(IndexError) as cm:
+      jax.jit(lambda x, i: x.at[i:i + 2].set(0))(x, 2)
+    self.assertIn("jax.ds(start, size)", str(cm.exception))
+
   def testBooleanIndexingWithEmptyResult(self):
     # based on a TensorFlow Probability test that started failing after #1622
     x = jnp.array([-1])


### PR DESCRIPTION
When a NumPy-style slice contains a traced value (e.g. x[i:i+2] with i traced under jit), the IndexError now suggests x[jax.ds(start, size)] and lax.dynamic_slice/dynamic_update_slice, and appends the tracer's origin (the transform and user source line that produced the abstract value), matching what ConcretizationTypeError reports.

Fixes #7222

