### PR TITLE
[shape_poly] Decide mod residues via equality gcd analysis

### DIFF
--- a/docs/export/shape_poly.md
+++ b/docs/export/shape_poly.md
@@ -372,40 +372,36 @@ b*d + b*c
 The symbolic constraints can also help to work around the
 limitations in the JAX reasoning mechanisms.
 For example, in the code below JAX will attempt to prove that
-the slice size `x.shape[0] % 3`, which is the symbolic expression
-`mod(b, 3)`, is less or equal to the axis size, which is `b`.
+the slice size `x.shape[0] % x.shape[1]`, which is the symbolic expression
+`mod(b, c)`, is less or equal to the axis size, which is `b`.
 This happens to be true for all strictly positive values of
-`b`, but it is not something JAX's symbolic comparison rules
+`b` and `c`, but it is not something JAX's symbolic comparison rules
 can prove. Hence, the following code raises an error:
 
 ```python
 from jax import lax
->>> b, = export.symbolic_shape("b")
->>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % 3)
+>>> b, c = export.symbolic_shape("b, c")
+>>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % x.shape[1])
 >>> export.export(jax.jit(f))(
-...     jax.ShapeDtypeStruct((b,), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
+...     jax.ShapeDtypeStruct((b, c), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
 Traceback (most recent call last):
-jax._src.export.shape_poly.InconclusiveDimensionOperation: Symbolic dimension comparison 'b' >= 'mod(b, 3)' is inconclusive.
+jax._src.export.shape_poly.InconclusiveDimensionOperation: Symbolic dimension comparison 'b' >= 'mod(b, c)' is inconclusive.
 This error arises for comparison operations with shapes that
 are non-constant, and the result of the operation cannot be represented as
 a boolean value for all values of the symbolic dimensions involved.
 
 ```
 
-One option here would be to restrict the code to work only on
-axis sizes that are multiple of `3` (by replacing
-`b` with `3*b` in the shape). Then, JAX would be able
-to simplify the modulo operation `mod(3*b, 3)` to `0`.
-Another option is to add a symbolic constraint
+One option is to add a symbolic constraint
 with the exact inconclusive inequality that JAX
 is attempting to prove:
 
 ```python
->>> b, = export.symbolic_shape("b",
-...                            constraints=["b >= mod(b, 3)"])
->>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % 3)
+>>> b, c = export.symbolic_shape("b, c",
+...                              constraints=["b >= mod(b, c)"])
+>>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % x.shape[1])
 >>> _ = export.export(jax.jit(f))(
-...     jax.ShapeDtypeStruct((b,), dtype=np.int32))
+...     jax.ShapeDtypeStruct((b, c), dtype=np.int32))
 
 ```
 

--- a/docs/new_docs/501/shape-polymorphism.md
+++ b/docs/new_docs/501/shape-polymorphism.md
@@ -375,40 +375,36 @@ b*d + b*c
 The symbolic constraints can also help to work around the
 limitations in the JAX reasoning mechanisms.
 For example, in the code below JAX will attempt to prove that
-the slice size `x.shape[0] % 3`, which is the symbolic expression
-`mod(b, 3)`, is less or equal to the axis size, which is `b`.
+the slice size `x.shape[0] % x.shape[1]`, which is the symbolic expression
+`mod(b, c)`, is less or equal to the axis size, which is `b`.
 This happens to be true for all strictly positive values of
