### PR TITLE
Update broken profiling docs links

### DIFF
--- a/docs/201/profiling.md
+++ b/docs/201/profiling.md
@@ -268,7 +268,7 @@ You can also use the following tools:
 - [Memory Profile](https://openxla.org/xprof/memory_profile)
 - [Memory Viewer](https://openxla.org/xprof/memory_viewer)
 - [HLO Op Profile](https://openxla.org/xprof/hlo_op_profile)
-- [Roofline Model](https://openxla.org/xprof/roofline_analysis)<br /><br />
+- [Roofline Model](https://openxla.org/xprof/roofline_model)<br /><br />
 
 #### Adding custom trace events
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -258,7 +258,7 @@ You can also use the following tools:
 - [Memory Profile](https://openxla.org/xprof/memory_profile)
 - [Memory Viewer](https://openxla.org/xprof/memory_viewer)
 - [HLO Op Profile](https://openxla.org/xprof/hlo_op_profile)
-- [Roofline Model](https://openxla.org/xprof/roofline_analysis)<br /><br />
+- [Roofline Model](https://openxla.org/xprof/roofline_model)<br /><br />
 
 ### Adding custom trace events
 


### PR DESCRIPTION
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->

# Summary

A minor fix for out-of-date profiling docs links.


# Code Changes

Update link [`https://openxla.org/xprof/roofline_analysis`](https://openxla.org/xprof/roofline_analysis) -> [`https://openxla.org/xprof/roofline_model`](https://openxla.org/xprof/roofline_model)

# Rebuilt Docs Screenshot

<img width="1280" height="737" alt="Screenshot 2026-08-30 at 12 16 22 AM" src="https://github.com/user-attachments/assets/dce5d372-d215-4d62-b801-289685a1e018" />


