### PR TITLE
[mosaic:gpu] Right-align splat/tiled layout compatibility

### DIFF
--- a/jax/experimental/mosaic/gpu/layouts.py
+++ b/jax/experimental/mosaic/gpu/layouts.py
@@ -139,10 +139,14 @@ def splat_is_compatible_with_tiled(
     l1: fa.WGSplatFragLayout, l2: fa.TiledLayout
 ) -> bool:
   # A splat layout is compatible with a tiled layout up to replication if each
-  # dimension in the shape of the splat layout is divisible by the corresponding
-  # dimension in the base tile shape.
+  # trailing dimension in the shape of the splat layout is divisible by the
+  # corresponding dimension in the base tile shape.
   s1, s2 = l1.shape, l2.base_tile_shape
-  return all(d1 % d2 == 0 for d1, d2 in zip(s1, s2))
+  offset = len(s1) - len(s2)
+  return offset >= 0 and all(
+      d1 % d2 == 0
+      for d1, d2 in zip(s1[offset:], s2, strict=True)
+  )
 
 
 def to_transform_attr(

--- a/tests/mosaic/gpu_constraints_test.py
+++ b/tests/mosaic/gpu_constraints_test.py
@@ -116,6 +116,16 @@ class ConstraintSystemTest(parameterized.TestCase):
           mgpu.WGStridedFragLayout((128, 128), vec_size=1),
           True,
       ),
+      (
+          mgpu.WGSplatFragLayout((4, 8)),
+          mgpu.WGMMA_LAYOUT.reduce([0]),
+          True,
+      ),
+      (
+          mgpu.WGSplatFragLayout((8, 4)),
+          mgpu.WGMMA_LAYOUT.reduce([0]),
+          False,
+      ),
   )
   def test_strict_relayout_constraint_holds(self, src, tgt, holds):
     self.assertEqual(


### PR DESCRIPTION
## Summary

Fix `splat_is_compatible_with_tiled` to align a splat shape with the trailing dimensions of a tiled layout's base tile.

Before this, the implementation used `zip(s1, s2)`, which left-aligned the two shapes. `TiledLayout` applies its tiling to trailing array dimensions, so this could produce both false negatives and false positives when the splat shape has higher rank than the base tile.

For example, with a base tile shape of `(8,)`:

-  1. `(4, 8)` should be compatible, but was reported as incompatible.
- 2. `(8, 4)` should be incompatible, but was reported as compatible.

The compatibility check is now explicitly offsets into the tiled suffix before checking divisibility.

Extended the regression coverage both cases to the existing strict relayout tests.

Fixes #39998