### PR TITLE
[custom_vjp3] use eval_jaxpr_p to reduce trace times

### DIFF
--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -1332,6 +1332,7 @@ pytype_strict_library(
         ":layout",
         ":mesh",
         ":mlir",
+        ":partial_eval",
         ":sharding",
         ":sharding_impls",
         ":source_info_util",

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -41,7 +41,6 @@ from jax._src.interpreters.remat import remat_transform
 from jax._src.hijax import VJPHiPrimitive, call_hi_primitive_p, Static
 from jax._src.lax import lax as lax_internal
 from jax._src.lax import convolution as lax_convolution
-from jax._src.lax.eval_jaxpr import eval_jaxpr_p
 from jax._src.lib.mlir.dialects import hlo
 from jax._src.state import discharge
 from jax._src.state.types import AbstractRef
@@ -1094,12 +1093,7 @@ class RematTraced(VJPHiPrimitive):
 
   @source_info_util.extend_name_stack('checkpoint')
   def expand(self, *args):
-    if not self.jaxpr.is_high:
-      return eval_jaxpr_p.bind(*args, jaxpr=self.jaxpr)
-    if (any(a.has_qdd for a in self.jaxpr.in_aval_qdds) or
-        any(a.has_qdd for a in self.jaxpr.final_aval_qdds)):
-      return core.jaxpr_as_fun(self.jaxpr)(*args)
-    return custom_derivatives._lower_and_eval('checkpoint', self.jaxpr, args)
+    return pe._call_jaxpr('checkpoint', self.jaxpr, args)
 
   def vjp_fwd(self, _nzs_in, *primals):
     # TODO eval_jaxpr_p trace time

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -18,7 +18,6 @@ from collections.abc import Callable, Sequence
 import dataclasses
 from functools import update_wrapper, reduce, partial, wraps
 from typing import Any, Generic, TypeVar
-import itertools as it
 
 from jax._src import config
 from jax._src import core
@@ -55,29 +54,6 @@ zip = safe_zip
 
 
 ### util
-
-def _lower_and_eval(
-    name: str, jaxpr: core.Jaxpr, args: Sequence[Any]
-) -> list[Any]:
-  from jax._src.lax.eval_jaxpr import eval_jaxpr_p  # pyrefly: ignore[missing-import]
-  if any(aval.has_qdd for aval in jaxpr.in_aval_qdds):
-    raise NotImplementedError(f"{name!r} does not support qdd on inputs")
-  if any(aval.has_qdd for aval in jaxpr.final_aval_qdds):
-    raise NotImplementedError(f"{name!r} does not support qdd on outputs")
-
-  lo_jaxpr = pe.lower_jaxpr2(jaxpr)
-  lo_args = [
-      lo_val for aval, x in zip(jaxpr.in_avals, args)
-      for lo_val in aval.lower_val(x)
-  ]
-  lo_outs = eval_jaxpr_p.bind(*lo_args, jaxpr=lo_jaxpr)
-  lo_outs_ = iter(lo_outs)
-  hi_outs = [
-      t.raise_val(*it.islice(lo_outs_, len(t.lo_ty())))
-      for t in jaxpr.out_avals
-  ]
-  assert next(lo_outs_, None) is None
-  return hi_outs
 
 def _sum_tangents(_, x, *xs):
   return reduce(ad.add_tangents, xs, x)
@@ -419,7 +395,7 @@ class CustomJVPCallPrimitive(core.Primitive):
     return call_jaxpr.is_high
 
   def to_lojax(self, *hi_args, call_jaxpr: core.Jaxpr, **params):
-    return _lower_and_eval("custom_jvp_call", call_jaxpr, hi_args)
+    return pe._lower_and_eval("custom_jvp_call", call_jaxpr, hi_args)
 
   def get_bind_params(self, params):
     new_params = dict(params)
@@ -1027,7 +1003,7 @@ class CustomVJPCallPrimitive(core.Primitive):
     return call_jaxpr.is_high
 
   def to_lojax(self, *hi_args, call_jaxpr: core.Jaxpr, **params):
-    return _lower_and_eval("custom_vjp_call", call_jaxpr, hi_args)
+    return pe._lower_and_eval("custom_vjp_call", call_jaxpr, hi_args)
 
   def get_bind_params(self, params):
     new_params = dict(params)
@@ -1857,7 +1833,7 @@ def _remat_opt_dce(used_outs: list[bool], eqn: core.JaxprEqn):
     return used_ins, new_eqn
 
 def _remat_opt_to_lojax(*hi_args, fwd_jaxpr: core.Jaxpr, num_consts, **params):
-  return _lower_and_eval("remat_opt", fwd_jaxpr, hi_args)
+  return pe._lower_and_eval("remat_opt", fwd_jaxpr, hi_args)
 
 remat_opt_p = core.Primitive("remat_opt")
 remat_opt_p.multiple_results = True

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -281,7 +281,6 @@ class BatchTrace(Trace):
 
   def process_call(self, call_primitive, f, tracers, params, /):
     assert call_primitive.multiple_results
-    params = dict(params, name=params.get('name', f.__name__))
     vals, dims = unzip2(map(self.to_batch_info, tracers))
     f_, dims_out = batch_subtrace(f, self.tag, self.axis_data, tuple(dims))
 

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -2589,9 +2589,61 @@ def raise_lo_outs(hi_avals, lo_outs):
   return hi_outs
 
 
-def _closed_call_to_lojax(*hi_args, call_jaxpr: Jaxpr, **_):
-  from jax._src.custom_derivatives import _lower_and_eval  # pyrefly: ignore[missing-import]
+# eval_jaxpr_p is a call-like primitive parameterized by a jaxpr rather than a
+# Python callable: applying it evaluates the jaxpr, and staging it out is O(1),
+# emitting a single closed_call eqn rather than retracing the jaxpr. Its
+# transformation rules live in lax/eval_jaxpr.py; the primitive is defined here
+# so that jaxpr-level utilities below can use it without upward imports.
+eval_jaxpr_p = core.Primitive('eval_jaxpr')
+eval_jaxpr_p.multiple_results = True
 
+def _eval_jaxpr_staging(trace: DynamicJaxprTrace, source_info, *tracers,
+                        jaxpr: Jaxpr):
+  params = dict(call_jaxpr=jaxpr)
+  return trace.default_process_primitive(core.closed_call_p, tracers, params,
+                                         source_info=source_info)
+custom_staging_rules[eval_jaxpr_p] = _eval_jaxpr_staging
+
+@eval_jaxpr_p.def_effectful_abstract_eval  # abstract eval only used for jax2tf
+def _eval_jaxpr_abstract_eval(*_, jaxpr):
+  return jaxpr.out_avals, core.positional_effects(jaxpr)
+
+@eval_jaxpr_p.def_impl
+def _eval_jaxpr_impl(*args, jaxpr):
+  return core.jaxpr_as_fun(jaxpr)(*args)
+
+
+def _lower_and_eval(name: str, jaxpr: Jaxpr, args: Sequence[Any]) -> list[Any]:
+  if any(aval.has_qdd for aval in jaxpr.in_aval_qdds):
+    raise NotImplementedError(f"{name!r} does not support qdd on inputs")
+  if any(aval.has_qdd for aval in jaxpr.final_aval_qdds):
+    raise NotImplementedError(f"{name!r} does not support qdd on outputs")
+
+  lo_jaxpr = lower_jaxpr2(jaxpr)
+  lo_args = [
+      lo_val for aval, x in zip(jaxpr.in_avals, args)
+      for lo_val in aval.lower_val(x)
+  ]
+  lo_outs = eval_jaxpr_p.bind(*lo_args, jaxpr=lo_jaxpr)
+  lo_outs_ = iter(lo_outs)
+  hi_outs = [
+      t.raise_val(*it.islice(lo_outs_, len(t.lo_ty())))
+      for t in jaxpr.out_avals
+  ]
+  assert next(lo_outs_, None) is None
+  return hi_outs
+
+
+def _call_jaxpr(name: str, jaxpr: Jaxpr, args: Sequence[Any]) -> list[Any]:
+  if not jaxpr.is_high:
+    return eval_jaxpr_p.bind(*args, jaxpr=jaxpr)
+  if (any(aval.has_qdd for aval in jaxpr.in_aval_qdds) or
+      any(aval.has_qdd for aval in jaxpr.final_aval_qdds)):
+    return core.jaxpr_as_fun(jaxpr)(*args)
+  return _lower_and_eval(name, jaxpr, args)
+
+
+def _closed_call_to_lojax(*hi_args, call_jaxpr: Jaxpr, **_):
   return _lower_and_eval("closed_call", call_jaxpr, hi_args)
 
 

--- a/jax/_src/lax/eval_jaxpr.py
+++ b/jax/_src/lax/eval_jaxpr.py
@@ -11,38 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Module for eval_jaxpr primitive."""
+"""Transformation rules for the eval_jaxpr primitive.
+
+The primitive itself is defined in partial_eval.py; here we register the rules
+that depend on the ad and batching machinery.
+"""
 
 from jax._src import ad_util
 from jax._src import core
-from jax._src.core import Jaxpr
 from jax._src.interpreters import ad
 from jax._src.interpreters import batching
 from jax._src.interpreters import partial_eval as pe
+from jax._src.interpreters.partial_eval import eval_jaxpr_p
 from jax._src.tree_util import tree_leaves
 from jax._src.util import safe_map, safe_zip, split_list, subs_list
 
 _map = safe_map
 zip = safe_zip
 
-
-eval_jaxpr_p = core.Primitive('eval_jaxpr')
-eval_jaxpr_p.multiple_results = True
-
-def _stage_jaxpr(trace: pe.DynamicJaxprTrace, source_info, *tracers,
-                 jaxpr: Jaxpr):
-  params = dict(call_jaxpr=jaxpr)
-  return trace.default_process_primitive(core.closed_call_p, tracers, params,
-                                         source_info=source_info)
-pe.custom_staging_rules[eval_jaxpr_p] = _stage_jaxpr
-
-@eval_jaxpr_p.def_effectful_abstract_eval  # abstract eval only used for jax2tf
-def _stage_jaxpr_abstract_eval(*_, jaxpr):
-  return jaxpr.out_avals, core.positional_effects(jaxpr)
-
-@eval_jaxpr_p.def_impl
-def _eval_jaxpr_impl(*args, jaxpr):
-  return core.jaxpr_as_fun(jaxpr)(*args)
 
 def _eval_jaxpr_jvp(primals, tangents, *, jaxpr):
   nonzeros = [type(t) is not ad_util.Zero for t in tangents]

--- a/jax/_src/stages.py
+++ b/jax/_src/stages.py
@@ -46,6 +46,7 @@ from jax._src import tree_util
 from jax._src import util
 from jax._src.core import typeof
 from jax._src.interpreters import mlir
+from jax._src.interpreters import partial_eval as pe
 from jax._src.layout import AutoLayoutSingleton, Format, Layout
 from jax._src.lib import _jax
 from jax._src.lib import hlo
@@ -435,7 +436,7 @@ class Traced(Stage):
 
   def __call__(self, *args, **kwargs):
     args_flat = tree_util.tree_leaves_checked(self.in_tree, (args, kwargs))
-    out_flat = core.jaxpr_as_fun(self.jaxpr)(*args_flat)
+    out_flat = pe._call_jaxpr(self.fun_name, self.jaxpr, args_flat)
     return tree_unflatten(self.out_tree, out_flat)
 
   @property
@@ -452,7 +453,6 @@ class Traced(Stage):
       return self._lojax
 
     # TODO(mattjj): when pmap is deleted, merge with pjit.py BUILD rule
-    from jax._src.interpreters import partial_eval as pe  # type:ignore
     from jax._src.pjit import _lojax_expand_params  # pyrefly: ignore[missing-import]
     hi_jaxpr = self.jaxpr
     _, closed_over_himutables = pe.convert_const_himutables(hi_jaxpr)

--- a/tests/custom_api_test.py
+++ b/tests/custom_api_test.py
@@ -3624,6 +3624,22 @@ class CustomVJP3Test(CustomVJPTest):
         r"got fwd output type float32\[3\] which doesn't match",
         lambda: jax.grad(lambda x: scan_apply(f, x))(jnp.float32(1.)))
 
+  def test_expand_stages_call_without_inlining(self):
+    # lowering stages the traced primal as a single closed_call rather than
+    # retracing it eqn-by-eqn
+    @jax.custom_vjp
+    def f(x):
+      for _ in range(10):
+        x = jnp.sin(x)
+      return x
+    f.defvjp(lambda x: (f(x), x), lambda x, g: (g,))
+
+    hi = jax.jit(f).trace(1.).jaxpr
+    lo = pe.lower_jaxpr2(hi.jaxpr)
+    eqn, = lo.eqns
+    self.assertIs(eqn.primitive, core.closed_call_p)
+    self.assertLen(eqn.params['call_jaxpr'].eqns, 10)
+
 
 class CustomVmapTest(jtu.JaxTestCase):
 
@@ -4529,6 +4545,22 @@ class CustomJVP3Test(CustomJVPTest):
           in (b,) }
         """).strip()
     self.assertEqual(actual, expected)
