### PR TITLE
[typing] fix type checking errors under pyrefly v1.2.0

### DIFF
--- a/jax/_src/export/_export.py
+++ b/jax/_src/export/_export.py
@@ -811,7 +811,7 @@ def _export_lowered(
         apply_jit=True,
         flat_primal_fun=True,
         mesh=cur_mesh)
-    return export(fun_vjp_jax,
+    return export(fun_vjp_jax,  # pyrefly: ignore[bad-argument-type]
                   platforms=exp_primal.platforms,
                   disabled_checks=exp_primal.disabled_safety_checks)(*vjp_in_avals)
 

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1069,7 +1069,7 @@ def _unpack_conjugate_pairs(w: Array, vr: Array) -> Array:
   vr_shifted_left = lax.pad(vr, lax._zero(vr), pads)
   pads[-1] = (1, -1, 0)
   vr_shifted_right = lax.pad(vr, lax._zero(vr), pads)
-  dims = list(np.delete(np.arange(len(vr.shape), dtype=np.int32), -2))
+  dims = np.delete(np.arange(len(vr.shape), dtype=np.int32), -2).tolist()
   is_real = lax.broadcast_in_dim(is_real, vr.shape, broadcast_dimensions=dims)
   conj_pair_start = lax.broadcast_in_dim(conj_pair_start, vr.shape,
                                          broadcast_dimensions=dims)

--- a/jax/_src/lax/pallas_lowerings/gpu/ragged_dot.py
+++ b/jax/_src/lax/pallas_lowerings/gpu/ragged_dot.py
@@ -269,7 +269,8 @@ def gmm(
   with api.named_scope("pallas_triton_ragged_dot"):
     out = pl.pallas_call(
       partial(
-        _gpu_ragged_dot_kernel, size=size, block=block_sizes, **other_kws
+        _gpu_ragged_dot_kernel, size=size, block=block_sizes,
+        **other_kws  # pyrefly: ignore[bad-argument-type]
       ),
       out_shape=out_shape,
       grid=grid,
@@ -395,7 +396,7 @@ def tgmm(
   with api.named_scope("tgmm_ragged_dot"):
     out = pl.pallas_call(
       partial(_tgmm_ragged_dot_kernel, size=size, block=block_sizes,
-              **dtype_spec),
+              **dtype_spec),  # pyrefly: ignore[bad-argument-type]
       out_shape=out_shape,
       grid=grid,
       in_specs=in_specs,

--- a/jax/_src/lax_reference.py
+++ b/jax/_src/lax_reference.py
@@ -314,7 +314,7 @@ def ragged_dot(
   assert lhs.dtype == rhs.dtype
 
   out = np.zeros((m, n), dtype=lhs.dtype)
-  result_iota = np.expand_dims(np.arange(out.shape[0]), list(range(1, out.ndim)))
+  result_iota = np.expand_dims(np.arange(out.shape[0]), tuple(range(1, out.ndim)))
   result_iota = result_iota.astype(group_sizes.dtype)
   start = np.asarray(0, dtype=group_sizes.dtype)
   for i, size in enumerate(group_sizes):

--- a/jax/_src/pallas/mosaic_gpu/lowering.py
+++ b/jax/_src/pallas/mosaic_gpu/lowering.py
@@ -1919,7 +1919,7 @@ def _handle_transforms[T: (ir.Value, tcgen05.TMEMRef)](
 ) -> tuple[T, state_types.AbstractRef, Sequence[state_types.Transform]]:
   # Before we handle other transforms, we resolve any possible leading
   # aliasing transform.
-  ref, ref_aval, transform_avals, transforms = _extract_aliased_ref(  # pyrefly: ignore[no-matching-overload]
+  ref, ref_aval, transform_avals, transforms = _extract_aliased_ref(  # pyrefly: ignore[bad-assignment,no-matching-overload]
       ref,
       ref_aval,
       transform_avals,

--- a/jax/_src/pallas/mosaic_gpu/pallas_call.py
+++ b/jax/_src/pallas/mosaic_gpu/pallas_call.py
@@ -100,7 +100,7 @@ def pallas_call(
 
     @functools.partial(
         pipeline.emit_pipeline,
-        grid=sequential_grid,
+        grid=sequential_grid,  # pyrefly: ignore[bad-argument-type]
         in_specs=[
             _make_pipeline_spec(s)
             for s in _normalize_specs(in_specs, in_shapes)

--- a/jax/_src/pallas/mosaic_gpu/pipeline.py
+++ b/jax/_src/pallas/mosaic_gpu/pipeline.py
@@ -840,7 +840,7 @@ def emit_pipeline_warp_specialized(
 
     if collective_axes:
       consumed_barrier_type = functools.partial(
-          gpu_core.ClusterBarrier, collective_axes=collective_axes
+          gpu_core.ClusterBarrier, collective_axes=collective_axes  # pyrefly: ignore[bad-argument-type]
       )
     else:
       consumed_barrier_type = gpu_core.Barrier

--- a/jax/_src/traceback_util.py
+++ b/jax/_src/traceback_util.py
@@ -146,7 +146,7 @@ def _running_under_ipython() -> bool:
 def _ipython_supports_tracebackhide() -> bool:
   """Returns true if the IPython version supports __tracebackhide__."""
   import IPython  # pyrefly: ignore[missing-import]
-  return IPython.version_info[:2] >= (7, 17)
+  return IPython.version_info[:2] >= (7, 17)  # pyrefly: ignore[unsupported-operation] # pyrefly#896
 
 def _filtering_mode() -> str:
   mode = config.traceback_filtering.value

--- a/jax/experimental/array_serialization/serialization_test.py
+++ b/jax/experimental/array_serialization/serialization_test.py
@@ -945,7 +945,7 @@ class UserPytreeAPITest(UserAPITestCase):
   def test_register_as_decorator(self):
     @partial(register_pytree_node_serialization,
                        serialized_name='CustomDNode',
-                       serialize_auxdata=json.dumps,
+                       serialize_auxdata=json.dumps,  # pyrefly: ignore[bad-argument-type]
                        deserialize_auxdata=json.loads)
     @partial(jax.tree_util.register_dataclass, data_fields=['a', 'b'],
                       meta_fields=[])

--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py
@@ -2580,7 +2580,7 @@ def _make_splash_attention(
   )
 
   fwd_mask_info, mask_function_fwd = process_mask_fn(
-      mask,
+      mask,  # pyrefly: ignore[bad-argument-type]
       (block_sizes.block_q, block_sizes.block_kv),
       downcast_smem_data=downcast_smem_data,
       head_shards=head_shards,
@@ -2596,8 +2596,8 @@ def _make_splash_attention(
     else:
       bq_dq, bkv_dq = block_sizes.block_q_dq, block_sizes.block_kv_dq
       dq_mask_info, mask_function_dq = process_mask_fn(
-          mask,
-          (bq_dq, bkv_dq),
+          mask,  # pyrefly: ignore[bad-argument-type]
+          (bq_dq, bkv_dq),  # pyrefly: ignore[bad-argument-type]
           downcast_smem_data=downcast_smem_data,
           head_shards=head_shards,
           q_seq_shards=q_seq_shards,
@@ -2606,8 +2606,8 @@ def _make_splash_attention(
       dq_mask_info = tree_util.tree_map(jnp.array, dq_mask_info)
     bq_dkv, bkv_dkv = block_sizes.block_q_dkv, block_sizes.block_kv_dkv
     dkv_mask_info, mask_function_dkv = process_mask_dvk_fn(
-        mask,
-        (bq_dkv, bkv_dkv),
+        mask,  # pyrefly: ignore[bad-argument-type]
+        (bq_dkv, bkv_dkv),  # pyrefly: ignore[bad-argument-type]
         downcast_smem_data=downcast_smem_data,
         head_shards=head_shards,
         q_seq_shards=q_seq_shards,


### PR DESCRIPTION
Running under pyrefly v1.2.0 passes with these updates: https://github.com/jax-ml/jax/actions/runs/32283156055/job/96166366019?pr=40094

For now I'm skipping actually updating to pyrefly 1.2 in our CI, since internal tests are still at v1.1.1. But I'd like to land these changes in order to experiment with shape types locally, which requires v1.2.