### PR TITLE
Update missing or stale args in numpy and scipy docstrings

### DIFF
--- a/jax/_src/numpy/array_constructors.py
+++ b/jax/_src/numpy/array_constructors.py
@@ -393,6 +393,9 @@ def asarray(a: Any, dtype: DTypeLike | None = None, order: str | None = None,
       None, which will only copy when necessary.
     device: optional :class:`~jax.Device` or :class:`~jax.sharding.Sharding`
       to which the created array will be committed.
+    out_sharding: optional :class:`~jax.sharding.PartitionSpec` or
+      :class:`~jax.NamedSharding` specifying the sharding of the output array.
+      Cannot be used together with ``device``.
 
   Returns:
     A JAX array constructed from the input.

--- a/jax/_src/numpy/array_creation.py
+++ b/jax/_src/numpy/array_creation.py
@@ -222,6 +222,9 @@ def full(shape: Any, fill_value: ArrayLike,
       fill value.
     device: (optional) :class:`~jax.Device` or :class:`~jax.sharding.Sharding`
       to which the created array will be committed.
+    out_sharding: optional :class:`~jax.sharding.PartitionSpec` or
+      :class:`~jax.NamedSharding` specifying the sharding of the output array.
+      Cannot be used together with ``device``.
 
   Returns:
     Array of the specified shape and dtype, on the specified device if specified.
@@ -279,6 +282,9 @@ def zeros_like(a: ArrayLike | DuckTypedArray,
     dtype: optionally override the dtype of the created array.
     device: (optional) :class:`~jax.Device` or :class:`~jax.sharding.Sharding`
       to which the created array will be committed.
+    out_sharding: optional :class:`~jax.sharding.PartitionSpec` or
+      :class:`~jax.NamedSharding` specifying the sharding of the output array.
+      Cannot be used together with ``device``.
 
   Returns:
     Array of the specified shape and dtype, on the specified device if specified.
@@ -329,6 +335,9 @@ def ones_like(a: ArrayLike | DuckTypedArray,
     dtype: optionally override the dtype of the created array.
     device: (optional) :class:`~jax.Device` or :class:`~jax.sharding.Sharding`
       to which the created array will be committed.
+    out_sharding: optional :class:`~jax.sharding.PartitionSpec` or
+      :class:`~jax.NamedSharding` specifying the sharding of the output array.
+      Cannot be used together with ``device``.
 
   Returns:
     Array of the specified shape and dtype, on the specified device if specified.
@@ -430,6 +439,9 @@ def full_like(a: ArrayLike | DuckTypedArray,
     dtype: optionally override the dtype of the created array.
     device: (optional) :class:`~jax.Device` or :class:`~jax.sharding.Sharding`
       to which the created array will be committed.
+    out_sharding: optional :class:`~jax.sharding.PartitionSpec` or
+      :class:`~jax.NamedSharding` specifying the sharding of the output array.
+      Cannot be used together with ``device``.
 
   Returns:
     Array of the specified shape and dtype, on the specified device if specified.
@@ -522,6 +534,7 @@ def linspace(start: ArrayLike, stop: ArrayLike, num: int = 50,
       If False, then exclude the ``stop`` value.
     retstep: If True, then return a ``(result, step)`` tuple, where ``step`` is the
       interval between adjacent values in ``result``.
+    dtype: optional. Specifies the dtype of the output.
     axis: integer axis along which to generate the linspace. Defaults to zero.
     device: optional :class:`~jax.Device` or :class:`~jax.sharding.Sharding`
       to which the created array will be committed.

--- a/jax/_src/numpy/einsum.py
+++ b/jax/_src/numpy/einsum.py
@@ -103,6 +103,8 @@ def einsum(
     out: unsupported by JAX
     _dot_general: optionally override the ``dot_general`` callable used by ``einsum``.
       This parameter is experimental, and may be removed without warning at any time.
+    out_sharding: optional sharding specification for the output. If not specified,
+      it will be determined automatically by the compiler.
 
   Returns:
     array containing the result of the einstein summation.

--- a/jax/_src/numpy/indexing.py
+++ b/jax/_src/numpy/indexing.py
@@ -628,6 +628,7 @@ def take(
     indices: N-dimensional array of integer indices of values to take from the array.
     axis: the axis along which to take values. If not specified, the array will
       be flattened before indexing is applied.
+    out: unsupported by JAX.
     mode: Out-of-bounds indexing mode, either ``"fill"`` or ``"clip"``. The default
       ``mode="fill"`` returns invalid values (e.g. NaN) for out-of bounds indices;
       the ``fill_value`` argument gives control over this value. For more discussion
@@ -784,10 +785,10 @@ def take_along_axis(
   in the case of out-of-bound indices; see the ``mode`` parameter below.
 
   Args:
-    a: array from which to take values.
+    arr: array from which to take values.
     indices: array of integer indices. If ``axis`` is ``None``, must be
-      one-dimensional. If ``axis`` is not None, must have ``a.ndim ==
-      indices.ndim``, and ``a`` must be broadcast-compatible with ``indices``
+      one-dimensional. If ``axis`` is not None, must have ``arr.ndim ==
+      indices.ndim``, and ``arr`` must be broadcast-compatible with ``indices``
       along dimensions other than ``axis``.
     axis: the axis along which to take values. If not specified, the array will
       be flattened before indexing is applied.
@@ -795,13 +796,15 @@ def take_along_axis(
       default ``mode="fill"`` returns invalid values (e.g. NaN) for out-of
       bounds indices. For more discussion of ``mode`` options, see
       :attr:`jax.numpy.ndarray.at`.
+    fill_value: The fill value to return for out-of-bounds indices when
+      ``mode="fill"``. Ignored otherwise.
     wrap_negative_indices: Whether to wrap negative indices to positive like
       Numpy. If unset, defaults to a legacy behavior (wrapping unless the
       indexing mode is 'promise_in_bounds'), but this will likely be removed and
       the default changed to True in the future, so do not depend on it.
 
   Returns:
-    Array of values extracted from ``a``.
+    Array of values extracted from ``arr``.
 
   See also:
     - :attr:`jax.numpy.ndarray.at`: take values via indexing syntax.

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1921,6 +1921,8 @@ def reshape(
       JAX does not support ``order="A"``.
     copy: unused by JAX; JAX always returns a copy, though under JIT the compiler
       may optimize such copies away.
+    out_sharding: optional sharding specification for the output. If not specified,
+      it will be determined automatically by the compiler.
 
   Returns:
     reshaped copy of input array with the specified shape.
@@ -2002,6 +2004,8 @@ def ravel(a: ArrayLike, order: str = "C", *, out_sharding=None) -> Array:
     order: ``'F'`` or ``'C'``, specifies whether the reshape should apply column-major
       (fortran-style, ``"F"``) or row-major (C-style, ``"C"``) order; default is ``"C"``.
       JAX does not support `order="A"` or `order="K"`.
+    out_sharding: optional sharding specification for the output. If not specified,
+      it will be determined automatically by the compiler.
 
   Returns:
     flattened copy of input array.
@@ -3096,6 +3100,8 @@ def broadcast_to(array: ArrayLike, shape: DimSize | Shape,
   Args:
     array: array to be broadcast.
     shape: shape to which the array will be broadcast.
+    out_sharding: optional sharding specification for the output. If not specified,
+      it will be determined automatically by the compiler.
 
   Returns:
     a copy of array broadcast to the specified shape.
@@ -4819,8 +4825,6 @@ def column_stack(tup: np.ndarray | Array | Sequence[ArrayLike]) -> Array:
       Input arrays will be promoted to at least rank 2. If a single array is given
       it will be treated equivalently to `tup = unstack(tup)`, but the implementation
       will avoid explicit unstacking.
-    dtype: optional dtype of the resulting array. If not specified, the dtype
-      will be determined via type promotion rules described in :ref:`type-promotion`.
 
   Returns:
     the stacked result.
@@ -6280,6 +6284,8 @@ def repeat(a: ArrayLike, repeats: ArrayLike, axis: int | None = None, *,
       If ``sum(repeats)`` is larger than the specified ``total_repeat_length``,
       the remaining values will be discarded. If ``sum(repeats)`` is smaller
       than ``total_repeat_length``, the final value will be repeated.
+    out_sharding: optional sharding specification for the output. If not specified,
+      it will be determined automatically by the compiler.
 
   Returns:
     an array constructed from repeated values of ``a``.

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -1892,6 +1892,8 @@ def tensordot(x1: ArrayLike, x2: ArrayLike, /, *,
     preferred_element_type: either ``None`` (default), which means the default
       accumulation type for the input types, or a datatype, indicating to
       accumulate results to and return a result with that datatype.
+    out_sharding: optional sharding specification for the output. If not specified,
+      it will be determined automatically by the compiler.
 
   Returns:
     array containing the tensor dot product of the inputs

--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -2740,6 +2740,8 @@ def percentile(a: ArrayLike, q: ArrayLike,
       Values with higher weights contribute more to the percentile calculation.
       The weights array must be broadcastable to the shape of `a` along the specified axis.
       Currently, weighted percentiles are only supported when `method="inverted_cdf"`.
+    out_sharding: optional sharding specification for the output. If not specified,
+      it will be determined automatically by the compiler.
 
   Returns:
     An array containing the specified percentiles along the specified axes.

--- a/jax/_src/numpy/tensor_contractions.py
+++ b/jax/_src/numpy/tensor_contractions.py
@@ -61,6 +61,8 @@ def dot(a: ArrayLike, b: ArrayLike, *,
     preferred_element_type: either ``None`` (default), which means the default
       accumulation type for the input types, or a datatype, indicating to
       accumulate results to and return a result with that datatype.
+    out_sharding: optional sharding specification for the output. If not specified,
+      it will be determined automatically by the compiler.
 
   Returns:
     An array containing the dot product of the inputs.  Unlike :func:`matmul`,
@@ -154,6 +156,8 @@ def matmul(a: ArrayLike, b: ArrayLike, *,
     preferred_element_type: either ``None`` (default), which means the default
       accumulation type for the input types, or a datatype, indicating to
       accumulate results to and return a result with that datatype.
+    out_sharding: optional sharding specification for the output. If not specified,
+      it will be determined automatically by the compiler.
 
   Returns:
     array containing the matrix product of the inputs. Shape is ``a.shape[:-1]``
@@ -417,20 +421,20 @@ def vecdot(x1: ArrayLike, x2: ArrayLike, /, *, axis: int = -1,
   JAX implementation of :func:`numpy.vecdot`.
 
   Args:
-    a: left-hand side array.
-    b: right-hand side array. Size of ``b[axis]`` must match size of ``a[axis]``,
-      and remaining dimensions must be broadcast-compatible.
+    x1: left-hand side array.
+    x2: right-hand side array. Size of ``x2[axis]`` must match size of
+      ``x1[axis]``, and remaining dimensions must be broadcast-compatible.
     axis: axis along which to compute the dot product (default: -1)
     precision: either ``None`` (default), which means the default precision for
       the backend, a :class:`~jax.lax.Precision` enum value (``Precision.DEFAULT``,
       ``Precision.HIGH`` or ``Precision.HIGHEST``) or a tuple of two
-      such values indicating precision of ``a`` and ``b``.
+      such values indicating precision of ``x1`` and ``x2``.
     preferred_element_type: either ``None`` (default), which means the default
       accumulation type for the input types, or a datatype, indicating to
       accumulate results to and return a result with that datatype.
 
   Returns:
-    array containing the conjugate dot product of ``a`` and ``b`` along ``axis``.
+    array containing the conjugate dot product of ``x1`` and ``x2`` along ``axis``.
     The non-contracted dimensions are broadcast together.
 
   See Also:
@@ -444,7 +448,7 @@ def vecdot(x1: ArrayLike, x2: ArrayLike, /, *, axis: int = -1,
 
     >>> a = jnp.array([1j, 2j, 3j])
     >>> b = jnp.array([4., 5., 6.])
-    >>> jnp.linalg.vecdot(a, b)
+    >>> jnp.vecdot(a, b)
     Array(0.-32.j, dtype=complex64)
 
     Batched vector dot product of two 2D arrays:
@@ -452,7 +456,7 @@ def vecdot(x1: ArrayLike, x2: ArrayLike, /, *, axis: int = -1,
     >>> a = jnp.array([[1, 2, 3],
     ...                [4, 5, 6]])
     >>> b = jnp.array([[2, 3, 4]])
-    >>> jnp.linalg.vecdot(a, b, axis=-1)
+    >>> jnp.vecdot(a, b, axis=-1)
     Array([20, 47], dtype=int32)
   """
   from jax._src.numpy.lax_numpy import moveaxis
@@ -490,6 +494,8 @@ def tensordot(a: ArrayLike, b: ArrayLike,
     preferred_element_type: either ``None`` (default), which means the default
       accumulation type for the input types, or a datatype, indicating to
       accumulate results to and return a result with that datatype.
+    out_sharding: optional sharding specification for the output. If not specified,
+      it will be determined automatically by the compiler.
 
   Returns:
     array containing the tensor dot product of the inputs

--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -3563,6 +3563,7 @@ def isposinf(x, /, out=None):
 
   Args:
     x: input array or scalar. ``complex`` dtype are not supported.
+    out: unsupported by JAX.
 
   Returns:
     A boolean array of same shape as ``x`` containing ``True`` where ``x`` is
@@ -3598,6 +3599,7 @@ def isneginf(x, /, out=None):
 
   Args:
     x: input array or scalar. ``complex`` dtype are not supported.
+    out: unsupported by JAX.
 
   Returns:
     A boolean array of same shape as ``x`` containing ``True`` where ``x`` is

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -199,7 +199,7 @@ def cho_solve(c_and_lower: tuple[ArrayLike, bool], b: ArrayLike,
     b: right-hand-side of linear system. Array of shape ``(N,)`` (for a
       1-dimensional right-hand-side) or ``(..., N, M)`` (for a batched
       2-dimensional right-hand-side).
-    overwrite_a: unused by JAX
+    overwrite_b: unused by JAX
     check_finite: unused by JAX
 
   Returns:
@@ -2082,7 +2082,6 @@ def polar(a: ArrayLike, side: str = 'right', *, method: str = 'qdwh', eps: float
       If ``side`` is ``"right"`` then :math:`a = up`. If ``side`` is ``"left"``
       then :math:`a = pu`. The default is ``"right"``.
     method: Determines the algorithm used, as described above.
-    precision: :class:`~jax.lax.Precision` object specifying the matmul precision.
     eps: The final result will satisfy
       :math:`\left|x_k - x_{k-1}\right| < \left|x_k\right| (4\epsilon)^{\frac{1}{3}}`,
       where :math:`x_k` are the QDWH iterates. Ignored if ``method`` is not

--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -279,12 +279,6 @@ def convolve2d(in1: Array, in2: Array, mode: ModeString = 'full', boundary: str 
 
     boundary: only ``"fill"`` is supported.
     fillvalue: only ``0`` is supported.
-    method: controls the computation method. Options are
-
-      * ``"auto"``: (default) always uses the ``"direct"`` method.
-      * ``"direct"``: lower to :func:`jax.lax.conv_general_dilated`.
-      * ``"fft"``: compute the result via a fast Fourier transform.
-
     precision: Specify the precision of the computation. Refer to
       :class:`jax.lax.Precision` for a description of available values.
 
@@ -413,12 +407,6 @@ def correlate2d(in1: Array, in2: Array, mode: ModeString = 'full', boundary: str
 
     boundary: only ``"fill"`` is supported.
     fillvalue: only ``0`` is supported.
-    method: controls the computation method. Options are
-
-      * ``"auto"``: (default) always uses the ``"direct"`` method.
-      * ``"direct"``: lower to :func:`jax.lax.conv_general_dilated`.
-      * ``"fft"``: compute the result via a fast Fourier transform.
-
     precision: Specify the precision of the computation. Refer to
       :class:`jax.lax.Precision` for a description of available values.
 

--- a/jax/_src/scipy/stats/logistic.py
+++ b/jax/_src/scipy/stats/logistic.py
@@ -34,7 +34,6 @@ def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
 
   Args:
     x: arraylike, value at which to evaluate the PDF
-    a: arraylike, distribution shape parameter
     loc: arraylike, distribution offset parameter
     scale: arraylike, distribution scale parameter
 


### PR DESCRIPTION
### Description
- Updates missing or stale argument documentation in jax.numpy and jax.scipy
- No functionality changes
