### PR TITLE
[ROCm] Take the wheel metadata ROCm version from the build config

### DIFF
--- a/jax_plugins/rocm/plugin_setup.py
+++ b/jax_plugins/rocm/plugin_setup.py
@@ -53,13 +53,15 @@ class BinaryDistribution(Distribution):
   def has_ext_modules(self):
     return True
 
+_description = f"JAX Plugin for AMD GPUs (ROCm:{rocm_detected_version})"
+
 setup(
     name=project_name,
     version=__version__,
     cmdclass=_cmdclass,
-    description=f"JAX Plugin for AMD GPUs (ROCm:{rocm_detected_version})",
-    long_description="",
-    long_description_content_type="text/markdown",
+    description=_description,
+    long_description=_description,
+    long_description_content_type="text/plain",
     author="ROCm JAX Devs",
     author_email="dl.dl-JAX@amd.com",
     packages=[package_name],

--- a/jax_plugins/rocm/setup.py
+++ b/jax_plugins/rocm/setup.py
@@ -52,12 +52,14 @@ packages = find_namespace_packages(
     ]
 )
 
+_description = f"JAX XLA PJRT Plugin for AMD GPUs (ROCm:{rocm_detected_version})"
+
 setup(
     name=project_name,
     version=__version__,
-    description=f"JAX XLA PJRT Plugin for AMD GPUs (ROCm:{rocm_detected_version})",
-    long_description="",
-    long_description_content_type="text/markdown",
+    description=_description,
+    long_description=_description,
+    long_description_content_type="text/plain",
     author="ROCm JAX Devs",
     author_email="dl.dl-JAX@amd.com",
     packages=packages,

--- a/jaxlib/jax.bzl
+++ b/jaxlib/jax.bzl
@@ -34,6 +34,7 @@ load("@test_shard_count//:test_shard_count.bzl", "USE_MINIMAL_SHARD_COUNT")
 load("@xla//third_party/py:python_wheel.bzl", "collect_data_files", "transitive_py_deps")
 load("@xla//xla/tsl:tsl.bzl", "transitive_hdrs", _if_windows = "if_windows", _pybind_extension = "tsl_pybind_extension_opensource")
 load("@xla//xla/tsl/platform:build_config_root.bzl", _tf_cuda_tests_tags = "tf_cuda_tests_tags", _tf_exec_properties = "tf_exec_properties")
+load("//jaxlib/rocm:rocm_version.bzl", "ROCM_FULL_VERSION")
 
 # Explicitly re-exports names to avoid "unused variable" warnings from .bzl
 # lint tools.
@@ -510,6 +511,9 @@ def _jax_wheel_impl(ctx):
         if ctx.attr.platform_version == "":
             fail("platform_version must be set to a valid rocm version for rocm wheels")
         args.add("--platform_version", ctx.attr.platform_version)  # required for gpu wheels
+
+        # platform_version is major-only; wheel metadata needs the full version.
+        env["ROCM_VERSION"] = ROCM_FULL_VERSION
     if ctx.attr.enable_oneapi:
         args.add("--enable-oneapi", "True")
         if ctx.attr.platform_version == "":

--- a/jaxlib/rocm/rocm_version.bzl
+++ b/jaxlib/rocm/rocm_version.bzl
@@ -27,3 +27,8 @@ _version = rocm_version_number()
 ROCM_MAJOR_VERSION = str(_version // 10000)
 ROCM_MINOR_VERSION = str((_version % 10000) // 100)
 ROCM_PATCH_VERSION = str(_version % 100)
+ROCM_FULL_VERSION = "%s.%s.%s" % (
+    ROCM_MAJOR_VERSION,
+    ROCM_MINOR_VERSION,
+    ROCM_PATCH_VERSION,
+)


### PR DESCRIPTION
## Summary

The release `jax-rocm<major>-pjrt` and `jax-rocm<major>-plugin` wheels publish `ROCm:unknown` in their PyPI Summary, and still did after #40001.

Release wheels carry no `+rocm…` local version segment, so `detect_rocm_version()` falls through to `ROCM_VERSION`. `rocm.bazelrc` forwards that variable with `--action_env`, but the wheel action in `jaxlib/jax.bzl` runs with an explicit `env` and `use_default_shell_env = False`, and Bazel does not merge `--action_env` into an action that supplies its own environment. So a value exported around the build never reached `setup.py`, and no amount of exporting it in CI would have.

This takes the version from the build configuration rather than the client environment. `@local_config_rocm` already reports it, and `jaxlib/rocm/rocm_version.bzl` already derives from it the ROCm major that names the wheel, so the full version comes from the same place and is set directly in the env of the ROCm wheel actions.

## Changes

- `jaxlib/rocm/rocm_version.bzl`: add `ROCM_FULL_VERSION` next to the existing major/minor/patch constants.
- `jaxlib/jax.bzl`: set `ROCM_VERSION` in the wheel action env, under `enable_rocm`.
- `jax_plugins/rocm/setup.py` and `plugin_setup.py`: give both wheels a real `long_description` with an explicit `text/plain` content type. They declared `text/markdown` over an empty string, which twine warns about on upload.

## Why this is safe

- **No new dependency.** `jaxlib/jax.bzl` already loads `@local_config_rocm//rocm:build_defs.bzl`, so routing through `jaxlib/rocm/rocm_version.bzl` adds nothing to the load graph that was not already there.
- **Only ROCm wheels change.** The assignment sits inside `if ctx.attr.enable_rocm`, so the CUDA, TPU, CPU and oneAPI wheel actions keep identical action keys and cache entries.
- **TheRock is unaffected.** A wheel version suffix that names a ROCm version, such as `+rocm10.0.0rc2`, still takes precedence over `ROCM_VERSION` in `detect_rocm_version()`, and `ROCM_VERSION_EXTRA` still overrides both.
- **ROCm not configured stays as it was.** The generated dummy repository returns `rocm_version_number() == 0` rather than failing, and that is already the source of the wheel name in that case.

## Test plan

- Build both wheels through `ci/build_rocm_artifacts.sh` and read the Summary out of the wheel METADATA.
- Run `twine check` on both wheels, which is what reported the `long_description` warning.
- Confirm the wheel version keeps its plain semver, with no `+rocm` suffix added.
- Check that the CPU, CUDA and ROCm wheel targets still analyse.

## Test result

Against a hermetic ROCm 7.14.0, both wheels now carry the version:

| wheel | Summary |
| --- | --- |
| `jax_rocm7_pjrt` | `JAX XLA PJRT Plugin for AMD GPUs (ROCm:7.14.0)` |
| `jax_rocm7_plugin` | `JAX Plugin for AMD GPUs (ROCm:7.14.0)` |

`twine check` passes on both with no warnings, and `Description-Content-Type: text/plain` is present. Wheel versions stay plain semver. `pre-commit run --files` is clean on the four files.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->
