### PR TITLE
[jaxlib] Ship FFI extension headers (collectives, record) in the wheel

### DIFF
--- a/jaxlib/tools/build_wheel.py
+++ b/jaxlib/tools/build_wheel.py
@@ -427,12 +427,20 @@ def prepare_wheel(wheel_sources_path: pathlib.Path, *, cpu, wheel_sources):
         "xla/ffi/api/c_api.h",
         "xla/ffi/api/api.h",
         "xla/ffi/api/ffi.h",
+        "xla/ffi/api/collectives_c_api.h",
+        "xla/ffi/api/collectives_api.h",
+        "xla/ffi/api/record_c_api.h",
+        "xla/ffi/api/record_api.h",
     ]
   else:
     xla_ffi_files = [
         f"{source_file_prefix}jaxlib/include/xla/ffi/api/c_api.h",
         f"{source_file_prefix}jaxlib/include/xla/ffi/api/api.h",
         f"{source_file_prefix}jaxlib/include/xla/ffi/api/ffi.h",
+        f"{source_file_prefix}jaxlib/include/xla/ffi/api/collectives_c_api.h",
+        f"{source_file_prefix}jaxlib/include/xla/ffi/api/collectives_api.h",
+        f"{source_file_prefix}jaxlib/include/xla/ffi/api/record_c_api.h",
+        f"{source_file_prefix}jaxlib/include/xla/ffi/api/record_api.h",
     ]
 
   copy_files(


### PR DESCRIPTION
`build_wheel.py` enumerates the XLA FFI headers to copy into the wheel and was never updated when the per-extension headers (`collectives_{c_api,api}.h`, `record_{c_api,api}.h`) landed in XLA. As a result, downstream FFI consumers can't build against an installed jaxlib.

This PR adds the four missing headers to both branches of the list.