### PR TITLE
[custom_vjp3] set_current_trace in hijax staging for pytree ctx dependence

### DIFF
--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -400,9 +400,10 @@ core.custom_typechecks[call_hi_primitive_p] = _call_hi_primitive_typecheck
 
 def _call_hi_primitive_staging(trace, source_info, *args_flat, _prim):
   trace.frame.is_high = True
-  args = tree_unflatten(_prim.in_tree, args_flat)
-  ans = _prim.staging(trace, source_info, *args)
-  return tree_leaves_checked(_prim.out_tree, ans)
+  with core.set_current_trace(trace):  # user pytree hooks may ask for the trace
+    args = tree_unflatten(_prim.in_tree, args_flat)
+    ans = _prim.staging(trace, source_info, *args)
+    return tree_leaves_checked(_prim.out_tree, ans)
 pe.custom_staging_rules[call_hi_primitive_p] = _call_hi_primitive_staging
 
 def _call_hi_primitive_to_lojax(*args_flat, _prim):

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -2532,6 +2532,35 @@ class HijaxTest(jtu.JaxTestCase):
     out_tangent = f_lin(jnp.ones((5,)))
     self.assertArraysEqual(out_tangent, jnp.zeros((5,)))
 
+  def test_staging_pytree_hooks_see_current_trace(self):
+    from jax._src.hijax import custom_vjp3
+    from jax.extend.core import get_opaque_trace_state
+
+    @jax.tree_util.register_pytree_node_class
+    class Box:
+      def __init__(self, x):
+        self.x = x
+
+      def tree_flatten(self):
+        return (self.x,), None
+
+      @classmethod
+      def tree_unflatten(cls, _, xs):
+        get_opaque_trace_state()  # flax's nnx.Variable does this
+        return cls(*xs)
+
+    @custom_vjp3
+    def f(box):
+      return Box(box.x * 2)
+
+    f.defvjp(lambda box: (Box(box.x * 2), ()),
+             lambda res, g: (Box(g.x * 2),))
+
+    out = jax.jit(lambda b: f(b).x)(Box(jnp.float32(3.)))
+    self.assertAllClose(out, jnp.float32(6.))
+    g = jax.jit(jax.grad(lambda b: f(b).x))(Box(jnp.float32(3.)))
+    self.assertAllClose(g.x, jnp.float32(2.))
+
 
 class RefTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Custom pytree nodes (like Flax's) might call get_opaque_trace_state in their flatten/unflatten functions, so we set the trace context. Classic custom_vjp only flattens in the user scope, vs with custom_vjp3 we have pytrees built into the hijax primitive.