### PR TITLE
fix(numpy): return NaN for nanquantile on empty reduction axes

### DIFF
--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -2573,6 +2573,11 @@ def _quantile(a: Array, q: Array, axis: int | tuple[int, ...] | None,
   a_shape = a.shape
   q_orig = q
   if squash_nans:
+    # When the reduction axis is empty, nanquantile has no values to aggregate.
+    # NumPy falls back to nanmean in this case, returning NaN with the reduced shape.
+    # Match that behaviour instead of raising an indexing error.
+    if a_shape[axis] == 0:
+      return nanmean(a, axis=axis, keepdims=keepdims)
     a = _where(lax._isnan(a), np.nan, a) # Ensure nans are positive so they sort to the end.
     if weights is not None:
       a, weights = lax.sort_key_val(a, weights, dimension=axis)

--- a/tests/lax_numpy_reducers_test.py
+++ b/tests/lax_numpy_reducers_test.py
@@ -1118,5 +1118,35 @@ class JaxNumpyReducerTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker, tol=tol)
 
+  @jtu.ignore_warning(category=RuntimeWarning, message="Mean of empty slice")
+  def testNanquantileEmptyAxis(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/39468
+    # jnp.nanquantile should return NaN (not raise) when the reduction axis is empty.
+    # NumPy's nanquantile falls back to nanmean for empty axes, so we match that shape.
+
+    # scalar q, axis=0: shape (0, 4) -> (4,) of NaNs
+    x = jnp.empty((0, 4), dtype=jnp.float32)
+    with jtu.ignore_warning(category=RuntimeWarning):
+      expected = np.nanquantile(np.empty((0, 4), dtype=np.float32), 0.5, axis=0)
+    result = jnp.nanquantile(x, 0.5, axis=0)
+    self.assertEqual(result.shape, expected.shape)
+    self.assertTrue(np.all(np.isnan(result)))
+
+    # axis=1, empty along axis=1: shape (4, 0) -> (4,) of NaNs
+    x2 = jnp.empty((4, 0), dtype=jnp.float32)
+    with jtu.ignore_warning(category=RuntimeWarning):
+      expected2 = np.nanquantile(np.empty((4, 0), dtype=np.float32), 0.5, axis=1)
+    result2 = jnp.nanquantile(x2, 0.5, axis=1)
+    self.assertEqual(result2.shape, expected2.shape)
+    self.assertTrue(np.all(np.isnan(result2)))
+
+    # keepdims=True: shape (0, 4) with axis=0 -> (1, 4) of NaNs
+    with jtu.ignore_warning(category=RuntimeWarning):
+      expected_kd = np.nanquantile(np.empty((0, 4), dtype=np.float32), 0.5, axis=0, keepdims=True)
+    result_kd = jnp.nanquantile(x, 0.5, axis=0, keepdims=True)
+    self.assertEqual(result_kd.shape, expected_kd.shape)
+    self.assertTrue(np.all(np.isnan(result_kd)))
+
+
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
## Description

Fixes #39468

`jnp.nanquantile` raised an indexing/gather error when the reduction axis had size 0:

```python
x = jnp.empty((0, 4), dtype=jnp.float32)
jnp.nanquantile(x, 0.5, axis=0)  # raised IndexError
```

NumPy's `nanquantile` falls back to `nanmean` for empty axes, returning NaN with the reduced shape. The fix adds an early return in `_quantile()` that delegates to `nanmean` when `squash_nans=True` and the reduction axis is empty.

## Testing

Added `testNanquantileEmptyAxis` in `tests/lax_numpy_reducers_test.py` covering:
- scalar `q`, `axis=0` on shape `(0, 4)` → shape `(4,)` of NaNs
- `axis=1` on shape `(4, 0)` → shape `(4,)` of NaNs
- `keepdims=True` → shape `(1, 4)` of NaNs

Note: full test suite requires nightly `jaxlib` (>= 0.11.0) not yet on PyPI. The fix was validated against NumPy's output shapes for all tested cases.

Implemented with Claude Code assistance. All changed lines reviewed manually.