### PR TITLE
Add Open MPI 5 PRRTE cluster detection

### DIFF
--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -1668,6 +1668,7 @@ pytype_strict_library(
         "clusters/k8s_cluster.py",
         "clusters/mpi4py_cluster.py",
         "clusters/ompi_cluster.py",
+        "clusters/prrte_cluster.py",
         "clusters/slurm_cluster.py",
         "distributed.py",
         "xla_bridge.py",

--- a/jax/_src/clusters/__init__.py
+++ b/jax/_src/clusters/__init__.py
@@ -21,6 +21,7 @@ from .cluster import ClusterEnv as ClusterEnv
 # to :func:`jax.distributed.initialize`, the first
 # available one from the list will be picked.
 from .ompi_cluster import OmpiCluster as OmpiCluster
+from .prrte_cluster import PrrteCluster as PrrteCluster
 from .slurm_cluster import SlurmCluster as SlurmCluster
 from .mpi4py_cluster import Mpi4pyCluster as Mpi4pyCluster
 from .cloud_tpu_cluster import GkeTpuCluster as GkeTpuCluster

--- a/jax/_src/clusters/prrte_cluster.py
+++ b/jax/_src/clusters/prrte_cluster.py
@@ -1,0 +1,95 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import re
+
+from jax._src import clusters
+
+
+_PRTE_LAUNCHED = "PRTE_LAUNCHED"
+_PMIX_NAMESPACE = "PMIX_NAMESPACE"
+_PMIX_SERVER_URIS = (
+    "PMIX_SERVER_URI41",
+    "PMIX_SERVER_URI4",
+    "PMIX_SERVER_URI3",
+    "PMIX_SERVER_URI21",
+    "PMIX_SERVER_URI2",
+)
+_PROCESS_COUNT = "OMPI_COMM_WORLD_SIZE"
+_PROCESS_ID = "OMPI_COMM_WORLD_RANK"
+_LOCAL_PROCESS_ID = "OMPI_COMM_WORLD_LOCAL_RANK"
+
+
+class PrrteCluster(clusters.ClusterEnv):
+
+  name: str = "prrte"
+
+  @classmethod
+  def is_env_present(cls) -> bool:
+    return os.environ.get(_PRTE_LAUNCHED) == "1"
+
+  @classmethod
+  def get_coordinator_address(
+      cls,
+      timeout_secs: int | None,
+      override_coordinator_port: str | None,
+  ) -> str:
+    del timeout_secs
+    pmix_uri = next(
+        (os.environ[var] for var in _PMIX_SERVER_URIS if var in os.environ),
+        None,
+    )
+    if pmix_uri is None:
+      raise RuntimeError(
+          "Could not find a PMIX_SERVER_URI in the PRRTE environment."
+      )
+
+    ipv4_match = re.search(r"tcp4://([^,:;]+):", pmix_uri)
+    ipv6_match = re.search(r"tcp6://\[([^,\]]+)\]", pmix_uri)
+    if ipv4_match is not None:
+      coordinator_host = ipv4_match.group(1)
+    elif ipv6_match is not None:
+      coordinator_host = f"[{ipv6_match.group(1)}]"
+    else:
+      raise RuntimeError(
+          "Could not parse coordinator IP address from PRRTE environment."
+      )
+
+    if override_coordinator_port:
+      port = override_coordinator_port
+    else:
+      namespace = os.environ.get(_PMIX_NAMESPACE, "")
+      job_id_match = re.search(r"-(\d+)@", namespace)
+      if job_id_match is None:
+        raise RuntimeError(
+            "Could not parse job ID from PMIX_NAMESPACE in PRRTE environment."
+        )
+      job_id = int(job_id_match.group(1))
+      port = str(job_id % 2**12 + (65535 - 2**12 + 1))
+    return f"{coordinator_host}:{port}"
+
+  @classmethod
+  def get_process_count(cls) -> int:
+    return int(os.environ[_PROCESS_COUNT])
+
+  @classmethod
+  def get_process_id(cls) -> int:
+    return int(os.environ[_PROCESS_ID])
+
+  @classmethod
+  def get_local_process_id(cls) -> int | None:
+    return int(os.environ[_LOCAL_PROCESS_ID])

--- a/tests/distributed_initialize_test.py
+++ b/tests/distributed_initialize_test.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
+from unittest import mock
 
 from absl.testing import absltest
 import jax
+from jax._src import clusters
 from jax._src import test_util as jtu
 
 try:
@@ -24,6 +27,72 @@ except ImportError:
   portpicker = None
 
 jax.config.parse_flags_with_absl()
+
+_PRRTE_ENV = {
+    "PRTE_LAUNCHED": "1",
+    "PMIX_NAMESPACE": "prterun-node18-12345@1",
+    "PMIX_SERVER_URI41": (
+        "prterun-node18-12345@0.0;tcp4://10.20.30.40:45678"
+    ),
+    "OMPI_COMM_WORLD_SIZE": "8",
+    "OMPI_COMM_WORLD_RANK": "3",
+    "OMPI_COMM_WORLD_LOCAL_RANK": "1",
+}
+
+
+@mock.patch.dict(os.environ, _PRRTE_ENV, clear=True)
+class PrrteClusterTest(jtu.JaxTestCase):
+
+  def test_cluster_properties(self):
+    self.assertTrue(clusters.PrrteCluster.is_env_present())
+    self.assertEqual(
+        clusters.PrrteCluster.get_coordinator_address(None, None),
+        "10.20.30.40:61497",
+    )
+    self.assertEqual(clusters.PrrteCluster.get_process_count(), 8)
+    self.assertEqual(clusters.PrrteCluster.get_process_id(), 3)
+    self.assertEqual(clusters.PrrteCluster.get_local_process_id(), 1)
+
+  def test_auto_detect(self):
+    actual = clusters.ClusterEnv.auto_detect_unset_distributed_params(
+        None, None, None, None, None, 300
+    )
+    self.assertEqual(actual, ("10.20.30.40:61497", 8, 3, [1]))
+
+  def test_coordinator_port_override(self):
+    self.assertEqual(
+        clusters.PrrteCluster.get_coordinator_address(None, "1234"),
+        "10.20.30.40:1234",
+    )
+
+  def test_ipv6_coordinator(self):
+    with mock.patch.dict(
+        os.environ,
+        {
+            "PMIX_SERVER_URI41": (
+                "prterun-node18-12345@0.0;tcp6://[2001:db8::1]:45678"
+            )
+        },
+    ):
+      self.assertEqual(
+          clusters.PrrteCluster.get_coordinator_address(None, None),
+          "[2001:db8::1]:61497",
+      )
+
+  def test_requires_prrte_launcher(self):
+    with mock.patch.dict(os.environ, {"PRTE_LAUNCHED": "0"}):
+      self.assertFalse(clusters.PrrteCluster.is_env_present())
+
+  def test_missing_server_uri(self):
+    env = {k: v for k, v in _PRRTE_ENV.items() if k != "PMIX_SERVER_URI41"}
+    with mock.patch.dict(os.environ, env, clear=True):
+      with self.assertRaisesRegex(RuntimeError, "PMIX_SERVER_URI"):
+        clusters.PrrteCluster.get_coordinator_address(None, None)
+
+  def test_invalid_namespace(self):
+    with mock.patch.dict(os.environ, {"PMIX_NAMESPACE": "invalid"}):
+      with self.assertRaisesRegex(RuntimeError, "PMIX_NAMESPACE"):
+        clusters.PrrteCluster.get_coordinator_address(None, None)
 
 
 @unittest.skipIf(not portpicker, "Test requires portpicker")


### PR DESCRIPTION
## Summary

- add a `ClusterEnv` implementation for Open MPI 5's PRRTE runtime
- detect PRRTE through `PRTE_LAUNCHED` and parse coordinator information from the PMIx environment
- preserve the existing Open MPI/ORTE path and add IPv4, IPv6, port override, error-path, and auto-detection coverage

Fixes #14576.

## Testing

- `JAX_PLATFORMS=cpu JAX_ENABLE_X64=true python -m pytest -q tests/distributed_initialize_test.py` (`7 passed, 1 skipped`)
- single-process synthetic PRRTE auto-detection plus `jax.distributed.initialize()` / `shutdown()`
- Open MPI 4.1.2 ORTE compatibility smoke test
- Ruff, Pyrefly, copyright check, `py_compile`, `git diff --check`, and the applicable lightweight pre-commit hooks

The available test host has Open MPI 4.1.2 rather than Open MPI 5, so the PRRTE environment fixture is based on the environment reported in #14576; a real multi-process Open MPI 5 integration test was not available locally.
