### PR TITLE
[OneAPI GPU] Add OneAPI Scaled matmul lowering.

### DIFF
--- a/jax/_src/cudnn/scaled_matmul_stablehlo.py
+++ b/jax/_src/cudnn/scaled_matmul_stablehlo.py
@@ -193,6 +193,14 @@ mlir.register_lowering(
     platform="rocm",
 )
 
+# OneAPI reuses the ROCm composite lowering, which XLA expands to standard HLO
+# until OneAPI `scaled-dot` optimization support is added.
+mlir.register_lowering(
+    _scaled_matmul_p,
+    _scaled_matmul_rocm_lowering,
+    platform="oneapi",
+)
+
 _scaled_matmul_p_wrapper = core.Primitive("scaled_matmul_wrapper")
 _scaled_matmul_p_wrapper.multiple_results = True
 _scaled_matmul_p_wrapper.def_impl(_scaled_matmul_impl)


### PR DESCRIPTION
This PR adds following change:
1. jax/_src/cudnn/scaled_matmul_stablehlo.py It reuses the scaled matmul composite lowering for OneAPI, which XLA expands to standard HLO Ops.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->