### PR TITLE
Shorten the bazel output base on Windows.

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -149,7 +149,7 @@ jobs:
 
           # Set bazel output base on Windows runner machine
           if [[ "${RUNNER_TYPE}" == *windows-x86* ]]; then
-            printf '%s\n' 'JAXCI_BAZEL_OUTPUT_BASE=C:\actions-runner\_work\bazel_output_base' >> "$GITHUB_ENV"
+            printf '%s\n' 'JAXCI_BAZEL_OUTPUT_BASE=C:\_b' >> "$GITHUB_ENV"
           fi
 
           # Enable Bazel remote cache (with writes enabled) if building on Linux Aarch64

--- a/ci/run_bazel_test_cpu_rbe.sh
+++ b/ci/run_bazel_test_cpu_rbe.sh
@@ -48,7 +48,7 @@ bazel_output_base=""
 if [[  $os  =~ "msys_nt" ]] && [[ $arch =~ "x86_64" ]]; then
   os="windows"
   arch="amd64"
-  bazel_output_base="--output_base=C:\actions-runner\_work\bazel_output_base"
+  bazel_output_base="--output_base=C:\_b"
 fi
 
 if [[ "$JAXCI_HERMETIC_PYTHON_VERSION" == *t || "$JAXCI_HERMETIC_PYTHON_VERSION" == *-ft || "$JAXCI_HERMETIC_PYTHON_VERSION" == *-nogil ]]; then


### PR DESCRIPTION
Avoids some long path errors in CI.
