### PR TITLE
[vjp3] add defvjp_with_logs so custom_vjp rules can log

### DIFF
--- a/docs/new_docs/301/custom-derivatives.md
+++ b/docs/new_docs/301/custom-derivatives.md
@@ -1288,8 +1288,10 @@ rules, so a `vjp_bwd` rule — where logs originate — never runs inside a
 rematted region: a hijax primitive with only `vjp_fwd`/`vjp_bwd` rules
 can't be differentiated under it at all. Under the new implementation
 (`jax_remat3`), rematted code is differentiated through the same `vjp`
-rules as everywhere else, and logs flow out as described above. This
-caveat disappears once `jax_remat3` becomes the default.
+rules as everywhere else, and logs flow out as described above. (Logs from
+`jax.custom_vjp` rules registered with `defvjp_with_logs` are the
+exception: they flow out of rematted code under either implementation.)
+This caveat disappears once `jax_remat3` becomes the default.
 ```
 
 For example, with a `scan`:
@@ -1328,11 +1330,47 @@ branch that logs the key but wasn't taken (here `'neg'`), and `None` for a
 branch that doesn't log the key at all. Branches needn't agree on keys or
 types, and nested `cond`s nest their `CondSum`s.
 
-A rule's log return must be a dict (or `None`, meaning no logs). A couple
-of transposed contexts don't yet plumb logs through — `jax.custom_vjp`
-backward rules and `lax.while_loop` — and logs inside them are silently
-dropped, consistent with drop-by-default. For plumbing data out of a
-backward pass with mutable refs instead, see {doc}`refs`.
+`jax.custom_vjp` backward rules can log too, with no hijax rewrite needed:
+register the rules with `defvjp_with_logs` instead of `defvjp`. The only
+difference is the backward rule's return convention: it returns a pair
+`(in_cts, logs)`, where `in_cts` is the usual tuple of cotangents and
+`logs` is a dict of named pytrees, or `None` to log nothing. (The separate
+registration is needed because a plain `defvjp` backward rule can already
+return any pytree of cotangents, so a trailing log dict would be
+ambiguous.)
+
+```{code-cell}
+@jax.custom_vjp
+def f(x, y):
+  return jnp.sin(x) * y
+
+def f_fwd(x, y):
+  return f(x, y), (jnp.cos(x), jnp.sin(x), y)
+
+def f_bwd(res, g):
+  cos_x, sin_x, y = res
+  return (cos_x * g * y, sin_x * g), {'f': {'ct_out': g}}
+
+f.defvjp_with_logs(f_fwd, f_bwd)
+
+_, f_vjp = jax.vjp(f, 1., 2.)
+_, logs = f_vjp.with_logs(1.)
+print(logs)
+```
+
+The `jax.custom_gradient` convenience wrapper supports the same thing via
+`@custom_gradient(with_logs=True)`, with the returned VJP function producing
+a pair `(in_cts, logs)`.
+
+Retval-style hijax rules can opt in the same way: set
+`vjp_bwd_retval_logs = True` on the primitive class, and have
+`vjp_bwd_retval` return `(args_grad, logs)` instead of just `args_grad`.
+
+A rule's log return must be a dict (or `None`, meaning no logs). One
+transposed context doesn't yet plumb logs through — `lax.while_loop` — and
+logs inside it are silently dropped, consistent with drop-by-default. For
+plumbing data out of a backward pass with mutable refs instead, see
+{doc}`refs`.
 
 (jax-301-structured-residuals)=
 

--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -1117,8 +1117,10 @@ def custom_vjp_call_rule(in_err, enabled_errors, *in_vals,
   # TODO(necula): the fwd result_paths are not quite the same as fun_jaxpr
   checkified_fwd_wrapped = lu.wrap_init(checkified_fwd,
                                         debug_info=fwd_jaxpr_thunk.debug_info)
-  bwd_ = lu.wrap_init(lambda *args: (*(None,)*num_errs, *bwd.call_wrapped(*args)),
-                      debug_info=bwd.debug_info)
+  def bwd_with_errs(*args):
+    cts, logs = bwd.call_wrapped(*args)  # flat bwd returns a (cts, logs) pair
+    return (*(None,) * num_errs, *cts), logs
+  bwd_ = lu.wrap_init(bwd_with_errs, debug_info=bwd.debug_info)
   checkified_fwd_wrapped, fwd_out_tree = flatten_fun_output(checkified_fwd_wrapped)
   all_outs = custom_derivatives.custom_vjp_call_p.bind(
       *err_vals, *in_vals, out_trees=out_trees, symbolic_zeros=symbolic_zeros,

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -587,6 +587,7 @@ class custom_vjp(Generic[ReturnValue]):
     self.bwd: Callable[..., tuple[Any, ...]] | None = None
     self.symbolic_zeros = False
     self.optimize_remat = False
+    self.with_logs = False
 
   __getattr__ = custom_api_util.forward_attr
 
@@ -688,6 +689,28 @@ class custom_vjp(Generic[ReturnValue]):
       raise NotImplementedError(
           "remat optimization for custom_vjp does not support symbolic zeros")
 
+  def defvjp_with_logs(self,
+                       fwd: Callable[..., tuple[ReturnValue, Any]],
+                       bwd: Callable[..., tuple[tuple[Any, ...], dict | None]],
+                       symbolic_zeros: bool = False,
+                       optimize_remat: bool = False,
+                       ) -> None:
+    """Like :py:func:`~jax.custom_vjp.defvjp`, but ``bwd`` can also log.
+
+    The only difference from ``defvjp`` is the return convention of ``bwd``:
+    it must return a pair ``(in_cts, logs)``, where ``in_cts`` is the usual
+    tuple of cotangents (one entry per primal argument), and ``logs`` is a
+    dict of named pytrees to log out of the backward pass, or ``None`` to log
+    nothing. To receive the logs, apply the VJP function via its
+    ``with_logs`` method: ``f_vjp.with_logs(out_ct)`` returns a pair
+    ``(arg_cts, logs)``. Logging is drop-by-default: a plain ``f_vjp(out_ct)``
+    call ignores the logs, and under ``jit`` the logging computation is
+    dead-code-eliminated.
+    """
+    self.defvjp(fwd, bwd, symbolic_zeros=symbolic_zeros,
+                optimize_remat=optimize_remat)
+    self.with_logs = True
+
   @partial(traceback_util.api_boundary,
            repro_api_name="jax.custom_vjp.__call__")
   def __call__(self, *args: Any, **kwargs: Any) -> ReturnValue:
@@ -741,7 +764,7 @@ class custom_vjp(Generic[ReturnValue]):
     flat_fwd, out_trees = _flatten_fwd(
         fwd_, self.nondiff_argnums, self.symbolic_zeros, debug_fun,
         debug_fwd, in_tree, out_type)
-    flat_bwd = _flatten_bwd(bwd, in_tree, in_avals, out_trees)
+    flat_bwd = _flatten_bwd(bwd, in_tree, in_avals, out_trees, self.with_logs)
     out_flat = custom_vjp_call_p.bind(*args_flat, subfuns=(flat_fun, flat_fwd, flat_bwd),
                                       out_trees=out_trees,
                                       symbolic_zeros=self.symbolic_zeros)
@@ -907,6 +930,7 @@ def _flatten_bwd(f: Callable,
                  in_tree: PyTreeDef,
                  in_avals: Sequence[core.AbstractValue],  # primal avals
                  out_trees: Callable[[], tuple[PyTreeDef, PyTreeDef, list[int | None]]],
+                 with_logs: bool,
                  *args):
   out_tree, res_tree, _ = out_trees()
   assert len(args) == res_tree.num_leaves + out_tree.num_leaves
@@ -914,6 +938,19 @@ def _flatten_bwd(f: Callable,
   py_res = tree_unflatten(res_tree, res)
   py_cts_out = tree_unflatten(out_tree, cts_out)
   py_cts_in = f(py_res, py_cts_out)
+  if with_logs:
+    if not (isinstance(py_cts_in, (list, tuple)) and len(py_cts_in) == 2):
+      raise TypeError(
+          "Custom VJP bwd rule was registered with defvjp_with_logs and so "
+          f"must produce a pair (in_cts, logs), but got {py_cts_in}.")
+    py_cts_in, logs = py_cts_in
+    if logs is not None and type(logs) is not dict:
+      raise TypeError(
+          "Custom VJP bwd rule was registered with defvjp_with_logs, and so "
+          "the second element of the pair it returns must be None or a dict "
+          f"of backward-pass log entries, but got {type(logs).__name__}.")
+  else:
+    logs = None
   if isinstance(py_cts_in, list) and len(py_cts_in) == len(treedef_children(in_tree)):
     py_cts_in = tuple(py_cts_in)
   # For each None in py_cts_in, indicating an argument for which the rule
@@ -971,7 +1008,7 @@ def _flatten_bwd(f: Callable,
                f"{core.aval_mismatch_extra(a, a_)}")
         raise ValueError(msg)
       results.append(ct)
-  return results
+  return results, logs
 
 def _ref_typecompat(a, a_):
   return (isinstance(a, AbstractRef) and
@@ -1031,7 +1068,8 @@ def lift_fwd(num_consts: int, fwd_jaxpr_thunk: lu.WrappedFun) -> lu.WrappedFun:
 
 @lu.transformation2
 def _handle_consts_in_bwd(f, const_avals, *args):
-  return [Zero(a) for a in const_avals] + list(f(*args))
+  cts, logs = f(*args)
+  return [Zero(a) for a in const_avals] + list(cts), logs
 
 custom_vjp_call_p = CustomVJPCallPrimitive('custom_vjp_call')
 # TODO(phawkins,mattjj): make this primitive cacheable.
@@ -1131,7 +1169,7 @@ mlir.register_lowering(ad.custom_lin_p, ad.raise_custom_vjp_error_on_jvp,
                        cacheable=False)
 
 
-def custom_gradient(fun):
+def custom_gradient(fun=None, /, *, with_logs: bool = False):
   """Convenience function for defining custom VJP rules (aka custom gradients).
 
   While the canonical way to define custom VJP rules is via ``jax.custom_vjp``,
@@ -1164,6 +1202,11 @@ def custom_gradient(fun):
       differentiated and its reverse-mode differentiation rule. It should return
       a pair consisting of an output value and a Python callable that represents
       the custom gradient function.
+    with_logs: optional bool, default ``False``. If ``True``, the custom
+      gradient function must return a pair ``(in_cts, logs)`` rather than just
+      the cotangents, where ``logs`` is a dict of named pytrees to log out of
+      the backward pass, or ``None`` to log nothing, as with
+      :py:meth:`jax.custom_vjp.defvjp_with_logs`.
 
   Returns:
     A Python callable that accepts the same arguments as ``fun`` and returns the
@@ -1191,7 +1234,25 @@ def custom_gradient(fun):
   12.0
   >>> print(jax.grad(f, argnums=(0, 1))(3., 4.))
   (Array(4., dtype=float32, weak_type=True), Array(3., dtype=float32, weak_type=True))
+
+  With ``with_logs=True``, the VJP function returns a pair of the cotangents
+  and a dict of backward-pass logs, received via the ``with_logs`` method of
+  the VJP function that :py:func:`jax.vjp` returns:
+
+  >>> @jax.custom_gradient(with_logs=True)
+  ... def f(x):
+  ...   return x ** 2, lambda g: ((g * 2 * x,), {'ct_out': g})
+  ...
+  >>> print(jax.grad(f)(3.))
+  6.0
+  >>> _, f_vjp = jax.vjp(f, 3.)
+  >>> (x_ct,), logs = f_vjp.with_logs(1.)
+  >>> print(logs['ct_out'])
+  1.0
   """
+  if fun is None:
+    return lambda f: custom_gradient(f, with_logs=with_logs)
+
   @custom_vjp
   def wrapped_fun(*args, **kwargs):
     ans, _ = fun(*args, **kwargs)
@@ -1199,6 +1260,8 @@ def custom_gradient(fun):
 
   def fwd(*args, **kwargs):
     ans, rule = fun(*args, **kwargs)
+    if with_logs:
+      rule = _custom_gradient_logs_rule(rule)
     ans_flat, out_tree = tree_flatten(((ans,), {}))
     debug_fwd = debug_info("custom_gradient fwd", rule, (ans,), {})
     ans_avals = [core.typeof(x).to_ct_aval() for x in ans_flat]
@@ -1213,12 +1276,39 @@ def custom_gradient(fun):
     if out_tree != out_tree_: raise TypeError(f'{out_tree}\n!=\n{out_tree_}')
     cts_out = core.eval_jaxpr(jaxpr, consts, *cts_flat)
     cts_out = tree_unflatten(in_tree, cts_out)
+    if with_logs:
+      cts_out, logs = cts_out
+      cts_tree, _ = treedef_children(in_tree)
+      if treedef_is_leaf(cts_tree):
+        cts_out = (cts_out,)
+      return cts_out, logs
     if treedef_is_leaf(in_tree):
       cts_out = (cts_out,)
     return cts_out
 
-  wrapped_fun.defvjp(fwd, bwd)
+  if with_logs:
+    wrapped_fun.defvjp_with_logs(fwd, bwd)
+  else:
+    wrapped_fun.defvjp(fwd, bwd)
   return wrapped_fun
+
+def _custom_gradient_logs_rule(rule):
+  @wraps(rule)
+  def rule_with_logs(*cts):
+    out = rule(*cts)
+    if not (isinstance(out, (list, tuple)) and len(out) == 2):
+      raise TypeError(
+          "custom_gradient function used with with_logs=True must return a "
+          "VJP function producing a pair (in_cts, logs), but the VJP function "
+          f"returned {out}.")
+    in_cts, logs = out
+    if logs is not None and type(logs) is not dict:
+      raise TypeError(
+          "custom_gradient function used with with_logs=True must return a "
+          "VJP function whose second output is None or a dict of "
+          f"backward-pass log entries, but got {type(logs).__name__}.")
+    return in_cts, logs
+  return rule_with_logs
 
 @register_pytree_node_class
 class Residuals:

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -430,10 +430,16 @@ class VJPHiPrimitive:
         "setting `vjp_fwd, vjp_bwd_retval = vjp_from_jvp` (or `= "
         "vjp_from_lin`)")
 
