### PR TITLE
remove call_p and closed_call_p, just use eval_jaxpr_p

### DIFF
--- a/docs/jax.extend.core.rst
+++ b/docs/jax.extend.core.rst
@@ -23,7 +23,6 @@
   TraceTag
   Var
   array_types
-  call_impl
   check_jaxpr
   concrete_or_error
   find_top_trace

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -1097,7 +1097,7 @@ class RematTraced(VJPHiPrimitive):
 
   @source_info_util.extend_name_stack('checkpoint')
   def expand(self, *args):
-    return pe._call_jaxpr('checkpoint', self.jaxpr, args)
+    return pe._call_jaxpr(self.jaxpr, args)
 
   def vjp_fwd(self, _nzs_in, *primals):
     # TODO eval_jaxpr_p trace time

--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -360,7 +360,7 @@ def default_checkify_rule(primitive: core.Primitive, error: Error,
 
   # call_jaxpr handling
   call_jaxpr = params.pop('call_jaxpr')
-  if isinstance(call_jaxpr, core.Jaxpr):  # handle closed_call_p
+  if isinstance(call_jaxpr, core.Jaxpr):  # jaxpr with attached consts
     jaxpr, consts = call_jaxpr, call_jaxpr.consts
   else:
     jaxpr, consts = call_jaxpr, ()
@@ -667,7 +667,7 @@ def div_error_check(error, enabled_errors, x, y):
   return nan_error_check(lax.div_p, error, enabled_errors, x, y)
 error_checks[lax.div_p] = div_error_check
 
-def eval_jaxpr_error_check(error, enabled_errors, *invals, call_jaxpr):
+def eval_jaxpr_error_check(error, enabled_errors, *invals, call_jaxpr, **_):
   return checkify_jaxpr(call_jaxpr, enabled_errors, error, *invals)
 error_checks[pe.eval_jaxpr_p] = eval_jaxpr_error_check
 

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -868,11 +868,6 @@ class Trace:
   def __repr__(self):
     return f'{self.__class__.__name__}'
 
-  def process_call(self, call_primitive, f, tracers, params, /):
-    msg = (f"{type(self)} must override process_call to handle call-like "
-           "primitives")
-    raise NotImplementedError(msg)
-
   def process_custom_jvp_call(self, primitive, fun, jvp, tracers, /, *,
                               symbolic_zeros):
     msg = (f"{type(self)} must override process_custom_jvp_call "
@@ -1306,14 +1301,6 @@ class EvalTrace(Trace):
         args = map(full_lower, args)
         check_eval_args(args)
         return primitive.impl(*args, **params)
-
-  def process_call(self, primitive, f, tracers, params, /):
-    with set_current_trace(self):
-      if config.debug_key_reuse.value:
-        from jax.experimental.key_reuse._core import call_impl_with_key_reuse_checks  # pyrefly: ignore[missing-import]
-        return call_impl_with_key_reuse_checks(primitive, primitive.impl, f, *tracers, **params)
-      else:
-        return primitive.impl(f, *tracers, **params)
 
   def process_custom_jvp_call(self, primitive, fun, jvp, tracers, /, **_):
     del primitive, jvp, _  # Unused.
@@ -3328,48 +3315,46 @@ def dim_value_aval() -> AbstractValue:
 
 # ------------------- Call -------------------
 
-class CallPrimitive(Primitive):
-  multiple_results = True
-  call_primitive = True
-  skip_canonicalization = True
+# eval_jaxpr_p is a call-like primitive parameterized by a jaxpr rather than a
+# Python callable: applying it evaluates the jaxpr, and staging it out is O(1),
+# emitting a single eqn that keeps its identity under retracing. Its
+# transformation rules live in partial_eval.py and lax/eval_jaxpr.py.
+eval_jaxpr_p = Primitive('eval_jaxpr')
+eval_jaxpr_p.multiple_results = True
+eval_jaxpr_p.def_impl(lambda *args, call_jaxpr, **_: jaxpr_as_fun(call_jaxpr)(*args))
+eval_jaxpr_p.def_effectful_abstract_eval(
+    lambda *_, call_jaxpr, **__: (call_jaxpr.out_avals, positional_effects(call_jaxpr)))
 
-  def bind_with_trace(self, trace, args, avals, params, /):
-    params = dict(params)
-    fun, = params.pop('subfuns')
-    return trace.process_call(self, fun, args, params)
+# Aliases for the deleted final-style call primitives, for downstream code that
+# matches on these names when interpreting jaxprs.
+call_p = closed_call_p = eval_jaxpr_p
 
-  def get_bind_params(self, params):
-    new_params = dict(params)
-    jaxpr = new_params.pop('call_jaxpr')
-    subfun = lu.hashable_partial(
-        lu.wrap_init(eval_jaxpr, debug_info=jaxpr.debug_info), jaxpr, ())
-    new_params['subfuns'] = (subfun,)
-    return new_params
-
-def call_impl(f: lu.WrappedFun, *args, **params):
-  del params  # params parameterize the call primitive, not the function
-  with set_current_trace(eval_trace):
-    return f.call_wrapped(*args)
-
-call_p: CallPrimitive = CallPrimitive('call')
-call = call_p.bind
-call_p.def_impl(call_impl)
-
-
-class ClosedCallPrimitive(CallPrimitive):
-  def get_bind_params(self, params):
-    new_params = dict(params)
-    jaxpr: Jaxpr = new_params.pop('call_jaxpr')
-    subfun = lu.wrap_init(partial(eval_jaxpr, jaxpr, jaxpr.consts),
-                          debug_info=jaxpr.debug_info)
-    new_params['subfuns'] = (subfun,)
-    return new_params
-
-closed_call_p: ClosedCallPrimitive = ClosedCallPrimitive('closed_call')
-closed_call_p.def_impl(call_impl)
-closed_call_p.def_effectful_abstract_eval(
-    lambda *_, call_jaxpr: (call_jaxpr.out_avals,
-                            positional_effects(call_jaxpr)))
+def CallPrimitive(name: str) -> Primitive:
+  from jax._src import checkify  # pyrefly: ignore[missing-import]
+  from jax._src.interpreters import ad, batching, mlir  # pyrefly: ignore[missing-import]
+  from jax._src.interpreters import partial_eval as pe  # pyrefly: ignore[missing-import]
+  from jax._src.lax import eval_jaxpr  # pyrefly: ignore[missing-import]
+  from jax._src.state import discharge  # pyrefly: ignore[missing-import]
+  prim = Primitive(name)
+  prim.multiple_results = True
+  # some rules are generic and ignore params
+  prim.def_impl(eval_jaxpr_p.impl)
+  prim.def_effectful_abstract_eval(eval_jaxpr_p.abstract_eval)
+  custom_typechecks[prim] = custom_typechecks[eval_jaxpr_p]
+  mlir.register_lowering(prim, partial(mlir.core_call_lowering, name=name), cacheable=False)
+  checkify.error_checks[prim] = checkify.error_checks[eval_jaxpr_p]
+  # others are generic and bind `prim`, passing through params
+  prim.to_lojax = partial(pe._eval_jaxpr_to_lojax, prim)
+  ad.primitive_jvps[prim] = partial(eval_jaxpr._eval_jaxpr_jvp, prim)
+  ad.primitive_linearizations[prim] = partial(eval_jaxpr._eval_jaxpr_linearize, prim)
+  ad.fancy_transposes[prim] = partial(eval_jaxpr._eval_jaxpr_transpose, prim)
+  batching.fancy_primitive_batchers[prim] = partial(eval_jaxpr._eval_jaxpr_batch, prim)
+  pe.custom_partial_eval_rules[prim] = partial(pe._eval_jaxpr_partial_eval, prim)
+  pe.partial_eval_jaxpr_custom_rules[prim] = pe.partial_eval_jaxpr_custom_rules[eval_jaxpr_p]
+  pe.dce_rules[prim] = pe.dce_rules[eval_jaxpr_p]
+  discharge.register_discharge_rule(prim)(partial(discharge._eval_jaxpr_discharge_rule, prim))
+  return prim
+ClosedCallPrimitive = CallPrimitive
 
 # ------------------- Map -------------------
 
@@ -3564,12 +3549,12 @@ class JaxprTypeError(TypeError):
 
 custom_typechecks: dict[Primitive, Callable] = {}
 
-def _check_closed_call(_, *in_atoms, call_jaxpr):
+def _check_closed_call(_, *in_atoms, call_jaxpr, **__):
   in_avals = [x.aval for x in in_atoms]
   if not all(map(typecompat, call_jaxpr.in_avals, in_avals)):
     raise JaxprTypeError("Closed call in_avals mismatch")
   return call_jaxpr.out_avals, positional_effects(call_jaxpr)
-custom_typechecks[closed_call_p] = _check_closed_call
+custom_typechecks[eval_jaxpr_p] = _check_closed_call
 
 def check_jaxpr(jaxpr: Jaxpr):
   """Checks well-formedness of a jaxpr.
@@ -3693,9 +3678,6 @@ def _check_jaxpr(
         if prim in custom_typechecks:
           out_type, eqn_effects = custom_typechecks[prim](
             ctx_factory, *in_atoms, **eqn.params)
-        elif prim.call_primitive:
-          out_type, eqn_effects = _check_call(ctx_factory, prim, in_atoms,
-                                              eqn.params)
         else:
           out_type, eqn_effects = check_eqn(prim, in_avals, eqn.params)
 

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -395,7 +395,7 @@ class CustomJVPCallPrimitive(core.Primitive):
     return call_jaxpr.is_high
 
   def to_lojax(self, *hi_args, call_jaxpr: core.Jaxpr, **params):
-    return pe._lower_and_eval("custom_jvp_call", call_jaxpr, hi_args)
+    return pe._lower_and_eval(pe.eval_jaxpr_p, call_jaxpr, hi_args)
 
   def get_bind_params(self, params):
     new_params = dict(params)
@@ -1040,7 +1040,7 @@ class CustomVJPCallPrimitive(core.Primitive):
     return call_jaxpr.is_high
 
   def to_lojax(self, *hi_args, call_jaxpr: core.Jaxpr, **params):
-    return pe._lower_and_eval("custom_vjp_call", call_jaxpr, hi_args)
+    return pe._lower_and_eval(pe.eval_jaxpr_p, call_jaxpr, hi_args)
 
   def get_bind_params(self, params):
     new_params = dict(params)
@@ -1917,13 +1917,13 @@ def _remat_opt_dce(used_outs: list[bool], eqn: core.JaxprEqn):
     _, invars = split_list(eqn.invars, [eqn.params["num_consts"]])
     invars = [v for used, v in zip(used_ins, invars) if used]
     new_eqn = pe.new_jaxpr_eqn(
-        invars, outvars, core.closed_call_p, dict(call_jaxpr=closed_jaxpr),
+        invars, outvars, core.eval_jaxpr_p, dict(call_jaxpr=closed_jaxpr),
         core.eqn_effects(closed_jaxpr, invars), eqn.source_info, eqn.ctx)
     used_ins = [False] * eqn.params["num_consts"] + used_ins
     return used_ins, new_eqn
 
 def _remat_opt_to_lojax(*hi_args, fwd_jaxpr: core.Jaxpr, num_consts, **params):
-  return pe._lower_and_eval("remat_opt", fwd_jaxpr, hi_args)
+  return pe._lower_and_eval(pe.eval_jaxpr_p, fwd_jaxpr, hi_args)
 
 remat_opt_p = core.Primitive("remat_opt")
 remat_opt_p.multiple_results = True

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -26,8 +26,7 @@ from jax._src import linear_util as lu
 from jax._src.interpreters import partial_eval as pe
 from jax._src import flattree as ft
 from jax._src.tree_util import (
-    tree_map, tree_flatten, tree_unflatten, tree_leaves, register_pytree_node,
-    PyTreeDef)
+    tree_map, tree_leaves, register_pytree_node, PyTreeDef)
 from jax._src import mesh as mesh_lib
 from jax._src import core
 from jax._src import source_info_util
@@ -35,29 +34,18 @@ from jax._src.ad_util import (
     add_jaxvals, replace_internal_symbolic_zeros,
     replace_rule_output_symbolic_zeros, Zero, zeros_like_aval, SymbolicZero,
     add_jaxvals_p, p2tz, p2cz)  # noqa: F401
-from jax._src.api_util import flatten_fun_nokwargs, debug_info
-from jax._src.core import (Trace, Tracer, typeof, call_p, Primitive, Literal)
+from jax._src.api_util import debug_info
+from jax._src.core import (Trace, Tracer, typeof, Primitive, Literal)
 from jax._src.dtypes import dtype, float0
 from jax._src.state.types import AbstractRef
 from jax._src.util import (unzip2, safe_map, safe_zip, split_list,
-                           split_list_checked, weakref_lru_cache,
-                           partition_list, subs_list2, foreach)
+                           weakref_lru_cache, partition_list, foreach)
 
 Array = Any
 Ref = Any
 zip = safe_zip
 map = safe_map
 def identity(x): return x
-
-def _update_annotation(
-    f: lu.WrappedFun,
-    orig_type: tuple[core.AbstractValue, ...] | None,
-    nonzeros: list[bool]
-  ) -> lu.WrappedFun:
-  if orig_type is None:
-    return f
-  tan_types = [aval.to_tangent_aval() for nz, aval in zip(nonzeros, orig_type) if nz]
-  return lu.annotate(f, (*orig_type, *tan_types))
 
 def jvp(fun: Callable, primals, tangents, has_aux=False, instantiate=True,
         transform_stack=True) -> Any:
@@ -130,47 +118,6 @@ def linearize_subtrace_2(f: Callable, is_vjp: bool,
   return out_primals, ft.flatten((ures, sres)), lin_data
 
 
-@lu.transformation_with_aux2
-def linearize_subtrace(_f: Callable, _store: lu.Store, _is_vjp: bool,
-                       _tag: core.TraceTag, nzs_in: Sequence[bool],
-                       debug_info: core.DebugInfo, *primals, **params):
-  source_info = source_info_util.current()
-  with core.take_current_trace() as parent_trace:
-    tangent_trace = pe.DynamicJaxprTrace(debug_info, auto_dce=True)
-    tangent_trace.tag = _tag
-    linearize_trace = LinearizeTrace(parent_trace, tangent_trace, _is_vjp)
-    tracers = [LinearizeTracer(linearize_trace, p,
-                               tangent_trace.new_arg(typeof(p).to_tangent_aval(),
-                                                     source_info))
-               if nz else p for p, nz in zip(primals, nzs_in)]
-    with core.set_current_trace(linearize_trace, check_leaks=True):
-      ans = _f(*tracers)
-      out_primals, out_tangents = unzip2(map(linearize_trace.to_primal_tangent_pair, ans))
-      structured_residuals = linearize_trace.structured_residuals
-      del linearize_trace, ans, tracers
-  nzs_out = tuple(type(t) is not Zero for t in out_tangents)
-  out_tangents = tuple(t for t, nz in zip(out_tangents, nzs_out) if nz)
-  out_tangents = map(partial(tangent_trace.to_jaxpr_tracer, source_info=source_info),
-                     out_tangents)
-  jaxpr, consts = tangent_trace.to_jaxpr(
-      out_tangents, debug_info.with_unknown_names(), source_info)
-  which_env = [(isinstance(c, pe.DynamicJaxprTracer) and
-                getattr(c._trace, 'tag', None) is _tag) for c in consts]
-  jaxpr = pe.move_envvars(jaxpr, tuple(which_env))
-  res, env = partition_list(which_env, consts)
-  # Which residuals are just forwarded inputs? Check object id.
-  id_map = {id(p): i for i, p in enumerate(primals)}
-  in_fwd: list[int | None] = [id_map.get(id(r)) for r in res]
-  # Which residuals are already primal outputs? Check object id.
-  id_map = {id(p): i for i, p in enumerate(out_primals)}
-  out_fwd: list[int | None] = [id_map.get(id(r)) for r in res]
-  # Prune residuals not to include forwarded primal inputs or outputs.
-  res = [p for p, f1, f2 in zip(res, in_fwd, out_fwd) if f1 is None and f2 is None]
-  fwd_out_ty = ft.flatten((out_primals, res, structured_residuals)).map(typeof)
-  _store.store((fwd_out_ty, nzs_out, jaxpr, env, in_fwd, out_fwd))
-  return *out_primals, *res, *tree_leaves(structured_residuals)
-
-# The result of `f` should be a `FlatTree`
 def jvp_subtrace_2(f: Callable, tag: core.TraceTag, primals, tangents):
   with core.take_current_trace() as parent_trace:
     trace = JVPTrace(parent_trace, tag)
@@ -179,17 +126,6 @@ def jvp_subtrace_2(f: Callable, tag: core.TraceTag, primals, tangents):
     with core.set_current_trace(trace):
       ans = f(*in_tracers)
   return ans.map(trace.to_primal_tangent_pair).unzip2()
-
-@lu.transformation2
-def jvp_subtrace(f: Callable, tag: core.TraceTag, primals, tangents):
-  with core.take_current_trace() as parent_trace:
-    trace = JVPTrace(parent_trace, tag)
-    in_tracers = [maybe_jvp_tracer(trace, x, t)
-                  for x, t in zip(primals, tangents)]
-    with core.set_current_trace(trace):
-      ans = f(*in_tracers)
-    out = unzip2(map(trace.to_primal_tangent_pair, ans))
-  return out
 
 def linearize_jaxpr(
     jaxpr: core.Jaxpr,
@@ -426,14 +362,7 @@ def backward_pass3(
             rule = get_primitive_transpose(eqn.primitive)
             primals = map(read, eqn.invars)
             up = lambda x: UndefinedPrimal(x.aval) if isinstance(x, GradAccum) else x
-            if eqn.primitive.call_primitive:
-              # TODO(mattjj,dougalm): remove this path by revising call/map trans
-              cts_in_avals = [v.aval for v in eqn.outvars]
-              params = dict(eqn.params)
-              call_jaxpr = params.pop('call_jaxpr')
-              cts_out = rule(params, call_jaxpr, map(up, primals), cts_in, cts_in_avals)
-            else:
-              cts_out = rule(cts_in, *map(up, primals), **eqn.params)
+            cts_out = rule(cts_in, *map(up, primals), **eqn.params)
             for x, ct in zip(primals, cts_out):
               if isinstance(x, GradAccum):
                 x.accum(ct)
@@ -578,13 +507,6 @@ def backward_pass(jaxpr, transform_stack: bool, consts, primals_in, cts_in,
   return (cts_out, logs) if return_logs else cts_out
 
 
-@lu.transformation_with_aux2
-def nonzero_tangent_outputs(f, store, *args, **kwargs):
-  results = (_, tangents_out) = f(*args, **kwargs)
-  store.store([type(r) is not Zero for r in tangents_out])
-  return results
-
-
 class JVPTrace(Trace):
   def __init__(self, parent_trace, tag):
     super().__init__()
@@ -626,26 +548,6 @@ class JVPTrace(Trace):
       return [maybe_jvp_tracer(self, x, t) for x, t in zip(primal_out, tangent_out)]
     else:
       return maybe_jvp_tracer(self, primal_out, tangent_out)
-
-  def process_call(self, call_primitive, f, tracers, params, /):
-    assert call_primitive.multiple_results
-    primals, tangents = unzip2(map(self.to_primal_tangent_pair, tracers))
-    which_nz = [     type(t) is not Zero           for t in tangents]
-    tangents = [t if type(t) is not Zero else None for t in tangents]
-    args, in_tree = tree_flatten((primals, tangents))
-    f_jvp = jvp_subtrace(f, self.tag)
-    f_jvp, which_nz_out = nonzero_tangent_outputs(f_jvp)
-    f_jvp, out_tree = traceable(f_jvp, in_tree)
-    update_params = call_param_updaters.get(call_primitive)
-    new_params = update_params(params, which_nz) if update_params else params
-    fun_and_args = _update_annotation(f_jvp.with_unknown_names(), f.in_type, which_nz)
-    new_params = dict(new_params, subfuns=(fun_and_args,))
-    avals = tuple(core.typeof(x) for x in args)
-    result = call_primitive.bind_with_trace(self.parent_trace, args, avals, new_params)
-    primal_out, tangent_out = tree_unflatten(out_tree(), result)
-    tangent_out = [p2tz(p) if t is None else t
-                   for p, t in zip(primal_out, tangent_out)]
-    return [maybe_jvp_tracer(self, p, t) for p, t in zip(primal_out, tangent_out)]
 
   def process_custom_jvp_call(self, primitive, fun, jvp, tracers, /, *, symbolic_zeros):
     primals_in, tangents_in = unzip2(map(self.to_primal_tangent_pair, tracers))
@@ -752,9 +654,6 @@ def _primal_tangent_shapes_match(primal, tangent):
       assert primal_aval.sharding == tangent_aval.sharding, (
           primal_aval.sharding, tangent_aval.sharding)
 
-call_param_updaters: dict[core.Primitive, Callable] = {}
-call_linearize_param_updaters: dict[core.Primitive, Callable] = {}
-call_transpose_param_updaters: dict[core.Primitive, Callable] = {}
 
 # -------------------- Linearize trace --------------------
 
@@ -888,47 +787,6 @@ class LinearizeTrace(Trace):
           out_avals=avals_out, symbolic_zeros=symbolic_zeros, in_zeros=in_zeros)
     tangent_nzs_out = [type(t) is not Zero for t in tangents_out]
     return map(partial(maybe_linearize_tracer, self), primals_out, tangent_nzs_out, tangents_out)
-
-  def process_call(self, call_primitive, f: lu.WrappedFun, tracers, params, /):
-    assert call_primitive.multiple_results
-    primals, tangents = unzip2(map(self.to_primal_tangent_pair, tracers))
-    nzs_in = tuple(type(t) is not Zero for t in tangents)
-    f_fwd, linearize_outs_thunk = linearize_subtrace(
-        f, self.is_vjp, self.tag, nzs_in, f.debug_info)
-
-    avals = [typeof(x) for x in primals]
-    all_fwd_results = call_primitive.bind_with_trace(
-        self.parent_trace, primals, avals, dict(params, subfuns=(f_fwd,)))
-    fwd_out_ty, nzs_out, lin_jaxpr, env, in_fwd, out_fwd = linearize_outs_thunk()
-    primal_out_avals, _, sres_out_avals = fwd_out_ty.unpack()
-    num_res_out = sum(f1 is None and f2 is None for f1, f2 in zip(in_fwd, out_fwd))
-    primals_out, non_fwd_res, structured_res = split_list_checked(
-        all_fwd_results, [len(primal_out_avals), num_res_out, len(sres_out_avals)])
-    residuals = subs_list2(in_fwd, out_fwd, primals, primals_out, non_fwd_res)
-    update_params = call_linearize_param_updaters.get(call_primitive)
-    num_new_args = len(residuals) + len(structured_res) + len(env)
-    new_params = (update_params(params, num_new_args, nzs_in)
-                  if update_params else params)
-
-    f_tangent = _get_f_tangent(lin_jaxpr, len(residuals), len(sres_out_avals))
-    nz_tangents_in = [t for (t, nz) in zip(tangents, nzs_in) if nz]
-    new_params = dict(new_params, subfuns=(lu.wrap_init(f_tangent, debug_info=lin_jaxpr.debug_info),))
-    args = (*residuals, *structured_res, *env, *nz_tangents_in)
-    avals = [typeof(x) for x in args]
-    nz_tangents_out = call_primitive.bind_with_trace(self.tangent_trace, args, avals, new_params)
-    nz_tangents_out_iter = iter(nz_tangents_out)
-    tangents_out = [next(nz_tangents_out_iter) if nz else p2tz(primal)
-                    for nz, primal in zip(nzs_out, primals_out)]
-    assert next(nz_tangents_out_iter, sentinel := object()) is sentinel
-    return map(partial(maybe_linearize_tracer, self), primals_out, nzs_out, tangents_out)
-
-
-@weakref_lru_cache
-def _get_f_tangent(lin_jaxpr, num_ures, num_sres):
-  def _f(*args):
-    consts, sres_flat, nz_tangents = split_list(args, [num_ures, num_sres])
-    return core.eval_jaxpr(lin_jaxpr, consts, *nz_tangents, *sres_flat)
-  return _f
 
 
 def maybe_linearize_tracer(trace, primal, is_nonzero, tangent):
@@ -1178,51 +1036,6 @@ def instantiate_zeros(tangent):
     return zeros_like_aval(tangent.aval)
   return tangent
 
-@lu.transformation_with_aux2
-def traceable(f, store, in_tree, *primals_and_tangents):
-  primals, tangents = tree_unflatten(in_tree, primals_and_tangents)
-  tangents = [p2tz(p) if t is None else t
-              for p, t in zip(primals, tangents)]
-  primals_out, tangents_out = f(primals, tangents)
-  tangents_out = [None if type(t) is Zero else t for t in tangents_out]
-  out_flat, out_tree = tree_flatten((primals_out, tangents_out))
-  store.store(out_tree)
-  return out_flat
-
-def call_transpose_fancy(primitive, cts, *args, call_jaxpr, **params):
-  if call_jaxpr.constvars: raise NotImplementedError
-  primals_ctrefs, specs = project_accums(args)
-  flat_args, treedef = tree_flatten((primals_ctrefs, cts))
-  cell = lambda: None
-
-  @partial(lu.wrap_init, debug_info=call_jaxpr.debug_info.with_unknown_names())
-  def transposed(*flat_args):
-    primals_ctrefs, cts = tree_unflatten(treedef, flat_args)
-    args = unproject_accums(specs, primals_ctrefs)
-    logs = backward_pass3(call_jaxpr, False, (), args, cts)
-    cts_out = [x.freeze() if isinstance(x, ValAccum) else None for x in args]
-    outs, cell.out_tree = tree_flatten((cts_out, logs))  # pyrefly: ignore[missing-attribute]
-    return outs
-
-  update_params = call_transpose_param_updaters.get(primitive)
-  if update_params:
-    params = update_params(params, [isinstance(x, GradAccum) for x in args],
-                           [type(x) is not Zero for x in cts])
-
-  out_flat = primitive.bind(*flat_args, subfuns=(transposed,), **params)
-  cts_out, logs = tree_unflatten(cell.out_tree, out_flat)  # pyrefly: ignore[missing-attribute]
-  for x, ct in zip(args, cts_out):
-    if isinstance(x, ValAccum): x.accum(ct)
-  return logs
-fancy_transposes[core.call_p] = partial(call_transpose_fancy, call_p)
-
-def _closed_call_transpose(ct, *args, call_jaxpr, **params):
-  jaxpr_, consts = call_jaxpr, call_jaxpr.consts
-  jaxpr_ = pe.convert_constvars_jaxpr(jaxpr_)
-  return call_transpose_fancy(core.closed_call_p, ct, *consts, *args,
-                              call_jaxpr=jaxpr_, **params)
-fancy_transposes[core.closed_call_p] = _closed_call_transpose
-
 def jvp_jaxpr(jaxpr: core.Jaxpr, nonzeros: Sequence[bool],
               instantiate: bool | Sequence[bool]
               ) -> tuple[core.Jaxpr, list[bool]]:
@@ -1339,20 +1152,6 @@ class CustomVJPException(Exception):
 # TODO(mattjj): remove this vestigial dict
 reducing_transposes: dict[core.Primitive, Callable] = {}
 
-# TODO(mattjj): remove this old code, used by something downstream
 def call_transpose(primitive, params, call_jaxpr: core.Jaxpr, args, ct, _):
-  if isinstance(call_jaxpr, core.Jaxpr):
-    call_jaxpr, consts = call_jaxpr, call_jaxpr.consts
-  else:
-    consts = ()
-  all_args, in_treedef = tree_flatten((consts, args, ct))
-  fun = lu.hashable_partial(
-      lu.wrap_init(backward_pass, debug_info=call_jaxpr.debug_info),
-      call_jaxpr, False)
-  fun, out_tree = flatten_fun_nokwargs(fun, in_treedef)
-  update_params = call_transpose_param_updaters.get(primitive)
-  if update_params:
-    params = update_params(params, map(is_undefined_primal, args),
-                           [type(x) is not Zero for x in ct])
-  out_flat = primitive.bind(*all_args, **dict(params, subfuns=(fun,)))
-  return tree_unflatten(out_tree(), out_flat)
+  del primitive, params
+  return backward_pass(call_jaxpr, False, call_jaxpr.consts, args, ct)

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -274,16 +274,6 @@ class BatchTrace(Trace):
     else:
       raise NotImplementedError(f"Batching rule for '{p}' not implemented")
 
-  def process_call(self, call_primitive, f, tracers, params, /):
-    assert call_primitive.multiple_results
-    vals, dims = unzip2(map(self.to_batch_info, tracers))
-    f_, dims_out = batch_subtrace(f, self.tag, self.axis_data, tuple(dims))
-
-    with core.set_current_trace(self.parent_trace):
-      vals_out = call_primitive.bind(*vals, subfuns=(f_,), **params)
-    src = source_info_util.current()
-    return [BatchTracer(self, v, d, src) for v, d in zip(vals_out, dims_out())]
-
   def process_custom_jvp_call(self, prim, fun, jvp, tracers, /, *, symbolic_zeros):
     in_vals, in_dims = unzip2(map(self.to_batch_info, tracers))
     fun, out_dims1 = batch_subtrace(fun, self.tag, self.axis_data, in_dims)

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -2788,9 +2788,9 @@ def call_lowering(fn_name, call_jaxpr: core.Jaxpr, backend,
   tokens_out = tokens_in.update_tokens(TokenSet(dict(zip(effects, tokens))))
   return out_nodes, tokens_out
 
-def core_call_lowering(ctx: LoweringRuleContext,
-                       *args, name, backend=None,
-                       call_jaxpr: core.Jaxpr):
+def core_call_lowering(
+    ctx: LoweringRuleContext, *args, name, backend=None, call_jaxpr: core.Jaxpr,
+    **_):
   effects = list(effects_lib.ordered_effects.filter_in(call_jaxpr.effects))
   tokens_in = ctx.tokens_in.subset(effects)
   out_nodes, tokens = call_lowering(
@@ -2802,11 +2802,6 @@ def core_call_lowering(ctx: LoweringRuleContext,
   return [lower_with_sharding_in_types(ctx, o, a)
           for o, a in zip(out_nodes, ctx.avals_out)]
 
-register_lowering(core.call_p, partial(core_call_lowering, name="core_call"))
-# TODO(phawkins): Not cacheable because of debug_print on TPU.
-register_lowering(core.closed_call_p,
-                  partial(core_call_lowering, name="closed_call"),
-                  cacheable=False)
 
 def map_compute_type(c_type: str) -> str:
   if c_type == "device_host":

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -48,7 +48,7 @@ from jax._src.tree_util import PyTreeDef
 from jax._src.util import (unzip2, safe_zip, safe_map, toposort, split_list,
                            merge_lists, partition_list, OrderedSet,
                            weakref_lru_cache, multi_weakref_lru_cache,
-                           subs_list, foreach, test_event)
+                           foreach, test_event)
 
 map, unsafe_map = safe_map, map
 zip, unsafe_zip = safe_zip, zip
@@ -207,61 +207,6 @@ class JaxprTrace(Trace):
       out_tracer.recipe = eqn
       return out_tracer
 
-  def process_call(self, primitive, f: lu.WrappedFun, tracers, params, /):
-    tracers = map(self.to_jaxpr_tracer, tracers)
-    rule = call_partial_eval_rules.get(primitive)
-    if rule:
-      return rule(self, primitive, f, tracers, params)
-
-    update_params = call_param_updaters.get(primitive) or (lambda p, _, __: p)
-    in_knowns, in_avals, in_consts = partition_pvals([t.pval for t in tracers])
-    # TODO(mattjj): check in_avals are consistent with f.in_type
-
-    # We want to partially evaluate this call into two calls: one evaluated now
-    # taking known values (in_consts) as inputs and producing known values
-    # (out_consts) as outputs, and the other staged out as an eqn into the jaxpr
-    # being built. The latter takes as input residuals (res) produced as outputs
-    # of the first call, shared closed-over values (env), and explicit arguments
-    # which were unknown to the first call (corresponding to in_avals).
-
-    # Wrap f to perform the partial evaluation and plumb out aux data.
-    f = f.with_unknown_names()
-    f_ = trace_to_subjaxpr_nounits_fwd(f, self.tag, f.debug_info, False)
-    f_, aux = partial_eval_wrapper_nounits(f_, tuple(in_knowns), tuple(in_avals))
-
-    # Adjust parameters (e.g. donated_invars) for the call to be evaluated now.
-    const_params = update_params(params, in_knowns, 0)
-    const_params = dict(const_params, subfuns=(f_,))
-
-    # Run the call, getting known out vals and aux data used for staged-out call
-    in_const_avals = tuple(core.typeof(c) for c in in_consts)
-    out = primitive.bind_with_trace(self.parent_trace, tuple(in_consts), in_const_avals, const_params)
-    fwds, out_knowns, out_type, jaxpr, env = aux()
-    # Split apart known outputs from the original call and non-fwded residuals.
-    out_consts, non_fwd_res = split_list(out, [sum(out_knowns)])
-    in_consts_full = in_consts
-    res = subs_list(fwds, in_consts_full, non_fwd_res)
-
-    # Create the input tracers for the staged-out (unknown-value) call.
-    res_tracers = map(self.instantiate_const, map(self.new_const, res))
-    env_tracers = map(self.to_jaxpr_tracer, env)
-    unknown_arg_tracers = [t for t in tracers if not t.is_known()]
-    # Adjust parameters (e.g. donated_invars) for the staged-out call's args.
-    num_new_args = len(res_tracers) + len(env_tracers)
-    new_jaxpr = convert_constvars_jaxpr(jaxpr)
-    staged_params = dict(params, call_jaxpr=new_jaxpr)
-    staged_params = update_params(staged_params, map(op.not_, in_knowns),
-                                  num_new_args)
-    out_tracers = [JaxprTracer(self, PartialVal.unknown(a), None)
-                   for a in out_type]
-    name_stack = self._current_truncated_name_stack()
-    source = source_info_util.current().replace(name_stack=name_stack)
-    eqn = new_eqn_recipe(self, (*res_tracers, *env_tracers, *unknown_arg_tracers),
-                         out_tracers, primitive, staged_params,
-                         core.positional_effects(new_jaxpr), source)
-    for t in out_tracers: t.recipe = eqn
-    return merge_lists(out_knowns, out_tracers, out_consts)
-
   def _current_truncated_name_stack(self):
     return source_info_util.current_name_stack()[len(self.name_stack):]
 
@@ -350,8 +295,7 @@ def partial_eval_wrapper_nounits(
   return (*out_consts, *res)
 
 custom_partial_eval_rules: dict[Primitive, Callable] = {}
-call_partial_eval_rules: dict[Primitive, Callable] = {}
-call_param_updaters: dict[Primitive, Callable[..., dict[str, Any]]] = {}
+
 
 def abstract_eval_fun(fun: Callable, *avals,
                       debug_info: core.DebugInfo, **params):
@@ -592,11 +536,6 @@ def new_eqn_recipe(trace: JaxprTrace,
                    effects: core.Effects,
                    source_info: source_info_util.SourceInfo,
                    ctx: JaxprEqnContext | None = None) -> JaxprEqnRecipe:
-  # TODO(necula): move these checks to core.check_jaxpr, and call in more places
-  if primitive.call_primitive:
-    assert "call_jaxpr" in params
-    assert ("donated_invars" not in params or
-            len(params["donated_invars"]) == len(params["call_jaxpr"].invars))
   out_avals = [t.aval for t in out_tracers]
   ctx = ctx or core.current_jaxpr_eqn_context()
   return JaxprEqnRecipe(next(trace.counter), tuple(in_tracers), map(ref, out_tracers),
@@ -1207,13 +1146,6 @@ def _closed_jaxpr_partial_eval_custom_cached(
   return (jaxpr_known_, jaxpr_staged_, unks_out, inst_out, num_res_ref,
           num_res_val, in_fwd, out_fwd)
 
-partial_eval_jaxpr_custom_rules[core.call_p] = \
-    partial(call_partial_eval_custom_rule, 'call_jaxpr',
-            lambda _, __, ___, ____, _____, x, y: (x, y))
-partial_eval_jaxpr_custom_rules[core.closed_call_p] = \
-    partial(closed_call_partial_eval_custom_rule, 'call_jaxpr',
-            lambda _, __, ___, ____, _____, ______, x, y: (x, y))
-
 
 def _jaxpr_forwarding(jaxpr: Jaxpr) -> list[int | None]:
   # Compute which inputs are just forwarded to outputs.
@@ -1376,29 +1308,6 @@ DCERule = Callable[[list[bool], JaxprEqn],
                    tuple[list[bool], Union[JaxprEqn, None]]]
 
 
-def dce_jaxpr_call_rule(used_outputs: list[bool], eqn: JaxprEqn
-                        ) -> tuple[list[bool], JaxprEqn | None]:
-  if not any(used_outputs) and not has_effects(eqn):
-    return [False] * len(eqn.invars), None
-  new_jaxpr, used_inputs = dce_jaxpr(eqn.params['call_jaxpr'], used_outputs)
-  new_params = dict(eqn.params, call_jaxpr=new_jaxpr)
-  update_params = call_param_updaters.get(eqn.primitive)
-  if update_params:
-    new_params = update_params(new_params, used_inputs, 0)
-  if not any(used_inputs) and not any(used_outputs) and not new_jaxpr.effects:
-    return used_inputs, None
-  else:
-    new_invars = [v for v, used in zip(eqn.invars, used_inputs) if used]
-    new_eqn = new_jaxpr_eqn(
-        new_invars,
-        [v for v, used in zip(eqn.outvars, used_outputs) if used],
-        eqn.primitive, new_params, core.eqn_effects(new_jaxpr, new_invars),
-        eqn.source_info, eqn.ctx)
-    return used_inputs, new_eqn
-
-dce_rules[core.call_p] = dce_jaxpr_call_rule
-
-
 @weakref_lru_cache
 def _cached_closed_call_dce(jaxpr_, used_outputs: tuple[bool, ...]
                             ) -> tuple[Jaxpr, list[bool]]:
@@ -1420,7 +1329,6 @@ def dce_jaxpr_closed_call_rule(used_outputs: list[bool], eqn: JaxprEqn
       [v for v, used in zip(eqn.outvars, used_outputs) if used],
       eqn.primitive, new_params, effects, eqn.source_info, eqn.ctx)
   return used_inputs, new_eqn
-dce_rules[core.closed_call_p] = dce_jaxpr_closed_call_rule
 
 def close_jaxpr(jaxpr: Jaxpr) -> Jaxpr:
   # Now that Jaxpr and ClosedJaxpr are merged, every jaxpr is closed: the
@@ -1883,34 +1791,6 @@ class DynamicJaxprTrace(core.Trace):
       self.frame.add_eqn(eqn)  # pyrefly: ignore[bad-argument-type]
     return out_tracers if primitive.multiple_results else out_tracers.pop()
 
-  def process_call(self, call_primitive, f: lu.WrappedFun, in_tracers,
-                   params, /):
-    source_info = source_info_util.current()
-    to_jaxpr_tracer = partial(self.to_jaxpr_tracer, source_info=source_info)
-    in_type = (tuple(typeof(t) for t in in_tracers) if f.in_type is None
-               else f.in_type)
-    f.in_type = None
-    assert in_type is not None
-    in_tracers = map(to_jaxpr_tracer, in_tracers)
-    # TODO(mattjj): check in_tracers are consistent with f.in_type annotation
-    jaxpr, out_avals, consts = _cached_trace_to_jaxpr(f, in_type)
-    if params.get('inline', False):
-      return core.eval_jaxpr(jaxpr, consts, *in_tracers,
-                             propagate_source_info=False)
-
-    new_jaxpr = convert_constvars_jaxpr(jaxpr)
-    self.frame.is_high |= new_jaxpr.is_high
-    new_params = dict(params, call_jaxpr=new_jaxpr)
-    update_params = call_param_updaters.get(call_primitive)
-    if update_params:
-      new_params = update_params(new_params, [True] * len(in_tracers),
-                                 len(consts))
-    const_tracers = map(to_jaxpr_tracer, consts)
-    return self.emit_eqn(
-        [*const_tracers, *in_tracers], out_avals, call_primitive,
-        new_params, core.positional_effects(new_params['call_jaxpr']),
-        source_info=source_info)
-
   def process_custom_jvp_call(self, prim, fun: lu.WrappedFun,
                               jvp: lu.WrappedFun, tracers, /, *,
                               symbolic_zeros: bool):
@@ -2004,12 +1884,6 @@ class DynamicJaxprTrace(core.Trace):
   def to_jaxpr(self, out_tracers: Sequence[Tracer],
                debug_info: core.DebugInfo, source_info: SourceInfo):
     return self.frame.to_jaxpr(self, out_tracers, debug_info, source_info)
-
-
-@lu.cache
-def _cached_trace_to_jaxpr(f, in_type):
-  jaxpr, out_type, consts = trace_to_jaxpr_dynamic(lu.annotate(f, in_type), in_type)
-  return jaxpr, out_type, consts
 
 
 custom_staging_rules: dict[Primitive, Callable] = {}
@@ -2491,31 +2365,18 @@ def raise_lo_outs(hi_avals, lo_outs):
   return hi_outs
 
 
-# eval_jaxpr_p is a call-like primitive parameterized by a jaxpr rather than a
-# Python callable: applying it evaluates the jaxpr, and staging it out is O(1),
-# emitting a single eqn (which stays an eval_jaxpr eqn under retracing) rather
-# than retracing the jaxpr. Its ad and batching rules live in
-# lax/eval_jaxpr.py; the primitive is defined here so that jaxpr-level
-# utilities below can use it without upward imports.
-eval_jaxpr_p = core.Primitive('eval_jaxpr')
-eval_jaxpr_p.multiple_results = True
+eval_jaxpr_p = core.eval_jaxpr_p
 
-@eval_jaxpr_p.def_effectful_abstract_eval
-def _eval_jaxpr_abstract_eval(*_, call_jaxpr):
-  return call_jaxpr.out_avals, core.positional_effects(call_jaxpr)
-
-@eval_jaxpr_p.def_impl
-def _eval_jaxpr_impl(*args, call_jaxpr):
-  return core.jaxpr_as_fun(call_jaxpr)(*args)
 dce_rules[eval_jaxpr_p] = dce_jaxpr_closed_call_rule
+dce_jaxpr_call_rule = dce_jaxpr_closed_call_rule  # alias for downstream users
 
-def _eval_jaxpr_partial_eval(trace, *in_tracers, call_jaxpr):
+def _eval_jaxpr_partial_eval(prim, trace, *in_tracers, call_jaxpr, **params):
   in_pvals = [t.pval for t in in_tracers]
   unknown_ins = [not pv.is_known() for pv in in_pvals]
   known_jaxpr, unknown_jaxpr, unknown_outs, res_avals, in_fwd_res = \
       partial_eval_jaxpr_nounits_fwd(call_jaxpr, unknown_ins, instantiate=False)
   consts = [pv.get_known() for pv in in_pvals if pv.is_known()]
-  all_known_outs = eval_jaxpr_p.bind(*consts, call_jaxpr=known_jaxpr)
+  all_known_outs = prim.bind(*consts, call_jaxpr=known_jaxpr, **params)
   known_outs, res = split_list(all_known_outs, [len(all_known_outs) - len(res_avals)])
   res_ = iter(res)
   res = [next(res_) if f is None else [*call_jaxpr.consts, *consts][f]
@@ -2526,42 +2387,35 @@ def _eval_jaxpr_partial_eval(trace, *in_tracers, call_jaxpr):
   unk_tracers_out = [JaxprTracer(trace, PartialVal.unknown(aval), None)
                      for aval in unknown_jaxpr.out_avals]
   eqn = new_eqn_recipe(trace, [*res_tracers, *unk_tracers_in], unk_tracers_out,
-                       eval_jaxpr_p, dict(call_jaxpr=unknown_jaxpr),
+                       prim, dict(params, call_jaxpr=unknown_jaxpr),
                        core.positional_effects(unknown_jaxpr),
                        source_info_util.current())
   for t in unk_tracers_out: t.recipe = eqn
   if effects.partial_eval_kept_effects.filter_in(unknown_jaxpr.effects):
     trace.effect_handles.append(EffectHandle([*unk_tracers_in, *res_tracers], eqn))  # type: ignore
   return merge_lists(unknown_outs, known_outs, unk_tracers_out)
-custom_partial_eval_rules[eval_jaxpr_p] = _eval_jaxpr_partial_eval
+custom_partial_eval_rules[eval_jaxpr_p] = partial(_eval_jaxpr_partial_eval, eval_jaxpr_p)
 
 partial_eval_jaxpr_custom_rules[eval_jaxpr_p] = \
-    partial_eval_jaxpr_custom_rules[core.closed_call_p]
+    partial(closed_call_partial_eval_custom_rule, 'call_jaxpr',
+            lambda _, __, ___, ____, _____, ______, x, y: (x, y))
 
-def _lower_and_eval(name: str, jaxpr: Jaxpr, args: Sequence[Any]) -> list[Any]:
+def _lower_and_eval(prim, jaxpr: Jaxpr, args: Sequence[Any], **params):
   lo_jaxpr = lower_jaxpr2(jaxpr)
-  lo_args = [
-      lo_val for aval, x in zip(jaxpr.in_avals, args)
-      for lo_val in aval.lower_val(x)
-  ]
-  lo_outs = eval_jaxpr_p.bind(*lo_args, call_jaxpr=lo_jaxpr)
+  lo_args = [lo_val for aval, x in zip(jaxpr.in_avals, args)
+             for lo_val in aval.lower_val(x)]
+  lo_outs = prim.bind(*lo_args, call_jaxpr=lo_jaxpr, **params)
   lo_outs_ = iter(lo_outs)
-  hi_outs = [
-      t.raise_val(*it.islice(lo_outs_, len(t.lo_ty())))
-      for t in jaxpr.out_avals
-  ]
+  hi_outs = [t.raise_val(*it.islice(lo_outs_, len(t.lo_ty())))
+             for t in jaxpr.out_avals]
   assert next(lo_outs_, None) is None
   return hi_outs
 
-def _call_jaxpr(name: str, jaxpr: Jaxpr, args: Sequence[Any]) -> list[Any]:
+def _call_jaxpr(jaxpr: Jaxpr, args: Sequence[Any]):
   if not jaxpr.is_high:
     return eval_jaxpr_p.bind(*args, call_jaxpr=jaxpr)
-  return _lower_and_eval(name, jaxpr, args)
+  return _lower_and_eval(eval_jaxpr_p, jaxpr, args)
 
-def _closed_call_to_lojax(*hi_args, call_jaxpr: Jaxpr, **_):
-  return _lower_and_eval("closed_call", call_jaxpr, hi_args)
-core.closed_call_p.to_lojax = _closed_call_to_lojax
-
-def _eval_jaxpr_to_lojax(*hi_args, call_jaxpr: Jaxpr):
-  return _lower_and_eval("eval_jaxpr", call_jaxpr, hi_args)
-eval_jaxpr_p.to_lojax = _eval_jaxpr_to_lojax
+def _eval_jaxpr_to_lojax(prim, *hi_args, call_jaxpr: Jaxpr, **params):
+  return _lower_and_eval(prim, call_jaxpr, hi_args, **params)
+eval_jaxpr_p.to_lojax = partial(_eval_jaxpr_to_lojax, eval_jaxpr_p)

--- a/jax/_src/interpreters/remat.py
+++ b/jax/_src/interpreters/remat.py
@@ -114,10 +114,6 @@ class RematTrace(core.Trace):
     else:
       return RematTracer(self, out_primal, out_primal2)
 
-  def process_call(self, call_primitive, f, tracers, params):
-    in_vals, in_vals2 = unzip2(map(self.to_val_tracer_pair, tracers))
-    raise NotImplementedError  # TODO remat_subtrace...
-
   def process_custom_jvp_call(self, prim, fun, jvp, tracers, /, *, symbolic_zeros):
     in_vals, in_vals2 = unzip2(map(self.to_val_tracer_pair, tracers))
     with core.set_current_trace(self.parent_trace):

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1395,7 +1395,7 @@ def _scan_partial_eval_custom(saveable, unks_in, inst_in, eqn: core.JaxprEqn):
 
   eqn_known = pe.new_jaxpr_eqn(
       ins_known, [*intensive_res, *out_binders_known, *extensive_res],
-      core.closed_call_p, dict(call_jaxpr=call_jaxpr),
+      core.eval_jaxpr_p, dict(call_jaxpr=call_jaxpr),
       core.eqn_effects(call_jaxpr, ins_known), eqn.source_info, eqn.ctx)
 
   # Create the staged eqn.

--- a/jax/_src/lax/eval_jaxpr.py
+++ b/jax/_src/lax/eval_jaxpr.py
@@ -21,13 +21,14 @@ from functools import partial
 
 from jax._src import ad_util
 from jax._src import core
+from jax._src import flattree as ft
 from jax._src.interpreters import ad
 from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
 from jax._src.interpreters import partial_eval as pe
 from jax._src.interpreters.partial_eval import eval_jaxpr_p
-from jax._src.tree_util import tree_leaves
-from jax._src.util import safe_map, safe_zip, split_list, subs_list
+from jax._src.tree_util import tree_leaves, tree_flatten, tree_unflatten
+from jax._src.util import safe_map, safe_zip, split_list, subs_list, weakref_lru_cache
 
 _map = safe_map
 zip = safe_zip
@@ -38,36 +39,34 @@ mlir.register_lowering(eval_jaxpr_p,
                        cacheable=False)
 
 
-def _eval_jaxpr_jvp(primals, tangents, *, call_jaxpr):
+def _eval_jaxpr_jvp(prim, primals, tangents, *, call_jaxpr, **params):
   nonzeros = [type(t) is not ad_util.Zero for t in tangents]
   jaxpr_jvp, nonzeros_out = ad.jvp_jaxpr(call_jaxpr, nonzeros, False)
   nz_tangents = [t for t, nz in zip(tangents, nonzeros) if nz]
-  outs = eval_jaxpr_p.bind(*primals, *nz_tangents, call_jaxpr=jaxpr_jvp)
+  outs = prim.bind(*primals, *nz_tangents, call_jaxpr=jaxpr_jvp, **params)
   primals_out, tangents_out = split_list(outs, [len(call_jaxpr.out_avals)])
   nz_tangents_out = iter(tangents_out)
   tangents_out = [next(nz_tangents_out) if nz else ad_util.Zero(aval.to_tangent_aval())
                   for aval, nz in zip(call_jaxpr.out_avals, nonzeros_out)]
   return primals_out, tangents_out
-ad.primitive_jvps[eval_jaxpr_p] = _eval_jaxpr_jvp
+ad.primitive_jvps[eval_jaxpr_p] = partial(_eval_jaxpr_jvp, eval_jaxpr_p)
 
-def _eval_jaxpr_batching_rule(axis_data, args, dims, *, call_jaxpr):
+def _eval_jaxpr_batch(prim, axis_data, args, dims, *, call_jaxpr, **params):
   batched = [d is not None for d in dims]
-  new_jaxpr, out_batched = batching.batch_jaxpr(call_jaxpr, axis_data, batched,
-                                                False)
-  new_args = [batching.moveaxis(x, d, 0)
-              if d is not None and d != 0 else x
+  new_jaxpr, out_batched = batching.batch_jaxpr(call_jaxpr, axis_data, batched, False)
+  new_args = [batching.moveaxis(x, d, 0) if d is not None and d != 0 else x
               for x, d in zip(args, dims)]
-  outs = eval_jaxpr_p.bind(*new_args, call_jaxpr=new_jaxpr)
+  outs = prim.bind(*new_args, call_jaxpr=new_jaxpr, **params)
   out_dims = [0 if b else None for b in out_batched]
   return outs, out_dims
-batching.fancy_primitive_batchers[eval_jaxpr_p] = _eval_jaxpr_batching_rule
+batching.fancy_primitive_batchers[eval_jaxpr_p] = partial(_eval_jaxpr_batch, eval_jaxpr_p)
 
-def _eval_jaxpr_linearize(is_vjp, nzs, *primals_in, call_jaxpr):
+def _eval_jaxpr_linearize(prim, is_vjp, nzs, *primals_in, call_jaxpr, **params):
   primal_jaxpr, out_tree, nzs_out, in_fwd_res, tangent_jaxpr = \
       ad.linearize_jaxpr(call_jaxpr, nzs, is_vjp=is_vjp)
   _, ures_avals, sres_avals = out_tree.unpack()
   num_res_out = len(ures_avals) + len(sres_avals)
-  primals_and_res = eval_jaxpr_p.bind(*primals_in, call_jaxpr=primal_jaxpr)
+  primals_and_res = prim.bind(*primals_in, call_jaxpr=primal_jaxpr, **params)
   primals_out, non_fwd_res = split_list(
       primals_and_res, [len(primals_and_res) - num_res_out])
   ures, sres_flat = split_list(non_fwd_res, [len(ures_avals)])
@@ -77,8 +76,8 @@ def _eval_jaxpr_linearize(is_vjp, nzs, *primals_in, call_jaxpr):
   def tangent_fun(res, sres, *tangents):
     sres_flat = tree_leaves(sres)
     nz_tangents = [ad.instantiate_zeros(x) for nz, x in zip(nzs, tangents) if nz]
-    nz_tangents_out = eval_jaxpr_p.bind(*res, *nz_tangents, *sres_flat,
-                                        call_jaxpr=tangent_jaxpr)
+    nz_tangents_out = prim.bind(*res, *nz_tangents, *sres_flat,
+                                call_jaxpr=tangent_jaxpr, **params)
     tangent_avals_out = [v.aval.to_tangent_aval() for v in call_jaxpr.outvars]
     nz_tangents_out_ = iter(nz_tangents_out)
     tangents_out = [next(nz_tangents_out_) if nz else ad_util.Zero(aval)
@@ -87,11 +86,34 @@ def _eval_jaxpr_linearize(is_vjp, nzs, *primals_in, call_jaxpr):
     return tangents_out
 
   return primals_out, nzs_out, res, sres, tangent_fun
-ad.primitive_linearizations[eval_jaxpr_p] = _eval_jaxpr_linearize
+ad.primitive_linearizations[eval_jaxpr_p] = partial(_eval_jaxpr_linearize, eval_jaxpr_p)
 
-def _eval_jaxpr_transpose(ct, *args, call_jaxpr):
-  jaxpr_, consts = call_jaxpr, call_jaxpr.consts
-  jaxpr_ = pe.convert_constvars_jaxpr(jaxpr_)
-  return ad.call_transpose_fancy(core.closed_call_p, ct, *consts, *args,
-                                 call_jaxpr=jaxpr_)
-ad.fancy_transposes[eval_jaxpr_p] = _eval_jaxpr_transpose
+def _eval_jaxpr_transpose(prim, ct, *args, call_jaxpr, **params):
+  primals_ctrefs, specs = ad.project_accums(args)
+  in_flat, in_tree = tree_flatten((primals_ctrefs, ct))
+  in_avals = [core.typeof(x) for x in in_flat]
+  trans_jaxpr, out_tree = _transpose_jaxpr(call_jaxpr, in_tree, (*in_avals,), specs)
+  outs = prim.bind(*in_flat, call_jaxpr=trans_jaxpr, **params)
+  cts_out, logs = tree_unflatten(out_tree, outs)
+  for x, ct in zip(args, cts_out):
+    if isinstance(x, ad.ValAccum):
+      x.accum(ct)
+  return logs
+ad.fancy_transposes[eval_jaxpr_p] = partial(_eval_jaxpr_transpose, eval_jaxpr_p)
+
+# TODO(mattjj): this is a copy of xla_metadata.py's _transpose_jaxpr, dedupe!
+# also dedupe with fused.py, compute_on.py... we have several call prims!
+@weakref_lru_cache
+def _transpose_jaxpr(jaxpr, in_tree, in_avals, specs):
+  out_tree = None
+  def transposed(*in_flat):
+    nonlocal out_tree
+    primals_ctrefs, cts_in = tree_unflatten(in_tree, in_flat)
+    args = ad.unproject_accums(specs, primals_ctrefs)
+    logs = ad.backward_pass3(jaxpr, False, jaxpr.consts, args, cts_in)
+    cts_out = [x.freeze() if isinstance(x, ad.ValAccum) else None for x in args]
+    outs, out_tree = tree_flatten((cts_out, logs))
+    return outs
+  dbg = jaxpr.debug_info.with_unknown_names()
+  trans_jaxpr, _ = pe.trace_to_jaxpr(transposed, ft.flatten_args(*in_avals), dbg)
+  return trans_jaxpr, out_tree

--- a/jax/_src/pallas/mosaic_gpu/primitives.py
+++ b/jax/_src/pallas/mosaic_gpu/primitives.py
@@ -3193,19 +3193,16 @@ def broadcasted_iota(
   return result
 
 
-@lowering.register_lowering_rule(jax_core.closed_call_p, mgpu.LoweringSemantics.Lane)
-@lowering.register_lowering_rule(jax_core.closed_call_p, mgpu.LoweringSemantics.Warpgroup)
 @lowering.register_lowering_rule(pe.eval_jaxpr_p, mgpu.LoweringSemantics.Lane)
 @lowering.register_lowering_rule(pe.eval_jaxpr_p, mgpu.LoweringSemantics.Warpgroup)
-def _closed_call_lowering_rule(ctx, *args, call_jaxpr: jax_core.Jaxpr):
+def _eval_jaxpr_lowering_rule(ctx, *args, call_jaxpr: jax_core.Jaxpr):
   if call_jaxpr.consts: raise NotImplementedError
   return lowering.lower_jaxpr_to_mosaic_gpu(
       ctx.module_ctx, ctx.launch_ctx, call_jaxpr, args)
 
 
-@lowering._register_resource_estimator(jax_core.closed_call_p)
 @lowering._register_resource_estimator(pe.eval_jaxpr_p)
-def _closed_call_resource_estimator(ctx, *args, call_jaxpr):
+def _eval_jaxpr_resource_estimator(ctx, *args, call_jaxpr):
   del args  # Unused.
   if call_jaxpr.consts: raise NotImplementedError
   return lowering._estimate_resources(ctx, call_jaxpr)

--- a/jax/_src/pallas/triton/lowering.py
+++ b/jax/_src/pallas/triton/lowering.py
@@ -473,7 +473,7 @@ def lower_fun(
     jaxpr, _ = pe.trace_to_jaxpr(
         fn, in_avals_ft, debug_info=debug_info, requires_low=True
     )
-    out = _closed_call_lowering_rule(ctx, *args, call_jaxpr=jaxpr)
+    out = _eval_jaxpr_lowering_rule(ctx, *args, call_jaxpr=jaxpr)
     return out if multiple_results else out[0]
 
   return f_lowered
@@ -2600,10 +2600,9 @@ def _reshard_lowering_rule(ctx, x, *, dst_sharding, concrete_mesh):
   return x
 
 
-@register_lowering(jax_core.closed_call_p)
 @register_lowering(pe.eval_jaxpr_p)
 @register_lowering(custom_derivatives.custom_jvp_call_p)
-def _closed_call_lowering_rule(
+def _eval_jaxpr_lowering_rule(
     ctx: LoweringRuleContext, *args, call_jaxpr, **_
 ):
   jaxpr, consts = call_jaxpr, call_jaxpr.consts

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -1443,10 +1443,6 @@ class ShardMapTrace(core.Trace):
     return out_vals.map2(out_mats,
                          lambda val, vma: ShardMapTracer(self, vma, val))
 
-  def process_call(self, call_primitive, fun, tracers, params, /):
-    with core.set_current_trace(self):
-      return fun.call_wrapped(*tracers)
-
   def process_custom_jvp_call(self, prim, fun, jvp, tracers, /, *, symbolic_zeros):
     # Since ShardMapTrace is only used as a base main, we can drop the jvp.
     del prim, jvp, symbolic_zeros

--- a/jax/_src/stages.py
+++ b/jax/_src/stages.py
@@ -436,7 +436,7 @@ class Traced(Stage):
 
   def __call__(self, *args, **kwargs):
     args_flat = tree_util.tree_leaves_checked(self.in_tree, (args, kwargs))
-    out_flat = pe._call_jaxpr(self.fun_name, self.jaxpr, args_flat)
+    out_flat = pe._call_jaxpr(self.jaxpr, args_flat)
     return tree_unflatten(self.out_tree, out_flat)
 
   @property

--- a/jax/_src/state/discharge.py
+++ b/jax/_src/state/discharge.py
@@ -211,8 +211,6 @@ def register_discharge_rule(prim: core.Primitive):
   return register
 
 
-
-
 def _eval_jaxpr_discharge_state(
     jaxpr: core.Jaxpr, should_discharge: Sequence[bool], consts: Sequence[Any],
     strip_memory_space: bool, *args: Any):
@@ -660,13 +658,11 @@ def _cached_closed_jaxpr_discharge(closed_jaxpr: core.Jaxpr, *, strip_memory_spa
                      debug_info=discharged_closed_jaxpr.debug_info)
   return discharged_closed_jaxpr, num_outs, fun
 
-def _closed_call_discharge_rule(
-    prim: core.Primitive, ctx: DischargeContext, *args, **params):
-  discharged_jaxpr, num_outs, fun = _cached_closed_jaxpr_discharge(
-      params['call_jaxpr'], strip_memory_space=ctx.strip_memory_space)
-  subfuns = dict(subfuns=(fun,)) if prim.call_primitive else {}
-  out_and_ref_vals = prim.bind(
-      *args, **subfuns, **dict(params, call_jaxpr=discharged_jaxpr))
+def _eval_jaxpr_discharge_rule(
+    prim, ctx: DischargeContext, *args, call_jaxpr: core.Jaxpr, **params):
+  discharged_jaxpr, num_outs, _ = _cached_closed_jaxpr_discharge(
+      call_jaxpr, strip_memory_space=ctx.strip_memory_space)
+  out_and_ref_vals = prim.bind(*args, call_jaxpr=discharged_jaxpr, **params)
   out_vals, ref_vals = split_list(out_and_ref_vals, [num_outs])
   ref_vals_iter = iter(ref_vals)
   new_invals = tuple(next(ref_vals_iter) if isinstance(aval, AbstractRef)
@@ -674,38 +670,12 @@ def _closed_call_discharge_rule(
   sentinel = object()
   assert next(ref_vals_iter, sentinel) is sentinel
   return new_invals, out_vals
-register_discharge_rule(core.closed_call_p)(
-    partial(_closed_call_discharge_rule, core.closed_call_p))
-register_discharge_rule(pe.eval_jaxpr_p)(
-    partial(_closed_call_discharge_rule, pe.eval_jaxpr_p))
+register_discharge_rule(pe.eval_jaxpr_p)(partial(_eval_jaxpr_discharge_rule, pe.eval_jaxpr_p))
 
-def _call_primitive_discharge_rule(
-    prim: core.Primitive,
-    ctx: DischargeContext, *args,
-    call_jaxpr: core.Jaxpr, **kwargs):
-  closed_call_jaxpr = call_jaxpr
-  discharged_closed_jaxpr, num_outs, fun = _cached_closed_jaxpr_discharge(
-      closed_call_jaxpr, strip_memory_space=ctx.strip_memory_space)
-  discharged_call_jaxpr = discharged_closed_jaxpr
-  discharged_consts = discharged_closed_jaxpr.consts
-  discharged_call_jaxpr = pe.convert_constvars_jaxpr(discharged_call_jaxpr)
-  out_and_ref_vals = prim.bind(
-      *discharged_consts,
-      *args,
-      subfuns=(fun,),
-      call_jaxpr=discharged_call_jaxpr,
-      **kwargs,
-  )
-  out_vals, ref_vals = split_list(out_and_ref_vals, [num_outs])
-  ref_vals_iter = iter(ref_vals)
-  new_invals = tuple(next(ref_vals_iter) if isinstance(aval, AbstractRef)
-                     else None for aval in ctx.in_avals)
-  sentinel = object()
-  assert next(ref_vals_iter, sentinel) is sentinel
-  return new_invals, out_vals
-register_discharge_rule(core.call_p)(
-    partial(_call_primitive_discharge_rule, core.call_p)
-)
+
+def _call_primitive_discharge_rule(prim, ctx, *args, call_jaxpr, **params):
+  del prim, params  # alias for downstream users of the old call discharge rule
+  return _eval_jaxpr_discharge_rule(ctx, *args, call_jaxpr=call_jaxpr)
 
 
 # # `run_state`

--- a/jax/extend/core/__init__.py
+++ b/jax/extend/core/__init__.py
@@ -36,7 +36,6 @@ from jax._src.core import (
   Token as Token,
   TraceTag as TraceTag,
   Var as Var,
-  call_impl as call_impl,
   check_jaxpr as check_jaxpr,
   concrete_or_error as concrete_or_error,
   find_top_trace as find_top_trace,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6389,9 +6389,10 @@ class RematTest(jtu.JaxTestCase):
     def named_call(f):
       def named_f(*args):
         my_f = lambda: (f(*args),)
-        f_ = lu.wrap_init(
-            my_f, debug_info=api_util.debug_info("test_remat", my_f, (), {}))
-        out, = core.call_p.bind(subfuns=(f_,))
+        dbg = api_util.debug_info("test_remat", my_f, (), {})
+        jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
+            lu.wrap_init(my_f, debug_info=dbg), [])
+        out, = core.eval_jaxpr_p.bind(*consts, call_jaxpr=jaxpr)
         return out
       return named_f
 
@@ -6444,9 +6445,10 @@ class RematTest(jtu.JaxTestCase):
     @jax_util.curry
     def call(f, *args):
       my_f = lambda *args: [f(*args)]
-      sub = lu.wrap_init(
-        my_f, debug_info=api_util.debug_info("test_remat", my_f, args, {}))
-      return core.call(*args, name='foo', subfuns=(sub,))[0]
+      dbg = api_util.debug_info("test_remat", my_f, args, {})
+      jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
+          lu.wrap_init(my_f, debug_info=dbg), [core.typeof(x) for x in args])
+      return core.eval_jaxpr_p.bind(*consts, *args, call_jaxpr=jaxpr)[0]
 
     f = call(add_one)
     g = jax.remat(lambda x: add_one(f(x)))
@@ -9286,6 +9288,24 @@ class EvalJaxprPrimitiveTest(jtu.JaxTestCase):
       return self._bind_eval_jaxpr(lambda x: [jnp.sin(x)], x)[0]
     x = jnp.array(1.0)
     self.assertAllClose(jax.jit(g)(x), jnp.sin(x))
+
+  def test_eval_jaxpr_linearize_of_while(self):
+    # JaxprTrace partial eval must split eval_jaxpr eqns into known and
+    # unknown parts rather than staging them atomically
+    def f(x):
+      def body(c):
+        i, v = c
+        v2 = self._bind_eval_jaxpr(lambda u: [jnp.sin(u) * 2.0], v)[0]
+        return i + 1, v2
+      _, y = lax.while_loop(lambda c: c[0] < 3, body, (0, x))
+      return y
+
+    x = jnp.float32(1.)
+    ref = lambda v: jnp.sin(jnp.sin(jnp.sin(v) * 2.) * 2.) * 2.
+    y, lin = jax.linearize(f, x)
+    y_ref, lin_ref = jax.linearize(ref, x)
+    self.assertAllClose(y, y_ref)
+    self.assertAllClose(lin(jnp.float32(1.)), lin_ref(jnp.float32(1.)))
 
 
 if __name__ == '__main__':

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -42,21 +42,13 @@ __ = pe.PartialVal.unknown(ShapedArray((), np.float32))
 def call(f, *args):
   return jit(f)(*args)
 
+@util.curry
 def core_call(f, *args):
   args, in_tree = jax.tree.flatten(args)
   dbg = debug_info("core_call_test", f, args, {})
   f, out_tree = flatten_fun_nokwargs(lu.wrap_init(f, debug_info=dbg), in_tree)
-  out = core.call_p.bind(*args, subfuns=(f,))
-  return jax.tree.unflatten(out_tree(), out)
-# call = core_call
-core_call = util.curry(core_call)
-
-@util.curry
-def core_closed_call(f, *args):
-  args, in_tree = jax.tree.flatten(args)
-  dbg = debug_info("core_closed_call_test", f, args, {})
-  f, out_tree = flatten_fun_nokwargs(lu.wrap_init(f, debug_info=dbg), in_tree)
-  out = core.closed_call_p.bind(*args, subfuns=(f,))
+  jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(f, [core.typeof(x) for x in args])
+  out = core.eval_jaxpr_p.bind(*consts, *args, call_jaxpr=jaxpr)
   return jax.tree.unflatten(out_tree(), out)
 
 def simple_fun(x, y):
@@ -150,9 +142,6 @@ for ts in test_specs_base:
   test_specs.append(CallSpec(core_call(ts.fun), ts.args))
   test_specs.append(CallSpec(core_call(jit(ts.fun)), ts.args))
   test_specs.append(CallSpec(core_call(core_call(ts.fun)), ts.args))
-  test_specs.append(CallSpec(core_closed_call(ts.fun), ts.args))
-  test_specs.append(CallSpec(core_closed_call(jit(ts.fun)), ts.args))
-  test_specs.append(CallSpec(core_closed_call(core_closed_call(ts.fun)), ts.args))
   test_specs.append(CallSpec(partial(jvp_unlinearized, ts.fun),
                              (ts.args, ts.args)))
 

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -538,7 +538,10 @@ class HijaxTest(jtu.JaxTestCase):
       flat_f, out_tree = api_util.flatten_fun_nokwargs(
           lu.wrap_init(f, debug_info=dbg), in_tree
       )
-      out = core.closed_call_p.bind(*flat_x, subfuns=(flat_f,))
+      from jax._src.interpreters import partial_eval as pe
+      jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
+          flat_f, [core.typeof(v) for v in flat_x])
+      out = core.closed_call_p.bind(*consts, *flat_x, call_jaxpr=jaxpr)
       return jax.tree.unflatten(out_tree(), out)
 
     res = test_fn(qx)
@@ -570,7 +573,10 @@ class HijaxTest(jtu.JaxTestCase):
     def test_fn(arr):
       dbg = api_util.debug_info('test_closed_call_low_io', f, [arr], {})
       f_wrapped = lu.wrap_init(f, debug_info=dbg)
-      (out,) = core.closed_call_p.bind(arr, subfuns=(f_wrapped,))
+      from jax._src.interpreters import partial_eval as pe
+      jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
+          f_wrapped, [core.typeof(arr)])
+      (out,) = core.closed_call_p.bind(*consts, arr, call_jaxpr=jaxpr)
       return out
 
     res = test_fn(x)

--- a/tests/jaxpr_effects_test.py
+++ b/tests/jaxpr_effects_test.py
@@ -167,8 +167,9 @@ class HigherOrderPrimitiveTest(jtu.JaxTestCase):
         effect_p.bind(effect=bar_effect)
         return [x]
       dbg = api_util.debug_info("test", f_, (2.,), {})
-      return core.call(
-          x, subfuns=(lu.wrap_init(f_, debug_info=dbg),))[0]
+      call_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
+          lu.wrap_init(f_, debug_info=dbg), [core.typeof(x)])
+      return core.eval_jaxpr_p.bind(*consts, x, call_jaxpr=call_jaxpr)[0]
     jaxpr = jax.make_jaxpr(f)(2.)
     self.assertIn(foo_effect, jaxpr.effects)
     self.assertIn(bar_effect, jaxpr.effects)

--- a/tests/name_stack_test.py
+++ b/tests/name_stack_test.py
@@ -21,6 +21,7 @@ import jax.numpy as jnp
 from jax._src import core
 from jax._src import linear_util as lu
 from jax._src import test_util as jtu
+from jax._src.interpreters import partial_eval as pe
 
 jax.config.parse_flags_with_absl()
 
@@ -89,13 +90,14 @@ class NameStackTest(jtu.JaxTestCase):
         return [x + 1]
       sub = lu.wrap_init(
         _f, debug_info=api_util.debug_info("test", _f, (0,), {}))
-      return core.call(x, subfuns=(sub,))[0]
+      jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(sub, [core.typeof(x)])
+      return core.eval_jaxpr_p.bind(*consts, x, call_jaxpr=jaxpr)[0]
 
     jaxpr = jax.make_jaxpr(f)(2)
     self.assertEqual(str(jaxpr.eqns[0].params['call_jaxpr'].eqns[0].source_info.name_stack), 'bar')
 
     hlo_text = _get_hlo(f)(2)
-    self.assertIn('jit(f)/foo/call', hlo_text)
+    self.assertIn('jit(f)/foo/eval_jaxpr', hlo_text)
     self.assertIn('bar/add', hlo_text)
 
   def test_jit_jaxpr_should_not_store_outer_name_stack(self):

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -2057,7 +2057,8 @@ class ShardMapTest(jtu.JaxTestCase):
       sub = lu.wrap_init(
         lambda x: [2. * x],
         debug_info=api_util.debug_info("test", lambda x: [2. * x], (x,), {}))
-      return core.call_p.bind(x, subfuns=(sub,))[0] * x
+      jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(sub, [core.typeof(x)])
+      return core.call_p.bind(*consts, x, call_jaxpr=jaxpr)[0] * x
 
     mesh = jtu.create_mesh((4,), ('x',))
     g = shard_map(f, mesh=mesh, in_specs=(P('x'),), out_specs=P('x'))
@@ -2076,7 +2077,8 @@ class ShardMapTest(jtu.JaxTestCase):
       sub = lu.wrap_init(
         lambda: [2. * x],
         debug_info=api_util.debug_info("test", lambda: [2. * x], (), {}))
-      return core.call_p.bind(subfuns=(sub,))[0] * x
+      jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(sub, [])
+      return core.call_p.bind(*consts, call_jaxpr=jaxpr)[0] * x
 
     x = jnp.arange(4.)
     y = f(x)

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -850,7 +850,9 @@ class StateDischargeTest(jtu.JaxTestCase):
       def g(x):
         y_ref[...] = x + 1.0
         return []
-      return core.call_p.bind(x, subfuns=(wrap_init(g, 1),))
+      jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(
+          wrap_init(g, 1), [core.typeof(x)])
+      return core.call_p.bind(*consts, x, call_jaxpr=jaxpr)
 
     y_ref_aval = shaped_array_ref((), jnp.float32)
     x_aval = core.ShapedArray((), jnp.float32)
@@ -1499,7 +1501,8 @@ class StateControlFlowTest(jtu.JaxTestCase):
       y_ref = jax.new_ref(jnp.zeros_like(x))
       g_ = partial(g, y_ref)
       sub = lu.wrap_init(g_, debug_info=api_util.debug_info("f", g, (x,), {}))
-      return prim.bind(x, subfuns=(sub,))[0]
+      jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(sub, [core.typeof(x)])
+      return prim.bind(*consts, x, call_jaxpr=jaxpr)[0]
     out = f(4.)
     np.testing.assert_array_equal(out, jnp.exp(4.))
 


### PR DESCRIPTION
That also means we can remove final-style call processing functions. Had to leave in some stubs/aliases for downstream users.