### PR TITLE
Lower multi-dimensional IRFFT on GPU to a single C2R transform again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
 * Changes
   * JAX now uses Bazel 8.7.0 to build from source.
   * JAX now uses Bzlmod for its Bazel builds instead of WORKSPACE.
+  * On GPU, multi-dimensional inverse real FFTs ({func}`jax.numpy.fft.irfftn`,
+    {func}`jax.numpy.fft.irfft2` and {func}`jax.lax.fft` with `FftType.IRFFT`)
+    are again lowered to a single C2R transform, as before JAX 0.10.0, instead
+    of an IFFT over the outer axes and a 1-D IRFFT with two transposes. The
+    input is first made Hermitian-symmetric along the outer axes, which does
+    not change the result under NumPy's convention (only the last axis is
+    assumed symmetric), so results are unchanged while the transform is
+    ~1.4x faster at typical sizes.
 
 ## JAX 0.11.1 (August 17, 2026)
 

--- a/jax/_src/lax/fft.py
+++ b/jax/_src/lax/fft.py
@@ -140,43 +140,62 @@ def _fft_lowering(ctx, x, *, fft_type, fft_lengths):
   ]
 
 
+def _symmetrize_irfft_input(x, *, fft_lengths):
+  """Makes the input of a multi-dimensional IRFFT a valid Hermitian half-spectrum.
+
+  An array in RFFT layout is the RFFT of some real array iff its slices at
+  index 0 and, for an even last length n, at index n // 2 along the last FFT
+  axis are themselves Hermitian-symmetric along the outer FFT axes; the
+  other entries are unconstrained. NumPy's irfftn (an IFFT over the outer axes
+  followed by a 1-D IRFFT, which reads only the real part of the DC and
+  Nyquist bins) depends on those two slices only through their
+  Hermitian-symmetric part, so replacing each by that part leaves the result
+  under NumPy's convention unchanged, and yields an input on which a
+  multi-dimensional C2R transform that assumes Hermitian symmetry on every
+  axis computes the same result.
+  """
+  ndim = x.ndim
+  n, m = fft_lengths[-1], x.shape[-1]
+  outer_axes = range(ndim - len(fft_lengths), ndim - 1)
+
+  def hermitian_part(k):
+    s = slicing.slice_in_dim(x, k, k + 1, axis=ndim - 1)
+    r = s
+    for ax in outer_axes:
+      # r[..., i, ...] = s[..., -i mod size, ...]
+      size = x.shape[ax]
+      if size > 1:
+        r = lax.concatenate(
+            [slicing.slice_in_dim(r, 0, 1, axis=ax),
+             lax.rev(slicing.slice_in_dim(r, 1, size, axis=ax), (ax,))], ax)
+    return 0.5 * (s + lax.conj(r))
+
+  # A single concatenate lowers to one fusion over the input, which is cheaper
+  # than updating the slices in place (XLA copies the operand to do so).
+  nyquist = n // 2 if n % 2 == 0 and 0 < n // 2 < m else None
+  parts = [hermitian_part(0)]
+  if nyquist is None:
+    parts.append(slicing.slice_in_dim(x, 1, m, axis=ndim - 1))
+  else:
+    parts.extend([slicing.slice_in_dim(x, 1, nyquist, axis=ndim - 1),
+                  hermitian_part(nyquist),
+                  slicing.slice_in_dim(x, nyquist + 1, m, axis=ndim - 1)])
+  return lax.concatenate(parts, ndim - 1)
+
+
 def _fft_lowering_gpu(ctx, x, *, fft_type, fft_lengths):
