### PR TITLE
[ad] Handle symbolic zero tangents in reduce_window_jvp

### DIFF
--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from functools import partial
+import operator
 from typing import Any
 import warnings
 
@@ -443,9 +444,24 @@ def reduce_window_jvp(
   if not all(isinstance(t, ad.Zero) for t in init_value_tangent):
     raise TypeError("reduce_window jvp does not support non-zero init_value_tangent.")
 
-  init_value_tangent = map(ad_util.instantiate, init_value_tangent)
   c_reduction_jaxpr = reduction_jaxpr.with_consts(consts)
-  jvp_reduction = ad.jvp_jaxpr(c_reduction_jaxpr, (True,) * len(tangents), [False] * len(init_value_tangent))[0]
+
+  # Fixpoint computation of which operand tangents are not ad.zero.
+  nonzero_tangents = [not isinstance(t, ad.Zero) for t in operand_tangent]
+  for _ in range(1 + n):
+    jvp_reduction, out_nonzero_tangents = ad.jvp_jaxpr(
+        c_reduction_jaxpr, [*nonzero_tangents, *nonzero_tangents],
+        instantiate=nonzero_tangents)
+    if out_nonzero_tangents == nonzero_tangents:
+      break
+    nonzero_tangents = map(operator.or_, nonzero_tangents, out_nonzero_tangents)
+  else:
+    assert False, "Fixpoint not reached"
+
+  operand_tangent = [ad.instantiate_zeros(t)
+                     for t, nz in zip(operand_tangent, nonzero_tangents) if nz]
+  init_value_tangent = [ad.instantiate_zeros(t)
+                        for t, nz in zip(init_value_tangent, nonzero_tangents) if nz]
 
   def wrapper(left, right):
     pl, tl = util.split_list(left, [n])
@@ -462,7 +478,10 @@ def reduce_window_jvp(
       base_dilation=base_dilation,
       window_dilation=window_dilation,
   )
-  primals, tangents = util.split_list(jvp_primals_tangents, [len(jvp_primals_tangents) // 2])
+  primals, tangents = util.split_list(jvp_primals_tangents, [n])
+  tangents_iter = iter(tangents)
+  tangents = [next(tangents_iter) if nz else ad_util.p2tz(p)
+              for p, nz in zip(primals, nonzero_tangents)]
   return [*primals], [*tangents]
 
 ad.primitive_jvps[reduce_window_p] = reduce_window_jvp

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -888,6 +888,54 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     check_grads(fun, (operand,), gradient_order, ["fwd", "rev"], tol, tol,
                 eps)
 
+  def testReduceWindowVariadicJVPIntegerOperand(self):
+    dims = (1, 2)
+    strides = (1, 2)
+    padding = ((0, 0), (0, 0))
+    init_values = (np.asarray(0, dtype=np.int32),
+                   np.array(-np.inf, dtype=np.float32))
+
+    def reducer(xs, ys):
+      x1, x2 = xs
+      y1, y2 = ys
+      which = x2 >= y2
+      return (lax.select(which, x1, y1), lax.select(which, x2, y2))
+
+    def fun(operand):
+      indices = lax.broadcasted_iota(np.int32, operand.shape, 1)
+      return lax.reduce_window((indices, operand), init_values, reducer, dims,
+                               strides, padding)
+
+    operand = np.array([[3., 1., 4., 1.], [5., 9., 2., 6.]], dtype=np.float32)
+    (indices, values), (indices_dot, values_dot) = jax.jvp(
+        fun, (operand,), (np.ones_like(operand),))
+    self.assertArraysEqual(indices, np.array([[0, 2], [1, 3]], dtype=np.int32))
+    self.assertAllClose(values, np.array([[3., 4.], [9., 6.]], dtype=np.float32))
+    self.assertArraysEqual(indices_dot,
+                           np.zeros(indices.shape, dtype=dtypes.float0))
+    self.assertAllClose(values_dot, np.ones_like(values))
+
+  def testReduceWindowVariadicJVPSymbolicZeroOperand(self):
+    dims = (2,)
+    strides = (2,)
+    padding = ((0, 0),)
+    init_values = (np.asarray(0, dtype=np.float32),
+                   np.array(-np.inf, dtype=np.float32))
+    const = np.array([10., 20., 30., 40.], dtype=np.float32)
+
+    def reducer(xs, ys):
+      x1, x2 = xs
+      y1, y2 = ys
+      which = x2 >= y2
+      return (lax.select(which, x1 + x2, y1 + y2), lax.select(which, x2, y2))
+
+    def fun(operand):
+      return lax.reduce_window((const, operand), init_values, reducer, dims,
+                               strides, padding)
+
+    operand = np.array([3., 1., 4., 1.], dtype=np.float32)
+    check_grads(fun, (operand,), 1, ["fwd"], eps=1e-2)
+
   @jtu.sample_product(
     [dict(op=op, dtype=dtype)
       for op, types in [


### PR DESCRIPTION
### What does this PR do?

First contribution!

→ Fixes [#32548](https://github.com/jax-ml/jax/issues/32548)
→ The [reduce_window_jvp](https://github.com/jax-ml/jax/blob/main/jax/_src/lax/windowed_reductions.py#L426) fn incorrectly assumed every operand has a tangent, we can fix it by following the same approach as [_run_state_jvp](https://github.com/jax-ml/jax/blob/main/jax/_src/state/discharge.py#L762), [_remat_jvp](https://github.com/jax-ml/jax/blob/main/jax/_src/ad_checkpoint.py#L581), and [_scan_jvp](https://github.com/jax-ml/jax/blob/main/jax/_src/lax/control_flow/loops.py#L752)

→ <ins>Tests</ins>: Added two regression tests.
→ <ins>Checked for regressions</ins> (`jaxlib` 0.11.0, CPU and CUDA 13 / NVIDIA L4):
- <ins>CPU</ins> `lax_autodiff_test.py` + `lax_control_flow_test.py` + `lax_test.py` + `lax_numpy_reducers_test.py`: 4887 passed, 92 skipped. `api_test.py`: 879 passed, 34 skipped.
- <ins>GPU</ins> `lax_autodiff_test.py`: 684 passed. `api_test.py`: 753 passed, 162 skipped. `lax_test.py -k "reduce_window or ReduceWindow or Variadic"`: 25 passed, 30 skipped.

cc: @mattjj @dougalm @jakevdp

**Before**

<img src="https://github.com/user-attachments/assets/a651e514-374c-4f6c-8293-d89f203a63e8" /><br>

**After**

<img src="https://github.com/user-attachments/assets/b705ce83-693f-497e-8ef3-53034d9d7c1c" />