### PR TITLE
[custom_vjp3] fix tracer leak in custom_vjp3 remat rule

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -505,7 +505,11 @@ def _saved_residuals(jaxpr: core.Jaxpr,
   # don't count reduce_precision_p as the producer, look through it instead
   subst = {e.outvars[0]: e.invars[0] for e in jaxpr.eqns
            if e.primitive is lax_internal.reduce_precision_p}
-  res_vars = {subst.get(v, v) for v in res_vars}
+  def look_through(v):
+    while v in subst:
+      v = subst[v]
+    return v
+  res_vars = {look_through(v) for v in res_vars}
 
   results = []
 

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -686,6 +686,20 @@ vjp_from_lin = _VJPFromLin(_vjp_fwd_from_lin, _transpose_linearized)
 
 
 class CustomVJPTraced(HiPrim):
+  """Applications take ``(consts, fwd_consts, *args)``.
+
+  The two leading arguments are synthetic, and both get zero cotangents:
+  ``consts`` is the primal function's closure environment promoted to an
+  argument (see ``Traced.with_consts_as_arg``), and ``fwd_consts`` is extra
+  inputs consumed only by the fwd rule and ignored by the primal (ordinarily
+  ``()``; the ``remat`` rule uses it to pass replay residuals to the helper
+  primitive it builds). Any value a rule needs beyond the primal arguments
+  must arrive through these slots as an explicit input, never by closure: the
+  rules are re-invoked by transformations after the trace of application time
+  is gone, so closed-over tracers go stale. The primal ``traced`` takes
+  ``(consts, *args)``; ``drop_fwd_consts`` maps the application signature
+  onto it.
+  """
   traced: Any
   fwd: Any
   bwd: Any
@@ -693,6 +707,11 @@ class CustomVJPTraced(HiPrim):
   static_argnums: Any
   opt_remat: bool
   with_logs: bool
+
+  @staticmethod
+  def drop_fwd_consts(consts, fwd_consts, *args):
+    del fwd_consts
+    return (consts, *args)
 
   def __init__(self, traced, fwd, bwd, in_avals, sym_zeros, static_argnums,
                opt_remat, with_logs=False):
@@ -706,8 +725,8 @@ class CustomVJPTraced(HiPrim):
     super().__init__()
 
   def expand(self, *args):
-    args = [x for x in args if not isinstance(x, Static)]
-    return self.traced(*args)
+    args = self.drop_fwd_consts(*args)
+    return self.traced(*[x for x in args if not isinstance(x, Static)])
 
   def lin(self, nzs_in, *primals):
     out, res, *rest = self.vjp_fwd(nzs_in, *primals)
@@ -777,7 +796,7 @@ class CustomVJPTraced(HiPrim):
     if not isinstance(in_cts, tuple):
       raise TypeError(f"Custom VJP bwd rule {self.bwd} must produce a tuple "
                       f"but got {type(in_cts)}.")
-    in_cts = (None, *in_cts)  # zero cotangent for the promoted-consts argument
+    in_cts = (None, None, *in_cts)  # zero cts for the consts and fwd_consts args
     if len(in_cts) != len(self.in_tree.children()) - len(self.static_argnums):
       raise ValueError(f"Custom VJP bwd rule {self.bwd} must produce a tuple "
                        "of length equal to the primal args tuple, but got "
@@ -785,7 +804,7 @@ class CustomVJPTraced(HiPrim):
     in_cts = broadcast_prefix(in_cts, in_avals_, is_leaf=lambda x: x is None)
     in_cts = tree_unflatten(self.in_tree, map(_replace_none, self.in_avals_flat, in_cts))
     tree_map_with_path(partial(_vjp_bwd_aval_mismatch_err, self.traced._fun_sourceinfo),
-                               self.in_avals[1:], in_cts[1:])
+                               self.in_avals[2:], in_cts[2:])
     if self.symbolic_zeros:
       in_cts = tree_map(ad_util.replace_rule_output_symbolic_zeros, in_cts)
     return (in_cts, logs) if self.with_logs else in_cts
@@ -810,7 +829,8 @@ class CustomVJPTraced(HiPrim):
     return primals_out, tangents_out
 
   def batch_dim_rule(self, axis_data, in_dims):
-    in_dims_flat = self.in_tree.flatten_up_to(in_dims)
+    _, primal_in_tree = tracing_registry.flatten(self.drop_fwd_consts(*self.in_avals))
+    in_dims_flat = primal_in_tree.flatten_up_to(self.drop_fwd_consts(*in_dims))
     _, out_dims = batching.batch_jaxpr2(self.traced.jaxpr, axis_data, tuple(in_dims_flat))
     return tree_unflatten(self.out_tree, out_dims)
 
@@ -831,15 +851,24 @@ class CustomVJPTraced(HiPrim):
       which_static = [i in self.static_argnums for i in range(len(args))]
       dyn_args, static_args = partition_list(which_static, args)
       static_args = [x.val for x in static_args]
-      fwd = lambda *dyn_args: self.fwd(*merge_lists(which_static, dyn_args, static_args))
+      fwd = lambda *dyn_args: self.fwd(*merge_lists(which_static, list(dyn_args), static_args))
     # custom_vjp_rules=False so that custom_vjp applications inside fwd hit
     # the early return above rather than recursively tracing their fwds.
     (out, _), rem_ = remat.remat_transform(trace.policy, fwd, *dyn_args,
                                            custom_vjp_rules=False)
-    rem = lambda *args: rem_(*[x for i, x in enumerate(args) if i not in self.static_argnums])
-    helper = CustomVJPTraced(self.traced, rem, self.bwd, self.in_avals,
+    res = tuple(rem_.args[0])
+    replay, statics = rem_.func, self.static_argnums
+    def fwd2(consts, fc_res, *rest):
+      fc, res = fc_res
+      args_ = (consts, fc, *rest)
+      return replay(res, *[x for i, x in enumerate(args_) if i not in statics])
+    in_avals = (self.in_avals[0],
+                (self.in_avals[1], tuple(map(typeof, res))),
+                *self.in_avals[2:])
+    helper = CustomVJPTraced(self.traced, fwd2, self.bwd, in_avals,
                              False, self.static_argnums, False, self.with_logs)
-    return out, helper
+    return out, lambda consts, fc, *rest: helper(consts, (fc, res), *rest)
+
 
 def _vjp_primal_fwd_tree_mismatch_err(self, tree):
   return (f"Custom VJP fwd rule {self.fwd.__name__} for function {self.traced.fun_name} "
@@ -931,12 +960,12 @@ class custom_vjp3:
       traced = api.jit(f).trace(*dyn_args)
     args = tuple(Static(x) if i in self.static_argnums else x for i, x in enumerate(args))
     consts, traced = traced.with_consts_as_arg()
-    fwd_ = update_wrapper(lambda _, *args: self.fwd(*args), self.fwd)
-    static_argnums = frozenset(i + 1 for i in self.static_argnums)
-    in_avals = tree_map(typeof, (consts, *args))
+    fwd_ = update_wrapper(lambda _, __, *args: self.fwd(*args), self.fwd)
+    static_argnums = frozenset(i + 2 for i in self.static_argnums)
+    in_avals = tree_map(typeof, (consts, (), *args))
     prim = CustomVJPTraced(traced, fwd_, self.bwd, in_avals, self.symz,
                            static_argnums, self.opt_remat, self.with_logs)
-    return prim(consts, *args)
+    return prim(consts, (), *args)
 
   def def_vmap(self, rule, /): return self.f.def_vmap(rule)
   def def_transpose(self, rule, /): return self.f.def_transpose(rule)

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -31,6 +31,8 @@ from jax import typeof
 from jax._src import config
 from jax._src import core
 from jax._src import state
+from jax._src.ad_checkpoint import saved_residuals
+from jax.ad_checkpoint import checkpoint_name
 from jax._src.state import indexing
 from jax._src.state import primitives as state_primitives
 from jax._src.custom_derivatives import custom_jvp_call_p
@@ -2851,6 +2853,74 @@ class HijaxTransformCoverageTest(jtu.JaxTestCase):
     hlo = jax.jit(f).lower(x).compile().as_text()
     self.assertIn("dce_sink", hlo)
     self.assertIn("custom_call", hlo)
+
+
+@jtu.with_config(jax_remat3=True, jax_custom_vjp3=True)
+class CustomVJPRemat3Test(jtu.JaxTestCase):
+
+  def _saved_sin(self):
+    @jax.custom_vjp
+    def f(y):
+      return jnp.sin(y)
+    def f_fwd(y):
+      return checkpoint_name(jnp.sin(y), 'saved'), (jnp.cos(y),)
+    def f_bwd(res, g):
+      c, = res
+      return (g * c,)
+    f.defvjp(f_fwd, f_bwd)
+    return f, jax.checkpoint_policies.save_only_these_names('saved')
+
+  def test_remat_of_jit_of_custom_vjp(self):
+    f, policy = self._saved_sin()
+    loss = lambda x: jax.remat(jax.jit(f), policy=policy)(x).sum()
+    x = jnp.arange(3.)
+    jax.jit(jax.grad(loss)).lower(x)
+    self.assertArraysAllClose(jax.grad(loss)(x), jnp.cos(x))
+
+  def test_remat_of_shard_map_of_custom_vjp(self):
+    f, policy = self._saved_sin()
+    mesh = jax.make_mesh((1,), ('i',))
+    P = jax.sharding.PartitionSpec
+    block = jax.jit(jax.shard_map(f, mesh=mesh, in_specs=P(), out_specs=P()))
+    loss = lambda x: jax.remat(block, policy=policy)(x).sum()
+    x = jnp.arange(3.)
+    jax.jit(jax.grad(loss)).lower(x)
+    self.assertArraysAllClose(jax.grad(loss)(x), jnp.cos(x))
+
+  def test_nested_remat_of_custom_vjp(self):
+    f, policy = self._saved_sin()
+    block = jax.jit(f)
+    loss = lambda x: jax.remat(jax.remat(block, policy=policy),
+                               policy=policy)(x).sum()
+    x = jnp.arange(3.)
+    self.assertArraysAllClose(jax.grad(loss)(x), jnp.cos(x))
+
+  def test_vmap_of_grad_of_remat_of_custom_vjp(self):
+    f, policy = self._saved_sin()
+    block = jax.jit(f)
+    loss = lambda x: jax.remat(block, policy=policy)(x[None]).sum()
+    x = jnp.arange(4.)
+    self.assertArraysAllClose(jax.vmap(jax.grad(loss))(x), jnp.cos(x))
+
+  def test_saved_residuals_names_value_in_custom_vjp_fwd(self):
+    @jax.custom_vjp
+    def f(x):
+      return jnp.sin(x) * 2.0
+    def f_fwd(x):
+      return checkpoint_name(jnp.sin(x) * 2.0, 'saved'), (x,)
+    def f_bwd(res, g):
+      x, = res
+      return (g * 2.0 * jnp.cos(x),)
+    f.defvjp(f_fwd, f_bwd)
+
+    def layer(x):
+      y = f(x)
+      return jnp.sum(y * y)
+
+    policy = jax.checkpoint_policies.save_only_these_names('saved')
+    res = saved_residuals(jax.remat(layer, policy=policy), jnp.arange(4.))
+    self.assertTrue(any("named 'saved'" in s for _, s in res),
+                    msg=f'saved residuals: {[s for _, s in res]}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The issue is that
1. custom_vjp rules (which are callables) can't close over Tracers, but
2. CustomVJPTraced.remat's generated fwd rule might close over Tracers.

The error we got from this issue was pretty far downsream: "No constant handler for DynamicJaxprTracer" in mlir.py, when setting `JAX_CUSTOM_VJP3=1` and `JAX_REMAT3=1`.

All Tracers have to be passed into bind. So we effectively needed to closure-convert the fwd rule generated in CustomVJPTraced.remat. But the primal and fwd rule must agree about their input signature, and both must also agree with the bwd rule's output signature in arity. So we need a unified signature that allows for the fwd rule having its own inputs that are ignored by the primal (and just populated with zeros by the bwd rule). This is analogous to cond: branches might each have their own consts that the other branches might ignore.

So our fix is to adapt the CustomVJPTraced call signature to have both primal consts and fwd consts, with each function's consts ignored by the other.

(We also fix a saved_residuals name attribution bug: we apply as many reduce_precisions as we have remats, so we made our look_through handle multiple reduce_precisions.)

In the near future we may want to make this kind of manipulation, like adding unused inputs, easier to do on Traced instances, since users might want to write their own CustomVJPTraced-like or Cond-like HiPrims, in which case they'll need to so manipulations like these on the branches. That's a TODO for the future though.