### PR TITLE
[oneAPI] Fix startup_failure by removing permissions escalation in called workflow

### DIFF
--- a/.github/workflows/build_oneapi_artifacts.yml
+++ b/.github/workflows/build_oneapi_artifacts.yml
@@ -75,8 +75,7 @@ on:
         type: string
         default: "no"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build-oneapi-wheel:


### PR DESCRIPTION
The called workflow declared `permissions: contents: read` while the caller (bazel_oneapi_presubmit.yml) used `permissions: {}`. GitHub Actions rejects this escalation at startup. Change to `permissions: {}` to match the pattern used by all other reusable workflows in this repo.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->