### PR TITLE
Fix chi2 logpdf nan at boundary points for df = 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * JAX now uses Bazel 8.7.0 to build from source.
   * JAX now uses Bzlmod for its Bazel builds instead of WORKSPACE.
 
+* Bug fixes
+  * {func}`jax.scipy.stats.chi2.logpdf` and {func}`jax.scipy.stats.chi2.pdf`
+    now evaluate the ``df == 2`` case correctly at the boundary points
+    ``x == 0`` and ``x = inf``, returning the finite scipy values instead of
+    ``nan``.
+
 ## JAX 0.11.1 (August 17, 2026)
 
 * New features

--- a/jax/_src/scipy/stats/chi2.py
+++ b/jax/_src/scipy/stats/chi2.py
@@ -18,7 +18,7 @@ from jax._src import lax
 from jax._src import numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.util import promote_args_inexact
-from jax._src.scipy.special import gammainc, gammaincc
+from jax._src.scipy.special import gammainc, gammaincc, xlogy
 from jax._src.typing import Array, ArrayLike
 
 
@@ -62,7 +62,9 @@ def logpdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1
   y = lax.div(lax.sub(x, loc), scale)
   df_on_two = lax.div(df, two)
 
-  kernel = lax.sub(lax.mul(lax.sub(df_on_two, one), lax.log(y)), lax.div(y,two))
+  coef = lax.sub(df_on_two, one)
+  # as in scipy, the log term is exactly zero when df == 2, even at y == 0
+  kernel = lax.sub(xlogy(coef, y), lax.div(y, two))
 
   nrml_cnst = lax.neg(lax.add(lax.lgamma(df_on_two),lax.div(lax.mul(lax.log(two), df),two)))
 

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -1347,6 +1347,25 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
                               tol=5e-4)
       self._CompileAndCheck(lax_fun, args_maker)
 
+  def testChi2BoundaryValues(self):
+    x = np.array([-1., 0., 5., np.inf], dtype=np.float32)
+    df = np.array([0.5, 1., 2., 3., 4.], dtype=np.float32)
+    xx = np.tile(x[:, None], (1, df.size))
+    dd = np.tile(df[None, :], (x.size, 1))
+    with np.errstate(divide='ignore', invalid='ignore'):
+      expected_logpdf = osp_stats.chi2.logpdf(xx, dd)
+      actual_logpdf = lsp_stats.chi2.logpdf(xx, dd)
+      expected_pdf = osp_stats.chi2.pdf(xx, dd)
+      actual_pdf = lsp_stats.chi2.pdf(xx, dd)
+    np.testing.assert_allclose(actual_logpdf, expected_logpdf, rtol=1e-5,
+                               equal_nan=True)
+    np.testing.assert_allclose(actual_pdf, expected_pdf, rtol=1e-5,
+                               equal_nan=True)
+    with np.errstate(divide='ignore', invalid='ignore'):
+      expected_logpdf = osp_stats.chi2.logpdf(0., 2., loc=1., scale=2.)
+      actual_logpdf = lsp_stats.chi2.logpdf(0., 2., loc=1., scale=2.)
+    self.assertEqual(actual_logpdf, expected_logpdf)
+
   @genNamedParametersNArgs(5)
   def testBetaBinomLogPmf(self, shapes, dtypes):
     rng = jtu.rand_positive(self.rng())


### PR DESCRIPTION
## Description

`jax.scipy.stats.chi2.logpdf` computed its kernel term `(df/2 - 1) * log(y)` directly. When `df == 2` the coefficient is zero, so at `y == 0` (that is, `x == loc`, an in-support point of the chi-square distribution) the product evaluates `0 * (-inf)` and returns `nan`; the same happened at `y = inf`. scipy returns finite values in both cases: `logpdf(0., 2.) = -log(2)` and `pdf(0., 2.) = 0.5`.

The fix wraps the term in `xlogy` from `jax._src.scipy.special`, which returns exactly zero when its first argument is zero and carries a correct custom JVP. This matches how scipy's own implementation handles the case and keeps derivatives with respect to `df` correct (a plain `jnp.where` guard was tried first and rejected because it zeroes the tangent whenever `df == 2`, silently corrupting `grad(..., argnums=1)` for the common exponential case).

Found by differential testing against scipy 1.17.1 while auditing `jax.scipy.stats` boundary behavior.

## AI assistance disclosure

This change was developed with AI assistance under my direction and review; I have examined the code and tests, run the verification below locally, and submit this in accordance with the project's AI policy and the Google CLA.

## Test plan (run locally on Windows, Python 3.12, scipy 1.17.1)

```
python -m pytest tests/scipy_stats_test.py -k "Chi2" -q
  51 passed, 932 deselected
JAX_ENABLE_X64=1 python -m pytest tests/scipy_stats_test.py -k "Chi2" -q
  51 passed, 971 deselected
python -m pytest tests/scipy_stats_test.py -q
  973 passed, 10 skipped
python -m ruff check jax/_src/scipy/stats/chi2.py
  All checks passed!
```

Boundary grid after the fix (float32, all cells match scipy):

```
x=0.0 df=2.0: logpdf -0.693147 (was nan), pdf 0.5 (was nan)
x=inf df=2.0: logpdf -inf   (was nan), pdf 0.0 (was nan)
x=0.0 df<2 / df>2: +inf / -inf, unchanged and matching scipy
grad wrt df at (x=1.5, df=2): 0.14476663, agrees with central differences
```
