### PR TITLE
[remat3] re-implement handling of checkpoint_name in custom_vjp fwd

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -985,18 +985,14 @@ def remat3(f=None, /, policy=None, static_argnums=(), static_argnames=(),
            prevent_cse=True):
   """Rematerialization decorator (new implementation, ``jax_remat3``).
 
-  Note on interaction with :func:`jax.custom_vjp`: when differentiating
-  rematted code, a custom_vjp application that appears *inside another
-  custom_vjp's fwd rule* is rematerialized as an opaque unit. For the
-  conventional idiom of a fwd rule calling its own custom_vjp-decorated
-  function to compute the primal output, that is exactly the intended
-  semantics. Values and gradients are unaffected at every order of
-  differentiation. The one observable consequence arises only under
-  higher-order AD: differentiating a second time runs the inner application's
-  own fwd rule (at first order it never runs, since the outer bwd rule
-  discharges the derivative), and values inside it (e.g.
-  ``checkpoint_name``-tagged intermediates) cannot be marked saveable by the
-  checkpoint ``policy`` there; they are always recomputed.
+  Note on interaction with :func:`jax.custom_vjp`: custom_vjp applications
+  are rematerialized as opaque units. Values and gradients are unaffected,
+  and a custom_vjp's fwd rule is re-run on the backward pass, but the
+  checkpoint ``policy`` does not reach inside custom_vjp rules: values there
+  (e.g. ``checkpoint_name``-tagged intermediates) cannot be marked saveable
+  by it. To control what gets saved inside custom-differentiated code, use
+  :func:`jax.experimental.custom_remat`, whose fwd rule receives the ambient
+  policy explicitly.
   """
   kwargs = dict(policy=policy, static_argnums=static_argnums,
                 static_argnames=static_argnames, prevent_cse=prevent_cse)
@@ -1052,22 +1048,22 @@ def _static_argnums(f, argnums, argnames) -> frozenset[int]:
   return frozenset(argnums)
 
 def dce(traced, policy):
-  in_fwd = pe._jaxpr_forwarding(traced.jaxpr)
-  jaxpr = pe.prune_jaxpr_outputs(traced.jaxpr, [f is None for f in in_fwd])
+  jaxpr_, attached = pe.separate_consts(traced.jaxpr)
+  in_fwd = pe._jaxpr_forwarding(jaxpr_)
+  jaxpr = pe.prune_jaxpr_outputs(jaxpr_, [f is None for f in in_fwd])
   for v in jaxpr.outvars:
     if isinstance(v.aval, AbstractRef):
       raise ValueError(
           "the rematted computation's closure contains a mutable array "
           f"reference of type {v.aval.str_short()} that is not one of the "
           "rematted function's inputs, but such refs cannot be saved")
-  # dce_jaxpr preserves attached consts (constvars are never pruned).
   jaxpr, used = pe.dce_jaxpr(jaxpr, True)
   keep = [u or i in {*in_fwd} for i, u in enumerate(used)]
   kept_idx = {i: p for p, i in enumerate(i for i, k in enumerate(keep) if k)}
   in_fwd = tuple(kept_idx[f] if f is not None else None for f in in_fwd)
   take = tuple(kept_idx[i] for i, u in enumerate(used) if u)
-  keep_res, keep_primals = split_list(keep, [traced._num_consts])
-  res = [r for r, u in zip(traced._consts, keep_res) if u]
+  keep_res, keep_primals = split_list(keep, [len(attached) + traced._num_consts])
+  res = [r for r, u in zip([*attached, *traced._consts], keep_res) if u]
   return keep_primals, Partial(
       partial(_dced, jaxpr, in_fwd, take, traced.out_tree, policy), res)
 
@@ -1107,8 +1103,7 @@ class RematTraced(HiPrim):
     # TODO eval_jaxpr_p trace time
     self._check_differentiable()
     traced = core.jaxpr_as_fun(self.jaxpr)
-    primals_out, fwd2 = remat_transform(self.policy, traced, *primals,
-                                        custom_vjp_rules=True)
+    primals_out, fwd2 = remat_transform(self.policy, traced, *primals)
     in_nzs = tuple(tree_leaves(nzs_in))
     out_nzs_cell = []
     def make_vjp(*xs):
@@ -1156,8 +1151,7 @@ class RematTraced(HiPrim):
   def lin(self, nzs_in, *primals):
     self._check_differentiable()
     traced = core.jaxpr_as_fun(self.jaxpr)
-    primals_out, fwd2 = remat_transform(self.policy, traced, *primals,
-                                        custom_vjp_rules=True)
+    primals_out, fwd2 = remat_transform(self.policy, traced, *primals)
     in_nzs = tuple(tree_leaves(nzs_in))
     out_nzs_cell = []
     def make_lin(*xs):
@@ -1189,12 +1183,11 @@ class RematTraced(HiPrim):
 
   def remat(self, trace, *args):  # pyrefly: ignore[bad-param-name-override]
     traced = core.jaxpr_as_fun(self.jaxpr)
-    out, rem_ = remat_transform(self.policy, traced, *args,
-                                custom_vjp_rules=trace.custom_vjp_rules)
+    out, rem_ = remat_transform(trace.policy, traced, *args)
     (jaxpr, in_tree, out_tree), (res,) = rem_.func.args, rem_.args
     def rem(*args_):
       args_flat = tree_leaves_checked(in_tree, args_)
-      out_flat = RematTraced(jaxpr, self.policy)(*res, *args_flat)
+      out_flat = RematTraced(jaxpr, trace.policy)(*res, *args_flat)
       return tree_unflatten(out_tree, out_flat)
     return out, rem
 
@@ -1227,26 +1220,19 @@ class CheckpointName(HiPrim):
   def remat(self, trace, x):  # pyrefly: ignore[bad-override]
     policy = trace.policy
     x = CheckpointName(self.name, self.in_avals[0])(x)
-    if isinstance(policy, (SaveOnlyTheseNames, SaveAnyNamesButThese)):
-      saveable = (self.name not in policy.names if isinstance(policy, SaveAnyNamesButThese)
-                  else self.name in policy.saveable_names)
-      rem = partial(primal_left_tangent_right, x) if saveable else lambda x: x
-      return x, rem
-    elif isinstance(policy, SaveAndOffloadOnlyTheseNames):
-      if self.name in policy.names_which_can_be_saved:
-        return x, partial(primal_left_tangent_right, x)
-      elif self.name in policy.names_which_can_be_offloaded:
-        x_host = api.device_put(x, core.mem_kind_to_space(policy.offload_dst),
-                                may_alias=False)
-        src_space = core.mem_kind_to_space(policy.offload_src)
-        def rem(x_rem):
-          x_dev = api.device_put(x_host, src_space, may_alias=False)
-          return primal_left_tangent_right(x_dev, x_rem)
-        return x, rem
-      else:
-        return x, lambda x: x  # full remat
-    elif policy is everything_saveable:
+    if policy is None:
+      return x, lambda x: x  # full remat
+    case = pe.ensure_enum(policy(name_p, name=self.name))
+    if isinstance(case, pe.SaveableType):
       return x, partial(primal_left_tangent_right, x)
+    elif isinstance(case, pe.Offloadable):
+      x_host = api.device_put(x, core.mem_kind_to_space(case.dst),
+                              may_alias=False)
+      src_space = core.mem_kind_to_space(case.src)
+      def rem(x_rem):
+        x_dev = api.device_put(x_host, src_space, may_alias=False)
+        return primal_left_tangent_right(x_dev, x_rem)
+      return x, rem
     else:
       return x, lambda x: x  # full remat
 
@@ -1280,13 +1266,13 @@ class PrimalLeftTangentRight(HiPrim):
     return x
 
   def lin(self, nzs_in, x, _x):  # type: ignore