+  vjp_bwd_retval_logs: bool = False
+
   def vjp_bwd(self, res, outgrad, /, *arg_accums):
-    args_grad = self.vjp_bwd_retval(res, outgrad)
+    if self.vjp_bwd_retval_logs:
+      args_grad, logs = self.vjp_bwd_retval(res, outgrad)
+    else:
+      args_grad, logs = self.vjp_bwd_retval(res, outgrad), None
     maybe_accum = lambda acc, v: isinstance(acc, ad.GradAccum) and acc.accum(v)
     tree_map(maybe_accum, arg_accums, args_grad)
+    return logs
 
   def vjp_bwd_retval(self, res, outgrad, /):
     # Classic API: returns values instead of using accumulators
@@ -516,6 +522,7 @@ class VmapOf(VJPHiPrimitive):
   out_dim: Any
 
   def __init__(self, prim, axis_data, in_dims, out_dim):
+    self.vjp_bwd_retval_logs = prim.vjp_bwd_retval_logs
     unmap = lambda a, d: core.unmapped_aval(axis_data.size, d, a,
                                             axis_data.explicit_mesh_axis)
     self.in_avals = tree_map(unmap, prim.in_avals, in_dims)
@@ -563,9 +570,12 @@ class VmapOf(VJPHiPrimitive):
     in_dims = tree_map(lambda x: batching.sum_axis if x is None else x, self.in_dims,
                        is_leaf=lambda x: x is None)
     g = tree_map(partial(map_zero, self.axis_data), self.out_dim, g, is_leaf=lambda x: x is None)
