### PR TITLE
Preserve signed zero in complex sqrt

### DIFF
--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -1132,6 +1132,24 @@ def arctanh(x: ArrayLike, /) -> Array:
   return out
 
 
+@custom_jvp
+def _complex_sqrt(x: Array) -> Array:
+  out = lax.sqrt(x)
+  imag = lax.imag(x)
+  out_imag = lax.imag(out)
+  return lax.complex(
+      lax.real(out),
+      _where(imag == 0, copysign(out_imag, imag), out_imag))
+
+
+@_complex_sqrt.defjvp
+def _complex_sqrt_jvp(primals, tangents):
+  x, = primals
+  tangent, = tangents
+  out = _complex_sqrt(x)
+  return out, lax.mul(tangent, lax.div(_lax_const(x, 0.5), out))
+
+
 @export
 @jit(inline=True)
 def sqrt(x: ArrayLike, /) -> Array:
@@ -1162,7 +1180,11 @@ def sqrt(x: ArrayLike, /) -> Array:
     >>> jnp.sqrt(-1)
     Array(nan, dtype=float32, weak_type=True)
   """
-  out = lax.sqrt(*promote_args_inexact('sqrt', x))
+  x, = promote_args_inexact('sqrt', x)
+  if dtypes.issubdtype(x.dtype, np.complexfloating):
+    out = _complex_sqrt(x)
+  else:
+    out = lax.sqrt(x)
   jnp_error._set_error_if_nan(out)
   return out
 

--- a/tests/lax_numpy_operators_test.py
+++ b/tests/lax_numpy_operators_test.py
@@ -659,6 +659,37 @@ class JaxNumpyOperatorTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
+  @jtu.sample_product(dtype=complex_dtypes)
+  def testSqrtPreservesBranchCutSign(self, dtype):
+    x = np.array([
+        complex(-1.0, 0.0), complex(-1.0, -0.0),
+        complex(1.0, 0.0), complex(1.0, -0.0),
+        complex(-0.0, 0.0), complex(-0.0, -0.0),
+    ], dtype=dtype)
+    expected = np.sqrt(x)
+    for actual in (jnp.sqrt(x), jax.jit(jnp.sqrt)(x)):
+      self.assertArraysEqual(actual, expected)
+      self.assertArraysEqual(np.signbit(actual.real), np.signbit(expected.real))
+      self.assertArraysEqual(np.signbit(actual.imag), np.signbit(expected.imag))
+
+  @jtu.sample_product(dtype=complex_dtypes)
+  def testSqrtSignedZeroJvp(self, dtype):
+    x = np.array([
+        complex(-1.0, 0.0), complex(-1.0, -0.0),
+        complex(1.0, 0.0), complex(1.0, -0.0),
+    ], dtype=dtype)
+    tangent = np.array([1j, -1j, 1j, -1j], dtype=dtype)
+    expected_primal = np.sqrt(x)
+    expected_tangent = tangent / (2 * expected_primal)
+
+    def sqrt_jvp(x, tangent):
+      return jax.jvp(jnp.sqrt, (x,), (tangent,))
+
+    for actual_primal, actual_tangent in (
+        sqrt_jvp(x, tangent), jax.jit(sqrt_jvp)(x, tangent)):
+      self.assertArraysEqual(actual_primal, expected_primal)
+      self.assertArraysAllClose(actual_tangent, expected_tangent)
+
   def testDeferToNamedTuple(self):
     class MyArray(NamedTuple):
       arr: jax.Array


### PR DESCRIPTION
## Summary

- preserve the sign of zero in the imaginary component of complex `jax.numpy.sqrt` results
- match NumPy on both sides of the negative-real branch cut
- add eager and JIT regression coverage for complex64 and complex128

Fixes #39110

## Verification

- `JAX_ENABLE_X64=true .venv/bin/python -m pytest -q tests/lax_numpy_operators_test.py --tb=short` (1630 passed)
- `.venv/bin/python -m ruff check jax/_src/numpy/ufuncs.py tests/lax_numpy_operators_test.py`
- `git diff --check`
- checked a 64-case special-value grid per complex dtype against NumPy and compared complex JVPs with `lax.sqrt` away from the branch cut
