### PR TITLE
[Mosaic GPU] Support collective tcgen05.commit arrivals in multidimensional clusters

### DIFF
--- a/jax/experimental/mosaic/gpu/tcgen05.py
+++ b/jax/experimental/mosaic/gpu/tcgen05.py
@@ -854,10 +854,10 @@ def commit_arrive(
   if collective:
     if ctx is None:
       raise ValueError("ctx must be provided for collective barriers")
-    if ctx.cluster_size[0] % 2:
+    if ctx.cluster_size[0] != 2:
       raise ValueError(
-          "Collective arrivals require an even cluster size along the x"
-          f" dimension, got: {ctx.cluster_size}"
+          "Collective arrivals require the minormost cluster dimension to"
+          f" have size 2, got: {ctx.cluster_size}"
       )
     i16 = ir.IntegerType.get_signless(16)
     block_idx = arith.index_castui(i16, utils.cluster_idx())

--- a/jax/experimental/mosaic/gpu/tcgen05.py
+++ b/jax/experimental/mosaic/gpu/tcgen05.py
@@ -854,11 +854,15 @@ def commit_arrive(
   if collective:
     if ctx is None:
       raise ValueError("ctx must be provided for collective barriers")
-    # TODO(apaszke): This is just 0b11 shifted by the even CTA index.
-    if ctx.cluster_size != (2, 1, 1):
-      raise NotImplementedError("Collective arrivals only support (2, 1, 1)-shaped clusters")
+    if ctx.cluster_size[0] % 2:
+      raise ValueError(
+          "Collective arrivals require an even cluster size along the x"
+          f" dimension, got: {ctx.cluster_size}"
+      )
     i16 = ir.IntegerType.get_signless(16)
-    mask = arith.constant(i16, 3)
+    block_idx = arith.index_castui(i16, utils.cluster_idx())
+    even_block_idx = arith.andi(block_idx, arith.constant(i16, ~1))
+    mask = arith.shli(arith.constant(i16, 0b11), even_block_idx)
     nvvm.tcgen05_commit(
         barrier, group=nvvm.CTAGroupKind.CTA_2, multicast_mask=mask
     )

--- a/jax/experimental/mosaic/gpu/tcgen05.py
+++ b/jax/experimental/mosaic/gpu/tcgen05.py
@@ -860,9 +860,12 @@ def commit_arrive(
           f" have size 2, got: {ctx.cluster_size}"
       )
     i16 = ir.IntegerType.get_signless(16)
-    block_idx = arith.index_castui(i16, utils.cluster_idx())
-    even_block_idx = arith.andi(block_idx, arith.constant(i16, ~1))
-    mask = arith.shli(arith.constant(i16, 0b11), even_block_idx)
+    if ctx.cluster_size == (2, 1, 1):
+      mask = arith.constant(i16, 3)
+    else:
+      block_idx = arith.index_castui(i16, utils.cluster_idx())
+      even_block_idx = arith.andi(block_idx, arith.constant(i16, ~1))
+      mask = arith.shli(arith.constant(i16, 0b11), even_block_idx)
     nvvm.tcgen05_commit(
         barrier, group=nvvm.CTAGroupKind.CTA_2, multicast_mask=mask
     )

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -3519,7 +3519,7 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
     atol = 2e-2 if out_jax_dtype == jnp.float16 else 5e-6
     np.testing.assert_allclose(z, ref, atol=atol)
 
-  @parameterized.product(cluster=((2, 2, 1), (4, 1, 1), (2, 1, 2)))
+  @parameterized.product(cluster=((2, 2, 1), (2, 1, 2)))
   def test_mma_collective_multidim_cluster(self, cluster):
     in_jax_dtype = jnp.float16
     out_jax_dtype = jnp.float32
@@ -3604,7 +3604,7 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
     ref = x.astype(np.float32) @ y.astype(np.float32)
     np.testing.assert_allclose(z, ref, atol=5e-6)
 
-  def test_raises_error_if_collective_arrival_with_odd_cluster_x_dim(self):
+  def test_raises_error_if_collective_arrival_minormost_cluster_dim_not_2(self):
     def kernel(ctx, out, barrier):
       del out
       tcgen05.commit_arrive(barrier, collective=True, ctx=ctx)
@@ -3612,8 +3612,8 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
     out_shape = jax.ShapeDtypeStruct((128,), jnp.int32)
     with self.assertRaisesRegex(
         ValueError,
-        "Collective arrivals require an even cluster size along the x"
-        " dimension",
+        "Collective arrivals require the minormost cluster dimension to have"
+        " size 2",
     ):
       mgpu.as_gpu_kernel(
           kernel, (1, 2, 1), (128, 1, 1), (), out_shape, mgpu.Barrier(1), cluster=(1, 2, 1)

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -3519,6 +3519,106 @@ class TCGen05Test(TestCase, jtu.CudaArchSpecificTest):
     atol = 2e-2 if out_jax_dtype == jnp.float16 else 5e-6
     np.testing.assert_allclose(z, ref, atol=atol)
 
+  @parameterized.product(cluster=((2, 2, 1), (4, 1, 1), (2, 1, 2)))
+  def test_mma_collective_multidim_cluster(self, cluster):
+    in_jax_dtype = jnp.float16
+    out_jax_dtype = jnp.float32
+    m = n = 128
+    swizzle = 128
+    k_steps = 2
+
+    in_mlir_dtype = utils.dtype_to_ir_type(in_jax_dtype)
+    m_block_tile = m // 2
+    n_block_tile = n // 2
+    swizzle_elems = swizzle // bytewidth(in_mlir_dtype)
+    k = swizzle_elems * k_steps
+    index = ir.IndexType.get()
+
+    tiling = (8, swizzle_elems)
+
+    def kernel(ctx, lhs, rhs, out, scratch):
+      lhs_smem, rhs_smem, barriers, cluster_barrier, mma_barrier, acc = scratch
+      # CTAs with linear cluster indices 2k and 2k + 1 form the k-th MMA pair.
+      block_idx = utils.cluster_idx()
+      pair_id = arith.divui(block_idx, c(2, index))
+      block_id = arith.remui(block_idx, c(2, index))
+      m_start = arith.muli(block_id, c(m_block_tile, index))
+      n_start = arith.muli(block_id, c(n_block_tile, index))
+      ctx.async_copy(
+          src_ref=lhs,
+          dst_ref=lhs_smem,
+          gmem_slice=(pair_id, ds(m_start, m_block_tile)),
+          swizzle=swizzle,
+          gmem_transform=mgpu.TileTransform(tiling),
+          barrier=barriers[0],
+      )
+      ctx.async_copy(
+          src_ref=rhs,
+          dst_ref=rhs_smem,
+          gmem_slice=(pair_id, slice(None), ds(n_start, n_block_tile)),
+          swizzle=swizzle,
+          gmem_transform=mgpu.TileTransform(tiling),
+          barrier=barriers[1],
+      )
+      barriers[0].wait()
+      barriers[1].wait()
+      # The MMA also reads the SMEM operands of the other CTA in the pair.
+      cluster_barrier.arrive()
+      cluster_barrier.wait()
+      is_leader_thread = single_thread_predicate()
+      is_first_block = arith.cmpi(arith.CmpIPredicate.eq, block_id, c(0, index))
+      with when(arith.andi(is_first_block, is_leader_thread)):
+        tcgen05.mma(
+            acc, lhs_smem, rhs_smem, a_swizzle=swizzle, b_swizzle=swizzle, accumulate=False, collective=True
+        )
+        tcgen05.commit_arrive(mma_barrier, collective=True, ctx=ctx)
+      mma_barrier.wait(orders_tensor_core=True)
+      m_slice = ds(m_start, m_block_tile)
+      acc.load().store_untiled(memref_slice(out, (pair_id, m_slice)), optimized=False)
+
+    in_finfo = jnp.finfo(in_jax_dtype)
+    exponent_bits, mantissa_bits = in_finfo.nexp, in_finfo.nmant
+    def quantize(x):
+      # Quantize the input to avoid rounding when feeding the TensorCore
+      return jax.lax.reduce_precision(x, exponent_bits, mantissa_bits)
+
+    x_block_shape = (m_block_tile, k)
+    y_block_shape = (k, n_block_tile)
+    # The two pairs compute GEMMs on different data, so an MMA that reads SMEM
+    # from a CTA outside its own pair, or a commit that signals another pair's
+    # barriers, fails the output comparison instead of passing by accident.
+    x = quantize(self.prng.uniform(-1, 1, (2, m, k))).astype(in_jax_dtype)
+    y = quantize(self.prng.uniform(-1, 1, (2, k, n))).astype(in_jax_dtype)
+    out_shape = jax.ShapeDtypeStruct((2, m, n), out_jax_dtype)
+    scratch_shape = [
+        jax.ShapeDtypeStruct(tile_shape(x_block_shape, tiling), in_jax_dtype),
+        jax.ShapeDtypeStruct(tile_shape(y_block_shape, tiling), in_jax_dtype),
+        mgpu.TMABarrier(2),
+        mgpu.ClusterBarrier(collective_dims=(gpu.Dimension.x,)),
+        mgpu.Barrier(1),
+        mgpu.TMEM((m_block_tile, n), out_jax_dtype, collective=True),
+    ]
+    z = mgpu.as_gpu_kernel(
+        kernel, cluster, (128, 1, 1), (x, y), out_shape, scratch_shape, cluster=cluster
+    )(x, y)
+    ref = x.astype(np.float32) @ y.astype(np.float32)
+    np.testing.assert_allclose(z, ref, atol=5e-6)
+
+  def test_raises_error_if_collective_arrival_with_odd_cluster_x_dim(self):
+    def kernel(ctx, out, barrier):
+      del out
+      tcgen05.commit_arrive(barrier, collective=True, ctx=ctx)
+
+    out_shape = jax.ShapeDtypeStruct((128,), jnp.int32)
+    with self.assertRaisesRegex(
+        ValueError,
+        "Collective arrivals require an even cluster size along the x"
+        " dimension",
+    ):
+      mgpu.as_gpu_kernel(
+          kernel, (1, 2, 1), (128, 1, 1), (), out_shape, mgpu.Barrier(1), cluster=(1, 2, 1)
+      )
+
   @parameterized.product(
       in_jax_dtype=(jnp.float16,),
       out_jax_dtype=(jnp.float32,),

--- a/tests/pallas/mosaic_gpu_test.py
+++ b/tests/pallas/mosaic_gpu_test.py
@@ -7207,6 +7207,77 @@ class PallasCallTCGen05Test(PallasTCGen05Test):
     atol, rtol = (1e-2, 1e-2) if is_fp8 else (0, 4e-3)
     np.testing.assert_allclose(result, expected, atol=atol, rtol=rtol)
 
+  @parameterized.product(
+      cluster=(((2, 2), ("y", "x")), ((2, 1, 2), ("z", "y", "x")))
+  )
+  def test_collective_matmul_multidim_cluster(self, cluster):
+    cluster_shape, cluster_names = cluster
+    m, n, k = 128, 128, 128
+    swizzle = 128
+    dtype = jnp.float16
+    block_lhs_shape = (m // 2, k)
+    block_rhs_shape = (k, n // 2)
+    block_acc_shape = (m // 2, n)
+    a_transforms = self.default_transforms(swizzle=swizzle, dtype=dtype)
+    b_transforms = self.default_transforms(swizzle=swizzle, dtype=dtype)
+    pair_axis = cluster_names[0]
+
+    def kernel(a_gmem, b_gmem, out_gmem, a_smem, b_smem, acc_tmem,
+               tma_barrier, mma_barrier, cluster_barrier):
+      pair_idx = lax.axis_index(pair_axis)
+      cluster_idx = lax.axis_index("x")
+      slice_lhs = pl.ds(cluster_idx * block_lhs_shape[0], block_lhs_shape[0])
+      slice_rhs = pl.ds(cluster_idx * block_rhs_shape[1], block_rhs_shape[1])
+
+      plgpu.copy_gmem_to_smem(
+          a_gmem.at[pair_idx, slice_lhs, :], a_smem, tma_barrier
+      )
+      plgpu.barrier_wait(tma_barrier)
+      plgpu.copy_gmem_to_smem(
+          b_gmem.at[pair_idx, :, slice_rhs], b_smem, tma_barrier
+      )
+      plgpu.barrier_wait(tma_barrier)
+
+      plgpu.barrier_arrive(cluster_barrier)
+      plgpu.barrier_wait(cluster_barrier)
+
+      plgpu.tcgen05_mma(
+          acc_tmem,
+          a_smem,
+          b_smem,
+          mma_barrier,
+          accumulate=False,
+          collective_axis="x",
+      )
+      plgpu.barrier_wait(mma_barrier)
+      out_gmem[pair_idx, slice_lhs, :] = plgpu.async_load_tmem(
+          acc_tmem, layout=plgpu.Layout.TCGEN05_M64_COLLECTIVE(n)
+      ).astype(dtype)
+
+    scratch_types = [
+        plgpu.SMEM(block_lhs_shape, dtype, transforms=a_transforms),
+        plgpu.SMEM(block_rhs_shape, dtype, transforms=b_transforms),
+        plgpu.TMEM(block_acc_shape, jnp.float32, collective=True),
+        plgpu.Barrier(),
+        plgpu.Barrier(orders_tensor_core=True),
+        plgpu.ClusterBarrier(collective_axes=("x",)),
+    ]
+    f = self.kernel(
+        kernel,
+        out_type=jax.ShapeDtypeStruct((2, m, n), dtype),
+        cluster=cluster_shape,
+        cluster_names=cluster_names,
+        scratch_types=scratch_types,
+    )
+    # The two pairs compute GEMMs on different data, so an MMA that reads SMEM
+    # from a CTA outside its own pair, or a commit that signals another pair's
+    # barriers, fails the output comparison instead of passing by accident.
+    x = jax.random.uniform(jax.random.key(0), shape=(2, m, k), dtype=dtype)
+    y = jax.random.uniform(jax.random.key(1), shape=(2, k, n), dtype=dtype)
+    result = f(x, y)
+    expected = x.astype(jnp.float32) @ y.astype(jnp.float32)
+    np.testing.assert_allclose(result, expected, atol=0, rtol=4e-3)
+
   @parameterized.parameters(
       (128, jnp.float16)
   )

--- a/tests/pallas/mosaic_gpu_test.py
+++ b/tests/pallas/mosaic_gpu_test.py
@@ -7229,13 +7229,9 @@ class PallasCallTCGen05Test(PallasTCGen05Test):
       slice_lhs = pl.ds(cluster_idx * block_lhs_shape[0], block_lhs_shape[0])
       slice_rhs = pl.ds(cluster_idx * block_rhs_shape[1], block_rhs_shape[1])
 
-      plgpu.copy_gmem_to_smem(
-          a_gmem.at[pair_idx, slice_lhs, :], a_smem, tma_barrier
-      )
+      plgpu.copy_gmem_to_smem(a_gmem.at[pair_idx, slice_lhs, :], a_smem, tma_barrier)
       plgpu.barrier_wait(tma_barrier)
-      plgpu.copy_gmem_to_smem(
-          b_gmem.at[pair_idx, :, slice_rhs], b_smem, tma_barrier
-      )
+      plgpu.copy_gmem_to_smem(b_gmem.at[pair_idx, :, slice_rhs], b_smem, tma_barrier)
       plgpu.barrier_wait(tma_barrier)
 
       plgpu.barrier_arrive(cluster_barrier)
@@ -7252,7 +7248,7 @@ class PallasCallTCGen05Test(PallasTCGen05Test):
       plgpu.barrier_wait(mma_barrier)
       out_gmem[pair_idx, slice_lhs, :] = plgpu.async_load_tmem(
           acc_tmem, layout=plgpu.Layout.TCGEN05_M64_COLLECTIVE(n)
-      ).astype(dtype)
+      )
 
     scratch_types = [
         plgpu.SMEM(block_lhs_shape, dtype, transforms=a_transforms),
@@ -7264,7 +7260,7 @@ class PallasCallTCGen05Test(PallasTCGen05Test):
     ]
     f = self.kernel(
         kernel,
-        out_type=jax.ShapeDtypeStruct((2, m, n), dtype),
+        out_type=jax.ShapeDtypeStruct((2, m, n), jnp.float32),
         cluster=cluster_shape,
         cluster_names=cluster_names,
         scratch_types=scratch_types,


### PR DESCRIPTION
This pr allows multidim cluster shapes for tcgen05 commit arrival instructions (fixes https://github.com/jax-ml/jax/issues/40165)

- The multicast mask is derived from issuing CTA's linear cluster index `(0b11 << (idx & ~1))`, matching the PTX ISA's CTA-pair definition ([9.7.17.5.1. CTA Pair](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-cta-pair)).