### PR TITLE
[ROCm] Remove upload-test-artifacts from ROCm workflows

### DIFF
--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -216,11 +216,3 @@ jobs:
             --action_env=JAX_ENABLE_X64="${ENABLE_X64}" \
             --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="${RBE_IMAGE}" \
             "${JAXCI_ROCM_LOCK_FLAG:-}"
-      - name: Upload test artifacts
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/upload-test-artifacts
-        with:
-          artifact-name: bazel-test-artifacts-${{ inputs.runner }}-py${{ inputs.python }}-rocm${{ inputs.rocm-version }}
-          inputs_json: ${{ toJSON(inputs) }}
-          matrix_json: ${{ toJSON(matrix) }}

--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -175,14 +175,6 @@ jobs:
       - name: Run Pytest ROCm tests
         timeout-minutes: 120
         run: ./ci/run_pytest_rocm.sh
-      - name: Upload test artifacts
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/upload-test-artifacts
-        with:
-          artifact-name: pytest-test-artifacts-${{ inputs.runner }}-py${{ inputs.python }}-rocm${{ inputs.rocm-version }}
-          inputs_json: ${{ toJSON(inputs) }}
-          matrix_json: ${{ toJSON(matrix) }}
       - name: Archive test logs
         if: ${{ !cancelled() }}
         run: |


### PR DESCRIPTION
The GCS upload step does not apply to ROCm CI today. On `pytest_rocm`, the step adds latency before the ROCm S3 log upload. Similarly, on `bazel_rocm`, it adds an additional step at the end of the job.

This PR removes the `upload-test-artifacts` step from ROCm workflows.