### PR TITLE
Manual Localization through Locality Domains

### DIFF
--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -580,6 +580,7 @@ pytype_strict_library(
         ":flattree",
         ":frozen_dict",
         ":layout",
+        ":localization",
         ":mesh",
         ":named_sharding",
         ":partition_spec",
@@ -1365,6 +1366,12 @@ pytype_strict_library(
         ":xla_metadata",
         "//jax/_src/lib",
     ],
+)
+
+pytype_strict_library(
+    name = "localization",
+    srcs = ["localization.py"],
+    type_checking = "pyrefly",
 )
 
 pytype_strict_library(

--- a/jax/_src/compute_on.py
+++ b/jax/_src/compute_on.py
@@ -51,12 +51,45 @@ def extend_compute_type(c_type: str | None):
     config.compute_on_context_manager.set_local(prev)
 
 
+def _is_locality_domain_compute_type(compute_type: str) -> bool:
+  return compute_type.startswith("gpu_stream:locality_domain:")
+
+
+def _device_memory_aval(aval):
+  return (
+      aval.update(memory_space=core.MemorySpace.Device)
+      if isinstance(aval, core.ShapedArray)
+      else aval
+  )
+
+
 def _check_valid(c_type: str):
   if (c_type not in {'device_host', 'device', 'tpu_sparsecore'}
       and not c_type.startswith("gpu_stream:")):
     raise ValueError(
         f'Invalid compute type {c_type}. Current supported values '
         'are `device_host`, `device`, `tpu_sparsecore`, and `gpu_stream:#`.')
+  if c_type.startswith("gpu_stream:"):
+    stream_annotation = c_type.split(":", 1)[1]
+    if stream_annotation.startswith("locality_domain"):
+      prefix = "locality_domain:"
+      if not stream_annotation.startswith(prefix):
+        raise ValueError(
+            "Invalid locality-domain stream annotation: expected "
+            f"`gpu_stream:{prefix}<d>`, got `{c_type}`.")
+      domain_id = stream_annotation[len(prefix):]
+      if not domain_id or any(c < "0" or c > "9" for c in domain_id):
+        raise ValueError(
+            "Invalid locality-domain stream annotation: domain id must be a "
+            f"nonempty unsigned decimal integer, got `{domain_id}`.")
+      normalized_domain_id = domain_id.lstrip("0") or "0"
+      max_uint64 = "18446744073709551615"
+      if (len(normalized_domain_id) > len(max_uint64)
+          or (len(normalized_domain_id) == len(max_uint64)
+              and normalized_domain_id > max_uint64)):
+        raise ValueError(
+            "Invalid locality-domain stream annotation: domain id is out of "
+            f"uint64 range, got `{domain_id}`.")
 
 
 def compute_on(f=None, *, compute_type, out_memory_spaces,
@@ -78,9 +111,19 @@ def _compute_on(f, *, compute_type, out_memory_spaces, compiler_options):
     dbg = debug_info('compute_on', f, args, kwargs)
     args_flat, in_tree = tree_flatten((args, kwargs))
     in_avals = tuple(core.shaped_abstractify(x) for x in args_flat)
-    with extend_compute_type(compute_type):
+    # Locality-domain execution is represented by the non-inlineable call
+    # boundary emitted below. Propagating the annotation into the body would
+    # create nested locality annotations, which XLA currently rejects.
+    is_locality_domain = _is_locality_domain_compute_type(compute_type)
+    body_compute_type = None if is_locality_domain else compute_type
+    if is_locality_domain:
+      body_in_avals = tuple(_device_memory_aval(aval) for aval in in_avals)
+    else:
+      body_in_avals = in_avals
+
+    with extend_compute_type(body_compute_type):
       jaxpr, out_avals = pe.trace_to_jaxpr(
-          f, ft.treedef_args_to_ft(in_tree, in_avals), dbg)
+          f, ft.treedef_args_to_ft(in_tree, body_in_avals), dbg)
       out_tree = out_avals.tree
       if any(isinstance(c, core.Tracer) for c in jaxpr.consts):
         jaxpr, consts = pe.separate_consts(jaxpr)
@@ -146,7 +189,9 @@ def _compute_on_lowering(ctx, *args, jaxpr, compute_type, out_memory_spaces,
 
   if compute_type.startswith("gpu_stream:"):
     dict_attr = {
-        "_xla_stream_annotation": ir.StringAttr.get(compute_type.split(":")[1]),
+        "_xla_stream_annotation": ir.StringAttr.get(
+            compute_type.split(":", 1)[1]
+        ),
         "inlineable": ir.StringAttr.get("false"),
     }
   else:
@@ -359,9 +404,37 @@ def _transpose_jaxpr(jaxpr, in_tree, in_avals, specs):
 
 def _compute_on_transpose(cts_in, *args, jaxpr, compute_type,
                           out_memory_spaces, compiler_options_json):
+  is_locality_domain = _is_locality_domain_compute_type(compute_type)
+  if is_locality_domain:
+    # The outlined locality computation uses generic device avals internally,
+    # while its outputs can live in a locality-domain memory space.
+    # Normalize incoming cotangents back to the inner computation's device
+    # memory type before transposing the body Jaxpr.
+    cts_in = tuple(
+        ct
+        if isinstance(ct, ad.Zero)
+        or core.typeof(ct).memory_space == core.MemorySpace.Device
+        else dispatch.device_put_p.bind(
+            ct,
+            devices=(core.MemorySpace.Device,),
+            srcs=(None,),
+            copy_semantics=(dispatch.ArrayCopySemantics.REUSE_INPUT,),
+        )[0]
+        for ct in cts_in
+    )
   primals_ctrefs, specs = ad.project_accums(args)
+  if is_locality_domain:
+    # Inner backward rules produce generic-device cotangents. Use matching
+    # temporary accumulator types, then let the outer compute_on_p result
+    # memory spaces below restore each argument's locality placement.
+    specs = tuple(
+        (accum_type, _device_memory_aval(aval))
+        for accum_type, aval in specs
+    )
   in_flat, in_tree = tree_flatten((primals_ctrefs, cts_in))
   in_avals = tuple(core.typeof(x) for x in in_flat)
+  if is_locality_domain:
+    in_avals = tuple(_device_memory_aval(aval) for aval in in_avals)
   trans_jaxpr, out_tree = _transpose_jaxpr(jaxpr, in_tree, in_avals, specs)
   cts_out_, logs_ = tree_unflatten(out_tree, trans_jaxpr.out_avals)
   arg_spaces = [x.aval.memory_space if isinstance(x, ad.GradAccum)  # type: ignore

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -822,7 +822,10 @@ def eval_jaxpr(jaxpr: Jaxpr, consts, *args, propagate_source_info=True) -> list[
 def check_avals_context_mesh(avals, prim_name):
   cur_mesh = mesh_lib.get_abstract_mesh()
   for a in avals:
-    if not isinstance(a.memory_space, MemorySpace):
+    if (
+        not isinstance(a.memory_space, MemorySpace)
+        and not hasattr(a.memory_space, "memory_kind")
+    ):
       raise TypeError(
           f"Primitive {prim_name} got aval {a} with unknown memory_space type:"
           f" {type(a.memory_space)}")
@@ -1914,9 +1917,13 @@ def valid_jaxtype(x) -> bool:
       return True
 
 
-def mem_kind_to_space(mem_kind: str | None) -> MemorySpace:
+def mem_kind_to_space(mem_kind: str | None) -> Any:
   if mem_kind == 'pinned_host':
     return MemorySpace.Host
+  if mem_kind is not None and mem_kind.startswith("locality_domain:"):
+    # Import lazily to keep core independent from the experimental public API.
+    from jax._src import localization  # pylint: disable=g-import-not-at-top
+    return localization._parse_locality_domain_memory_kind(mem_kind)
   return MemorySpace.Device
 
 
@@ -2634,8 +2641,12 @@ def str_short_aval(shape, dtype, mesh, spec, mat, memory_space,
   mesh_axes = f'({_axis_types_dict(mesh)})' if mesh_axis_types else ''
   vma_ur = _vma_ur_str(mat, spec.unreduced, spec.reduced, spec.unreduced_kind,
                        mesh)
-  ms_str = ("" if memory_space == MemorySpace.Device else
-            f"<{memory_space.name.lower()}>")
+  if memory_space == MemorySpace.Device:
+    ms_str = ""
+  elif isinstance(memory_space, MemorySpace):
+    ms_str = f"<{memory_space.name.lower()}>"
+  else:
+    ms_str = f"<{mem_space_to_kind(memory_space)}>"
   return f'{dt_str}{ms_str}[{shapestr}]{vma_ur}{mesh_axes}'
 
 def _create_str(x, prefix):

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -9703,7 +9703,26 @@ def _one_vjp(x):
   x_aval = core.typeof(x)
   ct_s = core.primal_sharding_to_cotangent_sharding(x_aval.sharding)
   ct_s = ct_s.update(spec=ct_s.spec.update(partitions=()))
-  return full_like(x, shape=(), fill_value=1, sharding=ct_s)
+  one = full_like(x, shape=(), fill_value=1, sharding=ct_s)
+  if x_aval.memory_space not in (
+      core.MemorySpace.Device,
+      core.MemorySpace.Any,
+  ):
+    target_sharding = ct_s.update(
+        memory_kind=core.mem_space_to_kind(x_aval.memory_space)
+    )
+    # This explicit placement is a correctness-first path and may materialize
+    # a small copy. This is required to support locality domain memory spaces since
+    # otherwise the cotangent seed will be created in the default device mem space causing
+    # a mismatch. The more optimal implementation is for full_like to accept memory_kind 
+    # and create the cotangent seed directly in the requested memory space.
+    one = dispatch.device_put_p.bind(
+        one,
+        devices=(target_sharding,),
+        srcs=(None,),
+        copy_semantics=(dispatch.ArrayCopySemantics.REUSE_INPUT,),
+    )[0]
+  return one
 
 _twos: Callable = partial(full_like, fill_value=2)
 _two: Callable = partial(full_like, shape=(), fill_value=2)

--- a/jax/_src/localization.py
+++ b/jax/_src/localization.py
@@ -1,0 +1,60 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import dataclasses
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class LocalityDomain:
+  """Identifies a locality domain for memory placement."""
+
+  id: int
+
+  def __post_init__(self):
+    if isinstance(self.id, bool) or not isinstance(self.id, int):
+      raise TypeError(
+          "LocalityDomain id must be an integer, "
+          f"but got {self.id!r} of type {type(self.id).__name__}."
+      )
+    max_locality_domain_id = ((1 << 63) - 1) - 16
+    if not 0 <= self.id <= max_locality_domain_id:
+      raise ValueError(
+          f"LocalityDomain id must be between 0 and {max_locality_domain_id}, "
+          f"but got {self.id}."
+      )
+
+  @property
+  def memory_kind(self) -> str:
+    """The canonical XLA memory kind for this locality domain."""
+    return f"locality_domain:{self.id}"
+
+
+def _parse_locality_domain_memory_kind(
+    memory_kind: str,
+) -> LocalityDomain:
+  """Parses a canonical `locality_domain:<d>` memory kind."""
+  if not memory_kind.startswith("locality_domain:"):
+    raise ValueError(
+      f"Locality-domain memory kind must start with 'locality_domain:', got {memory_kind!r}."
+    )
+  domain_id = memory_kind[16:]
+  if (
+      not domain_id
+      or not domain_id.isascii()
+      or not domain_id.isdecimal()
+      or (len(domain_id) > 1 and domain_id.startswith("0"))
+  ):
+    raise ValueError(
+        "Locality-domain memory kind must contain a canonical unsigned "
+        f"decimal id, got {memory_kind!r}."
+    )
+  return LocalityDomain(int(domain_id))

--- a/jax/experimental/BUILD
+++ b/jax/experimental/BUILD
@@ -173,6 +173,27 @@ pytype_strict_library(
 )
 
 pytype_strict_library(
+    name = "localization",
+    srcs = ["localization.py"],
+    type_checking = "pyrefly",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//jax/_src:localization",
+    ],
+)
+
+pytype_strict_library(
+    name = "control_deps",
+    srcs = ["control_deps.py"],
+    type_checking = "pyrefly",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//jax/_src:api",
+        "//jax/_src:ffi",
+    ],
+)
+
+pytype_strict_library(
     name = "custom_partitioning",
     srcs = ["custom_partitioning.py"],
     type_checking = "pyrefly",
@@ -789,6 +810,7 @@ filegroup(
     ]) + [
         "checkify.py",
         "fused.py",
+        "localization.py",
         "multihost_utils.py",
         "pjit.py",
         "scheduling_groups.py",

--- a/jax/experimental/localization.py
+++ b/jax/experimental/localization.py
@@ -1,0 +1,17 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Experimental locality-domain APIs."""
+
+from jax._src.localization import LocalityDomain as LocalityDomain

--- a/jaxlib/sharding.cc
+++ b/jaxlib/sharding.cc
@@ -129,6 +129,26 @@ static const std::array<std::string_view, 3> valid_memory_kinds = {
     "unpinned_host",
 };
 
+static bool IsCanonicalLocalityDomainMemoryKind(std::string_view memory_kind) {
+  constexpr std::string_view kPrefix = "locality_domain:";
+  // The maximum locality domain ID permissible is (INT64_MAX - 16 = 2^63 - 1) - 16
+  constexpr std::string_view kMaxLocalityDomainId = "9223372036854775791";
+
+  if (memory_kind.size() <= kPrefix.size() ||
+      memory_kind.substr(0, kPrefix.size()) != kPrefix) {
+    return false;
+  }
+  const std::string_view suffix = memory_kind.substr(kPrefix.size());
+  if ((suffix.size() > 1 && suffix.front() == '0') ||
+      !std::all_of(suffix.begin(), suffix.end(),
+                   [](char c) { return c >= '0' && c <= '9'; })) {
+    return false;
+  }
+  return suffix.size() < kMaxLocalityDomainId.size() ||
+         (suffix.size() == kMaxLocalityDomainId.size() &&
+          suffix <= kMaxLocalityDomainId);
+}
+
 NamedSharding::NamedSharding(nb::object mesh, nb::object spec,
                              nb::object memory_kind,
                              nb::object logical_device_ids)
@@ -149,15 +169,20 @@ NamedSharding::NamedSharding(nb::object mesh, nb::object spec,
     memory_kind_ =
         CheckAndCanonicalizeMemoryKind(memory_kind_, *internal_device_list_);
   } else {
+    const std::string_view memory_kind =
+        memory_kind_.is_none() ? std::string_view()
+                               : nb::cast<std::string_view>(memory_kind_);
     if (!memory_kind_.is_none() &&
-        (std::find(valid_memory_kinds.begin(), valid_memory_kinds.end(),
-                   nb::cast<std::string_view>(memory_kind_)) ==
-         valid_memory_kinds.end())) {
+        std::find(valid_memory_kinds.begin(), valid_memory_kinds.end(),
+                  memory_kind) == valid_memory_kinds.end() &&
+        !IsCanonicalLocalityDomainMemoryKind(memory_kind)) {
       throw nb::value_error(
           absl::StrCat("Got invalid memory kind: ",
-                       nb::cast<std::string_view>(memory_kind_),
+                       memory_kind,
                        ". Valid memory kinds are: ",
-                       absl::StrJoin(valid_memory_kinds, ", "))
+                       absl::StrJoin(valid_memory_kinds, ", "),
+                       ", or locality_domain:<unsigned decimal> with value at "
+                       "most 9223372036854775791")
               .c_str());
     }
   }

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -421,6 +421,7 @@ jax_multiplatform_test(
     tags = ["multiaccelerator"],
     deps = [
         "//jax/experimental:compute_on",
+        "//jax/experimental:localization",
         "//jax/experimental:pallas_mosaic_gpu",
     ] + py_deps([
         "absl/testing",

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -1373,6 +1373,37 @@ class ShardingTest(jtu.JaxTestCase):
         ValueError, 'Got invalid memory kind'):
       NamedSharding(abstract_mesh, P(), memory_kind='weird_device')
 
+  def test_locality_memory_kind_with_abstract_mesh(self):
+    abstract_mesh = AbstractMesh((2,), ('x',))
+    max_domain_id = (1 << 63) - 1 - 16
+
+    for memory_kind in (
+        'locality_domain:0',
+        'locality_domain:1',
+        'locality_domain:256',
+        f'locality_domain:{max_domain_id}',
+    ):
+      with self.subTest(memory_kind=memory_kind):
+        sharding = NamedSharding(
+            abstract_mesh, P(), memory_kind=memory_kind
+        )
+        self.assertEqual(sharding.memory_kind, memory_kind)
+
+    for memory_kind in (
+        'locality_domain:',
+        'locality_domain:-1',
+        'locality_domain:+1',
+        'locality_domain:01',
+        'locality_domain: 1',
+        'locality_domain:1 ',
+        'locality_domain:1.0',
+        'locality_domain:one',
+        f'locality_domain:{max_domain_id + 1}',
+    ):
+      with self.subTest(memory_kind=memory_kind):
+        with self.assertRaisesRegex(ValueError, 'invalid memory kind'):
+          NamedSharding(abstract_mesh, P(), memory_kind=memory_kind)
+
   def test_pspec_mix_axis_types(self):
     mesh = AbstractMesh(
         (2, 2, 2, 2), ('a', 'b', 'c', 'd'),

--- a/tests/memories_test.py
+++ b/tests/memories_test.py
@@ -35,6 +35,7 @@ from jax._src.sharding_impls import (
 from jax._src.sharding_impls import make_single_device_sharding
 from jax._src.xla_metadata import set_xla_metadata
 from jax._src.shard_map import shard_map
+from jax.experimental import localization
 from jax.experimental.compute_on import compute_on
 import jax.numpy as jnp
 import numpy as np
@@ -60,6 +61,416 @@ def _create_inputs(shape, pspec, mem_kind=None):
   s = NamedSharding(mesh, pspec, memory_kind=mem_kind)
   inp = jax.device_put(np_inp, s)
   return mesh, s, np_inp, inp
+
+
+class LocalityDomainTest(jtu.JaxTestCase):
+  max_locality_domain_id = ((1 << 63) - 1) - 16
+
+  def _locality_devices(self, count=1):
+    if not jtu.is_device_cuda():
+      self.skipTest("Locality domains are only supported on CUDA.")
+
+    required_kinds = {
+        localization.LocalityDomain(0).memory_kind,
+        localization.LocalityDomain(1).memory_kind,
+    }
+    locality_devices = []
+    for device in jax.local_devices():
+      try:
+        memory_kinds = {
+            memory.kind for memory in device.addressable_memories()
+        }
+      except (AttributeError, NotImplementedError, RuntimeError) as err:
+        self.skipTest(
+            f"Could not discover addressable CUDA memories: {err}"
+        )
+      if required_kinds.issubset(memory_kinds):
+        locality_devices.append(device)
+
+    if len(locality_devices) < count:
+      self.skipTest(
+          f"Test requires {count} addressable CUDA device(s) advertising "
+          f"{sorted(required_kinds)}; found {len(locality_devices)}."
+      )
+    return locality_devices[:count]
+
+  def _check_locality_array(self, out, expected, expected_sharding):
+    self.assertArraysEqual(out, expected)
+    self.assertEqual(out.sharding, expected_sharding)
+    self.assertEqual(
+        out.sharding.memory_kind, expected_sharding.memory_kind
+    )
+    for shard in out.addressable_shards:
+      self.assertArraysEqual(shard.data, expected[shard.index])
+      self.assertEqual(
+          shard.data.sharding.memory_kind, expected_sharding.memory_kind
+      )
+
+  def test_locality_domain_api(self):
+    ld0 = localization.LocalityDomain(0)
+    ld0_again = localization.LocalityDomain(0)
+    ld1 = localization.LocalityDomain(1)
+
+    self.assertEqual(ld0.memory_kind, "locality_domain:0")
+    self.assertEqual(ld1.memory_kind, "locality_domain:1")
+    self.assertEqual(ld0, ld0_again)
+    self.assertNotEqual(ld0, ld1)
+    self.assertEqual(hash(ld0), hash(ld0_again))
+    self.assertLen({ld0, ld0_again, ld1}, 2)
+    self.assertRegex(repr(ld0), r"^LocalityDomain\(.*0.*\)$")
+    with self.assertRaises((AttributeError, TypeError)):
+      ld0.id = 1
+
+    max_domain = localization.LocalityDomain(self.max_locality_domain_id)
+    self.assertEqual(
+        max_domain.memory_kind,
+        f"locality_domain:{self.max_locality_domain_id}",
+    )
+
+  def test_locality_domain_rejects_invalid_ids(self):
+    for domain_id in (True, False, 1.0, "1", np.int64(1), None):
+      with self.subTest(domain_id=domain_id):
+        with self.assertRaises(TypeError):
+          localization.LocalityDomain(domain_id)
+
+    for domain_id in (-1, self.max_locality_domain_id + 1):
+      with self.subTest(domain_id=domain_id):
+        with self.assertRaises(ValueError):
+          localization.LocalityDomain(domain_id)
+
+  def test_locality_memory_kind_round_trip(self):
+    for domain_id in (0, 1, 256):
+      with self.subTest(domain_id=domain_id):
+        memory_kind = f"locality_domain:{domain_id}"
+        memory_space = core.mem_kind_to_space(memory_kind)
+        self.assertEqual(memory_space, localization.LocalityDomain(domain_id))
+        self.assertEqual(core.mem_space_to_kind(memory_space), memory_kind)
+        aval = core.ShapedArray((1,), np.dtype(np.float32),
+                                memory_space=memory_space)
+        self.assertIn(f"<{memory_kind}>", aval.str_short())
+
+  def test_cuda_discovers_locality_domain_memories(self):
+    device = self._locality_devices()[0]
+    memory_kinds = {
+        memory.kind for memory in device.addressable_memories()
+    }
+    self.assertContainsSubset(
+        {"locality_domain:0", "locality_domain:1"}, memory_kinds
+    )
+
+  def test_single_device_put_and_cross_domain_copies(self):
+    device = self._locality_devices()[0]
+    values = np.arange(12, dtype=np.float32).reshape(3, 4)
+    ld0 = localization.LocalityDomain(0)
+    ld1 = localization.LocalityDomain(1)
+    s0 = make_single_device_sharding(
+        device, memory_kind=ld0.memory_kind
+    )
+    s1 = make_single_device_sharding(
+        device, memory_kind=ld1.memory_kind
+    )
+
+    arr0 = jax.device_put(values, s0)
+    self._check_locality_array(arr0, values, s0)
+
+    arr1 = jax.device_put(arr0, s1)
+    self._check_locality_array(arr1, values, s1)
+
+    arr0_again = jax.device_put(arr1, s0)
+    self._check_locality_array(arr0_again, values, s0)
+
+  def test_multi_device_put_and_cross_domain_copies(self):
+    devices = self._locality_devices(count=2)
+    mesh = jax.sharding.Mesh(np.asarray(devices), ("x",))
+    values = np.arange(16, dtype=np.float32).reshape(8, 2)
+    ld0 = localization.LocalityDomain(0)
+    ld1 = localization.LocalityDomain(1)
+    s0 = NamedSharding(mesh, P("x"), memory_kind=ld0.memory_kind)
+    s1 = NamedSharding(mesh, P("x"), memory_kind=ld1.memory_kind)
+
+    arr0 = jax.device_put(values, s0)
+    self._check_locality_array(arr0, values, s0)
+
+    arr1 = jax.device_put(arr0, s1)
+    self._check_locality_array(arr1, values, s1)
+
+    arr0_again = jax.device_put(arr1, s0)
+    self._check_locality_array(arr0_again, values, s0)
+
+  def test_jit_locality_shardings_and_executable_memory_kind(self):
+    device = self._locality_devices()[0]
+    values = np.arange(8, dtype=np.float32)
+    ld0 = localization.LocalityDomain(0)
+    ld1 = localization.LocalityDomain(1)
+    mesh = jax.sharding.Mesh(np.asarray([device]), ("x",))
+    s0 = NamedSharding(mesh, P(), memory_kind=ld0.memory_kind)
+    s1 = NamedSharding(mesh, P(), memory_kind=ld1.memory_kind)
+    arr0 = jax.device_put(values, s0)
+
+    @compute_on(compute_type="device", out_memory_spaces=ld1)
+    def on_device_with_ld1_output(x):
+      return x * 2 + 1
+
+    f = jax.jit(
+        on_device_with_ld1_output, in_shardings=s0, out_shardings=s1
+    )
+    out = f(arr0)
+
+    self._check_locality_array(out, values * 2 + 1, s1)
+    executable_kinds = get_memory_kinds_from_executable(f, [arr0])
+    self.assertEqual(executable_kinds[0], ld1.memory_kind)
+
+  def test_locality_compute_lowering_annotation(self):
+    @compute_on(
+        compute_type="gpu_stream:locality_domain:1",
+        out_memory_spaces=jax.memory.Space.Device,
+    )
+    def on_ld1(x):
+      return x + 1
+
+    lowered_text = jax.jit(on_ld1).lower(np.arange(4.0)).as_text()
+    self.assertRegex(
+        lowered_text,
+        r'mhlo\.frontend_attributes = '
+        r'\{_xla_stream_annotation = "locality_domain:1", '
+        r'inlineable = "false"\}',
+    )
+    self.assertEqual(
+        lowered_text.count('_xla_stream_annotation = "locality_domain:1"'), 1
+    )
+
+  def test_cross_domain_compute_with_localized_output(self):
+    device = self._locality_devices()[0]
+    values = np.arange(8, dtype=np.float32)
+    ld0 = localization.LocalityDomain(0)
+    mesh = jax.sharding.Mesh(np.asarray([device]), ("x",))
+    s0 = NamedSharding(mesh, P(), memory_kind=ld0.memory_kind)
+    arr0 = jax.device_put(values, s0)
+
+    @compute_on(
+        compute_type="gpu_stream:locality_domain:1",
+        out_memory_spaces=ld0,
+    )
+    def on_ld1(x):
+      return jnp.sin(x) * 2
+
+    f = jax.jit(on_ld1, in_shardings=s0, out_shardings=s0)
+    out = f(arr0)
+
+    self.assertArraysAllClose(out, np.sin(values) * 2)
+    self.assertEqual(out.sharding, s0)
+    executable_kinds = get_memory_kinds_from_executable(f, [arr0])
+    self.assertEqual(executable_kinds[0], ld0.memory_kind)
+
+  def test_multi_device_sharded_locality_compute(self):
+    devices = self._locality_devices(count=2)
+    mesh = jax.sharding.Mesh(np.asarray(devices), ("data",))
+    values = np.arange(16, dtype=np.float32)
+    ld0 = localization.LocalityDomain(0)
+    s0 = NamedSharding(mesh, P("data"), memory_kind=ld0.memory_kind)
+    arr0 = jax.device_put(values, s0)
+
+    @compute_on(
+        compute_type="gpu_stream:locality_domain:1",
+        out_memory_spaces=ld0,
+    )
+    def on_ld1(x):
+      return x * 2 + 1
+
+    f = jax.jit(on_ld1, in_shardings=s0, out_shardings=s0)
+    lowered = f.lower(arr0)
+    lowered_text = lowered.as_text()
+    self.assertEqual(
+        lowered_text.count('_xla_stream_annotation = "locality_domain:1"'), 1
+    )
+
+    compiled = lowered.compile()
+    out = compiled(arr0)
+    self._check_locality_array(out, values * 2 + 1, s0)
+    self.assertLen(out.addressable_shards, 2)
+    self.assertEqual(
+        compiled.runtime_executable().get_output_memory_kinds()[0],
+        [ld0.memory_kind],
+    )
+
+  def test_collective_over_locality_backed_shards(self):
+    devices = self._locality_devices(count=2)
+    mesh = jax.sharding.Mesh(np.asarray(devices), ("data",))
+    values = np.arange(8, dtype=np.float32)
+    expected = values.reshape(2, -1).sum(axis=0)
+    ld0 = localization.LocalityDomain(0)
+    input_sharding = NamedSharding(
+        mesh, P("data"), memory_kind=ld0.memory_kind
+    )
+    output_sharding = NamedSharding(
+        mesh, P(), memory_kind=ld0.memory_kind
+    )
+    arr0 = jax.device_put(values, input_sharding)
+
+    @jax.jit(
+        in_shardings=input_sharding,
+        out_shardings=output_sharding,
+        compiler_options={
+            "xla_gpu_experimental_use_collective_kernels": "",
+        },
+    )
+    @jax.shard_map(
+        mesh=mesh,
+        in_specs=P("data"),
+        out_specs=P(),
+    )
+    def collective(x):
+      return lax.psum(x, "data")
+
+    compiled = collective.lower(arr0).compile()
+    out = compiled(arr0)
+    self._check_locality_array(out, expected, output_sharding)
+    self.assertLen(out.addressable_shards, 2)
+    self.assertTrue(out.sharding.is_fully_replicated)
+    self.assertEqual(
+        compiled.runtime_executable().get_output_memory_kinds()[0],
+        [ld0.memory_kind],
+    )
+
+  def test_collective_inside_locality_compute_fails(self):
+    devices = self._locality_devices(count=2)
+    mesh = jax.sharding.Mesh(np.asarray(devices), ("data",))
+    values = np.arange(8, dtype=np.float32)
+    ld0 = localization.LocalityDomain(0)
+    input_sharding = NamedSharding(
+        mesh, P("data"), memory_kind=ld0.memory_kind
+    )
+    output_sharding = NamedSharding(
+        mesh, P(), memory_kind=ld0.memory_kind
+    )
+    arr0 = jax.device_put(values, input_sharding)
+
+    @compute_on(
+        compute_type="gpu_stream:locality_domain:0",
+        out_memory_spaces=ld0,
+    )
+    def invalid_locality_compute(x):
+      return lax.psum(x, "data")
+
+    @jax.jit(
+        in_shardings=input_sharding,
+        out_shardings=output_sharding,
+    )
+    @jax.shard_map(
+        mesh=mesh,
+        in_specs=P("data"),
+        out_specs=P(),
+    )
+    def collective(x):
+      return invalid_locality_compute(x)
+
+    with self.assertRaisesRegex(
+        jax.errors.JaxRuntimeError,
+        "Locality-domain stream call contains unsupported communication "
+        "instruction",
+    ):
+      collective.lower(arr0).compile()
+
+  def test_multi_device_locality_compute_with_donation(self):
+    devices = self._locality_devices(count=2)
+    mesh = jax.sharding.Mesh(np.asarray(devices), ("data",))
+    values = np.arange(16, dtype=np.float32)
+    ld0 = localization.LocalityDomain(0)
+    s0 = NamedSharding(mesh, P("data"), memory_kind=ld0.memory_kind)
+    arr0 = jax.device_put(values, s0)
+
+    @compute_on(
+        compute_type="gpu_stream:locality_domain:0",
+        out_memory_spaces=ld0,
+    )
+    def on_ld0(x):
+      return x * 2 + 1
+
+    f = jax.jit(
+        on_ld0,
+        in_shardings=s0,
+        out_shardings=s0,
+        donate_argnums=(0,),
+    )
+    compiled = f.lower(arr0).compile()
+    out = compiled(arr0)
+    out.block_until_ready()
+
+    self._check_locality_array(out, values * 2 + 1, s0)
+    self.assertTrue(arr0.is_deleted())
+    self.assertEqual(
+        compiled.runtime_executable().get_output_memory_kinds()[0],
+        [ld0.memory_kind],
+    )
+
+  def test_locality_compute_type_validation(self):
+    def f(x):
+      return x
+
+    valid_compute_types = (
+        "gpu_stream:locality_domain:0",
+        "gpu_stream:locality_domain:001",
+        f"gpu_stream:locality_domain:{(1 << 64) - 1}",
+    )
+    for compute_type in valid_compute_types:
+      with self.subTest(compute_type=compute_type):
+        wrapped = compute_on(
+            f,
+            compute_type=compute_type,
+            out_memory_spaces=jax.memory.Space.Device,
+        )
+        self.assertTrue(callable(wrapped))
+
+    invalid_compute_types = (
+        "gpu_stream:locality_domain",
+        "gpu_stream:locality_domain:",
+        "gpu_stream:locality_domain:-1",
+        "gpu_stream:locality_domain:+1",
+        "gpu_stream:locality_domain: 1",
+        "gpu_stream:locality_domain:1 ",
+        "gpu_stream:locality_domain:1.0",
+        "gpu_stream:locality_domain:one",
+        "gpu_stream:locality_domain:1:2",
+        "gpu_stream:locality_domain:\N{ARABIC-INDIC DIGIT ONE}",
+        f"gpu_stream:locality_domain:{1 << 64}",
+    )
+    for compute_type in invalid_compute_types:
+      with self.subTest(compute_type=compute_type):
+        with self.assertRaises(ValueError):
+          compute_on(
+              f,
+              compute_type=compute_type,
+              out_memory_spaces=jax.memory.Space.Device,
+          )
+
+  def test_locality_compute_jit_vmap_grad(self):
+    device = self._locality_devices()[0]
+    values = np.linspace(0.1, 0.8, 8, dtype=np.float32)
+    ld0 = localization.LocalityDomain(0)
+    mesh = jax.sharding.Mesh(np.asarray([device]), ("x",))
+    s0 = NamedSharding(mesh, P(), memory_kind=ld0.memory_kind)
+    arr0 = jax.device_put(values, s0)
+
+    @compute_on(
+        compute_type="gpu_stream:locality_domain:1",
+        out_memory_spaces=ld0,
+    )
+    def on_ld1(x):
+      return jnp.sin(x)
+
+    vmapped = jax.jit(
+        jax.vmap(on_ld1), in_shardings=s0, out_shardings=s0
+    )
+    self.assertArraysAllClose(vmapped(arr0), np.sin(values))
+
+    grad_fn = jax.jit(
+        jax.grad(lambda x: jnp.sum(on_ld1(x))),
+        in_shardings=s0,
+        out_shardings=s0,
+    )
+    grad_out = grad_fn(arr0)
+    self.assertArraysAllClose(grad_out, np.cos(values), rtol=1e-5)
+    self.assertEqual(grad_out.sharding, s0)
 
 
 class ShardingMemoriesTest(jtu.JaxTestCase):


### PR DESCRIPTION
This draft PR introduces API changes to allow JAX users to localize their memory allocations and computations to each locality domain on supported Nvidia GPUs. 

These changes are supported by a comprehensive set of XLA changes. At a high level:
- memory localization is achieved through the exposition of two new memory kinds, each corresponding to one of the locality domains.
- compute localization is achieved through a combination of green contexts and locality domain APIs (available from CUDA 13.4). 

JAX users will use the familiar device_put and compute_on stream annotation to consequently utilize the memory and compute localization features in XLA respectively. 