-    return x, None
+    return x, None, nzs_in[1]
 
   def linearized(self, _, xdot, _xdot):  # type: ignore
     return _xdot
 
   def vjp_fwd(self, nzs_in, x, _x):  # type: ignore
-    return x, None
+    return x, None, nzs_in[1]
 
   def vjp_bwd_retval(self, _, g):
     return None, g

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -38,6 +38,7 @@ from jax._src.interpreters import batching
 from jax._src.interpreters import mlir
 from jax._src.interpreters import partial_eval as pe
 from jax._src.interpreters.remat import remat_transform
+from jax._src import hijax
 from jax._src.hijax import HiPrim, call_hi_primitive_p, Static
 from jax._src.lax import lax as lax_internal
 from jax._src.lax import convolution as lax_convolution
@@ -985,14 +986,17 @@ def remat3(f=None, /, policy=None, static_argnums=(), static_argnames=(),
            prevent_cse=True):
   """Rematerialization decorator (new implementation, ``jax_remat3``).
 
-  Note on interaction with :func:`jax.custom_vjp`: custom_vjp applications
-  are rematerialized as opaque units. Values and gradients are unaffected,
-  and a custom_vjp's fwd rule is re-run on the backward pass, but the
-  checkpoint ``policy`` does not reach inside custom_vjp rules: values there
-  (e.g. ``checkpoint_name``-tagged intermediates) cannot be marked saveable
-  by it. To control what gets saved inside custom-differentiated code, use
-  :func:`jax.experimental.custom_remat`, whose fwd rule receives the ambient
-  policy explicitly.
+  Note on interaction with :func:`jax.custom_vjp`: values marked with
+  :func:`checkpoint_name` inside a custom_vjp fwd rule can be made saveable
+  by the checkpoint ``policy``. Without a policy, custom_vjp applications
+  are rematerialized as opaque units: the fwd rule contributes nothing to
+  the forward pass and is re-run on the backward pass. Values and gradients
+  are unaffected either way. Policy-driven saving inside fwd rules is not
+  supported for custom_vjps defined with ``symbolic_zeros`` or
+  ``defvjp_with_logs`` (an error is raised if the policy matches a name in
+  such a fwd rule); for explicit control over saving inside
+  custom-differentiated code, see :func:`jax.experimental.custom_remat`,
+  whose fwd rule receives the ambient policy explicitly.
   """
   kwargs = dict(policy=policy, static_argnums=static_argnums,
                 static_argnames=static_argnames, prevent_cse=prevent_cse)
@@ -1285,6 +1289,16 @@ class PrimalLeftTangentRight(HiPrim):
 
 def primal_left_tangent_right(x, _x):
   return PrimalLeftTangentRight(typeof(x), typeof(_x))(x, _x)