-  # Decompose multi-dimensional IRFFT into a sequence of transforms.
-  # cuFFT assumes Hermitian symmetry on all dimensions of a multi-dimensional
-  # C2R transform, whereas our other implementations and NumPy only require
-  # symmetry on the final dimension.
-  if fft_type == FftType.IRFFT and len(fft_lengths) > 1:
-    rank = len(ctx.avals_in[0].shape)
-
-    # Move the final C2R axis (at index -1) to the start of the FFT block.
-    target_pos = rank - len(fft_lengths)
-
-    perm_out = list(range(rank))
-    perm_out.insert(target_pos, perm_out.pop(-1))
-    x = hlo.transpose(x, mlir.dense_int_array(perm_out))
-
-    # Apply multi-dimensional IFFT on the outer axes (which are now at the end).
-    outer_lengths = fft_lengths[:-1]
-    x = hlo.fft(
-        x,
-        hlo.FftTypeAttr.get(FftType.IFFT.name),
-        mlir.dense_int_array(outer_lengths),
-    )
-
-    # Move the C2R axis back to the end.
-    perm_in = list(range(rank))
-    perm_in.append(perm_in.pop(target_pos))
-    x = hlo.transpose(x, mlir.dense_int_array(perm_in))
-
-    # Apply 1D IRFFT on the last axis.
-    x = hlo.fft(
-        x,
-        hlo.FftTypeAttr.get(FftType.IRFFT.name),
-        mlir.dense_int_array((fft_lengths[-1],)),
-    )
-
-    return [x]
-
+  # cuFFT and hipFFT assume Hermitian symmetry on all dimensions of a
+  # multi-dimensional C2R transform, whereas our other implementations and
+  # NumPy only require symmetry on the final dimension. Rather than
+  # decomposing the transform into an IFFT over the outer axes and a 1-D IRFFT
+  # (two FFT launches plus two transposes, measured at ~1.7x the cost of a
+  # single multi-dimensional C2R transform), make the input satisfy the
+  # stronger assumption, which does not change its IRFFT under NumPy's
+  # convention (see _symmetrize_irfft_input), and emit one C2R transform.
+  if (fft_type == FftType.IRFFT and len(fft_lengths) > 1
+      and is_constant_shape(fft_lengths)):
+    x, = mlir.lower_fun(_symmetrize_irfft_input, multiple_results=False)(
+        ctx, x, fft_lengths=fft_lengths)
   return _fft_lowering(ctx, x, fft_type=fft_type, fft_lengths=fft_lengths)
 
 

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -184,6 +184,51 @@ class FftTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fn, jnp_fn, lambda: (a,), check_dtypes=False, tol=1e-4)
     self._CompileAndCheck(jnp_fn, lambda: (a,), atol=2e-6)
 
