### PR TITLE
[ROCm] Drop the rocm-sdk PATH/LD_LIBRARY_PATH block from run_pytest_rocm.sh

### DIFF
--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -26,15 +26,6 @@ set -exu -o history -o allexport
 # Source default JAXCI environment variables.
 source ci/envs/default.env
 
-# Point PATH and LD_LIBRARY_PATH at the local TheRock installation.
-if command -v rocm-sdk >/dev/null 2>&1; then
-  sdk_root="$(rocm-sdk path --root)"
-  if [[ -n "$sdk_root" ]]; then
-    export PATH="$sdk_root/bin:$PATH"
-    export LD_LIBRARY_PATH="$sdk_root/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-  fi
-fi
-
 # Install jaxlib and ROCm plugin wheels inside the $JAXCI_OUTPUT_DIR directory
 echo "Installing wheels locally..."
 source ./ci/utilities/install_wheels_locally.sh


### PR DESCRIPTION
Same change as ROCm/jax#830, cherry-picked onto `main`.

cc @mminutoli, this removes the PATH/LD_LIBRARY_PATH block added in b0eb8fe08.

## Motivation

The ROCm suite cannot run with `rocm[libraries]`. `rocm-sdk path --root` needs `rocm[devel]` and exits 1 without it. The script runs under `set -exu`, so it stops there, before the wheels are even installed. Tests do not need `rocm[devel]`.

## Technical details

The block was meant to put `rocminfo` and `rocm-smi` on PATH, and ROCm libraries on `LD_LIBRARY_PATH`, in the `/opt/rocm`-less pip images. Neither is needed:

- `rocm-sdk-core` installs `rocminfo`, `rocm-smi` and `amd-smi` as pip console scripts. `rocm-sdk` is a console script too, from the `rocm` package. They all go to the same directory: `/usr/local/bin` in `ghcr.io/rocm/jax-base-ubu24.therock-7.14`.
- These tools do not need devel. `rocm_sdk_core._cli.rocm_smi` calls `_exec("bin/rocm-smi", expand_devel=False)`, so it runs the copy in the core wheel.
- The binaries find their libraries through their own RPATH (`$ORIGIN/../lib`), and the plugin wheels carry a TheRock-aware RUNPATH since 065e33be46.
- `$sdk_root/lib` is the devel tree, whose `lib` holds 136 `.so` files hardlinked from the core and libraries payloads. It does not exist in a libraries-only install and adds nothing RPATH does not already find.

So the gate is pointless: if `command -v rocm-sdk` works, the tools are already on PATH. If it fails, the block does nothing.

`--test_env=LD_LIBRARY_PATH` in `ci/run_bazel_test_rocm_rbe.sh` is untouched. That script computes `ROCM_SDK_ROOT` itself and passes the value explicitly, so the bazel job does not depend on anything this script exports.

## Test plan

8-GPU host, container from `ghcr.io/rocm/jax-base-ubu24.therock-7.14`, jax 0.11.0 with `jax-rocm7-plugin` 0.11.0, `LD_LIBRARY_PATH` unset.

Run twice: once with `rocm-sdk-devel` installed (what CI uses today), once with it removed (the `rocm[libraries]` case). Each time check:

1. `rocminfo` and `rocm-smi` work without touching PATH
2. `ldd` finds every library for the plugin and pjrt `.so` files
3. GPU ops: matmul, cholesky, eigh, conv, 8-way `psum`
4. `pytest tests/nn_test.py -k Softmax` and `pytest tests/pmap_test.py -k testPsum`

## Test result

Same in both cases:

| Check | Result |
| --- | --- |
| `rocminfo` / `rocm-smi` | 8 GPUs, VRAM reported, both from `/usr/local/bin` |
| `ldd` on 8 `.so` files | 0 missing |
| GPU ops | backend `gpu`, 8 devices, all results correct |
| `nn_test -k Softmax` | 10 passed, 1 skipped |
| `pmap_test -k testPsum` | 5 passed |

Removing the export therefore does not regress the devel-installed setup CI uses today.

Without devel, the removed command fails as expected:

```
$ rocm-sdk path --root
ERROR: Could not load the `rocm[devel]` package, which is required to access runtime tools and development files.
ERROR: rocm_sdk_devel module for the ROCm SDK development package is not installed.
exit=1
```

One caveat worth stating: the export was added alongside a bazel fix for a hermetic-ROCm version mismatch (XLA pinned to 7.13.0 against a 7.14.0 image). The test above used the published plugin wheels, not wheels built in-tree against the 7.13 pin.


<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->