### PR TITLE
Fix cuDNN SDPA non-causal sliding window silently attending to the future

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -1245,13 +1245,26 @@ def dot_product_attention(
         mask_type = MaskType.CAUSAL
       elif use_padding:
         mask_type = MaskType.PADDING
-      # CuDNN supports only the left window with an exclusive boundary when
-      # causal mask is enabled.
+      # cuDNN's sliding_window_length is an alias for the diagonal band's *left*
+      # bound only; the right bound comes from the causal mask. So a zero right
+      # window has to be requested as causal + left bound, otherwise the band is
+      # unbounded on the right and every query attends to its future.
       sliding_window = None
       if local_window_size is not None:
         l_window, r_window = local_window_size
-        if r_window == 0 or mask_type == MaskType.CAUSAL:
+        if (mask_type in (MaskType.CAUSAL, MaskType.PADDING_CAUSAL)
+            and r_window >= 0):
+          # A causal mask already clips at the diagonal, so a non-negative right
+          # window is subsumed by it. A negative one narrows the band further and
+          # cannot be expressed to cuDNN, so it falls through and raises.
           sliding_window = l_window + 1
+        elif r_window == 0:
+          sliding_window = l_window + 1
+          mask_type = (MaskType.PADDING_CAUSAL if mask_type == MaskType.PADDING
+                       else MaskType.CAUSAL)
+        elif r_window < 0:
+          raise ValueError(
+              f"cuDNN doesn't support a negative right window: {r_window}.")
         else:
           raise ValueError(f"cuDNN doesn't support right window: {r_window} "
                            "when causal mask is not used.")

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -266,7 +266,9 @@ class NNFunctionsTest(jtu.JaxTestCase):
   @parameterized.product(
       mask_mode=['bias', 'causal', 'padding', 'custom', ('causal', 'padding'),
                  ('custom', 'padding'), ('bias', 'causal'),
-                 ('causal', 'sliding_window')],
+                 ('causal', 'sliding_window'), 'sliding_window',
+                 ('sliding_window', 'padding'),
+                 ('causal', 'sliding_window', 'padding')],
   )
   def testDotProductAttentionMask(self, mask_mode):
     if isinstance(mask_mode, str):
@@ -276,8 +278,6 @@ class NNFunctionsTest(jtu.JaxTestCase):
     if use_cudnn:
       if not jtu.is_cuda_compute_capability_at_least("8.0"):
         raise unittest.SkipTest("Requires compute capability 8.0 or higher.")
-      if jtu.is_cuda_version_at_least(13, 0):
-        raise unittest.SkipTest("cuDNN creates no execution plans on CUDA 13.0.")
 
     dtype = jnp.bfloat16
     B, S, T, N, H = 2, 128, 128, 4, 32
