### PR TITLE
Reject malformed PyTreeDefProto instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     overwriting it, so HLO passes disabled via
     `XLA_FLAGS=--xla_disable_hlo_passes=...` stay disabled
     ({jax-issue}`#37391`).
+  * `PyTreeDef.deserialize_using_proto` now raises `ValueError` for a
+    malformed `PyTreeDefProto` instead of crashing the interpreter. A node
+    whose arity exceeds the subtrees preceding it is rejected, as is a dict
+    node whose arity disagrees with its key list, which previously segfaulted
+    later, when the structure was used to unflatten.
+    `PyTreeDef.compose` likewise raises `ValueError` rather than crashing when
+    an operand carries such an inconsistent arity, which is reachable from
+    `pickle.loads` ({jax-issue}`#37410`).
 
 ## JAX 0.11.0 (July 16, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,14 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     instances ({jax-issue}`#39297`).
   * Fixed `_get_prime_factors` in `jax.experimental.mesh_utils`
     ({jax-issue}`#38286`).
+  * `PyTreeDef.deserialize_using_proto` now raises `ValueError` for a
+    malformed `PyTreeDefProto` instead of crashing the interpreter. A node
+    whose arity exceeds the subtrees preceding it is rejected, as is a dict
+    node whose arity disagrees with its key list, which previously segfaulted
+    later, when the structure was used to unflatten.
+    `PyTreeDef.compose` likewise raises `ValueError` rather than crashing when
+    an operand carries such an inconsistent arity, which is reachable from
+    `pickle.loads` ({jax-issue}`#37410`).
 
 ## JAX 0.11.0 (July 16, 2026)
 

--- a/jaxlib/pytree.cc
+++ b/jaxlib/pytree.cc
@@ -1465,6 +1465,19 @@ void PyTreeDef::SetNumLeavesAndNumNodes() {
     if (traversal_[i].arity == 0) {
       starts.push_back(start);
     } else {
+      // A node absorbs `arity` subtrees, so that many must precede it; the
+      // resize and back() below read out of bounds otherwise.
+      if (traversal_[i].arity < 0) {
+        throw std::invalid_argument(absl::StrFormat(
+            "Malformed PyTreeDef: node %d has negative arity (%d).", i,
+            traversal_[i].arity));
+      }
+      if (static_cast<size_t>(traversal_[i].arity) > starts.size()) {
+        throw std::invalid_argument(absl::StrFormat(
+            "Malformed PyTreeDef: node %d has arity %d, exceeding the number "
+            "of subtrees preceding it (%d).",
+            i, traversal_[i].arity, starts.size()));
+      }
       starts.resize(starts.size() - (traversal_[i].arity - 1));
     }
     traversal_[i].num_leaves = num_leaves - starts.back().first;
@@ -1555,6 +1568,15 @@ nb_class_ptr<PyTreeDef> PyTreeDef::DeserializeFrom(
                 "Malformed pytree proto (dict_key out of range).");
           }
           node.sorted_dict_keys.push_back(interned_strings.at(str_id));
+        }
+        // MakeNode indexes sorted_dict_keys by [0, arity) without bounds
+        // checks; the proto carries the two fields independently.
+        if (node.arity < 0 || node.sorted_dict_keys.size() !=
+                                  static_cast<size_t>(node.arity)) {
+          throw std::invalid_argument(absl::StrFormat(
+              "Malformed pytree proto (dict node has arity %d, which does not "
+              "match its number of keys %d).",
+              node.arity, node.sorted_dict_keys.size()));
         }
         break;
       default:

--- a/jaxlib/pytree_test.py
+++ b/jaxlib/pytree_test.py
@@ -55,6 +55,40 @@ class Custom:
 registry.register_dataclass_node(Custom, ["a"], ["b"])
 
 
+# Hand-built PyTreeDefProto payloads, for structures the serializer itself
+# cannot produce. See jaxlib/pytree.proto for the field numbers.
+_LEAF, _LIST, _DICT = 1, 2, 5  # PyTreeNodeType values
+
+
+def _varint(value):
+  out = bytearray()
+  while True:
+    byte = value & 0x7F
+    value >>= 7
+    out.append(byte | (0x80 if value else 0))
+    if not value:
+      return bytes(out)
+
+
+def _proto_node(arity, kind, dict_key_ids=None):
+  body = b"\x08" + _varint(arity) + b"\x10" + _varint(kind)
+  if dict_key_ids is not None:
+    packed = b"".join(_varint(i) for i in dict_key_ids)
+    keys = b"\x0a" + _varint(len(packed)) + packed
+    body += b"\x1a" + _varint(len(keys)) + keys
+  return b"\x0a" + _varint(len(body)) + body
+
+
+def _proto_treedef(nodes, interned_strings=()):
+  out = b"".join(nodes)
+  for s in interned_strings:
+    out += b"\x12" + _varint(len(s)) + s.encode()
+  return out
+
+
+_LEAF_NODE = _proto_node(0, _LEAF)
+
+
 class PyTreeTest(parameterized.TestCase):
 
   def roundtrip_proto(self, example):
@@ -79,6 +113,57 @@ class PyTreeTest(parameterized.TestCase):
     o = object()
     with self.assertRaises(ValueError):
       self.roundtrip_proto({"a": ExampleType2(field0=o, field1=o)})
