### PR TITLE
Fix symbolic product bounds in shape_poly_decision.py

### DIFF
--- a/jax/_src/export/shape_poly_decision.py
+++ b/jax/_src/export/shape_poly_decision.py
@@ -374,10 +374,18 @@ class _DecisionByElimination:
         self.add_implicit_constraints_term(f1_t)
         a1_l, a1_u = self.bounds(f1_e, BoundsPrecision.BEST)
         assert a1_l <= a1_u
-        bounds.append((a1_l ** f1_exp, a1_u ** f1_exp))
+        factor_bound_candidates = [a1_l ** f1_exp, a1_u ** f1_exp]
+        if f1_exp % 2 == 0 and a1_l <= 0 <= a1_u:
+          factor_bound_candidates.append(0)
+        bounds.append((min(factor_bound_candidates),
+                       max(factor_bound_candidates)))
 
-      candidate_bounds = [math.prod(factor_bounds)
-                          for factor_bounds in itertools.product(*bounds)]
+      # Infinities represent open bounds, so a zero factor still makes the
+      # product zero rather than NaN.
+      candidate_bounds = [
+          0 if 0 in factor_bounds else math.prod(factor_bounds)
+          for factor_bounds in itertools.product(*bounds)
+      ]
       m_l = min(*candidate_bounds)
       m_u = max(*candidate_bounds)
       self.combine_and_add_constraint(Comparator.GEQ, t_e, m_l)

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -409,6 +409,29 @@ class DimExprTest(jtu.JaxTestCase):
     # Higher order polynomial
     self.assertEqual(_bounds(a*a + b - 2), (0, np.inf))
     self.assertEqual(_bounds(-2*a*b - b - 2), (-np.inf, -5))
+    sign_crossing_factor = core.min_dim(a - 5, 5)
+    self.assertEqual(_bounds(sign_crossing_factor**2), (0, 25))
+    self.assertEqual(_bounds(sign_crossing_factor**2 * b), (0, np.inf))
+    with self.assertRaises(core.InconclusiveDimensionOperation):
+      _ = sign_crossing_factor**2 >= 1
+
+  def test_bounds_product(self):
+    a, _ = shape_poly.symbolic_shape("a, b")
+
+    # Interval [-2, 1] squared (even power) should have bounds [0, 4].
+    x = core.max_dim(-2, core.min_dim(1, a - 5))
+    self.assertEqual((0, 4), _bounds(x * x))
+
+    # Interval [-2, 1] cubed (odd power) should have bounds [-8, 1].
+    self.assertEqual((-8, 1), _bounds(x * x * x))
+
+    # Product of (-inf, -1] and [0, inf) should have bounds (-inf, 0].
+    u = (a // -2) * core.max_dim(0, a - 5)
+    self.assertEqual((-np.inf, 0), _bounds(u))
+
+    # Product of [-1, 1] and [1, inf) should have unbounded bounds.
+    z = core.max_dim(-1, core.min_dim(1, a - 5))
+    self.assertEqual((-np.inf, np.inf), _bounds(z * a))
 
   def test_bounds_mod(self):
     a, b = shape_poly.symbolic_shape("a, b")


### PR DESCRIPTION
Account for zero when even-powered factor bounds cross zero and avoid NaN when a zero factor is paired with an open infinite bound.