### PR TITLE
Pick a dtype-appropriate default step in check_grads finite differences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     ({jax-issue}`#34685`).
 
 * Bug fixes
+  * `jax.test_util.check_grads` (and `check_jvp`/`check_vjp`) now pick a
+    dtype-appropriate default finite-difference step. Previously the 1e-4
+    default step was below machine epsilon for dtypes lower-precision than
+    float32 (such as `float16` and `bfloat16`), so at typical magnitudes the
+    perturbed inputs rounded back to the original values, the numerical
+    derivative was identically zero, and the check failed for perfectly
+    correct gradients. The default step for float32 and wider dtypes is
+    unchanged, as is any explicitly passed `eps`. Gradient mismatch messages
+    now also state which side is computed by JAX and which is the numerical
+    estimate ({jax-issue}`#7742`).
   * The batching rules of the cuDNN fused attention primitives (used by
     {func}`jax.nn.dot_product_attention` with `implementation='cudnn'`) now
     support operands that do not carry the vmap axis, including a shared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,16 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     `custom_partitioning`, `custom_gradient`, `closure_convert`,
     `linear_call`, or `run_state`) is retraced with different-shaped
     arguments ({jax-issue}`#40110`).
+  * `jax.test_util.check_grads` (and `check_jvp`/`check_vjp`) now pick a
+    dtype-appropriate default finite-difference step. Previously the 1e-4
+    default step was below machine epsilon for dtypes lower-precision than
+    float32 (such as `float16` and `bfloat16`), so at typical magnitudes the
+    perturbed inputs rounded back to the original values, the numerical
+    derivative was identically zero, and the check failed for perfectly
+    correct gradients. The default step for float32 and wider dtypes is
+    unchanged, as is any explicitly passed `eps`. Gradient mismatch messages
+    now also state which side is computed by JAX and which is the numerical
+    estimate ({jax-issue}`#7742`).
   * The batching rules of the cuDNN fused attention primitives (used by
     {func}`jax.nn.dot_product_attention` with `implementation='cudnn'`) now
     support operands that do not carry the vmap axis, including a shared

--- a/jax/_src/public_test_util.py
+++ b/jax/_src/public_test_util.py
@@ -19,7 +19,7 @@ from typing import Any, TypeAlias
 from jax._src import api
 from jax._src import config
 from jax._src import dtypes as _dtypes
-from jax._src.tree_util import tree_map, tree_reduce
+from jax._src.tree_util import tree_leaves, tree_map, tree_reduce
 
 import numpy as np
 
@@ -229,7 +229,24 @@ def rand_like(rng, x):
   return result.item() if is_python_scalar(x) else result
 
 
-def numerical_jvp(f, primals, tangents, eps=EPS):
+def _default_eps(primals):
+  # cbrt(machine eps) balances truncation and rounding error for central
+  # differences; rounded to a power of two so scaling by eps is lossless.
+  eps = EPS
+  f32_eps = float(np.finfo(np.float32).eps)
+  for leaf in tree_leaves(primals):
+    dt = _dtype(leaf)
+    if not _dtypes.issubdtype(dt, np.inexact):
+      continue
+    machine_eps = float(_dtypes.finfo(dt).eps)
+    if machine_eps > f32_eps:
+      eps = max(eps, 2.0 ** np.floor(np.log2(machine_eps ** (1 / 3))))
+  return float(eps)
+
+
+def numerical_jvp(f, primals, tangents, eps=None):
+  if eps is None:
+    eps = _default_eps(primals)
   delta = scalar_mul(tangents, eps)
   f_pos = f(*add(primals, delta))
   f_neg = f(*sub(primals, delta))
@@ -247,7 +264,12 @@ def _merge_tolerance(tol, default):
   return out
 
 
