### PR TITLE
scipy.optimize: fix signed bracket width in line search zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
     assumed symmetric), so results are unchanged while the transform is
     ~1.4x faster at typical sizes.
 
+* Bug fixes
+  * Fixed spurious line search failures in {func}`jax.scipy.optimize.minimize`
+    for `method='BFGS'` and
+    `method='l-bfgs-experimental-do-not-rely-on-this'` (for example on the
+    Rosenbrock function started away from the origin). The zoom stage of the
+    Wolfe line search declared failure from a signed bracket width comparison,
+    so any zoom entered with `a_hi < a_lo` was reported as failed even when it
+    found a valid step. The width is now compared in absolute terms against a
+    floating-point subdivision floor, and the zoom iteration cap was raised
+    so wide dynamic range searches do not run out of iterations.
+
 ## JAX 0.11.1 (August 17, 2026)
 
 * New features

--- a/jax/_src/scipy/optimize/line_search.py
+++ b/jax/_src/scipy/optimize/line_search.py
@@ -123,10 +123,10 @@ def _zoom(restricted_func_and_grad, wolfe_one: ConditionFn, wolfe_two: Condition
     cchk = delta1 * dalpha
     qchk = delta2 * dalpha
 
-    # This will cause the line search to stop, and since the Wolfe conditions
-    # are not satisfied the minimization should stop too.
-    threshold = jnp.where((dtypes.finfo(dalpha.dtype).bits < 64), 1e-5, 1e-10)
-    state = state._replace(failed=state.failed | (dalpha <= threshold))
+    # Stop only once the bracket is too narrow to subdivide in this dtype.
+    threshold = dtypes.finfo(dalpha.dtype).eps * jnp.maximum(
+        jnp.abs(state.a_lo), jnp.abs(state.a_hi))
+    state = state._replace(failed=state.failed | (jnp.abs(dalpha) <= threshold))
 
     # Cubmin is sometimes nan, though in this case the bounds check will fail.
     a_j_cubic = _cubicmin(state.a_lo, state.phi_lo, state.dphi_lo, state.a_hi,
@@ -219,7 +219,7 @@ def _zoom(restricted_func_and_grad, wolfe_one: ConditionFn, wolfe_two: Condition
     state = state._replace(j=state.j + 1)
     # Choose higher cutoff for maxiter than Scipy as Jax takes longer to find
     # the same value - possibly floating point issues?
-    state = state._replace(failed= state.failed | (state.j >= 30))
+    state = state._replace(failed= state.failed | (state.j >= 60))
     return state
 
   state = lax.while_loop(lambda state: (~state.done) & (~pass_through) & (~state.failed),

--- a/tests/scipy_optimize_test.py
+++ b/tests/scipy_optimize_test.py
@@ -64,6 +64,14 @@ def zakharovFromIndices(x, ii):
   return answer
 
 
+def classical_rosenbrock(np):
+  # The true Rosenbrock curved valley; rosenbrock() above squares plain diffs.
+  def func(x):
+    return np.sum(100. * (x[1:] - x[:-1] ** 2) ** 2 + (1. - x[:-1]) ** 2)
+
+  return func
+
+
 class TestBFGS(jtu.JaxTestCase):
 
   @jtu.sample_product(
@@ -116,6 +124,39 @@ class TestBFGS(jtu.JaxTestCase):
     eval_func = jax.jit(zakharov_fn)
     jax_res = jax.scipy.optimize.minimize(fun=eval_func, x0=x0, method='BFGS')
     self.assertLess(jax_res.fun, 1e-6)
+
+  @jtu.sample_product(
+    x0=[np.array([-1.2, 1.0], dtype='float32'), np.zeros(2, dtype='float32')],
+  )
+  def test_minimize_rosenbrock_curved_valley(self, x0):
+    func = classical_rosenbrock(jnp)
+
+    @jit
+    def min_op(x0):
+      return jax.scipy.optimize.minimize(func, x0, method='BFGS')
+
+    result = min_op(x0)
+    self.assertTrue(bool(result.success))
+    self.assertAllClose(result.x, np.ones(2), atol=2e-3, rtol=2e-3,
+                        check_dtypes=False)
+
+  @jtu.skip_on_flag('jax_enable_x64', False)
+  def test_minimize_rosenbrock_curved_valley_x64(self):
+    func = classical_rosenbrock(jnp)
+    for x0 in [np.array([-1.2, 1.0]), np.zeros(2), np.full(5, 0.5)]:
+      result = jax.scipy.optimize.minimize(func, x0, method='BFGS')
+      self.assertTrue(bool(result.success))
+      self.assertAllClose(result.x, np.ones_like(x0), atol=1e-4, rtol=1e-4)
+
+  @jtu.skip_on_flag('jax_enable_x64', False)
+  def test_minimize_steep_quadratic_x64(self):
+    def steep_quadratic(x):
+      return jnp.sum((1e6 * (x - 1.)) ** 2)
+
+    result = jax.scipy.optimize.minimize(
+        steep_quadratic, jnp.zeros(3), method='BFGS')
+    self.assertTrue(bool(result.success))
+    self.assertAllClose(result.x, np.ones(3), atol=1e-3, rtol=1e-3)
 
   @jtu.ignore_warning(category=RuntimeWarning, message='divide by zero')
   def test_minimize_bad_initial_values(self):
@@ -237,6 +278,17 @@ class TestLBFGS(jtu.JaxTestCase):
 
     jax_res = min_op(init)
     self.assertAllClose(jax_res, expect, atol=2e-5)
+
+  @jtu.skip_on_flag('jax_enable_x64', False)
+  def test_minimize_steep_quadratic_x64(self):
+    def steep_quadratic(x):
+      return jnp.sum((1e6 * (x - 1.)) ** 2)
+
+    result = jax.scipy.optimize.minimize(
+        steep_quadratic, jnp.zeros(3),
+        method='l-bfgs-experimental-do-not-rely-on-this')
+    self.assertTrue(bool(result.success))
+    self.assertAllClose(result.x, np.ones(3), atol=1e-3, rtol=1e-3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`jax.scipy.optimize.minimize(method="BFGS")` reports a line-search failure (status 3) on the classical 2D Rosenbrock function from the standard start points, in both float32 and float64, where `scipy.optimize.minimize` converges:

```
JAX_ENABLE_X64=1, x0=[0,0]:     success=False status=3 nit=1 fun=0.77657
JAX_ENABLE_X64=1, x0=[-1.2,1]:  success=False status=3 nit=8 fun=1.74729
float32,       x0=[-1.2,1]:     success=False status=3 nit=8 fun=1.74729
```

Root cause is in the zoom stage of the Wolfe line search (`jax/_src/scipy/optimize/line_search.py`). The failure guard compared a *signed* bracket width `dalpha <= threshold`. `zoom2` is always entered with `a_lo > a_hi` whenever the outer loop doubled alpha, and `zoom1` legitimately inverts its bracket after swaps, so on those iterations a negative width compared against a positive threshold set the sticky `failed` flag even while the bracket still contained steps satisfying the strong Wolfe conditions - scipy's `line_search_wolfe2` returns the identical step for the same inputs.

Second, the absolute thresholds (1e-5 narrow dtypes, 1e-10 otherwise) were neither scale nor dtype aware and rejected legitimate deep bisection (widths near 1e-12 on steep quadratics).

The guard now compares `abs(dalpha)` against `eps(dtype) * max(|a_lo|, |a_hi|)`, the width below which bisection cannot produce a distinct midpoint, and the zoom iteration cap moves from 30 to 60 so pure-bisection searches over wide dynamic ranges can finish.

Deliberately unchanged: the Wolfe condition definitions, the outer loop, and the float32 alpha floor in `line_search`. One interaction worth noting: the newly reachable deep zooms can end on an alpha below that pre-existing floor (`|alpha_k| < 1e-8` is floored to 1e-8 for narrow dtypes), so on problems with extreme curvature in float32 the L-BFGS path can report convergence at a step whose stored alpha was floored. That is pre-existing floor behavior on a previously unreachable path and is left to a separate change.

AI assistance disclosure: this fix was developed with AI coding assistance under my direction; I verified the root cause analysis, ran all tests shown below, and take responsibility for the change.

## Test Plan

New tests use the classical Rosenbrock valley (the file's existing helper squares plain differences and never forms it):

```
python -m pytest tests/scipy_optimize_test.py -k "curved_valley or steep_quadratic" -q
  default flags: 2 failed before the fix, 2 passed + 3 skipped after.
JAX_ENABLE_X64=1 python -m pytest tests/scipy_optimize_test.py -k "curved_valley or steep_quadratic" -q
  x64: 5 failed before the fix, 5 passed after.
python -m pytest tests/scipy_optimize_test.py -q -n auto
  default flags: 15 passed, 4 skipped.
JAX_ENABLE_X64=1 python -m pytest tests/scipy_optimize_test.py -q -n auto
  x64: 19 passed.
```

All previously-converging cases were checked for drift before/after: standard objectives converge to bit-identical results or shift by at most one iteration.

## References

- #16236 is the canonical issue for the signed-width defect: it names `dalpha = a_hi - a_lo < 0` at exactly these lines and prescribes `jnp.abs(dalpha)`; this PR implements that prescription plus the dtype/scale-aware threshold the absolute-constant version still needed. #4594 reports the same status=3 symptom from the user side. The `a_rec` slot correction in 88d98bdb3 fixed an adjacent zoom-state bug only; the signed-threshold guard remained untouched on main.