+
+def fwd_rule_saveable(policy):
+  if policy is None or policy is nothing_saveable:
+    return None
+  def saveable(prim, *_, **params):
+    return (prim is call_hi_primitive_p and
+            isinstance(p := params.get('_prim'), CheckpointName) and
+            policy(name_p, name=p.name))
+  return saveable
+hijax.custom_vjp_saveable_from_policy = fwd_rule_saveable
 
 
 def custom_remat(f, f_fwd, f_rem, f_bwd, *, static_argnums=(),

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -687,6 +687,8 @@ vjp_from_jvp = _VJPFromJVP(_vjp_fwd_from_jvp, _transpose_jvp)
 vjp_from_lin = _VJPFromLin(_vjp_fwd_from_lin, _transpose_linearized)
 
 
+custom_vjp_saveable_from_policy = lambda policy: None  # set by ad_checkpoint
+
 class CustomVJPTraced(HiPrim):
   traced: Any
   fwd: Any
@@ -815,6 +817,60 @@ class CustomVJPTraced(HiPrim):
     in_dims_flat = self.in_tree.flatten_up_to(in_dims)
     _, out_dims = batching.batch_jaxpr2(self.traced.jaxpr, axis_data, tuple(in_dims_flat))
     return tree_unflatten(self.out_tree, out_dims)
+
+  def remat(self, trace, *args):  # pyrefly: ignore[bad-param-name-override]
+    saveable = custom_vjp_saveable_from_policy(trace.policy)
+    if saveable is None:
+      return self(*args), self
+    args_flat = tree_leaves_checked(self.in_tree, args)
+    def fwd_flat(*leaves):
+      args_ = tree_unflatten(self.in_tree, leaves)
+      if self.symbolic_zeros:
+        args_ = tree_map(lambda x: CustomVJPPrimal(x, True), args_)
+      out, res = self.fwd(*(x.val if isinstance(x, Static) else x for x in args_))
+      if self.symbolic_zeros:
+        out = tree_map(lambda p: p.value if isinstance(p, CustomVJPPrimal) else p, out)
+      return out, res
+    fc, fwd_traced = api.jit(fwd_flat).trace(*args_flat).with_consts_as_arg()
+    jaxpr = fwd_traced.jaxpr
+    known, staged, _, _, num_res = pe.partial_eval_jaxpr_custom(
+        jaxpr, (False,) * len(jaxpr.invars), True, True, True, saveable)
+    if not num_res:
+      return self(*args), self
+    if self.symbolic_zeros or self.with_logs:
+      feature = 'symbolic_zeros' if self.symbolic_zeros else 'defvjp_with_logs'
+      raise NotImplementedError(
+          "under jax.remat, a checkpoint policy matched values marked with "
+          "checkpoint_name inside a custom_vjp fwd rule, but the custom_vjp "
+          f"was defined with {feature}, which does not support policy-driven "
+          "saving of fwd rule values; adjust the policy or the names so that "
+          f"nothing in this fwd rule is saveable, avoid {feature}, or use "
+          "jax.experimental.custom_remat to control saving explicitly")
+    known, _ = pe.dce_jaxpr(known, True, instantiate=True)
+    fc_flat, _ = tracing_registry.flatten(fc)
+    saved = core.eval_jaxpr(known, known.consts, *fc_flat, *args_flat)
+    which_static = [isinstance(x, Static) for x in self.in_avals]
+    statics = [x for x in self.in_avals if isinstance(x, Static)]
+    merge = lambda dyn: tuple(merge_lists(which_static, list(dyn), statics))
+
+    def helper_fun(_, __, *dyn):
+      return self.expand(*merge(dyn))
+    def helper_fwd(fc_, cs_, *dyn):
+      fc_flat_, _ = tracing_registry.flatten(fc_)
+      leaves = tree_leaves_checked(self.in_tree, merge(dyn))
+      out_res_flat = core.eval_jaxpr(staged, staged.consts, *cs_, *fc_flat_,
+                                     *leaves)
+      return tree_unflatten(fwd_traced.out_tree, out_res_flat)
+    static_vals = tuple(x.val for x in statics)
+    def helper_bwd(res, ct):
+      return (None, None, None, *self.bwd(*static_vals, res, ct))
+    helper = custom_vjp3(helper_fun)
+    helper.defvjp(helper_fwd, helper_bwd)
+
+    def rem(*args2):
+      dyn2 = tuple(x for x in args2 if not isinstance(x, Static))
+      return helper(fc, tuple(saved), *dyn2)
+    return self(*args), rem
 
   def check(self, *_):
     effs = self.traced.jaxpr.effects

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -432,6 +432,8 @@ def _call_hi_primitive_linearize(is_vjp, nz_in_flat, *args_flat, _prim):
 ad.primitive_linearizations[call_hi_primitive_p] = _call_hi_primitive_linearize
 
 def fake_linear_op(prim, nz_in_flat, nz_out_flat, rs, sres, *tangents):
+  if not any(nz_out_flat):
+    return [ad_util.Zero(a.to_tangent_aval()) for a in prim.out_avals_flat]
   rs = rs if sres is None else (rs, sres)  # unpacked in the transpose rule
   residuals_flat, residuals_tree = tree_flatten(rs)
   assert nz_in_flat == [not isinstance(t, ad_util.Zero) for t in tangents]
@@ -686,20 +688,6 @@ vjp_from_lin = _VJPFromLin(_vjp_fwd_from_lin, _transpose_linearized)
 
 
 class CustomVJPTraced(HiPrim):
-  """Applications take ``(consts, fwd_consts, *args)``.
-
-  The two leading arguments are synthetic, and both get zero cotangents:
-  ``consts`` is the primal function's closure environment promoted to an
-  argument (see ``Traced.with_consts_as_arg``), and ``fwd_consts`` is extra
-  inputs consumed only by the fwd rule and ignored by the primal (ordinarily
-  ``()``; the ``remat`` rule uses it to pass replay residuals to the helper
-  primitive it builds). Any value a rule needs beyond the primal arguments
-  must arrive through these slots as an explicit input, never by closure: the
-  rules are re-invoked by transformations after the trace of application time
-  is gone, so closed-over tracers go stale. The primal ``traced`` takes
-  ``(consts, *args)``; ``drop_fwd_consts`` maps the application signature
-  onto it.
-  """
   traced: Any
   fwd: Any
   bwd: Any
@@ -707,11 +695,6 @@ class CustomVJPTraced(HiPrim):
   static_argnums: Any
   opt_remat: bool
   with_logs: bool
-
-  @staticmethod
-  def drop_fwd_consts(consts, fwd_consts, *args):
-    del fwd_consts
-    return (consts, *args)
 
   def __init__(self, traced, fwd, bwd, in_avals, sym_zeros, static_argnums,
                opt_remat, with_logs=False):
@@ -725,8 +708,8 @@ class CustomVJPTraced(HiPrim):
     super().__init__()
 
   def expand(self, *args):
-    args = self.drop_fwd_consts(*args)
-    return self.traced(*[x for x in args if not isinstance(x, Static)])
+    args = [x for x in args if not isinstance(x, Static)]
+    return self.traced(*args)
 
   def lin(self, nzs_in, *primals):
     out, res, *rest = self.vjp_fwd(nzs_in, *primals)
@@ -796,7 +779,7 @@ class CustomVJPTraced(HiPrim):
     if not isinstance(in_cts, tuple):
       raise TypeError(f"Custom VJP bwd rule {self.bwd} must produce a tuple "
                       f"but got {type(in_cts)}.")
-    in_cts = (None, None, *in_cts)  # zero cts for the consts and fwd_consts args
+    in_cts = (None, *in_cts)  # zero cotangent for the promoted-consts argument
     if len(in_cts) != len(self.in_tree.children()) - len(self.static_argnums):
       raise ValueError(f"Custom VJP bwd rule {self.bwd} must produce a tuple "
                        "of length equal to the primal args tuple, but got "
@@ -804,7 +787,7 @@ class CustomVJPTraced(HiPrim):
     in_cts = broadcast_prefix(in_cts, in_avals_, is_leaf=lambda x: x is None)
     in_cts = tree_unflatten(self.in_tree, map(_replace_none, self.in_avals_flat, in_cts))
     tree_map_with_path(partial(_vjp_bwd_aval_mismatch_err, self.traced._fun_sourceinfo),
-                               self.in_avals[2:], in_cts[2:])
+                               self.in_avals[1:], in_cts[1:])
     if self.symbolic_zeros:
       in_cts = tree_map(ad_util.replace_rule_output_symbolic_zeros, in_cts)
     return (in_cts, logs) if self.with_logs else in_cts
@@ -829,8 +812,7 @@ class CustomVJPTraced(HiPrim):
     return primals_out, tangents_out
 
   def batch_dim_rule(self, axis_data, in_dims):
-    _, primal_in_tree = tracing_registry.flatten(self.drop_fwd_consts(*self.in_avals))
-    in_dims_flat = primal_in_tree.flatten_up_to(self.drop_fwd_consts(*in_dims))
+    in_dims_flat = self.in_tree.flatten_up_to(in_dims)
     _, out_dims = batching.batch_jaxpr2(self.traced.jaxpr, axis_data, tuple(in_dims_flat))
     return tree_unflatten(self.out_tree, out_dims)
 
@@ -839,35 +821,6 @@ class CustomVJPTraced(HiPrim):
     disallowed = effects.custom_derivatives_allowed_effects.filter_not_in(effs)
     if disallowed:
       raise NotImplementedError(f'Effects not supported in `custom_jvp`: {disallowed}')
-
-  def remat(self, trace, *args):  # type: ignore
-    if self.opt_remat:
-      return self(*args), self
-    if not trace.custom_vjp_rules:
-      return self(*args), self  # see https://github.com/jax-ml/jax/pull/38914
-    if not self.static_argnums:
-      fwd, dyn_args = self.fwd, args
-    else:
-      which_static = [i in self.static_argnums for i in range(len(args))]
-      dyn_args, static_args = partition_list(which_static, args)
-      static_args = [x.val for x in static_args]
-      fwd = lambda *dyn_args: self.fwd(*merge_lists(which_static, list(dyn_args), static_args))
-    # custom_vjp_rules=False so that custom_vjp applications inside fwd hit
-    # the early return above rather than recursively tracing their fwds.
-    (out, _), rem_ = remat.remat_transform(trace.policy, fwd, *dyn_args,
-                                           custom_vjp_rules=False)
-    res = tuple(rem_.args[0])
-    replay, statics = rem_.func, self.static_argnums
-    def fwd2(consts, fc_res, *rest):
-      fc, res = fc_res
-      args_ = (consts, fc, *rest)
-      return replay(res, *[x for i, x in enumerate(args_) if i not in statics])
-    in_avals = (self.in_avals[0],
-                (self.in_avals[1], tuple(map(typeof, res))),
-                *self.in_avals[2:])
-    helper = CustomVJPTraced(self.traced, fwd2, self.bwd, in_avals,
-                             False, self.static_argnums, False, self.with_logs)
-    return out, lambda consts, fc, *rest: helper(consts, (fc, res), *rest)
 
 
 def _vjp_primal_fwd_tree_mismatch_err(self, tree):
@@ -960,12 +913,12 @@ class custom_vjp3:
       traced = api.jit(f).trace(*dyn_args)
     args = tuple(Static(x) if i in self.static_argnums else x for i, x in enumerate(args))
     consts, traced = traced.with_consts_as_arg()
-    fwd_ = update_wrapper(lambda _, __, *args: self.fwd(*args), self.fwd)
-    static_argnums = frozenset(i + 2 for i in self.static_argnums)
-    in_avals = tree_map(typeof, (consts, (), *args))
+    fwd_ = update_wrapper(lambda _, *args: self.fwd(*args), self.fwd)
+    static_argnums = frozenset(i + 1 for i in self.static_argnums)
+    in_avals = tree_map(typeof, (consts, *args))
     prim = CustomVJPTraced(traced, fwd_, self.bwd, in_avals, self.symz,
                            static_argnums, self.opt_remat, self.with_logs)
-    return prim(consts, (), *args)
+    return prim(consts, *args)
 
   def def_vmap(self, rule, /): return self.f.def_vmap(rule)
   def def_transpose(self, rule, /): return self.f.def_transpose(rule)

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -710,6 +710,7 @@ class LinearizeTrace(Trace):
     tangent_nzs = [type(t) is not Zero for t in tangents_in]
     if (all(type(t) is Zero for t in tangents_in) and
         primitive is not core.ref_p and primitive is not core.empty_ref_p and
+        type(params.get('_prim')).__name__ != 'PrimalLeftTangentRight' and
         not any(isinstance(typeof(x), AbstractRef) for x in primals_in)):
       avals = tuple(core.typeof(x) for x in primals_in)
       return primitive.bind_with_trace(self.parent_trace, primals_in, avals, params)

--- a/jax/_src/interpreters/remat.py
+++ b/jax/_src/interpreters/remat.py
@@ -36,12 +36,12 @@ zip = safe_zip
 #  [ ] allow NotAvailable sentinels
 #  [ ] primal-output-to-residual forwarding
 
-def remat_transform(policy, f, *args, custom_vjp_rules):
+def remat_transform(policy, f, *args):
   dbg = api_util.debug_info("remat", f, args, {})
   with core.take_current_trace() as parent_trace:
     jaxpr_trace = pe.DynamicJaxprTrace(None)
     jaxpr_trace.tag = core.TraceTag()
-    trace = RematTrace(parent_trace, jaxpr_trace, policy, custom_vjp_rules)
+    trace = RematTrace(parent_trace, jaxpr_trace, policy)
     args_ft, _ = ft.flatten_args(*args).unpack()
     in_tracers = args_ft.map(
         lambda x: RematTracer(trace, x, jaxpr_trace.new_arg(typeof(x), None)))  # type: ignore # noqa F821
@@ -75,14 +75,12 @@ class RematTracer(core.Tracer['RematTrace']):
     self.tracer = jaxpr_tracer
 
 class RematTrace(core.Trace):
-  def __init__(self, parent_trace, jaxpr_trace, policy, custom_vjp_rules):
+  def __init__(self, parent_trace, jaxpr_trace, policy):
     super().__init__()
     self.parent_trace = parent_trace
     self.jaxpr_trace = jaxpr_trace
     self.policy = policy
     self.requires_low = False
-    # flag to handle checkpoint_name calls in custom_vjp fwd w/o inf recursion
-    self.custom_vjp_rules = custom_vjp_rules
 
   tag = property(lambda self: self.jaxpr_trace.tag)
 
@@ -135,12 +133,12 @@ class RematTrace(core.Trace):
     return map(partial(RematTracer, self), out_primal, out_primal2)
 
 def remat_subtrace(f: Callable, tag: core.TraceTag, policy,
-                   debug_info: core.DebugInfo, args, custom_vjp_rules):
+                   debug_info: core.DebugInfo, args):
   source_info = source_info_util.current()
   with core.take_current_trace() as parent_trace:
     rem_trace = pe.DynamicJaxprTrace(debug_info, auto_dce=True)
     rem_trace.tag = tag
