### PR TITLE
Fix free-threaded C extension builds on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -509,7 +509,7 @@ common:rbe_windows_amd64 --enable_runfiles
 common:rbe_windows_amd64 --define=override_eigen_strong_inline=true
 
 # Don't build the python zip archive in the RBE build.
-common:rbe_windows_amd64 --nobuild_python_zip
+# common:rbe_windows_amd64 --nobuild_python_zip
 
 common:rbe_windows_amd64 --config=ci_windows_amd64
 

--- a/.github/workflows/bazel_cpu_presubmit.yml
+++ b/.github/workflows/bazel_cpu_presubmit.yml
@@ -45,7 +45,16 @@ jobs:
             # Runner OS and Python values need to match the matrix stategy in the CPU tests job
             runner: ["linux-x86-n4-16", "linux-arm64-c4a-16", "windows-x86-n2-16"]
             artifact: ["jaxlib"]
-            python: ["3.14"]
+            python: ["3.14", "3.14t", "3.15t"]
+            exclude:
+              - runner: "linux-x86-n4-16"
+                python: "3.14t"
+              - runner: "linux-x86-n4-16"
+                python: "3.15t"
+              - runner: "linux-arm64-c4a-16"
+                python: "3.14t"
+              - runner: "linux-arm64-c4a-16"
+                python: "3.15t"
     # Note: For reasons unknown, Github actions groups jobs with the same top-level name in the
     # dashboard only if we use an expression in the "name" field. Otherwise, it appends the matrix
     # values to the name and creates a separate entry for each matrix combination.
@@ -62,8 +71,9 @@ jobs:
     uses: ./.github/workflows/bazel_cpu.yml
 # Begin Presubmit Naming Check - name modification requires internal check to be updated
     strategy:
+      fail-fast: false # don't cancel all jobs on failure
       matrix:
-        python: ["3.12", "3.14"]
+        python: ["3.12", "3.14", "3.14t", "3.15t"]
         runner: ["linux-x86-n4-16", "linux-arm64-c4a-16", "windows-x86-n2-16"]
         enable-x64: [1, 0]
         enable-bzlmod: [1, 0]
@@ -81,6 +91,24 @@ jobs:
               runner: "windows-x86-n2-16"
             # TODO: Just test against Python 3.12 without Bzlmod to avoid adding too much CI load.
             - python: "3.14"
+              enable-bzlmod: 0
+            # Exclude 3.14t on non-Windows runners and non-default flags
+            - python: "3.14t"
+              runner: "linux-x86-n4-16"
+            - python: "3.14t"
+              runner: "linux-arm64-c4a-16"
+            - python: "3.14t"
+              enable-x64: 0
+            - python: "3.14t"
+              enable-bzlmod: 0
+            # Exclude 3.15t on non-Windows runners and non-default flags
+            - python: "3.15t"
+              runner: "linux-x86-n4-16"
+            - python: "3.15t"
+              runner: "linux-arm64-c4a-16"
+            - python: "3.15t"
+              enable-x64: 0
+            - python: "3.15t"
               enable-bzlmod: 0
     name: "${{ (contains(matrix.runner, 'linux-x86') && 'Test' || 'Build') }}"
 # End Presubmit Naming Check github-cpu-presubmits

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -100,6 +100,7 @@ single_version_override(
         "//third_party/py:rules_python_local_wheel.patch",
         "//third_party/py:rules_python_cpython_3_15.patch",
         "//third_party/py:rules_python_windows_long_paths.patch",
+        "//third_party/py:rules_python_freethreaded_windows.patch",
     ],
     version = "2.2.0",
 )

--- a/ci/run_bazel_test_cpu_rbe.sh
+++ b/ci/run_bazel_test_cpu_rbe.sh
@@ -112,6 +112,7 @@ bazel $bazel_output_base $JAXCI_BAZEL_CPU_RBE_MODE \
     $BZLMOD_CONFIG \
     --profile="$TEST_ARTIFACTS_DIR/bazel_profile.json.gz" \
     --build_runfile_links=false \
+    --keep_going \
     --config=$rbe_config \
     --repo_env=HERMETIC_PYTHON_VERSION="$JAXCI_HERMETIC_PYTHON_VERSION" \
     --@rules_python//python/config_settings:py_freethreaded="$FREETHREADED_FLAG_VALUE" \

--- a/third_party/py/rules_python_freethreaded_windows.patch
+++ b/third_party/py/rules_python_freethreaded_windows.patch
@@ -1,0 +1,15 @@
+diff --git a/python/private/hermetic_runtime_repo_setup.bzl b/python/private/hermetic_runtime_repo_setup.bzl
+index b33ea71..1bc3ebc 100644
+--- a/python/private/hermetic_runtime_repo_setup.bzl
++++ b/python/private/hermetic_runtime_repo_setup.bzl
+@@ -118,6 +118,10 @@ def define_hermetic_runtime_toolchain_impl(
+             "//conditions:default": None,
+         }),
+         hdrs = [":includes"],
++        defines = select({
++            _IS_FREETHREADED_YES: ["Py_GIL_DISABLED=1"],
++            "//conditions:default": [],
++        }),
+         includes = [
+             "include",
+         ] + select({


### PR DESCRIPTION
Add rules_python_freethreaded_windows.patch to set Py_GIL_DISABLED=1 when compiling against free-threaded Python, preventing MSVC from linking the wrong CPython import library.
