### PR TITLE
jaxlib: malformed pickled PyTreeDef can crash flatten_up_to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,13 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     instances ({jax-issue}`#39297`).
   * Fixed `_get_prime_factors` in `jax.experimental.mesh_utils`
     ({jax-issue}`#38286`).
+  * Unpickling a malformed `PyTreeDef` whose cached `num_leaves` or
+    `num_nodes` is negative now raises instead of restoring an inconsistent
+    tree structure, and `PyTreeDef.flatten_up_to` now raises `ValueError`
+    instead of crashing when a treedef's leaf count is negative, which
+    {func}`jax.tree_util.treedef_tuple` could still produce by overflowing the
+    sum of its children's counts. Previously both cases could terminate the
+    interpreter with a segmentation fault ({jax-issue}`#37412`).
 
 ## JAX 0.11.0 (July 16, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     overwriting it, so HLO passes disabled via
     `XLA_FLAGS=--xla_disable_hlo_passes=...` stay disabled
     ({jax-issue}`#37391`).
+  * Unpickling a malformed `PyTreeDef` whose cached `num_leaves` or
+    `num_nodes` is negative now raises instead of restoring an inconsistent
+    tree structure, and `PyTreeDef.flatten_up_to` now raises `ValueError`
+    instead of crashing when a treedef's leaf count is negative, which
+    {func}`jax.tree_util.treedef_tuple` could still produce by overflowing the
+    sum of its children's counts. Previously both cases could terminate the
+    interpreter with a segmentation fault ({jax-issue}`#37412`).
 
 ## JAX 0.11.0 (July 16, 2026)
 