+
+  def testDeserializeHandBuiltProto(self):
+    # Control for the malformed payloads below: same construction, valid data.
+    o = object()
+    self.assertEqual(
+        pytree.PyTreeDef.deserialize_using_proto(
+            registry,
+            _proto_treedef([_LEAF_NODE, _LEAF_NODE, _proto_node(2, _LIST)]),
+        ),
+        registry.flatten([o, o])[1],
+    )
+
+  @parameterized.named_parameters(
+      ("root_arity_1", [_proto_node(1, _LIST)]),
+      ("root_arity_2", [_proto_node(2, _LIST)]),
+      (
+          "arity_exceeds_subtrees",
+          [_LEAF_NODE, _LEAF_NODE, _proto_node(3, _LIST)],
+      ),
+      ("arity_int_min", [_proto_node(0x80000000, _LIST)]),
+      ("arity_uint32_max", [_proto_node(0xFFFFFFFF, _LIST)]),
+  )
+  def testDeserializeProtoRejectsBadArity(self, nodes):
+    with self.assertRaisesRegex(ValueError, "Malformed PyTreeDef"):
+      pytree.PyTreeDef.deserialize_using_proto(registry, _proto_treedef(nodes))
+
+  @parameterized.named_parameters(
+      (
+          "arity_exceeds_keys",
+          [_LEAF_NODE, _LEAF_NODE, _proto_node(2, _DICT, [0])],
+          ["a"],
+      ),
+      (
+          "keys_exceed_arity",
+          [_LEAF_NODE, _proto_node(1, _DICT, [0, 1])],
+          ["a", "b"],
+      ),
+  )
+  def testDeserializeProtoRejectsDictKeyMismatch(self, nodes, interned_strings):
+    with self.assertRaisesRegex(ValueError, "dict node"):
+      pytree.PyTreeDef.deserialize_using_proto(
+          registry, _proto_treedef(nodes, interned_strings)
+      )
+
+  def testComposeRejectsBadArity(self):
+    # compose() recomputes the cached counts, so it must reject a traversal
+    # restored from a pickle whose root claims children it does not have.
+    with self.assertRaisesRegex(ValueError, "Malformed PyTreeDef"):
+      poisoned = pytree.PyTreeDef.__new__(pytree.PyTreeDef)
+      poisoned.__setstate__((registry, [(4, 1, None, None, 1, 1)]))
+      poisoned.compose(registry.flatten(0)[1])
 
   def roundtrip_node_data(self, example):
     original = registry.flatten(example)[1]

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -1277,6 +1277,15 @@ class StaticTest(parameterized.TestCase):
     )
     self.assertEqual(tree_structure, new_structure)
 
+  def test_deserialize_malformed_treedef(self):
+    # A single list node claiming a child that no earlier node supplies.
+    # This used to segfault rather than raise.
+    with self.assertRaisesRegex(ValueError, "Malformed PyTreeDef"):
+      jax.tree_util.PyTreeDef.deserialize_using_proto(
+        jax.tree_util.default_registry,
+        bytes.fromhex("0a0408011002")
+      )
+
   def test_compare_pytreedef_with_registries(self):
     class MyCustomType:
       def __init__(self, x):

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -1271,6 +1271,15 @@ class StaticTest(parameterized.TestCase):
     )
     self.assertEqual(tree_structure, new_structure)
 
+  def test_deserialize_malformed_treedef(self):
+    # A single list node claiming a child that no earlier node supplies.
+    # This used to segfault rather than raise.
+    with self.assertRaisesRegex(ValueError, "Malformed PyTreeDef"):
+      jax.tree_util.PyTreeDef.deserialize_using_proto(
+        jax.tree_util.default_registry,
+        bytes.fromhex("0a0408011002")
+      )
+
   def test_compare_pytreedef_with_registries(self):
     class MyCustomType:
       def __init__(self, x):


### PR DESCRIPTION
PyTreeDef::SetNumLeavesAndNumNodes walks the post-order traversal keeping a stack of finished subtrees, and for a node of arity a it does starts.resize(starts.size() - (a - 1)) followed by starts.back(). That assumes at least a subtrees are already on the stack. Flattening a real object always satisfies it, a traversal restored from bytes need not, and nothing checked.

deserialize_using_proto copies the proto arity verbatim, so the six byte payload from the issue (a single list node with arity 1) leaves the stack empty and never allocated, and back() dereferences a null data pointer. Only arity 1 faults: arity 2 or more underflows the resize count and throws length_error by accident, and with a non-empty stack back() reads one slot before the buffer without faulting, yielding a PyTreeDef with a garbage num_leaves rather than an error.

Reject a node whose arity is negative, which is what a proto arity above INT_MAX becomes in the int field, or exceeds the subtrees preceding it. The check lives in SetNumLeavesAndNumNodes rather than in the deserializer because compose() recomputes the same counts, so an unpickled PyTreeDef with a bad root arity reaches the identical crash.

Also reject a dict node whose arity disagrees with its key list. MakeNode indexes sorted_dict_keys over [0, arity) without bounds checking, and the proto carries the two fields independently, so such a payload deserialized cleanly and then crashed later, in unflatten.

A proto whose nodes do not reduce to a single root is still accepted. It is not memory unsafe, and every operation on such a PyTreeDef already raises.

Fixes #37410

