### PR TITLE
[MosaicGPU] fp4 sparsity support for Rubin

### DIFF
--- a/jax/_src/pallas/mosaic_gpu/pipeline.py
+++ b/jax/_src/pallas/mosaic_gpu/pipeline.py
@@ -36,7 +36,7 @@ from jax._src.pallas import core as pallas_core
 from jax._src.pallas.mosaic_gpu import core as gpu_core
 from jax._src.pallas.mosaic_gpu import primitives as gpu_primitives
 from jax.experimental import pallas as pl
-from jax.experimental.mosaic.gpu import core as mgpu_core
+from jax.experimental.mosaic.gpu import utils as mgpu_utils
 import jax.numpy as jnp
 
 
@@ -328,7 +328,7 @@ def emit_pipeline[T](
   if not has_dynamic_grid and max_concurrent_steps > num_steps:
     max_concurrent_steps = int(num_steps)
 
-  if is_cp_async := mgpu_core._infer_arch() < (9, 0):
+  if is_cp_async := mgpu_utils._infer_arch() < (9, 0):
     if out_specs:
       raise NotImplementedError(
           "emit_pipeline on pre-Hopper GPUs only supports input-only pipelines"

--- a/jax/experimental/mosaic/gpu/core.py
+++ b/jax/experimental/mosaic/gpu/core.py
@@ -39,7 +39,6 @@ from jax._src import util as jax_util
 from jax._src.interpreters import mlir
 from jax._src.lib import mosaic_gpu_dialect as dialect
 from jax._src.pallas.mosaic import error_handling as error
-from jax.extend import backend as jex_backend
 from jaxlib.mlir import ir
 from jaxlib.mlir import passmanager
 from jaxlib.mlir.dialects import _gpu_ops_gen
@@ -815,28 +814,6 @@ def _launch(
     gpu.terminator()
 
 
-def _infer_arch() -> tuple[int, int]:
-  device: Any = jax.sharding.get_abstract_mesh().abstract_device
-  default_device = jex_backend.get_default_device()
-  if device is None:
-    device = default_device
-  elif (
-      hasattr(default_device, "compute_capability")
-      and device.device_kind == default_device.device_kind
-  ):
-    device = default_device
-  if not hasattr(device, "compute_capability"):
-    return (9, 0)  # TODO(apaszke): Remove this once we figure out the export story.
-  arch_name = device.compute_capability
-  # Handle ROCm devices that return architecture strings like "gfxXXX".
-  if arch_name.startswith("gfx"):
-    raise ValueError(
-        f"Mosaic GPU does not yet support AMD ROCm devices. "
-        f"Got compute_capability: {arch_name}"
-    )
-  return tuple(map(int, arch_name.split(".")))  # pyrefly: ignore[bad-return]
-
-
 def _lower_as_gpu_kernel(
     body,
     grid: tuple[int, int, int],
@@ -880,7 +857,7 @@ def _lower_as_gpu_kernel(
   dialect.register_dialect(module.context)
   attrs = module.operation.attributes
   attrs["sym_name"] = ir.StringAttr.get(module_name)
-  arch_major, arch_minor = _infer_arch()
+  arch_major, arch_minor = utils._infer_arch()
   attrs["mosaic_gpu.arch_major"] = ir.IntegerAttr.get(i32, arch_major)
   attrs["mosaic_gpu.arch_minor"] = ir.IntegerAttr.get(i32, arch_minor)
   if uses_pdl:
@@ -1031,7 +1008,7 @@ def lower_mgpu_module(
           dump_options.dump_path
       )
 
-    layout_inference.infer_layout(module, arch=_infer_arch())
+    layout_inference.infer_layout(module, arch=utils._infer_arch())
 
     if dump_options is not None and dump_options.mlir_passes:
       utils.dump_to_file_or_stdout(

--- a/jax/experimental/mosaic/gpu/tcgen05.py
+++ b/jax/experimental/mosaic/gpu/tcgen05.py
@@ -112,6 +112,24 @@ def create_instr_descriptor(
   return arith.constant(ir.IntegerType.get_signless(32), desc)
 
 
+def _mxf4_sparsity_version() -> int:
+  """Sparsity version for .kind::mxf4{,nvf4}.
+
+  This needs to be set in the descriptor and encodes the sparsity granularity.
+  """
+  arch = utils.get_arch()
+  assert arch.major in {10, 11}, arch
+  return int(arch.major == 10 and arch.minor >= 7)
+
+
+def sparse_group_elems(element_type: ir.Type) -> int:
+  """The number of A elements described by one pair of metadata entries."""
+  assert utils.bitwidth(element_type) != 32, "tf32 support not implemented"
+  if utils.bitwidth(element_type) != 4:
+    return 4
+  return 4 if _mxf4_sparsity_version() == 1 else 8
+
+
 def _create_scaled_instr_descriptor(
     get_input_encoding: Callable[[ir.Type], int],
     m: int,
@@ -125,15 +143,23 @@ def _create_scaled_instr_descriptor(
     scale_type: ir.Type,
     sparse: bool = False,
 ) -> ir.Value:
+  # Use .kind::mxf4 and .kind::mxf4nvf4 encoding for 4-bit types
+  is_fp4 = utils.bitwidth(a_type) == 4 and utils.bitwidth(b_type) == 4
   desc = 0
-  # Bits 0, 1 are reserved
+  # Bits 0, 1 are reserved and must be 0
   desc |= sparse << 2  # Sparsity, bit 2
-  # Bit 3 is reserved
+  # Bit 3 is the upper bit of the encoded K dimension .kind::mxf4 and
+  # .kind::mxf4nvf4
   assert 0 <= b_scale_idx < 4
   desc |= b_scale_idx << 4  # B scale factor data ID, bits 4-5
   # Bit 6 is reserved
   desc |= get_input_encoding(a_type) << 7  # A dtype, bits 7-9
-  desc |= get_input_encoding(b_type) << 10  # B dtype, bits 10-12
+  desc |= get_input_encoding(b_type) << 10  # B dtype, bits 10-12 or 10-11
+  assert not is_fp4 or (desc >> 11) == 0
+  if is_fp4 and sparse:
+    sparsity_version = _mxf4_sparsity_version()
+    assert sparsity_version in {0, 1}
+    desc |= sparsity_version << 12  # Sparsity version, bit 12
   # We ignore negate bits 13-14
   desc |= transpose_a << 15  # Transpose A
   desc |= transpose_b << 16  # Transpose B
@@ -152,12 +178,19 @@ def _create_scaled_instr_descriptor(
     raise ValueError(f"M must be a multiple of 16 and <= 256, got: {m}")
   desc |= (m >> 7) << 27  # M >> 7, bits 27-28
   desc |= a_scale_idx << 29  # A scale factor data ID, bits 29-30
-  # Bit 31 is reserved
+  # Bit 31 is the lowest bit of the encoded K dimension for .kind::mxf4,
+  # .kind::mxf4nvf4, and .kind::mxf8f6f4. Zero means Dense K=64 / Sparse
+  # K=128 for .kind::mxf4 and .kind::mxf4nvf4 and Dense K=32 / Sparse K=64
+  # for .kind::mxf8f6f4.
   return arith.constant(ir.IntegerType.get_signless(32), desc)
 
 
 def create_scaled_f8f6f4_instr_descriptor(*args, **kwargs) -> ir.Value:
   def get_input_encoding(ty):
+    # The instruction descriptor encoding logic implemented above assumes
+    # that 4-bit types come through .kind::mxf4 or .kind::mxf4nvf4.
+    if utils.bitwidth(ty) == 4:
+      raise NotImplementedError(f"4-bit type {ty} not supported via f8f6f4")
     if ty == ir.Float8E4M3FNType.get():
       return 0
     elif ty == ir.Float8E5M2Type.get():
@@ -494,9 +527,8 @@ def mma(
           f" got {b_scale.shape}"
       )
   if is_sparse:
-    sparse_group_elems = 8 if utils.bitwidth(a_element_type) == 4 else 4
     # Each sparse group has 2 entries.
-    expected_meta_k = k // sparse_group_elems * 2
+    expected_meta_k = k // sparse_group_elems(a_element_type) * 2
     if a_sparse_metadata.shape != (m, expected_meta_k):
       raise ValueError(
           f"A sparse metadata shape mismatch: expected {(m, expected_meta_k)},"
@@ -588,9 +620,8 @@ def mma(
     if a_sparse_addr_base is not None:
       if n_groups != 1 or m_groups != 1:
         raise NotImplementedError("A sparse metadata address calculation for multiple tiles")
-      sparse_group_elems = 8 if utils.bitwidth(mma_a_element_type) == 4 else 4
       # Each sparse group has 2 entries, each TMEM column holds 16 i2 entries.
-      cols_per_k_group = k_group_elems // sparse_group_elems * 2 // 16
+      cols_per_k_group = k_group_elems // sparse_group_elems(mma_a_element_type) * 2 // 16
       a_sparse_addr = arith.addi(a_sparse_addr_base, utils.c(ki * cols_per_k_group, i32))
     else:
       a_sparse_addr = None
@@ -683,6 +714,7 @@ def _do_mma(
   is_scaled = a_scale_addr is not None
   is_sparse = a_sparse_addr is not None
   elem_bitwidth = utils.bitwidth(a_element_type)
+  # TODO: support larger K values on newer hardware
   instr_k = (1 + is_sparse) * 8 * 32 // elem_bitwidth
   packing = 8 * 4 // elem_bitwidth
 
@@ -765,16 +797,17 @@ def _do_mma(
   for k_step in range(k // instr_k):
     if is_sparse:
       assert a_sparse_addr is not None
-      sparse_group_elems = 8 if elem_bitwidth == 4 else 4
-      # Each sparse group has 2 entries, each TMEM column holds 16 i2 entries.
-      meta_cols_per_instr = instr_k // sparse_group_elems * 2 // 16
-      instrs_per_col_pair = 2 // meta_cols_per_instr
-      sp_selector = k_step % instrs_per_col_pair
-      sparse_addr = (
-          arith.addi(
-              a_sparse_addr, utils.c(k_step // instrs_per_col_pair * 2, i32)
-          ),
-      )
+      # Sparse metadata is organised as 32-row columns of 32-bit cells in TMEM; 4 bits
+      # of metadata map to 2 (1:2 sparsity), 4 (2:4 sparsity) or 8 (4:8 sparsity)
+      # of the `instr_k` columns in A consumed by each tcgen05.mma.sp instruction.
+      meta_cols_per_instr = instr_k // sparse_group_elems(a_element_type) * 2 // 16
+      # The metadata operand always names a column pair, and the descriptor's
+      # sparsity selector picks which half of that pair to read if needed. This
+      # selector is only non-zero for wider types (smaller instr_k) that only
+      # have one metadata column per instruction (e.g. .kind::f16).
+      meta_col = k_step * meta_cols_per_instr
+      sp_selector = meta_col % 2
+      sparse_addr = (arith.addi(a_sparse_addr, utils.c(meta_col // 2 * 2, i32)),)
     if is_scaled:
       assert scale_steps is not None
       scale_vec_width = 4 // scale_steps

--- a/jax/experimental/mosaic/gpu/utils.py
+++ b/jax/experimental/mosaic/gpu/utils.py
@@ -28,6 +28,7 @@ from typing import Any, Literal, cast, overload
 import jax
 from jax import numpy as jnp
 from jax._src.lib import mosaic_gpu_dialect as dialect  # noqa: F401
+from jax.extend import backend as jex_backend
 from jax.interpreters import mlir
 from jaxlib.mlir import ir
 from jaxlib.mlir.dialects import arith
@@ -2450,12 +2451,35 @@ class Arch:
   minor: int
 
 
-def get_arch() -> Arch:
-  ip = ir.InsertionPoint.current
-  if ip is None:
+def _infer_arch() -> tuple[int, int]:
+  device: Any = jax.sharding.get_abstract_mesh().abstract_device
+  default_device = jex_backend.get_default_device()
+  if device is None:
+    device = default_device
+  elif (
+      hasattr(default_device, "compute_capability")
+      and device.device_kind == default_device.device_kind
+  ):
+    device = default_device
+  if not hasattr(device, "compute_capability"):
+    return (9, 0)  # TODO(apaszke): Remove this once we figure out the export story.
+  arch_name = device.compute_capability
+  # Handle ROCm devices that return architecture strings like "gfxXXX".
+  if arch_name.startswith("gfx"):
     raise ValueError(
-        "Cannot retrieve the architecture without an insertion point"
+        f"Mosaic GPU does not yet support AMD ROCm devices. "
+        f"Got compute_capability: {arch_name}"
     )
+  return tuple(map(int, arch_name.split(".")))  # pyrefly: ignore[bad-return]
+
+
+def get_arch() -> Arch:
+  try:
+    ip = ir.InsertionPoint.current
+  except ValueError:
+    # Infer the architecture; this is needed when architecture-sensitive code
+    # is called from test setup code and there is no active module.
+    return Arch(*_infer_arch())
   block = ip.block
   op = block.owner
   while op is not None:

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -3309,6 +3309,7 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
     out_jax_dtype = jnp.float32
     sparse_meta_dtype = jnp.uint2
     block_size = base_block_size * 2
+    # TODO: increase k to allow sparse K=192 on sm_107a
     k_steps = 2
 
     in_mlir_dtype = utils.dtype_to_ir_type(in_jax_dtype)
@@ -3357,7 +3358,10 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
     y_shape = (n, k)
     y = self.prng.uniform(-1, 1, y_shape).astype(in_jax_dtype)
     out_shape = jax.ShapeDtypeStruct((m, n), out_jax_dtype)
-    meta_k = k // 4
+    # 8 (fp4 v0) or 4 (fp4 v1)
+    group_elems = tcgen05.sparse_group_elems(in_mlir_dtype)
+    n_groups = k // group_elems
+    meta_k = n_groups * 2
     scratch_shape = [
         jax.ShapeDtypeStruct(tile_shape(x_shape, lhs_tiling), in_jax_dtype),
         jax.ShapeDtypeStruct(tile_shape(y_shape, rhs_tiling), in_jax_dtype),
@@ -3371,7 +3375,6 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
         mgpu.TMEM((m, k // block_size), scale_jax_dtype, layout=tcgen05.scales_layout()),
         mgpu.TMEM((n, k // block_size), scale_jax_dtype, layout=tcgen05.scales_layout()),
     ]
-    n_groups = k // 8
     index_pairs = np.asarray(np.meshgrid(range(4), range(4))).T.reshape(-1, 2)
     valid_pairs = index_pairs[index_pairs[:, 0] < index_pairs[:, 1]]
     assert len(valid_pairs) == 6
@@ -3404,9 +3407,10 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
     z = mgpu.as_gpu_kernel(
         kernel, (1, 1, 1), (128, 1, 1), args, out_shape, scratch_shape
     )(*args)
-    # 4-bit sparse data is filled in pairs of elements.
-    x32 = x.astype(np.float32).reshape(m, n_groups, 2, 2)
-    x_logical32 = np.zeros((m, n_groups, 4, 2), dtype=np.float32)
+    # 4-bit sparse data is filled in sub-chunks of 2 (v0) or 1 (v1) elements.
+    sub_chunk = group_elems // 4
+    x32 = x.astype(np.float32).reshape(m, n_groups, 2, sub_chunk)
+    x_logical32 = np.zeros((m, n_groups, 4, sub_chunk), dtype=np.float32)
     np.put_along_axis(x_logical32, x_sparse[..., np.newaxis], x32, axis=-2)
     x_logical32 = x_logical32.reshape(m, k)
     y32 = y.astype(np.float32)


### PR DESCRIPTION
This makes this Mosaic GPU test pass on sm_107a; the instruction descriptor must be set differently on sm_107a to sm_100a and sm_103a (https://docs.nvidia.com/cuda/developer-preview/13.4/parallel-thread-execution/index.html#tcgen05-instuction-desc-kind-mxf4-mxf4nvf4).