### PR TITLE
Avoid quadratic tracing behaviour

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -1055,8 +1055,7 @@ class Tracer[TraceType: Trace](TracerBase, metaclass=TracerMeta):
     # Raising a ConcretizationTypeError would make sense, but for backward compatibility
     # we raise an AttributeError so that hasattr() and getattr() work as expected.
     raise AttributeError(
-        f"The 'sharding' attribute is not available on {self._error_repr()}."
-        f"{self._origin_msg()}")
+        f"The 'sharding' attribute is not available on {self._error_repr()}.")
 
   @property
   def committed(self):
@@ -1071,8 +1070,7 @@ class Tracer[TraceType: Trace](TracerBase, metaclass=TracerMeta):
     # Raising a ConcretizationTypeError would make sense, but for backward compatibility
     # we raise an AttributeError so that hasattr() and getattr() work as expected.
     raise AttributeError(
-      f"The 'device' attribute is not available on {self._error_repr()}."
-      f"{self._origin_msg()}")
+      f"The 'device' attribute is not available on {self._error_repr()}.")
 
   @property
   def addressable_shards(self):

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -16,6 +16,7 @@ import contextlib
 import gc
 import re
 import traceback
+from unittest import mock
 import weakref
 
 from absl.testing import absltest
@@ -29,6 +30,7 @@ from jax._src import core
 from jax._src import source_info_util
 from jax._src import test_util as jtu
 from jax._src import traceback_util
+from jax._src.interpreters import partial_eval as pe
 
 
 config.parse_flags_with_absl()
@@ -484,6 +486,35 @@ class CustomErrorsTest(jtu.JaxTestCase):
     err = ErrorClass(FakeTracer(None))
 
     self.assertIn(f'https://docs.jax.dev/en/latest/errors.html#jax.errors.{errorclass}', str(err))
+
+
+class TracerAttributeProbeTest(jtu.JaxTestCase):
+
+  def test_attribute_probes_do_not_build_origin_msg(self):
+    # hasattr()/getattr() probes of unavailable attributes on tracers are a
+    # common pattern in user code (e.g. flax NNX probes x.sharding on every
+    # Variable assignment while tracing a model). These probes swallow the
+    # AttributeError without reading its message, so the message -- in
+    # particular tracer._origin_msg(), which walks every equation traced so
+    # far -- must not be computed eagerly. Doing so makes each probe
+    # O(trace size) and overall tracing O(n^2).
+    probed_attrs = ('sharding', 'device')
+
+    forbidden = mock.Mock(
+        side_effect=AssertionError(
+            'tracer._origin_msg() was invoked while probing an attribute '
+            'with hasattr()/getattr(); this makes tracing quadratic.'))
+
+    def f(x):
+      for _ in range(3):
+        x = x + 1
+        for name in probed_attrs:
+          self.assertFalse(hasattr(x, name))
+          self.assertIsNone(getattr(x, name, None))
+      return x
+
+    with mock.patch.object(pe.DynamicJaxprTracer, '_origin_msg', forbidden):
+      jax.eval_shape(f, jax.ShapeDtypeStruct((2,), jnp.float32))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The now-removed error message computation walked all previously traced equations.

`Tracer.sharding` and `Tracer.device` raise AttributeError so that `hasattr()`/`getattr()` probes work as expected; the part of the error message that is removed in this commit walked the previously-traced computation. Code that probes these attributes once per operation while tracing -- e.g. flax NNX's `Variable.set_value` probes `value.sharding` on every parameter assignment -- therefore made tracing O(n^2). A gemma3-27b MaxText model with `scan_layers=False` was prohibitively slow to trace because of this.

