### PR TITLE
[Pallas:TPU] Constrain HBM inputs at the custom call boundary

### DIFF
--- a/jax/_src/pallas/mosaic/pallas_call_registration.py
+++ b/jax/_src/pallas/mosaic/pallas_call_registration.py
@@ -144,6 +144,9 @@ def _resolve_memory_spaces(
     *,
     input_output_aliases: tuple[tuple[int, int], ...],
     kernel_type: tpu_core.CoreType | None,
+    input_memory_space_fallbacks: (
+        tuple[tpu_custom_call.MemorySpace | None, ...] | None
+    ),
 ) -> tuple[
     tuple[tpu_custom_call.MemorySpace | None, ...] | None,
     tuple[tpu_custom_call.MemorySpace | None, ...] | None,
@@ -158,27 +161,36 @@ def _resolve_memory_spaces(
     input_memory_spaces = _get_memory_spaces_from_avals(
         in_avals, kernel_type=kernel_type
     )
-    # ShapedArrayWithMemorySpace wasn't allowed to escape the Pallas kernel, so
-    # it was stripped from the original out_avals. We need to resolve this for
-    # outputs aliased to inputs with pltpu.with_memory_space_constraint.
-    if input_memory_spaces is not None:
-      output_memory_spaces_list: list[tpu_custom_call.MemorySpace | None]
-      if output_memory_spaces is None:
-        output_memory_spaces_list = [None] * len(out_avals)
-      else:
-        output_memory_spaces_list = list(output_memory_spaces)
-      modified = False
-      for in_idx, out_idx in input_output_aliases:
-        if (ms := input_memory_spaces[in_idx]) is not None:
-          if (out_ms := output_memory_spaces_list[out_idx]) not in (None, ms):
-            raise ValueError(
-                f"In/out memory space conflict for alias {in_idx}->{out_idx}:"
-                f" {ms} != {out_ms}"
-            )
-          output_memory_spaces_list[out_idx] = ms
-          modified = True
-      if modified:
-        output_memory_spaces = tuple(output_memory_spaces_list)
+  if input_memory_space_fallbacks is not None:
+    assert len(input_memory_space_fallbacks) == len(in_avals)
+    if input_memory_spaces is None:
+      input_memory_spaces = input_memory_space_fallbacks
+    else:
+      input_memory_spaces = tuple(
+          memory_space if memory_space is not None else fallback
+          for memory_space, fallback in zip(
+              input_memory_spaces, input_memory_space_fallbacks, strict=True
+          )
+      )
+  if input_memory_spaces is not None:
+    # An output aliased to a constrained input must use the same memory space.
+    output_memory_spaces_list: list[tpu_custom_call.MemorySpace | None]
+    if output_memory_spaces is None:
+      output_memory_spaces_list = [None] * len(out_avals)
+    else:
+      output_memory_spaces_list = list(output_memory_spaces)
+    modified = False
+    for in_idx, out_idx in input_output_aliases:
+      if (ms := input_memory_spaces[in_idx]) is not None:
+        if (out_ms := output_memory_spaces_list[out_idx]) not in (None, ms):
+          raise ValueError(
+              f"In/out memory space conflict for alias {in_idx}->{out_idx}:"
+              f" {ms} != {out_ms}"
+          )
+        output_memory_spaces_list[out_idx] = ms
+        modified = True
+    if modified:
+      output_memory_spaces = tuple(output_memory_spaces_list)
   if output_memory_spaces is not None:
     input_memory_spaces_list: list[tpu_custom_call.MemorySpace | None]
     if input_memory_spaces is None:
@@ -276,6 +288,9 @@ def _lower_to_custom_call(
     mosaic_params: tpu_core.CompilerParams,
     kernel_type: tpu_core.CoreType | None,
     num_dynamic_grid_bounds: int,
+    input_memory_space_fallbacks: (
+        tuple[tpu_custom_call.MemorySpace | None, ...] | None
+    ),
     input_output_aliases: tuple[tuple[int, int], ...],
     cost_estimate: pallas_core.CostEstimate | None,
     out_avals: tuple[jax_core.AbstractValue, ...],
@@ -318,6 +333,7 @@ def _lower_to_custom_call(
       out_avals,
       input_output_aliases=input_output_aliases,
       kernel_type=kernel_type,
+      input_memory_space_fallbacks=input_memory_space_fallbacks,
   )
 
   if cost_estimate is not None:
@@ -444,6 +460,21 @@ def pallas_call_tpu_lowering_rule(
     print(f"\nThe Mosaic module for pallas_call {debug_info.func_src_info}:")
     print(mosaic_module.operation.get_asm(use_name_loc_as_prefix=True))
 
+  block_input_memory_spaces = tuple(
+      tpu_custom_call.MemorySpace.HBM
+      if tpu_core.memory_space_to_tpu_memory_space(
+          block_mapping.block_aval.memory_space, tpu_core.CoreType.TC
+      ) is tpu_core.MemorySpace.HBM
+      else None
+      for block_mapping in grid_mapping.block_mappings[:grid_mapping.num_inputs]
+  )
+  input_memory_space_fallbacks = (
+      (None,) * (len(ctx.avals_in) - grid_mapping.num_inputs)
+      + block_input_memory_spaces
+      if any(block_input_memory_spaces)
+      else None
+  )
+
   return _lower_to_custom_call(
       ctx,
       *in_nodes,
@@ -451,6 +482,7 @@ def pallas_call_tpu_lowering_rule(
       mosaic_params=mosaic_params,
       kernel_type=tpu_core.CoreType.TC,
       num_dynamic_grid_bounds=grid_mapping.num_dynamic_grid_bounds,
+      input_memory_space_fallbacks=input_memory_space_fallbacks,
       input_output_aliases=input_output_aliases,
       cost_estimate=cost_estimate,
       out_avals=out_avals,
@@ -719,6 +751,7 @@ def mpmd_map_tpu_lowering_rule(
       mosaic_params=mosaic_params,
       kernel_type=kernel_type,
       num_dynamic_grid_bounds=0,
+      input_memory_space_fallbacks=None,
       input_output_aliases=tuple(input_output_aliases.items()),
       cost_estimate=cost_estimate,
       out_avals=out_avals,

--- a/tests/pallas/tpu_pallas_memory_space_test.py
+++ b/tests/pallas/tpu_pallas_memory_space_test.py
@@ -64,6 +64,55 @@ def _json_value_pattern(value):
   return re.escape(json.dumps(value, separators=(',', ':')))
 
 
+class PallasCallHBMInputLoweringTest(jtu.JaxTestCase):
+
+  def test_hbm_inputs_are_constrained_at_custom_call_boundary(self):
+    source_shape = (2, 256)
+    unused_shape = (16, 128)
+    out_shape = (1, 256)
+
+    def kernel(source_hbm, unused_hbm, out_hbm, staging):
+      del unused_hbm
+      pltpu.sync_copy(source_hbm.at[pl.ds(0, 1), :], staging)
+      pltpu.sync_copy(staging, out_hbm)
+
+    def hbm(shape):
+      return pl.BlockSpec(shape, memory_space=pltpu.HBM)
+
+    copy_first_row = pl.pallas_call(
+        kernel,
+        out_shape=jax.ShapeDtypeStruct(out_shape, jnp.float32),
+        in_specs=[hbm(source_shape), hbm(unused_shape)],
+        out_specs=hbm(out_shape),
+        scratch_shapes=[pltpu.VMEM(out_shape, jnp.float32)],
+        grid=(1,),
+    )
+
+    def run(source):
+      return copy_first_row(source, jnp.ones(unused_shape, jnp.float32))
+
+    exported = jax.export.export(jax.jit(run), platforms=("tpu",))(
+        jax.ShapeDtypeStruct(source_shape, jnp.float32)
+    )
+    matches = re.findall(
+        r'backend_config = "(.*?)"', str(exported.mlir_module())
+    )
+    self.assertLen(matches, 1)
+    backend_config = json.loads(matches[0].replace(r'\22', '"'))
+    self.assertEqual(
+        backend_config["custom_call_config"]["input_memory_space_colors"],
+        [
+            {"operand_index": 0, "color": 0},
+            {"operand_index": 1, "color": 0},
+        ],
+    )
+    if jtu.test_device_matches(["tpu"]):
+      source = jnp.arange(np.prod(source_shape), dtype=jnp.float32).reshape(
+          source_shape
+      )
+      self.assertArraysEqual(jax.jit(run)(source), source[:1])
+
+
 class TPUPallasCallMemorySpaceTest(jtu.JaxTestCase):
 
   def setUp(self):


### PR DESCRIPTION
An HBM `BlockSpec` is reflected in the Mosaic kernel parameter type, but was not propagated to the custom call's input memory-space constraints. This allowed XLA to place an operand in CMEM while the Mosaic kernel still generated an HBM DMA path, causing the incorrect results reported on TPU v4.

Use HBM block specifications as fallback input constraints when lowering `pallas_call`. Explicit input memory-space annotations still take precedence, and `pl.ANY` inputs remain unconstrained.

The regression test exports the reproducer from #39744 and checks that both HBM operands receive memory-space color 0. It also verifies the result when running on TPU hardware.

Tests:
- `python -m pytest tests/pallas/tpu_pallas_memory_space_test.py -q`
- `python -m pytest tests/pallas/pallas_shape_poly_test.py -k copy -q`
- `ruff check jax/_src/pallas/mosaic/pallas_call_registration.py tests/pallas/tpu_pallas_memory_space_test.py`

Fixes #39744