### PR TITLE
[ROCm] Make test_vmap_ellipsis insensitive to reduced-precision matmuls

### DIFF
--- a/tests/lax_numpy_hijax_test.py
+++ b/tests/lax_numpy_hijax_test.py
@@ -782,6 +782,9 @@ class EinsumTest(jtu.JaxTestCase):
     actual = hijax.einsum("...jk,kl->...jl", x, y)
     self.assertAllClose(expected, actual, atol=1e-5, rtol=1e-5)
 
+  # Set the highest precision here so that on platforms like ROCm we avoid one
+  # dot compiling to xf32 and the other to FMA, which makes the results disagree.
+  @jax.default_matmul_precision("float32")
   def test_vmap_ellipsis(self):
     x = self.rng().uniform(size=(5, 2, 3, 4))
     y = self.rng().uniform(size=(4, 5))


### PR DESCRIPTION
EinsumTest.test_vmap_ellipsis compares hijax.einsum against jnp.einsum for the same contraction. Under vmap the two lower to transposed dots, dot(f32[4,5], f32[4,30]) and dot(f32[30,4], f32[4,5]) , and with f32 DEFAULT precision a dot may be compiled to an xf32 matrix instruction on gfx942, which keeps only the top 10 mantissa bits. When only one of the two is, they disagree by ~1e-3 and the rtol=1e-5 assertion fails. hence we set the test to use
highest precision decorator.