### PR TITLE
Narrow/widen a handful of numpy/scipy type annotations

### DIFF
--- a/jax/_src/numpy/array_methods.py
+++ b/jax/_src/numpy/array_methods.py
@@ -228,16 +228,16 @@ def _copy(self: Array) -> Array:
   """
   return lax_numpy.copy(self)
 
-def _cumprod(self: Array, axis: reductions.Axis = None, dtype: DTypeLike | None = None,
-             out: None = None) -> Array:
+def _cumprod(self: Array, axis: int | None = None,
+             dtype: DTypeLike | None = None, out: None = None) -> Array:
   """Return the cumulative product of the array.
 
   Refer to :func:`jax.numpy.cumprod` for the full documentation.
   """
   return reductions.cumprod(self, axis=axis, dtype=dtype, out=out)
 
-def _cumsum(self: Array, axis: reductions.Axis = None, dtype: DTypeLike | None = None,
-            out: None = None) -> Array:
+def _cumsum(self: Array, axis: int | None = None,
+            dtype: DTypeLike | None = None, out: None = None) -> Array:
   """Return the cumulative sum of the array.
 
   Refer to :func:`jax.numpy.cumsum` for the full documentation.

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -30,7 +30,8 @@ from functools import partial
 import math
 import operator
 import os
-from typing import Any, IO, Literal, Protocol, TypeVar, Union, cast, overload
+from typing import (Any, IO, Literal, Protocol, TypeVar, Union, cast, overload,
+                    TypedDict)
 
 import numpy as np
 
@@ -55,6 +56,7 @@ from jax._src.numpy import reductions
 from jax._src.numpy import tensor_contractions
 from jax._src.numpy import ufuncs
 from jax._src.numpy import util
+from jax._src.numpy.reductions import Axis
 from jax._src.numpy.sorting import argsort, sort
 from jax._src.numpy.vectorize import vectorize
 from jax._src.sharding_impls import canonicalize_sharding
@@ -1395,7 +1397,7 @@ def flip(m: ArrayLike, axis: int | Sequence[int] | None = None) -> Array:
   return _flip(arr, reductions._ensure_optional_axes(axis))
 
 @api.jit(static_argnames=('axis',))
-def _flip(m: Array, axis: int | tuple[int, ...] | None = None) -> Array:
+def _flip(m: Array, axis: Axis = None) -> Array:
   if axis is None:
     return lax.rev(m, list(range(len(np.shape(m)))))
   axis = _ensure_index_tuple(axis)
@@ -2329,7 +2331,7 @@ def squeeze(a: ArrayLike, axis: int | Sequence[int] | None = None) -> Array:
   return _squeeze(arr, _ensure_index_tuple(axis) if axis is not None else None)
 
 @api.jit(static_argnames=('axis',), inline=True)
-def _squeeze(a: Array, axis: tuple[int, ...]) -> Array:
+def _squeeze(a: Array, axis: tuple[int, ...] | None) -> Array:
   if axis is None:
     a_shape = np.shape(a)
     if not core.is_constant_shape(a_shape):
