### PR TITLE
[ROCm] Find ROCm plugin packages by major version

### DIFF
--- a/jax_plugins/rocm/__init__.py
+++ b/jax_plugins/rocm/__init__.py
@@ -27,7 +27,19 @@ logger = logging.getLogger(__name__)
 
 # rocm_plugin_extension locates inside jaxlib. `jaxlib` is for testing without
 # preinstalled jax rocm plugin packages.
-for pkg_name in ['jax_rocm7_plugin', 'jax_rocm60_plugin', 'jaxlib.rocm']:
+_pkg_names = [
+    'jax_rocm10_plugin', 'jax_rocm7_plugin', 'jax_rocm60_plugin', 'jaxlib.rocm'
+]
+
+# A wheel installs this package as jax_plugins.xla_rocm<major>, paired with
+# jax_rocm<major>_plugin, so prefer the matching name over the list above, which
+# cannot know about ROCm majors released later. Non-digit means a source
+# checkout, where the list is all we have.
+_major = (__package__ or '').rpartition('xla_rocm')[2]
+if _major.isdigit() and f'jax_rocm{_major}_plugin' not in _pkg_names:
+  _pkg_names.insert(0, f'jax_rocm{_major}_plugin')
+
+for pkg_name in _pkg_names:
   try:
     rocm_plugin_extension = importlib.import_module(
         f'{pkg_name}.rocm_plugin_extension'

--- a/jaxlib/plugin_support.py
+++ b/jaxlib/plugin_support.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 from collections.abc import Sequence
+import functools
 import importlib
+import pkgutil
 import re
 from types import ModuleType
 import warnings
@@ -23,9 +25,30 @@ from .version import __version__ as jaxlib_version
 
 _PLUGIN_MODULE_NAMES = {
     "cuda": ["jax_cuda13_plugin", "jax_cuda12_plugin"],
-    "rocm": ["jax_rocm7_plugin", "jax_rocm60_plugin"],
+    "rocm": ["jax_rocm10_plugin", "jax_rocm7_plugin", "jax_rocm60_plugin"],
     "oneapi": ["jax_oneapi_plugin"],
 }
+
+# ROCm plugin packages embed the ROCm major version in their name, so each new
+# ROCm major introduces a name this jaxlib cannot already know.
+_ROCM_PLUGIN_MODULE_RE = re.compile(r"jax_rocm(\d+)_plugin")
+
+
+@functools.cache
+def _discovered_rocm_plugin_module_names() -> tuple[str, ...]:
+  """Finds installed ROCm plugin packages not listed above, newest major first.
+
+  This is what lets a ROCm major released after this jaxlib work. Enumeration
+  only sees sys.path, so the list above stays the backstop.
+  """
+  majors = [
+      int(match.group(1))
+      for module in pkgutil.iter_modules()
+      if (match := _ROCM_PLUGIN_MODULE_RE.fullmatch(module.name))
+  ]
+  known = _PLUGIN_MODULE_NAMES["rocm"]
+  names = (f"jax_rocm{major}_plugin" for major in sorted(majors, reverse=True))
+  return tuple(name for name in names if name not in known)
 
 
 def import_from_plugin(
@@ -47,8 +70,11 @@ def import_from_plugin(
   """
   if plugin_name not in _PLUGIN_MODULE_NAMES:
     raise ValueError(f"Unknown plugin: {plugin_name}")
+  module_names = _PLUGIN_MODULE_NAMES[plugin_name]
+  if plugin_name == "rocm":
+    module_names = [*_discovered_rocm_plugin_module_names(), *module_names]
   return maybe_import_plugin_submodule(
-      [f".{plugin_name}"] + _PLUGIN_MODULE_NAMES[plugin_name],
+      [f".{plugin_name}"] + module_names,
       submodule_name,
       check_version=check_version,
   )
@@ -70,11 +96,7 @@ def check_plugin_version(
   # ROCm plugins skip runtime version checks. Version compatibility is managed
   # via pip dependency constraints in setup.py instead. This allows ROCm plugins
   # to be released on their own schedule without strict jaxlib version coupling.
-  is_rocm_plugin = any(
-      rocm_name in plugin_name
-      for rocm_name in _PLUGIN_MODULE_NAMES.get("rocm", [])
-  )
-  if is_rocm_plugin:
+  if _ROCM_PLUGIN_MODULE_RE.search(plugin_name) is not None:
     return True
 
   # Regex to match a dotted version prefix 0.1.23.456.789 of a PEP440 version.


### PR DESCRIPTION
# Description
ROCm plugin packages embed the ROCm major version in their name (`jax_rocm7_plugin`, `jax_rocm10_plugin`, ...), and both lookup sites hard-code the names they know. An already released jaxlib therefore cannot load the plugin for a ROCm major that ships later: the FFI handlers live in the plugin, so they go unregistered and linalg, sparse, PRNG and Triton lowerings fail at runtime with `NOT_FOUND: No FFI handler registered for hipsolver_*`. Today that means a jaxlib release has to follow every ROCm major bump.

- `jaxlib/plugin_support.py` also enumerates installed `jax_rocm<major>_plugin` packages, newest major first. The static list stays as the backstop for anything `pkgutil` cannot see, and the version-check carve-out becomes a pattern match so it covers every major rather than the names listed.
- `jax_plugins/rocm/__init__.py` derives the companion plugin name from its own package, since a wheel installs the shim as `jax_plugins.xla_rocm<major>`. A source checkout has no major to derive and falls back to the list.

ROCm 7 behaviour is unchanged: discovery finds nothing new, so the only delta is one extra import attempt that raises `ImportError` and is already handled.

### Testing

gfx950 (MI355X), jax/jaxlib 0.11.0, `tests/linalg_test.py` and `tests/random_test.py` filtered to `-k "cholesky or svd or Eigh or lu_factor or triangular_solve or qr"`:

| plugin wheels | before | after |
| --- | --- | --- |
| ROCm 7.15 | 137 passed, 36 skipped | 137 passed, 36 skipped |
| ROCm 10.0 | 108 failed, 29 passed, 36 skipped | 137 passed, 36 skipped |

All 108 ROCm 10 failures are missing FFI handlers (`hipsolver_geqrf_ffi` x50, `hipsolver_gesvdj_ffi` x19, `hipsolver_potrf_ffi` x10, `hiphybrid_geqp3` x10, and the rest of that set). Also checked on both: 7/7 GPU kernel modules resolve from the right package, the shim loads the matching `rocm_plugin_extension`, a stub `jax_rocm99_plugin` is discovered as a future major, and the CUDA path is untouched and still rejects a version-mismatched plugin.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->