### PR TITLE
eval_jaxpr_p should round-trip to eval_jaxpr_p

### DIFF
--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -667,6 +667,10 @@ def div_error_check(error, enabled_errors, x, y):
   return nan_error_check(lax.div_p, error, enabled_errors, x, y)
 error_checks[lax.div_p] = div_error_check
 
+def eval_jaxpr_error_check(error, enabled_errors, *invals, call_jaxpr):
+  return checkify_jaxpr(call_jaxpr, enabled_errors, error, *invals)
+error_checks[pe.eval_jaxpr_p] = eval_jaxpr_error_check
+
 def oob_payload(oob_mask, indices, dims_map, operand_shape):
   # Get first OOB index, axis and axis size so it can be added to the error msg.
   flat_idx = jnp.argmin(jnp.logical_not(oob_mask))

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -2591,26 +2591,25 @@ def raise_lo_outs(hi_avals, lo_outs):
 
 # eval_jaxpr_p is a call-like primitive parameterized by a jaxpr rather than a
 # Python callable: applying it evaluates the jaxpr, and staging it out is O(1),
-# emitting a single closed_call eqn rather than retracing the jaxpr. Its
-# transformation rules live in lax/eval_jaxpr.py; the primitive is defined here
-# so that jaxpr-level utilities below can use it without upward imports.
+# emitting a single eqn (which stays an eval_jaxpr eqn under retracing) rather
+# than retracing the jaxpr. Its ad and batching rules live in
+# lax/eval_jaxpr.py; the primitive is defined here so that jaxpr-level
+# utilities below can use it without upward imports.
 eval_jaxpr_p = core.Primitive('eval_jaxpr')
 eval_jaxpr_p.multiple_results = True
 
-def _eval_jaxpr_staging(trace: DynamicJaxprTrace, source_info, *tracers,
-                        jaxpr: Jaxpr):
-  params = dict(call_jaxpr=jaxpr)
-  return trace.default_process_primitive(core.closed_call_p, tracers, params,
-                                         source_info=source_info)
-custom_staging_rules[eval_jaxpr_p] = _eval_jaxpr_staging
-
-@eval_jaxpr_p.def_effectful_abstract_eval  # abstract eval only used for jax2tf
-def _eval_jaxpr_abstract_eval(*_, jaxpr):
-  return jaxpr.out_avals, core.positional_effects(jaxpr)
+@eval_jaxpr_p.def_effectful_abstract_eval
+def _eval_jaxpr_abstract_eval(*_, call_jaxpr):
+  return call_jaxpr.out_avals, core.positional_effects(call_jaxpr)
 
 @eval_jaxpr_p.def_impl
-def _eval_jaxpr_impl(*args, jaxpr):
-  return core.jaxpr_as_fun(jaxpr)(*args)
+def _eval_jaxpr_impl(*args, call_jaxpr):
+  return core.jaxpr_as_fun(call_jaxpr)(*args)
+
+dce_rules[eval_jaxpr_p] = dce_jaxpr_closed_call_rule
+
+partial_eval_jaxpr_custom_rules[eval_jaxpr_p] = \
+    partial_eval_jaxpr_custom_rules[core.closed_call_p]
 
 
 def _lower_and_eval(name: str, jaxpr: Jaxpr, args: Sequence[Any]) -> list[Any]:
@@ -2624,7 +2623,7 @@ def _lower_and_eval(name: str, jaxpr: Jaxpr, args: Sequence[Any]) -> list[Any]:
       lo_val for aval, x in zip(jaxpr.in_avals, args)
       for lo_val in aval.lower_val(x)
   ]