+    out_axes = (in_dims, 0) if self.vjp_bwd_retval_logs else in_dims
     out = api.vmap(self.prim.vjp_bwd_retval, in_axes=(res_axes, self.out_dim),  # pyrefly: ignore[missing-attribute]
-                   out_axes=in_dims, **self._vmap_params, sum_match=True)(res, g)
-    return tree_map(partial(unmap_zero, self.axis_data), self.in_dims, out, is_leaf=lambda x: x is None)
+                   out_axes=out_axes, **self._vmap_params, sum_match=True)(res, g)
+    out, logs = out if self.vjp_bwd_retval_logs else (out, None)
+    out = tree_map(partial(unmap_zero, self.axis_data), self.in_dims, out, is_leaf=lambda x: x is None)
+    return (out, logs) if self.vjp_bwd_retval_logs else out
 
   def batch_dim_rule(self, axis_data, in_dims):
     fix = lambda d, d_: d if (d is None or d_ is None) else d - (d_ < d)
@@ -942,12 +952,16 @@ class CustomVJPTraced(VJPHiPrimitive):
   symbolic_zeros: Any
   static_argnums: Any
   opt_remat: bool
+  with_logs: bool
 
-  def __init__(self, traced, fwd, bwd, in_avals, sym_zeros, static_argnums, opt_remat):
+  def __init__(self, traced, fwd, bwd, in_avals, sym_zeros, static_argnums,
+               opt_remat, with_logs=False):
+    self.vjp_bwd_retval_logs = with_logs
     self.in_avals = in_avals
     self.out_aval = traced.out_avals
     self.params = dict(traced=traced, fwd=fwd, bwd=bwd, symbolic_zeros=sym_zeros,
-                       static_argnums=static_argnums, opt_remat=opt_remat)
+                       static_argnums=static_argnums, opt_remat=opt_remat,
+                       with_logs=with_logs)
     super().__init__()
 
   def expand(self, *args):
