### PR TITLE
fix(scipy.special): return -inf for betaln when one argument is +inf

### DIFF
--- a/jax/_src/third_party/scipy/betaln.py
+++ b/jax/_src/third_party/scipy/betaln.py
@@ -40,7 +40,11 @@ def algdiv(a: ArrayLike, b: ArrayLike) -> Array:
     w = ((((c5 * s11 * t + c4 * s9) * t + c3 * s7) * t + c2 * s5) * t + c1 * s3) * t + c0
     w = w * (c / b)
     # Combine the results
-    u = d * lax.log1p(a / b)
+    # When b is infinite, log1p(a/b) = 0 so u = d * 0. Because d may also be
+    # infinite (d = b + a - 0.5), this produces 0 * inf = NaN. The correct
+    # limiting value is u = 0 (since a/b -> 0 as b -> inf and log1p(0) = 0).
+    log1p_ab = lax.log1p(a / b)
+    u = jnp.where(jnp.isinf(b) & jnp.isfinite(a), 0.0, d * log1p_ab)
     v = a * (lax.log(b) - 1.0)
     return jnp.where(u <= v, (w - v) - u, (w - u) - v)
 
@@ -60,4 +64,10 @@ def betaln(a: ArrayLike, b: ArrayLike) -> Array:
     a, b = jnp.minimum(a, b), jnp.maximum(a, b)
     small_b = lax.lgamma(a) + (lax.lgamma(b) - lax.lgamma(a + b))
     large_b = lax.lgamma(a) + algdiv(a, b)
-    return jnp.where(b < 8, small_b, large_b)
+    result = jnp.where(b < 8, small_b, large_b)
+    # When exactly one argument is +inf and the other is finite positive,
+    # beta(a, inf) -> 0 so betaln -> -inf.  The algdiv path handles this
+    # correctly after the fix above, but small_b = lgamma(a) + lgamma(inf) -
+    # lgamma(inf) = lgamma(a) + nan, so we must force -inf here.
+    one_inf = jnp.isinf(b) & jnp.isfinite(a) & (a > 0)
+    return jnp.where(one_inf, jnp.full_like(result, -jnp.inf), result)

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -253,6 +253,22 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     # Check that d/dx betaln(x, 1) = d/dx -log(x) = -1/x.
     self.assertAllClose(tangents_out, -1 / xs, atol=atol)
 
+
+  def testBetalnInfiniteArguments(self):
+    """betaln should return -inf (not NaN) when one argument is +inf.
+
+    Regression test for https://github.com/jax-ml/jax/issues/39106.
+    Root cause: algdiv computed u = d * log1p(a/b) where d=inf and
+    log1p(a/inf)=0, producing inf * 0 = NaN.
+    """
+    inf = jnp.inf
+    # One argument inf, other finite positive -> betaln = -inf
+    cases_a = jnp.array([inf,  inf,  10.0, 0.25], dtype=jnp.float32)
+    cases_b = jnp.array([0.25, 2.0,  inf,  inf],  dtype=jnp.float32)
+    expected = jnp.full(4, -inf, dtype=jnp.float32)
+    result = lsp_special.betaln(cases_a, cases_b)
+    self.assertAllClose(result, expected)
+
   def testXlogyShouldReturnZero(self):
     self.assertAllClose(lsp_special.xlogy(0., 0.), 0., check_dtypes=False)
 


### PR DESCRIPTION
## Description

Fixes #39106

`jax.scipy.special.betaln(inf, b)` and `betaln(a, inf)` for finite positive `a`, `b` were returning `NaN` instead of `-inf`.

## Root cause

In `algdiv`, the combination step computes:
```
u = d * log1p(a / b)
```
When `b = inf`: `d = b + (a - 0.5) = inf` and `log1p(a/inf) = log1p(0) = 0`, so `u = inf * 0 = NaN`.

The correct limiting value is `u = 0` (since `log1p(a/b) -> 0` as `b -> inf`).

Additionally, the `small_b` path also produces NaN via `lgamma(inf) - lgamma(inf) = inf - inf`, so an explicit `-inf` guard is needed in `betaln` for the one-infinite-argument case.

## Fix

- In `algdiv`: set `u = 0` when `b` is infinite and `a` is finite, avoiding the `0 * inf` indeterminate form.
- In `betaln`: add an explicit `-inf` guard for the one-infinite-argument case.

## Testing

Added `testBetalnInfiniteArguments` regression test covering all four permutations. Full test suite requires nightly jaxlib; logic verified against SciPy.

Implemented with Claude Code assistance. All changed lines reviewed manually.