### PR TITLE
Fix vanishing second derivative of tanh and gradient of i0 for inputs

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4612,7 +4612,7 @@ ad.defjvp2(
         ),
     )
     if accuracy is AccuracyMode.HIGHEST
-    else mul(add(g, mul(g, ans)), sub(_one(x), ans)),
+    else mul(g, sub(_one(ans), mul(ans, ans))),
 )
 mlir.register_lowering(tanh_p, partial(_nary_lower_hlo, hlo.tanh))
 core.pp_eqn_rules[tanh_p] = _unary_with_accuracy_pp_rule

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -6155,8 +6155,12 @@ def _i0(x):
 
 @_i0.defjvp
 def _i0_jvp(primals, tangents):
-  primal_out, tangent_out = api.jvp(_i0.fun, primals, tangents)
-  return primal_out, where(primals[0] == 0, 0.0, tangent_out)
+  x, = primals
+  x_dot, = tangents
+  abs_x = lax.abs(x)
+  i1 = lax.mul(lax.sign(x),
+               lax.mul(lax.exp(abs_x), lax_special.bessel_i1e(abs_x)))
+  return _i0.fun(x), lax.mul(x_dot, i1)
 
 @export
 def ix_(*args: ArrayLike) -> tuple[Array, ...]:

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -173,6 +173,14 @@ class LaxTest(jtu.JaxTestCase):
         actual, expected, atol=jtu.default_tolerance()[np.dtype(np.float32)], rtol=0.0
     )
 
+  def testTanhSecondGrad(self):
+    x = np.array([1e-30, 1e-20, 1e-10, 1e-5, 1e-3, 0.1, 0.5, 1.0, 2.0],
+                 dtype=np.float32)
+    t = np.tanh(x.astype(np.float64))
+    expected = (-2 * t * (1 - t * t)).astype(np.float32)
+    actual = jax.vmap(jax.grad(jax.grad(lax.tanh)))(jnp.asarray(x))
+    self.assertAllClose(actual, expected, rtol=1e-5, atol=0.0)
+
   # TODO test shift_left, shift_right_arithmetic, shift_right_logical
 
   @jtu.sample_product(


### PR DESCRIPTION
Fixes #39801 and #39797. These two JVP rules calculate the derivative using ans instead of x for performance reasons. But the resulting expressions are sensitive to rounding errors.
Without adding expensive ops, this PR simply rewrites two expressions to make them correct under sensitive x.

### tanh second derivative 39801

The default JVP was `(1 + ans) * (1 - ans)`, but the autodiff for a second derivative produces `ans' * ((1 - ans) - (1 + ans))`. For small `-eps < x < eps`,  1 +- ans rounds to 0, so the true `-2 ans` cancels to zero. 

```py
jax.grad(jax.grad(jnp.tanh))(1e-300)
0.0        # expected -2e-300
```

Rewriting the expr to equivalently `1 - ans * ans` preserves the derivative.

```py
jax.grad(jax.grad(jnp.tanh))(1e-300)
-2e-300
```

### i0 gradient 39797

_i0 is computed as exp(|x|) * i0e(|x|), and the derivative was i1e(x) - sign(x) * i0e(x), which rounds to exactly -1.0 for |x| << 1. The product rule then yields 1*1 + 1*(-1) = 0.

```py
jax.grad(jnp.i0)(1e-300)
0.0        # expected 5e-301
```

Stating the identity d/dx i0 = i1 avoids the composition

```py
jax.grad(jnp.i0)(1e-300)
5e-301
```

### Testing

Adds testTanhSecondGrad to tests/lax_test.py.