@@ -985,6 +999,20 @@ class CustomVJPTraced(VJPHiPrimitive):
     else:
       out_ct = tree_map(ad_util.instantiate, out_ct, is_leaf=leaf)
     in_cts = self.bwd(*static_args, res, out_ct)
+    logs = None
+    if self.with_logs:
+      if not (isinstance(in_cts, (list, tuple)) and len(in_cts) == 2):
+        raise TypeError(
+            f"Custom VJP bwd rule {self.bwd} was registered with "
+            "defvjp_with_logs and so must produce a pair (in_cts, logs), "
+            f"but got {in_cts}.")
+      in_cts, logs = in_cts
+      if logs is not None and type(logs) is not dict:
+        raise TypeError(
+            f"Custom VJP bwd rule {self.bwd} was registered with "
+            "defvjp_with_logs, and so the second element of the pair it "
+            "returns must be None or a dict of backward-pass log entries, "
+            f"but got {type(logs).__name__}.")
     if isinstance(in_cts, list):
       in_cts = tuple(in_cts)
     if not isinstance(in_cts, tuple):
@@ -999,7 +1027,7 @@ class CustomVJPTraced(VJPHiPrimitive):
     tree_map_with_path(_vjp_bwd_aval_mismatch_err, self.in_avals, in_cts)
     if self.symbolic_zeros:
       in_cts = tree_map(ad_util.replace_rule_output_symbolic_zeros, in_cts)
