### PR TITLE
[hijax] Fix vmap over scan with HiType values

### DIFF
--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -3428,8 +3428,20 @@ call_p = closed_call_p = eval_jaxpr_p
 
 
 # ------------------- Map -------------------
+@dataclass(frozen=True)
+class _StackedAxis:
+  """A mapped axis nested underneath one stacked leading axis."""
+  stack_size: AxisSize
+  axis: Any
 
 def mapped_aval(size: AxisSize, axis, aval: AbstractValue) -> AbstractValue:
+  if isinstance(axis, _StackedAxis):
+    # Strip the stacked leading axis, map the inner value, then put the
+    # stacked axis back.
+    aval = mapped_leading_aval(axis.stack_size, aval)
+    aval = mapped_aval(size, axis.axis, aval)
+    return unmapped_leading_aval(axis.stack_size, aval)
+
   from jax._src.hijax import HiType  # pyrefly: ignore[missing-import]
   if isinstance(aval, HiType):
     return aval.dec_rank(size, axis)  # pyrefly: ignore[bad-argument-type]
@@ -3443,8 +3455,15 @@ def mapped_leading_aval(size, aval) -> AbstractValue:
   return mapped_aval(size, aval.leading_axis_spec(), aval)
 
 # TODO(yashkatariya): take axis data
-def unmapped_aval(size: AxisSize, axis: int | None,
+def unmapped_aval(size: AxisSize, axis,
                   aval: AbstractValue, explicit_mesh_axis=None) -> AbstractValue:
+  if isinstance(axis, _StackedAxis):
+    # Inverse of the _StackedAxis case in mapped_aval.
+    aval = mapped_leading_aval(axis.stack_size, aval)
+    aval = unmapped_aval(
+        size, axis.axis, aval, explicit_mesh_axis)
+    return unmapped_leading_aval(axis.stack_size, aval)
+
   from jax._src.hijax import HiType  # pyrefly: ignore[missing-import]
   if isinstance(aval, HiType):
     return aval.inc_rank(size, axis)  # pyrefly: ignore[bad-argument-type]

--- a/jax/_src/interpreters/batching.py
+++ b/jax/_src/interpreters/batching.py
@@ -153,7 +153,8 @@ class BatchTracer(Tracer['BatchTrace']):
     elif type(batch_dim) is int:
       aval = core.mapped_aval(aval.shape[batch_dim], batch_dim, aval)
     elif isinstance(aval, hijax.HiType):
-      aval = aval.dec_rank(trace.axis_data.size, batch_dim)  # pyrefly: ignore[bad-argument-type]
+      aval = core.mapped_aval(
+        trace.axis_data.size, batch_dim, aval)  # pyrefly: ignore[bad-argument-type]
     else:
       raise Exception("batch dim should be int or `None`")
 
@@ -423,17 +424,25 @@ def _batch_jaxpr(closed_jaxpr, axis_data, in_batched, instantiate):
           all(isinstance(b, bool) for b in instantiate))
   if isinstance(instantiate, bool):
     instantiate = [instantiate] * len(closed_jaxpr.out_avals)
-  in_axes = [0 if b else None for b in in_batched]
-  out_axes_dest = [0 if inst else zero_if_mapped for inst in instantiate]
+  in_axes = [
+    aval.leading_axis_spec() if b else None
+    for aval, b in zip(closed_jaxpr.in_avals, in_batched)
+  ]
+  out_axes_dest = [
+    aval.leading_axis_spec() if inst else zero_if_mapped
+    for aval, inst in zip(closed_jaxpr.out_avals, instantiate)
+  ]
   return batch_jaxpr_axes(closed_jaxpr, axis_data, in_axes, out_axes_dest)
 
 def batch_jaxpr_axes(closed_jaxpr, axis_data, in_axes, out_axes_dest):
   return _batch_jaxpr_axes(closed_jaxpr, axis_data, tuple(in_axes), tuple(out_axes_dest))
 
 @weakref_lru_cache
-def _batch_jaxpr_axes(closed_jaxpr: core.Jaxpr,
-                      axis_data: AxisData,
-                      in_axes: Sequence[int], out_axes_dest: Sequence[int]):
+def _batch_jaxpr_axes(
+    closed_jaxpr: core.Jaxpr,
+    axis_data: AxisData,
+    in_axes: Sequence[MapSpec],
+    out_axes_dest: Sequence[MapSpec]):
   f = lu.wrap_init(core.jaxpr_as_fun(closed_jaxpr),
                    debug_info=closed_jaxpr.debug_info)
   f, out_axes = _batch_jaxpr_inner(f, axis_data)
@@ -717,12 +726,22 @@ def spmd_names_insert_pvary(*args):
 
 def matchaxis(axis_data, src, dst, x, sum_match=False):
   try:
-    _ = core.typeof(x)
+    aval = core.typeof(x)
   except TypeError as e:
