### PR TITLE
Define linalg.norm gradient at zero as zero (subgradient convention)

### DIFF
--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -1149,6 +1149,38 @@ def inv(a: ArrayLike) -> Array:
     arr, lax.broadcast(jnp.eye(arr.shape[-1], dtype=arr.dtype), arr.shape[:-2]))
 
 
+@custom_jvp
+def _sqrt0_non_negative(s: Array) -> Array:
+  # ufuncs.sqrt with a custom gradient of 0, the symmetric subgradient of the norm.
+  # The Hessian is NaN, since the second derivative is genuinely singular. Other derivatives
+  # remain untouched. Function must not be called with negative values.
+  return ufuncs.sqrt(s)
+
+
+@custom_jvp
+def _dsqrt0_non_negative(s: Array) -> Array:
+  # Clamping keeps the value finite at s = 0, making the gradient 0.
+  # Function is never called with negative values.
+  return 0.5 / ufuncs.sqrt(ufuncs.maximum(s, jnp.finfo(s.dtype).tiny))
+
+
+@_sqrt0_non_negative.defjvp
+def _sqrt0_non_negative_jvp(primals, tangents):
+  s, = primals
+  ds, = tangents
+  return _sqrt0_non_negative(s), _dsqrt0_non_negative(s) * ds
+
+
+@_dsqrt0_non_negative.defjvp
+def _dsqrt0_non_negative_jvp(primals, tangents):
+  s, = primals
+  ds, = tangents
+  # Second derivative of sqrt is -0.25 s**-1.5 away from zero, and NaN at zero. The Hessian's
+  # x_i x_j term is then 0 * NaN = NaN at the origin
+  d2 = jnp.where(s > 0, -0.25 * s ** -1.5, np.nan)
+  return _dsqrt0_non_negative(s), d2 * ds
+
+
 @export
 @api.jit(static_argnames=('ord', 'axis', 'keepdims'))
 def norm(x: ArrayLike, ord: int | str | float | None = None,
@@ -1231,7 +1263,7 @@ def norm(x: ArrayLike, ord: int | str | float | None = None,
     # NumPy has an undocumented behavior that admits arbitrary rank inputs if
     # `ord` is None: https://github.com/numpy/numpy/issues/14215
     if ord is None:
-      return ufuncs.sqrt(reductions.sum(ufuncs.real(x * ufuncs.conj(x)), keepdims=keepdims))
+      return _sqrt0_non_negative(reductions.sum(ufuncs.real(x * ufuncs.conj(x)), keepdims=keepdims))
     axis = tuple(range(ndim))
   elif isinstance(axis, tuple):
     axis = tuple(canonicalize_axis(x, ndim) for x in axis)
@@ -1243,7 +1275,7 @@ def norm(x: ArrayLike, ord: int | str | float | None = None,
       return vector_norm(x, ord=2 if ord is None else ord, axis=axis, keepdims=keepdims)
     case [row_axis, col_axis]:
       if ord is None or ord in ('f', 'fro'):
-        return ufuncs.sqrt(reductions.sum(ufuncs.real(x * ufuncs.conj(x)), axis=axis,
+        return _sqrt0_non_negative(reductions.sum(ufuncs.real(x * ufuncs.conj(x)), axis=axis,
                                         keepdims=keepdims))
       elif ord == 1:
         if not keepdims and col_axis > row_axis:
@@ -1727,7 +1759,7 @@ def vector_norm(x: ArrayLike, /, *, axis: int | tuple[int, ...] | None = None, k
   """
   x = ensure_arraylike('jnp.linalg.vector_norm', x)
   if ord is None or ord == 2:
-    return ufuncs.sqrt(reductions.sum(ufuncs.real(x * ufuncs.conj(x)), axis=axis,
+    return _sqrt0_non_negative(reductions.sum(ufuncs.real(x * ufuncs.conj(x)), axis=axis,
                                       keepdims=keepdims))
   elif ord == np.inf:
     return reductions.amax(ufuncs.abs(x), axis=axis, keepdims=keepdims, initial=0)

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -446,11 +446,11 @@ def disable_gc():
 @jtu.with_config(jax_traceback_filtering='auto')  # JaxTestCase defaults to off.
 class UserContextTracebackTest(jtu.JaxTestCase):
 
-  def test_grad_norm(self):
+  def test_NaN_grad(self):
     e = None
     try:
       with jax.debug_nans(True):
-        jax.grad(jnp.linalg.norm)(jnp.zeros((3, 3), jnp.float32))
+        jax.grad(lambda x: jnp.sum(x * jnp.sqrt(x)))(jnp.zeros((3, 3), jnp.float32))
     except FloatingPointError as exc:
       e = exc
     self.assertIsNot(e, None)

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -600,6 +600,53 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     norm = jnp.linalg.vector_norm(x, ord=ord)
     self.assertEqual(norm, 0)
 
+  @jtu.sample_product(
+      [dict(shape=shape, ord=ord)
+       for shape, ord in [((3,), None), ((3,), 2), ((2, 3), 'fro')]],
+      dtype=float_types,
+  )
+  def testNormGradAtZero(self, shape, ord, dtype):
+    # The L2/Frobenius norm uses the subgradient convention grad(0) = 0 consistently in forward and
+    # reverse mode.
+    x = jnp.zeros(shape, dtype)
+    norm = partial(jnp.linalg.norm, ord=ord)
+    for jac in [grad, jax.jacfwd, jax.jacrev]:
+      self.assertArraysEqual(jac(norm)(x), jnp.zeros_like(x))
+
+  @jtu.sample_product(dtype=complex_types)
+  def testNormComplexGradAtZero(self, dtype):
+    x = jnp.zeros(3, dtype)
+    self.assertArraysEqual(grad(jnp.linalg.norm)(x), jnp.zeros_like(x))
+
+  @jtu.sample_product(
+      [dict(shape=shape, ord=ord)
+       for shape, ord in [((3,), None), ((3,), 2), ((2, 3), 'fro')]],
+      dtype=float_types,
+  )
+  def testNormHessianAtZeroIsNan(self, shape, ord, dtype):
+    # The norm's second derivative is singular at the origin, so its Hessian is
+    # NaN there in every autodiff-mode composition.
+    x = jnp.zeros(shape, dtype)
+    norm = partial(jnp.linalg.norm, ord=ord)
+    hessians = [jax.hessian,
+                lambda f: jax.jacfwd(jax.jacrev(f)),
+                lambda f: jax.jacrev(jax.jacfwd(f)),
+                lambda f: jax.jacfwd(jax.jacfwd(f)),
+                lambda f: jax.jacrev(jax.jacrev(f))]
+    for hessian in hessians:
+      self.assertTrue(jnp.all(jnp.isnan(hessian(norm)(x))))
+
+  @jtu.sample_product(dtype=float_types)
+  def testNormGradOffZero(self, dtype):
+    # Away from the origin the gradient is the usual x / norm(x).
+    x = jnp.arange(1, 5, dtype=dtype)
+    self.assertAllClose(grad(jnp.linalg.norm)(x), x / jnp.linalg.norm(x))
+
+  def testNormGradHomogeneityAtZero(self):
+    # d/da norm(a * x) is well-defined (zero) at x = 0.
+    x = jnp.zeros(3)
+    self.assertEqual(grad(lambda a: jnp.linalg.norm(a * x))(1.3), 0)
+
   # jnp.linalg.vecdot is an alias of jnp.vecdot; do a minimal test here.
   @jtu.sample_product(
       [


### PR DESCRIPTION
The gradient of `jax.numpy.linalg.norm` is currently NaN at 0. This is a common pain-point in optimization problems containing normalizations to unit norms. One example are rotations with axis-angles, which produce a normalized axis and an angle magnitude when converted to quaternions (see e.g. in [scipy.spatial.transform](https://github.com/scipy/scipy/blob/be3f7ee909811e665b8bc63fb88d2559af7988a1/scipy/spatial/transform/_rotation_xp.py#L166-L181)).

 #26248 described the issue, and #27935 experimented with a solution. The attempt was abandoned because there was no consensus on how do handle higher-order derivatives. This PR is another shot at getting subgradients into `linalg.norm`.

## Gradient definition
The gradient of the norm is undefined at 0, and we can basically choose any vector from the unit ball around 0. Here we chose 0. The reason is that the norm is even, 

$$
n(-x) = n(x).
$$

Differentiating both sides and using the chain rule on the inner $-x$, we get 

$$
\nabla n(-x) = -\nabla n(x).
$$

The gradient is thus an odd function, and we expect 

$$
\nabla n(0) = -\nabla n(0)
$$

at the origin, which forces $\nabla n(0) = 0$. 0 is thus the only value at the origin that keeps the gradient odd, and hence the value we adapt in this PR.

## Higher-order derivatives
As far as I can tell, #27935 was abandoned because of issues with higher-order derivatives. The norm's Hessian is

$$
\begin{align*}
\nabla^2 n(x) = \frac{1}{\lVert x \rVert}\left(I - \hat{x}\hat{x}^{\top}\right), \\
\hat{x} = \frac{x}{\lVert x \rVert}.
\end{align*}
$$

Its eigenvalues are $0$ along $\hat{x}$, and $1/\lVert x \rVert$ in the other $n - 1$ directions. Along one direction the norm is linear, $n(t\hat{x}) = t$, so the curvature there is $0$. Sideways the curvature is $1/\lVert x \rVert$, which blows up as $x \to 0$. So the eigenvalues at the origin are

$$\{0, \infty, \dots, \infty }.$$

There is no finite matrix for the Hessian to converge to. Hence we choose `NaN` to expresses that this derivative does not exist. Conveniently, the behavior does not change for anything using second derivatives.

## Implementation and performance
`linalg.norm` is likely used by a large majority of the jax user base, and a meaningful slow-down from the custom jvp would hardly be acceptable. I benchmarked the function by looking at the HLO produced by XLA, and found that the max operation was significantly more performant than a `jnp.where`. It introduces no additional reads of x, and the timings are within measurement noise on my machine.

@jakevdp @mattjj Since there wasn't much movement in #26248 I decided to go forward and pitch this as an actual PR. It would be great to know if there is at least some interest in this, or if this has little chance of making it in.