### PR TITLE
docs(pallas): document SparseCore gather support for 16-bit dtypes an…

### DIFF
--- a/docs/pallas/tpu/sparsecore.ipynb
+++ b/docs/pallas/tpu/sparsecore.ipynb
@@ -14,8 +14,15 @@
     "\n",
     "This guide will give an overview on SparseCore architecture and show how to\n",
     "write Pallas kernels that runs on TPU SparseCores.\n",
-    "\n",
-    "```python\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from functools import partial\n",
     "import jax\n",
     "from jax.experimental import pallas as pl\n",
@@ -24,8 +31,13 @@
     "import jax.numpy as jnp\n",
     "import numpy as np\n",
     "\n",
-    "assert pltpu.get_tpu_info().sparse_core is not None, \"No SparseCore found\"\n",
-    "```\n",
+    "assert pltpu.get_tpu_info().sparse_core is not None, \"No SparseCore found\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "## Hardware overview\n",
     "\n",
@@ -69,14 +81,26 @@
     "\n",
     "You can also use `pltpu.get_tpu_info()` to quickly obtain specs for your current\n",
     "hardware.\n",
-    "\n",
-    "```python\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Quick way to query basic SC info\n",
     "\n",
     "assert (sc_info := pltpu.get_tpu_info().sparse_core)\n",
     "print(f\"SparseCore info for TPU {pltpu.get_tpu_info().chip_version}:\")\n",
-    "print(sc_info)\n",
-    "```\n",
+    "print(sc_info)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "```\n",
     "SparseCore info for TPU 7x:\n",
@@ -119,8 +143,15 @@
     "collectives on SparseCores. Check out our\n",
     "[collectives guide](https://docs.jax.dev/en/latest/pallas/tpu/distributed.html)\n",
     "if you want to learn more.\n",
-    "\n",
-    "```python\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "scalar_mesh = plsc.ScalarSubcoreMesh(axis_name=\"core\",\n",
     "                                     num_cores=sc_info.num_cores)\n",
     "print(scalar_mesh)\n",
@@ -128,8 +159,13 @@
     "vector_mesh = plsc.VectorSubcoreMesh(\n",
     "    core_axis_name=\"core\", subcore_axis_name=\"subcore\"\n",
     ")\n",
-    "print(vector_mesh)\n",
-    "```\n",
+    "print(vector_mesh)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "```\n",
     "ScalarSubcoreMesh(axis_name='core', num_cores=2)\n",
@@ -141,8 +177,15 @@
     "See below for a simple scalar subcore kernel that includes DMAs, per-core\n",
     "customizing and compute operations. Note that the scalar subcore can only do\n",
     "scalar operations.\n",
-    "\n",
-    "```python\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "@jax.jit\n",
     "def cumsum(x):\n",
     "  @pl.kernel(out_type=x, mesh=scalar_mesh,\n",
@@ -162,16 +205,28 @@
     "\n",
     "x_shape = (sc_info.num_cores, sc_info.num_lanes)\n",
     "x = jax.random.randint(jax.random.key(0), x_shape, 0, 64, jnp.int32)\n",
-    "np.testing.assert_array_equal(cumsum(x), jnp.cumsum(x, axis=1))\n",
-    "```\n",
+    "np.testing.assert_array_equal(cumsum(x), jnp.cumsum(x, axis=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "## Pipelining in SparseCore kernels\n",
     "\n",
     "You can `pltpu.emit_pipeline` to write pipelined SparseCore kernels. The\n",
     "`core_axis_name` and `dimension_semantics` arguments to `emit_pipeline` enable\n",
     "partitioning the pipeline across SparseCores/subcores.\n",
-    "\n",
-    "```python\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "SC_REG_OP_SHAPE = (1, sc_info.num_lanes)\n",
     "dma_block = (8, 128)\n",
     "\n",
@@ -203,8 +258,13 @@
     "\n",
     "x = jax.random.randint(jax.random.key(0), (4096, 128), 0, 64, jnp.int32)\n",
     "y = sc_add_one(x)\n",
