### PR TITLE
[vjp3] add bwd pass logging support to remat / remat3

### DIFF
--- a/docs/new_docs/301/custom-derivatives.md
+++ b/docs/new_docs/301/custom-derivatives.md
@@ -1275,7 +1275,22 @@ the forward computation:
   each logged key maps to a `CondSum` recording which branch ran, with one
   slot per branch (example below);
 * out of a transposed `shard_map`, stacked along a leading mesh axis (a
-  per-shard scalar becomes a vector of shape `(num_shards,)`).
+  per-shard scalar becomes a vector of shape `(num_shards,)`);
+* out of a rematerialized (`jax.remat`, i.e. `jax.checkpoint`) backward
+  pass, unchanged — rematerialization affects what's saved versus
+  recomputed, not what's logged.
+
+```{note}
+Backward-pass logging doesn't work nicely with `jax.remat` unless you set
+`JAX_REMAT3=1` (or `jax.config.update('jax_remat3', True)`). The classic
+default remat implementation differentiates rematted code through `jvp`
+rules, so a `vjp_bwd` rule — where logs originate — never runs inside a
+rematted region: a hijax primitive with only `vjp_fwd`/`vjp_bwd` rules
+can't be differentiated under it at all. Under the new implementation
+(`jax_remat3`), rematted code is differentiated through the same `vjp`
+rules as everywhere else, and logs flow out as described above. This
+caveat disappears once `jax_remat3` becomes the default.
+```
 
 For example, with a `scan`:
 
@@ -1313,11 +1328,11 @@ branch that logs the key but wasn't taken (here `'neg'`), and `None` for a
 branch that doesn't log the key at all. Branches needn't agree on keys or
 types, and nested `cond`s nest their `CondSum`s.
 
-A rule's log return must be a dict (or `None`, meaning no logs). A few
-transposed contexts don't yet plumb logs through — `jax.remat`,
-`jax.custom_vjp` backward rules, and `lax.while_loop` — and logs inside
-them are silently dropped, consistent with drop-by-default. For plumbing
-data out of a backward pass with mutable refs instead, see {doc}`refs`.
+A rule's log return must be a dict (or `None`, meaning no logs). A couple
+of transposed contexts don't yet plumb logs through — `jax.custom_vjp`
+backward rules and `lax.while_loop` — and logs inside them are silently
+dropped, consistent with drop-by-default. For plumbing data out of a
+backward pass with mutable refs instead, see {doc}`refs`.
 
 (jax-301-structured-residuals)=
 

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -731,7 +731,7 @@ def remat_transpose(out_cts, *args, jaxpr, prevent_cse, **params):
   assert not jaxpr.constvars
   in_linear = [ad.is_undefined_primal(x) for x in args_]
   out_zeros = [type(ct) is ad_util.Zero for ct in out_cts]
-  transposed_jaxpr_, in_zeros = transpose_jaxpr(
+  transposed_jaxpr_, in_zeros, out_tree = transpose_jaxpr(
       jaxpr, in_linear, out_zeros)
   transposed_jaxpr, consts = transposed_jaxpr_, transposed_jaxpr_.consts
   transposed_jaxpr = pe.convert_constvars_jaxpr(transposed_jaxpr)
@@ -739,18 +739,20 @@ def remat_transpose(out_cts, *args, jaxpr, prevent_cse, **params):
   if isinstance(prevent_cse, tuple):
     prevent_cse_, _ = partition_list(in_linear, prevent_cse)
     prevent_cse = tuple(prevent_cse_) + (True,) * (len(out_zeros) - sum(out_zeros))
-  in_cts_nz = remat_p.bind(*consts, *flat_args, jaxpr=transposed_jaxpr,
-                           prevent_cse=prevent_cse, **params)
+  outs = remat_p.bind(*consts, *flat_args, jaxpr=transposed_jaxpr,
+                      prevent_cse=prevent_cse, **params)
+  in_cts_nz, logs = tree_unflatten(out_tree, outs)
   in_cts_nz_, in_zeros_ = iter(in_cts_nz), iter(in_zeros)
   for x in args:
     if isinstance(x, ad.GradAccum) and not next(in_zeros_):
       x.accum(next(in_cts_nz_))
+  return logs
 ad.fancy_transposes[remat_p] = remat_transpose
 
 # TODO(mattjj): move this to ad.py
 def transpose_jaxpr(jaxpr: core.Jaxpr, in_linear: bool | Sequence[bool],
                     out_zeros: bool | Sequence[bool],
-                    ) -> tuple[core.Jaxpr, list[bool]]:
+                    ) -> tuple[core.Jaxpr, list[bool], PyTreeDef]:
   if isinstance(in_linear, bool):
     in_linear = (in_linear,) * len(jaxpr.in_avals)
   if isinstance(out_zeros, bool):
