### PR TITLE
[remat3] add jax_remat_barrier_no_cotangents upgrade flag

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -272,9 +272,8 @@ def checkpoint(fun: Callable, *, prevent_cse: bool | Sequence[bool] = True,
       with tuples matched against argument containers by their number of
       children) — selecting which arguments' saved values to pin. Computed
       (policy-saved) residuals are always pinned when any prevention is on.
-      Under ``jax_remat3``, cotangents are pinned only by
-      ``prevent_cse=True`` exactly, so an all-True tuple pins everything
-      except the cotangents.
+      Under ``jax_remat3``, cotangents are likewise pinned unless the
+      ``jax_remat_barrier_no_cotangents`` upgrade flag is enabled.
     static_argnums: Optional, int or sequence of ints, a keyword-only argument
       indicating which argument values on which to specialize for tracing and
       caching purposes. Specifying arguments as static can avoid
@@ -1119,18 +1118,19 @@ class RematTraced(VJPHiPrimitive):
   def vjp_bwd(self, primals_rem, outgrad, *arg_accums):
     primals, prevent_cse, rem = primals_rem
     prevent_cse = prevent_cse.val
-    if prevent_cse is True:
+    if prevent_cse is not False:
+      which = ([True] * len(primals) if prevent_cse is True else
+               list(prevent_cse))
+      unpinned, pinned = partition_list(which, primals)
       res, = rem.args
-      primals, res, outgrad = lax_internal.optimization_barrier(
-          (primals, res, outgrad))
+      if config.remat_barrier_no_cotangents.value:
+        if pinned or res:
+          pinned, res = lax_internal.optimization_barrier((pinned, res))
+      else:
+        pinned, res, outgrad = lax_internal.optimization_barrier(
+            (pinned, res, outgrad))
       rem = Partial(rem.func, res)
-    elif prevent_cse is not False:
-      res, = rem.args
-      unpinned, pinned = partition_list(prevent_cse, primals)
-      if pinned or res:
-        pinned, res = lax_internal.optimization_barrier((pinned, res))
-        rem = Partial(rem.func, res)
-      primals = merge_lists(prevent_cse, unpinned, pinned)
+      primals = merge_lists(which, unpinned, pinned)
     bwd = rem(*primals)
     bwd.with_refs(*arg_accums)(outgrad)
 

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1344,6 +1344,16 @@ custom_jvp3 = bool_state(
     include_in_trace_context=True,
 )
 
