### PR TITLE
[ROCm] Drop --security-opt seccomp=unconfined from the ROCm CI containers

### DIFF
--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -126,7 +126,6 @@ jobs:
       options: >-
         --device=/dev/kfd
         --device=/dev/dri
-        --security-opt seccomp=unconfined
         --group-add video
         --shm-size 64G
         --env-file /etc/podinfo/gha-gpu-isolation-settings

--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -133,7 +133,6 @@ jobs:
       volumes:
         - /data:/data
       options: >-
-        --security-opt seccomp=unconfined
         --shm-size 64G
 
     env:

--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -138,7 +138,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
+      options: --device=/dev/kfd --device=/dev/dri --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
     name: "${{ (contains(inputs.runner, 'gfx950.1') && 'gfx950 1-GPU') ||
         (contains(inputs.runner, 'gfx950.4') && 'gfx950 4-GPU') ||
         (contains(inputs.runner, 'gfx950.8') && 'gfx950 8-GPU') }}, ROCm ${{ inputs.rocm-release-version || inputs.rocm-version }}, py${{ inputs.python }}"


### PR DESCRIPTION
## Motivation

`--security-opt seccomp=unconfined` was copied into the ROCm CI containers from ROCm's standard `docker run` recipe when these workflows were first added, and was never tied to an observed failure. It is not needed, and dropping it puts the ROCm CI containers back under Docker's default seccomp profile.

This is the upstream counterpart of ROCm/jax#878, which is already merged into the ROCm fork's `amd-main`.

## Technical Details

- Remove `--security-opt seccomp=unconfined` from the container options in `bazel_rocm.yml`, `pytest_rocm.yml` and `build_rocm_artifacts.yml`. No other container options change.

## Test Plan

Ran the ROCm CI images on an MI355X host with the CI container options minus `--security-opt`, and compared syscall availability against the unconfined profile. The same change is running in the ROCm fork's CI via ROCm/jax#878.

## Test Result

Pass. Under the default seccomp profile: `rocminfo` enumerates all 8 agents, a HIP kernel and `hipMemcpy` round-trip succeed, `hipMallocManaged` succeeds, and JAX with the ROCm 7.14 plugin runs a GPU matmul plus a 4-GPU RCCL all-reduce clean. Syscall diff versus unconfined is limited to `unshare(CLONE_NEWUSER)`, `bpf` and `kcmp`, none of which the CI uses.
