### PR TITLE
[ROCm] Replace rocm-smi with amd-smi in CI diagnostics

### DIFF
--- a/ci/utilities/prepare_rocm_tests.sh
+++ b/ci/utilities/prepare_rocm_tests.sh
@@ -37,7 +37,7 @@ echo "Installed packages:"
 
 "$JAXCI_PYTHON" -c "import jax; print(jax.default_backend()); print(jax.devices()); print(len(jax.devices()))"
 
-rocm-smi
+amd-smi list
 
 source ./ci/utilities/rocm_test_env.sh
 


### PR DESCRIPTION
## Summary
- Replace deprecated `rocm-smi` CLI with `amd-smi list` in ROCm pytest prep.

## Context
ROCm SMI is deprecated in favor of AMD SMI (ROCm/TheRock#6852). Branch lives on [ROCm/jax](https://github.com/ROCm/jax); diagnostic-only CLI change.

## Test plan
- [x] `amd-smi list` exits 0 on ROCm 7.14
- [x] `bash -n ci/utilities/prepare_rocm_tests.sh` passes