### PR TITLE
[ROCm] Name ROCm CI jobs after the ROCm release they test

### DIFF
--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -137,7 +137,7 @@ jobs:
       HSA_NO_SCRATCH_RECLAIM: "1"
 
 # Begin Presubmit Naming Check - name modification requires internal check to be updated
-    name: "linux x86, py${{ inputs.python }}, ROCM=${{ inputs.rocm-version }}, jaxlib=${{ inputs.jaxlib-version }}, x64=${{ inputs.enable-x64 }}, build_jax=${{ inputs.build_jax }}, build_jaxlib=${{ inputs.build_jaxlib }}"
+    name: "linux x86, py${{ inputs.python }}, ROCM=${{ inputs.rocm-release-version || inputs.rocm-version }}, jaxlib=${{ inputs.jaxlib-version }}, x64=${{ inputs.enable-x64 }}, build_jax=${{ inputs.build_jax }}, build_jaxlib=${{ inputs.build_jaxlib }}"
 # End Presubmit Naming Check github-rocm-presubmits
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -135,7 +135,7 @@ jobs:
       JAXCI_CLONE_MAIN_XLA: "${{ inputs.clone_main_xla }}"
       JAXCI_OUTPUT_DIR: "${{ github.workspace }}/dist"
 
-    name: "${{ inputs.artifact }}, py ${{ inputs.python }}, ROCm ${{ inputs.rocm-version }}"
+    name: "${{ inputs.artifact }}, py ${{ inputs.python }}, ROCm ${{ inputs.rocm-release-version || inputs.rocm-version }}"
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -134,9 +134,9 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
       options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
-    name: "${{ (contains(inputs.runner, 'gfx950.1') && 'gfx950.1') ||
-        (contains(inputs.runner, 'gfx950.4') && 'gfx950.4') ||
-        (contains(inputs.runner, 'gfx950.8') && 'gfx950.8') }}, ROCm ${{ inputs.rocm-version }}, py${{ inputs.python }}"
+    name: "${{ (contains(inputs.runner, 'gfx950.1') && 'gfx950 1-GPU') ||
+        (contains(inputs.runner, 'gfx950.4') && 'gfx950 4-GPU') ||
+        (contains(inputs.runner, 'gfx950.8') && 'gfx950 8-GPU') }}, ROCm ${{ inputs.rocm-release-version || inputs.rocm-version }}, py${{ inputs.python }}"
 
     env:
       JAXCI_HERMETIC_PYTHON_VERSION: "${{ inputs.python }}"

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -511,7 +511,7 @@ jobs:
               python: "3.13"
             - artifact: "jax-rocm-pjrt"
               python: "3.14"
-    name: "Build ROCm artifacts (${{ matrix.rocm.label }})"
+    name: "Build ROCm artifacts ${{ matrix.rocm.label }}"
     with:
       runner: ${{ matrix.runner }}
       artifact: ${{ matrix.artifact }}
@@ -547,7 +547,7 @@ jobs:
           rocm: [
             {label: "TheRock 7.14.0", wheel-version: "7", release-version: "7.14.0", tag: "therock-7.14"},
           ]
-    name: "Pytest ROCm (${{ matrix.rocm.label }})"
+    name: "Pytest ROCm ${{ matrix.rocm.label }}"
     with:
       runner: ${{ matrix.runner }}
       python: ${{ matrix.python }}
@@ -577,13 +577,13 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          runner: ["amd-do-linux.jax.gpu.gfx950.4", "amd-do-linux.jax.gpu.gfx950.8"]
+          runner: ["amd-do-linux.jax.gpu.gfx950.4"]
           python: ["3.12"]
           rocm: [
             {label: "TheRock 7.14.0", wheel-version: "7", release-version: "7.14.0", tag: "therock-7.14"},
           ]
           enable-x64: [0]
-    name: "Bazel ROCm (${{ matrix.rocm.label }})"
+    name: "Bazel ROCm ${{ matrix.rocm.label }}"
     with:
       runner: ${{ matrix.runner }}
       python: ${{ matrix.python }}

