### PR TITLE
Fix eigh gradients for large eigenvalues

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1357,7 +1357,8 @@ def _eigh_jvp_rule(
   eye_n = lax._eye(a.dtype, (n, n))
   # carefully build reciprocal delta-eigenvalue matrix, avoiding NaNs.
   with config.numpy_rank_promotion("allow"):
-    Fmat = lax.integer_pow(eye_n + w[..., np.newaxis, :] - w[..., np.newaxis], -1) - eye_n
+    delta_w = w[..., np.newaxis, :] - w[..., np.newaxis]
+    Fmat = lax.integer_pow(delta_w + eye_n, -1) - eye_n
   # eigh impl doesn't support batch dims, but future-proof the grad.
   dot = partial(lax.dot if a.ndim == 2 else lax.batch_matmul,
                 precision=lax.Precision.HIGHEST)

--- a/tests/eigh_test.py
+++ b/tests/eigh_test.py
@@ -290,6 +290,23 @@ class EighTest(jtu.JaxTestCase):
     jtu.assert_dot_precision(
         lax.Precision.HIGHEST, partial(jvp, jnp.linalg.eigh), (a,), (a,))
 
+  def testEighGradLargeEigenvalues(self):
+    # At 2**24, float32 can no longer represent every consecutive integer.
+    a = jnp.diag(
+        jnp.array(
+            [2**24, 2**24 + 2, 2**24 + 4],
+            dtype=jnp.float32,
+        )
+    )
+
+    def eigenvectors(x):
+      return jnp.linalg.eigh(x)[1]
+
+    for jacobian in (jax.jacfwd, jax.jacrev):
+      with self.subTest(jacobian=jacobian.__name__):
+        jac = jacobian(eigenvectors)(a)
+        self.assertTrue(np.isfinite(np.asarray(jac)).all())
+
   def testEighGradRankPromotion(self):
     rng = jtu.rand_default(self.rng())
     a = rng((10, 3, 3), np.float32)


### PR DESCRIPTION
Fixes #40141.

`_eigh_jvp_rule` constructs the reciprocal eigenvalue-gap matrix using
```
    eye + w_j - w_i
```
to avoid dividing by zero on its diagonal.

Although this is correct in exact arithmetic, the evaluation order is
numerically unsafe for large eigenvalues. 

For example, at `2**24` in
float32, adding `1` to an eigenvalue may round back to the same
floating-point value. The subsequent subtraction can therefore produce
zero (or another incorrect value) on the diagonal, causing the
reciprocal to produce non-finite or incorrect entries.

Compute the eigenvalue differences first and add the identity guard
afterward:
```
    (w_j - w_i) + eye
```
Diagonal subtraction is then exactly zero before the guard is
added, while off-diagonal eigenvalue differences are unchanged.

Add a regression test using distinct float32 eigenvalues around
`2**24`, checking that both `jacfwd` and `jacrev` of the eigenvectors
remain finite.

Tests passed:
- `pytest tests/eigh_test.py -k EighGradLargeEigenvalues`
- `pytest tests/eigh_test.py -k EighGrad`
- `pytest tests/eigh_test.py`
- `JAX_ENABLE_X64=1 pytest tests/eigh_test.py -k EighGrad`