-def check_jvp(f, f_jvp, args, atol=None, rtol=None, eps=EPS, err_msg=''):
+def _labeled_err_msg(err_msg, part, explanation):
+  base = f'{err_msg} {part}' if err_msg else part
+  return f'{base} ({explanation})'
+
+
+def check_jvp(f, f_jvp, args, atol=None, rtol=None, eps=None, err_msg=''):
   """Check a JVP from automatic differentiation against finite differences.
 
   Gradients are only checked in a single randomly chosen direction, which
@@ -261,7 +283,12 @@ def check_jvp(f, f_jvp, args, atol=None, rtol=None, eps=EPS, err_msg=''):
     args: tuple of argument values.
     atol: absolute tolerance for gradient equality.
     rtol: relative tolerance for gradient equality.
-    eps: step size used for finite differences.
+    eps: step size used for finite differences. If None (default), the step is
+      chosen based on the dtypes of ``args``: 1e-4 for float32 and wider
+      dtypes, and a larger dtype-appropriate step for lower-precision dtypes
+      such as float16 and bfloat16, for which perturbing by 1e-4 rounds away
+      at typical magnitudes. With mixed-precision arguments, the step of the
+      lowest-precision leaf is used for all leaves.
     err_msg: additional error message to include if checks fail.
 
   Raises:
@@ -280,12 +307,18 @@ def check_jvp(f, f_jvp, args, atol=None, rtol=None, eps=EPS, err_msg=''):
   # but due to nondeterminism especially on GPU (e.g., due to convolution
   # autotuning) we only require "close".
   check_close(v_out, v_out_expected, atol=atol, rtol=rtol,
-              err_msg=f'{err_msg} primal' if err_msg else 'primal')
+              err_msg=_labeled_err_msg(
+                  err_msg, 'primal',
+                  'ACTUAL is the primal output of the JVP function, DESIRED '
+                  'is the function evaluated directly'))
   check_close(t_out, t_out_expected, atol=atol, rtol=rtol,
-              err_msg=f'{err_msg} tangent' if err_msg else 'tangent')
+              err_msg=_labeled_err_msg(
+                  err_msg, 'tangent',
+                  'ACTUAL is the JVP computed by JAX, DESIRED is the '
+                  'numerical estimate from finite differences'))
 
 
-def check_vjp(f, f_vjp, args, atol=None, rtol=None, eps=EPS, err_msg=''):
+def check_vjp(f, f_vjp, args, atol=None, rtol=None, eps=None, err_msg=''):
   """Check a VJP from automatic differentiation against finite differences.
 
   Gradients are only checked in a single randomly chosen direction, which
@@ -299,7 +332,12 @@ def check_vjp(f, f_vjp, args, atol=None, rtol=None, eps=EPS, err_msg=''):
     args: tuple of argument values.
     atol: absolute tolerance for gradient equality.
     rtol: relative tolerance for gradient equality.
-    eps: step size used for finite differences.
+    eps: step size used for finite differences. If None (default), the step is
+      chosen based on the dtypes of ``args``: 1e-4 for float32 and wider
+      dtypes, and a larger dtype-appropriate step for lower-precision dtypes
+      such as float16 and bfloat16, for which perturbing by 1e-4 rounds away
+      at typical magnitudes. With mixed-precision arguments, the step of the
+      lowest-precision leaf is used for all leaves.
     err_msg: additional error message to include if checks fail.
 
   Raises:
@@ -311,7 +349,10 @@ def check_vjp(f, f_vjp, args, atol=None, rtol=None, eps=EPS, err_msg=''):
   v_out, vjpfun = f_vjp(*args)
   v_out_expected = f(*args)
   check_close(v_out, v_out_expected, atol=atol, rtol=rtol,
-              err_msg=f'{err_msg} primal' if err_msg else 'primal')
+              err_msg=_labeled_err_msg(
+                  err_msg, 'primal',
+                  'ACTUAL is the primal output of the VJP function, DESIRED '
+                  'is the function evaluated directly'))
   tangent = tree_map(_rand_like, args)
   tangent_out = numerical_jvp(f, args, tangent, eps=eps)
   cotangent = tree_map(_rand_like, v_out)
