### PR TITLE
ROCm CI: add --init to container jobs to fix slow/zombie teardown

### DIFF
--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -125,6 +125,7 @@ jobs:
         --group-add video
         --shm-size 64G
         --env-file /etc/podinfo/gha-gpu-isolation-settings
+        --init
 
     env:
       JAXCI_CLONE_MAIN_XLA: ${{ inputs.clone_main_xla }}

--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -129,6 +129,7 @@ jobs:
       options: >-
         --security-opt seccomp=unconfined
         --shm-size 64G
+        --init
 
     env:
       JAXCI_HERMETIC_PYTHON_VERSION: "${{ inputs.python }}"

--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -133,7 +133,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
+      options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings --init
     name: "${{ (contains(inputs.runner, 'gfx950.1') && 'gfx950.1') ||
         (contains(inputs.runner, 'gfx950.4') && 'gfx950.4') ||
         (contains(inputs.runner, 'gfx950.8') && 'gfx950.8') }}, ROCm ${{ inputs.rocm-version }}, py${{ inputs.python }}"


### PR DESCRIPTION
## What

Adds `--init` to the GitHub Actions `container:` `options:` for the ROCm CI workflows:

- `.github/workflows/bazel_rocm.yml` (job `run-tests`)
- `.github/workflows/build_rocm_artifacts.yml` (job `build-artifacts`)
- `.github/workflows/pytest_rocm.yml` (job `run-tests`)

## Why

ROCm CI containers can be very slow to shut down (40+ minutes in some cases). Without an init process as PID 1, orphaned/zombie child processes are never reaped, which can hang the container on teardown. Adding `--init` runs `tini` as PID 1 so it reaps zombies and containers tear down promptly.

This failure mode is already documented in `build/rocm/ci_build` for the local dev docker-run path:

```python
# NOTE(mrodden): bazel times out without --init, probably blocking on a zombie PID
cmd.extend(
    [
        "--init",
        "--rm",
        image_name,
```

`--init` was added there but never propagated to the GHA `container:` jobs used by actual CI. This PR closes that gap.

Observed live on AMD's DOKS MI350X Actions runners: job containers stuck in teardown for tens of minutes with the runner agent's `docker stop` / pod teardown blocked on unreapable processes.

## Test plan

- Confirm the ROCm CI workflows (`bazel_rocm`, `build_rocm_artifacts`, `pytest_rocm`) run successfully with `--init` in the container options.
- Compare container teardown times before/after: expect the multi-minute (up to 40+ min) teardown hangs to disappear now that zombie PIDs are reaped by the init process.
- YAML validated with `yaml.safe_load`; each container job has `--init` exactly once (no duplicates).