### PR TITLE
Allow rank 3 cp.async

### DIFF
--- a/jax/experimental/mosaic/gpu/fragmented_array.py
+++ b/jax/experimental/mosaic/gpu/fragmented_array.py
@@ -5294,12 +5294,19 @@ def copy_tiled(src: ir.Value, dst: ir.Value, swizzle: int = 16):
     layout = tiled_copy_smem_gmem_layout(
         *smem_ty.shape[-4:-2], swizzle, bitwidth  # pyrefly: ignore[bad-argument-count]
     )
+    # Only the two minor dimensions are tiled, as the rank check above says, so
+    # the tiling rank has to be stated: the default of half the SMEM rank is odd
+    # for an odd-ranked copy, and wrong for any rank but two.
+    tiling_rank = smem_ty.rank - gmem_ty.rank
     if utils.is_smem_ref(src_ty):
-      regs = FragmentedArray.load_tiled(src, swizzle, is_signed=is_signed, layout=layout)
+      regs = FragmentedArray.load_tiled(
+          src, swizzle, is_signed=is_signed, layout=layout,
+          tiling_rank=tiling_rank,
+      )
       regs.store_untiled(dst, optimized=False)
     else:
       regs = FragmentedArray.load_untiled(src, is_signed=is_signed, layout=layout, optimized=False)
-      regs.store_tiled(dst, swizzle)
+      regs.store_tiled(dst, swizzle, tiling_rank=tiling_rank)
     return
   raise NotImplementedError(f"Unsupported copy: {src.type} -> {dst.type}")
 

--- a/jax/experimental/mosaic/gpu/launch_context.py
+++ b/jax/experimental/mosaic/gpu/launch_context.py
@@ -1448,15 +1448,32 @@ class LaunchContext:
         dyn_offset = arith.divui(dyn_offset, c(offset_scale, i32))
         dyn_offset = arith.extui(i64, dyn_offset)
         dyn_offset = arith.addi(dyn_offset, gmem_offset)
-        if gmem_ref_ty.rank != 2:
-          raise NotImplementedError("Only 2D copies implemented")
+        # The tiling applies to the two minor dimensions, so the dimensions
+        # above them are whole, and both the layout above and ``transfer_tiled``
+        # below treat them as logical dimensions to iterate over. Everything
+        # here that indexes GMEM does so through ``Tiling``, which applies to a
+        # suffix of the strides, so it is indifferent to how many there are.
+        tiling_rank = len(tiling)
+        if gmem_ref_ty.rank < tiling_rank:
+          raise NotImplementedError(
+              f"Tiled copies need at least {tiling_rank} dimensions, got"
+              f" {gmem_ref_ty.rank}"
+          )
         gmem_slice_shape = tuple(
             s
             for i, s in enumerate(untransformed_slice_shape)
             if i not in squeezed_dims
         )
         transfers = fa.FragmentedArray.transfer_tiled(
-            smem_ref, swizzle, layout, gmem_slice_shape, optimized=False
+            smem_ref,
+            swizzle,
+            layout,
+            gmem_slice_shape,
+            optimized=False,
+            # Only the two minor dimensions are tiled, so the SMEM ref's rank
+            # exceeds GMEM's by two, whatever GMEM's is. That makes it odd for an
+            # odd-ranked copy, which the default of half the rank cannot handle.
+            ref_tiling_rank=tiling_rank,
         )
         gmem_base_ptr = utils.getelementptr(utils.memref_ptr(gmem_ref), [dyn_offset], gep_type)
         gmem_base_ptr = llvm.addrspacecast(

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -4841,7 +4841,11 @@ class AsyncCopyTest(TestCase, jtu.CudaArchSpecificTest):
 
   @parameterized.product(
       swizzle=(16, 32, 64, 128),
-      shape=((64, 128), (128, 32)),
+      # Only the two minor dimensions are tiled, so a rank-3 copy is the rank-2
+      # one repeated over the leading dimension. Rank 4 would be too: it stops
+      # here because tiling two of four dimensions leaves six strided ones, over
+      # the limit of five that an async copy supports.
+      shape=((64, 128), (128, 32), (2, 64, 128)),
       dtype=(jnp.float32, jnp.float16, jnp.float8_e5m2, jnp.int4),
       use_barrier=(False, True),
   )


### PR DESCRIPTION
Closes #40201 

Currently, `cp.async` refuses any GMEM ref that is not exactly 2-D. This PR relaxes that restriction. To test it,`tests/mosaic/gpu_test.py::AsyncCopyTest::test_cp_async_tiled` already covers this path for rank 2, and `_test_cp_async` is rank-agnostic, so we just add a shape parameterization of `(2, 64, 128)` to the test. 