### PR TITLE
Fix shape indexing in matmul_small function

### DIFF
--- a/docs/pallas/tpu/matmul.ipynb
+++ b/docs/pallas/tpu/matmul.ipynb
@@ -81,7 +81,7 @@
    "outputs": [],
    "source": [
     "def matmul_small(x: np.ndarray, y: np.ndarray) -> np.ndarray:\n",
-    "  m, k, n = x.shape[0], x.shape[1], y.shape[0]\n",
+    "  m, k, n = x.shape[0], x.shape[1], y.shape[1]\n",
     "  assert m <= 256\n",
     "  assert k <= 256\n",
     "  assert n <= 256\n",

--- a/docs/pallas/tpu/matmul.md
+++ b/docs/pallas/tpu/matmul.md
@@ -73,7 +73,7 @@ Therefore, each output block $z_{ij}$ is the sum of several smaller block matrix
 :id: PACqDMtQrMOL
 
 def matmul_small(x: np.ndarray, y: np.ndarray) -> np.ndarray:
-  m, k, n = x.shape[0], x.shape[1], y.shape[0]
+  m, k, n = x.shape[0], x.shape[1], y.shape[1]
   assert m <= 256
   assert k <= 256
   assert n <= 256


### PR DESCRIPTION
I noticed a minor dimension assignment bug in the matmul_small pseudocode in the Pallas matrix multiplication guide.

In the original code, n is assigned to y.shape[0]
Since matrix Y has the shape (k,n), y.shape[0] corresponds to the inner dimension k This means the variable n is assigned the value of k instead of the column dimension n.

I have updated y.shape[0] to y.shape[1] in matmul_small to correctly bind n to the column dimension:

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->