### PR TITLE
Annotate two TSAN suppressions with their upstream fix revisions

### DIFF
--- a/tests/config/tsan-suppressions_3.14.txt
+++ b/tests/config/tsan-suppressions_3.14.txt
@@ -6,6 +6,12 @@ race:llvm::RuntimeDyldELF::registerEHFrames
 race:dnnl_sgemm
 
 # https://github.com/python/cpython/issues/128050
+# Fixed on the 3.14 branch by https://github.com/python/cpython/pull/143882
+# (merged 2026-01-16). Remove once the hermetic TSAN CPython tarball is
+# known to be built from a revision containing that fix (the tarball URL is
+# an unversioned "3.14.x" name, so its upload date does not establish the
+# source revision), or after a deliberately triggered green TSAN run with
+# the suppression removed.
 race:partial_vectorcall_fallback
 
 # Races because the LAPACK and BLAS in our scipy isn't TSAN instrumented.
@@ -21,4 +27,7 @@ race:gemm_oncopy
 race:type_update_dict
 
 # https://github.com/python/cpython/issues/154821
+# Fixed on the 3.14 branch by https://github.com/python/cpython/pull/154831
+# (merged 2026-07-29). Remove once the hermetic TSAN CPython tarball is
+# built from a revision containing that fix.
 race:func_set_name


### PR DESCRIPTION
Add removal-condition comments for `race:partial_vectorcall_fallback` (fixed by python/cpython#143882) and `race:func_set_name` (fixed by python/cpython#154831). Both suppressions are retained: the hermetic TSAN CPython tarball is an unversioned "3.14.x" artefact, so its upload date does not establish the source revision, and a wrongly removed suppression halts the nightly suite while a stale one costs nothing.