### PR TITLE
Work around Windows MAX_PATH limit in jax2tf multiprocess test

### DIFF
--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -600,3 +600,5 @@ jobs:
       clone_main_xla: 0
       xla_commit: ''
       halt-for-connection: 'no'
+
+

--- a/jax/experimental/jax2tf/tests/multiprocess/jax2tf_multiprocess_test.py
+++ b/jax/experimental/jax2tf/tests/multiprocess/jax2tf_multiprocess_test.py
@@ -14,6 +14,18 @@
 
 """Multihost test for JAX2TF."""
 
+import os
+import sys
+
+# Work around Windows MAX_PATH limit when loading C-extension DLLs (e.g. ml_dtypes)
+if os.name == "nt":
+  sys.path = [
+      f"\\\\?\\{os.path.abspath(p)}"
+      if os.path.isabs(p) and not p.startswith("\\\\?\\")
+      else p
+      for p in sys.path
+  ]
+
 import jax
 from jax import numpy as jnp
 from jax._src import pjit


### PR DESCRIPTION
Prefix absolute paths in sys.path with \\?\ on Windows to avoid DLL load errors (such as _ml_dtypes_ext) when the runfiles path exceeds MAX_PATH (260 characters).