-    return in_cts
+    return (in_cts, logs) if self.with_logs else in_cts
 
   def jvp(self, primals, tangents):
     if self.symbolic_zeros: ad.raise_custom_vjp_error_on_jvp()
@@ -1047,7 +1075,7 @@ class CustomVJPTraced(VJPHiPrimitive):
                                            custom_vjp_rules=False)
     rem = lambda *args: rem_(*[x for i, x in enumerate(args) if i not in self.static_argnums])
     helper = CustomVJPTraced(self.traced, rem, self.bwd, self.in_avals,
-                             False, self.static_argnums, False)
+                             False, self.static_argnums, False, self.with_logs)
     return out, helper
 
 def _vjp_primal_fwd_tree_mismatch_err(self, tree):
@@ -1098,6 +1126,7 @@ class custom_vjp3:
   bwd: Callable | None = None
   symz: bool = False
   opt_remat: bool = False
+  with_logs: bool = False
 
   def __init__(self, f, nondiff_argnums=(), nondiff_argnames=()):
     self.f = f
@@ -1109,6 +1138,13 @@ class custom_vjp3:
     self.bwd = bwd
     self.symz = symbolic_zeros
     self.opt_remat = optimize_remat
+    return self
+
+  def defvjp_with_logs(self, fwd, bwd, *, symbolic_zeros=False,
+                       optimize_remat=False):
+    self.defvjp(fwd, bwd, symbolic_zeros=symbolic_zeros,
+                optimize_remat=optimize_remat)
+    self.with_logs = True
     return self
 
   def __call__(self, *args, **kwargs):
@@ -1139,7 +1175,7 @@ class custom_vjp3:
     args = tuple(Static(x) if i in self.static_argnums else x for i, x in enumerate(args))
     in_avals = tree_map(typeof, args)
     prim = CustomVJPTraced(traced, self.fwd, self.bwd, in_avals, self.symz,
-                           self.static_argnums, self.opt_remat)
+                           self.static_argnums, self.opt_remat, self.with_logs)
     return prim(*args)
 
   def def_vmap(self, rule, /): return self.f.def_vmap(rule)

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -1316,19 +1316,22 @@ def raise_custom_vjp_error_on_jvp(*_, **__):
                   "function.")
 custom_lin_p.def_impl(raise_custom_vjp_error_on_jvp)
 
-def _custom_lin_transpose(cts_out, *invals, num_res,
-                          bwd: lu.WrappedFun, out_avals,
-                          symbolic_zeros, in_zeros):
-  res, _ = split_list(invals, [num_res])
+def _custom_lin_transpose_fancy(cts_out, *invals, num_res,
+                                bwd: lu.WrappedFun, out_avals,
+                                symbolic_zeros, in_zeros):
+  res, accums = split_list(invals, [num_res])
   if symbolic_zeros:
     cts_out = map(replace_internal_symbolic_zeros, cts_out)
   else:
     cts_out = map(instantiate_zeros, cts_out)
-  cts_in = bwd.call_wrapped(*res, *cts_out)
+  cts_in, logs = bwd.call_wrapped(*res, *cts_out)
   cts_in = map(replace_rule_output_symbolic_zeros, cts_in)
   nz_cts_in, _ = partition_list(in_zeros, cts_in)
