### PR TITLE
Make the jaxlib cc_tests build and pass in the OSS checkout

### DIFF
--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -1645,6 +1645,9 @@ cc_test(
     srcs = ["reentrant_hash_test.cc"],
     copts = ["-fexceptions"],
     features = ["-use_header_modules"],
+    # With -fvisibility=hidden (.bazelrc, posix) the dynamic-mode .so deps
+    # export no symbols, so the default linkstatic = 0 fails to link.
+    linkstatic = True,
     deps = [
         ":reentrant_hash_map",
         ":reentrant_hash_set",
@@ -1662,6 +1665,7 @@ cc_test(
 cc_test(
     name = "reentrant_hash_benchmark",
     srcs = ["reentrant_hash_benchmark.cc"],
+    linkstatic = True,  # See reentrant_hash_test.
     deps = [
         ":reentrant_hash_map",
         ":reentrant_hash_set",

--- a/jaxlib/mosaic/dialect/gpu/BUILD
+++ b/jaxlib/mosaic/dialect/gpu/BUILD
@@ -117,6 +117,9 @@ cc_library(
 cc_test(
     name = "mosaic_gpu_test",
     srcs = ["mosaic_gpu_test.cc"],
+    # With -fvisibility=hidden (.bazelrc, posix) the dynamic-mode .so deps
+    # export no symbols, so the default linkstatic = 0 fails to link.
+    linkstatic = True,
     deps = [
         ":mosaic_gpu",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/jaxlib/mosaic/dialect/gpu/BUILD
+++ b/jaxlib/mosaic/dialect/gpu/BUILD
@@ -124,6 +124,7 @@ cc_test(
         ":mosaic_gpu",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/status:statusor",
         "@com_google_googletest//:gtest_main",
         "@llvm-project//llvm:Support",

--- a/jaxlib/mosaic/dialect/gpu/mosaic_gpu_test.cc
+++ b/jaxlib/mosaic/dialect/gpu/mosaic_gpu_test.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
@@ -51,7 +52,7 @@ namespace {
 
 using ::testing::HasSubstr;
 using ::testing::UnorderedElementsAre;
-using ::testing::status::StatusIs;
+using ::absl_testing::StatusIs;
 
 template <typename T1, typename T2, typename... Ts>
 absl::StatusOr<mlir::func::FuncOp> FromCppFunc(

--- a/jaxlib/mosaic/gpu/BUILD
+++ b/jaxlib/mosaic/gpu/BUILD
@@ -93,6 +93,9 @@ cc_library(
 cc_test(
     name = "dump_test",
     srcs = ["dump_test.cc"],
+    # With -fvisibility=hidden (.bazelrc, posix) the dynamic-mode .so deps
+    # export no symbols, so the default linkstatic = 0 fails to link.
+    linkstatic = True,
     deps = [
         ":dump",
         "@com_google_googletest//:gtest_main",
@@ -103,6 +106,7 @@ cc_test(
 cc_test(
     name = "gpu_module_to_assembly_test",
     srcs = ["gpu_module_to_assembly_test.cc"],
+    linkstatic = True,  # See dump_test.
     deps = [
         ":passes",
         "//jaxlib/mosaic/dialect/gpu:mosaic_gpu",
@@ -392,6 +396,7 @@ cc_test(
     name = "custom_call_test",
     srcs = ["custom_call_test.cc"],
     args = ["--heap_check="],  # TODO(b/452513034): Enable heapcheck once the bug is fixed.
+    linkstatic = True,  # See dump_test.
     local_defines = [
         "ABSL_DEFINE_UNQUALIFIED_STATUS_MACROS=1",
     ],


### PR DESCRIPTION
Set `linkstatic = True` on the six `//jaxlib/...` `cc_test` targets that remain in this repository so they link under the existing `-fvisibility=hidden` POSIX configuration. Also replace `::testing::status::StatusIs` with `absl_testing::StatusIs` in `mosaic_gpu_test.cc` — the internal-only matcher never compiled in OSS.

The three mosaic test targets that previously lived in `jaxlib/mosaic/BUILD` (`tiled_layout_test`, `divisibility_check_test`, `tpu_ops_verification_test`) have moved to `@xla//xla/mosaic` and are now alias entries here; their `linkstatic` and status-matcher fixes need to be applied in the XLA repository.

Tested on Linux x86_64: the remaining runnable test targets pass; `reentrant_hash_benchmark` builds.