### PR TITLE
fix(scipy.signal): use default nperseg=256 in _triage_segments

### DIFF
--- a/jax/_src/third_party/scipy/signal_helper.py
+++ b/jax/_src/third_party/scipy/signal_helper.py
@@ -42,7 +42,10 @@ def _triage_segments(window: ArrayLike | str | tuple[Any, ...], nperseg: int | N
       256. If window is array_like, nperseg is set to the length of the window.
   """
   if isinstance(window, (str, tuple)):
-    nperseg_int = input_length if nperseg is None else int(nperseg)
+    if nperseg is None:
+      nperseg_int = 256
+    else:
+      nperseg_int = int(nperseg)
     if nperseg_int > input_length:
       warnings.warn(f'nperseg={nperseg_int} is greater than {input_length=},'
                     f' using nperseg={input_length}')

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -341,6 +341,27 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, rtol=tol, atol=tol)
     self._CompileAndCheck(jsp_fun, args_maker, rtol=tol, atol=tol)
 
+  def testWelchDefaultNperseg(self):
+    # Regression test for #40012: default nperseg should be 256 when input_length > 256
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=1000).astype(np.float32)
+    f_osp, pxx_osp = osp_signal.welch(x)
+    f_jsp, pxx_jsp = jsp_signal.welch(x)
+    self.assertEqual(f_jsp.shape, (129,))
+    self.assertEqual(pxx_jsp.shape, (129,))
+    self.assertAllClose(
+        f_jsp.astype(_real_dtype(np.float32)),
+        f_osp.astype(_real_dtype(np.float32)),
+        rtol=1e-5,
+        atol=1e-5,
+    )
+    self.assertAllClose(
+        pxx_jsp.astype(_real_dtype(np.float32)),
+        pxx_osp.astype(_real_dtype(np.float32)),
+        rtol=1e-5,
+        atol=1e-5,
+    )
+
   @jtu.sample_product(
     [dict(shape=shape, nperseg=nperseg, noverlap=noverlap, timeaxis=timeaxis)
       for shape, nperseg, noverlap, timeaxis in welch_test_shapes
@@ -353,8 +374,6 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
   def testWelchWithDefaultStepArgsAgainstNumpy(
       self, *, shape, dtype, nperseg, noverlap, use_nperseg, use_noverlap,
       use_window, timeaxis):
-    if tuple(shape) == (2, 3, 389, 5) and nperseg == 17 and noverlap == 13:
-      raise unittest.SkipTest("Test fails for these inputs")
     kwargs = {'axis': timeaxis}
 
     if use_nperseg:
@@ -368,7 +387,11 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
     def osp_fun(x):
       freqs, Pxx = osp_signal.welch(x, **kwargs)
       return freqs.astype(_real_dtype(dtype)), Pxx.astype(_real_dtype(dtype))
-    jsp_fun = partial(jsp_signal.welch, **kwargs)
+
+    @jtu.ignore_warning(message="nperseg")
+    def jsp_fun(x):
+      return jsp_signal.welch(x, **kwargs)
+
     tol = {
         np.float32: 1e-5, np.float64: 1e-12,
         np.complex64: 1e-5, np.complex128: 1e-12


### PR DESCRIPTION
## Summary

Fixes #40012.

When \
perseg\ is not specified (\
perseg=None\) in \jax.scipy.signal.welch\, \csd\, or \_spectral_helper\, \_triage_segments\ incorrectly assigned \
perseg_int = input_length\ rather than the default of \256\. For inputs longer than 256 samples, this caused the segment length to equal the full signal length, producing incorrect PSD frequency bins and periodogram dimensions compared to \scipy.signal.welch\.

## Root Cause

In \jax/_src/third_party/scipy/signal_helper.py\, \_triage_segments\ handled string/tuple windows with:
\\\python
nperseg_int = input_length if nperseg is None else int(nperseg)
\\\
Per \scipy.signal\ specification and the function's own docstring, when \window\ is specified as a string/tuple and \
perseg\ is \None\, \
perseg\ should default to \256\ (and subsequently clamp to \input_length\ with a warning if \
perseg > input_length\).

## What Changed

- Updated \_triage_segments\ in \jax/_src/third_party/scipy/signal_helper.py\ to initialize \
perseg_int = 256\ when \
perseg is None\.
- Added unit test \	estWelchDefaultNperseg\ in \	ests/scipy_signal_test.py\ to assert that \jax.scipy.signal.welch\ with default \
perseg\ produces matching output shapes and numerical values against \scipy.signal.welch\ for signals with \input_length > 256\.
- Removed obsolete \SkipTest\ on input shape \(2, 3, 389, 5)\ in \	estWelchWithDefaultStepArgsAgainstNumpy\ which was previously triggered by the \
perseg=None\ mismatch.

## Validation

- Verified reproduction from #40012: \x\ with shape \(100000,)\ now outputs \.shape == (129,)\ and \Pxx.shape == (129,)\, matching SciPy.
- Verified short input handling (\input_length < 256\) continues to clamp to \input_length\ and issue warning as expected.
- Regression tests added.