-    trace = RematTrace(parent_trace, rem_trace, policy, custom_vjp_rules)
+    trace = RematTrace(parent_trace, rem_trace, policy)
     tracers = [RematTracer(trace, x, rem_trace.new_arg(typeof(x), source_info))
                for x in args]
     with core.set_current_trace(trace, check_leaks=True):
@@ -174,21 +172,21 @@ reduce_precision_handlers: dict[type, Callable] = {}
 
 
 def remat_jaxpr(
-    jaxpr, policy, custom_vjp_rules, allow_fwds
+    jaxpr, policy, allow_fwds
 ) -> tuple[core.Jaxpr, core.Jaxpr, list[int | None]]:
   n = len(jaxpr.outvars)
   if type(allow_fwds) is bool:
     allow_fwds = (allow_fwds,) * n
   assert len(allow_fwds) == n
-  return _remat_jaxpr(jaxpr, policy, custom_vjp_rules, tuple(allow_fwds))
+  return _remat_jaxpr(jaxpr, policy, tuple(allow_fwds))
 
 @weakref_lru_cache
-def _remat_jaxpr(jaxpr, policy, custom_vjp_rules, allow_fwds):
+def _remat_jaxpr(jaxpr, policy, allow_fwds):
   dbg = jaxpr.debug_info
   fwd_trace = pe.DynamicJaxprTrace(dbg)
   rem_trace = pe.DynamicJaxprTrace(dbg, auto_dce=True)
   rem_trace.tag = core.TraceTag()
-  trace = RematTrace(fwd_trace, rem_trace, policy, custom_vjp_rules)
+  trace = RematTrace(fwd_trace, rem_trace, policy)
   src = source_info_util.current()
 
   def new_arg(a):

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -997,7 +997,7 @@ def _cond_remat(trace, *args, branches, **params):
     # TODO(mattjj): allow forwarding (requires per-branch wiring to survive
     # the cross-branch residual merging below).
     jaxpr_fwd, jaxpr_rem, fwds = remat.remat_jaxpr(
-      jaxpr, trace.policy, trace.custom_vjp_rules, allow_fwds=False)
+      jaxpr, trace.policy, allow_fwds=False)
     num_res = len(fwds)
     branches_fwd.append(jaxpr_fwd)
     branches_rem.append(jaxpr_rem)

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -1533,7 +1533,7 @@ def _scan_remat(trace, *args, jaxpr, ft_in, ft_out, **params):
   # TODO(mattjj): allow forwarding for ys outputs; carry outputs can't be
   # forwarded since residuals ride in the stacked ys position.
   jaxpr_fwd, jaxpr_rem_, fwds = remat.remat_jaxpr(
-      jaxpr, trace.policy, trace.custom_vjp_rules, allow_fwds=False)
+      jaxpr, trace.policy, allow_fwds=False)
   # Residuals ride along as extra ys (fwd scan) / extra xs (remnant scan).
   res_g = ft.nones(len(fwds))
   carry_out_g, ys_g = ft_out.unpack()

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1648,7 +1648,7 @@ ad.primitive_linearizations[jit_p] = _pjit_linearize
 
 def _pjit_remat(trace, *args, jaxpr, **params):
   jaxpr_fwd, jaxpr_rem, fwds = remat.remat_jaxpr(
-      jaxpr, trace.policy, trace.custom_vjp_rules, allow_fwds=True)
+      jaxpr, trace.policy, allow_fwds=True)
   num_res_out = sum(f is None for f in fwds)
   params_fwd, params_rem = _add_res_to_params(num_res_out, len(fwds), **params)
   primals_res_out = jit_p.bind(*args, jaxpr=jaxpr_fwd, **params_fwd)

--- a/jax/_src/shard_map.py
+++ b/jax/_src/shard_map.py
@@ -1852,8 +1852,7 @@ def _shard_map_remat(trace, shard_map_p, f, tracers, mesh, in_specs, check_vma,
 
   def f_fwd(*in_vals):
     res, ans_aux, rem_data = remat.remat_subtrace(
-        f, trace.tag, trace.policy, debug_info, in_vals,
-        custom_vjp_rules=trace.custom_vjp_rules)
+        f, trace.tag, trace.policy, debug_info, in_vals)
     primals_out, out_specs = ans_aux.unpack_aux()
 
     res_avals, _, _, in_fwd, out_fwd = rem_data

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -8366,10 +8366,9 @@ class Remat3Test(RematTest):
     with assertEvals(3):
       vjp(v)
 
-  @unittest.skip("custom_vjp applications are opaque to remat3 policies; "
-                 "use custom_remat for policy-controlled saving")
   @config.custom_vjp3(True)
   def test_custom_vjp_with_checkpoint_name_in_fwd(self):
+    assert jax.config.jax_custom_vjp3
     sin = jax.custom_vjp(jnp.sin)
     def fwd(x):
       return jnp.sin(x), checkpoint_name(jnp.cos(x), 'cos')
@@ -8394,6 +8393,12 @@ class Remat3Test(RematTest):
     fwd_str, bwd_str = fwd_bwd_jaxpr_strs(f, jnp.arange(3.))
     self.assertIn('cos ', fwd_str)
     self.assertNotIn('cos ', bwd_str)
+    jtu.check_grads(f, (3.,), order=2, modes=['rev'])
+
+    f = jax.remat(sin)
+    fwd_str, bwd_str = fwd_bwd_jaxpr_strs(f, jnp.arange(3.))
+    self.assertNotIn('cos', fwd_str)
+    self.assertIn('cos ', bwd_str)
     jtu.check_grads(f, (3.,), order=2, modes=['rev'])
 
   @config.custom_vjp3(True)
