### PR TITLE
Fix docs CustomClass example that breaks with array-valued attributes

### DIFF
--- a/docs/201/jit.md
+++ b/docs/201/jit.md
@@ -370,7 +370,7 @@ naively, it misbehaves:
 
 ```{code-cell}
 class CustomClass:
-  def __init__(self, x: jax.Array, mul: bool):
+  def __init__(self, x: float, mul: bool):
     self.x = x
     self.mul = mul
 
@@ -400,7 +400,7 @@ of the object's contents, so that differing objects actually miss the cache:
 
 ```{code-cell}
 class CustomClass:
-  def __init__(self, x: jax.Array, mul: bool):
+  def __init__(self, x: float, mul: bool):
     self.x = x
     self.mul = mul
 
@@ -417,6 +417,14 @@ class CustomClass:
     return (isinstance(other, CustomClass) and
             (self.x, self.mul) == (other.x, other.mul))
 ```
+
+For this to work at all, every attribute used in `__hash__` and `__eq__`
+must be hashable and must compare with a plain boolean result. `jax.Array`
+and NumPy arrays are neither, which is why `x` is a `float` in this
+example. Array-valued attributes shouldn't be static in the first place: a
+static value is baked into the compiled program as a constant, so every new
+array would mean a recompile even if hashing worked. Classes that hold
+arrays belong in Strategy 1 or Strategy 3.
 
 This works with `jit` and other transformations **so long as you never
 mutate the object**: mutating a value that's in use as a hash key leads to

--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -715,7 +715,7 @@
    "outputs": [],
    "source": [
     "class CustomClass:\n",
-    "  def __init__(self, x: jnp.ndarray, mul: bool):\n",
+    "  def __init__(self, x: float, mul: bool):\n",
     "    self.x = x\n",
     "    self.mul = mul\n",
     "\n",
@@ -793,7 +793,7 @@
    "outputs": [],
    "source": [
     "class CustomClass:\n",
-    "  def __init__(self, x: jnp.ndarray, mul: bool):\n",
+    "  def __init__(self, x: float, mul: bool):\n",
     "    self.x = x\n",
     "    self.mul = mul\n",
     "\n",
@@ -817,6 +817,8 @@
    "source": [
     "(see the [`object.__hash__`](https://docs.python.org/3/reference/datamodel.html#object.__hash__) documentation for more discussion of the requirements\n",
     "when overriding `__hash__`).\n",
+    "\n",
+    "Note that for this strategy to work, every attribute used in `__hash__` and `__eq__` must be hashable and must compare with a plain boolean result. JAX and NumPy arrays satisfy neither requirement, which is why `x` is annotated as a `float` here: with an array-valued `x`, `hash((self.x, self.mul))` would raise `TypeError: unhashable type`, and the tuple comparison in `__eq__` would fail as well. Array-valued attributes should not be marked static anyway, because static values are baked into the compiled program as constants, so each new array value would trigger a re-compilation even if hashing worked. If your class stores arrays, use Strategy 1 or Strategy 3 instead.\n",
     "\n",
     "This should work correctly with JIT and other transforms **so long as you never mutate your object**. Mutations of objects used as hash keys lead to several subtle problems, which is why for example mutable Python containers (e.g. [`dict`](https://docs.python.org/3/library/stdtypes.html#dict), [`list`](https://docs.python.org/3/library/stdtypes.html#list)) don't define `__hash__`, while their immutable counterparts (e.g. [`tuple`](https://docs.python.org/3/library/stdtypes.html#tuple)) do.\n",
     "\n",

--- a/docs/notebooks/Common_Gotchas_in_JAX.md
+++ b/docs/notebooks/Common_Gotchas_in_JAX.md
@@ -358,7 +358,7 @@ Another common pattern is to use `static_argnums` to mark the `self` argument as
 
 ```{code-cell} ipython3
 class CustomClass:
-  def __init__(self, x: jnp.ndarray, mul: bool):
+  def __init__(self, x: float, mul: bool):
     self.x = x
     self.mul = mul
 
@@ -390,7 +390,7 @@ You can partially address this by defining an appropriate `__hash__` and `__eq__
 
 ```{code-cell} ipython3
 class CustomClass:
-  def __init__(self, x: jnp.ndarray, mul: bool):
+  def __init__(self, x: float, mul: bool):
     self.x = x
     self.mul = mul
 
@@ -410,6 +410,8 @@ class CustomClass:
 
 (see the [`object.__hash__`](https://docs.python.org/3/reference/datamodel.html#object.__hash__) documentation for more discussion of the requirements
 when overriding `__hash__`).
+
+Note that for this strategy to work, every attribute used in `__hash__` and `__eq__` must be hashable and must compare with a plain boolean result. JAX and NumPy arrays satisfy neither requirement, which is why `x` is annotated as a `float` here: with an array-valued `x`, `hash((self.x, self.mul))` would raise `TypeError: unhashable type`, and the tuple comparison in `__eq__` would fail as well. Array-valued attributes should not be marked static anyway, because static values are baked into the compiled program as constants, so each new array value would trigger a re-compilation even if hashing worked. If your class stores arrays, use Strategy 1 or Strategy 3 instead.
 
 This should work correctly with JIT and other transforms **so long as you never mutate your object**. Mutations of objects used as hash keys lead to several subtle problems, which is why for example mutable Python containers (e.g. [`dict`](https://docs.python.org/3/library/stdtypes.html#dict), [`list`](https://docs.python.org/3/library/stdtypes.html#list)) don't define `__hash__`, while their immutable counterparts (e.g. [`tuple`](https://docs.python.org/3/library/stdtypes.html#tuple)) do.
 


### PR DESCRIPTION
Fixes #39858.

The "how to use jit with methods" section (Common Gotchas notebook, and the same example in new_docs/201/jit.md) annotates the CustomClass attribute as x: jnp.ndarray, but Strategy 2 then defines __hash__ and __eq__ over that attribute. If you actually store an array there, like the annotation suggests, it breaks: JAX arrays are not hashable, so hash(c) raises TypeError and the jitted method call fails too. The __eq__ tuple comparison also fails for multi element arrays. The executed cells never notice because they pass x=2, a plain int.

This changes the annotation to x: float in the two Strategy 2 cells only (Strategies 1 and 3 keep the array annotation since they really do support arrays), and adds a short paragraph after the __hash__/__eq__ example saying that static attributes need to be hashable and compare to a plain bool, that an array attribute shouldn't be static anyway (it would be baked in as a constant and recompile for every new value), and pointing classes that hold arrays to Strategy 1 or 3.

The .ipynb is the jupytext regenerated pair of the .md, no cell outputs changed, and both pages still execute cleanly (they are force-executed in the docs build). Out of scope: the friendliness of the "Non-hashable static arguments" runtime error itself, which is tracked separately in #7826.