### PR TITLE
Fix custom_root tangents for integer auxiliary values

### DIFF
--- a/jax/_src/lax/control_flow/solves.py
+++ b/jax/_src/lax/control_flow/solves.py
@@ -164,9 +164,9 @@ def _root_jvp(const_lengths, jaxprs, primals, tangents):
   rhs = f_at_solution_lin(*params_dot.f)
   solution_dot = _map(
       operator.neg, linearize_and_solve(*solution, *rhs))
-  # append aux, create symbolic zero tangents for the aux values
+  # append aux, create zero tangents of the appropriate tangent type
   solution += aux
-  solution_dot += _map(ad_util.zeros_like_jaxval, aux)
+  solution_dot += _map(ad_util.zero_from_primal, aux)
 
   return solution, solution_dot
 

--- a/tests/custom_root_test.py
+++ b/tests/custom_root_test.py
@@ -227,6 +227,20 @@ class CustomRootTest(jtu.JaxTestCase):
 
     jtu.check_close(fwd_aux, jax.tree.map(jnp.zeros_like, fwd_aux))
 
+  def test_custom_root_with_integer_aux(self):
+    def root(a):
+      f = lambda x: x - a
+      solve = lambda f, x: (a, np.array(1))
+      tangent_solve = lambda g, y: y
+      return lax.custom_root(f, 0., solve, tangent_solve, has_aux=True)
+
+    (value, aux), (value_dot, aux_dot) = jax.jvp(root, (2.,), (1.,))
+
+    self.assertAllClose(value, 2.)
+    self.assertAllClose(aux, 1)
+    self.assertAllClose(value_dot, 1.)
+    self.assertEqual(aux_dot.dtype, jax.dtypes.float0)
+
   def test_custom_root_with_xla_metadata_call(self):
     """Test that custom_root VJP works when f contains xla_metadata_call."""
     from jax.experimental import xla_metadata


### PR DESCRIPTION
Fixes #24295.

`custom_root(..., has_aux=True)` creates auxiliary tangents with
`zeros_like_jaxval`, giving integer auxiliary values integer tangents
instead of the required `float0` tangents.

Use `zero_from_primal` to construct correctly typed zero tangents and add
a regression test for integer auxiliary outputs.

Tests: `tests/custom_root_test.py` with and without x64; pre-commit checks.