### PR TITLE
Give exactly-zero results of remainder, floor_divide and divmod the correct sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     ``size=0``, which previously raised a ValueError; they now return empty
     arrays of the natural result dtype.
 
+* Bug fixes
+  * Exactly-zero floating-point results of {func}`jax.numpy.remainder`,
+    {func}`jax.numpy.mod`, {func}`jax.numpy.floor_divide`,
+    {func}`jax.numpy.divmod` and the corresponding `%`, `//` and `divmod`
+    operators now have the same sign as in NumPy and Python (the divisor's
+    sign for the remainder, the true quotient's sign for the floored
+    quotient); previously the sign of a zero result followed the dividend or
+    was lost ({jax-issue}`#40028`).
+
 ## JAX 0.11.1 (August 17, 2026)
 
 * New features

--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -2590,12 +2590,19 @@ def _float_divmod(x1: ArrayLike, x2: ArrayLike) -> tuple[Array, Array]:
   # see float_divmod in floatobject.c of CPython
   mod = lax.rem(x1, x2)
   x1_corrected = _where(x2 == 0, x1, lax.sub(x1, mod))
+  # give exactly-zero results CPython's sign; copysign needs signbit, which
+  # only supports 16-bit and wider floats
+  fix_zero_sign = dtypes.finfo(dtypes.dtype(x1)).bits >= 16
+  if fix_zero_sign:
+    x1_corrected = copysign(x1_corrected, x1)
   div = lax.div(x1_corrected, x2)
 
   ind = lax.bitwise_and(mod != 0, lax.sign(x2) != lax.sign(mod))
   mod = lax.select(ind, mod + x2, mod)
   div = lax.select(ind, div - 1.0, div)
 
+  if fix_zero_sign:
+    mod = copysign(mod, x2)
   return lax.round(div), mod
 
 
@@ -3136,6 +3143,11 @@ def remainder(x1: ArrayLike, x2: ArrayLike, /) -> Array:
   do_plus = lax.bitwise_and(
       lax.ne(lax.lt(trunc_mod, zero), lax.lt(x2, zero)), trunc_mod_not_zero)
   out = lax.select(do_plus, lax.add(trunc_mod, x2), trunc_mod)
+  if (dtypes.issubdtype(x1.dtype, np.floating)
+      and dtypes.finfo(x1.dtype).bits >= 16):
+    # give exactly-zero results the divisor's sign, matching NumPy; skipped
+    # for sub-16-bit floats, which copysign/signbit do not support
+    out = copysign(out, x2)
   jnp_error._set_error_if_nan(out)
   return out
 

--- a/tests/array_api_skips.txt
+++ b/tests/array_api_skips.txt
@@ -11,23 +11,8 @@ array_api_tests/test_creation_functions.py::test_asarray_arrays
 
 # Returns wrong zero sign
 array_api_tests/test_special_cases.py::test_unary[sign((x_i is -0 or x_i == +0)) -> 0]
-array_api_tests/test_special_cases.py::test_iop[__imod__(x1_i is +0 and x2_i < 0) -> -0]
-array_api_tests/test_special_cases.py::test_iop[__imod__(x1_i is -0 and x2_i > 0) -> +0]
-array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is -0 and x2_i > 0) -> -0]
-array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is -0 and x2_i < 0) -> +0]
-array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is -0 and x2_i > 0) -> -0]
 array_api_tests/test_special_cases.py::test_binary[__floordiv__(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
-array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is -0 and x2_i < 0) -> +0]
 array_api_tests/test_special_cases.py::test_binary[__floordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
-array_api_tests/test_special_cases.py::test_binary[remainder(x1_i is -0 and x2_i > 0) -> +0]
-array_api_tests/test_special_cases.py::test_binary[__mod__(x1_i is -0 and x2_i > 0) -> +0]
-array_api_tests/test_special_cases.py::test_binary[floor_divide(isfinite(x1_i) and x1_i < 0 and x2_i is -infinity) -> +0]
-array_api_tests/test_special_cases.py::test_binary[__mod__(x1_i is +0 and x2_i < 0) -> -0]
-array_api_tests/test_special_cases.py::test_binary[remainder(x1_i is +0 and x2_i < 0) -> -0]
-array_api_tests/test_special_cases.py::test_binary[__floordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is -infinity) -> +0]
-array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -0 and x2_i > 0) -> -0]
-array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -0 and x2_i < 0) -> +0]
-array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is -infinity) -> +0]
 
 # Array API expects default value for axis argument.
 array_api_tests/test_indexing_functions.py::test_take_along_axis

--- a/tests/lax_numpy_operators_test.py
+++ b/tests/lax_numpy_operators_test.py
@@ -724,6 +724,55 @@ class JaxNumpyOperatorTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np.floor_divide, jnp.floor_divide, args_maker)
     self._CompileAndCheck(jnp.floor_divide, args_maker)
 