@@ -784,20 +786,23 @@ def _transpose_jaxpr(jaxpr: core.Jaxpr,
     assert next(out_cts_iter, None) is None
     dummy_args = [ad.UndefinedPrimal(aval.to_ct_aval())
                   for aval in lin_jaxpr.in_avals[len(consts):]]
-    in_cts = ad.backward_pass(lin_jaxpr, False, lin_jaxpr.consts,
-                              [*consts, *dummy_args], out_cts)
+    in_cts, logs = ad.backward_pass(lin_jaxpr, False, lin_jaxpr.consts,
+                                    [*consts, *dummy_args], out_cts,
+                                    return_logs=True)
     in_cts = in_cts[len(consts):]
 
-    # Identify symbolic zeros in the resulting cotangents, and return nonzeros.
+    # Identify symbolic zeros in the resulting cotangents, and return nonzeros,
+    # with any backward-pass log leaves riding along as extra outputs.
     in_zeros = cell.in_cts_zero = [type(ct) is ad_util.Zero for ct in in_cts]  # pyrefly: ignore[missing-attribute]
     in_cts_nz, _ = partition_list(in_zeros, in_cts)
-    return in_cts_nz
+    outs, cell.out_tree = tree_flatten((in_cts_nz, logs))  # pyrefly: ignore[missing-attribute]
+    return outs
 
   dbg = jaxpr.debug_info.with_unknown_names()
   in_avals_flat_tree = ft.flatten((tuple(in_avals), {}))
   transposed_closed_jaxpr, _ = pe.trace_to_jaxpr(
       transposed, in_avals_flat_tree, dbg)
-  return transposed_closed_jaxpr, cell.in_cts_zero  # pyrefly: ignore[missing-attribute]
+  return transposed_closed_jaxpr, cell.in_cts_zero, cell.out_tree  # pyrefly: ignore[missing-attribute]
 
 def remat_vmap(axis_data, args, dims, *, jaxpr, **params):
   assert not jaxpr.constvars
@@ -1131,7 +1136,8 @@ class RematTraced(VJPHiPrimitive):
       rem = Partial(rem.func, res)
       primals = merge_lists(which, unpinned, pinned)
     bwd = rem(*primals)
-    bwd.with_refs(*arg_accums)(outgrad)
+    _, logs = bwd.with_logs.with_refs(*arg_accums)(outgrad)
+    return logs
 
   def jvp(self, primals, tangents):
     traced = core.jaxpr_as_fun(self.jaxpr)

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -568,12 +568,14 @@ def accum_typeof(x):
     return typeof(x)
 
 # TODO(mattjj): this is for for backward (get it?) compatibility. Remove, maybe.
-def backward_pass(jaxpr, transform_stack: bool, consts, primals_in, cts_in):
+def backward_pass(jaxpr, transform_stack: bool, consts, primals_in, cts_in,
+                  *, return_logs: bool = False):
   primals_in = [ValAccum(x.aval) if isinstance(x, UndefinedPrimal) else x
                 for x in primals_in]
-  backward_pass3(jaxpr, transform_stack, consts, primals_in, cts_in)
-  return [x.freeze() if isinstance(x, ValAccum) else p2cz(x)
-          for x in primals_in]
+  logs = backward_pass3(jaxpr, transform_stack, consts, primals_in, cts_in)
+  cts_out = [x.freeze() if isinstance(x, ValAccum) else p2cz(x)
+             for x in primals_in]
+  return (cts_out, logs) if return_logs else cts_out
 
 
 @lu.transformation_with_aux2

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -2062,6 +2062,110 @@ class HijaxTest(jtu.JaxTestCase):
       (ct,) = f_vjp(1.0)  # plain call drops the logs without error
       self.assertAllClose(ct, 2 * jnp.cos(1.0))
 
+  def test_backward_pass_logging_remat3(self):
+    # Under remat3, a vjp_bwd rule's logs flow out of a rematted computation's
+    # backward pass.
+    class Square(VJPHiPrimitive):
+      def __init__(self, in_aval, tag):
+        self.in_avals = (in_aval,)
+        self.out_aval = in_aval
+        self.params = dict(tag=tag)
+        super().__init__()
+
+      def expand(self, x):
+        return x ** 2
+
+      def vjp_fwd(self, nzs_in, x):
+        return self(x), x
+
+      def vjp_bwd(self, res, t, x_accum):
+        if isinstance(x_accum, ad.GradAccum):
+          x_accum.accum(t * 2.0 * res)
+        return {self.tag: {'x': res, 'ct_in': t}}
+
+    def square(x, tag='sq'):
+      return Square(jax.typeof(x), tag)(x)
+
+    with config.remat3(True):
+      f = jax.checkpoint(lambda x: square(jnp.sin(x)))
+      _, f_vjp = jax.vjp(f, 3.0)
+      cts, logs = f_vjp.with_logs(1.0)
+      self.assertAllClose(cts[0], 2 * jnp.sin(3.0) * jnp.cos(3.0))
+      self.assertAllClose(logs, {'sq': {'x': jnp.sin(3.0), 'ct_in': 1.0}},
+                          check_dtypes=False)
+      (ct,) = f_vjp(1.0)  # plain call drops the logs without error
+      self.assertAllClose(ct, 2 * jnp.sin(3.0) * jnp.cos(3.0))
+
+      # under jit, and with with_logs itself traced
+      _, logsj = jax.vjp(jax.jit(f), 3.0)[1].with_logs(1.0)
+      self.assertAllClose(logsj['sq']['x'], jnp.sin(3.0))
+      _, logst = jax.jit(lambda x, ct: jax.vjp(f, x)[1].with_logs(ct))(3.0, 1.0)
+      self.assertAllClose(logst['sq']['x'], jnp.sin(3.0))
+
+      # nested remat
+      g = jax.checkpoint(lambda x: square(jax.checkpoint(
+          lambda y: square(y, 'inner'))(x), 'outer'))
+      cts, logs = jax.vjp(g, 2.0)[1].with_logs(1.0)
+      self.assertAllClose(cts[0], 32.0, check_dtypes=False)
+      self.assertEqual(set(logs), {'inner', 'outer'})
+      self.assertAllClose(logs['inner']['x'], 2.0, check_dtypes=False)
+      self.assertAllClose(logs['outer']['x'], 4.0, check_dtypes=False)
+
+      # remat-of-scan stacks the body's logs across iterations
+      def f_scan(xs):
+        c, _ = jax.lax.scan(lambda c, x: (c + square(x), None), 0., xs)
+        return c
+      xs = jnp.arange(1., 4.)
+      _, logss = jax.vjp(jax.checkpoint(f_scan), xs)[1].with_logs(1.0)
+      self.assertArraysEqual(logss['sq']['x'], xs)
+
+      # a checkpoint policy doesn't disturb the logs
+      fp = jax.checkpoint(lambda x: square(jnp.sin(x)),
+                          policy=jax.checkpoint_policies.nothing_saveable)
+      _, logsp = jax.vjp(fp, 3.0)[1].with_logs(1.0)
+      self.assertAllClose(logsp['sq']['x'], jnp.sin(3.0))
+
+  @parameterized.parameters([False, True])
+  def test_backward_pass_logging_remat_fancy_transpose(self, remat3):
+    # A fancy transpose rule's logs flow out of a rematted computation's
+    # backward pass, under both the classic remat_p implementation and remat3.
+    # (Unlike a vjp_bwd-only VJPHiPrimitive, a primitive with a jvp rule and a
+    # logging transpose rule works under classic remat's jvp-based
+    # differentiation too.)
+    from jax._src.interpreters import mlir
+
+    log_id_p = core.Primitive('log_id')
+    log_id_p.def_impl(lambda x: x)
+    log_id_p.def_abstract_eval(lambda a: a)
+    ad.defjvp(log_id_p, lambda g, x: log_id_p.bind(g))
+    mlir.register_lowering(log_id_p, lambda ctx, x: [x])
+    def _log_id_transpose(ct, x):
+      if isinstance(x, ad.ValAccum):
+        x.accum(ct)
+      return {'canary': ct}
+    ad.fancy_transposes[log_id_p] = _log_id_transpose
+
+    with config.remat3(remat3):
+      f = jax.checkpoint(lambda x: log_id_p.bind(jnp.sin(x)) * 2.)
+      _, f_vjp = jax.vjp(f, 1.0)
+      cts, logs = f_vjp.with_logs(1.0)
+      self.assertAllClose(cts[0], 2 * jnp.cos(1.0))
+      self.assertAllClose(logs, {'canary': 2.0}, check_dtypes=False)
+      (ct,) = f_vjp(1.0)  # plain call drops the logs without error
+      self.assertAllClose(ct, 2 * jnp.cos(1.0))
+
+      # under jit, and with with_logs itself traced
+      _, logsj = jax.vjp(jax.jit(f), 1.0)[1].with_logs(1.0)
+      self.assertAllClose(logsj, {'canary': 2.0}, check_dtypes=False)
+      _, logst = jax.jit(lambda x, ct: jax.vjp(f, x)[1].with_logs(ct))(1.0, 1.0)
+      self.assertAllClose(logst, {'canary': 2.0}, check_dtypes=False)
+
+      # nested remat
+      g = jax.checkpoint(lambda x: jax.checkpoint(
+          lambda y: log_id_p.bind(jnp.sin(y)))(x) * 2.)
+      _, logsn = jax.vjp(g, 1.0)[1].with_logs(1.0)
+      self.assertAllClose(logsn, {'canary': 2.0}, check_dtypes=False)
+
   def test_jvp_derived_from_lin(self):
     class RaiseToStaticPower(VJPHiPrimitive):
       def __init__(self, in_aval, *, power):


### PR DESCRIPTION
For remat3 the change was trivial. For classic remat, we follow what we do for jit.