### PR TITLE
Widen jax.random.generalized_normal's p parameter type from float to RealArray

### DIFF
--- a/jax/_src/random/core.py
+++ b/jax/_src/random/core.py
@@ -3058,7 +3058,7 @@ def _orthogonal(key, n, _m, shape, dtype):
 
 def generalized_normal(
   key: ArrayLike,
-  p: float,
+  p: RealArray,
   shape: Shape = (),
   dtype: DTypeLikeFloat | None = None,
   *,
@@ -3076,7 +3076,8 @@ def generalized_normal(
 
   Args:
     key: a PRNG key used as the random key.
-    p: a float representing the shape parameter.
+    p: a float or array of floats broadcast-compatible with ``shape``
+      representing the shape parameter.
     shape: optional, the batch dimensions of the result. Default ().
     dtype: optional, a float dtype for the returned values (default float64 if
       jax_enable_x64 is true, otherwise float32).


### PR DESCRIPTION
Widen [`jax.random.generalized_normal`](https://docs.jax.dev/en/latest/_autosummary/jax.random.generalized_normal.html)'s `p` parameter type from `float` to `RealArray`.

The current narrow annotation makes type checkers reject perfectly valid calls.

```python3
import jax, jax.numpy as jnp
key = jax.random.key(0)
p = jnp.array([1.5, 3.0])
x = jax.random.generalized_normal(key, p, shape=(2,))
print(x)
# Array([1.06, 0.097], dtype=float32)
# but pyright flags this as an error under `p: float`
```

This PR widens `p` to `RealArray`, which matches the convention already used by every other array-like parameter in this file.