@@ -4149,7 +4151,7 @@ def _pad_func(array: Array, pad_width: PadValue[int], func: Callable[..., Any], 
 
 @api.jit(static_argnums=(1, 2, 4, 5, 6))
 def _pad(array: ArrayLike, pad_width: PadValueLike[int], mode: str,
-         constant_values: ArrayLike, stat_length: PadValueLike[int],
+         constant_values: ArrayLike, stat_length: PadValueLike[int] | None,
          end_values: PadValueLike[ArrayLike], reflect_type: str):
   array = asarray(array)
   nd = np.ndim(array)
@@ -4353,7 +4355,8 @@ def pad(array: ArrayLike, pad_width: PadValueLike[int | Array | np.ndarray],
   end_values = kwargs.get('end_values', 0)
   reflect_type = kwargs.get('reflect_type', "even")
 
-  return _pad(array, pad_width, mode, constant_values, stat_length, end_values, reflect_type)
+  return _pad(array, pad_width, mode, constant_values, stat_length, end_values,
+              reflect_type)
 
 ### Array-creation functions
 
@@ -4970,7 +4973,7 @@ def _atleast_nd(x: ArrayLike, n: int) -> Array:
   m = np.ndim(x)
   return lax.broadcast(x, (1,) * (n - m)) if m < n else asarray(x)
 
-def _block(xs: ArrayLike | list[ArrayLike]) -> tuple[Array, int]:
+def _block(xs: ArrayLike | list[Any]) -> tuple[Array, int]:
   if isinstance(xs, tuple):
     raise ValueError("jax.numpy.block does not allow tuples, got {}"
                      .format(xs))
@@ -4989,7 +4992,7 @@ def _block(xs: ArrayLike | list[ArrayLike]) -> tuple[Array, int]:
 
 @export
 @api.jit
-def block(arrays: ArrayLike | list[ArrayLike]) -> Array:
+def block(arrays: ArrayLike | list[Any]) -> Array:
   """Create an array from a list of blocks.
 
   JAX implementation of :func:`numpy.block`.
@@ -9452,7 +9455,10 @@ def digitize(x: ArrayLike, bins: ArrayLike, right: bool = False,
   if bins_arr.shape[0] == 0:
     return array_creation.zeros_like(x, dtype=np.int32)
   side = 'right' if not right else 'left'
-  kwds: dict[str, str] = {} if method is None else {'method': method}
+
+  class Kwds(TypedDict, total=False):
+    method: str
+  kwds: Kwds = {} if method is None else {'method': method}
   return where(
     bins_arr[-1] >= bins_arr[0],
     searchsorted(bins_arr, x, side=side, **kwds),

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -1151,7 +1151,7 @@ def inv(a: ArrayLike) -> Array:
 
 @export
 @api.jit(static_argnames=('ord', 'axis', 'keepdims'))
-def norm(x: ArrayLike, ord: int | str | None = None,
+def norm(x: ArrayLike, ord: int | str | float | None = None,
          axis: None | tuple[int, ...] | int = None,
          keepdims: bool = False) -> Array:
   """Compute the norm of a matrix or vector.
@@ -1691,7 +1691,7 @@ def matrix_transpose(x: ArrayLike, /) -> Array:
 
 @export
 def vector_norm(x: ArrayLike, /, *, axis: int | tuple[int, ...] | None = None, keepdims: bool = False,
-                ord: int | str = 2) -> Array:
+                ord: int | str | float = 2) -> Array:
   """Compute the vector norm of a vector or batch of vectors.
 
   JAX implementation of :func:`numpy.linalg.vector_norm`.

--- a/jax/_src/numpy/ufunc_api.py
+++ b/jax/_src/numpy/ufunc_api.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from collections.abc import Callable
 import math
 import operator
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 
@@ -178,7 +178,8 @@ class ufunc:
       raise NotImplementedError(f"out argument of {self}")
     if where is not None:
       raise NotImplementedError(f"where argument of {self}")
-    call = self.__static_props['call'] or self._call_vectorized
+    call = (self.__static_props['call']
+            or cast(Callable[..., Any], self._call_vectorized))
     return call(*args)
 
   @api.jit(static_argnames=['self'])

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -2169,7 +2169,7 @@ def _sqrtm_triu(T: Array) -> Array:
   return U
 
 @jit
-def _sqrtm(A: ArrayLike) -> Array:
+def _sqrtm(A: Array) -> Array:
   T, Z = schur(A, output='complex')
   sqrt_T = _sqrtm_triu(T)
   return jnp.matmul(jnp.matmul(Z, sqrt_T, precision=lax.Precision.HIGHEST),


### PR DESCRIPTION
Prerequisite for #14688 (giving `jax.jit`'s overloads a `ParamSpec`).
With `jit`'s signature no longer erased to `Any`, Pyrefly follows
these `@api.jit`-wrapped functions through their wrapper and needs
their declared types to actually match what's passed/returned:

- `_cumprod`/`_cumsum`: narrow `axis` to `int | None`; single-axis only.
- `_flip`: reuse the shared `Axis` alias.
- `_squeeze`/`_pad`: widen `axis`/`stat_length` to allow `None`.
- `digitize`: `TypedDict` for `**kwds` so splatting type-checks.
- `norm`/`vector_norm`: widen `ord` to include `float`.
- `ufunc.__call__`: cast to `Callable`; jit can't express bound-self.
- `_sqrtm`: narrow parameter to `Array` (call site already guarantees it).
- `block`: widen list element type to `Any`.

Pure type-annotation changes, no behavior change.