### PR TITLE
Fix zero outer-reverse second derivatives of saturated tanh by hoisting the tangent out of its JVP rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@ When releasing, please add the new-release-boilerplate to docs/pallas/CHANGELOG.
   * Fixed {func}`jax.numpy.intersect1d` and {func}`jax.numpy.setxor1d` with
     ``size=0``, which previously raised a ValueError; they now return empty
     arrays of the natural result dtype.
+  * Fixed a bug where second derivatives of `tanh` with reverse mode as the
+    outermost transformation (e.g. `jax.grad(jax.grad(f))`) could return zero
+    instead of the correct value when `tanh` saturates (its output rounded to
+    exactly -1): the default tanh JVP rule now applies the tangent as a
+    single multiplication, whose transpose no longer loses the surviving
+    terms to rounding. First derivatives of `tanh` may shift in the last bit
+    and no longer have unbounded relative error deep in the negative
+    saturation tail ({jax-issue}`#40315`).
 
 ## JAX 0.11.1 (August 17, 2026)
 

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4610,7 +4610,9 @@ ad.defjvp2(
         ),
     )
     if accuracy is AccuracyMode.HIGHEST
-    else mul(add(g, mul(g, ans)), sub(_one(x), ans)),
+    # Keep g outside the factored product: distributing it inside makes the
+    # transpose cancel the exact (1 + ans) zero too late (#40315).
+    else mul(g, mul(sub(_one(x), ans), add(_one(x), ans))),
 )
 mlir.register_lowering(tanh_p, partial(_nary_lower_hlo, hlo.tanh))
 core.pp_eqn_rules[tanh_p] = _unary_with_accuracy_pp_rule

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -607,6 +607,21 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     ans = jax.grad(jax.jit(lambda x, n: x ** n))(0., 0)
     self.assertAllClose(ans, 0., check_dtypes=False)
 
+  def testTanhSaturatedSecondReverseDerivative(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/40315: with
+    # tanh(u) rounded to exactly -1, outer-reverse second derivatives were -0.0.
+    c = 1e4
+    def f(v):
+      u = -c * v
+      return lax.tanh(u) * u * u
+    expected = -2 * c * c  # f''(v) = 2*c*c*tanh(-c*v) at the saturated point
+    for second_deriv in [jax.grad(jax.grad(f)), jax.grad(jax.jacfwd(f)),
+                         jax.jacfwd(jax.jacfwd(f))]:
+      self.assertAllClose(float(second_deriv(1.0)), expected,
+                          check_dtypes=False)
+      self.assertAllClose(float(jax.jit(second_deriv)(1.0)), expected,
+                          check_dtypes=False)
+
   @jax.numpy_dtype_promotion('standard')  # This test explicitly exercises mixed type promotion
   def testPowIntPowerAtZero2(self):
     # https://github.com/jax-ml/jax/issues/17995


### PR DESCRIPTION
Fixes #40315.

For f(v) = tanh(u) * u * u with u = -1e8 * v, the second derivative at v = 1 is -2e16 and jacfwd(jacfwd) computes it exactly, but grad(grad) and any other combination with reverse mode outermost returned -0.0. tanh(u) rounds to exactly -1 there, and the correct value flows through terms that survive that rounding, so this was a real forward/reverse asymmetry, not expected precision loss. Notably clip and erf in the same program shape were fine; only tanh misbehaved.

The cause is the exact form of the default tanh JVP rule, the Herbie rewrite from 2020: (g + gans) * (1 - ans). It distributes the tangent g inside the (1 + ans) factor. Evaluated forward, g(1 + ans) collapses to an exact zero early (ans is exactly -1) and everything stays small. The transpose, which is what an outer grad evaluates, multiplies the cotangent by the large residuals first (intermediates around 1e24 for the repro), so the true answer term at 2e8 scale is absorbed by rounding before the matching pair cancels to zero. The transpose is mathematically exact; the evaluation order it induces is catastrophic.

The fix hoists g out: g * ((1 - ans) * (1 + ans)). The tangent path becomes a single multiplication by a factor computed purely from the primal, so the transpose sees the exact zero immediately, like the logistic rule next to it already does. Same operation count, and the compiled HLO for a tanh-MLP gradient is identical op for op (XLA fuses both forms the same way). The AccuracyMode.HIGHEST variant is untouched.

On first-derivative numerics, being fully upfront for anyone with golden gradient values: forward-mode JVPs with unit tangents are bitwise identical to before (checked over 200k points in f32 and f64), but reverse-mode grad(tanh) transposes to a differently associated expression and shifts in the last bit for many inputs. The shifts stay inside each form's error band, and the worst case strictly improves: the old g + g*ans add cancels at g's magnitude, with unbounded relative error deep in the negative saturation tail (observed errors up to about 1), while the new form stays within about 2 ulp of the value implied by the rounded primal everywhere we sampled, since 1 + ans is exact by the Sterbenz lemma for ans in [-1, -0.5].

The regression test checks grad(grad), grad(jacfwd) and jacfwd(jacfwd) agree on the exact second derivative at a saturated point, eager and jit, at a float32-safe scale; it fails before this change (-0.0) and passes after.