### PR TITLE
[ROCm] Add Python 3.15 to the ROCm CI matrices

### DIFF
--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -28,6 +28,7 @@ on:
         - "3.12"
         - "3.13"
         - "3.14"
+        - "3.15"
       rocm-version:
         description: "Which ROCm version to build for?"
         type: string

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -502,7 +502,7 @@ jobs:
         matrix:
           runner: ["amd-do-linux.jax.cpu"]
           artifact: ["jax-rocm-plugin", "jax-rocm-pjrt"]
-          python: ["3.12", "3.13", "3.14"]
+          python: ["3.12", "3.13", "3.14", "3.15"]
           rocm: [
             {label: "TheRock 10.0.0", wheel-version: "10", release-version: "10.0.0", manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-10.0:latest" },
           ]
@@ -511,6 +511,8 @@ jobs:
               python: "3.13"
             - artifact: "jax-rocm-pjrt"
               python: "3.14"
+            - artifact: "jax-rocm-pjrt"
+              python: "3.15"
     name: "Build ROCm artifacts ${{ matrix.rocm.label }}"
     with:
       runner: ${{ matrix.runner }}

--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -189,7 +189,7 @@ jobs:
         matrix:
           runner: ["amd-do-linux.jax.cpu"]
           artifact: ["jax-rocm-plugin", "jax-rocm-pjrt"]
-          python: ["3.12", "3.13", "3.14"]
+          python: ["3.12", "3.13", "3.14", "3.15"]
           rocm: [
             {label: "TheRock 10.0.0", wheel-version: "10", release-version: "10.0.0", manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-10.0:latest" },
             {label: "TheRock Next (pre-release)", wheel-version: "10", release-version: "therock-latest", manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-latest:latest"},
@@ -199,6 +199,8 @@ jobs:
               python: "3.13"
             - artifact: "jax-rocm-pjrt"
               python: "3.14"
+            - artifact: "jax-rocm-pjrt"
+              python: "3.15"
     name: "Build ROCm artifacts ${{ matrix.rocm.label }}"
     with:
       runner: ${{ matrix.runner }}
@@ -223,7 +225,7 @@ jobs:
         fail-fast: false # don't cancel all jobs on failure
         matrix:
           runner: ["amd-do-linux.jax.gpu.gfx950.1", "amd-do-linux.jax.gpu.gfx950.4", "amd-do-linux.jax.gpu.gfx950.8"]
-          python: ["3.12", "3.13", "3.14"]
+          python: ["3.12", "3.13", "3.14", "3.15"]
           rocm: [
             {label: "TheRock 10.0.0", wheel-version: "10", release-version: "10.0.0", tag: "therock-10.0"},
             {label: "TheRock Next (pre-release)", wheel-version: "10", release-version: "therock-latest", tag: "therock-latest"},
@@ -251,7 +253,7 @@ jobs:
         fail-fast: false # don't cancel all jobs on failure
         matrix:
           runner: ["amd-do-linux.jax.gpu.gfx950.1"]
-          python: ["3.12", "3.13", "3.14"]
+          python: ["3.12", "3.13", "3.14", "3.15"]
           rocm: [
             {label: "TheRock 10.0.0", wheel-version: "10", release-version: "10.0.0", tag: "therock-10.0"},
             {label: "TheRock Next (pre-release)", wheel-version: "10", release-version: "therock-latest", tag: "therock-latest"},

--- a/build/rocm/tools/build_wheels.py
+++ b/build/rocm/tools/build_wheels.py
@@ -252,7 +252,7 @@ def parse_args():
     )
     p.add_argument(
         "--python-versions",
-        default=["3.12,3.13,3.14"],
+        default="3.12,3.13,3.14,3.15",
         help="Comma separated CPython versions that wheels will be built and output for",
     )
     p.add_argument(


### PR DESCRIPTION
Adds Python 3.15 coverage to the ROCm CI, matching how 3.13 and 3.14 are already handled.

- Build `jax-rocm-plugin` for 3.15 in `wheel_tests_continuous.yml` and `wheel_tests_nightly_release.yml`, and run the nightly ROCm pytest and Bazel legs against 3.15.
- Keep `jax-rocm-pjrt` excluded at 3.15, since it is built once against 3.12.
- Offer 3.15 in the `build_rocm_artifacts.yml` manual dispatch choices.
- Add 3.15 to the default version list in `build/rocm/tools/build_wheels.py`, used by `build/rocm/ci_build`. The default was a list rather than a comma-separated string, so it raised `AttributeError` on `.split(",")` whenever the flag was not passed explicitly; it is now a string.