### PR TITLE
[OneAPI GPU] Extend JAX’s GPU platform compatibility shim to OneAPI devices.

### DIFF
--- a/jaxlib/py_device.cc
+++ b/jaxlib/py_device.cc
@@ -71,7 +71,8 @@ std::string_view PyDevice::platform() const {
   // expect "gpu". Migrate users and remove this
   // code.
   absl::string_view platform_name = device_->PlatformName();
-  if (platform_name == "cuda" || platform_name == "rocm") {
+  if (platform_name == "cuda" || platform_name == "rocm" ||
+      platform_name == "oneapi") {
     return std::string_view("gpu");
   } else {
     return platform_name;

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -36,8 +36,8 @@ class DeviceTest(jtu.JaxTestCase):
           repr(device),
           'TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0)',
       )
-    elif jtu.test_device_matches(['oneapi']):
-      self.assertEqual(device.platform, 'oneapi')
+    elif jtu.is_device_oneapi():
+      self.assertEqual(device.platform, 'gpu')
       self.assertEqual(repr(device), 'OneapiDevice(id=0)')
     elif jtu.test_device_matches(['cpu']):
       self.assertEqual(device.platform, 'cpu')


### PR DESCRIPTION
This PR adds following changes:
1. Extend the compatibility shim in`jaxlib/py_device.cc` to map OneAPI's underlying platform name to `gpu`, consistent with existing platform mappings.
2. Updated `tests/device_test.py` to validate the new platform value.



<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->