### PR TITLE
Keep preconditioned CG finite when its inner products underflow, and run the transpose solve at unit rhs norm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * Fixed {func}`jax.numpy.intersect1d` and {func}`jax.numpy.setxor1d` with
     ``size=0``, which previously raised a ValueError; they now return empty
     arrays of the natural result dtype.
+  * Fixed a bug where reverse-mode derivatives of
+    {func}`jax.scipy.sparse.linalg.cg` and
+    {func}`jax.scipy.sparse.linalg.bicgstab` could silently return all-NaN
+    results when the incoming cotangent's norm is many orders of magnitude
+    below the primal right-hand side: the transpose solve is now performed at
+    unit right-hand-side norm, and CG exits with the last iterate reached
+    instead of dividing by an inner product that underflowed to zero
+    ({jax-issue}`#40254`). As part of this, CG now stops early if an inner
+    product that is positive for symmetric positive definite inputs turns out
+    non-positive.
 
 ## JAX 0.11.1 (August 17, 2026)
 

--- a/jax/_src/scipy/sparse/linalg.py
+++ b/jax/_src/scipy/sparse/linalg.py
@@ -111,19 +111,27 @@ def _cg_solve(A, b, x0=None, *, maxiter, tol=1e-5, atol=0.0, M=_identity):
   def cond_fun(value):
     _, r, gamma, _, k = value
     rs = gamma.real if M is _identity else _vdot_real_tree(r, r)
-    return (rs > atol2) & (k < maxiter)
+    # k < 0 signals breakdown detected in body_fun
+    return (rs > atol2) & (k < maxiter) & (k >= 0)
 
   def body_fun(value):
     x, r, gamma, p, k = value
     Ap = A(p)
-    alpha = gamma / _vdot_real_tree(p, Ap).astype(dtype)
+    pAp = _vdot_real_tree(p, Ap).astype(dtype)
+    # Both are positive for SPD A and M but can underflow to zero in low
+    # precision; keep the previous iterate and exit instead of dividing by 0.
+    breakdown = (pAp.real <= 0) | (gamma.real <= 0)
+    safe = lambda d: jnp.where(breakdown, jnp.ones_like(d), d)
+    alpha = gamma / safe(pAp)
     x_ = _add(x, _mul(alpha, p))
     r_ = _sub(r, _mul(alpha, Ap))
     z_ = M(r_)
     gamma_ = _vdot_real_tree(r_, z_).astype(dtype)
-    beta_ = gamma_ / gamma
+    beta_ = gamma_ / safe(gamma)
     p_ = _add(z_, _mul(beta_, p))
-    return x_, r_, gamma_, p_, k + 1
+    keep_old = partial(tree_map, partial(jnp.where, breakdown))
+    return (keep_old(x, x_), keep_old(r, r_), jnp.where(breakdown, gamma, gamma_),
+            keep_old(p, p_), jnp.where(breakdown, -1, k + 1))
 
   r0 = _sub(b, A(x0))
   p0 = z0 = M(r0)
