### PR TITLE
improve error when custom_jvp/vjp rules close over tracers

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -903,7 +903,7 @@ def escaped_tracer_error(tracer, detail=None):
     msg += ('\nThe function being traced when the value leaked was '
             f'{dbg.func_src_info} traced for {dbg.traced_for}.')
   line_info = getattr(tracer, '_line_info', None)
-  if line_info is not None:
+  if line_info is not None and source_info_util.summarize(line_info):
     divider = '\n' + '-'*30 + '\n'
     msg += divider
     msg += ('The leaked intermediate value was created on line '
@@ -914,6 +914,9 @@ def escaped_tracer_error(tracer, detail=None):
               'frames (most recent last) excluding JAX-internal frames were:')
       msg += divider + source_info_util.summarize(
           line_info, num_frames=num_frames) + divider
+  elif dbg is not None:
+    msg += ('\nThe leaked value has no associated source line; it may be an '
+            f'argument of {dbg.func_src_info}.')
   msg += ('\nTo catch the leak earlier, try setting the environment variable '
           'JAX_CHECK_TRACER_LEAKS or using the `jax.checking_leaks` context '
           'manager.')

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -755,7 +755,11 @@ class CustomVJPTraced(VJPHiPrimitive):
     if self.symbolic_zeros:
       args = tree_map(CustomVJPPrimal, args, in_nzs)  # tree_map skips Statics
     args_ = tuple(x.val if isinstance(x, Static) else x for x in args)
-    out, res = self.fwd(*args_)
+    try:
+      out, res = self.fwd(*args_)
+    except UnexpectedTracerError as e:
+      e.add_note(pe.custom_rule_leak_note('custom_vjp', 'fwd'))
+      raise
     if config.mutable_array_checks.value:
       _check_for_returned_refs(self.fwd, (out, res), "fwd", tree_leaves(args),
                                self.out_tree.num_leaves)
@@ -1031,7 +1035,11 @@ class CustomJVPTraced(VJPHiPrimitive):
                            is_leaf=zero)
     else:
       tangents_ = tree_map(ad_util.instantiate, tangents_, is_leaf=zero)
-    pair_out = self.jvp_fun(*static_args, primals_, tangents_)
+    try:
+      pair_out = self.jvp_fun(*static_args, primals_, tangents_)
+    except UnexpectedTracerError as e:
+      e.add_note(pe.custom_rule_leak_note('custom_jvp', 'jvp'))
+      raise
     jvp_name = getattr(self.jvp_fun, '__name__', str(self.jvp_fun))
     if not isinstance(pair_out, (list, tuple)) or len(pair_out) != 2:
       raise TypeError(

--- a/jax/_src/interpreters/partial_eval.py
+++ b/jax/_src/interpreters/partial_eval.py
@@ -1640,7 +1640,7 @@ class DynamicJaxprTrace(core.Trace):
 
   def invalidate(self):
     # TODO(mattjj): exposed existing tracer leaks; fix them and re-enable!
-    # super().invalidate()
+    super().invalidate()
 
     # avoid cyclic refs
     self.frame.tracing_eqns = []  # thunk -> eqn -> in_tracers -> trace ->
@@ -1819,8 +1819,12 @@ class DynamicJaxprTrace(core.Trace):
       nz_tangent_avals, zero_avals = partition_list(in_zeros, in_tangent_avals)
       jvp_, out_zeros = _jvp_jaxpr_zeros(jvp, in_zeros, tuple(zero_avals))
       in_avals_ = (*in_avals, *nz_tangent_avals)
-      jaxpr, _, out_consts = trace_to_jaxpr_dynamic(jvp_.with_unknown_names(),
-                                                    in_avals_, lower=self.requires_low)
+      try:
+        jaxpr, _, out_consts = trace_to_jaxpr_dynamic(jvp_.with_unknown_names(),
+                                                      in_avals_, lower=self.requires_low)
+      except core.UnexpectedTracerError as e:
+        e.add_note(custom_rule_leak_note('custom_jvp', 'jvp'))
+        raise
       return jaxpr, out_consts, out_zeros()
 
     const_tracers = map(to_jaxpr_tracer, consts)
@@ -1862,7 +1866,11 @@ class DynamicJaxprTrace(core.Trace):
     def fwd_jaxpr_from_zeros(*zeros):
       for store in fwd.stores: store and store.reset()
       fwd_ = _interleave_fun(fwd.with_unknown_names(), zeros)
-      jaxpr, _, consts = trace_to_jaxpr_dynamic(fwd_, in_avals, lower=self.requires_low)
+      try:
+        jaxpr, _, consts = trace_to_jaxpr_dynamic(fwd_, in_avals, lower=self.requires_low)
+      except core.UnexpectedTracerError as e:
+        e.add_note(custom_rule_leak_note('custom_vjp', 'fwd'))
+        raise
       return jaxpr, consts
 
     def out_trees_():
@@ -1885,6 +1893,17 @@ class DynamicJaxprTrace(core.Trace):
                debug_info: core.DebugInfo, source_info: SourceInfo):
     return self.frame.to_jaxpr(self, out_tracers, debug_info, source_info)
 
