### PR TITLE
Handle missing atime files in LRU cache eviction

### DIFF
--- a/jax/_src/lru_cache.py
+++ b/jax/_src/lru_cache.py
@@ -185,7 +185,13 @@ class LRUCache(CacheInterface):
 
       key = cache_path.name.removesuffix(_CACHE_SUFFIX)
       atime_path = self.path / f"{key}{_ATIME_SUFFIX}"
-      file_atime = int.from_bytes(atime_path.read_bytes(), "little")
+      if atime_path.exists():
+        file_atime = int.from_bytes(atime_path.read_bytes(), "little")
+      else:
+        # A process may have exited after writing the cache file but before
+        # writing its atime file. Treat such incomplete entries as the least
+        # recently used instead of failing the entire eviction pass.
+        file_atime = 0
 
       dir_size += file_size
       heapq.heappush(h, (file_atime, key, file_size))
@@ -203,6 +209,7 @@ class LRUCache(CacheInterface):
       atime_path = self.path / f"{key}{_ATIME_SUFFIX}"
 
       cache_path.unlink()
-      atime_path.unlink()
+      if atime_path.exists():
+        atime_path.unlink()
 
       dir_size -= file_size

--- a/tests/lru_cache_test.py
+++ b/tests/lru_cache_test.py
@@ -143,6 +143,32 @@ class LRUCacheTest(LRUCacheTestCase):
     cache.put("c", b"c")
     self.assertCacheKeys(("a", "c"))
 
+  def test_missing_atime_is_evicted_first(self):
+    cache = LRUCache(self.name, max_size=2)
+
+    cache.put("a", b"a")
+    (self.path / f"a{_ATIME_SUFFIX}").unlink()
+
+    # A missing atime should not prevent writes while there is enough space.
+    cache.put("b", b"b")
+    self.assertCacheKeys(("a", "b"))
+
+    # Once eviction is needed, the entry without an atime should be evicted
+    # before entries with a valid atime.
+    cache.put("c", b"c")
+    self.assertCacheKeys(("b", "c"))
+
+  def test_enable_eviction_for_existing_unbounded_cache(self):
+    cache = LRUCache(self.name, max_size=-1)
+    cache.put("a", b"a")
+
+    # Unbounded caches intentionally do not have atime files. Enabling
+    # eviction for an existing cache directory should preserve those entries
+    # while there is enough space and should not prevent new writes.
+    cache = LRUCache(self.name, max_size=2)
+    cache.put("b", b"b")
+    self.assertCacheKeys(("a", "b"))
+
   def test_max_size(self):
     cache = LRUCache(self.name, max_size=1)
 


### PR DESCRIPTION
## Summary

Fixes #39880.

This PR makes the persistent compilation cache's LRU eviction pass tolerate cache entries whose `-atime` sidecar is missing.

A missing atime is treated as timestamp zero, which makes the corresponding entry the least recently used entry in the cache:

- if the cache is still below its size limit, the entry is retained and the pending write can proceed;
- if eviction is required, the entry is evicted before entries with known access times;
- if the entry is read before eviction becomes necessary, the normal `get()` path recreates its atime and effectively migrates it back into the regular bounded-cache format.

The eviction path now also removes cache and atime files with `missing_ok=True`. This is required because selecting an entry with a missing atime for eviction would otherwise fail later when attempting to unlink the missing sidecar.

## Background

The persistent compilation cache stores an executable and its LRU metadata as two separate files:

- `KEY-cache` contains the cached compilation artifact;
- `KEY-atime` contains the last-access timestamp used by the eviction policy.

The separate atime file is intentional. In particular, the cache cannot rely on filesystem access-time behavior uniformly across local and remote filesystems, and updating an explicit sidecar gives the LRU implementation a portable timestamp that can be refreshed on each cache hit.

Atime files are only maintained when eviction is enabled. When `max_size == -1`, the cache is unbounded and deliberately avoids the additional metadata write on every cache access. This matters for large-scale and network filesystems where the extra write may be expensive.

When eviction is enabled, `put()` currently performs the following operations while holding the cache lock:

1. scan the existing entries and evict entries if necessary;
2. write `KEY-cache`;
3. write `KEY-atime`.

The lock serializes cooperating cache users, but it does not make the final two filesystem writes a single atomic transaction. A process that exits after the cache file has been created but before its atime has been written can therefore leave a cache-only entry behind.

There is also a compatibility path that produces the same on-disk shape without any process failure: entries previously written with `max_size == -1` have no atime by design. If the same directory is later opened with a finite size limit, those valid older entries are indistinguishable from cache-only entries left by an interrupted bounded-cache write.

## Failure mode

Before this change, `_evict_if_needed()` assumed that every `KEY-cache` had a corresponding `KEY-atime`.

Because every new `put()` performs a full eviction scan before writing the new value, one missing atime anywhere in the directory caused the scan to raise `FileNotFoundError`. The new value was never written.

Healthy reads were unaffected because `get()` does not perform a full directory scan. Consequently, an affected cache could continue serving old hits and updating their atime files while rejecting every new entry. At the persistent compilation cache call site the error is normally converted into a warning, allowing execution to continue after recompilation but preventing the new executable from being persisted.

This state remains until the cache-only entry is manually removed or happens to be read and given a new atime.

## Approach

When an atime sidecar cannot be found, this PR assigns the entry an effective atime of zero.

All normally generated timestamps come from `time.time_ns()` and are therefore newer than zero. The cache-only entry is consequently placed at the front of the LRU priority queue.

This behavior is preferable to immediately deleting every cache-only entry:

- valid entries created while the cache was unbounded remain available when the bounded cache still has enough capacity;
- a later cache hit recreates the missing atime through the existing `get()` behavior;
- entries with no recorded access history are still the first entries removed when space is required;
- a single incomplete entry no longer disables writes for the entire cache.

It is also preferable to skipping the entry entirely, because skipped cache files would not contribute to the calculated cache size and could allow the directory to exceed the configured limit.

Using timestamp zero is deliberately conservative. The cache file's mtime could provide an approximation of its creation time, but it does not represent a known cache access time. Ranking entries without LRU metadata before entries with known access history gives deterministic behavior and does not require additional filesystem-specific timestamp handling.

## Safe removal

Handling the missing timestamp while building the priority queue is not sufficient on its own. If capacity pressure causes that entry to be selected, the old eviction code would successfully remove `KEY-cache` and then raise `FileNotFoundError` while removing the already-missing `KEY-atime`. The current write would still be aborted. Both removals therefore use `missing_ok=True`.