-    "np.testing.assert_array_equal(y, x + 1)\n",
-    "```\n",
+    "np.testing.assert_array_equal(y, x + 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "Alternatively, you can use axis_index to compute the core index and use it to\n",
     "split up work across cores (example\n",
@@ -215,8 +275,15 @@
     "It is very simple to overlap kernels written in TensorCore vs SparseCore: just\n",
     "put them together inside a `jax.jit`. The XLA compiler will handle their\n",
     "scheduling.\n",
-    "\n",
-    "```python\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "@jax.jit\n",
     "def tc_add_one(x):\n",
     "  return x + 1\n",
@@ -225,17 +292,34 @@
     "@jax.jit\n",
     "def two_add_ones(x):\n",
     "  return sc_add_one(x), tc_add_one(x)\n",
-    "jax.tree.map(np.testing.assert_array_equal, two_add_ones(x), (x + 1, x + 1));\n",
-    "```\n",
+    "jax.tree.map(np.testing.assert_array_equal, two_add_ones(x), (x + 1, x + 1));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "A benchmark here shows the total time is less than the two functions combined.\n",
-    "\n",
-    "```python\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "%timeit sc_add_one(x).block_until_ready()\n",
     "%timeit tc_add_one(x).block_until_ready()\n",
     "\n",
-    "%timeit jax.block_until_ready(two_add_ones(x))\n",
-    "```\n",
+    "%timeit jax.block_until_ready(two_add_ones(x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "```\n",
     "120 µs ± 2.46 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)\n",
@@ -256,8 +340,15 @@
     "\n",
     "Below is a kernel that pipelines loading indices into a vector subcore's VMEM.\n",
     "In the body, we execute a gather using those indices.\n",
-    "\n",
-    "```python\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "batch_size = 4096\n",
     "value_dim = 128\n",
     "gather_window_size = 128\n",
@@ -293,13 +384,25 @@
     "\n",
     "out = gather(x, indices)\n",
     "np.testing.assert_array_equal(out, jnp.take(x, indices, axis=0))\n",
-    "\n",
-    "```\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "A scatter (indexed overwrite) is the opposite of a gather. See an example kernel\n",
     "below.\n",
-    "\n",
-    "```python\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "@jax.jit\n",
     "def scatter(x, indices):\n",
     "  indices = indices.reshape((1, num_indices))\n",
@@ -325,29 +428,115 @@
     "\n",
     "gathered = jnp.take(x, indices, axis=0)\n",
     "out = scatter(gathered, indices)\n",
-    "np.testing.assert_array_equal(out, x)\n",
-    "\n",
-    "```\n",
+    "np.testing.assert_array_equal(out, x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "## Benchmark against TensorCore\n",
     "\n",
     "Sparsecores are particularly good at gather and scatter operations. We can\n",
     "implement the same using vanilla JAX APIs, which by default run on TensorCore,\n",
     "and compare the results.\n",
-    "\n",
-    "```python\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "%timeit jax.block_until_ready(gather(x, indices))\n",
     "\n",
     "gather_tc = jax.jit(lambda x, i: jnp.take(x, i, axis=0))\n",
     "gather_tc(x, indices).block_until_ready()\n",
     "\n",