@@ -8437,10 +8442,10 @@ class Remat3Test(RematTest):
     self.assertIn('cos ', bwd_str)
     jtu.check_grads(f, (3.,), order=2, modes=['rev'])
 
-  @unittest.skip("custom_vjp applications are opaque to remat3 policies; "
-                 "use custom_remat for policy-controlled saving")
   @config.custom_vjp3(True)
   def test_custom_vjp_with_checkpoint_name_in_fwd_static_argnums(self):
+    # Like the above test, but exercises nondiff_argnums
+    assert jax.config.jax_custom_vjp3
     sin = jax.custom_vjp(lambda _, x: jnp.sin(x), nondiff_argnums=(0,))
     def fwd(_, x):
       return jnp.sin(x), checkpoint_name(jnp.cos(x), 'cos')
@@ -8448,12 +8453,29 @@ class Remat3Test(RematTest):
       return cos_x * g,
     sin.defvjp(fwd, bwd)
 
+    def fwd_bwd_jaxpr_strs(f, *args):
+      fwd_jaxpr = jax.jit(partial(jax.vjp, f)).trace(*args).lojax.jaxpr
+      fwd_jaxpr, _ = pe.dce_jaxpr(fwd_jaxpr, True)
+      fwd_str = fwd_jaxpr.pretty_print(use_color=False)
+
+      y, f_vjp = jax.vjp(f, *args)
+      bwd_jaxpr = jax.jit(f_vjp).trace(y).lojax.jaxpr
+      bwd_jaxpr, _ = pe.dce_jaxpr(bwd_jaxpr, True)
+      bwd_str = bwd_jaxpr.pretty_print(use_color=False)
+
+      return fwd_str, bwd_str
+
     policy = jax.checkpoint_policies.save_only_these_names('cos')
     f = jax.remat(partial(sin, 'hi'), policy=policy)
-    y, f_vjp = jax.vjp(f, jnp.arange(3.))
-    bwd_jaxpr = jax.jit(f_vjp).trace(y).lojax.jaxpr
-    bwd_jaxpr, _ = pe.dce_jaxpr(bwd_jaxpr, True)
-    self.assertNotIn('cos ', bwd_jaxpr.pretty_print(use_color=False))
+    fwd_str, bwd_str = fwd_bwd_jaxpr_strs(f, jnp.arange(3.))
+    self.assertIn('cos ', fwd_str)
+    self.assertNotIn('cos ', bwd_str)
+    jtu.check_grads(f, (3.,), order=2, modes=['rev'])
+
+    f = jax.remat(partial(sin, 'hi'))
+    fwd_str, bwd_str = fwd_bwd_jaxpr_strs(f, jnp.arange(3.))
+    self.assertNotIn('cos', fwd_str)
+    self.assertIn('cos ', bwd_str)
     jtu.check_grads(f, (3.,), order=2, modes=['rev'])
 
   @config.custom_vjp3(True)
@@ -8469,8 +8491,61 @@ class Remat3Test(RematTest):
     f = jax.remat(partial(sin, 'hi'), policy=policy)
     jtu.check_grads(f, (3.,), order=2, modes=['rev'])
 
-  @unittest.skip("custom_vjp applications are opaque to remat3 policies; "
-                 "use custom_remat for policy-controlled saving")
+  @config.custom_vjp3(True)
+  def test_custom_vjp_offload_names_in_fwd_jaxpr(self):
+    # Jaxpr-level check like test_remat_offload_names_jaxpr, but with the
+    # named values inside a custom_vjp fwd rule: the offloaded residual is
+    # device_put to the offload destination on the fwd pass and saved there,
+    # then device_put back on the bwd pass.
+    policy = jax.checkpoint_policies.save_and_offload_only_these_names(
+        names_which_can_be_saved=['cos'], names_which_can_be_offloaded=['sin2'],
+        offload_src='device', offload_dst='pinned_host')
+
+    sin = jax.custom_vjp(jnp.sin)
+    def fwd(x):
+      return jnp.sin(x), (checkpoint_name(jnp.cos(x), 'cos'),
+                          checkpoint_name(jnp.sin(x * 2), 'sin2'))
+    def bwd(res, g):
+      cos_x, sin_2x = res
+      return (cos_x + 0 * sin_2x) * g,
+    sin.defvjp(fwd, bwd)
+
+    f = jax.remat(sin, policy=policy)
+    jaxpr_text = str(api.make_jaxpr(api.grad(lambda x: f(x).sum()))(jnp.arange(16.)))
+    self.assertEqual(jaxpr_text.count('MemorySpace.Host'), 1)
+    self.assertEqual(jaxpr_text.count('MemorySpace.Device'), 1)
+
+  @config.custom_vjp3(True)
+  def test_custom_vjp_remat_policy_symbolic_zeros_error(self):
+    # Policy-driven saving inside fwd rules is unsupported for symbolic_zeros
+    # and defvjp_with_logs: raise rather than silently not saving, but only
+    # when the policy actually matches a name in the fwd rule.
+    policy = jax.checkpoint_policies.save_only_these_names('cos')
+    def bwd(c, g):
+      return c * g,
+
+    sin = jax.custom_vjp(jnp.sin)
+    def fwd(x):
+      return jnp.sin(x.value), checkpoint_name(jnp.cos(x.value), 'cos')
+    sin.defvjp(fwd, bwd, symbolic_zeros=True)
+    with self.assertRaisesRegex(NotImplementedError, 'symbolic_zeros'):
+      jax.vjp(jax.remat(sin, policy=policy), jnp.arange(3.))
+
+    sin2 = jax.custom_vjp(jnp.sin)
+    def fwd2(x):
+      return jnp.sin(x.value), jnp.cos(x.value)
+    sin2.defvjp(fwd2, bwd, symbolic_zeros=True)
+    jtu.check_grads(jax.remat(sin2, policy=policy), (3.,), order=2, modes=['rev'])
+
+    sin3 = jax.custom_vjp(jnp.sin)
+    def fwd3(x):
+      return jnp.sin(x), checkpoint_name(jnp.cos(x), 'cos')
+    def bwd3(c, g):
+      return (c * g,), None
+    sin3.defvjp_with_logs(fwd3, bwd3)
+    with self.assertRaisesRegex(NotImplementedError, 'defvjp_with_logs'):
+      jax.vjp(jax.remat(sin3, policy=policy), jnp.arange(3.))
+
   @config.custom_vjp3(True)
   def test_custom_vjp_saved_residual_is_vjp_pytree_leaf(self):
     sin = jax.custom_vjp(jnp.sin)
@@ -8578,6 +8653,102 @@ class Remat3Test(RematTest):
         jax.remat(jax.remat(sin), policy=policy)))
     self.assertTrue(bwd_recomputes_cos(
         jax.remat(jax.remat(sin, policy=policy))))
