### PR TITLE
Make `api_util.fun_sourceinfo` better at nested wrapped + partial'd functions

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -687,10 +687,12 @@ _fun_name_re = re.compile(r"(?:<built-in function (\S+)>)")
 
 # TODO(mattjj): make this function internal to this module
 def fun_sourceinfo(fun: Callable) -> str:
-  # See DebugInfo.fun_src_info
-  while isinstance(fun, partial):
-    fun = fun.func
+  # See DebugInfo.func_src_info
+
+  # inspect.unwrap unwraps through multiple wrapped functions
   fun = inspect.unwrap(fun)
+  while isinstance(fun, partial):
+    fun = inspect.unwrap(fun.func)
   try:
     filename = fun.__code__.co_filename
     lineno = fun.__code__.co_firstlineno

--- a/tests/api_util_test.py
+++ b/tests/api_util_test.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import partial
 import itertools as it
+
 from absl.testing import absltest
 from absl.testing import parameterized
+
 import jax
 from jax._src import api_util
 from jax import numpy as jnp
@@ -123,6 +126,25 @@ class ApiUtilTest(jtu.JaxTestCase):
     shardings = {"a": [None, None], "b": (None, None)}
     with self.assertRaisesRegex(ValueError, r"Mismatch details \(2 found\)"):
       api_util.flatten_axis_resources("test_spec", tree, shardings, False)
+
+  def test_fun_sourceinfo(self):
+    fsi = api_util.fun_sourceinfo
+
+    def f(): return None
+
+    expected = "f at .*/api_util_test.py:[0-9]+"
+
+    self.assertRegex(fsi(f), expected)
+    self.assertRegex(fsi(partial(f)), expected)
+    self.assertRegex(fsi(jax.jit(f)), expected)
+    self.assertRegex(fsi(partial(partial(jax.jit(partial(jax.jit(jax.jit((f)))))))),
+                     expected)
+
+    # Thwart CPython's collapsing of nested partials
+    g = partial(f)
+    g.foo = "bar"
+    self.assertNotEqual(partial(g).func, g.func)
+    self.assertRegex(fsi(partial(g)), expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Prior to this change, `fun_sourceinfo` couldn't recover functions that were wrapped partials, only the other way around. This change makes it unwrap and un-partial repeatedly.

In addition to making the debug info more useful, this avoids falling back to `str(fun)` in more cases, which can sometimes be expensive if called many times.