-    "%timeit jax.block_until_ready(gather_tc(x, indices))\n",
-    "```\n",
+    "%timeit jax.block_until_ready(gather_tc(x, indices))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "```\n",
     "4.05 ms ± 2.02 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n",
     "18.1 ms ± 5.24 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n",
-    "```"
+    "```\n",
+    "\n",
+    "## Gathering and scattering 16-bit dtypes\n",
+    "\n",
+    "SparseCore DMA hardware natively supports only 32-bit transfers (`int32`, `float32`, `uint32`). You cannot directly gather 16-bit types like `bfloat16` or `float16`.\n",
+    "\n",
+    "To gather 16-bit data, you can pack pairs of rows into 32-bit words in HBM, issue the gather with halved indices, and unpack the target row in VMEM:\n",
+    "\n",
+    "1. Pair adjacent rows along the last dimension and view them as `int32`. A table of shape `(batch_size, value_dim)` in `bfloat16` becomes `(batch_size // 2, value_dim)` in `int32`.\n",
+    "2. Gather using `index // 2` (via `pltpu.sync_copy`, or `pl.Indirect` on the data table). Each 32-bit row fetched contains both row `2*i` and row `2*i + 1`.\n",
+    "3. In VMEM, view the buffer back as `bfloat16` and select the requested row based on whether the original index was even or odd (`index % 2`).\n",
+    "\n",
+    "Below is an example gathering `bfloat16` values with packed rows:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_bf16 = x.astype(jnp.bfloat16)\n",
+    "\n",
+    "\n",
+    "@jax.jit\n",
+    "def gather_bf16_packed(x, indices):\n",
+    "  packing = 32 // 16  # 2\n",
+    "  # Pack adjacent 16-bit rows (2*i, 2*i+1) into 32-bit int32 words on HBM\n",
+    "  x_packed = x.reshape(batch_size // packing, packing * value_dim).view(\n",
+    "      jnp.int32\n",
+    "  )\n",
+    "\n",
+    "  @pl.kernel(\n",
+    "      out_type=jax.ShapeDtypeStruct((num_indices, value_dim), x.dtype),\n",
+    "      mesh=vector_mesh,\n",
+    "      scratch_types=dict(\n",
+    "          gather_vmem=pltpu.VMEM((gather_window_size, value_dim), jnp.int32)\n",
+    "      ),\n",
+    "  )\n",
+    "  def kernel(x_packed_hbm, i_hbm, o_hbm, *, gather_vmem):\n",
+    "    def body(idx_vmem, o_vmem):\n",
+    "      # Issue indirect 32-bit DMA gather using halved index\n",
+    "      pltpu.sync_copy(\n",
+    "          x_packed_hbm.at[jax.lax.div(idx_vmem, packing)], gather_vmem\n",
+    "      )\n",
+    "      # Vectorized pair selection across the gathered window\n",
+    "      pairs = gather_vmem.view(jnp.bfloat16).reshape(-1, packing, value_dim)\n",
+    "      is_odd = (idx_vmem % 2)[:, None]\n",
+    "      o_vmem[...] = jnp.where(is_odd == 1, pairs[:, 1], pairs[:, 0])\n",
+    "\n",
+    "    pltpu.emit_pipeline(\n",
+    "        body,\n",
+    "        grid=(num_indices // gather_window_size,),\n",
+    "        in_specs=[\n",
+    "            pl.BlockSpec((gather_window_size,), index_map=lambda i: (i,))\n",
+    "        ],\n",
+    "        out_specs=[\n",
+    "            pl.BlockSpec(\n",
+    "                (gather_window_size, value_dim), index_map=lambda i: (i, 0)\n",
+    "            )\n",
+    "        ],\n",
+    "        core_axis_name='subcore',\n",
+    "        dimension_semantics=(pltpu.PARALLEL,),\n",
+    "    )(i_hbm, o_hbm)\n",
+    "\n",
+    "  return kernel(x_packed, indices)\n",
+    "\n",
+    "\n",
+    "out = gather_bf16_packed(x_bf16, indices)\n",
+    "np.testing.assert_array_equal(out, jnp.take(x_bf16, indices, axis=0))"
    ]
   }
  ],

--- a/docs/pallas/tpu/sparsecore.md
+++ b/docs/pallas/tpu/sparsecore.md
@@ -334,7 +334,6 @@ def scatter(x, indices):
 gathered = jnp.take(x, indices, axis=0)
 out = scatter(gathered, indices)
 np.testing.assert_array_equal(out, x)
