### PR TITLE
[typing] use implicitly-defined typevars in internal utilities

### DIFF
--- a/jax/_src/ad_util.py
+++ b/jax/_src/ad_util.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import types
-from typing import Any, TypeVar
+from typing import Any
 
 from jax._src import core
 from jax._src.core import typeof
@@ -26,8 +26,6 @@ from jax._src.typing import Array, ArrayLike
 from jax._src.util import safe_map
 
 traceback_util.register_exclusion(__file__)
-
-T = TypeVar('T')
 
 map = safe_map
 
@@ -96,7 +94,7 @@ def a2tz(primal_aval):
   return Zero(primal_aval.to_tangent_aval())
 
 
-def _stop_gradient_impl(x: T) -> T:
+def _stop_gradient_impl[T](x: T) -> T:
   if not core.valid_jaxtype(x):
     raise TypeError("stop_gradient only works on valid JAX arrays, but "
                     f"input argument is: {x}")

--- a/jax/_src/source_info_util.py
+++ b/jax/_src/source_info_util.py
@@ -24,7 +24,7 @@ import re
 import sysconfig
 import threading
 import types
-from typing import Any, NamedTuple, TypeVar, cast
+from typing import Any, NamedTuple, cast
 
 from jax._src.lib import xla_client
 
@@ -266,9 +266,6 @@ def current_name_stack() -> NameStack:
   return _source_info_context.context.name_stack
 
 
-_F = TypeVar('_F', bound=Callable[..., Any])
-
-
 class ExtendNameStackContextManager:
   __slots__ = ['name', 'prev']
 
@@ -284,12 +281,12 @@ class ExtendNameStackContextManager:
   def __exit__(self, exc_type, exc_value, traceback):
     _source_info_context.context = self.prev
 
-  def __call__(self, func: _F) -> _F:
+  def __call__[F: Callable[..., Any]](self, func: F) -> F:
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
       with ExtendNameStackContextManager(self.name):
         return func(*args, **kwargs)
-    return cast(_F, wrapper)
+    return cast(F, wrapper)
 
 extend_name_stack = ExtendNameStackContextManager
 
@@ -307,12 +304,12 @@ class SetNameStackContextManager:
   def __exit__(self, exc_type, exc_value, traceback):
     _source_info_context.context = self.prev
 
-  def __call__(self, func: _F) -> _F:
+  def __call__[F: Callable[..., Any]](self, func: F) -> F:
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
       with SetNameStackContextManager(self.name_stack):
         return func(*args, **kwargs)
-    return cast(_F, wrapper)
+    return cast(F, wrapper)
 
 
 set_name_stack = SetNameStackContextManager
@@ -343,11 +340,11 @@ class TransformNameStackContextManager:
   def __exit__(self, exc_type, exc_value, traceback):
     _source_info_context.context = self.prev
 
-  def __call__(self, func: _F) -> _F:
+  def __call__[F: Callable[..., Any]](self, func: F) -> F:
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
       with TransformNameStackContextManager(self.name):
         return func(*args, **kwargs)
-    return cast(_F, wrapper)
+    return cast(F, wrapper)
 
 transform_name_stack = TransformNameStackContextManager

--- a/jax/_src/traceback_util.py
+++ b/jax/_src/traceback_util.py
@@ -18,15 +18,12 @@ import functools
 import os
 import traceback
 import types
-from typing import TypeVar, cast
+from typing import cast
 
 from jax._src import config
 from jax._src import util
 from jax._src.lib import _jax
 
-
-# TODO(slebedev): Add `bound=Callable` once facebook/pyrefly#3329 is fixed.
-C = TypeVar("C")
 
 _exclude_paths: list[str] = []
 
@@ -160,7 +157,9 @@ def _filtering_mode() -> str:
       mode = "quiet_remove_frames"
   return mode
 
-def api_boundary(
+
+# TODO(slebedev): use [C: Callable[..., Any]] once facebook/pyrefly#3329 is fixed.
+def api_boundary[C](
     fun: C, *,
     repro_api_name: str | None = None,
     repro_user_func: bool = False) -> C:


### PR DESCRIPTION
This syntax is available starting in Python 3.12.

I'm doing just a few changes at a time because similar changes have caused unexpected downstream test failures.