### PR TITLE
Improve Python 3.15 free-threaded support in Bazel builds

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
 load(
     "@xla//third_party/py:py_import.bzl",
     "py_import",
@@ -192,4 +194,85 @@ pytype_test(
         "manual",
         "notap",
     ],
+)
+
+py_library(
+    name = "empty",
+    visibility = ["//:__subpackages__"],
+)
+
+selects.config_setting_group(
+    name = "is_python_3_14_or_3_15",
+    match_any = [
+        "@rules_python//python/config_settings:is_python_3.14",
+        "@rules_python//python/config_settings:is_python_3.15",
+    ],
+)
+
+selects.config_setting_group(
+    name = "is_python_3_14_freethreaded",
+    match_all = [
+        "@rules_python//python/config_settings:is_python_3.14",
+        "@rules_python//python/config_settings:is_py_freethreaded",
+    ],
+)
+
+selects.config_setting_group(
+    name = "is_python_3_15_freethreaded",
+    match_all = [
+        "@rules_python//python/config_settings:is_python_3.15",
+        "@rules_python//python/config_settings:is_py_freethreaded",
+    ],
+)
+
+# portpicker depends on psutil, which does not currently provide wheels for
+# free-threaded Python 3.15.
+alias(
+    name = "pypi_optional_portpicker",
+    actual = select({
+        ":is_python_3_15_freethreaded": ":empty",
+        "//conditions:default": "@pypi//portpicker",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+# matplotlib does not yet provide wheels for Python 3.15.
+alias(
+    name = "pypi_optional_matplotlib",
+    actual = select({
+        "@rules_python//python/config_settings:is_python_3.15": ":empty",
+        "//conditions:default": "@pypi//matplotlib",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+# tensorstore does not yet provide wheels for Python 3.15.
+alias(
+    name = "pypi_optional_tensorstore",
+    actual = select({
+        "@rules_python//python/config_settings:is_python_3.15": ":empty",
+        "//conditions:default": "@pypi//tensorstore",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+# tensorflow does not provide wheels for Python 3.14 or 3.15.
+alias(
+    name = "pypi_optional_tensorflow",
+    actual = select({
+        ":is_python_3_14_or_3_15": ":empty",
+        "//conditions:default": "@pypi//tensorflow",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+# zstandard is included in the Python standard library in Python 3.14+, so the
+# external PyPI package is not needed or available on Python 3.14+.
+alias(
+    name = "pypi_optional_zstandard",
+    actual = select({
+        ":is_python_3_14_or_3_15": ":empty",
+        "//conditions:default": "@pypi//zstandard",
+    }),
+    visibility = ["//:__subpackages__"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -182,7 +182,8 @@ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_depen
         # Explicitly list both x86_64 and aarch64 to ensure cross-compilation works.
         "{os}_x86_64",
         "{os}_aarch64",
-        "{os}_{arch}_freethreaded",
+        "{os}_x86_64_freethreaded",
+        "{os}_aarch64_freethreaded",
     ],
     whl_modifications = {
         "//build:numpy.json": "numpy",  # @pypi_mods is defined in XLA's MODULE.bazel

--- a/jaxlib/jax.bzl
+++ b/jaxlib/jax.bzl
@@ -26,7 +26,7 @@ load("@local_config_rocm//rocm:build_defs.bzl", _if_rocm_is_configured = "if_roc
 # TODO(Intel-tf): Update `sycl` with `oneapi` when xla changes to use `oneapi`.
 load("@local_config_sycl//sycl:build_defs.bzl", _if_oneapi_is_configured = "if_sycl_is_configured", _oneapi_library = "sycl_library")
 load("@nvidia_wheel_versions//:versions.bzl", "NVIDIA_WHEEL_VERSIONS")
-load("@python_version_repo//:py_version.bzl", "HERMETIC_PYTHON_VERSION", "HERMETIC_PYTHON_VERSION_KIND")
+load("@python_version_repo//:py_version.bzl", "HERMETIC_PYTHON_VERSION")
 load("@rocm_external_test_deps//:external_deps.bzl", "EXTERNAL_DEPS")
 load("@rocm_prebuilt_test_deps//:external_deps.bzl", PREBUILT_EXTERNAL_DEPS = "EXTERNAL_DEPS")
 load("@rules_python//python:defs.bzl", _py_binary = "py_binary", _py_library = "py_library", _py_test = "py_test")
@@ -77,14 +77,6 @@ PLATFORM_TAGS_DICT = {
     ("Windows", "AMD64"): ("win", "amd64"),
 }
 
-def get_optional_dep(package, excluded_py_versions):
-    py_ver = HERMETIC_PYTHON_VERSION
-    if HERMETIC_PYTHON_VERSION_KIND == "ft":
-        py_ver += "-ft"
-    if py_ver in excluded_py_versions:
-        return []
-    return [package]
-
 _py_deps = {
     "absl-all": ["@pypi//absl_py"],
     "absl/logging": ["@pypi//absl_py"],
@@ -97,22 +89,22 @@ _py_deps = {
     "flatbuffers": ["@pypi//flatbuffers"],
     "hypothesis": ["@pypi//hypothesis"],
     "magma": [],
-    "matplotlib": get_optional_dep("@pypi//matplotlib", ["3.15", "3.15-ft"]),
+    "matplotlib": ["//:pypi_optional_matplotlib"],
     "mpmath": ["@pypi//mpmath"],
     "opt_einsum": ["@pypi//opt_einsum"],
     "pil": ["@pypi//pillow"],
-    "portpicker": get_optional_dep("@pypi//portpicker", ["3.15-ft"]),
+    "portpicker": ["//:pypi_optional_portpicker"],
     "ml_dtypes": ["@pypi//ml_dtypes"],
     "numpy": ["@pypi//numpy"],
     "scipy": ["@pypi//scipy"],
     "tensorflow_core": [],
-    "tensorstore": get_optional_dep("@pypi//tensorstore", ["3.15", "3.15-ft"]),
+    "tensorstore": ["//:pypi_optional_tensorstore"],
     "torch": [],
-    "tensorflow": get_optional_dep("@pypi//tensorflow", ["3.14", "3.14-ft", "3.15", "3.15-ft"]),
+    "tensorflow": ["//:pypi_optional_tensorflow"],
     "tpu_ops": [],
     # We're never going to need zstandard for 3.14+ because zstandard is now
     # in the Python stdlib.
-    "zstandard": get_optional_dep("@pypi//zstandard", ["3.14", "3.14-ft", "3.15", "3.15-ft"]),
+    "zstandard": ["//:pypi_optional_zstandard"],
 }
 
 def all_py_deps(excluded = []):
@@ -260,12 +252,12 @@ def _get_jax_test_deps(deps):
       If --//jax:build_jax=false, returns jax pypi wheel dep and transitive pypi test deps.
       If --//jax:build_jax=wheel, returns jax py_import dep and transitive pypi test deps.
     """
-    non_pypi_deps = [d for d in deps if not d.startswith("@pypi//")]
+    non_pypi_deps = [d for d in deps if not (d.startswith("@pypi//") or d.startswith("//:pypi_optional_"))]
 
     # A lot of tests don't have explicit dependencies on scipy, ml_dtypes, etc. But the tests
     # transitively depends on them via //jax. So we need to make sure that these dependencies are
     # included in the test when JAX is built from source.
-    pypi_deps = depset([d for d in deps if d.startswith("@pypi//")])
+    pypi_deps = depset([d for d in deps if d.startswith("@pypi//") or d.startswith("//:pypi_optional_")])
     pypi_deps = depset(py_deps([
         "ml_dtypes",
         "scipy",

--- a/third_party/py/rules_python_whl_abi_tags.patch
+++ b/third_party/py/rules_python_whl_abi_tags.patch
@@ -17,52 +17,56 @@ diff --git a/python/private/pypi/extension.bzl b/python/private/pypi/extension.b
 index 094cac7f..2e9498ca 100644
 --- a/python/private/pypi/extension.bzl
 +++ b/python/private/pypi/extension.bzl
-@@ -91,7 +91,11 @@ def default_platforms():
+@@ -91,7 +91,12 @@ def default_platforms():
                  "marker": "python_version >= '3.13'" if freethreaded else "",
                  "name": platform_name,
                  "os_name": "linux",
 -                "whl_abi_tags": ["cp{major}{minor}t"] if freethreaded else [
 +                "whl_abi_tags": [
 +                    "none",
++                    "abi3t",
 +                    "cp{major}{minor}t",
 +                ] if freethreaded else [
 +                    "none",
                      "abi3",
                      "cp{major}{minor}",
                  ],
-@@ -121,7 +125,11 @@ def default_platforms():
+@@ -121,7 +126,12 @@ def default_platforms():
                  "marker": "python_version >= '3.13'" if freethreaded else "",
                  "name": platform_name,
                  "os_name": "osx",
 -                "whl_abi_tags": ["cp{major}{minor}t"] if freethreaded else [
 +                "whl_abi_tags": [
 +                    "none",
++                    "abi3t",
 +                    "cp{major}{minor}t",
 +                ] if freethreaded else [
 +                    "none",
                      "abi3",
                      "cp{major}{minor}",
                  ],
-@@ -147,7 +155,11 @@ def default_platforms():
+@@ -147,7 +157,12 @@ def default_platforms():
              "marker": "python_version >= '3.13'" if freethreaded else "",
              "name": platform_name,
              "os_name": "windows",
 -            "whl_abi_tags": ["cp{major}{minor}t"] if freethreaded else [
 +            "whl_abi_tags": [
 +                "none",
++                "abi3t",
 +                "cp{major}{minor}t",
 +            ] if freethreaded else [
 +                "none",
                  "abi3",
                  "cp{major}{minor}",
              ],
-@@ -170,7 +182,11 @@ def default_platforms():
+@@ -170,7 +185,12 @@ def default_platforms():
              "marker": "python_version >= '3.13'" if freethreaded else "python_version >= '3.11'",
              "name": platform_name,
              "os_name": "windows",
 -            "whl_abi_tags": ["cp{major}{minor}t"] if freethreaded else [
 +            "whl_abi_tags": [
 +                "none",
++                "abi3t",
 +                "cp{major}{minor}t",
 +            ] if freethreaded else [
 +                "none",
@@ -124,8 +128,8 @@ index dcdb6128..c76599d2 100644
          return platform_string
  
 +    py_ver = version.parse(python_version) if "." in python_version else None
-+    if py_ver and len(py_ver.release) >= 3:
-+        return "cp{}{}.{}_{}".format(py_ver.release[0], py_ver.release[1], py_ver.release[2], platform_string)
++    if py_ver and len(py_ver.release) >= 2:
++        return "cp{}{}_{}".format(py_ver.release[0], py_ver.release[1], platform_string)
 +
      major, _, tail = python_version.partition(".")
  


### PR DESCRIPTION
- Update the rules_python patch to support `abi3t` wheel tags and fix `cp315` platform string generation.
- Add explicit free-threaded target platforms in MODULE.bazel.
- Replace macro-time dependency exclusion in jax.bzl with `//:pypi_optional_*` aliases in BUILD.bazel that resolve to an empty library on unsupported configurations (e.g. portpicker on 3.15 free-threaded).
