### PR TITLE
[ROCm] Stage libhipsparse in the ROCm wheel test dependencies

### DIFF
--- a/jaxlib/tools/BUILD.bazel
+++ b/jaxlib/tools/BUILD.bazel
@@ -547,6 +547,7 @@ collect_data_files(
         "@local_config_rocm//rocm:hipfft",
         "@local_config_rocm//rocm:hiprand",
         "@local_config_rocm//rocm:hipsolver",
+        "@local_config_rocm//rocm:hipsparse",
         "@local_config_rocm//rocm:miopen",
         "@local_config_rocm//rocm:rccl",
         "@local_config_rocm//rocm:rocm_smi",


### PR DESCRIPTION
We are moving the ROCm build over to a fully hermetic TheRock setup (openxla/xla#46510). With that in place, the tridiagonal solve tests fail with `NOT_FOUND: No FFI handler registered for hipsparse_gtsv2_ffi`, because libhipsparse is never staged into the test runfiles and the plugin's `_sparse` module therefore cannot load.

`rocm_libs_data` was missing `@local_config_rocm//rocm:hipsparse`, so this adds it. The current non-hermetic CI hides the problem by pointing `LD_LIBRARY_PATH` at the host ROCm libraries.