-`b`, but it is not something JAX's symbolic comparison rules
+`b` and `c`, but it is not something JAX's symbolic comparison rules
 can prove. Hence, the following code raises an error:
 
 ```python
 from jax import lax
->>> b, = export.symbolic_shape("b")
->>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % 3)
+>>> b, c = export.symbolic_shape("b, c")
+>>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % x.shape[1])
 >>> export.export(jax.jit(f))(
-...     jax.ShapeDtypeStruct((b,), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
+...     jax.ShapeDtypeStruct((b, c), dtype=np.int32))  # doctest: +IGNORE_EXCEPTION_DETAIL
 Traceback (most recent call last):
-jax._src.export.shape_poly.InconclusiveDimensionOperation: Symbolic dimension comparison 'b' >= 'mod(b, 3)' is inconclusive.
+jax._src.export.shape_poly.InconclusiveDimensionOperation: Symbolic dimension comparison 'b' >= 'mod(b, c)' is inconclusive.
 This error arises for comparison operations with shapes that
 are non-constant, and the result of the operation cannot be represented as
 a boolean value for all values of the symbolic dimensions involved.
 
 ```
 
-One option here would be to restrict the code to work only on
-axis sizes that are multiple of `3` (by replacing
-`b` with `3*b` in the shape). Then, JAX would be able
-to simplify the modulo operation `mod(3*b, 3)` to `0`.
-Another option is to add a symbolic constraint
+One option is to add a symbolic constraint
 with the exact inconclusive inequality that JAX
 is attempting to prove:
 
 ```python
->>> b, = export.symbolic_shape("b",
-...                            constraints=["b >= mod(b, 3)"])
->>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % 3)
+>>> b, c = export.symbolic_shape("b, c",
+...                              constraints=["b >= mod(b, c)"])
+>>> f = lambda x: lax.slice_in_dim(x, 0, x.shape[0] % x.shape[1])
 >>> _ = export.export(jax.jit(f))(
-...     jax.ShapeDtypeStruct((b,), dtype=np.int32))
+...     jax.ShapeDtypeStruct((b, c), dtype=np.int32))
 
 ```
 

--- a/jax/_src/export/shape_poly_decision.py
+++ b/jax/_src/export/shape_poly_decision.py
@@ -399,6 +399,12 @@ class _DecisionByElimination:
         self.combine_and_add_constraint(Comparator.GEQ, t_e, 0)  # m >= 0
         self.combine_and_add_constraint(Comparator.GEQ, op2 - 1, t_e)  # m <= op2 - 1
         self.combine_and_add_constraint(Comparator.GEQ, op2_b_u - 1, t_e)
+        # FLOORDIV constraints add
+        # `op1 == op2 * floordiv(op1, op2) + mod(op1, op2)`.
+        fd_e = _DimExpr._from_operation(_DimFactor.FLOORDIV, op1, op2,
+                                        scope=self.scope)
+        if isinstance(fd_e, _DimExpr):
+          self.add_implicit_constraints_expr(fd_e)
       elif op2_b_u < 0:  # negative divisor
         self.combine_and_add_constraint(Comparator.GEQ, t_e, op2 + 1)  # m >= op2 + 1
         self.combine_and_add_constraint(Comparator.GEQ, t_e, op2_b_l + 1)

--- a/jax/_src/export/shape_poly_decision.py
+++ b/jax/_src/export/shape_poly_decision.py
@@ -72,6 +72,9 @@ class _DecisionByElimination:
     # The other fields are for keeping an efficient representation of
     # the explicit constraints.
     self._term_bounds: dict[_DimTerm, tuple[float, float]] = {}
+    # Known residues: t -> (d, r) with d >= 2 means "t ≡ r (mod d)", derived
+    # from equality constraints. See _tighten_term_bounds_with_residues.
+    self._term_residues: dict[_DimTerm, tuple[int, int]] = {}
     # The _expr_constraints represents a set of constraints that are not
     # just simple terms. The set is represented as a mapping from a
     # term "t" to tuples (cmp, k, c) where "c >= 0" (if cmp is GEQ else "c == 0")
@@ -113,6 +116,7 @@ class _DecisionByElimination:
     c = _DecisionByElimination(scope)
     c._processed_for_internal_constraints = d._processed_for_internal_constraints.copy()
     c._term_bounds = d._term_bounds.copy()
+    c._term_residues = d._term_residues.copy()
     c._expr_constraints = {
         lead_t: lead_t_constraints.copy()
         for lead_t, lead_t_constraints in d._expr_constraints.items()}
