### PR TITLE
Document per-jit control of XLA constant folding

### DIFF
--- a/docs/debugging/slow_tracing_compilation.md
+++ b/docs/debugging/slow_tracing_compilation.md
@@ -133,6 +133,22 @@ I0610 23:33:59.678832 deepsea_compiler_base.cc:984] END_TO_END stage duration: 1
 * **Action:** If `HLO_PASSES` is exceptionally slow, the graph likely
   contains massive unrolled loops. Inspect the `eqn_count_pprof` dump.
 
+If XLA reports that constant folding an instruction is taking more than a
+second, check whether the jitted function closes over a large array. Passing
+the array as an argument instead prevents XLA from treating it as a compile-time
+constant. If that is not practical, constant folding can be disabled for an
+individual top-level `jit`:
+
+```python
+f_jit = jax.jit(
+    f,
+    compiler_options={"xla_disable_hlo_passes": "constant_folding"},
+)
+```
+
+Disabling an optimization can reduce compilation time at the cost of runtime
+performance, so apply this option selectively.
+
 ---
 
 (debugging-slow-tracing-compilation-caching-gotchas)=

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -315,6 +315,9 @@ def jit(
       the inlining policy for nested jitted functions. Can be passed as a boolean
       (``True`` for ``jax.Inline.JAX_EARLY``, ``False`` for ``jax.Inline.AUTO``)
       or a :class:`jax.Inline` enum member. Default ``False`` (``jax.Inline.AUTO``).
+    compiler_options: Optional dictionary of XLA compiler options that apply to
+      the compilation of ``fun``. Keys are XLA flag names without the ``--``
+      prefix, and values are booleans, numbers, or strings.
 
   Returns:
     A wrapped version of ``fun``, set up for just-in-time compilation.

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1369,6 +1369,7 @@ class JitTest(jtu.BufferDonationTestCase):
             "xla_embed_ir_in_executable": True,
             "xla_dump_max_hlo_modules": 200,
             "xla_gpu_auto_spmd_partitioning_memory_budget_ratio": 0.5,
+            "xla_disable_hlo_passes": "constant_folding",
         }
     )
 
@@ -1382,6 +1383,7 @@ class JitTest(jtu.BufferDonationTestCase):
             "xla_embed_ir_in_executable": True,
             "xla_dump_max_hlo_modules": 200,
             "xla_gpu_auto_spmd_partitioning_memory_budget_ratio": 0.5,
+            "xla_disable_hlo_passes": "constant_folding",
         })(1.0)  # doesn't crash.
 
   def test_effort_level_compiler_option(self):


### PR DESCRIPTION
Document how to disable XLA constant folding for an individual top-level `jax.jit` using `compiler_options`.

This also adds the missing `compiler_options` description to the `jax.jit` API documentation and extends the existing compiler-option tests to cover the string-valued `xla_disable_hlo_passes` option.

Tests:
- `python -m pytest tests/api_test.py -k compiler_option -q`
- `ruff check jax/_src/api.py tests/api_test.py`

Fixes #21300