-  return [None] * num_res + nz_cts_in
-primitive_transposes[custom_lin_p] = _custom_lin_transpose
+  for acc, ct in zip(accums, nz_cts_in):
+    if isinstance(acc, GradAccum):
+      acc.accum(ct)
+  return logs
+fancy_transposes[custom_lin_p] = _custom_lin_transpose_fancy
 
 def _custom_lin_pp_rule(eqn: core.JaxprEqn, context: core.JaxprPpContext,
                         settings: core.JaxprPpSettings) -> core.pp.Doc:

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -549,17 +549,30 @@ def batch_custom_vjp_bwd(bwd: lu.WrappedFun, tag: core.TraceTag,
             for x, dim in zip(args, in_dims_)]
     in_dims_ = [None if type(x) is SymbolicZero else d
                 for x, d in zip(args, in_dims_)]
-    bwd_, out_dims_thunk = batch_subtrace(bwd, tag, axis_data, in_dims_)
-    bwd_ = _match_axes_and_sum(bwd_, axis_data, out_dims_thunk, out_dim_dests)
-    return bwd_.call_wrapped(*args)
+    bwd_pair, pair_info_thunk = _flatten_cts_logs_pair(bwd)
+    bwd_, out_dims_thunk = batch_subtrace(bwd_pair, tag, axis_data, in_dims_)
+    all_dests = lambda: (*out_dim_dests, *(0,) * pair_info_thunk()[1].num_leaves)
+    bwd_ = _match_axes_and_sum(bwd_, axis_data, out_dims_thunk, all_dests)
+    outs = bwd_.call_wrapped(*args)
+    num_cts, log_tree = pair_info_thunk()
+    cts, log_leaves = split_list(outs, [num_cts])
+    return cts, tree_unflatten(log_tree, log_leaves)
   return lu.wrap_init(new_bwd, debug_info=bwd.debug_info)
 
+@lu.transformation_with_aux2
+def _flatten_cts_logs_pair(f, store, *args):
+  cts, logs = f(*args)
+  log_leaves, log_tree = tree_flatten(logs)
+  store.store((len(cts), log_tree))
+  return [*cts, *log_leaves]
+
 @lu.transformation2
-def _match_axes_and_sum(f, axis_data, out_dims_thunk, out_dim_dests, *in_vals):
+def _match_axes_and_sum(f, axis_data, out_dims_thunk, out_dim_dests_thunk,
+                        *in_vals):
   # this is like _match_axes, but we do reduce-sums as needed
   out_vals = f(*in_vals)
   return map(partial(_matchaxis_symzeros, axis_data, sum_match=True),
-             out_dims_thunk(), out_dim_dests, out_vals)
+             out_dims_thunk(), out_dim_dests_thunk(), out_vals)
 
 def _matchaxis_symzeros(axis_data, src, dst, x, sum_match=False):
   # Just like `matchaxis`, but handles symbolic zeros using ad_util.py

--- a/tests/custom_api_test.py
+++ b/tests/custom_api_test.py
@@ -2545,6 +2545,48 @@ class CustomVJPTest(jtu.JaxTestCase):
     self.assertAllClose(api.grad(f)(3.), 3., check_dtypes=False)
     self.assertAllClose(api.grad(api.grad(f))(3.), 1., check_dtypes=False)
 
+  def test_custom_gradient_with_logs(self):
+    @jax.custom_gradient(with_logs=True)
+    def f(x, y):
+      return x * y, lambda g: ((g * y, g * x), {'f': {'ct_out': g, 'x': x}})
+
+    self.assertAllClose(f(3., 4.), 12., check_dtypes=False)
+    self.assertAllClose(api.grad(f)(3., 4.), 4., check_dtypes=False)
+    _, f_vjp = jax.vjp(f, 3., 4.)
+    (x_ct, y_ct), logs = f_vjp.with_logs(1.)
+    self.assertAllClose(x_ct, 4., check_dtypes=False)
+    self.assertAllClose(y_ct, 3., check_dtypes=False)
+    self.assertAllClose(logs, {'f': {'ct_out': 1., 'x': 3.}},
+                        check_dtypes=False)
+    x_ct2, _ = f_vjp(1.)  # plain call drops the logs without error
+    self.assertAllClose(x_ct2, 4., check_dtypes=False)
+
+    _, logsj = jax.jit(
+        lambda x, y, ct: jax.vjp(f, x, y)[1].with_logs(ct))(3., 4., 1.)
+    self.assertAllClose(logsj['f']['x'], 3., check_dtypes=False)
+
+    @jax.custom_gradient(with_logs=True)
+    def g(x):
+      return x ** 2, lambda ct: (ct * 2 * x, {'ct': ct})  # singleton cts
+
+    self.assertAllClose(api.grad(g)(3.), 6., check_dtypes=False)
+    (x_ct,), logsg = jax.vjp(g, 3.)[1].with_logs(1.)
+    self.assertAllClose(x_ct, 6., check_dtypes=False)
+    self.assertAllClose(logsg['ct'], 1., check_dtypes=False)
+
+  def test_custom_gradient_with_logs_bad_return_errors(self):
+    @jax.custom_gradient(with_logs=True)
+    def e(x):
+      return x, lambda ct: (ct,)
+    with self.assertRaisesRegex(TypeError, "pair"):
+      api.grad(e)(1.)
+
+    @jax.custom_gradient(with_logs=True)
+    def e2(x):
+      return x, lambda ct: (ct, [1.0])
+    with self.assertRaisesRegex(TypeError, "None or a dict"):
+      api.grad(e2)(1.)
+
   def test_closure_convert(self):
     def cos_after(fn, x):
       converted_fn, aux_args = jax.closure_convert(fn, x)