-  lo_outs = eval_jaxpr_p.bind(*lo_args, jaxpr=lo_jaxpr)
+  lo_outs = eval_jaxpr_p.bind(*lo_args, call_jaxpr=lo_jaxpr)
   lo_outs_ = iter(lo_outs)
   hi_outs = [
       t.raise_val(*it.islice(lo_outs_, len(t.lo_ty())))
@@ -2636,7 +2635,7 @@ def _lower_and_eval(name: str, jaxpr: Jaxpr, args: Sequence[Any]) -> list[Any]:
 
 def _call_jaxpr(name: str, jaxpr: Jaxpr, args: Sequence[Any]) -> list[Any]:
   if not jaxpr.is_high:
-    return eval_jaxpr_p.bind(*args, jaxpr=jaxpr)
+    return eval_jaxpr_p.bind(*args, call_jaxpr=jaxpr)
   if (any(aval.has_qdd for aval in jaxpr.in_aval_qdds) or
       any(aval.has_qdd for aval in jaxpr.final_aval_qdds)):
     return core.jaxpr_as_fun(jaxpr)(*args)
@@ -2648,3 +2647,10 @@ def _closed_call_to_lojax(*hi_args, call_jaxpr: Jaxpr, **_):
 
 
 core.closed_call_p.to_lojax = _closed_call_to_lojax
+
+
+def _eval_jaxpr_to_lojax(*hi_args, call_jaxpr: Jaxpr):
+  return _lower_and_eval("eval_jaxpr", call_jaxpr, hi_args)
+
+
+eval_jaxpr_p.to_lojax = _eval_jaxpr_to_lojax

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -651,12 +651,12 @@ def _scan_impl(*args, reverse, length, ft_in, ft_out, jaxpr,
   def inner(n, carry, xs):
     ys = []
     if unroll == 1:
-      carry_y = eval_jaxpr_p.bind(*consts, *carry, *xs, jaxpr=jaxpr)
+      carry_y = eval_jaxpr_p.bind(*consts, *carry, *xs, call_jaxpr=jaxpr)
       return _map(list, ft_out.update(carry_y).unpack())
     for i_ in range(n):
       i = n - i_ - 1 if reverse else i_
       x = [slicing.index_in_dim(x, i, keepdims=False) for x in xs]
-      carry_y = eval_jaxpr_p.bind(*consts, *carry, *x, jaxpr=jaxpr)
+      carry_y = eval_jaxpr_p.bind(*consts, *carry, *x, call_jaxpr=jaxpr)
       carry, y = _map(list, ft_out.update(carry_y).unpack())
       ys.append(y)
     ys = list(reversed(ys)) if reverse else ys
@@ -1482,7 +1482,7 @@ def _scan_state_discharge_rule(
     xs_refvals = [ds(x, i) for x in xs_refvals_]
     consts = merge_lists(is_ref_const, pure_consts, const_refvals)
     xs = merge_lists(is_ref_xs, pure_xs, xs_refvals)
-    outs = eval_jaxpr_p.bind(*consts, *carry, *xs, jaxpr=discharged_jaxpr)
+    outs = eval_jaxpr_p.bind(*consts, *carry, *xs, call_jaxpr=discharged_jaxpr)
     carry, ys, const_refvals, xs_updates = split_list_checked(
         outs, [num_carry, num_ys, num_const_refs, num_xs_refs])
     xs_refvals = [dus(x, u, i) for x, u in zip(xs_refvals_, xs_updates)]

--- a/jax/_src/lax/eval_jaxpr.py
+++ b/jax/_src/lax/eval_jaxpr.py
@@ -17,10 +17,13 @@ The primitive itself is defined in partial_eval.py; here we register the rules
 that depend on the ad and batching machinery.
 """
 
+from functools import partial
+
 from jax._src import ad_util
 from jax._src import core
 from jax._src.interpreters import ad
 from jax._src.interpreters import batching
+from jax._src.interpreters import mlir
 from jax._src.interpreters import partial_eval as pe
 from jax._src.interpreters.partial_eval import eval_jaxpr_p
 from jax._src.tree_util import tree_leaves
@@ -30,47 +33,53 @@ _map = safe_map
 zip = safe_zip
 
 
-def _eval_jaxpr_jvp(primals, tangents, *, jaxpr):
+mlir.register_lowering(eval_jaxpr_p,
+                       partial(mlir.core_call_lowering, name="eval_jaxpr"),
+                       cacheable=False)
+
+
+def _eval_jaxpr_jvp(primals, tangents, *, call_jaxpr):
   nonzeros = [type(t) is not ad_util.Zero for t in tangents]
-  jaxpr_jvp, nonzeros_out = ad.jvp_jaxpr(jaxpr, nonzeros, False)
+  jaxpr_jvp, nonzeros_out = ad.jvp_jaxpr(call_jaxpr, nonzeros, False)
   nz_tangents = [t for t, nz in zip(tangents, nonzeros) if nz]
-  outs = eval_jaxpr_p.bind(*primals, *nz_tangents, jaxpr=jaxpr_jvp)
-  primals_out, tangents_out = split_list(outs, [len(jaxpr.out_avals)])
+  outs = eval_jaxpr_p.bind(*primals, *nz_tangents, call_jaxpr=jaxpr_jvp)
+  primals_out, tangents_out = split_list(outs, [len(call_jaxpr.out_avals)])
   nz_tangents_out = iter(tangents_out)
   tangents_out = [next(nz_tangents_out) if nz else ad_util.Zero(aval.to_tangent_aval())
-                  for aval, nz in zip(jaxpr.out_avals, nonzeros_out)]
+                  for aval, nz in zip(call_jaxpr.out_avals, nonzeros_out)]
   return primals_out, tangents_out
 ad.primitive_jvps[eval_jaxpr_p] = _eval_jaxpr_jvp
 
-def _eval_jaxpr_batching_rule(axis_data, args, dims, *, jaxpr):
+def _eval_jaxpr_batching_rule(axis_data, args, dims, *, call_jaxpr):
   batched = [d is not None for d in dims]
-  new_jaxpr, out_batched = batching.batch_jaxpr(jaxpr, axis_data, batched, False)
+  new_jaxpr, out_batched = batching.batch_jaxpr(call_jaxpr, axis_data, batched,
+                                                False)
   new_args = [batching.moveaxis(x, d, 0)
               if d is not None and d != 0 else x
               for x, d in zip(args, dims)]
-  outs = eval_jaxpr_p.bind(*new_args, jaxpr=new_jaxpr)
+  outs = eval_jaxpr_p.bind(*new_args, call_jaxpr=new_jaxpr)
   out_dims = [0 if b else None for b in out_batched]
   return outs, out_dims
 batching.fancy_primitive_batchers[eval_jaxpr_p] = _eval_jaxpr_batching_rule
 
-def _eval_jaxpr_linearize(is_vjp, nzs, *primals_in, jaxpr):
+def _eval_jaxpr_linearize(is_vjp, nzs, *primals_in, call_jaxpr):
   primal_jaxpr, out_tree, nzs_out, in_fwd_res, tangent_jaxpr = \
-      ad.linearize_jaxpr(jaxpr, nzs, is_vjp=is_vjp)
+      ad.linearize_jaxpr(call_jaxpr, nzs, is_vjp=is_vjp)
   _, ures_avals, sres_avals = out_tree.unpack()
   num_res_out = len(ures_avals) + len(sres_avals)
-  primals_and_res = eval_jaxpr_p.bind(*primals_in, jaxpr=primal_jaxpr)
+  primals_and_res = eval_jaxpr_p.bind(*primals_in, call_jaxpr=primal_jaxpr)
   primals_out, non_fwd_res = split_list(
       primals_and_res, [len(primals_and_res) - num_res_out])
   ures, sres_flat = split_list(non_fwd_res, [len(ures_avals)])
-  res = subs_list(in_fwd_res, [*jaxpr.consts, *primals_in], ures)
+  res = subs_list(in_fwd_res, [*call_jaxpr.consts, *primals_in], ures)
   sres = sres_avals.update(sres_flat).unflatten()
 
   def tangent_fun(res, sres, *tangents):
     sres_flat = tree_leaves(sres)
     nz_tangents = [ad.instantiate_zeros(x) for nz, x in zip(nzs, tangents) if nz]
     nz_tangents_out = eval_jaxpr_p.bind(*res, *nz_tangents, *sres_flat,
-                                        jaxpr=tangent_jaxpr)
-    tangent_avals_out = [v.aval.to_tangent_aval() for v in jaxpr.outvars]
+                                        call_jaxpr=tangent_jaxpr)
+    tangent_avals_out = [v.aval.to_tangent_aval() for v in call_jaxpr.outvars]
     nz_tangents_out_ = iter(nz_tangents_out)
     tangents_out = [next(nz_tangents_out_) if nz else ad_util.Zero(aval)
                     for aval, nz in zip(tangent_avals_out, nzs_out)]
@@ -80,8 +89,8 @@ def _eval_jaxpr_linearize(is_vjp, nzs, *primals_in, jaxpr):
   return primals_out, nzs_out, res, sres, tangent_fun
 ad.primitive_linearizations[eval_jaxpr_p] = _eval_jaxpr_linearize
 
-def _eval_jaxpr_transpose(ct, *args, jaxpr):
-  jaxpr_, consts = jaxpr, jaxpr.consts
+def _eval_jaxpr_transpose(ct, *args, call_jaxpr):
+  jaxpr_, consts = call_jaxpr, call_jaxpr.consts
   jaxpr_ = pe.convert_constvars_jaxpr(jaxpr_)
   return ad.call_transpose_fancy(core.closed_call_p, ct, *consts, *args,
                                  call_jaxpr=jaxpr_)

--- a/jax/_src/pallas/fuser/fusible.py
+++ b/jax/_src/pallas/fuser/fusible.py
@@ -85,7 +85,7 @@ class Fusible(hijax.VJPHiPrimitive):
     else:
       lo_args = flat_args
       lo_jaxpr = jax_core.ClosedJaxpr(self.jaxpr, consts)
-    lo_outs = eval_jaxpr_p.bind(*lo_args, jaxpr=lo_jaxpr)
+    lo_outs = eval_jaxpr_p.bind(*lo_args, call_jaxpr=lo_jaxpr)
     out_flat = pe.raise_lo_outs(self.out_avals_flat, lo_outs)
     return tree_util.tree_unflatten(self.out_tree, out_flat)
 

--- a/jax/_src/pallas/mosaic_gpu/primitives.py
+++ b/jax/_src/pallas/mosaic_gpu/primitives.py
@@ -36,6 +36,7 @@ from jax._src import pretty_printer as pp
 from jax._src import state
 from jax._src import tree_util
 from jax._src import util
+from jax._src.interpreters import partial_eval as pe
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import arith as arith_dialect
 from jax._src.lib.mlir.dialects import builtin as builtin_dialect
@@ -3078,6 +3079,8 @@ def broadcasted_iota(
 
 @lowering.register_lowering_rule(jax_core.closed_call_p, mgpu.LoweringSemantics.Lane)
 @lowering.register_lowering_rule(jax_core.closed_call_p, mgpu.LoweringSemantics.Warpgroup)
+@lowering.register_lowering_rule(pe.eval_jaxpr_p, mgpu.LoweringSemantics.Lane)
+@lowering.register_lowering_rule(pe.eval_jaxpr_p, mgpu.LoweringSemantics.Warpgroup)
 def _closed_call_lowering_rule(ctx, *args, call_jaxpr: jax_core.Jaxpr):
   if call_jaxpr.consts: raise NotImplementedError
   return lowering.lower_jaxpr_to_mosaic_gpu(
@@ -3085,6 +3088,7 @@ def _closed_call_lowering_rule(ctx, *args, call_jaxpr: jax_core.Jaxpr):
 
 
 @lowering._register_resource_estimator(jax_core.closed_call_p)
+@lowering._register_resource_estimator(pe.eval_jaxpr_p)
 def _closed_call_resource_estimator(ctx, *args, call_jaxpr):
   del args  # Unused.
   if call_jaxpr.consts: raise NotImplementedError

--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -2603,6 +2603,7 @@ def _reshard_lowering_rule(ctx, x, *, dst_sharding, concrete_mesh):
 
 
 @register_lowering(jax_core.closed_call_p)
+@register_lowering(pe.eval_jaxpr_p)
 @register_lowering(custom_derivatives.custom_jvp_call_p)
 def _closed_call_lowering_rule(
     ctx: LoweringRuleContext, *args, call_jaxpr, **_

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -2060,7 +2060,7 @@ def _add_reshapes(which: Sequence[bool],
   assert not jaxpr_known.constvars and not jaxpr_staged.constvars
 
   def known(*args):
-    out = eval_jaxpr_p.bind(*args, jaxpr=jaxpr_known)
+    out = eval_jaxpr_p.bind(*args, call_jaxpr=jaxpr_known)
     out_known, res = split_list(out, [len(out) - sum(which)])
     res = [_add_singleton(x) if not x.shape else x for x in res]
     return [*out_known, *res]
@@ -2073,7 +2073,7 @@ def _add_reshapes(which: Sequence[bool],
     res_, ins = split_list(args, [len(which)])
     res = [_rem_singleton(x) if w else x for x, w in zip(res_, which_)]
     closed_jaxpr_staged = jaxpr_staged
-    return eval_jaxpr_p.bind(*res, *ins, jaxpr=closed_jaxpr_staged)
+    return eval_jaxpr_p.bind(*res, *ins, call_jaxpr=closed_jaxpr_staged)
   res_avals = [core.unmapped_aval(1, 0, v.aval) if w else v.aval
                for w, v in zip(which_, jaxpr_staged.invars[:len(which)])]
   avals_in = (*res_avals, *[v.aval for v in jaxpr_staged.invars[len(which):]])

--- a/jax/_src/state/discharge.py
+++ b/jax/_src/state/discharge.py
@@ -660,14 +660,13 @@ def _cached_closed_jaxpr_discharge(closed_jaxpr: core.Jaxpr, *, strip_memory_spa
                      debug_info=discharged_closed_jaxpr.debug_info)
   return discharged_closed_jaxpr, num_outs, fun
 
-@register_discharge_rule(core.closed_call_p)
 def _closed_call_discharge_rule(
-    ctx: DischargeContext, *args,
-    call_jaxpr: core.Jaxpr):
-  discharged_closed_jaxpr, num_outs, fun = _cached_closed_jaxpr_discharge(
-      call_jaxpr, strip_memory_space=ctx.strip_memory_space)
-  out_and_ref_vals = core.closed_call_p.bind(*args, subfuns=(fun,),
-                                             call_jaxpr=discharged_closed_jaxpr)
+    prim: core.Primitive, ctx: DischargeContext, *args, **params):
+  discharged_jaxpr, num_outs, fun = _cached_closed_jaxpr_discharge(
+      params['call_jaxpr'], strip_memory_space=ctx.strip_memory_space)
+  subfuns = dict(subfuns=(fun,)) if prim.call_primitive else {}
+  out_and_ref_vals = prim.bind(
+      *args, **subfuns, **dict(params, call_jaxpr=discharged_jaxpr))
   out_vals, ref_vals = split_list(out_and_ref_vals, [num_outs])
   ref_vals_iter = iter(ref_vals)
   new_invals = tuple(next(ref_vals_iter) if isinstance(aval, AbstractRef)
@@ -675,6 +674,10 @@ def _closed_call_discharge_rule(
   sentinel = object()
   assert next(ref_vals_iter, sentinel) is sentinel
   return new_invals, out_vals
+register_discharge_rule(core.closed_call_p)(
+    partial(_closed_call_discharge_rule, core.closed_call_p))
+register_discharge_rule(pe.eval_jaxpr_p)(
+    partial(_closed_call_discharge_rule, pe.eval_jaxpr_p))
 
 def _call_primitive_discharge_rule(
     prim: core.Primitive,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -8265,7 +8265,7 @@ class Remat3Test(RematTest):
     self.assertIs(eqn2.params['_prim'], jaxpr.eqns[0].params['_prim'])
 
   def test_remat_expand_stages_call_without_inlining(self):
-    # expand binds eval_jaxpr_p, staging a single closed_call eqn rather than
+    # expand binds eval_jaxpr_p, staging a single eval_jaxpr eqn rather than
     # retracing the body, so lowering work doesn't scale with the jaxpr size
     @jax.remat
     def f(x):
@@ -8276,12 +8276,12 @@ class Remat3Test(RematTest):
     hi = jax.jit(f).trace(1.).jaxpr
     lo = pe.lower_jaxpr2(hi.jaxpr)
     eqn, = lo.eqns
-    self.assertIs(eqn.primitive, core.closed_call_p)
+    self.assertIs(eqn.primitive, pe.eval_jaxpr_p)
     self.assertLen(eqn.params['call_jaxpr'].eqns, 10)
 
   def test_remat_expand_stages_call_without_inlining_high_jaxpr(self):
     # a high (here nested-remat) body is lowered and staged as a single
-    # closed_call rather than inlined
+    # eval_jaxpr call rather than inlined
     inner = jax.remat(lambda x: jnp.cos(jnp.cos(x)))
 
     @jax.remat
@@ -8293,7 +8293,7 @@ class Remat3Test(RematTest):
     hi = jax.jit(f).trace(1.).jaxpr
     lo = pe.lower_jaxpr2(hi.jaxpr)
     eqn, = lo.eqns
-    self.assertIs(eqn.primitive, core.closed_call_p)
+    self.assertIs(eqn.primitive, pe.eval_jaxpr_p)
     self.assertLen(eqn.params['call_jaxpr'].eqns, 11)  # 10 sins + inner call
 
 
@@ -9227,7 +9227,7 @@ class EvalJaxprPrimitiveTest(jtu.JaxTestCase):
   def _bind_eval_jaxpr(self, f, *args):
     """Trace f into a jaxpr and evaluate it via eval_jaxpr_p.bind."""
     closed_jaxpr = jax.make_jaxpr(f)(*args)
-    return eval_jaxpr_p.bind(*args, jaxpr=closed_jaxpr)
+    return eval_jaxpr_p.bind(*args, call_jaxpr=closed_jaxpr)
 
   def test_eval_jaxpr_impl(self):
     def f(x, y):

--- a/tests/custom_api_test.py
+++ b/tests/custom_api_test.py
@@ -3625,7 +3625,7 @@ class CustomVJP3Test(CustomVJPTest):
         lambda: jax.grad(lambda x: scan_apply(f, x))(jnp.float32(1.)))
 
   def test_expand_stages_call_without_inlining(self):
-    # lowering stages the traced primal as a single closed_call rather than
+    # lowering stages the traced primal as a single eval_jaxpr call rather than
     # retracing it eqn-by-eqn
     @jax.custom_vjp
     def f(x):
@@ -3637,7 +3637,7 @@ class CustomVJP3Test(CustomVJPTest):
     hi = jax.jit(f).trace(1.).jaxpr
     lo = pe.lower_jaxpr2(hi.jaxpr)
     eqn, = lo.eqns
-    self.assertIs(eqn.primitive, core.closed_call_p)
+    self.assertIs(eqn.primitive, pe.eval_jaxpr_p)
     self.assertLen(eqn.params['call_jaxpr'].eqns, 10)
 
 
@@ -4547,7 +4547,7 @@ class CustomJVP3Test(CustomJVPTest):
     self.assertEqual(actual, expected)
 
   def test_expand_stages_call_without_inlining(self):
-    # lowering stages the traced primal as a single closed_call rather than
+    # lowering stages the traced primal as a single eval_jaxpr call rather than
     # retracing it eqn-by-eqn
     @jax.custom_jvp
     def f(x):
@@ -4559,7 +4559,7 @@ class CustomJVP3Test(CustomJVPTest):
     hi = jax.jit(f).trace(1.).jaxpr
     lo = pe.lower_jaxpr2(hi.jaxpr)
     eqn, = lo.eqns
-    self.assertIs(eqn.primitive, core.closed_call_p)
+    self.assertIs(eqn.primitive, pe.eval_jaxpr_p)
     self.assertLen(eqn.params['call_jaxpr'].eqns, 10)
 
 

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -2052,7 +2052,7 @@ class HijaxTest(jtu.JaxTestCase):
     fns = [scheduling_group('g')(f),
            compute_on2(f, compute_type='device_host',
                        out_memory_spaces=jax.memory.Space.Device),
-           lambda x: eval_jaxpr_p.bind(x, jaxpr=jaxpr)[0]]
+           lambda x: eval_jaxpr_p.bind(x, call_jaxpr=jaxpr)[0]]
     for fn in fns:
       _, f_vjp = jax.vjp(fn, 1.0)
       cts, logs = f_vjp.with_logs(1.0)


### PR DESCRIPTION
That is, if we do a trace-to-jaxpr and eval-jaxpr, we want eval_jaxpr_p to stay as eval_jaxpr_p and not get converted to a closed_call_p. That behavior was vestigial.

Actually, eval_jaxpr_p is now the same as closed_call_p, except that it doesn't have closed_call_p's weird round-tripping behavior of converting its jaxpr into a Python callable during eval_jaxpr, which closed_call_p does because it's final-style and so takes a callable at bind time. That behavior actually sucks. So I plan to remove call_p and closed_call_p, and we'll just be left with eval_jaxpr_p. That means we'd be able to remove all our process_call etc paths too. I'll do that in follow-up work though.