### PR TITLE
[ROCm] Put the ROCm runtime libraries in the bazel GPU test runfiles

### DIFF
--- a/ci/run_bazel_test_rocm_rbe.sh
+++ b/ci/run_bazel_test_rocm_rbe.sh
@@ -62,13 +62,13 @@ done
 TEST_ARTIFACTS_DIR="test-artifacts"
 mkdir -p "$TEST_ARTIFACTS_DIR"
 
-# Point ROCM_PATH and LD_LIBRARY_PATH at the local TheRock installation.
+# Point ROCM_PATH at the local TheRock installation. Tests find ROCm through
+# their runfiles, so they need no LD_LIBRARY_PATH.
 ROCM_SDK_FLAGS=()
 if command -v rocm-sdk >/dev/null 2>&1; then
     ROCM_SDK_ROOT="$(rocm-sdk path --root)"
     ROCM_SDK_FLAGS=(
         "--repo_env=ROCM_PATH=${ROCM_SDK_ROOT}"
-        "--test_env=LD_LIBRARY_PATH=${ROCM_SDK_ROOT}/lib"
     )
 fi
 echo "::endgroup::" >&2

--- a/jaxlib/tools/BUILD.bazel
+++ b/jaxlib/tools/BUILD.bazel
@@ -22,7 +22,9 @@ load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 
 # TODO(Intel-tf): Update `sycl` with `oneapi` when xla changes to use `oneapi`.
 load("@local_config_sycl//sycl:build_defs.bzl", "if_sycl")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
 load(
     "@xla//third_party/py:py_import.bzl",
     "py_import",
@@ -539,36 +541,60 @@ py_import(
     wheel_deps = if_pypi_cuda_wheel_deps([":nvidia_wheel_deps"]),
 )
 
+ROCM_LIBS = [
+    "@local_config_rocm//rocm:hip_runtime",
+    "@local_config_rocm//rocm:hipblas",
+    "@local_config_rocm//rocm:hipfft",
+    "@local_config_rocm//rocm:hiprand",
+    "@local_config_rocm//rocm:hipsolver",
+    "@local_config_rocm//rocm:hipsparse",
+    "@local_config_rocm//rocm:miopen",
+    "@local_config_rocm//rocm:rccl",
+    "@local_config_rocm//rocm:rocm_smi",
+    "@local_config_rocm//rocm:rocprofiler_sdk",
+    "@local_config_rocm//rocm:rocsolver",
+]
+
 collect_data_files(
     name = "rocm_libs_data",
-    deps = [
-        "@local_config_rocm//rocm:hip_runtime",
-        "@local_config_rocm//rocm:hipblas",
-        "@local_config_rocm//rocm:hipfft",
-        "@local_config_rocm//rocm:hiprand",
-        "@local_config_rocm//rocm:hipsolver",
-        "@local_config_rocm//rocm:miopen",
-        "@local_config_rocm//rocm:rccl",
-        "@local_config_rocm//rocm:rocm_smi",
-        "@local_config_rocm//rocm:rocprofiler_sdk",
-        "@local_config_rocm//rocm:rocsolver",
-    ],
+    deps = ROCM_LIBS,
+)
+
+# collect_data_files keeps a file only when its extension is exactly "so", so
+# the SONAME-versioned libraries the plugin links against (libamdhip64.so.7,
+# librocblas.so.5, ...) are dropped. Carry the unfiltered set as runfiles, where
+# @local_config_rocm//rocm:rocm_rpath already points.
+cc_library(
+    name = "rocm_runtime_libs",
+    deps = ROCM_LIBS,
 )
 
 py_import(
-    name = "jax_rocm_plugin_py_import",
+    name = "jax_rocm_plugin_wheel_py_import",
     wheel = ":jax_rocm_plugin_wheel",
     wheel_deps = [
         ":rocm_libs_data",
     ],
 )
 
+py_library(
+    name = "jax_rocm_plugin_py_import",
+    data = [":rocm_runtime_libs"],
+    deps = [":jax_rocm_plugin_wheel_py_import"],
+)
+
 py_import(
-    name = "jax_rocm_pjrt_py_import",
+    name = "jax_rocm_pjrt_wheel_py_import",
     wheel = ":jax_rocm_pjrt_wheel",
     wheel_deps = [
         ":rocm_libs_data",
     ],
+)
+
+py_library(
+    name = "jax_rocm_pjrt_py_import",
+    data = [":rocm_runtime_libs"],
+    deps = [":jax_rocm_pjrt_wheel_py_import"],
 )
 
 # The targets below are used for GPU tests with `--//jax:build_jaxlib=false`.


### PR DESCRIPTION
Follow-up to #39765, where @mminutoli asked whether the `--test_env=LD_LIBRARY_PATH` in `ci/run_bazel_test_rocm_rbe.sh` could go too. Removing it on its own fails, so this PR removes the reason it is needed first.

## Motivation

No ROCm runtime library the plugin links against reaches the bazel test runfiles today. The suite passes only because the script exports `LD_LIBRARY_PATH` to the SDK, which substitutes the whole installation for a runfiles set that never had the libraries in it. That hides gaps in the hermetic dependency set and ranks ahead of every RUNPATH the wheels carry.

Dropping the export without this change fails immediately, on both the blocking gate (`build_jaxlib=true`) and the `build_jaxlib=wheel` job:

```
jax.errors.JaxRuntimeError: INTERNAL: Failed to open
  .../jax_rocm_pjrt_py_import_unpacked_wheel/jax_plugins/xla_rocm7/xla_rocm_plugin.so:
  librocprofiler-sdk.so.1: cannot open shared object file: No such file or directory
```

## Technical details

`jax_rocm_plugin_py_import` and `jax_rocm_pjrt_py_import` pull ROCm in through `collect_data_files`. Its aspect keeps a file only when the extension matches exactly:

```starlark
for ext in extensions:      # ["so", "pyd", "pyi", "dll", "dylib", "lib", "pd"]
    if f.extension == ext:
```

Every ROCm SONAME is versioned, so `File.extension` is the version digit and the aspect drops the file. `readelf -d` on `xla_rocm_plugin.so` lists only versioned ROCm dependencies:

```
librocprofiler-sdk.so.1  librccl.so.1     libhipblaslt.so.1   libhipfft.so.0
libMIOpen.so.1           librocblas.so.5  librocm_smi64.so.1  libamdhip64.so.7
```

What survives the filter is the unversioned development symlinks, which no `DT_NEEDED` entry asks for. `librocprofiler-sdk.so.1` is simply first in the list, so it is the one the loader names.

This PR adds the ROCm targets a second time, unfiltered, as a `cc_library` in the runfiles of both `py_import` targets, and adds `hipsparse` to the set. The plugin's `_sparse` extension links `libhipsparse.so.4`, and jax imports that extension inside a `try`/`except`, so a missing library does not surface as a load error at all. It surfaces later as `NOT_FOUND: No FFI handler registered for hipsparse_gtsv2_ffi`, which is what `//tests:batching_test_gpu` hit before `hipsparse` was added. The libraries then sit at their `local_config_rocm` repo path, where the RUNPATH that `@local_config_rocm//rocm:rocm_rpath` links into every ROCm consumer already points, so the tests resolve ROCm on their own. The public labels keep their names, so `MODULE.bazel` and `WORKSPACE` are untouched.

`--repo_env=ROCM_PATH` stays. It is what makes the build use the image's SDK instead of the hermetic ROCm version XLA pins, and it is unrelated to how tests find libraries at runtime.

A tidier fix belongs in XLA: `collect_data_aspect` could match `.so.<n>` instead of comparing `File.extension`, which would help any versioned shared library, not just ROCm. XLA is pinned here, so this is the jax-side equivalent. Happy to send that upstream too if reviewers prefer it.

## Test plan

The ROCm bazel jobs on this PR are the test, and all three pass with the export gone:

- `build_jaxlib=wheel`: 69 of 69, with the suite executed rather than served from cache.
- ROCm blocking gate (`build_jaxlib=true`, gfx950): passes.
- `jaxlib=pypi_latest` (`build_jaxlib=false`): passes, as expected. Those wheels carry their own TheRock RUNPATH and never needed the export.

Worth flagging for reviewers: a green ROCm bazel job is not by itself evidence here. Several recent runs report `Executed 0 out of 69 tests`, so a change that only touches the CI script can go green on cache hits alone. The runs behind the numbers above executed the tests.