+
+def custom_rule_leak_note(api_name: str, rule_name: str) -> str:
+  return (
+      f"This error arose while running the {rule_name} rule of a {api_name} "
+      "function for differentiation, which can happen after the trace in "
+      f"which the {api_name} function was defined has completed. If the rule "
+      "closes over values traced by an enclosing jit (or other "
+      "transformation), those values become invalid at that point. To fix, "
+      f"define {api_name}-decorated functions, and especially their rules, "
+      "at the top level of your module (i.e. fully dedented), passing any "
+      "values they need as explicit arguments.")
 
 custom_staging_rules: dict[Primitive, Callable] = {}
 

--- a/tests/custom_api_test.py
+++ b/tests/custom_api_test.py
@@ -334,6 +334,21 @@ class CustomJVPTest(jtu.JaxTestCase):
     self.assertRaises(UnexpectedTracerError, lambda: api.jvp(f, (3.,), (1.,)))
     self.assertRaises(UnexpectedTracerError, lambda: api.grad(f)(3.))
 
+  def test_closed_over_jit_tracer_leak_error(self):
+    @jit
+    def g(x, w):
+      @jax.custom_jvp
+      def f(y):
+        return y * w
+      def f_jvp(primals, tangents):
+        (y,), (t,) = primals, tangents
+        return y * w, t * w
+      f.defjvp(f_jvp)
+      return f(x)
+
+    with self.assertRaises(UnexpectedTracerError):
+      api.grad(lambda x: g(x, 3.))(2.)
+
   def test_nondiff_argnums(self):
     @partial(jax.custom_jvp, nondiff_argnums=(0,))
     def app(f, x):
@@ -1963,6 +1978,25 @@ class CustomVJPTest(jtu.JaxTestCase):
       _ = g(2., 3.)
     with self.assertRaisesRegex(UnexpectedTracerError, "custom_vjp"):
       _ = api.grad(g, 1)(2., 3.)
+
+  def test_closed_over_jit_tracer_leak_error(self):
+    @jit
+    def g(x, w):
+      @jax.custom_vjp
+      def f(y):
+        return y * w
+      def f_fwd(y):
+        return f(y), (y, w)
+      def f_bwd(res, ct):
+        y, w_ = res
+        return (ct * w_,)
+      f.defvjp(f_fwd, f_bwd)
+      return f(x)
+
+    with self.assertRaises(UnexpectedTracerError) as cm:
+      api.grad(lambda x: g(x, 3.))(2.)
+    self.assertTrue(any('custom_vjp' in note for note in
+                        getattr(cm.exception, '__notes__', [])))
 
   def test_vmap_axes(self):
     raise unittest.SkipTest("TODO")  # TODO(mattjj): write test


### PR DESCRIPTION
Previously, we'd get an mlir.py "No constant handler for DynamicJaxprTracer" TypeError, which was confusing for me and extra confusing for users. The fix is basically to uncomment an `invalidate` call. Also add small other fixes.