### PR TITLE
[oneAPI] Add OneMKL dependencies for solver and sparse kernels

### DIFF
--- a/jax_plugins/oneapi/__init__.py
+++ b/jax_plugins/oneapi/__init__.py
@@ -112,6 +112,8 @@ def _load_oneapi_libraries():
       'libmkl_sycl_rng.so*',
       'libmkl_sycl_sparse.so*',
       'libmkl_sycl_stats.so*',
+      'libmkl_avx512.so*',
+      'libmkl_def.so*',
   ]
 
   loaded = set()


### PR DESCRIPTION
## Summary

Adds two missing OneMKL shared library patterns to the oneAPI plugin loader in `jax_plugins/oneapi/__init__.py`:

- `libmkl_avx512.so*` — AVX-512 optimized MKL kernels required by solver and sparse operations on Intel hardware
- `libmkl_def.so*` — default MKL kernels needed as a fallback for the above

Without these, the solver and sparse MKL SYCL libraries (`libmkl_sycl_lapack`, `libmkl_sycl_sparse`) may fail to load at runtime on Intel XPU.

## Test plan

- [x] Verify `jax.lax.linalg` solver ops work correctly on Intel XPU
- [x] Verify sparse kernel operations load without missing symbol errors