### PR TITLE
TCGen05Test.test_mma_block_scaled_sparse_f4: add skip for Rubin

### DIFF
--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -3285,6 +3285,8 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
   ):
     if scale_jax_dtype == jnp.float8_e4m3fn and base_block_size != 16:
       self.skipTest("e4m3fn scale only supports block size 16.")
+    if not any(map(jtu.is_cuda_compute_capability_equal, ("10.0", "10.1", "10.3", "11.0"))):
+      self.skipTest("nvbug/6412668")
     out_jax_dtype = jnp.float32
     sparse_meta_dtype = jnp.uint2
     block_size = base_block_size * 2


### PR DESCRIPTION
In upcoming NVPTX 9.4 [1], not all `tcgen05.mma.sp` instructions are supported on PTX target `sm_107` (Rubin)

[1] [Parallel Thread Execution ISA Version 9.4 - 13. Release Notes](https://docs.nvidia.com/cuda/developer-preview/13.4/parallel-thread-execution/index.html#release-notes) (Table 72) 