### PR TITLE
Skip test_vmap_of_checkify_of_while on TPU

### DIFF
--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -1292,6 +1292,7 @@ class AssertPrimitiveTests(jtu.JaxTestCase):
     # TODO(lenamartens): re-enable assertions below.
     # self.assertIsNone(err.get())
 
+  @jtu.skip_on_devices("tpu")
   def test_vmap_of_checkify_of_while(self):
     # vmap-of-checkify-of-while is a supported composition: checkify injects a
     # dce_sink into the while body and the outer vmap must batch it. Regression


### PR DESCRIPTION
Decorate `vmap-of-checkify-of-while` test with @jtu.skip_on_devices("tpu") to be consistent with other checkify `while_loop` tests.

The test was added in `832bedffbc` but this decorator was missing, since it was added to #39502 after the import snapshot was taken.