### PR TITLE
Ensure arraylike inputs are converted before internal use

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1799,7 +1799,8 @@ register_cpu_gpu_lowering(lu_p, _lu_cpu_gpu_lowering)
 def lu_solve(lu: ArrayLike, permutation: ArrayLike, b: ArrayLike,
              trans: int = 0) -> Array:
   """LU solve with broadcasting."""
-  return _lu_solve(lu, permutation, b, trans)
+  return _lu_solve(lax.asarray(lu), lax.asarray(permutation), lax.asarray(b),
+                   trans)
 
 
 def _lu_solve_core(lu: Array, permutation: Array, b: Array, trans: int) -> Array:

--- a/jax/_src/numpy/array_methods.py
+++ b/jax/_src/numpy/array_methods.py
@@ -1022,7 +1022,7 @@ def _chunk_iter(x, size):
   if size > x.shape[0]:
     yield x
   else:
-    num_chunks, tail = ufuncs.divmod(x.shape[0], size)
+    num_chunks, tail = divmod(x.shape[0], size)
     for i in range(num_chunks):
       yield lax_slicing.dynamic_slice_in_dim(x, i * size, size)
     if tail:

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -33,7 +33,7 @@ from jax._src.lax import linalg as lax_linalg
 from jax._src.numpy import linalg as jnp_linalg
 from jax._src.numpy import vectorize as jnp_vectorize
 from jax._src.numpy.util import (
-    check_arraylike, promote_dtypes, promote_dtypes_inexact,
+    check_arraylike, ensure_arraylike, promote_dtypes, promote_dtypes_inexact,
     promote_dtypes_complex, promote_args_inexact)
 from jax._src.scipy.special import comb
 from jax._src.tpu.linalg import qdwh
@@ -574,7 +574,7 @@ def schur(a: ArrayLike, output: str = 'real') -> tuple[Array, Array]:
   if output not in ('real', 'complex'):
     raise ValueError(
       f"Expected 'output' to be either 'real' or 'complex', got {output=}.")
-  return _schur(a, output)
+  return _schur(ensure_arraylike("scipy.schur", a), output)
 
 
 def inv(a: ArrayLike, overwrite_a: bool = False, check_finite: bool = True) -> Array:
@@ -2222,7 +2222,7 @@ def sqrtm(A: ArrayLike, blocksize: int = 1) -> Array:
   """
   if blocksize > 1:
       raise NotImplementedError("Blocked version is not implemented yet.")
-  return _sqrtm(A)
+  return _sqrtm(ensure_arraylike("scipy.sqrtm", A))
 
 
 @jit

--- a/jax/_src/scipy/stats/kde.py
+++ b/jax/_src/scipy/stats/kde.py
@@ -92,7 +92,7 @@ class gaussian_kde:
       )
 
     data_covariance = jnp.atleast_2d(
-        jnp.cov(dataset, rowvar=1, bias=False, aweights=weights))
+        jnp.cov(dataset, rowvar=True, bias=False, aweights=weights))
     data_inv_cov = jnp.linalg.inv(data_covariance)
     covariance = data_covariance * factor**2
     inv_cov = data_inv_cov / factor**2

--- a/jax/_src/tpu/linalg/eigh.py
+++ b/jax/_src/tpu/linalg/eigh.py
@@ -579,6 +579,7 @@ def eigh(
   if sort_eigenvalues or compute_slice:
     sort_idxs = jnp.argsort(eig_vals)
     if compute_slice:
+      assert subset_by_index is not None
       sort_idxs = sort_idxs[subset_by_index[0] : subset_by_index[1]]
     eig_vals = eig_vals[sort_idxs]
     eig_vecs = eig_vecs[:, sort_idxs]


### PR DESCRIPTION
A handful of internal helpers assumed their inputs were already `Array`
(calling `.shape`/`.ndim`/`.astype`, or feeding them through code that
expects a static Python int), but their public wrappers only guaranteed
`ArrayLike`. Convert explicitly at the boundary instead:

- `lu_solve`: convert `lu`/`permutation`/`b` to `Array` before `_lu_solve`
  reads `.shape`/`.ndim`.
- `schur`/`sqrtm`: convert via `ensure_arraylike` before `_schur`/`_sqrtm`,
  which call `.astype`.
- `_chunk_iter`: use the builtin `divmod` instead of `ufuncs.divmod`, so the
  chunk count/tail stay static Python ints rather than traced values.
- `kde`: pass `rowvar=True` instead of `1`, since `rowvar` is typed as `bool`.
- `eigh`: assert `subset_by_index is not None` before indexing into it when
  `compute_slice` is set.

Split out of #14688 as a prerequisite — these are real fixes independent of
the typing work, kept separate so the ParamSpec change on top only needs to
touch type annotations.