### PR TITLE
Declare clear_cache() on JitWrapped

### DIFF
--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -686,6 +686,10 @@ class JitWrapped(stages.Wrapped):
   def trace(self, *args, **kwargs) -> stages.Traced:
     raise NotImplementedError
 
+  def clear_cache(self) -> None:
+    """Clear the cached traces and compiled executables of this function."""
+    raise NotImplementedError
+
 
 # in_shardings and out_shardings can't be None as the default value
 # because `None` means that the input is fully replicated.

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -181,3 +181,10 @@ if TYPE_CHECKING:
   assert_type(jnp.average(vals), jax.Array)
   assert_type(jnp.average(vals, returned=False), jax.Array)
   assert_type(jnp.average(vals, returned=True), tuple[jax.Array, jax.Array])
+
+  # jax.jit: methods patched onto the wrapped function at runtime are declared
+  # on the JitWrapped return type.
+  jitted = jax.jit(lambda x: x)
+  assert_type(jitted.clear_cache(), None)
+  assert_type(jitted.trace(vals), jax.stages.Traced)
+  assert_type(jitted.lower(vals), jax.stages.Lowered)


### PR DESCRIPTION
Fixes #38244.

`f.clear_cache()` exists at runtime on jit-wrapped functions (it's patched onto the C++ `PjitFunction` class in `jax/_src/pjit.py`), but it was never declared on `JitWrapped`, the return type of `jax.jit`. So type checkers reject valid code like `jax.jit(f).clear_cache()` with a missing-attribute error, while the sibling patched methods (`lower`, `trace`, `eval_shape`) all check fine.

This adds the missing declaration on `JitWrapped`, same style as its `eval_shape` and `trace` neighbors, plus static assertions in `tests/typing_test.py` so it doesn't regress (that file is checked with pytype/pyrefly rather than by the OSS CI pyrefly hook, which only covers `jax/**`).

I put the declaration on `JitWrapped` rather than `jax.stages.Wrapped` on purpose: `Wrapped` is a public runtime_checkable Protocol and `jax.export` does isinstance checks against it, so adding a member there would change runtime behavior for third-party objects that implement the current protocol. `clear_cache` is jit-specific anyway.

No runtime behavior change, typing only.