--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -182,14 +182,14 @@ jobs:
           python: ["3.12", "3.13", "3.14"]
           rocm: [
             {label: "TheRock 7.14.0", wheel-version: "7", release-version: "7.14.0", manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-7.14:latest" },
-            {label: "TheRock latest", wheel-version: "10", release-version: "therock-latest", manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-latest:latest"},
+            {label: "TheRock Next (pre-release)", wheel-version: "10", release-version: "therock-latest", manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-latest:latest"},
           ]
           exclude:
             - artifact: "jax-rocm-pjrt"
               python: "3.13"
             - artifact: "jax-rocm-pjrt"
               python: "3.14"
-    name: "Build ROCm artifacts (${{ matrix.rocm.label }})"
+    name: "Build ROCm artifacts ${{ matrix.rocm.label }}"
     with:
       runner: ${{ matrix.runner }}
       artifact: ${{ matrix.artifact }}
@@ -216,9 +216,9 @@ jobs:
           python: ["3.12", "3.13", "3.14"]
           rocm: [
             {label: "TheRock 7.14.0", wheel-version: "7", release-version: "7.14.0", tag: "therock-7.14"},
-            {label: "TheRock latest", wheel-version: "10", release-version: "therock-latest", tag: "therock-latest"},
+            {label: "TheRock Next (pre-release)", wheel-version: "10", release-version: "therock-latest", tag: "therock-latest"},
           ]
-    name: "Pytest ROCm (${{ matrix.rocm.label }})"
+    name: "Pytest ROCm ${{ matrix.rocm.label }}"
     with:
       runner: ${{ matrix.runner }}
       python: ${{ matrix.python }}
@@ -244,10 +244,10 @@ jobs:
           python: ["3.12", "3.13", "3.14"]
           rocm: [
             {label: "TheRock 7.14.0", wheel-version: "7", release-version: "7.14.0", tag: "therock-7.14"},
-            {label: "TheRock latest", wheel-version: "10", release-version: "therock-latest", tag: "therock-latest"},
+            {label: "TheRock Next (pre-release)", wheel-version: "10", release-version: "therock-latest", tag: "therock-latest"},
           ]
           enable-x64: [0]
-    name: "Bazel ROCm (${{ matrix.rocm.label }})"
+    name: "Bazel ROCm ${{ matrix.rocm.label }}"
     with:
       runner: ${{ matrix.runner }}
       python: ${{ matrix.python }}


### PR DESCRIPTION
As we discussed in G chat , this is an effort to simplify flow names such that one can identify which flow is run for pre-release rocm and which is for current release. new flow name table below.

| Flow | Job | Old | New |
|---|---|---|---|
| Nightly | Build artifacts, pre-release | `Build ROCm artifacts (TheRock latest) / jax-rocm-plugin, py 3.12, ROCm 10` | `Build ROCm artifacts TheRock Next (pre-release) / jax-rocm-plugin, py 3.12, ROCm therock-latest` |
| Nightly | Build artifacts, release | `Build ROCm artifacts (TheRock 7.14.0) / jax-rocm-plugin, py 3.12, ROCm 7` | `Build ROCm artifacts TheRock 7.14.0 / jax-rocm-plugin, py 3.12, ROCm 7.14.0` |
| Nightly | Pytest, pre-release | `Pytest ROCm (TheRock latest) / gfx950.8, ROCm 10, py3.12` | `Pytest ROCm TheRock Next (pre-release) / gfx950 8-GPU, ROCm therock-latest, py3.12` |
| Nightly | Pytest, release | `Pytest ROCm (TheRock 7.14.0) / gfx950.8, ROCm 7, py3.12` | `Pytest ROCm TheRock 7.14.0 / gfx950 8-GPU, ROCm 7.14.0, py3.12` |
| Nightly | Bazel, pre-release | `Bazel ROCm (TheRock latest) / linux x86, py3.12, ROCM=10, ...` | `Bazel ROCm TheRock Next (pre-release) / linux x86, py3.12, ROCM=therock-latest, ...` |
| Nightly | Bazel, release | `Bazel ROCm (TheRock 7.14.0) / linux x86, py3.12, ROCM=7, ...` | `Bazel ROCm TheRock 7.14.0 / linux x86, py3.12, ROCM=7.14.0, ...` |
| Continuous | Build artifacts | `Build ROCm artifacts (TheRock 7.14.0) / jax-rocm-plugin, py 3.12, ROCm 7` | `Build ROCm artifacts TheRock 7.14.0 / jax-rocm-plugin, py 3.12, ROCm 7.14.0` |
| Continuous | Pytest | `Pytest ROCm (TheRock 7.14.0) / gfx950.4, ROCm 7, py3.12` | `Pytest ROCm TheRock 7.14.0 / gfx950 4-GPU, ROCm 7.14.0, py3.12` |
| Continuous | Bazel | `Bazel ROCm (TheRock 7.14.0) / linux x86, py3.12, ROCM=7, ...` — 2 identical jobs | `Bazel ROCm TheRock 7.14.0 / linux x86, py3.12, ROCM=7.14.0, ...` — 1 job |
| Presubmit | Bazel, `run-tests` | `Bazel ROCm / Test / linux x86, py3.14, ROCM=7, ...` | `Bazel ROCm / Test / linux x86, py3.14, ROCM=7.14.0, ...` |
| Presubmit | Bazel, blocking gate | `Bazel ROCm / ROCm blocking gate / linux x86, py3.12, ROCM=7, ...` | `Bazel ROCm / ROCm blocking gate / linux x86, py3.12, ROCM=7.14.0, ...` |

Also dropped duplicate bazel run cont . 2nd run should be using pypi_latest. at the moment to save HW load we will drop this. but we will continue to run pypi_latest option in per PR bazel tests. I think we dont loose coverage becuase of this new change.