The included test is not performance-based, to avoid it being annoyingly flaky, but a test that illustrates the problem is:
```python
#!/usr/bin/env python
"""Bisectable reproducer for quadratic JAX tracing when getattr(tracer, 'sharding', ...) is used.

Background
----------
flax NNX's Variable.set_value (flax/nnx/variablelib.py, `getattr(value, 'sharding', None)`)
probes the .sharding attribute of every value assigned to a Variable. Under a jit/eval_shape
trace the value is a Tracer, whose `.sharding` property raises AttributeError -- but the error
message eagerly computes tracer._origin_msg(), which calls
DynamicJaxprTraceFrame.find_progenitors() and get_eqns(), i.e. it walks (and in recent JAX
reconstructs a JaxprEqn for) EVERY equation traced so far. getattr() then swallows the
exception and all that work is discarded. One probe per traced op => O(N^2) tracing.

This makes MaxText gemma3-27b with scan_layers=False (unrolled, tens of thousands of eqns,
one .sharding probe per parameter assignment via flax NNX) take a pathologically long time
in tracing, e.g.:
  python -m maxtext.trainers.pre_train.train ... model_name=gemma3-27b scan_layers=False ...
py-spy stack of the stuck process:
  get_eqns / find_progenitors (jax/_src/interpreters/partial_eval.py)
  <- _origin_msg <- Tracer.sharding (jax/_src/core.py)
  <- flax/nnx/variablelib.py set_value <- model __init__ under jax.eval_shape

What this script does
---------------------
Traces a function of N ops with one getattr(x, 'sharding', None) per op, at N and 4*N,
using jax.eval_shape on ShapeDtypeStructs (no device execution, so it runs on CPU and
even with a mismatched jaxlib). If tracing is linear in N the time ratio is ~4;
if quadratic it is ~16.

Exit code 0: fast (linear) tracing.
Exit code 1: slow (quadratic) tracing, i.e. the bug is present.

Usage: JAX_PLATFORMS=cpu python jax_tracing_slowdown_repro.py
"""
import sys
import time

import jax
import numpy as np

N_SMALL = 600
N_BIG = 4 * N_SMALL
RATIO_THRESHOLD = 8.0  # linear -> ~4x, quadratic -> ~16x


def make(n, probe_sharding):
  def f(x):
    for _ in range(n):
      x = x + 1  # add one equation to the trace
      if probe_sharding:
        # This is what flax NNX Variable.set_value does for every parameter
        # assignment. On a Tracer it raises AttributeError whose message is
        # expensive to build (walks all equations traced so far); getattr
        # swallows the exception.
        getattr(x, "sharding", None)
    return x

  return f


def trace_time(n, probe_sharding):
  x = jax.ShapeDtypeStruct((8,), np.float32)
  best = float("inf")
  for _ in range(2):
    t0 = time.perf_counter()
    jax.eval_shape(make(n, probe_sharding), x)
    best = min(best, time.perf_counter() - t0)
  return best


def main():
  print(f"jax {jax.__version__} from {jax.__file__}")
  jax.eval_shape(make(10, True), jax.ShapeDtypeStruct((8,), np.float32))  # warmup

  base_small = trace_time(N_SMALL, False)
  base_big = trace_time(N_BIG, False)
  probe_small = trace_time(N_SMALL, True)
  probe_big = trace_time(N_BIG, True)

  base_ratio = base_big / base_small
  probe_ratio = probe_big / probe_small
  overhead = probe_big / base_big

  print(f"no probe   : N={N_SMALL}: {base_small:.3f}s  N={N_BIG}: {base_big:.3f}s  ratio {base_ratio:.1f}x")
  print(f"with probe : N={N_SMALL}: {probe_small:.3f}s  N={N_BIG}: {probe_big:.3f}s  ratio {probe_ratio:.1f}x")
  print(f"probe overhead at N={N_BIG}: {overhead:.1f}x")

  # Slow/buggy iff the probed trace scales superlinearly. The overhead check
  # guards against a noisy ratio on a fast machine where all times are tiny.
  slow = probe_ratio > RATIO_THRESHOLD and overhead > 5.0
  print("RESULT: SLOW (quadratic tracing)" if slow else "RESULT: FAST (linear tracing)")
  return 1 if slow else 0


if __name__ == "__main__":
  sys.exit(main())
```