### PR TITLE
Fix jnp.histogram on an empty array

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -793,7 +793,7 @@ def histogram_bin_edges(a: ArrayLike, bins: ArrayLike = 10,
   bins_int = core.concrete_or_error(operator.index, bins,
                                     "bins argument of histogram_bin_edges")
   if range is None:
-    range = [arr.min(), arr.max()]
+    range = [0, 1] if arr.size == 0 else [arr.min(), arr.max()]
   range = asarray(range, dtype=dtype)
   if np.shape(range) != (2,):
     raise ValueError(f"`range` must be either None or a sequence of scalars, got {range}")

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3199,6 +3199,24 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                             tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker)
 
+  @jtu.sample_product(bins=[1, 3, 10])
+  def testHistogramEmptyInput(self, bins):
+    # The range cannot be inferred from an empty array; NumPy falls back to
+    # (0, 1) rather than failing inside min/max.
+    np_fun = lambda a: np.histogram(a, bins=bins)
+    jnp_fun = lambda a: jnp.histogram(a, bins=bins)
+    args_maker = lambda: [jnp.array([], dtype='float32')]
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
+  @jtu.sample_product(bins=[1, 3, 10])
+  def testHistogramBinEdgesEmptyInput(self, bins):
+    np_fun = lambda a: np.histogram_bin_edges(a, bins=bins)
+    jnp_fun = lambda a: jnp.histogram_bin_edges(a, bins=bins)
+    args_maker = lambda: [jnp.array([], dtype='float32')]
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
   @jtu.sample_product(
     shape=[(5,), (12,)],
     dtype=int_dtypes,


### PR DESCRIPTION
Fixes #40020

### Problem

`histogram_bin_edges` infers its range as `[arr.min(), arr.max()]` when none is given, and both reductions fail on a zero-size array:

```python
>>> jnp.histogram(jnp.array([]), bins=3)
ValueError: zero-size array to reduction operation min which has no identity

>>> np.histogram(np.array([]), bins=3)
(array([0, 0, 0]), array([0., 0.33333333, 0.66666667, 1.]))
```

NumPy special-cases it: when the input is empty and no range is supplied it falls back to `(0, 1)` (`_get_outer_edges`: *"handle empty arrays. Can't determine range, so use 0-1."*).

The divergence is only in range inference — with an explicit `range=` JAX already matched NumPy on empty input:

```python
>>> jnp.histogram(jnp.array([]), bins=3, range=(0, 1))   # already worked
```

Empty input is not exotic here: a histogram of a filtered or masked batch produces it whenever the filter matches nothing, and inside jitted code that's data-dependent, so the caller can't easily branch around it.

### Change

Fall back to `(0, 1)` when the array is empty and no range is given.

`arr.size` is static, so the branch resolves at trace time and the function still jits — verified below.

### Verified

```python
jnp.histogram(jnp.array([]), bins=3)
# counts [0.0, 0.0, 0.0], edges [0.0, 0.3333, 0.6667, 1.0]   (matches NumPy exactly)

jnp.histogram_bin_edges(jnp.array([2.,5.,3.,6.,4.,1.]), bins=5)
# [1., 2., 3., 4., 5., 6.]                                    (non-empty unchanged)

jax.jit(lambda x: jnp.histogram(x, bins=3)[0])(jnp.array([]))
# [0.0, 0.0, 0.0]                                             (jits fine)

jnp.histogram2d(jnp.array([]), jnp.array([]), bins=2)[0].shape
# (2, 2)                                                      (also fixed, same helper)
```

`histogram2d` and `histogramdd` route through the same helper, so they're fixed by this too.

### Tests

Added `testHistogramEmptyInput` and `testHistogramBinEdgesEmptyInput`, both parametrised over `bins=[1, 3, 10]` and using `_CheckAgainstNumpy` + `_CompileAndCheck` in line with the surrounding histogram tests, so they pin both the NumPy agreement and the jit path.