+
+  @config.custom_vjp3(True)
+  def test_custom_vjp_layered_outermost_policy_wins(self):
+    sin = jax.custom_vjp(jnp.sin)
+    def fwd(x):
+      return jnp.sin(x), checkpoint_name(jnp.cos(x), 'cos')
+    def bwd(cos_x, g):
+      return cos_x * g,
+    sin.defvjp(fwd, bwd)
+    policy = jax.checkpoint_policies.save_only_these_names('cos')
+    x = jnp.arange(3.)
+
+    def bwd_recomputes_cos(f):
+      y, f_vjp = jax.vjp(f, x)
+      jaxpr = jax.jit(f_vjp).trace(y).lojax.jaxpr
+      jaxpr, _ = pe.dce_jaxpr(jaxpr, True)
+      return '= cos' in jaxpr.pretty_print(use_color=False)
+
+    self.assertFalse(bwd_recomputes_cos(
+        jax.remat(jax.remat(sin), policy=policy)))
+    self.assertTrue(bwd_recomputes_cos(
+        jax.remat(jax.remat(sin, policy=policy))))
+    jtu.check_grads(jax.remat(jax.remat(sin), policy=policy), (3.,),
+                    order=2, modes=['rev'])
+
+  @config.custom_vjp3(True)
+  def test_custom_vjp_fwd_combined_policy(self):
+    # save_from_both_policies returns a plain callable policy, not one of the
+    # name-based policy classes; names inside custom_vjp fwd rules must honor
+    # it via the policy(prim, ...) protocol.
+    policy = jax.checkpoint_policies.save_from_both_policies(
+        jax.checkpoint_policies.save_only_these_names('cos'),
+        jax.checkpoint_policies.save_only_these_names('other'))
+    x = jnp.arange(3.)
+
+    def bwd_recomputes_cos(f):
+      y, f_vjp = jax.vjp(f, x)
+      jaxpr = jax.jit(f_vjp).trace(y).lojax.jaxpr
+      jaxpr, _ = pe.dce_jaxpr(jaxpr, True)
+      return '= cos' in jaxpr.pretty_print(use_color=False)
+
+    sin = jax.custom_vjp(jnp.sin)
+    def fwd(z):
+      return jnp.sin(z), checkpoint_name(jnp.cos(z), 'cos')
+    def bwd(c, g):
+      return c * g,
+    sin.defvjp(fwd, bwd)
+    self.assertFalse(bwd_recomputes_cos(jax.remat(sin, policy=policy)))
+    jtu.check_grads(jax.remat(sin, policy=policy), (3.,), order=2,
+                    modes=['rev'])
+
+  @config.custom_vjp3(True)
+  def test_custom_vjp_opaque_kernel_stays_opaque_when_policy_misses(self):
+    # A custom_vjp wrapping a primitive with no AD rules must stay an opaque
+    # unit under a policy that matches nothing in its fwd rule, even when the
+    # vjp machinery runs inside an outer differentiation context (the
+    # layer_stack pattern) or under higher-order AD.
+    dummy_p = core.Primitive('dummy_no_ad')
+    dummy_p.def_impl(lambda x: x * 2.0)
+    dummy_p.def_abstract_eval(lambda a: a)
+
+    op = jax.custom_vjp(lambda x: dummy_p.bind(x))
+    def fwd(x):
+      return dummy_p.bind(x), (x,)
+    def bwd(res, g):
+      return (g * 2.0,)
+    op.defvjp(fwd, bwd)
+
+    policy = jax.checkpoint_policies.save_only_these_names('unrelated')
+    f = jax.remat(op, policy=policy)
+
+    def outer_fwd(x):
+      out, _ = jax.vjp(f, x)
+      return out
+    y, f_vjp = jax.vjp(outer_fwd, 3.0)
+    self.assertAllClose(y, 6.0, check_dtypes=False)
+    self.assertAllClose(f_vjp(1.0)[0], 2.0, check_dtypes=False)
+    self.assertAllClose(jax.grad(jax.grad(f))(3.0), 0.0, check_dtypes=False)
+
+    # With a matched policy, only the named chains are hoisted onto the fwd
+    # pass; the kernel stays on the primal path behind the opaque unit, so
+    # the same outer differentiation contexts still work.
+    op2 = jax.custom_vjp(lambda x: dummy_p.bind(x))
+    def fwd2(x):
+      return dummy_p.bind(x), checkpoint_name(jnp.cos(x), 'saved')
+    def bwd2(c, g):
+      return (0. * c + g * 2.0,)
+    op2.defvjp(fwd2, bwd2)
+    f2 = jax.remat(op2, policy=jax.checkpoint_policies.save_only_these_names('saved'))
+    def outer_fwd2(x):
+      out, _ = jax.vjp(f2, x)
+      return out
+    y2, f2_vjp = jax.vjp(outer_fwd2, 3.0)
+    self.assertAllClose(y2, 6.0, check_dtypes=False)
+    self.assertAllClose(f2_vjp(1.0)[0], 2.0, check_dtypes=False)
+    self.assertAllClose(jax.grad(jax.grad(f2))(3.0), 0.0, check_dtypes=False)
 
   def test_custom_remat_saving_through_shard_map(self):
     def f_fwd(policy, x):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -8291,7 +8291,7 @@ class Remat3Test(RematTest):
     jaxpr = jax.jit(body).trace(1.).jaxpr
     policy = jax.checkpoint_policies.save_only_these_names('y')
     fwd_jaxpr, _, fwds = remat_internal.remat_jaxpr(
-        jaxpr, policy, custom_vjp_rules=True, allow_fwds=True)
+        jaxpr, policy, allow_fwds=True)
     self.assertEqual(fwds, [0])
     self.assertLen(fwd_jaxpr.outvars, len(jaxpr.jaxpr.outvars))
 
@@ -8366,9 +8366,10 @@ class Remat3Test(RematTest):
     with assertEvals(3):
       vjp(v)
 
+  @unittest.skip("custom_vjp applications are opaque to remat3 policies; "
+                 "use custom_remat for policy-controlled saving")
   @config.custom_vjp3(True)
   def test_custom_vjp_with_checkpoint_name_in_fwd(self):
-    assert jax.config.jax_custom_vjp3
     sin = jax.custom_vjp(jnp.sin)
     def fwd(x):
       return jnp.sin(x), checkpoint_name(jnp.cos(x), 'cos')
@@ -8395,22 +8396,21 @@ class Remat3Test(RematTest):
     self.assertNotIn('cos ', bwd_str)
     jtu.check_grads(f, (3.,), order=2, modes=['rev'])
 
-    f = jax.remat(sin)
-    fwd_str, bwd_str = fwd_bwd_jaxpr_strs(f, jnp.arange(3.))
-    self.assertNotIn('cos', fwd_str)
-    self.assertIn('cos ', bwd_str)
-    jtu.check_grads(f, (3.,), order=2, modes=['rev'])
-
   @config.custom_vjp3(True)
-  def test_custom_vjp_with_checkpoint_name_in_fwd_static_argnums(self):
-    # Like the above test, but exercises nondiff_argnums
-    assert jax.config.jax_custom_vjp3
-    sin = jax.custom_vjp(lambda _, x: jnp.sin(x), nondiff_argnums=(0,))
-    def fwd(_, x):
-      return jnp.sin(x), checkpoint_name(jnp.cos(x), 'cos')
-    def bwd(_, cos_x, g):
+  def test_custom_remat_policy_controlled_residuals(self):
+    def wants_cos(policy):
+      return (isinstance(policy, ad_checkpoint.SaveOnlyTheseNames) and
+              'cos' in policy.saveable_names)
+    def f(x):
+      return jnp.sin(x)
+    def f_fwd(policy, x):
+      return jnp.sin(x), (jnp.cos(x) if wants_cos(policy) else None)
+    def f_rem(res, x):
+      cos_x = res if res is not None else jnp.cos(x)
+      return jnp.sin(x), cos_x
+    def f_bwd(cos_x, g):
       return cos_x * g,
-    sin.defvjp(fwd, bwd)
+    sin = ad_checkpoint.custom_remat(f, f_fwd, f_rem, f_bwd)
 
     def fwd_bwd_jaxpr_strs(f, *args):
       fwd_jaxpr = jax.jit(partial(jax.vjp, f)).trace(*args).lojax.jaxpr
@@ -8425,17 +8425,183 @@ class Remat3Test(RematTest):
       return fwd_str, bwd_str
 
     policy = jax.checkpoint_policies.save_only_these_names('cos')
