### PR TITLE
[pallas:mosaic] Reject array ref indices instead of emitting bad IR

### DIFF
--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -1954,7 +1954,11 @@ def _index_to_start_size_stride(
     stride = 1
     squeeze = True
   else:
-    if np.shape(idx):
+    # ``np.shape`` is always () for an already lowered index, so the MLIR type
+    # has to be checked separately.
+    if np.shape(idx) or (
+        isinstance(idx, ir.Value) and isinstance(idx.type, ir.VectorType)
+    ):
       raise ValueError(f"Can only use ()-shaped and slice indexing: {idx}")
     start = _maybe_cast_to_index(cast_to_index, idx)
     size = 1

--- a/tests/pallas/tpu_sparsecore_pallas_test.py
+++ b/tests/pallas/tpu_sparsecore_pallas_test.py
@@ -3177,6 +3177,33 @@ class PallasTpuSparseCoreLoweringErrorTest(jtu.JaxTestCase):
       ):
         run_mpmd.lower(x).compile()
 
+  def test_array_indexing_of_ref(self):
+    abstract_mesh = jax.sharding.AbstractMesh(
+        (), (), abstract_device=jax.sharding.AbstractDevice("TPU v6e", 1, "tpu")
+    )
+    with jax.sharding.use_abstract_mesh(abstract_mesh):
+      mesh = plsc.VectorSubcoreMesh(
+          core_axis_name="core", subcore_axis_name="subcore", num_cores=1
+      )
+
+      @pl.kernel(
+          out_type=jax.ShapeDtypeStruct((8,), jnp.int32),
+          mesh=mesh,
+          scratch_types=dict(
+              x_ref=pltpu.VMEM((8, 128), jnp.int32),
+              i_ref=pltpu.VMEM((8,), jnp.int32),
+              o_ref=pltpu.VMEM((8,), jnp.int32),
+          ),
+      )
+      def kernel(o_hbm_ref, *, x_ref, i_ref, o_ref):
+        o_ref[...] = x_ref[i_ref[...], i_ref[...]]
+        pltpu.sync_copy(o_ref, o_hbm_ref)
+
+      with self.assertRaisesRegex(
+          ValueError, r"Can only use \(\)-shaped and slice indexing"
+      ):
+        jax.jit(kernel).trace().lower(lowering_platforms=("tpu",))
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Fixes #39518 (partially, see below).

Indexing a VMEM ref with an array inside a SparseCore kernel, e.g.
`blocks_ref[rows, local_offsets]`, crashed with "Pallas encountered an internal
verification error. Please file a bug", from
`'arith.index_cast' op requires the same shape for all operands and results`.

Root cause: `_index_to_start_size_stride` rejects array-valued indices with
`if np.shape(idx)`, but at that point `idx` is an `ir.Value` and `np.shape` of an
`ir.Value` is always `()`, so the guard never fired. The TC path happens to
reject array indices earlier in `_canonicalize_transforms_to_indexer`; the SC
get/swap rules do not, so the index went straight into `arith.index_cast` and
produced `index_cast : (vector<8xi32>) -> index`. The fix checks the MLIR type as
well, so the existing `ValueError` fires and the user gets a normal compilation
diagnostic. Both the load and the store path are covered by that one check.

What this does not do: it does not add block-local offset selection. The
`jnp.take_along_axis` formulation in the issue still lowers to
`tpu.dynamic_gather` over a source wider than one vreg, which Mosaic's
apply-vector-layout rejects. That is in XLA, not here, so #39518 should stay open
for it. For what it is worth, `plsc.load_gather(blocks_ref, [rows, offsets])`
lowers to `tpu.vector_load_idx`, the SparseCore per-lane VMEM load, and looks
like the in-pipeline pattern the reporter wants, but I have not run it.

Verified: no TPU was available, so the repro and the new test lower a SparseCore
kernel ahead of time against an abstract TPU v6e device
(`jax.sharding.AbstractDevice("TPU v6e", 1, "tpu")` plus
`use_abstract_mesh`, then `.trace().lower(lowering_platforms=("tpu",))`). The new
test in `PallasTpuSparseCoreLoweringErrorTest` runs on CPU, fails before this
change with the verification error and passes after. Also ran on CPU:
`tpu_sparsecore_pallas_test.py` (535 of 538 skipped, no TPU),
`tpu_pallas_interpret_test.py` (94 pass), `indexing_test.py`,
`pallas_error_handling_test.py`, and ruff on both changed files. Nothing was
executed on TPU hardware, so I have not confirmed the change is neutral on a real
SparseCore run beyond the fact that the rejected program previously produced
invalid IR.

Thanks to @samixyzdev for the detailed report.