### PR TITLE
Fix precision loss in splash attention dsinks gradient (fixes #40128)

### DIFF
--- a/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py
+++ b/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py
@@ -316,7 +316,8 @@ def _attention_reference_custom_bwd(
   if sinks is not None:  # the gradient is ``sum(-exp(s) / exp(lse) * o * do)``
     sinks_exp = -jnp.exp(sinks[..., None, None].astype(jnp.float32)
                          - logsumexp[..., None].astype(jnp.float32))
-    dsinks = jnp.sum(sinks_exp.astype(o.dtype) * do * o)
+    dsinks = jnp.sum(sinks_exp * do.astype(jnp.float32)
+                     * o.astype(jnp.float32)).astype(o.dtype)
   return None, dq, dk, dv, None, dsinks
 
 
@@ -2357,7 +2358,8 @@ def _splash_attention_bwd(
   if sinks is not None:
     sinks_exp = -jnp.exp(sinks[..., None, None].astype(jnp.float32)
                          - logsumexp[..., None].astype(jnp.float32))
-    dsinks = jnp.sum(sinks_exp.astype(o.dtype) * o * do, axis=(-1, -2))
+    dsinks = jnp.sum(sinks_exp * o.astype(jnp.float32)
+                     * do.astype(jnp.float32), axis=(-1, -2)).astype(o.dtype)
   return (
       None,  # fwd_mask_info
       None,  # dq_mask_info

--- a/tests/pallas/tpu_splash_attention_kernel_test.py
+++ b/tests/pallas/tpu_splash_attention_kernel_test.py
@@ -837,5 +837,51 @@ class SplashAttentionTest(PallasBaseTest):
     np.testing.assert_array_equal(shrink_out, no_shrink_out)
 
 
+class SplashAttentionPrecisionTest(jtu.JaxTestCase):
+
+  def test_splash_attention_dsinks_precision(self):
+    """Test that dsinks maintains high precision in bfloat16 (issue #40128)."""
+    H, D, S = 4, 128, 8192
+    rng = np.random.default_rng(0)
+    sinks = jnp.asarray(rng.normal(0, 1, (H,)), jnp.float32)
+    lse = jnp.full((H, S), np.log(S), jnp.float32)
+    o = jnp.asarray(rng.normal(0, 1, (H, S, D)), jnp.bfloat16)
+    do = jnp.asarray(rng.normal(0, 1, (H, S, D)), jnp.bfloat16)
+
+    # 1. Exact float32 analytical reference
+    w = jnp.exp(sinks[..., None].astype(jnp.float32) - lse.astype(jnp.float32))
+    di = jnp.einsum(
+        "hsd,hsd->hs", o.astype(jnp.float32), do.astype(jnp.float32)
+    )
+    exact = -jnp.sum(w * di, axis=-1)
+
+    # 2. Directly call _attention_reference_custom_bwd on actual runtime tensors
+    mask = jnp.ones((S, S), dtype=jnp.bool_)
+    q = jnp.zeros((S, D), dtype=jnp.bfloat16)
+    k = jnp.zeros((S, D), dtype=jnp.bfloat16)
+    v = jnp.zeros((S, D), dtype=jnp.bfloat16)
+
+    dsinks_actual = []
+    for h in range(H):
+      res = (mask, q, k, v, None, sinks[h], o[h], lse[h])
+      _, _, _, _, _, dsink_h = splash._attention_reference_custom_bwd(
+          mask_value=splash.DEFAULT_MASK_VALUE,
+          save_residuals=False,
+          custom_type="flash",
+          attn_logits_soft_cap=None,
+          res=res,
+          do=do[h],
+      )
+      dsinks_actual.append(dsink_h)
+    dsinks_actual = jnp.stack(dsinks_actual)
+
+    # 3. Verify actual dsinks achieves < 0.5% relative error
+    for h in range(H):
+      r = float(exact[h])
+      f = float(dsinks_actual[h])
+      rel_err = abs(f - r) / abs(r)
+      self.assertLess(rel_err, 0.005)
+
+
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Fix for #40128

In the splash attention backward pass, dsinks previously truncated intermediate terms to o.dtype (e.g. bfloat16) before performing the summation / reduction. Because attention sink gradients involve heavily cancelling terms, early rounding led to substantial numerical cancellation and precision loss.

Adds regression test in tests/pallas/tpu_splash_attention_kernel_test.py.