### PR TITLE
[OneAPI GPU] Add python and buffer callback support for OneAPI

### DIFF
--- a/jax/_src/buffer_callback.py
+++ b/jax/_src/buffer_callback.py
@@ -240,11 +240,12 @@ def _buffer_callback_lowering(
       "cpu": "xla_buffer_python_cpu_callback",
       "cuda": "xla_buffer_python_gpu_callback",
       "rocm": "xla_buffer_python_gpu_callback",
+      "oneapi": "xla_buffer_python_gpu_callback",
   }.get(platform)
   if target_name is None:
     raise ValueError(f"`buffer_callback` not supported on {platform} backend.")
 
-  if command_buffer_compatible and platform in ("cuda", "rocm"):
+  if command_buffer_compatible and platform in ("cuda", "rocm", "oneapi"):
     target_name += "_cmd_buffer"
 
   def wrapped_callback(exec_ctx, *args: Any):

--- a/jax/_src/callback.py
+++ b/jax/_src/callback.py
@@ -797,11 +797,11 @@ def emit_python_callback(
   if len(ctx.module_context.platforms) > 1:
     raise NotImplementedError("multi-platform lowering for python_callback")
   platform = ctx.module_context.platforms[0]
-  if platform not in {"cpu", "cuda", "rocm", "tpu"}:
+  if platform not in {"cpu", "cuda", "rocm", "tpu", "oneapi"}:
     raise ValueError(
         f"`EmitPythonCallback` not supported on {platform} backend.")
   if partitioned:
-    if platform not in {"cpu", "cuda", "rocm"}:
+    if platform not in {"cpu", "cuda", "rocm", "oneapi"}:
       raise NotImplementedError(
           f"Partitioned callback not implemented on {platform} backend.")
     if result_avals:
@@ -860,7 +860,7 @@ def emit_python_callback(
         for result_aval in result_avals]
     return outputs, token, None
 
-  device = "gpu" if platform in {"cuda", "rocm"} else "cpu"
+  device = "gpu" if platform in {"cuda", "rocm", "oneapi"} else "cpu"
   partition = "_partitioned" if partitioned else ""
   call_target_name = f"xla_ffi{partition}_python_{device}_callback"
   if token:

--- a/jaxlib/gpu/py_client_gpu.cc
+++ b/jaxlib/gpu/py_client_gpu.cc
@@ -295,6 +295,8 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
     kXlaBufferPythonGpuCallback,
 #ifdef JAX_GPU_CUDA
     (jax::XlaBufferCallback<kDLCUDA>),
+#elif defined(JAX_GPU_ONEAPI)
+    (jax::XlaBufferCallback<kDLOneAPI>),
 #else
     (jax::XlaBufferCallback<kDLROCM>),
 #endif
@@ -310,6 +312,8 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
     kXlaBufferPythonGpuCallbackCmdBuffer,
 #ifdef JAX_GPU_CUDA
     (jax::XlaBufferCallback<kDLCUDA>),
+#elif defined(JAX_GPU_ONEAPI)
+    (jax::XlaBufferCallback<kDLOneAPI>),
 #else
     (jax::XlaBufferCallback<kDLROCM>),
 #endif

--- a/jaxlib/oneapi/BUILD.bazel
+++ b/jaxlib/oneapi/BUILD.bazel
@@ -177,14 +177,57 @@ py_library(
     ],
 )
 
+sycl_library(
+    name = "py_client_gpu",
+    srcs = ["//jaxlib/gpu:py_client_gpu.cc"],
+    hdrs = ["//jaxlib/gpu:py_client_gpu.h"],
+    copts = [
+        "-fexceptions",
+        "-fno-strict-aliasing",
+    ],
+    features = ["-use_header_modules"],
+    deps = [
+        ":oneapi_gpu_kernel_helpers",
+        ":oneapi_gpu_runtime",
+        ":oneapi_vendor",
+        "//jaxlib:ffi",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+        "@dlpack",
+        "@nanobind",
+        "@xla//third_party/python_runtime:headers",  # buildcleaner: keep
+        "@xla//xla:comparison_util",
+        "@xla//xla:shape_util",
+        "@xla//xla:xla_data_proto_cc",
+        "@xla//xla/ffi:ffi_api",
+        "@xla//xla/ffi/api:ffi",
+        "@xla//xla/pjrt:host_callback",
+        "@xla//xla/pjrt:transpose",
+        "@xla//xla/python:nb_numpy",
+        "@xla//xla/python:types",
+        "@xla//xla/service:platform_util",
+    ],
+)
+
 nanobind_extension(
     name = "oneapi_plugin_extension",
     srcs = ["oneapi_plugin_extension.cc"],
     module_name = "oneapi_plugin_extension",
     deps = [
+        ":py_client_gpu",
         "//jaxlib:kernel_nanobind_helpers",
         "//jaxlib/gpu:gpu_plugin_extension",
-        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/strings",
+        "@oneapi//:headers",
         "@nanobind",
     ],
 )

--- a/jaxlib/oneapi/BUILD.bazel
+++ b/jaxlib/oneapi/BUILD.bazel
@@ -127,14 +127,57 @@ py_library(
     ],
 )
 
