### PR TITLE
Fix jax.scipy.signal.istft handling of noverlap=0, inferred nfft, and nperseg=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,13 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     `custom_partitioning`, `custom_gradient`, `closure_convert`,
     `linear_call`, or `run_state`) is retraced with different-shaped
     arguments ({jax-issue}`#40110`).
+  * Fixed three defects in {func}`jax.scipy.signal.istft`. `noverlap=0` is
+    no longer treated as an omitted argument, which silently applied the
+    default 50 percent overlap and produced a wrong reconstruction. The
+    inverse FFT now uses the resolved FFT length, fixing a shape error when
+    `nfft` is unspecified with one-sided input and an odd `nperseg`. And
+    `nperseg=0` is now rejected with an error, matching
+    `scipy.signal.istft` ({jax-issue}`#38315`).
   * The batching rules of the cuDNN fused attention primitives (used by
     {func}`jax.nn.dot_product_attention` with `implementation='cudnn'`) now
     support operands that do not carry the vmap axis, including a shared

--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -1109,8 +1109,9 @@ def istft(Zxx: Array, fs: ArrayLike = 1.0, window: str = 'hann',
   n_default = (2 * (Zxx.shape[freq_axis] - 1) if input_onesided
                else Zxx.shape[freq_axis])
 
-  nperseg_int = core.concrete_or_error(int, nperseg or n_default,
-                                           "nperseg: segment length of STFT")
+  nperseg_int = core.concrete_or_error(
+      int, n_default if nperseg is None else nperseg,
+      "nperseg: segment length of STFT")
   if nperseg_int < 1:
     raise ValueError('nperseg must be a positive integer')
 
@@ -1126,7 +1127,8 @@ def istft(Zxx: Array, fs: ArrayLike = 1.0, window: str = 'hann',
         f'FFT length ({nfft_int}) must be longer than nperseg ({nperseg_int}).')
 
   noverlap_int = core.concrete_or_error(
-      int, noverlap or nperseg_int // 2, "noverlap of STFT")
+      int, nperseg_int // 2 if noverlap is None else noverlap,
+      "noverlap of STFT")
   if noverlap_int >= nperseg_int:
     raise ValueError('noverlap must be less than nperseg.')
   nstep = nperseg_int - noverlap_int
@@ -1140,7 +1142,7 @@ def istft(Zxx: Array, fs: ArrayLike = 1.0, window: str = 'hann',
   # Perform IFFT
   ifunc = jnp_fft.irfft if input_onesided else jnp_fft.ifft
   # xsubs: [..., T, N], N is the number of frames, T is the frame length.
-  xsubs = ifunc(Zxx, axis=-2, n=nfft)[..., :nperseg_int, :]
+  xsubs = ifunc(Zxx, axis=-2, n=nfft_int)[..., :nperseg_int, :]
 
   # Get window as array
   if isinstance(window, str) and window == 'hann':

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -430,5 +430,57 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
                             check_dtypes=False)
     self._CompileAndCheck(jsp_fun, args_maker, rtol=tol, atol=tol)
 
+  @jtu.sample_product(onesided=[False, True])
+  def testIstftZeroNoverlap(self, *, onesided):
+    # noverlap=0 is valid and must not fall back to the default overlap
+    # (https://github.com/jax-ml/jax/issues/38315).
+    shape = (33, 10) if onesided else (64, 10)
+    kwds = dict(window='boxcar', nperseg=64, noverlap=0,
+                input_onesided=onesided, boundary=False)
+    osp_fun = partial(osp_signal.istft, **kwds)
+    jsp_fun = partial(jsp_signal.istft, **kwds)
+    tol = _TPU_FFT_TOL if jtu.test_device_matches(['tpu']) else 1e-4
+
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape, np.complex64)]
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, rtol=tol, atol=tol,
+                            check_dtypes=False)
+    self._CompileAndCheck(jsp_fun, args_maker, rtol=tol, atol=tol)
+
+  def testIstftDefaultNfftOddNperseg(self):
+    # With nfft=None, one-sided input and odd nperseg, the IFFT must use the
+    # resolved nfft_int (https://github.com/jax-ml/jax/issues/38315).
+    shape = (4, 10)  # 4 freq bins -> n_default = 6, odd nperseg = 7
+    kwds = dict(window='boxcar', nperseg=7, input_onesided=True,
+                boundary=False)
+    osp_fun = partial(osp_signal.istft, **kwds)
+    jsp_fun = partial(jsp_signal.istft, **kwds)
+    tol = _TPU_FFT_TOL if jtu.test_device_matches(['tpu']) else 1e-4
+
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape, np.complex64)]
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, rtol=tol, atol=tol,
+                            check_dtypes=False)
+    self._CompileAndCheck(jsp_fun, args_maker, rtol=tol, atol=tol)
+
+  def testIstftInvalidNperseg(self):
+    # nperseg=0 must be rejected like scipy does, not silently replaced.
+    Zxx = jnp.zeros((17, 5), np.complex64)
+    with self.assertRaisesRegex(ValueError,
+                                "nperseg must be a positive integer"):
+      jsp_signal.istft(Zxx, nperseg=0)
+
+  def testIstftRoundTripZeroNoverlap(self):
+    # istft must invert stft at noverlap=0 (boxcar satisfies NOLA).
+    kwds = dict(window='boxcar', nperseg=64, noverlap=0)
+    tol = _TPU_FFT_TOL if jtu.test_device_matches(['tpu']) else 1e-4
+
+    rng = jtu.rand_default(self.rng())
+    x = rng((640,), np.float32)
+    _, _, Zxx = jsp_signal.stft(x, **kwds)
+    _, x_rec = jsp_signal.istft(Zxx, **kwds)
+    self.assertAllClose(x_rec[:x.shape[0]], x, rtol=tol, atol=tol,
+                        check_dtypes=False)
+
 if __name__ == "__main__":
     absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Fixes #38315.

istft resolves defaulted parameters with value or default, and 0 is falsy in Python. So noverlap=0, which is a perfectly valid value (segments just don't overlap), silently turned into the default 50 percent overlap and the reconstruction came out wrong (in the issue's example scipy returns 640 samples, jax returned 352). The same idiom on nperseg means nperseg=0 silently used the default segment length, where scipy and jax's own stft both raise "nperseg must be a positive integer". That third bug isn't in the issue, I found it while fixing the other two.

There is also the second bug from the issue: the corrected FFT length nfft_int is computed but the inverse FFT was called with the raw n=nfft. When nfft is None with one-sided input and odd nperseg it's actually worse than a wrong length, it crashes with a broadcasting TypeError because the frame comes out one sample shorter than the window.

The fix is three lines: resolve nperseg and noverlap with explicit is None checks (same style _spectral_helper already uses, which is why stft never had these bugs), and pass n=nfft_int to the IFFT. Added five regression tests (noverlap=0 one-sided and two-sided against scipy, the odd-nperseg crash case, the nperseg=0 error, and a stft/istft round trip at zero overlap) plus a CHANGELOG entry. All fail before the fix. I also swept 480 parameter combinations old vs new to confirm nothing outside the three fixed behaviors changed, and everything now matches scipy.

Note: #38319 and #38389 are earlier PRs fixing the first two bugs, both apparently stalled since June. This one additionally fixes the nperseg=0 case and adds the round-trip and two-sided coverage.