-    raise TypeError(f"Output from batched function {x!r} with type "
-                    f"{type(x)} is not a valid JAX type") from e
+    raise TypeError(
+      f"Output from batched function {x!r} with type "
+      f"{type(x)} is not a valid JAX type") from e
+
+  if aval.is_high:
+    leading_axis_spec = aval.leading_axis_spec()
+    if type(src) is int and src == 0:
+      src = leading_axis_spec
+    if type(dst) is int and dst == 0:
+      dst = leading_axis_spec
+
   if src == dst or dst is infer:
     return x
+
   elif type(src) == type(dst) == int:
     return moveaxis(x, src, dst)
   elif src is None and type(dst) is int:

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1238,22 +1238,56 @@ def _scan_batching_rule(axis_data, args, dims, reverse, length, jaxpr,
 
   consts, init, xs = ft_in.update(args).unpack()
   consts_bdims, init_bdims, xs_bdims = ft_in.update(dims).unpack()
-  new_consts = [batching.moveaxis(x, d, 0) if d is not None and d != 0
-                else x for x, d in zip(consts, consts_bdims)]
-  new_init = [batching.broadcast(x, axis_data.size, 0, axis_data.explicit_mesh_axis)
-              if now_batched and not was_batched
-              else batching.moveaxis(x, d, 0) if now_batched else x
-              for x, d, was_batched, now_batched in
-              zip(init, init_bdims, init_batched, carry_batched)]
-  new_xs = [batching.moveaxis(x, d, 1) if d is not None and d != 1
-            else x for x, d in zip(xs, xs_bdims)]
+  # Helper functions
+  def move_to_leading_axis(x, d):
+    aval = core.typeof(x)
+    return batching.matchaxis(
+      axis_data, d, aval.leading_axis_spec(), x)
+
+  def move_to_scan_axis(x, d):
+    if isinstance(d, core._StackedAxis):
+      assert d.stack_size == length
+      return x
+    if d is not None and d != 1:
+      return batching.moveaxis(x, d, 1)
+    return x
+
+  new_consts = [
+    move_to_leading_axis(x, d) if d is not None
+    else x
+    for x, d in zip(consts, consts_bdims)
+  ]
+  new_init = [
+    batching.broadcast(
+      x, axis_data.size, 0, axis_data.explicit_mesh_axis)
+    if now_batched and not was_batched
+    else move_to_leading_axis(x, d) if now_batched else x
+    for x, d, was_batched, now_batched in
+    zip(init, init_bdims, init_batched, carry_batched)
+  ]
+  new_xs = [
+    move_to_scan_axis(x, d)
+    for x, d in zip(xs, xs_bdims)
+  ]
   new_args = new_consts + new_init + new_xs
 
   outs = scan_p.bind(
       *new_args, reverse=reverse, length=length, jaxpr=jaxpr_batched,
       ft_in=ft_in, ft_out=ft_out, unroll=unroll)
-  carry_bdims = [0 if b else None for b in carry_batched]
-  ys_bdims = [1 if b else None for b in ys_batched]
+  carry_avals, y_avals = ft_out.update(
+    jaxpr_batched.out_avals).unpack()
+
+  carry_bdims = [
+    aval.leading_axis_spec() if b else None
+    for aval, b in zip(carry_avals, carry_batched)
+  ]
+
+  ys_bdims = [
+    (core._StackedAxis(length, aval.leading_axis_spec())
+     if aval.is_high else 1)
+    if b else None
+    for aval, b in zip(y_avals, ys_batched)
+  ]
   return outs, carry_bdims + ys_bdims
 
 def _scan_dce_rule(used_outputs: list[bool], eqn: core.JaxprEqn

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -2166,6 +2166,129 @@ class HijaxTest(jtu.JaxTestCase):
     self.assertFalse(eqn.params['jaxpr'].is_high)
     self.assertEqual(eqn.params['out_spaces'], (jax.memory.Space.Device,))
 
+  def test_vmap_scan_hitype_carry(self):
+    @dataclass(frozen=True)
+    class BoxSpec(MappingSpec):
+      pass
+
+    @dataclass(frozen=True)
+    class Box:
+      a: jax.Array
+
+    @dataclass(frozen=True)
+    class BoxTy(HiType):
+      shape: tuple[int, ...]
+
+      def lo_ty(self):
+        return [ShapedArray(self.shape, jnp.dtype('float32'))]
+
+      def lower_val(self, b):
+        return [b.a]
+
+      def raise_val(self, a):
+        return Box(a)
+
+      def to_tangent_aval(self):
+        return ShapedArray(self.shape, jnp.dtype('float32'))
+
+      def dec_rank(self, size, spec):
+        assert isinstance(spec, BoxSpec)
+        assert self.shape[0] == size
+        return BoxTy(self.shape[1:])
+
+      def inc_rank(self, size, spec):
+        assert isinstance(spec, BoxSpec)
+        return BoxTy((size, *self.shape))
+
+      def leading_axis_spec(self):
+        return BoxSpec()
+
+      def str_short(self, short_dtypes=False, **_):
+        return f"box{list(self.shape)}"
+
+    register_hitype(Box, lambda b: BoxTy(b.a.shape))
+
+    class Wrap(HiPrim):
+      def __init__(self, aval):
+        self.in_avals = (aval,)
+        self.out_aval = BoxTy(aval.shape)
+        self.params = {}
+        super().__init__()
+
+      def expand(self, a):
+        return Box(a)
+
+      def jvp(self, primals, tangents):
+        (a,), (da,) = primals, tangents
+        return wrap(a), da
+
+      vjp_fwd, vjp_bwd_retval = vjp_from_jvp
+
+      def batch(self, _axis_data, args, dims):
+        (a,), (d,) = args, dims
+        if d is None:
+          return wrap(a), None
+        return wrap(jnp.moveaxis(a, d, 0)), BoxSpec()
+
+    class Unwrap(HiPrim):
+      def __init__(self, aval):
+        self.in_avals = (aval,)
+        self.out_aval = ShapedArray(aval.shape, jnp.dtype('float32'))
+        self.params = {}
+        super().__init__()
+
+      def expand(self, b):
+        return b.a
+
+      def jvp(self, primals, tangents):
+        (b,), (db,) = primals, tangents
+        return unwrap(b), db
+
+      vjp_fwd, vjp_bwd_retval = vjp_from_jvp
+
+      def batch(self, _axis_data, args, dims):
+        (b,), (d,) = args, dims
+        if d is None:
+          return unwrap(b), None
+        assert isinstance(d, BoxSpec)
+        return unwrap(b), 0
+
+    wrap = lambda a: Wrap(jax.typeof(a))(a)
+    unwrap = lambda b: Unwrap(jax.typeof(b))(b)
+
+    def f(k):
+      box = wrap(jnp.arange(3, dtype='float32') * k)
+      box, _ = jax.lax.scan(
+          lambda c, _: (wrap(unwrap(c) * 2.0), None),
+          box,
+          None,
+          length=2,
+      )
+      return jnp.sum(unwrap(box) ** 2)
+
+    ks = jnp.linspace(1.0, 2.0, 4, dtype='float32')
+
+    expected = jnp.stack([f(k) for k in ks])
+    self.assertAllClose(jax.vmap(f)(ks), expected)
+
+    def g(k):
+      box = wrap(jnp.arange(3, dtype='float32'))
+
+      def step(u, _):
+        inner = wrap(unwrap(box) + u)
+        return u + 0.1 * k * unwrap(inner), None
+
+      u, _ = jax.lax.scan(
+          step,
+          jnp.zeros(3, dtype='float32'),
+          None,
+          length=3,
+      )
+      return jnp.sum(u ** 2)
+
+    expected_grad = jnp.stack([jax.grad(g)(k) for k in ks])
+    self.assertAllClose(jax.vmap(jax.grad(g))(ks), expected_grad)
+
   def test_backward_pass_logging_call_primitives(self):
     from jax._src import api_util
     from jax._src import flattree as ft


### PR DESCRIPTION
Fixes #39727.

This fixes `vmap` over `lax.scan` when HiJAX values are involved, including a less obvious case where a HiType only shows up as a residual created by reverse-mode AD.

### What goes wrong

The scan batching rule was treating mapped axes as ordinary integer array axes. Which works for normal arrays, but HiTypes can define their own mapping semantics through `MappingSpec`.

For a HiType scan carry, this meant its custom mapping spec could get replaced by an integer axis.

There was a second issue with `vmap(grad(...))`: reverse-mode can save a HiType as a scan residual. Once `scan` stacks that residual, the outer `vmap` axis sits underneath the scan axis. Representing that as integer axis `1` is meaningful for arrays, but not for a HiType whose mapping is described by something like `BoxSpec()`.

### Changes

The batching path now preserves `aval.leading_axis_spec()` for HiTypes instead of assuming axis `0`.

For scan carries, the HiType's mapping spec is propagated directly.

For scan-stacked HiType outputs/residuals, this introduces an internal stacked-axis representation that keeps track of both:

* 1. the leading axis added by `scan`, and
* 2.  the underlying HiType `MappingSpec` used by `vmap`.

`mapped_aval` , `unmapped_aval` then temporarily peel off the scan axis, apply the HiType mapping operation, and restore the scan axis.

Ordinary arrays are unchanged: their `leading_axis_spec()` is still `0`, and scan outputs still use the integer batch dimension `1`.

### Tests

Also added regression coverage for both cases from the issue:

* 1. `vmap` over a scan whose carry is a HiType
* 2  .  `vmap(grad(...))` where reverse-mode creates a HiType scan residual

### Checks done and passed

```text
pytest tests/hijax_test.py \
  -k vmap_scan_hitype_carry \
  -vv
1 passed, 102 deselected
pytest -q tests/hijax_test.py
103 passed, 3 subtests passed
JAX_ENABLE_X64=True pytest -q tests/hijax_test.py
102 passed, 1 skipped, 3 subtests passed
pytest -q tests/api_test.py -k vmap
45 passed, 885 deselected in 1.29s
pre-commit run --all-files
```