@@ -3427,6 +3469,94 @@ class CustomVJPTest(jtu.JaxTestCase):
           in (b,) }
         """).strip()
     self.assertEqual(actual, expected)
+
+  def test_defvjp_with_logs(self):
+    @jax.custom_vjp
+    def f(x, y):
+      return jnp.sin(x) * y
+
+    def f_fwd(x, y):
+      return f(x, y), (jnp.cos(x), jnp.sin(x), y)
+
+    def f_bwd(res, g):
+      cos_x, sin_x, y = res
+      return (cos_x * g * y, sin_x * g), {'f': {'ct_out': g, 'y': y}}
+
+    f.defvjp_with_logs(f_fwd, f_bwd)
+
+    _, f_vjp = jax.vjp(f, 1.0, 2.0)
+    (x_ct, y_ct), logs = f_vjp.with_logs(1.0)
+    self.assertAllClose(x_ct, jnp.cos(1.0) * 2.0)
+    self.assertAllClose(y_ct, jnp.sin(1.0))
+    self.assertAllClose(logs, {'f': {'ct_out': 1.0, 'y': 2.0}},
+                        check_dtypes=False)
+    x_ct2, _ = f_vjp(1.0)  # plain call drops the logs without error
+    self.assertAllClose(x_ct2, jnp.cos(1.0) * 2.0)
+    self.assertAllClose(jax.grad(f)(1.0, 2.0), jnp.cos(1.0) * 2.0,
+                        check_dtypes=False)
+
+    _, logsj = jax.vjp(jax.jit(f), 1.0, 2.0)[1].with_logs(1.0)
+    self.assertAllClose(logsj['f']['y'], 2.0, check_dtypes=False)
+    _, logst = jax.jit(
+        lambda x, y, ct: jax.vjp(f, x, y)[1].with_logs(ct))(1.0, 2.0, 1.0)
+    self.assertAllClose(logst['f']['y'], 2.0, check_dtypes=False)
+
+    def f_scan(xs):
+      c, _ = jax.lax.scan(lambda c, x: (c + f(x, 2.0), None), 0., xs)
+      return c
+    xs = jnp.arange(1., 4.)
+    cts, logss = jax.vjp(f_scan, xs)[1].with_logs(1.0)
+    self.assertAllClose(cts[0], 2.0 * jnp.cos(xs))
+    self.assertEqual(logss['f']['ct_out'].shape, (3,))
+    self.assertArraysAllClose(logss['f']['y'], jnp.full((3,), 2.0),
+                              check_dtypes=False)
+
+    (x_cts, _), logsv = jax.vmap(
+        lambda x, y, ct: jax.vjp(f, x, y)[1].with_logs(ct))(
+            xs, jnp.full((3,), 2.0), jnp.ones(3))
+    self.assertAllClose(x_cts, 2.0 * jnp.cos(xs))
+    self.assertEqual(logsv['f']['y'].shape, (3,))
+
+    r = jax.grad(lambda x: jax.vmap(f, in_axes=(0, None))(x, 2.0).sum())(xs)
+    self.assertAllClose(r, 2.0 * jnp.cos(xs))
+    _, logsvm = jax.vjp(
+        lambda x: jax.vmap(f, in_axes=(0, None))(x, 2.0), xs
+        )[1].with_logs(jnp.ones(3))
+    self.assertEqual(logsvm['f']['ct_out'].shape, (3,))
+
+    fr = jax.checkpoint(lambda x, y: f(x, y) * 3.)
+    (x_ct, _), logsr = jax.vjp(fr, 1.0, 2.0)[1].with_logs(1.0)
+    self.assertAllClose(x_ct, 3.0 * jnp.cos(1.0) * 2.0, check_dtypes=False)
+    self.assertAllClose(logsr['f']['ct_out'], 3.0, check_dtypes=False)
+
+  def test_defvjp_with_logs_nondiff_argnums_and_none_logs(self):
+    g = jax.custom_vjp(lambda n, x: x * n, nondiff_argnums=(0,))
+    g.defvjp_with_logs(lambda n, x: (g(n, x), None),
+                       lambda n, res, ct: ((ct * n,), {'g': ct * n}))
+    (x_ct,), logs = jax.vjp(lambda x: g(3.0, x), 2.0)[1].with_logs(1.0)
+    self.assertAllClose(x_ct, 3.0, check_dtypes=False)
+    self.assertAllClose(logs['g'], 3.0, check_dtypes=False)
+
+    h = jax.custom_vjp(lambda x: x * 2.)
+    h.defvjp_with_logs(lambda x: (h(x), None), lambda _, ct: ((2. * ct,), None))
+    (ct,), logs = jax.vjp(h, 1.0)[1].with_logs(1.0)
+    self.assertAllClose(ct, 2.0, check_dtypes=False)
+    self.assertEqual(logs, {})
+
+  def test_defvjp_with_logs_bad_return_errors(self):
+    @jax.custom_vjp
+    def e(x):
+      return x
+    e.defvjp_with_logs(lambda x: (e(x), None), lambda _, ct: (ct,))
+    with self.assertRaisesRegex(TypeError, "must produce a pair"):
+      jax.grad(e)(1.0)
+
+    @jax.custom_vjp
+    def e2(x):
+      return x
+    e2.defvjp_with_logs(lambda x: (e2(x), None), lambda _, ct: ((ct,), [1.0]))
+    with self.assertRaisesRegex(TypeError, "None or a dict"):
+      jax.grad(e2)(1.0)
 
 @jtu.with_config(jax_custom_vjp3=True)
 class CustomVJP3Test(CustomVJPTest):

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -2126,27 +2126,21 @@ class HijaxTest(jtu.JaxTestCase):
       self.assertAllClose(logsp['sq']['x'], jnp.sin(3.0))
 
   @parameterized.parameters([False, True])
-  def test_backward_pass_logging_remat_fancy_transpose(self, remat3):
-    # A fancy transpose rule's logs flow out of a rematted computation's
-    # backward pass, under both the classic remat_p implementation and remat3.
-    # (Unlike a vjp_bwd-only VJPHiPrimitive, a primitive with a jvp rule and a
-    # logging transpose rule works under classic remat's jvp-based
-    # differentiation too.)
-    from jax._src.interpreters import mlir
+  def test_backward_pass_logging_remat_custom_vjp(self, remat3):
+    @jax.custom_vjp
+    def log_id(x):
+      return x
 
-    log_id_p = core.Primitive('log_id')
-    log_id_p.def_impl(lambda x: x)
-    log_id_p.def_abstract_eval(lambda a: a)
-    ad.defjvp(log_id_p, lambda g, x: log_id_p.bind(g))
-    mlir.register_lowering(log_id_p, lambda ctx, x: [x])
-    def _log_id_transpose(ct, x):
-      if isinstance(x, ad.ValAccum):
-        x.accum(ct)
-      return {'canary': ct}
-    ad.fancy_transposes[log_id_p] = _log_id_transpose
+    def log_id_fwd(x):
+      return log_id(x), None
+
+    def log_id_bwd(_, ct):
+      return (ct,), {'canary': ct}
+
+    log_id.defvjp_with_logs(log_id_fwd, log_id_bwd)
 
     with config.remat3(remat3):
-      f = jax.checkpoint(lambda x: log_id_p.bind(jnp.sin(x)) * 2.)
+      f = jax.checkpoint(lambda x: log_id(jnp.sin(x)) * 2.)
       _, f_vjp = jax.vjp(f, 1.0)
       cts, logs = f_vjp.with_logs(1.0)
       self.assertAllClose(cts[0], 2 * jnp.cos(1.0))
@@ -2162,7 +2156,7 @@ class HijaxTest(jtu.JaxTestCase):
 
       # nested remat
       g = jax.checkpoint(lambda x: jax.checkpoint(
-          lambda y: log_id_p.bind(jnp.sin(y)))(x) * 2.)
+          lambda y: log_id(jnp.sin(y)))(x) * 2.)
       _, logsn = jax.vjp(g, 1.0)[1].with_logs(1.0)
       self.assertAllClose(logsn, {'canary': 2.0}, check_dtypes=False)
 


### PR DESCRIPTION
Implemented both on classic custom_vjp and custom_vjp3. So the long-run code complexity increase is mainly the hijax.py stuff.