### PR TITLE
[custom_vjp3] support closing over tracers via closure conversion

### DIFF
--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -750,6 +750,8 @@ class CustomVJPTraced(VJPHiPrimitive):
     return tree_unflatten(self.out_tree, outs_flat)
 
   def vjp_fwd(self, in_nzs, *args):
+    if any(tree_leaves(in_nzs[0])):
+      raise ad.CustomVJPException()
     if self.symbolic_zeros:
       args = tree_map(CustomVJPPrimal, args, in_nzs)  # tree_map skips Statics
     args_ = tuple(x.val if isinstance(x, Static) else x for x in args)
@@ -799,6 +801,7 @@ class CustomVJPTraced(VJPHiPrimitive):
     if not isinstance(in_cts, tuple):
       raise TypeError(f"Custom VJP bwd rule {self.bwd} must produce a tuple "
                       f"but got {type(in_cts)}.")
+    in_cts = (None, *in_cts)  # zero cotangent for the promoted-consts argument
     if len(in_cts) != len(self.in_tree.children()) - len(self.static_argnums):
       raise ValueError(f"Custom VJP bwd rule {self.bwd} must produce a tuple "
                        "of length equal to the primal args tuple, but got "
@@ -806,7 +809,7 @@ class CustomVJPTraced(VJPHiPrimitive):
     in_cts = broadcast_prefix(in_cts, in_avals_, is_leaf=lambda x: x is None)
     in_cts = tree_unflatten(self.in_tree, map(_replace_none, self.in_avals_flat, in_cts))
     tree_map_with_path(partial(_vjp_bwd_aval_mismatch_err, self.traced._fun_sourceinfo),
-                               self.in_avals, in_cts)
+                               self.in_avals[1:], in_cts[1:])
     if self.symbolic_zeros:
       in_cts = tree_map(ad_util.replace_rule_output_symbolic_zeros, in_cts)
     return (in_cts, logs) if self.with_logs else in_cts
@@ -814,12 +817,14 @@ class CustomVJPTraced(VJPHiPrimitive):
   def jvp(self, primals, tangents):
     if self.symbolic_zeros: ad.raise_custom_vjp_error_on_jvp()
     zero = lambda x: isinstance(x, ad_util.Zero)
+    nzs_in = tuple(tree_map(lambda t: not isinstance(t, ad_util.Zero), t,
+                            is_leaf=zero) for t in tangents)
     tangents = tree_map(ad_util.instantiate, tangents, is_leaf=zero)
     if self.opt_remat:
-      fwd_traced = api.jit(partial(self.vjp_fwd, (True,) * len(primals))).trace(*primals)
+      fwd_traced = api.jit(partial(self.vjp_fwd, nzs_in)).trace(*primals)
       primals_out, residuals = OptRemat(self, fwd_traced)(*primals)
     else:
-      primals_out, residuals, *_ = self.vjp_fwd((True,) * len(primals), *primals)
+      primals_out, residuals, *_ = self.vjp_fwd(nzs_in, *primals)
     nzs_in_flat = [True] * len(self.in_avals_flat)
     nzs_out_flat = [True] * len(self.out_avals_flat)
     tangents_flat = tree_leaves_checked(self.in_tree, tangents)
@@ -934,7 +939,8 @@ class custom_vjp3:
       raise AttributeError(msg)
 
     args = resolve_kwargs(self.f, args, kwargs)
-    if any(isinstance(args[i], core.Tracer) for i in self.static_argnums):
+    if any(isinstance(l, core.Tracer) for i in self.static_argnums
+           for l in tree_leaves(args[i])):
       raise UnexpectedTracerError("custom_vjp inputs marked with nondiff_argnums "
                                   "must be static, not Tracers")
     if all(is_hashable(args[i]) for i in self.static_argnums):
@@ -947,17 +953,14 @@ class custom_vjp3:
       f = dyn_args_fun(self.f, self.static_argnums,
                        tuple(map(WrapHashably, static_args)), len(args))
       traced = api.jit(f).trace(*dyn_args)
-    if any(isinstance(x, core.Tracer) for x in traced._consts):
-      t = next(x for x in traced._consts if isinstance(x, core.Tracer))
-      raise UnexpectedTracerError(
-          f"custom_vjp-decorated function {self.f} closed over a {type(t).__name__} "
-          f"of type {t.aval.str_short()}, but custom_vjp functions can't close "
-          f"over Tracers. Rewrite {self.f} to take it as an explicit input.")
     args = tuple(Static(x) if i in self.static_argnums else x for i, x in enumerate(args))
