### PR TITLE
Add --init to docker options in ROCm CI container workflows

### DIFF
--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -119,6 +119,7 @@ jobs:
       volumes:
         - /data:/data
       options: >-
+        --init
         --device=/dev/kfd
         --device=/dev/dri
         --security-opt seccomp=unconfined

--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -127,6 +127,7 @@ jobs:
       volumes:
         - /data:/data
       options: >-
+        --init
         --security-opt seccomp=unconfined
         --shm-size 64G
 

--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -133,7 +133,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
+      options: --init --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
     name: "${{ (contains(inputs.runner, 'gfx950.1') && 'gfx950.1') ||
         (contains(inputs.runner, 'gfx950.4') && 'gfx950.4') ||
         (contains(inputs.runner, 'gfx950.8') && 'gfx950.8') }}, ROCm ${{ inputs.rocm-version }}, py${{ inputs.python }}"


### PR DESCRIPTION
## Summary
- Adds `--init` to the `options:` field of the GHA `container:` blocks in `pytest_rocm.yml`, `bazel_rocm.yml`, and `build_rocm_artifacts.yml`.
- ROCm CI containers have been suffering from very slow shutdown times (40+ minutes in some cases). Without an init process as PID 1, orphaned/zombie child processes are never reaped, which can cause containers to hang on teardown.
- `build/rocm/ci_build` already carries a comment (`bazel times out without --init, probably blocking on a zombie PID`) documenting this exact failure mode for the local dev docker-run path — `--init` was added there but never propagated to the GHA container jobs used by actual CI. This PR closes that gap.

## Test plan
- [ ] Confirm the ROCm CI workflows run successfully with `--init` set
- [ ] Compare container shutdown/teardown times before and after this change across a few CI runs