### PR TITLE
Treat the device-to-host leg of an explicit cross-client device_put as explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * Fixed {func}`jax.numpy.intersect1d` and {func}`jax.numpy.setxor1d` with
     ``size=0``, which previously raised a ValueError; they now return empty
     arrays of the natural result dtype.
+  * Fixed a bug where an explicit {func}`jax.device_put` onto a device of
+    another client (e.g. from GPU onto a device of the CPU client) was
+    rejected under `jax.transfer_guard("disallow")` unless the array's value
+    was already cached on the host: the device-to-host leg of the
+    cross-client copy was misclassified as an implicit transfer
+    ({jax-issue}`#40285`).
 
 ## JAX 0.11.1 (August 17, 2026)
 

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -2002,12 +2002,18 @@ jax_xla_profile_version = int_state(
 def explicit_device_put_scope() -> Generator[None]:
   """Indicates that the current context is an explicit device_put*() call."""
   state = guard_lib.thread_local_state()
-  prev = state.explicit_device_put
+  prev_put = state.explicit_device_put
+  prev_get = state.explicit_device_get
+  # Explicitness is call-scoped: any transfer made while servicing an explicit
+  # device_put*() call is explicit. A cross-client device_put (e.g. GPU -> the
+  # CPU client) fetches the value to host first, so set the get flag too.
   state.explicit_device_put = True
+  state.explicit_device_get = True
   try:
     yield
   finally:
-    state.explicit_device_put = prev
+    state.explicit_device_put = prev_put
+    state.explicit_device_get = prev_get
 
 @contextlib.contextmanager
 def explicit_device_get_scope() -> Generator[None]:

--- a/tests/transfer_guard_test.py
+++ b/tests/transfer_guard_test.py
@@ -225,6 +225,47 @@ class TransferGuardTest(jtu.JaxTestCase):
           # will occur.
           func()
 
+  @parameterized.named_parameters(
+      ("device_to_host", jax.transfer_guard_device_to_host),
+      ("all", jax.transfer_guard),
+  )
+  def test_disallow_allows_explicit_cross_client_device_put(
+      self, jax_transfer_guard):
+    # Regression test for https://github.com/jax-ml/jax/issues/40285: the
+    # device-to-host fetch inside a cross-client device_put (e.g. GPU -> the
+    # CPU client) must count as part of the explicit transfer.
+    if jax.default_backend() == "cpu":
+      self.skipTest("Test requires a non-CPU backend and the CPU client.")
+    cpu_device = jax.devices("cpu")[0]
+    with jax.transfer_guard_host_to_device("allow"):
+      # Must stay cold: a cached host value would make the put incur no
+      # transfer.
+      x = jnp.arange(8, dtype=jnp.float32)
+    with jax_transfer_guard("disallow"):
+      with self.assertAllows("explicit cross-client device_put"):
+        y = jax.device_put(x, device=cpu_device)
+        y.block_until_ready()
+    self.assertEqual(list(y.devices()), [cpu_device])
+    self.assertArraysEqual(y, np.arange(8, dtype=np.float32))
+
+  @parameterized.named_parameters(
+      ("device_to_host", jax.transfer_guard_device_to_host),
+      ("all", jax.transfer_guard),
+  )
+  def test_disallow_explicit_rejects_cross_client_device_put(
+      self, jax_transfer_guard):
+    # "disallow_explicit" must keep rejecting the cross-client put. Only the
+    # device_to_host parameterization reaches the device-to-host leg; the
+    # blanket guard rejects at the device-to-device check first.
+    if jax.default_backend() == "cpu":
+      self.skipTest("Test requires a non-CPU backend and the CPU client.")
+    cpu_device = jax.devices("cpu")[0]
+    with jax.transfer_guard_host_to_device("allow"):
+      x = jnp.arange(8, dtype=jnp.float32)
+    with jax_transfer_guard("disallow_explicit"):
+      with self.assertRaisesRegex(Exception, "Disallowed"):
+        jax.device_put(x, device=cpu_device)
+
   @parameterized.named_parameters(*_COMMON_TEST_PARAMETERS)
   def test_log_explicit(self, func_generator, jax_transfer_guard):
     for func_name, _, func in func_generator():


### PR DESCRIPTION
Fixes #40285.

Under `jax.transfer_guard("disallow")`, an explicit `jax.device_put(x, device=cpu_device)` of a
GPU-backed array raised

```
jax.errors.JaxRuntimeError: INVALID_ARGUMENT: Disallowed device-to-host transfer: shape=(10), dtype=F32, device=cuda:0
```

unless the array's value happened to be cached on the host already (in which case the same call
succeeded, since no transfer occurs). The [transfer guard
docs](https://docs.jax.dev/en/latest/transfer_guard.html) define `"disallow"` as "Disallow
implicit transfers. Silently allow explicit transfers.", and `jax.device_put` is the canonical
explicit transfer, so the cold-path error is a bug.

The cause is a classification mismatch inside the put. A `device_put` whose source array and
target device live on different clients (e.g. CUDA → the CPU client) cannot be copied directly,
so `HandlePyArray` falls back to fetching the value to host via `_value` and re-uploading it.
The put itself is checked against the device-to-device guard, which honors the
`explicit_device_put` thread-local flag that `jax.device_put` sets — allowed. But the internal
device-to-host fetch is checked against the device-to-host guard, which only honors
`explicit_device_get` — and that flag is only set by `jax.device_get`. The same explicit call
was therefore allowed at the operation level and rejected in its implementation.

This change makes `explicit_device_put_scope()` set both flags, so any transfer leg performed in
service of an explicit `device_put`/`device_put_sharded`/`device_put_replicated` call counts as
explicit, whichever direction the implementation needs. Genuinely implicit device-to-host
transfers (`np.asarray`, `str`, `.item()`, printing, pickling) remain guarded, and the
`"disallow_explicit"`/`"log_explicit"` levels are unaffected — they ignore the explicit flags
entirely, so strict users still catch every transfer.

Tests: two new parameterized tests in `tests/transfer_guard_test.py` (each run for
`transfer_guard_device_to_host` and the blanket `transfer_guard`), exercising the cross-client
path with a cold array. They require a non-CPU backend plus the CPU client and skip on CPU-only
jobs. Without the fix, the `"disallow"`-allows-explicit tests fail with the error above; the
`"disallow_explicit"`-still-rejects tests pass before and after, pinning the conservative
behavior. Also verified against the issue's 16-case array/dataclass × direction × cold/warm
matrix on a CUDA machine: all cases pass with the fix, and the only pre-fix failures were the
two reported `gpu → cpu-device` cold cells.