### PR TITLE
Fix color cycling in sharding visualization

### DIFF
--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -802,10 +802,13 @@ def _get_text_color(color: str) -> str:
 def make_color_iter(color_map, num_rows, num_cols):
   num_colors = num_rows * num_cols
   color_values = np.linspace(0, 1, num_colors)
+  # A step coprime to num_colors visits every color exactly once.
+  step = (num_colors // 2 + bool(num_colors % 2 == 0)
+          + bool(num_colors % 4 == 2))
   idx = 0
   for _ in range(num_colors):
     yield color_map(color_values[idx])
-    idx = (idx + num_colors // 2 + bool(num_colors % 2 == 0)) % num_colors
+    idx = (idx + step) % num_colors
 
 def visualize_sharding(shape: Sequence[int], sharding: Sharding, *,
                        use_color: bool = True, scale: float = 1.,

--- a/tests/debugging_primitives_test.py
+++ b/tests/debugging_primitives_test.py
@@ -933,6 +933,15 @@ class VisualizeShardingTest(jtu.JaxTestCase):
     devices = [DummyDevice("CPU", i, "CPU") for i in range(num_devices)]
     return np.array(devices).reshape(shape)
 
+  @parameterized.parameters(
+      (1, 1), (1, 2), (1, 5), (2, 2), (2, 3), (2, 4), (2, 5))
+  def test_make_color_iter_uses_all_colors(self, num_rows, num_cols):
+    num_colors = num_rows * num_cols
+    colors = list(debugging.make_color_iter(lambda x: x, num_rows, num_cols))
+
+    self.assertLen(colors, num_colors)
+    self.assertArraysEqual(np.sort(colors), np.linspace(0, 1, num_colors))
+
   def test_trivial_sharding(self):
     mesh = jax.sharding.Mesh(self._create_devices(1), ['x'])
     pspec = jax.sharding.PartitionSpec('x')


### PR DESCRIPTION
Fixes #25695.

This change makes the color-cycle step coprime to the number of colors, ensuring that every color is visited exactly once before the cycle repeats. It also adds a focused regression test covering representative grid sizes.