### PR TITLE
scipy.optimize: report ftol termination in L-BFGS as converged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     {func}`jax.numpy.linalg.cholesky` with `symmetrize_input=False` where
     non-zero gradients leaked into the unused triangle of the input matrix
     ({jax-issue}`#40421`).
+  * {func}`jax.scipy.optimize.minimize` with method
+    `l-bfgs-experimental-do-not-rely-on-this` now reports a run stopped by the
+    `ftol` criterion (small function decrease) as converged (`success=True`,
+    `status=0`) instead of as failed with status 4, provided the line search
+    at that iteration succeeded. An iteration whose line search failed still
+    ends the run as failed (status 5, `success=False`).
 
 ## JAX 0.11.1 (August 17, 2026)
 

--- a/jax/_src/scipy/optimize/_lbfgs.py
+++ b/jax/_src/scipy/optimize/_lbfgs.py
@@ -54,8 +54,7 @@ class LBFGSResults(NamedTuple):
       tolerance.
     status: integer describing the status:
       0 = nominal  ,  1 = max iters reached  ,  2 = max fun evals reached
-      3 = max grad evals reached  ,  4 = insufficient progress (ftol)
-      5 = line search failed
+      3 = max grad evals reached  ,  5 = line search failed
     ls_status: integer describing the end status of the last line search
   """
   converged: Array
@@ -103,7 +102,10 @@ def _minimize_lbfgs(
     maxiter: maximum number of iterations
     norm: order of norm for convergence check. Default inf.
     maxcor: maximum number of metric corrections ("history size")
-    ftol: terminates the minimization when `(f_k - f_{k+1}) < ftol`
+    ftol: terminates the minimization when `(f_k - f_{k+1}) < ftol`. Such a
+      termination is reported as converged unless the line search failed at
+      that iteration, in which case the run is reported as failed with
+      status 5.
     gtol: terminates the minimization when `|g_k|_norm < gtol`
     maxfun: maximum number of function evaluations
     maxgrad: maximum number of gradient evaluations
@@ -175,13 +177,14 @@ def _minimize_lbfgs(
 
     # replacements for next iteration
     status = jnp.array(0)
-    status = jnp.where(state.f_k - f_kp1 < ftol, 4, status)
     status = jnp.where(state.ngev >= maxgrad, 3, status)
     status = jnp.where(state.nfev >= maxfun, 2, status)
     status = jnp.where(state.k >= maxiter, 1, status)
     status = jnp.where(ls_results.failed, 5, status)
 
-    converged = jnp_linalg.norm(g_kp1, ord=norm) < gtol
+    ls_ok = ~ls_results.failed
+    converged = ((ls_ok & (state.f_k - f_kp1 < ftol)) |
+                 (jnp_linalg.norm(g_kp1, ord=norm) < gtol))
 
     # TODO(jakevdp): use a fixed-point procedure rather than type-casting?
     state = state._replace(

--- a/tests/scipy_optimize_test.py
+++ b/tests/scipy_optimize_test.py
@@ -238,6 +238,92 @@ class TestLBFGS(jtu.JaxTestCase):
     jax_res = min_op(init)
     self.assertAllClose(jax_res, expect, atol=2e-5)
 
+  def test_ftol_termination_is_converged(self):
+    # A run stopped by the ftol criterion must report success=True, matching
+    # scipy L-BFGS-B which treats a small function reduction as convergence.
+    func = rosenbrock(jnp)
+
+    @jit
+    def min_op(x0):
+      return jax.scipy.optimize.minimize(
+          func,
+          x0,
+          method='l-bfgs-experimental-do-not-rely-on-this',
+          options=dict(ftol=0.5),
+      )
+
+    result = min_op(jnp.zeros(4))
+    self.assertTrue(result.success)
+    self.assertEqual(int(result.status), 0)
+    self.assertLess(int(result.nit), 10)
+    self.assertGreater(int(result.nit), 0)
+
+  def test_default_termination_unaffected(self):
+    func = rosenbrock(jnp)
+    result = jax.scipy.optimize.minimize(
+        func,
+        jnp.zeros(4),
+        method='l-bfgs-experimental-do-not-rely-on-this',
+    )
+    self.assertTrue(result.success)
+    self.assertEqual(int(result.status), 0)
+    self.assertGreater(int(result.nit), 1)
+    self.assertLess(int(result.nit), 200)
+    self.assertAllClose(result.fun, 0., atol=1e-6)
+
+  def test_gtol_convergence_still_success(self):
+    func = rosenbrock(jnp)
+    result = jax.scipy.optimize.minimize(
+        func,
+        jnp.zeros(4),
+        method='l-bfgs-experimental-do-not-rely-on-this',
+        options=dict(gtol=1e-7, ftol=0.),
+    )
+    self.assertTrue(result.success)
+    self.assertEqual(int(result.status), 0)
+    # The gradient criterion itself is met, so this stop is gtol-driven.
+    self.assertLess(float(np.linalg.norm(np.asarray(result.jac))), 1e-7)
+    self.assertAllClose(result.fun, 0., atol=1e-6)
+
+  def test_ftol_not_reported_when_line_search_fails(self):
+    # On this scaled Rosenbrock float32 L-BFGS fails its first line search.
+    # The failed search returns a far-away point whose spurious decrease
+    # satisfies the ftol test, so an ungated check reports success=True at
+    # garbage coordinates. A failed line search must never count as
+    # convergence via ftol.
+    def func(x):
+      return 1e8 * jnp.sum(
+          100. * (x[1:] - x[:-1] ** 2) ** 2 + (1. - x[:-1]) ** 2)
+
+    @jit
+    def min_op(x0):
+      return jax.scipy.optimize.minimize(
+          func,
+          x0,
+          method='l-bfgs-experimental-do-not-rely-on-this',
+      )
+
+    result = min_op(jnp.array([1.5, 1.5]))
+    self.assertFalse(result.success)
+    self.assertEqual(int(result.status), 5)
+    result_again = min_op(jnp.array([1.5, 1.5]))
+    self.assertArraysEqual(result.x, result_again.x)
+
+  def test_ftol_takes_precedence_over_maxiter(self):
+    # When the ftol criterion and the maxiter cap fire on the same
+    # iteration, the run is reported as converged, matching scipy where
+    # convergence is checked before the iteration limit.
+    func = rosenbrock(jnp)
+    result = jax.scipy.optimize.minimize(
+        func,
+        jnp.zeros(4),
+        method='l-bfgs-experimental-do-not-rely-on-this',
+        options=dict(maxiter=1, ftol=0.5),
+    )
+    self.assertTrue(result.success)
+    self.assertEqual(int(result.status), 0)
+    self.assertEqual(int(result.nit), 1)
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
## Description

In `jax.scipy.optimize.minimize(method="l-bfgs-experimental-do-not-rely-on-this")`, an iteration whose function decrease satisfied `(f_k - f_{k+1}) < ftol` was recorded as status 4 ("insufficient progress") while the converged mask tested only the gradient norm. Such runs ended with `success=False` even though they met the requested tolerance. SciPy's L-BFGS-B treats the same condition as convergence.

The ftol condition now feeds `converged`, so an ftol-stopped run reports `converged=True`, status 0, `success=True`, provided the line search at that iteration succeeded. If the line search failed at that iteration, the run still ends as a failure exactly as before (a failed search returns a finite objective decrease that would otherwise masquerade as ftol convergence). Status value 4 no longer occurs; termination points are unchanged for every input - such iterations previously stopped the loop via `failed` and now stop it via `converged`.

Deliberate scope limit: the ftol criterion stays an absolute decrease, unlike SciPy's relative reduction over `max{|f_k|, |f_{k+1}|, 1}`. The absolute form is what the docstring has always documented, switching would move termination points for existing inputs, and JAX already disclaims result parity with SciPy for this method.

AI assistance disclosure: this fix was developed with AI coding assistance under my direction; I verified the root cause analysis, ran all tests shown below, and take responsibility for the change.

## Test Plan

```
python -m pytest tests/scipy_optimize_test.py -k "ftol_termination or default_termination or gtol_convergence or ftol_not_reported or ftol_takes_precedence" -q
  default flags: green after the fix; test_ftol_not_reported_when_line_search_fails fails against the unfixed tree with
  AssertionError: Array(True, dtype=bool) is not false
python -m pytest tests/scipy_optimize_test.py -k "minimize or bfgs or lbfgs" -q
  default flags: 18 passed, 1 skipped.
JAX_ENABLE_X64=1 python -m pytest tests/scipy_optimize_test.py -k "minimize or bfgs or lbfgs" -q
  x64: 19 passed.
python -m pytest tests/scipy_optimize_test.py -q   (full file)
  default flags: 18 passed, 1 skipped; x64: 19 passed.
```

Byte-level probes confirm identical nit/nfev/x/fun before and after the change for gtol-only and default runs; only the success/status reporting of ftol stops flips.

## References

- #15486 reported exactly this ("L-BFGS fails when ftol is met") and closed without a fix. This PR is the minimal reporting fix for the method as shipped; no parity beyond clean stops is claimed, and the absolute-ftol semantics are unchanged. I am aware of the sentiment in that thread favoring directing users to jaxopt - until any deprecation actually lands, users of this method still hit the failure reporting, and this change alters nothing except that reporting.
