### PR TITLE
DOC: clarify list to array conversion example

### DIFF
--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -1265,7 +1265,7 @@
     }
    ],
    "source": [
-    "jnp.sum(jnp.array(x))"
+    "make_jaxpr(permissive_sum)(jnp.array(x))"
    ]
   },
   {

--- a/docs/notebooks/Common_Gotchas_in_JAX.md
+++ b/docs/notebooks/Common_Gotchas_in_JAX.md
@@ -582,7 +582,7 @@ If you would like to pass a tuple or list to a JAX function, you can do so by fi
 :id: nFf_DydixG8v
 :outputId: e31b43b3-05f7-4300-fdd2-40e3896f6f8f
 
-jnp.sum(jnp.array(x))
+make_jaxpr(permissive_sum)(jnp.array(x))
 ```
 
 +++ {"id": "MUycRNh6e50W"}


### PR DESCRIPTION
The "Non-array inputs: NumPy vs JAX" section introduces `permissive_sum` and discusses the difference between passing a Python list and an array to a JAX function.

The final example currently uses:

```python
jnp.sum(jnp.array(x))
```
This bypasses the permissive_sum function introduced in the preceding examples.

This change uses:
```python
make_jaxpr(permissive_sum)(jnp.array(x))
```
so the example consistently uses permissive_sum and demonstrates the resulting JAXPR when the list is explicitly converted to an array before being passed to the function.

This makes the connection to the preceding `make_jaxpr(permissive_sum)(x) `example clearer.