### PR TITLE
Fix unlimited captured constant frame reports

### DIFF
--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -1286,17 +1286,21 @@ def check_jaxpr_constants(closed_jaxpr: core.Jaxpr):
     warnings.warn(message)
     return
 
+  num_constants = min(5, len(closed_jaxpr.consts))
   message += (
       "The subsequent report may be disabled by setting JAX_CAPTURED_CONSTANTS_REPORT_FRAMES=0.\n\n"
-      f"Largest {min(num_frames, len(closed_jaxpr.consts))} allocation(s):\n"
+      f"Largest {num_constants} allocation(s):\n"
   )
+  report_frames = None if num_frames < 0 else num_frames
   try:
     nbytes_var_const = zip(nbytes_iter, closed_jaxpr.constvars, closed_jaxpr.consts)
-    for nbytes, var, const in heapq.nlargest(5, nbytes_var_const, key=operator.itemgetter(0)):
+    for nbytes, var, const in heapq.nlargest(num_constants, nbytes_var_const,
+                                             key=operator.itemgetter(0)):
       message += f"  Constant {type(const)}, {var.aval.str_short()}, {util.pprint_bytes(nbytes)} captured at:\n"
 
       for eqn in jaxpr_util.eqns_using_var(closed_jaxpr, var):
-        call_frame_source_info = source_info_util.summarize(eqn.source_info, num_frames)
+        call_frame_source_info = source_info_util.summarize(
+            eqn.source_info, report_frames)
         message += "  " * 2 + call_frame_source_info.replace("\n", "\n" + "  " * 2) + "\n\n"
 
     warnings.warn(message)
@@ -1309,8 +1313,9 @@ def log_closed_over_constant(v: core.Literal, eqn: core.JaxprEqn,
     return
   msg = (f"Closed-over constant {type(v.val)}: {v.aval.str_short()} "
          f"in {debug_info.func_src_info}")
-  if (num_frames := config.captured_constants_report_frames.value) > 0:
-    eqn_si = source_info_util.summarize(eqn.source_info, num_frames)
+  if num_frames := config.captured_constants_report_frames.value:
+    report_frames = None if num_frames < 0 else num_frames
+    eqn_si = source_info_util.summarize(eqn.source_info, report_frames)
     msg += (" used at:\n" +
            "  " * 2 + eqn_si.replace("\n", "\n" + "  " * 2) +
            "\n\n")

--- a/jax/_src/source_info_util.py
+++ b/jax/_src/source_info_util.py
@@ -193,7 +193,7 @@ def _summarize_frame(frame: Frame) -> str:
   else:
     return f"{frame.file_name}:{frame.start_line} ({frame.function_name})"
 
-def summarize(source_info: SourceInfo, num_frames=1) -> str:
+def summarize(source_info: SourceInfo, num_frames: int | None = 1) -> str:
   frames = itertools.islice(user_frames(source_info.traceback), num_frames)
   frame_strs = [_summarize_frame(frame) if frame else "unknown"
                 for frame in frames]

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -269,6 +269,13 @@ class JaxJitTest(jtu.JaxTestCase):
       with config.captured_constants_warn_bytes(-1):
         jit_maker()(x)
 
+    with self.assertWarnsRegex(
+        UserWarning,
+        r"(?s)Largest 1 allocation\(s\):.*captured at:\n.+jax_jit_test.py"):
+      with config.captured_constants_warn_bytes(y.nbytes):
+        with config.captured_constants_report_frames(-1):
+          jit_maker()(x)
+
   @jtu.skip_on_flag("jax_use_simplified_jaxpr_constants", False)
   def test_check_for_large_number_of_constants_new(self):
     self.enter_context(config.embedded_constants_max_bytes(4))
@@ -291,6 +298,11 @@ class JaxJitTest(jtu.JaxTestCase):
 
       with config.captured_constants_warn_bytes(-1):
         jit_maker()(x)
+
+    with self.assertWarnsRegex(UserWarning, r"(?s)used at:\n.+jax_jit_test.py"):
+      with config.captured_constants_warn_bytes(y.nbytes):
+        with config.captured_constants_report_frames(-1):
+          jit_maker()(x)
 
   def testParseArguments(self):
     pytree_registry = jaxlib.pytree.default_registry()


### PR DESCRIPTION
Fixes #30642.

`jax_captured_constants_report_frames=-1` is documented to report all source frames. The legacy constant-lowering path passed `-1` directly to `itertools.islice`, which raises an error, while the simplified-constants path ignored negative values entirely.

This change treats negative frame limits as unbounded in both paths. It also corrects the report header to reflect the existing five-allocation limit.

Tests:
- `pytest tests/jax_jit_test.py tests/source_info_test.py -q`
- `JAX_USE_SIMPLIFIED_JAXPR_CONSTANTS=0 pytest tests/jax_jit_test.py tests/source_info_test.py -q`
- `ruff check jax/_src/source_info_util.py jax/_src/interpreters/mlir.py tests/jax_jit_test.py`