+sycl_library(
+    name = "py_client_gpu",
+    srcs = ["//jaxlib/gpu:py_client_gpu.cc"],
+    hdrs = ["//jaxlib/gpu:py_client_gpu.h"],
+    copts = [
+        "-fexceptions",
+        "-fno-strict-aliasing",
+    ],
+    features = ["-use_header_modules"],
+    deps = [
+        ":oneapi_gpu_kernel_helpers",
+        ":oneapi_gpu_runtime",
+        ":oneapi_vendor",
+        "//jaxlib:ffi",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+        "@dlpack",
+        "@nanobind",
+        "@xla//third_party/python_runtime:headers",  # buildcleaner: keep
+        "@xla//xla:comparison_util",
+        "@xla//xla:shape_util",
+        "@xla//xla:xla_data_proto_cc",
+        "@xla//xla/ffi:ffi_api",
+        "@xla//xla/ffi/api:ffi",
+        "@xla//xla/pjrt:host_callback",
+        "@xla//xla/pjrt:transpose",
+        "@xla//xla/python:nb_numpy",
+        "@xla//xla/python:types",
+        "@xla//xla/service:platform_util",
+    ],
+)
+
 nanobind_extension(
     name = "oneapi_plugin_extension",
     srcs = ["oneapi_plugin_extension.cc"],
     module_name = "oneapi_plugin_extension",
     deps = [
+        ":py_client_gpu",
         "//jaxlib:kernel_nanobind_helpers",
         "//jaxlib/gpu:gpu_plugin_extension",
-        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/strings",
+        "@oneapi//:headers",
         "@nanobind",
     ],
 )

--- a/jaxlib/oneapi/oneapi_plugin_extension.cc
+++ b/jaxlib/oneapi/oneapi_plugin_extension.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "nanobind/nanobind.h"
 #include "jaxlib/gpu/gpu_plugin_extension.h"
+#include "jaxlib/gpu/py_client_gpu.h"
 #include "jaxlib/kernel_nanobind_helpers.h"
 #include "xla/pjrt/status_casters.h"
 
@@ -26,8 +27,37 @@ namespace nb = nanobind;
 namespace jax {
 namespace {
 
-nb::dict FfiTypes() { return nb::dict(); }
-nb::dict FfiHandlers() { return nb::dict(); }
+static nb::dict GpuTransposePlanCacheType() {
+  auto [type_id, type_info] = oneapi::GpuTransposePlanCacheTypeInfo();
+  nb::dict d;
+  d["type_id"] = nb::capsule(type_id);
+  d["type_info"] = nb::capsule(type_info);
+  return d;
+}
+
+nb::dict FfiTypes() {
+  nb::dict dict;
+  dict["GpuTransposePlanCache"] = GpuTransposePlanCacheType();
+  return dict;
+}
+
+nb::dict FfiHandlers() {
+  nb::dict dict;
+  nb::dict gpu_callback_dict;
+  gpu_callback_dict["instantiate"] =
+      EncapsulateFfiHandler(oneapi::kGpuTransposePlanCacheInstantiate);
+  gpu_callback_dict["execute"] =
+      EncapsulateFfiHandler(oneapi::kXlaFfiPythonGpuCallback);
+  dict["xla_ffi_python_gpu_callback"] = gpu_callback_dict;
+  dict["xla_ffi_partitioned_python_gpu_callback"] = gpu_callback_dict;
+  dict["xla_buffer_python_gpu_callback"] =
+      EncapsulateFfiHandler(oneapi::kXlaBufferPythonGpuCallback);
+  dict["xla_buffer_python_gpu_callback_cmd_buffer"] =
+      EncapsulateFfiHandler(oneapi::kXlaBufferPythonGpuCallbackCmdBuffer);
+  dict["dce_sink"] =
+      EncapsulateFfiHandler(oneapi::dce_sink_gpu_ffi);
+  return dict;
+}
 
 }  // namespace
 

--- a/tests/buffer_callback_test.py
+++ b/tests/buffer_callback_test.py
@@ -96,6 +96,7 @@ class BufferCallbackTest(jtu.JaxTestCase):
       dtype=jtu.dtypes.all, command_buffer_compatible=[True, False]
   )
   @jtu.run_on_devices("gpu")
+  @jtu.skip_on_devices("oneapi")
   def test_cuda_array_interface(self, dtype, command_buffer_compatible):
 
     def callback(ctx, out, arg):


### PR DESCRIPTION
This PR introduces following canges:
1.  Wires up JAX's GPU Python callback infrastructure for the OneAPI backend. 
2.  `buffer_callback.py` map the `oneapi` platform to xla_buffer_python_gpu_callback.
3.  `callback.py`: allow `oneapi` in emit_python_callback.
4.   `oneapi_plugin_extension.cc` replace the empty FfiTypes() / FfiHandlers() stubs with real registrations.
5. `py_client_gpu.cc` dispatch the buffer-callback FFI handlers to `XlaBufferCallback<kDLOneAPI>`
 6. `tests/buffer_callback_test.py` skip `test_cuda_array_interface` on OneAPI as `__cuda_array_interface__`  is not applicable to the OneAPI backend).

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->