### PR TITLE
Export `NDIndexer` in Pallas module

### DIFF
--- a/jax/experimental/pallas/__init__.py
+++ b/jax/experimental/pallas/__init__.py
@@ -74,6 +74,7 @@ from jax._src.pallas.utils import strides_from_shape as strides_from_shape
 from jax._src.state.discharge import run_state as run_state
 from jax._src.state.indexing import ds as ds
 from jax._src.state.indexing import dslice as dslice
+from jax._src.state.indexing import NDIndexer as NDIndexer
 from jax._src.state.indexing import Slice as Slice
 from jax._src.state.primitives import broadcast_to as broadcast_to
 


### PR DESCRIPTION
Inspecting a jaxpr's in/outvars tree will lead to the occurrence of NDIndexer objects, which are currently private to JAX.

Exporting the name in Pallas similarly to the other already present indexing types makes it easier to produce more concise type annotations when processing these jaxprs in user code.

---------------

Hey, I'd like this for [nicholasjng/palladium](https://github.com/nicholasjng/palladium). I'm trying to translate ref gets/swaps into MSL loads/stores, which usually requires a few calculations (buffer offsets, result shapes). Exporting this type would help with some type annotations in my code.

-Nico