### PR TITLE
fix: Include trace context in device_replica_id_map cache key to avoid compile-time blowup (closes #39483)

### DIFF
--- a/jax/_src/sharding_impls.py
+++ b/jax/_src/sharding_impls.py
@@ -65,7 +65,7 @@ def hashed_index(x) -> int:
   return hash(tuple((v.start, v.stop) if isinstance(v, slice) else v for v in x))
 
 
-@util.cache(max_size=4096, trace_context_in_key=False)
+@util.cache(max_size=4096, trace_context_in_key=True)
 def device_replica_id_map(sharding, global_shape: Shape) -> Mapping[Device, int]:
   try:
     device_indices_map_fn = sharding.devices_indices_map


### PR DESCRIPTION
## What
When a jitted function ends with a reduction after a chain of scatter-adds, GPU compile time increases ~190x (0.4s -> 75s). The compiled module size is not significantly larger, indicating the compile-time cost is not due to generated code but likely from repeated expensive computations during compilation.

## Fix
The `device_replica_id_map` function is cached with `trace_context_in_key=False`, meaning the cache key is only the sharding object and shape. Across different JIT traces (e.g., when the trace shape or sharding changes due to the added reduction), stale cache entries can cause invalid hits or trigger repeated recomputation in ways that compound with many sharded operations. By including the trace context in the cache key (as is done in other JAX caches), each trace gets its own cache entry, preventing cross-trace cache pollution and reducing repeated device-to-index mapping work.

This is a minimal one-line change and matches the existing caching conventions in JAX. It does not change semantics, only invalidates the cache across traces. If the cache was not intended to be shared across traces, this is the correct fix.

Closes #39483