### PR TITLE
Add a benchmark smoke-test workflow

### DIFF
--- a/.github/workflows/benchmark_smoke.yml
+++ b/.github/workflows/benchmark_smoke.yml
@@ -1,0 +1,72 @@
+name: Benchmark smoke test
+
+# Executes every benchmarks/*_benchmark.py file for a single iteration on
+# CPU (benchmarks needing more devices skip themselves). The "Bazel
+# nobuild" workflow only checks that //benchmarks/... resolves in the
+# build graph; actually running the files is what catches runtime rot
+# (renamed or moved internal APIs).
+#
+# Pull requests are checked only when they touch benchmarks/ or this
+# workflow; breakage introduced from elsewhere (e.g. a rename in jax/_src)
+# is caught by the nightly run.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'benchmarks/**'
+      - '.github/workflows/benchmark_smoke.yml'
+  schedule:
+    - cron: '0 3 * * *'  # nightly, after the regular test cycles
+  workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'main' }}
+
+jobs:
+  benchmark-smoke:
+    if: github.repository == 'jax-ml/jax'
+    name: Benchmark smoke test (CPU, one iteration)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      JAX_PLATFORMS: cpu
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+      - name: Install JAX (CPU) and benchmark dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[ci]' google-benchmark absl-py
+      - name: Run each benchmark for one iteration
+        run: |
+          set -uo pipefail
+          failed=0
+          for f in benchmarks/*_benchmark.py; do
+            echo "::group::$f"
+            # A file that silently registers no benchmarks would otherwise
+            # "pass" while testing nothing; require at least one.
+            if ! names="$(python "$f" --benchmark_list_tests=true)"; then
+              echo "FAILED to list benchmarks: $f"
+              failed=1
+            elif [ -z "$names" ]; then
+              echo "NO benchmarks registered: $f"
+              failed=1
+            elif ! python "$f" --benchmark_min_time=1x; then
+              echo "FAILED: $f"
+              failed=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "$failed"

--- a/benchmarks/shape_poly_benchmark.py
+++ b/benchmarks/shape_poly_benchmark.py
@@ -49,7 +49,7 @@ def builder_linear_arith(state):
           for r_k in [1, 2, -2]:
             comb = l * l_k + r * r_k
             if not isinstance(comb, int):
-              _ = comb.leading_term  # Ensure we actually materialize
+              _ = comb._leading_term  # Ensure we actually materialize
 
 
 @benchmark.register
@@ -71,11 +71,12 @@ def load_constraints(state):
 @benchmark.register
 def inequalities_slice(state):
 
+  from jax._src import core as src_core
   a, b = export.symbolic_shape("a, b")
   while state:
     for _ in range(30):
       a.scope._clear_caches()
-      start, _, slice_size = core.canonicalize_slice(slice(2, a, 4), b)
+      start, _, slice_size = src_core.canonicalize_slice(slice(2, a, 4), b)
       _ = 0 <= slice_size <= b
       _ = start >= 0
       _ = start + slice_size <= b

--- a/docs/export/shape_poly.md
+++ b/docs/export/shape_poly.md
@@ -372,40 +372,36 @@ b*d + b*c
 The symbolic constraints can also help to work around the
 limitations in the JAX reasoning mechanisms.
 For example, in the code below JAX will attempt to prove that
-the slice size `x.shape[0] % 3`, which is the symbolic expression
-`mod(b, 3)`, is less or equal to the axis size, which is `b`.
+the slice size `x.shape[0] % x.shape[1]`, which is the symbolic expression
+`mod(b, c)`, is less or equal to the axis size, which is `b`.
 This happens to be true for all strictly positive values of
-`b`, but it is not something JAX's symbolic comparison rules
+`b` and `c`, but it is not something JAX's symbolic comparison rules
 can prove. Hence, the following code raises an error:
 
 ```python
 from jax import lax
->>> b, = export.symbolic_shape("b")
->>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % 3)
+>>> b, c = export.symbolic_shape("b, c")
+>>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % x.shape[1])
 >>> export.export(jax.jit(f))(
-...     jax.ShapeDtypeStruct((b,), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
+...     jax.ShapeDtypeStruct((b, c), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
 Traceback (most recent call last):
-jax._src.export.shape_poly.InconclusiveDimensionOperation: Symbolic dimension comparison 'b' >= 'mod(b, 3)' is inconclusive.
+jax._src.export.shape_poly.InconclusiveDimensionOperation: Symbolic dimension comparison 'b' >= 'mod(b, c)' is inconclusive.
 This error arises for comparison operations with shapes that
 are non-constant, and the result of the operation cannot be represented as
 a boolean value for all values of the symbolic dimensions involved.
 
 ```
 
-One option here would be to restrict the code to work only on
-axis sizes that are multiple of `3` (by replacing
-`b` with `3*b` in the shape). Then, JAX would be able
-to simplify the modulo operation `mod(3*b, 3)` to `0`.
-Another option is to add a symbolic constraint
+One option is to add a symbolic constraint
 with the exact inconclusive inequality that JAX
 is attempting to prove:
 
 ```python
->>> b, = export.symbolic_shape("b",
-...                            constraints=["b >= mod(b, 3)"])
->>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % 3)
+>>> b, c = export.symbolic_shape("b, c",
+...                              constraints=["b >= mod(b, c)"])
+>>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % x.shape[1])
 >>> _ = export.export(jax.jit(f))(
-...     jax.ShapeDtypeStruct((b,), dtype=np.int32))
+...     jax.ShapeDtypeStruct((b, c), dtype=np.int32))
 
 ```
 

--- a/docs/new_docs/501/shape-polymorphism.md
+++ b/docs/new_docs/501/shape-polymorphism.md
@@ -375,40 +375,36 @@ b*d + b*c
 The symbolic constraints can also help to work around the
 limitations in the JAX reasoning mechanisms.
 For example, in the code below JAX will attempt to prove that
-the slice size `x.shape[0] % 3`, which is the symbolic expression
-`mod(b, 3)`, is less or equal to the axis size, which is `b`.
+the slice size `x.shape[0] % x.shape[1]`, which is the symbolic expression
+`mod(b, c)`, is less or equal to the axis size, which is `b`.
 This happens to be true for all strictly positive values of
-`b`, but it is not something JAX's symbolic comparison rules
+`b` and `c`, but it is not something JAX's symbolic comparison rules
 can prove. Hence, the following code raises an error:
 
 ```python
 from jax import lax
->>> b, = export.symbolic_shape("b")
->>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % 3)
+>>> b, c = export.symbolic_shape("b, c")
+>>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % x.shape[1])
 >>> export.export(jax.jit(f))(
-...     jax.ShapeDtypeStruct((b,), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
+...     jax.ShapeDtypeStruct((b, c), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
 Traceback (most recent call last):
-jax._src.export.shape_poly.InconclusiveDimensionOperation: Symbolic dimension comparison 'b' >= 'mod(b, 3)' is inconclusive.
+jax._src.export.shape_poly.InconclusiveDimensionOperation: Symbolic dimension comparison 'b' >= 'mod(b, c)' is inconclusive.
 This error arises for comparison operations with shapes that
 are non-constant, and the result of the operation cannot be represented as
 a boolean value for all values of the symbolic dimensions involved.
 
 ```
 
-One option here would be to restrict the code to work only on
-axis sizes that are multiple of `3` (by replacing
-`b` with `3*b` in the shape). Then, JAX would be able
-to simplify the modulo operation `mod(3*b, 3)` to `0`.
-Another option is to add a symbolic constraint
+One option is to add a symbolic constraint
 with the exact inconclusive inequality that JAX
 is attempting to prove:
 
 ```python
->>> b, = export.symbolic_shape("b",
-...                            constraints=["b >= mod(b, 3)"])
->>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % 3)
+>>> b, c = export.symbolic_shape("b, c",
+...                              constraints=["b >= mod(b, c)"])
+>>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % x.shape[1])
 >>> _ = export.export(jax.jit(f))(
-...     jax.ShapeDtypeStruct((b,), dtype=np.int32))
+...     jax.ShapeDtypeStruct((b, c), dtype=np.int32))
 
 ```
 

--- a/jax/_src/export/shape_poly_decision.py
+++ b/jax/_src/export/shape_poly_decision.py
@@ -399,6 +399,12 @@ class _DecisionByElimination:
         self.combine_and_add_constraint(Comparator.GEQ, t_e, 0)  # m >= 0
         self.combine_and_add_constraint(Comparator.GEQ, op2 - 1, t_e)  # m <= op2 - 1
         self.combine_and_add_constraint(Comparator.GEQ, op2_b_u - 1, t_e)
+        # FLOORDIV constraints add
+        # `op1 == op2 * floordiv(op1, op2) + mod(op1, op2)`.
+        fd_e = _DimExpr._from_operation(_DimFactor.FLOORDIV, op1, op2,
+                                        scope=self.scope)
+        if isinstance(fd_e, _DimExpr):
+          self.add_implicit_constraints_expr(fd_e)
       elif op2_b_u < 0:  # negative divisor
         self.combine_and_add_constraint(Comparator.GEQ, t_e, op2 + 1)  # m >= op2 + 1
         self.combine_and_add_constraint(Comparator.GEQ, t_e, op2_b_l + 1)

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -385,7 +385,8 @@ class DimExprTest(jtu.JaxTestCase):
     self.assertEqual(_bounds(-2*a + -3*b + -5*c + 20), (-np.inf, 10))
 
     # Additions
-    self.assertEqual(_bounds(bounded_ge0_le4 + bounded_le4), (-np.inf, 8))
+    # a % 5 + 5 - a = 5 - 5 * (a // 5) <= 5.
+    self.assertEqual(_bounds(bounded_ge0_le4 + bounded_le4), (-np.inf, 5))
     self.assertEqual(_bounds(bounded_ge0_le4 + bounded_ge2), (2, np.inf))
     self.assertEqual(_bounds(bounded_le4 + bounded_ge2), (-np.inf, np.inf))
 
@@ -432,6 +433,16 @@ class DimExprTest(jtu.JaxTestCase):
     # This arises in convolutions, because we use "-2 * div(-b, 2)" to get
     # the "2*ceil(b / 2)".
     self.assertGreaterEqual(-2 * ((- b) // 2), b)
+
+  def test_bounds_mod_euclidean_decomposition(self):
+    a, b = shape_poly.symbolic_shape("a, b")
+
+    self.assertGreaterEqual(b, b % 3)
+    self.assertEqual(_bounds(b - b % 3), (0, np.inf))
+
+    with self.assertRaisesRegex(core.InconclusiveDimensionOperation,
+                                "inconclusive"):
+      b >= b % a
 
   def test_bounds_floordiv(self):
     a, b = shape_poly.symbolic_shape("a, b")
@@ -1639,6 +1650,13 @@ class ShapePolyTest(jtu.JaxTestCase):
                      arg_descriptors=[RandArg((16,), _i32)],
                      polymorphic_shapes=["a"],
                      symbolic_constraints=["a >= 8"])
+
+  def test_slice_in_dim_mod(self):
+    def f(x):  # x: i32[a]
+      return lax.slice_in_dim(x, 0, x.shape[0] % 3)
+    check_shape_poly(self, f,
+                     arg_descriptors=[RandArg((16,), _i32)],
+                     polymorphic_shapes=["a"])
 
   def test_constraints_slice_in_dim(self):
     def f(x):  # x: i32[a], with a >= 8


### PR DESCRIPTION
No CI job currently executes the `benchmarks/*_benchmark.py` files: the "Bazel nobuild" workflow only analyses the build graph, so runtime rot is invisible — `benchmarks/shape_poly_benchmark.py` is currently unrunnable. Add a nightly job that runs every `benchmarks/*_benchmark.py` file for a single iteration on CPU, also triggered by pull requests touching `benchmarks/`; each file must register at least one benchmark, so a file that silently degrades to a no-op fails rather than passing vacuously.

Stacked on #39841 (the smoke test fails on main without the benchmark repair).
