### PR TITLE
[remat3][vjp3] propagate zeros through remat3 via jax.vjp/linearize

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -1099,28 +1099,34 @@ class RematTraced(VJPHiPrimitive):
   def expand(self, *args):
     return pe._call_jaxpr(self.jaxpr, args)
 
-  def vjp_fwd(self, _nzs_in, *primals):
+  def vjp_fwd(self, nzs_in, *primals):
     # TODO eval_jaxpr_p trace time
     self._check_differentiable()
     traced = core.jaxpr_as_fun(self.jaxpr)
     primals_out, fwd2 = remat_transform(self.policy, traced, *primals,
                                         custom_vjp_rules=True)
+    in_nzs = tuple(tree_leaves(nzs_in))
+    out_nzs_cell = []
+    def make_vjp(*xs):
+      _, f_vjp = api.vjp(fwd2, *xs, in_nzs=in_nzs)
+      out_nzs_cell.append(f_vjp.out_nzs)  # pyrefly: ignore[missing-attribute]
+      return f_vjp
     with config.mutable_array_checks(False):
-      traced_vjp = api.jit(lambda *xs: api.vjp(fwd2, *xs)[1]).trace(*primals)
+      traced_vjp = api.jit(make_vjp).trace(*primals)
     used, rem = dce(traced_vjp, self.policy)
     primals_ = [x for x, u in zip(tree_leaves(primals), used) if u]
     if isinstance(self.prevent_cse, bool):
       prevent_cse = self.prevent_cse
     else:
       prevent_cse = tuple(f for f, u in zip(self.prevent_cse, used) if u)
-    # TODO(mattjj): propagate symbolic zeros more generally
-    nzs_out = [getattr(a.to_tangent_aval(), 'dtype', None) is not dtypes.float0
-               for a in self.out_aval]
-    return primals_out, (primals_, Static(prevent_cse), rem), nzs_out
+    out_nzs, = out_nzs_cell
+    return primals_out, (primals_, Static(prevent_cse), rem), list(out_nzs)
 
   def vjp_bwd(self, primals_rem, outgrad, *arg_accums):
     primals, prevent_cse, rem = primals_rem
     prevent_cse = prevent_cse.val
+    outgrad = tree_map(ad_util.instantiate, outgrad,
+                       is_leaf=lambda x: isinstance(x, ad_util.Zero))
     if prevent_cse is not False:
       which = ([True] * len(primals) if prevent_cse is True else
                list(prevent_cse))
@@ -1148,18 +1154,26 @@ class RematTraced(VJPHiPrimitive):
     traced = core.jaxpr_as_fun(self.jaxpr)
     primals_out, fwd2 = remat_transform(self.policy, traced, *primals,
                                         custom_vjp_rules=True)
+    in_nzs = tuple(tree_leaves(nzs_in))
+    out_nzs_cell = []
+    def make_lin(*xs):
+      _, f_jvp = api.linearize(fwd2, *xs, in_nzs=in_nzs)
+      out_nzs_cell.append(f_jvp.out_nzs)  # pyrefly: ignore[missing-attribute]
+      return f_jvp
     with config.mutable_array_checks(False):
-      traced_lin = api.jit(
-          lambda *xs: api.linearize(fwd2, *xs)[1]).trace(*primals)
+      traced_lin = api.jit(make_lin).trace(*primals)
     used, rem = dce(traced_lin, self.policy)
     primals_ = [x for x, u in zip(tree_leaves(primals), used) if u]
-    return primals_out, (primals_, rem)
+    out_nzs, = out_nzs_cell
+    return primals_out, (primals_, rem, tuple(out_nzs)), list(out_nzs)
 
   def linearized(self, primals_rem, *tangents):  # pyrefly: ignore[bad-param-name-override]
-    primals, rem = primals_rem
+    primals, rem, out_nzs = primals_rem
     lin = rem(*lax_internal.optimization_barrier(primals))
     tangents = map(ad_util.instantiate, tangents)  # TODO
