### PR TITLE
[ROCm] Build ROCm artifacts on CPU runners

### DIFF
--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -10,9 +10,9 @@ on:
       runner:
         description: "Which runner should the workflow run on?"
         type: choice
-        default: "amd-do-linux.jax.gpu.gfx950.1"
+        default: "amd-do-linux.jax.cpu"
         options:
-        - "amd-do-linux.jax.gpu.gfx950.1"
+        - "amd-do-linux.jax.cpu"
       artifact:
         description: "Which ROCm artifact to build?"
         type: choice
@@ -63,7 +63,7 @@ on:
       runner:
         description: "Which runner should the workflow run on?"
         type: string
-        default: "amd-do-linux.jax.gpu.gfx950.1"
+        default: "amd-do-linux.jax.cpu"
       artifact:
         description: "Which ROCm artifact to build?"
         type: string
@@ -127,10 +127,7 @@ jobs:
       volumes:
         - /data:/data
       options: >-
-        --device=/dev/kfd
-        --device=/dev/dri
         --security-opt seccomp=unconfined
-        --group-add video
         --shm-size 64G
 
     env:
@@ -148,18 +145,6 @@ jobs:
         run: |
           curl -fSsL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
           chmod +x /usr/local/bin/bazel
-      - name: ROCm Info
-        run: |
-          # TheRock (pip) ROCm images are /opt/rocm-less; rocminfo lives in the
-          # SDK bin dir, so put it on PATH via rocm-sdk. apt-ROCm images lack
-          # rocm-sdk and already have rocminfo on PATH.
-          if command -v rocm-sdk >/dev/null 2>&1; then
-            sdk_bin="$(rocm-sdk path --bin)"
-            if [[ -n "$sdk_bin" ]]; then
-              export PATH="$sdk_bin:$PATH"
-            fi
-          fi
-          rocminfo
       # Halt for testing
       - name: Wait For Connection
         uses: google-ml-infra/actions/ci_connection@7f5ca0c263a81ed09ea276524c1b9192f1304e3c

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -500,7 +500,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          runner: ["amd-do-linux.jax.gpu.gfx950.1"]
+          runner: ["amd-do-linux.jax.cpu"]
           artifact: ["jax-rocm-plugin", "jax-rocm-pjrt"]
           python: ["3.12", "3.13", "3.14"]
           rocm: [

--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -177,7 +177,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          runner: ["amd-do-linux.jax.gpu.gfx950.1"]
+          runner: ["amd-do-linux.jax.cpu"]
           artifact: ["jax-rocm-plugin", "jax-rocm-pjrt"]
           python: ["3.12", "3.13", "3.14"]
           rocm: [


### PR DESCRIPTION
This PR builds the `jax-rocm-plugin` and `jax-rocm-pjrt` artifacts on CPU runners instead of GPU runners.

The build only requires the ROCm SDK provided by the manylinux container image and compiles HIP device code without executing GPU kernels. Since no GPU is required, this change frees GPU runners for ROCm test jobs (`pytest_rocm` and `bazel_rocm`) that require GPU hardware.