### PR TITLE
[oneAPI] Fix jax_oneapi_pjrt build failures due to missing @triton/intel deps

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -283,6 +283,7 @@ common:tsan_shared --linkopt=-shared-libsan
 common:oneapi --@rules_ml_toolchain//common:enable_sycl=True
 common:oneapi --repo_env=TF_NEED_SYCL=1
 common:oneapi --define=tensorflow_mkldnn_contraction_kernel=0
+common:oneapi --repo_env=ENABLE_INTEL_XPU_TRITON=1
 
 # oneAPI Hermetic setup
 common:oneapi --repo_env=SYCL_BUILD_HERMETIC=1


### PR DESCRIPTION
## Summary

- **`.bazelrc`**: Adds `--repo_env=ENABLE_INTEL_XPU_TRITON=1` to the `oneapi` config. Without this, XLA's `triton_archive` rule fetches upstream Triton (NVIDIA-focused) which lacks `third_party/intel`, causing `@triton//third_party/intel:TritonIntelGPUToLLVM` to fail at analysis time.

## Test plan

- [ ] Run `python build/build.py build --wheels=jax-oneapi-pjrt --config=oneapi` and confirm build completes without analysis errors
- [ ] Verify `bazel clean --expunge` is run first to force re-fetch of Triton with new env var