--- a/jaxlib/pytree.cc
+++ b/jaxlib/pytree.cc
@@ -959,11 +959,22 @@ nb::object PyTreeDef::Unflatten(absl::Span<const nb::object> leaves) const {
 }
 
 nb::list PyTreeDef::FlattenUpTo(nb::handle xs) const {
-  nb::list leaves = nb::steal<nb::list>(PyList_New(num_leaves()));
+  // A negative count (reachable by overflow in Tuple() and
+  // FromNodeDataAndChildren()) would defeat the `leaf < 0` guard below.
+  const int num_leaves = this->num_leaves();
+  if (num_leaves < 0) {
+    throw std::invalid_argument(absl::StrFormat(
+        "Malformed PyTreeDef: num_leaves is negative (%d).", num_leaves));
+  }
+  PyObject* py_leaves = PyList_New(num_leaves);
+  if (py_leaves == nullptr) {
+    throw nb::python_error();
+  }
+  nb::list leaves = nb::steal<nb::list>(py_leaves);
   std::vector<nb::object> agenda;
   agenda.push_back(nb::borrow<nb::object>(xs));
   auto it = traversal_.rbegin();
-  int leaf = num_leaves() - 1;
+  int leaf = num_leaves - 1;
   while (!agenda.empty()) {
     if (it == traversal_.rend()) {
       throw std::invalid_argument(absl::StrFormat(
@@ -1424,6 +1435,14 @@ void PyTreeDef::FromPickle(nb::object pickle) {
         break;
       case PyTreeKind::kDict:
         node.sorted_dict_keys = nb::cast<std::vector<nb::object>>(t[2]);
+        // MakeNode indexes sorted_dict_keys by [0, arity) without bounds
+        // checks.
+        if (node.arity < 0 || node.sorted_dict_keys.size() !=
+                                  static_cast<size_t>(node.arity)) {
+          throw xla::XlaRuntimeError(absl::StrCat(
+              "Malformed pickled PyTreeDef: dict with ",
+              node.sorted_dict_keys.size(), " keys has arity ", node.arity));
+        }
         break;
       case PyTreeKind::kCustom:
       case PyTreeKind::kDataclass:
@@ -1450,6 +1469,13 @@ void PyTreeDef::FromPickle(nb::object pickle) {
     }
     node.num_leaves = nb::cast<int>(t[4]);
     node.num_nodes = nb::cast<int>(t[5]);
+    // Valid cached counts are never negative (see SetNumLeavesAndNumNodes),
+    // and consumers such as FlattenUpTo are memory-unsafe if they are.
+    if (node.num_leaves < 0 || node.num_nodes < 0) {
+      throw xla::XlaRuntimeError(absl::StrCat(
+          "Malformed pickled PyTreeDef: negative num_leaves (",
+          node.num_leaves, ") or num_nodes (", node.num_nodes, ")"));
+    }
   }
 }
 

--- a/jaxlib/pytree_test.py
+++ b/jaxlib/pytree_test.py
@@ -15,6 +15,7 @@
 import collections
 import dataclasses
 import gc
+import pickle
 import warnings
 
 from absl.testing import absltest, parameterized
@@ -79,6 +80,93 @@ class PyTreeTest(parameterized.TestCase):
     o = object()
     with self.assertRaises(ValueError):
       self.roundtrip_proto({"a": ExampleType2(field0=o, field1=o)})
+
+  def restore_from_traversal(self, traversal):
+    # Rebuilds a PyTreeDef straight from pickle state, as pickle.loads does.
+    # Entries: (kind, arity, node_data, custom_type, num_leaves, num_nodes).
+    treedef = pytree.PyTreeDef.__new__(pytree.PyTreeDef)
+    treedef.__setstate__((registry, traversal))
+    return treedef
+
+  @parameterized.named_parameters(
+      # num_leaves = INT_MIN made flatten_up_to write through a null list
+      # (issue #37412); the other cases are caught by existing guards.
+      ("num_leaves_int_min", -(2**31), 4),
+      ("num_leaves_negative", -1, 4),
+      ("num_nodes_int_min", 3, -(2**31)),
+      ("num_nodes_negative", 3, -1),
+  )
+  def testUnpicklingRejectsNegativeCachedCounts(self, num_leaves, num_nodes):
+    leaf = (0, 0, None, None, 1, 1)
+    # Matches the other malformed-pickle rejections in PyTreeDef::FromPickle,
+    # which raise XlaRuntimeError (a RuntimeError subclass in Python).
+    with self.assertRaisesRegex(RuntimeError, "negative num_leaves"):
+      self.restore_from_traversal(
+          [leaf, leaf, leaf, (4, 3, None, None, num_leaves, num_nodes)]
+      )
+
+  @parameterized.named_parameters(
+      ("no_keys", []),
+      ("too_few_keys", ["a"]),
+      ("too_many_keys", ["a", "b", "c", "d"]),
+  )
+  def testUnpicklingRejectsDictKeyArityMismatch(self, keys):
+    # MakeNode indexes sorted_dict_keys by [0, arity), so a key list shorter
+    # than the arity used to read out of bounds and crash unflatten.
+    leaf = (0, 0, None, None, 1, 1)
+    with self.assertRaisesRegex(RuntimeError, "dict with .* keys has arity"):
+      self.restore_from_traversal(
+          [leaf, leaf, leaf, (5, 3, keys, None, 3, 4)]
+      )
+
+  def testUnpicklingAcceptsMatchingDictKeys(self):
+    o = object()
+    original = registry.flatten({"a": o, "b": o})[1]
+    restored = self.restore_from_traversal(original.__getstate__()[1])
+    self.assertEqual(restored, original)
+    self.assertEqual(restored.unflatten([1, 2]), {"a": 1, "b": 2})
+
+  def testFlattenUpToRejectsNegativeNumLeaves(self):
+    # treedef_tuple and from_node_data_and_children sum children's counts
+    # without overflow checks, so a negative total can still reach here.
+    leaf = (0, 0, None, None, 1, 1)
+    child = [leaf, leaf, leaf, (4, 3, None, None, 2**30, 4)]
+    children = [self.restore_from_traversal(child) for _ in range(2)]
+
+    parent = pytree.treedef_tuple(registry, children)
+    self.assertLess(parent.num_leaves, 0)
+    with self.assertRaisesRegex(ValueError, "num_leaves is negative"):
+      parent.flatten_up_to(([1, 2, 3], [4, 5, 6]))
+
+    parent = pytree.PyTreeDef.from_node_data_and_children(
+        registry, (list, None), children
+    )
+    self.assertLess(parent.num_leaves, 0)
+    with self.assertRaisesRegex(ValueError, "num_leaves is negative"):
+      parent.flatten_up_to([[1, 2, 3], [4, 5, 6]])
+
+  def testUnpicklingAcceptsValidCachedCounts(self):
+    # The counts above are rejected for being negative, not for disagreeing
+    # with the traversal, so well-formed state must still restore exactly.
+    o = object()
+    original = registry.flatten([o, {"a": o, "b": o}, (o, None)])[1]
+    restored = self.restore_from_traversal(original.__getstate__()[1])
+    self.assertEqual(restored, original)
+    self.assertEqual(restored.num_leaves, 4)
+    self.assertEqual(
+        list(restored.flatten_up_to([1, {"a": 2, "b": 3}, (4, None)])),
+        [1, 2, 3, 4],
+    )
+
+    # Also exercise a real pickle round trip, which needs a registry that is
+    # itself picklable; the module-level one above is not.
+    original = pytree.default_registry().flatten([o, {"a": o}, (o, None)])[1]
+    restored = pickle.loads(pickle.dumps(original))
+    self.assertEqual(restored, original)
+    self.assertEqual(restored.num_leaves, 3)
+    self.assertEqual(
+        list(restored.flatten_up_to([1, {"a": 2}, (3, None)])), [1, 2, 3]
+    )
 
   def roundtrip_node_data(self, example):
     original = registry.flatten(example)[1]


### PR DESCRIPTION
Fixes #37412.

Unpickling a malformed PyTreeDef could crash the interpreter. FromPickle trusted the cached num_leaves/num_nodes and the dict key list from the pickle, and flatten_up_to and unflatten segfault when those are inconsistent. The reported case: num_leaves = INT_MIN makes PyList_New fail and return null, the null was never checked, and the loop counter overflow skipped the leaf < 0 guard.

Changes:

* FromPickle rejects negative num_leaves/num_nodes and a dict node whose key list doesn't match its arity. Bad pickles now fail at pickle.loads.
* flatten_up_to checks for a negative leaf count and for PyList_New failing. Still needed without pickle: treedef_tuple can overflow the sum of its children's counts into a negative total, which also segfaulted.