### PR TITLE
[ROCm] Enable more bazel tests in ROCm CI

### DIFF
--- a/.github/workflows/scripts/select_continuous_wheel_test_jobs.py
+++ b/.github/workflows/scripts/select_continuous_wheel_test_jobs.py
@@ -133,6 +133,15 @@ JOB_SPECS = (
         ),
     ),
     # LINT.ThenChange(.github/workflows/wheel_tests_continuous.yml:run_bazel_test_rocm)
+    # LINT.IfChange(run_bazel_test_rocm_pypi)
+    JobSpec(
+        job_id='run_bazel_test_rocm_pypi',
+        platform='rocm',
+        suite='bazel',
+        # jaxlib/plugin/pjrt come from PyPI; jax is built from source.
+        requires_builds=(),
+    ),
+    # LINT.ThenChange(.github/workflows/wheel_tests_continuous.yml:run_bazel_test_rocm_pypi)
 )
 
 VALID_XLA_TRACKS = frozenset(('pinned', 'head', 'commit'))
@@ -147,6 +156,7 @@ ROCM_JOB_IDS = frozenset((
     'build_rocm_artifacts',
     'run_pytest_rocm',
     'run_bazel_test_rocm',
+    'run_bazel_test_rocm_pypi',
 ))
 HALT_FOR_CONNECTION_JOB_IDS = tuple(
     job_id for job_id in ALL_JOB_IDS if job_id not in ROCM_JOB_IDS

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -26,7 +26,11 @@
 #                           wheels and uploads them to an S3 bucket.
 # 11. run-pytest-rocm:      Calls the `pytest_rocm.yml` workflow which downloads the jaxlib and
 #                           ROCm artifacts and runs the ROCm tests.
-# 12. run-bazel-test-rocm:  Calls the `bazel_rocm.yml` workflow which runs the ROCm Bazel tests.
+# 12. run-bazel-test-rocm:  Calls the `bazel_rocm.yml` workflow which runs the ROCm Bazel tests
+#                           against jaxlib/plugin/pjrt wheels built in this run.
+# 13. run-bazel-test-rocm-pypi: Calls the `bazel_rocm.yml` workflow which runs the same
+#                           ROCm Bazel tests against jaxlib/plugin/pjrt wheels from PyPI
+#                           (same pypi_latest path as bazel_rocm_presubmit.yml).
 
 name: CI - Wheel Tests (Continuous)
 permissions:
@@ -598,6 +602,46 @@ jobs:
       build_jaxlib: ${{ 'false' }}
       build_jax: ${{ 'false' }}
       jaxlib-version: "head"
+      run_multiaccelerator_tests: ${{ 'false' }}
+      clone_main_xla: 0
+      xla_commit: ''
+      halt-for-connection: 'no'
+
+  # LINT.IfChange(run_bazel_test_rocm_pypi)
+  run-bazel-test-rocm-pypi:
+    needs: [select-jobs]
+  # LINT.ThenChange(.github/workflows/scripts/select_continuous_wheel_test_jobs.py:run_bazel_test_rocm_pypi)
+    if: >-
+      ${{
+          fromJSON(needs.select-jobs.outputs.selected_jobs || '{}').run_bazel_test_rocm_pypi == true
+          && (github.repository_owner == 'jax-ml' || github.repository_owner == 'ROCm')
+      }}
+    uses: ./.github/workflows/bazel_rocm.yml
+    permissions:
+      contents: read
+      actions: read
+    strategy:
+        fail-fast: false
+        matrix:
+          runner: ["amd-do-linux.jax.gpu.gfx950.4"]
+          python: ["3.12"]
+          rocm: [
+            {label: "TheRock 10.0.0", wheel-version: "10", release-version: "10.0.0", tag: "therock-10.0"},
+          ]
+          enable-x64: [0]
+    name: "Bazel ROCm PyPI ${{ matrix.rocm.label }}"
+    with:
+      runner: ${{ matrix.runner }}
+      python: ${{ matrix.python }}
+      rocm-version: ${{ matrix.rocm.wheel-version }}
+      rocm-release-version: ${{ matrix.rocm.release-version }}
+      rocm-tag: ${{ matrix.rocm.tag }}
+      enable-x64: ${{ matrix.enable-x64 }}
+      download-jax-from-gcs: 0
+      skip-download-jaxlib-and-plugins-from-gcs: 0
+      jaxlib-version: "pypi_latest"
+      build_jaxlib: ${{ 'false' }}
+      build_jax: ${{ 'true' }}
       run_multiaccelerator_tests: ${{ 'false' }}
       clone_main_xla: 0
       xla_commit: ''

--- a/build/rocm/ci_test_targets.txt
+++ b/build/rocm/ci_test_targets.txt
@@ -7,50 +7,12 @@
 //tests/pallas:gpu_tests
 //tests/pallas:backend_independent_tests
 //jaxlib/tools:check_gpu_wheel_sources_test
--//tests/pallas:pallas_test_gpu
--//tests/pallas:ops_test_gpu
+
 -//tests/pallas:ops_test_mgpu_gpu
--//tests/pallas:pallas_shape_poly_test_gpu
--//tests/pallas:pallas_vmap_test_gpu
+
+# Known ROCm bug in TritonPallasTest.test_atomic_counter4 (8 threads).
 -//tests/pallas:triton_pallas_test_gpu
--//tests/pallas:gpu_paged_attention_test_gpu
+
+# Flaky on the CI workers.
+-//tests:lru_cache_test
 -//tests:export_harnesses_multi_platform_test_gpu
--//tests:jet_test_gpu
--//tests:lax_autodiff_test_gpu
--//tests:lax_numpy_setops_test_gpu
--//tests:lax_numpy_test_gpu
--//tests:lax_test_gpu
--//tests:linalg_test_gpu
--//tests:logging_test_gpu
--//tests:random_lax_test_gpu
--//tests:scipy_signal_test_gpu
--//tests:stax_test_gpu
--//tests:ode_test_gpu
--//tests:lobpcg_test_gpu
--//tests:scipy_stats_test_gpu
--//tests:nn_test_gpu
--//tests:lax_scipy_sparse_test_gpu
--//tests:lax_scipy_spectral_dac_test_gpu
--//tests:lax_scipy_special_functions_test_gpu
--//tests:cholesky_update_test_gpu
--//tests:api_test_gpu
--//tests:ann_test_gpu
--//tests:experimental_rnn_test_gpu
--//tests:lax_vmap_test_gpu
--//tests:qdwh_test_gpu
--//tests:scaled_dot_test_gpu
--//tests:scipy_spatial_test_gpu
--//tests:shape_poly_test_gpu
--//tests:sparsify_test_gpu
--//tests:lax_numpy_reducers_test_gpu
--//tests:scipy_optimize_test_gpu
--//tests:lax_numpy_einsum_test_gpu
--//tests:lax_scipy_test_gpu
--//tests:sparse_test_gpu
--//tests:sparse_bcoo_bcsr_test_gpu
--//tests:svd_test_gpu
--//tests:eigh_test_gpu
--//tests:image_test_gpu
-# buffer_callback_test_gpu uses py_import deps that are incompatible with
-# pre-built plugin wheels (build_jaxlib=false); exclude it unconditionally.
--//tests:buffer_callback_test_gpu

--- a/build/rocm/rocm.bazelrc
+++ b/build/rocm/rocm.bazelrc
@@ -72,7 +72,7 @@ build:rocm_rbe --repo_env=REMOTE_GPU_TESTING=1
 build:rocm_rbe --remote_download_outputs=minimal
 
 test:rocm_rbe --remote_timeout=3600
-test:rocm_rbe --jobs=32
+test:rocm_rbe --jobs=64
 test:rocm_rbe --strategy=TestRunner=remote,local
 test:rocm_rbe --worker_sandboxing=true
 test:rocm_rbe --repo_env=REMOTE_GPU_TESTING=1

--- a/ci/run_bazel_test_rocm_rbe.sh
+++ b/ci/run_bazel_test_rocm_rbe.sh
@@ -43,7 +43,7 @@ fi
 # Run Bazel GPU tests with RBE (single accelerator tests with one GPU apiece).
 echo "Running RBE GPU tests..."
 
-TAG_FILTERS="jax_test_gpu,-config-cuda-only,-manual"
+TAG_FILTERS="-config-cuda-only,-manual"
 
 # JAXCI_GATE_TARGETS_FILE selects which Bazel target pattern file to use.
 # Defaults to the full CI suite; set to build/rocm/ci_blocking_test_targets.txt
@@ -52,10 +52,10 @@ TARGETS_FILE="${JAXCI_GATE_TARGETS_FILE:-build/rocm/ci_test_targets.txt}"
 
 for arg in "$@"; do
     if [[ "$arg" == "--config=multi_gpu" ]]; then
-        TAG_FILTERS="${TAG_FILTERS},multiaccelerator"
+        TAG_FILTERS="jax_test_gpu,${TAG_FILTERS},multiaccelerator"
     fi
     if [[ "$arg" == "--config=single_gpu" ]]; then
-        TAG_FILTERS="${TAG_FILTERS},gpu,-multiaccelerator"
+        TAG_FILTERS="${TAG_FILTERS},-multiaccelerator"
     fi
 done
 


### PR DESCRIPTION
- This is an attempt to improve bazel test coverage on ROCm. We have been running this configuration downstream for a while and would like to upstream it.

- I skipped //tests/pallas:triton_pallas_test_gpu because we have a code gen bug which causes atomic counter test to fail. will enable it once it is fixed.
- and skipped
//tests:lru_cache_test
//tests:export_harnesses_multi_platform_test_gpu becuase they are flaky in rbe.

- also upped workers for rocm from 32 to 64 since I think we now have big enough pool to handle it
- Now cont flows runs bazel tests against pypi latest wheels aswell.