-
 ```
 
 ## Benchmark against TensorCore
@@ -355,4 +354,68 @@ gather_tc(x, indices).block_until_ready()
 ```
 4.05 ms ± 2.02 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
 18.1 ms ± 5.24 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+```
+
+## Gathering and scattering 16-bit dtypes
+
+SparseCore DMA hardware natively supports only 32-bit transfers (`int32`, `float32`, `uint32`). You cannot directly gather 16-bit types like `bfloat16` or `float16`.
+
+To gather 16-bit data, you can pack pairs of rows into 32-bit words in HBM, issue the gather with halved indices, and unpack the target row in VMEM:
+
+1. Pair adjacent rows along the last dimension and view them as `int32`. A table of shape `(batch_size, value_dim)` in `bfloat16` becomes `(batch_size // 2, value_dim)` in `int32`.
+2. Gather using `index // 2` (via `pltpu.sync_copy`, or `pl.Indirect` on the data table). Each 32-bit row fetched contains both row `2*i` and row `2*i + 1`.
+3. In VMEM, view the buffer back as `bfloat16` and select the requested row based on whether the original index was even or odd (`index % 2`).
+
+Below is an example gathering `bfloat16` values with packed rows:
+
+```python
+x_bf16 = x.astype(jnp.bfloat16)
+
+
+@jax.jit
+def gather_bf16_packed(x, indices):
+  packing = 32 // 16  # 2
+  # Pack adjacent 16-bit rows (2*i, 2*i+1) into 32-bit int32 words on HBM
+  x_packed = x.reshape(batch_size // packing, packing * value_dim).view(
+      jnp.int32
+  )
+
+  @pl.kernel(
+      out_type=jax.ShapeDtypeStruct((num_indices, value_dim), x.dtype),
+      mesh=vector_mesh,
+      scratch_types=dict(
+          gather_vmem=pltpu.VMEM((gather_window_size, value_dim), jnp.int32)
+      ),
+  )
+  def kernel(x_packed_hbm, i_hbm, o_hbm, *, gather_vmem):
+    def body(idx_vmem, o_vmem):
+      # Issue indirect 32-bit DMA gather using halved index
+      pltpu.sync_copy(
+          x_packed_hbm.at[jax.lax.div(idx_vmem, packing)], gather_vmem
+      )
+      # Vectorized pair selection across the gathered window
+      pairs = gather_vmem.view(jnp.bfloat16).reshape(-1, packing, value_dim)
+      is_odd = (idx_vmem % 2)[:, None]
+      o_vmem[...] = jnp.where(is_odd == 1, pairs[:, 1], pairs[:, 0])
+
+    pltpu.emit_pipeline(
+        body,
+        grid=(num_indices // gather_window_size,),
+        in_specs=[
+            pl.BlockSpec((gather_window_size,), index_map=lambda i: (i,))
+        ],
+        out_specs=[
+            pl.BlockSpec(
+                (gather_window_size, value_dim), index_map=lambda i: (i, 0)
+            )
+        ],
+        core_axis_name='subcore',
+        dimension_semantics=(pltpu.PARALLEL,),
+    )(i_hbm, o_hbm)
+
+  return kernel(x_packed, indices)
+
+
+out = gather_bf16_packed(x_bf16, indices)
+np.testing.assert_array_equal(out, jnp.take(x_bf16, indices, axis=0))
 ```


### PR DESCRIPTION
Document SparseCore indirect DMA transfer constraints and workarounds for 16-bit data types (bfloat16, float16) in Pallas TPU kernels:
- Document hardware limitation where indirect DMA transfers (pltpu.sync_copy on indirect Refs) natively only support 32-bit element types (float32, int32, uint32).
- Detail 16-bit workaround pattern using .view(dtype=jnp.float32) and .view(dtype=jnp.bfloat16) to pack pairs of 16-bit values into 32-bit transfers.
- Highlight performance best practice recommending static pre-packing of embedding tables at initialization/weight loading to avoid runtime memory relayout overhead caused by dynamic .view(f32) in hot execution paths.

Fixes/References: b/543060365, issue #39577

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->