### PR TITLE
jnp.log2: improve accuracy by pre-computing 1/log(2) factor

### DIFF
--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -2819,13 +2819,14 @@ def log2(x: ArrayLike, /) -> Array:
     Array([-2., -1.,  0.,  1.,  2.,  3.], dtype=float32)
   """
   x, = promote_args_inexact("log2", x)
+  one_over_log2 = np.array(1.4426950408889634,  # exact value of 1 / log(2)
+                           dtype=dtypes.finfo(x.dtype).dtype)
   if dtypes.issubdtype(x.dtype, np.complexfloating):
     r = lax.log(x)
     re = lax.real(r)
     im = lax.imag(r)
-    ln2 = lax.log(_constant_like(re, 2))
-    return lax.complex(lax.div(re, ln2), lax.div(im, ln2))
-  out = lax.div(lax.log(x), lax.log(_constant_like(x, 2)))
+    return lax.complex(lax.mul(re, one_over_log2), lax.mul(im, one_over_log2))
+  out = lax.mul(lax.log(x), one_over_log2)
   jnp_error._set_error_if_nan(out)
   return out
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6457,6 +6457,28 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     with self.assertWarnsRegex(DeprecationWarning, msg):
       op([1, 2, 3])
 
+  @jtu.run_on_devices("cpu")
+  def testLog2Accuracy(self):
+    # Regression test for https://github.com/jax-ml/jax/issues/40419
+    exponents_f32 = np.arange(-10, 11)
+    values_f32 = np.ldexp(1.0, exponents_f32).astype(jnp.float32)
+    self.assertArraysEqual(jnp.log2(values_f32), exponents_f32.astype(jnp.float32))
+
+    exponents_bf16 = np.array([-5, 5, 10, 19, 20, 38, 40, 53, 57, 67, 76, 80, 89, 93, 106, 114, 119, 127])
+    values_bf16 = np.ldexp(1.0, exponents_bf16).astype(jnp.bfloat16)
+    self.assertArraysEqual(jnp.log2(values_bf16), exponents_bf16.astype(jnp.bfloat16))
+
+  @jtu.run_on_devices("cpu")
+  def testLog10Accuracy(self):
+    # Using precomputed 1/log(10) instead of dividing by log(10) improves accuracy.
+    exponents_f32 = np.array([-8, -7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 7, 8])
+    values_f32 = np.power(10.0, exponents_f32).astype(np.float32)
+    self.assertArraysEqual(jnp.log10(values_f32), exponents_f32.astype(np.float32))
+
+    exponents_bf16 = np.array([-7, 7, 9, 11, 14, 17, 18, 22, 23, 27, 28, 29, 31, 34, 36])
+    values_bf16 = np.power(10.0, exponents_bf16).astype(jnp.bfloat16)
+    self.assertArraysEqual(jnp.log10(values_bf16), exponents_bf16.astype(jnp.bfloat16))
+
 
 # Most grad tests are at the lax level (see lax_test.py), but we add some here
 # as needed for e.g. particular compound ops of interest.


### PR DESCRIPTION
This is the same approach already used in `jnp.log10`.

As discussed in https://github.com/jax-ml/jax/issues/40419#issuecomment-5529191337