### PR TITLE
use tracing registry in other higher-order APIs, fix explain bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,11 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     closed-form LU decomposition with row pivoting for 2x2 and 3x3 matrices
     instead of closed-form polynomial expansions to avoid numerical instability
     and catastrophic cancellation ({jax-issue}`#39905`).
+  * Fixed a crash when `jax_explain_cache_misses` is enabled and a
+    `jax.custom_batching.custom_vmap`-decorated function (or
+    `custom_partitioning`, `custom_gradient`, `closure_convert`,
+    `linear_call`, or `run_state`) is retraced with different-shaped
+    arguments ({jax-issue}`#40110`).
   * The batching rules of the cuDNN fused attention primitives (used by
     {func}`jax.nn.dot_product_attention` with `implementation='cudnn'`) now
     support operands that do not carry the vmap axis, including a shared

--- a/jax/_src/compute_on.py
+++ b/jax/_src/compute_on.py
@@ -26,7 +26,8 @@ from jax._src import effects as effects_lib
 from jax._src import source_info_util
 from jax._src.interpreters import ad, batching, mlir, partial_eval as pe
 from jax._src import flattree as ft
-from jax._src.tree_util import tree_flatten, tree_leaves, tree_unflatten
+from jax._src.tree_util import (tree_flatten, tree_leaves, tree_unflatten,
+                                tracing_registry)
 from jax._src.util import (safe_map, safe_zip, weakref_lru_cache, unzip2,
                            split_list, subs_list, merge_lists)
 from jax._src.api_util import debug_info, flatten_axes
@@ -76,7 +77,7 @@ def _compute_on(f, *, compute_type, out_memory_spaces, compiler_options):
   def wrapped(*args, **kwargs):
     nonlocal compiler_options
     dbg = debug_info('compute_on', f, args, kwargs)
-    args_flat, in_tree = tree_flatten((args, kwargs))
+    args_flat, in_tree = tracing_registry.flatten((args, kwargs))
     in_avals = tuple(core.shaped_abstractify(x) for x in args_flat)
     with extend_compute_type(compute_type):
       jaxpr, out_avals = pe.trace_to_jaxpr(

--- a/jax/_src/custom_batching.py
+++ b/jax/_src/custom_batching.py
@@ -34,7 +34,9 @@ from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
 from jax._src.interpreters import partial_eval as pe
 from jax._src.tree_util import (tree_flatten, tree_map, tree_structure,
-                                tree_unflatten, treedef_tuple)
+                                tree_unflatten, treedef_tuple,
+                                tracing_registry,
+                                treedef_tuple_tracing_registry)
 
 
 source_info_util.register_exclusion(__file__)
@@ -154,14 +156,15 @@ class custom_vmap:
       raise AttributeError(
           f"No batching rule defined for custom_vmap function {debug_fun.func_name} "
           "using def_vmap.")
-    args_flat, in_tree = tree_flatten(args)
+    args_flat, in_tree = tracing_registry.flatten(args)
     in_avals = [core.typeof(x) for x in args_flat]
     jaxpr, out_avals = pe.trace_to_jaxpr(
         self.fun, ft.pack((ft.treedef_args_to_ft(in_tree, in_avals), {})),
         debug_fun)
     closed_call, consts = pe.separate_consts(jaxpr)
     out_tree = tree_structure(out_avals.unflatten())
-    in_tree = treedef_tuple((tree_structure(consts), in_tree))
+    in_tree = treedef_tuple_tracing_registry(
+        (tracing_registry.flatten(consts)[1], in_tree))
     assert self.vmap_rule is not None
     debug_rule = api_util.debug_info("custom_vmap rule", self.vmap_rule,
                                      (0, args, args), {})
