### PR TITLE
Don't overwrite XLA_FLAGS-disabled HLO passes when disabling the remat pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     all. The amax outputs are whole-batch statistics and do not carry the
     vmap axis; vmap over the scale/descale operands raises a clear
     `NotImplementedError`.
+  * Setting `jax_compiler_enable_remat_pass` to `False` now adds
+    `rematerialization` to the set of disabled XLA passes instead of
+    overwriting it, so HLO passes disabled via
+    `XLA_FLAGS=--xla_disable_hlo_passes=...` stay disabled
+    ({jax-issue}`#37391`).
 
 ## JAX 0.11.0 (July 16, 2026)
 

--- a/jax/_src/compiler.py
+++ b/jax/_src/compiler.py
@@ -98,6 +98,19 @@ CompileOptions = xc.CompileOptions
 logger = logging.getLogger(__name__)
 
 
+def _add_disabled_hlo_pass(disabled_passes: str, pass_name: str) -> str:
+  """Adds a pass to a comma-separated pass list, preserving existing entries.
+
+  ``DebugOptions.xla_disable_hlo_passes`` may already hold passes the user
+  disabled via ``XLA_FLAGS=--xla_disable_hlo_passes=...``; those must not be
+  overwritten. Entries are stripped because XLA matches pass names exactly.
+  """
+  passes = [p.strip() for p in disabled_passes.split(",") if p.strip()]
+  if pass_name not in passes:
+    passes.append(pass_name)
+  return ",".join(passes)
+
+
 def _get_cross_compile_backend(compile_only_backend):
   """Returns a real backend for cross-compilation via a real client.
 
@@ -254,7 +267,8 @@ def get_compile_options(
     debug_options.xla_test_all_input_layouts = False
 
   if not config.enable_remat_opt_pass.value:
-    debug_options.xla_disable_hlo_passes = "rematerialization"
+    debug_options.xla_disable_hlo_passes = _add_disabled_hlo_pass(
+        debug_options.xla_disable_hlo_passes, "rematerialization")
 
   # XLA-AutoFDO profile version: precedence order is:
   # 1. Whatever --jax_xla_profile_version is set to.

--- a/tests/xla_bridge_test.py
+++ b/tests/xla_bridge_test.py
@@ -14,6 +14,10 @@
 
 import os
 import platform
+import subprocess
+import sys
+import textwrap
+import unittest
 
 from absl import logging
 from absl.testing import absltest
@@ -112,6 +116,74 @@ class XlaBridgeTest(jtu.JaxTestCase):
     self.assertEqual(c1str, c1.SerializeAsString())
     # Map order does not matter.
     self.assertEqual(c1str, c2.SerializeAsString())
+
+  def test_add_disabled_hlo_pass(self):
+    self.assertEqual(
+        compiler._add_disabled_hlo_pass("", "rematerialization"),
+        "rematerialization",
+    )
+    self.assertEqual(
+        compiler._add_disabled_hlo_pass(
+            "scalar-constant-sinker", "rematerialization"
+        ),
+        "scalar-constant-sinker,rematerialization",
+    )
+    # No duplicates, and entries are normalized (XLA matches names exactly,
+    # so a leading space would make a pass name unmatchable).
+    self.assertEqual(
+        compiler._add_disabled_hlo_pass(
+            "scalar-constant-sinker, rematerialization", "rematerialization"
+        ),
+        "scalar-constant-sinker,rematerialization",
+    )
+
+  def test_disable_remat_pass(self):
+    # Note: compile_options must outlive debug_options, which is a view
+    # into it that does not keep it alive.
+    with config.enable_remat_opt_pass(False):
+      compile_options = compiler.get_compile_options(
+          num_replicas=1, num_partitions=1
+      )
+      debug_options = compile_options.executable_build_options.debug_options
+      disabled = debug_options.xla_disable_hlo_passes.split(",")
+      self.assertEqual(disabled.count("rematerialization"), 1)
+    with config.enable_remat_opt_pass(True):
+      compile_options = compiler.get_compile_options(
+          num_replicas=1, num_partitions=1
+      )
+      debug_options = compile_options.executable_build_options.debug_options
+      self.assertNotIn(
+          "rematerialization",
+          debug_options.xla_disable_hlo_passes.split(","),
+      )
+
+  @unittest.skipIf(platform.system() == "Windows",
+                   "Subprocess test doesn't work on Windows")
+  def test_disable_remat_pass_preserves_disabled_hlo_passes(self):
+    # https://github.com/jax-ml/jax/issues/37391: disabling the remat pass
+    # must add to xla_disable_hlo_passes, not overwrite passes the user
+    # disabled via XLA_FLAGS. XLA_FLAGS is parsed once at initialization,
+    # so the end-to-end check needs a fresh process.
+    if sys.executable is None:
+      raise self.skipTest("test requires access to python binary")
+    program = textwrap.dedent("""
+        import jax
+        jax.config.update("jax_compiler_enable_remat_pass", False)
+        from jax._src import compiler
+        opts = compiler.get_compile_options(num_replicas=1, num_partitions=1)
+        print(opts.executable_build_options.debug_options.xla_disable_hlo_passes)
+    """)
+    env = dict(
+        os.environ,
+        XLA_FLAGS="--xla_disable_hlo_passes=scalar-constant-sinker",
+    )
+    p = subprocess.run(
+        [sys.executable, "-c", program], env=env,
+        capture_output=True, text=True, check=True,
+    )
+    disabled = p.stdout.strip().split(",")
+    self.assertIn("scalar-constant-sinker", disabled)
+    self.assertIn("rematerialization", disabled)
 
   def test_local_devices(self):
     self.assertNotEmpty(xb.local_devices())


### PR DESCRIPTION
Fixes #37391

Setting jax_compiler_enable_remat_pass to False wrote "rematerialization" into debug_options.xla_disable_hlo_passes with a plain assignment, so any passes the user had disabled through XLA_FLAGS=--xla_disable_hlo_passes=... were silently dropped.

Now the pass is appended to whatever is already there. Entries get stripped and deduped since XLA matches pass names exactly, a leading space would make a name unmatchable.

Added regression tests in tests/xla_bridge_test.py: unit cases for the append logic, the get_compile_options output for both values of the flag, and a subprocess test that sets XLA_FLAGS for real (it is parsed once at startup, so the end-to-end check needs a fresh process). The subprocess test fails on the old code with exactly the reported clobbering. Plus a CHANGELOG entry.

One thing left as is: passing xla_disable_hlo_passes through compiler_options / env_options_overrides still replaces the field at compile time in XLA itself. That path has override semantics on purpose and is untouched here.