### PR TITLE
Clarify device profiler configuration

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -305,21 +305,25 @@ jax.profiler.stop_trace()
     `3`: Includes level 2 traces plus more verbose, low-level program execution
     details such as cheap XLA operations.
 
-2. `device_tracer_level`: Controls whether device tracing is enabled.
-
-    Supported Values:
-
-    `0`: Disables device tracing.
-
-    `1`: Enables device tracing (default).
-
-3.  `python_tracer_level`: Controls whether Python tracing is enabled.
+2. `python_tracer_level`: Controls whether Python tracing is enabled.
 
     Supported Values:
 
     `0`: Disables Python function call tracing (default).
 
     `1`: Enables Python tracing.
+
+3. `raise_error_on_start_failure`: Controls whether profiler startup failures
+   are raised. The default is `False`, which allows the available collectors to
+   continue if another collector fails to start. Set this to `True` when
+   diagnosing a missing device trace so that a device collector startup failure
+   is not hidden by a host-only trace.
+
+Device tracing is enabled by default. Although `device_tracer_level` is part of
+the underlying profiler protocol, it is not currently exposed as a writable
+field of the Python `ProfileOptions` API. Assigning
+`options.device_tracer_level` creates an unused Python attribute and does not
+change the profiler configuration.
 
 #### Advanced configuration options
 


### PR DESCRIPTION
## Summary

- Remove `device_tracer_level` from the list of writable Python `ProfileOptions` fields.
- Explain that device tracing is enabled by default and assigning this field creates an unused Python attribute.
- Document `raise_error_on_start_failure` as the way to expose collector startup failures while debugging missing device traces.

## Why

The profiling guide currently presents `device_tracer_level` as configurable through the Python API. The native binding does not expose that property. Python accepts an assignment in the instance dictionary, but the assignment does not change native profiler configuration. This can make a failed TPU or GPU trace look correctly configured while producing only host events.

## Validation

- Reproduced with JAX 0.11.0: the class has no native `device_tracer_level` descriptor, and assignment appears only in `vars(options)`.
- Confirmed `raise_error_on_start_failure` is a native property whose default is `False`.
- Ran `pre-commit run --files docs/profiling.md` successfully.
- Ran `git diff --check` successfully.