+  @jtu.sample_product(
+    [dict(shape=shape, s=s)
+     for shape, s in [((5, 1), (5, 1)), ((3, 5, 1), (5, 1)), ((4, 1), (4, 1)),
+                      ((6, 2), (6, 2)), ((5, 2), (5, 2)), ((6, 5), (6, 8)),
+                      ((5, 4), (5, 7)), ((3, 6, 5), (6, 8)), ((4, 6, 1), (4, 6, 1)),
+                      ((4, 4, 3), (4, 4, 4)), ((3, 5, 4), (3, 5, 7)),
+                      ((2, 3, 4, 3), (3, 4, 5))]],
+    dtype=jtu.dtypes.complex,
+  )
+  def testIrfftnNonHermitianOuterAxes(self, shape, s, dtype):
+    # Like NumPy, only the last axis of a multi-dimensional IRFFT input is
+    # assumed to be Hermitian-symmetric; the slices at index 0 and n // 2 of
+    # the last axis need not be symmetric along the outer axes. Exercises
+    # even/odd lengths and the degenerate last lengths 1 and 2 (the GPU
+    # lowering makes the input symmetric before a single C2R transform; see
+    # https://github.com/jax-ml/jax/issues/29325).
+    rng = jtu.rand_default(self.rng())
+    axes = tuple(range(-len(s), 0))
+    def args_maker():
+      # Zero the imaginary parts of the DC and Nyquist bins of the last axis
+      # (as _zero_for_irfft does), keeping the outer axes non-symmetric.
+      z = np.array(rng(shape, dtype))
+      z[..., 0] = z[..., 0].real
+      if s[-1] % 2 == 0 and s[-1] // 2 < shape[-1]:
+        z[..., s[-1] // 2] = z[..., s[-1] // 2].real
+      return (z,)
+    jnp_fn = lambda x: jnp.fft.irfftn(x, s=s, axes=axes)
+    np_fn = lambda x: np.fft.irfftn(x, s=s, axes=axes)
+    self._CheckAgainstNumpy(np_fn, jnp_fn, args_maker, check_dtypes=False,
+                            tol=1e-4)
+    self._CompileAndCheck(jnp_fn, args_maker, atol={np.complex64: 3e-6},
+                          rtol={np.float32: 2e-6, np.complex64: 3e-6})
+
+  def testIrfftnGpuLoweringIsASingleFft(self):
+    # On GPU a multi-dimensional IRFFT lowers to a single C2R FFT op (preceded
+    # by the symmetrization of the DC/Nyquist slices of the last axis), not to
+    # an IFFT over the outer axes plus a 1-D IRFFT with two transposes, which
+    # costs ~1.7x as much.
+    x = jnp.ones((2, 6, 5), jnp.complex64)
+    f = jax.jit(lambda a: jnp.fft.irfft2(a, s=(6, 8)))
+    text = f.trace(x).lower(lowering_platforms=("cuda",)).as_text()
+    self.assertEqual(text.count("stablehlo.fft"), 1)
+    self.assertIn("type = IRFFT, length = [6, 8]", text)
+    self.assertNotIn("stablehlo.transpose", text)
+
   def testIrfftTranspose(self):
     # regression test for https://github.com/jax-ml/jax/issues/6223
     def build_matrix(linear_func, size):


### PR DESCRIPTION
Fixes #40143. Related: #29325.

Since 0533a2068 (0.10.0) the GPU lowering decomposes a multi-dimensional IRFFT into an IFFT over the outer axes and a 1-D IRFFT, with two transposes, so that results match NumPy/CPU/TPU (Hermitian symmetry assumed only along the last axis) rather than cuFFT's multi-dimensional C2R (assumed along every axis). The decomposition costs ~1.7× the time of one multi-dimensional C2R.

This PR keeps the NumPy semantics and restores the single C2R: the input is first made Hermitian-symmetric along the outer axes, which does not change its IRFFT.

*Why it is exact.* An array in RFFT layout is the RFFT of some real array iff its slices at index 0 and, for an even last length n, at n//2 along the last axis are Hermitian-symmetric along the outer FFT axes; the other entries are unconstrained. NumPy's `irfftn` (IFFT over the outer axes, then a 1-D IRFFT that reads only the real part of the DC and Nyquist bins) is `(1/N) Σ_{k∈half} m_k Re(z_k e^{+2πi k·j/N})`, which depends on those two slices only through their Hermitian-symmetric part. Replacing each slice by `(z_k + conj(z_{-k}))/2` therefore leaves the result unchanged under NumPy's convention, and yields a valid half-spectrum on which a C2R transform that assumes symmetry on every axis computes the same inverse. The symmetrization is a single `concatenate` (one elementwise fusion over the input, which fuses with a producing elementwise op); updating the slices in place makes XLA copy the operand and was slower.

*Measurements* (L40S, cuFFT 11.4, jaxlib 0.11.1, complex64, min of 15; input as a jit parameter / as an intermediate of the same jit):

| irfftn | before (0.10.0–0.11.1) | this PR | bare C2R, no symmetrization |
|---|---:|---:|---:|
| `(49, 262, 80, 41) → (80, 80)` | 7.29 / 7.29 ms | 5.25 / 5.24 ms | 4.17 / 5.18 ms |
| `(49, 16, 160, 81) → (160, 160)` | 1.56 / 1.56 ms | 1.09 / 1.09 ms | 0.85 / 1.08 ms |
| `(8, 32, 32, 17) → (32, 32, 32)` | 0.05 ms | 0.04–0.05 ms | 0.05 ms |

`max|new − old| / max|old| = 2e-7` (rounding). Outputs agree with NumPy to float32 rounding for inputs that are not symmetric along the outer axes, including the `s=(5, 1)` case of #29325 (where the bare cuFFT C2R does differ), and gradients (GPU == CPU) are unchanged.

*Tests.* `testIrfftnNonHermitianOuterAxes` (12 shape/`s` combinations incl. last lengths 1 and 2, 3-D, batch dims, against NumPy) and `testIrfftnGpuLoweringIsASingleFft` (lowers for `cuda` via `lowering_platforms`, so it runs on CPU CI: one `stablehlo.fft … IRFFT, length = [6, 8]`, no transpose); the existing `testIrfftnNonSymmetricOuterAxes` is kept. `tests/fft_test.py` passes on CPU and on an L40S with and without `JAX_ENABLE_X64`. The lowering is the same for `rocm` (not tested here). CHANGELOG entry added.