-    in_avals = tree_map(typeof, args)
-    prim = CustomVJPTraced(traced, self.fwd, self.bwd, in_avals, self.symz,
-                           self.static_argnums, self.opt_remat, self.with_logs)
-    return prim(*args)
+    consts, traced = traced.with_consts_as_arg()
+    fwd_ = update_wrapper(lambda _, *args: self.fwd(*args), self.fwd)
+    static_argnums = frozenset(i + 1 for i in self.static_argnums)
+    in_avals = tree_map(typeof, (consts, *args))
+    prim = CustomVJPTraced(traced, fwd_, self.bwd, in_avals, self.symz,
+                           static_argnums, self.opt_remat, self.with_logs)
+    return prim(consts, *args)
 
   def def_vmap(self, rule, /): return self.f.def_vmap(rule)
   def def_transpose(self, rule, /): return self.f.def_transpose(rule)

--- a/jax/_src/stages.py
+++ b/jax/_src/stages.py
@@ -414,7 +414,7 @@ class Traced(Stage):
   representations via `.jaxpr` and `.lojax` properties respectively.
   """
   __slots__ = ['_meta_tys_flat', '_params', '_in_tree', 'out_tree', '_consts',
-               '_fun_sourceinfo', '_lojax']
+               '_fun_sourceinfo', '_lojax', '_closure_converted']
 
   def __init__(self, meta_tys_flat, params, in_tree, out_tree, consts,
                fun_sourceinfo):
@@ -425,6 +425,7 @@ class Traced(Stage):
     self._consts = consts
     self._fun_sourceinfo = fun_sourceinfo
     self._lojax = None
+    self._closure_converted = None
 
   jaxpr = property(lambda self: self._params['jaxpr'])
   fun_name = property(lambda self: self._params['name'])
@@ -440,6 +441,56 @@ class Traced(Stage):
     args_flat = tree_util.tree_leaves_checked(self.in_tree, (args, kwargs))
     out_flat = core.eval_jaxpr_p.bind(*args_flat, call_jaxpr=self.jaxpr)
     return tree_unflatten(self.out_tree, out_flat)
+
+  def closure_convert(self):
+    """Closure conversion: makes this Traced's captured constants explicit.
+
+    Returns a pair ``(consts, fun)``, where ``consts`` are the values this
+    Traced captured from its function's closure during tracing (not Python
+    ``__closure__`` cells: any values encountered during tracing that
+    determine the output), and ``fun`` is a closed function such that
+    ``fun(consts, *args, **kwargs)`` computes the same results as this Traced
+    applied to ``args`` and ``kwargs``. The environment ``consts`` is passed
+    as a single leading argument, and may be replaced by any pytree of values
+    of the same types.
+    """
+    if self._closure_converted is None:
+      consts = [*self.jaxpr.consts, *self._consts]
+      _, consts_tree = tree_util.tracing_registry.flatten(consts)
+      jaxpr = self.jaxpr.replace(consts=None)
+      in_tree = tree_util.treedef_tuple_tracing_registry(
+          (consts_tree, *self.in_tree.children()))
+      out_tree = self.out_tree
+      def fun(consts, *args, **kwargs):
+        args_flat = tree_util.tree_leaves_checked(in_tree, (consts, args, kwargs))
+        out_flat = core.eval_jaxpr_p.bind(*args_flat, call_jaxpr=jaxpr)
+        return tree_unflatten(out_tree, out_flat)
+      self._closure_converted = (consts, fun)
+    return self._closure_converted
+
+  def with_consts_as_arg(self) -> tuple[list[Any], Traced]:
+    """Returns consts and an equivalent Traced taking them as one leading argument.
+
+    Built on ``closure_convert``: the converted function is re-traced with the
+    consts environment as a single leading argument, so that the tracing
+    machinery reconstructs all per-argument bookkeeping consistently. The
+    non-const argument types are taken from this Traced. The retrace stages a
+    single call eqn, not a re-trace of the original function.
+    """
+    from jax._src.api import jit  # type: ignore
+    consts, fun = self.closure_convert()
+    arg_avals = self.jaxpr.in_avals[len(self._consts):]
+    args, kwargs = tree_unflatten(self.in_tree, arg_avals)
+    traced = jit(fun).trace(consts, *args, **kwargs)
+    jaxpr = traced.jaxpr
+    if (not jaxpr.consts and len(jaxpr.eqns) == 1 and
+        (eqn := jaxpr.eqns[0]).primitive is core.eval_jaxpr_p and
+        list(eqn.invars) == list(jaxpr.invars) and
+        list(eqn.outvars) == list(jaxpr.outvars)):
+      traced._params = dict(traced._params, jaxpr=eqn.params['call_jaxpr'])
+    traced._params = dict(traced._params, name=self.fun_name)
+    traced._fun_sourceinfo = self._fun_sourceinfo
+    return consts, traced
 
   @property
   def lojax(self) -> LoJax:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4284,6 +4284,16 @@ class APITest(jtu.JaxTestCase):
 
     self.assertIn('is referred to by', scope())  # doesn't crash
 
+  def test_traced_closure_convert(self):
+    x = jnp.float32(2.)
+    traced = jit(lambda y: y ** 2 * x).trace(jnp.float32(3.))
+    consts, fun = traced.closure_convert()
+    self.assertAllClose(fun(consts, jnp.float32(3.)), jnp.float32(18.))
+    self.assertAllClose(fun([jnp.float32(10.)], jnp.float32(3.)),
+                        jnp.float32(90.))
+    consts2, traced2 = traced.with_consts_as_arg()
+    self.assertAllClose(traced2(consts2, jnp.float32(3.)), jnp.float32(18.))
+
   def test_default_backend(self):
     first_local_device = jax.local_devices()[0]
     self.assertEqual(first_local_device.platform, jax.default_backend())
@@ -9303,7 +9313,7 @@ class TracebackTest(jtu.JaxTestCase):
   def test_custom_vjp_traceback(self):
     # TODO(dougalm): improve this
     expected_depth_f = 7 if config.custom_vjp3.value else 9
-    expected_depth_f_fwd = 16
+    expected_depth_f_fwd = 17 if config.custom_vjp3.value else 16
     expected_depth_f_rev = 12
     init_depth = self.cur_depth()
     @jax.custom_vjp

--- a/tests/custom_api_test.py
+++ b/tests/custom_api_test.py
@@ -3622,7 +3622,7 @@ class CustomVJP3Test(CustomVJPTest):
         """).strip()
     self.assertEqual(actual, expected)
 
