### PR TITLE
Fixed failing as_torch_kernel and as_torch_gpu_kernel

### DIFF
--- a/jax/experimental/mosaic/gpu/core.py
+++ b/jax/experimental/mosaic/gpu/core.py
@@ -1177,7 +1177,7 @@ def _compile_as_torch_gpu_kernel(module_asm: bytes):
   else:
     dll = ctypes.CDLL(cuda_plugin._get_library_path())
   compile_func = dll.MosaicGpuCompile
-  compile_func.argtypes = [ctypes.c_void_p]
+  compile_func.argtypes = [ctypes.c_char_p, ctypes.c_int]
   compile_func.restype = ctypes.POINTER(ctypes.c_void_p)
   unload_func = dll.MosaicGpuUnload
   unload_func.argtypes = [compile_func.restype]
@@ -1186,23 +1186,17 @@ def _compile_as_torch_gpu_kernel(module_asm: bytes):
   compiled = compile_func(ctypes.c_char_p(module_asm), ctypes.c_int(len(module_asm)))
   if not compiled:
     raise RuntimeError("Failed to compile the module")
-  ctx, launch_ptr = compiled[0], compiled[1]
-  ctx_ptr_ptr = ctypes.pointer(ctypes.c_void_p(ctx))
-  launch_c = ctypes.CFUNCTYPE(None, ctypes.c_void_p)(launch_ptr)
+  function, launch_ptr = compiled[0], compiled[1]
+  launch_c = ctypes.CFUNCTYPE(
+      None, ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)
+  )(launch_ptr)
 
   def launch(arg_ptrs, device):
-    # Allocate another buffer for args of the host-side program. This is sadly
-    # the default MLIR calling convention.
-    launch_args_ptr = (ctypes.POINTER(ctypes.c_void_p) * 3)()
-    launch_args_ptr[0] = ctx_ptr_ptr
-    launch_args_ptr[1] = ctypes.pointer(
-        torch.cuda.default_stream(device)._as_parameter_
+    launch_c(
+        function,
+        torch.cuda.default_stream(device)._as_parameter_,
+        arg_ptrs,
     )
-    launch_args_ptr[2] = ctypes.cast(
-        ctypes.pointer(ctypes.pointer(arg_ptrs)),
-        ctypes.POINTER(ctypes.c_void_p),
-    )
-    launch_c(launch_args_ptr)
 
   return launch, functools.partial(unload_func, compiled)
 

--- a/jaxlib/mosaic/gpu/custom_call.cc
+++ b/jaxlib/mosaic/gpu/custom_call.cc
@@ -1675,6 +1675,9 @@ extern "C" {
 
 __attribute__((visibility("default"))) void** MosaicGpuCompile(
     const char* module, int num_module_bytes) {
+  // We should make sure that NVPTX target is initialized before
+  // getting cuda compute capability
+  mosaic::gpu::EnsureLLVMNVPTXTargetIsRegistered();
   std::string module_str(module, num_module_bytes);
   auto cc = GetCudaComputeCapability();
   if (!cc.ok()) {


### PR DESCRIPTION
Description:
- Call EnsureLLVMNVPTXTargetIsRegistered in MosaicGpuCompile otherwise GetCudaComputeCapability is failing with `Unable to find target for this triple (no targets are registered)`
- Recoded (with the help of AI) the compiled kernel launch as C function following compiled host launcher signature and without using three-entry wrapper argument array. Otherwise, data pointers passed into the C functions were incorrect:
```
mosaic_gpu_init_tma_desc, call cuTensorMapEncodeTiled
- rank=1
- tma_sizes=128
- tma_strides=1
- tma_window_shape=128
- element_strides=1
- swizzle=0
- tma_desc=-745308928
- data_type=2
- base_addr=0x1   <----- HERE
```

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->