### PR TITLE
simpler skipping of linearize rules when all input tangents are zero

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -1085,6 +1085,7 @@ def _dced(jaxpr, in_fwd, take, out_tree, policy, res, *args):
 
 
 class RematTraced(HiPrim):
+  skip_linearization_on_zero_tangents = True
   jaxpr: core.Jaxpr
   policy: Any
   prevent_cse: bool | tuple[bool, ...]
@@ -1397,6 +1398,7 @@ def custom_remat(f, f_fwd, f_rem, f_bwd, *, static_argnums=(),
   return call
 
 class CustomRemat(HiPrim):
+  skip_linearization_on_zero_tangents = True
   jaxpr: core.Jaxpr
   f1: Callable
   f2_fbwd: Callable

--- a/jax/_src/hijax.py
+++ b/jax/_src/hijax.py
@@ -168,6 +168,7 @@ class HiPrim:
         "vjp_from_lin`)")
 
   vjp_bwd_retval_logs: bool = False
+  skip_linearization_on_zero_tangents: bool = False
 
   def vjp_bwd(self, res, outgrad, /, *arg_accums):
     if self.vjp_bwd_retval_logs:
@@ -261,6 +262,7 @@ class VmapOf(HiPrim):
 
   def __init__(self, prim, axis_data, in_dims, out_dim):
     self.vjp_bwd_retval_logs = prim.vjp_bwd_retval_logs
+    self.skip_linearization_on_zero_tangents = prim.skip_linearization_on_zero_tangents
     unmap = lambda a, d: core.unmapped_aval(axis_data.size, d, a,
                                             axis_data.explicit_mesh_axis)
     self.in_avals = tree_map(unmap, prim.in_avals, in_dims)
@@ -410,6 +412,12 @@ batching.fancy_primitive_batchers[call_hi_primitive_p] = _call_hi_primitive_batc
 # backward rule receives them explicitly: `linearized(res, sres, *tangents)`,
 # and `vjp_bwd(res, sres, outgrad, *arg_accums)` (which must be overridden).
 def _call_hi_primitive_linearize(is_vjp, nz_in_flat, *args_flat, _prim):
+  zero_in = (not any(nz_in_flat) and
+             not any(isinstance(typeof(x), AbstractRef) for x in args_flat))
+  if zero_in and _prim.skip_linearization_on_zero_tangents:
+    ans_flat = call_hi_primitive_p.bind(*args_flat, _prim=_prim)
+    linearized = lambda _, __, *ts: [ad_util.p2tz(x) for x in ans_flat]
+    return ans_flat, [False] * len(ans_flat), None, None, linearized
   args = tree_unflatten(_prim.in_tree, args_flat)
   nzs_in = tree_unflatten(_prim.in_tree, nz_in_flat)
   if is_vjp:
@@ -419,7 +427,7 @@ def _call_hi_primitive_linearize(is_vjp, nz_in_flat, *args_flat, _prim):
     ans, residuals, *rest = _prim.lin(nzs_in, *args)
     linearized = partial(flatten_user_linearized, _prim)
   ans_flat = tree_leaves_checked(_prim.out_tree, ans)
-  nzs_out = rest[0] if rest else True
+  nzs_out = rest[0] if rest else not zero_in
   sres = rest[1] if len(rest) > 1 else None
   if (sres is not None and is_vjp and
       type(_prim).vjp_bwd is HiPrim.vjp_bwd):
@@ -430,6 +438,7 @@ def _call_hi_primitive_linearize(is_vjp, nz_in_flat, *args_flat, _prim):
   linearized = partial(linearized, nzs_out_flat) if is_vjp else linearized
   return ans_flat, nzs_out_flat, residuals, sres, linearized
 ad.primitive_linearizations[call_hi_primitive_p] = _call_hi_primitive_linearize
+ad.linearize_on_zero_tangents.add(call_hi_primitive_p)
 
 def fake_linear_op(prim, nz_in_flat, nz_out_flat, rs, sres, *tangents):
   if not any(nz_out_flat):
@@ -688,6 +697,7 @@ vjp_from_lin = _VJPFromLin(_vjp_fwd_from_lin, _transpose_linearized)
 
 
 class CustomVJPTraced(HiPrim):
+  skip_linearization_on_zero_tangents = True  # run the primal, not the fwd rule
   """Applications take ``(consts, fwd_consts, *args)``.
 
   The two leading arguments are synthetic, and both get zero cotangents:

--- a/jax/_src/interpreters/ad.py
+++ b/jax/_src/interpreters/ad.py
@@ -708,9 +708,8 @@ class LinearizeTrace(Trace):
   def process_primitive(self, primitive, tracers, params, /):
     primals_in, tangents_in = unzip2(map(self.to_primal_tangent_pair, tracers))
     tangent_nzs = [type(t) is not Zero for t in tangents_in]
-    if (all(type(t) is Zero for t in tangents_in) and
-        primitive is not core.ref_p and primitive is not core.empty_ref_p and
-        type(params.get('_prim')).__name__ != 'PrimalLeftTangentRight' and
+    if (not any(tangent_nzs) and
+        primitive not in linearize_on_zero_tangents and
         not any(isinstance(typeof(x), AbstractRef) for x in primals_in)):
       avals = tuple(core.typeof(x) for x in primals_in)
       return primitive.bind_with_trace(self.parent_trace, primals_in, avals, params)
@@ -921,6 +920,7 @@ class LinearizeTracer(Tracer[LinearizeTrace]):
 primitive_jvps : dict[core.Primitive, Callable] = {}
 primitive_transposes: dict[core.Primitive, Callable] = {}
 primitive_linearizations : dict[core.Primitive, Callable]  = {}
+linearize_on_zero_tangents: set[core.Primitive] = set()  # never skip these rules
 
 def deflinear(primitive, transpose_rule):
   primitive_jvps[primitive] = partial(linear_jvp, primitive)

--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -1147,6 +1147,7 @@ def _ref_lin(_is_vjp, nzs, x, *, memory_space, kind, pin):
 
 ad.primitive_jvps[core.ref_p] = _ref_jvp
 ad.primitive_linearizations[core.ref_p] = _ref_lin
+ad.linearize_on_zero_tangents.add(core.ref_p)
 # TODO(mattjj): lin rule for freeze and accum_grad_in_ref?
 ad.defjvp(core.freeze_p, lambda g, _: core.freeze(g))
 ad.defjvp(core.accum_grad_in_ref_p, lambda g, _: core.accum_grad_in_ref_p.bind(g))
@@ -1166,6 +1167,7 @@ def _empty_ref_lin(_is_vjp, nzs_in, *, ty, memory_space, pin):
                                  memory_space=memory_space, pin=pin)
   return primal_ref, True, None, None, lin
 ad.primitive_linearizations[core.empty_ref_p] = _empty_ref_lin
+ad.linearize_on_zero_tangents.add(core.empty_ref_p)
 
 def _free_ref_jvp(primals, tangents):
   [primal_ref], [tangent_ref] = primals, tangents


### PR DESCRIPTION
The main simplification was [here](https://github.com/jax-ml/jax/compare/main...mattjj:jax:push-ztutkrtzntvz?expand=1#diff-af6216ea04ba29495025d310b4978b00ce0e6df6fcc579bb5bcdd9262132c9e7L711).