+
+  def test_expand_stages_call_without_inlining(self):
+    # lowering stages the traced primal as a single closed_call rather than
+    # retracing it eqn-by-eqn
+    @jax.custom_jvp
+    def f(x):
+      for _ in range(10):
+        x = jnp.cos(x)
+      return x
+    f.defjvp(lambda primals, tangents: (f(primals[0]), tangents[0]))
+
+    hi = jax.jit(f).trace(1.).jaxpr
+    lo = pe.lower_jaxpr2(hi.jaxpr)
+    eqn, = lo.eqns
+    self.assertIs(eqn.primitive, core.closed_call_p)
+    self.assertLen(eqn.params['call_jaxpr'].eqns, 10)
 
 
 @jtu.with_config(jax_remat3=True)


### PR DESCRIPTION
Also had to fix up some unneeded-since-xla_call-was-deleted BatchTrace.process_call vestige.

```python
# Trace-time benchmark for custom_vjp3/custom_jvp3 expansion via eval_jaxpr_p.
# Run with: python bench_custom3_expand.py
import time
import jax
import jax.numpy as jnp
from jax._src import hijax
from jax._src.interpreters import partial_eval as pe

jax.config.update('jax_custom_vjp3', True)
jax.config.update('jax_custom_jvp3', True)

new_vjp_expand = hijax.CustomVJPTraced.expand
new_jvp_expand = hijax.CustomJVPTraced.expand

def old_expand(self, *args):  # the previous implementation, for comparison
	args = [x for x in args if not isinstance(x, hijax.Static)]
	return self.traced(*args)

def make_vjp_f(n):
	@jax.custom_vjp
	def f(x):
		for _ in range(n):
			x = jnp.sin(x)
		return x
	f.defvjp(lambda x: (f(x), x), lambda x, g: (g,))
	return f

def make_jvp_f(n):
	@jax.custom_jvp
	def f(x):
		for _ in range(n):
			x = jnp.cos(x)
		return x
	f.defjvp(lambda primals, tangents: (f(primals[0]), tangents[0]))
	return f

def measure_lower_pass(make_f, n, k=5):
	# time just the hi->lo lowering pass on a fresh traced jaxpr each iteration
	ts = []
	for _ in range(k):
		hi = jax.jit(make_f(n)).trace(1.0).jaxpr
		t0 = time.perf_counter()
		pe.lower_jaxpr2(hi.jaxpr)
		ts.append(time.perf_counter() - t0)
	return min(ts)

def measure_full_lower(n, calls, k=3):
	# time full jit lowering, same custom_vjp block called `calls` times
	ts = []
	for _ in range(k):
		jax.clear_caches()
		block = make_vjp_f(n)
		def g(x):
			for _ in range(calls):
				x = block(x)
			return x
		t0 = time.perf_counter()
		jax.jit(g).lower(1.0)
		ts.append(time.perf_counter() - t0)
	return min(ts)

for name, vjp_expand, jvp_expand in [
		('before', old_expand, old_expand),
		('after', new_vjp_expand, new_jvp_expand)]:
	hijax.CustomVJPTraced.expand = vjp_expand
	hijax.CustomJVPTraced.expand = jvp_expand
	print(f'--- {name} ---')
	for n in [100, 400, 1600]:
		t = measure_lower_pass(make_vjp_f, n)
		print(f'  hi->lo pass, custom_vjp, {n:5d}-eqn body: {t*1e3:8.2f} ms')
	for n in [100, 400, 1600]:
		t = measure_lower_pass(make_jvp_f, n)
		print(f'  hi->lo pass, custom_jvp, {n:5d}-eqn body: {t*1e3:8.2f} ms')
	for calls in [1, 8]:
		t = measure_full_lower(400, calls)
		print(f'  full jit lower, 400-eqn custom_vjp x {calls} call(s): {t*1e3:6.2f} ms')
```