@@ -218,13 +226,28 @@ def _isolve(_isolve_solve, A, b, x0=None, *, tol=1e-5, atol=0.0,
   isolve_solve = partial(
       _isolve_solve, x0=x0, tol=tol, atol=atol, maxiter=maxiter, M=M)
 
+  def scale_tree(scale, tree):
+    return tree_map(lambda leaf: leaf * scale.astype(leaf.dtype), tree)
+
+  def transpose_solve(vecmat, b):
+    # The rhs is the incoming cotangent, which can be arbitrarily small; solve
+    # at unit rhs norm to keep the inner products in floating-point range.
+    nrm = jnp.sqrt(_vdot_real_tree(b, b))
+    inv = 1 / nrm
+    # fall back to the unscaled solve when the norm is 0, inf, or nan
+    scale = jnp.where(jnp.isfinite(inv) & (inv > 0), inv, 1.0)
+    x = _isolve_solve(vecmat, scale_tree(scale, b),
+                      x0=scale_tree(scale, x0), tol=tol, atol=atol * scale,
+                      maxiter=maxiter, M=M)
+    return scale_tree(1 / scale, x)
+
   # real-valued positive-definite linear operators are symmetric
   def real_valued(x):
     return not issubclass(x.dtype.type, np.complexfloating)
   symmetric = all(map(real_valued, tree_leaves(b))) \
     if check_symmetric else False
   x = lax.custom_linear_solve(
-      A, b, solve=isolve_solve, transpose_solve=isolve_solve,
+      A, b, solve=isolve_solve, transpose_solve=transpose_solve,
       symmetric=symmetric)
   info = None
   return x, info

--- a/tests/lax_scipy_sparse_test.py
+++ b/tests/lax_scipy_sparse_test.py
@@ -213,6 +213,39 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     x, _ = jax.scipy.sparse.linalg.bicgstab(lambda x: x, 1.0)
     self.assertTrue(dtypes.is_weakly_typed(x))
 
+  def _small_scale_cg_system(self):
+    # SPD system at 1e12 scale with a Jacobi preconditioner: a rhs of norm
+    # ~1e-18 underflows the preconditioned float32 inner products to zero.
+    n = 8
+    base = 2.0 * np.eye(n) + 0.25 * (np.eye(n, k=1) + np.eye(n, k=-1))
+    a64 = 1e12 * base
+    A = jnp.asarray(a64.astype(np.float32))
+    inv_diag = jnp.asarray((1.0 / np.diag(a64)).astype(np.float32))
+    return a64, A, lambda r: inv_diag * r
+
+  def test_cg_breakdown_returns_finite(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/40254: an
+    # underflowing solve must return the last iterate, not NaN from 0/0.
+    _, A, M = self._small_scale_cg_system()
+    b = jnp.full((A.shape[0],), 1e-18, dtype=jnp.float32)
+    x, _ = jax.scipy.sparse.linalg.cg(A, b, M=M, maxiter=100)
+    self.assertTrue(jnp.isfinite(x).all())
+
+  def test_cg_grad_small_cotangent(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/40254: the
+    # transpose solve runs at unit rhs norm so tiny cotangents stay finite.
+    a64, A, M = self._small_scale_cg_system()
+    b = jnp.ones((A.shape[0],), dtype=jnp.float32)
+
+    def loss(b):
+      sol, _ = jax.scipy.sparse.linalg.cg(A, b, M=M, maxiter=100)
+      return jnp.float32(1e-18) * jnp.sum(sol)
+
+    actual = jax.jit(jax.grad(loss))(b)
+    expected = 1e-18 * np.linalg.solve(a64.T, np.ones(a64.shape[0]))
+    self.assertTrue(jnp.isfinite(actual).all())
+    self.assertAllClose(np.asarray(actual, np.float64), expected, rtol=1e-4)
+
   # BICGSTAB
   @jtu.sample_product(
     shape=[(5, 5)],


### PR DESCRIPTION
Fixes #40254.

`jax.grad` through `jax.scipy.sparse.linalg.cg` with a preconditioner can silently return an
all-NaN gradient while the primal solve converges cleanly. `_isolve` reuses the forward solver
as the `transpose_solve` of `custom_linear_solve`, so the backward pass runs the same
preconditioned CG with the incoming *cotangent* as its right-hand side — and the cotangent's
norm is set by whatever the surrounding program computes, routinely many orders of magnitude
below the primal rhs (1e-13 in the issue's pipeline). At that scale the float32 inner products
inside `_cg_solve` underflow to exact zero while the loop keeps running, because with a
preconditioner `cond_fun` tests the *unpreconditioned* residual but the body divides by
*preconditioned* inner products.

Instrumenting `_cg_solve` on the issue's reproducer shows the breakdown can strike either
division: on x86 CPU it is `pAp = ⟨p, A p⟩` underflowing to exact zero while `gamma` is still
positive (so `alpha = gamma/0 = inf` poisons the iterate) — not only the `gamma == 0` →
`beta = 0/0` route the issue describes. A guard on `gamma` alone therefore doesn't cover the
reported case; both divisions need protection. The failure is also reachable without AD: a
direct `cg` call with a cotangent-scale rhs NaNs the same way.

Two complementary changes (both proposed in the issue, the guard extended per the measurement
above):

1. **Run the transpose solve at unit rhs norm** (`_isolve`): scale the cotangent rhs, `x0`,
   and `atol` by `1/‖b‖`, solve, and unscale the result. CG/BiCGSTAB are scale-invariant and
   `tol` is relative, so this is semantically neutral, but it keeps the backward solve in the
   range float32 handles regardless of the cotangent's scale. This restores accurate
   gradients: on the issue's reproducer the previously all-NaN float32 gradients now match a
   float64 reference to ~4e-6 relative error (cosine similarity 1.0), while primal results
   stay bit-identical.
2. **Detect breakdown in `_cg_solve`**: if `⟨p, A p⟩` or `⟨r, M r⟩` — positive for SPD
   operators in exact arithmetic — is not positive, keep the previous iterate and exit, using
   the same sentinel pattern `_bicgstab_solve` already uses for its breakdown cases. Runs that
   currently return inf/NaN now return the last iterate reached.

The rescale falls back to the unscaled solve when `1/‖b‖` is zero, infinite, or NaN (exactly
zero, norm-overflowing, or NaN cotangents), preserving today's behavior at those fringes.

Tests: two deterministic regression tests (an SPD system at 1e12 scale with a Jacobi
preconditioner and 1e-18-scale rhs/cotangent, chosen so the float32 products underflow below
the subnormal cutoff on every backend): the direct tiny-rhs solve must stay finite, and the
small-cotangent gradient must match the analytic solution to 1e-4. Both fail before this
change on CPU and GPU (NaN) and pass after. The full `lax_scipy_sparse_test.py` suite is green
on CPU, GPU, and CPU+x64; the per-leaf dtype cast in the rescale keeps complex trees working
under `jax_numpy_dtype_promotion=strict`.