@@ -333,7 +336,7 @@ def custom_vmap_jvp(primals, tangents, *,
 
   tangents = map(ad.instantiate_zeros, tangents)
   jvp_call, _ = ad.jvp_jaxpr(call, [True] * len(primals), True)
-  jvp_in_tree = treedef_tuple((in_tree, in_tree))
+  jvp_in_tree = treedef_tuple_tracing_registry((in_tree, in_tree))
   jvp_out_tree = treedef_tuple((out_tree, out_tree))
   outs = custom_vmap_p.bind(
       *primals, *tangents,

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -42,7 +42,8 @@ from jax._src.interpreters import partial_eval as pe
 from jax._src.tree_util import (
     tree_flatten, tree_unflatten, tree_map, treedef_is_leaf, treedef_tuple,
     register_pytree_node_class, tree_leaves, tree_flatten_with_path,
-    tree_leaves_with_path, keystr, treedef_children, tree_structure, PyTreeDef)
+    tree_leaves_with_path, keystr, treedef_children, tree_structure, PyTreeDef,
+    tracing_registry)
 from jax._src.util import (cache, safe_zip, safe_map, split_list, unzip2,
                            weakref_lru_cache)
 
@@ -1266,7 +1267,7 @@ def custom_gradient(fun=None, *, with_logs: bool = False):
     ans, rule = fun(*args, **kwargs)
     if with_logs:
       rule = _custom_gradient_logs_rule(rule)
-    ans_flat, out_tree = tree_flatten(((ans,), {}))
+    ans_flat, out_tree = tracing_registry.flatten(((ans,), {}))
     debug_fwd = debug_info("custom_gradient fwd", rule, (ans,), {})
     ans_avals = [core.typeof(x).to_ct_aval() for x in ans_flat]
     closed_jaxpr, rule_out = pe.trace_to_jaxpr(
@@ -1393,7 +1394,7 @@ def closure_convert(fun: Callable, *example_args) -> tuple[Callable, list[Any]]:
     values hoisted from its closure, and (ii) a list of values hoisted
     from the closure.
   """
-  flat_args, in_tree = tree_flatten((example_args, {}))
+  flat_args, in_tree = tracing_registry.flatten((example_args, {}))
   in_avals = tuple(map(core.typeof, flat_args))
   debug = debug_info("closure_convert", fun, example_args, {})
   if config.check_tracer_leaks.value:
@@ -1547,8 +1548,8 @@ def linear_call(fun: Callable,
 
   .. _Haskell-like type signatures: https://wiki.haskell.org/Type_signature
   """
-  operands_res, res_tree = tree_flatten(residual_args)
-  operands_lin, lin_tree = tree_flatten(linear_args)
+  operands_res, res_tree = tracing_registry.flatten(residual_args)
+  operands_lin, lin_tree = tracing_registry.flatten(linear_args)
 
   res_avals = map(core.typeof, operands_res)
   lin_avals = map(core.typeof, operands_lin)

--- a/jax/_src/custom_partitioning.py
+++ b/jax/_src/custom_partitioning.py
@@ -523,7 +523,7 @@ class custom_partitioning:
     else:
       static_args = ()
       f_, dyn_args = self.fun, args
-    args_flat, in_tree = tree_util.tree_flatten(dyn_args)
+    args_flat, in_tree = tree_util.tracing_registry.flatten(dyn_args)
     in_avals = [core.typeof(x) for x in args_flat]
     mesh = mesh_lib.thread_resources.env.physical_mesh
     with core.extend_axis_env_nd(mesh.shape.items()):

--- a/jax/_src/state/discharge.py
+++ b/jax/_src/state/discharge.py
@@ -840,7 +840,7 @@ T = TypeVar('T')
 def run_state(f: Callable[..., None]) -> Callable[[T], T]:
   def wrapped(args):
     dbg = api_util.debug_info("run_state", f, (args,), {})
-    flat_args, in_tree = tree_util.tree_flatten(args)
+    flat_args, in_tree = tree_util.tracing_registry.flatten(args)
     ref_avals, ref_args = unzip2(map(get_ref_aval_from_value, flat_args))
     # There may be some uninitialized values here in ref_args.
     jaxpr_ = initial_style_jaxpr(f, in_tree, ref_avals, dbg)
@@ -861,7 +861,7 @@ def run_state(f: Callable[..., None]) -> Callable[[T], T]:
 def run_state_reference(f: Callable[..., None]):
   def wrapped(args):
     dbg = api_util.debug_info("run_state", f, (args,), {})
-    flat_args, in_tree = tree_util.tree_flatten(args)
+    flat_args, in_tree = tree_util.tracing_registry.flatten(args)
     ref_avals, ref_args = unzip2(map(get_ref_aval_from_value, flat_args))
     jaxpr_ = initial_style_jaxpr(f, in_tree, ref_avals, dbg)
     consts = jaxpr_.consts

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -43,7 +43,10 @@ jax_multiplatform_test(
         "gpu": 5,
         "tpu": 5,
     },
-    deps = py_deps([
+    deps = [
+        "//jax/experimental:compute_on",
+        "//jax/experimental:custom_partitioning",
+    ] + py_deps([
         "absl/testing",
         "numpy",
     ]),

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -5133,6 +5133,138 @@ class APITest(jtu.JaxTestCase):
     self.assertIn("at y, now f32[2] and before f32[1]", msg)
     self.assertNotIn("explanation unavailable!", msg)
 
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_custom_vmap(self):
+    # https://github.com/jax-ml/jax/issues/40110
+    @jax.custom_batching.custom_vmap
+    def f(a): return jnp.sin(a)
+
+    @f.def_vmap
+    def f_vmap(axis_size, in_batched, a): return jnp.sin(a), in_batched[0]
+
+    f(jnp.ones(3, 'float32'))
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        f(jnp.ones(7, 'float32'))
+    self.assertTrue(any("different input types" in msg for msg in cm.output))
+    self.assertTrue(any("at a, now f32[7] and before f32[3]" in msg
+                        for msg in cm.output))
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_custom_partitioning(self):
+    # https://github.com/jax-ml/jax/issues/40110
+    from jax.experimental.custom_partitioning import custom_partitioning
+
+    @custom_partitioning
+    def f(x): return jnp.sin(x)
+
+    def partition(mesh, arg_shapes, result_shape):
+      raise NotImplementedError
+
+    def infer_sharding_from_operands(mesh, arg_shapes, result_shape):
+      raise NotImplementedError
+
+    f.def_partition(partition=partition,
+                    infer_sharding_from_operands=infer_sharding_from_operands,
+                    sharding_rule='i -> i')
+
+    f(jnp.ones(3, 'float32'))
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        f(jnp.ones(7, 'float32'))
+    self.assertTrue(any("at x, now f32[7] and before f32[3]" in msg
+                        for msg in cm.output))
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_custom_gradient(self):
+    # https://github.com/jax-ml/jax/issues/40110
+    # The bwd rule must be a stable function (not a per-call closure) so that
+    # the second trace of it finds the first trace's cache entry to diff.
+    def rule(g): return (g,)
+
+    @jax.custom_gradient
+    def f(x):
+      return jnp.sin(x), rule
+
+    jax.vjp(f, jnp.ones(3, 'float32'))
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        jax.vjp(f, jnp.ones(7, 'float32'))
+    self.assertTrue(any("at g, now f32[7] and before f32[3]" in msg
+                        for msg in cm.output))
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_closure_convert(self):
+    # https://github.com/jax-ml/jax/issues/40110
+    def fn(x): return x * 2.
+
+    jax.closure_convert(fn, jnp.ones(3, 'float32'))
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        jax.closure_convert(fn, jnp.ones(7, 'float32'))
+    self.assertTrue(any("at x, now f32[7] and before f32[3]" in msg
+                        for msg in cm.output))
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_linear_call(self):
+    # https://github.com/jax-ml/jax/issues/40110
+    def mul(r, x): return r * x
+    def mul_t(r, ct): return r * ct
+
+    jax.custom_derivatives.linear_call(mul, mul_t, jnp.ones(3, 'float32'), jnp.ones(3, 'float32'))
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        jax.custom_derivatives.linear_call(mul, mul_t, jnp.ones(7, 'float32'),
+                                           jnp.ones(7, 'float32'))
+    self.assertTrue(any("now f32[7] and before f32[3]" in msg
+                        for msg in cm.output))
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_compute_on(self):
+    # https://github.com/jax-ml/jax/issues/40110
+    from jax.experimental.compute_on import compute_on
+
+    @compute_on(compute_type='device_host',
+                out_memory_spaces=jax.memory.Space.Device)
+    def f(x): return jnp.sin(x)
+
+    f(jnp.ones(3, 'float32'))
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        f(jnp.ones(7, 'float32'))
+    self.assertTrue(any("at x, now f32[7] and before f32[3]" in msg
+                        for msg in cm.output))
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_run_state(self):
+    # https://github.com/jax-ml/jax/issues/40110
+    from jax._src.state.discharge import run_state
+
+    def body(refs):
+      a, b = refs
+      a[...] = a[...] + b[...]
+
+    run_state(body)((jnp.ones(3), jnp.ones(3)))
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        run_state(body)((jnp.ones(7), jnp.ones(7)))
+    self.assertTrue(any("different input types" in msg for msg in cm.output))
+
+  @jtu.thread_unsafe_test()  # logging is not thread-safe
+  def test_cache_miss_explanations_run_state_reference(self):
+    # https://github.com/jax-ml/jax/issues/40110
+    from jax._src.state.discharge import run_state_reference
+
+    def body(refs):
+      a, b = refs
+      a[...] = a[...] + b[...]
+
+    run_state_reference(body)((jnp.ones(3), jnp.ones(3)))
+    with config.explain_cache_misses(True):
+      with self.assertLogs(level="WARNING") as cm:
+        run_state_reference(body)((jnp.ones(7), jnp.ones(7)))
+    self.assertTrue(any("different input types" in msg for msg in cm.output))
+
   @unittest.skip('TODO(mattjj): re-enable after updating cache miss explainer')
   @jtu.thread_unsafe_test()  # logging is not thread-safe
   def test_cache_miss_explanations_other_shape_explain_closest(self):


### PR DESCRIPTION
Whenever a higher-order API flattens inputs in order to trace them, we should use the tracing pytree registry. The default registry is for user-facing tree_util aka jax.tree.* operations. The only difference between the two registries is how TransformedRefs are handled. (Note FlatTree uses the tracing registry by default, so we could also update these sites to use FlatTrees, but I didn't do that for now.)

fixes #40110