### PR TITLE
Raise JaxRuntimeError instead of ValueError from the jit C++ fastpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,14 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     `custom_partitioning`, `custom_gradient`, `closure_convert`,
     `linear_call`, or `run_state`) is retraced with different-shaped
     arguments ({jax-issue}`#40110`).
+  * Runtime errors surfacing through the C++ fast path of jitted functions
+    are now raised as {class}`jax.errors.JaxRuntimeError` instead of a
+    plain `ValueError`. Since JAX 0.7.2 this affected exceptions raised
+    inside a {func}`jax.pure_callback` after an earlier successful call of
+    the jitted function; longer-standing instances of the same bug include
+    errors such as reusing a donated buffer. Code that catches `ValueError`
+    for these failures should catch `jax.errors.JaxRuntimeError` (a
+    `RuntimeError` subclass) instead ({jax-issue}`#34083`).
   * The batching rules of the cuDNN fused attention primitives (used by
     {func}`jax.nn.dot_product_attention` with `implementation='cudnn'`) now
     support operands that do not carry the vmap axis, including a shared

--- a/jaxlib/pjit.cc
+++ b/jaxlib/pjit.cc
@@ -1107,6 +1107,27 @@ PjitFunction* AsPjitFunction(nb::handle handle) {
   return PjitFunction::AsPjitFunctionUnchecked(handle);
 }
 
+// The JaxRuntimeError Python type, stashed by BuildPjitSubmodule. Its lifetime
+// is tied to the module that registered it.
+nb::handle jax_runtime_error_type;
+
+// Sets the Python error to a JaxRuntimeError built from `status`. Needed
+// because nanobind's exception translation does not run in raw type slots.
+void SetPyErrFromStatus(const absl::Status& status) {
+  std::string message = status.ToString();
+  if (!jax_runtime_error_type.is_valid()) {
+    PyErr_SetString(PyExc_RuntimeError, message.c_str());
+    return;
+  }
+  try {
+    nb::object exc_inst = jax_runtime_error_type(
+        message, static_cast<int>(status.code()));
+    PyErr_SetObject(jax_runtime_error_type.ptr(), exc_inst.ptr());
+  } catch (nb::python_error& e) {
+    e.restore();
+  }
+}
+
 extern "C" {
 
 PyObject* PjitFunction_tp_vectorcall(PyObject* callable, PyObject* const* args,
@@ -1119,7 +1140,7 @@ PyObject* PjitFunction_tp_vectorcall(PyObject* callable, PyObject* const* args,
     absl::StatusOr<nb::object> out =
         o->fun.Call(callable, args, nargs, kwnames);
     if (!out.ok()) {
-      PyErr_SetString(PyExc_ValueError, out.status().ToString().c_str());
+      SetPyErrFromStatus(out.status());
       return nullptr;
     }
     return out.value().release().ptr();
@@ -1568,6 +1589,10 @@ class NumpyHandler : public ShardArgsHandler {
 }  // namespace
 
 void BuildPjitSubmodule(nb::module_& m) {
+  // Registered by register_runtime_error_bindings before this runs; the
+  // module keeps the type alive.
+  jax_runtime_error_type = m.attr("JaxRuntimeError");
+
   m.attr("_PyTreeRegistry") = m.attr("pytree").attr("PyTreeRegistry");
 
   nb::class_<PjitFunctionCache> cache(m, "PjitFunctionCache");

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -612,6 +612,22 @@ class JitTest(jtu.BufferDonationTestCase):
     f(inp1=x)
     self.assertDeleted(x)
 
+  @jtu.device_supports_buffer_donation()
+  def test_donated_buffer_reuse_error_type(self):
+    # Regression test for #34083: fastpath errors must be JaxRuntimeError.
+    if jtu.parse_version(jax.lib.__version__) < (0, 11, 1):
+      self.skipTest("Requires jaxlib 0.11.1 or newer.")
+
+    @jax.jit(donate_argnums=0)
+    def f(x):
+      return x + 1
+
+    x = jax.device_put(jnp.arange(4.0), jax.devices()[0])
+    f(x)
+    # The message is backend-specific, so assert only the exception type.
+    with self.assertRaises(jax.errors.JaxRuntimeError):
+      f(x)
+
   def test_donate_args_info_aot(self):
     def fn(x, y):
       return jax.tree.map(lambda i: i * 2, x), y * 2

--- a/tests/python_callback_test.py
+++ b/tests/python_callback_test.py
@@ -1140,6 +1140,34 @@ class PureCallbackTest(jtu.JaxTestCase):
       f(x)
     self.assertEqual(count(), 1)
 
+  def test_pure_callback_exception_type_independent_of_cpp_cache(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/34083
+    if jtu.parse_version(jax.lib.__version__) < (0, 11, 1):
+      self.skipTest("Requires jaxlib 0.11.1 or newer.")
+
+    def cb(x):
+      if x > 0:
+        raise RuntimeError("test exception")
+      return np.asarray(x)
+
+    def make_f():
+      @jax.jit
+      def f(x):
+        return jax.pure_callback(cb, jax.ShapeDtypeStruct((), np.float32), x)
+      return f
+
+    # A raising first call reports the error via the Python slow path.
+    f = make_f()
+    with self.assertRaisesRegex(jax.errors.JaxRuntimeError, "test exception"):
+      jax.block_until_ready(f(jnp.float32(1.)))
+
+    # A successful first call populates the C++ fastpath cache; errors raised
+    # through it must also surface as JaxRuntimeError, not ValueError.
+    f = make_f()
+    jax.block_until_ready(f(jnp.float32(-1.)))
+    with self.assertRaisesRegex(jax.errors.JaxRuntimeError, "test exception"):
+      jax.block_until_ready(f(jnp.float32(1.)))
+
 
 class IOCallbackTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Fixes #34083.

Since jax 0.7.2, an exception raised inside a `jax.pure_callback` under jit surfaces as a plain `ValueError` instead of `jax.errors.JaxRuntimeError`, but only when the first call of the jitted function succeeded. That's because a successful first call installs the C++ fastpath cache, and the fastpath's vectorcall slot converted any failed status into `PyErr_SetString(PyExc_ValueError, ...)`. The Python slow path (used before the cache is populated) types the same error correctly, which is why the exception type depends on call order. The same conversion also mistypes other runtime errors that surface synchronously through the fastpath, for example reusing a donated buffer, on CPU and GPU alike.

The trigger in 0.7.2 was 75163e1f4b letting callback computations use the fastpath (a good perf fix, untouched here); the ValueError conversion itself is much older.

The fix: `BuildPjitSubmodule` stashes the registered `JaxRuntimeError` type (registered earlier in module init), and the vectorcall error branch now raises that type with the status message and code, matching what the slow path and nanobind's exception translator produce. No import by module name, so it works in both wheel and Bazel layouts. Error messages are unchanged, only the type changes.

There's an older PR for this issue, #34179, which restores the callback's Python exception from inside the CPU FFI handler. I went with the dispatch-layer fix instead because it also covers non-callback errors and doesn't leave pending exception state on FFI threads.

Two regression tests: a pure_callback one asserting `JaxRuntimeError` on both the slow path and the after-success fastpath, and a donated-buffer-reuse one. Both fail before the fix. Heads-up for reviewers: code written against 0.7.2+ that catches `ValueError` for these failures needs to catch `jax.errors.JaxRuntimeError` (a `RuntimeError` subclass) instead; there's a CHANGELOG note.