### PR TITLE
[shape_poly] Know the Euclidean decomposition for mod factors, not only floordiv

### DIFF
--- a/benchmarks/shape_poly_benchmark.py
+++ b/benchmarks/shape_poly_benchmark.py
@@ -49,7 +49,7 @@ def builder_linear_arith(state):
           for r_k in [1, 2, -2]:
             comb = l * l_k + r * r_k
             if not isinstance(comb, int):
-              _ = comb.leading_term  # Ensure we actually materialize
+              _ = comb._leading_term  # Ensure we actually materialize
 
 
 @benchmark.register
@@ -71,11 +71,12 @@ def load_constraints(state):
 @benchmark.register
 def inequalities_slice(state):
 
+  from jax._src import core as src_core
   a, b = export.symbolic_shape("a, b")
   while state:
     for _ in range(30):
       a.scope._clear_caches()
-      start, _, slice_size = core.canonicalize_slice(slice(2, a, 4), b)
+      start, _, slice_size = src_core.canonicalize_slice(slice(2, a, 4), b)
       _ = 0 <= slice_size <= b
       _ = start >= 0
       _ = start + slice_size <= b

--- a/docs/export/shape_poly.md
+++ b/docs/export/shape_poly.md
@@ -372,40 +372,36 @@ b*d + b*c
 The symbolic constraints can also help to work around the
 limitations in the JAX reasoning mechanisms.
 For example, in the code below JAX will attempt to prove that
-the slice size `x.shape[0] % 3`, which is the symbolic expression
-`mod(b, 3)`, is less or equal to the axis size, which is `b`.
+the slice size `x.shape[0] % x.shape[1]`, which is the symbolic expression
+`mod(b, c)`, is less or equal to the axis size, which is `b`.
 This happens to be true for all strictly positive values of
-`b`, but it is not something JAX's symbolic comparison rules
+`b` and `c`, but it is not something JAX's symbolic comparison rules
 can prove. Hence, the following code raises an error:
 
 ```python
 from jax import lax
->>> b, = export.symbolic_shape("b")
->>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % 3)
+>>> b, c = export.symbolic_shape("b, c")
+>>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % x.shape[1])
 >>> export.export(jax.jit(f))(
-...     jax.ShapeDtypeStruct((b,), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
+...     jax.ShapeDtypeStruct((b, c), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
 Traceback (most recent call last):
-jax._src.export.shape_poly.InconclusiveDimensionOperation: Symbolic dimension comparison 'b' >= 'mod(b, 3)' is inconclusive.
+jax._src.export.shape_poly.InconclusiveDimensionOperation: Symbolic dimension comparison 'b' >= 'mod(b, c)' is inconclusive.
 This error arises for comparison operations with shapes that
 are non-constant, and the result of the operation cannot be represented as
 a boolean value for all values of the symbolic dimensions involved.
 
 ```
 
-One option here would be to restrict the code to work only on
-axis sizes that are multiple of `3` (by replacing
-`b` with `3*b` in the shape). Then, JAX would be able
-to simplify the modulo operation `mod(3*b, 3)` to `0`.
-Another option is to add a symbolic constraint
+One option is to add a symbolic constraint
 with the exact inconclusive inequality that JAX
 is attempting to prove:
 
 ```python
->>> b, = export.symbolic_shape("b",
-...                            constraints=["b >= mod(b, 3)"])
->>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % 3)
+>>> b, c = export.symbolic_shape("b, c",
+...                              constraints=["b >= mod(b, c)"])
+>>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % x.shape[1])
 >>> _ = export.export(jax.jit(f))(
-...     jax.ShapeDtypeStruct((b,), dtype=np.int32))
+...     jax.ShapeDtypeStruct((b, c), dtype=np.int32))
 
 ```
 

--- a/docs/new_docs/501/shape-polymorphism.md
+++ b/docs/new_docs/501/shape-polymorphism.md
@@ -375,40 +375,36 @@ b*d + b*c
 The symbolic constraints can also help to work around the
 limitations in the JAX reasoning mechanisms.
 For example, in the code below JAX will attempt to prove that
-the slice size `x.shape[0] % 3`, which is the symbolic expression
-`mod(b, 3)`, is less or equal to the axis size, which is `b`.
+the slice size `x.shape[0] % x.shape[1]`, which is the symbolic expression
+`mod(b, c)`, is less or equal to the axis size, which is `b`.
 This happens to be true for all strictly positive values of
-`b`, but it is not something JAX's symbolic comparison rules
+`b` and `c`, but it is not something JAX's symbolic comparison rules
 can prove. Hence, the following code raises an error:
 
 ```python
 from jax import lax
->>> b, = export.symbolic_shape("b")
->>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % 3)
+>>> b, c = export.symbolic_shape("b, c")
+>>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % x.shape[1])
 >>> export.export(jax.jit(f))(
-...     jax.ShapeDtypeStruct((b,), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
+...     jax.ShapeDtypeStruct((b, c), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
 Traceback (most recent call last):
-jax._src.export.shape_poly.InconclusiveDimensionOperation: Symbolic dimension comparison 'b' >= 'mod(b, 3)' is inconclusive.
+jax._src.export.shape_poly.InconclusiveDimensionOperation: Symbolic dimension comparison 'b' >= 'mod(b, c)' is inconclusive.
 This error arises for comparison operations with shapes that
 are non-constant, and the result of the operation cannot be represented as
 a boolean value for all values of the symbolic dimensions involved.
 
 ```
 
