### PR TITLE
[ROCm] Automatically collect rocm libraries needed to run the rocm wheels under test

### DIFF
--- a/ci/run_bazel_test_rocm_rbe.sh
+++ b/ci/run_bazel_test_rocm_rbe.sh
@@ -62,13 +62,13 @@ done
 TEST_ARTIFACTS_DIR="test-artifacts"
 mkdir -p "$TEST_ARTIFACTS_DIR"
 
-# Point ROCM_PATH and LD_LIBRARY_PATH at the local TheRock installation.
+# Point ROCM_PATH at the local TheRock installation. Tests find ROCm through
+# their runfiles, so they need no LD_LIBRARY_PATH.
 ROCM_SDK_FLAGS=()
 if command -v rocm-sdk >/dev/null 2>&1; then
     ROCM_SDK_ROOT="$(rocm-sdk path --root)"
     ROCM_SDK_FLAGS=(
         "--repo_env=ROCM_PATH=${ROCM_SDK_ROOT}"
-        "--test_env=LD_LIBRARY_PATH=${ROCM_SDK_ROOT}/lib"
     )
 fi
 echo "::endgroup::" >&2

--- a/jaxlib/tools/BUILD.bazel
+++ b/jaxlib/tools/BUILD.bazel
@@ -32,10 +32,6 @@ load(
     "verify_manylinux_compliance_test",
 )
 load(
-    "@xla//third_party/py:python_wheel.bzl",
-    "collect_data_files",
-)
-load(
     "//jaxlib:jax.bzl",
     "PLATFORM_TAGS_DICT",
     "compare_srcs_and_test_deps_test",
@@ -48,6 +44,7 @@ load(
     "wheel_sources",
 )
 load("//jaxlib/rocm:rocm_version.bzl", "ROCM_MAJOR_VERSION")
+load("//jaxlib/tools:rocm_wheel_deps.bzl", "collect_rocm_data_files")
 
 licenses(["notice"])  # Apache 2
 
@@ -539,36 +536,26 @@ py_import(
     wheel_deps = if_pypi_cuda_wheel_deps([":nvidia_wheel_deps"]),
 )
 
-collect_data_files(
-    name = "rocm_libs_data",
-    deps = [
-        "@local_config_rocm//rocm:hip_runtime",
-        "@local_config_rocm//rocm:hipblas",
-        "@local_config_rocm//rocm:hipfft",
-        "@local_config_rocm//rocm:hiprand",
-        "@local_config_rocm//rocm:hipsolver",
-        "@local_config_rocm//rocm:miopen",
-        "@local_config_rocm//rocm:rccl",
-        "@local_config_rocm//rocm:rocm_smi",
-        "@local_config_rocm//rocm:rocprofiler_sdk",
-        "@local_config_rocm//rocm:rocsolver",
-    ],
+collect_rocm_data_files(
+    name = "rocm_plugin_libs",
+    roots = ["//jaxlib/rocm:rocm_gpu_support"],
+)
+
+collect_rocm_data_files(
+    name = "rocm_pjrt_libs",
+    roots = ["//jax_plugins/rocm:pjrt_c_api_gpu_plugin.so"],
 )
 
 py_import(
     name = "jax_rocm_plugin_py_import",
     wheel = ":jax_rocm_plugin_wheel",
-    wheel_deps = [
-        ":rocm_libs_data",
-    ],
+    deps = [":rocm_plugin_libs"],
 )
 
 py_import(
     name = "jax_rocm_pjrt_py_import",
     wheel = ":jax_rocm_pjrt_wheel",
-    wheel_deps = [
-        ":rocm_libs_data",
-    ],
+    deps = [":rocm_pjrt_libs"],
 )
 
 # The targets below are used for GPU tests with `--//jax:build_jaxlib=false`.

--- a/jaxlib/tools/rocm_wheel_deps.bzl
+++ b/jaxlib/tools/rocm_wheel_deps.bzl
@@ -1,0 +1,48 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build rules for aggregating rocm runtime dependecies into a single target."""
+
+def _collect_rocm_data_files_impl(ctx):
+    rocm_repo = ctx.attr.rocm_repo.label.repo_name
+
+    runfiles = depset(transitive = [
+        root[DefaultInfo].default_runfiles.files
+        for root in ctx.attr.roots
+    ])
+    files = {}
+    for f in runfiles.to_list():
+        if f.owner and f.owner.repo_name == rocm_repo:
+            files[f] = True
+    files_depset = depset(files.keys())
+    return [DefaultInfo(
+        files = files_depset,
+        runfiles = ctx.runfiles(transitive_files = files_depset),
+    )]
+
+_collect_rocm_data_files = rule(
+    implementation = _collect_rocm_data_files_impl,
+    attrs = {
+        "roots": attr.label_list(
+            mandatory = True,
+        ),
+        "rocm_repo": attr.label(
+            default = Label("@local_config_rocm//rocm:hip_runtime"),
+        ),
+    },
+)
+
+def collect_rocm_data_files(name, roots):
+    _collect_rocm_data_files(name = name + "_gather", roots = roots)
+    native.cc_library(name = name, data = [":" + name + "_gather"])


### PR DESCRIPTION
This avoids having to manually maintain the list of ROCm libraries.