@@ -294,6 +294,10 @@ class NNFunctionsTest(jtu.JaxTestCase):
     if 'padding' in mask_mode:
       q_seqlen = jnp.array([T // 2, T // 4], dtype=jnp.int32)
       kv_seqlen = jnp.array([S // 4, S // 2], dtype=jnp.int32)
+      if 'sliding_window' in mask_mode:
+        # Keep every query's window over at least one unpadded key: on fully
+        # masked rows cuDNN returns 0 and the reference returns mean(V).
+        q_seqlen = jnp.minimum(q_seqlen, kv_seqlen)
     if 'custom' in mask_mode:
       # Use a generated causal mask as the custom mask.
       custom_mask = jnp.tril(jnp.ones((T, S), dtype=jnp.bool_))


### PR DESCRIPTION
# Fix cuDNN SDPA non-causal sliding window silently attending to the future

## Summary

`nn.dot_product_attention(..., implementation='cudnn', local_window_size=(L, 0))` with
`is_causal=False` produced numerically wrong output: cuDNN was told the *left* bound of the
attention band but never the right one, so every query attended to its entire future instead of
to `[i-L, i]`. The result was silently wrong — no error, no warning — in both forward and
backward, on every architecture we tested (sm80/sm89/sm90/sm100). The same code path also
rejected the perfectly valid combination `is_causal=True` + `local_window_size=(L, R)` +
`query_seq_lengths` with `"cuDNN doesn't support right window"`. This PR fixes both and adds the
test coverage that would have caught them.

### 1. `local_window_size=(L, 0)` without `is_causal` leaks future tokens

`jax/_src/nn/functions.py:1248-1266`. The old code was:

```python
mask_type = MaskType.NO_MASK   # is_causal=False, no padding
...
if r_window == 0 or mask_type == MaskType.CAUSAL:
    sliding_window = l_window + 1
```

so for `local_window_size=(L, 0)` with `is_causal=False` it left `mask_type = NO_MASK` and
forwarded only `sliding_window_length = L + 1`. That is not enough information for cuDNN.
In the cuDNN frontend, `set_sliding_window_length()` is a pure alias for the *left* bound:

```cpp
// cudnn_frontend/include/cudnn_frontend/graph_properties.h:2162-2167
// calls set_diagonal_band_left_bound(value)
set_sliding_window_length(int const value) {
    return set_diagonal_band_left_bound(value);
}
```

The right bound of the diagonal band is set by the causal-mask attribute
(`set_causal_mask*()` → `set_diagonal_band_right_bound(0)`, same file, lines 2133-2151). With
`NO_MASK` no right bound is ever set, so the graph cuDNN executes is `j >= i - L` — left bound
only, unbounded to the right.

Failure scenario: a decoder-only model that asks for a strictly backward-looking local window via
`local_window_size=(L, 0)` instead of `is_causal=True` gets full bidirectional attention over
`[i-L, S)`. Training silently sees the labels it is supposed to predict.

Fix: when `r_window == 0`, promote `NO_MASK -> CAUSAL` and `PADDING -> PADDING_CAUSAL` in addition
to forwarding the left bound, so cuDNN receives both bounds of the band.

### 2. Spurious rejection of causal + right window + varlen

Same block. `mask_type == MaskType.CAUSAL` was compared by equality, so the `PADDING_CAUSAL`
case (i.e. `is_causal=True` together with `query_seq_lengths`/`key_value_seq_lengths`) fell
through to the `else` and raised

```
ValueError: cuDNN doesn't support right window: 16 when causal mask is not used.
```

even though a causal mask *is* used and already clips the band at the diagonal, making any
`r_window >= 0` redundant. Fix: test `mask_type in (CAUSAL, PADDING_CAUSAL)`.

### 3. Test coverage holes that let this through

`tests/nn_test.py`.

(a) `testDotProductAttentionMask` already computed the buggy configuration —
`window_size = (3, 2) if is_causal else (3, 0)` — but the `else` branch was dead code: the
`mask_mode` product only ever paired `'sliding_window'` with `'causal'`. Added standalone
`'sliding_window'`, `('sliding_window', 'padding')` and `('causal', 'sliding_window', 'padding')`
so the non-causal window path and the varlen window path are actually compared against the XLA
reference. The third case is the one that used to raise the `ValueError` from item 2.

For the two `padding` + `sliding_window` cases the test clamps `q_seqlen` to `kv_seqlen`. With the
existing asymmetric lengths (`q=[64, 32]`, `kv=[32, 64]`) and a 4-wide window, batch 0 queries
32..63 have *no* unpadded key inside their window; on such fully masked rows cuDNN returns 0 while
the XLA reference returns `mean(V)` (softmax over a uniformly `-inf` row). That divergence is
pre-existing and orthogonal to this PR, so the test avoids it rather than encoding either
behaviour.

(b) **Judgement call, please confirm against your CI matrix.** `tests/nn_test.py:279-280` skipped
the entire test on CUDA >= 13.0 with `"cuDNN creates no execution plans on CUDA 13.0."`. That
reason is stale — this is exactly why the bug survived. We removed the skip for
`testDotProductAttentionMask` only. Verified locally: the full `tests/nn_test.py` passes on a
CUDA 13.0.3 / cuDNN 9.24 jaxlib (377 passed, 35 skipped). As a data point, removing *all three*
`is_cuda_version_at_least(13, 0)` skips in `nn_test.py` also passes (41/41 `DotProductAttention`
tests), and the same stale skip is present in `tests/cudnn_fusion_test.py:39`,
`tests/fused_attention_stablehlo_test.py:271,374` and
`tests/fused_attention_stablehlo_multigpu_test.py:272`. We left those untouched because the
decision depends on which cuDNN version your CUDA-13 CI images ship; if they are on a cuDNN that
does produce plans, all of these skips can go. If you would rather keep a guard, narrowing it to a
`cuda_versions.cudnn_get_version()` lower bound would be strictly better than the current CUDA
runtime check, since the missing plans were a cuDNN-version property, not a CUDA-version one.

## Evidence

Hypothesis fitting on H100, bf16, B=2 S=128 H=4 D=64, comparing the cuDNN output against masks
computed in fp32 numpy (max_abs):

| hypothesis | L=4 | L=16 | L=32 |
| --- | --- | --- | --- |
| band [i-L, i] (requested) | 3.16797 | 3.16797 | 3.16797 |
| left-bound-only j >= i-L | 0.00474 | 0.00438 | 0.00304 |
| no mask at all | 2.04064 | 1.28480 | 1.16451 |
| causal only | 3.16797 | 3.16797 | 3.16797 |

The output matches "left-bound-only" to bf16 noise and is off by ~3.17 from the band the user
asked for, i.e. cuDNN really is running `j >= i - L` with no right bound.

Reproduced on all of sm80, sm89, sm90 and 2x sm100, forward and backward. Backward before the fix:
dQ max_abs 9.71 against a reference max of 10.375, dK 9.66/9.50, dV 12.00/12.00. After the fix
dQ/dK/dV drop to 0.0625 and the forward matches the requested band at 0.0078 (bf16 noise).

Also fixed: `is_causal=True, local_window_size=(16,16)` + `query_seq_lengths` previously raised
"cuDNN doesn't support right window: 16 when causal mask is not used" even though causal IS used;
it now succeeds.

## Testing

`tests/nn_test.py -k testDotProductAttentionMask`, run on an L40S (sm89) against jaxlib with
CUDA runtime 13.0.3 and cuDNN 9.24:

- Before the source fix: `3 failed, 8 passed` — the two new non-causal-window cases fail
  numerically (max abs difference 3.19) and `('causal', 'sliding_window', 'padding')` fails with
  the `ValueError` from item 2.
- After the fix: `11 passed`.
- Full file after the fix: `377 passed, 35 skipped`.

Found by an integration audit of cuDNN SDPA consumers by the NVIDIA cuDNN team.