-    f = jax.remat(partial(sin, 'hi'), policy=policy)
+    f = jax.remat(sin, policy=policy)
     fwd_str, bwd_str = fwd_bwd_jaxpr_strs(f, jnp.arange(3.))
     self.assertIn('cos ', fwd_str)
     self.assertNotIn('cos ', bwd_str)
     jtu.check_grads(f, (3.,), order=2, modes=['rev'])
 
-    f = jax.remat(partial(sin, 'hi'))
+    f = jax.remat(sin)
     fwd_str, bwd_str = fwd_bwd_jaxpr_strs(f, jnp.arange(3.))
     self.assertNotIn('cos', fwd_str)
     self.assertIn('cos ', bwd_str)
     jtu.check_grads(f, (3.,), order=2, modes=['rev'])
+
+  @unittest.skip("custom_vjp applications are opaque to remat3 policies; "
+                 "use custom_remat for policy-controlled saving")
+  @config.custom_vjp3(True)
+  def test_custom_vjp_with_checkpoint_name_in_fwd_static_argnums(self):
+    sin = jax.custom_vjp(lambda _, x: jnp.sin(x), nondiff_argnums=(0,))
+    def fwd(_, x):
+      return jnp.sin(x), checkpoint_name(jnp.cos(x), 'cos')
+    def bwd(_, cos_x, g):
+      return cos_x * g,
+    sin.defvjp(fwd, bwd)
+
+    policy = jax.checkpoint_policies.save_only_these_names('cos')
+    f = jax.remat(partial(sin, 'hi'), policy=policy)
+    y, f_vjp = jax.vjp(f, jnp.arange(3.))
+    bwd_jaxpr = jax.jit(f_vjp).trace(y).lojax.jaxpr
+    bwd_jaxpr, _ = pe.dce_jaxpr(bwd_jaxpr, True)
+    self.assertNotIn('cos ', bwd_jaxpr.pretty_print(use_color=False))
+    jtu.check_grads(f, (3.,), order=2, modes=['rev'])
+
+  @config.custom_vjp3(True)
+  def test_custom_vjp_nondiff_argnums_under_remat(self):
+    sin = jax.custom_vjp(lambda _, x: jnp.sin(x), nondiff_argnums=(0,))
+    def fwd(_, x):
+      return jnp.sin(x), jnp.cos(x)
+    def bwd(_, cos_x, g):
+      return cos_x * g,
+    sin.defvjp(fwd, bwd)
+
+    policy = jax.checkpoint_policies.save_only_these_names('cos')
+    f = jax.remat(partial(sin, 'hi'), policy=policy)
+    jtu.check_grads(f, (3.,), order=2, modes=['rev'])
+
+  @unittest.skip("custom_vjp applications are opaque to remat3 policies; "
+                 "use custom_remat for policy-controlled saving")
+  @config.custom_vjp3(True)
+  def test_custom_vjp_saved_residual_is_vjp_pytree_leaf(self):
+    sin = jax.custom_vjp(jnp.sin)
+    def fwd(x):
+      return jnp.sin(x), checkpoint_name(jnp.cos(x), 'cos')
+    def bwd(c, g):
+      return c * g,
+    sin.defvjp(fwd, bwd)
+
+    policy = jax.checkpoint_policies.save_only_these_names('cos')
+    x = jnp.arange(3.)
+    for block in [sin, jax.jit(sin)]:
+      _, f_vjp = jax.vjp(jax.remat(block, policy=policy), x)
+      leaves = jax.tree.leaves(f_vjp)
+      self.assertTrue(any(l.shape == x.shape and jnp.allclose(l, jnp.cos(x))
+                          for l in leaves))
+      x_bar, = f_vjp(jnp.ones_like(x))
+      self.assertArraysAllClose(x_bar, jnp.cos(x))
+
+  @config.custom_vjp3(True)
+  def test_custom_remat_saved_residual_is_vjp_pytree_leaf(self):
+    def f_fwd(policy, x):
+      saveable = (isinstance(policy, SaveOnlyTheseNames) and
+                  'cos' in policy.saveable_names)
+      return jnp.sin(x), (jnp.cos(x) if saveable else None)
+    def f_rem(res, x):
+      return jnp.sin(x), (jnp.cos(x) if res is None else res)
+    def f_bwd(cos_x, g):
+      return cos_x * g,
+    sin = custom_remat(jnp.sin, f_fwd, f_rem, f_bwd)
+
+    policy = jax.checkpoint_policies.save_only_these_names('cos')
+    x = jnp.arange(3.)
+    for block in [sin, jax.jit(sin)]:
+      _, f_vjp = jax.vjp(jax.remat(block, policy=policy), x)
+      leaves = jax.tree.leaves(f_vjp)
+      self.assertTrue(any(l.shape == x.shape and jnp.allclose(l, jnp.cos(x))
+                          for l in leaves))
+      x_bar, = f_vjp(jnp.ones_like(x))
+      self.assertArraysAllClose(x_bar, jnp.cos(x))
+
+  def test_checkpoint_name_zero_tangent_residuals(self):
+    pos = jnp.arange(3.)
+    policy = jax.checkpoint_policies.save_only_these_names('scale')
+    def f(x):
+      return x * checkpoint_name(jnp.cos(pos * 2.0), 'scale')
+
+    x = jnp.ones(3)
+    for block in [f, jax.jit(f)]:
+      _, f_vjp = jax.vjp(jax.remat(block, policy=policy), x)
+      leaves = jax.tree.leaves(f_vjp)
+      self.assertLen(leaves, 1)
+      self.assertArraysAllClose(leaves[0], jnp.cos(pos * 2.0))
+
+    fwd_jaxpr = jax.jit(
+        partial(jax.vjp, jax.remat(f, policy=policy))).trace(x).lojax.jaxpr
+    fwd_jaxpr, _ = pe.dce_jaxpr(fwd_jaxpr, True)
+    self.assertEqual(
+        fwd_jaxpr.pretty_print(use_color=False).count('reduce_precision'), 1)
+
+    g = jax.remat(
+        lambda x: (x * x * checkpoint_name(jnp.cos(pos * 2.0), 'scale')).sum(),
+        policy=policy)
+    g2 = jax.grad(lambda x: jax.grad(g)(x).sum())(x)
+    self.assertArraysAllClose(g2, 2 * jnp.cos(pos * 2.0))
+
+  def test_checkpoint_name_combined_policy(self):
+    # save_from_both_policies returns a plain callable policy, not one of the
+    # name-based policy classes; checkpoint_name must honor it via the
+    # policy(prim, ...) protocol.
+    policy = jax.checkpoint_policies.save_from_both_policies(
+        jax.checkpoint_policies.save_only_these_names('cos'),
+        jax.checkpoint_policies.save_only_these_names('other'))
+    x = jnp.arange(3.)
+
+    def plain(z):
+      return z * checkpoint_name(jnp.cos(z), 'cos')
+    y, f_vjp = jax.vjp(jax.remat(plain, policy=policy), x)
+    jaxpr = jax.jit(f_vjp).trace(jnp.ones_like(y)).lojax.jaxpr
+    jaxpr, _ = pe.dce_jaxpr(jaxpr, True)
+    self.assertNotIn('= cos', jaxpr.pretty_print(use_color=False))
+    jtu.check_grads(jax.remat(plain, policy=policy), (jnp.arange(3.),),
+                    order=2, modes=['rev'])
+
+  def test_custom_remat_layered_outermost_policy_wins(self):
+    def f_fwd(policy, x):
+      saveable = (isinstance(policy, SaveOnlyTheseNames) and
+                  'cos' in policy.saveable_names)
+      return jnp.sin(x), (jnp.cos(x) if saveable else None)
+    def f_rem(res, x):
+      return jnp.sin(x), (jnp.cos(x) if res is None else res)
+    def f_bwd(cos_x, g):
+      return cos_x * g,
+    sin = custom_remat(jnp.sin, f_fwd, f_rem, f_bwd)
+    policy = jax.checkpoint_policies.save_only_these_names('cos')
+    x = jnp.arange(3.)
+
+    def bwd_recomputes_cos(f):
+      y, f_vjp = jax.vjp(f, x)
+      jaxpr = jax.jit(f_vjp).trace(y).lojax.jaxpr
+      jaxpr, _ = pe.dce_jaxpr(jaxpr, True)
+      return '= cos' in jaxpr.pretty_print(use_color=False)
+
+    self.assertFalse(bwd_recomputes_cos(
+        jax.remat(jax.remat(sin), policy=policy)))
+    self.assertTrue(bwd_recomputes_cos(
+        jax.remat(jax.remat(sin, policy=policy))))
+
+  def test_custom_remat_saving_through_shard_map(self):
+    def f_fwd(policy, x):
+      saveable = (isinstance(policy, SaveOnlyTheseNames) and
+                  'cos' in policy.saveable_names)
+      return jnp.sin(x), (jnp.cos(x) if saveable else None)
+    def f_rem(res, x):
+      return jnp.sin(x), (jnp.cos(x) if res is None else res)
+    def f_bwd(cos_x, g):
+      return cos_x * g,
+    sin = custom_remat(jnp.sin, f_fwd, f_rem, f_bwd)
+    policy = jax.checkpoint_policies.save_only_these_names('cos')
+
+    mesh = jax.make_mesh((1,), ('i',))
+    P = jax.sharding.PartitionSpec
+    block = jax.shard_map(sin, mesh=mesh, in_specs=P(), out_specs=P())
+    f = jax.remat(block, policy=policy)
+    x = jnp.arange(3.)
+
+    y, f_vjp = jax.vjp(f, x)
+    bwd_jaxpr = jax.jit(f_vjp).trace(y).lojax.jaxpr
+    bwd_jaxpr, _ = pe.dce_jaxpr(bwd_jaxpr, True)
+    self.assertNotIn('= cos', bwd_jaxpr.pretty_print(use_color=False))
+    self.assertArraysAllClose(f_vjp(jnp.ones_like(y))[0], jnp.cos(x))
 
   def test_remat_dce_input_to_output_forwarding(self):
     traced = jax.jit(lambda x, y: (x, x * y)).trace(

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -2858,8 +2858,6 @@ class HijaxTransformCoverageTest(jtu.JaxTestCase):
 @jtu.with_config(jax_remat3=True, jax_custom_vjp3=True)
 class CustomVJPRemat3Test(jtu.JaxTestCase):
 
-  @unittest.skip("custom_vjp applications are opaque to remat3 policies; "
-                 "use custom_remat for policy-controlled saving")
   def test_saved_residuals_names_value_in_custom_vjp_fwd(self):
     @jax.custom_vjp
     def f(x):

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -2858,6 +2858,27 @@ class HijaxTransformCoverageTest(jtu.JaxTestCase):
 @jtu.with_config(jax_remat3=True, jax_custom_vjp3=True)
 class CustomVJPRemat3Test(jtu.JaxTestCase):
 
+  @unittest.skip("custom_vjp applications are opaque to remat3 policies; "
+                 "use custom_remat for policy-controlled saving")
+  def test_saved_residuals_names_value_in_custom_vjp_fwd(self):
+    @jax.custom_vjp
+    def f(x):
+      return jnp.sin(x) * 2.0
+    def f_fwd(x):
+      return checkpoint_name(jnp.sin(x) * 2.0, 'saved'), (x,)
+    def f_bwd(res, g):
+      x, = res
+      return (g * 2.0 * jnp.cos(x),)
+    f.defvjp(f_fwd, f_bwd)
+
+    def layer(x):
+      y = f(x)
+      return jnp.sum(y * y)
+
+    policy = jax.checkpoint_policies.save_only_these_names('saved')
+    res = saved_residuals(jax.remat(layer, policy=policy), jnp.arange(4.))
+    self.assertTrue(any("named 'saved'" in s for _, s in res))
+
   def _saved_sin(self):
     @jax.custom_vjp
     def f(y):
@@ -2901,26 +2922,6 @@ class CustomVJPRemat3Test(jtu.JaxTestCase):
     loss = lambda x: jax.remat(block, policy=policy)(x[None]).sum()
     x = jnp.arange(4.)
     self.assertArraysAllClose(jax.vmap(jax.grad(loss))(x), jnp.cos(x))
-
-  def test_saved_residuals_names_value_in_custom_vjp_fwd(self):
-    @jax.custom_vjp
-    def f(x):
-      return jnp.sin(x) * 2.0
-    def f_fwd(x):
-      return checkpoint_name(jnp.sin(x) * 2.0, 'saved'), (x,)
-    def f_bwd(res, g):
-      x, = res
-      return (g * 2.0 * jnp.cos(x),)
-    f.defvjp(f_fwd, f_bwd)
-
-    def layer(x):
-      y = f(x)
-      return jnp.sum(y * y)
-
-    policy = jax.checkpoint_policies.save_only_these_names('saved')
-    res = saved_residuals(jax.remat(layer, policy=policy), jnp.arange(4.))
-    self.assertTrue(any("named 'saved'" in s for _, s in res),
-                    msg=f'saved residuals: {[s for _, s in res]}')
 
 
 if __name__ == '__main__':

--- a/tests/shard_map_test.py
+++ b/tests/shard_map_test.py
@@ -1111,7 +1111,7 @@ class ShardMapTest(jtu.JaxTestCase):
       return z.sum()
 
     x = jax.device_put(jnp.arange(2.), jax.P('i'))
-    y1, f_ = remat_transform(policy, f, x, custom_vjp_rules=True)  # don't crash
+    y1, f_ = remat_transform(policy, f, x)  # don't crash
     y2 = f_(x)
     self.assertAllClose(y1, y2, check_dtypes=False)
 


### PR DESCRIPTION
Recover the support for policy-driving saving of residuals in custom_vjp fwd rules by using partial eval. This is a much more limited use of partial eval than under remat2, and it's essentially necessary since handling checkpoint_name in custom_vjp fwd rules basically means automatically unzipping the function into a fwd pass and a remat pass. By using the good ol' partial eval machinery, rather than bespoke stuff, regressions and unexpected bugs seem less likely.

This complexity, indeed the entire `CustomVJPTraced.remat` method, can be deleted when we migrate users to custom_remat or similar. But for now it's necessary to avoid the regression.

One diff from the remat2 behavior is that this doesn't work with symbolic_zeros=True on custom_vjp. It essentially can't because with remat3 we're doing the remat pass *before* autodiff, ie here we need to trace (and then unzip) the fwd during the remat pass, and the symbolic zeros information is only available during autodiff. An error is raised rather than silent failure.

Another issue here is we re-trace the fwd rule on each application of a rematted function. Again, that'll just disappear.

| behavior                               | remat2      | this change |
|----------------------------------------|-------------|-------------|
| named value in fwd, matched policy (1) | saved       | saved       |
| fwd primal provenance, policy'd (2)    | fwd rule    | fwd rule    |
| fwd primal provenance, no policy (2)   | fwd rule    | f           |
| effects in fwd, matched policy (3)     | both passes | both passes |
| effects in fwd, no policy (3)          | both passes | bwd only    |
| atomic-kernel fwd, no policy (5)       | res early   | never early |
| scan-in-fwd names (6)                  | saved       | saved       |
| unbalanced-cond-in-fwd names (6)       | recomputed  | recomputed  |
| nested-jit-in-fwd names (6)            | saved       | saved       |
| symz/with_logs + matched names (7)     | saved       | raises      |
| offload names in fwd (8)               | offloaded   | offloaded   |

The numbers correspond to sections of custom_vjp_fwd_unzip_demos.py. I'm just leaving it here for my own future reference.