-    return lin(*tangents)
+    outs = lin(*tangents)
+    return [o if nz else ad_util.Zero(typeof(o))
+            for o, nz in zip(outs, out_nzs)]
 
   def batch(self, axis_data, args, dims):
     jaxpr_batched, out_batched = batching.batch_jaxpr_axes(

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1479,17 +1479,18 @@ def _jvp(fun: Callable, primals, tangents, has_aux=False):
   return out_primals.unflatten(), out_tangents.unflatten(), *aux
 
 @overload
-def linearize(fun: Callable, *primals, has_aux: Literal[False] = False
-              ) -> tuple[Any, Callable]:
+def linearize(fun: Callable, *primals, has_aux: Literal[False] = False,
+              in_nzs: Any = None) -> tuple[Any, Callable]:
   ...
 
 @overload
-def linearize(fun: Callable, *primals, has_aux: Literal[True]
-              ) -> tuple[Any, Callable, Any]:
+def linearize(fun: Callable, *primals, has_aux: Literal[True],
+              in_nzs: Any = None) -> tuple[Any, Callable, Any]:
   ...
 
 @partial(api_boundary, repro_api_name="jax.linearize")
-def linearize(fun: Callable, *primals, has_aux: bool = False
+def linearize(fun: Callable, *primals, has_aux: bool = False,
+              in_nzs: Any = None
               ) -> tuple[Any, Callable] | tuple[Any, Callable, Any]:
   """Produces a linear approximation to ``fun`` using :py:func:`jvp` and partial eval.
 
@@ -1504,6 +1505,12 @@ def linearize(fun: Callable, *primals, has_aux: bool = False
     has_aux: Optional, bool. Indicates whether ``fun`` returns a pair where the first
       element is considered the output of the mathematical function to be linearized,
       and the second is auxiliary data. Default False.
+    in_nzs: Optional, a tuple-tree of bools (see ``in_nzs`` on :func:`jax.vjp`),
+      by default ``None`` meaning all-True. Declares which primal inputs have
+      (possibly) nonzero tangents; a False-marked input's tangent is treated as
+      symbolically zero during linearization. The resulting per-output nonzeros
+      pattern is available as the ``out_nzs`` attribute of the returned
+      linearized function (though not preserved across pytree flattening).
 
   Returns:
     If ``has_aux`` is ``False``, returns a pair where the first element is the value of
@@ -1558,17 +1565,20 @@ def linearize(fun: Callable, *primals, has_aux: bool = False
   """
   check_callable(fun)
   primals_ft = ft.flatten(primals)
-  out_primals_ft, out_known, jaxpr, consts, structured_residuals, *maybe_aux = \
-      ad.linearize(fun, primals_ft, has_aux=has_aux)
+  in_nzs_flat = None if in_nzs is None else tuptree_flags(
+      in_nzs, primals_ft.tree, 'in_nzs', 'the in_nzs argument to jax.linearize')
+  out_primals_ft, out_zeros, jaxpr, consts, structured_residuals, *maybe_aux = \
+      ad.linearize(fun, primals_ft, has_aux=has_aux, in_nzs=in_nzs_flat)
   in_avals = primals_ft.map(core.typeof)
   out_avals = out_primals_ft.map(core.typeof)
   lifted_jvp = Partial(
-      partial(_lift_linearized, jaxpr, in_avals, out_avals, out_known),
+      partial(_lift_linearized, jaxpr, in_avals, out_avals, out_zeros),
       consts, structured_residuals)
+  lifted_jvp.out_nzs = tuple(not z for z in out_zeros)  # pyrefly: ignore[missing-attribute]
   return out_primals_ft.unflatten(), lifted_jvp, *maybe_aux
 
 
-def _lift_linearized(jaxpr, in_avals, out_avals, out_known, consts,
+def _lift_linearized(jaxpr, in_avals, out_avals, out_zeros, consts,
                      structured_residuals, *tangents):
   tangents_ft = ft.flatten(tangents)
   if tangents_ft.tree != in_avals.tree:
@@ -1604,7 +1614,7 @@ def _lift_linearized(jaxpr, in_avals, out_avals, out_known, consts,
   tangents_out = eval_jaxpr(jaxpr, consts, *tangents_ft, *sres_flat)
   tangents_out_ = iter(tangents_out)
   full_out = [a2tz(aval).instantiate() if known else next(tangents_out_)
-              for aval, known in zip(out_avals, out_known)]
+              for aval, known in zip(out_avals, out_zeros)]
   assert next(tangents_out_, None) is None
   return out_avals.update(full_out).unflatten()
 
@@ -1619,20 +1629,22 @@ def vjp(fun: Callable[..., T],
         *primals: Any,
         has_aux: Literal[False] = False,
         reduce_axes: Sequence[AxisName] = (),
-        saveable_args: Any = True) -> tuple[T, Callable]:
+        saveable_args: Any = True,
+        in_nzs: Any = None) -> tuple[T, Callable]:
   ...
 
 @overload
 def vjp(fun: Callable[..., tuple[T, U]], *primals: Any,
         has_aux: Literal[True],
         reduce_axes: Sequence[AxisName] = (),
-        saveable_args: Any = True) -> tuple[T, Callable, U]:
+        saveable_args: Any = True,
+        in_nzs: Any = None) -> tuple[T, Callable, U]:
   ...
 
 @partial(api_boundary, repro_api_name="jax.vjp")
 def vjp(
     fun: Callable, *primals, has_aux: bool = False, reduce_axes=(),
-    saveable_args: Any = True,
+    saveable_args: Any = True, in_nzs: Any = None,
   ) -> tuple[Any, Callable] | tuple[Any, Callable, Any]:
   """Compute a (reverse-mode) vector-Jacobian product of ``fun``.
 
@@ -1662,6 +1674,13 @@ def vjp(
       must restore them (e.g. by assigning to ``vjpfun.args_res``) before
       applying ``vjpfun``. Only argument values saved verbatim are affected;
       residuals computed from the arguments are saved as usual.
+    in_nzs: Optional, a tuple-tree of bools like ``saveable_args``, by default
+      ``None`` meaning all-True. Declares which primal inputs have (possibly)
+      nonzero tangents. Where a False entry applies, that input's tangent is
+      treated as symbolically zero during linearization, which can make more
+      outputs' tangents symbolically zero; the resulting per-output nonzeros
+      pattern is available as the ``out_nzs`` attribute of ``vjpfun``, and
+      ``vjpfun`` returns a zero cotangent for any False-marked input.
 
   Returns:
     If ``has_aux`` is ``False``, returns a ``(primals_out, vjpfun)`` pair, where
@@ -1694,8 +1713,11 @@ def vjp(
   primals_ft = ft.flatten(primals).map(canon)
   primals_ft.map(dispatch.check_arg)
   saveable = _saveable_args_flags(saveable_args, primals_ft.tree)
-  out_primals_ft, out_known, jaxpr, residuals, structured_residuals, *maybe_aux = \
-      ad.linearize(fun, primals_ft, is_vjp=True, has_aux=has_aux)
+  in_nzs_flat = None if in_nzs is None else tuptree_flags(
+      in_nzs, primals_ft.tree, 'in_nzs', 'the in_nzs argument to jax.vjp')
+  out_primals_ft, out_zeros, jaxpr, residuals, structured_residuals, *maybe_aux = \
+      ad.linearize(fun, primals_ft, is_vjp=True, has_aux=has_aux,
+                   in_nzs=in_nzs_flat)
 
   id_map = {id(x): i for i, x in enumerate(primals_ft)}
   used, opaque_residuals = set(), []
@@ -1705,12 +1727,12 @@ def vjp(
   keep = lambda x, s: ((x if s else NotSaveable()) if id(x) in used else NotNeeded())
   args_res = tuptree_map(keep, primals_ft.tree, primals_ft, saveable)
   out_primal_avals = list(out_primals_ft.map(typeof))
-  f_vjp = VJP(partial(_vjp3_callable, spec, out_known, jaxpr, out_primal_avals),
+  f_vjp = VJP(partial(_vjp3_callable, spec, out_zeros, jaxpr, out_primal_avals),
               primals_ft.tree, out_primals_ft.tree, list(args_res),
               opaque_residuals, structured_residuals)
   return out_primals_ft.unflatten(), f_vjp, *maybe_aux
 
-def _vjp3_callable(spec, out_known, jaxpr, out_primal_avals, in_tree, out_tree,
+def _vjp3_callable(spec, out_zeros, jaxpr, out_primal_avals, in_tree, out_tree,
                    args_res, opaque_res, structured_res, want_logs,
                    *maybe_ct_refs):
   explicit_refs = bool(maybe_ct_refs)
@@ -1729,7 +1751,7 @@ def _vjp3_callable(spec, out_known, jaxpr, out_primal_avals, in_tree, out_tree,
   arg_invars = jaxpr.invars[len(spec):]  # skip the residual invars
   maybe_accums = [_vjp_accum(jaxpr, in_tree, explicit_refs, idx, v, x)
                   for idx, (v, x) in enumerate(unsafe_zip(arg_invars, maybe_ct_refs_flat))]
-  return Partial(partial(_vjp3_bwd, in_tree, out_tree, out_known, jaxpr,
+  return Partial(partial(_vjp3_bwd, in_tree, out_tree, out_zeros, jaxpr,
                          out_primal_avals, want_logs), residuals, structured_res,
                  maybe_accums)
 
@@ -1819,13 +1841,13 @@ def check_accum(aval, acc):
     raise ValueError(f"Accumulator aval mismatch: expected {aval}, got {acc.aval}")
   return acc
 
-def _vjp3_bwd(in_tree, out_tree, out_known, jaxpr, out_primal_avals, want_logs,
+def _vjp3_bwd(in_tree, out_tree, out_zeros, jaxpr, out_primal_avals, want_logs,
               residuals, structured_res, maybe_accums, out_ct):
   cts_flat, out_tree_ = tree_flatten(out_ct, is_leaf=lambda x: isinstance(x, ad.Zero))
   if out_tree != out_tree_:
     _vjp_ct_tree_error(jaxpr, out_tree, out_tree_)
   _vjp_check_ct_avals(cts_flat, out_primal_avals)
-  cts_flat = [ct for ct, k in zip(cts_flat, out_known) if not k]
+  cts_flat = [ct for ct, k in zip(cts_flat, out_zeros) if not k]
   primals_in = [*maybe_accums, *tree_leaves(structured_res)]
   logs = ad.backward_pass3(jaxpr, True, residuals, primals_in, cts_flat)
   arg_cts = [x.freeze() if isinstance(x, ad.ValAccum) else
@@ -2004,6 +2026,7 @@ class VJP:
   structured_residuals: list[Any]
   want_logs: bool = False
   jaxpr = property(lambda self: self.fun.args[2])
+  out_nzs = property(lambda self: tuple(not z for z in self.fun.args[1]))
 
   def __call__(self, out_ct, *extra_args):
     if extra_args:

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -223,38 +223,43 @@ def _strip_tracer(tracer_type, tag, x):
    else:
      return x
 
-def linearize(traceable, primals_ft, has_aux=False, is_vjp=False):
+def linearize(traceable, primals_ft, has_aux=False, is_vjp=False, in_nzs=None):
   dbg = debug_info("linearize", traceable, primals_ft, {})
   tag = core.TraceTag()
+  in_nzs = [True] * len(primals_ft) if in_nzs is None else list(in_nzs)
+  assert len(in_nzs) == len(primals_ft)
   with core.take_current_trace() as parent_trace:
     source_info = source_info_util.current()
     tangent_trace = pe.DynamicJaxprTrace(dbg, auto_dce=True)
     tangent_trace.tag = tag
     lin_trace = LinearizeTrace(parent_trace, tangent_trace, is_vjp)
-    def make_tracer(_lin_trace, p):
-      t = tangent_trace.new_arg(typeof(p).to_tangent_aval(), source_info)
-      if (not isinstance(t, Zero)
-          and isinstance(typeof(t), core.ShapedArray)
-          and dtype(t) == float0):
-        t = p2tz(t)
-      return LinearizeTracer(_lin_trace, p, t).full_lower()
-    tracers = primals_ft.map(partial(make_tracer, lin_trace))
+    with core.ensure_no_leaks(lin_trace):
+      def make_tracer(_lin_trace, p, nz):
+        t = tangent_trace.new_arg(typeof(p).to_tangent_aval(), source_info)
+        if (not nz
+            or (not isinstance(t, Zero)
+                and isinstance(typeof(t), core.ShapedArray)
+                and dtype(t) == float0)):
+          t = p2tz(p)
+        return LinearizeTracer(_lin_trace, p, t).full_lower()
+      tracers = primals_ft.map2(in_nzs, partial(make_tracer, lin_trace))
 
-    with (core.set_current_trace(lin_trace),
-          source_info_util.transform_name_stack('jvp')):
-      ans = traceable(*tracers.unflatten())
-      if has_aux:
-        if not isinstance(ans, (list, tuple)) or len(ans) != 2:
-          raise TypeError("expected function with aux output to return a two-element "
-                          f"tuple, but got type {type(ans)} with value {ans!r}")
-        ans, aux = ans
-        auxs = ft.flatten(aux).map(partial(_strip_tracer, LinearizeTracer, tag)),
-      else:
-        auxs = ()
-      out_primals, out_tangents = ft.flatten(ans).map(
-          lin_trace.to_primal_tangent_pair).unzip2()
-      structured_residuals = lin_trace.structured_residuals
-      del lin_trace, ans, tracers
+      with (core.set_current_trace(lin_trace),
+            source_info_util.transform_name_stack('jvp')):
+        ans = traceable(*tracers.unflatten())
+        aux = None
+        if has_aux:
+          if not isinstance(ans, (list, tuple)) or len(ans) != 2:
+            raise TypeError("expected function with aux output to return a two-element "
+                            f"tuple, but got type {type(ans)} with value {ans!r}")
+          ans, aux = ans
+          auxs = ft.flatten(aux).map(partial(_strip_tracer, LinearizeTracer, tag)),
+        else:
+          auxs = ()
+        out_primals, out_tangents = ft.flatten(ans).map(
+            lin_trace.to_primal_tangent_pair).unzip2()
+        structured_residuals = lin_trace.structured_residuals
+        del lin_trace, ans, tracers, aux
   out_nzs = [type(t) is not Zero for t in out_tangents]
   out_nz_tangents = [t for t, nz in zip(out_tangents, out_nzs) if nz]
   out_nz_tangents = map(partial(tangent_trace.to_jaxpr_tracer,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4147,6 +4147,25 @@ class APITest(jtu.JaxTestCase):
     with config.remat3(True), jax.checking_leaks():
       jax.grad(f)(jnp.ones(3), jnp.ones((2, 3)))  # doesn't crash
 
+  def test_leak_checker_remat3_zero_tangent_output_stays_concrete(self):
+    def f(x):
+      y, aux = jax.remat(lambda x: (jnp.sin(x), lax.stop_gradient(x) * 2.0))(x)
+      self.assertNotIsInstance(aux, core.Tracer)
+      return y
+
+    with config.remat3(True), jax.checking_leaks():
+      jax.value_and_grad(f)(3.0)  # doesn't crash
+
+  def test_leak_checker_remat3_linearize_zero_tangent_output(self):
+    def f(x):
+      y, aux = jax.remat(lambda x: (jnp.sin(x), lax.stop_gradient(x) * 2.0))(x)
+      self.assertNotIsInstance(aux, core.Tracer)
+      return y
+
+    with config.remat3(True), jax.checking_leaks():
+      _, f_jvp = jax.linearize(f, 3.0)
+    self.assertAllClose(f_jvp(1.0), jnp.cos(3.0))
+
   def test_leak_checker_catches_a_sublevel_leak(self):
     with jax.checking_leaks():
       @jit
@@ -4240,6 +4259,17 @@ class APITest(jtu.JaxTestCase):
       with self.assertRaisesRegex(
           Exception, r"local variable 'sneaky' of the frame .*scope"):
         scope()
+
+  def test_leak_checker_catches_linearize_tracer_escape(self):
+    sneaky = None
+    def f(x):
+      nonlocal sneaky
+      sneaky = jnp.sin(x)
+      return sneaky * 2.0
+
+    with jax.checking_leaks():
+      with self.assertRaisesRegex(Exception, r"Leaked trace LinearizeTrace"):
+        jax.value_and_grad(f)(1.0)
 
   def test_why_alive_ref_chain_ending_in_frame_local(self):
     class Sentinel:


### PR DESCRIPTION
add in_nzs to jax.vjp and jax.linearize, a tuple-tree of per-input nonzero-tangent flags. out_nzs can be queried from the returned callable. the returned callable from ad.linearize still accepts (dead) tangent invars corresponding to the zeros.

use this zero propagation in RematTraced.vjp_fwd. this fixes a bug we ran into downstream where, without this, Tracers were coming out and getting leaked due to a flax pattern.