-One option here would be to restrict the code to work only on
-axis sizes that are multiple of `3` (by replacing
-`b` with `3*b` in the shape). Then, JAX would be able
-to simplify the modulo operation `mod(3*b, 3)` to `0`.
-Another option is to add a symbolic constraint
+One option is to add a symbolic constraint
 with the exact inconclusive inequality that JAX
 is attempting to prove:
 
 ```python
->>> b, = export.symbolic_shape("b",
-...                            constraints=["b >= mod(b, 3)"])
->>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % 3)
+>>> b, c = export.symbolic_shape("b, c",
+...                              constraints=["b >= mod(b, c)"])
+>>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % x.shape[1])
 >>> _ = export.export(jax.jit(f))(
-...     jax.ShapeDtypeStruct((b,), dtype=np.int32))
+...     jax.ShapeDtypeStruct((b, c), dtype=np.int32))
 
 ```
 

--- a/jax/_src/export/shape_poly_decision.py
+++ b/jax/_src/export/shape_poly_decision.py
@@ -399,6 +399,12 @@ class _DecisionByElimination:
         self.combine_and_add_constraint(Comparator.GEQ, t_e, 0)  # m >= 0
         self.combine_and_add_constraint(Comparator.GEQ, op2 - 1, t_e)  # m <= op2 - 1
         self.combine_and_add_constraint(Comparator.GEQ, op2_b_u - 1, t_e)
+        # FLOORDIV constraints add
+        # `op1 == op2 * floordiv(op1, op2) + mod(op1, op2)`.
+        fd_e = _DimExpr._from_operation(_DimFactor.FLOORDIV, op1, op2,
+                                        scope=self.scope)
+        if isinstance(fd_e, _DimExpr):
+          self.add_implicit_constraints_expr(fd_e)
       elif op2_b_u < 0:  # negative divisor
         self.combine_and_add_constraint(Comparator.GEQ, t_e, op2 + 1)  # m >= op2 + 1
         self.combine_and_add_constraint(Comparator.GEQ, t_e, op2_b_l + 1)

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -385,7 +385,8 @@ class DimExprTest(jtu.JaxTestCase):
     self.assertEqual(_bounds(-2*a + -3*b + -5*c + 20), (-np.inf, 10))
 
     # Additions
-    self.assertEqual(_bounds(bounded_ge0_le4 + bounded_le4), (-np.inf, 8))
+    # a % 5 + 5 - a = 5 - 5 * (a // 5) <= 5.
+    self.assertEqual(_bounds(bounded_ge0_le4 + bounded_le4), (-np.inf, 5))
     self.assertEqual(_bounds(bounded_ge0_le4 + bounded_ge2), (2, np.inf))
     self.assertEqual(_bounds(bounded_le4 + bounded_ge2), (-np.inf, np.inf))
 
@@ -432,6 +433,16 @@ class DimExprTest(jtu.JaxTestCase):
     # This arises in convolutions, because we use "-2 * div(-b, 2)" to get
     # the "2*ceil(b / 2)".
     self.assertGreaterEqual(-2 * ((- b) // 2), b)
+
+  def test_bounds_mod_euclidean_decomposition(self):
+    a, b = shape_poly.symbolic_shape("a, b")
+
+    self.assertGreaterEqual(b, b % 3)
+    self.assertEqual(_bounds(b - b % 3), (0, np.inf))
+
+    with self.assertRaisesRegex(core.InconclusiveDimensionOperation,
+                                "inconclusive"):
+      b >= b % a
 
   def test_bounds_floordiv(self):
     a, b = shape_poly.symbolic_shape("a, b")
@@ -1639,6 +1650,13 @@ class ShapePolyTest(jtu.JaxTestCase):
                      arg_descriptors=[RandArg((16,), _i32)],
                      polymorphic_shapes=["a"],
                      symbolic_constraints=["a >= 8"])
+
+  def test_slice_in_dim_mod(self):
+    def f(x):  # x: i32[a]
+      return lax.slice_in_dim(x, 0, x.shape[0] % 3)
+    check_shape_poly(self, f,
+                     arg_descriptors=[RandArg((16,), _i32)],
+                     polymorphic_shapes=["a"])
 
   def test_constraints_slice_in_dim(self):
     def f(x):  # x: i32[a], with a >= 8


### PR DESCRIPTION
The decision procedure adds the Euclidean decomposition `op1 == op2 * floordiv(op1, op2) + mod(op1, op2)` only when it processes a `floordiv` factor, so comparisons mentioning only the `mod` factor — e.g. `b >= mod(b, 3)`, the documentation's own example of an inconclusive comparison — were inconclusive although they hold for every valuation. We now process the implicit constraints of the corresponding `floordiv` when processing a `mod` factor with a provably positive divisor. Comparisons with symbolic divisors (`b >= mod(b, c)`) remain inconclusive, and the documentation example moves to that form.

Also repairs `benchmarks/shape_poly_benchmark.py`, which no longer ran after the `_leading_term` privatisation and a `jax.core.canonicalize_slice` call that only exists in `jax._src.core`.