@@ -177,6 +181,89 @@ class _DecisionByElimination:
       lead_t_constraints = set()
       self._expr_constraints[lead_t] = lead_t_constraints
     lead_t_constraints.add((cmp, lead_t_k, e))
+    if cmp == Comparator.EQ:
+      self._tighten_term_bounds_with_residues(e, debug_str)
+
+  def _add_term_residue(self, t: _DimTerm, d: int, r: int,
+                        debug_str: str | None):
+    """Records `t ≡ r (mod d)`, merging with any known residue.
+
+    Compatible facts merge by CRT; incompatible facts are unsatisfiable.
+    """
+    assert d >= 2
+    r = r % d
+    prev = self._term_residues.get(t)
+    if prev is not None:
+      d1, r1 = prev
+      g = math.gcd(d1, d)
+      if (r - r1) % g:
+        raise ValueError(
+            f"Unsatisfiable constraint: {debug_str or str(t)} "
+            f"(mod {d1} residue {r1} vs mod {d} residue {r})")
+      if d1 % d == 0:
+        return  # The known fact is at least as strong.
+      if d % d1 == 0:
+        self._term_residues[t] = (d, r)  # The new fact is strictly stronger.
+        return
+      lcm = d1 * d // g
+      # CRT: x ≡ r1 (mod d1) and x ≡ r (mod d) -> x ≡ merged (mod lcm)
+      merged = (r1 + d1 * (((r - r1) // g) * pow(d1 // g, -1, d // g))) % lcm
+      d, r = lcm, merged
+    self._term_residues[t] = (d, r)
+
+  def _tighten_term_bounds_with_residues(self,
+                                          e: _DimExpr,
+                                          debug_str: str | None):
+    """Derives and applies residue facts from equality `e == 0`.
+
+    For target `t` with `abs(t_k) == 1`, write
+    `e == t*t_k + sum(o_k * o) + c`.
+    Treat pinned terms as constants; for other terms, use known
+    `o ≡ r_o (mod d_o)` (or `d_o == 1, r_o == 0`).
+    Let `g = gcd(abs(o_k) * d_o for other terms o)`. Then
+    `t ≡ -t_k * (c + sum(o_k * r_o)) (mod g)`.
+    The fact is recorded and may pin `t` when its bounds admit one value.
+    Propagation is forward-only: prior equalities are not revisited, so
+    precision may depend on constraint order.
+    """
+    const = 0
+    non_const_terms: list[tuple[_DimTerm, int]] = []
+    for t, t_k in e._sorted_terms:
+      if t.is_constant:
+        const = t_k
+      else:
+        non_const_terms.append((t, t_k))
+    if len(non_const_terms) < 2: return
+    for idx, (t, t_k) in enumerate(non_const_terms):
+      if abs(t_k) != 1: continue
+      lb, ub = self._term_bounds.get(t, (- np.inf, np.inf))
+      if lb == ub: continue  # already pinned
+      # The modulus in which the equality constrains t, and the sum of the
+      # known residues of the other terms (times their coefficients).
+      g = 0
+      others_residue = const
+      for o_idx, (o, o_k) in enumerate(non_const_terms):
+        if o_idx == idx: continue
+        o_lb, o_ub = self._term_bounds.get(o, (- np.inf, np.inf))
+        if o_lb == o_ub:  # pinned term: just a constant
+          others_residue += o_k * int(o_lb)
+          continue
+        o_d, o_r = self._term_residues.get(o, (1, 0))
+        g = math.gcd(g, abs(o_k) * o_d)
+        if g == 1: break  # The gcd cannot recover; no fact for this target.
+        others_residue += o_k * o_r
+      if g < 2: continue
+      residue = (- t_k * others_residue) % g
+      self._add_term_residue(t, g, residue, debug_str)
+      if np.isinf(lb) or np.isinf(ub): continue
+      # Smallest member of the residue class that is >= lb.
+      t_val = int(lb) + (residue - int(lb)) % g
+      if t_val > ub:
+        raise ValueError(f"Unsatisfiable constraint: {debug_str or str(e) + ' == 0'}")
+      if t_val + g <= ub: continue  # More than one candidate; no pin.
+      self._term_bounds[t] = (t_val, t_val)
+      # The newly pinned term may make previously cached bounds imprecise.
+      self.scope._bounds_cache.clear()
 
   def combine_term_with_existing(self, t: _DimTerm, t_k: int, *,
                                  scope: shape_poly.SymbolicScope,

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -444,6 +444,16 @@ class DimExprTest(jtu.JaxTestCase):
                                 "inconclusive"):
       b >= b % a
 
+  def test_bounds_mod_residue_parity(self):
+    # `mod(b, 2) + b` and `3 * b + mod(b, 2)` are even, so both
+    # remainders modulo 2 are zero.
+    b, = shape_poly.symbolic_shape("b")
+    self.assertEqual(_bounds((b % 2 + b) % 2), (0, 0))
+    # `_DimExpr.__eq__` is syntactic and never invokes the decision procedure.
+    self.assertGreaterEqual(0, (b % 2 + b) % 2)
+    b2, = shape_poly.symbolic_shape("b")
+    self.assertEqual(_bounds((3 * b2 + b2 % 2) % 2), (0, 0))
+
   def test_bounds_floordiv(self):
     a, b = shape_poly.symbolic_shape("a, b")
     self.assertEqual(_bounds((a + 4) // 2), (2, np.inf))
@@ -1108,6 +1118,48 @@ class DimExprTest(jtu.JaxTestCase):
 
     self.assertGreaterEqual(b, b // 4)
     self.assertGreaterEqual(b, 3 * (b // 4))
+
+  def test_constraints_eq_mod_residue(self):
+    # `m ≡ 0 (mod 6)` implies `m ≡ 0 (mod 3)` and `m ≡ 0 (mod 2)`.
+    m, = shape_poly.symbolic_shape("m", constraints=("mod(m, 6) == 0",))
+    self.assertEqual(_bounds(m % 3), (0, 0))
+    self.assertGreaterEqual(0, m % 3)
+    self.assertEqual(_bounds(m % 2), (0, 0))
+
+    # `m ≡ 4 (mod 6)` implies `m ≡ 1 (mod 3)`.
+    m4, = shape_poly.symbolic_shape("m", constraints=("mod(m, 6) == 4",))
+    self.assertEqual(_bounds(m4 % 3), (1, 1))
+
+    # `m ≡ 0 (mod 5)` does not determine `m mod 3`.
+    m5, = shape_poly.symbolic_shape("m", constraints=("mod(m, 5) == 0",))
+    self.assertEqual(_bounds(m5 % 3), (0, 2))
+
+    # `m ≡ 0 (mod 6)` permits both 0 and 2 as `m mod 4`.
+    m6, = shape_poly.symbolic_shape("m", constraints=("mod(m, 6) == 0",))
+    self.assertEqual(_bounds(m6 % 4), (0, 3))
+
+  def test_constraints_eq_mod_residue_crt(self):
+    # `m ≡ 1 (mod 4)` and `m ≡ 3 (mod 6)` imply `m ≡ 9 (mod 12)`.
+    m, = shape_poly.symbolic_shape(
+        "m", constraints=("mod(m, 4) == 1", "mod(m, 6) == 3"))
+    self.assertEqual(_bounds(m % 12), (9, 9))
+
+    # `m ≡ 0 (mod 12)` implies `m ≡ 0 (mod 4)`.
+    m2, = shape_poly.symbolic_shape(
+        "m", constraints=("mod(m, 12) == 0", "mod(m, 4) == 0"))
+    self.assertEqual(_bounds(m2 % 12), (0, 0))
+    self.assertEqual(_bounds(m2 % 4), (0, 0))
+
+    # `m ≡ 1 (mod 4)` and `m ≡ 0 (mod 6)` are incompatible.
+    m3, = shape_poly.symbolic_shape(
+        "m", constraints=("mod(m, 4) == 1", "mod(m, 6) == 0"))
+    with self.assertRaisesRegex(ValueError, "Unsatisfiable"):
+      _bounds(m3 % 12)
+
+  def test_constraints_eq_mod_residue_signed(self):
+    # `6 * c == b + 2` implies `b ≡ 4 (mod 6)`.
+    b, c = shape_poly.symbolic_shape("b, c", constraints=("6*c == b + 2",))
+    self.assertEqual(_bounds(b % 6), (4, 4))
 
   def test_constraints_eq_a_minus_4d(self):
     # simulates d = div(a, 4) and m = mod(a, 4)

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -385,7 +385,8 @@ class DimExprTest(jtu.JaxTestCase):
     self.assertEqual(_bounds(-2*a + -3*b + -5*c + 20), (-np.inf, 10))
 
     # Additions
-    self.assertEqual(_bounds(bounded_ge0_le4 + bounded_le4), (-np.inf, 8))
+    # a % 5 + 5 - a = 5 - 5 * (a // 5) <= 5.
+    self.assertEqual(_bounds(bounded_ge0_le4 + bounded_le4), (-np.inf, 5))
     self.assertEqual(_bounds(bounded_ge0_le4 + bounded_ge2), (2, np.inf))
     self.assertEqual(_bounds(bounded_le4 + bounded_ge2), (-np.inf, np.inf))
 
@@ -432,6 +433,16 @@ class DimExprTest(jtu.JaxTestCase):
     # This arises in convolutions, because we use "-2 * div(-b, 2)" to get
     # the "2*ceil(b / 2)".
     self.assertGreaterEqual(-2 * ((- b) // 2), b)
+
+  def test_bounds_mod_euclidean_decomposition(self):
+    a, b = shape_poly.symbolic_shape("a, b")
+
+    self.assertGreaterEqual(b, b % 3)
+    self.assertEqual(_bounds(b - b % 3), (0, np.inf))
+
+    with self.assertRaisesRegex(core.InconclusiveDimensionOperation,
+                                "inconclusive"):
+      b >= b % a
 
   def test_bounds_floordiv(self):
     a, b = shape_poly.symbolic_shape("a, b")
@@ -1639,6 +1650,13 @@ class ShapePolyTest(jtu.JaxTestCase):
                      arg_descriptors=[RandArg((16,), _i32)],
                      polymorphic_shapes=["a"],
                      symbolic_constraints=["a >= 8"])
+
+  def test_slice_in_dim_mod(self):
+    def f(x):  # x: i32[a]
+      return lax.slice_in_dim(x, 0, x.shape[0] % 3)
+    check_shape_poly(self, f,
+                     arg_descriptors=[RandArg((16,), _i32)],
+                     polymorphic_shapes=["a"])
 
   def test_constraints_slice_in_dim(self):
     def f(x):  # x: i32[a], with a >= 8


### PR DESCRIPTION
With the Euclidean decompositions in the decision state, facts like "`mod(b, 2) + b` is even" reduce to a residue argument: in an equality `e == 0` where every term but one contributes a multiple of `g`, a remaining unit-coefficient term is confined to a residue class mod `g`. Elimination alone cannot recover this because normalization rewrites `6*floordiv(m, 6)` straight back to `m`, undoing the combining step, so we track residue facts `t ≡ r (mod d)` as decision state: derived from equalities, merged by CRT, and used to pin a term when its bounds admit exactly one member of its class. The decision procedure can now infer `mod(m, 3) == 0` from `mod(m, 6) == 0`, and `mod(m, 3) == 1` from `mod(m, 6) == 4`.

Fixes #24144.

Depends on the Euclidean-decomposition change in #39841; it does not include that PR's benchmark repair.