+remat_barrier_no_cotangents = bool_state(
+    name='jax_remat_barrier_no_cotangents',
+    default=False,
+    upgrade=True,
+    help=('If True, embrace the future of remat CSE-prevention barriers, '
+          'which do not pin cotangents.'),
+    include_in_jit_key=True,
+    include_in_trace_context=True,
+)
+
 
 distributed_debug = bool_state(
     name='jax_distributed_debug',

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -7764,7 +7764,7 @@ class RematTest(jtu.JaxTestCase):
     np.testing.assert_allclose(jax.ref.get(grad_ref), jax.grad(f)(param))
 
 
-@jtu.with_config(jax_remat3=True)
+@jtu.with_config(jax_remat3=True, jax_remat_barrier_no_cotangents=False)
 class Remat3Test(RematTest):
   # The original versions of these tests used a "save cosine" policy that can't
   # be expressed the same way with remat3. Instead, we use custom_remat.
@@ -8117,30 +8117,7 @@ class Remat3Test(RematTest):
     self.assertAllClose(rem(jnp.float32(3.), jnp.float32(4.)), (3., 16.),
                         check_dtypes=False)
 
-  # Under remat3, a prevent_cse tuple pins only the selected saved primals:
-  # unlike remat2, cotangents are pinned only by scalar prevent_cse=True.
-  def test_remat_partial_cse_prevention(self):
-    @partial(jax.remat, prevent_cse=(False, True))
-    def layer(W, x):
-      res = x @ W
-      res += jnp.array([1.0, 2.0, 3.0])  # ensure the jaxpr also contains a const
-      return res
-
-    def net(Ws, x):
-      for W in Ws:
-        x = layer(W, x)
-      return x
-
-    def loss(Ws, x):
-      return jnp.sum(net(Ws, x)**2)
-
-    Ws = [jnp.ones((3, 3)) for _ in range(2)]
-    x = jnp.ones(3)
-    txt = jax.jit(jax.grad(loss, (0, 1))).lower(Ws, x).as_text()
-    self.assertRegex(txt, r'optimization_barrier %[a-z0-9]+ :')
-    self.assertNotRegex(txt, r'optimization_barrier %[a-z0-9]+, %')
-
-  def test_remat_partial_cse_prevention_pytree(self):
+  def test_remat_partial_cse_prevention_pytree_prefix_forms(self):
     # remat3 accepts a pytree prefix or an isomorphic tuple-tree prefix
     # (tuples matched against containers by their number of children)
     for prevent_cse in [({'W': False, 'x': True},), ((False, True),)]:
@@ -8159,8 +8136,7 @@ class Remat3Test(RematTest):
       Ws = [jnp.ones((3, 3)) for _ in range(2)]
       x = jnp.ones(3)
       txt = jax.jit(jax.grad(loss, (0, 1))).lower(Ws, x).as_text()
-      self.assertRegex(txt, r'optimization_barrier %[a-z0-9]+ :')
-      self.assertNotRegex(txt, r'optimization_barrier %[a-z0-9]+, %')
+      self.assertRegex(txt, r'optimization_barrier %[a-z0-9]+, %[a-z0-9]+ :')
 
   def test_remat_computed_residuals_cse_prevention(self):
     # computed (policy-saved) residuals are always barriered when any cse
@@ -8174,23 +8150,29 @@ class Remat3Test(RematTest):
       return jnp.tanh(x @ W)
 
     W, x = jnp.ones((3, 3)), jnp.ones(3)
-    txt = jax.jit(jax.grad(lambda W, x: layer(W, x).sum(), (0, 1))
-                  ).lower(W, x).as_text()
-    self.assertRegex(txt, r'optimization_barrier %[a-z0-9]+ :')
+    f = jax.grad(lambda W, x: layer(W, x).sum(), (0, 1))
+    txt = jax.jit(f).lower(W, x).as_text()
+    self.assertRegex(txt, r'optimization_barrier %[a-z0-9]+, %[a-z0-9]+ :')
+    with config.remat_barrier_no_cotangents(True):
+      txt = jax.jit(f).lower(W, x).as_text()
+      self.assertRegex(txt, r'optimization_barrier %[a-z0-9]+ :')
+      self.assertNotRegex(txt, r'optimization_barrier %[a-z0-9]+, %')
 
-  def test_remat_all_true_cse_prevention_excludes_cotangents(self):
-    @partial(jax.remat, prevent_cse=(True, True))
-    def layer(W, x):
-      return x @ W
-
+  def test_remat_cse_prevention_no_cotangents_flag(self):
+    # under the upgrade flag, barriers never pin cotangents, and scalar True
+    # is equivalent to an all-True tuple
     def loss(W, x):
       return jnp.sum(layer(W, x)**2)
 
     W, x = jnp.ones((3, 3)), jnp.ones(3)
-    txt = jax.jit(jax.grad(loss, (0, 1))).lower(W, x).as_text()
-    # both saved primals pinned together, but not the cotangent
-    self.assertRegex(txt, r'optimization_barrier %[a-z0-9]+, %[a-z0-9]+ :')
-    self.assertNotRegex(txt, r'optimization_barrier %[a-z0-9]+, %[a-z0-9]+, %')
+    with config.remat_barrier_no_cotangents(True):
+      for prevent_cse in [True, (True, True)]:
+        layer = jax.remat(lambda W, x: x @ W, prevent_cse=prevent_cse)
+        txt = jax.jit(jax.grad(loss, (0, 1))).lower(W, x).as_text()
+        # both saved primals pinned together, but not the cotangent
+        self.assertRegex(txt, r'optimization_barrier %[a-z0-9]+, %[a-z0-9]+ :')
+        self.assertNotRegex(txt,
+                            r'optimization_barrier %[a-z0-9]+, %[a-z0-9]+, %')
 
   def test_remat_unhashable_static_argnums(self):
     # unhashable static values are closed over rather than hashed


### PR DESCRIPTION
Both remat3 and remat2 currently include `outgrad` in the CSE-foiling `optimization_barrier`, for no good reason! We don't want to include `outgrad` in the optimization barrier, but some downstream goldens are sensitive to that change. So, let's make an upgrade flag, and try to flip its default!

(Now prevent_cse=True is the same as prevent_cse=(True, ..., True).)