### PR TITLE
numpy: return empty results for intersect1d and setxor1d at size 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * Fixed a bug where {func}`jax.numpy.linalg.cond` returned NaN instead of
     infinity for singular matrices when `p` is `None` or `2`, matching NumPy
     and the other norms.
+  * Fixed {func}`jax.numpy.intersect1d` and {func}`jax.numpy.setxor1d` with
+    ``size=0``, which previously raised a ValueError; they now return empty
+    arrays of the natural result dtype.
 
 ## JAX 0.11.1 (August 17, 2026)
 

--- a/jax/_src/numpy/setops.py
+++ b/jax/_src/numpy/setops.py
@@ -277,7 +277,12 @@ def _setxor1d_size(arr1: Array, arr2: Array, fill_value: ArrayLike | None, *,
     vals = aux.at[indices].get(mode='fill', fill_value=0)
   else:
     vals = zeros(size, aux.dtype)
-  if fill_value is None:
+  if vals.size == 0:
+    # fill values are irrelevant in an empty array.
+    return vals
+  elif fill_value is None:
+    # launder the zero-filled padding through max() before taking the min,
+    # so unfilled slots are padded with the smallest real result.
     vals = where(arange(len(vals)) < num_results, vals, vals.max())
     return where(arange(len(vals)) < num_results, vals, vals.min())
   else:
@@ -404,7 +409,11 @@ def _intersect1d_size(arr1: Array, arr2: Array, fill_value: ArrayLike | None, as
   else:
     val_indices = arange(0)
     vals = zeros(size, aux.dtype)
-  if fill_value is None:
+  if vals.size == 0:
+    pass  # fill values are irrelevant in an empty array.
+  elif fill_value is None:
+    # launder the zero-filled padding through max() before taking the min,
+    # so unfilled slots are padded with the smallest real result.
     vals = where(arange(len(vals)) < num_results, vals, vals.max())
     vals = where(arange(len(vals)) < num_results, vals, vals.min())
   else:

--- a/tests/lax_numpy_setops_test.py
+++ b/tests/lax_numpy_setops_test.py
@@ -213,6 +213,11 @@ class LaxNumpySetopsTest(jtu.JaxTestCase):
     with jtu.strict_promotion_if_dtypes_match([dtype1, dtype2]):
       self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
 
+  def testSetxor1dSizeZero(self):
+    ar1 = np.array([1, 3, 5])
+    ar2 = np.array([2, 3, 4])
+    self.assertEqual(jnp.setxor1d(ar1, ar2, size=0).shape, (0,))
+
   @jtu.sample_product(
     dtype1=[s for s in default_dtypes if s != jnp.bfloat16],
     dtype2=[s for s in default_dtypes if s != jnp.bfloat16],
@@ -252,6 +257,11 @@ class LaxNumpySetopsTest(jtu.JaxTestCase):
 
     with jtu.strict_promotion_if_dtypes_match([dtype1, dtype2]):
       self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
+
+  def testIntersect1dSizeZero(self):
+    ar1 = np.array([1, 2, 3, 4])
+    ar2 = np.array([3, 4, 5])
+    self.assertEqual(jnp.intersect1d(ar1, ar2, size=0).shape, (0,))
 
   @jtu.sample_product(
     [dict(shape=shape, axis=axis)


### PR DESCRIPTION
## Description

`jnp.intersect1d` and `jnp.setxor1d` with a concrete `size=0` raise `ValueError: zero-size array to reduction operation max which has no identity`, because the `_intersect1d_size` / `_setxor1d_size` helpers compute their default padding via `vals.max()` (and `.min()`) on a zero-size result:

```
jnp.intersect1d(jnp.arange(5), jnp.array([2]), size=0)   # ValueError
jnp.setxor1d(jnp.arange(5), jnp.array([2]), size=0)      # ValueError
jnp.union1d(jnp.arange(5), jnp.array([2]), size=0)       # fine: Array([], dtype=int32)
```

The fix guards the padding reductions on `vals.size`; an empty output has nothing to pad, so the arrays are returned as-is. With an explicit `fill_value` the size=0 path already worked and is unchanged; behavior at any nonzero size is bit-identical (`vals` always has shape `(size,)`, so the guard fires only at size 0).

Scope note: `setdiff1d` has its own size=0 crash with a different mechanism, fixed separately (#40230); `union1d` is untouched.

AI assistance disclosure: this fix was developed with AI coding assistance under my direction; I verified the mechanisms against NumPy oracles, ran all tests shown below, and take responsibility for the change.

## Test Plan

```
python -m pytest tests/lax_numpy_setops_test.py -k "intersect or setxor or union or setdiff" -q
  default flags: 90 passed.
JAX_ENABLE_X64=1 python -m pytest tests/lax_numpy_setops_test.py -k "intersect or setxor or union or setdiff" -q
  x64: 90 passed.
python -m pytest tests/lax_numpy_setops_test.py -n auto -q
  default flags: 172 passed; x64: 176 passed.
```

The new `testIntersect1dSizeZero` / `testSetxor1dSizeZero` fail on the unfixed tree exactly on the fill_value=None variants with the ValueError above (9 failed pre-fix), all pass after. A 576-case differential grid over sizes {0,1,2,3,5,10} x dtypes x assume_unique x fill_value x return_indices shows the only behavioral change is size=0 + default-fill going from raise to empty.

Recent neighboring fixes to the same file: #32335, #32402, #32340. Sibling PRs: #40229 (unique empty-axis shapes), #40230 (setdiff1d size=0).
