### PR TITLE
Fix multinomial logpmf validity mask for batched input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * JAX now uses Bazel 8.7.0 to build from source.
   * JAX now uses Bzlmod for its Bazel builds instead of WORKSPACE.
 
+* Bug fixes
+  * {func}`jax.scipy.stats.multinomial.logpmf` and
+    {func}`jax.scipy.stats.multinomial.pmf` now perform their support check
+    over the last axis of ``x`` only, so batched inputs containing rows whose
+    counts do not sum to ``n`` return correct values for the valid rows
+    instead of ``-inf`` everywhere.
+
 ## JAX 0.11.1 (August 17, 2026)
 
 * New features

--- a/jax/_src/scipy/stats/multinomial.py
+++ b/jax/_src/scipy/stats/multinomial.py
@@ -53,7 +53,7 @@ def logpmf(x: ArrayLike, n: ArrayLike, p: ArrayLike) -> Array:
   x = x.astype(p.dtype)
   n = n.astype(p.dtype)
   logprobs = gammaln(n + 1) + jnp.sum(xlogy(x, p) - gammaln(x + 1), axis=-1)
-  return jnp.where(jnp.equal(jnp.sum(x), n), logprobs, -np.inf)
+  return jnp.where(jnp.equal(jnp.sum(x, axis=-1), n), logprobs, -np.inf)
 
 
 def pmf(x: ArrayLike, n: ArrayLike, p: ArrayLike) -> Array:

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -1422,6 +1422,20 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
                             tol=5e-4)
 
+  def testMultinomialLogPmfBatched(self):
+    p = np.array([0.2, 0.3, 0.5], np.float32)
+    n = 10
+    xs = [
+      np.array([[10, 0, 0], [4, 3, 3]], np.int32),
+      np.array([[10, 0, 0], [8, 0, 0]], np.int32),
+      np.array([[10, 0, 0], [0, 0, 0]], np.int32),
+    ]
+    for x in xs:
+      self.assertAllClose(
+        osp_stats.multinomial.logpmf(x, n, p),
+        lsp_stats.multinomial.logpmf(x, n, p),
+        check_dtypes=False)
+
   @jtu.sample_product(
     [dict(x_shape=x_shape, mean_shape=mean_shape, cov_shape=cov_shape)
       for x_shape, mean_shape, cov_shape in [


### PR DESCRIPTION
## Description

`jax.scipy.stats.multinomial.logpmf` checked its support condition with `jnp.sum(x)` over all axes instead of the category axis. For batched input the mask therefore compared a single global total against `n`, so a batch containing one row whose counts did not sum to `n` returned `-inf` for every row, and a batch whose grand total coincidentally equaled `n` returned finite garbage for invalid rows (for example `logpmf([[10,0,0],[0,0,0]], 10, p)` returned about `+15.1` for the impossible zero row). The fix sums over the last axis only, matching the per-row semantics of `scipy.stats.multinomial`.

Found by differential testing against scipy 1.17.1 while auditing `jax.scipy.stats` boundary behavior; the existing parametrized test always generated rows summing to `n`, so the bug was invisible to it. The new regression test covers a fully valid batch, a wrong-total row, and the grand-total coincidence case.

## AI assistance disclosure

This change was developed with AI assistance under my direction and review; I have examined the code and tests, run the verification below locally, and submit this in accordance with the project's AI policy and the Google CLA.

## Test plan (run locally on Windows, Python 3.12, scipy 1.17.1)

```
python -m pytest tests/scipy_stats_test.py -k Multinomial -q
  4 passed, 979 deselected
JAX_ENABLE_X64=1 python -m pytest tests/scipy_stats_test.py -k Multinomial -q
  11 passed, 1011 deselected
python -m pytest tests/scipy_stats_test.py -q
  973 passed, 10 skipped
python -m ruff check jax/_src/scipy/stats/multinomial.py tests/scipy_stats_test.py
  All checks passed!
```

Before/after on the regression case:

```
before: logpmf([[10,0,0],[4,3,3]], 10, p) = [-inf, -inf]
after : logpmf([[10,0,0],[4,3,3]], 10, p) = [-16.09438, -3.78627]   (scipy agrees)
before: logpmf([[10,0,0],[0,0,0]], 10, p) = [-16.09438, +15.10441]
after : logpmf([[10,0,0],[0,0,0]], 10, p) = [-16.09438, -inf]       (scipy agrees)
```
