### PR TITLE
[typing] modernize type declarations across test files

### DIFF
--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -18,7 +18,7 @@ from collections.abc import Callable
 from contextlib import contextmanager
 from functools import partial
 import itertools as it
-from typing import Any, TypeVar, Union
+from typing import Any
 
 import numpy as np
 from absl.testing import absltest
@@ -1260,7 +1260,7 @@ class BatchingTest(jtu.JaxTestCase):
 
 Array = Any
 ArrayElt = Any
-Int = Union[int, core.Tracer]
+Int = int | core.Tracer
 
 # Can't used NamedTuple here b/c those are pytrees
 class NamedArray:
@@ -1323,13 +1323,11 @@ def temporarily_register_named_array_vmappable():
   finally:
     batching.unregister_vmappable(NamedArray)
 
-a = TypeVar('a')
-
-def list_pop(lst: list[a], idx: int) -> a:
+def list_pop[T](lst: list[T], idx: int) -> T:
   lst = list(lst)
   return lst, lst.pop(idx)
 
-def list_insert(lst: list[a], idx: int, val: a) -> list[a]:
+def list_insert[T](lst: list[T], idx: int, val: T) -> list[T]:
   lst = list(lst)
   lst.insert(idx, val)
   return lst

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -24,7 +24,7 @@ import io
 import itertools
 import math
 import platform
-from typing import Union, cast
+from typing import cast
 import unittest
 from unittest import SkipTest
 
@@ -4648,7 +4648,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     [dict(shape=shape, axis=axis)
       for shape in [(3,), (3, 4), (3, 4, 5)]
       for axis in itertools.chain(range(-len(shape), len(shape)),
-                                  [cast(Union[int, None], None)])
+                                  [cast(int | None, None)])
     ],
     index_shape=scalar_shapes + [(3,), (2, 1, 3)],
     dtype=all_dtypes,
@@ -4700,7 +4700,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         filter(_shapes_are_broadcast_compatible,
                itertools.combinations_with_replacement(nonempty_nonscalar_array_shapes, 2)))
       for axis in itertools.chain(range(len(x_shape)), [-1],
-                                  [cast(Union[int, None], None)])
+                                  [cast(int | None, None)])
     ],
     dtype=default_dtypes,
     index_dtype=int_dtypes,

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from functools import partial
 import itertools
 import math
-from typing import Union, cast
+from typing import cast
 import unittest
 
 from absl.testing import absltest
@@ -72,8 +72,8 @@ class LaxVmapTest(jtu.JaxTestCase):
      for lhs_shape in [(b * batch_group_count, i * feature_group_count, 6, 7)]
      for rhs_shape in [(j * batch_group_count * feature_group_count, i, 1, 2)]],
     [dict(lhs_bdim=lhs_bdim, rhs_bdim=rhs_bdim)
-        for lhs_bdim in itertools.chain([cast(Union[int, None], None)], range(5))
-        for rhs_bdim in itertools.chain([cast(Union[int, None], None)], range(5))
+        for lhs_bdim in itertools.chain([cast(int | None, None)], range(5))
+        for rhs_bdim in itertools.chain([cast(int | None, None)], range(5))
         if (lhs_bdim, rhs_bdim) != (None, None)
     ],
     [dict(dimension_numbers=dim_nums, perms=perms)

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -21,7 +21,7 @@ import math
 from random import shuffle
 import re
 import gc
-from typing import Union, cast
+from typing import cast
 import unittest
 from unittest import SkipTest
 
@@ -53,7 +53,7 @@ jtu.request_cpu_devices(8)
 compatible_shapes = [[(3,)], [(3, 4), (3, 1), (1, 4)], [(2, 3, 4), (2, 1, 4)]]
 
 def all_bdims(*shapes):
-  bdims = (it.chain([cast(Union[int, None], None)], range(len(shape) + 1))
+  bdims = (it.chain([cast(int | None, None)], range(len(shape) + 1))
            for shape in shapes)
   return (t for t in it.product(*bdims) if not all(e is None for e in t))
 

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -20,7 +20,7 @@ import itertools as it
 import math
 import operator as op
 from types import SimpleNamespace
-from typing import Any, NamedTuple, TypeVar
+from typing import Any, NamedTuple
 import unittest
 
 from absl.testing import absltest
@@ -5834,15 +5834,14 @@ def make_out_spec(
 
 # Combinatorial helper functions
 
-T = TypeVar('T')
-def partitions(s: Sequence[T], k: int) -> Iterator[list[list[T]]]:
+def partitions[T](s: Sequence[T], k: int) -> Iterator[list[list[T]]]:
   for indices in it.product(range(k), repeat=len(s)):
     outs: list[list[T]] = [[] for _ in range(k)]
     for i, elt in zip(indices, s):
       outs[i].append(elt)
     yield outs
 
-def powerset(s: Iterable[T]) -> Iterator[Sequence[T]]:
+def powerset[T](s: Iterable[T]) -> Iterator[Sequence[T]]:
   s = list(s)
   return it.chain.from_iterable(it.combinations(s, r) for r in range(len(s)+1))
 

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from functools import partial
 import itertools as it
-from typing import Any, NamedTuple, Union
+from typing import Any, NamedTuple
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -1033,7 +1033,7 @@ def set_vmap_params(draw):
                             elements=_float_elements))
   return SetVmapParams(vmap_index_param, bat_ref, bat_val, bat_idxs)
 
-Indexer = tuple[Union[int, slice, np.ndarray]]
+Indexer = tuple[int | slice | np.ndarray, ...]
 
 def _unpack_idx(idx: Indexer
     ) -> tuple[Sequence[int | np.ndarray], Sequence[bool]]:


### PR DESCRIPTION
Limiting to test files because these should be safe from rollbacks.