Output on my machine:

```
--- before ---
	hi->lo pass, custom_vjp,   100-eqn body:     0.58 ms
	hi->lo pass, custom_vjp,   400-eqn body:     2.28 ms
	hi->lo pass, custom_vjp,  1600-eqn body:     9.00 ms
	hi->lo pass, custom_jvp,   100-eqn body:     0.60 ms
	hi->lo pass, custom_jvp,   400-eqn body:     2.30 ms
	hi->lo pass, custom_jvp,  1600-eqn body:     9.10 ms
	full jit lower, 400-eqn custom_vjp x 1 call(s):   8.88 ms
	full jit lower, 400-eqn custom_vjp x 8 call(s):  39.17 ms
--- after ---
	hi->lo pass, custom_vjp,   100-eqn body:     0.05 ms
	hi->lo pass, custom_vjp,   400-eqn body:     0.05 ms
	hi->lo pass, custom_vjp,  1600-eqn body:     0.05 ms
	hi->lo pass, custom_jvp,   100-eqn body:     0.04 ms
	hi->lo pass, custom_jvp,   400-eqn body:     0.05 ms
	hi->lo pass, custom_jvp,  1600-eqn body:     0.05 ms
	full jit lower, 400-eqn custom_vjp x 1 call(s):   5.93 ms
	full jit lower, 400-eqn custom_vjp x 8 call(s):   6.78 ms
```

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->