### PR TITLE
[typing] use inline typevar in several places

### DIFF
--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -17,7 +17,7 @@ from collections.abc import Callable, Sequence
 import dataclasses
 import functools
 import itertools as it
-from typing import TypeVar, Any
+from typing import Any
 
 import numpy as np
 
@@ -74,7 +74,6 @@ Int = int | Array
 ErrorCategory = type['JaxException']
 Payload = list[np.ndarray | Array]
 PyTreeDef = jtu.PyTreeDef
-Out = TypeVar('Out')
 
 # Concrete errors
 
@@ -1175,9 +1174,9 @@ automatic_checks = float_checks | index_checks
 all_checks = automatic_checks | user_checks
 
 
-def checkify(f: Callable[..., Out],
-             errors: frozenset[ErrorCategory] = user_checks
-             ) -> Callable[..., tuple[Error, Out]]:
+def checkify[T](f: Callable[..., T],
+                errors: frozenset[ErrorCategory] = user_checks
+                ) -> Callable[..., tuple[Error, T]]:
   """Functionalize `check` calls in `fun`, and optionally add run-time error checks.
 
   Run-time errors are either user-added :func:`~check` assertions, or

--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -26,7 +26,6 @@ import itertools
 import operator
 import re
 import types
-import typing
 from typing import Any, NamedTuple, Protocol, cast as type_cast
 import warnings
 
@@ -66,8 +65,6 @@ import numpy as np
 
 map, unsafe_map = util.safe_map, map
 zip, unsafe_zip = util.safe_zip, zip
-
-T = typing.TypeVar("T")
 
 Value = ir.Value
 

--- a/jax/_src/state/discharge.py
+++ b/jax/_src/state/discharge.py
@@ -19,7 +19,7 @@ import dataclasses
 from functools import partial
 import math
 import operator
-from typing import Any, Protocol, TypeVar
+from typing import Any, Protocol
 
 from jax._src import ad_util
 from jax._src import api_util
@@ -836,8 +836,7 @@ def _initial_style_jaxpr(fun: Callable,
   return jaxpr
 
 
-T = TypeVar('T')
-def run_state(f: Callable[..., None]) -> Callable[[T], T]:
+def run_state[T](f: Callable[..., None]) -> Callable[[T], T]:
   def wrapped(args):
     dbg = api_util.debug_info("run_state", f, (args,), {})
     flat_args, in_tree = tree_util.tracing_registry.flatten(args)


### PR DESCRIPTION
Limited this to remaining files where this change will not likely lead to downstream failures