-  # vmap closure: don't support anymore, but raise good errors
+  # vmap closure: supported by promoting closed-over tracers to explicit args
   def test_closed_over_vmap_tracer(self):
     def outer(x):
       @jax.custom_vjp
@@ -3639,8 +3639,9 @@ class CustomVJP3Test(CustomVJPTest):
     def g(x):
       return outer(x)(3.)
 
-    with self.assertRaisesRegex(UnexpectedTracerError, "can't close over"):
-      g(np.arange(3.))
+    ans = g(np.arange(3.))
+    expected = np.arange(3.) * 3
+    self.assertAllClose(ans, expected, check_dtypes=False)
 
   def test_closed_over_tracer3(self):
     def outer(x):
@@ -3659,8 +3660,32 @@ class CustomVJP3Test(CustomVJPTest):
     def g(x):
       return outer(x)(3.)
 
-    with self.assertRaisesRegex(UnexpectedTracerError, "can't close over"):
-      g(np.arange(3.))
+    ans = g(np.arange(3.))
+    expected = np.cos(3.) * np.arange(3.)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def test_closed_over_tracer_grad_error(self):
+    def outer(c, x):
+      @jax.custom_vjp
+      def f(y):
+        return c * y
+      f.defvjp(lambda y: (c * y, (y,)), lambda res, g: (c * g,))
+      return f(x)
+
+    with self.assertRaisesRegex(Exception, "closed-over value"):
+      api.vmap(api.grad(outer, argnums=0))(jnp.arange(3.) + 1., jnp.arange(3.))
+
+  def test_closed_over_vmap_tracer_remat(self):
+    def outer(c, x):
+      @jax.custom_vjp
+      def f(y):
+        return c * y
+      f.defvjp(lambda y: (c * y, (y,)), lambda res, g: (c * g,))
+      return jax.remat(f)(x)
+
+    ans = api.vmap(api.grad(outer, argnums=1))(jnp.arange(3.) + 1.,
+                                               jnp.arange(3.))
+    self.assertAllClose(ans, jnp.arange(3.) + 1., check_dtypes=False)
 
   def test_closure_with_vmap2(self):
     # https://github.com/jax-ml/jax/issues/8783
@@ -3681,7 +3706,10 @@ class CustomVJP3Test(CustomVJPTest):
 
       return jax.vmap(f)(jnp.arange(3., dtype='float32')).sum()
 
-    with self.assertRaisesRegex(UnexpectedTracerError, "can't close over"):
+    # Closing over a vmap tracer in the fwd rule, with vmap inside grad, isn't
+    # supported: the fwd rule's residuals capture the tracer, which is out of
+    # scope by the time the backward pass runs.
+    with self.assertRaisesRegex(UnexpectedTracerError, "unexpected tracer"):
       jtu.check_grads(h, (jnp.float32(3.14),), order=1, modes=['rev'])
 
   def test_overbatched_fwd_rule_error(self):


### PR DESCRIPTION
* add Traced.closure_convert() (of independent interest), a memoized function that returns (consts, callable), and Traced.with_consts_as_arg() which is a wrapper around closure_convert() that traces back to a Traced
* custom_vjp3: support custom_vjp's closed-over-tracers behaviors