### PR TITLE
Fix vmap of a scan closing over a Ref batched on a non-leading axis

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1218,6 +1218,15 @@ def _scan_batching_rule(axis_data, args, dims, reverse, length, jaxpr,
                         ft_in, ft_out, unroll):
   orig_batched = [d is not None for d in dims]
   const_batched, init_batched, xs_batched = ft_in.update(orig_batched).unpack()
+  consts, init, xs = ft_in.update(args).unpack()
+  consts_bdims, init_bdims, xs_bdims = ft_in.update(dims).unpack()
+
+  # A batched const which is a Ref can't have its batch dimension moved to the
+  # front, since that would require transposing the underlying mutable memory.
+  # Instead we batch the body jaxpr along the dimension the ref already has.
+  const_axes = [d if d is not None and isinstance(typeof(x), AbstractRef)
+                else 0 if b else None
+                for x, d, b in zip(consts, consts_bdims, const_batched)]
 
   # Fixpoint computation of which carry are batched: either
   # batched from init, or the carry out is batched. Each iteration promotes
@@ -1226,10 +1235,13 @@ def _scan_batching_rule(axis_data, args, dims, reverse, length, jaxpr,
   # carry_batched.
   carry_batched = init_batched
   for _ in range(1 + len(carry_batched)):
-    batched = list(ft.pack((const_batched, carry_batched, xs_batched)))
-    jaxpr_batched, batched_out = batching.batch_jaxpr(
-        jaxpr, axis_data, batched,
-        instantiate=list(carry_batched) + [False] * len(ft_out.unpack()[1]))
+    in_axes = (const_axes + [0 if b else None for b in carry_batched]
+               + [0 if b else None for b in xs_batched])
+    instantiate = list(carry_batched) + [False] * len(ft_out.unpack()[1])
+    out_axes_dest = [0 if inst else batching.zero_if_mapped
+                     for inst in instantiate]
+    jaxpr_batched, batched_out = batching.batch_jaxpr_axes(
+        jaxpr, axis_data, in_axes, out_axes_dest)
     carry_batched_out, ys_batched = ft_out.update(batched_out).unpack()
     if list(carry_batched_out) == list(carry_batched):
       break
@@ -1238,10 +1250,8 @@ def _scan_batching_rule(axis_data, args, dims, reverse, length, jaxpr,
   else:
     assert False, "Fixpoint not reached"
 
-  consts, init, xs = ft_in.update(args).unpack()
-  consts_bdims, init_bdims, xs_bdims = ft_in.update(dims).unpack()
-  new_consts = [batching.moveaxis(x, d, 0) if d is not None and d != 0
-                else x for x, d in zip(consts, consts_bdims)]
+  new_consts = [batching.moveaxis(x, d, 0) if a == 0 and d != 0 else x
+                for x, d, a in zip(consts, consts_bdims, const_axes)]
   new_init = [batching.broadcast(x, axis_data.size, 0, axis_data.explicit_mesh_axis)
               if now_batched and not was_batched
               else batching.moveaxis(x, d, 0) if now_batched else x

--- a/tests/mutable_array_test.py
+++ b/tests/mutable_array_test.py
@@ -341,6 +341,49 @@ class MutableArrayTest(jtu.JaxTestCase):
     jax.vmap(f, in_axes=(1, 0))(ref, jnp.ones((3, 2)))  # don't crash
     self.assertAllClose(ref[...], jnp.ones((2, 3)), check_dtypes=False)
 
+  @parameterized.parameters([True, False])
+  def test_vmap_axes_scan_closed_over_ref(self, jit):
+    # https://github.com/jax-ml/jax/issues/39288
+    def f(r):
+      def body(carry, _):
+        r[0] += 1.
+        return carry + r[0], None
+      carry, _ = jax.lax.scan(body, 0., length=3)
+      return carry
+
+    def doit(ref):
+      return jax.vmap(f, in_axes=1)(ref)
+    if jit:
+      doit = jax.jit(doit)
+
+    ref = jax.new_ref(jnp.zeros((2, 3)))
+    out = doit(ref)
+    # Batching over axis 1 means each batch element sees ref[:, i], so the
+    # writes land in row 0 and the carry accumulates 1. + 2. + 3.
+    self.assertAllClose(ref[...], jnp.array([[3., 3., 3.], [0., 0., 0.]]),
+                        check_dtypes=False)
+    self.assertAllClose(out, jnp.full((3,), 6.), check_dtypes=False)
+
+  @parameterized.parameters([True, False])
+  def test_vmap_axes_scan_ref_extensive_inputs(self, jit):
+    # https://github.com/jax-ml/jax/issues/39288
+    def f(r, xs):
+      def body(carry, x):
+        r[...] += x
+        return carry, None
+      jax.lax.scan(body, None, xs)
+
+    def doit(ref, xs):
+      jax.vmap(f, in_axes=(1, 0))(ref, xs)
+    if jit:
+      doit = jax.jit(doit)
+
+    ref = jax.new_ref(jnp.zeros((2, 3)))
+    xs = jnp.arange(6.).reshape(3, 2)
+    doit(ref, xs)
+    self.assertAllClose(ref[...], jnp.tile(xs.sum(axis=1), (2, 1)),
+                        check_dtypes=False)
+
   def test_vmap_extensive_inputs(self):
     def f(x_ref, val):
       x_ref[...] += val


### PR DESCRIPTION
Fixes the two `scan` failures reported in #39288, where a `Ref` passed to `vmap` with a non-leading `in_axes` and then read or written inside a `lax.scan` crashed.

Root cause: `_scan_batching_rule` batches the body jaxpr with `batching.batch_jaxpr`, whose interface is per-input booleans, so a batched input is always assumed to be batched on the leading axis. To make the values agree with that jaxpr, the rule then moved every batched const to the leading axis with `batching.moveaxis`. That is fine for arrays, but a ref cannot be transposed: moving its batch dimension would mean transposing the mutable memory it points at. So a batched ref const with a batch dimension other than 0 hit `batching.moveaxis` and raised `AttributeError: 'Ref' object has no attribute 'transpose'` in eager mode, and a confusing `Triggering __jax_array__() during abstractification is no longer supported` error under `jit`. This is the case @mattjj described in the issue thread.

Fix: batch the body jaxpr along the batch dimension a ref const already has instead of moving the ref. The rule now calls `batching.batch_jaxpr_axes` with explicit per-input axes and skips the `moveaxis` for those consts. `AbstractRef` already has aval mapping handlers that accept any axis, so no other machinery needed changing. Array consts keep their existing leading-axis treatment, the carry fixpoint is untouched, and the boolean `instantiate` to `out_axes_dest` translation is exactly the one `batch_jaxpr` was already doing internally, so nothing changes for cases that worked before.

Verification, all on CPU with jaxlib 0.11.0.

The three snippets in the issue, plus its two controls, on this branch:

```
snip3 (full-ref write)   [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]
snip4 (scan, eager)      [[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]]
snip5 (scan, jit)        [[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]]
control, batch axis 0    [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]
control, no scan         [[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]]
```

The two scan cases now agree with the no-scan control, which is the result the issue expects. `snip3` was already fixed on main and is covered by `test_vmap_axes_basic`.

Added `test_vmap_axes_scan_closed_over_ref` and `test_vmap_axes_scan_ref_extensive_inputs` in `tests/mutable_array_test.py`, each parameterized over eager and `jit`. The first also exercises the carry fixpoint, since the scan carry starts unbatched and becomes batched only because of the read from the batched ref. All four fail on main with the errors above and pass with this change.

I also checked non-leading batch dimensions on a rank-3 ref for every axis, and confirmed the batched result matches the batch-axis-0 computation on the transposed ref, including the scan output carry.

Test suites run locally, all green: `tests/mutable_array_test.py` and `tests/state_test.py` (314 passed, 3 skipped), `tests/lax_control_flow_test.py` (1023 passed, 2 skipped), `tests/batching_test.py` (232 passed).

`lax.while_loop` and `lax.fori_loop` already handled this case correctly, and `lax.cond` with state effects under `vmap` still raises its existing `NotImplementedError`, tracked separately in #39290, so this change is limited to `scan`.