+  @jtu.sample_product(
+      dtype=float_dtypes,
+      fn=["remainder", "mod", "floor_divide", "divmod"],
+  )
+  @jtu.ignore_warning(category=RuntimeWarning, message="divide by zero*")
+  @jtu.ignore_warning(category=RuntimeWarning, message="invalid value*")
+  def test_divlike_result_sign(self, fn, dtype):
+    # Regression test for https://github.com/jax-ml/jax/issues/40028: an
+    # exactly-zero result must match NumPy's sign (the divisor's sign for
+    # remainder/mod, the true quotient's sign for floor_divide). NaN results
+    # are mapped to True so that their (unspecified) sign bit is not compared.
+    if jtu.test_device_matches(["tpu"]) and dtype == np.float16:
+      # TPU gives wrong float16 results for finite dividends with an
+      # infinite divisor.
+      raise SkipTest("wrong float16 results for infinite divisors on TPU")
+    vals = np.array([-4.0, -3.0, -1.0, -0.5, -0.0, 0.0, 0.5, 1.0, 3.0, 4.0,
+                     np.inf, -np.inf], dtype=dtype)
+    x1, x2 = map(np.ravel, np.meshgrid(vals, vals))
+    args_maker = lambda: [x1, x2]
+
+    def jnp_fun(*args):
+      result = getattr(jnp, fn)(*args)
+      return jax.tree.map(lambda x: jnp.isnan(x) | jnp.signbit(x), result)
+
+    def np_fun(*args):
+      result = getattr(np, fn)(*args)
+      return jax.tree.map(lambda x: np.isnan(x) | np.signbit(x), result)
+
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
+  @jtu.sample_product(
+      dtype=[jnp.float8_e4m3fn, jnp.float8_e5m2],
+      fn=["remainder", "mod", "floor_divide", "divmod"],
+  )
+  def test_float8_division_ops(self, fn, dtype):
+    # The signed-zero fix (#40028) is skipped for float8 (signbit/copysign do
+    # not support it); these ops must keep working there.
+    x1 = np.array([-3.0, -1.0, 0.0, 2.5], dtype=dtype)
+    x2 = np.array([2.0, -2.0, -3.0, 1.5], dtype=dtype)
+    np_fun, jnp_fun = getattr(np, fn), getattr(jnp, fn)
+    expected = np_fun(x1, x2)
+    for f in [jnp_fun, jax.jit(jnp_fun)]:
+      actual = f(x1, x2)
+      exp_outs = expected if isinstance(expected, tuple) else (expected,)
+      act_outs = actual if isinstance(actual, tuple) else (actual,)
+      for exp, act in zip(exp_outs, act_outs):
+        self.assertArraysEqual(np.asarray(act), exp, check_dtypes=False)
+
   @jtu.sample_product(dtype=float_dtypes)
   def test_heaviside_nan(self, dtype):
     # Regression test for https://github.com/jax-ml/jax/issues/38105


### PR DESCRIPTION
Fixes #40028.

For floating point inputs, `jnp.remainder` returned an exactly-zero result with the sign of the dividend, while NumPy, Python's `%` and jax's own docstring say it should have the divisor's sign. `jnp.floor_divide` had the matching problem for a zero quotient (for example `-0.0 // 3.0` returned `0.0` instead of `-0.0`), and `jnp.mod`, `jnp.divmod` and the `%`, `//`, `divmod` operators inherit both. The sign of a zero is observable, `1 / result` flips between `inf` and `-inf`, so this propagates to real wrong values.

The cause is that `_float_divmod` in `jax/_src/numpy/ufuncs.py` is a port of CPython's `float_divmod` (the code comment points there) but drops its two zero-sign branches, `mod = copysign(0.0, wx)` and `floordiv = copysign(0.0, vx / wx)`. `remainder` is a separate formula with the same gap: its sign fixup is gated on the remainder being nonzero, so a zero keeps `lax.rem`'s dividend sign. The fix restores those branches with `copysign`, which is a no-op for every nonzero result (they already carry the right sign), so only the zeros change. Verified against NumPy over a special-value grid and a 200k-sample random sweep: no sign mismatches left and no nonzero value changes, on CPU and GPU, eager and jit, for float64/float32/float16/bfloat16 (the only remaining CPU-only divergence involves the smallest subnormals, where XLA:CPU comparisons flush to zero; that pre-exists this change and also affects the untouched `fmod`). Integer dtypes take a separate branch and are untouched. The copysign is skipped for sub-16-bit floats because `signbit` does not support them; float8 keeps its previous behavior, and a test pins that those ops keep working there.

This also lets us drop 15 entries from `tests/array_api_skips.txt` ("Returns wrong zero sign" section). I ran the pinned array-api-tests suite locally with the trimmed skips file and the full special-cases file passes. The two `__floordiv__` inf entries stay: there jax returns `-1.0`, matching NumPy and CPython against the spec, which is a separate (deliberate) divergence this PR does not touch.

One note for reviewers: the gradient of `remainder` changes at points where the result is exactly zero and the divisor is negative (the copysign flips the tangent sign there). That set has measure zero and sits on discontinuities of the primal where the derivative is a convention anyway; gradients everywhere else are bit-identical, and `floor_divide`'s gradient (zero via `round`) is unaffected.