### PR TITLE
[OneAPI GPU] Fix OneAPI test compatibility and enable psend lowering

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -1265,7 +1265,8 @@ core.effects.control_flow_allowed_effects.add_type(SingleSideCollectiveEffect)
 
 def _psend_lowering_gpu(ctx, x, *, axis_name, perm):
   if ("cuda" not in ctx.module_context.platforms and
-      "rocm" not in ctx.module_context.platforms):
+      "rocm" not in ctx.module_context.platforms and
+      "oneapi" not in ctx.module_context.platforms):
     raise NotImplementedError("psend is currently only implemented on GPUs")
 
   full_perm, other_args = _pcollectives_lowering_common(

--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -246,6 +246,10 @@ class DLPackTest(jtu.JaxTestCase):
     self.assertAllClose(np.astype(x.dtype), z)
 
   @jtu.run_on_devices("gpu", "tpu")
+  # DLPack has no kDLOneAPIHost device type to preserve pinned-host memory.
+  # Therefore skip the test on oneAPI devices.
+  # TODO(Intel-tf): Remove the skip once kDLOneAPIHost is added and supported.
+  @jtu.skip_on_devices("oneapi")
   def testJaxPinnedHostRoundTrip(self):
     device = jax.devices()[0]
     if device.platform not in ["gpu", "tpu"]:

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1196,6 +1196,15 @@ class LaxTest(jtu.JaxTestCase):
         raise SkipTest(
             f"The dot algorithm '{algorithm}' is not supported on CPU.")
     if jtu.test_device_matches(["gpu"]):
+      # TF32 presets are not currently supported on OneAPI.
+      # TODO(Intel-tf): Remove this skip once OneAPI supports TF32 presets.
+      if algorithm in {
+          lax.DotAlgorithmPreset.TF32_TF32_F32,
+          lax.DotAlgorithmPreset.TF32_TF32_F32_X3,
+      }:
+        if jtu.test_device_matches(["oneapi"]):
+          raise SkipTest(
+              f"The dot algorithm '{algorithm}' is not supported on OneAPI.")
       # GPU algorithm support is a little spotty. It is checked in
       # xla/service/algorithm_util.cc and the logic is copied here.
       if algorithm in {


### PR DESCRIPTION
This PR adds following changes:

1. `jax/_src/lax/parallel.py`:  Enable `psend` lowering on OneAPI GPUs.
2.  `tests/array_interoperability_test.py`:  Skip the pinned-host DLPack round-trip test on OneAPI.
3. `tests/lax_test.py`: Skip unsupported TF32 dot algorithm tests on OneAPI.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->