### PR TITLE
Fix cp.async tiled bug

### DIFF
--- a/jax/experimental/mosaic/gpu/launch_context.py
+++ b/jax/experimental/mosaic/gpu/launch_context.py
@@ -1034,12 +1034,18 @@ class LaunchContext:
                         *(t.batch(len(squeezed_dims)) for t in gmem_transform))
 
     slice_shape = tuple(slice_shape)
+    # The logical shape of the window we extract from GMEM, before any user
+    # transforms are applied. Transforms are not always shape-preserving (e.g.
+    # tiling), so we return it separately for the benefit of callers that need
+    # to reason about the untransformed window.
+    logical_slice_shape = slice_shape
     for t in gmem_transform:
       dyn_base_indices = t.transform_index(dyn_base_indices)
       slice_shape = t.transform_shape(slice_shape)
 
     return (
         list(slice_shape),
+        list(logical_slice_shape),
         dyn_base_indices,
         squeezed_dims,
         gather_indices,
@@ -1299,6 +1305,7 @@ class LaunchContext:
 
     (
         slice_shape,
+        logical_slice_shape,
         dyn_base_indices,
         squeezed_dims,
         gather_indices,
@@ -1444,7 +1451,8 @@ class LaunchContext:
         if gmem_ref_ty.rank != 2:
           raise NotImplementedError("Only 2D copies implemented")
         transfers = fa.FragmentedArray.transfer_tiled(
-            smem_ref, swizzle, layout, tuple(gmem_ref_ty.shape), optimized=False
+            smem_ref, swizzle, layout, tuple(logical_slice_shape),
+            optimized=False,
         )
         gmem_base_ptr = utils.getelementptr(utils.memref_ptr(gmem_ref), [dyn_offset], gep_type)
         gmem_base_ptr = llvm.addrspacecast(
@@ -1922,6 +1930,7 @@ class LaunchContext:
     impl =  AsyncCopyImplementation.TMA
     (
         slice_shape,
+        _,
         dyn_base_indices,
         squeezed_dims,
         gather_indices,

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -4796,6 +4796,46 @@ class AsyncCopyTest(TestCase, jtu.CudaArchSpecificTest):
     self._test_cp_async(shape, dtype, swizzle=swizzle, tiling=tiling)
 
   @parameterized.product(
+      swizzle=(32, 64, 128),
+      dtype=(jnp.float32, jnp.float16),
+  )
+  def test_cp_async_tiled_window(self, swizzle, dtype):
+    # A tiled copy of a sub-block of the array: the transfer must be built from
+    # the shape of the window, not the shape of the whole GMEM ref.
+    bw = bitwidth(dtype_to_ir_type(dtype))
+    swizzle_elems = 8 * swizzle // bw
+    tiling = (8, swizzle_elems)
+    window_shape = (64, swizzle_elems)
+    shape = (4 * window_shape[0], window_shape[1])
+    row = window_shape[0]  # Copy the second block of rows.
+
+    def kernel(ctx, src, dst, scratch):
+      tmp, barrier = scratch
+      ctx.async_copy(
+          src_ref=src,
+          dst_ref=tmp,
+          gmem_slice=(slice(row, row + window_shape[0]), slice(None)),
+          swizzle=swizzle,
+          gmem_transform=mgpu.TileTransform(tiling),
+          implementation=mgpu.AsyncCopyImplementation.CP_ASYNC,
+          barrier=barrier,
+      )
+      barrier.wait()
+      mgpu.copy_tiled(tmp, dst, swizzle=swizzle)
+
+    x = np.arange(np.prod(shape), dtype=dtype).reshape(shape)
+    smem = jax.ShapeDtypeStruct(mgpu.tile_shape(window_shape, tiling), dtype)
+    y = mgpu.as_gpu_kernel(
+        kernel,
+        (1, 1, 1),
+        (128, 1, 1),
+        x,
+        jax.ShapeDtypeStruct(window_shape, dtype),
+        (smem, mgpu.Barrier(arrival_count=1)),
+    )(x)
+    np.testing.assert_array_equal(y, x[row : row + window_shape[0]])
+
+  @parameterized.product(
       shape=((64, 128), (128, 40), (5, 256)),
       dtype=(jnp.float32, jnp.float16),
   )


### PR DESCRIPTION
Fixes #39687

Every tiled `cp.async` copy of a *sub-block* of an array fails to lower. Since a pipelined copy is by definition a sub-block copy, the tiled `cp.async` path is unusable from `plgpu.emit_pipeline`. This PR fixes the incorrect shape that leads to errors like

```
ValueError: The reference has untiled shape of (64, 256) while the register
             array has shape (256, 256)
```
raised from `FragmentedArray.transfer_tiled` (`fragmented_array.py:4200`).