### PR TITLE
Prefix ordered-effect tokens onto propagated_out_mem_kinds in lower_jaxpr_to_fun

### DIFF
--- a/jax/_src/interpreters/mlir.py
+++ b/jax/_src/interpreters/mlir.py
@@ -1766,6 +1766,9 @@ def lower_jaxpr_to_fun(
   if result_memory_kinds is not None:
     token_memory_kinds = [None] * num_tokens
     result_memory_kinds = [*token_memory_kinds, *result_memory_kinds]
+  if propagated_out_mem_kinds is not None:
+    token_memory_kinds = [None] * num_tokens
+    propagated_out_mem_kinds = (*token_memory_kinds, *propagated_out_mem_kinds)
   if arg_layouts is not None:
     prefix_layouts = [None] * (num_dim_vars + num_tokens)
     arg_layouts = [*prefix_layouts, *arg_layouts]

--- a/tests/memories_test.py
+++ b/tests/memories_test.py
@@ -35,6 +35,7 @@ from jax._src.sharding_impls import (
 from jax._src.sharding_impls import make_single_device_sharding
 from jax._src.xla_metadata import set_xla_metadata
 from jax._src.shard_map import shard_map
+from jax.experimental import io_callback
 from jax.experimental.compute_on import compute_on
 import jax.numpy as jnp
 import numpy as np
@@ -1323,6 +1324,28 @@ class ComputeOffload(jtu.BufferDonationTestCase):
     self.assertEqual(out.sharding, out_s)
     executable_mk = get_memory_kinds_from_executable(h, [inp])
     self._check_mem_kind(executable_mk[0], out.sharding, "pinned_host")
+
+  def test_ordered_effect_with_non_default_memory_kind(self):
+    _, s, np_inp, inp = _create_inputs((8, 2), P("x", "y"))
+    out_s = s.with_memory_kind("pinned_host")
+
+    def f(x):
+      io_callback(lambda _: None, None, x, ordered=True)
+      return x * 2
+
+    out = jax.jit(f, out_shardings=out_s)(inp)
+    self.assertEqual(out.sharding, out_s)
+    self.assertArraysEqual(out, np_inp * 2)
+
+    @jax.jit
+    def g(x):
+      io_callback(lambda _: None, None, x, ordered=True)
+      return jax.device_put(x * 2, out_s)
+
+    out = g(inp)
+    self.assertEqual(out.sharding.memory_kind, "pinned_host")
+    self.assertArraysEqual(out, np_inp * 2)
+    jax.effects_barrier()
 
   def test_jit_in_shardings(self):
     _, s, np_inp, inp = _create_inputs((8, 2), P("x", "y"))

--- a/tests/memories_test.py
+++ b/tests/memories_test.py
@@ -28,6 +28,7 @@ from jax._src import test_util as jtu
 from jax._src import xla_bridge as xb
 from jax._src.layout import Layout as DLL, Format
 from jax._src import config
+from jax._src.callback import io_callback
 from jax.ad_checkpoint import checkpoint_name, Recompute
 from jax._src.sharding import common_devices_indices_map
 from jax._src.sharding_impls import (
@@ -35,7 +36,6 @@ from jax._src.sharding_impls import (
 from jax._src.sharding_impls import make_single_device_sharding
 from jax._src.xla_metadata import set_xla_metadata
 from jax._src.shard_map import shard_map
-from jax.experimental import io_callback
 from jax.experimental.compute_on import compute_on
 import jax.numpy as jnp
 import numpy as np


### PR DESCRIPTION
This PR fixes output memory kinds being misaligned when a jitted function has ordered effects, by accounting for the effect tokens prepended to the results.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->