### PR TITLE
Increment shard count for mosaic_gpu_test

### DIFF
--- a/tests/pallas/BUILD
+++ b/tests/pallas/BUILD
@@ -293,7 +293,7 @@ jax_multiplatform_test(
         "gpu_b200",
     ],
     env = {"XLA_FLAGS": "--xla_gpu_autotune_level=0 --xla_gpu_enable_triton_gemm=0"},
-    shard_count = 16,
+    shard_count = 24,
     tags = [
         "mosaic_gpu_test",
         "noasan",


### PR DESCRIPTION
Observed intermittent timeouts of `//tests/pallas:mosaic_gpu_test_gpu` shards when the target runs as part of the full test battery with 4x test processes per GPU, particularly on B300 nodes. The logs contain no evidence of a deadlock, and the issue does not reproduce when the target is run interactively in isolation, suggesting contention from concurrent test actions rather than any intrinsic test failure. Increasing shard count to address this