@@ -319,8 +360,10 @@ def check_vjp(f, f_vjp, args, atol=None, rtol=None, eps=EPS, err_msg=''):
   ip = inner_prod(tangent, cotangent_out)
   ip_expected = inner_prod(tangent_out, cotangent)
   check_close(ip, ip_expected, atol=atol, rtol=rtol,
-              err_msg=(f'{err_msg} cotangent projection'
-                       if err_msg else 'cotangent projection'))
+              err_msg=_labeled_err_msg(
+                  err_msg, 'cotangent projection',
+                  'ACTUAL is computed with the VJP from JAX, DESIRED with '
+                  'the numerical JVP from finite differences'))
 
 
 def check_grads(f, args, order,
@@ -338,13 +381,20 @@ def check_grads(f, args, order,
     modes: lists of gradient modes to check ('fwd' and/or 'rev').
     atol: absolute tolerance for gradient equality.
     rtol: relative tolerance for gradient equality.
-    eps: step size used for finite differences.
+    eps: step size used for finite differences. If None (default), the step is
+      chosen based on the dtypes of ``args``: 1e-4 for float32 and wider
+      dtypes, and a larger dtype-appropriate step for lower-precision dtypes
+      such as float16 and bfloat16, for which perturbing by 1e-4 rounds away
+      at typical magnitudes. With mixed-precision arguments, the step of the
+      lowest-precision leaf is used for all leaves.
+      Note that checks of ``order > 1`` in low-precision dtypes may need
+      explicit ``atol``/``rtol``: nested numerical differentiation there can
+      exceed the default tolerances even for correct gradients.
 
   Raises:
     AssertionError: if gradients do not match.
   """
   args = tuple(args)
-  eps = eps or EPS
 
   _check_jvp = partial(check_jvp, atol=atol, rtol=rtol, eps=eps)
   _check_vjp = partial(check_vjp, atol=atol, rtol=rtol, eps=eps)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -2253,6 +2253,15 @@ jax_py_test(
 )
 
 jax_py_test(
+    name = "public_test_util_test",
+    srcs = ["public_test_util_test.py"],
+    deps = [
+        "//jax",
+        "//jax/_src:test_util",
+    ] + py_deps("absl/testing") + py_deps("numpy"),
+)
+
+jax_py_test(
     name = "source_mapper_test",
     srcs = ["source_mapper_test.py"],
     deps = [

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -2248,6 +2248,15 @@ jax_py_test(
 )
 
 jax_py_test(
+    name = "public_test_util_test",
+    srcs = ["public_test_util_test.py"],
+    deps = [
+        "//jax",
+        "//jax/_src:test_util",
+    ] + py_deps("absl/testing") + py_deps("numpy"),
+)
+
+jax_py_test(
     name = "source_mapper_test",
     srcs = ["source_mapper_test.py"],
     deps = [

--- a/tests/public_test_util_test.py
+++ b/tests/public_test_util_test.py
@@ -1,0 +1,107 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+
+import jax
+from jax import numpy as jnp
+from jax._src import test_util as jtu
+from jax._src.public_test_util import _default_eps, numerical_jvp
+
+import numpy as np
+
+jax.config.parse_flags_with_absl()
+
+
+def _wrong_gradient_fn():
+  @jax.custom_jvp
+  def bad(x):
+    return jnp.sin(x)
+
+  @bad.defjvp
+  def bad_jvp(primals, tangents):
+    (x,), (dx,) = primals, tangents
+    return jnp.sin(x), 2.0 * jnp.cos(x) * dx
+
+  return bad
+
+
+class PublicTestUtilTest(jtu.JaxTestCase):
+
+  @jtu.sample_product(dtype=[np.float16, jnp.bfloat16])
+  def test_check_grads_low_precision(self, dtype):
+    # Regression test for https://github.com/jax-ml/jax/issues/7742: the fixed
+    # 1e-4 step underflowed to zero for sub-float32 dtypes, so correct
+    # gradients failed the check.
+    x = jnp.asarray(1.0, dtype)
+    jtu.check_grads(jnp.sin, (x,), order=1, modes=("fwd", "rev"))
+
+  @jtu.sample_product(dtype=[np.float16, jnp.bfloat16])
+  def test_check_grads_low_precision_catches_wrong_gradient(self, dtype):
+    bad = _wrong_gradient_fn()
+    x = jnp.asarray(1.0, dtype)
+    with self.assertRaises(AssertionError):
+      jtu.check_grads(bad, (x,), order=1, modes=("fwd",))
+
+  def test_default_eps_by_dtype(self):
+    # The float32-and-wider default must stay exactly 1e-4: downstream test
+    # tolerances are tuned to it (see the rollback in 78599e65d1).
+    for dtype in [np.float32, np.float64, np.complex64, np.complex128]:
+      self.assertEqual(_default_eps((np.asarray(1.0, dtype),)), 1e-4)
+    self.assertEqual(_default_eps((np.asarray(1.0, np.float16),)), 0.0625)
+    self.assertEqual(_default_eps((np.asarray(1.0, jnp.bfloat16),)), 0.125)
+    # Mixed trees resolve to the step of the lowest-precision leaf.
+    self.assertEqual(
+        _default_eps(
+            (np.asarray(1.0, np.float32), np.asarray(1.0, jnp.bfloat16))
+        ),
+        0.125,
+    )
+    # Non-float leaves and Python scalars fall back to the default.
+    self.assertEqual(_default_eps((np.asarray(1, np.int32),)), 1e-4)
+    self.assertEqual(_default_eps((1.0,)), 1e-4)
+
+  def test_numerical_jvp_step_is_nonzero_in_low_precision(self):
+    seen = []
+
+    def f(x):
+      seen.append(x)
+      return x
+
+    x = jnp.bfloat16(1.0)
+    numerical_jvp(f, (x,), (jnp.bfloat16(1.0),))
+    self.assertNotEqual(seen[0], seen[1])
+
+  def test_explicit_eps_still_honored(self):
+    # An explicit eps must win over the dtype-based default; 1e-4 underflows
+    # the bfloat16 step, so the numerical side is zero and the check fails.
+    x = jnp.bfloat16(1.0)
+    with self.assertRaises(AssertionError):
+      jtu.check_grads(jnp.sin, (x,), order=1, modes=("fwd",), eps=1e-4)
+
+  def test_failure_message_labels_sides(self):
+    bad = _wrong_gradient_fn()
+    x = jnp.float32(1.0)
+    with self.assertRaisesRegex(
+        AssertionError, "DESIRED is the numerical estimate from finite"
+    ):
+      jtu.check_grads(bad, (x,), order=1, modes=("fwd",))
+    with self.assertRaisesRegex(
+        AssertionError, "DESIRED with the numerical JVP from finite"
+    ):
+      jtu.check_grads(bad, (x,), order=1, modes=("rev",))
+
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Fixes the first half of #7742 and the error message part too.

`jax.test_util.check_grads` uses a fixed `EPS = 1e-4` step for its finite
differences. For float16 and bfloat16 inputs that step is smaller than machine
epsilon, so `x + eps == x`, the numerical derivative comes out exactly zero,
and the check fails for perfectly correct gradients. That's the confusing
"zeros in the results" situation described in the issue.

With this change, when no explicit `eps` is passed, the step is picked from
the dtype of the primals: dtypes coarser than float32 get
`2**floor(log2(cbrt(machine_eps)))`, everything else keeps the old 1e-4. I
kept float32 and wider untouched on purpose: a previous attempt to change the
step for all dtypes (d14e144651) was rolled back a day later because
downstream test tolerances are tuned against the 1e-4 default. Explicitly
passed `eps` values behave exactly as before. With the new defaults,
first-order check_grads on sin/exp/tanh/sigmoid/x^3 passes for f16 and bf16
where today every single case fails, and a deliberately wrong gradient is
still caught.

The failure messages now also say which side is which, e.g. "ACTUAL is the
JVP computed by JAX, DESIRED is the numerical estimate from finite
differences", which is the second ask in the issue.

Two behavior notes. For mixed-precision argument trees the step of the
lowest-precision leaf is used for all leaves (documented in the docstrings);
that rescues the common mixed case with a low-precision output, at the cost
of a slightly coarser step for the float32 leaves. And passing `eps=0`
explicitly used to be silently coerced to 1e-4 by `check_grads`; it now
propagates (and fails loudly), since the coercion was masking a caller bug.

Out of scope: default tolerances are unchanged, the step is still absolute
rather than scaled to the input magnitude, and order > 1 checks in
low-precision dtypes can still need explicit atol/rtol (nested numerical
differentiation in a 8-bit-mantissa dtype only gets so accurate); the
check_grads docstring now mentions that.