### PR TITLE
[remat3] use eval_jaxpr_p in RematTraced.expand to reduce trace times

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -41,6 +41,7 @@ from jax._src.interpreters.remat import remat_transform
 from jax._src.hijax import VJPHiPrimitive, call_hi_primitive_p, Static
 from jax._src.lax import lax as lax_internal
 from jax._src.lax import convolution as lax_convolution
+from jax._src.lax.eval_jaxpr import eval_jaxpr_p
 from jax._src.lib.mlir.dialects import hlo
 from jax._src.state import discharge
 from jax._src.state.types import AbstractRef
@@ -1093,8 +1094,12 @@ class RematTraced(VJPHiPrimitive):
 
   @source_info_util.extend_name_stack('checkpoint')
   def expand(self, *args):
-    # TODO eval_jaxpr_p
-    return core.jaxpr_as_fun(self.jaxpr)(*args)
+    if not self.jaxpr.is_high:
+      return eval_jaxpr_p.bind(*args, jaxpr=self.jaxpr)
+    if (any(a.has_qdd for a in self.jaxpr.in_aval_qdds) or
+        any(a.has_qdd for a in self.jaxpr.final_aval_qdds)):
+      return core.jaxpr_as_fun(self.jaxpr)(*args)
+    return custom_derivatives._lower_and_eval('checkpoint', self.jaxpr, args)
 
   def vjp_fwd(self, _nzs_in, *primals):
     # TODO eval_jaxpr_p trace time

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -8264,6 +8264,38 @@ class Remat3Test(RematTest):
     eqn2, = dced2.eqns
     self.assertIs(eqn2.params['_prim'], jaxpr.eqns[0].params['_prim'])
 
+  def test_remat_expand_stages_call_without_inlining(self):
+    # expand binds eval_jaxpr_p, staging a single closed_call eqn rather than
+    # retracing the body, so lowering work doesn't scale with the jaxpr size
+    @jax.remat
+    def f(x):
+      for _ in range(10):
+        x = jnp.sin(x)
+      return x
+
+    hi = jax.jit(f).trace(1.).jaxpr
+    lo = pe.lower_jaxpr2(hi.jaxpr)
+    eqn, = lo.eqns
+    self.assertIs(eqn.primitive, core.closed_call_p)
+    self.assertLen(eqn.params['call_jaxpr'].eqns, 10)
+
+  def test_remat_expand_stages_call_without_inlining_high_jaxpr(self):
+    # a high (here nested-remat) body is lowered and staged as a single
+    # closed_call rather than inlined
+    inner = jax.remat(lambda x: jnp.cos(jnp.cos(x)))
+
+    @jax.remat
+    def f(x):
+      for _ in range(10):
+        x = jnp.sin(x)
+      return inner(x)
+
+    hi = jax.jit(f).trace(1.).jaxpr
+    lo = pe.lower_jaxpr2(hi.jaxpr)
+    eqn, = lo.eqns
+    self.assertIs(eqn.primitive, core.closed_call_p)
+    self.assertLen(eqn.params['call_jaxpr'].eqns, 11)  # 10 sins + inner call
+
 
 @jtu.with_config(jax_pprint_use_color=False)
 class JaxprTest(jtu.JaxTestCase):


### PR DESCRIPTION
```python
# Trace-time benchmark for RematTraced.expand via eval_jaxpr_p.
# Run with: JAX_REMAT3=1 python bench_remat3_expand.py
import time
import jax
import jax.numpy as jnp
from jax._src import core
from jax._src import ad_checkpoint
from jax._src.interpreters import partial_eval as pe

assert jax.config.jax_remat3

new_expand = ad_checkpoint.RematTraced.expand

def old_expand(self, *args):  # the previous implementation, for comparison
  return core.jaxpr_as_fun(self.jaxpr)(*args)

def make_block(n, nested):
  inner = jax.checkpoint(lambda x: jnp.cos(jnp.cos(x)))
  def f(x):
    for _ in range(n):
      x = jnp.sin(x)
    return inner(x) if nested else x
  return jax.checkpoint(f)

def measure_lower_pass(n, calls=1, nested=False, k=5):
  # time the hi->lo lowering pass on a fresh traced jaxpr each iteration
  ts = []
  for _ in range(k):
    block = make_block(n, nested)
    def g(x):
      for _ in range(calls):
        x = block(x)
      return x
    hi = jax.jit(g).trace(1.0).jaxpr
    t0 = time.perf_counter()
    pe.lower_jaxpr2(hi.jaxpr)
    ts.append(time.perf_counter() - t0)
  return min(ts)

def measure_full_lower(n, calls, k=3):
  # time full jit lowering, same remat block called `calls` times
  ts = []
  for _ in range(k):
    jax.clear_caches()
    block = make_block(n, nested=False)
    def g(x):
      for _ in range(calls):
        x = block(x)
      return x
    t0 = time.perf_counter()
    jax.jit(g).lower(1.0)
    ts.append(time.perf_counter() - t0)
  return min(ts)

for name, expand in [('before', old_expand), ('after', new_expand)]:
  ad_checkpoint.RematTraced.expand = expand
  print(f'--- {name} ---')
  for n in [100, 400, 1600]:
    t = measure_lower_pass(n)
    print(f'  hi->lo pass, lo body, {n:5d} eqns:        {t*1e3:8.2f} ms')
  for n in [400, 1600]:
    t = measure_lower_pass(n, nested=True)
    print(f'  hi->lo pass, hi body (nested), {n:5d} eqns: {t*1e3:6.2f} ms')
  t = measure_lower_pass(400, calls=8, nested=True)
  print(f'  hi->lo pass, hi body, 400 eqns x 8 calls: {t*1e3:8.2f} ms')
  for calls in [1, 8]:
    t = measure_full_lower(400, calls)
    print(f'  full jit lower, 400-eqn block x {calls} call(s): {t*1e3:6.2f} ms')
```

On my laptop:

```
--- before ---
  hi->lo pass, lo body,   100 eqns:            0.58 ms
  hi->lo pass, lo body,   400 eqns:            2.22 ms
  hi->lo pass, lo body,  1600 eqns:            8.87 ms
  hi->lo pass, hi body (nested),   400 eqns:   2.29 ms
  hi->lo pass, hi body (nested),  1600 eqns:   9.47 ms
  hi->lo pass, hi body, 400 eqns x 8 calls:    18.87 ms
  full jit lower, 400-eqn block x 1 call(s):   8.33 ms
  full jit lower, 400-eqn block x 8 call(s):  37.50 ms
--- after ---
  hi->lo pass, lo body,   100 eqns:            0.04 ms
  hi->lo pass, lo body,   400 eqns:            0.04 ms
  hi->lo pass, lo body,  1600 eqns:            0.05 ms
  hi->lo pass, hi body (nested),   400 eqns:   0.27 ms
  hi->lo pass, hi body (nested),  1600 eqns:   0.83 ms
  hi->lo pass, hi body, 400 eqns x 8 calls:     0.36 ms
  full jit lower, 400-eqn block x 1 call(s):   5.70 ms
  full jit lower, 400-eqn block x 8 call(s):   6.06 ms
```

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->