### PR TITLE
[OneAPI GPU] Enable hybrid solver kernels for the OneAPI backend

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1258,7 +1258,7 @@ eig_p = linalg_primitive(
     multiple_results=True)
 ad.primitive_jvps[eig_p] = eig_jvp_rule
 mlir.register_lowering(eig_p, _eig_cpu_lowering, platform="cpu")
-register_cpu_gpu_lowering(eig_p, _eig_gpu_lowering, ("cuda", "rocm"))
+register_cpu_gpu_lowering(eig_p, _eig_gpu_lowering, ("cuda", "rocm", "oneapi"))
 
 
 # Symmetric/Hermitian eigendecomposition
@@ -2056,7 +2056,8 @@ def _geqp3_cpu_gpu_lowering(ctx, a, jpvt, *, use_magma, target_name_prefix):
 geqp3_p = linalg_primitive(
     _geqp3_dtype_rule, (_float | _complex, _int), (2, 1),
     _geqp3_shape_rule, "geqp3", multiple_results=True, require_same=False)
-register_cpu_gpu_lowering(geqp3_p, _geqp3_cpu_gpu_lowering)
+register_cpu_gpu_lowering(geqp3_p, _geqp3_cpu_gpu_lowering,
+                          ("cpu", "cuda", "rocm", "oneapi"))
 
 
 def _qr_shape_rule(shape, *, pivoting, full_matrices, **_):

--- a/jaxlib/gpu/hybrid_kernels.cc
+++ b/jaxlib/gpu/hybrid_kernels.cc
@@ -279,6 +279,8 @@ class PivotingQrFactorizationHost {
       jpvt_tmp = std::make_unique<IntType[]>(n);
     }
 
+    FFI_RETURN_IF_ERROR_STATUS(JAX_AS_STATUS(gpuStreamSynchronize(stream)));
+
     for (int64_t i = 0; i < batch; ++i) {
       IntType info_v;
       if constexpr (std::is_same_v<IntType, int32_t>) {

--- a/jaxlib/gpu_solver.py
+++ b/jaxlib/gpu_solver.py
@@ -23,6 +23,7 @@ _hipsolver = import_from_plugin("rocm", "_solver")
 _hiphybrid = import_from_plugin("rocm", "_hybrid")
 
 _oneapisolver = import_from_plugin("oneapi", "_solver")
+_oneapihybrid = import_from_plugin("oneapi", "_hybrid")
 
 
 def registrations() -> dict[str, list[tuple[str, Any, int]]]:
@@ -38,7 +39,8 @@ def registrations() -> dict[str, list[tuple[str, Any, int]]]:
           (name, value, int(name.endswith("_ffi")))
           for name, value in module.registrations().items()
       )
-  for platform, module in [("CUDA", _cuhybrid), ("ROCM", _hiphybrid)]:
+  for platform, module in [("CUDA", _cuhybrid), ("ROCM", _hiphybrid),
+                            ("ONEAPI", _oneapihybrid)]:
     if module:
       registrations[platform].extend(
           (*i, 1) for i in module.registrations().items()
@@ -53,7 +55,7 @@ def batch_partitionable_targets() -> list[str]:
       targets.extend(
           name for name in module.registrations() if name.endswith("_ffi")
       )
-  for module in [_cuhybrid, _hiphybrid]:
+  for module in [_cuhybrid, _hiphybrid, _oneapihybrid]:
     if module:
       targets.extend(name for name in module.registrations())
   return targets
@@ -64,6 +66,8 @@ def initialize_hybrid_kernels():
     _cuhybrid.initialize()
   if _hiphybrid:
     _hiphybrid.initialize()
+  if _oneapihybrid:
+    _oneapihybrid.initialize()
 
 
 def has_magma():

--- a/jaxlib/oneapi/BUILD.bazel
+++ b/jaxlib/oneapi/BUILD.bazel
@@ -169,11 +169,59 @@ nanobind_extension(
     ],
 )
 
+cc_library(
+    name = "oneapi_hybrid_kernels",
+    srcs = ["//jaxlib/gpu:hybrid_kernels.cc"],
+    hdrs = ["//jaxlib/gpu:hybrid_kernels.h"],
+    features = ["-use_header_modules"],
+    deps = [
+        ":oneapi_gpu_kernel_helpers",
+        ":oneapi_vendor",
+        ":oneapi_gpu_runtime",
+        "//jaxlib:ffi_helpers",
+        "//jaxlib/cpu:lapack_kernels",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/types:span",
+        "@xla//xla/ffi/api:ffi",
+    ],
+)
+
+nanobind_extension(
+    name = "_hybrid",
+    srcs = ["//jaxlib/gpu:hybrid.cc"],
+    copts = [
+        "-fexceptions",
+        "-fno-strict-aliasing",
+    ],
+    features = ["-use_header_modules"],
+    linkopts = ["-link_stage"],
+    module_name = "_hybrid",
+    deps = [
+        ":oneapi_gpu_kernel_helpers",
+        ":oneapi_hybrid_kernels",
+        ":oneapi_vendor",
+        "//jaxlib:kernel_nanobind_helpers",
+        "//jaxlib/cpu:lapack_kernels",
+        "@com_google_absl//absl/base",
+        "@oneapi//:headers",
+        "@nanobind",
+        "@xla//xla/ffi/api:ffi",
+        "@xla//xla/python:safe_static_init",
+    ],
+)
+
 py_library(
     name = "oneapi_gpu_support",
     deps = [
         ":_prng",
         ":_solver",
+        ":_hybrid",
     ],
 )
 

--- a/jaxlib/tools/build_gpu_kernels_wheel.py
+++ b/jaxlib/tools/build_gpu_kernels_wheel.py
@@ -247,6 +247,7 @@ def prepare_wheel_oneapi(
   copy_files(
       dst_dir=plugin_dir,
       src_files=[
+          f"{source_file_prefix}jaxlib/oneapi/_hybrid.{pyext}",
           f"{source_file_prefix}jaxlib/oneapi/_prng.{pyext}",
           f"{source_file_prefix}jaxlib/oneapi/_solver.{pyext}",
           f"{source_file_prefix}jaxlib/oneapi/oneapi_plugin_extension.{pyext}",


### PR DESCRIPTION
This PR adds following changes:

1. Wires the `_hybrid` extension into the OneAPI plugin.
2.  The check is added in `SyclMemcpyAsync` to synchronize the memcpy when usm buffer pointer type is `usm::alloc::unknown`. (`D2H` memory transfer.)
3. `jaxlib/gpu_solver.py` - import and register the OneAPI `_hybrid` module under the ONEAPI platform.
4. `jax/_src/lax/linalg.py` - register geqp3/eig lowerings for OneAPI.
5. `jaxlib/tools/build_gpu_kernels_wheel.py` - package _hybrid.so into the OneAPI wheel.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->