### PR TITLE
Document that buffer donation is disabled under jax_debug_nans

### DIFF
--- a/docs/buffer_donation.md
+++ b/docs/buffer_donation.md
@@ -90,3 +90,35 @@ y = jax.device_put(np.ones((1, 3)))  # `y` has different shape than the output
 z = jax.jit(add, donate_argnums=(1,))(x, y)
 # >> UserWarning: Some donated buffers were not usable: f32[1,3]{1,0}
 ```
+
+(buffer-donation-debug-nans)=
+## Donation is disabled under `jax_debug_nans`
+
+Buffer donation is disabled while the `jax_debug_nans` configuration option
+(see {func}`jax.debug_nans`) is enabled. When that mode detects an invalid
+value in the output of a compiled function, JAX re-runs the function without
+`jit` on the original arguments to locate the operation that produced it, and
+that re-run needs the input buffers that donation would have invalidated.
+Donation requests are silently ignored in this mode; there is no warning.
+
+Donation is dropped when the function is traced and compiled, and the compiled
+function is cached. So a `jax.jit`-compiled function first called while
+`jax_debug_nans` is enabled keeps ignoring its donation request even after the
+option is disabled, until the cached executable is dropped:
+
+```python
+f = jax.jit(lambda x: x + 1, donate_argnums=(0,))
+
+with jax.debug_nans(True):
+  f(x)  # Donation is ignored, and the compiled function is cached.
+
+f(y)  # Still no donation: this reuses the cached executable.
+f.clear_cache()
+f(z)  # Donates again.
+```
+
+Conversely, an executable compiled before the option was enabled keeps
+donating while it is on. (`jax.pmap` re-derives donation on every call, so it
+is only affected while the option is enabled.)
+
+The `jax_debug_infs` option does not currently disable buffer donation.

--- a/docs/debugging/flags.md
+++ b/docs/debugging/flags.md
@@ -86,6 +86,7 @@ with jax.debug_nans(False):
 ##### Limitations
 * Re-running functions eagerly can be slow. You shouldn't have the NaN-checker on if you're not debugging, as it can introduce lots of device-host round-trips and performance regressions.
 * Errors on false positives (e.g. intentionally created NaNs)
+* Disables buffer donation: `donate_argnums`/`donate_argnames` requests are silently ignored in functions compiled while `jax_debug_nans` is enabled, because the de-optimized re-run needs the input buffers (see {ref}`buffer-donation-debug-nans`)
 
 ## `jax_debug_infs` configuration option and context manager
 

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -284,6 +284,11 @@ def jit(
       parameters listed in either ``donate_argnums`` or ``donate_argnames`` will
       be donated.
 
+      Donation is ignored (with no warning) in functions compiled while the
+      ``jax_debug_nans`` configuration option is enabled, since that debugging
+      mode needs the input buffers to re-run the function when an invalid
+      value is detected.
+
       For more details on buffer donation see the
       `FAQ <https://docs.jax.dev/en/latest/faq.html#buffer-donation>`_.
     donate_argnames: optional, a string or collection of strings specifying

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -1282,7 +1282,9 @@ debug_nans = bool_state(
     help=('Add nan checks to every operation. When a nan is detected on the '
           'output of a jit-compiled computation, call into the un-compiled '
           'version in an attempt to more precisely identify the operation '
-          'which produced the nan.'))
+          'which produced the nan. Enabling this option disables buffer '
+          'donation: donation requests are ignored in functions compiled '
+          'while it is enabled.'))
 
 debug_infs = bool_state(
     name='jax_debug_infs',


### PR DESCRIPTION
Fixes #33949.

Buffer donation is silently skipped for functions compiled while jax_debug_nans is enabled. That's intentional (#13144, fixing #12514: the nan debugger re-runs the un-jitted function on the original arguments, which donation would have destroyed), but it wasn't documented anywhere, so it's easy to lose time wondering why donate_argnums stopped working.

This adds a note in four places: the donate_argnums section of the jax.jit docstring, the jax_debug_nans help string (which is also what the config options page and the jax.debug_nans docstring render), a short section in the buffer donation doc, and the limitations list in the debugging flags doc.

It also covers the two subtleties from the issue thread: donation is dropped at compile time and stays off for cached executables until clear_cache(), and debug_infs currently does not disable donation.

