### PR TITLE
Fix overly strict broadcast_in_dim rank rejection

### DIFF
--- a/jax/experimental/mosaic/gpu/fragmented_array.py
+++ b/jax/experimental/mosaic/gpu/fragmented_array.py
@@ -3501,13 +3501,16 @@ class FragmentedArray:
       )
     if not isinstance(self.layout, TiledLayout) or not isinstance(layout, TiledLayout):
       raise NotImplementedError(self.layout, layout)
-    if len(layout.base_tile_shape) != len(shape):
+    untiled_rank = len(shape) - len(layout.base_tile_shape)
+    if untiled_rank < 0:
       raise NotImplementedError(
-          "Tiling rank different than broadcast result rank, "
+          "Tiling rank exceeds broadcast result rank, "
           f"{layout.base_tile_shape} vs {shape}"
       )
     new_dimensions = sorted(set(range(len(shape))) - set(source_dimensions))
-    expected_layout = layout.reduce(new_dimensions)
+    expected_layout = layout.reduce(
+        [d - untiled_rank for d in new_dimensions if d >= untiled_rank]
+    )
     if expected_layout != self.layout:
       raise ValueError(
           "Source and destination layouts aren't compatible for a broadcast"
@@ -3515,9 +3518,13 @@ class FragmentedArray:
     new_registers_shape = layout.registers_shape(shape)
     pre_broadcast_registers_shape = list(new_registers_shape)
     for new_dim in new_dimensions:
-      for i, is_new in enumerate(layout.tiling.tile_dimension(new_dim)):
+      if new_dim < untiled_rank:
+        pre_broadcast_registers_shape[new_dim] = 1
+        continue
+      tile_dims = layout.tiling.tile_dimension(new_dim - untiled_rank)
+      for i, is_new in enumerate(tile_dims):
         if is_new:
-          pre_broadcast_registers_shape[i] = 1
+          pre_broadcast_registers_shape[untiled_rank + i] = 1
     # The broadcast for all dims but the vector_dim amounts to repeating the
     # registers along the new dimensions. Along the vector_dim, we actually need
     # to extend the vector length to change the type of the registers.


### PR DESCRIPTION
Fixes #40081. 

In `jax/experimental/mosaic/gpu/fragmented_array.py:broadcast_in_dim`, we see the following:

```python
    if len(layout.base_tile_shape) != len(shape):
      raise NotImplementedError(
          "Tiling rank different than broadcast result rank, "
          f"{layout.base_tile_shape} vs {shape}"
      )
```

This effectively prevents the shape from having length > 2. But this is unnecessary: what we really care about is that the untiled rank is above zero, where `untiled_rank = len(shape) - len(layout.base_tile_shape)`. A leading axis outside of the tiling dimensions is okay. 

This does expose two indexing bugs just below:

```python
    new_dimensions = sorted(set(range(len(shape))) - set(source_dimensions))
    expected_layout = layout.reduce(new_dimensions)
    ...
    for new_dim in new_dimensions:
      for i, is_new in enumerate(layout.tiling.tile_dimension(new_dim)):
```
Here, `new_dimensions` are indices into the array dimensions, not the tile dimensions. But `layout.reduce` and `tiling.tile_dimension` expect tile indices, not array indices. We need to subtract `untiled_rank` from each of the `new_dimensions` to do the conversion. 