### PR TITLE
Add type annotations to jax.scipy.stats.truncnorm.

### DIFF
--- a/jax/_src/scipy/stats/truncnorm.py
+++ b/jax/_src/scipy/stats/truncnorm.py
@@ -20,6 +20,7 @@ from jax._src import numpy as jnp
 from jax._src.numpy.util import promote_args_inexact
 from jax._src.scipy.stats import norm
 from jax._src.scipy.special import logsumexp, log_ndtr, ndtr
+from jax._src.typing import Array, ArrayLike
 
 
 def _log_diff(x, y):
@@ -62,7 +63,13 @@ def _log_gauss_mass(a, b):
 
 
 @api.jit
-def logpdf(x, a, b, loc=0, scale=1):
+def logpdf(
+  x: ArrayLike,
+  a: ArrayLike,
+  b: ArrayLike,
+  loc: ArrayLike = 0,
+  scale: ArrayLike = 1,
+) -> Array:
   r"""Truncated normal log probability distribution function.
 
   JAX implementation of :obj:`scipy.stats.truncnorm` ``logpdf``.
@@ -106,7 +113,13 @@ def logpdf(x, a, b, loc=0, scale=1):
   return val
 
 
-def pdf(x, a, b, loc=0, scale=1):
+def pdf(
+  x: ArrayLike,
+  a: ArrayLike,
+  b: ArrayLike,
+  loc: ArrayLike = 0,
+  scale: ArrayLike = 1,
+) -> Array:
   r"""Truncated normal probability distribution function.
 
   JAX implementation of :obj:`scipy.stats.truncnorm` ``pdf``.
@@ -144,7 +157,13 @@ def pdf(x, a, b, loc=0, scale=1):
   return lax.exp(logpdf(x, a, b, loc, scale))
 
 @api.jit
-def logsf(x, a, b, loc=0, scale=1):
+def logsf(
+  x: ArrayLike,
+  a: ArrayLike,
+  b: ArrayLike,
+  loc: ArrayLike = 0,
+  scale: ArrayLike = 1,
+) -> Array:
   """Truncated normal distribution log survival function.
 
   JAX implementation of :obj:`scipy.stats.truncnorm` ``logsf``
@@ -180,7 +199,13 @@ def logsf(x, a, b, loc=0, scale=1):
 
 
 @api.jit
-def sf(x, a, b, loc=0, scale=1):
+def sf(
+  x: ArrayLike,
+  a: ArrayLike,
+  b: ArrayLike,
+  loc: ArrayLike = 0,
+  scale: ArrayLike = 1,
+) -> Array:
   """Truncated normal distribution survival function.
 
   JAX implementation of :obj:`scipy.stats.truncnorm` ``sf``
@@ -215,7 +240,13 @@ def sf(x, a, b, loc=0, scale=1):
 
 
 @api.jit
-def logcdf(x, a, b, loc=0, scale=1):
+def logcdf(
+  x: ArrayLike,
+  a: ArrayLike,
+  b: ArrayLike,
+  loc: ArrayLike = 0,
+  scale: ArrayLike = 1,
+) -> Array:
   r"""Truncated normal log cumulative distribution function.
 
   JAX implementation of :obj:`scipy.stats.truncnorm` ``logcdf``.
@@ -262,7 +293,13 @@ def logcdf(x, a, b, loc=0, scale=1):
   return logcdf
 
 @api.jit
-def cdf(x, a, b, loc=0, scale=1):
+def cdf(
+  x: ArrayLike,
+  a: ArrayLike,
+  b: ArrayLike,
+  loc: ArrayLike = 0,
+  scale: ArrayLike = 1,
+) -> Array:
   r"""Truncated normal cumulative distribution function.
 
   JAX implementation of :obj:`scipy.stats.truncnorm` ``cdf``.


### PR DESCRIPTION
Add missing type annotations to [`jax.scipy.stats.truncnorm`](https://docs.jax.dev/en/latest/jax.scipy.html#module-jax.scipy.stats.truncnorm).

Because `loc`/`scale` default to bare `int` literals with no annotation, type checkers like pyright infer their type as `int` and reject valid float/array arguments, even though the implementation accepts array-valued `loc`/`scale` at runtime:

```python3
import jax.scipy.stats as jss
jss.truncnorm.pdf(x, a, b, loc=jnp.array([1.0, 2.0]), scale=jnp.array([1.0, 2.0]))
# runs fine
# rejected by pyright under the current (inferred int) signature
```

This PR adds the same `ArrayLike`/`Array` annotations already used everywhere else in `jax.scipy.stats`, with no behavior change.