### PR TITLE
[shape_poly] Add symbolic_dim_bounds API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 
 ## Unreleased
 
+* New features
+  * Added {func}`jax.export.symbolic_dim_bounds` for querying conservative
+    bounds on symbolic dimension expressions ({jax-issue}`#40006`).
+
 * Changes
   * JAX now uses Bazel 8.7.0 to build from source.
   * JAX now uses Bzlmod for its Bazel builds instead of WORKSPACE.

--- a/docs/export/shape_poly.md
+++ b/docs/export/shape_poly.md
@@ -413,6 +413,26 @@ Just like the implicit constraints, the explicit
 symbolic constraints are checked at compile time,
 using the same mechanism as explained [below](#shape-assertion-errors).
 
+#### Inspecting symbolic dimension bounds
+
+You can inspect the inclusive bounds that JAX can prove for a symbolic
+dimension or an expression derived from symbolic dimensions. The bounds are
+conservative and may not be tight. An infinite bound means that JAX could not
+establish a finite bound; it does not prove that the dimension is
+mathematically unbounded.
+
+```python
+>>> batch, free = export.symbolic_shape(
+...     "batch, free", constraints=("batch >= 128", "batch <= 1024"))
+>>> export.symbolic_dim_bounds(batch)
+(128, 1024)
+>>> export.symbolic_dim_bounds(2 * batch + 1)
+(257, 2049)
+>>> export.symbolic_dim_bounds(free)
+(1, inf)
+
+```
+
 #### Symbolic dimension scopes
 
 The symbolic constraints are stored in αn

--- a/docs/jax.export.rst
+++ b/docs/jax.export.rst
@@ -43,6 +43,7 @@ Functions related to shape polymorphism
   symbolic_shape
   symbolic_args_specs
   is_symbolic_dim
+  symbolic_dim_bounds
   SymbolicScope
 
 Constants

--- a/jax/_src/export/shape_poly.py
+++ b/jax/_src/export/shape_poly.py
@@ -1227,6 +1227,32 @@ def is_symbolic_dim(p: DimSize) -> TypeGuard[_DimExpr]:
   """
   return isinstance(p, _DimExpr)
 
+
+def symbolic_dim_bounds(
+    dimension: DimSize | SupportsIndex,
+) -> tuple[float, float]:
+  """Returns inclusive bounds that JAX can prove for a dimension expression.
+
+  The returned bounds are conservative and may not be tight. Infinite bounds
+  mean that JAX could not establish a finite bound; they do not prove that the
+  dimension is unbounded.
+
+  Args:
+    dimension: An integer or symbolic dimension expression.
+
+  Returns:
+    A ``(lower_bound, upper_bound)`` pair. A lower bound of ``-inf`` or an
+    upper bound of ``inf`` means that JAX did not establish a finite bound.
+
+  Raises:
+    TypeError: If ``dimension`` is not an integer or symbolic dimension.
+    jax.errors.InconclusiveDimensionOperation: If the bounds cannot be computed
+      because JAX cannot prove that an operation in the expression is defined.
+  """
+  resolved_dimension: DimSize = core.concrete_dim_or_error(
+      dimension, "argument `dimension` of `symbolic_dim_bounds`")
+  return _bounds_decision(resolved_dimension, BoundsPrecision.BEST)
+
 dtypes.python_scalar_types.add(_DimExpr)
 dtypes.python_scalar_types_to_dtypes[_DimExpr] = dtypes.python_scalar_types_to_dtypes[int]
 dtypes.register_canonicalize_value_handler(_DimExpr, None)

--- a/jax/export.py
+++ b/jax/export.py
@@ -18,6 +18,7 @@ __all__ = ["DisabledSafetyCheck", "Exported", "export", "deserialize",
            "minimum_supported_calling_convention_version",
            "default_export_platform",
            "SymbolicScope", "is_symbolic_dim",
+           "symbolic_dim_bounds",
            "symbolic_shape", "symbolic_args_specs"]
 
 from jax._src.export._export import (
@@ -36,5 +37,6 @@ del shape_poly_decision
 from jax._src.export.shape_poly import (
   SymbolicScope,
   is_symbolic_dim,
+  symbolic_dim_bounds,
   symbolic_shape,
   symbolic_args_specs)

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -433,6 +433,32 @@ class DimExprTest(jtu.JaxTestCase):
     z = core.max_dim(-1, core.min_dim(1, a - 5))
     self.assertEqual((-np.inf, np.inf), _bounds(z * a))
 
+  def test_symbolic_dim_bounds(self):
+    m, n, free1, free2 = export.symbolic_shape(
+        "m, n, free1, free2",
+        constraints=("m >= 2", "m <= 8", "n >= 3", "n <= 10"),
+    )
+
+    self.assertEqual(export.symbolic_dim_bounds(np.int32(7)), (7, 7))
+    self.assertEqual(export.symbolic_dim_bounds(m), (2, 8))
+    self.assertEqual(export.symbolic_dim_bounds(m * n + 1), (7, 81))
+    self.assertEqual(export.symbolic_dim_bounds(free1), (1, np.inf))
+    self.assertEqual(
+        export.symbolic_dim_bounds(5 - free1), (-np.inf, 4))
+    self.assertEqual(
+        export.symbolic_dim_bounds(free1 - free2), (-np.inf, np.inf))
+
+    with self.assertRaises(TypeError):
+      export.symbolic_dim_bounds(1.5)
+
+  def test_symbolic_dim_bounds_propagates_inconclusive_operation(self):
+    a, b = export.symbolic_shape("a, b")
+    with self.assertRaisesRegex(
+        jax.errors.InconclusiveDimensionOperation,
+        "Possible division by 0",
+    ):
+      export.symbolic_dim_bounds(a // (b - 1))
+
   def test_bounds_mod(self):
     a, b = shape_poly.symbolic_shape("a, b")
 

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -156,6 +156,16 @@ if TYPE_CHECKING:
   assert_type(vals, jax.Array)
   assert_type(mask, jax.Array)
 
+  symbolic_dim, = jax.export.symbolic_shape("symbolic_dim")
+  assert_type(
+      jax.export.symbolic_dim_bounds(symbolic_dim),
+      tuple[float, float],
+  )
+  assert_type(
+      jax.export.symbolic_dim_bounds(np.int32(7)),
+      tuple[float, float],
+  )
+
   # Functions with non-trivial typing overloads:
   # jnp.linspace
   assert_type(jnp.linspace(0, 10), jax.Array)


### PR DESCRIPTION
## Summary

Adds `jax.export.symbolic_dim_bounds`, a public API for querying conservative
bounds that JAX can prove for a symbolic dimension or a derived expression.

The API exposes JAX's existing symbolic bounds decision procedure through a
supported public interface. Bounds are inclusive and may not be tight; infinite
endpoints mean JAX could not establish a finite bound.

This supports consumers that need a safe upper bound for intermediate symbolic
expressions, such as sizing workspace buffers during ahead-of-time kernel
compilation. This change does not add new constraint reasoning.

## Testing

Added public API, typing, constraint-composition, and solver soundness coverage,
tested with both default and x64 configurations.