### PR TITLE
Switch ROCm RBE to linux_x64_gpu_do_gfx950 pool

### DIFF
--- a/build/rocm/rocm.bazelrc
+++ b/build/rocm/rocm.bazelrc
@@ -46,9 +46,9 @@ test:rocm --test_verbose_timeout_warnings
 test:rocm --run_under=@xla//build_tools/rocm:parallel_gpu_execute
 
 # Configs for ROCm RBE tests
-build:single_gpu --repo_env=TF_ROCM_RBE_POOL="linux_x64_gpu"
-build:single_gpu --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL="linux_x64_gpu"
-build:single_gpu --repo_env=TF_ROCM_RBE_MULTI_GPU_POOL="linux_x64_gpu"
+build:single_gpu --repo_env=TF_ROCM_RBE_POOL="linux_x64_gpu_do_gfx950"
+build:single_gpu --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL="linux_x64_gpu_do_gfx950"
+build:single_gpu --repo_env=TF_ROCM_RBE_MULTI_GPU_POOL="linux_x64_gpu_do_gfx950"
 
 build:multi_gpu --repo_env=TF_ROCM_RBE_POOL="linux_x64_multigpu"
 build:multi_gpu --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL="linux_x64_multigpu"


### PR DESCRIPTION
Switch ROCm Bazel RBE CI to use the `linux_x64_gpu_do_gfx950` pool instead of the `linux_x64_gpu` pool that has newer hardware